### PR TITLE
A few compile time improvements

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/Analysis/AliasAnalysis.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Analysis/AliasAnalysis.swift
@@ -288,8 +288,8 @@ struct AliasAnalysis {
       }
       return effects
 
-    case let apply as FullApplySite:
-      return getApplyEffect(of: apply, on: memLoc)
+    case isFullApplySite:
+      return getApplyEffect(of: inst as! FullApplySite, on: memLoc)
 
     case let partialApply as PartialApplyInst:
       return getPartialApplyEffect(of: partialApply, on: memLoc)
@@ -858,7 +858,7 @@ private struct EscapesToInstructionVisitor : EscapeVisitor {
     if user == target {
       return .abort
     }
-    if user is ReturnInstruction {
+    if user.isReturnInstruction {
       // Anything which is returned cannot escape to an instruction inside the function.
       return .ignore
     }

--- a/SwiftCompilerSources/Sources/Optimizer/Analysis/AliasAnalysis.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Analysis/AliasAnalysis.swift
@@ -452,6 +452,9 @@ struct AliasAnalysis {
       }
       return .noEffects
     default:
+      if builtin.memoryEffects == .noEffects {
+        return .noEffects
+      }
       return defaultEffects(of: builtin, on: memLoc)
     }
   }

--- a/SwiftCompilerSources/Sources/Optimizer/Analysis/CalleeAnalysis.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Analysis/CalleeAnalysis.swift
@@ -134,8 +134,8 @@ extension Instruction {
   /// Deinitialization barriers constrain variable lifetimes. Lexical
   /// end_borrow, destroy_value, and destroy_addr cannot be hoisted above them.
   final func isDeinitBarrier(_ analysis: CalleeAnalysis) -> Bool {
-    if let site = self as? FullApplySite {
-      return site.isBarrier(analysis)
+    if self.isFullApplySite {
+      return (self as! FullApplySite).isBarrier(analysis)
     }
     if let eai = self as? EndApplyInst {
       return eai.isBarrier(analysis)

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ComputeSideEffects.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ComputeSideEffects.swift
@@ -197,7 +197,8 @@ private struct CollectedEffects {
       let addr = inst.operands[0].value
       addEffects(.read, to: addr)
 
-    case let apply as FullApplySite:
+    case isFullApplySite:
+      let apply = inst as! FullApplySite
       if apply.callee.type.isCalleeConsumedFunction {
         addEffects(.destroy, to: apply.callee)
         globalEffects = .worstEffects
@@ -254,7 +255,7 @@ private struct CollectedEffects {
       // effect, it would not give any significant benefit in any of our current optimizations.
       addEffects(.destroy, to: inst.operands[0].value, fromInitialPath: SmallProjectionPath(.anyValueFields))
 
-    case is ReturnInstruction:
+    case isReturnInstruction:
       if inst.parentFunction.convention.hasAddressResult {
         addEffects(.read, to: inst.operands[0].value)
       }

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/RedundantLoadElimination.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/RedundantLoadElimination.swift
@@ -107,7 +107,10 @@ func eliminateRedundantLoads(in function: Function,
     var iter = block.instructions.reversed().first
     while let succ = iter, let inst = succ.previous {
 
-      if let load = inst as? LoadingInstruction {
+      // TODO: replace this with `if let inst as? LoadingInstruction` once the toolchain builders are
+      // upgraded to a compiler version with fast type casting (https://github.com/swiftlang/swift/pull/88270).
+      if inst is LoadInst || inst is CopyAddrInst {
+        let load = inst as! LoadingInstruction
         if !context.continueWithNextSubpassRun(for: load) {
           return changed
         }

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/EscapeUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/EscapeUtils.swift
@@ -396,7 +396,7 @@ fileprivate struct EscapeWalker<V: EscapeVisitor> : ValueDefUseWalker,
       if handleDestroy(of: operand.value, path: path) == .abortWalk {
         return .abortWalk
       }
-    case is ReturnInstruction:
+    case isReturnInstruction:
       return isEscaping
     case is ApplyInst, is TryApplyInst, is BeginApplyInst:
       return walkDownCallee(argOp: operand, apply: instruction as! FullApplySite, path: path)
@@ -543,7 +543,7 @@ fileprivate struct EscapeWalker<V: EscapeVisitor> : ValueDefUseWalker,
       if handleDestroy(of: operand.value, path: path) == .abortWalk {
         return .abortWalk
       }
-    case is ReturnInstruction:
+    case isReturnInstruction:
       return isEscaping
     case is ApplyInst, is TryApplyInst, is BeginApplyInst:
       return walkDownCallee(argOp: operand, apply: instruction as! FullApplySite, path: path)

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/EscapeUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/EscapeUtils.swift
@@ -398,7 +398,7 @@ fileprivate struct EscapeWalker<V: EscapeVisitor> : ValueDefUseWalker,
       }
     case isReturnInstruction:
       return isEscaping
-    case is ApplyInst, is TryApplyInst, is BeginApplyInst:
+    case isFullApplySite:
       return walkDownCallee(argOp: operand, apply: instruction as! FullApplySite, path: path)
     case let pai as PartialApplyInst:
       // Check whether the partially applied argument can escape in the body.
@@ -545,7 +545,7 @@ fileprivate struct EscapeWalker<V: EscapeVisitor> : ValueDefUseWalker,
       }
     case isReturnInstruction:
       return isEscaping
-    case is ApplyInst, is TryApplyInst, is BeginApplyInst:
+    case isFullApplySite:
       return walkDownCallee(argOp: operand, apply: instruction as! FullApplySite, path: path)
     case let pai as PartialApplyInst:
       if walkDownCallee(argOp: operand, apply: pai, path: path.with(knownType: nil)) == .abortWalk {

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/OptUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/OptUtils.swift
@@ -930,7 +930,7 @@ private struct EscapesToValueVisitor : EscapeVisitor {
     if operand.value == target.value && path.projectionPath.mayOverlap(with: target.path) {
       return .abort
     }
-    if operand.instruction is ReturnInstruction {
+    if operand.instruction.isReturnInstruction {
       // Anything which is returned cannot escape to an instruction inside the function.
       return .ignore
     }

--- a/SwiftCompilerSources/Sources/SIL/ApplySite.swift
+++ b/SwiftCompilerSources/Sources/SIL/ApplySite.swift
@@ -410,6 +410,30 @@ extension FullApplySite {
   }
 }
 
+extension Instruction {
+  /// To be used for fast type casting to `FullApplySite` in time critical code.
+  /// This is a workaround for the slow runtime type casts. After toolchain builders are
+  /// upgraded to a compiler version which includes the fix for this problem
+  /// (https://github.com/swiftlang/swift/pull/88270), we don't need this anymore and
+  /// the regular `as FullApplySite` casts can be used instead.
+  public var isFullApplySite: Bool {
+    switch self {
+    case is ApplyInst, is TryApplyInst, is BeginApplyInst:
+      return true
+    default:
+      return false
+    }
+  }
+}
+
+/// For pattern matching in switch statements.
+public struct IsFullApplySite {}
+public let isFullApplySite = IsFullApplySite()
+
+public func ~= (pattern: IsFullApplySite, value: Instruction) -> Bool {
+  return value.isFullApplySite
+}
+
 let addressableTest = Test("addressable_arguments") {
   function, arguments, context in
 

--- a/SwiftCompilerSources/Sources/SIL/Instruction.swift
+++ b/SwiftCompilerSources/Sources/SIL/Instruction.swift
@@ -181,7 +181,7 @@ public class Instruction : CustomStringConvertible, Hashable {
 
   public final var isDeinitBarrier: Bool {
     switch self {
-    case is FullApplySite, is EndApplyInst, is AbortApplyInst:
+    case SIL.isFullApplySite, is EndApplyInst, is AbortApplyInst:
       return true
     default:
       return mayAccessPointerOrGlobal || mayLoadWeakOrUnowned || maySynchronize
@@ -2067,6 +2067,25 @@ final public class UnreachableInst : TermInst {
 @_semantics("fast_cast")
 public protocol ReturnInstruction: Instruction {
   var returnedValue: Value { get }
+}
+
+public extension Instruction {
+  /// To be used for fast type casting to `isReturnInstruction` in time critical code.
+  /// This is a workaround for the slow runtime type casts. After toolchain builders are
+  /// upgraded to a compiler version which includes the fix for this problem
+  /// (https://github.com/swiftlang/swift/pull/88270), we don't need this anymore and
+  /// the regular `as isReturnInstruction` casts can be used instead.
+  var isReturnInstruction: Bool {
+    self is ReturnInst || self is ReturnBorrowInst
+  }
+}
+
+/// For pattern matching in switch statements.
+public struct IsReturnInstruction {}
+public let isReturnInstruction = IsReturnInstruction()
+
+public func ~= (pattern: IsReturnInstruction, value: Instruction) -> Bool {
+  return value.isReturnInstruction
 }
 
 final public class ReturnInst : TermInst, UnaryInstruction, ReturnInstruction {

--- a/lib/SILOptimizer/Utils/OSSACanonicalizeOwned.cpp
+++ b/lib/SILOptimizer/Utils/OSSACanonicalizeOwned.cpp
@@ -1414,12 +1414,14 @@ bool OSSACanonicalizeOwned::computeLiveness() {
     clear();
     return false;
   }
+#ifndef SWIFT_ENABLE_SWIFT_IN_SWIFT // requires complete lifetimes
   if (respectsDeadEnds() && hasAnyDeadEnds()) {
     if (respectsDeinitBarriers()) {
       extendLexicalLivenessToDeadEnds();
     }
     extendLivenessToDeadEnds();
   }
+#endif
   if (respectsDeinitBarriers()) {
     extendLivenessToDeinitBarriers();
   }


### PR DESCRIPTION
- **Explanation**:

- Workaround for fast type casting to the `FullApplySite` and `ReturnInstruction` protocols

Rather than doing a standard swift runtime cast to an existential, explicitly check for the conforming instruction classes, which is much faster.
The new `isFullApplySite` and `isReturnInstruction` casting utilities are used in the (very few) time critical places in the optimizer.

After toolchain builders are upgraded to a compiler version which includes the fix for this problem (https://github.com/swiftlang/swift/pull/88270), we don't need this workaround anymore and the regular `as`/`is` casts can be used again.

Now the runtime casts doesn't show up prominently in compile-time profiling data anymore - even with a host compiler which doesn't implement fast type checks, yet.

- Speed up memory effect computation for builtin instructions in AliasAnalysis

If a builtin has no memory effects defined (which is the case for most builtins) we don't need to do escape analysis to compute memory effects.

- Don't do analysis for dead-end blocks in OSSACanonicalizeOwned

This is expensive and not needed anymore since we have complete lifetimes.

- **Scope**:
Affects compile time in the SIL optimizer.

- **Issues**:
rdar://175941357

- **Risk**:
Low. These are small, well understood changes in fundamental parts of the optimizer. Problems would immediately pop up in many regressions tests.

- **Testing**:
The changed code is covered by our regular LIT tests.

- **Reviewers**:
@DougGregor, @atrick
