### PR TITLE
Avoid unnecessary recomputation of DominanceInfo during SIL verification

### DIFF
--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -43,6 +43,7 @@ class BasicBlockBitfield;
 class NodeBitfield;
 class OperandBitfield;
 class CalleeCache;
+class DominanceInfo;
 class SILTypeProperties;
 class SILUndef;
 
@@ -1741,14 +1742,15 @@ public:
   /// verify - Run the SIL verifier to make sure that the SILFunction follows
   /// invariants.
   void verify(CalleeCache *calleeCache = nullptr,
-              bool SingleFunction = true,
-              bool isCompleteOSSA = true,
+              DominanceInfo *dominanceInfo = nullptr,
+              bool SingleFunction = true, bool isCompleteOSSA = true,
               bool checkLinearLifetime = true) const;
 
   /// Run the SIL verifier without assuming OSSA lifetimes end at dead end
   /// blocks.
   void verifyIncompleteOSSA() const {
-    verify(/*calleeCache*/nullptr, /*SingleFunction=*/true, /*completeOSSALifetimes=*/false);
+    verify(/*calleeCache*/ nullptr, /*dominanceInfo=*/nullptr,
+           /*SingleFunction=*/true, /*completeOSSALifetimes=*/false);
   }
 
   /// Verifies the lifetime of memory locations in the function.

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -1053,6 +1053,7 @@ class SILVerifier : public SILVerifierBase<SILVerifier> {
   ModuleDecl *M;
   const SILFunction &F;
   CalleeCache *calleeCache;
+  DominanceInfo *Dominance;
   SILFunctionConventions fnConv;
   Lowering::TypeConverter &TC;
   InstructionIndices instIndices;
@@ -1148,7 +1149,7 @@ public:
 
 private:
   VerifierErrorEmitter ErrorEmitter;
-  std::unique_ptr<DominanceInfo> Dominance;
+  std::unique_ptr<DominanceInfo> LocalDominance = nullptr;
 
   /// TODO: LifetimeCompletion: Remove.
   std::shared_ptr<DeadEndBlocks> DEBlocks;
@@ -1420,14 +1421,13 @@ public:
   }
 
   SILVerifier(const SILFunction &F, CalleeCache *calleeCache,
-              bool SingleFunction, bool checkLinearLifetime)
-      : M(F.getModule().getSwiftModule()), F(F),
-        calleeCache(calleeCache),
-        fnConv(F.getConventionsInContext()), TC(F.getModule().Types),
-        instIndices(const_cast<SILFunction *>(&F)),
+              DominanceInfo *dominanceInfo = nullptr,
+              bool SingleFunction = true, bool checkLinearLifetime = true)
+      : M(F.getModule().getSwiftModule()), F(F), calleeCache(calleeCache),
+        Dominance(dominanceInfo), fnConv(F.getConventionsInContext()),
+        TC(F.getModule().Types), instIndices(const_cast<SILFunction *>(&F)),
         SingleFunction(SingleFunction),
-        checkLinearLifetime(checkLinearLifetime),
-        Dominance(nullptr) {
+        checkLinearLifetime(checkLinearLifetime) {
     if (F.isExternalDeclaration())
       return;
 
@@ -1439,7 +1439,10 @@ public:
               "Basic blocks must end with a terminator instruction");
     }
 
-    Dominance.reset(new DominanceInfo(const_cast<SILFunction *>(&F)));
+    if (!Dominance) {
+      LocalDominance.reset(new DominanceInfo(const_cast<SILFunction *>(&F)));
+      Dominance = LocalDominance.get();
+    }
 
     auto *DebugScope = F.getDebugScope();
     require(DebugScope, "All SIL functions must have a debug scope");
