### PR TITLE
Fix assertion in getOpStructuralPackIndex

### DIFF
--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -325,7 +325,7 @@ public:
   /// corresponding structural index in the remapped pack type.
   unsigned getOpStructuralPackIndex(CanPackType origPackType,
                                     unsigned origIndex) {
-    ASSERT(origIndex < origPackType->getNumElements());
+    ASSERT(origIndex <= origPackType->getNumElements());
     unsigned newIndex = 0;
     for (unsigned i = 0; i != origIndex; ++i) {
       auto origComponentType = origPackType.getElementType(i);

--- a/test/SILOptimizer/pack_inliner_crash.sil
+++ b/test/SILOptimizer/pack_inliner_crash.sil
@@ -1,0 +1,42 @@
+// RUN: %target-sil-opt -inline %s | %FileCheck %s
+
+sil_stage canonical
+
+import Builtin
+import Swift
+
+sil @callee : $@convention(thin) (@pack_guaranteed Pack{}) -> () {
+bb0(%pack : $*Pack{}):
+  %len = integer_literal $Builtin.Word, 0
+  %zero = integer_literal $Builtin.Word, 0
+  br bb1(%zero : $Builtin.Word)
+
+bb1(%idx : $Builtin.Word):
+  %cmp = builtin "cmp_eq_Word"(%idx : $Builtin.Word, %len : $Builtin.Word) : $Builtin.Int1
+  cond_br %cmp, bb3, bb2
+
+bb2:
+  %dyn = dynamic_pack_index %idx of $Pack{}
+  %ppi = pack_pack_index 0, %dyn of $Pack{}
+  %one = integer_literal $Builtin.Word, 1
+  %next = builtin "add_Word"(%idx : $Builtin.Word, %one : $Builtin.Word) : $Builtin.Word
+  br bb1(%next : $Builtin.Word)
+
+bb3:
+  %ret = tuple ()
+  return %ret : $()
+}
+
+// Ensure no crash after inlining
+// CHECK-LABEL: sil @caller : $@convention(thin) () -> () {
+// CHECK-NOT: apply
+// CHECK-LABEL: } // end sil function 'caller'
+sil @caller : $@convention(thin) () -> () {
+bb0:
+  %pack = alloc_pack $Pack{}
+  %f = function_ref @callee : $@convention(thin) (@pack_guaranteed Pack{}) -> ()
+  %r = apply %f(%pack) : $@convention(thin) (@pack_guaranteed Pack{}) -> ()
+  dealloc_pack %pack : $*Pack{}
+  %ret = tuple ()
+  return %ret : $()
+}


### PR DESCRIPTION
- **Explanation**:
Relax the assertion in getOpStructuralPackIndex to allow pack_pack_index with an empty pack type to be cloned during inlining. This can occur due to other optimizations producing `pack_pack_index 0 of \$Pack{}` where `origIndex` equals `getNumElements()`. This fix is similar to the changes in https://github.com/swiftlang/swift/pull/87844 
- **Scope**: Affects packs
- **Issues**: rdar://175696710
- **Risk**: Low
- **Testing**: Added unit test, CI testing