### PR TITLE
Mark the various with* functions as @safe

### DIFF
--- a/lib/Macros/Sources/SwiftMacros/SwiftifyImportMacro.swift
+++ b/lib/Macros/Sources/SwiftMacros/SwiftifyImportMacro.swift
@@ -597,7 +597,7 @@ struct CxxSpanThunkBuilder: SpanBoundsThunkBuilder, ParamBoundsThunkBuilder {
       // so unwrap it to an UnsafeMutableBufferPointer that we can cast
       let unwrappedCall = ExprSyntax(
         """
-        unsafe \(name).withUnsafeMutableBufferPointer { \(unwrappedName) in
+        \(name).withUnsafeMutableBufferPointer { \(unwrappedName) in
           return \(call)
         }
         """)
@@ -916,7 +916,7 @@ struct CountedOrSizedPointerThunkBuilder: ParamBoundsThunkBuilder, PointerBounds
         }
       let unwrappedCall = ExprSyntax(
         """
-        unsafe \(raw: name)\(raw: questionMark).\(raw: funcName) { unsafe $0 }
+        \(raw: name)\(raw: questionMark).\(raw: funcName) { unsafe $0 }
         """)
       res.append(CodeBlockItemSyntax.Item(try VariableDeclSyntax("let \(unwrappedName) = \(unwrappedCall)")))
       let lifetimeFix = ExprSyntax("_fixLifetime(\(raw: name))")

