### PR TITLE
Sema: Fix two performance tests for exotic CI configurations

### DIFF
--- a/validation-test/Sema/type_checker_perf/fast/issue-52629.swift
+++ b/validation-test/Sema/type_checker_perf/fast/issue-52629.swift
@@ -1,6 +1,9 @@
 // RUN: %target-swift-frontend %s -typecheck -verify -solver-scope-threshold=100
 // REQUIRES: objc_interop
 
+// rdar://173654813
+// REQUIRES: OS=macosx
+
 // https://github.com/swiftlang/swift/issues/52629
 
 import Foundation

--- a/validation-test/Sema/type_checker_perf/slow/rdar119215676.swift
+++ b/validation-test/Sema/type_checker_perf/slow/rdar119215676.swift
@@ -1,9 +1,10 @@
-// RUN: %target-typecheck-verify-swift -solver-scope-threshold=100000
+// RUN: not %target-swift-frontend -typecheck %s -solver-scope-threshold=100000 -diagnostic-style llvm 2>&1 | %FileCheck %s
 // REQUIRES: OS=macosx
 
 import Foundation
 import RegexBuilder
 
+// CHECK: rdar119215676.swift:{{.*}}: error: the compiler is unable to type-check this expression in reasonable time
 internal enum DODRelativeDateRegexes {
     static let year = Reference<Int?>()
     static let month = Reference<Int?>()
@@ -30,7 +31,7 @@ internal enum DODRelativeDateRegexes {
         Capture(as: month) {
             Regex {
                 Capture {
-                    ChoiceOf {  // expected-error {{reasonable time}}
+                    ChoiceOf {
                         Regex {
                             "1"
                             ("0"..."2")


### PR DESCRIPTION
This is a test-only change.

Fixes rdar://173762142.
Fixes rdar://173654813.