### PR TITLE
[Sema] Clarify diagnostic for type attributes only valid in inheritance clauses

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6183,7 +6183,7 @@ ERROR(sendable_raw_storage,none,
       "protocol", (DeclName))
 
 ERROR(typeattr_not_inheritance_clause,none,
-      "%0 only applies in inheritance clauses",
+      "%0 can only be used as a type attribute in inheritance clauses",
       (const TypeAttribute *))
 ERROR(typeattr_not_extension_inheritance_clause,none,
       "%0 only applies in inheritance clauses in extensions",

--- a/test/Concurrency/concurrent_value_checking_typechecker_errors.swift
+++ b/test/Concurrency/concurrent_value_checking_typechecker_errors.swift
@@ -62,6 +62,6 @@ class C12: @unchecked C11 { } // expected-error {{'@unchecked' cannot apply to n
 
 protocol P { }
 
-protocol Q: @unchecked Sendable { } // expected-error {{'@unchecked' only applies in inheritance clauses}}
+protocol Q: @unchecked Sendable { } // expected-error {{'@unchecked' can only be used as a type attribute in inheritance clauses}}
 
-typealias TypeAlias1 = @unchecked P // expected-error {{'@unchecked' only applies in inheritance clauses}}
+typealias TypeAlias1 = @unchecked P // expected-error {{'@unchecked' can only be used as a type attribute in inheritance clauses}}

--- a/test/Concurrency/preconcurrency_conformances.swift
+++ b/test/Concurrency/preconcurrency_conformances.swift
@@ -15,18 +15,22 @@ do {
   struct B : @preconcurrency K {
     // expected-error@-1 {{'@preconcurrency' cannot apply to non-protocol type 'K'}}
     var x: @preconcurrency Int
-    // expected-error@-1 {{'@preconcurrency' only applies in inheritance clauses}}
+    // expected-error@-1 {{'@preconcurrency' can only be used as a type attribute in inheritance clauses}}
   }
 
   typealias T = @preconcurrency Q
-  // expected-error@-1 {{'@preconcurrency' only applies in inheritance clauses}}
+  // expected-error@-1 {{'@preconcurrency' can only be used as a type attribute in inheritance clauses}}
 
   func test(_: @preconcurrency K) {}
-  // expected-error@-1 {{'@preconcurrency' only applies in inheritance clauses}}
+  // expected-error@-1 {{'@preconcurrency' can only be used as a type attribute in inheritance clauses}}
+
+  // https://github.com/swiftlang/swift/issues/88338
+  let _: @preconcurrency @MainActor () -> Void = {}
+  // expected-error@-1 {{'@preconcurrency' can only be used as a type attribute in inheritance clauses}}
 }
 
 protocol InvalidUseOfPreconcurrencyAttr : @preconcurrency Q {
-  // expected-error@-1 {{'@preconcurrency' only applies in inheritance clauses}}
+  // expected-error@-1 {{'@preconcurrency' can only be used as a type attribute in inheritance clauses}}
 }
 
 struct TestPreconcurrencyAttr {}


### PR DESCRIPTION
Fixes #88338.

The shared diagnostic `typeattr_not_inheritance_clause` fires for `@unchecked`, `@preconcurrency`, `@unsafe`, and `@nonisolated` when used as a type attribute outside an inheritance clause. The old wording, `"%0 only applies in inheritance clauses"`, reads as a universal claim about the attribute, but all four have valid declaration-attribute uses elsewhere (imports, funcs, etc.).

Reworded to `"%0 can only be used as a type attribute in inheritance clauses"` so the error scopes itself to the type-attribute form.

## Changes
- `include/swift/AST/DiagnosticsSema.def`: updated diagnostic text.
- `test/Concurrency/preconcurrency_conformances.swift`: updated 4 expectations, added a regression test for the reporter's repro (`let _: @preconcurrency @MainActor () -> Void = {}`).
- `test/Concurrency/concurrent_value_checking_typechecker_errors.swift`: updated 2 expectations.

No logic changes. The `@retroactive` sibling diagnostic is unchanged since its wording is already scoped correctly.