### PR TITLE
Reparenting: use resilient indexing to access base witness table

### DIFF
--- a/docs/Reparenting.md
+++ b/docs/Reparenting.md
@@ -87,11 +87,14 @@ extension Contract: @reparented Identity // (7)
 6. All other requirements of the new parent must have default implementations within scope of the reparented extension. Thus, if there are methods only conditionally available (i.e., within other extensions constrained by a `where` clause), they cannot be used to implement the requirements.
 7. Reparentable protocols can only inherit from marker protocols like `Sendable`.
 8. You cannot conditionalize a reparented extension based on conformance requirements, e.g., `where ID: Equatable` is not permitted.
-9. Adding another reparented extension to a protocol that has already been reparented once before is not currently supported. Thus, all reparented extensions need to be added for the protocol within the same release.
 
 ## Gotchas
 
 There are a few subtle aspects of reparenting to keep in mind.
+
+### Overhead
+
+For any type conforming to a reparentable protocol, accessing the witness table for that reparentable protocol is less efficient; a relative offset amounting to an extra subtraction of two addresses must be computed. This has more overhead than a normal protocol, which uses a fixed offset.   
 
 ### Default Type Witnesses
 

--- a/include/swift/IRGen/Linking.h
+++ b/include/swift/IRGen/Linking.h
@@ -1657,6 +1657,10 @@ public:
     assert(isDeclKind(getKind()));
     return reinterpret_cast<ValueDecl*>(Pointer);
   }
