### PR TITLE
[NFC] Add Builtin.makeBorrowAt to replace unsafeAddress

### DIFF
--- a/include/swift/AST/Builtins.def
+++ b/include/swift/AST/Builtins.def
@@ -545,10 +545,18 @@ BUILTIN_SIL_OPERATION(HopToActor, "hopToActor", None)
 /// Returns the number of items in a pack.
 BUILTIN_SIL_OPERATION(PackLength, "packLength", Special)
 
-/// makeBorrow: @lifetime(borrow referent)<T: ~Copyable>(_ referent: borrowing T) -> Borrow<T>
+/// makeBorrow: @lifetime(borrow referent)<T: ~Copyable & ~Escapable>(
+///   _ referent: borrowing T) -> Borrow<T>
 ///
 /// Form a `Builtin.Borrow` referencing the argument.
 BUILTIN_SIL_OPERATION(MakeBorrow, "makeBorrow", Special)
+
+/// borrowAt: <T: ~Copyable & ~Escapable>(_ referent: Builtin.RawPointer) -> T
+///
+/// Access the value stored at `referent` as a guaranteed value.
+///
+/// Assumes natural alignment. Does not assume strict aliasing.
+BUILTIN_SIL_OPERATION(BorrowAt, "borrowAt", Special)
 
 /// dereferenceBorrow: <T: ~Copyable>(_ borrow: Borrow<T>) -> T
 ///

--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -2455,6 +2455,17 @@ static ValueDecl *getMakeBorrow(ASTContext &ctx, Identifier id) {
   return builder.build(id);
 }
 
+static ValueDecl *getBorrowAt(ASTContext &ctx, Identifier id) {
+  BuiltinFunctionBuilder builder(ctx, /* genericParamCount */ 1);
+
+  auto T = makeGenericParam(0);
+
+  builder.addParameter(makeConcrete(ctx.TheRawPointerType));
+  builder.setResult(T);
+
+  return builder.build(id);
+}
+
 static ValueDecl *getDereferenceBorrow(ASTContext &ctx, Identifier id) {
   BuiltinFunctionBuilder builder(ctx, /* genericParamCount */ 1);
 
@@ -3587,6 +3598,9 @@ ValueDecl *swift::getBuiltinValueDecl(ASTContext &Context, Identifier Id) {
 
   case BuiltinValueKind::MakeBorrow:
     return getMakeBorrow(Context, Id);
+
+  case BuiltinValueKind::BorrowAt:
+    return getBorrowAt(Context, Id);
 
   case BuiltinValueKind::DereferenceBorrow:
     return getDereferenceBorrow(Context, Id);

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -3515,6 +3515,23 @@ SILGenFunction::tryEmitAddressableParameterAsAddress(ArgumentSource &&arg,
       }
     }
   }
+  if (auto ae = dyn_cast<ApplyExpr>(expr)) {
+    if (auto declRef = ae->getFn()->getReferencedDecl()) {
+      if (declRef.getDecl()->getModuleContext()->isBuiltinModule()) {
+        auto &builtinInfo
+          = SGM.M.getBuiltinInfo(declRef.getDecl()->getBaseIdentifier());
+        // TODO: Support things like Builtin.makeBorrow(Builtin.borrowAt(p)).
+        // We should call a SGF.tryEmitBuiltinAsAddres() helper here. But
+        // CallEmission does not have a way to query ahead of time whether its
+        // result will be loaded into its RValue result.
+        if (builtinInfo.ID == BuiltinValueKind::BorrowAt) {
+          SGM.diagnose(expr, diag::not_implemented,
+                       "Builtin.borrowAt must be direclty returned from a "
+                       "borrow accessor");
+        }
+      }
+    }
+  }
   
   // Property or subscript member accesses may also be addressable.
   

--- a/lib/SILGen/SILGenBuiltin.cpp
+++ b/lib/SILGen/SILGenBuiltin.cpp
@@ -2306,6 +2306,40 @@ static ManagedValue emitBuiltinMakeBorrow(SILGenFunction &SGF,
   return emitBorrowAddress(SGF, loc, loweredBorrowTy, referent.getValue(), C);
 }
 
