### PR TITLE
[swift-snapshot-tool] Improve swift-snapshot-tool bisect reliability and cache GitHub API calls

### DIFF
--- a/utils/swift_snapshot_tool/Sources/swift_snapshot_tool/bisect_toolchains.swift
+++ b/utils/swift_snapshot_tool/Sources/swift_snapshot_tool/bisect_toolchains.swift
@@ -191,6 +191,7 @@ struct BisectToolchains: AsyncParsableCommand {
 
       if midIsEndIndex {
         log("Last successful value: \(tags[mid+1])")
+        log("First failing value: \(tags[mid])")
         break
       }
     }

--- a/utils/swift_snapshot_tool/Sources/swift_snapshot_tool/bisect_toolchains.swift
+++ b/utils/swift_snapshot_tool/Sources/swift_snapshot_tool/bisect_toolchains.swift
@@ -108,7 +108,7 @@ struct BisectToolchains: AsyncParsableCommand {
 
     let badTagIndex: Int
     if let newDateAsDate = self.newDateAsDate {
-      let b = tags.firstIndex(where: { $0.tag.date(branch: self.branch) < newDateAsDate })
+      let b = tags.firstIndex(where: { $0.tag.date(branch: self.branch) <= newDateAsDate })
       guard let b else {
         log("Failed to find tag newer than date: \(newDateAsDate)")
         fatalError()

--- a/utils/swift_snapshot_tool/Sources/swift_snapshot_tool/get_tags.swift
+++ b/utils/swift_snapshot_tool/Sources/swift_snapshot_tool/get_tags.swift
@@ -77,10 +77,40 @@ func getTagsFromSwiftRepo(branch: Branch, dryRun: Bool = false) async throws -> 
   let decoder = JSONDecoder()
   decoder.keyDecodingStrategy = .convertFromSnakeCase
 
-  log("[INFO] Starting to download snapshot information from github.")
-  async let data = URLSession.shared.data(from: github_tag_list_url).0
-  let allTags = try! decoder.decode([Tag].self, from: await data)
-  log("[INFO] Finished downloading snapshot information from github.")
+  // Cache tags to a temporary file for 1 hour to avoid GitHub API rate limits.
+  let cachePath = URL(fileURLWithPath: "/tmp/swift_snapshot_tool_tags_cache.json")
+  let cacheTTL: TimeInterval = 3600 // 1 hour
+
+  let allTags: [Tag]
+  if let attrs = try? FileManager.default.attributesOfItem(atPath: cachePath.path),
+     let modDate = attrs[.modificationDate] as? Date,
+     Date().timeIntervalSince(modDate) < cacheTTL,
+     let cachedData = try? Data(contentsOf: cachePath) {
+    log("[INFO] Using cached snapshot information.")
+    allTags = try! decoder.decode([Tag].self, from: cachedData)
+  } else {
+    log("[INFO] Starting to download snapshot information from github.")
+    async let data = URLSession.shared.data(from: github_tag_list_url).0
+    let downloadedData = try await data
+
+    // GitHub may return a dictionary (e.g. rate limit error) instead of
+    // the expected array. Detect this and fall back to a stale cache if
+    // available.
+    if let firstByte = downloadedData.first, firstByte == UInt8(ascii: "{") {
+      log("[INFO] GitHub API returned an error response (likely rate-limited).")
+      if let cachedData = try? Data(contentsOf: cachePath) {
+        log("[INFO] Falling back to stale cache.")
+        allTags = try! decoder.decode([Tag].self, from: cachedData)
+      } else {
+        let body = String(data: downloadedData, encoding: .utf8) ?? "(unreadable)"
+        fatalError("GitHub API rate limited and no cache available: \(body)")
+      }
+    } else {
+      allTags = try! decoder.decode([Tag].self, from: downloadedData)
+      try? downloadedData.write(to: cachePath)
+      log("[INFO] Finished downloading snapshot information from github.")
+    }
+  }
 
   // Then filter the tags to just include the specific snapshot branch
   // prefix. Add the branch to an aggregate BranchTag.
@@ -90,7 +120,7 @@ func getTagsFromSwiftRepo(branch: Branch, dryRun: Bool = false) async throws -> 
     BranchTag(tag: $0, branch: branch)
   }
 
-  // Then sort so that the newest branch prefix 
+  // Then sort so that the newest branch prefix
   filteredTags.sort { $0.tag.ref < $1.tag.ref }
   filteredTags.reverse()
 


### PR DESCRIPTION
This PR adds the following things to swift-snapshot-tool:

- **Cache GitHub API responses**. It does this for 1 hour to avoid rate limiting during repeated bisect runs, with automatic        
  fallback to stale cache when the API returns an error response.
- **Fix bisect boundary condition** by using `<=` instead of `<` when comparing dates, ensuring the tag matching the  
  exact `--new-date` is included in the search range.                                                                   
 - **Emit the first failing snapshot** alongside the last successful one at the end of a bisect, which is especially 
  useful with `--invert` where the user needs both boundary points without manually consulting git.                     
