### PR TITLE
[PrintAsClang] Sort textual include statements in emitted clang headers

### DIFF
--- a/lib/PrintAsClang/PrintAsClang.cpp
+++ b/lib/PrintAsClang/PrintAsClang.cpp
@@ -293,7 +293,7 @@ static llvm::SmallString<128> normalizePath(const llvm::StringRef path) {
 // Augment requiredTextualIncludes with the set of headers required.
 static void collectClangModuleHeaderIncludes(
     const clang::Module *clangModule, clang::FileManager &fileManager,
-    llvm::SmallSet<llvm::SmallString<128>, 10> &requiredTextualIncludes,
+    llvm::SmallVector<llvm::SmallString<128>, 10> &requiredTextualIncludes,
     llvm::SmallSet<const clang::Module *, 10> &visitedModules,
     const llvm::SmallSet<llvm::SmallString<128>, 10> &includeDirs,
     const llvm::StringRef cwd) {
@@ -335,7 +335,7 @@ static void collectClangModuleHeaderIncludes(
                                            frameworkName);
     }
 
-    requiredTextualIncludes.insert(textualInclude);
+    requiredTextualIncludes.push_back(textualInclude);
   };
 
   if (std::optional<clang::Module::Header> umbrellaHeader =
@@ -436,7 +436,7 @@ writeImports(raw_ostream &out, llvm::SmallPtrSetImpl<ImportModuleTy> &imports,
   clang::FileSystemOptions fileSystemOptions;
   clang::FileManager fileManager{fileSystemOptions};
 
-  llvm::SmallSet<llvm::SmallString<128>, 10>
+  llvm::SmallVector<llvm::SmallString<128>, 10>
       requiredTextualIncludes; // Only included without modules.
   llvm::SmallVector<StringRef, 1> textualIncludes; // always included.
   llvm::SmallSet<const clang::Module *, 10> visitedModules;
@@ -540,6 +540,11 @@ writeImports(raw_ostream &out, llvm::SmallPtrSetImpl<ImportModuleTy> &imports,
   }
 
   if (useNonModularIncludes && !requiredTextualIncludes.empty()) {
+    // Sort and deduplicate includes
+    llvm::sort(requiredTextualIncludes);
+    requiredTextualIncludes.erase(std::unique(requiredTextualIncludes.begin(), requiredTextualIncludes.end()), 
+                    requiredTextualIncludes.end());
+
     out << "#elif defined(__OBJC__)\n";
     for (auto header : requiredTextualIncludes)
       out << "#import <" << header << ">\n";

--- a/test/PrintAsObjC/emit-clang-header-nonmodular-includes-mock-sdk.swift
+++ b/test/PrintAsObjC/emit-clang-header-nonmodular-includes-mock-sdk.swift
@@ -35,11 +35,11 @@ public class HelloWorld: NSObject {
 // CHECK-NEXT: #elif defined(__OBJC__)
 // CHECK-NEXT: #import <CoreGraphics.h>
 // CHECK-NEXT: #import <Mixed/Mixed.h>
-// CHECK-NEXT: #import <objc/objc.h>
 // CHECK-NEXT: #import <objc/NSObject.h>
+// CHECK-NEXT: #import <objc/objc.h>
 // CHECK-NEXT: #else
 // CHECK-NEXT: #include <CoreGraphics.h>
 // CHECK-NEXT: #include <Mixed/Mixed.h>
-// CHECK-NEXT: #include <objc/objc.h>
 // CHECK-NEXT: #include <objc/NSObject.h>
+// CHECK-NEXT: #include <objc/objc.h>
 // CHECK-NEXT: #endif


### PR DESCRIPTION
When producing a ObjC header, we emit #import / #include statements and previously did not guarantee any kind of stable order. This kind of non-determinsm is bad for build systems causing unnecessary invaldation.

Make sure the includes are emitted in a deterministic order.

<!--
The main branch is now in convergence, which means major changes, such as large refactoring or new features, should be avoided. This strategy is intended to maintain the stability of the Swift 6.4 release leading up to the May 4th branch. For any work that requires broad changes or introduces new features, create a feature branch and open a draft pull request. All updates to the swiftlang/swift repository’s main branch require approval from the release managers. A pull request targeting swiftlang/swift will automatically add release managers. You can also contact them via @release-managers in the forum group.
-->

<!-- Please fill out the following form: --> 
- **Explanation**:
  <!--
  A description of the changes. This can be brief, but it should be clear.
  -->
  Generated ObjC headers contain include directives when -emit-clang-header-nonmodular-includes is pass, and these are currently not emitted in a deterministic order. Fix that.
  
- **Scope**:
  <!--
  An assessment of the impact and importance of the changes. For example, can
  the changes break existing code?
  -->
  Unless header order is significant in user's applications, it should not change anything, and likely very few users use `-emit-clang-header-nonmodular-includes`. 
  
- **Issues**:
  <!--
  References to issues the changes resolve, if any.
  -->
- **Risk**:
  <!--
  The (specific) risk to the release for taking the changes.
  -->
  Low
  
- **Testing**:
  <!--
  The specific testing that has been done or needs to be done to further
  validate any impact of the changes.
  -->
  Included LIT Tests

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
