### PR TITLE
[rbi] Respect nonisolated(unsafe) overrides on fields.

### DIFF
--- a/lib/SILOptimizer/Utils/SILIsolationInfo.cpp
+++ b/lib/SILOptimizer/Utils/SILIsolationInfo.cpp
@@ -352,9 +352,12 @@ static SILIsolationInfo computeIsolationForClassField(SILValue queriedValue,
   // override what is on the class.
   auto varIsolation = swift::getActorIsolation(field);
 
-  // If we have an explicitly global actor isolated field, then we must prefer
-  // that isolation since it takes precedence over any isolation directly on the
-  // underlying class type.
+  // If we have a global actor isolated field, then prefer that.
+  //
+  // NOTE: This handles both cases where the field has an explicit isolation and
+  // a field where the field does not have an explicit isolation but inherits
+  // its isolation from its parent type since swift::getActorIsolation handles
+  // this for us.
   if (varIsolation.isGlobalActor()) {
     assert(!varIsolation.isNonisolatedUnsafe() &&
            "Cannot apply both nonisolated(unsafe) and a global actor attribute "
@@ -363,44 +366,29 @@ static SILIsolationInfo computeIsolationForClassField(SILValue queriedValue,
         queriedValue, varIsolation.getGlobalActor());
   }
 
-  // Then check if our field is explicitly nonisolated (not
-  // nonisolated(unsafe)). In such a case, we want to return disconnected since
-  // we are overriding the isolation of the actual nominal type. If we have
-  // nonisolated(unsafe), we want to respect the isolation of the nominal type
-  // since we just want to squelch the error but still have it be isolated in
-  // its normal way. This provides more information since we know what the
-  // underlying isolation /would/ have been.
-  if (varIsolation.isNonisolatedOrConcurrent() && !varIsolation.isNonisolatedUnsafe())
-    return SILIsolationInfo::getDisconnected(false /*nonisolated unsafe*/);
+  // Then check if our field is explicitly nonisolated or
+  // nonisolated(unsafe). If so, return early here.
+  if (varIsolation.isNonisolatedOrConcurrent())
+    return SILIsolationInfo::getDisconnected(
+        varIsolation.isNonisolatedUnsafe());
 
-  // Ok, we know that we do not have any overriding isolation from the var
-  // itself... so now we should use isolation from the underlying nominal type.
-
-  // First see if we have an actor instance value from an isolated
-  // SILFunctionArgument.
+  // Check if we actually have an actor as our class value. First see if we have
+  // an actor instance value from an isolated SILFunctionArgument.
   if (auto instance = ActorInstance::getForValue(classValue)) {
     if (auto *fArg = llvm::dyn_cast_or_null<SILFunctionArgument>(
             instance.maybeGetValue())) {
       if (auto info =
               SILIsolationInfo::getActorInstanceIsolated(queriedValue, fArg)) {
-        return info.withUnsafeNonIsolated(varIsolation.isNonisolatedUnsafe());
+        return info;
       }
     }
   }
 
-  // First find out if our classValue is a nominal type and exit early...
-  if (auto *nomDecl = classValue->getType().getNominalOrBoundGenericNominal()) {
-    if (auto isolation = swift::getActorIsolation(nomDecl);
-        isolation && isolation.isGlobalActor()) {
-      return SILIsolationInfo::getGlobalActorIsolated(
-                 queriedValue, isolation.getGlobalActor())
-          .withUnsafeNonIsolated(varIsolation.isNonisolatedUnsafe());
-    }
-
-    if (nomDecl->isAnyActor())
-      return SILIsolationInfo::getActorInstanceIsolated(queriedValue,
-                                                        classValue, nomDecl)
-          .withUnsafeNonIsolated(varIsolation.isNonisolatedUnsafe());
+  // Then check if our classValue is an any Actor.
+  if (auto *nomDecl = classValue->getType().getNominalOrBoundGenericNominal();
+      nomDecl && nomDecl->isAnyActor()) {
+    return SILIsolationInfo::getActorInstanceIsolated(queriedValue, classValue,
+                                                      nomDecl);
   }
 
   // If we have a metatype...
@@ -749,14 +737,9 @@ SILIsolationInfo SILIsolationInfo::get(SILInstruction *inst) {
     // itself. We should use that instead.
     if (varIsolation.isGlobalActor()) {
       return SILIsolationInfo::getGlobalActorIsolated(
-                 sei, varIsolation.getGlobalActor())
-          .withUnsafeNonIsolated(varIsolation.isNonisolatedUnsafe());
+          sei, varIsolation.getGlobalActor());
     }
 
-    if (auto isolation =
-            SILIsolationInfo::getGlobalActorIsolated(sei, sei->getStructDecl()))
-      return isolation.withUnsafeNonIsolated(
-          varIsolation.isNonisolatedUnsafe());
     return SILIsolationInfo::getDisconnected(
         varIsolation.isNonisolatedUnsafe());
   }
@@ -764,19 +747,13 @@ SILIsolationInfo SILIsolationInfo::get(SILInstruction *inst) {
   if (auto *seai = dyn_cast<StructElementAddrInst>(inst)) {
     auto varIsolation = swift::getActorIsolation(seai->getField());
 
-    // If our var is global actor isolated, then we override the isolation of
-    // whatever our struct was with a specific isolation on the struct
-    // itself. We should use that instead.
+    // If our var is explicitly global actor isolated, return it.
     if (varIsolation.isGlobalActor()) {
       return SILIsolationInfo::getGlobalActorIsolated(
-                 seai, varIsolation.getGlobalActor())
-          .withUnsafeNonIsolated(varIsolation.isNonisolatedUnsafe());
+          seai, varIsolation.getGlobalActor());
     }
 
-    if (auto isolation = SILIsolationInfo::getGlobalActorIsolated(
-            seai, seai->getStructDecl()))
-      return isolation.withUnsafeNonIsolated(
-          varIsolation.isNonisolatedUnsafe());
+    // Otherwise, just return disconnected.
     return SILIsolationInfo::getDisconnected(
         varIsolation.isNonisolatedUnsafe());
   }

--- a/test/Concurrency/silisolationinfo_inference.sil
+++ b/test/Concurrency/silisolationinfo_inference.sil
@@ -106,6 +106,25 @@ struct NonisolatedStruct {
   nonisolated(unsafe) var nsNonisolatedUnsafe: NonSendableKlass
 }
 
+@MainActor final class MainActorIsolatedFinalKlass {
+  nonisolated(unsafe) var nsNonisolatedUnsafe: NonSendableKlass
+}
+
+@MainActor class MainActorIsolatedGenericKlass<T> {
+  var field: T
+  nonisolated(unsafe) var nsNonisolatedUnsafe: NonSendableKlass
+}
+
+@MainActor struct MainActorIsolatedGenericStruct<T> {
+  var field: T
+  nonisolated(unsafe) var nsNonisolatedUnsafe: NonSendableKlass
+}
+
+struct NonisolatedGenericStruct<T> {
+  var field: T
+  nonisolated(unsafe) var nsNonisolatedUnsafe: NonSendableKlass
+}
+
 sil @transferNonSendableKlass : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
 sil @useNonSendableKlass : $@convention(thin) (@guaranteed NonSendableKlass) -> ()
 sil @constructNonSendableKlass : $@convention(thin) () -> @owned NonSendableKlass
@@ -1020,7 +1039,7 @@ bb0(%0 : @guaranteed $MyActor):
 
 // CHECK-LABEL: begin running test 1 of 1 on test_globalactor_inference_on_nominal_field_actor_nonisolated_unsafe: sil_isolation_info_inference with: @trace[0]
 // CHECK: Input Value:   %2 = ref_element_addr %0 : $MyActor, #MyActor.nsNonisolatedUnsafe
-// CHECK: Isolation: 'self'-isolated: nonisolated(unsafe)
+// CHECK: Isolation: disconnected: nonisolated(unsafe)
 // CHECK: end running test 1 of 1 on test_globalactor_inference_on_nominal_field_actor_nonisolated_unsafe: sil_isolation_info_inference with: @trace[0]
 sil [ossa] @test_globalactor_inference_on_nominal_field_actor_nonisolated_unsafe : $@convention(thin) (@guaranteed MyActor) -> () {
 bb0(%0 : @guaranteed $MyActor):
@@ -1062,7 +1081,7 @@ bb0(%0 : @guaranteed $MainActorIsolatedKlass):
 
 // CHECK-LABEL: begin running test 1 of 1 on test_globalactor_inference_on_nominal_field_globalactorklass_nonisolated_unsafe: sil_isolation_info_inference with: @trace[0]
 // CHECK: Input Value:   %2 = ref_element_addr %0 : $MainActorIsolatedKlass, #MainActorIsolatedKlass.nsNonisolatedUnsafe
-// CHECK: Isolation: main actor-isolated: nonisolated(unsafe)
+// CHECK: Isolation: disconnected: nonisolated(unsafe)
 // CHECK: end running test 1 of 1 on test_globalactor_inference_on_nominal_field_globalactorklass_nonisolated_unsafe: sil_isolation_info_inference with: @trace[0]
 sil [ossa] @test_globalactor_inference_on_nominal_field_globalactorklass_nonisolated_unsafe : $@convention(thin) (@guaranteed MainActorIsolatedKlass) -> () {
 bb0(%0 : @guaranteed $MainActorIsolatedKlass):
@@ -1146,7 +1165,7 @@ bb0(%0 : @guaranteed $MainActorIsolatedStruct):
 
 // CHECK-LABEL: begin running test 1 of 1 on test_globalactor_inference_on_nominal_field_globalactorstruct_nonisolated_unsafe: sil_isolation_info_inference with: @trace[0]
 // CHECK: Input Value:   %2 = struct_extract %0 : $MainActorIsolatedStruct, #MainActorIsolatedStruct.nsNonisolatedUnsafe
-// CHECK: Isolation: main actor-isolated: nonisolated(unsafe)
+// CHECK: Isolation: disconnected: nonisolated(unsafe)
 // CHECK: end running test 1 of 1 on test_globalactor_inference_on_nominal_field_globalactorstruct_nonisolated_unsafe: sil_isolation_info_inference with: @trace[0]
 sil [ossa] @test_globalactor_inference_on_nominal_field_globalactorstruct_nonisolated_unsafe : $@convention(thin) (@guaranteed MainActorIsolatedStruct) -> () {
 bb0(%0 : @guaranteed $MainActorIsolatedStruct):
@@ -1188,7 +1207,7 @@ bb0(%0 : $*MainActorIsolatedStruct):
 
 // CHECK-LABEL: begin running test 1 of 1 on test_globalactor_inference_on_nominal_field_globalactorstruct_addr_nonisolated_unsafe: sil_isolation_info_inference with: @trace[0]
 // CHECK: Input Value:   %2 = struct_element_addr %0 : $*MainActorIsolatedStruct, #MainActorIsolatedStruct.nsNonisolatedUnsafe
-// CHECK: Isolation: main actor-isolated: nonisolated(unsafe)
+// CHECK: Isolation: disconnected: nonisolated(unsafe)
 // CHECK: end running test 1 of 1 on test_globalactor_inference_on_nominal_field_globalactorstruct_addr_nonisolated_unsafe: sil_isolation_info_inference with: @trace[0]
 sil [ossa] @test_globalactor_inference_on_nominal_field_globalactorstruct_addr_nonisolated_unsafe : $@convention(thin) (@in_guaranteed MainActorIsolatedStruct) -> () {
 bb0(%0 : $*MainActorIsolatedStruct):
@@ -1279,6 +1298,108 @@ bb0(%0 : $*NonisolatedStruct):
   specify_test "sil_isolation_info_inference @trace[0]"
   debug_value %0 : $*NonisolatedStruct, let, name "self"
   %1 = struct_element_addr %0 : $*NonisolatedStruct, #NonisolatedStruct.nsNonisolatedUnsafe
+  debug_value [trace] %1
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+/////////////////////////////////////////////////////////////
+// MARK: Nonisolated Unsafe Field Override Disconnect Tests //
+/////////////////////////////////////////////////////////////
+
+// CHECK-LABEL: begin running test 1 of 1 on test_nonisolated_unsafe_field_override_final_class: sil_isolation_info_inference with: @trace[0]
+// CHECK: Input Value:   %2 = ref_element_addr %0 : $MainActorIsolatedFinalKlass, #MainActorIsolatedFinalKlass.nsNonisolatedUnsafe
+// CHECK: Isolation: disconnected: nonisolated(unsafe)
+// CHECK: end running test 1 of 1 on test_nonisolated_unsafe_field_override_final_class: sil_isolation_info_inference with: @trace[0]
+sil [ossa] @test_nonisolated_unsafe_field_override_final_class : $@convention(thin) (@guaranteed MainActorIsolatedFinalKlass) -> () {
+bb0(%0 : @guaranteed $MainActorIsolatedFinalKlass):
+  specify_test "sil_isolation_info_inference @trace[0]"
+  debug_value %0 : $MainActorIsolatedFinalKlass, let, name "self"
+  %1 = ref_element_addr %0 : $MainActorIsolatedFinalKlass, #MainActorIsolatedFinalKlass.nsNonisolatedUnsafe
+  debug_value [trace] %1
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on test_nonisolated_unsafe_field_override_class: sil_isolation_info_inference with: @trace[0]
+// CHECK: Input Value:   %2 = ref_element_addr %0 : $MainActorIsolatedKlass, #MainActorIsolatedKlass.nsNonisolatedUnsafe
+// CHECK: Isolation: disconnected: nonisolated(unsafe)
+// CHECK: end running test 1 of 1 on test_nonisolated_unsafe_field_override_class: sil_isolation_info_inference with: @trace[0]
+sil [ossa] @test_nonisolated_unsafe_field_override_class : $@convention(thin) (@guaranteed MainActorIsolatedKlass) -> () {
+bb0(%0 : @guaranteed $MainActorIsolatedKlass):
+  specify_test "sil_isolation_info_inference @trace[0]"
+  debug_value %0 : $MainActorIsolatedKlass, let, name "self"
+  %1 = ref_element_addr %0 : $MainActorIsolatedKlass, #MainActorIsolatedKlass.nsNonisolatedUnsafe
+  debug_value [trace] %1
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on test_nonisolated_unsafe_field_override_struct: sil_isolation_info_inference with: @trace[0]
+// CHECK: Input Value:   %2 = struct_extract %0 : $MainActorIsolatedStruct, #MainActorIsolatedStruct.nsNonisolatedUnsafe
+// CHECK: Isolation: disconnected: nonisolated(unsafe)
+// CHECK: end running test 1 of 1 on test_nonisolated_unsafe_field_override_struct: sil_isolation_info_inference with: @trace[0]
+sil [ossa] @test_nonisolated_unsafe_field_override_struct : $@convention(thin) (@guaranteed MainActorIsolatedStruct) -> () {
+bb0(%0 : @guaranteed $MainActorIsolatedStruct):
+  specify_test "sil_isolation_info_inference @trace[0]"
+  debug_value %0 : $MainActorIsolatedStruct, let, name "self"
+  %1 = struct_extract %0 : $MainActorIsolatedStruct, #MainActorIsolatedStruct.nsNonisolatedUnsafe
+  debug_value [trace] %1
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on test_nonisolated_unsafe_field_override_struct_addr: sil_isolation_info_inference with: @trace[0]
+// CHECK: Input Value:   %2 = struct_element_addr %0 : $*MainActorIsolatedStruct, #MainActorIsolatedStruct.nsNonisolatedUnsafe
+// CHECK: Isolation: disconnected: nonisolated(unsafe)
+// CHECK: end running test 1 of 1 on test_nonisolated_unsafe_field_override_struct_addr: sil_isolation_info_inference with: @trace[0]
+sil [ossa] @test_nonisolated_unsafe_field_override_struct_addr : $@convention(thin) (@in_guaranteed MainActorIsolatedStruct) -> () {
+bb0(%0 : $*MainActorIsolatedStruct):
+  specify_test "sil_isolation_info_inference @trace[0]"
+  debug_value %0 : $*MainActorIsolatedStruct, let, name "self"
+  %1 = struct_element_addr %0 : $*MainActorIsolatedStruct, #MainActorIsolatedStruct.nsNonisolatedUnsafe
+  debug_value [trace] %1
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on test_nonisolated_unsafe_field_override_generic_struct_addr: sil_isolation_info_inference with: @trace[0]
+// CHECK: Input Value:   %2 = struct_element_addr %0 : $*MainActorIsolatedGenericStruct<T>, #MainActorIsolatedGenericStruct.nsNonisolatedUnsafe
+// CHECK: Isolation: disconnected: nonisolated(unsafe)
+// CHECK: end running test 1 of 1 on test_nonisolated_unsafe_field_override_generic_struct_addr: sil_isolation_info_inference with: @trace[0]
+sil [ossa] @test_nonisolated_unsafe_field_override_generic_struct_addr : $@convention(thin) <T> (@in_guaranteed MainActorIsolatedGenericStruct<T>) -> () {
+bb0(%0 : $*MainActorIsolatedGenericStruct<T>):
+  specify_test "sil_isolation_info_inference @trace[0]"
+  debug_value %0 : $*MainActorIsolatedGenericStruct<T>, let, name "self"
+  %1 = struct_element_addr %0 : $*MainActorIsolatedGenericStruct<T>, #MainActorIsolatedGenericStruct.nsNonisolatedUnsafe
+  debug_value [trace] %1
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on test_nonisolated_unsafe_field_override_nonisolated_generic_struct_addr: sil_isolation_info_inference with: @trace[0]
+// CHECK: Input Value:   %2 = struct_element_addr %0 : $*NonisolatedGenericStruct<T>, #NonisolatedGenericStruct.nsNonisolatedUnsafe
+// CHECK: Isolation: disconnected: nonisolated(unsafe)
+// CHECK: end running test 1 of 1 on test_nonisolated_unsafe_field_override_nonisolated_generic_struct_addr: sil_isolation_info_inference with: @trace[0]
+sil [ossa] @test_nonisolated_unsafe_field_override_nonisolated_generic_struct_addr : $@convention(thin) <T> (@in_guaranteed NonisolatedGenericStruct<T>) -> () {
+bb0(%0 : $*NonisolatedGenericStruct<T>):
+  specify_test "sil_isolation_info_inference @trace[0]"
+  debug_value %0 : $*NonisolatedGenericStruct<T>, let, name "self"
+  %1 = struct_element_addr %0 : $*NonisolatedGenericStruct<T>, #NonisolatedGenericStruct.nsNonisolatedUnsafe
+  debug_value [trace] %1
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on test_nonisolated_unsafe_field_override_generic_class: sil_isolation_info_inference with: @trace[0]
+// CHECK: Input Value:   %2 = ref_element_addr %0 : $MainActorIsolatedGenericKlass<T>, #MainActorIsolatedGenericKlass.nsNonisolatedUnsafe
+// CHECK: Isolation: disconnected: nonisolated(unsafe)
+// CHECK: end running test 1 of 1 on test_nonisolated_unsafe_field_override_generic_class: sil_isolation_info_inference with: @trace[0]
+sil [ossa] @test_nonisolated_unsafe_field_override_generic_class : $@convention(thin) <T> (@guaranteed MainActorIsolatedGenericKlass<T>) -> () {
+bb0(%0 : @guaranteed $MainActorIsolatedGenericKlass<T>):
+  specify_test "sil_isolation_info_inference @trace[0]"
+  debug_value %0 : $MainActorIsolatedGenericKlass<T>, let, name "self"
+  %1 = ref_element_addr %0 : $MainActorIsolatedGenericKlass<T>, #MainActorIsolatedGenericKlass.nsNonisolatedUnsafe
   debug_value [trace] %1
   %9999 = tuple ()
   return %9999 : $()
@@ -1656,7 +1777,7 @@ bb0:
 
 // CHECK-LABEL: begin running test 1 of 1 on globalactor_isolated_class_nonisolatedunsafeclassproperty_getter: sil_isolation_info_inference with: @trace[0]
 // CHECK: Input Value:   %1 = class_method %0 : $@thick MainActorIsolatedKlass.Type, #MainActorIsolatedKlass.nsNonisolatedUnsafeClassComputed!getter : (MainActorIsolatedKlass.Type) -> () -> NonSendableKlass, $@convention(method) (@thick MainActorIsolatedKlass.Type) -> @owned NonSendableKlass
-// CHECK: Isolation: main actor-isolated: nonisolated(unsafe)
+// CHECK: Isolation: disconnected: nonisolated(unsafe)
 // CHECK: end running test 1 of 1 on globalactor_isolated_class_nonisolatedunsafeclassproperty_getter: sil_isolation_info_inference with: @trace[0]
 sil [ossa] @globalactor_isolated_class_nonisolatedunsafeclassproperty_getter : $@convention(thin) () -> () {
 bb0:
@@ -1670,7 +1791,7 @@ bb0:
 
 // CHECK-LABEL: begin running test 1 of 1 on globalactor_isolated_class_nonisolatedunsafeclassproperty_setter: sil_isolation_info_inference with: @trace[0]
 // CHECK: Input Value:   %1 = class_method %0 : $@thick MainActorIsolatedKlass.Type, #MainActorIsolatedKlass.nsNonisolatedUnsafeClassComputed!setter : (MainActorIsolatedKlass.Type) -> (NonSendableKlass) -> (), $@convention(method) (@owned NonSendableKlass, @thick MainActorIsolatedKlass.Type) -> ()
-// CHECK: Isolation: main actor-isolated: nonisolated(unsafe)
+// CHECK: Isolation: disconnected: nonisolated(unsafe)
 // CHECK: end running test 1 of 1 on globalactor_isolated_class_nonisolatedunsafeclassproperty_setter: sil_isolation_info_inference with: @trace[0]
 sil [ossa] @globalactor_isolated_class_nonisolatedunsafeclassproperty_setter : $@convention(thin) () -> () {
 bb0:

--- a/test/Concurrency/transfernonsendable_global_actor.swift
+++ b/test/Concurrency/transfernonsendable_global_actor.swift
@@ -29,6 +29,8 @@ func useValueAsync<T>(_ t: T) async {}
 @MainActor func useValueMainActor<T>(_ t: T) {}
 @MainActor func mainActorFunction() {}
 
+func mergeValues(_ x: NonSendableKlass, _ y: NonSendableKlass) {}
+
 var booleanFlag: Bool { false }
 @MainActor var mainActorIsolatedGlobal = NonSendableKlass()
 @CustomActor var customActorIsolatedGlobal = NonSendableKlass()
@@ -383,5 +385,187 @@ class SetterAssignmentMustInferGlobalIsolationTest {
     nsField = ns
     await CustomActor.shared.acceptValue(ns) // expected-warning {{sending 'ns' risks causing data races}}
     // expected-note @-1 {{sending main actor-isolated 'ns' to actor-isolated instance method 'acceptValue' risks causing data races between actor-isolated and main actor-isolated uses}}
+  }
+}
+
+//////////////////////////////////////////////
+// MARK: nonisolated(unsafe) override tests //
+//////////////////////////////////////////////
+
+func NonisolatedUnsafeOverrideTests() {
+
+class MyObj {}
+
+  @MainActor
+  struct StructWrapper {
+    nonisolated(unsafe) var _store: MyObj?
+  }
+
+  @MainActor
+  struct GenericStructWrapper<T> {
+    nonisolated(unsafe) var _store: MyObj?
+    var t: T? = nil
+  }
+
+  @MainActor
+  class ClassWrapper {
+    nonisolated(unsafe) var _store: MyObj?
+  }
+
+  @MainActor
+  final class FinalClassWrapper {
+    nonisolated(unsafe) var _store: MyObj?
+  }
+
+  struct Box {
+    var oldStore: MyObj?
+
+    func structTest(w: StructWrapper) {
+      let _ = oldStore === w._store
+    }
+
+    func genericStructTest<T>(w: GenericStructWrapper<T>) {
+      let _ = oldStore === w._store
+    }
+
+    func classTest(w: ClassWrapper) {
+      let _ = oldStore === w._store
+    }
+
+    func finalClassTest(w: FinalClassWrapper) {
+      let _ = oldStore === w._store
+    }
+  }
+
+  @MainActor
+  struct MainActorStruct {
+    nonisolated(unsafe) var field: NonSendableKlass? = nil
+    var field2: NonSendableKlass? = nil
+    @CustomActor var customField: NonSendableKlass? = nil
+
+    init() {
+      mergeValues(field!, customField!)
+      mergeValues(field2!, customField!) // expected-warning {{passing global actor 'CustomActor'-isolated 'self.customField' and main actor-isolated 'self.field2' as arguments to local function 'mergeValues' risks causing data races}}
+      // expected-note @-1 {{'self.field2' could begin referencing 'self.customField' allowing concurrent access to 'self.customField' by main actor-isolated code and global actor 'CustomActor'-isolated code}}
+    }
+
+    func testMultipleAccessesAreIndependent() async {
+      let x = field
+      await transferToCustomActor(field)
+      useValue(x)
+      await transferToCustomActor(x) // expected-warning {{sending 'x' risks causing data races}}
+      // expected-note @-1 {{sending 'x' to global actor 'CustomActor'-isolated global function 'transferToCustomActor' risks causing data races between global actor 'CustomActor'-isolated and local main actor-isolated uses}}
+      useValue(x) // expected-note {{access can happen concurrently}}
+      useValue(field)
+    }
+  }
+
+  func mergeValues<T>(_ x: T, _ y: NonSendableKlass) {}
+
+  @MainActor
+  struct MainActorIndirectStruct<T> {
+    nonisolated(unsafe) var field: T? = nil
+    var field2: T? = nil
+    @CustomActor var customField: NonSendableKlass? = nil
+    init() {
+      mergeValues(field!, customField!)
+      mergeValues(field2!, customField!) // expected-warning {{passing global actor 'CustomActor'-isolated 'self.customField' and main actor-isolated 'self.field2' as arguments to local function 'mergeValues' risks causing data races}}
+      // expected-note @-1 {{'self.field2' could begin referencing 'self.customField' allowing concurrent access to 'self.customField' by main actor-isolated code and global actor 'CustomActor'-isolated code}}
+    }
+
+    func testMultipleAccessesAreIndependent() async {
+      let x = field
+      await transferToCustomActor(field)
+      useValue(x)
+      await transferToCustomActor(x) // expected-warning {{sending 'x' risks causing data races}}
+      // expected-note @-1 {{sending 'x' to global actor 'CustomActor'-isolated global function 'transferToCustomActor' risks causing data races between global actor 'CustomActor'-isolated and local main actor-isolated uses}}
+      useValue(x) // expected-note {{access can happen concurrently}}
+      useValue(field)
+    }
+  }
+
+  @MainActor
+  final class MainActorFinalClass {
+    nonisolated(unsafe) var field: NonSendableKlass? = nil
+    var field2: NonSendableKlass? = nil
+    @CustomActor var customField: NonSendableKlass? = nil
+
+    init() {
+      mergeValues(field!, customField!)
+      mergeValues(field2!, customField!) // expected-warning {{passing global actor 'CustomActor'-isolated 'self.customField' and main actor-isolated 'self.field2' as arguments to local function 'mergeValues' risks causing data races}}
+      // expected-note @-1 {{'self.field2' could begin referencing 'self.customField' allowing concurrent access to 'self.customField' by main actor-isolated code and global actor 'CustomActor'-isolated code}}
+    }
+
+    func testMultipleAccessesAreIndependent() async {
+      let x = field
+      await transferToCustomActor(field)
+      useValue(x)
+      await transferToCustomActor(x) // expected-warning {{sending 'x' risks causing data races}}
+      // expected-note @-1 {{sending 'x' to global actor 'CustomActor'-isolated global function 'transferToCustomActor' risks causing data races between global actor 'CustomActor'-isolated and local main actor-isolated uses}}
+      useValue(x) // expected-note {{access can happen concurrently}}
+      useValue(field)
+    }
+  }
+
+  @MainActor
+  class MainActorClass {
+    nonisolated(unsafe) var field: NonSendableKlass? = nil
+    var field2: NonSendableKlass? = nil
+    @CustomActor var customField: NonSendableKlass? = nil
+
+    init() {
+      mergeValues(field!, customField!)
+      mergeValues(field2!, customField!) // expected-warning {{passing global actor 'CustomActor'-isolated 'self.customField' and main actor-isolated 'self.field2' as arguments to local function 'mergeValues' risks causing data races}}
+      // expected-note @-1 {{'self.field2' could begin referencing 'self.customField' allowing concurrent access to 'self.customField' by main actor-isolated code and global actor 'CustomActor'-isolated code}}
+    }
+
+    func testMultipleAccessesAreIndependent() async {
+      let x = field
+      await transferToCustomActor(field)
+      useValue(x)
+      await transferToCustomActor(x) // expected-warning {{sending 'x' risks causing data races}}
+      // expected-note @-1 {{sending 'x' to global actor 'CustomActor'-isolated global function 'transferToCustomActor' risks causing data races between global actor 'CustomActor'-isolated and local main actor-isolated uses}}
+      useValue(x) // expected-note {{access can happen concurrently}}
+      useValue(field)
+    }
+  }
+
+  // Test that a differently-isolated context can access a nonisolated(unsafe)
+  // field on a @MainActor type without producing spurious cross-isolation merge
+  // errors.
+  @CustomActor
+  func crossActorAccessTest(s: MainActorStruct, c: MainActorClass, fc: MainActorFinalClass) async {
+    let x = s.field
+    useValue(x)
+
+    let y = c.field
+    useValue(y)
+
+    let z = fc.field
+    useValue(z)
+  }
+
+}
+
+///////////////////////////////////////////////////////////
+// MARK: Actor init with nonisolated(unsafe) merge tests //
+///////////////////////////////////////////////////////////
+
+actor ActorWithNonisolatedUnsafeField {
+  nonisolated(unsafe) var field: NonSendableKlass? = nil
+  var field2: NonSendableKlass? = nil
+  @MainActor var mainField: NonSendableKlass? = nil
+
+  init() {
+    mergeValues(field!, mainField!)
+    mergeValues(field2!, mainField!) // expected-warning {{passing main actor-isolated 'self.mainField' and 'self'-isolated 'self.field2' as arguments to global function 'mergeValues' risks causing data races}}
+    // expected-note @-1 {{'self.field2' could begin referencing 'self.mainField' allowing concurrent access to 'self.mainField' by 'self'-isolated code and main actor-isolated code}}
+  }
+
+  func testMultipleAccessesAreIndependent() async {
+    let x = field
+    await transferToMainActor(field)
+    useValue(x)
+    useValue(field)
   }
 }

--- a/test/Concurrency/transfernonsendable_nonisolatedunsafe.swift
+++ b/test/Concurrency/transfernonsendable_nonisolatedunsafe.swift
@@ -404,11 +404,18 @@ actor MyActor {
     await transferToMainIndirect(nonIsolatedUnsafeVarObject)
     // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
+    // We used to emit a warning here since we would leave
+    // nonIsolatedUnsafeLetObject as propagated MainActor isolation, but we do
+    // not anymore.
     let x = nonIsolatedUnsafeLetObject
     await transferToMainDirect(x)
-    // expected-warning @-1 {{sending 'x' risks causing data races}}
-    // expected-note @-2 {{sending 'self'-isolated 'x' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and 'self'-isolated uses}}
-    // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  }
+
+  func testMultipleAccessesAreIndependent() async {
+    let x = nonIsolatedUnsafeLetObject
+    await transferToMainDirect(nonIsolatedUnsafeLetObject)
+    print(x)
+    print(nonIsolatedUnsafeLetObject)
   }
 }
 
@@ -426,11 +433,18 @@ final actor MyFinalActor {
     await transferToMainIndirect(nonIsolatedUnsafeVarObject)
     // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
+    // We used to emit a warning here since we would leave
+    // nonIsolatedUnsafeLetObject as propagated MainActor isolation, but we do
+    // not anymore.
     let x = nonIsolatedUnsafeLetObject
     await transferToMainDirect(x)
-    // expected-warning @-1 {{sending 'x' risks causing data races}}
-    // expected-note @-2 {{sending 'self'-isolated 'x' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and 'self'-isolated uses}}
-    // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  }
+
+  func testMultipleAccessesAreIndependent() async {
+    let x = nonIsolatedUnsafeLetObject
+    await transferToMainDirect(nonIsolatedUnsafeLetObject)
+    print(x)
+    print(nonIsolatedUnsafeLetObject)
   }
 }
 
@@ -565,6 +579,19 @@ enum NonIsolatedUnsafeComputedEnum: Sendable {
     // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
     print(x)
   }
+
+  func testMultipleAccessesAreIndependent() async {
+    // We do not emit errors here since every time that we access
+    // nonIsolatedUnsafeLetObject in SILGen, we reaccess and load a new value
+    // from a struct_element_addr. Since the root type is Sendable, this ensures
+    // that we in a certain sense simulate a sendable value. The best way to do
+    // that is to actually represent it at the SIL value as a Sendable value,
+    // but that is a much more invasive change.
+    let x = nonIsolatedUnsafeLetObject
+    await transferToMainDirect(nonIsolatedUnsafeLetObject)
+    print(x)
+    print(nonIsolatedUnsafeLetObject)
+  }
 }
 
 @CustomActor class CustomActorNonIsolatedUnsafeFieldKlass {
@@ -581,14 +608,26 @@ enum NonIsolatedUnsafeComputedEnum: Sendable {
     await transferToMainIndirect(nonIsolatedUnsafeVarObject)
     // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
-    // x is treated as global actor 'CustomActor' isolated since the
-    // nonisolated(unsafe) only applies to nonIsolatedUnsafeLetObject.
+    // We used to emit a warning here just on passing 'x' since we would leave
+    // nonIsolatedUnsafeLetObject as propagated MainActor isolation, but we do
+    // not anymore.
     let x = nonIsolatedUnsafeLetObject
-    await transferToMainDirect(x)
-    // expected-warning @-1 {{sending 'x' risks causing data races}}
-    // expected-note @-2 {{sending global actor 'CustomActor'-isolated 'x' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and global actor 'CustomActor'-isolated uses}}
-    // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+    await transferToMainDirect(x) // expected-warning {{sending 'x' risks causing data races}}
+    // expected-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and local global actor 'CustomActor'-isolated uses}}
+    print(x) // expected-note {{access can happen concurrently}}
+  }
+
+  func testMultipleAccessesAreIndependent() async {
+    // We do not emit errors here since every time that we access
+    // nonIsolatedUnsafeLetObject in SILGen, we reaccess and load a new value
+    // from a struct_element_addr. Since the root type is Sendable, this ensures
+    // that we in a certain sense simulate a sendable value. The best way to do
+    // that is to actually represent it at the SIL value as a Sendable value,
+    // but that is a much more invasive change.
+    let x = nonIsolatedUnsafeLetObject
+    await transferToMainDirect(nonIsolatedUnsafeLetObject)
     print(x)
+    print(nonIsolatedUnsafeLetObject)
   }
 }
 
@@ -606,13 +645,23 @@ enum NonIsolatedUnsafeComputedEnum: Sendable {
     await transferToMainIndirect(nonIsolatedUnsafeVarObject)
     // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
-    // 'x' is treated as global actor 'CustomActor'-isolated.
     let x = nonIsolatedUnsafeLetObject
-    await transferToMainDirect(x)
-    // expected-warning @-1 {{sending 'x' risks causing data races}}
-    // expected-note @-2 {{sending global actor 'CustomActor'-isolated 'x' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and global actor 'CustomActor'-isolated uses}}
-    // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+    await transferToMainDirect(x) // expected-warning {{sending 'x' risks causing data races}}
+    // expected-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and local global actor 'CustomActor'-isolated uses}}
+    print(x) // expected-note {{access can happen concurrently}}
+  }
+
+  func testMultipleAccessesAreIndependent() async {
+    // We do not emit errors here since every time that we access
+    // nonIsolatedUnsafeLetObject in SILGen, we reaccess and load a new value
+    // from a struct_element_addr. Since the root type is Sendable, this ensures
+    // that we in a certain sense simulate a sendable value. The best way to do
+    // that is to actually represent it at the SIL value as a Sendable value,
+    // but that is a much more invasive change.
+    let x = nonIsolatedUnsafeLetObject
+    await transferToMainDirect(nonIsolatedUnsafeLetObject)
     print(x)
+    print(nonIsolatedUnsafeLetObject)
   }
 }
 
@@ -626,35 +675,36 @@ enum NonIsolatedUnsafeComputedEnum: Sendable {
 
   func test() async {
     await transferToMainDirect(nonIsolatedUnsafeLetObject)
-    // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
     await transferToMainDirect(nonIsolatedUnsafeVarObject)
-    // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
     await transferToMainIndirect(nonIsolatedUnsafeLetObject)
-    // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
     await transferToMainIndirect(nonIsolatedUnsafeVarObject)
-    // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
-    // 'x' is treated as global actor 'CustomActor'-isolated.
     let x = nonIsolatedUnsafeLetObject
-    await transferToMainDirect(x)
-    // expected-warning @-1 {{sending 'x' risks causing data races}}
-    // expected-note @-2 {{sending global actor 'CustomActor'-isolated 'x' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and global actor 'CustomActor'-isolated uses}}
-    // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+    await transferToMainDirect(x) // expected-warning {{sending 'x' risks causing data races; this is an error in the Swift 6 language mode}}
+    // expected-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and local global actor 'CustomActor'-isolated uses}}
 
     let x2 = nonIsolatedUnsafeVarObject
     await transferToMainDirect(x2)
-    // expected-warning @-1 {{sending 'x2' risks causing data races}}
-    // expected-note @-2 {{sending global actor 'CustomActor'-isolated 'x2' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and global actor 'CustomActor'-isolated uses}}
-    // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
     let x3 = nonIsolatedUnsafeVarComputedObject
-    await transferToMainDirect(x3)
-    // expected-warning @-1 {{sending 'x3' risks causing data races}}
-    // expected-note @-2 {{sending global actor 'CustomActor'-isolated 'x3' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and global actor 'CustomActor'-isolated uses}}
-    // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+    await transferToMainDirect(x3) // expected-warning {{sending 'x3' risks causing data races; this is an error in the Swift 6 language mode}}
+    // expected-note @-1 {{sending global actor 'CustomActor'-isolated 'x3' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and global actor 'CustomActor'-isolated uses}}
 
-    print(x)
+    print(x) // expected-note {{access can happen concurrently}}
   }
+
+  func testMultipleAccessesAreIndependent() async {
+    // We do not emit errors here since every time that we access
+    // nonIsolatedUnsafeLetObject in SILGen, we reaccess and load a new value
+    // from a struct_element_addr. Since the root type is Sendable, this ensures
+    // that we in a certain sense simulate a sendable value. The best way to do
+    // that is to actually represent it at the SIL value as a Sendable value,
+    // but that is a much more invasive change.
+    let x = nonIsolatedUnsafeLetObject
+    await transferToMainDirect(nonIsolatedUnsafeLetObject)
+    print(x)
+    print(nonIsolatedUnsafeLetObject)
+  }  
 }
 
 @CustomActor enum CustomActorNonIsolatedUnsafeComputedEnum {


### PR DESCRIPTION
Previously, a nonisolated(unsafe) field on an actor-isolated type was inferred as carrying the enclosing type's isolation (e.g., "main actor-isolated: nonisolated(unsafe)"). The intent was to propagate the type's isolation to everything in the field's region while simply suppressing diagnostics on the field access itself, relying on Sema to have already validated the declaration. This was incorrect: Sema allows a nonisolated(unsafe) value to be used in any isolation context, so propagating the enclosing type's isolation could place differently- isolated values in the same region — violating an RBI invariant.

This became a problem now that RBI checks region-merge compatibility more aggressively rather than deferring to Sema. When a nonisolated(unsafe) field's region — still carrying main-actor isolation — was merged with a differently-isolated region, RBI would emit a spurious incompatible-region-merge error. For example:

    @MainActor
    struct MainActorStruct {
        nonisolated(unsafe) var field: NonSendableKlass? = nil
        @CustomActor var customField: NonSendableKlass? = nil

        init() {
            mergeValues(field, customField) // incompatible merge error!
        }
    }

Here `field` was inferred as main-actor-isolated, so merging its region with the @CustomActor-isolated `customField` region would fail.

Similarly, accessing a nonisolated(unsafe) field from a nonisolated context would produce errors because the field's region carried its parent type's actor isolation:

    @MainActor struct StructWrapper {
        nonisolated(unsafe) var _store: MyObj?
    }

    struct Box {
        var oldStore: MyObj?
        func structTest(w: StructWrapper) {
            let _ = oldStore === w._store // error from merge
        }
    }

Fix this by inferring nonisolated(unsafe) fields as disconnected in all three field-access paths: ref_element_addr (classes), struct_extract, and struct_element_addr. A disconnected region can merge freely with any isolation, so the spurious errors are eliminated and we match Sema's behavior.

Covers classes, final classes, structs, and generic structs — both value and address access patterns.

NB: Ideally these fields would be treated as effectively Sendable in RBI. That is a more invasive change touching many SILIsolationInfo:: isSendable call sites and is too risky at this point in the release. Since treating them as Sendable would only reduce the set of emitted diagnostics, it can be done as a follow-up without regression.

rdar://175180417

-----

<!--
The main branch is now in convergence, which means major changes, such as large refactoring or new features, should be avoided. This strategy is intended to maintain the stability of the Swift 6.4 release leading up to the May 4th branch. For any work that requires broad changes or introduces new features, create a feature branch and open a draft pull request. All updates to the swiftlang/swift repository’s main branch require approval from the release managers. A pull request targeting swiftlang/swift will automatically add release managers. You can also contact them via @release-managers in the forum group.
-->

<!-- Please fill out the following form: --> 
- **Explanation**: Originally, `nonisolated(unsafe)` on a field was treated as a diagnostic suppression mechanism — the field still inherited its enclosing type’s isolation (e.g., main-actor-isolated), and that isolation propagated to everything in the field’s region. Diagnostics on accesses to the field itself were suppressed, but the isolation propagation continued as normal. This worked when RBI relied on Sema to prevent mixing of isolation domains. With new changes to flow isolation for supporting initializers of global-actor-isolated types with fields of different global actor isolation — and Sema now leaving verification of merge failures in those inits to RBI — RBI must itself enforce that regions are isolated to at most one concurrency domain. This exposed a problem: even though RBI could squelch an error when merging the `nonisolated(unsafe)` value directly, when a disconnected value in the same region as the `nonisolated(unsafe)` value triggered a merge, RBI would not see a `nonisolated(unsafe)` element directly, would perform the merge, and would violate the single-isolation-domain invariant.

  Rather than thinking of `nonisolated(unsafe)` as just suppressing errors, the right model is that `nonisolated(unsafe)` is essentially saying the value is Sendable. The user is telling the compiler not to check this value — it should be usable in any way, from any context, even from multiple different concurrency domains. Making `nonisolated(unsafe)` introduce actually-Sendable values in RBI would be a larger change touching many `SILIsolationInfo::isSendable` call sites, which is inappropriate at this point in the release. Instead, this fix takes advantage of the fact that RBI runs early enough that accesses to fields always create new GEPs and no optimization has combined them yet. By marking `nonisolated(unsafe)` fields as disconnected in all three field-access paths (`ref_element_addr`, `struct_extract`, `struct_element_addr`), each access to the field produces a new, independent disconnected value. This is effectively like making the value Sendable: if one sends the field to another isolation domain and accesses it again later, the two accesses are treated as different disconnected values, so no error occurs. If one assigns the field to a binding, sends that binding to another isolation domain, and then reuses the field, the new field usage is a completely different value. And if one assigns multiple bindings to the field, each binding is treated as a separate value since each is loaded from a different GEP — just as if the original value were Sendable. Tests validating all of these behaviors are included.
- **Scope**: This change only affects RBI’s isolation inference for `nonisolated(unsafe)` stored properties. It strictly reduces the set of emitted diagnostics — previously-clean code remains unaffected, and code that was getting spurious errors will now compile correctly. No existing correct diagnostics are suppressed.
- **Issues**: rdar://175180417
- **Risk**: Low. The change is a small, localized addition of three early-return checks in `SILIsolationInfo.cpp`. It only makes RBI more permissive (fewer diagnostics), never more restrictive, so it cannot introduce new build failures.
- **Testing**: Added comprehensive tests across all affected type kinds:
  - `silisolationinfo_inference.sil`: 6 new SIL unit tests (final class, class, struct, struct addr, generic struct, nonisolated generic struct) plus 6 updated CHECK lines verifying disconnected inference.
  - `transfernonsendable_global_actor.swift`: 146 new lines of end-to-end tests covering structs, generic structs, classes, and final classes — verifying `nonisolated(unsafe)` fields merge freely while differently-isolated non-unsafe fields still error.
  - `transfernonsendable_nonisolatedunsafe.swift`: Updated existing tests to reflect new inference, added `testMultipleAccessesAreIndependent` tests across actors, final actors, classes, and enums.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
