### PR TITLE
Don't delete dead instructions that forward move-only values in ossa

### DIFF
--- a/include/swift/SIL/InstWrappers.h
+++ b/include/swift/SIL/InstWrappers.h
@@ -330,6 +330,25 @@ public:
     return forwardingInst->getAllOperands();
   }
 
+  /// Return true if this forwarding operation destructures an owned operand,
+  /// extracting sub-components from an aggregate or enum value.
+  bool isOwnedValueDestructure() const {
+    if (auto *op = getSingleForwardingOperand()) {
+      if (op->get()->getOwnershipKind() != OwnershipKind::Owned) {
+        return false;
+      }
+    }
+    switch (forwardingInst->getKind()) {
+    case SILInstructionKind::DestructureStructInst:
+    case SILInstructionKind::DestructureTupleInst:
+    case SILInstructionKind::UncheckedEnumDataInst:
+    case SILInstructionKind::UncheckedValueCastInst:
+      return true;
+    default:
+      return false;
+    }
+  }
+
   bool canForwardOwnedCompatibleValuesOnly() {
     switch (forwardingInst->getKind()) {
     case SILInstructionKind::MarkUninitializedInst:

--- a/include/swift/SILOptimizer/Utils/InstOptUtils.h
+++ b/include/swift/SILOptimizer/Utils/InstOptUtils.h
@@ -132,6 +132,11 @@ bool isInstructionTriviallyDead(SILInstruction *inst);
 
 bool canTriviallyDeleteOSSAEndScopeInst(SILInstruction *inst);
 
+/// Return true if \p inst is a forwarding operation that destructures an owned
+/// move-only value. Such instructions must not be deleted because they end
+/// the lifetime of their operand.
+bool canDeleteDeadMoveOnlyOwnedDestructureInst(SILInstruction *inst);
+
 /// Return true if this is a release instruction that's not going to
 /// free the object.
 bool isIntermediateRelease(SILInstruction *inst, EpilogueARCFunctionInfo *erfi);

--- a/lib/SILOptimizer/Transforms/DeadCodeElimination.cpp
+++ b/lib/SILOptimizer/Transforms/DeadCodeElimination.cpp
@@ -15,7 +15,6 @@
 #include "swift/Basic/BlotSetVector.h"
 #include "swift/SIL/BasicBlockBits.h"
 #include "swift/SIL/DebugUtils.h"
-#include "swift/SIL/InstWrappers.h"
 #include "swift/SIL/MemAccessUtils.h"
 #include "swift/SIL/NodeBits.h"
 #include "swift/SIL/OwnershipUtils.h"
@@ -94,17 +93,8 @@ static bool seemsUseful(SILInstruction *I) {
     return true;
   }
 
-  // A dead forwarding operation with an owned argument can appear for a
-  // non-copyable or non-escapable struct which has only trivial elements.
-  // The instruction is not trivially dead because it ends the lifetime of
-  // its operand.
-  if (auto forwardingOperation = ForwardingOperation(I)) {
-    if (auto *op = forwardingOperation.getSingleForwardingOperand()) {
-      if (op->get()->getOwnershipKind() == OwnershipKind::Owned &&
-          op->get()->getType().isMoveOnly()) {
-        return true;
-      }
-    }
+  if (!canDeleteDeadMoveOnlyOwnedDestructureInst(I)) {
+    return true;
   }
 
   return false;

--- a/lib/SILOptimizer/Transforms/DeadCodeElimination.cpp
+++ b/lib/SILOptimizer/Transforms/DeadCodeElimination.cpp
@@ -15,6 +15,7 @@
 #include "swift/Basic/BlotSetVector.h"
 #include "swift/SIL/BasicBlockBits.h"
 #include "swift/SIL/DebugUtils.h"
+#include "swift/SIL/InstWrappers.h"
 #include "swift/SIL/MemAccessUtils.h"
 #include "swift/SIL/NodeBits.h"
 #include "swift/SIL/OwnershipUtils.h"
@@ -93,14 +94,16 @@ static bool seemsUseful(SILInstruction *I) {
     return true;
   }
 
-  // A dead `destructure_struct` with an owned argument can appear for a
-  // non-copyable struct which has only trivial elements. The instruction is not
-  // trivially dead because it ends the lifetime of its operand.
-  if (auto *dsi = dyn_cast<DestructureStructInst>(I)) {
-    auto structOp = dsi->getOperand();
-    if (structOp->getOwnershipKind() == OwnershipKind::Owned &&
-        structOp->getType().isMoveOnly()) {
-      return true;
+  // A dead forwarding operation with an owned argument can appear for a
+  // non-copyable or non-escapable struct which has only trivial elements.
+  // The instruction is not trivially dead because it ends the lifetime of
+  // its operand.
+  if (auto forwardingOperation = ForwardingOperation(I)) {
+    if (auto *op = forwardingOperation.getSingleForwardingOperand()) {
+      if (op->get()->getOwnershipKind() == OwnershipKind::Owned &&
+          op->get()->getType().isMoveOnly()) {
+        return true;
+      }
     }
   }
 

--- a/lib/SILOptimizer/Utils/InstOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/InstOptUtils.cpp
@@ -141,6 +141,23 @@ bool swift::canTriviallyDeleteOSSAEndScopeInst(SILInstruction *i) {
          !opValue->getType().isMoveOnly();
 }
 
+/// Return true if \p inst is a forwarding operation that destructures an owned
+/// move-only value. Such instructions must not be deleted because they end
+/// the lifetime of their operand.
+bool swift::canDeleteDeadMoveOnlyOwnedDestructureInst(SILInstruction *inst) {
+  auto forwardingOperation = ForwardingOperation(inst);
+  if (!forwardingOperation || !forwardingOperation.isOwnedValueDestructure()) {
+    return true;
+  }
+  auto *singleForwardingOp = forwardingOperation.getSingleForwardingOperand();
+  ASSERT(singleForwardingOp);
+  if (!singleForwardingOp->get()->getType().isMoveOnly()) {
+    return true;
+  }
+
+  return false;
+}
+
 /// Perform a fast local check to see if the instruction is dead.
 ///
 /// This routine only examines the state of the instruction at hand.
@@ -180,15 +197,8 @@ bool swift::isInstructionTriviallyDead(SILInstruction *inst) {
   if (isa<BorrowedFromInst>(inst))
     return false;
 
-  // A dead forwarding operation with an owned argument can appear for a non-copyable or
-  // non-escapable struct which has only trivial elements. The instruction is not trivially
-  // dead because it ends the lifetime of its operand.
-  if (auto forwardingOperation = ForwardingOperation(inst)) {
-    if (auto *op = forwardingOperation.getSingleForwardingOperand()) {
-      if (op->get()->getOwnershipKind() == OwnershipKind::Owned && op->get()->getType().isMoveOnly()) {
-        return false;
-      }
-    }
+  if (!canDeleteDeadMoveOnlyOwnedDestructureInst(inst)) {
+    return false;
   }
 
   // These invalidate enums so "write" memory, but that is not an essential

--- a/lib/SILOptimizer/Utils/InstOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/InstOptUtils.cpp
@@ -180,12 +180,15 @@ bool swift::isInstructionTriviallyDead(SILInstruction *inst) {
   if (isa<BorrowedFromInst>(inst))
     return false;
 
-  // A dead `destructure_struct` with an owned argument can appear for a non-copyable or
+  // A dead forwarding operation with an owned argument can appear for a non-copyable or
   // non-escapable struct which has only trivial elements. The instruction is not trivially
   // dead because it ends the lifetime of its operand.
-  if (isa<DestructureStructInst>(inst) &&
-      inst->getOperand(0)->getOwnershipKind() == OwnershipKind::Owned) {
-    return false;
+  if (auto forwardingOperation = ForwardingOperation(inst)) {
+    if (auto *op = forwardingOperation.getSingleForwardingOperand()) {
+      if (op->get()->getOwnershipKind() == OwnershipKind::Owned && op->get()->getType().isMoveOnly()) {
+        return false;
+      }
+    }
   }
 
   // These invalidate enums so "write" memory, but that is not an essential

--- a/test/SILOptimizer/copy_propagation_borrow.sil
+++ b/test/SILOptimizer/copy_propagation_borrow.sil
@@ -985,7 +985,6 @@ bb0:
 // CHECK: [[INSTANCE:%.*]] = apply
 // CHECK-NEXT:  [[COPY:%[^,]+]] = copy_value [[INSTANCE]] : $HasObjectAndInt
 // CHECK-NEXT:  begin_borrow
-// CHECK-NEXT:  destructure_struct
 // CHECK-NEXT:  end_borrow
 // CHECK-NEXT:  ([[OBJECT:%[^,]+]], {{%[^,]+}}) = destructure_struct [[COPY]] : $HasObjectAndInt
 // CHECK-NEXT:  [[BORROW:%[^,]+]] = begin_borrow [[OBJECT]] : $C

--- a/test/SILOptimizer/dead_code_elimination_nontrivial_ossa.sil
+++ b/test/SILOptimizer/dead_code_elimination_nontrivial_ossa.sil
@@ -1493,3 +1493,33 @@ bb0(%0 : @owned $NCWithoutDeinit):
   return %r
 }
 
+struct MoveOnlyPair : ~Copyable {
+  @_hasStorage var a: Int { get set }
+  @_hasStorage var b: Int { get set }
+}
+
+enum MoveOnlyTrivialPayloadEnum : ~Copyable {
+  case payload(Int)
+  case empty
+}
+
+// CHECK-LABEL: sil [ossa] @dce_dont_delete_dead_unchecked_enum_data_moveonly :
+// CHECK:         unchecked_enum_data
+// CHECK-LABEL: } // end sil function 'dce_dont_delete_dead_unchecked_enum_data_moveonly'
+sil [ossa] @dce_dont_delete_dead_unchecked_enum_data_moveonly : $@convention(thin) (@owned MoveOnlyTrivialPayloadEnum) -> () {
+bb0(%0 : @owned $MoveOnlyTrivialPayloadEnum):
+  %1 = unchecked_enum_data %0, #MoveOnlyTrivialPayloadEnum.payload!enumelt
+  %r = tuple ()
+  return %r
+}
+
+// CHECK-LABEL: sil [ossa] @dce_dont_delete_dead_unchecked_value_cast_moveonly :
+// CHECK:         unchecked_value_cast
+// CHECK-LABEL: } // end sil function 'dce_dont_delete_dead_unchecked_value_cast_moveonly'
+sil [ossa] @dce_dont_delete_dead_unchecked_value_cast_moveonly : $@convention(thin) (@owned MoveOnlyPair) -> () {
+bb0(%0 : @owned $MoveOnlyPair):
+  %1 = unchecked_value_cast %0 to $(Int, Int)
+  %r = tuple ()
+  return %r
+}
+

--- a/test/SILOptimizer/sil_combine_moveonly.sil
+++ b/test/SILOptimizer/sil_combine_moveonly.sil
@@ -229,3 +229,43 @@ bb1:
   return %5
 }
 
+struct MoveOnlyPair : ~Copyable {
+  @_hasStorage var a: Int { get set }
+  @_hasStorage var b: Int { get set }
+}
+
+enum MoveOnlyTrivialPayloadEnum : ~Copyable {
+  case payload(Int)
+  case empty
+}
+
+// CHECK-LABEL: sil [ossa] @dont_delete_dead_unchecked_enum_data_moveonly :
+// CHECK:         unchecked_enum_data
+// CHECK-LABEL: } // end sil function 'dont_delete_dead_unchecked_enum_data_moveonly'
+sil [ossa] @dont_delete_dead_unchecked_enum_data_moveonly : $@convention(thin) (@owned MoveOnlyTrivialPayloadEnum) -> () {
+bb0(%0 : @owned $MoveOnlyTrivialPayloadEnum):
+  %1 = unchecked_enum_data %0, #MoveOnlyTrivialPayloadEnum.payload!enumelt
+  %r = tuple ()
+  return %r
+}
+
+// CHECK-LABEL: sil [ossa] @dont_delete_dead_destructure_struct_moveonly_trivial :
+// CHECK:         destructure_struct
+// CHECK-LABEL: } // end sil function 'dont_delete_dead_destructure_struct_moveonly_trivial'
+sil [ossa] @dont_delete_dead_destructure_struct_moveonly_trivial : $@convention(thin) (@owned MoveOnlyPair) -> () {
+bb0(%0 : @owned $MoveOnlyPair):
+  (%1, %2) = destructure_struct %0
+  %r = tuple ()
+  return %r
+}
+
+// CHECK-LABEL: sil [ossa] @dont_delete_dead_unchecked_value_cast_moveonly :
+// CHECK:         unchecked_value_cast
+// CHECK-LABEL: } // end sil function 'dont_delete_dead_unchecked_value_cast_moveonly'
+sil [ossa] @dont_delete_dead_unchecked_value_cast_moveonly : $@convention(thin) (@owned MoveOnlyPair) -> () {
+bb0(%0 : @owned $MoveOnlyPair):
+  %1 = unchecked_value_cast %0 to $(Int, Int)
+  %r = tuple ()
+  return %r
+}
+

--- a/test/SILOptimizer/simplify_cfg_ossa.sil
+++ b/test/SILOptimizer/simplify_cfg_ossa.sil
@@ -2055,3 +2055,46 @@ bb9:
   return %23
 }
 
+struct NCWrapper : ~Copyable {
+  var val: Builtin.Int64
+  deinit
+}
+
+enum NCOptional : ~Copyable {
+  case some(NCWrapper)
+  case none
+}
+
+// CHECK-LABEL: sil [ossa] @test_switch_enum_thread_overconsume :
+// CHECK-NOT:     switch_enum
+// CHECK-LABEL: } // end sil function 'test_switch_enum_thread_overconsume'
+sil [ossa] @test_switch_enum_thread_overconsume : $@convention(thin) (Builtin.Int64) -> () {
+bb0(%0 : $Builtin.Int64):
+  %stk = alloc_stack $NCWrapper
+  cond_br undef, bb_init, bb_none
+
+bb_init:
+  %w = struct $NCWrapper (%0 : $Builtin.Int64)
+  %some = enum $NCOptional, #NCOptional.some!enumelt, %w : $NCWrapper
+  br bb_switch(%some : $NCOptional)
+
+bb_none:
+  %none = enum $NCOptional, #NCOptional.none!enumelt
+  br bb_switch(%none : $NCOptional)
+
+bb_switch(%opt : @owned $NCOptional):
+  switch_enum %opt : $NCOptional, case #NCOptional.some!enumelt: bb_some, case #NCOptional.none!enumelt: bb_use_none
+
+bb_some(%val : @owned $NCWrapper):
+  store %val to [init] %stk : $*NCWrapper
+  destroy_addr %stk : $*NCWrapper
+  br bb_exit
+
+bb_use_none:
+  br bb_exit
+
+bb_exit:
+  dealloc_stack %stk : $*NCWrapper
+  %r = tuple ()
+  return %r : $()
+}


### PR DESCRIPTION
- **Explanation**: A dead forwarding operation (e.g. `unchecked_enum_data`, `unchecked_value_cast`, `destructure_struct`) with an owned move-only operand must not be deleted because it ends the lifetime of its operand. Previously, only `destructure_struct` was guarded against deletion. This change uses `ForwardingOperation::isOwnedValueDestructure`  to cover all owned forwarding instructions that destructure.

- **Scope**: Effects optimizations on non-copyable types
- **Issues**: rdar://175150849
- **Risk**: Low. Adds a bailout from existing optimizations
- **Testing**: Added unit tests, CI testing
