### PR TITLE
Fix call emission of borrow accessors on class let properties

### DIFF
--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -5500,9 +5500,6 @@ ManagedValue CallEmission::applyBorrowMutateAccessor() {
   // Get the callee type information.
   auto calleeTypeInfo = callee.getTypeInfo(SGF);
 
-  std::optional<ManagedValue> self;
-  auto fnValue = callee.getFnValue(SGF, self);
-
   // Evaluate the arguments.
   SmallVector<ManagedValue, 4> uncurriedArgs;
   std::optional<SILLocation> uncurriedLoc;
@@ -5512,6 +5509,12 @@ ManagedValue CallEmission::applyBorrowMutateAccessor() {
       uncurriedArgs, uncurriedLoc);
 
   auto selfArgMV = uncurriedArgs.back();
+
+  std::optional<ManagedValue> self;
+  if (callee.requiresSelfValueForDispatch()) {
+    self = selfArgMV;
+  }
+  auto fnValue = callee.getFnValue(SGF, self);
 
   // Strip the unnecessary copy_value + mark_unresolved_non_copyable_value +
   // begin_borrow instructions added for move-only self argument.

--- a/test/SILGen/borrow_accessor_class_dispatch.swift
+++ b/test/SILGen/borrow_accessor_class_dispatch.swift
@@ -1,0 +1,43 @@
+// RUN:%target-swift-frontend -emit-silgen %s | %FileCheck %s
+
+class Klass {
+  init() {}
+}
+
+struct NonTrivial {
+  var k = Klass()
+}
+
+class C {
+  let _x: Int = 0
+  var x: Int { borrow { _x } }
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s30borrow_accessor_class_dispatch1fySiAA1CCF
+// CHECK:         [[METHOD:%.*]] = class_method %0, #C.x!borrow : (C) -> () -> Int
+// CHECK:         [[RESULT:%.*]] = apply [[METHOD]](%0)
+// CHECK:         return [[RESULT]]
+// CHECK:       } // end sil function '$s30borrow_accessor_class_dispatch1fySiAA1CCF'
+func f(_ c: C) -> Int { c.x }
+
+class D {
+  let _nt: NonTrivial = NonTrivial()
+  var nt: NonTrivial { borrow { _nt } }
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s30borrow_accessor_class_dispatch1gySiAA1DCF
+// CHECK:         [[METHOD:%.*]] = class_method %0, #D.nt!borrow : (D) -> () -> NonTrivial
+// CHECK:         [[RESULT:%.*]] = apply [[METHOD]](%0)
+// CHECK:       } // end sil function '$s30borrow_accessor_class_dispatch1gySiAA1DCF'
+func g(_ d: D) -> Int {
+  let _ = d.nt
+  return 0
+}
+
+// CHECK-LABEL: sil_vtable C {
+// CHECK:         #C.x!borrow: {{.*}} : @$s30borrow_accessor_class_dispatch1CC1xSivb
+// CHECK:       }
+
+// CHECK-LABEL: sil_vtable D {
+// CHECK:         #D.nt!borrow: {{.*}} : @$s30borrow_accessor_class_dispatch1DC2ntAA10NonTrivialVvb
+// CHECK:       }


### PR DESCRIPTION
- **Explanation**: In `applyBorrowMutateAccessor()`, the self value was not being passed to `getFnValue()` for class method dispatch. Fix this by correctly passing the self value when it is required for dispatch similar to the call emission of other accessors.

- **Scope**: SILGen of borrow accessors returning `let` properties of classes 

- **Issues**: rdar://175821999

- **Risk**: Low

- **Testing**: Added unit test, CI testing
