### PR TITLE
[cxx-interop] Forward sanitizer flags to Clang importer

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -824,6 +824,20 @@ void importer::getNormalInvocationArguments(
 
   if (!LangOpts.DisableSafeInteropWrappers)
     invocationArgStrs.push_back("-fexperimental-bounds-safety-attributes");
+
+  if (ctx.SILOpts.Sanitizers & SanitizerKind::Address)
+    invocationArgStrs.push_back("-fsanitize=address");
+  if (ctx.SILOpts.Sanitizers & SanitizerKind::Thread)
+    invocationArgStrs.push_back("-fsanitize=thread");
+  if (ctx.SILOpts.Sanitizers & SanitizerKind::Undefined)
+    invocationArgStrs.push_back("-fsanitize=undefined");
+  if (ctx.SILOpts.Sanitizers & SanitizerKind::MemTagStack) {
+    invocationArgStrs.push_back("-fsanitize=memtag-stack");
+    invocationArgStrs.push_back("-Xclang");
+    invocationArgStrs.push_back("-target-feature");
+    invocationArgStrs.push_back("-Xclang");
+    invocationArgStrs.push_back("+mte");
+  }
 }
 
 static void

--- a/test/Interop/Cxx/driver/asan-clang-importer.swift
+++ b/test/Interop/Cxx/driver/asan-clang-importer.swift
@@ -1,0 +1,24 @@
+// REQUIRES: executable_test
+// REQUIRES: asan_runtime
+
+// XFAIL: OS=windows-msvc
+
+// RUN: %target-swiftc_driver %s -sanitize=address -import-objc-header %S/sanitizer-detect.h -o %t_asan -cxx-interoperability-mode=default
+// RUN: %target-codesign %t_asan
+// RUN: %target-run %t_asan
+
+// RUN: %target-swiftc_driver %s -import-objc-header %S/sanitizer-detect.h -o %t_no_asan -DEXPECT_NO_SANITIZER -cxx-interoperability-mode=default
+// RUN: %target-codesign %t_no_asan
+// RUN: %target-run %t_no_asan
+
+#if EXPECT_NO_SANITIZER
+assert(!is_asan_enabled(), "ASan should NOT be detected without -sanitize=address")
+assert(!is_tsan_enabled(), "TSan should NOT be detected without -sanitize=thread")
+assert(!is_ubsan_enabled(), "UBSan should NOT be detected without -sanitize=undefined")
+assert(!is_memtagstack_enabled(), "MemTag should NOT be detected without -sanitize=memtag-stack")
+#else
+assert(is_asan_enabled(), "ASan should be detected with -sanitize=address")
+assert(!is_tsan_enabled(), "TSan should NOT be detected with -sanitize=address")
+assert(!is_ubsan_enabled(), "UBSan should NOT be detected with -sanitize=address")
+assert(!is_memtagstack_enabled(), "MemTag should NOT be detected with -sanitize=address")
+#endif

--- a/test/Interop/Cxx/driver/memtag-clang-importer.swift
+++ b/test/Interop/Cxx/driver/memtag-clang-importer.swift
@@ -1,0 +1,22 @@
+// REQUIRES: executable_test
+// REQUIRES: memtag_sanitizer
+
+// RUN: %target-swiftc_driver %s -sanitize=memtag-stack -import-objc-header %S/sanitizer-detect.h -o %t_memtag -cxx-interoperability-mode=default -target arm64-apple-macosx10.9
+// RUN: %target-codesign %t_memtag
+// RUN: %target-run %t_memtag
+
+// RUN: %target-swiftc_driver %s -import-objc-header %S/sanitizer-detect.h -o %t_no_memtag -DEXPECT_NO_SANITIZER -cxx-interoperability-mode=default
+// RUN: %target-codesign %t_no_memtag
+// RUN: %target-run %t_no_memtag
+
+#if EXPECT_NO_SANITIZER
+assert(!is_memtagstack_enabled(), "MemTag should NOT be detected without -sanitize=memtag-stack")
+assert(!is_asan_enabled(), "ASan should NOT be detected without -sanitize=memtag-stack")
+assert(!is_tsan_enabled(), "TSan should NOT be detected without -sanitize=memtag-stack")
+assert(!is_ubsan_enabled(), "UBSan should NOT be detected without -sanitize=memtag-stack")
+#else
+assert(is_memtagstack_enabled(), "MemTag should be detected with -sanitize=memtag-stack")
+assert(!is_asan_enabled(), "ASan should NOT be detected with -sanitize=memtag-stack")
+assert(!is_tsan_enabled(), "TSan should NOT be detected with -sanitize=memtag-stack")
+assert(!is_ubsan_enabled(), "UBSan should NOT be detected with -sanitize=memtag-stack")
+#endif

