### PR TITLE
[AST] Fix crash in IRGenDebugInfo when a raw identifier is used for `-module-abi-name`.

### DIFF
--- a/lib/AST/ASTDemangler.cpp
+++ b/lib/AST/ASTDemangler.cpp
@@ -1336,7 +1336,9 @@ llvm::ArrayRef<ModuleDecl *>
 ASTBuilder::findPotentialModules(NodePointer node, ModuleDecl *&scratch) {
   assert(node->getKind() == Demangle::Node::Kind::Module);
 
-  const auto moduleName = node->getText();
+  // Round-trip the module name through getIdentifier to normalize it if a raw
+  // identifier was passed to `-module-abi-name`.
+  const auto moduleName = getIdentifier(node->getText()).str();
 
   if (moduleName == CLANG_HEADER_MODULE_NAME) {
     auto *importer = Ctx.getClangModuleLoader();

--- a/test/IRGen/raw_module_abi_name.swift
+++ b/test/IRGen/raw_module_abi_name.swift
@@ -1,0 +1,8 @@
+// Ensure that raw module ABI names are mangled correctly and without crashing
+// IRGenDebugInfo.
+//
+// RUN: %target-swift-frontend -module-name foo_bar -module-abi-name foo/bar -g %s -emit-ir | %FileCheck %s
+
+// CHECK: @"$s0016foobar_dsJCadlhaMXM"
+// CHECK: @"$s0016foobar_dsJCadlha0020MyStruct_kiaBDEDGcjaVMn"
+struct `My Struct` {}


### PR DESCRIPTION
- **Explanation**: When looking up modules, ASTDemangler is not correctly removing the backticks from the mangled ABI name if it's a raw identifier, which causes a crash later in `IRGenDebugInfo`.

    For example, `swiftc -v -g -module-abi-name foo/bar` with a source file of `struct S {}` produces:

    ```
    Abort: function getMangledName at IRGenDebugInfo.cpp:1098
    Failed to reconstruct type for $s0016foobar_dsJCadlha1SVD
    Original type:
    (struct_type decl="output.(file).S@<source>:17:8")
    Please submit a bug report (https://swift.org/contributing/#reporting-bugs) and include the crash backtrace.
    Pass '-Xfrontend -disable-round-trip-debug-types' to disable this assertion.
    Please submit a bug report (https://swift.org/contributing/#reporting-bugs) and include the crash backtrace.
    Stack dump:
    0.	Program arguments: /cefs/82/829658c2cef5f7c883a47ebb_swift-nightly/usr/bin/swift-frontend -frontend -emit-ir -primary-file <source> -target x86_64-unknown-linux-gnu -disable-objc-interop -no-color-diagnostics -Xcc -fno-color-diagnostics -g -debug-info-format=dwarf -dwarf-version=4 -module-abi-name "foo bar" -empty-abi-descriptor -enable-anonymous-context-mangled-names -file-compilation-dir /app -Xllvm --x86-asm-syntax=intel -no-auto-bridging-header-chaining -module-name output -in-process-plugin-server-path /cefs/82/829658c2cef5f7c883a47ebb_swift-nightly/usr/lib/swift/host/libSwiftInProcPluginServer.so -plugin-path /cefs/82/829658c2cef5f7c883a47ebb_swift-nightly/usr/lib/swift/host/plugins -plugin-path /cefs/82/829658c2cef5f7c883a47ebb_swift-nightly/usr/local/lib/swift/host/plugins -o /app/output.s
    1.	Swift version 6.4-dev (LLVM b8889af02f47cf7, Swift cf7481b28905381)
    2.	Compiling with effective version 5.10
    3.	While evaluating request IRGenRequest(IR Generation for file "<source>")
    4.	While emitting IR SIL function "@$s0018foobar_rgaGGJCFbha1SVACycfC".
     for 'init()' (at <source>:1:8)
    5.	Abort: function getMangledName at IRGenDebugInfo.cpp:1105
    | 	Failed to reconstruct type for $s0018foobar_rgaGGJCFbha1SVD
    | 	Original type:
    | 	(struct_type decl="output.(file).S@<source>:1:8")
    | 	Please submit a bug report (https://swift.org/contributing/#reporting-bugs) and include the crash backtrace.
    | 	Pass '-Xfrontend -disable-round-trip-debug-types' to disable this assertion.
     #0 0x000056c55f618318 llvm::sys::PrintStackTrace(llvm::raw_ostream&, int) (/cefs/82/829658c2cef5f7c883a47ebb_swift-nightly/usr/bin/swift-frontend+0x8b71318)
     #1 0x000056c55f615b05 llvm::sys::RunSignalHandlers() (/cefs/82/829658c2cef5f7c883a47ebb_swift-nightly/usr/bin/swift-frontend+0x8b6eb05)
     #2 0x000056c55f6190c1 SignalHandler(int, siginfo_t*, void*) Signals.cpp:0:0
     #3 0x000079fd88042520 (/lib/x86_64-linux-gnu/libc.so.6+0x42520)
     #4 0x000079fd880969fc pthread_kill (/lib/x86_64-linux-gnu/libc.so.6+0x969fc)
     #5 0x000079fd88042476 gsignal (/lib/x86_64-linux-gnu/libc.so.6+0x42476)
     #6 0x000079fd880287f3 abort (/lib/x86_64-linux-gnu/libc.so.6+0x287f3)
     #7 0x000056c559776962 (/cefs/82/829658c2cef5f7c883a47ebb_swift-nightly/usr/bin/swift-frontend+0x2ccf962)
     #8 0x000056c559776a4c (/cefs/82/829658c2cef5f7c883a47ebb_swift-nightly/usr/bin/swift-frontend+0x2ccfa4c)
     #9 0x000056c557c912a7 (anonymous namespace)::IRGenDebugInfoImpl::getMangledName(swift::irgen::DebugTypeInfo) IRGenDebugInfo.cpp:0:0
    #10 0x000056c557c8ceaf (anonymous namespace)::IRGenDebugInfoImpl::getOrCreateType(swift::irgen::DebugTypeInfo, llvm::DIScope*) IRGenDebugInfo.cpp:0:0
    #11 0x000056c557c8cb0f (anonymous namespace)::IRGenDebugInfoImpl::getOrCreateContext(swift::DeclContext*) IRGenDebugInfo.cpp:0:0
    #12 0x000056c557c84fb3 (anonymous namespace)::IRGenDebugInfoImpl::emitFunction(swift::SILDebugScope const*, llvm::Function*, swift::SILFunctionTypeRepresentation, swift::SILType, swift::DeclContext*, llvm::StringRef) IRGenDebugInfo.cpp:0:0
    #13 0x000056c557c8601f (anonymous namespace)::IRGenDebugInfoImpl::emitFunction(swift::SILFunction&, llvm::Function*) IRGenDebugInfo.cpp:0:0
    #14 0x000056c557ca6934 (anonymous namespace)::IRGenSILFunction::emitSILFunction() IRGenSIL.cpp:0:0
    #15 0x000056c557ca5ca5 swift::irgen::IRGenModule::emitSILFunction(swift::SILFunction*) (/cefs/82/829658c2cef5f7c883a47ebb_swift-nightly/usr/bin/swift-frontend+0x11feca5)
    #16 0x000056c557b3bd92 swift::irgen::IRGenerator::emitGlobalTopLevel(std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>> const&) (/cefs/82/829658c2cef5f7c883a47ebb_swift-nightly/usr/bin/swift-frontend+0x1094d92)
    #17 0x000056c5579a874c swift::IRGenRequest::evaluate(swift::Evaluator&, swift::IRGenDescriptor) const (/cefs/82/829658c2cef5f7c883a47ebb_swift-nightly/usr/bin/swift-frontend+0xf0174c)
    #18 0x000056c557a1e472 swift::GeneratedModule swift::SimpleRequest<swift::IRGenRequest, swift::GeneratedModule (swift::IRGenDescriptor), (swift::RequestFlags)17>::callDerived<0ul>(swift::Evaluator&, std::integer_sequence<unsigned long, 0ul>) const crtstuff.c:0:0
    #19 0x000056c557a1e349 swift::SimpleRequest<swift::IRGenRequest, swift::GeneratedModule (swift::IRGenDescriptor), (swift::RequestFlags)17>::evaluateRequest(swift::IRGenRequest const&, swift::Evaluator&) crtstuff.c:0:0
    #20 0x000056c5571ff86c swift::IRGenRequest::OutputType swift::Evaluator::getResultUncached<swift::IRGenRequest, swift::IRGenRequest::OutputType swift::evaluateOrFatal<swift::IRGenRequest>(swift::Evaluator&, swift::IRGenRequest)::'lambda'()>(swift::IRGenRequest const&, swift::IRGenRequest::OutputType swift::evaluateOrFatal<swift::IRGenRequest>(swift::Evaluator&, swift::IRGenRequest)::'lambda'()) crtstuff.c:0:0
    #21 0x000056c5579ac5bd swift::performIRGeneration(swift::FileUnit*, swift::IRGenOptions const&, swift::TBDGenOptions const&, std::unique_ptr<swift::SILModule, std::default_delete<swift::SILModule>>, llvm::StringRef, swift::PrimarySpecificPaths const&, std::shared_ptr<llvm::cas::ObjectStore>, llvm::StringRef, llvm::GlobalVariable**, swift::cas::SwiftCASOutputBackend*, std::optional<llvm::cas::ObjectRef>) (/cefs/82/829658c2cef5f7c883a47ebb_swift-nightly/usr/bin/swift-frontend+0xf055bd)
    #22 0x000056c5574b9db5 generateIR(swift::IRGenOptions const&, swift::TBDGenOptions const&, std::unique_ptr<swift::SILModule, std::default_delete<swift::SILModule>>, swift::PrimarySpecificPaths const&, std::shared_ptr<llvm::cas::ObjectStore>, swift::cas::SwiftCASOutputBackend*, llvm::StringRef, llvm::PointerUnion<swift::ModuleDecl*, swift::SourceFile*>, llvm::GlobalVariable*&, llvm::ArrayRef<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>, llvm::ArrayRef<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>, std::optional<llvm::cas::ObjectRef>) FrontendTool.cpp:0:0
    #23 0x000056c5574b27f3 performCompileStepsPostSILGen(swift::CompilerInstance&, std::unique_ptr<swift::SILModule, std::default_delete<swift::SILModule>>, llvm::PointerUnion<swift::ModuleDecl*, swift::SourceFile*>, swift::PrimarySpecificPaths const&, int&, swift::FrontendObserver*, llvm::ArrayRef<char const*>, llvm::ArrayRef<swift::PrimarySpecificPaths>) FrontendTool.cpp:0:0
    #24 0x000056c5574b0c1f swift::performCompileStepsPostSema(swift::CompilerInstance&, int&, swift::FrontendObserver*, llvm::ArrayRef<char const*>) (/cefs/82/829658c2cef5f7c883a47ebb_swift-nightly/usr/bin/swift-frontend+0xa09c1f)
    #25 0x000056c5574c8b7a withSemanticAnalysis(swift::CompilerInstance&, swift::FrontendObserver*, llvm::function_ref<bool (swift::CompilerInstance&)>, bool) FrontendTool.cpp:0:0
    #26 0x000056c5574b6a59 performCompile(swift::CompilerInstance&, int&, swift::FrontendObserver*, llvm::ArrayRef<char const*>) FrontendTool.cpp:0:0
    #27 0x000056c5574b368e swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/cefs/82/829658c2cef5f7c883a47ebb_swift-nightly/usr/bin/swift-frontend+0xa0c68e)
    #28 0x000056c5571d64f8 swift::mainEntry(int, char const**) (/cefs/82/829658c2cef5f7c883a47ebb_swift-nightly/usr/bin/swift-frontend+0x72f4f8)
    #29 0x000079fd88029d90 (/lib/x86_64-linux-gnu/libc.so.6+0x29d90)
    #30 0x000079fd88029e40 __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x29e40)
    #31 0x000056c5571d53b5 _start (/cefs/82/829658c2cef5f7c883a47ebb_swift-nightly/usr/bin/swift-frontend+0x72e3b5)
    ```

    I'm not sure when the regression began. The 6.3 release doesn't have this bug, but `main` does. The code in ASTDemangler here hasn't been touched in a while, but I believe this is the right fix—once demangled, we need to use the logic in `getIdentifier` to strip the backticks as we would for any other text node that represents an identifier.

- **Scope**: Low
- **Issues**: N/A.
- **Original PRs**: N/A.
- **Risk**: Low. This only impacts module ABI names that use raw identifiers and fixes a crash.
- **Testing**: Added lit tests to catch future regressions.
- **Reviewers**: N/A.
