### PR TITLE
[6.3] [SIL/SILOptimizer] Fix a few issues where OptimizeHopToExecutor removed valid hops

### DIFF
--- a/include/swift/SIL/ApplySite.h
+++ b/include/swift/SIL/ApplySite.h
@@ -21,6 +21,7 @@
 #ifndef SWIFT_SIL_APPLYSITE_H
 #define SWIFT_SIL_APPLYSITE_H
 
+#include "swift/AST/ActorIsolation.h"
 #include "swift/AST/ExtInfo.h"
 #include "swift/Basic/STLExtras.h"
 #include "swift/SIL/SILArgument.h"
@@ -942,10 +943,16 @@ public:
     if (auto isolation = getIsolationCrossing();
         isolation && isolation->getCalleeIsolation())
       return isolation->getCalleeIsolation();
-    auto *calleeFunction = getCalleeFunction();
-    if (!calleeFunction)
-      return {};
-    return calleeFunction->getActorIsolation();
+    if (auto *calleeFunction = getCalleeFunction())
+      return calleeFunction->getActorIsolation();
+
+    if (auto isolatedParam =
+            getSubstCalleeType()->maybeGetIsolatedParameter()) {
+      if (isolatedParam->hasOption(SILParameterInfo::ImplicitLeading))
+        return ActorIsolation::forCallerIsolationInheriting();
+    }
+
+    return std::nullopt;
   }
 
   bool isCallerIsolationInheriting() const {

--- a/lib/SILOptimizer/FunctionSignatureTransforms/FunctionSignatureOpts.h
+++ b/lib/SILOptimizer/FunctionSignatureTransforms/FunctionSignatureOpts.h
@@ -114,6 +114,13 @@ struct ArgumentDescriptor {
   /// Returns true if all function signature opt passes are able to process
   /// this.
   bool canOptimizeLiveArg() const {
+    if (PInfo.has_value()) {
+      // Skip implicit isolation parameter for `nonisolated(nonsending)`
+      // functions because removing it would also change isolation.
+      if (PInfo->hasOption(SILParameterInfo::Flag::ImplicitLeading))
+        return false;
+    }
+
     if (Arg->getType().isObject()) {
       return true;
     }

--- a/lib/SILOptimizer/Mandatory/OptimizeHopToExecutor.cpp
+++ b/lib/SILOptimizer/Mandatory/OptimizeHopToExecutor.cpp
@@ -396,14 +396,15 @@ bool OptimizeHopToExecutor::needsExecutor(SILInstruction *inst) {
     return true;
   }
 
-  // Treat returns from a caller isolation inheriting function as requiring the
-  // liveness of hop to executors before it.
+  // Treat function exits from a caller isolation inheriting function as
+  // requiring the liveness of hop to executors before it.
   //
   // DISCUSSION: We do this since callers of callee functions with isolation
   // inheriting isolation are not required to have a hop after the return from
   // the callee function... so we have no guarantee that there isn't code in the
   // caller that needs this hop to executor to run on the correct actor.
-  if (isa<ReturnInst>(inst)) {
+  if (auto *term = dyn_cast<TermInst>(inst);
+      term && term->isFunctionExiting()) {
     if (auto isolation = inst->getFunction()->getActorIsolation();
         isolation && isolation->isCallerIsolationInheriting()) {
       return true;

--- a/test/Concurrency/Runtime/nonisolated_nonsending_hop_to_executor_throws.swift
+++ b/test/Concurrency/Runtime/nonisolated_nonsending_hop_to_executor_throws.swift
@@ -1,0 +1,151 @@
+// RUN: %target-run-simple-swift | %FileCheck %s
+// RUN: %target-run-simple-swift(-enable-upcoming-feature NonisolatedNonsendingByDefault) | %FileCheck %s
+
+// REQUIRES: concurrency
+// REQUIRES: concurrency_runtime
+// REQUIRES: executable_test
+// REQUIRES: swift_feature_NonisolatedNonsendingByDefault
+
+// UNSUPPORTED: freestanding
+
+// Regression tests for: https://github.com/swiftlang/swift/issues/88259
+//
+// Verifies that nonisolated(nonsending) functions that throw correctly
+// hop back to the caller's executor before exiting.
+
+protocol ErrorFactory: Error {
+  static func make() -> Self
+}
+
+struct SomeError: ErrorFactory {
+  static func make() -> SomeError { SomeError() }
+}
+
+@concurrent func asyncThrows_throw() async throws {
+  throw SomeError()
+}
+
+@concurrent func asyncTypedThrows_throw() async throws(SomeError) {
+  throw SomeError()
+}
+
+@concurrent func asyncTypedThrowsGeneric_throw<E: ErrorFactory>(_: E.Type = E.self) async throws(E) {
+  throw E.make()
+}
+
+@concurrent func asyncThrows_nothrow() async throws {}
+
+@concurrent func asyncTypedThrows_nothrow() async throws(SomeError) {}
+
+@concurrent func asyncTypedThrowsGeneric_nothrow<E: Error>(_: E.Type = E.self) async throws(E) {}
+
+// MARK: - forwarding wrappers
+
+func callThrows_throw() async throws {
+  try await asyncThrows_throw()
+}
+
+func callTypedThrows_throw() async throws(SomeError) {
+  try await asyncTypedThrows_throw()
+}
+
+func callGenericTypedThrows_throw<E: ErrorFactory>(_ e: E.Type = E.self) async throws(E) {
+  try await asyncTypedThrowsGeneric_throw(e)
+}
+
+func callThrows_nothrow() async throws {
+  try await asyncThrows_nothrow()
+}
+
+func callTypedThrows_nothrow() async throws(SomeError) {
+  try await asyncTypedThrows_nothrow()
+}
+
+func callGenericTypedThrows_nothrow<E: Error>(_ e: E.Type = E.self) async throws(E) {
+  try await asyncTypedThrowsGeneric_nothrow(e)
+}
+
+// MARK: - Tests
+
+@MainActor
+func test_callThrows_throw() async {
+  // CHECK: callThrows_throw: caught on main
+  do {
+    try await callThrows_throw()
+    fatalError("should have thrown")
+  } catch {
+    MainActor.preconditionIsolated("should be on main")
+    print("callThrows_throw: caught on main")
+  }
+}
+
+@MainActor
+func test_callTypedThrows_throw() async {
+  // CHECK: callTypedThrows_throw: caught on main
+  do {
+    try await callTypedThrows_throw()
+    fatalError("should have thrown")
+  } catch {
+    MainActor.preconditionIsolated("should be on main")
+    print("callTypedThrows_throw: caught on main")
+  }
+}
+
+@MainActor
+func test_callGenericTypedThrows_throw() async {
+  // CHECK: callGenericTypedThrows_throw: caught on main
+  do {
+    try await callGenericTypedThrows_throw(SomeError.self)
+    fatalError("should have thrown")
+  } catch {
+    MainActor.preconditionIsolated("should be on main")
+    print("callGenericTypedThrows_throw: caught on main")
+  }
+}
+
+@MainActor
+func test_callThrows_nothrow() async {
+  // CHECK: callThrows_nothrow: return on main
+  do {
+    try await callThrows_nothrow()
+    MainActor.preconditionIsolated("should be on main")
+    print("callThrows_nothrow: return on main")
+  } catch {
+    fatalError("should not throw")
+  }
+}
+
+@MainActor
+func test_callTypedThrows_nothrow() async {
+  // CHECK: callTypedThrows_nothrow: return on main
+  do {
+    try await callTypedThrows_nothrow()
+    MainActor.preconditionIsolated("should be on main")
+    print("callTypedThrows_nothrow: return on main")
+  } catch {
+    fatalError("should not throw")
+  }
+}
+
+@MainActor
+func test_callGenericTypedThrows_nothrow() async {
+  // CHECK: callGenericTypedThrows_nothrow: return on main
+  do {
+    try await callGenericTypedThrows_nothrow(SomeError.self)
+    MainActor.preconditionIsolated("should be on main")
+    print("callGenericTypedThrows_nothrow: return on main")
+  } catch {
+    fatalError("should not throw")
+  }
+}
+
+@MainActor func run() async {
+  await test_callThrows_throw()
+  await test_callTypedThrows_throw()
+  await test_callGenericTypedThrows_throw()
+  await test_callThrows_nothrow()
+  await test_callTypedThrows_nothrow()
+  await test_callGenericTypedThrows_nothrow()
+}
+
+await run()

--- a/test/Concurrency/nonisolated_nonsending.swift
+++ b/test/Concurrency/nonisolated_nonsending.swift
@@ -26,6 +26,7 @@ func testPartialApplication(p: [any P]) async {
 //   Reabstraction thunk from caller-isolated () -> () to caller-isolated () -> T
 // CHECK-LABEL: sil shared [transparent] [reabstraction_thunk] @$sBAIeghHgIL_BAytIeghHgILr_TR : $@convention(thin) @Sendable @async (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, @guaranteed @Sendable @async @callee_guaranteed (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor) -> ()) -> @out () {
 // CHECK:       bb0(%0 : $*(), %1 : $Builtin.ImplicitActor, %2 : $@Sendable @async @callee_guaranteed (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor) -> ()):
+// CHECK-NEXT:    hop_to_executor %1
 // CHECK-NEXT:    apply %2(%1) :
 
 func takesGenericAsyncFunction<T>(_ fn: nonisolated(nonsending) (T) async -> Void) {}
@@ -44,6 +45,7 @@ func testReabstractionPreservingCallerIsolation(fn: nonisolated(nonsending) (Int
 // CHECK-LABEL: sil shared [transparent] [reabstraction_thunk] @$sBASiIgHgILy_BASiIegHgILn_TR : $@convention(thin) @async (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, @in_guaranteed Int, @guaranteed @noescape @async @callee_guaranteed (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, Int) -> ()) -> () {
 // CHECK:       bb0(%0 : $Builtin.ImplicitActor, %1 : $*Int, %2 : $@noescape @async @callee_guaranteed (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, Int) -> ()):
 // CHECK-NEXT:    %3 = load %1
+// CHECK-NEXT:    hop_to_executor %0
 // CHECK-NEXT:    apply %2(%0, %3)
 
 func takesAsyncIsolatedAnyFunction(_ fn: @isolated(any) () async -> Void) {}

--- a/test/Concurrency/nonisolated_nonsending_optimize_hoptoexecutor.swift
+++ b/test/Concurrency/nonisolated_nonsending_optimize_hoptoexecutor.swift
@@ -28,3 +28,55 @@ public func caller() async {
   await test2()
   await test3()
 }
+
+// Regression test for: https://github.com/swiftlang/swift/issues/88259
+
+@inline(never)
+nonisolated func asyncThrows() async throws {}
+
+// CHECK-LABEL: sil hidden @$s4test0A7GH88259yyYaKF : $@convention(thin) @async (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor) -> @error any Error
+// CHECK: try_apply {{.*}} normal [[NORMALBB:bb[0-9]+]], error [[ERRORBB:bb[0-9]+]]
+// CHECK: [[NORMALBB]]
+// CHECK: hop_to_executor
+// CHECK: return
+// CHECK: [[ERRORBB]]
+// CHECK: hop_to_executor
+// CHECK: throw
+// CHECK: } // end sil function '$s4test0A7GH88259yyYaKF'
+nonisolated(nonsending) func testGH88259() async throws {
+  try await asyncThrows()
+}
+
+struct SomeError: Error {}
+
+@inline(never)
+nonisolated func asyncThrowsTyped() async throws(SomeError) {}
+
+// CHECK-LABEL: sil hidden @$s4test0A12GH88259TypedyyYaAA9SomeErrorVYKF : $@convention(thin) @async (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor) -> @error SomeError
+// CHECK: try_apply {{.*}} normal [[NORMALBB:bb[0-9]+]], error [[ERRORBB:bb[0-9]+]]
+// CHECK: [[NORMALBB]]
+// CHECK: hop_to_executor
+// CHECK: return
+// CHECK: [[ERRORBB]]
+// CHECK: hop_to_executor
+// CHECK: throw
+// CHECK: } // end sil function '$s4test0A12GH88259TypedyyYaAA9SomeErrorVYKF'
+nonisolated(nonsending) func testGH88259Typed() async throws(SomeError) {
+  try await asyncThrowsTyped()
+}
+
+@inline(never)
+nonisolated func asyncThrowsGeneric<E: Error>(_ error: E.Type = E.self) async throws(E) {}
+
+// CHECK-LABEL: sil hidden @$s4test0A14GH88259GenericyyxYaxYKs5ErrorRzlF : $@convention(thin) @async <E where E : Error> (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, @in_guaranteed E) -> @error_indirect E
+// CHECK: try_apply {{.*}} normal [[NORMALBB:bb[0-9]+]], error [[ERRORBB:bb[0-9]+]]
+// CHECK: [[NORMALBB]]
+// CHECK: hop_to_executor
+// CHECK: return
+// CHECK: [[ERRORBB]]
+// CHECK: hop_to_executor
+// CHECK: throw_addr
+// CHECK: } // end sil function '$s4test0A14GH88259GenericyyxYaxYKs5ErrorRzlF'
+nonisolated(nonsending) func testGH88259Generic<E: Error>(_ error: E) async throws(E) {
+  try await asyncThrowsGeneric(E.self)
+}

--- a/test/Interpreter/pound_isolation_with_nonisolated_nonsending_parameter.swift
+++ b/test/Interpreter/pound_isolation_with_nonisolated_nonsending_parameter.swift
@@ -1,0 +1,37 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift  -target %target-swift-5.1-abi-triple %s -parse-as-library -module-name main -o %t/main
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main | %FileCheck %s
+
+// REQUIRES: concurrency
+// REQUIRES: concurrency_runtime
+// REQUIRES: executable_test
+
+// UNSUPPORTED: back_deployment_runtime
+
+// https://github.com/swiftlang/swift/issues/86083
+
+actor MyActor {
+  func test(_ closure: nonisolated(nonsending) () async -> Void) async {
+    await closure()
+  }
+}
+
+nonisolated func test() async {
+  let a = MyActor()
+
+  await a.test {
+    let iso = #isolation
+    // CHECK: Optional(main.MyActor)
+    print(iso as Any)
+    assert(iso === a)
+    iso!.assertIsolated()
+    a.assertIsolated()
+  }
+}
+
+@main struct Main {
+  static func main() async {
+    await test()
+  }
+}

--- a/test/SILOptimizer/optimize_hop_to_executor.sil
+++ b/test/SILOptimizer/optimize_hop_to_executor.sil
@@ -14,6 +14,8 @@ actor MyActor {
 
 sil [ossa] @requiredToRunOnActor : $@convention(method) (@guaranteed MyActor) -> ()
 sil [ossa] @anotherAsyncFunction : $@convention(thin) @async () -> ()
+sil [ossa] @asyncThrowingFunction : $@convention(thin) @async () -> @error any Error
+
 sil [ossa] @syncFunction : $@convention(thin) () -> ()
 
 // CHECK-LABEL: sil [ossa] @simpleRedundantActor : $@convention(method) @async (@guaranteed MyActor) -> () {
@@ -436,4 +438,29 @@ bb0(%0 : @guaranteed $MyActor, %1 : @guaranteed $MyActor, %2 : @guaranteed $MyAc
   hop_to_executor %0
   %9999 = tuple ()
   return %9999 : $()
+}
+
+// https://github.com/swiftlang/swift/issues/88259
+
+// CHECK-LABEL: sil [isolation "caller_isolation_inheriting"] [ossa] @callerIsolationInheritingPreservesHopBeforeThrow : $@convention(thin) @async (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor) -> @error any Error {
+// CHECK: bb1
+// CHECK:   hop_to_executor
+// CHECK:   return
+// CHECK: bb2
+// CHECK:   hop_to_executor
+// CHECK:   throw
+// CHECK: } // end sil function 'callerIsolationInheritingPreservesHopBeforeThrow'
+sil [isolation "caller_isolation_inheriting"] [ossa] @callerIsolationInheritingPreservesHopBeforeThrow : $@convention(thin) @async (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor) -> @error any Error {
+bb0(%0 : @guaranteed $Builtin.ImplicitActor):
+  %f = function_ref @asyncThrowingFunction : $@convention(thin) @async () -> @error any Error
+  try_apply %f() : $@convention(thin) @async () -> @error any Error, normal bb1, error bb2
+
+bb1(%result : $()):
+  hop_to_executor %0 : $Builtin.ImplicitActor
+  %ret = tuple ()
+  return %ret: $()
+
+bb2(%error : @owned $any Error):
+  hop_to_executor %0 : $Builtin.ImplicitActor
+  throw %error : $any Error
 }


### PR DESCRIPTION
<!--
The main branch is now in convergence, which means major changes, such as large refactoring or new features, should be avoided. This strategy is intended to maintain the stability of the Swift 6.4 release leading up to the May 4th branch. For any work that requires broad changes or introduces new features, create a feature branch and open a draft pull request. All updates to the swiftlang/swift repository’s main branch require approval from the release managers. A pull request targeting swiftlang/swift will automatically add release managers. You can also contact them via @release-managers in the forum group.
-->

<!-- Please fill out the following form: --> 
- **Explanation**:
  
  Fixes a few issues related to `OptimizeHopExecutor` has that removes valid hops in some situations which open up holes in concurrency model, this is a regression from 6.2 that went unnoticed for some time. 

  Incorporates a significantly slimmed down version of https://github.com/swiftlang/swift/pull/88404 (which detects whether function is `nonisolated(nonsending)` by checking whether it has a leading isolation parameter) and https://github.com/swiftlang/swift/pull/88285.

- **Scope**:

  The changes are very important for `nonisolated(nonsending)` because it prevents invalid runtime behavior when error is thrown from a `nonisolated(nonsending)` or when `nonisolated(nonsending)` function value is called when it comes from a parameter. The change also prevents function signature optimization from dropping leading isolation parameter.

- **Issues**:

  -rdar://175173376

- **Risk**:
 
  Low, the change here is reduced for minimal risk from the original main change. It only affects calls to `nonisolated(nonsending)` functions and throws statements inside of them.

- **Testing**:
  
  Added new test-cases into the Concurrency and SILOptimizer suites.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
