### PR TITLE
[Embedded] Build standard library & friends for ARMv8-M and ARMv8.1-M

### DIFF
--- a/cmake/modules/SwiftSetIfArchBitness.cmake
+++ b/cmake/modules/SwiftSetIfArchBitness.cmake
@@ -21,6 +21,8 @@ function(set_if_arch_bitness var_name)
      "${SIA_ARCH}" STREQUAL "armv7m" OR
      "${SIA_ARCH}" STREQUAL "armv7em" OR
      "${SIA_ARCH}" STREQUAL "armv7s" OR
+     "${SIA_ARCH}" STREQUAL "armv8m.main" OR
+     "${SIA_ARCH}" STREQUAL "armv8.1m.main" OR
      "${SIA_ARCH}" STREQUAL "m68k" OR
      "${SIA_ARCH}" STREQUAL "riscv32" OR
      "${SIA_ARCH}" STREQUAL "wasm32" OR

--- a/stdlib/public/CMakeLists.txt
+++ b/stdlib/public/CMakeLists.txt
@@ -213,6 +213,8 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB_CROSS_COMPILING)
         "armv7    armv7-apple-none-macho    armv7-apple-none-macho"
         "armv7m   armv7m-apple-none-macho   armv7m-apple-none-macho"
         "armv7em  armv7em-apple-none-macho  armv7em-apple-none-macho"
+        "armv8m.main   armv8m.main-apple-none-macho   armv8m.main-apple-none-macho"
+        "armv8.1m.main armv8.1m.main-apple-none-macho armv8.1m.main-apple-none-macho"
       )
     endif()
     if("AArch64" IN_LIST LLVM_TARGETS_TO_BUILD)
@@ -232,6 +234,8 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB_CROSS_COMPILING)
         "armv6m   armv6m-none-none-eabi     armv6m-none-none-eabi"
         "armv7    armv7-none-none-eabi      armv7-none-none-eabi"
         "armv7em  armv7em-none-none-eabi    armv7em-none-none-eabi"
+        "armv8m.main  armv8m.main-none-none-eabi    armv8m.main-none-none-eabi"
+        "armv8.1m.main  armv8.1m.main-none-none-eabi    armv8.1m.main-none-none-eabi"
       )
     endif()
     if("AArch64" IN_LIST LLVM_TARGETS_TO_BUILD)

--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -318,17 +318,19 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB AND SWIFT_SHOULD_BUILD_EMBEDDED_CONCURRENC
         continue()
       endif()
     elseif (SWIFT_HOST_VARIANT STREQUAL "macosx")
-      if(NOT "${mod}" MATCHES "x86_64|arm64|arm64e|armv7|armv7m|armv7em")
+      if(NOT "${mod}" MATCHES "x86_64|arm64|arm64e|armv7|armv7m|armv7em|armv8m.main|armv8.1m.main")
         continue()
       endif()
 
-      if(NOT "${mod}" MATCHES "-apple-" OR "${mod}" MATCHES "-none-macho" OR "${arch}" STREQUAL "armv7m" OR "${arch}" STREQUAL "armv7em")
+      if(NOT "${mod}" MATCHES "-apple-" OR "${mod}" MATCHES "-none-macho" OR "${arch}" STREQUAL "armv7m" OR "${arch}" STREQUAL "armv7em" OR "${arch}" STREQUAL "armv8m.main" OR "${arch}" STREQUAL "armv8.1m.main")
         # Host is macOS with a macOS SDK. To be able to build the C++ Concurrency runtime for non-Darwin targets using the macOS SDK,
         # we need to pass some extra flags and search paths.
         set(extra_c_compile_flags -stdlib=libc++ -isystem${SWIFT_SDK_OSX_PATH}/usr/include/c++/v1 -isystem${SWIFT_SDK_OSX_PATH}/usr/include -D__APPLE__)
         # Before Xcode 26.4, we were getting these macros from TargetConditionals.h
         # now it's on us to define those to keep using the macOS SDK for non Darwin targets
         if("${arch}" MATCHES "armv7")
+          list(APPEND extra_c_compile_flags -DTARGET_CPU_ARM=1)
+        elseif("${arch}" MATCHES "armv8")
           list(APPEND extra_c_compile_flags -DTARGET_CPU_ARM=1)
         elseif("${arch}" MATCHES "arm64")
           list(APPEND extra_c_compile_flags -DTARGET_CPU_ARM64=1)

--- a/test/embedded/builtin-float.swift
+++ b/test/embedded/builtin-float.swift
@@ -3,6 +3,8 @@
 // RUN: %{python} %utils/split_file.py -o %t %s
 
 // RUN: %target-swift-frontend -target armv7em-none-none-eabi -emit-ir %t/Main.swift -enable-experimental-feature Embedded -module-cache-path %t/ModuleCache -Xcc -I%t/include
+// RUN: %target-swift-frontend -target armv8m.main-none-none-eabi -emit-ir %t/Main.swift -enable-experimental-feature Embedded -module-cache-path %t/ModuleCache -Xcc -I%t/include
+// RUN: %target-swift-frontend -target armv8.1m.main-none-none-eabi -emit-ir %t/Main.swift -enable-experimental-feature Embedded -module-cache-path %t/ModuleCache -Xcc -I%t/include
 
 // UNSUPPORTED: CPU=wasm32
 // REQUIRES: swift_in_compiler

--- a/utils/swift_build_support/swift_build_support/products/llvm.py
+++ b/utils/swift_build_support/swift_build_support/products/llvm.py
@@ -361,7 +361,7 @@ class LLVM(cmake_product.CMakeProduct):
             llvm_cmake_options.define(
                 f'BUILTINS_{builtins_runtimes_target_for_darwin}_'
                 'COMPILER_RT_FORCE_BUILD_BAREMETAL_MACHO_BUILTINS_ARCHS:'
-                'STRING', 'armv6 armv6m armv7 armv7m armv7em')
+                'STRING', 'armv6 armv6m armv7 armv7m armv7em armv8m.main armv8.1m.main')
 
         llvm_enable_projects = ['clang']
         llvm_enable_runtimes = []

--- a/utils/swift_build_support/swift_build_support/targets.py
+++ b/utils/swift_build_support/swift_build_support/targets.py
@@ -278,7 +278,7 @@ class StdlibDeploymentTarget(object):
     # to build the stdlib as standalone and/or statically linked.
     Freestanding = Platform("freestanding", archs=[
         "i386", "x86_64",
-        "armv7", "armv7s", "armv7k", "armv7m", "armv7em",
+        "armv7", "armv7s", "armv7k", "armv7m", "armv7em", "armv8m.main", "armv8.1m.main",
         "arm64", "arm64e", "arm64_32"])
 
     Linux = Platform("linux", archs=[


### PR DESCRIPTION
- **Explanation**: Add support for building `armv8m.main` and `armv8.1m.main` variants of the Embedded Swift libraries.
- **Scope**: Limited to Embedded Swift build machinery.
- **Issues**: rdar://152598746
- **Risk**: Low. It's adding a new target to the embedded Swift build, separate from everything else.
- **Testing**: Extended test to make sure the new target triples work.
  