### PR TITLE
[cxx-interop] Import virtual functions lazily

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -971,10 +971,6 @@ static bool shouldEagerlyImportClangRecordMember(const clang::NamedDecl *decl,
 
     case clang::DeclarationName::Identifier:
       if (auto *md = dyn_cast<clang::CXXMethodDecl>(fn)) {
-        // Import virtual functions eagerly for now, those are synthesized
-        if (md->isVirtual())
-          return true;
-
         // Name lookup doesn't know about these renamed methods, import eagerly
         if (LangOpts.CxxInteropGettersSettersAsProperties ||
             hasComputedPropertyAttr(fn)) {

--- a/test/Interop/Cxx/class/inheritance/Inputs/virtual-methods.h
+++ b/test/Interop/Cxx/class/inheritance/Inputs/virtual-methods.h
@@ -4,8 +4,6 @@ inline void testFunctionCollected() {}
 
 struct Base {
   virtual void foo() = 0;
-  virtual void virtualRename() const
-      __attribute__((swift_name("swiftVirtualRename()")));
 };
 
 template <class T>
@@ -30,6 +28,25 @@ struct Base3 { virtual int f() { return 111; } };
 struct Derived3 : public Base3 { virtual int f() {  return 222; } };
 struct Derived4 : public Base3 {};
 struct DerivedFromDerived2 : public Derived2 {};
+
+struct VirtualRenamedBase {
+  virtual int cxxName() const
+      __attribute__((swift_name("swiftName()")))
+      { return 101; }
+};
+struct VirtualRenamedInherited : VirtualRenamedBase {};
+struct VirtualRenamedOverridden : VirtualRenamedBase {
+  virtual int cxxName() const override { return 303; }
+};
+
+struct PureVirtualRenamedBase {
+  virtual int cxxName() const
+      __attribute__((swift_name("swiftName()"))) = 0;
+};
+struct PureVirtualRenamedInherited : PureVirtualRenamedBase {};
+struct PureVirtualRenamedOverridden : PureVirtualRenamedBase {
+  virtual int cxxName() const override { return 404; }
+};
 
 struct VirtualNonAbstractBase {
   virtual void nonAbstractMethod() const;

--- a/test/Interop/Cxx/class/inheritance/Inputs/virtual-methods.h
+++ b/test/Interop/Cxx/class/inheritance/Inputs/virtual-methods.h
@@ -1,8 +1,6 @@
-extern "C" void puts(const char *_Null_unspecified);
+#pragma once
 
-inline void testFunctionCollected() {
-  puts("test\n");
-}
+inline void testFunctionCollected() {}
 
 struct Base {
   virtual void foo() = 0;
@@ -10,32 +8,28 @@ struct Base {
       __attribute__((swift_name("swiftVirtualRename()")));
 };
 
-struct Base2 { virtual int f() = 0; };
-struct Base3 { virtual int f() { return 24; } };
-struct Derived2 : public Base2 { virtual int f() {  return 42; } };
-struct Derived3 : public Base3 { virtual int f() {  return 42; } };
-struct Derived4 : public Base3 { };
-struct DerivedFromDerived2 : public Derived2 {};
-
 template <class T>
 struct Derived : Base {
-  inline void foo() override {
-    testFunctionCollected();
-  }
-
-  void callMe() {
-  }
+  inline void foo() override { testFunctionCollected(); }
+  void callMe() {}
 };
 
 using DerivedInt = Derived<int>;
 
 template <class T>
 struct Unused : Base {
-  inline void foo() override {
-  }
+  inline void foo() override {}
 };
 
 using UnusedInt = Unused<int>;
+
+struct Base2 { virtual int f() = 0; };
+struct Derived2 : public Base2 { virtual int f() {  return 999; } };
+
+struct Base3 { virtual int f() { return 111; } };
+struct Derived3 : public Base3 { virtual int f() {  return 222; } };
+struct Derived4 : public Base3 {};
+struct DerivedFromDerived2 : public Derived2 {};
 
 struct VirtualNonAbstractBase {
   virtual void nonAbstractMethod() const;

--- a/test/Interop/Cxx/class/inheritance/virtual-methods-executable.swift
+++ b/test/Interop/Cxx/class/inheritance/virtual-methods-executable.swift
@@ -27,4 +27,15 @@ VirtualMethodsTestSuite.test("value type") {
   expectEqual(789, d6.getPureInt())
 }
 
+VirtualMethodsTestSuite.test("renamed virtual methods") {
+  let vrb = VirtualRenamedBase()
+  expectEqual(101, vrb.swiftName())
+  let vri = VirtualRenamedInherited()
+  expectEqual(101, vri.swiftName())
+  let vro = VirtualRenamedOverridden()
+  expectEqual(303, vro.swiftName())
+  let pvro = PureVirtualRenamedOverridden()
+  expectEqual(404, pvro.swiftName())
+}
+
 runAllTests()

--- a/test/Interop/Cxx/class/inheritance/virtual-methods-executable.swift
+++ b/test/Interop/Cxx/class/inheritance/virtual-methods-executable.swift
@@ -1,6 +1,4 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=swift-5.9)
-// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=swift-6)
-// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift)
+// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=default)
 // RUN: %target-run-simple-swift(-g -I %S/Inputs -cxx-interoperability-mode=default)
 
 // REQUIRES: executable_test
@@ -12,13 +10,13 @@ var VirtualMethodsTestSuite = TestSuite("Virtual Methods")
 
 VirtualMethodsTestSuite.test("value type") {
   var d2 = Derived2()
-  expectEqual(42, d2.f())
+  expectEqual(999, d2.f())
 
   var d3 = Derived3()
-  expectEqual(42, d3.f())
+  expectEqual(222, d3.f())
 
   var d4 = Derived4()
-  expectEqual(24, d4.f())
+  expectEqual(111, d4.f())
 
   let d5 = DerivedFromCallsPureMethod()
   expectEqual(790, d5.getInt())

--- a/test/Interop/Cxx/class/inheritance/virtual-methods-irgen.swift
+++ b/test/Interop/Cxx/class/inheritance/virtual-methods-irgen.swift
@@ -1,6 +1,4 @@
-// RUN: %target-swift-emit-ir -I %S/Inputs -cxx-interoperability-mode=upcoming-swift %s -validate-tbd-against-ir=none -Xcc -fignore-exceptions | %FileCheck %s
-// RUN: %target-swift-emit-ir -I %S/Inputs -cxx-interoperability-mode=swift-5.9 %s -validate-tbd-against-ir=none -Xcc -fignore-exceptions | %FileCheck %s
-// RUN: %target-swift-emit-ir -I %S/Inputs -cxx-interoperability-mode=swift-6 %s -validate-tbd-against-ir=none -Xcc -fignore-exceptions | %FileCheck %s
+// RUN: %target-swift-emit-ir -I %S/Inputs -cxx-interoperability-mode=default %s -validate-tbd-against-ir=none -Xcc -fignore-exceptions | %FileCheck %s
 
 import VirtualMethods
 

--- a/test/Interop/Cxx/class/inheritance/virtual-methods-module-interface.swift
+++ b/test/Interop/Cxx/class/inheritance/virtual-methods-module-interface.swift
@@ -5,20 +5,17 @@
 // CHECK-NEXT:   init()
 // CHECK-NEXT:   @available(*, unavailable, message: "virtual function is not available in Swift because it is pure")
 // CHECK-NEXT:   mutating func foo()
-// CHECK-NEXT:   func swiftVirtualRename()
 // CHECK-NEXT: }
 //
 // CHECK: struct Derived<CInt> {
 // CHECK-NEXT:  init()
 // CHECK-NEXT:  mutating func foo()
 // CHECK-NEXT:  mutating func callMe()
-// CHECK-NEXT:  func swiftVirtualRename()
 // CHECK-NEXT: }
 //
 // CHECK: struct Unused<CInt> {
 // CHECK-NEXT:  init()
 // CHECK-NEXT:  @_addressableSelf mutating func foo()
-// CHECK-NEXT:  func swiftVirtualRename()
 // CHECK-NEXT: }
 
 // CHECK:       struct Base2 {
@@ -56,6 +53,34 @@
 // CHECK-NEXT:    init()
 // CHECK-NEXT:    @discardableResult
 // CHECK-NEXT:    mutating func f() -> Int32
+// CHECK-NEXT:  }
+//
+// CHECK:       struct VirtualRenamedBase {
+// CHECK-NEXT:    init()
+// CHECK-NEXT:    @discardableResult
+// CHECK-NEXT:    @_addressableSelf func swiftName() -> Int32
+// CHECK-NEXT:  }
+// CHECK:       struct VirtualRenamedInherited {
+// CHECK-NEXT:    init()
+// CHECK-NEXT:    @discardableResult
+// CHECK-NEXT:    func swiftName() -> Int32
+// CHECK-NEXT:  }
+// CHECK:       struct VirtualRenamedOverridden {
+// CHECK-NEXT:    init()
+// CHECK-NEXT:    @discardableResult
+// CHECK-NEXT:    @_addressableSelf func swiftName() -> Int32
+// CHECK-NEXT:  }
+//
+// CHECK:       struct PureVirtualRenamedBase {
+// CHECK-NEXT:    @available(*, unavailable, message: "constructors of abstract C++ classes are unavailable in Swift")
+// CHECK-NEXT:    init()
+// CHECK-NEXT:    @available(*, unavailable, message: "virtual function is not available in Swift because it is pure")
+// CHECK-NEXT:    @_addressableSelf func swiftName() -> Int32
+// CHECK-NEXT:  }
+// CHECK:       struct PureVirtualRenamedOverridden {
+// CHECK-NEXT:    init()
+// CHECK-NEXT:    @discardableResult
+// CHECK-NEXT:    @_addressableSelf func swiftName() -> Int32
 // CHECK-NEXT:  }
 //
 // CHECK: struct VirtualNonAbstractBase {

--- a/test/Interop/Cxx/class/inheritance/virtual-methods-module-interface.swift
+++ b/test/Interop/Cxx/class/inheritance/virtual-methods-module-interface.swift
@@ -1,6 +1,4 @@
-// RUN: %target-swift-ide-test -print-module -cxx-interoperability-mode=swift-5.9 -print-implicit-attrs -module-to-print=VirtualMethods -I %S/Inputs -source-filename=x | %FileCheck %s
-// RUN: %target-swift-ide-test -print-module -cxx-interoperability-mode=swift-6 -print-implicit-attrs -module-to-print=VirtualMethods -I %S/Inputs -source-filename=x | %FileCheck %s
-// RUN: %target-swift-ide-test -print-module -cxx-interoperability-mode=upcoming-swift -print-implicit-attrs -module-to-print=VirtualMethods -I %S/Inputs -source-filename=x | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -cxx-interoperability-mode=default -print-implicit-attrs -module-to-print=VirtualMethods -I %S/Inputs -source-filename=x | %FileCheck %s
 
 // CHECK: struct Base {
 // CHECK-NEXT:   @available(*, unavailable, message: "constructors of abstract C++ classes are unavailable in Swift")
@@ -9,26 +7,57 @@
 // CHECK-NEXT:   mutating func foo()
 // CHECK-NEXT:   func swiftVirtualRename()
 // CHECK-NEXT: }
-
-// CHECK: struct Base3 {
-// CHECK-NEXT:   init()
-// CHECK-NEXT:   @discardableResult
-// CHECK-NEXT:   @_addressableSelf mutating func f() -> Int32
-// CHECK-NEXT: }
-
-// CHECK: struct Derived2 {
-// CHECK-NEXT:   init()
-// CHECK-NEXT:   @discardableResult
-// CHECK-NEXT:   @_addressableSelf mutating func f() -> Int32
-// CHECK-NEXT: }
-
+//
 // CHECK: struct Derived<CInt> {
 // CHECK-NEXT:  init()
 // CHECK-NEXT:  mutating func foo()
 // CHECK-NEXT:  mutating func callMe()
 // CHECK-NEXT:  func swiftVirtualRename()
 // CHECK-NEXT: }
+//
+// CHECK: struct Unused<CInt> {
+// CHECK-NEXT:  init()
+// CHECK-NEXT:  @_addressableSelf mutating func foo()
+// CHECK-NEXT:  func swiftVirtualRename()
+// CHECK-NEXT: }
 
+// CHECK:       struct Base2 {
+// CHECK-NEXT:    @available(*, unavailable, message: "constructors of abstract C++ classes are unavailable in Swift")
+// CHECK-NEXT:    init()
+// CHECK-NEXT:    @available(*, unavailable, message: "virtual function is not available in Swift because it is pure")
+// CHECK-NEXT:    @_addressableSelf mutating func f() -> Int32
+// CHECK-NEXT:  }
+//
+// CHECK:       struct Derived2 {
+// CHECK-NEXT:    init()
+// CHECK-NEXT:    @discardableResult
+// CHECK-NEXT:    @_addressableSelf mutating func f() -> Int32
+// CHECK-NEXT:  }
+//
+// CHECK:       struct Base3 {
+// CHECK-NEXT:    init()
+// CHECK-NEXT:    @discardableResult
+// CHECK-NEXT:    @_addressableSelf mutating func f() -> Int32
+// CHECK-NEXT:  }
+//
+// CHECK:       struct Derived3 {
+// CHECK-NEXT:    init()
+// CHECK-NEXT:    @discardableResult
+// CHECK-NEXT:    @_addressableSelf mutating func f() -> Int32
+// CHECK-NEXT:  }
+//
+// CHECK:       struct Derived4 {
+// CHECK-NEXT:    init()
+// CHECK-NEXT:    @discardableResult
+// CHECK-NEXT:    mutating func f() -> Int32
+// CHECK-NEXT:  }
+//
+// CHECK:       struct DerivedFromDerived2 {
+// CHECK-NEXT:    init()
+// CHECK-NEXT:    @discardableResult
+// CHECK-NEXT:    mutating func f() -> Int32
+// CHECK-NEXT:  }
+//
 // CHECK: struct VirtualNonAbstractBase {
 // CHECK-NEXT:  init()
 // CHECK-NEXT:  func nonAbstractMethod()

--- a/test/Interop/Cxx/class/inheritance/virtual-methods-typechecker.swift
+++ b/test/Interop/Cxx/class/inheritance/virtual-methods-typechecker.swift
@@ -1,21 +1,25 @@
-// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -verify-ignore-unknown -I %S/Inputs -cxx-interoperability-mode=upcoming-swift
-// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -verify-ignore-unknown -I %S/Inputs -cxx-interoperability-mode=swift-5.9
-// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -verify-ignore-unknown -I %S/Inputs -cxx-interoperability-mode=swift-6
+// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -verify-ignore-unknown -I %S/Inputs -cxx-interoperability-mode=default
 
 import VirtualMethods
 
 let _ = Base() // expected-error {{'init()' is unavailable: constructors of abstract C++ classes are unavailable in Swift}}
+let _ = DerivedInt()
+
+func callVirtualRenamedMethod(_ b: Base) {
+  b.virtualRename() // expected-error {{has no member 'virtualRename'}}
+  b.swiftVirtualRename()
+}
+
+func callVirtualRenamedMethod(_ d: DerivedInt) {
+  d.virtualRename() // expected-error {{has no member 'virtualRename'}}
+  d.swiftVirtualRename()
+}
+
 let _ = Base2() // expected-error {{'init()' is unavailable: constructors of abstract C++ classes are unavailable in Swift}}
 
-let _ = DerivedInt()
 let _ = Derived2()
 let _ = Derived3()
 let _ = Derived4()
 let _ = DerivedFromDerived2()
 
 VirtualNonAbstractBase().nonAbstractMethod()
-
-func callVirtualRenamedMethod(_ b: Base) {
-  b.virtualRename()  // expected-error {{value of type 'Base' has no member 'virtualRename'}}
-  b.swiftVirtualRename()
-}

--- a/test/Interop/Cxx/class/inheritance/virtual-methods-typechecker.swift
+++ b/test/Interop/Cxx/class/inheritance/virtual-methods-typechecker.swift
@@ -1,19 +1,9 @@
-// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -verify-ignore-unknown -I %S/Inputs -cxx-interoperability-mode=default
+// RUN: %target-typecheck-verify-swift -suppress-notes -I %S/Inputs -cxx-interoperability-mode=default
 
 import VirtualMethods
 
 let _ = Base() // expected-error {{'init()' is unavailable: constructors of abstract C++ classes are unavailable in Swift}}
 let _ = DerivedInt()
-
-func callVirtualRenamedMethod(_ b: Base) {
-  b.virtualRename() // expected-error {{has no member 'virtualRename'}}
-  b.swiftVirtualRename()
-}
-
-func callVirtualRenamedMethod(_ d: DerivedInt) {
-  d.virtualRename() // expected-error {{has no member 'virtualRename'}}
-  d.swiftVirtualRename()
-}
 
 let _ = Base2() // expected-error {{'init()' is unavailable: constructors of abstract C++ classes are unavailable in Swift}}
 
@@ -21,5 +11,27 @@ let _ = Derived2()
 let _ = Derived3()
 let _ = Derived4()
 let _ = DerivedFromDerived2()
+
+let vrb = VirtualRenamedBase()
+let _ = vrb.cxxName() // expected-error {{has no member 'cxxName'}}
+let _ = vrb.swiftName()
+let vri = VirtualRenamedInherited()
+let _ = vri.cxxName() // expected-error {{has no member 'cxxName'}}
+let _ = vri.swiftName()
+let vro = VirtualRenamedOverridden()
+let _ = vro.cxxName() // expected-error {{has no member 'cxxName'}}
+let _ = vro.swiftName()
+
+func check(pvrb: PureVirtualRenamedBase) {
+  let _ = pvrb.cxxName() // expected-error {{has no member 'cxxName'}}
+  let _ = pvrb.swiftName() // expected-error {{virtual function is not available in Swift because it is pure}}
+}
+func check(pvri: PureVirtualRenamedInherited) {
+  let _ = pvri.cxxName() // expected-error {{has no member 'cxxName'}}
+  let _ = pvri.swiftName() // expected-error {{virtual function is not available in Swift because it is pure}}
+}
+let pvro = PureVirtualRenamedOverridden()
+let _ = pvro.cxxName() // expected-error {{has no member 'cxxName'}}
+let _ = pvro.swiftName()
 
 VirtualNonAbstractBase().nonAbstractMethod()

--- a/test/Interop/Cxx/class/invalid-members/function-members-with-invalid-types.swift
+++ b/test/Interop/Cxx/class/invalid-members/function-members-with-invalid-types.swift
@@ -68,6 +68,9 @@ struct GoodStruct {
   // expected-swift-note@+1 {{unavailable (cannot import)}}
   static Bro<Ken> badStatic(Bro<Ken>);
 
+  // expected-swift-note@+1 * {{unavailable (cannot import)}}
+  virtual Bro<Ken> badVirtual(Bro<Ken>);
+
   void overloadsSameNumArgs(int) const;
   void overloadsSameNumArgs(Bro<Ken>) const;
 
@@ -92,6 +95,8 @@ struct GoodStruct {
 //
 // NOTE-MISSING: func badStatic(_: Never) -> Never
 //
+// NOTE-MISSING: func badVirtual(_: Never) -> Never
+//
 // CHECK-NEXT:   func overloadsSameNumArgs(_: Int32)
 // NOTE-MISSING: func overloadsSameNumArgs(_: Never)
 //
@@ -108,6 +113,7 @@ struct DerivedGoodStruct : GoodStruct {};
 // CHECK-NEXT:   init()
 // CHECK-NEXT:   func badReturn() -> Never
 // CHECK-NEXT:   func getBad() -> Never
+// NOTE-MISSING: func badVirtual(_: Never) -> Never
 // CHECK-NEXT:   func overloadsSameNumArgs(_: Int32)
 // CHECK-NEXT:   func overloadsDiffNumArgs(_: Int32, _: Int32)
 // CHECK-NEXT:   func __beginUnsafe() -> Never
@@ -176,12 +182,14 @@ void err(void) {
   gs.badArg(inc);
   auto inc2 = gs.getBad();
   GoodStruct::badStatic(inc2);
+  gs.badVirtual(inc);
 
   DerivedGoodStruct dgs;
   auto dinc = dgs.badReturn();
   dgs.badArg(dinc);
   auto dinc2 = dgs.getBad();
   DerivedGoodStruct::badStatic(dinc2);
+  dgs.badVirtual(dinc);
 
   UsingGoodStruct ugs;
   auto uinc = ugs.badReturn();
@@ -230,6 +238,7 @@ func err() {
                              // expected-swift-warning@-1 {{an enum with no cases}}
                              // expected-swift-note@-2 {{add an explicit type annotation}}
   GoodStruct.badStatic(inc2) // expected-swift-error {{has no member}}
+  gs.badVirtual(inc)        // expected-swift-error {{has no member}}
 
   let _ = GoodStruct(inc) // expected-swift-error {{call that takes no arguments}}
 
@@ -250,6 +259,8 @@ func err() {
   dgs.badArg(dinc)            // expected-swift-error {{has no member}}
 
   let _ = dgs.getBad()  // expected-swift-error {{is unavailable}}
+
+  dgs.badVirtual(dinc)        // expected-swift-error {{has no member}}
 
   let ugs = UsingGoodStruct()
   let uinc = ugs.badReturn() // expected-swift-error {{is unavailable}}


### PR DESCRIPTION
- **Explanation**: Previously, with `ImportCxxMembersLazily` enabled, `virtual` functions would still be imported eagerly. I had thought that importing them lazily might cause lookup problems because virtual functions are synthesized + handled specially, but it turns out I was wrong. Importing them lazily works just fine. This patch enables that.
- **Scope**: This patch only affects behavior when `ImportCxxMembersLazily` is enabled. which it is not by default.
- **Issues**: rdar://174587922
- **Risk**: Low
- **Testing**: Existing tests for `virtual` functions still pass, and I added a test case demonstrating/ensuring that `virtual` functions are now imported lazily. This patch set also includes some improvements for some virtual function tests. In particular, I expand a test case related to name lookup for a virtual function renamed via `SWIFT_NAME`.