### PR TITLE
[cxx-interop] Fix an optimizer crash for some single field structs

### DIFF
--- a/lib/SILOptimizer/Utils/InstOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/InstOptUtils.cpp
@@ -2168,20 +2168,29 @@ SILValue swift::createEmptyAndUndefValue(SILType ty,
   return SILUndef::get(insertionPoint->getFunction(), ty);
 }
 
+static bool findUnreferenceableStorageInType(SILType ty, SILFunction *func) {
+  if (auto *structDecl = ty.getStructOrBoundGenericStruct()) {
+    return swift::findUnreferenceableStorage(structDecl, ty, func);
+  }
+  if (auto tupleTy = ty.getAs<TupleType>()) {
+    for (unsigned i = 0, e = tupleTy->getNumElements(); i < e; ++i) {
+      if (findUnreferenceableStorageInType(ty.getTupleElementType(i), func))
+        return true;
+    }
+  }
+  return false;
+}
+
 bool swift::findUnreferenceableStorage(StructDecl *decl, SILType structType,
                                        SILFunction *func) {
   if (decl->hasUnreferenceableStorage()) {
     return true;
   }
-  // Check if any fields have unreferenceable stoage
   for (auto *field : decl->getStoredProperties()) {
     TypeExpansionContext tec = *func;
     auto fieldTy = structType.getFieldType(field, func->getModule(), tec);
-    if (auto *fieldStructDecl = fieldTy.getStructOrBoundGenericStruct()) {
-      if (findUnreferenceableStorage(fieldStructDecl, fieldTy, func)) {
-        return true;
-      }
-    }
+    if (findUnreferenceableStorageInType(fieldTy, func))
+      return true;
   }
   return false;
 }

--- a/test/Interop/Cxx/stdlib/Inputs/module.modulemap
+++ b/test/Interop/Cxx/stdlib/Inputs/module.modulemap
@@ -128,3 +128,9 @@ module IncludeMath {
   header "include-math.h"
   export *
 }
+
+module StdSingleFieldAggregate {
+  header "std-single-field-aggregate.h"
+  requires cplusplus
+  export *
+}

--- a/test/Interop/Cxx/stdlib/Inputs/std-single-field-aggregate.h
+++ b/test/Interop/Cxx/stdlib/Inputs/std-single-field-aggregate.h
@@ -1,0 +1,17 @@
+#ifndef TEST_INTEROP_CXX_STDLIB_INPUTS_STD_SINGLE_FIELD_AGGREGATE_H
+#define TEST_INTEROP_CXX_STDLIB_INPUTS_STD_SINGLE_FIELD_AGGREGATE_H
+
+#include <array>
+#include <optional>
+
+struct SingleFieldArray {
+  std::array<std::optional<int>, 2> elements;
+};
+
+inline std::optional<SingleFieldArray> makeOptionalSingleFieldArray() {
+  SingleFieldArray s;
+  s.elements[0] = 42;
+  return s;
+}
+
+#endif

--- a/test/Interop/Cxx/stdlib/use-std-single-field-aggregate.swift
+++ b/test/Interop/Cxx/stdlib/use-std-single-field-aggregate.swift
@@ -1,0 +1,11 @@
+// RUN: %target-swift-frontend -c -primary-file %s -I %S/Inputs -cxx-interoperability-mode=default -O -module-name test
+
+import StdSingleFieldAggregate
+
+func test() -> Bool {
+  let opt = makeOptionalSingleFieldArray()
+  if let sfa = opt.value {
+    return sfa.elements[0].value != nil
+  }
+  return false
+}


### PR DESCRIPTION
**Explanation:**
Some types that are in fact unreferenceable were mistakenly classified as referenceable and the optimizer tried to do some optimizations that are not valid that resulted in crashes.
**Scope:**
Code using C++ interoperability. 
**Issues:**
rdar://175037688
**Risk:**
Low, the new checking is more comprehensively identify unreferenceable types but it does not change any other logic.
**Testing:**
Added compiler tests.

---


There is some logic to figure out if a type is unreferenceable but that did not handle tuple fields. C arrays are imported as Swift tuples, so in case a C array had unreferenceable element type we can end up taking the wrong path in the optimizer and trigger a crash.

rdar://175037688