### PR TITLE
[cxx-interop] Fix missing entry in the witness table for operator-

### DIFF
--- a/lib/ClangImporter/ClangDerivedConformances.cpp
+++ b/lib/ClangImporter/ClangDerivedConformances.cpp
@@ -444,6 +444,7 @@ instantiateTemplatedOperator(ClangImporter::Implementation &impl,
       auto lookupTable2 = impl.findLookupTable(owningModule);
       if (lookupTable1 != lookupTable2)
         addEntryToLookupTable(*lookupTable2, clangCallee, impl.getNameImporter());
+      impl.synthesizedAndAlwaysVisibleDecls.insert(clangCallee);
       return clangCallee;
     }
     break;

--- a/test/Interop/Cxx/stdlib/use-std-vector-of-string-cross-module.swift
+++ b/test/Interop/Cxx/stdlib/use-std-vector-of-string-cross-module.swift
@@ -1,0 +1,71 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: %target-build-swift %t/test.swift -I %t/Inputs -o %t/out -cxx-interoperability-mode=swift-6
+// RUN: %target-codesign %t/out
+// RUN: %target-run %t/out
+
+// REQUIRES: executable_test
+
+//--- Inputs/module.modulemap
+module VectorOfStringLib {
+    header "vector-of-string-lib.h"
+    requires cplusplus
+    export *
+}
+
+//--- Inputs/vector-of-string-lib.h
+#ifndef VECTOR_OF_STRING_LIB_H
+#define VECTOR_OF_STRING_LIB_H
+
+#include <string>
+#include <vector>
+
+using VectorOfString = std::vector<std::string>;
+
+inline VectorOfString makeVectorOfString() {
+    return {"hello", "world", "test"};
+}
+
+inline void triggerCrash() {
+    VectorOfString::const_iterator a;
+    // Used to crash when std::vector<std::string> is imported from a
+    // C++ module whose code triggers instantiation of const_iterator::operator-,
+    (void)(a - a); // This was crucial for the crash.
+}
+
+#endif
+
+//--- test.swift
+import StdlibUnittest
+import VectorOfStringLib
+import CxxStdlib
+
+var Suite = TestSuite("VectorOfStringCrossModule")
+
+Suite.test("map on vector<string> from push_back") {
+    var v = VectorOfString()
+    v.push_back(std.string("abc"))
+    v.push_back(std.string("a"))
+    v.push_back(std.string("ab"))
+
+    let lengths = v.map { $0.length() }
+    expectEqual(lengths, [3, 1, 2])
+}
+
+Suite.test("map on vector<string> from factory function") {
+    let v = makeVectorOfString()
+
+    let lengths = v.map { $0.length() }
+    expectEqual(lengths, [5, 5, 4])
+}
+
+Suite.test("for loop over vector<string>") {
+    let v = makeVectorOfString()
+    var count = 0
+    for s in v {
+        count += s.length()
+    }
+    expectEqual(count, 14)
+}
+
+runAllTests()


### PR DESCRIPTION
**Explanation:**
The witness table was missing an entry for operator- due to a failed lookup which resulted in a null pointer dereference. This PR makes sure the template instantiated in a different module is visible to lookup. 
**Scope:**
Code using C++ interoperability and automatic conformances to some protocols in our overlay (including the standard library types).
**Issues:**
rdar://175038715
**Risk:**
Low, the changes are relatively straightforward. 
**Testing:**
Added compiler tests.

---

In some cases we did not add the operator- to the witness table resulting in a runtime crash (dereferencing a null pointer) due to the function not being visible when the table was populated. The happens when the instantiated operator- is in a module that is not directly visible. Now we mark such functions as always visible (we already do this for operator==), so the declaration is always found by lookup and the witness table is properly populated.

rdar://175038715
