### PR TITLE
Don't optimize alloc_stack with dynamic_lifetime in TempLValueElimination

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/TempLValueElimination.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/TempLValueElimination.swift
@@ -66,7 +66,8 @@ let tempLValueElimination = FunctionPass(name: "temp-lvalue-elimination") {
 
 private func tryEliminate(copy: CopyLikeInstruction, _ context: FunctionPassContext) {
   guard let allocStack = copy.sourceAddress as? AllocStackInst,
-        allocStack.isDeallocatedInSameBlock(as: copy)
+        allocStack.isDeallocatedInSameBlock(as: copy),
+        !allocStack.parentFunction.hasOwnership || !allocStack.hasDynamicLifetime
   else {
     return
   }

--- a/test/SILOptimizer/templvalueopt_ossa.sil
+++ b/test/SILOptimizer/templvalueopt_ossa.sil
@@ -699,3 +699,51 @@ bb0(%0 : $*Int, %1 : $Int):
   return %8
 }
 
+class Klass {}
+
+struct NonTrivialStruct {
+  var val:Klass
+}
+
+sil @get_nontrivialstruct : $@convention(thin) () -> @owned NonTrivialStruct
+
+// CHECK-LABEL: sil [ossa] @dont_eliminate_dynamic_lifetime_in_loop :
+// CHECK:         alloc_stack [dynamic_lifetime]
+// CHECK:         copy_addr
+// CHECK-LABEL: } // end sil function 'dont_eliminate_dynamic_lifetime_in_loop'
+sil [ossa] @dont_eliminate_dynamic_lifetime_in_loop : $@convention(thin) (@owned NonTrivialStruct) -> () {
+bb0(%0 : @owned $NonTrivialStruct):
+  %dest = alloc_stack [var_decl] $NonTrivialStruct
+  %temp = alloc_stack [dynamic_lifetime] $NonTrivialStruct
+  %flag_init = integer_literal $Builtin.Int1, 0
+  br bb1(%flag_init : $Builtin.Int1)
+
+bb1(%flag : $Builtin.Int1):
+  cond_br %flag, bb2, bb3
+
+bb2:
+  destroy_addr %temp : $*NonTrivialStruct
+  br bb4
+
+bb3:
+  br bb4
+
+bb4:
+  %flag_set = integer_literal $Builtin.Int1, -1
+  %copy = copy_value %0 : $NonTrivialStruct
+  store %copy to [init] %temp : $*NonTrivialStruct
+  cond_br undef, bb5, bb6
+
+bb5:
+  br bb1(%flag_set : $Builtin.Int1)
+
+bb6:
+  copy_addr [take] %temp to [init] %dest : $*NonTrivialStruct
+  dealloc_stack %temp : $*NonTrivialStruct
+  destroy_addr %dest : $*NonTrivialStruct
+  dealloc_stack %dest : $*NonTrivialStruct
+  destroy_value %0 : $NonTrivialStruct
+  %res = tuple ()
+  return %res : $()
+}
+


### PR DESCRIPTION
- **Explanation**: The [dynamic_lifetime] attribute represents that the stack location's initialization state is tracked dynamically via a boolean flag — it may be uninitialized at certain program points. TempLValueElimination pass can replace an alloc_stack [dynamic_lifetime] with a destination alloc_stack that does not have dynamic_lifetime. This results in invalid SIL which triggers verifier errors due to lifetime mismatches in some program paths in ossa.

This PR fixes this issue by bailing out of TempLValueElimination for alloc_stack [dynamic_lifetime] in ossa.

- **Scope**: Affects `alloc_stack` with `dynamic_lifetime`

- **Issues**: rdar://175097584 and https://github.com/swiftlang/swift/issues/88545 
 
- **Risk**: Low. Adding a bailout for illegal optimization

- **Testing**: Added unit test, CI testing

