### PR TITLE
[Runtime] Add back pointers to the ends of metadata allocator pages.

### DIFF
--- a/include/swift/Runtime/Debug.h
+++ b/include/swift/Runtime/Debug.h
@@ -277,6 +277,14 @@ const size_t _swift_debug_metadataAllocatorPageSize;
 SWIFT_RUNTIME_STDLIB_SPI
 std::atomic<const void *> _swift_debug_metadataAllocationBacktraceList;
 
+// The end of a metadata allocation pool page contains a pointer to the previous
+// page. This is the offset of that pointer within a page. The back pointer
+// points to the previous back pointer, so a user of this value can subtract the
+// offset to find the beginning of the containing page. A value of ~0 means
+// there is no back pointer.
+SWIFT_RUNTIME_STDLIB_SPI
+size_t _swift_debug_allocationPoolBackPointerOffset;
+
 SWIFT_RUNTIME_STDLIB_SPI
 const void * const _swift_debug_protocolConformanceStatePointer;
 

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -8221,6 +8221,7 @@ const void * const swift::_swift_debug_allocationPoolPointer = &AllocationPool;
 const size_t swift::_swift_debug_allocationPoolSize = InitialPoolSize;
 const size_t swift::_swift_debug_metadataAllocatorPageSize = PoolRange::PageSize;
 std::atomic<const void *> swift::_swift_debug_metadataAllocationBacktraceList;
+size_t swift::_swift_debug_allocationPoolBackPointerOffset = ~0;
 
 static void recordBacktrace(void *allocation) {
   withCurrentBacktrace([&](void **addrs, int count) {
@@ -8287,6 +8288,7 @@ static void checkAllocatorDebugEnvironmentVariables(void *context) {
                      "Warning: SWIFT_DEBUG_ENABLE_METADATA_BACKTRACE_LOGGING "
                      "without SWIFT_DEBUG_ENABLE_METADATA_ALLOCATION_ITERATION "
                      "has no effect.\n");
+    _swift_debug_allocationPoolBackPointerOffset = PoolRange::PageSize - sizeof(void **);
     return;
   }
 
@@ -8299,6 +8301,7 @@ static void checkAllocatorDebugEnvironmentVariables(void *context) {
   memcpy(InitialAllocationPool.Pool + newPoolSize, &trailer, sizeof(trailer));
   poolCopy.Remaining = newPoolSize;
   AllocationPool.store(poolCopy, std::memory_order_relaxed);
+  _swift_debug_allocationPoolBackPointerOffset = PoolRange::PageSize - sizeof(PoolTrailer);
 }
 
 void *MetadataAllocator::Allocate(size_t size, size_t alignment) {
@@ -8333,19 +8336,24 @@ void *MetadataAllocator::Allocate(size_t size, size_t alignment) {
       newState = PoolRange{curState.Begin + sizeWithHeader,
                            curState.Remaining - sizeWithHeader};
     } else {
-      auto poolSize = PoolRange::PageSize;
-      if (SWIFT_UNLIKELY(_swift_debug_metadataAllocationIterationEnabled))
-        poolSize -= sizeof(PoolTrailer);
       allocatedNewPage = true;
       allocation = reinterpret_cast<char *>(swift_slowAlloc(PoolRange::PageSize,
                                                             alignof(char) - 1));
       memsetScribble(allocation, PoolRange::PageSize);
 
+      auto poolSize = PoolRange::PageSize;
       if (SWIFT_UNLIKELY(_swift_debug_metadataAllocationIterationEnabled)) {
+        poolSize -= sizeof(PoolTrailer);
         PoolTrailer *newTrailer = (PoolTrailer *)(allocation + poolSize);
         char *prevTrailer = curState.Begin + curState.Remaining;
         newTrailer->PrevTrailer = prevTrailer;
         newTrailer->PoolSize = poolSize;
+      } else {
+        // Write a single back pointer to the end of the pool for the benefit of
+        // memory analysis tools.
+        poolSize -= sizeof(void *);
+        void **ptr = (void **)(allocation + poolSize);
+        *ptr = curState.Begin + curState.Remaining;
       }
       newState = PoolRange{allocation + sizeWithHeader,
                            poolSize - sizeWithHeader};

--- a/test/abi/macOS/arm64/stdlib.swift
+++ b/test/abi/macOS/arm64/stdlib.swift
@@ -1310,3 +1310,6 @@ Added: _$ss9UniqueBoxVsRi_zrlE7pointerSpyxGvg
 
 // Cross-encoding strcmp for Foundation
 Added: __swift_unicodeBuffersEqual_nonNormalizing
+
+// Debug variable for metadata allocator back pointer
+Added: __swift_debug_allocationPoolBackPointerOffset

--- a/test/abi/macOS/x86_64/stdlib.swift
+++ b/test/abi/macOS/x86_64/stdlib.swift
@@ -1306,3 +1306,6 @@ Added: _$ss9UniqueBoxVsRi_zrlE7pointerSpyxGvg
 
 // Cross-encoding strcmp for Foundation
 Added: __swift_unicodeBuffersEqual_nonNormalizing
+
+// Debug variable for metadata allocator back pointer
+Added: __swift_debug_allocationPoolBackPointerOffset


### PR DESCRIPTION
Memory analysis tools have trouble identifying the metadata allocator pages. When allocating a new page, write a pointer to the previous page at the end. Combined with the existing _swift_debug_allocationPoolPointer variable, this will allow all metadata allocation pages to be identified definitively.

rdar://175515505