### PR TITLE
[rbi] Add diagnostic groups and documentation for cross-isolation data race and unknown pattern errors

### DIFF
--- a/include/swift/AST/DiagnosticGroups.def
+++ b/include/swift/AST/DiagnosticGroups.def
@@ -77,6 +77,8 @@ GROUP(PreconcurrencyImport,DefaultIgnoreWarnings,"preconcurrency-import")
 GROUP(PropertyWrappers,none,"property-wrapper-requirements")
 GROUP(ProtocolTypeNonConformance,none,"protocol-type-non-conformance")
 GROUP(RegionIsolation,none,"region-isolation")
+GROUP(RegionIsolationCrossIsolationDataRace,none,"region-isolation-cross-isolation-data-race")
+GROUP(RegionIsolationUnknownPattern,none,"region-isolation-unknown-pattern")
 GROUP(ResultBuilderMethods,none,"result-builder-methods")
 GROUP(ReturnTypeImplicitCopy,ToolchainLocalDocumentation,"return-type-implicit-copy")
 GROUP(SendableClosureCaptures,none,"sendable-closure-captures")
@@ -102,6 +104,8 @@ GROUP_LINK(PerformanceHints,UntypedThrows)
 
 GROUP_LINK(RegionIsolation,SendingClosureRisksDataRace)
 GROUP_LINK(RegionIsolation,SendingRisksDataRace)
+GROUP_LINK(RegionIsolation,RegionIsolationCrossIsolationDataRace)
+GROUP_LINK(RegionIsolation,RegionIsolationUnknownPattern)
 
 GROUP_LINK(StrictLanguageFeatures, UnrecognizedStrictLanguageFeatures)
 

