### PR TITLE
Fix initializing property wrapper fields in delegating inits

### DIFF
--- a/lib/SILOptimizer/Mandatory/RawSILInstLowering.cpp
+++ b/lib/SILOptimizer/Mandatory/RawSILInstLowering.cpp
@@ -193,12 +193,6 @@ lowerAssignOrInitInstruction(SILBuilderWithScope &b,
   SILBuilderWithScope forCleanup(std::next(inst->getIterator()));
 
   switch (inst->getMode()) {
-    case AssignOrInitInst::Unknown:
-      assert(b.getModule().getASTContext().hadError() &&
-             "assign_or_init must have a valid mode");
-      // In case DefiniteInitialization already gave up with an error, just
-      // treat the assign_or_init with an "init" mode.
-      LLVM_FALLTHROUGH;
     case AssignOrInitInst::Init: {
       SILValue initFn = inst->getInitializer();
       CanSILFunctionType fTy = initFn->getType().castTo<SILFunctionType>();
@@ -350,6 +344,10 @@ lowerAssignOrInitInstruction(SILBuilderWithScope &b,
       }
       break;
     }
+    case AssignOrInitInst::Unknown:
+      // "Unknown" can be the case in a delegating initializer, where self was
+      // already assigned. Therefore it can only be a "set".
+      LLVM_FALLTHROUGH;
     case AssignOrInitInst::Set: {
       SILValue setterFn = inst->getSetter();
 

--- a/test/Concurrency/flow_isolation_basic.swift
+++ b/test/Concurrency/flow_isolation_basic.swift
@@ -805,9 +805,8 @@ func testActorWithInitAccessorInit() {
       let escapingSelf: (EscapeBeforeFullInit) -> Void = { _ in }
 
       escapingSelf(self) // expected-error {{'self' used before all stored properties are initialized}}
-      // expected-note @-1 {{after a call involving 'self', only nonisolated properties of 'self' can be accessed from this init}}
 
-      self.a = v // expected-warning {{cannot access property '_a' here in nonisolated initializer; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
+      self.a = v // expected-warning {{actor-isolated property 'a' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode; this is an error in the Swift 6 language mode}}
     }
   }
 

--- a/test/SILOptimizer/di_property_wrappers.swift
+++ b/test/SILOptimizer/di_property_wrappers.swift
@@ -151,6 +151,17 @@ final class GenericClass<T : IntInitializable> {
   }
 }
 
+struct TestDelegatingInitializer {
+  @Wrapper var x: Int? = nil
+
+  init() {}
+
+  // Just check that this compiles successfully
+  init(x: Int?) {
+    self.init()
+    self.x = x
+  }
+}
 
 func testIntStruct() {
   // CHECK: ## IntStruct

--- a/test/SILOptimizer/raw_sil_inst_lowering.sil
+++ b/test/SILOptimizer/raw_sil_inst_lowering.sil
@@ -379,3 +379,43 @@ bb0(%0 : $*GenericRefStruct<T>, %1 : $*T, %2 : $@thin GenericRefStruct<T>.Type):
   %38 = tuple ()                                  // user: %39
   return %38 : $()                                // id: %39
 }
+
+@propertyWrapper struct Box<Value> {
+  @_hasStorage private var storage: AnyObject
+  var wrappedValue: Value
+}
+
+struct S {
+  @Box var x: Int?
+}
+
+sil @designated_init : $@convention(method) (@thin S.Type) -> @owned S
+sil @field_init : $@convention(thin) (Optional<Int>, @thin S.Type) -> @out Box<Optional<Int>>
+sil @field_set : $@convention(method) (Optional<Int>, @inout S) -> ()
+
+// Just check that this compiles successfully.
+sil [ossa] @test_delegating_init : $@convention(method) (Optional<Int>, @thin S.Type) -> @owned S {
+bb0(%0 : $Optional<Int>, %1 : $@thin S.Type):
+  %2 = alloc_stack [lexical] [var_decl] $S, var, name "self", type $S
+  %3 = mark_uninitialized [delegatingself] %2
+  debug_value %0, let, name "x", argno 1
+
+  %5 = function_ref @designated_init : $@convention(method) (@thin S.Type) -> @owned S
+  %6 = apply %5(%1) : $@convention(method) (@thin S.Type) -> @owned S
+  assign %6 to %3
+  %8 = begin_access [modify] [static] %3
+
+  %9 = function_ref @field_init : $@convention(thin) (Optional<Int>, @thin S.Type) -> @out Box<Optional<Int>>
+  %10 = partial_apply [callee_guaranteed] %9(%1) : $@convention(thin) (Optional<Int>, @thin S.Type) -> @out Box<Optional<Int>>
+
+  %11 = function_ref @field_set : $@convention(method) (Optional<Int>, @inout S) -> ()
+  %12 = partial_apply [callee_guaranteed] [on_stack] %11(%8) : $@convention(method) (Optional<Int>, @inout S) -> ()
+  assign_or_init #S.x, self %8, value %0, init %10, set %12
+  end_access %8
+  destroy_value %12
+  destroy_value %10
+  %17 = load [copy] %3
+  destroy_addr %3
+  dealloc_stack %2
+  return %17
+}


### PR DESCRIPTION
* **Explanation**:  DefiniteInitialization handles delegating initializers specially. In this case `assign` (for regular fields) and `assign_or_init` (for property wrappers) don't get the mode set and need to implicitly assumed to be "re-assign" (and not "init"). RawSILInstLowering did handle this correctly for `assign`, but not for `assign_or_init`. This resulted in an assert failure or - even worse - in a mis-compile with non-assert compilers.
* **Risk**: Very low. It's a simple fix which only affects code which would have failed with an assert anyway.
* **Testing**: Tested by lit tests.
* **Issue**: rdar://174758663
