### PR TITLE
[Reflection] Fix incorrect count and segment matching in ReflectionContext mach-o parsing.

### DIFF
--- a/include/swift/RemoteInspection/ReflectionContext.h
+++ b/include/swift/RemoteInspection/ReflectionContext.h
@@ -89,6 +89,7 @@ template <> struct MachOTraits<4> {
   using SegmentCmd = const struct llvm::MachO::segment_command;
   using Section = const struct llvm::MachO::section;
   static constexpr size_t MagicNumber = llvm::MachO::MH_MAGIC;
+  static constexpr uint32_t SegmentLoadCommand = llvm::MachO::LC_SEGMENT;
 };
 
 template <> struct MachOTraits<8> {
@@ -96,6 +97,7 @@ template <> struct MachOTraits<8> {
   using SegmentCmd = const struct llvm::MachO::segment_command_64;
   using Section = const struct llvm::MachO::section_64;
   static constexpr size_t MagicNumber = llvm::MachO::MH_MAGIC_64;
+  static constexpr uint32_t SegmentLoadCommand = llvm::MachO::LC_SEGMENT_64;
 };
 
 template <unsigned char ELFClass> struct ELFTraits;
@@ -262,47 +264,59 @@ public:
     auto Header = reinterpret_cast<typename T::Header *>(Buf.get());
     assert(Header->magic == T::MagicNumber && "invalid MachO file");
 
-    auto NumCommands = Header->sizeofcmds;
+    auto NumCommands = Header->ncmds;
+    auto SizeOfCommands = Header->sizeofcmds;
 
     // The layout of the executable is such that the commands immediately follow
     // the header.
     auto CmdStartAddress = ImageStart + sizeof(typename T::Header);
-    uint32_t SegmentCmdHdrSize = sizeof(typename T::SegmentCmd);
-    uint64_t Offset = 0;
+
+    // Read all of the load commands into .
+    auto LoadCmdsBuf =
+        this->getReader().readBytes(CmdStartAddress, SizeOfCommands);
+    if (!LoadCmdsBuf)
+      return {};
+    auto LoadCmds = reinterpret_cast<const char *>(LoadCmdsBuf.get());
+
+    // Invoke `visitor(CmdHdr, Offset)` for each segment load command. Return
+    // false to stop iteration.
+    auto forEachSegment = [&](auto &&visitor) {
+      uint64_t Offset = 0;
+      for (unsigned I = 0; I < NumCommands; ++I) {
+        if (Offset + sizeof(llvm::MachO::load_command) > SizeOfCommands)
+          return;
+        auto Cmd = reinterpret_cast<const llvm::MachO::load_command *>(
+            LoadCmds + Offset);
+        auto CmdSize = Cmd->cmdsize;
+        if (Cmd->cmd == T::SegmentLoadCommand) {
+          auto CmdHdr =
+              reinterpret_cast<typename T::SegmentCmd *>(LoadCmds + Offset);
+          if (!visitor(CmdHdr, Offset))
+            return;
+        }
+        Offset += CmdSize;
+      }
+    };
 
     // Find the __TEXT segment.
     typename T::SegmentCmd *TextCommand = nullptr;
-    for (unsigned I = 0; I < NumCommands; ++I) {
-      auto CmdBuf = this->getReader().readBytes(CmdStartAddress + Offset,
-                                                SegmentCmdHdrSize);
-      if (!CmdBuf)
-        return {};
-      auto CmdHdr = reinterpret_cast<typename T::SegmentCmd *>(CmdBuf.get());
-      if (strncmp(CmdHdr->segname, "__TEXT", sizeof(CmdHdr->segname)) == 0) {
-        TextCommand = CmdHdr;
-        savedBuffers.push_back(std::move(CmdBuf));
-        break;
-      }
-      Offset += CmdHdr->cmdsize;
-    }
+    uint64_t TextOffset = 0;
+    forEachSegment([&](auto *CmdHdr, uint64_t Offset) {
+      if (strncmp(CmdHdr->segname, "__TEXT", sizeof(CmdHdr->segname)) != 0)
+        return true;
+      TextCommand = CmdHdr;
+      TextOffset = Offset;
+      return false;
+    });
 
     // No __TEXT segment, bail out.
     if (!TextCommand)
       return {};
 
-   // Find the load command offset.
-    auto loadCmdOffset = ImageStart + Offset + sizeof(typename T::Header);
-
-    // Read the load command.
-    auto LoadCmdBuf = this->getReader().readBytes(
-        loadCmdOffset, sizeof(typename T::SegmentCmd));
-    if (!LoadCmdBuf)
-      return {};
-    auto LoadCmd = reinterpret_cast<typename T::SegmentCmd *>(LoadCmdBuf.get());
-
-    // The sections start immediately after the load command.
-    unsigned NumSect = LoadCmd->nsects;
-    auto SectAddress = loadCmdOffset + sizeof(typename T::SegmentCmd);
+    // The sections start immediately after the __TEXT segment's load command.
+    unsigned NumSect = TextCommand->nsects;
+    auto SectAddress =
+        CmdStartAddress + TextOffset + sizeof(typename T::SegmentCmd);
     auto Sections = this->getReader().readBytes(
         SectAddress, NumSect * sizeof(typename T::Section));
     if (!Sections)
@@ -376,14 +390,8 @@ public:
     auto TextSegmentEnd = TextSegmentStart + TextCommand->vmsize;
     textRanges.push_back(std::make_tuple(TextSegmentStart, TextSegmentEnd));
 
-    // Find the __DATA segments.
-    for (unsigned I = 0; I < NumCommands; ++I) {
-      auto CmdBuf = this->getReader().readBytes(CmdStartAddress + Offset,
-                                                SegmentCmdHdrSize);
-      if (!CmdBuf)
-        return {};
-      auto CmdHdr = reinterpret_cast<typename T::SegmentCmd *>(CmdBuf.get());
-      // Look for any segment name starting with __DATA or __AUTH.
+    // Find the __DATA and __AUTH segments.
+    forEachSegment([&](auto *CmdHdr, uint64_t Offset) {
       if (strncmp(CmdHdr->segname, "__DATA", 6) == 0 ||
           strncmp(CmdHdr->segname, "__AUTH", 6) == 0) {
         auto DataSegmentStart = Slide + CmdHdr->vmaddr;
@@ -392,8 +400,8 @@ public:
                "invalid range for __DATA/__AUTH");
         dataRanges.push_back(std::make_tuple(DataSegmentStart, DataSegmentEnd));
       }
-      Offset += CmdHdr->cmdsize;
-    }
+      return true;
+    });
 
     savedBuffers.push_back(std::move(Buf));
     savedBuffers.push_back(std::move(Sections));


### PR DESCRIPTION
We used the load commands size in bytes as the command count, and didn't check if a command was a segment command before doing a string comparison on its name. This could have caused some other data to be misinterpreted as a section command, although it's very unlikely.

While we're fixing this, clean things up a bit. Take advantage of the sizeofcmds field to read all of the commands in one go, instead of reading bit by bit. Make a helper for iterating over the segment commands instead of replicating the logic for __TEXT and __DATA/__AUTH.

rdar://175364354