--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -1010,7 +1010,7 @@ NOTE(sil_referencebinding_inout_binding_here, none,
 //===
 // Misc
 
-ERROR(regionbasedisolation_unknown_pattern, none,
+GROUPED_ERROR(regionbasedisolation_unknown_pattern, RegionIsolationUnknownPattern, none,
       "pattern that the region-based isolation checker does not understand how to check. Please file a bug",
       ())
 NOTE(regionbasedisolation_maybe_race, none,
@@ -1228,36 +1228,36 @@ NOTE(regionbasedisolation_inout_sending_in_same_region_note, none,
 // Merge Region Failure Error
 //
 
-ERROR(regionbasedisolation_merge_region_failure_error_unknown, none,
+GROUPED_ERROR(regionbasedisolation_merge_region_failure_error_unknown, RegionIsolationCrossIsolationDataRace, none,
       "allowing references between %select{%0|%1 %0}4 and %3 %2 risks causing data races",
       (Identifier, StringRef, Identifier, StringRef, bool))
 NOTE(regionbasedisolation_merge_region_failure_error_unknown_note, none,
      "%0 could become accessible to %3 code despite remaining accessible to %select{code in the current task|%1 code}4",
      (Identifier, StringRef, Identifier, StringRef, bool))
-ERROR(regionbasedisolation_merge_region_failure_error_assign, none,
+GROUPED_ERROR(regionbasedisolation_merge_region_failure_error_assign, RegionIsolationCrossIsolationDataRace, none,
       "assigning %select{%0|%1 %0}4 to %3 %2 risks causing data races",
       (Identifier, StringRef, Identifier, StringRef, bool))
 NOTE(regionbasedisolation_merge_region_failure_error_assign_note, none,
       "%0 could become accessible to %2 code despite remaining accessible to %select{code in the current task|%1 code}3",
       (Identifier, StringRef, StringRef, bool))
-ERROR(regionbasedisolation_merge_region_failure_error_functionisolation, none,
+GROUPED_ERROR(regionbasedisolation_merge_region_failure_error_functionisolation, RegionIsolationCrossIsolationDataRace, none,
       "passing %select{%0|%1 %0}4 to %3 %kind2 risks causing data races",
       (Identifier, StringRef, const ValueDecl *, StringRef, bool))
-ERROR(regionbasedisolation_merge_region_failure_error_functionisolation_type, none,
+GROUPED_ERROR(regionbasedisolation_merge_region_failure_error_functionisolation_type, RegionIsolationCrossIsolationDataRace, none,
       "passing %select{%0|%1 %0}4 to %3 %kind2 risks causing data races",
       (Type, StringRef, const ValueDecl *, StringRef, bool))
-ERROR(regionbasedisolation_merge_region_failure_error_functionisolation_sil, none,
+GROUPED_ERROR(regionbasedisolation_merge_region_failure_error_functionisolation_sil, RegionIsolationCrossIsolationDataRace, none,
       "passing %1 %0 to %3 %2 risks causing data races",
       (Identifier, StringRef, Identifier, StringRef))
 
 // We always put the potential task-isolated value first to simplify the note.
-ERROR(regionbasedisolation_merge_region_failure_error_nonisolatedfunction, none,
+GROUPED_ERROR(regionbasedisolation_merge_region_failure_error_nonisolatedfunction, RegionIsolationCrossIsolationDataRace, none,
       "passing %select{%0|%1 %0}5 and %3 %2 as arguments to %kind4 risks causing data races",
       (Identifier, StringRef, Identifier, StringRef, const ValueDecl *, bool))
 NOTE(regionbasedisolation_merge_region_failure_error_nonisolatedfunction_note, none,
      "%2 could begin referencing %0 allowing concurrent access to %0 by %3 code and %select{code in the current task|%1 code}5", (Identifier, StringRef, Identifier, StringRef, const ValueDecl *, bool))
 
-ERROR(regionbasedisolation_merge_region_failure_error_cast, none,
+GROUPED_ERROR(regionbasedisolation_merge_region_failure_error_cast, RegionIsolationCrossIsolationDataRace, none,
       "casting %select{%0|%1 %0}4 to %3 %2 risks causing data races",
       (Identifier, StringRef, Type, StringRef, bool))
 

--- a/userdocs/diagnostics/diagnostic-groups.md
+++ b/userdocs/diagnostics/diagnostic-groups.md
@@ -64,6 +64,7 @@ Or upgrade all warnings except deprecated declaration to errors:
 - <doc:sendable-closure-captures>
 - <doc:compilation-caching>
 - <doc:string-interpolation-conformance>
+- <doc:region-isolation-cross-isolation-data-race>
 - <doc:deprecated-declaration>
 - <doc:implementation-only-deprecated>
 - <doc:dynamic-exclusivity>
@@ -99,6 +100,7 @@ Or upgrade all warnings except deprecated declaration to errors:
 - <doc:strict-memory-safety>
 - <doc:temporary-pointers>
 - <doc:opaque-type-inference>
+- <doc:region-isolation-unknown-pattern>
 - <doc:unknown-warning-group>
 - <doc:availability-unrecognized-name>
 - <doc:mutable-global-variable>

--- a/userdocs/diagnostics/region-isolation-cross-isolation-data-race.md
+++ b/userdocs/diagnostics/region-isolation-cross-isolation-data-race.md
@@ -1,0 +1,11 @@
+# Cross-isolation data race (RegionIsolationCrossIsolationDataRace)
+
+## Overview
+
+The region-based isolation checker tracks values using regions, which are conservative approximations of object graphs. A region can be either non-isolated or isolated to a single concurrency domain (an actor, a global actor, or the current task), but it can never be isolated to more than one concurrency domain at a time.
+
+This error occurs when an operation would merge two regions that are isolated to different concurrency domains. Merging such regions would allow values from both domains to be referenced through the same object graph, risking concurrent access and data races.
+
+Common examples include assigning an actor-isolated value to a variable accessible from a different isolation domain, passing values from different isolation domains as arguments to the same function call, or casting a value to a type with different isolation.
+
+To resolve this, ensure that values from different isolation domains are not mixed together in ways that could allow concurrent access. Consider making the types involved conform to `Sendable`, or restructuring the code so that values are only accessed from a single isolation domain.

--- a/userdocs/diagnostics/region-isolation-unknown-pattern.md
+++ b/userdocs/diagnostics/region-isolation-unknown-pattern.md
@@ -1,0 +1,5 @@
+# Unknown region isolation pattern (RegionIsolationUnknownPattern)
+
+## Overview
+
+This diagnostic indicates that the region-based isolation checker has detected an isolation error but the compiler does not currently know how to emit a descriptive diagnostic for the detected pattern. This is a compiler bug. If you encounter this diagnostic, please file a bug report at [https://github.com/swiftlang/swift/issues](https://github.com/swiftlang/swift/issues) with a minimal example that reproduces the issue.


### PR DESCRIPTION
[rbi] Add diagnostic groups and documentation for cross-isolation data race and unknown pattern errors

Introduce two new diagnostic groups: RegionIsolationCrossIsolationDataRace
and RegionIsolationUnknownPattern, both linked as children of the existing
RegionIsolation group. This converts the merge-region-failure errors and the
unknown-pattern error from plain ERROR to GROUPED_ERROR, which allows users
to selectively downgrade these diagnostics (e.g. the unknown pattern error
can be downgraded since it represents a compiler limitation rather than a
definite user error).

Add user-facing documentation for both groups explaining what triggers the
diagnostics and how to resolve them.

rdar://175771878

----

**Explanation:** This PR introduces two new diagnostic groups (RegionIsolationCrossIsolationDataRace and RegionIsolationUnknownPattern) as children of the existing RegionIsolation group. The merge-region-failure errors are converted from ERROR to GROUPED_ERROR under the cross-isolation group, and the unknown-pattern error is similarly grouped. This lets users selectively downgrade these diagnostics via -Wwarning=region-isolation-unknown-pattern or -Wwarning=region-isolation-cross-isolation-data-race. User-facing documentation is added for both groups.
**Scope:** Diagnostic definitions in DiagnosticGroups.def, DiagnosticsSIL.def, and new userdocs under userdocs/diagnostics/. No changes to the isolation checker logic itself.
**Issues:** rdar://175771878
**Risk:** Low. The only behavioral change is that these errors are now grouped, enabling user downgrade. No existing behavior changes unless a user explicitly opts in via warning flags.
**Testing:** Existing region-based isolation tests continue to pass. The diagnostic grouping is validated by the existing test infrastructure for grouped diagnostics.