+static ManagedValue emitBuiltinBorrowAt(SILGenFunction &SGF,
+                                        SILLocation loc,
+                                        SubstitutionMap subs,
+                                        ArrayRef<ManagedValue> args,
+                                        SGFContext C) {
+  ASSERT(subs.getReplacementTypes().size() == 1 &&
+         "makeBorrowAt should have one type argument");
+  ASSERT(args.size() == 1 && "makeBorrowAt should have a single argument");
+
+  // The substitution determines the type of the thing we're borrowing.
+
+  auto argTy = subs.getReplacementTypes()[0]->getCanonicalType();
+  auto loweredArgTy = SGF.getLoweredType(argTy);
+
+  // Convert the pointer argument to a SIL address.
+  //
+  // Default to an unaligned pointer. This can be optimized in the presence of
+  // Builtin.assumeAlignment.
+  //
+  // Assume the borrowed value's address is from a raw pointer. Make no attempt
+  // at strict aliasing.
+  //
+  // The memory is invariant over the borrow scope, but not generally invariant.
+  //
+  // Assume natural alignment.
+  SILValue addr =
+    SGF.B.createPointerToAddress(loc, args[0].getUnmanagedValue(),
+                                 loweredArgTy.getAddressType(),
+                                 /*isStrict*/false, /*isInvariant*/false,
+                                 llvm::MaybeAlign());
+
+  // This can only be used in a borrow accessor. For bitwise-borrowable types,
+  // the accessor will emit the load_borrow + return_borrow pair.
+  return ManagedValue::forRValueWithoutOwnership(addr);
 }
 
 static ManagedValue emitBuiltinDereferenceBorrow(SILGenFunction &SGF,

--- a/lib/SILGen/SILGenBuiltin.cpp
+++ b/lib/SILGen/SILGenBuiltin.cpp
@@ -2229,11 +2229,56 @@ static ManagedValue emitBuiltinTaskAddPriorityEscalationHandler(
   return ManagedValue::forRValueWithoutOwnership(b);
 }
 
+static bool isBorrowedByAddress(SILGenFunction &SGF, SILType loweredTy) {
+  if (loweredTy.isAddressableForDeps(SGF.F)) {
+    return true;
+  }
+  if (!SGF.useLoweredAddresses())
+    return false;
+
+  return !loweredTy.isLoadable(SGF.F);
+}
+
+static ManagedValue emitBorrowObject(
+  SILGenFunction &SGF, SILLocation loc, SILType loweredBorrowTy,
+  ArgumentSource &&arg) {
+
+  // Loadable referent (therefore loadable borrow).
+  assert(loweredBorrowTy.isLoadable(SGF.F)
+         && "borrow must be loadable if referent is");
+
+  auto referent = std::move(arg).getAsSingleValue(
+    SGF, SGFContext::AllowGuaranteedPlusZero);
+  if (referent.getType().isAddress()) {
+    referent = SGF.B.createLoadBorrow(loc, referent);
+  }
+  auto borrow = SGF.B.createMakeBorrow(loc, referent.getValue());
+  return ManagedValue::forUnmanagedOwnedValue(borrow);
+}
+
+static ManagedValue emitBorrowAddress(
+  SILGenFunction &SGF, SILLocation loc, SILType loweredBorrowTy,
+  SILValue referentAddr, SGFContext C) {
+
+  if (loweredBorrowTy.isLoadable(SGF.F)) {
+    // Address referent, loadable borrow.
+    auto borrow = SGF.B.createMakeAddrBorrow(loc, referentAddr);
+    return ManagedValue::forUnmanagedOwnedValue(borrow);
+  }
+
+  // Address-only referent and borrow.
+  loweredBorrowTy = loweredBorrowTy.getAddressType();
+  auto buffer = SGF.getBufferForExprResult(loc, loweredBorrowTy, C);
+  SGF.B.createInitBorrowAddr(loc, buffer, referentAddr);
+  return SGF.manageBufferForExprResult(buffer,
+                                       SGF.getTypeLowering(loweredBorrowTy), C);
+}
+
 static ManagedValue emitBuiltinMakeBorrow(SILGenFunction &SGF,
-                                       SILLocation loc,
-                                       SubstitutionMap subs,
-                                       PreparedArguments &&preparedArgs,
-                                       SGFContext C) {
+                                          SILLocation loc,
+                                          SubstitutionMap subs,
+                                          PreparedArguments &&preparedArgs,
+                                          SGFContext C) {
   auto args = std::move(preparedArgs).getSources();
   ASSERT(args.size() == 1 && "should only have one argument");
   ASSERT(subs.getReplacementTypes().size() == 1
@@ -2243,30 +2288,9 @@ static ManagedValue emitBuiltinMakeBorrow(SILGenFunction &SGF,
   auto loweredArgTy = SGF.getLoweredType(argTy);
   auto loweredBorrowTy = SILType::getPrimitiveObjectType(
        BuiltinBorrowType::get(loweredArgTy.getASTType()));
-
-  bool loadableReferent;
-  if (loweredArgTy.isAddressableForDeps(SGF.F)) {
-    loadableReferent = false;
-  } else {
-    loadableReferent = !SGF.useLoweredAddresses()
-      || loweredArgTy.isLoadable(SGF.F);
+  if (!isBorrowedByAddress(SGF, loweredArgTy)) {
+    return emitBorrowObject(SGF, loc, loweredBorrowTy, std::move(args[0]));
   }
-
-  if (loadableReferent) {
-    // Loadable referent (therefore loadable borrow).
-    assert(loweredBorrowTy.isLoadable(SGF.F)
-           && "borrow must be loadable if referent is");
-
-    auto referent = std::move(args[0]).getAsSingleValue(SGF,
-                                          SGFContext::AllowGuaranteedPlusZero);
-    if (referent.getType().isAddress()) {
-      referent = SGF.B.createLoadBorrow(loc, referent);
-    }
-    
-    auto borrow = SGF.B.createMakeBorrow(loc, referent.getValue());
-    return ManagedValue::forUnmanagedOwnedValue(borrow);
-  }
-
   // Form an address referent by prefering the addressable representation
   // if available.
   ManagedValue referent
@@ -2279,20 +2303,9 @@ static ManagedValue emitBuiltinMakeBorrow(SILGenFunction &SGF,
       referent = SGF.B.createStoreBorrowOrTrivial(loc, referent, temp);
     }
   }
-  
-  if (loweredBorrowTy.isLoadable(SGF.F)) {
-    // Address referent, loadable borrow.
-    // 
-    auto borrow = SGF.B.createMakeAddrBorrow(loc, referent.getValue());
-    return ManagedValue::forUnmanagedOwnedValue(borrow);
-  }
+  return emitBorrowAddress(SGF, loc, loweredBorrowTy, referent.getValue(), C);
+}
 
-  // Address-only referent and borrow.
-  loweredBorrowTy = loweredBorrowTy.getAddressType();
-  auto buffer = SGF.getBufferForExprResult(loc, loweredBorrowTy, C);
-  SGF.B.createInitBorrowAddr(loc, buffer, referent.getValue());
-  return SGF.manageBufferForExprResult(buffer,
-                                       SGF.getTypeLowering(loweredBorrowTy), C);
 }
 
 static ManagedValue emitBuiltinDereferenceBorrow(SILGenFunction &SGF,

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -3481,6 +3481,34 @@ LValue SILGenLValue::visitApplyExpr(ApplyExpr *e, SGFAccessKind accessKind,
     lv.add<ValueComponent>(deref, std::nullopt, typeData, /*isRValue*/ true);
     return lv;
   }
+  case BuiltinValueKind::BorrowAt: {
+    ManagedValue borrowedValue = SGF.emitRValueAsSingleValue(e);
+    // Emitting the call to Builtin.borrowAt requires the usual emitRValue
+    // pathways. So the result follows RValue rules: an address for address-only
+    // types, a load_borrow value for loadable types. If the borrowedValue is
+    // addressable-for-dependencies, then strip off the load_borrow to get back
+    // to the original address required for an LValue.
+    if (!borrowedValue.getType().isAddress()) {
+      if (borrowedValue.getType().isAddressableForDeps(SGF.F)) {
+        // RValue construction is expected to emit load_borrow.
+        auto *load = cast<SingleValueInstruction>(borrowedValue.getValue());
+        ASSERT(isa<LoadInst>(load) || isa<LoadBorrowInst>(load));
+        SILValue addr = load->getOperand(0);
+        // Replace the borrowed value with an address. Borrowed values have no
+        // cleanups. The dead borrow will be removed by Onone simplification.
+        borrowedValue = ManagedValue::forRValueWithoutOwnership(addr);
+      } else {
+        // Allow this LValue to be used in a return expression, which violates
+        // end_borrow ownership.
+        borrowedValue = SGF.B.createUncheckedOwnership(e, borrowedValue);
+      }
+    }
+    auto typeData = getValueTypeData(SGF, accessKind, e);
+    LValue lv;
+    lv.add<ValueComponent>(borrowedValue, std::nullopt, typeData,
+                           /*isRValue*/ true);
+    return lv;
+  }
 
   default:
     llvm_unreachable("not an lvalue builtin");

--- a/lib/SILGen/StorageRefResult.h
+++ b/lib/SILGen/StorageRefResult.h
@@ -113,13 +113,18 @@ public:
       auto &builtinInfo
         = M.getBuiltinInfo(declRef.getDecl()->getBaseIdentifier());
 
-      if (builtinInfo.ID != BuiltinValueKind::DereferenceBorrow) {
-        return StorageRefResult();
-      }
-
-      if (auto result = findStorageReferenceExprForBorrow(M,
-                                                  ae->getArgs()->getExpr(0))) {
-        return result.withTransitiveRoot(e);
+      switch (builtinInfo.ID) {
+      default:
+        break;
+      case BuiltinValueKind::DereferenceBorrow:
+        if (auto result = findStorageReferenceExprForBorrow(
+              M, ae->getArgs()->getExpr(0))) {
+          return result.withTransitiveRoot(e);
+        }
+        break;
+      case BuiltinValueKind::BorrowAt:
+        // Builtin.borrowAt produces the base storage address.
+        return StorageRefResult(e);
       }
     }
 

--- a/test/SILGen/builtin_borrowat.swift
+++ b/test/SILGen/builtin_borrowat.swift
@@ -1,0 +1,162 @@
+// RUN: %target-swift-emit-silgen -module-name main \
+// RUN: -enable-experimental-feature BuiltinModule \
+// RUN: -enable-experimental-feature AddressableTypes \
+// RUN: -enable-experimental-feature Lifetimes \
+// RUN: %s | %FileCheck %s
+
+// RUN: %target-swift-emit-sil -module-name main \
+// RUN: -enable-experimental-feature BuiltinModule \
+// RUN: -enable-experimental-feature AddressableTypes \
+// RUN: -enable-experimental-feature Lifetimes \
+// RUN: %s | %FileCheck --check-prefix=CHECK-POST-CLEANUP %s
+
+// REQUIRES: swift_feature_BuiltinModule
+// REQUIRES: swift_feature_AddressableTypes
+// REQUIRES: swift_feature_Lifetimes
+
+import Builtin
+
+struct NonGeneric {
+  var x: AnyObject
+}
+
+struct NonGenericAO {
+  var x: Any
+}
+
+struct Fixed<T> {
+  var x: Int
+}
+
+@_addressableForDependencies
+struct AFD { var x: AnyObject }
+
+@_addressableForDependencies
+struct AFDTrivial { var x: Int }
+
+struct BorrowTrivial: ~Escapable {
+  var pointer: Builtin.RawPointer
+
+  var value: Int {
+    // CHECK-LABEL: sil{{.*}} @$s{{.*}}13BorrowTrivialV5value{{.*}}vb :
+    // CHECK:       bb0([[STRUCT:%.*]] :
+    // CHECK:         [[POINTER:%.*]] = struct_extract [[STRUCT]]
+    // CHECK:         [[ADDR:%.*]] = pointer_to_address [[POINTER]]
+    // CHECK:         [[REFERENT:%.*]] = load [trivial] [[ADDR]]
+    // CHECK:         return [[REFERENT]]
+    @_unsafeSelfDependentResult
+    borrow {
+      return Builtin.borrowAt(pointer)
+    }
+  }
+}
+
+struct BorrowLoadable: ~Escapable {
+  var pointer: Builtin.RawPointer
+
+  var value: NonGeneric {
+    // CHECK-LABEL: sil{{.*}} @$s{{.*}}14BorrowLoadableV5value{{.*}}vb :
+    // CHECK:       bb0([[STRUCT:%.*]] :
+    // CHECK:         [[POINTER:%.*]] = struct_extract [[STRUCT]]
+    // CHECK:         [[ADDR:%.*]] = pointer_to_address [[POINTER]]
+    // CHECK:         [[REFERENT:%.*]] = load_borrow [[ADDR]]
+    // CHECK:         [[UNCHECKED:%.*]] = unchecked_ownership [[REFERENT]]
+    // CHECK:         end_borrow [[REFERENT]]
+    // CHECK:         return [[UNCHECKED]]
+    //
+    // SILGenCleanup fixes this to the more principled `return_borrow`,
+    // which after ownership elimination gives us:
+    // CHECK-POST-CLEANUP-LABEL: sil{{.*}} @$s{{.*}}14BorrowLoadableV5value{{.*}}vb :
+    // CHECK-POST-CLEANUP:       bb0([[STRUCT:%.*]] :
+    // CHECK-POST-CLEANUP:         [[POINTER:%.*]] = struct_extract [[STRUCT]]
+    // CHECK-POST-CLEANUP:         [[ADDR:%.*]] = pointer_to_address [[POINTER]]
+    // CHECK-POST-CLEANUP:         [[REFERENT:%.*]] = load [[ADDR]]
+    // CHECK-POST-CLEANUP:         return [[REFERENT]]
+    @_unsafeSelfDependentResult
+    borrow {
+      return Builtin.borrowAt(pointer)
+    }
+  }
+}
+
+struct BorrowAO: ~Escapable {
+  var pointer: Builtin.RawPointer
+
+  var value: NonGenericAO {
+    // CHECK-LABEL: sil{{.*}} @$s{{.*}}8BorrowAOV5value{{.*}}vb :
+    // CHECK:       bb0([[STRUCT:%.*]] :
+    // CHECK:         [[POINTER:%.*]] = struct_extract [[STRUCT]]
+    // CHECK:         [[REFERENT:%.*]] = pointer_to_address [[POINTER]]
+    // CHECK-NOT:     load
+    // CHECK:         return [[REFERENT]]
+    @_unsafeSelfDependentResult
+    borrow {
+      return Builtin.borrowAt(pointer)
+    }
+  }
+}
+
+struct BorrowAFD: ~Escapable {
+  var pointer: Builtin.RawPointer
+
+  var value: AFD {
+    // CHECK-LABEL: sil{{.*}} @$s{{.*}}9BorrowAFDV5value{{.*}}vb :
+    // CHECK:       bb0([[STRUCT:%.*]] :
+    // CHECK:         [[POINTER:%.*]] = struct_extract [[STRUCT]]
+    // CHECK:         [[REFERENT:%.*]] = pointer_to_address [[POINTER]]
+    // CHECK:         load_borrow [[REFERENT]]
+    // CHECK:         return [[REFERENT]]
+
+    // CHECK-POST-CLEANUP-LABEL: sil{{.*}} @$s{{.*}}9BorrowAFDV5value{{.*}}vb :
+    // CHECK-POST-CLEANUP:       bb0([[STRUCT:%.*]] :
+    // CHECK-POST-CLEANUP:         [[POINTER:%.*]] = struct_extract [[STRUCT]]
+    // CHECK-POST-CLEANUP:         [[REFERENT:%.*]] = pointer_to_address [[POINTER]]
+    // CHECK-POST-CLEANUP-NOT:     load
+    // CHECK-POST-CLEANUP:         return [[REFERENT]]
+    @_unsafeSelfDependentResult
+    borrow {
+      return Builtin.borrowAt(pointer)
+    }
+  }
+}
+
+struct BorrowAFDTrivial: ~Escapable {
+  var pointer: Builtin.RawPointer
+
+  var value: AFDTrivial {
+    // CHECK-LABEL: sil{{.*}} @$s{{.*}}16BorrowAFDTrivialV5value{{.*}}vb :
+    // CHECK:       bb0([[STRUCT:%.*]] :
+    // CHECK:         [[POINTER:%.*]] = struct_extract [[STRUCT]]
+    // CHECK:         [[REFERENT:%.*]] = pointer_to_address [[POINTER]]
+    // CHECK:         load [trivial] [[REFERENT]]
+    // CHECK:         return [[REFERENT]]
+
+    // CHECK-POST-CLEANUP-LABEL: sil{{.*}} @$s{{.*}}16BorrowAFDTrivialV5value{{.*}}vb :
+    // CHECK-POST-CLEANUP:       bb0([[STRUCT:%.*]] :
+    // CHECK-POST-CLEANUP:         [[POINTER:%.*]] = struct_extract [[STRUCT]]
+    // CHECK-POST-CLEANUP:         [[REFERENT:%.*]] = pointer_to_address [[POINTER]]
+    // CHECK-POST-CLEANUP-NOT:     load
+    // CHECK-POST-CLEANUP:         return [[REFERENT]]
+    @_unsafeSelfDependentResult
+    borrow {
+      return Builtin.borrowAt(pointer)
+    }
+  }
+}
+
+struct BorrowDep<T>: ~Escapable {
+  private var pointer: Builtin.RawPointer
+
+  var value: T {
+    // CHECK-LABEL: sil{{.*}} @$s{{.*}}9BorrowDepV5value{{.*}}vb :
+    // CHECK:       bb0([[STRUCT:%.*]] :
+    // CHECK:         [[POINTER:%.*]] = struct_extract [[STRUCT]]
+    // CHECK:         [[REFERENT:%.*]] = pointer_to_address [[POINTER]]
+    // CHECK-NOT:     load
+    // CHECK:         return [[REFERENT]]
+    @_unsafeSelfDependentResult
+    borrow {
+      return Builtin.borrowAt(pointer)
+    }
+  }
+}

--- a/test/SILGen/builtin_borrowat_unimplemented.swift
+++ b/test/SILGen/builtin_borrowat_unimplemented.swift
@@ -1,0 +1,95 @@
+// RUN: %target-swift-emit-silgen \
+// RUN: -enable-experimental-feature BuiltinModule \
+// RUN: -enable-experimental-feature AddressableTypes \
+// RUN: -enable-experimental-feature Lifetimes \
+// RUN: -verify %s
+
+// TODO: Support Builtin.makeBorrow(Builtin.borrowAt(referent)). See
+// SILGenFunction::tryEmitAddressableParameterAsAddress.
+
+// UN: %target-swift-emit-silgen -module-name main \
+// UN: -enable-experimental-feature BuiltinModule \
+// UN: -enable-experimental-feature AddressableType \
+// UN: -enable-experimental-feature Lifetimes \
+// UN: -I %t %s | %FileCheck %s
+
+// REQUIRES: swift_feature_BuiltinModule
+// REQUIRES: swift_feature_AddressableTypes
+// REQUIRES: swift_feature_Lifetimes
+
+import Builtin
+
+struct NonGeneric {
+  var x: AnyObject
+}
+
+struct NonGenericAO {
+  var x: Any
+}
+
+@_addressableForDependencies
+struct AFD { var x: AnyObject }
+
+@_addressableForDependencies
+struct AFDTrivial { var x: Int }
+
+// HECK-LABEL: sil{{.*}} @$s{{.*}}06value_B12_make_borrow
+// HECK:       bb0([[REFERENT:%.*]] :
+// HECK:         [[ADDR:%.*]] = pointer_to_address [[REFERENT]]
+// HECK:         [[LOAD:%.*]] = load [trivial] [[ADDR]]
+// HECK:         [[BORROW:%.*]] = make_borrow [[LOAD]]
+// HECK:         return [[BORROW]]
+@_lifetime(borrow referent)
+func trivial_make_borrow(_ referent: Builtin.RawPointer) -> Builtin.Borrow<Int> {
+  return Builtin.makeBorrow(Builtin.borrowAt(referent))
+}
+
+// HECK-LABEL: sil{{.*}} @$s{{.*}}06value_B12_make_borrow
+// HECK:       bb0([[REFERENT:%.*]] :
+// HECK:         [[ADDR:%.*]] = pointer_to_address [[REFERENT]]
+// HECK:         [[LOAD:%.*]] = load_borrow [[ADDR]]
+// HECK:         [[BORROW:%.*]] = make_borrow [[LOAD]]
+// HECK:         return [[BORROW]]
+@_lifetime(borrow referent)
+func value_value_make_borrow(_ referent: Builtin.RawPointer) -> Builtin.Borrow<NonGeneric> {
+  return Builtin.makeBorrow(Builtin.borrowAt(referent))
+}
+
+// HECK-LABEL: sil{{.*}} @$s{{.*}}22value_address_borrowat
+// HECK:       bb0([[REFERENT:%.*]] :
+// HECK:         [[ADDR:%.*]] = pointer_to_address [[REFERENT]]
+// HECK:         [[BORROW:%.*]] = make_addr_borrow [[ADDR]]
+// HECK:         return [[BORROW]]
+@_lifetime(borrow referent)
+func value_address_borrowat(_ referent: Builtin.RawPointer) -> Builtin.Borrow<NonGenericAO> {
+  return Builtin.makeBorrow(Builtin.borrowAt(referent)) // expected-error{{INTERNAL ERROR: feature not implemented: Builtin.borrowAt must be direclty returned from a borrow accessor}}
+}
+
+// HECK-LABEL: sil{{.*}} @$s{{.*}}26value_address_borrowat_afd
+// HECK:       bb0([[REFERENT:%.*]] :
+// HECK:         [[ADDR:%.*]] = pointer_to_address [[REFERENT]]
+// HECK:         [[BORROW:%.*]] = make_addr_borrow [[ADDR]]
+// HECK:         return [[BORROW]]
+@_lifetime(borrow referent)
+func value_address_borrowat_afd(_ referent: Builtin.RawPointer) -> Builtin.Borrow<AFD> {
+  return Builtin.makeBorrow(Builtin.borrowAt(referent)) // expected-error{{INTERNAL ERROR: feature not implemented: Builtin.borrowAt must be direclty returned from a borrow accessor}}
+}
+
+// HECK-LABEL: sil{{.*}} @$s{{.*}}34value_address_borrowat_afd_trivial
+// HECK:       bb0([[REFERENT:%.*]] :
+// HECK:         [[ADDR:%.*]] = pointer_to_address [[REFERENT]]
+// HECK:         [[BORROW:%.*]] = make_addr_borrow [[ADDR]]
+// HECK:         return [[BORROW]]
+@_lifetime(borrow referent)
+func value_address_borrowat_afd_trivial(_ referent: Builtin.RawPointer) -> Builtin.Borrow<AFDTrivial> {
+  return Builtin.makeBorrow(Builtin.borrowAt(referent)) // expected-error{{INTERNAL ERROR: feature not implemented: Builtin.borrowAt must be direclty returned from a borrow accessor}}
+}
+
+// HECK-LABEL: sil{{.*}} @$s{{.*}}08address_B9_borrowat
+// HECK:       bb0([[RESULT:%.*]] : $*Builtin.Borrow{{.*}}, [[REFERENT:%.*]] :
+// HECK:         [[ADDR:%.*]] = pointer_to_address [[REFERENT]]
+// HECK:         make_addr_borrow [[RESULT]] with [[ADDR]]
+@_lifetime(borrow referent)
+func address_address_borrowat<T>(_ referent: Builtin.RawPointer) -> Builtin.Borrow<T> {
+  return Builtin.makeBorrow(Builtin.borrowAt(referent)) // expected-error{{INTERNAL ERROR: feature not implemented: Builtin.borrowAt must be direclty returned from a borrow accessor}}
+}


### PR DESCRIPTION
- **Explanation**: Add a compiler builtin needed for `Span<~E>`. This allows `Span.subscript` to be reimplemented as a borrow accessor rather than `unsafeAddress`.

- **Scope**: No functional change in this PR.

- **Issues**: rdar://175382153 (Add Builtin.borrowAt: allows borrowing in-memory values)

- **Risk**: None

- **Testing**: New unit tests for Builtin.borrowAt to cover the relevant SILGen code paths.

- **Reviewers**: TBD