### PR TITLE
utils: extract Build-Bootstrap{Foundation,Testing}Macros (NFC)

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -4082,6 +4082,32 @@ function Test-SourceKitLSP {
   }
 }
 
+function Build-BootstrapFoundationMacros([Hashtable] $Platform) {
+  Build-CMakeProject `
+    -Src $SourceCache\swift-foundation\Sources\FoundationMacros `
+    -Bin (Get-ProjectBinaryCache $Platform BootstrapFoundationMacros) `
+    -BuildTargets default `
+    -Platform $Platform `
+    -UsePinnedCompilers Swift `
+    -SwiftSDK (Get-PinnedToolchainSDK -OS $Platform.OS) `
+    -Defines @{
+      SwiftSyntax_DIR = (Get-ProjectCMakeModules $Platform Compilers);
+    }
+}
+
+function Build-BootstrapTestingMacros([Hashtable] $Platform) {
+  Build-CMakeProject `
+    -Src $SourceCache\swift-testing\Sources\TestingMacros `
+    -Bin (Get-ProjectBinaryCache $Platform BootstrapTestingMacros) `
+    -BuildTargets default `
+    -Platform $Platform `
+    -UsePinnedCompilers Swift `
+    -SwiftSDK (Get-PinnedToolchainSDK -OS $Platform.OS) `
+    -Defines @{
+      SwiftSyntax_DIR = (Get-ProjectCMakeModules $Platform Compilers);
+    }
+}
+
 function Build-TestingMacros([Hashtable] $Platform) {
   Build-CMakeProject `
     -Src $SourceCache\swift-testing\Sources\TestingMacros `
@@ -4313,28 +4339,8 @@ if (-not $SkipBuild) {
     Invoke-BuildStep Build-CompilerRuntime $_
   }
 
-  # Build Macros
-  Build-CMakeProject `
-    -Src $SourceCache\swift-foundation\Sources\FoundationMacros `
-    -Bin (Get-ProjectBinaryCache $BuildPlatform BootstrapFoundationMacros) `
-    -BuildTargets default `
-    -Platform $BuildPlatform `
-    -UsePinnedCompilers Swift `
-    -SwiftSDK (Get-PinnedToolchainSDK -OS $BuildPlatform.OS) `
-    -Defines @{
-      SwiftSyntax_DIR = (Get-ProjectCMakeModules $BuildPlatform Compilers);
-    }
-
-  Build-CMakeProject `
-    -Src $SourceCache\swift-testing\Sources\TestingMacros `
-    -Bin (Get-ProjectBinaryCache $BuildPlatform BootstrapTestingMacros) `
-    -BuildTargets default `
-    -Platform $BuildPlatform `
-    -UsePinnedCompilers Swift `
-    -SwiftSDK (Get-PinnedToolchainSDK -OS $BuildPlatform.OS) `
-    -Defines @{
-      SwiftSyntax_DIR = (Get-ProjectCMakeModules $BuildPlatform Compilers);
-    }
+  Invoke-BuildStep Build-BootstrapFoundationMacros $BuildPlatform
+  Invoke-BuildStep Build-BootstrapTestingMacros $BuildPlatform
 
   if ($Windows) {
     Build-SDKDependencies $WindowsSDKBuilds


### PR DESCRIPTION
The two bootstrap macro builds were inlined directly in the main build sequence as raw Build-CMakeProject calls, inconsistent with every other build step which is expressed as Invoke-BuildStep <Function> <Platform>. Extract them into named functions so the build sequence is a uniform list of Invoke-BuildStep invocations.

- **Explanation**: Structural cleanup for build.ps1
- **Scope**: Impacts only the structure of the build script for windows
- **Issues**:
- **Risk**: Extremely low risk, no functional change involved
- **Testing**: Build a toolchain