### PR TITLE
Sema: require UnderscoreOwned to use `@_owned`

### DIFF
--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -332,7 +332,8 @@ public:
   void visitOwnedAttr(OwnedAttr *attr) {
     assert(!D->hasClangNode() && "@_owned on imported declaration?");
 
-    if (!Ctx.LangOpts.hasFeature(Feature::UnderscoreOwned)) {
+    if (!Ctx.LangOpts.hasFeature(Feature::UnderscoreOwned) &&
+        !D->getDeclContext()->isInSwiftinterface()) {
       Ctx.Diags.diagnose(attr->getLocation(),
                          diag::attribute_requires_experimental_feature, attr,
                          "UnderscoreOwned");

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -332,6 +332,12 @@ public:
   void visitOwnedAttr(OwnedAttr *attr) {
     assert(!D->hasClangNode() && "@_owned on imported declaration?");
 
+    if (!Ctx.LangOpts.hasFeature(Feature::UnderscoreOwned)) {
+      Ctx.Diags.diagnose(attr->getLocation(),
+                         diag::attribute_requires_experimental_feature, attr,
+                         "UnderscoreOwned");
+    }
+
     auto *ASD = cast<AbstractStorageDecl>(D);
 
     // Ensure it defines a 'get' for read accesses.

--- a/test/Interpreter/moveonly_resilient_capture_during_deinit.swift
+++ b/test/Interpreter/moveonly_resilient_capture_during_deinit.swift
@@ -1,11 +1,11 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -emit-module-path %t -enable-library-evolution -module-name moveonly_resilient_type -parse-as-library %S/Inputs/moveonly_resilient_type.swift -c -o %t/moveonly_resilient_type.o
-// RUN: %target-build-swift -enable-library-evolution -module-name moveonly_resilient_type -parse-as-library %S/Inputs/moveonly_resilient_type.swift -c -o %t/moveonly_resilient_type.o
+// RUN: %target-build-swift -enable-experimental-feature UnderscoreOwned -emit-module-path %t -enable-library-evolution -module-name moveonly_resilient_type -parse-as-library %S/Inputs/moveonly_resilient_type.swift -c -o %t/moveonly_resilient_type.o
 // RUN: %target-build-swift -o %t/a.out -I %t %s %t/moveonly_resilient_type.o
 // RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: executable_test
+// REQUIRES: swift_feature_UnderscoreOwned
 
 import moveonly_resilient_type
 

--- a/test/Interpreter/moveonly_resilient_deinit_on_throw.swift
+++ b/test/Interpreter/moveonly_resilient_deinit_on_throw.swift
@@ -1,11 +1,11 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -emit-module-path %t -enable-library-evolution -module-name moveonly_resilient_type -parse-as-library %S/Inputs/moveonly_resilient_type.swift -c -o %t/moveonly_resilient_type.o
-// RUN: %target-build-swift -enable-library-evolution -module-name moveonly_resilient_type -parse-as-library %S/Inputs/moveonly_resilient_type.swift -c -o %t/moveonly_resilient_type.o
+// RUN: %target-build-swift -enable-experimental-feature UnderscoreOwned -emit-module-path %t -enable-library-evolution -module-name moveonly_resilient_type -parse-as-library %S/Inputs/moveonly_resilient_type.swift -c -o %t/moveonly_resilient_type.o
 // RUN: %target-build-swift -o %t/a.out -I %t %s %t/moveonly_resilient_type.o
 // RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: executable_test
+// REQUIRES: swift_feature_UnderscoreOwned
 
 // CHECK: starting
 

--- a/test/Interpreter/moveonly_resilient_owned_get.swift
+++ b/test/Interpreter/moveonly_resilient_owned_get.swift
@@ -1,11 +1,11 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -emit-module-path %t -enable-library-evolution -module-name moveonly_resilient_type -parse-as-library %S/Inputs/moveonly_resilient_type.swift -c -o %t/moveonly_resilient_type.o
-// RUN: %target-build-swift -enable-library-evolution -module-name moveonly_resilient_type -parse-as-library %S/Inputs/moveonly_resilient_type.swift -c -o %t/moveonly_resilient_type.o
+// RUN: %target-build-swift -enable-experimental-feature UnderscoreOwned -emit-module-path %t -enable-library-evolution -module-name moveonly_resilient_type -parse-as-library %S/Inputs/moveonly_resilient_type.swift -c -o %t/moveonly_resilient_type.o
 // RUN: %target-build-swift -o %t/a.out -I %t %s %t/moveonly_resilient_type.o
 // RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: executable_test
+// REQUIRES: swift_feature_UnderscoreOwned
 
 import moveonly_resilient_type
 

--- a/test/SILGen/moveonly_consuming_get_on_rvalue.swift
+++ b/test/SILGen/moveonly_consuming_get_on_rvalue.swift
@@ -1,7 +1,8 @@
-// RUN: %target-swift-emit-silgen -module-name test -enable-experimental-feature Lifetimes %s | %FileCheck %s
-// RUN: %target-swift-emit-sil -module-name test -enable-experimental-feature Lifetimes %s -sil-verify-all
+// RUN: %target-swift-emit-silgen -module-name test -enable-experimental-feature UnderscoreOwned -enable-experimental-feature Lifetimes %s | %FileCheck %s
+// RUN: %target-swift-emit-sil -module-name test -enable-experimental-feature UnderscoreOwned -enable-experimental-feature Lifetimes %s -sil-verify-all
 
 // REQUIRES: swift_feature_Lifetimes
+// REQUIRES: swift_feature_UnderscoreOwned
 
 // Test that calling a consuming accessor on a noncopyable rvalue passes the owned value directly
 // instead of initiating a borrow scope and copying the value within it.

--- a/test/SILGen/owned_attr.swift
+++ b/test/SILGen/owned_attr.swift
@@ -1,6 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -enable-library-evolution -emit-module-path=%t/OwnedAttrLib.swiftmodule -emit-module-interface-path %t/OwnedAttrLib.swiftinterface -module-name=OwnedAttrLib %S/Inputs/owned_attr.swift \
-// RUN:     -enable-experimental-feature Lifetimes
+// RUN:     -enable-experimental-feature Lifetimes \
+// RUN:     -enable-experimental-feature UnderscoreOwned
 
 // RUN: %target-swift-emit-silgen -module-name X %s -I %t -enable-experimental-feature Lifetimes | %FileCheck %s
 // RUN: %target-swift-emit-sil -module-name X %s -I %t -enable-experimental-feature Lifetimes -verify
@@ -8,6 +9,7 @@
 // RUN: %FileCheck --check-prefix CHECK-INTERFACE %s < %t/OwnedAttrLib.swiftinterface
 
 // REQUIRES: swift_feature_Lifetimes
+// REQUIRES: swift_feature_UnderscoreOwned
 
 import OwnedAttrLib
 

--- a/test/SILGen/owned_attr.swift
+++ b/test/SILGen/owned_attr.swift
@@ -6,6 +6,7 @@
 // RUN: %target-swift-emit-silgen -module-name X %s -I %t -enable-experimental-feature Lifetimes | %FileCheck %s
 // RUN: %target-swift-emit-sil -module-name X %s -I %t -enable-experimental-feature Lifetimes -verify
 
+// RUN: %target-swift-typecheck-module-from-interface(%t/OwnedAttrLib.swiftinterface)
 // RUN: %FileCheck --check-prefix CHECK-INTERFACE %s < %t/OwnedAttrLib.swiftinterface
 
 // REQUIRES: swift_feature_Lifetimes

--- a/test/attr/attr_borrowed.swift
+++ b/test/attr/attr_borrowed.swift
@@ -28,9 +28,11 @@ public class Holder {
     get throws { "" } // expected-error {{getter cannot be '@_borrowed' if it is 'async' or 'throws'}}
   }
 
+  // expected-error@+1 {{'@_owned' is an experimental feature; use '-enable-experimental-feature UnderscoreOwned'}}
   @_borrowed @_owned var three: String { // expected-error {{property cannot be '@_borrowed' and '@_owned' at the same time}}
     get { "" }
   }
+  // expected-error@+1 {{'@_owned' is an experimental feature; use '-enable-experimental-feature UnderscoreOwned'}}
   @_owned var four: String { // expected-error {{property must define a 'get' to support '@_owned'}}
     _read {
       let x = ""


### PR DESCRIPTION
If we don't require that experimental feature to be enabled, users might accidentally publish swiftinterface files with public types using the attribute, but their swiftinterface file will lack the `-enable-experimental-feature UnderscoreOwned`, which would tell compilers consuming that interface file to enable the feature if they support it. If we're missing that, all of the properties guarded by `#if $UnderscoreOwned` will evaluate to false and thus they'll not appear to be part of the type's interface.

It's a valuable thing to make an error as people may be publishing interfaces that are hiding the computed property always.

resolves rdar://174880934