### PR TITLE
add REQUIRES: differentiable_programming to SourceManager-getLocOffsetInBuffer-dd5d62.swift

### DIFF
--- a/validation-test/IDE/crashers/SourceManager-getLocOffsetInBuffer-dd5d62.swift
+++ b/validation-test/IDE/crashers/SourceManager-getLocOffsetInBuffer-dd5d62.swift
@@ -1,3 +1,4 @@
+REQUIRES: differentiable_programming
 // {"kind":"complete","original":"05c97bf1","signature":"swift::SourceManager::getLocOffsetInBuffer(swift::SourceLoc, unsigned int) const","signatureAssert":"Assertion failed: (Loc.getPointer() >= Buffer->getBuffer().begin() && Loc.getPointer() <= Buffer->getBuffer().end() && \"Location is not from the specified buffer\"), function getLocOffsetInBuffer","signatureNext":"Lexer::getStateForBeginningOfTokenLoc","useSourceOrderCompletion":true}
 // RUN: not --crash %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -source-order-completion -source-filename %s
 // REQUIRES: OS=macosx


### PR DESCRIPTION


The test should REQUIRES: differentiable_programming otherwise it breaks on builds without that enabled

<!--
The main branch is now in convergence, which means major changes, such as large refactoring or new features, should be avoided. This strategy is intended to maintain the stability of the Swift 6.4 release leading up to the May 4th branch. For any work that requires broad changes or introduces new features, create a feature branch and open a draft pull request. All updates to the swiftlang/swift repository’s main branch require approval from the release managers. A pull request targeting swiftlang/swift will automatically add release managers. You can also contact them via @release-managers in the forum group.
-->

<!-- Please fill out the following form: --> 
- **Explanation**:

  The test fails on builds that doesn't enable the differentiable_programming feature/module. The test should add REQUIRES: differentiable_programming 

- **Scope**:

  The change won't break existing code. It's just fixing a test. 

- **Issues**:
 
  The change fixed the test failure of SourceManager-getLocOffsetInBuffer-dd5d62.swift on toolchain that doesn't enable differentiable_programming

- **Risk**:

  very low, only fixing a test

- **Testing**:

the test still passes on toolchain enable differentiable_programming, and will now pass on without differentiable_programming


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
