### PR TITLE
[Embedded] Avoid `if #available` in Embedded Swift standard library

### DIFF
--- a/stdlib/public/core/FloatingPointParsing.swift.gyb
+++ b/stdlib/public/core/FloatingPointParsing.swift.gyb
@@ -180,10 +180,14 @@ extension ${Self}: LosslessStringConvertible {
     // unconditionally delegate to init(_:Substring)
     self.init(Substring(text))
   %else:
+    #if $Embedded
+      self.init(Substring(text))
+    #else
     if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
       // On SwiftStdlib 5.3 and later, we can just delegate to the
       // init(_:Substring) initializer:
       self.init(Substring(text))
+      return
     } else {
       // When running on SwiftStdlib <5.3, we can't just delegate to
       // the init(_:Substring) initializer, so we have to inline the whole thing...
@@ -212,6 +216,7 @@ extension ${Self}: LosslessStringConvertible {
         return nil
       }
     }
+    #endif
   %end
   }
 

--- a/test/embedded/floatingpointparsing.swift
+++ b/test/embedded/floatingpointparsing.swift
@@ -1,20 +1,15 @@
-// RUN: %target-run-simple-swift(-enable-experimental-feature Embedded -parse-as-library -wmo %target-embedded-posix-shim) | %FileCheck %s
+// RUN: %target-swift-frontend -emit-ir -o - %s -enable-experimental-feature Embedded -parse-as-library | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
-// REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
 // REQUIRES: swift_feature_Embedded
 
 // Check that initializing a Double with a string literal doesn't result in unresolved symbols
-@inline(never)
-func testLiteral() -> Double? {
-  Double("1.5")
-}
+// CHECK-NOT: stdlib_isOSVersionAtLeast
 
-@main
-struct Main {
-  static func main() {
-    print(testLiteral() == 1.5)
-    // CHECK: true
-  }
+// CHECK: define {{.*}} @"$e20floatingpointparsing11testLiteralSdSgyF"()
+public func testLiteral() -> Double? {
+  // CHECK: call swiftcc { i64, i8 } @"$eSdySdSgxcSyRzlufCSS_Tt0g5"
+  // CHECK-NOT: stdlib_isOSVersionAtLeast
+  Double("1.5")
 }

--- a/test/embedded/floatingpointparsing.swift
+++ b/test/embedded/floatingpointparsing.swift
@@ -9,7 +9,7 @@
 
 // CHECK: define {{.*}} @"$e20floatingpointparsing11testLiteralSdSgyF"()
 public func testLiteral() -> Double? {
-  // CHECK: call swiftcc { i64, i8 } @"$eSdySdSgxcSyRzlufCSS_Tt0g5"
+  // CHECK: call swiftcc {{.*}} @"$eSdySdSgxcSyRzlufCSS_Tt0g5"
   // CHECK-NOT: stdlib_isOSVersionAtLeast
   Double("1.5")
 }

--- a/test/embedded/floatingpointparsing.swift
+++ b/test/embedded/floatingpointparsing.swift
@@ -1,0 +1,20 @@
+// RUN: %target-run-simple-swift(-enable-experimental-feature Embedded -parse-as-library -wmo %target-embedded-posix-shim) | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: executable_test
+// REQUIRES: optimized_stdlib
+// REQUIRES: swift_feature_Embedded
+
+// Check that initializing a Double with a string literal doesn't result in unresolved symbols
+@inline(never)
+func testLiteral() -> Double? {
+  Double("1.5")
+}
+
+@main
+struct Main {
+  static func main() {
+    print(testLiteral() == 1.5)
+    // CHECK: true
+  }
+}


### PR DESCRIPTION
- **Explanation**: Inlinable code that uses `if #available` in the standard library currently ends up referencing `_stdlib_isOSVersionAtLeast`. Avoid using it in the floating point parsing code.
- **Scope**: Limited to the Embedded Swift standard library.
- **Issues**: #88698 / rdar://175730290
- **Risk**: Very low. Conditionalizes code for Embedded Swift.
- **Testing**: new test.
