### PR TITLE
[SE-0525] Initial implementation of `Convertible{To,From}Bytes` marker protocols

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -8405,8 +8405,17 @@ NOTE(add_generic_parameter_non_bitwise_copyable_conformance,none,
 ERROR(bitwise_copyable_outside_module,none,
       "conformance to 'BitwiseCopyable' must occur in the same module as %kind0",
       (const ValueDecl *))
+ERROR(convertible_to_bytes_outside_stdlib,none,
+      "type conforming to 'ConvertibleToBytes' must be defined in the standard library module",
+      (const ValueDecl *))
 ERROR(convertible_to_bytes_outside_module,none,
       "conformance to 'ConvertibleToBytes' must occur in the same module as %kind0",
+      (const ValueDecl *))
+ERROR(convertible_from_bytes_outside_stdlib,none,
+      "type conforming to 'ConvertibleFromBytes' must be defined in the standard library module",
+      (const ValueDecl *))
+ERROR(convertible_from_bytes_outside_module,none,
+      "conformance to 'ConvertibleFromBytes' must occur in the same module as %kind0",
       (const ValueDecl *))
 ERROR(suppress_inferrable_protocol_extension,none,
       "conformance to inferrable protocol %0 cannot be suppressed in an extension", (const ProtocolDecl *))

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -8404,6 +8404,9 @@ NOTE(add_generic_parameter_non_bitwise_copyable_conformance,none,
      (Type))
 ERROR(bitwise_copyable_outside_module,none,
       "conformance to 'BitwiseCopyable' must occur in the same module as %kind0",
+      (const ValueDecl *))
+ERROR(convertible_to_bytes_outside_module,none,
+      "conformance to 'ConvertibleToBytes' must occur in the same module as %kind0",
       (const ValueDecl *))
 ERROR(suppress_inferrable_protocol_extension,none,
       "conformance to inferrable protocol %0 cannot be suppressed in an extension", (const ProtocolDecl *))

--- a/include/swift/AST/KnownProtocols.def
+++ b/include/swift/AST/KnownProtocols.def
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -158,6 +158,9 @@ PROTOCOL(AsyncIteratorProtocol)
 
 PROTOCOL(BorrowingSequence)
 PROTOCOL(BorrowingIteratorProtocol)
+
+PROTOCOL(ConvertibleToBytes)
+PROTOCOL(ConvertibleFromBytes)
 
 PROTOCOL(FloatingPoint)
 

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2025 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -7469,6 +7469,8 @@ SpecialProtocol irgen::getSpecialProtocolID(ProtocolDecl *P) {
   case KnownProtocolKind::Escapable:
   case KnownProtocolKind::BitwiseCopyable:
   case KnownProtocolKind::SendableMetatype:
+  case KnownProtocolKind::ConvertibleToBytes:
+  case KnownProtocolKind::ConvertibleFromBytes:
     return SpecialProtocol::None;
   }
 

--- a/lib/Sema/CMakeLists.txt
+++ b/lib/Sema/CMakeLists.txt
@@ -75,6 +75,7 @@ add_swift_host_library(swiftSema STATIC
   TypeCheckExpr.cpp
   TypeCheckExprObjC.cpp
   TypeCheckEmbedded.cpp
+  TypeCheckFullyInhabited.cpp
   TypeCheckGeneric.cpp
   TypeCheckInvertible.cpp
   TypeCheckMacros.cpp

--- a/lib/Sema/TypeCheckFullyInhabited.cpp
+++ b/lib/Sema/TypeCheckFullyInhabited.cpp
@@ -1,8 +1,8 @@
-//===------ TypeFullyInhabited.cpp ----------------------------------------===//
+//===------ TypeCheckFullyInhabited.cpp -----------------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -15,37 +15,34 @@
 //===----------------------------------------------------------------------===//
 
 #include "TypeCheckFullyInhabited.h"
-#include "TypeCheckInvertible.h" // StorageVisitor
 #include "TypeChecker.h"
 #include "swift/AST/ASTContext.h"
-#include "swift/AST/Builtins.h"
-#include "swift/AST/ConformanceLookup.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/DiagnosticEngine.h"
-#include "swift/AST/Ownership.h"
 #include "swift/AST/TypeCheckRequests.h"
-#include "swift/AST/Types.h"
 #include "swift/Basic/Assertions.h"
-#include "swift/Basic/Defer.h"
 
 using namespace swift;
 
-bool checkFullyInhabitedSubConformance(ProtocolConformance *conformance,
-                                       KnownProtocolKind kind) {
+static void assertProtocolIdentity(ProtocolConformance *conformance,
+                                   KnownProtocolKind kind) {
   assert(conformance->getProtocol() ==
          conformance->getDeclContext()
              ->getParentModule()
              ->getASTContext()
              .getProtocol(kind));
+}
+
+static void convertibleToBytesConformance(ProtocolConformance *conformance) {
   auto conformanceDC = conformance->getDeclContext();
   auto nominal = conformance->getType()->getAnyNominal();
   if (!nominal)
-    return false;
+    return;
 
   // If this is an always-unavailable conformance, there's nothing to check.
   if (auto ext = dyn_cast<ExtensionDecl>(conformanceDC)) {
     if (ext->isUnavailable())
-      return false;
+      return;
   }
 
   // ConvertibleToBytes must be added in the same module or its overlay.
@@ -53,23 +50,63 @@ bool checkFullyInhabitedSubConformance(ProtocolConformance *conformance,
   if (!conformanceDecl->getModuleContext()->isSameModuleLookingThroughOverlays(
           nominal->getModuleContext())) {
     conformanceDecl->diagnose(diag::convertible_to_bytes_outside_module, nominal);
-    return true;
+    return;
   }
 
+  // Insert structural checking here:
+  // - all stored properties must also be `ConvertibleToBytes`.
+  // - there must be no padding.
+
+  // ConvertibleToBytes must (currently) be a conformance in the standard library.
   if (conformanceDecl->getDeclContext()->getParentModule()->isStdlibModule()) {
-    return true;
+    return;
+  }
+  conformanceDecl->diagnose(diag::convertible_to_bytes_outside_stdlib, nominal);
+}
+
+void swift::checkConvertibleToBytesConformance(ProtocolConformance *conformance) {
+  assertProtocolIdentity(conformance, KnownProtocolKind::ConvertibleToBytes);
+  convertibleToBytesConformance(conformance);
+}
+
+static void convertibleFromBytesConformance(ProtocolConformance *conformance) {
+  auto conformanceDC = conformance->getDeclContext();
+  auto nominal = conformance->getType()->getAnyNominal();
+  if (!nominal)
+    return;
+
+  // If this is an always-unavailable conformance, there's nothing to check.
+  if (auto ext = dyn_cast<ExtensionDecl>(conformanceDC)) {
+    if (ext->isUnavailable())
+      return;
   }
 
-  conformanceDecl->diagnose(diag::convertible_to_bytes_outside_module, nominal);
-  return false;
+  // ConvertibleFromBytes must be added in the same module or its overlay.
+  auto conformanceDecl = conformanceDC->getAsDecl();
+  if (!conformanceDecl->getModuleContext()->isSameModuleLookingThroughOverlays(
+          nominal->getModuleContext())) {
+    conformanceDecl->diagnose(diag::convertible_from_bytes_outside_module, nominal);
+    return;
+  }
+
+  // Insert structural checking here:
+  // - all stored properties must also be `ConvertibleFromBytes`.
+
+  // ConvertibleFromBytes is a valid conformance in the standard library.
+  if (conformanceDecl->getDeclContext()->getParentModule()->isStdlibModule()) {
+    return;
+  }
+
+  // Allow conformances outside the stdlib with @unchecked.
+  // if (auto *normal = conformance->getRootNormalConformance()) {
+  //   if (normal->isUnchecked()) {
+  //     return;
+  //   }
+  // }
+  conformanceDecl->diagnose(diag::convertible_from_bytes_outside_stdlib, nominal);
 }
 
-bool swift::checkConvertibleToBytesConformance(ProtocolConformance *conformance) {
-  return checkFullyInhabitedSubConformance(conformance,
-                                           KnownProtocolKind::ConvertibleToBytes);
-}
-
-bool swift::checkConvertibleFromBytesConformance(ProtocolConformance *conformance) {
-  return checkFullyInhabitedSubConformance(conformance,
-                                           KnownProtocolKind::ConvertibleFromBytes);
+void swift::checkConvertibleFromBytesConformance(ProtocolConformance *conformance) {
+  assertProtocolIdentity(conformance, KnownProtocolKind::ConvertibleFromBytes);
+  convertibleFromBytesConformance(conformance);
 }

--- a/lib/Sema/TypeCheckFullyInhabited.cpp
+++ b/lib/Sema/TypeCheckFullyInhabited.cpp
@@ -26,7 +26,7 @@ using namespace swift;
 
 static void assertProtocolIdentity(ProtocolConformance *conformance,
                                    KnownProtocolKind kind) {
-  assert(conformance->getProtocol() ==
+  ASSERT(conformance->getProtocol() ==
          conformance->getDeclContext()
              ->getParentModule()
              ->getASTContext()

--- a/lib/Sema/TypeCheckFullyInhabited.cpp
+++ b/lib/Sema/TypeCheckFullyInhabited.cpp
@@ -1,0 +1,75 @@
+//===------ TypeFullyInhabited.cpp ----------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// Semantic analysis for ConvertibleToBytes and ConvertibleFromBytes.
+//
+//===----------------------------------------------------------------------===//
+
+#include "TypeCheckFullyInhabited.h"
+#include "TypeCheckInvertible.h" // StorageVisitor
+#include "TypeChecker.h"
+#include "swift/AST/ASTContext.h"
+#include "swift/AST/Builtins.h"
+#include "swift/AST/ConformanceLookup.h"
+#include "swift/AST/Decl.h"
+#include "swift/AST/DiagnosticEngine.h"
+#include "swift/AST/Ownership.h"
+#include "swift/AST/TypeCheckRequests.h"
+#include "swift/AST/Types.h"
+#include "swift/Basic/Assertions.h"
+#include "swift/Basic/Defer.h"
+
+using namespace swift;
+
+bool checkFullyInhabitedSubConformance(ProtocolConformance *conformance,
+                                       KnownProtocolKind kind) {
+  assert(conformance->getProtocol() ==
+         conformance->getDeclContext()
+             ->getParentModule()
+             ->getASTContext()
+             .getProtocol(kind));
+  auto conformanceDC = conformance->getDeclContext();
+  auto nominal = conformance->getType()->getAnyNominal();
+  if (!nominal)
+    return false;
+
+  // If this is an always-unavailable conformance, there's nothing to check.
+  if (auto ext = dyn_cast<ExtensionDecl>(conformanceDC)) {
+    if (ext->isUnavailable())
+      return false;
+  }
+
+  // ConvertibleToBytes must be added in the same module or its overlay.
+  auto conformanceDecl = conformanceDC->getAsDecl();
+  if (!conformanceDecl->getModuleContext()->isSameModuleLookingThroughOverlays(
+          nominal->getModuleContext())) {
+    conformanceDecl->diagnose(diag::convertible_to_bytes_outside_module, nominal);
+    return true;
+  }
+
+  if (conformanceDecl->getDeclContext()->getParentModule()->isStdlibModule()) {
+    return true;
+  }
+
+  conformanceDecl->diagnose(diag::convertible_to_bytes_outside_module, nominal);
+  return false;
+}
+
+bool swift::checkConvertibleToBytesConformance(ProtocolConformance *conformance) {
+  return checkFullyInhabitedSubConformance(conformance,
+                                           KnownProtocolKind::ConvertibleToBytes);
+}
+
+bool swift::checkConvertibleFromBytesConformance(ProtocolConformance *conformance) {
+  return checkFullyInhabitedSubConformance(conformance,
+                                           KnownProtocolKind::ConvertibleFromBytes);
+}

--- a/lib/Sema/TypeCheckFullyInhabited.h
+++ b/lib/Sema/TypeCheckFullyInhabited.h
@@ -1,14 +1,27 @@
-#ifndef SWIFT_SEMA_TYPEFULLYINHABITED_H
-#define SWIFT_SEMA_TYPEFULLYINHABITED_H
+//===------ TypeCheckFullyInhabited.h -------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// Semantic analysis for ConvertibleToBytes and ConvertibleFromBytes.
+//
+//===----------------------------------------------------------------------===//
 
-#include "swift/AST/ProtocolConformance.h"
-#include "swift/AST/TypeCheckRequests.h"
+#ifndef SWIFT_SEMA_TYPECHECKFULLYINHABITED_H
+#define SWIFT_SEMA_TYPECHECKFULLYINHABITED_H
 
 namespace swift {
 class ProtocolConformance;
 
-bool checkConvertibleToBytesConformance(ProtocolConformance *conformance);
-bool checkConvertibleFromBytesConformance(ProtocolConformance *conformance);
+void checkConvertibleToBytesConformance(ProtocolConformance *conformance);
+void checkConvertibleFromBytesConformance(ProtocolConformance *conformance);
 } // end namespace swift
 
-#endif // !SWIFT_SEMA_TYPEFULLYINHABITED_H
+#endif // !SWIFT_SEMA_TYPECHECKFULLYINHABITED_H

--- a/lib/Sema/TypeCheckFullyInhabited.h
+++ b/lib/Sema/TypeCheckFullyInhabited.h
@@ -1,0 +1,14 @@
+#ifndef SWIFT_SEMA_TYPEFULLYINHABITED_H
+#define SWIFT_SEMA_TYPEFULLYINHABITED_H
+
+#include "swift/AST/ProtocolConformance.h"
+#include "swift/AST/TypeCheckRequests.h"
+
+namespace swift {
+class ProtocolConformance;
+
+bool checkConvertibleToBytesConformance(ProtocolConformance *conformance);
+bool checkConvertibleFromBytesConformance(ProtocolConformance *conformance);
+} // end namespace swift
+
+#endif // !SWIFT_SEMA_TYPEFULLYINHABITED_H

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2025 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -25,6 +25,7 @@
 #include "TypeCheckConcurrency.h"
 #include "TypeCheckDistributed.h"
 #include "TypeCheckEffects.h"
+#include "TypeCheckFullyInhabited.h"
 #include "TypeCheckInvertible.h"
 #include "TypeCheckObjC.h"
 #include "TypeCheckUnsafe.h"
@@ -6881,6 +6882,14 @@ void TypeChecker::checkConformancesInContext(IterableDeclContext *idc) {
         checkBitwiseCopyableConformance(
             conformance, /*isImplicit=*/conformance->getSourceKind() ==
                              ConformanceEntryKind::Synthesized);
+        break;
+      }
+      case KnownProtocolKind::ConvertibleToBytes: {
+        checkConvertibleToBytesConformance(conformance);
+        break;
+      }
+      case KnownProtocolKind::ConvertibleFromBytes: {
+        checkConvertibleFromBytesConformance(conformance);
         break;
       }
       default:

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -2456,8 +2456,9 @@ static void diagnoseConformanceImpliedByConditionalConformance(
 /// to the given protocol. This should return true when @unchecked can be
 /// used to disable those semantic checks.
 static bool hasAdditionalSemanticChecks(ProtocolDecl *proto) {
-  return proto->isSpecificProtocol(KnownProtocolKind::Sendable) ||
-      proto->isSpecificProtocol(KnownProtocolKind::SendableMetatype);
+  return proto->isSpecificProtocol(KnownProtocolKind::Sendable)
+      || proto->isSpecificProtocol(KnownProtocolKind::SendableMetatype)
+      || proto->isSpecificProtocol(KnownProtocolKind::ConvertibleFromBytes);
 }
 
 /// Determine whether a conformance to this protocol can be determined at

--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -93,6 +93,7 @@ split_embedded_sources(
   EMBEDDED Flatten.swift
   EMBEDDED FloatingPoint.swift
   EMBEDDED FloatingPointRandom.swift
+  EMBEDDED FullyInhabited.swift
   EMBEDDED HashTable.swift
   EMBEDDED Hashable.swift
   EMBEDDED Hasher.swift

--- a/stdlib/public/core/FullyInhabited.swift
+++ b/stdlib/public/core/FullyInhabited.swift
@@ -1,0 +1,104 @@
+//===--- FullyInhabited.swift ---------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// A protocol for types whose memory can safely be read as individual raw bytes.
+///
+/// A type can conform to ConvertibleToBytes if its memory representation
+/// includes no padding. The sum of the size of its stored properties must be
+/// equal to its stride.
+///
+/// A type that conforms to ConvertibleToBytes must have:
+/// * one or more stored properties,
+/// * all of its stored properties have a type which conforms to
+///   `ConvertibleToBytes`,
+/// * its stored properties are stored contiguously in memory, with no padding,
+/// * none of its values disregards a subset of its bytes, making most enums
+///   ineligible.
+@_marker public protocol ConvertibleToBytes: Copyable {}
+
+/// A protocol for types whose memory can safely be populated from raw bytes,
+/// resulting in a valid instance.
+///
+/// A type can conform to ConvertibleFromBytes if every bit pattern for
+/// every byte of its stored properties is valid. Note that this allows
+/// conformances for types with internal or trailing padding.
+/// A conformer to ConvertibleFromBytes must not have semantic constraints
+/// on the values of its stored properties.
+/// All its stored properties must themselves conform to ConvertibleFromBytes.
+@_marker public protocol ConvertibleFromBytes: BitwiseCopyable {}
+
+/// A protocol for types whose memory can safely be written as or read from
+/// raw bytes.
+public typealias FullyInhabited = ConvertibleToBytes & ConvertibleFromBytes
+
+extension UInt8:   ConvertibleToBytes, ConvertibleFromBytes {}
+extension Int8:    ConvertibleToBytes, ConvertibleFromBytes {}
+extension UInt16:  ConvertibleToBytes, ConvertibleFromBytes {}
+extension Int16:   ConvertibleToBytes, ConvertibleFromBytes {}
+extension UInt32:  ConvertibleToBytes, ConvertibleFromBytes {}
+extension Int32:   ConvertibleToBytes, ConvertibleFromBytes {}
+extension UInt64:  ConvertibleToBytes, ConvertibleFromBytes {}
+extension Int64:   ConvertibleToBytes, ConvertibleFromBytes {}
+extension UInt:    ConvertibleToBytes, ConvertibleFromBytes {}
+extension Int:     ConvertibleToBytes, ConvertibleFromBytes {}
+
+@available(SwiftStdlib 6.0, *)
+extension UInt128: ConvertibleToBytes, ConvertibleFromBytes {}
+@available(SwiftStdlib 6.0, *)
+extension Int128:  ConvertibleToBytes, ConvertibleFromBytes {}
+
+//extension Float16: ConvertibleToBytes, ConvertibleFromBytes {}
+extension Float32: ConvertibleToBytes, ConvertibleFromBytes {} // `Float`
+extension Float64: ConvertibleToBytes, ConvertibleFromBytes {} // `Double`
+
+@available(StdlibDeploymentTarget 5.7, *)
+extension Duration: ConvertibleToBytes, ConvertibleFromBytes {}
+
+@available(SwiftStdlib 6.2, *)
+extension InlineArray: ConvertibleToBytes
+  where Element: ConvertibleToBytes {}
+@available(SwiftStdlib 6.2, *)
+extension InlineArray: ConvertibleFromBytes
+  where Element: ConvertibleFromBytes {}
+
+extension CollectionOfOne: ConvertibleToBytes
+  where Element: ConvertibleToBytes {}
+extension CollectionOfOne: ConvertibleFromBytes
+  where Element: ConvertibleFromBytes {}
+
+extension ClosedRange: ConvertibleToBytes
+  where Bound: ConvertibleToBytes {}
+extension Range: ConvertibleToBytes
+  where Bound: ConvertibleToBytes {}
+
+extension PartialRangeFrom: ConvertibleToBytes
+  where Bound: ConvertibleToBytes {}
+extension PartialRangeFrom.Iterator: ConvertibleToBytes
+  where Bound: ConvertibleToBytes {}
+extension PartialRangeThrough: ConvertibleToBytes
+  where Bound: ConvertibleToBytes {}
+extension PartialRangeUpTo: ConvertibleToBytes
+  where Bound: ConvertibleToBytes {}
+
+extension Bool: ConvertibleToBytes {}
+extension ObjectIdentifier: ConvertibleToBytes {}
+
+extension UnsafePointer: ConvertibleToBytes {}
+extension UnsafeMutablePointer: ConvertibleToBytes {}
+extension UnsafeRawPointer: ConvertibleToBytes {}
+extension UnsafeMutableRawPointer: ConvertibleToBytes {}
+extension OpaquePointer: ConvertibleToBytes {}
+
+extension UnsafeBufferPointer: ConvertibleToBytes {}
+extension UnsafeMutableBufferPointer: ConvertibleToBytes {}
+extension UnsafeRawBufferPointer: ConvertibleToBytes {}
+extension UnsafeMutableRawBufferPointer: ConvertibleToBytes {}

--- a/stdlib/public/core/GroupInfo.json
+++ b/stdlib/public/core/GroupInfo.json
@@ -268,6 +268,7 @@
     "Equatable.swift",
     "Comparable.swift",
     "Codable.swift",
+    "FullyInhabited.swift",
     "LegacyABI.swift",
     "MigrationSupport.swift",
     "PtrAuth.swift",

--- a/test/Sema/fully_inhabited.swift
+++ b/test/Sema/fully_inhabited.swift
@@ -1,0 +1,54 @@
+// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated \
+// RUN:     -disable-availability-checking                      \
+// RUN:     -enable-builtin-module                              \
+// RUN:     -debug-diagnostic-names
+
+// Test conformances for non-stdlib types
+
+func load1<T: ConvertibleFromBytes>(as: T.Type = T.self) -> T { fatalError() }
+func store1<T: ConvertibleToBytes>(_ t: T) {}
+
+class C1_Implicit {}
+
+func storeC1_Implicit(_ c: C1_Implicit) { store1(c) } // expected-error {{type_does_not_conform_decl_owner}}
+                                                      // expected-note@-5 {{where_requirement_failure_one_subst}}
+
+func loadC1_Implicit() -> C1_Implicit { load1() } // expected-error {{type_does_not_conform_decl_owner}}
+                                                  // expected-note@-9 {{where_requirement_failure_one_subst}}
+
+struct A1: ConvertibleToBytes { var a: Int } // expected-error {{convertible_to_bytes_outside_stdlib}}
+
+struct B1 { var a, b: Int }
+extension B1: ConvertibleFromBytes {} // expected-error {{convertible_from_bytes_outside_stdlib}}
+
+struct C1 { var a: Int16 }
+@available(*, unavailable) extension C1: ConvertibleToBytes {}   // no diagnostic
+@available(*, unavailable) extension C1: ConvertibleFromBytes {} // no diagnostic
+
+struct D1 { var a, b: Int }
+extension D1: BitwiseCopyable {}
+extension D1: @unchecked ConvertibleToBytes {}   // expected-warning {{unchecked_conformance_not_special}}
+                                                 // expected-error@-1 {{convertible_to_bytes_outside_stdlib}}
+extension D1: @unchecked ConvertibleFromBytes {} // expected-error {{convertible_from_bytes_outside_stdlib}}
+
+//struct E1: ~Copyable { var a, b: Int }
+//extension E1: ConvertibleToBytes {}
+
+//struct F1 { var a, b: Int }
+//@available(*, unavailable) extension F1: BitwiseCopyable {}
+//extension F1: ConvertibleFromBytes {}
+
+// Test conformances of stdlib types
+
+func load2<T: ConvertibleFromBytes>(as: T.Type = T.self) -> T { fatalError() }
+func loadUInt64() -> UInt64 { load2() }
+
+func storeUInt64(_ i: UInt64) { store2(i) }
+func store2<T: ConvertibleToBytes>(_ t: T) {}
+
+func roundTrip2<T: FullyInhabited>(_ t: T) -> T { store2(t); return load2() }
+func roundTripInt32(_ i: Int32) -> Int32 { roundTrip2(i) }
+
+extension ManagedBuffer: @retroactive ConvertibleToBytes {}   // expected-error {{convertible_to_bytes_outside_module}}
+extension ManagedBuffer: @retroactive ConvertibleFromBytes {} // expected-error {{convertible_from_bytes_outside_module}}
+                                                              // expected-error@-1 {{bitwise_copyable_outside_module}}

--- a/test/api-digester/Outputs/dump-module/cake-abi.json
+++ b/test/api-digester/Outputs/dump-module/cake-abi.json
@@ -2099,6 +2099,20 @@
           },
           {
             "kind": "Conformance",
+            "name": "ConvertibleFromBytes",
+            "printedName": "ConvertibleFromBytes",
+            "usr": "s:s20ConvertibleFromBytesP",
+            "mangledName": "$ss20ConvertibleFromBytesP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "ConvertibleToBytes",
+            "printedName": "ConvertibleToBytes",
+            "usr": "s:s18ConvertibleToBytesP",
+            "mangledName": "$ss18ConvertibleToBytesP"
+          },
+          {
+            "kind": "Conformance",
             "name": "Copyable",
             "printedName": "Copyable",
             "usr": "s:s8CopyableP",

--- a/test/api-digester/Outputs/dump-module/cake.json
+++ b/test/api-digester/Outputs/dump-module/cake.json
@@ -1986,6 +1986,20 @@
           },
           {
             "kind": "Conformance",
+            "name": "ConvertibleFromBytes",
+            "printedName": "ConvertibleFromBytes",
+            "usr": "s:s20ConvertibleFromBytesP",
+            "mangledName": "$ss20ConvertibleFromBytesP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "ConvertibleToBytes",
+            "printedName": "ConvertibleToBytes",
+            "usr": "s:s18ConvertibleToBytesP",
+            "mangledName": "$ss18ConvertibleToBytesP"
+          },
+          {
+            "kind": "Conformance",
             "name": "Copyable",
             "printedName": "Copyable",
             "usr": "s:s8CopyableP",


### PR DESCRIPTION
Implements the compiler side of SE-0525 "Safe loading API for `RawSpan`" ([proposal document](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0525-rawspan-safe-loading-api.md)), recognizing `ConvertibleToBytes` and `ConvertibleFromBytes` as special. This implementation prevents conformances from outside the standard library; structural checking will be added in a later PR.

- **Explanation**:
Implements the compiler side of SE-0525 "Safe loading API for `RawSpan`", recognizing `ConvertibleToBytes` and `ConvertibleFromBytes` as special.

- **Scope**:
The changes affect parsing for new code that adds conformances to `ConvertibleToBytes` and `ConvertibleFromBytes`.

- **Issues**:
Addresses rdar://175794023. (The library changes are in a [separate PR](https://github.com/swiftlang/swift/pull/88702).)

- **Risk**:
This could break code that has declared protocols of the same name.

- **Testing**:
Adds "test/Sema/fully_inhabited.swift".

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
