### PR TITLE
[windows] build the toolchain with Python 3.11.9

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -165,7 +165,7 @@ param
 
   # Dependencies
   [ValidatePattern('^\d+(\.\d+)*$')]
-  [string] $PythonVersion = "3.10.1",
+  [string] $PythonVersion = "3.11.9",
 
   # Toolchain Version Info
   [string] $ProductVersion = "0.0.0",
@@ -427,6 +427,24 @@ $KnownPythons = @{
     ARM64_Embedded = @{
       URL = "https://www.python.org/ftp/python/3.10.1/python-3.10.1-embed-arm64.zip";
       SHA256 = "1f9e215fe4e8f22a8e8fba1859efb1426437044fb3103ce85794630e3b511bc2";
+    };
+  };
+  "3.11.9" = @{
+    AMD64 = @{
+      URL = "https://www.nuget.org/api/v2/package/python/3.11.9";
+      SHA256 = "9283876d58c017e0e846f95b490da3bca0fc0a6ee1134b2870677cfb7eec3c67";
+    };
+    AMD64_Embedded = @{
+      URL = "https://www.python.org/ftp/python/3.11.9/python-3.11.9-embed-amd64.zip";
+      SHA256 = "009d6bf7e3b2ddca3d784fa09f90fe54336d5b60f0e0f305c37f400bf83cfd3b";
+    };
+    ARM64 = @{
+      URL = "https://www.nuget.org/api/v2/package/pythonarm64/3.11.9";
+      SHA256 = "2f5b3bee38850fdde1b44227a23b8130d329839558376d2eb11099ce2b2cc33c";
+    };
+    ARM64_Embedded = @{
+      URL = "https://www.python.org/ftp/python/3.11.9/python-3.11.9-embed-arm64.zip";
+      SHA256 = "1a6dae49d15320270a7141f93b574ff7686a7a526efa65e63ddbebf9b409929a";
     };
   };
 }


### PR DESCRIPTION
<!--
The main branch is now in convergence, which means major changes, such as large refactoring or new features, should be avoided. This strategy is intended to maintain the stability of the Swift 6.4 release leading up to the May 4th branch. For any work that requires broad changes or introduces new features, create a feature branch and open a draft pull request. All updates to the swiftlang/swift repository’s main branch require approval from the release managers. A pull request targeting swiftlang/swift will automatically add release managers. You can also contact them via @release-managers in the forum group.
-->

<!-- Please fill out the following form: --> 
- **Explanation**:
Update the Python version used to build the Swift toolchain from `3.10.1` to `3.11.9`. As a consequence, Python `3.11` will be required to run lldb on Windows (instead of 3.10).
- **Scope**:
This change should not have any impact on the code, upstream lldb uses Python 3.11 on Windows already.
- **Issues**:
	- fixes https://github.com/swiftlang/swift/issues/76525
- **Risk**:
Python 3.10 will be deprecated in October 2026. Since lldb needs Python at runtime, there is a risk lldb 6.4 on Windows will require a deprecated version of Python to run (depending on the release date of the toolchain).
- **Testing**:
	- Tested that CI passes.
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
