### PR TITLE
[Embedded] Lift the restriction on the use of metatypes in Embedded Swift

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/ModulePasses/EmbeddedSwiftDiagnostics.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/ModulePasses/EmbeddedSwiftDiagnostics.swift
@@ -77,47 +77,37 @@ private struct FunctionChecker {
 
   mutating func checkInstruction(_ instruction: Instruction) throws {
     switch instruction {
-    case is OpenExistentialMetatypeInst,
-         is InitExistentialMetatypeInst:
-      throw Diagnostic(.embedded_swift_metatype_type, instruction.operands[0].value.type, at: instruction.location)
-
     case is OpenExistentialBoxInst,
          is OpenExistentialBoxValueInst,
          is OpenExistentialValueInst,
          is OpenExistentialAddrInst,
-         is InitExistentialAddrInst,
-         is InitExistentialValueInst,
-         is ExistentialMetatypeInst:
-      if let ie = instruction as? InitExistentialAddrInst {
-        for conf in ie.conformances {
-          try checkConformance(conf, location: ie.location)
-        }
-      } else if instruction is OpenExistentialAddrInst
-             || instruction is OpenExistentialBoxInst
-             || instruction is OpenExistentialBoxValueInst {
-          // okay
-      } else {
-          // not supported even in embedded with existentials
-        throw Diagnostic(.embedded_swift_existential_type, instruction.operands[0].value.type, at: instruction.location)
-      }
+         is OpenExistentialMetatypeInst:
+      break
 
     case is AllocExistentialBoxInst:
       break
 
-    case let ier as InitExistentialRefInst:
-      for conf in ier.conformances {
-        try checkConformance(conf, location: ier.location)
+    case is InitExistentialAddrInst,
+         is InitExistentialValueInst,
+         is InitExistentialRefInst,
+         is InitExistentialMetatypeInst:
+      let ie = instruction as! any InitExistentialInstruction
+      for conf in ie.conformances {
+        try checkConformance(conf, location: ie.location)
       }
 
     case is ValueMetatypeInst,
-         is MetatypeInst:
+         is MetatypeInst,
+         is ExistentialMetatypeInst:
       let metaType = (instruction as! SingleValueInstruction).type
-      if metaType.representationOfMetatype != .thin {
+      switch metaType.representationOfMetatype {
+      case .objC:
         let rawType = metaType.canonicalType.rawType.instanceTypeOfMetatype
         let type = rawType.isDynamicSelf ? rawType.staticTypeOfDynamicSelf : rawType
-        if !type.isClass {
-          throw Diagnostic(.embedded_swift_metatype_type, type, at: instruction.location)
-        }
+        throw Diagnostic(.embedded_swift_metatype_type, type, at: instruction.location)
+
+      case .thick, .thin:
+        break
       }
 
     case is KeyPathInst:

--- a/SwiftCompilerSources/Sources/SIL/Instruction.swift
+++ b/SwiftCompilerSources/Sources/SIL/Instruction.swift
@@ -950,8 +950,14 @@ final public class IndexRawPointerInst : SingleValueInstruction, IndexingInstruc
 final public
 class TailAddrInst : SingleValueInstruction, IndexingInstruction {}
 
+/// An instruction that initializes an existential
+@_semantics("fast_cast")
+public protocol InitExistentialInstruction: Instruction {
+  var conformances: ConformanceArray { get }
+}
+
 final public
-class InitExistentialRefInst : SingleValueInstruction, UnaryInstruction {
+class InitExistentialRefInst : SingleValueInstruction, UnaryInstruction, InitExistentialInstruction {
   public var instance: Value { operand.value }
 
   public var conformances: ConformanceArray {
@@ -969,13 +975,17 @@ class OpenExistentialRefInst : SingleValueInstruction, UnaryInstruction {
 }
 
 final public
-class InitExistentialValueInst : SingleValueInstruction, UnaryInstruction {}
+class InitExistentialValueInst : SingleValueInstruction, UnaryInstruction, InitExistentialInstruction {
+  public var conformances: ConformanceArray {
+    ConformanceArray(bridged: bridged.InitExistentialValueInst_getConformances())
+  }
+}
 
 final public
 class OpenExistentialValueInst : SingleValueInstruction, UnaryInstruction {}
 
 final public
-class InitExistentialAddrInst : SingleValueInstruction, UnaryInstruction {
+class InitExistentialAddrInst : SingleValueInstruction, UnaryInstruction, InitExistentialInstruction {
   public var conformances: ConformanceArray {
     ConformanceArray(bridged: bridged.InitExistentialAddrInst_getConformances())
   }
@@ -1003,8 +1013,12 @@ final public
 class OpenExistentialBoxValueInst : SingleValueInstruction, UnaryInstruction {}
 
 final public
-class InitExistentialMetatypeInst : SingleValueInstruction, UnaryInstruction {
+class InitExistentialMetatypeInst : SingleValueInstruction, UnaryInstruction, InitExistentialInstruction {
   public var metatype: Value { operand.value }
+
+  public var conformances: ConformanceArray {
+    ConformanceArray(bridged: bridged.InitExistentialMetatypeInst_getConformances())
+  }
 }
 
 final public

--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -394,10 +394,6 @@ GROUPED_ERROR(embedded_cannot_specialize_witness_method,EmbeddedRestrictions,non
       "a protocol type cannot contain a generic method %0 in embedded Swift", (DeclName))
 GROUPED_ERROR(cannot_specialize_class,EmbeddedRestrictions,none,
       "cannot specialize %0 because class definition is not available (make sure to build with -wmo)", (Type))
-GROUPED_ERROR(embedded_swift_existential_type,EmbeddedRestrictions,none,
-      "cannot use a value of protocol type %0 in embedded Swift", (Type))
-GROUPED_ERROR(embedded_swift_existential,EmbeddedRestrictions,none,
-      "cannot use a value of protocol type in embedded Swift", ())
 GROUPED_ERROR(embedded_swift_value_deinit,EmbeddedRestrictions,none,
       "cannot de-virtualize deinit of type %0", (Type))
 GROUPED_ERROR(embedded_swift_metatype_type,EmbeddedRestrictions,none,

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -814,7 +814,9 @@ struct BridgedInstruction {
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedConformanceArray InitExistentialRefInst_getConformances() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedCanType InitExistentialRefInst_getFormalConcreteType() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedConformanceArray InitExistentialAddrInst_getConformances() const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedConformanceArray InitExistentialValueInst_getConformances() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedCanType InitExistentialAddrInst_getFormalConcreteType() const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedConformanceArray InitExistentialMetatypeInst_getConformances() const;
   BRIDGED_INLINE bool OpenExistentialAddr_isImmutable() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedGlobalVar GlobalAccessInst_getGlobal() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedGlobalVar AllocGlobalInst_getGlobal() const;

--- a/include/swift/SIL/SILBridgingImpl.h
+++ b/include/swift/SIL/SILBridgingImpl.h
@@ -1306,8 +1306,16 @@ BridgedConformanceArray BridgedInstruction::InitExistentialAddrInst_getConforman
   return {getAs<swift::InitExistentialAddrInst>()->getConformances()};
 }
 
+BridgedConformanceArray BridgedInstruction::InitExistentialValueInst_getConformances() const {
+  return {getAs<swift::InitExistentialValueInst>()->getConformances()};
+}
+
 BridgedCanType BridgedInstruction::InitExistentialAddrInst_getFormalConcreteType() const {
   return getAs<swift::InitExistentialAddrInst>()->getFormalConcreteType();
+}
+
+BridgedConformanceArray BridgedInstruction::InitExistentialMetatypeInst_getConformances() const {
+  return {getAs<swift::InitExistentialMetatypeInst>()->getConformances()};
 }
 
 bool BridgedInstruction::OpenExistentialAddr_isImmutable() const {

--- a/lib/IRGen/ExistentialMetadataVisitor.h
+++ b/lib/IRGen/ExistentialMetadataVisitor.h
@@ -1,0 +1,56 @@
+//===--- ExistentialMetadataVisitor.h - CRTP for 'any' metadata -*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// A CRTP class useful for laying out existential metadata.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_IRGEN_EXISTENTIALMETADATALAYOUT_H
+#define SWIFT_IRGEN_EXISTENTIALMETADATALAYOUT_H
+
+#include "swift/AST/Type.h"
+
+namespace swift {
+namespace irgen {
+
+/// A CRTP class for laying out existential metadata.
+///
+/// This produces an object corresponding to a ExistentialTypeMetadata type.
+/// It does not itself doing anything special for metadata templates.
+template <class Impl> struct ExistentialMetadataVisitor
+       : public MetadataVisitor<Impl> {
+  using super = MetadataVisitor<Impl>;
+
+protected:
+  using super::asImpl;
+
+  Type Target;
+
+  ExistentialMetadataVisitor(IRGenModule &IGM, Type target)
+    : super(IGM), Target(target) {
+    assert(target->isAnyExistentialType());
+  }
+
+public:
+
+  void embeddedLayout() {
+    // The embedded layout consists of:
+    // -1 : vwt
+    //  0 : metadata flags
+    super::layout();
+  }
+};
+
+} // end namespace irgen
+} // end namespace swift
+
+#endif

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -5526,7 +5526,9 @@ IRGenModule::getAddrOfTypeMetadata(CanType concreteType,
 
   if (hasEmbeddedExistentials &&
       (isa<TupleType>(concreteType) ||
-       isa<FunctionType>(concreteType))) {
+       isa<FunctionType>(concreteType) ||
+       concreteType->isAnyExistentialType() ||
+       isa<MetatypeType>(concreteType))) {
     IRGen.noteUseOfSpecializedValueMetadata(concreteType);
   }
 

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -53,6 +53,7 @@
 #include "ClassTypeInfo.h"
 #include "ConstantBuilder.h"
 #include "EnumMetadataVisitor.h"
+#include "ExistentialMetadataVisitor.h"
 #include "ExtendedExistential.h"
 #include "Field.h"
 #include "FixedTypeInfo.h"
@@ -71,6 +72,7 @@
 #include "IRGenModule.h"
 #include "MetadataLayout.h"
 #include "MetadataRequest.h"
+#include "MetatypeMetadataVisitor.h"
 #include "ProtocolInfo.h"
 #include "ScalarTypeInfo.h"
 #include "StructLayout.h"
@@ -5762,9 +5764,14 @@ void irgen::emitLazySpecializedValueMetadata(IRGenModule &IGM,
   } else if (valueTy->getStructOrBoundGenericStruct()) {
     emitSpecializedGenericStructMetadata(IGM, valueTy,
                                          *valueTy.getStructOrBoundGenericStruct());
+  } else if (auto enumTy = valueTy->getEnumOrBoundGenericEnum()) {
+    emitSpecializedGenericEnumMetadata(IGM, valueTy, *enumTy);
+  } else if (valueTy->isAnyExistentialType()) {
+    emitLazyExistentialMetadata(IGM, valueTy);
+  } else if (isa<MetatypeType>(valueTy)) {
+    emitLazyMetatypeMetadata(IGM, valueTy);
   } else {
-    emitSpecializedGenericEnumMetadata(IGM, valueTy,
-                                       *valueTy.getEnumOrBoundGenericEnum());
+    llvm_unreachable("unhandled specialized value metadata");
   }
 }
 
@@ -6414,7 +6421,7 @@ void irgen::emitSpecializedGenericStructMetadata(IRGenModule &IGM, CanType type,
                          init.finishAndCreateFuture());
 }
 
-// Tuples (currently only used in embedded existentials mode)
+// Tuples (currently only used in Embedded Swift)
 //
 namespace {
 class TupleMetadataBuilder : public TupleMetadataVisitor<TupleMetadataBuilder> {
@@ -6472,7 +6479,7 @@ void irgen::emitLazyTupleMetadata(IRGenModule &IGM, CanType tupleTy) {
                          init.finishAndCreateFuture());
 }
 
-// Functions (only used in embedded existentials mode)
+// Functions (only used in Embedded Swift)
 //
 namespace {
 class FunctionMetadataBuilder : public FunctionMetadataVisitor<FunctionMetadataBuilder> {
@@ -6531,6 +6538,127 @@ void irgen::emitLazyFunctionMetadata(IRGenModule &IGM, CanType funTy) {
                          init.finishAndCreateFuture());
 
 }
+
+// Existentials (currently only used in Embedded Swift)
+//
+namespace {
+class ExistentialMetadataBuilder : public ExistentialMetadataVisitor<ExistentialMetadataBuilder> {
+  using super = ExistentialMetadataVisitor<ExistentialMetadataBuilder>;
+
+  ConstantStructBuilder &B;
+
+protected:
+
+  using super::asImpl;
+  using super::IGM;
+  using super::Target;
+
+public:
+  ExistentialMetadataBuilder(IRGenModule &IGM, CanType existentialTy, ConstantStructBuilder &B) :
+    super(IGM, existentialTy), B(B) {}
+
+  ConstantReference emitValueWitnessTable(bool relativeReference) {
+    return irgen::emitValueWitnessTable(IGM, Target->getCanonicalType(),
+                                        false, relativeReference);
+  }
+
+  void addMetadataFlags() {
+    B.addInt(IGM.MetadataKindTy,
+             unsigned(Target->isExistentialType()
+                        ? MetadataKind::Existential
+                        : MetadataKind::ExistentialMetatype));
+  }
+
+  void addValueWitnessTable() {
+    auto vwtPointer = emitValueWitnessTable(false).getValue();
+    B.addSignedPointer(vwtPointer,
+                       IGM.getOptions().PointerAuth.ValueWitnessTable,
+                       PointerAuthEntity());
+  }
+};
+} // end anonymous namespace
+
+void irgen::emitLazyExistentialMetadata(IRGenModule &IGM, CanType existentialTy) {
+  assert(IGM.isEmbeddedWithExistentials());
+  assert(existentialTy.isAnyExistentialType());
+
+  auto &context = existentialTy->getASTContext();
+  PrettyStackTraceType stackTraceRAII(
+      context, "emitting prespecialized metadata for", existentialTy);
+
+  ConstantInitBuilder initBuilder(IGM);
+  auto init = initBuilder.beginStruct();
+  init.setPacked(true);
+
+  bool isPattern = false;
+  bool canBeConstant = true;
+
+  ExistentialMetadataBuilder builder(IGM, existentialTy, init);
+  builder.embeddedLayout();
+
+  IGM.defineTypeMetadata(existentialTy, isPattern, canBeConstant,
+                         init.finishAndCreateFuture());
+}
+
+// Metatypes (currently only used in embedded Swift)
+//
+namespace {
+class MetatypeMetadataBuilder : public MetatypeMetadataVisitor<MetatypeMetadataBuilder> {
+  using super = MetatypeMetadataVisitor<MetatypeMetadataBuilder>;
+
+  ConstantStructBuilder &B;
+
+protected:
+
+  using super::asImpl;
+  using super::IGM;
+  using super::Target;
+
+public:
+  MetatypeMetadataBuilder(IRGenModule &IGM, MetatypeType *const metatypeTy, ConstantStructBuilder &B) :
+    super(IGM, metatypeTy), B(B) {}
+
+  ConstantReference emitValueWitnessTable(bool relativeReference) {
+    return irgen::emitValueWitnessTable(IGM, Target->getCanonicalType(),
+                                        false, relativeReference);
+  }
+
+  void addMetadataFlags() {
+    B.addInt(IGM.MetadataKindTy, unsigned(MetadataKind::Metatype));
+  }
+
+  void addValueWitnessTable() {
+    auto vwtPointer = emitValueWitnessTable(false).getValue();
+    B.addSignedPointer(vwtPointer,
+                       IGM.getOptions().PointerAuth.ValueWitnessTable,
+                       PointerAuthEntity());
+  }
+};
+} // end anonymous namespace
+
+void irgen::emitLazyMetatypeMetadata(IRGenModule &IGM, CanType metatypeTy) {
+  assert(IGM.isEmbeddedWithExistentials());
+  assert(isa<MetatypeType>(metatypeTy));
+
+  auto &context = metatypeTy->getASTContext();
+  PrettyStackTraceType stackTraceRAII(
+      context, "emitting prespecialized metadata for", metatypeTy);
+
+  ConstantInitBuilder initBuilder(IGM);
+  auto init = initBuilder.beginStruct();
+  init.setPacked(true);
+
+  bool isPattern = false;
+  bool canBeConstant = true;
+
+  MetatypeMetadataBuilder builder(IGM, cast<MetatypeType>(metatypeTy), init);
+  builder.embeddedLayout();
+
+  IGM.defineTypeMetadata(metatypeTy, isPattern, canBeConstant,
+                         init.finishAndCreateFuture());
+}
+
+
 // Enums
 
 static std::optional<Size>

--- a/lib/IRGen/GenMeta.h
+++ b/lib/IRGen/GenMeta.h
@@ -116,6 +116,12 @@ namespace irgen {
   /// Emit the metadata associated with a given function type.
   void emitLazyFunctionMetadata(IRGenModule &IGM, CanType funTy);
 
+  /// Emit the metadata associated with a given existential type.
+  void emitLazyExistentialMetadata(IRGenModule &IGM, CanType existentialTy);
+
+  /// Emit the metadata associated with a given metatype type.
+  void emitLazyMetatypeMetadata(IRGenModule &IGM, CanType metatypeTy);
+
   /// Emit the metadata associated with a given instantiation of a generic
   // class.
   void emitSpecializedGenericClassMetadata(IRGenModule &IGM, CanType type,

--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -2037,6 +2037,10 @@ namespace {
       if (auto metatype = tryGetLocal(type, request))
         return metatype;
 
+      if (IGF.IGM.isEmbeddedWithExistentials()) {
+        return MetadataResponse::forComplete(IGF.IGM.getAddrOfTypeMetadata(type));
+      }
+
       auto instMetadata =
         IGF.emitAbstractTypeMetadataRef(type.getInstanceType());
 

--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -2123,6 +2123,11 @@ namespace {
     }
 
     llvm::Value *emitExistentialTypeMetadata(CanExistentialType type) {
+      if (IGF.IGM.Context.LangOpts.hasFeature(Feature::Embedded)) {
+        llvm::Constant *result = IGF.IGM.getAddrOfTypeMetadata(type);
+        return result;
+      }
+
       auto layout = type.getExistentialLayout();
 
       if (!layout.getParameterizedProtocols().empty()) {

--- a/lib/IRGen/MetatypeMetadataVisitor.h
+++ b/lib/IRGen/MetatypeMetadataVisitor.h
@@ -1,0 +1,54 @@
+//===--- MetatypeMetadataVisitor.h - CRTP for metatype metadata -*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// A CRTP class useful for laying out metatype metadata.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_IRGEN_METATYPEMETADATALAYOUT_H
+#define SWIFT_IRGEN_METATYPEMETADATALAYOUT_H
+
+#include "swift/AST/Type.h"
+
+namespace swift {
+namespace irgen {
+
+/// A CRTP class for laying out metatype metadata.
+///
+/// This produces an object corresponding to a MetatypeTypeMetadata type.
+/// It does not itself doing anything special for metadata templates.
+template <class Impl> struct MetatypeMetadataVisitor
+       : public MetadataVisitor<Impl> {
+  using super = MetadataVisitor<Impl>;
+
+protected:
+  using super::asImpl;
+
+  MetatypeType *const Target;
+
+  MetatypeMetadataVisitor(IRGenModule &IGM, MetatypeType *const target)
+    : super(IGM), Target(target) { }
+
+public:
+
+  void embeddedLayout() {
+    // The embedded layout consists of:
+    // -1 : vwt
+    //  0 : metadata flags
+    super::layout();
+  }
+};
+
+} // end namespace irgen
+} // end namespace swift
+
+#endif

--- a/lib/SILGen/SILGen.h
+++ b/lib/SILGen/SILGen.h
@@ -59,7 +59,7 @@ public:
   /// Mapping from SILDeclRefs to emitted SILFunctions.
   llvm::DenseMap<SILDeclRef, SILFunction*> emittedFunctions;
   /// Mapping from ProtocolConformances to emitted SILWitnessTables.
-  llvm::DenseMap<NormalProtocolConformance*, SILWitnessTable*> emittedWitnessTables;
+  llvm::DenseMap<RootProtocolConformance*, SILWitnessTable*> emittedWitnessTables;
 
   /// Mapping from SILDeclRefs to where the given function will be inserted
   /// when it's emitted. Used for non-externally visible symbols.
@@ -81,10 +81,10 @@ public:
   llvm::DenseSet<TypeBase *> usedConformancesFromObjectiveCTypes;
 
   /// Queue of delayed conformances that need to be emitted.
-  std::deque<NormalProtocolConformance *> pendingConformances;
+  std::deque<RootProtocolConformance *> pendingConformances;
 
   /// Set of delayed conformances that have already been forced.
-  llvm::DenseSet<NormalProtocolConformance *> forcedConformances;
+  llvm::DenseSet<RootProtocolConformance *> forcedConformances;
 
   /// Imported noncopyable types that we have seen.
   llvm::DenseSet<NominalTypeDecl *> importedNontrivialNoncopyableTypes;
@@ -389,7 +389,7 @@ public:
   void emitObjCDestructorThunk(DestructorDecl *destructor);
 
   /// Get or emit the witness table for a protocol conformance.
-  SILWitnessTable *getWitnessTable(NormalProtocolConformance *conformance);
+  SILWitnessTable *getWitnessTable(RootProtocolConformance *conformance);
 
   /// Emit a protocol witness entry point.
   SILFunction *
@@ -406,7 +406,7 @@ public:
   SILFunction *emitDefaultOverride(SILDeclRef replacement, SILDeclRef original);
 
   /// Emit the self-conformance witness table for a protocol.
-  void emitSelfConformanceWitnessTable(ProtocolDecl *protocol);
+  SILWitnessTable *emitSelfConformanceWitnessTable(ProtocolDecl *protocol);
 
   /// Emit the lazy initializer function for a global pattern binding
   /// declaration.

--- a/lib/SILGen/SILGenLazyConformance.cpp
+++ b/lib/SILGen/SILGenLazyConformance.cpp
@@ -83,27 +83,45 @@ void SILGenModule::useConformance(SILInstruction *inst,
     conformance = specialized->getGenericConformance();
   }
 
-  // Get the normal conformance. If we don't have one, this is a self
-  // conformance, which we can ignore.
-  auto normal = dyn_cast<NormalProtocolConformance>(conformance);
-  if (normal == nullptr)
+  // At this point, we should have a root conformance.
+  auto rootConformance = dyn_cast<RootProtocolConformance>(conformance);
+  if (!rootConformance)
     return;
 
-  // If this conformance was not synthesized, we're not going to be emitting
-  // it lazily either, so we can avoid doing anything below.
-  if (!normal->isSynthesized())
+  // Builtin protocol conformances don't require anything to be emitted.
+  if (isa<BuiltinProtocolConformance>(rootConformance))
     return;
+
+  // If this is a normal conformance that needs to be synthesized, we'll want
+  // to emit it.
+  if (auto normal = dyn_cast<NormalProtocolConformance>(conformance)) {
+    // If this conformance was not synthesized, we're not going to be emitting
+    // it lazily either, so we can avoid doing anything below.
+    if (!normal->isSynthesized())
+      return;
+  } else if (auto self = dyn_cast<SelfProtocolConformance>(conformance)) {
+    // Marker protocols don't need anything synthesized.
+    if (self->getProtocol()->isMarkerProtocol())
+      return;
+
+    // Only Embedded Swift defers the synthesis of this symbol.
+    if (!getASTContext().LangOpts.hasFeature(Feature::Embedded))
+      return;
+  } else {
+    // Nothing to synthesize.
+    return;
+  }
 
   // If we already emitted this witness table, we don't need to track the fact
   // we need it.
-  if (emittedWitnessTables.count(normal))
+  if (emittedWitnessTables.count(rootConformance))
     return;
 
   // Check if we already forced this witness table but haven't emitted it yet.
-  if (!forcedConformances.insert(normal).second)
+  if (!forcedConformances.insert(rootConformance).second)
     return;
 
-  pendingConformances.push_back(normal);
+  pendingConformances.push_back(rootConformance);
 }
 
 void SILGenModule::useConformancesFromSubstitutions(

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -718,13 +718,20 @@ public:
 } // end anonymous namespace
 
 SILWitnessTable *
-SILGenModule::getWitnessTable(NormalProtocolConformance *conformance) {
+SILGenModule::getWitnessTable(RootProtocolConformance *conformance) {
   // If we've already emitted this witness table, return it.
   auto found = emittedWitnessTables.find(conformance);
   if (found != emittedWitnessTables.end())
     return found->second;
 
-  SILWitnessTable *table = SILGenConformance(*this, conformance).emit();
+  SILWitnessTable *table;
+
+  if (auto normal = dyn_cast<NormalProtocolConformance>(conformance)) {
+    table = SILGenConformance(*this, normal).emit();
+  } else {
+    auto self = cast<SelfProtocolConformance>(conformance);
+    table = emitSelfConformanceWitnessTable(self->getProtocol());
+  }
   emittedWitnessTables.insert({conformance, table});
 
   return table;
@@ -1022,7 +1029,7 @@ public:
       serialized(getConformanceSerializedKind(conformance)) {
   }
 
-  void emit() {
+  SILWitnessTable *emit() {
     PrettyStackTraceConformance trace("generating SIL witness table",
                                       conformance);
 
@@ -1030,7 +1037,7 @@ public:
     visitProtocolDecl(conformance->getProtocol());
 
     // Create the witness table.
-    (void) SILWitnessTable::create(SGM.M, linkage, serialized, conformance,
+    return SILWitnessTable::create(SGM.M, linkage, serialized, conformance,
                                    entries, /*conditional*/ {}, /*specialized=*/false);
   }
 
@@ -1060,9 +1067,9 @@ public:
 };
 }
 
-void SILGenModule::emitSelfConformanceWitnessTable(ProtocolDecl *protocol) {
+SILWitnessTable *SILGenModule::emitSelfConformanceWitnessTable(ProtocolDecl *protocol) {
   auto conformance = getASTContext().getSelfConformance(protocol);
-  SILGenSelfConformanceWitnessTable(*this, conformance).emit();
+  return SILGenSelfConformanceWitnessTable(*this, conformance).emit();
 }
 
 namespace {
@@ -1474,7 +1481,10 @@ public:
         if (!SF || SF->Kind != SourceFileKind::Interface)
           SGM.emitDefaultWitnessTable(protocol);
       }
-      if (protocol->requiresSelfConformanceWitnessTable()) {
+
+      // Self-conformance witness tables are emitted lazily in Embedded Swift.
+      if (protocol->requiresSelfConformanceWitnessTable() &&
+          !SGM.getASTContext().LangOpts.hasFeature(Feature::Embedded)) {
         SGM.emitSelfConformanceWitnessTable(protocol);
       }
       return;

--- a/stdlib/public/core/Builtin.swift
+++ b/stdlib/public/core/Builtin.swift
@@ -206,8 +206,7 @@ public func != (
 }
 
 #if !$Embedded
-// Embedded Swift is unhappy about conversions from `Any.Type` to
-// `any (~Copyable & ~Escapable).Type` (rdar://145706221)
+// Embedded Swift doesn't need legacy ABI entrypoints.
 @usableFromInline
 @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
 internal func == (t0: Any.Type?, t1: Any.Type?) -> Bool {

--- a/stdlib/public/core/EmbeddedRuntime.swift
+++ b/stdlib/public/core/EmbeddedRuntime.swift
@@ -597,7 +597,26 @@ public func swift_dynamicCast(
      unsafe _swift_embedded_get_heap_object_metadata_pointer(
        UnsafeMutableRawPointer(boxPtrRaw)) == UnsafeMutableRawPointer(Builtin.addressof(&_errorMetadataStorage)) {
     // src holds a pointer to an error box. Extract the concrete type.
-    let contents = unsafe _errorBoxContents(UnsafeRawPointer(boxPtrRaw))
+    var contents = unsafe _errorBoxContents(UnsafeRawPointer(boxPtrRaw))
+
+    // When Failure == any Error, passing an error through a typed-generic continuation
+    // (e.g. AsyncThrowingStream<E, Error>) can produce a chain of error boxes where
+    // each outer box stores `any Error` (Swift.Error) and its value field holds a raw
+    // pointer to the next inner box.  Unwrap the chain until we find the concrete type
+    // or the value is no longer an error box.
+    for _ in 0..<16 {
+      if unsafe contents.type == UnsafeRawPointer(dstMetadata) { break }
+      // Read the first word of the stored value as a potential inner box pointer.
+      let innerPtr: Builtin.RawPointer = unsafe contents.value
+        .assumingMemoryBound(to: Builtin.RawPointer.self).pointee
+      let innerBits = UInt(Builtin.ptrtoint_Word(innerPtr))
+      guard innerBits != 0 &&
+            (unsafe innerBits & UInt(MemoryLayout<UnsafeRawPointer>.alignment - 1)) == 0 else { break }
+      guard unsafe _swift_embedded_get_heap_object_metadata_pointer(
+              UnsafeMutableRawPointer(innerPtr))
+            == UnsafeMutableRawPointer(Builtin.addressof(&_errorMetadataStorage)) else { break }
+      unsafe contents = unsafe _errorBoxContents(UnsafeRawPointer(innerPtr))
+    }
 
     // For class types, check the superclass chain; for value types, compare directly.
     var typeMatches = unsafe contents.type == UnsafeRawPointer(dstMetadata)

--- a/test/embedded/anyobject-error-no-stdlib.swift
+++ b/test/embedded/anyobject-error-no-stdlib.swift
@@ -16,5 +16,5 @@ public typealias AnyObject = Builtin.AnyObject
 precedencegroup AssignmentPrecedence { assignment: true }
 
 public func foo(_ x: AnyObject) {
-  _ = type(of: x) // expected-error {{cannot use a value of protocol type 'AnyObject' in embedded Swift}}
+  _ = type(of: x)
 }

--- a/test/embedded/concurrency-stream-throwing.swift
+++ b/test/embedded/concurrency-stream-throwing.swift
@@ -1,0 +1,51 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -enable-experimental-feature Embedded -parse-as-library %s -c -o %t/a.o
+// RUN: %target-clang %t/a.o %target-embedded-posix-shim -o %t/a.out -L%swift_obj_root/lib/swift/embedded/%module-target-triple %target-clang-resource-dir-opt -lswift_Concurrency %target-swift-default-executor-opt -dead_strip
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: swift_in_compiler
+// REQUIRES: optimized_stdlib
+// REQUIRES: OS=macosx || OS=wasip1
+// REQUIRES: swift_feature_Embedded
+
+import _Concurrency
+
+enum StreamError: Error {
+case numberTooBig(Int)
+}
+
+@main struct Main {
+  static func main() async {
+    let (stream, continuation) = AsyncThrowingStream.makeStream(of: String.self, throwing: Error.self)
+    Task {
+      for i in 0 ..< 10 {
+        continuation.yield("\(i)")
+      }
+      
+      continuation.finish(throwing: StreamError.numberTooBig(10))
+    }
+
+    do {
+      for try await value in stream {
+        print(value)
+      }
+      fatalError("Didn't throw")
+      // CHECK: 0
+      // CHECK: 1
+      // CHECK: 2
+      // CHECK: 3
+      // CHECK: 4
+      // CHECK: 5
+      // CHECK: 6
+      // CHECK: 7
+      // CHECK: 8
+      // CHECK: 9
+    } catch is StreamError {
+      // CHECK: Caught error
+      print("Caught error")
+    } catch {
+      fatalError("Wrong error type")
+    }
+  }
+}

--- a/test/embedded/concurrency-taskgroup.swift
+++ b/test/embedded/concurrency-taskgroup.swift
@@ -42,20 +42,51 @@ func yielding() async {
   }
 }
 
-@main struct Main {
-    static func main() async {
-        await yielding()
-        print("All done!")
-        // CHECK: One @ 0
-        // CHECK: Two @ 0
-        // CHECK: One @ 1
-        // CHECK: Two @ 1
-        // CHECK: One @ 2
-        // CHECK: Two @ 2
-        // CHECK: One @ 3
-        // CHECK: Two @ 3
-        // CHECK: One @ 4
-        // CHECK: Two @ 4
-        // CHECK: All done!
+enum HomeworkError: Error {
+case dogAteIt
+}
+
+func throwing() async throws {
+  print("Ready to throw")
+  let one = One()
+  let two = Two()
+  try await withThrowingTaskGroup(of: Int.self) { group in
+    group.addTask {
+      await one.go(times: 5)
     }
+    group.addTask {
+      throw HomeworkError.dogAteIt
+    }
+
+    _ = try await group.next()
+    _ = try await group.next()
+  }
+}
+
+@main struct Main {
+  static func main() async {
+    await yielding()
+    print("All done!")
+    // CHECK: One @ 0
+    // CHECK: Two @ 0
+    // CHECK: One @ 1
+    // CHECK: Two @ 1
+    // CHECK: One @ 2
+    // CHECK: Two @ 2
+    // CHECK: One @ 3
+    // CHECK: Two @ 3
+    // CHECK: One @ 4
+    // CHECK: Two @ 4
+    // CHECK: All done!
+
+    // CHECK: Ready to throw
+    do {
+      try await throwing()
+    } catch let error as HomeworkError {
+      // CHECK: Caught HomeworkError
+      print("Caught HomeworkError")
+    } catch {
+      fatalError("Couldn't match HomeworkError")
+    }
+  }
 }

--- a/test/embedded/metatypes-run.swift
+++ b/test/embedded/metatypes-run.swift
@@ -1,0 +1,40 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -enable-experimental-feature Embedded -parse-as-library %s -c -o %t/a.o
+// RUN: %target-clang %t/a.o %target-embedded-posix-shim -o %t/a.out -L%swift_obj_root/lib/swift/embedded/%module-target-triple %target-clang-resource-dir-opt -lswift_Concurrency %target-swift-default-executor-opt -dead_strip
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: swift_in_compiler
+// REQUIRES: optimized_stdlib
+// REQUIRES: OS=macosx || OS=wasip1
+// REQUIRES: swift_feature_Embedded
+
+public func compare (
+  _ t0: (any (~Copyable & ~Escapable).Type)?,
+  _ t1: (any (~Copyable & ~Escapable).Type)?
+) -> Bool {
+  switch (t0, t1) {
+  case (.none, .none):
+    return true
+  case let (.some(ty0), .some(ty1)):
+    // FIXME: this should just return Bool(Builtin.is_same_metatype(ty0, ty1))
+    let p1 = unsafeBitCast(ty0, to: UnsafeRawPointer.self)
+    let p2 = unsafeBitCast(ty1, to: UnsafeRawPointer.self)
+    return p1 == p2
+  default:
+    return false
+  }
+}
+
+@main
+struct Main {
+  static func main() {
+    // CHECK: Starting...
+    print("Starting...")
+    precondition(compare(Void.self, Void.self))
+    precondition(compare((Int, Float).self, (Int, Float).self))
+    precondition(!compare((Float).self, (Int, Float).self))
+    // CHECK: Done!
+    print("Done!")
+  }
+}

--- a/test/embedded/metatypes-run.swift
+++ b/test/embedded/metatypes-run.swift
@@ -32,6 +32,8 @@ struct Main {
     precondition(compare(Void.self, Void.self))
     precondition(compare((Int, Float).self, (Int, Float).self))
     precondition(!compare((Float).self, (Int, Float).self))
+    precondition(!compare((Float).Type.self, (Int, Float).self))
+    precondition(compare((any Error).Type.self, (any Error).Type.self))
     // CHECK: Done!
     print("Done!")
   }

--- a/test/embedded/metatypes-run.swift
+++ b/test/embedded/metatypes-run.swift
@@ -6,7 +6,6 @@
 // REQUIRES: executable_test
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx || OS=wasip1
 // REQUIRES: swift_feature_Embedded
 
 public func compare (
@@ -17,7 +16,6 @@ public func compare (
   case (.none, .none):
     return true
   case let (.some(ty0), .some(ty1)):
-    // FIXME: this should just return Bool(Builtin.is_same_metatype(ty0, ty1))
     let p1 = unsafeBitCast(ty0, to: UnsafeRawPointer.self)
     let p2 = unsafeBitCast(ty1, to: UnsafeRawPointer.self)
     return p1 == p2

--- a/test/embedded/typeof.swift
+++ b/test/embedded/typeof.swift
@@ -39,9 +39,13 @@ func getType<T>(of: T.Type) -> Any.Type {
 
 // CHECK-LABEL: define {{.*}}swiftcc ptr @"$e6typeof7getType2ofypXpxm_tlFSi_Sdt_Ttg5"
 // CHECK: ptr @"$eSi_SdtMf"
+
+// CHECK-LABEL: define linkonce_odr hidden swiftcc ptr @"$e6typeof7getType2ofypXpxm_tlFSd_Sdtm_Ttg5"()
+// CHECK: ptr @"$eSd_SdtmMf"
 public func readTypes() {
   _ = getType(of: Void.self)
   _ = getType(of: (Int, Double).self)
+  _ = getType(of: (Double, Double).Type.self)
 }
 
 public class C { }

--- a/test/embedded/typeof.swift
+++ b/test/embedded/typeof.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-ir -verify %s -enable-experimental-feature Embedded -wmo
+// RUN: %target-swift-emit-ir %s -enable-experimental-feature Embedded -wmo -o - | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib
@@ -6,7 +6,7 @@
 
 public func unsafeWriteArray<T, R>(_ elementType: R.Type, array: inout T, index n: Int, value: R) {
   precondition(_isPOD(elementType))
-  precondition(_isPOD(type(of: array))) // expected-error {{cannot use metatype of type '(Int, Int, Int, Int)' in embedded Swift}}
+  precondition(_isPOD(type(of: array)))
 
   return withUnsafeMutableBytes(of: &array) { ptr in
     let buffer = ptr.bindMemory(to: R.self)
@@ -20,5 +20,48 @@ public func test() {
   var args: (Int, Int, Int, Int) = (0, 0, 0, 0)
   let n = 2
   let value = 42
-  unsafeWriteArray(type(of: args.0), array: &args, index: n, value: value) // expected-note {{generic specialization called here}}
+  unsafeWriteArray(type(of: args.0), array: &args, index: n, value: value)
+}
+
+
+func getType<T>(of: T.Type) -> Any.Type {
+  return T.self
+}
+
+// Type metadata symbols
+// CHECK: @"$eytWV" = linkonce_odr hidden constant
+// CHECK: @"$eytMf" = linkonce_odr hidden constant
+// CHECK: @"$eSi_SdtWV" = linkonce_odr hidden constant
+// CHECK: @"$eSi_SdtMf" = linkonce_odr hidden constant
+
+// CHECK-LABEL: define {{.*}}swiftcc ptr @"$e6typeof7getType2ofypXpxm_tlFyt_Ttg5"
+// CHECK: ptr @"$eytMf"
+
+// CHECK-LABEL: define {{.*}}swiftcc ptr @"$e6typeof7getType2ofypXpxm_tlFSi_Sdt_Ttg5"
+// CHECK: ptr @"$eSi_SdtMf"
+public func readTypes() {
+  _ = getType(of: Void.self)
+  _ = getType(of: (Int, Double).self)
+}
+
+public class C { }
+class D: C { }
+
+func realGetType<T>(of value: T) -> Any.Type {
+  return type(of: value)
+}
+
+// CHECK-LABEL: define linkonce_odr hidden swiftcc ptr @"$e6typeof11realGetType2ofypXpx_tlFSd_Tg5"(double %0)
+// CHECK: ptr @"$eSdMf"
+
+// CHECK-LABEL: define linkonce_odr hidden swiftcc ptr @"$e6typeof11realGetType2ofypXpx_tlFAA1CC_Tg5"(ptr %0)
+// CHECK: [[ALLOCA:%.*]] = alloca ptr
+// CHECK: store ptr %0, ptr [[ALLOCA]]
+// CHECK: [[VTABLE:%.*]] = load ptr, ptr [[ALLOCA]]
+// CHECK: [[METADATA:%.*]] = load ptr, ptr [[VTABLE]]
+// CHECK: ret ptr [[METADATA]]
+
+public func readTypesWithTypeOf(c: C) {
+  _ = realGetType(of: 3.1415)
+  _ = realGetType(of: c)
 }

--- a/test/embedded/typeof.swift
+++ b/test/embedded/typeof.swift
@@ -33,6 +33,8 @@ func getType<T>(of: T.Type) -> Any.Type {
 // CHECK: @"$eytMf" = linkonce_odr hidden constant
 // CHECK: @"$eSi_SdtWV" = linkonce_odr hidden constant
 // CHECK: @"$eSi_SdtMf" = linkonce_odr hidden constant
+// CHECK: @"$eSd_SdtmMf" = linkonce_odr hidden constant
+// CHECK: @"$es5Error_pMf" = linkonce_odr hidden constant
 
 // CHECK-LABEL: define {{.*}}swiftcc ptr @"$e6typeof7getType2ofypXpxm_tlFyt_Ttg5"
 // CHECK: ptr @"$eytMf"
@@ -42,10 +44,15 @@ func getType<T>(of: T.Type) -> Any.Type {
 
 // CHECK-LABEL: define linkonce_odr hidden swiftcc ptr @"$e6typeof7getType2ofypXpxm_tlFSd_Sdtm_Ttg5"()
 // CHECK: ptr @"$eSd_SdtmMf"
+
+// CHECK-LABEL: define linkonce_odr hidden swiftcc ptr @"$e6typeof7getType2ofypXpxm_tlFs5Error_p_Ttg5"()
+// CHECK: ptr @"$es5Error_pMf"
+
 public func readTypes() {
   _ = getType(of: Void.self)
   _ = getType(of: (Int, Double).self)
   _ = getType(of: (Double, Double).Type.self)
+  _ = getType(of: (any Error).self)
 }
 
 public class C { }


### PR DESCRIPTION
- **Explanation**: Lift the restriction on the use of metatypes in Embedded Swift. With the generalization of existential types, we now have all of the infrastructure for lazily emitting type metadata, making this restriction no longer necessary.
- **Scope**: Limited to Embedded Swift, enabling functionality that was there but disabled.
- **Issues**: rdar://145706221
- **Risk**: Low due to limited scope.
- **Testing**: New tests, CI.