@@ -7550,7 +7553,7 @@ static bool verificationEnabled(const SILModule &M) {
 
 /// verify - Run the SIL verifier to make sure that the SILFunction follows
 /// invariants.
-void SILFunction::verify(CalleeCache *calleeCache,
+void SILFunction::verify(CalleeCache *calleeCache, DominanceInfo *dominanceInfo,
                          bool SingleFunction, bool isCompleteOSSA,
                          bool checkLinearLifetime) const {
   if (!verificationEnabled(getModule()))
@@ -7563,7 +7566,8 @@ void SILFunction::verify(CalleeCache *calleeCache,
   // Please put all checks in visitSILFunction in SILVerifier, not here. This
   // ensures that the pretty stack trace in the verifier is included with the
   // back trace when the verifier crashes.
-  SILVerifier verifier(*this, calleeCache, SingleFunction, checkLinearLifetime);
+  SILVerifier verifier(*this, calleeCache, dominanceInfo, SingleFunction,
+                       checkLinearLifetime);
   verifier.verify(isCompleteOSSA);
 }
 
@@ -7572,8 +7576,10 @@ void SILFunction::verifyCriticalEdges() const {
     return;
 
   SILVerifier(*this, /*calleeCache=*/nullptr,
-                     /*SingleFunction=*/true,
-                     /*checkLinearLifetime=*/ false).verifyBranches(this);
+              /*dominanceInfo=*/nullptr,
+              /*SingleFunction=*/true,
+              /*checkLinearLifetime=*/false)
+      .verifyBranches(this);
 }
 
 /// Validate that all SILUndef in \p f have f as a parent.
@@ -7721,8 +7727,9 @@ void SILVTable::verify(const SILModule &M) const {
       // function must be compatible with being used as the requirement
       // type.
       SILVerifier(*entry.getImplementation(), /*calleeCache=*/nullptr,
-                                              /*SingleFunction=*/true,
-                                              /*checkLinearLifetime=*/ false)
+                  /*dominanceInfo=*/nullptr,
+                  /*SingleFunction=*/true,
+                  /*checkLinearLifetime=*/false)
           .requireABICompatibleFunctionTypes(
               entry.getImplementation()->getLoweredFunctionType(),
               baseInfo.getSILType().castTo<SILFunctionType>(),
@@ -7833,6 +7840,7 @@ void SILWitnessTable::verify(const SILModule &mod) const {
       }
 
       SILVerifier verifier(*witnessFunction, /*calleeCache=*/nullptr,
+                           /*dominanceInfo*/ nullptr,
                            /*SingleFunction=*/true,
                            /*checkLinearLifetime=*/false);
       SILVerifier::VerifierErrorEmitterGuard guard(&verifier, this);
@@ -7885,6 +7893,7 @@ void SILDefaultWitnessTable::verify(const SILModule &mod) const {
       }
 
       SILVerifier(*witnessFunction, /*calleeCache=*/nullptr,
+                  /*dominanceInfo=*/nullptr,
                   /*SingleFunction=*/true,
                   /*checkLinearLifetime=*/false)
           .requireABICompatibleFunctionTypes(
@@ -7945,7 +7954,8 @@ void SILModule::verify(CalleeCache *calleeCache,
       llvm::errs() << "Symbol redefined: " << f.getName() << "!\n";
       assert(false && "triggering standard assertion failure routine");
     }
-    f.verify(calleeCache, /*singleFunction*/ false, isCompleteOSSA, checkLinearLifetime);
+    f.verify(calleeCache, /*dominanceInfo=*/nullptr, /*singleFunction*/ false,
+             isCompleteOSSA, checkLinearLifetime);
   }
 
   // Check all globals.

--- a/lib/SILOptimizer/PassManager/PassManager.cpp
+++ b/lib/SILOptimizer/PassManager/PassManager.cpp
@@ -24,6 +24,7 @@
 #include "swift/SIL/SILFunction.h"
 #include "swift/SIL/SILModule.h"
 #include "swift/SILOptimizer/Analysis/BasicCalleeAnalysis.h"
+#include "swift/SILOptimizer/Analysis/DominanceAnalysis.h"
 #include "swift/SILOptimizer/Analysis/FunctionOrder.h"
 #include "swift/SILOptimizer/PassManager/PrettyStackTrace.h"
 #include "swift/SILOptimizer/PassManager/Transforms.h"
@@ -33,11 +34,11 @@
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/Statistic.h"
 #include "llvm/ADT/StringSwitch.h"
+#include "llvm/Support/Casting.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/GraphWriter.h"
 #include "llvm/Support/ManagedStatic.h"
-#include "llvm/Support/Casting.h"
 #include <fstream>
 
 #ifndef SWIFT_ENABLE_SWIFT_IN_SWIFT
@@ -684,7 +685,8 @@ void SILPassManager::runPassOnFunction(unsigned TransIdx, SILFunction *F) {
       (SILVerifyAroundPass.end() != std::find_if(SILVerifyAroundPass.begin(),
                                                  SILVerifyAroundPass.end(),
                                                  MatchFun))) {
-    F->verify(getAnalysis<BasicCalleeAnalysis>()->getCalleeCache());
+    F->verify(getAnalysis<BasicCalleeAnalysis>()->getCalleeCache(),
+              getAnalysis<DominanceAnalysis>()->get(F));
     verifyAnalyses();
     runSwiftFunctionVerification(F);
   }
@@ -794,7 +796,8 @@ void SILPassManager::runPassOnFunction(unsigned TransIdx, SILFunction *F) {
 
   if (getOptions().VerifyAll &&
       (CurrentPassHasInvalidated || SILVerifyWithoutInvalidation)) {
-    F->verify(getAnalysis<BasicCalleeAnalysis>()->getCalleeCache());
+    F->verify(getAnalysis<BasicCalleeAnalysis>()->getCalleeCache(),
+              getAnalysis<DominanceAnalysis>()->get(F));
     verifyAnalyses(F);
     runSwiftFunctionVerification(F);
   } else if (getOptions().VerifyOwnershipAll &&
@@ -807,7 +810,8 @@ void SILPassManager::runPassOnFunction(unsigned TransIdx, SILFunction *F) {
         (SILVerifyAroundPass.end() != std::find_if(SILVerifyAroundPass.begin(),
                                                    SILVerifyAroundPass.end(),
                                                    MatchFun))) {
-      F->verify(getAnalysis<BasicCalleeAnalysis>()->getCalleeCache());
+      F->verify(getAnalysis<BasicCalleeAnalysis>()->getCalleeCache(),
+                getAnalysis<DominanceAnalysis>()->get(F));
       verifyAnalyses();
       runSwiftFunctionVerification(F);
     }
@@ -1168,7 +1172,8 @@ void SILPassManager::addFunctionToWorklist(SILFunction *F,
     // this function to the pass manager to ensure that we perform this
     // verification.
     if (getOptions().VerifyAll) {
-      F->verify(getAnalysis<BasicCalleeAnalysis>()->getCalleeCache());
+      F->verify(getAnalysis<BasicCalleeAnalysis>()->getCalleeCache(),
+                getAnalysis<DominanceAnalysis>()->get(F));
     }
 
     NewLevel = DerivationLevels[DerivedFrom] + 1;


### PR DESCRIPTION
- **Explanation**: Previously, the SILVerifier always recomputed DominanceInfo for every function it verified. This is unnecesscary if previous passes have not invalidated the analysis. Query DominanceInfo from SIL's analysis infrastructure and pass that for verification. This speeds up `-sil-verify-all` builds of standard library around 10% and has the potential to speed up macos CI testing (did not measure).

- **Scope**: Affects SIL verification
- **Issues**: TBD
- **Risk**: Low
- **Testing**: CI testing