### PR TITLE
Enable load_borrow simplification at -Onone

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyLoadBorrow.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyLoadBorrow.swift
@@ -12,7 +12,7 @@
 
 import SIL
 
-extension LoadBorrowInst : Simplifiable, SILCombineSimplifiable {
+extension LoadBorrowInst : OnoneSimplifiable, SILCombineSimplifiable {
   func simplify(_ context: SimplifyContext) {
     if uses.ignoreDebugUses.ignore(usersOfType: EndBorrowInst.self).isEmpty {
       context.erase(instructionIncludingAllUsers: self)

--- a/test/SILOptimizer/simplify_load_borrow.sil
+++ b/test/SILOptimizer/simplify_load_borrow.sil
@@ -1,3 +1,4 @@
+// RUN: %target-sil-opt %s -onone-simplification -simplify-instruction=load_borrow | %FileCheck %s
 // RUN: %target-sil-opt %s -simplification -simplify-instruction=load_borrow | %FileCheck %s
 
 import Swift
@@ -190,4 +191,3 @@ bb1(%5 : @reborrow $B):
   dealloc_stack %1
   return %0
 }
-


### PR DESCRIPTION
Required for Builtin.borrowAt. SILGen may generate dead borrow scopes for
loadable values used in a return expression that for a borrow access that uses
guaranteed_address convention.

rdar://175382154 (Enable load_borrow simplification at -Onone)

---
- **Explanation**: Eliminate dead load instructions after SILGen at -Onone.

- **Scope**: Previously, -Onone only removed normal loads. This change also removes load_borrow/end_borrow pairs. This means that additional SIL-level optimization will now run at -Onone, but the scope is limited to borrow patterns.

- **Issues**: rdar://175382154 (Enable load_borrow simplification at -Onone). This change blocks `Span<~E>` adoption.

- **Risk**: This enables a few small peephole optimizations -Onone that were previously only running at -O. It could expose optimizer bugs in projects that only built with -Onone.

- **Testing**: Existing -O unit tests are now enabled at -Onone. Subsequent PRs will test SIL output from the new Builtin.borrowAt.

- **Reviewers**: @eeckstein

