### PR TITLE
[SILGen] Mark +0 base unresolved for consuming accessor

### DIFF
--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -7467,7 +7467,8 @@ ArgumentSource AccessorBaseArgPreparer::prepareAccessorAddressBaseArg() {
       // If the base is move only and a +0 value, then the copy we're about to emit is invalid
       // and will later be diagnosed by the move checker. We'll mark the base as unresolved
       // to give the move checker a chance to salvage things if it can eliminate the copy.
-      if (!shouldTake && base.getType().isMoveOnly()) {
+      if (!shouldTake && base.getType().isMoveOnly() &&
+          !isa<MarkUnresolvedNonCopyableValueInst>(base.getValue())) {
           auto marked = SGF.B.createMarkUnresolvedNonCopyableValueInst(
               loc, base.getValue(),
               MarkUnresolvedNonCopyableValueInst::CheckKind::NoConsumeOrAssign);

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -7467,7 +7467,7 @@ ArgumentSource AccessorBaseArgPreparer::prepareAccessorAddressBaseArg() {
       // If the base is move only and a +0 value, then the copy we're about to emit is invalid
       // and will later be diagnosed by the move checker. We'll mark the base as unresolved
       // to give the move checker a chance to salvage things if it can eliminate the copy.
-      if (!shouldTake && base.getType().isMoveOnly() &&
+      if (selfParam.isConsumedInCaller() && !shouldTake && base.getType().isMoveOnly() &&
           !isa<MarkUnresolvedNonCopyableValueInst>(base.getValue())) {
           auto marked = SGF.B.createMarkUnresolvedNonCopyableValueInst(
               loc, base.getValue(),

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -7463,6 +7463,16 @@ ArgumentSource AccessorBaseArgPreparer::prepareAccessorAddressBaseArg() {
     if (selfParam.isConsumedInCaller() || base.getType().isAddressOnly(SGF.F)) {
       // The load can only be a take if the base is a +1 rvalue.
       auto shouldTake = IsTake_t(base.hasCleanup());
+      
+      // If the base is move only and a +0 value, then the copy we're about to emit is invalid
+      // and will later be diagnosed by the move checker. We'll mark the base as unresolved
+      // to give the move checker a chance to salvage things if it can eliminate the copy.
+      if (!shouldTake && base.getType().isMoveOnly()) {
+          auto marked = SGF.B.createMarkUnresolvedNonCopyableValueInst(
+              loc, base.getValue(),
+              MarkUnresolvedNonCopyableValueInst::CheckKind::NoConsumeOrAssign);
+          base = ManagedValue::forBorrowedAddressRValue(marked);
+      }
 
       auto isGuaranteed = selfParam.isGuaranteedInCaller();
 

--- a/test/SILGen/Inputs/resilient_consuming_getter_nonescapable.swift
+++ b/test/SILGen/Inputs/resilient_consuming_getter_nonescapable.swift
@@ -8,3 +8,13 @@ public struct NCNE: ~Escapable, ~Copyable {
     }
   }
 }
+
+public struct NC: ~Copyable {
+  public init() {}
+
+  @_owned public var value: NC {
+    consuming get {
+      NC()
+    }
+  }
+}

--- a/test/SILGen/Inputs/resilient_consuming_getter_nonescapable.swift
+++ b/test/SILGen/Inputs/resilient_consuming_getter_nonescapable.swift
@@ -1,0 +1,10 @@
+public struct NCNE: ~Escapable, ~Copyable {
+  var _bytes: UnsafeMutableBufferPointer<Int>
+
+  @_owned public var bytes: MutableSpan<Int> {
+    @_lifetime(copy self)
+    consuming get {
+      _overrideLifetime(MutableSpan(_unsafeElements: _bytes), copying: self)
+    }
+  }
+}

--- a/test/SILGen/resilient_consuming_getter_nonescapable_test.swift
+++ b/test/SILGen/resilient_consuming_getter_nonescapable_test.swift
@@ -1,0 +1,21 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -enable-library-evolution -emit-module-path=%t/ResilientLib.swiftmodule -module-name=ResilientLib %S/Inputs/resilient_consuming_getter_nonescapable.swift -enable-experimental-feature Lifetimes -enable-experimental-feature UnderscoreOwned
+// RUN: %target-swift-emit-silgen %s -I %t -enable-experimental-feature Lifetimes -enable-experimental-feature UnderscoreOwned | %FileCheck %s
+// RUN: %target-swift-emit-sil %s -I %t -enable-experimental-feature Lifetimes -enable-experimental-feature UnderscoreOwned -verify
+
+import ResilientLib
+
+// Verify that calling a consuming getter on a noncopyable l-value from a resilient library
+// gets a `mark_unresolved_non_copyable_value` and compiles.
+
+// CHECK-LABEL: sil hidden [ossa] @$s{{.*}}9takeThing{{.*}} : $@convention(thin) (@in Thing) -> ()
+func takeThing(out: consuming NCNE) {
+  // CHECK: [[ACCESS:%.*]] = begin_access [read]
+  // CHECK: [[MARKED:%.*]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[ACCESS]]
+  // CHECK: [[TEMP:%.*]] = alloc_stack $Thing
+  // CHECK: copy_addr [[MARKED]] to [init] [[TEMP]]
+  // CHECK: [[GETTER:%.*]] = function_ref @$s12ResilientLib5ThingV5bytess11MutableSpanVySiGvg
+  // CHECK: apply [[GETTER]]([[TEMP]])
+  let bytes = out.bytes
+  _ = consume bytes
+}

--- a/test/SILGen/resilient_consuming_getter_nonescapable_test.swift
+++ b/test/SILGen/resilient_consuming_getter_nonescapable_test.swift
@@ -3,6 +3,9 @@
 // RUN: %target-swift-emit-silgen %s -I %t -enable-experimental-feature Lifetimes -enable-experimental-feature UnderscoreOwned | %FileCheck %s
 // RUN: %target-swift-emit-sil %s -I %t -enable-experimental-feature Lifetimes -enable-experimental-feature UnderscoreOwned -verify
 
+// REQUIRES: swift_feature_Lifetimes
+// REQUIRES: swift_feature_UnderscoreOwned
+
 import ResilientLib
 
 // Verify that calling a consuming getter on a noncopyable l-value from a resilient library

--- a/test/SILGen/resilient_consuming_getter_nonescapable_test.swift
+++ b/test/SILGen/resilient_consuming_getter_nonescapable_test.swift
@@ -8,14 +8,20 @@ import ResilientLib
 // Verify that calling a consuming getter on a noncopyable l-value from a resilient library
 // gets a `mark_unresolved_non_copyable_value` and compiles.
 
-// CHECK-LABEL: sil hidden [ossa] @$s{{.*}}9takeThing{{.*}} : $@convention(thin) (@in Thing) -> ()
+// CHECK-LABEL: sil hidden [ossa] @$s{{.*}}9takeThing{{.*}} : $@convention(thin) (@in NCNE) -> ()
 func takeThing(out: consuming NCNE) {
   // CHECK: [[ACCESS:%.*]] = begin_access [read]
   // CHECK: [[MARKED:%.*]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[ACCESS]]
-  // CHECK: [[TEMP:%.*]] = alloc_stack $Thing
+  // CHECK: [[TEMP:%.*]] = alloc_stack $NCNE
   // CHECK: copy_addr [[MARKED]] to [init] [[TEMP]]
-  // CHECK: [[GETTER:%.*]] = function_ref @$s12ResilientLib5ThingV5bytess11MutableSpanVySiGvg
+  // CHECK: [[GETTER:%.*]] = function_ref @$s12ResilientLib4NCNEV5bytess11MutableSpanVySiGvg
   // CHECK: apply [[GETTER]]([[TEMP]])
   let bytes = out.bytes
+  _ = consume bytes
+}
+
+// Verify that calling a consuming getter on a borrowed noncopyable value is rejected.
+func takeThingBorrowing(out: borrowing NCNE) { // expected-error {{'out' is borrowed and cannot be consumed}}
+  let bytes = out.bytes // expected-error {{'out' is borrowed and cannot be consumed}} expected-note 2 {{consumed here}}
   _ = consume bytes
 }

--- a/test/SILGen/resilient_consuming_getter_nonescapable_test.swift
+++ b/test/SILGen/resilient_consuming_getter_nonescapable_test.swift
@@ -25,3 +25,10 @@ func takeThingBorrowing(out: borrowing NCNE) { // expected-error {{'out' is borr
   let bytes = out.bytes // expected-error {{'out' is borrowed and cannot be consumed}} expected-note 2 {{consumed here}}
   _ = consume bytes
 }
+
+// This function is here to test that a normal NC value with consuming getter invoked compiles
+// and specifically doesn't fail due to duplicate mark_unresolved_non_copyable_value instructions with the change for rdar://175724267.
+func takeNC(out: consuming NC) {
+  let v = out.value
+  _ = consume v
+}

--- a/test/SILGen/resilient_consuming_getter_nonescapable_test.swift
+++ b/test/SILGen/resilient_consuming_getter_nonescapable_test.swift
@@ -22,7 +22,7 @@ func takeThing(out: consuming NCNE) {
 
 // Verify that calling a consuming getter on a borrowed noncopyable value is rejected.
 func takeThingBorrowing(out: borrowing NCNE) { // expected-error {{'out' is borrowed and cannot be consumed}}
-  let bytes = out.bytes // expected-error {{'out' is borrowed and cannot be consumed}} expected-note 2 {{consumed here}}
+  let bytes = out.bytes // expected-note {{consumed here}}
   _ = consume bytes
 }
 


### PR DESCRIPTION
<!-- Please fill out the following form: --> 
- **Explanation**:
Calling a `consuming get` accessor on a resilient type fails to compile with `copy of noncopyable typed value` error. Fixed by adding the canary marker for the move checker on the offending value that gets copied so it can eliminate the copy.
- **Scope**:
Modifies one function on the SILGen path for preparing a base of a consuming accessor to add a `MarkUnresolvedNonCopyableValueInst`
- **Issues**:
rdar://175724267
- **Risk**:
Should be little to no risk. This should strictly allow some code that previously fails to compile to now compile (but was semantically valid all along).
- **Testing**:
Added a unit test that covers the sample usage

This is somewhat of an expanded version of the fix I previously added here https://github.com/swiftlang/swift/pull/87440. Currently it seems that there's many paths in the earlier part of SILGen that assume that emitting an lvalue path on some base value should be creating a borrow scope and then performing the access, which I think works well for all types of accessors except `consuming` ones. In that previous PR I updated one of these paths to be aware that the accessor might be consuming and avoid emitting a borrow scope, and it fixed that case. However there are at least a few other (maybe more I haven't considered) cases where we end up having already constructed the borrow scope and arrive in `AccessorBaseArgPreparer::prepareAccessorAddressBaseArg` where we have a +0 value and need to copy it to invoke a consuming accessor... which will fail for noncopyable types.

So instead of updating each source location that assumes the accessor can be invoked on a +0 value, we can add a more resilient safety net in `AccessorBaseArgPreparer::prepareAccessorAddressBaseArg` which sees when it's about to emit an invalid copy (move only +0 value) and insert a `mark_unresolved_non_copyable_value [no_consume_or_assign]` to give the move checker a chance to eliminate the copy in the case where the borrow scope was unnecessary to begin with (which it seems to already do well!).

The example reproducer:
```
// Resilient library
public struct NCNE: ~Escapable, ~Copyable {
  var _bytes: UnsafeMutableBufferPointer<Int>

  @_owned public var bytes: MutableSpan<Int> {
    @_lifetime(copy self)
    consuming get {
      _overrideLifetime(MutableSpan(_unsafeElements: _bytes), copying: self)
    }
  }
}
```

Client code:
```
func takeThing(out: consuming NCNE) {
  let bytes = out.bytes // error: copy of noncopyable typed value. This is a compiler bug. Please file a bug with a small example of the bug
}
```

This now compiles without error.

