### PR TITLE
[SILOptimizer]: Improve DI handling of lets & struct self-assigns

### DIFF
--- a/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
+++ b/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
@@ -1535,10 +1535,51 @@ void LifetimeChecker::handleStoreUse(unsigned UseID) {
     return;
   }
 
+  // Check for instructions that are assignments to the memory location being
+  // analyzed. This is used to suppress diagnostics that would otherwise be
+  // produced when fully-assigning to a struct `self` in init where a `let`
+  // property has already been assigned, and for certain compatibility
+  // diagnostics when initializing structs across module boundaries.
+  auto isFullValueAssignment = [this](const SILInstruction *inst) -> bool {
+    SILValue addr;
+    if (auto *copyAddr = dyn_cast<CopyAddrInst>(inst))
+      addr = copyAddr->getDest();
+    else if (auto *moveAddr = dyn_cast<MarkUnresolvedMoveAddrInst>(inst))
+      addr = moveAddr->getDest();
+    else if (auto *assign = dyn_cast<AssignInst>(inst))
+      addr = assign->getDest();
+    else
+      return false;
+
+    if (auto *access = dyn_cast<BeginAccessInst>(addr))
+      addr = access->getSource();
+    if (auto *projection = dyn_cast<ProjectBoxInst>(addr))
+      addr = projection->getOperand();
+
+    return addr == TheMemory.getUninitializedValue();
+  };
+
+  auto isFullValueStructInitAssignment = [&](const DIMemoryUse &Use) -> bool {
+    if (TheMemory.isStructInitSelf() && isFullValueAssignment(Use.Inst)) {
+      ASSERT(
+          Use.FirstElement == 0 &&
+          Use.NumElements == TheMemory.getNumElements() &&
+          "expected full-value store to struct self to produce a use of every "
+          "element");
+      return true;
+    }
+
+    return false;
+  };
+
   // If this is a store to a 'let' property in an initializer, then we only
   // allow the assignment if the property was completely uninitialized.
