### PR TITLE
Fix merging bounds checks with fixed-storage semantics

### DIFF
--- a/lib/SILOptimizer/LoopTransforms/BoundsCheckOpts.cpp
+++ b/lib/SILOptimizer/LoopTransforms/BoundsCheckOpts.cpp
@@ -1873,13 +1873,15 @@ std::optional<SILValue>
 BoundsCheckOpts::cloneFixedStorageIndex(SILValue indexValue,
                                         SILInstruction *insertPos,
                                         InstructionIndices &instIndices) {
-  SmallVector<SILInstruction *, 8> toClone;
+  SmallVector<SILInstruction *, 8> worklist;
   llvm::DenseMap<ValueBase *, SILValue> valueMap;
+  ValueSet visited(getFunction());
 
-  ValueWorklist worklist(getFunction());
-  worklist.push(indexValue);
 
-  while (auto value = worklist.pop()) {
+  std::function<bool(SILValue)> collectOperands = [&](SILValue value) -> bool {
+    if (!visited.insert(value)) {
+      return true;
+    }
     auto *inst = value->getDefiningInstruction();
 
     // In ossa, bailout when we have an instruction with lifetime ending
@@ -1887,7 +1889,7 @@ BoundsCheckOpts::cloneFixedStorageIndex(SILValue indexValue,
     if (inst && getFunction()->hasOwnership()) {
       for (auto &operand : inst->getAllOperands()) {
         if (operand.isLifetimeEnding()) {
-          return std::nullopt;
+          return false;
         }
       }
     }
@@ -1900,24 +1902,28 @@ BoundsCheckOpts::cloneFixedStorageIndex(SILValue indexValue,
         inst->getParent() != insertPos->getParent() ||
         instIndices.get(inst) < instIndices.get(insertPos)) {
       mapValue(value, value, valueMap);
-      continue;
+      return true;
     }
 
     if (!inst->isTriviallyDuplicatable() || inst->mayHaveSideEffects()) {
-      return std::nullopt;
+      return false;
     }
-
-    toClone.push_back(inst);
 
     for (auto operand : inst->getOperandValues()) {
-      worklist.pushIfNotVisited(operand);
+      if (!collectOperands(operand)) {
+        return false;
+      }
     }
+
+    worklist.push_back(inst);
+    return true;
+  };
+
+  if (!collectOperands(indexValue)) {
+    return std::nullopt;
   }
 
-  // Reverse the list to get topological order
-  std::reverse(toClone.begin(), toClone.end());
-
-  for (auto *inst : toClone) {
+  for (auto *inst : worklist) {
     auto *cloned = inst->clone(insertPos);
     mapOperands(cloned, valueMap);
     mapResults(cloned, inst, valueMap);

--- a/test/SILOptimizer/fixed_storage_bounds_check_hoisting.sil
+++ b/test/SILOptimizer/fixed_storage_bounds_check_hoisting.sil
@@ -191,3 +191,41 @@ bb0(%0 : @noImplicitCopy @guaranteed $Span<Int>, %1 : @guaranteed $NonTrivialWra
   %t = tuple ()
   return %t : $()
 }
+
+// CHECK-LABEL: sil [ossa] @test_topological_index_clone :
+// CHECK: [[CHECK:%[0-9]+]] = function_ref @checkIndex
+// CHECK: apply [[CHECK]]
+// CHECK-NEXT: apply [[CHECK]]
+// CHECK-LABEL: } // end sil function 'test_topological_index_clone'
+sil [ossa] @test_topological_index_clone : $@convention(thin) (@guaranteed Span<Int>) -> Bool {
+bb0(%0 : @guaranteed $Span<Int>):
+  %zero = integer_literal $Builtin.Int64, 0
+  %cnt = struct_extract %0, #Span._count
+  %count = struct_extract %cnt, #Int._value
+  br bb1(%zero : $Builtin.Int64)
+
+bb1(%i : $Builtin.Int64):
+  %done = builtin "cmp_eq_Int64"(%i : $Builtin.Int64, %count : $Builtin.Int64) : $Builtin.Int1
+  cond_br %done, bb3, bb2
+
+bb2:
+  %idx_i = struct $Int (%i : $Builtin.Int64)
+  %chk = function_ref @checkIndex : $@convention(method) (Int, @guaranteed Span<Int>) -> ()
+  %c1 = apply %chk(%idx_i, %0) : $@convention(method) (Int, @guaranteed Span<Int>) -> ()
+  %no_trap = integer_literal $Builtin.Int1, 0
+  %one = integer_literal $Builtin.Int64, 1
+  %sub1 = builtin "ssub_with_overflow_Int64"(%count : $Builtin.Int64, %one : $Builtin.Int64, %no_trap : $Builtin.Int1) : $(Builtin.Int64, Builtin.Int1)
+  %sub1v = tuple_extract %sub1 : $(Builtin.Int64, Builtin.Int1), 0
+  %sub2 = builtin "ssub_with_overflow_Int64"(%sub1v : $Builtin.Int64, %i : $Builtin.Int64, %no_trap : $Builtin.Int1) : $(Builtin.Int64, Builtin.Int1)
+  %mirror = tuple_extract %sub2 : $(Builtin.Int64, Builtin.Int1), 0
+  %idx_m = struct $Int (%mirror : $Builtin.Int64)
+  %c2 = apply %chk(%idx_m, %0) : $@convention(method) (Int, @guaranteed Span<Int>) -> ()
+  %inc = builtin "sadd_with_overflow_Int64"(%i : $Builtin.Int64, %one : $Builtin.Int64, %no_trap : $Builtin.Int1) : $(Builtin.Int64, Builtin.Int1)
+  %next = tuple_extract %inc : $(Builtin.Int64, Builtin.Int1), 0
+  br bb1(%next : $Builtin.Int64)
+
+bb3:
+  %true_val = integer_literal $Builtin.Int1, -1
+  %ret = struct $Bool (%true_val : $Builtin.Int1)
+  return %ret : $Bool
+}


### PR DESCRIPTION
- **Explanation**:
When merging fixed-storage bounds checks with the same self value, cloneFixedStorageIndex clones the index computation of a later check to place it adjacent to an earlier one. The previous implementation could lead to illegal SIL due to dominance violation in some cases by cloning an instruction before its operands were cloned. Fix this with a recursive DFS that appends instructions in postorder. Since a node is only added to the worklist after all its operands are recursively processed, the resulting order is a valid topological sort that guarantees every cloned instruction's operands are already available.

- **Scope**: Affects bounds check optimizations on various Span types 
- **Issues**: rdar://175274477
- **Risk**: Low
- **Testing**: Added unit test, CI testing
