### PR TITLE
[Sema] Add another exclusion to the double-typecheck guard in `NamingPatternRequest`

### DIFF
--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2746,9 +2746,23 @@ NamingPatternRequest::evaluate(Evaluator &evaluator, VarDecl *VD) const {
       // FIXME: The check for 'IsForSourceKit' is a hack to workaround cases
       // where we're doing cursor info in an invalid extension, we ought to
       // still be type-checking decls in invalid extensions.
+      auto inSecondaryScriptFile = [&]() -> bool {
+        // FIXME: We can hit this when lazily type-checking decls in a
+        // main.swift when it's a secondary file, avoid asserting since the
+        // DeclChecker won't be run on the file. We only need to handle the
+        // secondary case since main files are always type-checked first when
+        // primary.
+        //
+        // Once we fix script variables to either be consistently local or
+        // global we can remove this.
+        auto *SF = VD->getDeclContext()->getOutermostParentSourceFile();
+        return SF && SF->isScriptMode() && !SF->isPrimary() &&
+          !SF->getParentModule()->getPrimarySourceFiles().empty();
+      };
       ASSERT(Context.SourceMgr.hasIDEInspectionTargetBuffer() ||
              Context.LangOpts.IsForSourceKit ||
-             Context.TypeCheckerOpts.EnableLazyTypecheck &&
+             Context.TypeCheckerOpts.EnableLazyTypecheck ||
+             inSecondaryScriptFile() &&
              "Querying VarDecl's type before type-checking parent stmt");
 
       // Try type checking parent control statement.

--- a/validation-test/compiler_crashers_fixed/rdar175699234.swift
+++ b/validation-test/compiler_crashers_fixed/rdar175699234.swift
@@ -1,0 +1,18 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: %target-swift-frontend -typecheck -verify %t/other.swift -primary-file %t/main.swift
+// RUN: %target-swift-frontend -typecheck -verify -primary-file %t/other.swift %t/main.swift
+// RUN: %target-swift-frontend -typecheck -verify -primary-file %t/other.swift -primary-file %t/main.swift
+// RUN: %target-swift-frontend -typecheck -verify -primary-file %t/main.swift -primary-file %t/other.swift
+// RUN: %target-swift-frontend -typecheck -verify %t/other.swift %t/main.swift
+// RUN: %target-swift-frontend -typecheck -verify %t/main.swift %t/other.swift
+
+// Make sure we don't crash when lazily type-checking 'y' from other.
+
+//--- main.swift
+var x: Int?
+guard let x else { fatalError() }
+let y = x
+
+//--- other.swift
+let z = y


### PR DESCRIPTION
- Explanation: Fixes an assertion failure that could occur when referencing a decl in a secondary `main.swift` file
- Scope: Affects type-checking of secondary `main.swift` files
- Issue: rdar://175699234
- Risk: Low, makes an assert more permissive
- Testing: Added test to test suite