### PR TITLE
Fix use-after-free in Demangler caused by Words[] not saved across nested demangle calls

### DIFF
--- a/include/swift/Demangling/Demangler.h
+++ b/include/swift/Demangling/Demangler.h
@@ -496,6 +496,7 @@ protected:
     Vector<NodePointer> NodeStack;
     Vector<NodePointer> Substitutions;
     int NumWords;
+    StringRef Words[MaxNumWords];
     StringRef Text;
     size_t Pos;
     std::function<SymbolicReferenceResolver_t> SymbolicReferenceResolver;

--- a/lib/Demangling/Demangler.cpp
+++ b/lib/Demangling/Demangler.cpp
@@ -735,6 +735,7 @@ Demangler::DemangleInitRAII::DemangleInitRAII(Demangler &Dem,
     NumWords(Dem.NumWords), Text(Dem.Text), Pos(Dem.Pos),
     SymbolicReferenceResolver(std::move(Dem.SymbolicReferenceResolver))
 {
+  std::copy(Dem.Words, Dem.Words + MaxNumWords, Words);
   // Reset the demangler state for a nested job.
   Dem.NodeStack.init(Dem, 16);
   Dem.Substitutions.init(Dem, 16);
@@ -749,6 +750,7 @@ Demangler::DemangleInitRAII::~DemangleInitRAII() {
   Dem.NodeStack = NodeStack;
   Dem.Substitutions = Substitutions;
   Dem.NumWords = NumWords;
+  std::copy(Words, Words + MaxNumWords, Dem.Words);
   Dem.Text = Text;
   Dem.Pos = Pos;
   Dem.SymbolicReferenceResolver = std::move(SymbolicReferenceResolver);

--- a/unittests/Basic/DemangleTest.cpp
+++ b/unittests/Basic/DemangleTest.cpp
@@ -58,3 +58,80 @@ TEST(Demangle, DeepEquals) {
     EXPECT_TRUE(tree1->isDeepEqualTo(tree2)) << "Failing symbol: " << Symbol;
   }
 }
+
+// Test that DemangleInitRAII correctly saves and restores the Words[] array
+// across nested demangle calls.
+//
+// When demangleType hits a symbolic reference, the resolver may call
+// demangleSymbol on the same Demangler. This is what MetadataReader does
+// when resolving context descriptors via buildContextManglingForSymbol.
+// The inner call processes identifiers that populate Words[] with StringRefs
+// into its own Text buffer. DemangleInitRAII must save and restore Words[]
+// so the outer demangling's word substitutions still reference the correct
+// strings.
+//
+// The mangled type encodes something like:
+//   SomeModule.SomeType<OtherModule.OtherType>
+// where the generic argument's context comes from a symbolic reference.
+// "SomeModule" and "SomeType" produce Words[0]="Some", [1]="Module",
+// [2]="Some", [3]="Type". The suffix "05OtherD0" reconstructs "OtherType"
+// using word substitution 'D' = Words[3] = "Type".
+TEST(Demangle, WordsArraySavedAcrossNestedDemangle) {
+  Demangler dem;
+
+  // Mangled type: 10SomeModule 8SomeType V y \x01<offset> 05OtherD0 V G
+  static const char mangledName[] =
+      "10SomeModule"         // module identifier
+      "8SomeType"            // type identifier
+      "V"                    // struct
+      "y"                    // begin generic args
+      "\x01\x00\x00\x00\x00" // symbolic reference (0x01) + int32 offset (unused)
+      "05OtherD0"            // identifier with word substitution 'D' = Words[3]
+      "V"                    // struct
+      "G";                   // end generic args
+
+  auto resolver = [&](SymbolicReferenceKind kind, Directness directness,
+                      int32_t offset,
+                      const void *base) -> NodePointer {
+    // Demangle a symbol on the same Demangler instance, triggering
+    // DemangleInitRAII. The symbol string is a local std::string whose
+    // buffer is freed when the lambda returns — if Words[] is not properly
+    // saved/restored, the outer demangling reads stale pointers.
+    std::string symbol("$s11OtherModule9OtherTypeVMn");
+    auto node = dem.demangleSymbol(symbol);
+    if (!node)
+      return nullptr;
+    // Unwrap Global → NominalTypeDescriptor → Type
+    if (node->getKind() == Node::Kind::Global)
+      node = node->getChild(0);
+    if (node->getKind() == Node::Kind::NominalTypeDescriptor)
+      node = node->getChild(0);
+    return node;
+  };
+
+  auto mangledStr = makeSymbolicMangledNameStringRef(mangledName);
+  auto result = dem.demangleType(mangledStr, resolver);
+
+  ASSERT_NE(result, nullptr);
+
+  // The word substitution 'D' in "05OtherD0" must resolve to Words[3]="Type"
+  // (from the outer "SomeType"), producing the identifier "OtherType".
+  ASSERT_EQ(result->getKind(), Node::Kind::Type);
+  auto boundGeneric = result->getChild(0);
+  ASSERT_EQ(boundGeneric->getKind(), Node::Kind::BoundGenericStructure);
+
+  auto someType = boundGeneric->getChild(0);
+  ASSERT_EQ(someType->getKind(), Node::Kind::Type);
+  auto structure = someType->getChild(0);
+  ASSERT_EQ(structure->getKind(), Node::Kind::Structure);
+  EXPECT_EQ(structure->getChild(0)->getText(), "SomeModule");
+  EXPECT_EQ(structure->getChild(1)->getText(), "SomeType");
+
+  auto typeList = boundGeneric->getChild(1);
+  ASSERT_EQ(typeList->getKind(), Node::Kind::TypeList);
+  auto argType = typeList->getChild(0);
+  ASSERT_EQ(argType->getKind(), Node::Kind::Type);
+  auto argStruct = argType->getChild(0);
+  ASSERT_EQ(argStruct->getKind(), Node::Kind::Structure);
+  EXPECT_EQ(argStruct->getChild(1)->getText(), "OtherType");
+}

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -17,6 +17,7 @@ if(SWIFT_INCLUDE_TOOLS)
   add_subdirectory(Sema)
   add_subdirectory(SIL)
   add_subdirectory(SILOptimizer)
+  add_subdirectory(MetadataReader)
   add_subdirectory(SwiftDemangle)
 
   add_subdirectory(Threading)

--- a/unittests/MetadataReader/CMakeLists.txt
+++ b/unittests/MetadataReader/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_swift_unittest(SwiftMetadataReaderTests
+  MetadataReaderTest.cpp)
+target_link_libraries(SwiftMetadataReaderTests
+  PRIVATE
+  swiftBasic
+  swiftDemangling
+  )

--- a/unittests/MetadataReader/MetadataReaderTest.cpp
+++ b/unittests/MetadataReader/MetadataReaderTest.cpp
@@ -1,0 +1,234 @@
+//===--- MetadataReaderTest.cpp -------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/Remote/MetadataReader.h"
+#include "swift/Remote/MemoryReader.h"
+#include "swift/Demangling/Demangle.h"
+#include "swift/Demangling/Demangler.h"
+#include "gtest/gtest.h"
+
+#include <cstring>
+#include <map>
+#include <vector>
+
+using namespace swift;
+using namespace swift::remote;
+using namespace swift::Demangle;
+
+namespace {
+
+/// A MemoryReader that serves pre-configured memory regions and can return
+/// symbols for specific addresses, enabling tests that exercise MetadataReader
+/// code paths without requiring a real remote process.
+class MockMemoryReader final : public MemoryReader {
+public:
+  /// Register a block of bytes at the given address.
+  void addMemory(uint64_t address, const void *data, size_t size) {
+    auto &vec = Memory[address];
+    vec.resize(size);
+    memcpy(vec.data(), data, size);
+  }
+
+  /// Register a symbol for resolvePointerAsSymbol at the given address.
+  void addResolveSymbol(uint64_t address, std::string symbol) {
+    ResolveSymbols[address] = std::move(symbol);
+  }
+
+private:
+  std::map<uint64_t, std::vector<uint8_t>> Memory;
+  std::map<uint64_t, std::string> ResolveSymbols;
+
+  bool queryDataLayout(DataLayoutQueryType type, void *inBuffer,
+                       void *outBuffer) override {
+    switch (type) {
+    case DLQ_GetPointerSize: {
+      *static_cast<uint8_t *>(outBuffer) = 8;
+      return true;
+    }
+    case DLQ_GetSizeSize: {
+      *static_cast<uint8_t *>(outBuffer) = 8;
+      return true;
+    }
+    case DLQ_GetPtrAuthMask: {
+      *static_cast<uint64_t *>(outBuffer) = ~uint64_t(0);
+      return true;
+    }
+    case DLQ_GetObjCReservedLowBits: {
+      *static_cast<uint8_t *>(outBuffer) = 0;
+      return true;
+    }
+    case DLQ_GetLeastValidPointerValue: {
+      *static_cast<uint64_t *>(outBuffer) = 0x1000;
+      return true;
+    }
+    case DLQ_GetObjCInteropIsEnabled:
+      return false;
+    }
+    return false;
+  }
+
+  RemoteAddress getSymbolAddress(const std::string &name) override {
+    return RemoteAddress();
+  }
+
+  bool readString(RemoteAddress address, std::string &dest) override {
+    auto it = Memory.find(address.getRawAddress());
+    if (it == Memory.end())
+      return false;
+    const char *data = reinterpret_cast<const char *>(it->second.data());
+    size_t maxLen = it->second.size();
+    size_t len = strnlen(data, maxLen);
+    dest.assign(data, len);
+    return true;
+  }
+
+  ReadBytesResult readBytes(RemoteAddress address, uint64_t size) override {
+    auto it = Memory.find(address.getRawAddress());
+    if (it == Memory.end())
+      return ReadBytesResult();
+    if (size > it->second.size())
+      return ReadBytesResult();
+    void *buf = malloc(size);
+    memcpy(buf, it->second.data(), size);
+    return ReadBytesResult(buf,
+                           [](const void *p) { free(const_cast<void *>(p)); });
+  }
+
+  std::optional<RemoteAbsolutePointer>
+  resolvePointerAsSymbol(RemoteAddress address) override {
+    auto it = ResolveSymbols.find(address.getRawAddress());
+    if (it != ResolveSymbols.end())
+      return RemoteAbsolutePointer(it->second, 0, address);
+    return std::nullopt;
+  }
+};
+
+/// A minimal builder type that satisfies MetadataReader's template
+/// requirements. None of these types are exercised by the code under test.
+struct StubBuilder {
+  using BuiltType = const void *;
+  using BuiltTypeDecl = const void *;
+  using BuiltProtocolDecl = const void *;
+  using BuiltRequirement = std::monostate;
+  using BuiltSubstitution = std::monostate;
+  using BuiltSubstitutionMap = std::monostate;
+  using BuiltGenericSignature = const void *;
+};
+
+using Runtime = External<NoObjCInterop<RuntimeTarget<8>>>;
+using TestMetadataReader = MetadataReader<Runtime, StubBuilder>;
+
+} // end anonymous namespace
+
+// Test that DemangleInitRAII correctly saves and restores the Words[] array
+// across nested demangle calls.
+//
+// When the demangler hits a symbolic reference during demangleType, the
+// resolver calls buildContextManglingForSymbol → dem.demangleSymbol(symbol)
+// on the same Demangler instance. The inner demangleSymbol processes
+// identifiers that populate Words[] with StringRefs into its own Text
+// buffer. DemangleInitRAII must save and restore Words[] so the outer
+// demangling's word substitutions still reference the correct strings.
+//
+// Consider a Swift program with types whose mangled names use word
+// substitutions and symbolic references:
+//
+//   // SomeModule
+//   struct SomeType<T> { var field: T }
+//
+//   // OtherModule (compiled separately, referenced via symbolic ref)
+//   struct OtherType { ... }
+//
+//   // A field of type SomeModule.SomeType<OtherModule.OtherType>
+//   // The field's type reference in the reflection metadata is mangled as:
+//   //   10SomeModule 8SomeType V y \x01<symref> 05OtherD0 V G
+//   //
+//   // The demangler splits identifiers into words at camelCase boundaries
+//   // (see docs/ABI/Mangling.rst). "SomeModule" produces Words[0]="Some",
+//   // Words[1]="Module". "SomeType" produces Words[2]="Some",
+//   // Words[3]="Type". \x01<symref> is a symbolic reference to
+//   // OtherModule's context descriptor. "05OtherD0" reconstructs
+//   // "OtherType" using word substitution 'D' = Words[3] = "Type".
+TEST(MetadataReader, WordsArraySavedAcrossNestedDemangle) {
+  auto reader = std::make_shared<MockMemoryReader>();
+
+  // Mangled type (see breakdown above):
+  //   10SomeModule 8SomeType V y \x01<offset> 05OtherD0 V G \0
+  const uint64_t mangledNameAddr = 0x5000;
+  const uint64_t symbolicRefTarget = 0x5100;
+
+  // The \x01 byte is at index 23 ("10SomeModule8SomeTypeVy" = 23 bytes).
+  // The resolver computes: remoteAddress = (mangledNameAddr + 24) + offset.
+  int32_t offset = symbolicRefTarget - (mangledNameAddr + 24);
+
+  uint8_t mangledName[40];
+  const char *prefix = "10SomeModule8SomeTypeVy";
+  memcpy(&mangledName[0], prefix, 23);
+  mangledName[23] = 0x01; // direct context symbolic reference
+  memcpy(&mangledName[24], &offset, 4);
+  const char *suffix = "05OtherD0VG";
+  memcpy(&mangledName[28], suffix, 12); // includes NUL terminator
+
+  reader->addMemory(mangledNameAddr, mangledName, sizeof(mangledName));
+
+  // getSymbol(symbolicRefTarget) returns the nominal type descriptor for
+  // OtherModule.OtherType. The resolver creates a ParentContextDescriptorRef
+  // and calls dem.demangleSymbol() on its string, which is the nested
+  // demangle call whose Words[] must not leak into the outer context.
+  const char *otherModuleDescriptor = "$s11OtherModule9OtherTypeVMn";
+  reader->addResolveSymbol(symbolicRefTarget, otherModuleDescriptor);
+
+  TestMetadataReader metadataReader(reader);
+  Demangler dem;
+
+  // The word substitution 'D' in "05OtherD0" references Words[3].
+  // If Words[] is correctly saved/restored across the nested demangle,
+  // Words[3] = "Type" (from the outer "SomeType") and the identifier
+  // resolves to "OtherType".
+  auto result = metadataReader.demangle(
+      RemoteRef<char>(RemoteAddress(mangledNameAddr, 0),
+                      reinterpret_cast<const char *>(mangledName)),
+      MangledNameKind::Type, dem);
+
+  ASSERT_NE(result, nullptr);
+
+  // Result: SomeModule.SomeType<OtherModule.OtherType.OtherType>
+  // Tree: Type → BoundGenericStructure → [Type(Structure), TypeList]
+  ASSERT_EQ(result->getKind(), Node::Kind::Type);
+  auto boundGeneric = result->getChild(0);
+  ASSERT_EQ(boundGeneric->getKind(), Node::Kind::BoundGenericStructure);
+
+  // First child: the generic type SomeModule.SomeType
+  auto someType = boundGeneric->getChild(0);
+  ASSERT_EQ(someType->getKind(), Node::Kind::Type);
+  auto structure = someType->getChild(0);
+  ASSERT_EQ(structure->getKind(), Node::Kind::Structure);
+  auto module = structure->getChild(0);
+  ASSERT_EQ(module->getKind(), Node::Kind::Module);
+  EXPECT_EQ(module->getText(), "SomeModule");
+  auto ident = structure->getChild(1);
+  ASSERT_EQ(ident->getKind(), Node::Kind::Identifier);
+  EXPECT_EQ(ident->getText(), "SomeType");
+
+  // Second child: the type argument list containing the generic argument.
+  // The word substitution 'D' = Words[3] = "Type" must resolve correctly
+  // for this identifier to be "OtherType".
+  auto typeList = boundGeneric->getChild(1);
+  ASSERT_EQ(typeList->getKind(), Node::Kind::TypeList);
+  auto argType = typeList->getChild(0);
+  ASSERT_EQ(argType->getKind(), Node::Kind::Type);
+  auto argStruct = argType->getChild(0);
+  ASSERT_EQ(argStruct->getKind(), Node::Kind::Structure);
+  auto argIdent = argStruct->getChild(1);
+  ASSERT_EQ(argIdent->getKind(), Node::Kind::Identifier);
+  EXPECT_EQ(argIdent->getText(), "OtherType");
+}


### PR DESCRIPTION
DemangleInitRAII saves and restores NumWords but not the Words[] array itself. When a nested demangleSymbol/demangleType call processes identifiers, it overwrites Words[] entries with StringRefs pointing into its own Text buffer. After ~DemangleInitRAII restores the outer NumWords, those entries still reference the inner (now-destroyed) buffer. The outer demangling then hits a word substitution and reads freed memory through the stale StringRef.

In practice this is triggered by MetadataReader::demangle(): the symbolic reference resolver calls buildContextManglingForSymbol which calls dem.demangleSymbol() on the same Demangler. The inner symbol's identifiers overwrite Words[] with pointers into the ParentContextDescriptorRef's temporary string. When the resolver returns and the PCCDR is destroyed, the outer demangleType accesses dangling Words[] entries via word substitution identifiers.

The fix adds Words[] to DemangleInitRAII's saved/restored state.

rdar://172223904

<!--
The main branch is now in convergence, which means major changes, such as large refactoring or new features, should be avoided. This strategy is intended to maintain the stability of the Swift 6.4 release leading up to the May 4th branch. For any work that requires broad changes or introduces new features, create a feature branch and open a draft pull request. All updates to the swiftlang/swift repository’s main branch require approval from the release managers. A pull request targeting swiftlang/swift will automatically add release managers. You can also contact them via @release-managers in the forum group.
-->

<!-- Please fill out the following form: --> 
- **Explanation**:
Fix a use-after-free in the Demangler
- **Scope**:
This only touches the DemanglerInitRAII object which. 
- **Issues**:
This fixes a use-after-free in the MetadataReader used through LLDB that has been reported. 
- **Risk**:
No significant risk this is a targeted bug fix.
- **Testing**:
The change includes unit tests that fail without the fix and succeed after the fix.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
