### PR TITLE
[SILOptimizer] Correctly compute the effects of TSan instrumentation

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/Analysis/AliasAnalysis.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Analysis/AliasAnalysis.swift
@@ -441,6 +441,11 @@ struct AliasAnalysis {
         return .init(write: true)
       }
       return .noEffects
+    case .TSanInoutAccess:
+      if memLoc.mayAlias(with: builtin.arguments[0], self) {
+        return .init(read: true)
+      }
+      return .noEffects
     default:
       return defaultEffects(of: builtin, on: memLoc)
     }

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ComputeSideEffects.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ComputeSideEffects.swift
@@ -249,6 +249,9 @@ private struct CollectedEffects {
       is CondFailInst:
       break
 
+    case let bi as BuiltinInst where bi.id == .TSanInoutAccess:
+      break
+
     case is BeginCOWMutationInst, is IsUniqueInst:
       // Model reference count reading as "destroy" for now. Although we could introduce a "read-refcount"
       // effect, it would not give any significant benefit in any of our current optimizations.
@@ -586,6 +589,9 @@ private struct ArgumentEscapingWalker : ValueDefUseWalker, AddressDefUseWalker {
     // Warning: all instruction listed here, must also be handled in `CollectedEffects.addInstructionEffects`
     case is StoreInst, is StoreWeakInst, is StoreUnownedInst, is ApplySite, is DestroyAddrInst,
          is DebugValueInst:
+      return .continueWalk
+
+    case let bi as BuiltinInst where bi.id == .TSanInoutAccess:
       return .continueWalk
 
     default:

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/EscapeUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/EscapeUtils.swift
@@ -572,6 +572,8 @@ fileprivate struct EscapeWalker<V: EscapeVisitor> : ValueDefUseWalker,
     case is DeallocStackInst, is InjectEnumAddrInst, is FixLifetimeInst, is EndBorrowInst, is EndAccessInst,
          is IsUniqueInst, is DebugValueInst:
       return .continueWalk
+    case let bi as BuiltinInst where bi.id == .TSanInoutAccess:
+      return .continueWalk
     case let uac as UncheckedAddrCastInst:
       if uac.type != uac.fromAddress.type {
         // It's dangerous to continue walking over an `unchecked_addr_cast` which casts between two different types.

--- a/test/SILOptimizer/Inputs/module.modulemap
+++ b/test/SILOptimizer/Inputs/module.modulemap
@@ -1,3 +1,8 @@
 module CXXTypesWithUserProvidedDestructor {
   header "CXXTypesWithUserProvidedDestructor.h"
 }
+
+module TsanCxxWitnessCopy {
+  header "tsan_cxx_witness_copy.h"
+  requires cplusplus
+}

--- a/test/SILOptimizer/Inputs/tsan_cxx_witness_copy.h
+++ b/test/SILOptimizer/Inputs/tsan_cxx_witness_copy.h
@@ -1,0 +1,15 @@
+#pragma once
+
+struct Ref {};
+
+struct RefVec {
+    Ref* m_buffer;
+    int m_size;
+
+    RefVec() : m_buffer(nullptr), m_size(0) {}
+    RefVec(const RefVec& o) : m_buffer(o.m_buffer), m_size(o.m_size) {}
+    ~RefVec() {}
+
+    int size() const { return m_size; }
+    const Ref* at(int i) const { return &m_buffer[i]; }
+};

--- a/test/SILOptimizer/memory-effects_unit.sil
+++ b/test/SILOptimizer/memory-effects_unit.sil
@@ -2133,3 +2133,20 @@ bb0(%0 : $*Int32):
   return %r : $()
 }
 
+// CHECK-LABEL: @test_tsan_inout_access
+// CHECK:       PAIR #0.
+// CHECK-NEXT:      %2 = builtin "tsanInoutAccess"(%0 : $*Int32) : $()
+// CHECK-NEXT:      %0 = argument of bb0 : $*Int32
+// CHECK-NEXT:    r=1,w=0
+// CHECK:       PAIR #1.
+// CHECK-NEXT:      %2 = builtin "tsanInoutAccess"(%0 : $*Int32) : $()
+// CHECK-NEXT:      %1 = argument of bb0 : $*Int32
+// CHECK-NEXT:    r=0,w=0
+sil [ossa] @test_tsan_inout_access : $@convention(thin) (@inout Int32, @inout Int32) -> () {
+bb0(%0 : $*Int32, %1 : $*Int32):
+  specify_test "memory_effects"
+  %3 = builtin "tsanInoutAccess"(%0 : $*Int32) : $()
+  %r = tuple ()
+  return %r : $()
+}
+

--- a/test/SILOptimizer/side_effects.sil
+++ b/test/SILOptimizer/side_effects.sil
@@ -1171,6 +1171,27 @@ bb0(%0 : $*X):
   return %3 : $()
 }
 
+// CHECK-LABEL: sil @tsan_inout_access_test
+// CHECK-NEXT:  [global: deinit_barrier]
+// CHECK-NEXT:  {{^[^[]}}
+sil @tsan_inout_access_test : $@convention(thin) (@inout Int32) -> () {
+bb0(%0 : $*Int32):
+  %1 = builtin "tsanInoutAccess"(%0 : $*Int32) : $()
+  %3 = tuple()
+  return %3 : $()
+}
+
+// CHECK-LABEL: sil @tsan_inout_access_does_not_escape
+// CHECK-NEXT:  [%0: read v**]
+// CHECK-NEXT:  [global: deinit_barrier]
+// CHECK-NEXT:  {{^[^[]}}
+sil @tsan_inout_access_does_not_escape : $@convention(thin) (@in_guaranteed Int32) -> Int32 {
+bb0(%0 : $*Int32):
+  %1 = builtin "tsanInoutAccess"(%0 : $*Int32) : $()
+  %2 = load %0 : $*Int32
+  return %2 : $Int32
+}
+
 // CHECK-LABEL: sil @destroy_not_escaped_closure_test
 // CHECK-NEXT:  [%0: read v**.c*.v**, write v**.c*.v**, copy v**.c*.v**, destroy v**.c*.v**]
 // CHECK-NEXT:  [global: read,write,copy,destroy,allocate,deinit_barrier]

--- a/test/SILOptimizer/tsan_cxx_witness_copy.swift
+++ b/test/SILOptimizer/tsan_cxx_witness_copy.swift
@@ -1,0 +1,45 @@
+// RUN: %target-swift-emit-sil -O -wmo -sanitize=thread -cxx-interoperability-mode=default -swift-version 6 -I %S/Inputs %s | %FileCheck %s
+// REQUIRES: OS=macosx
+
+import TsanCxxWitnessCopy
+
+protocol VecProto {
+    associatedtype Element
+    func size() -> CInt
+    func __atUnsafe(_ i: CInt) -> UnsafePointer<Element>?
+}
+
+extension RefVec: VecProto {
+    typealias Element = Ref
+}
+
+struct VecIter<V: VecProto> {
+    var vec: V
+    var pos: CInt = 0
+
+    @inline(never)
+    mutating func next() -> UnsafePointer<V.Element>? {
+        guard pos < vec.size() else { return nil }
+        let item = vec.__atUnsafe(pos)
+        pos += 1
+        return item
+    }
+}
+
+@inline(never)
+func iterate(vec: RefVec) -> UnsafePointer<Ref>? {
+    var iter = VecIter(vec: vec)
+    return iter.next()
+}
+
+public func testEntry() -> UnsafePointer<Ref>? {
+    let vec = RefVec()
+    return iterate(vec: vec)
+}
+
+// The optimized SIL for `next()` should pass `self.vec` directly to the
+// protocol witness — no temporary copy.
+//
+// CHECK-LABEL: sil {{.*}}4next{{.*}}
+// CHECK-NOT: copy_addr
+// CHECK-LABEL: } // end sil function


### PR DESCRIPTION
Passing a C++ object to the TSanInOutAccess builtin resulted in an extra temporary copy. This copy was not optimized out because the semantics of this builtin was not understood by the optimizer. Teaching the utils that this intrinsic does not actually modify the object, does not escape it, and does not read it lets the optimizer eliminate this copy.

Strictly speaking, the test code that uses interop is not safe/correct, this is why it had a lifetime issue.

rdar://173921363
