### PR TITLE
Fix issue #88533 result-builder diagnostic fallback

### DIFF
--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -4789,6 +4789,48 @@ void ConstraintSystem::diagnoseFailureFor(SyntacticElementTarget target) {
         .highlight(closure->getSourceRange());
       return;
     }
+
+    if (auto *call = dyn_cast<CallExpr>(expr->getSemanticsProvidingExpr())) {
+      ClosureExpr *builderClosure = nullptr;
+      if (auto *args = call->getArgs()) {
+        for (const auto &arg : *args) {
+          auto *argExpr = arg.getExpr();
+          if (!argExpr)
+            continue;
+
+          auto *closure =
+              dyn_cast<ClosureExpr>(argExpr->getSemanticsProvidingExpr());
+          if (!closure)
+            continue;
+
+          if (getAppliedResultBuilderTransform(closure)) {
+            builderClosure = closure;
+            break;
+          }
+        }
+      }
+
+      if (builderClosure) {
+        auto *fn = call->getFn()->getSemanticsProvidingExpr();
+
+        if (auto *UDE = dyn_cast<UnresolvedDotExpr>(fn)) {
+          DE.diagnose(UDE->getLoc(), diag::ambiguous_decl_ref, UDE->getName())
+              .highlight(UDE->getSourceRange());
+          return;
+        }
+
+        if (auto *ODRE = dyn_cast<OverloadedDeclRefExpr>(fn)) {
+          DE.diagnose(ODRE->getLoc(), diag::ambiguous_decl_ref,
+                      ODRE->getName())
+              .highlight(ODRE->getSourceRange());
+          return;
+        }
+
+        DE.diagnose(builderClosure->getLoc(), diag::cannot_infer_closure_type)
+            .highlight(builderClosure->getSourceRange());
+        return;
+      }
+    }
   }
 
   // Emit a poor fallback message.

--- a/validation-test/Sema/SwiftUI/issue-88533.swift
+++ b/validation-test/Sema/SwiftUI/issue-88533.swift
@@ -1,0 +1,16 @@
+// RUN: %target-typecheck-verify-swift -target %target-cpu-apple-macosx10.15 -swift-version 5
+// REQUIRES: objc_interop
+// REQUIRES: OS=macosx
+
+// https://github.com/swiftlang/swift/issues/88533
+
+import SwiftUI
+
+struct ReproMinimalView: View {
+  var body: some View {
+    Text("body").toolbar { // expected-error {{ambiguous use of 'toolbar'}}
+      Text("bare view in toolbar")
+      ToolbarItem(placement: .principal) { Text("x") }
+    }
+  }
+}


### PR DESCRIPTION
- **Explanation**:
  Improve diagnostics for mixed SwiftUI `toolbar` builder content. When overload resolution is ambiguous, diagnose the call reference (`ambiguous use of 'toolbar'`) instead of falling back to the generic closure inference diagnostic.

- **Scope**:
  `ConstraintSystem::diagnoseFailureFor` diagnostic handling for this case, plus one validation test.

- **Issues**:
  Fixes #88533.

- **Risk**:
  Low. Diagnostic-only behavior change with narrow matching of result-builder transformed closure arguments.

- **Testing**:
  Added `validation-test/Sema/SwiftUI/issue-88533.swift` for the reported repro (`expected-error {{ambiguous use of 'toolbar'}}`).