### PR TITLE
[Sema] Relax separately type-checked binding assert for macro expansions

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -10184,6 +10184,12 @@ const ParamDecl *getParameterAt(const ValueDecl *source, unsigned index);
 /// nullptr if the source does not have a parameter list.
 const ParamDecl *getParameterAt(const DeclContext *source, unsigned index);
 
+/// Whether the given \p loc is within a macro expansion relative to
+/// \p parentSF. If the file is itself in a macro expansion, the method
+/// returns \c true if the loc is in a different macro expansion buffer than
+/// the file. If \p parentSF is \c nullptr, \c false is returned.
+bool isMacroExpansionInContext(SourceLoc loc, SourceFile *parentSF);
+
 class ABIRole {
 public:
   enum Value : uint8_t {

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1019,9 +1019,7 @@ SourceRange Decl::getSourceRangeIncludingAttrs() const {
 
 bool Decl::isInMacroExpansionInContext() const {
   auto *mod = getModuleContext();
-  auto *file = mod->getSourceFileContainingLocation(getStartLoc());
-
-  auto parentFile = [&]() {
+  auto *parentSF = [&]() {
     // For accessors, the storage decl is the more accurate thing to check
     // since the entire property/subscript could be macro-generated, in which
     // case the accessor shouldn't be considered "added by macro expansion".
@@ -1032,17 +1030,7 @@ bool Decl::isInMacroExpansionInContext() const {
     }
     return getDeclContext()->getParentSourceFile();
   }();
-
-  // Decls in macro expansions always have a source file. The source
-  // file can be null if the decl is implicit or has an invalid
-  // source location.
-  if (!parentFile || !file)
-    return false;
-
-  if (file->getBufferID() == parentFile->getBufferID())
-    return false;
-
-  return file->getFulfilledMacroRole() != std::nullopt;
+  return swift::isMacroExpansionInContext(getStartLoc(), parentSF);
 }
 
 bool Decl::isInMacroExpansionFromClangHeader() const {
@@ -10253,6 +10241,23 @@ const ParamDecl *swift::getParameterAt(const DeclContext *source,
     return index < params->size() ? params->get(index) : nullptr;
   }
   return nullptr;
+}
+
+bool swift::isMacroExpansionInContext(SourceLoc loc, SourceFile *parentSF) {
+  if (!parentSF)
+    return false;
+
+  // Macro expansions always have a source file. The source file can be null if
+  // the loc is for an implicit decl or is invalid.
+  auto *mod = parentSF->getParentModule();
+  auto *file = mod->getSourceFileContainingLocation(loc);
+  if (!file)
+    return false;
+
+  if (file->getBufferID() == parentSF->getBufferID())
+    return false;
+
+  return file->getFulfilledMacroRole() != std::nullopt;
 }
 
 CaptureInfo AbstractFunctionDecl::getCaptureInfo() const {

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -665,9 +665,16 @@ bool TypeChecker::typeCheckBinding(Pattern *&pattern, Expr *&initializer,
 
   // Bindings cannot be type-checked independently from their context in a
   // closure. If we want to be able to lazily type-check these we'll need to
-  // type-check the entire surrounding expression.
+  // type-check the entire surrounding expression. The only exception to this
+  // is macro expansions since they cannot refer to closure parameters.
+  //
+  // FIXME: We'll likely still have crashers for macro expansions in cases
+  // where e.g the return type of the closure is being queried in the constraint
+  // system.
   if (auto *CE = dyn_cast<ClosureExpr>(DC)) {
-    if (!pattern->isImplicit()) {
+    if (!pattern->isImplicit() &&
+        !swift::isMacroExpansionInContext(pattern->getStartLoc(),
+                                          DC->getParentSourceFile())) {
       // Completion may trigger lazy type-checking, just decline to type-check.
       auto &ctx = CE->getASTContext();
       if (ctx.SourceMgr.hasIDEInspectionTargetBuffer()) {

--- a/test/Macros/macro_expand_binding_in_closure.swift
+++ b/test/Macros/macro_expand_binding_in_closure.swift
@@ -1,0 +1,72 @@
+// REQUIRES: swift_swift_parser
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %t/macro.swift -g -no-toolchain-stdlib-rpath
+
+// RUN: %target-swift-frontend -typecheck -verify -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) %t/main.swift
+
+// FIXME: This ought to not crash (https://github.com/swiftlang/swift/issues/88740)
+// RUN: not --crash %target-swift-frontend -typecheck -verify -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) %t/main.swift -DCRASH
+
+//--- macro.swift
+
+import SwiftSyntax
+import SwiftSyntaxMacros
+
+struct BindingMacro: DeclarationMacro, PeerMacro {
+  static func expansion(
+    of node: AttributeSyntax,
+    providingPeersOf declaration: some DeclSyntaxProtocol,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    ["let \(context.makeUniqueName("x")) = 0"]
+  }
+
+  static func expansion(
+    of node: some FreestandingMacroExpansionSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    ["let \(context.makeUniqueName("y")) = 0"]
+  }
+}
+
+struct IfExprBindingMacro: DeclarationMacro {
+  static func expansion(
+    of node: some FreestandingMacroExpansionSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    ["let \(context.makeUniqueName("z")) = if .random() { return 0 } else { 0 }"]
+  }
+}
+
+//--- main.swift
+
+@freestanding(declaration)
+macro NewBinding() = #externalMacro(module: "MacroDefinition", type: "BindingMacro")
+
+@attached(peer)
+macro PeerBinding() = #externalMacro(module: "MacroDefinition", type: "BindingMacro")
+
+@freestanding(declaration)
+macro IfExprBinding() = #externalMacro(module: "MacroDefinition", type: "IfExprBindingMacro")
+
+func foo() {
+  // Make sure we can type-check the bindings in the closures here.
+  _ = {
+    #NewBinding // expected-note {{in expansion of macro}}
+    // expected-expansion@-1:5 {{
+    //   expected-warning@1 {{initialization of immutable value}}
+    // }}
+    @PeerBinding
+    func bar() {}
+  }
+
+  #if CRASH
+  _ = {
+    #IfExprBinding
+  }
+  #endif
+}
+


### PR DESCRIPTION
- Explanation: Relaxes the separately type-checked binding assertion to account for the fact that macro-expanded bindings can in-fact be type-checked separately from their enclosing closure expression
- Scope: Affects macro-expanded bindings in closures
- Issue: rdar://174880226
- Risk: Low, relaxes an assert
- Testing: Added tests to test suite