### PR TITLE
Synchronization: Adaptive spinning on Linux

### DIFF
--- a/docs/SynchronizationMutexLinux.md
+++ b/docs/SynchronizationMutexLinux.md
@@ -1,0 +1,73 @@
+# Synchronization: Linux Mutex
+
+Implementation notes for `Synchronization.Mutex` on Linux
+(`stdlib/public/Synchronization/Mutex/LinuxImpl.swift`).
+
+The lock is a plain-futex mutex with a 3-state lock word, a bounded user-space
+spin phase, and a kernel fallback via `FUTEX_WAIT` / `FUTEX_WAKE`.
+
+## Lock word states
+
+- `.unlocked` - free.
+- `.locked` - held, no waiters parked in the kernel.
+- `.contended` - held, at least one waiter parked in the kernel. The unlock
+  path issues `FUTEX_WAKE` only when it observes this state, avoiding a syscall
+  on the uncontended path.
+
+## Tunables
+
+- `spinTries` (20): spin-phase iteration budget per `_lockSlow` entry.
+- `pauseBase` (64): CPU `pause` count per spin iteration, before jitter. Must
+  be a power of two - the jitter is derived as `cycleCounter & (pauseBase - 1)`
+  so that N concurrent spinners do not retry in lockstep.
+- `maxActiveSpinners` (4): once this many threads are already in the kernel
+  phase, new arrivals skip the spin loop and park immediately. Keeps the set
+  of actively-spinning threads bounded so the lock holder's critical section
+  runs without cache-line interference from spinners.
+
+## Lock / unlock flow
+
+```mermaid
+flowchart TD
+    subgraph lockflow ["_lock()"]
+        fastCAS{{"compareExchange(.unlocked, .locked)"}}
+        fastCAS -- "exchanged == true" --> locked([LOCKED])
+        fastCAS -- "exchanged == false" --> slow([_lockSlow])
+
+        slow --> stateCheck{"initialState == .contended?"}
+        stateCheck -- no --> spinTry
+        stateCheck -- yes --> depthCheck{"depth >= maxActiveSpinners?"}
+        depthCheck -- no --> spinTry
+        depthCheck -- yes --> parkClaim
+
+        subgraph spinloop ["spin loop (repeat while spinsRemaining > 0)"]
+            spinTry{{"compareExchange(.unlocked, .locked)"}} -- "exchanged == false, state == .locked" --> pause["pause CPU<br/>(pauseBase + per-thread jitter)"]
+            pause --> spinsCheck{"spinsRemaining -= 1<br/>spinsRemaining > 0?"}
+            spinsCheck -- yes --> spinTry
+        end
+        spinTry -- "exchanged == true" --> locked
+        spinTry -- "state == .contended" --> parkClaim
+        spinsCheck -- no --> parkClaim
+
+        subgraph parkloop ["park loop (while true)"]
+            parkClaim["storage.exchange(.contended)"] --> exchResult{"returned == .unlocked?"}
+            exchResult -- no --> inc["slowPathDepth += 1<br/>(first miss only)"]
+            inc --> wait[["_futexWait(expected: .contended)"]]
+            wait -- "woken / EAGAIN / EINTR" --> parkClaim
+        end
+        exchResult -- yes --> dec["slowPathDepth -= 1<br/>(if previously bumped)"]
+        dec --> locked
+    end
+
+    subgraph unlockflow ["_unlock()"]
+        unlockSwap{{"storage.exchange(.unlocked)"}}
+        unlockSwap -- "== .locked" --> done([done])
+        unlockSwap -- "== .contended" --> wake[["_futexWake(count: 1)"]]
+    end
+
+    wake -. wakes parker .-> wait
+
+    %% highlight loop back-edges (spin continue, park retry)
+    linkStyle 9 stroke:#ff8800,stroke-width:2px
+    linkStyle 16 stroke:#ff8800,stroke-width:2px
+```

--- a/stdlib/public/SwiftShims/swift/shims/_SynchronizationShims.h
+++ b/stdlib/public/SwiftShims/swift/shims/_SynchronizationShims.h
@@ -32,6 +32,10 @@ static inline __swift_uint32_t _swift_stdlib_gettid() {
   return tid;
 }
 
