### PR TITLE
Sema: Preserve ExtInfo of SubscriptDecls, in particular isolation, when forming the opened type

### DIFF
--- a/lib/Sema/TypeOfReference.cpp
+++ b/lib/Sema/TypeOfReference.cpp
@@ -2234,12 +2234,14 @@ Type ConstraintSystem::getEffectiveOverloadType(ConstraintLocator *locator,
     };
 
     if (auto subscript = dyn_cast<SubscriptDecl>(decl)) {
-      auto elementTy = subscript->getElementInterfaceType();
+      auto *funcTy = type->castTo<AnyFunctionType>();
+      auto indices = funcTy->getParams();
 
+      auto elementTy = funcTy->getResult();
       if (doesStorageProduceLValue(subscript, overload.getBaseType(),
-                                   useDC, *this, locator))
+                                   useDC, *this, locator)) {
         elementTy = LValueType::get(elementTy);
-      else if (elementTy->hasDynamicSelfType()) {
+      } else if (elementTy->hasDynamicSelfType()) {
         elementTy = withDynamicSelfResultReplaced(elementTy);
       }
 
@@ -2249,10 +2251,7 @@ Type ConstraintSystem::getEffectiveOverloadType(ConstraintLocator *locator,
       if (subscript->getAttrs().hasAttribute<OptionalAttr>())
         elementTy = OptionalType::get(elementTy->getRValueType());
 
-      auto indices = subscript->getInterfaceType()
-                       ->castTo<AnyFunctionType>()->getParams();
-      // FIXME: Verify ExtInfo state is correct, not working by accident.
-      FunctionType::ExtInfo info;
+      auto info = funcTy->getExtInfo();
       type = adjustFunctionTypeForConcurrency(
           FunctionType::get(indices, elementTy, info), overload.getBaseType(),
           subscript, useDC, /*numApplies=*/1, /*isMainDispatchQueue=*/false,

--- a/lib/Sema/TypeOfReference.cpp
+++ b/lib/Sema/TypeOfReference.cpp
@@ -1588,17 +1588,17 @@ std::pair<Type, Type> ConstraintSystem::getOpenedStorageType(
   // If the access is mutating, wrap the storage type in an lvalue type.
   Type refType;
   if (auto *subscript = dyn_cast<SubscriptDecl>(value)) {
-    auto elementTy = subscript->getElementInterfaceType();
+    auto *funcTy = subscript->getInterfaceType()->castTo<AnyFunctionType>();
 
+    auto indices = funcTy->getParams();
+
+    auto elementTy = funcTy->getResult();
     if (doesStorageProduceLValue(subscript, baseTy, useDC, *this, locator))
       elementTy = LValueType::get(elementTy);
 
-    auto indices = subscript->getInterfaceType()
-                            ->castTo<AnyFunctionType>()->getParams();
-
     // Transfer the thrown error type into the subscript reference type,
     // which will be used in the application.
-    FunctionType::ExtInfo info;
+    auto info = funcTy->getExtInfo();
     if (thrownErrorType) {
       info = info.withThrows(true, thrownErrorType);
       thrownErrorType = Type();

--- a/test/Concurrency/isolated_parameters.swift
+++ b/test/Concurrency/isolated_parameters.swift
@@ -333,6 +333,19 @@ class ClassWithIsolatedAsyncInitializer {
     init(isolation: isolated (any Actor)? = #isolation) async {}
 }
 
+// Subscripts
+struct SubscriptTest {
+  subscript(x: isolated (any Actor)? = #isolation) -> Int { return 0 }
+}
+
+func f1(x: (any Actor)?) async {
+  _ = await SubscriptTest()[x]
+}
+
+func f2() async {
+  _ = await SubscriptTest()[]
+}
+
 // https://github.com/swiftlang/swift/issues/80992
 struct WritableActorKeyPath<Root: Actor, Value>: Sendable {
     var getter: @Sendable (isolated Root) -> Value

--- a/validation-test/compiler_crashers_fixed/FunctionType-get-8b7957.swift
+++ b/validation-test/compiler_crashers_fixed/FunctionType-get-8b7957.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","original":"cc0c34b4","signature":"swift::FunctionType::get(llvm::ArrayRef<swift::AnyFunctionType::Param>, swift::Type, std::__1::optional<swift::ASTExtInfo>)","signatureAssert":"Assertion failed: (isConsistentAboutIsolation(info, params)), function FunctionType","signatureNext":"ConstraintSystem::getEffectiveOverloadType"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 struct a {
   subscript(isolated  Actor)  String {
     a[

--- a/validation-test/compiler_crashers_fixed/FunctionType-get-a36494.swift
+++ b/validation-test/compiler_crashers_fixed/FunctionType-get-a36494.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","original":"6af182ec","signature":"swift::FunctionType::get(llvm::ArrayRef<swift::AnyFunctionType::Param>, swift::Type, std::__1::optional<swift::ASTExtInfo>)","signatureAssert":"Assertion failed: (isConsistentAboutIsolation(info, params)), function FunctionType","signatureNext":"ConstraintSystem::getOpenedStorageType"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 @propertyWrapper struct a<b> {
   wrappedValue : b  static subscript<
     c: Actor


### PR DESCRIPTION
* **Description:** A PR by a contributor exposed an existing issue that was not covered by our tests, where we would crash if a subscript had an `isolated` parameter. This was because when opening a reference to a subscript, we would form a new FunctionType with blank ExtInfo, instead of preserving the ExtInfo from the original declaration like we do when opening the type of a function. Fix this in the two places it was happening to make the behavior consistent with function declarations.

* **Risk:** Should be low since the ExtInfo for an opened function type isn't used for much other than isolation, which we now preserve.

* **Tested:** New test added.

* **Reviewed by:** @xedin 