-  // Overwrites are not permitted.
-  if (Use.Kind == DIUseKind::PartialStore || !isFullyUninitialized) {
+  // Overwrites of an initialized `let` property are not permitted. However,
+  // if we're performing a full-element store to `self` in a `struct`
+  // initializer, then the assignment is permitted, since this replaces the
+  // entire aggregate, and doesn't re-assign existing elements.
+  if ((Use.Kind == DIUseKind::PartialStore || !isFullyUninitialized) &&
+      !isFullValueStructInitAssignment(Use)) {
     for (unsigned i = Use.FirstElement, e = i+Use.NumElements;
          i != e; ++i) {
       if (Liveness.get(i) == DIKind::No || !TheMemory.isElementLetProperty(i))
@@ -1569,25 +1610,6 @@ void LifetimeChecker::handleStoreUse(unsigned UseID) {
   // than DelegatingSelf for Swift 4 compatibility. We look for a problem case by
   // seeing if there are any assignments to individual fields that might be
   // initializations; that is, that they're not dominated by `self = other`.
-
-  auto isFullValueAssignment = [this](const SILInstruction *inst) -> bool {
-    SILValue addr;
-    if (auto *copyAddr = dyn_cast<CopyAddrInst>(inst))
-      addr = copyAddr->getDest();
-    else if (auto *moveAddr = dyn_cast<MarkUnresolvedMoveAddrInst>(inst))
-      addr = moveAddr->getDest();
-    else if (auto *assign = dyn_cast<AssignInst>(inst))
-      addr = assign->getDest();
-    else
-      return false;
-
-    if (auto *access = dyn_cast<BeginAccessInst>(addr))
-      addr = access->getSource();
-    if (auto *projection = dyn_cast<ProjectBoxInst>(addr))
-      addr = projection->getOperand();
-
-    return addr == TheMemory.getUninitializedValue();
-  };
 
   if (!isFullyInitialized && WantsCrossModuleStructInitializerDiagnostic &&
       !isFullValueAssignment(Use.Inst)) {

--- a/test/SILOptimizer/definite_init_cross_module_swift4.swift
+++ b/test/SILOptimizer/definite_init_cross_module_swift4.swift
@@ -75,7 +75,9 @@ extension ImmutablePoint {
 
   init(other: ImmutablePoint, xx: Double) {
     self.x = xx // expected-warning {{initializer for struct 'ImmutablePoint' must use "self.init(...)" or "self = ..." because it is not in module 'OtherModule'}}
-    self = other // expected-error {{immutable value 'self.x' may only be initialized once}}
+    // A subsequent whole-self overwrite is now permitted: it replaces the
+    // entire value, rather than re-initializing the already-written `let`.
+    self = other
   }
 
   init(other: ImmutablePoint, x: Double, cond: Bool) {

--- a/test/SILOptimizer/definite_init_value_types_diagnostics.swift
+++ b/test/SILOptimizer/definite_init_value_types_diagnostics.swift
@@ -91,3 +91,144 @@ struct InitLogicalUseBeforeDef {
     offset = UInt16(value)
   }
 }
+
+// Cases motivated by:
+// https://forums.swift.org/t/value-semantics-of-init-with-defaulted-private-let-fields-does-not-make-sense/86193/
+// Full self assignment of structs within their initializers should not trigger
+// errors if `let` fields have already been initialized.
+
+struct PaddedLet {
+  let x: Int
+  private let padding: Int = 0
+  init(x: Int) { self.x = x }
+}
+
+extension PaddedLet {
+  init() {
+    // `padding` is default-initialized here, but a full self-assign should
+    // not complain about that.
+    self = .init(x: 0)
+  }
+
+  // Multiple whole-self overwrites are allowed.
+  init(twice: Bool) {
+    self = .init(x: 0)
+    self = .init(x: 1)
+  }
+}
+
+struct AllLet {
+  let x: Int // expected-note {{change 'let' to 'var' to make it mutable}} {{3-6=var}}
+  let y: Int
+
+  init(x: Int, y: Int) {
+    self.x = x
+    self.y = y
+  }
+}
+
+extension AllLet {
+  // Whole-self overwrite after element-level init is permitted.
+  init(rebuild xx: Int) {
+    self.x = xx
+    self.y = 0
+    self = .init(x: 0, y: 0)
+  }
+
+  // Partial init followed by whole-self overwrite is allowed.
+  init(partialInit z: Int) {
+    self.x = z
+    self = .init(x: 1, y: 2)
+  }
+
+  // Element-level overwrite of a `let` after `self = ...` is still rejected.
+  init(other: AllLet, x: Int) {
+    self = other
+    self.x = x // expected-error {{immutable value 'self.x' may only be initialized once}}
+  }
+}
+
+struct NestedLet {
+  let tup: (Int, (Bool, String?)) // expected-note {{change 'let' to 'var' to make it mutable}} {{3-6=var}}
+  var mut = 0
+}
+
+extension NestedLet {
+  init(zzz: Void) {
+    self.tup.1.0 = true
+    self = .init(tup: (1, (true, nil)), mut: 1)
+    self.tup.1.0 = false // expected-error {{immutable value 'self.tup.1.0' may only be initialized once}}
+  }
+}
+
+// Composes with move-only checking.
+
+struct Resource: ~Copyable {
+  let x: Int
+  var mut: Int = 0
+  private let padding: Int = 0
+  init(x: Int) { self.x = x }
+}
+
+extension Resource {
+  init() {
+    self = .init(x: 0)
+  }
+
+  init(z: Int) {
+    self.x = z
+    self = .init(x: z)
+  }
+
+  init(multiInit x: consuming Resource, y: consuming Resource) {
+    self.mut = 1
+    self = x
+    self.mut = 2
+    self = y
+    self.mut = 3
+  }
+}
+
+// Failable and throwing initializers should have analogous diagnostic behavior
+
+struct Fallible {
+  let x: Int
+  private let padding: Int = 0
+  init(x: Int) { self.x = x }
+}
+
+extension Fallible {
+  init?(maybe x: Int?) {
+    guard let x else { return nil }
+    self = .init(x: x)
+  }
+
+  init?(cond: Bool, x: Int) {
+    if cond {
+      self = .init(x: x)
+    } else {
+      return nil
+    }
+  }
+}
+
+struct Throwing {
+  let x: Int
+  private let padding: Int = 0
+  init(x: Int) { self.x = x }
+
+  static func makeOrThrow(x: Int) throws -> Throwing {
+    return .init(x: x)
+  }
+}
+
+extension Throwing {
+  init(rethrowing x: Int) throws {
+    self = try Self.makeOrThrow(x: x)
+  }
+
+  init(rethrowingTwice x: Int) throws {
+    self = try Self.makeOrThrow(x: x)
+    self = try Self.makeOrThrow(x: x + 1)
+  }
+}


### PR DESCRIPTION
Previously DI would error if a struct initializer initialized a `let` property and subsequently re-assigned `self` to a new value. This change adds logic to test for such assigments and suppress the error that used to be produced.

Resolves: https://github.com/swiftlang/swift/issues/88619

