### PR TITLE
[Windows] Enable incremental dependency scan for CAS

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1814,7 +1814,12 @@ function Build-CMakeProject {
       }
 
       if ($UseSwift) {
-        Add-FlagsDefine $Defines CMAKE_Swift_FLAGS @("-explicit-module-build", "-cache-compile-job", "-cas-path", $Cache)
+        Add-FlagsDefine $Defines CMAKE_Swift_FLAGS @(
+          "-explicit-module-build",
+          "-cache-compile-job",
+          "-cas-path", $Cache,
+          "-incremental-dependency-scan"
+        )
       }
     }
 


### PR DESCRIPTION
- **Explanation**: This enables incremental dependency scan for CAS on the Windows toolchain build, which bring small but meaningful speedup in incremental builds with CAS enabled.
- **Scope**: It's a simple flag flip. The flag is already used in the swift driver tests and is known to work.
- **Issues**: None.
- **Risk**: Low. CAS isn't enabled by default.
- **Testing**: Local toolchain build for Windows and the swift CI.