### PR TITLE
Fix AccessEnforcementOpts; miscompile; incorrect address projection

### DIFF
--- a/lib/SILOptimizer/Transforms/AccessEnforcementOpts.cpp
+++ b/lib/SILOptimizer/Transforms/AccessEnforcementOpts.cpp
@@ -990,6 +990,10 @@ canMergeBegin(PostDominanceInfo *postDomTree,
   return true;
 }
 
+static bool isDirectBaseAccess(BeginAccessInst *beginAccess) {
+  return beginAccess->getSource() == getAccessBase(beginAccess->getSource());
+}
+
 static bool
 canMerge(PostDominanceInfo *postDomTree,
          const llvm::DenseMap<SILBasicBlock *, SCCInfo> &blockToSCCMap,
@@ -998,6 +1002,17 @@ canMerge(PostDominanceInfo *postDomTree,
   // introducing new conflicts that were previously ignored. Merging read/modify
   // will require additional data flow information.
   if (childIns->getAccessKind() != parentIns->getAccessKind())
+    return false;
+
+  // 'parentIns' and 'childIns' have the same AccessStorage, but their address
+  // operands may originate from a different chain of address projections or
+  // address casts. 'mergeAccesses()' simply replaces all uses of 'childInst'
+  // with 'parentIns' rather than rematerializing those address projections or
+  // casts. Therefore, filter out access scopes unless they directly use the
+  // access base. It is unexpected for dynamic access to be on a projection, but
+  // it can result from optimization and inlining. And even though this pass
+  // will probably convert them to static accesses, they remain in the worklist.
+  if (!isDirectBaseAccess(childIns) || !isDirectBaseAccess(parentIns))
     return false;
 
   if (!canMergeBegin(postDomTree, blockToSCCMap, parentIns, childIns))

--- a/test/SILOptimizer/access_enforcement_opts_ossa.sil
+++ b/test/SILOptimizer/access_enforcement_opts_ossa.sil
@@ -1973,3 +1973,48 @@ bb1:
   %19 = tuple ()
   return %19 : $()
 }
+
+// rdar://175181392 - miscompile; incorrect address projection
+//
+// Avoid merging two accesses that have identical storage but are accessing different projections. This is a strange
+// situation for dynamic access scopes, which should normally only occur on the access base.
+
+struct Inner {
+  @_hasStorage var field: Int64
+}
+
+struct Outer {
+  @_hasStorage var padding: Int64
+  @_hasStorage var content: Inner
+}
+
+sil @use_addr : $@convention(thin) (@inout Int64) -> ()
+
+// CHECK-LABEL: sil @test_merge_different_type_access : $@convention(thin) () -> () {
+// CHECK:   [[ALLOC:%[0-9]+]] = alloc_stack $Outer
+// CHECK:   [[ACCESS1:%[0-9]+]] = begin_access [modify] [static] [no_nested_conflict] [[ALLOC]] : $*Outer
+// CHECK:   end_access [[ACCESS1]] : $*Outer
+// CHECK:   [[PROJ:%[0-9]+]] = struct_element_addr %0 : $*Outer, #Outer.content
+// CHECK:   [[ACCESS2:%[0-9]+]] = begin_access [modify] [static] [no_nested_conflict] [[PROJ]] : $*Inner
+// CHECK:   end_access [[ACCESS2]] : $*Inner
+// CHECK-LABEL: } // end sil function 'test_merge_different_type_access'
+sil @test_merge_different_type_access : $@convention(thin) () -> () {
+bb0:
+  %s = alloc_stack $Outer
+  %a1 = begin_access [modify] [dynamic] [no_nested_conflict] %s : $*Outer
+  %padding_addr = struct_element_addr %a1 : $*Outer, #Outer.padding
+  %zero = integer_literal $Builtin.Int64, 0
+  %int_zero = struct $Int64 (%zero : $Builtin.Int64)
+  store %int_zero to %padding_addr : $*Int64
+  end_access %a1 : $*Outer
+  %proj = struct_element_addr %s : $*Outer, #Outer.content
+  %a2 = begin_access [modify] [dynamic] %proj : $*Inner
+  %field_addr = struct_element_addr %a2 : $*Inner, #Inner.field
+  %one = integer_literal $Builtin.Int64, 1
+  %int_one = struct $Int64 (%one : $Builtin.Int64)
+  store %int_one to %field_addr : $*Int64
+  end_access %a2 : $*Inner
+  dealloc_stack %s : $*Outer
+  %r = tuple ()
+  return %r : $()
+}


### PR DESCRIPTION

- **Explanation**: Fixes AccessEnforcementOpts; miscompile; incorrect address projection. Add a bailout for an unexpected SIL pattern.

- **Scope**: This only affects a SIL pattern that was not supposed to be possible. In this case it disables an optimization, which is almost certainly incorrect in that case.

- **Issues**: rdar://175181392

- **Risk**: Negligible

- **Testing**: New unit test

- **Reviewers**: TBD

---
Normally, access scopes for dynamic exclusivity enforcement are supposed to be
on the address that is the based of a formal access. When this is true, it's
possible to merge two accesses whenever that have the same base by blindly
replacing all uses. But, in some strange situation that seems to result from
optimization and inlining, we end up with dynamic access on a projection. Simply
recognize that case and bailout.
