### PR TITLE
[cxx-interop] Accessing stored properties of C++ move-only types

### DIFF
--- a/lib/SIL/Utils/FieldSensitivePrunedLiveness.cpp
+++ b/lib/SIL/Utils/FieldSensitivePrunedLiveness.cpp
@@ -202,6 +202,13 @@ SubElementOffset::computeForAddress(SILValue projectionDerivedFromRoot,
             dyn_cast<StructElementAddrInst>(projectionDerivedFromRoot)) {
       SILType type = seai->getOperand()->getType();
 
+      // If this struct has unreferenceable storage, don't try to decompose it
+      // (e.g. C++ records with bases)
+      if (!getFullyReferenceableStruct(type)) {
+        projectionDerivedFromRoot = seai->getOperand();
+        continue;
+      }
+
       // Keep track of what subelement is being referenced.
       StructDecl *structDecl = seai->getStructDecl();
       for (auto *fieldDecl : structDecl->getStoredProperties()) {

--- a/test/Interop/Cxx/class/move-only/Inputs/move-only-cxx-value-type.h
+++ b/test/Interop/Cxx/class/move-only/Inputs/move-only-cxx-value-type.h
@@ -29,6 +29,14 @@ struct NonCopyableDerivedDerived: public NonCopyableDerived {
     NonCopyableDerivedDerived(int x) : NonCopyableDerived(x) {}
 };
 
+struct NonCopyableDerivedWithFields : public NonCopyable {
+  int first;
+  int second;
+
+  NonCopyableDerivedWithFields(int x, int f, int s)
+      : NonCopyable(x), first(f), second(s) {}
+};
+
 struct NonCopyableHolder {
     inline NonCopyableHolder(int x) : x(x) {}
     inline NonCopyableHolder(const NonCopyableHolder &) = delete;

--- a/test/Interop/Cxx/class/move-only/move-only-cxx-value-type.swift
+++ b/test/Interop/Cxx/class/move-only/move-only-cxx-value-type.swift
@@ -74,4 +74,12 @@ MoveOnlyCxxValueType.test("Test move only field in anonymous struct") {
   let a = FieldInAnonStructNC()
   let b = a
 }
+
+MoveOnlyCxxValueType.test("Test move only type with stored properties") {
+  var c = NonCopyableDerivedWithFields(2, -2, 42)
+  expectEqual(c.x, 2)
+  expectEqual(c.first, -2)
+  expectEqual(c.second, 42)
+}
+
 runAllTests()


### PR DESCRIPTION
<!--
The main branch is now in convergence, which means major changes, such as large refactoring or new features, should be avoided. This strategy is intended to maintain the stability of the Swift 6.4 release leading up to the May 4th branch. For any work that requires broad changes or introduces new features, create a feature branch and open a draft pull request. All updates to the swiftlang/swift repository’s main branch require approval from the release managers. A pull request targeting swiftlang/swift will automatically add release managers. You can also contact them via @release-managers in the forum group.
-->

<!-- Please fill out the following form: --> 
- **Explanation**: accessing a stored property of a C++ record with unreferenceable storage caused an out-of-bounds assertion failure in the `MoveOnlyChecker`. If the struct is not fully referenceable, then we shouldn't try to decompose it. 
  <!--
  A description of the changes. This can be brief, but it should be clear.
  -->
- **Scope**: these changes prevent an out-of-bounds access and do not affect types that are fully referenceable.
  <!--
  An assessment of the impact and importance of the changes. For example, can
  the changes break existing code?
  -->
- **Issues**: rdar://175162988
  <!--
  References to issues the changes resolve, if any.
  -->
- **Risk**: low, only affects structs with unreferenceable storage.
  <!--
  The (specific) risk to the release for taking the changes.
  -->
- **Testing**: added a small reproducer that used to crash before my changes. 
  <!--
  The specific testing that has been done or needs to be done to further
  validate any impact of the changes.
  -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
