### PR TITLE
[Swiftify] limit lifetimebound on implicit "this" to experimental mode

### DIFF
--- a/lib/ClangImporter/SwiftifyDecl.cpp
+++ b/lib/ClangImporter/SwiftifyDecl.cpp
@@ -582,17 +582,24 @@ static bool swiftifyImpl(ClangImporter::Implementation &Self,
     bool returnHasLifetimeInfo = false;
     if (getImplicitObjectParamAnnotation<clang::LifetimeBoundAttr>(ClangDecl)) {
       DLOG("Found lifetimebound attribute on implicit 'this'\n");
-      if (!dependsOnClass(
-              MappedDecl->getImplicitSelfDecl(/*createIfNeeded*/ true))) {
-        if (returnValueCanBeNonEscapable) {
-          printer.printLifetimeboundReturn(SwiftifyInfoPrinter::SELF_PARAM_INDEX,
-                                           true);
-          returnHasLifetimeInfo = true;
+      if (Self.SwiftContext.LangOpts.hasFeature(Feature::SafeInteropWrappers)) {
+        if (!dependsOnClass(
+                MappedDecl->getImplicitSelfDecl(/*createIfNeeded*/ true))) {
+          if (returnValueCanBeNonEscapable) {
+            printer.printLifetimeboundReturn(
+                SwiftifyInfoPrinter::SELF_PARAM_INDEX, true);
+            returnHasLifetimeInfo = true;
+          } else {
+            DLOG("lifetimebound ignored because return value is escapable");
+          }
         } else {
-          DLOG("lifetimebound ignored because return value is escapable");
+          DLOG("lifetimebound ignored because it depends on class with "
+               "refcount\n");
         }
       } else {
-        DLOG("lifetimebound ignored because it depends on class with refcount\n");
+        DLOG("lifetimebound not yet supported by stable feature-set - "
+             "skipping\n");
+        return false;
       }
     }
 

--- a/test/Interop/Cxx/stdlib/std-span-interface.swift
+++ b/test/Interop/Cxx/stdlib/std-span-interface.swift
@@ -22,8 +22,8 @@ import CxxStdlib
 
 // CHECK:     struct DependsOnSelf {
 // CHECK:       @safe borrowing func get() -> ConstSpanOfInt
-// CHECK:       @_lifetime(borrow self)
-// CHECK-NEXT:  @_alwaysEmitIntoClient @_disfavoredOverload public borrowing func get() -> Span<CInt>
+// CHECK-LEGACY:       @_lifetime(borrow self)
+// CHECK-LEGACY-NEXT:  @_alwaysEmitIntoClient @_disfavoredOverload public borrowing func get() -> Span<CInt>
 // CHECK:     }
 
 // CHECK:     struct CaptureByReference {
@@ -40,10 +40,10 @@ import CxxStdlib
 // CHECK-DAG:    /// This is an auto-generated wrapper for safer interop
 // CHECK-DAG:    @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
 // CHECK-DAG:    @_alwaysEmitIntoClient @_disfavoredOverload public mutating func methodWithSafeWrapper(_ s: Span<CInt>)
-// CHECK-DAG:    /// This is an auto-generated wrapper for safer interop
-// CHECK-DAG:    @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-// CHECK-DAG:    @_lifetime(&self)
-// CHECK-DAG:    @_alwaysEmitIntoClient @_disfavoredOverload public mutating func getMutable(_ s: Span<CInt>) -> MutableSpan<CInt>
+// CHECK-LEGCAY-DAG: /// This is an auto-generated wrapper for safer interop
+// CHECK-LEGACY-DAG: @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+// CHECK-LEGACY-DAG: @_lifetime(&self)
+// CHECK-LEGACY-DAG: @_alwaysEmitIntoClient @_disfavoredOverload public mutating func getMutable(_ s: Span<CInt>) -> MutableSpan<CInt>
 // CHECK-NEXT: }
 
 // CHECK:      mutating func methodWithMutableSafeWrapper(_ s: SpanOfInt)
@@ -169,7 +169,7 @@ import CxxStdlib
 
 func callMethodWithSafeWrapper(_ x: inout X, s: Span<CInt>) {
     x.methodWithSafeWrapper(s)
-    let _ = x.getMutable(s)
+    let _ = x.getMutable(s) // expected-default-error {{cannot convert value of type 'Span<CInt>' (aka 'Span<Int32>') to expected argument type 'ConstSpanOfInt'}}
 }
 
 func callFooBar(_ x: inout SpanWithoutTypeAlias, _ s: ConstSpanOfInt) {

--- a/test/Interop/Cxx/stdlib/std-span-interface.swift
+++ b/test/Interop/Cxx/stdlib/std-span-interface.swift
@@ -1,10 +1,10 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-ide-test -plugin-path %swift-plugin-dir -I %S/Inputs -print-module -module-to-print=StdSpan -source-filename=x -enable-experimental-cxx-interop -Xcc -std=c++20 -module-cache-path %t > %t/interface.swift
-// RUN: %FileCheck %s --match-full-lines < %t/interface.swift
+// RUN: %FileCheck %s --match-full-lines --implicit-check-not "@_alwaysEmitIntoClient" < %t/interface.swift
 
 // Test legacy wrappers
 // RUN: %target-swift-ide-test -plugin-path %swift-plugin-dir -I %S/Inputs -print-module -module-to-print=StdSpan -source-filename=x -enable-experimental-cxx-interop -enable-experimental-feature SafeInteropWrappers -Xcc -std=c++20 -module-cache-path %t > %t/interface-lifetimebound.swift
-// RUN: %FileCheck %s --match-full-lines --check-prefixes=CHECK,CHECK-LEGACY < %t/interface-lifetimebound.swift
+// RUN: %FileCheck %s --match-full-lines --implicit-check-not "@_alwaysEmitIntoClient" --check-prefixes=CHECK,CHECK-LEGACY < %t/interface-lifetimebound.swift
 
 // Make sure we trigger typechecking and SIL diagnostics
 // RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -I %S/Inputs -enable-experimental-feature Lifetimes -cxx-interoperability-mode=default -strict-memory-safety -verify -Xcc -std=c++20 %s -verify-additional-prefix default- -suppress-notes
@@ -45,6 +45,13 @@ import CxxStdlib
 // CHECK-DAG:    @_lifetime(&self)
 // CHECK-DAG:    @_alwaysEmitIntoClient @_disfavoredOverload public mutating func getMutable(_ s: Span<CInt>) -> MutableSpan<CInt>
 // CHECK-NEXT: }
+
+// CHECK:      mutating func methodWithMutableSafeWrapper(_ s: SpanOfInt)
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
+// CHECK-NEXT: @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+// CHECK-NEXT: @_lifetime(s: copy s)
+// CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public mutating func methodWithMutableSafeWrapper(_ s: inout MutableSpan<CInt>)
+
 // CHECK: struct SpanWithoutTypeAlias {
 // CHECK-NEXT:   init()
 // CHECK-NEXT:   mutating func bar() -> std.{{.*}}span<__cxxConst<CInt>, _C{{.*}}_{{.*}}>


### PR DESCRIPTION
- **Explanation**:
When safe interop was stabilized, lifetimebound support was deliberately not
stabilized. The check for lifetimebound on the implicit "this" parameter
was accidentally not gated behind the experimental feature check,
however. Now lifetimebound on implicit "this" is no longer included in the stable
feature set.
- **Scope**:
This affects any code using the nightly toolchains that started using lifetimebound on the implicit "this" parameter, without enabling the experimental SafeInteropWrappers flag. This should be exceedingly rare, since all other uses of lifetimebound for safe interop is gated behind SafeInteropWrappers.
- **Issues**:
rdar://175396896
- **Risk**:
Low, this disables an experimental code path that should never have been stabilized, and was never stabilized in a major release.
- **Testing**:
Lit regression tests.
