### PR TITLE
[cxx-interop] Add RETURNS_RETAINED annotations to C++ thunks

### DIFF
--- a/include/swift/PrintAsClang/ClangMacros.def
+++ b/include/swift/PrintAsClang/ClangMacros.def
@@ -122,6 +122,18 @@ CLANG_MACRO_CONDITIONAL("SWIFT_WARN_UNUSED_RESULT", , \
                         "__has_attribute(warn_unused_result)", \
                         "__attribute__((warn_unused_result))")
 
+CLANG_MACRO_CONDITIONAL("NS_RETURNS_RETAINED", , \
+                        "__has_attribute(ns_returns_retained)", \
+                        "__attribute__((ns_returns_retained))")
+
+CLANG_MACRO_CONDITIONAL("CF_RETURNS_RETAINED", , \
+                        "__has_attribute(cf_returns_retained)", \
+                        "__attribute__((cf_returns_retained))")
+
+CLANG_MACRO_CONDITIONAL("SWIFT_RETURNS_RETAINED", , \
+                        "__has_attribute(swift_attr)", \
+                        "__attribute__((swift_attr(\"returns_retained\")))")
+
 CLANG_MACRO_CONDITIONAL("SWIFT_NORETURN", , \
                         "__has_attribute(noreturn)", \
                         "__attribute__((noreturn))")

--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -1515,7 +1515,8 @@ private:
   }
 
   /// Print C or C++ trailing attributes for a function declaration.
-  void printFunctionClangAttributes(FuncDecl *FD, AnyFunctionType *funcTy) {
+  void printFunctionClangAttributes(FuncDecl *FD, AnyFunctionType *funcTy,
+                                    Type resultTy) {
     if (funcTy->getResult()->isUninhabited()) {
       if (funcTy->isThrowing())
         os << " SWIFT_NORETURN_EXCEPT_ERRORS";
@@ -1525,6 +1526,9 @@ private:
                !FD->getAttrs().hasAttribute<DiscardableResultAttr>()) {
       os << " SWIFT_WARN_UNUSED_RESULT";
     }
+    if (outputLang == OutputLanguageMode::Cxx)
+      DeclAndTypeClangFunctionPrinter::printCxxReturnsRetainedAttribute(
+          os, resultTy);
   }
 
   // Print out the function signature for a @_cdecl function.
@@ -1544,7 +1548,7 @@ private:
     os << "SWIFT_EXTERN ";
     printFunctionDeclAsCFunctionDecl(FD, FD->getCDeclName(), resultTy);
     os << " SWIFT_NOEXCEPT";
-    printFunctionClangAttributes(FD, funcTy);
+    printFunctionClangAttributes(FD, funcTy, resultTy);
     printAvailability(FD);
     os << ";\n";
   }
@@ -1751,7 +1755,7 @@ private:
         modifiers);
     assert(
         !result.isUnsupported()); // The C signature should be unsupported too.
