### PR TITLE
[AST]: Update isStructurallyUninhabited() to account for enums with only unconstructible cases

### DIFF
--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -43,6 +43,7 @@
 #include "swift/AST/Types.h"
 #include "swift/Basic/Assertions.h"
 #include "swift/Basic/Compiler.h"
+#include "swift/Basic/Defer.h"
 #include "clang/AST/DeclCXX.h"
 #include "llvm/ADT/APFloat.h"
 #include "llvm/ADT/STLExtras.h"
@@ -124,15 +125,71 @@ bool TypeBase::isUninhabited() {
   return false;
 }
 
-bool TypeBase::isStructurallyUninhabited() {
-  if (isUninhabited()) return true;
-  
+static bool
+computeIsStructurallyUninhabited(Type T,
+                                 SmallPtrSetImpl<TypeBase *> &visitingSet) {
+  if (T->isUninhabited())
+    return true;
+
   // Tuples of uninhabited types are uninhabited
-  if (auto *TTy = getAs<TupleType>())
+  if (auto *TTy = T->getAs<TupleType>()) {
     for (auto eltTy : TTy->getElementTypes())
-      if (eltTy->isStructurallyUninhabited())
+      if (computeIsStructurallyUninhabited(eltTy, visitingSet))
         return true;
+    return false;
+  }
+
+  // An enum is structurally uninhabited iff every available case has at least
+  // one structurally uninhabited associated value.
+  if (auto *enumDecl = T->getEnumOrBoundGenericEnum()) {
+    // Conservatively treat @objc enums that were imported by clang as always
+    // potentially being inhabited.
+    // TODO: is this appropriate and/or the right test?
+    if (enumDecl->isObjC() && enumDecl->hasClangNode())
+      return false;
+
+    // TODO: is this assertion correct?
+    // Guard against recursion through indirect enums. If we cycle back to a
+    // type, there's presumably no way to construct the case containing the
+    // cycle, so treat it as uninhabited.
+    auto *canTyPtr = T->getCanonicalType().getPointer();
+    if (!visitingSet.insert(canTyPtr).second)
+      return true;
+    SWIFT_DEFER { visitingSet.erase(canTyPtr); };
+
+    for (auto *enumEltDecl : enumDecl->getAllElements()) {
+      // TODO: is this the appropriate treatment of unavailable cases?
+      if (enumEltDecl->isUnavailable())
+        continue;
+
+      // A case with no associated values is always constructible.
+      if (!enumEltDecl->hasAssociatedValues())
+        return false;
+
+      bool anyPayloadUninhabited = false;
+      for (auto &param : enumEltDecl->getCaseConstructorParams()) {
+        auto payloadTy =
+            T->getTypeOfMember(enumEltDecl, param.getParameterType());
+        if (computeIsStructurallyUninhabited(payloadTy, visitingSet)) {
+          anyPayloadUninhabited = true;
+          break;
+        }
+      }
+
+      // If no payload was uninhabited, the case is constructible.
+      if (!anyPayloadUninhabited)
+        return false;
+    }
+
+    return true;
+  }
+
   return false;
+}
+
+bool TypeBase::isStructurallyUninhabited() {
+  SmallPtrSet<TypeBase *, 4> visitingSet;
+  return computeIsStructurallyUninhabited(this, visitingSet);
 }
 
 bool TypeBase::isAny() {

--- a/test/Sema/exhaustive_switch.swift
+++ b/test/Sema/exhaustive_switch.swift
@@ -1516,3 +1516,175 @@ do {
     case nil?: break
   }
 }
+
+// https://github.com/swiftlang/swift/issues/88463
+
+do {
+  enum Foo {
+    case bar(Bar)
+  }
+  enum Bar {}
+  func foo(foo: Foo) {
+    switch foo {  // type is "effectively uninhabited" so should not warn
+    case .bar:
+      break
+    }
+  }
+
+  func foo2(foo: Foo) {
+    switch foo {} // type is "effectively uninhabited" so should not warn
+  }
+
+  // Further edge cases:
+
+  enum EffectivelyUninhabEnum1 {
+    case one(Never)
+    case two(MyNever)
+  }
+
+  enum EffectivelyUninhabEnum2 {
+    case one(EffectivelyUninhabEnum1)
+    case two((EffectivelyUninhabEnum1, EffectivelyUninhabEnum1))
+    indirect case three(EffectivelyUninhabEnum2)
+  }
+
+  enum MixedUninhabitedEnum {
+    case inhab_one
+    case inhab_two(Int)
+    case uninhab_one(Never)
+    case uninab_two(MyNever)
+    case uninhab_three(EffectivelyUninhabEnum2)
+  }
+
+  func test_mixed_uninhabited(_ mixed: MixedUninhabitedEnum) {
+    switch mixed {
+      case .inhab_one, .inhab_two: break
+      // remaining cases effectively uninhabited
+    }
+  }
+
+  func test_effective_uninhabited_tuple(_ tup: (EffectivelyUninhabEnum1, EffectivelyUninhabEnum2)) {
+    switch tup {}
+  }
+
+  func test_mixed_uninhabited_tuple(_ tup: (Int, MixedUninhabitedEnum)) {
+    switch tup {}
+    // expected-error @-1 {{switch must be exhaustive}}
+    // expected-note @-2 {{add missing case: '(_, _)'}}
+
+    switch tup {
+      // expected-error @-1 {{switch must be exhaustive}}
+      // expected-note @-2 {{add missing case: '(_, .inhab_two(_))'}}
+      case (_, .inhab_one): break
+    }
+
+    switch tup {
+      case (_, .inhab_one): break
+      case (_, .inhab_two): break
+    }
+  }
+
+  // Generic enums: substitution can make a type effectively uninhabited.
+  enum GenericWrapper<T> {
+    case value(T)
+  }
+
+  func test_generic_uninhabited(_ x: GenericWrapper<Never>) {
+    switch x {} // effectively uninhabited via Never substitution
+  }
+
+  func test_generic_inhabited(_ x: GenericWrapper<Int>) {
+    switch x {}
+    // expected-error @-1 {{switch must be exhaustive}}
+    // expected-note @-2 {{add missing case: '.value(_)'}}
+  }
+
+  func test_generic_nested_uninhabited(_ x: GenericWrapper<GenericWrapper<Never>>) {
+    switch x {} // nested generic, still effectively uninhabited
+  }
+
+  // Multi-payload case where one payload is uninhabited.
+  enum MultiPayload {
+    case pair(Never, Int)
+  }
+
+  func test_multi_payload_uninhabited(_ x: MultiPayload) {
+    switch x {} // uninhabited: Never makes the case unconstructible
+  }
+
+  // Mutual recursion: neither type has a base case.
+  enum MutualA {
+    indirect case a(MutualB)
+  }
+  enum MutualB {
+    indirect case b(MutualA)
+  }
+
+  func test_mutual_recursion(_ a: MutualA) {
+    switch a {} // mutually recursive with no base case
+  }
+
+  func test_mutual_recursion_b(_ b: MutualB) {
+    switch b {} // symmetric case
+  }
+
+  // Indirect enum with no base case.
+  enum InfiniteTree { // expected-warning {{enum containing only recursive cases is impossible to instantiate}}
+    indirect case node(InfiniteTree)
+  }
+
+  func test_indirect_no_base_case(_ x: InfiniteTree) {
+    switch x {} // no base case, not constructible
+  }
+
+  // Indirect enum with a base case must still be exhaustive.
+  enum FiniteTree {
+    case leaf
+    indirect case node(FiniteTree, FiniteTree)
+  }
+
+  func test_indirect_with_base_case(_ x: FiniteTree) {
+    switch x {}
+    // expected-error @-1 {{switch must be exhaustive}}
+    // expected-note @-2 {{add missing case: '.leaf'}}
+    // expected-note @-3 {{add missing case: '.node(_, _)'}}
+    // expected-note @-4 {{add missing cases}}
+  }
+
+  // Optional of an effectively-uninhabited type: Optional itself is still
+  // inhabited via .none.
+  func test_optional_of_uninhabited(_ x: Foo?) {
+    switch x {}
+    // expected-error @-1 {{switch must be exhaustive}}
+    // expected-note @-2 {{add missing case: '.none'}}
+
+    switch x {
+    case .none: break
+    } // .some(Foo) is effectively uninhabited, so this is exhaustive
+  }
+
+  // Struct wrapping an uninhabited type. We only traverse tuples and enums so structs
+  // should not be considered "effectively uninhabited" (even if they really are).
+  struct NeverBox {
+    var value: Never
+  }
+  enum StructPayload {
+    case boxed(NeverBox)
+  }
+
+  func test_struct_payload(_ x: StructPayload) {
+    switch x {}
+    // expected-error @-1 {{switch must be exhaustive}}
+    // expected-note @-2 {{add missing case: '.boxed(_)'}}
+  }
+
+  enum OnlyUnavailableInhabited {
+    @available(*, unavailable)
+    case available_one
+    case unavailable_payload(Never)
+  }
+
+  func test_only_unavailable_inhabited(_ x: OnlyUnavailableInhabited) {
+    switch x {} // only non-unavailable case has Never payload
+  }
+}


### PR DESCRIPTION
This change extends the `isStructurallyUninhabited()` check to take into account enums that contain cases but where no case can actually be constructed.

Resolves: https://github.com/swiftlang/swift/issues/88463