### PR TITLE
[ModuleTrace] Overlay modules are not direct imports

### DIFF
--- a/lib/FrontendTool/LoadedModuleTrace.cpp
+++ b/lib/FrontendTool/LoadedModuleTrace.cpp
@@ -897,8 +897,17 @@ bool swift::emitLoadedModuleTraceIfNeeded(const ModuleDependencyID &mainModule,
   // compute the full set of swift module dependencies.
   auto *info = cache.findKnownDependency(mainModule).getAsSwiftSourceModule();
   assert(info && "main module is not source module");
+
   std::set<ModuleDependencyID> directDeps;
-  for (auto &dep : cache.getAllSwiftDependencies(mainModule)) {
+  // Add directly imported swift modules.
+  for (auto &dep : cache.getImportedSwiftDependencies(mainModule)) {
+    if (llvm::find(info->dependencyOnlyImports, dep.ModuleName) ==
+        info->dependencyOnlyImports.end())
+      directDeps.insert(dep);
+  }
+  // Add swift cross module overlay since cross module overlay requires direct
+  // import of both parent modules.
+  for (auto &dep : cache.getCrossImportOverlayDependencies(mainModule)) {
     if (llvm::find(info->dependencyOnlyImports, dep.ModuleName) ==
         info->dependencyOnlyImports.end())
       directDeps.insert(dep);

--- a/test/ScanDependencies/loaded_module_trace.swift
+++ b/test/ScanDependencies/loaded_module_trace.swift
@@ -6,12 +6,12 @@
 // RUN: split-file %s %t
 // RUN: ln -s %t/C_real.swiftinterface %t/C.swiftinterface
 
-// RUN: %target-build-swift -emit-module -module-name Module %S/../Driver/Inputs/loaded_module_trace_empty.swift \
-// RUN:   -o %t/Module.swiftmodule -module-cache-path %t/cache
-// RUN: %target-build-swift -emit-module -module-name Module2 %S/../Driver/Inputs/loaded_module_trace_imports_module.swift \
-// RUN:   -o %t/Module2.swiftmodule -I %t -module-cache-path %t/cache -strict-memory-safety
+// RUN: %target-swift-frontend -emit-module -module-name Module %S/../Driver/Inputs/loaded_module_trace_empty.swift \
+// RUN:   -o %t/Module.swiftmodule
+// RUN: %target-swift-frontend -emit-module -module-name Module2 %S/../Driver/Inputs/loaded_module_trace_imports_module.swift \
+// RUN:   -o %t/Module2.swiftmodule -I %t -strict-memory-safety
 // RUN: %target-build-swift -emit-library -module-name Plugin %S/../Driver/Inputs/loaded_module_trace_compiler_plugin.swift \
-// RUN:   -o %t/%target-library-name(Plugin) -module-cache-path %t/cache
+// RUN:   -o %t/%target-library-name(Plugin)
 
 // RUN: %target-swift-frontend -scan-dependencies %t/test.swift -emit-loaded-module-trace -emit-loaded-module-trace-path %t/trace.json \
 // RUN:   -enable-upcoming-feature RegionBasedIsolation -strict-memory-safety -module-name Test -dependency-only-import B \
@@ -34,6 +34,9 @@
 // CHECK-DAG: {"name":"Module","path":"{{[^"]*\\[/\\]}}Module.swiftmodule","isImportedDirectly":false,"supportsLibraryEvolution":false,"strictMemorySafety":false}
 // CHECK-DAG: {"name":"A","path":"{{[^"]*\\[/\\]}}A.swiftinterface","isImportedDirectly":true,"supportsLibraryEvolution":true,"strictMemorySafety":true}
 // CHECK-DAG: {"name":"C","path":"{{[^"]*\\[/\\]}}C_real.swiftinterface","isImportedDirectly":true,"supportsLibraryEvolution":true,"strictMemorySafety":false}
+// CHECK-DAG: {"name":"_C_A","path":"{{[^"]*\\[/\\]}}_C_A.swiftinterface","isImportedDirectly":true,"supportsLibraryEvolution":true,"strictMemorySafety":false}
+// CHECK-DAG: {"name":"D","path":"{{[^"]*\\[/\\]}}D.swiftinterface","isImportedDirectly":true,"supportsLibraryEvolution":true,"strictMemorySafety":false}
+// CHECK-DAG: {"name":"F","path":"{{[^"]*\\[/\\]}}F.swiftinterface","isImportedDirectly":false,"supportsLibraryEvolution":true,"strictMemorySafety":false}
 // CHECK: ],
 // CHECK: "swiftmacros":[
 // CHECK-DAG: {"name":"Plugin","path":"{{[^"]*\\[/\\]}}{{libPlugin.dylib|libPlugin.so|Plugin.dll}}"}
@@ -45,6 +48,7 @@
 import Module2
 import C
 import A
+import D
 
 @freestanding(expression) macro echo<T>(_: T) -> T = #externalMacro(module: "Plugin", type: "EchoMacro")
 
@@ -64,14 +68,35 @@ public func funcB() { }
 // swift-module-flags: -module-name C
 public func funcC() { }
 
+//--- _C_A.swiftinterface
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name _C_A
+
+//--- D.swiftinterface
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name D
+@_exported import D
+
+//--- F.swiftinterface
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name F
+@_exported import F
+
+//--- D.h
+#import <F.h>
+
+//--- F.h
+
 //--- module.modulemap
-module _C_A {
-  header "c_a.h"
+module D {
+  header "D.h"
   export *
 }
 
-//--- c_a.h
-void c_a(void);
+module F {
+  header "F.h"
+  export *
+}
 
 //--- C.swiftcrossimport/A.swiftoverlay
 %YAML 1.2


### PR DESCRIPTION
In the dependency scanning graph, swift overlay modules are listed as direct imports of the main modules in the output just because how they are discovered. In reality, only overlay modules indirectly discovered through clang module will be categorized as overlay module and they are not explicit imported in the main module. Thus the module trace file should not list them as direct import.

This fixes the module trace generated from dependency scanning graph only since that is the path forward. The old module trace sometimes lists overlay modules as direct and some as indirect and they will not be fixed.

<!-- Please fill out the following form: --> 
- **Explanation**: Fix module trace file emitted from dependency scanner
  <!--
  A description of the changes. This can be brief, but it should be clear.
  -->
- **Scope**: Affect swift module trace file emitted when explicit module is used.
  <!--
  An assessment of the impact and importance of the changes. For example, can
  the changes break existing code?
  -->
- **Issues**: rdar://175155835
  <!--
  References to issues the changes resolve, if any.
  -->
- **Risk**: Low. Mark some modules that was marked as directly imported to indirectly imported.
  <!--
  The (specific) risk to the release for taking the changes.
  -->
- **Testing**: Unit test. 
  <!--
  The specific testing that has been done or needs to be done to further
  validate any impact of the changes.
  -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
