### PR TITLE
[IRGen] Disable SimplifyCFG within CoroCleanup at -Onone

### DIFF
--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -408,6 +408,18 @@ void swift::performLLVMOptimizations(
                               Opts.VerifyEach, PrintPassOpts);
   SI.registerCallbacks(PIC, &MAM);
 
+  // At -Onone, skip SimplifyCFG to preserve debug line info.
+  // SimplifyCFG is added by the CoroSplitter to cleanup async functions and
+  // coroutines, but it loses debug locations.
+  // Clang avoids this by setting optnone on all functions at -O0, but
+  // Swift cannot use optnone as we need mandatory inlining.
+  if (!Opts.shouldOptimize()) {
+    PIC.registerShouldRunOptionalPassCallback(
+        [](StringRef PassID, Any IR) {
+          return !PassID.contains("SimplifyCFGPass");
+        });
+  }
+
   PassBuilder PB(TargetMachine, PTO, PGOOpt, &PIC, FS);
 
   // Attempt to load pass plugins and register their callbacks with PB.

--- a/test/DebugInfo/async-let.swift
+++ b/test/DebugInfo/async-let.swift
@@ -1,6 +1,8 @@
 // RUN: %target-swift-frontend %s -emit-ir -g -o - \
 // RUN:    -module-name M  -target %target-swift-5.1-abi-triple \
-// RUN:    -parse-as-library | %FileCheck %s --check-prefix=CHECK
+// RUN:    -parse-as-library \
+// RUN:    | %swift-llvm-opt -passes=unreachableblockelim \
+// RUN:    | %FileCheck %s --check-prefix=CHECK
 
 // REQUIRES: concurrency
 // REQUIRES: CPU=x86_64 || CPU=arm64

--- a/test/DebugInfo/async-simplifycfg-debugloc.swift
+++ b/test/DebugInfo/async-simplifycfg-debugloc.swift
@@ -1,0 +1,23 @@
+// RUN: %target-swift-frontend %s -emit-ir -g -Onone -o - \
+// RUN:    -module-name M -disable-availability-checking \
+// RUN:    -parse-as-library | %FileCheck %s
+
+// REQUIRES: concurrency
+
+// Verify that the early return inside an async function retains a real
+// instruction at its debug location.
+
+func fib(_ n: Int) async -> Int {
+  if n < 2 {
+    // CHECK-DAG: ![[RET_LOC:[0-9]+]] = !DILocation(line: [[@LINE+2]],
+    // CHECK-DAG: br label {{.*}}, !dbg ![[RET_LOC]]
+    return 1
+  }
+  let task1 = Task {
+    return await fib(n - 1)
+  }
+  let task2 = Task {
+    return await fib(n - 2)
+  }
+  return await task1.value + task2.value
+}

