### PR TITLE
[Swiftify] enable safe wrappers for std::span without typedef

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -1019,6 +1019,10 @@ namespace swift {
     /// eagerly typechecking source files after parsing.
     bool EnableLazyTypecheck = false;
 
+    /// Enables eager type-checking of declarations in macro expansions.
+    /// For testing purposes.
+    bool TypeCheckMacrosEagerly = false;
+
     /// Disable the component splitter phase of the expression type checker.
     bool SolverDisableSplitter = false;
 

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -468,6 +468,9 @@ def dump_requirement_machine : Flag<["-"], "dump-requirement-machine">,
 def debug_requirement_machine : Joined<["-"], "debug-requirement-machine=">,
   HelpText<"Fine-grained debug output from the generics implementation">;
 
+def eager_macro_checking : Flag<["-"], "eager-macro-checking">,
+  HelpText<"Enable eager type-checking of declarations in macro expansions">;
+
 def dump_macro_expansions : Flag<["-"], "dump-macro-expansions">,
   HelpText<"Dumps the results of each macro expansion">;
 def emit_macro_expansion_files : Separate<["-"], "emit-macro-expansion-files">,

--- a/lib/ClangImporter/SwiftifyDecl.cpp
+++ b/lib/ClangImporter/SwiftifyDecl.cpp
@@ -345,6 +345,21 @@ struct UnaliasedInstantiationVisitor
     DLOG("Signature contains raw template, skipping\n");
     return false;
   }
+
+  static bool checkTemplates(clang::QualType clangType, bool hasLifetime,
+                             bool isStdSpan) {
+    if (hasLifetime && isStdSpan) {
+      // std::span is transformed to Swift Span, so the std::span template
+      // instantiation won't show up in the macro expansion's signature. The
+      // element type still needs to be checked.
+      const auto *TST = clangType->getAs<clang::TemplateSpecializationType>();
+      ASSERT(TST && "std::span is not specialized?");
+      clangType = TST->template_arguments()[0].getAsType();
+    }
+    UnaliasedInstantiationVisitor checker;
+    checker.TraverseType(clangType);
+    return checker.hasUnaliasedInstantiation;
+  }
 };
 
 static const clang::Decl *getTemplateInstantiation(const clang::Decl *D) {
@@ -619,8 +634,6 @@ static bool swiftifyImpl(ClangImporter::Implementation &Self,
       return false;
     }
 
-    UnaliasedInstantiationVisitor templateChecker;
-
     size_t selfParamIndex = MappedDecl->isImportAsInstanceMember()
                                 ? MappedDecl->getSelfIndex()
                                 : getNumParams(ClangDecl);
@@ -695,29 +708,27 @@ static bool swiftifyImpl(ClangImporter::Implementation &Self,
           return false;
         }
       }
+      if (UnaliasedInstantiationVisitor::checkTemplates(
+              clangParamTy, paramHasLifetimeInfo, paramIsStdSpan)) {
+        return false;
+      }
       if (paramIsStdSpan && paramHasLifetimeInfo) {
         DLOG("Found both std::span and lifetime info\n");
         attachMacro = true;
-      } else {
-        // std::span is transformed to Swift Span, it won't show up in the
-        // signature, but all other templated types need to be hidden behind
-        // typedefs.
-        templateChecker.TraverseType(clangParamTy);
-        if (templateChecker.hasUnaliasedInstantiation)
-          return false;
       }
     }
     if (!returnHasLifetimeInfo && returnValueIsNonEscapable) {
       DLOG("~Escapable return value without lifetime info\n");
       return false;
     }
+
+    if (UnaliasedInstantiationVisitor::checkTemplates(
+            clangReturnTy, returnHasLifetimeInfo, returnIsStdSpan)) {
+      return false;
+    }
     if (returnIsStdSpan && returnHasLifetimeInfo) {
       DLOG("Found both std::span and lifetime info for return value\n");
       attachMacro = true;
-    } else {
-      templateChecker.TraverseType(clangReturnTy);
-      if (templateChecker.hasUnaliasedInstantiation)
-        return false;
     }
   }
   return attachMacro;

--- a/lib/ClangImporter/SwiftifyDecl.cpp
+++ b/lib/ClangImporter/SwiftifyDecl.cpp
@@ -82,6 +82,11 @@ ValueDecl *getKnownSingleDecl(ASTContext &SwiftContext, StringRef DeclName) {
   return decls[0];
 }
 
