### PR TITLE
[IRGen] Fix debug info indirection for shadow copies of moveable values

### DIFF
--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -1025,11 +1025,12 @@ public:
   /// register allocator doesn't elide the dbg.value intrinsic when
   /// register pressure is high.  There is a trade-off to this: With
   /// shadow copies, we lose the precise lifetime.
-  llvm::Value *
-  emitShadowCopyIfNeeded(llvm::Value *Storage, llvm::Type *StorageType,
-                         const SILDebugScope *Scope, SILDebugVariable VarInfo,
-                         bool IsAnonymous, bool WasMoved,
-                         std::optional<Alignment> Align = std::nullopt) {
+  ///
+  /// Returns the shadow copy, or nullptr if no shadow copy was needed.
+  llvm::Value *emitShadowCopyIfNeededOrNull(
+      llvm::Value *Storage, llvm::Type *StorageType, const SILDebugScope *Scope,
+      SILDebugVariable VarInfo, bool IsAnonymous, bool WasMoved,
+      std::optional<Alignment> Align = std::nullopt) {
     // Never emit shadow copies when optimizing, or if already on the stack.  No
     // debug info is emitted for refcounts either
 
@@ -1047,7 +1048,7 @@ public:
     // generating extra shadow copies for debug_value [poison].
     if (!shouldShadowVariable(VarInfo, IsAnonymous)
         || !shouldShadowStorage(Storage, StorageType)) {
-      return Storage;
+      return nullptr;
     }
 
     // Emit a shadow copy.
@@ -1065,6 +1066,19 @@ public:
     }
 
     return shadow;
+  }
+
+  /// Like \c emitShadowCopyIfNeededOrNull() but returns the original storage
+  /// when no shadow copy is needed (never returns nullptr).
+  llvm::Value *
+  emitShadowCopyIfNeeded(llvm::Value *Storage, llvm::Type *StorageType,
+                         const SILDebugScope *Scope, SILDebugVariable VarInfo,
+                         bool IsAnonymous, bool WasMoved,
+                         std::optional<Alignment> Align = std::nullopt) {
+    if (auto *shadow = emitShadowCopyIfNeededOrNull(
+            Storage, StorageType, Scope, VarInfo, IsAnonymous, WasMoved, Align))
+      return shadow;
+    return Storage;
   }
 
   /// Like \c emitShadowCopyIfNeeded() but takes an \c Address instead of an
