### PR TITLE
[Concurrency][Runtime] Fix `isCurrentGlobalActorHook`.

### DIFF
--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -1076,7 +1076,7 @@ struct ConcurrencyStandardTypeDescriptors {
 /// Function that determines whether we are executing on the given global
 /// actor. The metadata is for the global actor type, and the witness table
 /// is the conformance of that type to the GlobalActor protocol.
-typedef SWIFT_CC(swift) bool (*IsCurrentGlobalActor)(SWIFT_CONTEXT const Metadata *, const Metadata *, const WitnessTable *);
+typedef SWIFT_CC(swift) bool (*IsCurrentGlobalActor)(const Metadata *, const WitnessTable *, SWIFT_CONTEXT const Metadata *);
 
 /// Register various concurrency-related data and hooks needed in the Swift
 /// standard library / runtime. This includes type descriptors with standard

--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -1076,7 +1076,7 @@ struct ConcurrencyStandardTypeDescriptors {
 /// Function that determines whether we are executing on the given global
 /// actor. The metadata is for the global actor type, and the witness table
 /// is the conformance of that type to the GlobalActor protocol.
-typedef bool (* SWIFT_CC(swift) IsCurrentGlobalActor)(const Metadata *, const WitnessTable *);
+typedef SWIFT_CC(swift) bool (*IsCurrentGlobalActor)(SWIFT_CONTEXT const Metadata *, const Metadata *, const WitnessTable *);
 
 /// Register various concurrency-related data and hooks needed in the Swift
 /// standard library / runtime. This includes type descriptors with standard

--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -1939,8 +1939,10 @@ static void swift_task_startOnMainActorImpl(AsyncTask* task) {
 // Defined in Swift, redeclared here so we can register it with the runtime.
 extern "C" SWIFT_CC(swift)
 bool _swift_task_isCurrentGlobalActor(
-  SWIFT_CONTEXT const swift::Metadata *, const swift::Metadata *,
-  const swift::WitnessTable *);
+  const swift::Metadata *,
+  const swift::WitnessTable *,
+  SWIFT_CONTEXT const swift::Metadata *
+);
 
 // Register our type descriptors with standard manglings when the concurrency
 // runtime is loaded. This allows the runtime to quickly resolve those standard

--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -1939,7 +1939,8 @@ static void swift_task_startOnMainActorImpl(AsyncTask* task) {
 // Defined in Swift, redeclared here so we can register it with the runtime.
 extern "C" SWIFT_CC(swift)
 bool _swift_task_isCurrentGlobalActor(
-    const swift::Metadata *, const swift::WitnessTable *);
+  SWIFT_CONTEXT const swift::Metadata *, const swift::Metadata *,
+  const swift::WitnessTable *);
 
 // Register our type descriptors with standard manglings when the concurrency
 // runtime is loaded. This allows the runtime to quickly resolve those standard

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -1055,9 +1055,9 @@ _findContextDescriptor(Demangle::NodePointer node,
 
 /// Function to check whether we're currently running on the given global
 /// actor.
-bool (* __ptrauth_swift_is_global_actor_function SWIFT_CC(swift)
+SWIFT_CC(swift) bool (* __ptrauth_swift_is_global_actor_function
         swift::_swift_task_isCurrentGlobalActorHook)(
-    const Metadata *, const WitnessTable *);
+    SWIFT_CONTEXT const Metadata *, const Metadata *, const WitnessTable *);
 
 void swift::_swift_registerConcurrencyRuntime(
     const ConcurrencyStandardTypeDescriptors *descriptors,

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -1057,7 +1057,7 @@ _findContextDescriptor(Demangle::NodePointer node,
 /// actor.
 SWIFT_CC(swift) bool (* __ptrauth_swift_is_global_actor_function
         swift::_swift_task_isCurrentGlobalActorHook)(
-    SWIFT_CONTEXT const Metadata *, const Metadata *, const WitnessTable *);
+    const Metadata *, const WitnessTable *, SWIFT_CONTEXT const Metadata *);
 
 void swift::_swift_registerConcurrencyRuntime(
     const ConcurrencyStandardTypeDescriptors *descriptors,

--- a/stdlib/public/runtime/Private.h
+++ b/stdlib/public/runtime/Private.h
@@ -787,9 +787,9 @@ public:
   /// Hook function that calls into the concurrency library to check whether
   /// we are currently executing the given global actor.
   SWIFT_RUNTIME_LIBRARY_VISIBILITY
-  extern bool (* __ptrauth_swift_is_global_actor_function SWIFT_CC(swift)
-                     _swift_task_isCurrentGlobalActorHook)(
-      const Metadata *, const WitnessTable *);
+  extern SWIFT_CC(swift) bool (*__ptrauth_swift_is_global_actor_function
+                               _swift_task_isCurrentGlobalActorHook)(
+      SWIFT_CONTEXT const Metadata *, const Metadata *, const WitnessTable *);
 
 } // end namespace swift
 

--- a/stdlib/public/runtime/Private.h
+++ b/stdlib/public/runtime/Private.h
@@ -789,7 +789,7 @@ public:
   SWIFT_RUNTIME_LIBRARY_VISIBILITY
   extern SWIFT_CC(swift) bool (*__ptrauth_swift_is_global_actor_function
                                _swift_task_isCurrentGlobalActorHook)(
-      SWIFT_CONTEXT const Metadata *, const Metadata *, const WitnessTable *);
+      const Metadata *, const WitnessTable *, SWIFT_CONTEXT const Metadata *);
 
 } // end namespace swift
 

--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -1640,8 +1640,8 @@ static bool swift_isInConformanceExecutionContextImpl(
     // Check whether we are running on this global actor.
     if (!_swift_task_isCurrentGlobalActorHook(
            context->globalActorIsolationType,
-           context->globalActorIsolationType,
-           context->globalActorIsolationWitnessTable))
+           context->globalActorIsolationWitnessTable,
+           context->globalActorIsolationType))
       return false;
   }
 

--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -1640,6 +1640,7 @@ static bool swift_isInConformanceExecutionContextImpl(
     // Check whether we are running on this global actor.
     if (!_swift_task_isCurrentGlobalActorHook(
            context->globalActorIsolationType,
+           context->globalActorIsolationType,
            context->globalActorIsolationWitnessTable))
       return false;
   }

--- a/test/Concurrency/issue-85134.swift
+++ b/test/Concurrency/issue-85134.swift
@@ -1,0 +1,25 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -o %t/issue-85134
+// RUN: %target-codesign %t/issue-85134
+// RUN: %target-run %t/issue-85134
+
+// REQUIRES: concurrency
+// REQUIRES: concurrency_runtime
+// REQUIRES: executable_test
+
+// UNSUPPORTED: back_deployment_runtime
+
+@globalActor
+final actor FooActor { // IMPORTANT: **final** actor
+    static let shared = FooActor()
+}
+
+protocol P {}
+struct Foo: @FooActor P {}
+
+func checkConformance() {
+    let foo = Foo()
+    let _ = foo is P // 💥 Runtime crash: EXC_BAD_ACCESS (code=1, address=0x0)
+}
+
+checkConformance()


### PR DESCRIPTION
We were crashing when using this hook function because the hook points at a Swift function, which expects `self` to be set, but we weren't telling the C compiler and so when we called through the function pointer from C++ code, the relevant register wasn't set and we'd crash.

Fixes #85134

rdar://163401438
