### PR TITLE
[Backtracing][Cross Compile] Attempt to fix CI build failures.

### DIFF
--- a/stdlib/public/RuntimeModule/CMakeLists.txt
+++ b/stdlib/public/RuntimeModule/CMakeLists.txt
@@ -201,6 +201,8 @@ if(SWIFT_ENABLE_BACKTRACING)
             message(STATUS "Using get-cpu-context.S for target ${target}")
             target_sources(${target}
               PRIVATE get-cpu-context.S)
+            target_compile_options(${target} PRIVATE
+              "$<$<COMPILE_LANGUAGE:ASM>:-target;${SWIFT_SDK_${sdk}_ARCH_${arch}_TRIPLE}>")
           endif()
         endif()
       endforeach()


### PR DESCRIPTION
- **Explanation**:
Attempt to fix the static linux build; the target flag isn't being passed to clang when compiling the `cpu-get-context.S` file. This is happening because of our abuse of CMake, and only affects the old build system. (The new build system would do the right thing automatically.)

- **Scope**:
Affects building the runtime. In most builds it should have no effect at the target was being defaulted correctly. The exception I think is cross compiling, in particular the assembly files in the Runtime module.

- **Issues**:
rdar://175202251

- **Risk**:
Low. This specifically affects cross-compilation situations, and the only thing really doing that (with the Runtime module) is the Static SDK for Linux.

- **Testing**:
Built locally to test the fix (by @al45tair).
