### PR TITLE
[cxx-interop] Disambiguate instantiations with template template parameters

### DIFF
--- a/lib/ClangImporter/ClangClassTemplateNamePrinter.cpp
+++ b/lib/ClangImporter/ClangClassTemplateNamePrinter.cpp
@@ -74,6 +74,32 @@ struct TemplateInstantiationNamePrinter
       buffer << ">";
   }
 
+  void emitQualifiedName(const clang::NamedDecl *namedDecl,
+                          llvm::raw_svector_ostream &buffer) {
+    SmallVector<DeclName, 2> qualifiedNameComponents;
+    auto unqualifiedName = nameImporter->importName(namedDecl, version);
+    qualifiedNameComponents.push_back(unqualifiedName.getDeclName());
+    const clang::DeclContext *parentCtx =
+        unqualifiedName.getEffectiveContext().getAsDeclContext();
+    while (parentCtx) {
+      if (auto namedParentDecl = dyn_cast<clang::NamedDecl>(parentCtx)) {
+        // If this component of the fully-qualified name is a decl that is
+        // imported into Swift, remember its name.
+        auto componentName = nameImporter->importName(namedParentDecl, version);
+        qualifiedNameComponents.push_back(componentName.getDeclName());
+        parentCtx = componentName.getEffectiveContext().getAsDeclContext();
+      } else {
+        // If this component is not imported into Swift, skip it.
+        parentCtx = parentCtx->getParent();
+      }
+    }
+
+    llvm::interleave(
+        llvm::reverse(qualifiedNameComponents),
+        [&](const DeclName &each) { each.print(buffer); },
+        [&]() { buffer << "."; });
+  }
+
   std::string VisitTagType(const clang::TagType *type) {
     auto tagDecl = type->getAsTagDecl();
     if (auto namedArg = dyn_cast_or_null<clang::NamedDecl>(tagDecl)) {
@@ -81,31 +107,7 @@ struct TemplateInstantiationNamePrinter
         namedArg = typeDefDecl;
       llvm::SmallString<128> storage;
       llvm::raw_svector_ostream buffer(storage);
-
-      // Print the fully-qualified type name.
-      std::vector<DeclName> qualifiedNameComponents;
-      auto unqualifiedName = nameImporter->importName(namedArg, version);
-      qualifiedNameComponents.push_back(unqualifiedName.getDeclName());
-      const clang::DeclContext *parentCtx =
-          unqualifiedName.getEffectiveContext().getAsDeclContext();
-      while (parentCtx) {
-        if (auto namedParentDecl = dyn_cast<clang::NamedDecl>(parentCtx)) {
-          // If this component of the fully-qualified name is a decl that is
-          // imported into Swift, remember its name.
-          auto componentName =
-              nameImporter->importName(namedParentDecl, version);
-          qualifiedNameComponents.push_back(componentName.getDeclName());
-          parentCtx = componentName.getEffectiveContext().getAsDeclContext();
-        } else {
-          // If this component is not imported into Swift, skip it.
-          parentCtx = parentCtx->getParent();
-        }
-      }
-
-      llvm::interleave(
-          llvm::reverse(qualifiedNameComponents),
-          [&](const DeclName &each) { each.print(buffer); },
-          [&]() { buffer << "."; });
+      emitQualifiedName(namedArg, buffer);
       return buffer.str().str();
     }
     return "_";
@@ -263,6 +265,16 @@ struct TemplateArgumentPrinter
         buffer << ", ";
       Visit(arg, buffer);
       needsComma = true;
+    }
+  }
+
+  void VisitTemplateTemplateArgument(const clang::TemplateArgument &arg,
+                                     llvm::raw_svector_ostream &buffer) {
+    auto templateName = arg.getAsTemplate();
+    if (auto templateDecl = templateName.getAsTemplateDecl()) {
+      typePrinter.emitQualifiedName(templateDecl, buffer);
+    } else {
+      buffer << "_";
     }
   }
 };

--- a/test/Interop/Cxx/templates/Inputs/class-template-template-parameter.h
+++ b/test/Interop/Cxx/templates/Inputs/class-template-template-parameter.h
@@ -20,4 +20,20 @@ struct TemplatedMagicWrapper {
 
 typedef TemplatedMagicWrapper<MagicWrapper> TemplatedWrappedMagicInt;
 typedef MagicWrapper<IntWrapper> WrappedMagicInt;
+
+template<template <typename> typename>
+struct HasTemplateTemplateParam {};
+
+template <typename> struct Traits1 {};
+template <typename> struct Traits2 {};
+
+using HasTraits1 = HasTemplateTemplateParam<Traits1>;
+using HasTraits2 = HasTemplateTemplateParam<Traits2>;
+
+struct Outer {
+  template <typename> struct NestedTraits {};
+};
+
+using HasNestedTraits = HasTemplateTemplateParam<Outer::NestedTraits>;
+
 #endif // TEST_INTEROP_CXX_TEMPLATES_INPUTS_CLASS_TEMPLATE_TEMPLATE_PARAMETER_H

--- a/test/Interop/Cxx/templates/class-template-template-parameter.swift
+++ b/test/Interop/Cxx/templates/class-template-template-parameter.swift
@@ -23,4 +23,10 @@ TemplatesTestSuite.test("typedeffed-template-template-parameter") {
 //   expectEqual(templatedWrappedMagicInt.getValuePlusTwiceTheArg(10), 62)
 // }
 
+TemplatesTestSuite.test("template-template-parameter-distinct-names") {
+  var x = HasTraits1()
+  var y = HasTraits2()
+  var z = HasNestedTraits()
+}
+
 runAllTests()

--- a/test/Interop/Cxx/templates/class-template-with-template-parameter-module-interface.swift
+++ b/test/Interop/Cxx/templates/class-template-with-template-parameter-module-interface.swift
@@ -1,0 +1,6 @@
+// RUN: %target-swift-ide-test -print-module -module-to-print=ClassTemplateTemplateParameter -cxx-interoperability-mode=default -I %S/Inputs -source-filename=x | %FileCheck %s
+
+// CHECK: typealias TemplatedWrappedMagicInt = TemplatedMagicWrapper<MagicWrapper>
+// CHECK: typealias HasTraits1 = HasTemplateTemplateParam<Traits1>
+// CHECK: typealias HasTraits2 = HasTemplateTemplateParam<Traits2>
+// CHECK: typealias HasNestedTraits = HasTemplateTemplateParam<Outer.NestedTraits>


### PR DESCRIPTION
<!-- Please fill out the following form: --> 
- **Explanation**:
`template<template <typename> typename>` was tripping up the template class name printer – different instantiations of a class template were getting assigned the same name.
- **Scope**:
This adjusts the instantiation name printer to emit an actual name of the template parameter instead of a placeholder (`_`).
- **Issues**:
rdar://169199221
- **Risk**:
Low, this is covered by tests.
- **Testing**:
Added compiler tests.
