### PR TITLE
[Documentation] Update custom icon for true/false keywords in the documentation navigation sidebar

### DIFF
--- a/stdlib/stdlib.docc/Assets/keyword-icon.svg
+++ b/stdlib/stdlib.docc/Assets/keyword-icon.svg
@@ -1,8 +1,4 @@
-<svg data-v-992f7eb0="" data-v-40abbb1e="" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" class="svg-icon single-letter-icon icon-inline" style="--color-svg-icon: rgb(134, 134, 139); --color-figure-gray-secondary: rgb(110, 110, 115); width: 1em; height: 1em; flex: 0 0 auto; color: var(--color-svg-icon, var(--color-figure-gray-secondary)); font-family: 'SF Pro Text', system-ui, -apple-system, BlinkMacSystemFont, 'Helvetica Neue', 'Helvetica', 'Arial', sans-serif;" viewBox="0 0 16 16">
-    <g data-v-992f7eb0="" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <rect data-v-992f7eb0="" stroke="currentColor" x="1" y="1" width="13" height="13" rx="3"></rect>
-        <text data-v-992f7eb0="" font-size="11" font-weight="bold" fill="currentColor" x="46.5%" y="11.2" text-anchor="middle">
-            <tspan data-v-992f7eb0="">K</tspan>
-        </text>
-    </g>
+<svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="16px" height="16px" viewBox="0 0 16 16">
+  <rect stroke="#666" fill="none" x="1" y="1" width="14" height="14" />
+  <text font-family="'Helvetica Neue', 'Helvetica', 'Arial', sans-serif" font-size="11" font-weight="bold" fill="#666" x="49%" y="12" text-anchor="middle">K</text>
 </svg>

--- a/stdlib/stdlib.docc/Assets/keyword-icon~dark.svg
+++ b/stdlib/stdlib.docc/Assets/keyword-icon~dark.svg
@@ -1,8 +1,4 @@
-<svg data-v-992f7eb0="" data-v-40abbb1e="" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" class="svg-icon single-letter-icon icon-inline" style="--color-svg-icon: rgb(134, 134, 139); --color-figure-gray-secondary: rgb(110, 110, 115); width: 1em; height: 1em; flex: 0 0 auto; color: var(--color-svg-icon, var(--color-figure-gray-secondary)); font-family: 'SF Pro Text', system-ui, -apple-system, BlinkMacSystemFont, 'Helvetica Neue', 'Helvetica', 'Arial', sans-serif;" viewBox="0 0 16 16">
-    <g data-v-992f7eb0="" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <rect data-v-992f7eb0="" stroke="currentColor" x="1" y="1" width="13" height="13" rx="3"></rect>
-        <text data-v-992f7eb0="" font-size="11" font-weight="bold" fill="currentColor" x="46.5%" y="11.2" text-anchor="middle">
-            <tspan data-v-992f7eb0="">K</tspan>
-        </text>
-    </g>
+<svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="16px" height="16px" viewBox="0 0 16 16">
+  <rect stroke="#ccc" fill="none" x="1" y="1" width="14" height="14" />
+  <text font-family="'Helvetica Neue', 'Helvetica', 'Arial', sans-serif" font-size="11" font-weight="bold" fill="#ccc" x="49%" y="12" text-anchor="middle">K</text>
 </svg>


### PR DESCRIPTION

- **Explanation**:
  This is a documentation-only change that updates the custom icon used for the `true` and `false` keywords in the documentation navigation sidebar. 
  
  This new icon (in its light mode variant and dark mode variant) match the color, font, and general appearance of the default icons in the documentation navigator sidebar, used for other kinds of symbols (classes, protocols, methods, etc.). See comparison screenshots in the "Testing" section below.
- **Scope**:
  This is a documentation (asset) only change.
- **Issues**:
  rdar://174344255
- **Risk**:
  There is essentially no risk with this change. It's only updating an asset that's only used for documentation.
- **Testing**:
  I locally previewed the Swift documentation to compare the new icons in both light mode and dark mode.
  
  The table below shows a comparison of the current icon and the new icon in both light mode and dark mode. Note how the current icon has rounded corners and is a bit too dim/faded in both light mode and dark more whereas the new icon matches the color, shape, and font of the "M" icon (for methods) above it:
  
  |                      | Current icon (before this change) | New icon (with this change) |
  |-------------|-------------|-----------|
  | Light mode | <img width="269" height="205" src="https://github.com/user-attachments/assets/e8d280d6-b569-4988-847d-ba0e7745f113" /> | <img width="288" height="209" src="https://github.com/user-attachments/assets/b3b898a2-964c-44cb-8bd7-481bd2b3de55" /> |
  | Dark mode | <img width="283" height="208" src="https://github.com/user-attachments/assets/d9517784-bb69-4f51-b5a3-c2025b09f686" /> | <img width="302" height="207" alt="Screenshot 2026-04-23 at 16 46 55" src="https://github.com/user-attachments/assets/b67cd26f-2758-4a98-b46e-fff8394a2376" /> |




