### PR TITLE
🍒[cxx-interop] Add `std::expected` into the libstdc++ modulemap on Linux

### DIFF
--- a/lib/ClangImporter/ClangIncludePaths.cpp
+++ b/lib/ClangImporter/ClangIncludePaths.cpp
@@ -422,6 +422,7 @@ static void getLibStdCxxFileMapping(
       "bits/valarray_array.h", "bits/valarray_before.h", "bits/version.h",
       // C++20 and newer:
       "barrier",
+      "bit",
       "compare",
       "concepts",
       "format",
@@ -433,6 +434,11 @@ static void getLibStdCxxFileMapping(
       "span",
       "stop_token",
       "syncstream",
+      // C++23 and newer:
+      "expected",
+      "flat_map",
+      "flat_set",
+      "mdspan",
     };
   std::string additionalHeaderDirectives;
   llvm::raw_string_ostream os(additionalHeaderDirectives);

--- a/test/Interop/Cxx/stdlib/use-std-expected-typechecker.swift
+++ b/test/Interop/Cxx/stdlib/use-std-expected-typechecker.swift
@@ -1,7 +1,6 @@
 // RUN: not %target-swift-frontend %s -typecheck -I %S/Inputs -cxx-interoperability-mode=default -Xcc -std=c++23 -diagnostic-style llvm 2>&1 | %FileCheck %s
 
-// TODO <expected> not yet supported with libstdc++
-// UNSUPPORTED: OS=linux-gnu
+// REQUIRES: std_expected
 
 // https://github.com/apple/swift/issues/70226
 // UNSUPPORTED: OS=windows-msvc

--- a/test/Interop/lit.local.cfg
+++ b/test/Interop/lit.local.cfg
@@ -48,23 +48,34 @@ if get_target_os() in ['linux-gnu']:
     if os.path.exists('/usr/include/c++/v1') or os.path.exists('/usr/local/include/c++/v1'):
         config.available_features.add('system_wide_libcxx')
 
-if config.target_sdk_libcxx_path != '':
-    if os.path.exists(os.path.join(config.target_sdk_libcxx_path, "span")):
-        config.available_features.add('std_span')
-elif get_target_os() in ['linux-gnu']:
-    for p in ['/usr/include/c++/', '/usr/local/include/c++/']:
-        if not os.path.isdir(p):
-            continue
-        for subdir in os.listdir(p):
-            if not subdir.isdigit():
-                # skip paths libc++ paths like /usr/include/c++/v1, we want libstdc++ paths only (like /usr/include/c++/13)
+
+def has_cxx_stdlib_header(header_name):
+    if config.target_sdk_libcxx_path != '':
+        if os.path.exists(
+                os.path.join(config.target_sdk_libcxx_path, header_name)):
+            return True
+    elif get_target_os() in ['linux-gnu']:
+        for cxx_stdlib_root in ['/usr/include/c++/', '/usr/local/include/c++/']:
+            if not os.path.isdir(cxx_stdlib_root):
                 continue
-            if os.path.exists(os.path.join(p, subdir, "span")):
-                config.available_features.add('std_span')
-elif get_target_os() in ['windows-msvc']:
-    # We don't test on any versions of MSVC without std::span support.
-    # FIXME: figure out where to do lookup for C++ stdlib headers on Windows - we'll probably need it eventually
+            for subdir in os.listdir(cxx_stdlib_root):
+                if not subdir.isdigit():
+                    # skip paths libc++ paths like /usr/include/c++/v1, we want libstdc++ paths only (like /usr/include/c++/13)
+                    continue
+                if os.path.exists(
+                        os.path.join(cxx_stdlib_root, subdir, header_name)):
+                    return True
+    elif get_target_os() in ['windows-msvc']:
+        # We don't test on any versions of MSVC without std::span support.
+        # FIXME: figure out where to do lookup for C++ stdlib headers on Windows - we'll probably need it eventually
+        return True
+    return False
+
+
+if has_cxx_stdlib_header('span'):
     config.available_features.add('std_span')
+if has_cxx_stdlib_header('expected'):
+    config.available_features.add('std_expected')
 
 # Enable C++ interop when compiling Swift sources.
 config.substitutions.insert(0, ('%target-interop-build-swift',


### PR DESCRIPTION
<!--
The main branch is now in convergence, which means major changes, such as large refactoring or new features, should be avoided. This strategy is intended to maintain the stability of the Swift 6.4 release leading up to the May 4th branch. For any work that requires broad changes or introduces new features, create a feature branch and open a draft pull request. All updates to the swiftlang/swift repository’s main branch require approval from the release managers. A pull request targeting swiftlang/swift will automatically add release managers. You can also contact them via @release-managers in the forum group.
-->

<!-- Please fill out the following form: --> 
- **Explanation**:
Projects on Linux had trouble importing C++ libraries that use the `<expected>` C++ header. This was due to a modularization error: the libstdc++ modulemap did not list `<expected>` as one of its headers.
- **Scope**:
Changes the libstdc++ modulemap that the Swift compiler injects into system include paths using LLVM VFS.
- **Issues**:
rdar://175155283
- **Risk**:
Low, this only affects Linux and is covered by tests.
- **Testing**:
Enabled existing `std::expected` test on Linux.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
