### PR TITLE
Remove unnecessary fields from the pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,10 +16,6 @@ The main branch is now in convergence, which means major changes, such as large 
   <!--
   References to issues the changes resolve, if any.
   -->
-- **Original PRs**:
-  <!--
-  Links to mainline branch pull requests in which the changes originated.
-  -->
 - **Risk**:
   <!--
   The (specific) risk to the release for taking the changes.
@@ -28,13 +24,6 @@ The main branch is now in convergence, which means major changes, such as large 
   <!--
   The specific testing that has been done or needs to be done to further
   validate any impact of the changes.
-  -->
-- **Reviewers**:
-  <!--
-  The code owners that GitHub-approved the original changes in the mainline
-  branch pull requests. If an original change has not been GitHub-approved by
-  a respective code owner, provide a reason. Technical review can be delegated
-  by a code owner or otherwise requested as deemed appropriate or useful.
   -->
 
 <!--


### PR DESCRIPTION
With `main` in convergence mode and no release branch active yet, the "Original PR:" and "Reviewers:" fields of the pull request template are confusing because they don't make sense for the vast majority of PRs. Once there is a release branch that changes are being regularly cherry-picked to, the fields can be added back on the release branch.