+static bool isStdSpanType(clang::QualType clangType) {
+  const auto *decl = clangType->getAsTagDecl();
+  return decl && decl->isInStdNamespace() && decl->getName() == "span";
+}
+
 struct SwiftifyInfoPrinter {
   static const ssize_t SELF_PARAM_INDEX = -2;
   static const ssize_t RETURN_VALUE_INDEX = -1;
@@ -201,8 +206,7 @@ struct SwiftifyInfoFunctionPrinter : public SwiftifyInfoPrinter {
   }
 
   bool registerStdSpanTypeMapping(Type swiftType, const clang::QualType clangType) {
-    const auto *decl = clangType->getAsTagDecl();
-    if (decl && decl->isInStdNamespace() && decl->getName() == "span") {
+    if (isStdSpanType(clangType)) {
       typeMapping.try_emplace(swiftType->getString(),
                               swiftType->getDesugaredType()->getString());
       return true;
@@ -552,17 +556,6 @@ static bool swiftifyImpl(ClangImporter::Implementation &Self,
   // has lifetime information, since std::span already contains bounds info.
   bool attachMacro = false;
   {
-    Type swiftReturnTy;
-    if (const auto *funcDecl = dyn_cast<FuncDecl>(MappedDecl))
-      swiftReturnTy = funcDecl->getResultInterfaceType();
-    else if (const auto *ctorDecl = dyn_cast<ConstructorDecl>(MappedDecl))
-      swiftReturnTy = ctorDecl->getResultInterfaceType();
-    else
-      ABORT("Unexpected AbstractFunctionDecl subclass.");
-    clang::QualType clangReturnTy = ClangDecl->getReturnType();
-
-    if (CheckForwardDecls.IsIncompatibleImport(swiftReturnTy, clangReturnTy))
-      return false;
 
     auto isNonEscapable = [&Self](clang::QualType ty) {
       // We only care whether it's _known_ ~Escapable, because it affects
@@ -573,18 +566,13 @@ static bool swiftifyImpl(ClangImporter::Implementation &Self,
              CxxEscapability::NonEscapable;
     };
 
-    bool returnIsStdSpan = printer.registerStdSpanTypeMapping(
-        swiftReturnTy, clangReturnTy);
-    bool returnHasBoundsInfo = returnIsStdSpan;
-    auto *CAT = clangReturnTy->getAs<clang::CountAttributedType>();
-    if (SwiftifiableCAT(clangASTContext, CAT, swiftReturnTy)) {
-      printer.printCountedBy(CAT, SwiftifyInfoPrinter::RETURN_VALUE_INDEX);
-      DLOG("Found bounds info '" << clang::QualType(CAT, 0) << "' on return value\n");
-      returnHasBoundsInfo = attachMacro = true;
-    }
     auto dependsOnClass = [](const ParamDecl *fromParam) {
       return fromParam->getInterfaceType()->isAnyClassReferenceType();
     };
+    clang::QualType clangReturnTy = ClangDecl->getReturnType();
+    bool returnIsStdSpan = isStdSpanType(clangReturnTy);
+    auto *CAT = clangReturnTy->getAs<clang::CountAttributedType>();
+    bool returnHasBoundsInfo = returnIsStdSpan || CAT != nullptr;
     bool returnValueIsNonEscapable = isNonEscapable(clangReturnTy);
     bool returnValueCanBeNonEscapable = returnValueIsNonEscapable || returnHasBoundsInfo;
     bool returnHasLifetimeInfo = false;
@@ -728,6 +716,29 @@ static bool swiftifyImpl(ClangImporter::Implementation &Self,
     }
     if (returnIsStdSpan && returnHasLifetimeInfo) {
       DLOG("Found both std::span and lifetime info for return value\n");
+      attachMacro = true;
+    }
+
+    if (!attachMacro && CAT == nullptr)
+      // The return type is not imported eagerly (unlike parameter types). Exit
+      // early to avoid unnecessarily importing types we might not need.
+      return false;
+
+    Type swiftReturnTy;
+    if (const auto *funcDecl = dyn_cast<FuncDecl>(MappedDecl))
+      swiftReturnTy = funcDecl->getResultInterfaceType();
+    else if (const auto *ctorDecl = dyn_cast<ConstructorDecl>(MappedDecl))
+      swiftReturnTy = ctorDecl->getResultInterfaceType();
+    else
+      ABORT("Unexpected AbstractFunctionDecl subclass.");
+
+    if (CheckForwardDecls.IsIncompatibleImport(swiftReturnTy, clangReturnTy))
+      return false;
+    (void)printer.registerStdSpanTypeMapping(
+        swiftReturnTy, clangReturnTy);
+    if (SwiftifiableCAT(clangASTContext, CAT, swiftReturnTy)) {
+      printer.printCountedBy(CAT, SwiftifyInfoPrinter::RETURN_VALUE_INDEX);
+      DLOG("Found bounds info '" << clang::QualType(CAT, 0) << "' on return value\n");
       attachMacro = true;
     }
   }

--- a/lib/ClangImporter/SwiftifyDecl.cpp
+++ b/lib/ClangImporter/SwiftifyDecl.cpp
@@ -508,13 +508,6 @@ static bool swiftifyImpl(ClangImporter::Implementation &Self,
   if (shouldSkipModule(MappedDecl->getParentModule()))
     return false;
 
-  {
-    UnaliasedInstantiationVisitor visitor;
-    visitor.TraverseType(ClangDecl->getType());
-    if (visitor.hasUnaliasedInstantiation)
-      return false;
-  }
-
   // FIXME: for private macro generated functions we do not serialize the
   // SILFunction's body anywhere triggering assertions.
   if (ClangDecl->getAccess() == clang::AS_protected ||
@@ -626,6 +619,8 @@ static bool swiftifyImpl(ClangImporter::Implementation &Self,
       return false;
     }
 
+    UnaliasedInstantiationVisitor templateChecker;
+
     size_t selfParamIndex = MappedDecl->isImportAsInstanceMember()
                                 ? MappedDecl->getSelfIndex()
                                 : getNumParams(ClangDecl);
@@ -703,6 +698,13 @@ static bool swiftifyImpl(ClangImporter::Implementation &Self,
       if (paramIsStdSpan && paramHasLifetimeInfo) {
         DLOG("Found both std::span and lifetime info\n");
         attachMacro = true;
+      } else {
+        // std::span is transformed to Swift Span, it won't show up in the
+        // signature, but all other templated types need to be hidden behind
+        // typedefs.
+        templateChecker.TraverseType(clangParamTy);
+        if (templateChecker.hasUnaliasedInstantiation)
+          return false;
       }
     }
     if (!returnHasLifetimeInfo && returnValueIsNonEscapable) {
@@ -712,6 +714,10 @@ static bool swiftifyImpl(ClangImporter::Implementation &Self,
     if (returnIsStdSpan && returnHasLifetimeInfo) {
       DLOG("Found both std::span and lifetime info for return value\n");
       attachMacro = true;
+    } else {
+      templateChecker.TraverseType(clangReturnTy);
+      if (templateChecker.hasUnaliasedInstantiation)
+        return false;
     }
   }
   return attachMacro;

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -2173,6 +2173,8 @@ static bool ParseTypeCheckerArgs(TypeCheckerOptions &Opts, ArgList &Args,
       FrontendOptions::ActionType::TypecheckModuleFromInterface)
     Opts.EnableLazyTypecheck = false;
 
+  Opts.TypeCheckMacrosEagerly = Args.hasArg(OPT_eager_macro_checking);
+
   return HadError;
 }
 

--- a/lib/Frontend/DiagnosticVerifier.cpp
+++ b/lib/Frontend/DiagnosticVerifier.cpp
@@ -1665,7 +1665,9 @@ processExpansions(SourceManager &SM, llvm::DenseMap<SourceLoc, unsigned> &Expans
     if (ExpansionStart.isInvalid())
       continue;
     if (Expansions.count(ExpansionStart)) {
-      ASSERT(Expansions[ExpansionStart] == diag.SourceBufferID.value());
+      ASSERT(Expansions[ExpansionStart] == diag.SourceBufferID.value() &&
+             "diagnostics in multiple expansions for the same decl not "
+             "supported by -verify");
       continue;
     }
     Expansions.insert(std::make_pair(ExpansionStart, diag.SourceBufferID.value()));

--- a/lib/Macros/Sources/SwiftMacros/SwiftifyImportMacro.swift
+++ b/lib/Macros/Sources/SwiftMacros/SwiftifyImportMacro.swift
@@ -582,15 +582,21 @@ struct CxxSpanThunkBuilder: SpanBoundsThunkBuilder, ParamBoundsThunkBuilder {
   func buildFunctionCall(_ pointerArgs: [Int: ExprSyntax]) throws -> ExprSyntax {
     var args = pointerArgs
     let typeName = getUnattributedType(oldType).description
+    let castName =
+      if typeMappings[typeName] == typeName {
+        ".init"  // std::span is not hidden behind any type alias, can't name it using Swift syntax
+      } else {
+        typeName // use the concrete type for readability, and to be polite to the typechecker
+      }
     assert(args[index] == nil)
 
     let (_, isConst) = dropCxxQualifiers(try genericArg)
     if isConst {
-      args[index] = ExprSyntax("\(raw: typeName)(\(raw: name))")
+      args[index] = ExprSyntax("\(raw: castName)(\(raw: name))")
       return try base.buildFunctionCall(args)
     } else {
       let unwrappedName = TokenSyntax("_\(name.withoutBackticks)Ptr")
-      args[index] = ExprSyntax("\(raw: typeName)(\(unwrappedName))")
+      args[index] = ExprSyntax("\(raw: castName)(\(unwrappedName))")
       let call = try base.buildFunctionCall(args)
 
       // MutableSpan - unlike Span - cannot be bitcast to std::span due to being ~Copyable,

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -598,6 +598,9 @@ bool swift::isInvalidAttachedMacro(MacroRole role,
 static void diagnoseInvalidDecl(Decl *decl,
                                 MacroDecl *macro,
                                 llvm::function_ref<bool(DeclName)> coversName) {
+  if (decl->getASTContext().TypeCheckerOpts.TypeCheckMacrosEagerly)
+    TypeChecker::typeCheckDecl(decl);
+
   auto &ctx = decl->getASTContext();
 
   // Diagnose invalid declaration kinds.

--- a/test/Interop/C/swiftify-import/availability.swift
+++ b/test/Interop/C/swiftify-import/availability.swift
@@ -2,7 +2,7 @@
 // RUN: split-file %s %t
 
 // RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -o %t/test.swiftmodule %t/test.swift -I %t -strict-memory-safety \
-// RUN:   -verify -verify-additional-file %t%{fs-sep}test.h
+// RUN:   -verify -verify-additional-file %t%{fs-sep}test.h -eager-macro-checking
 
 // RUN: env SWIFT_BACKTRACE="" %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -o %t/test.swiftmodule %t/test.swift -I %t -strict-memory-safety \
 // RUN:   -dump-macro-expansions 2> %t/expansions.out

--- a/test/Interop/C/swiftify-import/bridging-header-from-module.swift
+++ b/test/Interop/C/swiftify-import/bridging-header-from-module.swift
@@ -2,7 +2,7 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 
-// RUN: %target-swift-frontend -typecheck -plugin-path %swift-plugin-dir -o %t/test.swiftmodule -I %t -import-objc-header %t/bridging.h -strict-memory-safety -warnings-as-errors -Xcc -Werror -Xcc -Wno-nullability-completeness -Xcc -Wno-div-by-zero -Xcc -Wno-pointer-to-int-cast %t/test.swift -verify
+// RUN: %target-swift-frontend -typecheck -plugin-path %swift-plugin-dir -o %t/test.swiftmodule -I %t -import-objc-header %t/bridging.h -strict-memory-safety -warnings-as-errors -Xcc -Werror -Xcc -Wno-nullability-completeness -Xcc -Wno-div-by-zero -Xcc -Wno-pointer-to-int-cast %t/test.swift -verify -eager-macro-checking
 // RUN: %target-swift-frontend -typecheck -plugin-path %swift-plugin-dir -o %t/test.swiftmodule -I %t -import-objc-header %t/bridging.h -strict-memory-safety -warnings-as-errors -Xcc -Werror -Xcc -Wno-nullability-completeness -Xcc -Wno-div-by-zero -Xcc -Wno-pointer-to-int-cast %t/test.swift -dump-macro-expansions 2>&1 | %FileCheck --dry-run > %t/macro-expansions.out
 // RUN: %diff %t/macro-expansions.out %t/macro-expansions.expected
 // RUN: %target-swift-frontend -typecheck -plugin-path %swift-plugin-dir -o %t/test.swiftmodule -I %t -import-objc-header %t/bridging.h -strict-memory-safety -warnings-as-errors -Xcc -Werror -Xcc -Wno-nullability-completeness -Xcc -Wno-div-by-zero -Xcc -Wno-pointer-to-int-cast %t/test.swift -dump-source-file-imports 2>&1 | %FileCheck --dry-run > %t/imports.out

--- a/test/Interop/C/swiftify-import/bridging-header-import-once.swift
+++ b/test/Interop/C/swiftify-import/bridging-header-import-once.swift
@@ -1,7 +1,7 @@
 
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
-// RUN: %target-swift-frontend -emit-module -import-bridging-header %t%{fs-sep}bridging_header.h -I %t -plugin-path %swift-plugin-dir %t/test.swift -Rmacro-expansions -verify -verify-additional-file %t%{fs-sep}header.h -disable-objc-interop
+// RUN: %target-swift-frontend -emit-module -import-bridging-header %t%{fs-sep}bridging_header.h -I %t -plugin-path %swift-plugin-dir %t/test.swift -Rmacro-expansions -verify -verify-additional-file %t%{fs-sep}header.h -disable-objc-interop -eager-macro-checking
 
 //--- module.modulemap
 module Module {

--- a/test/Interop/C/swiftify-import/bridging-header-including-module.swift
+++ b/test/Interop/C/swiftify-import/bridging-header-including-module.swift
@@ -3,7 +3,7 @@
 // RUN: split-file %s %t
 
 // RUN: %target-swift-frontend -typecheck -plugin-path %swift-plugin-dir -o %t/test.swiftmodule -I %t -import-bridging-header %t/bridging.h -strict-memory-safety %t/test.swift \
-// RUN:   -verify
+// RUN:   -verify -eager-macro-checking
 
 // RUN: %target-swift-frontend -typecheck -plugin-path %swift-plugin-dir -o %t/test.swiftmodule -I %t -import-bridging-header %t/bridging.h -strict-memory-safety %t/test.swift \
 // RUN:   -dump-macro-expansions 2>&1 | %FileCheck --dry-run > %t/macro-expansions.out

--- a/test/Interop/C/swiftify-import/bridging-header-nontrivial.swift
+++ b/test/Interop/C/swiftify-import/bridging-header-nontrivial.swift
@@ -2,7 +2,7 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 
-// RUN: %target-swiftc_driver -typecheck -disable-bridging-pch -plugin-path %swift-plugin-dir -o %t/test.swiftmodule -I %t -Xcc -I -Xcc %t -import-objc-header %t/bridging.h -strict-memory-safety -warnings-as-errors -Xcc -Werror -Xcc -Wno-nullability-completeness -Xcc -Wno-div-by-zero -Xcc -Wno-pointer-to-int-cast %t/test.swift -Xfrontend -verify
+// RUN: %target-swiftc_driver -typecheck -disable-bridging-pch -plugin-path %swift-plugin-dir -o %t/test.swiftmodule -I %t -Xcc -I -Xcc %t -import-objc-header %t/bridging.h -strict-memory-safety -warnings-as-errors -Xcc -Werror -Xcc -Wno-nullability-completeness -Xcc -Wno-div-by-zero -Xcc -Wno-pointer-to-int-cast %t/test.swift -Xfrontend -verify -Xfrontend -eager-macro-checking
 // RUN: %target-swiftc_driver -typecheck -disable-bridging-pch -plugin-path %swift-plugin-dir -o %t/test.swiftmodule -I %t -import-objc-header %t/bridging.h -strict-memory-safety -warnings-as-errors -Xcc -Werror -Xcc -Wno-nullability-completeness -Xcc -Wno-div-by-zero -Xcc -Wno-pointer-to-int-cast %t/test.swift -Xfrontend -dump-macro-expansions 2>&1 | %FileCheck --dry-run > %t/macro-expansions.out
 // RUN: %diff %t/macro-expansions.out %t/macro-expansions.expected
 // RUN: %target-swiftc_driver -typecheck -disable-bridging-pch -plugin-path %swift-plugin-dir -o %t/test.swiftmodule -I %t -import-objc-header %t/bridging.h -strict-memory-safety -warnings-as-errors -Xcc -Werror -Xcc -Wno-nullability-completeness -Xcc -Wno-div-by-zero -Xcc -Wno-pointer-to-int-cast %t/test.swift -Xfrontend -dump-source-file-imports 2>&1 | %FileCheck --sanitize TEST_SWIFT=%t/test.swift --dry-run > %t/imports.out

--- a/test/Interop/C/swiftify-import/bridging-header.swift
+++ b/test/Interop/C/swiftify-import/bridging-header.swift
@@ -2,7 +2,7 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 
-// RUN: %target-swift-frontend -typecheck -plugin-path %swift-plugin-dir -o %t/test.swiftmodule -I %t -import-objc-header %t/bridging.h -strict-memory-safety -warnings-as-errors -Xcc -Werror -Xcc -Wno-nullability-completeness -Xcc -Wno-div-by-zero -Xcc -Wno-pointer-to-int-cast %t/test.swift -verify
+// RUN: %target-swift-frontend -typecheck -plugin-path %swift-plugin-dir -o %t/test.swiftmodule -I %t -import-objc-header %t/bridging.h -strict-memory-safety -warnings-as-errors -Xcc -Werror -Xcc -Wno-nullability-completeness -Xcc -Wno-div-by-zero -Xcc -Wno-pointer-to-int-cast %t/test.swift -verify -eager-macro-checking
 // RUN: %target-swift-frontend -typecheck -plugin-path %swift-plugin-dir -o %t/test.swiftmodule -I %t -import-objc-header %t/bridging.h -strict-memory-safety -warnings-as-errors -Xcc -Werror -Xcc -Wno-nullability-completeness -Xcc -Wno-div-by-zero -Xcc -Wno-pointer-to-int-cast %t/test.swift -dump-macro-expansions 2>&1 | %FileCheck --dry-run > %t/macro-expansions.out
 // RUN: %diff %t/macro-expansions.out %t/macro-expansions.expected
 // RUN: %target-swift-frontend -typecheck -plugin-path %swift-plugin-dir -o %t/test.swiftmodule -I %t -import-objc-header %t/bridging.h -strict-memory-safety -warnings-as-errors -Xcc -Werror -Xcc -Wno-nullability-completeness -Xcc -Wno-div-by-zero -Xcc -Wno-pointer-to-int-cast %t/test.swift -dump-source-file-imports 2>&1 | %FileCheck --dry-run > %t/imports.out

--- a/test/Interop/C/swiftify-import/clang-includes-no-swift.swift
+++ b/test/Interop/C/swiftify-import/clang-includes-no-swift.swift
@@ -4,7 +4,7 @@
 
 // RUN: %target-swift-frontend -typecheck -plugin-path %swift-plugin-dir -I %t%{fs-sep}Inputs %t/succeed.swift
 // RUN: not %target-swift-frontend -typecheck -plugin-path %swift-plugin-dir -I %t%{fs-sep}Inputs %t/fail.swift -dump-source-file-imports 2>&1 | %FileCheck %s
-// RUN: %target-swift-frontend -typecheck -plugin-path %swift-plugin-dir -I %t%{fs-sep}Inputs %t/fail.swift -verify -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}B1.h -verify-ignore-macro-note
+// RUN: %target-swift-frontend -typecheck -plugin-path %swift-plugin-dir -I %t%{fs-sep}Inputs %t/fail.swift -verify -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}B1.h -verify-ignore-macro-note -eager-macro-checking
 
 // Tests that we don't try to import modules that don't work well with Swift
 

--- a/test/Interop/C/swiftify-import/conflicting-opaqueness.swift
+++ b/test/Interop/C/swiftify-import/conflicting-opaqueness.swift
@@ -3,7 +3,7 @@
 // RUN: split-file %s %t
 
 // RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -o %t/test.swiftmodule %t/test.swift -I %t -strict-memory-safety \
-// RUN:   -verify -verify-additional-file %t%{fs-sep}foo.h -verify-additional-file %t%{fs-sep}bar.h -verify-additional-file %t%{fs-sep}baz.h -verify-additional-file %t%{fs-sep}qux.h -Rmacro-expansions
+// RUN:   -verify -verify-additional-file %t%{fs-sep}foo.h -verify-additional-file %t%{fs-sep}bar.h -verify-additional-file %t%{fs-sep}baz.h -verify-additional-file %t%{fs-sep}qux.h -Rmacro-expansions -eager-macro-checking
 
 // Macro expansions in foo.h do not have access to the definition of `struct qux`,
 // so don't attach macro on functions that use contain that type in foo.h.

--- a/test/Interop/C/swiftify-import/counted-by-lifetimebound.swift
+++ b/test/Interop/C/swiftify-import/counted-by-lifetimebound.swift
@@ -5,11 +5,11 @@
 // RUN: split-file %s %t
 
 // RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -I %t -enable-experimental-feature SafeInteropWrappers -enable-experimental-feature Lifetimes -strict-memory-safety -Xcc -Wno-nullability-completeness \
-// RUN:   %t/test.swift -verify -verify-additional-file %t%{fs-sep}test.h -Rmacro-expansions -suppress-notes -verify-additional-prefix experimental-
+// RUN:   %t/test.swift -verify -verify-additional-file %t%{fs-sep}test.h -Rmacro-expansions -suppress-notes -verify-additional-prefix experimental- -eager-macro-checking
 
 // lifetimebound support is not stabilized yet. Don't generate _any_ overloads on functions with lifetimebound to prevent future sourcebreak.
 // RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -I %t -enable-experimental-feature Lifetimes -strict-memory-safety -Xcc -Wno-nullability-completeness \
-// RUN:   %t/test.swift -verify -verify-additional-file %t%{fs-sep}test.h -Rmacro-expansions -suppress-notes -verify-additional-prefix stable-
+// RUN:   %t/test.swift -verify -verify-additional-file %t%{fs-sep}test.h -Rmacro-expansions -suppress-notes -verify-additional-prefix stable- -eager-macro-checking
 
 // Check that ClangImporter correctly infers and expands @_SwiftifyImport macros for functions with __counted_by __lifetimebound parameters and return values.
 

--- a/test/Interop/C/swiftify-import/counted-by-noescape.swift
+++ b/test/Interop/C/swiftify-import/counted-by-noescape.swift
@@ -4,7 +4,7 @@
 // RUN: split-file %s %t
 
 // RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -I %t -enable-experimental-feature Lifetimes -strict-memory-safety -Xcc -Wno-ignored-attributes -Xcc -Wno-nullability-completeness \
-// RUN:   %t/test.swift -verify -verify-additional-file %t%{fs-sep}test.h -Rmacro-expansions -suppress-notes
+// RUN:   %t/test.swift -verify -verify-additional-file %t%{fs-sep}test.h -Rmacro-expansions -suppress-notes -eager-macro-checking
 
 // Check that ClangImporter correctly infers and expands @_SwiftifyImport macros for functions with __counted_by __noescape parameters.
 

--- a/test/Interop/C/swiftify-import/counted-by.swift
+++ b/test/Interop/C/swiftify-import/counted-by.swift
@@ -2,7 +2,7 @@
 // RUN: split-file %s %t
 
 // RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -I %t -strict-memory-safety -Xcc -Wno-nullability-completeness -Xcc -Wno-div-by-zero -Xcc -Wno-pointer-to-int-cast \
-// RUN:   %t/test.swift -verify -verify-additional-file %t%{fs-sep}test.h -Rmacro-expansions -suppress-notes
+// RUN:   %t/test.swift -verify -verify-additional-file %t%{fs-sep}test.h -Rmacro-expansions -suppress-notes -eager-macro-checking
 
 // Check that ClangImporter correctly infers and expands @_SwiftifyImport macros for functions with __counted_by parameters.
 

--- a/test/Interop/C/swiftify-import/import-as-instance-method.swift
+++ b/test/Interop/C/swiftify-import/import-as-instance-method.swift
@@ -3,10 +3,11 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 
+// FIXME: enable -eager-macro-checking once imported functions with FRTs inherit FRT availability rdar://175799573
 // RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -o %t/Test.swiftmodule -I %t%{fs-sep}Inputs -enable-experimental-feature SafeInteropWrappers -strict-memory-safety \
-// RUN:    -verify -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}instance.h %t/test.swift -I %bridging-path -DVERIFY -eager-macro-checking
+// RUN:    -verify -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}instance.h %t/test.swift -I %bridging-path -DVERIFY
 // RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -o %t/Test.swiftmodule -I %t%{fs-sep}Inputs -strict-memory-safety \
-// RUN:    -verify -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}instance.h %t/test.swift -I %bridging-path -DVERIFY -verify-additional-prefix nolifetimebound- -eager-macro-checking
+// RUN:    -verify -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}instance.h %t/test.swift -I %bridging-path -DVERIFY -verify-additional-prefix nolifetimebound-
 // RUN: env SWIFT_BACKTRACE="" %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -o %t/Test.swiftmodule -I %t/Inputs -enable-experimental-feature SafeInteropWrappers -strict-memory-safety -warnings-as-errors -Xcc -Werror %t/test.swift -dump-macro-expansions -I %bridging-path 2> %t/out.txt
 // RUN: diff --strip-trailing-cr %t/out.txt %t/out.expected
 

--- a/test/Interop/C/swiftify-import/import-as-instance-method.swift
+++ b/test/Interop/C/swiftify-import/import-as-instance-method.swift
@@ -4,9 +4,9 @@
 // RUN: split-file %s %t
 
 // RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -o %t/Test.swiftmodule -I %t%{fs-sep}Inputs -enable-experimental-feature SafeInteropWrappers -strict-memory-safety \
-// RUN:    -verify -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}instance.h %t/test.swift -I %bridging-path -DVERIFY
+// RUN:    -verify -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}instance.h %t/test.swift -I %bridging-path -DVERIFY -eager-macro-checking
 // RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -o %t/Test.swiftmodule -I %t%{fs-sep}Inputs -strict-memory-safety \
-// RUN:    -verify -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}instance.h %t/test.swift -I %bridging-path -DVERIFY -verify-additional-prefix nolifetimebound-
+// RUN:    -verify -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}instance.h %t/test.swift -I %bridging-path -DVERIFY -verify-additional-prefix nolifetimebound- -eager-macro-checking
 // RUN: env SWIFT_BACKTRACE="" %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -o %t/Test.swiftmodule -I %t/Inputs -enable-experimental-feature SafeInteropWrappers -strict-memory-safety -warnings-as-errors -Xcc -Werror %t/test.swift -dump-macro-expansions -I %bridging-path 2> %t/out.txt
 // RUN: diff --strip-trailing-cr %t/out.txt %t/out.expected
 

--- a/test/Interop/C/swiftify-import/memcmp.swift
+++ b/test/Interop/C/swiftify-import/memcmp.swift
@@ -7,7 +7,7 @@
 // RUN: %empty-directory(%t/sdk)
 
 // RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -strict-memory-safety -sdk %t/sdk \
-// RUN:   -Xcc -Werror %t%{fs-sep}test.swift -import-objc-header %t%{fs-sep}test.h -verify -verify-additional-file %t%{fs-sep}test.h -Rmacro-expansions
+// RUN:   -Xcc -Werror %t%{fs-sep}test.swift -import-objc-header %t%{fs-sep}test.h -verify -verify-additional-file %t%{fs-sep}test.h -Rmacro-expansions -eager-macro-checking
 
 // Check that ClangImporter does not try to apply _SwiftifyImport to functions in SwiftShims,
 // as it does not import the standard library types.

--- a/test/Interop/C/swiftify-import/nonescapable-return-without-lifetime.swift
+++ b/test/Interop/C/swiftify-import/nonescapable-return-without-lifetime.swift
@@ -3,7 +3,7 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 // RUN: %target-swift-frontend -emit-module -I %t -plugin-path %swift-plugin-dir -strict-memory-safety -enable-experimental-feature Lifetimes %t/test.swift \
-// RUN:    -Rmacro-expansions -verify -verify-additional-file %t%{fs-sep}test.h
+// RUN:    -Rmacro-expansions -verify -verify-additional-file %t%{fs-sep}test.h -eager-macro-checking
 
 //--- module.modulemap
 module Test {

--- a/test/Interop/C/swiftify-import/sized-by-lifetimebound.swift
+++ b/test/Interop/C/swiftify-import/sized-by-lifetimebound.swift
@@ -5,11 +5,11 @@
 // RUN: split-file %s %t
 
 // RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -I %t -enable-experimental-feature SafeInteropWrappers -enable-experimental-feature Lifetimes -strict-memory-safety -Xcc -Wno-nullability-completeness \
-// RUN:   %t/test.swift -verify -verify-additional-file %t%{fs-sep}test.h -verify-additional-prefix experimental- -Rmacro-expansions -suppress-notes
+// RUN:   %t/test.swift -verify -verify-additional-file %t%{fs-sep}test.h -verify-additional-prefix experimental- -Rmacro-expansions -suppress-notes -eager-macro-checking
 
 // lifetimebound support is not stabilized yet. Don't generate _any_ overloads on functions with lifetimebound to prevent future sourcebreak.
 // RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -I %t -enable-experimental-feature Lifetimes -strict-memory-safety -Xcc -Wno-nullability-completeness \
-// RUN:   %t/test.swift -verify -verify-additional-file %t%{fs-sep}test.h -verify-additional-prefix stable- -Rmacro-expansions -suppress-notes
+// RUN:   %t/test.swift -verify -verify-additional-file %t%{fs-sep}test.h -verify-additional-prefix stable- -Rmacro-expansions -suppress-notes -eager-macro-checking
 
 // Check that ClangImporter correctly infers and expands @_SwiftifyImport macros for functions with __sized_by __lifetimebound parameters and return values.
 

--- a/test/Interop/C/swiftify-import/sized-by-noescape.swift
+++ b/test/Interop/C/swiftify-import/sized-by-noescape.swift
@@ -4,7 +4,7 @@
 // RUN: split-file %s %t
 
 // RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -I %t -enable-experimental-feature Lifetimes -strict-memory-safety -Xcc -Wno-ignored-attributes -Xcc -Wno-nullability-completeness \
-// RUN:   %t/test.swift -verify -verify-additional-file %t%{fs-sep}test.h -Rmacro-expansions -suppress-notes
+// RUN:   %t/test.swift -verify -verify-additional-file %t%{fs-sep}test.h -Rmacro-expansions -suppress-notes -eager-macro-checking
 
 // Check that ClangImporter correctly infers and expands @_SwiftifyImport macros for functions with __sized_by __noescape parameters.
 

--- a/test/Interop/C/swiftify-import/sized-by.swift
+++ b/test/Interop/C/swiftify-import/sized-by.swift
@@ -2,7 +2,7 @@
 // RUN: split-file %s %t
 
 // RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -I %t -strict-memory-safety -Xcc -Wno-nullability-completeness \
-// RUN:   %t/test.swift -verify -verify-additional-file %t%{fs-sep}test.h -Rmacro-expansions -suppress-notes
+// RUN:   %t/test.swift -verify -verify-additional-file %t%{fs-sep}test.h -Rmacro-expansions -suppress-notes -eager-macro-checking
 
 // Check that ClangImporter correctly infers and expands @_SwiftifyImport macros for functions with __sized_by parameters.
 

--- a/test/Interop/C/swiftify-import/text-interface.swift
+++ b/test/Interop/C/swiftify-import/text-interface.swift
@@ -3,11 +3,11 @@
 // RUN: split-file %s %t
 
 // RUN: %target-swift-frontend -swift-version 5 -enable-library-evolution -emit-module -emit-module-interface-path %t/test.swiftinterface -plugin-path %swift-plugin-dir -o %t/test.swiftmodule %t/test.swift -I %t -strict-memory-safety \
-// RUN:   -verify -verify-additional-file %t%{fs-sep}test.h
+// RUN:   -verify -verify-additional-file %t%{fs-sep}test.h -eager-macro-checking
 
 // Verify that including the binary module works as expected
 // RUN: %target-swift-frontend -swift-version 5 -emit-module -o %t/depender.swiftmodule %t/depender.swift -I %t -strict-memory-safety \
-// RUN:   -verify -verify-additional-file %t%{fs-sep}test.h
+// RUN:   -verify -verify-additional-file %t%{fs-sep}test.h -eager-macro-checking
 
 // Make sure we trigger compilation from text interface
 // RUN: rm %t/test.swiftmodule %t/depender.swiftmodule
@@ -21,7 +21,7 @@
 
 // Verify that absence of the macro plugin doesn't break compilation by itself - only if one of the inlinable functions calls the safe wrapper
 // RUN: %target-swift-frontend -swift-version 5 -emit-module -o %t/depender.swiftmodule %t/depender.swift -I %t -strict-memory-safety \
-// RUN:   -verify -verify-additional-file %t%{fs-sep}test.h -verify-additional-file %t%{fs-sep}test.swiftinterface -verify-additional-prefix textinterface- -suppress-notes
+// RUN:   -verify -verify-additional-file %t%{fs-sep}test.h -verify-additional-file %t%{fs-sep}test.swiftinterface -verify-additional-prefix textinterface- -suppress-notes -eager-macro-checking
 
 
 //--- test.h

--- a/test/Interop/Cxx/class/invalid-members/function-members-with-incomplete-types.swift
+++ b/test/Interop/Cxx/class/invalid-members/function-members-with-incomplete-types.swift
@@ -77,9 +77,7 @@ struct GoodStruct {
 //
 // NOTE-MISSING: static func +(lhs: GoodStruct, rhs: Never) -> Int32
 //
-// CHECK-NEXT:   @available(*, unavailable, message: "return type is unavailable in Swift")
 // CHECK-NEXT:   func __beginUnsafe() -> Never
-// CHECK-NEXT:   @available(*, unavailable, message: "return type is unavailable in Swift")
 // CHECK-NEXT:   func __endUnsafe() -> Never
 // CHECK-NEXT: }
 

--- a/test/Interop/Cxx/stdlib/Inputs/std-span.h
+++ b/test/Interop/Cxx/stdlib/Inputs/std-span.h
@@ -175,8 +175,13 @@ struct S {};
 struct SpanWithoutTypeAlias {
   std::span<const int> bar() [[clang::lifetimebound]];
   void foo(std::span<const int> s [[clang::noescape]]);
+  std::span<S<int>> nestedTemplateInstantiationReturn() [[clang::lifetimebound]];
+  void nestedTemplateInstantiationParam(std::span<S<int>> s [[clang::noescape]]);
+  S<int> * __counted_by(len) nestedTemplateInstantiationReturnCounted(int len) [[clang::lifetimebound]];
+  void nestedTemplateInstantiationParamCounted(S<int> * __counted_by(len) p [[clang::noescape]], int len);
   void otherTemplatedType(ConstSpanOfInt copy [[clang::noescape]], S<int>);
   void otherTemplatedType2(ConstSpanOfInt copy [[clang::noescape]], S<int> *);
+  S<int> *otherTemplatedTypeReturn(ConstSpanOfInt copy [[clang::noescape]]);
 };
 
 inline void func(ConstSpanOfInt copy [[clang::noescape]]) {}

--- a/test/Interop/Cxx/stdlib/std-span-interface.swift
+++ b/test/Interop/Cxx/stdlib/std-span-interface.swift
@@ -58,6 +58,13 @@ import CxxStdlib
 // CHECK-NEXT:   mutating func foo(_ s: std.{{.*}}span<__cxxConst<CInt>, _C{{.*}}_{{.*}}>)
 // CHECK-NEXT:   mutating func otherTemplatedType(_ copy: ConstSpanOfInt, _: S<CInt>)
 // CHECK-NEXT:   mutating func otherTemplatedType2(_ copy: ConstSpanOfInt, _: UnsafeMutablePointer<S<CInt>>!)
+// CHECK-LEGACY-DAG:   /// This is an auto-generated wrapper for safer interop
+// CHECK-LEGACY-DAG:   @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+// CHECK-LEGACY-DAG:   @_lifetime(&self)
+// CHECK-LEGACY-DAG:   @_alwaysEmitIntoClient @_disfavoredOverload public mutating func bar() -> Span<CInt>
+// CHECK-DAG:   /// This is an auto-generated wrapper for safer interop
+// CHECK-DAG:   @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+// CHECK-DAG:   @_alwaysEmitIntoClient @_disfavoredOverload public mutating func foo(_ s: Span<CInt>)
 // CHECK-NEXT: }
 
 // CHECK: class DependsOnSelfFRT {
@@ -167,13 +174,22 @@ import CxxStdlib
 // CHECK-NEXT: @_lifetime(copy: copy copy)
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func mutableKeyword(_ copy: inout MutableSpan<CInt>)
 
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
+// CHECK-NEXT: @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+// CHECK-NEXT: @_lifetime(s: copy s)
+// CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func mutableSpanWithoutTypeAlias(_ s: inout MutableSpan<CInt>)
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
+// CHECK-NEXT: @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+// CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func spanWithoutTypeAlias(_ s: Span<CInt>)
+
 func callMethodWithSafeWrapper(_ x: inout X, s: Span<CInt>) {
     x.methodWithSafeWrapper(s)
     let _ = x.getMutable(s) // expected-default-error {{cannot convert value of type 'Span<CInt>' (aka 'Span<Int32>') to expected argument type 'ConstSpanOfInt'}}
 }
 
 func callFooBar(_ x: inout SpanWithoutTypeAlias, _ s: ConstSpanOfInt) {
-    let _: Span<CInt> = x.bar() // expected-error {{cannot convert value of type}}
+    let _: Span<CInt> = x.bar() // expected-default-error{{cannot convert value of type}}
     unsafe x.foo(s)
 }
 
@@ -279,9 +295,9 @@ func callMutableKeyword(_ span: inout MutableSpan<CInt>) {
 }
 
 func callSpanWithoutTypeAlias(_ span: Span<CInt>) {
-  spanWithoutTypeAlias(span) // expected-error {{cannot convert value of type}}
+  spanWithoutTypeAlias(span)
 }
 
 func callMutableSpanWithoutTypeAlias(_ span: consuming MutableSpan<CInt>) {
-  mutableSpanWithoutTypeAlias(&span) // expected-error {{cannot convert value of type}}
+  mutableSpanWithoutTypeAlias(&span)
 }

--- a/test/Interop/Cxx/stdlib/std-span-interface.swift
+++ b/test/Interop/Cxx/stdlib/std-span-interface.swift
@@ -15,9 +15,7 @@
 // REQUIRES: swift_feature_Lifetimes
 // REQUIRES: std_span
 
-#if !BRIDGING_HEADER
 import StdSpan
-#endif
 import CxxStdlib
 
 // CHECK:     struct DependsOnSelf {

--- a/test/Interop/Cxx/stdlib/std-span-interface.swift
+++ b/test/Interop/Cxx/stdlib/std-span-interface.swift
@@ -7,9 +7,9 @@
 // RUN: %FileCheck %s --match-full-lines --implicit-check-not "@_alwaysEmitIntoClient" --check-prefixes=CHECK,CHECK-LEGACY < %t/interface-lifetimebound.swift
 
 // Make sure we trigger typechecking and SIL diagnostics
-// RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -I %S/Inputs -enable-experimental-feature Lifetimes -cxx-interoperability-mode=default -strict-memory-safety -verify -Xcc -std=c++20 %s -verify-additional-prefix default- -suppress-notes
+// RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -I %S/Inputs -enable-experimental-feature Lifetimes -cxx-interoperability-mode=default -strict-memory-safety -verify -Xcc -std=c++20 %s -verify-additional-prefix default- -suppress-notes -eager-macro-checking
 
-// RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -I %S/Inputs -enable-experimental-feature SafeInteropWrappers -enable-experimental-feature Lifetimes -cxx-interoperability-mode=default -strict-memory-safety -verify -Xcc -std=c++20 %s
+// RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -I %S/Inputs -enable-experimental-feature SafeInteropWrappers -enable-experimental-feature Lifetimes -cxx-interoperability-mode=default -strict-memory-safety -verify -Xcc -std=c++20 %s -eager-macro-checking
 
 // REQUIRES: swift_feature_SafeInteropWrappers
 // REQUIRES: swift_feature_Lifetimes

--- a/test/Interop/Cxx/stdlib/std-span-interface.swift
+++ b/test/Interop/Cxx/stdlib/std-span-interface.swift
@@ -54,6 +54,10 @@ import CxxStdlib
 // CHECK-NEXT:   init()
 // CHECK-NEXT:   mutating func bar() -> std.{{.*}}span<__cxxConst<CInt>, _C{{.*}}_{{.*}}>
 // CHECK-NEXT:   mutating func foo(_ s: std.{{.*}}span<__cxxConst<CInt>, _C{{.*}}_{{.*}}>)
+// CHECK-NEXT:   mutating func nestedTemplateInstantiationReturn() -> std.{{.*}}span<S<CInt>, _C{{.*}}_{{.*}}>
+// CHECK-NEXT:   mutating func nestedTemplateInstantiationParam(_ s: std.{{.*}}span<S<CInt>, _C{{.*}}_{{.*}}>)
+// CHECK-NEXT:   mutating func nestedTemplateInstantiationReturnCounted(_ len: Int32) -> UnsafeMutablePointer<S<CInt>>!
+// CHECK-NEXT:   mutating func nestedTemplateInstantiationParamCounted(_ p: UnsafeMutablePointer<S<CInt>>!, _ len: Int32)
 // CHECK-NEXT:   mutating func otherTemplatedType(_ copy: ConstSpanOfInt, _: S<CInt>)
 // CHECK-NEXT:   mutating func otherTemplatedType2(_ copy: ConstSpanOfInt, _: UnsafeMutablePointer<S<CInt>>!)
 // CHECK-LEGACY-DAG:   /// This is an auto-generated wrapper for safer interop

--- a/test/Interop/Cxx/stdlib/std-span-transformed-execution.swift
+++ b/test/Interop/Cxx/stdlib/std-span-transformed-execution.swift
@@ -9,9 +9,7 @@
 // REQUIRES: executable_test
 // REQUIRES: std_span
 
-#if !BRIDGING_HEADER
 import StdSpan
-#endif
 import CxxStdlib
 
 func canCallSafeSpanAPIs(_ x: Span<CInt>) {

--- a/test/Interop/Cxx/stdlib/use-std-span.swift
+++ b/test/Interop/Cxx/stdlib/use-std-span.swift
@@ -12,9 +12,7 @@
 // REQUIRES: swift_feature_BorrowingForLoop
 
 import StdlibUnittest
-#if !BRIDGING_HEADER
 import StdSpan
-#endif
 import CxxStdlib
 
 var StdSpanTestSuite = TestSuite("StdSpan")

--- a/test/Interop/Cxx/swiftify-import/bounds-attrs-in-template.swift
+++ b/test/Interop/Cxx/swiftify-import/bounds-attrs-in-template.swift
@@ -1,7 +1,7 @@
 
 // RUN: rm -rf %t
 // RUN: split-file %s %t
-// RUN: %target-swift-frontend -plugin-path %swift-plugin-dir -I %t/Inputs -cxx-interoperability-mode=default %t/template.swift -dump-macro-expansions -emit-ir -o %t/out -verify -verify-ignore-unrelated
+// RUN: %target-swift-frontend -plugin-path %swift-plugin-dir -I %t/Inputs -cxx-interoperability-mode=default %t/template.swift -dump-macro-expansions -emit-ir -o %t/out -verify -verify-ignore-unrelated -eager-macro-checking
 // RUN: %target-swift-ide-test -plugin-path %swift-plugin-dir -I %t/Inputs -cxx-interoperability-mode=default -print-module -module-to-print=Template -source-filename=x | %FileCheck %s
 
 // CHECK: func cb_template<T>(_ p: UnsafePointer<T>!, _ size: Int{{.*}}) -> UnsafePointer<T>

--- a/test/Interop/Cxx/swiftify-import/clang-includes-no-cxx.swift
+++ b/test/Interop/Cxx/swiftify-import/clang-includes-no-cxx.swift
@@ -6,19 +6,19 @@
 
 // Case 1: a.swift calls A1.B1.foo with C++ interop
 // RUN: not %target-swift-frontend -typecheck -plugin-path %swift-plugin-dir -cxx-interoperability-mode=default -I %t%{fs-sep}Inputs %t/a.swift -dump-source-file-imports 2>&1 | %FileCheck --check-prefixes CHECK-A,CHECK-A-CXX %s
-// RUN:     %target-swift-frontend -typecheck -plugin-path %swift-plugin-dir -cxx-interoperability-mode=default -I %t%{fs-sep}Inputs %t/a.swift -verify -verify-additional-prefix cxx- -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}B1.h -verify-ignore-macro-note
+// RUN:     %target-swift-frontend -typecheck -plugin-path %swift-plugin-dir -cxx-interoperability-mode=default -I %t%{fs-sep}Inputs %t/a.swift -verify -verify-additional-prefix cxx- -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}B1.h -verify-ignore-macro-note -eager-macro-checking
 
 // Case 2: a.swift calls A1.B1.foo without C++ interop
 // RUN: %target-swift-frontend -typecheck -plugin-path %swift-plugin-dir -I %t%{fs-sep}Inputs %t/a.swift -dump-source-file-imports 2>&1 | %FileCheck --check-prefixes CHECK-A,CHECK-A-C %s
-// RUN: %target-swift-frontend -typecheck -plugin-path %swift-plugin-dir -I %t%{fs-sep}Inputs %t/a.swift -verify
+// RUN: %target-swift-frontend -typecheck -plugin-path %swift-plugin-dir -I %t%{fs-sep}Inputs %t/a.swift -verify -eager-macro-checking
 
 // Case 3: b.swift calls A2.B2.foo with C++ interop
 // RUN: %target-swift-frontend -typecheck -plugin-path %swift-plugin-dir -cxx-interoperability-mode=default -I %t%{fs-sep}Inputs %t/b.swift -dump-source-file-imports 2>&1 | %FileCheck --check-prefixes CHECK-B,CHECK-B-CXX %s
-// RUN: %target-swift-frontend -typecheck -plugin-path %swift-plugin-dir -cxx-interoperability-mode=default -I %t%{fs-sep}Inputs %t/b.swift -verify
+// RUN: %target-swift-frontend -typecheck -plugin-path %swift-plugin-dir -cxx-interoperability-mode=default -I %t%{fs-sep}Inputs %t/b.swift -verify -eager-macro-checking
 
 // Case 4: b.swift calls A2.B2.foo without C++ interop
 // RUN: not %target-swift-frontend -typecheck -plugin-path %swift-plugin-dir -I %t%{fs-sep}Inputs %t/b.swift -dump-source-file-imports 2>&1 | %FileCheck --check-prefix CHECK-B %s
-// RUN:     %target-swift-frontend -typecheck -plugin-path %swift-plugin-dir -I %t%{fs-sep}Inputs %t/b.swift -verify -verify-additional-prefix c- -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}B2.h -verify-ignore-macro-note
+// RUN:     %target-swift-frontend -typecheck -plugin-path %swift-plugin-dir -I %t%{fs-sep}Inputs %t/b.swift -verify -verify-additional-prefix c- -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}B2.h -verify-ignore-macro-note -eager-macro-checking
 
 // CHECK-A:      imports for {{.*}}a.swift:
 // CHECK-A-NEXT: 	Swift

--- a/test/Interop/Cxx/swiftify-import/counted-by-in-namespace.swift
+++ b/test/Interop/Cxx/swiftify-import/counted-by-in-namespace.swift
@@ -1,7 +1,7 @@
 
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
-// RUN: %target-swift-frontend -plugin-path %swift-plugin-dir -I %t/Inputs -cxx-interoperability-mode=default %t/namespace.swift -emit-module -verify
+// RUN: %target-swift-frontend -plugin-path %swift-plugin-dir -I %t/Inputs -cxx-interoperability-mode=default %t/namespace.swift -emit-module -verify -eager-macro-checking
 // RUN: %target-swift-ide-test -plugin-path %swift-plugin-dir -I %t/Inputs -cxx-interoperability-mode=upcoming-swift -print-module -module-to-print=Namespace -source-filename=x > %t/interface.txt
 // RUN: diff %t/interface.txt %t/interface.txt.expected
 

--- a/test/Interop/Cxx/swiftify-import/counted-by-method.swift
+++ b/test/Interop/Cxx/swiftify-import/counted-by-method.swift
@@ -2,7 +2,7 @@
 // RUN: rm -rf %t
 // RUN: split-file %s %t
 // RUN: %target-swift-ide-test -plugin-path %swift-plugin-dir -I %t/Inputs -cxx-interoperability-mode=upcoming-swift -print-module -module-to-print=Method -source-filename=x | %FileCheck %s
-// RUN: %target-swift-frontend -plugin-path %swift-plugin-dir -I %t/Inputs -cxx-interoperability-mode=default %t/method.swift -dump-macro-expansions -typecheck -verify
+// RUN: %target-swift-frontend -plugin-path %swift-plugin-dir -I %t/Inputs -cxx-interoperability-mode=default %t/method.swift -dump-macro-expansions -typecheck -verify -eager-macro-checking
 
 // CHECK: @_alwaysEmitIntoClient 
 // CHECK-SAME: public mutating func bar(_ p: UnsafeMutableBufferPointer<Float>)

--- a/test/Interop/Cxx/swiftify-import/import-as-instance-method.swift
+++ b/test/Interop/Cxx/swiftify-import/import-as-instance-method.swift
@@ -5,9 +5,9 @@
 // RUN: split-file %s %t
 
 // RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -o %t/Test.swiftmodule -I %t/Inputs -enable-experimental-feature SafeInteropWrappers -strict-memory-safety -Xcc -Werror %t/test.swift  -cxx-interoperability-mode=default -Xcc -std=c++20 \
-// RUN:   -verify -verify-additional-file %t/Inputs/instance.h -DVERIFY
+// RUN:   -verify -verify-additional-file %t/Inputs/instance.h -DVERIFY -eager-macro-checking
 // RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -o %t/Test.swiftmodule -I %t/Inputs -strict-memory-safety -Xcc -Werror %t/test.swift  -cxx-interoperability-mode=default -Xcc -std=c++20 \
-// RUN:   -verify -verify-additional-file %t/Inputs/instance.h -DVERIFY -verify-additional-prefix nolifetimebound-
+// RUN:   -verify -verify-additional-file %t/Inputs/instance.h -DVERIFY -verify-additional-prefix nolifetimebound- -eager-macro-checking
 // RUN: env SWIFT_BACKTRACE="" %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -o %t/Test.swiftmodule -I %t/Inputs -enable-experimental-feature SafeInteropWrappers -strict-memory-safety -warnings-as-errors -Xcc -Werror %t/test.swift -cxx-interoperability-mode=default -Xcc -std=c++20 -dump-macro-expansions 2>&1 | %FileCheck %s --match-full-lines --strict-whitespace --implicit-check-not __swiftmacro
 
 //--- test.swift

--- a/test/Interop/Cxx/swiftify-import/no-safe-wrapper-attr.swift
+++ b/test/Interop/Cxx/swiftify-import/no-safe-wrapper-attr.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 // RUN: %target-swift-frontend -plugin-path %swift-plugin-dir -I %t -cxx-interoperability-mode=default %t/test.swift -emit-module \
-// RUN:   -verify -Rmacro-expansions -verify-additional-file %t%{fs-sep}test.h -suppress-notes
+// RUN:   -verify -Rmacro-expansions -verify-additional-file %t%{fs-sep}test.h -suppress-notes -eager-macro-checking
 
 //--- test.h
 #define __counted_by(x) __attribute__((__counted_by__(x)))

--- a/test/Interop/Cxx/swiftify-import/parameter-type-from-namespace.swift
+++ b/test/Interop/Cxx/swiftify-import/parameter-type-from-namespace.swift
@@ -3,7 +3,7 @@
 // RUN: split-file %s %t
 
 // RUN: %target-swift-frontend -plugin-path %swift-plugin-dir -I %t -cxx-interoperability-mode=default %t/namespace.swift -emit-module \
-// RUN:   -verify -verify-additional-file %t%{fs-sep}namespace.h -Rmacro-expansions -strict-memory-safety -o %t/out.swiftmodule -import-bridging-header %t/bridging.h
+// RUN:   -verify -verify-additional-file %t%{fs-sep}namespace.h -Rmacro-expansions -strict-memory-safety -o %t/out.swiftmodule -import-bridging-header %t/bridging.h -eager-macro-checking
 
 // RUN: %target-swift-frontend -plugin-path %swift-plugin-dir -I %t -cxx-interoperability-mode=default %t/namespace.swift -typecheck \
 // RUN:   -dump-source-file-imports -import-bridging-header %t/bridging.h 2>&1 | %FileCheck --dry-run > %t/imports.txt

--- a/test/Interop/Cxx/swiftify-import/span-in-ctor.swift
+++ b/test/Interop/Cxx/swiftify-import/span-in-ctor.swift
@@ -3,7 +3,7 @@
 // RUN: rm -rf %t
 // RUN: split-file %s %t
 // RUN: %target-swift-frontend -c -plugin-path %swift-plugin-dir -I %t%{fs-sep}Inputs -Xcc -std=c++20 -cxx-interoperability-mode=default %t/method.swift \
-// RUN:   -Rmacro-expansions -verify -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}method.h -suppress-notes
+// RUN:   -Rmacro-expansions -verify -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}method.h -suppress-notes -eager-macro-checking
 
 
 //--- Inputs/module.modulemap


### PR DESCRIPTION
- **Explanation**:
We previously prevented generating safe wrappers on functions with
template instantiations in the signature, unless those instantiations
were hidden behind a typedef. This is because those template
instantiations cannot be expressed in Swift syntax, so the macro
would expand to a function with invalid syntax.

For the std::span parameter itself however, that type is replaced with a
Swift Span in the safe wrapper, so it's not an issue in the type
signature. We would previously use the std::span type name from the
original signature to cast from Span to std::span, which does not work
with the raw std::span type. This uses `.init` instead when this is the
case, which avoids spelling out the type. When possible, we still use
the concrete type name, for clarity and by providing information we have
accessible the typechecker needs to do less work.
- **Scope**:
This expands the scope of safe interop wrappers a bit: previously it was limited to std::span parameters where the type was hidden behind a typedef, which people don't typically do unless to deliberately support Swift interop. This is no longer needed. _However_ the parameter still needs a `__noescape` annotation, which is also not very widespread outside of Swift interop, since upstream currently Clang emits an error for `__noescape` on `std::span`. _But_ `__noescape` is expected to see more widespread use in the future, and we are working with upstream Clang to support it on `std::span`, so it'll be more realistic for future code that didn't intentionally go out of its way to support safe Swift interop to end up with safe wrappers.
- **Issues**:
rdar://167712240
#86339
- **Risk**:
The risk of breaking current code is low: current macro expansions are not changed, and it's unlikely for existing code to accidentally get safe wrappers. But going forward it does expand the exposure surface for safe interop, increasing the impact of regressions in safe interop wrappers.
- **Testing**:
Lit regression tests. Will run a SWB and include these changes in a sweep of OSS code before merging, but I have not done that yet.
