### PR TITLE
Sema: Skip MemberImportVisibility diagnostics for self-witnessing requirements

### DIFF
--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -2058,7 +2058,8 @@ RequirementCheck WitnessChecker::checkWitness(ValueDecl *requirement,
   }
 
   // Check whether the witness has been imported appropriately.
-  if (shouldDiagnoseMissingImportForMember(match.Witness, DC))
+  if (requirement != match.Witness &&
+      shouldDiagnoseMissingImportForMember(match.Witness, DC))
     return CheckKind::RequiresMissingImport;
 
   return CheckKind::Success;

--- a/test/ModuleInterface/transitive-member-witness-in-interface.swift
+++ b/test/ModuleInterface/transitive-member-witness-in-interface.swift
@@ -2,10 +2,10 @@
 // RUN: split-file %s %t
 
 // Build the supporting modules.
-// RUN: %target-swift-frontend -emit-module %t/ExtensionModule.swift -o %t \
-// RUN:   -module-name ExtensionModule -swift-version 5 -enable-library-evolution
 // RUN: %target-swift-frontend -emit-module %t/ProtoModule.swift -o %t \
-// RUN:   -I %t -module-name ProtoModule -swift-version 5 -enable-library-evolution
+// RUN:   -module-name ProtoModule -swift-version 5 -enable-library-evolution
+// RUN: %target-swift-frontend -emit-module %t/RefinementModule.swift -o %t \
+// RUN:   -I %t -module-name RefinementModule -swift-version 5 -enable-library-evolution
 
 // Typecheck the handwritten swiftinterface. This should succeed without errors
 // even when MemberImportVisibility is enabled, because swiftinterfaces are
@@ -16,23 +16,25 @@
 
 // REQUIRES: swift_feature_MemberImportVisibility
 
-//--- ExtensionModule.swift
-
-extension Int {
-  public func witnessMe() { }
-}
-
 //--- ProtoModule.swift
-
-import ExtensionModule
 
 public protocol Proto {
   func witnessMe()
 }
 
+extension Proto {
+  public func witnessMe() { }
+}
+
+//--- RefinementModule.swift
+
+import ProtoModule
+
+public protocol RefinedProto: Proto { }
+
 //--- Client.swiftinterface
 // swift-interface-format-version: 1.0
 // swift-module-flags: -swift-version 5 -enable-library-evolution -module-name Client -enable-upcoming-feature MemberImportVisibility
-import ProtoModule
+import RefinementModule
 
-extension Int: Proto {}
+struct S: RefinedProto {}


### PR DESCRIPTION
- **Explanation**: When a requirement witnesses itself that indicates that no witness was found and the conformance checker is treating the witness as "opaque". The visibility of the requirement should not be diagnosed; otherwise swiftinterface files for modules with MemberImportVisibility enabled can fail to build spuriously. Fixes an issue that was not caught in the test introduced in https://github.com/swiftlang/swift/pull/88616.
- **Scope**: Affects protocol conformance checking generally, but in a very narrow way that should only relax checking requirements.
- **Issues**: rdar://175691719
- **Risk**: Low, this change only accepts more code by relaxing conformance checking. 
- **Testing**: Modified the test from https://github.com/swiftlang/swift/pull/88616 so that it reproduces another variant of the issue that the original fix was meant to address.
