### PR TITLE
[ubuntu 26.04] disable use-std-set.swift

### DIFF
--- a/test/Interop/Cxx/stdlib/use-std-set.swift
+++ b/test/Interop/Cxx/stdlib/use-std-set.swift
@@ -18,6 +18,7 @@
 // REQUIRES: OS=macosx || OS=linux-gnu
 // UNSUPPORTED: LinuxDistribution=fedora-41
 // UNSUPPORTED: LinuxDistribution=rhel-10.1
+// UNSUPPORTED: LinuxDistribution=ubuntu-26.04
 
 import StdlibUnittest
 #if !BRIDGING_HEADER


### PR DESCRIPTION
<!--
The main branch is now in convergence, which means major changes, such as large refactoring or new features, should be avoided. This strategy is intended to maintain the stability of the Swift 6.4 release leading up to the May 4th branch. For any <!--
The main branch is now in convergence, which means major changes, such as large refactoring or new features, should be avoided. This strategy is intended to maintain the stability of the Swift 6.4 release leading up to the May 4th branch. For any work that requires broad changes or introduces new features, create a feature branch and open a draft pull request. All updates to the swiftlang/swift repository’s main branch require approval from the release managers. A pull request targeting swiftlang/swift will automatically add release managers. You can also contact them via @release-managers in the forum group.
-->

<!-- Please fill out the following form: --> 
- **Explanation**:
  Disable test for ubuntu 26.04 as part of platform bringup
- **Scope**:
  Small scope, simply expanding failed distros
- **Issues**:
  NA
- **Risk**:
  Small, almost none
- **Testing**:
  NA

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
