### PR TITLE
[Sema] Skip redundant MainActor suggestion on conformance

### DIFF
--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -5074,7 +5074,9 @@ static bool isolationsMatch(
   if (lhs.isGlobalActor() && rhs.isGlobalActor())
     return lhs.getGlobalActor()->isEqual(rhs.getGlobalActor());
 
-  if (lhs.isActorInstanceForSelfParameter() &&
+  if (lhs.getKind() == ActorIsolation::ActorInstance &&
+      rhs.getKind() == ActorIsolation::ActorInstance &&
+      lhs.isActorInstanceForSelfParameter() &&
       rhs.isActorInstanceForSelfParameter())
     return true;
 
@@ -5223,20 +5225,38 @@ static void diagnoseConformanceIsolationErrors(
     // Suggest isolating the conformance, if possible.
     if (potentialIsolation && potentialIsolation->isGlobalActor() &&
         !conformance->isIsolated()) {
-      bool isMainActor = false;
-      Type globalActorType = potentialIsolation->getGlobalActor();
-      if (auto nominal = globalActorType->getAnyNominal())
-        isMainActor = nominal->isMainActor();
+      // Skip the suggestion when the conforming nominal already carries the
+      // same global actor and the user hasn't explicitly opted the conformance
+      // out of isolation: writing the attribute on the conformance would be
+      // redundant with the nominal's isolation. Explicit 'nonisolated' keeps
+      // the suggestion, since it reflects a deliberate choice the user may
+      // want to reconsider.
+      auto *nominal =
+          conformance->getDeclContext()->getSelfNominalTypeDecl();
+      bool explicitlyNonisolated =
+          conformance->getOptions().contains(
+              ProtocolConformanceFlags::Nonisolated);
+      bool redundantWithNominal =
+          nominal && !explicitlyNonisolated &&
+          isolationsMatch(getActorIsolation(nominal), *potentialIsolation);
 
-      // Take permanent ownership of the string. The diagnostic may outlive this
-      // function call.
-      auto globalActorTypeStr = ctx.AllocateCopy(globalActorType.getString());
-      auto diag =
-          ctx.Diags.diagnose(conformance->getProtocolNameLoc(),
-                             diag::note_isolate_conformance_to_global_actor,
-                             globalActorType, isMainActor, globalActorTypeStr);
-      conformance->applyConformanceAttribute(diag,
-                                             "@" + globalActorTypeStr.str());
+      if (!redundantWithNominal) {
+        bool isMainActor = false;
+        Type globalActorType = potentialIsolation->getGlobalActor();
+        if (auto nominal = globalActorType->getAnyNominal())
+          isMainActor = nominal->isMainActor();
+
+        // Take permanent ownership of the string. The diagnostic may outlive
+        // this function call.
+        auto globalActorTypeStr =
+            ctx.AllocateCopy(globalActorType.getString());
+        auto diag =
+            ctx.Diags.diagnose(conformance->getProtocolNameLoc(),
+                               diag::note_isolate_conformance_to_global_actor,
+                               globalActorType, isMainActor, globalActorTypeStr);
+        conformance->applyConformanceAttribute(diag,
+                                               "@" + globalActorTypeStr.str());
+      }
     }
 
     // If the conformance could be @preconcurrency, suggest it.

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -5226,18 +5226,13 @@ static void diagnoseConformanceIsolationErrors(
     if (potentialIsolation && potentialIsolation->isGlobalActor() &&
         !conformance->isIsolated()) {
       // Skip the suggestion when the conforming nominal already carries the
-      // same global actor and the user hasn't explicitly opted the conformance
-      // out of isolation: writing the attribute on the conformance would be
-      // redundant with the nominal's isolation. Explicit 'nonisolated' keeps
-      // the suggestion, since it reflects a deliberate choice the user may
-      // want to reconsider.
+      // same global actor: the inserted attribute would either duplicate the
+      // nominal's isolation, or (when the conformance is explicitly
+      // 'nonisolated') conflict with it.
       auto *nominal =
           conformance->getDeclContext()->getSelfNominalTypeDecl();
-      bool explicitlyNonisolated =
-          conformance->getOptions().contains(
-              ProtocolConformanceFlags::Nonisolated);
       bool redundantWithNominal =
-          nominal && !explicitlyNonisolated &&
+          nominal &&
           isolationsMatch(getActorIsolation(nominal), *potentialIsolation);
 
       if (!redundantWithNominal) {

--- a/test/Concurrency/global_actor_inference.swift
+++ b/test/Concurrency/global_actor_inference.swift
@@ -125,7 +125,6 @@ protocol Interface {
 @MainActor
 class Object: Interface {
   // expected-note@-1{{turn data races into runtime errors with '@preconcurrency'}}{{15-15=@preconcurrency }}
-  // expected-note@-2{{isolate this conformance to the main actor with '@MainActor'}}
 
   var baz: Int = 42 // expected-note{{main actor-isolated property 'baz' cannot satisfy nonisolated requirement}}
   // expected-note@-1{{change property 'baz' to a 'nonisolated let' constant}}{{3-6=nonisolated let}}

--- a/test/Concurrency/global_actor_inference_swift6.swift
+++ b/test/Concurrency/global_actor_inference_swift6.swift
@@ -204,7 +204,6 @@ protocol InferenceConflictWithSuperclass: MainActorSuperclass, InferSomeGlobalAc
 // expected-error@+1{{conformance of 'C2' to protocol 'InferenceConflictWithSuperclass' crosses into main actor-isolated code and can cause data races}}
 class C2: MainActorSuperclass, InferenceConflictWithSuperclass {
   //expected-note@-1 {{turn data races into runtime errors with '@preconcurrency'}}
-  // expected-note@-2{{isolate this conformance to the main actor with '@MainActor'}}
 
   func f() {}
 

--- a/test/Concurrency/isolated_conformance.swift
+++ b/test/Concurrency/isolated_conformance.swift
@@ -10,8 +10,7 @@ protocol P {
 // Definition of isolated conformances
 // ----------------------------------------------------------------------------
 
-// expected-warning@+3{{conformance of 'CWithNonIsolated' to protocol 'P' crosses into main actor-isolated code and can cause data races}}
-// expected-note@+2{{isolate this conformance to the main actor with '@MainActor'}}{{25-25=@MainActor }}
+// expected-warning@+2{{conformance of 'CWithNonIsolated' to protocol 'P' crosses into main actor-isolated code and can cause data races}}
 @MainActor
 class CWithNonIsolated: P {
   // expected-note@-1{{turn data races into runtime errors with '@preconcurrency'}}{{25-25=@preconcurrency }}
@@ -28,8 +27,7 @@ do {
     protocol Q { func f() }
   }
   do {
-    // expected-warning@+3 {{conformance of 'S' to protocol 'P' crosses into main actor-isolated code and can cause data races}}
-    // expected-note@+2 {{isolate this conformance to the main actor with '@MainActor'}}{{26-26=@MainActor }}
+    // expected-warning@+2 {{conformance of 'S' to protocol 'P' crosses into main actor-isolated code and can cause data races}}
     // expected-note@+1 {{turn data races into runtime errors with '@preconcurrency'}}{{26-26=@preconcurrency }}
     @MainActor struct S: Nested.P {
       func f() {} // expected-note {{main actor-isolated instance method 'f()' cannot satisfy nonisolated requirement}}
@@ -37,19 +35,16 @@ do {
     }
   }
   do {
-    // Attribute inserted *before* '@unsafe'.
     @MainActor struct S: @unsafe Nested.P {
     // expected-warning@-1 {{conformance of 'S' to protocol 'P' crosses into main actor-isolated code and can cause data races}}
-    // expected-note@-2 {{isolate this conformance to the main actor with '@MainActor'}}{{26-26=@MainActor }}
-    // expected-note@-3 {{turn data races into runtime errors with '@preconcurrency'}}{{26-26=@preconcurrency }}
+    // expected-note@-2 {{turn data races into runtime errors with '@preconcurrency'}}{{26-26=@preconcurrency }}
       func f() {} // expected-note {{main actor-isolated instance method 'f()' cannot satisfy nonisolated requirement}}
       // expected-note@-1 {{mark instance method 'f()' 'nonisolated'}}{{7-7=nonisolated }}
     }
   }
   do {
-    // expected-warning@+4 {{conformance of 'S' to protocol 'Q' crosses into main actor-isolated code and can cause data races}}
-    // expected-warning@+3 {{conformance of 'S' to protocol 'P' crosses into main actor-isolated code and can cause data races}}
-    // expected-note@+2 2 {{isolate this conformance to the main actor with '@MainActor'}}{{26-26=@MainActor }}
+    // expected-warning@+3 {{conformance of 'S' to protocol 'Q' crosses into main actor-isolated code and can cause data races}}
+    // expected-warning@+2 {{conformance of 'S' to protocol 'P' crosses into main actor-isolated code and can cause data races}}
     // expected-note@+1 2 {{turn data races into runtime errors with '@preconcurrency'}}{{26-26=@preconcurrency }}
     @MainActor struct S: Nested.P & Nested.Q {
       func f() {} // expected-note 2 {{main actor-isolated instance method 'f()' cannot satisfy nonisolated requirement}}
@@ -58,8 +53,7 @@ do {
   }
   do {
     // FIXME: We shouldn't be applying nonisolated to both protocols.
-    // expected-warning@+3 {{conformance of 'S' to protocol 'P' crosses into main actor-isolated code and can cause data races}}
-    // expected-note@+2 {{isolate this conformance to the main actor with '@MainActor'}}{{26-26=@MainActor }}
+    // expected-warning@+2 {{conformance of 'S' to protocol 'P' crosses into main actor-isolated code and can cause data races}}
     // expected-note@+1 {{turn data races into runtime errors with '@preconcurrency'}}{{26-26=@preconcurrency }}
     @MainActor struct S: Nested.P & EmptyP  {
       func f() {} // expected-note {{main actor-isolated instance method 'f()' cannot satisfy nonisolated requirement}}
@@ -106,7 +100,6 @@ protocol Q {
 @MainActor
 struct SMissingIsolation: Q {
   // expected-note@-1{{conformance depends on main actor-isolated conformance of 'C' to protocol 'P'}}
-  // expected-note@-2{{isolate this conformance to the main actor with '@MainActor'}}
   typealias A = C
 }
 
@@ -118,7 +111,6 @@ struct PWrapper<T: P>: P {
 @MainActor
 struct SMissingIsolationViaWrapper: Q {
   // expected-note@-1{{conformance depends on main actor-isolated conformance of 'C' to protocol 'P'}}
-  // expected-note@-2{{isolate this conformance to the main actor with '@MainActor'}}{{37-37=@MainActor }}
   typealias A = PWrapper<C>
 }
 
@@ -260,8 +252,7 @@ protocol Distinguishable {
   var id: Self.ID { get }
 }
 
-// expected-warning@+4{{conformance of 'MyDistinguishable' to protocol 'Distinguishable' crosses into main actor-isolated code and can cause data races}}
-// expected-note@+3{{isolate this conformance to the main actor with '@MainActor'}}{{26-26=@MainActor }}
+// expected-warning@+3{{conformance of 'MyDistinguishable' to protocol 'Distinguishable' crosses into main actor-isolated code and can cause data races}}
 // expected-note@+2{{turn data races into runtime errors with '@preconcurrency'}}{{26-26=@preconcurrency }}
 @MainActor
 class MyDistinguishable: Distinguishable {
@@ -275,11 +266,9 @@ protocol HasMutableVar {
   var val: Self.Val { get set }
 }
 
-// expected-warning@+7{{conformance of 'ImmutableWithSeparateMutable' to protocol 'Distinguishable' crosses into main actor-isolated code and can cause data races}}
-// expected-note@+6{{isolate this conformance to the main actor with '@MainActor'}}
-// expected-note@+5{{turn data races into runtime errors with '@preconcurrency'}}
-// expected-warning@+4{{conformance of 'ImmutableWithSeparateMutable' to protocol 'HasMutableVar' crosses into main actor-isolated code and can cause data races}}
-// expected-note@+3{{isolate this conformance to the main actor with '@MainActor'}}
+// expected-warning@+5{{conformance of 'ImmutableWithSeparateMutable' to protocol 'Distinguishable' crosses into main actor-isolated code and can cause data races}}
+// expected-note@+4{{turn data races into runtime errors with '@preconcurrency'}}
+// expected-warning@+3{{conformance of 'ImmutableWithSeparateMutable' to protocol 'HasMutableVar' crosses into main actor-isolated code and can cause data races}}
 // expected-note@+2{{turn data races into runtime errors with '@preconcurrency'}}
 @MainActor
 class ImmutableWithSeparateMutable: Distinguishable, HasMutableVar {
@@ -293,8 +282,7 @@ protocol MixedMutability {
   var count: Int { get set }
 }
 
-// expected-warning@+4{{conformance of 'MixedMutabilityWitness' to protocol 'MixedMutability' crosses into main actor-isolated code and can cause data races}}
-// expected-note@+3{{isolate this conformance to the main actor with '@MainActor'}}
+// expected-warning@+3{{conformance of 'MixedMutabilityWitness' to protocol 'MixedMutability' crosses into main actor-isolated code and can cause data races}}
 // expected-note@+2{{turn data races into runtime errors with '@preconcurrency'}}
 @MainActor
 class MixedMutabilityWitness: MixedMutability {
@@ -308,8 +296,7 @@ protocol MultipleReadOnly {
   var second: Int { get }
 }
 
-// expected-warning@+4{{conformance of 'MultipleReadOnlyWitness' to protocol 'MultipleReadOnly' crosses into main actor-isolated code and can cause data races}}
-// expected-note@+3{{isolate this conformance to the main actor with '@MainActor'}}
+// expected-warning@+3{{conformance of 'MultipleReadOnlyWitness' to protocol 'MultipleReadOnly' crosses into main actor-isolated code and can cause data races}}
 // expected-note@+2{{turn data races into runtime errors with '@preconcurrency'}}
 @MainActor
 class MultipleReadOnlyWitness: MultipleReadOnly {
@@ -320,8 +307,7 @@ class MultipleReadOnlyWitness: MultipleReadOnly {
   var third = true
 }
 
-// expected-warning@+4{{conformance of 'ComputedWitness' to protocol 'Distinguishable' crosses into main actor-isolated code and can cause data races}}
-// expected-note@+3{{isolate this conformance to the main actor with '@MainActor'}}
+// expected-warning@+3{{conformance of 'ComputedWitness' to protocol 'Distinguishable' crosses into main actor-isolated code and can cause data races}}
 // expected-note@+2{{turn data races into runtime errors with '@preconcurrency'}}
 @MainActor
 class ComputedWitness: Distinguishable {
@@ -334,16 +320,14 @@ struct Wrapped<Value> {
   var wrappedValue: Value
 }
 
-// expected-warning@+4{{conformance of 'WrappedWitness' to protocol 'Distinguishable' crosses into main actor-isolated code and can cause data races}}
-// expected-note@+3{{isolate this conformance to the main actor with '@MainActor'}}
+// expected-warning@+3{{conformance of 'WrappedWitness' to protocol 'Distinguishable' crosses into main actor-isolated code and can cause data races}}
 // expected-note@+2{{turn data races into runtime errors with '@preconcurrency'}}
 @MainActor
 class WrappedWitness: Distinguishable {
   @Wrapped var id: String = "wrapped" // expected-note{{main actor-isolated property 'id' cannot satisfy nonisolated requirement}}
 }
 
-// expected-warning@+4{{conformance of 'ComputedGetSetWitness' to protocol 'HasMutableVar' crosses into main actor-isolated code and can cause data races}}
-// expected-note@+3{{isolate this conformance to the main actor with '@MainActor'}}
+// expected-warning@+3{{conformance of 'ComputedGetSetWitness' to protocol 'HasMutableVar' crosses into main actor-isolated code and can cause data races}}
 // expected-note@+2{{turn data races into runtime errors with '@preconcurrency'}}
 @MainActor
 class ComputedGetSetWitness: HasMutableVar {
@@ -352,4 +336,18 @@ class ComputedGetSetWitness: HasMutableVar {
     get { 42 }
     set { }
   }
+}
+
+// https://github.com/swiftlang/swift/issues/87776
+// The '@MainActor' suggestion on a conformance is suppressed when the
+// nominal already carries '@MainActor', since the attribute would be
+// redundant. The suggestion still fires for nominals with a different or
+// no global actor, and for conformances explicitly marked 'nonisolated'.
+// expected-warning@+2{{conformance of 'Issue87776' to protocol 'Identifiable' crosses into main actor-isolated code and can cause data races}}
+@MainActor
+class Issue87776: Identifiable {
+  // expected-note@-1{{turn data races into runtime errors with '@preconcurrency'}}{{19-19=@preconcurrency }}
+  var id: String = ""
+  // expected-note@-1{{main actor-isolated property 'id' cannot satisfy nonisolated requirement}}
+  // expected-note@-2{{change property 'id' to a 'nonisolated let' constant}}{{3-6=nonisolated let}}
 }

--- a/test/Concurrency/isolated_conformance.swift
+++ b/test/Concurrency/isolated_conformance.swift
@@ -340,9 +340,9 @@ class ComputedGetSetWitness: HasMutableVar {
 
 // https://github.com/swiftlang/swift/issues/87776
 // The '@MainActor' suggestion on a conformance is suppressed when the
-// nominal already carries '@MainActor', since the attribute would be
-// redundant. The suggestion still fires for nominals with a different or
-// no global actor, and for conformances explicitly marked 'nonisolated'.
+// nominal already carries '@MainActor', since the inserted attribute would
+// either duplicate the nominal's isolation or, for explicit 'nonisolated'
+// conformances, conflict with it.
 // expected-warning@+2{{conformance of 'Issue87776' to protocol 'Identifiable' crosses into main actor-isolated code and can cause data races}}
 @MainActor
 class Issue87776: Identifiable {
@@ -350,4 +350,15 @@ class Issue87776: Identifiable {
   var id: String = ""
   // expected-note@-1{{main actor-isolated property 'id' cannot satisfy nonisolated requirement}}
   // expected-note@-2{{change property 'id' to a 'nonisolated let' constant}}{{3-6=nonisolated let}}
+}
+
+// Same suppression for an explicit 'nonisolated' conformance on a '@MainActor'
+// nominal: inserting '@MainActor' next to 'nonisolated' would be contradictory.
+// expected-warning@+2{{conformance of 'Issue87776Nonisolated' to protocol 'P' crosses into main actor-isolated code and can cause data races}}
+@MainActor
+class Issue87776Nonisolated: nonisolated P {
+  // expected-note@-1{{turn data races into runtime errors with '@preconcurrency'}}{{30-30=@preconcurrency }}
+  func f() {}
+  // expected-note@-1{{main actor-isolated instance method 'f()' cannot satisfy nonisolated requirement}}
+  // expected-note@-2{{mark instance method 'f()' 'nonisolated'}}{{3-3=nonisolated }}
 }

--- a/test/Concurrency/isolated_conformance_default_actor.swift
+++ b/test/Concurrency/isolated_conformance_default_actor.swift
@@ -14,8 +14,7 @@ protocol Q {
   func g()
 }
 
-// expected-note@+3{{turn data races into runtime errors with '@preconcurrency'}}
-// expected-note@+2{{isolate this conformance to the main actor with '@MainActor'}}
+// expected-note@+2{{turn data races into runtime errors with '@preconcurrency'}}
 // expected-error@+1{{conformance of 'CImplicitMainActorNonisolatedConformance' to protocol 'P' crosses into main actor-isolated code and can cause data races}}
 class CImplicitMainActorNonisolatedConformance: nonisolated P {
   func f() { // expected-note{{main actor-isolated instance method 'f()' cannot satisfy nonisolated requirement}}

--- a/test/Concurrency/preconcurrency_conformances.swift
+++ b/test/Concurrency/preconcurrency_conformances.swift
@@ -107,7 +107,6 @@ final class K : @preconcurrency Initializable {
 @MainActor
 final class MainActorK: Initializable {
   // expected-note@-1{{turn data races into runtime errors with '@preconcurrency'}}{{25-25=@preconcurrency }}
-  // expected-note@-2{{isolate this conformance to the main actor with '@MainActor'}}
   init() { } // expected-note{{main actor-isolated initializer 'init()' cannot satisfy nonisolated requirement}}
   // expected-note@-1{{mark initializer 'init()' 'nonisolated'}}{{3-3=nonisolated }}
 }
@@ -236,7 +235,6 @@ do {
   @MainActor struct S4: @preconcurrency P3, P2 {
     // expected-warning@-1:21 {{'@preconcurrency' on conformance to 'P3' has no effect}}
     // expected-note@-2:45 {{turn data races into runtime errors with '@preconcurrency'}}
-    // expected-note@-3{{isolate this conformance to the main actor with '@MainActor'}}
     func foo() {}
     // expected-note@-1 {{main actor-isolated instance method 'foo()' cannot satisfy nonisolated requirement}}
     // expected-note@-2{{mark instance method 'foo()' 'nonisolated'}}{{5-5=nonisolated }}
@@ -245,7 +243,6 @@ do {
   @MainActor struct S5: P2, @preconcurrency P3 {
     // expected-warning@-1:21 {{'@preconcurrency' on conformance to 'P3' has no effect}}
     // expected-note@-2:25 {{turn data races into runtime errors with '@preconcurrency'}}
-    // expected-note@-3{{isolate this conformance to the main actor with '@MainActor'}}
     func foo() {}
     // expected-note@-1 {{main actor-isolated instance method 'foo()' cannot satisfy nonisolated requirement}}
     // expected-note@-2{{mark instance method 'foo()' 'nonisolated'}}{{5-5=nonisolated }}
@@ -306,7 +303,6 @@ do {
   @MainActor struct S4: P6, @preconcurrency P5 {
     // expected-warning@-1:21 {{'@preconcurrency' on conformance to 'P5' has no effect}}
     // expected-note@-2{{turn data races into runtime errors with '@preconcurrency'}}
-    // expected-note@-3{{isolate this conformance to the main actor with '@MainActor'}}
     func foo() {}
     // expected-note@-1 {{main actor-isolated instance method 'foo()' cannot satisfy nonisolated requirement}}
     // expected-note@-2{{mark instance method 'foo()' 'nonisolated'}}{{5-5=nonisolated }}

--- a/test/Concurrency/predates_concurrency.swift
+++ b/test/Concurrency/predates_concurrency.swift
@@ -227,7 +227,6 @@ protocol NotIsolated {
 // expected-complete-warning@+1{{conformance of 'MainActorPreconcurrency' to protocol 'NotIsolated' crosses into main actor-isolated code and can cause data races}}
 extension MainActorPreconcurrency: NotIsolated {
   // expected-complete-note@-1{{turn data races into runtime errors with '@preconcurrency'}}{{36-36=@preconcurrency }}
-  // expected-complete-note@-2{{isolate this conformance to the main actor with '@MainActor'}}
   func requirement() {}
   // expected-complete-note@-1 {{main actor-isolated instance method 'requirement()' cannot satisfy nonisolated requirement}}
   // expected-complete-note@-2 {{mark instance method 'requirement()' 'nonisolated'}}{{3-3=nonisolated }}

--- a/test/decl/class/actor/global_actor_conformance.swift
+++ b/test/decl/class/actor/global_actor_conformance.swift
@@ -57,7 +57,6 @@ protocol NonIsolatedRequirement {
 // expected-warning@+1{{conformance of 'OnMain' to protocol 'NonIsolatedRequirement' crosses into main actor-isolated code}}
 extension OnMain: NonIsolatedRequirement {
   // expected-note@-1{{turn data races into runtime errors with '@preconcurrency'}}
-  // expected-note@-2{{isolate this conformance to the main actor with '@MainActor'}}
   // expected-note@+1 {{main actor-isolated instance method 'requirement()' cannot satisfy nonisolated requirement}}
   func requirement() {}
   // expected-note@-1{{mark instance method 'requirement()' 'nonisolated'}}{{3-3=nonisolated }}


### PR DESCRIPTION
## Summary

- Fixes #87776: the note advising to "isolate this conformance to the main actor with `@MainActor`" fired even when the conforming nominal already carried `@MainActor`, producing a redundant fix-it.
- In `diagnoseConformanceIsolationErrors`, skip the suggestion when `getActorIsolation(nominal)` matches the accumulated `potentialIsolation`, unless the conformance is explicitly `nonisolated` (in which case the note still fires as a prompt to reconsider).
- Fixes a latent assertion in `isolationsMatch` that fired when either isolation was neither a global actor nor an actor instance.

## Test plan

- [x] `test/Concurrency/isolated_conformance.swift` (incl. new `Issue87776` regression): 1/1 passed.
- [x] Full `test/Concurrency` suite: 451/451 supported passed, 14 unsupported, 0 failures.