### PR TITLE
Runtime: Propagate addressable-for-dependencies and bitwise-borrow bits through multi-payload enum CVWs.

### DIFF
--- a/stdlib/public/runtime/Enum.cpp
+++ b/stdlib/public/runtime/Enum.cpp
@@ -451,7 +451,7 @@ static void swift_cvw_initEnumMetadataMultiPayloadWithLayoutStringImpl(
 
   // Accumulate the layout requirements of the payloads.
   size_t payloadSize = 0, alignMask = 0;
-  bool isPOD = true, isBT = true;
+  bool isPOD = true, isBT = true, isBB = true, isAFD = false;
 
   size_t payloadRefCountBytes = 0;
   for (unsigned i = 0; i < numPayloads; ++i) {
@@ -461,6 +461,8 @@ static void swift_cvw_initEnumMetadataMultiPayloadWithLayoutStringImpl(
     alignMask |= payloadLayout->flags.getAlignmentMask();
     isPOD &= payloadLayout->flags.isPOD();
     isBT &= payloadLayout->flags.isBitwiseTakable();
+    isBB &= payloadLayout->flags.isBitwiseBorrowable();
+    isAFD |= payloadLayout->flags.isAddressableForDependencies();
 
     payloadRefCountBytes += _swift_refCountBytesForMetatype(payloadLayouts[i]);
     // NUL terminator
@@ -560,6 +562,8 @@ static void swift_cvw_initEnumMetadataMultiPayloadWithLayoutStringImpl(
                      .withAlignmentMask(alignMask)
                      .withPOD(isPOD)
                      .withBitwiseTakable(isBT)
+                     .withBitwiseBorrowable(isBB)
+                     .withAddressableForDependencies(isAFD)
                      .withEnumWitnesses(true)
                      .withInlineStorage(ValueWitnessTable::isValueInline(
                          isBT, totalSize, alignMask + 1)),


### PR DESCRIPTION
In an oversight, I neglected to update this function while updating the other runtime metadata paths. This function isn't actually used yet, but we want it to be ready if we do start using it in the future.

rdar://174974129
