### PR TITLE
[cxx-interop] Use Clang's constant expression evaluator for macro import

### DIFF
--- a/lib/ClangImporter/ImportMacro.cpp
+++ b/lib/ClangImporter/ImportMacro.cpp
@@ -31,35 +31,12 @@
 #include "clang/AST/Expr.h"
 #include "clang/Lex/MacroInfo.h"
 #include "clang/Lex/Preprocessor.h"
-#include "clang/Sema/DelayedDiagnostic.h"
+#include "clang/Parse/Parser.h"
 #include "clang/Sema/Lookup.h"
 #include "clang/Sema/Sema.h"
-#include "clang/StaticAnalyzer/Core/PathSensitive/APSIntType.h"
-#include "llvm/ADT/SmallString.h"
 
 using namespace swift;
 using namespace importer;
-
-template <typename T = clang::Expr>
-static const T *
-parseNumericLiteral(ClangImporter::Implementation &impl,
-                    const clang::Token &tok) {
-  auto result = impl.getClangSema().ActOnNumericConstant(tok);
-  if (result.isUsable())
-    return dyn_cast<T>(result.get());
-  return nullptr;
-}
-
-static std::optional<StringRef>
-getTokenSpelling(ClangImporter::Implementation &impl, const clang::Token &tok) {
-  bool tokenInvalid = false;
-  llvm::SmallString<32> spellingBuffer;
-  StringRef tokenSpelling = impl.getClangPreprocessor().getSpelling(
-      tok, spellingBuffer, &tokenInvalid);
-  if (tokenInvalid)
-    return std::nullopt;
-  return tokenSpelling;
-}
 
 static ValueDecl *
 createMacroConstant(ClangImporter::Implementation &Impl,
@@ -77,207 +54,47 @@ createMacroConstant(ClangImporter::Implementation &Impl,
                                                    ClangN, AccessLevel::Public);
 }
 
-static ValueDecl *importNumericLiteral(ClangImporter::Implementation &Impl,
-                                       DeclContext *DC,
-                                       const clang::MacroInfo *MI,
-                                       Identifier name,
-                                       const clang::Token *signTok,
-                                       const clang::Token &tok,
-                                       ClangNode ClangN,
-                                       clang::QualType castType) {
-  assert(tok.getKind() == clang::tok::numeric_constant &&
-         "not a numeric token");
-  {
-    // Temporary hack to reject literals with ud-suffix.
-    // FIXME: remove this when the following radar is implemented:
-    // <rdar://problem/16445608> Swift should set up a DiagnosticConsumer for
-    // Clang
-    std::optional<StringRef> TokSpelling = getTokenSpelling(Impl, tok);
-    if (!TokSpelling)
-      return nullptr;
-    if (TokSpelling->contains('_'))
-      return nullptr;
-  }
-
-  if (const clang::Expr *parsed = parseNumericLiteral<>(Impl, tok)) {
-    auto clangTy = parsed->getType();
-    auto literalType = Impl.importTypeIgnoreIUO(
-        clangTy, ImportTypeKind::Value,
-        ImportDiagnosticAdder(Impl, MI, tok.getLocation()),
-        isInSystemModule(DC), Bridgeability::None, ImportTypeAttrs());
-    if (!literalType)
-      return nullptr;
-
-    Type constantType;
-    if (castType.isNull()) {
-      constantType = literalType;
-    } else {
-      constantType = Impl.importTypeIgnoreIUO(
-          castType, ImportTypeKind::Value,
-          ImportDiagnosticAdder(Impl, MI, MI->getDefinitionLoc()),
-          isInSystemModule(DC), Bridgeability::None, ImportTypeAttrs());
-      if (!constantType)
-        return nullptr;
-    }
-
-    auto &ctx = DC->getASTContext();
-    auto *constantTyNominal = constantType->getAnyNominal();
-    if (!constantTyNominal)
-      return nullptr;
-
-    if (auto *integer = dyn_cast<clang::IntegerLiteral>(parsed)) {
-      // Determine the value.
-      llvm::APSInt value{integer->getValue(), clangTy->isUnsignedIntegerType()};
-
-      // If there was a - sign, negate the value.
-      // If there was a ~, flip all bits.
-      if (signTok) {
-        if (signTok->is(clang::tok::minus)) {
-          if (!value.isMinSignedValue())
-            value = -value;
-        } else if (signTok->is(clang::tok::tilde)) {
-          value.flipAllBits();
-        }
-      }
-
-      // Make sure the destination type actually conforms to the builtin literal
-      // protocol or is Bool before attempting to import, otherwise we'll crash
-      // since `createConstant` expects it to.
-      // FIXME: We ought to be careful checking conformance here since it can
-      // result in cycles. Additionally we ought to consider checking for the
-      // non-builtin literal protocol to allow any ExpressibleByIntegerLiteral
-      // type to be supported.
-      if (!isBoolOrBoolEnumType(constantType) &&
-          !ctx.getIntBuiltinInitDecl(constantTyNominal)) {
-        return nullptr;
-      }
-      return createMacroConstant(Impl, MI, name, DC, constantType,
-                                 clang::APValue(value),
-                                 ConstantConvertKind::None,
-                                 /*static*/ false, ClangN);
-    }
-
-    if (auto *floating = dyn_cast<clang::FloatingLiteral>(parsed)) {
-      // ~ doesn't make sense with floating-point literals.
-      if (signTok && signTok->is(clang::tok::tilde))
-        return nullptr;
-
-      llvm::APFloat value = floating->getValue();
-
-      // If there was a - sign, negate the value.
-      if (signTok && signTok->is(clang::tok::minus)) {
-        value.changeSign();
-      }
-
-      // Make sure the destination type actually conforms to the builtin literal
-      // protocol before attempting to import, otherwise we'll crash since
-      // `createConstant` expects it to.
-      // FIXME: We ought to be careful checking conformance here since it can
-      // result in cycles. Additionally we ought to consider checking for the
-      // non-builtin literal protocol to allow any ExpressibleByFloatLiteral
-      // type to be supported.
-      if (!ctx.getFloatBuiltinInitDecl(constantTyNominal))
-        return nullptr;
-
-      return createMacroConstant(Impl, MI, name, DC, constantType,
-                                 clang::APValue(value),
-                                 ConstantConvertKind::None,
-                                 /*static*/ false, ClangN);
-    }
-    // TODO: Other numeric literals (complex, imaginary, etc.)
-  }
-  return nullptr;
-}
-
 static bool isStringToken(const clang::Token &tok) {
   return tok.is(clang::tok::string_literal) ||
          tok.is(clang::tok::utf8_string_literal);
 }
 
-// Describes the kind of string literal we're importing.
-enum class MappedStringLiteralKind {
-  CString,  // "string"
-  NSString, // @"string"
-  CFString  // CFSTR("string")
-};
-
-static ValueDecl *importStringLiteral(ClangImporter::Implementation &Impl,
-                                      DeclContext *DC,
-                                      const clang::MacroInfo *MI,
-                                      Identifier name,
-                                      const clang::Token &tok,
-                                      MappedStringLiteralKind kind,
-                                      ClangNode ClangN) {
-  assert(isStringToken(tok));
-
-  clang::ActionResult<clang::Expr*> result =
-    Impl.getClangSema().ActOnStringLiteral(tok);
-  if (!result.isUsable())
+static ValueDecl *importStringConstant(ClangImporter::Implementation &Impl,
+                                       DeclContext *DC, Identifier name,
+                                       const clang::StringLiteral *literal,
+                                       ClangNode ClangN) {
+  if (!literal->isOrdinary() && !literal->isUTF8())
     return nullptr;
 
-  auto parsed = dyn_cast<clang::StringLiteral>(result.get());
-  if (!parsed)
+  StringRef text = literal->getString();
+  if (!unicode::isWellFormedUTF8(text))
     return nullptr;
 
   Type importTy = Impl.getNamedSwiftType(Impl.getStdlibModule(), "String");
   if (!importTy)
     return nullptr;
 
-  StringRef text = parsed->getString();
-  if (!unicode::isWellFormedUTF8(text))
-    return nullptr;
-
   return SwiftDeclSynthesizer(Impl).createConstant(
       name, DC, importTy, text, ConstantConvertKind::None,
-      /*static*/ false, ClangN, AccessLevel::Public);
+      /*isStatic=*/false, ClangN, AccessLevel::Public);
 }
 
