### PR TITLE
Improve compatibility alias indexing from Swift to match Clang.

### DIFF
--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -28,6 +28,8 @@
 #include "swift/AST/Types.h"
 #include "swift/AST/USRGeneration.h"
 #include "swift/Basic/Assertions.h"
+#include "clang/AST/DeclObjC.h"
+#include "swift/AST/ClangModuleLoader.h"
 #include "swift/Basic/SourceManager.h"
 #include "swift/Basic/StringExtras.h"
 #include "swift/IDE/SourceEntityWalker.h"
@@ -910,7 +912,28 @@ private:
     if (Data.isImplicit)
       Info.roles |= (unsigned)SymbolRole::Implicit;
 
+    // When Clang's indexing encounters a "@compatibility_alias", it emits
+    // references to the underlying type. ClangImporter generates a typealias
+    // that is never emitted, so references to that typealias have no
+    // corresponding definition. Opting to match Clang's behavior and reach
+    // "through" the alias to the underlying type.
+    auto resolveCompatibilityAlias = [](auto &decl) {
+      if (!decl) return;
+      if (auto *TAD = dyn_cast<TypeAliasDecl>(decl)) {
+        if (auto *importer = decl->getASTContext().getClangModuleLoader()) {
+          if (ClangNode ClangN = importer->getEffectiveClangNode(TAD)) {
+            if (isa<clang::ObjCCompatibleAliasDecl>(ClangN.getAsDecl())) {
+              if (auto *nominal = TAD->getUnderlyingType()->getAnyNominal()) {
+                decl = nominal;
+              }
+            }
+          }
+        }
+      }
+    };
+
     if (CtorTyRef) {
+      resolveCompatibilityAlias(CtorTyRef);
       IndexSymbol CtorInfo(Info);
       if (Data.isImplicitCtorType)
         CtorInfo.roles |= (unsigned)SymbolRole::Implicit;
@@ -921,6 +944,8 @@ private:
     if (auto *GenParam = dyn_cast<GenericTypeParamDecl>(D)) {
       D = canonicalizeGenericTypeParamDeclForIndex(GenParam);
     }
+
+    resolveCompatibilityAlias(D);
 
     if (!reportRef(D, Loc, Info, Data.AccKind))
       return false;

--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -889,26 +889,6 @@ private:
     llvm_unreachable("Can't find the generic parameter in the extended type");
   }
 
