### PR TITLE
Add support for `SwiftImportAs: opaque_pointer`

### DIFF
--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -777,6 +777,12 @@ bool isCxxConstReferenceType(const clang::Type *type);
 /// makes it import as a reference types. Does not check its bases, if any.
 bool hasImportReferenceAttr(const clang::RecordDecl *decl);
 
+/// Determine whether the given Clang record declaration has the
+/// swift_attr("import_opaque_pointer") attribute, which causes any pointer
+/// to this type to be imported as OpaquePointer regardless of whether the
+/// struct definition is complete.
+bool hasImportAsOpaquePointerAttr(const clang::RecordDecl *decl);
+
 /// Determine whether this typedef is a CF type.
 bool isCFTypeDecl(const clang::TypedefNameDecl *Decl);
 

--- a/lib/ClangImporter/ClangAnalysis.cpp
+++ b/lib/ClangImporter/ClangAnalysis.cpp
@@ -21,6 +21,14 @@ bool importer::hasImportReferenceAttr(const clang::RecordDecl *decl) {
          });
 }
 
+bool importer::hasImportAsOpaquePointerAttr(const clang::RecordDecl *decl) {
+  return decl->hasAttrs() && llvm::any_of(decl->getAttrs(), [](auto *attr) {
+           if (auto swiftAttr = dyn_cast<clang::SwiftAttrAttr>(attr))
+             return swiftAttr->getAttribute() == "import_opaque_pointer";
+           return false;
+         });
+}
+
 /// This routine determines whether \a decl is a foreign reference type, and
 /// whether its foreign reference type attributes are valid. This determinition
 /// considers attributes annotated on both \a decl itself as well as its

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -519,6 +519,20 @@ namespace {
       // All other C pointers to concrete types map to
       // UnsafeMutablePointer<T> or OpaquePointer.
 
+      // If the pointee record is annotated with swift_attr("import_opaque_pointer"),
+      // import as OpaquePointer regardless of whether the struct definition is
+      // complete. This allows SDK overlays (e.g. Android NDK) to normalize a type
+      // like FILE* that is complete on some API levels and opaque on others.
+      if (const auto *recordType = pointeeQualType->getAs<clang::RecordType>()) {
+        if (importer::hasImportAsOpaquePointerAttr(recordType->getDecl())) {
+          auto opaquePointerDecl = Impl.SwiftContext.getOpaquePointerDecl();
+          if (!opaquePointerDecl)
+            return Type();
+          return {opaquePointerDecl->getDeclaredInterfaceType(),
+                  ImportHint::OtherPointer};
+        }
+      }
+
       // With pointer conversions enabled, map to the normal pointer types
       // without special hints.
       Type pointeeType = Impl.importTypeIgnoreIUO(

--- a/test/Interop/C/struct/Inputs/OpaquePointerImportAPINotes.apinotes
+++ b/test/Interop/C/struct/Inputs/OpaquePointerImportAPINotes.apinotes
@@ -1,0 +1,5 @@
+---
+Name: OpaquePointerImportAPINotes
+Tags:
+- Name: FileImpl
+  SwiftImportAs: opaque_pointer

--- a/test/Interop/C/struct/Inputs/module.modulemap
+++ b/test/Interop/C/struct/Inputs/module.modulemap
@@ -22,3 +22,11 @@ module NoncopyableStructs {
 module ReturnForeignReference {
   header "return-foreign-reference.h"
 }
+
+module OpaquePointerImport {
+  header "opaque-pointer-import.h"
+}
+
+module OpaquePointerImportAPINotes {
+  header "opaque-pointer-import-apinotes.h"
+}

--- a/test/Interop/C/struct/Inputs/opaque-pointer-import-apinotes.h
+++ b/test/Interop/C/struct/Inputs/opaque-pointer-import-apinotes.h
@@ -1,0 +1,13 @@
+// Struct with a complete definition but no swift_attr in the header.
+// The OpaquePointerImportAPINotes.apinotes file applies the annotation.
+
+struct FileImpl {
+  int fd;
+  char buf[64];
+};
+
+typedef struct FileImpl *FileHandle;
+
+FileHandle openFileHandle(void);
+void closeFileHandle(FileHandle f);
+struct FileImpl *getRawFileImpl(void);

--- a/test/Interop/C/struct/Inputs/opaque-pointer-import.h
+++ b/test/Interop/C/struct/Inputs/opaque-pointer-import.h
@@ -1,0 +1,20 @@
+// Two structs with full definitions (complete types).
+// OpaqueHandleImpl is annotated to have its pointer imported as OpaquePointer;
+// PlainStruct is not annotated, so its pointer imports as UnsafeMutablePointer<PlainStruct>.
+
+struct __attribute__((swift_attr("import_opaque_pointer"))) OpaqueHandleImpl {
+  int value;
+};
+
+struct PlainStruct {
+  int value;
+};
+
+typedef struct OpaqueHandleImpl *OpaqueHandle;
+
+OpaqueHandle createOpaqueHandle(void);
+void consumeOpaqueHandle(OpaqueHandle h);
+struct OpaqueHandleImpl *getOpaqueHandleRaw(void);
+
+struct PlainStruct *createPlainStruct(void);
+void consumePlainStruct(struct PlainStruct *s);

--- a/test/Interop/C/struct/opaque-pointer-import-apinotes.swift
+++ b/test/Interop/C/struct/opaque-pointer-import-apinotes.swift
@@ -1,0 +1,17 @@
+// RUN: %target-swift-frontend -typecheck -I %S/Inputs/ %s -verify
+
+// Test that SwiftImportAs: opaque_pointer in an .apinotes file causes
+// pointer-to-struct to be imported as OpaquePointer. This requires the
+// corresponding Clang APINotes change in apple/llvm-project to translate
+// the YAML key into swift_attr("import_pointer_as_opaque") on the record.
+
+import OpaquePointerImportAPINotes
+
+func testAnnotatedViaAPINotes(f: FileHandle) {
+  let _: OpaquePointer = f
+  let _: OpaquePointer? = openFileHandle()
+  closeFileHandle(f)
+
+  let raw = getRawFileImpl()
+  let _: OpaquePointer? = raw
+}

--- a/test/Interop/C/struct/opaque-pointer-import.swift
+++ b/test/Interop/C/struct/opaque-pointer-import.swift
@@ -1,0 +1,25 @@
+// RUN: %target-swift-frontend -typecheck -I %S/Inputs/ %s -verify
+
+// Test that a C struct annotated with swift_attr("import_pointer_as_opaque")
+// causes pointer-to-struct to be imported as OpaquePointer, even though the
+// struct definition is complete.
+
+import OpaquePointerImport
+
+// Pointers to the annotated struct come through as OpaquePointer.
+func testAnnotatedViaAttr(h: OpaqueHandle) {
+  // OpaqueHandle is a typedef for OpaqueHandleImpl*, which should be OpaquePointer.
+  let _: OpaquePointer = h
+  let _: OpaquePointer? = createOpaqueHandle()
+  consumeOpaqueHandle(h)
+
+  // Direct struct pointer (not through the typedef) should also be OpaquePointer.
+  let raw = getOpaqueHandleRaw()
+  let _: OpaquePointer? = raw
+}
+
+// Pointers to the unannotated struct still come through as UnsafeMutablePointer<PlainStruct>.
+func testUnannotated(s: UnsafeMutablePointer<PlainStruct>) {
+  let _: UnsafeMutablePointer<PlainStruct>? = createPlainStruct()
+  consumePlainStruct(s)
+}


### PR DESCRIPTION
<!--
The main branch is now in convergence, which means major changes, such as large refactoring or new features, should be avoided. This strategy is intended to maintain the stability of the Swift 6.4 release leading up to the May 4th branch. For any work that requires broad changes or introduces new features, create a feature branch and open a draft pull request. All updates to the swiftlang/swift repository’s main branch require approval from the release managers. A pull request targeting swiftlang/swift will automatically add release managers. You can also contact them via @release-managers in the forum group.
-->

<!-- Please fill out the following form: --> 
- **Explanation**: Adds support for making pointers to C structs always import as `OpaquePointer` through API notes. This is needed to bring down the Android SDK to API level 23, since `FILE` is imported differently on API 23 vs 24.
- **Scope**: This is purely an additive change and won't break any existing code.
- **Issues**: https://forums.swift.org/t/extend-apinotes-to-support-always-importing-c-pointers-as-opaquepointer
- **Risk**: I don't think there is much risk, as mentioned previously this just adds support for an additional API note feature.
- **Testing**: I've ran the tests locally and they pass.
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
