### PR TITLE
SIL: fix `UncheckedTakeEnumDataAddrInst::isDestructive`

### DIFF
--- a/lib/SIL/IR/SILInstruction.cpp
+++ b/lib/SIL/IR/SILInstruction.cpp
@@ -2225,9 +2225,13 @@ UncheckedTakeEnumDataAddrInst::isDestructive(EnumDecl *forEnum, SILModule &M) {
   // We only potentially use spare bit optimization when an enum is always
   // loadable.
   auto sig = forEnum->getGenericSignature().getCanonicalSignature();
-  if (SILType::isAddressOnly(forEnum->getDeclaredInterfaceType()->getReducedType(sig),
-                             M.Types, sig,
-                             TypeExpansionContext::minimal())) {
+  if (SILType::isAddressOnly(
+      forEnum->getDeclaredInterfaceType()->getReducedType(sig),
+      M.Types, sig,
+      // "maximum" is the safe default because it makes enums "less" address-only.
+      // For example, an enum in an inlinable function is address-only before
+      // serialization. However it becomes loadable after the module is serialized.
+      TypeExpansionContext::maximalResilienceExpansionOnly())) {
     return false;
   }
   

--- a/lib/SILGen/SILGenPattern.cpp
+++ b/lib/SILGen/SILGenPattern.cpp
@@ -2288,9 +2288,6 @@ void PatternMatchEmission::emitEnumElementDispatch(
   // After this point we now that we must have an address only type.
   assert(src.getType().isAddressOnly(SGF.F) &&
          "Should have an address only type here");
-  assert(!UncheckedTakeEnumDataAddrInst::isDestructive(src.getType().getEnumOrBoundGenericEnum(),
-                                                       SGF.getModule()) &&
-         "address only enum projection should never be destructive");
 
   CanType sourceType = rows[0].Pattern->getType()->getCanonicalType();
 

--- a/test/SILOptimizer/destructive-resilient-enum.swift
+++ b/test/SILOptimizer/destructive-resilient-enum.swift
@@ -1,0 +1,58 @@
+// RUN: %empty-directory(%t) 
+// RUN: split-file %s %t
+
+// RUN: %target-build-swift -parse-as-library -enable-library-evolution -emit-module -emit-module-path=%t/Enum.swiftmodule -module-name=Enum %t/enum.swift -c -o %t/enum.o
+// RUN: %target-build-swift -module-name=Main -I %t %t/main.swift -c -o %t/main.o
+// RUN: %target-swiftc_driver %t/main.o %t/enum.o -o %t/a.out
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+// REQUIRES: executable_test
+
+//--- enum.swift
+
+public struct Payload {
+  public let a: Int?
+  public let b: Int?
+  public let c: Int?
+  public let d: Int?
+}
+
+public enum MyEnum {
+  case big(Payload)
+  case small(String)
+}
+
+public extension MyEnum {
+  @inlinable var isSmall: Bool {
+    if case .small = self {
+      return true
+    }
+    return false
+  }
+
+  @inlinable var smallValue: String? {
+    if case .small(let t) = self {
+      return t
+    }
+    return nil
+  }
+}
+
+//--- main.swift
+
+import Enum
+
+func main() {
+  let v: MyEnum = .small("hello")
+  _ = v.isSmall
+  let smallValue = v.smallValue
+
+  precondition(smallValue == "hello")
+
+  // CHECK: ok
+  print("ok")
+}
+
+main()
+


### PR DESCRIPTION
When doing the address-only check to see if an `unchecked_take_enum_data_addr` instruction is destructive we need to use "maximum" resilience expansion. "Maximum" is the safe default because it makes enums "less" address-only. For example, an enum in an inlinable function is address-only before serialization. However it becomes loadable after the module is serialized.

Fixes a mis-compile
rdar://174952822