-  ValueDecl *resolveCompatibilityAlias(ValueDecl *D) {
-    // When Clang's indexing encounters a "@compatibility_alias", it emits
-    // references to the underlying type. ClangImporter synthesizes a typealias
-    // that is never emitted, so references to that typealias have no
-    // corresponding definition. Opting to match Clang's behavior and reach
-    // "through" the alias to the underlying type.
-    if (!D)
-      return D;
-    if (auto *TAD = dyn_cast<TypeAliasDecl>(D)) {
-      if (ClangNode ClangN = swift::ide::getEffectiveClangNode(TAD)) {
-        if (isa<clang::ObjCCompatibleAliasDecl>(ClangN.getAsDecl())) {
-          if (auto *nominal = TAD->getUnderlyingType()->getAnyNominal()) {
-            return nominal;
-          }
-        }
-      }
-    }
-    return D;
-  }
-
   bool visitDeclReference(ValueDecl *D, SourceRange Range, TypeDecl *CtorTyRef,
                           ExtensionDecl *ExtTyRef, Type T,
                           ReferenceMetaData Data) override {
@@ -916,6 +896,29 @@ private:
 
     if (Loc.isInvalid() || isSuppressed(Loc))
       return true;
+
+    // When Clang's indexing encounters a "@compatibility_alias", it emits
+    // references to the underlying type. ClangImporter generates a typealias
+    // that is never emitted, so references to that typealias have no
+    // corresponding definition. Match Clang's behavior and reach through
+    // the alias to the underlying type.
+    auto resolveCompatibilityAlias = [](auto &decl) -> bool {
+      if (!decl)
+        return false;
+      if (auto *TAD = dyn_cast<TypeAliasDecl>(decl)) {
+        if (ClangNode ClangN = swift::ide::getEffectiveClangNode(TAD)) {
+          if (isa<clang::ObjCCompatibleAliasDecl>(ClangN.getAsDecl())) {
+            decl = TAD->getUnderlyingType()->getAnyNominal();
+            return true;
+          }
+        }
+      }
+      return false;
+    };
+
+    if (resolveCompatibilityAlias(D)) {
+      Data.isImplicit = true;
+    }
 
     IndexSymbol Info;
 
@@ -933,11 +936,10 @@ private:
       Info.roles |= (unsigned)SymbolRole::Implicit;
 
     if (CtorTyRef) {
-      if (auto *resolvedAlias =
-              dyn_cast<swift::TypeDecl>(resolveCompatibilityAlias(CtorTyRef))) {
-        CtorTyRef = resolvedAlias;
-      }
       IndexSymbol CtorInfo(Info);
+      if (resolveCompatibilityAlias(CtorTyRef)) {
+        CtorInfo.roles |= (unsigned)SymbolRole::Implicit;
+      }
       if (Data.isImplicitCtorType)
         CtorInfo.roles |= (unsigned)SymbolRole::Implicit;
       if (!reportRef(CtorTyRef, Loc, CtorInfo, Data.AccKind))
@@ -947,8 +949,6 @@ private:
     if (auto *GenParam = dyn_cast<GenericTypeParamDecl>(D)) {
       D = canonicalizeGenericTypeParamDeclForIndex(GenParam);
     }
-
-    D = resolveCompatibilityAlias(D);
 
     if (!reportRef(D, Loc, Info, Data.AccKind))
       return false;
@@ -1635,17 +1635,25 @@ bool IndexSwiftASTWalker::reportRelatedTypeRefImpl(const TypeLoc &TL,
   auto *VD = declRefTR->getBoundDecl();
   if (!VD)
     return true;
-  if (auto *resolvedAlias =
-          dyn_cast<swift::TypeDecl>(resolveCompatibilityAlias(VD))) {
-    VD = resolvedAlias;
-  }
 
   if (auto *TAD = dyn_cast<TypeAliasDecl>(VD)) {
-    IndexSymbol Info;
-    if (Implicit)
-      Info.roles |= (unsigned)SymbolRole::Implicit;
-    if (!reportRef(TAD, Loc, Info, std::nullopt))
-      return false;
+    bool isObjcCompAlias = false;
+    if (ClangNode ClangN = swift::ide::getEffectiveClangNode(TAD)) {
+      if (isa<clang::ObjCCompatibleAliasDecl>(ClangN.getAsDecl())) {
+        isObjcCompAlias = true;
+      }
+    }
+
+    // Skip the reference to the typealias for an Objective-C compatibility
+    // alias. Match Clang's behavior by only emitting references to the
+    // underlying type.
+    if (!isObjcCompAlias) {
+      IndexSymbol Info;
+      if (Implicit)
+        Info.roles |= (unsigned)SymbolRole::Implicit;
+      if (!reportRef(TAD, Loc, Info, std::nullopt))
+        return false;
+    }
 
     // Recurse into the underlying type and report any found references as
     // implicit references at the location of the typealias reference.

--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -889,6 +889,26 @@ private:
     llvm_unreachable("Can't find the generic parameter in the extended type");
   }
 
+  ValueDecl *resolveCompatibilityAlias(ValueDecl *D) {
+    // When Clang's indexing encounters a "@compatibility_alias", it emits
+    // references to the underlying type. ClangImporter synthesizes a typealias
+    // that is never emitted, so references to that typealias have no
+    // corresponding definition. Opting to match Clang's behavior and reach
+    // "through" the alias to the underlying type.
+    if (!D)
+      return D;
+    if (auto *TAD = dyn_cast<TypeAliasDecl>(D)) {
+      if (ClangNode ClangN = swift::ide::getEffectiveClangNode(TAD)) {
+        if (isa<clang::ObjCCompatibleAliasDecl>(ClangN.getAsDecl())) {
+          if (auto *nominal = TAD->getUnderlyingType()->getAnyNominal()) {
+            return nominal;
+          }
+        }
+      }
+    }
+    return D;
+  }
+
   bool visitDeclReference(ValueDecl *D, SourceRange Range, TypeDecl *CtorTyRef,
                           ExtensionDecl *ExtTyRef, Type T,
                           ReferenceMetaData Data) override {
@@ -912,28 +932,11 @@ private:
     if (Data.isImplicit)
       Info.roles |= (unsigned)SymbolRole::Implicit;
 
-    // When Clang's indexing encounters a "@compatibility_alias", it emits
-    // references to the underlying type. ClangImporter generates a typealias
-    // that is never emitted, so references to that typealias have no
-    // corresponding definition. Opting to match Clang's behavior and reach
-    // "through" the alias to the underlying type.
-    auto resolveCompatibilityAlias = [](auto &decl) {
-      if (!decl) return;
-      if (auto *TAD = dyn_cast<TypeAliasDecl>(decl)) {
-        if (auto *importer = decl->getASTContext().getClangModuleLoader()) {
-          if (ClangNode ClangN = importer->getEffectiveClangNode(TAD)) {
-            if (isa<clang::ObjCCompatibleAliasDecl>(ClangN.getAsDecl())) {
-              if (auto *nominal = TAD->getUnderlyingType()->getAnyNominal()) {
-                decl = nominal;
-              }
-            }
-          }
-        }
-      }
-    };
-
     if (CtorTyRef) {
-      resolveCompatibilityAlias(CtorTyRef);
+      if (auto *resolvedAlias =
+              dyn_cast<swift::TypeDecl>(resolveCompatibilityAlias(CtorTyRef))) {
+        CtorTyRef = resolvedAlias;
+      }
       IndexSymbol CtorInfo(Info);
       if (Data.isImplicitCtorType)
         CtorInfo.roles |= (unsigned)SymbolRole::Implicit;
@@ -945,7 +948,7 @@ private:
       D = canonicalizeGenericTypeParamDeclForIndex(GenParam);
     }
 
-    resolveCompatibilityAlias(D);
+    D = resolveCompatibilityAlias(D);
 
     if (!reportRef(D, Loc, Info, Data.AccKind))
       return false;
@@ -1632,6 +1635,10 @@ bool IndexSwiftASTWalker::reportRelatedTypeRefImpl(const TypeLoc &TL,
   auto *VD = declRefTR->getBoundDecl();
   if (!VD)
     return true;
+  if (auto *resolvedAlias =
+          dyn_cast<swift::TypeDecl>(resolveCompatibilityAlias(VD))) {
+    VD = resolvedAlias;
+  }
 
   if (auto *TAD = dyn_cast<TypeAliasDecl>(VD)) {
     IndexSymbol Info;

--- a/test/Index/index_objc_compatibility_alias.swift
+++ b/test/Index/index_objc_compatibility_alias.swift
@@ -1,0 +1,31 @@
+// REQUIRES: objc_interop
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-ide-test -print-indexed-symbols -enable-objc-interop -source-filename %t/ObjcUser.swift -Xcc -fmodule-map-file=%t/module.modulemap | %FileCheck -check-prefix=SWIFT %s
+
+//--- objc_decls.h
+@interface Test
+- (instancetype)init;
+@end
+
+@compatibility_alias NEWTest Test;
+
+void testFunc(NEWTest *t);
+
+//--- module.modulemap
+module objc_decls {
+  header "objc_decls.h"
+  export *
+}
+
+//--- ObjcUser.swift
+import objc_decls
+func test() {
+  let _: NEWTest? = nil
+  // SWIFT: 3:10 | class/Swift | Test | c:objc(cs)Test | Ref,RelCont | rel: 1
+
+  _ = NEWTest()
+  // SWIFT: 6:7 | class/Swift | Test | c:objc(cs)Test | Ref,RelCont | rel: 1
+}

--- a/test/Index/index_objc_compatibility_alias.swift
+++ b/test/Index/index_objc_compatibility_alias.swift
@@ -29,3 +29,6 @@ func test() {
   _ = NEWTest()
   // SWIFT: 6:7 | class/Swift | Test | c:objc(cs)Test | Ref,RelCont | rel: 1
 }
+
+class C: NEWTest {}
+// SWIFT: 10:10 | class/Swift | Test | c:objc(cs)Test | Ref,RelBase | rel: 1

--- a/test/Index/index_objc_compatibility_alias.swift
+++ b/test/Index/index_objc_compatibility_alias.swift
@@ -22,13 +22,17 @@ module objc_decls {
 
 //--- ObjcUser.swift
 import objc_decls
+// SWIFT-NOT: NEWTest
 func test() {
   let _: NEWTest? = nil
-  // SWIFT: 3:10 | class/Swift | Test | c:objc(cs)Test | Ref,RelCont | rel: 1
+  // SWIFT: 4:10 | class/Swift | Test | c:objc(cs)Test | Ref,Impl,RelCont | rel: 1
+  // SWIFT-NOT: NEWTest
 
   _ = NEWTest()
-  // SWIFT: 6:7 | class/Swift | Test | c:objc(cs)Test | Ref,RelCont | rel: 1
+  // SWIFT: 8:7 | class/Swift | Test | c:objc(cs)Test | Ref,Impl,RelCont | rel: 1
+  // SWIFT-NOT: NEWTest
 }
 
 class C: NEWTest {}
-// SWIFT: 10:10 | class/Swift | Test | c:objc(cs)Test | Ref,RelBase | rel: 1
+// SWIFT: 13:10 | class/Swift | Test | c:objc(cs)Test | Ref,Impl,RelBase | rel: 1
+// SWIFT-NOT: NEWTest


### PR DESCRIPTION
- **Explanation**:

When Clang's indexer encounters a compatibility alias reference, it actually emits the reference to the underlying type. I've verified the behavior by building indexstores for Objc decls and refs, but I'm honestly not positive how/where that happens interally in Clang. I suspect it's because `Sema::ClassifyName` [resolves the type when it finds a compatibility alias](https://github.com/swiftlang/llvm-project/blob/e1ac486ddde5f4ce162facd7d9dc90cb2d241588/clang/lib/Sema/SemaDecl.cpp#L1240-L1243).

Before this patch, Swift would generate a typealias declaration when it encountered a reference to a name defined by a compatibility alias. Then emit a reference to that typealias. Unfortunately that typealias never has a definition so it's "dangling". To resolve that I considered some options:

1. (Selected) Match Clang's behavior and emit a reference directly to the underlying type. This has a downside in that it doesn't fully match the "actual" code. The reference really is for the compatibility alias, and if that alias and the underlying declaration are in separate headers or even separate modules it can be confusing. This implementation is simpler though and apparently the behavior has been close enough for Clang.
2. (Not selected) Emit a definition occurrence for the generated typealias used by Swift when referencing the alias name. This seems like a robust and fully correct solution, but I didn't see any prior art for creating definitions like this. Specifically, the synthesized typealias only exists _when it's referenced_ from Swift so it wouldn't appear if someone compiled a PCM from an objc module with indexing enabled. Given those limitations, this didn't seem like a good solution.

- **Scope**:

This change impacts the indexstore output when using index-while-building for Swift modules that reference `@compatibility_alias` declarations from Objective-C.

- **Issues**:

https://github.com/swiftlang/swift/issues/88653

- **Risk**:

Downstream use cases for indexstore data can be impacted, e.g. Swift's language services (SourceKit and SourceKit-LSP). Those downstream indexstore consumers could fail to resolve impacted symbols properly.

- **Testing**:

Ran Swift project tests.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
