### PR TITLE
[Diagnostics] Emit more specific `nonisolated` diagnostics

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6251,8 +6251,19 @@ GROUPED_ERROR(inverse_requires_any,ExistentialAny,none,
               "constraint that suppresses conformance requires 'any'", ())
 
 ERROR(nonisolated_mutable_storage,none,
-      "'nonisolated' cannot be applied to mutable stored properties",
-      ())
+     "'nonisolated' can not be applied to mutable stored property %0 "
+     "of %kind1",
+     (const VarDecl *, const NominalTypeDecl *))
+ERROR(nonisolated_mutable_storage_no_nominal,none,
+     "'nonisolated' can not be applied to mutable stored property %0",
+     (const VarDecl *))
+ERROR(nonisolated_lazy_storage,none,
+     "'nonisolated' can not be applied to 'lazy' stored property %0",
+     (const VarDecl *))
+ERROR(nonisolated_wrapped_storage,none,
+     "'nonisolated' can not be applied to stored property %0 with a "
+     "property wrapper",
+     (const VarDecl *))
 NOTE(nonisolated_mutable_storage_note,none,
      "convert %0 to a 'let' constant or consider declaring it "
      "'nonisolated(unsafe)' if manually managing concurrency safety",

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -8230,18 +8230,25 @@ void AttributeChecker::visitNonisolatedAttr(NonisolatedAttr *attr) {
         // Otherwise, this stored property has to be qualified as 'unsafe'.
         if (var->supportsMutation() && !attr->isUnsafe() && !canBeNonisolated) {
           if (var->hasAttachedPropertyWrapper()) {
-            diagnoseAndRemoveAttr(attr, diag::nonisolated_mutable_storage)
+            diagnoseAndRemoveAttr(attr, diag::nonisolated_wrapped_storage, var)
                 .warnUntilLanguageModeIf(attr->isImplicit(), LanguageMode::v6)
                 .fixItInsertAfter(attr->getRange().End, "(unsafe)");
             return;
           } else if (var->getAttrs().hasAttribute<LazyAttr>()) {
-            diagnoseAndRemoveAttr(attr, diag::nonisolated_mutable_storage)
+            diagnoseAndRemoveAttr(attr, diag::nonisolated_lazy_storage, var)
                 .warnUntilLanguageMode(LanguageMode::v6)
                 .fixItInsertAfter(attr->getRange().End, "(unsafe)");
             return;
           } else {
-            diagnoseAndRemoveAttr(attr, diag::nonisolated_mutable_storage)
-              .fixItInsertAfter(attr->getRange().End, "(unsafe)");
+            if (auto nominal = dc->getSelfNominalTypeDecl()) {
+                diagnoseAndRemoveAttr(attr, diag::nonisolated_mutable_storage,
+                                      var, nominal)
+                    .fixItInsertAfter(attr->getRange().End, "(unsafe)");
+            } else {
+                diagnoseAndRemoveAttr(attr, diag::nonisolated_mutable_storage_no_nominal,
+                                      var)
+                    .fixItInsertAfter(attr->getRange().End, "(unsafe)");
+            }
             if (var->hasStorage())
               var->diagnose(diag::nonisolated_mutable_storage_note, var);
             return;

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -813,29 +813,29 @@ actor LazyActor {
     lazy var l25: Int = { [unowned self] in self.l }()
 
     nonisolated lazy var l31: Int = { v }()
-    // expected-warning@-1 {{'nonisolated' cannot be applied to mutable stored properties; this is an error in the Swift 6 language mode}}
+    // expected-warning@-1 {{'nonisolated' can not be applied to 'lazy' stored property 'l31'; this is an error in the Swift 6 language mode}}
     // expected-warning@-2 {{actor-isolated default value in a nonisolated context; this is an error in the Swift 6 language mode}}
     nonisolated lazy var l32: Int = v
-    // expected-warning@-1 {{'nonisolated' cannot be applied to mutable stored properties; this is an error in the Swift 6 language mode}}
+    // expected-warning@-1 {{'nonisolated' can not be applied to 'lazy' stored property 'l32'; this is an error in the Swift 6 language mode}}
     nonisolated lazy var l33: Int = { self.v }()
-    // expected-warning@-1 {{'nonisolated' cannot be applied to mutable stored properties; this is an error in the Swift 6 language mode}}
+    // expected-warning@-1 {{'nonisolated' can not be applied to 'lazy' stored property 'l33'; this is an error in the Swift 6 language mode}}
     // expected-warning@-2 {{actor-isolated default value in a nonisolated context; this is an error in the Swift 6 language mode}}
     nonisolated lazy var l34: Int = self.v
-    // expected-warning@-1 {{'nonisolated' cannot be applied to mutable stored properties; this is an error in the Swift 6 language mode}}
+    // expected-warning@-1 {{'nonisolated' can not be applied to 'lazy' stored property 'l34'; this is an error in the Swift 6 language mode}}
     nonisolated lazy var l35: Int = { [unowned self] in self.v }()
-    // expected-warning@-1 {{'nonisolated' cannot be applied to mutable stored properties; this is an error in the Swift 6 language mode}}
+    // expected-warning@-1 {{'nonisolated' can not be applied to 'lazy' stored property 'l35'; this is an error in the Swift 6 language mode}}
     // expected-warning@-2 {{actor-isolated default value in a nonisolated context; this is an error in the Swift 6 language mode}}
 
     nonisolated lazy var l41: Int = { l }()
-    // expected-warning@-1 {{'nonisolated' cannot be applied to mutable stored properties; this is an error in the Swift 6 language mode}}
+    // expected-warning@-1 {{'nonisolated' can not be applied to 'lazy' stored property 'l41'; this is an error in the Swift 6 language mode}}
     nonisolated lazy var l42: Int = l
-    // expected-warning@-1 {{'nonisolated' cannot be applied to mutable stored properties; this is an error in the Swift 6 language mode}}
+    // expected-warning@-1 {{'nonisolated' can not be applied to 'lazy' stored property 'l42'; this is an error in the Swift 6 language mode}}
     nonisolated lazy var l43: Int = { self.l }()
-    // expected-warning@-1 {{'nonisolated' cannot be applied to mutable stored properties; this is an error in the Swift 6 language mode}}
+    // expected-warning@-1 {{'nonisolated' can not be applied to 'lazy' stored property 'l43'; this is an error in the Swift 6 language mode}}
     nonisolated lazy var l44: Int = self.l
-    // expected-warning@-1 {{'nonisolated' cannot be applied to mutable stored properties; this is an error in the Swift 6 language mode}}
+    // expected-warning@-1 {{'nonisolated' can not be applied to 'lazy' stored property 'l44'; this is an error in the Swift 6 language mode}}
     nonisolated lazy var l45: Int = { [unowned self] in self.l }()
-    // expected-warning@-1 {{'nonisolated' cannot be applied to mutable stored properties; this is an error in the Swift 6 language mode}}
+    // expected-warning@-1 {{'nonisolated' can not be applied to 'lazy' stored property 'l45'; this is an error in the Swift 6 language mode}}
 }
 
 // Infer global actors from context only for instance members.

--- a/test/Concurrency/actor_isolation_objc.swift
+++ b/test/Concurrency/actor_isolation_objc.swift
@@ -65,7 +65,7 @@ actor Pumpkin: NSObject {}
 
 actor Bad {
   @objc nonisolated lazy var invalid = 0
-  // expected-warning@-1 {{'nonisolated' cannot be applied to mutable stored properties; this is an error in the Swift 6 language mode}}
+  // expected-warning@-1 {{'nonisolated' can not be applied to 'lazy' stored property 'invalid'; this is an error in the Swift 6 language mode}}
   // expected-error@-2 {{actor-isolated setter for property 'invalid' cannot be '@objc'}}
   // expected-error@-3 {{actor-isolated getter for property 'invalid' cannot be '@objc'}}
 }

--- a/test/Concurrency/global_actor_inference.swift
+++ b/test/Concurrency/global_actor_inference.swift
@@ -399,7 +399,7 @@ struct HasWrapperOnActor {
     synced = 17
   }
 
-  @WrapperActor var actorSynced: Int = 0 // expected-warning {{'nonisolated' cannot be applied to mutable stored properties}}
+  @WrapperActor var actorSynced: Int = 0 // expected-warning {{'nonisolated' can not be applied to stored property 'actorSynced' with a property wrapper; this is an error in the Swift 6 language mode}}
   func testActorSynced() {
     _ = actorSynced
     _ = $actorSynced

--- a/test/Concurrency/global_actor_inference_swift6.swift
+++ b/test/Concurrency/global_actor_inference_swift6.swift
@@ -113,7 +113,7 @@ struct HasWrapperOnActor {
     synced = 17
   }
 
-  @WrapperActor var actorSynced: Int = 0 // expected-error {{'nonisolated' cannot be applied to mutable stored properties}}
+  @WrapperActor var actorSynced: Int = 0 // expected-error {{'nonisolated' can not be applied to stored property 'actorSynced' with a property wrapper}}
 
   func testActorSynced() {
     _ = actorSynced

--- a/test/Concurrency/nonisolated_rules.swift
+++ b/test/Concurrency/nonisolated_rules.swift
@@ -36,8 +36,8 @@ struct ImplicitlySendable {
   nonisolated var d = 0
 
   // never okay
-  nonisolated lazy var e = 0 // expected-error {{'nonisolated' cannot be applied to mutable stored properties}}
-  @P nonisolated var f = 0  // expected-error {{'nonisolated' cannot be applied to mutable stored properties}}
+  nonisolated lazy var e = 0 // expected-error {{'nonisolated' can not be applied to 'lazy' stored property 'e'}}
+  @P nonisolated var f = 0  // expected-error {{'nonisolated' can not be applied to stored property 'f' with a property wrapper}}
 }
 
 struct ImplicitlyNonSendable {
@@ -60,8 +60,8 @@ public struct PublicSendable: Sendable {
   nonisolated var d = 0
 
   // never okay
-  nonisolated lazy var e = 0  // expected-error {{'nonisolated' cannot be applied to mutable stored properties}}
-  @P nonisolated var f = 0  // expected-error {{'nonisolated' cannot be applied to mutable stored properties}}
+  nonisolated lazy var e = 0  // expected-error {{'nonisolated' can not be applied to 'lazy' stored property 'e'}}
+  @P nonisolated var f = 0  // expected-error {{'nonisolated' can not be applied to stored property 'f' with a property wrapper}}
 }
 
 public struct PublicNonSendable {
@@ -94,8 +94,8 @@ nonisolated struct StructRemovesGlobalActor: GloballyIsolated {
 
 @MainActor struct S {
   var value: NonSendable // globally-isolated
-  @P nonisolated var x = 0 // expected-error {{'nonisolated' cannot be applied to mutable stored properties}}
-  nonisolated lazy var y = 1 // expected-error {{'nonisolated' cannot be applied to mutable stored properties}}
+  @P nonisolated var x = 0 // expected-error {{'nonisolated' can not be applied to stored property 'x' with a property wrapper}}
+  nonisolated lazy var y = 1 // expected-error {{'nonisolated' can not be applied to 'lazy' stored property 'y'}}
   struct Nested {} // 'Nested' is not @MainActor-isolated
 }
 
@@ -304,7 +304,7 @@ struct B: Sendable {
 
 final class KlassB: Sendable {
   // expected-note@+2 {{convert 'test' to a 'let' constant or consider declaring it 'nonisolated(unsafe)' if manually managing concurrency safety}}
-  // expected-error@+1 {{'nonisolated' cannot be applied to mutable stored properties}}
+  // expected-error@+1 {{'nonisolated' can not be applied to mutable stored property 'test' of class 'KlassB'}}
   nonisolated var test: Int = 1
 }
 


### PR DESCRIPTION
- **Explanation**: 

Emit more specific diagnostics when `nonisolated` is applied to a mutable stored property that doesn't qualify, addressing #88709. The previous diagnostic was too broad, since `nonisolated` can be applied to a mutable stored property of a `Sendable` value type. The message is split per branch of the existing check, with three primary forms and one fallback for an edge case:

- Plain mutable stored property: `'nonisolated' can not be applied to mutable stored property '<name>' of <kind> '<TypeName>'`
- Property with a property wrapper: `'nonisolated' can not be applied to stored property '<name>' with a property wrapper`
- `lazy` stored property: `'nonisolated' can not be applied to 'lazy' stored property '<name>'`
- The fourth form, `nonisolated_mutable_storage_no_nominal`, is emitted if the general branch fires without an enclosing nominal type (see comment below for more information).

In all cases, the accompanying note is unchanged.

- **Scope**: Diagnostic-wording change only.

- **Issues**: Closes #88709

- **Original PRs**: None.

- **Risk**:  Low, this is a diagnostic-wording change only.

- **Testing**: Updated five existing tests in `test/Concurrency/` to match the new diagnostic wording. The full test suite passes locally with no new failures relative to a baseline run.

- **Reviewers**: Pending.