--- a/test/Interop/Cxx/driver/sanitizer-detect.h
+++ b/test/Interop/Cxx/driver/sanitizer-detect.h
@@ -1,0 +1,33 @@
+#pragma once
+
+bool is_asan_enabled() {
+#if __has_feature(address_sanitizer)
+  return true;
+#else
+  return false;
+#endif
+}
+
+bool is_tsan_enabled() {
+#if __has_feature(thread_sanitizer)
+  return true;
+#else
+  return false;
+#endif
+}
+
+bool is_ubsan_enabled() {
+#if __has_feature(undefined_behavior_sanitizer)
+  return true;
+#else
+  return false;
+#endif
+}
+
+bool is_memtagstack_enabled() {
+#if __has_feature(memtag_stack)
+  return true;
+#else
+  return false;
+#endif
+}

--- a/test/Interop/Cxx/driver/sanitizer-forwarding.swift
+++ b/test/Interop/Cxx/driver/sanitizer-forwarding.swift
@@ -1,0 +1,16 @@
+// REQUIRES: OS=macosx || OS=linux-gnu
+
+// RUN: %swift_frontend_plain -typecheck -parse-stdlib %s -sanitize=address -dump-clang-diagnostics 2>&1 | %FileCheck %s -check-prefix CHECK-ASAN
+// RUN: %swift_frontend_plain -typecheck -parse-stdlib %s -sanitize=thread -dump-clang-diagnostics 2>&1 | %FileCheck %s -check-prefix CHECK-TSAN
+// RUN: %swift_frontend_plain -typecheck -parse-stdlib %s -sanitize=undefined -dump-clang-diagnostics 2>&1 | %FileCheck %s -check-prefix CHECK-UBSAN
+// RUN: %swift_frontend_plain -typecheck -parse-stdlib %s -sanitize=memtag-stack -dump-clang-diagnostics -target arm64-apple-macosx10.9 2>&1 | %FileCheck %s -check-prefix CHECK-MEMTAG
+// RUN: %swift_frontend_plain -typecheck -parse-stdlib %s -dump-clang-diagnostics 2>&1 | %FileCheck %s -check-prefix CHECK-NONE
+
+// CHECK-ASAN: clang importer cc1 args: {{.*}} '-fsanitize=address'
+// CHECK-TSAN: clang importer driver args: {{.*}} '-fsanitize=thread'
+// CHECK-UBSAN: clang importer driver args: {{.*}} '-fsanitize=undefined'
+// CHECK-MEMTAG: clang importer driver args: {{.*}} '-fsanitize=memtag-stack'
+// CHECK-NONE-NOT: '-fsanitize=address'
+// CHECK-NONE-NOT: '-fsanitize=thread'
+// CHECK-NONE-NOT: '-fsanitize=undefined'
+// CHECK-NONE-NOT: '-fsanitize=memtag-stack'

