### PR TITLE
Sema: Skip `MemberImportVisibility` diags for conformances in swiftinterfaces

### DIFF
--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1695,6 +1695,14 @@ bool WitnessChecker::findBestWitness(
       if (ignoreMissingImportsDuringRegularLookup)
         continue;
 
+      // Conformance checking in swiftinterfaces is lenient and can recover
+      // from missing witnesses by assuming that the protocol witness table
+      // will have an entry for the requirement at runtime. As a result,
+      // diagnosing missing imports for witnesses here could break source
+      // compatibility for existing interface files and must be skipped.
+      if (DC->isInSwiftinterface())
+        continue;
+
       // Try again, this time ignoring missing imports to find more candidates.
       witnesses = lookupValueWitnesses(DC, requirement, ignoringNames,
                                        /*ignoreMissingImports=*/true);

--- a/test/ModuleInterface/transitive-member-witness-in-interface.swift
+++ b/test/ModuleInterface/transitive-member-witness-in-interface.swift
@@ -1,0 +1,38 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// Build the supporting modules.
+// RUN: %target-swift-frontend -emit-module %t/ExtensionModule.swift -o %t \
+// RUN:   -module-name ExtensionModule -swift-version 5 -enable-library-evolution
+// RUN: %target-swift-frontend -emit-module %t/ProtoModule.swift -o %t \
+// RUN:   -I %t -module-name ProtoModule -swift-version 5 -enable-library-evolution
+
+// Typecheck the handwritten swiftinterface. This should succeed without errors
+// even when MemberImportVisibility is enabled, because swiftinterfaces are
+// generated from valid source and conformance witnesses should not trigger
+// import visibility diagnostics.
+// RUN: %target-swift-typecheck-module-from-interface(%t/Client.swiftinterface) \
+// RUN:   -module-name Client -I %t -enable-upcoming-feature MemberImportVisibility
+
+// REQUIRES: swift_feature_MemberImportVisibility
+
+//--- ExtensionModule.swift
+
+extension Int {
+  public func witnessMe() { }
+}
+
+//--- ProtoModule.swift
+
+import ExtensionModule
+
+public protocol Proto {
+  func witnessMe()
+}
+
+//--- Client.swiftinterface
+// swift-interface-format-version: 1.0
+// swift-module-flags: -swift-version 5 -enable-library-evolution -module-name Client -enable-upcoming-feature MemberImportVisibility
+import ProtoModule
+
+extension Int: Proto {}


### PR DESCRIPTION
- **Explanation:** Conformance checking in swiftinterfaces is lenient and can recover from missing witnesses by assuming that the protocol witness table will have an entry for the requirement at runtime. As a result, diagnosing missing imports for witnesses here could break source compatibility for existing interface files and must be skipped. This fixes a regression introduced by https://github.com/swiftlang/swift/pull/88470.
- **Scope:** Affects compilation of modules from their interfaces when those modules were built with `MemberImportVisibility` enabled.
- **Issues:** rdar://175215763
- **Risk:** Low. This change reverts to the existing behavior that module interface builds had prior to https://github.com/swiftlang/swift/pull/88470.
- **Testing:** A new compiler test.