### PR TITLE
Allow `String.init(describing:)` in Embedded Swift (sometimes).

### DIFF
--- a/stdlib/public/core/Mirror.swift
+++ b/stdlib/public/core/Mirror.swift
@@ -585,7 +585,9 @@ extension String {
     self.init()
     _print_unlocked(instance, &self)
   }
+}
 
+extension String {
   // These overloads serve as fast paths for init(describing:), but they 
   // also preserve source compatibility for clients which accidentally  
   // used init(stringInterpolationSegment:) through constructs like 
@@ -725,7 +727,10 @@ extension String {
   {
     self = instance.description
   }
+}
 
+@_unavailableInEmbedded
+extension String {
   /// Creates a string with a detailed representation of the given value,
   /// suitable for debugging.
   ///

--- a/test/embedded/string-describing.swift
+++ b/test/embedded/string-describing.swift
@@ -5,11 +5,11 @@
 // REQUIRES: swift_feature_Embedded
 
 public struct MyStruct: CustomStringConvertible {
-  var description: String { "" }
+  public var description: String { "" }
 }
 
 public struct MyStreamableStruct: TextOutputStreamable {
-  func write<Target: TextOutputStream>(to target: inout Target) {}
+  public func write<Target: TextOutputStream>(to target: inout Target) {}
 }
 
 public func foo(s: MyStruct) {

--- a/test/embedded/string-describing.swift
+++ b/test/embedded/string-describing.swift
@@ -1,0 +1,21 @@
+// RUN: %target-swift-emit-ir -verify -verify-ignore-unrelated %s -enable-experimental-feature Embedded -wmo
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: optimized_stdlib
+// REQUIRES: swift_feature_Embedded
+
+public struct MyStruct: CustomStringConvertible {
+  var description: String { "" }
+}
+
+public struct MyStreamableStruct: TextOutputStreamable {
+  func write<Target: TextOutputStream>(to target: inout Target) {}
+}
+
+public func foo(s: MyStruct) {
+  _ = String(describing: s)
+}
+
+public func bar(s: MyStreamableStruct) {
+  _ = String(describing: s)
+}


### PR DESCRIPTION
This PR allows the use, in Embedded Swift, of the overloads of `String.init(describing:)` that are constrained to specific protocols (currently `CustomStringConvertible` and `TextOutputStreamable`). These overloads can be fully supported in Embedded Swift as they do not rely on runtime type inspection and just call through to protocol requirements known at compile time.

- **Explanation**: Allows some uses of `String.init(describing:)` in Embedded Swift.
- **Scope**: Embedded Swift, stringification
- **Issues**: rdar://139729101
- **Risk**: Low
- **Testing**: Existing CI coverage and new test file.