### PR TITLE
IRGen: Zero single-value enum/struct payloads larger than PtrSize with memset

### DIFF
--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -897,7 +897,9 @@ void irgen::storeFixedTypeEnumTagSinglePayload(
   payloadIndex->addIncoming(payloadIndex0, payloadLT4BB);
 
   if (fixedSize > Size(0)) {
-    if (fixedSize.getValueInBits() <= llvm::IntegerType::MAX_INT_BITS / 4) {
+    // TODO: Setting the threshold at PointerSize causes stack clobbering in
+    // Windows validation tests. Investigate this before lowering the value further.
+    if (fixedSize <= IGM.getPointerSize() * 2) {
       // Write the value to the payload as a zero extended integer.
       auto *intType = Builder.getIntNTy(fixedSize.getValueInBits());
       Builder.CreateStore(Builder.CreateZExtOrTrunc(payloadIndex, intType),

--- a/test/IRGen/typelayout_based_value_witness.swift
+++ b/test/IRGen/typelayout_based_value_witness.swift
@@ -1,6 +1,6 @@
-// RUN: %target-swift-frontend -enable-type-layout -primary-file %s -emit-ir | %FileCheck %s --check-prefix=CHECK
-// RUN: %target-swift-frontend -enable-type-layout -primary-file %s -O -emit-ir | %FileCheck %s --check-prefix=OPT --check-prefix=OPT-%target-ptrsize --check-prefix=OPT-%target-ptrauth
-// RUN: %target-swift-frontend -primary-file %s -emit-ir | %FileCheck %s --check-prefix=NOTL
+// RUN: %target-swift-frontend -disable-availability-checking -enable-type-layout -primary-file %s -emit-ir | %FileCheck %s --check-prefix=CHECK
+// RUN: %target-swift-frontend -disable-availability-checking -enable-type-layout -primary-file %s -O -emit-ir | %FileCheck %s --check-prefix=OPT --check-prefix=OPT-%target-ptrsize --check-prefix=OPT-%target-ptrauth
+// RUN: %target-swift-frontend -disable-availability-checking -primary-file %s -emit-ir | %FileCheck %s --check-prefix=NOTL
 
 // REQUIRES: PTRSIZE=64
 
@@ -155,4 +155,51 @@ public enum E3<T> {
   case empty
   case first(T)
   case second(T)
+}
+
+// Value types storing large InlineArray can have excessively large value witnesses #88579
+
+// CHECK:      define {{.*}} void @"$s30typelayout_based_value_witness2S1Vwst"(ptr noalias %value, i32 %whichCase, i32 %numEmptyCases, {{.*}}) {{.*}} {
+// CHECK:        [[CASEVAL:%[0-9]+]] = trunc i32 [[CASEID:%[0-9]+]] to i8
+// CHECK-NEXT:   store i8 [[CASEVAL]], ptr %value, align 1
+// CHECK-NOT:    memset
+// CHECK:      }
+struct S1 {
+  var a: InlineArray<1, Int8>
+}
+
+// CHECK:     define {{.*}} void @"$s30typelayout_based_value_witness4S16BVwst"(ptr noalias %value, i32 %whichCase, i32 %numEmptyCases, {{.*}}) {{.*}} {
+// CHECK-NOT:   memset
+// CHECK:     }
+struct S16B {
+  var a: InlineArray<16, Int8>
+}
+
+// CHECK:     define {{.*}} void @"$s30typelayout_based_value_witness4S17BVwst"(ptr noalias %value, i32 %whichCase, i32 %numEmptyCases, {{.*}}) {{.*}} {
+// CHECK:       memset
+// CHECK:     }
+struct S17B {
+  var a: InlineArray<17, Int8>
+}
+
+
+// CHECK:      define {{.*}} void @"$s30typelayout_based_value_witness3S10Vwst"(ptr noalias %value, i32 %whichCase, i32 %numEmptyCases, {{.*}}) {{.*}} {
+// CHECK:        [[CASEVAL:%[0-9]+]] = zext i32 [[CASEID:%[0-9]+]] to i64
+// CHECK-NEXT:   store i64 [[CASEVAL]], ptr %value, align 8
+// CHECK-NEXT:   [[PAYLOAD_BASE:%[0-9]+]] = getelementptr inbounds i8, ptr %value, i32 8
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr align 8 [[PAYLOAD_BASE]], i8 0, i64 72, i1 false)
+// CHECK:      }
+struct S10 {
+    var a: InlineArray<10, Int>
+}
+
+// CHECK:      define {{.*}} void @"$s30typelayout_based_value_witness4S100Vwst"(ptr noalias %value, i32 %whichCase, i32 %numEmptyCases, {{.*}}) {{.*}} {
+// CHECK:        entry:
+// CHECK:        [[CASEVAL:%[0-9]+]] = zext i32 [[CASEID:%[0-9]+]] to i64
+// CHECK-NEXT:   store i64 [[CASEVAL]], ptr %value, align 8
+// CHECK-NEXT:   [[PAYLOAD_BASE:%[0-9]+]] = getelementptr inbounds i8, ptr %value, i32 8
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr align 8 [[PAYLOAD_BASE]], i8 0, i64 792, i1 false)
+// CHECK:      }
+struct S100 {
+    var a: InlineArray<100, Int>
 }


### PR DESCRIPTION
<!--
The main branch is now in convergence, which means major changes, such as large refactoring or new features, should be avoided. This strategy is intended to maintain the stability of the Swift 6.4 release leading up to the May 4th branch. For any work that requires broad changes or introduces new features, create a feature branch and open a draft pull request. All updates to the swiftlang/swift repository’s main branch require approval from the release managers. A pull request targeting swiftlang/swift will automatically add release managers. You can also contact them via @release-managers in the forum group.
-->

<!-- Please fill out the following form: --> 
- **Explanation**: In `irgen::storeFixedTypeEnumTagSinglePayload`, change the threshold for zeroing the payload using memset from `MAX_INT_BITS / 4 == 1<<21` to ~the size of a pointer~ `sizeof(pointer) * 2`.
  We would previously zero payloads up to an incredibly large size by zero-extending the payload index and storing that value. This could cause `storeEnumTagSinglePayload` witness methods for large types to become excessively large.
  LLVM can do a better job at generating code for the memset intrinsic; it even has the option of generating multiple store instructions if appropriate.
  <!--
  A description of the changes. This can be brief, but it should be clear.
  -->
- **Scope**: This only affects the generation of a specific kind of witness method, and the only difference should be how that method sets a region of memory to zero. The change is simple and isolated, so it is unlikely to break existing code.
  <!--
  An assessment of the impact and importance of the changes. For example, can
  the changes break existing code?
  -->
- **Issues**: #88579 == rdar://175252112
  <!--
  References to issues the changes resolve, if any.
  -->
- **Risk**: Low, due to the isolated nature of the change.
  <!--
  The (specific) risk to the release for taking the changes.
  -->
- **Testing**: Unit tests added, CI testing.
  <!--
  The specific testing that has been done or needs to be done to further
  validate any impact of the changes.
  -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
