### PR TITLE
[SwiftMergeFunctions] Skip functions with musttail calls

### DIFF
--- a/lib/LLVMPasses/LLVMMergeFunctions.cpp
+++ b/lib/LLVMPasses/LLVMMergeFunctions.cpp
@@ -673,6 +673,29 @@ static unsigned getBenefit(Function *F) {
   return Benefit;
 }
 
+/// musttail requires caller and callee signatures to match exactly;
+/// the merge trampoline would add parameters, breaking that contract.
+static bool containsMusttailCall(Function *F) {
+  for (BasicBlock &BB : *F) {
+    auto *Term = BB.getTerminator();
+    if (!isa<ReturnInst>(Term))
+      continue;
+    auto It = Term->getIterator();
+    if (It == BB.begin())
+      continue;
+    --It;
+    if (isa<BitCastInst>(&*It)) {
+      if (It == BB.begin())
+        continue;
+      --It;
+    }
+    if (auto *CI = dyn_cast<CallInst>(&*It))
+      if (CI->getTailCallKind() == CallInst::TCK_MustTail)
+        return true;
+  }
+  return false;
+}
+
 /// Returns true if function \p F is eligible for merging.
 static bool isEligibleFunction(Function *F) {
   if (F->isDeclaration())
@@ -687,6 +710,9 @@ static bool isEligibleFunction(Function *F) {
   if (F->getCallingConv() == CallingConv::SwiftTail)
     return false;
   
+  if (containsMusttailCall(F))
+    return false;
+
   unsigned Benefit = getBenefit(F);
   if (Benefit < FunctionMergeThreshold)
     return false;

--- a/test/LLVMPasses/merge_func_musttail.ll
+++ b/test/LLVMPasses/merge_func_musttail.ll
@@ -1,0 +1,51 @@
+; RUN: %swift-llvm-opt -passes='swift-merge-functions' -swiftmergefunc-threshold=2 %s | %FileCheck %s
+;
+; Verify that SwiftMergeFunctions does not merge functions containing
+; musttail calls.
+
+target datalayout = "e-m:o-i64:64-i128:128-n32:64-S128-Fn32"
+target triple = "arm64-apple-ios18.0"
+
+; CHECK-LABEL: define linkonce_odr hidden ptr @thunk_a(
+; CHECK: musttail call ptr @impl_a(
+; CHECK: ret ptr
+define linkonce_odr hidden ptr @thunk_a(ptr noundef %self) unnamed_addr {
+entry:
+  %sel = load ptr, ptr @selector_a, align 8, !invariant.load !0
+  %realized = tail call ptr @objc_msgSend(ptr noundef %self, ptr noundef %sel)
+  %ret = musttail call ptr @impl_a(ptr noundef %self)
+  ret ptr %ret
+}
+
+; CHECK-LABEL: define linkonce_odr hidden ptr @thunk_b(
+; CHECK: musttail call ptr @impl_b(
+; CHECK: ret ptr
+define linkonce_odr hidden ptr @thunk_b(ptr noundef %self) unnamed_addr {
+entry:
+  %sel = load ptr, ptr @selector_b, align 8, !invariant.load !0
+  %realized = tail call ptr @objc_msgSend(ptr noundef %self, ptr noundef %sel)
+  %ret = musttail call ptr @impl_b(ptr noundef %self)
+  ret ptr %ret
+}
+
+; CHECK-LABEL: define linkonce_odr hidden ptr @thunk_c(
+; CHECK: musttail call ptr @impl_c(
+; CHECK: ret ptr
+define linkonce_odr hidden ptr @thunk_c(ptr noundef %self) unnamed_addr {
+entry:
+  %sel = load ptr, ptr @selector_c, align 8, !invariant.load !0
+  %realized = tail call ptr @objc_msgSend(ptr noundef %self, ptr noundef %sel)
+  %ret = musttail call ptr @impl_c(ptr noundef %self)
+  ret ptr %ret
+}
+
+@selector_a = external global ptr
+@selector_b = external global ptr
+@selector_c = external global ptr
+
+declare ptr @objc_msgSend(ptr, ptr, ...)
+declare ptr @impl_a(ptr)
+declare ptr @impl_b(ptr)
+declare ptr @impl_c(ptr)
+
+!0 = !{}


### PR DESCRIPTION
SwiftMergeFunctions replaces merged function bodies with tail-call trampolines that have different parameter counts than the original. This breaks the `musttail` contract which requires the caller and callee to have exactly matching parameter counts and types.

The fix excludes any function containing a `musttail` call from merge candidates. Without this, structurally similar functions with `musttail` calls (e.g. ObjC direct method precondition thunks [LLVM #170618](https://github.com/llvm/llvm-project/pull/170618)) get merged into trampolines that produce invalid LLVM IR ("input module is broken").

Added a test, which would've become an invalid module without the fix.