### PR TITLE
Correctly invalidate analyses after keypath optimization

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/PassManager/ContextCommon.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/PassManager/ContextCommon.swift
@@ -100,7 +100,12 @@ extension MutatingContext {
   }
   
   func tryOptimizeKeypath(apply: FullApplySite) -> Bool {
-    return bridgedPassContext.tryOptimizeKeypath(apply.bridged)
+    if bridgedPassContext.tryOptimizeKeypath(apply.bridged) {
+      notifyBranchesChanged()
+      notifyInstructionsChanged()
+      return true
+    }
+    return false
   }
 
   func inlineFunction(apply: FullApplySite, mandatoryInline: Bool) {

--- a/test/SILOptimizer/optimize_keypath.swift
+++ b/test/SILOptimizer/optimize_keypath.swift
@@ -7,6 +7,12 @@
 // RUN: %FileCheck --check-prefix=CHECK --check-prefix=CHECK2 %s < %t/output6.sil
 // RUN: %FileCheck -check-prefix=CHECK-ALL %s < %t/output6.sil
 
+// Turning on force verification of analyses is exposing:
+// rdar://175520775 (RegionAnalysis crashes saying it cannot handle `assign` instruction)
+// TODO: %target-swift-frontend -primary-file %s -O -Xllvm -sil-verify-force-analysis=true -swift-version 6 -Xllvm -sil-print-types -emit-sil >%t/output2.sil
+// TODO: %FileCheck --check-prefix=CHECK --check-prefix=CHECK2 %s < %t/output2.sil
+// TODO: %FileCheck -check-prefix=CHECK-ALL %s < %t/output2.sil
+
 // RUN: %target-build-swift -O %s -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s -check-prefix=CHECK-OUTPUT -check-prefix=CHECK5-OUTPUT
 


### PR DESCRIPTION
- **Explanation**: Keypath simplification can create new basic blocks when projecting optional chain components (`OptionalChainProjector` splits the block and creates new conditional branches). However, the Swift-side `tryOptimizeKeypath` was not notifying the pass manager about CFG or instruction changes, leaving analyses like the dominator tree stale. Fix this by calling `notifyBranchesChanged()` and `notifyInstructionsChanged()` when `tryOptimizeKeypath` succeeds.

- **Scope**: Affects optimization behaviour when keypaths are involved

- **Issues**: Exposed by https://github.com/swiftlang/swift/pull/88642

- **Risk**: Low

- **Testing**: CI testing
