### PR TITLE
[Windows] [ARM64] Do not attempt to use minject to patch.

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -2436,6 +2436,12 @@ function Patch-mimalloc() {
     [hashtable]$Platform
   )
 
+  # mimalloc patching is not supported when cross-compiling.
+  if ($IsCrossCompiling) { return }
+
+  # use the version of mimalloc that runs on this platform
+  # note: it will also target binaries that run on this platform and inject dlls
+  # for this platform, because mimalloc is not supported when cross-compiling
   $BuildSuffix = if ($BuildPlatform -eq $KnownPlatforms["WindowsX64"]) { "" } else { "-arm64" }
 
   $Tools = @(


### PR DESCRIPTION




<!--
The main branch is now in convergence, which means major changes, such as large refactoring or new features, should be avoided. This strategy is intended to maintain the stability of the Swift 6.4 release leading up to the May 4th branch. For any work that requires broad changes or introduces new features, create a feature branch and open a draft pull request. All updates to the swiftlang/swift repository’s main branch require approval from the release managers. A pull request targeting swiftlang/swift will automatically add release managers. You can also contact them via @release-managers in the forum group.
-->

<!-- Please fill out the following form: --> 
- **Explanation**:
We are getting inconsistencies and instability using minject cross compiling the ARM64 Windows installer. As a simple fix, disable minject patching when cross compiling a toolchain/installer.

Because the build runs on an Intel Windows CI system, in practical terms this means mimalloc will only be used by the Intel build of the Swift compiler. But the small loss in performance feels acceptable to have a stable/working arm64 Windows installer.

- **Scope**:
This could break the Windows build. But we should know immediately if it does and it won't cause instability.

- **Issues**:
rdar://173864813

- **Risk**:
Should be no risk for Darwin or Linux. May break the build temporarily for Windows but easily reverted if so and once it works it should keep working, not be flaky.

- **Testing**:
Build run on local machine.
