### PR TITLE
tests: disable IRGen/sensitive.swift for asan builds

### DIFF
--- a/test/IRGen/sensitive.swift
+++ b/test/IRGen/sensitive.swift
@@ -19,6 +19,9 @@
 // REQUIRES: swift_feature_Sensitive
 // UNSUPPORTED: use_os_stdlib
 
+// For some reason this fails with an asan build: rdar://172392429
+// UNSUPPORTED: asan
+
 var checkBuffer: UnsafeBufferPointer<UInt32>?
 
 @inline(never)


### PR DESCRIPTION
For some reason this test started failing in asan builds

rdar://172392429
