### PR TITLE
Diagnose overloaded function ref ambiguity in argument position

### DIFF
--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -2526,6 +2526,7 @@ public:
   unsigned getParamIdx() const;
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override;
 
   static AllowArgumentMismatch *create(ConstraintSystem &cs, Type argType,
                                        Type paramType,

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -1954,6 +1954,69 @@ unsigned AllowArgumentMismatch::getParamIdx() const {
   return elt.getParamIdx();
 }
 
+bool AllowArgumentMismatch::diagnoseForAmbiguity(
+    CommonFixesArray commonFixes) const {
+  if (ContextualMismatch::diagnoseForAmbiguity(commonFixes))
+    return true;
+
+  auto *locator = getLocator();
+  auto argConv = locator->getLastElementAs<LocatorPathElt::ApplyArgToParam>();
+  if (!argConv)
+    return false;
+
+  auto getExpectedType =
+      [](const std::pair<const Solution *, const ConstraintFix *> &entry)
+      -> Type {
+    auto &solution = *entry.first;
+    auto *fix = static_cast<const AllowArgumentMismatch *>(entry.second);
+    return solution.simplifyType(fix->getToType());
+  };
+
+  auto expectedType = getExpectedType(commonFixes.front());
+  // Only collapse this ambiguity when every solution is trying to satisfy the
+  // same outer argument expectation e.g. `degrees(open)`. If candidate
+  // overloads have different parameter types, a single diagnostic would be
+  // misleading and the generic ambiguity path should handle it instead.
+  if (!llvm::all_of(
+          commonFixes,
+          [&](const std::pair<const Solution *, const ConstraintFix *> &entry) {
+            return expectedType->isEqual(getExpectedType(entry));
+          })) {
+    return false;
+  }
+
+  auto &cs = getConstraintSystem();
+  auto &DE = cs.getASTContext().Diags;
+  auto &solution = *commonFixes.front().first;
+
+  auto *argLoc = cs.getConstraintLocator(simplifyLocatorToAnchor(locator));
+  auto overload =
+      solution.getOverloadChoiceIfAvailable(solution.getCalleeLocator(argLoc));
+  if (!overload)
+    return false;
+
+  auto name = overload->choice.getName().getBaseName();
+  DE.diagnose(getLoc(getAnchor()), diag::no_candidates_match_argument_type,
+              name.userFacingName(), expectedType, argConv->getParamIdx());
+
+  for (const auto &entry : commonFixes) {
+    auto &solution = *entry.first;
+    auto overload =
+        solution.getOverloadChoiceIfAvailable(solution.getCalleeLocator(argLoc));
+
+    if (!(overload && overload->choice.isDecl()))
+      continue;
+
+    auto *decl = overload->choice.getDecl();
+    if (decl->getLoc().isValid()) {
+      DE.diagnose(decl, diag::found_candidate_type,
+                  solution.simplifyType(overload->adjustedOpenedType));
+    }
+  }
+
+  return true;
+}
+
 bool AllowArgumentMismatch::diagnose(const Solution &solution,
                                      bool asNote) const {
   ArgumentMismatchFailure failure(solution, getFromType(), getToType(),

--- a/test/Sema/diag_ambiguous_overloads.swift
+++ b/test/Sema/diag_ambiguous_overloads.swift
@@ -163,6 +163,13 @@ do {
 
   f2(f1) // expected-error {{no 'f1' candidates produce the expected type '(String) -> Void' for parameter #0}}
 }
+do {
+  func `open`(_ p: Int) {} // expected-note {{found candidate with type '(Int) -> ()'}}
+  func `open`(_ p: Bool) {} // expected-note {{found candidate with type '(Bool) -> ()'}}
+  func degrees(_ value: Int) {}
+
+  degrees(open) // expected-error {{no 'open' candidates produce the expected type 'Int' for parameter #0}}
+}
 
 // https://forums.swift.org/t/1-x-type-inference/69417/15
 protocol N { associatedtype D }


### PR DESCRIPTION
I was looking at #61039 and this seems to come from the ambiguity-with-fixes path not handling one specific overloaded function reference case.

With code like:

```swift
func `open`(_: Int) {}
func `open`(_: Bool) {}

func degrees(_: Int) {}
degrees(open)
```

both `open` overloads end up with an `AllowArgumentMismatch` fix, but we only diagnose the ambiguity if the contextual mismatch types collapse to the same source/destination pair. In this case the expected outer argument type is the same, but the candidate function reference types differ, so we end up falling through to `failed to produce diagnostic for expression`.

What this changes:

- adds an ambiguity diagnostic path for `AllowArgumentMismatch` in this shape
- reuses the existing `no_candidates_match_argument_type` diagnostic
- adds a regression test for the `degrees(open)` case

I haven’t run the full Swift test suite locally yet.
