### PR TITLE
[Frontend] Fix matching of blocklist extensions

### DIFF
--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -161,7 +161,7 @@ void CompilerInvocation::setDefaultBlocklistsIfNecessary() {
     for (llvm::sys::fs::directory_iterator F(blocklistDir, EC), FE;
          F != FE; F.increment(EC)) {
       StringRef ext = llvm::sys::path::extension(F->path());
-      if (ext == "yml" || ext == "yaml") {
+      if (ext.ends_with(".yml") || ext.ends_with(".yaml")) {
         LangOpts.BlocklistConfigFilePaths.push_back(F->path());
       }
     }


### PR DESCRIPTION
<!--
The main branch is now in convergence, which means major changes, such as large refactoring or new features, should be avoided. This strategy is intended to maintain the stability of the Swift 6.4 release leading up to the May 4th branch. For any work that requires broad changes or introduces new features, create a feature branch and open a draft pull request. All updates to the swiftlang/swift repository’s main branch require approval from the release managers. A pull request targeting swiftlang/swift will automatically add release managers. You can also contact them via @release-managers in the forum group.
-->

<!-- Please fill out the following form: --> 
- **Explanation**:
  
 `llvm::sys::path::extension` produces an extension together with the leading `.` which the original code didn't respect. We  also don't care about any other components as long as the last one is `.yaml` or `.yml`.

- **Scope**:

   Fixes in issue where valid block files in a default directory would be ignored because of the incorrect match on the extension.  

- **Issues**:
  
   N/A 

- **Risk**:

   Very Low. the fact that it didn't work means that nobody used this feature.  

- **Testing**:
 
  Local testing only, automated testing is not possible due to the nature of the change.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
