### PR TITLE
CrossModuleOptimization: two improvements for default CMO

### DIFF
--- a/lib/SILOptimizer/IPO/CrossModuleOptimization.cpp
+++ b/lib/SILOptimizer/IPO/CrossModuleOptimization.cpp
@@ -350,9 +350,9 @@ static bool isSerializeCandidate(SILFunction *F, SILOptions options) {
 
 bool CrossModuleOptimization::isReferenceSerializeCandidate(SILFunction *F, 
                                                             SILOptions options) {
+  if (isSerializedWithRightKind(F->getModule(), F))
+    return true;
   if (isPackageCMOEnabled(F->getModule().getSwiftModule())) {
-    if (isSerializedWithRightKind(F->getModule(), F))
-      return true;
     return hasPublicOrPackageVisibility(F->getLinkage(),
                                         /*includePackage*/ true);
   }
@@ -561,7 +561,14 @@ bool CrossModuleOptimization::canSerializeFunction(
   // or should at least increase the size limit.
   bool skipSizeLimitCheck = isPackageCMOEnabled(M.getSwiftModule());
 
-  if (!conservative) {
+  int sizeLimit = CMOFunctionSizeLimit;
+
+  if (conservative) {
+    // Even in conservative mode we want to serialize most generic functions,
+    // except they are large (for code size reasons).
+    if (function->getLoweredFunctionType()->isPolymorphic())
+      sizeLimit = sizeLimit * 20;
+  } else {
     // The basic heuristic: serialize all generic functions, because it makes a
     // huge difference if generic functions can be specialized or not.
     if (function->getLoweredFunctionType()->isPolymorphic())
@@ -571,12 +578,11 @@ bool CrossModuleOptimization::canSerializeFunction(
   }
 
   if (!skipSizeLimitCheck) {
-    // Also serialize "small" non-generic functions.
     int size = 0;
     for (SILBasicBlock &block : *function) {
       for (SILInstruction &inst : block) {
         size += (int)instructionInlineCost(inst);
-        if (size >= CMOFunctionSizeLimit)
+        if (size >= sizeLimit)
           return false;
       }
     }

--- a/test/SILOptimizer/Inputs/cross-module/default-module.swift
+++ b/test/SILOptimizer/Inputs/cross-module/default-module.swift
@@ -70,3 +70,29 @@ public func callPrivateCFunc() -> Int {
 public func usePrivateCVar() -> Int {
   return Int(privateCVar);
 }
+
+public struct S {
+  @usableFromInline
+  final class C {
+    @usableFromInline var p: UnsafeMutableRawPointer
+
+    init(p: UnsafeMutableRawPointer) { self.p = p }
+  }
+
+  @usableFromInline var c: C
+
+  public let b: Bool
+
+  public init(p: UnsafeMutableRawPointer, b: Bool) {
+    self.c = C(p: p)
+    self.b = b
+  }
+
+  public func load<T>(t: T.Type, i: Int) -> T {
+    if b {
+      return c.p.advanced(by: i).loadUnaligned(as: T.self)
+    }
+    return c.p.advanced(by: i).load(as: T.self)
+  }
+}
+

--- a/test/SILOptimizer/default-cmo.swift
+++ b/test/SILOptimizer/default-cmo.swift
@@ -103,3 +103,11 @@ public func getModuleKlassMemberTBD() -> Int {
   return ModuleTBD.moduleKlassMember()
 }
 
+// CHECK-LABEL: sil @$s4Main8testLoad1sSi6Module1SV_tF :
+// CHECK-NOT:     function_ref 
+// CHECK-NOT:     apply 
+// CHECK:       } // end sil function '$s4Main8testLoad1sSi6Module1SV_tF'
+public func testLoad(s: Module.S) -> Int {
+  return s.load(t: Int.self, i: 0)
+}
+


### PR DESCRIPTION
* Allow serialization of larger generic functions. So far we only serialized very small generic functions. However, it's important for performance to serialize more generic functions.
* Allow serialization of functions which call another function which is already marked as serializable. This can e.g. happen for default argument functions.

https://github.com/swiftlang/swift/issues/88441
rdar://174659028
