### PR TITLE
[android][test] Switch tests that are failing with NDK 28 to XFAIL

### DIFF
--- a/test/Interop/Cxx/class/invalid-members/stdlib-containers-of-incomplete.swift
+++ b/test/Interop/Cxx/class/invalid-members/stdlib-containers-of-incomplete.swift
@@ -31,7 +31,7 @@
 // REQUIRES: swift_feature_ImportCxxMembersLazily
 
 // Requires specifying the Android API when compiling
-// UNSUPPORTED: OS=linux-android, OS=linux-androideabi
+// XFAIL: OS=linux-android, OS=linux-androideabi
 
 //--- Inputs/module.modulemap
 module StdContain {

--- a/test/Reflection/typeref_decoding_packs.swift
+++ b/test/Reflection/typeref_decoding_packs.swift
@@ -18,7 +18,7 @@
 // RUN: %target-swift-reflection-dump %t/TypesToReflect | %FileCheck %s
 
 // Fails only with Android NDK 28 because of an lld issue
-// UNSUPPORTED: OS=linux-android
+// XFAIL: OS=linux-android
 
 // CHECK: FIELDS:
 // CHECK: =======

--- a/test/Reflection/typeref_lowering_packs.swift
+++ b/test/Reflection/typeref_lowering_packs.swift
@@ -17,7 +17,7 @@
 // REQUIRES: PTRSIZE=64
 
 // Fails only with Android NDK 28 because of an lld issue
-// UNSUPPORTED: OS=linux-android
+// XFAIL: OS=linux-android
 
 12TypeLowering6SimpleV
 


### PR DESCRIPTION
We're getting the next LTS NDK 30 ready, some of these can be re-enabled after that.

- **Explanation**: These tests were marked as unsupported because one Android CI was building with NDK 27 and another with NDK 28 at the time we were updating the Windows CI to NDK 28. Now that both CI are on NDK 28, we can mark them `XFAIL`, as @compnerd wanted, so that we are notified when we go to NDK 30 and they start passing, if we forget.

- **Scope**: Only three tests when run on Android alone

- **Issues**: the first test fails because of versioned target triples, #85522, the others because of an old lld in NDK 28

- **Risk**: None

- **Testing**: Makes no difference, since they are expected to fail either way

- **Reviewers**: @compnerd
