### PR TITLE
Remove usePoints parameter from swift::castValueToABICompatibleType

### DIFF
--- a/include/swift/SILOptimizer/Utils/InstOptUtils.h
+++ b/include/swift/SILOptimizer/Utils/InstOptUtils.h
@@ -190,16 +190,10 @@ SILValue getConcreteValueOfExistentialBoxAddr(SILValue addr,
 /// - a type of the return value is a subclass of the expected return type.
 /// - actual return type and expected return type differ in optionality.
 /// - both types are tuple-types and some of the elements need to be casted.
-///
-/// \p usePoints is required when \p value has guaranteed ownership. It must be
-/// the last users of the returned, casted value. A usePoint cannot be a
-/// BranchInst (a phi is never the last guaranteed user). \p builder's current
-/// insertion point must dominate all \p usePoints.
 std::pair<SILValue, bool /* changedCFG */>
 castValueToABICompatibleType(SILBuilder *builder, SILPassManager *pm,
-                             SILLocation Loc,
-                             SILValue value, SILType srcTy, SILType destTy,
-                             ArrayRef<SILInstruction *> usePoints);
+                             SILLocation Loc, SILValue value, SILType srcTy,
+                             SILType destTy);
 
 /// Returns true if the layout of a generic nominal type is dependent on its generic parameters.
 /// This is usually the case. Some examples, where they layout is _not_ dependent:

--- a/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
@@ -1653,11 +1653,9 @@ SILCombiner::visitDifferentiableFunctionExtractInst(DifferentiableFunctionExtrac
     if (!opTI->isABICompatibleWith(resTI, *DFEI->getFunction()).isCompatible())
       return nullptr;
 
-    std::tie(newValue, std::ignore) =
-      castValueToABICompatibleType(&Builder, parentTransform->getPassManager(),
-                                   DFEI->getLoc(),
-                                   newValue,
-                                   newValue->getType(), DFEI->getType(), {});
+    std::tie(newValue, std::ignore) = castValueToABICompatibleType(
+        &Builder, parentTransform->getPassManager(), DFEI->getLoc(), newValue,
+        newValue->getType(), DFEI->getType());
   }
 
   replaceInstUsesWith(*DFEI, newValue);

--- a/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
+++ b/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
@@ -2578,7 +2578,7 @@ bool SimplifyCFG::simplifyTryApplyBlock(TryApplyInst *TAI) {
     std::tie(Arg, std::ignore) = castValueToABICompatibleType(
         &Builder, PM, TAI->getLoc(), Arg,
         origConv.getSILArgumentType(i, context),
-        targetConv.getSILArgumentType(calleeArgIdx, context), {TAI});
+        targetConv.getSILArgumentType(calleeArgIdx, context));
     Args.push_back(Arg);
     calleeArgIdx += 1;
   }
@@ -2611,7 +2611,7 @@ bool SimplifyCFG::simplifyTryApplyBlock(TryApplyInst *TAI) {
   // Non-guaranteed values don't need use points when casting.
   SILValue CastedResult;
   std::tie(CastedResult, std::ignore) = castValueToABICompatibleType(
-      &Builder, PM, Loc, NewAI, ResultTy, OrigResultTy, /*usePoints*/ {});
+      &Builder, PM, Loc, NewAI, ResultTy, OrigResultTy);
 
   BranchInst *branch = Builder.createBranch(Loc, NormalBB, {CastedResult});
 

--- a/lib/SILOptimizer/Utils/Devirtualize.cpp
+++ b/lib/SILOptimizer/Utils/Devirtualize.cpp
@@ -531,7 +531,7 @@ replaceApplyInst(SILBuilder &builder, SILPassManager *pm, SILLocation loc, Apply
   // guaranteed value, so this cast cannot generate borrow scopes and it can be
   // used anywhere the original oldAI was used.
   auto castRes = castValueToABICompatibleType(
-    &builder, pm, loc, newAI, newAI->getType(), oldAI->getType(), /*usePoints*/ {});
+      &builder, pm, loc, newAI, newAI->getType(), oldAI->getType());
 
   oldAI->replaceAllUsesWith(castRes.first);
   return {newAI, castRes.second};
@@ -592,7 +592,7 @@ replaceTryApplyInst(SILBuilder &builder, SILPassManager *pm, SILLocation loc, Tr
     // borrow scopes and it can be used anywhere the original oldAI was
     // used--usePoints are not required.
     std::tie(resultValue, std::ignore) = castValueToABICompatibleType(
-        &builder, pm, loc, resultValue, newResultTy, oldResultTy, /*usePoints*/ {});
+        &builder, pm, loc, resultValue, newResultTy, oldResultTy);
     builder.createBranch(loc, normalBB, {resultValue});
   }
 
