### PR TITLE
LoadableByAddress: More robust handling of `Builtin.Borrow` instructions.

### DIFF
--- a/lib/IRGen/LoadableByAddress.cpp
+++ b/lib/IRGen/LoadableByAddress.cpp
@@ -36,9 +36,11 @@
 #include "swift/SILOptimizer/Analysis/DeadEndBlocksAnalysis.h"
 #include "swift/SILOptimizer/PassManager/Transforms.h"
 #include "swift/SILOptimizer/Utils/BasicBlockOptUtils.h"
+#include "swift/SILOptimizer/Utils/CompileTimeInterpolationUtils.h"
 #include "swift/SILOptimizer/Utils/DebugOptUtils.h"
 #include "swift/SILOptimizer/Utils/InstOptUtils.h"
 #include "swift/SILOptimizer/Utils/StackNesting.h"
+#include "swift/SILOptimizer/Utils/ValueLifetime.h"
 #include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/SmallSet.h"
@@ -2131,6 +2133,62 @@ static void createStructElementAddrInstrAndLoad(LoadableStorageAllocation &alloc
   }
 }
 
+static SILValue getMakeAddrBorrowOperand(SILBuilder &builder,
+                                         MakeBorrowInst *orig) {
+  auto &fn = builder.getFunction();
+  auto loc = orig->getLoc();
+  auto operand = orig->getOperand();
+  
+  // If the operand was already spilled to an address by the pass, then use
+  // it as is.
+  if (operand->getType().isAddress()) {
+    return operand;
+  }
+
+  // If the operand is a load or load_borrow of a memory location, borrow that
+  // original address.
+  if (auto load = dyn_cast<LoadInst>(operand)) {
+    return load->getOperand();
+  }
+  if (auto lb = dyn_cast<LoadBorrowInst>(operand)) {
+    return lb->getOperand();
+  }
+
+  // Otherwise, this value is local, and can be spilled to a local stack
+  // allocation.
+  AllocStackInst *stack = builder.createAllocStack(loc, operand->getType());
+  StoreBorrowInst *borrow = nullptr;
+  SILValue result = stack;
+  bool hasOwnership = fn.hasOwnership()
+                      && !operand->getType().isTrivial(fn);
+  if (hasOwnership) {
+    borrow = builder.createStoreBorrow(loc, operand, stack);
+    result = borrow;
+  } else {
+    builder.createStore(loc, operand, stack, StoreOwnershipQualifier::Unqualified);
+  }
+
+  // End the new stack slot and borrow after the borrow is no longer used.
+  SmallVector<SILInstruction *, 16> transitiveUsers;
+  getTransitiveUsers(orig, transitiveUsers);
+  ValueLifetimeAnalysis lifetimeAnalysis(orig, transitiveUsers);
+  ValueLifetimeBoundary boundary;
+  lifetimeAnalysis.computeLifetimeBoundary(boundary);
+  for (auto *boundaryInst : boundary.lastUsers) {
+    SavedInsertionPointRAII save(builder);
+    builder.setInsertionPoint(boundaryInst->getNextInstruction());
+
+    if (borrow) {
+      builder.createEndBorrow(loc, borrow);
+    }
+    builder.createDeallocStack(loc, stack);
+  }
+
+  StackNesting::fixNesting(&fn);
+  
+  return result;
+}
+
 static void createMakeAddrBorrow(LoadableStorageAllocation &allocator,
                                  MakeBorrowInst *instr,
                                  StructLoweringState &pass) {
@@ -2140,8 +2198,9 @@ static void createMakeAddrBorrow(LoadableStorageAllocation &allocator,
   }
 
   SILBuilderWithScope builder(instr);
+  auto operand = getMakeAddrBorrowOperand(builder, instr);
   SingleValueInstruction *newInstr = builder.createMakeAddrBorrow(
-      instr->getLoc(), instr->getOperand());
+      instr->getLoc(), operand);
 
   // `make_addr_borrow` produces a `Borrow<T>` by-value, like `make_borrow`,
   // so it is a drop-in replacement.

--- a/test/IRGen/builtin_borrow_large.swift
+++ b/test/IRGen/builtin_borrow_large.swift
@@ -1,4 +1,5 @@
-// RUN: %target-swift-frontend -enable-experimental-feature Lifetimes -O -disable-llvm-optzns -disable-availability-checking -emit-ir -module-name main %s | %FileCheck %s
+// RUN: %target-swift-frontend -sil-verify-all -enable-experimental-feature Lifetimes -O -disable-llvm-optzns -disable-availability-checking -emit-ir -module-name main %s | %FileCheck %s
+// RUN: %target-swift-frontend -sil-verify-all -enable-experimental-feature Lifetimes -disable-llvm-optzns -disable-availability-checking -emit-ir -verify -module-name main %s
 
 // REQUIRES: swift_feature_Lifetimes
 

