### PR TITLE
Test: ensure sending parameters of ObjC thunks are working

### DIFF
--- a/test/Interpreter/Inputs/objc_sending_execution.h
+++ b/test/Interpreter/Inputs/objc_sending_execution.h
@@ -1,0 +1,37 @@
+#import <Foundation/Foundation.h>
+
+@class Bar;
+@class Baz;
+@protocol FooDelegate;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface Foo: NSObject
+@property (weak, nullable) id <FooDelegate> delegate;
+- (NSString *)doSomething;
+@end
+
+@protocol FooDelegate <NSObject>
+- (NSString *)takingObject:(NSObject *)NS_SWIFT_SENDING object;
+
+- (NSObject * NS_SWIFT_SENDING)identityFn:(NSObject *)NS_SWIFT_SENDING object;
+@end
+
+NS_ASSUME_NONNULL_END
+
+// ----------------------------------------------------
+// From https://github.com/swiftlang/swift/issues/87659
+
+@class Payload;
+
+@interface Payload : NSObject
+@property (nonatomic, copy) NSString *name;
+@end
+
+NS_SWIFT_SENDABLE
+@protocol Handler <NSObject>
+- (void)handle:(NS_SWIFT_SENDING Payload *)value;
+@end
+
+@interface LegacyObjCHandler : NSObject <Handler>
+@end

--- a/test/Interpreter/Inputs/objc_sending_execution.m
+++ b/test/Interpreter/Inputs/objc_sending_execution.m
@@ -1,0 +1,29 @@
+
+#import "objc_sending_execution.h"
+
+@implementation Foo {
+  __weak id <FooDelegate> _delegate;
+}
+
+@synthesize delegate=_delegate;
+
+- (NSString *)doSomething {
+  NSObject *obj = [[NSObject alloc] init];
+  obj = [_delegate identityFn: obj];
+  return [_delegate takingObject: obj];
+}
+
+@end
+
+
+// ----------------------------------------------------
+// From https://github.com/swiftlang/swift/issues/87659
+
+@implementation Payload
+@end
+
+@implementation LegacyObjCHandler
+- (void)handle:(Payload *)value {
+    NSLog(@"LegacyObjCHandler received: %@", value.name);
+}
+@end

--- a/test/Interpreter/objc_sending_execution.swift
+++ b/test/Interpreter/objc_sending_execution.swift
@@ -1,0 +1,82 @@
+// RUN: %empty-directory(%t)
+//
+// RUN: %target-clang -fobjc-arc %S/Inputs/objc_sending_execution.m -c -o %t/objc_sending_execution.o
+// RUN: %target-build-swift -import-objc-header %S/Inputs/objc_sending_execution.h -Xlinker %t/objc_sending_execution.o %s -o %t/a.out
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out
+
+
+// ---------------------------------------------------
+// NOTE: Same as above, but with optimizations enabled
+
+// RUN: %empty-directory(%t)
+//
+// RUN: %target-clang -O3 -fobjc-arc %S/Inputs/objc_sending_execution.m -c -o %t/objc_sending_execution.o
+// RUN: %target-build-swift -O -import-objc-header %S/Inputs/objc_sending_execution.h -Xlinker %t/objc_sending_execution.o %s -o %t/a.out
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out
+
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+import Foundation
+import StdlibUnittest
+
+var ObjcSendingTestSuite = TestSuite("Sending")
+
+class MyDelegate: NSObject, FooDelegate {
+  func taking(_ object: sending NSObject) -> String {
+    print("in MyDelegate.taking")
+    return "hello! " + object.description
+  }
+
+  func identityFn(_ object: sending NSObject) -> sending NSObject {
+    print("in MyDelegate.identityFn")
+    return object
+  }
+}
+
+ObjcSendingTestSuite.test("ensure no double free") {
+  let foo = Foo()
+  let delegate = MyDelegate()
+  foo.delegate = delegate
+  let ans = foo.doSomething()
+  print(ans)
+  expectEqual(ans.contains("hello!"), true)
+  expectEqual(ans.contains("NSObject"), true)
+}
+
+
+// ----------------------------------------------------
+// From https://github.com/swiftlang/swift/issues/87659
+
+public final class SwiftHandler: NSObject, @unchecked Sendable, Handler {
+  public func handle(_ value: sending Payload) {
+    print("SwiftHandler received: \(value.name ?? "nil")")
+  }
+}
+func getHandler(useSwift: Bool) -> any Handler {
+  if useSwift {
+    return SwiftHandler()
+  } else {
+    return LegacyObjCHandler()
+  }
+}
+
+@inline(never)
+func entryPoint(useSwift: Bool) {
+  let handler: any Handler = getHandler(useSwift: useSwift)
+  let obj = Payload()
+  obj.name = "test-intent"
+  handler.handle(obj)
+}
+
+ObjcSendingTestSuite.test("Crasher from https://github.com/swiftlang/swift/issues/87659") {
+  MainActor.assumeIsolated {
+    entryPoint(useSwift: false)
+    entryPoint(useSwift: true)
+  }
+}
+
+
+runAllTests()

