### PR TITLE
Make non-`@escaping` function types ~Escapable

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2908,6 +2908,8 @@ NOTE(nonsendable_function_type,none,
 NOTE(nonsendable_tuple_type,none,
      "a tuple type must be composed of 'Sendable' elements to conform to "
      "'Sendable'", ())
+NOTE(nonescapable_function_type,none,
+     "a function type can be marked '@escaping' to conform to 'Escapable'", ())
 NOTE(non_sendable_nominal,none,
      "%kind0 does not conform to the 'Sendable' protocol",
       (const ValueDecl *))

--- a/lib/AST/ConformanceLookup.cpp
+++ b/lib/AST/ConformanceLookup.cpp
@@ -317,21 +317,17 @@ static bool isSendableFunctionType(EitherFunctionType eitherFnTy) {
 
 /// Whether the given function type conforms to Escapable.
 static bool isEscapableFunctionType(EitherFunctionType eitherFnTy) {
-//  if (auto silFnTy = eitherFnTy.dyn_cast<const SILFunctionType *>()) {
-//    return !silFnTy->isNoEscape();
-//  }
-//
-// auto functionType = cast<const FunctionType *>(eitherFnTy);
-//
-//  // TODO: what about autoclosures?
-//  return !functionType->isNoEscape();
+  if (auto silFnTy = eitherFnTy.dyn_cast<const SILFunctionType *>()) {
+    return !silFnTy->isNoEscape();
+  }
+
+  auto functionType = cast<const AnyFunctionType *>(eitherFnTy);
+
+  return !functionType->isNoEscape();
 
   // FIXME: unify TypeBase::isNoEscape with TypeBase::isEscapable
   // LazyConformanceEmitter::visitDestroyValueInst chokes on these instructions
   // destroy_value %2 : $@convention(block) @noescape () -> ()
-  //
-  // Wrongly claim that all functions today conform to Escapable for now:
-  return true;
 }
 
 static bool isBitwiseCopyableFunctionType(EitherFunctionType eitherFnTy) {

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -732,12 +732,18 @@ bool MissingConformanceFailure::diagnoseTypeCannotConform(
 
   bool emittedSpecializedNote = false;
   if (auto protoType = protocolType->getAs<ProtocolType>()) {
-    if (protoType->getDecl()->isSpecificProtocol(KnownProtocolKind::Sendable)) {
+    auto *protoDecl = protoType->getDecl();
+    if (protoDecl->isSpecificProtocol(KnownProtocolKind::Sendable)) {
       if (nonConformingType->is<FunctionType>()) {
         emitDiagnostic(diag::nonsendable_function_type);
         emittedSpecializedNote = true;
       } else if (nonConformingType->is<TupleType>()) {
         emitDiagnostic(diag::nonsendable_tuple_type);
+        emittedSpecializedNote = true;
+      }
+    } else if (protoDecl->isSpecificProtocol(KnownProtocolKind::Escapable)) {
+      if (nonConformingType->is<AnyFunctionType>()) {
+        emitDiagnostic(diag::nonescapable_function_type);
         emittedSpecializedNote = true;
       }
     }

--- a/test/Constraints/tuple_arguments.swift
+++ b/test/Constraints/tuple_arguments.swift
@@ -1756,6 +1756,7 @@ func rdar48443263() {
 
 func autoclosureSplat() {
   func takeFn<T>(_: (T) -> ()) {}
+  // expected-note@-1 {{required by local function 'takeFn' where 'T' = '() -> Int'}}
 
   takeFn { (fn: @autoclosure () -> Int) in }
   // This type checks because we find a solution T:= @escaping () -> Int and
@@ -1764,6 +1765,8 @@ func autoclosureSplat() {
   takeFn { (fn: @autoclosure () -> Int, x: Int) in }
   // expected-error@-1 {{contextual closure type '(() -> Int) -> ()' expects 1 argument, but 2 were used in closure body}}
   // expected-error@-2 {{converting non-escaping value to 'T' may allow it to escape}}
+  // expected-error@-3 {{type '() -> Int' cannot conform to 'Escapable'}}
+  // expected-note@-4 {{a function type can be marked '@escaping' to conform to 'Escapable'}}
 
   takeFn { (fn: @autoclosure @escaping () -> Int) in }
   // FIXME: It looks like matchFunctionTypes() does not check @autoclosure at all.
@@ -1788,6 +1791,9 @@ func noescapeSplat() {
   do {
     let t = takesFn { (fn: () -> Int, x: Int) in }
     // expected-error@-1 {{converting non-escaping value to 'T' may allow it to escape}}
+    // expected-error@-2 {{type '() -> Int' cannot conform to 'Escapable'}}
+    // expected-note@-3 {{a function type can be marked '@escaping' to conform to 'Escapable'}}
+    // expected-note@-4 {{requirement from conditional conformance of '(() -> Int, Int)' to 'Escapable'}}
     takesEscaping(t.0)
   }
 }

--- a/test/SIL/closure_lifetime_dependence.swift
+++ b/test/SIL/closure_lifetime_dependence.swift
@@ -101,3 +101,15 @@ func callContextAndArgDependentPicker() {
 // The captures dependence here is technically unnecessary, but causes no harm, since the closure is only called in one place.
 // CHECK-LABEL: sil private @$s27closure_lifetime_dependence32callContextAndArgDependentPickeryyFAA2NEVADXEfU0_ : $@convention(thin) (@guaranteed NE) -> @lifetime(captures, copy 0) @owned NE {
 // CHECK-LABEL: } // end sil function '$s27closure_lifetime_dependence32callContextAndArgDependentPickeryyFAA2NEVADXEfU0_'
+
+
+// Closures as Lifetime Dependence Sources
+// CHECK-LABEL: sil hidden @$s27closure_lifetime_dependence13copyClosureNE4bodyAA0F0VAEyXE_tF : $@convention(thin) (@guaranteed @noescape @callee_guaranteed () -> @lifetime(captures) @owned NE) -> @lifetime(copy 0) @owned NE {
+// CHECK: bb0(%0 : $@noescape @callee_guaranteed () -> @lifetime(captures) @owned NE):
+// CHECK: [[RESULT:%[0-9]+]] = apply %0() : $@noescape @callee_guaranteed () -> @lifetime(captures) @owned NE
+// CHECK-NEXT: return [[RESULT]]
+// CHECK-LABEL: } // end sil function '$s27closure_lifetime_dependence13copyClosureNE4bodyAA0F0VAEyXE_tF'
+@_lifetime(copy body)
+func copyClosureNE(body: () -> NE) -> NE {
+  body()
+}

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_closure.swift
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_closure.swift
@@ -207,3 +207,30 @@ do {
   // expected-note@-5{{it depends on a closure capture; this is not yet supported}}
   // expected-note@-6{{this use causes the lifetime-dependent value to escape}}
 }
+
+// ~Escapable function types
+@_lifetime(borrow body)
+func borrowClosureNE(body: /* @_lifetime(captures) */ () -> NE) -> NE {
+  body()
+}
+
+func callBorrowClosureNE(ne: NE) -> NE {
+  // expected-error@-1{{lifetime-dependent variable 'ne' escapes its scope}}
+  // expected-note@-2{{it depends on the lifetime of argument 'ne'}}
+  let neo = borrowClosureNE { ne }
+  // expected-error@-1{{lifetime-dependent variable 'neo' escapes its scope}}
+  // expected-note@-2{{this use causes the lifetime-dependent value to escape}}
+  // expected-note@-3{{it depends on the lifetime of this parent value}}
+
+  return neo // expected-note{{this use causes the lifetime-dependent value to escape}}
+}
+
+@_lifetime(copy body)
+func copyClosureNE(body: () -> NE) -> NE {
+  body()
+}
+
+func callCopyClosureNE(ne: NE) -> NE {
+  let neo = copyClosureNE { ne }
+  return neo
+}

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_param_fail.swift
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_param_fail.swift
@@ -138,3 +138,13 @@ func fail_smuggle_ne(oNE: inout NE2, f: (NE2) -> NE2) {
   oNE = f(ne)
   // expected-note @+1 {{this use causes the lifetime-dependent value to escape}}
 }
+
+@_lifetime(copy body)
+func copyClosureNE2(body: () -> NE2) -> NE2 {
+  body()
+}
+
+@_lifetime(borrow body)
+func borrowClosureNE2(body: () -> NE2) -> NE2 {
+  body()
+}

--- a/test/SILOptimizer/lifetime_dependence/verify_diagnostics.swift
+++ b/test/SILOptimizer/lifetime_dependence/verify_diagnostics.swift
@@ -461,10 +461,9 @@ func testBasicClosureDependency(value: AnyObject, body: () -> NE) -> NE {
 
 // Implicit dependence on a nonescaping closure context. The result is escaping in the current generic context, so
 // should not be diagnosed as an escape.
-//
-// TODO: remove the _overrideLifetime when context dependencies are tracked.
+@_lifetime(copy f)
 func testIndirectClosureResult<T>(f: () -> CNE<T>) -> CNE<T> {
-  return _overrideLifetime(f(), copying: ())
+  return f()
 }
 
 // =============================================================================

--- a/test/Sema/lifetime_dependence_functype.swift
+++ b/test/Sema/lifetime_dependence_functype.swift
@@ -330,6 +330,12 @@ func inout01(ne0: inout NE, ne1: NE) {}
 func takeInout0(f: @_lifetime(ne0: copy ne0) (_ ne0: inout NE, _ ne1: NE) -> ()) {}
 func takeInout01(f: @_lifetime(ne0: copy ne0, copy ne1) (_ ne0: inout NE, _ ne1: NE) -> ()) {}
 
+
+func takeCaptures(
+  f: @_lifetime(captures)
+    (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE) {}
+
+
 func takeCopying0Captures(
   f: @_lifetime(copy ne0, captures)
     (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE) {}
@@ -406,10 +412,39 @@ func callLifetimeFunctions() {
   let copying0Captures: @_lifetime(copy ne0, captures)
     (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE = {
       ne0, ne1, ne2, ne3, ne4 in
+      true ? ne5 : ne0
+    }
+
+  let capturesOnly: @_lifetime(captures)
+    (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE = {
+      ne0, ne1, ne2, ne3, ne4 in
       ne5
     }
 
   takeCopying0(f: copying0Captures) // expected-error{{cannot convert value of type '@_lifetime(captures, copy ne0) @_lifetime(ne4: copy ne4) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE' to expected argument type '@_lifetime(copy ne0) @_lifetime(ne4: copy ne4) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
+  takeCopying0(f: capturesOnly) // expected-error{{cannot convert value of type '@_lifetime(captures) @_lifetime(ne4: copy ne4) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE' to expected argument type '@_lifetime(copy ne0) @_lifetime(ne4: copy ne4) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
+  takeCopying0Captures(f: capturesOnly) // OK
   takeCopying0Captures(f: copying0) // OK
   takeCopying0Captures(f: copying0Captures) // OK
+}
+
+// ~Escapable function types
+@_lifetime(body) // expected-error{{cannot infer the lifetime dependence scope on a function with a ~Escapable parameter, specify '@_lifetime(borrow body)' or '@_lifetime(copy body)'}}
+func implicitDependClosureNE(body: () -> NE) -> NE {
+  body()
+}
+
+@_lifetime(copy body)
+func explicitCopyClosureNE(body: () -> NE) -> NE {
+  body()
+}
+
+@_lifetime(borrow body)
+func explicitBorrowClosureNE(body: () -> NE) -> NE {
+  body()
+}
+
+func callCopyClosureNE(ne: NE) -> NE {
+  let neo = explicitCopyClosureNE { ne }
+  return neo
 }

--- a/test/attr/attr_noescape.swift
+++ b/test/attr/attr_noescape.swift
@@ -23,8 +23,8 @@ func takesVariadic(_ fns: () -> Int...) {
   doesEscape(fns[0]) // Okay - variadic-of-function parameters are escaping
 }
 
-func takesNoEscapeClosure(_ fn : () -> Int) { // expected-note 1 {{parameter 'fn' is implicitly non-escaping}} {{34-34=@escaping }}
-  // expected-note@-1 6{{parameter 'fn' is implicitly non-escaping}} {{34-34=@escaping }}
+func takesNoEscapeClosure(_ fn : () -> Int) {
+  // expected-note@-1 5{{parameter 'fn' is implicitly non-escaping}} {{34-34=@escaping }}
   takesNoEscapeClosure { 4 }  // ok
 
   _ = fn()  // ok
@@ -36,15 +36,18 @@ func takesNoEscapeClosure(_ fn : () -> Int) { // expected-note 1 {{parameter 'fn
   takesGenericClosure(4, fn)       // ok
   takesGenericClosure(4) { fn() }  // ok.
 
-  _ = [fn] // expected-error {{using non-escaping parameter 'fn' in a context expecting an '@escaping' closure}}
+  _ = [fn] // expected-error {{converting non-escaping value to 'Any' may allow it to escape}}
   _ = [doesEscape(fn)] // expected-error {{passing non-escaping parameter 'fn' to function expecting an '@escaping' closure}}
-  _ = [1 : fn] // expected-error {{using non-escaping parameter 'fn' in a context expecting an '@escaping' closure}}
+  _ = [1 : fn] // expected-error {{converting non-escaping value to 'Any' may allow it to escape}}
   _ = [1 : doesEscape(fn)] // expected-error {{passing non-escaping parameter 'fn' to function expecting an '@escaping' closure}}
   _ = "\(doesEscape(fn))" // expected-error {{passing non-escaping parameter 'fn' to function expecting an '@escaping' closure}}
   _ = "\(takesArray([fn]))" // expected-error {{using non-escaping parameter 'fn' in a context expecting an '@escaping' closure}}
 
   assignToGlobal(fn) // expected-error {{converting non-escaping parameter 'fn' to generic parameter 'T' may allow it to escape}}
   assignToGlobal((fn, fn)) // expected-error {{converting non-escaping value to 'T' may allow it to escape}}
+  // expected-error@-1 {{type '() -> Int' cannot conform to 'Escapable'}}
+  // expected-note@-2 {{a function type can be marked '@escaping' to conform to 'Escapable'}}
+  // expected-note@-3 {{requirement from conditional conformance of '(() -> Int, () -> Int)' to 'Escapable'}}
 }
 
 class SomeClass {


### PR DESCRIPTION
This is not intended for inclusion in the 6.4 release.
<!--
The main branch is now in convergence, which means major changes, such as large refactoring or new features, should be avoided. This strategy is intended to maintain the stability of the Swift 6.4 release leading up to the May 4th branch. For any work that requires broad changes or introduces new features, create a feature branch and open a draft pull request. All updates to the swiftlang/swift repository’s main branch require approval from the release managers. A pull request targeting swiftlang/swift will automatically add release managers. You can also contact them via @release-managers in the forum group.
-->

<!-- Please fill out the following form: --> 
- **Explanation**: Require that function types are `@escaping` for them to conform to the `Escapable` protocol. This allows us to use non-`@escaping` function types as lifetime dependence sources.
  <!--
  A description of the changes. This can be brief, but it should be clear.
  -->
- **Scope**:
  - This is highly important, since it will allow a `~Escapable` callback closure's result to be returned, by specifying a `copy` lifetime dependence on the closure.
  - In its current form, **this will break existing code**, since non-`@escaping` function type parameters will become `~Escapable`. This will prevent the compiler from inferring a `borrow` lifetime dependence on the function, as it currently does.
  <!--
  An assessment of the impact and importance of the changes. For example, can
  the changes break existing code?
  -->
- **Issues**: rdar://172511809 ([nonescapable] Allow a nonescaping function to be a lifetime dependency source), partial.
  <!--
  References to issues the changes resolve, if any.
  -->
- **Risk**: ***Very high***: this change allows incorrect programs to compile due to missing diagnostic support for lifetime dependencies on closure captures (see example below, rdar://169974878). This change should not be included in a release without those diagnostics.

```swift
// 'body's result depends on its captures
@_lifetime(copy body)
func copyClosureSpan(body: () -> Span<Int>) -> Span<Int> {
  body()
}

func bar() -> Int {
  var a = [1, 2, 3]
  let span = copyClosureSpan { a.span }
  a.append(4) // Expected error "overlapping accesses to 'a'" not emitted.
  return span[0]
}
``` 
  <!--
  The (specific) risk to the release for taking the changes.
  -->
- **Testing**: Unit tests added. CI testing.
  <!--
  The specific testing that has been done or needs to be done to further
  validate any impact of the changes.
  -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
