### PR TITLE
[Diagnostics] Ambiguous argument diagnostic message

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5031,8 +5031,64 @@ WARNING(use_of_void_pointer,none,
 "Unsafe%0Pointer<Void> has been replaced by Unsafe%0RawPointer", (StringRef))
 
 // Ambiguities
+ERROR(incorrect_argument_for_call,none,
+      "cannot convert argument of type %1 to expected argument type %2 for %0",
+      (DeclNameRef, Type, Type))
+ERROR(incorrect_argument_for_init,none,
+      "cannot convert argument of type %0 to expected argument type %1 for initializer",
+      (Type, Type))
+ERROR(incorrect_operand_for_op,none,
+      "cannot convert value of type %1 to expected %0 operand type %2",
+      (DeclNameRef, Type, Type))
+ERROR(incorrect_function_for_call,none,
+      "cannot select between %select{function types %3|%2}1 for expected argument type %4 for %0",
+      (DeclNameRef, bool, StringRef, StringRef, Type))
+ERROR(unsupported_closure_argument,none,
+      "closure argument %select{with type%2|}1 passed to %0, which expects %3",
+      (DeclNameRef, bool, Type, Type))
+ERROR(incorrect_function_for_init,none,
+      "cannot select between %select{function types %2|%1}0 for expected argument type %3 for initializer",
+      (bool, StringRef, StringRef, Type))
+ERROR(incorrect_function_operand_for_op,none,
+      "cannot select between %select{function types %3|%2}1 for expected %0 operand type %4",
+      (DeclNameRef, bool, StringRef, StringRef, Type))
+ERROR(unsupported_closure_arg_options,none,
+      "closure argument with %select{possible types %4|%3}2 passed to %0, which expects %3",
+      (DeclNameRef, bool, StringRef, StringRef, Type))
+ERROR(ambiguous_decl_ref_types,none,
+       "ambiguous use of %0; cannot convert argument of type %1 to any of potential %select{types %4|%3}2",
+       (DeclNameRef, Type, bool, StringRef, StringRef))
+ERROR(ambiguous_decl_ref_function_types,none,
+       "ambiguous use of %0; cannot select argument %select{between potential function types %3|%2}1 to any of expected %select{%types %6|%5}4",
+       (DeclNameRef, bool, StringRef, StringRef, bool, StringRef, StringRef))
+ERROR(unsupported_closure_arg_to_options,none,
+       "closure argument %select{|with type %2}1passed to %0, which expects %select{potential types %5|%4}3",
+       (DeclNameRef, bool, Type, bool, StringRef, StringRef))
+ERROR(cannot_match_expr_pattern_with_options,none,
+       "cannot match given pattern expression type %0 with expected %select{potential types %3|%2}1",
+       (Type, bool, StringRef, StringRef))
+ERROR(ambiguous_operator_ref_types,none,
+      "ambiguous use of operator %0; cannot convert value of type %1 to any of potential types %2",
+       (DeclNameRef, Type, StringRef))
+ERROR(ambiguous_decl_ref_unknown,none,
+      "ambiguous use of %0; cannot select between potential%1 types %2",
+      (DeclNameRef, StringRef, StringRef))
+ERROR(ambiguous_operator_ref_unknown,none,
+      "ambiguous use of operator %0; cannot select between potential%1 types %2",
+      (DeclNameRef, StringRef, StringRef))
+ERROR(ambiguous_initializer_unknown,none,
+      "ambiguous use of initializer; cannot determine which initializer for potential types %0",
+      (StringRef))
 ERROR(ambiguous_decl_ref,none,
       "ambiguous use of %0", (DeclNameRef))
+ERROR(ambiguous_init,none,
+      "ambiguous use of initializer; cannot convert argument of type %0 to any of potential %select{types %3|%2}1",
+      (Type, bool, StringRef, StringRef))
+ERROR(ambiguous_function_init,none,
+      "ambiguous use of initializer; cannot select argument of potential %select{function types %2|%1}0 to any of potential expected %select{types %5|%4}3",
+      (bool, StringRef, StringRef, bool, StringRef, StringRef))
+NOTE(ambiguous_because_no_candidates_were_found,none,
+     "no candidates found for specified argument %0", (DeclNameRef))
 ERROR(ambiguous_operator_ref,none,
       "ambiguous use of operator %0", (DeclNameRef))
 NOTE(ambiguous_because_of_trailing_closure,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5159,8 +5159,50 @@ WARNING(use_of_void_pointer,none,
 "Unsafe%0Pointer<Void> has been replaced by Unsafe%0RawPointer", (StringRef))
 
 // Ambiguities
+ERROR(incorrect_argument_for_call,none,
+      "cannot convert argument of type %1 to expected argument type %2 for %0",
+      (DeclNameRef, Type, Type))
+ERROR(incorrect_argument_for_init,none,
+      "cannot convert argument of type %0 to expected argument type %1 for initializer",
+      (Type, Type))
+ERROR(incorrect_operand_for_op,none,
+      "cannot convert value of type %1 to expected %0 operand type %2",
+      (DeclNameRef, Type, Type))
+ERROR(incorrect_function_for_call,none,
+      "cannot select between %select{function types %3|%2}1 for expected argument type %4 for %0",
+      (DeclNameRef, bool, StringRef, StringRef, Type))
+ERROR(unsupported_closure_argument,none,
+      "closure argument %select{with type%2|}1 passed to %0, which expects %3",
+      (DeclNameRef, bool, Type, Type))
+ERROR(incorrect_function_for_init,none,
+      "cannot select between %select{function types %2|%1}0 for expected argument type %3 for initializer",
+      (bool, StringRef, StringRef, Type))
+ERROR(incorrect_function_operand_for_op,none,
+      "cannot select between %select{function types %3|%2}1 for expected %0 operand type %4",
+      (DeclNameRef, bool, StringRef, StringRef, Type))
+ERROR(unsupported_closure_arg_options,none,
+      "closure argument with %select{possible types %4|%3}2 passed to %0, which expects %3",
+      (DeclNameRef, bool, StringRef, StringRef, Type))
+ERROR(ambiguous_decl_ref_types,none,
+       "no exact %0 candidates found; cannot convert argument of type %1 to any of potential %select{types %4|%3}2",
+       (DeclNameRef, Type, bool, StringRef, StringRef))
+ERROR(ambiguous_decl_ref_function_types,none,
+       "no exact %0 candidates found; cannot select argument %select{between potential function types %3|%2}1 to any of expected %select{%types %6|%5}4",
+       (DeclNameRef, bool, StringRef, StringRef, bool, StringRef, StringRef))
+ERROR(unsupported_closure_arg_to_options,none,
+       "closure argument %select{|with type %2}1passed to %0, which expects %select{potential types %5|%4}3",
+       (DeclNameRef, bool, Type, bool, StringRef, StringRef))
+ERROR(cannot_match_expr_pattern_with_options,none,
+       "cannot match given pattern expression type %0 with expected %select{potential types %3|%2}1",
+       (Type, bool, StringRef, StringRef))
 ERROR(ambiguous_decl_ref,none,
       "ambiguous use of %0", (DeclNameRef))
+ERROR(ambiguous_init,none,
+      "no exact initializer candidates found; cannot convert argument of type %0 to any of potential %select{types %3|%2}1",
+      (Type, bool, StringRef, StringRef))
+ERROR(ambiguous_function_init,none,
+      "no exact initializer candidates found; cannot select argument of potential %select{function types %2|%1}0 to any of expected %select{types %5|%4}3",
+      (bool, StringRef, StringRef, bool, StringRef, StringRef))
 ERROR(ambiguous_operator_ref,none,
       "ambiguous use of operator %0", (DeclNameRef))
 NOTE(ambiguous_because_of_trailing_closure,none,

--- a/include/swift/AST/Type.h
+++ b/include/swift/AST/Type.h
@@ -347,6 +347,10 @@ public:
   std::string getString(const PrintOptions &PO = PrintOptions(),
                         NonRecursivePrintOptions OPO = std::nullopt) const;
 
+  std::string
+  getTypeListAsString(ArrayRef<CanType> types,
+                      const PrintOptions &PO = PrintOptions()) const;
+
   /// Return the name of the type, adding parens in cases where
   /// appending or prepending text to the result would cause that text
   /// to be appended to only a portion of the returned type. For

--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -49,6 +49,7 @@ class ConstraintLocatorBuilder;
 enum class ConversionRestrictionKind;
 enum ScoreKind: unsigned int;
 class Solution;
+class SolutionDiff;
 struct MemberLookupResult;
 
 /// Describes the kind of fix to apply to the given constraint before
@@ -566,9 +567,7 @@ public:
   using CommonFixesArray =
       ArrayRef<std::pair<const Solution *, const ConstraintFix *>>;
 
-  virtual bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const {
-    return false;
-  }
+  virtual bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const;
 
   template <typename E>
   bool directlyAt() const {
@@ -609,9 +608,7 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
-  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
-    return diagnose(*commonFixes.front().first);
-  }
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override;
 
   static UnwrapOptionalBase *create(ConstraintSystem &cs, DeclNameRef member,
                                     Type memberBaseType,
@@ -632,9 +629,7 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
-  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
-    return diagnose(*commonFixes.front().first);
-  }
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override;
 
   /// Assess the impact this fix is going to have at the given location.
   static unsigned assessImpact(ConstraintSystem &cs,
@@ -898,9 +893,7 @@ public:
   }
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
-  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
-    return diagnose(*commonFixes.front().first);
-  }
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override;
 
   static TreatArrayLiteralAsDictionary *attempt(ConstraintSystem &cs,
                                                 Type dictionaryTy, Type arrayTy,
@@ -1268,9 +1261,7 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
-  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
-    return diagnose(*commonFixes.front().first);
-  }
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override;
 
   static RemoveUnwrap *create(ConstraintSystem &cs, Type baseType,
                               ConstraintLocator *locator);
@@ -1319,9 +1310,7 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
-  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
-    return diagnose(*commonFixes.front().first);
-  }
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override;
 
   static UsePropertyWrapper *create(ConstraintSystem &cs, VarDecl *wrapped,
                                     bool usingProjection, Type base,
@@ -1353,9 +1342,7 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
-  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
-    return diagnose(*commonFixes.front().first);
-  }
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override;
 
   static UseWrappedValue *create(ConstraintSystem &cs, VarDecl *propertyWrapper,
                                  Type base, Type wrapper,
@@ -1382,9 +1369,7 @@ public:
     return "allow invalid property wrapper type";
   }
 
-  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
-    return diagnose(*commonFixes.front().first);
-  }
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override;
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
@@ -1802,9 +1787,7 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
-  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
-    return diagnose(*commonFixes.front().first);
-  }
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override;
 
   static AddMissingArguments *create(ConstraintSystem &cs,
                                      ArrayRef<SynthesizedArg> synthesizedArgs,
@@ -1850,9 +1833,7 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
-  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
-    return diagnose(*commonFixes.front().first);
-  }
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override;
 
   /// FIXME(diagnostics): Once `resolveDeclRefExpr` is gone this
   /// logic would be obsolete.
@@ -1928,9 +1909,7 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
-  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
-    return diagnose(*commonFixes.front().first);
-  }
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override;
 
   static AllowInaccessibleMember *create(ConstraintSystem &cs, Type baseType,
                                          ValueDecl *member, DeclNameRef name,
@@ -2344,9 +2323,7 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
-  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
-    return diagnose(*commonFixes.front().first);
-  }
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override;
 
   static DefaultGenericArgument *create(ConstraintSystem &cs,
                                         GenericTypeParamType *param,
@@ -2532,6 +2509,8 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override;
+
   static AllowArgumentMismatch *create(ConstraintSystem &cs, Type argType,
                                        Type paramType,
                                        ConstraintLocator *locator);
@@ -2607,9 +2586,7 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
-  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
-    return diagnose(*commonFixes.front().first);
-  }
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override;
 
   static UseRawValue *create(ConstraintSystem &cs, Type rawReprType,
                              Type expectedType, ConstraintLocator *locator);
@@ -2655,9 +2632,7 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
-  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
-    return diagnose(*commonFixes.front().first);
-  }
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override;
 
   static RemoveInvalidCall *create(ConstraintSystem &cs,
                                    ConstraintLocator *locator);
@@ -2683,6 +2658,8 @@ public:
   std::string getName() const override;
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
+
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override;
 
   static TreatEphemeralAsNonEphemeral *
   create(ConstraintSystem &cs, ConstraintLocator *locator, Type srcType,
@@ -2714,9 +2691,7 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
-  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
-    return diagnose(*commonFixes.front().first);
-  }
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override;
 
   static AllowSendingMismatch *create(ConstraintSystem &cs, Type srcType,
                                       Type dstType, ConstraintLocator *locator);
@@ -2743,9 +2718,7 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
-  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
-    return diagnose(*commonFixes.front().first);
-  }
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override;
 
   static SpecifyBaseTypeForContextualMember *
   create(ConstraintSystem &cs, DeclNameRef member, ConstraintLocator *locator);
@@ -2764,9 +2737,7 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
-  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
-    return diagnose(*commonFixes.front().first);
-  }
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override;
 
   static SpecifyClosureParameterType *create(ConstraintSystem &cs,
                                              ConstraintLocator *locator);
@@ -2787,9 +2758,7 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
-  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
-    return diagnose(*commonFixes.front().first);
-  }
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override;
 
   static SpecifyClosureReturnType *create(ConstraintSystem &cs,
                                           ConstraintLocator *locator);
@@ -2947,9 +2916,7 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
-  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
-    return diagnose(*commonFixes.front().first);
-  }
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override;
 
   static SpecifyKeyPathRootType *create(ConstraintSystem &cs,
                                         ConstraintLocator *locator);
@@ -3062,9 +3029,7 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
-  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
-    return diagnose(*commonFixes.front().first);
-  }
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override;
 
   static IgnoreInvalidResultBuilderBody *create(ConstraintSystem &cs,
                                                 ConstraintLocator *locator);
@@ -3109,9 +3074,7 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
-  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
-    return diagnose(*commonFixes.front().first);
-  }
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override;
 
   static IgnoreInvalidASTNode *create(ConstraintSystem &cs,
                                       ConstraintLocator *locator);
@@ -3133,9 +3096,7 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
-  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
-    return diagnose(*commonFixes.front().first);
-  }
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override;
 
   static IgnoreUnresolvedPatternVar *
   create(ConstraintSystem &cs, Pattern *pattern, ConstraintLocator *locator);
@@ -3160,9 +3121,7 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
-  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
-    return diagnose(*commonFixes.front().first);
-  }
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override;
 
   static IgnoreInvalidPatternInExpr *
   create(ConstraintSystem &cs, Pattern *pattern, ConstraintLocator *locator);
@@ -3184,9 +3143,7 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
-  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
-    return diagnose(*commonFixes.front().first);
-  }
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override;
 
   static SpecifyContextualTypeForNil *create(ConstraintSystem & cs,
                                              ConstraintLocator * locator);
@@ -3207,9 +3164,7 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
-  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
-    return diagnose(*commonFixes.front().first);
-  }
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override;
 
   static IgnoreInvalidPlaceholder *create(ConstraintSystem &cs,
                                           ConstraintLocator *locator);
@@ -3230,9 +3185,7 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
-  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
-    return diagnose(*commonFixes.front().first);
-  }
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override;
 
   static SpecifyTypeForPlaceholder *create(ConstraintSystem &cs,
                                            ConstraintLocator *locator);
@@ -3253,9 +3206,7 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
-  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
-    return diagnose(*commonFixes.front().first);
-  }
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override;
 
   static AllowRefToInvalidDecl *create(ConstraintSystem &cs,
                                        ConstraintLocator *locator);
@@ -3444,9 +3395,7 @@ public:
     return "allow invalid static member reference on a protocol metatype";
   }
 
-  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
-    return diagnose(*commonFixes.front().first);
-  }
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override;
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
@@ -3592,9 +3541,7 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
-  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
-    return diagnose(*commonFixes.front().first);
-  }
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override;
 
   static RenameConflictingPatternVariables *
   create(ConstraintSystem &cs, Type expectedTy, ArrayRef<VarDecl *> conflicts,
@@ -3618,9 +3565,7 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
-  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
-    return diagnose(*commonFixes.front().first);
-  }
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override;
 
   static MacroMissingPound *
   create(ConstraintSystem &cs, MacroDecl *macro,
@@ -3701,9 +3646,7 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
-  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
-    return diagnose(*commonFixes.front().first);
-  }
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override;
 
   static AllowValueExpansionWithoutPackReferences *
   create(ConstraintSystem &cs, ConstraintLocator *locator);
@@ -3728,9 +3671,7 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
-  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
-    return diagnose(*commonFixes.front().first);
-  }
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override;
 
   static IgnoreMissingEachKeyword *
   create(ConstraintSystem &cs, Type valuePackTy, ConstraintLocator *locator);
@@ -3760,9 +3701,7 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
-  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
-    return diagnose(*commonFixes.front().first);
-  }
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override;
 
   static AllowInvalidMemberReferenceInInitAccessor *
   create(ConstraintSystem &cs, DeclNameRef memberName,
@@ -3791,9 +3730,7 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
-  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
-    return diagnose(*commonFixes.front().first);
-  }
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override;
 
   static AllowConcreteTypeSpecialization *
   create(ConstraintSystem &cs, Type concreteTy, ValueDecl *decl,
@@ -3821,9 +3758,7 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
-  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
-    return diagnose(*commonFixes.front().first);
-  }
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override;
 
   static AllowFunctionSpecialization *
   create(ConstraintSystem &cs, ValueDecl *decl, ConstraintLocator *locator);
@@ -3844,9 +3779,7 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
-  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
-    return diagnose(*commonFixes.front().first);
-  }
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override;
 
   static IgnoreOutOfPlaceThenStmt *create(ConstraintSystem &cs,
                                           ConstraintLocator *locator);
@@ -3879,9 +3812,7 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
-  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
-    return diagnose(*commonFixes.front().first);
-  }
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override;
 
   static IgnoreGenericSpecializationArityMismatch *
   create(ConstraintSystem &cs, ValueDecl *decl, unsigned numParams,
@@ -3955,9 +3886,7 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
-  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
-    return diagnose(*commonFixes.front().first);
-  }
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override;
 
   static TooManyDynamicMemberLookups *
   create(ConstraintSystem &cs, DeclNameRef name, ConstraintLocator *locator);
@@ -3983,9 +3912,7 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
-  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
-    return diagnose(*commonFixes.front().first);
-  }
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override;
 
   static IgnoreIsolatedConformance *create(ConstraintSystem &cs,
                                            ConstraintLocator *locator,

--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -49,6 +49,7 @@ class ConstraintLocatorBuilder;
 enum class ConversionRestrictionKind;
 enum ScoreKind: unsigned int;
 class Solution;
+class SolutionDiff;
 struct MemberLookupResult;
 
 /// Describes the kind of fix to apply to the given constraint before
@@ -619,9 +620,7 @@ public:
   using CommonFixesArray =
       ArrayRef<std::pair<const Solution *, const ConstraintFix *>>;
 
-  virtual bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const {
-    return false;
-  }
+  virtual bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const;
 
   template <typename E>
   bool directlyAt() const {
@@ -662,9 +661,7 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
-  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
-    return diagnose(*commonFixes.front().first);
-  }
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override;
 
   static UnwrapOptionalBase *create(ConstraintSystem &cs, DeclNameRef member,
                                     Type memberBaseType,
@@ -685,9 +682,7 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
-  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
-    return diagnose(*commonFixes.front().first);
-  }
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override;
 
   /// Assess the impact this fix is going to have at the given location.
   static FixImpact assessImpact(ConstraintSystem &cs, ConstraintLocator *atLoc);
@@ -950,9 +945,7 @@ public:
   }
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
-  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
-    return diagnose(*commonFixes.front().first);
-  }
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override;
 
   static TreatArrayLiteralAsDictionary *attempt(ConstraintSystem &cs,
                                                 Type dictionaryTy, Type arrayTy,
@@ -1320,9 +1313,7 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
-  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
-    return diagnose(*commonFixes.front().first);
-  }
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override;
 
   static RemoveUnwrap *create(ConstraintSystem &cs, Type baseType,
                               ConstraintLocator *locator);
@@ -1371,9 +1362,7 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
-  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
-    return diagnose(*commonFixes.front().first);
-  }
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override;
 
   static UsePropertyWrapper *create(ConstraintSystem &cs, VarDecl *wrapped,
                                     bool usingProjection, Type base,
@@ -1405,9 +1394,7 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
-  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
-    return diagnose(*commonFixes.front().first);
-  }
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override;
 
   static UseWrappedValue *create(ConstraintSystem &cs, VarDecl *propertyWrapper,
                                  Type base, Type wrapper,
@@ -1434,9 +1421,7 @@ public:
     return "allow invalid property wrapper type";
   }
 
-  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
-    return diagnose(*commonFixes.front().first);
-  }
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override;
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
@@ -1889,9 +1874,7 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
-  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
-    return diagnose(*commonFixes.front().first);
-  }
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override;
 
   static AddMissingArguments *create(ConstraintSystem &cs,
                                      ArrayRef<SynthesizedArg> synthesizedArgs,
@@ -1937,9 +1920,7 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
-  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
-    return diagnose(*commonFixes.front().first);
-  }
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override;
 
   /// FIXME(diagnostics): Once `resolveDeclRefExpr` is gone this
   /// logic would be obsolete.
@@ -2015,9 +1996,7 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
-  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
-    return diagnose(*commonFixes.front().first);
-  }
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override;
 
   static AllowInaccessibleMember *create(ConstraintSystem &cs, Type baseType,
                                          ValueDecl *member, DeclNameRef name,
@@ -2431,9 +2410,7 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
-  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
-    return diagnose(*commonFixes.front().first);
-  }
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override;
 
   static DefaultGenericArgument *create(ConstraintSystem &cs,
                                         GenericTypeParamType *param,
@@ -2619,6 +2596,8 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override;
+
   static AllowArgumentMismatch *create(ConstraintSystem &cs, Type argType,
                                        Type paramType,
                                        ConstraintLocator *locator);
@@ -2694,9 +2673,7 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
-  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
-    return diagnose(*commonFixes.front().first);
-  }
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override;
 
   static UseRawValue *create(ConstraintSystem &cs, Type rawReprType,
                              Type expectedType, ConstraintLocator *locator);
@@ -2742,9 +2719,7 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
-  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
-    return diagnose(*commonFixes.front().first);
-  }
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override;
 
   static RemoveInvalidCall *create(ConstraintSystem &cs,
                                    ConstraintLocator *locator);
@@ -2770,6 +2745,8 @@ public:
   std::string getName() const override;
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
+
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override;
 
   static TreatEphemeralAsNonEphemeral *
   create(ConstraintSystem &cs, ConstraintLocator *locator, Type srcType,
@@ -2801,9 +2778,7 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
-  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
-    return diagnose(*commonFixes.front().first);
-  }
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override;
 
   static AllowSendingMismatch *create(ConstraintSystem &cs, Type srcType,
                                       Type dstType, ConstraintLocator *locator);
@@ -2830,9 +2805,7 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
-  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
-    return diagnose(*commonFixes.front().first);
-  }
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override;
 
   static SpecifyBaseTypeForContextualMember *
   create(ConstraintSystem &cs, DeclNameRef member, ConstraintLocator *locator);
