### PR TITLE
Ensure SDKs in the Windows distribution have unique canonical names

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -3127,7 +3127,7 @@ function Build-ExperimentalRuntime([Hashtable] $Platform, [switch] $Static = $fa
 
 function Write-SDKSettings([OS] $OS, [string] $Identifier = $OS.ToString()) {
   $SDKSettings = @{
-    CanonicalName = $OS.ToString().ToLowerInvariant()
+    CanonicalName = $Identifier.ToLowerInvariant()
     DisplayName = $OS.ToString()
     IsBaseSDK = "YES"
     Version = "${ProductVersion}"


### PR DESCRIPTION


**Explanation**: The build system expects to be able to uniquely identify loaded SDKs by canonical name. Use "windowsexperimental" and "androidexperimental" as the canonical names for the experimental SDKs so they can be distinguished from their older counterparts. These can be safely renamed back to "windows" and "android" when they're promoted to being the primary versions and the older ones are removed.
**Scope**: Metadata of the Windows SDKs
**Risk**: Low. The canonical name field is primarily read by the build system
**Testing**: Existing CI tests, manual verification of the resulting toolchain