### PR TITLE
[Reflection] Fix overrun when reading field records of nonstandard size.

### DIFF
--- a/include/swift/RemoteInspection/Records.h
+++ b/include/swift/RemoteInspection/Records.h
@@ -116,19 +116,25 @@ using FieldRecord = TargetFieldRecord<InProcess>;
 
 template <typename Runtime>
 struct TargetFieldRecordIterator {
+  uint16_t RecordSize;
   const TargetFieldRecord<Runtime> *Cur;
   const TargetFieldRecord<Runtime> *const End;
 
-  TargetFieldRecordIterator(const TargetFieldRecord<Runtime> *Cur,
+  TargetFieldRecordIterator(uint16_t RecordSize,
+                            const TargetFieldRecord<Runtime> *Cur,
                             const TargetFieldRecord<Runtime> *const End)
-      : Cur(Cur), End(End) {}
+      : RecordSize(RecordSize), Cur(Cur), End(End) {}
 
   const TargetFieldRecord<Runtime> &operator*() const { return *Cur; }
 
   const TargetFieldRecord<Runtime> *operator->() const { return Cur; }
 
+  static const TargetFieldRecord<Runtime> *advanceRecordPointer(const TargetFieldRecord<Runtime> *Ptr, size_t bytes) {
+    return reinterpret_cast<const TargetFieldRecord<Runtime> *>(reinterpret_cast<const char *>(Ptr) + bytes);
+  }
+
   TargetFieldRecordIterator &operator++() {
-    ++Cur;
+    Cur = advanceRecordPointer(Cur, RecordSize);
     return *this;
   }
 
@@ -215,14 +221,15 @@ public:
 
   const_iterator begin() const {
     auto Begin = getFieldRecordBuffer();
-    auto End = Begin + NumFields;
-    return const_iterator { Begin, End };
+    auto End = FieldRecordIterator::advanceRecordPointer(Begin, NumFields * FieldRecordSize);
+    fprintf(stderr, "FieldRecordIterator begin %p end %p\n", Begin, End);
+    return const_iterator { FieldRecordSize, Begin, End };
   }
 
   const_iterator end() const {
     auto Begin = getFieldRecordBuffer();
-    auto End = Begin + NumFields;
-    return const_iterator { End, End };
+    auto End = FieldRecordIterator::advanceRecordPointer(Begin, NumFields * FieldRecordSize);
+    return const_iterator { FieldRecordSize, End, End };
   }
 
   llvm::ArrayRef<TargetFieldRecord<Runtime>> getFields() const {


### PR DESCRIPTION
When we read field descriptors, we compute the size of each one and bail out if it goes past the end of the section. The size consists of the header, plus record size multiplied by count. However, when we iterate, we ignore the record size and just iterate using the known standard size. If the record size field is smaller than standard, especially zero, we can go off the end of the section. This only happens with corrupt data, but we do want to gracefully handle corrupt data.

rdar://175435261