@@ -2851,9 +2824,7 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
-  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
-    return diagnose(*commonFixes.front().first);
-  }
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override;
 
   static SpecifyClosureParameterType *create(ConstraintSystem &cs,
                                              ConstraintLocator *locator);
@@ -2874,9 +2845,7 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
-  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
-    return diagnose(*commonFixes.front().first);
-  }
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override;
 
   static SpecifyClosureReturnType *create(ConstraintSystem &cs,
                                           ConstraintLocator *locator);
@@ -3034,9 +3003,7 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
-  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
-    return diagnose(*commonFixes.front().first);
-  }
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override;
 
   static SpecifyKeyPathRootType *create(ConstraintSystem &cs,
                                         ConstraintLocator *locator);
@@ -3149,9 +3116,7 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
-  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
-    return diagnose(*commonFixes.front().first);
-  }
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override;
 
   static IgnoreInvalidResultBuilderBody *create(ConstraintSystem &cs,
                                                 ConstraintLocator *locator);
@@ -3196,9 +3161,7 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
-  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
-    return diagnose(*commonFixes.front().first);
-  }
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override;
 
   static IgnoreInvalidASTNode *create(ConstraintSystem &cs,
                                       ConstraintLocator *locator);
@@ -3220,9 +3183,7 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
-  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
-    return diagnose(*commonFixes.front().first);
-  }
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override;
 
   static IgnoreUnresolvedPatternVar *
   create(ConstraintSystem &cs, Pattern *pattern, ConstraintLocator *locator);
@@ -3247,9 +3208,7 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
-  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
-    return diagnose(*commonFixes.front().first);
-  }
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override;
 
   static IgnoreInvalidPatternInExpr *
   create(ConstraintSystem &cs, Pattern *pattern, ConstraintLocator *locator);
@@ -3271,9 +3230,7 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
-  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
-    return diagnose(*commonFixes.front().first);
-  }
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override;
 
   static SpecifyContextualTypeForNil *create(ConstraintSystem & cs,
                                              ConstraintLocator * locator);
@@ -3294,9 +3251,7 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
-  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
-    return diagnose(*commonFixes.front().first);
-  }
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override;
 
   static IgnoreInvalidPlaceholder *create(ConstraintSystem &cs,
                                           ConstraintLocator *locator);
@@ -3317,9 +3272,7 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
-  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
-    return diagnose(*commonFixes.front().first);
-  }
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override;
 
   static SpecifyTypeForPlaceholder *create(ConstraintSystem &cs,
                                            ConstraintLocator *locator);
@@ -3340,9 +3293,7 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
-  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
-    return diagnose(*commonFixes.front().first);
-  }
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override;
 
   static AllowRefToInvalidDecl *create(ConstraintSystem &cs,
                                        ConstraintLocator *locator);
@@ -3531,9 +3482,7 @@ public:
     return "allow invalid static member reference on a protocol metatype";
   }
 
-  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
-    return diagnose(*commonFixes.front().first);
-  }
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override;
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
@@ -3679,9 +3628,7 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
-  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
-    return diagnose(*commonFixes.front().first);
-  }
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override;
 
   static RenameConflictingPatternVariables *
   create(ConstraintSystem &cs, Type expectedTy, ArrayRef<VarDecl *> conflicts,
@@ -3705,9 +3652,7 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
-  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
-    return diagnose(*commonFixes.front().first);
-  }
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override;
 
   static MacroMissingPound *
   create(ConstraintSystem &cs, MacroDecl *macro,
@@ -3788,9 +3733,7 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
-  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
-    return diagnose(*commonFixes.front().first);
-  }
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override;
 
   static AllowValueExpansionWithoutPackReferences *
   create(ConstraintSystem &cs, ConstraintLocator *locator);
@@ -3815,9 +3758,7 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
-  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
-    return diagnose(*commonFixes.front().first);
-  }
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override;
 
   static IgnoreMissingEachKeyword *
   create(ConstraintSystem &cs, Type valuePackTy, ConstraintLocator *locator);
@@ -3847,9 +3788,7 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
-  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
-    return diagnose(*commonFixes.front().first);
-  }
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override;
 
   static AllowInvalidMemberReferenceInInitAccessor *
   create(ConstraintSystem &cs, DeclNameRef memberName,
@@ -3878,9 +3817,7 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
-  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
-    return diagnose(*commonFixes.front().first);
-  }
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override;
 
   static AllowConcreteTypeSpecialization *
   create(ConstraintSystem &cs, Type concreteTy, ValueDecl *decl,
@@ -3908,9 +3845,7 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
-  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
-    return diagnose(*commonFixes.front().first);
-  }
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override;
 
   static AllowFunctionSpecialization *
   create(ConstraintSystem &cs, ValueDecl *decl, ConstraintLocator *locator);
@@ -3931,9 +3866,7 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
-  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
-    return diagnose(*commonFixes.front().first);
-  }
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override;
 
   static IgnoreOutOfPlaceThenStmt *create(ConstraintSystem &cs,
                                           ConstraintLocator *locator);
@@ -3966,9 +3899,7 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
-  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
-    return diagnose(*commonFixes.front().first);
-  }
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override;
 
   static IgnoreGenericSpecializationArityMismatch *
   create(ConstraintSystem &cs, ValueDecl *decl, unsigned numParams,
@@ -4044,9 +3975,7 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
-  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
-    return diagnose(*commonFixes.front().first);
-  }
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override;
 
   static TooManyDynamicMemberLookups *
   create(ConstraintSystem &cs, DeclNameRef name, ConstraintLocator *locator);
@@ -4072,9 +4001,7 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
-  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
-    return diagnose(*commonFixes.front().first);
-  }
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override;
 
   static IgnoreIsolatedConformance *create(ConstraintSystem &cs,
                                            ConstraintLocator *locator,

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -1248,6 +1248,11 @@ bool AttributedFuncToTypeConversionFailure::diagnoseAsError() {
   return true;
 }
 
+/*bool AttributedFuncToTypeConversionFailure::diagnoseForAmbiguity(
+    MutableArrayRef<FailureDiagnostic> commonDiagnostics) {
+  return commonDiagnostics[0].diagnoseAsError();
+}*/
+
 static VarDecl *getDestinationVarDecl(AssignExpr *AE,
                                       const Solution &solution) {
   ConstraintLocator *locator = nullptr;
@@ -2963,6 +2968,11 @@ bool ContextualFailure::diagnoseAsNote() {
   return true;
 }
 
+bool ContextualFailure::diagnoseForAmbiguity(
+    MutableArrayRef<ContextualFailure> commonDiagnostics) {
+  return commonDiagnostics[0].diagnoseAsError();
+}
+
 static std::optional<Diag<Type>>
 getContextualNilDiagnostic(ContextualTypePurpose CTP) {
   switch (CTP) {
@@ -3969,6 +3979,12 @@ bool FunctionTypeMismatch::diagnoseAsError() {
   emitDiagnostic(*diagnostic, getFromType(), getToType());
   return true;
 }
+
+/*bool FunctionTypeMismatch::diagnoseForAmbiguity(
+    MutableArrayRef<FailureDiagnostic> commonDiagnostics) {
+  return commonDiagnostics[0].diagnoseAsError();
+}*/
+
 
 bool AutoClosurePointerConversionFailure::diagnoseAsError() {
   auto diagnostic = diag::invalid_autoclosure_pointer_conversion;
@@ -5550,6 +5566,11 @@ bool MissingArgumentsFailure::diagnoseAsNote() {
 
   return false;
 }
+
+/*bool MissingArgumentsFailure::diagnoseForAmbiguity(
+    MutableArrayRef<FailureDiagnostic> commonDiagnostics) {
+  return commonDiagnostics[0].diagnoseAsError();
+}*/
 
 bool MissingArgumentsFailure::diagnoseSingleMissingArgument() const {
   auto &ctx = getASTContext();
@@ -7592,11 +7613,21 @@ bool ThrowingFunctionConversionFailure::diagnoseAsError() {
   return true;
 }
 
+/*bool ThrowingFunctionConversionFailure::diagnoseForAmbiguity(
+    MutableArrayRef<FailureDiagnostic> commonDiagnostics) {
+  return commonDiagnostics[0].diagnoseAsError();
+}*/
+
 bool ThrownErrorTypeConversionFailure::diagnoseAsError() {
   emitDiagnostic(diag::thrown_error_type_mismatch, getFromType(),
                  getToType());
   return true;
 }
+
+/*bool ThrownErrorTypeConversionFailure::diagnoseForAmbiguity(
+    MutableArrayRef<FailureDiagnostic> commonDiagnostics) {
+  return commonDiagnostics[0].diagnoseAsError();
+}*/
 
 bool AsyncFunctionConversionFailure::diagnoseAsError() {
   auto *locator = getLocator();
@@ -7861,6 +7892,236 @@ bool ArgumentMismatchFailure::diagnoseAsNote() {
     return true;
   }
 
+  return false;
+}
+
+bool ArgumentMismatchFailure::diagnoseForAmbiguity(
+    MutableArrayRef<ArgumentMismatchFailure> commonDiagnostics) {
+  //This diagnostic and first diagnostic will be the same diagnostic if
+  //called from AllowArgumentMismatch diagnoseForAmbiguity. So the
+  //solution, loc, fromType, and toType are present within the set of diagnostics
+
+  Type resolvedFromType = resolveType(getFromType());
+
+  //We want to compare FunctionTypes that could be polymorphically interchanged. But that
+  //will be better using mergeable. This is a short term partial solution.
+  auto matchableFuncType = [&](Type currentFromType) {
+    if (auto funFromType = resolvedFromType->getAs<AnyFunctionType>()) {
+      if (auto funCurrentF = currentFromType->getAs<AnyFunctionType>()) {
+        return funFromType->getNumParams() == funCurrentF->getNumParams();
+      }
+    }
+    return false;
+  };
+
+  // Check if all From types pass isEqual checks
+  bool equalTypes = llvm::all_of(
+      commonDiagnostics,
+      [&](ArgumentMismatchFailure &entry) {
+        auto currentFromType = entry.resolveType(entry.getFromType());
+        return resolvedFromType->isEqual(currentFromType);
+      });
+  // Check if all From types are functions And similar
+  bool similarFunctionalTypes = llvm::all_of(
+      commonDiagnostics,
+      [&](ArgumentMismatchFailure &entry) {
+        auto currentFromType = entry.resolveType(entry.getFromType());
+        return matchableFuncType(currentFromType);
+      });
+
+  if (equalTypes || similarFunctionalTypes) {
+    auto &CS = getConstraintSystem();
+    auto &DE = CS.getASTContext().Diags;
+    auto loc = getLocator();
+    auto overload = getCalleeOverloadChoiceIfAvailable(loc);
+
+    if (!overload)
+      return false;
+
+    auto argumentExp = getFunctionArgApplyInfo(loc).value().getArgExpr();
+    bool closureAnchor = false;
+    if (isExpr<ClosureExpr>(argumentExp)) {
+      closureAnchor = true;
+    }
+    bool functionToType = false;
+
+    auto primaryDecl = overload->choice.getDecl();
+    DeclNameRef diagnosisName =
+        DeclNameRef(primaryDecl->getName().getBaseName());
+    llvm::StringSet<> overloadedToTypes;
+    llvm::StringSet<> overloadedFromTypes;
+
+    llvm::SmallSetVector<Decl *, 4> matchedDecls;
+
+    for (auto &entry : commonDiagnostics) {
+      auto currentDiag = entry.castTo<ArgumentMismatchFailure>();
+      matchedDecls.insert(
+          currentDiag->getOverloadChoice(currentDiag->getLocator())->choice.getDecl());
+      auto toType = currentDiag->resolveType(currentDiag->getToType());
+      overloadedToTypes.insert(toType.getString());
+      if (toType->is<AnyFunctionType>())
+        functionToType = true;
+
+      if (similarFunctionalTypes)
+        overloadedFromTypes.insert(
+            currentDiag->resolveType(currentDiag->getFromType()).getString());
+    }
+
+    auto srcLoc = ::getLoc(getAnchor());
+
+    SmallString<80> fromTypeStr;
+    {
+      llvm::raw_svector_ostream OS(fromTypeStr);
+      SmallVector<std::string> temp;
+      if (!overloadedFromTypes.empty()) {
+        for (auto &t : overloadedFromTypes)
+          temp.emplace_back(StringRef(t.getKey()).str());
+        llvm::sort(temp);
+        llvm::interleaveComma(temp, OS,
+                              [&OS](auto type) { OS << "'" << type << "'"; });
+      }
+    }
+
+    std::optional<std::string> fromTypeSummary;
+    /// This is an arbitrary cut off to avoid very long
+    /// diagnostic messages when there are many overloads
+    /// TODO: make a shape based message, and make a ranking
+    /// to select the most likely types for a partial message
+    if (fromTypeStr.size() > 80) {
+      fromTypeSummary =
+          std::to_string(overloadedFromTypes.size()) + " function types";
+    }
+
+    auto toType = resolveType(getToType());
+    if (similarFunctionalTypes && overloadedToTypes.size() == 1) {
+      auto useFromTypeSummary = fromTypeSummary.has_value();
+      auto fromTypeSummaryS = fromTypeSummary.value_or("");
+
+      if (closureAnchor && !functionToType)
+        DE.diagnose(srcLoc, diag::unsupported_closure_arg_options,
+                    diagnosisName, useFromTypeSummary, fromTypeSummaryS,
+                    fromTypeStr, toType);
+      else if (diagnosisName.isOperator())
+        DE.diagnose(srcLoc, diag::incorrect_function_operand_for_op,
+                    diagnosisName, useFromTypeSummary, fromTypeSummaryS,
+                    fromTypeStr, toType);
+      else if (isa<ConstructorDecl>(primaryDecl))
+        DE.diagnose(srcLoc, diag::incorrect_function_for_init,
+                    useFromTypeSummary, fromTypeSummaryS, fromTypeStr, toType);
+      else
+        DE.diagnose(srcLoc, diag::incorrect_function_for_call, diagnosisName,
+                    useFromTypeSummary, fromTypeSummaryS, fromTypeStr, toType);
+      return true;
+    }
+
+      // Lift to CSDiagnostic
+    if (overloadedToTypes.size() == 1) {
+      if (closureAnchor && !functionToType)
+       DE.diagnose(srcLoc, diag::unsupported_closure_argument, diagnosisName,
+                    resolvedFromType->hasPlaceholder(), resolvedFromType, toType);
+      else if (diagnoseConversionToBool()) {
+        return true;
+      } else if (diagnosisName.isOperator() &&
+                 diagnosisName.getBaseName().getIdentifier().str() == "~=") {
+        DE.diagnose(srcLoc, diag::cannot_match_expr_pattern_with_value,
+                    resolvedFromType, toType);
+      } else if (diagnosisName.isOperator()) {
+        auto diag = DE.diagnose(srcLoc, diag::incorrect_operand_for_op,
+                                diagnosisName, resolvedFromType, toType);
+        tryFixIts(diag);
+      } else if (isa<ConstructorDecl>(primaryDecl)) {
+        auto diag = DE.diagnose(srcLoc, diag::incorrect_argument_for_init,
+                                resolvedFromType, toType);
+        tryFixIts(diag);
+      } else {
+        auto diag = DE.diagnose(srcLoc, diag::incorrect_argument_for_call,
+                                diagnosisName, resolvedFromType, toType);
+        tryFixIts(diag);
+      }
+      return true;
+    }
+
+    auto sizeOverloadedToTypes = overloadedToTypes.size();
+
+    SmallString<80> toTypeStr;
+    {
+      llvm::raw_svector_ostream OS(toTypeStr);
+      SmallVector<std::string> temp;
+      if (!overloadedToTypes.empty()) {
+        for (auto &t : overloadedToTypes)
+          temp.emplace_back(StringRef(t.getKey()).str());
+        llvm::sort(temp);
+        llvm::interleaveComma(temp, OS,
+                              [&OS](auto type) { OS << "'" << type << "'"; });
+      }
+    }
+
+    std::optional<std::string> toTypesSummary = std::nullopt;
+    if (toTypeStr.size() > 80) {
+      toTypesSummary =
+          std::to_string(sizeOverloadedToTypes) + " different types";
+    }
+
+    auto useToTypeSummary = toTypesSummary.has_value();
+    auto toTypesSummaryS = toTypesSummary.value_or("");
+
+    if (similarFunctionalTypes) {
+      auto useFromTypeSummary = fromTypeSummary.has_value();
+      auto fromTypeSummaryS = fromTypeSummary.value_or("");
+
+      // no exact matches ... and should be in cs diagnostic but with all of the useSummary information
+      if (isa<ConstructorDecl>(primaryDecl))
+        DE.diagnose(srcLoc, diag::ambiguous_function_init, useFromTypeSummary,
+                    fromTypeSummaryS, fromTypeStr, useToTypeSummary,
+                    toTypesSummaryS, toTypeStr);
+      else
+        DE.diagnose(srcLoc, diag::ambiguous_decl_ref_function_types,
+                    diagnosisName, useFromTypeSummary, fromTypeSummaryS,
+                    fromTypeStr, useToTypeSummary, toTypesSummaryS, toTypeStr);
+
+    } else {
+      if (closureAnchor && !functionToType)
+        DE.diagnose(srcLoc, diag::unsupported_closure_arg_to_options,
+                    diagnosisName, resolvedFromType->hasPlaceholder(), resolvedFromType,
+                    useToTypeSummary, toTypesSummaryS, toTypeStr);
+      else if (diagnosisName.isOperator() &&
+               diagnosisName.getBaseName().getIdentifier().str() == "~=") {
+        DE.diagnose(srcLoc, diag::cannot_match_expr_pattern_with_options,
+                    resolvedFromType, useToTypeSummary, toTypesSummaryS, toTypeStr);
+      } else if (isa<ConstructorDecl>(primaryDecl))
+        DE.diagnose(srcLoc, diag::ambiguous_init, resolvedFromType, useToTypeSummary,
+                    toTypesSummaryS, toTypeStr);
+      else
+        DE.diagnose(srcLoc, diag::ambiguous_decl_ref_types, diagnosisName,
+                    resolvedFromType, useToTypeSummary, toTypesSummaryS, toTypeStr);
+    }
+    for (auto &entry : commonDiagnostics) {
+      auto overload =
+          entry.getOverloadChoice(entry.getLocator())->choice.getDecl();
+      if (!matchedDecls.contains(overload))
+        continue;
+
+      auto parameters = overload->getParameterList();
+      unsigned paramIdx =
+          getFunctionArgApplyInfo(entry.getLocator())
+              ->getParamPosition();
+      if (closureAnchor && !entry.getToType()->is<AnyFunctionType>()) {
+        // TODO: make this take the parameter position
+        DE.diagnose(overload, diag::candidate_has_invalid_closure_at_position,
+                    entry.resolveType(entry.getToType()));
+      } else
+        DE.diagnose(overload, diag::candidate_has_invalid_argument_at_position,
+                    entry.resolveType(entry.getToType()), paramIdx,
+                    !parameters
+                        ? false
+                        : (parameters->size() == 0
+                               ? false
+                               : parameters->get(paramIdx - 1)->isInOut()),
+                    entry.resolveType(entry.getFromType()));
+      matchedDecls.remove(overload);
+    }
+    return true;
+  }
   return false;
 }
 

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -57,6 +57,11 @@ public:
 
   virtual ~FailureDiagnostic();
 
+  template <typename Diagnostic>
+  const Diagnostic *castTo() const {
+   return static_cast<const Diagnostic *>(this);
+  }
+
   virtual SourceLoc getLoc() const { return constraints::getLoc(getAnchor()); }
 
   virtual SourceRange getSourceRange() const {
@@ -689,6 +694,8 @@ public:
 
   bool diagnoseAsNote() override;
 
+  bool diagnoseForAmbiguity(MutableArrayRef<ContextualFailure> commonDiagnostics);
+
   /// If the type of a key path literal is read-only due to setter
   /// availability restrictions but the context requires a writable
   /// key path, let's produce a tailed availability diagnostic that
@@ -837,6 +844,8 @@ public:
   bool diagnoseAsError() override;
   bool diagnoseAsNote() override;
 
+  //bool diagnoseForAmbiguity(MutableArrayRef<FailureDiagnostic> commonDiagnostics) override;
+
 private:
   /// Emit tailored diagnostics for no-escape/non-sendable parameter
   /// conversions e.g. passing such parameter as an @escaping or @Sendable
@@ -967,6 +976,9 @@ public:
   }
 
   bool diagnoseAsError() override;
+
+  //bool diagnoseForAmbiguity(
+  //    MutableArrayRef<FailureDiagnostic> commonDiagnostics) override;
 };
 
 /// Diagnose failures related to conversion between the thrown error type
@@ -985,6 +997,9 @@ public:
   }
 
   bool diagnoseAsError() override;
+
+ // bool diagnoseForAmbiguity(
+ //     MutableArrayRef<FailureDiagnostic> commonDiagnostics) override;
 };
 
 /// Diagnose failures related to conversion between 'async' function type
@@ -1118,6 +1133,9 @@ public:
   }
 
   bool diagnoseAsError() override;
+
+  //bool diagnoseForAmbiguity(
+  //    MutableArrayRef<FailureDiagnostic> commonDiagnostics) override;
 };
 
 /// Diagnose invalid pointer conversions for an autoclosure result type.
@@ -1454,6 +1472,7 @@ public:
   bool diagnoseAsError() override;
 };
 
+// This one should likely have a diagnoseForAmbiguity ... so perhaps not just ContextualFailures
 class InvalidInitRefFailure : public FailureDiagnostic {
 protected:
   Type BaseType;
@@ -1540,6 +1559,7 @@ public:
   bool diagnoseAsError() override;
 };
 
+//This really likely needs ambiguity
 class MissingArgumentsFailure final : public FailureDiagnostic {
   SmallVector<SynthesizedArg, 4> SynthesizedArgs;
 
@@ -1559,6 +1579,8 @@ public:
   bool diagnoseAsError() override;
 
   bool diagnoseAsNote() override;
+
+  //bool diagnoseForAmbiguity(MutableArrayRef<FailureDiagnostic> commonDiagnostics) override;
 
   bool diagnoseSingleMissingArgument() const;
 
@@ -2311,6 +2333,7 @@ public:
 
   bool diagnoseAsError() override;
   bool diagnoseAsNote() override;
+  bool diagnoseForAmbiguity(MutableArrayRef<ArgumentMismatchFailure> commonDiagnostics);
 
   /// If both argument and parameter are represented by `ArchetypeType`
   /// produce a special diagnostic in case their names match.
@@ -2434,6 +2457,12 @@ protected:
   /// \returns The flags of a parameter at a given index.
   ParameterTypeFlags getParameterFlagsAtIndex(unsigned idx) const {
     return Info.getParameterFlagsAtIndex(idx);
+  }
+
+  //poke through the protected blocks
+  std::optional<SelectedOverload>
+  getOverloadChoice(ConstraintLocator *locator) const {
+    return this->getCalleeOverloadChoiceIfAvailable(locator);
   }
 };
 

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -68,6 +68,10 @@ void ConstraintFix::print(llvm::raw_ostream &Out) const {
   getLocator()->dump(&CS.getASTContext().SourceMgr, Out);
 }
 
