### PR TITLE
Fix markdown formatting in Swift README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ## Welcome to Swift
 
-Swift is a high-performance system programming language.  It has a clean
+Swift is a high-performance system programming language. It has a clean
 and modern syntax, offers seamless access to existing C and Objective-C code
 and frameworks, and is memory-safe by default.
 
@@ -32,8 +32,7 @@ To learn more about the compiler's internal design, see the
 Contributions to Swift are welcomed and encouraged! Please see the
 [Contributing to Swift guide](https://swift.org/contributing/).
 
-Before submitting the pull request, please make sure you have [tested your
- changes](https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md)
+Before submitting the pull request, please make sure you have [tested your changes](https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md)
  and that they follow the Swift project [guidelines for contributing
  code](https://swift.org/contributing/#contributing-code).
 
@@ -68,7 +67,7 @@ We also have an [FAQ](/docs/HowToGuides/FAQ.md) that answers common questions.
 
 Swift toolchains are created using the script
 [build-toolchain](https://github.com/apple/swift/blob/main/utils/build-toolchain). This
-script is used by swift.org's CI to produce snapshots and can allow for one to
+script is used by swift.org's CI to produce snapshots and allows developers to
 locally reproduce such builds for development or distribution purposes. A typical 
 invocation looks like the following:
 

--- a/README.md
+++ b/README.md
@@ -32,9 +32,10 @@ To learn more about the compiler's internal design, see the
 Contributions to Swift are welcomed and encouraged! Please see the
 [Contributing to Swift guide](https://swift.org/contributing/).
 
-Before submitting the pull request, please make sure you have [tested your changes](https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md)
- and that they follow the Swift project [guidelines for contributing
- code](https://swift.org/contributing/#contributing-code).
+Before submitting the pull request, please make sure you have [tested your changes]
+(https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md)
+ and that they follow the Swift project [guidelines for contributing code]
+ (https://swift.org/contributing/#contributing-code).
 
 To be a truly great community, [Swift.org](https://swift.org/) needs to welcome
 developers from all walks of life, with different backgrounds, and with a wide


### PR DESCRIPTION
- **Explanation**:
  Cleaned up minor Markdown formatting issues in the README, including trailing spaces and small wording/spacing improvements.

- **Scope**:
  Documentation-only change. No impact on compiler behavior, APIs, tests, or existing code.

- **Issues**:
  None.

- **Risk**:
  Very low. The change only affects README formatting/readability.

- **Testing**:
  Reviewed the Markdown changes locally.