### PR TITLE
[stdlib] Improve documentation of Span family API

### DIFF
--- a/stdlib/public/core/Span/MutableRawSpan.swift
+++ b/stdlib/public/core/Span/MutableRawSpan.swift
@@ -430,7 +430,7 @@ extension MutableRawSpan {
   /// - Parameter bounds: A valid range of positions. Every position in
   ///     this range must be within the bounds of this `MutableRawSpan`.
   ///
-  /// - Returns: A `MutableRawSpan` over the bytes within `bounds`
+  /// - Returns: A `MutableRawSpan` over the bytes within `bounds`.
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
@@ -456,7 +456,7 @@ extension MutableRawSpan {
   /// - Parameter bounds: A valid range of positions. Every position in
   ///     this range must be within the bounds of this `MutableRawSpan`.
   ///
-  /// - Returns: A `MutableRawSpan` over the bytes within `bounds`
+  /// - Returns: A `MutableRawSpan` over the bytes within `bounds`.
   ///
   /// - Complexity: O(1)
   @available(*, deprecated, renamed: "_mutatingExtracting(_:)")
@@ -476,7 +476,7 @@ extension MutableRawSpan {
   /// - Parameter bounds: A valid range of positions. Every position in
   ///     this range must be within the bounds of this `MutableRawSpan`.
   ///
-  /// - Returns: A `MutableRawSpan` over the bytes within `bounds`
+  /// - Returns: A `MutableRawSpan` over the bytes within `bounds`.
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
@@ -504,7 +504,7 @@ extension MutableRawSpan {
   /// - Parameter bounds: A valid range of positions. Every position in
   ///     this range must be within the bounds of this `MutableRawSpan`.
   ///
-  /// - Returns: A `MutableRawSpan` over the bytes within `bounds`
+  /// - Returns: A `MutableRawSpan` over the bytes within `bounds`.
   ///
   /// - Complexity: O(1)
   @unsafe
@@ -530,7 +530,7 @@ extension MutableRawSpan {
   /// - Parameter bounds: A valid range of positions. Every position in
   ///     this range must be within the bounds of this `MutableRawSpan`.
   ///
-  /// - Returns: A `MutableRawSpan` over the bytes within `bounds`
+  /// - Returns: A `MutableRawSpan` over the bytes within `bounds`.
   ///
   /// - Complexity: O(1)
   @unsafe
@@ -553,7 +553,7 @@ extension MutableRawSpan {
   /// - Parameter bounds: A valid range of positions. Every position in
   ///     this range must be within the bounds of this `MutableRawSpan`.
   ///
-  /// - Returns: A `MutableRawSpan` over the bytes within `bounds`
+  /// - Returns: A `MutableRawSpan` over the bytes within `bounds`.
   ///
   /// - Complexity: O(1)
   @unsafe
@@ -577,7 +577,7 @@ extension MutableRawSpan {
   /// - Parameter bounds: A valid range of positions. Every position in
   ///     this range must be within the bounds of this `MutableRawSpan`.
   ///
-  /// - Returns: A `MutableRawSpan` over the bytes within `bounds`
+  /// - Returns: A `MutableRawSpan` over the bytes within `bounds`.
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
@@ -600,7 +600,7 @@ extension MutableRawSpan {
   /// - Parameter bounds: A valid range of positions. Every position in
   ///     this range must be within the bounds of this `MutableRawSpan`.
   ///
-  /// - Returns: A `MutableRawSpan` over the bytes within `bounds`
+  /// - Returns: A `MutableRawSpan` over the bytes within `bounds`.
   ///
   /// - Complexity: O(1)
   @available(*, deprecated, renamed: "_mutatingExtracting(_:)")
@@ -622,7 +622,7 @@ extension MutableRawSpan {
   /// - Parameter bounds: A valid range of positions. Every position in
   ///     this range must be within the bounds of this `MutableRawSpan`.
   ///
-  /// - Returns: A `MutableRawSpan` over the bytes within `bounds`
+  /// - Returns: A `MutableRawSpan` over the bytes within `bounds`.
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
@@ -647,7 +647,7 @@ extension MutableRawSpan {
   /// - Parameter bounds: A valid range of positions. Every position in
   ///     this range must be within the bounds of this `MutableRawSpan`.
   ///
-  /// - Returns: A `MutableRawSpan` over the bytes within `bounds`
+  /// - Returns: A `MutableRawSpan` over the bytes within `bounds`.
   ///
   /// - Complexity: O(1)
   @unsafe
@@ -676,7 +676,7 @@ extension MutableRawSpan {
   /// - Parameter bounds: A valid range of positions. Every position in
   ///     this range must be within the bounds of this `MutableRawSpan`.
   ///
-  /// - Returns: A `MutableRawSpan` over the bytes within `bounds`
+  /// - Returns: A `MutableRawSpan` over the bytes within `bounds`.
   ///
   /// - Complexity: O(1)
   @unsafe
@@ -701,7 +701,7 @@ extension MutableRawSpan {
   /// - Parameter bounds: A valid range of positions. Every position in
   ///     this range must be within the bounds of this `MutableRawSpan`.
   ///
-  /// - Returns: A `MutableRawSpan` over the bytes within `bounds`
+  /// - Returns: A `MutableRawSpan` over the bytes within `bounds`.
   ///
   /// - Complexity: O(1)
   @unsafe
@@ -774,7 +774,7 @@ extension MutableRawSpan {
 extension MutableRawSpan {
 
   /// Returns a span containing the initial bytes of this span,
-  /// up to the specified maximum byte count.
+  /// up to the specified maximum length.
   ///
   /// If the maximum length exceeds the length of this span,
   /// the result contains all the bytes.
@@ -804,7 +804,7 @@ extension MutableRawSpan {
   }
 
   /// Returns a span containing the initial bytes of this span,
-  /// up to the specified maximum byte count.
+  /// up to the specified maximum length.
   ///
   /// If the maximum length exceeds the length of this span,
   /// the result contains all the bytes.
@@ -828,7 +828,7 @@ extension MutableRawSpan {
   }
 
   /// Returns a span containing the initial bytes of this span,
-  /// up to the specified maximum byte count.
+  /// up to the specified maximum length.
   ///
   /// If the maximum length exceeds the length of this span,
   /// the result contains all the bytes.
@@ -936,7 +936,7 @@ extension MutableRawSpan {
 #endif
   }
 
-  /// Returns a span containing the final bytes of the span,
+  /// Returns a span containing the trailing bytes of the span,
   /// up to the given maximum length.
   ///
   /// If the maximum length exceeds the length of this span,
@@ -967,7 +967,7 @@ extension MutableRawSpan {
 #endif
   }
 
-  /// Returns a span containing the final bytes of the span,
+  /// Returns a span containing the trailing bytes of the span,
   /// up to the given maximum length.
   ///
   /// If the maximum length exceeds the length of this span,
@@ -991,7 +991,7 @@ extension MutableRawSpan {
     _mutatingExtracting(last: maxLength)
   }
 
-  /// Returns a span containing the final bytes of the span,
+  /// Returns a span containing the trailing bytes of the span,
   /// up to the given maximum length.
   ///
   /// If the maximum length exceeds the length of this span,

--- a/stdlib/public/core/Span/MutableRawSpan.swift
+++ b/stdlib/public/core/Span/MutableRawSpan.swift
@@ -421,6 +421,8 @@ extension MutableRawSpan {
   /// Constructs a new span over the bytes within the supplied range of
   /// positions within this span.
   ///
+  /// The returned span represents a mutation of this span.
+  ///
   /// The returned span's first item is always at offset 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
@@ -444,6 +446,8 @@ extension MutableRawSpan {
 
   /// Constructs a new span over the bytes within the supplied range of
   /// positions within this span.
+  ///
+  /// The returned span represents a mutation of this span.
   ///
   /// The returned span's first item is always at offset 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
@@ -489,6 +493,8 @@ extension MutableRawSpan {
   /// Constructs a new span over the bytes within the supplied range of
   /// positions within this span.
   ///
+  /// The returned span represents a mutation of this span.
+  ///
   /// The returned span's first item is always at offset 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
@@ -512,6 +518,8 @@ extension MutableRawSpan {
 
   /// Constructs a new span over the bytes within the supplied range of
   /// positions within this span.
+  ///
+  /// The returned span represents a mutation of this span.
   ///
   /// The returned span's first item is always at offset 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
@@ -560,6 +568,8 @@ extension MutableRawSpan {
   /// Constructs a new span over the bytes within the supplied range of
   /// positions within this span.
   ///
+  /// The returned span represents a mutation of this span.
+  ///
   /// The returned span's first item is always at offset 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
@@ -580,6 +590,8 @@ extension MutableRawSpan {
 
   /// Constructs a new span over the bytes within the supplied range of
   /// positions within this span.
+  ///
+  /// The returned span represents a mutation of this span.
   ///
   /// The returned span's first item is always at offset 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
@@ -624,6 +636,8 @@ extension MutableRawSpan {
   /// Constructs a new span over the bytes within the supplied range of
   /// positions within this span.
   ///
+  /// The returned span represents a mutation of this span.
+  ///
   /// The returned span's first item is always at offset 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
@@ -650,6 +664,8 @@ extension MutableRawSpan {
 
   /// Constructs a new span over the bytes within the supplied range of
   /// positions within this span.
+  ///
+  /// The returned span represents a mutation of this span.
   ///
   /// The returned span's first item is always at offset 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
@@ -702,6 +718,8 @@ extension MutableRawSpan {
 
   /// Constructs a new span over all the bytes of this span.
   ///
+  /// The returned span represents a mutation of this span.
+  ///
   /// The returned span's first item is always at offset 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
@@ -717,6 +735,8 @@ extension MutableRawSpan {
   }
 
   /// Constructs a new span over all the bytes of this span.
+  ///
+  /// The returned span represents a mutation of this span.
   ///
   /// The returned span's first item is always at offset 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
@@ -759,6 +779,8 @@ extension MutableRawSpan {
   /// If the maximum length exceeds the length of this span,
   /// the result contains all the bytes.
   ///
+  /// The returned span represents a mutation of this span.
+  ///
   /// The returned span's first item is always at offset 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
@@ -786,6 +808,8 @@ extension MutableRawSpan {
   ///
   /// If the maximum length exceeds the length of this span,
   /// the result contains all the bytes.
+  ///
+  /// The returned span represents a mutation of this span.
   ///
   /// The returned span's first item is always at offset 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
@@ -836,6 +860,8 @@ extension MutableRawSpan {
   /// If the number of bytes to drop exceeds the number of bytes in
   /// the span, the result is an empty span.
   ///
+  /// The returned span represents a mutation of this span.
+  ///
   /// The returned span's first item is always at offset 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
@@ -863,6 +889,8 @@ extension MutableRawSpan {
   ///
   /// If the number of bytes to drop exceeds the number of bytes in
   /// the span, the result is an empty span.
+  ///
+  /// The returned span represents a mutation of this span.
   ///
   /// The returned span's first item is always at offset 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
@@ -914,6 +942,8 @@ extension MutableRawSpan {
   /// If the maximum length exceeds the length of this span,
   /// the result contains all the bytes.
   ///
+  /// The returned span represents a mutation of this span.
+  ///
   /// The returned span's first item is always at offset 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
@@ -942,6 +972,8 @@ extension MutableRawSpan {
   ///
   /// If the maximum length exceeds the length of this span,
   /// the result contains all the bytes.
+  ///
+  /// The returned span represents a mutation of this span.
   ///
   /// The returned span's first item is always at offset 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
@@ -993,6 +1025,8 @@ extension MutableRawSpan {
   /// If the number of bytes to drop exceeds the number of bytes in
   /// the span, the result is an empty span.
   ///
+  /// The returned span represents a mutation of this span.
+  ///
   /// The returned span's first item is always at offset 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
@@ -1021,6 +1055,8 @@ extension MutableRawSpan {
   ///
   /// If the number of bytes to drop exceeds the number of bytes in
   /// the span, the result is an empty span.
+  ///
+  /// The returned span represents a mutation of this span.
   ///
   /// The returned span's first item is always at offset 0; unlike buffer
   /// slices, extracted spans do not share their indices with the

--- a/stdlib/public/core/Span/MutableRawSpan.swift
+++ b/stdlib/public/core/Span/MutableRawSpan.swift
@@ -418,17 +418,17 @@ extension MutableRawSpan {
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension MutableRawSpan {
 
-  /// Constructs a new span over the items within the supplied range of
-  /// indices within this span.
+  /// Constructs a new span over the bytes within the supplied range of
+  /// positions within this span.
   ///
   /// The returned span's first item is always at offset 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
-  /// - Parameter bounds: A valid range of indices. Every index in
-  ///     this range must be within the bounds of this `MutableSpan`.
+  /// - Parameter bounds: A valid range of positions. Every position in
+  ///     this range must be within the bounds of this `MutableRawSpan`.
   ///
-  /// - Returns: A `MutableSpan` over the items within `bounds`
+  /// - Returns: A `MutableRawSpan` over the bytes within `bounds`
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
@@ -442,17 +442,17 @@ extension MutableRawSpan {
     return unsafe _mutatingExtracting(unchecked: bounds)
   }
 
-  /// Constructs a new span over the items within the supplied range of
-  /// indices within this span.
+  /// Constructs a new span over the bytes within the supplied range of
+  /// positions within this span.
   ///
   /// The returned span's first item is always at offset 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
-  /// - Parameter bounds: A valid range of indices. Every index in
+  /// - Parameter bounds: A valid range of positions. Every position in
   ///     this range must be within the bounds of this `MutableRawSpan`.
   ///
-  /// - Returns: A `MutableRawSpan` over the items within `bounds`
+  /// - Returns: A `MutableRawSpan` over the bytes within `bounds`
   ///
   /// - Complexity: O(1)
   @available(*, deprecated, renamed: "_mutatingExtracting(_:)")
@@ -462,17 +462,17 @@ extension MutableRawSpan {
     _mutatingExtracting(bounds)
   }
 
-  /// Constructs a new span over the items within the supplied range of
-  /// indices within this span.
+  /// Constructs a new span over the bytes within the supplied range of
+  /// positions within this span.
   ///
   /// The returned span's first item is always at offset 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
-  /// - Parameter bounds: A valid range of indices. Every index in
+  /// - Parameter bounds: A valid range of positions. Every position in
   ///     this range must be within the bounds of this `MutableRawSpan`.
   ///
-  /// - Returns: A `MutableRawSpan` over the items within `bounds`
+  /// - Returns: A `MutableRawSpan` over the bytes within `bounds`
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
@@ -486,8 +486,8 @@ extension MutableRawSpan {
     return unsafe _consumingExtracting(unchecked: bounds)
   }
 
-  /// Constructs a new span over the items within the supplied range of
-  /// indices within this span.
+  /// Constructs a new span over the bytes within the supplied range of
+  /// positions within this span.
   ///
   /// The returned span's first item is always at offset 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
@@ -495,10 +495,10 @@ extension MutableRawSpan {
   ///
   /// This function does not validate `bounds`; this is an unsafe operation.
   ///
-  /// - Parameter bounds: A valid range of indices. Every index in
-  ///     this range must be within the bounds of this `MutableSpan`.
+  /// - Parameter bounds: A valid range of positions. Every position in
+  ///     this range must be within the bounds of this `MutableRawSpan`.
   ///
-  /// - Returns: A `MutableSpan` over the items within `bounds`
+  /// - Returns: A `MutableRawSpan` over the bytes within `bounds`
   ///
   /// - Complexity: O(1)
   @unsafe
@@ -510,8 +510,8 @@ extension MutableRawSpan {
     return unsafe _overrideLifetime(newSpan, mutating: &self)
   }
 
-  /// Constructs a new span over the items within the supplied range of
-  /// indices within this span.
+  /// Constructs a new span over the bytes within the supplied range of
+  /// positions within this span.
   ///
   /// The returned span's first item is always at offset 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
@@ -519,10 +519,10 @@ extension MutableRawSpan {
   ///
   /// This function does not validate `bounds`; this is an unsafe operation.
   ///
-  /// - Parameter bounds: A valid range of indices. Every index in
+  /// - Parameter bounds: A valid range of positions. Every position in
   ///     this range must be within the bounds of this `MutableRawSpan`.
   ///
-  /// - Returns: A `MutableRawSpan` over the items within `bounds`
+  /// - Returns: A `MutableRawSpan` over the bytes within `bounds`
   ///
   /// - Complexity: O(1)
   @unsafe
@@ -533,8 +533,8 @@ extension MutableRawSpan {
     unsafe _mutatingExtracting(unchecked: bounds)
   }
 
-  /// Constructs a new span over the items within the supplied range of
-  /// indices within this span.
+  /// Constructs a new span over the bytes within the supplied range of
+  /// positions within this span.
   ///
   /// The returned span's first item is always at offset 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
@@ -542,10 +542,10 @@ extension MutableRawSpan {
   ///
   /// This function does not validate `bounds`; this is an unsafe operation.
   ///
-  /// - Parameter bounds: A valid range of indices. Every index in
+  /// - Parameter bounds: A valid range of positions. Every position in
   ///     this range must be within the bounds of this `MutableRawSpan`.
   ///
-  /// - Returns: A `MutableRawSpan` over the items within `bounds`
+  /// - Returns: A `MutableRawSpan` over the bytes within `bounds`
   ///
   /// - Complexity: O(1)
   @unsafe
@@ -557,17 +557,17 @@ extension MutableRawSpan {
     return unsafe _overrideLifetime(newSpan, copying: self)
   }
 
-  /// Constructs a new span over the items within the supplied range of
-  /// indices within this span.
+  /// Constructs a new span over the bytes within the supplied range of
+  /// positions within this span.
   ///
   /// The returned span's first item is always at offset 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
-  /// - Parameter bounds: A valid range of indices. Every index in
-  ///     this range must be within the bounds of this `MutableSpan`.
+  /// - Parameter bounds: A valid range of positions. Every position in
+  ///     this range must be within the bounds of this `MutableRawSpan`.
   ///
-  /// - Returns: A `MutableSpan` over the items within `bounds`
+  /// - Returns: A `MutableRawSpan` over the bytes within `bounds`
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
@@ -578,17 +578,17 @@ extension MutableRawSpan {
     _mutatingExtracting(bounds.relative(to: byteOffsets))
   }
 
-  /// Constructs a new span over the items within the supplied range of
-  /// indices within this span.
+  /// Constructs a new span over the bytes within the supplied range of
+  /// positions within this span.
   ///
   /// The returned span's first item is always at offset 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
-  /// - Parameter bounds: A valid range of indices. Every index in
+  /// - Parameter bounds: A valid range of positions. Every position in
   ///     this range must be within the bounds of this `MutableRawSpan`.
   ///
-  /// - Returns: A `MutableRawSpan` over the items within `bounds`
+  /// - Returns: A `MutableRawSpan` over the bytes within `bounds`
   ///
   /// - Complexity: O(1)
   @available(*, deprecated, renamed: "_mutatingExtracting(_:)")
@@ -600,17 +600,17 @@ extension MutableRawSpan {
     _mutatingExtracting(bounds)
   }
 
-  /// Constructs a new span over the items within the supplied range of
-  /// indices within this span.
+  /// Constructs a new span over the bytes within the supplied range of
+  /// positions within this span.
   ///
   /// The returned span's first item is always at offset 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
-  /// - Parameter bounds: A valid range of indices. Every index in
+  /// - Parameter bounds: A valid range of positions. Every position in
   ///     this range must be within the bounds of this `MutableRawSpan`.
   ///
-  /// - Returns: A `MutableRawSpan` over the items within `bounds`
+  /// - Returns: A `MutableRawSpan` over the bytes within `bounds`
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
@@ -621,8 +621,8 @@ extension MutableRawSpan {
     _consumingExtracting(bounds.relative(to: byteOffsets))
   }
 
-  /// Constructs a new span over the items within the supplied range of
-  /// indices within this span.
+  /// Constructs a new span over the bytes within the supplied range of
+  /// positions within this span.
   ///
   /// The returned span's first item is always at offset 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
@@ -630,10 +630,10 @@ extension MutableRawSpan {
   ///
   /// This function does not validate `bounds`; this is an unsafe operation.
   ///
-  /// - Parameter bounds: A valid range of indices. Every index in
-  ///     this range must be within the bounds of this `MutableSpan`.
+  /// - Parameter bounds: A valid range of positions. Every position in
+  ///     this range must be within the bounds of this `MutableRawSpan`.
   ///
-  /// - Returns: A `MutableSpan` over the items within `bounds`
+  /// - Returns: A `MutableRawSpan` over the bytes within `bounds`
   ///
   /// - Complexity: O(1)
   @unsafe
@@ -648,8 +648,8 @@ extension MutableRawSpan {
     return unsafe _mutatingExtracting(unchecked: range)
   }
 
-  /// Constructs a new span over the items within the supplied range of
-  /// indices within this span.
+  /// Constructs a new span over the bytes within the supplied range of
+  /// positions within this span.
   ///
   /// The returned span's first item is always at offset 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
@@ -657,10 +657,10 @@ extension MutableRawSpan {
   ///
   /// This function does not validate `bounds`; this is an unsafe operation.
   ///
-  /// - Parameter bounds: A valid range of indices. Every index in
+  /// - Parameter bounds: A valid range of positions. Every position in
   ///     this range must be within the bounds of this `MutableRawSpan`.
   ///
-  /// - Returns: A `MutableRawSpan` over the items within `bounds`
+  /// - Returns: A `MutableRawSpan` over the bytes within `bounds`
   ///
   /// - Complexity: O(1)
   @unsafe
@@ -673,8 +673,8 @@ extension MutableRawSpan {
     unsafe _mutatingExtracting(unchecked: bounds)
   }
 
-  /// Constructs a new span over the items within the supplied range of
-  /// indices within this span.
+  /// Constructs a new span over the bytes within the supplied range of
+  /// positions within this span.
   ///
   /// The returned span's first item is always at offset 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
@@ -682,10 +682,10 @@ extension MutableRawSpan {
   ///
   /// This function does not validate `bounds`; this is an unsafe operation.
   ///
-  /// - Parameter bounds: A valid range of indices. Every index in
+  /// - Parameter bounds: A valid range of positions. Every position in
   ///     this range must be within the bounds of this `MutableRawSpan`.
   ///
-  /// - Returns: A `MutableRawSpan` over the items within `bounds`
+  /// - Returns: A `MutableRawSpan` over the bytes within `bounds`
   ///
   /// - Complexity: O(1)
   @unsafe
@@ -700,13 +700,13 @@ extension MutableRawSpan {
     return unsafe _consumingExtracting(unchecked: range)
   }
 
-  /// Constructs a new span over all the items of this span.
+  /// Constructs a new span over all the bytes of this span.
   ///
   /// The returned span's first item is always at offset 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
-  /// - Returns: A `MutableSpan` over all the items of this span.
+  /// - Returns: A `MutableRawSpan` over all the bytes of this span.
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
@@ -716,13 +716,13 @@ extension MutableRawSpan {
     return unsafe _overrideLifetime(newSpan, mutating: &self)
   }
 
-  /// Constructs a new span over all the items of this span.
+  /// Constructs a new span over all the bytes of this span.
   ///
   /// The returned span's first item is always at offset 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
-  /// - Returns: A `MutableRawSpan` over all the items of this span.
+  /// - Returns: A `MutableRawSpan` over all the bytes of this span.
   ///
   /// - Complexity: O(1)
   @available(*, deprecated, renamed: "_mutatingExtracting(_:)")
@@ -732,13 +732,13 @@ extension MutableRawSpan {
     _mutatingExtracting(...)
   }
 
-  /// Constructs a new span over all the items of this span.
+  /// Constructs a new span over all the bytes of this span.
   ///
   /// The returned span's first item is always at offset 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
-  /// - Returns: A `MutableRawSpan` over all the items of this span.
+  /// - Returns: A `MutableRawSpan` over all the bytes of this span.
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
@@ -753,19 +753,19 @@ extension MutableRawSpan {
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension MutableRawSpan {
 
-  /// Returns a span containing the initial elements of this span,
-  /// up to the specified maximum length.
+  /// Returns a span containing the initial bytes of this span,
+  /// up to the specified maximum byte count.
   ///
   /// If the maximum length exceeds the length of this span,
-  /// the result contains all the elements.
+  /// the result contains all the bytes.
   ///
   /// The returned span's first item is always at offset 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
-  /// - Parameter maxLength: The maximum number of elements to return.
+  /// - Parameter maxLength: The maximum number of bytes to return.
   ///   `maxLength` must be greater than or equal to zero.
-  /// - Returns: A span with at most `maxLength` elements.
+  /// - Returns: A span with at most `maxLength` bytes.
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
@@ -781,19 +781,19 @@ extension MutableRawSpan {
 #endif
   }
 
-  /// Returns a span containing the initial elements of this span,
-  /// up to the specified maximum length.
+  /// Returns a span containing the initial bytes of this span,
+  /// up to the specified maximum byte count.
   ///
   /// If the maximum length exceeds the length of this span,
-  /// the result contains all the elements.
+  /// the result contains all the bytes.
   ///
   /// The returned span's first item is always at offset 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
-  /// - Parameter maxLength: The maximum number of elements to return.
+  /// - Parameter maxLength: The maximum number of bytes to return.
   ///   `maxLength` must be greater than or equal to zero.
-  /// - Returns: A span with at most `maxLength` elements.
+  /// - Returns: A span with at most `maxLength` bytes.
   ///
   /// - Complexity: O(1)
   @available(*, deprecated, renamed: "_mutatingExtracting(first:)")
@@ -803,19 +803,19 @@ extension MutableRawSpan {
     _mutatingExtracting(first: maxLength)
   }
 
-  /// Returns a span containing the initial elements of this span,
-  /// up to the specified maximum length.
+  /// Returns a span containing the initial bytes of this span,
+  /// up to the specified maximum byte count.
   ///
   /// If the maximum length exceeds the length of this span,
-  /// the result contains all the elements.
+  /// the result contains all the bytes.
   ///
   /// The returned span's first item is always at offset 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
-  /// - Parameter maxLength: The maximum number of elements to return.
+  /// - Parameter maxLength: The maximum number of bytes to return.
   ///   `maxLength` must be greater than or equal to zero.
-  /// - Returns: A span with at most `maxLength` elements.
+  /// - Returns: A span with at most `maxLength` bytes.
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
@@ -831,25 +831,25 @@ extension MutableRawSpan {
 #endif
   }
 
-  /// Returns a span over all but the given number of trailing elements.
+  /// Returns a span over all but the given number of trailing bytes.
   ///
-  /// If the number of elements to drop exceeds the number of elements in
+  /// If the number of bytes to drop exceeds the number of bytes in
   /// the span, the result is an empty span.
   ///
   /// The returned span's first item is always at offset 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
-  /// - Parameter k: The number of elements to drop off the end of
+  /// - Parameter k: The number of bytes to drop off the end of
   ///   the span. `k` must be greater than or equal to zero.
-  /// - Returns: A span leaving off the specified number of elements at the end.
+  /// - Returns: A span leaving off the specified number of bytes at the end.
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
   @lifetime(&self)
   mutating public func _mutatingExtracting(droppingLast k: Int) -> Self {
 #if compiler(>=5.3) && hasFeature(SendableCompletionHandlers)
-    _precondition(k >= 0, "Can't drop a negative number of elements")
+    _precondition(k >= 0, "Can't drop a negative number of bytes")
     let droppedCount = min(k, byteCount)
     let newCount = byteCount &- droppedCount
     let newSpan = unsafe Self(_unchecked: _pointer, byteCount: newCount)
@@ -859,18 +859,18 @@ extension MutableRawSpan {
 #endif
   }
 
-  /// Returns a span over all but the given number of trailing elements.
+  /// Returns a span over all but the given number of trailing bytes.
   ///
-  /// If the number of elements to drop exceeds the number of elements in
+  /// If the number of bytes to drop exceeds the number of bytes in
   /// the span, the result is an empty span.
   ///
   /// The returned span's first item is always at offset 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
-  /// - Parameter k: The number of elements to drop off the end of
+  /// - Parameter k: The number of bytes to drop off the end of
   ///   the span. `k` must be greater than or equal to zero.
-  /// - Returns: A span leaving off the specified number of elements at the end.
+  /// - Returns: A span leaving off the specified number of bytes at the end.
   ///
   /// - Complexity: O(1)
   @available(*, deprecated, renamed: "_mutatingExtracting(droppingLast:)")
@@ -880,25 +880,25 @@ extension MutableRawSpan {
     _mutatingExtracting(droppingLast: k)
   }
 
-  /// Returns a span over all but the given number of trailing elements.
+  /// Returns a span over all but the given number of trailing bytes.
   ///
-  /// If the number of elements to drop exceeds the number of elements in
+  /// If the number of bytes to drop exceeds the number of bytes in
   /// the span, the result is an empty span.
   ///
   /// The returned span's first item is always at offset 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
-  /// - Parameter k: The number of elements to drop off the end of
+  /// - Parameter k: The number of bytes to drop off the end of
   ///   the span. `k` must be greater than or equal to zero.
-  /// - Returns: A span leaving off the specified number of elements at the end.
+  /// - Returns: A span leaving off the specified number of bytes at the end.
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
   @lifetime(copy self)
   consuming public func _consumingExtracting(droppingLast k: Int) -> Self {
 #if compiler(>=5.3) && hasFeature(SendableCompletionHandlers)
-    _precondition(k >= 0, "Can't drop a negative number of elements")
+    _precondition(k >= 0, "Can't drop a negative number of bytes")
     let droppedCount = min(k, byteCount)
     let newCount = byteCount &- droppedCount
     let newSpan = unsafe Self(_unchecked: _pointer, byteCount: newCount)
@@ -908,19 +908,19 @@ extension MutableRawSpan {
 #endif
   }
 
-  /// Returns a span containing the final elements of the span,
+  /// Returns a span containing the final bytes of the span,
   /// up to the given maximum length.
   ///
   /// If the maximum length exceeds the length of this span,
-  /// the result contains all the elements.
+  /// the result contains all the bytes.
   ///
   /// The returned span's first item is always at offset 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
-  /// - Parameter maxLength: The maximum number of elements to return.
+  /// - Parameter maxLength: The maximum number of bytes to return.
   ///   `maxLength` must be greater than or equal to zero.
-  /// - Returns: A span with at most `maxLength` elements.
+  /// - Returns: A span with at most `maxLength` bytes.
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
@@ -937,19 +937,19 @@ extension MutableRawSpan {
 #endif
   }
 
-  /// Returns a span containing the final elements of the span,
+  /// Returns a span containing the final bytes of the span,
   /// up to the given maximum length.
   ///
   /// If the maximum length exceeds the length of this span,
-  /// the result contains all the elements.
+  /// the result contains all the bytes.
   ///
   /// The returned span's first item is always at offset 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
-  /// - Parameter maxLength: The maximum number of elements to return.
+  /// - Parameter maxLength: The maximum number of bytes to return.
   ///   `maxLength` must be greater than or equal to zero.
-  /// - Returns: A span with at most `maxLength` elements.
+  /// - Returns: A span with at most `maxLength` bytes.
   ///
   /// - Complexity: O(1)
   @available(*, deprecated, renamed: "_mutatingExtracting(last:)")
@@ -959,19 +959,19 @@ extension MutableRawSpan {
     _mutatingExtracting(last: maxLength)
   }
 
-  /// Returns a span containing the final elements of the span,
+  /// Returns a span containing the final bytes of the span,
   /// up to the given maximum length.
   ///
   /// If the maximum length exceeds the length of this span,
-  /// the result contains all the elements.
+  /// the result contains all the bytes.
   ///
   /// The returned span's first item is always at offset 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
-  /// - Parameter maxLength: The maximum number of elements to return.
+  /// - Parameter maxLength: The maximum number of bytes to return.
   ///   `maxLength` must be greater than or equal to zero.
-  /// - Returns: A span with at most `maxLength` elements.
+  /// - Returns: A span with at most `maxLength` bytes.
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
@@ -988,18 +988,18 @@ extension MutableRawSpan {
 #endif
   }
 
-  /// Returns a span over all but the given number of initial elements.
+  /// Returns a span over all but the given number of initial bytes.
   ///
-  /// If the number of elements to drop exceeds the number of elements in
+  /// If the number of bytes to drop exceeds the number of bytes in
   /// the span, the result is an empty span.
   ///
   /// The returned span's first item is always at offset 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
-  /// - Parameter k: The number of elements to drop from the beginning of
+  /// - Parameter k: The number of bytes to drop from the beginning of
   ///   the span. `k` must be greater than or equal to zero.
-  /// - Returns: A span starting after the specified number of elements.
+  /// - Returns: A span starting after the specified number of bytes.
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
@@ -1017,18 +1017,18 @@ extension MutableRawSpan {
 #endif
   }
 
-  /// Returns a span over all but the given number of initial elements.
+  /// Returns a span over all but the given number of initial bytes.
   ///
-  /// If the number of elements to drop exceeds the number of elements in
+  /// If the number of bytes to drop exceeds the number of bytes in
   /// the span, the result is an empty span.
   ///
   /// The returned span's first item is always at offset 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
-  /// - Parameter k: The number of elements to drop from the beginning of
+  /// - Parameter k: The number of bytes to drop from the beginning of
   ///   the span. `k` must be greater than or equal to zero.
-  /// - Returns: A span starting after the specified number of elements.
+  /// - Returns: A span starting after the specified number of bytes.
   ///
   /// - Complexity: O(1)
   @available(*, deprecated, renamed: "_mutatingExtracting(droppingFirst:)")
@@ -1038,18 +1038,18 @@ extension MutableRawSpan {
     _mutatingExtracting(droppingFirst: k)
   }
 
-  /// Returns a span over all but the given number of initial elements.
+  /// Returns a span over all but the given number of initial bytes.
   ///
-  /// If the number of elements to drop exceeds the number of elements in
+  /// If the number of bytes to drop exceeds the number of bytes in
   /// the span, the result is an empty span.
   ///
   /// The returned span's first item is always at offset 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
-  /// - Parameter k: The number of elements to drop from the beginning of
+  /// - Parameter k: The number of bytes to drop from the beginning of
   ///   the span. `k` must be greater than or equal to zero.
-  /// - Returns: A span starting after the specified number of elements.
+  /// - Returns: A span starting after the specified number of bytes.
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient

--- a/stdlib/public/core/Span/MutableRawSpan.swift
+++ b/stdlib/public/core/Span/MutableRawSpan.swift
@@ -419,13 +419,13 @@ extension MutableRawSpan {
 extension MutableRawSpan {
 
   /// Constructs a new span over the items within the supplied range of
-  /// positions within this span.
+  /// indices within this span.
   ///
   /// The returned span's first item is always at offset 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
-  /// - Parameter bounds: A valid range of positions. Every position in
+  /// - Parameter bounds: A valid range of indices. Every index in
   ///     this range must be within the bounds of this `MutableSpan`.
   ///
   /// - Returns: A `MutableSpan` over the items within `bounds`
@@ -442,6 +442,19 @@ extension MutableRawSpan {
     return unsafe _mutatingExtracting(unchecked: bounds)
   }
 
+  /// Constructs a new span over the items within the supplied range of
+  /// indices within this span.
+  ///
+  /// The returned span's first item is always at offset 0; unlike buffer
+  /// slices, extracted spans do not share their indices with the
+  /// span from which they are extracted.
+  ///
+  /// - Parameter bounds: A valid range of indices. Every index in
+  ///     this range must be within the bounds of this `MutableRawSpan`.
+  ///
+  /// - Returns: A `MutableRawSpan` over the items within `bounds`
+  ///
+  /// - Complexity: O(1)
   @available(*, deprecated, renamed: "_mutatingExtracting(_:)")
   @_alwaysEmitIntoClient
   @lifetime(&self)
@@ -449,6 +462,19 @@ extension MutableRawSpan {
     _mutatingExtracting(bounds)
   }
 
+  /// Constructs a new span over the items within the supplied range of
+  /// indices within this span.
+  ///
+  /// The returned span's first item is always at offset 0; unlike buffer
+  /// slices, extracted spans do not share their indices with the
+  /// span from which they are extracted.
+  ///
+  /// - Parameter bounds: A valid range of indices. Every index in
+  ///     this range must be within the bounds of this `MutableRawSpan`.
+  ///
+  /// - Returns: A `MutableRawSpan` over the items within `bounds`
+  ///
+  /// - Complexity: O(1)
   @_alwaysEmitIntoClient
   @lifetime(copy self)
   consuming public func _consumingExtracting(_ bounds: Range<Int>) -> Self {
@@ -461,7 +487,7 @@ extension MutableRawSpan {
   }
 
   /// Constructs a new span over the items within the supplied range of
-  /// positions within this span.
+  /// indices within this span.
   ///
   /// The returned span's first item is always at offset 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
@@ -469,7 +495,7 @@ extension MutableRawSpan {
   ///
   /// This function does not validate `bounds`; this is an unsafe operation.
   ///
-  /// - Parameter bounds: A valid range of positions. Every position in
+  /// - Parameter bounds: A valid range of indices. Every index in
   ///     this range must be within the bounds of this `MutableSpan`.
   ///
   /// - Returns: A `MutableSpan` over the items within `bounds`
@@ -484,6 +510,21 @@ extension MutableRawSpan {
     return unsafe _overrideLifetime(newSpan, mutating: &self)
   }
 
+  /// Constructs a new span over the items within the supplied range of
+  /// indices within this span.
+  ///
+  /// The returned span's first item is always at offset 0; unlike buffer
+  /// slices, extracted spans do not share their indices with the
+  /// span from which they are extracted.
+  ///
+  /// This function does not validate `bounds`; this is an unsafe operation.
+  ///
+  /// - Parameter bounds: A valid range of indices. Every index in
+  ///     this range must be within the bounds of this `MutableRawSpan`.
+  ///
+  /// - Returns: A `MutableRawSpan` over the items within `bounds`
+  ///
+  /// - Complexity: O(1)
   @unsafe
   @available(*, deprecated, renamed: "_mutatingExtracting(unchecked:)")
   @_alwaysEmitIntoClient
@@ -492,6 +533,21 @@ extension MutableRawSpan {
     unsafe _mutatingExtracting(unchecked: bounds)
   }
 
+  /// Constructs a new span over the items within the supplied range of
+  /// indices within this span.
+  ///
+  /// The returned span's first item is always at offset 0; unlike buffer
+  /// slices, extracted spans do not share their indices with the
+  /// span from which they are extracted.
+  ///
+  /// This function does not validate `bounds`; this is an unsafe operation.
+  ///
+  /// - Parameter bounds: A valid range of indices. Every index in
+  ///     this range must be within the bounds of this `MutableRawSpan`.
+  ///
+  /// - Returns: A `MutableRawSpan` over the items within `bounds`
+  ///
+  /// - Complexity: O(1)
   @unsafe
   @_alwaysEmitIntoClient
   @lifetime(copy self)
@@ -502,13 +558,13 @@ extension MutableRawSpan {
   }
 
   /// Constructs a new span over the items within the supplied range of
-  /// positions within this span.
+  /// indices within this span.
   ///
   /// The returned span's first item is always at offset 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
-  /// - Parameter bounds: A valid range of positions. Every position in
+  /// - Parameter bounds: A valid range of indices. Every index in
   ///     this range must be within the bounds of this `MutableSpan`.
   ///
   /// - Returns: A `MutableSpan` over the items within `bounds`
@@ -522,6 +578,19 @@ extension MutableRawSpan {
     _mutatingExtracting(bounds.relative(to: byteOffsets))
   }
 
+  /// Constructs a new span over the items within the supplied range of
+  /// indices within this span.
+  ///
+  /// The returned span's first item is always at offset 0; unlike buffer
+  /// slices, extracted spans do not share their indices with the
+  /// span from which they are extracted.
+  ///
+  /// - Parameter bounds: A valid range of indices. Every index in
+  ///     this range must be within the bounds of this `MutableRawSpan`.
+  ///
+  /// - Returns: A `MutableRawSpan` over the items within `bounds`
+  ///
+  /// - Complexity: O(1)
   @available(*, deprecated, renamed: "_mutatingExtracting(_:)")
   @_alwaysEmitIntoClient
   @lifetime(&self)
@@ -531,6 +600,19 @@ extension MutableRawSpan {
     _mutatingExtracting(bounds)
   }
 
+  /// Constructs a new span over the items within the supplied range of
+  /// indices within this span.
+  ///
+  /// The returned span's first item is always at offset 0; unlike buffer
+  /// slices, extracted spans do not share their indices with the
+  /// span from which they are extracted.
+  ///
+  /// - Parameter bounds: A valid range of indices. Every index in
+  ///     this range must be within the bounds of this `MutableRawSpan`.
+  ///
+  /// - Returns: A `MutableRawSpan` over the items within `bounds`
+  ///
+  /// - Complexity: O(1)
   @_alwaysEmitIntoClient
   @lifetime(copy self)
   consuming public func _consumingExtracting(
@@ -540,7 +622,7 @@ extension MutableRawSpan {
   }
 
   /// Constructs a new span over the items within the supplied range of
-  /// positions within this span.
+  /// indices within this span.
   ///
   /// The returned span's first item is always at offset 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
@@ -548,7 +630,7 @@ extension MutableRawSpan {
   ///
   /// This function does not validate `bounds`; this is an unsafe operation.
   ///
-  /// - Parameter bounds: A valid range of positions. Every position in
+  /// - Parameter bounds: A valid range of indices. Every index in
   ///     this range must be within the bounds of this `MutableSpan`.
   ///
   /// - Returns: A `MutableSpan` over the items within `bounds`
@@ -566,6 +648,21 @@ extension MutableRawSpan {
     return unsafe _mutatingExtracting(unchecked: range)
   }
 
+  /// Constructs a new span over the items within the supplied range of
+  /// indices within this span.
+  ///
+  /// The returned span's first item is always at offset 0; unlike buffer
+  /// slices, extracted spans do not share their indices with the
+  /// span from which they are extracted.
+  ///
+  /// This function does not validate `bounds`; this is an unsafe operation.
+  ///
+  /// - Parameter bounds: A valid range of indices. Every index in
+  ///     this range must be within the bounds of this `MutableRawSpan`.
+  ///
+  /// - Returns: A `MutableRawSpan` over the items within `bounds`
+  ///
+  /// - Complexity: O(1)
   @unsafe
   @available(*, deprecated, renamed: "_mutatingExtracting(unchecked:)")
   @_alwaysEmitIntoClient
@@ -576,6 +673,21 @@ extension MutableRawSpan {
     unsafe _mutatingExtracting(unchecked: bounds)
   }
 
+  /// Constructs a new span over the items within the supplied range of
+  /// indices within this span.
+  ///
+  /// The returned span's first item is always at offset 0; unlike buffer
+  /// slices, extracted spans do not share their indices with the
+  /// span from which they are extracted.
+  ///
+  /// This function does not validate `bounds`; this is an unsafe operation.
+  ///
+  /// - Parameter bounds: A valid range of indices. Every index in
+  ///     this range must be within the bounds of this `MutableRawSpan`.
+  ///
+  /// - Returns: A `MutableRawSpan` over the items within `bounds`
+  ///
+  /// - Complexity: O(1)
   @unsafe
   @_alwaysEmitIntoClient
   @lifetime(copy self)
@@ -604,6 +716,15 @@ extension MutableRawSpan {
     return unsafe _overrideLifetime(newSpan, mutating: &self)
   }
 
+  /// Constructs a new span over all the items of this span.
+  ///
+  /// The returned span's first item is always at offset 0; unlike buffer
+  /// slices, extracted spans do not share their indices with the
+  /// span from which they are extracted.
+  ///
+  /// - Returns: A `MutableRawSpan` over all the items of this span.
+  ///
+  /// - Complexity: O(1)
   @available(*, deprecated, renamed: "_mutatingExtracting(_:)")
   @_alwaysEmitIntoClient
   @lifetime(&self)
@@ -611,6 +732,15 @@ extension MutableRawSpan {
     _mutatingExtracting(...)
   }
 
+  /// Constructs a new span over all the items of this span.
+  ///
+  /// The returned span's first item is always at offset 0; unlike buffer
+  /// slices, extracted spans do not share their indices with the
+  /// span from which they are extracted.
+  ///
+  /// - Returns: A `MutableRawSpan` over all the items of this span.
+  ///
+  /// - Complexity: O(1)
   @_alwaysEmitIntoClient
   @lifetime(copy self)
   consuming public func _consumingExtracting(_: UnboundedRange) -> Self {
@@ -651,6 +781,21 @@ extension MutableRawSpan {
 #endif
   }
 
+  /// Returns a span containing the initial elements of this span,
+  /// up to the specified maximum length.
+  ///
+  /// If the maximum length exceeds the length of this span,
+  /// the result contains all the elements.
+  ///
+  /// The returned span's first item is always at offset 0; unlike buffer
+  /// slices, extracted spans do not share their indices with the
+  /// span from which they are extracted.
+  ///
+  /// - Parameter maxLength: The maximum number of elements to return.
+  ///   `maxLength` must be greater than or equal to zero.
+  /// - Returns: A span with at most `maxLength` elements.
+  ///
+  /// - Complexity: O(1)
   @available(*, deprecated, renamed: "_mutatingExtracting(first:)")
   @_alwaysEmitIntoClient
   @lifetime(&self)
@@ -658,6 +803,21 @@ extension MutableRawSpan {
     _mutatingExtracting(first: maxLength)
   }
 
+  /// Returns a span containing the initial elements of this span,
+  /// up to the specified maximum length.
+  ///
+  /// If the maximum length exceeds the length of this span,
+  /// the result contains all the elements.
+  ///
+  /// The returned span's first item is always at offset 0; unlike buffer
+  /// slices, extracted spans do not share their indices with the
+  /// span from which they are extracted.
+  ///
+  /// - Parameter maxLength: The maximum number of elements to return.
+  ///   `maxLength` must be greater than or equal to zero.
+  /// - Returns: A span with at most `maxLength` elements.
+  ///
+  /// - Complexity: O(1)
   @_alwaysEmitIntoClient
   @lifetime(copy self)
   consuming public func _consumingExtracting(first maxLength: Int) -> Self {
@@ -699,6 +859,20 @@ extension MutableRawSpan {
 #endif
   }
 
+  /// Returns a span over all but the given number of trailing elements.
+  ///
+  /// If the number of elements to drop exceeds the number of elements in
+  /// the span, the result is an empty span.
+  ///
+  /// The returned span's first item is always at offset 0; unlike buffer
+  /// slices, extracted spans do not share their indices with the
+  /// span from which they are extracted.
+  ///
+  /// - Parameter k: The number of elements to drop off the end of
+  ///   the span. `k` must be greater than or equal to zero.
+  /// - Returns: A span leaving off the specified number of elements at the end.
+  ///
+  /// - Complexity: O(1)
   @available(*, deprecated, renamed: "_mutatingExtracting(droppingLast:)")
   @_alwaysEmitIntoClient
   @lifetime(&self)
@@ -706,6 +880,20 @@ extension MutableRawSpan {
     _mutatingExtracting(droppingLast: k)
   }
 
+  /// Returns a span over all but the given number of trailing elements.
+  ///
+  /// If the number of elements to drop exceeds the number of elements in
+  /// the span, the result is an empty span.
+  ///
+  /// The returned span's first item is always at offset 0; unlike buffer
+  /// slices, extracted spans do not share their indices with the
+  /// span from which they are extracted.
+  ///
+  /// - Parameter k: The number of elements to drop off the end of
+  ///   the span. `k` must be greater than or equal to zero.
+  /// - Returns: A span leaving off the specified number of elements at the end.
+  ///
+  /// - Complexity: O(1)
   @_alwaysEmitIntoClient
   @lifetime(copy self)
   consuming public func _consumingExtracting(droppingLast k: Int) -> Self {
@@ -749,6 +937,21 @@ extension MutableRawSpan {
 #endif
   }
 
+  /// Returns a span containing the final elements of the span,
+  /// up to the given maximum length.
+  ///
+  /// If the maximum length exceeds the length of this span,
+  /// the result contains all the elements.
+  ///
+  /// The returned span's first item is always at offset 0; unlike buffer
+  /// slices, extracted spans do not share their indices with the
+  /// span from which they are extracted.
+  ///
+  /// - Parameter maxLength: The maximum number of elements to return.
+  ///   `maxLength` must be greater than or equal to zero.
+  /// - Returns: A span with at most `maxLength` elements.
+  ///
+  /// - Complexity: O(1)
   @available(*, deprecated, renamed: "_mutatingExtracting(last:)")
   @_alwaysEmitIntoClient
   @lifetime(&self)
@@ -756,6 +959,21 @@ extension MutableRawSpan {
     _mutatingExtracting(last: maxLength)
   }
 
+  /// Returns a span containing the final elements of the span,
+  /// up to the given maximum length.
+  ///
+  /// If the maximum length exceeds the length of this span,
+  /// the result contains all the elements.
+  ///
+  /// The returned span's first item is always at offset 0; unlike buffer
+  /// slices, extracted spans do not share their indices with the
+  /// span from which they are extracted.
+  ///
+  /// - Parameter maxLength: The maximum number of elements to return.
+  ///   `maxLength` must be greater than or equal to zero.
+  /// - Returns: A span with at most `maxLength` elements.
+  ///
+  /// - Complexity: O(1)
   @_alwaysEmitIntoClient
   @lifetime(copy self)
   consuming public func _consumingExtracting(last maxLength: Int) -> Self {
@@ -799,6 +1017,20 @@ extension MutableRawSpan {
 #endif
   }
 
+  /// Returns a span over all but the given number of initial elements.
+  ///
+  /// If the number of elements to drop exceeds the number of elements in
+  /// the span, the result is an empty span.
+  ///
+  /// The returned span's first item is always at offset 0; unlike buffer
+  /// slices, extracted spans do not share their indices with the
+  /// span from which they are extracted.
+  ///
+  /// - Parameter k: The number of elements to drop from the beginning of
+  ///   the span. `k` must be greater than or equal to zero.
+  /// - Returns: A span starting after the specified number of elements.
+  ///
+  /// - Complexity: O(1)
   @available(*, deprecated, renamed: "_mutatingExtracting(droppingFirst:)")
   @_alwaysEmitIntoClient
   @lifetime(&self)
@@ -806,6 +1038,20 @@ extension MutableRawSpan {
     _mutatingExtracting(droppingFirst: k)
   }
 
+  /// Returns a span over all but the given number of initial elements.
+  ///
+  /// If the number of elements to drop exceeds the number of elements in
+  /// the span, the result is an empty span.
+  ///
+  /// The returned span's first item is always at offset 0; unlike buffer
+  /// slices, extracted spans do not share their indices with the
+  /// span from which they are extracted.
+  ///
+  /// - Parameter k: The number of elements to drop from the beginning of
+  ///   the span. `k` must be greater than or equal to zero.
+  /// - Returns: A span starting after the specified number of elements.
+  ///
+  /// - Complexity: O(1)
   @_alwaysEmitIntoClient
   @lifetime(copy self)
   consuming public func _consumingExtracting(droppingFirst k: Int) -> Self {

--- a/stdlib/public/core/Span/MutableRawSpan.swift
+++ b/stdlib/public/core/Span/MutableRawSpan.swift
@@ -14,8 +14,8 @@
 import Swift
 #endif
 
-// A MutableRawSpan represents a span of memory which
-// contains initialized `Element` instances.
+/// `MutableRawSpan` represents a contiguous region of memory
+/// which contains initialized bytes.
 @safe
 @frozen
 @available(SwiftCompatibilitySpan 5.0, *)
@@ -33,6 +33,7 @@ public struct MutableRawSpan: ~Copyable & ~Escapable {
     unsafe _pointer._unsafelyUnwrappedUnchecked
   }
 
+  /// Create an empty span.
   @_alwaysEmitIntoClient
   @inline(__always)
   @lifetime(immortal)
@@ -134,14 +135,19 @@ extension MutableRawSpan {
 @available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension MutableRawSpan {
+  /// The number of bytes in the span.
   @_alwaysEmitIntoClient
   @_semantics("fixed_storage.get_count")
   public var byteCount: Int { _assumeNonNegative(_count) }
 
+  /// A Boolean value indicating whether the span is empty.
   @_alwaysEmitIntoClient
   @_transparent
   public var isEmpty: Bool { byteCount == 0 }
 
+  /// The valid byte offsets for accessing this span, in ascending order.
+  ///
+  /// - Complexity: O(1)
   @_alwaysEmitIntoClient
   public var byteOffsets: Range<Int> {
     unsafe Range(_uncheckedBounds: (0, byteCount))
@@ -152,6 +158,20 @@ extension MutableRawSpan {
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension MutableRawSpan {
 
+  /// Calls the given closure with a pointer to the underlying bytes of
+  /// the viewed contiguous storage.
+  ///
+  /// The buffer pointer passed as an argument to `body` is valid only
+  /// during the execution of `withUnsafeBytes(_:)`.
+  /// Do not store or return the pointer for later use.
+  ///
+  /// - Parameter body: A closure with an `UnsafeRawBufferPointer`
+  ///   parameter that points to the viewed contiguous storage.
+  ///   If `body` has a return value, that value is also
+  ///   used as the return value for the `withUnsafeBytes(_:)` method.
+  ///   The closure's parameter is valid only for the duration of
+  ///   its execution.
+  /// - Returns: The return value of the `body` closure parameter.
   @_alwaysEmitIntoClient
   @_transparent
   @safe
@@ -161,6 +181,20 @@ extension MutableRawSpan {
     try unsafe body(.init(start: _pointer, count: _count))
   }
 
+  /// Calls the given closure with a mutable pointer to the underlying bytes
+  /// of the viewed contiguous storage.
+  ///
+  /// The buffer pointer passed as an argument to `body` is valid only
+  /// during the execution of `withUnsafeMutableBytes(_:)`.
+  /// Do not store or return the pointer for later use.
+  ///
+  /// - Parameter body: A closure with an `UnsafeMutableRawBufferPointer`
+  ///   parameter that points to the viewed contiguous storage.
+  ///   If `body` has a return value, that value is also
+  ///   used as the return value for the `withUnsafeMutableBytes(_:)` method.
+  ///   The closure's parameter is valid only for the duration of
+  ///   its execution.
+  /// - Returns: The return value of the `body` closure parameter.
   @_alwaysEmitIntoClient
   @_transparent
   @lifetime(self: copy self)
@@ -189,6 +223,7 @@ extension RawSpan {
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension MutableRawSpan {
 
+  /// Borrow the underlying initialized memory for read-only access.
   public var bytes: RawSpan {
     @_alwaysEmitIntoClient
     @_transparent
@@ -337,6 +372,14 @@ extension MutableRawSpan {
     unsafe _start().loadUnaligned(fromByteOffset: offset, as: T.self)
   }
 
+  /// Stores the given value's bytes into the span's raw memory at the
+  /// specified byte offset.
+  ///
+  /// - Parameters:
+  ///   - value: The value to store as raw bytes.
+  ///   - offset: The offset from the start of the span, in bytes.
+  ///     `offset` must be nonnegative. The default is zero.
+  ///   - type: The type of `value`.
   @_alwaysEmitIntoClient
   @lifetime(self: copy self)
   public mutating func storeBytes<T: BitwiseCopyable>(
@@ -350,6 +393,16 @@ extension MutableRawSpan {
     unsafe storeBytes(of: value, toUncheckedByteOffset: offset, as: type)
   }
 
+  /// Stores the given value's bytes into the span's raw memory at the
+  /// specified byte offset.
+  ///
+  /// This function does not validate `offset`; this is an unsafe operation.
+  ///
+  /// - Parameters:
+  ///   - value: The value to store as raw bytes.
+  ///   - offset: The offset from the start of the span, in bytes.
+  ///     `offset` must be nonnegative.
+  ///   - type: The type of `value`.
   @unsafe
   @_alwaysEmitIntoClient
   @lifetime(self: copy self)

--- a/stdlib/public/core/Span/MutableSpan.swift
+++ b/stdlib/public/core/Span/MutableSpan.swift
@@ -249,7 +249,7 @@ extension MutableSpan where Element: ~Copyable {
   @_transparent
   public var isEmpty: Bool { _count == 0 }
 
-  /// The type that represents a position in a `MutableSpan`.
+  /// The type that represents an index in a `MutableSpan`.
   public typealias Index = Int
 
   /// The range of valid indices for subscripting the span.
@@ -304,7 +304,7 @@ extension MutableSpan where Element: ~Copyable {
   internal func _checkIndex(_ position: Index) {
     _precondition(indices.contains(position), "index out of bounds")
   }
-  /// Accesses the element at the specified position in the `MutableSpan`.
+  /// Accesses the element at the specified index in the `MutableSpan`.
   ///
   /// - Parameter position: The offset of the element to access. `position`
   ///     must be greater or equal to zero, and less than `count`.
@@ -325,7 +325,7 @@ extension MutableSpan where Element: ~Copyable {
     }
   }
 
-  /// Accesses the element at the specified position in the `MutableSpan`.
+  /// Accesses the element at the specified index in the `MutableSpan`.
   ///
   /// This subscript does not validate `position`; this is an unsafe operation.
   ///
@@ -532,13 +532,13 @@ extension MutableSpan {
 extension MutableSpan where Element: ~Copyable {
 
   /// Constructs a new span over the items within the supplied range of
-  /// positions within this span.
+  /// indices within this span.
   ///
   /// The returned span's first item is always at offset 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
-  /// - Parameter bounds: A valid range of positions. Every position in
+  /// - Parameter bounds: A valid range of indices. Every index in
   ///     this range must be within the bounds of this `MutableSpan`.
   ///
   /// - Returns: A `MutableSpan` over the items within `bounds`

--- a/stdlib/public/core/Span/MutableSpan.swift
+++ b/stdlib/public/core/Span/MutableSpan.swift
@@ -14,8 +14,8 @@
 import Swift
 #endif
 
-// A MutableSpan<Element> represents a span of memory which
-// contains initialized `Element` instances.
+/// `MutableSpan<Element>` represents a contiguous region of memory which
+/// contains initialized instances of `Element`.
 @safe
 @frozen
 @available(SwiftCompatibilitySpan 5.0, *)
@@ -34,6 +34,7 @@ public struct MutableSpan<Element: ~Copyable>
     unsafe _pointer._unsafelyUnwrappedUnchecked
   }
 
+  /// Create an empty span.
   @_alwaysEmitIntoClient
   @inline(__always)
   @lifetime(immortal)
@@ -192,6 +193,7 @@ extension Span where Element: ~Copyable {
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension MutableSpan where Element: ~Copyable {
 
+  /// Borrow the underlying initialized memory for read-only access.
   @_alwaysEmitIntoClient
   @_transparent
   public var span: Span<Element> {
@@ -237,16 +239,20 @@ extension MutableSpan where Element: ~Copyable {
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension MutableSpan where Element: ~Copyable {
 
+  /// The number of elements in the span.
   @_alwaysEmitIntoClient
   @_semantics("fixed_storage.get_count")
   public var count: Int { _assumeNonNegative(_count) }
 
+  /// A Boolean value indicating whether the span is empty.
   @_alwaysEmitIntoClient
   @_transparent
   public var isEmpty: Bool { _count == 0 }
 
+  /// The type that represents a position in a `MutableSpan`.
   public typealias Index = Int
 
+  /// The range of valid indices for subscripting the span.
   @_alwaysEmitIntoClient
   public var indices: Range<Index> {
     unsafe Range(_uncheckedBounds: (0, count))
@@ -356,6 +362,10 @@ extension MutableSpan where Element: ~Copyable {
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension MutableSpan where Element: ~Copyable {
 
+  /// Exchange the elements at the two given indices.
+  ///
+  /// - Parameter i: A valid index into this span.
+  /// - Parameter j: A valid index into this span.
   @_alwaysEmitIntoClient
   @lifetime(self: copy self)
   public mutating func swapAt(_ i: Index, _ j: Index) {
@@ -364,6 +374,12 @@ extension MutableSpan where Element: ~Copyable {
     unsafe swapAt(unchecked: i, unchecked: j)
   }
 
+  /// Exchange the elements at the two given indices.
+  ///
+  /// This function does not validate `i` or `j`; this is an unsafe operation.
+  ///
+  /// - Parameter i: A valid index into this span.
+  /// - Parameter j: A valid index into this span.
   @unsafe
   @_alwaysEmitIntoClient
   @lifetime(self: copy self)
@@ -380,6 +396,18 @@ extension MutableSpan where Element: ~Copyable {
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension MutableSpan where Element: ~Copyable {
 
+  /// Call a closure with a pointer to the viewed contiguous storage.
+  ///
+  /// The buffer pointer passed as an argument to `body` is valid only
+  /// during the execution of `withUnsafeBufferPointer(_:)`.
+  /// Do not store or return the pointer for later use.
+  ///
+  /// - Parameter body: A closure with an `UnsafeBufferPointer` parameter
+  ///   that points to the viewed contiguous storage. If `body` has
+  ///   a return value, that value is also used as the return value
+  ///   for the `withUnsafeBufferPointer(_:)` method. The closure's
+  ///   parameter is valid only for the duration of its execution.
+  /// - Returns: The return value of the `body` closure parameter.
   //FIXME: mark closure parameter as non-escaping
   @_alwaysEmitIntoClient
   @_transparent
@@ -390,6 +418,19 @@ extension MutableSpan where Element: ~Copyable {
     try Span(_mutableSpan: self).withUnsafeBufferPointer(body)
   }
 
+  /// Call a closure with a pointer to the viewed mutable contiguous
+  /// storage.
+  ///
+  /// The buffer pointer passed as an argument to `body` is valid only
+  /// during the execution of `withUnsafeMutableBufferPointer(_:)`.
+  /// Do not store or return the pointer for later use.
+  ///
+  /// - Parameter body: A closure with an `UnsafeMutableBufferPointer`
+  ///   parameter that points to the viewed contiguous storage. If `body`
+  ///   has a return value, that value is also used as the return value
+  ///   for the `withUnsafeMutableBufferPointer(_:)` method. The closure's
+  ///   parameter is valid only for the duration of its execution.
+  /// - Returns: The return value of the `body` closure parameter.
   //FIXME: mark closure parameter as non-escaping
   @_alwaysEmitIntoClient
   @_transparent
@@ -414,6 +455,20 @@ extension MutableSpan where Element: ~Copyable {
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension MutableSpan where Element: BitwiseCopyable {
 
+  /// Calls the given closure with a pointer to the underlying bytes of
+  /// the viewed contiguous storage.
+  ///
+  /// The buffer pointer passed as an argument to `body` is valid only
+  /// during the execution of `withUnsafeBytes(_:)`.
+  /// Do not store or return the pointer for later use.
+  ///
+  /// - Parameter body: A closure with an `UnsafeRawBufferPointer`
+  ///   parameter that points to the viewed contiguous storage.
+  ///   If `body` has a return value, that value is also
+  ///   used as the return value for the `withUnsafeBytes(_:)` method.
+  ///   The closure's parameter is valid only for the duration of
+  ///   its execution.
+  /// - Returns: The return value of the `body` closure parameter.
   //FIXME: mark closure parameter as non-escaping
   @_alwaysEmitIntoClient
   @_transparent
@@ -424,6 +479,20 @@ extension MutableSpan where Element: BitwiseCopyable {
     try RawSpan(_mutableSpan: self).withUnsafeBytes(body)
   }
 
+  /// Calls the given closure with a mutable pointer to the underlying bytes
+  /// of the viewed contiguous storage.
+  ///
+  /// The buffer pointer passed as an argument to `body` is valid only
+  /// during the execution of `withUnsafeMutableBytes(_:)`.
+  /// Do not store or return the pointer for later use.
+  ///
+  /// - Parameter body: A closure with an `UnsafeMutableRawBufferPointer`
+  ///   parameter that points to the viewed contiguous storage.
+  ///   If `body` has a return value, that value is also
+  ///   used as the return value for the `withUnsafeMutableBytes(_:)` method.
+  ///   The closure's parameter is valid only for the duration of
+  ///   its execution.
+  /// - Returns: The return value of the `body` closure parameter.
   //FIXME: mark closure parameter as non-escaping
   @_alwaysEmitIntoClient
   @_transparent
@@ -444,6 +513,9 @@ extension MutableSpan where Element: BitwiseCopyable {
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension MutableSpan {
 
+  /// Update every element of this span to the given value.
+  ///
+  /// - Parameter repeatedValue: The value to set for every element.
   @_alwaysEmitIntoClient
   @lifetime(self: copy self)
   public mutating func update(repeating repeatedValue: consuming Element) {

--- a/stdlib/public/core/Span/MutableSpan.swift
+++ b/stdlib/public/core/Span/MutableSpan.swift
@@ -265,7 +265,7 @@ extension MutableSpan where Element: BitwiseCopyable {
 
   /// Construct a raw span over the memory represented by this span.
   ///
-  /// - Returns: a RawSpan over the memory represented by this span
+  /// - Returns: A `RawSpan` over the memory represented by this span.
   @_alwaysEmitIntoClient
   @_transparent
   @unsafe
@@ -282,7 +282,7 @@ extension MutableSpan where Element: BitwiseCopyable {
   /// it is possible to mutate a byte so as to produce an invalid
   /// bit pattern in the corresponding instance of `Element`.
   ///
-  /// - Returns: a MutableRawSpan over the memory represented by this span
+  /// - Returns: A `MutableRawSpan` over the memory represented by this span.
   @_alwaysEmitIntoClient
   @_transparent
   @unsafe
@@ -534,6 +534,8 @@ extension MutableSpan where Element: ~Copyable {
   /// Constructs a new span over the items within the supplied range of
   /// indices within this span.
   ///
+  /// The returned span represents a mutation of this span.
+  ///
   /// The returned span's first item is always at offset 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
@@ -541,7 +543,7 @@ extension MutableSpan where Element: ~Copyable {
   /// - Parameter bounds: A valid range of indices. Every index in
   ///     this range must be within the bounds of this `MutableSpan`.
   ///
-  /// - Returns: A `MutableSpan` over the items within `bounds`
+  /// - Returns: A `MutableSpan` over the items within `bounds`.
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
@@ -567,7 +569,7 @@ extension MutableSpan where Element: ~Copyable {
   /// - Parameter bounds: A valid range of indices. Every index in
   ///     this range must be within the bounds of this `MutableSpan`.
   ///
-  /// - Returns: A `MutableSpan` over the items within `bounds`
+  /// - Returns: A `MutableSpan` over the items within `bounds`.
   ///
   /// - Complexity: O(1)
   @available(*, deprecated, renamed: "_mutatingExtracting(_:)")
@@ -587,7 +589,7 @@ extension MutableSpan where Element: ~Copyable {
   /// - Parameter bounds: A valid range of indices. Every index in
   ///     this range must be within the bounds of this `MutableSpan`.
   ///
-  /// - Returns: A `MutableSpan` over the items within `bounds`
+  /// - Returns: A `MutableSpan` over the items within `bounds`.
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
@@ -615,7 +617,7 @@ extension MutableSpan where Element: ~Copyable {
   /// - Parameter bounds: A valid range of indices. Every index in
   ///     this range must be within the bounds of this `MutableSpan`.
   ///
-  /// - Returns: A `MutableSpan` over the items within `bounds`
+  /// - Returns: A `MutableSpan` over the items within `bounds`.
   ///
   /// - Complexity: O(1)
   @unsafe
@@ -642,7 +644,7 @@ extension MutableSpan where Element: ~Copyable {
   /// - Parameter bounds: A valid range of indices. Every index in
   ///     this range must be within the bounds of this `MutableSpan`.
   ///
-  /// - Returns: A `MutableSpan` over the items within `bounds`
+  /// - Returns: A `MutableSpan` over the items within `bounds`.
   ///
   /// - Complexity: O(1)
   @unsafe
@@ -665,7 +667,7 @@ extension MutableSpan where Element: ~Copyable {
   /// - Parameter bounds: A valid range of indices. Every index in
   ///     this range must be within the bounds of this `MutableSpan`.
   ///
-  /// - Returns: A `MutableSpan` over the items within `bounds`
+  /// - Returns: A `MutableSpan` over the items within `bounds`.
   ///
   /// - Complexity: O(1)
   @unsafe
@@ -690,7 +692,7 @@ extension MutableSpan where Element: ~Copyable {
   /// - Parameter bounds: A valid range of indices. Every index in
   ///     this range must be within the bounds of this `MutableSpan`.
   ///
-  /// - Returns: A `MutableSpan` over the items within `bounds`
+  /// - Returns: A `MutableSpan` over the items within `bounds`.
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
@@ -713,7 +715,7 @@ extension MutableSpan where Element: ~Copyable {
   /// - Parameter bounds: A valid range of indices. Every index in
   ///     this range must be within the bounds of this `MutableSpan`.
   ///
-  /// - Returns: A `MutableSpan` over the items within `bounds`
+  /// - Returns: A `MutableSpan` over the items within `bounds`.
   ///
   /// - Complexity: O(1)
   @available(*, deprecated, renamed: "_mutatingExtracting(_:)")
@@ -735,7 +737,7 @@ extension MutableSpan where Element: ~Copyable {
   /// - Parameter bounds: A valid range of indices. Every index in
   ///     this range must be within the bounds of this `MutableSpan`.
   ///
-  /// - Returns: A `MutableSpan` over the items within `bounds`
+  /// - Returns: A `MutableSpan` over the items within `bounds`.
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
@@ -760,7 +762,7 @@ extension MutableSpan where Element: ~Copyable {
   /// - Parameter bounds: A valid range of indices. Every index in
   ///     this range must be within the bounds of this `MutableSpan`.
   ///
-  /// - Returns: A `MutableSpan` over the items within `bounds`
+  /// - Returns: A `MutableSpan` over the items within `bounds`.
   ///
   /// - Complexity: O(1)
   @unsafe
@@ -789,7 +791,7 @@ extension MutableSpan where Element: ~Copyable {
   /// - Parameter bounds: A valid range of indices. Every index in
   ///     this range must be within the bounds of this `MutableSpan`.
   ///
-  /// - Returns: A `MutableSpan` over the items within `bounds`
+  /// - Returns: A `MutableSpan` over the items within `bounds`.
   ///
   /// - Complexity: O(1)
   @unsafe
@@ -814,7 +816,7 @@ extension MutableSpan where Element: ~Copyable {
   /// - Parameter bounds: A valid range of indices. Every index in
   ///     this range must be within the bounds of this `MutableSpan`.
   ///
-  /// - Returns: A `MutableSpan` over the items within `bounds`
+  /// - Returns: A `MutableSpan` over the items within `bounds`.
   ///
   /// - Complexity: O(1)
   @unsafe
@@ -1049,7 +1051,7 @@ extension MutableSpan where Element: ~Copyable {
 #endif
   }
 
-  /// Returns a span containing the final elements of the span,
+  /// Returns a span containing the trailing elements of the span,
   /// up to the given maximum length.
   ///
   /// If the maximum length exceeds the length of this span,
@@ -1081,7 +1083,7 @@ extension MutableSpan where Element: ~Copyable {
 #endif
   }
 
-  /// Returns a span containing the final elements of the span,
+  /// Returns a span containing the trailing elements of the span,
   /// up to the given maximum length.
   ///
   /// If the maximum length exceeds the length of this span,
@@ -1105,7 +1107,7 @@ extension MutableSpan where Element: ~Copyable {
     _mutatingExtracting(last: maxLength)
   }
 
-  /// Returns a span containing the final elements of the span,
+  /// Returns a span containing the trailing elements of the span,
   /// up to the given maximum length.
   ///
   /// If the maximum length exceeds the length of this span,

--- a/stdlib/public/core/Span/MutableSpan.swift
+++ b/stdlib/public/core/Span/MutableSpan.swift
@@ -555,6 +555,21 @@ extension MutableSpan where Element: ~Copyable {
     return unsafe _mutatingExtracting(unchecked: bounds)
   }
 
+  /// Constructs a new span over the items within the supplied range of
+  /// indices within this span.
+  ///
+  /// The returned span represents a mutation of this span.
+  ///
+  /// The returned span's first item is always at offset 0; unlike buffer
+  /// slices, extracted spans do not share their indices with the
+  /// span from which they are extracted.
+  ///
+  /// - Parameter bounds: A valid range of indices. Every index in
+  ///     this range must be within the bounds of this `MutableSpan`.
+  ///
+  /// - Returns: A `MutableSpan` over the items within `bounds`
+  ///
+  /// - Complexity: O(1)
   @available(*, deprecated, renamed: "_mutatingExtracting(_:)")
   @_alwaysEmitIntoClient
   @lifetime(&self)
@@ -562,6 +577,19 @@ extension MutableSpan where Element: ~Copyable {
     _mutatingExtracting(bounds)
   }
 
+  /// Constructs a new span over the items within the supplied range of
+  /// indices within this span.
+  ///
+  /// The returned span's first item is always at offset 0; unlike buffer
+  /// slices, extracted spans do not share their indices with the
+  /// span from which they are extracted.
+  ///
+  /// - Parameter bounds: A valid range of indices. Every index in
+  ///     this range must be within the bounds of this `MutableSpan`.
+  ///
+  /// - Returns: A `MutableSpan` over the items within `bounds`
+  ///
+  /// - Complexity: O(1)
   @_alwaysEmitIntoClient
   @lifetime(copy self)
   consuming public func _consumingExtracting(_ bounds: Range<Index>) -> Self {
@@ -574,7 +602,9 @@ extension MutableSpan where Element: ~Copyable {
   }
 
   /// Constructs a new span over the items within the supplied range of
-  /// positions within this span.
+  /// indices within this span.
+  ///
+  /// The returned span represents a mutation of this span.
   ///
   /// The returned span's first item is always at offset 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
@@ -582,7 +612,7 @@ extension MutableSpan where Element: ~Copyable {
   ///
   /// This function does not validate `bounds`; this is an unsafe operation.
   ///
-  /// - Parameter bounds: A valid range of positions. Every position in
+  /// - Parameter bounds: A valid range of indices. Every index in
   ///     this range must be within the bounds of this `MutableSpan`.
   ///
   /// - Returns: A `MutableSpan` over the items within `bounds`
@@ -598,6 +628,23 @@ extension MutableSpan where Element: ~Copyable {
     return unsafe _overrideLifetime(newSpan, mutating: &self)
   }
 
+  /// Constructs a new span over the items within the supplied range of
+  /// indices within this span.
+  ///
+  /// The returned span represents a mutation of this span.
+  ///
+  /// The returned span's first item is always at offset 0; unlike buffer
+  /// slices, extracted spans do not share their indices with the
+  /// span from which they are extracted.
+  ///
+  /// This function does not validate `bounds`; this is an unsafe operation.
+  ///
+  /// - Parameter bounds: A valid range of indices. Every index in
+  ///     this range must be within the bounds of this `MutableSpan`.
+  ///
+  /// - Returns: A `MutableSpan` over the items within `bounds`
+  ///
+  /// - Complexity: O(1)
   @unsafe
   @available(*, deprecated, renamed: "_mutatingExtracting(unchecked:)")
   @_alwaysEmitIntoClient
@@ -606,6 +653,21 @@ extension MutableSpan where Element: ~Copyable {
     unsafe _mutatingExtracting(unchecked: bounds)
   }
 
+  /// Constructs a new span over the items within the supplied range of
+  /// indices within this span.
+  ///
+  /// The returned span's first item is always at offset 0; unlike buffer
+  /// slices, extracted spans do not share their indices with the
+  /// span from which they are extracted.
+  ///
+  /// This function does not validate `bounds`; this is an unsafe operation.
+  ///
+  /// - Parameter bounds: A valid range of indices. Every index in
+  ///     this range must be within the bounds of this `MutableSpan`.
+  ///
+  /// - Returns: A `MutableSpan` over the items within `bounds`
+  ///
+  /// - Complexity: O(1)
   @unsafe
   @_alwaysEmitIntoClient
   @lifetime(copy self)
@@ -617,13 +679,15 @@ extension MutableSpan where Element: ~Copyable {
   }
 
   /// Constructs a new span over the items within the supplied range of
-  /// positions within this span.
+  /// indices within this span.
+  ///
+  /// The returned span represents a mutation of this span.
   ///
   /// The returned span's first item is always at offset 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
-  /// - Parameter bounds: A valid range of positions. Every position in
+  /// - Parameter bounds: A valid range of indices. Every index in
   ///     this range must be within the bounds of this `MutableSpan`.
   ///
   /// - Returns: A `MutableSpan` over the items within `bounds`
@@ -637,6 +701,21 @@ extension MutableSpan where Element: ~Copyable {
     _mutatingExtracting(bounds.relative(to: indices))
   }
 
+  /// Constructs a new span over the items within the supplied range of
+  /// indices within this span.
+  ///
+  /// The returned span represents a mutation of this span.
+  ///
+  /// The returned span's first item is always at offset 0; unlike buffer
+  /// slices, extracted spans do not share their indices with the
+  /// span from which they are extracted.
+  ///
+  /// - Parameter bounds: A valid range of indices. Every index in
+  ///     this range must be within the bounds of this `MutableSpan`.
+  ///
+  /// - Returns: A `MutableSpan` over the items within `bounds`
+  ///
+  /// - Complexity: O(1)
   @available(*, deprecated, renamed: "_mutatingExtracting(_:)")
   @_alwaysEmitIntoClient
   @lifetime(&self)
@@ -646,6 +725,19 @@ extension MutableSpan where Element: ~Copyable {
     _mutatingExtracting(bounds)
   }
 
+  /// Constructs a new span over the items within the supplied range of
+  /// indices within this span.
+  ///
+  /// The returned span's first item is always at offset 0; unlike buffer
+  /// slices, extracted spans do not share their indices with the
+  /// span from which they are extracted.
+  ///
+  /// - Parameter bounds: A valid range of indices. Every index in
+  ///     this range must be within the bounds of this `MutableSpan`.
+  ///
+  /// - Returns: A `MutableSpan` over the items within `bounds`
+  ///
+  /// - Complexity: O(1)
   @_alwaysEmitIntoClient
   @lifetime(copy self)
   consuming public func _consumingExtracting(
@@ -655,7 +747,9 @@ extension MutableSpan where Element: ~Copyable {
   }
 
   /// Constructs a new span over the items within the supplied range of
-  /// positions within this span.
+  /// indices within this span.
+  ///
+  /// The returned span represents a mutation of this span.
   ///
   /// The returned span's first item is always at offset 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
@@ -663,7 +757,7 @@ extension MutableSpan where Element: ~Copyable {
   ///
   /// This function does not validate `bounds`; this is an unsafe operation.
   ///
-  /// - Parameter bounds: A valid range of positions. Every position in
+  /// - Parameter bounds: A valid range of indices. Every index in
   ///     this range must be within the bounds of this `MutableSpan`.
   ///
   /// - Returns: A `MutableSpan` over the items within `bounds`
@@ -681,6 +775,23 @@ extension MutableSpan where Element: ~Copyable {
     return unsafe _mutatingExtracting(unchecked: range)
   }
 
+  /// Constructs a new span over the items within the supplied range of
+  /// indices within this span.
+  ///
+  /// The returned span represents a mutation of this span.
+  ///
+  /// The returned span's first item is always at offset 0; unlike buffer
+  /// slices, extracted spans do not share their indices with the
+  /// span from which they are extracted.
+  ///
+  /// This function does not validate `bounds`; this is an unsafe operation.
+  ///
+  /// - Parameter bounds: A valid range of indices. Every index in
+  ///     this range must be within the bounds of this `MutableSpan`.
+  ///
+  /// - Returns: A `MutableSpan` over the items within `bounds`
+  ///
+  /// - Complexity: O(1)
   @unsafe
   @available(*, deprecated, renamed: "_mutatingExtracting(unchecked:)")
   @_alwaysEmitIntoClient
@@ -691,6 +802,21 @@ extension MutableSpan where Element: ~Copyable {
     unsafe _mutatingExtracting(unchecked: bounds)
   }
 
+  /// Constructs a new span over the items within the supplied range of
+  /// indices within this span.
+  ///
+  /// The returned span's first item is always at offset 0; unlike buffer
+  /// slices, extracted spans do not share their indices with the
+  /// span from which they are extracted.
+  ///
+  /// This function does not validate `bounds`; this is an unsafe operation.
+  ///
+  /// - Parameter bounds: A valid range of indices. Every index in
+  ///     this range must be within the bounds of this `MutableSpan`.
+  ///
+  /// - Returns: A `MutableSpan` over the items within `bounds`
+  ///
+  /// - Complexity: O(1)
   @unsafe
   @_alwaysEmitIntoClient
   @lifetime(copy self)
@@ -704,6 +830,8 @@ extension MutableSpan where Element: ~Copyable {
   }
 
   /// Constructs a new span over all the items of this span.
+  ///
+  /// The returned span represents a mutation of this span.
   ///
   /// The returned span's first item is always at offset 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
@@ -719,6 +847,17 @@ extension MutableSpan where Element: ~Copyable {
     return unsafe _overrideLifetime(newSpan, mutating: &self)
   }
 
+  /// Constructs a new span over all the items of this span.
+  ///
+  /// The returned span represents a mutation of this span.
+  ///
+  /// The returned span's first item is always at offset 0; unlike buffer
+  /// slices, extracted spans do not share their indices with the
+  /// span from which they are extracted.
+  ///
+  /// - Returns: A `MutableSpan` over all the items of this span.
+  ///
+  /// - Complexity: O(1)
   @available(*, deprecated, renamed: "_mutatingExtracting(_:)")
   @_alwaysEmitIntoClient
   @lifetime(&self)
@@ -726,6 +865,15 @@ extension MutableSpan where Element: ~Copyable {
     _mutatingExtracting(...)
   }
 
+  /// Constructs a new span over all the items of this span.
+  ///
+  /// The returned span's first item is always at offset 0; unlike buffer
+  /// slices, extracted spans do not share their indices with the
+  /// span from which they are extracted.
+  ///
+  /// - Returns: A `MutableSpan` over all the items of this span.
+  ///
+  /// - Complexity: O(1)
   @_alwaysEmitIntoClient
   @lifetime(copy self)
   consuming public func _consumingExtracting(_: UnboundedRange) -> Self {
@@ -743,6 +891,8 @@ extension MutableSpan where Element: ~Copyable {
   ///
   /// If the maximum length exceeds the length of this span,
   /// the result contains all the elements.
+  ///
+  /// The returned span represents a mutation of this span.
   ///
   /// The returned span's first item is always at offset 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
@@ -766,6 +916,23 @@ extension MutableSpan where Element: ~Copyable {
 #endif
   }
 
+  /// Returns a span containing the initial elements of this span,
+  /// up to the specified maximum length.
+  ///
+  /// If the maximum length exceeds the length of this span,
+  /// the result contains all the elements.
+  ///
+  /// The returned span represents a mutation of this span.
+  ///
+  /// The returned span's first item is always at offset 0; unlike buffer
+  /// slices, extracted spans do not share their indices with the
+  /// span from which they are extracted.
+  ///
+  /// - Parameter maxLength: The maximum number of elements to return.
+  ///   `maxLength` must be greater than or equal to zero.
+  /// - Returns: A span with at most `maxLength` elements.
+  ///
+  /// - Complexity: O(1)
   @available(*, deprecated, renamed: "_mutatingExtracting(first:)")
   @_alwaysEmitIntoClient
   @lifetime(&self)
@@ -773,6 +940,21 @@ extension MutableSpan where Element: ~Copyable {
     _mutatingExtracting(first: maxLength)
   }
 
+  /// Returns a span containing the initial elements of this span,
+  /// up to the specified maximum length.
+  ///
+  /// If the maximum length exceeds the length of this span,
+  /// the result contains all the elements.
+  ///
+  /// The returned span's first item is always at offset 0; unlike buffer
+  /// slices, extracted spans do not share their indices with the
+  /// span from which they are extracted.
+  ///
+  /// - Parameter maxLength: The maximum number of elements to return.
+  ///   `maxLength` must be greater than or equal to zero.
+  /// - Returns: A span with at most `maxLength` elements.
+  ///
+  /// - Complexity: O(1)
   @_alwaysEmitIntoClient
   @lifetime(copy self)
   consuming public func _consumingExtracting(first maxLength: Int) -> Self {
@@ -790,6 +972,8 @@ extension MutableSpan where Element: ~Copyable {
   ///
   /// If the number of elements to drop exceeds the number of elements in
   /// the span, the result is an empty span.
+  ///
+  /// The returned span represents a mutation of this span.
   ///
   /// The returned span's first item is always at offset 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
@@ -814,6 +998,22 @@ extension MutableSpan where Element: ~Copyable {
 #endif
   }
 
+  /// Returns a span over all but the given number of trailing elements.
+  ///
+  /// If the number of elements to drop exceeds the number of elements in
+  /// the span, the result is an empty span.
+  ///
+  /// The returned span represents a mutation of this span.
+  ///
+  /// The returned span's first item is always at offset 0; unlike buffer
+  /// slices, extracted spans do not share their indices with the
+  /// span from which they are extracted.
+  ///
+  /// - Parameter k: The number of elements to drop off the end of
+  ///   the span. `k` must be greater than or equal to zero.
+  /// - Returns: A span leaving off the specified number of elements at the end.
+  ///
+  /// - Complexity: O(1)
   @available(*, deprecated, renamed: "_mutatingExtracting(droppingLast:)")
   @_alwaysEmitIntoClient
   @lifetime(&self)
@@ -821,6 +1021,20 @@ extension MutableSpan where Element: ~Copyable {
     _mutatingExtracting(droppingLast: k)
   }
 
+  /// Returns a span over all but the given number of trailing elements.
+  ///
+  /// If the number of elements to drop exceeds the number of elements in
+  /// the span, the result is an empty span.
+  ///
+  /// The returned span's first item is always at offset 0; unlike buffer
+  /// slices, extracted spans do not share their indices with the
+  /// span from which they are extracted.
+  ///
+  /// - Parameter k: The number of elements to drop off the end of
+  ///   the span. `k` must be greater than or equal to zero.
+  /// - Returns: A span leaving off the specified number of elements at the end.
+  ///
+  /// - Complexity: O(1)
   @_alwaysEmitIntoClient
   @lifetime(copy self)
   consuming public func _consumingExtracting(droppingLast k: Int) -> Self {
@@ -840,6 +1054,8 @@ extension MutableSpan where Element: ~Copyable {
   ///
   /// If the maximum length exceeds the length of this span,
   /// the result contains all the elements.
+  ///
+  /// The returned span represents a mutation of this span.
   ///
   /// The returned span's first item is always at offset 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
@@ -865,6 +1081,23 @@ extension MutableSpan where Element: ~Copyable {
 #endif
   }
 
+  /// Returns a span containing the final elements of the span,
+  /// up to the given maximum length.
+  ///
+  /// If the maximum length exceeds the length of this span,
+  /// the result contains all the elements.
+  ///
+  /// The returned span represents a mutation of this span.
+  ///
+  /// The returned span's first item is always at offset 0; unlike buffer
+  /// slices, extracted spans do not share their indices with the
+  /// span from which they are extracted.
+  ///
+  /// - Parameter maxLength: The maximum number of elements to return.
+  ///   `maxLength` must be greater than or equal to zero.
+  /// - Returns: A span with at most `maxLength` elements.
+  ///
+  /// - Complexity: O(1)
   @available(*, deprecated, renamed: "_mutatingExtracting(last:)")
   @_alwaysEmitIntoClient
   @lifetime(&self)
@@ -872,6 +1105,21 @@ extension MutableSpan where Element: ~Copyable {
     _mutatingExtracting(last: maxLength)
   }
 
+  /// Returns a span containing the final elements of the span,
+  /// up to the given maximum length.
+  ///
+  /// If the maximum length exceeds the length of this span,
+  /// the result contains all the elements.
+  ///
+  /// The returned span's first item is always at offset 0; unlike buffer
+  /// slices, extracted spans do not share their indices with the
+  /// span from which they are extracted.
+  ///
+  /// - Parameter maxLength: The maximum number of elements to return.
+  ///   `maxLength` must be greater than or equal to zero.
+  /// - Returns: A span with at most `maxLength` elements.
+  ///
+  /// - Complexity: O(1)
   @_alwaysEmitIntoClient
   @lifetime(copy self)
   consuming public func _consumingExtracting(last maxLength: Int) -> Self {
@@ -891,6 +1139,8 @@ extension MutableSpan where Element: ~Copyable {
   ///
   /// If the number of elements to drop exceeds the number of elements in
   /// the span, the result is an empty span.
+  ///
+  /// The returned span represents a mutation of this span.
   ///
   /// The returned span's first item is always at offset 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
@@ -917,6 +1167,22 @@ extension MutableSpan where Element: ~Copyable {
 #endif
   }
 
+  /// Returns a span over all but the given number of initial elements.
+  ///
+  /// If the number of elements to drop exceeds the number of elements in
+  /// the span, the result is an empty span.
+  ///
+  /// The returned span represents a mutation of this span.
+  ///
+  /// The returned span's first item is always at offset 0; unlike buffer
+  /// slices, extracted spans do not share their indices with the
+  /// span from which they are extracted.
+  ///
+  /// - Parameter k: The number of elements to drop from the beginning of
+  ///   the span. `k` must be greater than or equal to zero.
+  /// - Returns: A span starting after the specified number of elements.
+  ///
+  /// - Complexity: O(1)
   @available(*, deprecated, renamed: "_mutatingExtracting(droppingFirst:)")
   @_alwaysEmitIntoClient
   @lifetime(&self)
@@ -924,6 +1190,20 @@ extension MutableSpan where Element: ~Copyable {
     _mutatingExtracting(droppingFirst: k)
   }
 
+  /// Returns a span over all but the given number of initial elements.
+  ///
+  /// If the number of elements to drop exceeds the number of elements in
+  /// the span, the result is an empty span.
+  ///
+  /// The returned span's first item is always at offset 0; unlike buffer
+  /// slices, extracted spans do not share their indices with the
+  /// span from which they are extracted.
+  ///
+  /// - Parameter k: The number of elements to drop from the beginning of
+  ///   the span. `k` must be greater than or equal to zero.
+  /// - Returns: A span starting after the specified number of elements.
+  ///
+  /// - Complexity: O(1)
   @_alwaysEmitIntoClient
   @lifetime(copy self)
   consuming public func _consumingExtracting(droppingFirst k: Int) -> Self {

--- a/stdlib/public/core/Span/OutputRawSpan.swift
+++ b/stdlib/public/core/Span/OutputRawSpan.swift
@@ -14,8 +14,10 @@
 import Swift
 #endif
 
-// OutputRawSpan is a reference to a contiguous region of memory which starts
-// some number of initialized bytes, followed by uninitialized memory.
+/// `OutputRawSpan` is a reference to a contiguous region of memory which starts
+/// with some number of initialized bytes, followed by uninitialized memory.
+/// It provides operations to access the bytes it stores,
+/// as well as to append and to remove bytes.
 @safe
 @frozen
 @available(SwiftCompatibilitySpan 5.0, *)
@@ -24,6 +26,7 @@ public struct OutputRawSpan: ~Copyable, ~Escapable {
   @usableFromInline
   internal let _pointer: UnsafeMutableRawPointer?
 
+  /// The total number of bytes that this output span can contain.
   public let capacity: Int
 
   @usableFromInline
@@ -166,6 +169,8 @@ extension OutputRawSpan {
 extension OutputRawSpan {
 
   /// Append a single byte to this span.
+  ///
+  /// - Parameter value: The byte to append.
   @_alwaysEmitIntoClient
   @lifetime(self: copy self)
   public mutating func append(_ value: UInt8) {
@@ -175,6 +180,10 @@ extension OutputRawSpan {
   }
 
   /// Remove the last byte from this span.
+  ///
+  /// Returns the last byte. The `OutputRawSpan` must not be empty.
+  ///
+  /// - Returns: The removed byte.
   @_alwaysEmitIntoClient
   @discardableResult
   @lifetime(self: copy self)
@@ -184,16 +193,19 @@ extension OutputRawSpan {
     return unsafe _tail().load(as: UInt8.self)
   }
 
-  /// Remove the last N elements, returning the memory they occupy
-  /// to the uninitialized state.
+  /// Remove the last n bytes from this span, returning the memory
+  /// they occupy to the uninitialized state.
   ///
-  /// `n` must not be greater than `count`
+  /// `n` must not be greater than `byteCount`.
+  ///
+  /// - Parameter n: The number of bytes to remove.
+  ///     `n` must not be negative or greater than `byteCount`.
   @_alwaysEmitIntoClient
   @lifetime(self: copy self)
-  public mutating func removeLast(_ k: Int) {
-    _precondition(k >= 0, "Can't remove a negative number of bytes")
-    _precondition(k <= _count, "OutputRawSpan underflow")
-    _count &-= k
+  public mutating func removeLast(_ n: Int) {
+    _precondition(n >= 0, "Can't remove a negative number of bytes")
+    _precondition(n <= _count, "OutputRawSpan underflow")
+    _count &-= n
   }
 
   /// Remove all this span's elements and return its memory
@@ -211,6 +223,10 @@ extension OutputRawSpan {
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension OutputRawSpan {
   /// Appends the given value's bytes to this span's bytes.
+  ///
+  /// - Parameters:
+  ///   - value: The value to store as raw bytes.
+  ///   - type: The type of the value.
   @_alwaysEmitIntoClient
   @unsafe
   @lifetime(self: copy self)
@@ -223,6 +239,12 @@ extension OutputRawSpan {
   }
 
   /// Appends the given value's bytes repeatedly to this span's bytes.
+  ///
+  /// - Parameters:
+  ///   - repeatedValue: The value to store as raw bytes.
+  ///   - count: The number of copies of `repeatedValue` to append
+  ///       to this span.
+  ///   - type: The type of the instance to store repeatedly.
   @_alwaysEmitIntoClient
   @unsafe
   @lifetime(self: copy self)
@@ -293,6 +315,10 @@ extension OutputRawSpan {
   /// This function cannot verify these two invariants, and therefore
   /// this is an unsafe operation. Violating the invariants of `OutputRawSpan`
   /// may result in undefined behavior.
+  ///
+  /// - Parameter body: A closure that can read from and write to the
+  ///     buffer and update the initialized count.
+  /// - Returns: The return value of the `body` closure.
   @_alwaysEmitIntoClient
   @_transparent
   @lifetime(self: copy self)

--- a/stdlib/public/core/Span/OutputRawSpan.swift
+++ b/stdlib/public/core/Span/OutputRawSpan.swift
@@ -32,7 +32,7 @@ public struct OutputRawSpan: ~Copyable, ~Escapable {
   @usableFromInline
   internal var _count: Int
 
-  /// Create an OutputRawSpan with zero capacity
+  /// Create an OutputRawSpan with zero capacity.
   @_alwaysEmitIntoClient
   @lifetime(immortal)
   public init() {
@@ -208,7 +208,7 @@ extension OutputRawSpan {
     _count &-= n
   }
 
-  /// Remove all this span's elements and return its memory
+  /// Remove all this span's bytes and return its memory
   /// to the uninitialized state.
   @_alwaysEmitIntoClient
   @lifetime(self: copy self)
@@ -308,7 +308,7 @@ extension OutputRawSpan {
   /// 1. The inout integer passed in as the second argument must be the exact
   ///     number of initialized bytes in the buffer passed in as the first
   ///     argument.
-  /// 2. These initialized elements must be located in a single contiguous
+  /// 2. These initialized bytes must be located in a single contiguous
   ///     region starting at the beginning of the buffer. The rest of the buffer
   ///     must hold uninitialized memory.
   ///
@@ -347,8 +347,7 @@ extension OutputRawSpan {
 @available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension OutputRawSpan {
-  /// Consume the output span (relinquishing its control over the buffer it is
-  /// addressing), and return the number of initialized bytes in it.
+  /// Consume the output span and return the number of initialized bytes.
   ///
   /// This method should be invoked in the scope where the `OutputRawSpan` was
   /// created, when it is time to commit the contents of the updated buffer
@@ -375,8 +374,7 @@ extension OutputRawSpan {
     return _count
   }
 
-  /// Consume the output span (relinquishing its control over the buffer it is
-  /// addressing), and return the number of initialized bytes in it.
+  /// Consume the output span and return the number of initialized bytes.
   ///
   /// This method should be invoked in the scope where the `OutputRawSpan` was
   /// created, when it is time to commit the contents of the updated buffer

--- a/stdlib/public/core/Span/OutputSpan.swift
+++ b/stdlib/public/core/Span/OutputSpan.swift
@@ -189,10 +189,10 @@ extension OutputSpan {
 @available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension OutputSpan where Element: ~Copyable {
-  /// The type that represents an initialized position in an `OutputSpan`.
+  /// The type that represents an initialized index in an `OutputSpan`.
   public typealias Index = Int
 
-  /// The range of initialized positions for this `OutputSpan`.
+  /// The range of initialized indices for this `OutputSpan`.
   @_alwaysEmitIntoClient
   public var indices: Range<Index> {
     unsafe Range(_uncheckedBounds: (0, count))
@@ -206,7 +206,7 @@ extension OutputSpan where Element: ~Copyable {
     _precondition(indices.contains(index), "index out of bounds")
   }
 
-  /// Accesses the element at the specified position.
+  /// Accesses the element at the specified index.
   ///
   /// - Parameter index: A valid index into this span.
   ///
@@ -224,9 +224,9 @@ extension OutputSpan where Element: ~Copyable {
     }
   }
 
-  /// Accesses the element at the specified position.
+  /// Accesses the element at the specified index.
   ///
-  /// This subscript does not validate `position`; this is an unsafe operation.
+  /// This subscript does not validate `index`; this is an unsafe operation.
   ///
   /// - Parameter index: A valid index into this span.
   ///

--- a/stdlib/public/core/Span/OutputSpan.swift
+++ b/stdlib/public/core/Span/OutputSpan.swift
@@ -45,7 +45,7 @@ public struct OutputSpan<Element: ~Copyable>: ~Copyable, ~Escapable {
     }
   }
 
-  /// Create an OutputSpan with zero capacity
+  /// Create an OutputSpan with zero capacity.
   @_alwaysEmitIntoClient
   @lifetime(immortal)
   public init() {
@@ -253,7 +253,7 @@ extension OutputSpan where Element: ~Copyable {
     return unsafe address.assumingMemoryBound(to: Element.self)
   }
 
-  /// Exchange the elements at the two given offsets
+  /// Exchange the elements at the two given indices.
   ///
   /// - Parameter i: A valid index into this span.
   /// - Parameter j: A valid index into this span.
@@ -265,7 +265,7 @@ extension OutputSpan where Element: ~Copyable {
     unsafe swapAt(unchecked: i, unchecked: j)
   }
 
-  /// Exchange the elements at the two given offsets
+  /// Exchange the elements at the two given indices.
   ///
   /// This function does not validate `i` or `j`; this is an unsafe operation.
   ///

--- a/stdlib/public/core/Span/OutputSpan.swift
+++ b/stdlib/public/core/Span/OutputSpan.swift
@@ -14,10 +14,10 @@
 import Swift
 #endif
 
-// `OutputSpan` is a reference to a contiguous region of memory that starts with
-// some number of initialized `Element` instances followed by uninitialized
-// memory. It provides operations to access the items it stores, as well as to
-// add new elements and to remove existing ones.
+/// `OutputSpan` is a reference to a contiguous region of memory that starts
+/// with some number of initialized `Element` instances followed by
+/// uninitialized memory. It provides operations to access the items it stores,
+/// as well as to add new elements and to remove existing ones.
 @safe
 @frozen
 @available(SwiftCompatibilitySpan 5.0, *)
@@ -26,6 +26,7 @@ public struct OutputSpan<Element: ~Copyable>: ~Copyable, ~Escapable {
   @usableFromInline
   internal let _pointer: UnsafeMutableRawPointer?
 
+  /// The total number of elements that this output span can contain.
   public let capacity: Int
 
   @usableFromInline
@@ -286,6 +287,8 @@ extension OutputSpan where Element: ~Copyable {
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension OutputSpan where Element: ~Copyable {
   /// Append a single element to this span.
+  ///
+  /// - Parameter value: The element to append.
   @_alwaysEmitIntoClient
   @lifetime(self: copy self)
   public mutating func append(_ value: consuming Element) {
@@ -297,6 +300,8 @@ extension OutputSpan where Element: ~Copyable {
   /// Remove the last initialized element from this span.
   ///
   /// Returns the last element. The `OutputSpan` must not be empty.
+  ///
+  /// - Returns: The removed element.
   @_alwaysEmitIntoClient
   @lifetime(self: copy self)
   public mutating func removeLast() -> Element {
@@ -307,18 +312,21 @@ extension OutputSpan where Element: ~Copyable {
     }
   }
 
-  /// Remove the last N elements of this span, returning the memory they occupy
-  /// to the uninitialized state.
+  /// Remove the last n elements of this span, returning the memory
+  /// they occupy to the uninitialized state.
   ///
-  /// `n` must not be greater than `count`
+  /// `n` must not be greater than `count`.
+  ///
+  /// - Parameter n: The number of elements to remove.
+  ///     `n` must not be negative or greater than `count`.
   @_alwaysEmitIntoClient
   @lifetime(self: copy self)
-  public mutating func removeLast(_ k: Int) {
-    _precondition(k >= 0, "Can't remove a negative number of elements")
-    _precondition(k <= _count, "OutputSpan underflow")
-    _count &-= k
-    unsafe _tail().withMemoryRebound(to: Element.self, capacity: k) {
-      _ = unsafe $0.deinitialize(count: k)
+  public mutating func removeLast(_ n: Int) {
+    _precondition(n >= 0, "Can't remove a negative number of elements")
+    _precondition(n <= _count, "OutputSpan underflow")
+    _count &-= n
+    unsafe _tail().withMemoryRebound(to: Element.self, capacity: n) {
+      _ = unsafe $0.deinitialize(count: n)
     }
   }
 
@@ -341,6 +349,11 @@ extension OutputSpan where Element: ~Copyable {
 extension OutputSpan {
 
   /// Repeatedly append an element to this span.
+  ///
+  /// - Parameters:
+  ///   - repeatedValue: The element to append repeatedly.
+  ///   - count: The number of times to append `repeatedValue`.
+  ///       `count` must not exceed `freeCapacity`.
   @_alwaysEmitIntoClient
   @lifetime(self: copy self)
   public mutating func append(repeating repeatedValue: Element, count: Int) {
@@ -408,6 +421,10 @@ extension OutputSpan where Element: ~Copyable {
   /// This function cannot verify these two invariants, and therefore
   /// this is an unsafe operation. Violating the invariants of `OutputSpan`
   /// may result in undefined behavior.
+  ///
+  /// - Parameter body: A closure that can read from and write to the
+  ///     buffer and update the initialized count.
+  /// - Returns: The return value of the `body` closure.
   @_alwaysEmitIntoClient
   @_transparent
   @lifetime(self: copy self)

--- a/stdlib/public/core/Span/RawSpan.swift
+++ b/stdlib/public/core/Span/RawSpan.swift
@@ -67,7 +67,7 @@ public struct RawSpan: ~Escapable, Copyable, BitwiseCopyable {
   ///
   /// The region of `byteCount` bytes of memory starting at `pointer`
   /// must remain valid, initialized and immutable
-  /// throughout the lifetime of the newly-created `Span`.
+  /// throughout the lifetime of the newly-created `RawSpan`.
   /// Failure to maintain this invariant results in undefined behaviour.
   ///
   /// - Parameters:
@@ -310,7 +310,7 @@ extension RawSpan {
     )
   }
 
-  /// Create a `RawSpan` over the memory represented by a `Span<T>`
+  /// Create a `RawSpan` over the memory represented by a `Span<T>`.
   ///
   /// - Parameters:
   ///   - span: An existing `Span<T>`, which will define both this
@@ -376,7 +376,7 @@ extension RawSpan {
   /// - Parameter bounds: A valid range of positions. Every position in
   ///     this range must be within the bounds of this `RawSpan`.
   ///
-  /// - Returns: A span over the bytes within `bounds`
+  /// - Returns: A `RawSpan` over the bytes within `bounds`.
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
@@ -409,7 +409,7 @@ extension RawSpan {
   /// - Parameter bounds: A valid range of positions. Every position in
   ///     this range must be within the bounds of this `RawSpan`.
   ///
-  /// - Returns: A span over the bytes within `bounds`
+  /// - Returns: A `RawSpan` over the bytes within `bounds`.
   ///
   /// - Complexity: O(1)
   @unsafe
@@ -439,7 +439,7 @@ extension RawSpan {
   /// - Parameter bounds: A valid range of positions. Every position in
   ///     this range must be within the bounds of this `RawSpan`.
   ///
-  /// - Returns: A span over the bytes within `bounds`
+  /// - Returns: A `RawSpan` over the bytes within `bounds`.
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
@@ -467,7 +467,7 @@ extension RawSpan {
   /// - Parameter bounds: A valid range of positions. Every position in
   ///     this range must be within the bounds of this `RawSpan`.
   ///
-  /// - Returns: A span over the bytes within `bounds`
+  /// - Returns: A `RawSpan` over the bytes within `bounds`.
   ///
   /// - Complexity: O(1)
   @unsafe
@@ -496,7 +496,7 @@ extension RawSpan {
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
-  /// - Returns: A span over all the bytes of this span.
+  /// - Returns: A `RawSpan` over all the bytes of this span.
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
@@ -545,7 +545,7 @@ extension RawSpan {
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension RawSpan {
 
-  /// View the bytes of this span as type `T`
+  /// View the bytes of this span as type `T`.
   ///
   /// This is the equivalent of `unsafeBitCast(_:to:)`. The
   /// underlying bytes must be initialized as type `T`, be
@@ -726,14 +726,12 @@ extension RawSpan {
     unsafe (self._pointer == other._pointer) && (self._count == other._count)
   }
 
-  /// Returns the offsets where the memory of `other` is located within
-  /// the memory represented by `self`
-  ///
-  /// Note: `other` must be a subrange of `self`
+  /// Returns the byte offsets within this span where the memory represented
+  /// by other is located, or nil if other is not located within this span.
   ///
   /// - Parameters:
-  ///   - other: a subrange of `self`
-  /// - Returns: A range of offsets within `self`
+  ///   - other: a span that may be a subrange of `self`
+  /// - Returns: A range of byte offsets within `self`, or `nil`.
   @_alwaysEmitIntoClient
   public func byteOffsets(of other: borrowing Self) -> Range<Int>? {
     if other._count > _count { return nil }
@@ -754,7 +752,7 @@ extension RawSpan {
 extension RawSpan {
 
   /// Returns a span containing the initial bytes of this span,
-  /// up to the specified maximum byte count.
+  /// up to the specified maximum length.
   ///
   /// If the maximum length exceeds the length of this span,
   /// the result contains all the bytes.

--- a/stdlib/public/core/Span/RawSpan.swift
+++ b/stdlib/public/core/Span/RawSpan.swift
@@ -51,6 +51,7 @@ public struct RawSpan: ~Escapable, Copyable, BitwiseCopyable {
   @usableFromInline
   internal let _count: Int
 
+  /// Create an empty span.
   @_alwaysEmitIntoClient
   @inline(__always)
   @lifetime(immortal)
@@ -523,8 +524,6 @@ extension RawSpan {
   /// during the execution of `withUnsafeBytes(_:)`.
   /// Do not store or return the pointer for later use.
   ///
-  /// Note: For an empty `RawSpan`, the closure always receives a `nil` pointer.
-  ///
   /// - Parameter body: A closure with an `UnsafeRawBufferPointer`
   ///   parameter that points to the viewed contiguous storage.
   ///   If `body` has a return value, that value is also
@@ -695,8 +694,17 @@ extension RawSpan {
 @available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension RawSpan {
-  /// Returns a Boolean value indicating whether two `RawSpan` instances
-  /// refer to the same region in memory.
+  /// Returns a Boolean value indicating whether two instances refer to the same
+  /// memory region.
+  ///
+  /// Two spans are identical if they reference the same starting address
+  /// and have the same number of elements.
+  ///
+  /// - Parameter other: A span to compare with this one.
+  /// - Returns: Whether `self` and `other` reference the same region
+  ///     in memory.
+  ///
+  /// - Complexity: O(1)
   @_alwaysEmitIntoClient
   public func isIdentical(to other: Self) -> Bool {
     unsafe (self._pointer == other._pointer) && (self._count == other._count)
@@ -704,6 +712,13 @@ extension RawSpan {
 
   /// Returns a Boolean value indicating whether two instances refer to the same
   /// memory region.
+  ///
+  /// Two spans are identical if they reference the same starting address
+  /// and have the same number of elements.
+  ///
+  /// - Parameter other: A span to compare with this one.
+  /// - Returns: Whether `self` and `other` reference the same region
+  ///     in memory.
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient

--- a/stdlib/public/core/Span/RawSpan.swift
+++ b/stdlib/public/core/Span/RawSpan.swift
@@ -337,7 +337,7 @@ extension RawSpan {
   /// The number of bytes in the span.
   ///
   /// To check whether the span is empty, use its `isEmpty` property
-  /// instead of comparing `count` to zero.
+  /// instead of comparing `byteCount` to zero.
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
@@ -698,7 +698,7 @@ extension RawSpan {
   /// memory region.
   ///
   /// Two spans are identical if they reference the same starting address
-  /// and have the same number of elements.
+  /// and have the same number of bytes.
   ///
   /// - Parameter other: A span to compare with this one.
   /// - Returns: Whether `self` and `other` reference the same region
@@ -714,7 +714,7 @@ extension RawSpan {
   /// memory region.
   ///
   /// Two spans are identical if they reference the same starting address
-  /// and have the same number of elements.
+  /// and have the same number of bytes.
   ///
   /// - Parameter other: A span to compare with this one.
   /// - Returns: Whether `self` and `other` reference the same region
@@ -786,7 +786,7 @@ extension RawSpan {
 
   /// Returns a span over all but the given number of trailing bytes.
   ///
-  /// If the number of elements to drop exceeds the number of elements in
+  /// If the number of bytes to drop exceeds the number of bytes in
   /// the span, the result is an empty span.
   ///
   /// The returned span's first byte is always at offset 0; unlike buffer
@@ -851,7 +851,7 @@ extension RawSpan {
 
   /// Returns a span over all but the given number of initial bytes.
   ///
-  /// If the number of elements to drop exceeds the number of bytes in
+  /// If the number of bytes to drop exceeds the number of bytes in
   /// the span, the result is an empty span.
   ///
   /// The returned span's first byte is always at offset 0; unlike buffer

--- a/stdlib/public/core/Span/Span.swift
+++ b/stdlib/public/core/Span/Span.swift
@@ -400,7 +400,7 @@ extension Span where Element: ~Copyable {
   @_transparent
   public var isEmpty: Bool { _count == 0 }
 
-  /// The representation for a position in `Span`.
+  /// The representation for an index in `Span`.
   public typealias Index = Int
 
   /// The indices that are valid for subscripting the span, in ascending
@@ -424,7 +424,7 @@ extension Span where Element: ~Copyable {
     _precondition(indices.contains(position), "Index out of bounds")
   }
 
-  /// Accesses the element at the specified position in the `Span`.
+  /// Accesses the element at the specified index in the `Span`.
   ///
   /// - Parameter position: The offset of the element to access. `position`
   ///     must be greater or equal to zero, and less than `count`.
@@ -439,7 +439,7 @@ extension Span where Element: ~Copyable {
     }
   }
 
-  /// Accesses the element at the specified position in the `Span`.
+  /// Accesses the element at the specified index in the `Span`.
   ///
   /// This subscript does not validate `position`. Using this subscript
   /// with an invalid `position` results in undefined behaviour.
@@ -471,7 +471,7 @@ extension Span where Element: ~Copyable {
 @available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension Span where Element: BitwiseCopyable {
-  /// Accesses the element at the specified position in the `Span`.
+  /// Accesses the element at the specified index in the `Span`.
   ///
   /// - Parameter position: The offset of the element to access. `position`
   ///     must be greater or equal to zero, and less than `count`.
@@ -485,7 +485,7 @@ extension Span where Element: BitwiseCopyable {
     }
   }
 
-  /// Accesses the element at the specified position in the `Span`.
+  /// Accesses the element at the specified index in the `Span`.
   ///
   /// This subscript does not validate `position`. Using this subscript
   /// with an invalid `position` results in undefined behaviour.
@@ -530,13 +530,13 @@ extension Span where Element: BitwiseCopyable {
 extension Span where Element: ~Copyable {
 
   /// Constructs a new span over the items within the supplied range of
-  /// positions within this span.
+  /// indices within this span.
   ///
   /// The returned span's first item is always at offset 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
-  /// - Parameter bounds: A valid range of positions. Every position in
+  /// - Parameter bounds: A valid range of indices. Every index in
   ///     this range must be within the bounds of this `Span`.
   ///
   /// - Returns: A `Span` over the items within `bounds`
@@ -561,7 +561,7 @@ extension Span where Element: ~Copyable {
   }
 
   /// Constructs a new span over the items within the supplied range of
-  /// positions within this span.
+  /// indices within this span.
   ///
   /// The returned span's first item is always at offset 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
@@ -569,7 +569,7 @@ extension Span where Element: ~Copyable {
   ///
   /// This function does not validate `bounds`; this is an unsafe operation.
   ///
-  /// - Parameter bounds: A valid range of positions. Every position in
+  /// - Parameter bounds: A valid range of indices. Every index in
   ///     this range must be within the bounds of this `Span`.
   ///
   /// - Returns: A `Span` over the items within `bounds`
@@ -596,13 +596,13 @@ extension Span where Element: ~Copyable {
   }
 
   /// Constructs a new span over the items within the supplied range of
-  /// positions within this span.
+  /// indices within this span.
   ///
   /// The returned span's first item is always at offset 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
   /// span from which they are extracted.
   ///
-  /// - Parameter bounds: A valid range of positions. Every position in
+  /// - Parameter bounds: A valid range of indices. Every index in
   ///     this range must be within the bounds of this `Span`.
   ///
   /// - Returns: A `Span` over the items within `bounds`
@@ -624,7 +624,7 @@ extension Span where Element: ~Copyable {
   }
 
   /// Constructs a new span over the items within the supplied range of
-  /// positions within this span.
+  /// indices within this span.
   ///
   /// The returned span's first item is always at offset 0; unlike buffer
   /// slices, extracted spans do not share their indices with the
@@ -632,7 +632,7 @@ extension Span where Element: ~Copyable {
   ///
   /// This function does not validate `bounds`; this is an unsafe operation.
   ///
-  /// - Parameter bounds: A valid range of positions. Every position in
+  /// - Parameter bounds: A valid range of indices. Every index in
   ///     this range must be within the bounds of this `Span`.
   ///
   /// - Returns: A `Span` over the items within `bounds`

--- a/stdlib/public/core/Span/Span.swift
+++ b/stdlib/public/core/Span/Span.swift
@@ -51,6 +51,7 @@ public struct Span<Element: ~Copyable>: ~Escapable, Copyable, BitwiseCopyable {
   @usableFromInline
   internal let _count: Int
 
+  /// Create an empty span.
   @_alwaysEmitIntoClient
   @inline(__always)
   @lifetime(immortal)
@@ -691,8 +692,6 @@ extension Span where Element: ~Copyable  {
   /// during the execution of `withUnsafeBufferPointer(_:)`.
   /// Do not store or return the pointer for later use.
   ///
-  /// Note: For an empty `Span`, the closure always receives a `nil` pointer.
-  ///
   /// - Parameter body: A closure with an `UnsafeBufferPointer` parameter
   ///   that points to the viewed contiguous storage. If `body` has
   ///   a return value, that value is also used as the return value
@@ -726,8 +725,6 @@ extension Span where Element: BitwiseCopyable {
   /// during the execution of `withUnsafeBytes(_:)`.
   /// Do not store or return the pointer for later use.
   ///
-  /// Note: For an empty `Span`, the closure always receives a `nil` pointer.
-  ///
   /// - Parameter body: A closure with an `UnsafeRawBufferPointer`
   ///   parameter that points to the viewed contiguous storage.
   ///   If `body` has a return value, that value is also
@@ -751,8 +748,17 @@ extension Span where Element: BitwiseCopyable {
 @available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension Span where Element: ~Copyable {
-  /// Returns a Boolean value indicating whether two `Span` instances
-  /// refer to the same region in memory.
+  /// Returns a Boolean value indicating whether two instances refer to the same
+  /// memory region.
+  ///
+  /// Two spans are identical if they reference the same starting address
+  /// and have the same number of elements.
+  ///
+  /// - Parameter other: A span to compare with this one.
+  /// - Returns: Whether `self` and `other` reference the same region
+  ///     in memory.
+  ///
+  /// - Complexity: O(1)
   @_alwaysEmitIntoClient
   public func isIdentical(to other: Self) -> Bool {
     unsafe (self._pointer == other._pointer) && (self._count == other._count)
@@ -760,6 +766,13 @@ extension Span where Element: ~Copyable {
 
   /// Returns a Boolean value indicating whether two instances refer to the same
   /// memory region.
+  ///
+  /// Two spans are identical if they reference the same starting address
+  /// and have the same number of elements.
+  ///
+  /// - Parameter other: A span to compare with this one.
+  /// - Returns: Whether `self` and `other` reference the same region
+  ///     in memory.
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient

--- a/stdlib/public/core/Span/Span.swift
+++ b/stdlib/public/core/Span/Span.swift
@@ -361,7 +361,7 @@ extension Span where Element: BitwiseCopyable {
     self = unsafe _overrideLifetime(span, borrowing: buffer)
   }
 
-  /// Create a `Span` over the bytes represented by a `RawSpan`
+  /// Create a `Span` over the bytes represented by a `RawSpan`.
   ///
   /// - Parameters:
   ///   - bytes: An existing `RawSpan`, which will define both this
@@ -511,7 +511,7 @@ extension Span where Element: BitwiseCopyable {
 
   /// Construct a raw span over the memory represented by this span.
   ///
-  /// - Returns: a RawSpan over the memory represented by this span
+  /// - Returns: A `RawSpan` over the memory represented by this span.
   @_alwaysEmitIntoClient
   @_transparent
   @unsafe
@@ -539,7 +539,7 @@ extension Span where Element: ~Copyable {
   /// - Parameter bounds: A valid range of indices. Every index in
   ///     this range must be within the bounds of this `Span`.
   ///
-  /// - Returns: A `Span` over the items within `bounds`
+  /// - Returns: A `Span` over the items within `bounds`.
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
@@ -572,7 +572,7 @@ extension Span where Element: ~Copyable {
   /// - Parameter bounds: A valid range of indices. Every index in
   ///     this range must be within the bounds of this `Span`.
   ///
-  /// - Returns: A `Span` over the items within `bounds`
+  /// - Returns: A `Span` over the items within `bounds`.
   ///
   /// - Complexity: O(1)
   @unsafe
@@ -605,7 +605,7 @@ extension Span where Element: ~Copyable {
   /// - Parameter bounds: A valid range of indices. Every index in
   ///     this range must be within the bounds of this `Span`.
   ///
-  /// - Returns: A `Span` over the items within `bounds`
+  /// - Returns: A `Span` over the items within `bounds`.
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
@@ -635,7 +635,7 @@ extension Span where Element: ~Copyable {
   /// - Parameter bounds: A valid range of indices. Every index in
   ///     this range must be within the bounds of this `Span`.
   ///
-  /// - Returns: A `Span` over the items within `bounds`
+  /// - Returns: A `Span` over the items within `bounds`.
   ///
   /// - Complexity: O(1)
   @unsafe
@@ -780,12 +780,12 @@ extension Span where Element: ~Copyable {
     unsafe (self._pointer == other._pointer) && (self._count == other._count)
   }
 
-  /// Returns the indices within `self` where the memory represented by `other`
-  /// is located, or `nil` if `other` is not located within `self`.
+  /// Returns the indices within this span where the memory represented
+  /// by other is located, or nil if other is not located within this span.
   ///
   /// - Parameters:
-  /// - other: a span that may be a subrange of `self`
-  /// - Returns: A range of indices within `self`, or `nil`
+  ///   - other: a span that may be a subrange of `self`
+  /// - Returns: A range of indices within `self`, or `nil`.
   @_alwaysEmitIntoClient
   public func indices(of other: borrowing Self) -> Range<Index>? {
     if other._count > _count { return nil }
@@ -871,7 +871,7 @@ extension Span where Element: ~Copyable {
     extracting(droppingLast: k)
   }
 
-  /// Returns a span containing the final elements of the span,
+  /// Returns a span containing the trailing elements of the span,
   /// up to the given maximum length.
   ///
   /// If the maximum length exceeds the length of this span,


### PR DESCRIPTION
- **Explanation**:
Add missing doc-comments. The doc-comments existed on some but not all functions; this applies them to the functions where they were missing, adapted as appropriate.

- **Scope**:
No change in functionality.

- **Issues**:

- **Risk**:
Low. There is no change in functionality.

- **Testing**:
Regular tests.
