### PR TITLE
[Parse] Speculative fix for crash in  parseExternAttribute()

### DIFF
--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -1286,9 +1286,7 @@ bool Parser::parseExternAttribute(DeclAttributes &Attributes,
   } else {
     diagnoseExpectLanguage();
     DiscardAttribute = true;
-    while (Tok.isNot(tok::r_paren)) {
-      consumeToken();
-    }
+    skipUntilDeclRBrace(tok::r_paren, tok::NUM_TOKENS);
   }
 
   rParenLoc = Tok.getLoc();
@@ -1301,7 +1299,7 @@ bool Parser::parseExternAttribute(DeclAttributes &Attributes,
   auto AttrRange = SourceRange(Loc, rParenLoc);
 
   // Reject duplicate attributes with the same kind.
-  if (ExternAttr::find(Attributes, kind)) {
+  if (!DiscardAttribute && ExternAttr::find(Attributes, kind)) {
     diagnose(Loc, diag::duplicate_attribute, false);
     DiscardAttribute = true;
   }

--- a/validation-test/compiler_crashers_fixed/Parser-consumeTokenWithoutFeedingReceiver-4809d4.swift
+++ b/validation-test/compiler_crashers_fixed/Parser-consumeTokenWithoutFeedingReceiver-4809d4.swift
@@ -1,3 +1,3 @@
 // {"kind":"typecheck","signature":"swift::Parser::consumeTokenWithoutFeedingReceiver()","signatureAssert":"Assertion failed: (Tok.isNot(tok::eof) && \"Lexing past eof!\"), function discardToken","signatureNext":"Parser::parseExternAttribute"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 @_extern(a


### PR DESCRIPTION
* **Explanation**: Fix two bugs in `parseExternAttribute()` could cause  crashes when unregnized `@_extern` kind was parsed.
  1. The recovery loop while `(Tok.isNot(tok::r_paren)) { consumeToken(); }` could consume past the end of the token stream if the `)` was missing, leading to a crash. Replaced with                 
  `skipUntilDeclRBrace(tok::r_paren, tok::NUM_TOKENS)`, which handles EOF and declaration boundaries safely.
  2. `ExternAttr::find(Attributes, kind)` was reading the uninitialized kind variable. Added a `!DiscardAttribute` guard to skip that check when the attribute is already being discarded.
 * **Scope**: Attribute parsing
 * **Risk**: Low. The change is localized in a function and obvious.
 * **Testing**: Passes existing test cases.
 * **Issues**: rdar://174704688