### PR TITLE
Revert "[Windows] [ARM64] Fix cross compiled arm64 package"

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -2436,7 +2436,7 @@ function Patch-mimalloc() {
     [hashtable]$Platform
   )
 
-  $BuildSuffix = if ($Platform -eq $KnownPlatforms["WindowsX64"]) { "" } else { "-arm64" }
+  $BuildSuffix = if ($BuildPlatform -eq $KnownPlatforms["WindowsX64"]) { "" } else { "-arm64" }
 
   $Tools = @(
     "swift.exe",


### PR DESCRIPTION
Reverts swiftlang/swift#88482

failed in https://ci-external.swift.org/job/swift-main-windows-toolchain-arm64/1960