### PR TITLE
Improve Swift documentation wording

### DIFF
--- a/stdlib/stdlib.docc/Swift.md
+++ b/stdlib/stdlib.docc/Swift.md
@@ -8,7 +8,7 @@ Swift includes modern features like type inference, optionals, and closures, whi
 make the syntax concise yet expressive. Swift ensures your code is fast and efficient,
 while its memory safety and native error handling make the language safe by design.
 Writing Swift code is interactive and fun in Swift Playgrounds, playgrounds in Xcode,
-and REPL.
+and the REPL.
 
 ```swift
 var interestingNumbers = [


### PR DESCRIPTION
- **Explanation**:
  Improved wording in the Swift documentation overview by changing “and REPL” to “and the REPL.”

- **Scope**:
  Documentation-only change. No impact on compiler behavior, APIs, tests, or existing code.

- **Issues**:
  None.

- **Risk**:
  Very low. The change only affects documentation readability.

- **Testing**:
  Reviewed the documentation change locally.