### PR TITLE
utils: avoid building examples in ArgumentParser

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -3722,6 +3722,7 @@ function Build-ArgumentParser([Hashtable] $Platform) {
     -Defines @{
       BUILD_SHARED_LIBS = "YES";
       BUILD_TESTING = "NO";
+      BUILD_EXAMPLES = "NO";
       CMAKE_STATIC_LIBRARY_PREFIX_Swift = "lib";
     }
 }


### PR DESCRIPTION
The examples are not distributed, avoid building them.

- **Explanation**: avoid unnecessary building in the Windows build
- **Scope**: Simply changes the ArgumentParser build to not build examples
- **Issues**:
- **Risk**: extremely low risk; packaging will fail if required components are unavailable
- **Testing**: build toolchain