### PR TITLE
Add a bailout to open_existential_addr CSE

### DIFF
--- a/lib/SILOptimizer/Transforms/CSE.cpp
+++ b/lib/SILOptimizer/Transforms/CSE.cpp
@@ -1360,6 +1360,21 @@ static bool tryToCSEOpenExtCall(OpenExistentialAddrInst *From,
   if (ToAI->getSubstitutionMap().getReplacementTypes().size() != 1)
     return false;
 
+  // Bail out if any apply argument (other than the open_existential_addr
+  // itself) has a type that depends on the opened archetype. The operand
+  // replacement below cannot remap such types, which would result in an
+  // apply with mismatched archetypes.
+  auto *FromEnv = From->getDefinedOpenedArchetype()->getGenericEnvironment();
+  for (auto Op : FromAI->getArguments()) {
+    if (Op == From) {
+      continue;
+    }
+    if (Op->getType().hasOpenedExistential() &&
+        Op->getType().getASTType()->hasLocalArchetypeFromEnvironment(FromEnv)) {
+      return false;
+    }
+  }
+
   // Prepare the Apply args.
   SmallVector<SILValue, 8> Args;
   for (auto Op : FromAI->getArguments()) {

--- a/test/SILOptimizer/cse_ossa.sil
+++ b/test/SILOptimizer/cse_ossa.sil
@@ -1507,3 +1507,33 @@ bb1(%6 : $Builtin.RawPointer):
   return %11
 }
 
+protocol Q {}
+protocol P : Identifiable where Self.ID : Q {}
+
+// CHECK-LABEL: sil [ossa] @test_cse_open_existential_addr
+// The second open_existential_addr must not be eliminated.
+// CHECK: open_existential_addr
+// CHECK: open_existential_addr
+// CHECK: } // end sil function 'test_cse_open_existential_addr'
+sil [ossa] @test_cse_open_existential_addr : $@convention(thin) (@in_guaranteed any P) -> () {
+bb0(%0 : $*any P):
+  %1 = open_existential_addr immutable_access %0 to $*@opened("00000000-0000-0000-0000-000000000001", any P) Self
+  %2 = alloc_stack $any Hashable & Q
+  %3 = witness_method $@opened("00000000-0000-0000-0000-000000000001", any P) Self, #Identifiable.id!getter : <Self where Self : Identifiable> (Self) -> () -> Self.ID, %1 : $*@opened("00000000-0000-0000-0000-000000000001", any P) Self : $@convention(witness_method: Identifiable) <τ_0_0 where τ_0_0 : Identifiable> (@in_guaranteed τ_0_0) -> @out τ_0_0.ID
+  %4 = init_existential_addr %2, $(@opened("00000000-0000-0000-0000-000000000001", any P) Self).ID
+  %5 = apply %3<@opened("00000000-0000-0000-0000-000000000001", any P) Self>(%4, %1) : $@convention(witness_method: Identifiable) <τ_0_0 where τ_0_0 : Identifiable> (@in_guaranteed τ_0_0) -> @out τ_0_0.ID
+  destroy_addr %2
+  dealloc_stack %2
+
+  %8 = open_existential_addr immutable_access %0 to $*@opened("00000000-0000-0000-0000-000000000002", any P) Self
+  %9 = alloc_stack $any Hashable & Q
+  %10 = witness_method $@opened("00000000-0000-0000-0000-000000000002", any P) Self, #Identifiable.id!getter : <Self where Self : Identifiable> (Self) -> () -> Self.ID, %8 : $*@opened("00000000-0000-0000-0000-000000000002", any P) Self : $@convention(witness_method: Identifiable) <τ_0_0 where τ_0_0 : Identifiable> (@in_guaranteed τ_0_0) -> @out τ_0_0.ID
+  %11 = init_existential_addr %9, $(@opened("00000000-0000-0000-0000-000000000002", any P) Self).ID
+  %12 = apply %10<@opened("00000000-0000-0000-0000-000000000002", any P) Self>(%11, %8) : $@convention(witness_method: Identifiable) <τ_0_0 where τ_0_0 : Identifiable> (@in_guaranteed τ_0_0) -> @out τ_0_0.ID
+  destroy_addr %9
+  dealloc_stack %9
+
+  %15 = tuple ()
+  return %15 : $()
+}
+


### PR DESCRIPTION
- **Explanation**:
`tryToCSEOpenExtCall` replaces `open_existential_addr` operands in apply instructions, but doesn't remap types of other arguments that depend on the opened archetype (e.g. `init_existential_addr` results). This can create illegal apply with mismatched archetypes. Add a check that bails out if any apply argument (other than the open_existential_addr itself) has a type depending on the opened archetype's generic environment.

- **Scope**: CSE optimization involving generic types

- **Issues**: Resolves an issue exposed in rdar://100426072

 
- **Risk**: Low. Adding an optimization bailout

- **Testing**: Unit test and CI testing