--- a/test/SILGen/Inputs/objc_sending.h
+++ b/test/SILGen/Inputs/objc_sending.h
@@ -1,0 +1,11 @@
+@import ObjectiveC;
+
+#define SWIFT_SENDABLE __attribute__((swift_attr("@Sendable")))
+#define SWIFT_SENDING __attribute__((swift_attr("sending")))
+
+SWIFT_SENDABLE
+@protocol ObjCHandlerWithSending <NSObject>
+- (void)handle:(NSObject * SWIFT_SENDING)value;
+
+- (NSObject* SWIFT_SENDING)identity:(NSObject * SWIFT_SENDING)value;
+@end

--- a/test/SILGen/objc_sending.swift
+++ b/test/SILGen/objc_sending.swift
@@ -1,0 +1,106 @@
+// RUN: %target-swift-emit-silgen(mock-sdk: %clang-importer-sdk) -module-name objc_sending -Xllvm -sil-print-types -import-objc-header %S/Inputs/objc_sending.h %s | %FileCheck %s
+// RUN: %target-swift-emit-sil(mock-sdk: %clang-importer-sdk) -sil-verify-all -module-name objc_sending -Xllvm -sil-print-types -import-objc-header %S/Inputs/objc_sending.h %s
+
+// REQUIRES: objc_interop
+
+import Foundation
+
+// ============================================================================
+// Swift method with `sending` witnessing an imported ObjC protocol requirement.
+
+public class Handler: NSObject, ObjCHandlerWithSending {
+  public func handle(_ value: sending NSObject) {}
+
+  // CHECK-LABEL: sil {{.*}}[ossa] @$s12objc_sending7HandlerC6handleyySo8NSObjectCnF : $@convention(method) (@sil_sending @owned NSObject, @guaranteed Handler) -> ()
+  // CHECK: bb0(%0 : @owned $NSObject, %1 : @guaranteed $Handler):
+
+  // The @objc thunk must receive the sending param as @unowned and retain it:
+
+  // CHECK-LABEL: sil private [thunk] [ossa] @$s12objc_sending7HandlerC6handleyySo8NSObjectCnFTo : $@convention(objc_method) (@sil_sending NSObject, Handler) -> () {
+  // CHECK: bb0([[SENDING_ARG:%.*]] : @unowned $NSObject, [[SELF_ARG:%.*]] : @unowned $Handler):
+  // CHECK-NEXT:   [[SENDING_COPY:%.*]] = copy_value [[SENDING_ARG]] : $NSObject
+  // CHECK-NEXT:   [[SELF_COPY:%.*]] = copy_value [[SELF_ARG]] : $Handler
+  // CHECK-NEXT:   [[SELF_BORROW:%.*]] = begin_borrow [[SELF_COPY]] : $Handler
+  // CHECK:        [[NATIVE_FN:%.*]] = function_ref @$s12objc_sending7HandlerC6handleyySo8NSObjectCnF : $@convention(method) (@sil_sending @owned NSObject, @guaranteed Handler) -> ()
+  // CHECK-NEXT:   apply [[NATIVE_FN]]([[SENDING_COPY]], [[SELF_BORROW]]) : $@convention(method) (@sil_sending @owned NSObject, @guaranteed Handler) -> ()
+  // CHECK-NEXT:   end_borrow [[SELF_BORROW]] : $Handler
+  // CHECK-NEXT:   destroy_value [[SELF_COPY]] : $Handler
+  // CHECK:      } // end sil function
+
+  public func identity(_ value: sending NSObject) -> sending NSObject { return value }
+
+  // CHECK-LABEL: sil {{.*}}[ossa] @$s12objc_sending7HandlerC8identityySo8NSObjectCAFnF : $@convention(method) (@sil_sending @owned NSObject, @guaranteed Handler) -> @sil_sending @owned NSObject {
+  // CHECK:         bb0(%0 : @owned $NSObject, %1 : @guaranteed $Handler):
+  // CHECK:      } // end sil function
+
+  // CHECK-LABEL: sil private [thunk] [ossa] @$s12objc_sending7HandlerC8identityySo8NSObjectCAFnFTo : $@convention(objc_method) (@sil_sending NSObject, Handler) -> @sil_sending @autoreleased NSObject {
+  // CHECK:         bb0(%0 : @unowned $NSObject, %1 : @unowned $Handler):
+  // CHECK:      } // end sil function
+}
+
+
+
+
+// =========================================================================================
+// Pure Swift @objc method with `sending` this should exercise ObjCSelectorFamilyConventions
+
+public class Processor: NSObject {
+  @objc public func process(_ value: sending NSObject) {}
+
+  // The native Swift entry point expects @sil_sending @owned.
+  // CHECK-LABEL: sil {{.*}}[ossa] @$s12objc_sending9ProcessorC7processyySo8NSObjectCnF : $@convention(method) (@sil_sending @owned NSObject, @guaranteed Processor) -> ()
+  // CHECK: bb0(%0 : @owned $NSObject, %1 : @guaranteed $Processor):
+  // CHECK:      } // end sil function
+
+
+  // CHECK-LABEL: sil private [thunk] [ossa] @$s12objc_sending9ProcessorC7processyySo8NSObjectCnFTo : $@convention(objc_method) (@sil_sending NSObject, Processor) -> () {
+  // CHECK: bb0([[SENDING_ARG:%.*]] : @unowned $NSObject, [[SELF_ARG:%.*]] : @unowned $Processor):
+  // CHECK-NEXT:   [[SENDING_COPY:%.*]] = copy_value [[SENDING_ARG]] : $NSObject
+  // CHECK-NEXT:   [[SELF_COPY:%.*]] = copy_value [[SELF_ARG]] : $Processor
+  // CHECK-NEXT:   [[SELF_BORROW:%.*]] = begin_borrow [[SELF_COPY]] : $Processor
+  // CHECK:        [[NATIVE_FN:%.*]] = function_ref @$s12objc_sending9ProcessorC7processyySo8NSObjectCnF : $@convention(method) (@sil_sending @owned NSObject, @guaranteed Processor) -> ()
+  // CHECK-NEXT:   apply [[NATIVE_FN]]([[SENDING_COPY]], [[SELF_BORROW]]) : $@convention(method) (@sil_sending @owned NSObject, @guaranteed Processor) -> ()
+  // CHECK-NEXT:   end_borrow [[SELF_BORROW]] : $Processor
+  // CHECK-NEXT:   destroy_value [[SELF_COPY]] : $Processor
+  // CHECK:      } // end sil function
+
+  @objc public func identity(_ value: sending NSObject) -> sending NSObject { return value }
+
+  // CHECK-LABEL: sil {{.*}}[ossa] @$s12objc_sending9ProcessorC8identityySo8NSObjectCAFnF : $@convention(method) (@sil_sending @owned NSObject, @guaranteed Processor) -> @sil_sending @owned NSObject {
+  // CHECK:         bb0(%0 : @owned $NSObject, %1 : @guaranteed $Processor):
+  // CHECK:      } // end sil function
+
+  // CHECK-LABEL: sil private [thunk] [ossa] @$s12objc_sending9ProcessorC8identityySo8NSObjectCAFnFTo : $@convention(objc_method) (@sil_sending NSObject, Processor) -> @sil_sending @autoreleased NSObject {
+  // CHECK:         bb0(%0 : @unowned $NSObject, %1 : @unowned $Processor):
+  // CHECK:      } // end sil function
+}
+
+
+
+
+@objc class SendingTest: NSObject {
+    @objc static func foo(_ object: sending Any) {}
+    // CHECK-LABEL: sil {{.*}}[ossa] @$s12objc_sending11SendingTestC3fooyyypnFZ : $@convention(method) (@sil_sending @in Any, @thick SendingTest.Type) -> () {
+    // CHECK:         bb0(%0 : $*Any, %1 : $@thick SendingTest.Type):
+    // CHECK:       } // end sil function
+
+    // CHECK-LABEL: sil private [thunk] [ossa] @$s12objc_sending11SendingTestC3fooyyypnFZTo : $@convention(objc_method) (@sil_sending AnyObject, @objc_metatype SendingTest.Type) -> () {
+    // CHECK:         bb0([[SENDING_ARG:%.*]] : @unowned $AnyObject, %1 : $@objc_metatype SendingTest.Type):
+    // CHECK:         [[SENDING_COPY:%.*]] = copy_value [[SENDING_ARG]] : $AnyObject
+    // CHECK:         unchecked_ref_cast [[SENDING_COPY]] : $AnyObject to $Optional<AnyObject>
+    // CHECK:         function_ref @$s12objc_sending11SendingTestC3fooyyypnFZ : $@convention(method) (@sil_sending @in Any, @thick SendingTest.Type) -> ()
+    // CHECK:       } // end sil function
+
+    @objc static func bar(_ object: sending NSObject) -> sending NSObject { return object }
+    // CHECK-LABEL: sil {{.*}}[ossa] @$s12objc_sending11SendingTestC3barySo8NSObjectCAFnFZ : $@convention(method) (@sil_sending @owned NSObject, @thick SendingTest.Type) -> @sil_sending @owned NSObject {
+    // CHECK: bb0(%0 : @owned $NSObject, %1 : $@thick SendingTest.Type):
+    // CHECK:      } // end sil function
+
+    // CHECK-LABEL: sil private [thunk] [ossa] @$s12objc_sending11SendingTestC3barySo8NSObjectCAFnFZTo : $@convention(objc_method) (@sil_sending NSObject, @objc_metatype SendingTest.Type) -> @sil_sending @autoreleased NSObject {
+    // CHECK:        bb0([[SENDING_ARG:%.*]] : @unowned $NSObject, %1 : $@objc_metatype SendingTest.Type):
+    // CHECK:        [[SENDING_COPY:%.*]] = copy_value [[SENDING_ARG]] : $NSObject
+    // CHECK:        [[NATIVE_FN:%.*]] = function_ref @$s12objc_sending11SendingTestC3barySo8NSObjectCAFnFZ : $@convention(method) (@sil_sending @owned NSObject, @thick SendingTest.Type) -> @sil_sending @owned NSObject
+    // CHECK:        [[RETVAL:%.*]] = apply [[NATIVE_FN]]([[SENDING_COPY]], {{.*}}) : $@convention(method) (@sil_sending @owned NSObject, @thick SendingTest.Type) -> @sil_sending @owned NSObject
+    // CHECK:        return [[RETVAL]] : $NSObject
+    // CHECK:      } // end sil function
+}


### PR DESCRIPTION
- **Explanation**: Adds testing to cover `sending` parameter convention interactions with ObjC.
- **Scope**:  There was a bug with `sending` and ObjC thunks leading to a potential double-free of objects. A recent change (https://github.com/swiftlang/swift/pull/87926) appears to have fixed that bug unintentionally. Thus, this PR, which subsumes https://github.com/swiftlang/swift/pull/87661, is meant to only add regression test coverage to ensure the `sending` bug is fixed.
- **Issues**: https://github.com/swiftlang/swift/issues/87659 and rdar://143019970
- **Risk**: None.
- **Testing**: That's all this is!
