### PR TITLE
[Embedded] Enable throwing in the concurrency library

### DIFF
--- a/stdlib/public/Concurrency/AsyncLet.cpp
+++ b/stdlib/public/Concurrency/AsyncLet.cpp
@@ -345,11 +345,7 @@ static void _asyncLet_finish_continuation(
 
   // Destroy the error, or the result that was stored to the buffer.
   if (error) {
-    #if SWIFT_CONCURRENCY_EMBEDDED
-    swift_unreachable("untyped error used in embedded Swift");
-    #else
     swift_errorRelease((SwiftError*)error);
-    #endif
   } else {
     alet->getTask()->futureFragment()->getResultType().vw_destroy(resultBuffer);
   }

--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -102,11 +102,7 @@ void FutureFragment::destroy() {
     break;
 
   case Status::Error:
-    #if SWIFT_CONCURRENCY_EMBEDDED
-    swift_unreachable("untyped error used in embedded Swift");
-    #else
     swift_errorRelease(getError());
-    #endif
     break;
   }
 }
@@ -300,11 +296,7 @@ void AsyncTask::completeFuture(AsyncContext *context) {
     auto waitingContext =
       static_cast<TaskFutureWaitAsyncContext *>(waitingTask->ResumeContext);
     if (hadErrorResult) {
-      #if SWIFT_CONCURRENCY_EMBEDDED
-      swift_unreachable("untyped error used in embedded Swift");
-      #else
       waitingContext->fillWithError(fragment);
-      #endif
     } else {
       waitingContext->fillWithSuccess(fragment);
     }
@@ -1449,15 +1441,11 @@ void swift_task_future_wait_throwingImpl(
   }
 
   case FutureFragment::Status::Error: {
-    #if SWIFT_CONCURRENCY_EMBEDDED
-    swift_unreachable("untyped error used in embedded Swift");
-    #else
     // Run the task with an error result.
     auto future = task->futureFragment();
     auto error = future->getError();
     swift_errorRetain(error);
     return resumeFunction(callerContext, error);
-    #endif
   }
   }
 }

--- a/stdlib/public/Concurrency/TaskPrivate.h
+++ b/stdlib/public/Concurrency/TaskPrivate.h
@@ -343,12 +343,8 @@ public:
     fillWithError(future->getError());
   }
   void fillWithError(SwiftError *error) {
-    #if SWIFT_CONCURRENCY_EMBEDDED
-    swift_unreachable("untyped error used in embedded Swift");
-    #else
     errorResult = error;
     swift_errorRetain(error);
-    #endif
   }
 };
 

--- a/test/embedded/concurrency-async-let.swift
+++ b/test/embedded/concurrency-async-let.swift
@@ -36,6 +36,29 @@ func asyncFib(_ n: Int) async -> Int {
   return result
 }
 
+enum FibError: Error {
+case unhandledValue(Int)
+}
+
+@available(SwiftStdlib 5.1, *)
+func throwingFib(_ n: Int) async throws -> Int {
+  if n == 0 || n == 1 {
+    return n
+  }
+
+  async let first = throwingFib(n-2)
+  async let second = throwingFib(n-1)
+
+  let result = try await first + second
+
+  let s2nd = try await second
+  if s2nd > 17 && s2nd % 17 == 0 {
+    throw FibError.unhandledValue(try await second)
+  }
+
+  return result
+}
+
 @available(SwiftStdlib 5.1, *)
 func runFibonacci(_ n: Int) async {
   let result = await asyncFib(n)
@@ -49,5 +72,15 @@ func runFibonacci(_ n: Int) async {
 @main struct Main {
   static func main() async {
     await runFibonacci(10)
+
+    do {
+      _ = try await throwingFib(10)
+      fatalError("Throwing test failed to fail")
+    } catch let FibError {
+      // CHECK: Caught a FibError
+      print("Caught a FibError")
+    } catch {
+      fatalError("Caught something else??")
+    }
   }
 }

--- a/test/embedded/concurrency-throwing-task.swift
+++ b/test/embedded/concurrency-throwing-task.swift
@@ -1,0 +1,88 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -enable-experimental-feature Embedded -parse-as-library %s -c -o %t/a.o
+// RUN: %target-clang %t/a.o %target-embedded-posix-shim -o %t/a.out -L%swift_obj_root/lib/swift/embedded/%module-target-triple %target-clang-resource-dir-opt -lswift_Concurrency %target-swift-default-executor-opt -dead_strip
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: swift_in_compiler
+// REQUIRES: optimized_stdlib
+// REQUIRES: OS=macosx || OS=wasip1
+// REQUIRES: swift_feature_Embedded
+
+import _Concurrency
+
+enum NumberError: Error {
+case isMultipleOfSeven(Int)
+}
+
+actor Number {
+    var val: Int
+    var task: Task<Void, any Error>?
+
+    func increment() throws {
+        if val > 7 && val % 7 == 0 {
+            throw NumberError.isMultipleOfSeven(val)
+        }
+        val += 1
+    }
+
+    func fib(n: Int) -> Int {
+        if n < 2 {
+            return n
+        }
+        return fib(n: n-1) + fib(n: n-2)
+    }
+
+    init() async {
+        val = 0
+
+        task = Task.detached(priority: .high) {
+            for _ in 0..<100 {
+                try await self.increment()
+            }
+        }
+ 
+        // do some synchronous work
+        let ans = fib(n: 37)
+        guard ans == 24157817 else {
+            fatalError("miscomputation?")
+        }
+
+        // make sure task didn't modify me!
+        guard val == 0 else {
+            fatalError("race!")
+        }
+
+        print("finished init()")
+    }
+
+    init(iterations: Int) async {
+        var iter = iterations
+        repeat {
+            val = iter
+            iter -= 1
+        } while iter > 0
+    }
+}
+
+@main struct Main {
+    static func main() async {
+
+        // CHECK:       finished init()
+        // CHECK:       Found thrown error
+        do {
+            let n1 = await Number()
+            try await n1.task!.value
+            print("Error wasn't thrown!?")
+            fatalError("Error wasn't thrown??")
+        } catch let e as NumberError {
+            switch e {
+            case .isMultipleOfSeven(let value):
+                print("Found thrown error")
+                precondition(value % 7 == 0)
+            }
+        } catch {
+            fatalError("Not thrown")
+        }
+    }
+}


### PR DESCRIPTION
- **Explanation**: Now that we have untyped throws support in Embedded Swift, remove the special cases that trapped when a task (or anything built on it) throws. This allows a `Task` or `async let` to throw in Embedded Swift.
- **Scope**: Limited to the concurrency runtime in Embedded Swift.
- **Issues**: rdar://175590869
- **Risk**: Low. Removes special cases in the concurrency runtime for Embedded Swift without affecting anything else.
- **Testing**: Added tests for the new behavior.
