### PR TITLE
[cxx-interop] Do not import default arguments of constructors that require template instantiation

### DIFF
--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -2710,6 +2710,12 @@ bool ClangImporter::Implementation::isDefaultArgSafeToImport(
     // HACK: Clang will crash while trying to instantiate this default arg.
     return false;
 
+  if (param->hasUninstantiatedDefaultArg() &&
+      isa<clang::CXXConstructorDecl>(functionDecl))
+    // HACK: Constructors of std::set have default arguments that rely on the
+    // comparator type being copyable.
+    return false;
+
   clang::CXXDefaultArgExpr *defaultArgExpr = nullptr;
   // Try to instantiate the default expression.
   auto defaultArgExprResult = getClangSema().BuildCXXDefaultArgExpr(

--- a/test/Interop/Cxx/stdlib/Inputs/std-set.h
+++ b/test/Interop/Cxx/stdlib/Inputs/std-set.h
@@ -23,4 +23,18 @@ struct NonCopyable {
 
 using SetOfNonCopyable = std::set<NonCopyable>;
 
+struct NonDefaultInitComparator {
+  int dummy;
+  NonDefaultInitComparator(int d) : dummy(d) {}
+  bool operator()(int a, int b) const { return a < b; }
+};
+
+using SetOfCIntWithCustomComparator =
+    std::set<int, NonDefaultInitComparator>;
+
+inline SetOfCIntWithCustomComparator initSetOfCIntWithCustomComparator() {
+  return SetOfCIntWithCustomComparator({1, 5, 3},
+                                       NonDefaultInitComparator(0));
+}
+
 #endif // TEST_INTEROP_CXX_STDLIB_INPUTS_STD_SET_H

--- a/test/Interop/Cxx/stdlib/use-std-set.swift
+++ b/test/Interop/Cxx/stdlib/use-std-set.swift
@@ -183,4 +183,14 @@ StdSetTestSuite.test("UnorderedSetOfCInt.remove") {
     expectFalse(s.contains(2))
 }
 
+StdSetTestSuite.test("SetOfCIntWithCustomComparator") {
+    let s = initSetOfCIntWithCustomComparator()
+    expectEqual(s.count(1), 1)
+    // FIXME: uncomment the following checks (https://github.com/swiftlang/swift/issues/88588)
+//     expectTrue(s.contains(1))
+//     expectFalse(s.contains(2))
+//     expectTrue(s.contains(3))
+//     expectTrue(s.contains(5))
+}
+
 runAllTests()


### PR DESCRIPTION
<!-- Please fill out the following form: --> 
- **Explanation**:
After a2b7b8fb, Swift began emitting template instantiation errors for the default expression of `std::set` constructor that takes a comparator. The default expression calls the default constructor of the comparator type, which might be deleted. This works around the problem by excluding default arguments of constructors that require instantiation out of the feature.
- **Scope**:
This reduces the number of scenarios where the default argument of a C++ constructor is honored by Swift.
- **Issues**:
rdar://175267666
- **Risk**:
Low, this backs out a part of a newly added feature, which has caused a regression.
- **Testing**:
Added a compiler test.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
