### PR TITLE
[cxx-interop] C++ types with empty bases have referenceable storage

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2740,8 +2740,15 @@ namespace {
           cxxRecordDecl->isCompleteDefinition() &&
           !cxxRecordDecl->bases().empty();
       if (hasBaseClasses) {
-        hasUnreferenceableStorage = true;
-        hasMemberwiseInitializer = false;
+        bool hasNonEmptyBaseClasses = llvm::any_of(
+            cxxRecordDecl->bases(), [](const clang::CXXBaseSpecifier &base) {
+              auto *record = base.getType()->getAsCXXRecordDecl();
+              return !record || !record->isEmpty();
+            });
+        if (hasNonEmptyBaseClasses) {
+          hasUnreferenceableStorage = true;
+          hasMemberwiseInitializer = false;
+        }
       }
 
       bool needsEmptyInitializer = true;

--- a/test/Interop/Cxx/class/inheritance/fields-module-interface.swift
+++ b/test/Interop/Cxx/class/inheritance/fields-module-interface.swift
@@ -54,6 +54,7 @@
 // CHECK-NEXT: }
 
 // CHECK-NEXT: struct NonTrivialHasThreeFields {
+// CHECK-NEXT:   init(a: Int32, b: Int32, c: Int32)
 // CHECK-NEXT:   init()
 // CHECK-NEXT:   var a: Int32
 // CHECK-NEXT:   var b: Int32

--- a/test/Interop/Cxx/class/inheritance/functions-module-interface.swift
+++ b/test/Interop/Cxx/class/inheritance/functions-module-interface.swift
@@ -133,6 +133,7 @@
 // CHECK-NEXT: }
 
 // CHECK-NEXT: public struct DerivedFromEmptyBaseClass {
+// CHECK-NEXT:   public init(a: Int32, b: Int32)
 // CHECK-NEXT:   public init()
 // CHECK-NEXT:   @discardableResult
 // CHECK-NEXT:   public func inBase() -> UnsafePointer<CChar>?

--- a/test/Interop/Cxx/class/move-only/Inputs/move-only-cxx-value-type.h
+++ b/test/Interop/Cxx/class/move-only/Inputs/move-only-cxx-value-type.h
@@ -68,4 +68,30 @@ struct FieldInAnonStruct {
 
 using FieldInAnonStructNC = FieldInAnonStruct<NonCopyable>;
 
+struct EmptyBase {};
+
+struct __attribute__((swift_attr("~Copyable"))) TrivialNonCopyable {
+  int x;
+};
+struct __attribute__((swift_attr("~Copyable"))) DerivesEmptyBase
+    : public EmptyBase {
+  NonCopyable first;
+  TrivialNonCopyable second;
+  Copyable third;
+
+  DerivesEmptyBase(int f, int s, int t) : first{f}, second{s}, third{t} {}
+};
+
+struct DerivesEmptyBaseNoAttr : public EmptyBase {
+  NonCopyable first;
+  TrivialNonCopyable second;
+  Copyable third;
+
+  DerivesEmptyBaseNoAttr(int f, int s, int t) : first{f}, second{s}, third{t} {}
+  DerivesEmptyBaseNoAttr(const DerivesEmptyBaseNoAttr &other) = delete;
+  DerivesEmptyBaseNoAttr(DerivesEmptyBaseNoAttr &&other)
+      : first(std::move(other.first)), second(other.second),
+        third(other.third) {}
+};
+
 #endif // TEST_INTEROP_CXX_CLASS_MOVE_ONLY_VT_H

--- a/test/Interop/Cxx/class/move-only/move-only-cxx-value-type.swift
+++ b/test/Interop/Cxx/class/move-only/move-only-cxx-value-type.swift
@@ -74,4 +74,17 @@ MoveOnlyCxxValueType.test("Test move only field in anonymous struct") {
   let a = FieldInAnonStructNC()
   let b = a
 }
+
+MoveOnlyCxxValueType.test("Test move only type with an empty base") {
+  let a = DerivesEmptyBase(3, 5, 7)
+  expectEqual(a.first.x, 3)
+  expectEqual(a.second.x, 5)
+  expectEqual(a.third.x, 7)
+
+  let b = DerivesEmptyBaseNoAttr(9, 11, 13)
+  expectEqual(b.first.x, 9)
+  expectEqual(b.second.x, 11)
+  expectEqual(b.third.x, 13)
+}
+
 runAllTests()

--- a/test/Interop/Cxx/stdlib/use-std-pair.swift
+++ b/test/Interop/Cxx/stdlib/use-std-pair.swift
@@ -6,8 +6,6 @@
 // RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift -Xcc -std=c++20)
 
 // REQUIRES: executable_test
-// FIXME importing a move-only std::pair into Swift causes a crash in the MoveOnlyChecker, in Linux
-// REQUIRES: OS=macosx || OS=windows-msvc
 
 import StdlibUnittest
 import StdPair


### PR DESCRIPTION
<!--
The main branch is now in convergence, which means major changes, such as large refactoring or new features, should be avoided. This strategy is intended to maintain the stability of the Swift 6.4 release leading up to the May 4th branch. For any work that requires broad changes or introduces new features, create a feature branch and open a draft pull request. All updates to the swiftlang/swift repository’s main branch require approval from the release managers. A pull request targeting swiftlang/swift will automatically add release managers. You can also contact them via @release-managers in the forum group.
-->

<!-- Please fill out the following form: --> 
- **Explanation**: 
Previously, all C++ types with base classes were marked as unreferenceable storage. This caused a crash in the `MoveOnlyChecker` when using non-copyable `std::pair` on Linux, where libstdc++'s `std::pair` inherits from an empty `__pair_base`. 
However, if all bases are empty, then we can still assume the type has referenceable storage since the empty bases don't contribute any storage that Swift needs to account for. This not only fixes the `std::pair` crash, but also allows Swift to optimize accesses to individual fields of these types.
  <!--
  A description of the changes. This can be brief, but it should be clear.
  -->
- **Scope**: Small change in the `VisitRecordDecl` in the ClangImporter. 
  <!--
  An assessment of the impact and importance of the changes. For example, can
  the changes break existing code?
  -->
- **Issues**: rdar://170142833
  <!--
  References to issues the changes resolve, if any.
  -->
- **Risk**: Low, only affects C++ types with empty base classes.
  <!--
  The (specific) risk to the release for taking the changes.
  -->
- **Testing**: Re-enabled the `use-std-pair.swift` test on Linux and added a couple of tests that crashed before my changes.
  <!--
  The specific testing that has been done or needs to be done to further
  validate any impact of the changes.
  -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
