### PR TITLE
SILGen: fix non-dominated dealloc_stack in throw emission 

### DIFF
--- a/lib/SILGen/SILGenPattern.cpp
+++ b/lib/SILGen/SILGenPattern.cpp
@@ -4078,6 +4078,9 @@ void SILGenFunction::emitCatchDispatch(DoCatchStmt *S, ManagedValue exn,
       scope.pushCleanupState(exn.getCleanup(),
                              CleanupState::PersistentlyActive);
     }
+
+    // We may create temporaries while bridging from typed to untyped throws.
+    FullExpr throwScope(Cleanups, CleanupLocation(location));
     emitThrow(S, exn);
   };
   // Set up an initial clause matrix.

--- a/test/SILGen/typed_throws.swift
+++ b/test/SILGen/typed_throws.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -Xllvm -sil-print-types %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -Xllvm -sil-print-types %s | %FileCheck %s --enable-var-scope
 // RUN: %target-swift-emit-sil -sil-verify-all %s
 
 enum MyError: Error {

--- a/test/SILGen/typed_throws.swift
+++ b/test/SILGen/typed_throws.swift
@@ -435,6 +435,37 @@ func testOverloadingWithConcreteErrorType() throws {
   }
 }
 
+
+// From https://github.com/swiftlang/swift/issues/88220
+enum APIError: Error, Sendable {
+    case duplicateItem
+}
+func execute() throws(APIError) {}
+func store(replaceDuplicates: Bool) throws {
+    do {
+        try execute()
+    }
+    catch APIError.duplicateItem where replaceDuplicates {}
+}
+// CHECK-LABEL: sil {{.*}}[ossa] @$s12typed_throws5store17replaceDuplicatesySb_tKF : $@convention(thin) (Bool) -> @error any Error {
+// CHECK:          [[BOOL_VAL:%.*]] = struct_extract %0 : $Bool, #Bool._value
+// CHECK:          cond_br [[BOOL_VAL]], [[TRUE_BB:bb[0-9]+]], [[FALSE_BB:bb[0-9]+]]
+
+// CHECK:        [[TRUE_BB]]:
+// CHECK-NEXT:     br bb
+
+// CHECK:         [[FALSE_BB]]:
+// CHECK-NEXT:      alloc_stack $any Error
+// CHECK: } // end sil function
+
+
+
+
+
+
+// ----------------------------------------------------
+// Tests that must go at the end
+
 // CHECK-LABEL:      sil_vtable MySubclass {
 // CHECK-NEXT:   #MyClass.init!allocator: <E where E : Error> (MyClass.Type) -> (() throws(E) -> ()) throws(E) -> MyClass : @$s12typed_throws10MySubclassC4bodyACyyxYKXE_txYKcs5ErrorRzlufC [override]
 // CHECK-NEXT:  #MyClass.f: (MyClass) -> () throws -> () : @$s12typed_throws10MySubclassC1fyyAA0C5ErrorOYKFAA0C5ClassCADyyKFTV [override]


### PR DESCRIPTION
- **Explanation**: Fixes a bug in typed-throws emission where it emits invalid SIL. That SIL is recently started being rejected by StackNesting.
- **Scope**: Fixes a regression since 6.3.
- **Issues**: https://github.com/swiftlang/swift/issues/88220 / rdar://173812126
- **Risk**: Low; I wouldn't expect emitThrow to create any exotic temporaries that an extra scope would incorrectly delimit.
- **Testing**: Regression test added.
