### PR TITLE
[flow-isolation] Restore old behavior for unhandled instructions in use analysis

### DIFF
--- a/lib/SILOptimizer/Mandatory/FlowIsolation.cpp
+++ b/lib/SILOptimizer/Mandatory/FlowIsolation.cpp
@@ -1051,9 +1051,15 @@ void FunctionInfo::analyze(SILValue selfParam) {
         // Ignore these.
         continue;
       default:
+#if false        
         // Anything we do not understand mark as a property use to be
         // conservative.
         markPropertyUse(operand, true /*default*/);
+#else
+        // For now if we do not understand something, just ignore it to restore
+        // the previous behavior.
+        markIgnored(user);
+#endif
         continue;
       }
   }

--- a/test/Concurrency/flow_isolation_objc.swift
+++ b/test/Concurrency/flow_isolation_objc.swift
@@ -1,0 +1,14 @@
+// RUN: %target-swift-frontend -strict-concurrency=complete -swift-version 5 -parse-as-library -emit-sil -verify %s -o /dev/null
+
+// REQUIRES: objc_interop
+// REQUIRES: concurrency
+
+import ObjectiveC
+
+@MainActor
+final class SimpleDeinitTestWithObjC: NSObject {
+    let name: String = ""
+    deinit {
+        _ = { self.name }
+    }
+}


### PR DESCRIPTION
When analyzing uses of `self`, the flow-isolation pass was recently changed to conservatively treat unrecognized instructions as property uses. This caused errors in real-world projects that use instructions the pass does not yet handle, since they were being incorrectly flagged as property accesses.

Restore the previous behavior of ignoring unrecognized instructions for now. This lets affected projects compile again while we tighten this up in a more measured way.

rdar://175530379

----

<!--
The main branch is now in convergence, which means major changes, such as large refactoring or new features, should be avoided. This strategy is intended to maintain the stability of the Swift 6.4 release leading up to the May 4th branch. For any work that requires broad changes or introduces new features, create a feature branch and open a draft pull request. All updates to the swiftlang/swift repository’s main branch require approval from the release managers. A pull request targeting swiftlang/swift will automatically add release managers. You can also contact them via @release-managers in the forum group.
-->

<!-- Please fill out the following form: --> 
- **Explanation**: The flow-isolation pass’s `self`-use analysis was recently changed to conservatively treat unrecognized instructions as property uses via `markPropertyUse`. This meant any instruction the pass did not have an explicit case for would be treated as accessing a property of `self`. In practice, real-world code uses instructions the pass does not yet handle (e.g., ObjC-interop instructions like `objc_super_method`), and these were being flagged as property accesses, producing errors in projects that compiled before. This change restores the previous behavior of calling `markIgnored` on unrecognized instructions, so they do not affect property-use tracking. The conservative `markPropertyUse` default is preserved behind `#if false` so it can be re-enabled once the pass handles more instruction kinds. This is temporary and we may fix it in this release if we feel good about this or we may leave the current semantics alone.
- **Scope**: This change only affects the flow-isolation pass’s handling of unrecognized instructions during `self`-use analysis. It restores the previous behavior, so code that compiled before the conservative change will compile again. No new diagnostics are introduced.
- **Issues**: rdar://175530379
- **Risk**: Low. This is reverting to the previous behavior for unrecognized instructions. The conservative behavior (`markPropertyUse`) was the new addition; this restores what shipped before. The only risk is that unrecognized instructions that do access properties will be ignored rather than flagged, but that was the existing behavior prior to the recent change and is the safer default at this point in the release.
- **Testing**: Added `test/Concurrency/flow_isolation_objc.swift` — a `@MainActor final class` inheriting from `NSObject` with a `deinit` that captures `self` in a closure. This exercises the ObjC-interop instruction path (`objc_super_method`) that triggered the false positive.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
