### PR TITLE
ManualOwnership: permit use in production builds

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -480,7 +480,7 @@ EXPERIMENTAL_FEATURE(StaticExclusiveOnly, true)
 /// Enable the ManualOwnership diagnostic groups:
 ///   * -Wwarning SemanticCopies
 ///   * -Wwarning DynamicExclusivity
-EXPERIMENTAL_FEATURE(ManualOwnership, false)
+EXPERIMENTAL_FEATURE(ManualOwnership, true)
 
 /// Enable the @extractConstantsFromMembers attribute.
 EXPERIMENTAL_FEATURE(ExtractConstantsFromMembers, false)


### PR DESCRIPTION
- **Explanation**: Permits use of `SemanticCopies` and `DynamicExclusivity` diagnostic groups in production compiler builds, while keeping their maturity level "experimental".
- **Scope**: Changes a bool from false to true.
- **Issues**: rdar://175897573
- **Risk**: none.
- **Testing**: none needed.