### PR TITLE
[DiagnosticVerifier] add -verify-child-notes

### DIFF
--- a/docs/Diagnostics.md
+++ b/docs/Diagnostics.md
@@ -213,3 +213,32 @@ An expected diagnostic is denoted by a comment which begins with `expected-error
   * If two (or more) expected fix-its are juxtaposed with nothing (or whitespace) between them, then both must be present for the verifier to match. If two (or more) expected fix-its have `||` between them, then one of them must be present for the verifier to match. `||` binds more tightly than juxtaposition: `{{1-1=a}} {{2-2=b}} || {{2-2=c}} {{3-3=d}} {{none}}` will only match if there is either a set of three fix-its that insert `a`, `b`, and `d`, or a set of three fix-its that insert `a`, `c`, and `d`. (Without the `{{none}}`, it would also permit all four fix-its, but only because one of the four would be unmatched and ignored.)
 
 - (Optional) Expected documentation file. These is the name of the documentation file, enclosed in double curly braces and prefixed by 'documentation-file='. For example, `{{documentation-file=some-file}}` will verify the documentation group with filename `some-note` appears. Do not include the file extension when specifying the name.
+
+- (Optional) Expected child notes. When `-verify-child-notes` is passed, notes that are attached to a parent diagnostic (child notes) must be matched inside a `{{children:}}` block on the parent's expectation comment. This makes it explicit which note belongs to which diagnostic.
+
+  The `{{children:}}` block appears after any fix-it or documentation-file matchers and contains one or more `expected-note` entries. Only notes are allowed inside a `{{children:}}` block.
+
+  ```swift
+  struct A {}
+  struct A {} // expected-error {{invalid redeclaration of 'A'}} {{children:
+              //   expected-note@-2 {{'A' previously declared here}}
+              // }}
+  ```
+
+  Child notes can also use line markers to reference notes far from the parent:
+
+  ```swift
+  struct B {} // #b-orig
+  struct B {} // expected-error {{invalid redeclaration of 'B'}} {{children:
+              //   expected-note@#b-orig {{'B' previously declared here}}
+              // }}
+  ```
+
+  Single-line syntax is also supported:
+
+  ```swift
+  struct C {}
+  struct C {} // expected-error {{invalid redeclaration of 'C'}} {{children: expected-note@-1 {{'C' previously declared here}} }}
+  ```
+
+  Without `-verify-child-notes`, child notes are matched as ordinary notes and `{{children:}}` blocks are not allowed.

--- a/include/swift/Basic/DiagnosticOptions.h
+++ b/include/swift/Basic/DiagnosticOptions.h
@@ -52,6 +52,9 @@ public:
   /// kind are not printed by \c PrintingDiagnosticConsumer.
   bool VerifyIgnoreMacroLocationNote = false;
 
+  /// If true, enforce that child notes are listed in {{children:}} blocks.
+  bool VerifyChildNotes = false;
+
   /// Indicates whether diagnostic passes should be skipped.
   bool SkipDiagnosticPasses = false;
 

--- a/include/swift/Frontend/DiagnosticVerifier.h
+++ b/include/swift/Frontend/DiagnosticVerifier.h
@@ -154,6 +154,10 @@ private:
   unsigned parseExpectedDiagInfo(unsigned BufferID, StringRef MatchStart,
                                  unsigned &PrevExpectedContinuationLine,
                                  ExpectedDiagnosticInfo &Expected);
+  void parseNestedExpectedDiagInfoBlock(unsigned BufferID,
+                                        StringRef MatchStartIn,
+                                        unsigned &PrevExpectedContinuationLine,
+                                        ExpectedDiagnosticInfo &Expected, size_t &End);
   void
   verifyDiagnostics(std::vector<ExpectedDiagnosticInfo> &ExpectedDiagnostics,
                     unsigned BufferID);

--- a/include/swift/Frontend/DiagnosticVerifier.h
+++ b/include/swift/Frontend/DiagnosticVerifier.h
@@ -21,6 +21,7 @@
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringMap.h"
+#include "llvm/Support/SourceMgr.h"
 #include "swift/AST/DiagnosticConsumer.h"
 #include "swift/Basic/LLVM.h"
 
@@ -78,18 +79,34 @@ struct CapturedDiagnosticInfo {
   unsigned Column;
   SmallVector<CapturedFixItInfo, 2> FixIts;
   std::string CategoryDocFile;
+  // Original index into CapturedDiagnostics. Allows identifying it even as
+  // elements get erased.
+  size_t ID;
+  // ID of the parent CapturedDiagnosticInfo, set for child notes when
+  // VerifyChildNotes is enabled.
+  std::optional<size_t> ParentID;
+  bool HasChildren;
 
   CapturedDiagnosticInfo(llvm::SmallString<128> Message,
                          std::optional<unsigned> SourceBufferID,
                          DiagnosticKind Classification, SourceLoc Loc,
                          unsigned Line, unsigned Column,
                          SmallVector<CapturedFixItInfo, 2> FixIts,
-                         const std::string &categoryDocFile)
+                         const std::string &categoryDocFile, size_t ID,
+                         std::optional<size_t> ParentIdx, bool HasChildren)
       : Message(Message), SourceBufferID(SourceBufferID),
         Classification(Classification), Loc(Loc), Line(Line), Column(Column),
-        FixIts(FixIts), CategoryDocFile(categoryDocFile) {
-  }
+        FixIts(FixIts), CategoryDocFile(categoryDocFile), ID(ID),
+        ParentID(ParentIdx), HasChildren(HasChildren) {}
 };
+
+struct SMDiagnosticWithNotes {
+  llvm::SMDiagnostic Diag;
+  llvm::SmallVector<llvm::SMDiagnostic, 1> Notes;
+  SMDiagnosticWithNotes(llvm::SMDiagnostic &&Diag) : Diag(Diag) {}
+  SMDiagnosticWithNotes(llvm::SMDiagnostic &Diag) : Diag(std::move(Diag)) {}
+};
+
 /// This class implements support for -verify mode in the compiler.  It
 /// buffers up diagnostics produced during compilation, then checks them
 /// against expected-error markers in the source file.
@@ -102,6 +119,7 @@ class DiagnosticVerifier : public DiagnosticConsumer {
   bool IgnoreUnknown;
   bool IgnoreUnrelated;
   bool IgnoreMacroLocationNote;
+  bool VerifyChildNotes;
   bool UseColor;
   ArrayRef<std::string> AdditionalExpectedPrefixes;
 
@@ -110,12 +128,14 @@ public:
                               ArrayRef<std::string> AdditionalFilePaths,
                               bool AutoApplyFixes, bool IgnoreUnknown,
                               bool IgnoreUnrelated,
-                              bool IgnoreMacroLocationNote, bool UseColor,
+                              bool IgnoreMacroLocationNote,
+                              bool VerifyChildNotes, bool UseColor,
                               ArrayRef<std::string> AdditionalExpectedPrefixes)
       : SM(SM), BufferIDs(BufferIDs), AdditionalFilePaths(AdditionalFilePaths),
         AutoApplyFixes(AutoApplyFixes), IgnoreUnknown(IgnoreUnknown),
         IgnoreUnrelated(IgnoreUnrelated),
-        IgnoreMacroLocationNote(IgnoreMacroLocationNote), UseColor(UseColor),
+        IgnoreMacroLocationNote(IgnoreMacroLocationNote),
+        VerifyChildNotes(VerifyChildNotes), UseColor(UseColor),
         AdditionalExpectedPrefixes(AdditionalExpectedPrefixes) {}
 
   virtual void handleDiagnostic(SourceManager &SM,
@@ -135,6 +155,7 @@ private:
   };
 
   void printDiagnostic(const llvm::SMDiagnostic &Diag) const;
+  void printDiagnostic(const SMDiagnosticWithNotes &Diag) const;
 
   /// Check whether there were any diagnostics in files without expected
   /// diagnostics
@@ -144,7 +165,7 @@ private:
   bool
   verifyUnknown(std::vector<CapturedDiagnosticInfo> &CapturedDiagnostics) const;
 
-  std::vector<llvm::SMDiagnostic> Errors;
+  std::vector<SMDiagnosticWithNotes> Errors;
 
   /// verifyFile - After the file has been processed, check to see if we
   /// got all of the expected diagnostics and check to see if there were any
@@ -154,17 +175,26 @@ private:
   unsigned parseExpectedDiagInfo(unsigned BufferID, StringRef MatchStart,
                                  unsigned &PrevExpectedContinuationLine,
                                  ExpectedDiagnosticInfo &Expected);
-  void parseNestedExpectedDiagInfoBlock(unsigned BufferID,
-                                        StringRef MatchStartIn,
-                                        unsigned &PrevExpectedContinuationLine,
-                                        ExpectedDiagnosticInfo &Expected, size_t &End);
+  void parseNestedExpectedDiagInfoBlock(
+      unsigned BufferID, StringRef MatchStartIn,
+      unsigned &PrevExpectedContinuationLine,
+      std::vector<ExpectedDiagnosticInfo> &NestedDiagsOut, size_t &End);
   void
   verifyDiagnostics(std::vector<ExpectedDiagnosticInfo> &ExpectedDiagnostics,
-                    unsigned BufferID);
+                    unsigned BufferID, std::optional<size_t> ParentID);
   void verifyRemaining(std::vector<ExpectedDiagnosticInfo> &ExpectedDiagnostics,
                        const char *FileStart);
   void addError(const char *Loc, const Twine &message,
                 ArrayRef<llvm::SMFixIt> FixIts = {});
+  /// Add a note to the last error added.
+  void addNote(const char *Loc, const Twine &message);
+
+  /// Emit an "unexpected diagnostic produced" error for \p DiagIter, erase
+  /// its child notes (if \c VerifyChildNotes), and erase the diagnostic
+  /// itself. Returns the iterator past the erased element.
+  std::vector<CapturedDiagnosticInfo>::iterator
+  reportAndEraseUnexpected(
+      std::vector<CapturedDiagnosticInfo>::iterator DiagIter);
 
   std::optional<LineColumnRange>
   parseExpectedFixItRange(StringRef &Str, unsigned DiagnosticLineNo);

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -186,6 +186,8 @@ def verify_ignore_unrelated: Flag<["-"], "verify-ignore-unrelated">,
   HelpText<"Allow diagnostics in files outside those with expected diagnostics in verify mode">;
 def verify_ignore_macro_note: Flag<["-"], "verify-ignore-macro-note">,
   HelpText<"Skip verifying notes about macro location">;
+def verify_child_notes: Flag<["-"], "verify-child-notes">,
+  HelpText<"Verify child notes in child diagnostics blocks">;
 def verify_generic_signatures : Separate<["-"], "verify-generic-signatures">,
   MetaVarName<"<module-name>">,
   HelpText<"Verify the generic signatures in the given module">;

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -2762,6 +2762,7 @@ static bool ParseDiagnosticArgs(DiagnosticOptions &Opts, ArgList &Args,
   Opts.VerifyIgnoreUnknown |= Args.hasArg(OPT_verify_ignore_unknown);
   Opts.VerifyIgnoreUnrelated |= Args.hasArg(OPT_verify_ignore_unrelated);
   Opts.VerifyIgnoreMacroLocationNote |= Args.hasArg(OPT_verify_ignore_macro_note);
+  Opts.VerifyChildNotes |= Args.hasArg(OPT_verify_child_notes);
   Opts.SkipDiagnosticPasses |= Args.hasArg(OPT_disable_diagnostic_passes);
   Opts.ShowDiagnosticsAfterFatalError |=
     Args.hasArg(OPT_show_diagnostics_after_fatal);

--- a/lib/Frontend/DiagnosticVerifier.cpp
+++ b/lib/Frontend/DiagnosticVerifier.cpp
@@ -724,6 +724,44 @@ bool DiagnosticVerifier::parseTargetBufferName(StringRef &MatchStart,
   return true;
 }
 
+void DiagnosticVerifier::parseNestedExpectedDiagInfoBlock(
+    unsigned BufferID, StringRef MatchStartIn,
+    unsigned &PrevExpectedContinuationLine, ExpectedDiagnosticInfo &Expected,
+    size_t &End) {
+  size_t NestedMatch = MatchStartIn.find("expected-");
+  // Scan the memory buffer looking for expected-note/warning/error.
+  while (NestedMatch != StringRef::npos) {
+    StringRef NestedMatchStartIn = MatchStartIn.substr(NestedMatch);
+    ExpectedDiagnosticInfo NestedExpected(nullptr, nullptr, nullptr,
+                                          DiagnosticKind(-1));
+    unsigned NestedCount =
+        parseExpectedDiagInfo(BufferID, NestedMatchStartIn,
+                              PrevExpectedContinuationLine, NestedExpected);
+
+    size_t PrevMatchEnd = NestedMatch + 1;
+    if (NestedCount > 0) {
+      // Add the diagnostic the expected number of times.
+      for (; NestedCount; --NestedCount)
+        Expected.NestedDiags.push_back(NestedExpected);
+      size_t NestedMatchEnd =
+          NestedExpected.ExpectedEnd - NestedMatchStartIn.data();
+      assert(NestedMatchEnd > 0);
+      PrevMatchEnd = NestedMatch + NestedMatchEnd;
+    } else {
+      // Skip line if this an expected diagnostic with a prefix this invocation
+      // ignores, otherwise its }} will close the expansion.
+      PrevMatchEnd = MatchStartIn.find("\n", PrevMatchEnd);
+    }
+
+    size_t NextEnd = MatchStartIn.find("}}", PrevMatchEnd);
+    NestedMatch = MatchStartIn.find("expected-", PrevMatchEnd);
+    if (NextEnd < NestedMatch) {
+      End = NextEnd;
+      break;
+    }
+  }
+}
+
 unsigned DiagnosticVerifier::parseExpectedDiagInfo(
     unsigned BufferID, StringRef MatchStartIn,
     unsigned &PrevExpectedContinuationLine,
@@ -889,43 +927,12 @@ unsigned DiagnosticVerifier::parseExpectedDiagInfo(
 
   size_t End = StringRef::npos;
   if (Expected.Classification == DiagnosticKindExpansion) {
-    size_t NestedMatch = MatchStart.find("expected-");
-    // Scan the memory buffer looking for expected-note/warning/error.
-    while (NestedMatch != StringRef::npos) {
-      StringRef NestedMatchStart = MatchStart.substr(NestedMatch);
-      ExpectedDiagnosticInfo NestedExpected(nullptr, nullptr, nullptr,
-                                      DiagnosticKind(-1));
-      unsigned NestedCount =
-          parseExpectedDiagInfo(BufferID, NestedMatchStart,
-                                PrevExpectedContinuationLine, NestedExpected);
-
-      size_t PrevMatchEnd = NestedMatch + 1;
-      if (NestedCount > 0) {
-        // Add the diagnostic the expected number of times.
-        for (; NestedCount; --NestedCount)
-          Expected.NestedDiags.push_back(NestedExpected);
-        size_t NestedMatchEnd =
-            NestedExpected.ExpectedEnd - NestedMatchStart.data();
-        assert(NestedMatchEnd > 0);
-        PrevMatchEnd = NestedMatch + NestedMatchEnd;
-      } else {
-        // Skip line if this an expected diagnostic with a prefix this invocation ignores,
-        // otherwise its }} will close the expansion.
-        PrevMatchEnd = MatchStart.find("\n", PrevMatchEnd);
-      }
-
-      size_t NextEnd = MatchStart.find("}}", PrevMatchEnd);
-      NestedMatch = MatchStart.find("expected-", PrevMatchEnd);
-      if (NextEnd < NestedMatch) {
-        End = NextEnd;
-        break;
-      }
-    }
+    parseNestedExpectedDiagInfoBlock(
+        BufferID, MatchStart, PrevExpectedContinuationLine, Expected, End);
 
     if (End == StringRef::npos) {
-      addError(
-          DiagnosticLoc,
-          "didn't find '}}' to match '{{' in expected-expansion");
+      addError(DiagnosticLoc,
+               "didn't find '}}' to match '{{' in expected-expansion");
       return 0;
     }
     if (Expected.NestedDiags.size() == 0) {

--- a/lib/Frontend/DiagnosticVerifier.cpp
+++ b/lib/Frontend/DiagnosticVerifier.cpp
@@ -15,6 +15,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "swift/Frontend/DiagnosticVerifier.h"
+#include "swift/AST/DiagnosticConsumer.h"
 #include "swift/AST/DiagnosticsFrontend.h"
 #include "swift/Basic/Assertions.h"
 #include "swift/Basic/ColorUtils.h"
@@ -27,6 +28,7 @@
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/raw_ostream.h"
+#include <optional>
 
 using namespace swift;
 
@@ -234,6 +236,13 @@ struct ExpectedDiagnosticInfo {
 
   std::vector<ExpectedDiagnosticInfo> NestedDiags = {};
 
+  std::vector<ExpectedDiagnosticInfo> ExpectedChildNotes = {};
+  // Locs of {{children: and }}
+  const char *ChildrenMarkerStartLoc = nullptr;
+  const char *ChildrenMarkerEndLoc = nullptr;
+  // This diagnostic has been matched, but contains unmatched child notes
+  bool HasBeenFound = false;
+
   ExpectedDiagnosticInfo(const char *ExpectedStart,
                          const char *ClassificationStart,
                          const char *ClassificationEnd,
@@ -259,6 +268,23 @@ static std::string getDiagKindString(DiagnosticKind Kind) {
   llvm_unreachable("Unhandled DiagKind in switch.");
 }
 
+[[deprecated("only for use in the debugger")]] LLVM_ATTRIBUTE_USED
+static llvm::raw_ostream &operator<<(llvm::raw_ostream &OS,
+                                     const CapturedDiagnosticInfo &D) {
+      OS << "[id=" << D.ID;
+  if (D.ParentID)
+    OS << " parent=" << *D.ParentID;
+  OS << " " << getDiagKindString(D.Classification);
+  OS << " " << D.Line << ":" << D.Column;
+  OS << " \"" << D.Message << "\"";
+  if (!D.FixIts.empty())
+    OS << " fixit-count=" << D.FixIts.size();
+  if (!D.CategoryDocFile.empty())
+    OS << " doc=" << D.CategoryDocFile;
+  OS << "]";
+  return OS;
+}
+
 /// Render the verifier syntax for a given documentation file.
 static std::string
 renderDocumentationFile(const std::string &documentationFile) {
@@ -274,7 +300,8 @@ renderDocumentationFile(const std::string &documentationFile) {
 /// Otherwise return \c CapturedDiagnostics.end() with \c false.
 static std::tuple<std::vector<CapturedDiagnosticInfo>::iterator, bool>
 findDiagnostic(std::vector<CapturedDiagnosticInfo> &CapturedDiagnostics,
-               const ExpectedDiagnosticInfo &Expected, unsigned BufferID, SourceManager &SM) {
+               const ExpectedDiagnosticInfo &Expected, unsigned BufferID,
+               SourceManager &SM, std::optional<size_t> ParentID) {
   auto fallbackI = CapturedDiagnostics.end();
 
   for (auto I = CapturedDiagnostics.begin(), E = CapturedDiagnostics.end();
@@ -290,6 +317,11 @@ findDiagnostic(std::vector<CapturedDiagnosticInfo> &CapturedDiagnostics,
     // Verify the classification and string.
     if (I->Message.find(Expected.MessageStr) == StringRef::npos)
       continue;
+
+    // Verify the parent.
+    if (ParentID && I->ParentID != ParentID) {
+      continue;
+    }
 
     // Verify the classification and, if incorrect, remember as a second choice.
     if (I->Classification != Expected.Classification) {
@@ -310,12 +342,12 @@ findDiagnostic(std::vector<CapturedDiagnosticInfo> &CapturedDiagnostics,
 /// and actual diagnostics produced), apply fixits to the original source
 /// file and drop it back in place.
 static void autoApplyFixes(SourceManager &SM, unsigned BufferID,
-                           ArrayRef<llvm::SMDiagnostic> diags) {
+                           ArrayRef<SMDiagnosticWithNotes> diags) {
   // Walk the list of diagnostics, pulling out any fixits into an array of just
   // them.
   SmallVector<llvm::SMFixIt, 4> FixIts;
   for (auto &diag : diags)
-    FixIts.append(diag.getFixIts().begin(), diag.getFixIts().end());
+    FixIts.append(diag.Diag.getFixIts().begin(), diag.Diag.getFixIts().end());
 
   // If we have no fixits to apply, avoid touching the file.
   if (FixIts.empty())
@@ -487,6 +519,12 @@ bool DiagnosticVerifier::checkForFixIt(
   }
 
   return false;
+}
+
+void DiagnosticVerifier::printDiagnostic(const SMDiagnosticWithNotes &Diag) const {
+  printDiagnostic(Diag.Diag);
+  for (const auto &Note : Diag.Notes)
+    printDiagnostic(Note);
 }
 
 void DiagnosticVerifier::printDiagnostic(const llvm::SMDiagnostic &Diag) const {
@@ -726,8 +764,8 @@ bool DiagnosticVerifier::parseTargetBufferName(StringRef &MatchStart,
 
 void DiagnosticVerifier::parseNestedExpectedDiagInfoBlock(
     unsigned BufferID, StringRef MatchStartIn,
-    unsigned &PrevExpectedContinuationLine, ExpectedDiagnosticInfo &Expected,
-    size_t &End) {
+    unsigned &PrevExpectedContinuationLine,
+    std::vector<ExpectedDiagnosticInfo> &NestedDiagsOut, size_t &End) {
   size_t NestedMatch = MatchStartIn.find("expected-");
   // Scan the memory buffer looking for expected-note/warning/error.
   while (NestedMatch != StringRef::npos) {
@@ -742,7 +780,7 @@ void DiagnosticVerifier::parseNestedExpectedDiagInfoBlock(
     if (NestedCount > 0) {
       // Add the diagnostic the expected number of times.
       for (; NestedCount; --NestedCount)
-        Expected.NestedDiags.push_back(NestedExpected);
+        NestedDiagsOut.push_back(NestedExpected);
       size_t NestedMatchEnd =
           NestedExpected.ExpectedEnd - NestedMatchStartIn.data();
       assert(NestedMatchEnd > 0);
@@ -927,8 +965,9 @@ unsigned DiagnosticVerifier::parseExpectedDiagInfo(
 
   size_t End = StringRef::npos;
   if (Expected.Classification == DiagnosticKindExpansion) {
-    parseNestedExpectedDiagInfoBlock(
-        BufferID, MatchStart, PrevExpectedContinuationLine, Expected, End);
+    parseNestedExpectedDiagInfoBlock(BufferID, MatchStart,
+                                     PrevExpectedContinuationLine,
+                                     Expected.NestedDiags, End);
 
     if (End == StringRef::npos) {
       addError(DiagnosticLoc,
@@ -976,7 +1015,8 @@ unsigned DiagnosticVerifier::parseExpectedDiagInfo(
   // Scan for fix-its: {{10-14=replacement text}}
   bool startNewAlternatives = true;
   StringRef ExtraChecks = MatchStart.substr(End + 2).ltrim(" \t");
-  while (ExtraChecks.starts_with("{{")) {
+  while (ExtraChecks.starts_with("{{") &&
+         !ExtraChecks.starts_with("{{children:")) {
     // First make sure we have a closing "}}".
     size_t EndIndex = ExtraChecks.find("}}");
     if (EndIndex == StringRef::npos) {
@@ -1110,6 +1150,45 @@ unsigned DiagnosticVerifier::parseExpectedDiagInfo(
     Expected.Fixits.back().push_back(FixIt);
   }
 
+  if (ExtraChecks.starts_with("{{children:")) {
+    Expected.ChildrenMarkerStartLoc = ExtraChecks.data();
+    ExtraChecks = ExtraChecks.substr(StringRef("{{children:").size());
+    parseNestedExpectedDiagInfoBlock(
+        BufferID, ExtraChecks, PrevExpectedContinuationLine, Expected.ExpectedChildNotes, End);
+
+    if (End == StringRef::npos) {
+      addError(Expected.ChildrenMarkerStartLoc,
+               "didn't find '}}' to match '{{children:'");
+      return 0;
+    }
+    Expected.ChildrenMarkerEndLoc = ExtraChecks.substr(End).data();
+
+    if (!VerifyChildNotes) {
+      addError(Expected.ChildrenMarkerStartLoc,
+               "child diagnostics block requires -verify-child-notes");
+      Expected.ExpectedChildNotes.clear();
+    } else if (Expected.ExpectedChildNotes.size() == 0) {
+      addError(DiagnosticLoc, "child diagnostics block is empty");
+    }
+
+    auto ChildNote = Expected.ExpectedChildNotes.begin();
+    while (ChildNote != Expected.ExpectedChildNotes.end()) {
+      if (ChildNote->Classification != DiagnosticKind::Note) {
+        addError(ChildNote->ClassificationStart,
+                 "only notes allowed in child diagnostics block");
+        ChildNote = Expected.ExpectedChildNotes.erase(ChildNote);
+      } else {
+        ++ChildNote;
+      }
+    }
+    ExtraChecks = ExtraChecks.substr(End + 2).ltrim(" \t");
+
+    if (ExtraChecks.starts_with("{{")) {
+      addError(ExtraChecks.data(),
+               "fix-it and documentation matchers must come before child notes");
+    }
+  }
+
   // If there's a trailing empty alternation, remove it.
   if (!Expected.Fixits.empty() && Expected.Fixits.back().empty())
     Expected.Fixits.pop_back();
@@ -1123,7 +1202,9 @@ unsigned DiagnosticVerifier::parseExpectedDiagInfo(
   return Count;
 }
 
-void DiagnosticVerifier::verifyDiagnostics(std::vector<ExpectedDiagnosticInfo> &ExpectedDiagnostics, unsigned BufferID) {
+void DiagnosticVerifier::verifyDiagnostics(
+    std::vector<ExpectedDiagnosticInfo> &ExpectedDiagnostics, unsigned BufferID,
+    std::optional<size_t> ParentID) {
   // Make sure all the expected diagnostics appeared.
   std::reverse(ExpectedDiagnostics.begin(), ExpectedDiagnostics.end());
 
@@ -1142,13 +1223,14 @@ void DiagnosticVerifier::verifyDiagnostics(std::vector<ExpectedDiagnosticInfo> &
         continue;
       }
       unsigned ExpansionBufferID = Expansions[Loc];
-      verifyDiagnostics(expected.NestedDiags, ExpansionBufferID);
+      verifyDiagnostics(expected.NestedDiags, ExpansionBufferID,
+                        /*ParentDiagnostic=*/std::nullopt);
       if (expected.NestedDiags.empty())
         ExpectedDiagnostics.erase(ExpectedDiagnostics.begin()+i);
       continue;
     }
     auto FoundDiagnosticInfo =
-        findDiagnostic(CapturedDiagnostics, expected, ID, SM);
+        findDiagnostic(CapturedDiagnostics, expected, ID, SM, ParentID);
     auto FoundDiagnosticIter = std::get<0>(FoundDiagnosticInfo);
     if (FoundDiagnosticIter == CapturedDiagnostics.end()) {
       // Diagnostic didn't exist.  If this is a 'mayAppear' diagnostic, then
@@ -1171,14 +1253,22 @@ void DiagnosticVerifier::verifyDiagnostics(std::vector<ExpectedDiagnosticInfo> &
 
     if (!std::get<1>(FoundDiagnosticInfo)) {
       // Found a diagnostic with the right location and text but the wrong
-      // classification. We'll emit an error about the mismatch and
+      // classification or parent. We'll emit an error about the mismatch and
       // thereafter pretend that the diagnostic fully matched.
       auto expectedKind = getDiagKindString(expected.Classification);
       auto actualKind = getDiagKindString(FoundDiagnostic.Classification);
-      emitFixItsError(expected.ClassificationStart,
-          llvm::Twine("expected ") + expectedKind + ", not " + actualKind,
-          expected.ClassificationStart, expected.ClassificationEnd,
-          actualKind);
+      if (expectedKind != actualKind)
+        emitFixItsError(expected.ClassificationStart,
+                        llvm::Twine("expected ") + expectedKind + ", not " +
+                            actualKind,
+                        expected.ClassificationStart,
+                        expected.ClassificationEnd, actualKind);
+      else {
+        ASSERT(ParentID &&
+               "fallback that matches kind but is not child note");
+        addError(expected.ExpectedStart,
+                 "matched child note with different parent");
+      }
     }
 
     const char *missedFixitLoc = nullptr;
@@ -1314,6 +1404,23 @@ void DiagnosticVerifier::verifyDiagnostics(std::vector<ExpectedDiagnosticInfo> &
       }
     }
 
+    if (VerifyChildNotes && !expected.ExpectedChildNotes.empty()) {
+      verifyDiagnostics(expected.ExpectedChildNotes, BufferID,
+                        FoundDiagnostic.ID);
+    }
+
+    if (FoundDiagnostic.HasChildren) {
+      auto ChildNoteIter = FoundDiagnosticIter + 1;
+      while (ChildNoteIter != CapturedDiagnostics.end() &&
+             ChildNoteIter->ParentID == FoundDiagnostic.ID) {
+        addError(getRawLoc(ChildNoteIter->Loc).getPointer(),
+                 ("unexpected child note produced: " +
+                  ChildNoteIter->Message).str());
+        addNote(expected.ExpectedStart, "for parent matched here");
+        ChildNoteIter = CapturedDiagnostics.erase(ChildNoteIter);
+      }
+    }
+
     // Actually remove the diagnostic from the list, so we don't match it
     // again. We do have to do this after checking fix-its, though, because
     // the diagnostic owns its fix-its.
@@ -1323,8 +1430,10 @@ void DiagnosticVerifier::verifyDiagnostics(std::vector<ExpectedDiagnosticInfo> &
     // number of diagnostics, in which case we want to reprocess this.
     if (expected.mayAppear)
       ++i;
+    else if (expected.ExpectedChildNotes.empty())
+      ExpectedDiagnostics.erase(ExpectedDiagnostics.begin() + i);
     else
-      ExpectedDiagnostics.erase(ExpectedDiagnostics.begin()+i);
+      expected.HasBeenFound = true;
   }
 }
 
@@ -1333,6 +1442,11 @@ void DiagnosticVerifier::verifyRemaining(
     const char *FileStart) {
   std::reverse(ExpectedDiagnostics.begin(), ExpectedDiagnostics.end());
   for (auto &expected : ExpectedDiagnostics) {
+    if (expected.HasBeenFound) {
+      // Only emit errors for unmatched child notes if the parent matched.
+      verifyRemaining(expected.ExpectedChildNotes, FileStart);
+      continue;
+    }
     if (expected.Classification == DiagnosticKindExpansion) {
       verifyRemaining(expected.NestedDiags, FileStart);
       continue;
@@ -1388,9 +1502,39 @@ void DiagnosticVerifier::verifyRemaining(
 void DiagnosticVerifier::addError(const char *Loc, const Twine &message,
                                   ArrayRef<llvm::SMFixIt> FixIts) {
   auto loc = SourceLoc::getFromPointer(Loc);
-  auto diag =
-      SM.GetMessage(loc, llvm::SourceMgr::DK_Error, message, {}, FixIts);
-  Errors.push_back(diag);
+  Errors.emplace_back(
+      SM.GetMessage(loc, llvm::SourceMgr::DK_Error, message, {}, FixIts));
+}
+
+void DiagnosticVerifier::addNote(const char *Loc, const Twine &message) {
+  ASSERT(!Errors.empty() && "addNote requires a preceding addError");
+  auto loc = SourceLoc::getFromPointer(Loc);
+  Errors.back().Notes.emplace_back(
+      SM.GetMessage(loc, llvm::SourceMgr::DK_Note, message, {}, {}));
+}
+
+std::vector<CapturedDiagnosticInfo>::iterator
+DiagnosticVerifier::reportAndEraseUnexpected(
+    std::vector<CapturedDiagnosticInfo>::iterator DiagIter) {
+  addError(getRawLoc(DiagIter->Loc).getPointer(),
+           ("unexpected " + getDiagKindString(DiagIter->Classification) +
+            " produced: " + DiagIter->Message)
+               .str());
+
+  if (VerifyChildNotes) {
+    auto ChildIter = DiagIter + 1;
+    // All child notes occur immediately after their parent so we only need to
+    // look forward in the list for as long as we keep seeing child notes. This
+    // also lets us erase the child notes without invalidating DiagIter.
+    while (ChildIter != CapturedDiagnostics.end() &&
+           ChildIter->ParentID == DiagIter->ID) {
+      addNote(getRawLoc(ChildIter->Loc).getPointer(),
+              ("with child note: " + ChildIter->Message).str());
+      ChildIter = CapturedDiagnostics.erase(ChildIter);
+    }
+  }
+
+  return CapturedDiagnostics.erase(DiagIter);
 }
 
 /// Scan the buffer for location marker definitions of the form "// #name".
@@ -1471,13 +1615,7 @@ bool DiagnosticVerifier::verifyDeferredMarkerDiagnostics() {
       continue;
     }
     HadError = true;
-    std::string Message =
-        ("unexpected " +
-         getDiagKindString(CapturedDiagIter->Classification) +
-         " produced: " + CapturedDiagIter->Message)
-            .str();
-    addError(getRawLoc(CapturedDiagIter->Loc).getPointer(), Message);
-    CapturedDiagIter = CapturedDiagnostics.erase(CapturedDiagIter);
+    CapturedDiagIter = reportAndEraseUnexpected(CapturedDiagIter);
   }
   for (auto &Err : Errors)
     printDiagnostic(Err);
@@ -1525,12 +1663,19 @@ DiagnosticVerifier::Result DiagnosticVerifier::verifyFile(unsigned BufferID) {
     PrevMatchEnd = Expected.ExpectedEnd;
   }
 
-  verifyDiagnostics(ExpectedDiagnostics, BufferID);
+  verifyDiagnostics(ExpectedDiagnostics, BufferID,
+                    /*ParentDiagnostic=*/std::nullopt);
 
   // Check to see if we have any incorrect diagnostics.  If so, diagnose them as
   // such.
   auto expectedDiagIter = ExpectedDiagnostics.begin();
   while (expectedDiagIter != ExpectedDiagnostics.end()) {
+    if (expectedDiagIter->HasBeenFound) {
+      // FIXME: extract this "near miss" pass and recurse
+      // over child notes and expansion contents
+      ++expectedDiagIter;
+      continue;
+    }
     // Check to see if any found diagnostics have the right line and
     // classification, but the wrong text.
     auto I = CapturedDiagnostics.begin();
@@ -1601,25 +1746,28 @@ DiagnosticVerifier::Result DiagnosticVerifier::verifyFile(unsigned BufferID) {
     }
 
     HadUnexpectedDiag = true;
-    std::string Message =
-        ("unexpected " + getDiagKindString(CapturedDiagIter->Classification) +
-         " produced: " + CapturedDiagIter->Message)
-            .str();
-    addError(getRawLoc(CapturedDiagIter->Loc).getPointer(), Message);
-    CapturedDiagIter = CapturedDiagnostics.erase(CapturedDiagIter);
+    CapturedDiagIter = reportAndEraseUnexpected(CapturedDiagIter);
   }
 
-  // Sort the diagnostics by their address in the memory buffer as the primary
-  // key.  This ensures that an "unexpected diagnostic" and
-  // "expected diagnostic" in the same place are emitted next to each other.
+  // Sort the diagnostics with buffer ID as the primary key and address within
+  // the buffer as the secondary key. This ensures that an "unexpected
+  // diagnostic" and "expected diagnostic" in the same place are emitted next
+  // to each other, and that the order is stable across source files.
   std::sort(Errors.begin(), Errors.end(),
-            [&](const llvm::SMDiagnostic &lhs,
-                const llvm::SMDiagnostic &rhs) -> bool {
-              return lhs.getLoc().getPointer() < rhs.getLoc().getPointer();
+            [&](const SMDiagnosticWithNotes &lhs,
+                const SMDiagnosticWithNotes &rhs) -> bool {
+              auto lhsLoc = SourceLoc::getFromPointer(lhs.Diag.getLoc().getPointer());
+              auto rhsLoc = SourceLoc::getFromPointer(rhs.Diag.getLoc().getPointer());
+              unsigned lhsBuf = SM.findBufferContainingLoc(lhsLoc);
+              unsigned rhsBuf = SM.findBufferContainingLoc(rhsLoc);
+              if (lhsBuf != rhsBuf)
+                return lhsBuf < rhsBuf;
+              return lhs.Diag.getLoc().getPointer() <
+                     rhs.Diag.getLoc().getPointer();
             });
 
   // Emit all of the queue'd up errors.
-  for (auto Err : Errors)
+  for (const auto &Err : Errors)
     printDiagnostic(Err);
 
   // If auto-apply fixits is on, rewrite the original source file.
@@ -1682,7 +1830,11 @@ processExpansions(SourceManager &SM, llvm::DenseMap<SourceLoc, unsigned> &Expans
 static void createDiagnosticInfo(const DiagnosticInfo &Info,
                                  SourceManager &DiagSM,
                                  SourceManager &VerifierSM,
+                                 bool VerifyChildNotes,
+                                 std::optional<size_t> ParentID,
                                  std::vector<CapturedDiagnosticInfo> &Out) {
+  ASSERT(!Info.IsChildNote ||
+         Info.ChildDiagnosticInfo.empty() && "child note of child note??");
   SmallVector<CapturedFixItInfo, 2> fixIts;
   for (const auto &fixIt : Info.FixIts) {
     fixIts.emplace_back(DiagSM, fixIt);
@@ -1696,10 +1848,17 @@ static void createDiagnosticInfo(const DiagnosticInfo &Info,
   }
 
   DiagLoc loc(DiagSM, VerifierSM, Info.Loc);
+  const size_t Idx = Out.size();
   Out.emplace_back(
       message, loc.bufferID, Info.Kind, loc.sourceLoc, loc.line, loc.column,
-      fixIts, llvm::sys::path::stem(Info.getCategoryDocumentationURL()).str());
+      fixIts, llvm::sys::path::stem(Info.getCategoryDocumentationURL()).str(),
+      Idx, ParentID, VerifyChildNotes && !Info.ChildDiagnosticInfo.empty());
 
+  if (VerifyChildNotes) {
+    for (const DiagnosticInfo *ChildInfo : Info.ChildDiagnosticInfo)
+      createDiagnosticInfo(*ChildInfo, DiagSM, VerifierSM, VerifyChildNotes,
+                           Idx, Out);
+  }
 }
 
 //===----------------------------------------------------------------------===//
@@ -1717,8 +1876,12 @@ void DiagnosticVerifier::handleDiagnostic(SourceManager &SM,
     return;
   if (IgnoreMacroLocationNote && Info.ID == diag::in_macro_expansion.ID)
     return;
+  if (VerifyChildNotes && Info.IsChildNote)
+    // Already added with parent diagnostic
+    return;
 
-  createDiagnosticInfo(Info, SM, this->SM, CapturedDiagnostics);
+  createDiagnosticInfo(Info, SM, this->SM, VerifyChildNotes, std::nullopt,
+                       CapturedDiagnostics);
 }
 
 /// Once all diagnostics have been captured, perform verification.

--- a/lib/Frontend/DiagnosticVerifier.cpp
+++ b/lib/Frontend/DiagnosticVerifier.cpp
@@ -1679,6 +1679,29 @@ processExpansions(SourceManager &SM, llvm::DenseMap<SourceLoc, unsigned> &Expans
   }
 }
 
+static void createDiagnosticInfo(const DiagnosticInfo &Info,
+                                 SourceManager &DiagSM,
+                                 SourceManager &VerifierSM,
+                                 std::vector<CapturedDiagnosticInfo> &Out) {
+  SmallVector<CapturedFixItInfo, 2> fixIts;
+  for (const auto &fixIt : Info.FixIts) {
+    fixIts.emplace_back(DiagSM, fixIt);
+  }
+
+  llvm::SmallString<128> message;
+  {
+    llvm::raw_svector_ostream Out(message);
+    DiagnosticEngine::formatDiagnosticText(Out, Info.FormatString,
+                                           Info.FormatArgs);
+  }
+
+  DiagLoc loc(DiagSM, VerifierSM, Info.Loc);
+  Out.emplace_back(
+      message, loc.bufferID, Info.Kind, loc.sourceLoc, loc.line, loc.column,
+      fixIts, llvm::sys::path::stem(Info.getCategoryDocumentationURL()).str());
+
+}
+
 //===----------------------------------------------------------------------===//
 // Main entrypoints
 //===----------------------------------------------------------------------===//
@@ -1694,23 +1717,8 @@ void DiagnosticVerifier::handleDiagnostic(SourceManager &SM,
     return;
   if (IgnoreMacroLocationNote && Info.ID == diag::in_macro_expansion.ID)
     return;
-  SmallVector<CapturedFixItInfo, 2> fixIts;
-  for (const auto &fixIt : Info.FixIts) {
-    fixIts.emplace_back(SM, fixIt);
-  }
 
-  llvm::SmallString<128> message;
-  {
-    llvm::raw_svector_ostream Out(message);
-    DiagnosticEngine::formatDiagnosticText(Out, Info.FormatString,
-                                           Info.FormatArgs);
-  }
-
-  DiagLoc loc(SM, this->SM, Info.Loc);
-  CapturedDiagnostics.emplace_back(message, loc.bufferID, Info.Kind,
-                                   loc.sourceLoc, loc.line, loc.column, fixIts,
-                                   llvm::sys::path::stem(
-                                      Info.getCategoryDocumentationURL()).str());
+  createDiagnosticInfo(Info, SM, this->SM, CapturedDiagnostics);
 }
 
 /// Once all diagnostics have been captured, perform verification.

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -440,7 +440,8 @@ bool CompilerInstance::setupDiagnosticVerifierIfNeeded() {
         SourceMgr, InputSourceCodeBufferIDs, diagOpts.AdditionalVerifierFiles,
         diagOpts.VerifyMode == DiagnosticOptions::VerifyAndApplyFixes,
         diagOpts.VerifyIgnoreUnknown, diagOpts.VerifyIgnoreUnrelated,
-        diagOpts.VerifyIgnoreMacroLocationNote, diagOpts.UseColor,
+        diagOpts.VerifyIgnoreMacroLocationNote, diagOpts.VerifyChildNotes,
+        diagOpts.UseColor,
         diagOpts.AdditionalDiagnosticVerifierPrefixes);
 
     addDiagnosticConsumer(DiagVerifier.get());

--- a/test/Frontend/DiagnosticVerifier/verify-child-notes-multifile-negative.swift
+++ b/test/Frontend/DiagnosticVerifier/verify-child-notes-multifile-negative.swift
@@ -1,0 +1,42 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file --leading-lines %s %t
+
+// RUN: not %target-swift-frontend -typecheck -verify -verify-child-notes %t/mainA.swift %t/otherA.swift 2>&1 | %FileCheck %s --implicit-check-not error: --implicit-check-not warning: --implicit-check-not note: --check-prefix A
+
+// RUN: not %target-swift-frontend -typecheck -verify -verify-child-notes %t/mainB.swift %t/otherB.swift 2>&1 | %FileCheck %s --implicit-check-not error: --implicit-check-not warning: --implicit-check-not note: --check-prefix B
+
+// RUN: not %target-swift-frontend -typecheck -verify -verify-child-notes %t/mainC.swift %t/otherC.swift 2>&1 | %FileCheck %s --implicit-check-not error: --implicit-check-not warning: --implicit-check-not note: --check-prefix C
+
+//--- otherA.swift
+struct CrossBuf {} // #crossbuf-orig
+
+//--- mainA.swift
+struct CrossBuf {}
+// A: [[@LINE+3]]:{{[0-9]+}}: error: expected note not produced
+// A: {{.*}}otherA.swift:[[@LINE-5]]:{{[0-9]+}}: error: unexpected child note produced: 'CrossBuf' previously declared here
+// A: [[@LINE+1]]:{{[0-9]+}}: note: for parent matched here
+// expected-error@-4 {{invalid redeclaration of 'CrossBuf'}} {{children: expected-note@#crossbuf-orig {{wrong message}} }}
+
+//--- otherB.swift
+struct CrossBuf1 {} // #1
+struct CrossBuf2 {} // #2
+
+//--- mainB.swift
+struct CrossBuf1 {}
+// expected-error@-1 {{invalid redeclaration of 'CrossBuf1'}} {{children: expected-note@#1 {{wrong message}} }}
+// B: mainB.swift:[[@LINE-1]]:{{[0-9]+}}: error: expected note not produced
+// B: otherB.swift:[[@LINE-7]]:{{[0-9]+}}: error: unexpected child note produced: 'CrossBuf1' previously declared here
+// B: mainB.swift:[[@LINE-3]]:{{[0-9]+}}: note: for parent matched here
+struct CrossBuf2 {}
+// B: otherB.swift:[[@LINE-9]]:{{[0-9]+}}: error: unexpected child note produced: 'CrossBuf2' previously declared here
+// B: mainB.swift:[[@LINE+1]]:{{[0-9]+}}: note: for parent matched here
+// expected-error@-3 {{invalid redeclaration of 'CrossBuf2'}}
+
+//--- mainC.swift
+struct CrossBuf {}
+// C: mainC.swift:[[@LINE-1]]:{{[0-9]+}}: error: unexpected error produced: invalid redeclaration of 'CrossBuf'
+
+//--- otherC.swift
+struct CrossBuf {}
+// C: otherC.swift:[[@LINE-1]]:{{[0-9]+}}: note: with child note: 'CrossBuf' previously declared here
+

--- a/test/Frontend/DiagnosticVerifier/verify-child-notes-multifile.swift
+++ b/test/Frontend/DiagnosticVerifier/verify-child-notes-multifile.swift
@@ -1,0 +1,57 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -typecheck -verify -verify-child-notes %t/mainA.swift %t/otherA.swift
+// RUN: %target-swift-frontend -typecheck -verify -verify-child-notes %t/mainB.swift %t/otherB.swift
+// RUN: %target-swift-frontend -typecheck -verify -verify-child-notes %t/mainC.swift %t/otherC.swift
+// RUN: %target-swift-frontend -typecheck -verify -verify-child-notes %t/mainD.swift %t/otherD.swift
+// RUN: %target-swift-frontend -typecheck -verify -verify-child-notes %t/mainE.swift %t/otherE.swift
+
+//--- otherA.swift
+struct CrossBuf {} // #crossbuf-orig
+
+//--- mainA.swift
+struct CrossBuf {}
+// expected-error@-1 {{invalid redeclaration of 'CrossBuf'}} {{children:
+//   expected-note@#crossbuf-orig {{'CrossBuf' previously declared here}}
+// }}
+
+
+//--- otherB.swift
+struct CrossBuf {} // #crossbuf-orig
+
+//--- mainB.swift
+struct CrossBuf {} // #unused-tag
+// expected-error@-1 {{invalid redeclaration of 'CrossBuf'}} {{children:
+//   expected-note@#crossbuf-orig {{'CrossBuf' previously declared here}}
+// }}
+
+
+//--- otherC.swift
+struct CrossBuf {} // #crossbuf-orig
+
+//--- mainC.swift
+struct CrossBuf {} // #crossbuf-redecl
+// expected-error@#crossbuf-redecl {{invalid redeclaration of 'CrossBuf'}} {{children:
+//   expected-note@#crossbuf-orig {{'CrossBuf' previously declared here}}
+// }}
+
+
+//--- otherD.swift
+struct CrossBuf {} // #crossbuf-orig
+// expected-error@#crossbuf-redecl {{invalid redeclaration of 'CrossBuf'}} {{children:
+//   expected-note@#crossbuf-orig {{'CrossBuf' previously declared here}}
+// }}
+
+//--- mainD.swift
+struct CrossBuf {} // #crossbuf-redecl
+
+
+//--- otherE.swift
+struct CrossBuf {}
+// expected-error@#crossbuf-redecl {{invalid redeclaration of 'CrossBuf'}} {{children:
+//   expected-note@-2 {{'CrossBuf' previously declared here}}
+// }}
+
+//--- mainE.swift
+struct CrossBuf {} // #crossbuf-redecl

--- a/test/Frontend/DiagnosticVerifier/verify-child-notes-negative.swift
+++ b/test/Frontend/DiagnosticVerifier/verify-child-notes-negative.swift
@@ -1,0 +1,47 @@
+// Tests for error cases in -verify-child-notes mode.
+
+// RUN: not %target-typecheck-verify-swift -verify-child-notes 2>&1 | %FileCheck %s --implicit-check-not error: --implicit-check-not warning: --implicit-check-not note:
+
+// Non-note classification in children block is a parse error.
+struct NonNote {}
+struct NonNote {} // expected-error {{invalid redeclaration of 'NonNote'}} {{children: expected-error {{wrong}} expected-note@-1{{'NonNote' previously declared here}} }}
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: only notes allowed in child diagnostics block
+
+// Mismatched child note message leaves the child note unmatched.
+struct WrongMsg {}
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: unexpected child note produced: 'WrongMsg' previously declared here
+// CHECK: [[@LINE+1]]:{{[0-9]+}}: note: for parent matched here
+struct WrongMsg {} // expected-error {{invalid redeclaration of 'WrongMsg'}} {{children: expected-note@-3 {{wrong message}} }}
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: expected note not produced
+
+struct NoParent {}
+struct NoParent {}
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: unexpected error produced: invalid redeclaration of 'NoParent'
+// CHECK: [[@LINE-3]]:{{[0-9]+}}: note: with child note: 'NoParent' previously declared here
+
+enum WithNone { case none }
+
+func testAmbiguous1(_ x: WithNone?) {
+    switch x {
+    case .none: // expected-warning {{assuming you mean 'Optional<WithNone>.none'; did you mean 'WithNone.none' instead?}}
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: unexpected child note produced: use 'nil' to silence this warning
+// CHECK: [[@LINE-2]]:{{[0-9]+}}: note: for parent matched here
+// CHECK: [[@LINE-3]]:{{[0-9]+}}: error: unexpected child note produced: use 'none?' instead
+// CHECK: [[@LINE-4]]:{{[0-9]+}}: note: for parent matched here
+        break
+    default:
+        break
+    }
+}
+func testAmbiguous2(_ x: WithNone?) {
+    switch x {
+    case .none:
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: unexpected warning produced: assuming you mean 'Optional<WithNone>.none'; did you mean 'WithNone.none' instead?
+// CHECK: [[@LINE-2]]:{{[0-9]+}}: note: with child note: use 'nil' to silence this warning
+// CHECK: [[@LINE-3]]:{{[0-9]+}}: note: with child note: use 'none?' instead
+        break
+    default:
+        break
+    }
+}
+

--- a/test/Frontend/DiagnosticVerifier/verify-child-notes-not-enabled.swift
+++ b/test/Frontend/DiagnosticVerifier/verify-child-notes-not-enabled.swift
@@ -1,0 +1,11 @@
+// RUN: not %target-typecheck-verify-swift 2>&1 | %FileCheck %s --implicit-check-not error: --implicit-check-not warning: --implicit-check-not note:
+
+struct A {}
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: unexpected note produced: 'A' previously declared here
+struct A {} // expected-error {{invalid redeclaration of 'A'}} {{children: expected-note@-1 {{'A' previously declared here}} }}
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: child diagnostics block requires -verify-child-notes
+
+struct B {} // expected-note {{'B' previously declared here}}
+struct B {} // expected-error {{invalid redeclaration of 'B'}} {{children:  }}
+// CHECK: [[@LINE-1]]:{{[0-9]+}}: error: child diagnostics block requires -verify-child-notes
+

--- a/test/Frontend/DiagnosticVerifier/verify-child-notes-shared.swift
+++ b/test/Frontend/DiagnosticVerifier/verify-child-notes-shared.swift
@@ -1,0 +1,15 @@
+// RUN: not %target-typecheck-verify-swift -verify-child-notes 2>&1 | %FileCheck %s --implicit-check-not error: --implicit-check-not warning: --implicit-check-not note:
+
+struct A {}; struct B {}; struct C {}; struct D {}; struct E {} // #1
+
+struct A {} /* expected-error {{invalid redeclaration of 'A'}} {{children:
+                 expected-note@#1 {{previously declared here}}
+            }}*/
+struct C {} /* expected-error {{invalid redeclaration of 'C'}} {{children:
+                 expected-note@#1 {{'C' previously declared here}}
+            }}*/
+struct E {} /* expected-error {{invalid redeclaration of 'E'}} {{children:
+                 expected-note@#1 2{{previously declared here}}
+CHECK: [[@LINE-1]]:{{[0-9]+}}: error: expected note not produced
+            }}*/
+

--- a/test/Frontend/DiagnosticVerifier/verify-child-notes.swift
+++ b/test/Frontend/DiagnosticVerifier/verify-child-notes.swift
@@ -1,0 +1,46 @@
+// RUN: %target-typecheck-verify-swift -verify-child-notes
+
+struct A {}
+struct A {} // expected-error {{invalid redeclaration of 'A'}} {{children: expected-note@-1 {{'A' previously declared here}} }}
+
+struct B {}
+struct B {} /* expected-error {{invalid redeclaration of 'B'}} {{children:
+                 expected-note@-2 {{'B' previously declared here}}
+            }}*/
+
+struct C {}
+struct C {} // expected-error {{invalid redeclaration of 'C'}} {{children:
+            //   expected-note@-2 {{'C' previously declared here}}
+            // }}
+
+struct D {} // #1
+struct D {} /* expected-error {{invalid redeclaration of 'D'}} {{children:
+                 expected-note@#1 {{'D' previously declared here}}
+            }}*/
+
+struct E {} // #2
+struct E {} /* expected-error {{invalid redeclaration of 'E'}} {{children:
+                 expected-note@#2 {{'E' previously declared here}}
+            }}*/
+struct E {} /* expected-error {{invalid redeclaration of 'E'}} {{children:
+                 expected-note@#2 {{'E' previously declared here}}
+            }}*/
+
+struct F {}; struct G {} // #3
+struct F {} /* expected-error {{invalid redeclaration of 'F'}} {{children:
+                 expected-note@#3 {{previously declared here}}
+            }}*/
+struct G {} /* expected-error {{invalid redeclaration of 'G'}} {{children:
+                 expected-note@#3 {{previously declared here}}
+            }}*/
+
+
+enum WithNone { case none }
+func testAmbiguous(_ x: WithNone?) {
+    switch x {
+    case .none: // expected-warning {{assuming you mean 'Optional<WithNone>.none'; did you mean 'WithNone.none' instead?}} {{children: expected-note {{use 'nil' to silence this warning}} expected-note {{use 'none?' instead}} }}
+        break
+    default:
+        break
+    }
+}


### PR DESCRIPTION
With this option enabled the DiagnosticVerifier enforces a strict child
note hierarchy: if a note has a parent diagnostic (which it should), it
can only be matched by an expected-note matcher in the {{children:}}
block of the matcher of its parent diagnostic. This makes it clear when
reviewing which note belongs to which diagnostic, and lets
update-verify-tests keep that structure (support in update-verify-tests
not yet added). If the note is far away from the parent it can be
matched with a line marker (#foo on the line of the emitted note).

Without this option enabled (default behavior) {{children:}} blocks are
an error.

Additionally, change the verification error sort order to use buffer
ID as the primary key (address within buffer as secondary), so that
error output is stable across source files in multi-file compilations.