### PR TITLE
[stdlib] Span<~E>: Span & BorrowingSequence where Element: ~Escapable based on UnsafeRawPointer

### DIFF
--- a/stdlib/public/core/BorrowingSequence.swift
+++ b/stdlib/public/core/BorrowingSequence.swift
@@ -13,7 +13,7 @@
 /// A type that provides borrowed access to the values of a borrowing sequence.
 @available(SwiftStdlib 6.4, *)
 public protocol BorrowingIteratorProtocol<Element>: ~Copyable, ~Escapable {
-  associatedtype Element: ~Copyable
+  associatedtype Element: ~Copyable & ~Escapable
 
   /// Returns a span over the next group of elements that are ready to by visited,
   /// up to the specifed maximum.
@@ -72,7 +72,7 @@ public protocol BorrowingIteratorProtocol<Element>: ~Copyable, ~Escapable {
 }
 
 @available(SwiftStdlib 6.4, *)
-extension BorrowingIteratorProtocol where Self: ~Copyable & ~Escapable, Element: ~Copyable {
+extension BorrowingIteratorProtocol where Self: ~Copyable & ~Escapable, Element: ~Copyable & ~Escapable {
   /// Returns a span over the next group of elements that are ready to by visited,
   /// up to the specifed maximum.
   @_alwaysEmitIntoClient
@@ -98,7 +98,7 @@ extension BorrowingIteratorProtocol where Self: ~Copyable & ~Escapable, Element:
 
 @available(SwiftStdlib 6.4, *)
 public struct SpanIterator<Element>: BorrowingIteratorProtocol, ~Copyable, ~Escapable
-  where Element: ~Copyable
+  where Element: ~Copyable & ~Escapable
 {
   @usableFromInline
   internal var _span: Span<Element>
@@ -144,7 +144,7 @@ public struct SpanIterator<Element>: BorrowingIteratorProtocol, ~Copyable, ~Esca
 @reparentable
 public protocol BorrowingSequence<Element>: ~Copyable, ~Escapable {
   /// A type representing the sequence's elements.
-  associatedtype Element: ~Copyable
+  associatedtype Element: ~Copyable & ~Escapable
 
   /// A type that provides the sequence's iteration interface and
   /// encapsulates its iteration state.
@@ -163,7 +163,7 @@ public protocol BorrowingSequence<Element>: ~Copyable, ~Escapable {
 }
 
 @available(SwiftStdlib 6.4, *)
-extension BorrowingSequence where Self: ~Copyable & ~Escapable, Element: ~Copyable {
+extension BorrowingSequence where Self: ~Copyable & ~Escapable, Element: ~Copyable & ~Escapable {
   @inlinable
   public var underestimatedCount: Int { 0 }
   @inlinable

--- a/stdlib/public/core/Span/RawSpan.swift
+++ b/stdlib/public/core/Span/RawSpan.swift
@@ -321,7 +321,7 @@ extension RawSpan {
   @_alwaysEmitIntoClient
   @unsafe
   @lifetime(copy span)
-  public init<Element>(_elements span: Span<Element>) {
+  public init<Element: ~Escapable>(_elements span: Span<Element>) {
     unsafe self = Self.init(unsafeElements: span)
   }
 
@@ -335,7 +335,7 @@ extension RawSpan {
   @_alwaysEmitIntoClient
   @unsafe
   @_lifetime(copy span)
-  public init<Element>(unsafeElements span: Span<Element>) {
+  public init<Element: ~Escapable>(unsafeElements span: Span<Element>) {
     let rawSpan = unsafe RawSpan(
       _unchecked: unsafe span._pointer,
       byteCount: span.count == 1 ? MemoryLayout<Element>.size
@@ -625,7 +625,7 @@ extension RawSpan {
   @unsafe
   @_alwaysEmitIntoClient
   @lifetime(copy self)
-  consuming public func _unsafeView<T: BitwiseCopyable>(
+  consuming public func _unsafeView<T: BitwiseCopyable & ~Escapable>(
     as type: T.Type
   ) -> Span<T> {
     let rawBuffer = unsafe UnsafeRawBufferPointer(start: _pointer, count: _count)
@@ -715,7 +715,8 @@ extension RawSpan {
   ///     with the value in the range of memory referenced by this pointer.
   @unsafe
   @_alwaysEmitIntoClient
-  public func unsafeLoadUnaligned<T: BitwiseCopyable>(
+  @_lifetime(borrow self)
+  public func unsafeLoadUnaligned<T: BitwiseCopyable & ~Escapable>(
     fromByteOffset offset: Int = 0, as type: T.Type
   ) -> T {
     _precondition(
@@ -747,10 +748,12 @@ extension RawSpan {
   ///     with the value in the range of memory referenced by this pointer.
   @unsafe
   @_alwaysEmitIntoClient
-  public func unsafeLoadUnaligned<T: BitwiseCopyable>(
+  @_lifetime(borrow self)
+  public func unsafeLoadUnaligned<T: BitwiseCopyable & ~Escapable>(
     fromUncheckedByteOffset offset: Int, as type: T.Type
   ) -> T {
-    unsafe _start().loadUnaligned(fromByteOffset: offset, as: T.self)
+    let element = unsafe _start().loadUnaligned(fromByteOffset: offset, as: T.self)
+    return unsafe _overrideLifetime(element, borrowing: self)
   }
 
   /// Returns a value constructed from the raw memory at the specified offset.

--- a/stdlib/public/core/Span/RawSpan.swift
+++ b/stdlib/public/core/Span/RawSpan.swift
@@ -715,7 +715,7 @@ extension RawSpan {
   ///     with the value in the range of memory referenced by this pointer.
   @unsafe
   @_alwaysEmitIntoClient
-  @_lifetime(borrow self)
+  @_lifetime(copy self)
   public func unsafeLoadUnaligned<T: BitwiseCopyable & ~Escapable>(
     fromByteOffset offset: Int = 0, as type: T.Type
   ) -> T {
@@ -748,12 +748,12 @@ extension RawSpan {
   ///     with the value in the range of memory referenced by this pointer.
   @unsafe
   @_alwaysEmitIntoClient
-  @_lifetime(borrow self)
+  @_lifetime(copy self)
   public func unsafeLoadUnaligned<T: BitwiseCopyable & ~Escapable>(
     fromUncheckedByteOffset offset: Int, as type: T.Type
   ) -> T {
     let element = unsafe _start().loadUnaligned(fromByteOffset: offset, as: T.self)
-    return unsafe _overrideLifetime(element, borrowing: self)
+    return unsafe _overrideLifetime(element, copying: self)
   }
 
   /// Returns a value constructed from the raw memory at the specified offset.

--- a/stdlib/public/core/Span/Span.swift
+++ b/stdlib/public/core/Span/Span.swift
@@ -1004,7 +1004,7 @@ extension Span where Element == UInt8 {
 
 #if !SPAN_COMPATIBILITY_STUB
 @available(SwiftStdlib 6.4, *)
-extension Span: BorrowingSequence where Element: ~Copyable {
+extension Span: BorrowingSequence where Element: ~Copyable & ~Escapable {
   @available(SwiftStdlib 6.4, *)
   @inlinable
   @lifetime(borrow self)

--- a/stdlib/public/core/Span/Span.swift
+++ b/stdlib/public/core/Span/Span.swift
@@ -26,7 +26,7 @@ import Swift
 @safe
 @available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
-public struct Span<Element: ~Copyable>: ~Escapable, Copyable, BitwiseCopyable {
+public struct Span<Element: ~Copyable & ~Escapable>: ~Escapable, Copyable, BitwiseCopyable {
 
   /// The starting address of this `Span`.
   ///
@@ -88,7 +88,7 @@ public struct Span<Element: ~Copyable>: ~Escapable, Copyable, BitwiseCopyable {
 
 @available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
-extension Span: @unchecked Sendable where Element: Sendable & ~Copyable {}
+extension Span: @unchecked Sendable where Element: Sendable & ~Copyable & ~Escapable {}
 
 @available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
@@ -217,7 +217,7 @@ extension Span /*where Element: Copyable*/ {
 
 @available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
-extension Span where Element: BitwiseCopyable {
+extension Span where Element: BitwiseCopyable & ~Escapable {
 
   /// Unsafely create a `Span` over initialized memory.
   ///
@@ -402,7 +402,7 @@ extension Span where Element: BitwiseCopyable {
 
 @available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
-extension Span where Element: ~Copyable {
+extension Span where Element: ~Copyable & ~Escapable {
 
   /// The number of elements in the span.
   ///
@@ -436,7 +436,7 @@ extension Span where Element: ~Copyable {
 
 @available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
-extension Span where Element: ~Copyable {
+extension Span where Element: ~Copyable & ~Escapable {
   // SILOptimizer looks for fixed_storage.check_index semantics for bounds check optimizations.
   @_semantics("fixed_storage.check_index")
   @inline(__always)
@@ -453,10 +453,12 @@ extension Span where Element: ~Copyable {
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
   public subscript(_ position: Index) -> Element {
-    //FIXME: change to unsafeRawAddress when ready
-    unsafeAddress {
+    @_lifetime(copy self)
+    @_unsafeSelfDependentResult
+    borrow {
       _checkIndex(position)
-      return unsafe _unsafeAddressOfElement(unchecked: position)
+      let pointer = unsafe _unsafeAddressOfElement(unchecked: position)
+      return Builtin.borrowAt(pointer._rawValue)
     }
   }
 
@@ -472,9 +474,11 @@ extension Span where Element: ~Copyable {
   @unsafe
   @_alwaysEmitIntoClient
   public subscript(unchecked position: Index) -> Element {
-    //FIXME: change to unsafeRawAddress when ready
-    unsafeAddress {
-      unsafe _unsafeAddressOfElement(unchecked: position)
+    @_lifetime(copy self)
+    @_unsafeSelfDependentResult
+    borrow {
+      let pointer = unsafe _unsafeAddressOfElement(unchecked: position)
+      return Builtin.borrowAt(pointer._rawValue)
     }
   }
 
@@ -482,16 +486,15 @@ extension Span where Element: ~Copyable {
   @_alwaysEmitIntoClient
   internal func _unsafeAddressOfElement(
     unchecked position: Index
-  ) -> UnsafePointer<Element> {
+  ) -> UnsafeRawPointer {
     let elementOffset = position &* MemoryLayout<Element>.stride
-    let address = unsafe _start().advanced(by: elementOffset)
-    return unsafe address.assumingMemoryBound(to: Element.self)
+    return unsafe _start().advanced(by: elementOffset)
   }
 }
 
 @available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
-extension Span where Element: BitwiseCopyable {
+extension Span where Element: BitwiseCopyable & ~Escapable {
   /// Accesses the element at the specified index in the `Span`.
   ///
   /// - Parameter position: The offset of the element to access. `position`
@@ -500,6 +503,7 @@ extension Span where Element: BitwiseCopyable {
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
   public subscript(_ position: Index) -> Element {
+    @_lifetime(copy self)
     get {
       _checkIndex(position)
       return unsafe self[unchecked: position]
@@ -518,17 +522,19 @@ extension Span where Element: BitwiseCopyable {
   @unsafe
   @_alwaysEmitIntoClient
   public subscript(unchecked position: Index) -> Element {
+    @_lifetime(copy self)
     get {
       let elementOffset = position &* MemoryLayout<Element>.stride
       let address = unsafe _start().advanced(by: elementOffset)
-      return unsafe address.loadUnaligned(as: Element.self)
+      let element = unsafe address.loadUnaligned(as: Element.self)
+      return unsafe _overrideLifetime(element, copying: self)
     }
   }
 }
 
 @available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
-extension Span where Element: Copyable {
+extension Span where Element: Copyable & ~Escapable {
 
   /// Construct a raw span over the memory represented by this span.
   ///
@@ -565,7 +571,7 @@ extension Span where Element: ConvertibleToBytes {
 // MARK: sub-spans
 @available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
-extension Span where Element: ~Copyable {
+extension Span where Element: ~Copyable & ~Escapable {
 
   /// Constructs a new span over the items within the supplied range of
   /// indices within this span.
@@ -722,7 +728,7 @@ extension Span where Element: ~Copyable {
 // MARK: UnsafeBufferPointer access hatch
 @available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
-extension Span where Element: ~Copyable  {
+extension Span where Element: ~Copyable {
 
   /// Calls a closure with a pointer to the viewed contiguous storage.
   ///
@@ -754,7 +760,7 @@ extension Span where Element: ~Copyable  {
 
 @available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
-extension Span where Element: BitwiseCopyable {
+extension Span where Element: BitwiseCopyable & ~Escapable {
 
   /// Calls the given closure with a pointer to the underlying bytes of
   /// the viewed contiguous storage.
@@ -785,7 +791,7 @@ extension Span where Element: BitwiseCopyable {
 
 @available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
-extension Span where Element: ~Copyable {
+extension Span where Element: ~Copyable & ~Escapable {
   /// Returns a Boolean value indicating whether two instances refer to the same
   /// memory region.
   ///
@@ -846,7 +852,7 @@ extension Span where Element: ~Copyable {
 // MARK: prefixes and suffixes
 @available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
-extension Span where Element: ~Copyable {
+extension Span where Element: ~Copyable & ~Escapable {
 
   /// Returns a span containing the initial elements of this span,
   /// up to the specified maximum length.

--- a/stdlib/public/core/Span/Span.swift
+++ b/stdlib/public/core/Span/Span.swift
@@ -88,6 +88,22 @@ public struct Span<Element: ~Copyable & ~Escapable>: ~Escapable, Copyable, Bitwi
 
 @available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
+@usableFromInline
+@_silgen_name("$ss4SpanVsRi_zrlE6_countSivg")
+internal func _oldCountGetter<T: ~Copyable>(_ span: Span<T>) -> Int {
+  span._count
+}
+
+@available(SwiftCompatibilitySpan 5.0, *)
+@_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
+@usableFromInline
+@_silgen_name("$ss4SpanVsRi_zrlE8_pointerSVSgvg")
+internal func _oldPointerGetter<T: ~Copyable>(_ span: Span<T>) -> UnsafeRawPointer? {
+  unsafe span._pointer
+}
+
+@available(SwiftCompatibilitySpan 5.0, *)
+@_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension Span: @unchecked Sendable where Element: Sendable & ~Copyable & ~Escapable {}
 
 @available(SwiftCompatibilitySpan 5.0, *)

--- a/test/Interop/CxxToSwiftToCxx/bridge-cxx-enum-back-to-cxx-execution.cpp
+++ b/test/Interop/CxxToSwiftToCxx/bridge-cxx-enum-back-to-cxx-execution.cpp
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 
-// RUN: %target-swift-frontend -parse-as-library %stdlib_dir/Swift.swiftmodule/%module-target-triple.swiftinterface -enable-library-evolution -disable-objc-attr-requires-foundation-module -typecheck -module-name Swift -parse-stdlib -enable-experimental-cxx-interop -clang-header-expose-decls=has-expose-attr -emit-clang-header-path %t/Swift.h  -experimental-skip-all-function-bodies -enable-experimental-feature LifetimeDependence -enable-experimental-feature BorrowingSequence -enable-experimental-feature Reparenting -enable-experimental-feature AddressableParameters
+// RUN: %target-swift-frontend -parse-as-library %stdlib_dir/Swift.swiftmodule/%module-target-triple.swiftinterface -enable-library-evolution -disable-objc-attr-requires-foundation-module -typecheck -module-name Swift -parse-stdlib -enable-experimental-cxx-interop -clang-header-expose-decls=has-expose-attr -emit-clang-header-path %t/Swift.h  -experimental-skip-all-function-bodies -enable-experimental-feature LifetimeDependence -enable-experimental-feature Lifetimes -enable-experimental-feature BorrowingSequence -enable-experimental-feature Reparenting -enable-experimental-feature AddressableParameters
 // RUN: %target-swift-frontend -typecheck %t/use-cxx-types.swift -typecheck -module-name UseCxx -emit-clang-header-path %t/UseCxx.h -I %t -enable-experimental-cxx-interop -clang-header-expose-decls=all-public
 
 // RUN: %target-interop-build-clangxx -std=c++20 -c %t/use-swift-cxx-types.cpp -I %t -o %t/swift-cxx-execution.o -g
@@ -12,6 +12,7 @@
 
 // REQUIRES: executable_test
 // REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_Lifetimes
 // REQUIRES: swift_feature_BorrowingSequence
 // REQUIRES: swift_feature_Reparenting
 // REQUIRES: swift_feature_AddressableParameters

--- a/test/Interop/CxxToSwiftToCxx/bridge-cxx-struct-back-to-cxx-execution.cpp
+++ b/test/Interop/CxxToSwiftToCxx/bridge-cxx-struct-back-to-cxx-execution.cpp
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 
-// RUN: %target-swift-frontend -parse-as-library %platform-module-dir/Swift.swiftmodule/%module-target-triple.swiftinterface -enable-library-evolution -disable-objc-attr-requires-foundation-module -typecheck -module-name Swift -parse-stdlib -enable-experimental-cxx-interop -clang-header-expose-decls=has-expose-attr -emit-clang-header-path %t/Swift.h  -experimental-skip-all-function-bodies -enable-experimental-feature LifetimeDependence -enable-experimental-feature BorrowingSequence -enable-experimental-feature Reparenting -enable-experimental-feature AddressableParameters
+// RUN: %target-swift-frontend -parse-as-library %platform-module-dir/Swift.swiftmodule/%module-target-triple.swiftinterface -enable-library-evolution -disable-objc-attr-requires-foundation-module -typecheck -module-name Swift -parse-stdlib -enable-experimental-cxx-interop -clang-header-expose-decls=has-expose-attr -emit-clang-header-path %t/Swift.h  -experimental-skip-all-function-bodies -enable-experimental-feature LifetimeDependence -enable-experimental-feature Lifetimes -enable-experimental-feature BorrowingSequence -enable-experimental-feature Reparenting -enable-experimental-feature AddressableParameters
 
 // RUN: %target-swift-frontend -typecheck %t/use-cxx-types.swift -typecheck -module-name UseCxx -emit-clang-header-path %t/UseCxx.h -I %t -enable-experimental-cxx-interop -clang-header-expose-decls=all-public
 
@@ -13,6 +13,7 @@
 
 // REQUIRES: executable_test
 // REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_Lifetimes
 // REQUIRES: swift_feature_BorrowingSequence
 // REQUIRES: swift_feature_Reparenting
 // REQUIRES: swift_feature_AddressableParameters

--- a/test/Interop/SwiftToCxx/stdlib/swift-stdlib-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/stdlib/swift-stdlib-in-cxx.swift
@@ -1,11 +1,12 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -parse-as-library %platform-module-dir/Swift.swiftmodule/%module-target-triple.swiftinterface -enable-library-evolution -disable-objc-attr-requires-foundation-module -typecheck -module-name Swift -parse-stdlib -enable-experimental-cxx-interop -clang-header-expose-decls=has-expose-attr-or-stdlib -emit-clang-header-path %t/Swift.h  -experimental-skip-all-function-bodies -enable-experimental-feature LifetimeDependence  -enable-experimental-feature BorrowingSequence -enable-experimental-feature Reparenting -enable-experimental-feature AddressableParameters
+// RUN: %target-swift-frontend -parse-as-library %platform-module-dir/Swift.swiftmodule/%module-target-triple.swiftinterface -enable-library-evolution -disable-objc-attr-requires-foundation-module -typecheck -module-name Swift -parse-stdlib -enable-experimental-cxx-interop -clang-header-expose-decls=has-expose-attr-or-stdlib -emit-clang-header-path %t/Swift.h  -experimental-skip-all-function-bodies -enable-experimental-feature LifetimeDependence -enable-experimental-feature Lifetimes -enable-experimental-feature BorrowingSequence -enable-experimental-feature Reparenting -enable-experimental-feature AddressableParameters
 // RUN: %FileCheck %s < %t/Swift.h
 
 // RUN: %check-interop-cxx-header-in-clang(%t/Swift.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY -Wno-unused-private-field -Wno-unused-function -Wc++98-compat-extra-semi)
 // RUN: %check-interop-cxx-header-in-clang(%t/Swift.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY -Wno-unused-private-field -Wno-unused-function -Wc++98-compat-extra-semi -DDEBUG=1)
 
 // REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_Lifetimes
 // REQUIRES: swift_feature_BorrowingSequence
 // REQUIRES: swift_feature_Reparenting
 // REQUIRES: swift_feature_AddressableParameters

--- a/test/SILGen/foreach_borrowing.swift
+++ b/test/SILGen/foreach_borrowing.swift
@@ -21,9 +21,9 @@ extension NoncopyableInt: Equatable {
 @available(SwiftStdlib 6.4, *)
 func testNonCopyableBorrowingSequence(seq: borrowing Span<NoncopyableInt>) {
   // With borrowing feature enabled, we expect makeBorrowingIterator and nextSpan to be called
-  // CHECK: = function_ref @$ss4SpanVsRi_zrlE21makeBorrowingIterators0aD0VyxGyF : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (@guaranteed Span<τ_0_0>) -> @lifetime(borrow 0) @out SpanIterator<τ_0_0>
-  // CHECK: = function_ref @$ss12SpanIteratorVsRi_zrlE04nextA012maximumCounts0A0VyxGSi_tF : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (Int, @lifetime(copy 1) @inout SpanIterator<τ_0_0>) -> @lifetime(borrow address_for_deps 1) @owned Span<τ_0_0>
-  // CHECK: [[IS_EMPTY_CHECK:%.*]] = function_ref @$ss4SpanVsRi_zrlE7isEmptySbvg : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (@guaranteed Span<τ_0_0>) -> Bool
+  // CHECK: = function_ref @$ss4SpanVsRi_zRi0_zrlE21makeBorrowingIterators0aD0VyxGyF : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable, τ_0_0 : ~Escapable> (@guaranteed Span<τ_0_0>) -> @lifetime(borrow 0) @out SpanIterator<τ_0_0>
+  // CHECK: function_ref @$ss12SpanIteratorVsRi_zRi0_zrlE04nextA012maximumCounts0A0VyxGSi_tF : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable, τ_0_0 : ~Escapable> (Int, @lifetime(copy 1) @inout SpanIterator<τ_0_0>) -> @lifetime(borrow address_for_deps 1) @owned Span<τ_0_0>
+  // CHECK: [[IS_EMPTY_CHECK:%.*]] = function_ref @$ss4SpanVsRi_zRi0_zrlE7isEmptySbvg : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable, τ_0_0 : ~Escapable> (@guaranteed Span<τ_0_0>) -> Bool
   // CHECK: [[IS_EMPTY_CALL:%.*]] = apply [[IS_EMPTY_CHECK]]
   // CHECK: [[NOT_EMPTY:%.*]] = function_ref @$sSb1nopyS2bFZ : $@convention(method) (Bool, @thin Bool.Type) -> Bool
   // CHECK: [[NOT_EMPTY_CALL:%.*]] = apply [[NOT_EMPTY]]([[IS_EMPTY_CALL]]
@@ -43,9 +43,9 @@ func testNonCopyableBorrowingSequence(seq: borrowing Span<NoncopyableInt>) {
 @available(SwiftStdlib 6.4, *)
 func testCopyableBorrowingSequence(seq: borrowing Span<Int>) {
   // With borrowing feature enabled, we expect makeBorrowingIterator and nextSpan to be called
-  // CHECK: = function_ref @$ss4SpanVsRi_zrlE21makeBorrowingIterators0aD0VyxGyF : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (@guaranteed Span<τ_0_0>) -> @lifetime(borrow 0) @out SpanIterator<τ_0_0>
-  // CHECK: = function_ref @$ss12SpanIteratorVsRi_zrlE04nextA012maximumCounts0A0VyxGSi_tF : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (Int, @lifetime(copy 1) @inout SpanIterator<τ_0_0>) -> @lifetime(borrow address_for_deps 1) @owned Span<τ_0_0>
-  // CHECK: [[IS_EMPTY_CHECK:%.*]] = function_ref @$ss4SpanVsRi_zrlE7isEmptySbvg : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (@guaranteed Span<τ_0_0>) -> Bool
+  // CHECK: function_ref @$ss4SpanVsRi_zRi0_zrlE21makeBorrowingIterators0aD0VyxGyF : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable, τ_0_0 : ~Escapable> (@guaranteed Span<τ_0_0>) -> @lifetime(borrow 0) @out SpanIterator<τ_0_0>
+  // CHECK: = function_ref @$ss12SpanIteratorVsRi_zRi0_zrlE04nextA012maximumCounts0A0VyxGSi_tF : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable, τ_0_0 : ~Escapable> (Int, @lifetime(copy 1) @inout SpanIterator<τ_0_0>) -> @lifetime(borrow address_for_deps 1) @owned Span<τ_0_0>
+  // CHECK: [[IS_EMPTY_CHECK:%.*]] = function_ref @$ss4SpanVsRi_zRi0_zrlE7isEmptySbvg : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable, τ_0_0 : ~Escapable> (@guaranteed Span<τ_0_0>) -> Bool
   // CHECK: [[IS_EMPTY_CALL:%.*]] = apply [[IS_EMPTY_CHECK]]
   // CHECK: [[NOT_EMPTY:%.*]] = function_ref @$sSb1nopyS2bFZ : $@convention(method) (Bool, @thin Bool.Type) -> Bool
   // CHECK: [[NOT_EMPTY_CALL:%.*]] = apply [[NOT_EMPTY]]([[IS_EMPTY_CALL]]
@@ -143,11 +143,11 @@ func testForEachLocations(seq: borrowing Span<Int>, val: Int) {
   //   }
 
   // makeBorrowingIterator() function_ref should be at "for" keyword location (172:3)
-  // CHECK: [[MAKE_BORROWING_IT:%.*]] = function_ref @$ss4SpanVsRi_zrlE21makeBorrowingIterators0aD0VyxGyF {{.*}}, loc "{{.*}}":[[@LINE+31]]:3
+  // CHECK: [[MAKE_BORROWING_IT:%.*]] = function_ref @$ss4SpanVsRi_zRi0_zrlE21makeBorrowingIterators0aD0VyxGyF {{.*}}, loc "{{.*}}":[[@LINE+31]]:3
   // CHECK: apply [[MAKE_BORROWING_IT]]{{.*}}, loc "{{.*}}":[[@LINE+30]]:18
 
   // nextSpan() function_ref should be at "for" keyword location
-  // CHECK: [[NEXT_SPAN:%.*]] = function_ref @$ss12SpanIteratorVsRi_zrlE04nextA012maximumCounts0A0VyxGSi_tF {{.*}}, loc "{{.*}}":[[@LINE+27]]:3
+  // CHECK: [[NEXT_SPAN:%.*]] = function_ref @$ss12SpanIteratorVsRi_zRi0_zrlE04nextA012maximumCounts0A0VyxGSi_tF {{.*}}, loc "{{.*}}":[[@LINE+27]]:3
   // CHECK: apply [[NEXT_SPAN]]{{.*}}, loc "{{.*}}":[[@LINE+26]]:3
 
   // $span debug_value should be at "for" keyword location

--- a/test/abi/macOS/arm64/stdlib.swift
+++ b/test/abi/macOS/arm64/stdlib.swift
@@ -1221,7 +1221,7 @@ Added: _$ss25BorrowingIteratorProtocolP4skip2byS2i_tFTq
 Added: _$ss25BorrowingIteratorProtocolP8nextSpan12maximumCounts0E0Vy7ElementQzGSi_tFTj
 Added: _$ss25BorrowingIteratorProtocolP8nextSpan12maximumCounts0E0Vy7ElementQzGSi_tFTq
 Added: _$ss25BorrowingIteratorProtocolTL
-Added: _$ss4SpanVyxGs17BorrowingSequencesRi_zrlMc
+Added: _$ss4SpanVyxGs17BorrowingSequencesRi_zRi0_zrlMc
 Added: _$ss7RawSpanV5_spans0B0Vys5UInt8VGvg
 Added: _$ss7RawSpanVs17BorrowingSequencesMc
 Added: _$ss7RawSpanVs17BorrowingSequencesWP
@@ -1229,26 +1229,26 @@ Added: _$ss11InlineArrayVsRi__rlE21makeBorrowingIterators04SpanE0Vyq_GyF
 Added: _$ss11MutableSpanVsRi_zrlE21makeBorrowingIterators0bE0VyxGyF
 Added: _$ss12SpanIteratorVMa
 Added: _$ss12SpanIteratorVMn
-Added: _$ss12SpanIteratorVsRi_zrlE5_spans0A0VyxGvM
-Added: _$ss12SpanIteratorVsRi_zrlE5_spans0A0VyxGvg
-Added: _$ss12SpanIteratorVsRi_zrlE5_spans0A0VyxGvs
-Added: _$ss12SpanIteratorVsRi_zrlE6_countSivM
-Added: _$ss12SpanIteratorVsRi_zrlE6_countSivg
-Added: _$ss12SpanIteratorVsRi_zrlE6_countSivs
-Added: _$ss12SpanIteratorVsRi_zrlE6_startSivM
-Added: _$ss12SpanIteratorVsRi_zrlE6_startSivg
-Added: _$ss12SpanIteratorVsRi_zrlE6_startSivs
-Added: _$ss12SpanIteratorVsRi_zrlEyAByxGs0A0VyxGcfC
-Added: _$ss12SpanIteratorVyxGs09BorrowingB8ProtocolsRi_zrlMc
+Added: _$ss12SpanIteratorVsRi_zRi0_zrlE5_spans0A0VyxGvM
+Added: _$ss12SpanIteratorVsRi_zRi0_zrlE5_spans0A0VyxGvg
+Added: _$ss12SpanIteratorVsRi_zRi0_zrlE5_spans0A0VyxGvs
+Added: _$ss12SpanIteratorVsRi_zRi0_zrlE6_countSivM
+Added: _$ss12SpanIteratorVsRi_zRi0_zrlE6_countSivg
+Added: _$ss12SpanIteratorVsRi_zRi0_zrlE6_countSivs
+Added: _$ss12SpanIteratorVsRi_zRi0_zrlE6_startSivM
+Added: _$ss12SpanIteratorVsRi_zRi0_zrlE6_startSivg
+Added: _$ss12SpanIteratorVsRi_zRi0_zrlE6_startSivs
+Added: _$ss12SpanIteratorVsRi_zRi0_zrlEyAByxGs0A0VyxGcfC
+Added: _$ss12SpanIteratorVyxGs09BorrowingB8ProtocolsRi_zRi0_zrlMc
 Added: _$ss14MutableRawSpanV21makeBorrowingIterators0cF0Vys5UInt8VGyF
 Added: _$ss17BorrowingSequenceP19underestimatedCountSivgTj
 Added: _$ss17BorrowingSequenceP19underestimatedCountSivgTq
 Added: _$ss17BorrowingSequenceP31_customContainsEquatableElementySbSg0F0QzFTj
 Added: _$ss17BorrowingSequenceP31_customContainsEquatableElementySbSg0F0QzFTq
-Added: _$ss17BorrowingSequencePsRi_zRi0_z7ElementRj_zrlE024_customContainsEquatableC0ySbSgADF
-Added: _$ss17BorrowingSequencePsRi_zRi0_z7ElementRj_zrlE19underestimatedCountSivg
-Added: _$ss17BorrowingSequencePsRi_zRi0_z7ElementRj_zrlE19underestimatedCountSivpMV
-Added: _$ss4SpanVsRi_zrlE21makeBorrowingIterators0aD0VyxGyF
+Added: _$ss17BorrowingSequencePsRi_zRi0_z7ElementRj_zADRI0_rlE024_customContainsEquatableC0ySbSgADF
+Added: _$ss17BorrowingSequencePsRi_zRi0_z7ElementRj_zADRI0_rlE19underestimatedCountSivg
+Added: _$ss17BorrowingSequencePsRi_zRi0_z7ElementRj_zADRI0_rlE19underestimatedCountSivpMV
+Added: _$ss4SpanVsRi_zRi0_zrlE21makeBorrowingIterators0aD0VyxGyF
 Added: _$ss7RawSpanV21makeBorrowingIterators0bE0Vys5UInt8VGyF
 Added: _$sSTss17BorrowingSequenceRzrlE19underestimatedCountSivg
 Added: _$sSTss17BorrowingSequenceRzrlE19underestimatedCountSivpMV
@@ -1308,3 +1308,9 @@ Added: _$ss9UniqueBoxVsRi_zrlE7pointerSpyxGvg
 
 // Cross-encoding strcmp for Foundation
 Added: __swift_unicodeBuffersEqual_nonNormalizing
+
+// New manglings of Span._count and _pointer for ~Escapable elements
+Added: $ld$previous$@rpath/libswiftCompatibilitySpan.dylib$$1$1.0$26.0$_$ss4SpanVsRi_zRi0_zrlE6_countSivg$
+Added: $ld$previous$@rpath/libswiftCompatibilitySpan.dylib$$1$1.0$26.0$_$ss4SpanVsRi_zRi0_zrlE8_pointerSVSgvg$
+Added: _$ss4SpanVsRi_zRi0_zrlE6_countSivg
+Added: _$ss4SpanVsRi_zRi0_zrlE8_pointerSVSgvg

--- a/test/abi/macOS/x86_64/stdlib.swift
+++ b/test/abi/macOS/x86_64/stdlib.swift
@@ -1216,7 +1216,7 @@ Added: _$ss25BorrowingIteratorProtocolP4skip2byS2i_tFTq
 Added: _$ss25BorrowingIteratorProtocolP8nextSpan12maximumCounts0E0Vy7ElementQzGSi_tFTj
 Added: _$ss25BorrowingIteratorProtocolP8nextSpan12maximumCounts0E0Vy7ElementQzGSi_tFTq
 Added: _$ss25BorrowingIteratorProtocolTL
-Added: _$ss4SpanVyxGs17BorrowingSequencesRi_zrlMc
+Added: _$ss4SpanVyxGs17BorrowingSequencesRi_zRi0_zrlMc
 Added: _$ss7RawSpanV5_spans0B0Vys5UInt8VGvg
 Added: _$ss7RawSpanVs17BorrowingSequencesMc
 Added: _$ss7RawSpanVs17BorrowingSequencesWP
@@ -1224,26 +1224,26 @@ Added: _$ss11InlineArrayVsRi__rlE21makeBorrowingIterators04SpanE0Vyq_GyF
 Added: _$ss11MutableSpanVsRi_zrlE21makeBorrowingIterators0bE0VyxGyF
 Added: _$ss12SpanIteratorVMa
 Added: _$ss12SpanIteratorVMn
-Added: _$ss12SpanIteratorVsRi_zrlE5_spans0A0VyxGvM
-Added: _$ss12SpanIteratorVsRi_zrlE5_spans0A0VyxGvg
-Added: _$ss12SpanIteratorVsRi_zrlE5_spans0A0VyxGvs
-Added: _$ss12SpanIteratorVsRi_zrlE6_countSivM
-Added: _$ss12SpanIteratorVsRi_zrlE6_countSivg
-Added: _$ss12SpanIteratorVsRi_zrlE6_countSivs
-Added: _$ss12SpanIteratorVsRi_zrlE6_startSivM
-Added: _$ss12SpanIteratorVsRi_zrlE6_startSivg
-Added: _$ss12SpanIteratorVsRi_zrlE6_startSivs
-Added: _$ss12SpanIteratorVsRi_zrlEyAByxGs0A0VyxGcfC
-Added: _$ss12SpanIteratorVyxGs09BorrowingB8ProtocolsRi_zrlMc
+Added: _$ss12SpanIteratorVsRi_zRi0_zrlE5_spans0A0VyxGvM
+Added: _$ss12SpanIteratorVsRi_zRi0_zrlE5_spans0A0VyxGvg
+Added: _$ss12SpanIteratorVsRi_zRi0_zrlE5_spans0A0VyxGvs
+Added: _$ss12SpanIteratorVsRi_zRi0_zrlE6_countSivM
+Added: _$ss12SpanIteratorVsRi_zRi0_zrlE6_countSivg
+Added: _$ss12SpanIteratorVsRi_zRi0_zrlE6_countSivs
+Added: _$ss12SpanIteratorVsRi_zRi0_zrlE6_startSivM
+Added: _$ss12SpanIteratorVsRi_zRi0_zrlE6_startSivg
+Added: _$ss12SpanIteratorVsRi_zRi0_zrlE6_startSivs
+Added: _$ss12SpanIteratorVsRi_zRi0_zrlEyAByxGs0A0VyxGcfC
+Added: _$ss12SpanIteratorVyxGs09BorrowingB8ProtocolsRi_zRi0_zrlMc
 Added: _$ss14MutableRawSpanV21makeBorrowingIterators0cF0Vys5UInt8VGyF
 Added: _$ss17BorrowingSequenceP19underestimatedCountSivgTj
 Added: _$ss17BorrowingSequenceP19underestimatedCountSivgTq
 Added: _$ss17BorrowingSequenceP31_customContainsEquatableElementySbSg0F0QzFTj
 Added: _$ss17BorrowingSequenceP31_customContainsEquatableElementySbSg0F0QzFTq
-Added: _$ss17BorrowingSequencePsRi_zRi0_z7ElementRj_zrlE024_customContainsEquatableC0ySbSgADF
-Added: _$ss17BorrowingSequencePsRi_zRi0_z7ElementRj_zrlE19underestimatedCountSivg
-Added: _$ss17BorrowingSequencePsRi_zRi0_z7ElementRj_zrlE19underestimatedCountSivpMV
-Added: _$ss4SpanVsRi_zrlE21makeBorrowingIterators0aD0VyxGyF
+Added: _$ss17BorrowingSequencePsRi_zRi0_z7ElementRj_zADRI0_rlE024_customContainsEquatableC0ySbSgADF
+Added: _$ss17BorrowingSequencePsRi_zRi0_z7ElementRj_zADRI0_rlE19underestimatedCountSivg
+Added: _$ss17BorrowingSequencePsRi_zRi0_z7ElementRj_zADRI0_rlE19underestimatedCountSivpMV
+Added: _$ss4SpanVsRi_zRi0_zrlE21makeBorrowingIterators0aD0VyxGyF
 Added: _$ss7RawSpanV21makeBorrowingIterators0bE0Vys5UInt8VGyF
 Added: _$sSTss17BorrowingSequenceRzrlE19underestimatedCountSivg
 Added: _$sSTss17BorrowingSequenceRzrlE19underestimatedCountSivpMV
@@ -1304,3 +1304,9 @@ Added: _$ss9UniqueBoxVsRi_zrlE7pointerSpyxGvg
 
 // Cross-encoding strcmp for Foundation
 Added: __swift_unicodeBuffersEqual_nonNormalizing
+
+// New manglings of Span._count and _pointer for ~Escapable elements
+Added: $ld$previous$@rpath/libswiftCompatibilitySpan.dylib$$1$1.0$26.0$_$ss4SpanVsRi_zRi0_zrlE6_countSivg$
+Added: $ld$previous$@rpath/libswiftCompatibilitySpan.dylib$$1$1.0$26.0$_$ss4SpanVsRi_zRi0_zrlE8_pointerSVSgvg$
+Added: _$ss4SpanVsRi_zRi0_zrlE6_countSivg
+Added: _$ss4SpanVsRi_zRi0_zrlE8_pointerSVSgvg


### PR DESCRIPTION
- **[stdlib] Span<~Escapable>**
  Support for non-Escapable Span elements.
  
  UnsafePointer-based APIs are not supported.
  

- **[stdlib] RawSpan initialize/load/view where T: ~Escapable.**
  

- **[stdlib] BorrowingSequence where Element: ~Escapable**

This depends on two PRs that will land first:
- [[NFC] Add Builtin.makeBorrowAt to replace unsafeAddress
#88542](https://github.com/swiftlang/swift/pull/88542)
- [[stdlib] ~Escapable raw pointer access: API adoption in URP, UMRP, URBP, UMRBP
#84701](https://github.com/swiftlang/swift/pull/84701)
  