### PR TITLE
Make -scan-dependencies exit 1 on failures

### DIFF
--- a/lib/DependencyScan/ScanDependencies.cpp
+++ b/lib/DependencyScan/ScanDependencies.cpp
@@ -1544,12 +1544,7 @@ bool swift::dependencies::scanDependencies(CompilerInstance &CI) {
                         dependencies))
     return true;
 
-  // This process succeeds regardless of whether any errors occurred.
-  // FIXME: We shouldn't need this, but it's masking bugs in our scanning
-  // logic where we don't create a fresh context when scanning Swift interfaces
-  // that includes their own command-line flags.
-  ctx.Diags.resetHadAnyError();
-  return false;
+  return ctx.hadError();
 }
 
 bool swift::dependencies::prescanDependencies(CompilerInstance &instance) {

--- a/test/CAS/binary_module_deps.swift
+++ b/test/CAS/binary_module_deps.swift
@@ -6,7 +6,7 @@
 
 // RUN: %target-swift-frontend -emit-module -module-cache-path %t/clang-module-cache %S/../ScanDependencies/Inputs/Swift/E.swiftinterface -o %t/E.swiftmodule -I %S/../ScanDependencies/Inputs/CHeaders -I %S/../ScanDependencies/Inputs/Swift -swift-version 4
 // RUN: %target-swift-frontend -emit-module -module-cache-path %t/clang-module-cache %S/../ScanDependencies/Inputs/Swift/A.swiftinterface -o %t/A.swiftmodule -I %S/../ScanDependencies/Inputs/CHeaders -I %S/../ScanDependencies/Inputs/Swift -swift-version 4
-// RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t/clang-module-cache %s -o %t/deps.json -I %t -swift-version 4 -cache-compile-job -cas-path %t/cas
+// RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t/clang-module-cache %s -o %t/deps.json -I %t -I %S/../ScanDependencies/Inputs/CHeaders -swift-version 4 -cache-compile-job -cas-path %t/cas
 // RUN: %validate-json %t/deps.json | %FileCheck %s -DTEMP=%t
 
 /// Test binary module key: binary module key is the CASID of itself.

--- a/test/CAS/module_dep_path.swift
+++ b/test/CAS/module_dep_path.swift
@@ -11,7 +11,7 @@
 // B
 
 // RUN: echo "import A" > %t/B.swift
-// RUN: %target-swift-frontend -module-name B -scan-dependencies -module-cache-path %t/clang-module-cache %t/B.swift -o %t/B-deps.json -swift-version 6 -cache-compile-job -cas-path %t/cas %t/B.swift  -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib -O -I %t
+// RUN: %target-swift-frontend -module-name B -scan-dependencies -module-cache-path %t/clang-module-cache %t/B.swift -o %t/B-deps.json -swift-version 6 -cache-compile-job -cas-path %t/cas -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib -O -I %t
 
 // RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/B-deps.json B> %t/B.cmd
 // RUN: %{python} %S/Inputs/GenerateExplicitModuleMap.py %t/B-deps.json > %t/B-map.json
@@ -26,7 +26,7 @@
 
 // Main
 
-// RUN: %target-swift-frontend -module-name Main -scan-dependencies -module-cache-path %t/clang-module-cache %s -o %t/deps.json -swift-version 6 -cache-compile-job -cas-path %t/cas %s  -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib -O -I %t
+// RUN: %target-swift-frontend -module-name Main -scan-dependencies -module-cache-path %t/clang-module-cache %s -o %t/deps.json -swift-version 6 -cache-compile-job -cas-path %t/cas -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib -O -I %t
 // UN: %validate-json %t/deps.json | %FileCheck %s -DTEMP=%t
 
 // RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json Main> %t/Main.cmd

--- a/test/ModuleInterface/infer-arch-from-file.swift
+++ b/test/ModuleInterface/infer-arch-from-file.swift
@@ -1,3 +1,5 @@
+// REQUIRES: OS=macosx
+
 // RUN: %empty-directory(%t)
 // RUN: %empty-directory(%t/Bar.swiftmodule)
 // RUN: echo "// swift-interface-format-version: 1.0" > %t/arm64.swiftinterface

--- a/test/ScanDependencies/cached-missing-module-found-in-serialized-paths.swift
+++ b/test/ScanDependencies/cached-missing-module-found-in-serialized-paths.swift
@@ -15,7 +15,7 @@
 // to emit the diagnostic
 // RUN: rm %t/deps/C.swiftinterface
 
-// RUN: %target-swift-frontend -scan-dependencies -o %t/deps.json %t/client.swift -I %t/deps -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -Rdependency-scan-cache -load-dependency-scan-cache -dependency-scan-cache-path %t/cache.moddepcache -validate-prior-dependency-scan-cache &> %t/output.txt
+// RUN: not %target-swift-frontend -scan-dependencies -o %t/deps.json %t/client.swift -I %t/deps -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -Rdependency-scan-cache -load-dependency-scan-cache -dependency-scan-cache-path %t/cache.moddepcache -validate-prior-dependency-scan-cache &> %t/output.txt
 // RUN: cat %t/output.txt | %FileCheck %s
 
 // CHECK: remark: Incremental module scan: Re-using serialized module scanning dependency cache from: '{{.*}}cache.moddepcache'.

--- a/test/ScanDependencies/candidate_binary_module_diagnostics.swift
+++ b/test/ScanDependencies/candidate_binary_module_diagnostics.swift
@@ -5,7 +5,7 @@
 // RUN: split-file %s %t
 
 // RUN: echo "Not Really a module" >> %t/moduleInputs/FooBar.swiftmodule
-// RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t/clang-module-cache %t/main.swift -o %t/deps.json -I %t/moduleInputs -diagnostic-style llvm -scanner-module-validation 2>&1 | %FileCheck %s -check-prefix=ERROR
+// RUN: not %target-swift-frontend -scan-dependencies -module-cache-path %t/clang-module-cache %t/main.swift -o %t/deps.json -I %t/moduleInputs -diagnostic-style llvm -scanner-module-validation 2>&1 | %FileCheck %s -check-prefix=ERROR
 
 // ERROR: error: unable to resolve Swift module dependency to a compatible module: 'FooBar'
 // ERROR: note: found incompatible module '{{.*}}{{/|\\}}moduleInputs{{/|\\}}FooBar.swiftmodule': malformed

--- a/test/ScanDependencies/diagnose-missing-module-found-in-serialized-paths.swift
+++ b/test/ScanDependencies/diagnose-missing-module-found-in-serialized-paths.swift
@@ -6,7 +6,7 @@
 
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/deps/B.swiftmodule -module-cache-path %t/module-cache %t/B.swift -module-name B -I %t/moreDeps
 
-// RUN: %target-swift-frontend -scan-dependencies -o %t/deps.json %t/client.swift -I %t/deps -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import &> %t/output.txt
+// RUN: not %target-swift-frontend -scan-dependencies -o %t/deps.json %t/client.swift -I %t/deps -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import &> %t/output.txt
 // RUN: cat %t/output.txt | %FileCheck %s
 
 // CHECK: error: compilation search paths unable to resolve module dependency: 'C'

--- a/test/ScanDependencies/error_path.swift
+++ b/test/ScanDependencies/error_path.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: mkdir -p %t/clang-module-cache
 // REQUIRES: objc_interop
-// RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t/clang-module-cache %s -o %t/deps.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -emit-dependencies -emit-dependencies-path %t/deps.d -import-objc-header %S/Inputs/CHeaders/Bridging.h -swift-version 4 2>&1 | %FileCheck %s
+// RUN: not %target-swift-frontend -scan-dependencies -module-cache-path %t/clang-module-cache %s -o %t/deps.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -emit-dependencies -emit-dependencies-path %t/deps.d -import-objc-header %S/Inputs/CHeaders/Bridging.h -swift-version 4 2>&1 | %FileCheck %s
 
 import P
 

--- a/test/ScanDependencies/error_source_locations.swift
+++ b/test/ScanDependencies/error_source_locations.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: mkdir -p %t/clang-module-cache
 // REQUIRES: objc_interop
-// RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t/clang-module-cache %s -o %t/deps.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -emit-dependencies -emit-dependencies-path %t/deps.d -import-objc-header %S/Inputs/CHeaders/Bridging.h -swift-version 4 2>&1 | %FileCheck %s
+// RUN: not %target-swift-frontend -scan-dependencies -module-cache-path %t/clang-module-cache %s -o %t/deps.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -emit-dependencies -emit-dependencies-path %t/deps.d -import-objc-header %S/Inputs/CHeaders/Bridging.h -swift-version 4 2>&1 | %FileCheck %s
 
 import P
 import FooBar

--- a/test/ScanDependencies/explicit-scanner-input.swift
+++ b/test/ScanDependencies/explicit-scanner-input.swift
@@ -17,7 +17,7 @@
 
 // Step 4: verify that the usual invalid module candidate diagnostics apply
 // RUN: echo "Not Really a module" > %t/Inputs/Foo.swiftmodule/%target-swiftmodule-name
-// RUN: %target-swift-frontend -scan-dependencies %t/test.swift -o %t/deps.json  -scanner-module-validation -swift-module-file=Foo=%t/Inputs/Foo.swiftmodule/%target-swiftmodule-name -diagnostic-style llvm 2>&1 | %FileCheck %s -check-prefix=CHECK-INVALID-MODULE-DIAG
+// RUN: not %target-swift-frontend -scan-dependencies %t/test.swift -o %t/deps.json  -scanner-module-validation -swift-module-file=Foo=%t/Inputs/Foo.swiftmodule/%target-swiftmodule-name -diagnostic-style llvm 2>&1 | %FileCheck %s -check-prefix=CHECK-INVALID-MODULE-DIAG
 
 // CHECK-INPUT: "swiftPrebuiltExternal": "Foo"
 // CHECK-WARN-MULTIPLE: warning: multiple Swift module file inputs with identifier "Foo": replacing '{{.*}}NotAModule.swiftmodule'

--- a/test/ScanDependencies/incompatible-arch.swift
+++ b/test/ScanDependencies/incompatible-arch.swift
@@ -4,7 +4,7 @@
 // RUN: touch %t/inputs/Foo.swiftmodule/i387.swiftmodule
 // RUN: touch %t/inputs/Foo.swiftmodule/ppc65.swiftmodule
 
-// RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t/module-cache %s -o %t/deps.json -I %t/inputs -diagnostic-style llvm -scanner-module-validation 2>&1 | %FileCheck %s
+// RUN: not %target-swift-frontend -scan-dependencies -module-cache-path %t/module-cache %s -o %t/deps.json -I %t/inputs -diagnostic-style llvm -scanner-module-validation 2>&1 | %FileCheck %s
 
 // CHECK-DAG: warning: module file '{{.*}}Foo.swiftmodule{{/|\\}}ppc65.swiftmodule' is incompatible with this Swift compiler: built for incompatible target
 // CHECK-DAG: warning: module file '{{.*}}Foo.swiftmodule{{/|\\}}i387.swiftmodule' is incompatible with this Swift compiler: built for incompatible target

--- a/test/ScanDependencies/invalid_binary_module_only.swift
+++ b/test/ScanDependencies/invalid_binary_module_only.swift
@@ -4,7 +4,7 @@
 
 // RUN: echo "Not Really a module" >> %t/moduleInputs/FooBar.swiftmodule
 
-// RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t/clang-module-cache %s -o %t/deps.json -I %t/moduleInputs -diagnostic-style llvm -scanner-module-validation 2>&1 | %FileCheck %s
+// RUN: not %target-swift-frontend -scan-dependencies -module-cache-path %t/clang-module-cache %s -o %t/deps.json -I %t/moduleInputs -diagnostic-style llvm -scanner-module-validation 2>&1 | %FileCheck %s
 
 import FooBar
 

--- a/test/ScanDependencies/restrict-swiftmodule-to-revision.swift
+++ b/test/ScanDependencies/restrict-swiftmodule-to-revision.swift
@@ -17,21 +17,21 @@
 // RUN:   -emit-module-interface-path %t/revision/Foo.swiftinterface -enable-library-evolution %t/foo.swift
 
 // RUN: env SWIFT_DEBUG_FORCE_SWIFTMODULE_REVISION=1.0.0.0.1 \
-// RUN:   %target-swift-frontend -scan-dependencies -scanner-module-validation -module-name Test -O -module-load-mode prefer-binary \
+// RUN:   %target-swift-frontend -scan-dependencies -scanner-module-validation -module-name Test -O -module-load-mode prefer-serialized \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
 // RUN:   %t/main.swift -o %t/deps-1.json -swift-version 5 -I %t/match
 
 // RUN: %FileCheck %s --check-prefix=BINARY --input-file=%t/deps-1.json
 
 // RUN: env SWIFT_DEBUG_FORCE_SWIFTMODULE_REVISION=1.0.0.0.1 \
-// RUN:   %target-swift-frontend -scan-dependencies -scanner-module-validation -module-name Test -O -module-load-mode prefer-binary \
+// RUN:   %target-swift-frontend -scan-dependencies -scanner-module-validation -module-name Test -O -module-load-mode prefer-serialized \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
 // RUN:   %t/main.swift -o %t/deps-2.json -swift-version 5 -I %t/new
 
 // RUN: %FileCheck %s --check-prefix=TEXTUAL --input-file=%t/deps-2.json
 
 // RUN: env SWIFT_DEBUG_FORCE_SWIFTMODULE_REVISION=1.0.0.0.1 \
-// RUN:   %target-swift-frontend -scan-dependencies -scanner-module-validation -module-name Test -O -module-load-mode prefer-binary \
+// RUN:   %target-swift-frontend -scan-dependencies -scanner-module-validation -module-name Test -O -module-load-mode prefer-serialized \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
 // RUN:   %t/main.swift -o %t/deps-3.json -swift-version 5 -I %t/revision
 

--- a/test/ScanDependencies/scan-dependencies-missing-import.swift
+++ b/test/ScanDependencies/scan-dependencies-missing-import.swift
@@ -1,0 +1,5 @@
+// RUN: not %target-swiftc_driver -scan-dependencies %s -o %t/deps.json 2>&1 | %FileCheck %s
+
+import invalid_module_that_never_exists
+
+// CHECK: error: unable to resolve module dependency: 'invalid_module_that_never_exists'

--- a/test/ScanDependencies/test_clang_gmodules.swift
+++ b/test/ScanDependencies/test_clang_gmodules.swift
@@ -1,3 +1,5 @@
+// REQUIRES: OS=macosx
+
 // RUN: %empty-directory(%t)
 // RUN: %empty-directory(%t/module-cache)
 // RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t/module-cache %s -o %t/deps.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -target %target-cpu-apple-macosx10.14 -disable-implicit-concurrency-module-import -disable-implicit-string-processing-module-import

--- a/test/ScanDependencies/testable-dependencies.swift
+++ b/test/ScanDependencies/testable-dependencies.swift
@@ -53,7 +53,7 @@
 // WARN: warning: module file '{{.*}}{{/|\\}}A.swiftmodule' is incompatible with this Swift compiler: module built without '-enable-testing'
 
 /// Testable import non-testable build enable testing, warning about the finding then error out.
-// RUN: %target-swift-frontend -scan-dependencies -scanner-module-validation -module-load-mode prefer-interface -module-name Test %t/testable.swift \
+// RUN: not %target-swift-frontend -scan-dependencies -scanner-module-validation -module-load-mode prefer-interface -module-name Test %t/testable.swift \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib -enable-testing \
 // RUN:   -o %t/deps5.json -I %t/regular -swift-version 5 -Rmodule-loading 2>&1 | %FileCheck %s --check-prefix ERROR
 // ERROR: error: unable to resolve Swift module dependency to a compatible module: 'A'
@@ -81,4 +81,3 @@ internal import B
 
 //--- B.swift
 public func b() {}
-

--- a/test/ScanDependencies/wrong_target_candidate_diagnostic.swift
+++ b/test/ScanDependencies/wrong_target_candidate_diagnostic.swift
@@ -8,7 +8,7 @@
 // ERROR: note: found incompatible module '{{.*}}{{/|\\}}moduleInputs{{/|\\}}FooBar.swiftmodule': compiled for a different target platform
 
 // RUN: %target-swift-frontend -emit-module %t/FooBar.swift -emit-module-path %t/moduleInputs/FooBar.swiftmodule -module-name FooBar -target x86_64-unknown-linux-gnu -parse-stdlib
-// RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t/clang-module-cache %t/main.swift -o %t/deps.json -I %t/moduleInputs -I %t/moduleInputs2 -diagnostic-style llvm -scanner-module-validation -target arm64e-apple-macosx11.0 2>&1 | %FileCheck %s -check-prefix=ERROR
+// RUN: not %target-swift-frontend -scan-dependencies -module-cache-path %t/clang-module-cache %t/main.swift -o %t/deps.json -I %t/moduleInputs -I %t/moduleInputs2 -diagnostic-style llvm -scanner-module-validation -target arm64e-apple-macosx11.0 2>&1 | %FileCheck %s -check-prefix=ERROR
 
 //--- main.swift
 import FooBar


### PR DESCRIPTION
Previously even if you gave this a totally bogus file it would exit 0.