--- a/test/DebugInfo/move_function_dbginfo_async.swift
+++ b/test/DebugInfo/move_function_dbginfo_async.swift
@@ -106,7 +106,6 @@ public func letSimpleTest<T>(_ msg: __owned T) async {
 // CHECK:   #dbg_value(ptr %{{[0-9]+}}, !{{[0-9]+}}, !DIExpression(DW_OP_LLVM_entry_value, 1, DW_OP_deref, DW_OP_plus_uconst, 24, DW_OP_deref, DW_OP_deref)
 // CHECK: musttail call swifttailcc void @swift_task_switch(ptr swiftasync %{{[0-9]+}}, ptr @"$s27move_function_dbginfo_async13varSimpleTestyyxz_xtYalFTY1_", i64 0, i64 0)
 // CHECK-NEXT: ret void
-// CHECK-NEXT: }
 //
 // CHECK-LABEL: define internal swifttailcc void @"$s27move_function_dbginfo_async13varSimpleTestyyxz_xtYalFTY1_"(ptr swiftasync %0)
 // CHECK: entryresume.1:
@@ -114,7 +113,6 @@ public func letSimpleTest<T>(_ msg: __owned T) async {
 // CHECK:   #dbg_value(ptr undef, ![[METADATA]], !DIExpression(DW_OP_deref), ![[ADDR_LOC]]
 // CHECK:   musttail call swifttailcc void @"$s27move_function_dbginfo_async10forceSplityyYaF"(ptr swiftasync
 // CHECK-NEXT: ret void
-// CHECK-NEXT: }
 //
 // CHECK-LABEL: define internal swifttailcc void @"$s27move_function_dbginfo_async13varSimpleTestyyxz_xtYalFTQ2_"(ptr swiftasync %0)
 // CHECK: entryresume.2:
@@ -126,7 +124,6 @@ public func letSimpleTest<T>(_ msg: __owned T) async {
 // CHECK:   #dbg_value(ptr %{{[0-9]+}}, ![[METADATA]], !DIExpression(DW_OP_LLVM_entry_value, 1, DW_OP_plus_uconst, 24, DW_OP_deref, DW_OP_deref), ![[ADDR_LOC]]
 // CHECK: musttail call swifttailcc void @"$s27move_function_dbginfo_async10forceSplityyYaF"(
 // CHECK-NEXT:   ret void
-// CHECK-NEXT: }
 //
 // RUN: %llvm-dwarfdump -c --name='$s3out13varSimpleTestyyxz_xtYalF' %t/out.o | %FileCheck -check-prefix=DWARF4 %s
 // DWARF4: DW_AT_linkage_name	("$s3out13varSimpleTestyyxz_xtYalF")
@@ -315,11 +312,10 @@ public func varSimpleTestVar() async {
 // CHECK:  #dbg_value(ptr %{{[0-9]+}}, !{{[0-9]+}}, !DIExpression(DW_OP_LLVM_entry_value, 1, DW_OP_deref, DW_OP_plus_uconst, 24, DW_OP_deref, DW_OP_deref),
 // CHECK:  musttail call swifttailcc void @swift_task_switch(ptr swiftasync %{{[0-9]+}}, ptr @"$s27move_function_dbginfo_async20letArgCCFlowTrueTestyyxnYalFTY1_", i64 0, i64 0)
 // CHECK-NEXT: ret void
-// CHECK-NEXT: }
 
 // CHECK-LABEL: define internal swifttailcc void @"$s27move_function_dbginfo_async20letArgCCFlowTrueTestyyxnYalFTY1_"(
 // CHECK: #dbg_value(ptr %{{[0-9]+}}, ![[METADATA:[0-9]*]], !DIExpression(DW_OP_LLVM_entry_value, 1, DW_OP_plus_uconst, 24, DW_OP_deref, DW_OP_deref), ![[ADDR_LOC:[0-9]*]]
-// CHECK:    br i1 %{{[0-9]}}, label %[[LHS_BLOCK:[a-zA-Z\.0-9]*]], label %[[RHS_BLOCK:[a-zA-Z\.0-9]*]],
+// CHECK:    br i1 %{{[0-9]+}}, label %[[LHS_BLOCK:[a-zA-Z\.0-9]*]], label %[[RHS_BLOCK:[a-zA-Z\.0-9]*]],
 //
 // CHECK: [[LHS_BLOCK]]:
 // CHECK:  #dbg_value(ptr undef, ![[METADATA]], !DIExpression(DW_OP_deref), ![[ADDR_LOC]]
@@ -348,7 +344,6 @@ public func varSimpleTestVar() async {
 // CHECK-NEXT:  #dbg_value(ptr undef, ![[msg_var]]
 // CHECK:   musttail call swifttailcc void @"$s27move_function_dbginfo_async11forceSplit4yyYaF"(
 // CHECK-NEXT:   ret void,
-// CHECK-NEXT: }
 //
 // This is the continuation block
 // CHECK-LABEL: define internal swifttailcc void @"$s27move_function_dbginfo_async20letArgCCFlowTrueTestyyxnYalFTQ4_"(
@@ -494,7 +489,6 @@ public func letArgCCFlowTrueTest<T>(_ msg: __owned T) async {
 // CHECK-NOT: #dbg_value(
 // CHECK:  musttail call swifttailcc void %{{[0-9]+}}(ptr swiftasync
 // CHECK-NEXT:  ret void,
-// CHECK-NEXT: }
 
 // RUN: %llvm-dwarfdump -c --name='$s3out20varArgCCFlowTrueTestyyxzYaAA1PRzlF' %t/out.o | %FileCheck -check-prefix=DWARF24 %s
 // DWARF24: DW_AT_linkage_name	("$s3out20varArgCCFlowTrueTestyyxzYaAA1PRzlF")


### PR DESCRIPTION
- **Explanation**: SimplifyCFG being run at -Onone causes a loss of debug locations within swift async functions. Some branch instructions can be optimised away and will cause stepping through an async function unreliable.
  <!--
  A description of the changes. This can be brief, but it should be clear.
  -->
- **Scope**: Changes IRGen to disable SimplifyCFG at -Onone. This might slightly regress the performance of swift async functions at -Onone.
  <!--
  An assessment of the impact and importance of the changes. For example, can
  the changes break existing code?
  -->
- **Issues**: rdar://152449680 
  <!--
  References to issues the changes resolve, if any.
  -->
- **Risk**: This might slightly regress the performance of swift async functions at -Onone. LLVM CodeGen already calls UnreachableBlockElim before ISel which covers most of what SimplifyCFG was used for.
  <!--
  The (specific) risk to the release for taking the changes.
  -->
- **Testing**: A test has been added for the resolved issue.
  <!--
  The specific testing that has been done or needs to be done to further
  validate any impact of the changes.
  -->
