### PR TITLE
Write `yielding` accessor names to swiftinterface files

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -524,8 +524,6 @@ EXPERIMENTAL_FEATURE(ImportCxxMembersLazily, true)
 // TODO: When this is turned on by default, take care of:
 // * "TODO" around line 8100 of lib/Parse/ParseDecl.cpp
 //   (Don't diagnose bare "read"/"modify" in accessors in source files.)
-// * "TODO" around line 12475 of lib/AST/Decl.cpp
-//   (Don't use "read"/"modify" in swiftinterface files.)
 SUPPRESSIBLE_EXPERIMENTAL_FEATURE(CoroutineAccessors, true)
 
 /// `yielding borrow` and `yielding mutate` coroutine

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -12597,15 +12597,8 @@ StringRef swift::getAccessorLabel(AccessorKind kind) {
 #define ACCESSOR(ID, KEYWORD)
 #include "swift/AST/AccessorKinds.def"
 
-    // Transitional terminology.  Let's use this for a little
-    // while to ease the transition.  (Both forms are parsed
-    // correctly, this just changes what gets written into
-    // .swiftinterface files.)
-    case AccessorKind::YieldingBorrow: return "read";
-    case AccessorKind::YieldingMutate: return "modify";
-    // TODO: Switch to the final terminology before shipping...
-    // case AccessorKind::YieldingBorrow: return "yielding borrow";
-    // case AccessorKind::YieldingMutate: return "yielding mutate";
+    case AccessorKind::YieldingBorrow: return "yielding borrow";
+    case AccessorKind::YieldingMutate: return "yielding mutate";
   }
   llvm_unreachable("bad accessor kind");
 }

--- a/test/ModuleInterface/coroutine_accessors.swift
+++ b/test/ModuleInterface/coroutine_accessors.swift
@@ -12,8 +12,8 @@ var _i: Int = 0
 
 // CHECK:      #if compiler(>=5.3) && $CoroutineAccessors
 // CHECK-NEXT: public var i: Swift::Int {
-// CHECK-NEXT:   read
-// CHECK-NEXT:   modify
+// CHECK-NEXT:   yielding borrow
+// CHECK-NEXT:   yielding mutate
 // CHECK-NEXT: }
 // CHECK-NEXT: #else
 // CHECK-NEXT: public var i: Swift::Int {


### PR DESCRIPTION
Back in January, I updated the swiftinterface _reading_ code to accept either `read`/`modify` or `yielding borrow`/`yielding mutate`.  That update has been around for long enough that we can now switch over the swiftinterface _writing_ code to emit the standard final `yielding borrow`/`yielding mutate` spellings.

Interface files written with the old spellings will continue to be accepted for some time (likely a year or more).

- **Explanation**:  Use the SE-0474 spellings in swift interface files
- **Scope**: Affects the writing of swift interface files for software that uses the still-experimental `CoroutineAccessors` feature
- **Issues**:  rdar://168152401 
- **Risk**: The swift interface _reading_ code has recognized this spelling as a synonym for the older `read`/`modify` spelling since mid-January.
- **Testing**:  Updated existing unit tests to verify the new spelling is written.  There are already existing tests to verify the new spelling is correctly read.