### PR TITLE
Fix bug in String->Double conversion

### DIFF
--- a/stdlib/public/core/FloatingPointFromString.swift
+++ b/stdlib/public/core/FloatingPointFromString.swift
@@ -2303,21 +2303,8 @@ internal func parse_float64(_ span: Span<UInt8>) -> Optional<Float64> {
           let sdigits = sign == .minus ? -Double(digits) : Double(digits)
           return sdigits / doublePowersOf10_exact[Int(-base10Exponent)]
         }
-      } else if base10Exponent == 0 {
-        // At most 19 digits with a zero exponent, we can use
-        // a single correctly-rounded int64-to-double conversion.
-        if unparsedDigitCount == 0 {
-          switch sign {
-          case .plus:
-            return Double(digits)
-          case .minus:
-            if digits == UInt64(bitPattern: Int64.min) {
-              return Double(-Int64(truncatingIfNeeded: UInt64.max/2))
-            }
-            return Double(-Int64(truncatingIfNeeded: digits))
-          }
-        }
-      } else if unparsedDigitCount == 0 {
+      }
+      else if unparsedDigitCount == 0 {
         // At most 19 digits with a positive exponent; a little
         // prep work lets us use a single correctly-rounded FMA:
         let lowMask = UInt64(0x7ff)

--- a/test/stdlib/ParseFloat64.swift
+++ b/test/stdlib/ParseFloat64.swift
@@ -345,11 +345,15 @@ tests.test("Substring - short") {
   expectEqual(parsed!.bitPattern, (2.0).bitPattern)
 }
 
-tests.test("Int64.min") {
-  // found in rdar://174966224
-  let s = "-9223372036854775808e0"
-  let parsed = Float64(s)
-  expectEqual(parsed!, -9.2233720368547758E+18)
+tests.test("Int64.min to -1e19") {
+  expectParse("9223372036854775808e0", 9.2233720368547758E+18)
+  expectParse("-9223372036854775808e0", -9.2233720368547758E+18)
+  expectParse("9223372036854775809e0", 9.2233720368547758E+18)
+  expectParse("-9223372036854775809e0", -9.2233720368547758E+18)
+  expectParse("9999999999999999999e0", 1.0E+19)
+  expectParse("-9999999999999999999e0", -1.0E+19)
+  expectParse("10000000000000000000e0", 1.0E+19)
+  expectParse("-10000000000000000000e0", -1.0E+19)
 }
 
 tests.test("Substring - long") {


### PR DESCRIPTION
The existing code (new in 6.4) has a special case for when the exponent was zero to do a straight conversion instead of splitting the integer and doing an FMA. However, this either gave incorrect results or trapped when signed `digits` was too large to fit into an `Int64`. The old approach could be made to work without too much fuss, but we can also just let this case fall through and use the non-zero exponent path, which simplifies the code somewhat. We might want to rework all of this in the future for further performance gains, but this simplifying fix is totally straightforward and easy to take for now.

Resolves rdar://175568950

<!-- Please fill out the following form: --> 
- **Explanation**:
Eliminates a special case for String->Double conversion that introduced a bug for certain values, allowing execution to fall through into more general code that handles the special case correctly as well.
- **Scope**:
Narrowly-focused. Allows us to get the correct result for some inputs that would otherwise regress in 6.4 and produce values of the wrong sign.
- **Issues**:
rdar://175568950
- **Risk**:
Low
- **Testing**:
No special testing required; added new test cases to the stdlib tests to exercise the paths in question.