--- a/test/Interop/Cxx/driver/tsan-clang-importer.swift
+++ b/test/Interop/Cxx/driver/tsan-clang-importer.swift
@@ -1,0 +1,23 @@
+// REQUIRES: executable_test
+// REQUIRES: tsan_runtime
+// REQUIRES: OS=macosx
+
+// RUN: %target-swiftc_driver %s -sanitize=thread -import-objc-header %S/sanitizer-detect.h -o %t_tsan -cxx-interoperability-mode=default
+// RUN: %target-codesign %t_tsan
+// RUN: %target-run %t_tsan
+
+// RUN: %target-swiftc_driver %s -import-objc-header %S/sanitizer-detect.h -o %t_no_tsan -DEXPECT_NO_SANITIZER -cxx-interoperability-mode=default
+// RUN: %target-codesign %t_no_tsan
+// RUN: %target-run %t_no_tsan
+
+#if EXPECT_NO_SANITIZER
+assert(!is_tsan_enabled(), "TSan should NOT be detected without -sanitize=thread")
+assert(!is_asan_enabled(), "ASan should NOT be detected without -sanitize=address")
+assert(!is_ubsan_enabled(), "UBSan should NOT be detected without -sanitize=undefined")
+assert(!is_memtagstack_enabled(), "MemTag should NOT be detected without -sanitize=memtag-stack")
+#else
+assert(is_tsan_enabled(), "TSan should be detected with -sanitize=thread")
+assert(!is_asan_enabled(), "ASan should NOT be detected with -sanitize=thread")
+assert(!is_ubsan_enabled(), "UBSan should NOT be detected with -sanitize=thread")
+assert(!is_memtagstack_enabled(), "MemTag should NOT be detected with -sanitize=thread")
+#endif

--- a/test/Interop/Cxx/driver/ubsan-clang-importer.swift
+++ b/test/Interop/Cxx/driver/ubsan-clang-importer.swift
@@ -1,0 +1,22 @@
+// REQUIRES: executable_test
+// REQUIRES: ubsan_runtime
+
+// RUN: %target-swiftc_driver %s -sanitize=undefined -import-objc-header %S/sanitizer-detect.h -o %t_ubsan -cxx-interoperability-mode=default
+// RUN: %target-codesign %t_ubsan
+// RUN: %target-run %t_ubsan
+
+// RUN: %target-swiftc_driver %s -import-objc-header %S/sanitizer-detect.h -o %t_no_ubsan -DEXPECT_NO_SANITIZER -cxx-interoperability-mode=default
+// RUN: %target-codesign %t_no_ubsan
+// RUN: %target-run %t_no_ubsan
+
+#if EXPECT_NO_SANITIZER
+assert(!is_ubsan_enabled(), "UBSan should NOT be detected without -sanitize=undefined")
+assert(!is_asan_enabled(), "ASan should NOT be detected without -sanitize=undefined")
+assert(!is_tsan_enabled(), "TSan should NOT be detected without -sanitize=undefined")
+assert(!is_memtagstack_enabled(), "MemTag should NOT be detected without -sanitize=undefined")
+#else
+assert(is_ubsan_enabled(), "UBSan should be detected with -sanitize=undefined")
+assert(!is_asan_enabled(), "ASan should NOT be detected with -sanitize=undefined")
+assert(!is_tsan_enabled(), "TSan should NOT be detected with -sanitize=undefined")
+assert(!is_memtagstack_enabled(), "MemTag should NOT be detected with -sanitize=undefined")
+#endif

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -2641,6 +2641,9 @@ if run_ptrsize == '64' and 'libdispatch' in config.available_features:
 
 check_runtime_libs(runtime_libs)
 
+if run_cpu in ('aarch64', 'arm64') and run_os == 'macosx':
+    config.available_features.add('memtag_sanitizer')
+
 config.substitutions.append(('%target-objc-interop', run_objc_interop))
 
 


### PR DESCRIPTION
**Explanation:**
Sanitized Swift builds might compile imported inline C++ code without the instrumentation causing false negatives and/or false positives. This PR fixes that by forwarding the corresponding flags to the ClangImporter.
**Scope:**
Sanitized builds using interop.
**Issues:**
rdar://170982364
**Risk:**
Low, these flags are unlikely to cause any trouble and they might be worked around via `-Xcc` when they do.
**Testing:**
Added compiler tests.

----

Turning on the sanitizer for Swift did not have an effect on C++ code imported by the ClangImporter. This is confusing behavior, this PR makes sure the sanitizer frontend flags corresponding to the sanitizers used by Swift are set.

rdar://170982364
