### PR TITLE
Revert "SwiftCompilerSources: workaround a crash in the LoadableByAddress pass when building on Windows"

### DIFF
--- a/SwiftCompilerSources/CMakeLists.txt
+++ b/SwiftCompilerSources/CMakeLists.txt
@@ -194,10 +194,6 @@ function(add_swift_compiler_modules_library name)
     # For "swift/shims/*.h".
     list(APPEND sdk_option "-I" "${SWIFT_PATH_TO_SWIFT_SDK}/usr/lib")
 
-    # Workaround a crash in the LoadableByAddress pass
-    # https://github.com/apple/swift/issues/73254
-    list(APPEND swift_compile_options "-Xllvm" "-sil-disable-pass=loadable-address")
-
     # MSVC 14.40 (VS 17.10, MSVC_VERSION 1940) added a requirement for Clang 17 or higher.
     # Swift 6.0 is the first version to include Clang 17.
     # MSVC 14.43 (VS 17.13, MSVC_VERSION 1943) added a requirement for Clang 18 or higher.


### PR DESCRIPTION
- **Explanation**:
This reverts commit 338dd185e78918d9a3469b1439db72f9ba8a868c.
The problem is already fixed and disabling the loadable-address pass causes other problems: When the pass is disabled a `swiftself` attribute is missing for the stdlib `Hasher.finalize` declaration in LLVM IR. This causes a mis-compile.

- **Scope**:
Only affects Windows

- **Issues**:
https://github.com/swiftlang/swift/issues/73254

- **Risk**:
Very low. It only affects Windows. It's reverting a workaround for a compiler crash. If the Windows build succeeds, we know that the workaround is no longer needed.

- **Testing**:
Tested by Windows CI testing

- **Reviewers**:
@elsakeirouz 


