### PR TITLE
Flip my email in .mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -84,7 +84,7 @@ Johannes Weiß <johannesweiss@apple.com> <github@tux4u.de>
 John Regner <john@johnregner.com> <regnerjr@gmail.com>
 Karoy Lorentey <klorentey@apple.com> <karoly@lorentey.hu>
 Kavon Farvardin <kfarvardin@apple.com> <kavon@farvard.in>
-Keith Smiley <k@keith.so> <keithbsmiley@gmail.com>
+Keith Smiley <keithbsmiley@gmail.com> <k@keith.so>
 Kevin Saldaña <ksaldana1@gmail.com>
 Kim Topley <ktopley@apple.com>
 Kosuke Ogawa <ogawa_kousuke@aratana.jp> <koogawa.app@gmail.com>


### PR DESCRIPTION
The gmail is my canonical email, but I committed many years ago with the
other so it's nice to have both, but this way in `git log` you see my
active one.
