### PR TITLE
Faster FP printing + Float80

### DIFF
--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift
@@ -803,6 +803,7 @@ public func expectCrash(withMessage message: String = "", executing: () -> Void)
 }
 
 func _defaultTestSuiteFailedCallback() {
+  fflush(nil)
   abort()
 }
 
@@ -813,6 +814,7 @@ public func _setTestSuiteFailedCallback(_ callback: @escaping () -> Void) {
 }
 
 func _defaultTrappingExpectationFailedCallback() {
+  fflush(nil)
   abort()
 }
 

--- a/stdlib/public/SwiftShims/swift/shims/RuntimeShims.h
+++ b/stdlib/public/SwiftShims/swift/shims/RuntimeShims.h
@@ -32,6 +32,34 @@ extern "C" {
 SWIFT_RUNTIME_STDLIB_API
 void *_swift_objCMirrorSummary(const void * nsObject);
 
+// Caveat: _swift_stdlib_strto{f,d,ld}_clocale() was called directly from inlineable
+// code until Feb 2020 (commit 4d0e2adbef4d changed this), so they need to be
+// exported with the same C-callable ABI for as long as we support code compiled
+// with Swift 5.3.
+
+// _swift_stdlib_strto{d,f,f16}_clocale were reimplemented in
+// Swift in Dec 2025.  See FloatingPointFromString.swift
+// _swift_stdlib_strtold_clocale was reimplemented in May 2026.
+
+/// Call strtold_l with the C locale, swapping argument and return
+/// types so we can operate on Float80.
+SWIFT_RUNTIME_STDLIB_API
+const char *_swift_stdlib_strtold_clocale(const char *nptr, void *outResult);
+/// Call strtod_l with the C locale, swapping argument and return
+/// types so we can operate consistently on Float80.
+SWIFT_RUNTIME_STDLIB_API
+const char *_swift_stdlib_strtod_clocale(const char *nptr, double *outResult);
+/// Call strtof_l with the C locale, swapping argument and return
+/// types so we can operate consistently on Float80.
+SWIFT_RUNTIME_STDLIB_API
+const char *_swift_stdlib_strtof_clocale(const char *nptr, float *outResult);
+/// Call strtof_l with the C locale, swapping argument and return
+/// types so we can operate consistently on Float80.
+// FIXME? Can this be deleted?  _swift_stdlib_strtof16_clocale was never
+// actually called from inlineable code.
+SWIFT_RUNTIME_STDLIB_API
+const char *_swift_stdlib_strtof16_clocale(const char *nptr, __fp16 *outResult);
+
 SWIFT_RUNTIME_STDLIB_API
 void _swift_stdlib_immortalize(void *obj);
   

--- a/stdlib/public/SwiftShims/swift/shims/RuntimeShims.h
+++ b/stdlib/public/SwiftShims/swift/shims/RuntimeShims.h
@@ -32,34 +32,6 @@ extern "C" {
 SWIFT_RUNTIME_STDLIB_API
 void *_swift_objCMirrorSummary(const void * nsObject);
 
-// Caveat: _swift_stdlib_strto{f,d,ld}_clocale() was called directly from inlineable
-// code until Feb 2020 (commit 4d0e2adbef4d changed this), so they need to be
-// exported with the same C-callable ABI for as long as we support code compiled
-// with Swift 5.3.
-
-// _swift_stdlib_strto{d,f,f16}_clocale were reimplemented in
-// Swift in Dec 2025.  See FloatingPointFromString.swift
-// _swift_stdlib_strtold_clocale was not reimplemented at that time.
-
-/// Call strtold_l with the C locale, swapping argument and return
-/// types so we can operate on Float80.
-SWIFT_RUNTIME_STDLIB_API
-const char *_swift_stdlib_strtold_clocale(const char *nptr, void *outResult);
-/// Call strtod_l with the C locale, swapping argument and return
-/// types so we can operate consistently on Float80.
-SWIFT_RUNTIME_STDLIB_API
-const char *_swift_stdlib_strtod_clocale(const char *nptr, double *outResult);
-/// Call strtof_l with the C locale, swapping argument and return
-/// types so we can operate consistently on Float80.
-SWIFT_RUNTIME_STDLIB_API
-const char *_swift_stdlib_strtof_clocale(const char *nptr, float *outResult);
-/// Call strtof_l with the C locale, swapping argument and return
-/// types so we can operate consistently on Float80.
-// FIXME? Can this be deleted?  _swift_stdlib_strtof16_clocale was never
-// actually called from inlineable code.
-SWIFT_RUNTIME_STDLIB_API
-const char *_swift_stdlib_strtof16_clocale(const char *nptr, __fp16 *outResult);
-
 SWIFT_RUNTIME_STDLIB_API
 void _swift_stdlib_immortalize(void *obj);
   

--- a/stdlib/public/core/FloatingPointFromString.swift
+++ b/stdlib/public/core/FloatingPointFromString.swift
@@ -1339,6 +1339,8 @@ fileprivate func multiplyMPBy96(
   range: inout Range<Int>,
   multiplier: _UInt128
 ) {
+  // Multiplier must be <= 96 bits so the efficient multiply loop works.
+  _internalInvariant(multiplier._high.leadingZeroBitCount >= 32)
   let bitsPerMPWord = MPWord.bitWidth
   var i = range.lowerBound
   var t = _UInt128(0)
@@ -1616,57 +1618,62 @@ fileprivate let powersOfFive : _InlineArray<_, UInt32> = [
   0xa3041a5c, 0xdb7be437, 0x192edcb6, 0xba7ea880, 0xba4f93c8, 0x7e3766d,
   0x4d642a92, 0x983ee842,
 
-  // Values beyond this point are only used for Float80/Float128.
-  // Trimming them would save 760 bytes...
-
+  // The values below are only needed by Float80/Float128 and have been
+  // commented out to save 760 bytes.  Float80 still works correctly
+  // without them — `multiplyByFiveToTheN` just has more work to do for
+  // very large exponents.  If Float128 is ever supported and its
+  // performance becomes important, restore these (and bump
+  // `powersOfFive_maxPower` below from 358 to 633).
+  //
   // Alternatively, we could speed things up by breaking here and having a
   // second triangular table starting with 5^413 (30 words) and increasing by 30
   // words for each successive value.  That would cost 6600 bytes and limit
   // calls to multiplyByFiveToTheN to at most 5^412.
 
   // 5 ** 413    120 bytes
-  0xc7418055, 0xe0fd09d8, 0x1f6fef06, 0xe0aa919a, 0x3a932696, 0xeefa64b7,
-  0x4ad4b5c1, 0xc7b36de4, 0x46739345, 0x4842174f, 0x18b983bc, 0xa98ab9ff,
-  0x97d0164c, 0xd7c61ef2, 0x1e75294b, 0xb45d0246, 0x9ad20a7d, 0x7d2b6dfa,
-  0xadf139f0, 0xa50a7cc6, 0x6f8b9285, 0xff5ca1c0, 0xab0bcbe, 0x32501df6,
-  0xed5227ea, 0x74628fef, 0x2c471432, 0xa2c33b1b, 0x29d341b6, 0x7c2e645e,
+  // 0xc7418055, 0xe0fd09d8, 0x1f6fef06, 0xe0aa919a, 0x3a932696, 0xeefa64b7,
+  // 0x4ad4b5c1, 0xc7b36de4, 0x46739345, 0x4842174f, 0x18b983bc, 0xa98ab9ff,
+  // 0x97d0164c, 0xd7c61ef2, 0x1e75294b, 0xb45d0246, 0x9ad20a7d, 0x7d2b6dfa,
+  // 0xadf139f0, 0xa50a7cc6, 0x6f8b9285, 0xff5ca1c0, 0xab0bcbe, 0x32501df6,
+  // 0xed5227ea, 0x74628fef, 0x2c471432, 0xa2c33b1b, 0x29d341b6, 0x7c2e645e,
 
   // 5 ** 468    136 bytes
-  0x663d5f31, 0xc852d43d, 0x628adfb8, 0x7532907f, 0x519a9fcf, 0xff6d61c3,
-  0xee47a4fb, 0x5364a40, 0x8307a5e7, 0xc51a19b6, 0x152115bd, 0xd64160ca,
-  0x5a7fc303, 0x4420c114, 0xb0472914, 0x4701c038, 0xa75d51fb, 0x9329af1e,
-  0xfd726810, 0x95a1fec8, 0x433b921e, 0xac637005, 0x4b769501, 0x97b6965a,
-  0x5c15ca6c, 0x2e3a3781, 0xa1c3722f, 0x9cee9acc, 0x243794ea, 0x98d384d2,
-  0x8f51a4f3, 0xfb591b83, 0x74dd9297, 0x654a3f98,
+  // 0x663d5f31, 0xc852d43d, 0x628adfb8, 0x7532907f, 0x519a9fcf, 0xff6d61c3,
+  // 0xee47a4fb, 0x5364a40, 0x8307a5e7, 0xc51a19b6, 0x152115bd, 0xd64160ca,
+  // 0x5a7fc303, 0x4420c114, 0xb0472914, 0x4701c038, 0xa75d51fb, 0x9329af1e,
+  // 0xfd726810, 0x95a1fec8, 0x433b921e, 0xac637005, 0x4b769501, 0x97b6965a,
+  // 0x5c15ca6c, 0x2e3a3781, 0xa1c3722f, 0x9cee9acc, 0x243794ea, 0x98d384d2,
+  // 0x8f51a4f3, 0xfb591b83, 0x74dd9297, 0x654a3f98,
 
   // 5 ** 523    152 bytes
-  0x9a8b26dd, 0xbf2c0cb0, 0x55574b71, 0xbaf1ae94, 0x909d4708, 0x3a0e3864,
-  0x96024957, 0x220c2ed9, 0x3c846d96, 0xa8f2eb24, 0x4c42f275, 0x2fbb514b,
-  0xc2c02b99, 0x2943f65a, 0x59784a24, 0x966b340, 0x8aa1aecc, 0x12c6b3ee,
-  0x694ef465, 0xde3eaa92, 0x232dffbe, 0xce590fe4, 0xacdaed02, 0xdb515c72,
-  0xed4346e1, 0x80a57e71, 0x62e788b1, 0xafbcf17e, 0x71c9d096, 0x71bf4008,
-  0x77961314, 0x3cc04087, 0xd031224e, 0x37315310, 0x24aba8bc, 0x42b158b6,
-  0x550880c, 0x529e5882,
+  // 0x9a8b26dd, 0xbf2c0cb0, 0x55574b71, 0xbaf1ae94, 0x909d4708, 0x3a0e3864,
+  // 0x96024957, 0x220c2ed9, 0x3c846d96, 0xa8f2eb24, 0x4c42f275, 0x2fbb514b,
+  // 0xc2c02b99, 0x2943f65a, 0x59784a24, 0x966b340, 0x8aa1aecc, 0x12c6b3ee,
+  // 0x694ef465, 0xde3eaa92, 0x232dffbe, 0xce590fe4, 0xacdaed02, 0xdb515c72,
+  // 0xed4346e1, 0x80a57e71, 0x62e788b1, 0xafbcf17e, 0x71c9d096, 0x71bf4008,
+  // 0x77961314, 0x3cc04087, 0xd031224e, 0x37315310, 0x24aba8bc, 0x42b158b6,
+  // 0x550880c, 0x529e5882,
 
   // 5 ** 578    168 bytes
-  0x6ac93f19, 0xb0528df3, 0x1bd0d93b, 0x6887cf42, 0x16c95762, 0xe06cf811,
-  0xef6a19f0, 0xc9642ada, 0xd0281f3b, 0x95048fea, 0x8a90381, 0x8e351ad1,
-  0x57cfc253, 0x4c526792, 0xd12ead90, 0x22519d79, 0x886cfbcc, 0x492e7dd2,
-  0x62cd8fad, 0xc3a19bf6, 0x63cb573d, 0x96988013, 0x6f26d941, 0xe0e8f38b,
-  0xd543d024, 0x4312f15, 0xaec520f3, 0x29c4a0e0, 0xc8330daf, 0x9194ca21,
-  0x3f122fb9, 0xc39177e7, 0xeec85730, 0x966c77b2, 0xfb50bc61, 0x650a689e,
-  0x69260814, 0x3a4513bd, 0x9e62b35d, 0xbdb41cdb, 0xadf47696, 0x43638e41,
+  // 0x6ac93f19, 0xb0528df3, 0x1bd0d93b, 0x6887cf42, 0x16c95762, 0xe06cf811,
+  // 0xef6a19f0, 0xc9642ada, 0xd0281f3b, 0x95048fea, 0x8a90381, 0x8e351ad1,
+  // 0x57cfc253, 0x4c526792, 0xd12ead90, 0x22519d79, 0x886cfbcc, 0x492e7dd2,
+  // 0x62cd8fad, 0xc3a19bf6, 0x63cb573d, 0x96988013, 0x6f26d941, 0xe0e8f38b,
+  // 0xd543d024, 0x4312f15, 0xaec520f3, 0x29c4a0e0, 0xc8330daf, 0x9194ca21,
+  // 0x3f122fb9, 0xc39177e7, 0xeec85730, 0x966c77b2, 0xfb50bc61, 0x650a689e,
+  // 0x69260814, 0x3a4513bd, 0x9e62b35d, 0xbdb41cdb, 0xadf47696, 0x43638e41,
 
   // 5 ** 633    184 bytes
-  0x560e14a5, 0xf6691422, 0x2c70055c, 0x5fc5dab3, 0xc8ad71e0, 0xa2bc1b0d,
-  0xc651c583, 0x7aa7847b, 0x2daed74b, 0xfe54e5a6, 0xa295aa36, 0x64026c31,
-  0x8712dcba, 0x9cca8c7d, 0x2be239e4, 0xd549bd5, 0xb48d5fa8, 0xaf5e76ed,
-  0x46811a6e, 0x78e4dec4, 0xad6da29a, 0x616c4a6e, 0x15a1974, 0x96f6c825,
-  0x1cd852b4, 0x6ab56842, 0xe45a6968, 0x75631650, 0xe5fc1f10, 0x2bca9511,
-  0x21c5300c, 0xab7e2dcf, 0xb61dde63, 0x6fd760e0, 0xe8c710c1, 0xde5ba724,
-  0xc57e501c, 0x497c1f1a, 0xee6cd3, 0xdd0175f2, 0xa199ce9f, 0x5a4b5d2,
-  0xbd6fa764, 0x9d58b359, 0xd4f4fb60, 0x36f774e8, 
+  // 0x560e14a5, 0xf6691422, 0x2c70055c, 0x5fc5dab3, 0xc8ad71e0, 0xa2bc1b0d,
+  // 0xc651c583, 0x7aa7847b, 0x2daed74b, 0xfe54e5a6, 0xa295aa36, 0x64026c31,
+  // 0x8712dcba, 0x9cca8c7d, 0x2be239e4, 0xd549bd5, 0xb48d5fa8, 0xaf5e76ed,
+  // 0x46811a6e, 0x78e4dec4, 0xad6da29a, 0x616c4a6e, 0x15a1974, 0x96f6c825,
+  // 0x1cd852b4, 0x6ab56842, 0xe45a6968, 0x75631650, 0xe5fc1f10, 0x2bca9511,
+  // 0x21c5300c, 0xab7e2dcf, 0xb61dde63, 0x6fd760e0, 0xe8c710c1, 0xde5ba724,
+  // 0xc57e501c, 0x497c1f1a, 0xee6cd3, 0xdd0175f2, 0xa199ce9f, 0x5a4b5d2,
+  // 0xbd6fa764, 0x9d58b359, 0xd4f4fb60, 0x36f774e8,
 ]
+fileprivate let powersOfFive_maxPower = 358
 
 // Build a multi-precision integer 5^n
 
@@ -1702,7 +1709,7 @@ fileprivate func fiveToTheN(
 
   // Otherwise, initialize with a multi-word value from the table above,
   // then multiply to get the final exact value.
-  let maxPower = 633 // Largest power supported by the table above
+  let maxPower = powersOfFive_maxPower
   let clampedPower = power > maxPower ? maxPower : power
   // We need to find the appropriate power of five from the table
   // above.  This maps the power to the index of the largest power of 5
@@ -1802,6 +1809,12 @@ fileprivate func mostSignificantBitsFrom(
   fraction &<<= 64 - fractionBits
 
   // Make sure fraction bits after the first are non-zero if they should be...
+  // Bit 63 of `fraction` is the round-half bit; the rounding decision below
+  // only distinguishes `fraction > 0x8000…`, `fraction == 0x8000…`, and
+  // `fraction < 0x8000…`.  Any non-zero bit below position 63 will tip
+  // `fraction` strictly above 0x8000…, regardless of where it lands.
+  // That lets us fold trailing words and the remainder-non-zero flag in
+  // with a plain OR — we don't need to track their bit positions.
   fraction |= unsafe UInt64(unsafeBitCast(remainderNonZero, to: UInt8.self))
   while i > range.lowerBound {
     i &-= 1
@@ -2724,6 +2737,12 @@ internal func parse_float80(_ span: Span<UInt8>) -> Optional<Float80> {
   // Verify the text format and parse the key pieces
   var parsed = fastParse64(targetFormat: targetFormat, input: span)
 
+  // Note: Unlike Float32/Float64, we don't bother with the
+  // single-FP-operation or fixed-precision-interval fast paths here.
+  // Float80 is rarely used in performance-sensitive parsing, so the
+  // extra code size and maintenance cost isn't justified; every
+  // decimal input goes straight to the arbitrary-precision fallback.
+
   // If we parsed a decimal, we need to convert it to binary
   if case .decimal(digits: let digits,
                    base10Exponent: let base10Exponent,
@@ -2830,6 +2849,12 @@ internal func parse_float128(_ span: Span<UInt8>) -> Optional<Float128> {
 
   // Verify the text format and parse the key pieces
   var parsed = fastParse64(targetFormat: targetFormat, input: span)
+
+  // TODO: Add fast paths analogous to Float32/Float64 (single-FP-operation
+  // and fixed-precision-interval arithmetic).  Float128 will need 128-bit
+  // (or wider) fixed-precision arithmetic for the interval path; for the
+  // single-FP path, consider whether the existing exact-power-of-10 table
+  // can produce exact Float128 inputs over a useful range.
 
   // If we parsed a decimal, we need to convert it to binary
   if case .decimal(digits: let digits,

--- a/stdlib/public/core/FloatingPointFromString.swift
+++ b/stdlib/public/core/FloatingPointFromString.swift
@@ -1711,10 +1711,12 @@ fileprivate func fiveToTheN(
   // then multiply to get the final exact value.
   let maxPower = powersOfFive_maxPower
   let clampedPower = power > maxPower ? maxPower : power
-  // We need to find the appropriate power of five from the table
-  // above.  This maps the power to the index of the largest power of 5
-  // in the table no greater than the desired power.
-  let index = (((clampedPower &* 4759) >> 16) - 2) / 4
+  // We need to find the appropriate power of five from the table above.  This
+  // maps the power to the index of the largest power of 5 in the table no
+  // greater than the desired power.  The constants 595 and 15894 were chosen by
+  // exhaustive search to keep the result correct (no overshoot) and optimal
+  // (picks the largest valid index) for every clampedPower in [28, 633].
+  let index = (clampedPower &* 595 &- 15894) >> 15
   // How many words in that item?
   let words = index * 4 + 2
   // The corresponding power of five

--- a/stdlib/public/core/FloatingPointFromString.swift
+++ b/stdlib/public/core/FloatingPointFromString.swift
@@ -2679,6 +2679,38 @@ internal func parse_float64(_ span: Span<UInt8>) -> Optional<Float64> {
 
 #if !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !(os(macOS) || os(iOS) || os(watchOS) || os(tvOS)))) && (arch(i386) || arch(x86_64))
 
+// Caveat:  This function was called directly from inlineable
+// code until Feb 2020 (commit 4d0e2adbef4d changed this),
+// so it still needs to be exported with the same C-callable ABI
+// for as long as we support code compiled with Swift 5.3.
+
+@c(_swift_stdlib_strtold_clocale)
+@usableFromInline
+internal func _swift_stdlib_strtold_clocale(
+  _ cText: Optional<UnsafePointer<CChar>>,
+  _ output: Optional<UnsafeMutablePointer<Float80>>
+) -> Optional<UnsafePointer<CChar>>
+{
+  guard let cText = unsafe cText, let output = unsafe output else {
+    return unsafe cText
+  }
+
+  // i = strlen(cText)
+  var i = 0
+  while unsafe cText[i] != 0 {
+    i &+= 1
+  }
+
+  let charSpan = unsafe Span<UInt8>(_unchecked: cText, count: i)
+  let result = parse_float80(charSpan)
+  if let result {
+    unsafe output.pointee = result
+    return unsafe cText + i
+  } else {
+    return nil
+  }
+}
+
 internal func parse_float80(_ span: Span<UInt8>) -> Optional<Float80> {
   let targetFormat = TargetFormat(
     significandBits: 64,

--- a/stdlib/public/core/FloatingPointFromString.swift
+++ b/stdlib/public/core/FloatingPointFromString.swift
@@ -1,4 +1,3 @@
-
 //===--- FloatingPointFromString.swift -----------------------*- Swift -*-===//
 //
 // This source file is part of the Swift.org open source project
@@ -420,10 +419,16 @@ fileprivate enum ParseResult {
                firstUnparsedDigitOffset: UInt16,
                leadingDigitCount: UInt8,
                sign: FloatingPointSign)
-  case binary(significand: UInt64, exponent: Int16, sign: FloatingPointSign)
+  case binary(significand: UInt64,
+              significandHigh: UInt64,
+              exponent: Int16,
+              sign: FloatingPointSign)
   case zero(sign: FloatingPointSign)
   case infinity(sign: FloatingPointSign)
-  case nan(payload: UInt64, signaling: Bool, sign: FloatingPointSign)
+  case nan(payload: UInt64,
+           payloadHigh: UInt64,
+           signaling: Bool,
+           sign: FloatingPointSign)
   case failure
 }
 
@@ -450,35 +455,35 @@ fileprivate func hexFloat(
 ) -> ParseResult {
   var i = start + 2 // Skip leading '0x'
   let firstDigitOffset = i
-  let limit = UInt64(1) << 60
-  var significand: UInt64 = 0
+  var significand: _UInt128 = 0
 
   //
   // Digits before the binary point
   //
 
-  // Accumulate the most significant 64 bits...
-  while i < input.count && hexdigit(input[i]) < 16 && significand < limit {
+  // Accumulate the most significant 128 bits...
+  let limit = UInt64(1) << 60
+  while i < input.count && hexdigit(input[i]) < 16 && significand._high < limit {
     significand &<<= 4
-    significand += UInt64(hexdigit(input[i]))
+    significand |= _UInt128(hexdigit(input[i]))
     i += 1
   }
 
   // Initialize binary exponent to the number of bits we collected above
   // minus 1 (to match the IEEE 754 convention that keeps exactly one
   // bit to the immediate left of the binary point).
-  var binaryExponent = 64 - 1 - significand.leadingZeroBitCount
+  var binaryExponent = 128 - 1 - significand.leadingZeroBitCount
   var remainderNonZero = false
 
   // Including <4 bits from the next digit
-  if i < input.count && hexdigit(input[i]) < 16 && significand.leadingZeroBitCount > 0 {
+  if i < input.count && hexdigit(input[i]) < 16 && significand._high.leadingZeroBitCount > 0 {
     // Number of bits we can fill
-    let bits = significand.leadingZeroBitCount
+    let bits = significand._high.leadingZeroBitCount
     significand &<<= bits
     // Fill that many bits from the next digit
     let digit = hexdigit(input[i])
     let upperPartialDigit = digit >> (4 - bits)
-    significand += UInt64(upperPartialDigit)
+    significand |= _UInt128(upperPartialDigit)
     // Did we drop any non-zero bits?
     remainderNonZero = remainderNonZero || ((digit - (upperPartialDigit << (4 - bits))) != 0)
 
@@ -516,24 +521,24 @@ fileprivate func hexFloat(
         let digit = hexdigit(input[i])
         let upperZeros = digit.leadingZeroBitCount - 4
         binaryExponent -= upperZeros
-        significand = UInt64(digit)
+        significand = _UInt128(digit)
         i += 1
       }
     }
-    // Pack more bits into the accumulator (up to 60)
-    while i < input.count && hexdigit(input[i]) < 16 && significand < limit {
+    // Pack more bits into the accumulator (up to 124)
+    while i < input.count && hexdigit(input[i]) < 16 && significand._high < limit {
       significand &<<= 4
-      significand += UInt64(hexdigit(input[i]))
+      significand |= _UInt128(hexdigit(input[i]))
       i += 1
     }
-    // Part of the digit that would overflow our 64-bit accumulator
-    if i < input.count && hexdigit(input[i]) < 16 && significand.leadingZeroBitCount > 0 {
-      let bits = significand.leadingZeroBitCount
+    // Part of the digit that would overflow our 128-bit accumulator
+    if i < input.count && hexdigit(input[i]) < 16 && significand._high.leadingZeroBitCount > 0 {
+      let bits = significand._high.leadingZeroBitCount
       significand &<<= bits
       // Fill that many bits from the next digit
       let digit = hexdigit(input[i])
       let upperPartialDigit = digit >> (4 - bits)
-      significand += UInt64(upperPartialDigit)
+      significand |= _UInt128(upperPartialDigit)
       // Did we drop any non-zero bits?
       remainderNonZero = remainderNonZero || ((digit - (upperPartialDigit << (4 - bits))) != 0)
       i += 1
@@ -611,11 +616,9 @@ fileprivate func hexFloat(
   // Align the significand so the most-significant bit
   // is the MSbit of the accumulator.
   significand <<= significand.leadingZeroBitCount
-
-  // Narrow to the target format and compute a 0.64 fraction
+  // Narrow to the target format and compute a 0.128 fraction
   // for the rest
-  var targetSignificand = significand >> (64 - significantBits)
-
+  var targetSignificand = significand >> (128 - significantBits)
   // Folding in `remainderNonZero` here helps us distinguish
   // "1.00000000000000000000000000000000000000" (== 1.0) from
   // "1.00000000000000000000000000000000000001" (> 1.0)
@@ -623,25 +626,30 @@ fileprivate func hexFloat(
   // It is `true` if any bits that were too insignificant to store
   // were actually non-zero and might therefore cause the result to
   // be rounded up.
-  let significandFraction = (significand << significantBits) + (remainderNonZero ? 1 : 0)
+  var significandFraction = (significand << significantBits) + (remainderNonZero ? 1 : 0)
 
   // Round up if fraction is > 1/2 or == 1/2 with odd significand
-  if (significandFraction > 0x8000000000000000
-      || (significandFraction == 0x8000000000000000
-          && (targetSignificand & 1) == 1)) {
-    // Round up, test for overflow
-    targetSignificand += 1
-    if targetSignificand >= (UInt64(1) << targetFormat.significandBits) {
-      // Normal overflowed, need to renormalize
-      targetSignificand >>= 1
-      binaryExponent += 1
-    } else if (binaryExponent < targetFormat.minBinaryExponent
-               && targetSignificand >= (UInt64(1) << (targetFormat.significandBits - 1))) {
-      // Subnormal overflowed to normal
-      binaryExponent += 1
+  if significandFraction >> 127 == 1 { // >= 1/2
+    significandFraction <<= 1  // Clear sign to simplify following
+    if (significandFraction != 0 // > 1/2
+          || (significandFraction == 0 // == 1/2
+                && (targetSignificand & 1) == 1)) // odd significand
+    {
+      // Round up, test for overflow
+      targetSignificand += 1
+      if targetSignificand >= (_UInt128(1) << targetFormat.significandBits) {
+        // Normal overflowed, need to renormalize
+        targetSignificand >>= 1
+        binaryExponent += 1
+      } else if (binaryExponent < targetFormat.minBinaryExponent
+                   && targetSignificand >= (_UInt128(1) << (targetFormat.significandBits - 1))) {
+        // Subnormal overflowed to normal
+        binaryExponent += 1
+      }
     }
   }
-  return .binary(significand: targetSignificand,
+  return .binary(significand: targetSignificand._low,
+                 significandHigh: targetSignificand._high,
                  exponent: Int16(binaryExponent),
                  sign: sign)
 }
@@ -658,14 +666,14 @@ fileprivate func nan_payload(
   input: Span<UInt8>,
   start: Int,
   end: Int
-) -> UInt64? {
+) -> _UInt128? {
   if start == end {
     return 0
   }
   var p = start
 
   // Figure out what base we're using
-  var base: UInt64 = 10 // Decimal by default
+  var base: UInt = 10 // Decimal by default
   if p + 1 < end {
     if input[p] == 0x30 {
       if input[p + 1] == 0x78 { // '0x' => hex
@@ -679,14 +687,14 @@ fileprivate func nan_payload(
   }
   // Accumulate the payload, preserving only
   // the least-significant 64 bits.
-  var payload : UInt64 = 0
+  var payload : _UInt128 = 0
   for i in p..<end {
     let d = hexdigit(input[i])
     if d >= base {
       return nil
     }
-    payload &*= UInt64(base)
-    payload &+= UInt64(d)
+    payload &*= _UInt128(base)
+    payload &+= _UInt128(d)
   }
   return payload
 }
@@ -741,7 +749,11 @@ fileprivate func fastParse64(
   // Reject empty strings or grotesquely overlong ones
   // Among other concerns, we want to be sure that 32-bit and 16-bit
   // exponent calculations below don't overflow.
-  if input.count == 0 || input.count > 16384 {
+
+  // TODO: handle overlong input more carefully so we can
+  // use this to parse an FP number as a prefix of a much
+  // longer string
+  if input.count == 0 || input.count > 32000 {
     return .failure
   }
   // Is this positive or negative?
@@ -788,7 +800,9 @@ fileprivate func fastParse64(
   } else if first > 0x39 {
     // Starts with a non-digit (and non-'.')
     // Hexfloats, infinity, NaN are all at least 3 characters
-    if i &+ 3 > input.count { return .failure }
+    if i &+ 3 > input.count {
+      return .failure
+    }
     let second = input[i &+ 1]
     let third = input[i &+ 2]
     if (first | 0x20) == 0x69 { // 'i' or 'I'
@@ -813,11 +827,14 @@ fileprivate func fastParse64(
         // NaN
         if i &+ 3 == input.count {
           // Bare 'nan' with no payload
-          return .nan(payload: 0, signaling: false, sign: sign)
+          return .nan(payload: 0, payloadHigh: 0, signaling: false, sign: sign)
         } else if input[i &+ 3] == 0x28 && input[input.count &- 1] == 0x29 {
           // 'nan' with payload
           if let payload = nan_payload(input: input, start: i &+ 4, end: input.count &- 1) {
-            return .nan(payload: payload, signaling: false, sign: sign)
+            return .nan(payload: payload._low,
+                        payloadHigh: payload._high,
+                        signaling: false,
+                        sign: sign)
           }
         }
       }
@@ -828,11 +845,14 @@ fileprivate func fastParse64(
         // sNaN
         if i &+ 4 == input.count {
           // Bare 'snan' with no payload
-          return .nan(payload: 0, signaling: true, sign: sign)
+          return .nan(payload: 0, payloadHigh: 0, signaling: true, sign: sign)
         } else if input[i &+ 4] == 0x28 && input[input.count &- 1] == 0x29 {
           // 'snan' with payload
           if let payload = nan_payload(input: input, start: i &+ 5, end: input.count &- 1) {
-            return .nan(payload: payload, signaling: true, sign: sign)
+            return .nan(payload: payload._low,
+                        payloadHigh: payload._high,
+                        signaling: true,
+                        sign: sign)
           }
         }
       }
@@ -1290,8 +1310,8 @@ fileprivate func divideMPbyMP(
   numerator = unsafe Range(_uncheckedBounds: (lower: quotient_lsw, upper: quotient_msw))
 }
 
-// Multiply a multi-precision value by a UInt32
-fileprivate func multiplyMPByN(
+// Multiply a multi-precision value by a 32-bit value
+fileprivate func multiplyMPBy32(
   work: inout MutableSpan<MPWord>,
   range: inout Range<Int>,
   multiplier: UInt32
@@ -1313,8 +1333,8 @@ fileprivate func multiplyMPByN(
   range = range.lowerBound..<i
 }
 
-// Multiply a multi-precision value by a UInt128
-fileprivate func multiplyMPByN(
+// Multiply a multi-precision value by a value of at most 96 bits
+fileprivate func multiplyMPBy96(
   work: inout MutableSpan<MPWord>,
   range: inout Range<Int>,
   multiplier: _UInt128
@@ -1331,6 +1351,40 @@ fileprivate func multiplyMPByN(
   while t > 0 {
     unsafe work[unchecked: i] = MPWord(truncatingIfNeeded: t)
     t >>= bitsPerMPWord
+    i &+= 1
+  }
+  range = range.lowerBound..<i
+}
+
+// Multiply a multi-precision value by a 128-bit value
+fileprivate func multiplyMPBy128(
+  work: inout MutableSpan<MPWord>,
+  range: inout Range<Int>,
+  multiplier: _UInt128
+) {
+  let bitsPerMPWord = MPWord.bitWidth
+  var i = range.lowerBound
+  let a = _UInt128(multiplier._high)
+  let b = _UInt128(multiplier._low)
+  var u = _UInt128(0)
+  var l = _UInt128(0)
+  while i < range.upperBound {
+    let word = _UInt128(unsafe work[unchecked: i])
+    l &+= b &* word
+    u &+= a &* word
+    unsafe work[unchecked: i] = MPWord(truncatingIfNeeded: l)
+    l >>= bitsPerMPWord
+    let t = MPWord(truncatingIfNeeded: u)
+    u >>= bitsPerMPWord
+    l += _UInt128(t) << bitsPerMPWord
+    i &+= 1
+  }
+  while u != 0 || l != 0 {
+    unsafe work[unchecked: i] = MPWord(truncatingIfNeeded: l)
+    l >>= bitsPerMPWord
+    let t = MPWord(truncatingIfNeeded: u)
+    u >>= bitsPerMPWord
+    l += _UInt128(t) << bitsPerMPWord
     i &+= 1
   }
   range = range.lowerBound..<i
@@ -1434,7 +1488,7 @@ fileprivate func initMPFromDigits(
       batch = batch &* 10 &+ UInt32(digitChar &- 0x30)
       digitPos &+= 1
     }
-    multiplyMPByN(work: &work, range: &range, multiplier: unsafe powersOfTen[unchecked: batchSize])
+    multiplyMPBy32(work: &work, range: &range, multiplier: unsafe powersOfTen[unchecked: batchSize])
     addToMP(work: &work, range: &range, addend: batch)
     remainingDigitCount &-= batchSize
   }
@@ -1443,7 +1497,7 @@ fileprivate func initMPFromDigits(
   // summarize the digits beyond that with a single digit: zero if
   // all the extra digits are zero, else one.
   if summarizeDigitCount > 0 {
-    multiplyMPByN(work: &work, range: &range, multiplier: UInt32(10))
+    multiplyMPBy32(work: &work, range: &range, multiplier: UInt32(10))
     while summarizeDigitCount > 0 {
       let digit = unsafe input[unchecked: digitPos]
       if digit >= 0x30 { // Excludes '.' (0x2e)
@@ -1500,7 +1554,7 @@ fileprivate func multiplyByFiveToTheN(
   // gives a < 128-bit result
   while remainingPower >= 40 {
     let fiveToThe40 = _UInt128(high: 493038065, low: 14077307678380127585)
-    multiplyMPByN(work: &work, range: &range, multiplier: fiveToThe40)
+    multiplyMPBy96(work: &work, range: &range, multiplier: fiveToThe40)
     remainingPower &-= 40
   }
 
@@ -1508,50 +1562,115 @@ fileprivate func multiplyByFiveToTheN(
   // 5 ** 27 is the largest power of 5 that fits in 64 bits
   if remainingPower >= 27 {
     let fiveToThe27 = _UInt128(7450580596923828125)
-    multiplyMPByN(work: &work, range: &range, multiplier: fiveToThe27)
+    multiplyMPBy96(work: &work, range: &range, multiplier: fiveToThe27)
     remainingPower &-= 27
   }
 
   if remainingPower >= 14 {
     // We know 14 <= remainingPower < 27
     let next = unsafe powersOfFive_64[unchecked: remainingPower &- 14]
-    multiplyMPByN(work: &work, range: &range, multiplier: _UInt128(next))
+    multiplyMPBy96(work: &work, range: &range, multiplier: _UInt128(next))
   } else if remainingPower > 0 {
     // We know remainingPower < 14
     let next = unsafe powersOfFive_32[unchecked: remainingPower]
-    multiplyMPByN(work: &work, range: &range, multiplier: next)
+    multiplyMPBy32(work: &work, range: &range, multiplier: next)
   }
 }
 
-// Table of pre-computed multi-word powers of 5.  These are the
-// largest powers of 5 that it into successive numbers of 32-bit
-// words.  (For example, 5 ** 13 is the largest power that fits in 1
-// word, 5 ** 82 is the largest that fits in six words).  Each
-// constant is broken down into 32-bit components stored from LSW to
-// MSW, assuming that MPWord == UInt32.
+// Table of pre-computed multi-word powers of 5.  These are the largest powers
+// of 5 that it into the appropriate number of 32-bit words.  (For example, 5 **
+// 82 is the largest power that fits in six words, 5 ** 358 is the largest that
+// fits in 26 words).  Each constant is broken down into 32-bit components
+// stored from LSW to MSW, assuming that MPWord == UInt32.
 fileprivate let powersOfFive : _InlineArray<_, UInt32> = [
-  1220703125, // 5 ** 13
-  4195354525, 1734723475, // 5 ** 27
-  1520552677, 3503241150, 2465190328, // 5 ** 41
-  4148285293, 4294227171, 3487696741, 3503246160, // 5 ** 55
-  1377153393, 419140343, 3542739626, 1966161609, 995682444, // 5 ** 68
-  3638046937, 1807989461, 112486150, 1644435829, 286361822, 1414949856, // 5 ** 82
-  3776417409, 3833115195, 474402842, 2046101519, 1659368615, 1657637457, 2010764683, // 5 ** 96
-  1399551081, 2264871549, 2930733413, 271785330, 1503646741, 3175827184, 883420894, 2857468478, // 5 ** 110
-  3691486353, 2604572144, 3704384674, 3457541460, 101893061, 3173229722, 3228011613, 3028118404, 4060706939, // 5 ** 124
-  // In theory, this table could be extended with the following powers:
-  // 137, 151, 165, 179, 192, 206, 220, 234, 248, 261, 275,
-  // 289, 303, 316, 330, 344, 358, 372, 385, 399
-  // That would let us compute a power of 5 for any Double with
-  // one constant lookup from this table and one multi-precision multiplication.
-  // With a little fussing in the calculation below, we could economize by only
-  // storing every second entry in the above list; that would give us any
-  // Double with one constant lookup and two multiplications.
+  // 5 ** 27    8 bytes
+  0xfa10079d, 0x6765c793,
+
+  // 5 ** 82    24 bytes
+  0xd8d830d9, 0x6bc3bad5, 0x6b46706, 0x62041975, 0x111188de, 0x54566be0,
+
+  // 5 ** 137    40 bytes
+  0xe9a54365, 0xeace01d4, 0x66ab8840, 0x712c6b0c, 0xf4ba22cc, 0x271ddfa7,
+  0x3c8e29d4, 0x350324a5, 0x3924bf5d, 0x44ca8257,
+
+  // 5 ** 192    56 bytes
+  0xac815d01, 0xa9e17e1f, 0x6412e125, 0x769dbb7e, 0xf1b8a046, 0xfea73c80,
+  0xe6a2cf4c, 0x73add001, 0xd6388cec, 0xc3c46289, 0xfd1ec505, 0xa16ef894,
+  0x4e49d55a, 0x381c3de3,
+
+  // 5 ** 248    72 bytes
+  0x27af0a21, 0xda87f33, 0x31619b4a, 0x6f97eb72, 0x4bfd6ba0, 0x1a0be7a1,
+  0xaae036d0, 0x848566cf, 0xd92da06d, 0x2c115ac9, 0x9dd02b0, 0xde27f9c4,
+  0x368498b9, 0x611fe6a4, 0xeaa5334a, 0xfabaf3f, 0x92a40515, 0xe4d5e823,
+
+  // 5 ** 303    88 bytes
+  0xd818ff0d, 0x80a8ab58, 0xacb4e04a, 0xd82ee807, 0x7d52768c, 0x3f2f7c3c,
+  0xdb4fd779, 0x592b1ec0, 0x1a048818, 0x5bbdb420, 0xe941dd25, 0xd490df5a,
+  0xff592863, 0x5487f097, 0xdc1740fd, 0xd6898606, 0x1dea2bc7, 0xbe643f00,
+  0x8f54e6ba, 0xd3056025, 0x8396cffd, 0xbaa718e6,
+
+  // 5 ** 358    104 bytes
+  0x862d1b89, 0xa1501485, 0xbab666a2, 0xbadfcd89, 0x32068b7c, 0x134b9681,
+  0x1c01b213, 0xe780ce52, 0xd2d0b297, 0x824f79b9, 0x71f68fd1, 0xdae28649,
+  0x6ce8a49d, 0x93fb45d9, 0x984b8ec7, 0xbfdb631, 0x7d14bc8e, 0x6fe2bfb3,
+  0xa3041a5c, 0xdb7be437, 0x192edcb6, 0xba7ea880, 0xba4f93c8, 0x7e3766d,
+  0x4d642a92, 0x983ee842,
+
+  // Values beyond this point are only used for Float80/Float128.
+  // Trimming them would save 760 bytes...
+
+  // Alternatively, we could speed things up by breaking here and having a
+  // second triangular table starting with 5^413 (30 words) and increasing by 30
+  // words for each successive value.  That would cost 6600 bytes and limit
+  // calls to multiplyByFiveToTheN to at most 5^412.
+
+  // 5 ** 413    120 bytes
+  0xc7418055, 0xe0fd09d8, 0x1f6fef06, 0xe0aa919a, 0x3a932696, 0xeefa64b7,
+  0x4ad4b5c1, 0xc7b36de4, 0x46739345, 0x4842174f, 0x18b983bc, 0xa98ab9ff,
+  0x97d0164c, 0xd7c61ef2, 0x1e75294b, 0xb45d0246, 0x9ad20a7d, 0x7d2b6dfa,
+  0xadf139f0, 0xa50a7cc6, 0x6f8b9285, 0xff5ca1c0, 0xab0bcbe, 0x32501df6,
+  0xed5227ea, 0x74628fef, 0x2c471432, 0xa2c33b1b, 0x29d341b6, 0x7c2e645e,
+
+  // 5 ** 468    136 bytes
+  0x663d5f31, 0xc852d43d, 0x628adfb8, 0x7532907f, 0x519a9fcf, 0xff6d61c3,
+  0xee47a4fb, 0x5364a40, 0x8307a5e7, 0xc51a19b6, 0x152115bd, 0xd64160ca,
+  0x5a7fc303, 0x4420c114, 0xb0472914, 0x4701c038, 0xa75d51fb, 0x9329af1e,
+  0xfd726810, 0x95a1fec8, 0x433b921e, 0xac637005, 0x4b769501, 0x97b6965a,
+  0x5c15ca6c, 0x2e3a3781, 0xa1c3722f, 0x9cee9acc, 0x243794ea, 0x98d384d2,
+  0x8f51a4f3, 0xfb591b83, 0x74dd9297, 0x654a3f98,
+
+  // 5 ** 523    152 bytes
+  0x9a8b26dd, 0xbf2c0cb0, 0x55574b71, 0xbaf1ae94, 0x909d4708, 0x3a0e3864,
+  0x96024957, 0x220c2ed9, 0x3c846d96, 0xa8f2eb24, 0x4c42f275, 0x2fbb514b,
+  0xc2c02b99, 0x2943f65a, 0x59784a24, 0x966b340, 0x8aa1aecc, 0x12c6b3ee,
+  0x694ef465, 0xde3eaa92, 0x232dffbe, 0xce590fe4, 0xacdaed02, 0xdb515c72,
+  0xed4346e1, 0x80a57e71, 0x62e788b1, 0xafbcf17e, 0x71c9d096, 0x71bf4008,
+  0x77961314, 0x3cc04087, 0xd031224e, 0x37315310, 0x24aba8bc, 0x42b158b6,
+  0x550880c, 0x529e5882,
+
+  // 5 ** 578    168 bytes
+  0x6ac93f19, 0xb0528df3, 0x1bd0d93b, 0x6887cf42, 0x16c95762, 0xe06cf811,
+  0xef6a19f0, 0xc9642ada, 0xd0281f3b, 0x95048fea, 0x8a90381, 0x8e351ad1,
+  0x57cfc253, 0x4c526792, 0xd12ead90, 0x22519d79, 0x886cfbcc, 0x492e7dd2,
+  0x62cd8fad, 0xc3a19bf6, 0x63cb573d, 0x96988013, 0x6f26d941, 0xe0e8f38b,
+  0xd543d024, 0x4312f15, 0xaec520f3, 0x29c4a0e0, 0xc8330daf, 0x9194ca21,
+  0x3f122fb9, 0xc39177e7, 0xeec85730, 0x966c77b2, 0xfb50bc61, 0x650a689e,
+  0x69260814, 0x3a4513bd, 0x9e62b35d, 0xbdb41cdb, 0xadf47696, 0x43638e41,
+
+  // 5 ** 633    184 bytes
+  0x560e14a5, 0xf6691422, 0x2c70055c, 0x5fc5dab3, 0xc8ad71e0, 0xa2bc1b0d,
+  0xc651c583, 0x7aa7847b, 0x2daed74b, 0xfe54e5a6, 0xa295aa36, 0x64026c31,
+  0x8712dcba, 0x9cca8c7d, 0x2be239e4, 0xd549bd5, 0xb48d5fa8, 0xaf5e76ed,
+  0x46811a6e, 0x78e4dec4, 0xad6da29a, 0x616c4a6e, 0x15a1974, 0x96f6c825,
+  0x1cd852b4, 0x6ab56842, 0xe45a6968, 0x75631650, 0xe5fc1f10, 0x2bca9511,
+  0x21c5300c, 0xab7e2dcf, 0xb61dde63, 0x6fd760e0, 0xe8c710c1, 0xde5ba724,
+  0xc57e501c, 0x497c1f1a, 0xee6cd3, 0xdd0175f2, 0xa199ce9f, 0x5a4b5d2,
+  0xbd6fa764, 0x9d58b359, 0xd4f4fb60, 0x36f774e8, 
 ]
 
 // Build a multi-precision integer 5^n
 
-// This is obviously a performance bottleneck when parsing Float80
+// This is obviously a performance bottleneck when parsing Float80/128
 // values with large negative exponents, such as `1e-4000`.  But note
 // that the exponent here is not necessarily limited to the range of
 // the target format, which means we can in theory have performance
@@ -1571,6 +1690,7 @@ fileprivate func fiveToTheN(
     range = range.lowerBound..<(range.lowerBound &+ 1)
     return
   }
+
   if power <= 27 {
     // 14 <= Power <= 27 can be satisfied from the 64-bit table
     let t = unsafe powersOfFive_64[unchecked: power &- 14]
@@ -1580,25 +1700,32 @@ fileprivate func fiveToTheN(
     return
   }
 
-  // Otherwise, initialize with a multi-word value, then multiply
-  // to get the final exact value.
-  // The table of pre-computed values here supports a larger
-  // range of exponents than the original C version, while
-  // requiring only a small amount of fixed table storage.
-  let maxPower = 124 // Largest power supported by the table above
+  // Otherwise, initialize with a multi-word value from the table above,
+  // then multiply to get the final exact value.
+  let maxPower = 633 // Largest power supported by the table above
   let clampedPower = power > maxPower ? maxPower : power
   // We need to find the appropriate power of five from the table
-  // above.  First, how many words are in that?  (This formula
-  // has been verified experimentally for every input up to 399.)
-  let words = ((clampedPower &+ 1) &* 1189) >> 14
-  // The power in the above table with that many words
+  // above.  This maps the power to the index of the largest power of 5
+  // in the table no greater than the desired power.
+  let index = (((clampedPower &* 4759) >> 16) - 2) / 4
+  // How many words in that item?
+  let words = index * 4 + 2
+  // The corresponding power of five
   let seedPower = (words &* 441) >> 5
-  // Find the starting offset of the constant in the table:
-  let startIndex = words &* (words &- 1) / 2 // Triangular numbers
+  // The offset where that item starts
+  let start = (index &* (index &- 1) / 2) * 4 + (index &* 2) // Triangular numbers
   for i in 0..<words {
-    unsafe work[unchecked: range.lowerBound &+ i] = unsafe powersOfFive[unchecked: startIndex &+ i]
+    unsafe work[unchecked: range.lowerBound &+ i] = unsafe powersOfFive[unchecked: start &+ i]
   }
   range = range.lowerBound..<(range.lowerBound &+ words)
+
+  // For very large Float80/Float128 exponents, the following call can account
+  // for up to 95% of the runtime.  E.g., "1e4900" initializes 5^633 above and
+  // then needs to make up 5^4267 with this call.  If performance for such large
+  // powers is ever a primary concern, we could expand the above logic with a
+  // larger range of precomputed powers or explore ways to speed up
+  // `multiplyByFiveToTheN` for large powers.  But for now, the increased code
+  // size isn't really justified.
   multiplyByFiveToTheN(work: &work, range: &range, power: power &- seedPower)
 }
 
@@ -1616,72 +1743,83 @@ fileprivate func bitCountMP(
   return totalBits &- emptyBitsInMSWord
 }
 
-// Returns a UInt64 with the most-significant
+// Returns a UInt128 with the most-significant
 // `count` bits from the multi-precision integer.
-
-// TODO: Float128 needs more than 64 bits. So to support Float128, we
-// would need a separate 128-bit version.
 @inline(never)
 fileprivate func mostSignificantBitsFrom(
   work: borrowing MutableSpan<MPWord>,
   range: Range<Int>,
   count: Int,
   remainderNonZero: Bool
-) -> UInt64 {
+) -> _UInt128 {
   let bitsPerMPWord = MPWord.bitWidth
 
   var i = range.upperBound &- 1
-  var t = unsafe UInt64(work[unchecked: i])
-  var remainderNonZero = remainderNonZero
+  let firstWord = unsafe work[unchecked: i]
+  let firstWordBits = bitsPerMPWord - firstWord.leadingZeroBitCount
+  var accumulator = _UInt128(firstWord)
+  var remainingBits = count
+  var fractionBits = 0
   var fraction = UInt64(0)
 
-  if _fastPath(i > range.lowerBound) {
-    t &<<= bitsPerMPWord
-    i &-= 1
-    t |= unsafe UInt64(work[unchecked: i])
+  if firstWordBits >= remainingBits {
+    accumulator &>>= firstWordBits - remainingBits
+    fractionBits = firstWordBits - remainingBits
+    fraction = UInt64((firstWord << (32 - fractionBits)) >> (32 - fractionBits))
+    remainingBits = 0
+  } else {
+    remainingBits -= firstWordBits
 
-    if i > range.lowerBound {
-      let extraBitCount = t.leadingZeroBitCount
-      t &<<= extraBitCount
+    // Fold full words into accumulator
+    while remainingBits >= bitsPerMPWord && i > range.lowerBound {
+      accumulator &<<= bitsPerMPWord
       i &-= 1
-      let nextWord = unsafe UInt64(work[unchecked: i])
+      accumulator |= unsafe _UInt128(work[unchecked: i])
+      remainingBits -= bitsPerMPWord
+    }
 
-      // TODO: For Float80, we need to compute fraction here so we
-      // can use these next bits for that
+    // Fold a partial word into accumulator
+    // Remainder goes into fraction
+    if remainingBits > 0 && i > range.lowerBound {
+      accumulator &<<= remainingBits
+      i &-= 1
+      let nextWord = unsafe work[unchecked: i]
+      accumulator |= _UInt128(nextWord &>> (32 &- remainingBits))
 
-      t |= nextWord &>> (32 &- extraBitCount)
-
-      if !remainderNonZero {
-        var extraBits = nextWord &<< (32 &+ extraBitCount)
-        while i > range.lowerBound {
-          i &-= 1
-          extraBits |= unsafe UInt64(work[unchecked: i])
-        }
-        remainderNonZero = (extraBits != 0)
-      }
+      fractionBits = 32 &- remainingBits
+      fraction = UInt64((nextWord &<< remainingBits) &>> remainingBits)
+      remainingBits = 0
     }
   }
 
-  t &<<= t.leadingZeroBitCount
-  let roundUpNonZero = unsafe UInt64(unsafeBitCast(remainderNonZero, to: UInt8.self))
+  // Ensure fraction isn't empty...
+  if i > range.lowerBound {
+    fraction &<<= 32
+    i &-= 1
+    fraction |= unsafe UInt64(work[unchecked: i])
+    fractionBits += 32
+  }
+  fraction &<<= 64 - fractionBits
 
-  // We special-case count == 0 here to avoid an extra
-  // arithmetic check below for t >>= 64 - count
+  // Make sure fraction bits after the first are non-zero if they should be...
+  fraction |= unsafe UInt64(unsafeBitCast(remainderNonZero, to: UInt8.self))
+  while i >= range.lowerBound {
+    i &-= 1
+    fraction |= unsafe UInt64(work[unchecked: i])
+  }
+
+  // Left-align the bits to the requested width
+  accumulator &<<= remainingBits
+
   if _slowPath(count == 0) {
-    return (t - 1 + roundUpNonZero) >> 63
-    // TODO: For Float80    } else if count == 64 {
+    // If count == 0, then value is zero, so we only care about rounding...
+    return unsafe _UInt128(unsafeBitCast(fraction > 0x8000000000000000, to: UInt8.self))
   }
 
-  fraction = t &<< count
-  t &>>= 64 &- count
-
-  if fraction == 0 {
-    return t
-  } else {
-    let roundUpOddSignificand = (t & 1)
-    let round = (fraction &- 1 &+ (roundUpNonZero | roundUpOddSignificand)) >> 63
-    return t &+ round
-  }
+  let greater = unsafe unsafeBitCast(fraction > 0x8000000000000000, to: UInt8.self)
+  let equal = unsafe unsafeBitCast(fraction == 0x8000000000000000, to: UInt8.self)
+  let roundUp = _UInt128(greater) | (_UInt128(equal) & accumulator)
+  return accumulator &+ roundUp
 }
 
 // Convert Decimal to Binary, with guaranteed correct results
@@ -1717,7 +1855,7 @@ fileprivate func slowDecimalToBinary(
   let significandWordsNeeded = (significandBitsNeeded &+ (bitsPerMPWord - 1)) / bitsPerMPWord
 
   var binaryExponent = 0
-  let targetSignificand: UInt64
+  let targetSignificand: _UInt128
 
   if decimalExponent >= 0 {
     // ================================================================
@@ -1751,15 +1889,21 @@ fileprivate func slowDecimalToBinary(
                      firstUnparsedDigitOffset: Int(firstUnparsedDigitOffset),
                      unparsedDigitCount: Int(unparsedDigitCount),
                      maxDecimalMidpointDigits: targetFormat.maxDecimalMidpointDigits)
-    // TODO: If `valueRange` at this point has 3 or fewer words
-    // (96 bits or less), then we should load that value into a
-    // local _UInt128, then overwrite `valueRange` with
-    // `fiveToTheN` and `multiplyMPByN()`.  That would be faster than
-    // using `multiplyByFiveToTheN()` for large exponents, since `fiveToTheN`
-    // is consistently faster.
 
-    // Multiply by 5^n
-    multiplyByFiveToTheN(work: &work, range: &valueRange, power: decimalExponent)
+    let sigBits = bitCountMP(work: work, range: valueRange)
+    if sigBits <= 128 && decimalExponent > 67 {
+      // For large exponents, fiveToTheN is much faster
+      // than multiplyByFiveToTheN.
+      let sig = mostSignificantBitsFrom(work: work,
+                                        range: valueRange,
+                                        count: sigBits,
+                                        remainderNonZero: false)
+      fiveToTheN(work: &work, range: &valueRange, power: decimalExponent)
+      multiplyMPBy128(work: &work, range: &valueRange, multiplier: sig)
+    } else {
+      // Multiply by 5^n
+      multiplyByFiveToTheN(work: &work, range: &valueRange, power: decimalExponent)
+    }
 
     let bits = bitCountMP(work: work, range: valueRange)
     binaryExponent = bits &+ decimalExponent &- 1
@@ -1769,7 +1913,7 @@ fileprivate func slowDecimalToBinary(
                                               count: targetFormat.significandBits,
                                               remainderNonZero: false)
 
-    if significand >= (UInt64(1) &<< targetFormat.significandBits) {
+    if significand >= (_UInt128(1) &<< targetFormat.significandBits) {
       significand >>= 1
       binaryExponent &+= 1
     }
@@ -1804,11 +1948,6 @@ fileprivate func slowDecimalToBinary(
     let denominatorWordsNeeded = exponentWordsNeeded
     let totalWordsNeeded = numeratorWordsNeeded &+ denominatorWordsNeeded
 
-    // TODO: Heap allocate if `work` isn't big enough
-    // TODO: For Float16/32/64, we always have a large enough work
-    // space on the stack.  If we ever try to support Float80/128,
-    // we may need to allow the caller to provide a smaller buffer
-    // and allocate temporarily on the heap for extreme inputs.
     precondition(totalWordsNeeded <= work.count)
 
     // Divide work buffer into Numerator storage followed by denominator storage
@@ -1865,7 +2004,7 @@ fileprivate func slowDecimalToBinary(
                                                 range: quotientRange,
                                                 count: targetFormat.significandBits,
                                                 remainderNonZero: remainderNonZero)
-      if significand >= (UInt64(1) &<< targetFormat.significandBits) {
+      if significand >= (_UInt128(1) &<< targetFormat.significandBits) {
         significand >>= 1
         binaryExponent &+= 1
       }
@@ -1889,7 +2028,7 @@ fileprivate func slowDecimalToBinary(
       // exponent.  Then we've transitioned from a subnormal to
       // a normal, so the extra overflow bit will naturally get
       // dropped, we just have to bump the exponent.
-      if significand >= (UInt64(1) &<< (targetFormat.significandBits &- 1)) {
+      if significand >= (_UInt128(1) &<< (targetFormat.significandBits &- 1)) {
         binaryExponent &+= 1
       }
       targetSignificand = significand
@@ -1899,7 +2038,8 @@ fileprivate func slowDecimalToBinary(
     }
   }
 
-  return .binary(significand: targetSignificand,
+  return .binary(significand: targetSignificand._low,
+                 significandHigh: targetSignificand._high,
                  exponent: Int16(truncatingIfNeeded: binaryExponent),
                  sign: sign)
 }
@@ -1984,6 +2124,7 @@ internal func parse_float16(_ span: Span<UInt8>) -> Optional<Float16> {
                  && upperSignificand == lowerSignificand) {
       // Normal with converged bounds
       parsed = .binary(significand: lowerSignificand,
+                       significandHigh: 0,
                        exponent: Int16(truncatingIfNeeded: binaryExponent),
                        sign: sign)
     } else {
@@ -2008,7 +2149,10 @@ internal func parse_float16(_ span: Span<UInt8>) -> Optional<Float16> {
 
   // Now we have either binary or a special form...
   switch parsed {
-  case .binary(significand: let sig, exponent: let binaryExponent, sign: let sign):
+  case .binary(significand: let sig,
+               significandHigh: _,
+               exponent: let binaryExponent,
+               sign: let sign):
     // Hex float or converted decimal
     // Parsers above give us the significand/exponent
     // already adjusted for subnormal, etc.
@@ -2031,7 +2175,10 @@ internal func parse_float16(_ span: Span<UInt8>) -> Optional<Float16> {
     } else {
       return Float16.infinity
     }
-  case .nan(payload: let payload, signaling: let signaling, sign: let sign):
+  case .nan(payload: let payload,
+            payloadHigh: _,
+            signaling: let signaling,
+            sign: let sign):
     let p = 255 & Float16.RawSignificand(truncatingIfNeeded: payload)
     if sign == .minus {
       return -Float16(nan: p, signaling: signaling)
@@ -2162,6 +2309,7 @@ internal func parse_float32(_ span: Span<UInt8>) -> Optional<Float32> {
                  && upperSignificand == lowerSignificand) {
       // Normal with converged bounds
       parsed = .binary(significand: lowerSignificand,
+                       significandHigh: 0,
                        exponent: Int16(truncatingIfNeeded: binaryExponent),
                        sign: sign)
     } else {
@@ -2186,7 +2334,10 @@ internal func parse_float32(_ span: Span<UInt8>) -> Optional<Float32> {
 
   // Now we have either binary or a special form...
   switch parsed {
-  case .binary(significand: let sig, exponent: let binaryExponent, sign: let sign):
+  case .binary(significand: let sig,
+               significandHigh: _,
+               exponent: let binaryExponent,
+               sign: let sign):
     // Hex float or converted decimal
     // Parsers above give us the significand/exponent
     // already adjusted for subnormal, etc.
@@ -2209,7 +2360,10 @@ internal func parse_float32(_ span: Span<UInt8>) -> Optional<Float32> {
     } else {
       return Float32.infinity
     }
-  case .nan(payload: let payload, signaling: let signaling, sign: let sign):
+  case .nan(payload: let payload,
+            payloadHigh: _,
+            signaling: let signaling,
+            sign: let sign):
     let p = 0x1fffff & Float32.RawSignificand(truncatingIfNeeded: payload)
     if sign == .minus {
       return -Float32(nan: p, signaling: signaling)
@@ -2440,6 +2594,7 @@ internal func parse_float64(_ span: Span<UInt8>) -> Optional<Float64> {
     } else if (binaryExponent > targetFormat.minBinaryExponent
                  && upperSignificand == lowerSignificand) {
       parsed = .binary(significand: lowerSignificand,
+                       significandHigh: 0,
                        exponent: Int16(binaryExponent),
                        sign: sign)
     } else {
@@ -2472,7 +2627,10 @@ internal func parse_float64(_ span: Span<UInt8>) -> Optional<Float64> {
 
   // Now we have either binary or a special form...
   switch parsed {
-  case .binary(significand: let sig, exponent: let binaryExponent, sign: let sign):
+  case .binary(significand: let sig,
+               significandHigh: _,
+               exponent: let binaryExponent,
+               sign: let sign):
     // Hex float or converted decimal
     // Parsers above give us the significand/exponent
     // already adjusted for subnormal, etc.
@@ -2495,7 +2653,10 @@ internal func parse_float64(_ span: Span<UInt8>) -> Optional<Float64> {
     } else {
       return Float64.infinity
     }
-  case .nan(payload: let payload, signaling: let signaling, sign: let sign):
+  case .nan(payload: let payload,
+            payloadHigh: _,
+            signaling: let signaling,
+            sign: let sign):
     let p = 0x3ffffffffffff & Float64.RawSignificand(truncatingIfNeeded: payload)
     if sign == .minus {
       return -Float64(nan: p, signaling: signaling)
@@ -2506,5 +2667,188 @@ internal func parse_float64(_ span: Span<UInt8>) -> Optional<Float64> {
     return nil
   }
 }
+
+// ================================================================
+//
+// Float80
+//
+// ================================================================
+
+// Float80 is only available on Intel x86/x86_64 processors on certain operating systems
+// This matches the condition for the Float80 type
+
+#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !(os(macOS) || os(iOS) || os(watchOS) || os(tvOS)))) && (arch(i386) || arch(x86_64))
+
+internal func parse_float80(_ span: Span<UInt8>) -> Optional<Float80> {
+  let targetFormat = TargetFormat(
+    significandBits: 64,
+    minBinaryExponent: -16382,
+    maxBinaryExponent: 16383,
+    minDecimalExponent: -5000,
+    maxDecimalExponent: 5000,
+    maxDecimalMidpointDigits: 11515
+  )
+
+  // Verify the text format and parse the key pieces
+  var parsed = fastParse64(targetFormat: targetFormat, input: span)
+
+  // If we parsed a decimal, we need to convert it to binary
+  if case .decimal(digits: let digits,
+                   base10Exponent: let base10Exponent,
+                   unparsedDigitCount: let unparsedDigitCount,
+                   firstUnparsedDigitOffset: let firstUnparsedDigitOffset,
+                   leadingDigitCount: let leadingDigitCount,
+                   sign: let sign) = parsed {
+    var workStorage = _InlineArray<2500, MPWord>(repeating: MPWord(0))
+    var work = workStorage.mutableSpan
+    parsed = slowDecimalToBinary(targetFormat: targetFormat,
+                                 input: span,
+                                 work: &work,
+                                 digits: digits,
+                                 base10Exponent: base10Exponent,
+                                 unparsedDigitCount: unparsedDigitCount,
+                                 firstUnparsedDigitOffset: firstUnparsedDigitOffset,
+                                 leadingDigitCount: leadingDigitCount,
+                                 sign: sign)
+  }
+
+  // Now we have either binary or a special form...
+  switch parsed {
+  case .binary(significand: let significandBits,
+               significandHigh: _,
+               exponent: let binaryExponent,
+               sign: let sign):
+    // Hex float or converted decimal
+    // Parsers above give us the significand/exponent
+    // already adjusted for subnormal, etc.
+    // So the conversion here is simple:
+    let exponentBits = UInt(binaryExponent + 16383)
+    return Float80(sign: sign,
+                   exponentBitPattern: exponentBits,
+                   significandBitPattern: significandBits)
+  case .zero(sign: let sign):
+    // Literal zero or underflow
+    if sign == .minus {
+      return -Float80()
+    } else {
+      return Float80()
+    }
+  case .infinity(sign: let sign):
+    // Literal infinity or overflow
+    if sign == .minus {
+      return -Float80.infinity
+    } else {
+      return Float80.infinity
+    }
+  case .nan(payload: let payload,
+            payloadHigh: _,
+            signaling: let signaling,
+            sign: let sign):
+    let p = 0x1fffffffffffffff & payload
+    if sign == .minus {
+      return -Float80(nan: p, signaling: signaling)
+    } else {
+      return Float80(nan: p, signaling: signaling)
+    }
+  default:
+    return nil
+  }
+}
+
+#endif
+
+// ================================================================
+// ================================================================
+//
+// Float128
+//
+// ================================================================
+// ================================================================
+
+/*
+
+// Note: Float128 will be introduced after UInt128, so we can use UInt128
+// in the implementation here instead of _UInt128
+@available(...)
+internal func parse_float128(_ span: Span<UInt8>) -> Optional<Float128> {
+  let targetFormat = TargetFormat(
+    significandBits: 113,
+    minBinaryExponent: -16382,
+    maxBinaryExponent: 16383,
+    minDecimalExponent: -5000,
+    maxDecimalExponent: 5000,
+    maxDecimalMidpointDigits: 11550
+  )
+
+  // Verify the text format and parse the key pieces
+  var parsed = fastParse64(targetFormat: targetFormat, input: span)
+
+  // If we parsed a decimal, we need to convert it to binary
+  if case .decimal(digits: let digits,
+                   base10Exponent: let base10Exponent,
+                   unparsedDigitCount: let unparsedDigitCount,
+                   firstUnparsedDigitOffset: let firstUnparsedDigitOffset,
+                   leadingDigitCount: let leadingDigitCount,
+                   sign: let sign) = parsed {
+    var workStorage = _InlineArray<2500, MPWord>(repeating: MPWord(0))
+    var work = workStorage.mutableSpan
+    parsed = slowDecimalToBinary(targetFormat: targetFormat,
+                                 input: span,
+                                 work: &work,
+                                 digits: digits,
+                                 base10Exponent: base10Exponent,
+                                 unparsedDigitCount: unparsedDigitCount,
+                                 firstUnparsedDigitOffset: firstUnparsedDigitOffset,
+                                 leadingDigitCount: leadingDigitCount,
+                                 sign: sign)
+  }
+
+  // Now we have either binary or a special form...
+  switch parsed {
+  case .binary(significand: let sigLo,
+               significandHigh: let sigHi,
+               exponent: let binaryExponent,
+               sign: let sign):
+    // Hex float or converted decimal
+    // Parsers above give us the significand/exponent
+    // already adjusted for subnormal, etc.
+    // So the conversion here is simple:
+    let exponentBits = UInt(binaryExponent + 16383)
+    let significandBits = UInt128(_low: sigLo, _high: sigHi)
+    return Float128(sign: sign,
+                    exponentBitPattern: exponentBits,
+                    significandBitPattern: significandBits)
+  case .zero(sign: let sign):
+    // Literal zero or underflow
+    if sign == .minus {
+      return -Float128()
+    } else {
+      return Float128()
+    }
+  case .infinity(sign: let sign):
+    // Literal infinity or overflow
+    if sign == .minus {
+      return -Float128.infinity
+    } else {
+      return Float128.infinity
+    }
+  case .nan(payload: let payload,
+            payloadHigh: let payloadHigh,
+            signaling: let signaling,
+            sign: let sign):
+    let payload = UInt128(_low: payload, _high: payloadHigh)
+    let p = 0x3fffffffffffffffffffffffffff & payload
+    if sign == .minus {
+      return -Float128(nan: p, signaling: signaling)
+    } else {
+      return Float128(nan: p, signaling: signaling)
+    }
+  default:
+    return nil
+  }
+}
+
+ */
+
 
 #endif // !_pointerBitWidth(_16)

--- a/stdlib/public/core/FloatingPointFromString.swift
+++ b/stdlib/public/core/FloatingPointFromString.swift
@@ -2787,6 +2787,22 @@ internal func parse_float80(_ span: Span<UInt8>) -> Optional<Float80> {
   }
 }
 
+#else
+
+// For "reasons known only to history", this symbol is exported
+// by the Swift runtime even on platforms where we
+// don't support Float80.  We should likely change that someday...
+
+@c(_swift_stdlib_strtold_clocale)
+@usableFromInline
+internal func _swift_stdlib_strtold_clocale(
+  _ cText: Optional<UnsafePointer<CChar>>,
+  _ output: Optional<UnsafeMutablePointer<CLongDouble>>
+) -> Optional<UnsafePointer<CChar>>
+{
+    fatalError("Float80 not supported on this platform")
+}
+
 #endif
 
 // ================================================================

--- a/stdlib/public/core/FloatingPointFromString.swift
+++ b/stdlib/public/core/FloatingPointFromString.swift
@@ -2797,7 +2797,7 @@ internal func parse_float80(_ span: Span<UInt8>) -> Optional<Float80> {
 @usableFromInline
 internal func _swift_stdlib_strtold_clocale(
   _ cText: Optional<UnsafePointer<CChar>>,
-  _ output: Optional<UnsafeMutablePointer<CLongDouble>>
+  _ output: Optional<UnsafeMutableRawPointer>
 ) -> Optional<UnsafePointer<CChar>>
 {
     fatalError("Float80 not supported on this platform")

--- a/stdlib/public/core/FloatingPointFromString.swift
+++ b/stdlib/public/core/FloatingPointFromString.swift
@@ -1803,7 +1803,7 @@ fileprivate func mostSignificantBitsFrom(
 
   // Make sure fraction bits after the first are non-zero if they should be...
   fraction |= unsafe UInt64(unsafeBitCast(remainderNonZero, to: UInt8.self))
-  while i >= range.lowerBound {
+  while i > range.lowerBound {
     i &-= 1
     fraction |= unsafe UInt64(work[unchecked: i])
   }

--- a/stdlib/public/core/FloatingPointParsing.swift.gyb
+++ b/stdlib/public/core/FloatingPointParsing.swift.gyb
@@ -220,8 +220,6 @@ extension ${Self}: LosslessStringConvertible {
   %end
   }
 
-  % if bits in [16, 32, 64]:
-
   // Various entry points that take concrete types.  Note that these
   // are deliberately NOT inlinable:
   // * There is no performance advantage to inlining
@@ -278,37 +276,6 @@ extension ${Self}: LosslessStringConvertible {
     }
   #endif
   }
-
-  % elif bits in [80]:
-
-  // For now, continue relying on libc-based implementation for Float80 support
-  // TODO: Implement `parse_float80(_:Span)` so this can
-  // be implemented the same as above.
-  @available(SwiftStdlib 5.3, *)
-  public init?(_ text: Substring) {
-    self = 0.0
-    let success = unsafe _withUnprotectedUnsafeMutablePointer(to: &self) { p -> Bool in
-      // Make a copy of `text` to ensure we have a null-terminated C string
-      // to pass to the libc API:
-      text.withCString { chars -> Bool in
-        switch unsafe chars[0] {
-        case 9, 10, 11, 12, 13, 32:
-          return false // Reject leading whitespace
-        case 0:
-          return false // Reject empty string
-        default:
-          break
-        }
-        let endPtr = unsafe _swift_stdlib_strto${cFuncSuffix2[bits]}_clocale(chars, p)
-        // Succeed only if endPtr points to end of C string
-        return unsafe endPtr != nil && endPtr![0] == 0
-      }
-    }
-    if !success {
-      return nil
-    }
-  }
-  % end
 }
 
 

--- a/stdlib/public/core/FloatingPointToString.swift
+++ b/stdlib/public/core/FloatingPointToString.swift
@@ -920,14 +920,14 @@ internal func _float80ToStringImpl(
 // * `buffer`: Buffer to place the result
 // Returns: Range of bytes within `buffer` that contain the result
 //
-// Buffer must be at least 40 bytes long and must be pre-filled
+// Buffer must be at least 64 bytes long and must be pre-filled
 // with "0" characters, e.g., via
-// `InlineArray<40,UTF8.CodeUnit>(repeating:0x30)`
+// `InlineArray<64,UTF8.CodeUnit>(repeating:0x30)`
 internal func _Float80ToASCII(
   value f: Float80,
   buffer utf8Buffer: inout MutableSpan<UTF8.CodeUnit>
 ) -> Range<Int> {
-  assert(utf8Buffer.count >= 40)
+  assert(utf8Buffer.count >= 64)
   var buffer = utf8Buffer.mutableBytes
 
   // Step 1: Handle special cases, decompose the input
@@ -1090,6 +1090,7 @@ fileprivate func _Float128Backend(
   significand: _UInt128,
   sign: FloatingPointSign
 ) -> Range<Int> {
+  assert(utf8Buffer.count >= 56)
   var buffer = utf8Buffer.mutableBytes
 
   // Step 2: Compute the base 10 exponent to match the rounding interval

--- a/stdlib/public/core/FloatingPointToString.swift
+++ b/stdlib/public/core/FloatingPointToString.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2018-2025 Apple Inc. and the Swift project authors
+// Copyright (c) 2018-2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -12,53 +12,89 @@
 //
 // Converts floating-point types to "optimal" text formats.
 //
-// The "optimal" form is one with a minimum number of significant
-// digits which will parse to exactly the original value.  This form
-// is ideal for JSON serialization and general printing where you
-// don't have specific requirements on the number of significant
-// digits.
+// The "optimal" form is one with a minimum number of significant digits which
+// will parse to exactly the original value.  This form is ideal for JSON
+// serialization, logging, debugging, and any general printing where you don't
+// have specific UI requirements.
+//
+// Because it doesn't have to support an arbitrary number of output
+// digits, this format can be generated _much_ faster than the
+// `printf` `%e`/`%f`/`%g` forms, which makes it even more ideal for
+// JSON, logging, and general output.
 //
 //===---------------------------------------------------------------------===//
 ///
-/// For binary16, this code uses a simple approach that is normally
-/// implemented with variable-length arithmetic.  However, due to the
-/// limited range of binary16, this can be implemented with only
-/// 32-bit integer arithmetic.
+/// This code has used a variety of different algorithms over the years, all
+/// generating exactly identical output.  The current implementation starts
+/// with a floating-point value `s * 2^e` where s and e are both integers.  We
+/// compute
+/// ```
+///   p = ceil(e * log10(2))
+/// ```
+/// and then do a fixed-precision multiply
+/// ```
+///   (s + 1/2) * 2^e * 10^-p
+/// ```
+/// with different rounding depending on whether the original
+/// `s` is even or odd.
 ///
-/// For other formats, we use a modified form of the Grisu2
-/// algorithm from Florian Loitsch; "Printing Floating-Point Numbers
-/// Quickly and Accurately with Integers", 2010.
+/// * About 40% of the time, the integer portion of this last value is
+///   precisely the integer significand of the optimal base-10
+///   representation we want.  We only need to convert this integer to
+///   digits with a fast integer conversion algorithm, such as the
+///   one below based on work by Paul Khuong.
+///
+/// * The remaining 60% of the time, we need to generate a single
+///   additional digit (with correct rounding).
+///
+/// The description above omits many key details, of course.  A more complete
+/// description appears in the extensive comments for the Float32 implementation
+/// below.  (The other implementations below use essentially the same approach,
+/// only with fewer comments.)
+///
+/// The implementation draws inspiration from the following papers:
+///
+/// ------------
+/// Raffaello Guilietti; "The Schubfach way to render doubles", 2021.
+/// Published online.
+///
+/// Credit: Guilietti computes the power-of-10 scaling factor based on
+/// the width of the rounding interval in order to obtain a
+/// nearly-final result from the initial scaling, avoiding the need
+/// for per-digit iteration.
+/// ------------
+/// Florian Loitsch; "Printing Floating-Point Numbers Quickly and
+/// Accurately with Integers", 2010.
 /// https://doi.org/10.1145/1806596.1806623
 ///
-/// Some of the Grisu2 modifications were suggested by the "Errol
-/// paper": Marc Andrysco, Ranjit Jhala, Sorin Lerner; "Printing
-/// Floating-Point Numbers: A Faster, Always Correct Method", 2016.
+/// Credit: Our test for whether the initial digits give us a value in
+/// the rounding interval is from Loitsch' Grisu algorithm.  The logic
+/// to generate an additional digit when needed is also based on Grisu.
+/// ------------
+/// Marc Andrysco, Ranjit Jhala, Sorin Lerner; "Printing Floating-Point
+/// Numbers: A Faster, Always Correct Method", 2016.
 /// https://doi.org/10.1145/2837614.2837654
-/// In particular, the Errol paper explored the impact of higher-precision
-/// fixed-width arithmetic on Grisu2 and showed a way to rapidly test
-/// the correctness of Grisu-style algorithms.
 ///
-/// A few further improvements were inspired by the Ryu algorithm
-/// from Ulf Anders; "Ryū: fast float-to-string conversion", 2018.
-/// https://doi.org/10.1145/3296979.3192369
+/// Credit: Andrysco, Jhala, and Lerner explored the impact of
+/// higher precision arithmetic on Grisu-style algorithms and
+/// provided a robust way to test implementations of such algorithms
+/// for correctness.
+/// ------------
+/// TODO: Cite vitaut's exploration of Schubfach variants?
 ///
-/// The full algorithm is extensively commented in the Float64 version
-/// below; refer to that for details.
-///
-/// In summary, this implementation is:
+/// In short, this implementation is:
 ///
 /// * Fast.  It uses only fixed-width integer arithmetic and has
-///   constant memory requirements.  For double-precision values on
-///   64-bit processors, it is competitive with Ryu. For double-precision
-///   values on 32-bit processors, and higher-precision values on all
-///   processors, it is considerably faster.
+///   constant memory requirements.  On an Apple M4 processor,
+///   _Float64ToASCII can convert a Float64 into text in about 10ns.
 ///
-/// * Always Accurate. Except for NaNs, converting the decimal form
-///   back to binary will always yield an equal value. For the IEEE
-///   754 formats, the round trip will produce exactly the same bit
-///   pattern in memory. This assumes, of course, that the conversion
-///   from text to binary uses a correctly-rounded algorithm such as
-///   Clinger 1990 or Eisel-Lemire 2021.
+/// * Always Round-trip Accurate. Except for NaNs, converting the
+///   decimal form back to binary will always yield an equal
+///   value. For the IEEE 754 formats, the round trip will produce
+///   exactly the same bit pattern in memory. (This assumes, of course,
+///   that the conversion from text to binary uses a correctly-rounded
+///   algorithm such as Clinger 1990, Eisel-Lemire 2021, or that
+///   used in FloatingPointFromString.swift.)
 ///
 /// * Always Short.  This always selects an accurate result with the
 ///   minimum number of significant digits.
@@ -81,40 +117,26 @@
 ///   form for fractional values bigger than 10^-4; always write at
 ///   least 2 digits for an exponent.
 /// * Apart from the above, we do prefer shorter output.
-
+///
 /// Note: If you want to compare performance of this implementation
 /// versus some others, keep in mind that this implementation does
-/// deliberately sacrifice some performance.  Any attempt to compare
-/// the performance of this implementation to others should
-/// try to compensate for the following:
+/// deliberately sacrifice some performance to achieve other goals.
+/// Any attempt to compare the performance of this implementation
+/// to others should consider the following:
 /// * The output ergonomics described above do take some time.
-///   It would be faster to always emit the form "123456e-78"
-//    (See `finishFormatting()`)
+///   It would be faster to always emit an integer significand
+///   followed by an exponent (e.g., "123456e-78").
 /// * The implementations in published papers generally include
 ///   large tables with every power of 10 computed out.  We've
 ///   factored these tables down to conserve code size, which
 ///   requires some additional work to reconstruct the needed power
-///   of 10. (See the `intervalContainingPowerOf10_*` functions)
-
-///
-/// This Swift implementation was ported from an earlier C version;
-/// the output is exactly the same in all cases.
-/// A few notes on the Swift transcription:
-/// * We use MutableSpan<UTF8.CodeUnit> and MutableRawSpan to
-///   identify blocks of working memory.
-/// * We use unsafe/unchecked operations extensively, supported by
-///   several years of analysis and testing of the original C
-///   implementation to ensure that no unsafety actually occurs.  For
-///   Float32, that testing was exhaustive -- we verified all 4
-///   billion possible Float32 values.
-/// * The Swift code uses an idiom of building up to 8 digit characters
-///   in a UInt64 and then writing the whole block to memory.
-/// * The Swift version is slightly faster than the C version;
-///   mostly thanks to various minor algorithmic tweaks that were
-///   found during the translation process.
+///   of 10. (See the `_powerOf10_*()` functions)
+/// * Compare code size as well as performance.  Our Float64
+///   implementation here is a little over 3kiB compiled, _including_
+///   the supporting data tables.  (Most published implementations
+///   require twice that just for their supporting tables.)
 ///
 // ----------------------------------------------------------------------------
-
 
 // ================================================================
 //
@@ -174,260 +196,196 @@ public func _float16ToStringImpl(
 }
 
 // Convert a Float16 to an optimal ASCII representation.
-// See notes above for comments on the output format here.
 // Inputs:
 // * `value`: Float16 input
 // * `buffer`: Buffer to place the result
 // Returns: Range of bytes within `buffer` that contain the result
 //
-// Buffer must be at least 32 bytes long and must be pre-filled
+// Buffer must be at least 20 bytes long and must be pre-filled
 // with "0" characters, e.g., via
 // `InlineArray<32,UTF8.CodeUnit>(repeating:0x30)`
 
+// Notes on the implementation here: This implementation writes out
+// all integer values in non-exponential form.  This is technically
+// not "optimal".  For example, "65504.0" shows 5 significant digits,
+// even though the 3 significant digits of "6.55e+04" is sufficient.
+// But that just looks silly.
+//
+// As a side-effect of the above, we end up handling integer values as
+// a special case, so the general path only has to deal with values
+// whose binary exponent is negative.  This means they are handled by
+// multiplying by a positive power of ten, which can be done exactly
+// with integer arithmetic due to the small range of Float16.
 @available(SwiftStdlib 5.3, *)
 internal func _Float16ToASCII(
   value f: Float16,
   buffer utf8Buffer: inout MutableSpan<UTF8.CodeUnit>
 ) -> Range<Int> {
   // We need a MutableRawSpan in order to use wide store/load operations
-  // TODO: Tune this value down to the actual minimum for Float16
-  precondition(utf8Buffer.count >= 32)
-  var buffer = utf8Buffer.mutableBytes
+  assert(utf8Buffer.count >= 24)
+  var buffer = unsafe utf8Buffer.mutableBytes
 
-  // Step 1: Handle various input cases:
+  let significandBitCount = Float16.significandBitCount + 1 // 11
+  let exponentBias = Int(bitPattern: Float16._exponentBias) - 1 + significandBitCount // 14 + 11 = 25
   let binaryExponent: Int
   let significand: Float16.RawSignificand
-  let exponentBias = (1 << (Float16.exponentBitCount - 1)) - 2 // 14
-  if (f.exponentBitPattern == 0x1f) { // NaN or Infinity
+
+  // Step 1: Handle the special cases, decompose the input
+
+  if f.exponentBitPattern == Float16._infinityExponent {
     if (f.isInfinite) {
       return _infinity(buffer: &buffer, sign: f.sign)
     } else { // f.isNaN
-      let quietBit =
-        (f.significandBitPattern >> (Float16.significandBitCount - 1)) & 1
-      let payloadMask = UInt16(1 &<< (Float16.significandBitCount - 2)) - 1
-      let payload16 = f.significandBitPattern & payloadMask
+      let quietBit = f.significandBitPattern & Float16._quietNaNMask
+      let payload = f.significandBitPattern & (Float16._significandMask &>> 2)
       return nan_details(
         buffer: &buffer,
         sign: f.sign,
         quiet: quietBit != 0,
         payloadHigh: 0,
-        payloadLow: UInt64(truncatingIfNeeded:payload16))
+        payloadLow: UInt64(truncatingIfNeeded:payload))
     }
-  } else if (f.exponentBitPattern == 0) {
+  } else if f.exponentBitPattern == 0 {
     if (f.isZero) {
       return _zero(buffer: &buffer, sign: f.sign)
-    } else { // Subnormal
-      binaryExponent = 1 - exponentBias
-      significand = f.significandBitPattern &<< 2
+    } else { // f.isSubnormal
+      significand = f.significandBitPattern
+      binaryExponent = 1 &- exponentBias
     }
-  } else { // normal
-    binaryExponent = Int(f.exponentBitPattern) &- exponentBias
-    let hiddenBit = Float16.RawSignificand(1) << Float16.significandBitCount
-    significand = (f.significandBitPattern &+ hiddenBit) &<< 2
-  }
-
-  // Step 2: Determine the exact target interval
-  let halfUlp: Float16.RawSignificand = 2
-  let quarterUlp = halfUlp >> 1
-  let upperMidpointExact =
-    significand &+ halfUlp
-  let lowerMidpointExact =
-    significand &- ((f.significandBitPattern == 0) ? quarterUlp : halfUlp)
-
-  var firstDigit = 1
-  var nextDigit = firstDigit
-
-  // Emit the text form differently depending on what range it's in.
-  // We use `storeBytes(of:toUncheckedByteOffset:as:)` for most of
-  // the output, but are careful to use the checked/safe form
-  // `storeBytes(of:toByteOffset:as:)` for the last byte so that we
-  // reliably crash if we overflow the provided buffer.
-
-  // Step 3: If it's < 10^-5, format as exponential form
-  if binaryExponent < -13 || (binaryExponent == -13 && significand < 0x1a38) {
-    var decimalExponent = -5
-    var u =
-      (UInt32(upperMidpointExact) << (28 - 13 &+ binaryExponent)) &* 100000
-    var l =
-      (UInt32(lowerMidpointExact) << (28 - 13 &+ binaryExponent)) &* 100000
-    var t =
-      (UInt32(significand) << (28 - 13 &+ binaryExponent)) &* 100000
-    let mask = (UInt32(1) << 28) - 1
-    if t < ((1 << 28) / 10) {
-      u &*= 100
-      l &*= 100
-      t &*= 100
-      decimalExponent &-= 2
-    }
-    if t < (1 << 28) {
-      u &*= 10
-      l &*= 10
-      t &*= 10
-      decimalExponent &-= 1
-    }
-    let uDigit = u >> 28
-    if uDigit == (l >> 28) {
-      // More than one digit, so write first digit, ".", then the rest
-      unsafe buffer.storeBytes(
-        of: 0x30 + UInt8(truncatingIfNeeded: uDigit),
-        toUncheckedByteOffset: nextDigit,
-        as: UInt8.self)
-      nextDigit &+= 1
-      unsafe buffer.storeBytes(
-        of: 0x2e,
-        toUncheckedByteOffset: nextDigit,
-        as: UInt8.self)
-      nextDigit &+= 1
-      while true {
-        u = (u & mask) &* 10
-        l = (l & mask) &* 10
-        t = (t & mask) &* 10
-        let uDigit = u >> 28
-        if uDigit != (l >> 28) {
-          // Stop before emitting the last digit
-          break
-        }
-        unsafe buffer.storeBytes(
-          of: 0x30 &+ UInt8(truncatingIfNeeded: uDigit),
-          toUncheckedByteOffset: nextDigit,
-          as: UInt8.self)
-        nextDigit &+= 1
-      }
-    }
-    let digit = 0x30 &+ (t &+ (1 << 27)) >> 28
-    unsafe buffer.storeBytes(
-      of: UInt8(truncatingIfNeeded: digit),
-      toUncheckedByteOffset: nextDigit,
-      as: UInt8.self)
-    nextDigit &+= 1
-    unsafe buffer.storeBytes(
-      of: 0x65, // "e"
-      toUncheckedByteOffset: nextDigit,
-      as: UInt8.self)
-    nextDigit &+= 1
-    unsafe buffer.storeBytes(
-      of: 0x2d, // "-"
-      toUncheckedByteOffset: nextDigit,
-      as: UInt8.self)
-    nextDigit &+= 1
-    unsafe buffer.storeBytes(
-      of: UInt8(truncatingIfNeeded: -decimalExponent / 10 &+ 0x30),
-      toUncheckedByteOffset: nextDigit,
-      as: UInt8.self)
-    nextDigit &+= 1
-    // Last write on this branch, so use a safe checked store
-    buffer.storeBytes(
-      of: UInt8(truncatingIfNeeded: -decimalExponent % 10 &+ 0x30),
-      toByteOffset: nextDigit,
-      as: UInt8.self)
-    nextDigit &+= 1
   } else {
-
-    // Step 4: Greater than 10^-5, so use decimal format "123.45"
-    // (Note: Float16 is never big enough to need exponential for
-    // positive exponents)
-    // First, split into integer and fractional parts:
-
-    let intPart : Float16.RawSignificand
-    let fractionPart : Float16.RawSignificand
-    if binaryExponent < 13 {
-      intPart = significand >> (13 &- binaryExponent)
-      fractionPart = significand &- (intPart &<< (13 &- binaryExponent))
-    } else {
-      intPart = significand &<< (binaryExponent &- 13)
-      fractionPart = significand &- (intPart >> (binaryExponent &- 13))
-    }
-
-    // Step 5: Emit the integer part
-    let text = _intToEightDigits(UInt32(intPart))
-    unsafe buffer.storeBytes(
-      of: text,
-      toUncheckedByteOffset: nextDigit,
-      as: UInt64.self)
-    nextDigit &+= 8
-
-    // Skip leading zeros
-    if intPart < 10 {
-      firstDigit &+= 7
-    } else if intPart < 100 {
-      firstDigit &+= 6
-    } else if intPart < 1000 {
-      firstDigit &+= 5
-    } else if intPart < 10000 {
-      firstDigit &+= 4
-    } else {
-      firstDigit &+= 3
-    }
-
-    // After the integer part comes a period...
-    unsafe buffer.storeBytes(
-      of: 0x2e,
-      toUncheckedByteOffset: nextDigit,
-      as: UInt8.self)
-    nextDigit &+= 1
-
-    if fractionPart == 0 {
-      // Step 6: No fraction, so ".0" and we're done
-      // "0" write is free since buffer is pre-initialized
-      nextDigit &+= 1
-    } else {
-      // Step 7: Emit the fractional part by repeatedly
-      // multiplying by 10 to produce successive digits:
-      var u = UInt32(upperMidpointExact) &<< (28 - 13 &+ binaryExponent)
-      var l = UInt32(lowerMidpointExact) &<< (28 - 13 &+ binaryExponent)
-      var t = UInt32(fractionPart) &<< (28 - 13 &+ binaryExponent)
-      let mask = (UInt32(1) << 28) - 1
-      var uDigit: UInt8 = 0
-      var lDigit: UInt8 = 0
-      while true {
-        u = (u & mask) &* 10
-        l = (l & mask) &* 10
-        uDigit = UInt8(truncatingIfNeeded: u >> 28)
-        lDigit = UInt8(truncatingIfNeeded: l >> 28)
-        if uDigit != lDigit {
-          t = (t & mask) &* 10
-          break
-        }
-        // This overflows, but we don't care at this point.
-        t &*= 10
-        unsafe buffer.storeBytes(
-          of: 0x30 &+ uDigit,
-          toUncheckedByteOffset: nextDigit,
-          as: UInt8.self)
-        nextDigit &+= 1
-      }
-      t &+= 1 << 27
-      if (t & mask) == 0 { // Exactly 1/2
-        t = (t >> 28) & ~1 // Round last digit even
-        // Rounding `t` even can end up moving `t` below
-        // `l`.  Detect and correct for this possibility.
-        // Exhaustive testing shows that the only input value
-        // affected by this is 0.015625 == 2^-6, which
-        // incorrectly prints as "0.01562" without this fix.
-        // With this, it prints correctly as "0.01563"
-        if t < lDigit || (t == lDigit && l > 0) {
-	        t += 1
-        }
-      } else {
-        t >>= 28
-      }
-      // Last write on this branch, so use a checked store
+    // Normal
+    let b = Int(f.exponentBitPattern) &- exponentBias
+    let implicitBit = Float16.RawSignificand(1) << Float16.significandBitCount
+    let s = f.significandBitPattern &+ implicitBit
+    if b > 0 {
+      // Special handling for integer values, as described above.
+      let base10Significand = UInt32(s) &<< b
+      let digits = _intToEightDecimalDigits(base10Significand)
+      var start = 1
       buffer.storeBytes(
-        of: UInt8(truncatingIfNeeded: 0x30 + t),
-        toByteOffset: nextDigit,
+        of: digits &+ 0x3030303030303030,
+        toByteOffset: start,
+        as: UInt64.self)
+      var end = start + 8
+
+      // Trim leading zeros and insert `-` if appropriate:
+      start += digits.trailingZeroBitCount / 8
+      if f.sign == .minus {
+        buffer.storeBytes(
+          of: 0x2d, // "-"
+          toByteOffset: start &- 1,
+          as: UInt8.self)
+        start &-= 1
+      }
+
+      // Add ".0" at end
+      buffer.storeBytes(
+        of: 0x2e, // "."
+        toByteOffset: end,
         as: UInt8.self)
-      nextDigit &+= 1
+      end += 2
+      return start..<end
+    } else {
+      significand = s
+      binaryExponent = b
     }
   }
-  if f.sign == .minus {
-    buffer.storeBytes(
-      of: 0x2d,
-      toByteOffset: firstDigit &- 1,
-      as: UInt8.self) // "-"
-    firstDigit &-= 1
+
+  // Step 2: Compute the base 10 exponent to match the rounding interval
+  // log10(2) * 2^8 ~= 77     log10(3/4) * 2^8 ~= -32
+  let maybeLogThreeQuarters = f.significandBitPattern == 0 ? -32 : 0
+  let rawBase10Power = binaryExponent &* 77 &+ maybeLogThreeQuarters
+  let roundedBase10Power = (rawBase10Power &+ 0xff) >> 8
+  var base10Power = Int(truncatingIfNeeded: roundedBase10Power)
+
+  // Step 3: Look up power-of-10 scale factor
+  let powerOfTen = UInt64(powersOf10_Float16[0 &- base10Power])
+
+  // Step 4: Scale the interval (with rounding)
+
+  // If significand is odd, we need to narrow the interval
+  let narrowInterval = f.significandBitPattern & 1
+
+  // Scale 1 binary ULP
+  var scaledBinaryUlp = powerOfTen &<< (32 &+ binaryExponent)
+  scaledBinaryUlp &+= 2 &- 4 &* UInt64(narrowInterval)
+
+  // We'll use 32.32 fixed point from here on...
+  let fractionBits = 32
+  let fractionMask = (UInt64(1) << fractionBits) - 1
+  let oneHalf = UInt64(1) << (fractionBits - 1)
+
+  // Scaled upper limit of the rounding interval
+  let u0 = powerOfTen &* UInt64(significand)
+  let u1 = u0 &<< (32 &+ binaryExponent)
+  let upperBound = u1 &+ (scaledBinaryUlp >> 1)
+  var base10Significand = UInt32(truncatingIfNeeded: upperBound >> fractionBits)
+  let delta = upperBound & fractionMask
+
+  // Scaled distance from the value above to the lower bound
+  // of the rounding interval.
+  var intervalWidth = scaledBinaryUlp
+  if f.significandBitPattern == 0 {
+    intervalWidth &-= intervalWidth >> 2
   }
-  return firstDigit..<nextDigit
+
+  // Step 6: Compute one more decimal digit if necessary
+  if intervalWidth < delta {
+    // Adjust intervalWidth and delta to measure from the
+    // actual target value to the lower bound of the rounding
+    // interval.  (Up to this point, they've measured from the upper
+    // bound of the rounding interval.)
+    let halfUlp = scaledBinaryUlp &* 5
+    var delta = delta &* 10 &- halfUlp
+    intervalWidth = intervalWidth &* 10 &- halfUlp
+
+    // Compute the additional digit
+    var digit = UInt8(truncatingIfNeeded: delta >> fractionBits)
+    delta &= fractionMask
+
+    // Note that `digit` is the largest value below the target value;
+    // `digit + 1` is the smallest value above the target value.  We
+    // want to select whichever is closer to the target value.
+    let greater = unsafe unsafeBitCast(delta > oneHalf, to: UInt8.self)
+    // If they're equally close, pick the even one
+    let greaterOrEqual = unsafe unsafeBitCast(delta >= oneHalf, to: UInt8.self)
+    // If the lower one is not in the interval, choose the higher one
+    let outOfInterval = unsafe unsafeBitCast(delta > intervalWidth, to: UInt8.self)
+    digit &+= greater | (greaterOrEqual & digit) | outOfInterval
+
+    // Add the new digit into the base10Significand
+    base10Significand = base10Significand &* 10 &+ UInt32(digit)
+    base10Power &-= 1
+  }
+
+  // Step 7: Convert the digits and write them out...
+  var digits = _intToEightDecimalDigits(base10Significand)
+  let trailingZeros = digits.leadingZeroBitCount / 8
+  digits &<<= trailingZeros * 8
+  base10Power &+= trailingZeros
+
+  let startOffset = 6
+  buffer.storeBytes(
+    of: digits &+ 0x3030303030303030,
+    toByteOffset: startOffset,
+    as: UInt64.self)
+  let firstDigit = startOffset &+ digits.trailingZeroBitCount / 8
+  let nextDigit = startOffset &+ 8
+
+  // Step 8: Finish formatting
+  return _finishFormatting(
+    buffer: &buffer,
+    sign: f.sign,
+    firstDigit: firstDigit,
+    nextDigit: nextDigit,
+    forceExponential: false,
+    base10Power: base10Power)
 }
+
+fileprivate let powersOf10_Float16: _InlineArray<_, UInt32> = [
+  1, 10, 100, 1000, 10000, 100000, 1000000, 10000000
+]
+
 #endif
 
 // ================================================================
@@ -466,219 +424,251 @@ internal func _float32ToStringImpl(
 }
 
 // Convert a Float32 to an optimal ASCII representation.
-// See notes above for comments on the output format here.
-// See _Float64ToASCII for comments on the algorithm.
 // Inputs:
 // * `value`: Float32 input
 // * `buffer`: Buffer to place the result
 // Returns: Range of bytes within `buffer` that contain the result
 //
-// Buffer must be at least 32 bytes long and must be pre-filled
+// Buffer must be at least 20 bytes long and must be pre-filled
 // with "0" characters, e.g., via
 // `InlineArray<32,UTF8.CodeUnit>(repeating:0x30)`
 internal func _Float32ToASCII(
   value f: Float32,
   buffer utf8Buffer: inout MutableSpan<UTF8.CodeUnit>
 ) -> Range<Int> {
-  // Note: The algorithm here is the same as for Float64, only
-  // with narrower arithmetic.  Refer to `_Float64ToASCII` for
-  // more detailed comments and explanation.
-
   // We need a MutableRawSpan in order to use wide store/load operations
-  // TODO: Tune this limit down to the actual minimum we need here
-  // TODO: `assert` that the buffer is filled with 0x30 bytes (in debug builds)
-  precondition(utf8Buffer.count >= 32)
-  var buffer = utf8Buffer.mutableBytes
+  assert(utf8Buffer.count >= 24)
+  var buffer = unsafe utf8Buffer.mutableBytes
 
-  // Step 1: Handle the special cases, decompose the input
-
+  let significandBitCount = Float.significandBitCount + 1 // 24
+  let exponentBias = Int(bitPattern: Float32._exponentBias) - 1 + significandBitCount // 126 + 24
   let binaryExponent: Int
   let significand: Float.RawSignificand
-  let exponentBias = (1 << (Float.exponentBitCount - 1)) - 2 // 126
-  if (f.exponentBitPattern == 0xff) {
+
+  // Step 1: Decompose the input, handle the special cases
+
+  if f.exponentBitPattern == Float32._infinityExponent {
     if (f.isInfinite) {
       return _infinity(buffer: &buffer, sign: f.sign)
     } else { // f.isNaN
-      let quietBit =
-        (f.significandBitPattern >> (Float.significandBitCount - 1)) & 1
-      let payloadMask = UInt32(1 << (Float.significandBitCount - 2)) - 1
-      let payload32 = f.significandBitPattern & payloadMask
+      let quietBit = f.significandBitPattern & Float32._quietNaNMask
+      let payload = f.significandBitPattern & (Float32._significandMask &>> 2)
       return nan_details(
         buffer: &buffer,
         sign: f.sign,
         quiet: quietBit != 0,
         payloadHigh: 0,
-        payloadLow: UInt64(truncatingIfNeeded:payload32))
+        payloadLow: UInt64(truncatingIfNeeded:payload))
     }
-  } else if (f.exponentBitPattern == 0) {
+  } else if f.exponentBitPattern == 0 {
     if (f.isZero) {
       return _zero(buffer: &buffer, sign: f.sign)
     } else { // f.isSubnormal
-      binaryExponent = 1 - exponentBias
-      significand = f.significandBitPattern &<< Float.exponentBitCount
+      significand = f.significandBitPattern
+      binaryExponent = 1 &- exponentBias
     }
   } else {
+    // Normal
+    let implicitBit = Float.RawSignificand(1) << Float.significandBitCount
+    significand = f.significandBitPattern &+ implicitBit
     binaryExponent = Int(f.exponentBitPattern) &- exponentBias
-    significand =
-      ((f.significandBitPattern &+ (1 << Float.significandBitCount))
-         &<< Float.exponentBitCount)
   }
 
-  // Step 2: Determine the exact unscaled target interval
+  // Step 2: Compute the base 10 exponent to match the rounding interval
 
-  let halfUlp: Float.RawSignificand = 1 << (Float.exponentBitCount - 1)
-  let quarterUlp = halfUlp >> 1
-  let upperMidpointExact =
-    significand &+ halfUlp
-  let lowerMidpointExact =
-    significand &- ((f.significandBitPattern == 0) ? quarterUlp : halfUlp)
-  let isOddSignificand = ((f.significandBitPattern & 1) != 0)
+  // Following Schubfach, let RI = the width of the rounding interval
+  // Compute base10Power such that
+  //    10^base10Power > RI > 10^(base10Power - 1)
+  // This guarantees:
+  // * AT MOST one multiple of 10^base10Power in our rounding interval
+  //   So if we find one, it's unique and we're done!
+  // * AT LEAST one multiple of 10^(base10Power-1) in that interval.
+  //   So if we don't find a multiple of 10^base10Power, then
+  //   we're certain to find a solution with just one more digit.
 
-  // Step 3: Estimate the base 10 exponent
+  // In the common case where RI = 2^e exactly, this implies that:
+  //    base10Power = ceiling(e * log10(2))
+  // For an exact power of 2, the rounding interval is 25% narrower, so
+  //    base10Power = ceiling(e * log10(2) + log10(0.75))
+  let maybeLogThreeQuarters = (f.significandBitPattern == 0
+                                 ? Int64(-536607787)
+                                 : Int64(0))
+  let rawBase10Power = Int64(binaryExponent) &* 1292913986 &+ maybeLogThreeQuarters
+  let roundedBase10Power = (rawBase10Power &+ 0xffffffff) &>> 32
+  var base10Power = Int(truncatingIfNeeded: roundedBase10Power)
 
-  var base10Exponent = decimalExponentFor2ToThe(binaryExponent)
+  // Step 3: Look up power-of-10 scale factor
 
-  // Step 4: Compute power-of-10 scale factor
+  // To obtain a binary floating-point value for the power of 10, look
+  // up the significand in a table and compute the corresponding
+  // exponent.  The power of 10 is then:
+  //     powerOfTen * 2^powerOfTenExponent
+  let powerOfTen = powersOf10_Float32[33 &- base10Power]
+  let powerOfTenExponent = binaryExponentFor10ToThe(0 &- base10Power)
 
-  var powerOfTenRoundedDown: UInt64 = 0
-  var powerOfTenRoundedUp: UInt64 = 0
+  // Step 4: Scale the interval (with rounding)
+  // We compute `upperBound` the upper bound of the rounding interval and
+  // `intervalWidth` the width, both scaled by 10^(-base10Power)
 
-  let bulkFirstDigits = 1
-  let powerOfTenExponent = _intervalContainingPowerOf10_Binary32(
-    p: -base10Exponent &+ bulkFirstDigits &- 1,
-    lower: &powerOfTenRoundedDown,
-    upper: &powerOfTenRoundedUp)
-  let extraBits = binaryExponent &+ powerOfTenExponent
-
-  // Step 5: Scale the interval (with rounding)
-
-  // Experimentally, 11 is as large as we can go here without
-  // introducing errors.
-  // We need 7 to generate 2 digits at a time below.
-  // 11 should allow us to generate 3 digits at a time, but
-  // that doesn't seem to be any faster.
-  let integerBits = 11
+  // After scaling, we need enough integer bits to represent the
+  // scaled significand.  The worst case is the asymmetric case: then
+  // 10^p > 3/4 * 2^e, so the maximum possible value of 2^e 10^-p is
+  // 4/3, which means we'll need one more bit than the binary
+  // significand.
+  let integerBits = significandBitCount + 1
   let fractionBits = 64 - integerBits
-  var u: UInt64
-  var l: UInt64
-  if isOddSignificand {
-    // Narrow the interval (odd significand)
-    let u1 = _multiply64x32RoundingDown(
-      powerOfTenRoundedDown,
-      upperMidpointExact)
-    u = u1 >> (integerBits - extraBits)
-    let l1 = _multiply64x32RoundingUp(
-      powerOfTenRoundedUp,
-      lowerMidpointExact)
-    let bias = UInt64((1 &<< (integerBits &- extraBits)) &- 1)
-    l = (l1 &+ bias) >> (integerBits &- extraBits)
+  let fractionMask = (UInt64(1) << fractionBits) - 1
+  let oneHalf = UInt64(1) << (fractionBits - 1)
+
+  // If the significand is even, we want to widen the interval by
+  // rounding up the upper midpoint and increasing intervalWidth.
+  // Conversely if the significand is odd.  This ensures that the
+  // exact endpoints of the rounding interval are handled correctly.
+  let narrowInterval = f.significandBitPattern & 1
+
+  // Scale one binary ULP
+  let align = integerBits &- (binaryExponent &+ powerOfTenExponent)
+  var scaledBinaryUlp = powerOfTen &>> align
+  // Widen or narrow the Ulp estimate -- this will flow through
+  // to the other places we need even/odd adjustments.
+  scaledBinaryUlp &+= 3 &- 6 &* UInt64(narrowInterval)
+
+  // Scaled upper bound of the rounding interval
+  let mask32 = UInt64(UInt32.max)
+  let low = (powerOfTen & mask32) &* UInt64(significand)
+  let high = (powerOfTen &>> 32) &* UInt64(significand)
+  // (high << 32) + low is the 96-bit intermediate value. Combine and
+  // align to 64 bit fixed-point, and add 1/2 ULP for the upper bound.
+  let upperBound = ((low &>> align)
+                      &+ (high &<< (32 &- align))
+                      &+ (scaledBinaryUlp &>> 1))
+
+  // Width of the scaled rounding interval
+  // In the non-power-of-two case, the rounding interval has width 1 ULP.
+  var intervalWidth = scaledBinaryUlp
+  if f.significandBitPattern == 0 {
+    // In the power-of-two case, the interval is 3/4 ULP.
+    intervalWidth &-= intervalWidth &>> 2
+  }
+
+  // Step 5: Emit most of the decimal digits into the destination buffer
+
+  // firstDigit starts at 6 to give us room to insert an initial minus
+  // sign and/or leading zeros.  This is used by the ergonomic formatting
+  // logic done in `finishFormatting()`.
+  var firstDigit = 6
+  var nextDigit = firstDigit
+
+  // Split the scaled upperBound into the integer part
+  // (initial base-10 significand) and fraction `delta` (distance
+  // between that significand and the upper bound of the
+  // interval).
+  let base10Significand = UInt32(truncatingIfNeeded: upperBound &>> fractionBits)
+  var delta = upperBound & fractionMask
+
+  // Convert the digits we have so far and write them out...  We could
+  // delay this and fold an extra digit (if necessary) into the
+  // base10Significand.  That would work because a UInt32 can hold any
+  // 9-digit integer.  It would allow us to mimic the Float16
+  // structure above, where this entire function basically just
+  // converts a pair of integers (significand, binaryExponent) into
+  // another pair of integers (base10Significand, base10Power) and
+  // then at the end converts that pair of integers into a textual
+  // representation.
+
+  // But if we do the conversion here, we know we don't have more than
+  // 8 digits, which eliminates the need for extra fussing to conditionally
+  // support up to 9 digits later on.
+  let digits = _intToEightDecimalDigits(base10Significand)
+  buffer.storeBytes(
+    of: digits + 0x3030303030303030,
+    toByteOffset: firstDigit,
+    as: UInt64.self)
+  nextDigit &+= 8
+
+  // Trim leading zero digits
+  // (Little-endian assumption means that the _trailing_
+  // zero digits in `digits` are the most-significant ones.)
+  firstDigit &+= digits.trailingZeroBitCount / 8
+
+  // Step 6: Compute one more decimal digit if necessary
+
+  // Because of how we computed base10Power above, either the digits
+  // so far are in the rounding interval and we're essentially done,
+  // or we need exactly one more digit.
+
+  // Intuitively: `intervalWidth` is the width of the rounding interval,
+  // `delta` is the distance from the value we've computed so far
+  // to our current target value.
+  if intervalWidth > delta {
+    // Step 6, Case A: We have a value that lies within the rounding
+    // interval, and it's a multiple of 10^base10Power.  As described
+    // earlier, there can only be one such. This is the fast case.
+
+    // Experimentally, ~39% of all inputs get here.
+
+    // We don't need any more digits, just trim trailing zeros
+    let trailingZeros = digits.leadingZeroBitCount / 8
+    nextDigit &-= trailingZeros
+    base10Power &+= trailingZeros
+    // No final-digit adjustment is needed
   } else {
-    // Widen the interval (even significand)
-    let u1 = _multiply64x32RoundingUp(
-      powerOfTenRoundedUp,
-      upperMidpointExact)
-    let bias = UInt64((1 &<< (integerBits &- extraBits)) &- 1)
-    u = (u1 &+ bias) >> (integerBits &- extraBits)
-    let l1 = _multiply64x32RoundingDown(
-      powerOfTenRoundedDown,
-      lowerMidpointExact)
-    l = l1 >> (integerBits &- extraBits)
-  }
+    // Step 6, Case B: We need another digit
+    // Experimentally, ~61% of all inputs get here.
 
-  // Step 6: Align first digit, adjust exponent
+    // Adjust `delta` to measure the distance from the value we've computed so
+    // far to the actual float value (instead of the upper endpoint).  This
+    // requires subtracting 1/2 ULP from both delta and intervalWidth:
+    let halfUlp = scaledBinaryUlp &* 5
+    // This is `delta -= ulp/2; delta *= 10` reordered to reduce precision loss
+    delta = delta &* 10 &- halfUlp
+    // Adjust `intervalWidth` to reflect only the lower part of the rounding interval
+    intervalWidth = intervalWidth &* 10 &- halfUlp
 
-  while u < (UInt64(1) &<< fractionBits) {
-    base10Exponent &-= 1
-    l &*= 10
-    u &*= 10
-  }
+    // Multiplying by 10 above scaled us from 10^base10Power
+    // to 10^(base10Power - 1), which gives us the extra digit we want:
+    var digit = UInt8(truncatingIfNeeded: delta &>> fractionBits)
+    delta &= fractionMask
 
-  // Step 7: Generate decimal digits into the destination buffer
+    // `delta` is now the scaled distance from our current base-10
+    // value to the actual binary target value. `digit` is the closest
+    // base-10 digit _below_ our target, `digit + 1` is the closest
+    // _above_ the target.  We need to choose the best one.
 
-  var t = u
-  var delta = u &- l
-  let fractionMask: UInt64 = (1 << fractionBits) - 1
+    // Note: Using arithmetic to combine booleans as below is considerably
+    // faster than the obvious if-else chain.  Swift booleans are consistently
+    // represented as single-byte 0 or 1 values.
+    let epsilon = UInt64(64)
+    // If `delta` is definitively > 1/2, then `digit` is further than `digit + 1`
+    let greater = unsafe unsafeBitCast(delta > (oneHalf &+ epsilon), to: UInt8.self)
+    // They might be equally close (ignoring precision loss in the earlier calculations),
+    // in which case we want `digit + 1` if that would make the result even.
+    let greaterOrEqual = unsafe unsafeBitCast(delta > (oneHalf &- epsilon), to: UInt8.self)
+    // If the lower value is outside of the interval, we definitely want the upper one:
+    // (Note: in the regular symmetric interval case, this is redundant with `greater`)
+    let outOfInterval = unsafe unsafeBitCast(delta > intervalWidth, to: UInt8.self)
+    // Select the upper value if any of these three conditions holds:
+    digit &+= greater | (greaterOrEqual & digit) | outOfInterval
 
-  // Overwrite the first digit at index 7:
-  let firstDigit = 7
-  let digit = (t >> fractionBits) &+ 0x30
-  t &= fractionMask
-  unsafe buffer.storeBytes(
-    of: UInt8(truncatingIfNeeded: digit),
-    toUncheckedByteOffset: firstDigit,
-    as: UInt8.self)
-  var nextDigit = firstDigit &+ 1
-
-  // Generate 2 digits at a time...
-  while (delta &* 10) < ((t &* 10) & fractionMask) {
-    delta &*= 100
-    t &*= 100
-    let d12 = Int(truncatingIfNeeded: t >> fractionBits)
-    let text = unsafe asciiDigitTable[unchecked: d12]
-    unsafe buffer.storeBytes(
-      of: text,
-      toUncheckedByteOffset: nextDigit,
-      as: UInt16.self)
-    nextDigit &+= 2
-    t &= fractionMask
-  }
-
-  // ... and a final single digit, if necessary
-  if delta < t {
-    delta &*= 10
-    t &*= 10
-    let text = 0x30 + UInt8(truncatingIfNeeded: t >> fractionBits)
-    unsafe buffer.storeBytes(
-      of: text,
-      toUncheckedByteOffset: nextDigit,
+    // Write out the extra digit
+    buffer.storeBytes(
+      of: digit &+ 0x30,
+      toByteOffset: nextDigit,
       as: UInt8.self)
     nextDigit &+= 1
-    t &= fractionMask
+    base10Power &-= 1
   }
 
-  // Adjust the final digit to be closer to the original value
+  // Step 7: Finish formatting
   let isBoundary = (f.significandBitPattern == 0)
-  if delta > t &+ (1 << fractionBits) {
-    let skew: UInt64
-    if isBoundary {
-      skew = delta &- delta / 3 &- t
-    } else {
-      skew = delta / 2 &- t
-    }
-    let one = UInt64(1) << (64 - integerBits)
-    let lastAccurateBit = UInt64(1) << 24
-    let fractionMask = (one - 1) & ~(lastAccurateBit - 1)
-    let oneHalf = one >> 1
-    var lastDigit = unsafe buffer.unsafeLoad(
-      fromUncheckedByteOffset: nextDigit &- 1,
-      as: UInt8.self)
-    if ((skew &+ (lastAccurateBit >> 1)) & fractionMask) == oneHalf {
-      // Skew is integer + 1/2, round even after adjustment
-      let adjust = skew >> (64 - integerBits)
-      lastDigit &-= UInt8(truncatingIfNeeded: adjust)
-      lastDigit &= ~1
-    } else {
-      // Round nearest
-      let adjust = (skew &+ oneHalf) >> (64 - integerBits)
-      lastDigit &-= UInt8(truncatingIfNeeded: adjust)
-    }
-    unsafe buffer.storeBytes(
-      of: lastDigit,
-      toUncheckedByteOffset: nextDigit &- 1,
-      as: UInt8.self)
-  }
-
-  // Step 8: Finish formatting
-  let forceExponential =
-    ((binaryExponent > 25)
-       || (binaryExponent == 25 && !isBoundary))
+  let forceExponential = ((binaryExponent > 1) || (binaryExponent == 1 && !isBoundary))
   return _finishFormatting(
     buffer: &buffer,
     sign: f.sign,
     firstDigit: firstDigit,
     nextDigit: nextDigit,
     forceExponential: forceExponential,
-    base10Exponent: base10Exponent)
+    base10Power: base10Power)
 }
 
 // ================================================================
@@ -717,9 +707,8 @@ internal func _float64ToStringImpl(
 }
 
 // Convert a Float64 to an optimal ASCII representation.
-// See notes above for comments on the output format here.
-// The algorithm is extensively commented inline; the comments
-// at the top of this source file give additional context.
+// See the Float32 implementation for extensive comments
+// explaining the algorithm.
 // Inputs:
 // * `value`: Float64 input
 // * `buffer`: Buffer to place the result
@@ -729,456 +718,157 @@ internal func _float64ToStringImpl(
 // with "0" characters, e.g., via
 // `InlineArray<32,UTF8.CodeUnit>(repeating:0x30)`
 internal func _Float64ToASCII(
-  value d: Float64,
+  value f: Float64,
   buffer utf8Buffer: inout MutableSpan<UTF8.CodeUnit>
 ) -> Range<Int> {
-  // We need a MutableRawSpan in order to use wide store/load operations
-  precondition(utf8Buffer.count >= 32)
-  var buffer = utf8Buffer.mutableBytes
+  assert(utf8Buffer.count >= 32)
+  var buffer = unsafe utf8Buffer.mutableBytes
 
-  //
-  // Step 1: Handle the special cases, decompose the input
-  //
+  let significandBitCount = Double.significandBitCount + 1 // 53
+  let exponentBias = Int(bitPattern: Float64._exponentBias) - 1 + significandBitCount
   let binaryExponent: Int
   let significand: Double.RawSignificand
-  let exponentBias = 1022 // (1 << (Double.exponentBitCount - 1)) - 2
 
-  if (d.exponentBitPattern == 0x7ff) {
-    if (d.isInfinite) {
-      return _infinity(buffer: &buffer, sign: d.sign)
-    } else { // d.isNaN
-      let quietBit =
-        (d.significandBitPattern >> (Double.significandBitCount - 1)) & 1
-      let payloadMask = (UInt64(1) &<< (Double.significandBitCount - 2)) - 1
-      let payload64 = d.significandBitPattern & payloadMask
+  // Step 1: Handle the special cases, decompose the input
+
+  if  f.exponentBitPattern == Float64._infinityExponent {
+    if (f.isInfinite) {
+      return _infinity(buffer: &buffer, sign: f.sign)
+    } else { // f.isNaN
+      let quietBit = f.significandBitPattern & Float64._quietNaNMask
+      let payload = f.significandBitPattern & (Float64._significandMask &>> 2)
       return nan_details(
         buffer: &buffer,
-        sign: d.sign,
+        sign: f.sign,
         quiet: quietBit != 0,
         payloadHigh: 0,
-        payloadLow: UInt64(truncatingIfNeeded:payload64))
+        payloadLow: payload
+      )
     }
-  } else if (d.exponentBitPattern == 0) {
-    if (d.isZero) {
-      return _zero(buffer: &buffer, sign: d.sign)
-    } else { // d.isSubnormal
-      binaryExponent = 1 - exponentBias
-      significand = d.significandBitPattern &<< Double.exponentBitCount
+  } else if f.exponentBitPattern == 0 {
+    if (f.isZero) {
+      return _zero(buffer: &buffer, sign: f.sign)
+    } else { // f.isSubnormal
+      significand = f.significandBitPattern
+      binaryExponent = 1 &- exponentBias
     }
   } else {
-    binaryExponent = Int(d.exponentBitPattern) &- exponentBias
-    significand =
-      ((d.significandBitPattern &+ (1 << Double.significandBitCount))
-         &<< Double.exponentBitCount)
+    // Normal
+    let implicitBit = Double.RawSignificand(1) << Double.significandBitCount
+    significand = f.significandBitPattern &+ implicitBit
+    binaryExponent = Int(f.exponentBitPattern) &- exponentBias
   }
-  // The input has been decomposed as significand * 2^binaryExponent,
-  // where `significand` is a 64-bit fraction with the binary
-  // point at the far left.
 
-  // Step 2: Determine the exact unscaled target interval
+  // Step 2: Compute the base 10 exponent to match the rounding interval
 
-  // Grisu-style algorithms construct the shortest decimal digit
-  // sequence within a specific interval.  To build the appropriate
-  // interval, we start by computing the midpoints between this
-  // floating-point value and the adjacent ones.  Note that this
-  // step is an exact computation.
+  let maybeLogThreeQuarters = (f.significandBitPattern == 0
+                                 ? Int64(-536607787)
+                                 : Int64(0))
+  let rawBase10Power = Int64(binaryExponent) &* 1292913986 &+ maybeLogThreeQuarters
+  let roundedBase10Power = (rawBase10Power &+ 0xffffffff) &>> 32
+  var base10Power = Int(truncatingIfNeeded: roundedBase10Power)
 
-  let halfUlp: Double.RawSignificand = 1 << (Double.exponentBitCount - 1)
-  let quarterUlp = halfUlp >> 1
-  let upperMidpointExact = significand &+ halfUlp
-  let lowerMidpointExact =
-    significand &- ((d.significandBitPattern == 0) ? quarterUlp : halfUlp)
-  let isOddSignificand = ((d.significandBitPattern & 1) != 0)
+  // Step 3: Look up power-of-10 scale factor
 
-  // Step 3: Estimate the base 10 exponent
+  var powerOfTen: _UInt128 = 0
+  let powerOfTenExponent = _powerOf10_Binary64(p: 0 &- base10Power,
+                                               significand: &powerOfTen)
 
-  // Grisu algorithms are based in part on a simple technique for
-  // generating a base-10 form for a binary floating-point number.
-  // Start with a binary floating-point number `f * 2^e` and then
-  // estimate the decimal exponent `p`. You can then rewrite your
-  // original number as:
-  //
-  // ```
-  //     f * 2^e * 10^-p * 10^p
-  // ```
-  //
-  // The last term is part of our output, and a good estimate for
-  // `p` will ensure that `2^e * 10^-p` is close to 1.  Multiplying
-  // the first three terms then yields a fraction suitable for
-  // producing the decimal digits.  Here we use a very fast estimate
-  // of `p` that is never off by more than 1; we'll have
-  // opportunities later to correct any error.
+  // Step 4: Scale the interval (with rounding)
 
-  var base10Exponent = decimalExponentFor2ToThe(binaryExponent)
+  // After scaling, we'll use a 54.74 fixed-point format
+  let integerBits = significandBitCount + 1
+  let fractionBits = 128 - integerBits
+  let fractionMask = (_UInt128(1) << fractionBits) - 1
+  let oneHalf = _UInt128(1) << (fractionBits - 1)
 
-  // Step 4: Compute power-of-10 scale factor
+  let narrowInterval = f.significandBitPattern & 1
 
-  // Compute `10^-p` to 128-bit precision.  We generate
-  // both over- and under-estimates to ensure we can exactly
-  // bound the later use of these values.
-  // The `powerOfTenRounded{Up,Down}` values are 128-bit
-  // pure fractions with the decimal point at the far left.
+  // Scale one binary ULP
+  let align = integerBits &- (binaryExponent &+ powerOfTenExponent)
+  var scaledBinaryUlp = powerOfTen &>> align
+  scaledBinaryUlp &+= _UInt128(bitPattern: _Int128(3 &- 6 &* Int(narrowInterval)))
 
-  var powerOfTenRoundedDown: _UInt128 = 0
-  var powerOfTenRoundedUp: _UInt128 = 0
+  // Scale the upper limit
+  let low = _UInt128(powerOfTen._low) &* _UInt128(significand)
+  let high = _UInt128(powerOfTen._high) &* _UInt128(significand)
+  let upperBound = ((low &>> align)
+                      &+ (high &<< (64 - align))
+                      &+ (scaledBinaryUlp &>> 1))
 
-  // Note the extra factor of 10^bulkFirstDigits -- that will give
-  // us a headstart on digit generation later on.  (In contrast, Ryu
-  // uses an extra factor of 10^17 here to get all the digits up
-  // front, but then has to back out any extra digits.  Doing that
-  // with a 17-digit value requires 64-bit division, which is the
-  // root cause of Ryu's poor performance on 32-bit processors.  We
-  // also might have to back out extra digits if 7 is too many, but
-  // will only need 32-bit division in that case.)
+  // Compute the width of the scaled rounding interval
+  var intervalWidth = scaledBinaryUlp
+  if f.significandBitPattern == 0 {
+    // In the power-of-two case, the interval is 3/4 ULP.
+    intervalWidth &-= intervalWidth &>> 2
+  }
 
-  let bulkFirstDigits = 7
-  let bulkFirstDigitFactor: UInt32 = 1000000 // 10^(bulkFirstDigits - 1)
+  // Step 5: Emit most of the decimal digits into the destination buffer
 
-  let powerOfTenExponent = _intervalContainingPowerOf10_Binary64(
-    p: -base10Exponent &+ bulkFirstDigits &- 1,
-    lower: &powerOfTenRoundedDown,
-    upper: &powerOfTenRoundedUp)
+  var firstDigit = 6
+  var nextDigit = firstDigit
 
-  let extraBits = binaryExponent + powerOfTenExponent
+  let base10Significand = UInt64(truncatingIfNeeded: upperBound >> fractionBits)
+  var delta = upperBound & fractionMask
 
-  // Step 5: Scale the interval (with rounding)
+  // Convert the digits we have so far and write them out...
+  let digits = _intToSixteenDecimalDigits(base10Significand)
+  let zeros = _UInt128(
+    _low: 0x3030303030303030,
+    _high: 0x3030303030303030)
+  buffer.storeBytes(
+    of: digits &+ zeros,
+    toByteOffset: firstDigit,
+    as: _UInt128.self)
+  nextDigit &+= 16
 
-  // As mentioned above, the final digit generation works
-  // with an interval, so we actually apply the scaling
-  // to the upper and lower midpoint values separately.
+  // Trim leading zero digits
+  firstDigit &+= digits.trailingZeroBitCount / 8
 
-  // As part of the scaling here, we'll switch from a pure
-  // fraction with zero bit integer portion and 128-bit fraction
-  // to a fixed-point form with 32 bits in the integer portion.
+  // Step 6: Compute one more decimal digit if necessary
 
-  let integerBits = 32
-  let roundingBias =
-    _UInt128((1 &<< UInt64(truncatingIfNeeded: integerBits &- extraBits)) &- 1)
-  var u: _UInt128
-  var l: _UInt128
-  if isOddSignificand {
-    // Case A: Narrow the interval (odd significand)
-
-    // Loitsch' original Grisu2 always rounds so as to narrow the
-    // interval.  Since our digit generation will select a value
-    // within the scaled interval, narrowing the interval
-    // guarantees that we will find a digit sequence that converts
-    // back to the original value.
-
-    // This ensures accuracy but, as explained in Loitsch' paper,
-    // this carries a risk that there will be a shorter digit
-    // sequence outside of our narrowed interval that we will
-    // miss. This risk obviously gets lower with increased
-    // precision, but it wasn't until the Errol paper that anyone
-    // had a good way to test whether a particular implementation
-    // had sufficient precision. That paper shows a way to enumerate
-    // the worst-case numbers; those numbers that are extremely close
-    // to the mid-points between adjacent floating-point values.
-    // These are the values that might sit just outside of the
-    // narrowed interval. By testing these values, we can verify
-    // the correctness of our implementation.
-
-    // Multiply out the upper midpoint, rounding down...
-    let u1 = _multiply128x64RoundingDown(
-      powerOfTenRoundedDown,
-      upperMidpointExact)
-    // Account for residual binary exponent and adjust
-    // to the fixed-point format
-    u = u1 >> (integerBits - extraBits)
-
-    // Conversely for the lower midpoint...
-    let l1 = _multiply128x64RoundingUp(
-      powerOfTenRoundedUp,
-      lowerMidpointExact)
-    l = (l1 + roundingBias) >> (integerBits - extraBits)
+  if intervalWidth > delta {
+    // Step 6, Case A: We have a value that lies within the interval
+    // We don't need any more digits, we only need to trim trailing zeros
+    let trailingZeros = digits.leadingZeroBitCount / 8
+    nextDigit &-= trailingZeros
+    base10Power &+= trailingZeros
+    // No final-digit adjustment is needed
   } else {
-    // Case B: Widen the interval (even significand)
+    // Step 6, Case B: We need another digit
+    let halfUlp = scaledBinaryUlp &* 5
+    delta = delta &* 10 &- halfUlp
+    intervalWidth = intervalWidth &* 10 &- halfUlp
 
-    // As explained in Errol Theorem 6, in certain cases there is
-    // a short decimal representation at the exact boundary of the
-    // scaled interval.  When such a number is converted back to
-    // binary, it will get rounded to the adjacent even
-    // significand.
+    var digit = UInt8(truncatingIfNeeded: delta >> fractionBits)
+    delta &= fractionMask
 
-    // So when the significand is even, we round so as to widen
-    // the interval in order to ensure that the exact midpoints
-    // are considered.  Of couse, this ensures that we find a
-    // short result but carries a risk of selecting a result
-    // outside of the exact scaled interval (which would be
-    // inaccurate).
-    // (This technique of rounding differently for even/odd significands
-    // seems to be new; I've not seen it described in any of the
-    // papers on floating-point printing.)
+    let epsilon = _UInt128(64)
+    let greater = unsafe unsafeBitCast(delta > (oneHalf &+ epsilon), to: UInt8.self)
+    let greaterOrEqual = unsafe unsafeBitCast(delta > (oneHalf &- epsilon), to: UInt8.self)
+    let outOfInterval = unsafe unsafeBitCast(delta > intervalWidth, to: UInt8.self)
+    digit &+= greater | (greaterOrEqual & digit) | outOfInterval
 
-    // The same testing approach described above (based on results
-    // in the Errol paper) also applies
-    // to this case.
-
-    let u1 = _multiply128x64RoundingUp(
-      powerOfTenRoundedUp,
-      upperMidpointExact)
-    u = (u1 &+ roundingBias) >> (integerBits - extraBits)
-    let l1 = _multiply128x64RoundingDown(
-      powerOfTenRoundedDown,
-      lowerMidpointExact)
-    l = l1 >> (integerBits - extraBits)
-  }
-
-  // Step 6: Align the first digit, adjust exponent
-
-  // Calculations above used an estimate for the power-of-ten scale.
-  // Here, we compensate for any error in that estimate by testing
-  // whether we have the expected number of digits in the integer
-  // portion and correcting as necessary.  This also serves to
-  // prune leading zeros from subnormals.
-
-  // Except for subnormals, this loop never runs more than once.
-  // For subnormals, this might run as many as 16 times.
-  let minimumU = _UInt128(bulkFirstDigitFactor) << (128 - integerBits)
-  while u < minimumU {
-    base10Exponent -= 1
-    l &*= 10
-    u &*= 10
-  }
-
-  // Step 7: Produce decimal digits
-
-  // One standard approach generates digits for the scaled upper and
-  // lower boundaries and stops at the first digit that
-  // differs. For example, note that 0.1234 is the shortest decimal
-  // between u = 0.123456 and l = 0.123345.
-
-  // Grisu optimizes this by generating digits for the upper bound
-  // (multiplying by 10 to isolate each digit) while simultaneously
-  // scaling the interval width `delta`.  As we remove each digit
-  // from the upper bound, the remainder is the difference between
-  // the base-10 value generated so far and the true upper bound.
-  // When that remainder is less than the scaled width of the
-  // interval, we know the current digits specify a value within the
-  // target interval.
-
-  // The logic below actually blends three different digit-generation
-  // strategies:
-  // * The first digits are already in the integer portion of the
-  //   fixed-point value, thanks to the `bulkFirstDigits` factor above.
-  //   We can just break those down and write them out.
-  // * If we generated too many digits, we use a Ryu-inspired technique
-  //   to backtrack.
-  // * If we generated too few digits (the usual case), we use an
-  //   optimized form of the Grisu2 method to produce the remaining
-  //   values.
-
-  //
-  // Generate digits and build the output.
-  //
-
-  // Generate digits for `t` with interval width `delta = u - l`
-  // As above, these are fixed-point with 32-bit integer, 96-bit fraction
-  var t = u
-  var delta = u &- l
-  let fractionMask = (_UInt128(1) << 96) - 1
-
-  var nextDigit = 5
-  var firstDigit = nextDigit
-
-  // Our initial scaling gave us the first 7 digits already:
-  let d12345678 = UInt32(truncatingIfNeeded: t._high >> 32)
-  t &= fractionMask
-
-  if delta >= t {
-    // Oops!  We have too many digits.  Back out the extra ones to
-    // get the right answer.  This is similar to Ryu, but since
-    // we've only produced seven digits, we only need 32-bit
-    // arithmetic here.  (Ryu needs 64-bit arithmetic to back out
-    // digits, which severely compromises performance on 32-bit
-    // processors.  The same problem occurs with Ryu for 128-bit
-    // floats on 64-bit processors.)
-    // A few notes:
-    // * Our target hardware always supports 32-bit hardware division,
-    //   so this should be reasonably fast.
-    // * For small integers (like "2.0"), Ryu would have to back out 16
-    //   digits; we only have to back out 6.
-    // * Very few double-precision values actually need fewer than 7
-    //   digits.  So this is rarely used except in workloads that
-    //   specifically use double for small integers.
-
-    // Why this is critical for performance: In order to use the
-    // 8-digits-at-a-time optimization below, we need at least 30
-    // bits in the integer part of our fixed-point format above.
-    // If we only use bulkDigits = 1, that leaves only 128 - 30 =
-    // 98 bit accuracy for our scaling step, which isn't enough
-    // (experiments suggest that binary64 needs ~110 bits for
-    // correctness).  So we have to use a large bulkDigits value
-    // to make full use of the 128-bit scaling above, which forces
-    // us to have some form of logic to handle the case of too
-    // many digits.  The alternatives are either to use >128 bit
-    // arithmetic, or to back up and repeat the original scaling
-    // with bulkDigits = 1.
-
-    let uHigh = u._high
-    let lHigh = (l &+ _UInt128(UInt64.max))._high
-    let tHigh: UInt64
-    if d.significand == 0 {
-      tHigh = (uHigh &+ lHigh &* 2) / 3
-    } else {
-      tHigh = (uHigh &+ lHigh) / 2
-    }
-    var u0 = UInt32(truncatingIfNeeded: uHigh >> (64 - integerBits))
-    var l0 = UInt32(truncatingIfNeeded: lHigh >> (64 - integerBits))
-    if lHigh & ((1 << (64 - integerBits)) - 1) != 0 {
-      l0 &+= 1
-    }
-    var t0 = UInt32(truncatingIfNeeded: tHigh >> (64 - integerBits))
-    var t0digits = 8
-
-    var u1 = u0 / 10
-    var l1 = (l0 &+ 9) / 10
-    var trailingZeros = (t == 0)
-    var droppedDigit = UInt32(
-      truncatingIfNeeded: ((tHigh &* 10) >> (64 - integerBits)) % 10)
-    while u1 >= l1 && u1 != 0 {
-      u0 = u1
-      l0 = l1
-      trailingZeros = trailingZeros && (droppedDigit == 0)
-      droppedDigit = t0 % 10
-      t0 /= 10
-      t0digits -= 1
-      u1 = u0 / 10
-      l1 = (l0 &+ 9) / 10
-    }
-    // Correct the final digit
-    if droppedDigit > 5 || (droppedDigit == 5 && !trailingZeros) { // > 0.5000
-      t0 &+= 1
-    } else if droppedDigit == 5 && trailingZeros { // == 0.5000
-      t0 &+= 1
-      t0 &= ~1
-    }
-    // t0 has t0digits digits.  Write them out
-    let text = _intToEightDigits(t0)
     buffer.storeBytes(
-      of: text,
+      of: digit &+ 0x30,
       toByteOffset: nextDigit,
-      as: UInt64.self)
-    nextDigit &+= 8
-    // Skip the leading zeros
-    firstDigit &+= 9 - t0digits
-  } else {
-    // Our initial scaling did not produce too many digits.  The
-    // `d12345678` value holds the first 7 digits (plus a leading
-    // zero).  The remainder of this algorithm is basically just a
-    // heavily-optimized variation of Grisu2.
-
-    // Write out exactly 8 digits, assuming little-endian.
-    let chars = _intToEightDigits(d12345678)
-    unsafe buffer.storeBytes(
-      of: chars,
-      toUncheckedByteOffset: nextDigit,
-      as: UInt64.self)
-    nextDigit &+= 8
-    firstDigit &+= 1
-
-    // >90% of random binary64 values need at least 15 digits.
-    // We have seven so there's probably at least 8 more, which
-    // we can grab all at once.
-    let TenToTheEighth = 100000000 as _UInt128 // 10^(15-bulkFirstDigits)
-    let d0 = delta * TenToTheEighth
-    var t0 = t * TenToTheEighth
-    // The integer part of t0 is the next 8 digits
-    let next8Digits = UInt32(truncatingIfNeeded: t0._high >> 32)
-    t0 &= fractionMask
-    if d0 < t0 {
-      // We got 8 more digits! (So number is at least 15 digits)
-      // Write them out:
-      let chars = _intToEightDigits(next8Digits)
-      unsafe buffer.storeBytes(
-        of: chars,
-        toUncheckedByteOffset: nextDigit,
-        as: UInt64.self)
-      nextDigit &+= 8
-      t = t0
-      delta = d0
-    }
-
-    // Generate remaining digits one at a time, following Grisu:
-    while (delta < t) {
-      delta &*= 10
-      t &*= 10
-      unsafe buffer.storeBytes(
-        of: UInt8(truncatingIfNeeded: t._high >> 32) &+ 0x30,
-        toUncheckedByteOffset: nextDigit,
-        as: UInt8.self)
-      nextDigit &+= 1
-      t &= fractionMask
-    }
-
-    // Adjust the final digit to be closer to the original value.
-    // This accounts for the fact that sometimes there is more than
-    // one shortest digit sequence.
-
-    // For example, consider how the above would work if you had the
-    // value 0.1234 and computed u = 0.1257, l = 0.1211.  The above
-    // digit generation works with `u`, so produces 0.125.  But the
-    // values 0.122, 0.123, and 0.124 are just as short and 0.123 is
-    // therefore the best choice, since it's closest to the original
-    // value.
-
-    // We know delta and t are both less than 10.0 here, so we can
-    // shed some excess integer bits to simplify the following:
-    let adjustIntegerBits = 4 // Integer bits for "adjust" phase
-    let deltaHigh64 = UInt64(
-      truncatingIfNeeded: delta >> (64 - integerBits + adjustIntegerBits))
-    let tHigh64 = UInt64(
-      truncatingIfNeeded: t >> (64 - integerBits + adjustIntegerBits))
-
-    let one = UInt64(1) << (64 - adjustIntegerBits)
-    let adjustFractionMask = one - 1
-    let oneHalf = one >> 1
-    if deltaHigh64 >= tHigh64 &+ one {
-      // The `skew` is the difference between our
-      // computed digits and the original exact value.
-      var skew: UInt64
-      if (d.significandBitPattern == 0) {
-        skew = deltaHigh64 &- deltaHigh64 / 3 &- tHigh64
-      } else {
-        skew = deltaHigh64 / 2 &- tHigh64
-      }
-
-      var lastDigit = unsafe buffer.unsafeLoad(
-        fromUncheckedByteOffset: nextDigit - 1,
-        as: UInt8.self)
-
-      // We use the `skew` to figure out whether there's
-      // a better base-10 value than our current one.
-      if (skew & adjustFractionMask) == oneHalf {
-        // Difference is an integer + exactly 1/2, so ...
-        let adjust = skew >> (64 - adjustIntegerBits)
-        lastDigit &-= UInt8(truncatingIfNeeded: adjust)
-        // ... we round the last digit even.
-        lastDigit &= ~1
-      } else {
-        let adjust = (skew + oneHalf) >> (64 - adjustIntegerBits)
-        lastDigit &-= UInt8(truncatingIfNeeded: adjust)
-      }
-      buffer.storeBytes(
-        of: lastDigit,
-        toByteOffset: nextDigit - 1,
-        as: UInt8.self)
-    }
+      as: UInt8.self)
+    nextDigit &+= 1
+    base10Power &-= 1
   }
 
-  // Step 8: Finalize formatting by rearranging
-  // the digits and filling in decimal points,
-  // exponents, and zero padding.
-  let isBoundary = (d.significandBitPattern == 0)
+  // Step 7: Finish formatting
+  let isBoundary = (f.significandBitPattern == 0)
   let forceExponential =
-    ((binaryExponent > 54) || (binaryExponent == 54 && !isBoundary))
+    ((binaryExponent > 1)
+       || (binaryExponent == 1 && !isBoundary))
   return _finishFormatting(
     buffer: &buffer,
-    sign: d.sign,
+    sign: f.sign,
     firstDigit: firstDigit,
     nextDigit: nextDigit,
     forceExponential: forceExponential,
-    base10Exponent: base10Exponent)
+    base10Power: base10Power)
 }
 
 
@@ -1223,23 +913,22 @@ internal func _float80ToStringImpl(
 }
 
 // Convert a Float80 to an optimal ASCII representation.
-// See notes above for comments on the output format here.
-// See _Float64ToASCII for comments on the algorithm.
+// See the Float32 implementation for extensive comments
+// explaining the algorithm.
 // Inputs:
 // * `value`: Float80 input
 // * `buffer`: Buffer to place the result
 // Returns: Range of bytes within `buffer` that contain the result
 //
-// Buffer must be at least 32 bytes long and must be pre-filled
+// Buffer must be at least 40 bytes long and must be pre-filled
 // with "0" characters, e.g., via
-// `InlineArray<32,UTF8.CodeUnit>(repeating:0x30)`
+// `InlineArray<40,UTF8.CodeUnit>(repeating:0x30)`
 internal func _Float80ToASCII(
   value f: Float80,
   buffer utf8Buffer: inout MutableSpan<UTF8.CodeUnit>
 ) -> Range<Int> {
-  // We need a MutableRawSpan in order to use wide store/load operations
-  precondition(utf8Buffer.count >= 32)
-  var buffer = utf8Buffer.mutableBytes
+  assert(utf8Buffer.count >= 40)
+  var buffer = unsafe utf8Buffer.mutableBytes
 
   // Step 1: Handle special cases, decompose the input
 
@@ -1247,37 +936,41 @@ internal func _Float80ToASCII(
   // make this a lot more complex than the corresponding logic for
   // the IEEE 754 portable formats.
 
-  // f.significandBitPattern is processed to try to mimic the
+  // Float80.significandBitPattern is processed to try to mimic the
   // semantics of IEEE portable formats.  But for the following,
   // we need the actual raw bits:
   let rawSignificand = f._representation.explicitSignificand
   let binaryExponent: Int
   let significand: Float80.RawSignificand
-  let exponentBias = (1 << (Float80.exponentBitCount - 1)) - 2 // 16382
+  let significandBits = Float80.significandBitCount + 1
+  let exponentBias = Int(bitPattern: Float80._exponentBias) - 1 + significandBits // 16382 + 64
   let isBoundary = f.significandBitPattern == 0
-  if f.exponentBitPattern == 0x7fff { // NaN or Infinity
+
+  if f.exponentBitPattern == Float80._infinityExponent { // NaN or Infinity
     // 80387 semantics and 80287 semantics differ somewhat;
     // we follow 80387 semantics here.
     // See: Wikipedia.org "Extended Precision"
     // See: Intel's "Floating Point Reference Sheet"
     // https://software.intel.com/content/dam/develop/external/us/en/documents/floating-point-reference-sheet.pdf
     let selector = rawSignificand >> 62
-    let payload = rawSignificand & ((1 << 62) - 1)
+    let payload = rawSignificand & (Float80._quietNaNMask - 1)
     switch selector {
-    case 0: // ∞ or snan on 287, invalid on 387
+    case 0: // ∞ or sNaN on 287, invalid on 387
       fallthrough
-    case 1: // Pseudo-NaN: snan on 287, invalid on 387
-      // Invalid patterns treated as plain "nan"
+    case 1: // Pseudo-NaN: sNaN on 287, invalid on 387
+      // We treat invalid/indefinite patterns as plain qNaN
+      fallthrough
+    case 3: // sNaN on 287, qNaN on 387
       return nan_details(
         buffer: &buffer,
-        sign: .plus,
+        sign: f.sign,
         quiet: true,
         payloadHigh: 0,
         payloadLow: payload)
     case 2:
-      if payload == 0 {  // snan on 287, ∞ on 387
+      if payload == 0 {  // sNaN on 287, ∞ on 387
         return _infinity(buffer: &buffer, sign: f.sign)
-      } else { // snan on 287 and 387
+      } else { // sNaN on 287 and 387
         return nan_details(
           buffer: &buffer,
           sign: f.sign,
@@ -1285,29 +978,21 @@ internal func _Float80ToASCII(
           payloadHigh: 0,
           payloadLow: payload)
       }
-    case 3:
-      // Zero payload and sign bit set is "indefinite" (treated as qNaN here),
-      // otherwise qNaN on 387, sNaN on 287
-      return nan_details(
-        buffer: &buffer,
-        sign: f.sign,
-        quiet: true,
-        payloadHigh: 0,
-        payloadLow: payload)
     default:
       fatalError()
     }
   } else if f.exponentBitPattern == 0 {
     if rawSignificand == 0 { // Zero
       return _zero(buffer: &buffer, sign: f.sign)
-    } else { // subnormal
-      binaryExponent = 1 - exponentBias
+    } else { // Subnormal
+      binaryExponent = 1 &- exponentBias
       significand = rawSignificand
     }
-  } else if rawSignificand >> 63 == 1 { // Normal
-    binaryExponent = Int(bitPattern:f.exponentBitPattern) - exponentBias
+  } else if rawSignificand >> 63 == 1 { // Normal (J-bit set)
+    binaryExponent = Int(f.exponentBitPattern) &- exponentBias
     significand = rawSignificand
   } else {
+    // Invalid: non-zero exponent with J-bit clear ("unnormal")
     return nan_details(
       buffer: &buffer,
       sign: .plus,
@@ -1316,30 +1001,12 @@ internal func _Float80ToASCII(
       payloadLow: 0)
   }
 
-  // Step 2: Determine the exact unscaled target interval
-  let halfUlp = UInt64(1) << 63
-  let quarterUlp = halfUlp >> 1
-  let threeQuarterUlp = halfUlp + quarterUlp
-  // Significand is the upper 64 bits of our 128-bit franction
-  // Upper midpoint adds 1/2 ULP:
-  let upperMidpointExact = _UInt128(_low: halfUlp, _high: significand)
-  // Lower midpoint subtracts 1 ULP and then adds 1/2 or 3/4 ULP:
-  let lowerMidpointExact = _UInt128(
-    _low: isBoundary ? threeQuarterUlp : halfUlp,
-    _high: significand - 1)
-
-  let forceExponential =
-    (binaryExponent > 65
-       || (binaryExponent == 65 && !isBoundary))
-  return _backend_256bit(
-    buffer: &buffer,
-    upperMidpointExact: upperMidpointExact,
-    lowerMidpointExact: lowerMidpointExact,
-    sign: f.sign,
+  return _Float128Backend(
+    utf8Buffer: &utf8Buffer,
     isBoundary: isBoundary,
-    isOddSignificand: (f.significandBitPattern & 1) != 0,
     binaryExponent: binaryExponent,
-    forceExponential: forceExponential)
+    significand: _UInt128(significand),
+    sign: f.sign)
 }
 #endif
 
@@ -1349,212 +1016,266 @@ internal func _Float80ToASCII(
 //
 // ================================================================
 
-#if false
-// Note: We don't need _float128ToStringImpl, since that's only for
-// backwards compatibility, and the legacy ABI never supported
-// Float128.
+// This requires only the most basic `Float128` type.  In particular,
+// it requires absolutely no arithmetic on that type.
 
+/*
+ 
+@available(macOS 15.0, watchOS 11.0, *)
 internal func _Float128ToASCII(
-  value d: Float128,
+  value f: Float128,
   buffer utf8Buffer: inout MutableSpan<UTF8.CodeUnit>
 ) -> Range<Int> {
-  // TODO:  Write Me!
+  assert(utf8Buffer.count >= 64)
+  var buffer = unsafe utf8Buffer.mutableBytes
 
-  // Note: All the interesting parts are already implemented in _backend_256bit(...),
-  // so this can easily be implemented someday by just copyihng _Float80ToASCII
-  // and making the obvious changes.  (See the introductory parts of
-  // _Float64ToASCII for the structure common to all IEEE 754 formats.)
-}
-#endif
+  let significandBitCount = Float128.significandBitCount + 1 // 113
+  let exponentBias = Int(bitPattern: Float128._exponentBias) - 1 + significandBitCount // 16382 + 113
+  let binaryExponent: Int
+  let significand: UInt128
 
-// ================================================================
-//
-// Float80/Float128 common backend
-//
-// This uses 256-bit fixed-width arithmetic to efficiently compute the
-// optimal form for a decomposed float80 or binary128 value.  It is
-// less heavily commented than the 128-bit Double implementation
-// above; see that implementation for detailed explanation of the
-// logic here.
-//
-// Float80 could be handled more efficiently with 192-bit fixed-width
-// arithmetic.  But the code size savings from sharing this logic
-// between float80 and binary128 are substantial, and the resulting
-// float80 performance is still much better than competing
-// implementations.
-//
-// Also in the interest of code size savings, this eschews some of the
-// optimizations used by the 128-bit Double implementation above.
-// Those optimizations are simple to reintroduce if you're interested
-// in further performance improvements.
-//
-// If you are interested in extreme code size, you can also use this
-// backend for binary32 and binary64, eliminating the separate 128-bit
-// implementation. That variation offers surprisingly reasonable
-// performance overall.
-//
-// ================================================================
-
-#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !(os(macOS) || os(iOS) || os(watchOS) || os(tvOS)))) && (arch(i386) || arch(x86_64))
-
-fileprivate func _backend_256bit(
-  buffer: inout MutableRawSpan,
-  upperMidpointExact: _UInt128,
-  lowerMidpointExact: _UInt128,
-  sign: FloatingPointSign,
-  isBoundary: Bool,
-  isOddSignificand: Bool,
-  binaryExponent: Int,
-  forceExponential: Bool
-) -> Range<Int> {
-
-  // Step 3: Estimate the base 10 exponent
-  var base10Exponent = decimalExponentFor2ToThe(binaryExponent)
-
-  // Step 4: Compute a power-of-10 scale factor
-  var powerOfTenRoundedDown = _UInt256()
-  var powerOfTenRoundedUp = _UInt256()
-  let powerOfTenExponent = _intervalContainingPowerOf10_Binary128(
-    p: -base10Exponent,
-    lower: &powerOfTenRoundedDown,
-    upper: &powerOfTenRoundedUp)
-  let extraBits = binaryExponent &+ powerOfTenExponent
-
-  // Step 5: Scale the interval (with rounding)
-  let integerBits = 14
-  let high64FractionBits = 64 - integerBits
-  var u: _UInt256
-  var l: _UInt256
-  if isOddSignificand {
-    // Narrow the interval (odd significand)
-    u = powerOfTenRoundedDown
-    u.multiplyRoundingDown(by: upperMidpointExact)
-    u.shiftRightRoundingDown(by: integerBits &- extraBits)
-
-    l = powerOfTenRoundedUp
-    l.multiplyRoundingUp(by: lowerMidpointExact)
-    l.shiftRightRoundingUp(by: integerBits &- extraBits)
+  // Step 1: Handle the special cases, decompose the input
+  if  f.exponentBitPattern == Float128._infinityExponent {
+    if (f.isInfinite) {
+      return _infinity(buffer: &buffer, sign: f.sign)
+    } else { // f.isNaN
+      let quietBit = f.significandBitPattern & Float128._quietNaNMask
+      let payload = f.significandBitPattern & (Float128._significandMask &>> 2)
+      return nan_details(
+        buffer: &buffer,
+        sign: f.sign,
+        quiet: quietBit != 0,
+        payloadHigh: payload._high,
+        payloadLow: payload._low
+      )
+    }
+  } else if f.exponentBitPattern == 0 {
+    if (f.isZero) {
+      return _zero(buffer: &buffer, sign: f.sign)
+    } else { // f.isSubnormal
+      significand = f.significandBitPattern
+      binaryExponent = 1 &- exponentBias
+    }
   } else {
-    // Widen the interval (even significand)
-    u = powerOfTenRoundedUp
-    u.multiplyRoundingUp(by: upperMidpointExact)
-    u.shiftRightRoundingUp(by: integerBits &- extraBits)
-
-    l = powerOfTenRoundedDown
-    l.multiplyRoundingDown(by: lowerMidpointExact)
-    l.shiftRightRoundingDown(by: integerBits &- extraBits)
+    // Normal
+    let implicitBit = UInt128(1) << Float128.significandBitCount
+    significand = f.significandBitPattern &+ implicitBit
+    binaryExponent = Int(f.exponentBitPattern) &- exponentBias
   }
 
-  // Step 6: Align first digit, adjust exponent
-  while u.high._high < (UInt64(1) << high64FractionBits) {
-    base10Exponent &-= 1
-    l.multiply(by: UInt32(10))
-    u.multiply(by: UInt32(10))
+  return _Float128Backend(
+    utf8Buffer: &utf8Buffer,
+    isBoundary: f.significandBitPattern == 0,
+    binaryExponent: binaryExponent,
+    significand: _UInt128(significand),
+    sign: f.sign)
+}
+
+*/
+
+// ================================================================
+//
+// General conversion supporting any format up to Float128
+//
+// ================================================================
+
+// Core conversion logic for any format with <= 113 bit significand
+// and <= 15 bit exponent.  This can be used for Float128, Float80, as
+// well as any smaller format.  (Of course, the tuned implementations
+// for Float64, Float32, and Float16 above are much faster.)
+fileprivate func _Float128Backend(
+  utf8Buffer: inout MutableSpan<UTF8.CodeUnit>,
+  isBoundary: Bool,
+  binaryExponent: Int,
+  significand: _UInt128,
+  sign: FloatingPointSign
+) -> Range<Int> {
+  var buffer = unsafe utf8Buffer.mutableBytes
+
+  // Step 2: Compute the base 10 exponent to match the rounding interval
+
+  let maybeLogThreeQuarters = (isBoundary
+                                 ? Int64(-536607787)
+                                 : Int64(0))
+  let rawBase10Power = Int64(binaryExponent) &* 1292913986 &+ maybeLogThreeQuarters
+  let roundedBase10Power = (rawBase10Power &+ 0xffffffff) &>> 32
+  var base10Power = Int(truncatingIfNeeded: roundedBase10Power)
+
+  // Step 3: Look up power-of-10 scale factor
+
+  var powerOfTen = _UInt256()
+  let powerOfTenExponent = _powerOf10_Binary128(
+    p: 0 &- base10Power,
+    significand: &powerOfTen)
+
+  // Step 4: Scale the interval (with rounding)
+
+  // Fixed-point format: 114 integer bits, 142 fraction bits = 256 total
+  let significandBits = 113 // Sufficient for Float128
+  let integerBits = significandBits + 1
+  let fractionMask = _UInt256(
+    high: 0,
+    UInt64.max >> (integerBits - 64),
+    UInt64.max,
+    low: UInt64.max)
+  let oneHalf = _UInt256(
+    high: 0,
+    UInt64(1) << (128 - 1 - integerBits),
+    0,
+    low: 0)
+
+  let narrowInterval = significand & 1
+
+  // Scale one binary ULP: scaledBinaryUlp = powerOfTen >> align
+  let align = integerBits &- (binaryExponent &+ powerOfTenExponent)
+  var scaledBinaryUlp = powerOfTen &>> align
+  // Widen or narrow the ULP for even/odd significand
+  let adjustment = 4 &- 8 &* Int(narrowInterval)
+  scaledBinaryUlp &+= adjustment
+
+  // Scale the upper limit
+  var rawProduct = powerOfTen
+  rawProduct.multiply(by: significand, lsr: align)
+  let upperBound = rawProduct &+ (scaledBinaryUlp &>> 1)
+
+  // Compute the width of the scaled rounding interval
+  var intervalWidth = scaledBinaryUlp
+  if isBoundary {
+    // Power-of-two: interval is 3/4 ULP
+    intervalWidth = intervalWidth &- (intervalWidth &>> 2)
   }
-  var t = u
-  var delta = u &- l
 
-  // Step 7: Generate digits
+  // Step 5: Emit most of the decimal digits into the destination buffer
 
-  // Leave 8 bytes at the beginning for finishFormatting to use
-  let firstDigit = 8
+  // Float80 requires 1-21 digits for round-trip correctness; initial
+  // scaling will produce a value of up to 4/3 * 2^64 ≈ 2.45e19 (0-20
+  // digits, regarding 65 bits) at this point.
+  // Float128 requires 1-36 digits; initial scaling can produce a value
+  // up to 4/3 * 2^113 ≈ 1.38e34 (0-35 digits, requiring 114 bits).
+  // Larger than Float128 would likely require more than 256 bit arithmetic.
+
+  var firstDigit = 8
   var nextDigit = firstDigit
+
+  // Extract the integer part
+  let base10Significand = upperBound.high >> (128 - integerBits)
+  var delta = upperBound & fractionMask
+
+  let zeros8 = UInt64(0x3030303030303030)
+  let zeros16 = _UInt128(
+    _low: 0x3030303030303030,
+    _high: 0x3030303030303030)
+  let TenE16 = UInt64(10000000000000000)
+
+  // As noted above, Float128 has at most 35 digits at this point.
+  // Top part is at most 1.38e18, which fits in 64 bits
+  let reciprocal = _UInt128(UInt64(0xe69594bec44de15b)) // ≈ 2^117 / 10^16
+  let hi19low = (_UInt128(base10Significand._low) * reciprocal) >> 64
+  let hi19extended = (_UInt128(base10Significand._high) * reciprocal + hi19low) >> 53
+  var hi19 = UInt64(truncatingIfNeeded: hi19extended)
+  var lo16 = UInt64(truncatingIfNeeded: base10Significand - _UInt128(hi19) * _UInt128(TenE16))
+  // Correct the two values above...
+  if lo16 >= TenE16 {
+    lo16 -= TenE16
+    hi19 += 1
+  }
+
+  // The above is a faster version of this div/rem pair, which otherwise
+  // accounts for >80% of the total runtime of this function:
+  // let hi19 = UInt64(truncatingIfNeeded: base10Significand / _UInt128(TenE16))
+  // let lo16 = UInt64(truncatingIfNeeded: base10Significand % _UInt128(TenE16))
+
+  let hi3 = UInt32(truncatingIfNeeded: hi19 / TenE16)
+  let digitsHi = _intToEightDecimalDigits(hi3)
   buffer.storeBytes(
-    of: 0x30 + UInt8(truncatingIfNeeded: t.extractIntegerPart(integerBits)),
+    of: digitsHi &+ zeros8,
+    toByteOffset: firstDigit,
+    as: UInt64.self)
+  nextDigit &+= 8
+
+  let mid16 = UInt64(truncatingIfNeeded: hi19 % TenE16)
+  let digitsMid = _intToSixteenDecimalDigits(mid16)
+  buffer.storeBytes(
+    of: digitsMid &+ zeros16,
     toByteOffset: nextDigit,
-    as: UInt8.self)
-  nextDigit &+= 1
+    as: _UInt128.self)
+  nextDigit &+= 16
 
-  // It would be nice to generate 8 digits at a time and take
-  // advantage of intToEightDigits, but our integer portion has only
-  // 14 bits.  We can't make that bigger without either sacrificing
-  // too much precision for correct Float128 or folding the first
-  // digits into the scaling (as we do with Double) which would
-  // require a back-out phase here (as we do with Double).
+  let digitsLo = _intToSixteenDecimalDigits(lo16)
+  buffer.storeBytes(
+    of: digitsLo &+ zeros16,
+    toByteOffset: nextDigit,
+    as: _UInt128.self)
+  nextDigit &+= 16
 
-  // If there is at least one more digit possible...
-  if delta < t {
-
-    // Try grabbing four digits at a time
-    var d0 = delta
-    var t0 = t
-    d0.multiply(by: 10000)
-    t0.multiply(by: 10000)
-    var d1234 = t0.extractIntegerPart(integerBits)
-    while d0 < t0 {
-      let d12 = d1234 / 100
-      let d34 = d1234 % 100
-      unsafe buffer.storeBytes(
-        of: asciiDigitTable[Int(bitPattern:d12)],
-        toUncheckedByteOffset: nextDigit,
-        as: UInt16.self)
-      unsafe buffer.storeBytes(
-        of: asciiDigitTable[Int(bitPattern:d34)],
-        toUncheckedByteOffset: nextDigit &+ 2,
-        as: UInt16.self)
-      nextDigit &+= 4
-      t = t0
-      delta = d0
-      d0.multiply(by: 10000)
-      t0.multiply(by: 10000)
-      d1234 = t0.extractIntegerPart(integerBits)
-    }
-
-    // Finish by generating one digit at a time...
-    while delta < t {
-      delta.multiply(by: UInt32(10))
-      t.multiply(by: UInt32(10))
-      let digit = UInt8(truncatingIfNeeded: t.extractIntegerPart(integerBits))
-      unsafe buffer.storeBytes(
-        of: 0x30 &+ digit,
-        toUncheckedByteOffset: nextDigit,
-        as: UInt8.self)
-      nextDigit &+= 1
-    }
+  // Trim leading zero digits
+  if digitsHi != 0 {
+    firstDigit &+= digitsHi.trailingZeroBitCount / 8
+  } else if digitsMid != 0 {
+    firstDigit &+= 8 + digitsMid.trailingZeroBitCount / 8
+  } else {
+    firstDigit &+= 24 &+ digitsLo.trailingZeroBitCount / 8
   }
 
-  // Adjust the final digit to be closer to the original value
-  // We've already consumed most of our available precision, and only
-  // need a couple of integer bits, so we can narrow down to
-  // 64 bits here.
-  let deltaHigh64 = delta.high._high
-  let tHigh64 = t.high._high
-  if deltaHigh64 >= tHigh64 &+ (UInt64(1) << high64FractionBits) {
-    let skew: UInt64
-    if isBoundary {
-      skew = deltaHigh64 &- deltaHigh64 / 3 &- tHigh64
+  // Step 6: Compute one more decimal digit if necessary
+
+  if intervalWidth > delta {
+    // Step 6, Case A: Value lies within the interval.
+    // Trim trailing zeros.
+    let trailingZeros: Int
+    if digitsLo != 0 {
+      trailingZeros = digitsLo.leadingZeroBitCount / 8
+    } else if digitsMid != 0 {
+      trailingZeros = 16 &+ digitsMid.leadingZeroBitCount / 8
     } else {
-      skew = deltaHigh64 / 2 &- tHigh64
+      trailingZeros = 32 &+ digitsHi.leadingZeroBitCount / 8
     }
-    let one = UInt64(1) << high64FractionBits
-    let fractionMask = one - 1
-    let oneHalf = one >> 1
-    var lastDigit = unsafe buffer.unsafeLoad(
-      fromUncheckedByteOffset: nextDigit &- 1,
-      as: UInt8.self)
-    if (skew & fractionMask) == oneHalf {
-      let adjust = skew >> high64FractionBits
-      lastDigit &-= UInt8(truncatingIfNeeded: adjust)
-      lastDigit &= ~1
-    } else {
-      let adjust = (skew + oneHalf) >> high64FractionBits
-      lastDigit &-= UInt8(truncatingIfNeeded: adjust)
-    }
+    nextDigit &-= trailingZeros
+    base10Power &+= trailingZeros
+  } else {
+    // Step 6, Case B: We need another digit
+    var halfUlp = scaledBinaryUlp
+    halfUlp.multiply(by: UInt32(5))
+    // delta = delta * 10 - halfUlp
+    delta.multiply(by: UInt32(10))
+    delta = delta &- halfUlp
+    // intervalWidth = intervalWidth * 10 - halfUlp
+    intervalWidth.multiply(by: UInt32(10))
+    intervalWidth = intervalWidth &- halfUlp
+
+    // Extract the next digit
+    var digit = UInt8(truncatingIfNeeded: delta.high >> (128 - integerBits))
+    delta = delta & fractionMask
+
+    let epsilon = _UInt256(UInt64(256))
+    let greater = unsafe unsafeBitCast(
+      delta > (oneHalf &+ epsilon), to: UInt8.self)
+    let greaterOrEqual = unsafe unsafeBitCast(
+      delta > (oneHalf &- epsilon), to: UInt8.self)
+    let outOfInterval = unsafe unsafeBitCast(
+      delta > intervalWidth, to: UInt8.self)
+    digit &+= greater | (greaterOrEqual & digit) | outOfInterval
+
     buffer.storeBytes(
-      of: lastDigit,
-      toByteOffset: nextDigit &- 1,
+      of: digit &+ 0x30,
+      toByteOffset: nextDigit,
       as: UInt8.self)
+    nextDigit &+= 1
+    base10Power &-= 1
   }
 
+  // Step 7: Finish formatting
+  let forceExponential =
+    ((binaryExponent > 1)
+       || (binaryExponent == 1 && !isBoundary))
   return _finishFormatting(
     buffer: &buffer,
     sign: sign,
     firstDigit: firstDigit,
     nextDigit: nextDigit,
     forceExponential: forceExponential,
-    base10Exponent: base10Exponent)
+    base10Power: base10Power)
 }
-#endif
 
 // ================================================================
 //
@@ -1567,7 +1288,7 @@ fileprivate func _backend_256bit(
 // `finishFormatting` converts this into the final text form,
 // inserting decimal points, minus signs, exponents, etc, as
 // necessary.  To minimize the work here, this assumes that there are
-// at least 5 unused bytes at the beginning of `buffer` before
+// at least 6 unused bytes at the beginning of `buffer` before
 // `firstDigit` and that all unused bytes are filled with `"0"` (0x30)
 // characters.
 
@@ -1577,7 +1298,7 @@ fileprivate func _finishFormatting(
   firstDigit: Int,
   nextDigit: Int,
   forceExponential: Bool,
-  base10Exponent: Int
+  base10Power: Int
 ) -> Range<Int> {
   // Performance note: This could be made noticeably faster by
   // writing the output consistently in exponential form with no
@@ -1587,7 +1308,8 @@ fileprivate func _finishFormatting(
   var nextDigit = nextDigit
 
   let digitCount = nextDigit &- firstDigit
-  if base10Exponent < -4 || forceExponential {
+  var p = base10Power &+ digitCount &- 1
+  if p < -4 || forceExponential {
     // Exponential form: "-1.23456789e+123"
     // Rewrite "123456789" => "1.23456789" by moving the first
     // digit to the left one byte and overwriting a period.
@@ -1598,7 +1320,7 @@ fileprivate func _finishFormatting(
         fromUncheckedByteOffset: firstDigit,
         as: UInt8.self)
       unsafe buffer.storeBytes(
-        of: 0x2e,
+        of: 0x2e, // "."
         toUncheckedByteOffset: firstDigit,
         as: UInt8.self)
       firstDigit &-= 1
@@ -1613,56 +1335,56 @@ fileprivate func _finishFormatting(
       toUncheckedByteOffset: nextDigit,
       as: UInt8.self)
     nextDigit &+= 1
-    var e = base10Exponent
-    let expSign: UInt8
-    if base10Exponent < 0 {
-      expSign = 0x2d // "-"
-      e = 0 &- e
+    let powerSign: UInt8
+    if p < 0 {
+      powerSign = 0x2d // "-"
+      p = 0 &- p
     } else {
-      expSign = 0x2b // "+"
+      powerSign = 0x2b // "+"
     }
     unsafe buffer.storeBytes(
-      of: expSign,
+      of: powerSign,
       toUncheckedByteOffset: nextDigit,
       as: UInt8.self)
     nextDigit &+= 1
-    if e > 99 {
-      if e > 999 {
-        let d = asciiDigitTable[e / 100]
+    if p > 99 {
+      if p > 999 {
+        let d = asciiDigitTable[p / 100]
         unsafe buffer.storeBytes(
           of: d,
           toUncheckedByteOffset: nextDigit,
           as: UInt16.self)
         nextDigit &+= 2
       } else {
-        let d = 0x30 &+ UInt8(truncatingIfNeeded: (e / 100))
+        let d = 0x30 &+ UInt8(truncatingIfNeeded: (p / 100))
         unsafe buffer.storeBytes(
           of: d,
           toUncheckedByteOffset: nextDigit,
           as: UInt8.self)
         nextDigit &+= 1
       }
-      e = e % 100
+      p = p % 100
     }
-    let d = unsafe asciiDigitTable[unchecked: e]
+    // For historical reasons, exponents are always at least 2 digits
+    let d = unsafe asciiDigitTable[unchecked: p]
     buffer.storeBytes(
       of: d,
       toByteOffset: nextDigit,
       as: UInt16.self)
     nextDigit &+= 2
-    } else if base10Exponent < 0 {
+  } else if p < 0 {
     // "-0.000123456789"
-    // We need up to 5 leading characters before the digits.
+    // We need up to 6 leading characters before the digits.
     // Note that the formatters above all insert extra leading "0" characters
     // to the beginning of the buffer, so we don't need to memset() here,
     // just back up the start to include them...
-    firstDigit &+= base10Exponent - 1
+    firstDigit &+= p &- 1
     // ... and then overwrite a decimal point to get "0." at the beginning
     buffer.storeBytes(
       of: 0x2e, // "."
       toByteOffset: firstDigit &+ 1,
       as: UInt8.self)
-  } else if base10Exponent &+ 1 < digitCount {
+  } else if p &+ 1 < digitCount {
     // "123456.789"
     // We move the first digits forward one position
     // so we can insert a decimal point in the middle.
@@ -1670,7 +1392,7 @@ fileprivate func _finishFormatting(
     // more than one digit around in the buffer.
     // TODO: Find out how to use C memmove() here
     firstDigit &-= 1
-    for i in 0...(base10Exponent &+ 1) {
+    for i in 0...(p &+ 1) {
       let t = unsafe buffer.unsafeLoad(
         fromUncheckedByteOffset: firstDigit &+ i &+ 1,
         as: UInt8.self)
@@ -1680,17 +1402,17 @@ fileprivate func _finishFormatting(
         as: UInt8.self)
     }
     buffer.storeBytes(
-      of: 0x2e,
-      toByteOffset: firstDigit &+ base10Exponent &+ 1,
+      of: 0x2e, // "."
+      toByteOffset: firstDigit &+ p &+ 1,
       as: UInt8.self)
   } else {
     // "12345678900.0"
     // Fill trailing zeros, put ".0" at the end
     // so the result is obviously floating-point.
     // Remember buffer was initialized with "0"
-    nextDigit = firstDigit &+ base10Exponent &+ 3
+    nextDigit = firstDigit &+ p &+ 3
     buffer.storeBytes(
-      of: 0x2e,
+      of: 0x2e, // "."
       toByteOffset: nextDigit &- 2,
       as: UInt8.self)
   }
@@ -1774,6 +1496,7 @@ fileprivate let hexdigits: _InlineArray<16, UInt8> = [
   0x38, 0x39, 0x61, 0x62, 0x63, 0x64, 0x65, 0x66
 ]
 
+// Emit up to 16 hex digits, pruning leading zeros
 fileprivate func _hexWithoutLeadingZeros(
   buffer: inout MutableRawSpan,
   offset: inout Int,
@@ -1794,6 +1517,7 @@ fileprivate func _hexWithoutLeadingZeros(
   }
 }
 
+// Emit exactly 16 hex digits
 fileprivate func _hexWithLeadingZeros(
   buffer: inout MutableRawSpan,
   offset: inout Int,
@@ -1857,14 +1581,14 @@ fileprivate func nan_details(
   return 0..<i
 }
 
-// Convert an integer less than 10^8 into exactly 8 ASCII digits in a
-// UInt64.  Assuming little-endian, the resulting UInt64 can be stored
-// directly to memory.
+// Convert an integer less than 10^8 into exactly 8 decimal digits in a
+// UInt64.  Assuming little-endian, you can add 0x3030303030303030 and
+// store the result directly to memory to get an ASCII decimal.
 //
 // This implementation is based on work by Paul Khuong:
 // https://pvk.ca/Blog/2017/12/22/appnexus-common-framework-its-out-also-how-to-print-integers-faster/
 @inline(__always)
-fileprivate func _intToEightDigits(_ n: UInt32) -> UInt64 {
+fileprivate func _intToEightDecimalDigits(_ n: UInt32) -> UInt64 {
   // Break into two numbers of 4 decimal digits each
   let div8 = n / 10000
   let mod8 = n &- div8 &* 10000
@@ -1882,68 +1606,25 @@ fileprivate func _intToEightDigits(_ n: UInt32) -> UInt64 {
   let mod2 = pairs &- 10 &* div2
   let singles = div2 | (mod2 &<< 8)
 
-  // Convert 8 digits to ASCII characters
-  return singles &+ 0x3030303030303030
+  return singles
+}
+
+@inline(__always)
+fileprivate func _intToSixteenDecimalDigits(_ n: UInt64) -> _UInt128 {
+  let hi8 = n / 100000000
+  let lo8 = n &- hi8 * 100000000
+
+  return _UInt128(
+    _low: _intToEightDecimalDigits(UInt32(truncatingIfNeeded: hi8)),
+    _high: _intToEightDecimalDigits(UInt32(truncatingIfNeeded: lo8))
+  )
 }
 
 // ================================================================
 //
 // Arithmetic Helpers
 //
-// The code above works with fixed-point values.  Standard
-// addition/subtraction/comparison works fine, but we need rounding
-// control when multiplying such values.
-//
-// For exmaple, `multiply128x64RoundingDown` multiplies a 0.128
-// fixed-point value by a 0.64 fixed-point fraction, returning a 0.128
-// value that's been rounded down from the exact 192-bit result.
-//
 // ================================================================
-
-@inline(__always)
-fileprivate func _multiply64x32RoundingDown(
-  _ lhs: UInt64,
-  _ rhs: UInt32
-) -> UInt64 {
-  let mask32 = UInt64(UInt32.max)
-  let t = ((lhs & mask32) * UInt64(rhs)) >> 32
-  return t + (lhs >> 32) * UInt64(rhs)
-}
-
-@inline(__always)
-fileprivate func _multiply64x32RoundingUp(
-  _ lhs: UInt64,
-  _ rhs: UInt32
-) -> UInt64 {
-  let mask32 = UInt64(UInt32.max)
-  let t = (((lhs & mask32) * UInt64(rhs)) + mask32) >> 32
-  return t + (lhs >> 32) * UInt64(rhs)
-}
-
-@inline(__always)
-fileprivate func _multiply128x64RoundingDown(
-  _ lhs: _UInt128,
-  _ rhs: UInt64
-) -> _UInt128 {
-  let lhsHigh = _UInt128(truncatingIfNeeded: lhs._high)
-  let lhsLow = _UInt128(truncatingIfNeeded: lhs._low)
-  let rhs128 = _UInt128(truncatingIfNeeded: rhs)
-  return (lhsHigh &* rhs128) &+ ((lhsLow &* rhs128) >> 64)
-}
-
-@inline(__always)
-fileprivate func _multiply128x64RoundingUp(
-  _ lhs: _UInt128,
-  _ rhs: UInt64
-) -> _UInt128 {
-  let lhsHigh = _UInt128(truncatingIfNeeded: lhs._high)
-  let lhsLow = _UInt128(truncatingIfNeeded: lhs._low)
-  let rhs128 = _UInt128(truncatingIfNeeded: rhs)
-  let h = lhsHigh &* rhs128
-  let l = lhsLow &* rhs128
-  let bias = (_UInt128(1) << 64) &- 1
-  return h + ((l &+ bias) &>> 64)
-}
 
 // Custom 256-bit unsigned integer type, with various arithmetic
 // helpers as methods.
@@ -1967,31 +1648,14 @@ fileprivate struct _UInt256 {
     self.low = low
   }
 
-  mutating func shiftRightRoundingDown(by shift: Int) {
-    assert(shift < 32 && shift >= 0)
-    var t = _UInt128(low._low >> shift)
-    t |= _UInt128(low._high) &<< (64 - shift)
-    let newlow = t._low
-    t = _UInt128(t._high)
-    t |= _UInt128(high._low) &<< (64 - shift)
-    low = _UInt128(_low: newlow, _high: t._low)
-    t = _UInt128(t._high)
-    t |= _UInt128(high._high) &<< (64 - shift)
-    high = t
+  init(_ low: _UInt128) {
+      self.high = 0
+      self.low = low
   }
 
-  mutating func shiftRightRoundingUp(by shift: Int) {
-    assert(shift < 32 && shift >= 0)
-    let bias = (UInt64(1) &<< shift) - 1
-    var t = _UInt128((low._low + bias) >> shift)
-    t |= _UInt128(low._high) &<< (64 - shift)
-    let newlow = t._low
-    t = _UInt128(t._high)
-    t |= _UInt128(high._low) &<< (64 - shift)
-    low = _UInt128(_low: newlow, _high: t._low)
-    t = _UInt128(t._high)
-    t |= _UInt128(high._high) &<< (64 - shift)
-    high = t
+  init(_ low: UInt64) {
+      self.high = 0
+      self.low = _UInt128(low)
   }
 
   mutating func multiply(by rhs: UInt32) {
@@ -2006,101 +1670,209 @@ fileprivate struct _UInt256 {
     assert(t._high == 0)
   }
 
-  mutating func multiplyRoundingDown(by rhs: _UInt128) {
-    var current = _UInt128(low._low) * _UInt128(rhs._low)
+  // Multiply by a UInt128,
+  // shift 384-bit intermediate value right by the specified amount, and
+  // return the low-order 256 bits
+  mutating func multiply(by rhs: _UInt128, lsr: Int) {
+    // Break into 64-bit components
+    let rhs1 = _UInt128(rhs._high)
+    let rhs0 = _UInt128(rhs._low)
+    let lhs3 = _UInt128(high._high)
+    let lhs2 = _UInt128(high._low)
+    let lhs1 = _UInt128(low._high)
+    let lhs0 = _UInt128(low._low)
+
+    // Compute cross-products, propagate carries
+    let w0 = rhs0 * lhs0
+    let w1a = rhs0 * lhs1
+    let w1b = rhs1 * lhs0
+    let w1 = (_UInt128(w0._high)
+                + _UInt128(w1a._low) + _UInt128(w1b._low))
+    let w2a = rhs0 * lhs2
+    let w2b = rhs1 * lhs1
+    let w2 = (_UInt128(w1a._high) + _UInt128(w1b._high) + _UInt128(w1._high)
+                + _UInt128(w2a._low) + _UInt128(w2b._low))
+    let w3a = rhs0 * lhs3
+    let w3b = rhs1 * lhs2
+    let w3 = (_UInt128(w2a._high) + _UInt128(w2b._high) + _UInt128(w2._high)
+                + _UInt128(w3a._low) + _UInt128(w3b._low))
+    let w4 = (_UInt128(w3a._high) + _UInt128(w3b._high) + _UInt128(w3._high)
+                + rhs1 * lhs3)
+
+    // Discard overhead bits
+    var x0 = w0._low
+    var x1 = w1._low
+    var x2 = w2._low
+    var x3 = w3._low
+    var x4 = w4._low
+    var x5 = w4._high
+
+    // Shift right by a multiple of 64 bits
+    var shift = lsr
+    while shift >= 64 {
+      x0 = x1
+      x1 = x2
+      x2 = x3
+      x3 = x4
+      x4 = x5
+      x5 = 0
+      shift -= 64
+    }
+
+    // Shift the remainder
+    if shift > 0 {
+      x0 = (x0 >> shift) + (x1 << (64 - shift))
+      x1 = (x1 >> shift) + (x2 << (64 - shift))
+      x2 = (x2 >> shift) + (x3 << (64 - shift))
+      x3 = (x3 >> shift) + (x4 << (64 - shift))
+//    x4 = (x4 >> shift) + (x5 << (64 - shift))
+//    x5 = (x5 >> shift)
+    }
+
+    // Keep the low-order 256 bits
+    low = _UInt128(_low: x0, _high: x1)
+    high = _UInt128(_low: x2, _high: x3)
+  }
+
+  mutating func multiplyHigh(by rhs: _UInt128) {
+    multiply(by: rhs, lsr: 128)
+  }
+
+  // TODO: Reduce code size here either by rephrasing it
+  // as a nested for loop with additional bookkeeping, or
+  // by recursively using the 256-bit x 128-bit multiplies above.
+  mutating func multiplyHigh(by rhs: _UInt256) {
+    var current = _UInt128(low._low) * _UInt128(rhs.low._low)
 
     current = _UInt128(current._high)
-    var t = _UInt128(low._low) &* _UInt128(rhs._high)
+    var t = _UInt128(low._low) &* _UInt128(rhs.low._high)
     current += _UInt128(t._low)
     var next = _UInt128(t._high)
-    t = _UInt128(low._high) &* _UInt128(rhs._low)
+    t = _UInt128(low._high) &* _UInt128(rhs.low._low)
     current += _UInt128(t._low)
     next += _UInt128(t._high)
 
     current = next + _UInt128(current._high)
-    t = _UInt128(low._high) &* _UInt128(rhs._high)
+    t = _UInt128(low._low) &* _UInt128(rhs.high._low)
     current += _UInt128(t._low)
     next = _UInt128(t._high)
-    t = _UInt128(high._low) &* _UInt128(rhs._low)
+    t = _UInt128(low._high) &* _UInt128(rhs.low._high)
+    current += _UInt128(t._low)
+    next += _UInt128(t._high)
+    t = _UInt128(high._low) &* _UInt128(rhs.low._low)
+    current += _UInt128(t._low)
+    next += _UInt128(t._high)
+
+    current = next + _UInt128(current._high)
+    t = _UInt128(low._low) &* _UInt128(rhs.high._high)
+    current += _UInt128(t._low)
+    next = _UInt128(t._high)
+    t = _UInt128(low._high) &* _UInt128(rhs.high._low)
+    current += _UInt128(t._low)
+    next += _UInt128(t._high)
+    t = _UInt128(high._low) &* _UInt128(rhs.low._high)
+    current += _UInt128(t._low)
+    next += _UInt128(t._high)
+    t = _UInt128(high._high) &* _UInt128(rhs.low._low)
+    current += _UInt128(t._low)
+    next += _UInt128(t._high)
+
+    current = next + _UInt128(current._high)
+    t = _UInt128(low._high) &* _UInt128(rhs.high._high)
+    current += _UInt128(t._low)
+    next = _UInt128(t._high)
+    t = _UInt128(high._low) &* _UInt128(rhs.high._low)
+    current += _UInt128(t._low)
+    next += _UInt128(t._high)
+    t = _UInt128(high._high) &* _UInt128(rhs.low._high)
     current += _UInt128(t._low)
     next += _UInt128(t._high)
     let newlow = current._low
 
     current = next + _UInt128(current._high)
-    t = _UInt128(high._low) &* _UInt128(rhs._high)
+    t = _UInt128(high._low) &* _UInt128(rhs.high._high)
     current += _UInt128(t._low)
     next = _UInt128(t._high)
-    t = _UInt128(high._high) &* _UInt128(rhs._low)
+    t = _UInt128(high._high) &* _UInt128(rhs.high._low)
     current += _UInt128(t._low)
     next += _UInt128(t._high)
     low = _UInt128(_low: newlow, _high: current._low)
 
     current = next + _UInt128(current._high)
-    t = _UInt128(high._high) &* _UInt128(rhs._high)
-    high = current + t
-  }
-
-  mutating func multiplyRoundingUp(by rhs: _UInt128) {
-    var current = _UInt128(low._low) &* _UInt128(rhs._low)
-    current += _UInt128(UInt64.max)
-
-    current = _UInt128(current._high)
-    var t = _UInt128(low._low) &* _UInt128(rhs._high)
-    current += _UInt128(t._low)
-    var next = _UInt128(t._high)
-    t = _UInt128(low._high) &* _UInt128(rhs._low)
-    current += _UInt128(t._low)
-    next += _UInt128(t._high)
-    current += _UInt128(UInt64.max)
-
-    current = next + _UInt128(current._high)
-    t = _UInt128(low._high) &* _UInt128(rhs._high)
-    current += _UInt128(t._low)
-    next = _UInt128(t._high)
-    t = _UInt128(high._low) &* _UInt128(rhs._low)
-    current += _UInt128(t._low)
-    next += _UInt128(t._high)
-    let newlow = current._low
-
-    current = next + _UInt128(current._high)
-    t = _UInt128(high._low) &* _UInt128(rhs._high)
-    current += _UInt128(t._low)
-    next = _UInt128(t._high)
-    t = _UInt128(high._high) &* _UInt128(rhs._low)
-    current += _UInt128(t._low)
-    next += _UInt128(t._high)
-    low = _UInt128(_low: newlow, _high: current._low)
-
-    current = next + _UInt128(current._high)
-    t = _UInt128(high._high) &* _UInt128(rhs._high)
-    high = current + t
-  }
-
-  mutating func extractIntegerPart(_ bits: Int) -> UInt {
-    assert(bits < 16)
-    let integral = high._high >> (64 &- bits)
-    high = _UInt128(
-      _low: high._low,
-      _high: high._high &- (integral &<< (64 &- bits)))
-    return UInt(truncatingIfNeeded: integral)
+    high = current + _UInt128(high._high) &* _UInt128(rhs.high._high)
   }
 
   static func &- (lhs: _UInt256, rhs: _UInt256) -> _UInt256 {
     var t = _UInt128(lhs.low._low) &+ _UInt128(~rhs.low._low) &+ 1
-    let newlowlow = t._low
+    let w0 = t._low
     t = _UInt128(t._high) &+ _UInt128(lhs.low._high) &+ _UInt128(~rhs.low._high)
-    let newlow = _UInt128(_low: newlowlow, _high: t._low)
+    let w1 = t._low
     t = _UInt128(t._high) &+ _UInt128(lhs.high._low) &+ _UInt128(~rhs.high._low)
-    let newhigh = _UInt128(
-      _low: t._low,
-      _high: t._high &+ lhs.high._high &+ ~rhs.high._high)
-    return _UInt256(high: newhigh, low: newlow)
+    let w2 = t._low
+    let w3 = t._high &+ lhs.high._high &+ ~rhs.high._high
+    return _UInt256(high: w3, w2, w1, low: w0)
   }
 
   static func < (lhs: _UInt256, rhs: _UInt256) -> Bool {
     return (lhs.high < rhs.high)
       || (lhs.high == rhs.high
             && lhs.low < rhs.low)
+  }
+
+  static func > (lhs: _UInt256, rhs: _UInt256) -> Bool {
+    return rhs < lhs
+  }
+
+  static func &+ (lhs: _UInt256, rhs: _UInt256) -> _UInt256 {
+    let low = lhs.low &+ rhs.low
+    let carry: _UInt128 = low < lhs.low ? 1 : 0
+    let high = lhs.high &+ rhs.high &+ carry
+    return _UInt256(high: high, low: low)
+  }
+
+  // Add a signed int...
+  static func &+= (lhs: inout _UInt256, rhs: Int) {
+    if rhs >= 0 {
+      let r = _UInt128(UInt(rhs))
+      let newlow = lhs.low &+ r
+      let carry: _UInt128 = newlow < lhs.low ? 1 : 0
+      lhs.high &+= carry
+      lhs.low = newlow
+    } else {
+      let magnitude = _UInt128(UInt(bitPattern: 0 &- rhs))
+      let borrow: _UInt128 = lhs.low < magnitude ? 1 : 0
+      lhs.low &-= magnitude
+      lhs.high &-= borrow
+    }
+  }
+
+  static func & (lhs: _UInt256, rhs: _UInt256) -> _UInt256 {
+    return _UInt256(high: lhs.high & rhs.high, low: lhs.low & rhs.low)
+  }
+
+  // Right-shift by 0..<128 bits
+  static func &>> (lhs: _UInt256, rhs: Int) -> _UInt256 {
+    var hi = lhs.high._high
+    var midhi = lhs.high._low
+    var midlo = lhs.low._high
+    var lo = lhs.low._low
+    // Shift by whole 64-bit words first
+    if rhs >= 64 {
+      lo = midlo
+      midlo = midhi
+      midhi = hi
+      hi = 0
+    }
+    // Shift by remaining bits
+    let r = rhs & 63
+    if r > 0 {
+      let anti = 64 &- r
+      lo = (lo >> r) | (midlo << anti)
+      midlo = (midlo >> r) | (midhi << anti)
+      midhi = (midhi >> r) | (hi << anti)
+      hi = hi >> r
+    }
+    return _UInt256(high: hi, midhi, midlo, low: lo)
   }
 }
 
@@ -2111,38 +1883,14 @@ fileprivate struct _UInt256 {
 // ================================================================
 
 @inline(__always)
-fileprivate func _intervalContainingPowerOf10_Binary32(
+fileprivate func _powerOf10_Binary64(
   p: Int,
-  lower: inout UInt64,
-  upper: inout UInt64
-) -> Int {
-  if p >= 0 {
-    let base = powersOf10_Exact128[p &* 2 &+ 1]
-    lower = base
-    if p < 28 {
-      upper = base
-    } else {
-      upper = base &+ 1
-    }
-  } else {
-    let base = powersOf10_negativeBinary32[p &+ 40]
-    lower = base
-    upper = base &+ 1
-  }
-  return binaryExponentFor10ToThe(p)
-}
-
-@inline(__always)
-fileprivate func _intervalContainingPowerOf10_Binary64(
-  p: Int,
-  lower: inout _UInt128,
-  upper: inout _UInt128
+  significand: inout _UInt128
 ) -> Int {
   if p >= 0 && p <= 55 {
     let upper64 = powersOf10_Exact128[p &* 2 &+ 1]
     let lower64 = powersOf10_Exact128[p &* 2]
-    upper = _UInt128(_low: lower64, _high: upper64)
-    lower = upper
+    significand = _UInt128(_low: lower64, _high: upper64)
     return binaryExponentFor10ToThe(p)
   }
 
@@ -2154,18 +1902,66 @@ fileprivate func _intervalContainingPowerOf10_Binary64(
   let baseExponent = binaryExponentFor10ToThe(p &- extraPower)
 
   if extraPower == 0 {
-    lower = _UInt128(_low: baseLow, _high: baseHigh)
-    upper = lower &+ 1
+    significand = _UInt128(_low: baseLow, _high: baseHigh)
     return baseExponent
   } else {
     let extra = powersOf10_Exact128[extraPower &* 2 &+ 1]
-    lower = ((_UInt128(truncatingIfNeeded:baseHigh)
+    let high = (_UInt128(truncatingIfNeeded:baseHigh)
                 &* _UInt128(truncatingIfNeeded:extra))
-               &+ ((_UInt128(truncatingIfNeeded:baseLow)
-                      &* _UInt128(truncatingIfNeeded:extra)) &>> 64))
-    upper = lower &+ 2
+    let low = (_UInt128(truncatingIfNeeded:baseLow)
+               &* _UInt128(truncatingIfNeeded:extra)
+               &+ _UInt128(UInt64.max >> 1))
+    significand = high &+ (low &>> 64)
     return baseExponent &+ binaryExponentFor10ToThe(extraPower)
   }
+}
+
+// To keep the supporting table size to a minimum, this
+// picks a value from each of three tables and multiplies
+// them together to get a sufficiently-accurate final result.
+fileprivate func _powerOf10_Binary128(
+  p: Int,
+  significand: inout _UInt256
+) -> Int {
+  if p >= 0 && p <= 55 {
+    let exactLow = powersOf10_Exact128[p * 2]
+    let exactHigh = powersOf10_Exact128[p * 2 + 1]
+    significand = _UInt256(high: exactHigh, exactLow, 0, low: 0)
+    return binaryExponentFor10ToThe(p)
+  }
+
+  let index = p + 5376
+  let finePower = index % 56
+  let mediumPower = index % 896 - finePower
+  let coarsePower = p - mediumPower - finePower
+
+  let coarseIndex = (index / 896) * 4
+  let mediumIndex = (mediumPower / 56) * 4
+  let fineIndex = finePower * 2
+
+  significand = _UInt256(
+    high: powersOf10_Binary128_Coarse[coarseIndex + 3],
+    powersOf10_Binary128_Coarse[coarseIndex + 2],
+    powersOf10_Binary128_Coarse[coarseIndex + 1],
+    low: powersOf10_Binary128_Coarse[coarseIndex + 0])
+
+  let medium = _UInt256(
+    high: powersOf10_Binary128_Medium[mediumIndex + 3],
+    powersOf10_Binary128_Medium[mediumIndex + 2],
+    powersOf10_Binary128_Medium[mediumIndex + 1],
+    low: powersOf10_Binary128_Medium[mediumIndex + 0])
+  significand.multiplyHigh(by: medium)
+
+  let fine = _UInt128(
+    _low: powersOf10_Exact128[fineIndex],
+    _high: powersOf10_Exact128[fineIndex + 1])
+  significand.multiplyHigh(by: fine)
+
+  let coarseExponent = binaryExponentFor10ToThe(coarsePower)
+  let mediumExponent = binaryExponentFor10ToThe(mediumPower)
+  let fineExponent = binaryExponentFor10ToThe(finePower)
+
+  return coarseExponent + mediumExponent + fineExponent
 }
 
 @inline(__always)
@@ -2173,36 +1969,24 @@ fileprivate func binaryExponentFor10ToThe(_ p: Int) -> Int {
   return Int(((Int64(p) &* 55732705) >> 24) &+ 1)
 }
 
-@inline(__always)
-fileprivate func decimalExponentFor2ToThe(_ p: Int) -> Int {
-  return Int((Int64(p) &* 20201781) >> 26)
-}
-
-// Each of the constant values here have an implicit binary point at
-// the extreme left and when not exact, are rounded _down_ from the
-// exact values.  For example, the first row of the first table says
-// that:
+// Each of the constant values here have an implicit binary point at the extreme
+// left and when not exact, are rounded _down_ from the exact values.  For
+// example, the first row of the powersOf10_Binary64 table below says that:
 //
-//   0x0.8b61313bbabce2c6 x 2^-132
+//   0x0.95fe7e07c91efafa3931b850df08e738 x 2^-1328
 //
-// is the result of rounding down the exact binary value of 10^-40 to
-// 64 significant bits.  The logic above uses these tables to compute
+// is the result of rounding down the exact binary value of 10^-400 to
+// 128 significant bits.  The logic above uses these tables to compute
 // bounds for the exact value of the power of 10.
 
 // Note the binary exponent is not stored; it is computed by the
 // `binaryExponentFor10ToThe(p)` function.
 
-// This covers the negative powers of 10 for Float32.
-// Positive powers of 10 come from the next table below.
-// Table size: 320 bytes
-fileprivate let powersOf10_negativeBinary32: _InlineArray<_, UInt64> = [
-  0x8b61313bbabce2c6, // x 2^-132 ~= 10^-40
-  0xae397d8aa96c1b77, // x 2^-129 ~= 10^-39
-  0xd9c7dced53c72255, // x 2^-126 ~= 10^-38
-  0x881cea14545c7575, // x 2^-122 ~= 10^-37
-  0xaa242499697392d2, // x 2^-119 ~= 10^-36
-  0xd4ad2dbfc3d07787, // x 2^-116 ~= 10^-35
-  0x84ec3c97da624ab4, // x 2^-112 ~= 10^-34
+// ## powersOf10_Float32
+
+// Complete table suitable for Float32 conversion.
+
+fileprivate let powersOf10_Float32: _InlineArray<_, UInt64> = [
   0xa6274bbdd0fadd61, // x 2^-109 ~= 10^-33
   0xcfb11ead453994ba, // x 2^-106 ~= 10^-32
   0x81ceb32c4b43fcf4, // x 2^-102 ~= 10^-31
@@ -2236,7 +2020,60 @@ fileprivate let powersOf10_negativeBinary32: _InlineArray<_, UInt64> = [
   0x83126e978d4fdf3b, // x 2^-9 ~= 10^-3
   0xa3d70a3d70a3d70a, // x 2^-6 ~= 10^-2
   0xcccccccccccccccc, // x 2^-3 ~= 10^-1
+  0x8000000000000000, // x 2^1 == 10^0 exactly
+  0xa000000000000000, // x 2^4 == 10^1 exactly
+  0xc800000000000000, // x 2^7 == 10^2 exactly
+  0xfa00000000000000, // x 2^10 == 10^3 exactly
+  0x9c40000000000000, // x 2^14 == 10^4 exactly
+  0xc350000000000000, // x 2^17 == 10^5 exactly
+  0xf424000000000000, // x 2^20 == 10^6 exactly
+  0x9896800000000000, // x 2^24 == 10^7 exactly
+  0xbebc200000000000, // x 2^27 == 10^8 exactly
+  0xee6b280000000000, // x 2^30 == 10^9 exactly
+  0x9502f90000000000, // x 2^34 == 10^10 exactly
+  0xba43b74000000000, // x 2^37 == 10^11 exactly
+  0xe8d4a51000000000, // x 2^40 == 10^12 exactly
+  0x9184e72a00000000, // x 2^44 == 10^13 exactly
+  0xb5e620f480000000, // x 2^47 == 10^14 exactly
+  0xe35fa931a0000000, // x 2^50 == 10^15 exactly
+  0x8e1bc9bf04000000, // x 2^54 == 10^16 exactly
+  0xb1a2bc2ec5000000, // x 2^57 == 10^17 exactly
+  0xde0b6b3a76400000, // x 2^60 == 10^18 exactly
+  0x8ac7230489e80000, // x 2^64 == 10^19 exactly
+  0xad78ebc5ac620000, // x 2^67 == 10^20 exactly
+  0xd8d726b7177a8000, // x 2^70 == 10^21 exactly
+  0x878678326eac9000, // x 2^74 == 10^22 exactly
+  0xa968163f0a57b400, // x 2^77 == 10^23 exactly
+  0xd3c21bcecceda100, // x 2^80 == 10^24 exactly
+  0x84595161401484a0, // x 2^84 == 10^25 exactly
+  0xa56fa5b99019a5c8, // x 2^87 == 10^26 exactly
+  0xcecb8f27f4200f3a, // x 2^90 == 10^27 exactly
+  0x813f3978f8940984, // x 2^94 ~= 10^28
+  0xa18f07d736b90be5, // x 2^97 ~= 10^29
+  0xc9f2c9cd04674ede, // x 2^100 ~= 10^30
+  0xfc6f7c4045812296, // x 2^103 ~= 10^31
+  0x9dc5ada82b70b59d, // x 2^107 ~= 10^32
+  0xc5371912364ce305, // x 2^110 ~= 10^33
+  0xf684df56c3e01bc6, // x 2^113 ~= 10^34
+  0x9a130b963a6c115c, // x 2^117 ~= 10^35
+  0xc097ce7bc90715b3, // x 2^120 ~= 10^36
+  0xf0bdc21abb48db20, // x 2^123 ~= 10^37
+  0x96769950b50d88f4, // x 2^127 ~= 10^38
+  0xbc143fa4e250eb31, // x 2^130 ~= 10^39
+  0xeb194f8e1ae525fd, // x 2^133 ~= 10^40
+  0x92efd1b8d0cf37be, // x 2^137 ~= 10^41
+  0xb7abc627050305ad, // x 2^140 ~= 10^42
+  0xe596b7b0c643c719, // x 2^143 ~= 10^43
+  0x8f7e32ce7bea5c6f, // x 2^147 ~= 10^44
+  0xb35dbf821ae4f38b, // x 2^150 ~= 10^45
+  0xe0352f62a19e306e, // x 2^153 ~= 10^46
+  0x8c213d9da502de45, // x 2^157 ~= 10^47
+  0xaf298d050e4395d6, // x 2^160 ~= 10^48
+  0xdaf3f04651d47b4c, // x 2^163 ~= 10^49
+  0x88d8762bf324cd0f, // x 2^167 ~= 10^50
 ]
+
+// ## powersOf10_Exact128
 
 // All the powers of 10 that can be represented exactly
 // in 128 bits, represented as binary floating-point values
@@ -2244,13 +2081,10 @@ fileprivate let powersOf10_negativeBinary32: _InlineArray<_, UInt64> = [
 // with 128 bit significands.
 
 // This table is used in four places:
-// * The high order 64 bits are used for positive powers of 10
-//   when converting Float32.
 // * The full 128-bit value is used for 10^0 through 10^55 for Float64.
 // * The first 28 entries are combined with the next table for
 //   all other Float64 values.
-// * This is combined with the 256-bit table below for Float80/Float128
-//   support.
+// * This is combined with the 256-bit table below for Float80 support.
 
 // Table size: 896 bytes
 fileprivate let powersOf10_Exact128: _InlineArray<_, UInt64> = [
@@ -2313,6 +2147,8 @@ fileprivate let powersOf10_Exact128: _InlineArray<_, UInt64> = [
   0xfff4b4e3f741cf6d, 0xd0cf4b50cfe20765, // x 2^183 == 10^55 exactly
 ]
 
+// ## powersOf10_Binary64
+
 // Every 28th power of 10 across the full range of Double.
 // Combined with a 64-bit exact power of 10 from the previous
 // table, this lets us reconstruct a 128-bit lower bound for
@@ -2358,103 +2194,15 @@ fileprivate let powersOf10_Binary64: _InlineArray<_, UInt64> = [
   0x1027fff56784f444, 0xc4c5e310aef8aa17, // x 2^1276 ~= 10^384
 ]
 
-// Needed by 80- and 128-bit formatters above
+// ## powersOf10_Binary128
 
-// We could cut this in half by keeping only the positive powers and doing
-// a single additional 256-bit multiplication by 10^-4984 to recover the negative powers.
+// Needed by 80-bit formatter.  This is sufficient precision
+// to support a future Float128 implementation if anyone's interested.
 
-// Table size: 5728 bytes
-fileprivate let powersOf10_Binary128: _InlineArray<_, UInt64> = [
-  // Low-order ... high-order
-  0xaec2e6aff96b46ae, 0xf91044c2eff84750, 0x2b55c9e70e00c557, 0xb6536903bf8f2bda, // x 2^-16556 ~= 10^-4984
-  0xda1b3c3dd3889587, 0x73a7380aba84a6b1, 0xbddb2dfde3f8a6e3, 0xb9e5428330737362, // x 2^-16370 ~= 10^-4928
-  0xa2d23c57cfebb9ec, 0x9f165c039ead6d77, 0x88227fdfc13ab53d, 0xbd89006346a9a34d, // x 2^-16184 ~= 10^-4872
-  0x0333d510cf27e5a5, 0x4e3cc383eaa17b7b, 0xe05fe4207ca3d508, 0xc13efc51ade7df64, // x 2^-15998 ~= 10^-4816
-  0xff242c569bc1f539, 0x5c67ba58680c4cce, 0x3c55f3f947fef0e9, 0xc50791bd8dd72edb, // x 2^-15812 ~= 10^-4760
-  0xe4b75ae27bec50bf, 0x25b0419765fdfcdb, 0x0915564d8ab057ee, 0xc8e31de056f89c19, // x 2^-15626 ~= 10^-4704
-  0x548b1e80a94f3434, 0xe418e9217ce83755, 0x801e38463183fc88, 0xccd1ffc6bba63e21, // x 2^-15440 ~= 10^-4648
-  0x541950a0fdc2b4d9, 0xeea173da1f0eb7b4, 0xcfadf6b2aa7c4f43, 0xd0d49859d60d40a3, // x 2^-15254 ~= 10^-4592
-  0x7e64501be95ad76b, 0x451e855d8acef835, 0x9e601e707a2c3488, 0xd4eb4a687c0253e8, // x 2^-15068 ~= 10^-4536
-  0xdadd9645f360cb51, 0xf290163350ecb3eb, 0xa8edffdccfe4db4b, 0xd9167ab0c1965798, // x 2^-14882 ~= 10^-4480
-  0x7e447db3018ffbdf, 0x4fa1860c08a85923, 0xb17cd86e7fcece75, 0xdd568fe9ab559344, // x 2^-14696 ~= 10^-4424
-  0x61cd4655bf64d265, 0xb19fd88fe285b3bc, 0x1151250681d59705, 0xe1abf2cd11206610, // x 2^-14510 ~= 10^-4368
-  0xa5703f5ce7a619ec, 0x361243a84b55574d, 0x025a8e1e5dbb41d6, 0xe6170e21b2910457, // x 2^-14324 ~= 10^-4312
-  0xb93897a6cf5d3e61, 0x18746fcc6a190db9, 0x66e849253e5da0c2, 0xea984ec57de69f13, // x 2^-14138 ~= 10^-4256
-  0x309043d12ab5b0ac, 0x79c93cff11f09319, 0xf5a7800f23ef67b8, 0xef3023b80a732d93, // x 2^-13952 ~= 10^-4200
-  0xa3baa84c049b52b9, 0xbec466ee1b586342, 0x0e85fc7f4edbd3ca, 0xf3defe25478e074a, // x 2^-13766 ~= 10^-4144
-  0xd1f4628316b15c7a, 0xae16192410d3135e, 0x4268a54f70bd28c4, 0xf8a551706112897c, // x 2^-13580 ~= 10^-4088
-  0x9eb9296cc5749dba, 0x48324e275376dfdd, 0x5052e9289f0f2333, 0xfd83933eda772c0b, // x 2^-13394 ~= 10^-4032
-  0xff6aae669a5a0d8a, 0x24fed95087b9006e, 0x01b02378a405b421, 0x813d1dc1f0c754d6, // x 2^-13207 ~= 10^-3976
-  0xf993f18de00dc89b, 0x15617da021b89f92, 0xb782db1fc6aba49b, 0x83c4e245ed051dc1, // x 2^-13021 ~= 10^-3920
-  0xc6a0d64a712172b1, 0x2217669197ac1504, 0x4250be2eeba87d15, 0x86595584116caf3c, // x 2^-12835 ~= 10^-3864
-  0x0bdc0c67a220687b, 0x44a66a6d6fd6537b, 0x3f1f93f1943ca9b6, 0x88fab70d8b44952a, // x 2^-12649 ~= 10^-3808
-  0xb60b57164ad28122, 0xde5bd4572c25a830, 0x2c87f18b39478aa2, 0x8ba947b223e5783e, // x 2^-12463 ~= 10^-3752
-  0xbd59568efdb9bfee, 0x292f8f2c98d7f44c, 0x4054f5360249ebd1, 0x8e6549867da7d11a, // x 2^-12277 ~= 10^-3696
-  0x9fa0721e66791acc, 0x1789061d717d454c, 0xc1187fa0c18adbbe, 0x912effea7015b2c5, // x 2^-12091 ~= 10^-3640
-  0x982b64e953ac4e27, 0x45efb05f20cf48b3, 0x4b4de34e0ebc3e06, 0x9406af8f83fd6265, // x 2^-11905 ~= 10^-3584
-  0xa53f5950eec21dca, 0x3bd8754763bdbca1, 0xac73f0226eff5ea1, 0x96ec9e7f9004839b, // x 2^-11719 ~= 10^-3528
-  0x320e19f88f1161b7, 0x72e93fe0cce7cfd9, 0x2184706ea46a4c38, 0x99e11423765ec1d0, // x 2^-11533 ~= 10^-3472
-  0x491aba48dfc0e36e, 0xd3de560ee34022b2, 0xddadb80577b906bd, 0x9ce4594a044e0f1b, // x 2^-11347 ~= 10^-3416
-  0x06789d038697142f, 0x7a466a75be73db21, 0x60dbd8aa443b560f, 0x9ff6b82ef415d222, // x 2^-11161 ~= 10^-3360
-  0x40ed8056af76ac43, 0x08251c601e346456, 0x7401c6f091f87727, 0xa3187c82120dace6, // x 2^-10975 ~= 10^-3304
-  0x8c643ee307bffec6, 0xf369a11c6f66c05a, 0x4d5b32f713d7f476, 0xa649f36e8583e81a, // x 2^-10789 ~= 10^-3248
-  0xe32f5e080e36b4be, 0x3adf30ff2eb163d4, 0xb4b39dd9ddb8d317, 0xa98b6ba23e2300c7, // x 2^-10603 ~= 10^-3192
-  0x6b9d538c192cfb1b, 0x1c5af3bd4d2c60b5, 0xec41c1793d69d0d1, 0xacdd3555869159d1, // x 2^-10417 ~= 10^-3136
-  0x1adadaeedf7d699c, 0x71043692494aa743, 0x3ca5a7540d9d56c9, 0xb03fa252bd05a815, // x 2^-10231 ~= 10^-3080
-  0xec3e4e5fc6b03617, 0x47c9b16afe8fdf74, 0x92e1bc1fbb33f18d, 0xb3b305fe328e571f, // x 2^-10045 ~= 10^-3024
-  0x1d42fa68b12bdb23, 0xac46a7b3f2b4b34e, 0xa908fd4a88728b6a, 0xb737b55e31cdde04, // x 2^-9859 ~= 10^-2968
-  0x887dede507f2b618, 0x359a8fa0d014b9a7, 0x7c4c65d15c614c56, 0xbace07232df1c802, // x 2^-9673 ~= 10^-2912
-  0x504708e718b4b669, 0xfb4d9440822af452, 0xef84cc99cb4c5d17, 0xbe7653b01aae13e5, // x 2^-9487 ~= 10^-2856
-  0x5b7977525516bff0, 0x75913092420c9b35, 0xcfc147ade4843a24, 0xc230f522ee0a7fc2, // x 2^-9301 ~= 10^-2800
-  0xad5d11883cc1302b, 0x860a754894b9a0bc, 0x4668677d5f46c29b, 0xc5fe475d4cd35cff, // x 2^-9115 ~= 10^-2744
-  0x42032f9f971bfc07, 0x9fb576046ab35018, 0x474b3cb1fe1d6a7f, 0xc9dea80d6283a34c, // x 2^-8929 ~= 10^-2688
-  0xd3e7fbb72403a4dd, 0x8ca223055819af54, 0xd6ea3b733029ef0b, 0xcdd276b6e582284f, // x 2^-8743 ~= 10^-2632
-  0xba2431d885f2b7d9, 0xc9879fc42869f610, 0x3736730a9e47fef8, 0xd1da14bc489025ea, // x 2^-8557 ~= 10^-2576
-  0xa11edbcd65dd1844, 0xcb8edae81a295887, 0x3d24e68dc1027246, 0xd5f5e5681a4b9285, // x 2^-8371 ~= 10^-2520
-  0xa0f076652f69ad08, 0x9d19c341f5f42f2a, 0x742ab8f3864562c8, 0xda264df693ac3e30, // x 2^-8185 ~= 10^-2464
-  0x29f760ef115f2824, 0xe0ee47c041c9de0f, 0x8c119f3680212413, 0xde6bb59f56672cda, // x 2^-7999 ~= 10^-2408
-  0x8b90230b3409c9d3, 0x9d76eef2c1543e65, 0x43190b523f872b9c, 0xe2c6859f5c284230, // x 2^-7813 ~= 10^-2352
-  0xd44ce9993bc6611e, 0x777c9b2dfbede079, 0x2a0969bf88679396, 0xe7372943179706fc, // x 2^-7627 ~= 10^-2296
-  0xe8c5f5a63fd0fbd1, 0x0ccc12293f1d7a58, 0x131565be33dda91a, 0xebbe0df0c8201ac5, // x 2^-7441 ~= 10^-2240
-  0xdb97988dd6b776f4, 0xeb2106f435f7e1d5, 0xccfb1cc2ef1f44de, 0xf05ba3330181c750, // x 2^-7255 ~= 10^-2184
-  0x2fcbc8df94a1d54b, 0x796d0a8120801513, 0x5f8385b3a882ff4c, 0xf5105ac3681f2716, // x 2^-7069 ~= 10^-2128
-  0xc8700c11071a40f5, 0x23cb9e9df9331fe4, 0x166c15f456786c27, 0xf9dca895a3226409, // x 2^-6883 ~= 10^-2072
-  0x9589f4637a50cbb5, 0xea8242b0030e4a51, 0x6c656c3b1f2c9d91, 0xfec102e2857bc1f9, // x 2^-6697 ~= 10^-2016
-  0xc4be56c83349136c, 0x6188db81ac8e775d, 0xfa70b9a2ca60b004, 0x81def119b76837c8, // x 2^-6510 ~= 10^-1960
-  0xb85d39054658b363, 0xe7df06bc613fda21, 0x6a22490e8e9ec98b, 0x8469e0b6f2b8bd9b, // x 2^-6324 ~= 10^-1904
-  0x800b1e1349fef248, 0x469cfd2e6ca32a77, 0x69138459b0fa72d4, 0x87018eefb53c6325, // x 2^-6138 ~= 10^-1848
-  0xb62593291c768919, 0xc098e6ed0bfbd6f6, 0x6c83ad1260ff20f4, 0x89a63ba4c497b50e, // x 2^-5952 ~= 10^-1792
-  0x92ee7fce474479d3, 0xe02017175bf040c6, 0xd82ef2860273de8d, 0x8c5827f711735b46, // x 2^-5766 ~= 10^-1736
-  0x7b0e6375ca8c77d9, 0x5f07e1e10097d47f, 0x416d7f9ab1e67580, 0x8f17964dfc3961f2, // x 2^-5580 ~= 10^-1680
-  0xc8d869ed561af1ce, 0x8b6648e941de779b, 0x56700866b85d57fe, 0x91e4ca5db93dbfec, // x 2^-5394 ~= 10^-1624
-  0xfc04df783488a410, 0x64d1f15da2c146b1, 0x43cf71d5c4fd7868, 0x94c0092dd4ef9511, // x 2^-5208 ~= 10^-1568
-  0xfbaf03b48a965a64, 0x9b6122aa2b72a13c, 0x387898a6e22f821b, 0x97a9991fd8b3afc0, // x 2^-5022 ~= 10^-1512
-  0x50f7f7c13119aadd, 0xe415d8b25694250a, 0x8f8857e875e7774e, 0x9aa1c1f6110c0dd0, // x 2^-4836 ~= 10^-1456
-  0xce214403545fd685, 0xf36d1ad779b90e09, 0xa5c58d5f91a476d7, 0x9da8ccda75b341b5, // x 2^-4650 ~= 10^-1400
-  0x63ddfb68f971b0c5, 0x2822e38faf74b26e, 0x6e1f7f1642ebaac8, 0xa0bf0465b455e921, // x 2^-4464 ~= 10^-1344
-  0xf0d00cec9daf7444, 0x6bf3eea6f661a32a, 0xfad2be1679765f27, 0xa3e4b4a65e97b76a, // x 2^-4278 ~= 10^-1288
-  0x463b4ab4bd478f57, 0x6f6583b5b36d5426, 0x800cfab80c4e2eb1, 0xa71a2b283c14fba6, // x 2^-4092 ~= 10^-1232
-  0xef163df2fa96e983, 0xa825f32bc8f6b080, 0x850b0c5976b21027, 0xaa5fb6fbc115010b, // x 2^-3906 ~= 10^-1176
-  0x7db1b3f8e100eb43, 0x2862b1f61d64ddc3, 0x61363686961a41e5, 0xadb5a8bdaaa53051, // x 2^-3720 ~= 10^-1120
-  0xfd349cf00ba1e09a, 0x6d282fe1b7112879, 0xc6f075c4b81fc72d, 0xb11c529ec0d87268, // x 2^-3534 ~= 10^-1064
-  0xf7221741b221cf6f, 0x3739f15b06ac3c76, 0xb4e4be5b6455ef96, 0xb494086bbfea00c3, // x 2^-3348 ~= 10^-1008
-  0xc4e5a2f864c403bb, 0x6e33cdcda4367276, 0x24d256c540a50309, 0xb81d1f9569068d8e, // x 2^-3162 ~= 10^-952
-  0x276e3f0f67f0553b, 0x00de73d9d5be6974, 0x6d4aa5b50bb5dc0d, 0xbbb7ef38bb827f2d, // x 2^-2976 ~= 10^-896
-  0x51a34a3e674484ed, 0x1fb6069f8b26f840, 0x925624c0d7d93317, 0xbf64d0275747de70, // x 2^-2790 ~= 10^-840
-  0xcc775c8cb6de1dbc, 0x6d60d02eac6309ee, 0x8e5a2e5116baf191, 0xc3241cf0094a8e70, // x 2^-2604 ~= 10^-784
-  0x6023c8fa17d7b105, 0x069cf8f51d2e5e65, 0xb0560c246f90e9e8, 0xc6f631e782d57096, // x 2^-2418 ~= 10^-728
-  0x92c17acb2d08d5fd, 0xc26ffb8e81532725, 0x2ffff1289a804c5a, 0xcadb6d313c8736fc, // x 2^-2232 ~= 10^-672
-  0x47df78ab9e92897a, 0xc02b302a892b81dc, 0xa855e127113c887b, 0xced42ec885d9dbbe, // x 2^-2046 ~= 10^-616
-  0xdaf2dec03ec0c322, 0x72db3bc15b0c7014, 0xe00bad8dfc0d8c8e, 0xd2e0d889c213fd60, // x 2^-1860 ~= 10^-560
-  0xd3a04799e4473ac8, 0xa116409a2fdf1e9e, 0xc654d07271e6c39f, 0xd701ce3bd387bf47, // x 2^-1674 ~= 10^-504
-  0x5c8a5dc65d745a24, 0x2726c48a85389fa7, 0x84c663cee6b86e7c, 0xdb377599b6074244, // x 2^-1488 ~= 10^-448
-  0xd7ebc61ba77a9e66, 0x8bf77d4bc59b35b1, 0xcb285ceb2fed040d, 0xdf82365c497b5453, // x 2^-1302 ~= 10^-392
-  0x744ce999bfed213a, 0x363b1f2c568dc3e2, 0xfd1b1b2308169b25, 0xe3e27a444d8d98b7, // x 2^-1116 ~= 10^-336
-  0x6a40608fe10de7e7, 0xf910f9f648232f14, 0xd1b3400f8f9cff68, 0xe858ad248f5c22c9, // x 2^-930 ~= 10^-280
-  0x9bdbfc21260dd1ad, 0x4609ac5c7899ca36, 0xa4f8bf5635246428, 0xece53cec4a314ebd, // x 2^-744 ~= 10^-224
-  0xd88181aad19d7454, 0xf80f36174730ca34, 0xdc44e6c3cb279ac1, 0xf18899b1bc3f8ca1, // x 2^-558 ~= 10^-168
-  0xee19bfa6947f8e02, 0xaa09501d5954a559, 0x4d4617b5ff4a16d5, 0xf64335bcf065d37d, // x 2^-372 ~= 10^-112
-  0xebbc75a03b4d60e6, 0xac2e4f162cfad40a, 0xeed6e2f0f0d56712, 0xfb158592be068d2e, // x 2^-186 ~= 10^-56
+// Total table size: 512 + 384 = 896 bytes 
+
+// Table size: 512 bytes
+fileprivate let powersOf10_Binary128_Medium: _InlineArray<_, UInt64> = [
   0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x8000000000000000, // x 2^1 == 10^0 exactly
   0x0000000000000000, 0x2000000000000000, 0xbff8f10e7a8921a4, 0x82818f1281ed449f, // x 2^187 == 10^56 exactly
   0x51775f71e92bf2f2, 0x74a7ef0198791097, 0x03e2cf6bc604ddb0, 0x850fadc09923329e, // x 2^373 ~= 10^112
@@ -2471,113 +2219,20 @@ fileprivate let powersOf10_Binary128: _InlineArray<_, UInt64> = [
   0xf065089401df33b4, 0x1fc02370c451a755, 0x44b222741eb1ebbf, 0xa4b1ec80f47c84ad, // x 2^2419 ~= 10^728
   0xa62d0da836fce7d5, 0x75933380ceb5048c, 0x1cf4a5c3bc09fa6f, 0xa7eb6799e8aec999, // x 2^2605 ~= 10^784
   0x7a400df820f096c2, 0x802c4085068d2dd5, 0x3c4a575151b294dc, 0xab350c27feb90acc, // x 2^2791 ~= 10^840
-  0xf48b51375df06e86, 0x412fe9e72afd355e, 0x870a8d87239d8f35, 0xae8f2b2ce3d5dbe9, // x 2^2977 ~= 10^896
-  0x881883521930127c, 0xe53fd3fcb5b4df25, 0xdd929f09c3eff5ac, 0xb1fa17404a30e5e8, // x 2^3163 ~= 10^952
-  0x270cd9f1348eb326, 0x37ed82fe9c75fccf, 0x1931b583a9431d7e, 0xb5762497dbf17a9e, // x 2^3349 ~= 10^1008
-  0x8919b01a5b3d9ec1, 0x6a7669bdfc6f699c, 0xe30db03e0f8dd286, 0xb903a90f561d25e2, // x 2^3535 ~= 10^1064
-  0xf0461526b4201aa5, 0x7fe40defe17e55f5, 0x9eb5cb19647508c5, 0xbca2fc30cc19f090, // x 2^3721 ~= 10^1120
-  0xd67bf35422978bbf, 0x0dbb1c416ebe661f, 0x24bd4c00042ad125, 0xc054773d149bf26b, // x 2^3907 ~= 10^1176
-  0xdd093192ef5508d0, 0x6eac3085943ccc0f, 0x7ea30dbd7ea479e3, 0xc418753460cdcca9, // x 2^4093 ~= 10^1232
-  0xfe4ff20db6d25dc2, 0x5d5d5a9519e34a42, 0x764f4cf916b4dece, 0xc7ef52defe87b751, // x 2^4279 ~= 10^1288
-  0xd8adfb2e00494c5e, 0x72435286baf0e84e, 0xbeb7fbdc1cbe8b37, 0xcbd96ed6466cf081, // x 2^4465 ~= 10^1344
-  0xe07c1e4384f594af, 0x0c6b90b8874d5189, 0xdce472c619aa3f63, 0xcfd7298db6cb9672, // x 2^4651 ~= 10^1400
-  0x5dd902c68fa448cf, 0xea8d16bd9544e48e, 0xe47defc14a406e4f, 0xd3e8e55c3c1f43d0, // x 2^4837 ~= 10^1456
-  0x1223d79357bedca8, 0xeae6c2843752ac35, 0xb7157c60a24a0569, 0xd80f0685a81b2a81, // x 2^5023 ~= 10^1512
-  0xcff72d64bc79e429, 0xccc52c236decd778, 0xfb0b98f6bbc4f0cb, 0xdc49f3445824e360, // x 2^5209 ~= 10^1568
-  0x3731f76b905dffbb, 0x5e2bddd7d12a9e42, 0xc6c6c1764e047e15, 0xe09a13d30c2dba62, // x 2^5395 ~= 10^1624
-  0xeb58d8ef2ada7c09, 0xbc1a3b726b789947, 0x87e8dcfc09dbc33a, 0xe4ffd276eedce658, // x 2^5581 ~= 10^1680
-  0x249a5c06dc5d5db7, 0xa8f09440be97bfe6, 0xb1a3642a8da3cf4f, 0xe97b9b89d001dab3, // x 2^5767 ~= 10^1736
-  0xbf34ff7963028cd9, 0xc20578fa3851488b, 0x2d4070f33b21ab7b, 0xee0ddd84924ab88c, // x 2^5953 ~= 10^1792
-  0x002d0511317361d5, 0xd6919e041129a1a7, 0xa2bf0c63a814e04e, 0xf2b70909cd3fd35c, // x 2^6139 ~= 10^1848
-  0x1fa87f28acf1dcd2, 0xe7a0a88981d1a0f9, 0x08f13995cf9c2747, 0xf77790f0a48a45ce, // x 2^6325 ~= 10^1904
-  0x1b6ff8afbe589b72, 0xc851bb3f9aeb1211, 0x7a37993eb21444fa, 0xfc4fea4fd590b40a, // x 2^6511 ~= 10^1960
-  0xef23a4cbc039f0c2, 0xbb3f8498a972f18e, 0xb7b1ada9cdeba84d, 0x80a046447e3d49f1, // x 2^6698 ~= 10^2016
-  0x2cc44f2b602b6231, 0xf231f4b7996b7278, 0x0cc6866c5d69b2cb, 0x8324f8aa08d7d411, // x 2^6884 ~= 10^2072
-  0x822c97629a3a4c69, 0x8a9afcdbc940e6f9, 0x7fe2b4308dcbf1a3, 0x85b64a659077660e, // x 2^7070 ~= 10^2128
-  0xf66cfcf42d4896b0, 0x1f11852a20ed33c5, 0x1d73ef3eaac3c964, 0x88547abb1d8e5bd9, // x 2^7256 ~= 10^2184
-  0x63093ad0caadb06c, 0x31be1482014cdaf0, 0x1e34291b1ef566c7, 0x8affca2bd1f88549, // x 2^7442 ~= 10^2240
-  0xab50f69048738e9a, 0xa126c32ff4882be8, 0x9e9383d73d486881, 0x8db87a7c1e56d873, // x 2^7628 ~= 10^2296
-  0xe57e659432b0a73e, 0x47a0e15dfc7986b8, 0x9cc5ee51962c011a, 0x907eceba168949b3, // x 2^7814 ~= 10^2352
-  0x8a6ff950599f8ae5, 0xd1cbbb7d005a76d3, 0x413407cfeeac9743, 0x93530b43e5e2c129, // x 2^8000 ~= 10^2408
-  0xd4e6b6e847550caa, 0x56a3106227b87706, 0x7efa7d29c44e11b7, 0x963575ce63b6332d, // x 2^8186 ~= 10^2464
-  0xd835c90b09842263, 0xb69f01a641da2a42, 0x5a848859645d1c6f, 0x9926556bc8defe43, // x 2^8372 ~= 10^2520
-  0x9b0ae73c204ecd61, 0x0794fd5e5a51ac2f, 0x51edea897b34601f, 0x9c25f29286e9ddb6, // x 2^8558 ~= 10^2576
-  0x3130484fb0a61d89, 0x32b7105223a27365, 0xb50008d92529e91f, 0x9f3497244186fca4, // x 2^8744 ~= 10^2632
-  0x8cd036553f38a1e8, 0x5e997e9f45d7897d, 0xf09e780bcc8238d9, 0xa2528e74eaf101fc, // x 2^8930 ~= 10^2688
-  0xe1f8b43b08b5d0ef, 0xa0eaf3f62dc1777c, 0x3a5828869701a165, 0xa580255203f84b47, // x 2^9116 ~= 10^2744
-  0x3c7f62e3154fa708, 0x5786f3927eb15bd5, 0x8b231a70eb5444ce, 0xa8bdaa0a0064fa44, // x 2^9302 ~= 10^2800
-  0x1ebc24a19cd70a2a, 0x843fddd10c7006b8, 0xfa1bde1f473556a4, 0xac0b6c73d065f8cc, // x 2^9488 ~= 10^2856
-  0x46b6aae34cfd26fc, 0x00db7d919b136c68, 0x7730e00421da4d55, 0xaf69bdf68fc6a740, // x 2^9674 ~= 10^2912
-  0x1c4edcb83fc4c49d, 0x61c0edd56bbcb3e8, 0x7f959cb702329d14, 0xb2d8f1915ba88ca5, // x 2^9860 ~= 10^2968
-  0x428c840d247382fe, 0x9cc3b1569b1325a4, 0x40c3a071220f5567, 0xb6595be34f821493, // x 2^10046 ~= 10^3024
-  0xbeb82e734787ec63, 0xbeff12280d5a1676, 0x11c48d02b8326bd3, 0xb9eb5333aa272e9b, // x 2^10232 ~= 10^3080
-  0x302349e12f45c73f, 0xb494bcc96d53e49c, 0x566765461bd2f61b, 0xbd8f2f7a1ba47d6d, // x 2^10418 ~= 10^3136
-  0x5704ebf5f16946ce, 0x431388ec68ac7a26, 0xb889018e4f6e9a52, 0xc1454a673cb9b1ce, // x 2^10604 ~= 10^3192
-  0x5a30431166af9b23, 0x132d031fc1d1fec0, 0xf85333a94848659f, 0xc50dff6d30c3aefc, // x 2^10790 ~= 10^3248
-  0x7573d4b3ffe4ba3b, 0xf888498a40220657, 0x1a1aeae7cf8a9d3d, 0xc8e9abc872eb2bc1, // x 2^10976 ~= 10^3304
-  0xb5eaef7441511eb9, 0xc9cf998035a91664, 0x12e29f09d9061609, 0xccd8ae88cf70ad84, // x 2^11162 ~= 10^3360
-  0x73aed4f1908f4d01, 0x8c53e7beeca4578f, 0xdf7601457ca20b35, 0xd0db689a89f2f9b1, // x 2^11348 ~= 10^3416
-  0x5adbd55696e1cdd9, 0x4949d09424b87626, 0xcbdcd02f23cc7690, 0xd4f23ccfb1916df5, // x 2^11534 ~= 10^3472
-  0x3f500ccf4ea03593, 0x9b80aac81b50762a, 0x44289dd21b589d7a, 0xd91d8fe9a3d019cc, // x 2^11720 ~= 10^3528
-  0x134ca67a679b84ae, 0x8909e424a112a3cd, 0x95aa118ec1d08317, 0xdd5dc8a2bf27f3f7, // x 2^11906 ~= 10^3584
-  0xe89e3cf733d9ff40, 0x014344660a175c36, 0x72c4d2cad73b0a7b, 0xe1b34fb846321d04, // x 2^12092 ~= 10^3640
-  0x68c0a2c6c02dae9a, 0x0b11160a6edb5f57, 0xe20a88f1134f906d, 0xe61e8ff47461cda9, // x 2^12278 ~= 10^3696
-  0x47fa54906741561a, 0xaa13acba1e5511f5, 0xc7c91d5c341ed39d, 0xea9ff638c54554e1, // x 2^12464 ~= 10^3752
-  0x365460ed91271c24, 0xabe33496aff629b4, 0xf659ede2159a45ec, 0xef37f1886f4b6690, // x 2^12650 ~= 10^3808
-  0xe4cbf4acc7fba37f, 0x350e915f7055b1b8, 0x78d946bab954b82f, 0xf3e6f313130ef0ef, // x 2^12836 ~= 10^3864
-  0xe692accdfa5bd859, 0xf4d4d3202379829e, 0xc9b1474d8f89c269, 0xf8ad6e3fa030bd15, // x 2^13022 ~= 10^3920
-  0xeca0018ea3b8d1b4, 0xe878edb67072c26d, 0x6b1d2745340e7b14, 0xfd8bd8b770cb469e, // x 2^13208 ~= 10^3976
-  0xce5fec949ab87cf7, 0x0151dcd7a53488c3, 0xf22e502fcdd4bca2, 0x81415538ce493bd5, // x 2^13395 ~= 10^4032
-  0x5e1731fbff8c032e, 0xe752f53c2f8fa6c1, 0x7c1735fc3b813c8c, 0x83c92edf425b292d, // x 2^13581 ~= 10^4088
-  0xb552102ea83f47e6, 0xdf0fd2002ff6b3a3, 0x0367500a8e9a178f, 0x865db7a9ccd2839e, // x 2^13767 ~= 10^4144
-  0x76507bafe00ec873, 0x71b256ecd954434c, 0xc9ac50475e25293a, 0x88ff2f2bade74531, // x 2^13953 ~= 10^4200
-  0x5e2075ba289a360b, 0xac376f28b45e5acc, 0x0879b2e5f6ee8b1c, 0x8badd636cc48b341, // x 2^14139 ~= 10^4256
-  0xab87d85e6311e801, 0xb7f786d14d58173d, 0x2f33c652bd12fab7, 0x8e69eee1f23f2be5, // x 2^14325 ~= 10^4312
-  0x7fed9b68d77255be, 0x35dc241819de7182, 0xad6a6308a8e8b557, 0x9133bc8f2a130fe5, // x 2^14511 ~= 10^4368
-  0x728ae72899d4bd12, 0xe5413d9414142a55, 0x9dbaa465efe141a0, 0x940b83f23a55842a, // x 2^14697 ~= 10^4424
-  0x0f7740145246fb8f, 0x186ef2c39acb4103, 0x888c9ab2fc5b3437, 0x96f18b1742aad751, // x 2^14883 ~= 10^4480
-  0xd8bb0fba2183c6ef, 0xbf66d66cc34f0197, 0xba00864671d1053f, 0x99e6196979b978f1, // x 2^15069 ~= 10^4536
-  0x9b71ed2ceb790e49, 0x6faac32d59cc1f5d, 0x61d59d402aae4fea, 0x9ce977ba0ce3a0bd, // x 2^15255 ~= 10^4592
-  0xa0aa6d5e63991cfb, 0x19482fa0ac45669c, 0x803c1cd864033781, 0x9ffbf04722750449, // x 2^15441 ~= 10^4648
-  0x95a9949e04b8bff3, 0x900aa3c2f02ac9d4, 0xa28a151725a55e10, 0xa31dcec2fef14b30, // x 2^15627 ~= 10^4704
-  0x3acf9496dade0ce9, 0xbd8ecf923d23bec0, 0x5b8452af2302fe13, 0xa64f605b4e3352cd, // x 2^15813 ~= 10^4760
-  0x6204425d2b58e822, 0xdee162a8a1248550, 0x82b84cabc828bf93, 0xa990f3c09110c544, // x 2^15999 ~= 10^4816
-  0x091a2658e0639f32, 0x66fa2184cee0b861, 0x8d29dd5122e4278d, 0xace2d92db0390b59, // x 2^16185 ~= 10^4872
-  0x80acda113324758a, 0xded179c26d9ab828, 0x58f8fde02c03a6c6, 0xb045626fb50a35e7, // x 2^16371 ~= 10^4928
-  0x7128a8aad239ce8f, 0x8737bd250290cd5b, 0xd950102978dbd0ff, 0xb3b8e2eda91a232d, // x 2^16557 ~= 10^4984
 ]
 
-fileprivate func _intervalContainingPowerOf10_Binary128(
-  p: Int,
-  lower: inout _UInt256,
-  upper: inout _UInt256
-) -> Int {
-  if p >= 0 && p <= 55 {
-    let exactLow = powersOf10_Exact128[p * 2]
-    let exactHigh = powersOf10_Exact128[p * 2 + 1]
-    lower = _UInt256(high: exactHigh, exactLow, 0, low: 0)
-    upper = lower
-    return binaryExponentFor10ToThe(p)
-  }
-
-  let index = p + 4984
-  let offset = (index / 56) * 4
-  lower = _UInt256(
-    high: powersOf10_Binary128[offset + 3],
-    powersOf10_Binary128[offset + 2],
-    powersOf10_Binary128[offset + 1],
-    low: powersOf10_Binary128[offset + 0])
-  let extraPower = index % 56
-  var e = binaryExponentFor10ToThe(p - extraPower)
-
-  if extraPower > 0 {
-    let extra = _UInt128(
-      _low: powersOf10_Exact128[extraPower * 2],
-      _high: powersOf10_Exact128[extraPower * 2 + 1])
-    lower.multiplyRoundingDown(by: extra)
-    e += binaryExponentFor10ToThe(extraPower)
-  }
-  upper = lower
-  upper.low += 2
-  return e
-}
+// Table size: 12 * 32 = 384 bytes
+fileprivate let powersOf10_Binary128_Coarse: _InlineArray<_, UInt64> = [
+  0x9f855c9864e639d5, 0x257261546827afab, 0xeddb8bd5b1dd7ed8, 0x9f2f658cea3b24bc, // x 2^-17858 ~= 10^-5376
+  0xdadd9645f360cb51, 0xf290163350ecb3eb, 0xa8edffdccfe4db4b, 0xd9167ab0c1965798, // x 2^-14882 ~= 10^-4480
+  0x982b64e953ac4e27, 0x45efb05f20cf48b3, 0x4b4de34e0ebc3e06, 0x9406af8f83fd6265, // x 2^-11905 ~= 10^-3584
+  0x42032f9f971bfc07, 0x9fb576046ab35018, 0x474b3cb1fe1d6a7f, 0xc9dea80d6283a34c, // x 2^-8929 ~= 10^-2688
+  0xb62593291c768919, 0xc098e6ed0bfbd6f6, 0x6c83ad1260ff20f4, 0x89a63ba4c497b50e, // x 2^-5952 ~= 10^-1792
+  0x276e3f0f67f0553b, 0x00de73d9d5be6974, 0x6d4aa5b50bb5dc0d, 0xbbb7ef38bb827f2d, // x 2^-2976 ~= 10^-896
+  0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x8000000000000000, // x 2^1 == 10^0 exactly
+  0xf48b51375df06e86, 0x412fe9e72afd355e, 0x870a8d87239d8f35, 0xae8f2b2ce3d5dbe9, // x 2^2977 ~= 10^896
+  0xbf34ff7963028cd9, 0xc20578fa3851488b, 0x2d4070f33b21ab7b, 0xee0ddd84924ab88c, // x 2^5953 ~= 10^1792
+  0x8cd036553f38a1e8, 0x5e997e9f45d7897d, 0xf09e780bcc8238d9, 0xa2528e74eaf101fc, // x 2^8930 ~= 10^2688
+  0x134ca67a679b84ae, 0x8909e424a112a3cd, 0x95aa118ec1d08317, 0xdd5dc8a2bf27f3f7, // x 2^11906 ~= 10^3584
+  0x0f7740145246fb8f, 0x186ef2c39acb4103, 0x888c9ab2fc5b3437, 0x96f18b1742aad751, // x 2^14883 ~= 10^4480
+]

--- a/stdlib/public/core/FloatingPointToString.swift
+++ b/stdlib/public/core/FloatingPointToString.swift
@@ -223,7 +223,7 @@ internal func _Float16ToASCII(
 ) -> Range<Int> {
   // We need a MutableRawSpan in order to use wide store/load operations
   assert(utf8Buffer.count >= 24)
-  var buffer = unsafe utf8Buffer.mutableBytes
+  var buffer = utf8Buffer.mutableBytes
 
   let significandBitCount = Float16.significandBitCount + 1 // 11
   let exponentBias = Int(bitPattern: Float16._exponentBias) - 1 + significandBitCount // 14 + 11 = 25
@@ -438,7 +438,7 @@ internal func _Float32ToASCII(
 ) -> Range<Int> {
   // We need a MutableRawSpan in order to use wide store/load operations
   assert(utf8Buffer.count >= 24)
-  var buffer = unsafe utf8Buffer.mutableBytes
+  var buffer = utf8Buffer.mutableBytes
 
   let significandBitCount = Float.significandBitCount + 1 // 24
   let exponentBias = Int(bitPattern: Float32._exponentBias) - 1 + significandBitCount // 126 + 24
@@ -722,7 +722,7 @@ internal func _Float64ToASCII(
   buffer utf8Buffer: inout MutableSpan<UTF8.CodeUnit>
 ) -> Range<Int> {
   assert(utf8Buffer.count >= 32)
-  var buffer = unsafe utf8Buffer.mutableBytes
+  var buffer = utf8Buffer.mutableBytes
 
   let significandBitCount = Double.significandBitCount + 1 // 53
   let exponentBias = Int(bitPattern: Float64._exponentBias) - 1 + significandBitCount
@@ -928,7 +928,7 @@ internal func _Float80ToASCII(
   buffer utf8Buffer: inout MutableSpan<UTF8.CodeUnit>
 ) -> Range<Int> {
   assert(utf8Buffer.count >= 40)
-  var buffer = unsafe utf8Buffer.mutableBytes
+  var buffer = utf8Buffer.mutableBytes
 
   // Step 1: Handle special cases, decompose the input
 
@@ -1027,7 +1027,7 @@ internal func _Float128ToASCII(
   buffer utf8Buffer: inout MutableSpan<UTF8.CodeUnit>
 ) -> Range<Int> {
   assert(utf8Buffer.count >= 64)
-  var buffer = unsafe utf8Buffer.mutableBytes
+  var buffer = utf8Buffer.mutableBytes
 
   let significandBitCount = Float128.significandBitCount + 1 // 113
   let exponentBias = Int(bitPattern: Float128._exponentBias) - 1 + significandBitCount // 16382 + 113
@@ -1090,7 +1090,7 @@ fileprivate func _Float128Backend(
   significand: _UInt128,
   sign: FloatingPointSign
 ) -> Range<Int> {
-  var buffer = unsafe utf8Buffer.mutableBytes
+  var buffer = utf8Buffer.mutableBytes
 
   // Step 2: Compute the base 10 exponent to match the rounding interval
 

--- a/stdlib/public/core/FloatingPointTypes.swift.gyb
+++ b/stdlib/public/core/FloatingPointTypes.swift.gyb
@@ -118,7 +118,11 @@ extension ${Self}: CustomDebugStringConvertible {
   /// This property has the same value as the `description` property, except
   /// that NaN values are printed in an extended format.
   public var debugDescription: String {
+    %if bits > 64:
     var buffer = _InlineArray<64, UTF8.CodeUnit>(repeating: 0x30)
+    %else:
+    var buffer = _InlineArray<32, UTF8.CodeUnit>(repeating: 0x30)
+    %end
     var span = buffer.mutableSpan
     let textRange = _Float${bits}ToASCII(value: self, buffer: &span)
     let textStart = unsafe span._start().assumingMemoryBound(to: UTF8.CodeUnit.self) + textRange.lowerBound

--- a/stdlib/public/core/Int128.swift
+++ b/stdlib/public/core/Int128.swift
@@ -15,7 +15,7 @@
 /// A 128-bit signed integer value type.
 @available(SwiftStdlib 6.0, *)
 @frozen
-public struct Int128: Sendable {
+public struct Int128: Sendable, BitwiseCopyable {
 #if _pointerBitWidth(_64) || arch(arm64_32)
   //  On 64-bit platforms (including arm64_32 and any similar targets with
   //  32b pointers but HW-backed 64b integers), the layout is simply that

--- a/stdlib/public/core/UInt128.swift
+++ b/stdlib/public/core/UInt128.swift
@@ -15,7 +15,7 @@
 /// A 128-bit unsigned integer value type.
 @available(SwiftStdlib 6.0, *)
 @frozen
-public struct UInt128: Sendable {
+public struct UInt128: Sendable, BitwiseCopyable {
 #if _pointerBitWidth(_64) || arch(arm64_32)
   //  On 64-bit platforms (including arm64_32 and any similar targets with
   //  32b pointers but HW-backed 64b integers), the layout is simply that

--- a/stdlib/public/stubs/Stubs.cpp
+++ b/stdlib/public/stubs/Stubs.cpp
@@ -43,16 +43,6 @@
 #include <sstream>
 #endif
 
-#if SWIFT_STDLIB_HAS_LOCALE
-#include <clocale>
-#if __has_include(<xlocale.h>)
-#include <xlocale.h>
-#endif
-#if defined(_WIN32)
-#define locale_t _locale_t
-#endif
-#endif // SWIFT_STDLIB_HAS_LOCALE
-
 #include <limits>
 #ifndef SWIFT_THREADING_NONE
 #include <thread>
@@ -72,40 +62,6 @@
 #include "swift/shims/RuntimeStubs.h"
 
 #include "llvm/ADT/StringExtras.h"
-
-#if SWIFT_STDLIB_HAS_LOCALE
-#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__ANDROID__)
-static inline locale_t getCLocale() {
-  // On these platforms convenience functions from xlocale.h interpret nullptr
-  // as C locale.
-  return nullptr;
-}
-#elif defined(_WIN32)
-static _locale_t makeCLocale() {
-  _locale_t CLocale = _create_locale(LC_ALL, "C");
-  if (!CLocale) {
-    swift::crash("makeCLocale: _create_locale() returned a null pointer");
-  }
-  return CLocale;
-}
-
-static _locale_t getCLocale() {
-  return SWIFT_LAZY_CONSTANT(makeCLocale());
-}
-#else
-static locale_t makeCLocale() {
-  locale_t CLocale = newlocale(LC_ALL_MASK, "C", nullptr);
-  if (!CLocale) {
-    swift::crash("makeCLocale: newlocale() returned a null pointer");
-  }
-  return CLocale;
-}
-
-static locale_t getCLocale() {
-  return SWIFT_LAZY_CONSTANT(makeCLocale());
-}
-#endif
-#endif // SWIFT_STDLIB_HAS_LOCALE
 
 #if SWIFT_STDLIB_HAS_STDIN
 
@@ -173,52 +129,6 @@ swift_stdlib_readLine_stdin(unsigned char **LinePtr) {
 }
 
 #endif  // SWIFT_STDLIB_HAS_STDIN
-
-static bool swift_stringIsSignalingNaN(const char *nptr) {
-  if (nptr[0] == '+' || nptr[0] == '-') {
-    ++nptr;
-  }
-
-  if ((nptr[0] == 's' || nptr[0] == 'S') &&
-      (nptr[1] == 'n' || nptr[1] == 'N') &&
-      (nptr[2] == 'a' || nptr[2] == 'A') &&
-      (nptr[3] == 'n' || nptr[3] == 'N') && (nptr[4] == '\0')) {
-    return true;
-  }
-
-  return false;
-}
-
-#if defined(__CYGWIN__) || defined(__HAIKU__)
-// This implementation should only be used on platforms without the
-// relevant strto* functions, such as Cygwin or Haiku.
-// Note that using this currently causes test failures.
-template <typename T>
-T _swift_strto(const char *nptr, char **endptr) {
-  std::istringstream ValueStream(nptr);
-  ValueStream.imbue(std::locale::classic());
-  T ParsedValue;
-  ValueStream >> ParsedValue;
-
-  std::streamoff pos = ValueStream.tellg();
-  if (ValueStream.eof())
-    pos = static_cast<std::streamoff>(strlen(nptr));
-  if (pos <= 0) {
-    errno = ERANGE;
-    return 0.0;
-  }
-
-  return ParsedValue;
-}
-#endif
-
-static inline void _swift_set_errno(int to) {
-#if defined(_WIN32)
-  _set_errno(0);
-#else
-  errno = 0;
-#endif
-}
 
 // _swift_stdlib_strto{d,f,f16}_clocale were reimplemented in Swift
 // in December 2025.  See FloatingPointFromString.swift.

--- a/stdlib/public/stubs/Stubs.cpp
+++ b/stdlib/public/stubs/Stubs.cpp
@@ -212,74 +212,6 @@ T _swift_strto(const char *nptr, char **endptr) {
 }
 #endif
 
-#if SWIFT_STDLIB_HAS_LOCALE
-
-#if defined(__OpenBSD__) || defined(_WIN32) || defined(__CYGWIN__) || defined(__HAIKU__)
-#define NEED_SWIFT_STRTOD_L
-#define strtod_l swift_strtod_l
-#define NEED_SWIFT_STRTOF_L
-#define strtof_l swift_strtof_l
-#define NEED_SWIFT_STRTOLD_L
-#define strtold_l swift_strtold_l
-#elif defined(__ANDROID__)
-#if __ANDROID_API__ < 21 // Introduced in Android API 21 - L
-#define NEED_SWIFT_STRTOLD_L
-#define strtold_l swift_strtold_l
-#endif
-
-#if __ANDROID_API__ < 26 // Introduced in Android API 26 - O
-#define NEED_SWIFT_STRTOD_L
-#define strtod_l swift_strtod_l
-#define NEED_SWIFT_STRTOF_L
-#define strtof_l swift_strtof_l
-#endif
-#endif
-
-#endif // SWIFT_STDLIB_HAS_LOCALE
-
-#if defined(NEED_SWIFT_STRTOD_L)
-static double swift_strtod_l(const char *nptr, char **endptr, locale_t loc) {
-#if defined(_WIN32)
-  return _strtod_l(nptr, endptr, getCLocale());
-#elif defined(__CYGWIN__) || defined(__HAIKU__)
-  return _swift_strto<double>(nptr, endptr);
-#else
-  return strtod(nptr, endptr);
-#endif
-}
-#endif
-
-#if defined(NEED_SWIFT_STRTOF_L)
-static float swift_strtof_l(const char *nptr, char **endptr, locale_t loc) {
-#if defined(_WIN32)
-  return _strtof_l(nptr, endptr, getCLocale());
-#elif defined(__CYGWIN__) || defined(__HAIKU__)
-  return _swift_strto<float>(nptr, endptr);
-#else
-  return strtof(nptr, endptr);
-#endif
-}
-#endif
-
-#if defined(NEED_SWIFT_STRTOLD_L)
-static long double swift_strtold_l(const char *nptr, char **endptr,
-                                   locale_t loc) {
-#if defined(_WIN32)
-  return _strtod_l(nptr, endptr, getCLocale());
-#elif defined(__ANDROID__)
-  return strtod(nptr, endptr);
-#elif defined(__CYGWIN__) || defined(__HAIKU__)
-  return _swift_strto<long double>(nptr, endptr);
-#else
-  return strtold(nptr, endptr);
-#endif
-}
-#endif
-
-#undef NEED_SWIFT_STRTOD_L
-#undef NEED_SWIFT_STRTOF_L
-#undef NEED_SWIFT_STRTOLD_L
-
 static inline void _swift_set_errno(int to) {
 #if defined(_WIN32)
   _set_errno(0);
@@ -288,50 +220,9 @@ static inline void _swift_set_errno(int to) {
 #endif
 }
 
-// We can't return Float80, but we can receive a pointer to one, so
-// switch the return type and the out parameter on strtold.
-template <typename T>
-#if SWIFT_STDLIB_HAS_LOCALE
-static const char *_swift_stdlib_strtoX_clocale_impl(
-    const char *nptr, T *outResult, T huge,
-    T (*posixImpl)(const char *, char **, locale_t))
-#else
-static const char *_swift_stdlib_strtoX_impl(
-    const char *nptr, T *outResult,
-    T (*posixImpl)(const char *, char **))
-#endif
-{
-  if (swift_stringIsSignalingNaN(nptr)) {
-    // TODO: ensure that the returned sNaN bit pattern matches that of sNaNs
-    // produced by Swift.
-    *outResult = std::numeric_limits<T>::signaling_NaN();
-    return nptr + std::strlen(nptr);
-  }
-
-  char *EndPtr;
-  _swift_set_errno(0);
-#if SWIFT_STDLIB_HAS_LOCALE
-  const auto result = posixImpl(nptr, &EndPtr, getCLocale());
-#else
-  const auto result = posixImpl(nptr, &EndPtr);
-#endif
-  *outResult = result;
-  return EndPtr;
-}
-
-const char *_swift_stdlib_strtold_clocale(const char *nptr, void *outResult) {
-#if SWIFT_STDLIB_HAS_LOCALE
-  return _swift_stdlib_strtoX_clocale_impl(
-      nptr, static_cast<long double *>(outResult), HUGE_VALL, strtold_l);
-#else
-  return _swift_stdlib_strtoX_impl(
-      nptr, static_cast<long double *>(outResult), strtold);
-#endif
-}
-
 // _swift_stdlib_strto{d,f,f16}_clocale were reimplemented in Swift
 // in December 2025.  See FloatingPointFromString.swift.
-// _swift_stdlib_strtold_clocale was not reimplemented in Swift at that time.
+// _swift_stdlib_strtold_clocale was reimplemented in Swift in May 2026.
 
 void _swift_stdlib_flockfile_stdout() {
 #if defined(_WIN32)

--- a/test/stdlib/ParseFloat16.swift
+++ b/test/stdlib/ParseFloat16.swift
@@ -229,6 +229,11 @@ tests.test("Decimal Floats") {
   expectParse("1e0", 1.0)
   expectParse("3.7e1", 37.0)
   expectParse("12.34e3", 12336.0)
+  expectParse("12.348e3", 12352.0)  // midway 12344 (odd) / 12352 (even)
+  expectParse("-12.34e3", -12336.0) // midway, negative
+  expectParse("1024.5", 1024.0)     // midway 1024 (even) / 1025 (odd), neg. exp
+  expectParse("1025.5", 1026.0)     // midway 1025 (odd) / 1026 (even), neg. exp
+  expectParse("32784", 32768.0)     // midway 32768 (even) / 32800 (odd)
   expectParse("-00.0047e5", -470.0)
   expectParse("2e0", 2.0)
   expectParse("1e1", 10.0)


### PR DESCRIPTION
- **Explanation**:  Implements a new, faster `debugDescription` for floating-point types that uses a modified form of Rafaello Giulietti's Schubfach algorithm.  Also expands the Swift-based printing and parsing routines to fully support Float80.
- **Scope**: The new routines provide exactly the same API and behavior as the previous floating-point printing and parsing.  The addition of Float80 parsing support insulates us from OS-specific variations in `strtold` support.
- **Risk**: Modest.  The code has been well-tested, but there has been a history of 32-bit issues with previous work in this area.
- **Testing**: Existing unit tests all pass, including tests that verify that we're exporting the same internal endpoints.  In addition, correctness has been verified with an offline test suite.

I do not currently plan to cherry-pick this into 6.4, but will consider doing so if there's demand.

Notes:
* The core `_Float64ToASCII` function is about 1/2 the code+data of the previous implementation and also nearly 2x faster than before.  This means that `Double.debugDescription` now spends most of its time allocating memory for the returned `String`.
* The Float80 support for printing and parsing has enough extra precision to also support Float128 if we ever want to add that.