### PR TITLE
[SIL] NFC: Remove `FullSiteApply::getActorIsolation`

### DIFF
--- a/include/swift/SIL/ApplySite.h
+++ b/include/swift/SIL/ApplySite.h
@@ -944,16 +944,6 @@ public:
            getNumIndirectSILErrorResults();
   }
 
-  std::optional<ActorIsolation> getActorIsolation() const {
-    if (auto isolation = getIsolationCrossing();
-        isolation && isolation->getCalleeIsolation())
-      return isolation->getCalleeIsolation();
-    auto *calleeFunction = getCalleeFunction();
-    if (!calleeFunction)
-      return {};
-    return calleeFunction->getActorIsolation();
-  }
-
   bool isCallerIsolationInheriting() const {
     return getSubstCalleeType()->hasNonisolatedNonsendingIsolation();
   }


### PR DESCRIPTION
<!--
The main branch is now in convergence, which means major changes, such as large refactoring or new features, should be avoided. This strategy is intended to maintain the stability of the Swift 6.4 release leading up to the May 4th branch. For any work that requires broad changes or introduces new features, create a feature branch and open a draft pull request. All updates to the swiftlang/swift repository’s main branch require approval from the release managers. A pull request targeting swiftlang/swift will automatically add release managers. You can also contact them via @release-managers in the forum group.
-->

<!-- Please fill out the following form: --> 
- **Explanation**:
 
  This method was used by `isCallerIsolationInheriting` but it's no longer needed. It also currently cannot produce correct results from function values, so it's better to remove it completely for now and avoid
possible confusion.

- **Scope**:

  Removes now-dead code.  

- **Issues**:
  N/A.

- **Risk**:
  
  Extra low.  

- **Testing**:
  No testing is necessary.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
