### PR TITLE
[cxx-interop] Basic support for move-only clang types in reverse interop

### DIFF
--- a/lib/AST/SwiftNameTranslation.cpp
+++ b/lib/AST/SwiftNameTranslation.cpp
@@ -343,7 +343,9 @@ swift::cxx_translation::getDeclRepresentation(
       return {Unsupported, UnrepresentableProtocol};
     }
     // Swift's consume semantics are not yet supported in C++.
-    if (!typeDecl->canBeCopyable())
+    // However, non-copyable types imported from C/C++ can be exposed back,
+    // as C++ already knows how to handle them.
+    if (!typeDecl->canBeCopyable() && !typeDecl->hasClangNode())
       return {Unsupported, UnrepresentableMoveOnly};
     if (isa<ClassDecl>(VD) && VD->isObjC())
       return {Unsupported, UnrepresentableObjC};

--- a/lib/PrintAsClang/PrintClangFunction.cpp
+++ b/lib/PrintAsClang/PrintClangFunction.cpp
@@ -937,6 +937,15 @@ ClangRepresentation DeclAndTypeClangFunctionPrinter::printFunctionSignature(
   if (kind == FunctionSignatureKind::CFunctionProto) {
     // First, verify that the C++ param types are representable.
     for (auto param : *FD->getParameters()) {
+      // Consuming a non-copyable type is not supported, as the
+      // generated thunk would need to copy the parameter.
+      if (param->getSpecifier() == ParamDecl::Specifier::Consuming) {
+        if (auto *nominal =
+                param->getInterfaceType()->getNominalOrBoundGenericNominal()) {
+          if (!nominal->canBeCopyable())
+            return ClangRepresentation::unsupported;
+        }
+      }
       OptionalTypeKind optKind;
       Type objTy;
       std::tie(objTy, optKind) =

--- a/test/Interop/CxxToSwiftToCxx/bridge-noncopyable-cxx-struct-back-to-cxx.swift
+++ b/test/Interop/CxxToSwiftToCxx/bridge-noncopyable-cxx-struct-back-to-cxx.swift
@@ -1,0 +1,56 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend %t/use-cxx-types.swift -module-name UseCxxTy -typecheck -verify -emit-clang-header-path %t/UseCxxTy.h -I %t -cxx-interoperability-mode=default
+
+// RUN: %FileCheck %s --input-file %t/UseCxxTy.h
+
+// RUN: echo "#include \"header.h\"" > %t/full-cxx-swift-cxx-bridging.h
+// RUN: cat %t/UseCxxTy.h >> %t/full-cxx-swift-cxx-bridging.h
+
+// RUN: %check-interop-cxx-header-in-clang(%t/full-cxx-swift-cxx-bridging.h -Wno-reserved-identifier)
+
+//--- header.h
+
+struct NonCopyable {
+    NonCopyable() : x(0) {}
+    NonCopyable(const NonCopyable &) = delete;
+    NonCopyable(NonCopyable &&other) = default;
+    ~NonCopyable() = default;
+    int x;
+};
+
+struct NonCopyableNonTrivial {
+    NonCopyableNonTrivial() : x(0) {}
+    NonCopyableNonTrivial(const NonCopyableNonTrivial &) = delete;
+    NonCopyableNonTrivial(NonCopyableNonTrivial &&other) : x(other.x) { other.x = -1; }
+    ~NonCopyableNonTrivial() { x = -1; }
+    int x;
+};
+
+//--- module.modulemap
+module CxxTest {
+    header "header.h"
+    requires cplusplus
+}
+
+//--- use-cxx-types.swift
+import CxxTest
+
+// CHECK: SWIFT_INLINE_THUNK NonCopyable returnNonCopyable() noexcept {{.*}}{
+public func returnNonCopyable() -> NonCopyable { return NonCopyable() }
+
+// CHECK: SWIFT_INLINE_THUNK NonCopyableNonTrivial returnNonCopyableNonTrivial() noexcept {{.*}}{
+public func returnNonCopyableNonTrivial() -> NonCopyableNonTrivial { return NonCopyableNonTrivial() }
+
+// CHECK: SWIFT_INLINE_THUNK void takeNonCopyable(const NonCopyable& x) noexcept {{.*}}{
+public func takeNonCopyable(_ x: borrowing NonCopyable) {}
+
+// CHECK: SWIFT_INLINE_THUNK void takeNonCopyableNonTrivial(const NonCopyableNonTrivial& x) noexcept {{.*}}{
+public func takeNonCopyableNonTrivial(_ x: borrowing NonCopyableNonTrivial) {}
+
+// Not yet supported.
+// CHECK: Unavailable in C++: Swift global function 'consumeNonCopyable(_:)'.
+public func consumeNonCopyable(_ x: consuming NonCopyable) {}
+// CHECK: Unavailable in C++: Swift global function 'consumeNonCopyableNonTrivial(_:)'.
+public func consumeNonCopyableNonTrivial(_ x: consuming NonCopyableNonTrivial) {}


### PR DESCRIPTION
**Explanation:**
Currently, move only types are never exposed in reverse interop because the generated interop header does not support Swift's move semantics. On the other hand, Clang types work out of the box with borrowing. This PR enables exporting Swift functions that are borrowing or returning move-only Clang types.
**Scope:**
C++ reverse interop
**Issues:**
rdar://162361370
**Risk:**
Low, Swift APIs taking move only C++ types that are exposed back to C++ are not frequent and in case they trigger some problems they can be excluded from reverse interop. 
**Testing:**
Added compiler tests.
