### PR TITLE
[Sema] Don't force interface type of VarDecl in getIUOReferenceKind

### DIFF
--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1981,6 +1981,16 @@ OverloadChoice::getIUOReferenceKind(ConstraintSystem &cs,
   if (!decl || !decl->isImplicitlyUnwrappedOptional())
     return std::nullopt;
 
+  // A variable or parameter spelled with an IUO type (`x: T!`) is always an
+  // IUO value; only functions and subscripts can carry an IUO on the return.
+  // Short-circuit here so we don't force the declaration's interface type.
+  // Doing so while the solver is mid-closure can re-enter
+  // `typeCheckPatternBinding` from outside the closure's own type-check
+  // context and trip the assertion in `TypeChecker::typeCheckBinding` (see
+  // https://github.com/swiftlang/swift/issues/88530).
+  if (isa<VarDecl>(decl))
+    return IUOReferenceKind::Value;
+
   // If this isn't an IUO return () -> T!, it's an IUO value.
   if (!decl->getInterfaceType()->is<AnyFunctionType>())
     return IUOReferenceKind::Value;

--- a/test/Constraints/iuo.swift
+++ b/test/Constraints/iuo.swift
@@ -247,3 +247,14 @@ func testCompoundRefs() {
   let _: (Int) -> Int = hasArgLabel(x:) // expected-error {{cannot convert value of type '(Int) -> Int?' to specified type '(Int) -> Int}}
   let _: (Int) -> Int? = hasArgLabel(x:)
 }
+
+// https://github.com/swiftlang/swift/issues/88530
+// An IUO binding inside a closure, typed as an unbound generic member, used
+// to crash the compiler because `OverloadChoice::getIUOReferenceKind` forced
+// the VarDecl's interface type, re-entering `typeCheckPatternBinding` from
+// outside the closure's own type-check context.
+struct GenericBox<T> { struct Inner {} }
+let closureWithUnboundGenericIUO = {
+  var x: GenericBox.Inner! = GenericBox<Int>.Inner()
+  _ = x
+}

--- a/test/Constraints/iuo.swift
+++ b/test/Constraints/iuo.swift
@@ -255,6 +255,6 @@ func testCompoundRefs() {
 // outside the closure's own type-check context.
 struct GenericBox<T> { struct Inner {} }
 let closureWithUnboundGenericIUO = {
-  var x: GenericBox.Inner! = GenericBox<Int>.Inner()
+  let x: GenericBox.Inner! = GenericBox<Int>.Inner()
   _ = x
 }


### PR DESCRIPTION
- Explanation: Fixes an assertion failure that could occur when using an implicitly-unwrapped optional with an unbound generic type for a local variable within a closure.
- Scope: Affects the use of implicitly-wrapped optional local vars in closures
- Issue: #88530
- Risk: Low, the existing logic would never permit a VarDecl to be anything other than `IUOReferenceKind::Value` since the compiler rejects any IUO VarDecl that isn't a top-level optional, this change just bypasses the need to query the interface type
- Testing: Added test to test suite

---

Fixes #88530.

## The crash

```swift
struct G<T> { struct I {} }
let f = { var x: G.I! = G<Int>.I(); _ = x }
```

```
Abort: function typeCheckBinding at TypeCheckConstraints.cpp:677
Cannot type-check PatternBindingDecl without closure context
```

Regression from #85141 (the tightened `ABORT` in `typeCheckBinding`).

## Root cause

While the solver is mid-closure and encounters the reference to `x`, `OverloadChoice::getIUOReferenceKind` calls `decl->getInterfaceType()` on the inner `VarDecl` (at `ConstraintSystem.cpp:1985`) to distinguish `var x: T!` from `var x: () -> T!`. For this `VarDecl`:

- `InterfaceTypeRequest::evaluate` (`TypeCheckDecl.cpp:2476`) calls `VD->getNamingPattern()`
- `NamingPatternRequest::evaluate` (`TypeCheckDecl.cpp:2722`) calls `PBD->getCheckedPatternBindingEntry(i)`
- which re-enters `TypeChecker::typeCheckPatternBinding` on the inner binding from **outside** the closure's own type-check context — exactly what #85141 forbids.

**Why only with unbound generic.** When the annotation is spelled fully (`G<Int>.I!`), the pattern type is resolvable syntactically, so during the closure's own pass `coercePatternToType` calls `setNamingPattern` on `x` (`TypeCheckPattern.cpp:1223`); later `getInterfaceType()` finds the naming pattern cached and never re-invokes `PatternBindingEntryRequest`. With an unbound generic annotation (`G.I!`), the pattern can't be resolved without initializer inference, so `setNamingPattern` isn't called on that path, and the deferred `getInterfaceType()` re-enters the pattern-binding type-check.

## Fix

`VarDecl` (and its subclass `ParamDecl`) can never have an IUO on a function return — that spelling is only valid for `FuncDecl` and `SubscriptDecl`. So the answer is already known: `IUOReferenceKind::Value`. Short-circuit before forcing the interface type.

```cpp
if (isa<VarDecl>(decl))
  return IUOReferenceKind::Value;
```

This targets the crash narrowly and avoids cutting across the invariant #85141 is trying to enforce. It's consistent with the preference to not eagerly force interface types during constraint solving.

## Test

Added a regression case to `test/Constraints/iuo.swift`.

## Notes

- PR #85141 also enabled a sister `ASSERT(...)` in `NamingPatternRequest::evaluate` (`TypeCheckDecl.cpp:2749`). This fix doesn't touch that path; if other IUO-in-closure shapes trip the sister assertion, they'd be a separate issue.
- I haven't been able to run the full test suite locally (no stage2 build); relying on CI here.

cc @hamishknight