### PR TITLE
[Sema] Reject global-actor type attributes on non-protocol inheritance

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6200,6 +6200,9 @@ ERROR(typeattr_reparented_requires_reparentable_protocol,none,
 ERROR(typeattr_invalid_for_objc_protocol,none,
       "@objc protocol %1 cannot be %0",
       (const TypeAttribute *, const TypeDecl *))
+ERROR(global_actor_attr_inheritance_non_protocol,none,
+      "global actor %0 cannot apply to non-protocol type %1",
+      (TypeRepr *, Type))
 
 WARNING(unchecked_conformance_not_special,none,
       "'@unchecked' conformance to %0 has no meaning", (Type))

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -3813,8 +3813,17 @@ TypeResolver::resolveAttributedType(TypeRepr *repr, TypeResolutionOptions option
   // If we're in an inheritance clause, check for a global actor.
   if (options.is(TypeResolverContext::Inherited)) {
     CustomAttr *customAttr = nullptr;
-    (void)resolveGlobalActor(repr->getLoc(), options,
-                             customAttr, attrs);
+    Type globalActor = resolveGlobalActor(repr->getLoc(), options,
+                                          customAttr, attrs);
+    // A global actor attribute in an inheritance clause marks an isolated
+    // conformance, so it's only meaningful when applied to a protocol.
+    if (customAttr && globalActor && !globalActor->hasError() &&
+        !ty->hasError() && !ty->isConstraintType()) {
+      diagnoseInvalid(repr, customAttr->AtLoc,
+                      diag::global_actor_attr_inheritance_non_protocol,
+                      customAttr->getTypeRepr(), ty);
+      ty = ErrorType::get(getASTContext());
+    }
   }
 
   if (handleInheritedOnly(claim<UncheckedTypeAttr>(attrs)) ||

--- a/test/Concurrency/isolated_conformance.swift
+++ b/test/Concurrency/isolated_conformance.swift
@@ -353,3 +353,16 @@ class ComputedGetSetWitness: HasMutableVar {
     set { }
   }
 }
+
+// https://github.com/swiftlang/swift/issues/86693
+// A global actor is only meaningful on a protocol in an inheritance clause,
+// since it designates an isolated conformance.
+class Base {}
+
+class DerivedFromBase: @MainActor Base {}
+// expected-error@-1 {{global actor 'MainActor' cannot apply to non-protocol type 'Base'}}
+
+class DerivedFromBaseAndP: @MainActor Base, P {
+  // expected-error@-1 {{global actor 'MainActor' cannot apply to non-protocol type 'Base'}}
+  func f() {}
+}


### PR DESCRIPTION
## Summary

- Fixes #86693: `class Derived: @MainActor Base { }` was silently accepted, even though a global actor on a superclass entry is meaningless (it designates an isolated conformance, which only applies to protocols).
- In `TypeResolver::resolveAttributedType`, the global actor custom attribute in an inheritance clause was resolved just to claim it; the resulting type was discarded. Now we also check that the inherited type is a constraint type (protocol / protocol composition / parameterized protocol) and emit an error otherwise, mirroring the existing handling of `@preconcurrency`, `@unchecked`, `@unsafe`, and `@nonisolated`.
- Adds a new diagnostic `global_actor_attr_inheritance_non_protocol`: "global actor 'MainActor' cannot apply to non-protocol type 'Base'".

## Test plan

- [x] Added regression test in `test/Concurrency/isolated_conformance.swift` covering both the bare `class D: @MainActor Base {}` case and the mixed `class D: @MainActor Base, P {}` case.
- [x] No existing `@GlobalActor P` usage in the test suite is affected — every occurrence in `test/Concurrency/*.swift`, `test/SILGen`, `test/SILOptimizer`, `test/IRGen`, `test/ModuleInterface`, and `test/Serialization` applies the attribute to a protocol, so `isConstraintType()` remains `true`.
- [x] Local build: `./utils/build-script --release --skip-build-benchmarks` on macOS 26.1 / arm64, exit 0.
- [x] `test/Concurrency/isolated_conformance.swift` — 1/1 passed.
- [x] Full `test/Concurrency` suite — **451/451 supported tests passed**, 14 unsupported, 0 failures.