+// The three `_swift_stdlib_futex_lock` / `_trylock` / `_unlock` helpers below are the PI-futex shims used by the previous
+// Mutex implementation on Linux; the current plain-futex implementation in LinuxImpl.swift no longer calls them. They are
+// retained here only to minimize the diff against the prior header surface - being `static inline`, unused copies carry no
+// link-time cost. Safe to delete if a later cleanup pass wants to drop them.
 static inline __swift_uint32_t _swift_stdlib_futex_lock(__swift_uint32_t *lock) {
   int ret = syscall(SYS_futex, lock, FUTEX_LOCK_PI_PRIVATE,
                     /* val */ 0, // this value is ignored by this futex op
@@ -59,6 +63,34 @@ static inline __swift_uint32_t _swift_stdlib_futex_unlock(__swift_uint32_t *lock
 
   if (ret == 0) {
     return ret;
+  }
+
+  return errno;
+}
+
+// Plain-futex wait: sleeps if *addr == expected. Returns 0 on success
+// (woken by FUTEX_WAKE) or the errno value (EAGAIN=11, EINTR=4 are the
+// expected retryable cases).
+static inline __swift_uint32_t _swift_stdlib_futex_wait(
+    __swift_uint32_t *addr, __swift_uint32_t expected) {
+  int ret = syscall(SYS_futex, addr, FUTEX_WAIT_PRIVATE, expected,
+                    /* timeout */ NULL);
+
+  if (ret == 0) {
+    return 0;
+  }
+
+  return errno;
+}
+
+// Plain-futex wake: wakes up to `count` waiters parked on `addr`.
+// Returns the number woken on success, or the errno value on failure.
+static inline __swift_uint32_t _swift_stdlib_futex_wake(
+    __swift_uint32_t *addr, __swift_uint32_t count) {
+  int ret = syscall(SYS_futex, addr, FUTEX_WAKE_PRIVATE, count);
+
+  if (ret >= 0) {
+    return (__swift_uint32_t)ret;
   }
 
   return errno;

--- a/stdlib/public/SwiftShims/swift/shims/_SynchronizationShims.h
+++ b/stdlib/public/SwiftShims/swift/shims/_SynchronizationShims.h
@@ -32,42 +32,6 @@ static inline __swift_uint32_t _swift_stdlib_gettid() {
   return tid;
 }
 
-// The three `_swift_stdlib_futex_lock` / `_trylock` / `_unlock` helpers below are the PI-futex shims used by the previous
-// Mutex implementation on Linux; the current plain-futex implementation in LinuxImpl.swift no longer calls them. They are
-// retained here only to minimize the diff against the prior header surface - being `static inline`, unused copies carry no
-// link-time cost. Safe to delete if a later cleanup pass wants to drop them.
-static inline __swift_uint32_t _swift_stdlib_futex_lock(__swift_uint32_t *lock) {
-  int ret = syscall(SYS_futex, lock, FUTEX_LOCK_PI_PRIVATE,
-                    /* val */ 0, // this value is ignored by this futex op
-                    /* timeout */ NULL); // block indefinitely
-
-  if (ret == 0) {
-    return ret;
-  }
-
-  return errno;
-}
-
-static inline __swift_uint32_t _swift_stdlib_futex_trylock(__swift_uint32_t *lock) {
-  int ret = syscall(SYS_futex, lock, FUTEX_TRYLOCK_PI);
-
-  if (ret == 0) {
-    return ret;
-  }
-
-  return errno;
-}
-
-static inline __swift_uint32_t _swift_stdlib_futex_unlock(__swift_uint32_t *lock) {
-  int ret = syscall(SYS_futex, lock, FUTEX_UNLOCK_PI_PRIVATE);
-
-  if (ret == 0) {
-    return ret;
-  }
-
-  return errno;
-}
-
 // Plain-futex wait: sleeps if *addr == expected. Returns 0 on success
 // (woken by FUTEX_WAKE) or the errno value (EAGAIN=11, EINTR=4 are the
 // expected retryable cases).

--- a/stdlib/public/Synchronization/Mutex/LinuxImpl.swift
+++ b/stdlib/public/Synchronization/Mutex/LinuxImpl.swift
@@ -19,6 +19,18 @@ import Musl
 import Glibc
 #endif
 
+@_extern(c, "llvm.readcyclecounter")
+internal func _readCycleCounter() -> UInt64
+
+@inline(__always)
+internal func _cycleCounter() -> UInt64 {
+#if arch(i386) || arch(x86_64)
+  return _readCycleCounter()
+#else
+  return 0
+#endif
+}
+
 extension Atomic where Value == _MutexHandle.State {
   // Sleeps while the underlying word equals `expected`. Returns 0 on a normal
   // wake or the errno value (EAGAIN=11 and EINTR=4 are the expected retryable
@@ -53,13 +65,31 @@ public struct _MutexHandle: ~Copyable {
   @usableFromInline
   let storage: Atomic<State>
 
+  // Approximate count of threads currently in `_lockSlow`'s kernel phase. Read by the entry depth gate;
+  // inexact (e.g. counts briefly run between wake and retry), but used only as a hint.
+  @usableFromInline
+  let slowPathDepth: Atomic<UInt32>
+
   @available(SwiftStdlib 6.0, *)
   @_alwaysEmitIntoClient
   @_transparent
   public init() {
     storage = Atomic(.unlocked)
+    slowPathDepth = Atomic(0)
   }
 }
+
+// Spin-phase iteration budget.
+private let spinTries: Int = 20
+
+// CPU pauses per spin iteration, before jitter. Must be a power of two (masked to generate the jitter via
+// `jitter & (pauseBase - 1)`).
+private let pauseBase: UInt32 = 64
+
+// Once this many threads are already waiting for the lock, new arrivals skip the spin loop and go to sleep
+// immediately. Keeps the set of actively-spinning threads bounded so the lock holder's critical section runs
+// without cache-line interference from the spinners.
+private let maxActiveSpinners: UInt32 = 4
 
 @available(SwiftStdlib 6.0, *)
 extension _MutexHandle {
@@ -82,40 +112,34 @@ extension _MutexHandle {
     _lockSlow(0)
   }
 
-  // Slow path for `_lock`: runs a bounded adaptive spin, then parks in the kernel via FUTEX_WAIT. The spin is adaptive in two
-  // senses: the number of CPU pauses issued per iteration grows exponentially round-to-round, and its upper bound is
-  // re-chosen each iteration from the lock state we just observed. The exact upper-bound values and reasoning are inline at
-  // the `maxPauseCount` declaration below.
+  // Slow path for `_lock`:
+  //   - Depth gate: if the queue is already deep, skip straight to parking. Bounds tail latency and keeps the spinner
+  //     pool small so the owner's critical section runs uncontested.
+  //   - Spin: bounded pause-based spin with per-thread jitter. Stops early if the lock is observed contended, so we
+  //     don't steal it from a thread the kernel is about to wake.
+  //   - Kernel: loop try-acquire plus FUTEX_WAIT until acquired. A thread that has to park bumps `slowPathDepth` on
+  //     its first failed try-acquire and drops it on successful acquire. This feeds the depth gate: once enough
+  //     threads are parked, new arrivals skip spinning and park directly, which stops spinners from stealing the
+  //     lock out from under parked threads and bounds tail latency. Threads that win the initial try-acquire never
+  //     touch the counter.
   //
-  // `selfId` is retained only to preserve the mangled ABI symbol for clients compiled against the previous PI-futex
-  // implementation; the plain-futex code has no need for a thread id.
+  // `selfId` is retained only to preserve the mangled ABI symbol from the prior PI-futex implementation.
   @available(SwiftStdlib 6.0, *)
   @usableFromInline
   internal borrowing func _lockSlow(_ selfId: UInt32) {
-    // Before relinquishing control to the kernel to block this particular
-    // thread, run a little spin lock to keep this thread busy in the scenario
-    // where the current owner thread's critical section is somewhat quick. We
-    // avoid a lot of the syscall overhead in these cases which allow both the
-    // owner thread and this current thread to do the user-space atomic for
-    // releasing and acquiring (assuming no existing waiters).
-    do {
-      // Total spin-loop iterations we are willing to run before giving up and asking the kernel to park us.
-      var spinsRemaining: Int = 14
+    // Skip the spin when the queue is already deep - extra spinners just slow down the parked threads' handoff.
+    let initialState = storage.load(ordering: .acquiring)
+    let depth = slowPathDepth.load(ordering: .acquiring)
+    let skipSpin = (initialState == .contended) && (depth >= maxActiveSpinners)
 
-      // Number of `_spinLoopHint()` CPU pauses we will issue on the current iteration before re-checking the lock word.
-      // Grows exponentially (4 -> 8 -> 16 -> 32) up to the per-iteration `maxPauseCount`. The initial value of 4 is a floor
-      // chosen over 1 to skip the first few iterations where the lock state has not yet had time to change and tight
-      // back-to-back loads would generate wasted cache traffic for no information gain.
-      var pauseCount: UInt32 = 4
+    if !skipSpin {
+      // Cycle-counter low bits provide per-thread jitter to de-correlate pause timings across threads released
+      // together by a lock handoff.
+      let jitter = UInt32(truncatingIfNeeded: _cycleCounter())
+      let mask = pauseBase &- 1
+      var spinsRemaining = spinTries
 
-      repeat {
-        // Do a relaxed load of the futex value to prevent introducing a memory
-        // barrier on each iteration of this loop. We're already informing the
-        // CPU that this is a spin loop via the '_spinLoopHint' call which
-        // should hopefully slow down the loop a considerable amount to view an
-        // actually change in the value potentially. An extra memory barrier
-        // would make it even slower on top of the fact that we may not even be
-        // able to attempt to acquire the lock.
+      while spinsRemaining > 0 {
         let state = storage.load(ordering: .relaxed)
 
         if state == .unlocked, storage.compareExchange(
@@ -128,52 +152,38 @@ extension _MutexHandle {
           return
         }
 
-        spinsRemaining &-= 1
-
-        // Upper bound on `pauseCount` for this iteration - i.e. the maximum number of `_spinLoopHint()` CPU pauses we will
-        // issue before re-checking the lock word. Chosen per iteration from the state we just observed:
-        //
-        //   state == contended (at least one waiter is parked in the kernel):
-        //     maxPauseCount = 6.
-        //     Short pauses let us re-check the lock word often enough to catch the narrow release window when the owner
-        //     unlocks, before the kernel wakes the parked waiter.
-        //
-        //   state == locked, or state == unlocked but our CAS just lost:
-        //     maxPauseCount = 32.
-        //     Long pauses give the owner (or the thread that just beat us to the CAS) CPU time to finish its critical
-        //     section, and avoid generating exclusive-state cache traffic that would fight the owner's access to the lock.
-        let maxPauseCount: UInt32 = (state == .contended) ? 6 : 32
+        // Don't steal the lock from a thread the kernel is about to wake.
+        if state == .contended { break }
 
         // Inform the CPU that we're doing a spin loop which should have the
         // effect of slowing down this loop if only by a little to preserve
         // energy.
-        for _ in 0 ..< pauseCount {
+        let pauses = pauseBase &+ (jitter & mask)
+        for _ in 0 ..< pauses {
           _spinLoopHint()
         }
 
-        if pauseCount < maxPauseCount {
-          // Exponential doubling to back off.
-          pauseCount &<<= 1
-        } else if pauseCount > maxPauseCount {
-          // The cap just dropped - e.g. the lock state flipped from `locked` to `contended` on this iteration, so
-          // `maxPauseCount` went from 32 down to 6 while `pauseCount` had already grown to 8, 16, or 32. Force `pauseCount`
-          // back down to the new ceiling so the short-pause budget takes effect on the very next iteration.
-          pauseCount = maxPauseCount
-        }
-      } while spinsRemaining > 0
+        spinsRemaining -= 1
+      }
     }
 
-    // We've exhausted our spins. Mark the lock contended and ask the kernel to block for us until the owner releases.
-    //
-    // exchange(contended) marks the lock "has waiters" unconditionally. If the previous value was `unlocked` the owner released
-    // between our last spin iteration and this exchange - we have just acquired (the next unlock will emit one spurious
-    // FUTEX_WAKE, which is harmless). Otherwise the lock is still held and `*word == contended`, so the next unlock is
-    // guaranteed to wake us.
+    var visibleToSpinners = false
+
     while true {
-      let prev = storage.exchange(.contended, ordering: .acquiring)
-      if prev == .unlocked {
+      // `.contended`, not `.locked`: parked threads exist and must be woken by the next unlock.
+      if storage.exchange(.contended, ordering: .acquiring) == .unlocked {
+        if visibleToSpinners {
+          _ = slowPathDepth.wrappingSubtract(1, ordering: .relaxed)
+        }
         // Locked!
         return
+      }
+
+      // Didn't get the lock - either it's still held, or we were woken but a spinner / fast-path arrival got in first.
+      if !visibleToSpinners {
+        // Make arriving threads park instead of spinning, so parked threads can make progress.
+        _ = slowPathDepth.wrappingAdd(1, ordering: .relaxed)
+        visibleToSpinners = true
       }
 
       // Sleep while `*word == contended`. Returns 0 on a normal wake from FUTEX_WAKE, or an errno for retryable cases.
@@ -196,8 +206,8 @@ extension _MutexHandle {
   @_alwaysEmitIntoClient
   @_transparent
   internal borrowing func _tryLock() -> Bool {
-    // Do a user space cmpxchg to see if we can easily acquire the lock. The lock word goes from `unlocked` directly to
-    // `locked` on success - there is no intermediate state and no kernel involvement.
+    // Userspace CAS unlocked -> locked. Plain futex has no kernel-side recovery path, so if the CAS fails the lock is
+    // held by someone else and no retry can change that.
     if storage.compareExchange(
       expected: .unlocked,
       desired: .locked,
@@ -208,17 +218,13 @@ extension _MutexHandle {
       return true
     }
 
-    // The CAS failed, so the lock is currently held by someone else. Plain futex has no kernel-side recovery path that could
-    // change that answer, so fall through to `_tryLockSlow` which just returns false.
     return _tryLockSlow()
   }
 
   @available(SwiftStdlib 6.0, *)
   @usableFromInline
   internal borrowing func _tryLockSlow() -> Bool {
-    // Retained for ABI compatibility with clients compiled against the prior PI-futex implementation whose inlined `_tryLock`
-    // bodies reference this mangled symbol. Plain futex has no kernel-side trylock recovery path, so if the userspace CAS in
-    // `_tryLock` failed the lock is simply held by someone else.
+    // Retained only to preserve the mangled ABI symbol from the prior PI-futex implementation.
     return false
   }
 
@@ -238,9 +244,7 @@ extension _MutexHandle {
   @available(SwiftStdlib 6.0, *)
   @usableFromInline
   internal borrowing func _unlockSlow() {
-    // Wake exactly one parked waiter. Any other parked waiters, plus threads still spinning on the acquire path, will
-    // compete for the lock on the next release. FUTEX_WAKE's return value (count actually woken) is not needed here - a
-    // wake targeting an already-departed waiter is harmless.
+    // Wake exactly one parked waiter. Remaining parkers and newly-arriving spinners compete on the next release.
     _ = storage._futexWake(count: 1)
   }
 }

--- a/stdlib/public/Synchronization/Mutex/LinuxImpl.swift
+++ b/stdlib/public/Synchronization/Mutex/LinuxImpl.swift
@@ -36,12 +36,12 @@ internal func _cycleCounter() -> UInt64 {
 #endif
 }
 
-extension Atomic where Value == _MutexHandle.State {
+extension Atomic where Value == UInt32 {
   // Sleeps while the underlying word equals `expected`. Returns 0 on a normal
   // wake or the errno value (`EAGAIN=11` and `EINTR=4` are the expected retryable
   // cases).
-  internal borrowing func _futexWait(expected: _MutexHandle.State) -> UInt32 {
-    unsafe _swift_stdlib_futex_wait(.init(_rawAddress), expected.rawValue)
+  internal borrowing func _futexWait(expected: UInt32) -> UInt32 {
+    unsafe _swift_stdlib_futex_wait(.init(_rawAddress), expected)
   }
 
   // Wakes up to `count` waiters parked on this word. Result is the number
@@ -51,24 +51,18 @@ extension Atomic where Value == _MutexHandle.State {
   }
 }
 
-@available(SwiftStdlib 6.0, *)
-extension _MutexHandle {
-  @available(SwiftStdlib 6.0, *)
-  @frozen
-  @usableFromInline
-  internal enum State: UInt32, AtomicRepresentable {
-    case unlocked
-    case locked      // held, no waiters parked in the kernel
-    case contended   // held, at least one waiter parked in the kernel
-  }
-}
 
 @available(SwiftStdlib 6.0, *)
 @frozen
 @_staticExclusiveOnly
 public struct _MutexHandle: ~Copyable {
+  // Lock word states.
+  @usableFromInline internal static var unlocked:  UInt32 { 0 } // no owner
+  @usableFromInline internal static var locked:    UInt32 { 1 } // held, no waiters parked in kernel
+  @usableFromInline internal static var contended: UInt32 { 2 } // held, at least one waiter parked in kernel
+
   @usableFromInline
-  let storage: Atomic<State>
+  let storage: Atomic<UInt32>
 
   // Approximate count of threads currently in `_lockSlow`'s kernel phase. Read by the entry depth gate;
   // inexact (e.g. counts briefly run between wake and retry), but used only as a hint.
@@ -79,7 +73,7 @@ public struct _MutexHandle: ~Copyable {
   @_alwaysEmitIntoClient
   @_transparent
   public init() {
-    storage = Atomic(.unlocked)
+    storage = Atomic(0)
     slowPathDepth = Atomic(0)
   }
 }
@@ -103,8 +97,8 @@ extension _MutexHandle {
   @_transparent
   internal borrowing func _lock() {
     let (exchanged, _) = storage.compareExchange(
-      expected: .unlocked,
-      desired: .locked,
+      expected: Self.unlocked,
+      desired: Self.locked,
       successOrdering: .acquiring,
       failureOrdering: .relaxed
     )
@@ -140,7 +134,7 @@ extension _MutexHandle {
     // Skip the spin when the queue is already deep - extra spinners just slow down the parked threads' handoff.
     let initialState = storage.load(ordering: .relaxed)
     let depth = slowPathDepth.load(ordering: .relaxed)
-    let skipSpin = (initialState == .contended) && (depth >= maxActiveSpinners)
+    let skipSpin = (initialState == Self.contended) && (depth >= maxActiveSpinners)
 
     if !skipSpin {
       // Cycle-counter low bits provide per-thread jitter to de-correlate pause timings across threads released
@@ -159,10 +153,10 @@ extension _MutexHandle {
         // able to attempt to acquire the lock.
         var state = storage.load(ordering: .relaxed)
 
-        if state == .unlocked {
+        if state == Self.unlocked {
           let (exchanged, original) = storage.compareExchange(
-            expected: .unlocked,
-            desired: .locked,
+            expected: Self.unlocked,
+            desired: Self.locked,
             successOrdering: .acquiring,
             failureOrdering: .relaxed
           )
@@ -170,13 +164,13 @@ extension _MutexHandle {
             // Locked!
             return
           }
-          // CAS failed: another thread beat us to `.locked`, or a thread in the kernel phase wrote `.contended`.
+          // CAS failed: another thread beat us to `locked`, or a thread in the kernel phase wrote `contended`.
           // Refresh state with what we actually observed so the check below sees it.
           state = original
         }
 
         // Don't steal the lock from a thread the kernel is about to wake.
-        if state == .contended { break }
+        if state == Self.contended { break }
 
         // Inform the CPU that we're doing a spin loop which should have the
         // effect of slowing down this loop if only by a little to preserve
@@ -199,7 +193,7 @@ extension _MutexHandle {
       // Runs unconditionally, even on the skipSpin path: this exchange sometimes grabs the lock
       // (when the unlocker released during the gate->kernel transit), cheaper than forcing every
       // gated thread through a `futex_wait` + wake round-trip.
-      if storage.exchange(.contended, ordering: .acquiring) == .unlocked {
+      if storage.exchange(Self.contended, ordering: .acquiring) == Self.unlocked {
         if visibleToSpinners {
           _ = slowPathDepth.wrappingSubtract(1, ordering: .relaxed)
         }
@@ -215,7 +209,7 @@ extension _MutexHandle {
       }
 
       // Sleep while `*word == .contended`. Returns 0 on a normal wake from `FUTEX_WAKE`, or an errno for retryable cases.
-      let waitResult = storage._futexWait(expected: .contended)
+      let waitResult = storage._futexWait(expected: Self.contended)
       switch waitResult {
       // `EINTR`  - "A `FUTEX_WAIT` or `FUTEX_WAIT_BITSET` operation was interrupted
       //             by a signal (see signal(7)). Before Linux 2.6.22, this error
@@ -240,8 +234,8 @@ extension _MutexHandle {
   internal borrowing func _tryLock() -> Bool {
     // Do a user space cmpxchg to see if we can easily acquire the lock.
     return storage.compareExchange(
-      expected: .unlocked,
-      desired: .locked,
+      expected: Self.unlocked,
+      desired: Self.locked,
       successOrdering: .acquiring,
       failureOrdering: .relaxed
     ).exchanged
@@ -252,7 +246,7 @@ extension _MutexHandle {
   @_transparent
   internal borrowing func _unlock() {
     // Release the lock atomically in userspace. Previous value tells us whether anyone is parked.
-    if storage.exchange(.unlocked, ordering: .releasing) == .locked {
+    if storage.exchange(Self.unlocked, ordering: .releasing) == Self.locked {
       // No waiters, unlocked!
       return
     }

--- a/stdlib/public/Synchronization/Mutex/LinuxImpl.swift
+++ b/stdlib/public/Synchronization/Mutex/LinuxImpl.swift
@@ -9,6 +9,55 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
+//
+// Plain-futex Mutex: 3-state lock word, bounded spin, kernel fallback.
+//
+// ```mermaid
+// flowchart TD
+//     subgraph lockflow ["_lock()"]
+//         fastCAS{{"compareExchange(.unlocked, .locked)"}}
+//         fastCAS -- "exchanged == true" --> locked([LOCKED])
+//         fastCAS -- "exchanged == false" --> slow([_lockSlow])
+//
+//         slow --> stateCheck{"initialState == .contended?"}
+//         stateCheck -- no --> spinTry
+//         stateCheck -- yes --> depthCheck{"depth >= maxActiveSpinners?"}
+//         depthCheck -- no --> spinTry
+//         depthCheck -- yes --> parkClaim
+//
+//         subgraph spinloop ["spin loop (repeat while spinsRemaining > 0)"]
+//             spinTry{{"compareExchange(.unlocked, .locked)"}} -- "exchanged == false, state == .locked" --> pause["pause CPU<br/>(pauseBase + per-thread jitter)"]
+//             pause --> spinsCheck{"spinsRemaining -= 1<br/>spinsRemaining > 0?"}
+//             spinsCheck -- yes --> spinTry
+//         end
+//         spinTry -- "exchanged == true" --> locked
+//         spinTry -- "state == .contended" --> parkClaim
+//         spinsCheck -- no --> parkClaim
+//
+//         subgraph parkloop ["park loop (while true)"]
+//             parkClaim["storage.exchange(.contended)"] --> exchResult{"returned == .unlocked?"}
+//             exchResult -- no --> inc["slowPathDepth += 1<br/>(first miss only)"]
+//             inc --> wait[["_futexWait(expected: .contended)"]]
+//             wait -- "woken / EAGAIN / EINTR" --> parkClaim
+//         end
+//         exchResult -- yes --> dec["slowPathDepth -= 1<br/>(if previously bumped)"]
+//         dec --> locked
+//     end
+//
+//     subgraph unlockflow ["_unlock()"]
+//         unlockSwap{{"storage.exchange(.unlocked)"}}
+//         unlockSwap -- "== .locked" --> done([done])
+//         unlockSwap -- "== .contended" --> wake[["_futexWake(count: 1)"]]
+//     end
+//
+//     wake -. wakes parker .-> wait
+//
+//     %% highlight loop back-edges (spin continue, park retry)
+//     linkStyle 9 stroke:#ff8800,stroke-width:2px
+//     linkStyle 16 stroke:#ff8800,stroke-width:2px
+// ```
+//
+//===----------------------------------------------------------------------===//
 
 import _SynchronizationShims
 #if canImport(Android)
@@ -33,7 +82,7 @@ internal func _cycleCounter() -> UInt64 {
 
 extension Atomic where Value == _MutexHandle.State {
   // Sleeps while the underlying word equals `expected`. Returns 0 on a normal
-  // wake or the errno value (EAGAIN=11 and EINTR=4 are the expected retryable
+  // wake or the errno value (`EAGAIN=11` and `EINTR=4` are the expected retryable
   // cases).
   internal borrowing func _futexWait(expected: _MutexHandle.State) -> UInt32 {
     unsafe _swift_stdlib_futex_wait(.init(_rawAddress), expected.rawValue)
@@ -80,16 +129,16 @@ public struct _MutexHandle: ~Copyable {
 }
 
 // Spin-phase iteration budget.
-private let spinTries: Int = 20
+private var spinTries: UInt32 { 20 }
 
 // CPU pauses per spin iteration, before jitter. Must be a power of two (masked to generate the jitter via
 // `jitter & (pauseBase - 1)`).
-private let pauseBase: UInt32 = 64
+private var pauseBase: UInt32 { 64 }
 
 // Once this many threads are already waiting for the lock, new arrivals skip the spin loop and go to sleep
 // immediately. Keeps the set of actively-spinning threads bounded so the lock holder's critical section runs
 // without cache-line interference from the spinners.
-private let maxActiveSpinners: UInt32 = 4
+private var maxActiveSpinners: UInt32 { 4 }
 
 @available(SwiftStdlib 6.0, *)
 extension _MutexHandle {
@@ -109,7 +158,7 @@ extension _MutexHandle {
       return
     }
 
-    _lockSlow(0)
+    _lockSlow()
   }
 
   // Slow path for `_lock`:
@@ -117,16 +166,14 @@ extension _MutexHandle {
   //     pool small so the owner's critical section runs uncontested.
   //   - Spin: bounded pause-based spin with per-thread jitter. Stops early if the lock is observed contended, so we
   //     don't steal it from a thread the kernel is about to wake.
-  //   - Kernel: loop try-acquire plus FUTEX_WAIT until acquired. A thread that has to park bumps `slowPathDepth` on
+  //   - Kernel: loop try-acquire plus `FUTEX_WAIT` until acquired. A thread that has to park bumps `slowPathDepth` on
   //     its first failed try-acquire and drops it on successful acquire. This feeds the depth gate: once enough
   //     threads are parked, new arrivals skip spinning and park directly, which stops spinners from stealing the
   //     lock out from under parked threads and bounds tail latency. Threads that win the initial try-acquire never
   //     touch the counter.
-  //
-  // `selfId` is retained only to preserve the mangled ABI symbol from the prior PI-futex implementation.
   @available(SwiftStdlib 6.0, *)
   @usableFromInline
-  internal borrowing func _lockSlow(_ selfId: UInt32) {
+  internal borrowing func _lockSlow() {
     // Before relinquishing control to the kernel to block this particular
     // thread, run a little spin lock to keep this thread busy in the scenario
     // where the current owner thread's critical section is somewhat quick. We
@@ -135,8 +182,8 @@ extension _MutexHandle {
     // releasing and acquiring (assuming no existing waiters).
 
     // Skip the spin when the queue is already deep - extra spinners just slow down the parked threads' handoff.
-    let initialState = storage.load(ordering: .acquiring)
-    let depth = slowPathDepth.load(ordering: .acquiring)
+    let initialState = storage.load(ordering: .relaxed)
+    let depth = slowPathDepth.load(ordering: .relaxed)
     let skipSpin = (initialState == .contended) && (depth >= maxActiveSpinners)
 
     if !skipSpin {
@@ -154,16 +201,22 @@ extension _MutexHandle {
         // actually change in the value potentially. An extra memory barrier
         // would make it even slower on top of the fact that we may not even be
         // able to attempt to acquire the lock.
-        let state = storage.load(ordering: .relaxed)
+        var state = storage.load(ordering: .relaxed)
 
-        if state == .unlocked, storage.compareExchange(
-          expected: .unlocked,
-          desired: .locked,
-          successOrdering: .acquiring,
-          failureOrdering: .relaxed
-        ).exchanged {
-          // Locked!
-          return
+        if state == .unlocked {
+          let (exchanged, original) = storage.compareExchange(
+            expected: .unlocked,
+            desired: .locked,
+            successOrdering: .acquiring,
+            failureOrdering: .relaxed
+          )
+          if exchanged {
+            // Locked!
+            return
+          }
+          // CAS failed: another thread beat us to `.locked`, or a thread in the kernel phase wrote `.contended`.
+          // Refresh state with what we actually observed so the check below sees it.
+          state = original
         }
 
         // Don't steal the lock from a thread the kernel is about to wake.
@@ -181,10 +234,17 @@ extension _MutexHandle {
       } while spinsRemaining > 0
     }
 
-    // We've exhausted our spins. Ask the kernel to block for us until the owner releases the lock.
+    // We've exhausted our spins (or the depth gate told us to skip them). Ask the kernel to block for us until the
+    // owner releases the lock.
     var visibleToSpinners = false
 
     while true {
+      // Always attempt the exchange first, even when the depth gate fired. The gate's relaxed load can race ahead
+      // of an owner release; skipping this exchange turned ~1200/iter cheap first-try wins into `FUTEX_WAIT`
+      // roundtrips that returned `EAGAIN` (word had already moved off `.contended`) and then re-acquired via the
+      // next iteration's exchange anyway. Measured ~20% regression at t=32. The one RMW on the owner's cache
+      // line is cheaper than the wasted syscall.
+      //
       // `.contended`, not `.locked`: parked threads exist and must be woken by the next unlock.
       if storage.exchange(.contended, ordering: .acquiring) == .unlocked {
         if visibleToSpinners {
@@ -201,16 +261,16 @@ extension _MutexHandle {
         visibleToSpinners = true
       }
 
-      // Sleep while `*word == contended`. Returns 0 on a normal wake from FUTEX_WAKE, or an errno for retryable cases.
+      // Sleep while `*word == .contended`. Returns 0 on a normal wake from `FUTEX_WAKE`, or an errno for retryable cases.
       let waitResult = storage._futexWait(expected: .contended)
       switch waitResult {
-      // EINTR  - "A FUTEX_WAIT or FUTEX_WAIT_BITSET operation was interrupted
-      //           by a signal (see signal(7)). Before Linux 2.6.22, this error
-      //           could also be returned for a spurious wakeup; since Linux
-      //           2.6.22, this no longer happens."
-      // EAGAIN - "The expected value specified by val did not match the value
-      //           in the futex word"; another thread unlocked in the window
-      //           between our `exchange(.contended)` and the syscall.
+      // `EINTR`  - "A `FUTEX_WAIT` or `FUTEX_WAIT_BITSET` operation was interrupted
+      //             by a signal (see signal(7)). Before Linux 2.6.22, this error
+      //             could also be returned for a spurious wakeup; since Linux
+      //             2.6.22, this no longer happens."
+      // `EAGAIN` - "The expected value specified by val did not match the value
+      //             in the futex word"; another thread unlocked in the window
+      //             between our `exchange(.contended)` and the syscall.
       case 0, 11, 4:
         continue
 
@@ -226,37 +286,25 @@ extension _MutexHandle {
   @_transparent
   internal borrowing func _tryLock() -> Bool {
     // Do a user space cmpxchg to see if we can easily acquire the lock.
-    if storage.compareExchange(
+    return storage.compareExchange(
       expected: .unlocked,
       desired: .locked,
       successOrdering: .acquiring,
       failureOrdering: .relaxed
-    ).exchanged {
-      // Locked!
-      return true
-    }
-
-    return _tryLockSlow()
-  }
-
-  @available(SwiftStdlib 6.0, *)
-  @usableFromInline
-  internal borrowing func _tryLockSlow() -> Bool {
-    // Retained only to preserve the mangled ABI symbol from the prior PI-futex implementation.
-    return false
+    ).exchanged
   }
 
   @available(SwiftStdlib 6.0, *)
   @_alwaysEmitIntoClient
   @_transparent
   internal borrowing func _unlock() {
-    // Attempt to release the lock atomically in userspace. If there are waiters we must inform the kernel via
-    // FUTEX_WAKE.
-    guard storage.exchange(.unlocked, ordering: .releasing) == .contended else {
+    // Release the lock atomically in userspace. Previous value tells us whether anyone is parked.
+    if storage.exchange(.unlocked, ordering: .releasing) == .locked {
       // No waiters, unlocked!
       return
     }
 
+    // At least one waiter parked in the kernel; wake one via `FUTEX_WAKE`.
     _unlockSlow()
   }
 

--- a/stdlib/public/Synchronization/Mutex/LinuxImpl.swift
+++ b/stdlib/public/Synchronization/Mutex/LinuxImpl.swift
@@ -239,13 +239,10 @@ extension _MutexHandle {
     var visibleToSpinners = false
 
     while true {
-      // Always attempt the exchange first, even when the depth gate fired. The gate's relaxed load can race ahead
-      // of an owner release; skipping this exchange turned ~1200/iter cheap first-try wins into `FUTEX_WAIT`
-      // roundtrips that returned `EAGAIN` (word had already moved off `.contended`) and then re-acquired via the
-      // next iteration's exchange anyway. Measured ~20% regression at t=32. The one RMW on the owner's cache
-      // line is cheaper than the wasted syscall.
-      //
       // `.contended`, not `.locked`: parked threads exist and must be woken by the next unlock.
+      // Runs unconditionally, even on the skipSpin path: this exchange sometimes grabs the lock
+      // (when the unlocker released during the gate->kernel transit), cheaper than forcing every
+      // gated thread through a `futex_wait` + wake round-trip.
       if storage.exchange(.contended, ordering: .acquiring) == .unlocked {
         if visibleToSpinners {
           _ = slowPathDepth.wrappingSubtract(1, ordering: .relaxed)

--- a/stdlib/public/Synchronization/Mutex/LinuxImpl.swift
+++ b/stdlib/public/Synchronization/Mutex/LinuxImpl.swift
@@ -11,51 +11,7 @@
 //===----------------------------------------------------------------------===//
 //
 // Plain-futex Mutex: 3-state lock word, bounded spin, kernel fallback.
-//
-// ```mermaid
-// flowchart TD
-//     subgraph lockflow ["_lock()"]
-//         fastCAS{{"compareExchange(.unlocked, .locked)"}}
-//         fastCAS -- "exchanged == true" --> locked([LOCKED])
-//         fastCAS -- "exchanged == false" --> slow([_lockSlow])
-//
-//         slow --> stateCheck{"initialState == .contended?"}
-//         stateCheck -- no --> spinTry
-//         stateCheck -- yes --> depthCheck{"depth >= maxActiveSpinners?"}
-//         depthCheck -- no --> spinTry
-//         depthCheck -- yes --> parkClaim
-//
-//         subgraph spinloop ["spin loop (repeat while spinsRemaining > 0)"]
-//             spinTry{{"compareExchange(.unlocked, .locked)"}} -- "exchanged == false, state == .locked" --> pause["pause CPU<br/>(pauseBase + per-thread jitter)"]
-//             pause --> spinsCheck{"spinsRemaining -= 1<br/>spinsRemaining > 0?"}
-//             spinsCheck -- yes --> spinTry
-//         end
-//         spinTry -- "exchanged == true" --> locked
-//         spinTry -- "state == .contended" --> parkClaim
-//         spinsCheck -- no --> parkClaim
-//
-//         subgraph parkloop ["park loop (while true)"]
-//             parkClaim["storage.exchange(.contended)"] --> exchResult{"returned == .unlocked?"}
-//             exchResult -- no --> inc["slowPathDepth += 1<br/>(first miss only)"]
-//             inc --> wait[["_futexWait(expected: .contended)"]]
-//             wait -- "woken / EAGAIN / EINTR" --> parkClaim
-//         end
-//         exchResult -- yes --> dec["slowPathDepth -= 1<br/>(if previously bumped)"]
-//         dec --> locked
-//     end
-//
-//     subgraph unlockflow ["_unlock()"]
-//         unlockSwap{{"storage.exchange(.unlocked)"}}
-//         unlockSwap -- "== .locked" --> done([done])
-//         unlockSwap -- "== .contended" --> wake[["_futexWake(count: 1)"]]
-//     end
-//
-//     wake -. wakes parker .-> wait
-//
-//     %% highlight loop back-edges (spin continue, park retry)
-//     linkStyle 9 stroke:#ff8800,stroke-width:2px
-//     linkStyle 16 stroke:#ff8800,stroke-width:2px
-// ```
+// See: docs/SynchronizationMutexLinux.md
 //
 //===----------------------------------------------------------------------===//
 

--- a/stdlib/public/Synchronization/Mutex/LinuxImpl.swift
+++ b/stdlib/public/Synchronization/Mutex/LinuxImpl.swift
@@ -19,23 +19,30 @@ import Musl
 import Glibc
 #endif
 
-extension Atomic where Value == UInt32 {
-  // This returns 'false' on success and 'true' on error. Check 'errno' for the
-  // specific error value.
-  internal borrowing func _futexLock() -> UInt32 {
-    unsafe _swift_stdlib_futex_lock(.init(_rawAddress))
+extension Atomic where Value == _MutexHandle.State {
+  // Sleeps while the underlying word equals `expected`. Returns 0 on a normal
+  // wake or the errno value (EAGAIN=11 and EINTR=4 are the expected retryable
+  // cases).
+  internal borrowing func _futexWait(expected: _MutexHandle.State) -> UInt32 {
+    unsafe _swift_stdlib_futex_wait(.init(_rawAddress), expected.rawValue)
   }
 
-  // This returns 'false' on success and 'true' on error. Check 'errno' for the
-  // specific error value.
-  internal borrowing func _futexTryLock() -> UInt32 {
-    unsafe _swift_stdlib_futex_trylock(.init(_rawAddress))
+  // Wakes up to `count` waiters parked on this word. Result is the number
+  // woken (or errno on failure); callers typically discard it.
+  internal borrowing func _futexWake(count: UInt32) -> UInt32 {
+    unsafe _swift_stdlib_futex_wake(.init(_rawAddress), count)
   }
+}
 
-  // This returns 'false' on success and 'true' on error. Check 'errno' for the
-  // specific error value.
-  internal borrowing func _futexUnlock() -> UInt32 {
-    unsafe _swift_stdlib_futex_unlock(.init(_rawAddress))
+@available(SwiftStdlib 6.0, *)
+extension _MutexHandle {
+  @available(SwiftStdlib 6.0, *)
+  @frozen
+  @usableFromInline
+  internal enum State: UInt32, AtomicRepresentable {
+    case unlocked
+    case locked      // held, no waiters parked in the kernel
+    case contended   // held, at least one waiter parked in the kernel
   }
 }
 
@@ -43,18 +50,14 @@ extension Atomic where Value == UInt32 {
 @frozen
 @_staticExclusiveOnly
 public struct _MutexHandle: ~Copyable {
-  // There are only 3 different values that storage can hold at a single time.
-  // 0: unlocked
-  // TID: locked, current thread's id (uncontended)
-  // (TID | FUTEX_WAITERS): locked, current thread's id (contended)
   @usableFromInline
-  let storage: Atomic<UInt32>
+  let storage: Atomic<State>
 
   @available(SwiftStdlib 6.0, *)
   @_alwaysEmitIntoClient
   @_transparent
   public init() {
-    storage = Atomic(0)
+    storage = Atomic(.unlocked)
   }
 }
 
@@ -64,12 +67,9 @@ extension _MutexHandle {
   @_alwaysEmitIntoClient
   @_transparent
   internal borrowing func _lock() {
-    // Note: This is being TLS cached.
-    let selfId = _swift_stdlib_gettid()
-
     let (exchanged, _) = storage.compareExchange(
-      expected: 0,
-      desired: selfId,
+      expected: .unlocked,
+      desired: .locked,
       successOrdering: .acquiring,
       failureOrdering: .relaxed
     )
@@ -79,9 +79,16 @@ extension _MutexHandle {
       return
     }
 
-    _lockSlow(selfId)
+    _lockSlow(0)
   }
 
+  // Slow path for `_lock`: runs a bounded adaptive spin, then parks in the kernel via FUTEX_WAIT. The spin is adaptive in two
+  // senses: the number of CPU pauses issued per iteration grows exponentially round-to-round, and its upper bound is
+  // re-chosen each iteration from the lock state we just observed. The exact upper-bound values and reasoning are inline at
+  // the `maxPauseCount` declaration below.
+  //
+  // `selfId` is retained only to preserve the mangled ABI symbol for clients compiled against the previous PI-futex
+  // implementation; the plain-futex code has no need for a thread id.
   @available(SwiftStdlib 6.0, *)
   @usableFromInline
   internal borrowing func _lockSlow(_ selfId: UInt32) {
@@ -90,13 +97,16 @@ extension _MutexHandle {
     // where the current owner thread's critical section is somewhat quick. We
     // avoid a lot of the syscall overhead in these cases which allow both the
     // owner thread and this current thread to do the user-space atomic for
-    // releasing and acquiring (assuming no existing waiters). The waiter bit is
-    // typically unset when a call to 'FUTEX_UNLOCK_PI' has no other pi state,
-    // meaning there is no one else waiting to acquire the lock.
+    // releasing and acquiring (assuming no existing waiters).
     do {
-      // This value is controlled on a per architecture bases defined in
-      // 'SpinLoopHint.swift'.
-      var tries = _tries
+      // Total spin-loop iterations we are willing to run before giving up and asking the kernel to park us.
+      var spinsRemaining: Int = 14
+
+      // Number of `_spinLoopHint()` CPU pauses we will issue on the current iteration before re-checking the lock word.
+      // Grows exponentially (4 -> 8 -> 16 -> 32) up to the per-iteration `maxPauseCount`. The initial value of 4 is a floor
+      // chosen over 1 to skip the first few iterations where the lock state has not yet had time to change and tight
+      // back-to-back loads would generate wasted cache traffic for no information gain.
+      var pauseCount: UInt32 = 4
 
       repeat {
         // Do a relaxed load of the futex value to prevent introducing a memory
@@ -108,9 +118,9 @@ extension _MutexHandle {
         // able to attempt to acquire the lock.
         let state = storage.load(ordering: .relaxed)
 
-        if state == 0, storage.compareExchange(
-          expected: 0,
-          desired: selfId,
+        if state == .unlocked, storage.compareExchange(
+          expected: .unlocked,
+          desired: .locked,
           successOrdering: .acquiring,
           failureOrdering: .relaxed
         ).exchanged {
@@ -118,81 +128,66 @@ extension _MutexHandle {
           return
         }
 
-        tries &-= 1
+        spinsRemaining &-= 1
+
+        // Upper bound on `pauseCount` for this iteration - i.e. the maximum number of `_spinLoopHint()` CPU pauses we will
+        // issue before re-checking the lock word. Chosen per iteration from the state we just observed:
+        //
+        //   state == contended (at least one waiter is parked in the kernel):
+        //     maxPauseCount = 6.
+        //     Short pauses let us re-check the lock word often enough to catch the narrow release window when the owner
+        //     unlocks, before the kernel wakes the parked waiter.
+        //
+        //   state == locked, or state == unlocked but our CAS just lost:
+        //     maxPauseCount = 32.
+        //     Long pauses give the owner (or the thread that just beat us to the CAS) CPU time to finish its critical
+        //     section, and avoid generating exclusive-state cache traffic that would fight the owner's access to the lock.
+        let maxPauseCount: UInt32 = (state == .contended) ? 6 : 32
 
         // Inform the CPU that we're doing a spin loop which should have the
         // effect of slowing down this loop if only by a little to preserve
         // energy.
-        _spinLoopHint()
-      } while tries != 0
+        for _ in 0 ..< pauseCount {
+          _spinLoopHint()
+        }
+
+        if pauseCount < maxPauseCount {
+          // Exponential doubling to back off.
+          pauseCount &<<= 1
+        } else if pauseCount > maxPauseCount {
+          // The cap just dropped - e.g. the lock state flipped from `locked` to `contended` on this iteration, so
+          // `maxPauseCount` went from 32 down to 6 while `pauseCount` had already grown to 8, 16, or 32. Force `pauseCount`
+          // back down to the new ceiling so the short-pause budget takes effect on the very next iteration.
+          pauseCount = maxPauseCount
+        }
+      } while spinsRemaining > 0
     }
 
-    // We've exhausted our spins. Ask the kernel to block for us until the owner
-    // releases the lock.
+    // We've exhausted our spins. Mark the lock contended and ask the kernel to block for us until the owner releases.
     //
-    // Note: The kernel will attempt to acquire the lock for us as well which
-    // could succeed if the owner releases in between finishing spinning the
-    // futex syscall.
+    // exchange(contended) marks the lock "has waiters" unconditionally. If the previous value was `unlocked` the owner released
+    // between our last spin iteration and this exchange - we have just acquired (the next unlock will emit one spurious
+    // FUTEX_WAKE, which is harmless). Otherwise the lock is still held and `*word == contended`, so the next unlock is
+    // guaranteed to wake us.
     while true {
-      // Block until an equivalent '_futexUnlock' has been called by the owner.
-      // This returns '0' on success which means the kernel has acquired the
-      // lock for us.
-      let lockResult = storage._futexLock()
-      switch lockResult {
-      case 0:
+      let prev = storage.exchange(.contended, ordering: .acquiring)
+      if prev == .unlocked {
         // Locked!
         return
+      }
 
-      // EINTR  - "A FUTEX_WAIT or FUTEX_WAIT_BITSET operation was interrupted
-      //           by a signal (see signal(7)). Before Linux 2.6.22, this error
-      //           could also be returned for a spurious wakeup; since Linux
-      //           2.6.22, this no longer happens."
-      // EAGAIN - "The futex owner thread ID of uaddr is about to exit, but has
-      //           not yet handled the internal state cleanup. Try again."
-      case 4, 11:
+      // Sleep while `*word == contended`. Returns 0 on a normal wake from FUTEX_WAKE, or an errno for retryable cases.
+      let waitResult = storage._futexWait(expected: .contended)
+      switch waitResult {
+      // 0      - woken normally by FUTEX_WAKE from the unlocker
+      // EAGAIN - *word changed before the kernel-side comparison; retry
+      // EINTR  - signal-interrupted before sleep; retry
+      case 0, 11, 4:
         continue
 
-      // EDEADLK - "The futex word at uaddr is already locked by the caller."
-      case 35:
-        // TODO: Replace with a colder function / one that takes a StaticString
-        fatalError("Recursive call to lock Mutex")
-
-      // This handles all of the following errors which generally aren't
-      // applicable to this implementation:
-      //
-      // EACCES - "No read access to the memory of a futex word."
-      // EFAULT - "A required pointer argument did not point to a valid
-      //           user-space address."
-      // EINVAL - "The operation in futex_op is one of those that employs a
-      //           timeout, but the supplied timeout argument was invalid
-      //           (tv_sec was less than zero, or tv_nsec was not less than
-      //           1,000,000,000)."
-      //          OR
-      //          "The operation specified in futex_op employs one or both of
-      //           the pointers uaddr and uaddr2, but one of these does not
-      //           point to a valid object—that is, the address is not four-
-      //           byte-aligned."
-      //          OR
-      //          "The kernel detected an inconsistency between the user-space
-      //           state at uaddr and the kernel state. This indicates either
-      //           state corruption or that the kernel found a waiter on uaddr
-      //           which is waiting via FUTEX_WAIT or FUTEX_WAIT_BITSET."
-      //          OR
-      //          "Invalid argument."
-      // ENOMEM - "The kernel could not allocate memory to hold state
-      //           information."
-      // ENOSYS - "Invalid operation specified in futex_op."
-      //          OR
-      //          "A run-time check determined that the operation is not
-      //           available. The PI-futex operations are not implemented on all
-      //           architectures and are not supported on some CPU variants."
-      // EPERM  - "The caller is not allowed to attach itself to the futex at
-      //           uaddr (This may be caused by a state corruption in user
-      //           space.)"
-      // ESRCH  - "The thread ID in the futex word at uaddr does not exist."
       default:
         // TODO: Replace with a colder function / one that takes a StaticString
-        fatalError("Unknown error occurred while attempting to acquire a Mutex: \(lockResult)")
+        fatalError("Unknown error occurred while attempting to acquire a Mutex: \(waitResult)")
       }
     }
   }
@@ -201,12 +196,11 @@ extension _MutexHandle {
   @_alwaysEmitIntoClient
   @_transparent
   internal borrowing func _tryLock() -> Bool {
-    // Do a user space cmpxchg to see if we can easily acquire the lock.
+    // Do a user space cmpxchg to see if we can easily acquire the lock. The lock word goes from `unlocked` directly to
+    // `locked` on success - there is no intermediate state and no kernel involvement.
     if storage.compareExchange(
-      expected: 0,
-
-      // Note: This is being TLS cached.
-      desired: _swift_stdlib_gettid(),
+      expected: .unlocked,
+      desired: .locked,
       successOrdering: .acquiring,
       failureOrdering: .relaxed
     ).exchanged {
@@ -214,91 +208,27 @@ extension _MutexHandle {
       return true
     }
 
-    // The quick atomic op failed, ask the kernel to see if it can acquire the
-    // lock for us.
+    // The CAS failed, so the lock is currently held by someone else. Plain futex has no kernel-side recovery path that could
+    // change that answer, so fall through to `_tryLockSlow` which just returns false.
     return _tryLockSlow()
   }
 
   @available(SwiftStdlib 6.0, *)
   @usableFromInline
   internal borrowing func _tryLockSlow() -> Bool {
-    // Note: "Because the kernel has access to more state information than user
-    //        space, acquisition of the lock might succeed if performed by the
-    //        kernel in cases where the futex word (i.e., the state information
-    //        accessible to use-space) contains stale state (FUTEX_WAITERS
-    //        and/or FUTEX_OWNER_DIED). This can happen when the owner of the
-    //        futex died. User space cannot handle this condition in a race-free
-    //        manner, but the kernel can fix this up and acquire the futex."
-    switch storage._futexTryLock() {
-    case 0:
-      // Locked!
-      return true
-
-    // EDEADLK - "The futex word at uaddr is already locked by the caller."
-    case 35:
-      return false
-
-    // This handles all of the following errors which generally aren't
-    // applicable to this implementation:
-    //
-    // EACCES - "No read access to the memory of a futex word."
-    // EAGAIN - "The futex owner thread ID of uaddr is about to exit, but has
-    //           not yet handled the internal state cleanup. Try again."
-    // EFAULT - "A required pointer argument did not point to a valid
-    //           user-space address."
-    // EINVAL - "The operation in futex_op is one of those that employs a
-    //           timeout, but the supplied timeout argument was invalid
-    //           (tv_sec was less than zero, or tv_nsec was not less than
-    //           1,000,000,000)."
-    //          OR
-    //          "The operation specified in futex_op employs one or both of
-    //           the pointers uaddr and uaddr2, but one of these does not
-    //           point to a valid object—that is, the address is not four-
-    //           byte-aligned."
-    //          OR
-    //          "The kernel detected an inconsistency between the user-space
-    //           state at uaddr and the kernel state. This indicates either
-    //           state corruption or that the kernel found a waiter on uaddr
-    //           which is waiting via FUTEX_WAIT or FUTEX_WAIT_BITSET."
-    //          OR
-    //          "Invalid argument."
-    // ENOMEM - "The kernel could not allocate memory to hold state
-    //           information."
-    // ENOSYS - "Invalid operation specified in futex_op."
-    //          OR
-    //          "A run-time check determined that the operation is not
-    //           available. The PI-futex operations are not implemented on all
-    //           architectures and are not supported on some CPU variants."
-    // EPERM  - "The caller is not allowed to attach itself to the futex at
-    //           uaddr (This may be caused by a state corruption in user
-    //           space.)"
-    // ESRCH  - "The thread ID in the futex word at uaddr does not exist."
-    default:
-      // Note: We could maybe retry this operation when given EAGAIN, but this
-      //       is more or less supposed to be a quick yes/no.
-      return false
-    }
+    // Retained for ABI compatibility with clients compiled against the prior PI-futex implementation whose inlined `_tryLock`
+    // bodies reference this mangled symbol. Plain futex has no kernel-side trylock recovery path, so if the userspace CAS in
+    // `_tryLock` failed the lock is simply held by someone else.
+    return false
   }
 
   @available(SwiftStdlib 6.0, *)
   @_alwaysEmitIntoClient
   @_transparent
   internal borrowing func _unlock() {
-    // Note: This is being TLS cached.
-    let selfId = _swift_stdlib_gettid()
-
-    // Attempt to release the lock. We can only atomically release the lock in
-    // user-space when there are no other waiters. If there are waiters, the
-    // waiter bit is set and we need to inform the kernel that we're unlocking.
-    let (exchanged, _) = storage.compareExchange(
-      expected: selfId,
-      desired: 0,
-      successOrdering: .releasing,
-      failureOrdering: .relaxed
-    )
-
-    if _fastPath(exchanged) {
-      // No waiters, unlocked!
+    // If the previous value was `contended`, a waiter is parked in the kernel and we must wake one via FUTEX_WAKE.
+    guard storage.exchange(.unlocked, ordering: .releasing) == .contended else {
+      // Unlocked, syscall-free (the common case).
       return
     }
 
@@ -308,62 +238,9 @@ extension _MutexHandle {
   @available(SwiftStdlib 6.0, *)
   @usableFromInline
   internal borrowing func _unlockSlow() {
-    while true {
-      let unlockResult = storage._futexUnlock()
-      switch unlockResult {
-      case 0:
-        // Unlocked!
-        return
-
-      // EINTR  - "A FUTEX_WAIT or FUTEX_WAIT_BITSET operation was interrupted
-      //           by a signal (see signal(7)). Before Linux 2.6.22, this error
-      //           could also be returned for a spurious wakeup; since Linux
-      //           2.6.22, this no longer happens."
-      case 4:
-        continue
-
-      // EPERM  - "The caller does not own the lock represented by the futex
-      //           word."
-      case 1:
-        // TODO: Replace with a colder function / one that takes a StaticString
-        fatalError(
-          "Call to unlock Mutex on a thread which hasn't acquired the lock"
-        )
-
-      // This handles all of the following errors which generally aren't
-      // applicable to this implementation:
-      //
-      // EACCES - "No read access to the memory of a futex word."
-      // EFAULT - "A required pointer argument did not point to a valid
-      //           user-space address."
-      // EINVAL - "The operation in futex_op is one of those that employs a
-      //           timeout, but the supplied timeout argument was invalid
-      //           (tv_sec was less than zero, or tv_nsec was not less than
-      //           1,000,000,000)."
-      //          OR
-      //          "The operation specified in futex_op employs one or both of
-      //           the pointers uaddr and uaddr2, but one of these does not
-      //           point to a valid object—that is, the address is not four-
-      //           byte-aligned."
-      //          OR
-      //          "The kernel detected an inconsistency between the user-space
-      //           state at uaddr and the kernel state. This indicates either
-      //           state corruption or that the kernel found a waiter on uaddr
-      //           which is waiting via FUTEX_WAIT or FUTEX_WAIT_BITSET."
-      //          OR
-      //          "Invalid argument."
-      // ENOSYS - "Invalid operation specified in futex_op."
-      //          OR
-      //          "A run-time check determined that the operation is not
-      //           available. The PI-futex operations are not implemented on all
-      //           architectures and are not supported on some CPU variants."
-      // EPERM  - "The caller is not allowed to attach itself to the futex at
-      //           uaddr (This may be caused by a state corruption in user
-      //           space.)"
-      default:
-        // TODO: Replace with a colder function / one that takes a StaticString
-        fatalError("Unknown error occurred while attempting to release a Mutex: \(unlockResult)")
-      }
-    }
+    // Wake exactly one parked waiter. Any other parked waiters, plus threads still spinning on the acquire path, will
+    // compete for the lock on the next release. FUTEX_WAKE's return value (count actually woken) is not needed here - a
+    // wake targeting an already-departed waiter is harmless.
+    _ = storage._futexWake(count: 1)
   }
 }

--- a/stdlib/public/Synchronization/Mutex/LinuxImpl.swift
+++ b/stdlib/public/Synchronization/Mutex/LinuxImpl.swift
@@ -127,6 +127,13 @@ extension _MutexHandle {
   @available(SwiftStdlib 6.0, *)
   @usableFromInline
   internal borrowing func _lockSlow(_ selfId: UInt32) {
+    // Before relinquishing control to the kernel to block this particular
+    // thread, run a little spin lock to keep this thread busy in the scenario
+    // where the current owner thread's critical section is somewhat quick. We
+    // avoid a lot of the syscall overhead in these cases which allow both the
+    // owner thread and this current thread to do the user-space atomic for
+    // releasing and acquiring (assuming no existing waiters).
+
     // Skip the spin when the queue is already deep - extra spinners just slow down the parked threads' handoff.
     let initialState = storage.load(ordering: .acquiring)
     let depth = slowPathDepth.load(ordering: .acquiring)
@@ -139,7 +146,14 @@ extension _MutexHandle {
       let mask = pauseBase &- 1
       var spinsRemaining = spinTries
 
-      while spinsRemaining > 0 {
+      repeat {
+        // Do a relaxed load of the futex value to prevent introducing a memory
+        // barrier on each iteration of this loop. We're already informing the
+        // CPU that this is a spin loop via the '_spinLoopHint' call which
+        // should hopefully slow down the loop a considerable amount to view an
+        // actually change in the value potentially. An extra memory barrier
+        // would make it even slower on top of the fact that we may not even be
+        // able to attempt to acquire the lock.
         let state = storage.load(ordering: .relaxed)
 
         if state == .unlocked, storage.compareExchange(
@@ -164,9 +178,10 @@ extension _MutexHandle {
         }
 
         spinsRemaining -= 1
-      }
+      } while spinsRemaining > 0
     }
 
+    // We've exhausted our spins. Ask the kernel to block for us until the owner releases the lock.
     var visibleToSpinners = false
 
     while true {
@@ -189,9 +204,13 @@ extension _MutexHandle {
       // Sleep while `*word == contended`. Returns 0 on a normal wake from FUTEX_WAKE, or an errno for retryable cases.
       let waitResult = storage._futexWait(expected: .contended)
       switch waitResult {
-      // 0      - woken normally by FUTEX_WAKE from the unlocker
-      // EAGAIN - *word changed before the kernel-side comparison; retry
-      // EINTR  - signal-interrupted before sleep; retry
+      // EINTR  - "A FUTEX_WAIT or FUTEX_WAIT_BITSET operation was interrupted
+      //           by a signal (see signal(7)). Before Linux 2.6.22, this error
+      //           could also be returned for a spurious wakeup; since Linux
+      //           2.6.22, this no longer happens."
+      // EAGAIN - "The expected value specified by val did not match the value
+      //           in the futex word"; another thread unlocked in the window
+      //           between our `exchange(.contended)` and the syscall.
       case 0, 11, 4:
         continue
 
@@ -206,8 +225,7 @@ extension _MutexHandle {
   @_alwaysEmitIntoClient
   @_transparent
   internal borrowing func _tryLock() -> Bool {
-    // Userspace CAS unlocked -> locked. Plain futex has no kernel-side recovery path, so if the CAS fails the lock is
-    // held by someone else and no retry can change that.
+    // Do a user space cmpxchg to see if we can easily acquire the lock.
     if storage.compareExchange(
       expected: .unlocked,
       desired: .locked,
@@ -232,9 +250,10 @@ extension _MutexHandle {
   @_alwaysEmitIntoClient
   @_transparent
   internal borrowing func _unlock() {
-    // If the previous value was `contended`, a waiter is parked in the kernel and we must wake one via FUTEX_WAKE.
+    // Attempt to release the lock atomically in userspace. If there are waiters we must inform the kernel via
+    // FUTEX_WAKE.
     guard storage.exchange(.unlocked, ordering: .releasing) == .contended else {
-      // Unlocked, syscall-free (the common case).
+      // No waiters, unlocked!
       return
     }
 

--- a/stdlib/public/Synchronization/Mutex/SpinLoopHint.swift
+++ b/stdlib/public/Synchronization/Mutex/SpinLoopHint.swift
@@ -12,11 +12,6 @@
 
 #if arch(arm) || arch(arm64) || arch(arm64_32)
 
-@inline(__always)
-var _tries: Int {
-  100
-}
-
 #if arch(arm)
 
 // The following are acceptable operands to the aarch64 hint intrinsic from
@@ -58,20 +53,8 @@ func _wfe() {
 
 #elseif arch(i386) || arch(x86_64)
 
-@inline(__always)
-var _tries: Int {
-  1000
-}
-
 @_extern(c, "llvm.x86.sse2.pause")
 func _pause()
-
-#else
-
-@inline(__always)
-var _tries: Int {
-  100
-}
 
 #endif
 


### PR DESCRIPTION
* **Explanation**: Replaces the Linux `Synchronization.Mutex` implementation with a plain-futex adaptive-spinning lock instead of priority-inheritance which due to the fairness is significantly slower.
* **Scope**:  Linux only `Synchronization.Mutex` internals.  No API change.
* **Issues**:  https://github.com/swiftlang/swift/issues/88440
* **Risk**: Low. Same 3-state lock-word / wait-on-contended / wake-one mechanism as the existing WASI implementation.
* **Testing**: Throughput / tail-latency validated with the contention harness. No regressions on uncontended or low-contention paths and consistent improvement above 4 contending threads.

**Details**:
Switches the Linux `Synchronization.Mutex` from PI-futex to plain-futex with a short adaptive spin.

On a > 16 CPU core Linux system ( x86/arm), there is very large contention.

The `Optimal` label is what is implemented in the PR.

<img width="2800" height="980" alt="contention-scaling__grid" src="https://github.com/user-attachments/assets/915ec03b-b745-4e7d-be99-f320a7a79947" />

Comparing to NIOLock and at improvement adaptive spinning gives from 4 core system to all the way to 192 cores:
<img width="1022" height="700" alt="contention-scaling__ratio_NIOLock_over_Optimal" src="https://github.com/user-attachments/assets/f2466494-a798-4771-aef0-da8acb9e4000" />


The pseudo code:
```swift
lock():
      if CAS(unlocked -> locked): return                        // fast path

      // slow path: depth gate decides whether to spin
      state = load(word, acquire)
      depth = load(slowPathDepth, acquire)
      skipSpin = (state == contended) && (depth >= depthThreshold)  // default 4

      if !skipSpin:
          // flat-base spin with per-thread jitter
          jitter = cycle_counter() as UInt32                    // x86: rdtsc, arm: 0
          spinsRemaining = 20
          while spinsRemaining > 0:
              state = load(word, relaxed)
              if state == unlocked, CAS(unlocked -> locked): return
              if state == contended: break                       // don't barge kernel-woken thread
              pause x (64 + (jitter & 63))
              spinsRemaining -= 1

      // kernel phase with lazy waiter registration
      registered = false
      repeat:
          if exchange(contended) == unlocked:
              if registered: atomic_sub(slowPathDepth, 1)
              return
          if !registered:
              atomic_add(slowPathDepth, 1); registered = true
          futex_wait(word, contended)                           // retry on EAGAIN / EINTR

  unlock():
      if exchange(unlocked) == contended: futex_wake(1)
```


```mermaid
 flowchart TD
     subgraph lockflow ["_lock()"]
         lock([_lock]) --> fast{{"compareExchange(.unlocked, .locked)"}}
         fast -- acquired --> locked([LOCKED])
         fast -- missed --> slow([_lockSlow])

         slow --> stateCheck{"initialState == .contended?"}
         stateCheck -- no --> spinTry
         stateCheck -- yes --> depthCheck{"depth >= maxActiveSpinners?"}
         depthCheck -- no --> spinTry
         depthCheck -- yes --> exchange

         subgraph spinloop [spin loop]
             spinTry{{"compareExchange(.unlocked, .locked)"}} -- still .locked --> pause["pause CPU<br/>(pauseBase + per-thread jitter)"]
             pause -- spins remaining --> spinTry
         end
         spinTry -- acquired --> locked
         spinTry -- observed .contended --> exchange
         pause -- exhausted --> exchange

         subgraph parkloop [park loop]
             exchange["storage.exchange(.contended)"] --> exchResult{"returned .unlocked?"}
             exchResult -- yes --> dec["slowPathDepth -= 1"]
             exchResult -- no --> inc["slowPathDepth += 1"]
             inc --> wait[["_futexWait(expected: .contended)"]]
             wait -- woken --> exchange
             wait -- EAGAIN / EINTR --> exchange
         end
         dec --> locked
     end

     subgraph unlockflow ["_unlock()"]
         unlock([_unlock]) --> rel{{"storage.exchange(.unlocked)"}}
         rel -- was .locked --> done([done])
         rel -- was .contended --> wake[["_futexWake(count: 1)"]]
     end

     wake -. wakes parker .-> wait
```



Why per-thread jitter (RDTSC low bits):
1. Deterministic pause counts re-synchronize threads released together by a lock handoff — they collide on the next lock-word load, defeating the pause.
2. RDTSC low bits vary per thread, so every thread gets a distinct pause pattern
3. Breaks the lock-convoy re-sync structurally rather than hoping the OS scheduler happens to stagger arrivals
4. Required for high core counts to prevent degradation

Why larger pauses:
1. Measurements, large core counts with NUMA, CXC all significantly degrade
2. The variable that actually matters is *spacing between lock-word loads*, not iteration count. Tight spacing invalidates the owner's cache lines and slows the critical section, which cascades into slower queue drain. Lower values regressed heavily on AMD EPYC.

**Scope**:
Linux only performance fix of Synchronization.Mutex.

**Issues**:
https://github.com/swiftlang/swift/issues/88440

**Testing**: 
Benchmark suite: https://github.com/ordo-one/synchronization-benchmarks
