### PR TITLE
[SIL] Remove `SILFunction::setActorIsolation`

### DIFF
--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -1530,10 +1530,6 @@ public:
     return false;
   }
 
-  void setActorIsolation(ActorIsolation newActorIsolation) {
-    actorIsolation = newActorIsolation;
-  }
-
   ActorIsolation getActorIsolation() const {
     return actorIsolation;
   }

--- a/include/swift/SIL/TypeLowering.h
+++ b/include/swift/SIL/TypeLowering.h
@@ -1215,7 +1215,7 @@ CanSILFunctionType getNativeSILFunctionType(
 /// origConstant is the parent decl ref in the case of class methods and the
 /// witness method decl ref if we are working with a protocol witness. Pass in
 /// None otherwise.
-std::optional<ActorIsolation>
+ActorIsolation
 getSILFunctionTypeActorIsolation(CanAnyFunctionType substFnInterfaceType,
                                  std::optional<SILDeclRef> origConstant,
                                  std::optional<SILDeclRef> constant);

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -1849,7 +1849,7 @@ class DestructureInputs {
   TypeConverter &TC;
   const Conventions &Convs;
   const ForeignInfo &Foreign;
-  std::optional<ActorIsolation> IsolationInfo;
+  ActorIsolation IsolationInfo;
   struct ForeignSelfInfo {
     AbstractionPattern OrigSelfParam;
     AnyFunctionType::CanParam SubstSelfParam;
@@ -1873,7 +1873,7 @@ class DestructureInputs {
 public:
   DestructureInputs(TypeExpansionContext expansion, TypeConverter &TC,
                     const Conventions &conventions, const ForeignInfo &foreign,
-                    std::optional<ActorIsolation> isolationInfo,
+                    ActorIsolation isolationInfo,
                     SmallVectorImpl<SILParameterInfo> &inputs,
                     SmallVectorImpl<int> &parameterMap,
                     SmallBitVector &addressableParams,
@@ -1949,7 +1949,7 @@ private:
 
     // If the function has nonisolated(nonsending) isolation, insert the
     // implicit isolation parameter.
-    if (IsolationInfo && IsolationInfo->isNonisolatedNonsending() &&
+    if (IsolationInfo.isNonisolatedNonsending() &&
         Convs.hasNonisolatedNonsendingActorParameter()) {
       addParameter(-1, CanType(TC.Context.TheImplicitActorType),
                    ParameterConvention::Direct_Guaranteed,
@@ -2645,7 +2645,7 @@ static void destructureYieldsForCoroutine(TypeConverter &TC,
   }
 }
 
-std::optional<ActorIsolation>
+ActorIsolation
 swift::getSILFunctionTypeActorIsolation(CanAnyFunctionType substFnInterfaceType,
                                         std::optional<SILDeclRef> origConstant,
                                         std::optional<SILDeclRef> constant) {
@@ -2679,7 +2679,7 @@ swift::getSILFunctionTypeActorIsolation(CanAnyFunctionType substFnInterfaceType,
     return ActorIsolation::forNonisolatedNonsending();
   }
 
-  return {};
+  return ActorIsolation::forUnspecified();
 }
 
 /// Create the appropriate SIL function type for the given formal type
@@ -3127,7 +3127,7 @@ static CanSILFunctionType getSILFunctionType(
   }
 
   bool isNonisolatedNonsending =
-      actorIsolation && actorIsolation->isNonisolatedNonsending() &&
+      actorIsolation.isNonisolatedNonsending() &&
       conventions.hasNonisolatedNonsendingActorParameter();
 
   auto silExtInfo =
@@ -3165,7 +3165,7 @@ static CanSILFunctionType getSILFunctionTypeForInitAccessor(
   {
     bool unimplementable = false;
     ForeignInfo foreignInfo;
-    std::optional<ActorIsolation> actorIsolation; // For now always null.
+    ActorIsolation actorIsolation = ActorIsolation::forUnspecified(); // For now always unspecified.
     SmallVector<int, 8> unusedParameterMap;
     SmallBitVector unusedAddressableParams;
     SmallBitVector unusedConditionalAddressableParams;

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -238,6 +238,7 @@ bool SILParser::diagnoseProblems() {
 /// it up and return an appropriate SIL function.
 SILFunction *SILParser::getGlobalNameForDefinition(Identifier name,
                                                    CanSILFunctionType ty,
+                                                   ActorIsolation isolation,
                                                    SourceLoc sourceLoc) {
   SILParserFunctionBuilder builder(SILMod);
   auto silLoc = RegularLocation(sourceLoc);
@@ -253,7 +254,8 @@ SILFunction *SILParser::getGlobalNameForDefinition(Identifier name,
       P.diagnose(sourceLoc, diag::sil_value_use_type_mismatch, name.str(),
                  fn->getLoweredFunctionType(), ty);
       P.diagnose(iter->second.Loc, diag::sil_prior_reference);
-      fn = builder.createFunctionForForwardReference("" /*name*/, ty, silLoc);
+      fn = builder.createFunctionForForwardReference("" /*name*/, ty, isolation,
+                                                     silLoc);
     }
 
     assert(fn->isExternalDeclaration() && "Forward defns cannot have bodies!");
@@ -272,17 +274,20 @@ SILFunction *SILParser::getGlobalNameForDefinition(Identifier name,
   // defined already.
   if (SILMod.lookUpFunction(name.str()) != nullptr) {
     P.diagnose(sourceLoc, diag::sil_value_redefinition, name.str());
-    return builder.createFunctionForForwardReference("" /*name*/, ty, silLoc);
+    return builder.createFunctionForForwardReference("" /*name*/, ty, isolation,
+                                                     silLoc);
   }
 
   // Otherwise, this definition is the first use of this name.
-  return builder.createFunctionForForwardReference(name.str(), ty, silLoc);
+  return builder.createFunctionForForwardReference(name.str(), ty, isolation,
+                                                   silLoc);
 }
 
 /// getGlobalNameForReference - Given a reference to a global name, look it
 /// up and return an appropriate SIL function.
 SILFunction *SILParser::getGlobalNameForReference(Identifier name,
                                                   CanSILFunctionType funcTy,
+                                                  ActorIsolation isolation,
                                                   SourceLoc sourceLoc,
                                                   bool ignoreFwdRef) {
   SILParserFunctionBuilder builder(SILMod);
@@ -299,13 +304,13 @@ SILFunction *SILParser::getGlobalNameForReference(Identifier name,
                fn->getLoweredFunctionType(), funcTy);
 
     return builder.createFunctionForForwardReference("" /*name*/, funcTy,
-                                                     silLoc);
+                                                     isolation, silLoc);
   }
   
   // If we didn't find a function, create a new one - it must be a forward
   // reference.
-  auto *fn =
-      builder.createFunctionForForwardReference(name.str(), funcTy, silLoc);
+  auto *fn = builder.createFunctionForForwardReference(name.str(), funcTy,
+                                                       isolation, silLoc);
   TUState.ForwardRefFns[name] = {fn, ignoreFwdRef ? SourceLoc() : sourceLoc};
   return fn;
 }
@@ -7259,8 +7264,9 @@ bool SILParser::parseSILFunctionRef(SILLocation InstLoc,
     P.diagnose(Loc, diag::expected_sil_function_type);
     return true;
   }
-  
-  ResultFn = getGlobalNameForReference(Name, FnTy, Loc);
+
+  ResultFn = getGlobalNameForReference(
+      Name, FnTy, ActorIsolation::forUnspecified(), Loc);
   return false;
 }
 
@@ -7513,9 +7519,9 @@ bool SILParserState::parseDeclSIL(Parser &P) {
       P.diagnose(FnNameLoc, diag::expected_sil_function_type);
       return true;
     }
-  
-    FunctionState.F =
-      FunctionState.getGlobalNameForDefinition(FnName, SILFnType, FnNameLoc);
+
+    FunctionState.F = FunctionState.getGlobalNameForDefinition(
+        FnName, SILFnType, actorIsolation, FnNameLoc);
     FunctionState.F->setBare(IsBare);
     FunctionState.F->setTransparent(IsTransparent_t(isTransparent));
     FunctionState.F->setSerializedKind(SerializedKind_t(isSerialized));
@@ -7558,8 +7564,7 @@ bool SILParserState::parseDeclSIL(Parser &P) {
     for (auto &Attr : Semantics) {
       FunctionState.F->addSemanticsAttr(Attr);
     }
-    if (actorIsolation)
-      FunctionState.F->setActorIsolation(actorIsolation);
+
     // Now that we have a SILFunction parse the body, if present.
 
     bool isDefinition = false;
@@ -9117,7 +9122,8 @@ bool SILParserState::parseSILScope(Parser &P) {
       P.diagnose(FnLoc, diag::expected_sil_function_type);
       return true;
     }
-    ParentFn = ScopeState.getGlobalNameForReference(FnName, FnTy, FnLoc, true);
+    ParentFn = ScopeState.getGlobalNameForReference(
+        FnName, FnTy, ActorIsolation::forUnspecified(), FnLoc, true);
     ScopeState.TUState.PotentialZombieFns.insert(ParentFn);
   }
 

--- a/lib/SIL/Parser/SILParser.h
+++ b/lib/SIL/Parser/SILParser.h
@@ -101,12 +101,15 @@ public:
   /// getGlobalNameForReference - Given a reference to a global name, look it
   /// up and return an appropriate SIL function.
   SILFunction *getGlobalNameForReference(Identifier Name, CanSILFunctionType Ty,
+                                         ActorIsolation isolation,
                                          SourceLoc Loc,
                                          bool IgnoreFwdRef = false);
   /// getGlobalNameForDefinition - Given a definition of a global name, look
   /// it up and return an appropriate SIL function.
   SILFunction *getGlobalNameForDefinition(Identifier Name,
-                                          CanSILFunctionType Ty, SourceLoc Loc);
+                                          CanSILFunctionType Ty,
+                                          ActorIsolation isolation,
+                                          SourceLoc Loc);
 
   /// getBBForDefinition - Return the SILBasicBlock for a definition of the
   /// specified block.

--- a/lib/SIL/Parser/SILParserFunctionBuilder.h
+++ b/lib/SIL/Parser/SILParserFunctionBuilder.h
@@ -25,11 +25,12 @@ public:
 
   SILFunction *createFunctionForForwardReference(StringRef name,
                                                  CanSILFunctionType ty,
+                                                 ActorIsolation isolation,
                                                  SILLocation loc) {
     auto *result = builder.createFunction(
-        SILLinkage::Private, name, ty, ActorIsolation::forUnspecified(),
-        nullptr, loc, IsNotBare, IsNotTransparent, IsNotSerialized,
-        IsNotDynamic, IsNotDistributed, IsNotRuntimeAccessible);
+        SILLinkage::Private, name, ty, isolation, nullptr, loc, IsNotBare,
+        IsNotTransparent, IsNotSerialized, IsNotDynamic, IsNotDistributed,
+        IsNotRuntimeAccessible);
     result->setDebugScope(new (builder.mod) SILDebugScope(loc, result));
 
     // If we did not have a declcontext set, as a fallback set the parent module

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -819,7 +819,6 @@ SILFunction *SILGenModule::getFunction(SILDeclRef constant,
       });
 
   F->setDeclRef(constant);
-  F->setActorIsolation(constant.getActorIsolation());
 
   assert(F && "SILFunction should have been defined");
 
@@ -1350,9 +1349,6 @@ void SILGenModule::preEmitFunction(SILDeclRef constant, SILFunction *F,
 
   // Initialize F with the constant we created for it.
   F->setDeclRef(constant);
-
-  // Set our actor isolation.
-  F->setActorIsolation(constant.getActorIsolation());
 
   // Closures automatically infer [manual_ownership] based on outermost func.
   //

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -891,7 +891,8 @@ SILFunction *SILGenModule::emitProtocolWitness(
 
   SILGenFunctionBuilder builder(*this);
   f = builder.createFunction(
-      linkage, nameBuffer, witnessSILFnType, ActorIsolation::forUnspecified(),
+      linkage, nameBuffer, witnessSILFnType,
+      getSILFunctionTypeActorIsolation(reqtSubstTy, requirement, witnessRef),
       genericEnv, SILLocation(witnessRef.getDecl()), IsNotBare, IsTransparent,
       serializedKind, IsNotDynamic, IsNotDistributed, IsNotRuntimeAccessible,
       ProfileCounter(), thunkKind, SubclassScope::NotApplicable,
@@ -928,11 +929,6 @@ SILFunction *SILGenModule::emitProtocolWitness(
                           witness.getEnterIsolation());
 
   emitLazyConformancesForFunction(f);
-
-  if (auto isolation = getSILFunctionTypeActorIsolation(
-          reqtSubstTy, requirement, witnessRef)) {
-    f->setActorIsolation(*isolation);
-  }
 
   return f;
 }


### PR DESCRIPTION
<!--
The main branch is now in convergence, which means major changes, such as large refactoring or new features, should be avoided. This strategy is intended to maintain the stability of the Swift 6.4 release leading up to the May 4th branch. For any work that requires broad changes or introduces new features, create a feature branch and open a draft pull request. All updates to the swiftlang/swift repository’s main branch require approval from the release managers. A pull request targeting swiftlang/swift will automatically add release managers. You can also contact them via @release-managers in the forum group.
-->

<!-- Please fill out the following form: --> 
- **Explanation**:
  
   This is a follow-up to https://github.com/swiftlang/swift/pull/88600. 

    Removes a way to change actor isolation of a `SILFunction` to prevent any possibility of knowingly or unknowingly creating mismatches between creation and use of a function.

- **Scope**:

   This is an NFC change.

- **Issues**:
  
   N/A

- **Risk**:

   Very low. There is no observable difference in behavior here, the isolation is set to the same value just slightly earlier than before in a few places.  

- **Testing**:
  
   Since this is NFC, no new tests were added to the suite.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
