### PR TITLE
Downgrade to warning isolated_conformance_may_cross_isolation

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -9025,7 +9025,7 @@ GROUPED_WARNING(isolated_conformance_will_become_nonisolated,IsolatedConformance
 GROUPED_ERROR(isolated_conformance_to_sendable_metatype,IsolatedConformances,none,
     "cannot form %0 conformance of %1 to SendableMetatype-inheriting %kind2",
     (ActorIsolation, Type, const ValueDecl *))
-GROUPED_ERROR(isolated_conformance_may_cross_isolation,IsolatedConformances,none,
+GROUPED_WARNING(isolated_conformance_may_cross_isolation,IsolatedConformances,none,
     "conformance of %select{underlying type of 'some %1'|%0}0 to protocol "
     "'%1' may be isolated and cannot be passed to %2 context",
     (Identifier, StringRef, ActorIsolation))

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -9179,8 +9179,7 @@ bool swift::checkIsolatedConformancesForIsolationCrossing(
 
       ctx.Diags
           .diagnose(loc, diag::isolated_conformance_may_cross_isolation,
-                    genericParamName, proto->getName().str(), targetIsolation)
-          .warnUntilLanguageMode(LanguageMode::v6);
+                    genericParamName, proto->getName().str(), targetIsolation);
       diagnosed = true;
     }
   }

--- a/test/Concurrency/isolated_conformance_generic_escape.swift
+++ b/test/Concurrency/isolated_conformance_generic_escape.swift
@@ -58,13 +58,13 @@ nonisolated(nonsending) func nonsendingForwardToConcurrent(_ p: MyClass) async {
 // When the conformance is abstract (generic), we reject it because the concrete
 // conformance may be isolated.
 nonisolated(nonsending) func nonsendingForwardToConcurrentGeneric(_ p: some MyProtocol) async {
-  // expected-error@+1{{conformance of underlying type of 'some MyProtocol' to protocol 'MyProtocol' may be isolated and cannot be passed to nonisolated context}}
+  // expected-warning@+1{{conformance of underlying type of 'some MyProtocol' to protocol 'MyProtocol' may be isolated and cannot be passed to nonisolated context}}
   await callDoSomethingConcurrent(p)
 }
 
 struct Container<T: MyProtocol> {
   nonisolated(nonsending) func nonsendingForwardToConcurrentGeneric(_ p: T) async {
-    // expected-error@+1{{conformance of 'T' to protocol 'MyProtocol' may be isolated and cannot be passed to nonisolated context}}
+    // expected-warning@+1{{conformance of 'T' to protocol 'MyProtocol' may be isolated and cannot be passed to nonisolated context}}
     await callDoSomethingConcurrent(p)
   }
 }
@@ -89,7 +89,7 @@ nonisolated(nonsending) func nonsendingForwardSendableGeneric(_ p: some Sendable
 }
 
 nonisolated(nonsending) func nonsendingForwardSendableGenericComp<P: MyProtocol>(_ p: P) async { // expected-note{{consider making generic parameter 'P' conform to the 'Sendable' protocol}}
-  // expected-error@+2{{conformance of 'P' to protocol 'MyProtocol' may be isolated and cannot be passed to nonisolated context}}
+  // expected-warning@+2{{conformance of 'P' to protocol 'MyProtocol' may be isolated and cannot be passed to nonisolated context}}
   // expected-error@+1{{type 'P' does not conform to the 'Sendable' protocol}}
   await callSendableProtocolComp(p)
 }
@@ -98,7 +98,7 @@ final class Caller {
   @concurrent func call(first p: some MyProtocol, second fine: String) async { p.doSomething() }
 }
 nonisolated(nonsending) func nonsendingForwardSendableGeneric(caller: Caller, _ p: some MyProtocol) async {
-  // expected-error@+1{{conformance of underlying type of 'some MyProtocol' to protocol 'MyProtocol' may be isolated and cannot be passed to nonisolated context}}
+  // expected-warning@+1{{conformance of underlying type of 'some MyProtocol' to protocol 'MyProtocol' may be isolated and cannot be passed to nonisolated context}}
   await caller.call(first: p, second: "this is fine")
 }
 
@@ -123,7 +123,7 @@ func callDoSomethingConcurrentExplicit<ItsMe: MyProtocol>(_ p: ItsMe) async {
 }
 
 nonisolated(nonsending) func nonsendingForwardExplicitGeneric<TheProblemIsNotHere: MyProtocol>(_ p: TheProblemIsNotHere) async {
-  // expected-error@+1{{conformance of 'TheProblemIsNotHere' to protocol 'MyProtocol' may be isolated and cannot be passed to nonisolated context}}
+  // expected-warning@+1{{conformance of 'TheProblemIsNotHere' to protocol 'MyProtocol' may be isolated and cannot be passed to nonisolated context}}
   await callDoSomethingConcurrentExplicit(p)
 }
 
@@ -134,7 +134,7 @@ nonisolated(nonsending) func nonsendingForwardExplicitGeneric<TheProblemIsNotHer
 // @MainActor forwarding generic to @concurrent — same issue, rejected.
 @MainActor
 func mainActorForwardToConcurrentGeneric(_ p: some MyProtocol) async {
-  // expected-error@+1{{conformance of underlying type of 'some MyProtocol' to protocol 'MyProtocol' may be isolated and cannot be passed to nonisolated context}}
+  // expected-warning@+1{{conformance of underlying type of 'some MyProtocol' to protocol 'MyProtocol' may be isolated and cannot be passed to nonisolated context}}
   await callDoSomethingConcurrent(p)
 }
 


### PR DESCRIPTION
- Explanation:

  Since this is causing too many problems still; we upgrade it to a warning even in swift 6 mode for now...

  We have to revisit this, because these are real races this prevents. 

- Scope:

  This only affects situations when conformance is passed across an isolation boundary.

- Issues:

  - rdar://175013329
  - rdar://175285500

- Risk:
 
   Very low. This change downgrades error to a warning and won't break any existing code.

- Testing:

  Updated existing tests to produce warnings instead of errors.