-    printFunctionClangAttributes(FD, funcTy);
+    printFunctionClangAttributes(FD, funcTy, resultTy);
     printAvailability(FD);
     os << " {\n";
     funcPrinter.printCxxThunkBody(

--- a/lib/PrintAsClang/PrintClangFunction.cpp
+++ b/lib/PrintAsClang/PrintClangFunction.cpp
@@ -1676,6 +1676,7 @@ void DeclAndTypeClangFunctionPrinter::printCxxMethod(
   if (result.isUnsupported())
     return;
 
+  printCxxReturnsRetainedAttribute(os, resultTy);
   declAndTypePrinter.printAvailability(os, FD);
   if (!isDefinition) {
     os << ";\n";
@@ -1749,6 +1750,7 @@ void DeclAndTypeClangFunctionPrinter::printCxxPropertyAccessorMethod(
       printFunctionSignature(accessor, signature, accessorName, resultTy,
                              FunctionSignatureKind::CxxInlineThunk, modifiers);
   assert(!result.isUnsupported() && "C signature should be unsupported too!");
+  printCxxReturnsRetainedAttribute(os, resultTy);
   declAndTypePrinter.printAvailability(os, accessor->getStorage());
   if (!isDefinition) {
     os << ";\n";
@@ -1787,6 +1789,7 @@ void DeclAndTypeClangFunctionPrinter::printCxxSubscriptAccessorMethod(
       printFunctionSignature(accessor, signature, "operator []", resultTy,
                              FunctionSignatureKind::CxxInlineThunk, modifiers);
   assert(!result.isUnsupported() && "C signature should be unsupported too!");
+  printCxxReturnsRetainedAttribute(os, resultTy);
   declAndTypePrinter.printAvailability(os, accessor->getStorage());
   if (!isDefinition) {
     os << ";\n";
@@ -1916,4 +1919,41 @@ void DeclAndTypeClangFunctionPrinter::printTypeName(
       delegate, moduleContext, declPrinter,
       FunctionSignatureTypeUse::TypeReference);
   typePrinter.visit(ty, std::nullopt, /*isInOut=*/false);
+}
+
+void DeclAndTypeClangFunctionPrinter::printCxxReturnsRetainedAttribute(
+    raw_ostream &os, Type resultTy) {
+  if (resultTy->isVoid())
+    return;
+
+  // A function returning NSString? generates a thunk returning `NSString
+  // *_Nullable`.
+  Type unwrapped = resultTy->lookThroughSingleOptionalType();
+
+  if (auto *classDecl = unwrapped->getClassOrBoundGenericClass()) {
+    if (classDecl->hasClangNode()) {
+      if (isa<clang::ObjCContainerDecl>(classDecl->getClangDecl())) {
+        os << " NS_RETURNS_RETAINED";
+        return;
+      }
+      if (classDecl->getForeignClassKind() == ClassDecl::ForeignKind::CFType) {
+        os << " CF_RETURNS_RETAINED";
+        return;
+      }
+      if (classDecl->isForeignReferenceType()) {
+        os << " SWIFT_RETURNS_RETAINED";
+        return;
+      }
+    }
+
+    // Swift class, no annotation.
+    return;
+  }
+
+  // ObjC existential types (id, etc.), the thunks use __bridge_transfer just
+  // like ObjC classes, so emit NS_RETURNS_RETAINED too.
+  if (unwrapped->isObjCExistentialType()) {
+    os << " NS_RETURNS_RETAINED";
+    return;
+  }
 }

--- a/lib/PrintAsClang/PrintClangFunction.h
+++ b/lib/PrintAsClang/PrintClangFunction.h
@@ -180,6 +180,10 @@ public:
                         DeclAndTypePrinter &declPrinter,
                         const ModuleDecl *emittedModule, Type ty);
 
+  /// Emits a RETURNS_RETAINED trailing attribute if the given result type
+  /// represents a +1 reference type in a C++ thunk.
+  static void printCxxReturnsRetainedAttribute(raw_ostream &os, Type resultTy);
+
   /// Prints the name of the type including generic arguments.
   void printTypeName(Type ty, const ModuleDecl *moduleContext);
 

--- a/test/Interop/CxxToSwiftToCxx/bridge-cxx-struct-back-to-cxx.swift
+++ b/test/Interop/CxxToSwiftToCxx/bridge-cxx-struct-back-to-cxx.swift
@@ -194,11 +194,11 @@ public struct Strct {
 // CHECK: SWIFT_EXTERN void $s8UseCxxTy13retNonTrivialSo2nsO0030NonTrivialTemplateCInt_hHAFhrbVyF(SWIFT_INDIRECT_RESULT void * _Nonnull) SWIFT_NOEXCEPT SWIFT_CALL; // retNonTrivial()
 // CHECK: SWIFT_EXTERN struct swift_interop_returnStub_UseCxxTy_uint32_t_0_4 $s8UseCxxTy10retTrivialSo0E0VyF(void) SWIFT_NOEXCEPT SWIFT_CALL; // retTrivial()
 
-// CHECK: ns::Immortal *_Nonnull retImmortal() noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
+// CHECK: ns::Immortal *_Nonnull retImmortal() noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT SWIFT_RETURNS_RETAINED {
 // CHECK-NEXT: return UseCxxTy::_impl::$s8UseCxxTy11retImmortalSo2nsO0E0VyF();
 // CHECK-NEXT: }
 
-// CHECK:  ns::ImmortalTemplate<int> *_Nonnull retImmortalTemplate() noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
+// CHECK:  ns::ImmortalTemplate<int> *_Nonnull retImmortalTemplate() noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT SWIFT_RETURNS_RETAINED {
 // CHECK-NEXT: return UseCxxTy::_impl::$s8UseCxxTy19retImmortalTemplateSo2nsO0028ImmortalTemplateCInt_jBAGgnbVyF();
 // CHECK-NEXT: }
 // CHECK-EMPTY:

--- a/test/Interop/ObjCToSwiftToObjCxx/bridge-objc-types-back-to-objcxx.swift
+++ b/test/Interop/ObjCToSwiftToObjCxx/bridge-objc-types-back-to-objcxx.swift
@@ -133,21 +133,21 @@ public class KVOCookieMonster {
 // CHECK-NEXT:   }
 // CHECK-NEXT: };
 
-// CHECK: SWIFT_INLINE_THUNK id <ObjCProtocol> _Nonnull retObjCProtocol() noexcept SWIFT_SYMBOL("s:9UseObjCTy03retB9CProtocolSo0bE0_pyF") SWIFT_WARN_UNUSED_RESULT {
+// CHECK: SWIFT_INLINE_THUNK id <ObjCProtocol> _Nonnull retObjCProtocol() noexcept SWIFT_SYMBOL("s:9UseObjCTy03retB9CProtocolSo0bE0_pyF") SWIFT_WARN_UNUSED_RESULT NS_RETURNS_RETAINED {
 // CHECK-NEXT:  return (__bridge_transfer id <ObjCProtocol>)(__bridge void *)UseObjCTy::_impl::$s9UseObjCTy03retB9CProtocolSo0bE0_pyF();
 // CHECK-NEXT: }
 // CHECK-NEXT: #endif // defined(__OBJC__)
 
 // CHECK: #if defined(__OBJC__)
-// CHECK-NEXT: SWIFT_INLINE_THUNK id <ObjCProtocol> _Nullable retObjCProtocolNullable() noexcept SWIFT_SYMBOL("s:9UseObjCTy03retB17CProtocolNullableSo0bE0_pSgyF") SWIFT_WARN_UNUSED_RESULT {
+// CHECK-NEXT: SWIFT_INLINE_THUNK id <ObjCProtocol> _Nullable retObjCProtocolNullable() noexcept SWIFT_SYMBOL("s:9UseObjCTy03retB17CProtocolNullableSo0bE0_pSgyF") SWIFT_WARN_UNUSED_RESULT NS_RETURNS_RETAINED {
 // CHECK-NEXT: return (__bridge_transfer id <ObjCProtocol>)(__bridge void *)UseObjCTy::_impl::$s9UseObjCTy03retB17CProtocolNullableSo0bE0_pSgyF();
 // CHECK-NEXT: }
 // CHECK-NEXT: #endif // defined(__OBJC__)
 
-// CHECK: SWIFT_INLINE_THUNK ObjCKlass *_Nonnull retObjClass() noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
+// CHECK: SWIFT_INLINE_THUNK ObjCKlass *_Nonnull retObjClass() noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT NS_RETURNS_RETAINED {
 // CHECK-NEXT: return (__bridge_transfer ObjCKlass *)(__bridge void *)UseObjCTy::_impl::$s9UseObjCTy03retB5ClassSo0B6CKlassCyF();
 
-// CHECK: SWIFT_INLINE_THUNK ObjCKlass *_Nullable retObjClassNullable() noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
+// CHECK: SWIFT_INLINE_THUNK ObjCKlass *_Nullable retObjClassNullable() noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT NS_RETURNS_RETAINED {
 // CHECK-NEXT: return (__bridge_transfer ObjCKlass *)(__bridge void *)UseObjCTy::_impl::$s9UseObjCTy03retB13ClassNullableSo0B6CKlassCSgyF();
 
 // CHECK: void takeObjCClass(ObjCKlass *_Nonnull x) noexcept SWIFT_SYMBOL({{.*}}) {

--- a/test/Interop/SwiftToCxx/functions/swift-functions-returns-retained.swift
+++ b/test/Interop/SwiftToCxx/functions/swift-functions-returns-retained.swift
@@ -1,0 +1,196 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -module-name Functions -cxx-interoperability-mode=default -clang-header-expose-decls=all-public -I %S/Inputs/ -typecheck -verify -emit-clang-header-path %t/functions.h -disable-availability-checking
+// RUN: %FileCheck %s < %t/functions.h
+
+// REQUIRES: objc_interop
+
+// Check if the following annotations are attached to the generated thunk
+// signatures, based on the return type:
+// - NS_RETURNS_RETAINED for ObjC classes (NSString, etc.)
+// - CF_RETURNS_RETAINED for CF types (CFString, etc.)
+// - SWIFT_RETURNS_RETAINED for foreign reference types
+
+import Foundation
+import CPointerTypes
+
+// CHECK: #if !defined(NS_RETURNS_RETAINED)
+// CHECK: #if !defined(CF_RETURNS_RETAINED)
+// CHECK: #if !defined(SWIFT_RETURNS_RETAINED)
+
+public final class SwiftClass {
+  public init() {}
+}
+
+
+// Properties and methods (declarations)
+
+public final class Foo {
+  public var nameCF: CFString { "hello" as NSString }
+  public var nameNS: NSString { "hello" as NSString }
+
+  public func getCFString() -> CFString { "hello" as CFString }
+  public func getNSString() -> NSString { "hello" as NSString }
+
+  public func getFRT(_ x: FRT) -> FRT { x }
+
+  public func getSwiftClass() -> SwiftClass { SwiftClass() }
+}
+
+// CHECK: SWIFT_INLINE_THUNK CFStringRef _Nonnull getNameCF()
+// CHECK-SAME: CF_RETURNS_RETAINED
+
+// CHECK: SWIFT_INLINE_THUNK NSString *_Nonnull getNameNS()
+// CHECK-SAME: NS_RETURNS_RETAINED
+
+// CHECK: SWIFT_INLINE_THUNK CFStringRef _Nonnull getCFString()
+// CHECK-SAME: CF_RETURNS_RETAINED
+
+// CHECK: SWIFT_INLINE_THUNK NSString *_Nonnull getNSString()
+// CHECK-SAME: NS_RETURNS_RETAINED
+
+// CHECK: SWIFT_INLINE_THUNK FRT *_Nonnull getFRT(
+// CHECK-SAME: SWIFT_RETURNS_RETAINED
+
+// CHECK: SWIFT_INLINE_THUNK SwiftClass getSwiftClass(
+// CHECK-NOT: RETURNS_RETAINED
+// CHECK-SAME: ;
+
+
+// Pass through
+
+public func passThroughCFString(_ x: CFString) -> CFString {
+  return x
+}
+
+public func passThroughFRT(_ x: FRT) -> FRT {
+  return x
+}
+
+public func passThroughNSString(_ x: NSString) -> NSString {
+  return x
+}
+
+public func passThroughSwiftClass(_ x: SwiftClass) -> SwiftClass {
+  return x
+}
+
+// CHECK: SWIFT_INLINE_THUNK CFStringRef _Nonnull passThroughCFString(
+// CHECK-SAME: CF_RETURNS_RETAINED
+
+// CHECK: SWIFT_INLINE_THUNK FRT *_Nonnull passThroughFRT(
+// CHECK-SAME: SWIFT_RETURNS_RETAINED
+
+// CHECK: SWIFT_INLINE_THUNK NSString *_Nonnull passThroughNSString(
+// CHECK-SAME: NS_RETURNS_RETAINED
+
+// CHECK: SWIFT_INLINE_THUNK SwiftClass passThroughSwiftClass(
+// CHECK-SAME: SWIFT_WARN_UNUSED_RESULT
+// CHECK-NOT: RETURNS_RETAINED
+// CHECK-SAME: {
+
+
+// Return
+
+public func returnAnyObject() -> AnyObject {
+  fatalError()
+}
+
+public func returnCFString() -> CFString {
+  return "hello" as CFString
+}
+
+public func returnCFStringOpt() -> CFString? {
+  return nil
+}
+
+public func returnFRT(_ x: FRT) -> FRT {
+  return x
+}
+
+public func returnFRTOpt(_ x: FRT) -> FRT? {
+  return nil
+}
+
+public func returnNSString() -> NSString {
+  return "hello" as NSString
+}
+
+public func returnNSStringOpt() -> NSString? {
+  return nil
+}
+
+public func returnSwiftClass() -> SwiftClass {
+  return SwiftClass()
+}
+
+// CHECK: SWIFT_INLINE_THUNK id _Nonnull returnAnyObject()
+// CHECK-SAME: NS_RETURNS_RETAINED
+
+// CHECK: SWIFT_INLINE_THUNK CFStringRef _Nonnull returnCFString()
+// CHECK-SAME: CF_RETURNS_RETAINED
+
+// CHECK: SWIFT_INLINE_THUNK CFStringRef _Nullable returnCFStringOpt()
+// CHECK-SAME: CF_RETURNS_RETAINED
+
+// CHECK: SWIFT_INLINE_THUNK FRT *_Nonnull returnFRT(
+// CHECK-SAME: SWIFT_RETURNS_RETAINED
+
+// CHECK: SWIFT_INLINE_THUNK FRT *_Nullable returnFRTOpt(
+// CHECK-SAME: SWIFT_RETURNS_RETAINED
+
+// CHECK: SWIFT_INLINE_THUNK NSString *_Nonnull returnNSString()
+// CHECK-SAME: NS_RETURNS_RETAINED
+
+// CHECK: SWIFT_INLINE_THUNK NSString *_Nullable returnNSStringOpt()
+// CHECK-SAME: NS_RETURNS_RETAINED
+
+// CHECK: SWIFT_INLINE_THUNK SwiftClass returnSwiftClass()
+// CHECK-SAME: SWIFT_WARN_UNUSED_RESULT
+// CHECK-NOT: RETURNS_RETAINED
+// CHECK-SAME: {
+
+
+// Take
+
+public func takeNSString(_ x: NSString) {}
+public func takeFRT(_ x: FRT) {}
+public func takeCFString(_ x: NSString) {}
+public func takeSwiftClass(_ x: SwiftClass) {}
+
+// CHECK: SWIFT_INLINE_THUNK void takeCFString(
+// CHECK-NOT: RETURNS_RETAINED
+// CHECK-SAME: {
+
+// CHECK: SWIFT_INLINE_THUNK void takeFRT(
+// CHECK-NOT: RETURNS_RETAINED
+// CHECK-SAME: {
+
+// CHECK: SWIFT_INLINE_THUNK void takeNSString(
+// CHECK-NOT: RETURNS_RETAINED
+// CHECK-SAME: {
+
+// CHECK: SWIFT_INLINE_THUNK void takeSwiftClass(
+// CHECK-NOT: RETURNS_RETAINED
+// CHECK-SAME: {
+
+
+// Properties and methods (definitions)
+
+// CHECK: SWIFT_INLINE_THUNK CFStringRef _Nonnull Foo::getNameCF()
+// CHECK-SAME: CF_RETURNS_RETAINED
+
+// CHECK: SWIFT_INLINE_THUNK NSString *_Nonnull Foo::getNameNS()
+// CHECK-SAME: NS_RETURNS_RETAINED
+
+// CHECK: SWIFT_INLINE_THUNK CFStringRef _Nonnull Foo::getCFString()
+// CHECK-SAME: CF_RETURNS_RETAINED
+
+// CHECK: SWIFT_INLINE_THUNK NSString *_Nonnull Foo::getNSString()
+// CHECK-SAME: NS_RETURNS_RETAINED
+
+// CHECK: SWIFT_INLINE_THUNK FRT *_Nonnull Foo::getFRT(
+// CHECK-SAME: SWIFT_RETURNS_RETAINED
+
+// CHECK: SWIFT_INLINE_THUNK SwiftClass Foo::getSwiftClass(
+// CHECK-NOT: RETURNS_RETAINED
+// CHECK-SAME: {

--- a/test/Interop/SwiftToCxx/stdlib/core-foundation-types-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/stdlib/core-foundation-types-in-cxx.swift
@@ -40,6 +40,6 @@ public enum MyEnum {
 // CHECK: SWIFT_EXTERN void $s17UseCoreFoundation12testDispatch1xySo21OS_dispatch_semaphoreC_tF(dispatch_semaphore_t _Nonnull x) SWIFT_NOEXCEPT SWIFT_CALL; // testDispatch(x:)
 
 // CHECK: SWIFT_INLINE_THUNK swift::Optional<in_addr> networkThing() noexcept SWIFT_SYMBOL("s:17UseCoreFoundation12networkThingSo7in_addrVSgyF") SWIFT_WARN_UNUSED_RESULT {
-// CHECK: SWIFT_INLINE_THUNK CFDateRef _Nullable returnsCFDate() noexcept SWIFT_SYMBOL("s:17UseCoreFoundation13returnsCFDateSo0E3RefaSgyF") SWIFT_WARN_UNUSED_RESULT {
+// CHECK: SWIFT_INLINE_THUNK CFDateRef _Nullable returnsCFDate() noexcept SWIFT_SYMBOL("s:17UseCoreFoundation13returnsCFDateSo0E3RefaSgyF") SWIFT_WARN_UNUSED_RESULT CF_RETURNS_RETAINED {
 // CHECK: SWIFT_INLINE_THUNK void takesCFDate(CFDateRef _Nullable x) noexcept SWIFT_SYMBOL("s:17UseCoreFoundation11takesCFDate1xySo0E3RefaSg_tF") {
 // CHECK: SWIFT_INLINE_THUNK void testDispatch(dispatch_semaphore_t _Nonnull x) noexcept SWIFT_SYMBOL("s:17UseCoreFoundation12testDispatch1xySo21OS_dispatch_semaphoreC_tF") {


### PR DESCRIPTION
Swift functions exposed to C++ return +1 (retained) values, but the generated C++ thunks in the -Swift.h header lacked ownership annotations. This prevented Clang's static analyzer from verifying reference counts when C++ code calls into Swift.

Add NS_RETURNS_RETAINED, CF_RETURNS_RETAINED, and SWIFT_RETURNS_RETAINED annotations to thunk signatures based on the return type:
- NS_RETURNS_RETAINED for ObjC classes (NSString, etc.)
- CF_RETURNS_RETAINED for CF types (CFString, etc.)
- SWIFT_RETURNS_RETAINED for foreign reference types

rdar://165231653
