### PR TITLE
[Android] Make `FILE` import as `OpaquePointer` on all APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@
 
 ## Swift (next)
 
+* The compiler API note `SwiftImportAs` now has support for always importing C structs as `OpaquePointer`. 
+  This can be used to unify the imported C pointer type in situations where the visibility of the struct might differ.
+  For example, the C `FILE` pointer in Android imports differently on API 23 compared to API 24 and above. We can unify that using the new API note:
+  
+  ```
+  ---
+  Name: _stdio
+  Tags:
+  - Name: __sFILE
+    SwiftImportAs: opaque_pointer
+  ```
+
 * When building modules using library evolution, Swift now uses module selectors in module interface files by default,
   improving their robustness against name collisions and ambiguity. Compiler flags previously used to work around these
   issues are disabled in this configuration and can now be removed. If necessary, you can disable this new behavior by

--- a/stdlib/public/Platform/CMakeLists.txt
+++ b/stdlib/public/Platform/CMakeLists.txt
@@ -364,14 +364,17 @@ if("ANDROID" IN_LIST SWIFT_SDKS)
       ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_SOURCE_DIR}/posix_filesystem.apinotes" "${SWIFTLIB_DIR}/apinotes"
     COMMAND
       ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_SOURCE_DIR}/spawn.apinotes" "${SWIFTLIB_DIR}/apinotes"
+    COMMAND
+      ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_SOURCE_DIR}/_stdio.apinotes" "${SWIFTLIB_DIR}/apinotes"
     OUTPUT
       "${SWIFTLIB_DIR}/apinotes/posix_filesystem.apinotes"
       "${SWIFTLIB_DIR}/apinotes/spawn.apinotes"
+      "${SWIFTLIB_DIR}/apinotes/_stdio.apinotes"
     COMMENT
       "Copying Android API Notes to resource directories")
   add_dependencies(sdk-overlay ${copy_android_posix_filesystem_apinotes_resource})
   list(APPEND android_modulemap_target_list ${copy_android_posix_filesystem_apinotes_resource})
-  swift_install_in_component(FILES posix_filesystem.apinotes spawn.apinotes
+  swift_install_in_component(FILES posix_filesystem.apinotes spawn.apinotes _stdio.apinotes
                              DESTINATION "lib/swift/apinotes"
                              COMPONENT sdk-overlay)
 endif()

--- a/stdlib/public/Platform/_stdio.apinotes
+++ b/stdlib/public/Platform/_stdio.apinotes
@@ -1,0 +1,5 @@
+---
+Name: _stdio
+Tags:
+- Name: __sFILE
+  SwiftImportAs: opaque_pointer

--- a/test/ClangImporter/android-file-pointer-opaque.swift
+++ b/test/ClangImporter/android-file-pointer-opaque.swift
@@ -1,0 +1,25 @@
+// RUN: %target-swift-frontend -typecheck -target %target-triple23 %s
+// RUN: %target-swift-frontend -typecheck -target %target-triple24 %s
+
+// REQUIRES: OS=linux-android || OS=linux-androideabi
+
+// On Android API 23 and below, bionic's stdio.h exposes FILE as the complete struct.
+// Without an APINotes annotation, FILE* would import as
+// UnsafeMutablePointer<FILE> rather than OpaquePointer, breaking source
+// compatibility with code written against API 24+ where FILE is already opaque.
+// The _stdio.apinotes file annotates __sFILE with SwiftImportAs: opaque_pointer
+// to normalise the import type to OpaquePointer across all API levels.
+
+import Android
+
+func verifyFILEImportsAsOpaquePointer(path: UnsafePointer<CChar>,
+                                      mode: UnsafePointer<CChar>) {
+  // fopen / fdopen return FILE* — must be OpaquePointer? on both API 23 and 24+.
+  let fp: OpaquePointer? = fopen(path, mode)
+  if let fp {
+    fclose(fp)
+  }
+
+  let fp2: OpaquePointer? = fdopen(STDIN_FILENO, mode)
+  _ = fp2
+}


### PR DESCRIPTION
**Depends on #88714**

<!-- Please fill out the following form: --> 
- **Explanation**: Adds a API note to the `Android` module to make `FILE` import as `OpaquePointer` on API 23. This needed to make the official Android SDK support API 23.
- **Scope**: Limited to Android, only a breaking change if you were only building for API 23 and explicitly typing the FILE pointer as `UnsafeMutablePointer<FILE>`. 
- **Issues**: 
* https://forums.swift.org/t/extend-apinotes-to-support-always-importing-c-pointers-as-opaquepointer/85606
* https://forums.swift.org/t/android-api-minimum-for-the-swift-sdk-for-android/82874
- **Risk**: Again, limited to Android and only makes a difference on API 23.
- **Testing**: Adds an Android test to verify the behaviour