+
+  bool hasExtension() const {
+    return getKind() == Kind::ExtensionDescriptor;
+  }
   
   const ExtensionDecl *getExtension() const {
     assert(getKind() == Kind::ExtensionDescriptor);

--- a/lib/IRGen/ComputedWitnessIndex.h
+++ b/lib/IRGen/ComputedWitnessIndex.h
@@ -1,0 +1,64 @@
+//===--- ComputedWitnessIndex.h - Index into a witness table ----*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// Defines the ComputedWitnessIndex type, used to represent an index into a
+// witness table, whether known at compile-time or is a computed value.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_IRGEN_COMPUTEDWITNESSINDEX_H
+#define SWIFT_IRGEN_COMPUTEDWITNESSINDEX_H
+
+#include "WitnessIndex.h"
+#include "llvm/IR/Value.h"
+
+namespace swift {
+namespace irgen {
+
+/// A class which encapsulates an either a computed or statically-known index
+/// into a witness table.
+/// FIXME(naming): this is more of a "generalized" or "maybe static" index.
+class ComputedWitnessIndex {
+  union {
+    llvm::Value *ComputedValue;
+    WitnessIndex StaticValue;
+  };
+  bool hasStaticValue;
+
+public:
+  /*implicit*/ ComputedWitnessIndex(WitnessIndex index)
+      : StaticValue(index), hasStaticValue(true) {}
+
+  explicit ComputedWitnessIndex(llvm::Value *index)
+      : ComputedValue(index), hasStaticValue(false) {}
+
+  bool isStatic() const { return hasStaticValue; }
+
+  std::optional<WitnessIndex> getStaticIndex() const {
+    if (isStatic())
+      return StaticValue;
+
+    return std::nullopt;
+  }
+
+  llvm::Value *getDynamicIndex() const {
+    if (isStatic())
+      return nullptr;
+
+    return ComputedValue;
+  }
+};
+
+} // end namespace irgen
+} // end namespace swift
+
+#endif

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -4110,6 +4110,26 @@ IRGenModule::getAddrOfLLVMVariable(LinkEntity entity,
     auto existing = cast<llvm::GlobalValue>(existingGlobal);
     auto castVar = llvm::ConstantExpr::getBitCast(var, existing->getType());
     existing->replaceAllUsesWith(castVar);
+
+    // Sometimes, two extension descriptors with different LinkEntity's
+    // may refer to the same llvm::Constant* within the GlobalVars map;
+    // their mangled names would be the same. It's suspected to have to
+    // do with `getAddrOfSharedContextDescriptor`'s shenanigans, but not proven.
+    // This is currently only ben observed for extension descriptors created for
+    // protocol-to-protocol conformances. In that case, we check for additional
+    // references in the GlobalVars map to prevent a dangling pointer.
+    if (entity.hasExtension()) {
+      for (auto otherExt : IRGen.AllConformanceOfProtocolExtensionDescriptors) {
+        auto otherEntity = LinkEntity::forExtensionDescriptor(otherExt);
+        auto &entry = GlobalVars[otherEntity];
+        if (entry == existing) {
+          assert(otherExt->getExtendedNominal() ==
+                 entity.getExtension()->getExtendedNominal());
+          entry = var;
+        }
+      }
+    }
+
     existing->eraseFromParent();
   }
 

--- a/lib/IRGen/GenOpaque.cpp
+++ b/lib/IRGen/GenOpaque.cpp
@@ -30,6 +30,7 @@
 #include "swift/SIL/TypeLowering.h"
 
 #include "Callee.h"
+#include "ComputedWitnessIndex.h"
 #include "Explosion.h"
 #include "FixedTypeInfo.h"
 #include "GenPointerAuth.h"
@@ -310,27 +311,36 @@ llvm::StructType *IRGenModule::getEnumValueWitnessTableTy() {
 
 Address irgen::slotForLoadOfOpaqueWitness(IRGenFunction &IGF,
                                           llvm::Value *table,
-                                          WitnessIndex index,
+                                          ComputedWitnessIndex index,
                                           bool areEntriesRelative) {
   assert(table->getType() == IGF.IGM.WitnessTablePtrTy);
 
-  // Are we loading from a relative protocol witness table.
+  llvm::Value *slot = table;
+  llvm::Type *elementTy = table->getType();
+  Alignment align = IGF.IGM.getPointerAlignment();
+
+  // Are we loading from a relative protocol witness table?
   if (areEntriesRelative) {
-    llvm::Value *slot =
-      IGF.Builder.CreateBitOrPointerCast(table, IGF.IGM.RelativeAddressPtrTy);
-    if (index.getValue() != 0)
-      slot = IGF.Builder.CreateConstInBoundsGEP1_32(IGF.IGM.RelativeAddressTy,
-                                                    slot, index.getValue());
-    return Address(slot, IGF.IGM.RelativeAddressTy, Alignment(4));
+    slot =
+        IGF.Builder.CreateBitOrPointerCast(table, IGF.IGM.RelativeAddressPtrTy);
+    elementTy = IGF.IGM.RelativeAddressTy;
+    align = Alignment(4);
   }
 
-  // GEP to the appropriate index, avoiding spurious IR in the trivial case.
-  llvm::Value *slot = table;
-  if (index.getValue() != 0)
-    slot = IGF.Builder.CreateConstInBoundsGEP1_32(IGF.IGM.WitnessTableTy, table,
-                                                  index.getValue());
+  // Is the index statically known?
+  if (auto staticIdx = index.getStaticIndex()) {
+    // GEP to the appropriate index, avoiding spurious IR in the trivial case.
+    if (staticIdx->getValue() != 0)
+      slot = IGF.Builder.CreateConstInBoundsGEP1_32(elementTy, slot,
+                                                    staticIdx->getValue());
 
-  return Address(slot, IGF.IGM.WitnessTableTy, IGF.IGM.getPointerAlignment());
+    return Address(slot, elementTy, align);
+  }
+
+  // For a non-static index, we can't avoid a GEP.
+  slot =
+      IGF.Builder.CreateInBoundsGEP(elementTy, slot, index.getDynamicIndex());
+  return Address(slot, elementTy, align);
 }
 
 /// Load a specific witness from a known table.  The result is
@@ -338,7 +348,7 @@ Address irgen::slotForLoadOfOpaqueWitness(IRGenFunction &IGF,
 llvm::Value *irgen::emitInvariantLoadOfOpaqueWitness(IRGenFunction &IGF,
                                                      bool isProtocolWitness,
                                                      llvm::Value *table,
-                                                     WitnessIndex index,
+                                                     ComputedWitnessIndex index,
                                                      llvm::Value **slotPtr) {
   // Is this is a load of a relative protocol witness table entry.
   auto isRelativeTable = IGF.IGM.IRGen.Opts.UseRelativeProtocolWitnessTables &&

--- a/lib/IRGen/GenOpaque.h
+++ b/lib/IRGen/GenOpaque.h
@@ -30,6 +30,7 @@ namespace irgen {
   class IRGenModule;
   class TypeInfo;
   enum class ValueWitness : unsigned;
+  class ComputedWitnessIndex;
   class WitnessIndex;
 
   /// Return the size of a fixed buffer.
@@ -43,7 +44,7 @@ namespace irgen {
   /// If \p areEntriesRelative is true we are emitting code for a relative
   /// protocol witness table.
   Address slotForLoadOfOpaqueWitness(IRGenFunction &IGF, llvm::Value *table,
-                                     WitnessIndex index,
+                                     ComputedWitnessIndex index,
                                      bool areEntriesRelative = false);
 
   /// Given a witness table (protocol or value), load one of the
@@ -54,7 +55,7 @@ namespace irgen {
   llvm::Value *emitInvariantLoadOfOpaqueWitness(IRGenFunction &IGF,
                                                 bool isProtocolWitness,
                                                 llvm::Value *table,
-                                                WitnessIndex index,
+                                                ComputedWitnessIndex index,
                                                 llvm::Value **slot = nullptr);
 
   /// Given a witness table (protocol or value), load one of the

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -2220,6 +2220,7 @@ static TypeEntityReference getConformingEntityReference(
       cast<NormalProtocolConformance>(conformance)->isConformanceOfProtocol()) {
     auto ext = cast<ExtensionDecl>(conformance->getDeclContext());
     auto linkEntity = LinkEntity::forExtensionDescriptor(ext);
+    IGM.IRGen.AllConformanceOfProtocolExtensionDescriptors.insert(ext);
     IGM.IRGen.noteUseOfExtensionDescriptor(ext);
     return IGM.getContextDescriptorEntityReference(linkEntity);
   }

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -58,6 +58,7 @@
 #include "CallEmission.h"
 #include "ConformanceDescription.h"
 #include "ConstantBuilder.h"
+#include "ComputedWitnessIndex.h"
 #include "EntryPointArgumentEmission.h"
 #include "EnumPayload.h"
 #include "Explosion.h"
@@ -3118,29 +3119,11 @@ llvm::Value *IRGenFunction::optionallyLoadFromConditionalProtocolWitnessTable(
   return phi;
 }
 
-llvm::Value *irgen::loadParentProtocolWitnessTable(IRGenFunction &IGF,
-                                            llvm::Value *wtable,
-                                            WitnessIndex index) {
+static void createRelativeWitnessTableAccessorFuncBody(
+    IRGenFunction &IGF, llvm::Value *wtable, ComputedWitnessIndex index) {
   auto &IGM = IGF.IGM;
-  if (!IGM.IRGen.Opts.UseRelativeProtocolWitnessTables) {
-    auto baseWTable =
-      emitInvariantLoadOfOpaqueWitness(IGF,/*isProtocolWitness*/true, wtable,
-                                       index);
-    return baseWTable;
-  }
 
-  llvm::SmallString<40> fnName;
-  llvm::raw_svector_ostream(fnName)
-    << "__swift_relative_protocol_witness_table_parent_"
-    << index.getValue();
-
-  auto helperFn = cast<llvm::Function>(IGM.getOrCreateHelperFunction(
-    fnName, IGM.WitnessTablePtrTy, {IGM.WitnessTablePtrTy},
-    [&](IRGenFunction &subIGF) {
-
-  auto it = subIGF.CurFn->arg_begin();
-  llvm::Value *wtable =  &*it;
-  auto &Builder = subIGF.Builder;
+  auto &Builder = IGF.Builder;
   auto *ptrVal = Builder.CreatePtrToInt(wtable, IGM.IntPtrTy);
   auto *one = llvm::ConstantInt::get(IGM.IntPtrTy, 1);
   auto *isCond = Builder.CreateAnd(ptrVal, one);
@@ -3154,29 +3137,29 @@ llvm::Value *irgen::loadParentProtocolWitnessTable(IRGenFunction &IGF,
   auto *mask = Builder.CreateNot(one);
   auto *wtableAddr = Builder.CreateAnd(ptrVal, mask);
   wtableAddr = Builder.CreateIntToPtr(wtableAddr, IGM.WitnessTablePtrTy);
-  auto addr = slotForLoadOfOpaqueWitness(subIGF, wtableAddr, index,
+  auto addr = slotForLoadOfOpaqueWitness(IGF, wtableAddr, index,
                                          false /*isRelative*/);
   llvm::Value *baseWTable = Builder.CreateLoad(addr);
-  baseWTable = subIGF.Builder.CreateBitCast(baseWTable, IGM.WitnessTablePtrTy);
+  baseWTable = IGF.Builder.CreateBitCast(baseWTable, IGM.WitnessTablePtrTy);
   Builder.CreateBr(endBB);
 
   Builder.emitBlock(isNotCondBB);
-  if (auto &schema = subIGF.getOptions().PointerAuth.RelativeProtocolWitnessTable) {
-    auto info = PointerAuthInfo::emit(subIGF, schema, nullptr,
+  if (auto &schema = IGF.getOptions().PointerAuth.RelativeProtocolWitnessTable) {
+    auto info = PointerAuthInfo::emit(IGF, schema, nullptr,
                                       PointerAuthEntity());
-    wtable = emitPointerAuthAuth(subIGF, wtable, info);
+    wtable = emitPointerAuthAuth(IGF, wtable, info);
   }
   auto baseWTable2 =
-      emitInvariantLoadOfOpaqueWitness(subIGF,/*isProtocolWitness*/true, wtable,
+      emitInvariantLoadOfOpaqueWitness(IGF,/*isProtocolWitness*/true, wtable,
                                        index);
-  baseWTable2 = subIGF.Builder.CreateBitCast(baseWTable2,
-                                          subIGF.IGM.WitnessTablePtrTy);
-  if (auto &schema = subIGF.getOptions().PointerAuth.RelativeProtocolWitnessTable) {
-    auto info = PointerAuthInfo::emit(subIGF, schema, nullptr,
+  baseWTable2 = IGF.Builder.CreateBitCast(baseWTable2,
+                                          IGF.IGM.WitnessTablePtrTy);
+  if (auto &schema = IGF.getOptions().PointerAuth.RelativeProtocolWitnessTable) {
+    auto info = PointerAuthInfo::emit(IGF, schema, nullptr,
                                       PointerAuthEntity());
-    baseWTable2 = emitPointerAuthSign(subIGF, baseWTable2, info);
+    baseWTable2 = emitPointerAuthSign(IGF, baseWTable2, info);
 
-    baseWTable2 = subIGF.Builder.CreateBitCast(baseWTable2,
+    baseWTable2 = IGF.Builder.CreateBitCast(baseWTable2,
                                             IGM.WitnessTablePtrTy);
   }
 
@@ -3187,11 +3170,63 @@ llvm::Value *irgen::loadParentProtocolWitnessTable(IRGenFunction &IGF,
   phi->addIncoming(baseWTable, isCondBB);
   phi->addIncoming(baseWTable2, isNotCondBB);
   Builder.CreateRet(phi);
+}
 
-  }, true /*noinline*/));
+static void
+createDynamicIndexRelativeWitnessTableAccessorFunc(IRGenFunction &IGF) {
+  auto it = IGF.CurFn->arg_begin();
+  llvm::Value *wtable = &*it++;
+  llvm::Value *indexValue = &*it++;
+  createRelativeWitnessTableAccessorFuncBody(IGF, wtable,
+                                             ComputedWitnessIndex(indexValue));
+}
 
-  auto *call = IGF.Builder.CreateCallWithoutDbgLoc(
-    helperFn->getFunctionType(), helperFn, {wtable});
+llvm::Value *irgen::loadParentProtocolWitnessTable(IRGenFunction &IGF,
+                                                   llvm::Value *wtable,
+                                                   ComputedWitnessIndex index) {
+  auto &IGM = IGF.IGM;
+  if (!IGM.IRGen.Opts.UseRelativeProtocolWitnessTables) {
+    auto baseWTable = emitInvariantLoadOfOpaqueWitness(
+        IGF, /*isProtocolWitness*/ true, wtable, index);
+    return baseWTable;
+  }
+
+  if (!index.isStatic()) {
+    llvm::Value *dynamicIdx = index.getDynamicIndex();
+    llvm::Type *indexType = dynamicIdx->getType();
+
+    llvm::SmallString<70> fnName;
+    llvm::raw_svector_ostream(fnName)
+        << "__swift_relative_protocol_witness_table_parent_dynamic_index_i"
+        << indexType->getIntegerBitWidth();
+
+    auto helperFn = cast<llvm::Function>(IGM.getOrCreateHelperFunction(
+        fnName, IGM.WitnessTablePtrTy, {IGM.WitnessTablePtrTy, indexType},
+        createDynamicIndexRelativeWitnessTableAccessorFunc, true /*noinline*/));
+    auto *call = IGF.Builder.CreateCallWithoutDbgLoc(
+        helperFn->getFunctionType(), helperFn, {wtable, dynamicIdx});
+    call->setCallingConv(IGF.IGM.DefaultCC);
+    call->setDoesNotThrow();
+    return call;
+  }
+
+  assert(index.isStatic());
+  llvm::SmallString<50> fnName;
+  llvm::raw_svector_ostream(fnName)
+      << "__swift_relative_protocol_witness_table_parent_"
+      << index.getStaticIndex()->getValue();
+
+  auto helperFn = cast<llvm::Function>(IGM.getOrCreateHelperFunction(
+      fnName, IGM.WitnessTablePtrTy, {IGM.WitnessTablePtrTy},
+      [&](IRGenFunction &subIGF) {
+        auto it = subIGF.CurFn->arg_begin();
+        llvm::Value *wtableArg = &*it;
+        createRelativeWitnessTableAccessorFuncBody(subIGF, wtableArg, index);
+      },
+      true /*noinline*/));
+
+  auto *call = IGF.Builder.CreateCallWithoutDbgLoc(helperFn->getFunctionType(),
+                                                   helperFn, {wtable});
   call->setCallingConv(IGF.IGM.DefaultCC);
   call->setDoesNotThrow();
   return call;
@@ -3244,6 +3279,31 @@ emitAssociatedTypeWitnessTableRef(IRGenFunction &IGF,
   call->setDoesNotThrow();
   call->setDoesNotAccessMemory();
   return call;
+}
+
+/// Witness tables for inherited protocols that are reparentable must be
+/// accessed using resilient witness table indexing, rather than a compile-time
+/// known index. This ensures that future newly-added (reparentable) parents
+/// of a protocol in a resilient module do not visibly change the order
+/// of its base protocol witness table entries.
+static llvm::Value *computeReparentableBaseWitnessTableIndex(
+    IRGenFunction &IGF, ProtocolDecl *Proto, ProtocolDecl *Base) {
+  // Non-reparentable bases are expected to use constant offsets, though this
+  // indexing scheme could work for them, too.
+  assert(Base->getAttrs().hasAttribute<ReparentableAttr>());
+
+  BaseConformance baseConf(Proto, Base);
+  auto baseConfDescriptor =
+      IGF.IGM.getAddrOfBaseConformanceDescriptor(baseConf);
+
+  // The offset into the witness table;
+  // corresponds to this in swift_getAssociatedConformanceWitness:
+  //     unsigned witnessIndex = assocConformance - reqBase;
+  // where the assocConformance is our base conformance descriptor.
+  auto witnessIndex =
+      computeResilientWitnessTableIndex(IGF, Proto, baseConfDescriptor);
+  witnessIndex->setName("witnessIndex");
+  return witnessIndex;
 }
 
 /// Drill down on a single stage of component.
@@ -3463,9 +3523,18 @@ MetadataResponse MetadataPath::followComponent(IRGenFunction &IGF,
     if (!source) return MetadataResponse();
 
     auto wtable = source.getMetadata();
-    WitnessIndex index(component.getPrimaryIndex(), /*prefix*/ false);
-    auto baseWTable = loadParentProtocolWitnessTable(IGF, wtable,
-                                       index.forProtocolWitnessTable());
+    WitnessIndex primaryIndex(component.getPrimaryIndex(), /*prefix*/ false);
+
+    // For ordinary inherited protocols, the entry can be accessed using
+    // a static offset into the table. But for reparentable protocols, we need
+    // a dynamic offset that is computed at runtime.
+    ComputedWitnessIndex index =
+        inheritedProtocol->getAttrs().hasAttribute<ReparentableAttr>()
+            ? ComputedWitnessIndex(computeReparentableBaseWitnessTableIndex(
+                  IGF, protocol, inheritedProtocol))
+            : primaryIndex.forProtocolWitnessTable();
+
+    auto baseWTable = loadParentProtocolWitnessTable(IGF, wtable, index);
     baseWTable =
       IGF.Builder.CreateBitCast(baseWTable, IGF.IGM.WitnessTablePtrTy);
     setProtocolWitnessTableName(IGF.IGM, baseWTable, sourceKey.Type,

--- a/lib/IRGen/GenProto.h
+++ b/lib/IRGen/GenProto.h
@@ -19,6 +19,7 @@
 
 #include "swift/SIL/SILFunction.h"
 
+#include "ComputedWitnessIndex.h"
 #include "Fulfillment.h"
 #include "GenericRequirement.h"
 #include "MetadataSource.h"
@@ -105,7 +106,7 @@ namespace irgen {
 
   llvm::Value *loadParentProtocolWitnessTable(IRGenFunction &IGF,
                                               llvm::Value *wtable,
-                                              WitnessIndex index);
+                                              ComputedWitnessIndex index);
 
   llvm::Value *loadConditionalConformance(IRGenFunction &IGF,
                                           llvm::Value *wtable,

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -318,6 +318,13 @@ private:
 public:
   /// The set of eagerly emitted opaque types.
   llvm::SmallPtrSet<OpaqueTypeDecl *, 4> EmittedNonLazyOpaqueTypeDecls;
+
+  /// A record of all ExtensionDescriptors emitted for protocol-to-protocol
+  /// conformances, as two such LinkEntity's can be unequal
+  /// (point to different extensions of the same protocol) but name the same
+  /// symbol ultimately, because the two extensions may have the same
+  /// generic signature, etc.
+  llvm::DenseSet<ExtensionDecl*> AllConformanceOfProtocolExtensionDescriptors;
 private:
 
   /// The queue of lazy field metadata records to emit.

--- a/test/IRGen/Inputs/reparentable_lib.swift
+++ b/test/IRGen/Inputs/reparentable_lib.swift
@@ -1,0 +1,20 @@
+
+@reparentable
+public protocol A {
+  func helloA()
+}
+@reparentable
+public protocol B {
+  func helloB()
+}
+
+public protocol C {
+  func helloC()
+}
+
+@reparentable
+public protocol D {
+  func helloD()
+}
+
+public protocol MultiParent: A, B, C, D {}

--- a/test/IRGen/reparentable_witness_table.swift
+++ b/test/IRGen/reparentable_witness_table.swift
@@ -1,0 +1,83 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -enable-experimental-feature Reparenting -emit-module %S/Inputs/reparentable_lib.swift -o %t
+// RUN: %target-swift-frontend -module-name output -enable-experimental-feature Reparenting -emit-ir -parse-as-library %s -I %t -o %t/output.ll
+// RUN: %FileCheck --check-prefix=CHECK --check-prefix=DEFAULT %s < %t/output.ll
+
+// RUN: %target-swift-frontend -enable-experimental-feature Reparenting -enable-relative-protocol-witness-tables -emit-module %S/Inputs/reparentable_lib.swift -o %t
+// RUN: %target-swift-frontend -module-name output -enable-experimental-feature Reparenting -enable-relative-protocol-witness-tables -emit-ir -parse-as-library %s -I %t -o %t/relative.ll
+// RUN: %FileCheck --check-prefix=CHECK --check-prefix=RELATIVE --check-prefix=RELATIVE-%target-cpu %s < %t/relative.ll
+
+// REQUIRES: swift_feature_Reparenting
+
+// REQUIRES: CPU=x86_64 || CPU=arm64 || CPU=arm64e
+
+import reparentable_lib
+
+// CHECK-LABEL: define{{.*}} void @"$s6output9__start__yyxm16reparentable_lib11MultiParentRzlF"(ptr %0, ptr %T, ptr %T.MultiParent)
+// CHECK:     [[A_IDX:%.*]] = udiv i64 sub (i64 ptrtoint (ptr @"$s16reparentable_lib11MultiParentPAA1ATb" to i64), i64 ptrtoint (ptr @"$s16reparentable_lib11MultiParentTL" to i64)), 8
+// DEFAULT:   [[A_ADDR:%.*]] = getelementptr inbounds ptr, ptr %T.MultiParent, i64 [[A_IDX]]
+// DEFAULT:   %T.A = load ptr, ptr [[A_ADDR]], align 8, !invariant.load
+// RELATIVE:  %T.A = call ptr @__swift_relative_protocol_witness_table_parent_dynamic_index_i64(ptr %T.MultiParent, i64 [[A_IDX]])
+// CHECK:     call swiftcc void @"$s6output9__upToA__yyxm16reparentable_lib1ARzlF"(ptr %T, ptr %T, ptr %T.A)
+
+// CHECK:     [[B_IDX:%.*]] = udiv i64 sub (i64 ptrtoint (ptr @"$s16reparentable_lib11MultiParentPAA1BTb" to i64), i64 ptrtoint (ptr @"$s16reparentable_lib11MultiParentTL" to i64)), 8
+// DEFAULT:   [[B_ADDR:%.*]] = getelementptr inbounds ptr, ptr %T.MultiParent, i64 [[B_IDX]]
+// DEFAULT:   %T.B = load ptr, ptr [[B_ADDR]], align 8, !invariant.load
+// RELATIVE:  %T.B = call ptr @__swift_relative_protocol_witness_table_parent_dynamic_index_i64(ptr %T.MultiParent, i64 [[B_IDX]])
+// CHECK:     call swiftcc void @"$s6output9__upToB__yyxm16reparentable_lib1BRzlF"(ptr %T, ptr %T, ptr %T.B)
+
+//            ***  NOTE: C is not reparentable ***
+// DEFAULT:   [[C_OFFSET:%.*]] = getelementptr inbounds ptr, ptr %T.MultiParent, i32 1
+// DEFAULT:   %T.C = load ptr, ptr [[C_OFFSET]], align 8, !invariant.load
+// RELATIVE:  %T.C = call ptr @__swift_relative_protocol_witness_table_parent_1(ptr %T.MultiParent)
+// CHECK:     call swiftcc void @"$s6output9__upToC__yyxm16reparentable_lib1CRzlF"(ptr %T, ptr %T, ptr %T.C)
+
+// CHECK:     [[D_IDX:%.*]] = udiv i64 sub (i64 ptrtoint (ptr @"$s16reparentable_lib11MultiParentPAA1DTb" to i64), i64 ptrtoint (ptr @"$s16reparentable_lib11MultiParentTL" to i64)), 8
+// DEFAULT:   [[D_ADDR:%.*]] = getelementptr inbounds ptr, ptr %T.MultiParent, i64 [[D_IDX]]
+// DEFAULT:   %T.D = load ptr, ptr [[D_ADDR]], align 8, !invariant.load
+// RELATIVE:  %T.D = call ptr @__swift_relative_protocol_witness_table_parent_dynamic_index_i64(ptr %T.MultiParent, i64 [[D_IDX]])
+// CHECK:     call swiftcc void @"$s6output9__upToD__yyxm16reparentable_lib1DRzlF"(ptr %T, ptr %T, ptr %T.D)
+
+public func __start__<T: MultiParent>(_: T.Type) {
+  __upToA__(T.self)
+  __upToB__(T.self)
+  __upToC__(T.self)
+  __upToD__(T.self)
+}
+
+public func __upToA__<T: A>(_: T.Type) {}
+public func __upToB__<T: B>(_: T.Type) {}
+public func __upToC__<T: C>(_: T.Type) {}
+public func __upToD__<T: D>(_: T.Type) {}
+
+
+// RELATIVE: define{{.*}} hidden ptr @__swift_relative_protocol_witness_table_parent_dynamic_index_i64(ptr [[T_INHERITED:%.*]], i64 [[INDEX:%.*]])
+// RELATIVE:  [[T0:%.*]] = ptrtoint ptr [[T_INHERITED]] to i64
+// RELATIVE:  [[T1:%.*]] = and i64 [[T0]], 1
+// RELATIVE:  [[T2:%.*]] = icmp eq i64 [[T1]], 1
+// RELATIVE:  br i1 [[T2]], label %[[L1:.*]], label %[[L2:.*]]
+
+// RELATIVE:[[L1]]:
+// RELATIVE:  [[T3:%.*]] = and i64 [[T0]], -2
+// RELATIVE:  [[T4:%.*]] = inttoptr i64 [[T3]] to ptr
+// RELATIVE:  [[T5:%.*]] = getelementptr inbounds ptr, ptr [[T4]], i64 [[INDEX]]
+// RELATIVE:  [[T6:%.*]] = load ptr, ptr [[T5]]
+// RELATIVE:  br label %[[L3:.*]]
+
+// RELATIVE:[[L2]]:
+// RELATIVE-arm64e:  [[P0:%.*]] = ptrtoint ptr [[T_INHERITED]] to i64
+// RELATIVE-arm64e:  [[P1:%.*]] = call i64 @llvm.ptrauth.auth(i64 [[P0]], i32 2, i64 47152)
+// RELATIVE-arm64e:  [[T_INHERITED:%.*]] = inttoptr i64 [[P1]] to ptr
+// RELATIVE:  [[T9:%.*]] = getelementptr inbounds i32, ptr [[T_INHERITED]], i64 [[INDEX]]
+// RELATIVE:  [[T10:%.*]] = load i32, ptr [[T9]]
+// RELATIVE:  [[T11:%.*]] = sext i32 [[T10]] to i64
+// RELATIVE:  [[T12:%.*]] = ptrtoint ptr [[T9]] to i64
+// RELATIVE:  [[T13:%.*]] = add i64 [[T12]], [[T11]]
+// RELATIVE:  [[T14:%.*]] = inttoptr i64 [[T13]] to ptr
+// RELATIVE-arm64e:  [[T16:%.*]] = ptrtoint ptr [[T14]] to i64
+// RELATIVE-arm64e:  [[T17:%.*]] = call i64 @llvm.ptrauth.sign(i64 [[T16]], i32 2, i64 47152)
+// RELATIVE-arm64e:  [[T14:%.*]] = inttoptr i64 [[T17]] to ptr
+// RELATIVE:  br label %[[L3:.*]]
+
+// RELATIVE:[[L3]]:
+// RELATIVE:  phi ptr [ [[T6]], %[[L1]] ], [ [[T14]], %[[L2]] ]

--- a/utils/rth
+++ b/utils/rth
@@ -48,8 +48,10 @@ class ResilienceTest(object):
         self.additional_compile_flags = shlex.split(additional_compile_flags)
         self.triple = triple
 
-        self.experimental_features = \
-          [item for s in experimental_features.split(',') for item in ["-enable-experimental-feature", s]]
+        self.experimental_features = []
+        if experimental_features:
+          self.experimental_features = \
+            [item for s in experimental_features.split(',') for item in ["-enable-experimental-feature", s]]
 
         self.before_dir = os.path.join(self.tmp_dir, 'before')
         self.after_dir = os.path.join(self.tmp_dir, 'after')

--- a/validation-test/Evolution/Inputs/protocol_add_reparented.swift
+++ b/validation-test/Evolution/Inputs/protocol_add_reparented.swift
@@ -120,3 +120,72 @@ public func willChirp(_ e: some SeedEater) -> Bool {
   return e.containsChirps()
 }
 #endif
+
+
+// Ensure you can reparent a protocol that previously inherited from
+// other reparentable protocols.
+
+@reparentable
+public protocol A {
+  func helloA() -> Int
+}
+
+#if !BEFORE
+@reparentable
+public protocol B {
+  func helloB(extra: Int) -> Int
+}
+#endif
+
+public protocol C {
+  func helloC() -> Int
+}
+
+@reparentable
+public protocol D {
+  func helloD(extra: Int) -> Int
+}
+
+@reparentable
+public protocol E {
+  func helloE() -> Int
+}
+
+#if BEFORE
+public protocol MultiParent: A, C, D, E {}
+#else
+public protocol MultiParent: A, B, C, D, E {}
+
+extension MultiParent: @reparented B {
+  public func helloB(extra: Int) -> Int {
+    return libraryVersion() + (extra - 19)
+  }
+}
+#endif
+
+// Tests a pre-existing reparenting by D, ensuring we can reparent something that's been reparented.
+extension MultiParent: @reparented D {
+  public func helloD(extra: Int) -> Int { return 10 + (extra - 42) }
+}
+
+// The "extra:" parameters test to ensure we call the _right_ witness function, by
+// passing in the correct extra value to cancel-out the subtraction in the expected implementation.
+
+public func library_testMultiParent_someType(_ t: some MultiParent) -> Int {
+  let baseline = t.helloA() + t.helloC() + t.helloD(extra: 42) + t.helloE()
+  #if BEFORE
+    return baseline
+  #else
+    return baseline + t.helloB(extra: 19)
+  #endif
+}
+
+public func library_testMultiParent_anyType(_ t: any MultiParent) -> Int {
+  let baseline = t.helloA() + t.helloC() + t.helloD(extra: 42) + t.helloE()
+  #if BEFORE
+    return baseline
+  #else
+    return baseline + t.helloB(extra: 19)
+  #endif
+}
+

--- a/validation-test/Evolution/test_protocol_add_reparented.swift
+++ b/validation-test/Evolution/test_protocol_add_reparented.swift
@@ -118,4 +118,19 @@ ProtocolAddReparentedTest.test("Existential Types") {
   #endif
 }
 
+
+struct MultiParentConformer: MultiParent {
+  func helloA() -> Int { clientVersion }
+  func helloC() -> Int { clientVersion }
+  func helloE() -> Int { clientVersion }
+}
+
+ProtocolAddReparentedTest.test("MultiParent") {
+  let mpc = MultiParentConformer()
+  // 3 methods defined in client, 1 in the library, and the library *might* be new and provide the 5th one.
+  let ans = (3 * clientVersion) + 10 + libraryVersion()
+  expectEqual(library_testMultiParent_someType(mpc), ans)
+  expectEqual(library_testMultiParent_anyType(mpc), ans)
+}
+
 runAllTests()


### PR DESCRIPTION
- Explanation: Fixes code generation for reparentable protocols
- Scope: Changes IRGen's strategy for computing the index of the reparentable protocol, so that resilient libraries adding a new parent to a protocol that already inherits from a reparentable protocol (the multi-reparentable case) does not break.
- Issue: rdar://173409851
- Risk: Low. There are not yet any users of reparentable protocols, as the only known one is BorrowingSequence, which is gated behind an experimental feature flag to even mention that type.
- Testing: regression tests added, including execution tests.
- Reviewers: Arnold