### PR TITLE
Fix DiagnoseStaticExclusivity for lifetime dependent sub-objects

### DIFF
--- a/lib/SILOptimizer/Analysis/AccessSummaryAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/AccessSummaryAnalysis.cpp
@@ -507,6 +507,25 @@ getSingleAddressProjectionUser(SingleValueInstruction *I) {
     if (isa<BeginAccessInst>(I) && isa<EndAccessInst>(User))
       continue;
 
+    if (auto md = MarkDependenceInstruction(User)) {
+      // The base of a mark_dependence or mark_dependence_addr] is a
+      // begin_access. That creates a dependency on any part of the base value
+      // accessed inside this access scope. If, in addition to this dependency,
+      // the begin_access only has a single projection use, then we assume that
+      // only the sub-object at that projection can be accessed with the scope.
+      //
+      // FIXME: this isn't strictly safe because the dependency could, in
+      // theory, represent an access to other parts of the base, and those
+      // accesses may be invisible to the compiler. That is never expected
+      // happen when we have a single projection use. But to be safe, the base
+      // of the mark_dependency should really be the projection address instead
+      // to ensure that no other parts of the base can be accessed. Then we can
+      // remove this special case.
+      if (md.getBase() == Use->get()) {
+        continue;
+      }
+    }
+
     // Ignore sanitizer instrumentation when looking for a single projection
     // user. This ensures that we're able to find a single projection subpath
     // even when sanitization is enabled.

--- a/test/SILOptimizer/exclusivity_static_diagnostics_dependency.swift
+++ b/test/SILOptimizer/exclusivity_static_diagnostics_dependency.swift
@@ -1,0 +1,39 @@
+// RUN: %target-swift-frontend -emit-sil -enable-experimental-feature Lifetimes \
+// RUN:   -disable-availability-checking -primary-file %s -o /dev/null -verify
+
+// REQUIRES: swift_feature_Lifetimes
+
+// This is a dummy struct. Only the interface matters for exclusivity checks.
+// An example implementation is shown as comments only to motivate the interface.
+struct InoutPair: ~Escapable, ~Copyable {
+  //var x: Inout<Int>? = nil
+  //var x: Inout<Int>? = nil
+
+  @_lifetime(self: &x)
+  mutating func insertX(_ x: inout Int) {
+    //self.x = Inout(x)
+  }
+
+  @_lifetime(self: &y)
+  mutating func insertY(_ y: inout Int) {
+    //self.y = Inout(y)
+  }
+}
+
+func take(_ inoutPair: consuming InoutPair) {}
+
+struct Pair {
+  var x: Int
+  var y: Int
+
+  mutating func run() {
+    var inoutPair = InoutPair()
+    inoutPair.insertX(&x)
+    inoutPair.insertY(&y)
+
+    take(inoutPair) // OK: no overlapping access.
+    // The access of both &x and &y are extended up to the last use of 'inoutPair'.
+    // Exclusivity diagnostics determines that &x and &y are distinct sub-objects
+    // so their simultaneous access does not overlap.
+  }
+}


### PR DESCRIPTION
- **Explanation**: Allow simultaneous access to disjoint struct properties even when another value has a lifetime dependency on the property.

- **Scope**: This suppresses exclusivity diagnostics in situations involving non-Escapable types. The diagnostic is suppressed in the same what as it has always been done for Escapable types. This has no effect unless non-Escapable types are involved.

- **Issues**: rdar://175271283 ([exclusivity] handle simultaneous sub-object exclusivity with lifetime dependencies)

- **Risk**: Potentially weakens diagnostics in the very rare case on non-Escapable types. This is always safe given the current compiler design.

- **Testing**: Unit test

- **Reviewers**: TBD

---
For example:
```
struct InoutPair: ~Escapable, ~Copyable {
  @_lifetime(self: &x)
  mutating func insertX(_ x: inout Int) {...}

  @_lifetime(self: &y)
  mutating func insertY(_ y: inout Int) {...}
}

struct Pair {
  var x: Int
  var y: Int

  mutating func run() {
    var inoutPair = InoutPair()
    inoutPair.insertX(&x)
    inoutPair.insertY(&y)

    take(inoutPair) // The access of both &x and &y are extended up to here
  }
}
```

In the `Pair.run` method, the accesses to &x and &y are overlapping because the
final value of `inoutPair` depends on both. Fix DiagnoseStaticExclusivity to
recognize that these accesses are to independent subobjects even though that
have a lifetime dependency.

Fixes rdar://175271283 ([exclusivity] handle simultaneous sub-object exclusivity
with lifetime dependencies)

We can consider a more robust design in the future:
rdar://175275018 ([nonescapable] create mark_dependence on the projection rather than the base)

But in the meantime, this problem basically makes it impossible to have dependencies on multiple sub-objects.