### PR TITLE
Improve supporting types documentation wording

### DIFF
--- a/stdlib/stdlib.docc/supporting-types.md
+++ b/stdlib/stdlib.docc/supporting-types.md
@@ -1,7 +1,7 @@
 # Supporting Types
 
-Use wrappers, indices, and iterators in operations like slicing, flattening, and
-reversing a collection.
+Use wrappers, indices, and iterators for operations like slicing, flattening, and
+reversing collections.
 
 ## Topics
 
@@ -29,8 +29,8 @@ reversing a collection.
 
 ### Lazy Wrappers
 
-Use these lazy wrappers to defer any filtering or transformation of collection elements
-until elements are accessed.
+Use lazy wrappers to defer filtering or transformation of collection elements
+until the elements are accessed.
 
 - ``Swift/LazySequence``
 - ``Swift/LazyMapSequence``
@@ -69,8 +69,8 @@ instead of copying the collection's contents.
 
 ### Indices and Iterators
 
-Index and iterator types for other sequence and collection types in the standard
-library.
+Use index and iterator types with other sequence and collection types in the
+standard library.
 
 - ``Swift/IteratorSequence``
 - ``Swift/IndexingIterator``


### PR DESCRIPTION
- **Explanation**:
  Improved wording in `stdlib/stdlib.docc/supporting-types.md` for clarity and readability.

- **Scope**:
  Documentation-only change. No impact on compiler behavior, APIs, tests, or existing code.

- **Issues**:
  None.

- **Risk**:
  Very low. The change only affects documentation wording.

- **Testing**:
  Reviewed the documentation change locally.