### PR TITLE
CMake: Increase CMake minimum version to 3.29

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.19.6)
+cmake_minimum_required(VERSION 3.29)
 
 
 #  set_property(GLOBAL PROPERTY GLOBAL_DEPENDS_DEBUG_MODE 1)
@@ -8,21 +8,6 @@ cmake_minimum_required(VERSION 3.19.6)
 # rdar://37725888
 if(POLICY CMP0068)
   cmake_policy(SET CMP0068 OLD)
-endif()
-
-# Honour CMAKE_CXX_STANDARD in try_compile(), needed for check_cxx_native_regex.
-if(POLICY CMP0067)
-  cmake_policy(SET CMP0067 NEW)
-endif()
-
-# Convert relative paths to absolute for subdirectory `target_sources`
-if(POLICY CMP0076)
-  cmake_policy(SET CMP0076 NEW)
-endif()
-
-# Don't clobber existing variable values when evaluating `option()` declarations.
-if(POLICY CMP0077)
-  cmake_policy(SET CMP0077 NEW)
 endif()
 
 # Add path for custom CMake modules.

--- a/cmake/modules/AddPureSwift.cmake
+++ b/cmake/modules/AddPureSwift.cmake
@@ -28,10 +28,6 @@ function(_add_host_swift_compile_options name)
       "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -disable-implicit-string-processing-module-import>")
   endif()
 
-  # Emitting module seprately doesn't give us any benefit.
-  target_compile_options(${name} PRIVATE
-    "$<$<COMPILE_LANGUAGE:Swift>:-no-emit-module-separately-wmo>")
-
   if(SWIFT_ANALYZE_CODE_COVERAGE)
      set(_cov_flags $<$<COMPILE_LANGUAGE:Swift>:-profile-generate -profile-coverage-mapping>)
      target_compile_options(${name} PRIVATE ${_cov_flags})
@@ -303,22 +299,12 @@ function(add_pure_swift_host_library name)
     set(module_file "${module_base}/${module_triple}.swiftmodule")
     set(module_interface_file "${module_base}/${module_triple}.swiftinterface")
     set(module_private_interface_file "${module_base}/${module_triple}.private.swiftinterface")
-    set(module_sourceinfo_file "${module_base}/${module_triple}.swiftsourceinfo")
-
-    # Create the module directory.
-    add_custom_command(
-        TARGET ${name}
-        PRE_BUILD
-        COMMAND "${CMAKE_COMMAND}" -E make_directory ${module_base}
-        COMMENT "Generating module directory for ${name}")
 
     # Configure the emission of the Swift module files.
     target_compile_options("${name}" PRIVATE
         $<$<COMPILE_LANGUAGE:Swift>:
-        -module-name;$<TARGET_PROPERTY:${name},Swift_MODULE_NAME>;
         -enable-library-evolution;
         -emit-module-path;${module_file};
-        -emit-module-source-info-path;${module_sourceinfo_file};
         -emit-module-interface-path;${module_interface_file};
         -emit-private-module-interface-path;${module_private_interface_file}
         >)
@@ -421,6 +407,12 @@ function(add_pure_swift_host_tool name)
 
   # Create the library.
   add_executable(${name} ${APSHT_SOURCES})
+
+  # CMake auto-passes -module-name based on the target name.
+  # Swift module names must be valid identifiers, so sanitize hyphens to underscores.
+  string(REPLACE "-" "_" _swift_module_name ${name})
+  set_target_properties(${name} PROPERTIES Swift_MODULE_NAME ${_swift_module_name})
+
   _add_host_swift_compile_options(${name})
   _set_pure_swift_link_flags(${name} "../lib/")
   _set_pure_swift_package_options(${name} "${APSHT_PACKAGE_NAME}")


### PR DESCRIPTION
- **Explanation**:

CMake 3.29 introduces CMP0157, which improves Swift support in CMake.

These changes require swiftlang/swift-syntax#3321 to work properly as swift-syntax does not build with CMP0157 set to NEW otherwise.

- **Scope**:

The built artifacts should be identical with these changes.

- **Risk**:

Minimal. The changes were tested locally and will be tested on CI.
- **Testing**:

Local testing + CI.
