### PR TITLE
Replace opened Pack Element types with the concrete type of the element when it is statically known

### DIFF
--- a/SwiftCompilerSources/Sources/AST/CMakeLists.txt
+++ b/SwiftCompilerSources/Sources/AST/CMakeLists.txt
@@ -14,6 +14,7 @@ add_swift_compiler_module(AST
     DeclContext.swift
     Conformance.swift
     DiagnosticEngine.swift
+    GenericEnvironment.swift
     GenericSignature.swift
     Registration.swift
     SubstitutionMap.swift

--- a/SwiftCompilerSources/Sources/AST/GenericEnvironment.swift
+++ b/SwiftCompilerSources/Sources/AST/GenericEnvironment.swift
@@ -1,0 +1,45 @@
+//===--- GenericEnvironment.swift -----------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Basic
+import ASTBridging
+
+/// Describes the mapping between archetypes and interface types for the
+/// generic parameters of a DeclContext.
+public struct GenericEnvironment: CustomStringConvertible, NoReflectionChildren {
+  public let bridged: BridgedGenericEnvironment
+
+  public init(bridged: BridgedGenericEnvironment) {
+    self.bridged = bridged
+  }
+
+  public var description: String {
+    return String(taking: bridged.getDebugDescription())
+  }
+
+  /// The opened pack parameters for this opened-element environment,
+  /// parallel to the element parameters of the innermost generic context.
+  public var openedPackParams: TypeArray {
+    TypeArray(bridged: bridged.getOpenedPackParams())
+  }
+
+  /// Map an interface type to a contextual type.
+  public func mapTypeIntoEnvironment(_ type: Type) -> Type {
+    Type(bridged: bridged.mapTypeIntoEnvironment(type.bridged))
+  }
+
+  /// Map a type containing pack element type parameters to a contextual
+  /// type in the pack generic context.
+  public func mapElementTypeIntoPackContext(_ type: Type) -> Type {
+    Type(bridged: bridged.mapElementTypeIntoPackContext(type.bridged))
+  }
+}

--- a/SwiftCompilerSources/Sources/AST/Type.swift
+++ b/SwiftCompilerSources/Sources/AST/Type.swift
@@ -105,6 +105,10 @@ public struct Type: TypeProperties, CustomStringConvertible, NoReflectionChildre
   public var genericArgumentsOfBoundGenericType: TypeArray {
     TypeArray(bridged: bridged.BoundGenericType_getGenericArgs())
   }
+
+  public var elementTypesOfPackType: TypeArray {
+    TypeArray(bridged: bridged.PackType_getElementTypes())
+  }
 }
 
 /// A Type that is statically known to be canonical.