+bool ConstraintFix::diagnoseForAmbiguity(CommonFixesArray commonFixes) const {
+  return false;
+}
+
 void ConstraintFix::dump() const {print(llvm::errs()); }
 
 std::string ForceDowncast::getName() const {
@@ -110,6 +114,11 @@ bool UnwrapOptionalBase::diagnose(const Solution &solution, bool asNote) const {
   return failure.diagnose(asNote);
 }
 
+bool UnwrapOptionalBase::diagnoseForAmbiguity(
+    CommonFixesArray commonFixes) const {
+  return diagnose(*commonFixes.front().first);
+}
+
 UnwrapOptionalBase *UnwrapOptionalBase::create(ConstraintSystem &cs,
                                                DeclNameRef member,
                                                Type memberBaseType,
@@ -141,6 +150,11 @@ bool TreatRValueAsLValue::diagnose(const Solution &solution,
                                    bool asNote) const {
   RValueTreatedAsLValueFailure failure(solution, getLocator());
   return failure.diagnose(asNote);
+}
+
+bool TreatRValueAsLValue::diagnoseForAmbiguity(
+    CommonFixesArray commonFixes) const {
+  return diagnose(*commonFixes.front().first);
 }
 
 unsigned TreatRValueAsLValue::assessImpact(ConstraintSystem &cs,
@@ -217,6 +231,11 @@ bool TreatArrayLiteralAsDictionary::diagnose(const Solution &solution,
                                                     getToType(), getFromType(),
                                                     getLocator());
   return failure.diagnose(asNote);
+}
+
+bool TreatArrayLiteralAsDictionary::diagnoseForAmbiguity(
+    CommonFixesArray commonFixes) const {
+  return diagnose(*commonFixes.front().first);
 }
 
 TreatArrayLiteralAsDictionary *
@@ -860,6 +879,10 @@ bool RemoveUnwrap::diagnose(const Solution &solution, bool asNote) const {
   return failure.diagnose(asNote);
 }
 
+bool RemoveUnwrap::diagnoseForAmbiguity(CommonFixesArray commonFixes) const {
+  return diagnose(*commonFixes.front().first);
+}
+
 RemoveUnwrap *RemoveUnwrap::create(ConstraintSystem &cs, Type baseType,
                                    ConstraintLocator *locator) {
   return new (cs.getAllocator()) RemoveUnwrap(cs, baseType, locator);
@@ -881,6 +904,11 @@ bool UsePropertyWrapper::diagnose(const Solution &solution, bool asNote) const {
   return failure.diagnose(asNote);
 }
 
+bool UsePropertyWrapper::diagnoseForAmbiguity(
+    CommonFixesArray commonFixes) const {
+  return diagnose(*commonFixes.front().first);
+}
+
 UsePropertyWrapper *UsePropertyWrapper::create(ConstraintSystem &cs,
                                                VarDecl *wrapped,
                                                bool usingProjection,
@@ -897,6 +925,10 @@ bool UseWrappedValue::diagnose(const Solution &solution, bool asNote) const {
   return failure.diagnose(asNote);
 }
 
+bool UseWrappedValue::diagnoseForAmbiguity(CommonFixesArray commonFixes) const {
+  return diagnose(*commonFixes.front().first);
+}
+
 UseWrappedValue *UseWrappedValue::create(ConstraintSystem &cs,
                                          VarDecl *propertyWrapper, Type base,
                                          Type wrapper,
@@ -908,6 +940,11 @@ UseWrappedValue *UseWrappedValue::create(ConstraintSystem &cs,
 bool AllowInvalidPropertyWrapperType::diagnose(const Solution &solution, bool asNote) const {
   InvalidPropertyWrapperType failure(solution, wrapperType, getLocator());
   return failure.diagnose(asNote);
+}
+
+bool AllowInvalidPropertyWrapperType::diagnoseForAmbiguity(
+    CommonFixesArray commonFixes) const {
+  return diagnose(*commonFixes.front().first);
 }
 
 AllowInvalidPropertyWrapperType *
@@ -1130,6 +1167,11 @@ bool AddMissingArguments::diagnose(const Solution &solution,
   return failure.diagnose(asNote);
 }
 
+bool AddMissingArguments::diagnoseForAmbiguity(
+    CommonFixesArray commonFixes) const {
+  return diagnose(*commonFixes.front().first);
+}
+
 AddMissingArguments *
 AddMissingArguments::create(ConstraintSystem &cs,
                             ArrayRef<SynthesizedArg> synthesizedArgs,
@@ -1144,6 +1186,11 @@ bool RemoveExtraneousArguments::diagnose(const Solution &solution,
   ExtraneousArgumentsFailure failure(solution, ContextualType,
                                      getExtraArguments(), getLocator());
   return failure.diagnose(asNote);
+}
+
+bool RemoveExtraneousArguments::diagnoseForAmbiguity(
+    CommonFixesArray commonFixes) const {
+  return diagnose(*commonFixes.front().first);
 }
 
 bool RemoveExtraneousArguments::isMinMaxNameShadowing(
@@ -1216,6 +1263,11 @@ bool AllowInaccessibleMember::diagnose(const Solution &solution,
                                        bool asNote) const {
   InaccessibleMemberFailure failure(solution, getMember(), getLocator());
   return failure.diagnose(asNote);
+}
+
+bool AllowInaccessibleMember::diagnoseForAmbiguity(
+    CommonFixesArray commonFixes) const {
+  return diagnose(*commonFixes.front().first);
 }
 
 AllowInaccessibleMember *
@@ -1623,6 +1675,11 @@ bool DefaultGenericArgument::diagnose(const Solution &solution,
   return coalesceAndDiagnose(solution, {}, asNote);
 }
 
+bool DefaultGenericArgument::diagnoseForAmbiguity(
+    CommonFixesArray commonFixes) const {
+  return diagnose(*commonFixes.front().first);
+}
+
 DefaultGenericArgument *
 DefaultGenericArgument::create(ConstraintSystem &cs, GenericTypeParamType *param,
                                ConstraintLocator *locator) {
@@ -1955,6 +2012,10 @@ bool UseRawValue::diagnose(const Solution &solution, bool asNote) const {
   return failure.diagnose(asNote);
 }
 
+bool UseRawValue::diagnoseForAmbiguity(CommonFixesArray commonFixes) const {
+  return diagnose(*commonFixes.front().first);
+}
+
 UseRawValue *UseRawValue::create(ConstraintSystem &cs, Type rawReprType,
                                  Type expectedType,
                                  ConstraintLocator *locator) {
@@ -1962,17 +2023,244 @@ UseRawValue *UseRawValue::create(ConstraintSystem &cs, Type rawReprType,
       UseRawValue(cs, rawReprType, expectedType, locator);
 }
 
-unsigned AllowArgumentMismatch::getParamIdx() const {
-  const auto *locator = getLocator();
-  auto elt = locator->castLastElementTo<LocatorPathElt::ApplyArgToParam>();
-  return elt.getParamIdx();
-}
-
 bool AllowArgumentMismatch::diagnose(const Solution &solution,
                                      bool asNote) const {
   ArgumentMismatchFailure failure(solution, getFromType(), getToType(),
                                   getLocator());
   return failure.diagnose(asNote);
+}
+
+bool AllowArgumentMismatch::diagnoseForAmbiguity(
+    CommonFixesArray commonFixes) const {
+  auto *primaryFix = commonFixes.front().second->getAs<AllowArgumentMismatch>();
+  auto primarySolution = commonFixes.front().first;
+  auto primaryDiagnostic = new ArgumentMismatchFailure(
+      *primarySolution, primaryFix->getFromType(), primaryFix->getToType(),
+      primaryFix->getLocator());
+
+  Type fromType = primaryDiagnostic->resolveType(primaryFix->getFromType());
+
+  auto matchableFuncType = [&](Type currentFromType) {
+    if (auto funFromType = fromType->getAs<AnyFunctionType>()) {
+      if (auto funCurrentF = currentFromType->getAs<AnyFunctionType>()) {
+        return funFromType->getNumParams() == funCurrentF->getNumParams();
+      }
+    }
+    return false;
+  };
+
+  bool equalTypes = llvm::all_of(
+      commonFixes,
+      [&](const std::pair<const Solution *, const ConstraintFix *> &entry) {
+        auto *fix = entry.second->castTo<AllowArgumentMismatch>();
+        auto currentFromType(entry.first->simplifyType(fix->getFromType()));
+        return fromType->isEqual(currentFromType);
+      });
+  bool similarFunctionalTypes = llvm::all_of(
+      commonFixes,
+      [&](const std::pair<const Solution *, const ConstraintFix *> &entry) {
+        auto *fix = entry.second->castTo<AllowArgumentMismatch>();
+        auto currentFromType(entry.first->simplifyType(fix->getFromType()));
+        return matchableFuncType(currentFromType);
+      });
+
+  if (equalTypes || similarFunctionalTypes) {
+    auto &CS = getConstraintSystem();
+    auto &DE = CS.getASTContext().Diags;
+    auto loc = getLocator();
+    auto overload = primarySolution->getCalleeOverloadChoiceIfAvailable(loc);
+
+    if (!overload)
+      return false;
+
+    auto argumentExp =
+        primarySolution->getFunctionArgApplyInfo(loc).value().getArgExpr();
+    bool closureAnchor = false;
+    if (isExpr<ClosureExpr>(argumentExp)) {
+      closureAnchor = true;
+    }
+    bool functionToType = false;
+
+    auto primaryDecl = overload->choice.getDecl();
+    DeclNameRef diagnosisName =
+        DeclNameRef(primaryDecl->getName().getBaseName());
+    llvm::StringSet<> overloadedToTypes;
+    llvm::StringSet<> overloadedFromTypes;
+
+    llvm::SmallSetVector<Decl *, 4> matchedDecls;
+
+    for (auto fixEntry : commonFixes) {
+      matchedDecls.insert(
+          fixEntry.first->getCalleeOverloadChoice(loc).choice.getDecl());
+      auto currentFix = fixEntry.second->castTo<AllowArgumentMismatch>();
+      auto currentDiag = new ArgumentMismatchFailure(
+          *fixEntry.first, currentFix->getFromType(), currentFix->getToType(),
+          currentFix->getLocator());
+      auto toType = currentDiag->resolveType(currentFix->getToType());
+      overloadedToTypes.insert(toType.getString());
+      if (toType->is<AnyFunctionType>())
+        functionToType = true;
+
+      if (similarFunctionalTypes)
+        overloadedFromTypes.insert(
+            currentDiag->resolveType(currentFix->getFromType()).getString());
+    }
+
+    auto srcLoc = getLoc(getAnchor());
+
+    SmallString<75> fromTypeStr;
+    {
+      llvm::raw_svector_ostream OS(fromTypeStr);
+      SmallVector<std::string> temp;
+      if (!overloadedFromTypes.empty()) {
+        for (auto &t : overloadedFromTypes)
+          temp.emplace_back(StringRef(t.getKey()).str());
+        llvm::sort(temp);
+        llvm::interleaveComma(temp, OS,
+                              [&OS](auto type) { OS << "'" << type << "'"; });
+      }
+    }
+
+    std::optional<std::string> fromTypeSummary;
+    /// This is an arbitrary cut off to avoid very long
+    /// diagnostic messages when there are many overloads
+    /// TODO: make a shape based message, and make a ranking
+    /// to select the most likely types for a partial message
+    if (fromTypeStr.size() > 75) {
+      fromTypeSummary =
+          std::to_string(overloadedFromTypes.size()) + " function types";
+    }
+
+    auto toType = primaryDiagnostic->resolveType(primaryFix->getToType());
+    if (similarFunctionalTypes && overloadedToTypes.size() == 1) {
+      auto useFromTypeSummary = fromTypeSummary.has_value();
+      auto fromTypeSummaryS = fromTypeSummary.value_or("");
+
+      if (closureAnchor && !functionToType)
+        DE.diagnose(srcLoc, diag::unsupported_closure_arg_options,
+                    diagnosisName, useFromTypeSummary, fromTypeSummaryS,
+                    fromTypeStr, toType);
+      else if (diagnosisName.isOperator())
+        DE.diagnose(srcLoc, diag::incorrect_function_operand_for_op,
+                    diagnosisName, useFromTypeSummary, fromTypeSummaryS,
+                    fromTypeStr, toType);
+      else if (isa<ConstructorDecl>(primaryDecl))
+        DE.diagnose(srcLoc, diag::incorrect_function_for_init,
+                    useFromTypeSummary, fromTypeSummaryS, fromTypeStr, toType);
+      else
+        DE.diagnose(srcLoc, diag::incorrect_function_for_call, diagnosisName,
+                    useFromTypeSummary, fromTypeSummaryS, fromTypeStr, toType);
+      return true;
+    }
+
+    if (overloadedToTypes.size() == 1) {
+      if (closureAnchor && !functionToType)
+        DE.diagnose(srcLoc, diag::unsupported_closure_argument, diagnosisName,
+                    fromType->hasPlaceholder(), fromType, toType);
+      else if (primaryDiagnostic->diagnoseConversionToBool()) {
+        return true;
+      } else if (diagnosisName.isOperator() &&
+                 diagnosisName.getBaseName().getIdentifier().str() == "~=") {
+        DE.diagnose(srcLoc, diag::cannot_match_expr_pattern_with_value,
+                    fromType, toType);
+      } else if (diagnosisName.isOperator()) {
+        auto diag = DE.diagnose(srcLoc, diag::incorrect_operand_for_op,
+                                diagnosisName, fromType, toType);
+        primaryDiagnostic->tryFixIts(diag);
+      } else if (isa<ConstructorDecl>(primaryDecl)) {
+        auto diag = DE.diagnose(srcLoc, diag::incorrect_argument_for_init,
+                                fromType, toType);
+        primaryDiagnostic->tryFixIts(diag);
+      } else {
+        auto diag = DE.diagnose(srcLoc, diag::incorrect_argument_for_call,
+                                diagnosisName, fromType, toType);
+        primaryDiagnostic->tryFixIts(diag);
+      }
+      return true;
+    }
+
+    auto sizeOverloadedToTypes = overloadedToTypes.size();
+
+    SmallString<75> toTypeStr;
+    {
+      llvm::raw_svector_ostream OS(toTypeStr);
+      SmallVector<std::string> temp;
+      if (!overloadedToTypes.empty()) {
+        for (auto &t : overloadedToTypes)
+          temp.emplace_back(StringRef(t.getKey()).str());
+        llvm::sort(temp);
+        llvm::interleaveComma(temp, OS,
+                              [&OS](auto type) { OS << "'" << type << "'"; });
+      }
+    }
+
+    std::optional<std::string> toTypesSummary = std::nullopt;
+    if (toTypeStr.size() > 75) {
+      toTypesSummary =
+          std::to_string(sizeOverloadedToTypes) + " different types";
+    }
+
+    auto useToTypeSummary = toTypesSummary.has_value();
+    auto toTypesSummaryS = toTypesSummary.value_or("");
+
+    if (similarFunctionalTypes) {
+      auto useFromTypeSummary = fromTypeSummary.has_value();
+      auto fromTypeSummaryS = fromTypeSummary.value_or("");
+
+      if (isa<ConstructorDecl>(primaryDecl))
+        DE.diagnose(srcLoc, diag::ambiguous_function_init, useFromTypeSummary,
+                    fromTypeSummaryS, fromTypeStr, useToTypeSummary,
+                    toTypesSummaryS, toTypeStr);
+      else
+        DE.diagnose(srcLoc, diag::ambiguous_decl_ref_function_types,
+                    diagnosisName, useFromTypeSummary, fromTypeSummaryS,
+                    fromTypeStr, useToTypeSummary, toTypesSummaryS, toTypeStr);
+
+    } else {
+      if (closureAnchor && !functionToType)
+        DE.diagnose(srcLoc, diag::unsupported_closure_arg_to_options,
+                    diagnosisName, fromType->hasPlaceholder(), fromType,
+                    useToTypeSummary, toTypesSummaryS, toTypeStr);
+      else if (diagnosisName.isOperator() &&
+               diagnosisName.getBaseName().getIdentifier().str() == "~=") {
+        DE.diagnose(srcLoc, diag::cannot_match_expr_pattern_with_options,
+                    fromType, useToTypeSummary, toTypesSummaryS, toTypeStr);
+      } else if (isa<ConstructorDecl>(primaryDecl))
+        DE.diagnose(srcLoc, diag::ambiguous_init, fromType, useToTypeSummary,
+                    toTypesSummaryS, toTypeStr);
+      else
+        DE.diagnose(srcLoc, diag::ambiguous_decl_ref_types, diagnosisName,
+                    fromType, useToTypeSummary, toTypesSummaryS, toTypeStr);
+    }
+    for (auto &entry : commonFixes) {
+      auto overload =
+          entry.first->getCalleeOverloadChoice(loc).choice.getDecl();
+      auto *fix = entry.second->castTo<AllowArgumentMismatch>();
+      if (!matchedDecls.contains(overload))
+        continue;
+
+      auto parameters = overload->getParameterList();
+      unsigned paramIdx =
+          entry.first->getFunctionArgApplyInfo(fix->getLocator())
+              ->getParamPosition();
+      if (closureAnchor && !fix->getToType()->is<AnyFunctionType>()) {
+        // TODO: make this take the parameter position
+        DE.diagnose(overload, diag::candidate_has_invalid_closure_at_position,
+                    entry.first->simplifyType(fix->getToType()));
+      } else
+        DE.diagnose(overload, diag::candidate_has_invalid_argument_at_position,
+                    entry.first->simplifyType(fix->getToType()), paramIdx,
+                    !parameters
+                        ? false
+                        : (parameters->size() == 0
+                               ? false
+                               : parameters->get(paramIdx - 1)->isInOut()),
+                    entry.first->simplifyType(fix->getFromType()));
+      matchedDecls.remove(overload);
+    }
+    return true;
+  }
+  return false;
 }
 
 AllowArgumentMismatch *
@@ -1987,6 +2275,11 @@ bool RemoveInvalidCall::diagnose(const Solution &solution, bool asNote) const {
   return failure.diagnose(asNote);
 }
 
+bool RemoveInvalidCall::diagnoseForAmbiguity(
+    CommonFixesArray commonFixes) const {
+  return diagnose(*commonFixes.front().first);
+}
+
 RemoveInvalidCall *RemoveInvalidCall::create(ConstraintSystem &cs,
                                              ConstraintLocator *locator) {
   return new (cs.getAllocator()) RemoveInvalidCall(cs, locator);
@@ -1998,6 +2291,11 @@ bool TreatEphemeralAsNonEphemeral::diagnose(const Solution &solution,
                                         getToType(), ConversionKind,
                                         fixBehavior);
   return failure.diagnose(asNote);
+}
+
+bool TreatEphemeralAsNonEphemeral::diagnoseForAmbiguity(
+    CommonFixesArray commonFixes) const {
+  return ContextualMismatch::diagnoseForAmbiguity(commonFixes);
 }
 
 TreatEphemeralAsNonEphemeral *TreatEphemeralAsNonEphemeral::create(
@@ -2024,6 +2322,11 @@ bool AllowSendingMismatch::diagnose(const Solution &solution,
   return failure.diagnose(asNote);
 }
 
+bool AllowSendingMismatch::diagnoseForAmbiguity(
+    CommonFixesArray commonFixes) const {
+  return diagnose(*commonFixes.front().first);
+}
+
 AllowSendingMismatch *AllowSendingMismatch::create(ConstraintSystem &cs,
                                                    Type srcType, Type dstType,
                                                    ConstraintLocator *locator) {
@@ -2039,6 +2342,11 @@ bool SpecifyBaseTypeForContextualMember::diagnose(const Solution &solution,
   MissingContextualBaseInMemberRefFailure failure(solution, MemberName,
                                                   getLocator());
   return failure.diagnose(asNote);
+}
+
+bool SpecifyBaseTypeForContextualMember::diagnoseForAmbiguity(
+    CommonFixesArray commonFixes) const {
+  return diagnose(*commonFixes.front().first);
 }
 
 SpecifyBaseTypeForContextualMember *SpecifyBaseTypeForContextualMember::create(
@@ -2069,6 +2377,11 @@ bool SpecifyClosureParameterType::diagnose(const Solution &solution,
   return failure.diagnose(asNote);
 }
 
+bool SpecifyClosureParameterType::diagnoseForAmbiguity(
+    CommonFixesArray commonFixes) const {
+  return diagnose(*commonFixes.front().first);
+}
+
 SpecifyClosureParameterType *
 SpecifyClosureParameterType::create(ConstraintSystem &cs,
                                     ConstraintLocator *locator) {
@@ -2079,6 +2392,11 @@ bool SpecifyClosureReturnType::diagnose(const Solution &solution,
                                         bool asNote) const {
   UnableToInferClosureReturnType failure(solution, getLocator());
   return failure.diagnose(asNote);
+}
+
+bool SpecifyClosureReturnType::diagnoseForAmbiguity(
+    CommonFixesArray commonFixes) const {
+  return diagnose(*commonFixes.front().first);
 }
 
 SpecifyClosureReturnType *
@@ -2190,6 +2508,11 @@ bool SpecifyKeyPathRootType::diagnose(const Solution &solution,
   return failure.diagnose(asNote);
 }
 
+bool SpecifyKeyPathRootType::diagnoseForAmbiguity(
+    CommonFixesArray commonFixes) const {
+  return diagnose(*commonFixes.front().first);
+}
+
 bool UnwrapOptionalBaseKeyPathApplication::diagnose(const Solution &solution,
                                                     bool asNote) const {
   MissingOptionalUnwrapKeyPathFailure failure(solution, getFromType(),
@@ -2256,6 +2579,11 @@ bool IgnoreInvalidResultBuilderBody::diagnose(const Solution &solution,
   return diag.diagnose(asNote);
 }
 
+bool IgnoreInvalidResultBuilderBody::diagnoseForAmbiguity(
+    CommonFixesArray commonFixes) const {
+  return diagnose(*commonFixes.front().first);
+}
+
 IgnoreInvalidResultBuilderBody *
 IgnoreInvalidResultBuilderBody::create(ConstraintSystem &cs,
                                        ConstraintLocator *locator) {
@@ -2270,6 +2598,11 @@ bool IgnoreInvalidASTNode::diagnose(const Solution &solution,
   return diag.diagnose(asNote);
 }
 
+bool IgnoreInvalidASTNode::diagnoseForAmbiguity(
+    CommonFixesArray commonFixes) const {
+  return diagnose(*commonFixes.front().first);
+}
+
 IgnoreInvalidASTNode *IgnoreInvalidASTNode::create(ConstraintSystem &cs,
                                                    ConstraintLocator *locator) {
   return new (cs.getAllocator()) IgnoreInvalidASTNode(cs, locator);
@@ -2279,6 +2612,11 @@ bool IgnoreInvalidPatternInExpr::diagnose(const Solution &solution,
                                           bool asNote) const {
   InvalidPatternInExprFailure failure(solution, P, getLocator());
   return failure.diagnose(asNote);
+}
+
+bool IgnoreInvalidPatternInExpr::diagnoseForAmbiguity(
+    CommonFixesArray commonFixes) const {
+  return diagnose(*commonFixes.front().first);
 }
 
 IgnoreInvalidPatternInExpr *
@@ -2294,6 +2632,11 @@ bool SpecifyContextualTypeForNil::diagnose(const Solution &solution,
   return failure.diagnose(asNote);
 }
 
+bool SpecifyContextualTypeForNil::diagnoseForAmbiguity(
+    CommonFixesArray commonFixes) const {
+  return diagnose(*commonFixes.front().first);
+}
+
 SpecifyContextualTypeForNil *
 SpecifyContextualTypeForNil::create(ConstraintSystem &cs,
                                     ConstraintLocator *locator) {
@@ -2304,6 +2647,11 @@ bool IgnoreInvalidPlaceholder::diagnose(const Solution &solution,
                                         bool asNote) const {
   InvalidPlaceholderFailure failure(solution, getLocator());
   return failure.diagnose(asNote);
+}
+
+bool IgnoreInvalidPlaceholder::diagnoseForAmbiguity(
+    CommonFixesArray commonFixes) const {
+  return diagnose(*commonFixes.front().first);
 }
 
 IgnoreInvalidPlaceholder *
@@ -2318,6 +2666,11 @@ bool SpecifyTypeForPlaceholder::diagnose(const Solution &solution,
   return failure.diagnose(asNote);
 }
 
+bool SpecifyTypeForPlaceholder::diagnoseForAmbiguity(
+    CommonFixesArray commonFixes) const {
+  return diagnose(*commonFixes.front().first);
+}
+
 SpecifyTypeForPlaceholder *
 SpecifyTypeForPlaceholder::create(ConstraintSystem &cs,
                                   ConstraintLocator *locator) {
@@ -2328,6 +2681,11 @@ bool AllowRefToInvalidDecl::diagnose(const Solution &solution,
                                      bool asNote) const {
   ReferenceToInvalidDeclaration failure(solution, getLocator());
   return failure.diagnose(asNote);
+}
+
+bool AllowRefToInvalidDecl::diagnoseForAmbiguity(
+    CommonFixesArray commonFixes) const {
+  return diagnose(*commonFixes.front().first);
 }
 
 AllowRefToInvalidDecl *
@@ -2355,6 +2713,11 @@ bool IgnoreUnresolvedPatternVar::diagnose(const Solution &solution,
   // that means we couldn't infer the pattern. We don't have a diagnostic to
   // emit here, the failure should be diagnosed by the fix for expression.
   return false;
+}
+
+bool IgnoreUnresolvedPatternVar::diagnoseForAmbiguity(
+    CommonFixesArray commonFixes) const {
+  return diagnose(*commonFixes.front().first);
 }
 
 IgnoreUnresolvedPatternVar *
@@ -2612,6 +2975,11 @@ bool AllowInvalidStaticMemberRefOnProtocolMetatype::diagnose(
   return failure.diagnose(asNote);
 }
 
+bool AllowInvalidStaticMemberRefOnProtocolMetatype::diagnoseForAmbiguity(
+    CommonFixesArray commonFixes) const {
+  return diagnose(*commonFixes.front().first);
+}
+
 AllowInvalidStaticMemberRefOnProtocolMetatype *
 AllowInvalidStaticMemberRefOnProtocolMetatype::create(
     ConstraintSystem &cs, ConstraintLocator *locator) {
@@ -2692,6 +3060,11 @@ bool RenameConflictingPatternVariables::diagnose(const Solution &solution,
   return failure.diagnose(asNote);
 }
 
+bool RenameConflictingPatternVariables::diagnoseForAmbiguity(
+    CommonFixesArray commonFixes) const {
+  return diagnose(*commonFixes.front().first);
+}
+
 RenameConflictingPatternVariables *
 RenameConflictingPatternVariables::create(ConstraintSystem &cs, Type expectedTy,
                                           ArrayRef<VarDecl *> conflicts,
@@ -2707,6 +3080,11 @@ bool MacroMissingPound::diagnose(const Solution &solution,
                                                  bool asNote) const {
   AddMissingMacroPound failure(solution, macro, getLocator());
   return failure.diagnose(asNote);
+}
+
+bool MacroMissingPound::diagnoseForAmbiguity(
+    CommonFixesArray commonFixes) const {
+  return diagnose(*commonFixes.front().first);
 }
 
 MacroMissingPound *
@@ -2749,6 +3127,11 @@ bool AllowValueExpansionWithoutPackReferences::diagnose(
   return failure.diagnose(asNote);
 }
 
+bool AllowValueExpansionWithoutPackReferences::diagnoseForAmbiguity(
+    CommonFixesArray commonFixes) const {
+  return diagnose(*commonFixes.front().first);
+}
+
 AllowValueExpansionWithoutPackReferences *
 AllowValueExpansionWithoutPackReferences::create(ConstraintSystem &cs,
                                                  ConstraintLocator *locator) {
@@ -2763,6 +3146,11 @@ bool IgnoreMissingEachKeyword::diagnose(const Solution &solution,
   return failure.diagnose(asNote);
 }
 
+bool IgnoreMissingEachKeyword::diagnoseForAmbiguity(
+    CommonFixesArray commonFixes) const {
+  return diagnose(*commonFixes.front().first);
+}
+
 IgnoreMissingEachKeyword *
 IgnoreMissingEachKeyword::create(ConstraintSystem &cs, Type valuePackTy,
                                  ConstraintLocator *locator) {
@@ -2775,6 +3163,11 @@ bool AllowInvalidMemberReferenceInInitAccessor::diagnose(
   InvalidMemberReferenceWithinInitAccessor failure(solution, MemberName,
                                                    getLocator());
   return failure.diagnose(asNote);
+}
+
+bool AllowInvalidMemberReferenceInInitAccessor::diagnoseForAmbiguity(
+    CommonFixesArray commonFixes) const {
+  return diagnose(*commonFixes.front().first);
 }
 
 AllowInvalidMemberReferenceInInitAccessor *
@@ -2792,6 +3185,11 @@ bool AllowConcreteTypeSpecialization::diagnose(const Solution &solution,
   return failure.diagnose(asNote);
 }
 
+bool AllowConcreteTypeSpecialization::diagnoseForAmbiguity(
+    CommonFixesArray commonFixes) const {
+  return diagnose(*commonFixes.front().first);
+}
+
 AllowConcreteTypeSpecialization *AllowConcreteTypeSpecialization::create(
     ConstraintSystem &cs, Type concreteTy, ValueDecl *decl,
     ConstraintLocator *locator, FixBehavior fixBehavior) {
@@ -2804,6 +3202,11 @@ bool AllowFunctionSpecialization::diagnose(const Solution &solution,
   InvalidFunctionSpecialization failure(solution, Decl, getLocator(),
                                         fixBehavior);
   return failure.diagnose(asNote);
+}
+
+bool AllowFunctionSpecialization::diagnoseForAmbiguity(
+    CommonFixesArray commonFixes) const {
+  return diagnose(*commonFixes.front().first);
 }
 
 AllowFunctionSpecialization *
@@ -2822,6 +3225,11 @@ bool IgnoreOutOfPlaceThenStmt::diagnose(const Solution &solution,
   return failure.diagnose(asNote);
 }
 
+bool IgnoreOutOfPlaceThenStmt::diagnoseForAmbiguity(
+    CommonFixesArray commonFixes) const {
+  return diagnose(*commonFixes.front().first);
+}
+
 IgnoreOutOfPlaceThenStmt *
 IgnoreOutOfPlaceThenStmt::create(ConstraintSystem &cs,
                                  ConstraintLocator *locator) {
@@ -2833,6 +3241,11 @@ bool IgnoreGenericSpecializationArityMismatch::diagnose(
   InvalidTypeSpecializationArity failure(solution, D, NumParams, NumArgs,
                                          HasParameterPack, getLocator());
   return failure.diagnose(asNote);
+}
+
+bool IgnoreGenericSpecializationArityMismatch::diagnoseForAmbiguity(
+    CommonFixesArray commonFixes) const {
+  return diagnose(*commonFixes.front().first);
 }
 
 IgnoreGenericSpecializationArityMismatch *
@@ -2886,6 +3299,11 @@ bool TooManyDynamicMemberLookups::diagnose(const Solution &solution,
   return failure.diagnose(asNote);
 }
 
+bool TooManyDynamicMemberLookups::diagnoseForAmbiguity(
+    CommonFixesArray commonFixes) const {
+  return diagnose(*commonFixes.front().first);
+}
+
 IgnoreIsolatedConformance *
 IgnoreIsolatedConformance::create(ConstraintSystem &cs,
                                   ConstraintLocator *locator,
@@ -2898,4 +3316,9 @@ bool IgnoreIsolatedConformance::diagnose(const Solution &solution,
                                          bool asNote) const {
   DisallowedIsolatedConformance failure(solution, conformance, getLocator());
   return failure.diagnose(asNote);
+}
+
+bool IgnoreIsolatedConformance::diagnoseForAmbiguity(
+    CommonFixesArray commonFixes) const {
+  return diagnose(*commonFixes.front().first);
 }

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -68,6 +68,10 @@ void ConstraintFix::print(llvm::raw_ostream &Out) const {
   getLocator()->dump(&CS.getASTContext().SourceMgr, Out);
 }
 
+bool ConstraintFix::diagnoseForAmbiguity(CommonFixesArray commonFixes) const {
+  return false;
+}
+
 void ConstraintFix::dump() const {print(llvm::errs()); }
 
 std::string ForceDowncast::getName() const {
@@ -108,6 +112,11 @@ bool UnwrapOptionalBase::diagnose(const Solution &solution, bool asNote) const {
   MemberAccessOnOptionalBaseFailure failure(solution, getLocator(), MemberName,
                                             MemberBaseType, resultIsOptional);
   return failure.diagnose(asNote);
+}
+
+bool UnwrapOptionalBase::diagnoseForAmbiguity(
+    CommonFixesArray commonFixes) const {
+  return diagnose(*commonFixes.front().first);
 }
 
 UnwrapOptionalBase *UnwrapOptionalBase::create(ConstraintSystem &cs,
@@ -167,6 +176,11 @@ FixImpact TreatRValueAsLValue::assessImpact(ConstraintSystem &cs,
   return impact;
 }
 
+bool TreatRValueAsLValue::diagnoseForAmbiguity(
+    CommonFixesArray commonFixes) const {
+    return diagnose(*commonFixes.front().first);
+}
+
 TreatRValueAsLValue *TreatRValueAsLValue::create(ConstraintSystem &cs,
                                    ConstraintLocator *locator) {
   if (locator->isLastElement<LocatorPathElt::ApplyArgToParam>())
@@ -218,6 +232,11 @@ bool TreatArrayLiteralAsDictionary::diagnose(const Solution &solution,
                                                     getToType(), getFromType(),
                                                     getLocator());
   return failure.diagnose(asNote);
+}
+
+bool TreatArrayLiteralAsDictionary::diagnoseForAmbiguity(
+    CommonFixesArray commonFixes) const {
+  return diagnose(*commonFixes.front().first);
 }
 
 TreatArrayLiteralAsDictionary *
@@ -861,6 +880,10 @@ bool RemoveUnwrap::diagnose(const Solution &solution, bool asNote) const {
   return failure.diagnose(asNote);
 }
 
+bool RemoveUnwrap::diagnoseForAmbiguity(CommonFixesArray commonFixes) const {
+  return diagnose(*commonFixes.front().first);
+}
+
 RemoveUnwrap *RemoveUnwrap::create(ConstraintSystem &cs, Type baseType,
                                    ConstraintLocator *locator) {
   return new (cs.getAllocator()) RemoveUnwrap(cs, baseType, locator);
@@ -882,6 +905,11 @@ bool UsePropertyWrapper::diagnose(const Solution &solution, bool asNote) const {
   return failure.diagnose(asNote);
 }
 
+bool UsePropertyWrapper::diagnoseForAmbiguity(
+    CommonFixesArray commonFixes) const {
+  return diagnose(*commonFixes.front().first);
+}
+
 UsePropertyWrapper *UsePropertyWrapper::create(ConstraintSystem &cs,
                                                VarDecl *wrapped,
                                                bool usingProjection,
@@ -898,6 +926,10 @@ bool UseWrappedValue::diagnose(const Solution &solution, bool asNote) const {
   return failure.diagnose(asNote);
 }
 
+bool UseWrappedValue::diagnoseForAmbiguity(CommonFixesArray commonFixes) const {
+  return diagnose(*commonFixes.front().first);
+}
+
 UseWrappedValue *UseWrappedValue::create(ConstraintSystem &cs,
                                          VarDecl *propertyWrapper, Type base,
                                          Type wrapper,
@@ -909,6 +941,11 @@ UseWrappedValue *UseWrappedValue::create(ConstraintSystem &cs,
 bool AllowInvalidPropertyWrapperType::diagnose(const Solution &solution, bool asNote) const {
   InvalidPropertyWrapperType failure(solution, wrapperType, getLocator());
   return failure.diagnose(asNote);
+}
+
+bool AllowInvalidPropertyWrapperType::diagnoseForAmbiguity(
+    CommonFixesArray commonFixes) const {
+  return diagnose(*commonFixes.front().first);
 }
 
 AllowInvalidPropertyWrapperType *
@@ -1147,6 +1184,11 @@ bool AddMissingArguments::diagnose(const Solution &solution,
   return failure.diagnose(asNote);
 }
 
+bool AddMissingArguments::diagnoseForAmbiguity(
+    CommonFixesArray commonFixes) const {
+  return diagnose(*commonFixes.front().first);
+}
+
 AddMissingArguments *
 AddMissingArguments::create(ConstraintSystem &cs,
                             ArrayRef<SynthesizedArg> synthesizedArgs,
@@ -1161,6 +1203,11 @@ bool RemoveExtraneousArguments::diagnose(const Solution &solution,
   ExtraneousArgumentsFailure failure(solution, ContextualType,
                                      getExtraArguments(), getLocator());
   return failure.diagnose(asNote);
+}
+
+bool RemoveExtraneousArguments::diagnoseForAmbiguity(
+    CommonFixesArray commonFixes) const {
+  return diagnose(*commonFixes.front().first);
 }
 
 bool RemoveExtraneousArguments::isMinMaxNameShadowing(
@@ -1233,6 +1280,11 @@ bool AllowInaccessibleMember::diagnose(const Solution &solution,
                                        bool asNote) const {
   InaccessibleMemberFailure failure(solution, getMember(), getLocator());
   return failure.diagnose(asNote);
+}
+
+bool AllowInaccessibleMember::diagnoseForAmbiguity(
+    CommonFixesArray commonFixes) const {
+  return diagnose(*commonFixes.front().first);
 }
 
 AllowInaccessibleMember *
@@ -1640,6 +1692,11 @@ bool DefaultGenericArgument::diagnose(const Solution &solution,
   return coalesceAndDiagnose(solution, {}, asNote);
 }
 
+bool DefaultGenericArgument::diagnoseForAmbiguity(
+    CommonFixesArray commonFixes) const {
+  return diagnose(*commonFixes.front().first);
+}
+
 DefaultGenericArgument *
 DefaultGenericArgument::create(ConstraintSystem &cs, GenericTypeParamType *param,
                                ConstraintLocator *locator) {
@@ -1972,17 +2029,15 @@ bool UseRawValue::diagnose(const Solution &solution, bool asNote) const {
   return failure.diagnose(asNote);
 }
 
+bool UseRawValue::diagnoseForAmbiguity(CommonFixesArray commonFixes) const {
+  return diagnose(*commonFixes.front().first);
+}
+
 UseRawValue *UseRawValue::create(ConstraintSystem &cs, Type rawReprType,
                                  Type expectedType,
                                  ConstraintLocator *locator) {
   return new (cs.getAllocator())
       UseRawValue(cs, rawReprType, expectedType, locator);
-}
-
-unsigned AllowArgumentMismatch::getParamIdx() const {
-  const auto *locator = getLocator();
-  auto elt = locator->castLastElementTo<LocatorPathElt::ApplyArgToParam>();
-  return elt.getParamIdx();
 }
 
 bool AllowArgumentMismatch::diagnose(const Solution &solution,
@@ -1995,6 +2050,28 @@ bool AllowArgumentMismatch::diagnose(const Solution &solution,
   return failure.value().diagnose(asNote);
 }
 
+bool AllowArgumentMismatch::diagnoseForAmbiguity(
+  CommonFixesArray commonFixes) const {
+
+  SmallVector<ArgumentMismatchFailure, 4> diagnostics;
+  for (auto commonFix : commonFixes) {
+    auto currentFix = commonFix.second->getAs<AllowArgumentMismatch>();
+    std::optional<ArgumentMismatchFailure> failure =
+      ArgumentMismatchFailure::create(*commonFix.first,
+                                      currentFix->getFromType(),
+                                      currentFix->getToType(),
+                                      currentFix->getLocator());
+    if (failure.has_value())
+      diagnostics.emplace_back(std::move(failure.value()));
+  }
+
+  if (diagnostics.size() > 1)
+    return diagnostics[0].diagnoseForAmbiguity(diagnostics);
+  if (diagnostics.size() == 1)
+    return diagnostics[0].diagnoseAsError();
+  return false;
+}
+
 AllowArgumentMismatch *
 AllowArgumentMismatch::create(ConstraintSystem &cs, Type argType,
                               Type paramType, ConstraintLocator *locator) {
@@ -2005,6 +2082,11 @@ AllowArgumentMismatch::create(ConstraintSystem &cs, Type argType,
 bool RemoveInvalidCall::diagnose(const Solution &solution, bool asNote) const {
   ExtraneousCallFailure failure(solution, getLocator());
   return failure.diagnose(asNote);
+}
+
+bool RemoveInvalidCall::diagnoseForAmbiguity(
+    CommonFixesArray commonFixes) const {
+  return diagnose(*commonFixes.front().first);
 }
 
 RemoveInvalidCall *RemoveInvalidCall::create(ConstraintSystem &cs,
@@ -2022,6 +2104,11 @@ bool TreatEphemeralAsNonEphemeral::diagnose(const Solution &solution,
   if (failure.has_value())
     return failure.value().diagnose(asNote);
   return false;
+}
+
+bool TreatEphemeralAsNonEphemeral::diagnoseForAmbiguity(
+    CommonFixesArray commonFixes) const {
+  return ContextualMismatch::diagnoseForAmbiguity(commonFixes);
 }
 
 TreatEphemeralAsNonEphemeral *TreatEphemeralAsNonEphemeral::create(
@@ -2048,6 +2135,11 @@ bool AllowSendingMismatch::diagnose(const Solution &solution,
   return failure.diagnose(asNote);
 }
 
+bool AllowSendingMismatch::diagnoseForAmbiguity(
+    CommonFixesArray commonFixes) const {
+  return diagnose(*commonFixes.front().first);
+}
+
 AllowSendingMismatch *AllowSendingMismatch::create(ConstraintSystem &cs,
                                                    Type srcType, Type dstType,
                                                    ConstraintLocator *locator) {
@@ -2063,6 +2155,11 @@ bool SpecifyBaseTypeForContextualMember::diagnose(const Solution &solution,
   MissingContextualBaseInMemberRefFailure failure(solution, MemberName,
                                                   getLocator());
   return failure.diagnose(asNote);
+}
+
+bool SpecifyBaseTypeForContextualMember::diagnoseForAmbiguity(
+    CommonFixesArray commonFixes) const {
+  return diagnose(*commonFixes.front().first);
 }
 
 SpecifyBaseTypeForContextualMember *SpecifyBaseTypeForContextualMember::create(
@@ -2093,6 +2190,11 @@ bool SpecifyClosureParameterType::diagnose(const Solution &solution,
   return failure.diagnose(asNote);
 }
 
+bool SpecifyClosureParameterType::diagnoseForAmbiguity(
+    CommonFixesArray commonFixes) const {
+  return diagnose(*commonFixes.front().first);
+}
+
 SpecifyClosureParameterType *
 SpecifyClosureParameterType::create(ConstraintSystem &cs,
                                     ConstraintLocator *locator) {
@@ -2103,6 +2205,11 @@ bool SpecifyClosureReturnType::diagnose(const Solution &solution,
                                         bool asNote) const {
   UnableToInferClosureReturnType failure(solution, getLocator());
   return failure.diagnose(asNote);
+}
+
+bool SpecifyClosureReturnType::diagnoseForAmbiguity(
+    CommonFixesArray commonFixes) const {
+  return diagnose(*commonFixes.front().first);
 }
 
 SpecifyClosureReturnType *
@@ -2214,6 +2321,11 @@ bool SpecifyKeyPathRootType::diagnose(const Solution &solution,
   return failure.diagnose(asNote);
 }
 
+bool SpecifyKeyPathRootType::diagnoseForAmbiguity(
+    CommonFixesArray commonFixes) const {
+  return diagnose(*commonFixes.front().first);
+}
+
 bool UnwrapOptionalBaseKeyPathApplication::diagnose(const Solution &solution,
                                                     bool asNote) const {
   MissingOptionalUnwrapKeyPathFailure failure(solution, getFromType(),
@@ -2280,6 +2392,11 @@ bool IgnoreInvalidResultBuilderBody::diagnose(const Solution &solution,
   return diag.diagnose(asNote);
 }
 
+bool IgnoreInvalidResultBuilderBody::diagnoseForAmbiguity(
+    CommonFixesArray commonFixes) const {
+  return diagnose(*commonFixes.front().first);
+}
+
 IgnoreInvalidResultBuilderBody *
 IgnoreInvalidResultBuilderBody::create(ConstraintSystem &cs,
                                        ConstraintLocator *locator) {
@@ -2294,6 +2411,11 @@ bool IgnoreInvalidASTNode::diagnose(const Solution &solution,
   return diag.diagnose(asNote);
 }
 
+bool IgnoreInvalidASTNode::diagnoseForAmbiguity(
+    CommonFixesArray commonFixes) const {
+  return diagnose(*commonFixes.front().first);
+}
+
 IgnoreInvalidASTNode *IgnoreInvalidASTNode::create(ConstraintSystem &cs,
                                                    ConstraintLocator *locator) {
   return new (cs.getAllocator()) IgnoreInvalidASTNode(cs, locator);
@@ -2303,6 +2425,11 @@ bool IgnoreInvalidPatternInExpr::diagnose(const Solution &solution,
                                           bool asNote) const {
   InvalidPatternInExprFailure failure(solution, P, getLocator());
   return failure.diagnose(asNote);
+}
+
+bool IgnoreInvalidPatternInExpr::diagnoseForAmbiguity(
+    CommonFixesArray commonFixes) const {
+  return diagnose(*commonFixes.front().first);
 }
 
 IgnoreInvalidPatternInExpr *
@@ -2318,6 +2445,11 @@ bool SpecifyContextualTypeForNil::diagnose(const Solution &solution,
   return failure.diagnose(asNote);
 }
 
+bool SpecifyContextualTypeForNil::diagnoseForAmbiguity(
+    CommonFixesArray commonFixes) const {
+  return diagnose(*commonFixes.front().first);
+}
+
 SpecifyContextualTypeForNil *
 SpecifyContextualTypeForNil::create(ConstraintSystem &cs,
                                     ConstraintLocator *locator) {
@@ -2328,6 +2460,11 @@ bool IgnoreInvalidPlaceholder::diagnose(const Solution &solution,
                                         bool asNote) const {
   InvalidPlaceholderFailure failure(solution, getLocator());
   return failure.diagnose(asNote);
+}
+
+bool IgnoreInvalidPlaceholder::diagnoseForAmbiguity(
+    CommonFixesArray commonFixes) const {
+  return diagnose(*commonFixes.front().first);
 }
 
 IgnoreInvalidPlaceholder *
@@ -2342,6 +2479,11 @@ bool SpecifyTypeForPlaceholder::diagnose(const Solution &solution,
   return failure.diagnose(asNote);
 }
 
+bool SpecifyTypeForPlaceholder::diagnoseForAmbiguity(
+    CommonFixesArray commonFixes) const {
+  return diagnose(*commonFixes.front().first);
+}
+
 SpecifyTypeForPlaceholder *
 SpecifyTypeForPlaceholder::create(ConstraintSystem &cs,
                                   ConstraintLocator *locator) {
@@ -2352,6 +2494,11 @@ bool AllowRefToInvalidDecl::diagnose(const Solution &solution,
                                      bool asNote) const {
   ReferenceToInvalidDeclaration failure(solution, getLocator());
   return failure.diagnose(asNote);
+}
+
+bool AllowRefToInvalidDecl::diagnoseForAmbiguity(
+    CommonFixesArray commonFixes) const {
+  return diagnose(*commonFixes.front().first);
 }
 
 AllowRefToInvalidDecl *
@@ -2379,6 +2526,11 @@ bool IgnoreUnresolvedPatternVar::diagnose(const Solution &solution,
   // that means we couldn't infer the pattern. We don't have a diagnostic to
   // emit here, the failure should be diagnosed by the fix for expression.
   return false;
+}
+
+bool IgnoreUnresolvedPatternVar::diagnoseForAmbiguity(
+    CommonFixesArray commonFixes) const {
+  return diagnose(*commonFixes.front().first);
 }
 
 IgnoreUnresolvedPatternVar *
@@ -2636,6 +2788,11 @@ bool AllowInvalidStaticMemberRefOnProtocolMetatype::diagnose(
   return failure.diagnose(asNote);
 }
 
+bool AllowInvalidStaticMemberRefOnProtocolMetatype::diagnoseForAmbiguity(
+    CommonFixesArray commonFixes) const {
+  return diagnose(*commonFixes.front().first);
+}
+
 AllowInvalidStaticMemberRefOnProtocolMetatype *
 AllowInvalidStaticMemberRefOnProtocolMetatype::create(
     ConstraintSystem &cs, ConstraintLocator *locator) {
@@ -2716,6 +2873,11 @@ bool RenameConflictingPatternVariables::diagnose(const Solution &solution,
   return failure.diagnose(asNote);
 }
 
+bool RenameConflictingPatternVariables::diagnoseForAmbiguity(
+    CommonFixesArray commonFixes) const {
+  return diagnose(*commonFixes.front().first);
+}
+
 RenameConflictingPatternVariables *
 RenameConflictingPatternVariables::create(ConstraintSystem &cs, Type expectedTy,
                                           ArrayRef<VarDecl *> conflicts,
@@ -2731,6 +2893,11 @@ bool MacroMissingPound::diagnose(const Solution &solution,
                                                  bool asNote) const {
   AddMissingMacroPound failure(solution, macro, getLocator());
   return failure.diagnose(asNote);
+}
+
+bool MacroMissingPound::diagnoseForAmbiguity(
+    CommonFixesArray commonFixes) const {
+  return diagnose(*commonFixes.front().first);
 }
 
 MacroMissingPound *
@@ -2773,6 +2940,11 @@ bool AllowValueExpansionWithoutPackReferences::diagnose(
   return failure.diagnose(asNote);
 }
 
+bool AllowValueExpansionWithoutPackReferences::diagnoseForAmbiguity(
+    CommonFixesArray commonFixes) const {
+  return diagnose(*commonFixes.front().first);
+}
+
 AllowValueExpansionWithoutPackReferences *
 AllowValueExpansionWithoutPackReferences::create(ConstraintSystem &cs,
                                                  ConstraintLocator *locator) {
@@ -2787,6 +2959,11 @@ bool IgnoreMissingEachKeyword::diagnose(const Solution &solution,
   return failure.diagnose(asNote);
 }
 
+bool IgnoreMissingEachKeyword::diagnoseForAmbiguity(
+    CommonFixesArray commonFixes) const {
+  return diagnose(*commonFixes.front().first);
+}
+
 IgnoreMissingEachKeyword *
 IgnoreMissingEachKeyword::create(ConstraintSystem &cs, Type valuePackTy,
                                  ConstraintLocator *locator) {
@@ -2799,6 +2976,11 @@ bool AllowInvalidMemberReferenceInInitAccessor::diagnose(
   InvalidMemberReferenceWithinInitAccessor failure(solution, MemberName,
                                                    getLocator());
   return failure.diagnose(asNote);
+}
+
+bool AllowInvalidMemberReferenceInInitAccessor::diagnoseForAmbiguity(
+    CommonFixesArray commonFixes) const {
+  return diagnose(*commonFixes.front().first);
 }
 
 AllowInvalidMemberReferenceInInitAccessor *
@@ -2816,6 +2998,11 @@ bool AllowConcreteTypeSpecialization::diagnose(const Solution &solution,
   return failure.diagnose(asNote);
 }
 
+bool AllowConcreteTypeSpecialization::diagnoseForAmbiguity(
+    CommonFixesArray commonFixes) const {
+  return diagnose(*commonFixes.front().first);
+}
+
 AllowConcreteTypeSpecialization *AllowConcreteTypeSpecialization::create(
     ConstraintSystem &cs, Type concreteTy, ValueDecl *decl,
     ConstraintLocator *locator, FixBehavior fixBehavior) {
@@ -2828,6 +3015,11 @@ bool AllowFunctionSpecialization::diagnose(const Solution &solution,
   InvalidFunctionSpecialization failure(solution, Decl, getLocator(),
                                         fixBehavior);
   return failure.diagnose(asNote);
+}
+
+bool AllowFunctionSpecialization::diagnoseForAmbiguity(
+    CommonFixesArray commonFixes) const {
+  return diagnose(*commonFixes.front().first);
 }
 
 AllowFunctionSpecialization *
@@ -2846,6 +3038,11 @@ bool IgnoreOutOfPlaceThenStmt::diagnose(const Solution &solution,
   return failure.diagnose(asNote);
 }
 
+bool IgnoreOutOfPlaceThenStmt::diagnoseForAmbiguity(
+    CommonFixesArray commonFixes) const {
+  return diagnose(*commonFixes.front().first);
+}
+
 IgnoreOutOfPlaceThenStmt *
 IgnoreOutOfPlaceThenStmt::create(ConstraintSystem &cs,
                                  ConstraintLocator *locator) {
@@ -2857,6 +3054,11 @@ bool IgnoreGenericSpecializationArityMismatch::diagnose(
   InvalidTypeSpecializationArity failure(solution, D, NumParams, NumArgs,
                                          HasParameterPack, getLocator());
   return failure.diagnose(asNote);
+}
+
+bool IgnoreGenericSpecializationArityMismatch::diagnoseForAmbiguity(
+    CommonFixesArray commonFixes) const {
+  return diagnose(*commonFixes.front().first);
 }
 
 IgnoreGenericSpecializationArityMismatch *
@@ -2911,6 +3113,11 @@ bool TooManyDynamicMemberLookups::diagnose(const Solution &solution,
   return failure.diagnose(asNote);
 }
 
+bool TooManyDynamicMemberLookups::diagnoseForAmbiguity(
+    CommonFixesArray commonFixes) const {
+  return diagnose(*commonFixes.front().first);
+}
+
 IgnoreIsolatedConformance *
 IgnoreIsolatedConformance::create(ConstraintSystem &cs,
                                   ConstraintLocator *locator,
@@ -2923,6 +3130,11 @@ bool IgnoreIsolatedConformance::diagnose(const Solution &solution,
                                          bool asNote) const {
   DisallowedIsolatedConformance failure(solution, conformance, getLocator());
   return failure.diagnose(asNote);
+}
+
+bool IgnoreIsolatedConformance::diagnoseForAmbiguity(
+    CommonFixesArray commonFixes) const {
+  return diagnose(*commonFixes.front().first);
 }
 
 IgnoreClassRequirementForDynamicMemberLookup *

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2564,7 +2564,8 @@ static bool diagnoseAmbiguityWithContextualType(
 /// same-type requirement mismatches, etc.
 static bool diagnoseAmbiguityWithGenericRequirements(
     ConstraintSystem &cs,
-    ArrayRef<std::pair<const Solution *, const ConstraintFix *>> aggregate) {
+    ArrayRef<std::pair<const Solution *, const ConstraintFix *>> aggregate,
+    const SolutionDiff &diff) {
   // If all of the fixes point to the same overload choice,
   // we can diagnose this an a single error.
   bool hasNonDeclOverloads = false;
@@ -2621,7 +2622,7 @@ static bool diagnoseAmbiguityWithGenericRequirements(
 static bool diagnoseAmbiguity(
     ConstraintSystem &cs, const SolutionDiff::OverloadDiff &ambiguity,
     ArrayRef<std::pair<const Solution *, const ConstraintFix *>> aggregateFix,
-    ArrayRef<Solution> solutions) {
+    const SolutionDiff &diff, ArrayRef<Solution> solutions) {
   auto *locator = aggregateFix.front().second->getLocator();
   auto anchor = aggregateFix.front().second->getAnchor();
 
@@ -3078,7 +3079,8 @@ bool ConstraintSystem::diagnoseAmbiguityWithFixes(
       continue;
 
     auto aggregate = fixes->second;
-    diagnosed |= ::diagnoseAmbiguity(*this, ambiguity, aggregate, solutions);
+    diagnosed |= ::diagnoseAmbiguity(*this, ambiguity, aggregate, solutionDiff,
+                                     solutions);
 
     consideredFixes.insert(aggregate.begin(), aggregate.end());
   }
@@ -3138,7 +3140,8 @@ bool ConstraintSystem::diagnoseAmbiguityWithFixes(
     }
 
     for (auto &aggregate : viableGroups) {
-      if (diagnoseAmbiguityWithGenericRequirements(*this, aggregate)) {
+      if (diagnoseAmbiguityWithGenericRequirements(*this, aggregate,
+                                                   solutionDiff)) {
         // Remove diagnosed fixes.
         fixes.set_subtract(aggregate);
         diagnosed = true;

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2573,7 +2573,8 @@ static bool diagnoseAmbiguityWithContextualType(
 /// same-type requirement mismatches, etc.
 static bool diagnoseAmbiguityWithGenericRequirements(
     ConstraintSystem &cs,
-    ArrayRef<std::pair<const Solution *, const ConstraintFix *>> aggregate) {
+    ArrayRef<std::pair<const Solution *, const ConstraintFix *>> aggregate,
+    const SolutionDiff &diff) {
   // If all of the fixes point to the same overload choice,
   // we can diagnose this an a single error.
   bool hasNonDeclOverloads = false;
@@ -2630,7 +2631,7 @@ static bool diagnoseAmbiguityWithGenericRequirements(
 static bool diagnoseAmbiguity(
     ConstraintSystem &cs, const SolutionDiff::OverloadDiff &ambiguity,
     ArrayRef<std::pair<const Solution *, const ConstraintFix *>> aggregateFix,
-    ArrayRef<Solution> solutions) {
+    const SolutionDiff &diff, ArrayRef<Solution> solutions) {
   auto *locator = aggregateFix.front().second->getLocator();
   auto anchor = aggregateFix.front().second->getAnchor();
 
@@ -3087,7 +3088,8 @@ bool ConstraintSystem::diagnoseAmbiguityWithFixes(
       continue;
 
     auto aggregate = fixes->second;
-    diagnosed |= ::diagnoseAmbiguity(*this, ambiguity, aggregate, solutions);
+    diagnosed |= ::diagnoseAmbiguity(*this, ambiguity, aggregate, solutionDiff,
+                                     solutions);
 
     consideredFixes.insert(aggregate.begin(), aggregate.end());
   }
@@ -3147,7 +3149,8 @@ bool ConstraintSystem::diagnoseAmbiguityWithFixes(
     }
 
     for (auto &aggregate : viableGroups) {
-      if (diagnoseAmbiguityWithGenericRequirements(*this, aggregate)) {
+      if (diagnoseAmbiguityWithGenericRequirements(*this, aggregate,
+                                                   solutionDiff)) {
         // Remove diagnosed fixes.
         fixes.set_subtract(aggregate);
         diagnosed = true;

--- a/test/AssociatedTypeInference/missing_conformance.swift
+++ b/test/AssociatedTypeInference/missing_conformance.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated
+// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -verify-ignore-unknown
 
 // Test candidates for witnesses that are missing conformances
 // in various ways.

--- a/test/Constraints/bridging.swift
+++ b/test/Constraints/bridging.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated
+// RUN: %target-swift-frontend -typecheck -verify -verify-ignore-unknown -verify-ignore-unrelated %s
 
 // REQUIRES: objc_interop
 
@@ -272,9 +272,8 @@ func rdar19831919() {
 
 // <rdar://problem/19831698> Incorrect 'as' fixits offered for invalid literal expressions
 func rdar19831698() {
-  var v70 = true + 1 // expected-error@:13 {{cannot convert value of type 'Bool' to expected argument type 'Int'}}
-  var v71 = true + 1.0 // expected-error{{binary operator '+' cannot be applied to operands of type 'Bool' and 'Double'}}
-// expected-note@-1{{overloads for '+'}}
+  var v70 = true + 1 // expected-error@:18 {{cannot convert value of type 'Bool' to expected '+' operand type 'Int'}}
+  var v71 = true + 1.0 // expected-error@:18 {{ambiguous use of '+'; cannot convert argument of type 'Bool' to any of potential types 'Date', 'DispatchTime', 'DispatchWallTime', 'Double'}}
   var v72 = true + true // expected-error{{binary operator '+' cannot be applied to two 'Bool' operands}}
   var v73 = true + [] // expected-error@:13 {{cannot convert value of type 'Bool' to expected argument type 'Array<Bool>'}}
   var v75 = true + "str" // expected-error@:13 {{cannot convert value of type 'Bool' to expected argument type 'String'}}

--- a/test/Constraints/bridging.swift
+++ b/test/Constraints/bridging.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated
+// RUN: %target-swift-frontend -typecheck -verify -verify-ignore-unknown -verify-ignore-unrelated %s
 
 // REQUIRES: objc_interop
 
@@ -272,9 +272,8 @@ func rdar19831919() {
 
 // <rdar://problem/19831698> Incorrect 'as' fixits offered for invalid literal expressions
 func rdar19831698() {
-  var v70 = true + 1 // expected-error@:13 {{cannot convert value of type 'Bool' to expected argument type 'Int'}}
-  var v71 = true + 1.0 // expected-error{{binary operator '+' cannot be applied to operands of type 'Bool' and 'Double'}}
-// expected-note@-1{{overloads for '+'}}
+  var v70 = true + 1 // expected-error@:13 {{cannot convert value of type 'Bool' to expected '+' operand type 'Int'}}
+  var v71 = true + 1.0 // expected-error@:13 {{no exact '+' candidates found; cannot convert argument of type 'Bool' to any of potential types 'Date', 'DispatchTime', 'DispatchWallTime', 'Double'}}
   var v72 = true + true // expected-error{{binary operator '+' cannot be applied to two 'Bool' operands}}
   var v73 = true + [] // expected-error@:13 {{cannot convert value of type 'Bool' to expected argument type 'Array<Bool>'}}
   var v75 = true + "str" // expected-error@:13 {{cannot convert value of type 'Bool' to expected argument type 'String'}}

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -362,11 +362,11 @@ takeVoidVoidFn { () -> Void in
 
 // <rdar://problem/19997471> Swift: Incorrect compile error when calling a function inside a closure
 func f19997471(_ x: String) {} // expected-note {{candidate expects value of type 'String' for parameter #1 (got 'T')}}
-func f19997471(_ x: Int) {}    // expected-note {{candidate expects value of type 'Int' for parameter #1 (got 'T')}}
+func f19997471(_ x: Int) {} // expected-note {{candidate expects value of type 'Int' for parameter #1 (got 'T')}}
 
 func someGeneric19997471<T>(_ x: T) {
   takeVoidVoidFn {
-    f19997471(x) // expected-error {{no exact matches in call to global function 'f19997471'}}
+    f19997471(x) // expected-error {{ambiguous use of 'f19997471'; cannot convert argument of type 'T' to any of potential types 'Int', 'String'}}
   }
 }
 
@@ -788,7 +788,7 @@ takesTwoInOut { _ in } // expected-error {{contextual closure type '(Int, inout 
 func f20371273() {
   let x: [Int] = [1, 2, 3, 4]
   let y: UInt = 4
-  _ = x.filter { ($0 + y)  > 42 } // expected-error {{cannot convert value of type 'UInt' to expected argument type 'Int'}}
+  _ = x.filter { ($0 + y)  > 42 } // expected-error {{cannot convert value of type 'UInt' to expected '+' operand type 'Int'}}
 }
 
 // rdar://problem/42337247
@@ -1260,7 +1260,7 @@ do {
   func test(_: Int, _: String) {}
   // expected-note@-1 {{closure passed to parameter of type 'String' that does not accept a closure}}
 
-  test(42) { // expected-error {{no exact matches in call to local function 'test'}}
+  test(42) { // expected-error {{closure argument passed to 'test', which expects potential types 'Int', 'String'}}
     print($0)
   }
 }

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -362,11 +362,11 @@ takeVoidVoidFn { () -> Void in
 
 // <rdar://problem/19997471> Swift: Incorrect compile error when calling a function inside a closure
 func f19997471(_ x: String) {} // expected-note {{candidate expects value of type 'String' for parameter #1 (got 'T')}}
-func f19997471(_ x: Int) {}    // expected-note {{candidate expects value of type 'Int' for parameter #1 (got 'T')}}
+func f19997471(_ x: Int) {} // expected-note {{candidate expects value of type 'Int' for parameter #1 (got 'T')}}
 
 func someGeneric19997471<T>(_ x: T) {
   takeVoidVoidFn {
-    f19997471(x) // expected-error {{no exact matches in call to global function 'f19997471'}}
+    f19997471(x) // expected-error {{no exact 'f19997471' candidates found; cannot convert argument of type 'T' to any of potential types 'Int', 'String'}}
   }
 }
 
@@ -788,7 +788,7 @@ takesTwoInOut { _ in } // expected-error {{contextual closure type '(Int, inout 
 func f20371273() {
   let x: [Int] = [1, 2, 3, 4]
   let y: UInt = 4
-  _ = x.filter { ($0 + y)  > 42 } // expected-error {{cannot convert value of type 'UInt' to expected argument type 'Int'}}
+  _ = x.filter { ($0 + y)  > 42 } // expected-error {{cannot convert value of type 'UInt' to expected '+' operand type 'Int'}}
 }
 
 // rdar://problem/42337247
@@ -1257,7 +1257,7 @@ do {
   func test(_: Int, _: String) {}
   // expected-note@-1 {{closure passed to parameter of type 'String' that does not accept a closure}}
 
-  test(42) { // expected-error {{no exact matches in call to local function 'test'}}
+  test(42) { // expected-error {{closure argument passed to 'test', which expects potential types 'Int', 'String'}}
     print($0)
   }
 }

--- a/test/Constraints/construction.swift
+++ b/test/Constraints/construction.swift
@@ -95,9 +95,9 @@ _ = b as! Derived
 //  are special cased in the library.
 Int(i) // expected-warning{{unused}}
 _ = i as Int
-Z(z) // expected-error{{no exact matches in call to initializer}}
+Z(z) // expected-error{{ambiguous use of initializer; cannot convert argument of type 'Z' to any of potential types 'String', 'UnicodeScalar'}}
 
-Z.init(z)  // expected-error {{no exact matches in call to initializer}}
+Z.init(z)  // expected-error {{ambiguous use of initializer; cannot convert argument of type 'Z' to any of potential types 'String', 'UnicodeScalar'}}
 
 
 _ = z as Z

--- a/test/Constraints/construction.swift
+++ b/test/Constraints/construction.swift
@@ -95,9 +95,9 @@ _ = b as! Derived
 //  are special cased in the library.
 Int(i) // expected-warning{{unused}}
 _ = i as Int
-Z(z) // expected-error{{no exact matches in call to initializer}}
+Z(z) // expected-error{{no exact initializer candidates found; cannot convert argument of type 'Z' to any of potential types 'String', 'UnicodeScalar'}}
 
-Z.init(z)  // expected-error {{no exact matches in call to initializer}}
+Z.init(z)  // expected-error {{no exact initializer candidates found; cannot convert argument of type 'Z' to any of potential types 'String', 'UnicodeScalar'}}
 
 
 _ = z as Z

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated
+// RUN: %target-swift-frontend -typecheck -verify -verify-ignore-unknown -verify-ignore-unrelated %s
 
 protocol P {
   associatedtype SomeType
@@ -718,9 +718,8 @@ func r24251022() {
   var a = 1
   var b: UInt32 = 2
   _ = a + b // expected-error {{binary operator '+' cannot be applied to operands of type 'Int' and 'UInt32'}} expected-note {{overloads for '+' exist with these partially matching parameter lists: (Int, Int), (UInt32, UInt32)}}
-  a += a +
-    b // expected-error {{cannot convert value of type 'UInt32' to expected argument type 'Int'}}
-  a += b  // expected-error@:8 {{cannot convert value of type 'UInt32' to expected argument type 'Int'}}
+  a += a + b // expected-error {{cannot convert value of type 'UInt32' to expected '+' operand type 'Int'}}
+  a += b  // expected-error {{cannot convert value of type 'UInt32' to expected '+=' operand type 'Int'}}
 }
 
 func overloadSetResultType(_ a : Int, b : Int) -> Int {
@@ -821,7 +820,7 @@ func read<T : BinaryInteger>() -> T? {
 
 func f23213302() {
   var s = Set<Int>()
-  s.subtract(1) // expected-error {{cannot convert value of type 'Int' to expected argument type 'Set<Int>'}}
+  s.subtract(1) // expected-error {{cannot convert argument of type 'Int' to expected argument type 'Set<Int>' for 'subtract'}}
 }
 
 // <rdar://problem/24202058> QoI: Return of call to overloaded function in void-return context
@@ -887,7 +886,7 @@ do {
   let a: Int = 1
   let b: Int = 2
   let result = a / b
-  foo.bar(value: a / b)  // expected-error {{cannot convert value of type 'Int' to expected argument type 'UInt'}}
+  foo.bar(value: a / b)  // expected-error {{cannot convert argument of type 'Int' to expected argument type 'UInt' for 'bar'}}
   foo.bar(value: result) // expected-error {{cannot convert value of type 'Int' to expected argument type 'UInt'}}
   foo.bar(value: UInt(result)) // Ok
 }
@@ -952,10 +951,10 @@ do {
     case bar
   }
 
-  // expected-error@+1 {{cannot convert value of type 'Float' to expected argument type 'Int'}} {{35-35=Int(}} {{43-43=)}}
+  // expected-error@+1 {{cannot convert value of type 'Float' to expected '*' operand type 'Int'}}{{35-35=Int(}}{{43-43=)}}
   let _: Int = Foo.bar.rawValue * Float(0)
 
-  // expected-error@+1 {{cannot convert value of type 'Int' to expected argument type 'Float'}} {{18-18=Float(}} {{34-34=)}}
+  // expected-error@+1 {{cannot convert value of type 'Int' to expected '*' operand type 'Float'}}
   let _: Float = Foo.bar.rawValue * Float(0)
 
   // expected-error@+2 {{binary operator '*' cannot be applied to operands of type 'Int' and 'Float'}} {{none}}
@@ -966,10 +965,10 @@ do {
   let lhs = Float(3)
   let rhs = Int(0)
 
-  // expected-error@+1 {{cannot convert value of type 'Int' to expected argument type 'Float'}} {{24-24=Float(}} {{27-27=)}}
+  // expected-error@+1 {{cannot convert value of type 'Int' to expected '*' operand type 'Float'}}
   let _: Float = lhs * rhs
 
-  // expected-error@+1 {{cannot convert value of type 'Float' to expected argument type 'Int'}} {{16-16=Int(}} {{19-19=)}}
+  // expected-error@+1 {{cannot convert value of type 'Float' to expected '*' operand type 'Int'}}
   let _: Int = lhs * rhs
 
   // expected-error@+2 {{binary operator '*' cannot be applied to operands of type 'Float' and 'Int'}} {{none}}
@@ -977,11 +976,11 @@ do {
   lhs * rhs
 }
 do {
-  // expected-error@+1 {{cannot convert value of type 'String' to expected argument type 'Int'}} {{none}}
+  // expected-error@+1 {{cannot convert value of type 'String' to expected '*' operand type 'Int'}} {{none}}
   Int(3) * "0"
 
   struct S {}
-  // expected-error@+1 {{cannot convert value of type 'S' to expected argument type 'Int'}} {{none}}
+  // expected-error@+1 {{cannot convert value of type 'S' to expected '*' operand type 'Int'}} {{none}}
   Int(10) * S()
 }
 
@@ -1133,7 +1132,7 @@ func rdar17170728() {
   // FIXME: Bad diagnostic, `Bool.Stride` is bogus, we shouldn't be suggesting
   // `reduce(into:)`, and the actual problem is that Int cannot be used as a boolean
   // condition.
-  let _ = [i, j, k].reduce(0 as Int?) { // expected-error {{missing argument label 'into:' in call}}
+  let _ = [i, j, k].reduce(0 as Int?) { // expected-error {{ambiguous use of 'reduce'; cannot convert argument of type 'Int?' to any of potential 4 different types}} expected-error {{missing argument label 'into:' in call}}
     $0 && $1 ? $0 + $1 : ($0 ? $0 : ($1 ? $1 : nil))
     // expected-error@-1 {{binary operator '+' cannot be applied to operands of type 'Bool.Stride' and 'Bool'}}
   }
@@ -1546,7 +1545,7 @@ do {
   struct NonHashable {}
 
   func test(result: inout [AnyHashable], value: NonHashable) {
-    result.append(value) // expected-error {{argument type 'NonHashable' does not conform to expected type 'Hashable'}}
+    result.append(value) // expected-error {{cannot convert argument of type 'NonHashable' to expected argument type 'Hashable' for 'append'}}
   }
 }
 

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -solver-disable-enumerate-supertypes
+// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -verify-ignore-unknown -solver-disable-enumerate-supertypes
 
 protocol P {
   associatedtype SomeType
@@ -718,9 +718,8 @@ func r24251022() {
   var a = 1
   var b: UInt32 = 2
   _ = a + b // expected-error {{binary operator '+' cannot be applied to operands of type 'Int' and 'UInt32'}} expected-note {{overloads for '+' exist with these partially matching parameter lists: (Int, Int), (UInt32, UInt32)}}
-  a += a +
-    b // expected-error {{cannot convert value of type 'UInt32' to expected argument type 'Int'}}
-  a += b  // expected-error@:8 {{cannot convert value of type 'UInt32' to expected argument type 'Int'}}
+  a += a + b // expected-error {{cannot convert value of type 'UInt32' to expected '+' operand type 'Int'}}
+  a += b  // expected-error {{cannot convert value of type 'UInt32' to expected '+=' operand type 'Int'}}
 }
 
 func overloadSetResultType(_ a : Int, b : Int) -> Int {
@@ -821,7 +820,7 @@ func read<T : BinaryInteger>() -> T? {
 
 func f23213302() {
   var s = Set<Int>()
-  s.subtract(1) // expected-error {{cannot convert value of type 'Int' to expected argument type 'Set<Int>'}}
+  s.subtract(1) // expected-error {{cannot convert argument of type 'Int' to expected argument type 'Set<Int>' for 'subtract'}}
 }
 
 // <rdar://problem/24202058> QoI: Return of call to overloaded function in void-return context
@@ -887,7 +886,7 @@ do {
   let a: Int = 1
   let b: Int = 2
   let result = a / b
-  foo.bar(value: a / b)  // expected-error {{cannot convert value of type 'Int' to expected argument type 'UInt'}}
+  foo.bar(value: a / b)  // expected-error {{cannot convert argument of type 'Int' to expected argument type 'UInt' for 'bar'}}
   foo.bar(value: result) // expected-error {{cannot convert value of type 'Int' to expected argument type 'UInt'}}
   foo.bar(value: UInt(result)) // Ok
 }
@@ -952,10 +951,10 @@ do {
     case bar
   }
 
-  // expected-error@+1 {{cannot convert value of type 'Float' to expected argument type 'Int'}} {{35-35=Int(}} {{43-43=)}}
+  // expected-error@+1 {{cannot convert value of type 'Float' to expected '*' operand type 'Int'}}{{35-35=Int(}}{{43-43=)}}
   let _: Int = Foo.bar.rawValue * Float(0)
 
-  // expected-error@+1 {{cannot convert value of type 'Int' to expected argument type 'Float'}} {{18-18=Float(}} {{34-34=)}}
+  // expected-error@+1 {{cannot convert value of type 'Int' to expected '*' operand type 'Float'}}
   let _: Float = Foo.bar.rawValue * Float(0)
 
   // expected-error@+2 {{binary operator '*' cannot be applied to operands of type 'Int' and 'Float'}} {{none}}
@@ -966,10 +965,10 @@ do {
   let lhs = Float(3)
   let rhs = Int(0)
 
-  // expected-error@+1 {{cannot convert value of type 'Int' to expected argument type 'Float'}} {{24-24=Float(}} {{27-27=)}}
+  // expected-error@+1 {{cannot convert value of type 'Int' to expected '*' operand type 'Float'}}
   let _: Float = lhs * rhs
 
-  // expected-error@+1 {{cannot convert value of type 'Float' to expected argument type 'Int'}} {{16-16=Int(}} {{19-19=)}}
+  // expected-error@+1 {{cannot convert value of type 'Float' to expected '*' operand type 'Int'}}
   let _: Int = lhs * rhs
 
   // expected-error@+2 {{binary operator '*' cannot be applied to operands of type 'Float' and 'Int'}} {{none}}
@@ -977,11 +976,11 @@ do {
   lhs * rhs
 }
 do {
-  // expected-error@+1 {{cannot convert value of type 'String' to expected argument type 'Int'}} {{none}}
+  // expected-error@+1 {{cannot convert value of type 'String' to expected '*' operand type 'Int'}} {{none}}
   Int(3) * "0"
 
   struct S {}
-  // expected-error@+1 {{cannot convert value of type 'S' to expected argument type 'Int'}} {{none}}
+  // expected-error@+1 {{cannot convert value of type 'S' to expected '*' operand type 'Int'}} {{none}}
   Int(10) * S()
 }
 
@@ -1133,7 +1132,7 @@ func rdar17170728() {
   // FIXME: Bad diagnostic, `Bool.Stride` is bogus, we shouldn't be suggesting
   // `reduce(into:)`, and the actual problem is that Int cannot be used as a boolean
   // condition.
-  let _ = [i, j, k].reduce(0 as Int?) { // expected-error {{missing argument label 'into:' in call}}
+  let _ = [i, j, k].reduce(0 as Int?) { // expected-error {{no exact 'reduce' candidates found; cannot convert argument of type 'Int?' to any of potential 4 different types}} expected-error {{missing argument label 'into:' in call}}
     $0 && $1 ? $0 + $1 : ($0 ? $0 : ($1 ? $1 : nil))
     // expected-error@-1 {{binary operator '+' cannot be applied to operands of type 'Bool.Stride' and 'Bool'}}
   }
@@ -1546,7 +1545,7 @@ do {
   struct NonHashable {}
 
   func test(result: inout [AnyHashable], value: NonHashable) {
-    result.append(value) // expected-error {{argument type 'NonHashable' does not conform to expected type 'Hashable'}}
+    result.append(value) // expected-error {{cannot convert argument of type 'NonHashable' to expected argument type 'Hashable' for 'append'}}
   }
 }
 

--- a/test/Constraints/generics.swift
+++ b/test/Constraints/generics.swift
@@ -895,7 +895,7 @@ func rdar78781552() {
     Test(data?.filter)
     // expected-error@-1 {{generic struct 'Test' requires that '(((Int) throws(E) -> Bool) throws(E) -> [Int])?' conform to 'RandomAccessCollection'}}
     // expected-error@-2 {{generic parameter 'Content' could not be inferred}} expected-note@-2 {{explicitly specify the generic arguments to fix this issue}}
-    // expected-error@-3 {{cannot convert value of type '(((Int) throws(E) -> Bool) throws(E) -> [Int])?' to expected argument type '[(((Int) throws(E) -> Bool) throws(E) -> [Int])?]'}}
+    // expected-error@-3 {{cannot convert argument of type '(((Int) throws(E) -> Bool) throws(E) -> [Int])?' to expected argument type '[(((Int) throws(E) -> Bool) throws(E) -> [Int])?]' for initializer}}
     // expected-error@-4 {{missing argument label 'data:' in call}}
     // expected-error@-5 {{missing argument for parameter 'filter' in call}}
     // expected-error@-6 {{generic parameter 'E' could not be inferred}}

--- a/test/Constraints/generics.swift
+++ b/test/Constraints/generics.swift
@@ -899,7 +899,7 @@ func rdar78781552() {
     Test(data?.filter)
     // expected-error@-1 {{generic struct 'Test' requires that '(((Int) throws(E) -> Bool) throws(E) -> [Int])?' conform to 'RandomAccessCollection'}}
     // expected-error@-2 {{generic parameter 'Content' could not be inferred}} expected-note@-2 {{explicitly specify the generic arguments to fix this issue}}
-    // expected-error@-3 {{cannot convert value of type '(((Int) throws(E) -> Bool) throws(E) -> [Int])?' to expected argument type '[(((Int) throws(E) -> Bool) throws(E) -> [Int])?]'}}
+    // expected-error@-3 {{cannot convert argument of type '(((Int) throws(E) -> Bool) throws(E) -> [Int])?' to expected argument type '[(((Int) throws(E) -> Bool) throws(E) -> [Int])?]' for initializer}}
     // expected-error@-4 {{missing argument label 'data:' in call}}
     // expected-error@-5 {{missing argument for parameter 'filter' in call}}
     // expected-error@-6 {{generic parameter 'E' could not be inferred}}

--- a/test/Constraints/operator.swift
+++ b/test/Constraints/operator.swift
@@ -1,4 +1,5 @@
 // RUN: %target-typecheck-verify-swift -verify-ignore-unrelated
+// Unrelated files /stdlib/public/core/Equatable.swift ..Array ..Comparable ..Pointer ..FloatingPoint .. Stride
 
 // https://github.com/apple/swift/issues/43735
 // Test constraint simplification of chains of binary operators.
@@ -282,10 +283,11 @@ func rdar60727310() {
 }
 
 // https://github.com/apple/swift/issues/54877
-// FIXME: Bad diagnostic.
+// FIXME: Note could produce more information about type derivation for T.
+// Note: The number of types is 43 or 45 depending on which std library
 func f_54877(_ e: Error) {
-  func foo<T>(_ a: T, _ op: ((T, T) -> Bool)) {}
-  foo(e, ==) // expected-error {{failed to produce diagnostic for expression}}
+  func foo<T>(_ a: T, _ op: ((T, T) -> Bool)) {} // expected-note {{candidate expects value of type '()' for parameter #1 (got 'any Error')}}
+  foo(e, ==) // expected-error {{ambiguous use of 'foo'; cannot convert argument of type 'any Error' to any of potential }}
 }
 
 // rdar://problem/62054241 - Swift compiler crashes when passing < as the sort function in sorted(by:) and the type of the array is not comparable

--- a/test/Constraints/operator.swift
+++ b/test/Constraints/operator.swift
@@ -1,4 +1,5 @@
 // RUN: %target-typecheck-verify-swift -verify-ignore-unrelated
+// Unrelated files /stdlib/public/core/Equatable.swift ..Array ..Comparable ..Pointer ..FloatingPoint .. Stride
 
 // https://github.com/apple/swift/issues/43735
 // Test constraint simplification of chains of binary operators.
@@ -281,10 +282,11 @@ func rdar60727310() {
 }
 
 // https://github.com/apple/swift/issues/54877
-// FIXME: Bad diagnostic.
+// FIXME: Note could produce more information about type derivation for T.
+// Note: The number of types is 43 or 45 depending on which std library
 func f_54877(_ e: Error) {
-  func foo<T>(_ a: T, _ op: ((T, T) -> Bool)) {}
-  foo(e, ==) // expected-error {{failed to produce diagnostic for expression}}
+  func foo<T>(_ a: T, _ op: ((T, T) -> Bool)) {} // expected-note {{candidate expects value of type '()' for parameter #1 (got 'any Error')}}
+  foo(e, ==) // expected-error {{no exact 'foo' candidates found; cannot convert argument of type 'any Error' to any of potential }}
 }
 
 // rdar://problem/62054241 - Swift compiler crashes when passing < as the sort function in sorted(by:) and the type of the array is not comparable

--- a/test/Constraints/optional.swift
+++ b/test/Constraints/optional.swift
@@ -592,7 +592,7 @@ do {
   func test(_: String) {} // expected-note {{candidate expects value of type 'String' for parameter #1 (got 'Double')}}
 
   var x: Double = 42
-  test(x!) // expected-error {{no exact matches in call to local function 'test'}}
+  test(x!) // expected-error {{ambiguous use of 'test'; cannot convert argument of type 'Double' to any of potential types 'Int', 'String'}}
   // expected-error@-1 {{cannot force unwrap value of non-optional type 'Double'}}
 }
 
@@ -615,7 +615,7 @@ func testPassingOptionalChainAsWrongArgument() {
   }
 
   func test(test: Test, arr: [Int]?) {
-    test.fn(arr?.first) // expected-error {{cannot convert value of type 'Int?' to expected argument type 'String?'}}
+    test.fn(arr?.first) // expected-error {{cannot convert argument of type 'Int?' to expected argument type 'String?' for 'fn'}}
   }
 }
 

--- a/test/Constraints/optional.swift
+++ b/test/Constraints/optional.swift
@@ -592,7 +592,7 @@ do {
   func test(_: String) {} // expected-note {{candidate expects value of type 'String' for parameter #1 (got 'Double')}}
 
   var x: Double = 42
-  test(x!) // expected-error {{no exact matches in call to local function 'test'}}
+  test(x!) // expected-error {{no exact 'test' candidates found; cannot convert argument of type 'Double' to any of potential types 'Int', 'String'}}
   // expected-error@-1 {{cannot force unwrap value of non-optional type 'Double'}}
 }
 
@@ -615,7 +615,7 @@ func testPassingOptionalChainAsWrongArgument() {
   }
 
   func test(test: Test, arr: [Int]?) {
-    test.fn(arr?.first) // expected-error {{cannot convert value of type 'Int?' to expected argument type 'String?'}}
+    test.fn(arr?.first) // expected-error {{cannot convert argument of type 'Int?' to expected argument type 'String?' for 'fn'}}
   }
 }
 

--- a/test/Constraints/overload.swift
+++ b/test/Constraints/overload.swift
@@ -26,7 +26,7 @@ _ = f0(1)
 f1(f0(1))
 f1(identity(1))
 
-f0(x) // expected-error{{no exact matches in call to global function 'f0'}}
+f0(x) // expected-error{{ambiguous use of 'f0'; cannot convert argument of type 'X' to any of potential types 'Float', 'Int'}}
 
 _ = f + 1
 _ = f2(i)
@@ -244,7 +244,7 @@ func test_autoclosure1(ia: [Int]) {
 // rdar://problem/64368545 - failed to produce diagnostic (hole propagated to func result without recording a fix)
 func test_no_hole_propagation() {
   func test(withArguments arguments: [String]) -> String {
-    return arguments.reduce(0, +) // expected-error {{cannot convert value of type 'Int' to expected argument type 'String'}}
+    return arguments.reduce(0, +) // expected-error {{cannot convert argument of type 'Int' to expected argument type 'String' for 'reduce'}}
   }
 }
 

--- a/test/Constraints/overload.swift
+++ b/test/Constraints/overload.swift
@@ -26,7 +26,7 @@ _ = f0(1)
 f1(f0(1))
 f1(identity(1))
 
-f0(x) // expected-error{{no exact matches in call to global function 'f0'}}
+f0(x) // expected-error{{no exact 'f0' candidates found; cannot convert argument of type 'X' to any of potential types 'Float', 'Int'}}
 
 _ = f + 1
 _ = f2(i)
@@ -244,7 +244,7 @@ func test_autoclosure1(ia: [Int]) {
 // rdar://problem/64368545 - failed to produce diagnostic (hole propagated to func result without recording a fix)
 func test_no_hole_propagation() {
   func test(withArguments arguments: [String]) -> String {
-    return arguments.reduce(0, +) // expected-error {{cannot convert value of type 'Int' to expected argument type 'String'}}
+    return arguments.reduce(0, +) // expected-error {{cannot convert argument of type 'Int' to expected argument type 'String' for 'reduce'}}
   }
 }
 
@@ -428,6 +428,6 @@ do {
   func test(of: [String]) {} // expected-note {{candidate expects value of type '[String]' for parameter #1 (got '[S.Type]')}}
   func test(of: [Int]) {} // expected-note {{candidate expects value of type '[Int]' for parameter #1 (got '[S.Type]')}}
 
-  test(of: [S.self]) // expected-error {{no exact matches in call to local function 'test'}}
+  test(of: [S.self]) // expected-error {{no exact 'test' candidates found; cannot convert argument of type '[S.Type]' to any of potential types '[Int]', '[String]'}}
 }
 

--- a/test/Generics/function_defs.swift
+++ b/test/Generics/function_defs.swift
@@ -97,7 +97,7 @@ func testOverload<Ovl : Overload, OtherOvl : Overload>(_ ovl: Ovl, ovl2: Ovl,
   a = ovl2.f2(17)
   a = ovl2.f1(a)
 
-  other.f1(a) // expected-error{{no exact matches in call to instance method 'f1'}}
+  other.f1(a) // expected-error{{ambiguous use of 'f1'; cannot convert argument of type 'Ovl.A' to any of potential types 'OtherOvl.A', 'OtherOvl.B'}}
 
   // Overloading based on context
   var f3i : (Int) -> Int = ovl.f3

--- a/test/Generics/function_defs.swift
+++ b/test/Generics/function_defs.swift
@@ -97,7 +97,7 @@ func testOverload<Ovl : Overload, OtherOvl : Overload>(_ ovl: Ovl, ovl2: Ovl,
   a = ovl2.f2(17)
   a = ovl2.f1(a)
 
-  other.f1(a) // expected-error{{no exact matches in call to instance method 'f1'}}
+  other.f1(a) // expected-error{{no exact 'f1' candidates found; cannot convert argument of type 'Ovl.A' to any of potential types 'OtherOvl.A', 'OtherOvl.B'}}
 
   // Overloading based on context
   var f3i : (Int) -> Int = ovl.f3

--- a/test/Interop/Cxx/enum/hashable-enums-typecheck.swift
+++ b/test/Interop/Cxx/enum/hashable-enums-typecheck.swift
@@ -11,7 +11,7 @@ let _: Set = [kBlue, Pet.dogcow]    // expected-error {{conflicting arguments to
 
 let s: Set<Pet> = []                // construct an empty, type-annotated set
 let _ = s.contains(Pet.goat)        // query the empty set using a key
-let _ = s.contains(kTwo)            // expected-error {{cannot convert value of type 'Int' to expected argument type 'Pet'}}
+let _ = s.contains(kTwo)            // expected-error {{cannot convert argument of type 'Int' to expected argument type 'Pet' for 'contains'}}
 
 // Untyped enums can be used interchangeably with integers
 let _: Set = [kFour, kTwo]          // construct a set from untyped enum

--- a/test/Interop/Cxx/enum/hashable-enums-typecheck.swift
+++ b/test/Interop/Cxx/enum/hashable-enums-typecheck.swift
@@ -15,7 +15,7 @@ let _: Set = [kBlue, Pet.dogcow]    // expected-error {{type 'Any' cannot confor
 
 let s: Set<Pet> = []                // construct an empty, type-annotated set
 let _ = s.contains(Pet.goat)        // query the empty set using a key
-let _ = s.contains(kTwo)            // expected-error {{cannot convert value of type 'Int' to expected argument type 'Pet'}}
+let _ = s.contains(kTwo)            // expected-error {{cannot convert argument of type 'Int' to expected argument type 'Pet' for 'contains'}}
 
 // Untyped enums can be used interchangeably with integers
 let _: Set = [kFour, kTwo]          // construct a set from untyped enum

--- a/test/Interop/Cxx/operators/subscript-overloads-typechecker.swift
+++ b/test/Interop/Cxx/operators/subscript-overloads-typechecker.swift
@@ -35,7 +35,7 @@ u[num] = val // expected-error {{cannot convert value of type 'Num' to expected 
 
 
 let _: Float = v[float]
-v[float] = val // expected-error {{no exact matches in call to subscript}}
+v[float] = val // expected-error {{ambiguous use of 'subscript'; cannot convert argument of type 'Float' to any of potential types 'Num', 'UInt32'}}
                // FIXME: ^this should complain about 'u' being a 'let' constant
 
 let _: Float = u[float]
@@ -94,7 +94,7 @@ let getValPtr = Overloaded.GetValPtr(index: 0)
 let vGetPtr: CUnsignedInt = v[getPtr]
 v[getPtr] = vGetPtr
 let uGetPtr: CUnsignedInt = u[getPtr] // expected-error {{cannot use mutating getter on immutable value: 'u' is a 'let' constant}}
-u[getPtr] = uGetPtr // expected-error {{no exact matches in call to subscript}}
+u[getPtr] = uGetPtr // expected-error {{ambiguous use of 'subscript'; cannot convert argument of type 'Overloaded.GetPtr' to any of potential types 'Overloaded.GetPtrRef', 'Overloaded.GetRefVal'}}
                     // FIXME: ^this should complain about 'u' being a 'let' constant
 
 let vGetRef: UnsafeMutablePointer<UInt32>? = v[getRef]

--- a/test/Interop/Cxx/operators/subscript-overloads-typechecker.swift
+++ b/test/Interop/Cxx/operators/subscript-overloads-typechecker.swift
@@ -35,7 +35,7 @@ u[num] = val // expected-error {{cannot convert value of type 'Num' to expected 
 
 
 let _: Float = v[float]
-v[float] = val // expected-error {{no exact matches in call to subscript}}
+v[float] = val // expected-error {{no exact 'subscript' candidates found; cannot convert argument of type 'Float' to any of potential types 'CUnsignedInt', 'Num'}}
                // FIXME: ^this should complain about 'u' being a 'let' constant
 
 let _: Float = u[float]
@@ -94,7 +94,7 @@ let getValPtr = Overloaded.GetValPtr(index: 0)
 let vGetPtr: CUnsignedInt = v[getPtr]
 v[getPtr] = vGetPtr
 let uGetPtr: CUnsignedInt = u[getPtr] // expected-error {{cannot use mutating getter on immutable value: 'u' is a 'let' constant}}
-u[getPtr] = uGetPtr // expected-error {{no exact matches in call to subscript}}
+u[getPtr] = uGetPtr // expected-error {{no exact 'subscript' candidates found; cannot convert argument of type 'Overloaded.GetPtr' to any of potential types 'Overloaded.GetPtrRef', 'Overloaded.GetRefVal'}}
                     // FIXME: ^this should complain about 'u' being a 'let' constant
 
 let vGetRef: UnsafeMutablePointer<UInt32>? = v[getRef]

--- a/test/Interpreter/SDK/misc_osx.swift
+++ b/test/Interpreter/SDK/misc_osx.swift
@@ -7,7 +7,7 @@ import CoreServices
 func testFSEventStreamRef(stream: FSEventStreamRef) {
   // FIXME: These should be distinct types, constructible from one another.
   _ = stream as ConstFSEventStreamRef // works by coincidence because both are currently OpaquePointer
-  _ = ConstFSEventStreamRef(stream) // expected-error {{no exact matches in call to initializer}}
+  _ = ConstFSEventStreamRef(stream) // expected-error {{ambiguous use of initializer; cannot convert argument of type 'FSEventStreamRef' (aka 'OpaquePointer') to any of potential types 'UnsafeMutableRawPointer', 'UnsafeRawPointer'}}
 
   // This is not a CF object.
   FSEventStreamRetain(stream) // no-warning

--- a/test/Interpreter/SDK/misc_osx.swift
+++ b/test/Interpreter/SDK/misc_osx.swift
@@ -7,7 +7,7 @@ import CoreServices
 func testFSEventStreamRef(stream: FSEventStreamRef) {
   // FIXME: These should be distinct types, constructible from one another.
   _ = stream as ConstFSEventStreamRef // works by coincidence because both are currently OpaquePointer
-  _ = ConstFSEventStreamRef(stream) // expected-error {{no exact matches in call to initializer}}
+  _ = ConstFSEventStreamRef(stream) // expected-error {{no exact initializer candidates found; cannot convert argument of type 'FSEventStreamRef' (aka 'OpaquePointer') to any of potential types 'UnsafeMutableRawPointer', 'UnsafeRawPointer'}}
 
   // This is not a CF object.
   FSEventStreamRetain(stream) // no-warning

--- a/test/Macros/attached_macros_diags.swift
+++ b/test/Macros/attached_macros_diags.swift
@@ -67,7 +67,7 @@ struct TestMacroArgs {
 
   @m2(10.0) struct Args3 {}
 
-  @m2("") struct Args4 {} // expected-error{{no exact matches in call to macro 'm2'}}
+  @m2("") struct Args4 {} // expected-error{{ambiguous use of 'm2'; cannot convert argument of type 'String' to any of potential types 'Double', 'Int'}}
 
   @m2(Nested.x) struct Args5 {}
 

--- a/test/Macros/attached_macros_diags.swift
+++ b/test/Macros/attached_macros_diags.swift
@@ -67,7 +67,7 @@ struct TestMacroArgs {
 
   @m2(10.0) struct Args3 {}
 
-  @m2("") struct Args4 {} // expected-error{{no exact matches in call to macro 'm2'}}
+  @m2("") struct Args4 {} // expected-error{{no exact 'm2' candidates found; cannot convert argument of type 'String' to any of potential types 'Double', 'Int'}}
 
   @m2(Nested.x) struct Args5 {}
 

--- a/test/Misc/misc_diagnostics.swift
+++ b/test/Misc/misc_diagnostics.swift
@@ -103,10 +103,10 @@ func testIS1() -> Int { return 0 }
 let _: String = testIS1() // expected-error {{cannot convert value of type 'Int' to specified type 'String'}}
 
 func insertA<T>(array : inout [T], elt : T) {
-  array.append(T.self); // expected-error {{cannot convert value of type 'T.Type' to expected argument type 'T'}}
+  array.append(T.self); // expected-error {{cannot convert argument of type 'T.Type' to expected argument type 'T' for 'append'}}
 
   // FIXME: Kind of weird
-  array.append(T); // expected-error {{cannot convert value of type 'T.Type' to expected argument type 'T'}}
+  array.append(T); // expected-error {{cannot convert argument of type 'T.Type' to expected argument type 'T' for 'append'}}
 }
 
 extension Array {

--- a/test/Parse/switch.swift
+++ b/test/Parse/switch.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated
 
 // TODO: Implement tuple equality in the library.
 // BLOCKED: <rdar://problem/13822406>
@@ -336,8 +336,7 @@ func f1(x: String, y: Whichever) {
         break
     case Whichever.buzz: // expected-error {{type 'Whichever' has no member 'buzz'}}
         break
-    // expected-note @+1 {{overloads for '~=' exist with these partially matching parameter lists: (Substring, String)}}
-    case Whichever.alias: // expected-error {{expression pattern of type 'Whichever' cannot match values of type 'String'}}
+    case Whichever.alias: // expected-error {{cannot match given pattern expression type 'Whichever' with expected potential types 'String', 'Substring'}}
     // expected-error@-1 {{'case' label in a 'switch' must have at least one executable statement}}
     default:
       break

--- a/test/Parse/type_expr.swift
+++ b/test/Parse/type_expr.swift
@@ -325,7 +325,7 @@ func testFunctionCollectionTypes() {
   _ = (Int) -> Int // expected-error {{expected member name or initializer call after type name}} expected-note{{use '.self' to reference the type object}}
 
   _ = @convention(c) () -> Int // expected-error{{expected member name or initializer call after type name}} expected-note{{use '.self' to reference the type object}}
-  _ = 1 + (@convention(c) () -> Int).self // expected-error{{cannot convert value of type '(@convention(c) () -> Int).Type' to expected argument type 'Int'}}
+  _ = 1 + (@convention(c) () -> Int).self // expected-error{{cannot convert value of type '(@convention(c) () -> Int).Type' to expected '+' operand type 'Int'}}
 
   _ = (@autoclosure () -> Int) -> (Int, Int).2
   // expected-error@-1 {{expected type after '->'}}

--- a/test/Sema/diag_ambiguous_overloads.swift
+++ b/test/Sema/diag_ambiguous_overloads.swift
@@ -54,7 +54,7 @@ class DefaultValue {
   static func foo(_ a: Int, _ b: Int = 1) {}
   static func foo(_ a: Int, _ b: Int = 1, _ c: Int = 2) {}
 }
-DefaultValue.foo(1.0, 1) // expected-error {{cannot convert value of type 'Double' to expected argument type 'Int'}}
+DefaultValue.foo(1.0, 1) // expected-error {{cannot convert argument of type 'Double' to expected argument type 'Int'}}
 
 
 class Variadic {
@@ -152,7 +152,8 @@ do {
   func f1(_ u: String) -> Double {} // expected-note 2 {{candidate expects value of type 'String' for parameter #1 (got 'Double')}}
   func f2(_ u: Int) {}
 
-  f2(f1(1 as Double)) // expected-error {{no exact matches in call to local function 'f1'}}
+  f2(f1(1 as Double))
+  // expected-error@-1 {{ambiguous use of 'f1'; cannot convert argument of type 'Double' to any of potential types 'Int', 'String'}}
   f1(1 as Double) as Int // expected-error {{no exact matches in call to local function 'f1'}}
 }
 do {
@@ -188,4 +189,35 @@ do {
 
   let _ = i16 -- i16
   // expected-error@-1 {{ambiguous use of operator '--'}}
+}
+
+// https://github.com/swiftlang/swift/issues/79999
+do {
+  func foo(_ a: Int) -> [Int] { [] }
+
+  // TODO: fix fall through case on diagnoseForAmbiguity.
+  // These are falling all the way through diagnoseAmbiguity, but should get caught
+  let _ = foo(-)
+  // expected-error@-1 {{failed to produce diagnostic for expression}}
+
+  for _ in foo(-) {}
+  // expected-error@-1 {{failed to produce diagnostic for expression}}
+
+  func test() -> Int {}
+  func test() -> String {}
+  
+  func other(_: Int32) {}
+
+  // TODO: as above but slightly different case
+  other(test())
+  // expected-error@-1 {{failed to produce diagnostic for expression}}
+}
+
+do {
+  func test(_: Int) {} // expected-note {{candidate expects value of type 'Int' for parameter #1 (got 'Double')}}
+  func test(_: String) {} // expected-note {{candidate expects value of type 'String' for parameter #1 (got 'Double')}}
+
+  func compute() -> Double { 0 }
+  
+  test(compute()) // expected-error {{ambiguous use of 'test'; cannot convert argument of type 'Double' to any of potential types 'Int', 'String'}}
 }

--- a/test/Sema/diag_ambiguous_overloads.swift
+++ b/test/Sema/diag_ambiguous_overloads.swift
@@ -54,7 +54,7 @@ class DefaultValue {
   static func foo(_ a: Int, _ b: Int = 1) {}
   static func foo(_ a: Int, _ b: Int = 1, _ c: Int = 2) {}
 }
-DefaultValue.foo(1.0, 1) // expected-error {{cannot convert value of type 'Double' to expected argument type 'Int'}}
+DefaultValue.foo(1.0, 1) // expected-error {{cannot convert argument of type 'Double' to expected argument type 'Int'}}
 
 
 class Variadic {
@@ -152,7 +152,8 @@ do {
   func f1(_ u: String) -> Double {} // expected-note 2 {{candidate expects value of type 'String' for parameter #1 (got 'Double')}}
   func f2(_ u: Int) {}
 
-  f2(f1(1 as Double)) // expected-error {{no exact matches in call to local function 'f1'}}
+  f2(f1(1 as Double))
+  // expected-error@-1 {{no exact 'f1' candidates found; cannot convert argument of type 'Double' to any of potential types 'Int', 'String'}}
   f1(1 as Double) as Int // expected-error {{no exact matches in call to local function 'f1'}}
 }
 do {
@@ -188,4 +189,35 @@ do {
 
   let _ = i16 -- i16
   // expected-error@-1 {{ambiguous use of operator '--'}}
+}
+
+// https://github.com/swiftlang/swift/issues/79999
+do {
+  func foo(_ a: Int) -> [Int] { [] }
+
+  // TODO: fix fall through case on diagnoseForAmbiguity.
+  // These are falling all the way through diagnoseAmbiguity, but should get caught
+  let _ = foo(-)
+  // expected-error@-1 {{failed to produce diagnostic for expression}}
+
+  for _ in foo(-) {}
+  // expected-error@-1 {{failed to produce diagnostic for expression}}
+
+  func test() -> Int {}
+  func test() -> String {}
+  
+  func other(_: Int32) {}
+
+  // TODO: as above but slightly different case
+  other(test())
+  // expected-error@-1 {{failed to produce diagnostic for expression}}
+}
+
+do {
+  func test(_: Int) {} // expected-note {{candidate expects value of type 'Int' for parameter #1 (got 'Double')}}
+  func test(_: String) {} // expected-note {{candidate expects value of type 'String' for parameter #1 (got 'Double')}}
+
+  func compute() -> Double { 0 }
+  
+  test(compute()) // expected-error {{no exact 'test' candidates found; cannot convert argument of type 'Double' to any of potential types 'Int', 'String'}}
 }

--- a/test/Sema/diag_constantness_check_os_log.swift
+++ b/test/Sema/diag_constantness_check_os_log.swift
@@ -86,7 +86,7 @@ func testTypeIncorrectLogCalls() {
   // expected-error@-2 {{missing argument label 'assertion:' in call}}
 
   _osLogTestHelper("\(x, format: .hex)")
-  //expected-error@-1 {{no exact matches in call to instance method 'appendInterpolation'}}
+  //expected-error@-1 {{ambiguous use of 'appendInterpolation'; cannot convert argument of type 'TestClass' to any of potential types 'Double', 'Float', 'Int', 'Int32', 'UInt'}}
 
   _osLogTestHelper("\(10, format: .myFormat, privacy: .private)")
   //expected-error@-1 {{type 'OSLogIntegerFormatting' has no member 'myFormat'}}

--- a/test/Sema/diag_constantness_check_os_log.swift
+++ b/test/Sema/diag_constantness_check_os_log.swift
@@ -86,7 +86,7 @@ func testTypeIncorrectLogCalls() {
   // expected-error@-2 {{missing argument label 'assertion:' in call}}
 
   _osLogTestHelper("\(x, format: .hex)")
-  //expected-error@-1 {{no exact matches in call to instance method 'appendInterpolation'}}
+  //expected-error@-1 {{no exact 'appendInterpolation' candidates found; cannot convert argument of type 'TestClass' to any of potential types 'Double', 'Float', 'Int', 'Int32', 'UInt'}}
 
   _osLogTestHelper("\(10, format: .myFormat, privacy: .private)")
   //expected-error@-1 {{type 'OSLogIntegerFormatting' has no member 'myFormat'}}

--- a/test/Sema/inlinearray.swift
+++ b/test/Sema/inlinearray.swift
@@ -59,7 +59,7 @@ takeVectorOf2Int(["hello"]) // expected-error {{cannot convert value of type '[S
 takeVectorOf2Int(["hello", "world"]) // expected-error {{cannot convert value of type 'String' to expected element type 'Int'}}
                                      // expected-error@-1 {{cannot convert value of type 'String' to expected element type 'Int'}}
 
-takeVectorOf2Int(["hello", "world", "!"]) // expected-error {{cannot convert value of type '[String]' to expected argument type 'InlineArray<2, Int>'}}
+takeVectorOf2Int(["hello", "world", "!"]) // expected-error {{cannot convert argument of type '[String]' to expected argument type 'InlineArray<2, Int>' for 'takeVectorOf2Int'}}
 
 func takeSugarVectorOf2<T>(_: [2 of T], ty: T.Type = T.self) {}
 takeSugarVectorOf2([1, 2])

--- a/test/Sema/inlinearray.swift
+++ b/test/Sema/inlinearray.swift
@@ -59,7 +59,7 @@ takeVectorOf2Int(["hello"]) // expected-error {{cannot convert value of type '[S
 takeVectorOf2Int(["hello", "world"])
 // expected-error@-1 {{cannot convert value of type '[String]' to expected argument type 'InlineArray<2, Int>'}}
 
-takeVectorOf2Int(["hello", "world", "!"]) // expected-error {{cannot convert value of type '[String]' to expected argument type 'InlineArray<2, Int>'}}
+takeVectorOf2Int(["hello", "world", "!"]) // expected-error {{cannot convert argument of type '[String]' to expected argument type 'InlineArray<2, Int>' for 'takeVectorOf2Int'}}
 
 func takeSugarVectorOf2<T>(_: [2 of T], ty: T.Type = T.self) {}
 takeSugarVectorOf2([1, 2])

--- a/test/attr/attr_dynamic_member_lookup.swift
+++ b/test/attr/attr_dynamic_member_lookup.swift
@@ -1078,7 +1078,7 @@ func keypath_with_subscripts(_ arr: SubscriptLens<[Int]>,
 
 func keypath_with_incorrect_return_type(_ arr: Lens<Array<Int>>) {
   for idx in 0..<arr.count {
-    // expected-error@-1 {{cannot convert value of type 'Lens<Int>' to expected argument type 'Int'}}
+    // expected-error@-1 {{cannot convert value of type 'Lens<Int>' to expected '..<' operand type 'Int'}}
     let _ = arr[idx]
   }
 }

--- a/test/decl/func/local-function-overload.swift
+++ b/test/decl/func/local-function-overload.swift
@@ -34,18 +34,18 @@ func invalid1() {
 
 func invalid2() {
   func inner(_: Int) {}
-  // expected-note@-1 {{candidate expects value of type 'Int' for parameter #1}}
+  // expected-note@-1 {{candidate expects value of type 'Int' for parameter #1 (got '[Any]')}}
   // expected-note@-2 {{found this candidate}}
   // expected-note@-3 {{did you mean 'inner'?}}
   func inner(_: String) {}
-  // expected-note@-1 {{candidate expects value of type 'String' for parameter #1}}
+  // expected-note@-1 {{candidate expects value of type 'String' for parameter #1 (got '[Any]')}}
   // expected-note@-2 {{found this candidate}}
 
   func inner(label: Int) {}
   // expected-note@-1 {{found this candidate}}
 
   inner([])
-  // expected-error@-1 {{no exact matches in call to local function 'inner'}}
+  // expected-error@-1 {{ambiguous use of 'inner'; cannot convert argument of type '[Any]' to any of potential types 'Int', 'String'}}
 
   inner(label: "hi")
   // expected-error@-1 {{cannot convert value of type 'String' to expected argument type 'Int'}}

--- a/test/decl/func/local-function-overload.swift
+++ b/test/decl/func/local-function-overload.swift
@@ -34,18 +34,18 @@ func invalid1() {
 
 func invalid2() {
   func inner(_: Int) {}
-  // expected-note@-1 {{candidate expects value of type 'Int' for parameter #1}}
+  // expected-note@-1 {{candidate expects value of type 'Int' for parameter #1 (got '[Any]')}}
   // expected-note@-2 {{found this candidate}}
   // expected-note@-3 {{did you mean 'inner'?}}
   func inner(_: String) {}
-  // expected-note@-1 {{candidate expects value of type 'String' for parameter #1}}
+  // expected-note@-1 {{candidate expects value of type 'String' for parameter #1 (got '[Any]')}}
   // expected-note@-2 {{found this candidate}}
 
   func inner(label: Int) {}
   // expected-note@-1 {{found this candidate}}
 
   inner([])
-  // expected-error@-1 {{no exact matches in call to local function 'inner'}}
+  // expected-error@-1 {{no exact 'inner' candidates found; cannot convert argument of type '[Any]' to any of potential types 'Int', 'String'}}
 
   inner(label: "hi")
   // expected-error@-1 {{cannot convert value of type 'String' to expected argument type 'Int'}}

--- a/test/decl/subscript/subscripting.swift
+++ b/test/decl/subscript/subscripting.swift
@@ -406,15 +406,15 @@ func testSubscript1(_ s1 : SubscriptTest1) {
 }
 
 struct SubscriptTest2 {
-  subscript(a : String, b : Int) -> Int { return 0 } // expected-note {{candidate expects value of type 'Int' for parameter #2}}
+  subscript(a : String, b : Int) -> Int { return 0 } // expected-note {{candidate expects value of type 'Int' for parameter #2 (got 'Double')}}
   // expected-note@-1 2 {{declared here}}
-  subscript(a : String, b : String) -> Int { return 0 } // expected-note {{candidate expects value of type 'String' for parameter #2}}
+  subscript(a : String, b : String) -> Int { return 0 } // expected-note {{candidate expects value of type 'String' for parameter #2 (got 'Double')}}
 }
 
 func testSubscript1(_ s2 : SubscriptTest2) {
   _ = s2["foo"] // expected-error {{missing argument for parameter #2 in subscript}}
 
-  let a = s2["foo", 1.0] // expected-error {{no exact matches in call to subscript}}
+  let a = s2["foo", 1.0] // expected-error {{ambiguous use of 'subscript'; cannot convert argument of type 'Double' to any of potential types 'Int', 'String'}}
 
   _ = s2.subscript("hello", 6)
   // expected-error@-1 {{value of type 'SubscriptTest2' has no property or method named 'subscript'; did you mean to use the subscript operator?}} {{9-10=}} {{10-19=}} {{19-20=[}} {{30-31=]}}

--- a/test/decl/subscript/subscripting.swift
+++ b/test/decl/subscript/subscripting.swift
@@ -406,15 +406,15 @@ func testSubscript1(_ s1 : SubscriptTest1) {
 }
 
 struct SubscriptTest2 {
-  subscript(a : String, b : Int) -> Int { return 0 } // expected-note {{candidate expects value of type 'Int' for parameter #2}}
+  subscript(a : String, b : Int) -> Int { return 0 } // expected-note {{candidate expects value of type 'Int' for parameter #2 (got 'Double')}}
   // expected-note@-1 2 {{declared here}}
-  subscript(a : String, b : String) -> Int { return 0 } // expected-note {{candidate expects value of type 'String' for parameter #2}}
+  subscript(a : String, b : String) -> Int { return 0 } // expected-note {{candidate expects value of type 'String' for parameter #2 (got 'Double')}}
 }
 
 func testSubscript1(_ s2 : SubscriptTest2) {
   _ = s2["foo"] // expected-error {{missing argument for parameter #2 in subscript}}
 
-  let a = s2["foo", 1.0] // expected-error {{no exact matches in call to subscript}}
+  let a = s2["foo", 1.0] // expected-error {{no exact 'subscript' candidates found; cannot convert argument of type 'Double' to any of potential types 'Int', 'String'}}
 
   _ = s2.subscript("hello", 6)
   // expected-error@-1 {{value of type 'SubscriptTest2' has no property or method named 'subscript'; did you mean to use the subscript operator?}} {{9-10=}} {{10-19=}} {{19-20=[}} {{30-31=]}}

--- a/test/expr/cast/as_coerce.swift
+++ b/test/expr/cast/as_coerce.swift
@@ -195,7 +195,6 @@ do {
   (fn as (Int, Bool) -> Void)(i, i) // expected-error {{cannot convert value of type '(Int) -> ()' to type '(Int, Bool) -> Void' in coercion}}
   // expected-error@-1 {{type 'Int' cannot be used as a boolean; test for '!= 0' instead}}
   (fn as (String) -> Void)(i) // expected-error {{no exact matches in reference to local function 'fn'}}
-  // expected-error@-1 {{cannot convert value of type 'Int' to expected argument type 'String'}}
 
   // Extraneous parameters.
   (fn as () -> Void)() // expected-error {{no exact matches in reference to local function 'fn'}}

--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated
+// RUN: %target-swift-frontend -typecheck -verify -verify-ignore-unknown -verify-ignore-unrelated %s
 
 //===----------------------------------------------------------------------===//
 // Tests and samples.
@@ -794,9 +794,10 @@ func testOptionalChaining(_ a : Int?, b : Int!, c : Int??) {
 func testNilCoalescePrecedence(cond: Bool, a: Int?, r: ClosedRange<Int>?) {
   // ?? should have higher precedence than logical operators like || and comparisons.
   if cond || (a ?? 42 > 0) {}  // Ok.
-  if (cond || a) ?? 42 > 0 {}  // expected-error {{cannot be used as a boolean}} {{15-15=(}} {{16-16= != nil)}}
+  if (cond || a) ?? 42 > 0 {} // expected-error {{optional type 'Int?' cannot be used as a boolean; test for '!= nil' instead}}
   // expected-error@-1 {{binary operator '>' cannot be applied to operands of type 'Bool' and 'Int'}}  expected-note@-1 {{overloads for '>' exist with these partially matching parameter list}}
-  // expected-error@-2 {{binary operator '??' cannot be applied to operands of type 'Bool' and 'Int'}}
+  // expected-error@-2 {{ambiguous use of '??'; cannot convert argument of type 'Int' to any of potential types 'Bool', 'Bool?'}}
+
   if (cond || a) ?? (42 > 0) {}  // expected-error {{cannot be used as a boolean}} {{15-15=(}} {{16-16= != nil)}}
 
   if cond || a ?? 42 > 0 {}    // Parses as the first one, not the others.
@@ -822,11 +823,11 @@ func testOptionalTypeParsing(_ a : AnyObject) -> String {
 func testParenExprInTheWay() {
   let x = 42
   
-  if x & 4.0 {}  // expected-error {{cannot convert value of type 'Double' to expected argument type 'Int'}}
+  if x & 4.0 {}  // expected-error {{cannot convert value of type 'Double' to expected '&' operand type 'Int'}}
   // expected-error@-1 {{type 'Int' cannot be used as a boolean; test for '!= 0' instead}}
-  if (x & 4.0) {}   // expected-error {{cannot convert value of type 'Double' to expected argument type 'Int'}}
+  if (x & 4.0) {}   // expected-error {{cannot convert value of type 'Double' to expected '&' operand type 'Int'}}
   // expected-error@-1 {{type 'Int' cannot be used as a boolean; test for '!= 0' instead}}
-  if !(x & 4.0) {}  // expected-error {{cannot convert value of type 'Double' to expected argument type 'Int'}}
+  if !(x & 4.0) {}  // expected-error {{cannot convert value of type 'Double' to expected '&' operand type 'Int'}}
   // expected-error@-1 {{type 'Int' cannot be used as a boolean; test for '== 0' instead}} {{6-7=}}{{7-7=(}}{{16-16= == 0)}}
 
   if x & x {} // expected-error {{type 'Int' cannot be used as a boolean; test for '!= 0' instead}}

--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated
+// RUN: %target-swift-frontend -typecheck -verify -verify-ignore-unknown -verify-ignore-unrelated %s
 
 //===----------------------------------------------------------------------===//
 // Tests and samples.
@@ -793,8 +793,9 @@ func testOptionalChaining(_ a : Int?, b : Int!, c : Int??) {
 func testNilCoalescePrecedence(cond: Bool, a: Int?, r: ClosedRange<Int>?) {
   // ?? should have higher precedence than logical operators like || and comparisons.
   if cond || (a ?? 42 > 0) {}  // Ok.
-  if (cond || a) ?? 42 > 0 {}  // expected-error {{cannot be used as a boolean}} {{15-15=(}} {{16-16= != nil)}}
-  // expected-error@-1 {{cannot convert value of type 'Bool' to expected argument type 'Int'}}
+  if (cond || a) ?? 42 > 0 {} // expected-error {{optional type 'Int?' cannot be used as a boolean; test for '!= nil' instead}}
+  // expected-error@-1 {{cannot convert value of type 'Bool' to expected '??' operand type 'Int'}}
+
   if (cond || a) ?? (42 > 0) {}  // expected-error {{cannot be used as a boolean}} {{15-15=(}} {{16-16= != nil)}}
 
   if cond || a ?? 42 > 0 {}    // Parses as the first one, not the others.
@@ -820,11 +821,11 @@ func testOptionalTypeParsing(_ a : AnyObject) -> String {
 func testParenExprInTheWay() {
   let x = 42
   
-  if x & 4.0 {}  // expected-error {{cannot convert value of type 'Double' to expected argument type 'Int'}}
+  if x & 4.0 {}  // expected-error {{cannot convert value of type 'Double' to expected '&' operand type 'Int'}}
   // expected-error@-1 {{type 'Int' cannot be used as a boolean; test for '!= 0' instead}}
-  if (x & 4.0) {}   // expected-error {{cannot convert value of type 'Double' to expected argument type 'Int'}}
+  if (x & 4.0) {}   // expected-error {{cannot convert value of type 'Double' to expected '&' operand type 'Int'}}
   // expected-error@-1 {{type 'Int' cannot be used as a boolean; test for '!= 0' instead}}
-  if !(x & 4.0) {}  // expected-error {{cannot convert value of type 'Double' to expected argument type 'Int'}}
+  if !(x & 4.0) {}  // expected-error {{cannot convert value of type 'Double' to expected '&' operand type 'Int'}}
   // expected-error@-1 {{type 'Int' cannot be used as a boolean; test for '== 0' instead}} {{6-7=}}{{7-7=(}}{{16-16= == 0)}}
 
   if x & x {} // expected-error {{type 'Int' cannot be used as a boolean; test for '!= 0' instead}}

--- a/test/expr/postfix/dot/init_ref_delegation.swift
+++ b/test/expr/postfix/dot/init_ref_delegation.swift
@@ -549,5 +549,5 @@ do {
     init(_ x: inout [Int]) {}  // expected-note {{candidate expects in-out value of type '[Int]' for parameter #1}}
   }
   var a = 0
-  S.init(&a) // expected-error {{no exact matches in call to initializer}}
+  S.init(&a) // expected-error {{ambiguous use of initializer; cannot convert argument of type 'Int' to any of potential types 'String', '[Int]'}}
 }

--- a/test/expr/postfix/dot/init_ref_delegation.swift
+++ b/test/expr/postfix/dot/init_ref_delegation.swift
@@ -549,5 +549,5 @@ do {
     init(_ x: inout [Int]) {}  // expected-note {{candidate expects in-out value of type '[Int]' for parameter #1}}
   }
   var a = 0
-  S.init(&a) // expected-error {{no exact matches in call to initializer}}
+  S.init(&a) // expected-error {{no exact initializer candidates found; cannot convert argument of type 'Int' to any of potential types 'String', '[Int]'}}
 }

--- a/test/stdlib/UnicodeScalarDiagnostics.swift
+++ b/test/stdlib/UnicodeScalarDiagnostics.swift
@@ -19,16 +19,16 @@ func test_UnicodeScalarDoesNotImplementArithmetic(_ us: UnicodeScalar, i: Int) {
   // DurationProtocol is a near miss here
   let b4 = us / us // expected-error {{referencing operator function '/' on 'DurationProtocol' requires that 'UnicodeScalar' (aka 'Unicode.Scalar') conform to 'DurationProtocol'}}
 
-  let c1 = us + i // expected-error {{cannot convert value of type 'UnicodeScalar' (aka 'Unicode.Scalar') to expected argument type 'Int'}}
-  let c2 = us - i // expected-error {{cannot convert value of type 'UnicodeScalar' (aka 'Unicode.Scalar') to expected argument type 'Int'}}
+  let c1 = us + i // expected-error {{cannot convert value of type 'UnicodeScalar' (aka 'Unicode.Scalar') to expected '+' operand type 'Int'}}
+  let c2 = us - i // expected-error {{cannot convert value of type 'UnicodeScalar' (aka 'Unicode.Scalar') to expected '-' operand type 'Int'}}
   let c3 = us * i // expected-note {{overloads for '*' exist with these partially matching parameter lists: (Int, Int)}}
   // expected-error@-1 {{binary operator '*' cannot be applied to operands of type 'UnicodeScalar' (aka 'Unicode.Scalar') and 'Int'}}
   let c4 = us / i // expected-note {{overloads for '/' exist with these partially matching parameter lists: (Int, Int)}}
   // expected-error@-1 {{binary operator '/' cannot be applied to operands of type 'UnicodeScalar' (aka 'Unicode.Scalar') and 'Int'}}
 
-  let d1 = i + us // expected-error {{cannot convert value of type 'UnicodeScalar' (aka 'Unicode.Scalar') to expected argument type 'Int'}}
-  let d2 = i - us // expected-error {{cannot convert value of type 'UnicodeScalar' (aka 'Unicode.Scalar') to expected argument type 'Int'}}
-  let d3 = i * us // expected-error {{cannot convert value of type 'UnicodeScalar' (aka 'Unicode.Scalar') to expected argument type 'Int'}}
-  let d4 = i / us // expected-error {{cannot convert value of type 'UnicodeScalar' (aka 'Unicode.Scalar') to expected argument type 'Int'}}
+  let d1 = i + us // expected-error {{cannot convert value of type 'UnicodeScalar' (aka 'Unicode.Scalar') to expected '+' operand type 'Int'}}
+  let d2 = i - us // expected-error {{cannot convert value of type 'UnicodeScalar' (aka 'Unicode.Scalar') to expected '-' operand type 'Int'}}
+  let d3 = i * us // expected-error {{cannot convert value of type 'UnicodeScalar' (aka 'Unicode.Scalar') to expected '*' operand type 'Int'}}
+  let d4 = i / us // expected-error {{cannot convert value of type 'UnicodeScalar' (aka 'Unicode.Scalar') to expected '/' operand type 'Int'}}
 }
 

--- a/test/stdlib/UnsafePointerDiagnostics.swift
+++ b/test/stdlib/UnsafePointerDiagnostics.swift
@@ -61,8 +61,8 @@ func unsafePointerConversionAvailability(
   _ = UnsafeMutablePointer<Int>(umpi)
   _ = UnsafeMutablePointer<Int>(oumpi)
 
-  _ = UnsafeMutablePointer<Void>(rp)  // expected-error {{cannot convert value of type 'UnsafeRawPointer' to expected argument type 'UnsafeMutablePointer<Void>'}} expected-warning {{UnsafeMutablePointer<Void> has been replaced by UnsafeMutableRawPointer}}
-  _ = UnsafeMutablePointer<Void>(mrp) // expected-error {{cannot convert value of type 'UnsafeMutableRawPointer' to expected argument type 'UnsafeMutablePointer<Void>'}} expected-warning {{UnsafeMutablePointer<Void> has been replaced by UnsafeMutableRawPointer}}
+  _ = UnsafeMutablePointer<Void>(rp)  // expected-error {{cannot convert argument of type 'UnsafeRawPointer' to expected argument type 'UnsafeMutablePointer<Void>'}} expected-warning {{UnsafeMutablePointer<Void> has been replaced by UnsafeMutableRawPointer}}
+  _ = UnsafeMutablePointer<Void>(mrp) // expected-error {{cannot convert value of type 'UnsafeMutableRawPointer' to expected argument type 'UnsafeMutablePointer<Void>' because initializer 'init(_:)' was not imported from C header}} expected-warning {{UnsafeMutablePointer<Void> has been replaced by UnsafeMutableRawPointer}}
   _ = UnsafeMutablePointer<Void>(umpv) // expected-warning {{UnsafeMutablePointer<Void> has been replaced by UnsafeMutableRawPointer}}
   _ = UnsafeMutablePointer<Void>(umpi) // expected-warning {{UnsafeMutablePointer<Void> has been replaced by UnsafeMutableRawPointer}}
   _ = UnsafeMutablePointer<Void>(umps) // expected-warning {{UnsafeMutablePointer<Void> has been replaced by UnsafeMutableRawPointer}}
@@ -76,8 +76,8 @@ func unsafePointerConversionAvailability(
   _ = UnsafePointer<Void>(umps) // expected-warning {{UnsafePointer<Void> has been replaced by UnsafeRawPointer}}
   _ = UnsafePointer<Void>(ups) // expected-warning {{UnsafePointer<Void> has been replaced by UnsafeRawPointer}}
 
-  _ = UnsafeMutablePointer<Int>(rp) // expected-error {{cannot convert value of type 'UnsafeRawPointer' to expected argument type 'UnsafeMutablePointer<Int>'}}
-  _ = UnsafeMutablePointer<Int>(mrp) // expected-error {{cannot convert value of type 'UnsafeMutableRawPointer' to expected argument type 'UnsafeMutablePointer<Int>'}}
+  _ = UnsafeMutablePointer<Int>(rp) // expected-error {{cannot convert argument of type 'UnsafeRawPointer' to expected argument type 'UnsafeMutablePointer<Int>'}}
+  _ = UnsafeMutablePointer<Int>(mrp) // expected-error {{cannot convert argument of type 'UnsafeMutableRawPointer' to expected argument type 'UnsafeMutablePointer<Int>'}}
   // This is ambiguous because we have failable and non-failable initializers that accept the same argument type.
   _ = UnsafeMutablePointer<Int>(orp) // expected-error {{no exact matches in call to initializer}}
   // Two candidates here: OpaquePointer? and UnsafeMutablePointer<Int>?

--- a/test/stmt/foreach.swift
+++ b/test/stmt/foreach.swift
@@ -68,7 +68,7 @@ func patterns(gir: GoodRange<Int>, gtr: GoodTupleIterator) {
   for (i, f) in gtr {
     sum = sum + i
     sumf = sumf + f
-    sum = sum + f  // expected-error {{cannot convert value of type 'Float' to expected argument type 'Int'}} {{17-17=Int(}} {{18-18=)}}
+    sum = sum + f  // expected-error {{cannot convert value of type 'Float' to expected '+' operand type 'Int'}} {{17-17=Int(}} {{18-18=)}}
   }
 
   for (i, _) : (Int, Float) in gtr { sum = sum + i }

--- a/test/type/opaque.swift
+++ b/test/type/opaque.swift
@@ -26,7 +26,7 @@ struct GenericProperty<T: P> {
 let (bim, bam): some P = (1, 2) // expected-error{{'some' type can only be declared on a single property declaration}}
 var computedProperty: some P {
   get { return 1 }
-  set { _ = newValue + 1 } // expected-error{{cannot convert value of type 'some P' to expected argument type 'Int'}}
+  set { _ = newValue + 1 } // expected-error{{cannot convert value of type 'some P' to expected '+' operand type 'Int'}}
 }
 struct SubscriptTest {
   subscript(_ x: Int) -> some P {

--- a/validation-test/Sema/type_checker_perf/fast/rdar97631072.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar97631072.swift
@@ -13,7 +13,7 @@ struct MaskingView: View {
 	var body: some View {
 		ZStack {
 			ForEach( 0 ..< count, id: \.self ) { index in
-				let y: CGFloat = CGFloat(index * 20.0)  // expected-error {{cannot convert value of type 'Int' to expected argument type 'Double'}}
+				let y: CGFloat = CGFloat(index * 20.0)  // expected-error {{cannot convert value of type 'Int' to expected '*' operand type 'Double'}}
         // there's no * overload for (Int, Double)
 				Circle()
 					.fill((index%3==0) ? Color.white : Color.black)

--- a/validation-test/Sema/type_checker_perf/fast/rdar97631072.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar97631072.swift
@@ -31,7 +31,7 @@ struct MaskingView: View {
 	var body: some View {
 		ZStack {
 			ForEach( 0 ..< count, id: \.self ) { index in
-				let y: CGFloat = CGFloat(index * 20.0)  // expected-error {{cannot convert value of type 'Int' to expected argument type 'Double'}}
+				let y: CGFloat = CGFloat(index * 20.0)  // expected-error {{cannot convert value of type 'Int' to expected '*' operand type 'Double'}}
         // there's no * overload for (Int, Double)
 				Circle()
 					.fill((index%3==0) ? Color.white : Color.black)

--- a/validation-test/Sema/type_checker_perf/slow/issue-54143-1.swift
+++ b/validation-test/Sema/type_checker_perf/slow/issue-54143-1.swift
@@ -22,7 +22,9 @@ class UIView {
 }
 
 // Invalid expression, because there is no one-argument form of reduce()
-
+/// TODO: investigate how to encode more of the new cannot select diagnostic as CI vs local difference
+/// means that the number of overloads is not consistent ... message is
+/// cannot select between {N} function types for expected argument type 'CGFloat' for 'reduce'
 class SomeViewController: UIViewController {
     private func updatePreferredContentSize() {
         preferredContentSize = CGSize(
@@ -30,6 +32,7 @@ class SomeViewController: UIViewController {
             height: (view.subviews.map { $0.frame.height }
               .reduce(+)
               // expected-error@-1 {{missing argument for parameter #2 in call}}
+              // expected-error@-2 {{cannot select between }}
               ?? 0) + 20.0
         )
     }

--- a/validation-test/Sema/type_checker_perf/slow/issue-54143-1.swift
+++ b/validation-test/Sema/type_checker_perf/slow/issue-54143-1.swift
@@ -22,7 +22,9 @@ class UIView {
 }
 
 // Invalid expression, because there is no one-argument form of reduce()
-
+/// TODO: investigate how to encode more of the new cannot select diagnostic as CI vs local difference
+/// means that the number of overloads is not consistent ... message is
+/// cannot select between {N} function types for expected argument type 'CGFloat' for 'reduce'
 class SomeViewController: UIViewController {
     private func updatePreferredContentSize() {
         preferredContentSize = CGSize(

--- a/validation-test/compiler_crashers_fixed/0146-rdar38309176.swift
+++ b/validation-test/compiler_crashers_fixed/0146-rdar38309176.swift
@@ -4,5 +4,5 @@ func foo(_ msg: Int) {}    // expected-note {{candidate expects value of type 'I
 func foo(_ msg: Double) {} // expected-note {{candidate expects value of type 'Double' for parameter #1}}
 
 func rdar38309176(_ errors: inout [String]) {
-  foo("error: \(errors[0])") // expected-error {{no exact matches in call to global function 'foo'}}
+  foo("error: \(errors[0])") // expected-error {{ambiguous use of 'foo'; cannot convert argument of type 'String' to any of potential types 'Double', 'Int'}}
 }

--- a/validation-test/compiler_crashers_fixed/0146-rdar38309176.swift
+++ b/validation-test/compiler_crashers_fixed/0146-rdar38309176.swift
@@ -4,5 +4,5 @@ func foo(_ msg: Int) {}    // expected-note {{candidate expects value of type 'I
 func foo(_ msg: Double) {} // expected-note {{candidate expects value of type 'Double' for parameter #1}}
 
 func rdar38309176(_ errors: inout [String]) {
-  foo("error: \(errors[0])") // expected-error {{no exact matches in call to global function 'foo'}}
+  foo("error: \(errors[0])") // expected-error {{no exact 'foo' candidates found; cannot convert argument of type 'String' to any of potential types 'Double', 'Int'}}
 }

--- a/validation-test/compiler_crashers_fixed/0150-rdar39055736.swift
+++ b/validation-test/compiler_crashers_fixed/0150-rdar39055736.swift
@@ -12,5 +12,5 @@ import Foundation
 
 func baz(bar: Bar) {
   max(bar, bar.foo?.x ?? 0)
-  // expected-error@-1 {{cannot convert value of type 'any Bar' to expected argument type 'Int'}}
+  // expected-error@-1 {{cannot convert argument of type 'any Bar' to expected argument type 'Int' for 'max'}}
 }

--- a/validation-test/stdlib/FixedPointDiagnostics.swift.gyb
+++ b/validation-test/stdlib/FixedPointDiagnostics.swift.gyb
@@ -39,8 +39,8 @@ func testMixedSignArithmetic() {
     _ = ${T}(1) - Stride(0) // expected-error {{}} expected-note {{}}
     var x: ${T} = 0
     x += 1              // OK
-    x += Stride(1) // expected-error {{cannot convert value of type 'Stride' (aka 'Int') to expected argument type '${T}'}} {{10-10=${T}(}} {{19-19=)}}
-    x -= Stride(1) // expected-error {{cannot convert value of type 'Stride' (aka 'Int') to expected argument type '${T}'}} {{10-10=${T}(}} {{19-19=)}}
+    x += Stride(1) // expected-error {{cannot convert value of type 'Stride' (aka 'Int') to expected '+=' operand type '${T}'}}
+    x -= Stride(1) // expected-error {{cannot convert value of type 'Stride' (aka 'Int') to expected '-=' operand type '${T}'}}
 
     _ = (x - x) as Stride // expected-error {{}}
 
@@ -53,8 +53,8 @@ func testMixedSignArithmetic() {
     Stride(1) - ${T}(0) // expected-error {{}} expected-note {{}}
 
     var y: Stride = 0
-    y += ${T}(1)        // expected-error {{cannot convert value of type '${T}' to expected argument type 'Stride' (aka 'Int')}} {{10-10=Stride(}}
-    y -= ${T}(1)        // expected-error {{cannot convert value of type '${T}' to expected argument type 'Stride' (aka 'Int')}} {{10-10=Stride(}}
+    y += ${T}(1)        // expected-error {{ambiguous use of '+='; cannot convert argument of type '${T}' to any of potential types 'Int', 'Stride'}}
+    y -= ${T}(1)        // expected-error {{ambiguous use of '-='; cannot convert argument of type '${T}' to any of potential types 'Int', 'Stride'}}
   }
 % end
 }

--- a/validation-test/stdlib/FixedPointDiagnostics.swift.gyb
+++ b/validation-test/stdlib/FixedPointDiagnostics.swift.gyb
@@ -39,8 +39,8 @@ func testMixedSignArithmetic() {
     _ = ${T}(1) - Stride(0) // expected-error {{}} expected-note {{}}
     var x: ${T} = 0
     x += 1              // OK
-    x += Stride(1) // expected-error {{cannot convert value of type 'Stride' (aka 'Int') to expected argument type '${T}'}} {{10-10=${T}(}} {{19-19=)}}
-    x -= Stride(1) // expected-error {{cannot convert value of type 'Stride' (aka 'Int') to expected argument type '${T}'}} {{10-10=${T}(}} {{19-19=)}}
+    x += Stride(1) // expected-error {{cannot convert value of type 'Stride' (aka 'Int') to expected '+=' operand type '${T}'}}
+    x -= Stride(1) // expected-error {{cannot convert value of type 'Stride' (aka 'Int') to expected '-=' operand type '${T}'}}
 
     _ = (x - x) as Stride // expected-error {{}}
 
@@ -53,8 +53,8 @@ func testMixedSignArithmetic() {
     Stride(1) - ${T}(0) // expected-error {{}} expected-note {{}}
 
     var y: Stride = 0
-    y += ${T}(1)        // expected-error {{cannot convert value of type '${T}' to expected argument type 'Stride' (aka 'Int')}} {{10-10=Stride(}}
-    y -= ${T}(1)        // expected-error {{cannot convert value of type '${T}' to expected argument type 'Stride' (aka 'Int')}} {{10-10=Stride(}}
+    y += ${T}(1)        // expected-error {{no exact '+=' candidates found; cannot convert argument of type '${T}' to any of potential types 'Int', 'Stride'}}
+    y -= ${T}(1)        // expected-error {{no exact '-=' candidates found; cannot convert argument of type '${T}' to any of potential types 'Int', 'Stride'}}
   }
 % end
 }


### PR DESCRIPTION
For ambiguous arguments, provide diagnostic with the set of of options where applicable and improve message where the  options are all the same.

<!--
The main branch is now in convergence, which means major changes, such as large refactoring or new features, should be avoided. This strategy is intended to maintain the stability of the Swift 6.4 release leading up to the May 4th branch. For any work that requires broad changes or introduces new features, create a feature branch and open a draft pull request. All updates to the swiftlang/swift repository’s main branch require approval from the release managers. A pull request targeting swiftlang/swift will automatically add release managers. You can also contact them via @release-managers in the forum group.
-->

<!-- Please fill out the following form: --> 
- **Explanation**:
  Improves diagnostics for ambiguous function calls.
- **Scope**:
  Cannot break existing code, can only improve diagnostics for broken code.
- **Issues**:
  <!--
  References to issues the changes resolve, if any.
  -->
- **Risk**:
  Low risk
- **Testing**:
  Normal smoke tests

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
