### PR TITLE
[BridgingHeader] Don't use `#import` on windows

### DIFF
--- a/lib/DependencyScan/ModuleDependencyScanner.cpp
+++ b/lib/DependencyScan/ModuleDependencyScanner.cpp
@@ -1889,11 +1889,21 @@ llvm::Error ModuleDependencyScanner::performBridgingHeaderChaining(
   // embedded header path is also prefix mapped, thus it can't be found anyway.
   auto FS = ScanASTContext.SourceMgr.getFileSystem();
 
+  // Use #import to make sure the file only imported once, unless it is on
+  // Windows which will produce an error.
+  const auto &ClangLangOpts =
+      ScanASTContext.getClangModuleLoader()->getClangASTContext().getLangOpts();
+  bool supportImport = ClangLangOpts.ObjC || !ClangLangOpts.MSVCCompat;
+
   auto chainBridgingHeader = [&](StringRef moduleName, StringRef headerPath,
                                  StringRef binaryModulePath) -> llvm::Error {
     auto remapped = remapPath(headerPath);
     outOS << "#if __has_include(\"" << remapped << "\")\n";
-    outOS << "#import \"" << remapped << "\"\n";
+    if (supportImport)
+      outOS << "#import";
+    else
+      outOS << "#include";
+    outOS << " \"" << remapped << "\"\n";
     outOS << "#else\n";
 
     if (binaryModulePath.empty()) {

--- a/test/ScanDependencies/bridging-header-win.swift
+++ b/test/ScanDependencies/bridging-header-win.swift
@@ -1,0 +1,45 @@
+// REQUIRES: OS=windows-msvc
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -scan-dependencies -module-name Test -module-cache-path %t/clang-module-cache -O -module-load-mode prefer-serialized \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -scanner-module-validation \
+// RUN:   -I %t %t/test.swift -o %t/deps.json -auto-bridging-header-chaining -scanner-output-dir %t -import-objc-header %t/Bridging.h
+
+// RUN: %{python} %S/../../utils/swift-build-modules.py %swift_frontend_plain %t/deps.json -o %t/Test.cmd -b %t/header.cmd
+// RUN: %target-swift-frontend-plain @%t/header.cmd %t/Bridging.h -disable-implicit-swift-modules -O -o %t/bridging.pch
+
+// RUN: %target-swift-frontend-plain -module-name Test -O @%t/Test.cmd %t/test.swift \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
+// RUN:   -import-objc-header %t/Bridging.h -import-pch %t/bridging.pch \
+// RUN:   -emit-module -o %t/Test.swiftmodule
+
+// RUN: %target-swift-frontend -scan-dependencies -module-name User -O -module-load-mode prefer-serialized \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -scanner-module-validation \
+// RUN:   -I %t %t/user.swift -import-objc-header %t/Bridging.h -auto-bridging-header-chaining -scanner-output-dir %t \
+// RUN:   -o %t/deps2.json
+
+// RUN: %{python} %S/../../utils/swift-build-modules.py %swift_frontend_plain %t/deps2.json -o %t/User.cmd -b %t/header2.cmd
+
+// RUN: %target-swift-frontend-plain @%t/header2.cmd -disable-implicit-swift-modules -O -o %t/bridging2.pch
+
+// RUN: %target-swift-frontend-plain -module-name User -O \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
+// RUN:   -import-objc-header %t/Bridging.h -import-pch %t/bridging2.pch \
+// RUN:   @%t/User.cmd %t/user.swift \
+// RUN:   -emit-module -o %t/User.swiftmodule
+
+//--- test.swift
+public func test() {}
+
+//--- user.swift
+import Test
+
+
+//--- Bridging.h
+#include "Foo.h"
+int Bridge = 0;
+
+//--- Foo.h
+int Foo = 0;
+


### PR DESCRIPTION
Windows MSVC mode has a different #import meaning and it is not supported by clang. Use `#include` on windows instead.

This fixes scanning failure when bridging header chaining is happening on windows.

<!--
The main branch is now in convergence, which means major changes, such as large refactoring or new features, should be avoided. This strategy is intended to maintain the stability of the Swift 6.4 release leading up to the May 4th branch. For any work that requires broad changes or introduces new features, create a feature branch and open a draft pull request. All updates to the swiftlang/swift repository’s main branch require approval from the release managers. A pull request targeting swiftlang/swift will automatically add release managers. You can also contact them via @release-managers in the forum group.
-->

<!-- Please fill out the following form: --> 
- **Explanation**: Fix chaining bridging header on windows. 
  <!--
  A description of the changes. This can be brief, but it should be clear.
  -->
- **Scope**: Windows explicit module build only when a swift module that uses bridging header is importing another module with bridging header.
  <!--
  An assessment of the impact and importance of the changes. For example, can
  the changes break existing code?
  -->
- **Issues**: N/A
  <!--
  References to issues the changes resolve, if any.
  -->
- **Risk**: Low. This is a corner case with a trivial fix.
  <!--
  The (specific) risk to the release for taking the changes.
  -->
- **Testing**: unit test
  <!--
  The specific testing that has been done or needs to be done to further
  validate any impact of the changes.
  -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
