### PR TITLE
Fix synthesize-interface C++ interop, make it exit on failures

### DIFF
--- a/lib/DriverTool/swift_synthesize_interface_main.cpp
+++ b/lib/DriverTool/swift_synthesize_interface_main.cpp
@@ -135,9 +135,7 @@ int swift_synthesize_interface_main(ArrayRef<const char *> Args,
   Invocation.getLangOptions().EnableObjCInterop = Target.isOSDarwin();
   Invocation.getLangOptions().setCxxInteropFromArgs(ParsedArgs, Diags,
                                                     Invocation.getFrontendOptions());
-  if (Invocation.getLangOptions().EnableCXXInterop) {
-    Invocation.computeCXXStdlibOptions();
-  }
+  Invocation.computeCXXStdlibOptions();
 
   if (ParsedArgs.hasArg(OPT_disable_safe_interop_wrappers))
     Invocation.getLangOptions().DisableSafeInteropWrappers = true;

--- a/lib/DriverTool/swift_synthesize_interface_main.cpp
+++ b/lib/DriverTool/swift_synthesize_interface_main.cpp
@@ -135,6 +135,9 @@ int swift_synthesize_interface_main(ArrayRef<const char *> Args,
   Invocation.getLangOptions().EnableObjCInterop = Target.isOSDarwin();
   Invocation.getLangOptions().setCxxInteropFromArgs(ParsedArgs, Diags,
                                                     Invocation.getFrontendOptions());
+  if (Invocation.getLangOptions().EnableCXXInterop) {
+    Invocation.computeCXXStdlibOptions();
+  }
 
   if (ParsedArgs.hasArg(OPT_disable_safe_interop_wrappers))
     Invocation.getLangOptions().DisableSafeInteropWrappers = true;
@@ -225,6 +228,9 @@ int swift_synthesize_interface_main(ArrayRef<const char *> Args,
   StreamPrinter printer(fs);
   ide::printModuleInterface(M, /*GroupNames=*/{}, traversalOpts, printer,
                             printOpts, /*PrintSynthesizedExtensions=*/false);
+
+  if (CI.getASTContext().hadError())
+    return EXIT_FAILURE;
 
   return EXIT_SUCCESS;
 }

--- a/test/SynthesizeInterfaceTool/synthesize-interface-cxx-stdlib.swift
+++ b/test/SynthesizeInterfaceTool/synthesize-interface-cxx-stdlib.swift
@@ -1,0 +1,22 @@
+// REQUIRES: target-same-as-host
+
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -module-name CxxStdlibInterface -cxx-interoperability-mode=default -o %t/CxxStdlibInterface.swiftmodule %s
+
+// RUN: %target-swift-synthesize-interface -cxx-interoperability-mode=default -module-name CxxStdlibInterface -I %t -o - 2>&1 | %FileCheck %s --check-prefix=OK
+
+// RUN: not %target-swift-synthesize-interface -module-name CxxStdlibInterface -I %t -o - 2>&1 | %FileCheck %s --check-prefix=NEEDS_INTEROP
+
+public struct CxxStdlibInterfaceThing {
+  public var value: Int = 0
+  public func describe() -> String { "thing" }
+}
+
+// OK-NOT: but current compilation uses
+// OK-NOT: unknown C++ stdlib
+// OK:     public struct CxxStdlibInterfaceThing {
+// OK-DAG:     public var value: Int
+// OK-DAG:     public func describe() -> String
+// OK-DAG: }
+
+// NEEDS_INTEROP: error: module 'CxxStdlibInterface' was built with C++ interoperability enabled, but current compilation does not enable C++ interoperability

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -480,7 +480,7 @@ if kIsWindows and run_os in ['windows-msvc']:
     )
     # this variant is for extract-symbolgraph which doesn't accept all the same arugments as swiftc
     # so the extra ceremony lets us pass in the relevant pieces needed for Windows SDK access.
-    config.windows_vfs_overlay_opt = "-Xcc -vfsoverlay -Xcc {} -Xcc -strict-implicit-module-context -Xcc -Xclang -Xcc -fbuiltin-headers-in-system-modules".format(
+    config.windows_vfs_overlay_opt = "-Xcc -vfsoverlay -Xcc {} -Xcc -Xclang -Xcc -fbuiltin-headers-in-system-modules".format(
         os.path.join(config.swift_obj_root, "stdlib", "windows-vfs-overlay.yaml")
     )
     config.clang_system_overlay_opt = "-Xcc -ivfsoverlay -Xcc {} -Xcc -Xclang -Xcc -fbuiltin-headers-in-system-modules".format(


### PR DESCRIPTION
Previously swift-synthesize-interface would print errors about an
incompatible C++ stdlib, but it would still exit 0.

This is the same case as https://github.com/swiftlang/llvm-project/commit/cfcd7d28389234d8cbd223889505042a5d8d2dc3
