### PR TITLE
[cxx-interop] Fix codegen for base member accesses

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -5937,6 +5937,7 @@ synthesizeBaseClassMethodBody(AbstractFunctionDecl *afd, void *context) {
   return {body, /*isTypeChecked=*/true};
 }
 
+namespace {
 // How should the synthesized C++ method that returns the field of interest
 // from the base class should return the value - by value, or by reference.
 enum ReferenceReturnTypeBehaviorForBaseAccessorSynthesis {
@@ -5944,6 +5945,7 @@ enum ReferenceReturnTypeBehaviorForBaseAccessorSynthesis {
   ReturnByReference,
   ReturnByMutableReference
 };
+} // end anonymous namespace
 
 // Synthesize a C++ method that returns the field of interest from the base
 // class. This lets Clang take care of the cast from the derived class
@@ -5975,7 +5977,7 @@ static clang::CXXMethodDecl *synthesizeCxxBaseGetterAccessorMethod(
   auto valueReturnType = returnType;
   if (behavior !=
       ReferenceReturnTypeBehaviorForBaseAccessorSynthesis::ReturnByValue) {
-    returnType = clangCtx.getRValueReferenceType(
+    returnType = clangCtx.getLValueReferenceType(
         behavior == ReferenceReturnTypeBehaviorForBaseAccessorSynthesis::
                         ReturnByReference
             ? returnType.withConst()
@@ -6002,6 +6004,7 @@ static clang::CXXMethodDecl *synthesizeCxxBaseGetterAccessorMethod(
     newMethod->addAttr(clang::CFReturnsRetainedAttr::CreateImplicit(clangCtx));
   }
 
+  clang::Sema::SynthesizedFunctionScope scope(clangSema, newMethod);
   // Create a new Clang diagnostic pool to capture any diagnostics
   // emitted during the construction of the method.
   clang::sema::DelayedDiagnosticPool diagPool{
@@ -6036,12 +6039,8 @@ static clang::CXXMethodDecl *synthesizeCxxBaseGetterAccessorMethod(
         clang::DeclarationNameInfo(field->getDeclName(),
                                    clang::SourceLocation()),
         valueReturnType, clang::VK_LValue, clang::OK_Ordinary);
-    auto returnCast = clangSema.ImpCastExprToType(memberExpr, valueReturnType,
-                                                  clang::CK_LValueToRValue,
-                                                  clang::VK_PRValue);
-    if (!returnCast.isUsable())
-      return nullptr;
-    return returnCast.get();
+
+    return memberExpr;
   };
 
   llvm::SmallVector<clang::Stmt *, 2> body;
@@ -6073,9 +6072,11 @@ static clang::CXXMethodDecl *synthesizeCxxBaseGetterAccessorMethod(
   auto fieldExpr = createFieldAccess();
   if (!fieldExpr)
     return nullptr;
-  auto returnStmt = clang::ReturnStmt::Create(clangCtx, clang::SourceLocation(),
-                                              fieldExpr, nullptr);
-  body.push_back(returnStmt);
+  auto returnStmt =
+      clangSema.BuildReturnStmt(clang::SourceLocation(), fieldExpr);
+  if (!returnStmt.isUsable())
+    return nullptr;
+  body.push_back(returnStmt.get());
 
   // Check if there were any Clang errors during the construction
   // of the method body.

--- a/test/Interop/Cxx/class/inheritance/Inputs/inherited-string-field.h
+++ b/test/Interop/Cxx/class/inheritance/Inputs/inherited-string-field.h
@@ -1,0 +1,30 @@
+#include <string>
+
+struct BaseWithVirtualAndString {
+  std::string sauce = "";
+  int64_t id = 0;
+  std::string type = "";
+  virtual ~BaseWithVirtualAndString() = default;
+};
+
+struct DerivedWithStringField : public BaseWithVirtualAndString {
+  std::string data;
+};
+
+inline DerivedWithStringField makeDerivedWithLongStrings() {
+  DerivedWithStringField x;
+  x.data = "this has 23 characters.";
+  x.sauce = "this has 23 characters!";
+  x.id = 42;
+  x.type = "this has 22 characters";
+  return x;
+}
+
+inline DerivedWithStringField makeDerivedWithShortStrings() {
+  DerivedWithStringField x;
+  x.data = "short";
+  x.sauce = "short!";
+  x.id = 42;
+  x.type = "s";
+  return x;
+}

--- a/test/Interop/Cxx/class/inheritance/Inputs/module.modulemap
+++ b/test/Interop/Cxx/class/inheritance/Inputs/module.modulemap
@@ -58,3 +58,8 @@ module ProtectedSpecialMember {
   header "protected-special-member.h"
   requires cplusplus
 }
+
+module InheritedStringField {
+  header "inherited-string-field.h"
+  requires cplusplus
+}

--- a/test/Interop/Cxx/class/inheritance/inherited-string-field.swift
+++ b/test/Interop/Cxx/class/inheritance/inherited-string-field.swift
@@ -1,0 +1,27 @@
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -cxx-interoperability-mode=default)
+//
+// REQUIRES: executable_test
+
+import StdlibUnittest
+import CxxStdlib
+import InheritedStringField
+
+var InheritedStringFieldTestSuite = TestSuite("InheritedStringField")
+
+InheritedStringFieldTestSuite.test("Access inherited std::string fields with long strings") {
+  let obj = makeDerivedWithLongStrings()
+  expectEqual(String(obj.type), "this has 22 characters")
+  expectEqual(String(obj.data), "this has 23 characters.")
+  expectEqual(obj.id, 42)
+  expectEqual(String(obj.sauce), "this has 23 characters!")
+}
+
+InheritedStringFieldTestSuite.test("Access inherited std::string fields with short strings") {
+  let obj = makeDerivedWithShortStrings()
+  expectEqual(String(obj.type), "s")
+  expectEqual(String(obj.data), "short")
+  expectEqual(obj.id, 42)
+  expectEqual(String(obj.sauce), "short!")
+}
+
+runAllTests()


### PR DESCRIPTION

**Explanation:**
We synthesized incorrect AST for some member types that triggered a bitwise copy of a non-trivial object. This change removes explicit generation of casts and relies on Clang sema to insert the right casts instead. 
**Scope:**
This code path is triggered when someone accesses a field that is declared in a base class. If this triggers a problem a user could work this around by declaring a getter function instead of accessing the field directly. 
**Issues:**
rdar://136757628
**Risk:**
Medium, the call to Sema does way more semantic checks than what we used to do. So it is not inconceivable that the synthesized code would trigger a compilation error in some circumstances triggering a build failure for something that did compile before. That being said, in those cases we are probably not generating the right AST so every compilation failure like that is potentially preventing us from doing bad codegen. 
**Testing:**
Added compiler tests.

-------

The code path inserted a manual lvalue to rvalue conversion. This conversion triggered a bitwise copy operation that should not be used for non-trivial types (a CXXConstructExpr is required instead). Instead of manually trying to do the casts, let's rely on Clang's sema to figure out the right casts to instert. Also, the original code used an rvalue reference as the return type for the synthesized getter. This triggered some compilation errors in sema's buildReturnStmt. Returning an lvalue reference solved those errors and is more in line with wath we actually want to do here (since we do not really need the getter/setter to produce an rvalue reference, we do not want to move out of the field).

rdar://136757628