@@ -624,16 +624,10 @@ replaceBeginApplyInst(SILBuilder &builder, SILPassManager *pm, SILLocation loc,
   for (auto i : indices(oldYields)) {
     auto oldYield = oldYields[i];
     auto newYield = newYields[i];
-    // Insert any end_borrow if the yielded value before the token's uses.
-    SmallVector<SILInstruction *, 4> users(
-      makeUserIteratorRange(oldYield->getUses()));
-    if (!users.empty()) {
-      auto yieldCastRes = castValueToABICompatibleType(
-        &builder, pm, loc, newYield, newYield->getType(), oldYield->getType(),
-        users);
-      oldYield->replaceAllUsesWith(yieldCastRes.first);
-      changedCFG |= yieldCastRes.second;
-    }
+    auto yieldCastRes = castValueToABICompatibleType(
+        &builder, pm, loc, newYield, newYield->getType(), oldYield->getType());
+    oldYield->replaceAllUsesWith(yieldCastRes.first);
+    changedCFG |= yieldCastRes.second;
   }
 
   if (newArgBorrows.empty())
@@ -668,8 +662,7 @@ replacePartialApplyInst(SILBuilder &builder, SILPassManager *pm, SILLocation loc
   // A non-guaranteed cast needs no usePoints.
   assert(newPAI->getOwnershipKind() != OwnershipKind::Guaranteed);
   auto castRes = castValueToABICompatibleType(
-    &builder, pm, loc, newPAI, newPAI->getType(), oldPAI->getType(),
-    /*usePoints*/ {});
+      &builder, pm, loc, newPAI, newPAI->getType(), oldPAI->getType());
   oldPAI->replaceAllUsesWith(castRes.first);
 
   return {newPAI, castRes.second};
@@ -886,8 +879,8 @@ swift::devirtualizeClassMethod(SILPassManager *pm, FullApplySite applySite,
   for (auto resultTy : substConv.getIndirectSILResultTypes(
            applySite.getFunction()->getTypeExpansionContext())) {
     auto castRes = castValueToABICompatibleType(
-        &builder, pm, loc, *indirectResultArgIter, indirectResultArgIter->getType(),
-        resultTy, {applySite.getInstruction()});
+        &builder, pm, loc, *indirectResultArgIter,
+        indirectResultArgIter->getType(), resultTy);
     newArgs.push_back(castRes.first);
     changedCFG |= castRes.second;
     ++indirectResultArgIter;
@@ -897,9 +890,8 @@ swift::devirtualizeClassMethod(SILPassManager *pm, FullApplySite applySite,
     auto errorArgs = applySite.getIndirectSILErrorResults();
     ASSERT(errorArgs.size() == 1);
     SILValue errorArg = errorArgs[0];
-    auto castRes = castValueToABICompatibleType(
-        &builder, pm, loc, errorArg, errorArg->getType(),
-        errorTy, {applySite.getInstruction()});
+    auto castRes = castValueToABICompatibleType(&builder, pm, loc, errorArg,
+                                                errorArg->getType(), errorTy);
     newArgs.push_back(castRes.first);
     changedCFG |= castRes.second;
   }
@@ -917,10 +909,8 @@ swift::devirtualizeClassMethod(SILPassManager *pm, FullApplySite applySite,
       arg = borrowBuilder.createBeginBorrow(loc, arg);
       newArgBorrows.push_back(arg);
     }
-    auto argCastRes =
-      castValueToABICompatibleType(&builder, pm, loc, arg,
-                                   paramArgIter->getType(), paramType,
-                                   {applySite.getInstruction()});
+    auto argCastRes = castValueToABICompatibleType(
+        &builder, pm, loc, arg, paramArgIter->getType(), paramType);
 
     newArgs.push_back(argCastRes.first);
     changedCFG |= argCastRes.second;
@@ -1191,8 +1181,7 @@ devirtualizeWitnessMethod(SILPassManager *pm, ApplySite applySite, SILFunction *
         borrowedArgs.push_back(arg);
       }
       auto argCastRes = castValueToABICompatibleType(
-        &argBuilder, pm, applySite.getLoc(), arg, arg->getType(), paramType,
-        applySite.getInstruction());
+          &argBuilder, pm, applySite.getLoc(), arg, arg->getType(), paramType);
       arg = argCastRes.first;
       changedCFG |= argCastRes.second;
     }

