### PR TITLE
[cxx-interop] Deserialization failure with namespaces

### DIFF
--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -2489,16 +2489,24 @@ ModuleFile::resolveCrossReference(ModuleID MID, uint32_t pathLen) {
     // signature. Even if we recover, print as a warning the errors we skip.
     if (getContext().LangOpts.EnableWorkaroundBrokenModules &&
         errorKind == ModularizationError::Kind::DeclMoved &&
-        baseModule->findUnderlyingClangModule() &&
+        (baseModule->findUnderlyingClangModule() ||
+         baseModule->isClangHeaderImportModule()) &&
         foundIn->findUnderlyingClangModule() &&
         !values.empty()) {
-      // Print the error as a warning and notify of the recovery attempt.
-      llvm::handleAllErrors(std::move(error),
-        [&](const ModularizationError &modularError) {
-          modularError.diagnose(this, DiagnosticBehavior::Warning);
-        });
-      getContext().Diags.diagnose(SourceLoc(),
-                                  diag::modularization_issue_worked_around);
+      if (baseModule->isClangHeaderImportModule()) {
+        // C++ namespaces are placed in the '__ObjC' header import module
+        // but are found in their actual Clang module during deserialization.
+        // This is expected, so recover silently.
+        llvm::consumeError(std::move(error));
+      } else {
+        // Print the error as a warning and notify of the recovery attempt.
+        llvm::handleAllErrors(std::move(error),
+          [&](const ModularizationError &modularError) {
+            modularError.diagnose(this, DiagnosticBehavior::Warning);
+          });
+        getContext().Diags.diagnose(SourceLoc(),
+                                    diag::modularization_issue_worked_around);
+      }
     } else {
       return std::move(error);
     }

--- a/test/Interop/Cxx/enum/overload.swift
+++ b/test/Interop/Cxx/enum/overload.swift
@@ -1,0 +1,42 @@
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/include)
+// RUN: split-file %s %t
+//
+// RUN: %target-swift-frontend -emit-module -module-name a -emit-module-path %t/include/a.swiftmodule %t/a.swift -cxx-interoperability-mode=default -I %t/include
+// RUN: %target-swift-frontend -typecheck -primary-file %t/b1.swift %t/b2.swift -cxx-interoperability-mode=default -I %t/include
+
+//--- include/module.modulemap
+module cxx {
+  header "header.h"
+  export *
+}
+
+//--- include/header.h
+namespace swift {
+enum class DiagID {
+  x, y, z
+};
+}
+
+//--- a.swift
+import cxx
+public struct Loc1 {}
+public struct Loc2 {}
+public struct Engine {
+  public func diagnose(_: swift.DiagID, _: Loc1) {}
+  public func diagnose(_: swift.DiagID, _: Loc2) {}
+}
+
+//--- b1.swift
+import a
+import cxx
+private func test1(engine: Engine, loc: Loc1) {
+  engine.diagnose(.y, loc)
+}
+
+//--- b2.swift
+import a
+import cxx
+private func test2(engine: Engine, loc: Loc2, id: swift.DiagID) {
+  engine.diagnose(id, loc)
+}


### PR DESCRIPTION
Namespaces are imported into the __ObjC module. As a result, when a Swift module is serialized, it refers to the declarations in the __ObjC namespace. However, during deserialization, these declarations are found in their original C++ module. The first failure triggered a recovery that populated the __ObjC module so subsequent lookups succeed.

This PR makes sure we do not consider a declaration from the __ObjC module that was found in a different clang module problematic.

Fixes #82318, #82609

rdar://154592028