### PR TITLE
[update-checkout] fix duplicate lines on Windows

### DIFF
--- a/utils/update_checkout/update_checkout/parallel_runner.py
+++ b/utils/update_checkout/update_checkout/parallel_runner.py
@@ -89,6 +89,9 @@ class ParallelRunner:
         self._n_threads = n_threads
         self._monitor_polling_period = 0.1
         self._terminal_width = shutil.get_terminal_size().columns
+        if sys.platform == "win32":
+            # 1 column of padding to account for Windows using CRLF by default.
+            self._terminal_width -= 1
         self._pool_args = pool_args
         self._fn_name = fn.__name__
         self._fn = run_safely


### PR DESCRIPTION
Add a 1 col padding to the max terminal width in update checkout to account for Windows using CRLF by default. Without this padding, the output of the script gets truncated.

# Before

```
Running ``update_single_repository`` with up to 16 processes.
Updating [25/55] (llvm-project, swift, swift-syntax, swift-testing, swift-corelibs-xctest, swift-corelibs-foundation ...
Updating [29/55] (llvm-project, swift, swift-integration-tests, ninja, indexstore-db, sourcekit-lsp, swift-format, s ...
Updating [47/55] (llvm-project, curl, libxml2, zlib, brotli, mimalloc, swift-subprocess, boringssl)
```

# After

```
Running ``update_single_repository`` with up to 16 processes.
...
Update checkout succeeded.
```