### PR TITLE
Fix cxx interop errors with symbolgraph extract

### DIFF
--- a/lib/DriverTool/swift_symbolgraph_extract_main.cpp
+++ b/lib/DriverTool/swift_symbolgraph_extract_main.cpp
@@ -216,6 +216,9 @@ int swift_symbolgraph_extract_main(ArrayRef<const char *> Args,
 
   Invocation.getLangOptions().setCxxInteropFromArgs(ParsedArgs, Diags,
                                                     Invocation.getFrontendOptions());
+  if (Invocation.getLangOptions().EnableCXXInterop) {
+    Invocation.computeCXXStdlibOptions();
+  }
 
   std::string InstanceSetupError;
   if (CI.setup(Invocation, InstanceSetupError)) {
@@ -265,7 +268,13 @@ int swift_symbolgraph_extract_main(ArrayRef<const char *> Args,
     llvm::errs() << "Emitting symbol graph for module file: " << MainFile.getModuleDefiningPath() << '\n';
   
   int Success = symbolgraphgen::emitSymbolGraphForModule(M, Options);
-  
+
+  // Snapshot the diagnostic error state before we deliberately suppress
+  // cross-import overlay loading errors below, so the exit code reflects
+  // errors emitted up through the main module's extraction but not the
+  // intentionally-ignored overlay errors.
+  bool HadError = CI.getASTContext().hadError();
+
   // Look for cross-import overlays that the given module imports.
   
   // Clear out the diagnostic printer before looking for cross-import overlay modules,
@@ -288,6 +297,9 @@ int swift_symbolgraph_extract_main(ArrayRef<const char *> Args,
       Success |= symbolgraphgen::emitSymbolGraphForModule(CIM, Options);
     }
   }
+
+  if (HadError)
+    return EXIT_FAILURE;
 
   return Success;
 }

--- a/lib/DriverTool/swift_symbolgraph_extract_main.cpp
+++ b/lib/DriverTool/swift_symbolgraph_extract_main.cpp
@@ -216,9 +216,7 @@ int swift_symbolgraph_extract_main(ArrayRef<const char *> Args,
 
   Invocation.getLangOptions().setCxxInteropFromArgs(ParsedArgs, Diags,
                                                     Invocation.getFrontendOptions());
-  if (Invocation.getLangOptions().EnableCXXInterop) {
-    Invocation.computeCXXStdlibOptions();
-  }
+  Invocation.computeCXXStdlibOptions();
 
   std::string InstanceSetupError;
   if (CI.setup(Invocation, InstanceSetupError)) {

--- a/test/SymbolGraph/ClangImporter/CxxInterop.swift
+++ b/test/SymbolGraph/ClangImporter/CxxInterop.swift
@@ -1,0 +1,24 @@
+// REQUIRES: target-same-as-host
+
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/Output)
+// RUN: %target-build-swift %s -module-name CxxInterop -emit-module -emit-module-path %t/ -cxx-interoperability-mode=default
+
+// RUN: %target-swift-symbolgraph-extract -module-name CxxInterop -I %t -cxx-interoperability-mode=default -pretty-print -output-dir %t/Output 2>&1 | %FileCheck %s --check-prefix=STDLIB_OK --allow-empty
+// RUN: %FileCheck %s --check-prefix=SYMBOLS --input-file %t/Output/CxxInterop.symbols.json
+
+// RUN: not %target-swift-symbolgraph-extract -module-name CxxInterop -I %t -pretty-print -output-dir %t/Output 2>&1 | %FileCheck %s --check-prefix=NEEDS_INTEROP
+
+public struct CxxInteropThing {
+  public var value: Int = 0
+  public func describe() -> String { "thing" }
+}
+
+// STDLIB_OK-NOT: was built with
+// STDLIB_OK-NOT: unknown C++ stdlib
+
+// SYMBOLS-DAG: "title": "CxxInteropThing"
+// SYMBOLS-DAG: "title": "value"
+// SYMBOLS-DAG: "title": "describe()"
+
+// NEEDS_INTEROP: error: module 'CxxInterop' was built with C++ interoperability enabled, but current compilation does not enable C++ interoperability


### PR DESCRIPTION
Previously swift-symbolgraph-extract would print errors about an
incompatible C++ stdlib, but it would still exit 0.

This is the same case as https://github.com/swiftlang/llvm-project/commit/cfcd7d28389234d8cbd223889505042a5d8d2dc3