--- a/test/IRGen/loadable_by_address_borrow.sil
+++ b/test/IRGen/loadable_by_address_borrow.sil
@@ -1,0 +1,225 @@
+// RUN: %target-sil-opt -enable-sil-verify-all %s -loadable-address | %FileCheck %s
+
+import Swift
+
+public struct BigArc { var a, b, c, d, e: AnyObject }
+
+public struct BiggerArc { var bigArc: BigArc }
+
+sil @makeBigArc : $@convention(thin) () -> BigArc
+sil @takeBorrowBigArc : $@convention(thin) (@guaranteed Ref<BigArc>) -> ()
+
+// In test1, `%1` is a `BigArc` that will already become indirected because
+// it is the result of a function call that will become an indirect return.
+// `make_borrow` of the value becomes `make_borrow_addr` of the value's
+// lowered memory address.
+
+// CHECK-LABEL: sil @test1
+// CHECK:        apply {{%.*}}([[OUT:%[0-9]+]])
+// CHECK:        make_addr_borrow [[OUT]]
+sil @test1 : $@convention(thin) () -> () {
+bb0:
+  %0 = function_ref @makeBigArc : $@convention(thin) () -> BigArc
+  %1 = apply %0() : $@convention(thin) () -> BigArc
+  %2 = make_borrow %1
+  %3 = struct $Ref<BigArc> (%2)
+  %4 = function_ref @takeBorrowBigArc : $@convention(thin) (@guaranteed Ref<BigArc>) -> ()
+  %5 = apply %4(%3) : $@convention(thin) (@guaranteed Ref<BigArc>) -> ()
+  %6 = tuple ()
+  return %6
+}
+
+// In test2, `%4` is a `BigArc` that is `load`-ed from a memory location.
+// `make_borrow` of the load becomes `make_borrow_addr` of the loaded address.
+
+// CHECK-LABEL: sil @test2
+// CHECK:        apply {{%.*}}([[OUT:%[0-9]+]])
+// CHECK:        copy_addr [take] [[OUT]] to [init] [[LOCAL:%[0-9]+]]
+// CHECK:        make_addr_borrow [[LOCAL]]
+sil @test2 : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_stack $BigArc
+  %1 = function_ref @makeBigArc : $@convention(thin) () -> BigArc
+  %2 = apply %1() : $@convention(thin) () -> BigArc
+  store %2 to %0
+  %4 = load %0
+  %5 = make_borrow %4
+  %6 = struct $Ref<BigArc> (%5)
+  %7 = function_ref @takeBorrowBigArc : $@convention(thin) (@guaranteed Ref<BigArc>) -> ()
+  %8 = apply %7(%6) : $@convention(thin) (@guaranteed Ref<BigArc>) -> ()
+  destroy_addr %0
+  dealloc_stack %0
+  %11 = tuple ()
+  return %11
+}
+
+
+// In test2ossa, `%4` is a `BigArc` that is `load_borrow`-ed from a memory location.
+// `make_borrow` of the load becomes `make_borrow_addr` of the loaded address.
+
+// CHECK-LABEL: sil [ossa] @test2ossa
+// CHECK:        apply {{%.*}}([[OUT:%[0-9]+]])
+// CHECK:        copy_addr [take] [[OUT]] to [init] [[LOCAL:%[0-9]+]]
+// CHECK:        make_addr_borrow [[LOCAL]]
+sil [ossa] @test2ossa : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_stack $BigArc
+  %1 = function_ref @makeBigArc : $@convention(thin) () -> BigArc
+  %2 = apply %1() : $@convention(thin) () -> BigArc
+  store %2 to [init] %0
+  %4 = load_borrow %0
+  %5 = make_borrow %4
+  %6 = struct $Ref<BigArc> (%5)
+  %7 = function_ref @takeBorrowBigArc : $@convention(thin) (@guaranteed Ref<BigArc>) -> ()
+  %8 = apply %7(%6) : $@convention(thin) (@guaranteed Ref<BigArc>) -> ()
+  end_borrow %4
+  destroy_addr %0
+  dealloc_stack %0
+  %12 = tuple ()
+  return %12
+}
+
+// In test3, `%5` is a `BigArc` that is formed locally and doesn't directly
+// pass through any function boundaries. `make_borrow` of the local value
+// becomes `make_addr_borrow` of a temporary allocation.
+
+// CHECK-LABEL: sil @test3
+// CHECK:         [[BIGARC:%.*]] = struct $BigArc
+// CHECK:         [[BUF:%.*]] = alloc_stack
+// CHECK:         store [[BIGARC]] to [[BUF]]
+// CHECK:         [[B_BORROW:%.*]] = make_addr_borrow [[BUF]]
+// CHECK:         [[S_BORROW:%.*]] = struct $Ref<BigArc> ([[B_BORROW]])
+// CHECK:         apply {{.*}}([[S_BORROW]])
+// CHECK:         dealloc_stack [[BUF]]
+// CHECK:         release_value [[BIGARC]]
+sil @test3 : $@convention(thin) (@owned AnyObject) -> () {
+bb0(%0 : $AnyObject):
+  retain_value %0
+  retain_value %0
+  retain_value %0
+  retain_value %0
+
+  %5 = struct $BigArc(%0, %0, %0, %0, %0)
+  %6 = make_borrow %5
+  %7 = struct $Ref<BigArc> (%6)
+  %8 = function_ref @takeBorrowBigArc : $@convention(thin) (@guaranteed Ref<BigArc>) -> ()
+  %9 = apply %8(%7) : $@convention(thin) (@guaranteed Ref<BigArc>) -> ()
+  release_value %5
+  %11 = tuple ()
+  return %11
+}
+
+// CHECK-LABEL: sil [ossa] @test3ossa
+// CHECK:         [[BIGARC:%.*]] = struct $BigArc
+// CHECK:         [[BUF:%.*]] = alloc_stack
+// CHECK:         [[BUF_BORROW:%.*]] = store_borrow [[BIGARC]] to [[BUF]]
+// CHECK:         [[B_BORROW:%.*]] = make_addr_borrow [[BUF_BORROW]]
+// CHECK:         [[S_BORROW:%.*]] = struct $Ref<BigArc> ([[B_BORROW]])
+// CHECK:         apply {{.*}}([[S_BORROW]])
+// CHECK:         end_borrow [[BUF_BORROW]]
+// CHECK:         dealloc_stack [[BUF]]
+// CHECK:         destroy_value [[BIGARC]]
+sil [ossa] @test3ossa : $@convention(thin) (@owned AnyObject) -> () {
+bb0(%0 : @owned $AnyObject):
+  %1 = copy_value %0
+  %2 = copy_value %0
+  %3 = copy_value %0
+  %4 = copy_value %0
+
+  %5 = struct $BigArc(%0, %1, %2, %3, %4)
+  %6 = make_borrow %5
+  %7 = struct $Ref<BigArc> (%6)
+  %8 = function_ref @takeBorrowBigArc : $@convention(thin) (@guaranteed Ref<BigArc>) -> ()
+  %9 = apply %8(%7) : $@convention(thin) (@guaranteed Ref<BigArc>) -> ()
+  destroy_value %5
+  %11 = tuple ()
+  return %11
+}
+
+// In test4, `%1` is a `BigArc` that is projected from a `BiggerArc` that
+// is passed in by value and will be turned into an indirect parameter by
+// the pass.
+
+// CHECK-LABEL: sil @test4
+// CHECK:       bb0([[PARAM:%.*]] : $*BiggerArc):
+// CHECK:         [[BIGARC_ADDR:%.*]] = struct_element_addr [[PARAM]]
+// CHECK:         [[BORROW:%.*]] = make_addr_borrow [[BIGARC_ADDR]]
+sil @test4 : $@convention(thin) (@guaranteed BiggerArc) -> () {
+bb0(%0 : $BiggerArc):
+  %1 = struct_extract %0, #BiggerArc.bigArc
+  %2 = make_borrow %1
+  %3 = struct $Ref<BigArc> (%2)
+  %4 = function_ref @takeBorrowBigArc : $@convention(thin) (@guaranteed Ref<BigArc>) -> ()
+  %5 = apply %4(%3) : $@convention(thin) (@guaranteed Ref<BigArc>) -> ()
+  %6 = tuple ()
+  return %6
+}
+
+// In test5, `%7` is a `BigArc` that is projected from a `BiggerArc` that
+// is formed locally.
+
+// CHECK-LABEL: sil @test5
+// CHECK:         [[BIGARC:%.*]] = struct_extract {{%.*}}, #BiggerArc.bigArc
+// CHECK:         [[BUF:%.*]] = alloc_stack
+// CHECK:         store [[BIGARC]] to [[BUF]]
+// CHECK:         [[B_BORROW:%.*]] = make_addr_borrow [[BUF]]
+// CHECK:         [[S_BORROW:%.*]] = struct $Ref<BigArc> ([[B_BORROW]])
+// CHECK:         apply {{.*}}([[S_BORROW]])
+// CHECK:         dealloc_stack [[BUF]]
+// CHECK:         release_value [[BIGARC]]
+sil @test5 : $@convention(thin) (@owned AnyObject) -> () {
+bb0(%0 : $AnyObject):
+  retain_value %0
+  retain_value %0
+  retain_value %0
+  retain_value %0
+
+  %5 = struct $BigArc(%0, %0, %0, %0, %0)
+  %6 = struct $BiggerArc(%5)
+
+  %7 = struct_extract %6, #BiggerArc.bigArc
+  %8 = make_borrow %7
+  %9 = struct $Ref<BigArc> (%8)
+  %10 = function_ref @takeBorrowBigArc : $@convention(thin) (@guaranteed Ref<BigArc>) -> ()
+  %11 = apply %10(%9) : $@convention(thin) (@guaranteed Ref<BigArc>) -> ()
+  release_value %7
+  %13 = tuple ()
+  return %13
+}
+
+// CHECK-LABEL: sil [ossa] @test5ossa
+// CHECK:         [[BIGGER_ARC:%.*]] = struct $BiggerArc
+// CHECK:         [[BIGGER_ARC_BORROW:%.*]] = begin_borrow [[BIGGER_ARC]]
+// CHECK:         [[BIGARC:%.*]] = struct_extract [[BIGGER_ARC_BORROW]], #BiggerArc.bigArc
+// CHECK:         [[BUF:%.*]] = alloc_stack
+// CHECK:         [[BUF_BORROW:%.*]] = store_borrow [[BIGARC]] to [[BUF]]
+// CHECK:         [[B_BORROW:%.*]] = make_addr_borrow [[BUF_BORROW]]
+// CHECK:         [[S_BORROW:%.*]] = struct $Ref<BigArc> ([[B_BORROW]])
+// CHECK:         apply {{.*}}([[S_BORROW]])
+// CHECK:         end_borrow [[BUF_BORROW]]
+// CHECK:         dealloc_stack [[BUF]]
+// CHECK:         end_borrow [[BIGGER_ARC_BORROW]]
+// CHECK:         destroy_value [[BIGGER_ARC]]
+sil [ossa] @test5ossa : $@convention(thin) (@owned AnyObject) -> () {
+bb0(%0 : @owned $AnyObject):
+  %1 = copy_value %0
+  %2 = copy_value %0
+  %3 = copy_value %0
+  %4 = copy_value %0
+
+  %5 = struct $BigArc(%0, %1, %2, %3, %4)
+  %6 = struct $BiggerArc(%5)
+
+  %7 = begin_borrow %6
+  %8 = struct_extract %7, #BiggerArc.bigArc
+  %9 = make_borrow %8
+  %10 = struct $Ref<BigArc> (%9)
+  %11 = function_ref @takeBorrowBigArc : $@convention(thin) (@guaranteed Ref<BigArc>) -> ()
+  %12 = apply %11(%10) : $@convention(thin) (@guaranteed Ref<BigArc>) -> ()
+  end_borrow %7
+  destroy_value %6
+  %15 = tuple ()
+  return %15
+}
+
+


### PR DESCRIPTION
Explanation: Fixes compiler crashes or miscompiles while using the new `Borrow` type with large loadable types, where the compiler would either produce invalid SIL or an invalid borrow of a local buffer.

Scope: Fixes miscompiles and compile crashes when using `Borrow` with certain forms of type.

Issue: rdar://175799037

Risk: Low. Adds some handling to the `LoadableByAddress` specific to `MakeBorrowInst`, which is only used by `Borrow`, so there should be no impact on the rest of the compiler handling existing code.

Testing: Swift CI

---

When an argument is made indirect by the pass, and the argument value was the base of a `make_borrow` in the original function, then we must ensure the `make_addr_borrow` in the transformed function uses the lowered address of the argument as its base, in order to ensure that the lifetime of the borrow matches the lifetime of the argument in the caller. Also, LoadableByAddress does not always lower local values that do not interact with arguments or returns of the function to addresses, but IRGen expects all `make_borrow`s of large loadable types to be transformed into `make_borrow_addr`, so form a local `alloc_stack` and storage when necessary in these cases.

Fixes rdar://175799037.