-static ValueDecl *importLiteral(ClangImporter::Implementation &Impl,
-                                DeclContext *DC,
-                                const clang::MacroInfo *MI,
-                                Identifier name,
-                                const clang::Token &tok,
-                                ClangNode ClangN,
-                                clang::QualType castType) {
-  switch (tok.getKind()) {
-  case clang::tok::numeric_constant: {
-    ValueDecl *importedNumericLiteral = importNumericLiteral(
-        Impl, DC, MI, name, /*signTok*/ nullptr, tok, ClangN, castType);
-    if (!importedNumericLiteral) {
-      Impl.addImportDiagnostic(
-          &tok, Diagnostic(diag::macro_not_imported_invalid_numeric_literal),
-          tok.getLocation());
-      Impl.addImportDiagnostic(MI,
-                               Diagnostic(diag::macro_not_imported, name.str()),
-                               MI->getDefinitionLoc());
-    }
-    return importedNumericLiteral;
-  }
-  case clang::tok::string_literal:
-  case clang::tok::utf8_string_literal: {
-    ValueDecl *importedStringLiteral = importStringLiteral(
-        Impl, DC, MI, name, tok, MappedStringLiteralKind::CString, ClangN);
-    if (!importedStringLiteral) {
-      Impl.addImportDiagnostic(
-          &tok, Diagnostic(diag::macro_not_imported_invalid_string_literal),
-          tok.getLocation());
-      Impl.addImportDiagnostic(MI,
-                               Diagnostic(diag::macro_not_imported, name.str()),
-                               MI->getDefinitionLoc());
-    }
-    return importedStringLiteral;
-  }
+static ValueDecl *importStringLiteral(ClangImporter::Implementation &Impl,
+                                      DeclContext *DC, Identifier name,
+                                      const clang::Token &tok,
+                                      ClangNode ClangN) {
+  assert(isStringToken(tok));
 
-  // TODO: char literals.
-  default:
-    Impl.addImportDiagnostic(
-        &tok, Diagnostic(diag::macro_not_imported_unsupported_literal),
-        tok.getLocation());
-    Impl.addImportDiagnostic(MI,
-                             Diagnostic(diag::macro_not_imported, name.str()),
-                             MI->getDefinitionLoc());
+  clang::ActionResult<clang::Expr *> result =
+      Impl.getClangSema().ActOnStringLiteral(tok);
+  if (!result.isUsable())
     return nullptr;
-  }
+
+  const auto *parsed = dyn_cast<clang::StringLiteral>(result.get());
+  if (!parsed)
+    return nullptr;
+
+  return importStringConstant(Impl, DC, name, parsed, ClangN);
 }
 
 static ValueDecl *importNil(ClangImporter::Implementation &Impl,
@@ -289,113 +106,6 @@ static ValueDecl *importNil(ClangImporter::Implementation &Impl,
   return Impl.createUnavailableDecl(
       name, DC, type, "use 'nil' instead of this imported macro",
       /*isStatic=*/false, clangN, AccessLevel::Public);
-}
-
-static bool isSignToken(const clang::Token &tok) {
-  return tok.is(clang::tok::plus) || tok.is(clang::tok::minus) ||
-         tok.is(clang::tok::tilde);
-}
-
-static std::optional<clang::QualType>
-builtinTypeForToken(const clang::Token &tok, const clang::ASTContext &context) {
-  switch (tok.getKind()) {
-  case clang::tok::kw_short:
-    return clang::QualType(context.ShortTy);
-  case clang::tok::kw_long:
-    return clang::QualType(context.LongTy);
-  case clang::tok::kw___int64:
-    return clang::QualType(context.LongLongTy);
-  case clang::tok::kw___int128:
-    return clang::QualType(context.Int128Ty);
-  case clang::tok::kw_signed:
-    return clang::QualType(context.IntTy);
-  case clang::tok::kw_unsigned:
-    return clang::QualType(context.UnsignedIntTy);
-  case clang::tok::kw_void:
-    return clang::QualType(context.VoidTy);
-  case clang::tok::kw_char:
-    return clang::QualType(context.CharTy);
-  case clang::tok::kw_int:
-    return clang::QualType(context.IntTy);
-  case clang::tok::kw_float:
-    return clang::QualType(context.FloatTy);
-  case clang::tok::kw_double:
-    return clang::QualType(context.DoubleTy);
-  case clang::tok::kw_wchar_t:
-    return clang::QualType(context.WCharTy);
-  case clang::tok::kw_bool:
-    return clang::QualType(context.BoolTy);
-  case clang::tok::kw_char8_t:
-    return clang::QualType(context.Char8Ty);
-  case clang::tok::kw_char16_t:
-    return clang::QualType(context.Char16Ty);
-  case clang::tok::kw_char32_t:
-    return clang::QualType(context.Char32Ty);
-  default:
-    return std::nullopt;
-  }
-}
-
-static std::optional<std::pair<llvm::APSInt, Type>>
-getIntegerConstantForMacroToken(ClangImporter::Implementation &impl,
-                                const clang::MacroInfo *macro, DeclContext *DC,
-                                const clang::Token &token) {
-
-  // Integer literal.
-  if (token.is(clang::tok::numeric_constant)) {
-    if (auto literal = parseNumericLiteral<clang::IntegerLiteral>(impl,token)) {
-      auto value = llvm::APSInt { literal->getValue(),
-                                  literal->getType()->isUnsignedIntegerType() };
-      auto type = impl.importTypeIgnoreIUO(
-          literal->getType(), ImportTypeKind::Value,
-          ImportDiagnosticAdder(impl, macro, token.getLocation()),
-          isInSystemModule(DC), Bridgeability::None, ImportTypeAttrs());
-      return {{ value, type }};
-    }
-
-  // Macro identifier.
-  } else if (token.is(clang::tok::identifier)) {
-
-    auto rawID = token.getIdentifierInfo();
-
-    // When importing in (Objective-)C++ language mode, sometimes a macro might
-    // have an outdated identifier info, which would cause Clang preprocessor to
-    // assume that it does not have a definition.
-    if (rawID->isOutOfDate())
-      (void)impl.getClangPreprocessor().getLeafModuleMacros(rawID);
-
-    auto definition = impl.getClangPreprocessor().getMacroDefinition(rawID);
-    if (!definition)
-      return std::nullopt;
-
-    ClangNode macroNode;
-    const clang::MacroInfo *macroInfo;
-    if (definition.getModuleMacros().empty()) {
-      macroInfo = definition.getMacroInfo();
-      macroNode = macroInfo;
-    } else {
-      // Follow MacroDefinition::getMacroInfo in preferring the last ModuleMacro
-      // rather than the first.
-      const clang::ModuleMacro *moduleMacro =
-          definition.getModuleMacros().back();
-      macroInfo = moduleMacro->getMacroInfo();
-      macroNode = moduleMacro;
-    }
-    auto importedID = impl.getNameImporter().importMacroName(rawID, macroInfo);
-    (void)impl.importMacro(importedID, macroNode);
-
-    auto searcher = impl.ImportedMacroConstants.find(macroInfo);
-    if (searcher == impl.ImportedMacroConstants.end()) {
-      return std::nullopt;
-    }
-    auto importedConstant = searcher->second;
-    if (!importedConstant.first.isInt()) {
-      return std::nullopt;
-    }
-    return {{ importedConstant.first.getInt(), importedConstant.second }};
-  }
-
-  return std::nullopt;
 }
 
 namespace {
@@ -499,16 +209,308 @@ ValueDecl *importDeclAlias(ClangImporter::Implementation &clang,
 }
 } // namespace
 
-static ValueDecl *importMacro(ClangImporter::Implementation &impl,
-                              llvm::SmallSet<StringRef, 4> &visitedMacros,
-                              DeclContext *DC, Identifier name,
-                              const clang::MacroInfo *macro, ClangNode ClangN,
-                              clang::QualType castType) {
-  if (name.empty()) return nullptr;
+static llvm::ArrayRef<clang::Token>
+stripTokenParens(llvm::ArrayRef<clang::Token> tokens) {
+  while (tokens.size() > 2 && tokens.front().is(clang::tok::l_paren) &&
+         tokens.back().is(clang::tok::r_paren)) {
+    tokens.consume_front();
+    tokens.consume_back();
+  }
+  return tokens;
+}
 
-  assert(visitedMacros.count(name.str()) &&
-         "Add the name of the macro to visitedMacros before calling this "
-         "function.");
+/// Check whether \p II has a macro definition, first ensuring that any
+/// lazily-deserialized module macros are loaded. Prefer this over calling
+/// IdentifierInfo::hasMacroDefinition() directly, which can return stale
+/// results when Clang modules are in use.
+static bool hasMacroDefinition(const clang::IdentifierInfo *II,
+                               const clang::Preprocessor &PP) {
+  if (II->isOutOfDate())
+    (void)PP.getLeafModuleMacros(II);
+  return II->hasMacroDefinition();
+}
+
+/// Match token patterns that can't go through the constexpr evaluator:
+/// nil macros (NULL, (void*)0, (id)0), ObjC @"string", and CFSTR("string").
+static ValueDecl *
+tryImportMacroByTokenPattern(ClangImporter::Implementation &impl,
+                             DeclContext *DC, Identifier name,
+                             const clang::MacroInfo *macro, ClangNode ClangN) {
+  const auto tokens = stripTokenParens(macro->tokens());
+  if (tokens.empty())
+    return nullptr;
+
+  // Single identifier that names a nil macro (NULL, nil, Nil).
+  if (tokens.size() == 1 && tokens.front().is(clang::tok::identifier)) {
+    auto *clangID = tokens.front().getIdentifierInfo();
+    if (hasMacroDefinition(clangID, impl.getClangPreprocessor())) {
+      auto isNilMacro = llvm::StringSwitch<bool>(clangID->getName())
+#define NIL_MACRO(NAME) .Case(#NAME, true)
+#include "MacroTable.def"
+#undef NIL_MACRO
+        .Default(false);
+      if (isNilMacro)
+        return importNil(impl, DC, name, ClangN);
+    }
+  }
+
+  auto isZeroToken = [&impl](const clang::Token &tok) -> bool {
+    if (!tok.is(clang::tok::numeric_constant))
+      return false;
+    const auto result = impl.getClangSema().ActOnNumericConstant(tok);
+    if (!result.isUsable())
+      return false;
+    const auto *intLit = dyn_cast<clang::IntegerLiteral>(result.get());
+    return intLit && intLit->getValue() == 0;
+  };
+
+  // Import `(id)0` as nil.
+  if (tokens.size() == 4 &&
+      tokens[0].is(clang::tok::l_paren) &&
+      tokens[1].is(clang::tok::identifier) &&
+      tokens[1].getIdentifierInfo()->isStr("id") &&
+      tokens[2].is(clang::tok::r_paren) &&
+      isZeroToken(tokens[3])) {
+    return importNil(impl, DC, name, ClangN);
+  }
+
+  // Import `(void*)0` as nil.
+  if (tokens.size() == 5 &&
+      tokens[0].is(clang::tok::l_paren) &&
+      tokens[1].is(clang::tok::kw_void) &&
+      tokens[2].is(clang::tok::star) &&
+      tokens[3].is(clang::tok::r_paren) &&
+      isZeroToken(tokens[4])) {
+    return importNil(impl, DC, name, ClangN);
+  }
+
+  // Import ObjC `@"string"` as string.
+  if (tokens.size() == 2 &&
+      tokens[0].is(clang::tok::at) &&
+      isStringToken(tokens[1])) {
+    return importStringLiteral(impl, DC, name, tokens[1], ClangN);
+  }
+
+  // Import CoreFoundation's `CFSTR("string")` as string.
+  if (tokens.size() == 4 &&
+      tokens[0].is(clang::tok::identifier) &&
+      tokens[0].getIdentifierInfo()->isStr("CFSTR") &&
+      tokens[1].is(clang::tok::l_paren) &&
+      isStringToken(tokens[2]) &&
+      tokens[3].is(clang::tok::r_paren)) {
+    return importStringLiteral(impl, DC, name, tokens[2], ClangN);
+  }
+
+  return nullptr;
+}
+
+/// Recursively checks whether a macro's expansion chain references
+/// _Pragma/__pragma.
+static bool macroExpansionContainsPragma(const clang::MacroInfo *macro,
+                                         const clang::Preprocessor &pp) {
+  llvm::SmallVector<const clang::MacroInfo *, 4> worklist;
+  llvm::SmallPtrSet<const clang::MacroInfo *, 8> visited;
+  worklist.push_back(macro);
+  visited.insert(macro);
+  while (!worklist.empty()) {
+    const auto *mi = worklist.pop_back_val();
+    for (const auto &tok : mi->tokens()) {
+      if (!tok.is(clang::tok::identifier))
+        continue;
+      const auto *II = tok.getIdentifierInfo();
+      if (!II)
+        continue;
+      if (II->isStr("_Pragma") || II->isStr("__pragma"))
+        return true;
+      if (hasMacroDefinition(II, pp))
+        if (const auto *refMI = pp.getMacroInfo(II))
+          if (visited.insert(refMI).second)
+            worklist.push_back(refMI);
+    }
+  }
+  return false;
+}
+
+/// Try to import a C/C++ object-like macro as a Swift constant by using
+/// Clang's full expression parser and constant evaluator. Returns nullptr if
+/// the macro cannot be parsed, evaluated, or mapped.
+static ValueDecl *
+tryImportMacroAsConstantExpr(ClangImporter::Implementation &impl,
+                             DeclContext *DC, Identifier name,
+                             const clang::MacroInfo *macro, ClangNode ClangN) {
+  if (!impl.getClangParser())
+    return nullptr;
+
+  auto &pp = impl.getClangPreprocessor();
+  auto &sema = impl.getClangSema();
+  auto &parser = *impl.getClangParser();
+
+  if (macro->tokens_empty())
+    return nullptr;
+
+  // Walk the macro expansion chain to detect _Pragma/__pragma at any depth.
+  // Macros whose expansion triggers _Pragma() hit an assertion in the
+  // diagnostic state tracker (DiagStateMap expects monotonically increasing
+  // source locations, but our injected token stream has locations from the
+  // original header).
+  if (macroExpansionContainsPragma(macro, pp))
+    return nullptr;
+
+  // Save the parser's current token so we can restore state afterward.
+  // The token sequence we inject is: [macro tokens..., eof, savedToken].
+  clang::Token savedToken = parser.getCurToken();
+
+  clang::Token eof;
+  eof.startToken();
+  eof.setKind(clang::tok::eof);
+  eof.setLocation(savedToken.getEndLoc());
+
+  llvm::SmallVector<clang::Token, 8> tokens;
+  const size_t numTokensAsSizeT = macro->getNumTokens();
+  tokens.reserve(numTokensAsSizeT + 2);
+  tokens.append(macro->tokens_begin(), macro->tokens_end());
+  tokens.push_back(eof);
+  tokens.push_back(savedToken);
+
+  pp.EnterTokenStream(tokens, /*DisableMacroExpansion=*/false,
+                      /*IsReinject=*/false);
+  parser.ConsumeAnyToken(/*ConsumeCodeCompletionTok=*/true);
+
+  // Suppress diagnostics so that parse/eval failures for non-constant
+  // macros don't produce spurious Clang warnings or errors.
+  clang::DiagnosticsEngine &clangDiags = sema.getDiagnostics();
+  bool savedSuppress = clangDiags.getSuppressAllDiagnostics();
+  clangDiags.setSuppressAllDiagnostics(true);
+
+  clang::ExprResult parseResult = parser.ParseConstantExpression();
+
+  bool success =
+      !parseResult.isInvalid() && parser.getCurToken().is(clang::tok::eof);
+
+  if (!success)
+    parser.SkipUntil(clang::tok::eof);
+
+  clangDiags.setSuppressAllDiagnostics(savedSuppress);
+
+  if (!success)
+    return nullptr;
+
+  clang::Expr *resultExpr = parseResult.get()->IgnoreParenImpCasts();
+
+  // String literals can't go through EvaluateAsConstantExpr (they aren't
+  // scalar constants), so handle them directly.
+  if (const auto *stringLiteral = dyn_cast<clang::StringLiteral>(resultExpr))
+    return importStringConstant(impl, DC, name, stringLiteral, ClangN);
+
+  // Template-dependent expressions can't be evaluated at compile time.
+  clang::Expr::EvalResult evalResult;
+  if (resultExpr->isValueDependent() ||
+      !resultExpr->EvaluateAsConstantExpr(evalResult, sema.getASTContext()))
+    return nullptr;
+
+  if (!evalResult.Val.isInt() && !evalResult.Val.isFloat())
+    return nullptr;
+
+  // createMacroConstant() has an assertion for some reason:
+  // assert(value.getFloat().isFinite() && "can't handle infinities or NaNs");
+  if (evalResult.Val.isFloat() && !evalResult.Val.getFloat().isFinite())
+    return nullptr;
+
+  auto clangType = resultExpr->getType();
+
+  // Reject macros whose result type carries unavailability or deprecation
+  // attributes.
+  if (const auto *typedefType = clangType->getAs<clang::TypedefType>()) {
+    auto avail = typedefType->getDecl()->getAvailability();
+    if (avail == clang::AR_Unavailable || avail == clang::AR_Deprecated)
+      return nullptr;
+  }
+
+  // Map comparison (==, <, etc.) and logical (&&, ||, !) operators to bool.
+  bool shouldImportAsBool = clangType->isBooleanType();
+  if (!shouldImportAsBool) {
+    const clang::Expr *inner = resultExpr->IgnoreParenImpCasts();
+    if (const auto *binOp = dyn_cast<clang::BinaryOperator>(inner))
+      shouldImportAsBool = binOp->isComparisonOp() || binOp->isLogicalOp();
+    else if (const auto *unOp = dyn_cast<clang::UnaryOperator>(inner))
+      shouldImportAsBool = unOp->getOpcode() == clang::UO_LNot;
+  }
+
+  Type swiftType;
+  if (shouldImportAsBool && evalResult.Val.isInt()) {
+    swiftType = impl.SwiftContext.getBoolType();
+  } else {
+    swiftType = impl.importTypeIgnoreIUO(
+        clangType, ImportTypeKind::Value,
+        ImportDiagnosticAdder(impl, macro, macro->getDefinitionLoc()),
+        isInSystemModule(DC), Bridgeability::None, ImportTypeAttrs());
+  }
+  if (!swiftType)
+    return nullptr;
+
+  // createMacroConstant() preconditions.
+  auto &ctx = DC->getASTContext();
+  auto *constantTyNominal = swiftType->getAnyNominal();
+  if (!constantTyNominal)
+    return nullptr;
+  if (evalResult.Val.isInt()) {
+    if (!isBoolOrBoolEnumType(swiftType) &&
+        !ctx.getIntBuiltinInitDecl(constantTyNominal))
+      return nullptr;
+  } else {
+    if (!ctx.getFloatBuiltinInitDecl(constantTyNominal))
+      return nullptr;
+  }
+
+  return createMacroConstant(impl, macro, name, DC, swiftType, evalResult.Val,
+                             ConstantConvertKind::None,
+                             /*isStatic=*/false, ClangN);
+}
+
+/// Try to import a single-identifier macro as a Swift alias for a C/C++ decl.
+/// If the referenced decl's imported Swift name already matches the macro
+/// name, sets \p alreadyImported to true and returns nullptr, the declaration
+/// is already available under that name so neither an alias nor a constant
+/// should be created.
+static ValueDecl *tryImportMacroAsAlias(ClangImporter::Implementation &impl,
+                                        DeclContext *DC, Identifier name,
+                                        const clang::MacroInfo *macro,
+                                        ClangNode ClangN,
+                                        bool &alreadyImported) {
+  alreadyImported = false;
+  auto tokens = stripTokenParens(macro->tokens());
+  if (tokens.size() != 1 || !tokens[0].is(clang::tok::identifier))
+    return nullptr;
+
+  clang::Sema &S = impl.getClangSema();
+  clang::LookupResult R(S, {{tokens[0].getIdentifierInfo()}, {}},
+                        clang::Sema::LookupAnyName);
+  if (!S.LookupName(R, S.TUScope) ||
+      R.getResultKind() != clang::LookupResultKind::Found)
+    return nullptr;
+
+  const auto *foundDecl = R.getFoundDecl();
+
+  if (auto *imported = dyn_cast_or_null<ValueDecl>(
+          impl.importDecl(foundDecl, impl.CurrentVersion))) {
+    if (imported->getBaseIdentifier() == name) {
+      alreadyImported = true;
+      return nullptr;
+    }
+  }
+
+  if (const auto *VD = dyn_cast<clang::ValueDecl>(foundDecl))
+    return importDeclAlias(impl, DC, VD, name);
+
+  return nullptr;
+}
+
+/// Import a C/C++ object-like macro as a Swift declaration.
+static ValueDecl *importMacro(ClangImporter::Implementation &impl,
+                              DeclContext *DC, Identifier name,
+                              const clang::MacroInfo *macro, ClangNode ClangN) {
+  if (name.empty())
+    return nullptr;
 
   if (macro->isFunctionLike()) {
     impl.addImportDiagnostic(
@@ -517,391 +519,32 @@ static ValueDecl *importMacro(ClangImporter::Implementation &impl,
     return nullptr;
   }
 
-  auto numTokens = macro->getNumTokens();
-  auto tokenI = macro->tokens_begin(), tokenE = macro->tokens_end();
+  // Token patterns first: handles special forms (nil, ObjC/CF strings) that
+  // rely on specific token shapes and can't be expressed as constexpr.
+  if (auto *result =
+          tryImportMacroByTokenPattern(impl, DC, name, macro, ClangN))
+    return result;
 
-  // Drop one layer of parentheses.
-  if (numTokens > 2 &&
-      tokenI[0].is(clang::tok::l_paren) &&
-      tokenE[-1].is(clang::tok::r_paren)) {
-    ++tokenI;
-    --tokenE;
-    numTokens -= 2;
-  }
-
-  // Handle tokens starting with a type cast
-  bool castTypeIsId = false;
-  if (numTokens > 3 && tokenI[0].is(clang::tok::l_paren) &&
-      (tokenI[1].is(clang::tok::identifier) ||
-       tokenI[1].isSimpleTypeSpecifier(impl.getClangSema().getLangOpts())) &&
-      tokenI[2].is(clang::tok::r_paren)) {
-    if (!castType.isNull()) {
-      // this is a nested cast
-      // TODO(https://github.com/apple/swift/issues/57735): Diagnose nested cast.
+  // Alias before constexpr: a macro like `#define FOO some_enum_value` should
+  // produce an alias to the original decl, not a duplicate integer constant
+  // (which is what constexpr evaluation would yield).
+  if (DC->getASTContext().LangOpts.hasFeature(Feature::ImportMacroAliases)) {
+    bool alreadyImported;
+    if (auto *result = tryImportMacroAsAlias(impl, DC, name, macro, ClangN,
+                                             alreadyImported))
+      return result;
+    if (alreadyImported)
       return nullptr;
-    }
-
-    if (tokenI[1].is(clang::tok::identifier)) {
-      auto identifierInfo = tokenI[1].getIdentifierInfo();
-      if (identifierInfo->isStr("id")) {
-        castTypeIsId = true;
-      }
-      auto identifierName = identifierInfo->getName();
-      auto &identifier = impl.getClangASTContext().Idents.get(identifierName);
-
-      clang::sema::DelayedDiagnosticPool diagPool{
-          impl.getClangSema().DelayedDiagnostics.getCurrentPool()};
-      auto diagState = impl.getClangSema().DelayedDiagnostics.push(diagPool);
-      auto parsedType = impl.getClangSema().getTypeName(identifier,
-                                                        clang::SourceLocation(),
-                                                        impl.getClangSema().TUScope);
-      impl.getClangSema().DelayedDiagnostics.popWithoutEmitting(diagState);
-
-      if (parsedType && diagPool.empty()) {
-        castType = parsedType.get();
-      } else {
-        // TODO(https://github.com/apple/swift/issues/57735): Add diagnosis.
-        return nullptr;
-      }
-      if (!castType->isBuiltinType() && !castTypeIsId) {
-        // TODO(https://github.com/apple/swift/issues/57735): Add diagnosis.
-        return nullptr;
-      }
-    } else {
-      auto builtinType = builtinTypeForToken(tokenI[1],
-                                             impl.getClangASTContext());
-      if (builtinType) {
-        castType = builtinType.value();
-      } else {
-        // TODO(https://github.com/apple/swift/issues/57735): Add diagnosis.
-        return nullptr;
-      }
-    }
-    tokenI += 3;
-    numTokens -= 3;
   }
 
-  // FIXME: Ask Clang to try to parse and evaluate the expansion as a constant
-  // expression instead of doing these special-case pattern matches.
-  switch (numTokens) {
-  case 1: {
-    // Check for a single-token expansion of the form <literal>.
-    // TODO: or <identifier>.
-    const clang::Token &tok = *tokenI;
+  // General-purpose fallback: parse and evaluate as a constant expression.
+  if (auto *result =
+          tryImportMacroAsConstantExpr(impl, DC, name, macro, ClangN))
+    return result;
 
-    if (castTypeIsId && tok.is(clang::tok::numeric_constant)) {
-      auto *integerLiteral =
-        parseNumericLiteral<clang::IntegerLiteral>(impl, tok);
-      if (integerLiteral && integerLiteral->getValue() == 0)
-        return importNil(impl, DC, name, ClangN);
-    }
-
-    // If it's a literal token, we might be able to translate the literal.
-    if (tok.isLiteral()) {
-      return importLiteral(impl, DC, macro, name, tok, ClangN, castType);
-    }
-
-    if (tok.is(clang::tok::identifier)) {
-      auto clangID = tok.getIdentifierInfo();
-
-      if (clangID->isOutOfDate())
-        // Update the identifier with macro definitions subsequently loaded from
-        // a module/AST file. We're supposed to use
-        // Preprocessor::HandleIdentifier() to do that, but that method does too
-        // much to call it here. Instead, we call getLeafModuleMacros() for its
-        // side effect of calling updateOutOfDateIdentifier().
-        // FIXME: clang should give us a better way to do this.
-        (void)impl.getClangPreprocessor().getLeafModuleMacros(clangID);
-
-      // If it's an identifier that is itself a macro, look into that macro.
-      if (clangID->hasMacroDefinition()) {
-        auto isNilMacro =
-          llvm::StringSwitch<bool>(clangID->getName())
-#define NIL_MACRO(NAME) .Case(#NAME, true)
-#include "MacroTable.def"
-          .Default(false);
-        if (isNilMacro)
-          return importNil(impl, DC, name, ClangN);
-
-        auto macroID = impl.getClangPreprocessor().getMacroInfo(clangID);
-        if (macroID && macroID != macro) {
-          // If we've already visited this macro, then bail to prevent an
-          // infinite loop. Otherwise, record that we're going to visit it.
-          if (!visitedMacros.insert(clangID->getName()).second)
-            return nullptr;
-
-          // FIXME: This was clearly intended to pass the cast type down, but
-          // doing so would be a behavior change.
-          return importMacro(impl, visitedMacros, DC, name, macroID, ClangN,
-                             /*castType*/ {});
-        }
-      }
-
-      /* Create an alias for any Decl */
-      clang::Sema &S = impl.getClangSema();
-      clang::LookupResult R(S, {{tok.getIdentifierInfo()}, {}},
-                            clang::Sema::LookupAnyName);
-      if (S.LookupName(R, S.TUScope))
-        if (R.getResultKind() == clang::LookupResultKind::Found)
-          if (const auto *VD = dyn_cast<clang::ValueDecl>(R.getFoundDecl()))
-            return importDeclAlias(impl, DC, VD, name);
-    }
-
-    // TODO(https://github.com/apple/swift/issues/57735): Seems rare to have a single token that is neither a literal nor an identifier, but add diagnosis.
-    return nullptr;
-  }
-  case 2: {
-    // Check for a two-token expansion of the form +<number> or -<number>.
-    // These are technically subtly wrong without parentheses because they
-    // allow things like:
-    //   #define EOF -1
-    //   int pred(int x) { return x EOF; }
-    // but are pervasive in C headers anyway.
-    clang::Token const &first = tokenI[0];
-    clang::Token const &second = tokenI[1];
-
-    if (isSignToken(first) && second.is(clang::tok::numeric_constant)) {
-      ValueDecl *importedNumericLiteral = importNumericLiteral(
-          impl, DC, macro, name, &first, second, ClangN, castType);
-      if (!importedNumericLiteral) {
-        impl.addImportDiagnostic(
-            macro, Diagnostic(diag::macro_not_imported, name.str()),
-            macro->getDefinitionLoc());
-        impl.addImportDiagnostic(
-            &second,
-            Diagnostic(diag::macro_not_imported_invalid_numeric_literal),
-            second.getLocation());
-      }
-      return importedNumericLiteral;
-    }
-
-    // We also allow @"string".
-    if (first.is(clang::tok::at) && isStringToken(second)) {
-      ValueDecl *importedStringLiteral =
-          importStringLiteral(impl, DC, macro, name, second,
-                              MappedStringLiteralKind::NSString, ClangN);
-      if (!importedStringLiteral) {
-        impl.addImportDiagnostic(
-            macro, Diagnostic(diag::macro_not_imported, name.str()),
-            macro->getDefinitionLoc());
-        impl.addImportDiagnostic(
-            &second,
-            Diagnostic(diag::macro_not_imported_invalid_string_literal),
-            second.getLocation());
-      }
-      return importedStringLiteral;
-    }
-
-    break;
-  }
-  case 3: {
-    // Check for infix operations between two integer constants.
-    // Import the result as another integer constant:
-    //   #define INT3 (INT1 <op> INT2)
-    // Doesn't allow inner parentheses.
-
-    // Parse INT1.
-    llvm::APSInt firstValue;
-    Type firstSwiftType = nullptr;
-    if (auto firstInt = getIntegerConstantForMacroToken(impl, macro, DC,
-                                                        tokenI[0])) {
-      firstValue     = firstInt->first;
-      firstSwiftType = firstInt->second;
-    } else {
-      impl.addImportDiagnostic(
-          macro,
-          Diagnostic(diag::macro_not_imported_unsupported_structure,
-                     name.str()),
-          macro->getDefinitionLoc());
-      return nullptr;
-    }
-
-    // Parse INT2.
-    llvm::APSInt secondValue;
-    Type secondSwiftType = nullptr;
-    if (auto secondInt = getIntegerConstantForMacroToken(impl, macro, DC,
-                                                         tokenI[2])) {
-      secondValue     = secondInt->first;
-      secondSwiftType = secondInt->second;
-    } else {
-      impl.addImportDiagnostic(
-          macro,
-          Diagnostic(diag::macro_not_imported_unsupported_structure,
-                     name.str()),
-          macro->getDefinitionLoc());
-      return nullptr;
-    }
-
-    llvm::APSInt resultValue;
-    Type resultSwiftType = nullptr;
-
-    // Resolve width and signedness differences and find the type of the result.
-    auto firstIntSpec  = clang::ento::APSIntType(firstValue);
-    auto secondIntSpec = clang::ento::APSIntType(secondValue);
-    if (firstIntSpec == std::max(firstIntSpec, secondIntSpec)) {
-      firstIntSpec.apply(secondValue);
-      resultSwiftType = firstSwiftType;
-    } else {
-      secondIntSpec.apply(firstValue);
-      resultSwiftType = secondSwiftType;
-    }
-
-    // Addition.
-    if (tokenI[1].is(clang::tok::plus)) {
-      resultValue = firstValue + secondValue;
-
-    // Subtraction.
-    } else if (tokenI[1].is(clang::tok::minus)) {
-      resultValue = firstValue - secondValue;
-
-    // Multiplication.
-    } else if (tokenI[1].is(clang::tok::star)) {
-      resultValue = firstValue * secondValue;
-
-    // Division.
-    } else if (tokenI[1].is(clang::tok::slash)) {
-      if (secondValue == 0) { return nullptr; }
-      resultValue = firstValue / secondValue;
-
-    // Left-shift.
-    } else if (tokenI[1].is(clang::tok::lessless)) {
-      // Shift by a negative number is UB in C. Don't import.
-      if (secondValue.isNegative()) { return nullptr; }
-      resultValue = llvm::APSInt { firstValue.shl(secondValue),
-                                   firstValue.isUnsigned() };
-
-    // Right-shift.
-    } else if (tokenI[1].is(clang::tok::greatergreater)) {
-      // Shift by a negative number is UB in C. Don't import.
-      if (secondValue.isNegative()) { return nullptr; }
-      if (firstValue.isUnsigned()) {
-        resultValue = llvm::APSInt { firstValue.lshr(secondValue),
-                                     /*isUnsigned*/ true };
-      } else {
-        resultValue = llvm::APSInt { firstValue.ashr(secondValue),
-                                     /*isUnsigned*/ false };
-      }
-
-    // Bitwise OR.
-    } else if (tokenI[1].is(clang::tok::pipe)) {
-      firstValue.setIsUnsigned(true);
-      secondValue.setIsUnsigned(true);
-      resultValue = llvm::APSInt { firstValue | secondValue,
-                                   /*isUnsigned*/ true };
-
-    // Bitwise AND.
-    } else if (tokenI[1].is(clang::tok::amp)) {
-      firstValue.setIsUnsigned(true);
-      secondValue.setIsUnsigned(true);
-      resultValue = llvm::APSInt { firstValue & secondValue,
-                                   /*isUnsigned*/ true };
-
-    // XOR.
-    } else if (tokenI[1].is(clang::tok::caret)) {
-      firstValue.setIsUnsigned(true);
-      secondValue.setIsUnsigned(true);
-      resultValue = llvm::APSInt { firstValue ^ secondValue,
-                                   /*isUnsigned*/ true };
-
-    // Logical OR.
-    } else if (tokenI[1].is(clang::tok::pipepipe)) {
-      bool result  = firstValue.getBoolValue() || secondValue.getBoolValue();
-      resultValue  = llvm::APSInt::get(result);
-      resultSwiftType = impl.SwiftContext.getBoolType();
-
-    // Logical AND.
-    } else if (tokenI[1].is(clang::tok::ampamp)) {
-      bool result  = firstValue.getBoolValue() && secondValue.getBoolValue();
-      resultValue  = llvm::APSInt::get(result);
-      resultSwiftType = impl.SwiftContext.getBoolType();
-
-    // Equality.
-    } else if (tokenI[1].is(clang::tok::equalequal)) {
-      resultValue     = llvm::APSInt::get(firstValue == secondValue);
-      resultSwiftType = impl.SwiftContext.getBoolType();
-
-    // Less than.
-    } else if (tokenI[1].is(clang::tok::less)) {
-      resultValue     = llvm::APSInt::get(firstValue < secondValue);
-      resultSwiftType = impl.SwiftContext.getBoolType();
-
-    // Less than or equal.
-    } else if (tokenI[1].is(clang::tok::lessequal)) {
-      resultValue     = llvm::APSInt::get(firstValue <= secondValue);
-      resultSwiftType = impl.SwiftContext.getBoolType();
-
-    // Greater than.
-    } else if (tokenI[1].is(clang::tok::greater)) {
-      resultValue     = llvm::APSInt::get(firstValue > secondValue);
-      resultSwiftType = impl.SwiftContext.getBoolType();
-
-    // Greater than or equal.
-    } else if (tokenI[1].is(clang::tok::greaterequal)) {
-      resultValue     = llvm::APSInt::get(firstValue >= secondValue);
-      resultSwiftType = impl.SwiftContext.getBoolType();
-
-    // Unhandled operators.
-    } else {
-      if (std::optional<StringRef> operatorSpelling =
-              getTokenSpelling(impl, tokenI[1])) {
-        impl.addImportDiagnostic(
-            &tokenI[1],
-            Diagnostic(diag::macro_not_imported_unsupported_named_operator,
-                       *operatorSpelling),
-            tokenI[1].getLocation());
-      } else {
-        impl.addImportDiagnostic(
-            &tokenI[1],
-            Diagnostic(diag::macro_not_imported_unsupported_operator),
-            tokenI[1].getLocation());
-      }
-      impl.addImportDiagnostic(macro,
-                               Diagnostic(diag::macro_not_imported, name.str()),
-                               macro->getDefinitionLoc());
-      return nullptr;
-    }
-
-    return createMacroConstant(impl, macro, name, DC, resultSwiftType,
-                               clang::APValue(resultValue),
-                               ConstantConvertKind::None,
-                               /*isStatic=*/false, ClangN);
-  }
-  case 4: {
-    // Check for a CFString literal of the form CFSTR("string").
-    if (tokenI[0].is(clang::tok::identifier) &&
-        tokenI[0].getIdentifierInfo()->isStr("CFSTR") &&
-        tokenI[1].is(clang::tok::l_paren) &&
-        isStringToken(tokenI[2]) &&
-        tokenI[3].is(clang::tok::r_paren)) {
-      return importStringLiteral(impl, DC, macro, name, tokenI[2],
-                                 MappedStringLiteralKind::CFString, ClangN);
-    }
-    // FIXME: Handle BIT_MASK(pos) helper macros which expand to a constant?
-    break;
-  }
-  case 5:
-    // Check for the literal series of tokens (void*)0. (We've already stripped
-    // one layer of parentheses.)
-    if (tokenI[0].is(clang::tok::l_paren) &&
-        tokenI[1].is(clang::tok::kw_void) &&
-        tokenI[2].is(clang::tok::star) &&
-        tokenI[3].is(clang::tok::r_paren) &&
-        tokenI[4].is(clang::tok::numeric_constant)) {
-      auto *integerLiteral =
-        parseNumericLiteral<clang::IntegerLiteral>(impl, tokenI[4]);
-      if (!integerLiteral || integerLiteral->getValue() != 0)
-        break;
-      return importNil(impl, DC, name, ClangN);
-    }
-    break;
-  default:
-    break;
-  }
-
-  impl.addImportDiagnostic(
-      macro,
-      Diagnostic(diag::macro_not_imported_unsupported_structure, name.str()),
-      macro->getDefinitionLoc());
+  impl.addImportDiagnostic(macro,
+                           Diagnostic(diag::macro_not_imported, name.str()),
+                           macro->getDefinitionLoc());
   return nullptr;
 }
 
@@ -958,11 +601,7 @@ ValueDecl *ClangImporter::Implementation::importMacro(Identifier name,
     DC = ImportedHeaderUnit;
   }
 
-  llvm::SmallSet<StringRef, 4> visitedMacros;
-  visitedMacros.insert(name.str());
-  auto valueDecl =
-      ::importMacro(*this, visitedMacros, DC, name, macro, macroNode,
-                    /*castType*/ {});
+  auto valueDecl = ::importMacro(*this, DC, name, macro, macroNode);
 
   // Update the entry for the value we just imported.
   // It's /probably/ the last entry in ImportedMacros[name], but there's an

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -1008,6 +1008,11 @@ public:
     return Instance->getCodeGenOpts();
   }
 
+  /// Retrieve the Clang parser, if available.
+  clang::Parser *getClangParser() const {
+    return Parser.get();
+  }
+
   importer::ClangSourceBufferImporter &getBufferImporterForDiagnostics() {
     return BuffersForDiagnostics;
   }

--- a/test/ClangImporter/experimental_diagnostics_cmacros.swift
+++ b/test/ClangImporter/experimental_diagnostics_cmacros.swift
@@ -9,9 +9,6 @@ _ = INVALID_INTEGER_LITERAL_2
 // CHECK-NEXT: macros.h:{{[0-9]+}}:9: note: macro 'INVALID_INTEGER_LITERAL_2' unavailable (cannot import)
 // CHECK-NEXT:      #define INVALID_INTEGER_LITERAL_2 10abc
 // CHECK-NEXT: {{^}}        ^
-// CHECK-NEXT: macros.h:{{[0-9]+}}:35: note: invalid numeric literal
-// CHECK-NEXT:      #define INVALID_INTEGER_LITERAL_2 10abc
-// CHECK-NEXT: {{^}}                                  ^
 
 _ = FUNC_LIKE_MACRO()
 // CHECK:      experimental_diagnostics_cmacros.swift:{{[0-9]+}}:{{[0-9]+}}: error: cannot find 'FUNC_LIKE_MACRO' in scope
@@ -33,7 +30,7 @@ _ = INVALID_ARITHMETIC_1
 // CHECK:      experimental_diagnostics_cmacros.swift:{{[0-9]+}}:{{[0-9]+}}: error: cannot find 'INVALID_ARITHMETIC_1' in scope
 // CHECK-NEXT: _ = INVALID_ARITHMETIC_1
 // CHECK-NEXT:     ^~~~~~~~~~~~~~~~~~~~
-// CHECK-NEXT:      macros.h:{{[0-9]+}}:9: note: macro 'INVALID_ARITHMETIC_1' unavailable: structure not supported
+// CHECK-NEXT:      macros.h:{{[0-9]+}}:9: note: macro 'INVALID_ARITHMETIC_1' unavailable (cannot import)
 // CHECK-NEXT:      #define INVALID_ARITHMETIC_1 5 + INVALID_INTEGER_LITERAL_1
 // CHECK-NEXT: {{^}}        ^
 
@@ -41,7 +38,7 @@ _ = INVALID_ARITHMETIC_2
 // CHECK:      experimental_diagnostics_cmacros.swift:{{[0-9]+}}:{{[0-9]+}}: error: cannot find 'INVALID_ARITHMETIC_2' in scope
 // CHECK-NEXT: _ = INVALID_ARITHMETIC_2
 // CHECK-NEXT:     ^~~~~~~~~~~~~~~~~~~~
-// CHECK-NEXT: macros.h:{{[0-9]+}}:9: note: macro 'INVALID_ARITHMETIC_2' unavailable: structure not supported
+// CHECK-NEXT: macros.h:{{[0-9]+}}:9: note: macro 'INVALID_ARITHMETIC_2' unavailable (cannot import)
 // CHECK-NEXT:      #define INVALID_ARITHMETIC_2 INVALID_INTEGER_LITERAL_1 + ADD_TWO
 // CHECK-NEXT: {{^}}        ^
 
@@ -49,7 +46,7 @@ _ = INVALID_ARITHMETIC_3
 // CHECK:      experimental_diagnostics_cmacros.swift:{{[0-9]+}}:{{[0-9]+}}: error: cannot find 'INVALID_ARITHMETIC_3' in scope
 // CHECK-NEXT: _ = INVALID_ARITHMETIC_3
 // CHECK-NEXT:     ^~~~~~~~~~~~~~~~~~~~
-// CHECK-NEXT: macros.h:{{[0-9]+}}:9: note: macro 'INVALID_ARITHMETIC_3' unavailable: structure not supported
+// CHECK-NEXT: macros.h:{{[0-9]+}}:9: note: macro 'INVALID_ARITHMETIC_3' unavailable (cannot import)
 // CHECK-NEXT:      #define INVALID_ARITHMETIC_3 ADD_TWO + INVALID_INTEGER_LITERAL_1
 // CHECK-NEXT: {{^}}        ^
 
@@ -57,7 +54,7 @@ _ = INVALID_ARITHMETIC_4
 // CHECK:      experimental_diagnostics_cmacros.swift:{{[0-9]+}}:{{[0-9]+}}: error: cannot find 'INVALID_ARITHMETIC_4' in scope
 // CHECK-NEXT: _ = INVALID_ARITHMETIC_4
 // CHECK-NEXT:     ^~~~~~~~~~~~~~~~~~~~
-// CHECK-NEXT: macros.h:{{[0-9]+}}:9: note: macro 'INVALID_ARITHMETIC_4' unavailable: structure not supported
+// CHECK-NEXT: macros.h:{{[0-9]+}}:9: note: macro 'INVALID_ARITHMETIC_4' unavailable (cannot import)
 // CHECK-NEXT:      #define INVALID_ARITHMETIC_4                                                   \
 // CHECK-NEXT: {{^}}        ^
 
@@ -65,78 +62,15 @@ _ = INVALID_ARITHMETIC_5
 // CHECK:      experimental_diagnostics_cmacros.swift:{{[0-9]+}}:{{[0-9]+}}: error: cannot find 'INVALID_ARITHMETIC_5' in scope
 // CHECK-NEXT: _ = INVALID_ARITHMETIC_5
 // CHECK-NEXT:     ^~~~~~~~~~~~~~~~~~~~
-// CHECK-NEXT: macros.h:{{[0-9]+}}:9: note: macro 'INVALID_ARITHMETIC_5' unavailable: structure not supported
+// CHECK-NEXT: macros.h:{{[0-9]+}}:9: note: macro 'INVALID_ARITHMETIC_5' unavailable (cannot import)
 // CHECK-NEXT:      #define INVALID_ARITHMETIC_5 1 + VERSION_STRING
 // CHECK-NEXT: {{^}}        ^
 
-_ = INVALID_ARITHMETIC_6
-// CHECK:      experimental_diagnostics_cmacros.swift:{{[0-9]+}}:{{[0-9]+}}: error: cannot find 'INVALID_ARITHMETIC_6' in scope
-// CHECK-NEXT: _ = INVALID_ARITHMETIC_6
-// CHECK-NEXT:     ^~~~~~~~~~~~~~~~~~~~
-// CHECK-NEXT: macros.h:{{[0-9]+}}:9: note: macro 'INVALID_ARITHMETIC_6' unavailable: structure not supported
-// CHECK-NEXT:      #define INVALID_ARITHMETIC_6 1 + 'c'
-// CHECK-NEXT: {{^}}        ^
-
-_ = INVALID_ARITHMETIC_7
-// CHECK:      experimental_diagnostics_cmacros.swift:{{[0-9]+}}:{{[0-9]+}}: error: cannot find 'INVALID_ARITHMETIC_7' in scope
-// CHECK-NEXT: _ = INVALID_ARITHMETIC_7
-// CHECK-NEXT:     ^~~~~~~~~~~~~~~~~~~~
-// CHECK-NEXT: macros.h:{{[0-9]+}}:9: note: macro 'INVALID_ARITHMETIC_7' unavailable (cannot import)
-// CHECK-NEXT:      #define INVALID_ARITHMETIC_7 3 % 2
-// CHECK-NEXT: {{^}}        ^
-// CHECK-NEXT: macros.h:{{[0-9]+}}:32: note: operator '%' not supported in macro arithmetic
-// CHECK-NEXT:      #define INVALID_ARITHMETIC_7 3 % 2
-// CHECK-NEXT: {{^}}                               ^
-
-
-_ = CHAR_LITERAL
-// CHECK:      experimental_diagnostics_cmacros.swift:{{[0-9]+}}:{{[0-9]+}}: error: cannot find 'CHAR_LITERAL' in scope
-// CHECK-NEXT: _ = CHAR_LITERAL
-// CHECK-NEXT:     ^~~~~~~~~~~~
-// CHECK-NEXT: macros.h:{{[0-9]+}}:9: note: macro 'CHAR_LITERAL' unavailable (cannot import)
-// CHECK-NEXT:      #define CHAR_LITERAL 'a'
-// CHECK-NEXT: {{^}}        ^
-// CHECK-NEXT: macros.h:{{[0-9]+}}:22: note: only numeric and string macro literals supported
-// CHECK-NEXT:      #define CHAR_LITERAL 'a'
-// CHECK-NEXT: {{^}}                     ^
-
-
-UNSUPPORTED_1
-// CHECK:      experimental_diagnostics_cmacros.swift:{{[0-9]+}}:{{[0-9]+}}: error: cannot find 'UNSUPPORTED_1' in scope
-// CHECK-NEXT: UNSUPPORTED_1
-// CHECK-NEXT: ^~~~~~~~~~~~~
-// CHECK-NEXT: macros.h:{{[0-9]+}}:9: note: macro 'UNSUPPORTED_1' unavailable: structure not supported
-// CHECK-NEXT:      #define UNSUPPORTED_1 FUNC_LIKE_MACRO()
-// CHECK-NEXT: {{^}}        ^
-
-UNSUPPORTED_2
-// CHECK:      experimental_diagnostics_cmacros.swift:{{[0-9]+}}:{{[0-9]+}}: error: cannot find 'UNSUPPORTED_2' in scope
-// CHECK-NEXT: UNSUPPORTED_2
-// CHECK-NEXT: ^~~~~~~~~~~~~
-// CHECK-NEXT: macros.h:{{[0-9]+}}:9: note: macro 'UNSUPPORTED_2' unavailable: structure not supported
-// CHECK-NEXT:      #define UNSUPPORTED_2 FUNC_LIKE_MACRO_2(1)
-// CHECK-NEXT: {{^}}        ^
-
-UNSUPPORTED_3
-// CHECK:      experimental_diagnostics_cmacros.swift:{{[0-9]+}}:{{[0-9]+}}: error: cannot find 'UNSUPPORTED_3' in scope
-// CHECK-NEXT: UNSUPPORTED_3
-// CHECK-NEXT: ^~~~~~~~~~~~~
-// CHECK-NEXT: macros.h:{{[0-9]+}}:9: note: macro 'UNSUPPORTED_3' unavailable: structure not supported
-// CHECK-NEXT:      #define UNSUPPORTED_3 1 + FUNC_LIKE_MACRO_2(1)
-// CHECK-NEXT: {{^}}        ^
 
 UNSUPPORTED_4
 // CHECK:      experimental_diagnostics_cmacros.swift:{{[0-9]+}}:{{[0-9]+}}: error: cannot find 'UNSUPPORTED_4' in scope
 // CHECK-NEXT: UNSUPPORTED_4
 // CHECK-NEXT: ^~~~~~~~~~~~~
-// CHECK-NEXT: macros.h:{{[0-9]+}}:9: note: macro 'UNSUPPORTED_4' unavailable: structure not supported
+// CHECK-NEXT: macros.h:{{[0-9]+}}:9: note: macro 'UNSUPPORTED_4' unavailable (cannot import)
 // CHECK-NEXT:      #define UNSUPPORTED_4                                                          \
-// CHECK-NEXT: {{^}}        ^
-
-UNSUPPORTED_5
-// CHECK:      experimental_diagnostics_cmacros.swift:{{[0-9]+}}:{{[0-9]+}}: error: cannot find 'UNSUPPORTED_5' in scope
-// CHECK-NEXT: UNSUPPORTED_5
-// CHECK-NEXT: ^~~~~~~~~~~~~
-// CHECK-NEXT: macros.h:{{[0-9]+}}:9: note: macro 'UNSUPPORTED_5' unavailable: structure not supported
-// CHECK-NEXT:      #define UNSUPPORTED_5 1 + 1 + 1
 // CHECK-NEXT: {{^}}        ^

--- a/test/ClangImporter/experimental_eager_diagnostics.swift
+++ b/test/ClangImporter/experimental_eager_diagnostics.swift
@@ -1,4 +1,4 @@
-// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -swift-version 5 -enable-experimental-eager-clang-module-diagnostics -enable-objc-interop -typecheck %s -diagnostic-style llvm 2>&1 | %FileCheck %s --strict-whitespace
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -swift-version 5 -enable-experimental-eager-clang-module-diagnostics -enable-objc-interop -typecheck %s -diagnostic-style llvm 2>&1 | %FileCheck %s --strict-whitespace
 
 // REQUIRES: objc_interop
 
@@ -173,72 +173,34 @@ import macros
 
 // Macros
 
-// CHECK:      macros.h:{{[0-9]+}}:9: note: macro 'CHAR_LITERAL' unavailable (cannot import)
-// CHECK-NEXT:      #define CHAR_LITERAL 'a'
-// CHECK-NEXT: {{^}}        ^
-// CHECK-NEXT: macros.h:{{[0-9]+}}:22: note: only numeric and string macro literals supported
-// CHECK-NEXT:      #define CHAR_LITERAL 'a'
-// CHECK-NEXT: {{^}}                     ^
-
 // CHECK:      macros.h:{{[0-9]+}}:9: note: macro 'FUNC_LIKE_MACRO' unavailable: function like macros not supported
 // CHECK-NEXT:      #define FUNC_LIKE_MACRO() 0
 // CHECK-NEXT: {{^}}        ^
 
-// CHECK:      macros.h:{{[0-9]+}}:9: note: macro 'INVALID_ARITHMETIC_1' unavailable: structure not supported
+// CHECK:      macros.h:{{[0-9]+}}:9: note: macro 'INVALID_ARITHMETIC_1' unavailable (cannot import)
 // CHECK-NEXT:      #define INVALID_ARITHMETIC_1 5 + INVALID_INTEGER_LITERAL_1
 // CHECK-NEXT: {{^}}        ^
 
-// CHECK:      macros.h:{{[0-9]+}}:9: note: macro 'INVALID_ARITHMETIC_2' unavailable: structure not supported
+// CHECK:      macros.h:{{[0-9]+}}:9: note: macro 'INVALID_ARITHMETIC_2' unavailable (cannot import)
 // CHECK-NEXT:      #define INVALID_ARITHMETIC_2 INVALID_INTEGER_LITERAL_1 + ADD_TWO
 // CHECK-NEXT: {{^}}        ^
 
-// CHECK:      macros.h:{{[0-9]+}}:9: note: macro 'INVALID_ARITHMETIC_3' unavailable: structure not supported
+// CHECK:      macros.h:{{[0-9]+}}:9: note: macro 'INVALID_ARITHMETIC_3' unavailable (cannot import)
 // CHECK-NEXT:      #define INVALID_ARITHMETIC_3 ADD_TWO + INVALID_INTEGER_LITERAL_1
 // CHECK-NEXT: {{^}}        ^
 
-// CHECK:      macros.h:{{[0-9]+}}:9: note: macro 'INVALID_ARITHMETIC_4' unavailable: structure not supported
+// CHECK:      macros.h:{{[0-9]+}}:9: note: macro 'INVALID_ARITHMETIC_4' unavailable (cannot import)
 // CHECK-NEXT:      #define INVALID_ARITHMETIC_4                                                   \
 // CHECK-NEXT: {{^}}        ^
 
-// CHECK:      macros.h:{{[0-9]+}}:9: note: macro 'INVALID_ARITHMETIC_5' unavailable: structure not supported
+// CHECK:      macros.h:{{[0-9]+}}:9: note: macro 'INVALID_ARITHMETIC_5' unavailable (cannot import)
 // CHECK-NEXT:      #define INVALID_ARITHMETIC_5 1 + VERSION_STRING
 // CHECK-NEXT: {{^}}        ^
-
-// CHECK:      macros.h:{{[0-9]+}}:9: note: macro 'INVALID_ARITHMETIC_6' unavailable: structure not supported
-// CHECK-NEXT:      #define INVALID_ARITHMETIC_6 1 + 'c'
-// CHECK-NEXT: {{^}}        ^
-
-// CHECK:      macros.h:{{[0-9]+}}:9: note: macro 'INVALID_ARITHMETIC_7' unavailable (cannot import)
-// CHECK-NEXT:      #define INVALID_ARITHMETIC_7 3 % 2
-// CHECK-NEXT: {{^}}        ^
-// CHECK-NEXT: macros.h:{{[0-9]+}}:32: note: operator '%' not supported in macro arithmetic
-// CHECK-NEXT:      #define INVALID_ARITHMETIC_7 3 % 2
-// CHECK-NEXT: {{^}}                               ^
 
 // CHECK:      macros.h:{{[0-9]+}}:9: note: macro 'INVALID_INTEGER_LITERAL_2' unavailable (cannot import)
 // CHECK-NEXT:      #define INVALID_INTEGER_LITERAL_2 10abc
 // CHECK-NEXT: {{^}}        ^
-// CHECK-NEXT: macros.h:{{[0-9]+}}:35: note: invalid numeric literal
-// CHECK-NEXT:      #define INVALID_INTEGER_LITERAL_2 10abc
-// CHECK-NEXT: {{^}}                                  ^
 
-
-// CHECK:      macros.h:{{[0-9]+}}:9: note: macro 'UNSUPPORTED_1' unavailable: structure not supported
-// CHECK-NEXT:      #define UNSUPPORTED_1 FUNC_LIKE_MACRO()
-// CHECK-NEXT: {{^}}        ^
-
-// CHECK:      macros.h:{{[0-9]+}}:9: note: macro 'UNSUPPORTED_2' unavailable: structure not supported
-// CHECK-NEXT:      #define UNSUPPORTED_2 FUNC_LIKE_MACRO_2(1)
-// CHECK-NEXT: {{^}}        ^
-
-// CHECK:      macros.h:{{[0-9]+}}:9: note: macro 'UNSUPPORTED_3' unavailable: structure not supported
-// CHECK-NEXT:      #define UNSUPPORTED_3 1 + FUNC_LIKE_MACRO_2(1)
-// CHECK-NEXT: {{^}}        ^
-
-// CHECK:      macros.h:{{[0-9]+}}:9: note: macro 'UNSUPPORTED_4' unavailable: structure not supported
+// CHECK:      macros.h:{{[0-9]+}}:9: note: macro 'UNSUPPORTED_4' unavailable (cannot import)
 // CHECK-NEXT:      #define UNSUPPORTED_4                                                          \
-// CHECK-NEXT: {{^}}        ^
-
-// CHECK:      macros.h:{{[0-9]+}}:9: note: macro 'UNSUPPORTED_5' unavailable: structure not supported
-// CHECK-NEXT:      #define UNSUPPORTED_5 1 + 1 + 1
 // CHECK-NEXT: {{^}}        ^

--- a/test/ClangImporter/macro_bool_constants.swift
+++ b/test/ClangImporter/macro_bool_constants.swift
@@ -30,10 +30,9 @@ import CModule
 // Make sure we can import these constants.
 print(usesUnderscoreBoolAlias)
 print(usesBoolAlias)
+print(usesUnderscoreBool)
+print(usesBool)
 
 //--- invalid.swift
 import CModule
-
-// FIXME: These ought to work too
-print(usesUnderscoreBool) // expected-error {{cannot find 'usesUnderscoreBool' in scope}}
-print(usesBool) // expected-error {{cannot find 'usesBool' in scope}}
+// No macros are expected to fail import currently.

--- a/test/ClangImporter/rdar156524292.swift
+++ b/test/ClangImporter/rdar156524292.swift
@@ -8,11 +8,9 @@
 //--- cmodule.h
 #import <CoreGraphics/CoreGraphics.h>
 #define intLiteralCGFloat ((CGFloat)0)
-// expected-note@-1 {{invalid numeric literal}}
-// expected-note@-2 {{macro 'intLiteralCGFloat' unavailable (cannot import)}}
+// expected-note@-1 {{macro 'intLiteralCGFloat' unavailable (cannot import)}}
 #define floatLiteralCGFloat ((CGFloat)0.0)
-// expected-note@-1 {{invalid numeric literal}}
-// expected-note@-2 {{macro 'floatLiteralCGFloat' unavailable (cannot import)}}
+// expected-note@-1 {{macro 'floatLiteralCGFloat' unavailable (cannot import)}}
 
 //--- module.modulemap
 module CModule [system] {

--- a/test/Interop/Cxx/macros/Inputs/constexpr-macros.h
+++ b/test/Interop/Cxx/macros/Inputs/constexpr-macros.h
@@ -1,0 +1,75 @@
+#ifndef CONSTEXPR_MACROS_H
+#define CONSTEXPR_MACROS_H
+
+// Complex integer expressions
+#define COMPLEX_BITWISE (1 << 4 | 1 << 5 | 1 << 6)
+#define CHAINED_ADD (10 + 20 + 30)
+#define MODULO_EXPR (100 % 7)
+#define TERNARY_EXPR (10 > 5 ? 10 : 5)
+#define CHAR_LITERAL ('A')
+#define NESTED_PARENS ((((42))))
+#define MULTI_OP (3 * 4 + 5)
+#define SHIFT_AND_OR ((1 << 0) | (1 << 1) | (1 << 2))
+#define COMPLEX_ARITH ((100 - 50) * 2 + 10 / 5)
+#define CHAINED_SHIFT (1 << 2 << 1)
+#define NEGATION_EXPR (~0 & 0xFF)
+
+// Macro chains
+#define BASE_VAL 100
+#define DERIVED_VAL (BASE_VAL + 50)
+#define CHAINED_MACRO_EXPR (BASE_VAL * 2 + DERIVED_VAL)
+
+// Boolean / comparison results
+#define CMP_EQUAL (42 == 42)
+#define CMP_NOT_EQUAL (1 != 2)
+#define CMP_LESS (1 < 2)
+#define CMP_GREATER (10 > 5)
+#define LOGICAL_AND (1 && 1)
+#define LOGICAL_OR (0 || 1)
+#define LOGICAL_COMPLEX ((1 < 2) && (3 > 0))
+#define LOGICAL_NOT (!0)
+#define LOGICAL_NOT_EXPR (!(1 > 2))
+
+// Unsigned type preservation
+#define UNSIGNED_VAL 42U
+#define UNSIGNED_LONG_VAL 100UL
+#define UNSIGNED_EXPR (10U + 20U)
+
+// Float expressions
+#define FLOAT_LITERAL 3.14
+#define FLOAT_EXPR (1.5 + 2.5)
+#define FLOAT_NEG (-1.5)
+#define FLOAT_COMPLEX (3.0 * 2.0 + 1.0)
+
+// Type casts
+#define CAST_UNSIGNED ((unsigned)42)
+#define CAST_LONG_LONG ((long long)1)
+
+// Function-like macros in replacement text
+#define FUNC_LIKE() 42
+#define FUNC_LIKE_ARG(x) ((x) * 2)
+#define USES_FUNC_LIKE FUNC_LIKE()
+#define USES_FUNC_LIKE_ARG FUNC_LIKE_ARG(21)
+#define EXPR_WITH_FUNC_LIKE (1 + FUNC_LIKE())
+
+// Fancy errors
+#define ERR_SYS(x) ((signed)((((unsigned)(x)) & 0x3f) << 26))
+#define ERR_SUB(x) (((x) & 0xfff) << 14)
+#define SYS_FANCY ERR_SYS(0x38)
+#define SUB_FANCY_COMMON ERR_SUB(0)
+#define COMMON_ERR(return) (SYS_FANCY | SUB_FANCY_COMMON | return)
+#define FANCY_BAD_ARG COMMON_ERR(0x2c2)
+
+// Negative cases: should NOT be importable
+#define EMPTY_MACRO
+#define FUNC_LIKE_MACRO_ONLY(x) ((x) + 1)
+
+// Negative case: LValue to constexpr var
+constexpr int kConstexprVar = 99;
+#define MACRO_REF_CONSTEXPR kConstexprVar
+
+// Negative case: Enum constant
+enum Color { Red = 0, Green = 1, Blue = 2 };
+#define MACRO_REF_ENUM Green
+
+#endif

--- a/test/Interop/Cxx/macros/Inputs/module.modulemap
+++ b/test/Interop/Cxx/macros/Inputs/module.modulemap
@@ -1,0 +1,4 @@
+module ConstexprMacros {
+  header "constexpr-macros.h"
+  requires cplusplus
+}

--- a/test/Interop/Cxx/macros/constexpr-macro-import-negative.swift
+++ b/test/Interop/Cxx/macros/constexpr-macro-import-negative.swift
@@ -1,0 +1,12 @@
+// RUN: %target-swift-frontend -typecheck -I %S/Inputs %s -enable-experimental-cxx-interop -verify -verify-ignore-unrelated
+
+// REQUIRES: objc_interop
+
+import ConstexprMacros
+
+func testNegativeCases() {
+  _ = EMPTY_MACRO             // expected-error{{cannot find 'EMPTY_MACRO' in scope}}
+  _ = FUNC_LIKE_MACRO_ONLY(1) // expected-error{{cannot find 'FUNC_LIKE_MACRO_ONLY' in scope}}
+  _ = MACRO_REF_CONSTEXPR     // expected-error{{cannot find 'MACRO_REF_CONSTEXPR' in scope}}
+  _ = MACRO_REF_ENUM          // expected-error{{cannot find 'MACRO_REF_ENUM' in scope}}
+}

--- a/test/Interop/Cxx/macros/constexpr-macro-import.swift
+++ b/test/Interop/Cxx/macros/constexpr-macro-import.swift
@@ -1,0 +1,80 @@
+// RUN: %target-swift-frontend -typecheck -I %S/Inputs %s -enable-experimental-cxx-interop -verify
+
+// REQUIRES: objc_interop
+
+// expected-no-diagnostics
+
+import ConstexprMacros
+
+// Complex integer expressions
+func testComplexIntegerExpressions() {
+  let _: CInt = COMPLEX_BITWISE   // (1 << 4 | 1 << 5 | 1 << 6) = 112
+  let _: CInt = CHAINED_ADD       // 10 + 20 + 30 = 60
+  let _: CInt = MODULO_EXPR       // 100 % 7 = 2
+  let _: CInt = TERNARY_EXPR      // 10 > 5 ? 10 : 5 = 10
+  let _: CChar = CHAR_LITERAL     // 'A' = 65
+  let _: CInt = NESTED_PARENS     // ((((42)))) = 42
+  let _: CInt = MULTI_OP          // 3 * 4 + 5 = 17
+  let _: CInt = SHIFT_AND_OR      // (1<<0)|(1<<1)|(1<<2) = 7
+  let _: CInt = COMPLEX_ARITH     // (100-50)*2 + 10/5 = 102
+  let _: CInt = CHAINED_SHIFT     // 1 << 2 << 1 = 8
+  let _: CInt = NEGATION_EXPR     // ~0 & 0xFF = 255
+}
+
+// Macro chains
+func testMacroChains() {
+  let _: CInt = BASE_VAL           // 100
+  let _: CInt = DERIVED_VAL        // 150
+  let _: CInt = CHAINED_MACRO_EXPR // 100*2 + 150 = 350
+}
+
+// Boolean / comparison results
+func testBooleanResults() {
+  let _: Bool = CMP_EQUAL          // 42 == 42
+  let _: Bool = CMP_NOT_EQUAL      // 1 != 2
+  let _: Bool = CMP_LESS           // 1 < 2
+  let _: Bool = CMP_GREATER        // 10 > 5
+  let _: Bool = LOGICAL_AND        // 1 && 1
+  let _: Bool = LOGICAL_OR         // 0 || 1
+  let _: Bool = LOGICAL_COMPLEX    // (1 < 2) && (3 > 0)
+  let _: Bool = LOGICAL_NOT        // !0
+  let _: Bool = LOGICAL_NOT_EXPR   // !(1 > 2)
+
+  // Verify these are actually Bool, not Int32.
+  if CMP_EQUAL && LOGICAL_AND {}
+}
+
+// Unsigned type preservation
+func testUnsignedTypes() {
+  let _: CUnsignedInt = UNSIGNED_VAL       // 42U
+  let _: CUnsignedLong = UNSIGNED_LONG_VAL // 100UL
+  let _: CUnsignedInt = UNSIGNED_EXPR      // 10U + 20U = 30
+}
+
+// Float expressions
+func testFloatExpressions() {
+  let _: CDouble = FLOAT_LITERAL   // 3.14
+  let _: CDouble = FLOAT_EXPR      // 1.5 + 2.5 = 4.0
+  let _: CDouble = FLOAT_NEG       // -1.5
+  let _: CDouble = FLOAT_COMPLEX   // 3.0*2.0 + 1.0 = 7.0
+}
+
+// Type casts
+func testTypeCasts() {
+  let _: CUnsignedInt = CAST_UNSIGNED    // (unsigned)42
+  let _: CLongLong = CAST_LONG_LONG      // (long long)1
+}
+
+// Function-like macros in replacement text
+func testFuncLikeInBody() {
+  let _: CInt = USES_FUNC_LIKE           // FUNC_LIKE() = 42
+  let _: CInt = USES_FUNC_LIKE_ARG       // FUNC_LIKE_ARG(21) = 42
+  let _: CInt = EXPR_WITH_FUNC_LIKE      // 1 + FUNC_LIKE() = 43
+}
+
+// Fancy errors
+func testFancyErrors() {
+  let _: CInt = SYS_FANCY        // ERR_SYS(0x38)
+  let _: CInt = SUB_FANCY_COMMON // ERR_SUB(0)
+  let _: CInt = FANCY_BAD_ARG    // COMMON_ERR(0x2c2)
+}


### PR DESCRIPTION
Replace manual token pattern matching with Clang's Parser::ParseConstantExpression() + Expr::EvaluateAsConstantExpr(). This delegates arithmetic, casts, ternary operators, nested macros, and type inference to Clang rather than reimplementing them.

The import now proceeds in three phases:
1. Token patterns for nil/ObjC/CF constructs that aren't valid C++
2. Declaration alias
3. Clang's constexpr evaluation

New macros that now import correctly include complex bitwise expressions, chained arithmetic, modulo, ternary, char literals, C-style casts, and macros referencing other macros.

rdar://170757196