### PR TITLE
[Embedded] Remove the ability to disable existentials in Embedded Swift

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/ModulePasses/EmbeddedSwiftDiagnostics.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/ModulePasses/EmbeddedSwiftDiagnostics.swift
@@ -88,26 +88,21 @@ private struct FunctionChecker {
          is InitExistentialAddrInst,
          is InitExistentialValueInst,
          is ExistentialMetatypeInst:
-      if !context.options.enableEmbeddedSwiftExistentials {
-        throw Diagnostic(.embedded_swift_existential_type, instruction.operands[0].value.type, at: instruction.location)
-      } else if let ie = instruction as? InitExistentialAddrInst {
+      if let ie = instruction as? InitExistentialAddrInst {
         for conf in ie.conformances {
           try checkConformance(conf, location: ie.location)
         }
       } else if instruction is OpenExistentialAddrInst
              || instruction is OpenExistentialBoxInst
              || instruction is OpenExistentialBoxValueInst {
-          // okay in embedded with existentials
+          // okay
       } else {
           // not supported even in embedded with existentials
         throw Diagnostic(.embedded_swift_existential_type, instruction.operands[0].value.type, at: instruction.location)
       }
 
-    case let aeb as AllocExistentialBoxInst:
-      if !context.options.enableEmbeddedSwiftExistentials {
-        throw Diagnostic(.embedded_swift_existential_type, aeb.type, at: instruction.location)
-      }
-      // With EmbeddedExistentials enabled, error boxing is supported.
+    case is AllocExistentialBoxInst:
+      break
 
     case let ier as InitExistentialRefInst:
       for conf in ier.conformances {
@@ -130,20 +125,16 @@ private struct FunctionChecker {
 
     case is CheckedCastAddrBranchInst,
          is UnconditionalCheckedCastAddrInst:
-      if !context.options.enableEmbeddedSwiftExistentials {
-        throw Diagnostic(.embedded_swift_dynamic_cast, at: instruction.location)
-      } else {
-         if let checkedCast = instruction as? CheckedCastAddrBranchInst {
-           if !checkedCast.supportedInEmbeddedSwift {
-             throw Diagnostic(.embedded_swift_dynamic_cast, at: instruction.location)
-           }
-         } else {
-           let checkedCast = instruction as! UnconditionalCheckedCastAddrInst
-           if !checkedCast.supportedInEmbeddedSwift {
-             throw Diagnostic(.embedded_swift_dynamic_cast, at: instruction.location)
-           }
+       if let checkedCast = instruction as? CheckedCastAddrBranchInst {
+         if !checkedCast.supportedInEmbeddedSwift {
+           throw Diagnostic(.embedded_swift_dynamic_cast, at: instruction.location)
          }
-      }
+       } else {
+         let checkedCast = instruction as! UnconditionalCheckedCastAddrInst
+         if !checkedCast.supportedInEmbeddedSwift {
+           throw Diagnostic(.embedded_swift_dynamic_cast, at: instruction.location)
+         }
+       }
 
     case let abi as AllocBoxInst:
       // It needs a bit of work to support alloc_box of generic non-copyable structs/enums with deinit,
@@ -276,11 +267,6 @@ private struct FunctionChecker {
     else {
       return
     }
-    if !context.options.enableEmbeddedSwiftExistentials &&
-       !conformance.protocol.requiresClass {
-      throw Diagnostic(.embedded_swift_existential_protocol, conformance.protocol.name, at: location)
-    }
-
     for entry in witnessTable.entries {
       switch entry {
       case .invalid, .associatedType:

--- a/SwiftCompilerSources/Sources/Optimizer/PassManager/Options.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/PassManager/Options.swift
@@ -44,10 +44,6 @@ struct Options {
     hasFeature(.Embedded)
   }
 
-  var enableEmbeddedSwiftExistentials: Bool {
-    hasFeature(.Embedded) && hasFeature(.EmbeddedExistentials)
-  }
-
   var enableMergeableTraps: Bool {
     _bridged.enableMergeableTraps()
   }

--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -586,8 +586,6 @@ ERROR(layout_string_instantiation_without_layout_strings,none,
 
 ERROR(evolution_with_embedded,none,
       "Library evolution cannot be enabled with embedded Swift.", ())
-ERROR(embedded_existentials_without_embedded,none,
-      "EmbeddedExistentials requires enabling embedded Swift.", ())
 ERROR(wmo_with_embedded,none,
       "Whole module optimization (wmo) must be enabled with embedded Swift.", ())
 ERROR(objc_with_embedded,none,

--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -396,8 +396,6 @@ GROUPED_ERROR(cannot_specialize_class,EmbeddedRestrictions,none,
       "cannot specialize %0 because class definition is not available (make sure to build with -wmo)", (Type))
 GROUPED_ERROR(embedded_swift_existential_type,EmbeddedRestrictions,none,
       "cannot use a value of protocol type %0 in embedded Swift", (Type))
-GROUPED_ERROR(embedded_swift_existential_protocol,EmbeddedRestrictions,none,
-      "cannot use a value of protocol type 'any %0' in embedded Swift", (StringRef))
 GROUPED_ERROR(embedded_swift_existential,EmbeddedRestrictions,none,
       "cannot use a value of protocol type in embedded Swift", ())
 GROUPED_ERROR(embedded_swift_value_deinit,EmbeddedRestrictions,none,

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -590,9 +590,6 @@ EXPERIMENTAL_FEATURE(SwiftRuntimeAvailability, true)
 /// that have a built-in Swift runtime. Implies 'SwiftRuntimeAvailability'.
 EXPERIMENTAL_FEATURE(StandaloneSwiftAvailability, true)
 
-/// Allow use of protocol typed values in Embedded mode (`Any` and friends)
-EXPERIMENTAL_FEATURE(EmbeddedExistentials, true)
-
 /// Allow enabling dynamic exclusivity in Embedded Swift.
 EXPERIMENTAL_FEATURE(EmbeddedDynamicExclusivity, true)
 

--- a/include/swift/IRGen/Linking.h
+++ b/include/swift/IRGen/Linking.h
@@ -89,37 +89,6 @@ enum class TypeMetadataAddress {
 inline bool isEmbedded(CanType t) {
   return t->getASTContext().LangOpts.hasFeature(Feature::Embedded);
 }
-inline bool isEmbeddedWithoutEmbeddedExitentials(CanType t) {
-  auto &langOpts = t->getASTContext().LangOpts;
-  return langOpts.hasFeature(Feature::Embedded) &&
-    !langOpts.hasFeature(Feature::EmbeddedExistentials);
-}
-// Metadata is not generated and not allowed to be referenced in Embedded Swift,
-// expect for classes (both generic and non-generic), dynamic self, and
-// class-bound existentials.
-inline bool isMetadataAllowedInEmbedded(CanType t) {
-  auto &langOpts = t->getASTContext().LangOpts;
-  bool embeddedExistentials =
-    langOpts.hasFeature(Feature::EmbeddedExistentials) &&
-    langOpts.hasFeature(Feature::Embedded);
-
-  if (isa<ClassType>(t) || isa<BoundGenericClassType>(t) ||
-      isa<DynamicSelfType>(t)) {
-    return true;
-  }
-  if (auto existentialTy = dyn_cast<ExistentialType>(t)) {
-    if (existentialTy->requiresClass())
-      return true;
-  }
-  if (auto archeTy = dyn_cast<ArchetypeType>(t)) {
-    if (archeTy->requiresClass())
-      return true;
-  }
-
-  if (embeddedExistentials)
-    return true;
-  return false;
-}
 
 inline bool isEmbedded(Decl *d) {
   return d->getASTContext().LangOpts.hasFeature(Feature::Embedded);
@@ -127,11 +96,6 @@ inline bool isEmbedded(Decl *d) {
 
 inline bool isEmbedded(const ProtocolConformance *c) {
   return c->getType()->getASTContext().LangOpts.hasFeature(Feature::Embedded);
-}
-
-inline bool isEmbeddedWithoutEmbeddedExitentials(const ProtocolConformance *c) {
-  return isEmbedded(c) && !c->getType()->getASTContext().
-    LangOpts.hasFeature(Feature::EmbeddedExistentials);
 }
 
 /// A link entity is some sort of named declaration, combined with all
@@ -936,7 +900,6 @@ public:
                                     TypeMetadataAddress addr,
                                     bool forceShared = false) {
     assert(!isObjCImplementation(concreteType));
-    assert(!isEmbedded(concreteType) || isMetadataAllowedInEmbedded(concreteType));
     LinkEntity entity;
     entity.setForType(Kind::TypeMetadata, concreteType);
     entity.Data |= LINKENTITY_SET_FIELD(MetadataAddress, unsigned(addr));
@@ -1115,7 +1078,6 @@ public:
   }
 
   static LinkEntity forValueWitnessTable(CanType type) {
-    assert(!isEmbeddedWithoutEmbeddedExitentials(type));
     LinkEntity entity;
     entity.setForType(Kind::ValueWitnessTable, type);
     return entity;
@@ -1145,10 +1107,6 @@ public:
   }
 
   static LinkEntity forProtocolWitnessTable(const ProtocolConformance *C) {
-    if (isEmbeddedWithoutEmbeddedExitentials(C)) {
-      assert(C->getProtocol()->requiresClass());
-    }
-
     LinkEntity entity;
     entity.setForProtocolConformance(Kind::ProtocolWitnessTable, C);
     return entity;

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -175,7 +175,6 @@ UNINTERESTING_FEATURE(NonisolatedNonsendingByDefault)
 UNINTERESTING_FEATURE(KeyPathWithMethodMembers)
 UNINTERESTING_FEATURE(ImportMacroAliases)
 UNINTERESTING_FEATURE(NoExplicitNonIsolated)
-UNINTERESTING_FEATURE(EmbeddedExistentials)
 UNINTERESTING_FEATURE(EmbeddedDynamicExclusivity)
 UNINTERESTING_FEATURE(TypedAllocation)
 

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -882,7 +882,6 @@ static bool ParseEnabledFeatureArgs(LangOptions &Opts, ArgList &Args,
   // honored, we iterate over them in reverse order.
   std::vector<StringRef> psuedoFeatures;
   llvm::SmallSet<Feature, 8> seenFeatures;
-  bool shouldEnableEmbeddedExistentialsPerDefault = false;
   for (const Arg *A : Args.filtered_reverse(
            OPT_enable_experimental_feature, OPT_disable_experimental_feature,
            OPT_enable_upcoming_feature, OPT_disable_upcoming_feature)) {
@@ -998,21 +997,6 @@ static bool ParseEnabledFeatureArgs(LangOptions &Opts, ArgList &Args,
     if (!seenFeatures.insert(*feature).second)
       continue;
 
-    // "Embedded" enables "EmbeddedExistentials" per default except if
-    // EmbeddedExistentials is explicitly disabled.
-    // "Embedded" enables "EmbeddedExistentials" if we have not yet seen
-    // explicit feature handling of "EmbeddedExistentials".
-    // Because we can see "Embedded" before (parsing in reverse) we see explict
-    // disabling of "EmbeddedExistentials" we delay default enablement so that a
-    // later (when viewed in reverse as this loop's logic does) explicit
-    // disablement can take place.
-    if (*feature == Feature::Embedded &&
-        isEnableFeatureFlag &&
-        !seenFeatures.contains(Feature::EmbeddedExistentials))
-      shouldEnableEmbeddedExistentialsPerDefault = true;
-    else if (*feature == Feature::EmbeddedExistentials && !isEnableFeatureFlag)
-      shouldEnableEmbeddedExistentialsPerDefault = false;
-
     bool forMigration = featureMode.has_value();
 
     // Enable the feature if requested.
@@ -1068,10 +1052,6 @@ static bool ParseEnabledFeatureArgs(LangOptions &Opts, ArgList &Args,
       auto modules = featureName->split("=").second;
       modules.split(Opts.ModulesRequiringObjC, ",");
     }
-  }
-
-  if (shouldEnableEmbeddedExistentialsPerDefault) {
-    Opts.enableFeature(Feature::EmbeddedExistentials);
   }
 
   // Map historical flags over to experimental features. We do this for all
@@ -1904,11 +1884,6 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   }
   Opts.BypassResilienceChecks |= Args.hasArg(OPT_bypass_resilience);
 
-  if (Opts.hasFeature(Feature::EmbeddedExistentials) &&
-      !Opts.hasFeature(Feature::Embedded)) {
-      Diags.diagnose(SourceLoc(), diag::embedded_existentials_without_embedded);
-      HadError = true;
-  }
   if (Opts.hasFeature(Feature::Embedded)) {
     Opts.UnavailableDeclOptimizationMode = UnavailableDeclOptimization::Complete;
     Opts.DisableImplicitStringProcessingModuleImport = true;

--- a/lib/IRGen/ClassMetadataVisitor.h
+++ b/lib/IRGen/ClassMetadataVisitor.h
@@ -79,8 +79,7 @@ public:
   // The regular `layout` method can be used for layout tasks for which the
   // actual superclass pointer is not relevant.
   void layoutEmbedded(CanType classTy) {
-    if (IGM.isEmbeddedWithExistentials())
-      asImpl().addValueWitnessTable();
+    asImpl().addValueWitnessTable();
     asImpl().noteAddressPoint();
     asImpl().addEmbeddedSuperclass(classTy);
     asImpl().addDestructorFunction();
@@ -93,8 +92,7 @@ public:
                   "Adjustment index must be synchronized with this layout");
 
     if (IGM.Context.LangOpts.hasFeature(Feature::Embedded)) {
-      if (IGM.isEmbeddedWithExistentials())
-        asImpl().addValueWitnessTable();
+      asImpl().addValueWitnessTable();
       asImpl().noteAddressPoint();
       asImpl().addSuperclass();
       asImpl().addDestructorFunction();

--- a/lib/IRGen/GenCast.cpp
+++ b/lib/IRGen/GenCast.cpp
@@ -89,7 +89,7 @@ llvm::Value *irgen::emitCheckedCast(IRGenFunction &IGF,
   llvm::Value *srcMetadata = nullptr;
 
   // Embedded swift currently only supports existential -> concrete type casts.
-  if (IGF.IGM.isEmbeddedWithExistentials()) {
+  if (IGF.IGM.Context.LangOpts.hasFeature(Feature::Embedded)) {
     srcMetadata = llvm::ConstantPointerNull::get(IGF.IGM.TypeMetadataPtrTy);
   } else {
     srcMetadata = IGF.emitTypeMetadataRef(srcType);

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -1362,8 +1362,6 @@ void IRGenerator::emitLazyDefinitions() {
   if (SIL.getASTContext().LangOpts.hasFeature(Feature::Embedded)) {
     // In embedded Swift, the compiler cannot emit any metadata, etc.
     // Other than to support existentials.
-    assert(LazyTypeMetadata.empty() ||
-           SIL.getASTContext().LangOpts.hasFeature(Feature::EmbeddedExistentials));
     assert(LazySpecializedTypeMetadataRecords.empty());
     assert(LazyTypeContextDescriptors.empty());
     assert(LazyOpaqueTypeDescriptors.empty());
@@ -1589,9 +1587,7 @@ bool IRGenerator::hasLazyMetadata(TypeDecl *type) {
   if (found != HasLazyMetadata.end())
     return found->second;
   auto &langOpts = SIL.getASTContext().LangOpts;
-  auto isEmbeddedWithExistentials = langOpts.hasFeature(Feature::Embedded) &&
-    langOpts.hasFeature(Feature::EmbeddedExistentials);
-  if (isEmbeddedWithExistentials &&
+  if (langOpts.hasFeature(Feature::Embedded) &&
       (isa<StructDecl>(type) || isa<EnumDecl>(type))) {
     bool isGeneric = cast<NominalTypeDecl>(type)->isGenericContext();
     HasLazyMetadata[type] = !isGeneric;
@@ -5316,7 +5312,7 @@ llvm::GlobalValue *IRGenModule::defineTypeMetadata(
 
     return cast<llvm::GlobalValue>(addr);
   }
-  bool hasEmbeddedExistentials = isEmbeddedWithExistentials();
+  bool hasEmbeddedExistentials = Context.LangOpts.hasFeature(Feature::Embedded);
   auto entity =
       (isPrespecialized &&
        !irgen::isCanonicalInitializableTypeMetadataStaticallyAddressable(
@@ -5452,7 +5448,7 @@ IRGenModule::getAddrOfTypeMetadata(CanType concreteType,
 
   llvm::Type *defaultVarTy;
   unsigned adjustmentIndex;
-  auto hasEmbeddedExistentials = isEmbeddedWithExistentials();
+  auto hasEmbeddedExistentials = Context.LangOpts.hasFeature(Feature::Embedded);
   if (hasEmbeddedExistentials) {
     adjustmentIndex = 0;
     defaultVarTy = EmbeddedExistentialsMetadataStructTy;

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -6360,7 +6360,8 @@ void irgen::emitStructMetadata(IRGenModule &IGM, StructDecl *structDecl) {
 
   bool isPattern;
   bool canBeConstant;
-  bool hasEmbeddedExistentialFeature = IGM.isEmbeddedWithExistentials();
+  bool hasEmbeddedExistentialFeature =
+      IGM.Context.LangOpts.hasFeature(Feature::Embedded);
   if (structDecl->isGenericContext()) {
     assert(!hasEmbeddedExistentialFeature);
     GenericStructMetadataBuilder builder(IGM, structDecl, init);
@@ -6905,7 +6906,8 @@ void irgen::emitEnumMetadata(IRGenModule &IGM, EnumDecl *theEnum) {
   
   bool isPattern;
   bool canBeConstant;
-  bool hasEmbeddedExistentialFeature = IGM.isEmbeddedWithExistentials();
+  bool hasEmbeddedExistentialFeature =
+      IGM.Context.LangOpts.hasFeature(Feature::Embedded);
   if (theEnum->isGenericContext()) {
     assert(!hasEmbeddedExistentialFeature);
     GenericEnumMetadataBuilder builder(IGM, theEnum, init);

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -961,24 +961,10 @@ namespace {
     }
 
     void addAssociatedType(AssociatedTypeDecl *assocType) {
-      // In Embedded Swift witness tables don't have associated-types entries.
-      auto &langOpts = assocType->getASTContext().LangOpts;
-      if (langOpts.hasFeature(Feature::Embedded) &&
-          !langOpts.hasFeature(Feature::EmbeddedExistentials))
-        return;
       Entries.push_back(WitnessTableEntry::forAssociatedType(assocType));
     }
 
     void addAssociatedConformance(const AssociatedConformance &req) {
-      auto &langOpts = req.getAssociation()->getASTContext().LangOpts;
-      if (langOpts.hasFeature(Feature::Embedded) &&
-          !langOpts.hasFeature(Feature::EmbeddedExistentials) &&
-          !req.getAssociatedRequirement()->requiresClass()) {
-        // If it's not a class protocol, the associated type can never be used to create
-        // an existential. Therefore this witness entry is never used at runtime
-        // in embedded swift.
-        return;
-      }
       Entries.push_back(WitnessTableEntry::forAssociatedConformance(req));
     }
 
@@ -1749,12 +1735,6 @@ static bool isSpecializedConformance(ProtocolConformance *c) {
       auto &entry = SILEntries.front();
       SILEntries = SILEntries.slice(1);
 
-      // In Embedded Swift witness tables don't have associated-types entries.
-      auto &langOpts = IGM.Context.LangOpts;
-      if (langOpts.hasFeature(Feature::Embedded) &&
-          !langOpts.hasFeature(Feature::EmbeddedExistentials))
-        return;
-
 #ifndef NDEBUG
       assert(entry.getKind() == SILWitnessTable::AssociatedType
              && "sil witness table does not match protocol");
@@ -1812,15 +1792,6 @@ static bool isSpecializedConformance(ProtocolConformance *c) {
       auto &entry = SILEntries.front();
       (void)entry;
       SILEntries = SILEntries.slice(1);
-      auto &langOpts = IGM.Context.LangOpts;
-      if (langOpts.hasFeature(Feature::Embedded) &&
-          !langOpts.hasFeature(Feature::EmbeddedExistentials) &&
-          !requirement.getAssociatedRequirement()->requiresClass()) {
-        // If it's not a class protocol, the associated type can never be used to create
-        // an existential. Therefore this witness entry is never used at runtime
-        // in embedded swift.
-        return;
-      }
 
       ProtocolConformanceRef associatedConformance =
         ConformanceInContext.getAssociatedConformance(
@@ -2795,13 +2766,6 @@ static void addWTableTypeMetadata(IRGenModule &IGM,
 }
 
 void IRGenModule::emitSILWitnessTable(SILWitnessTable *wt) {
-  if (Context.LangOpts.hasFeature(Feature::Embedded)) {
-    // In Embedded Swift, only class-bound wtables are allowed.
-    if (!wt->getConformance()->getProtocol()->requiresClass() &&
-        !Context.LangOpts.hasFeature(Feature::EmbeddedExistentials))
-      return;
-  }
-
   // Don't emit a witness table if it is a declaration.
   if (wt->isDeclaration())
     return;
@@ -3817,13 +3781,6 @@ llvm::Value *irgen::emitWitnessTableRef(IRGenFunction &IGF,
                                         llvm::Value **srcMetadataCache,
                                         ProtocolConformanceRef conformance) {
   auto proto = conformance.getProtocol();
-
-  // In Embedded Swift, only class-bound wtables are allowed.
-  auto &langOpts = srcType->getASTContext().LangOpts;
-  if (langOpts.hasFeature(Feature::Embedded) &&
-      !langOpts.hasFeature(Feature::EmbeddedExistentials)) {
-    assert(proto->requiresClass());
-  }
 
   assert(Lowering::TypeConverter::protocolRequiresWitnessTable(proto)
          && "protocol does not have witness tables?!");

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -1467,13 +1467,6 @@ bool IRGenerator::canEmitWitnessTableLazily(SILWitnessTable *wt) {
 }
 
 void IRGenerator::addLazyWitnessTable(const ProtocolConformance *Conf) {
-  // In Embedded Swift, only class-bound wtables are allowed.
-  auto &langOpts = SIL.getASTContext().LangOpts;
-  if (langOpts.hasFeature(Feature::Embedded) &&
-      !langOpts.hasFeature(Feature::EmbeddedExistentials)) {
-    assert(Conf->getProtocol()->requiresClass());
-  }
-
   if (auto *wt = SIL.lookUpWitnessTable(Conf)) {
     // Add it to the queue if it hasn't already been put there.
     if (canEmitWitnessTableLazily(wt) &&
@@ -2448,7 +2441,5 @@ bool swift::writeEmptyOutputFilesFor(
 }
 
 bool IRGenModule::isEmbeddedWithExistentials() const {
-  auto &langOpts = Context.LangOpts;
-  return langOpts.hasFeature(Feature::Embedded) &&
-    langOpts.hasFeature(Feature::EmbeddedExistentials);
+  return Context.LangOpts.hasFeature(Feature::Embedded);
 }

--- a/lib/IRGen/Linking.cpp
+++ b/lib/IRGen/Linking.cpp
@@ -633,9 +633,7 @@ static bool isLazyEmissionOfPublicSymbolInMultipleModulesPossible(CanType ty) {
   // In embedded existenitals mode we generate lazy public metadata on demand
   // which makes it non unique.
   auto &langOpts = ty->getASTContext().LangOpts;
-  auto isEmbeddedWithExistentials = langOpts.hasFeature(Feature::Embedded) &&
-    langOpts.hasFeature(Feature::EmbeddedExistentials);
-  if (isEmbeddedWithExistentials) {
+  if (langOpts.hasFeature(Feature::Embedded)) {
     if (auto nominal = ty->getAnyNominal()) {
       if (SILDeclRef::declHasNonUniqueDefinition(nominal)) {
         return true;
@@ -1149,9 +1147,7 @@ llvm::Type *LinkEntity::getDefaultDeclarationType(IRGenModule &IGM) const {
     switch (getMetadataAddress()) {
     case TypeMetadataAddress::FullMetadata: {
       auto &langOpts = IGM.Context.LangOpts;
-      auto isEmbeddedWithExistentials = langOpts.hasFeature(Feature::Embedded) &&
-        langOpts.hasFeature(Feature::EmbeddedExistentials);
-      if (isEmbeddedWithExistentials) {
+      if (langOpts.hasFeature(Feature::Embedded)) {
         return IGM.EmbeddedExistentialsMetadataStructTy;
       }
       if (getType().getClassOrBoundGenericClass())

--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -3422,15 +3422,6 @@ llvm::Value *IRGenFunction::emitTypeMetadataRef(CanType type) {
 MetadataResponse
 IRGenFunction::emitTypeMetadataRef(CanType type,
                                    DynamicMetadataRequest request) {
-  auto &langOpts = type->getASTContext().LangOpts;
-  if (langOpts.hasFeature(Feature::Embedded) &&
-      !langOpts.hasFeature(Feature::EmbeddedExistentials) &&
-      !isMetadataAllowedInEmbedded(type)) {
-    llvm::errs() << "Metadata pointer requested in embedded Swift for type "
-                 << type << "\n";
-    llvm::report_fatal_error("metadata used in embedded mode");
-  }
-
   type = IGM.getRuntimeReifiedType(type);
   // Look through any opaque types we're allowed to.
   type = IGM.substOpaqueTypesWithUnderlyingTypes(type);
@@ -3444,7 +3435,7 @@ IRGenFunction::emitTypeMetadataRef(CanType type,
   if (type->hasArchetype() ||
       !shouldTypeMetadataAccessUseAccessor(IGM, type) ||
       isa<PackType>(type) ||
-      langOpts.hasFeature(Feature::Embedded)) {
+      IGM.Context.LangOpts.hasFeature(Feature::Embedded)) {
     return emitDirectTypeMetadataRef(*this, type, request);
   }
 

--- a/test/embedded/basic-errors-no-stdlib.swift
+++ b/test/embedded/basic-errors-no-stdlib.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-ir -verify %s -parse-stdlib -enable-experimental-feature Embedded -wmo -disable-experimental-feature EmbeddedExistentials
+// RUN: %target-swift-frontend -emit-ir -verify %s -parse-stdlib -enable-experimental-feature Embedded -wmo
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: swift_feature_Embedded
@@ -9,5 +9,5 @@ public protocol Player {}
 struct Concrete: Player {}
 
 public func test() -> any Player {
-  Concrete() // expected-error {{cannot use a value of protocol type 'any Player' in embedded Swift}}
+  Concrete()
 }

--- a/test/embedded/classes-generic-no-stdlib.swift
+++ b/test/embedded/classes-generic-no-stdlib.swift
@@ -1,6 +1,5 @@
 // RUN: %target-swift-emit-sil %s -parse-stdlib -enable-experimental-feature Embedded -target arm64e-apple-none -wmo | %FileCheck %s --check-prefix CHECK-SIL
-// RUN: %target-swift-emit-ir %s -parse-stdlib -disable-experimental-feature EmbeddedExistentials -enable-experimental-feature Embedded -target arm64e-apple-none -wmo | %FileCheck %s --check-prefix CHECK-IR
-// RUN: %target-swift-emit-ir %s -parse-stdlib -enable-experimental-feature Embedded -target arm64e-apple-none -wmo | %FileCheck %s --check-prefix CHECK-IR-EXIST
+// RUN: %target-swift-emit-ir %s -parse-stdlib -enable-experimental-feature Embedded -target arm64e-apple-none -wmo | %FileCheck %s --check-prefix CHECK-IR
 
 // UNSUPPORTED: CPU=wasm32
 // REQUIRES: swift_in_compiler
@@ -53,9 +52,6 @@ public func bar(t: T2) -> MyClass<T2> {
 // CHECK-SIL: }
 
 
-// CHECK-IR-DAG: @"$e4main7MyClassCyAA2T2VGN" = {{.*}}<{ ptr, ptr, ptr, ptr, ptr, ptr, ptr }> <{ ptr null, ptr @"$e4main7MyClassCfDAA2T2V_Tg5", ptr null, ptr @"$e4main7MyClassC1txvgAA2T2V_Tg5", ptr @"$e4main7MyClassC1txvsAA2T2V_Tg5", ptr @"$e4main7MyClassC1txvMAA2T2V_Tg5", ptr @"$e4main7MyClassC1tACyxGx_tcfCAA2T2V_Tg5" }>
-// CHECK-IR-DAG: @"$e4main7MyClassCyAA2T1VGN" = {{.*}}<{ ptr, ptr, ptr, ptr, ptr, ptr, ptr }> <{ ptr null, ptr @"$e4main7MyClassCfDAA2T1V_Tg5", ptr null, ptr @"$e4main7MyClassC1txvgAA2T1V_Tg5", ptr @"$e4main7MyClassC1txvsAA2T1V_Tg5", ptr @"$e4main7MyClassC1txvMAA2T1V_Tg5", ptr @"$e4main7MyClassC1tACyxGx_tcfCAA2T1V_Tg5" }>
-
 // CHECK-IR-DAG: define {{.*}}void @"$e4main7MyClassC1txvgAA2T1V_Tg5"(ptr swiftself %0)
 // CHECK-IR-DAG: define {{.*}}i1 @"$e4main7MyClassC1txvgAA2T2V_Tg5"(ptr swiftself %0)
 // CHECK-IR-DAG: define {{.*}}ptr @"$e4main7MyClassC1tACyxGx_tcfCAA2T1V_Tg5"(ptr swiftself %0)
@@ -73,8 +69,8 @@ public func bar(t: T2) -> MyClass<T2> {
 
 
 
-// CHECK-IR-EXIST-DAG: @"$e4main7MyClassCyAA2T1VGMf" = {{.*}} <{ ptr, ptr, ptr, ptr, ptr, ptr, ptr, ptr }> <{ ptr @"$eBoWV", ptr null, ptr @"$e4main7MyClassCfDAA2T1V_Tg5", ptr null, ptr @"$e4main7MyClassC1txvgAA2T1V_Tg5", ptr @"$e4main7MyClassC1txvsAA2T1V_Tg5", ptr @"$e4main7MyClassC1txvMAA2T1V_Tg5", ptr @"$e4main7MyClassC1tACyxGx_tcfCAA2T1V_Tg5" }>
-// CHECK-IR-EXIST-DAG: @"$e4main7MyClassCyAA2T2VGMf" = {{.*}} <{ ptr, ptr, ptr, ptr, ptr, ptr, ptr, ptr }> <{ ptr @"$eBoWV", ptr null, ptr @"$e4main7MyClassCfDAA2T2V_Tg5", ptr null, ptr @"$e4main7MyClassC1txvgAA2T2V_Tg5", ptr @"$e4main7MyClassC1txvsAA2T2V_Tg5", ptr @"$e4main7MyClassC1txvMAA2T2V_Tg5", ptr @"$e4main7MyClassC1tACyxGx_tcfCAA2T2V_Tg5" }>
+// CHECK-IR-DAG: @"$e4main7MyClassCyAA2T1VGMf" = {{.*}} <{ ptr, ptr, ptr, ptr, ptr, ptr, ptr, ptr }> <{ ptr @"$eBoWV", ptr null, ptr @"$e4main7MyClassCfDAA2T1V_Tg5", ptr null, ptr @"$e4main7MyClassC1txvgAA2T1V_Tg5", ptr @"$e4main7MyClassC1txvsAA2T1V_Tg5", ptr @"$e4main7MyClassC1txvMAA2T1V_Tg5", ptr @"$e4main7MyClassC1tACyxGx_tcfCAA2T1V_Tg5" }>
+// CHECK-IR-DAG: @"$e4main7MyClassCyAA2T2VGMf" = {{.*}} <{ ptr, ptr, ptr, ptr, ptr, ptr, ptr, ptr }> <{ ptr @"$eBoWV", ptr null, ptr @"$e4main7MyClassCfDAA2T2V_Tg5", ptr null, ptr @"$e4main7MyClassC1txvgAA2T2V_Tg5", ptr @"$e4main7MyClassC1txvsAA2T2V_Tg5", ptr @"$e4main7MyClassC1txvMAA2T2V_Tg5", ptr @"$e4main7MyClassC1tACyxGx_tcfCAA2T2V_Tg5" }>
 
-// CHECK-IR-EXIST-DAG: @"$e4main7MyClassCyAA2T1VGN" = {{.*}} alias {{.*}} ptr @"$e4main7MyClassCyAA2T1VGMf", i32 0, i32 1)
-// CHECK-IR-EXIST-DAG: @"$e4main7MyClassCyAA2T2VGN" = {{.*}} alias {{.*}} ptr @"$e4main7MyClassCyAA2T2VGMf", i32 0, i32 1)
+// CHECK-IR-DAG: @"$e4main7MyClassCyAA2T1VGN" = {{.*}} alias {{.*}} ptr @"$e4main7MyClassCyAA2T1VGMf", i32 0, i32 1)
+// CHECK-IR-DAG: @"$e4main7MyClassCyAA2T2VGN" = {{.*}} alias {{.*}} ptr @"$e4main7MyClassCyAA2T2VGMf", i32 0, i32 1)

--- a/test/embedded/classes-methods-no-stdlib.swift
+++ b/test/embedded/classes-methods-no-stdlib.swift
@@ -1,5 +1,4 @@
-// RUN: %target-swift-emit-ir %s -parse-stdlib -enable-experimental-feature Embedded -target arm64e-apple-none -wmo -disable-experimental-feature EmbeddedExistentials | %FileCheck %s
-// RUN: %target-swift-emit-ir %s -parse-stdlib -enable-experimental-feature Embedded -target arm64e-apple-none -wmo | %FileCheck %s --check-prefix=EXIST
+// RUN: %target-swift-emit-ir %s -parse-stdlib -enable-experimental-feature Embedded -target arm64e-apple-none -wmo | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: swift_feature_Embedded
@@ -13,8 +12,11 @@ public class MySubClass: MyClass {
   override func foo() { }
 }
 
-// CHECK: @"$e4main7MyClassCN" = {{.*}}<{ ptr, ptr, ptr, ptr, ptr, ptr }> <{ ptr null, ptr @"$e4main7MyClassCfD", ptr null, ptr @"$e4main7MyClassC3fooyyF", ptr @"$e4main7MyClassC3baryyF", ptr @swift_deletedMethodError }>
-// CHECK: @"$e4main10MySubClassCN" = {{.*}}<{ ptr, ptr, ptr, ptr, ptr, ptr }> <{ ptr @"$e4main7MyClassCN", ptr @"$e4main10MySubClassCfD", ptr null, ptr @"$e4main10MySubClassC3fooyyF", ptr @"$e4main7MyClassC3baryyF", ptr @"$e4main10MySubClassCACycfC" }>
+// CHECK: @"$e4main10MySubClassCMf" = {{.*}} <{ ptr @"$eBoWV", ptr getelementptr inbounds ({{.*}}, ptr @"$e4main7MyClassCMf", i32 0, i32 1), ptr @"$e4main10MySubClassCfD", ptr null, ptr @"$e4main10MySubClassC3fooyyF", ptr @"$e4main7MyClassC3baryyF", ptr @"$e4main10MySubClassCACycfC" }>
+// CHECK: @"$e4main7MyClassCMf" = {{.*}} <{ ptr @"$eBoWV", ptr null, ptr @"$e4main7MyClassCfD", ptr null, ptr @"$e4main7MyClassC3fooyyF", ptr @"$e4main7MyClassC3baryyF", ptr @swift_deletedMethodError }>
+
+// CHECK: @"$e4main10MySubClassCN" = {{.*}}alias{{.*}} ptr @"$e4main10MySubClassCMf", i32 0, i32 1)
+// CHECK: @"$e4main7MyClassCN" = {{.*}}alias{{.*}} ptr @"$e4main7MyClassCMf", i32 0, i32 1)
 
 // CHECK: define {{.*}}void @"$e4main4test1xyAA7MyClassC_tF"(ptr %0)
 public func test(x: MyClass) {
@@ -38,38 +40,3 @@ public func test(x: MyClass) {
   // CHECK: call swiftcc void @"$e4main7MyClassC3baryyF"
 
 }
-
-
-// EXIST: @"$e4main10MySubClassCMf" = {{.*}} <{ ptr @"$eBoWV", ptr getelementptr inbounds ({{.*}}, ptr @"$e4main7MyClassCMf", i32 0, i32 1), ptr @"$e4main10MySubClassCfD", ptr null, ptr @"$e4main10MySubClassC3fooyyF", ptr @"$e4main7MyClassC3baryyF", ptr @"$e4main10MySubClassCACycfC" }>
-// EXIST: @"$e4main7MyClassCMf" = {{.*}} <{ ptr @"$eBoWV", ptr null, ptr @"$e4main7MyClassCfD", ptr null, ptr @"$e4main7MyClassC3fooyyF", ptr @"$e4main7MyClassC3baryyF", ptr @swift_deletedMethodError }>
-
-// EXIST: @"$e4main10MySubClassCN" = {{.*}}alias{{.*}} ptr @"$e4main10MySubClassCMf", i32 0, i32 1)
-// EXIST: @"$e4main7MyClassCN" = {{.*}}alias{{.*}} ptr @"$e4main7MyClassCMf", i32 0, i32 1)
-
-
-// EXIST: define {{.*}}void @"$e4main4test1xyAA7MyClassC_tF"(ptr %0)
-
-// public func test(x: MyClass) {
-
-  // x.foo() // goes through the vtable
-
-  // EXIST: %1 = load ptr, ptr %0
-  // EXIST: %2 = getelementptr inbounds ptr, ptr %1, i64 3
-  // EXIST: %3 = load ptr, ptr %2
-  // EXIST: call swiftcc void %3(ptr swiftself %0)
-
-  // x.bar() // does not go through the vtable
-
-  // EXIST: call swiftcc void @"$e4main7MyClassC3baryyF"
-
-  // let y = MySubClass()
-
-  // EXIST: call swiftcc ptr @"$e4main10MySubClassCACycfC"
-
-  // y.foo() // does not go through the vtable
-
-  // EXIST: call swiftcc void @"$e4main10MySubClassC3fooyyF"
-
-  // y.bar() // does not go through the vtable
-
-  // EXIST: call swiftcc void @"$e4main7MyClassC3baryyF"

--- a/test/embedded/classes-no-stdlib.swift
+++ b/test/embedded/classes-no-stdlib.swift
@@ -1,5 +1,4 @@
-// RUN: %target-swift-emit-ir %s -parse-stdlib -enable-experimental-feature Embedded -target arm64e-apple-none -wmo -disable-experimental-feature EmbeddedExistentials | %FileCheck %s
-// RUN: %target-swift-emit-ir %s -parse-stdlib -enable-experimental-feature Embedded -target arm64e-apple-none -wmo | %FileCheck %s --check-prefix=EXIST
+// RUN: %target-swift-emit-ir %s -parse-stdlib -enable-experimental-feature Embedded -target arm64e-apple-none -wmo | %FileCheck %s
 
 
 // REQUIRES: swift_in_compiler
@@ -7,50 +6,37 @@
 
 public class MyClass {}
 
-// CHECK-DAG: @"$e4main7MyClassCN" = {{.*}}<{ ptr, ptr, ptr, ptr }> <{ ptr null, ptr @"$e4main7MyClassCfD", ptr null, ptr @"$e4main7MyClassCACycfC" }>
+public func foo() -> MyClass {
+  return MyClass()
+}
+
+public class MySubClass: MyClass {}
+
+
+public func bar() -> MyClass {
+  return MySubClass()
+}
+
+
+// CHECK-DAG: @"$e4main10MySubClassCMf" = {{.*}} <{ ptr @"$eBoWV", ptr getelementptr inbounds ({{.*}}, ptr @"$e4main7MyClassCMf", i32 0, i32 1), ptr @"$e4main10MySubClassCfD", ptr null, ptr @"$e4main10MySubClassCACycfC" }>
+// CHECK-DAG: @"$e4main7MyClassCMf" = {{.*}} <{ ptr @"$eBoWV", ptr null, ptr @"$e4main7MyClassCfD", ptr null, ptr @"$e4main7MyClassCACycfC" }>
+
+// CHECK-DAG: @"$e4main10MySubClassCN" = {{.*}} ptr @"$e4main10MySubClassCMf", i32 0, i32 1)
+// CHECK-DAG: @"$e4main7MyClassCN" = {{.*}} ptr @"$e4main7MyClassCMf", i32 0, i32 1)
+
+// CHECK-DAG: define {{.*}}ptr @"$e4main3barAA7MyClassCyF"
+
+
 // CHECK-DAG: define {{.*}}ptr @"$e4main7MyClassCfd"
 // CHECK-DAG: define {{.*}}void @"$e4main7MyClassCfD"
 // CHECK-DAG: define {{.*}}ptr @"$e4main7MyClassCACycfC"
 // CHECK-DAG: define {{.*}}ptr @"$e4main7MyClassCACycfc"
 
-public func foo() -> MyClass {
-  return MyClass()
-}
+
 // CHECK-DAG: define {{.*}}ptr @"$e4main3fooAA7MyClassCyF"
 
-public class MySubClass: MyClass {}
 
-// CHECK-DAG: @"$e4main10MySubClassCN" = {{.*}}<{ ptr, ptr, ptr, ptr }> <{ ptr @"$e4main7MyClassCN", ptr @"$e4main10MySubClassCfD", ptr null, ptr @"$e4main10MySubClassCACycfC" }>
 // CHECK-DAG: define {{.*}}ptr @"$e4main10MySubClassCACycfC"
 // CHECK-DAG: define {{.*}}ptr @"$e4main10MySubClassCACycfc"
 // CHECK-DAG: define {{.*}}ptr @"$e4main10MySubClassCfd"
 // CHECK-DAG: define {{.*}}void @"$e4main10MySubClassCfD"
-
-public func bar() -> MyClass {
-  return MySubClass()
-}
-// CHECK-DAG: define {{.*}}ptr @"$e4main3barAA7MyClassCyF"
-
-
-// EXIST-DAG: @"$e4main10MySubClassCMf" = {{.*}} <{ ptr @"$eBoWV", ptr getelementptr inbounds ({{.*}}, ptr @"$e4main7MyClassCMf", i32 0, i32 1), ptr @"$e4main10MySubClassCfD", ptr null, ptr @"$e4main10MySubClassCACycfC" }>
-// EXIST-DAG: @"$e4main7MyClassCMf" = {{.*}} <{ ptr @"$eBoWV", ptr null, ptr @"$e4main7MyClassCfD", ptr null, ptr @"$e4main7MyClassCACycfC" }>
-
-// EXIST-DAG: @"$e4main10MySubClassCN" = {{.*}} ptr @"$e4main10MySubClassCMf", i32 0, i32 1)
-// EXIST-DAG: @"$e4main7MyClassCN" = {{.*}} ptr @"$e4main7MyClassCMf", i32 0, i32 1)
-
-// EXIST-DAG: define {{.*}}ptr @"$e4main3barAA7MyClassCyF"
-
-
-// EXIST-DAG: define {{.*}}ptr @"$e4main7MyClassCfd"
-// EXIST-DAG: define {{.*}}void @"$e4main7MyClassCfD"
-// EXIST-DAG: define {{.*}}ptr @"$e4main7MyClassCACycfC"
-// EXIST-DAG: define {{.*}}ptr @"$e4main7MyClassCACycfc"
-
-
-// EXIST-DAG: define {{.*}}ptr @"$e4main3fooAA7MyClassCyF"
-
-
-// EXIST-DAG: define {{.*}}ptr @"$e4main10MySubClassCACycfC"
-// EXIST-DAG: define {{.*}}ptr @"$e4main10MySubClassCACycfc"
-// EXIST-DAG: define {{.*}}ptr @"$e4main10MySubClassCfd"
-// EXIST-DAG: define {{.*}}void @"$e4main10MySubClassCfD"

--- a/test/embedded/concurrency-deleted-method.swift
+++ b/test/embedded/concurrency-deleted-method.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -disable-experimental-feature EmbeddedExistentials -enable-experimental-feature Embedded -parse-as-library -module-name main %s -emit-ir | %FileCheck --check-prefix=CHECK-IR %s
-// RUN: %target-swift-frontend -disable-experimental-feature EmbeddedExistentials -enable-experimental-feature Embedded -parse-as-library -module-name main %s -c -o %t/a.o
+// RUN: %target-swift-frontend -enable-experimental-feature Embedded -parse-as-library -module-name main %s -emit-ir | %FileCheck --check-prefix=CHECK-IR %s
+// RUN: %target-swift-frontend -enable-experimental-feature Embedded -parse-as-library -module-name main %s -c -o %t/a.o
 // RUN: %target-clang %t/a.o %target-embedded-posix-shim -o %t/a.out -L%swift_obj_root/lib/swift/embedded/%module-target-triple %target-clang-resource-dir-opt -lswift_Concurrency %target-swift-default-executor-opt -dead_strip
 // RUN: %target-run %t/a.out | %FileCheck %s
 
@@ -38,7 +38,7 @@ actor MyActor {
 }
 
 // CHECK-IR:      @swift_deletedAsyncMethodErrorTu =
-// CHECK-IR:      @"$e4main7MyActorCN" = constant <{ ptr, ptr, ptr, ptr, ptr, ptr, ptr, ptr, ptr }> <{
+// CHECK-IR:      @"$e4main7MyActorCMf" = internal constant <{ {{.*}} }> <{
 // CHECK-IR-SAME:   ptr null,
 // CHECK-IR-SAME:   ptr @"$e4main7MyActorCfD{{(.ptrauth[.0-9]*)?}}",
 // CHECK-IR-SAME:   ptr null,

--- a/test/embedded/existential-class-bound5.swift
+++ b/test/embedded/existential-class-bound5.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-ir -parse-as-library -module-name main -verify %s -enable-experimental-feature Embedded -wmo -disable-experimental-feature EmbeddedExistentials
+// RUN: %target-swift-emit-ir -parse-as-library -module-name main -verify %s -enable-experimental-feature Embedded -wmo
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib
@@ -22,13 +22,13 @@ func test(existential: any ClassBound) {
 }
 
 func test(existential: any NotClassBound) {
-    existential.foo() // expected-error {{cannot use a value of protocol type 'any NotClassBound' in embedded Swift}}
+    existential.foo()
 }
 
 @main
 struct Main {
     static func main() {
         test(existential: MyClass() as (any ClassBound)) // ok
-        test(existential: MyClass() as (any NotClassBound)) // expected-error {{cannot use a value of protocol type 'any NotClassBound' in embedded Swift}}
+        test(existential: MyClass() as (any NotClassBound)) // ok
     }
 }

--- a/test/embedded/existential-composition.swift
+++ b/test/embedded/existential-composition.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-ir -parse-as-library -module-name main -verify %s -enable-experimental-feature Embedded -wmo -disable-experimental-feature EmbeddedExistentials
+// RUN: %target-swift-emit-ir -parse-as-library -module-name main -verify %s -enable-experimental-feature Embedded -wmo
 
 // REQUIRES: swift_feature_Embedded
 
@@ -22,6 +22,6 @@ func test(existential: any ClassBound & OtherProtocol) {
 @main
 struct Main {
   static func main() {
-    test(existential: MyClass()) // expected-error {{cannot use a value of protocol type 'any OtherProtocol' in embedded Swift}}
+    test(existential: MyClass())
   }
 }

--- a/test/embedded/existential.swift
+++ b/test/embedded/existential.swift
@@ -1,27 +1,14 @@
-// RUN: %target-swift-frontend -enable-experimental-feature EmbeddedExistentials -enable-experimental-feature Embedded -parse-as-library -wmo -emit-sil %s | %FileCheck %s
-// RUN: %target-run-simple-swift(-enable-experimental-feature EmbeddedExistentials -enable-experimental-feature Embedded -parse-as-library -wmo %target-embedded-posix-shim) | %FileCheck %s --check-prefix=OUTPUT
-// RUN: %target-run-simple-swift(-enable-experimental-feature EmbeddedExistentials -enable-experimental-feature Embedded -parse-as-library -wmo -O %target-embedded-posix-shim) | %FileCheck %s --check-prefix=OUTPUT
-
-// RUN: not %target-swift-frontend -enable-experimental-feature EmbeddedExistentials -parse-as-library -wmo -emit-sil %s 2>&1 | %FileCheck --check-prefix=ERRMSG %s
+// RUN: %target-swift-frontend -enable-experimental-feature Embedded -parse-as-library -wmo -emit-sil %s | %FileCheck %s
+// RUN: %target-run-simple-swift(-enable-experimental-feature Embedded -parse-as-library -wmo %target-embedded-posix-shim) | %FileCheck %s --check-prefix=OUTPUT
+// RUN: %target-run-simple-swift(-enable-experimental-feature Embedded -parse-as-library -wmo -O %target-embedded-posix-shim) | %FileCheck %s --check-prefix=OUTPUT
 
 // EmbeddedExistentials is the default.
 // RUN: %target-run-simple-swift( -enable-experimental-feature Embedded -parse-as-library -wmo %target-embedded-posix-shim) | %FileCheck %s --check-prefix=OUTPUT
-
-// Test -disable-experimental-feature EmbeddedExistentials
-// RUN: not %target-swift-frontend -disable-experimental-feature EmbeddedExistentials -enable-experimental-feature Embedded -parse-as-library -wmo -emit-sil %s 2>&1 | %FileCheck --check-prefix=ERRMSG2 %s
-// RUN: not %target-swift-frontend -enable-experimental-feature Embedded -disable-experimental-feature EmbeddedExistentials -parse-as-library -wmo -emit-sil %s 2>&1 | %FileCheck --check-prefix=ERRMSG2 %s
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
 // REQUIRES: swift_feature_Embedded
-// REQUIRES: swift_feature_EmbeddedExistentials
-
-// EmbeddedExistentials requires Embedded
-// ERRMSG: error: EmbeddedExistentials requires enabling embedded Swift.
-
-// -disable-experimental-feature EmbeddedExistentials
-// ERRMSG2: error: cannot use a value of protocol type 'Any' in embedded Swift
 
 class CP {
 }

--- a/test/embedded/existential_cast_fails.swift
+++ b/test/embedded/existential_cast_fails.swift
@@ -4,25 +4,25 @@
 
 // RUN: %target-build-swift -DT1 -enable-experimental-feature Embedded \
 // RUN:  -parse-as-library -Xlinker %t/unbuffered-putchar.o \
-// RUN:  -enable-experimental-feature EmbeddedExistentials \
+// RUN:  \
 // RUN:  -wmo -runtime-compatibility-version none %s  -o %t/t1.out %target-embedded-posix-shim
 // RUN: %target-not-crash %target-run %t/t1.out 2>&1 | %FileCheck %s --check-prefix=CHECK-T1
 
 // RUN: %target-build-swift -DT2 -enable-experimental-feature Embedded \
 // RUN:  -parse-as-library -Xlinker %t/unbuffered-putchar.o \
-// RUN:  -enable-experimental-feature EmbeddedExistentials \
+// RUN:  \
 // RUN:  -wmo -runtime-compatibility-version none %s  -o %t/t2.out %target-embedded-posix-shim
 // RUN: %target-not-crash %target-run %t/t2.out 2>&1 | %FileCheck %s --check-prefix=CHECK-T2
 
 // RUN: %target-build-swift -DT3 -enable-experimental-feature Embedded \
 // RUN:  -parse-as-library -Xlinker %t/unbuffered-putchar.o \
-// RUN:  -enable-experimental-feature EmbeddedExistentials \
+// RUN:  \
 // RUN:  -wmo -runtime-compatibility-version none %s  -o %t/t3.out %target-embedded-posix-shim
 // RUN: %target-not-crash %target-run %t/t3.out 2>&1 | %FileCheck %s --check-prefix=CHECK-T3
 
 // RUN: %target-build-swift -DT4 -enable-experimental-feature Embedded \
 // RUN:  -parse-as-library -Xlinker %t/unbuffered-putchar.o \
-// RUN:  -enable-experimental-feature EmbeddedExistentials \
+// RUN:  \
 // RUN:  -wmo -runtime-compatibility-version none %s  -o %t/t4.out %target-embedded-posix-shim
 // RUN: %target-not-crash %target-run %t/t4.out 2>&1 | %FileCheck %s --check-prefix=CHECK-T4
 
@@ -31,7 +31,6 @@
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
 // REQUIRES: swift_feature_Embedded
-// REQUIRES: swift_feature_EmbeddedExistentials
 
 // REQUIRES: OS=macosx || OS=wasip1
 

--- a/test/embedded/existential_foreign.swift
+++ b/test/embedded/existential_foreign.swift
@@ -1,11 +1,10 @@
-// RUN: %target-run-simple-swift(-import-objc-header %S/Inputs/existential_foreign.h -enable-experimental-feature EmbeddedExistentials -enable-experimental-feature Embedded -parse-as-library -wmo %target-embedded-posix-shim) | %FileCheck %s --check-prefix=OUTPUT
-// RUN: %target-run-simple-swift(-import-objc-header %S/Inputs/existential_foreign.h -enable-experimental-feature EmbeddedExistentials -enable-experimental-feature Embedded -parse-as-library -wmo -O %target-embedded-posix-shim) | %FileCheck %s --check-prefix=OUTPUT
+// RUN: %target-run-simple-swift(-import-objc-header %S/Inputs/existential_foreign.h -enable-experimental-feature Embedded -parse-as-library -wmo %target-embedded-posix-shim) | %FileCheck %s --check-prefix=OUTPUT
+// RUN: %target-run-simple-swift(-import-objc-header %S/Inputs/existential_foreign.h -enable-experimental-feature Embedded -parse-as-library -wmo -O %target-embedded-posix-shim) | %FileCheck %s --check-prefix=OUTPUT
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
 // REQUIRES: swift_feature_Embedded
-// REQUIRES: swift_feature_EmbeddedExistentials
 
 protocol P {
   func printme()

--- a/test/embedded/general-existentials1.swift
+++ b/test/embedded/general-existentials1.swift
@@ -1,12 +1,11 @@
-// RUN: %target-run-simple-swift(-enable-experimental-feature Embedded -enable-experimental-feature EmbeddedExistentials -parse-as-library -wmo %target-embedded-posix-shim) | %FileCheck %s
-// RUN: %target-run-simple-swift(-enable-experimental-feature Embedded -enable-experimental-feature EmbeddedExistentials -parse-as-library -wmo -O %target-embedded-posix-shim) | %FileCheck %s
-// RUN: %target-run-simple-swift(-enable-experimental-feature Embedded -enable-experimental-feature EmbeddedExistentials -parse-as-library -wmo -Osize %target-embedded-posix-shim) | %FileCheck %s
+// RUN: %target-run-simple-swift(-enable-experimental-feature Embedded -parse-as-library -wmo %target-embedded-posix-shim) | %FileCheck %s
+// RUN: %target-run-simple-swift(-enable-experimental-feature Embedded -parse-as-library -wmo -O %target-embedded-posix-shim) | %FileCheck %s
+// RUN: %target-run-simple-swift(-enable-experimental-feature Embedded -parse-as-library -wmo -Osize %target-embedded-posix-shim) | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
 // REQUIRES: swift_feature_Embedded
-// REQUIRES: swift_feature_EmbeddedExistentials
 
 protocol P {
     func foo()

--- a/test/embedded/lazy_metadata.swift
+++ b/test/embedded/lazy_metadata.swift
@@ -1,23 +1,22 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 
-// RUN: %target-swift-frontend -wmo -module-name A -emit-irgen -o %t/A1.ll %t/A.swift -enable-experimental-feature Embedded -enable-experimental-feature EmbeddedExistentials -parse-as-library -disable-implicit-concurrency-module-import
+// RUN: %target-swift-frontend -wmo -module-name A -emit-irgen -o %t/A1.ll %t/A.swift -enable-experimental-feature Embedded -parse-as-library -disable-implicit-concurrency-module-import
 // RUN: %FileCheck --check-prefix=A1 %s < %t/A1.ll
 
-// RUN: %target-swift-frontend -wmo -module-name A -num-threads 1 -emit-ir -o %t/A2.ll -o %t/B2.ll %t/A.swift %t/B.swift -enable-experimental-feature Embedded -enable-experimental-feature EmbeddedExistentials -parse-as-library -disable-implicit-concurrency-module-import
+// RUN: %target-swift-frontend -wmo -module-name A -num-threads 1 -emit-ir -o %t/A2.ll -o %t/B2.ll %t/A.swift %t/B.swift -enable-experimental-feature Embedded -parse-as-library -disable-implicit-concurrency-module-import
 // RUN: %FileCheck --check-prefix=A2 %s < %t/A2.ll
 // RUN: %FileCheck --check-prefix=B2 %s < %t/B2.ll
 
-// RUN: %target-swift-frontend  -emit-module -emit-module-path %t/A.swiftmodule -wmo -module-name A -emit-ir -o %t/A3.ll  %t/A.swift %t/B.swift -enable-experimental-feature Embedded -enable-experimental-feature EmbeddedExistentials -parse-as-library -disable-implicit-concurrency-module-import
+// RUN: %target-swift-frontend  -emit-module -emit-module-path %t/A.swiftmodule -wmo -module-name A -emit-ir -o %t/A3.ll  %t/A.swift %t/B.swift -enable-experimental-feature Embedded -parse-as-library -disable-implicit-concurrency-module-import
 // RUN: %FileCheck --check-prefix=A3 %s < %t/A3.ll
 
-// RUN: %target-swift-frontend -wmo -I %t -module-name C -emit-irgen -o %t/C4.ll  %t/C.swift -enable-experimental-feature Embedded -enable-experimental-feature EmbeddedExistentials -parse-as-library -disable-implicit-concurrency-module-import
+// RUN: %target-swift-frontend -wmo -I %t -module-name C -emit-irgen -o %t/C4.ll  %t/C.swift -enable-experimental-feature Embedded -parse-as-library -disable-implicit-concurrency-module-import
 // RUN: %FileCheck --check-prefix=C4 %s < %t/C4.ll
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib
 // REQUIRES: swift_feature_Embedded
-// REQUIRES: swift_feature_EmbeddedExistentials
 
 
 //--- A.swift

--- a/test/embedded/linkage/diamond_embedded_exist.swift
+++ b/test/embedded/linkage/diamond_embedded_exist.swift
@@ -2,10 +2,10 @@
 // RUN: split-file %S/diamond.swift %t
 
 // Test:  Main drives code generation
-// RUN: %target-swift-frontend -c -emit-module -o %t/Root.o %t/Root.swift -enable-experimental-feature Embedded -enable-experimental-feature DeferredCodeGen -parse-as-library -enable-experimental-feature EmbeddedExistentials
-// RUN: %target-swift-frontend -c -I %t -emit-module -o %t/ClientA.o %t/ClientA.swift -enable-experimental-feature Embedded -enable-experimental-feature DeferredCodeGen -parse-as-library -enable-experimental-feature EmbeddedExistentials
-// RUN: %target-swift-frontend -c -I %t -emit-module -o %t/ClientB.o %t/ClientB.swift -enable-experimental-feature Embedded -enable-experimental-feature DeferredCodeGen -parse-as-library -enable-experimental-feature EmbeddedExistentials
-// RUN: %target-swift-frontend -c -I %t -emit-module -o %t/Application.o %t/Application.swift -enable-experimental-feature Embedded -enable-experimental-feature DeferredCodeGen -parse-as-library -enable-experimental-feature EmbeddedExistentials
+// RUN: %target-swift-frontend -c -emit-module -o %t/Root.o %t/Root.swift -enable-experimental-feature Embedded -enable-experimental-feature DeferredCodeGen -parse-as-library
+// RUN: %target-swift-frontend -c -I %t -emit-module -o %t/ClientA.o %t/ClientA.swift -enable-experimental-feature Embedded -enable-experimental-feature DeferredCodeGen -parse-as-library
+// RUN: %target-swift-frontend -c -I %t -emit-module -o %t/ClientB.o %t/ClientB.swift -enable-experimental-feature Embedded -enable-experimental-feature DeferredCodeGen -parse-as-library
+// RUN: %target-swift-frontend -c -I %t -emit-module -o %t/Application.o %t/Application.swift -enable-experimental-feature Embedded -enable-experimental-feature DeferredCodeGen -parse-as-library
 // RUN: %target-clang %target-clang-resource-dir-opt %t/Root.o %t/ClientA.o %t/ClientB.o %t/Application.o %target-embedded-posix-shim -o %t/Application
 // RUN: %target-run %t/Application | %FileCheck %s
 
@@ -15,17 +15,16 @@
 // RUN: split-file %s %t
 
 // Test:  Main drives most code generation but Root.swift references PointClass.
-// RUN: %target-swift-frontend -c -emit-module -o %t/Root.o %t/Root.swift -enable-experimental-feature Embedded -enable-experimental-feature DeferredCodeGen -parse-as-library -enable-experimental-feature EmbeddedExistentials
-// RUN: %target-swift-frontend -c -I %t -emit-module -o %t/ClientA.o %t/ClientA.swift -enable-experimental-feature Embedded -enable-experimental-feature DeferredCodeGen -parse-as-library -enable-experimental-feature EmbeddedExistentials
-// RUN: %target-swift-frontend -c -I %t -emit-module -o %t/ClientB.o %t/ClientB.swift -enable-experimental-feature Embedded -enable-experimental-feature DeferredCodeGen -parse-as-library -enable-experimental-feature EmbeddedExistentials
-// RUN: %target-swift-frontend -c -I %t -emit-module -o %t/Application.o %t/Application.swift -enable-experimental-feature Embedded -enable-experimental-feature DeferredCodeGen -parse-as-library -enable-experimental-feature EmbeddedExistentials
+// RUN: %target-swift-frontend -c -emit-module -o %t/Root.o %t/Root.swift -enable-experimental-feature Embedded -enable-experimental-feature DeferredCodeGen -parse-as-library
+// RUN: %target-swift-frontend -c -I %t -emit-module -o %t/ClientA.o %t/ClientA.swift -enable-experimental-feature Embedded -enable-experimental-feature DeferredCodeGen -parse-as-library
+// RUN: %target-swift-frontend -c -I %t -emit-module -o %t/ClientB.o %t/ClientB.swift -enable-experimental-feature Embedded -enable-experimental-feature DeferredCodeGen -parse-as-library
+// RUN: %target-swift-frontend -c -I %t -emit-module -o %t/Application.o %t/Application.swift -enable-experimental-feature Embedded -enable-experimental-feature DeferredCodeGen -parse-as-library
 // RUN: %target-clang %target-clang-resource-dir-opt %t/Root.o %t/ClientA.o %t/ClientB.o %t/Application.o %target-embedded-posix-shim -o %t/Application
 // RUN: %target-run %t/Application | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
 // REQUIRES: swift_feature_Embedded
-// REQUIRES: swift_feature_EmbeddedExistentials
 // REQUIRES: swift_feature_DeferredCodeGen
 
 //--- Root.swift

--- a/test/embedded/linkage/leaf_application.swift
+++ b/test/embedded/linkage/leaf_application.swift
@@ -7,14 +7,13 @@
 // RUN: %target-swift-frontend %t/Library.swift -parse-as-library -entry-point-function-name Library_main -enable-experimental-feature Embedded -enable-experimental-feature DeferredCodeGen -emit-sil -emit-module-path %t/Modules/Library.swiftmodule -o - | %FileCheck -check-prefix LIBRARY-SIL %s
 
 // IR checking to ensure we get the right weak symbols.
-// RUN: %target-swift-frontend %t/Library.swift -disable-experimental-feature EmbeddedExistentials -parse-as-library -entry-point-function-name Library_main -enable-experimental-feature Embedded -enable-experimental-feature DeferredCodeGen -emit-ir -o - | %FileCheck -check-prefix LIBRARY-IR --dump-input-filter all %s
-// RUN: %target-swift-frontend %t/Library.swift -parse-as-library -entry-point-function-name Library_main -enable-experimental-feature Embedded -enable-experimental-feature DeferredCodeGen -emit-ir -o - | %FileCheck -check-prefix LIBRARY-EXIST-IR --dump-input-filter all %s
+// RUN: %target-swift-frontend %t/Library.swift -parse-as-library -entry-point-function-name Library_main -enable-experimental-feature Embedded -enable-experimental-feature DeferredCodeGen -emit-ir -o - | %FileCheck -check-prefix LIBRARY-IR --dump-input-filter all %s
 
 // Application module
 
 // RUN: %target-swift-frontend %t/Application.swift -I %t/Modules -parse-as-library -entry-point-function-name Application_main -enable-experimental-feature Embedded -emit-sil -o - | %FileCheck -check-prefix APPLICATION-SIL %s
 
-// RUN: %target-swift-frontend %t/Application.swift -disable-experimental-feature EmbeddedExistentials -I %t/Modules -parse-as-library -entry-point-function-name Application_main -enable-experimental-feature Embedded -emit-ir -o - | %FileCheck -check-prefix APPLICATION-IR --dump-input-filter all %s
+// RUN: %target-swift-frontend %t/Application.swift -I %t/Modules -parse-as-library -entry-point-function-name Application_main -enable-experimental-feature Embedded -emit-ir -o - | %FileCheck -check-prefix APPLICATION-IR --dump-input-filter all %s
 // RUN: %target-swift-frontend %t/Application.swift -I %t/Modules -parse-as-library -entry-point-function-name Application_main -enable-experimental-feature Embedded -emit-ir -o - | %FileCheck -check-prefix APPLICATION-IR --dump-input-filter all %s
 
 // REQUIRES: swift_in_compiler
@@ -23,8 +22,7 @@
 
 //--- Library.swift
 
-// LIBRARY-IR: @"$e7Library10PointClassCN" = linkonce_odr {{.*}}constant
-// LIBRARY-EXIST-IR: @"$e7Library10PointClassCMf" = {{.*}}linkonce_odr {{.*}}constant
+// LIBRARY-IR: @"$e7Library10PointClassCMf" = {{.*}}linkonce_odr {{.*}}constant
 
 // Never referenced.
 // LIBRARY-IR-NOT: @"$es23_swiftEmptyArrayStorageSi_S3itvp" = linkonce_odr {{(protected |dllexport )?}}constant

--- a/test/embedded/linkage/weak_linkage_bug.swift
+++ b/test/embedded/linkage/weak_linkage_bug.swift
@@ -2,8 +2,8 @@
 // RUN: split-file %s %t
 
 
-// RUN: %target-swift-frontend -c -wmo -emit-module -o %t/C.o %t/C.swift -enable-experimental-feature Embedded -parse-as-library -enable-experimental-feature EmbeddedExistentials
-// RUN: %target-swift-frontend -num-threads 1 -c -I %t -emit-module -o %t/D.o -o %t/D2.o %t/D.swift %t/D2.swift -wmo -enable-experimental-feature Embedded -parse-as-library -enable-experimental-feature EmbeddedExistentials
+// RUN: %target-swift-frontend -c -wmo -emit-module -o %t/C.o %t/C.swift -enable-experimental-feature Embedded -parse-as-library
+// RUN: %target-swift-frontend -num-threads 1 -c -I %t -emit-module -o %t/D.o -o %t/D2.o %t/D.swift %t/D2.swift -wmo -enable-experimental-feature Embedded -parse-as-library
 
 // RUN: %target-clang %target-clang-resource-dir-opt %t/C.o %t/D.o %t/D2.o  %target-embedded-posix-shim -o %t/Application
 // RUN: %target-run %t/Application | %FileCheck %s
@@ -12,8 +12,8 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 
-// RUN: %target-swift-frontend -emit-ir -wmo -emit-module -o %t/C.ll %t/C.swift -enable-experimental-feature Embedded -parse-as-library -enable-experimental-feature EmbeddedExistentials -enable-experimental-feature CoroutineAccessors
-// RUN: %target-swift-frontend -num-threads 1 -emit-ir -I %t -emit-module -o %t/D.ll -o %t/D2.ll %t/D.swift %t/D2.swift -wmo -enable-experimental-feature Embedded -parse-as-library -enable-experimental-feature EmbeddedExistentials -enable-experimental-feature CoroutineAccessors
+// RUN: %target-swift-frontend -emit-ir -wmo -emit-module -o %t/C.ll %t/C.swift -enable-experimental-feature Embedded -parse-as-library -enable-experimental-feature CoroutineAccessors
+// RUN: %target-swift-frontend -num-threads 1 -emit-ir -I %t -emit-module -o %t/D.ll -o %t/D2.ll %t/D.swift %t/D2.swift -wmo -enable-experimental-feature Embedded -parse-as-library -enable-experimental-feature CoroutineAccessors
 
 // RUN:  %FileCheck %s --check-prefix=VTABLE-C < %t/C.ll
 // RUN:  %FileCheck %s --check-prefix=VTABLE-D < %t/D.ll
@@ -22,7 +22,6 @@
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
 // REQUIRES: swift_feature_Embedded
-// REQUIRES: swift_feature_EmbeddedExistentials
 // REQUIRES: swift_feature_CoroutineAccessors
 
 // CHECK: MyClass.foo

--- a/test/embedded/managed-buffer.swift
+++ b/test/embedded/managed-buffer.swift
@@ -1,11 +1,7 @@
-// RUN: %target-swift-emit-ir -disable-experimental-feature EmbeddedExistentials %s -module-name=main -enable-experimental-feature Embedded | %FileCheck %s
 // RUN: %target-swift-emit-ir  %s -module-name=main -enable-experimental-feature Embedded | %FileCheck %s --check-prefix=EXIST
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: swift_feature_Embedded
-
-// CHECK: @"$e4main8MyBufferCN" = {{.*constant.*}} <{ ptr @"$es13ManagedBufferCySis5UInt8VGN", ptr @"$e4main8MyBufferCfD{{[^"]*}}", ptr null, ptr @"$e4main8MyBufferC12_doNotCallMeACyt_tcfC{{[^"]*}}" }>
-// CHECK: @"$es13ManagedBufferCySis5UInt8VGN" = {{.*constant.*}} <{ ptr null, ptr @"$es13ManagedBufferCfDSi_s5UInt8VTgq5{{[^"]*}}", ptr null, ptr @"$es13ManagedBufferC12_doNotCallMeAByxq_Gyt_tcfCSi_s5UInt8VTgq5{{[^"]*}}" }>
 
 // EXIST: @"$e4main8MyBufferCMf" = {{.*}} <{ ptr @"$eBoWV{{[^"]*}}", {{.*}} ptr @"$es13ManagedBufferCySis5UInt8VGMf", i32 0, i32 1), ptr @"$e4main8MyBufferCfD{{[^"]*}}", ptr null, ptr @"$e4main8MyBufferC12_doNotCallMeACyt_tcfC{{[^"]*}}" }>
 // EXIST: @"$es13ManagedBufferCySis5UInt8VGMf" = {{.*}} <{ ptr @"$eBoWV{{[^"]*}}", ptr null, ptr @"$es13ManagedBufferCfDSi_s5UInt8VTgq5{{[^"]*}}", ptr null, ptr @"$es13ManagedBufferC12_doNotCallMeAByxq_Gyt_tcfCSi_s5UInt8VTgq5{{[^"]*}}" }>
@@ -15,4 +11,3 @@
 
 final public class MyBuffer: ManagedBuffer<Int, UInt8> {
 }
-

--- a/test/embedded/untyped-throws-exec.swift
+++ b/test/embedded/untyped-throws-exec.swift
@@ -1,12 +1,11 @@
-// RUN: %target-run-simple-swift(-enable-experimental-feature Embedded -enable-experimental-feature EmbeddedExistentials -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
-// RUN: %target-run-simple-swift(-O -enable-experimental-feature Embedded -enable-experimental-feature EmbeddedExistentials -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
+// RUN: %target-run-simple-swift(-enable-experimental-feature Embedded -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
+// RUN: %target-run-simple-swift(-O -enable-experimental-feature Embedded -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
 // REQUIRES: OS=macosx || OS=linux-gnu || OS=wasip1
 // REQUIRES: swift_feature_Embedded
-// REQUIRES: swift_feature_EmbeddedExistentials
 
 enum MyError: Error, Equatable {
   case simple


### PR DESCRIPTION
- **Explanation**: Support for existentials in Embedded Swift has been available for a little while now and appears to be solid. Remove the ability to disable them (via `-disable-experimental-feature EmbeddedExistentials`), both because it simplifies the code and because it's an ABI break to disable the feature.
- **Scope**: Limited to Embedded Swift
- **Risk**: Low. Removing a default-off feature that shouldn't be used by anyone.
- **Testing**: CI, updated a bunch of tests
