### PR TITLE
[cxx-interop] Turn off caching for Clang Importer-related requests

### DIFF
--- a/include/swift/ClangImporter/ClangImporterRequests.h
+++ b/include/swift/ClangImporter/ClangImporterRequests.h
@@ -446,12 +446,11 @@ class ForeignReferenceTypeInfoRequest
     : public SimpleRequest<ForeignReferenceTypeInfoRequest,
                            ForeignReferenceTypeInfo(
                                ForeignReferenceTypeInfoDescriptor),
-                           RequestFlags::Cached> {
+                           RequestFlags::Uncached> {
 public:
   using SimpleRequest::SimpleRequest;
 
   SourceLoc getNearestLoc() const { return SourceLoc(); };
-  bool isCached() const { return true; }
 
 private:
   friend SimpleRequest;
@@ -627,12 +626,9 @@ class CustomRefCountingOperation
     : public SimpleRequest<CustomRefCountingOperation,
                            CustomRefCountingOperationResult(
                                CustomRefCountingOperationDescriptor),
-                           RequestFlags::Cached> {
+                           RequestFlags::Uncached> {
 public:
   using SimpleRequest::SimpleRequest;
-
-  // Caching
-  bool isCached() const { return true; }
 
   // Source location
   SourceLoc getNearestLoc() const { return SourceLoc(); };
@@ -763,13 +759,12 @@ SourceLoc extractNearestSourceLoc(ClangDeclExplicitSafetyDescriptor desc);
 class ClangDeclExplicitSafety
     : public SimpleRequest<ClangDeclExplicitSafety,
                            ExplicitSafety(ClangDeclExplicitSafetyDescriptor),
-                           RequestFlags::Cached> {
+                           RequestFlags::Uncached> {
 public:
   using SimpleRequest::SimpleRequest;
 
   // Source location
   SourceLoc getNearestLoc() const { return SourceLoc(); };
-  bool isCached() const;
 
 private:
   friend SimpleRequest;
@@ -810,13 +805,12 @@ class ClangRefCountedSmartPointer
     : public SimpleRequest<ClangRefCountedSmartPointer,
                            importer::RefCountedPtrRequestResult(
                                ClangRefCountedSmartPointerDescriptor),
-                           RequestFlags::Cached> {
+                           RequestFlags::Uncached> {
 public:
   using SimpleRequest::SimpleRequest;
 
   // Source location
   SourceLoc getNearestLoc() const { return SourceLoc(); };
-  bool isCached() const { return true; }
 
 private:
   friend SimpleRequest;
@@ -863,10 +857,9 @@ class CxxIteratorInfoRequest
     : public SimpleRequest<CxxIteratorInfoRequest,
                            std::optional<importer::CxxIteratorCategory>(
                                CxxRecordDeclDescriptor),
-                           RequestFlags::Cached> {
+                           RequestFlags::Uncached> {
 public:
   using SimpleRequest::SimpleRequest;
-  bool isCached() const { return true; }
 
 private:
   friend SimpleRequest;

--- a/include/swift/ClangImporter/ClangImporterTypeIDZone.def
+++ b/include/swift/ClangImporter/ClangImporterTypeIDZone.def
@@ -31,19 +31,19 @@ SWIFT_REQUEST(ClangImporter, ObjCInterfaceAndImplementationRequest,
               ObjCInterfaceAndImplementation(Decl *), SeparatelyCached,
               NoLocationInfo)
 SWIFT_REQUEST(ClangImporter, ForeignReferenceTypeInfoRequest,
-              ForeignReferenceTypeInfo(ForeignReferenceTypeInfoDescriptor), Cached,
+              ForeignReferenceTypeInfo(ForeignReferenceTypeInfoDescriptor), Uncached,
               NoLocationInfo)
 SWIFT_REQUEST(ClangImporter, CxxRecordSemantics,
-              CxxRecordSemanticsKind(CxxRecordSemanticsDescriptor), Cached,
+              CxxRecordSemanticsKind(CxxRecordSemanticsDescriptor), Uncached,
               NoLocationInfo)
 SWIFT_REQUEST(ClangImporter, CxxRecordAsSwiftType,
-              ValueDecl *(CxxRecordSemanticsDescriptor), Cached,
+              ValueDecl *(CxxRecordSemanticsDescriptor), Uncached,
               NoLocationInfo)
 SWIFT_REQUEST(ClangImporter, IsSafeUseOfCxxDecl,
-              bool(SafeUseOfCxxRecordDescriptor), Cached,
+              bool(SafeUseOfCxxRecordDescriptor), Uncached,
               NoLocationInfo)
 SWIFT_REQUEST(ClangImporter, CustomRefCountingOperation,
-              CustomRefCountingOperationResult(CustomRefCountingOperationDescriptor), Cached,
+              CustomRefCountingOperationResult(CustomRefCountingOperationDescriptor), Uncached,
               NoLocationInfo)
 SWIFT_REQUEST(ClangImporter, ClangTypeEscapability,
               CxxEscapability(EscapabilityLookupDescriptor), Cached,
@@ -52,11 +52,11 @@ SWIFT_REQUEST(ClangImporter, CxxValueSemantics,
               CxxValueSemanticsKind(CxxValueSemanticsDescriptor), Cached,
               NoLocationInfo)
 SWIFT_REQUEST(ClangImporter, ClangDeclExplicitSafety,
-              ExplicitSafety(ClangDeclExplicitSafetyDescriptor), Cached,
+              ExplicitSafety(ClangDeclExplicitSafetyDescriptor), Uncached,
               NoLocationInfo)
 SWIFT_REQUEST(ClangImporter, ClangRefCountedSmartPointer,
               RefCountedPtrRequestResult(ClangRefCountedSmartPointerDescriptor),
-              Cached, NoLocationInfo)
+              Uncached, NoLocationInfo)
 SWIFT_REQUEST(ClangImporter, CxxIteratorInfoRequest,
               std::optional<CxxIteratorCategory>(CxxRecordDeclDescriptor),
-              Cached, NoLocationInfo)
+              Uncached, NoLocationInfo)

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -8880,10 +8880,6 @@ ExplicitSafety ClangDeclExplicitSafety::evaluate(
   return ExplicitSafety::Safe;
 }
 
-bool ClangDeclExplicitSafety::isCached() const {
-  return isa<clang::RecordDecl>(std::get<0>(getStorage()).decl);
-}
-
 void swift::simple_display(llvm::raw_ostream &out,
                            ClangRefCountedSmartPointerDescriptor desc) {
   out << "Validating SWIFT_REFCOUNTED_PTR for '";


### PR DESCRIPTION
- **Explanation**: Disable caching for most Clang Importer-related requests.
  These requests are keyed on Clang AST pointer addresses, which might be deallocated and reused between module loading, causing stale cached results to be returned for unrelated decls and manifesting as spurious compiler errors. This is a follow-up to 22dd716b733, which disabled caching for IsSafeUseOfCxxDecl long ago for the same reason.
- Scope: Low impact. This change does not affect correctness, only performance (and the value of caching for these requests was never evaluated in the first place).
- Issues: rdar://175540597
- Risk: Low. Disabling caching is strictly more conservative than caching.
- Testing: Existing test suite covers correctness of these requests. Further investigation into Clang pointer stability is ongoing.