### PR TITLE
[SIL] Stop dropping options when undoing substitution

### DIFF
--- a/lib/SIL/IR/SILType.cpp
+++ b/lib/SIL/IR/SILType.cpp
@@ -975,30 +975,30 @@ TypeBase::replaceSubstitutedSILFunctionTypesWithUnsubstituted(SILModule &M) cons
           ->replaceSubstitutedSILFunctionTypesWithUnsubstituted(M)
           ->getCanonicalType();
         didChange |= param.getInterfaceType() != newParamTy;
-        newParams.push_back(SILParameterInfo(newParamTy, param.getConvention()));
+        newParams.push_back(param.getWithInterfaceType(newParamTy));
       }
       for (auto yield : sft->getYields()) {
         auto newYieldTy = yield.getInterfaceType()
           ->replaceSubstitutedSILFunctionTypesWithUnsubstituted(M)
           ->getCanonicalType();
         didChange |= yield.getInterfaceType() != newYieldTy;
-        newYields.push_back(SILYieldInfo(newYieldTy, yield.getConvention()));
+        newYields.push_back(yield.getWithInterfaceType(newYieldTy));
       }
       for (auto result : sft->getResults()) {
         auto newResultTy = result.getInterfaceType()
           ->replaceSubstitutedSILFunctionTypesWithUnsubstituted(M)
           ->getCanonicalType();
         didChange |= result.getInterfaceType() != newResultTy;
-        newResults.push_back(SILResultInfo(newResultTy, result.getConvention()));
+        newResults.push_back(result.getWithInterfaceType(newResultTy));
       }
       if (auto error = sft->getOptionalErrorResult()) {
         auto newErrorTy = error->getInterfaceType()
           ->replaceSubstitutedSILFunctionTypesWithUnsubstituted(M)
           ->getCanonicalType();
         didChange |= error->getInterfaceType() != newErrorTy;
-        newErrorResult = SILResultInfo(newErrorTy, error->getConvention());
+        newErrorResult = error->getWithInterfaceType(newErrorTy);
       }
-      
+
       if (!didChange)
         return sft;
       

--- a/test/Concurrency/issue-88500.swift
+++ b/test/Concurrency/issue-88500.swift
@@ -1,0 +1,24 @@
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -emit-irgen -O -g -module-name test -primary-file %s
+
+// REQUIRES: concurrency
+
+public nonisolated(nonsending) func withHandler<Return, Failure>(
+  operation: nonisolated(nonsending) () async throws(Failure) -> Return
+) async throws(Failure) -> Return {
+  try await operation()
+}
+
+public nonisolated(nonsending) func compute<T>(
+  _ fn: () -> Void
+) async -> T {
+  fatalError()
+}
+
+struct Test {
+  static func wait() async -> (@Sendable () async -> Void)? {
+    await withHandler {
+      await compute {
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!--
The main branch is now in convergence, which means major changes, such as large refactoring or new features, should be avoided. This strategy is intended to maintain the stability of the Swift 6.4 release leading up to the May 4th branch. For any work that requires broad changes or introduces new features, create a feature branch and open a draft pull request. All updates to the swiftlang/swift repository’s main branch require approval from the release managers. A pull request targeting swiftlang/swift will automatically add release managers. You can also contact them via @release-managers in the forum group.
-->

<!-- Please fill out the following form: --> 
- **Explanation**:

  Instead of constructing parameters, results, and yields directly to replace an interface type, let's use `getWithInterfaceType` API that preserves all other the information.

- **Scope**:

   Relevant to debug and reflection information emission only. Substituted function types with parameters, results and yields that contains non-empty options are affected. 

- **Issues**:
  <!--
  References to issues the changes resolve, if any.
  -->

  - Resolves: https://github.com/swiftlang/swift/issues/88500
  - Resolves: rdar://174922464


- **Risk**:
  <!--
  The (specific) risk to the release for taking the changes.
  -->

   Low. Relevant to debug and reflection information emission only in assert builds.

- **Testing**:

   Added new tests to the Concurrency test suite.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
