### PR TITLE
[cxx-interop] Fix crash due to invalid sourceloc of synthesized expr

### DIFF
--- a/lib/ClangImporter/ClangDerivedConformances.cpp
+++ b/lib/ClangImporter/ClangDerivedConformances.cpp
@@ -976,7 +976,7 @@ static void conformToCxxOptional(ClangImporter::Implementation &impl,
   auto fakeValueRefExpr = new (clangCtx) clang::DeclRefExpr(
       clangCtx, fakeValueVarDecl, false,
       constRefValueType.getNonReferenceType(), clang::ExprValueKind::VK_LValue,
-      clang::SourceLocation());
+      clangDecl->getLocation());
 
   auto clangDeclTyInfo = clangCtx.getTrivialTypeSourceInfo(
       clang::QualType(clangDecl->getTypeForDecl(), 0));

--- a/test/Interop/Cxx/stdlib/Inputs/std-optional.h
+++ b/test/Interop/Cxx/stdlib/Inputs/std-optional.h
@@ -55,4 +55,10 @@ struct ReturnsOptionalString {
   DerivedFromOptional getStrDerived() const { return "foo"; }
 };
 
+// compiler crasher: optional of a type with user-defined conversion operator
+//                   to an instantiated template type
+template <typename T> struct Templated {};
+struct ConvertsToTemplated { operator Templated<int>() const; };
+std::optional<ConvertsToTemplated> returnsConvertsToTemplated();
+
 #endif // TEST_INTEROP_CXX_STDLIB_INPUTS_STD_OPTIONAL_H

--- a/test/Interop/Cxx/stdlib/use-std-optional-typechecker.swift
+++ b/test/Interop/Cxx/stdlib/use-std-optional-typechecker.swift
@@ -18,3 +18,5 @@ var _ = nonNilCopyable.pointee // expected-warning {{'pointee' is deprecated: us
 let nonNilOptNonCopyable = getNonNilOptionalHasDeletedCopyCtor()
 takeCopyable(nonNilOptNonCopyable) // expected-error {{conform to 'Copyable'}}
 var _ = nonNilOptNonCopyable.pointee
+
+let _ = returnsConvertsToTemplated() // shouldn't crash the compiler


### PR DESCRIPTION
When conforming a type to CxxOptional, we try to construct some dummy expressions while synthesizing a constructor from the value type.

When that value type can convert to a template that happens to be instantiated, ClangImporter crashes because we synthesize those dummy expressions with empty (invalid) source locations.

This patch gives it some valid source location to prevent the compiler crash. Note that the actual source location doesn't actually matter because the Clang diagnostics are being swallowed by our SFINAE trap anyway.

rdar://175133739

----

- **Explanation**: Feeds a valid source location to Clang Sema so that it doesn't crash during template instantiation (failure).
- **Scope**: Rare. This is an ugly crash caused by a somewhat niche scenario, importing C++ types with conversion operators to then-uninstantiated templates.
- **Issues**: rdar://175133739
- **Risk**: Low. The patch strictly improves the compiler patch with a one-liner fix that honors an apparent invariant of Clang Sema.
- **Testing**: Added minimal reproducer for the issue to the test suite. That test crashes before my patch and passes after it.