### PR TITLE
🍒[cxx-interop] Fix modularization for `<cmath>` with libstdc++

### DIFF
--- a/stdlib/public/Cxx/libstdcxx/libstdcxx.modulemap
+++ b/stdlib/public/Cxx/libstdcxx/libstdcxx.modulemap
@@ -84,6 +84,12 @@ module std {
       export *
     }
 
+    module cmath {
+      header "cmath"
+      requires cplusplus
+      export *
+    }
+
     module cstdlib {
       header "cstdlib"
       requires cplusplus

--- a/test/Interop/Cxx/stdlib/Inputs/include-math.h
+++ b/test/Interop/Cxx/stdlib/Inputs/include-math.h
@@ -1,0 +1,3 @@
+#include <math.h>
+
+int getMyInt() { return 42; }

--- a/test/Interop/Cxx/stdlib/Inputs/module.modulemap
+++ b/test/Interop/Cxx/stdlib/Inputs/module.modulemap
@@ -105,3 +105,8 @@ module StdExpected {
   requires cplusplus
   export *
 }
+
+module IncludeMath {
+  header "include-math.h"
+  export *
+}

--- a/test/Interop/Cxx/stdlib/use-math.swift
+++ b/test/Interop/Cxx/stdlib/use-math.swift
@@ -1,0 +1,7 @@
+// RUN: %target-typecheck-verify-swift -I %S/Inputs -cxx-interoperability-mode=upcoming-swift
+
+// This ensures that Swift can import C/C++ modules that contain `#include <math.h>`.
+
+import IncludeMath
+
+let x = getMyInt()


### PR DESCRIPTION
**Original PR**: https://github.com/swiftlang/swift/pull/87620

<!-- Please fill out the following form: --> 
- **Explanation**:
  This fixes compiler errors on Fedora 42 and similar distros.
  `<cmath>` wasn't correctly listed in the modulemap that Swift injects into libstdc++.
- **Scope**:
  Changes the libstdc++ modulemap, which is only used on Linux.
- **Issues**:
  rdar://152032606 / resolves https://github.com/swiftlang/swift/issues/81774
- **Risk**:
  Low, this only affects Linux and has been on `main` for over a month.
- **Testing**:
  Added a compiler test + manual testing done.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
