### PR TITLE
[stdlib] Avoid a unary overflow in `parse_float64()`

### DIFF
--- a/stdlib/public/core/FloatingPointFromString.swift
+++ b/stdlib/public/core/FloatingPointFromString.swift
@@ -2311,6 +2311,9 @@ internal func parse_float64(_ span: Span<UInt8>) -> Optional<Float64> {
           case .plus:
             return Double(digits)
           case .minus:
+            if digits == UInt64(bitPattern: Int64.min) {
+              return Double(-Int64(truncatingIfNeeded: UInt64.max/2))
+            }
             return Double(-Int64(truncatingIfNeeded: digits))
           }
         }

--- a/test/stdlib/ParseFloat64.swift
+++ b/test/stdlib/ParseFloat64.swift
@@ -345,6 +345,13 @@ tests.test("Substring - short") {
   expectEqual(parsed!.bitPattern, (2.0).bitPattern)
 }
 
+tests.test("Int64.min") {
+  // found in rdar://174966224
+  let s = "-9223372036854775808e0"
+  let parsed = Float64(s)
+  expectEqual(parsed!, -9.2233720368547758E+18)
+}
+
 tests.test("Substring - long") {
   let s1 = "1.00000000000000000000000000000000002.0000000000000000000000000000000000000000000000000000000003.00000000000000004.0000000000000000"
   let s1sub = s1[s1.firstIndex(of: "2")!..<s1.firstIndex(of: "3")!]


### PR DESCRIPTION
- **Explanation**:
The floating-point parsing can unexpectedly trap when exactly the wrong value is encountered. This change handles this specific case.

- **Scope**:
Fix for a very specific case during Float64 parsing.

- **Issues**:
Addresses rdar://174966224

- **Risk**:
Minimal: eliminates a possible crash.

- **Testing**:
Added a test case in "test/stdlib/ParseFloat64.swift"