--- a/lib/SILOptimizer/Utils/InstOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/InstOptUtils.cpp
@@ -594,11 +594,6 @@ SILLinkage swift::getSpecializedLinkage(SILFunction *f, SILLinkage linkage) {
 /// to avoid any divergence between the check and the implementation in the
 /// future.
 ///
-/// \p usePoints are required when \p value has guaranteed ownership. It must be
-/// the last users of the returned, casted value. A usePoint cannot be a
-/// BranchInst (a phi is never the last guaranteed user). \p builder's current
-/// insertion point must dominate all \p usePoints. \p usePoints must
-/// collectively post-dominate \p builder's current insertion point.
 ///
 /// NOTE: The implementation of this function is very closely related to the
 /// rules checked by SILVerifier::requireABICompatibleFunctionTypes. It must
@@ -606,12 +601,8 @@ SILLinkage swift::getSpecializedLinkage(SILFunction *f, SILLinkage linkage) {
 /// areABICompatibleParamsOrReturns()).
 std::pair<SILValue, bool /* changedCFG */>
 swift::castValueToABICompatibleType(SILBuilder *builder, SILPassManager *pm,
-                                    SILLocation loc,
-                                    SILValue value, SILType srcTy,
-                                    SILType destTy,
-                                    ArrayRef<SILInstruction *> usePoints) {
-  assert(value->getOwnershipKind() != OwnershipKind::Guaranteed ||
-         !usePoints.empty() && "guaranteed value must have use points");
+                                    SILLocation loc, SILValue value,
+                                    SILType srcTy, SILType destTy) {
 
   // No cast is required if types are the same.
   if (srcTy == destTy)
@@ -689,7 +680,7 @@ swift::castValueToABICompatibleType(SILBuilder *builder, SILPassManager *pm,
     // Cast the unwrapped value.
     SILValue castedUnwrappedValue;
     std::tie(castedUnwrappedValue, std::ignore) = castValueToABICompatibleType(
-      builder, pm, loc, unwrappedValue, optionalSrcTy, optionalDestTy, usePoints);
+        builder, pm, loc, unwrappedValue, optionalSrcTy, optionalDestTy);
     // Wrap into optional. An owned value is forwarded through the cast and into
     // the Optional. A borrowed value will have a nested borrow for the
     // rewrapped Optional.
@@ -720,8 +711,7 @@ swift::castValueToABICompatibleType(SILBuilder *builder, SILPassManager *pm,
         builder->createOptionalSome(loc, value, loweredOptionalSrcType);
     // Cast the wrapped value.
     return castValueToABICompatibleType(builder, pm, loc, wrappedValue,
-                                        wrappedValue->getType(), destTy,
-                                        usePoints);
+                                        wrappedValue->getType(), destTy);
   }
 
   // Handle tuple types.
@@ -734,7 +724,7 @@ swift::castValueToABICompatibleType(SILBuilder *builder, SILPassManager *pm,
       bool neededCFGChange;
       std::tie(element, neededCFGChange) = castValueToABICompatibleType(
           builder, pm, loc, element, srcTy.getTupleElementType(idx),
-          destTy.getTupleElementType(idx), usePoints);
+          destTy.getTupleElementType(idx));
       changedCFG |= neededCFGChange;
       expectedTuple.push_back(element);
     };

--- a/test/SILOptimizer/borrow_accessor_devirt.swift
+++ b/test/SILOptimizer/borrow_accessor_devirt.swift
@@ -1,0 +1,36 @@
+// RUN: %target-swift-frontend -O -emit-sil %s | %FileCheck %s
+
+class RefCounted {
+  var data: [Int]
+  init(_ d: [Int]) { self.data = d }
+}
+
+protocol HasRef {
+  var ref: RefCounted { borrow mutate }
+}
+
+struct ConformingWrapper: HasRef {
+  var _ref: RefCounted
+  var ref: RefCounted {
+    borrow { return _ref }
+    mutate { return &_ref }
+  }
+  init(_ d: [Int]) { _ref = RefCounted(d) }
+}
+
+
+// CHECK-LABEL: sil hidden [noinline] @$s{{.*}}10testDevirt
+// CHECK-NOT: witness_method
+// CHECK-NOT: open_existential_addr
+// CHECK: ref_tail_addr
+// CHECK: } // end sil function '$s{{.*}}10testDevirt
+
+@inline(never)
+func testDevirt() -> Int {
+  let w: any HasRef = ConformingWrapper([5, 10, 15])
+  let borrowed = w.ref
+  return borrowed.data.reduce(0, +)
+}
+
+print(testDevirt())
+


### PR DESCRIPTION
- **Explanation**: usePoints is an artifact of the time when we didn't have guaranteed forwarding phis. It is no longer used and triggered an unnecessary assert for borrow accessors.
- **Scope**: Removes dead code.
- **Issues**: TBD
- **Risk**: Low
- **Testing**: Added unit test, CI testing