--- a/stdlib/public/Concurrency/CooperativeExecutor.swift
+++ b/stdlib/public/Concurrency/CooperativeExecutor.swift
@@ -27,7 +27,7 @@ extension ExecutorJob {
   fileprivate var cooperativeExecutorTimestampPointer: UnsafeMutablePointer<CooperativeExecutor.Timestamp> {
     get {
       assert(cooperativeExecutorTimestampIsIndirect)
-      return unsafe withUnsafeExecutorPrivateData {
+        return withUnsafeExecutorPrivateData {
         unsafe $0.withMemoryRebound(to: UnsafeMutablePointer<CooperativeExecutor.Timestamp>.self) {
           return unsafe $0[0]
         }
@@ -35,7 +35,7 @@ extension ExecutorJob {
     }
     set {
       assert(cooperativeExecutorTimestampIsIndirect)
-      unsafe withUnsafeExecutorPrivateData {
+        withUnsafeExecutorPrivateData {
         unsafe $0.withMemoryRebound(to: UnsafeMutablePointer<CooperativeExecutor.Timestamp>.self) {
           unsafe $0[0] = newValue
         }
@@ -49,7 +49,7 @@ extension ExecutorJob {
         let ptr = unsafe cooperativeExecutorTimestampPointer
         return unsafe ptr.pointee
       } else {
-        return unsafe withUnsafeExecutorPrivateData {
+          return withUnsafeExecutorPrivateData {
           return unsafe $0.assumingMemoryBound(
             to: CooperativeExecutor.Timestamp.self
           )[0]
@@ -61,7 +61,7 @@ extension ExecutorJob {
         let ptr = unsafe cooperativeExecutorTimestampPointer
         unsafe ptr.pointee = newValue
      } else {
-        unsafe withUnsafeExecutorPrivateData {
+         withUnsafeExecutorPrivateData {
           unsafe $0.withMemoryRebound(to: CooperativeExecutor.Timestamp.self) {
             unsafe $0[0] = newValue
           }

--- a/stdlib/public/Concurrency/CooperativeExecutor.swift
+++ b/stdlib/public/Concurrency/CooperativeExecutor.swift
@@ -27,7 +27,7 @@ extension ExecutorJob {
   fileprivate var cooperativeExecutorTimestampPointer: UnsafeMutablePointer<CooperativeExecutor.Timestamp> {
     get {
       assert(cooperativeExecutorTimestampIsIndirect)
-        return withUnsafeExecutorPrivateData {
+      return withUnsafeExecutorPrivateData {
         unsafe $0.withMemoryRebound(to: UnsafeMutablePointer<CooperativeExecutor.Timestamp>.self) {
           return unsafe $0[0]
         }
@@ -35,7 +35,7 @@ extension ExecutorJob {
     }
     set {
       assert(cooperativeExecutorTimestampIsIndirect)
-        withUnsafeExecutorPrivateData {
+      withUnsafeExecutorPrivateData {
         unsafe $0.withMemoryRebound(to: UnsafeMutablePointer<CooperativeExecutor.Timestamp>.self) {
           unsafe $0[0] = newValue
         }
@@ -49,7 +49,7 @@ extension ExecutorJob {
         let ptr = unsafe cooperativeExecutorTimestampPointer
         return unsafe ptr.pointee
       } else {
-          return withUnsafeExecutorPrivateData {
+        return withUnsafeExecutorPrivateData {
           return unsafe $0.assumingMemoryBound(
             to: CooperativeExecutor.Timestamp.self
           )[0]
@@ -61,7 +61,7 @@ extension ExecutorJob {
         let ptr = unsafe cooperativeExecutorTimestampPointer
         unsafe ptr.pointee = newValue
      } else {
-         withUnsafeExecutorPrivateData {
+        withUnsafeExecutorPrivateData {
           unsafe $0.withMemoryRebound(to: CooperativeExecutor.Timestamp.self) {
             unsafe $0[0] = newValue
           }

--- a/stdlib/public/Concurrency/Deque/Deque+Collection.swift
+++ b/stdlib/public/Concurrency/Deque/Deque+Collection.swift
@@ -140,7 +140,7 @@ extension _Deque: Sequence {
   ///
   /// - Complexity: O(1) when this instance has a unique reference to its
   ///    underlying storage; O(`count`) otherwise.
-  func withContiguousStorageIfAvailable<R>(
+  @safe func withContiguousStorageIfAvailable<R>(
     _ body: (UnsafeBufferPointer<Element>) throws -> R
   ) rethrows -> R? {
     return try unsafe _storage.read { handle in
@@ -412,7 +412,7 @@ extension _Deque: MutableCollection {
   /// - Complexity: O(1) when this instance has a unique reference to its
   ///    underlying storage; O(`count`) otherwise. (Not counting the call to
   ///    `body`.)
-  mutating func withContiguousMutableStorageIfAvailable<R>(
+  @safe mutating func withContiguousMutableStorageIfAvailable<R>(
     _ body: (inout UnsafeMutableBufferPointer<Element>) throws -> R
   ) rethrows -> R? {
     _storage.ensureUnique()
@@ -435,7 +435,7 @@ extension _Deque: MutableCollection {
   mutating func _withUnsafeMutableBufferPointerIfSupported<R>(
     _ body: (inout UnsafeMutableBufferPointer<Element>) throws -> R
   ) rethrows -> R? {
-    return try unsafe withContiguousMutableStorageIfAvailable(body)
+      return try withContiguousMutableStorageIfAvailable(body)
   }
 }
 

--- a/stdlib/public/Concurrency/Deque/Deque+Collection.swift
+++ b/stdlib/public/Concurrency/Deque/Deque+Collection.swift
@@ -435,7 +435,7 @@ extension _Deque: MutableCollection {
   mutating func _withUnsafeMutableBufferPointerIfSupported<R>(
     _ body: (inout UnsafeMutableBufferPointer<Element>) throws -> R
   ) rethrows -> R? {
-      return try withContiguousMutableStorageIfAvailable(body)
+    return try withContiguousMutableStorageIfAvailable(body)
   }
 }
 

--- a/stdlib/public/Concurrency/Deque/Deque+Storage.swift
+++ b/stdlib/public/Concurrency/Deque/Deque+Storage.swift
@@ -71,15 +71,15 @@ extension _Deque._Storage {
 
 
   internal var capacity: Int {
-      _buffer.withUnsafeMutablePointerToHeader { unsafe $0.pointee.capacity }
+      unsafe _buffer.withUnsafeMutablePointerToHeader { unsafe $0.pointee.capacity }
   }
 
   internal var count: Int {
-      _buffer.withUnsafeMutablePointerToHeader { unsafe $0.pointee.count }
+      unsafe _buffer.withUnsafeMutablePointerToHeader { unsafe $0.pointee.count }
   }
 
   internal var startSlot: _DequeSlot {
-      _buffer.withUnsafeMutablePointerToHeader { unsafe $0.pointee.startSlot
+      unsafe _buffer.withUnsafeMutablePointerToHeader { unsafe $0.pointee.startSlot
     }
   }
 }
@@ -90,7 +90,7 @@ extension _Deque._Storage {
   internal typealias _UnsafeHandle = _Deque._UnsafeHandle
 
   internal func read<R>(_ body: (_UnsafeHandle) throws -> R) rethrows -> R {
-      try _buffer.withUnsafeMutablePointers { header, elements in
+    try unsafe _buffer.withUnsafeMutablePointers { header, elements in
       let handle = unsafe _UnsafeHandle(header: header,
                                  elements: elements,
                                  isMutable: false)
@@ -99,7 +99,7 @@ extension _Deque._Storage {
   }
 
   internal func update<R>(_ body: (_UnsafeHandle) throws -> R) rethrows -> R {
-      try _buffer.withUnsafeMutablePointers { header, elements in
+    try unsafe _buffer.withUnsafeMutablePointers { header, elements in
       let handle = unsafe _UnsafeHandle(header: header,
                                  elements: elements,
                                  isMutable: true)

--- a/stdlib/public/Concurrency/Deque/Deque+Storage.swift
+++ b/stdlib/public/Concurrency/Deque/Deque+Storage.swift
@@ -71,15 +71,15 @@ extension _Deque._Storage {
 
 
   internal var capacity: Int {
-      unsafe _buffer.withUnsafeMutablePointerToHeader { unsafe $0.pointee.capacity }
+    unsafe _buffer.withUnsafeMutablePointerToHeader { unsafe $0.pointee.capacity }
   }
 
   internal var count: Int {
-      unsafe _buffer.withUnsafeMutablePointerToHeader { unsafe $0.pointee.count }
+    unsafe _buffer.withUnsafeMutablePointerToHeader { unsafe $0.pointee.count }
   }
 
   internal var startSlot: _DequeSlot {
-      unsafe _buffer.withUnsafeMutablePointerToHeader { unsafe $0.pointee.startSlot
+    unsafe _buffer.withUnsafeMutablePointerToHeader { unsafe $0.pointee.startSlot
     }
   }
 }

--- a/stdlib/public/Concurrency/Deque/Deque+Storage.swift
+++ b/stdlib/public/Concurrency/Deque/Deque+Storage.swift
@@ -71,15 +71,15 @@ extension _Deque._Storage {
 
 
   internal var capacity: Int {
-    unsafe _buffer.withUnsafeMutablePointerToHeader { unsafe $0.pointee.capacity }
+      _buffer.withUnsafeMutablePointerToHeader { unsafe $0.pointee.capacity }
   }
 
   internal var count: Int {
-    unsafe _buffer.withUnsafeMutablePointerToHeader { unsafe $0.pointee.count }
+      _buffer.withUnsafeMutablePointerToHeader { unsafe $0.pointee.count }
   }
 
   internal var startSlot: _DequeSlot {
-    unsafe _buffer.withUnsafeMutablePointerToHeader { unsafe $0.pointee.startSlot
+      _buffer.withUnsafeMutablePointerToHeader { unsafe $0.pointee.startSlot
     }
   }
 }
@@ -90,7 +90,7 @@ extension _Deque._Storage {
   internal typealias _UnsafeHandle = _Deque._UnsafeHandle
 
   internal func read<R>(_ body: (_UnsafeHandle) throws -> R) rethrows -> R {
-    try unsafe _buffer.withUnsafeMutablePointers { header, elements in
+      try _buffer.withUnsafeMutablePointers { header, elements in
       let handle = unsafe _UnsafeHandle(header: header,
                                  elements: elements,
                                  isMutable: false)
@@ -99,7 +99,7 @@ extension _Deque._Storage {
   }
 
   internal func update<R>(_ body: (_UnsafeHandle) throws -> R) rethrows -> R {
-    try unsafe _buffer.withUnsafeMutablePointers { header, elements in
+      try _buffer.withUnsafeMutablePointers { header, elements in
       let handle = unsafe _UnsafeHandle(header: header,
                                  elements: elements,
                                  isMutable: true)

--- a/stdlib/public/Concurrency/Deque/Deque+Testing.swift
+++ b/stdlib/public/Concurrency/Deque/Deque+Testing.swift
@@ -62,7 +62,7 @@ extension _Deque {
     }
     let storage = unsafe _Deque<Element>._Storage(unsafeDowncast(buffer, to: _DequeBuffer.self))
     if contents.count > 0 {
-        contents.withUnsafeBufferPointer { source in
+      contents.withUnsafeBufferPointer { source in
         unsafe storage.update { target in
           let segments = unsafe target.mutableSegments()
           let c = unsafe segments.first.count

--- a/stdlib/public/Concurrency/Deque/Deque+Testing.swift
+++ b/stdlib/public/Concurrency/Deque/Deque+Testing.swift
@@ -62,7 +62,7 @@ extension _Deque {
     }
     let storage = unsafe _Deque<Element>._Storage(unsafeDowncast(buffer, to: _DequeBuffer.self))
     if contents.count > 0 {
-      unsafe contents.withUnsafeBufferPointer { source in
+        contents.withUnsafeBufferPointer { source in
         unsafe storage.update { target in
           let segments = unsafe target.mutableSegments()
           let c = unsafe segments.first.count

--- a/stdlib/public/Concurrency/Deque/Deque+UnsafeHandle.swift
+++ b/stdlib/public/Concurrency/Deque/Deque+UnsafeHandle.swift
@@ -316,7 +316,7 @@ extension _Deque._UnsafeHandle {
 }
 
 extension _Deque._UnsafeHandle {
-  internal func withUnsafeSegment<R>(
+  @safe internal func withUnsafeSegment<R>(
     startingAt start: Int,
     maximumCount: Int?,
     _ body: (UnsafeBufferPointer<Element>) throws -> R

--- a/stdlib/public/Concurrency/Deque/_DequeBuffer.swift
+++ b/stdlib/public/Concurrency/Deque/_DequeBuffer.swift
@@ -16,7 +16,7 @@ import Swift
 
 internal class _DequeBuffer<Element>: ManagedBuffer<_DequeBufferHeader, Element> {
   deinit {
-    unsafe self.withUnsafeMutablePointers { header, elements in
+    self.withUnsafeMutablePointers { header, elements in
       unsafe header.pointee._checkInvariants()
 
       let capacity = unsafe header.pointee.capacity
@@ -36,7 +36,7 @@ internal class _DequeBuffer<Element>: ManagedBuffer<_DequeBufferHeader, Element>
 
 extension _DequeBuffer: CustomStringConvertible {
   internal var description: String {
-    unsafe withUnsafeMutablePointerToHeader { "_DequeStorage<\(Element.self)>\(unsafe $0.pointee)" }
+      withUnsafeMutablePointerToHeader { "_DequeStorage<\(Element.self)>\(unsafe $0.pointee)" }
   }
 }
 

--- a/stdlib/public/Concurrency/Deque/_DequeBuffer.swift
+++ b/stdlib/public/Concurrency/Deque/_DequeBuffer.swift
@@ -36,7 +36,7 @@ internal class _DequeBuffer<Element>: ManagedBuffer<_DequeBufferHeader, Element>
 
 extension _DequeBuffer: CustomStringConvertible {
   internal var description: String {
-      unsafe withUnsafeMutablePointerToHeader { "_DequeStorage<\(Element.self)>\(unsafe $0.pointee)" }
+    unsafe withUnsafeMutablePointerToHeader { "_DequeStorage<\(Element.self)>\(unsafe $0.pointee)" }
   }
 }
 

--- a/stdlib/public/Concurrency/Deque/_DequeBuffer.swift
+++ b/stdlib/public/Concurrency/Deque/_DequeBuffer.swift
@@ -16,7 +16,7 @@ import Swift
 
 internal class _DequeBuffer<Element>: ManagedBuffer<_DequeBufferHeader, Element> {
   deinit {
-    self.withUnsafeMutablePointers { header, elements in
+    unsafe self.withUnsafeMutablePointers { header, elements in
       unsafe header.pointee._checkInvariants()
 
       let capacity = unsafe header.pointee.capacity
@@ -36,7 +36,7 @@ internal class _DequeBuffer<Element>: ManagedBuffer<_DequeBufferHeader, Element>
 
 extension _DequeBuffer: CustomStringConvertible {
   internal var description: String {
-      withUnsafeMutablePointerToHeader { "_DequeStorage<\(Element.self)>\(unsafe $0.pointee)" }
+      unsafe withUnsafeMutablePointerToHeader { "_DequeStorage<\(Element.self)>\(unsafe $0.pointee)" }
   }
 }
 

--- a/stdlib/public/Concurrency/PartialAsyncTask.swift
+++ b/stdlib/public/Concurrency/PartialAsyncTask.swift
@@ -329,7 +329,7 @@ public struct ExecutorJob: Sendable, ~Copyable {
   /// Returns the result of executing the closure.
   @_spi(ExperimentalCustomExecutors)
   @available(StdlibDeploymentTarget 6.3, *)
-  public func withUnsafeExecutorPrivateData<R, E>(body: (UnsafeMutableRawBufferPointer) throws(E) -> R) throws(E) -> R {
+  @safe public func withUnsafeExecutorPrivateData<R, E>(body: (UnsafeMutableRawBufferPointer) throws(E) -> R) throws(E) -> R {
     let base = unsafe _jobGetExecutorPrivateData(self.context)
     let size = unsafe 2 * MemoryLayout<OpaquePointer>.stride
     return unsafe try body(UnsafeMutableRawBufferPointer(start: base,

--- a/stdlib/public/Concurrency/Task+immediate.swift.gyb
+++ b/stdlib/public/Concurrency/Task+immediate.swift.gyb
@@ -109,7 +109,7 @@ extension Task where Failure == ${FAILURE_TYPE} {
     if let name {
       #if $BuiltinCreateAsyncTaskOwnedTaskExecutor
       task =
-        unsafe name.utf8CString.withUnsafeBufferPointer { nameBytes in
+        name.utf8CString.withUnsafeBufferPointer { nameBytes in
           Builtin.createTask(
             flags: flags,
             initialSerialExecutor: builtinSerialExecutor,
@@ -119,7 +119,7 @@ extension Task where Failure == ${FAILURE_TYPE} {
         }
       #else // no $BuiltinCreateAsyncTaskOwnedTaskExecutor
       task =
-        unsafe name.utf8CString.withUnsafeBufferPointer { nameBytes in
+        name.utf8CString.withUnsafeBufferPointer { nameBytes in
           Builtin.createTask(
             flags: flags,
             initialSerialExecutor: builtinSerialExecutor,
@@ -298,7 +298,7 @@ extension ${GROUP_TYPE} {
     #if $BuiltinCreateAsyncTaskName
     if let name {
       task =
-        unsafe name.utf8CString.withUnsafeBufferPointer { nameBytes in
+        name.utf8CString.withUnsafeBufferPointer { nameBytes in
           ${TASK_CREATE_FN}(
             flags: flags,
             initialSerialExecutor: builtinSerialExecutor,

--- a/stdlib/public/Concurrency/Task+init.swift.gyb
+++ b/stdlib/public/Concurrency/Task+init.swift.gyb
@@ -317,7 +317,7 @@ extension Task where Failure == ${FAILURE_TYPE} {
       % if HAS_TASK_EXECUTOR:
       #if $BuiltinCreateAsyncTaskOwnedTaskExecutor
       task =
-        unsafe name.utf8CString.withUnsafeBufferPointer { nameBytes in
+        name.utf8CString.withUnsafeBufferPointer { nameBytes in
           Builtin.createTask(
             flags: flags,
             % if HAS_ISOLATED_ANY:
@@ -334,7 +334,7 @@ extension Task where Failure == ${FAILURE_TYPE} {
       let executorBuiltin: Builtin.Executor =
         taskExecutor.asUnownedTaskExecutor().executor
       task =
-        unsafe name.utf8CString.withUnsafeBufferPointer { nameBytes in
+        name.utf8CString.withUnsafeBufferPointer { nameBytes in
           Builtin.createTask(
             flags: flags,
             % if HAS_ISOLATED_ANY:
@@ -347,7 +347,7 @@ extension Task where Failure == ${FAILURE_TYPE} {
       #endif // $BuiltinCreateAsyncTaskOwnedTaskExecutor
       % else: # if no TASK_EXECUTOR
       task =
-        unsafe name.utf8CString.withUnsafeBufferPointer { nameBytes in
+        name.utf8CString.withUnsafeBufferPointer { nameBytes in
           Builtin.createTask(
             flags: flags,
             % if HAS_ISOLATED_ANY:

--- a/stdlib/public/Concurrency/TaskGroup+addTask.swift.gyb
+++ b/stdlib/public/Concurrency/TaskGroup+addTask.swift.gyb
@@ -297,7 +297,7 @@ extension ${TYPE} {
     #if $BuiltinCreateAsyncTaskName
     if let name {
       task =
-        unsafe name.utf8CString.withUnsafeBufferPointer { nameBytes in
+        name.utf8CString.withUnsafeBufferPointer { nameBytes in
           ${TASK_CREATE_FN}(
             flags: flags,
             initialSerialExecutor: builtinSerialExecutor,

--- a/stdlib/public/Concurrency/TaskLocal.swift
+++ b/stdlib/public/Concurrency/TaskLocal.swift
@@ -428,7 +428,7 @@ func _taskLocalsCopy(
 @available(*, deprecated, message: "The situation diagnosed by this is not handled gracefully rather than by crashing")
 func _checkIllegalTaskLocalBindingWithinWithTaskGroup(file: String, line: UInt) {
   if _taskHasTaskGroupStatusRecord() {
-      file.withCString { _fileStart in
+    file.withCString { _fileStart in
       unsafe _reportIllegalTaskLocalBindingWithinWithTaskGroup(
           _fileStart, file.count, true, line)
     }

--- a/stdlib/public/Concurrency/TaskLocal.swift
+++ b/stdlib/public/Concurrency/TaskLocal.swift
@@ -428,7 +428,7 @@ func _taskLocalsCopy(
 @available(*, deprecated, message: "The situation diagnosed by this is not handled gracefully rather than by crashing")
 func _checkIllegalTaskLocalBindingWithinWithTaskGroup(file: String, line: UInt) {
   if _taskHasTaskGroupStatusRecord() {
-    unsafe file.withCString { _fileStart in
+      file.withCString { _fileStart in
       unsafe _reportIllegalTaskLocalBindingWithinWithTaskGroup(
           _fileStart, file.count, true, line)
     }

--- a/stdlib/public/Cxx/CxxSpan.swift
+++ b/stdlib/public/Cxx/CxxSpan.swift
@@ -92,7 +92,7 @@ extension CxxSpan where Element: ~Copyable {
   @_alwaysEmitIntoClient
   @unsafe
   public init(_ span: Span<Element>) {
-    let p = unsafe span.withUnsafeBufferPointer {
+    let p = span.withUnsafeBufferPointer {
         unsafe $0
     }
     defer {
@@ -158,7 +158,7 @@ extension CxxMutableSpan where Element: ~Copyable {
   @_alwaysEmitIntoClient
   @unsafe
   public init(_ span: consuming MutableSpan<Element>) {
-    let p = unsafe span.withUnsafeMutableBufferPointer {
+    let p = span.withUnsafeMutableBufferPointer {
         unsafe $0
     }
     defer {

--- a/stdlib/public/Cxx/std/String.swift
+++ b/stdlib/public/Cxx/std/String.swift
@@ -21,7 +21,7 @@ extension std.string {
   ///   Swift string.
   @_alwaysEmitIntoClient
   public init(_ string: String) {
-    self = unsafe string.withCString(encodedAs: UTF8.self) { buffer in
+    self = string.withCString(encodedAs: UTF8.self) { buffer in
       // MSVC STL has a enable_if template guard on the 3-parameter constructor,
       // and thus it's not imported into Swift.
       // libc++ provides both 2-parameter and 3-parameter constructors.

--- a/stdlib/public/Distributed/DistributedActorSystem.swift
+++ b/stdlib/public/Distributed/DistributedActorSystem.swift
@@ -438,7 +438,7 @@ extension DistributedActorSystem {
 
     // Gen the generic environment (if any) associated with the target.
     let genericEnv =
-      unsafe targetNameUTF8.withUnsafeBufferPointer { targetNameUTF8 in
+      targetNameUTF8.withUnsafeBufferPointer { targetNameUTF8 in
         unsafe _getGenericEnvironmentOfDistributedTarget(
           targetNameUTF8.baseAddress!,
           UInt(targetNameUTF8.endIndex))
@@ -478,7 +478,7 @@ extension DistributedActorSystem {
     }
 
     let paramCount =
-      unsafe targetNameUTF8.withUnsafeBufferPointer { targetNameUTF8 in
+      targetNameUTF8.withUnsafeBufferPointer { targetNameUTF8 in
         unsafe __getParameterCount(
           targetNameUTF8.baseAddress!,
           UInt(targetNameUTF8.endIndex))
@@ -501,7 +501,7 @@ extension DistributedActorSystem {
     }
 
     // Demangle and write all parameter types into the prepared buffer
-    let decodedNum = unsafe targetNameUTF8.withUnsafeBufferPointer { targetNameUTF8 in
+    let decodedNum = targetNameUTF8.withUnsafeBufferPointer { targetNameUTF8 in
       unsafe __getParameterTypeInfo(
         targetNameUTF8.baseAddress!,
         UInt(targetNameUTF8.endIndex),
@@ -536,7 +536,7 @@ extension DistributedActorSystem {
     }
 
     let maybeReturnTypeFromTypeInfo =
-      unsafe targetNameUTF8.withUnsafeBufferPointer { targetNameUTF8 in
+      targetNameUTF8.withUnsafeBufferPointer { targetNameUTF8 in
         unsafe __getReturnTypeInfo(
           /*targetName:*/targetNameUTF8.baseAddress!,
           /*targetLength:*/UInt(targetNameUTF8.endIndex),

--- a/stdlib/public/Distributed/DistributedMetadata.swift
+++ b/stdlib/public/Distributed/DistributedMetadata.swift
@@ -19,7 +19,7 @@ import Swift
 public // SPI Distributed
 func _getParameterCount(mangledMethodName name: String) -> Int32 {
   let nameUTF8 = Array(name.utf8)
-  return unsafe nameUTF8.withUnsafeBufferPointer { nameUTF8 in
+  return nameUTF8.withUnsafeBufferPointer { nameUTF8 in
     return unsafe __getParameterCount(
         nameUTF8.baseAddress!, UInt(nameUTF8.endIndex))
   }
@@ -47,7 +47,7 @@ func _getParameterTypeInfo(
   into typesBuffer: Builtin.RawPointer, length typesLength: Int
 ) -> Int32 {
   let nameUTF8 = Array(name.utf8)
-  return unsafe nameUTF8.withUnsafeBufferPointer { nameUTF8 in
+  return nameUTF8.withUnsafeBufferPointer { nameUTF8 in
     return unsafe __getParameterTypeInfo(
         nameUTF8.baseAddress!, UInt(nameUTF8.endIndex),
         genericEnv, genericArguments, typesBuffer, typesLength)
@@ -75,7 +75,7 @@ func _getReturnTypeInfo(
   genericArguments: UnsafeRawPointer?
 ) -> Any.Type? {
   let nameUTF8 = Array(name.utf8)
-  return unsafe nameUTF8.withUnsafeBufferPointer { nameUTF8 in
+  return nameUTF8.withUnsafeBufferPointer { nameUTF8 in
     return unsafe __getReturnTypeInfo(nameUTF8.baseAddress!, UInt(nameUTF8.endIndex),
                                genericEnv, genericArguments)
   }

--- a/stdlib/public/RuntimeModule/PDB/String+EncodeAs.swift
+++ b/stdlib/public/RuntimeModule/PDB/String+EncodeAs.swift
@@ -47,7 +47,7 @@ extension String {
       if repaired {
         fatalError("Encoding failed")
       }
-      return try unsafe arg.withUnsafeBufferPointer {
+      return try arg.withUnsafeBufferPointer {
         return try unsafe body($0)
       }
     }

--- a/stdlib/public/core/Array.swift
+++ b/stdlib/public/core/Array.swift
@@ -1415,7 +1415,7 @@ extension Array: RangeReplaceableCollection {
   public mutating func _withUnsafeMutableBufferPointerIfSupported<R>(
     _ body: (inout UnsafeMutableBufferPointer<Element>) throws -> R
   ) rethrows -> R? {
-      return try withUnsafeMutableBufferPointer {
+    return try withUnsafeMutableBufferPointer {
       (bufferPointer) -> R in
       return try unsafe body(&bufferPointer)
     }
@@ -1426,7 +1426,7 @@ extension Array: RangeReplaceableCollection {
   public mutating func withContiguousMutableStorageIfAvailable<R>(
     _ body: (inout UnsafeMutableBufferPointer<Element>) throws -> R
   ) rethrows -> R? {
-      return try withUnsafeMutableBufferPointer {
+    return try withUnsafeMutableBufferPointer {
       (bufferPointer) -> R in
       return try unsafe body(&bufferPointer)
     }
@@ -1437,7 +1437,7 @@ extension Array: RangeReplaceableCollection {
   public func withContiguousStorageIfAvailable<R>(
     _ body: (UnsafeBufferPointer<Element>) throws -> R
   ) rethrows -> R? {
-      return try withUnsafeBufferPointer {
+    return try withUnsafeBufferPointer {
       (bufferPointer) -> R in
       return try unsafe body(bufferPointer)
     }
@@ -1705,7 +1705,7 @@ extension Array {
   internal func withUnsafeBufferPointer<R>(
     _ body: (UnsafeBufferPointer<Element>) throws -> R
   ) rethrows -> R {
-      return try _buffer.withUnsafeBufferPointer(body)
+    return try _buffer.withUnsafeBufferPointer(body)
   }
 
   /// Calls a closure with a pointer to the array's contiguous storage.
@@ -1742,7 +1742,7 @@ extension Array {
   public func withUnsafeBufferPointer<R, E>(
     _ body: (UnsafeBufferPointer<Element>) throws(E) -> R
   ) throws(E) -> R {
-      return try _buffer.withUnsafeBufferPointer(body)
+    return try _buffer.withUnsafeBufferPointer(body)
   }
 
   @available(SwiftStdlib 6.2, *)
@@ -2076,7 +2076,7 @@ extension Array {
   public mutating func withUnsafeMutableBytes<R>(
     _ body: (UnsafeMutableRawBufferPointer) throws -> R
   ) rethrows -> R {
-      return try self.withUnsafeMutableBufferPointer {
+    return try self.withUnsafeMutableBufferPointer {
       return try unsafe body(UnsafeMutableRawBufferPointer($0))
     }
   }
@@ -2113,7 +2113,7 @@ extension Array {
   public func withUnsafeBytes<R>(
     _ body: (UnsafeRawBufferPointer) throws -> R
   ) rethrows -> R {
-      return try self.withUnsafeBufferPointer {
+    return try self.withUnsafeBufferPointer {
       try unsafe body(UnsafeRawBufferPointer($0))
     }
   }

--- a/stdlib/public/core/Array.swift
+++ b/stdlib/public/core/Array.swift
@@ -1415,27 +1415,29 @@ extension Array: RangeReplaceableCollection {
   public mutating func _withUnsafeMutableBufferPointerIfSupported<R>(
     _ body: (inout UnsafeMutableBufferPointer<Element>) throws -> R
   ) rethrows -> R? {
-    return unsafe try withUnsafeMutableBufferPointer {
+      return try withUnsafeMutableBufferPointer {
       (bufferPointer) -> R in
       return try unsafe body(&bufferPointer)
     }
   }
 
   @inlinable
+  @safe
   public mutating func withContiguousMutableStorageIfAvailable<R>(
     _ body: (inout UnsafeMutableBufferPointer<Element>) throws -> R
   ) rethrows -> R? {
-    return unsafe try withUnsafeMutableBufferPointer {
+      return try withUnsafeMutableBufferPointer {
       (bufferPointer) -> R in
       return try unsafe body(&bufferPointer)
     }
   }
 
   @inlinable
+  @safe
   public func withContiguousStorageIfAvailable<R>(
     _ body: (UnsafeBufferPointer<Element>) throws -> R
   ) rethrows -> R? {
-    return unsafe try withUnsafeBufferPointer {
+      return try withUnsafeBufferPointer {
       (bufferPointer) -> R in
       return try unsafe body(bufferPointer)
     }
@@ -1699,10 +1701,11 @@ extension Array {
   // for ABI reasons.
   @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
   @usableFromInline
+  @safe
   internal func withUnsafeBufferPointer<R>(
     _ body: (UnsafeBufferPointer<Element>) throws -> R
   ) rethrows -> R {
-    return try unsafe _buffer.withUnsafeBufferPointer(body)
+      return try _buffer.withUnsafeBufferPointer(body)
   }
 
   /// Calls a closure with a pointer to the array's contiguous storage.
@@ -1735,10 +1738,11 @@ extension Array {
   ///   valid only for the duration of the method's execution.
   /// - Returns: The return value, if any, of the `body` closure parameter.
   @_alwaysEmitIntoClient
+  @safe
   public func withUnsafeBufferPointer<R, E>(
     _ body: (UnsafeBufferPointer<Element>) throws(E) -> R
   ) throws(E) -> R {
-    return try unsafe _buffer.withUnsafeBufferPointer(body)
+      return try _buffer.withUnsafeBufferPointer(body)
   }
 
   @available(SwiftStdlib 6.2, *)
@@ -1836,6 +1840,7 @@ extension Array {
   // caller such that we can combine the partial apply with the apply in this
   // function saving on allocating a closure context. This becomes unnecessary
   // once we allocate noescape closures on the stack.
+  @safe
   public mutating func withUnsafeMutableBufferPointer<R, E>(
     _ body: (inout UnsafeMutableBufferPointer<Element>) throws(E) -> R
   ) throws(E) -> R {
@@ -2067,10 +2072,11 @@ extension Array {
   ///   execution.
   /// - Returns: The return value, if any, of the `body` closure parameter.
   @inlinable
+  @safe
   public mutating func withUnsafeMutableBytes<R>(
     _ body: (UnsafeMutableRawBufferPointer) throws -> R
   ) rethrows -> R {
-    return try unsafe self.withUnsafeMutableBufferPointer {
+      return try self.withUnsafeMutableBufferPointer {
       return try unsafe body(UnsafeMutableRawBufferPointer($0))
     }
   }
@@ -2103,10 +2109,11 @@ extension Array {
   ///   argument is valid only for the duration of the closure's execution.
   /// - Returns: The return value, if any, of the `body` closure parameter.
   @inlinable
+  @safe
   public func withUnsafeBytes<R>(
     _ body: (UnsafeRawBufferPointer) throws -> R
   ) rethrows -> R {
-    return try unsafe self.withUnsafeBufferPointer {
+      return try self.withUnsafeBufferPointer {
       try unsafe body(UnsafeRawBufferPointer($0))
     }
   }

--- a/stdlib/public/core/ArrayBuffer.swift
+++ b/stdlib/public/core/ArrayBuffer.swift
@@ -651,6 +651,7 @@ extension _ArrayBuffer {
   }
 
   @_alwaysEmitIntoClient @inline(never)
+  @safe
   internal func withUnsafeBufferPointer_nonNative<R, E>(
     _ body: (UnsafeBufferPointer<Element>) throws(E) -> R
   ) throws(E) -> R {
@@ -674,13 +675,14 @@ extension _ArrayBuffer {
       return try unsafe body(
         UnsafeBufferPointer(start: firstElementAddress, count: count))
     }
-    return try unsafe ContiguousArray(self).withUnsafeBufferPointer(body)
+    return try ContiguousArray(self).withUnsafeBufferPointer(body)
   }
 
   /// Call `body(p)`, where `p` is an `UnsafeBufferPointer` over the
   /// underlying contiguous storage.  If no such storage exists, it is
   /// created on-demand.
   @_alwaysEmitIntoClient
+  @safe
   internal func withUnsafeBufferPointer<R, E>(
     _ body: (UnsafeBufferPointer<Element>) throws(E) -> R
   ) throws(E) -> R {
@@ -689,7 +691,7 @@ extension _ArrayBuffer {
       return try unsafe body(
         UnsafeBufferPointer(start: firstElementAddress, count: count))
     }
-    return try unsafe withUnsafeBufferPointer_nonNative(body)
+    return try withUnsafeBufferPointer_nonNative(body)
   }
 
   // Superseded by the typed-throws version of this function, but retained
@@ -699,7 +701,7 @@ extension _ArrayBuffer {
   internal mutating func __abi_withUnsafeMutableBufferPointer<R>(
     _ body: (UnsafeMutableBufferPointer<Element>) throws -> R
   ) rethrows -> R {
-    return try unsafe withUnsafeMutableBufferPointer(body)
+    return try withUnsafeMutableBufferPointer(body)
   }
 
   /// Call `body(p)`, where `p` is an `UnsafeMutableBufferPointer`
@@ -707,6 +709,7 @@ extension _ArrayBuffer {
   ///
   /// - Precondition: Such contiguous storage exists or the buffer is empty.
   @_alwaysEmitIntoClient
+  @safe
   internal mutating func withUnsafeMutableBufferPointer<R, E>(
     _ body: (UnsafeMutableBufferPointer<Element>) throws(E) -> R
   ) throws(E) -> R {

--- a/stdlib/public/core/ArrayBufferProtocol.swift
+++ b/stdlib/public/core/ArrayBufferProtocol.swift
@@ -79,6 +79,7 @@ where Indices == Range<Int> {
 #if !$Embedded
   // Superseded by the typed-throws version of this function, but retained
   // for ABI reasons.
+  @safe
   func withUnsafeBufferPointer<R>(
     _ body: (UnsafeBufferPointer<Element>) throws -> R
   ) rethrows -> R
@@ -88,6 +89,7 @@ where Indices == Range<Int> {
   /// underlying contiguous storage.  If no such storage exists, it is
   /// created on-demand.
   @available(SwiftStdlib 6.1, *)
+  @safe
   func withUnsafeBufferPointer<R, E>(
     _ body: (UnsafeBufferPointer<Element>) throws(E) -> R
   ) throws(E) -> R
@@ -95,6 +97,7 @@ where Indices == Range<Int> {
 #if !$Embedded
   // Superseded by the typed-throws version of this function, but retained
   // for ABI reasons.
+  @safe
   mutating func withUnsafeMutableBufferPointer<R>(
     _ body: (UnsafeMutableBufferPointer<Element>) throws -> R
   ) rethrows -> R
@@ -105,6 +108,7 @@ where Indices == Range<Int> {
   ///
   /// - Precondition: Such contiguous storage exists or the buffer is empty.
   @available(SwiftStdlib 6.1, *)
+  @safe
   mutating func withUnsafeMutableBufferPointer<R, E>(
     _ body: (UnsafeMutableBufferPointer<Element>) throws(E) -> R
   ) throws(E) -> R

--- a/stdlib/public/core/ArraySlice.swift
+++ b/stdlib/public/core/ArraySlice.swift
@@ -1100,27 +1100,29 @@ extension ArraySlice: RangeReplaceableCollection {
   public mutating func _withUnsafeMutableBufferPointerIfSupported<R>(
     _ body: (inout UnsafeMutableBufferPointer<Element>) throws -> R
   ) rethrows -> R? {
-    return unsafe try withUnsafeMutableBufferPointer {
+      return try withUnsafeMutableBufferPointer {
       (bufferPointer) -> R in
       return try unsafe body(&bufferPointer)
     }
   }
 
   @inlinable
+  @safe
   public mutating func withContiguousMutableStorageIfAvailable<R>(
     _ body: (inout UnsafeMutableBufferPointer<Element>) throws -> R
   ) rethrows -> R? {
-    return unsafe try withUnsafeMutableBufferPointer {
+    return try withUnsafeMutableBufferPointer {
       (bufferPointer) -> R in
       return try unsafe body(&bufferPointer)
     }
   }
 
   @inlinable
+  @safe
   public func withContiguousStorageIfAvailable<R>(
     _ body: (UnsafeBufferPointer<Element>) throws -> R
   ) rethrows -> R? {
-    return unsafe try withUnsafeBufferPointer {
+      return try withUnsafeBufferPointer {
       (bufferPointer) -> R in
       return try unsafe body(bufferPointer)
     }
@@ -1178,6 +1180,7 @@ extension ArraySlice {
   // for ABI reasons.
   @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
   @usableFromInline
+  @safe
   internal func withUnsafeBufferPointer<R>(
     _ body: (UnsafeBufferPointer<Element>) throws -> R
   ) rethrows -> R {
@@ -1214,6 +1217,7 @@ extension ArraySlice {
   ///   valid only for the duration of the method's execution.
   /// - Returns: The return value, if any, of the `body` closure parameter.
   @_alwaysEmitIntoClient
+  @safe
   public func withUnsafeBufferPointer<R, E>(
     _ body: (UnsafeBufferPointer<Element>) throws(E) -> R
   ) throws(E) -> R {
@@ -1246,7 +1250,7 @@ extension ArraySlice {
   mutating func __abi_withUnsafeMutableBufferPointer<R>(
     _ body: (inout UnsafeMutableBufferPointer<Element>) throws -> R
   ) rethrows -> R {
-    return try unsafe withUnsafeMutableBufferPointer(body)
+    return try withUnsafeMutableBufferPointer(body)
   }
 
   /// Calls the given closure with a pointer to the array's mutable contiguous
@@ -1291,6 +1295,7 @@ extension ArraySlice {
   // caller such that we can combine the partial apply with the apply in this
   // function saving on allocating a closure context. This becomes unnecessary
   // once we allocate noescape closures on the stack.
+  @safe
   public mutating func withUnsafeMutableBufferPointer<R, E>(
     _ body: (inout UnsafeMutableBufferPointer<Element>) throws(E) -> R
   ) throws(E) -> R {
@@ -1533,10 +1538,11 @@ extension ArraySlice {
   ///   execution.
   /// - Returns: The return value, if any, of the `body` closure parameter.
   @inlinable
+  @safe
   public mutating func withUnsafeMutableBytes<R>(
     _ body: (UnsafeMutableRawBufferPointer) throws -> R
   ) rethrows -> R {
-    return try unsafe self.withUnsafeMutableBufferPointer {
+    return try self.withUnsafeMutableBufferPointer {
       return try unsafe body(UnsafeMutableRawBufferPointer($0))
     }
   }
@@ -1569,10 +1575,11 @@ extension ArraySlice {
   ///   argument is valid only for the duration of the closure's execution.
   /// - Returns: The return value, if any, of the `body` closure parameter.
   @inlinable
+  @safe
   public func withUnsafeBytes<R>(
     _ body: (UnsafeRawBufferPointer) throws -> R
   ) rethrows -> R {
-    return try unsafe self.withUnsafeBufferPointer {
+    return try self.withUnsafeBufferPointer {
       try unsafe body(UnsafeRawBufferPointer($0))
     }
   }

--- a/stdlib/public/core/ArraySlice.swift
+++ b/stdlib/public/core/ArraySlice.swift
@@ -1100,7 +1100,7 @@ extension ArraySlice: RangeReplaceableCollection {
   public mutating func _withUnsafeMutableBufferPointerIfSupported<R>(
     _ body: (inout UnsafeMutableBufferPointer<Element>) throws -> R
   ) rethrows -> R? {
-      return try withUnsafeMutableBufferPointer {
+    return try withUnsafeMutableBufferPointer {
       (bufferPointer) -> R in
       return try unsafe body(&bufferPointer)
     }
@@ -1122,7 +1122,7 @@ extension ArraySlice: RangeReplaceableCollection {
   public func withContiguousStorageIfAvailable<R>(
     _ body: (UnsafeBufferPointer<Element>) throws -> R
   ) rethrows -> R? {
-      return try withUnsafeBufferPointer {
+    return try withUnsafeBufferPointer {
       (bufferPointer) -> R in
       return try unsafe body(bufferPointer)
     }

--- a/stdlib/public/core/Bitset.swift
+++ b/stdlib/public/core/Bitset.swift
@@ -358,7 +358,7 @@ extension _UnsafeBitset {
     wordCount: Int,
     body: (_UnsafeBitset) throws(E) -> R
   ) throws(E) -> R {
-    try unsafe withUnsafeTemporaryAllocation(
+    try withUnsafeTemporaryAllocation(
       of: _UnsafeBitset.Word.self, capacity: wordCount
     ) { (buffer: UnsafeMutableBufferPointer<_UnsafeBitset.Word>) throws(E) -> R in
       let bitset = unsafe _UnsafeBitset(

--- a/stdlib/public/core/BridgingBuffer.swift
+++ b/stdlib/public/core/BridgingBuffer.swift
@@ -33,7 +33,7 @@ where Header == _BridgingBufferHeader, Element == AnyObject {
     self.init(
       _uncheckedBufferClass: __BridgingBufferStorage.self,
       minimumCapacity: count)
-    unsafe self.withUnsafeMutablePointerToHeader {
+    self.withUnsafeMutablePointerToHeader {
       unsafe $0.initialize(to: Header(count))
     }
   }
@@ -52,14 +52,14 @@ where Header == _BridgingBufferHeader, Element == AnyObject {
   internal subscript(i: Int) -> Element {
     @inline(__always)
     get {
-      return unsafe withUnsafeMutablePointerToElements { unsafe $0[i] }
+      return withUnsafeMutablePointerToElements { unsafe $0[i] }
     }
   }
 
   internal var baseAddress: UnsafeMutablePointer<Element> {
     @inline(__always)
     get {
-      return unsafe withUnsafeMutablePointerToElements { unsafe $0 }
+      return withUnsafeMutablePointerToElements { unsafe $0 }
     }
   }
 

--- a/stdlib/public/core/BridgingBuffer.swift
+++ b/stdlib/public/core/BridgingBuffer.swift
@@ -33,7 +33,7 @@ where Header == _BridgingBufferHeader, Element == AnyObject {
     self.init(
       _uncheckedBufferClass: __BridgingBufferStorage.self,
       minimumCapacity: count)
-    self.withUnsafeMutablePointerToHeader {
+    unsafe self.withUnsafeMutablePointerToHeader {
       unsafe $0.initialize(to: Header(count))
     }
   }
@@ -52,14 +52,14 @@ where Header == _BridgingBufferHeader, Element == AnyObject {
   internal subscript(i: Int) -> Element {
     @inline(__always)
     get {
-      return withUnsafeMutablePointerToElements { unsafe $0[i] }
+      return unsafe withUnsafeMutablePointerToElements { unsafe $0[i] }
     }
   }
 
   internal var baseAddress: UnsafeMutablePointer<Element> {
     @inline(__always)
     get {
-      return withUnsafeMutablePointerToElements { unsafe $0 }
+      return unsafe withUnsafeMutablePointerToElements { unsafe $0 }
     }
   }
 

--- a/stdlib/public/core/CString.swift
+++ b/stdlib/public/core/CString.swift
@@ -71,7 +71,7 @@ extension String {
     "Use String(decoding: array, as: UTF8.self) instead, after truncating the null termination."
   )
   public init(cString nullTerminatedUTF8: [CChar]) {
-    self = unsafe nullTerminatedUTF8.withUnsafeBufferPointer {
+    self = nullTerminatedUTF8.withUnsafeBufferPointer {
       unsafe $0.withMemoryRebound(to: UInt8.self, String.init(_checkingCString:))
     }
   }
@@ -135,7 +135,7 @@ extension String {
     "Use String(decoding: array, as: UTF8.self) instead, after truncating the null termination."
   )
   public init(cString nullTerminatedUTF8: [UInt8]) {
-    self = unsafe nullTerminatedUTF8.withUnsafeBufferPointer {
+    self = nullTerminatedUTF8.withUnsafeBufferPointer {
       unsafe String(_checkingCString: $0)
     }
   }
@@ -259,7 +259,7 @@ extension String {
         "input of String.init(validatingCString:) must be null-terminated"
       )
     }
-    let string = unsafe nullTerminatedUTF8.prefix(length).withUnsafeBufferPointer {
+    let string = nullTerminatedUTF8.prefix(length).withUnsafeBufferPointer {
       unsafe $0.withMemoryRebound(to: UInt8.self, String._tryFromUTF8(_:))
     }
     guard let string else { return nil }
@@ -410,7 +410,7 @@ extension String {
     }
 
     if _fastPath(encoding == Unicode.UTF8.self) {
-      return unsafe cString.prefix(length).withUnsafeBufferPointer {
+      return cString.prefix(length).withUnsafeBufferPointer {
         buffer -> (result: String, repairsMade: Bool)? in
         return unsafe buffer.withMemoryRebound(to: UInt8.self) { codeUnits in
           if isRepairing {
@@ -424,7 +424,7 @@ extension String {
       }
     }
 
-    return unsafe cString.prefix(length).withUnsafeBufferPointer {
+    return cString.prefix(length).withUnsafeBufferPointer {
       buf -> (result: String, repairsMade: Bool)? in
       unsafe String._fromCodeUnits(buf, encoding: encoding, repair: isRepairing)
     }
@@ -438,7 +438,7 @@ extension String {
     as encoding: Encoding.Type,
     repairingInvalidCodeUnits isRepairing: Bool = true
   ) -> (result: String, repairsMade: Bool)? {
-    return unsafe cString.withCString(encodedAs: encoding) {
+    return cString.withCString(encodedAs: encoding) {
       unsafe String.decodeCString(
         $0, as: encoding, repairingInvalidCodeUnits: isRepairing
       )
@@ -518,7 +518,7 @@ extension String {
     decodingCString nullTerminatedCodeUnits: String,
     as encoding: Encoding.Type
   ) {
-    self = unsafe nullTerminatedCodeUnits.withCString(encodedAs: encoding) {
+    self = nullTerminatedCodeUnits.withCString(encodedAs: encoding) {
       unsafe String(decodingCString: $0, as: encoding.self)
     }
   }

--- a/stdlib/public/core/CocoaArray.swift
+++ b/stdlib/public/core/CocoaArray.swift
@@ -119,7 +119,7 @@ internal struct _CocoaArrayWrapper: RandomAccessCollection {
     // subRange.upperBound items are stored contiguously.  This is an
     // acceptable conservative behavior, but could potentially be
     // optimized for other cases.
-    let contiguousCount = unsafe withUnsafeMutablePointer(to: &enumerationState) {
+    let contiguousCount = withUnsafeMutablePointer(to: &enumerationState) {
       unsafe core.countByEnumerating(with: $0, objects: nil, count: 0)
     }
 

--- a/stdlib/public/core/CollectionAlgorithms.swift
+++ b/stdlib/public/core/CollectionAlgorithms.swift
@@ -398,7 +398,7 @@ extension MutableCollection where Self: BidirectionalCollection {
   public mutating func partition(
     by belongsInSecondPartition: (Element) throws -> Bool
   ) rethrows -> Index {
-    let maybeOffset = try unsafe withContiguousMutableStorageIfAvailable {
+    let maybeOffset = try withContiguousMutableStorageIfAvailable {
       (bufferPointer) -> Int in
       let unsafeBufferPivot = try unsafe bufferPointer._partitionImpl(
         by: belongsInSecondPartition)

--- a/stdlib/public/core/ContiguousArray.swift
+++ b/stdlib/public/core/ContiguousArray.swift
@@ -1005,27 +1005,29 @@ extension ContiguousArray: RangeReplaceableCollection {
   public mutating func _withUnsafeMutableBufferPointerIfSupported<R>(
     _ body: (inout UnsafeMutableBufferPointer<Element>) throws -> R
   ) rethrows -> R? {
-    return try unsafe withUnsafeMutableBufferPointer {
+    return try withUnsafeMutableBufferPointer {
       (bufferPointer) -> R in
       return try unsafe body(&bufferPointer)
     }
   }
 
   @inlinable
+  @safe
   public mutating func withContiguousMutableStorageIfAvailable<R>(
     _ body: (inout UnsafeMutableBufferPointer<Element>) throws -> R
   ) rethrows -> R? {
-    return try unsafe withUnsafeMutableBufferPointer {
+    return try withUnsafeMutableBufferPointer {
       (bufferPointer) -> R in
       return try unsafe body(&bufferPointer)
     }
   }
   
   @inlinable
+  @safe
   public func withContiguousStorageIfAvailable<R>(
     _ body: (UnsafeBufferPointer<Element>) throws -> R
   ) rethrows -> R? {
-    return try unsafe withUnsafeBufferPointer {
+    return try withUnsafeBufferPointer {
       (bufferPointer) -> R in
       return try unsafe body(bufferPointer)
     }
@@ -1243,10 +1245,11 @@ extension ContiguousArray {
   // for ABI reasons.
   @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
   @usableFromInline
+  @safe
   internal func withUnsafeBufferPointer<R>(
     _ body: (UnsafeBufferPointer<Element>) throws -> R
   ) rethrows -> R {
-    return try unsafe _buffer.withUnsafeBufferPointer(body)
+    return try _buffer.withUnsafeBufferPointer(body)
   }
 
   /// Calls a closure with a pointer to the array's contiguous storage.
@@ -1279,10 +1282,11 @@ extension ContiguousArray {
   ///   valid only for the duration of the method's execution.
   /// - Returns: The return value, if any, of the `body` closure parameter.
   @_alwaysEmitIntoClient
+  @safe
   public func withUnsafeBufferPointer<R, E>(
     _ body: (UnsafeBufferPointer<Element>) throws(E) -> R
   ) throws(E) -> R {
-    return try unsafe _buffer.withUnsafeBufferPointer(body)
+    return try _buffer.withUnsafeBufferPointer(body)
   }
 }
 
@@ -1311,7 +1315,7 @@ extension ContiguousArray {
   mutating func __abi_withUnsafeMutableBufferPointer<R>(
     _ body: (inout UnsafeMutableBufferPointer<Element>) throws -> R
   ) rethrows -> R {
-    return try unsafe withUnsafeMutableBufferPointer(body)
+    return try withUnsafeMutableBufferPointer(body)
   }
 
   /// Calls the given closure with a pointer to the array's mutable contiguous
@@ -1356,6 +1360,7 @@ extension ContiguousArray {
   // caller such that we can combine the partial apply with the apply in this
   // function saving on allocating a closure context. This becomes unnecessary
   // once we allocate noescape closures on the stack.
+  @safe
   public mutating func withUnsafeMutableBufferPointer<R, E>(
     _ body: (inout UnsafeMutableBufferPointer<Element>) throws(E) -> R
   ) throws(E) -> R {
@@ -1591,10 +1596,11 @@ extension ContiguousArray {
   ///   execution.
   /// - Returns: The return value, if any, of the `body` closure parameter.
   @inlinable
+  @safe
   public mutating func withUnsafeMutableBytes<R>(
     _ body: (UnsafeMutableRawBufferPointer) throws -> R
   ) rethrows -> R {
-    return try unsafe self.withUnsafeMutableBufferPointer {
+    return try self.withUnsafeMutableBufferPointer {
       return try unsafe body(UnsafeMutableRawBufferPointer($0))
     }
   }
@@ -1627,10 +1633,11 @@ extension ContiguousArray {
   ///   argument is valid only for the duration of the closure's execution.
   /// - Returns: The return value, if any, of the `body` closure parameter.
   @inlinable
+  @safe
   public func withUnsafeBytes<R>(
     _ body: (UnsafeRawBufferPointer) throws -> R
   ) rethrows -> R {
-    return try unsafe self.withUnsafeBufferPointer {
+    return try self.withUnsafeBufferPointer {
       try unsafe body(UnsafeRawBufferPointer($0))
     }
   }

--- a/stdlib/public/core/ContiguousArrayBuffer.swift
+++ b/stdlib/public/core/ContiguousArrayBuffer.swift
@@ -142,6 +142,7 @@ internal final class _ContiguousArrayStorage<
 #if _runtime(_ObjC)
   
   @_effects(releasenone)
+  @safe
   internal final override func withUnsafeBufferOfObjects<R>(
     _ body: (UnsafeBufferPointer<AnyObject>) throws -> R
   ) rethrows -> R {
@@ -165,7 +166,7 @@ internal final class _ContiguousArrayStorage<
       return 0
     }
     
-    return unsafe withUnsafeBufferOfObjects {
+    return withUnsafeBufferOfObjects {
       objects in
       unsafe enumerationState.mutationsPtr = _fastEnumerationStorageMutationsPtr
       unsafe enumerationState.itemsPtr =
@@ -179,7 +180,7 @@ internal final class _ContiguousArrayStorage<
   @inline(__always)
   @_effects(readonly)
   @nonobjc private func _objectAt(_ index: Int) -> Unmanaged<AnyObject> {
-    return unsafe withUnsafeBufferOfObjects {
+    return withUnsafeBufferOfObjects {
       objects in
       _precondition(
         _isValidArraySubscript(index, count: objects.count),
@@ -202,7 +203,7 @@ internal final class _ContiguousArrayStorage<
   
   @objc internal override final var count: Int {
     @_effects(readonly) get {
-      return unsafe withUnsafeBufferOfObjects { $0.count }
+      return withUnsafeBufferOfObjects { $0.count }
     }
   }
 
@@ -210,7 +211,7 @@ internal final class _ContiguousArrayStorage<
   @objc internal override final func getObjects(
     _ aBuffer: UnsafeMutablePointer<AnyObject>, range: _SwiftNSRange
   ) {
-    return unsafe withUnsafeBufferOfObjects {
+    return withUnsafeBufferOfObjects {
       objects in
       _precondition(
         _isValidArrayIndex(range.location, count: objects.count),
@@ -461,6 +462,7 @@ internal struct _ContiguousArrayBuffer<Element>: _ArrayBufferProtocol {
   /// Call `body(p)`, where `p` is an `UnsafeBufferPointer` over the
   /// underlying contiguous storage.
   @_alwaysEmitIntoClient
+  @safe
   internal func withUnsafeBufferPointer<R, E>(
     _ body: (UnsafeBufferPointer<Element>) throws(E) -> R
   ) throws(E) -> R {
@@ -484,6 +486,7 @@ internal struct _ContiguousArrayBuffer<Element>: _ArrayBufferProtocol {
   /// Call `body(p)`, where `p` is an `UnsafeMutableBufferPointer`
   /// over the underlying contiguous storage.
   @_alwaysEmitIntoClient
+  @safe
   internal mutating func withUnsafeMutableBufferPointer<R, E>(
     _ body: (UnsafeMutableBufferPointer<Element>) throws(E) -> R
   ) throws(E) -> R {

--- a/stdlib/public/core/Diffing.swift
+++ b/stdlib/public/core/Diffing.swift
@@ -612,7 +612,7 @@ func _linearSpaceMyers<C,D>(
   ) -> R {
     if let result = values.withContiguousStorageIfAvailable(body) { return result }
     let array = ContiguousArray(values)
-    return unsafe array.withUnsafeBufferPointer(body)
+    return array.withUnsafeBufferPointer(body)
   }
 
   return unsafe _withContiguousStorage(for: old) { a in

--- a/stdlib/public/core/FloatingPointParsing.swift.gyb
+++ b/stdlib/public/core/FloatingPointParsing.swift.gyb
@@ -285,7 +285,7 @@ extension ${Self}: LosslessStringConvertible {
     let success = unsafe _withUnprotectedUnsafeMutablePointer(to: &self) { p -> Bool in
       // Make a copy of `text` to ensure we have a null-terminated C string
       // to pass to the libc API:
-      unsafe text.withCString { chars -> Bool in
+      text.withCString { chars -> Bool in
         switch unsafe chars[0] {
         case 9, 10, 11, 12, 13, 32:
           return false // Reject leading whitespace

--- a/stdlib/public/core/Integers.swift
+++ b/stdlib/public/core/Integers.swift
@@ -1702,7 +1702,7 @@ extension BinaryInteger {
     let safetyMargin = radix >= 10 ? 21 : 65
     let capacity =
       (radix >= 10 ? (bitWidth * 5 + 15) &>> 4 : bitWidth) + safetyMargin
-    return unsafe withUnsafeTemporaryAllocation(
+    return withUnsafeTemporaryAllocation(
       of: UTF8.CodeUnit.self,
       capacity: capacity
     ) {

--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -639,7 +639,7 @@ public class ReferenceWritableKeyPath<
       func formalMutation<MutationRoot>(_ base: MutationRoot)
           -> UnsafeMutablePointer<Value> {
         var base2 = base
-        return unsafe withUnsafeBytes(of: &base2) { baseBytes in
+            return withUnsafeBytes(of: &base2) { baseBytes in
           var p = unsafe baseBytes.baseAddress.unsafelyUnwrapped
           var curType: Any.Type = MutationRoot.self
           while true {
@@ -1048,11 +1048,11 @@ internal final class ClassHolder<ProjectionType> {
     // withUnsafeMutablePointer(to:) because the instance was just allocated with
     // allocWithTailElems_1 and so we need to make sure to use an initialization
     // rather than an assignment.
-    unsafe withUnsafeMutablePointer(to: &holder.previous) {
+    withUnsafeMutablePointer(to: &holder.previous) {
       unsafe $0.initialize(to: previous)
     }
 
-    unsafe withUnsafeMutablePointer(to: &holder.instance) {
+    withUnsafeMutablePointer(to: &holder.instance) {
       unsafe $0.initialize(to: instance)
     }
 

--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -639,7 +639,7 @@ public class ReferenceWritableKeyPath<
       func formalMutation<MutationRoot>(_ base: MutationRoot)
           -> UnsafeMutablePointer<Value> {
         var base2 = base
-            return withUnsafeBytes(of: &base2) { baseBytes in
+        return withUnsafeBytes(of: &base2) { baseBytes in
           var p = unsafe baseBytes.baseAddress.unsafelyUnwrapped
           var curType: Any.Type = MutationRoot.self
           while true {

--- a/stdlib/public/core/LifetimeManager.swift
+++ b/stdlib/public/core/LifetimeManager.swift
@@ -121,6 +121,7 @@ public func _fixLifetime<T: ~Copyable & ~Escapable>(_ x: borrowing T) {
 /// - Returns: The return value, if any, of the `body` closure.
 @_alwaysEmitIntoClient
 @inline(always)
+@safe
 public func withUnsafeMutablePointer<
   T: ~Copyable, E: Error, Result: ~Copyable
 >(
@@ -182,6 +183,7 @@ public func _withUnprotectedUnsafeMutablePointer<
 /// - Returns: The return value, if any, of the `body` closure.
 @_alwaysEmitIntoClient
 @inline(always)
+@safe
 public func withUnsafePointer<T: ~Copyable, E: Error, Result: ~Copyable>(
   to value: borrowing T,
   _ body: (UnsafePointer<T>) throws(E) -> Result
@@ -231,6 +233,7 @@ internal func __abi_withUnsafePointer<T, Result>(
 /// - Returns: The return value, if any, of the `body` closure.
 @_alwaysEmitIntoClient
 @inline(always)
+@safe
 public func withUnsafePointer<T: ~Copyable, E: Error, Result: ~Copyable>(
   to value: inout T,
   _ body: (UnsafePointer<T>) throws(E) -> Result

--- a/stdlib/public/core/ManagedBuffer.swift
+++ b/stdlib/public/core/ManagedBuffer.swift
@@ -137,10 +137,11 @@ extension ManagedBuffer where Element: ~Copyable {
   ///   call to `body`.
   @_alwaysEmitIntoClient
   @inline(__always)
+  @safe
   public final func withUnsafeMutablePointerToHeader<E: Error, R: ~Copyable>(
     _ body: (UnsafeMutablePointer<Header>) throws(E) -> R
   ) throws(E) -> R {
-    try unsafe withUnsafeMutablePointers { (v, _) throws(E) in try unsafe body(v) }
+    try withUnsafeMutablePointers { (v, _) throws(E) in try unsafe body(v) }
   }
 
   /// Call `body` with an `UnsafeMutablePointer` to the `Element`
@@ -150,10 +151,11 @@ extension ManagedBuffer where Element: ~Copyable {
   ///   call to `body`.
   @_alwaysEmitIntoClient
   @inline(__always)
+  @safe
   public final func withUnsafeMutablePointerToElements<E: Error, R: ~Copyable>(
     _ body: (UnsafeMutablePointer<Element>) throws(E) -> R
   ) throws(E) -> R {
-    try unsafe withUnsafeMutablePointers { (_, v) throws(E) in try unsafe body(v) }
+    try withUnsafeMutablePointers { (_, v) throws(E) in try unsafe body(v) }
   }
 
   /// Call `body` with `UnsafeMutablePointer`s to the stored `Header`
@@ -163,6 +165,7 @@ extension ManagedBuffer where Element: ~Copyable {
   ///   call to `body`.
   @_alwaysEmitIntoClient
   @inline(__always)
+  @safe
   public final func withUnsafeMutablePointers<E: Error, R: ~Copyable>(
     _ body: (
       UnsafeMutablePointer<Header>, UnsafeMutablePointer<Element>
@@ -180,7 +183,7 @@ extension ManagedBuffer {
   internal final func __legacy_withUnsafeMutablePointerToHeader<R>(
     _ body: (UnsafeMutablePointer<Header>) throws -> R
   ) rethrows -> R {
-    return try unsafe withUnsafeMutablePointers { (v, _) in return try unsafe body(v) }
+    return try withUnsafeMutablePointers { (v, _) in return try unsafe body(v) }
   }
 
   @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
@@ -189,7 +192,7 @@ extension ManagedBuffer {
   internal final func __legacy_withUnsafeMutablePointerToElements<R>(
     _ body: (UnsafeMutablePointer<Element>) throws -> R
   ) rethrows -> R {
-    return try unsafe withUnsafeMutablePointers { return try unsafe body($1) }
+    return try withUnsafeMutablePointers { return try unsafe body($1) }
   }
 
   @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
@@ -278,7 +281,7 @@ public struct ManagedBufferPointer<
       bufferClass: bufferClass, minimumCapacity: minimumCapacity)
 
     // initialize the header field
-    try unsafe withUnsafeMutablePointerToHeader {
+    try withUnsafeMutablePointerToHeader {
       unsafe $0.initialize(to:
         try factory(
           self.buffer,
@@ -429,10 +432,11 @@ extension ManagedBufferPointer where Element: ~Copyable {
   /// - Note: This pointer is valid only
   ///   for the duration of the call to `body`.
   @_alwaysEmitIntoClient
+  @safe
   public func withUnsafeMutablePointerToHeader<E: Error, R: ~Copyable>(
     _ body: (UnsafeMutablePointer<Header>) throws(E) -> R
   ) throws(E) -> R {
-    try unsafe withUnsafeMutablePointers { (v, _) throws(E) in try unsafe body(v) }
+    try withUnsafeMutablePointers { (v, _) throws(E) in try unsafe body(v) }
   }
 
   /// Call `body` with an `UnsafeMutablePointer` to the `Element`
@@ -441,10 +445,11 @@ extension ManagedBufferPointer where Element: ~Copyable {
   /// - Note: This pointer is valid only for the duration of the
   ///   call to `body`.
   @_alwaysEmitIntoClient
+  @safe
   public func withUnsafeMutablePointerToElements<E: Error, R: ~Copyable>(
     _ body: (UnsafeMutablePointer<Element>) throws(E) -> R
   ) throws(E) -> R {
-    try unsafe withUnsafeMutablePointers { (_, v) throws(E) in try unsafe body(v) }
+    try withUnsafeMutablePointers { (_, v) throws(E) in try unsafe body(v) }
   }
 
   /// Call `body` with `UnsafeMutablePointer`s to the stored `Header`
@@ -453,6 +458,7 @@ extension ManagedBufferPointer where Element: ~Copyable {
   /// - Note: These pointers are valid only for the duration of the
   ///   call to `body`.
   @_alwaysEmitIntoClient
+  @safe
   public func withUnsafeMutablePointers<E: Error, R: ~Copyable>(
     _ body: (
       UnsafeMutablePointer<Header>, UnsafeMutablePointer<Element>

--- a/stdlib/public/core/ManagedBuffer.swift
+++ b/stdlib/public/core/ManagedBuffer.swift
@@ -134,38 +134,44 @@ extension ManagedBuffer where Element: ~Copyable {
   /// `Header`.
   ///
   /// - Note: This pointer is valid only for the duration of the
-  ///   call to `body`.
+  ///   call to `body`. The caller is responsible for ensuring that
+  ///   the buffer is not being accessed elsewhere while performing
+  ///   this call.
   @_alwaysEmitIntoClient
   @inline(__always)
-  @safe
+  @unsafe
   public final func withUnsafeMutablePointerToHeader<E: Error, R: ~Copyable>(
     _ body: (UnsafeMutablePointer<Header>) throws(E) -> R
   ) throws(E) -> R {
-    try withUnsafeMutablePointers { (v, _) throws(E) in try unsafe body(v) }
+    try unsafe withUnsafeMutablePointers { (v, _) throws(E) in try unsafe body(v) }
   }
 
   /// Call `body` with an `UnsafeMutablePointer` to the `Element`
   /// storage.
   ///
   /// - Note: This pointer is valid only for the duration of the
-  ///   call to `body`.
+  ///   call to `body`. The caller is responsible for ensuring that
+  ///   the buffer is not being accessed elsewhere while performing
+  ///   this call.
   @_alwaysEmitIntoClient
   @inline(__always)
-  @safe
+  @unsafe
   public final func withUnsafeMutablePointerToElements<E: Error, R: ~Copyable>(
     _ body: (UnsafeMutablePointer<Element>) throws(E) -> R
   ) throws(E) -> R {
-    try withUnsafeMutablePointers { (_, v) throws(E) in try unsafe body(v) }
+    try unsafe withUnsafeMutablePointers { (_, v) throws(E) in try unsafe body(v) }
   }
 
   /// Call `body` with `UnsafeMutablePointer`s to the stored `Header`
   /// and raw `Element` storage.
   ///
   /// - Note: These pointers are valid only for the duration of the
-  ///   call to `body`.
+  ///   call to `body`. The caller is responsible for ensuring that
+  ///   the buffer is not being accessed elsewhere while performing
+  ///   this call.
   @_alwaysEmitIntoClient
   @inline(__always)
-  @safe
+  @unsafe
   public final func withUnsafeMutablePointers<E: Error, R: ~Copyable>(
     _ body: (
       UnsafeMutablePointer<Header>, UnsafeMutablePointer<Element>
@@ -183,7 +189,7 @@ extension ManagedBuffer {
   internal final func __legacy_withUnsafeMutablePointerToHeader<R>(
     _ body: (UnsafeMutablePointer<Header>) throws -> R
   ) rethrows -> R {
-    return try withUnsafeMutablePointers { (v, _) in return try unsafe body(v) }
+    return try unsafe withUnsafeMutablePointers { (v, _) in return try unsafe body(v) }
   }
 
   @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
@@ -192,7 +198,7 @@ extension ManagedBuffer {
   internal final func __legacy_withUnsafeMutablePointerToElements<R>(
     _ body: (UnsafeMutablePointer<Element>) throws -> R
   ) rethrows -> R {
-    return try withUnsafeMutablePointers { return try unsafe body($1) }
+    return try unsafe withUnsafeMutablePointers { return try unsafe body($1) }
   }
 
   @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
@@ -281,7 +287,7 @@ public struct ManagedBufferPointer<
       bufferClass: bufferClass, minimumCapacity: minimumCapacity)
 
     // initialize the header field
-    try withUnsafeMutablePointerToHeader {
+    try unsafe withUnsafeMutablePointerToHeader {
       unsafe $0.initialize(to:
         try factory(
           self.buffer,
@@ -429,36 +435,40 @@ extension ManagedBufferPointer where Element: ~Copyable {
   /// Call `body` with an `UnsafeMutablePointer` to the stored
   /// `Header`.
   ///
-  /// - Note: This pointer is valid only
-  ///   for the duration of the call to `body`.
+  /// - Note: This pointer is valid only for the duration of the call to
+  /// `body`. The caller is responsible for ensuring that the buffer is not
+  /// being accessed anyone else while performing this call.
   @_alwaysEmitIntoClient
-  @safe
+  @unsafe
   public func withUnsafeMutablePointerToHeader<E: Error, R: ~Copyable>(
     _ body: (UnsafeMutablePointer<Header>) throws(E) -> R
   ) throws(E) -> R {
-    try withUnsafeMutablePointers { (v, _) throws(E) in try unsafe body(v) }
+    try unsafe withUnsafeMutablePointers { (v, _) throws(E) in try unsafe body(v) }
   }
 
   /// Call `body` with an `UnsafeMutablePointer` to the `Element`
   /// storage.
   ///
   /// - Note: This pointer is valid only for the duration of the
-  ///   call to `body`.
+  ///   call to `body`. The caller is responsible for ensuring that the
+  ///   buffer is not being accessed anyone else while performing this call.
   @_alwaysEmitIntoClient
-  @safe
+  @unsafe
   public func withUnsafeMutablePointerToElements<E: Error, R: ~Copyable>(
     _ body: (UnsafeMutablePointer<Element>) throws(E) -> R
   ) throws(E) -> R {
-    try withUnsafeMutablePointers { (_, v) throws(E) in try unsafe body(v) }
+    try unsafe withUnsafeMutablePointers { (_, v) throws(E) in try unsafe body(v) }
   }
 
   /// Call `body` with `UnsafeMutablePointer`s to the stored `Header`
   /// and raw `Element` storage.
   ///
   /// - Note: These pointers are valid only for the duration of the
-  ///   call to `body`.
+  ///   call to `body`. The caller is responsible for ensuring that
+  ///   the buffer is not being accessed elsewhere while performing
+  ///   this call.
   @_alwaysEmitIntoClient
-  @safe
+  @unsafe
   public func withUnsafeMutablePointers<E: Error, R: ~Copyable>(
     _ body: (
       UnsafeMutablePointer<Header>, UnsafeMutablePointer<Element>

--- a/stdlib/public/core/Misc.swift
+++ b/stdlib/public/core/Misc.swift
@@ -62,7 +62,7 @@ public // SPI (Distributed)
 func _getFunctionFullNameFromMangledName(mangledName: String) -> String? {
   let mangledNameUTF8 = Array(mangledName.utf8)
   let (stringPtr, count) =
-  mangledNameUTF8.withUnsafeBufferPointer { (mangledNameUTF8) in
+    mangledNameUTF8.withUnsafeBufferPointer { (mangledNameUTF8) in
     return unsafe _getFunctionFullNameFromMangledNameImpl(
       mangledNameUTF8.baseAddress!,
       UInt(mangledNameUTF8.endIndex))

--- a/stdlib/public/core/Misc.swift
+++ b/stdlib/public/core/Misc.swift
@@ -62,7 +62,7 @@ public // SPI (Distributed)
 func _getFunctionFullNameFromMangledName(mangledName: String) -> String? {
   let mangledNameUTF8 = Array(mangledName.utf8)
   let (stringPtr, count) =
-    unsafe mangledNameUTF8.withUnsafeBufferPointer { (mangledNameUTF8) in
+  mangledNameUTF8.withUnsafeBufferPointer { (mangledNameUTF8) in
     return unsafe _getFunctionFullNameFromMangledNameImpl(
       mangledNameUTF8.baseAddress!,
       UInt(mangledNameUTF8.endIndex))
@@ -126,7 +126,7 @@ func _mangledTypeName(_ type: any (~Copyable & ~Escapable).Type) -> String? {
 public // SPI(Foundation)
 func _typeByName(_ name: String) -> Any.Type? {
   let nameUTF8 = Array(name.utf8)
-  return unsafe nameUTF8.withUnsafeBufferPointer { (nameUTF8) in
+  return nameUTF8.withUnsafeBufferPointer { (nameUTF8) in
     return  unsafe _getTypeByMangledNameUntrusted(nameUTF8.baseAddress!,
                                   UInt(nameUTF8.endIndex))
   }

--- a/stdlib/public/core/MutableCollection.swift
+++ b/stdlib/public/core/MutableCollection.swift
@@ -234,6 +234,7 @@ where SubSequence: MutableCollection
   /// - Returns: The value returned from `body`, unless the collection doesn't
   ///   support contiguous storage, in which case the method ignores `body` and
   ///   returns `nil`.
+  @safe
   mutating func withContiguousMutableStorageIfAvailable<R>(
     _ body: (_ buffer: inout UnsafeMutableBufferPointer<Element>) throws -> R
   ) rethrows -> R?
@@ -250,6 +251,7 @@ extension MutableCollection {
   }
 
   @inlinable
+  @safe
   public mutating func withContiguousMutableStorageIfAvailable<R>(
     _ body: (inout UnsafeMutableBufferPointer<Element>) throws -> R
   ) rethrows -> R? {

--- a/stdlib/public/core/ReflectionMirror.swift
+++ b/stdlib/public/core/ReflectionMirror.swift
@@ -79,7 +79,7 @@ internal func _getQuickLookObject<T>(_: T) -> AnyObject?
 internal func _isImpl(_ object: AnyObject, kindOf: UnsafePointer<CChar>) -> Bool
 
 internal func _is(_ object: AnyObject, kindOf `class`: String) -> Bool {
-  return unsafe `class`.withCString {
+  return `class`.withCString {
     return unsafe _isImpl(object, kindOf: $0)
   }
 }

--- a/stdlib/public/core/Runtime.swift
+++ b/stdlib/public/core/Runtime.swift
@@ -139,7 +139,7 @@ func _stdlib_atomicInitializeARCRef(
   let desiredPtr = unsafe unmanaged.toOpaque()
   let rawTarget = unsafe UnsafeMutableRawPointer(target).assumingMemoryBound(
     to: Optional<UnsafeRawPointer>.self)
-  let wonRace = unsafe withUnsafeMutablePointer(to: &expected) {
+  let wonRace = withUnsafeMutablePointer(to: &expected) {
     unsafe _stdlib_atomicCompareExchangeStrongPtr(
       object: rawTarget, expected: $0, desired: desiredPtr
     )

--- a/stdlib/public/core/RuntimeFunctionCounters.swift
+++ b/stdlib/public/core/RuntimeFunctionCounters.swift
@@ -292,7 +292,7 @@ internal struct _RuntimeFunctionCountersState: _RuntimeFunctionCountersStats {
           "0..<\(_RuntimeFunctionCounters.numRuntimeFunctionCounters)")
       }
       var tmpCounters = counters
-      let counter: UInt32 = unsafe withUnsafePointer(to: &tmpCounters) { ptr in
+      let counter: UInt32 = withUnsafePointer(to: &tmpCounters) { ptr in
         return unsafe ptr.withMemoryRebound(to: UInt32.self, capacity: 64) { buf in
           return unsafe buf[index]
         }
@@ -306,7 +306,7 @@ internal struct _RuntimeFunctionCountersState: _RuntimeFunctionCountersStats {
         fatalError("Counter index should be in the range " +
           "0..<\(_RuntimeFunctionCounters.numRuntimeFunctionCounters)")
       }
-      unsafe withUnsafeMutablePointer(to: &counters) {
+      withUnsafeMutablePointer(to: &counters) {
         unsafe $0.withMemoryRebound(to: UInt32.self, capacity: 64) {
           unsafe $0[index] = newValue
         }

--- a/stdlib/public/core/Slice.swift
+++ b/stdlib/public/core/Slice.swift
@@ -222,6 +222,7 @@ extension Slice: Collection {
   }
 
   @_alwaysEmitIntoClient @inlinable
+  @safe
   public func withContiguousStorageIfAvailable<R>(
     _ body: (UnsafeBufferPointer<Element>) throws -> R
   ) rethrows -> R? {
@@ -239,7 +240,7 @@ extension Slice {
   public __consuming func _copyContents(
       initializing buffer: UnsafeMutableBufferPointer<Element>
   ) -> (Iterator, UnsafeMutableBufferPointer<Element>.Index) {
-    if let (_, copied) = unsafe self.withContiguousStorageIfAvailable({
+    if let (_, copied) = self.withContiguousStorageIfAvailable({
       unsafe $0._copyContents(initializing: buffer)
     }) {
       let position = index(startIndex, offsetBy: copied)
@@ -293,6 +294,7 @@ extension Slice: MutableCollection where Base: MutableCollection {
   }
 
   @_alwaysEmitIntoClient @inlinable
+  @safe
   public mutating func withContiguousMutableStorageIfAvailable<R>(
     _ body: (inout UnsafeMutableBufferPointer<Element>) throws -> R
   ) rethrows -> R? {
@@ -300,13 +302,13 @@ extension Slice: MutableCollection where Base: MutableCollection {
     // that we don't calculate index distances unless we know we'll use them.
     // The expectation here is that the base collection will make itself
     // contiguous on the first try and the second call will be relatively cheap.
-    guard unsafe _base.withContiguousMutableStorageIfAvailable({ _ in }) != nil
+    guard _base.withContiguousMutableStorageIfAvailable({ _ in }) != nil
     else {
       return nil
     }
     let start = _base.distance(from: _base.startIndex, to: _startIndex)
     let count = _base.distance(from: _startIndex, to: _endIndex)
-    return try unsafe _base.withContiguousMutableStorageIfAvailable { buffer in
+    return try _base.withContiguousMutableStorageIfAvailable { buffer in
       var slice = unsafe UnsafeMutableBufferPointer(
         rebasing: buffer[start ..< start + count])
       let copy = unsafe slice

--- a/stdlib/public/core/SmallString.swift
+++ b/stdlib/public/core/SmallString.swift
@@ -157,7 +157,7 @@ extension _SmallString {
 
     // No bits should be set between the last code unit and the discriminator
     var copy = self
-    unsafe withUnsafeBytes(of: &copy._storage) {
+    withUnsafeBytes(of: &copy._storage) {
       unsafe _internalInvariant(
         $0[count..<_SmallString.capacity].allSatisfy { $0 == 0 })
     }
@@ -271,7 +271,7 @@ extension _SmallString {
   fileprivate mutating func withMutableCapacity<E: Error>(
     _ f: (UnsafeMutableRawBufferPointer) throws(E) -> Int
   ) throws(E) {
-    let len = try unsafe withUnsafeMutableBytes(of: &_storage) { buffer throws(E) in
+    let len = try withUnsafeMutableBytes(of: &_storage) { buffer throws(E) in
       try unsafe f(.init(start: buffer.baseAddress, count: _SmallString.capacity))
     }
 

--- a/stdlib/public/core/Sort.swift
+++ b/stdlib/public/core/Sort.swift
@@ -247,7 +247,7 @@ extension MutableCollection where Self: RandomAccessCollection {
     by areInIncreasingOrder: (Element, Element) throws -> Bool
   ) rethrows {
     let didSortUnsafeBuffer: Void? =
-      try unsafe withContiguousMutableStorageIfAvailable { buffer in
+    try withContiguousMutableStorageIfAvailable { buffer in
         try unsafe buffer._stableSortImpl(by: areInIncreasingOrder)
       }
     if didSortUnsafeBuffer == nil {

--- a/stdlib/public/core/Sort.swift
+++ b/stdlib/public/core/Sort.swift
@@ -247,7 +247,7 @@ extension MutableCollection where Self: RandomAccessCollection {
     by areInIncreasingOrder: (Element, Element) throws -> Bool
   ) rethrows {
     let didSortUnsafeBuffer: Void? =
-    try withContiguousMutableStorageIfAvailable { buffer in
+      try withContiguousMutableStorageIfAvailable { buffer in
         try unsafe buffer._stableSortImpl(by: areInIncreasingOrder)
       }
     if didSortUnsafeBuffer == nil {

--- a/stdlib/public/core/Span/MutableRawSpan.swift
+++ b/stdlib/public/core/Span/MutableRawSpan.swift
@@ -154,6 +154,7 @@ extension MutableRawSpan {
 
   @_alwaysEmitIntoClient
   @_transparent
+  @safe
   public func withUnsafeBytes<E: Error, Result: ~Copyable>(
     _ body: (_ buffer: UnsafeRawBufferPointer) throws(E) -> Result
   ) throws(E) -> Result {
@@ -163,6 +164,7 @@ extension MutableRawSpan {
   @_alwaysEmitIntoClient
   @_transparent
   @lifetime(self: copy self)
+  @safe
   public mutating func withUnsafeMutableBytes<E: Error, Result: ~Copyable>(
     _ body: (UnsafeMutableRawBufferPointer) throws(E) -> Result
   ) throws(E) -> Result {

--- a/stdlib/public/core/Span/MutableSpan.swift
+++ b/stdlib/public/core/Span/MutableSpan.swift
@@ -387,7 +387,7 @@ extension MutableSpan where Element: ~Copyable {
   public func withUnsafeBufferPointer<E: Error, Result: ~Copyable>(
     _ body: (_ buffer: UnsafeBufferPointer<Element>) throws(E) -> Result
   ) throws(E) -> Result {
-      try Span(_mutableSpan: self).withUnsafeBufferPointer(body)
+    try Span(_mutableSpan: self).withUnsafeBufferPointer(body)
   }
 
   //FIXME: mark closure parameter as non-escaping
@@ -421,7 +421,7 @@ extension MutableSpan where Element: BitwiseCopyable {
   public func withUnsafeBytes<E: Error, Result: ~Copyable>(
     _ body: (_ buffer: UnsafeRawBufferPointer) throws(E) -> Result
   ) throws(E) -> Result {
-      try RawSpan(_mutableSpan: self).withUnsafeBytes(body)
+    try RawSpan(_mutableSpan: self).withUnsafeBytes(body)
   }
 
   //FIXME: mark closure parameter as non-escaping

--- a/stdlib/public/core/Span/MutableSpan.swift
+++ b/stdlib/public/core/Span/MutableSpan.swift
@@ -383,16 +383,18 @@ extension MutableSpan where Element: ~Copyable {
   //FIXME: mark closure parameter as non-escaping
   @_alwaysEmitIntoClient
   @_transparent
+  @safe
   public func withUnsafeBufferPointer<E: Error, Result: ~Copyable>(
     _ body: (_ buffer: UnsafeBufferPointer<Element>) throws(E) -> Result
   ) throws(E) -> Result {
-    try unsafe Span(_mutableSpan: self).withUnsafeBufferPointer(body)
+      try Span(_mutableSpan: self).withUnsafeBufferPointer(body)
   }
 
   //FIXME: mark closure parameter as non-escaping
   @_alwaysEmitIntoClient
   @_transparent
   @lifetime(self: copy self)
+  @safe
   public mutating func withUnsafeMutableBufferPointer<
     E: Error, Result: ~Copyable
   >(
@@ -415,16 +417,18 @@ extension MutableSpan where Element: BitwiseCopyable {
   //FIXME: mark closure parameter as non-escaping
   @_alwaysEmitIntoClient
   @_transparent
+  @safe
   public func withUnsafeBytes<E: Error, Result: ~Copyable>(
     _ body: (_ buffer: UnsafeRawBufferPointer) throws(E) -> Result
   ) throws(E) -> Result {
-    try unsafe RawSpan(_mutableSpan: self).withUnsafeBytes(body)
+      try RawSpan(_mutableSpan: self).withUnsafeBytes(body)
   }
 
   //FIXME: mark closure parameter as non-escaping
   @_alwaysEmitIntoClient
   @_transparent
   @lifetime(self: copy self)
+  @safe
   public mutating func withUnsafeMutableBytes<E: Error, Result: ~Copyable>(
     _ body: (_ buffer: UnsafeMutableRawBufferPointer) throws(E) -> Result
   ) throws(E) -> Result {

--- a/stdlib/public/core/Span/OutputRawSpan.swift
+++ b/stdlib/public/core/Span/OutputRawSpan.swift
@@ -296,7 +296,7 @@ extension OutputRawSpan {
   @_alwaysEmitIntoClient
   @_transparent
   @lifetime(self: copy self)
-  @safe
+  @unsafe
   public mutating func withUnsafeMutableBytes<E: Error, R: ~Copyable>(
     _ body: (
       UnsafeMutableRawBufferPointer,

--- a/stdlib/public/core/Span/OutputRawSpan.swift
+++ b/stdlib/public/core/Span/OutputRawSpan.swift
@@ -296,6 +296,7 @@ extension OutputRawSpan {
   @_alwaysEmitIntoClient
   @_transparent
   @lifetime(self: copy self)
+  @safe
   public mutating func withUnsafeMutableBytes<E: Error, R: ~Copyable>(
     _ body: (
       UnsafeMutableRawBufferPointer,

--- a/stdlib/public/core/Span/OutputSpan.swift
+++ b/stdlib/public/core/Span/OutputSpan.swift
@@ -411,6 +411,7 @@ extension OutputSpan where Element: ~Copyable {
   @_alwaysEmitIntoClient
   @_transparent
   @lifetime(self: copy self)
+  @safe
   public mutating func withUnsafeMutableBufferPointer<E: Error, R: ~Copyable>(
     _ body: (
       UnsafeMutableBufferPointer<Element>,

--- a/stdlib/public/core/Span/OutputSpan.swift
+++ b/stdlib/public/core/Span/OutputSpan.swift
@@ -411,7 +411,7 @@ extension OutputSpan where Element: ~Copyable {
   @_alwaysEmitIntoClient
   @_transparent
   @lifetime(self: copy self)
-  @safe
+  @unsafe
   public mutating func withUnsafeMutableBufferPointer<E: Error, R: ~Copyable>(
     _ body: (
       UnsafeMutableBufferPointer<Element>,

--- a/stdlib/public/core/Span/RawSpan.swift
+++ b/stdlib/public/core/Span/RawSpan.swift
@@ -534,6 +534,7 @@ extension RawSpan {
   /// - Returns: The return value of the `body` closure parameter.
   @_alwaysEmitIntoClient
   @_transparent
+  @safe
   public func withUnsafeBytes<E: Error, Result: ~Copyable>(
     _ body: (_ buffer: UnsafeRawBufferPointer) throws(E) -> Result
   ) throws(E) -> Result {

--- a/stdlib/public/core/Span/Span.swift
+++ b/stdlib/public/core/Span/Span.swift
@@ -701,6 +701,7 @@ extension Span where Element: ~Copyable  {
   /// - Returns: The return value of the `body` closure parameter.
   @_alwaysEmitIntoClient
   @_transparent
+  @safe
   public func withUnsafeBufferPointer<E: Error, Result: ~Copyable>(
     _ body: (_ buffer: UnsafeBufferPointer<Element>) throws(E) -> Result
   ) throws(E) -> Result {
@@ -736,6 +737,7 @@ extension Span where Element: BitwiseCopyable {
   /// - Returns: The return value of the `body` closure parameter.
   @_alwaysEmitIntoClient
   @_transparent
+  @safe
   public func withUnsafeBytes<E: Error, Result: ~Copyable>(
     _ body: (_ buffer: UnsafeRawBufferPointer) throws(E) -> Result
   ) throws(E) -> Result {

--- a/stdlib/public/core/StaticBigInt.swift
+++ b/stdlib/public/core/StaticBigInt.swift
@@ -150,7 +150,7 @@ extension StaticBigInt: CustomDebugStringConvertible {
     // Equivalent to `ceil(bitWidthExcludingSignBit / fourBitsPerHexDigit)`.
     // Underestimated for `-(16 ** y)` values (e.g. "-0x1", "-0x10", "-0x100").
     let capacity = indicator.utf8.count + (((bitWidth - 1) + 3) / 4)
-    var result = unsafe String(unsafeUninitializedCapacity: capacity) { utf8 in
+    var result = String(unsafeUninitializedCapacity: capacity) { utf8 in
 
       // Pre-initialize with zeros, ignoring extra capacity.
       var utf8 = unsafe utf8.prefix(capacity)

--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -424,7 +424,7 @@ extension String {
     C: Collection
   >(_ input: C) -> (result: String, repairsMade: Bool) {
     _internalInvariant(C.Element.self == UInt8.self)
-    return unsafe Array(input).withUnsafeBufferPointer {
+    return Array(input).withUnsafeBufferPointer {
       unsafe UnsafeRawBufferPointer($0).withMemoryRebound(to: UInt8.self) {
         unsafe String._fromUTF8Repairing($0)
       }
@@ -545,7 +545,7 @@ extension String {
       }
     )
     if error { return nil }
-    self = unsafe transcoded.withUnsafeBufferPointer{
+    self = transcoded.withUnsafeBufferPointer{
       unsafe String._uncheckedFromUTF8($0, asciiPreScanResult: isASCII)
     }
   }
@@ -644,6 +644,7 @@ extension String {
 #if hasFeature(Embedded)
   @_alwaysEmitIntoClient @inline(__always)
   @available(SwiftStdlib 5.3, *)
+  @safe
   public init<E: Error>(
     unsafeUninitializedCapacity capacity: Int,
     initializingUTF8With initializer: (
@@ -675,6 +676,7 @@ extension String {
 #else
   @_alwaysEmitIntoClient @inline(__always)
   @available(SwiftStdlib 5.3, *)
+  @safe
   public init<E: Error>(
     unsafeUninitializedCapacity capacity: Int,
     initializingUTF8With initializer: (
@@ -759,6 +761,7 @@ extension String {
   ///   duration of the method's execution.
   /// - Returns: The return value, if any, of the `body` closure parameter.
   @_alwaysEmitIntoClient // (Primarily @inlinable) fast-path: already C-string compatible
+  @safe
   public func withCString<Result, E: Error>(
     _ body: (UnsafePointer<Int8>) throws(E) -> Result
   ) throws(E) -> Result {
@@ -776,7 +779,7 @@ extension String {
   internal func __rethrows_withCString<Result>(
     _ body: (UnsafePointer<Int8>) throws -> Result
   ) throws -> Result {
-    return try unsafe withCString(body)
+    return try withCString(body)
   }
 #endif // !hasFeature(Embedded)
 
@@ -798,12 +801,13 @@ extension String {
   /// - Returns: The return value, if any, of the `body` closure parameter.
   @_alwaysEmitIntoClient
   @inline(__always) // Eliminate dynamic type check when possible
+  @safe
   public func withCString<Result, TargetEncoding: Unicode.Encoding, E: Error>(
     encodedAs targetEncoding: TargetEncoding.Type,
     _ body: (UnsafePointer<TargetEncoding.CodeUnit>) throws(E) -> Result
   ) throws(E) -> Result {
     if targetEncoding == UTF8.self {
-      return try unsafe self.withCString {
+      return try self.withCString {
         (cPtr: UnsafePointer<CChar>) throws(E) -> Result  in
         _internalInvariant(UInt8.self == TargetEncoding.CodeUnit.self)
         let ptr = unsafe UnsafeRawPointer(cPtr).assumingMemoryBound(
@@ -827,7 +831,7 @@ extension String {
     encodedAs targetEncoding: TargetEncoding.Type,
     _ body: (UnsafePointer<TargetEncoding.CodeUnit>) throws -> Result
   ) throws -> Result {
-    return try unsafe withCString(encodedAs: targetEncoding, body)
+    return try withCString(encodedAs: targetEncoding, body)
   }
 #endif // !hasFeature(Embedded)
 
@@ -1140,7 +1144,7 @@ extension String {
   @_effects(releasenone)
   public func lowercased() -> String {
     if _fastPath(_guts.isFastASCII) {
-      return unsafe _guts.withFastUTF8 { utf8 in
+      return _guts.withFastUTF8 { utf8 in
         return unsafe String(_uninitializedCapacity: utf8.count) { buffer in
           for i in 0 ..< utf8.count {
             unsafe buffer[i] = unsafe _lowercaseASCII(utf8[i])
@@ -1174,7 +1178,7 @@ extension String {
   @_effects(releasenone)
   public func uppercased() -> String {
     if _fastPath(_guts.isFastASCII) {
-      return unsafe _guts.withFastUTF8 { utf8 in
+      return _guts.withFastUTF8 { utf8 in
         return unsafe String(_uninitializedCapacity: utf8.count) { buffer in
           for i in 0 ..< utf8.count {
             unsafe buffer[i] = unsafe _uppercaseASCII(utf8[i])

--- a/stdlib/public/core/StringBridge.swift
+++ b/stdlib/public/core/StringBridge.swift
@@ -418,7 +418,7 @@ private func _withCocoaASCIIPointer<R>(
       return nil // tagged pointer strings don't support _fastCStringContents
     }
     if let smol = _SmallString(taggedASCIICocoa: str) {
-      return unsafe _StringGuts(smol).withFastUTF8 {
+      return _StringGuts(smol).withFastUTF8 {
         unsafe work($0.baseAddress._unsafelyUnwrappedUnchecked)
       }
     }
@@ -443,7 +443,7 @@ private func _withCocoaUTF8Pointer<R>(
       return nil // tagged pointer strings don't support _fastCStringContents
     }
     if let smol = _SmallString(taggedCocoa: str) {
-      return unsafe _StringGuts(smol).withFastUTF8 {
+      return _StringGuts(smol).withFastUTF8 {
         unsafe work($0.baseAddress._unsafelyUnwrappedUnchecked)
       }
     }

--- a/stdlib/public/core/StringComparison.swift
+++ b/stdlib/public/core/StringComparison.swift
@@ -53,8 +53,8 @@ internal func _stringCompareInternal(
   }
 
   let isNFC = lhs.isNFC && rhs.isNFC
-  return unsafe lhs.withFastUTF8 { lhsUTF8 in
-    return unsafe rhs.withFastUTF8 { rhsUTF8 in
+  return lhs.withFastUTF8 { lhsUTF8 in
+    return rhs.withFastUTF8 { rhsUTF8 in
       return unsafe _stringCompareFastUTF8(
         lhsUTF8, rhsUTF8, expecting: expecting, bothNFC: isNFC)
     }
@@ -88,8 +88,8 @@ internal func _stringCompareInternal(
   }
 
   let isNFC = lhs.isNFC && rhs.isNFC
-  return unsafe lhs.withFastUTF8(range: lhsRange) { lhsUTF8 in
-    return unsafe rhs.withFastUTF8(range: rhsRange) { rhsUTF8 in
+  return lhs.withFastUTF8(range: lhsRange) { lhsUTF8 in
+    return rhs.withFastUTF8(range: rhsRange) { rhsUTF8 in
       return unsafe _stringCompareFastUTF8(
         lhsUTF8, rhsUTF8, expecting: expecting, bothNFC: isNFC)
     }

--- a/stdlib/public/core/StringCreate.swift
+++ b/stdlib/public/core/StringCreate.swift
@@ -296,7 +296,7 @@ extension String {
       into: { contents.append($0) })
     _internalInvariant(!repaired, "Error present")
 
-    return unsafe contents.withUnsafeBufferPointer {
+    return contents.withUnsafeBufferPointer {
       unsafe String._uncheckedFromUTF8($0, precalculatedUTF16Count: input.count)
     }
   }
@@ -329,12 +329,12 @@ extension String {
 
     let str:String
     if Encoding.self == UTF16.self {
-      str = unsafe contents.withUnsafeBufferPointer {
+      str = contents.withUnsafeBufferPointer {
         unsafe String._uncheckedFromUTF8(
           $0, precalculatedUTF16Count: input.count)
       }
     } else {
-      str = unsafe contents.withUnsafeBufferPointer {
+      str = contents.withUnsafeBufferPointer {
         unsafe String._uncheckedFromUTF8($0)
       }
     }
@@ -393,7 +393,7 @@ extension String {
       return resultOrSlow(strOpt)
     }
 
-    return unsafe resultOrSlow(Array(input).withUnsafeBufferPointer {
+    return resultOrSlow(Array(input).withUnsafeBufferPointer {
         let buffer = unsafe UnsafeRawBufferPointer($0).bindMemory(to: UInt8.self)
         return unsafe String._fromASCIIValidating(buffer)
       })
@@ -426,7 +426,7 @@ extension String {
   @inline(never) // slow-path
   internal static func _copying(_ str: Substring) -> String {
     if _fastPath(str._wholeGuts.isFastUTF8) {
-      var new = unsafe str._wholeGuts.withFastUTF8(range: str._offsetRange) {
+      var new = str._wholeGuts.withFastUTF8(range: str._offsetRange) {
         unsafe String._uncheckedFromUTF8($0)
       }
 #if os(watchOS) && _pointerBitWidth(_32)
@@ -440,7 +440,7 @@ extension String {
 #endif
       return new
     }
-    return unsafe Array(str.utf8).withUnsafeBufferPointer {
+    return Array(str.utf8).withUnsafeBufferPointer {
       unsafe String._uncheckedFromUTF8($0)
     }
   }

--- a/stdlib/public/core/StringGraphemeBreaking.swift
+++ b/stdlib/public/core/StringGraphemeBreaking.swift
@@ -208,7 +208,7 @@ extension _StringGuts {
   internal func _opaqueCharacterStride(startingAt i: Int) -> Int {
     _internalInvariant(i < endIndex._encodedOffset)
     if isFastUTF8 {
-      let fast = unsafe withFastUTF8 { utf8 in
+      let fast = withFastUTF8 { utf8 in
         if i &+ 1 == utf8.count { return true }
         let pair = unsafe UnsafeRawPointer(
           utf8.baseAddress.unsafelyUnwrapped
@@ -231,7 +231,7 @@ extension _StringGuts {
       return _foreignOpaqueCharacterStride(startingAt: i)
     }
 
-    let nextIdx = unsafe withFastUTF8 { utf8 in
+    let nextIdx = withFastUTF8 { utf8 in
       nextBoundary(startingAt: i) { j in
         _internalInvariant(j >= 0)
         guard j < utf8.count else { return nil }
@@ -257,7 +257,7 @@ extension _StringGuts {
       return i
     }
     if isFastUTF8 {
-      let fast = unsafe withFastUTF8 { utf8 in
+      let fast = withFastUTF8 { utf8 in
         let pair = unsafe UnsafeRawPointer(
           utf8.baseAddress.unsafelyUnwrapped
         ).loadUnaligned(fromByteOffset: i &- 2, as: UInt16.self)
@@ -279,7 +279,7 @@ extension _StringGuts {
       return _foreignOpaqueCharacterStride(endingAt: i)
     }
 
-    let previousIdx = unsafe withFastUTF8 { utf8 in
+    let previousIdx = withFastUTF8 { utf8 in
       previousBoundary(endingAt: i) { j in
         _internalInvariant(j <= utf8.count)
         guard j > 0 else { return nil }
@@ -308,7 +308,7 @@ extension _StringGuts {
       return _foreignOpaqueCharacterStride(endingAt: i, in: bounds)
     }
 
-    let previousIdx = unsafe withFastUTF8 { utf8 in
+    let previousIdx = withFastUTF8 { utf8 in
       previousBoundary(endingAt: i) { j in
         _internalInvariant(j <= bounds.upperBound)
         guard j > bounds.lowerBound else { return nil }

--- a/stdlib/public/core/StringGuts.swift
+++ b/stdlib/public/core/StringGuts.swift
@@ -163,6 +163,7 @@ extension _StringGuts {
   }
 
   @_alwaysEmitIntoClient @inline(__always)
+  @safe
   internal func withFastUTF8<R, E: Error>(
     _ f: (UnsafeBufferPointer<UInt8>) throws(E) -> R
   ) throws(E) -> R {
@@ -185,16 +186,17 @@ extension _StringGuts {
   internal func __rethrows_withFastUTF8<R>(
     _ f: (UnsafeBufferPointer<UInt8>) throws -> R
   ) throws -> R {
-    return try unsafe self.withFastUTF8(f)
+    return try self.withFastUTF8(f)
   }
 #endif // !hasFeature(Embedded)
 
   @_alwaysEmitIntoClient @inline(__always)
+  @safe
   internal func withFastUTF8<R, E: Error>(
     range: Range<Int>,
     _ f: (UnsafeBufferPointer<UInt8>) throws(E) -> R
   ) throws(E) -> R {
-    return try unsafe self.withFastUTF8 { wholeUTF8 throws(E) in
+    return try self.withFastUTF8 { wholeUTF8 throws(E) in
       return try unsafe f(unsafe UnsafeBufferPointer(rebasing: wholeUTF8[range]))
     }
   }
@@ -212,7 +214,7 @@ extension _StringGuts {
     range: Range<Int>,
     _ f: (UnsafeBufferPointer<UInt8>) throws -> R
   ) throws -> R {
-    return try unsafe self.withFastUTF8(range: range, f)
+    return try self.withFastUTF8(range: range, f)
   }
 #endif // !hasFeature(Embedded)
 
@@ -220,7 +222,7 @@ extension _StringGuts {
   internal func withFastCChar<R, E: Error>(
     _ f: (UnsafeBufferPointer<CChar>) throws(E) -> R
   ) throws(E) -> R {
-    return try unsafe self.withFastUTF8 { utf8 throws(E) in
+    return try self.withFastUTF8 { utf8 throws(E) in
       return try unsafe utf8.withMemoryRebound(to: CChar.self, f)
     }
   }
@@ -303,7 +305,7 @@ extension _StringGuts {
     _ body: (UnsafePointer<Int8>) throws(E) -> Result
   ) throws(E) -> Result {
     _internalInvariant(!_object.isFastZeroTerminated)
-    return try unsafe String(self).utf8CString.withUnsafeBufferPointer { buffer throws(E) in
+    return try String(self).utf8CString.withUnsafeBufferPointer { buffer throws(E) in
       let ptr = unsafe buffer.baseAddress._unsafelyUnwrappedUnchecked
       return try unsafe body(ptr)
     }
@@ -332,7 +334,7 @@ extension _StringGuts {
   internal func copyUTF8(into mbp: UnsafeMutableBufferPointer<UInt8>) -> Int? {
     let ptr = unsafe mbp.baseAddress._unsafelyUnwrappedUnchecked
     if _fastPath(self.isFastUTF8) {
-      return unsafe self.withFastUTF8 { utf8 in
+      return self.withFastUTF8 { utf8 in
         guard utf8.count <= mbp.count else { return nil }
 
         let utf8Start = unsafe utf8.baseAddress._unsafelyUnwrappedUnchecked

--- a/stdlib/public/core/StringGutsRangeReplaceable.swift
+++ b/stdlib/public/core/StringGutsRangeReplaceable.swift
@@ -124,7 +124,7 @@ extension _StringGuts {
     // strings or foreign strings that provide contiguous UTF-8 access.
     if _fastPath(isFastUTF8) {
       let isASCII = self.isASCII
-      let storage = unsafe self.withFastUTF8 {
+      let storage = self.withFastUTF8 {
         unsafe __StringStorage.create(
           initializingFrom: $0,
           codeUnitCapacity: growthTarget,
@@ -220,7 +220,7 @@ extension _StringGuts {
       return asSmall
     }
     if isFastUTF8 {
-      return unsafe withFastUTF8 { unsafe _SmallString($0)! }
+      return withFastUTF8 { unsafe _SmallString($0)! }
     }
     return _foreignConvertedToSmall()
   }
@@ -337,14 +337,14 @@ extension _StringGuts {
     if isUniqueNative {
       if let repl = newElements as? String {
         if repl._guts.isFastUTF8 {
-          return unsafe repl._guts.withFastUTF8 {
+          return repl._guts.withFastUTF8 {
             unsafe uniqueNativeReplaceSubrange(
               bounds, with: $0, isASCII: repl._guts.isASCII)
           }
         }
       } else if let repl = newElements as? Substring {
         if repl._wholeGuts.isFastUTF8 {
-          return unsafe repl._wholeGuts.withFastUTF8(range: repl._offsetRange) {
+          return repl._wholeGuts.withFastUTF8(range: repl._offsetRange) {
             unsafe uniqueNativeReplaceSubrange(
               bounds, with: $0, isASCII: repl._wholeGuts.isASCII)
           }
@@ -380,14 +380,14 @@ extension _StringGuts {
     if isUniqueNative {
       if let repl = newElements as? String.UnicodeScalarView {
         if repl._guts.isFastUTF8 {
-          return unsafe repl._guts.withFastUTF8 {
+          return repl._guts.withFastUTF8 {
             unsafe uniqueNativeReplaceSubrange(
               bounds, with: $0, isASCII: repl._guts.isASCII)
           }
         }
       } else if let repl = newElements as? Substring.UnicodeScalarView {
         if repl._wholeGuts.isFastUTF8 {
-          return unsafe repl._wholeGuts.withFastUTF8(range: repl._offsetRange) {
+          return repl._wholeGuts.withFastUTF8(range: repl._offsetRange) {
             unsafe uniqueNativeReplaceSubrange(
               bounds, with: $0, isASCII: repl._wholeGuts.isASCII)
           }

--- a/stdlib/public/core/StringGutsSlice.swift
+++ b/stdlib/public/core/StringGutsSlice.swift
@@ -82,7 +82,7 @@ internal struct _StringGutsSlice {
   internal func withFastUTF8<R, E: Error>(
     _ f: (UnsafeBufferPointer<UInt8>) throws(E) -> R
   ) throws(E) -> R {
-    return try unsafe _guts.withFastUTF8(range: _offsetRange, f)
+    return try _guts.withFastUTF8(range: _offsetRange, f)
   }
 
   @_effects(releasenone)

--- a/stdlib/public/core/StringHashable.swift
+++ b/stdlib/public/core/StringHashable.swift
@@ -20,7 +20,7 @@ extension String: Hashable {
   ///   of this instance.
   public func hash(into hasher: inout Hasher) {
     if _fastPath(self._guts.isNFCFastUTF8) {
-      unsafe self._guts.withFastUTF8 {
+      self._guts.withFastUTF8 {
         unsafe hasher.combine(bytes: UnsafeRawBufferPointer($0))
       }
       hasher.combine(0xFF as UInt8) // terminator

--- a/stdlib/public/core/StringLegacy.swift
+++ b/stdlib/public/core/StringLegacy.swift
@@ -124,9 +124,9 @@ extension String {
   public func hasPrefix(_ prefix: String) -> Bool {
     if _fastPath(self._guts.isNFCFastUTF8 && prefix._guts.isNFCFastUTF8) {
       guard prefix._guts.count <= self._guts.count else { return false }
-      let isPrefix = unsafe prefix._guts.withFastUTF8 { nfcPrefix in
+      let isPrefix = prefix._guts.withFastUTF8 { nfcPrefix in
         let prefixEnd = nfcPrefix.count
-        return unsafe self._guts.withFastUTF8(range: 0..<prefixEnd) { nfcSlicedSelf in
+        return self._guts.withFastUTF8(range: 0..<prefixEnd) { nfcSlicedSelf in
           return unsafe _binaryCompare(nfcSlicedSelf, nfcPrefix) == 0
         }
       }
@@ -143,8 +143,8 @@ extension String {
     if _fastPath(self._guts.isNFCFastUTF8 && suffix._guts.isNFCFastUTF8) {
       let suffixStart = self._guts.count - suffix._guts.count
       guard suffixStart >= 0 else { return false }
-      let isSuffix = unsafe suffix._guts.withFastUTF8 { nfcSuffix in
-        return unsafe self._guts.withFastUTF8(range: suffixStart..<self._guts.count) {
+      let isSuffix = suffix._guts.withFastUTF8 { nfcSuffix in
+        return self._guts.withFastUTF8(range: suffixStart..<self._guts.count) {
           nfcSlicedSelf in return unsafe _binaryCompare(nfcSlicedSelf, nfcSuffix) == 0
         }
       }

--- a/stdlib/public/core/StringProtocol.swift
+++ b/stdlib/public/core/StringProtocol.swift
@@ -229,7 +229,7 @@ extension String {
     _ body: (UnsafeBufferPointer<UInt8>) throws(E) -> R
   ) throws(E) -> R {
     makeContiguousUTF8()
-    return try unsafe _guts.withFastUTF8(body)
+    return try _guts.withFastUTF8(body)
   }
 }
 
@@ -297,6 +297,6 @@ extension Substring {
     _ body: (UnsafeBufferPointer<UInt8>) throws(E) -> R
   ) throws(E) -> R {
     makeContiguousUTF8()
-    return try unsafe _wholeGuts.withFastUTF8(range: _offsetRange, body)
+    return try _wholeGuts.withFastUTF8(range: _offsetRange, body)
   }
 }

--- a/stdlib/public/core/StringSwitch.swift
+++ b/stdlib/public/core/StringSwitch.swift
@@ -78,7 +78,7 @@ func _findStringSwitchCaseWithCache(
   let cacheRawPtr = unsafe oncePtr + MemoryLayout<Builtin.Word>.stride
   let cachePtr = unsafe cacheRawPtr.bindMemory(to: _StringSwitchCache.self, capacity: 1)
   var context = unsafe _StringSwitchContext(cases: cases, cachePtr: cachePtr)
-    withUnsafeMutablePointer(to: &context) { (context) -> () in
+  withUnsafeMutablePointer(to: &context) { (context) -> () in
     Builtin.onceWithContext(oncePtr._rawValue, _createStringTableCache,
                             context._rawValue)
   }

--- a/stdlib/public/core/StringSwitch.swift
+++ b/stdlib/public/core/StringSwitch.swift
@@ -78,7 +78,7 @@ func _findStringSwitchCaseWithCache(
   let cacheRawPtr = unsafe oncePtr + MemoryLayout<Builtin.Word>.stride
   let cachePtr = unsafe cacheRawPtr.bindMemory(to: _StringSwitchCache.self, capacity: 1)
   var context = unsafe _StringSwitchContext(cases: cases, cachePtr: cachePtr)
-  unsafe withUnsafeMutablePointer(to: &context) { (context) -> () in
+    withUnsafeMutablePointer(to: &context) { (context) -> () in
     Builtin.onceWithContext(oncePtr._rawValue, _createStringTableCache,
                             context._rawValue)
   }

--- a/stdlib/public/core/StringUTF16View.swift
+++ b/stdlib/public/core/StringUTF16View.swift
@@ -767,7 +767,7 @@ extension String.UTF16View {
   internal func _utf16Distance(from start: Index, to end: Index) -> Int {
     _internalInvariant(end.transcodedOffset == 0 || end.transcodedOffset == 1)
         
-    return unsafe (end.transcodedOffset - start.transcodedOffset) + _guts.withFastUTF8(
+    return (end.transcodedOffset - start.transcodedOffset) + _guts.withFastUTF8(
       range: start._encodedOffset ..< end._encodedOffset
     ) { utf8 in
       let rawBuffer = UnsafeRawBufferPointer(utf8)
@@ -924,7 +924,7 @@ extension String.UTF16View {
     _internalInvariant(crumb._canBeUTF8 && crumb._encodedOffset <= _guts.count)
     if remaining == 0 { return crumb }
 
-    return unsafe _guts.withFastUTF8 { utf8 in
+    return _guts.withFastUTF8 { utf8 in
       var readIdx = crumb._encodedOffset
       let readEnd = utf8.count
       _internalInvariant(readIdx < readEnd)
@@ -996,7 +996,7 @@ extension String.UTF16View {
     if _slowPath(range.isEmpty) { return }
     
     let isASCII = _guts.isASCII
-    return unsafe _guts.withFastUTF8 { utf8 in
+    return _guts.withFastUTF8 { utf8 in
       var writeIdx = 0
       let writeEnd = buffer.count
       var readIdx = range.lowerBound._encodedOffset

--- a/stdlib/public/core/StringUTF8View.swift
+++ b/stdlib/public/core/StringUTF8View.swift
@@ -233,7 +233,7 @@ extension String.UTF8View: BidirectionalCollection {
   @_alwaysEmitIntoClient @inline(__always)
   internal subscript(_unchecked i: Index) -> UTF8.CodeUnit {
     if _fastPath(_guts.isFastUTF8) {
-      return unsafe _guts.withFastUTF8 { utf8 in unsafe utf8[_unchecked: i._encodedOffset] }
+      return _guts.withFastUTF8 { utf8 in unsafe utf8[_unchecked: i._encodedOffset] }
     }
 
     return _foreignSubscript(position: i)
@@ -677,11 +677,12 @@ extension String.Index {
 
 extension String.UTF8View {
   @inlinable
+  @safe
   public func withContiguousStorageIfAvailable<R>(
     _ body: (UnsafeBufferPointer<Element>) throws -> R
   ) rethrows -> R? {
     guard _guts.isFastUTF8 else { return nil }
-    return unsafe try _guts.withFastUTF8(body)
+    return try _guts.withFastUTF8(body)
   }
 }
 

--- a/stdlib/public/core/StringUnicodeScalarView.swift
+++ b/stdlib/public/core/StringUnicodeScalarView.swift
@@ -139,7 +139,7 @@ extension String.UnicodeScalarView: BidirectionalCollection {
   internal func _uncheckedIndex(before i: Index) -> Index {
     // TODO(String performance): isASCII fast-path
     if _fastPath(_guts.isFastUTF8) {
-      let len = unsafe _guts.withFastUTF8 { utf8 in
+      let len = _guts.withFastUTF8 { utf8 in
         unsafe _utf8ScalarLength(utf8, endingAt: i._encodedOffset)
       }
       _internalInvariant(len <= 4, "invalid UTF8")

--- a/stdlib/public/core/StringWordBreaking.swift
+++ b/stdlib/public/core/StringWordBreaking.swift
@@ -724,7 +724,7 @@ extension _StringGuts {
   @_effects(releasenone)
   internal func _nextUTF8WordIndex(after index: Index) -> Index {
     _internalInvariant(self.isFastUTF8)
-    let result = unsafe self.withFastUTF8 { utf8 in
+    let result = self.withFastUTF8 { utf8 in
       var offset = index._encodedOffset
       let first = unsafe _decodeScalar(utf8, startingAt: offset)
       offset &+= first.scalarLength

--- a/stdlib/public/core/Substring.swift
+++ b/stdlib/public/core/Substring.swift
@@ -518,11 +518,12 @@ extension Substring: StringProtocol {
   ///   duration of the method's execution.
   /// - Returns: The return value, if any, of the `body` closure parameter.
   @_alwaysEmitIntoClient // (Primarily @inlinable) specialization
+  @safe
   public func withCString<Result, E: Error>(
     _ body: (UnsafePointer<CChar>) throws(E) -> Result) throws(E) -> Result {
     // TODO(String performance): Detect when we cover the rest of a nul-
     // terminated String, and thus can avoid a copy.
-    return try unsafe String(self).withCString(body)
+      return try String(self).withCString(body)
   }
 
 #if !hasFeature(Embedded)
@@ -536,7 +537,7 @@ extension Substring: StringProtocol {
   internal func __rethrows_withCString<Result>(
     _ body: (UnsafePointer<CChar>) throws -> Result
   ) throws -> Result {
-    return try unsafe withCString(body)
+    return try withCString(body)
   }
 #endif // !hasFeature(Embedded)
 
@@ -557,13 +558,14 @@ extension Substring: StringProtocol {
   ///     interpreted.
   /// - Returns: The return value, if any, of the `body` closure parameter.
   @_alwaysEmitIntoClient // (Primarily @inlinable) specialization
+  @safe
   public func withCString<Result, TargetEncoding: _UnicodeEncoding, E: Error>(
     encodedAs targetEncoding: TargetEncoding.Type,
     _ body: (UnsafePointer<TargetEncoding.CodeUnit>) throws(E) -> Result
   ) throws(E) -> Result {
     // TODO(String performance): Detect when we cover the rest of a nul-
     // terminated String, and thus can avoid a copy.
-    return try unsafe String(self).withCString(encodedAs: targetEncoding, body)
+    return try String(self).withCString(encodedAs: targetEncoding, body)
   }
 
 #if !hasFeature(Embedded)
@@ -579,7 +581,7 @@ extension Substring: StringProtocol {
     encodedAs targetEncoding: TargetEncoding.Type,
     _ body: (UnsafePointer<TargetEncoding.CodeUnit>) throws -> Result
   ) throws -> Result {
-    return try unsafe withCString(encodedAs: targetEncoding, body)
+    return try withCString(encodedAs: targetEncoding, body)
   }
 #endif // !hasFeature(Embedded)
 }
@@ -742,7 +744,7 @@ extension Substring.UTF8View: BidirectionalCollection {
   public func withContiguousStorageIfAvailable<R>(
     _ body: (UnsafeBufferPointer<Element>) throws -> R
   ) rethrows -> R? {
-    return try unsafe _slice.withContiguousStorageIfAvailable(body)
+    return try _slice.withContiguousStorageIfAvailable(body)
   }
 
   @inlinable

--- a/stdlib/public/core/Substring.swift
+++ b/stdlib/public/core/Substring.swift
@@ -523,7 +523,7 @@ extension Substring: StringProtocol {
     _ body: (UnsafePointer<CChar>) throws(E) -> Result) throws(E) -> Result {
     // TODO(String performance): Detect when we cover the rest of a nul-
     // terminated String, and thus can avoid a copy.
-      return try String(self).withCString(body)
+    return try String(self).withCString(body)
   }
 
 #if !hasFeature(Embedded)

--- a/stdlib/public/core/SwiftNativeNSArray.swift
+++ b/stdlib/public/core/SwiftNativeNSArray.swift
@@ -180,7 +180,7 @@ extension __SwiftNativeNSArrayWithContiguousStorage {
   @objc internal func getObjects(
     _ aBuffer: UnsafeMutablePointer<AnyObject>, range: _SwiftNSRange
   ) {
-    return unsafe contents.withContiguousStorageIfAvailable { objects in
+    return contents.withContiguousStorageIfAvailable { objects in
       //TODO: exceptions instead of preconditions, once that's possible
 
       _precondition(
@@ -214,7 +214,7 @@ extension __SwiftNativeNSArrayWithContiguousStorage {
       return 0
     }
 
-    return unsafe contents.withContiguousStorageIfAvailable {
+    return contents.withContiguousStorageIfAvailable {
       objects in
       unsafe enumerationState.mutationsPtr = _fastEnumerationStorageMutationsPtr
       unsafe enumerationState.itemsPtr =

--- a/stdlib/public/core/TemporaryAllocation.swift
+++ b/stdlib/public/core/TemporaryAllocation.swift
@@ -227,6 +227,7 @@ internal func _fallBackToHeapAllocation<R: ~Copyable, E: Error>(
 /// the buffer) must not escape. It will be deallocated when `body` returns and
 /// cannot be used afterward.
 @_alwaysEmitIntoClient @_transparent
+@safe
 public func withUnsafeTemporaryAllocation<R: ~Copyable, E: Error>(
   byteCount: Int,
   alignment: Int,
@@ -313,6 +314,7 @@ public func _withUnprotectedUnsafeTemporaryAllocation<R: ~Copyable, E: Error>(
 /// the buffer) must not escape. It will be deallocated when `body` returns and
 /// cannot be used afterward.
 @_alwaysEmitIntoClient @_transparent
+@safe
 public func withUnsafeTemporaryAllocation<
   T: ~Copyable, R: ~Copyable,
   E: Error

--- a/stdlib/public/core/UTF8EncodingError.swift
+++ b/stdlib/public/core/UTF8EncodingError.swift
@@ -223,7 +223,7 @@ extension UTF8 {
     // TODO: Fixed size buffer for non-contig inputs
     // TODO: Lifetime-dependent result variant
     let cus = Array(s)
-    return unsafe cus.withUnsafeBytes {
+    return cus.withUnsafeBytes {
       var bufPtr = unsafe $0
       var start = 0
       var errors: Array<UTF8.ValidationError> = []

--- a/stdlib/public/core/UnicodeHelpers.swift
+++ b/stdlib/public/core/UnicodeHelpers.swift
@@ -178,7 +178,7 @@ extension _StringGuts {
       return foreignIdx
     }
 
-    return unsafe String.Index(_encodedOffset:
+    return String.Index(_encodedOffset:
       self.withFastUTF8 { unsafe _scalarAlign($0, idx._encodedOffset) }
     )
   }
@@ -186,7 +186,7 @@ extension _StringGuts {
   @inlinable
   internal func fastUTF8ScalarLength(startingAt i: Int) -> Int {
     _internalInvariant(isFastUTF8)
-    let len = unsafe _utf8ScalarLength(self.withFastUTF8 { unsafe $0[_unchecked: i] })
+    let len = _utf8ScalarLength(self.withFastUTF8 { unsafe $0[_unchecked: i] })
     _internalInvariant((1...4) ~= len)
     return len
   }
@@ -195,7 +195,7 @@ extension _StringGuts {
   internal func fastUTF8ScalarLength(endingAt i: Int) -> Int {
     _internalInvariant(isFastUTF8)
 
-    return unsafe self.withFastUTF8 { utf8 in
+    return self.withFastUTF8 { utf8 in
       unsafe _internalInvariant(i == utf8.count || !UTF8.isContinuation(utf8[i]))
       var len = 1
       while unsafe UTF8.isContinuation(utf8[i &- len]) {
@@ -210,7 +210,7 @@ extension _StringGuts {
   @inlinable @inline(__always)
   internal func fastUTF8Scalar(startingAt i: Int) -> Unicode.Scalar {
     _internalInvariant(isFastUTF8)
-    return unsafe self.withFastUTF8 { unsafe _decodeScalar($0, startingAt: i).0 }
+    return self.withFastUTF8 { unsafe _decodeScalar($0, startingAt: i).0 }
   }
 
   @_alwaysEmitIntoClient
@@ -230,7 +230,7 @@ extension _StringGuts {
     if i == self.startIndex || i == self.endIndex { return true }
 
     if _fastPath(isFastUTF8) {
-      return unsafe self.withFastUTF8 {
+      return self.withFastUTF8 {
         return unsafe !UTF8.isContinuation($0[_unchecked: i._encodedOffset])
       }
     }
@@ -383,7 +383,7 @@ extension _StringGuts {
       ).0))
     }
 
-    return unsafe withUnsafeTemporaryAllocation(
+    return withUnsafeTemporaryAllocation(
       of: UInt16.self, capacity: count
     ) { buffer in
       self._object.withCocoaObject {
@@ -410,7 +410,7 @@ extension _StringGuts {
     startingAt i: Int
   ) -> (Unicode.Scalar, scalarLength: Int) {
     if _fastPath(isFastUTF8) {
-      return unsafe withFastUTF8 { unsafe _decodeScalar($0, startingAt: i) }
+      return withFastUTF8 { unsafe _decodeScalar($0, startingAt: i) }
     }
     return foreignErrorCorrectedScalar(
       startingAt: String.Index(_encodedOffset: i))
@@ -420,7 +420,7 @@ extension _StringGuts {
     startingAt start: Int, endingAt end: Int
   ) -> Character {
     if _fastPath(isFastUTF8) {
-      return unsafe withFastUTF8(range: start..<end) { utf8 in
+      return withFastUTF8(range: start..<end) { utf8 in
         return unsafe Character(unchecked: String._uncheckedFromUTF8(utf8))
       }
     }

--- a/stdlib/public/core/UnicodeSPI.swift
+++ b/stdlib/public/core/UnicodeSPI.swift
@@ -184,7 +184,7 @@ extension Unicode.Scalar.Properties {
   public var _caseFolded: String {
     var buffer: (UInt32, UInt32, UInt32) = (.max, .max, .max)
 
-    unsafe withUnsafeMutableBytes(of: &buffer) {
+    withUnsafeMutableBytes(of: &buffer) {
       // This is safe because the memory is already UInt32
       let ptr = unsafe $0.baseAddress!.assumingMemoryBound(to: UInt32.self)
       unsafe _swift_stdlib_getCaseMapping(_scalar.value, ptr)
@@ -194,7 +194,7 @@ extension Unicode.Scalar.Properties {
     // Max mapping is 3 scalars and the max UTF8 bytes of a scalar is 4.
     result.reserveCapacity(12)
 
-    unsafe withUnsafeBytes(of: &buffer) {
+    withUnsafeBytes(of: &buffer) {
       for unsafe scalar in unsafe $0.bindMemory(to: UInt32.self) {
         guard scalar != .max else {
           break

--- a/stdlib/public/core/UnicodeScalar.swift
+++ b/stdlib/public/core/UnicodeScalar.swift
@@ -512,7 +512,7 @@ extension Unicode.Scalar {
       _internalInvariant(utf16Count == 2)
       codeUnits.1 = self.utf16[1]
     }
-    return try unsafe Swift.withUnsafePointer(to: &codeUnits) {
+    return try Swift.withUnsafePointer(to: &codeUnits) {
       return try unsafe $0.withMemoryRebound(to: UInt16.self, capacity: 2) {
         return try unsafe body(UnsafeBufferPointer(start: $0, count: utf16Count))
       }

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -1282,6 +1282,7 @@ extension ${Self} {
 ///     of the closure's execution.
 /// - Returns: The return value, if any, of the `body` closure.
 @_alwaysEmitIntoClient
+@safe
 public func withUnsafeMutableBytes<T: ~Copyable, E: Error, Result: ~Copyable>(
   of value: inout T,
   _ body: (UnsafeMutableRawBufferPointer) throws(E) -> Result
@@ -1300,7 +1301,7 @@ func __abi_se0413_withUnsafeMutableBytes<T, Result>(
   of value: inout T,
   _ body: (UnsafeMutableRawBufferPointer) throws -> Result
 ) throws -> Result {
-  return try unsafe withUnsafeMutablePointer(to: &value) {
+  return try withUnsafeMutablePointer(to: &value) {
     return try unsafe body(unsafe UnsafeMutableRawBufferPointer(
         start: $0, count: MemoryLayout<T>.size))
   }
@@ -1351,6 +1352,7 @@ public func _withUnprotectedUnsafeMutableBytes<
 ///     `withUnsafeMutableBytes(of:_:)` instead.
 /// - Returns: The return value, if any, of the `body` closure.
 @_alwaysEmitIntoClient
+@safe
 public func withUnsafeBytes<T: ~Copyable, E: Error, Result: ~Copyable>(
   of value: inout T,
   _ body: (UnsafeRawBufferPointer) throws(E) -> Result
@@ -1369,7 +1371,7 @@ func __abi_se0413_withUnsafeBytes<T, Result>(
   of value: inout T,
   _ body: (UnsafeRawBufferPointer) throws -> Result
 ) throws -> Result {
-  return try unsafe withUnsafePointer(to: &value) {
+  return try withUnsafePointer(to: &value) {
     try unsafe body(unsafe UnsafeRawBufferPointer(start: $0, count: MemoryLayout<T>.size))
   }
 }
@@ -1415,6 +1417,7 @@ public func _withUnprotectedUnsafeBytes<
 ///     `withUnsafeMutableBytes(of:_:)` instead.
 /// - Returns: The return value, if any, of the `body` closure.
 @_alwaysEmitIntoClient
+@safe
 public func withUnsafeBytes<
   T: ~Copyable, E: Error, Result: ~Copyable
 >(

--- a/stdlib/public/core/UnsafeRawPointer.swift
+++ b/stdlib/public/core/UnsafeRawPointer.swift
@@ -1469,7 +1469,7 @@ extension UnsafeMutableRawPointer {
       "storeBytes only supports storing the bytes of BitwiseCopyable types."
     )
 
-    unsafe withUnsafePointer(to: value) { source in
+    withUnsafePointer(to: value) { source in
       // FIXME: to be replaced by _memcpy when conversions are implemented.
       unsafe Builtin.int_memcpy_RawPointer_RawPointer_Int64(
         (self + offset)._rawValue,
@@ -1504,7 +1504,7 @@ extension UnsafeMutableRawPointer {
       "storeBytes to misaligned raw pointer")
 
     var temp = value
-    unsafe withUnsafeMutablePointer(to: &temp) { source in
+    withUnsafeMutablePointer(to: &temp) { source in
       let rawSrc = UnsafeMutableRawPointer(source)._rawValue
       // FIXME: to be replaced by _memcpy when conversions are implemented.
       unsafe Builtin.int_memcpy_RawPointer_RawPointer_Int64(

--- a/test/Interop/C/swiftify-import/availability.swift
+++ b/test/Interop/C/swiftify-import/availability.swift
@@ -38,7 +38,7 @@ public func bufferPointer(_ _bufferPointer_param0: UnsafeMutableBufferPointer<In
 @available(macOS 10.5, *) @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
 public func span(_ p: inout MutableSpan<Int32>) {
     let len = Int32(exactly: p.count)!
-    let _pPtr = unsafe p.withUnsafeMutableBufferPointer {
+    let _pPtr = p.withUnsafeMutableBufferPointer {
         unsafe $0
     }
     defer {
@@ -63,7 +63,7 @@ public func bufferPointer(_ _bufferPointer_param0: UnsafeMutableBufferPointer<In
 @available(iOS 2.0, *) @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
 public func span(_ p: inout MutableSpan<Int32>) {
     let len = Int32(exactly: p.count)!
-    let _pPtr = unsafe p.withUnsafeMutableBufferPointer {
+    let _pPtr = p.withUnsafeMutableBufferPointer {
         unsafe $0
     }
     defer {
@@ -88,7 +88,7 @@ public func bufferPointer(_ _bufferPointer_param0: UnsafeMutableBufferPointer<In
 @available(watchOS 2.0, *) @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
 public func span(_ p: inout MutableSpan<Int32>) {
     let len = Int32(exactly: p.count)!
-    let _pPtr = unsafe p.withUnsafeMutableBufferPointer {
+    let _pPtr = p.withUnsafeMutableBufferPointer {
         unsafe $0
     }
     defer {
@@ -113,7 +113,7 @@ public func bufferPointer(_ _bufferPointer_param0: UnsafeMutableBufferPointer<In
 @available(visionOS 1.0, *) @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
 public func span(_ p: inout MutableSpan<Int32>) {
     let len = Int32(exactly: p.count)!
-    let _pPtr = unsafe p.withUnsafeMutableBufferPointer {
+    let _pPtr = p.withUnsafeMutableBufferPointer {
         unsafe $0
     }
     defer {
@@ -136,7 +136,7 @@ public func span(_ p: inout MutableSpan<Int32>) {
 /// This is an auto-generated wrapper for safer interop
 @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload public func span(_ p: inout MutableSpan<Int32>) {
     let len = Int32(exactly: p.count)!
-    let _pPtr = unsafe p.withUnsafeMutableBufferPointer {
+    let _pPtr = p.withUnsafeMutableBufferPointer {
         unsafe $0
     }
     defer {
@@ -159,7 +159,7 @@ public func span(_ p: inout MutableSpan<Int32>) {
 /// This is an auto-generated wrapper for safer interop
 @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload public func span(_ p: inout MutableSpan<Int32>) {
     let len = Int32(exactly: p.count)!
-    let _pPtr = unsafe p.withUnsafeMutableBufferPointer {
+    let _pPtr = p.withUnsafeMutableBufferPointer {
         unsafe $0
     }
     defer {

--- a/test/Interop/C/swiftify-import/bridging-header-from-module.swift
+++ b/test/Interop/C/swiftify-import/bridging-header-from-module.swift
@@ -31,7 +31,7 @@ imports for @__swiftmacro_So3foo15_SwiftifyImportfMp_.swift:
 /// This is an auto-generated wrapper for safer interop
 @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_disfavoredOverload public func foo(_ p: Span<Int32>, _ x: UnsafeMutablePointer<no_module_record_t>!) {
     let len = Int32(exactly: p.count)!
-    let _pPtr = unsafe p.withUnsafeBufferPointer {
+    let _pPtr = p.withUnsafeBufferPointer {
         unsafe $0
     }
     defer {

--- a/test/Interop/C/swiftify-import/bridging-header-nontrivial.swift
+++ b/test/Interop/C/swiftify-import/bridging-header-nontrivial.swift
@@ -35,7 +35,7 @@ imports for @__swiftmacro_So3bar15_SwiftifyImportfMp_.swift:
 /// This is an auto-generated wrapper for safer interop
 @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_disfavoredOverload public func foo(_ p: Span<Int32>) {
     let len = Int32(exactly: p.count)!
-    let _pPtr = unsafe p.withUnsafeBufferPointer {
+    let _pPtr = p.withUnsafeBufferPointer {
         unsafe $0
     }
     defer {
@@ -49,7 +49,7 @@ imports for @__swiftmacro_So3bar15_SwiftifyImportfMp_.swift:
 /// This is an auto-generated wrapper for safer interop
 @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_disfavoredOverload public func bar(_ p: Span<Int32>) {
     let len = Int32(exactly: p.count)!
-    let _pPtr = unsafe p.withUnsafeBufferPointer {
+    let _pPtr = p.withUnsafeBufferPointer {
         unsafe $0
     }
     defer {

--- a/test/Interop/C/swiftify-import/bridging-header.swift
+++ b/test/Interop/C/swiftify-import/bridging-header.swift
@@ -29,7 +29,7 @@ imports for @__swiftmacro_So3foo15_SwiftifyImportfMp_.swift:
 /// This is an auto-generated wrapper for safer interop
 @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_disfavoredOverload public func foo(_ p: Span<a_t>, _ x: UnsafeMutablePointer<no_module_record_t>!) {
     let len = no_module_t(exactly: p.count)!
-    let _pPtr = unsafe p.withUnsafeBufferPointer {
+    let _pPtr = p.withUnsafeBufferPointer {
         unsafe $0
     }
     defer {

--- a/test/Interop/C/swiftify-import/counted-by-lifetimebound.swift
+++ b/test/Interop/C/swiftify-import/counted-by-lifetimebound.swift
@@ -24,7 +24,7 @@
 //   expected-experimental-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy p) @_lifetime(p: copy p) @_disfavoredOverload public func simple(_ len: Int32, _ p: inout MutableSpan<Int32>) -> MutableSpan<Int32> {|}}
 //   expected-experimental-remark@3{{macro content: |    let len2 = Int32(exactly: p.count)!|}}
-//   expected-experimental-remark@4{{macro content: |    let _pPtr = unsafe p.withUnsafeMutableBufferPointer {|}}
+//   expected-experimental-remark@4{{macro content: |    let _pPtr = p.withUnsafeMutableBufferPointer {|}}
 //   expected-experimental-remark@5{{macro content: |        unsafe $0|}}
 //   expected-experimental-remark@6{{macro content: |    }|}}
 //   expected-experimental-remark@7{{macro content: |    defer {|}}
@@ -39,7 +39,7 @@ int * __counted_by(len) simple(int len, int len2, int * p __counted_by(len2) __l
 //   expected-experimental-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy p) @_lifetime(p: copy p) @_disfavoredOverload public func shared(_ p: inout MutableSpan<Int32>) -> MutableSpan<Int32> {|}}
 //   expected-experimental-remark@3{{macro content: |    let len = Int32(exactly: p.count)!|}}
-//   expected-experimental-remark@4{{macro content: |    let _pPtr = unsafe p.withUnsafeMutableBufferPointer {|}}
+//   expected-experimental-remark@4{{macro content: |    let _pPtr = p.withUnsafeMutableBufferPointer {|}}
 //   expected-experimental-remark@5{{macro content: |        unsafe $0|}}
 //   expected-experimental-remark@6{{macro content: |    }|}}
 //   expected-experimental-remark@7{{macro content: |    defer {|}}
@@ -54,7 +54,7 @@ int * __counted_by(len) shared(int len, int * p __counted_by(len) __lifetimeboun
 //   expected-experimental-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy p) @_lifetime(p: copy p) @_disfavoredOverload public func complexExpr(_ len: Int32, _ offset: Int32, _ p: inout MutableSpan<Int32>) -> MutableSpan<Int32> {|}}
 //   expected-experimental-remark@3{{macro content: |    let len2 = Int32(exactly: p.count)!|}}
-//   expected-experimental-remark@4{{macro content: |    let _pPtr = unsafe p.withUnsafeMutableBufferPointer {|}}
+//   expected-experimental-remark@4{{macro content: |    let _pPtr = p.withUnsafeMutableBufferPointer {|}}
 //   expected-experimental-remark@5{{macro content: |        unsafe $0|}}
 //   expected-experimental-remark@6{{macro content: |    }|}}
 //   expected-experimental-remark@7{{macro content: |    defer {|}}
@@ -69,7 +69,7 @@ int * __counted_by(len - offset) complexExpr(int len, int offset, int len2, int 
 //   expected-experimental-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy p) @_lifetime(p: copy p) @_disfavoredOverload public func nullUnspecified(_ len: Int32, _ p: inout MutableSpan<Int32>) -> MutableSpan<Int32> {|}}
 //   expected-experimental-remark@3{{macro content: |    let len2 = Int32(exactly: p.count)!|}}
-//   expected-experimental-remark@4{{macro content: |    let _pPtr = unsafe p.withUnsafeMutableBufferPointer {|}}
+//   expected-experimental-remark@4{{macro content: |    let _pPtr = p.withUnsafeMutableBufferPointer {|}}
 //   expected-experimental-remark@5{{macro content: |        unsafe $0|}}
 //   expected-experimental-remark@6{{macro content: |    }|}}
 //   expected-experimental-remark@7{{macro content: |    defer {|}}
@@ -84,7 +84,7 @@ int * __counted_by(len) _Null_unspecified nullUnspecified(int len, int len2, int
 //   expected-experimental-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy p) @_lifetime(p: copy p) @_disfavoredOverload public func nonnull(_ len: Int32, _ p: inout MutableSpan<Int32>) -> MutableSpan<Int32> {|}}
 //   expected-experimental-remark@3{{macro content: |    let len2 = Int32(exactly: p.count)!|}}
-//   expected-experimental-remark@4{{macro content: |    let _pPtr = unsafe p.withUnsafeMutableBufferPointer {|}}
+//   expected-experimental-remark@4{{macro content: |    let _pPtr = p.withUnsafeMutableBufferPointer {|}}
 //   expected-experimental-remark@5{{macro content: |        unsafe $0|}}
 //   expected-experimental-remark@6{{macro content: |    }|}}
 //   expected-experimental-remark@7{{macro content: |    defer {|}}
@@ -99,7 +99,7 @@ int * __counted_by(len) _Nonnull nonnull(int len, int len2, int * _Nonnull p __c
 //   expected-experimental-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy p) @_lifetime(p: copy p) @_disfavoredOverload public func nullable(_ len: Int32, _ p: inout MutableSpan<Int32>?) -> MutableSpan<Int32>? {|}}
 //   expected-experimental-remark@3{{macro content: |    let len2 = Int32(exactly: p?.count ?? 0)!|}}
-//   expected-experimental-remark@4{{macro content: |    let _pPtr = unsafe p?.withUnsafeMutableBufferPointer {|}}
+//   expected-experimental-remark@4{{macro content: |    let _pPtr = p?.withUnsafeMutableBufferPointer {|}}
 //   expected-experimental-remark@5{{macro content: |        unsafe $0|}}
 //   expected-experimental-remark@6{{macro content: |    }|}}
 //   expected-experimental-remark@7{{macro content: |    defer {|}}
@@ -135,7 +135,7 @@ int * __counted_by(len) noncountedLifetime(int len, int * p __lifetimebound);
 //   expected-experimental-remark@4{{macro content: |    if _pCount != 13 {|}}
 //   expected-experimental-remark@5{{macro content: |      fatalError("bounds check failure in constant: expected \\(13) but got \\(_pCount)")|}}
 //   expected-experimental-remark@6{{macro content: |    }|}}
-//   expected-experimental-remark@7{{macro content: |    let _pPtr = unsafe p?.withUnsafeMutableBufferPointer {|}}
+//   expected-experimental-remark@7{{macro content: |    let _pPtr = p?.withUnsafeMutableBufferPointer {|}}
 //   expected-experimental-remark@8{{macro content: |        unsafe $0|}}
 //   expected-experimental-remark@9{{macro content: |    }|}}
 //   expected-experimental-remark@10{{macro content: |    defer {|}}
@@ -169,7 +169,7 @@ struct __attribute__((swift_attr("~Escapable"))) NonescapableStruct {};
 //   expected-experimental-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy p) @_lifetime(p: copy p) @_disfavoredOverload public func lifetimeboundNonescapableReturn(_ p: inout MutableSpan<Int32>) -> NonescapableStruct {|}}
 //   expected-experimental-remark@3{{macro content: |    let len = Int32(exactly: p.count)!|}}
-//   expected-experimental-remark@4{{macro content: |    let _pPtr = unsafe p.withUnsafeMutableBufferPointer {|}}
+//   expected-experimental-remark@4{{macro content: |    let _pPtr = p.withUnsafeMutableBufferPointer {|}}
 //   expected-experimental-remark@5{{macro content: |        unsafe $0|}}
 //   expected-experimental-remark@6{{macro content: |    }|}}
 //   expected-experimental-remark@7{{macro content: |    defer {|}}
@@ -184,7 +184,7 @@ struct NonescapableStruct lifetimeboundNonescapableReturn(int len, int * __count
 //   expected-experimental-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy p, copy s) @_lifetime(p: copy p) @_disfavoredOverload public func lifetimeboundNonescapableReturnDoubleBounds(_ p: inout MutableSpan<Int32>, _ s: NonescapableStruct) -> NonescapableStruct {|}}
 //   expected-experimental-remark@3{{macro content: |    let len = Int32(exactly: p.count)!|}}
-//   expected-experimental-remark@4{{macro content: |    let _pPtr = unsafe p.withUnsafeMutableBufferPointer {|}}
+//   expected-experimental-remark@4{{macro content: |    let _pPtr = p.withUnsafeMutableBufferPointer {|}}
 //   expected-experimental-remark@5{{macro content: |        unsafe $0|}}
 //   expected-experimental-remark@6{{macro content: |    }|}}
 //   expected-experimental-remark@7{{macro content: |    defer {|}}
@@ -200,7 +200,7 @@ struct NonescapableStruct lifetimeboundNonescapableReturnDoubleBounds(int len, i
 //   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy p) @_lifetime(p: copy p) @_disfavoredOverload public func oneLifetimeboundOneEscapable(_ len: Int32, _ p: inout MutableSpan<Int32>, _ p2: UnsafeMutableBufferPointer<Int32>) -> MutableSpan<Int32> {|}}
 //   expected-experimental-remark@3{{macro content: |    let len2 = Int32(exactly: p.count)!|}}
 //   expected-experimental-remark@4{{macro content: |    let len3 = Int32(exactly: p2.count)!|}}
-//   expected-experimental-remark@5{{macro content: |    let _pPtr = unsafe p.withUnsafeMutableBufferPointer {|}}
+//   expected-experimental-remark@5{{macro content: |    let _pPtr = p.withUnsafeMutableBufferPointer {|}}
 //   expected-experimental-remark@6{{macro content: |        unsafe $0|}}
 //   expected-experimental-remark@7{{macro content: |    }|}}
 //   expected-experimental-remark@8{{macro content: |    defer {|}}

--- a/test/Interop/C/swiftify-import/counted-by-noescape.swift
+++ b/test/Interop/C/swiftify-import/counted-by-noescape.swift
@@ -18,7 +18,7 @@
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload public func simple(_ p: inout MutableSpan<Int32>) {|}}
 //   expected-remark@3{{macro content: |    let len = Int32(exactly: p.count)!|}}
-//   expected-remark@4{{macro content: |    let _pPtr = unsafe p.withUnsafeMutableBufferPointer {|}}
+//   expected-remark@4{{macro content: |    let _pPtr = p.withUnsafeMutableBufferPointer {|}}
 //   expected-remark@5{{macro content: |        unsafe $0|}}
 //   expected-remark@6{{macro content: |    }|}}
 //   expected-remark@7{{macro content: |    defer {|}}
@@ -33,7 +33,7 @@ void simple(int len, int * __counted_by(len) __noescape p);
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload public func swiftAttr(_ p: inout MutableSpan<Int32>) {|}}
 //   expected-remark@3{{macro content: |    let len = Int32(exactly: p.count)!|}}
-//   expected-remark@4{{macro content: |    let _pPtr = unsafe p.withUnsafeMutableBufferPointer {|}}
+//   expected-remark@4{{macro content: |    let _pPtr = p.withUnsafeMutableBufferPointer {|}}
 //   expected-remark@5{{macro content: |        unsafe $0|}}
 //   expected-remark@6{{macro content: |    }|}}
 //   expected-remark@7{{macro content: |    defer {|}}
@@ -52,13 +52,13 @@ void swiftAttr(int len, int *p) __attribute__((
 //   expected-remark@4{{macro content: |    if p2.count != len {|}}
 //   expected-remark@5{{macro content: |      fatalError("bounds check failure in shared: expected \\(len) but got \\(p2.count)")|}}
 //   expected-remark@6{{macro content: |    }|}}
-//   expected-remark@7{{macro content: |    let _p1Ptr = unsafe p1.withUnsafeMutableBufferPointer {|}}
+//   expected-remark@7{{macro content: |    let _p1Ptr = p1.withUnsafeMutableBufferPointer {|}}
 //   expected-remark@8{{macro content: |        unsafe $0|}}
 //   expected-remark@9{{macro content: |    }|}}
 //   expected-remark@10{{macro content: |    defer {|}}
 //   expected-remark@11{{macro content: |        _fixLifetime(p1)|}}
 //   expected-remark@12{{macro content: |    }|}}
-//   expected-remark@13{{macro content: |    let _p2Ptr = unsafe p2.withUnsafeMutableBufferPointer {|}}
+//   expected-remark@13{{macro content: |    let _p2Ptr = p2.withUnsafeMutableBufferPointer {|}}
 //   expected-remark@14{{macro content: |        unsafe $0|}}
 //   expected-remark@15{{macro content: |    }|}}
 //   expected-remark@16{{macro content: |    defer {|}}
@@ -76,7 +76,7 @@ void shared(int len, int * __counted_by(len) __noescape p1, int * __counted_by(l
 //   expected-remark@4{{macro content: |    if _pCount != len - offset {|}}
 //   expected-remark@5{{macro content: |      fatalError("bounds check failure in complexExpr: expected \\(len - offset) but got \\(_pCount)")|}}
 //   expected-remark@6{{macro content: |    }|}}
-//   expected-remark@7{{macro content: |    let _pPtr = unsafe p.withUnsafeMutableBufferPointer {|}}
+//   expected-remark@7{{macro content: |    let _pPtr = p.withUnsafeMutableBufferPointer {|}}
 //   expected-remark@8{{macro content: |        unsafe $0|}}
 //   expected-remark@9{{macro content: |    }|}}
 //   expected-remark@10{{macro content: |    defer {|}}
@@ -91,7 +91,7 @@ void complexExpr(int len, int offset, int * __counted_by(len - offset) __noescap
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload public func nullUnspecified(_ p: inout MutableSpan<Int32>) {|}}
 //   expected-remark@3{{macro content: |    let len = Int32(exactly: p.count)!|}}
-//   expected-remark@4{{macro content: |    let _pPtr = unsafe p.withUnsafeMutableBufferPointer {|}}
+//   expected-remark@4{{macro content: |    let _pPtr = p.withUnsafeMutableBufferPointer {|}}
 //   expected-remark@5{{macro content: |        unsafe $0|}}
 //   expected-remark@6{{macro content: |    }|}}
 //   expected-remark@7{{macro content: |    defer {|}}
@@ -106,7 +106,7 @@ void nullUnspecified(int len, int * __counted_by(len) _Null_unspecified __noesca
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload public func nonnull(_ p: inout MutableSpan<Int32>) {|}}
 //   expected-remark@3{{macro content: |    let len = Int32(exactly: p.count)!|}}
-//   expected-remark@4{{macro content: |    let _pPtr = unsafe p.withUnsafeMutableBufferPointer {|}}
+//   expected-remark@4{{macro content: |    let _pPtr = p.withUnsafeMutableBufferPointer {|}}
 //   expected-remark@5{{macro content: |        unsafe $0|}}
 //   expected-remark@6{{macro content: |    }|}}
 //   expected-remark@7{{macro content: |    defer {|}}
@@ -121,7 +121,7 @@ void nonnull(int len, int * __counted_by(len) _Nonnull __noescape p);
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload public func nullable(_ p: inout MutableSpan<Int32>?) {|}}
 //   expected-remark@3{{macro content: |    let len = Int32(exactly: p?.count ?? 0)!|}}
-//   expected-remark@4{{macro content: |    let _pPtr = unsafe p?.withUnsafeMutableBufferPointer {|}}
+//   expected-remark@4{{macro content: |    let _pPtr = p?.withUnsafeMutableBufferPointer {|}}
 //   expected-remark@5{{macro content: |        unsafe $0|}}
 //   expected-remark@6{{macro content: |    }|}}
 //   expected-remark@7{{macro content: |    defer {|}}
@@ -144,7 +144,7 @@ int * __counted_by(len) __noescape returnPointer(int len);
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(_anonymous_param1: copy _anonymous_param1) @_disfavoredOverload public func anonymous(_ _anonymous_param1: inout MutableSpan<Int32>?) {|}}
 //   expected-remark@3{{macro content: |    let _anonymous_param0 = Int32(exactly: _anonymous_param1?.count ?? 0)!|}}
-//   expected-remark@4{{macro content: |    let __anonymous_param1Ptr = unsafe _anonymous_param1?.withUnsafeMutableBufferPointer {|}}
+//   expected-remark@4{{macro content: |    let __anonymous_param1Ptr = _anonymous_param1?.withUnsafeMutableBufferPointer {|}}
 //   expected-remark@5{{macro content: |        unsafe $0|}}
 //   expected-remark@6{{macro content: |    }|}}
 //   expected-remark@7{{macro content: |    defer {|}}
@@ -168,7 +168,7 @@ void keyword(int len, int * __counted_by(len) _Nullable func __noescape,
     //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
     //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(`func`: copy `func`) @_disfavoredOverload public func keyword(_ `func`: inout MutableSpan<Int32>?, _ `extension`: Int32, _ `init`: Int32, _ open: Int32, _ `var`: Int32, _ `is`: Int32, _ `as`: Int32, _ `in`: Int32, _ `guard`: Int32, _ `where`: Int32) {|}}
     //   expected-remark@3{{macro content: |    let len = Int32(exactly: `func`?.count ?? 0)!|}}
-    //   expected-remark@4{{macro content: |    let _funcPtr = unsafe `func`?.withUnsafeMutableBufferPointer {|}}
+    //   expected-remark@4{{macro content: |    let _funcPtr = `func`?.withUnsafeMutableBufferPointer {|}}
     //   expected-remark@5{{macro content: |        unsafe $0|}}
     //   expected-remark@6{{macro content: |    }|}}
     //   expected-remark@7{{macro content: |    defer {|}}
@@ -184,7 +184,7 @@ void keyword(int len, int * __counted_by(len) _Nullable func __noescape,
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(_pointerName_param1: copy _pointerName_param1) @_disfavoredOverload public func pointerName(_ _pointerName_param1: inout MutableSpan<Int32>?) {|}}
 //   expected-remark@3{{macro content: |    let _pointerName_param0 = Int32(exactly: _pointerName_param1?.count ?? 0)!|}}
-//   expected-remark@4{{macro content: |    let __pointerName_param1Ptr = unsafe _pointerName_param1?.withUnsafeMutableBufferPointer {|}}
+//   expected-remark@4{{macro content: |    let __pointerName_param1Ptr = _pointerName_param1?.withUnsafeMutableBufferPointer {|}}
 //   expected-remark@5{{macro content: |        unsafe $0|}}
 //   expected-remark@6{{macro content: |    }|}}
 //   expected-remark@7{{macro content: |    defer {|}}
@@ -202,7 +202,7 @@ void pointerName(int len, int * __counted_by(len) _Nullable pointerName __noesca
 //   expected-remark@4{{macro content: |    if __lenName_param2Count != _lenName_param0 * _lenName_param1 {|}}
 //   expected-remark@5{{macro content: |      fatalError("bounds check failure in lenName: expected \\(_lenName_param0 * _lenName_param1) but got \\(__lenName_param2Count)")|}}
 //   expected-remark@6{{macro content: |    }|}}
-//   expected-remark@7{{macro content: |    let __lenName_param2Ptr = unsafe _lenName_param2?.withUnsafeMutableBufferPointer {|}}
+//   expected-remark@7{{macro content: |    let __lenName_param2Ptr = _lenName_param2?.withUnsafeMutableBufferPointer {|}}
 //   expected-remark@8{{macro content: |        unsafe $0|}}
 //   expected-remark@9{{macro content: |    }|}}
 //   expected-remark@10{{macro content: |    defer {|}}
@@ -217,7 +217,7 @@ void lenName(int lenName, int size, int * __counted_by(lenName * size) _Nullable
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(_func_param1: copy _func_param1) @_disfavoredOverload public func `func`(_ _func_param1: inout MutableSpan<Int32>?) {|}}
 //   expected-remark@3{{macro content: |    let _func_param0 = Int32(exactly: _func_param1?.count ?? 0)!|}}
-//   expected-remark@4{{macro content: |    let __func_param1Ptr = unsafe _func_param1?.withUnsafeMutableBufferPointer {|}}
+//   expected-remark@4{{macro content: |    let __func_param1Ptr = _func_param1?.withUnsafeMutableBufferPointer {|}}
 //   expected-remark@5{{macro content: |        unsafe $0|}}
 //   expected-remark@6{{macro content: |    }|}}
 //   expected-remark@7{{macro content: |    defer {|}}
@@ -241,7 +241,7 @@ void *funcRenameKeyword(int len, int * __counted_by(len) _Nullable func __noesca
     //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
     //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(`func`: copy `func`) @_disfavoredOverload public func funcRenamed(`func`: inout MutableSpan<Int32>?, `extension`: Int32, `init`: Int32, open: Int32, `var`: Int32, `is`: Int32, `as`: Int32, `in`: Int32, `guard`: Int32, `where`: Int32) -> UnsafeMutableRawPointer! {|}}
     //   expected-remark@3{{macro content: |    let len = Int32(exactly: `func`?.count ?? 0)!|}}
-    //   expected-remark@4{{macro content: |    let _funcPtr = unsafe `func`?.withUnsafeMutableBufferPointer {|}}
+    //   expected-remark@4{{macro content: |    let _funcPtr = `func`?.withUnsafeMutableBufferPointer {|}}
     //   expected-remark@5{{macro content: |        unsafe $0|}}
     //   expected-remark@6{{macro content: |    }|}}
     //   expected-remark@7{{macro content: |    defer {|}}
@@ -265,7 +265,7 @@ void *funcRenameKeywordAnonymous(int len, int * __counted_by(len) _Nullable __no
     //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
     //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(_funcRenamedAnon_param1: copy _funcRenamedAnon_param1) @_disfavoredOverload public func funcRenamedAnon(`func` _funcRenamedAnon_param1: inout MutableSpan<Int32>?, `extension` _funcRenamedAnon_param2: Int32, `init` _funcRenamedAnon_param3: Int32, open _funcRenamedAnon_param4: Int32, `var` _funcRenamedAnon_param5: Int32, `is` _funcRenamedAnon_param6: Int32, `as` _funcRenamedAnon_param7: Int32, `in` _funcRenamedAnon_param8: Int32, `guard` _funcRenamedAnon_param9: Int32, `where` _funcRenamedAnon_param10: Int32) -> UnsafeMutableRawPointer! {|}}
     //   expected-remark@3{{macro content: |    let _funcRenamedAnon_param0 = Int32(exactly: _funcRenamedAnon_param1?.count ?? 0)!|}}
-    //   expected-remark@4{{macro content: |    let __funcRenamedAnon_param1Ptr = unsafe _funcRenamedAnon_param1?.withUnsafeMutableBufferPointer {|}}
+    //   expected-remark@4{{macro content: |    let __funcRenamedAnon_param1Ptr = _funcRenamedAnon_param1?.withUnsafeMutableBufferPointer {|}}
     //   expected-remark@5{{macro content: |        unsafe $0|}}
     //   expected-remark@6{{macro content: |    }|}}
     //   expected-remark@7{{macro content: |    defer {|}}
@@ -280,7 +280,7 @@ void *funcRenameKeywordAnonymous(int len, int * __counted_by(len) _Nullable __no
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(`func`: copy `func`) @_disfavoredOverload public func clash(`func`: inout MutableSpan<Int32>?, clash `where`: Int32) {|}}
 //   expected-remark@3{{macro content: |    let len = Int32(exactly: `func`?.count ?? 0)!|}}
-//   expected-remark@4{{macro content: |    let _funcPtr = unsafe `func`?.withUnsafeMutableBufferPointer {|}}
+//   expected-remark@4{{macro content: |    let _funcPtr = `func`?.withUnsafeMutableBufferPointer {|}}
 //   expected-remark@5{{macro content: |        unsafe $0|}}
 //   expected-remark@6{{macro content: |    }|}}
 //   expected-remark@7{{macro content: |    defer {|}}
@@ -296,7 +296,7 @@ void funcRenameClash(int len, int * __counted_by(len) _Nullable func __noescape,
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(`func`: copy `func`) @_disfavoredOverload public func open(`func`: inout MutableSpan<Int32>?, open `where`: Int32) {|}}
 //   expected-remark@3{{macro content: |    let len = Int32(exactly: `func`?.count ?? 0)!|}}
-//   expected-remark@4{{macro content: |    let _funcPtr = unsafe `func`?.withUnsafeMutableBufferPointer {|}}
+//   expected-remark@4{{macro content: |    let _funcPtr = `func`?.withUnsafeMutableBufferPointer {|}}
 //   expected-remark@5{{macro content: |        unsafe $0|}}
 //   expected-remark@6{{macro content: |    }|}}
 //   expected-remark@7{{macro content: |    defer {|}}
@@ -312,7 +312,7 @@ void funcRenameClashKeyword(int len, int * __counted_by(len) _Nullable func __no
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(_clash2_param1: copy _clash2_param1) @_disfavoredOverload public func clash2(`func` _clash2_param1: inout MutableSpan<Int32>?, clash2 _clash2_param2: Int32) {|}}
 //   expected-remark@3{{macro content: |    let _clash2_param0 = Int32(exactly: _clash2_param1?.count ?? 0)!|}}
-//   expected-remark@4{{macro content: |    let __clash2_param1Ptr = unsafe _clash2_param1?.withUnsafeMutableBufferPointer {|}}
+//   expected-remark@4{{macro content: |    let __clash2_param1Ptr = _clash2_param1?.withUnsafeMutableBufferPointer {|}}
 //   expected-remark@5{{macro content: |        unsafe $0|}}
 //   expected-remark@6{{macro content: |    }|}}
 //   expected-remark@7{{macro content: |    defer {|}}
@@ -328,7 +328,7 @@ void funcRenameClashAnonymous(int len, int * __counted_by(len) _Nullable func __
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(_in_param1: copy _in_param1) @_disfavoredOverload public func `in`(`func` _in_param1: inout MutableSpan<Int32>?, `in` _in_param2: Int32) {|}}
 //   expected-remark@3{{macro content: |    let _in_param0 = Int32(exactly: _in_param1?.count ?? 0)!|}}
-//   expected-remark@4{{macro content: |    let __in_param1Ptr = unsafe _in_param1?.withUnsafeMutableBufferPointer {|}}
+//   expected-remark@4{{macro content: |    let __in_param1Ptr = _in_param1?.withUnsafeMutableBufferPointer {|}}
 //   expected-remark@5{{macro content: |        unsafe $0|}}
 //   expected-remark@6{{macro content: |    }|}}
 //   expected-remark@7{{macro content: |    defer {|}}
@@ -346,7 +346,7 @@ typedef struct actor_ *actor;
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload public func keywordType(_ p: inout MutableSpan<actor?>, _ p2: actor) -> actor {|}}
 //   expected-warning@3{{expression uses unsafe constructs but is not marked with 'unsafe'}}
 //   expected-remark@3{{macro content: |    let len = Int32(exactly: p.count)!|}}
-//   expected-remark@4{{macro content: |    let _pPtr = unsafe p.withUnsafeMutableBufferPointer {|}}
+//   expected-remark@4{{macro content: |    let _pPtr = p.withUnsafeMutableBufferPointer {|}}
 //   expected-remark@5{{macro content: |        unsafe $0|}}
 //   expected-remark@6{{macro content: |    }|}}
 //   expected-remark@7{{macro content: |    defer {|}}

--- a/test/Interop/C/swiftify-import/import-as-instance-method.swift
+++ b/test/Interop/C/swiftify-import/import-as-instance-method.swift
@@ -110,7 +110,7 @@ module Instance {
 @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
 public mutating func basic(_ p: inout MutableSpan<Int32>) {
     let len = Int32(exactly: p.count)!
-    let _pPtr = unsafe p.withUnsafeMutableBufferPointer {
+    let _pPtr = p.withUnsafeMutableBufferPointer {
         unsafe $0
     }
     defer {
@@ -125,7 +125,7 @@ public mutating func basic(_ p: inout MutableSpan<Int32>) {
 @available(swift, obsoleted: 3, renamed: "A.basic(self:_:_:)") @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
 public func basic(_ a: UnsafeMutablePointer<A>!, _ p: inout MutableSpan<Int32>) {
     let len = Int32(exactly: p.count)!
-    let _pPtr = unsafe p.withUnsafeMutableBufferPointer {
+    let _pPtr = p.withUnsafeMutableBufferPointer {
         unsafe $0
     }
     defer {
@@ -140,7 +140,7 @@ public func basic(_ a: UnsafeMutablePointer<A>!, _ p: inout MutableSpan<Int32>) 
 @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
 public mutating func bar(_ p: inout MutableSpan<Int32>) {
     let len = Int32(exactly: p.count)!
-    let _pPtr = unsafe p.withUnsafeMutableBufferPointer {
+    let _pPtr = p.withUnsafeMutableBufferPointer {
         unsafe $0
     }
     defer {
@@ -155,7 +155,7 @@ public mutating func bar(_ p: inout MutableSpan<Int32>) {
 @available(swift, obsoleted: 3, renamed: "A.bar(self:_:_:)") @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
 public func renamed(_ a: UnsafeMutablePointer<A>!, _ p: inout MutableSpan<Int32>) {
     let len = Int32(exactly: p.count)!
-    let _pPtr = unsafe p.withUnsafeMutableBufferPointer {
+    let _pPtr = p.withUnsafeMutableBufferPointer {
         unsafe $0
     }
     defer {
@@ -170,7 +170,7 @@ public func renamed(_ a: UnsafeMutablePointer<A>!, _ p: inout MutableSpan<Int32>
 @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
 public func constSelf(_ p: inout MutableSpan<Int32>) {
     let len = Int32(exactly: p.count)!
-    let _pPtr = unsafe p.withUnsafeMutableBufferPointer {
+    let _pPtr = p.withUnsafeMutableBufferPointer {
         unsafe $0
     }
     defer {
@@ -185,7 +185,7 @@ public func constSelf(_ p: inout MutableSpan<Int32>) {
 @available(swift, obsoleted: 3, renamed: "A.constSelf(self:_:_:)") @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
 public func constSelf(_ a: UnsafePointer<A>!, _ p: inout MutableSpan<Int32>) {
     let len = Int32(exactly: p.count)!
-    let _pPtr = unsafe p.withUnsafeMutableBufferPointer {
+    let _pPtr = p.withUnsafeMutableBufferPointer {
         unsafe $0
     }
     defer {
@@ -200,7 +200,7 @@ public func constSelf(_ a: UnsafePointer<A>!, _ p: inout MutableSpan<Int32>) {
 @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
 public func valSelf(_ p: inout MutableSpan<Int32>) {
     let len = Int32(exactly: p.count)!
-    let _pPtr = unsafe p.withUnsafeMutableBufferPointer {
+    let _pPtr = p.withUnsafeMutableBufferPointer {
         unsafe $0
     }
     defer {
@@ -215,7 +215,7 @@ public func valSelf(_ p: inout MutableSpan<Int32>) {
 @available(swift, obsoleted: 3, renamed: "A.valSelf(self:_:_:)") @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
 public func valSelf(_ a: A, _ p: inout MutableSpan<Int32>) {
     let len = Int32(exactly: p.count)!
-    let _pPtr = unsafe p.withUnsafeMutableBufferPointer {
+    let _pPtr = p.withUnsafeMutableBufferPointer {
         unsafe $0
     }
     defer {
@@ -246,7 +246,7 @@ public func lifetimeBoundSelf(_ a: A, _ len: Int32) -> MutableSpan<Int32> {
 @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
 public func refSelf(_ p: inout MutableSpan<Int32>) {
     let len = Int32(exactly: p.count)!
-    let _pPtr = unsafe p.withUnsafeMutableBufferPointer {
+    let _pPtr = p.withUnsafeMutableBufferPointer {
         unsafe $0
     }
     defer {
@@ -261,7 +261,7 @@ public func refSelf(_ p: inout MutableSpan<Int32>) {
 @available(swift, obsoleted: 3, renamed: "C.refSelf(self:_:_:)") @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
 public func refSelf(_ c: C!, _ p: inout MutableSpan<Int32>) {
     let len = Int32(exactly: p.count)!
-    let _pPtr = unsafe p.withUnsafeMutableBufferPointer {
+    let _pPtr = p.withUnsafeMutableBufferPointer {
         unsafe $0
     }
     defer {
@@ -276,7 +276,7 @@ public func refSelf(_ c: C!, _ p: inout MutableSpan<Int32>) {
 @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
 public func refSelf(_ p: inout MutableSpan<Int32>) {
     let len = Int32(exactly: p.count)!
-    let _pPtr = unsafe p.withUnsafeMutableBufferPointer {
+    let _pPtr = p.withUnsafeMutableBufferPointer {
         unsafe $0
     }
     defer {
@@ -291,7 +291,7 @@ public func refSelf(_ p: inout MutableSpan<Int32>) {
 @available(swift, obsoleted: 3, renamed: "D.refSelf(self:_:_:)") @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
 public func refSelfCF(_ d: D!, _ p: inout MutableSpan<Int32>) {
     let len = Int32(exactly: p.count)!
-    let _pPtr = unsafe p.withUnsafeMutableBufferPointer {
+    let _pPtr = p.withUnsafeMutableBufferPointer {
         unsafe $0
     }
     defer {
@@ -306,7 +306,7 @@ public func refSelfCF(_ d: D!, _ p: inout MutableSpan<Int32>) {
 @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
 public func nonescaping(_ p: inout MutableSpan<Int32>) {
     let len = Int32(exactly: p.count)!
-    let _pPtr = unsafe p.withUnsafeMutableBufferPointer {
+    let _pPtr = p.withUnsafeMutableBufferPointer {
         unsafe $0
     }
     defer {
@@ -347,7 +347,7 @@ public func createA(_ p: UnsafeMutableBufferPointer<Int32>) -> UnsafeMutablePoin
 @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
 public /*not inherited*/ init!(pointerA2 p: inout MutableSpan<Int32>) {
     let len = Int32(exactly: p.count)!
-    let _pPtr = unsafe p.withUnsafeMutableBufferPointer {
+    let _pPtr = p.withUnsafeMutableBufferPointer {
         unsafe $0
     }
     defer {
@@ -362,7 +362,7 @@ public /*not inherited*/ init!(pointerA2 p: inout MutableSpan<Int32>) {
 @available(swift, obsoleted: 3, renamed: "A.init(countA2:pointerA2:)") @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
 public func createA2(_ p: inout MutableSpan<Int32>) -> UnsafeMutablePointer<A>! {
     let len = Int32(exactly: p.count)!
-    let _pPtr = unsafe p.withUnsafeMutableBufferPointer {
+    let _pPtr = p.withUnsafeMutableBufferPointer {
         unsafe $0
     }
     defer {

--- a/test/Interop/C/swiftify-import/sized-by-lifetimebound.swift
+++ b/test/Interop/C/swiftify-import/sized-by-lifetimebound.swift
@@ -27,7 +27,7 @@
 //   expected-experimental-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy p) @_disfavoredOverload public func simple(_ len: Int32, _ p: RawSpan) -> RawSpan {|}}
 //   expected-experimental-remark@3{{macro content: |    let len2 = Int32(exactly: p.byteCount)!|}}
-//   expected-experimental-remark@4{{macro content: |    let _pPtr = unsafe p.withUnsafeBytes {|}}
+//   expected-experimental-remark@4{{macro content: |    let _pPtr = p.withUnsafeBytes {|}}
 //   expected-experimental-remark@5{{macro content: |        unsafe $0|}}
 //   expected-experimental-remark@6{{macro content: |    }|}}
 //   expected-experimental-remark@7{{macro content: |    defer {|}}
@@ -42,7 +42,7 @@ const void * __sized_by(len) simple(int len, int len2, const void * p __sized_by
 //   expected-experimental-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy p) @_disfavoredOverload public func shared(_ p: RawSpan) -> RawSpan {|}}
 //   expected-experimental-remark@3{{macro content: |    let len = Int32(exactly: p.byteCount)!|}}
-//   expected-experimental-remark@4{{macro content: |    let _pPtr = unsafe p.withUnsafeBytes {|}}
+//   expected-experimental-remark@4{{macro content: |    let _pPtr = p.withUnsafeBytes {|}}
 //   expected-experimental-remark@5{{macro content: |        unsafe $0|}}
 //   expected-experimental-remark@6{{macro content: |    }|}}
 //   expected-experimental-remark@7{{macro content: |    defer {|}}
@@ -57,7 +57,7 @@ const void * __sized_by(len) shared(int len, const void * p __sized_by(len) __li
 //   expected-experimental-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy p) @_disfavoredOverload public func complexExpr(_ len: Int32, _ offset: Int32, _ p: RawSpan) -> RawSpan {|}}
 //   expected-experimental-remark@3{{macro content: |    let len2 = Int32(exactly: p.byteCount)!|}}
-//   expected-experimental-remark@4{{macro content: |    let _pPtr = unsafe p.withUnsafeBytes {|}}
+//   expected-experimental-remark@4{{macro content: |    let _pPtr = p.withUnsafeBytes {|}}
 //   expected-experimental-remark@5{{macro content: |        unsafe $0|}}
 //   expected-experimental-remark@6{{macro content: |    }|}}
 //   expected-experimental-remark@7{{macro content: |    defer {|}}
@@ -72,7 +72,7 @@ const void * __sized_by(len - offset) complexExpr(int len, int offset, int len2,
 //   expected-experimental-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy p) @_disfavoredOverload public func nullUnspecified(_ len: Int32, _ p: RawSpan) -> RawSpan {|}}
 //   expected-experimental-remark@3{{macro content: |    let len2 = Int32(exactly: p.byteCount)!|}}
-//   expected-experimental-remark@4{{macro content: |    let _pPtr = unsafe p.withUnsafeBytes {|}}
+//   expected-experimental-remark@4{{macro content: |    let _pPtr = p.withUnsafeBytes {|}}
 //   expected-experimental-remark@5{{macro content: |        unsafe $0|}}
 //   expected-experimental-remark@6{{macro content: |    }|}}
 //   expected-experimental-remark@7{{macro content: |    defer {|}}
@@ -87,7 +87,7 @@ const void * __sized_by(len) _Null_unspecified nullUnspecified(int len, int len2
 //   expected-experimental-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy p) @_disfavoredOverload public func nonnull(_ len: Int32, _ p: RawSpan) -> RawSpan {|}}
 //   expected-experimental-remark@3{{macro content: |    let len2 = Int32(exactly: p.byteCount)!|}}
-//   expected-experimental-remark@4{{macro content: |    let _pPtr = unsafe p.withUnsafeBytes {|}}
+//   expected-experimental-remark@4{{macro content: |    let _pPtr = p.withUnsafeBytes {|}}
 //   expected-experimental-remark@5{{macro content: |        unsafe $0|}}
 //   expected-experimental-remark@6{{macro content: |    }|}}
 //   expected-experimental-remark@7{{macro content: |    defer {|}}
@@ -102,7 +102,7 @@ const void * __sized_by(len) _Nonnull nonnull(int len, int len2, const void * _N
 //   expected-experimental-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy p) @_disfavoredOverload public func nullable(_ len: Int32, _ p: RawSpan?) -> RawSpan? {|}}
 //   expected-experimental-remark@3{{macro content: |    let len2 = Int32(exactly: p?.byteCount ?? 0)!|}}
-//   expected-experimental-remark@4{{macro content: |    let _pPtr = unsafe p?.withUnsafeBytes {|}}
+//   expected-experimental-remark@4{{macro content: |    let _pPtr = p?.withUnsafeBytes {|}}
 //   expected-experimental-remark@5{{macro content: |        unsafe $0|}}
 //   expected-experimental-remark@6{{macro content: |    }|}}
 //   expected-experimental-remark@7{{macro content: |    defer {|}}
@@ -125,7 +125,7 @@ typedef struct foo opaque_t;
 //   expected-experimental-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy p) @_disfavoredOverload public func opaque(_ len: Int32, _ p: RawSpan) -> RawSpan {|}}
 //   expected-experimental-remark@3{{macro content: |    let len2 = Int32(exactly: p.byteCount)!|}}
-//   expected-experimental-remark@4{{macro content: |    let _pPtr = unsafe p.withUnsafeBytes {|}}
+//   expected-experimental-remark@4{{macro content: |    let _pPtr = p.withUnsafeBytes {|}}
 //   expected-experimental-remark@5{{macro content: |        unsafe $0|}}
 //   expected-experimental-remark@6{{macro content: |    }|}}
 //   expected-experimental-remark@7{{macro content: |    defer {|}}
@@ -148,7 +148,7 @@ const void * __sized_by(len) nonsizedLifetime(int len, const void * p __lifetime
 //   expected-experimental-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy p) @_disfavoredOverload public func bytesized(_ p: RawSpan) -> MutableRawSpan {|}}
 //   expected-experimental-remark@3{{macro content: |    let size = Int32(exactly: p.byteCount)!|}}
-//   expected-experimental-remark@4{{macro content: |    let _pPtr = unsafe p.withUnsafeBytes {|}}
+//   expected-experimental-remark@4{{macro content: |    let _pPtr = p.withUnsafeBytes {|}}
 //   expected-experimental-remark@5{{macro content: |        unsafe $0|}}
 //   expected-experimental-remark@6{{macro content: |    }|}}
 //   expected-experimental-remark@7{{macro content: |    defer {|}}
@@ -163,7 +163,7 @@ uint8_t *__sized_by(size)  bytesized(int size, const uint8_t * p __sized_by(size
 //   expected-experimental-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy p) @_lifetime(p: copy p) @_disfavoredOverload public func charsized(_ p: inout MutableRawSpan) -> MutableRawSpan {|}}
 //   expected-experimental-remark@3{{macro content: |    let size = Int32(exactly: p.byteCount)!|}}
-//   expected-experimental-remark@4{{macro content: |    let _pPtr = unsafe p.withUnsafeMutableBytes {|}}
+//   expected-experimental-remark@4{{macro content: |    let _pPtr = p.withUnsafeMutableBytes {|}}
 //   expected-experimental-remark@5{{macro content: |        unsafe $0|}}
 //   expected-experimental-remark@6{{macro content: |    }|}}
 //   expected-experimental-remark@7{{macro content: |    defer {|}}

--- a/test/Interop/C/swiftify-import/sized-by-noescape.swift
+++ b/test/Interop/C/swiftify-import/sized-by-noescape.swift
@@ -22,7 +22,7 @@
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_disfavoredOverload public func simple(_ p: RawSpan) {|}}
 //   expected-remark@3{{macro content: |    let len = Int32(exactly: p.byteCount)!|}}
-//   expected-remark@4{{macro content: |    let _pPtr = unsafe p.withUnsafeBytes {|}}
+//   expected-remark@4{{macro content: |    let _pPtr = p.withUnsafeBytes {|}}
 //   expected-remark@5{{macro content: |        unsafe $0|}}
 //   expected-remark@6{{macro content: |    }|}}
 //   expected-remark@7{{macro content: |    defer {|}}
@@ -37,7 +37,7 @@ void simple(int len, const void * __sized_by(len) __noescape p);
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_disfavoredOverload public func swiftAttr(_ p: RawSpan) {|}}
 //   expected-remark@3{{macro content: |    let len = Int32(exactly: p.byteCount)!|}}
-//   expected-remark@4{{macro content: |    let _pPtr = unsafe p.withUnsafeBytes {|}}
+//   expected-remark@4{{macro content: |    let _pPtr = p.withUnsafeBytes {|}}
 //   expected-remark@5{{macro content: |        unsafe $0|}}
 //   expected-remark@6{{macro content: |    }|}}
 //   expected-remark@7{{macro content: |    defer {|}}
@@ -56,13 +56,13 @@ void swiftAttr(int len, const void *p) __attribute__((swift_attr(
 //   expected-remark@4{{macro content: |    if p2.byteCount != len {|}}
 //   expected-remark@5{{macro content: |      fatalError("bounds check failure in shared: expected \\(len) but got \\(p2.byteCount)")|}}
 //   expected-remark@6{{macro content: |    }|}}
-//   expected-remark@7{{macro content: |    let _p1Ptr = unsafe p1.withUnsafeBytes {|}}
+//   expected-remark@7{{macro content: |    let _p1Ptr = p1.withUnsafeBytes {|}}
 //   expected-remark@8{{macro content: |        unsafe $0|}}
 //   expected-remark@9{{macro content: |    }|}}
 //   expected-remark@10{{macro content: |    defer {|}}
 //   expected-remark@11{{macro content: |        _fixLifetime(p1)|}}
 //   expected-remark@12{{macro content: |    }|}}
-//   expected-remark@13{{macro content: |    let _p2Ptr = unsafe p2.withUnsafeBytes {|}}
+//   expected-remark@13{{macro content: |    let _p2Ptr = p2.withUnsafeBytes {|}}
 //   expected-remark@14{{macro content: |        unsafe $0|}}
 //   expected-remark@15{{macro content: |    }|}}
 //   expected-remark@16{{macro content: |    defer {|}}
@@ -80,7 +80,7 @@ void shared(int len, const void * __sized_by(len) __noescape p1, const void * __
 //   expected-remark@4{{macro content: |    if _pCount != len - offset {|}}
 //   expected-remark@5{{macro content: |      fatalError("bounds check failure in complexExpr: expected \\(len - offset) but got \\(_pCount)")|}}
 //   expected-remark@6{{macro content: |    }|}}
-//   expected-remark@7{{macro content: |    let _pPtr = unsafe p.withUnsafeBytes {|}}
+//   expected-remark@7{{macro content: |    let _pPtr = p.withUnsafeBytes {|}}
 //   expected-remark@8{{macro content: |        unsafe $0|}}
 //   expected-remark@9{{macro content: |    }|}}
 //   expected-remark@10{{macro content: |    defer {|}}
@@ -95,7 +95,7 @@ void complexExpr(int len, int offset, const void * __sized_by(len - offset) __no
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_disfavoredOverload public func nullUnspecified(_ p: RawSpan) {|}}
 //   expected-remark@3{{macro content: |    let len = Int32(exactly: p.byteCount)!|}}
-//   expected-remark@4{{macro content: |    let _pPtr = unsafe p.withUnsafeBytes {|}}
+//   expected-remark@4{{macro content: |    let _pPtr = p.withUnsafeBytes {|}}
 //   expected-remark@5{{macro content: |        unsafe $0|}}
 //   expected-remark@6{{macro content: |    }|}}
 //   expected-remark@7{{macro content: |    defer {|}}
@@ -110,7 +110,7 @@ void nullUnspecified(int len, const void * __sized_by(len) __noescape _Null_unsp
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_disfavoredOverload public func nonnull(_ p: RawSpan) {|}}
 //   expected-remark@3{{macro content: |    let len = Int32(exactly: p.byteCount)!|}}
-//   expected-remark@4{{macro content: |    let _pPtr = unsafe p.withUnsafeBytes {|}}
+//   expected-remark@4{{macro content: |    let _pPtr = p.withUnsafeBytes {|}}
 //   expected-remark@5{{macro content: |        unsafe $0|}}
 //   expected-remark@6{{macro content: |    }|}}
 //   expected-remark@7{{macro content: |    defer {|}}
@@ -125,7 +125,7 @@ void nonnull(int len, const void * __sized_by(len) __noescape _Nonnull p);
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_disfavoredOverload public func nullable(_ p: RawSpan?) {|}}
 //   expected-remark@3{{macro content: |    let len = Int32(exactly: p?.byteCount ?? 0)!|}}
-//   expected-remark@4{{macro content: |    let _pPtr = unsafe p?.withUnsafeBytes {|}}
+//   expected-remark@4{{macro content: |    let _pPtr = p?.withUnsafeBytes {|}}
 //   expected-remark@5{{macro content: |        unsafe $0|}}
 //   expected-remark@6{{macro content: |    }|}}
 //   expected-remark@7{{macro content: |    defer {|}}
@@ -149,7 +149,7 @@ typedef struct foo opaque_t;
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_disfavoredOverload public func opaque(_ p: RawSpan) {|}}
 //   expected-remark@3{{macro content: |    let len = Int32(exactly: p.byteCount)!|}}
-//   expected-remark@4{{macro content: |    let _pPtr = unsafe p.withUnsafeBytes {|}}
+//   expected-remark@4{{macro content: |    let _pPtr = p.withUnsafeBytes {|}}
 //   expected-remark@5{{macro content: |        unsafe $0|}}
 //   expected-remark@6{{macro content: |    }|}}
 //   expected-remark@7{{macro content: |    defer {|}}
@@ -164,7 +164,7 @@ void opaque(int len, opaque_t * __sized_by(len) __noescape p);
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_disfavoredOverload public func bytesized(_ _bytesized_param1: RawSpan) {|}}
 //   expected-remark@3{{macro content: |    let _bytesized_param0 = Int32(exactly: _bytesized_param1.byteCount)!|}}
-//   expected-remark@4{{macro content: |    let __bytesized_param1Ptr = unsafe _bytesized_param1.withUnsafeBytes {|}}
+//   expected-remark@4{{macro content: |    let __bytesized_param1Ptr = _bytesized_param1.withUnsafeBytes {|}}
 //   expected-remark@5{{macro content: |        unsafe $0|}}
 //   expected-remark@6{{macro content: |    }|}}
 //   expected-remark@7{{macro content: |    defer {|}}
@@ -179,7 +179,7 @@ void bytesized(int size, const uint8_t *__sized_by(size) __noescape);
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(_charsized_param0: copy _charsized_param0) @_disfavoredOverload public func charsized(_ _charsized_param0: inout MutableRawSpan) {|}}
 //   expected-remark@3{{macro content: |    let _charsized_param1 = Int32(exactly: _charsized_param0.byteCount)!|}}
-//   expected-remark@4{{macro content: |    let __charsized_param0Ptr = unsafe _charsized_param0.withUnsafeMutableBytes {|}}
+//   expected-remark@4{{macro content: |    let __charsized_param0Ptr = _charsized_param0.withUnsafeMutableBytes {|}}
 //   expected-remark@5{{macro content: |        unsafe $0|}}
 //   expected-remark@6{{macro content: |    }|}}
 //   expected-remark@7{{macro content: |    defer {|}}

--- a/test/Interop/Cxx/swiftify-import/import-as-instance-method.swift
+++ b/test/Interop/Cxx/swiftify-import/import-as-instance-method.swift
@@ -89,7 +89,7 @@ module Instance {
 // CHECK-NEXT:/// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT:@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
 // CHECK-NEXT:public mutating func basic(_ p: inout MutableSpan<CInt>) {
-// CHECK-NEXT:    return unsafe p.withUnsafeMutableBufferPointer { _pPtr in
+// CHECK-NEXT:    return p.withUnsafeMutableBufferPointer { _pPtr in
 // CHECK-NEXT:      return unsafe basic(IntSpan(_pPtr))
 // CHECK-NEXT:    }
 // CHECK-NEXT:}
@@ -99,7 +99,7 @@ module Instance {
 // CHECK-NEXT:/// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT:@available(swift, obsoleted: 3, renamed: "A.basic(self:_:)") @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
 // CHECK-NEXT:public func basic(_ a: UnsafeMutablePointer<A>!, _ p: inout MutableSpan<CInt>) {
-// CHECK-NEXT:    return unsafe p.withUnsafeMutableBufferPointer { _pPtr in
+// CHECK-NEXT:    return p.withUnsafeMutableBufferPointer { _pPtr in
 // CHECK-NEXT:      return unsafe basic(a, IntSpan(_pPtr))
 // CHECK-NEXT:    }
 // CHECK-NEXT:}
@@ -109,7 +109,7 @@ module Instance {
 // CHECK-NEXT:/// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT:@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
 // CHECK-NEXT:public mutating func bar(_ p: inout MutableSpan<CInt>) {
-// CHECK-NEXT:    return unsafe p.withUnsafeMutableBufferPointer { _pPtr in
+// CHECK-NEXT:    return p.withUnsafeMutableBufferPointer { _pPtr in
 // CHECK-NEXT:      return unsafe bar(IntSpan(_pPtr))
 // CHECK-NEXT:    }
 // CHECK-NEXT:}
@@ -119,7 +119,7 @@ module Instance {
 // CHECK-NEXT:/// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT:@available(swift, obsoleted: 3, renamed: "A.bar(self:_:)") @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
 // CHECK-NEXT:public func renamed(_ a: UnsafeMutablePointer<A>!, _ p: inout MutableSpan<CInt>) {
-// CHECK-NEXT:    return unsafe p.withUnsafeMutableBufferPointer { _pPtr in
+// CHECK-NEXT:    return p.withUnsafeMutableBufferPointer { _pPtr in
 // CHECK-NEXT:      return unsafe renamed(a, IntSpan(_pPtr))
 // CHECK-NEXT:    }
 // CHECK-NEXT:}
@@ -129,7 +129,7 @@ module Instance {
 // CHECK-NEXT:/// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT:@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
 // CHECK-NEXT:public func constSelf(_ p: inout MutableSpan<CInt>) {
-// CHECK-NEXT:    return unsafe p.withUnsafeMutableBufferPointer { _pPtr in
+// CHECK-NEXT:    return p.withUnsafeMutableBufferPointer { _pPtr in
 // CHECK-NEXT:      return unsafe constSelf(IntSpan(_pPtr))
 // CHECK-NEXT:    }
 // CHECK-NEXT:}
@@ -139,7 +139,7 @@ module Instance {
 // CHECK-NEXT:/// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT:@available(swift, obsoleted: 3, renamed: "A.constSelf(self:_:)") @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
 // CHECK-NEXT:public func constSelf(_ a: UnsafePointer<A>!, _ p: inout MutableSpan<CInt>) {
-// CHECK-NEXT:    return unsafe p.withUnsafeMutableBufferPointer { _pPtr in
+// CHECK-NEXT:    return p.withUnsafeMutableBufferPointer { _pPtr in
 // CHECK-NEXT:      return unsafe constSelf(a, IntSpan(_pPtr))
 // CHECK-NEXT:    }
 // CHECK-NEXT:}
@@ -149,7 +149,7 @@ module Instance {
 // CHECK-NEXT:/// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT:@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
 // CHECK-NEXT:public func valSelf(_ p: inout MutableSpan<CInt>) {
-// CHECK-NEXT:    return unsafe p.withUnsafeMutableBufferPointer { _pPtr in
+// CHECK-NEXT:    return p.withUnsafeMutableBufferPointer { _pPtr in
 // CHECK-NEXT:      return unsafe valSelf(IntSpan(_pPtr))
 // CHECK-NEXT:    }
 // CHECK-NEXT:}
@@ -159,7 +159,7 @@ module Instance {
 // CHECK-NEXT:/// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT:@available(swift, obsoleted: 3, renamed: "A.valSelf(self:_:)") @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
 // CHECK-NEXT:public func valSelf(_ a: A, _ p: inout MutableSpan<CInt>) {
-// CHECK-NEXT:    return unsafe p.withUnsafeMutableBufferPointer { _pPtr in
+// CHECK-NEXT:    return p.withUnsafeMutableBufferPointer { _pPtr in
 // CHECK-NEXT:      return unsafe valSelf(a, IntSpan(_pPtr))
 // CHECK-NEXT:    }
 // CHECK-NEXT:}
@@ -169,7 +169,7 @@ module Instance {
 // CHECK-NEXT:/// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT:@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
 // CHECK-NEXT:public mutating func refSelf(_ p: inout MutableSpan<CInt>) {
-// CHECK-NEXT:    return unsafe p.withUnsafeMutableBufferPointer { _pPtr in
+// CHECK-NEXT:    return p.withUnsafeMutableBufferPointer { _pPtr in
 // CHECK-NEXT:      return unsafe refSelf(IntSpan(_pPtr))
 // CHECK-NEXT:    }
 // CHECK-NEXT:}
@@ -179,7 +179,7 @@ module Instance {
 // CHECK-NEXT:/// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT:@available(swift, obsoleted: 3, renamed: "A.refSelf(self:_:)") @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
 // CHECK-NEXT:public func refSelf(_ a: inout A, _ p: inout MutableSpan<CInt>) {
-// CHECK-NEXT:    return unsafe p.withUnsafeMutableBufferPointer { _pPtr in
+// CHECK-NEXT:    return p.withUnsafeMutableBufferPointer { _pPtr in
 // CHECK-NEXT:      return unsafe refSelf(&a, IntSpan(_pPtr))
 // CHECK-NEXT:    }
 // CHECK-NEXT:}
@@ -189,7 +189,7 @@ module Instance {
 // CHECK-NEXT:/// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT:@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
 // CHECK-NEXT:public mutating func namespaced(_ p: inout MutableSpan<CInt>) {
-// CHECK-NEXT:    return unsafe p.withUnsafeMutableBufferPointer { _pPtr in
+// CHECK-NEXT:    return p.withUnsafeMutableBufferPointer { _pPtr in
 // CHECK-NEXT:      return unsafe namespaced(IntSpan(_pPtr))
 // CHECK-NEXT:    }
 // CHECK-NEXT:}
@@ -199,7 +199,7 @@ module Instance {
 // CHECK-NEXT:/// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT:@available(swift, obsoleted: 3, renamed: "A.namespaced(self:_:)") @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
 // CHECK-NEXT:  public static func namespaced(_ a: UnsafeMutablePointer<A>!, _ p: inout MutableSpan<CInt>) {
-// CHECK-NEXT:    return unsafe p.withUnsafeMutableBufferPointer { _pPtr in
+// CHECK-NEXT:    return p.withUnsafeMutableBufferPointer { _pPtr in
 // CHECK-NEXT:      return unsafe namespaced(a, IntSpan(_pPtr))
 // CHECK-NEXT:    }
 // CHECK-NEXT:}
@@ -209,7 +209,7 @@ module Instance {
 // CHECK-NEXT:/// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT:@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
 // CHECK-NEXT:public mutating func decapseman(_ p: inout MutableSpan<CInt>)  {
-// CHECK-NEXT:    return unsafe p.withUnsafeMutableBufferPointer { _pPtr in
+// CHECK-NEXT:    return p.withUnsafeMutableBufferPointer { _pPtr in
 // CHECK-NEXT:      return unsafe decapseman(IntSpan(_pPtr))
 // CHECK-NEXT:    }
 // CHECK-NEXT:}
@@ -219,7 +219,7 @@ module Instance {
 // CHECK-NEXT:/// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT:@available(swift, obsoleted: 3, renamed: "baz.B.decapseman(self:_:)") @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
 // CHECK-NEXT:public func decapseman(_ b: UnsafeMutablePointer<baz.B>!, _ p: inout MutableSpan<CInt>) {
-// CHECK-NEXT:    return unsafe p.withUnsafeMutableBufferPointer { _pPtr in
+// CHECK-NEXT:    return p.withUnsafeMutableBufferPointer { _pPtr in
 // CHECK-NEXT:      return unsafe decapseman(b, IntSpan(_pPtr))
 // CHECK-NEXT:    }
 // CHECK-NEXT:}
@@ -229,7 +229,7 @@ module Instance {
 // CHECK-NEXT:/// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT:@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
 // CHECK-NEXT:public static func bar(_ a: inout A, _ p: inout MutableSpan<CInt>) {
-// CHECK-NEXT:    return unsafe p.withUnsafeMutableBufferPointer { _pPtr in
+// CHECK-NEXT:    return p.withUnsafeMutableBufferPointer { _pPtr in
 // CHECK-NEXT:      return unsafe bar(&a, IntSpan(_pPtr))
 // CHECK-NEXT:    }
 // CHECK-NEXT:}
@@ -239,7 +239,7 @@ module Instance {
 // CHECK-NEXT:/// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT:@available(swift, obsoleted: 3, renamed: "baz.bar(_:_:)") @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
 // CHECK-NEXT:  public static func renamed(_ a: inout A, _ p: inout MutableSpan<CInt>) {
-// CHECK-NEXT:    return unsafe p.withUnsafeMutableBufferPointer { _pPtr in
+// CHECK-NEXT:    return p.withUnsafeMutableBufferPointer { _pPtr in
 // CHECK-NEXT:      return unsafe renamed(&a, IntSpan(_pPtr))
 // CHECK-NEXT:    }
 // CHECK-NEXT:}
@@ -249,7 +249,7 @@ module Instance {
 // CHECK-NEXT:/// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT:@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
 // CHECK-NEXT:public static func this(_ a: inout A, _ p: inout MutableSpan<CInt>) {
-// CHECK-NEXT:    return unsafe p.withUnsafeMutableBufferPointer { _pPtr in
+// CHECK-NEXT:    return p.withUnsafeMutableBufferPointer { _pPtr in
 // CHECK-NEXT:      return unsafe this(&a, IntSpan(_pPtr))
 // CHECK-NEXT:    }
 // CHECK-NEXT:}
@@ -259,7 +259,7 @@ module Instance {
 // CHECK-NEXT:/// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT:@available(swift, obsoleted: 3, renamed: "this(_:_:)") @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
 // CHECK-NEXT:  public static func that(_ a: inout A, _ p: inout MutableSpan<CInt>) {
-// CHECK-NEXT:    return unsafe p.withUnsafeMutableBufferPointer { _pPtr in
+// CHECK-NEXT:    return p.withUnsafeMutableBufferPointer { _pPtr in
 // CHECK-NEXT:      return unsafe that(&a, IntSpan(_pPtr))
 // CHECK-NEXT:    }
 // CHECK-NEXT:}
@@ -277,7 +277,7 @@ module Instance {
 // CHECK-NEXT:/// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT:@available(swift, obsoleted: 3, renamed: "IntSpan.spanSelf(self:)") @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy p) @_lifetime(p: copy p) @_disfavoredOverload
 // CHECK-NEXT:public func spanSelf(_ p: inout MutableSpan<CInt>) -> MutableSpan<CInt> {
-// CHECK-NEXT:    return unsafe _swiftifyOverrideLifetime(MutableSpan(_unsafeCxxSpan: unsafe p.withUnsafeMutableBufferPointer { _pPtr in
+// CHECK-NEXT:    return unsafe _swiftifyOverrideLifetime(MutableSpan(_unsafeCxxSpan: p.withUnsafeMutableBufferPointer { _pPtr in
 // CHECK-NEXT:      return unsafe spanSelf(IntSpan(_pPtr))
 // CHECK-NEXT:            }), copying: ())
 // CHECK-NEXT:}
@@ -295,7 +295,7 @@ module Instance {
 // CHECK-NEXT:/// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT:@available(swift, obsoleted: 3, renamed: "IntSpan.spanConstSelf(self:)") @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy p) @_lifetime(p: copy p) @_disfavoredOverload
 // CHECK-NEXT:public func spanConstSelf(_ p: inout MutableSpan<CInt>) -> MutableSpan<CInt> {
-// CHECK-NEXT:    return unsafe _swiftifyOverrideLifetime(MutableSpan(_unsafeCxxSpan: unsafe p.withUnsafeMutableBufferPointer { _pPtr in
+// CHECK-NEXT:    return unsafe _swiftifyOverrideLifetime(MutableSpan(_unsafeCxxSpan: p.withUnsafeMutableBufferPointer { _pPtr in
 // CHECK-NEXT:      return unsafe spanConstSelf(IntSpan(_pPtr))
 // CHECK-NEXT:            }), copying: ())
 // CHECK-NEXT:}

--- a/test/Interop/Cxx/swiftify-import/parameter-type-from-namespace.swift
+++ b/test/Interop/Cxx/swiftify-import/parameter-type-from-namespace.swift
@@ -81,7 +81,7 @@ __attribute__((swift_attr("@_SwiftifyImport(.countedBy(pointer: .param(1), count
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_disfavoredOverload public func bar2(_ p: Span<foo.foo_t>, _ extra: foo.foo_t) {|}}
 //   expected-remark@3{{macro content: |    let len = foo.foo_t(exactly: p.count)!|}}
-//   expected-remark@4{{macro content: |    let _pPtr = unsafe p.withUnsafeBufferPointer {|}}
+//   expected-remark@4{{macro content: |    let _pPtr = p.withUnsafeBufferPointer {|}}
 //   expected-remark@5{{macro content: |        unsafe $0|}}
 //   expected-remark@6{{macro content: |    }|}}
 //   expected-remark@7{{macro content: |    defer {|}}
@@ -100,7 +100,7 @@ namespace baz {
   //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_disfavoredOverload|}}
   //   expected-remark@3{{macro content: |public static func baz_func(_ p: Span<foo.foo_t>, _ extra: foo.foo_t) {|}}
   //   expected-remark@4{{macro content: |    let len = foo.foo_t(exactly: p.count)!|}}
-  //   expected-remark@5{{macro content: |    let _pPtr = unsafe p.withUnsafeBufferPointer {|}}
+  //   expected-remark@5{{macro content: |    let _pPtr = p.withUnsafeBufferPointer {|}}
   //   expected-remark@6{{macro content: |        unsafe $0|}}
   //   expected-remark@7{{macro content: |    }|}}
   //   expected-remark@8{{macro content: |    defer {|}}

--- a/test/Macros/SwiftifyImport/CountedBy/Anonymous.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/Anonymous.swift
@@ -49,7 +49,7 @@ public func myFunc2(_ _myFunc2_param0: UnsafeBufferPointer<CInt>, _ _myFunc2_par
 @_alwaysEmitIntoClient @_disfavoredOverload
 public func myFunc3(_ _myFunc3_param0: Span<CInt>) {
     let _myFunc3_param1 = CInt(exactly: _myFunc3_param0.count)!
-    let __myFunc3_param0Ptr = unsafe _myFunc3_param0.withUnsafeBufferPointer {
+    let __myFunc3_param0Ptr = _myFunc3_param0.withUnsafeBufferPointer {
         unsafe $0
     }
     defer {
@@ -64,7 +64,7 @@ public func myFunc3(_ _myFunc3_param0: Span<CInt>) {
 @_alwaysEmitIntoClient @_lifetime(_myFunc4_param0: copy _myFunc4_param0) @_disfavoredOverload
 public func myFunc4(_ _myFunc4_param0: inout MutableSpan<CInt>) {
     let _myFunc4_param1 = CInt(exactly: _myFunc4_param0.count)!
-    let __myFunc4_param0Ptr = unsafe _myFunc4_param0.withUnsafeMutableBufferPointer {
+    let __myFunc4_param0Ptr = _myFunc4_param0.withUnsafeMutableBufferPointer {
         unsafe $0
     }
     defer {

--- a/test/Macros/SwiftifyImport/CountedBy/ConstantCount.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/ConstantCount.swift
@@ -117,7 +117,7 @@ public func noescape(_ ptr: Span<CInt>) {
     if _ptrCount != 37 {
       fatalError("bounds check failure in noescape: expected \(37) but got \(_ptrCount)")
     }
-    let _ptrPtr = unsafe ptr.withUnsafeBufferPointer {
+    let _ptrPtr = ptr.withUnsafeBufferPointer {
         unsafe $0
     }
     defer {
@@ -135,7 +135,7 @@ public func noescapeOpt(_ ptr: Span<CInt>?) {
     if _ptrCount != 37 {
       fatalError("bounds check failure in noescapeOpt: expected \(37) but got \(_ptrCount)")
     }
-    let _ptrPtr = unsafe ptr?.withUnsafeBufferPointer {
+    let _ptrPtr = ptr?.withUnsafeBufferPointer {
         unsafe $0
     }
     defer {
@@ -153,7 +153,7 @@ public func noescapeMut(_ ptr: inout MutableSpan<CInt>) {
     if _ptrCount != 37 {
       fatalError("bounds check failure in noescapeMut: expected \(37) but got \(_ptrCount)")
     }
-    let _ptrPtr = unsafe ptr.withUnsafeMutableBufferPointer {
+    let _ptrPtr = ptr.withUnsafeMutableBufferPointer {
         unsafe $0
     }
     defer {
@@ -171,7 +171,7 @@ public func noescapeMutOpt(_ ptr: inout MutableSpan<CInt>?) {
     if _ptrCount != 37 {
       fatalError("bounds check failure in noescapeMutOpt: expected \(37) but got \(_ptrCount)")
     }
-    let _ptrPtr = unsafe ptr?.withUnsafeMutableBufferPointer {
+    let _ptrPtr = ptr?.withUnsafeMutableBufferPointer {
         unsafe $0
     }
     defer {

--- a/test/Macros/SwiftifyImport/CountedBy/MutableSpan.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/MutableSpan.swift
@@ -19,7 +19,7 @@ public func myFunc(_ ptr: UnsafeMutablePointer<CInt>, _ len: CInt) {
 @_alwaysEmitIntoClient @_lifetime(ptr: copy ptr) @_disfavoredOverload
 public func myFunc(_ ptr: inout MutableSpan<CInt>) {
     let len = CInt(exactly: ptr.count)!
-    let _ptrPtr = unsafe ptr.withUnsafeMutableBufferPointer {
+    let _ptrPtr = ptr.withUnsafeMutableBufferPointer {
         unsafe $0
     }
     defer {

--- a/test/Macros/SwiftifyImport/CountedBy/Nullable.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/Nullable.swift
@@ -41,7 +41,7 @@ public func myFunc(_ ptr: UnsafeBufferPointer<CInt>?) {
 @_alwaysEmitIntoClient @_lifetime(ptr: copy ptr) @_disfavoredOverload
 public func myFunc2(_ ptr: inout MutableSpan<CInt>?) {
     let len = CInt(exactly: ptr?.count ?? 0)!
-    let _ptrPtr = unsafe ptr?.withUnsafeMutableBufferPointer {
+    let _ptrPtr = ptr?.withUnsafeMutableBufferPointer {
         unsafe $0
     }
     defer {
@@ -57,13 +57,13 @@ public func myFunc2(_ ptr: inout MutableSpan<CInt>?) {
 public func myFunc3(_ ptr: inout MutableSpan<CInt>?, _ ptr2: inout MutableSpan<CInt>?) {
     let len = CInt(exactly: ptr?.count ?? 0)!
     let len2 = CInt(exactly: ptr2?.count ?? 0)!
-    let _ptrPtr = unsafe ptr?.withUnsafeMutableBufferPointer {
+    let _ptrPtr = ptr?.withUnsafeMutableBufferPointer {
         unsafe $0
     }
     defer {
         _fixLifetime(ptr)
     }
-    let _ptr2Ptr = unsafe ptr2?.withUnsafeMutableBufferPointer {
+    let _ptr2Ptr = ptr2?.withUnsafeMutableBufferPointer {
         unsafe $0
     }
     defer {
@@ -78,7 +78,7 @@ public func myFunc3(_ ptr: inout MutableSpan<CInt>?, _ ptr2: inout MutableSpan<C
 @_alwaysEmitIntoClient @_lifetime(copy ptr) @_lifetime(ptr: copy ptr) @_disfavoredOverload
 public func myFunc4(_ ptr: inout MutableSpan<CInt>?) -> MutableSpan<CInt>? {
     let len = CInt(exactly: ptr?.count ?? 0)!
-    let _ptrPtr = unsafe ptr?.withUnsafeMutableBufferPointer {
+    let _ptrPtr = ptr?.withUnsafeMutableBufferPointer {
         unsafe $0
     }
     defer {

--- a/test/Macros/SwiftifyImport/CountedBy/PointerReturn.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/PointerReturn.swift
@@ -52,7 +52,7 @@ public func nonEscaping(_ len: CInt) -> UnsafeBufferPointer<CInt> {
 @_alwaysEmitIntoClient @_lifetime(copy p) @_disfavoredOverload
 public func lifetimeDependentCopy(_ p: Span<CInt>, _ len2: CInt) -> Span<CInt> {
     let len1 = CInt(exactly: p.count)!
-    let _pPtr = unsafe p.withUnsafeBufferPointer {
+    let _pPtr = p.withUnsafeBufferPointer {
         unsafe $0
     }
     defer {

--- a/test/Macros/SwiftifyImport/CountedBy/Protocol.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/Protocol.swift
@@ -56,7 +56,7 @@ extension SpanProtocol {
 @_alwaysEmitIntoClient @_disfavoredOverload public
       func foo(_ ptr: Span<CInt>) {
         let len = CInt(exactly: ptr.count)!
-        let _ptrPtr = unsafe ptr.withUnsafeBufferPointer {
+        let _ptrPtr = ptr.withUnsafeBufferPointer {
             unsafe $0
         }
         defer {
@@ -79,7 +79,7 @@ extension MixedProtocol {
       /// Some doc comment
       func foo(_ ptr: Span<CInt>) {
         let len = CInt(exactly: ptr.count)!
-        let _ptrPtr = unsafe ptr.withUnsafeBufferPointer {
+        let _ptrPtr = ptr.withUnsafeBufferPointer {
             unsafe $0
         }
         defer {

--- a/test/Macros/SwiftifyImport/CountedBy/SimpleSpan.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/SimpleSpan.swift
@@ -19,7 +19,7 @@ public func myFunc(_ ptr: UnsafePointer<CInt>, _ len: CInt) {
 @_alwaysEmitIntoClient @_disfavoredOverload
 public func myFunc(_ ptr: Span<CInt>) {
     let len = CInt(exactly: ptr.count)!
-    let _ptrPtr = unsafe ptr.withUnsafeBufferPointer {
+    let _ptrPtr = ptr.withUnsafeBufferPointer {
         unsafe $0
     }
     defer {

--- a/test/Macros/SwiftifyImport/CountedBy/SimpleSpanWithReturn.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/SimpleSpanWithReturn.swift
@@ -20,7 +20,7 @@ public func myFunc(_ ptr: UnsafePointer<CInt>, _ len: CInt) -> CInt {
 @_alwaysEmitIntoClient @_disfavoredOverload
 public func myFunc(_ ptr: Span<CInt>) -> CInt {
     let len = CInt(exactly: ptr.count)!
-    let _ptrPtr = unsafe ptr.withUnsafeBufferPointer {
+    let _ptrPtr = ptr.withUnsafeBufferPointer {
         unsafe $0
     }
     defer {

--- a/test/Macros/SwiftifyImport/CountedBy/SpanAndUnsafeBuffer.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/SpanAndUnsafeBuffer.swift
@@ -20,7 +20,7 @@ public func myFunc(_ ptr1: UnsafePointer<CInt>, _ len1: CInt, _ ptr2: UnsafePoin
 public func myFunc(_ ptr1: Span<CInt>, _ ptr2: UnsafeBufferPointer<CInt>) {
     let len1 = CInt(exactly: ptr1.count)!
     let len2 = CInt(exactly: ptr2.count)!
-    let _ptr1Ptr = unsafe ptr1.withUnsafeBufferPointer {
+    let _ptr1Ptr = ptr1.withUnsafeBufferPointer {
         unsafe $0
     }
     defer {

--- a/test/Macros/SwiftifyImport/CountedBy/UnrelatedNonescapableReturn.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/UnrelatedNonescapableReturn.swift
@@ -31,7 +31,7 @@ public func myFunc2(_ ptr: UnsafeMutablePointer<CInt>, _ len: CInt, _ extraNE: i
 @_alwaysEmitIntoClient @_lifetime(copy ptr) @_disfavoredOverload
 public func myFunc(_ ptr: Span<CInt>) -> NonescapableEnum {
     let len = CInt(exactly: ptr.count)!
-    let _ptrPtr = unsafe ptr.withUnsafeBufferPointer {
+    let _ptrPtr = ptr.withUnsafeBufferPointer {
         unsafe $0
     }
     defer {
@@ -46,7 +46,7 @@ public func myFunc(_ ptr: Span<CInt>) -> NonescapableEnum {
 @_alwaysEmitIntoClient @_lifetime(copy ptr, copy extraNE) @_lifetime(ptr: copy ptr) @_lifetime(extraNE: copy extraNE) @_disfavoredOverload
 public func myFunc2(_ ptr: inout MutableSpan<CInt>, _ extraNE: inout NonescapableEnum) -> NonescapableEnum {
     let len = CInt(exactly: ptr.count)!
-    let _ptrPtr = unsafe ptr.withUnsafeMutableBufferPointer {
+    let _ptrPtr = ptr.withUnsafeMutableBufferPointer {
         unsafe $0
     }
     defer {

--- a/test/Macros/SwiftifyImport/CountedBy/Whitespace.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/Whitespace.swift
@@ -21,13 +21,13 @@ public func myFunc(_ ptr: UnsafeMutablePointer<CInt>?, _ len: CInt, _ ptr2: Unsa
 public func myFunc(_ ptr: inout MutableSpan<CInt>?, _ ptr2: inout MutableSpan<CInt>?) -> MutableSpan<CInt>? {
     let len = CInt(exactly: ptr?.count ?? 0)!
     let len2 = CInt(exactly: ptr2?.count ?? 0)!
-    let _ptrPtr = unsafe ptr?.withUnsafeMutableBufferPointer {
+    let _ptrPtr = ptr?.withUnsafeMutableBufferPointer {
         unsafe $0
     }
     defer {
         _fixLifetime(ptr)
     }
-    let _ptr2Ptr = unsafe ptr2?.withUnsafeMutableBufferPointer {
+    let _ptr2Ptr = ptr2?.withUnsafeMutableBufferPointer {
         unsafe $0
     }
     defer {

--- a/test/Macros/SwiftifyImport/CxxSpan/LifetimeboundSpan.swift
+++ b/test/Macros/SwiftifyImport/CxxSpan/LifetimeboundSpan.swift
@@ -123,7 +123,7 @@ public func myFunc6(_ span: Span<CInt>, _ ptr: RawSpan, _ count: CInt, _ size: C
     if _ptrCount != count * size {
       fatalError("bounds check failure in myFunc6: expected \(count * size) but got \(_ptrCount)")
     }
-    let _ptrPtr = unsafe ptr.withUnsafeBytes {
+    let _ptrPtr = ptr.withUnsafeBytes {
         unsafe $0
     }
     defer {
@@ -141,7 +141,7 @@ public func myFunc7(_ span: Span<CInt>, _ ptr: RawSpan, _ count: CInt, _ size: C
     if _ptrCount != count * size {
       fatalError("bounds check failure in myFunc7: expected \(count * size) but got \(_ptrCount)")
     }
-    let _ptrPtr = unsafe ptr.withUnsafeBytes {
+    let _ptrPtr = ptr.withUnsafeBytes {
         unsafe $0
     }
     defer {
@@ -159,7 +159,7 @@ public func myFunc8(_ ptr: RawSpan, _ span: Span<CInt>, _ count: CInt, _ size: C
     if _ptrCount != count * size {
       fatalError("bounds check failure in myFunc8: expected \(count * size) but got \(_ptrCount)")
     }
-    let _ptrPtr = unsafe ptr.withUnsafeBytes {
+    let _ptrPtr = ptr.withUnsafeBytes {
         unsafe $0
     }
     defer {
@@ -173,7 +173,7 @@ public func myFunc8(_ ptr: RawSpan, _ span: Span<CInt>, _ count: CInt, _ size: C
 /// This is an auto-generated wrapper for safer interop
 @_alwaysEmitIntoClient @_lifetime(copy span) @_lifetime(span: copy span) @_disfavoredOverload
 public func myFunc9(_ span: inout MutableSpan<CInt>) -> MutableSpan<CInt> {
-    return unsafe _swiftifyOverrideLifetime(MutableSpan(_unsafeCxxSpan: unsafe span.withUnsafeMutableBufferPointer { _spanPtr in
+    return unsafe _swiftifyOverrideLifetime(MutableSpan(_unsafeCxxSpan: span.withUnsafeMutableBufferPointer { _spanPtr in
       return unsafe myFunc9(MutableSpanOfInt(_spanPtr))
             }), copying: ())
 }
@@ -183,7 +183,7 @@ public func myFunc9(_ span: inout MutableSpan<CInt>) -> MutableSpan<CInt> {
 /// This is an auto-generated wrapper for safer interop
 @_alwaysEmitIntoClient @_lifetime(copy `self`) @_lifetime(`self`: copy `self`) @_disfavoredOverload
 public func myFunc10(_ `self`: inout MutableSpan<CInt>) -> MutableSpan<CInt> {
-    return unsafe _swiftifyOverrideLifetime(MutableSpan(_unsafeCxxSpan: unsafe `self`.withUnsafeMutableBufferPointer { _selfPtr in
+    return unsafe _swiftifyOverrideLifetime(MutableSpan(_unsafeCxxSpan: `self`.withUnsafeMutableBufferPointer { _selfPtr in
       return unsafe myFunc10(MutableSpanOfInt(_selfPtr))
             }), copying: ())
 }

--- a/test/Macros/SwiftifyImport/CxxSpan/NoEscapeSpan.swift
+++ b/test/Macros/SwiftifyImport/CxxSpan/NoEscapeSpan.swift
@@ -43,7 +43,7 @@ public func myFunc(_ span: Span<CInt>, _ secondSpan: SpanOfInt) {
 /// This is an auto-generated wrapper for safer interop
 @_alwaysEmitIntoClient @_lifetime(span: copy span) @_disfavoredOverload
 public func myFunc2(_ span: inout MutableSpan<CInt>, _ secondSpan: MutableSpanOfInt) {
-    return unsafe span.withUnsafeMutableBufferPointer { _spanPtr in
+    return span.withUnsafeMutableBufferPointer { _spanPtr in
       return unsafe myFunc2(MutableSpanOfInt(_spanPtr), secondSpan)
     }
 }
@@ -53,7 +53,7 @@ public func myFunc2(_ span: inout MutableSpan<CInt>, _ secondSpan: MutableSpanOf
 /// This is an auto-generated wrapper for safer interop
 @_alwaysEmitIntoClient @_lifetime(span: copy span) @_disfavoredOverload
 public func myFunc3(_ span: inout MutableSpan<CInt>, _ secondSpan: Span<CInt>) {
-    return unsafe span.withUnsafeMutableBufferPointer { _spanPtr in
+    return span.withUnsafeMutableBufferPointer { _spanPtr in
       return unsafe myFunc3(MutableSpanOfInt(_spanPtr), SpanOfInt(secondSpan))
     }
 }
@@ -63,8 +63,8 @@ public func myFunc3(_ span: inout MutableSpan<CInt>, _ secondSpan: Span<CInt>) {
 /// This is an auto-generated wrapper for safer interop
 @_alwaysEmitIntoClient @_lifetime(span: copy span) @_lifetime(secondSpan: copy secondSpan) @_disfavoredOverload
 public func myFunc4(_ span: inout MutableSpan<CInt>, _ secondSpan: inout MutableSpan<CInt>) {
-    return unsafe secondSpan.withUnsafeMutableBufferPointer { _secondSpanPtr in
-      return unsafe span.withUnsafeMutableBufferPointer { _spanPtr in
+    return secondSpan.withUnsafeMutableBufferPointer { _secondSpanPtr in
+      return span.withUnsafeMutableBufferPointer { _spanPtr in
       return unsafe myFunc4(MutableSpanOfInt(_spanPtr), MutableSpanOfInt(_secondSpanPtr))
       }
     }

--- a/test/Macros/SwiftifyImport/SizedBy/MutableRawSpan.swift
+++ b/test/Macros/SwiftifyImport/SizedBy/MutableRawSpan.swift
@@ -19,7 +19,7 @@ public func myFunc(_ ptr: UnsafeMutableRawPointer, _ size: CInt) {
 @_alwaysEmitIntoClient @_lifetime(ptr: copy ptr) @_disfavoredOverload
 public func myFunc(_ ptr: inout MutableRawSpan) {
     let size = CInt(exactly: ptr.byteCount)!
-    let _ptrPtr = unsafe ptr.withUnsafeMutableBytes {
+    let _ptrPtr = ptr.withUnsafeMutableBytes {
         unsafe $0
     }
     defer {

--- a/test/Macros/SwiftifyImport/SizedBy/Nullable.swift
+++ b/test/Macros/SwiftifyImport/SizedBy/Nullable.swift
@@ -41,7 +41,7 @@ public func myFunc(_ ptr: UnsafeRawBufferPointer?) {
 @_alwaysEmitIntoClient @_lifetime(ptr: copy ptr) @_disfavoredOverload
 public func myFunc2(_ ptr: inout MutableRawSpan?) {
     let len = CInt(exactly: ptr?.byteCount ?? 0)!
-    let _ptrPtr = unsafe ptr?.withUnsafeMutableBytes {
+    let _ptrPtr = ptr?.withUnsafeMutableBytes {
         unsafe $0
     }
     defer {
@@ -57,13 +57,13 @@ public func myFunc2(_ ptr: inout MutableRawSpan?) {
 public func myFunc3(_ ptr: inout MutableRawSpan?, _ ptr2: inout MutableRawSpan?) {
     let len = CInt(exactly: ptr?.byteCount ?? 0)!
     let len2 = CInt(exactly: ptr2?.byteCount ?? 0)!
-    let _ptrPtr = unsafe ptr?.withUnsafeMutableBytes {
+    let _ptrPtr = ptr?.withUnsafeMutableBytes {
         unsafe $0
     }
     defer {
         _fixLifetime(ptr)
     }
-    let _ptr2Ptr = unsafe ptr2?.withUnsafeMutableBytes {
+    let _ptr2Ptr = ptr2?.withUnsafeMutableBytes {
         unsafe $0
     }
     defer {
@@ -78,7 +78,7 @@ public func myFunc3(_ ptr: inout MutableRawSpan?, _ ptr2: inout MutableRawSpan?)
 @_alwaysEmitIntoClient @_lifetime(copy ptr) @_lifetime(ptr: copy ptr) @_disfavoredOverload
 public func myFunc4(_ ptr: inout MutableRawSpan?) -> MutableRawSpan? {
     let len = CInt(exactly: ptr?.byteCount ?? 0)!
-    let _ptrPtr = unsafe ptr?.withUnsafeMutableBytes {
+    let _ptrPtr = ptr?.withUnsafeMutableBytes {
         unsafe $0
     }
     defer {

--- a/test/Macros/SwiftifyImport/SizedBy/Opaque.swift
+++ b/test/Macros/SwiftifyImport/SizedBy/Opaque.swift
@@ -66,7 +66,7 @@ public func impNullableUnsafeRawBufferPointer(_ ptr: UnsafeRawBufferPointer) {
 @_alwaysEmitIntoClient @_disfavoredOverload
 public func nonnullSpan(_ ptr: RawSpan) {
     let size = CInt(exactly: ptr.byteCount)!
-    let _ptrPtr = unsafe ptr.withUnsafeBytes {
+    let _ptrPtr = ptr.withUnsafeBytes {
         unsafe $0
     }
     defer {
@@ -81,7 +81,7 @@ public func nonnullSpan(_ ptr: RawSpan) {
 @_alwaysEmitIntoClient @_disfavoredOverload
 public func nullableSpan(_ ptr: RawSpan?) {
     let size = CInt(exactly: ptr?.byteCount ?? 0)!
-    let _ptrPtr = unsafe ptr?.withUnsafeBytes {
+    let _ptrPtr = ptr?.withUnsafeBytes {
         unsafe $0
     }
     defer {
@@ -96,7 +96,7 @@ public func nullableSpan(_ ptr: RawSpan?) {
 @_alwaysEmitIntoClient @_disfavoredOverload
 public func impNullableSpan(_ ptr: RawSpan) {
     let size = CInt(exactly: ptr.byteCount)!
-    let _ptrPtr = unsafe ptr.withUnsafeBytes {
+    let _ptrPtr = ptr.withUnsafeBytes {
         unsafe $0
     }
     defer {

--- a/test/Macros/SwiftifyImport/SizedBy/OpaqueReturn.swift
+++ b/test/Macros/SwiftifyImport/SizedBy/OpaqueReturn.swift
@@ -64,7 +64,7 @@ public func impNullableUnsafeRawBufferPointer(_ size: CInt) -> UnsafeRawBufferPo
 @_alwaysEmitIntoClient @_lifetime(copy p) @_disfavoredOverload
 public func nonnullSpan(p: RawSpan) -> RawSpan {
     let size = CInt(exactly: p.byteCount)!
-    let _pPtr = unsafe p.withUnsafeBytes {
+    let _pPtr = p.withUnsafeBytes {
         unsafe $0
     }
     defer {
@@ -79,7 +79,7 @@ public func nonnullSpan(p: RawSpan) -> RawSpan {
 @_alwaysEmitIntoClient @_lifetime(copy p) @_disfavoredOverload
 public func nullableSpan(p: RawSpan?) -> RawSpan? {
     let size = CInt(exactly: p?.byteCount ?? 0)!
-    let _pPtr = unsafe p?.withUnsafeBytes {
+    let _pPtr = p?.withUnsafeBytes {
         unsafe $0
     }
     defer {
@@ -101,7 +101,7 @@ public func nullableSpan(p: RawSpan?) -> RawSpan? {
 @_alwaysEmitIntoClient @_lifetime(copy p) @_disfavoredOverload
 public func impNullableSpan(p: RawSpan) -> RawSpan {
     let size = CInt(exactly: p.byteCount)!
-    let _pPtr = unsafe p.withUnsafeBytes {
+    let _pPtr = p.withUnsafeBytes {
         unsafe $0
     }
     defer {

--- a/test/Macros/SwiftifyImport/SizedBy/PointerReturn.swift
+++ b/test/Macros/SwiftifyImport/SizedBy/PointerReturn.swift
@@ -61,7 +61,7 @@ public func nonEscaping(_ len: CInt) -> UnsafeRawBufferPointer {
 @_alwaysEmitIntoClient @_lifetime(copy p) @_disfavoredOverload
 public func lifetimeDependentCopy(_ p: RawSpan, _ len2: CInt) -> RawSpan {
     let len1 = CInt(exactly: p.byteCount)!
-    let _pPtr = unsafe p.withUnsafeBytes {
+    let _pPtr = p.withUnsafeBytes {
         unsafe $0
     }
     defer {
@@ -85,7 +85,7 @@ public func lifetimeDependentBorrow(_ p: borrowing UnsafeRawBufferPointer, _ len
 @_alwaysEmitIntoClient @_lifetime(copy p) @_lifetime(p: copy p) @_disfavoredOverload
 public func lifetimeDependentCopyMut(_ p: inout MutableRawSpan, _ len2: CInt) -> MutableRawSpan {
     let len1 = CInt(exactly: p.byteCount)!
-    let _pPtr = unsafe p.withUnsafeMutableBytes {
+    let _pPtr = p.withUnsafeMutableBytes {
         unsafe $0
     }
     defer {

--- a/test/Macros/SwiftifyImport/SizedBy/SimpleRawSpan.swift
+++ b/test/Macros/SwiftifyImport/SizedBy/SimpleRawSpan.swift
@@ -19,7 +19,7 @@ public func myFunc(_ ptr: UnsafeRawPointer, _ size: CInt) {
 @_alwaysEmitIntoClient @_disfavoredOverload
 public func myFunc(_ ptr: RawSpan) {
     let size = CInt(exactly: ptr.byteCount)!
-    let _ptrPtr = unsafe ptr.withUnsafeBytes {
+    let _ptrPtr = ptr.withUnsafeBytes {
         unsafe $0
     }
     defer {

--- a/test/Macros/SwiftifyImport/SizedBy/SimpleRawSpanWithReturn.swift
+++ b/test/Macros/SwiftifyImport/SizedBy/SimpleRawSpanWithReturn.swift
@@ -20,7 +20,7 @@ public func myFunc(_ ptr: UnsafeRawPointer, _ size: CInt) -> CInt {
 @_alwaysEmitIntoClient @_disfavoredOverload
 public func myFunc(_ ptr: RawSpan) -> CInt {
     let size = CInt(exactly: ptr.byteCount)!
-    let _ptrPtr = unsafe ptr.withUnsafeBytes {
+    let _ptrPtr = ptr.withUnsafeBytes {
         unsafe $0
     }
     defer {

--- a/test/Macros/SwiftifyImport/SizedBy/TypedPointer.swift
+++ b/test/Macros/SwiftifyImport/SizedBy/TypedPointer.swift
@@ -106,7 +106,7 @@ public func exprReturn(_ size: CInt, _ count: CInt) -> UnsafeMutableRawBufferPoi
 @_alwaysEmitIntoClient @_disfavoredOverload
 public func constParamNoreturn(_ ptr: RawSpan) {
     let size = CInt(exactly: ptr.byteCount)!
-    let _ptrPtr = unsafe ptr.withUnsafeBytes {
+    let _ptrPtr = ptr.withUnsafeBytes {
         unsafe $0
     }
     defer {
@@ -121,7 +121,7 @@ public func constParamNoreturn(_ ptr: RawSpan) {
 @_alwaysEmitIntoClient @_lifetime(ptr: copy ptr) @_disfavoredOverload
 public func mutParamNoreturn(_ ptr: inout MutableRawSpan) {
     let size = CInt(exactly: ptr.byteCount)!
-    let _ptrPtr = unsafe ptr.withUnsafeMutableBytes {
+    let _ptrPtr = ptr.withUnsafeMutableBytes {
         unsafe $0
     }
     defer {
@@ -136,7 +136,7 @@ public func mutParamNoreturn(_ ptr: inout MutableRawSpan) {
 @_alwaysEmitIntoClient @_lifetime(copy ptr) @_disfavoredOverload
 public func constReturnDependence(_ ptr: RawSpan) -> RawSpan {
     let size = CInt(exactly: ptr.byteCount)!
-    let _ptrPtr = unsafe ptr.withUnsafeBytes {
+    let _ptrPtr = ptr.withUnsafeBytes {
         unsafe $0
     }
     defer {
@@ -151,7 +151,7 @@ public func constReturnDependence(_ ptr: RawSpan) -> RawSpan {
 @_alwaysEmitIntoClient @_lifetime(copy ptr) @_lifetime(ptr: copy ptr) @_disfavoredOverload
 public func mutReturnDependence(_ ptr: inout MutableRawSpan) -> MutableRawSpan {
     let size = CInt(exactly: ptr.byteCount)!
-    let _ptrPtr = unsafe ptr.withUnsafeMutableBytes {
+    let _ptrPtr = ptr.withUnsafeMutableBytes {
         unsafe $0
     }
     defer {

--- a/test/Unsafe/unsafe_stdlib.swift
+++ b/test/Unsafe/unsafe_stdlib.swift
@@ -8,9 +8,6 @@ func test(
   other: UnsafeMutablePointer<Int>
 ) {
   var array = [1, 2, 3]
-  // expected-warning@+3{{expression uses unsafe constructs but is not marked with 'unsafe'}}{{3-3=unsafe }}
-  // expected-note@+2{{argument #0 in call to instance method 'withUnsafeBufferPointer' has unsafe type '(UnsafeBufferPointer<Int>) -> ()'}}
-  // expected-note@+1{{reference to instance method 'withUnsafeBufferPointer' involves unsafe type 'UnsafeBufferPointer<Int>'}}
   array.withUnsafeBufferPointer{ buffer in
   // expected-warning@+1{{expression uses unsafe constructs but is not marked with 'unsafe'}}{{5-5=unsafe }}
     print(buffer) // expected-note{{reference to parameter 'buffer' involves unsafe type 'UnsafeBufferPointer<Int>'}}

--- a/test/embedded/safe-interop-wrapper.swift
+++ b/test/embedded/safe-interop-wrapper.swift
@@ -17,7 +17,7 @@
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_lifetime(p: copy p) @_disfavoredOverload public func simple(_ p: inout MutableSpan<Int32>) {|}}
 //   expected-remark@3{{macro content: |    let len = Int32(exactly: p.count)!|}}
-//   expected-remark@4{{macro content: |    let _pPtr = unsafe p.withUnsafeMutableBufferPointer {|}}
+//   expected-remark@4{{macro content: |    let _pPtr = p.withUnsafeMutableBufferPointer {|}}
 //   expected-remark@5{{macro content: |        unsafe $0|}}
 //   expected-remark@6{{macro content: |    }|}}
 //   expected-remark@7{{macro content: |    defer {|}}


### PR DESCRIPTION
- **Explanation**: Functions like `withUnsafeBufferPointer` are, by themselves, safe to call. It's only the operations on the unsafe pointers passed into the closure that are the safety issue. This was the intent spelled out in SE-0458 but was not fully realized in the library.
- **Scope**: Affects a number of functions in the standard library, as well as their uses.
- **Risk**: This will remove a bunch of "unsafe" warnings on the calls to `withUnsafe(Mutable)Buffer` and friends. 
- **Issues**: rdar://174519372.
- **Testing**: CI