### PR TITLE
[Backtracing] [Windows] Add a suitable PE id to windows crash logs

### DIFF
--- a/stdlib/public/RuntimeModule/BacktraceJSONFormatter.swift
+++ b/stdlib/public/RuntimeModule/BacktraceJSONFormatter.swift
@@ -388,6 +388,10 @@ internal extension BacktraceJSONFormatter {
             "endOfText": "\(image.endOfText)"
             """, flush: false)
 
+    if let peImageId = image.peImageId {
+      write(", \"peImageId\": \"\(peImageId)\"", flush: false)
+    }
+
     write(" }", flush: false)
   }
 }

--- a/stdlib/public/RuntimeModule/CrashLog.swift
+++ b/stdlib/public/RuntimeModule/CrashLog.swift
@@ -160,18 +160,21 @@ public struct CrashLog<Address: FixedWidthInteger>: Codable {
         public var path: String?
         public var baseAddress: String
         public var endOfText: String
+        public var peImageId: String?
 
         public init(
             name: String?,
             buildId: String?,
             path: String?,
             baseAddress: String,
-            endOfText: String) {
+            endOfText: String,
+            peImageId: String? = nil) {
                 self.name = name
                 self.buildId = buildId
                 self.path = path
                 self.baseAddress = baseAddress
                 self.endOfText = endOfText
+                self.peImageId = peImageId
             }
     }
 
@@ -381,6 +384,14 @@ extension CrashLog.Image {
         self.path = image.path
         self.baseAddress = hex(image.baseAddress)
         self.endOfText = hex(image.endOfText)
+        #if os(Windows)
+        if image.timeDateStamp != 0 || image.sizeOfImage != 0 {
+            let stamp = String(image.timeDateStamp, radix: 16, uppercase: true)
+            let stampPadded = String(repeating: "0", count: max(0, 8 - stamp.count)) + stamp
+            let size = String(image.sizeOfImage, radix: 16)
+            self.peImageId = "\(stampPadded)\(size)"
+        }
+        #endif
     }
 }
 

--- a/stdlib/public/RuntimeModule/ImageMap+Win32.swift
+++ b/stdlib/public/RuntimeModule/ImageMap+Win32.swift
@@ -224,12 +224,19 @@ extension ImageMap {
     // Turn that into a list of Images
     var images: [Image] = []
     for hModule in hModules {
+      guard let hModule else {
+        #if DEBUG_WIN32_IMAGEMAP_CAPTURE
+        print("Windows backtracing - Null module should not be possible.")
+        #endif
+        continue
+      }
+
       #if DEBUG_WIN32_IMAGEMAP_CAPTURE
       print("hModule: \(String(describing: hModule))")
       #endif
 
-      let moduleName = GetModuleBaseName(hProcess, hModule!)
-      let modulePath = GetModuleFileNameEx(hProcess, hModule!)
+      let moduleName = GetModuleBaseName(hProcess, hModule)
+      let modulePath = GetModuleFileNameEx(hProcess, hModule)
       var moduleInfo = MODULEINFO()
 
       #if DEBUG_WIN32_IMAGEMAP_CAPTURE
@@ -241,7 +248,7 @@ extension ImageMap {
                                  DWORD(MemoryLayout<MODULEINFO>.size))
       else {
         #if DEBUG_WIN32_IMAGEMAP_CAPTURE
-        print("GetModuleInformation() failed for \(hModule!)")
+        print("GetModuleInformation() failed for \(hModule)")
         #endif
         continue
       }
@@ -255,6 +262,7 @@ extension ImageMap {
       let endOfText: Address
       var debugEntry = IMAGE_DATA_DIRECTORY()
       var exceptionEntry = IMAGE_DATA_DIRECTORY()
+      var sizeOfImage: DWORD = 0
 
       var wMagic: WORD = 0
       var dwOffset: DWORD = 0
@@ -322,8 +330,10 @@ extension ImageMap {
         continue
       }
 
+      let timeDateStamp = header.TimeDateStamp
+
       if (header.Characteristics & WORD(IMAGE_FILE_32BIT_MACHINE)) != 0 {
-        // 32-bit
+        // 32-bit (from winnt.h see typedef struct _IMAGE_OPTIONAL_HEADER)
         var optionalHeader = IMAGE_OPTIONAL_HEADER32()
 
         #if DEBUG_WIN32_IMAGEMAP_CAPTURE
@@ -346,14 +356,16 @@ extension ImageMap {
 
         endOfText = baseAddress + Address(optionalHeader.BaseOfCode
                                           + optionalHeader.SizeOfCode)
+        sizeOfImage = optionalHeader.SizeOfImage
 
+        // from winnt.h see typedef struct _IMAGE_DATA_DIRECTORY
         // 3 is IMAGE_DIRECTORY_ENTRY_EXCEPTION
         exceptionEntry = optionalHeader.DataDirectory.3
 
         // 6 is IMAGE_DIRECTORY_ENTRY_DEBUG
         debugEntry = optionalHeader.DataDirectory.6
       } else {
-        // 64-bit
+        // 64-bit (from winnt.h - see typedef struct _IMAGE_OPTIONAL_HEADER64)
         var optionalHeader = IMAGE_OPTIONAL_HEADER64()
 
         #if DEBUG_WIN32_IMAGEMAP_CAPTURE
@@ -376,6 +388,7 @@ extension ImageMap {
 
         endOfText = baseAddress + Address(optionalHeader.BaseOfCode
                                           + optionalHeader.SizeOfCode)
+        sizeOfImage = optionalHeader.SizeOfImage
 
         // 3 is IMAGE_DIRECTORY_ENTRY_EXCEPTION
         exceptionEntry = optionalHeader.DataDirectory.3
@@ -504,7 +517,9 @@ extension ImageMap {
                           uniqueID: theUUID,
                           baseAddress: baseAddress,
                           endOfText: endOfText,
-                          exceptionTable: exceptionTable))
+                          exceptionTable: exceptionTable,
+                          timeDateStamp: timeDateStamp,
+                          sizeOfImage: sizeOfImage))
     }
 
     images.sort(by: { $0.baseAddress < $1.baseAddress })

--- a/stdlib/public/RuntimeModule/ImageMap.swift
+++ b/stdlib/public/RuntimeModule/ImageMap.swift
@@ -75,6 +75,10 @@ public struct ImageMap: Collection, Sendable, Hashable {
     #if os(Windows)
     @_spi(Testing)
     var exceptionTable: ExceptionTable?
+    @_spi(Testing)
+    public var timeDateStamp: UInt32 = 0
+    @_spi(Testing)
+    public var sizeOfImage: UInt32 = 0
     #endif
   }
 


### PR DESCRIPTION
- **Explanation**:
 Retrieving .exe files from symsrv needs a suitable id for the symsrv protocol.

This is different from the PDB id which should normally be output as the image ID. Hence I'm adding it to the end of the image line.

- **Scope**:
This affects only Windows crash logs

- **Issues**:

rdar://175499685

- **Risk**:
This will need some unit tests updated.

- **Testing**:
Compiling and testing locally. While this is in progress, this PR is still in draft.
