### PR TITLE
[Concurrency] Add a task_switch_executor signpost.

### DIFF
--- a/stdlib/public/Concurrency/Actor.cpp
+++ b/stdlib/public/Concurrency/Actor.cpp
@@ -2440,8 +2440,10 @@ static void runOnAssumedThread(AsyncTask *task, SerialExecutorRef executor,
   // there and tail-call the task.  We don't want these frames to
   // potentially accumulate linearly.
   if (oldTracking) {
+    auto newTaskExecutor = task->getPreferredTaskExecutor();
     oldTracking->setActiveExecutor(executor);
-    oldTracking->setTaskExecutor(task->getPreferredTaskExecutor());
+    oldTracking->setTaskExecutor(newTaskExecutor);
+    concurrency::trace::task_switch_executor(task, executor, newTaskExecutor);
 
     return task->runInFullyEstablishedContext(); // 'return' forces tail call
   }

--- a/stdlib/public/Concurrency/Tracing.h
+++ b/stdlib/public/Concurrency/Tracing.h
@@ -119,6 +119,13 @@ job_run_info job_run_begin(Job *job, SerialExecutorRef serialExecutor,
 
 void job_run_end(job_run_info info);
 
+// Emitted when a task switches executors without suspending (i.e., the
+// surrounding job_run interval continues, but the active executor has
+// changed). Lets trace consumers see executor hops that happen inside a
+// single job_run interval.
+void task_switch_executor(AsyncTask *task, SerialExecutorRef serialExecutor,
+                          TaskExecutorRef taskExecutor);
+
 } // namespace trace
 } // namespace concurrency
 } // namespace swift

--- a/stdlib/public/Concurrency/TracingSignpost.h
+++ b/stdlib/public/Concurrency/TracingSignpost.h
@@ -67,6 +67,7 @@
   "job_enqueue_global_with_delay"
 #define SWIFT_LOG_JOB_ENQUEUE_EXECUTOR_NAME "job_enqueue_executor"
 #define SWIFT_LOG_JOB_RUN_NAME "job_run"
+#define SWIFT_LOG_TASK_SWITCH_EXECUTOR_NAME "task_switch_executor"
 
 namespace swift {
 namespace concurrency {
@@ -402,6 +403,26 @@ inline void job_run_end(job_run_info info) {
     os_signpost_interval_end(TaskLog, info.handle, SWIFT_LOG_JOB_RUN_NAME,
                              "task=%" PRId64, info.taskId);
   }
+}
+
+inline void task_switch_executor(AsyncTask *task,
+                                 SerialExecutorRef serialExecutor,
+                                 TaskExecutorRef taskExecutor) {
+  ENSURE_LOGS();
+  HeapObject *executorIdentity =
+      serialExecutor.isGeneric() ? nullptr : serialExecutor.getIdentity();
+  auto metadata =
+      executorIdentity ? swift_getObjectType(executorIdentity) : nullptr;
+  auto descriptor =
+      metadata ? (const void *)metadata->getTypeContextDescriptor() : nullptr;
+  auto executorKind = classifyExecutor(serialExecutor, taskExecutor);
+  auto id = os_signpost_id_make_with_pointer(TaskLog, task);
+  os_signpost_event_emit(TaskLog, id, SWIFT_LOG_TASK_SWITCH_EXECUTOR_NAME,
+                         "task=%" PRId64 " taskPointer=%p"
+                         " executor=%p metadata=%p descriptor=%p"
+                         " executorKind=%u",
+                         task->getTaskId(), task, executorIdentity, metadata,
+                         descriptor, (unsigned)executorKind);
 }
 
 #pragma clang diagnostic pop

--- a/stdlib/public/Concurrency/TracingStubs.h
+++ b/stdlib/public/Concurrency/TracingStubs.h
@@ -84,6 +84,10 @@ inline job_run_info job_run_begin(Job *job, SerialExecutorRef serialExecutor,
 
 inline void job_run_end(job_run_info info) {}
 
+inline void task_switch_executor(AsyncTask *task,
+                                 SerialExecutorRef serialExecutor,
+                                 TaskExecutorRef taskExecutor) {}
+
 } // namespace trace
 } // namespace concurrency
 } // namespace swift

--- a/test/Concurrency/Runtime/signpost_tracing_test.swift
+++ b/test/Concurrency/Runtime/signpost_tracing_test.swift
@@ -516,6 +516,29 @@ tests.test("CustomSerialExecutorKind") {
   )
 }
 
+// Test the task_switch_executor signpost, emitted when a task hops
+// executors without suspending (inside a single job_run interval).
+tests.test("TaskSwitchExecutor") {
+  actor Inner {
+    func work() -> Int { return 1 }
+  }
+  actor Outer {
+    let inner: Inner
+    init(inner: Inner) { self.inner = inner }
+    func callInner() async -> Int { return await inner.work() }
+  }
+
+  let monitor = await SignpostMonitor.start()
+  let inner = Inner()
+  let outer = Outer(inner: inner)
+
+  let _ = await outer.callInner()
+
+  await monitor.expectAllSignpostsReceived(
+    [ExpectedSignpost(name: "task_switch_executor", type: .event)]
+  )
+}
+
 // Test executorKind for a task executor (executorKind=4).
 tests.test("TaskExecutorKind") {
   final class MyTaskExecutor: TaskExecutor {


### PR DESCRIPTION
Emit this in runOnAssumedThread. This handles the case where a task switches actors without suspending, and thus within a single job_run interval.

rdar://175776849

- **Explanation**: This adds a new signpost emitted when a task switches actors without suspending. Without this, it's difficult for instrumentation to correlate which tasks occupy the actor in that case.
- **Scope**: This adds a new signpost, off by default. Risk and impact is minimal.
- **Issues**: rdar://175776849
- **Original PRs**: N/A
- **Risk**: Low. This is a small change 
- **Testing**: A new test was added to confirm this signpost is emitted. Existing tests cover this code path extensively.
- **Reviewers**: @ktoso