### PR TITLE
[SIL] Fix linkage for private protocol conformances refining public p…

### DIFF
--- a/lib/SIL/IR/SIL.cpp
+++ b/lib/SIL/IR/SIL.cpp
@@ -105,6 +105,13 @@ swift::getLinkageForProtocolConformance(const ProtocolConformance *C,
   switch (access) {
     case AccessLevel::Private:
     case AccessLevel::FilePrivate:
+      // When the conforming type is more accessible than the protocol, the
+      // conformance may be referenced from other files (e.g. a public type
+      // conforming to a file-private protocol that refines a public protocol).
+      // Use Hidden/HiddenExternal so the descriptor can be linked across
+      // compilation units. If both are (file-)private, Private is correct.
+      if (typeDecl->getEffectiveAccess() > access)
+        return (definition ? SILLinkage::Hidden : SILLinkage::HiddenExternal);
       return SILLinkage::Private;
     case AccessLevel::Internal:
       return (definition ? SILLinkage::Hidden : SILLinkage::HiddenExternal);

--- a/test/IRGen/Inputs/fileprivate_conformance_descriptor_other.swift
+++ b/test/IRGen/Inputs/fileprivate_conformance_descriptor_other.swift
@@ -1,0 +1,14 @@
+public class Outer {
+    public struct Inner: _Private {
+        public init() {}
+    }
+}
+
+private protocol _Private: AsyncSequence where Element == Int {
+}
+
+extension _Private {
+    public func makeAsyncIterator() -> AsyncStream<Int>.AsyncIterator {
+        AsyncStream<Int> { nil }.makeAsyncIterator()
+    }
+}

--- a/test/IRGen/fileprivate_conformance_descriptor.swift
+++ b/test/IRGen/fileprivate_conformance_descriptor.swift
@@ -1,0 +1,15 @@
+// RUN: %target-swift-frontend -emit-ir -primary-file %s %S/Inputs/fileprivate_conformance_descriptor_other.swift -module-name TestMod -target %target-swift-5.10-abi-triple | %FileCheck %s
+
+// REQUIRES: concurrency
+
+// Verify that the conformance descriptor for the file-private protocol is
+// emitted as an external declaration (not internal) so the linker can resolve
+// it from the other object file.
+
+// CHECK: @"$s7TestMod5OuterC5InnerVAA8_Private{{[^"]*}}Mc" = external
+
+public func exercise() async throws {
+    for try await x in Outer.Inner() {
+        _ = x
+    }
+}


### PR DESCRIPTION
…rotocols

<!--
The main branch is now in convergence, which means major changes, such as large refactoring or new features, should be avoided. This strategy is intended to maintain the stability of the Swift 6.4 release leading up to the May 4th branch. For any work that requires broad changes or introduces new features, create a feature branch and open a draft pull request. All updates to the swiftlang/swift repository’s main branch require approval from the release managers. A pull request targeting swiftlang/swift will automatically add release managers. You can also contact them via @release-managers in the forum group.
-->

<!-- Please fill out the following form: --> 
- **Explanation**: When a private protocol refines a public protocol and a public type conforms to it, the protocol conformance must be linkable across different compilation units.
  <!--
  A description of the changes. This can be brief, but it should be clear.
  -->
- **Scope**: Only affects linkage of private protocol conformance
  <!--
  An assessment of the impact and importance of the changes. For example, can
  the changes break existing code?
  -->
- **Issues**: rdar://172047418
  <!--
  References to issues the changes resolve, if any.
  -->
- **Risk**: Low. The linkage goes from private to hidden and the symbols are mangled with a file discriminator, preventing collisions, so there should be no risk of breaking existing things.
  <!--
  The (specific) risk to the release for taking the changes.
  -->
- **Testing**: Added a regression test.
  <!--
  The specific testing that has been done or needs to be done to further
  validate any impact of the changes.
  -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
