### PR TITLE
lib/Basic: Emscripten triple support in `swift-frontend`

### DIFF
--- a/lib/Basic/LangOptions.cpp
+++ b/lib/Basic/LangOptions.cpp
@@ -87,6 +87,7 @@ static const SupportedConditionalValue SupportedConditionalCompilationOSs[] = {
   "Cygwin",
   "Haiku",
   "WASI",
+  "Emscripten",
   "none",
 };
 
@@ -577,6 +578,9 @@ std::pair<bool, bool> LangOptions::setTarget(llvm::Triple triple) {
     break;
   case llvm::Triple::WASI:
     addPlatformConditionValue(PlatformConditionKind::OS, "WASI");
+    break;
+  case llvm::Triple::Emscripten:
+    addPlatformConditionValue(PlatformConditionKind::OS, "Emscripten");
     break;
   case llvm::Triple::UnknownOS:
     if (Target.getOSName() == "none") {

--- a/lib/Basic/Platform.cpp
+++ b/lib/Basic/Platform.cpp
@@ -226,7 +226,6 @@ StringRef swift::getPlatformNameForTriple(const llvm::Triple &triple) {
   case llvm::Triple::DragonFly:
   case llvm::Triple::DriverKit:
   case llvm::Triple::ELFIAMCU:
-  case llvm::Triple::Emscripten:
   case llvm::Triple::Fuchsia:
   case llvm::Triple::HermitCore:
   case llvm::Triple::Hurd:
@@ -286,6 +285,8 @@ StringRef swift::getPlatformNameForTriple(const llvm::Triple &triple) {
     return "haiku";
   case llvm::Triple::WASI:
     return "wasi";
+  case llvm::Triple::Emscripten:
+    return "emscripten";
   case llvm::Triple::UnknownOS:
     return "none";
   case llvm::Triple::UEFI:

--- a/test/Driver/print_target_info.swift
+++ b/test/Driver/print_target_info.swift
@@ -8,6 +8,9 @@
 // RUN: %swift_driver -print-target-info -target x86_64-unknown-linux -static-stdlib | %FileCheck -check-prefix CHECK-LINUX-STATIC %s
 // RUN: %swift_frontend_plain -print-target-info -target x86_64-unknown-linux -use-static-resource-dir | %FileCheck -check-prefix CHECK-LINUX-STATIC %s
 
+// RUN: %swift_driver -print-target-info -target wasm32-unknown-emscripten | %FileCheck -check-prefix CHECK-EMSCRIPTEN %s
+// RUN: %target-swift-frontend -print-target-info -target wasm32-unknown-emscripten | %FileCheck -check-prefix CHECK-EMSCRIPTEN %s
+
 // RUN: %swift_driver -print-target-info -target x86_64-apple-macosx10.15 -target-variant x86_64-apple-ios13.1-macabi | %FileCheck -check-prefix CHECK-PRE-CONCURRENCY-ZIPPERED %s
 // RUN: %target-swift-frontend -print-target-info -target x86_64-apple-macosx10.15 -target-variant x86_64-apple-ios13.1-macabi | %FileCheck -check-prefix CHECK-PRE-CONCURRENCY-ZIPPERED %s
 
@@ -72,6 +75,18 @@
 // CHECK-LINUX-STATIC:   "runtimeResourcePath": "{{.*}}lib{{(/|\\\\)}}swift_static"
 
 // CHECK-LINUX-STATIC-NOT: "targetVariant":
+
+// CHECK-EMSCRIPTEN:   "compilerVersion": "{{.*}}Swift version
+
+// CHECK-EMSCRIPTEN:   "target": {
+// CHECK-EMSCRIPTEN:     "triple": "wasm32-unknown-emscripten",
+// CHECK-EMSCRIPTEN:     "moduleTriple": "wasm32-unknown-emscripten",
+// CHECK-EMSCRIPTEN:     "librariesRequireRPath": false
+// CHECK-EMSCRIPTEN:   }
+
+// CHECK-EMSCRIPTEN:   "runtimeResourcePath": "{{.*}}lib{{(/|\\\\)}}swift"
+
+// CHECK-EMSCRIPTEN-NOT: "targetVariant":
 
 // CHECK-PRE-CONCURRENCY-ZIPPERED: "target": {
 // CHECK-PRE-CONCURRENCY-ZIPPERED:   "triple": "x86_64-apple-macosx10.15"

--- a/test/Driver/print_target_info.swift
+++ b/test/Driver/print_target_info.swift
@@ -8,7 +8,6 @@
 // RUN: %swift_driver -print-target-info -target x86_64-unknown-linux -static-stdlib | %FileCheck -check-prefix CHECK-LINUX-STATIC %s
 // RUN: %swift_frontend_plain -print-target-info -target x86_64-unknown-linux -use-static-resource-dir | %FileCheck -check-prefix CHECK-LINUX-STATIC %s
 
-// RUN: %swift_driver -print-target-info -target wasm32-unknown-emscripten | %FileCheck -check-prefix CHECK-EMSCRIPTEN %s
 // RUN: %target-swift-frontend -print-target-info -target wasm32-unknown-emscripten | %FileCheck -check-prefix CHECK-EMSCRIPTEN %s
 
 // RUN: %swift_driver -print-target-info -target x86_64-apple-macosx10.15 -target-variant x86_64-apple-ios13.1-macabi | %FileCheck -check-prefix CHECK-PRE-CONCURRENCY-ZIPPERED %s

--- a/test/Parse/ConditionalCompilation/wasm32EmscriptenTarget.swift
+++ b/test/Parse/ConditionalCompilation/wasm32EmscriptenTarget.swift
@@ -1,0 +1,10 @@
+// RUN: %swift -typecheck %s -verify -target wasm32-unknown-emscripten -disable-objc-interop -parse-stdlib
+// RUN: %swift-ide-test -test-input-complete -source-filename %s -target wasm32-unknown-emscripten
+
+#if arch(wasm32) && os(Emscripten) && _runtime(_Native) && _endian(little) && _pointerBitWidth(_32)
+#if _hasAtomicBitWidth(_8) && _hasAtomicBitWidth(_16) && _hasAtomicBitWidth(_32) && _hasAtomicBitWidth(_64)
+class C {}
+var x = C()
+#endif
+#endif
+var y = x


### PR DESCRIPTION
- **Explanation**:  Adding support for `swift-frontend -print-target-info -target wasm32-unknown-emscripten`, which is required before this triple is supported in `swiftc`.
- **Scope**: Limited to Emscripten Wasm support.
- **Issues**: rdar://175887675
- **Risk**: Very low due to limited scope.
- **Testing**: Added a new case to the lit test suite.