### PR TITLE
[SILOptimizer] Fix ConstantCapturePropagation crash with archetype-tped constant args

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ConstantCapturePropagation.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ConstantCapturePropagation.swift
@@ -98,6 +98,19 @@ private func constantPropagateCaptures(of partialApply: PartialApplyInst, _ cont
     return
   }
 
+  // When the specialized closure would still be generic, bail out if any constant argument's
+  // callee parameter type involves archetypes. Cloning without type substitutions (to avoid
+  // ODR violations) would leave archetype types in the body, but the injected constant has
+  // concrete types, producing ill-typed SIL.
+  if partialApply.wouldSpecializationBeGeneric(nonConstantArguments: nonConstArgs) {
+    for constArgOp in constArgs {
+      let calleeArgIdx = partialApply.calleeArgumentIndex(of: constArgOp)!
+      if callee.arguments[calleeArgIdx].type.hasArchetype {
+        return
+      }
+    }
+  }
+
   let specializedName = context.mangle(withConstantCaptureArguments: constArgs.map {
                                            (partialApply.calleeArgumentIndex(of: $0)!, $0.value)
                                          },
@@ -151,13 +164,8 @@ private func specializeClosure(specializedName: String,
                                _ context: FunctionPassContext
 ) -> Function {
   let callee = partialApply.referencedFunction!
-  var newParams = [ParameterInfo]()
-  newParams.append(contentsOf: callee.convention.parameters.dropLast(partialApply.numArguments))
-  newParams.append(contentsOf: nonConstantArguments.map { partialApply.parameter(for: $0)! })
-
-  let isGeneric = newParams.contains { $0.type.hasTypeParameter } ||
-                  callee.convention.results.contains { $0.type.hasTypeParameter } ||
-                  callee.convention.errorResult?.type.hasTypeParameter ?? false
+  let newParams = partialApply.specializedParams(nonConstantArguments: nonConstantArguments)
+  let isGeneric = partialApply.wouldSpecializationBeGeneric(params: newParams)
 
   let representation = partialApply.callee.type.functionTypeRepresentation
   // We are removing arguments from the original function. If the removed argument is the
@@ -272,6 +280,26 @@ private func rewritePartialApply(_ partialApply: PartialApplyInst, withSpecializ
 }
 
 private extension PartialApplyInst {
+
+  func specializedParams(nonConstantArguments: [Operand]) -> [ParameterInfo] {
+    let callee = referencedFunction!
+    var newParams = [ParameterInfo]()
+    newParams.append(contentsOf: callee.convention.parameters.dropLast(numArguments))
+    newParams.append(contentsOf: nonConstantArguments.map { parameter(for: $0)! })
+    return newParams
+  }
+
+  func wouldSpecializationBeGeneric(params: [ParameterInfo]) -> Bool {
+    let callee = referencedFunction!
+    return params.contains { $0.type.hasTypeParameter } ||
+           callee.convention.results.contains { $0.type.hasTypeParameter } ||
+           callee.convention.errorResult?.type.hasTypeParameter ?? false
+  }
+
+  func wouldSpecializationBeGeneric(nonConstantArguments: [Operand]) -> Bool {
+    guard substitutionMap.hasAnySubstitutableParams else { return false }
+    return wouldSpecializationBeGeneric(params: specializedParams(nonConstantArguments: nonConstantArguments))
+  }
 
   /// Returns the callee if this is a `partial_apply` of a thunk which directly forwards all arguments
   /// to the callee and has no other side-effects.

--- a/test/SILOptimizer/constant_capture_propagation_generic_arg.sil
+++ b/test/SILOptimizer/constant_capture_propagation_generic_arg.sil
@@ -1,0 +1,47 @@
+// RUN: %target-sil-opt -enable-sil-verify-all %s -constant-capture-propagation | %FileCheck %s
+
+// When a generic closure is partially applied with a constant argument whose
+// callee parameter type involves archetypes, ConstantCapturePropagation must
+// skip the optimization. Injecting a concrete constant into a generic clone
+// (which preserves archetype types) would create ill-typed SIL.
+
+sil_stage raw
+
+import Builtin
+
+sil [ossa] @concrete_body : $@convention(thin) (@in_guaranteed Builtin.Int64) -> @out Builtin.Int64 {
+bb0(%0 : $*Builtin.Int64, %1 : $*Builtin.Int64):
+  copy_addr %1 to [init] %0 : $*Builtin.Int64
+  %r = tuple ()
+  return %r : $()
+}
+
+sil shared [ossa] @generic_with_func_arg : $@convention(thin) <T> (@in_guaranteed Builtin.Int64, @guaranteed @callee_guaranteed (@in_guaranteed Builtin.Int64) -> @out T) -> @out T {
+bb0(%0 : $*T, %1 : $*Builtin.Int64, %2 : @guaranteed $@callee_guaranteed (@in_guaranteed Builtin.Int64) -> @out T):
+  %r = apply %2(%0, %1) : $@callee_guaranteed (@in_guaranteed Builtin.Int64) -> @out T
+  %result = tuple ()
+  return %result : $()
+}
+
+// The constant argument (concrete_body) has callee parameter type
+// @callee_guaranteed (@in_guaranteed Builtin.Int64) -> @out T, which involves
+// archetype T. The optimization must be skipped — the partial_apply should
+// remain unchanged.
+//
+// CHECK-LABEL: sil [ossa] @caller_with_generic_const_arg
+// CHECK:         function_ref @generic_with_func_arg
+// CHECK:         partial_apply
+// CHECK:       } // end sil function 'caller_with_generic_const_arg'
+sil [ossa] @caller_with_generic_const_arg : $@convention(thin) (@in_guaranteed Builtin.Int64) -> @out Builtin.Int64 {
+bb0(%0 : $*Builtin.Int64, %1 : $*Builtin.Int64):
+  %body_ref = function_ref @concrete_body : $@convention(thin) (@in_guaranteed Builtin.Int64) -> @out Builtin.Int64
+  %body = thin_to_thick_function %body_ref : $@convention(thin) (@in_guaranteed Builtin.Int64) -> @out Builtin.Int64 to $@callee_guaranteed (@in_guaranteed Builtin.Int64) -> @out Builtin.Int64
+  %f = function_ref @generic_with_func_arg : $@convention(thin) <T> (@in_guaranteed Builtin.Int64, @guaranteed @callee_guaranteed (@in_guaranteed Builtin.Int64) -> @out T) -> @out T
+  %pa = partial_apply [callee_guaranteed] %f<Builtin.Int64>(%body) : $@convention(thin) <T> (@in_guaranteed Builtin.Int64, @guaranteed @callee_guaranteed (@in_guaranteed Builtin.Int64) -> @out T) -> @out T
+  %borrow = begin_borrow %pa : $@callee_guaranteed (@in_guaranteed Builtin.Int64) -> @out Builtin.Int64
+  %result = apply %borrow(%0, %1) : $@callee_guaranteed (@in_guaranteed Builtin.Int64) -> @out Builtin.Int64
+  end_borrow %borrow : $@callee_guaranteed (@in_guaranteed Builtin.Int64) -> @out Builtin.Int64
+  destroy_value %pa : $@callee_guaranteed (@in_guaranteed Builtin.Int64) -> @out Builtin.Int64
+  %r = tuple ()
+  return %r : $()
+}


### PR DESCRIPTION
- **Explanation**:

When a generic closure is partially applied with concrete type substitutions, `ConstantCapturePropagation` may clone the body without type substitutions to avoid ODR violations (See more in https://github.com/swiftlang/swift/pull/87916). If a constant argument's callee parameter type involves archetypes (e.g. `@callee_guaranteed (...) -> @out T`), injecting the concrete constant into the generic clone creates ill-typed SIL.

To fix it, we skip propagation for constant arguments whose callee parameter type has archetypes, while still allowing constants with concrete types (e.g. integer literals) to be propagated.

Also extract `specializedParams` and `wouldSpecializationBeGeneric` helpers on PartialApplyInst to share the "would specialization still be generic" logic between the new check and `specializeClosure`.

- **Scope**: SILOptimization

- **Issues**: https://github.com/swiftlang/swift/issues/87917

- **Original PRs**: https://github.com/swiftlang/swift/pull/87916, https://github.com/swiftlang/swift/pull/88076

- **Risk**:

None

- **Testing**:

Added a new test


[Assisted-by](https://t.ly/Dkjjk): [Claude Opus 4.6](https://www.anthropic.com/news/claude-opus-4-6)