@@ -6225,11 +6239,26 @@ void IRGenSILFunction::visitDebugValueInst(DebugValueInst *i) {
   // Put the value into a shadow-copy stack slot at -Onone.
   llvm::SmallVector<llvm::Value *, 8> Copy;
   if (IsAddrVal) {
-    auto &ti = getTypeInfo(SILVal->getType());
-    Copy.emplace_back(emitShadowCopyIfNeeded(
-        getLoweredAddress(SILVal).getAddress(), ti.getStorageType(),
-        i->getDebugScope(), *VarInfo, IsAnonymous,
-        i->usesMoveableValueDebugInfo()));
+    auto &TI = getTypeInfo(SILVal->getType());
+    auto Addr = getLoweredAddress(SILVal);
+    auto *Storage = Addr.getAddress();
+
+    if (auto *ShadowCopy = emitShadowCopyIfNeededOrNull(
+            Storage, TI.getStorageType(), i->getDebugScope(), *VarInfo,
+            IsAnonymous, i->usesMoveableValueDebugInfo())) {
+      Copy.emplace_back(ShadowCopy);
+      // The shadow alloca stores a pointer to the original storage,
+      // adding a level of indirection. For non-moveable values this is
+      // fine because dbg_declare inherently treats its argument as an
+      // address. Moveable values use dbg_value instead, which doesn't
+      // imply that indirection, so we set IndirectValue.
+      if (!IsInCoro && i->usesMoveableValueDebugInfo()) {
+        assert(Indirection != IndirectValue && "IndirectValue already set!");
+        Indirection = IndirectValue;
+      }
+    } else {
+      Copy.emplace_back(Storage);
+    }
   } else {
     emitShadowCopyIfNeeded(SILVal, i->getDebugScope(), *VarInfo, IsAnonymous,
                            i->usesMoveableValueDebugInfo(), Copy);

--- a/test/DebugInfo/move_function_dbginfo.swift
+++ b/test/DebugInfo/move_function_dbginfo.swift
@@ -171,10 +171,10 @@ public func copyableVarTest() {
 
 // CHECK-LABEL: define swiftcc void @"$s21move_function_dbginfo18copyableVarArgTestyyAA5KlassCzF"(
 // CHECK: #dbg_declare(ptr %m.debug,
-// CHECK: #dbg_value(ptr [[VAR:%.*]], ![[K_COPYABLE_VAR_METADATA:[0-9]+]], !DIExpression(DW_OP_deref, DW_OP_deref), ![[ADDR_LOC:[0-9]*]]
+// CHECK: #dbg_value(ptr [[VAR:%.*]], ![[K_COPYABLE_VAR_METADATA:[0-9]+]], !DIExpression(DW_OP_deref, DW_OP_deref, DW_OP_deref), ![[ADDR_LOC:[0-9]*]]
 // CHECK: #dbg_value(ptr undef, ![[K_COPYABLE_VAR_METADATA]], !DIExpression(DW_OP_deref), ![[ADDR_LOC]]
 // TODO: Should this be a deref like the original?
-// CHECK: #dbg_value(ptr [[VAR]], ![[K_COPYABLE_VAR_METADATA]], !DIExpression(DW_OP_deref, DW_OP_deref), ![[ADDR_LOC]]
+// CHECK: #dbg_value(ptr [[VAR]], ![[K_COPYABLE_VAR_METADATA]], !DIExpression(DW_OP_deref, DW_OP_deref, DW_OP_deref), ![[ADDR_LOC]]
 // CHECK: ret void
 // CHECK-NEXT: }
 //
@@ -211,7 +211,7 @@ public func copyableVarArgTest(_ k: inout Klass) {
 }
 
 // CHECK-LABEL: define swiftcc void @"$s21move_function_dbginfo20addressOnlyValueTestyyxAA1PRzlF"(ptr noalias %0, ptr %T, ptr %T.P)
-// CHECK: #dbg_value(ptr %{{.*}}, ![[K_ADDR_LET_METADATA:[0-9]+]], !DIExpression(DW_OP_deref), ![[ADDR_LOC:[0-9]*]]
+// CHECK: #dbg_value(ptr %{{.*}}, ![[K_ADDR_LET_METADATA:[0-9]+]], !DIExpression(DW_OP_deref, DW_OP_deref), ![[ADDR_LOC:[0-9]*]]
 // CHECK: #dbg_value(ptr undef, ![[K_ADDR_LET_METADATA]], !DIExpression(), ![[ADDR_LOC]]
 // CHECK: ret void
 // CHECK-NEXT: }
@@ -260,7 +260,7 @@ public func addressOnlyValueTest<T : P>(_ x: T) {
 // CHECK-LABEL: define swiftcc void @"$s21move_function_dbginfo23addressOnlyValueArgTestyyxnAA1PRzlF"(
 // CHECK: #dbg_declare(ptr %T1,
 // CHECK: #dbg_declare(ptr %m.debug,
-// CHECK: #dbg_value(ptr %k.debug, ![[K_ADDR_LET_METADATA:[0-9]+]], !DIExpression(DW_OP_deref, DW_OP_deref), ![[ADDR_LOC:[0-9]*]]
+// CHECK: #dbg_value(ptr %k.debug, ![[K_ADDR_LET_METADATA:[0-9]+]], !DIExpression(DW_OP_deref, DW_OP_deref, DW_OP_deref), ![[ADDR_LOC:[0-9]*]]
 // CHECK: #dbg_value(ptr undef, ![[K_ADDR_LET_METADATA]], !DIExpression(DW_OP_deref), ![[ADDR_LOC]]
 // CHECK: ret void
 // CHECK-NEXT: }
@@ -299,10 +299,10 @@ public func addressOnlyValueArgTest<T : P>(_ k: __owned T) {
 }
 
 // CHECK-LABEL: define swiftcc void @"$s21move_function_dbginfo18addressOnlyVarTestyyxAA1PRzlF"(ptr noalias %0, ptr %T, ptr %T.P)
-// CHECK: #dbg_value(ptr %{{.*}}, ![[K_ADDRONLY_VAR_METADATA:[0-9]+]], !DIExpression(DW_OP_deref), ![[ADDR_LOC:[0-9]*]]
+// CHECK: #dbg_value(ptr %{{.*}}, ![[K_ADDRONLY_VAR_METADATA:[0-9]+]], !DIExpression(DW_OP_deref, DW_OP_deref), ![[ADDR_LOC:[0-9]*]]
 // CHECK-NEXT: br
 // CHECK: #dbg_value(ptr undef, ![[K_ADDRONLY_VAR_METADATA]], !DIExpression(), ![[ADDR_LOC]]
-// CHECK: #dbg_value(ptr %{{.*}}, ![[K_ADDRONLY_VAR_METADATA]], !DIExpression(DW_OP_deref), ![[ADDR_LOC]]
+// CHECK: #dbg_value(ptr %{{.*}}, ![[K_ADDRONLY_VAR_METADATA]], !DIExpression(DW_OP_deref, DW_OP_deref), ![[ADDR_LOC]]
 // CHECK: ret void
 // CHECK-NEXT: }
 //
@@ -345,9 +345,9 @@ public func addressOnlyVarTest<T : P>(_ x: T) {
 }
 
 // CHECK-LABEL: define swiftcc void @"$s21move_function_dbginfo21addressOnlyVarArgTestyyxz_xtAA1PRzlF"(
-// CHECK: #dbg_value(ptr %k.debug, ![[K_ADDRONLY_VAR_METADATA:[0-9]+]], !DIExpression(DW_OP_deref, DW_OP_deref), ![[ADDR_LOC:[0-9]*]]
+// CHECK: #dbg_value(ptr %k.debug, ![[K_ADDRONLY_VAR_METADATA:[0-9]+]], !DIExpression(DW_OP_deref, DW_OP_deref, DW_OP_deref), ![[ADDR_LOC:[0-9]*]]
 // CHECK: #dbg_value(ptr undef, ![[K_ADDRONLY_VAR_METADATA]], !DIExpression(DW_OP_deref), ![[ADDR_LOC]]
-// CHECK: #dbg_value(ptr %k.debug, ![[K_ADDRONLY_VAR_METADATA]], !DIExpression(DW_OP_deref, DW_OP_deref), ![[ADDR_LOC]]
+// CHECK: #dbg_value(ptr %k.debug, ![[K_ADDRONLY_VAR_METADATA]], !DIExpression(DW_OP_deref, DW_OP_deref, DW_OP_deref), ![[ADDR_LOC]]
 // CHECK: ret void
 // CHECK-NEXT: }
 //
@@ -453,7 +453,7 @@ public func copyableVarTestCCFlowReinitOutOfBlockTest() {
 
 // CHECK-LABEL: define swiftcc void @"$s21move_function_dbginfo040copyableVarArgTestCCFlowReinitOutOfBlockG0yyAA5KlassCzF"(
 // CHECK: #dbg_declare(ptr %m.debug,
-// CHECK: #dbg_value(ptr [[VAR:%.*]], ![[K_COPYABLE_VAR_CCFLOW_REINIT_OUT_BLOCK_METADATA:[0-9]+]], !DIExpression(DW_OP_deref, DW_OP_deref), ![[ADDR_LOC:[0-9]*]]
+// CHECK: #dbg_value(ptr [[VAR:%.*]], ![[K_COPYABLE_VAR_CCFLOW_REINIT_OUT_BLOCK_METADATA:[0-9]+]], !DIExpression(DW_OP_deref, DW_OP_deref, DW_OP_deref), ![[ADDR_LOC:[0-9]*]]
 //
 // CHECK:      br i1 %{{[0-9]+}}, label %[[LHS:[0-9]+]], label %[[RHS:[0-9]+]],
 //
@@ -465,7 +465,7 @@ public func copyableVarTestCCFlowReinitOutOfBlockTest() {
 // CHECK:      br label %[[CONT_BB]],
 //
 // CHECK: [[CONT_BB]]:
-// CHECK: #dbg_value(ptr [[VAR]], ![[K_COPYABLE_VAR_CCFLOW_REINIT_OUT_BLOCK_METADATA]], !DIExpression(DW_OP_deref, DW_OP_deref), ![[ADDR_LOC]]
+// CHECK: #dbg_value(ptr [[VAR]], ![[K_COPYABLE_VAR_CCFLOW_REINIT_OUT_BLOCK_METADATA]], !DIExpression(DW_OP_deref, DW_OP_deref, DW_OP_deref), ![[ADDR_LOC]]
 // CHECK: ret void
 // CHECK-NEXT: }
 public func copyableVarArgTestCCFlowReinitOutOfBlockTest(_ k: inout Klass) {
@@ -512,14 +512,14 @@ public func copyableVarTestCCFlowReinitInBlockTest() {
 // CHECK-LABEL: define swiftcc void @"$s21move_function_dbginfo037copyableVarArgTestCCFlowReinitInBlockG0yyAA5KlassCzF"(
 // CHECK: entry:
 // CHECK: #dbg_declare(ptr %m.debug,
-// CHECK: #dbg_value(ptr [[VAR:%.*]], ![[K_COPYABLE_VAR_CCFLOW_REINIT_IN_BLOCK_METADATA:[0-9]+]], !DIExpression(DW_OP_deref, DW_OP_deref), ![[ADDR_LOC:[0-9]*]]
+// CHECK: #dbg_value(ptr [[VAR:%.*]], ![[K_COPYABLE_VAR_CCFLOW_REINIT_IN_BLOCK_METADATA:[0-9]+]], !DIExpression(DW_OP_deref, DW_OP_deref, DW_OP_deref), ![[ADDR_LOC:[0-9]*]]
 //
 // CHECK:      br i1 %{{[0-9]+}}, label %[[LHS:[0-9]+]], label %[[RHS:[0-9]+]],
 //
 // CHECK: [[LHS]]:
 // CHECK:      #dbg_value(ptr undef, ![[K_COPYABLE_VAR_CCFLOW_REINIT_IN_BLOCK_METADATA]], !DIExpression(DW_OP_deref), ![[ADDR_LOC]]
 // TODO: Should this be a deref like the original?
-// CHECK:      #dbg_value(ptr [[VAR]], ![[K_COPYABLE_VAR_CCFLOW_REINIT_IN_BLOCK_METADATA]], !DIExpression(DW_OP_deref, DW_OP_deref), ![[ADDR_LOC]]
+// CHECK:      #dbg_value(ptr [[VAR]], ![[K_COPYABLE_VAR_CCFLOW_REINIT_IN_BLOCK_METADATA]], !DIExpression(DW_OP_deref, DW_OP_deref, DW_OP_deref), ![[ADDR_LOC]]
 //
 // CHECK:      br label %[[CONT_BB:[a-z\.0-9]+]],
 //
@@ -570,7 +570,7 @@ public func addressOnlyVarTestCCFlowReinitOutOfBlockTest<T : P>(_ x: T.Type) {
 
 // CHECK-LABEL: define swiftcc void @"$s21move_function_dbginfo043addressOnlyVarArgTestCCFlowReinitOutOfBlockH0yyAA1P_pz_xmtAaCRzlF"(
 // CHECK: entry:
-// CHECK: #dbg_value(ptr [[VAR:%.*]], ![[K_ADDRESSONLY_VAR_CCFLOW_REINIT_OUT_BLOCK_METADATA:[0-9]+]], !DIExpression(DW_OP_deref, DW_OP_deref), ![[ADDR_LOC:[0-9]*]]
+// CHECK: #dbg_value(ptr [[VAR:%.*]], ![[K_ADDRESSONLY_VAR_CCFLOW_REINIT_OUT_BLOCK_METADATA:[0-9]+]], !DIExpression(DW_OP_deref, DW_OP_deref, DW_OP_deref), ![[ADDR_LOC:[0-9]*]]
 //
 // CHECK:      br i1 %{{[0-9]+}}, label %[[LHS:[0-9]+]], label %[[RHS:[0-9]+]],
 //
@@ -583,7 +583,7 @@ public func addressOnlyVarTestCCFlowReinitOutOfBlockTest<T : P>(_ x: T.Type) {
 //
 // CHECK: [[CONT_BB]]:
 // TODO: Should this be a deref like the original?
-// CHECK: #dbg_value(ptr [[VAR]], ![[K_ADDRESSONLY_VAR_CCFLOW_REINIT_OUT_BLOCK_METADATA]], !DIExpression(DW_OP_deref, DW_OP_deref), ![[ADDR_LOC]]
+// CHECK: #dbg_value(ptr [[VAR]], ![[K_ADDRESSONLY_VAR_CCFLOW_REINIT_OUT_BLOCK_METADATA]], !DIExpression(DW_OP_deref, DW_OP_deref, DW_OP_deref), ![[ADDR_LOC]]
 // CHECK: ret void
 // CHECK-NEXT: }
 public func addressOnlyVarArgTestCCFlowReinitOutOfBlockTest<T : P>(_ k: inout (any P), _ x: T.Type) {
@@ -628,14 +628,14 @@ public func addressOnlyVarTestCCFlowReinitInBlockTest<T : P>(_ x: T.Type) {
 
 // CHECK-LABEL: define swiftcc void @"$s21move_function_dbginfo040addressOnlyVarArgTestCCFlowReinitInBlockH0yyAA1P_pz_xmtAaCRzlF"(
 // CHECK: entry:
-// CHECK: #dbg_value(ptr [[VAR:%.*]], ![[K_ADDRESSONLY_VAR_CCFLOW_REINIT_IN_BLOCK_METADATA:[0-9]+]], !DIExpression(DW_OP_deref, DW_OP_deref), ![[ADDR_LOC:[0-9]*]]
+// CHECK: #dbg_value(ptr [[VAR:%.*]], ![[K_ADDRESSONLY_VAR_CCFLOW_REINIT_IN_BLOCK_METADATA:[0-9]+]], !DIExpression(DW_OP_deref, DW_OP_deref, DW_OP_deref), ![[ADDR_LOC:[0-9]*]]
 //
 // CHECK:      br i1 %{{[0-9]+}}, label %[[LHS:[0-9]+]], label %[[RHS:[0-9]+]],
 //
 // CHECK: [[LHS]]:
 // CHECK:      #dbg_value(ptr undef, ![[K_ADDRESSONLY_VAR_CCFLOW_REINIT_IN_BLOCK_METADATA]], !DIExpression(DW_OP_deref), ![[ADDR_LOC]]
 // TODO: Should this be a deref like the original?
-// CHECK:      #dbg_value(ptr [[VAR]], ![[K_ADDRESSONLY_VAR_CCFLOW_REINIT_IN_BLOCK_METADATA]], !DIExpression(DW_OP_deref, DW_OP_deref), ![[ADDR_LOC]]
+// CHECK:      #dbg_value(ptr [[VAR]], ![[K_ADDRESSONLY_VAR_CCFLOW_REINIT_IN_BLOCK_METADATA]], !DIExpression(DW_OP_deref, DW_OP_deref, DW_OP_deref), ![[ADDR_LOC]]
 //
 // CHECK:      br label %[[CONT_BB:[a-z\.0-9]+]],
 //

--- a/test/DebugInfo/noncopyable_shadow_copy_deref.swift
+++ b/test/DebugInfo/noncopyable_shadow_copy_deref.swift
@@ -1,0 +1,46 @@
+// RUN: %target-swift-frontend %s -emit-ir -g -o - | %FileCheck %s
+
+// Verify the DW_OP_deref count when shadow-copying address-only values with
+// usesMoveableValueDebugInfo. When a shadow copy is emitted and
+// usesMoveableValueDebugInfo is set, IndirectValue adds an extra DW_OP_deref.
+//
+// Case 1 (local variable): AllocStackHoisting hoists the alloc_stack to a
+//   dynamic alloca and creates a debug_value WITHOUT op_deref.
+//   Derefs: IndirectValue(1) + DbgValueDeref(1) = 2
+//
+// Case 2 (inout parameter): The debug_value has op_deref.
+//   Derefs: op_deref(1) + IndirectValue(1) + DbgValueDeref(1) = 3
+
+public protocol P {
+    mutating func use()
+}
+
+// Case 1: local address-only variable (hoisted alloc_stack, no op_deref).
+// The alloc_stack for `k` gets [moveable_value_debuginfo] and is hoisted
+// to a dynamic alloca. The shadow copy adds IndirectValue.
+//
+// CHECK-LABEL: define {{.*}} @"$s{{.*}}9testLocal{{.*}}"(
+// CHECK: #dbg_value(ptr %k.debug, ![[LOCAL_K:[0-9]+]], !DIExpression(DW_OP_deref, DW_OP_deref), ![[LOCAL_LOC:[0-9]+]]
+// CHECK: #dbg_value(ptr undef, ![[LOCAL_K]], !DIExpression(), ![[LOCAL_LOC]]
+// CHECK: ret void
+// CHECK-NEXT: }
+public func testLocal<T: P>(_ x: T) {
+    var k = x
+    k.use()
+    let _ = consume k
+}
+
+// Case 2: inout address-only parameter (has op_deref).
+// The debug_value's operand is the indirect parameter (not an
+// AllocStackInst), so op_deref is prepended. IndirectValue adds another.
+//
+// CHECK-LABEL: define {{.*}} @"$s{{.*}}12testInoutArg{{.*}}"(
+// CHECK: #dbg_value(ptr %k.debug, ![[ARG_K:[0-9]+]], !DIExpression(DW_OP_deref, DW_OP_deref, DW_OP_deref), ![[ARG_LOC:[0-9]+]]
+// CHECK: #dbg_value(ptr undef, ![[ARG_K]], !DIExpression(DW_OP_deref), ![[ARG_LOC]]
+// CHECK: ret void
+// CHECK-NEXT: }
+public func testInoutArg<T: P>(_ k: inout T) {
+    k.use()
+    let m = consume k
+    k = m
+}


### PR DESCRIPTION
When a shadow copy is emitted for an address-only value with usesMoveableValueDebugInfo, the shadow alloca stores a pointer to the original storage, adding a level of indirection. Since moveable values use dbg_value instead of dbg_declare, this indirection is not implicit and must be accounted for by setting IndirectValue. Introduce emitShadowCopyIfNeededOrNull to distinguish whether a shadow copy was actually created, and add the extra DW_OP_deref accordingly.