@@ -177,6 +181,8 @@ extension TypeProperties {
   public var isExistentialArchetypeWithError: Bool { rawType.bridged.isExistentialArchetypeWithError() }
   public var isRootArchetype: Bool { rawType.interfaceTypeOfArchetype.isGenericTypeParameter }
   public var isRootExistentialArchetype: Bool { isExistentialArchetype && isRootArchetype }
+  public var isLocalArchetype: Bool { rawType.bridged.isLocalArchetype() }
+  public var isRootLocalArchetype: Bool { isLocalArchetype && isRootArchetype }
   public var isExistential: Bool { rawType.bridged.isExistential() }
   public var isClassExistential: Bool { rawType.bridged.isClassExistential() }
   public var isGenericTypeParameter: Bool { rawType.bridged.isGenericTypeParam() }
@@ -186,6 +192,7 @@ extension TypeProperties {
   public var isDynamicSelf: Bool { rawType.bridged.isDynamicSelf()}
   public var isBox: Bool { rawType.bridged.isBox() }
   public var isPack: Bool { rawType.bridged.isPack() }
+  public var isPackExpansion: Bool { rawType.bridged.isPackExpansion() }
   public var isSILPack: Bool { rawType.bridged.isSILPack() }
 
   public var canBeClass: Type.TraitResult { rawType.bridged.canBeClass().result }

--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyAllocStack.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyAllocStack.swift
@@ -451,7 +451,7 @@ private extension AllocStackInst {
     let concreteType: CanonicalType
     if let initExistential {
       assert(self.type.isExistential)
-      if let cft = initExistential.concreteTypeOfDependentExistentialArchetype {
+      if let cft = initExistential.concreteTypeOfDependentOpenedType {
         // Case 1: We will replace the alloc_stack of an existential with the concrete type.
         //         `alloc_stack $any P` -> `alloc_stack $ConcreteType`
         concreteType = cft
@@ -467,7 +467,7 @@ private extension AllocStackInst {
         //         `alloc_stack $any P` -> `alloc_stack $@opened("...")`
         concreteType = initExistential.type.canonicalType
       }
-    } else if self.type.isExistentialArchetype, let cft = self.concreteTypeOfDependentExistentialArchetype {
+    } else if self.type.isExistentialArchetype, let cft = self.concreteTypeOfDependentOpenedType {
       // Case 3: We will replace the alloc_stack of an existential archetype with the concrete type:
       //         `alloc_stack $@opened("...")` -> `alloc_stack $ConcreteType`
       concreteType = cft

--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyApply.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyApply.swift
@@ -32,7 +32,7 @@ extension ApplyInst : OnoneSimplifiable, SILCombineSimplifiable {
       return
     }
     if !context.preserveDebugInfo {
-      _ = tryReplaceExistentialArchetype(of: self, context)
+      _ = tryReplaceLocalArchetype(of: self, context)
     }
   }
 }
@@ -43,7 +43,7 @@ extension TryApplyInst : OnoneSimplifiable, SILCombineSimplifiable {
       return
     }
     if !context.preserveDebugInfo {
-      _ = tryReplaceExistentialArchetype(of: self, context)
+      _ = tryReplaceLocalArchetype(of: self, context)
     }
   }
 }
@@ -158,8 +158,8 @@ private func tryOptimizeEnumComparison(apply: ApplyInst, _ context: SimplifyCont
   return true
 }
 
-/// If the apply uses an existential archetype (`@opened("...")`) and the concrete type is known,
-/// replace the existential archetype with the concrete type
+/// If the apply uses a local archetype (`@opened("...")` or `@pack_element("...")`) and the
+/// concrete type is known, replace the local archetype with the concrete type
 ///   1. in the apply's substitution map
 ///   2. in the arguments, e.g. by inserting address casts
 /// For example:
@@ -171,17 +171,17 @@ private func tryOptimizeEnumComparison(apply: ApplyInst, _ context: SimplifyCont
 ///   %4 = unchecked_addr_cast %2 to $*ConcreteType
 ///   %5 = apply %1<ConcreteType>(%4) : <τ_0_0> (τ_0_0) -> ()
 /// ```
-private func tryReplaceExistentialArchetype(of apply: ApplyInst, _ context: SimplifyContext) -> Bool {
+private func tryReplaceLocalArchetype(of apply: ApplyInst, _ context: SimplifyContext) -> Bool {
   if let concreteType = apply.concreteTypeOfDependentOpenedType,
-     apply.canReplaceExistentialArchetype()
+     apply.canReplaceLocalArchetype()
   {
-    let newArgs = apply.replaceExistentialArchetypeInArguments(withConcreteType: concreteType, context)
+    let newArgs = apply.replaceLocalArchetypeInArguments(withConcreteType: concreteType, context)
 
     let builder = Builder(after: apply, context)
 
     let newApply = builder.createApply(
       function: apply.callee,
-      apply.replaceOpenedArchetypeInSubstitutions(withConcreteType: concreteType, context),
+      apply.replaceLocalArchetypeInSubstitutions(withConcreteType: concreteType, context),
       arguments: newArgs,
       isNonThrowing: apply.isNonThrowing, isNonAsync: apply.isNonAsync,
       specializationInfo: apply.specializationInfo)
@@ -193,17 +193,17 @@ private func tryReplaceExistentialArchetype(of apply: ApplyInst, _ context: Simp
 }
 
 // The same as the previous function, just for try_apply instructions.
-private func tryReplaceExistentialArchetype(of tryApply: TryApplyInst, _ context: SimplifyContext) -> Bool {
+private func tryReplaceLocalArchetype(of tryApply: TryApplyInst, _ context: SimplifyContext) -> Bool {
   if let concreteType = tryApply.concreteTypeOfDependentOpenedType,
-     tryApply.canReplaceExistentialArchetype()
+     tryApply.canReplaceLocalArchetype()
   {
-    let newArgs = tryApply.replaceExistentialArchetypeInArguments(withConcreteType: concreteType, context)
+    let newArgs = tryApply.replaceLocalArchetypeInArguments(withConcreteType: concreteType, context)
 
     let builder = Builder(before: tryApply, context)
 
     builder.createTryApply(
       function: tryApply.callee,
-      tryApply.replaceOpenedArchetypeInSubstitutions(withConcreteType: concreteType, context),
+      tryApply.replaceLocalArchetypeInSubstitutions(withConcreteType: concreteType, context),
       arguments: newArgs,
       normalBlock: tryApply.normalBlock, errorBlock: tryApply.errorBlock,
       isNonAsync: tryApply.isNonAsync,
@@ -216,20 +216,20 @@ private func tryReplaceExistentialArchetype(of tryApply: TryApplyInst, _ context
 }
 
 private extension FullApplySite {
-  // Precondition: the apply uses only a single existential archetype.
+  // Precondition: the apply uses only a single local archetype.
   // This is checked in `concreteTypeOfDependentOpenedType`
-  func canReplaceExistentialArchetype() -> Bool {
-    // Make sure that existential archetype _is_ a replacement type and not e.g. _contained_ in a
+  func canReplaceLocalArchetype() -> Bool {
+    // Make sure that local archetype _is_ a replacement type and not e.g. _contained_ in a
     // replacement type, like
     //    apply %1<Array<@opened("...")>()
-    // TODO: support non-root existential archetypes
-    guard substitutionMap.replacementTypes.contains(where: { $0.isRootExistentialArchetype }),
-          substitutionMap.replacementTypes.allSatisfy({ $0.isRootExistentialArchetype || !$0.hasLocalArchetype })
+    // TODO: support non-root local archetypes
+    guard substitutionMap.replacementTypes.contains(where: { $0.isRootLocalArchetype }),
+          substitutionMap.replacementTypes.allSatisfy({ $0.isRootLocalArchetype || !$0.hasLocalArchetype })
     else {
       return false
     }
 
-    // Don't allow existential archetypes in direct results and error results.
+    // Don't allow local archetypes in direct results and error results.
     // Note that an opened existential value is address only, so it cannot be a direct result anyway
     // (but it can be once we have opaque values).
     // Also don't support things like direct `Array<@opened("...")>` return values.
@@ -243,23 +243,23 @@ private extension FullApplySite {
     return arguments.allSatisfy { value in
       let type = value.type
       // Allow three cases:
-             // case 1. the argument _is_ the existential archetype
-      return type.isRootExistentialArchetype ||
-             // case 2. the argument _is_ a metatype of the existential archetype
-             (type.isMetatype && type.canonicalType.instanceTypeOfMetatype.isRootExistentialArchetype) ||
-             // case 3. the argument has nothing to do with the existential archetype (or any other local archetype)
+             // case 1. the argument _is_ the local archetype
+      return type.isRootLocalArchetype ||
+             // case 2. the argument _is_ a metatype of the local archetype
+             (type.isMetatype && type.canonicalType.instanceTypeOfMetatype.isRootLocalArchetype) ||
+             // case 3. the argument has nothing to do with the local archetype (or any other local archetype)
              !type.hasLocalArchetype
     }
   }
 
-  func replaceExistentialArchetypeInArguments(
+  func replaceLocalArchetypeInArguments(
     withConcreteType concreteType: CanonicalType,
     _ context: SimplifyContext
   ) -> [Value] {
     let newArgs = argumentOperands.map { (argOp) -> Value in
       let arg = argOp.value
-      if arg.type.isExistentialArchetype {
-        // case 1. the argument _is_ the existential archetype:
+      if arg.type.isLocalArchetype {
+        // case 1. the argument _is_ the local archetype:
         //         just insert an address cast to satisfy type equivalence.
         let builder = Builder(before: self, context)
         let concreteSILType = concreteType.loweredType(in: self.parentFunction)
@@ -277,26 +277,26 @@ private extension FullApplySite {
           }
         }
       }
-      if arg.type.isMetatype, arg.type.canonicalType.instanceTypeOfMetatype.isExistentialArchetype {
-        // case 2. the argument _is_ a metatype of the existential archetype:
+      if arg.type.isMetatype, arg.type.canonicalType.instanceTypeOfMetatype.isLocalArchetype {
+        // case 2. the argument _is_ a metatype of the local archetype:
         //         re-create the metatype with the concrete type.
         let builder = Builder(before: self, context)
         return builder.createMetatype(ofInstanceType: concreteType, representation: arg.type.representationOfMetatype)
       }
-      // case 3. the argument has nothing to do with the existential archetype (or any other local archetype)
+      // case 3. the argument has nothing to do with the local archetype (or any other local archetype)
       return arg
     }
     return Array(newArgs)
   }
 
-  func replaceOpenedArchetypeInSubstitutions(
+  func replaceLocalArchetypeInSubstitutions(
     withConcreteType concreteType: CanonicalType,
     _ context: SimplifyContext
   ) -> SubstitutionMap {
-    let openedArcheType = substitutionMap.replacementTypes.first(where: { $0.isExistentialArchetype })!
+    let localArchetype = substitutionMap.replacementTypes.first(where: { $0.isLocalArchetype })!
 
     let newReplacementTypes = substitutionMap.replacementTypes.map {
-      return $0 == openedArcheType ? concreteType.rawType : $0
+      return $0 == localArchetype ? concreteType.rawType : $0
     }
     let genSig = callee.type.invocationGenericSignatureOfFunction
     return SubstitutionMap(genericSignature: genSig, replacementTypes: newReplacementTypes)

--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyApply.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyApply.swift
@@ -172,7 +172,7 @@ private func tryOptimizeEnumComparison(apply: ApplyInst, _ context: SimplifyCont
 ///   %5 = apply %1<ConcreteType>(%4) : <τ_0_0> (τ_0_0) -> ()
 /// ```
 private func tryReplaceExistentialArchetype(of apply: ApplyInst, _ context: SimplifyContext) -> Bool {
-  if let concreteType = apply.concreteTypeOfDependentExistentialArchetype,
+  if let concreteType = apply.concreteTypeOfDependentOpenedType,
      apply.canReplaceExistentialArchetype()
   {
     let newArgs = apply.replaceExistentialArchetypeInArguments(withConcreteType: concreteType, context)
@@ -194,7 +194,7 @@ private func tryReplaceExistentialArchetype(of apply: ApplyInst, _ context: Simp
 
 // The same as the previous function, just for try_apply instructions.
 private func tryReplaceExistentialArchetype(of tryApply: TryApplyInst, _ context: SimplifyContext) -> Bool {
-  if let concreteType = tryApply.concreteTypeOfDependentExistentialArchetype,
+  if let concreteType = tryApply.concreteTypeOfDependentOpenedType,
      tryApply.canReplaceExistentialArchetype()
   {
     let newArgs = tryApply.replaceExistentialArchetypeInArguments(withConcreteType: concreteType, context)
@@ -217,7 +217,7 @@ private func tryReplaceExistentialArchetype(of tryApply: TryApplyInst, _ context
 
 private extension FullApplySite {
   // Precondition: the apply uses only a single existential archetype.
-  // This is checked in `concreteTypeOfDependentExistentialArchetype`
+  // This is checked in `concreteTypeOfDependentOpenedType`
   func canReplaceExistentialArchetype() -> Bool {
     // Make sure that existential archetype _is_ a replacement type and not e.g. _contained_ in a
     // replacement type, like

--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyWitnessMethod.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyWitnessMethod.swift
@@ -30,7 +30,7 @@ extension WitnessMethodInst : Simplifiable, SILCombineSimplifiable {
 ///   %3 = witness_method $ConcreteType, #P.foo, %2
 /// ```
 private func tryReplaceExistentialArchetype(of witnessMethod: WitnessMethodInst, _ context: SimplifyContext) -> Bool {
-  guard let concreteType = witnessMethod.concreteTypeOfDependentExistentialArchetype else {
+  guard let concreteType = witnessMethod.concreteTypeOfDependentOpenedType else {
     return false
   }
   let conf = concreteType.checkConformance(to: witnessMethod.lookupProtocol)

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/OptUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/OptUtils.swift
@@ -575,21 +575,53 @@ extension Instruction {
     }
   }
 
-  /// If this instruction uses a (single) existential archetype, i.e. it has a type-dependent operand,
-  /// returns the concrete type if it is known.
-  var concreteTypeOfDependentExistentialArchetype: CanonicalType? {
+  /// If this instruction uses a (single) existential archetype or opened pack
+  /// element, i.e. it has a type-dependent operand, returns the concrete type
+  /// if it is known.
+  var concreteTypeOfDependentOpenedType: CanonicalType? {
     // For simplicity only support a single type dependent operand, which is true in most of the cases anyway.
-    if let openArchetypeOp = typeDependentOperands.singleElement,
-       // Match the sequence
-       //   %1 = metatype $T
-       //   %2 = init_existential_metatype %1, any P.Type
-       //   %3 = open_existential_metatype %2 to $@opened(...)
-       //   this_instruction_which_uses $@opened(...)  // type-defs: %3
-       let oemt = openArchetypeOp.value as? OpenExistentialMetatypeInst,
-       let iemt = oemt.operand.value as? InitExistentialMetatypeInst,
-       let mt = iemt.metatype as? MetatypeInst
-    {
-      return mt.type.canonicalType.instanceTypeOfMetatype
+    if let openArchetypeOp = typeDependentOperands.singleElement {
+      // Match the sequence
+      //   %1 = metatype $T
+      //   %2 = init_existential_metatype %1, any P.Type
+      //   %3 = open_existential_metatype %2 to $@opened(...)
+      //   this_instruction_which_uses $@opened(...)  // type-defs: %3
+      if let oemt = openArchetypeOp.value as? OpenExistentialMetatypeInst,
+        let iemt = oemt.operand.value as? InitExistentialMetatypeInst,
+        let mt = iemt.metatype as? MetatypeInst
+      {
+        return mt.type.canonicalType.instanceTypeOfMetatype
+      }
+
+      // Match the sequence
+      //  %1 = any_pack_index ...
+      //  %2 = open_pack_element %1 of <each ...> at <[[CONCRETE_PACK_TYPE]]>, shape $each T, uuid "[[UUID]]"
+      //  this_instruction_which_uses $@pack_element("[[UUID]]") // type-defs: %2
+      if let opet = openArchetypeOp.value as? OpenPackElementInst,
+         let opit = opet.operand.value as? AnyPackIndexInst,
+         let packIndex = opit.staticIndex
+      {
+        let environment = opet.openedGenericEnvironment
+
+        // TODO: Find a way to determine which opened pack type our type
+        // dependent operand corresponds to, which would allow us to get the
+        // concrete type even if there were multiple opened pack parameters.
+        if let genericPackTypeParam = environment.openedPackParams.singleElement
+        {
+          let packType = environment.mapTypeIntoEnvironment(genericPackTypeParam)
+          assert(packType.isPack)
+
+          let elementTypes = packType.elementTypesOfPackType
+          // If there is a pack expansion at or before packIndex, we can't
+          // statically determine what type is at the index.
+          if !elementTypes.indices.contains(packIndex) ||
+               elementTypes.prefix(packIndex).contains(where: { $0.isPackExpansion }) {
+            return nil
+          }
+
+          return elementTypes[packIndex].canonical
+        }
+      }
     }
     // TODO: also handle open_existential_addr and open_existential_ref.
     // Those cases are currently handled in SILCombine's `propagateConcreteTypeOfInitExistential`.

--- a/SwiftCompilerSources/Sources/SIL/Instruction.swift
+++ b/SwiftCompilerSources/Sources/SIL/Instruction.swift
@@ -1985,7 +1985,11 @@ final public class AllocPackMetadataInst : SingleValueInstruction, Allocation {}
 final public class DeallocPackInst : Instruction, UnaryInstruction, Deallocation {}
 final public class DeallocPackMetadataInst : Instruction, Deallocation {}
 
-final public class OpenPackElementInst : SingleValueInstruction {}
+final public class OpenPackElementInst : SingleValueInstruction, UnaryInstruction {
+  public var openedGenericEnvironment: GenericEnvironment {
+    GenericEnvironment(bridged: bridged.OpenPackElementInst_getOpenedGenericEnvironment())
+  }
+}
 final public class PackLengthInst : SingleValueInstruction {
   public var packType: CanonicalType {
     CanonicalType(bridged: bridged.PackLengthInst_getPackType())
@@ -2003,8 +2007,18 @@ extension AnyPackIndexInst {
   }
 }
 
-final public class DynamicPackIndexInst : SingleValueInstruction, AnyPackIndexInst {}
-final public class PackPackIndexInst : SingleValueInstruction, AnyPackIndexInst {}
+final public class DynamicPackIndexInst : SingleValueInstruction, UnaryInstruction, AnyPackIndexInst {}
+final public class PackPackIndexInst : SingleValueInstruction, UnaryInstruction, AnyPackIndexInst {
+  public var componentStartIndex: Int {
+    Int(bridged.PackPackIndexInst_getComponentStartIndex())
+  }
+  public var componentEndIndex: Int {
+    Int(bridged.PackPackIndexInst_getComponentEndIndex())
+  }
+  public var sliceIndexOperand: AnyPackIndexInst {
+    operand.value as! AnyPackIndexInst
+  }
+}
 final public class ScalarPackIndexInst : SingleValueInstruction, AnyPackIndexInst {
   public var componentIndex: Int {
     Int(bridged.ScalarPackIndexInst_getComponentIndex())

--- a/SwiftCompilerSources/Sources/SIL/Instruction.swift
+++ b/SwiftCompilerSources/Sources/SIL/Instruction.swift
@@ -1999,6 +1999,8 @@ final public class PackLengthInst : SingleValueInstruction {
 @_semantics("fast_cast")
 public protocol AnyPackIndexInst : SingleValueInstruction {
   var indexedPackType: CanonicalType { get }
+  // The index of the pack element being accessed, if it is statically known.
+  var staticIndex: Int? { get }
 }
 
 extension AnyPackIndexInst {
@@ -2007,7 +2009,12 @@ extension AnyPackIndexInst {
   }
 }
 
-final public class DynamicPackIndexInst : SingleValueInstruction, UnaryInstruction, AnyPackIndexInst {}
+final public class DynamicPackIndexInst : SingleValueInstruction, UnaryInstruction, AnyPackIndexInst {
+  public var staticIndex: Int? {
+    (operand.value as? IntegerLiteralInst)?.value
+  }
+}
+
 final public class PackPackIndexInst : SingleValueInstruction, UnaryInstruction, AnyPackIndexInst {
   public var componentStartIndex: Int {
     Int(bridged.PackPackIndexInst_getComponentStartIndex())
@@ -2018,10 +2025,22 @@ final public class PackPackIndexInst : SingleValueInstruction, UnaryInstruction,
   public var sliceIndexOperand: AnyPackIndexInst {
     operand.value as! AnyPackIndexInst
   }
+  public var staticIndex: Int? {
+    if let staticSliceIndex = sliceIndexOperand.staticIndex {
+      // This instruction produces a dynamic index into a slice of the operand
+      // pack, which starts at componentStartIndex.
+      return componentStartIndex + staticSliceIndex
+    }
+    return nil
+  }
 }
+
 final public class ScalarPackIndexInst : SingleValueInstruction, AnyPackIndexInst {
   public var componentIndex: Int {
     Int(bridged.ScalarPackIndexInst_getComponentIndex())
+  }
+  public var staticIndex: Int? {
+    componentIndex
   }
 }
 

--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -60,6 +60,7 @@ enum class DifferentiabilityKind : uint8_t;
 class Fingerprint;
 class Identifier;
 class IfConfigClauseRangeInfo;
+class GenericEnvironment;
 class GenericSignature;
 class GenericSignatureImpl;
 struct LabeledStmtInfo;
@@ -93,6 +94,7 @@ class BridgedLangOptions;
 struct BridgedSubstitutionMap;
 struct BridgedGenericSignature;
 struct BridgedCanGenericSignature;
+struct BridgedGenericEnvironment;
 struct BridgedConformance;
 class BridgedParameterList;
 
@@ -3082,6 +3084,7 @@ struct BridgedASTType {
   BRIDGED_INLINE bool archetypeRequiresClass() const;
   BRIDGED_INLINE bool isExistentialArchetype() const;
   BRIDGED_INLINE bool isExistentialArchetypeWithError() const;
+  BRIDGED_INLINE bool isLocalArchetype() const;
   BRIDGED_INLINE bool isExistential() const;
   BRIDGED_INLINE bool isDynamicSelf() const;
   BRIDGED_INLINE bool isClassExistential() const;
@@ -3105,6 +3108,7 @@ struct BridgedASTType {
   BRIDGED_INLINE bool isBuiltinFixedArray() const;
   BRIDGED_INLINE bool isBox() const;
   BRIDGED_INLINE bool isPack() const;
+  BRIDGED_INLINE bool isPackExpansion() const;
   BRIDGED_INLINE bool isSILPack() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedASTType getBuiltinVectorElementType() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedCanType getBuiltinFixedArrayElementType() const;
@@ -3145,6 +3149,8 @@ struct BridgedASTType {
   BRIDGED_INLINE bool isSILPackElementAddress() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedASTTypeArray
   BoundGenericType_getGenericArgs() const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedASTTypeArray
+  PackType_getElementTypes() const;
 };
 
 class BridgedCanType {
@@ -3230,6 +3236,17 @@ struct BridgedCanGenericSignature {
   BRIDGED_INLINE swift::CanGenericSignature unbridged() const;
   BRIDGED_INLINE BridgedGenericSignature getGenericSignature() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedASTType mapTypeIntoEnvironment(BridgedASTType type) const;
+};
+
+struct BridgedGenericEnvironment {
+  swift::GenericEnvironment * _Nonnull env;
+
+  BRIDGED_INLINE swift::GenericEnvironment * _Nonnull unbridged() const;
+  BridgedOwnedString getDebugDescription() const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedASTTypeArray getOpenedPackParams() const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedASTType mapTypeIntoEnvironment(BridgedASTType type) const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedASTType
+  mapElementTypeIntoPackContext(BridgedASTType type) const;
 };
 
 struct BridgedFingerprint {

--- a/include/swift/AST/ASTBridgingImpl.h
+++ b/include/swift/AST/ASTBridgingImpl.h
@@ -575,6 +575,10 @@ bool BridgedASTType::isExistentialArchetypeWithError() const {
   return unbridged()->isOpenedExistentialWithError();
 }
 
+bool BridgedASTType::isLocalArchetype() const {
+  return unbridged()->is<swift::LocalArchetypeType>();
+}
+
 bool BridgedASTType::isExistential() const {
   return unbridged()->is<swift::ExistentialType>();
 }
@@ -671,6 +675,10 @@ bool BridgedASTType::isBox() const {
 
 bool BridgedASTType::isPack() const {
   return unbridged()->is<swift::PackType>();
+}
+
+bool BridgedASTType::isPackExpansion() const {
+  return unbridged()->is<swift::PackExpansionType>();
 }
 
 bool BridgedASTType::isSILPack() const {
@@ -838,6 +846,10 @@ BridgedASTType::GenericTypeParam_getParamKind() const {
 
 BridgedASTTypeArray BridgedASTType::BoundGenericType_getGenericArgs() const {
   return {llvm::cast<swift::BoundGenericType>(type)->getGenericArgs()};
+}
+
+BridgedASTTypeArray BridgedASTType::PackType_getElementTypes() const {
+  return {llvm::cast<swift::PackType>(type)->getElementTypes()};
 }
 
 static_assert((int)BridgedASTType::TraitResult::IsNot == (int)swift::TypeTraitResult::IsNot);
@@ -1076,6 +1088,27 @@ swift::CanGenericSignature BridgedCanGenericSignature::unbridged() const {
 BridgedGenericSignature
 BridgedCanGenericSignature::getGenericSignature() const {
   return BridgedGenericSignature{impl};
+}
+
+//===----------------------------------------------------------------------===//
+// MARK: BridgedGenericEnvironment
+//===----------------------------------------------------------------------===//
+
+swift::GenericEnvironment * _Nonnull BridgedGenericEnvironment::unbridged() const {
+  return env;
+}
+
+BridgedASTTypeArray BridgedGenericEnvironment::getOpenedPackParams() const {
+  return {env->getOpenedPackParams()};
+}
+
+BridgedASTType BridgedGenericEnvironment::mapTypeIntoEnvironment(BridgedASTType type) const {
+  return {env->mapTypeIntoEnvironment(type.unbridged()).getPointer()};
+}
+
+BridgedASTType
+BridgedGenericEnvironment::mapElementTypeIntoPackContext(BridgedASTType type) const {
+  return {env->mapElementTypeIntoPackContext(type.unbridged()).getPointer()};
 }
 
 //===----------------------------------------------------------------------===//

--- a/include/swift/AST/GenericEnvironment.h
+++ b/include/swift/AST/GenericEnvironment.h
@@ -129,12 +129,6 @@ private:
   /// generic signature.
   ArrayRef<Type> getContextTypes() const;
 
-  /// Retrieve the array of opened pack parameters for this opened-element
-  /// environment.  This is parallel to the array of element parameters,
-  /// i.e. the innermost generic context.
-  MutableArrayRef<Type> getOpenedPackParams();
-  ArrayRef<Type> getOpenedPackParams() const;
-
   /// Get the nested type storage, allocating it if required.
   NestedTypeStorage &getOrCreateNestedTypeStorage();
 
@@ -178,6 +172,12 @@ public:
   bool isCanonical() const { return canonical; }
 
   ArrayRef<GenericTypeParamType *> getGenericParams() const;
+
+  /// Retrieve the array of opened pack parameters for this opened-element
+  /// environment.  This is parallel to the array of element parameters,
+  /// i.e. the innermost generic context.
+  MutableArrayRef<Type> getOpenedPackParams();
+  ArrayRef<Type> getOpenedPackParams() const;
 
   /// Retrieve the existential type for an opened existential environment.
   Type getOpenedExistentialType() const;

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -957,7 +957,10 @@ struct BridgedInstruction {
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedCanType TypeValueInst_getParamType() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedCanType PackLengthInst_getPackType() const;
   BRIDGED_INLINE SwiftInt ScalarPackIndexInst_getComponentIndex() const;
+  BRIDGED_INLINE SwiftInt PackPackIndexInst_getComponentStartIndex() const;
+  BRIDGED_INLINE SwiftInt PackPackIndexInst_getComponentEndIndex() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedCanType AnyPackIndexInst_getIndexedPackType() const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedGenericEnvironment OpenPackElementInst_getOpenedGenericEnvironment() const;
   BRIDGED_INLINE bool
   DifferentiableFunctionInst_hasExtractee(SwiftInt extractee) const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedValue

--- a/include/swift/SIL/SILBridgingImpl.h
+++ b/include/swift/SIL/SILBridgingImpl.h
@@ -1914,8 +1914,20 @@ SwiftInt BridgedInstruction::ScalarPackIndexInst_getComponentIndex() const {
   return getAs<swift::ScalarPackIndexInst>()->getComponentIndex();
 }
 
+SwiftInt BridgedInstruction::PackPackIndexInst_getComponentStartIndex() const {
+  return getAs<swift::PackPackIndexInst>()->getComponentStartIndex();
+}
+
+SwiftInt BridgedInstruction::PackPackIndexInst_getComponentEndIndex() const {
+  return getAs<swift::PackPackIndexInst>()->getComponentEndIndex();
+}
+
 BridgedCanType BridgedInstruction::AnyPackIndexInst_getIndexedPackType() const {
   return getAs<swift::AnyPackIndexInst>()->getIndexedPackType();
+}
+
+BridgedGenericEnvironment BridgedInstruction::OpenPackElementInst_getOpenedGenericEnvironment() const {
+  return {getAs<swift::OpenPackElementInst>()->getOpenedGenericEnvironment()};
 }
 
 bool BridgedInstruction::DifferentiableFunctionInst_hasExtractee(

--- a/lib/AST/Bridging/MiscBridging.cpp
+++ b/lib/AST/Bridging/MiscBridging.cpp
@@ -152,6 +152,17 @@ BridgedOwnedString BridgedGenericSignature::getDebugDescription() const {
 }
 
 //===----------------------------------------------------------------------===//
+// MARK: BridgedGenericEnvironment
+//===----------------------------------------------------------------------===//
+
+BridgedOwnedString BridgedGenericEnvironment::getDebugDescription() const {
+  std::string str;
+  llvm::raw_string_ostream os(str);
+  unbridged()->dump(os);
+  return BridgedOwnedString(str);
+}
+
+//===----------------------------------------------------------------------===//
 // MARK: BridgedPoundKeyword
 //===----------------------------------------------------------------------===//
 

--- a/test/SILOptimizer/issue-82000.swift
+++ b/test/SILOptimizer/issue-82000.swift
@@ -1,0 +1,37 @@
+// RUN: %target-swift-frontend %s -emit-ir -O -solver-disable-crash-on-valid-salvage | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+
+// Missed optimization combining pointers and parameter packs #82000
+func applyPointer<each T>(input: repeat UnsafePointer<each T>, op: (repeat each T) -> Int) -> Int {
+  op(repeat (each input).pointee)
+}
+
+// TODO: This should constant-fold to 27, like testDirect below.
+// CHECK: define {{.*}} i64 @"$s4main4testSiyF"()
+// CHECK-NEXT: entry:
+// CHECK-NEXT: [[OP1_LOC:%[0-9]+]] = alloca %TSi
+// CHECK-NEXT: [[OP2_LOC:%[0-9]+]] = alloca %TSi
+// CHECK-NEXT: [[IN_LOC:%[0-9]+]] = alloca %TSi
+// CHECK:      store i64 27, ptr [[IN_LOC]], align 8
+// CHECK:      %InitializeWithCopy.i(ptr noalias nonnull [[OP1_LOC]], ptr noalias nonnull [[IN_LOC]], ptr nonnull @"$sSiN")
+// CHECK-NEXT:      %InitializeWithCopy.i(ptr noalias nonnull [[OP2_LOC]], ptr noalias nonnull [[IN_LOC]], ptr nonnull @"$sSiN")
+// CHECK-NEXT: [[OP1:%[0-9]+]] = load {{.*}} [[OP1_LOC]]
+// CHECK-NEXT: [[OP2:%[0-9]+]] = load {{.*}} [[OP2_LOC]]
+// CHECK-NEXT: [[RESULT:%[0-9]+]] = call { i64, i1 } @llvm.sadd.with.overflow.i64(i64 [[OP1]], i64 [[OP2]])
+public func test() -> Int {
+    withUnsafePointer(to: 27) {
+        applyPointer(input: $0, $0) { ($0 + $1) }
+    }
+}
+
+func applyDirect<each T>(input: repeat each T, op: (repeat each T) -> Int) -> Int {
+  op(repeat (each input))
+}
+
+// CHECK: define {{.*}} i64 @"$s4main10testDirectSiyF"()
+// CHECK-NEXT: entry:
+// CHECK-NEXT: ret i64 54
+public func testDirect() -> Int {
+    applyDirect(input: 27, 27) { ($0 + $1) }
+}

--- a/test/SILOptimizer/pack_specialization.swift
+++ b/test/SILOptimizer/pack_specialization.swift
@@ -21,14 +21,11 @@ public func copyPackCaller(two: UnsafePointer<Int16>) -> (Int32, UnsafePointer<I
   return copyPack(xs: 1, two, 3.0)
 }
 
-// The pack specialization pass alone is not enough to eliminate packs when witness methods are called.
+// When iterating over a single pack, all pack code can be fully eliminated.
 // CHECK: define {{.*}} i32 @"$s19pack_specialization11addTogether2xsxxQp_txxQp_tRvzSjRzlFs5Int32V_QP_Tg5Tf8xx_n"(i32 %0)
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[IN_STACK:%[0-9]+]] = alloca %Ts5Int32V, align 4
-// CHECK-NEXT:    [[OUT_STACK:%[0-9]+]] = alloca %Ts5Int32V, align 4
-// CHECK:         store i32 %0, ptr [[IN_STACK]], align 4
-// CHECK:         call swiftcc void @"$ss18AdditiveArithmeticP1poiyxx_xtFZTj"
-// CHECK:         [[RESULT:%[0-9]+]] = load i32, ptr [[OUT_STACK]]
+// CHECK-NEXT:    [[SUM:%[0-9]+]] = tail call { i32, i1 } @llvm.sadd.with.overflow.i32(i32 %0, i32 %0)
+// CHECK:         [[RESULT:%[0-9]+]] = extractvalue { i32, i1 } %1, 0
 // CHECK:         ret i32 [[RESULT]]
 @inline(never)
 func addTogether<each A: Numeric>(xs: repeat each A) -> (repeat each A) {
@@ -37,4 +34,21 @@ func addTogether<each A: Numeric>(xs: repeat each A) -> (repeat each A) {
 
 public func addTogetherCaller() -> Int32 {
   return addTogether(xs: 1)
+}
+
+// When iterating over multiple packs simultaneously, some pack code cannot be
+// eliminated, so we still access the witness table in the resulting IR.
+// CHECK: define {{.*}} { i64, i64 } @"$s19pack_specialization8zipPacks2xs2zsx_q_txQp_txxQp_q_xQptRvzRv_SzRzq_RhzSzR_r0_lFs5Int32V_s6UInt32VQP_s4Int8V_s5Int16VQPTg5Tf8xxx_n"(i32 %0, i32 %1, i8 %2, i16 %3)
+// CHECK: @"$ss5Int32VABSzsWl"()
+// CHECK: @swift_getTupleTypeMetadata2{{.*}} @"$ss5Int32VN"
+// CHECK: @swift_getAssociatedTypeWitness{{.*}}
+// CHECK: call{{.*}}@"$sSj1moiyxx_xtFZTj"
+@inline(never)
+func zipPacks<each A: BinaryInteger, each B: BinaryInteger>(xs: repeat each A, zs: repeat each B) -> (repeat (each A, each B)) {
+  return (repeat (each xs * 2, each zs * 2))
+}
+
+public func zipAddPacksCaller(x: Int32, y: UInt32, a: Int8, b: Int16)
+  -> ((Int32, Int8), (UInt32, Int16)) {
+  return zipPacks(xs: x, y, zs: a, b)
 }

--- a/test/SILOptimizer/pack_specialization.swift
+++ b/test/SILOptimizer/pack_specialization.swift
@@ -52,3 +52,31 @@ public func zipAddPacksCaller(x: Int32, y: UInt32, a: Int8, b: Int16)
   -> ((Int32, Int8), (UInt32, Int16)) {
   return zipPacks(xs: x, y, zs: a, b)
 }
+
+// When applying a generic function to each element of a pack, the callee can be
+// specialized if the (variadic generic) caller is specialized.
+func numericOp<T: BinaryInteger>(_ x: T) -> T {
+  if x <= 1 {
+    return x
+  } else {
+    let (p, q) = numericLoop(x - 1, x - 2)
+    return p + q
+  }
+}
+
+// CHECK: define {{.*}} i64 @"$s19pack_specialization11numericLoopyxxQp_txxQpRvzSzRzlFs5Int32V_ADQP_Tg5Tf8xx_n"(i32 %0, i32 %1)
+// CHECK: [[SP1:%[0-9]+]] = add nsw i32 %0, -1
+// CHECK: [[SP2:%[0-9]+]] = add nsw i32 %0, -2
+// CHECK: [[SP_RESULT:%[0-9]+]] = tail call {{.*}} @"$s19pack_specialization11numericLoopyxxQp_txxQpRvzSzRzlFs5Int32V_ADQP_Tg5Tf8xx_n"(i32 [[SP1]], i32 [[SP2]])
+// CHECK-NEXT: [[SP_RESULT1:%[^ ]+]] = trunc i64 [[SP_RESULT]] to i32
+// CHECK-NEXT: [[SP_RESULT2_64:%[^ ]+]] = lshr i64 [[SP_RESULT]], 32
+// CHECK-NEXT: [[SP_RESULT2:%[^ ]+]] = trunc nuw i64 [[SP_RESULT2_64]] to i32
+// CHECK: tail call { i32, i1 } @llvm.sadd.with.overflow.i32(i32 [[SP_RESULT1]], i32 [[SP_RESULT2]])
+@inline(never)
+func numericLoop<each T: BinaryInteger>(_ xs: repeat each T) -> (repeat each T) {
+  return (repeat numericOp(each xs))
+}
+
+public func callNumericLoop() -> (Int32, Int32) {
+  numericLoop(39, 39)
+}

--- a/test/SILOptimizer/simplify_alloc_stack.sil
+++ b/test/SILOptimizer/simplify_alloc_stack.sil
@@ -813,3 +813,20 @@ bb0(%0 : $*V, %1 : $@thick V.Type, %2 : @owned $C2):
   %137 = tuple ()
   return %137
 }
+
+// TODO: replace pack element archetypes once the isExistentialArchetype check (Case 3) is
+// extended to also cover @pack_element types. For now, the alloc_stack is not simplified.
+
+// CHECK-LABEL: sil [ossa] @dont_replace_pack_element_archetype :
+// CHECK:         alloc_stack $@pack_element
+// CHECK:       } // end sil function 'dont_replace_pack_element_archetype'
+sil [ossa] @dont_replace_pack_element_archetype : $@convention(thin) () -> () {
+bb0:
+  %idx = scalar_pack_index 0 of $Pack{T1}
+  open_pack_element %idx of <each E where repeat each E : P> at <Pack{T1}>, shape $each E, uuid "55555555-0000-0000-0000-000000000000"
+  %stk = alloc_stack $@pack_element("55555555-0000-0000-0000-000000000000") each E
+  dealloc_stack %stk
+  %r = tuple ()
+  return %r : $()
+}
+

--- a/test/SILOptimizer/simplify_apply.sil
+++ b/test/SILOptimizer/simplify_apply.sil
@@ -323,14 +323,11 @@ bb0:
   return %9
 }
 
-// TODO: replace pack element archetypes once canReplaceExistentialArchetype() handles them.
-// The canReplaceExistentialArchetype() guard checks isRootExistentialArchetype, which is
-// false for @pack_element types, so the apply is not simplified.
-
-// CHECK-LABEL: sil [ossa] @dont_replace_pack_element_archetype :
-// CHECK:         apply %{{.*}}<@pack_element
-// CHECK:       } // end sil function 'dont_replace_pack_element_archetype'
-sil [ossa] @dont_replace_pack_element_archetype : $@convention(thin) (@in_guaranteed S) -> () {
+// CHECK-LABEL: sil [ossa] @replace_pack_element_archetype :
+// CHECKONONE:    apply %{{.*}}<@pack_element
+// CHECKO:        apply %{{.*}}<S>(
+// CHECK:       } // end sil function 'replace_pack_element_archetype'
+sil [ossa] @replace_pack_element_archetype : $@convention(thin) (@in_guaranteed S) -> () {
 bb0(%s : $*S):
   %idx = scalar_pack_index 0 of $Pack{S}
   open_pack_element %idx of <each T where repeat each T : P> at <Pack{S}>, shape $each T, uuid "44444444-0000-0000-0000-000000000000"

--- a/test/SILOptimizer/simplify_apply.sil
+++ b/test/SILOptimizer/simplify_apply.sil
@@ -98,6 +98,7 @@ sil @createit : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@thick τ_0_0.Type
 sil @create2 : $@convention(thin) <τ_0_0 where τ_0_0 : Q> (Int) -> @out τ_0_0
 sil @useGenS : $@convention(thin) <τ_0_0 where τ_0_0 : P> (GenS<τ_0_0>) -> ()
 sil @returnGenS : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@thick τ_0_0.Type) -> GenS<τ_0_0>
+sil @use_p : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> ()
 
 // CHECK-LABEL: sil [ossa] @replace_archetype :
 // CHECKO:        [[E:%.*]] = init_existential_addr %0
@@ -321,4 +322,23 @@ bb0:
   %9 = tuple ()
   return %9
 }
+
+// TODO: replace pack element archetypes once canReplaceExistentialArchetype() handles them.
+// The canReplaceExistentialArchetype() guard checks isRootExistentialArchetype, which is
+// false for @pack_element types, so the apply is not simplified.
+
+// CHECK-LABEL: sil [ossa] @dont_replace_pack_element_archetype :
+// CHECK:         apply %{{.*}}<@pack_element
+// CHECK:       } // end sil function 'dont_replace_pack_element_archetype'
+sil [ossa] @dont_replace_pack_element_archetype : $@convention(thin) (@in_guaranteed S) -> () {
+bb0(%s : $*S):
+  %idx = scalar_pack_index 0 of $Pack{S}
+  open_pack_element %idx of <each T where repeat each T : P> at <Pack{S}>, shape $each T, uuid "44444444-0000-0000-0000-000000000000"
+  %s_cast = unchecked_addr_cast %s to $*@pack_element("44444444-0000-0000-0000-000000000000") each T
+  %fn = function_ref @use_p : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> ()
+  apply %fn<@pack_element("44444444-0000-0000-0000-000000000000") each T>(%s_cast) : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> ()
+  %r = tuple ()
+  return %r : $()
+}
+
 

--- a/test/SILOptimizer/simplify_try_apply.sil
+++ b/test/SILOptimizer/simplify_try_apply.sil
@@ -62,6 +62,7 @@ sil_vtable Bar {
 sil @createit : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@thick τ_0_0.Type) -> (@out τ_0_0, @error any Error)
 sil @returnGenS : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@thick τ_0_0.Type) -> (GenS<τ_0_0>, @error any Error)
 sil @throwGenError : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@thick τ_0_0.Type) -> ((), @error GenError<τ_0_0>)
+sil @use_p_throwing : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> ((), @error any Error)
 
 // CHECK-LABEL: sil [ossa] @replace_archetype :
 // CHECKO:        [[E:%.*]] = init_existential_addr %0
@@ -158,4 +159,23 @@ bb3:
   destroy_value %5
   %9 = tuple ()
   return %9
+}
+
+// CHECK-LABEL: sil [ossa] @replace_pack_element_archetype :
+// CHECKONONE:    apply %{{.*}}<@pack_element
+// CHECKO:        try_apply %{{.*}}<S>(
+// CHECK:       } // end sil function 'replace_pack_element_archetype'
+sil [ossa] @replace_pack_element_archetype : $@convention(thin) (@in_guaranteed S) -> ((), @error any Error) {
+bb0(%s : $*S):
+  %idx = scalar_pack_index 0 of $Pack{S}
+  open_pack_element %idx of <each T where repeat each T : P> at <Pack{S}>, shape $each T, uuid "44444444-0000-0000-0000-000000000000"
+  %s_cast = unchecked_addr_cast %s to $*@pack_element("44444444-0000-0000-0000-000000000000") each T
+  %fn = function_ref @use_p_throwing : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> ((), @error any Error)
+  try_apply %fn<@pack_element("44444444-0000-0000-0000-000000000000") each T>(%s_cast) : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> ((), @error any Error), normal bb1, error bb2
+
+bb1(%r : $()):
+  return %r : $()
+
+bb2(%err : $any Error):
+  throw %err : $any Error
 }

--- a/test/SILOptimizer/simplify_witness_method.sil
+++ b/test/SILOptimizer/simplify_witness_method.sil
@@ -13,6 +13,12 @@ struct S: P {
   func foo()
 }
 
+struct S2: P {
+  var y: Int
+
+  func foo()
+}
+
 // CHECK-LABEL: sil [ossa] @replace_archetype :
 // CHECK:        = witness_method $S, #P.foo : <Self where Self : P> (Self) -> () -> () : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@thick τ_0_0.Type) -> ()
 // CHECK:       } // end sil function 'replace_archetype'
@@ -37,5 +43,94 @@ bb0(%0 : $@thick any P.Type):
   %4 = apply %3<@opened("82105EE0-DCB0-11E5-865D-C8E0EB309913", P) Self>(%2) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@thick τ_0_0.Type) -> ()
   %5 = tuple ()
   return %5
+}
+
+// Concrete type is determined via the pack element case:
+// %0 = scalar_pack_index 0 of $Pack{S}
+// open_pack_element %0 of <each T where repeat each T : P> at <Pack{S}>, shape $each T, uuid "..."
+// witness_method $@pack_element("...") each T, #P.foo
+
+// CHECK-LABEL: sil [ossa] @replace_pack_element_archetype :
+// CHECK:        = witness_method $S, #P.foo
+// CHECK:       } // end sil function 'replace_pack_element_archetype'
+sil [ossa] @replace_pack_element_archetype : $@convention(thin) () -> () {
+bb0:
+  %0 = scalar_pack_index 0 of $Pack{S}
+  open_pack_element %0 of <each T where repeat each T : P> at <Pack{S}>, shape $each T, uuid "11111111-0000-0000-0000-000000000000"
+  %1 = metatype $@thick (@pack_element("11111111-0000-0000-0000-000000000000") each T).Type
+  %2 = witness_method $@pack_element("11111111-0000-0000-0000-000000000000") each T, #P.foo, %1 : $@thick (@pack_element("11111111-0000-0000-0000-000000000000") each T).Type : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@thick τ_0_0.Type) -> ()
+  %3 = apply %2<@pack_element("11111111-0000-0000-0000-000000000000") each T>(%1) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@thick τ_0_0.Type) -> ()
+  %4 = tuple ()
+  return %4 : $()
+}
+
+// Concrete type is determined via a composed pack_pack_index:
+// %inner = scalar_pack_index 0 of $Pack{S}  -- staticIndex=0
+// %outer = pack_pack_index 1, %inner of $Pack{S2, S}  -- staticIndex=1+0=1
+// open_pack_element %outer of <...> at <Pack{S2, S}> → concrete type at index 1 = S
+
+// CHECK-LABEL: sil [ossa] @replace_pack_pack_index_archetype :
+// CHECK:        = witness_method $S, #P.foo
+// CHECK:       } // end sil function 'replace_pack_pack_index_archetype'
+sil [ossa] @replace_pack_pack_index_archetype : $@convention(thin) () -> () {
+bb0:
+  %0 = scalar_pack_index 0 of $Pack{S}
+  %1 = pack_pack_index 1, %0 of $Pack{S2, S}
+  open_pack_element %1 of <each T where repeat each T : P> at <Pack{S2, S}>, shape $each T, uuid "22222222-0000-0000-0000-000000000000"
+  %2 = metatype $@thick (@pack_element("22222222-0000-0000-0000-000000000000") each T).Type
+  %3 = witness_method $@pack_element("22222222-0000-0000-0000-000000000000") each T, #P.foo, %2 : $@thick (@pack_element("22222222-0000-0000-0000-000000000000") each T).Type : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@thick τ_0_0.Type) -> ()
+  %4 = apply %3<@pack_element("22222222-0000-0000-0000-000000000000") each T>(%2) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@thick τ_0_0.Type) -> ()
+  %5 = tuple ()
+  return %5 : $()
+}
+
+// No simplification: dynamic_pack_index has no static index.
+
+// CHECK-LABEL: sil [ossa] @dont_replace_pack_element_dynamic_index :
+// CHECK:        = witness_method $@pack_element
+// CHECK:       } // end sil function 'dont_replace_pack_element_dynamic_index'
+sil [ossa] @dont_replace_pack_element_dynamic_index : $@convention(thin) (Builtin.Word) -> () {
+bb0(%raw : $Builtin.Word):
+  %0 = dynamic_pack_index %raw of $Pack{S}
+  open_pack_element %0 of <each T where repeat each T : P> at <Pack{S}>, shape $each T, uuid "33333333-0000-0000-0000-000000000000"
+  %1 = metatype $@thick (@pack_element("33333333-0000-0000-0000-000000000000") each T).Type
+  %2 = witness_method $@pack_element("33333333-0000-0000-0000-000000000000") each T, #P.foo, %1 : $@thick (@pack_element("33333333-0000-0000-0000-000000000000") each T).Type : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@thick τ_0_0.Type) -> ()
+  %3 = apply %2<@pack_element("33333333-0000-0000-0000-000000000000") each T>(%1) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@thick τ_0_0.Type) -> ()
+  %4 = tuple ()
+  return %4 : $()
+}
+
+// No simplification: pack_pack_index wraps a dynamic_pack_index, so no static index.
+
+// CHECK-LABEL: sil [ossa] @dont_replace_pack_pack_index_dynamic :
+// CHECK:        = witness_method $@pack_element
+// CHECK:       } // end sil function 'dont_replace_pack_pack_index_dynamic'
+sil [ossa] @dont_replace_pack_pack_index_dynamic : $@convention(thin) (Builtin.Word) -> () {
+bb0(%raw : $Builtin.Word):
+  %0 = dynamic_pack_index %raw of $Pack{S}
+  %1 = pack_pack_index 1, %0 of $Pack{S2, S}
+  open_pack_element %1 of <each T where repeat each T : P> at <Pack{S2, S}>, shape $each T, uuid "44444444-0000-0000-0000-000000000000"
+  %2 = metatype $@thick (@pack_element("44444444-0000-0000-0000-000000000000") each T).Type
+  %3 = witness_method $@pack_element("44444444-0000-0000-0000-000000000000") each T, #P.foo, %2 : $@thick (@pack_element("44444444-0000-0000-0000-000000000000") each T).Type : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@thick τ_0_0.Type) -> ()
+  %4 = apply %3<@pack_element("44444444-0000-0000-0000-000000000000") each T>(%2) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@thick τ_0_0.Type) -> ()
+  %5 = tuple ()
+  return %5 : $()
+}
+
+// No simplification: there is a pack expansion before index 1, so the concrete type at index 1
+// cannot be determined statically.
+
+// CHECK-LABEL: sil [ossa] @dont_replace_pack_element_expansion_before_index :
+// CHECK:        = witness_method $@pack_element
+// CHECK:       } // end sil function 'dont_replace_pack_element_expansion_before_index'
+sil [ossa] @dont_replace_pack_element_expansion_before_index : $<each U where repeat each U : P> () -> () {
+bb0:
+  %0 = scalar_pack_index 1 of $Pack{repeat each U, S}
+  open_pack_element %0 of <each T where repeat each T : P> at <Pack{repeat each U, S}>, shape $each T, uuid "55555555-0000-0000-0000-000000000000"
+  %1 = metatype $@thick (@pack_element("55555555-0000-0000-0000-000000000000") each T).Type
+  %2 = witness_method $@pack_element("55555555-0000-0000-0000-000000000000") each T, #P.foo, %1 : $@thick (@pack_element("55555555-0000-0000-0000-000000000000") each T).Type : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@thick τ_0_0.Type) -> ()
+  %3 = apply %2<@pack_element("55555555-0000-0000-0000-000000000000") each T>(%1) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@thick τ_0_0.Type) -> ()
+  %4 = tuple ()
+  return %4 : $()
 }
 


### PR DESCRIPTION
<!--
The main branch is now in convergence, which means major changes, such as large refactoring or new features, should be avoided. This strategy is intended to maintain the stability of the Swift 6.4 release leading up to the May 4th branch. For any work that requires broad changes or introduces new features, create a feature branch and open a draft pull request. All updates to the swiftlang/swift repository’s main branch require approval from the release managers. A pull request targeting swiftlang/swift will automatically add release managers. You can also contact them via @release-managers in the forum group.
-->

<!-- Please fill out the following form: --> 
# Explanation

When using a `@pack_element` type to refer to an element of a concrete pack type at a compile-time-known index, we can replace the `@pack_element` with the concrete type of the element at that index.

- Doing this for `witness_method` allows us to replace the witness table lookup and call with a direct call to the witness function for the concrete type.
- Doing this for `apply` makes it possible to specialize calls to generic functions inside loops over pack elements.

  <!--
  A description of the changes. This can be brief, but it should be clear.
  -->
# Scope

This is intended to be a smaller version of the changes proposed in https://github.com/swiftlang/swift/pull/85333, and has limitations on what it can handle (e.g. it can only get the concrete pack type for `open_pack_element` instructions that open a single pack type). Nonetheless, it enables more effective optimisations in many cases, and should appreciably improve performance in most code that uses variadic generics.
  <!--
  An assessment of the impact and importance of the changes. For example, can
  the changes break existing code?
  -->

# Issues
  <!--
  References to issues the changes resolve, if any.
  -->
 rdar://163046681 (at least partially)
# Risk
  <!--
  The (specific) risk to the release for taking the changes.
  -->
This will affect most code that uses variadic generics, which are used heavily some significant projects like SwiftUI.
# Testing
  <!--
  The specific testing that has been done or needs to be done to further
  validate any impact of the changes.
  -->
- [x] Unit tests
- [x] Integration tests
- [ ] Benchmarks
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
