### PR TITLE
SemanticARCOpts: remove an optimization which eliminates copies without respecting deinit barriers

### DIFF
--- a/lib/SILOptimizer/SemanticARC/CopyValueOpts.cpp
+++ b/lib/SILOptimizer/SemanticARC/CopyValueOpts.cpp
@@ -268,53 +268,6 @@ bool SemanticARCOptVisitor::performGuaranteedCopyValueOptimization(
 }
 
 //===----------------------------------------------------------------------===//
-//                       Trivial Live Range Elimination
-//===----------------------------------------------------------------------===//
-
-/// If cvi only has destroy value users, then cvi is a dead live range. Lets
-/// eliminate all such dead live ranges.
-///
-/// FIXME: OSSACanonicalizeOwned replaces this.
-bool SemanticARCOptVisitor::eliminateDeadLiveRangeCopyValue(
-    CopyValueInst *cvi) {
-  // This is a cheap optimization generally.
-
-  // See if we are lucky and have a simple case.
-  if (auto *op = cvi->getSingleUse()) {
-    if (auto *dvi = dyn_cast<DestroyValueInst>(op->getUser())) {
-      LLVM_DEBUG(llvm::dbgs() << "Erasing single-use copy: " << *cvi);
-      eraseInstruction(dvi);
-      eraseInstructionAndAddOperandsToWorklist(cvi);
-      return true;
-    }
-  }
-
-  // If all of our copy_value users are destroy_value, zap all of the
-  // instructions. We begin by performing that check and gathering up our
-  // destroy_value.
-  SmallVector<DestroyValueInst *, 16> destroys;
-  if (!all_of(cvi->getUses(), [&](Operand *op) {
-        auto *dvi = dyn_cast<DestroyValueInst>(op->getUser());
-        if (!dvi)
-          return false;
-
-        // Stash dvi in destroys so we can easily eliminate it later.
-        destroys.push_back(dvi);
-        return true;
-      })) {
-    return false;
-  }
-
-  // Now that we have a truly dead live range copy value, eliminate it!
-  LLVM_DEBUG(llvm::dbgs() << "Eliminate dead copy: " << *cvi);
-  while (!destroys.empty()) {
-    eraseInstruction(destroys.pop_back_val());
-  }
-  eraseInstructionAndAddOperandsToWorklist(cvi);
-  return true;
-}
-
-//===----------------------------------------------------------------------===//
 //                             Live Range Joining
 //===----------------------------------------------------------------------===//
 
@@ -847,13 +800,6 @@ static FunctionTest SemanticARCOptsCopyValueOptsGuaranteedValueOptTest(
 //===----------------------------------------------------------------------===//
 
 bool SemanticARCOptVisitor::visitCopyValueInst(CopyValueInst *cvi) {
-  // If our copy value inst has only destroy_value users, it is a dead live
-  // range. Try to eliminate them.
-  if (ctx.shouldPerform(ARCTransformKind::RedundantCopyValueElimPeephole) &&
-      eliminateDeadLiveRangeCopyValue(cvi)) {
-    return true;
-  }
-
   // Then see if copy_value operand's lifetime ends after our copy_value via a
   // destroy_value. If so, we can join their lifetimes.
   if (ctx.shouldPerform(ARCTransformKind::LifetimeJoiningPeephole) &&

--- a/lib/SILOptimizer/SemanticARC/SemanticARCOptVisitor.h
+++ b/lib/SILOptimizer/SemanticARC/SemanticARCOptVisitor.h
@@ -204,7 +204,6 @@ struct LLVM_LIBRARY_VISIBILITY SemanticARCOptVisitor
   bool optimizeWithoutFixedPoint();
 
   bool performGuaranteedCopyValueOptimization(CopyValueInst *cvi);
-  bool eliminateDeadLiveRangeCopyValue(CopyValueInst *cvi);
   bool tryJoiningCopyValueLiveRangeWithOperand(CopyValueInst *cvi);
   bool tryPerformOwnedCopyValueOptimization(CopyValueInst *cvi);
 };

--- a/test/SILOptimizer/semantic-arc-opts-redundantcopyopts.sil
+++ b/test/SILOptimizer/semantic-arc-opts-redundantcopyopts.sil
@@ -20,6 +20,13 @@ case none
 case some(T)
 }
 
+struct MyArray<Element> {
+  let buffer: MyArrayBuffer
+}
+
+final class MyArrayBuffer {
+}
+
 sil [ossa] @guaranteed_user : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
 sil [ossa] @owned_user : $@convention(thin) (@owned Builtin.NativeObject) -> ()
 sil [ossa] @get_owned_obj : $@convention(thin) () -> @owned Builtin.NativeObject
@@ -237,4 +244,26 @@ bb0:
   %10 = tuple ()
   return %10
 }
+
+// CHECK-LABEL: sil [ossa] @test_deinit_barrier :
+// CHECK:         copy_value
+// CHECK-LABEL: } // end sil function 'test_deinit_barrier'
+sil [ossa] @test_deinit_barrier : $@convention(thin) () -> @owned AnyObject {
+bb0:
+  %0 = apply undef() : $@convention(thin) () -> @owned MyArray<AnyObject>
+  %1 = begin_borrow %0
+  %2 = struct_extract %1, #MyArray.buffer
+  %3 = copy_value %2
+  %4 = ref_tail_addr %2, $AnyObject
+  %5 = address_to_pointer %4 to $Builtin.RawPointer
+  end_borrow %1
+  destroy_value %0
+  %8 = pointer_to_address %5 to [strict] $*AnyObject
+  // This is load is a deinit-barrier because it loads from a pointer.
+  // Therefore the array buffer must not be destroyed earlier which means that the `copy_value` must be kept.
+  %9 = load [copy] %8
+  destroy_value %3
+  return %9
+}
+
 


### PR DESCRIPTION
The `eliminateDeadLiveRangeCopyValue` did hoist destroys over deinit-barriers. We can eliminate this optimization at all because it's covered e.g. by the copy-propagation pass (which respects deinit-barriers).

Fixes a mis-compile
rdar://174863412
