### PR TITLE
[cxx-interop] Deduplicate some code into shared helpers

### DIFF
--- a/lib/ClangImporter/ClangDerivedConformances.cpp
+++ b/lib/ClangImporter/ClangDerivedConformances.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "ClangDerivedConformances.h"
+#include "ClangSynthesizedDecls.h"
 #include "ImporterImpl.h"
 #include "SwiftLookupTable.h"
 #include "swift/AST/ConformanceLookup.h"
@@ -235,27 +236,31 @@ static ValueDecl *lookupOperator(
   return nullptr;
 }
 
+/// Get the underlying type of a parameter, returning a null QualType if the
+/// parameter is not read-only. A reference parameter must be const-qualified
+/// and non-volatile to be accepted.
+static clang::QualType getReadOnlyParamType(const clang::ParmVarDecl *param) {
+  auto ty = param->getType();
+  if (ty->isReferenceType()) {
+    ty = ty->getPointeeType();
+    if (!ty.isConstQualified() || ty.isVolatileQualified())
+      return clang::QualType();
+  }
+  return ty;
+}
+
 // Is this an operator where both arguments take T, or const T&?
 static bool isValidBinOp(NominalTypeDecl *decl, const clang::FunctionDecl *fd) {
   if (!fd)
     return false;
   auto ty = cast<clang::TypeDecl>(decl->getClangDecl())->getTypeForDecl();
-  auto getParamTy = [](const clang::ParmVarDecl *param) {
-    auto ty = param->getType();
-    if (ty->isReferenceType()) {
-      ty = ty->getPointeeType();
-      if (!ty.isConstQualified() || ty.isVolatileQualified())
-        return clang::QualType();
-    }
-    return ty;
-  };
   if (auto method = dyn_cast<clang::CXXMethodDecl>(fd)) {
     if (method->param_size() != 1)
       return false;
     if (!method->isConst())
       return false;
 
-    auto parTy = getParamTy(fd->getParamDecl(0));
+    auto parTy = getReadOnlyParamType(fd->getParamDecl(0));
     if (parTy.isNull())
       return false;
     auto thisTy = method->getParent()->getTypeForDecl();
@@ -264,8 +269,8 @@ static bool isValidBinOp(NominalTypeDecl *decl, const clang::FunctionDecl *fd) {
   }
   if (fd->param_size() != 2)
     return false;
-  auto lhsTy = getParamTy(fd->getParamDecl(0));
-  auto rhsTy = getParamTy(fd->getParamDecl(1));
+  auto lhsTy = getReadOnlyParamType(fd->getParamDecl(0));
+  auto rhsTy = getReadOnlyParamType(fd->getParamDecl(1));
   if (lhsTy.isNull() || rhsTy.isNull())
     return false;
   return lhsTy->getCanonicalTypeUnqualified() ==
@@ -342,22 +347,13 @@ static FuncDecl *getPlusEqualOperator(NominalTypeDecl *decl) {
     if (!fd)
       return false;
     auto ty = cast<clang::TypeDecl>(decl->getClangDecl())->getTypeForDecl();
-    auto getParamTy = [](const clang::ParmVarDecl *param) {
-      auto ty = param->getType();
-      if (ty->isReferenceType()) {
-        ty = ty->getPointeeType();
-        if (!ty.isConstQualified())
-          return clang::QualType();
-      }
-      return ty;
-    };
     if (auto method = dyn_cast<clang::CXXMethodDecl>(fd)) {
       if (method->param_size() != 1)
         return false;
       if (!method->isConst())
         return false;
 
-      auto parTy = getParamTy(fd->getParamDecl(0));
+      auto parTy = getReadOnlyParamType(fd->getParamDecl(0));
       if (parTy.isNull())
         return false;
       if (!parTy->isIntegerType())
@@ -368,8 +364,8 @@ static FuncDecl *getPlusEqualOperator(NominalTypeDecl *decl) {
     }
     if (fd->param_size() != 2)
       return false;
-    auto lhsTy = getParamTy(fd->getParamDecl(0));
-    auto rhsTy = getParamTy(fd->getParamDecl(1));
+    auto lhsTy = getReadOnlyParamType(fd->getParamDecl(0));
+    auto rhsTy = getReadOnlyParamType(fd->getParamDecl(1));
     if (lhsTy.isNull() || rhsTy.isNull())
       return false;
     if (rhsTy->isIntegerType())
@@ -405,6 +401,23 @@ static FuncDecl *getPlusEqualOperator(NominalTypeDecl *decl) {
   return dyn_cast_or_null<FuncDecl>(result);
 }
 
+/// Register a synthesized declaration in the lookup tables and mark it as
+/// always visible. Declarations are added to two lookup tables (the one for
+/// the record's context and the one for its owning module) to handle the case
+/// where a C++ namespace spans across multiple Clang modules.
+static void registerSynthesizedDecl(ClangImporter::Implementation &impl,
+                                    const clang::CXXRecordDecl *classDecl,
+                                    clang::FunctionDecl *decl) {
+  impl.synthesizedAndAlwaysVisibleDecls.insert(decl);
+  auto *lookupTable1 = impl.findLookupTable(classDecl);
+  addEntryToLookupTable(*lookupTable1, decl, impl.getNameImporter());
+  auto *owningModule =
+      importer::getClangOwningModule(classDecl, classDecl->getASTContext());
+  auto *lookupTable2 = impl.findLookupTable(owningModule);
+  if (lookupTable1 != lookupTable2)
+    addEntryToLookupTable(*lookupTable2, decl, impl.getNameImporter());
+}
+
 static clang::FunctionDecl *
 instantiateTemplatedOperator(ClangImporter::Implementation &impl,
                              const clang::CXXRecordDecl *classDecl,
@@ -433,18 +446,7 @@ instantiateTemplatedOperator(ClangImporter::Implementation &impl,
                                           best)) {
   case clang::OR_Success: {
     if (auto clangCallee = best->Function) {
-      // Declarations inside of a C++ namespace are added into two lookup
-      // tables: one for the __ObjC module, one for the actual owning Clang
-      // module of the decl. This is a hack that is meant to address the case
-      // when a namespace spans across multiple Clang modules. Mimic that
-      // behavior for the operator that we just instantiated.
-      auto lookupTable1 = impl.findLookupTable(classDecl);
-      addEntryToLookupTable(*lookupTable1, clangCallee, impl.getNameImporter());
-      auto owningModule = importer::getClangOwningModule(classDecl, clangCtx);
-      auto lookupTable2 = impl.findLookupTable(owningModule);
-      if (lookupTable1 != lookupTable2)
-        addEntryToLookupTable(*lookupTable2, clangCallee, impl.getNameImporter());
-      impl.synthesizedAndAlwaysVisibleDecls.insert(clangCallee);
+      registerSynthesizedDecl(impl, classDecl, clangCallee);
       return clangCallee;
     }
     break;
@@ -491,36 +493,22 @@ static bool synthesizeCXXOperator(ClangImporter::Implementation &impl,
       returnTy, {lhsTy, rhsTy}, clang::FunctionProtoType::ExtProtoInfo());
 
   // Create a `bool operator==(T, T)` function.
-  auto equalEqualDecl = clang::FunctionDecl::Create(
-      clangCtx, declContext, clang::SourceLocation(), clang::SourceLocation(),
-      declName, equalEqualTy, clangCtx.getTrivialTypeSourceInfo(returnTy),
-      clang::StorageClass::SC_Static);
-  equalEqualDecl->setImplicit();
-  equalEqualDecl->setImplicitlyInline();
+  auto equalEqualDecl =
+      createClangFunctionDecl(clangCtx, declContext, declName, equalEqualTy);
   // If this is a static member function of a class, it needs to be public.
   equalEqualDecl->setAccess(clang::AccessSpecifier::AS_public);
 
   // Create the parameters of the function. They are not referenced from source
   // code, so they don't need to have a name.
-  auto lhsParamId = nullptr;
-  auto lhsTyInfo = clangCtx.getTrivialTypeSourceInfo(lhsTy);
-  auto lhsParamDecl = clang::ParmVarDecl::Create(
-      clangCtx, equalEqualDecl, clang::SourceLocation(),
-      clang::SourceLocation(), lhsParamId, lhsTy, lhsTyInfo,
-      clang::StorageClass::SC_None, /*DefArg*/ nullptr);
-  auto lhsParamRefExpr = new (clangCtx) clang::DeclRefExpr(
-      clangCtx, lhsParamDecl, false, lhsTy, clang::ExprValueKind::VK_LValue,
-      clang::SourceLocation());
+  auto lhsParamDecl =
+      createClangParmVarDecl(clangCtx, equalEqualDecl, nullptr, lhsTy);
+  auto lhsParamRefExpr =
+      createClangDeclRefExpr(clangCtx, lhsParamDecl, lhsTy, clang::VK_LValue);
 
-  auto rhsParamId = nullptr;
-  auto rhsTyInfo = clangCtx.getTrivialTypeSourceInfo(rhsTy);
-  auto rhsParamDecl = clang::ParmVarDecl::Create(
-      clangCtx, equalEqualDecl, clang::SourceLocation(),
-      clang::SourceLocation(), rhsParamId, rhsTy, rhsTyInfo,
-      clang::StorageClass::SC_None, nullptr);
-  auto rhsParamRefExpr = new (clangCtx) clang::DeclRefExpr(
-      clangCtx, rhsParamDecl, false, rhsTy, clang::ExprValueKind::VK_LValue,
-      clang::SourceLocation());
+  auto rhsParamDecl =
+      createClangParmVarDecl(clangCtx, equalEqualDecl, nullptr, rhsTy);
+  auto rhsParamRefExpr =
+      createClangDeclRefExpr(clangCtx, rhsParamDecl, rhsTy, clang::VK_LValue);
 
   equalEqualDecl->setParams({lhsParamDecl, rhsParamDecl});
 
@@ -542,18 +530,9 @@ static bool synthesizeCXXOperator(ClangImporter::Implementation &impl,
     return false;
   auto underlyingCall = underlyingCallResult.get();
 
-  auto equalEqualBody = clang::ReturnStmt::Create(
-      clangCtx, clang::SourceLocation(), underlyingCall, nullptr);
-  equalEqualDecl->setBody(equalEqualBody);
+  equalEqualDecl->setBody(createClangReturnStmt(clangCtx, underlyingCall));
 
-  impl.synthesizedAndAlwaysVisibleDecls.insert(equalEqualDecl);
-  auto lookupTable1 = impl.findLookupTable(classDecl);
-  addEntryToLookupTable(*lookupTable1, equalEqualDecl, impl.getNameImporter());
-  auto owningModule = importer::getClangOwningModule(classDecl, clangCtx);
-  auto lookupTable2 = impl.findLookupTable(owningModule);
-  if (lookupTable1 != lookupTable2)
-    addEntryToLookupTable(*lookupTable2, equalEqualDecl,
-                          impl.getNameImporter());
+  registerSynthesizedDecl(impl, classDecl, equalEqualDecl);
   return true;
 }
 
@@ -1296,6 +1275,51 @@ bool swift::isUnsafeStdMethod(const clang::CXXMethodDecl *methodDecl) {
   return false;
 }
 
+/// Look up the `insert(const value_type&)` overload on a C++ container.
+///
+/// C++ containers like std::set and std::map have multiple `insert` overloads.
+/// This finds the overload that takes a single `const value_type&` parameter,
+/// which maps most closely to Swift's semantics. The return type of this
+/// overload is used as the InsertionResult associated type, since there is no
+/// equivalent typedef in C++ we can use directly.
+static const clang::CXXMethodDecl *
+findInsertMethod(clang::Sema &clangSema, clang::ASTContext &clangCtx,
+                 const clang::CXXRecordDecl *clangDecl,
+                 const clang::TypeDecl *valueType) {
+  auto R = clang::LookupResult(
+      clangSema, &clangSema.PP.getIdentifierTable().get("insert"),
+      clang::SourceLocation(), clang::Sema::LookupMemberName);
+  R.suppressDiagnostics();
+  clangSema.LookupQualifiedName(
+      R, const_cast<clang::CXXRecordDecl *>(clangDecl));
+  switch (R.getResultKind()) {
+  case clang::LookupResultKind::Found:
+  case clang::LookupResultKind::FoundOverloaded:
+    break;
+  default:
+    return nullptr;
+  }
+
+  for (auto *nd : R) {
+    if (auto *insertOverload = dyn_cast<clang::CXXMethodDecl>(nd)) {
+      if (insertOverload->param_size() != 1)
+        continue;
+      auto *paramTy = (*insertOverload->param_begin())
+                          ->getType()
+                          ->getAs<clang::ReferenceType>();
+      if (!paramTy)
+        continue;
+      if (paramTy->getPointeeType()->getCanonicalTypeUnqualified() !=
+          clangCtx.getTypeDeclType(valueType)->getCanonicalTypeUnqualified())
+        continue;
+      if (!paramTy->getPointeeType().isConstQualified())
+        continue;
+      return insertOverload;
+    }
+  }
+  return nullptr;
+}
+
 static void conformToCxxSet(ClangImporter::Implementation &impl,
                             NominalTypeDecl *decl,
                             const clang::CXXRecordDecl *clangDecl,
@@ -1322,64 +1346,7 @@ static void conformToCxxSet(ClangImporter::Implementation &impl,
   if (!size_type || !value_type || !iterator || !const_iterator)
     return;
 
-  const clang::CXXMethodDecl *insert = nullptr;
-  {
-    // CxxSet requires the InsertionResult associated type, which is the return
-    // type of std::set (and co.)'s insert function. But there is no equivalent
-    // typedef in C++ we can use directly, so we need get it by converting the
-    // return type of the insert function.
-    //
-    // A wrinkle here is that std::set actually has multiple insert overloads.
-    // There are two overloads that could work for us:
-    //
-    //    insert_return_type insert(const value_type &value);
-    //    insert_return_type insert(value_type &&value);
-    //
-    // where insert_return_type is std::pair<iterator, bool> for std::set and
-    // std::unordered_set and just iterator for std::multiset.
-    //
-    // Look for the version with the single const-lref value_type parameter,
-    // since that's the one that maps to Swift's semantics most closely.
-    //
-    // NOTE: this code is a bit lengthy, and could be abstracted into a helper
-    // function, but at this time of writing, the only two times we need to look
-    // for a member is for std::set and std::map's insert methods. We keep this
-    // lookup routine inlined for now until the interface for a reasonably
-    // encapsulated helper function emerges.
-
-    auto R = clang::LookupResult(
-        clangSema, &clangSema.PP.getIdentifierTable().get("insert"),
-        clang::SourceLocation(), clang::Sema::LookupMemberName);
-    R.suppressDiagnostics();
-    clangSema.LookupQualifiedName(
-        R, const_cast<clang::CXXRecordDecl *>(clangDecl));
-    switch (R.getResultKind()) {
-    case clang::LookupResultKind::Found:
-    case clang::LookupResultKind::FoundOverloaded:
-      break;
-    default:
-      return;
-    }
-
-    for (auto *nd : R) {
-      if (auto *insertOverload = dyn_cast<clang::CXXMethodDecl>(nd)) {
-        if (insertOverload->param_size() != 1)
-          continue;
-        auto *paramTy = (*insertOverload->param_begin())
-                            ->getType()
-                            ->getAs<clang::ReferenceType>();
-        if (!paramTy)
-          continue;
-        if (paramTy->getPointeeType()->getCanonicalTypeUnqualified() !=
-            clangCtx.getTypeDeclType(value_type)->getCanonicalTypeUnqualified())
-          continue;
-        if (!paramTy->getPointeeType().isConstQualified())
-          continue;
-        insert = insertOverload; // Found the insert() we're looking for
-        break;
-      }
-    }
-  }
+  auto *insert = findInsertMethod(clangSema, clangCtx, clangDecl, value_type);
   if (!insert)
     return;
 
@@ -1475,49 +1442,7 @@ static void conformToCxxDictionary(ClangImporter::Implementation &impl,
       !const_iterator)
     return;
 
-  const clang::CXXMethodDecl *insert = nullptr;
-  {
-    // CxxDictionary requires the InsertionResult associated type, which is the
-    // return type of std::map (and co.)'s insert function. But there is no
-    // equivalent typedef in C++ we can use directly, so we need get it by
-    // converting the return type of this overload of the insert function:
-    //
-    //    insert_return_type insert(const value_type &value);
-    //
-    // See also: extended monologuing in conformToCxxSet().
-    auto R = clang::LookupResult(
-        clangSema, &clangSema.PP.getIdentifierTable().get("insert"),
-        clang::SourceLocation(), clang::Sema::LookupMemberName);
-    R.suppressDiagnostics();
-    clangSema.LookupQualifiedName(
-        R, const_cast<clang::CXXRecordDecl *>(clangDecl));
-    switch (R.getResultKind()) {
-    case clang::LookupResultKind::Found:
-    case clang::LookupResultKind::FoundOverloaded:
-      break;
-    default:
-      return;
-    }
-
-    for (auto *nd : R) {
-      if (auto *insertOverload = dyn_cast<clang::CXXMethodDecl>(nd)) {
-        if (insertOverload->param_size() != 1)
-          continue;
-        auto *paramTy = (*insertOverload->param_begin())
-                            ->getType()
-                            ->getAs<clang::ReferenceType>();
-        if (!paramTy)
-          continue;
-        if (paramTy->getPointeeType()->getCanonicalTypeUnqualified() !=
-            clangCtx.getTypeDeclType(value_type)->getCanonicalTypeUnqualified())
-          continue;
-        if (!paramTy->getPointeeType().isConstQualified())
-          continue;
-        insert = insertOverload; // Found the insert() we're looking for
-        break;
-      }
-    }
-  }
+  auto *insert = findInsertMethod(clangSema, clangCtx, clangDecl, value_type);
   if (!insert)
     return;
 
@@ -1648,9 +1573,8 @@ static void conformToCxxSpan(ClangImporter::Implementation &impl,
       pointerType, clangCtx.getTrivialTypeSourceInfo(pointerType),
       clang::StorageClass::SC_None);
 
-  auto fakePointer = new (clangCtx) clang::DeclRefExpr(
-      clangCtx, fakePointerVarDecl, false, pointerType,
-      clang::ExprValueKind::VK_LValue, clang::SourceLocation());
+  auto fakePointer = createClangDeclRefExpr(clangCtx, fakePointerVarDecl,
+                                            pointerType, clang::VK_LValue);
 
   // create fake variable for count (constructor arg 2)
   auto fakeCountVarDecl = clang::VarDecl::Create(
@@ -1659,9 +1583,8 @@ static void conformToCxxSpan(ClangImporter::Implementation &impl,
       sizeType, clangCtx.getTrivialTypeSourceInfo(sizeType),
       clang::StorageClass::SC_None);
 
-  auto fakeCount = new (clangCtx) clang::DeclRefExpr(
-      clangCtx, fakeCountVarDecl, false, sizeType,
-      clang::ExprValueKind::VK_LValue, clang::SourceLocation());
+  auto fakeCount = createClangDeclRefExpr(clangCtx, fakeCountVarDecl, sizeType,
+                                         clang::VK_LValue);
 
   // Use clangSema.BuildCxxTypeConstructExpr to create a CXXTypeConstructExpr,
   // passing constPointer and count

--- a/lib/ClangImporter/ClangSynthesizedDecls.h
+++ b/lib/ClangImporter/ClangSynthesizedDecls.h
@@ -1,0 +1,62 @@
+//===--- ClangSynthesizedDecls.h - Clang AST synthesis helpers --*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+#ifndef SWIFT_CLANG_SYNTHESIZED_DECLS_H
+#define SWIFT_CLANG_SYNTHESIZED_DECLS_H
+
+#include "clang/AST/ASTContext.h"
+#include "clang/AST/Decl.h"
+#include "clang/AST/Expr.h"
+#include "clang/AST/Stmt.h"
+
+namespace swift {
+namespace importer {
+
+inline clang::ParmVarDecl *
+createClangParmVarDecl(clang::ASTContext &ctx, clang::DeclContext *dc,
+                       clang::IdentifierInfo *nameId, clang::QualType type) {
+  auto *param = clang::ParmVarDecl::Create(
+      ctx, dc, clang::SourceLocation(), clang::SourceLocation(), nameId, type,
+      ctx.getTrivialTypeSourceInfo(type), clang::SC_None, nullptr);
+  param->setImplicit();
+  return param;
+}
+
+inline clang::DeclRefExpr *
+createClangDeclRefExpr(clang::ASTContext &ctx, clang::ValueDecl *decl,
+                       clang::QualType type,
+                       clang::ExprValueKind vk = clang::VK_PRValue) {
+  return new (ctx) clang::DeclRefExpr(ctx, decl, false, type, vk,
+                                      clang::SourceLocation());
+}
+
+inline clang::ReturnStmt *createClangReturnStmt(clang::ASTContext &ctx,
+                                                clang::Expr *expr) {
+  return clang::ReturnStmt::Create(ctx, clang::SourceLocation(), expr,
+                                   nullptr);
+}
+
+inline clang::FunctionDecl *
+createClangFunctionDecl(clang::ASTContext &ctx, clang::DeclContext *dc,
+                        clang::DeclarationName name,
+                        clang::QualType funcType) {
+  auto *decl = clang::FunctionDecl::Create(
+      ctx, dc, clang::SourceLocation(), clang::SourceLocation(), name,
+      funcType, ctx.getTrivialTypeSourceInfo(funcType), clang::SC_Static);
+  decl->setImplicit();
+  decl->setImplicitlyInline();
+  return decl;
+}
+
+} // namespace importer
+} // namespace swift
+
+#endif // SWIFT_CLANG_SYNTHESIZED_DECLS_H

--- a/lib/ClangImporter/SwiftDeclSynthesizer.cpp
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.cpp
@@ -27,6 +27,7 @@
 #include "swift/Basic/Assertions.h"
 #include "swift/Basic/SourceLoc.h"
 #include "swift/ClangImporter/ClangImporterRequests.h"
+#include "ClangSynthesizedDecls.h"
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/Attrs.inc"
 #include "clang/AST/DeclCXX.h"
@@ -45,6 +46,47 @@
 
 using namespace swift;
 using namespace importer;
+
+/// Build forwarding argument expressions for a set of clang parameters.
+/// Parameters with rvalue reference types or move-only value types are wrapped
+/// in a static_cast to preserve move semantics.
+static SmallVector<clang::Expr *> buildClangForwardingArgs(
+    clang::ASTContext &clangCtx, clang::Sema &clangSema,
+    ArrayRef<clang::ParmVarDecl *> params,
+    ClangImporter::Implementation &impl) {
+  SmallVector<clang::Expr *> args;
+  args.reserve(params.size());
+  for (auto *param : params) {
+    auto type = param->getType();
+    clang::Expr *argExpr = createClangDeclRefExpr(
+        clangCtx, param, type.getNonReferenceType(), clang::VK_LValue);
+    bool isMoveOnly =
+        !type->isReferenceType() &&
+        getCxxValueSemanticsKind(type.getTypePtr(), impl) ==
+            CxxValueSemanticsKind::MoveOnly;
+    if (type->isRValueReferenceType() || isMoveOnly) {
+      argExpr = clangSema
+                    .BuildCXXNamedCast(
+                        clang::SourceLocation(), clang::tok::kw_static_cast,
+                        clangCtx.getTrivialTypeSourceInfo(
+                            isMoveOnly ? clangCtx.getRValueReferenceType(type)
+                                       : type),
+                        argExpr, clang::SourceRange(), clang::SourceRange())
+                    .get();
+    }
+    args.push_back(argExpr);
+  }
+  return args;
+}
+
+static std::pair<BraceStmt *, bool>
+createSingleReturnBody(ASTContext &ctx, Expr *expr,
+                       bool isTypeChecked = true) {
+  auto *ret = ReturnStmt::createImplicit(ctx, expr);
+  auto *body = BraceStmt::create(ctx, SourceLoc(), ASTNode(ret), SourceLoc(),
+                                 /*implicit*/ true);
+  return {body, isTypeChecked};
+}
 
 static Argument createSelfArg(AccessorDecl *accessorDecl) {
   ASTContext &ctx = accessorDecl->getASTContext();
@@ -94,6 +136,17 @@ static DeclRefExpr *createParamRefExpr(AbstractFunctionDecl *accessorDecl,
                                             /*Implicit*/ true);
   paramRefExpr->setType(paramDecl->getTypeInContext());
   return paramRefExpr;
+}
+
+static SmallVector<Expr *>
+createForwardingParamRefExprs(AbstractFunctionDecl *funcDecl,
+                              unsigned startIdx = 0) {
+  SmallVector<Expr *> result;
+  auto count = funcDecl->getParameters()->size();
+  result.reserve(count - startIdx);
+  for (size_t idx = startIdx; idx < count; ++idx)
+    result.push_back(createParamRefExpr(funcDecl, idx));
+  return result;
 }
 
 static AccessorDecl *makeFieldGetterDecl(ClangImporter::Implementation &Impl,
@@ -412,11 +465,7 @@ synthesizeConstantGetterBody(AbstractFunctionDecl *afd, void *voidContext) {
   }
   }
 
-  // Create the return statement.
-  auto ret = ReturnStmt::createImplicit(ctx, expr);
-
-  return {BraceStmt::create(ctx, SourceLoc(), ASTNode(ret), SourceLoc()),
-          /*isTypeChecked=*/true};
+  return createSingleReturnBody(ctx, expr);
 }
 
 ValueDecl *SwiftDeclSynthesizer::createConstant(Identifier name,
@@ -563,7 +612,6 @@ synthesizeValueConstructorBody(AbstractFunctionDecl *afd, void *context) {
   auto *selfDecl = constructor->getImplicitSelfDecl();
 
   // To keep DI happy, initialize stored properties before computed.
-  auto parameters = constructor->getParameters();
   for (unsigned pass = 0; pass < 2; ++pass) {
     unsigned paramPos = 0;
 
@@ -590,9 +638,7 @@ synthesizeValueConstructorBody(AbstractFunctionDecl *afd, void *context) {
       lhs->setType(LValueType::get(var->getTypeInContext()));
 
       // Construct right-hand side.
-      auto rhs = new (ctx) DeclRefExpr(parameters->get(paramPos), DeclNameLoc(),
-                                       /*Implicit=*/true);
-      rhs->setType(parameters->get(paramPos)->getTypeInContext());
+      auto rhs = createParamRefExpr(constructor, paramPos);
 
       // Add assignment.
       auto assign = new (ctx) AssignExpr(lhs, SourceLoc(), rhs,
@@ -710,9 +756,7 @@ synthesizeRawValueBridgingConstructorBody(AbstractFunctionDecl *afd,
   // Construct right-hand side.
   // FIXME: get the parameter from the init, and plug it in here.
   auto *paramDecl = init->getParameters()->get(0);
-  auto *paramRef =
-      new (ctx) DeclRefExpr(paramDecl, DeclNameLoc(), /*Implicit=*/true);
-  paramRef->setType(paramDecl->getTypeInContext());
+  auto *paramRef = createParamRefExpr(init, 0);
 
   Expr *rhs = paramRef;
   if (!storedRawValue->getInterfaceType()->isEqual(paramDecl->getInterfaceType())) {
@@ -759,11 +803,7 @@ synthesizeAsReferenceBody(AbstractFunctionDecl *afd, void *context) {
   auto *getterImplCallExpr =
       createAccessorImplCallExpr(getterImpl, selfArg, {});
 
-  auto *returnStmt = ReturnStmt::createImplicit(ctx, getterImplCallExpr);
-
-  auto body = BraceStmt::create(ctx, SourceLoc(), {returnStmt}, SourceLoc(),
-                                /*implicit*/ true);
-  return {body, /*isTypeChecked*/ true};
+  return createSingleReturnBody(ctx, getterImplCallExpr);
 }
 
 VarDecl *SwiftDeclSynthesizer::createSmartPtrBridgingProperty(
@@ -915,33 +955,10 @@ synthesizeUnionFieldGetterBody(AbstractFunctionDecl *afd, void *context) {
                                        /*implicit*/ true);
   selfRef->setType(selfDecl->getInterfaceType());
 
-  auto reinterpretCast = cast<FuncDecl>(
-      getBuiltinValueDecl(ctx, ctx.getIdentifier("reinterpretCast")));
-
-  ConcreteDeclRef reinterpretCastRef(
-      reinterpretCast,
-      SubstitutionMap::get(
-          reinterpretCast->getGenericSignature(),
-          {selfDecl->getInterfaceType(), importedFieldDecl->getInterfaceType()},
-          LookUpConformanceInModule()));
-  auto reinterpretCastRefExpr =
-      new (ctx) DeclRefExpr(reinterpretCastRef, DeclNameLoc(),
-                            /*implicit*/ true);
-  // FIXME: Verify ExtInfo state is correct, not working by accident.
-  FunctionType::ExtInfo info;
-  reinterpretCastRefExpr->setType(
-      FunctionType::get(AnyFunctionType::Param(selfDecl->getInterfaceType()),
-                        importedFieldDecl->getInterfaceType(), info));
-
-  auto *argList = ArgumentList::forImplicitUnlabeled(ctx, {selfRef});
-  auto reinterpreted =
-      CallExpr::createImplicit(ctx, reinterpretCastRefExpr, argList);
-  reinterpreted->setType(importedFieldDecl->getInterfaceType());
-  reinterpreted->setThrows(nullptr);
-  auto *ret = ReturnStmt::createImplicit(ctx, reinterpreted);
-  auto body = BraceStmt::create(ctx, SourceLoc(), ASTNode(ret), SourceLoc(),
-                                /*implicit*/ true);
-  return {body, /*isTypeChecked*/ true};
+  auto *reinterpreted = SwiftDeclSynthesizer::synthesizeReturnReinterpretCast(
+      ctx, selfDecl->getInterfaceType(), importedFieldDecl->getInterfaceType(),
+      selfRef);
+  return createSingleReturnBody(ctx, reinterpreted);
 }
 
 /// Synthesizer for the body of a union field setter.
@@ -1060,35 +1077,21 @@ std::pair<FuncDecl *, FuncDecl *> SwiftDeclSynthesizer::makeBitFieldAccessors(
   auto cGetterType =
       Ctx.getFunctionType(fieldDecl->getType(), recordType,
                           clang::FunctionProtoType::ExtProtoInfo());
-  auto cGetterTypeInfo = Ctx.getTrivialTypeSourceInfo(cGetterType);
-  auto cGetterDecl = clang::FunctionDecl::Create(
-      Ctx, structDecl->getDeclContext(), clang::SourceLocation(),
-      clang::SourceLocation(), cGetterName, cGetterType, cGetterTypeInfo,
-      clang::SC_Static);
-  cGetterDecl->setImplicit();
-  cGetterDecl->setImplicitlyInline();
+  auto cGetterDecl = createClangFunctionDecl(Ctx, structDecl->getDeclContext(),
+                                         cGetterName, cGetterType);
   assert(!cGetterDecl->isExternallyVisible());
 
   auto getterDecl = makeFieldGetterDecl(ImporterImpl, importedStructDecl,
                                         importedFieldDecl, cGetterDecl);
 
   // Setter: static inline void set(FieldType newValue, RecordType *self);
-  SmallVector<clang::QualType, 8> cSetterParamTypes;
-  cSetterParamTypes.push_back(fieldType);
-  cSetterParamTypes.push_back(recordPointerType);
-
   auto cSetterName = getAccessorDeclarationName(Ctx, importedStructDecl,
                                                 importedFieldDecl, "setter");
   auto cSetterType = Ctx.getFunctionType(
-      Ctx.VoidTy, cSetterParamTypes, clang::FunctionProtoType::ExtProtoInfo());
-  auto cSetterTypeInfo = Ctx.getTrivialTypeSourceInfo(cSetterType);
-
-  auto cSetterDecl = clang::FunctionDecl::Create(
-      Ctx, structDecl->getDeclContext(), clang::SourceLocation(),
-      clang::SourceLocation(), cSetterName, cSetterType, cSetterTypeInfo,
-      clang::SC_Static);
-  cSetterDecl->setImplicit();
-  cSetterDecl->setImplicitlyInline();
+      Ctx.VoidTy, {fieldType, recordPointerType},
+      clang::FunctionProtoType::ExtProtoInfo());
+  auto cSetterDecl = createClangFunctionDecl(Ctx, structDecl->getDeclContext(),
+                                         cSetterName, cSetterType);
   assert(!cSetterDecl->isExternallyVisible());
 
   auto setterDecl = makeFieldSetterDecl(ImporterImpl, importedStructDecl,
@@ -1099,59 +1102,38 @@ std::pair<FuncDecl *, FuncDecl *> SwiftDeclSynthesizer::makeBitFieldAccessors(
 
   // Synthesize the getter body
   {
-    auto cGetterSelfId = nullptr;
-    auto recordTypeInfo = Ctx.getTrivialTypeSourceInfo(recordType);
-    auto cGetterSelf = clang::ParmVarDecl::Create(
-        Ctx, cGetterDecl, clang::SourceLocation(), clang::SourceLocation(),
-        cGetterSelfId, recordType, recordTypeInfo, clang::SC_None, nullptr);
-    cGetterSelf->setImplicit();
+    auto cGetterSelf =
+        createClangParmVarDecl(Ctx, cGetterDecl, nullptr, recordType);
     cGetterDecl->setParams(cGetterSelf);
 
-    auto cGetterSelfExpr = new (Ctx)
-        clang::DeclRefExpr(Ctx, cGetterSelf, false, recordType,
-                           clang::VK_PRValue, clang::SourceLocation());
+    auto cGetterSelfExpr =
+        createClangDeclRefExpr(Ctx, cGetterSelf, recordType);
     auto cGetterExpr = clang::MemberExpr::CreateImplicit(
         Ctx, cGetterSelfExpr,
         /*isarrow=*/false, fieldDecl, fieldType, clang::VK_PRValue,
         clang::OK_BitField);
 
-    auto cGetterBody = clang::ReturnStmt::Create(Ctx, clang::SourceLocation(),
-                                                 cGetterExpr, nullptr);
-    cGetterDecl->setBody(cGetterBody);
+    cGetterDecl->setBody(createClangReturnStmt(Ctx, cGetterExpr));
   }
 
   // Synthesize the setter body
   {
-    SmallVector<clang::ParmVarDecl *, 2> cSetterParams;
-    auto fieldTypeInfo = Ctx.getTrivialTypeSourceInfo(fieldType);
-    auto cSetterValue = clang::ParmVarDecl::Create(
-        Ctx, cSetterDecl, clang::SourceLocation(), clang::SourceLocation(),
-        /* nameID? */ nullptr, fieldType, fieldTypeInfo, clang::SC_None,
-        nullptr);
-    cSetterValue->setImplicit();
-    cSetterParams.push_back(cSetterValue);
-    auto recordPointerTypeInfo =
-        Ctx.getTrivialTypeSourceInfo(recordPointerType);
-    auto cSetterSelf = clang::ParmVarDecl::Create(
-        Ctx, cSetterDecl, clang::SourceLocation(), clang::SourceLocation(),
-        /* nameID? */ nullptr, recordPointerType, recordPointerTypeInfo,
-        clang::SC_None, nullptr);
-    cSetterSelf->setImplicit();
-    cSetterParams.push_back(cSetterSelf);
-    cSetterDecl->setParams(cSetterParams);
+    auto cSetterValue =
+        createClangParmVarDecl(Ctx, cSetterDecl, nullptr, fieldType);
+    auto cSetterSelf =
+        createClangParmVarDecl(Ctx, cSetterDecl, nullptr, recordPointerType);
+    cSetterDecl->setParams({cSetterValue, cSetterSelf});
 
-    auto cSetterSelfExpr = new (Ctx)
-        clang::DeclRefExpr(Ctx, cSetterSelf, false, recordPointerType,
-                           clang::VK_PRValue, clang::SourceLocation());
+    auto cSetterSelfExpr =
+        createClangDeclRefExpr(Ctx, cSetterSelf, recordPointerType);
 
     auto cSetterMemberExpr = clang::MemberExpr::CreateImplicit(
         Ctx, cSetterSelfExpr,
         /*isarrow=*/true, fieldDecl, fieldType, clang::VK_LValue,
         clang::OK_BitField);
 
-    auto cSetterValueExpr = new (Ctx)
-        clang::DeclRefExpr(Ctx, cSetterValue, false, fieldType,
-                           clang::VK_PRValue, clang::SourceLocation());
+    auto cSetterValueExpr =
+        createClangDeclRefExpr(Ctx, cSetterValue, fieldType);
 
     auto cSetterExpr = clang::BinaryOperator::Create(
         Ctx, cSetterMemberExpr, cSetterValueExpr, clang::BO_Assign, fieldType,
@@ -1206,10 +1188,7 @@ synthesizeIndirectFieldGetterBody(AbstractFunctionDecl *afd, void *context) {
                                  DeclNameLoc(), /*implicit*/ true);
   expr->setType(anonymousInnerFieldDecl->getInterfaceType());
 
-  auto *ret = ReturnStmt::createImplicit(ctx, expr);
-  auto body = BraceStmt::create(ctx, SourceLoc(), ASTNode(ret), SourceLoc(),
-                                /*implicit*/ true);
-  return {body, /*isTypeChecked=*/true};
+  return createSingleReturnBody(ctx, expr);
 }
 
 /// Synthesize the setter body for an indirect field.
@@ -1345,31 +1324,13 @@ synthesizeEnumRawValueConstructorBody(AbstractFunctionDecl *afd,
                                        /*implicit*/ true);
   selfRef->setType(LValueType::get(selfDecl->getTypeInContext()));
 
-  auto param = ctorDecl->getParameters()->get(0);
-  auto paramRef = new (ctx) DeclRefExpr(param, DeclNameLoc(),
-                                        /*implicit*/ true);
-  paramRef->setType(param->getTypeInContext());
+  auto *paramRef = createParamRefExpr(ctorDecl, 0);
 
-  auto reinterpretCast = cast<FuncDecl>(
-      getBuiltinValueDecl(ctx, ctx.getIdentifier("reinterpretCast")));
   auto rawTy = enumDecl->getRawType();
   auto enumTy = enumDecl->getDeclaredInterfaceType();
-  SubstitutionMap subMap = SubstitutionMap::get(
-      reinterpretCast->getGenericSignature(), {rawTy, enumTy},
-      LookUpConformanceInModule());
-  ConcreteDeclRef concreteDeclRef(reinterpretCast, subMap);
-  auto reinterpretCastRef =
-      new (ctx) DeclRefExpr(concreteDeclRef, DeclNameLoc(), /*implicit*/ true);
-  // FIXME: Verify ExtInfo state is correct, not working by accident.
-  FunctionType::ExtInfo info;
-  reinterpretCastRef->setType(
-      FunctionType::get({FunctionType::Param(rawTy)}, enumTy, info));
-
-  auto *argList = ArgumentList::forImplicitUnlabeled(ctx, {paramRef});
-  auto reinterpreted =
-      CallExpr::createImplicit(ctx, reinterpretCastRef, argList);
-  reinterpreted->setType(enumTy);
-  reinterpreted->setThrows(nullptr);
+  auto *reinterpreted =
+      SwiftDeclSynthesizer::synthesizeReturnReinterpretCast(
+          ctx, rawTy, enumTy, paramRef);
 
   auto assign = new (ctx) AssignExpr(selfRef, SourceLoc(), reinterpreted,
                                      /*implicit*/ true);
@@ -1417,9 +1378,7 @@ synthesizeEnumRawValueConstructorBody(AbstractFunctionDecl *afd,
                                                  {defaultLabelItem}, defaultBody);
 
     // Create the switch statement
-    auto *switchParamRef = new (ctx) DeclRefExpr(param, DeclNameLoc(),
-                                                  /*implicit*/ true);
-    switchParamRef->setType(param->getTypeInContext());
+    auto *switchParamRef = createParamRefExpr(ctorDecl, 0);
 
     auto *switchStmt = SwitchStmt::create(LabeledStmtInfo(), SourceLoc(),
                                           switchParamRef, SourceLoc(),
@@ -1484,30 +1443,32 @@ synthesizeEnumRawValueGetterBody(AbstractFunctionDecl *afd, void *context) {
                                        /*implicit*/ true);
   selfRef->setType(selfDecl->getTypeInContext());
 
-  auto reinterpretCast = cast<FuncDecl>(
-      getBuiltinValueDecl(ctx, ctx.getIdentifier("reinterpretCast")));
-  SubstitutionMap subMap = SubstitutionMap::get(
-      reinterpretCast->getGenericSignature(), {enumTy, rawTy},
-      LookUpConformanceInModule());
-  ConcreteDeclRef concreteDeclRef(reinterpretCast, subMap);
+  auto *reinterpreted =
+      SwiftDeclSynthesizer::synthesizeReturnReinterpretCast(
+          ctx, enumTy, rawTy, selfRef);
 
-  auto reinterpretCastRef =
-      new (ctx) DeclRefExpr(concreteDeclRef, DeclNameLoc(), /*implicit*/ true);
-  // FIXME: Verify ExtInfo state is correct, not working by accident.
-  FunctionType::ExtInfo info;
-  reinterpretCastRef->setType(
-      FunctionType::get({FunctionType::Param(enumTy)}, rawTy, info));
+  return createSingleReturnBody(ctx, reinterpreted);
+}
 
-  auto *argList = ArgumentList::forImplicitUnlabeled(ctx, {selfRef});
-  auto reinterpreted =
-      CallExpr::createImplicit(ctx, reinterpretCastRef, argList);
-  reinterpreted->setType(rawTy);
-  reinterpreted->setThrows(nullptr);
-
-  auto *ret = ReturnStmt::createImplicit(ctx, reinterpreted);
-  auto body = BraceStmt::create(ctx, SourceLoc(), ASTNode(ret), SourceLoc(),
-                                /*implicit*/ true);
-  return {body, /*isTypeChecked=*/true};
+static AccessorDecl *makeRawValueGetterDecl(ASTContext &C,
+                                            VarDecl *storageVar,
+                                            Type returnTy,
+                                            NominalTypeDecl *parentDecl) {
+  auto *params = ParameterList::createEmpty(C);
+  auto getterDecl = AccessorDecl::create(
+      C,
+      /*declLoc=*/SourceLoc(),
+      /*AccessorKeywordLoc=*/SourceLoc(), AccessorKind::Get, storageVar,
+      /*Async=*/false, /*AsyncLoc=*/SourceLoc(),
+      /*Throws=*/false,
+      /*ThrowsLoc=*/SourceLoc(), /*ThrownType=*/TypeLoc(),
+      params, returnTy, parentDecl);
+  getterDecl->setImplicit();
+  getterDecl->setIsObjC(false);
+  getterDecl->setIsDynamic(false);
+  getterDecl->setIsTransparent(false);
+  getterDecl->copyFormalAccessFrom(parentDecl);
+  return getterDecl;
 }
 
 // Build the rawValue getter for an imported NS_ENUM.
@@ -1520,26 +1481,9 @@ synthesizeEnumRawValueGetterBody(AbstractFunctionDecl *afd, void *context) {
 // cast in order to preserve unknown or future cases from C.
 void SwiftDeclSynthesizer::makeEnumRawValueGetter(EnumDecl *enumDecl,
                                                   VarDecl *rawValueDecl) {
-  ASTContext &C = ImporterImpl.SwiftContext;
-
-  auto rawTy = enumDecl->getRawType();
-
-  auto *params = ParameterList::createEmpty(C);
-
-  auto getterDecl = AccessorDecl::create(
-      C,
-      /*declLoc=*/SourceLoc(),
-      /*AccessorKeywordLoc=*/SourceLoc(), AccessorKind::Get, rawValueDecl,
-      /*Async=*/false, /*AsyncLoc=*/SourceLoc(),
-      /*Throws=*/false,
-      /*ThrowsLoc=*/SourceLoc(), /*ThrownType=*/TypeLoc(),
-      params, rawTy, enumDecl);
-  getterDecl->setImplicit();
-  getterDecl->setIsObjC(false);
-  getterDecl->setIsDynamic(false);
-  getterDecl->setIsTransparent(false);
-
-  getterDecl->copyFormalAccessFrom(enumDecl);
+  auto &C = ImporterImpl.SwiftContext;
+  auto getterDecl = makeRawValueGetterDecl(C, rawValueDecl,
+                                           enumDecl->getRawType(), enumDecl);
   getterDecl->setBodySynthesizer(synthesizeEnumRawValueGetterBody, enumDecl);
   ClangImporter::Implementation::makeComputed(rawValueDecl, getterDecl,
                                               nullptr);
@@ -1575,36 +1519,17 @@ synthesizeStructRawValueGetterBody(AbstractFunctionDecl *afd, void *context) {
     result = CoerceExpr::createImplicit(ctx, bridge, computedType);
   }
 
-  auto ret = ReturnStmt::createImplicit(ctx, result);
-  auto body = BraceStmt::create(ctx, SourceLoc(), ASTNode(ret), SourceLoc(),
-                                /*implicit*/ true);
-  return {body, /*isTypeChecked=*/true};
+  return createSingleReturnBody(ctx, result);
 }
 
 AccessorDecl *SwiftDeclSynthesizer::makeStructRawValueGetter(
     StructDecl *structDecl, VarDecl *computedVar, VarDecl *storedVar) {
   assert(storedVar->hasStorage());
 
-  ASTContext &C = ImporterImpl.SwiftContext;
-
-  auto *params = ParameterList::createEmpty(C);
-
-  auto computedType = computedVar->getInterfaceType();
-
-  auto getterDecl = AccessorDecl::create(
-      C,
-      /*declLoc=*/SourceLoc(),
-      /*AccessorKeywordLoc=*/SourceLoc(), AccessorKind::Get, computedVar,
-      /*Async=*/false, /*AsyncLoc=*/SourceLoc(),
-      /*Throws=*/false,
-      /*ThrowsLoc=*/SourceLoc(), /*ThrownType=*/TypeLoc(),
-      params, computedType, structDecl);
-  getterDecl->setImplicit();
-  getterDecl->setIsObjC(false);
-  getterDecl->setIsDynamic(false);
-  getterDecl->setIsTransparent(false);
-
-  getterDecl->copyFormalAccessFrom(structDecl);
+  auto &C = ImporterImpl.SwiftContext;
+  auto getterDecl = makeRawValueGetterDecl(C, computedVar,
+                                           computedVar->getInterfaceType(),
+                                           structDecl);
   getterDecl->setBodySynthesizer(synthesizeStructRawValueGetterBody, storedVar);
   return getterDecl;
 }
@@ -1698,6 +1623,7 @@ Expr *SwiftDeclSynthesizer::synthesizeReturnReinterpretCast(ASTContext &ctx,
   ConcreteDeclRef concreteDeclRef(reinterpretCast, subMap);
   auto reinterpretCastRef =
       new (ctx) DeclRefExpr(concreteDeclRef, DeclNameLoc(), /*implicit*/ true);
+  // FIXME: Verify ExtInfo state is correct, not working by accident.
   FunctionType::ExtInfo info;
   reinterpretCastRef->setType(
       FunctionType::get({FunctionType::Param(givenType)}, exprType, info));
@@ -1723,10 +1649,7 @@ synthesizeUnwrappingGetterOrAddressGetterBody(AbstractFunctionDecl *afd,
   ASTContext &ctx = getterDecl->getASTContext();
 
   auto selfArg = createSelfArg(getterDecl);
-  SmallVector<Expr *> arguments;
-  for (size_t idx = 0, end = getterDecl->getParameters()->size(); idx < end;
-       ++idx)
-    arguments.push_back(createParamRefExpr(getterDecl, idx));
+  auto arguments = createForwardingParamRefExprs(getterDecl);
 
   Type elementTy = getterDecl->getResultInterfaceType();
 
@@ -1766,11 +1689,7 @@ synthesizeUnwrappingGetterOrAddressGetterBody(AbstractFunctionDecl *afd,
     propertyExpr = SwiftDeclSynthesizer::synthesizeReturnReinterpretCast(
         ctx, getterImpl->getResultInterfaceType(), elementTy, propertyExpr);
 
-  auto *returnStmt = ReturnStmt::createImplicit(ctx, propertyExpr);
-
-  auto body = BraceStmt::create(ctx, SourceLoc(), {returnStmt}, SourceLoc(),
-                                /*implicit*/ true);
-  return {body, /*isTypeChecked*/ true};
+  return createSingleReturnBody(ctx, propertyExpr);
 }
 
 static std::pair<BraceStmt *, bool>
@@ -1797,10 +1716,7 @@ synthesizeUnwrappingSetterBody(AbstractFunctionDecl *afd, void *context) {
 
   auto selfArg = createSelfArg(setterDecl);
   DeclRefExpr *valueParamRefExpr = createParamRefExpr(setterDecl, 0);
-  SmallVector<Expr *> arguments;
-  for (size_t idx = 1, end = setterDecl->getParameters()->size(); idx < end;
-       ++idx)
-    arguments.push_back(createParamRefExpr(setterDecl, idx));
+  auto arguments = createForwardingParamRefExprs(setterDecl, /*startIdx=*/1);
 
   Type elementTy = valueParamRefExpr->getDecl()->getInterfaceType();
 
@@ -1841,20 +1757,12 @@ synthesizeUnwrappingAddressSetterBody(AbstractFunctionDecl *afd,
   ASTContext &ctx = setterDecl->getASTContext();
 
   auto selfArg = createSelfArg(setterDecl);
-  SmallVector<Expr *> arguments;
-  arguments.reserve(setterDecl->getParameters()->size());
-  for (size_t idx = 0, end = setterDecl->getParameters()->size(); idx < end;
-       ++idx)
-    arguments.push_back(createParamRefExpr(setterDecl, idx));
+  auto arguments = createForwardingParamRefExprs(setterDecl);
 
   auto *setterImplCallExpr =
       createAccessorImplCallExpr(setterImpl, selfArg, arguments);
 
-  auto *returnStmt = ReturnStmt::createImplicit(ctx, setterImplCallExpr);
-
-  auto body = BraceStmt::create(ctx, SourceLoc(), {returnStmt}, SourceLoc(),
-                                /*implicit*/ true);
-  return {body, /*isTypeChecked*/ true};
+  return createSingleReturnBody(ctx, setterImplCallExpr);
 }
 
 SubscriptDecl *SwiftDeclSynthesizer::makeSubscript(FuncDecl *getter,
@@ -2228,11 +2136,7 @@ synthesizeOperatorMethodBody(AbstractFunctionDecl *afd, void *context) {
   callExpr->setType(funcDecl->getResultInterfaceType());
   callExpr->setThrows(nullptr);
 
-  auto *returnStmt = ReturnStmt::createImplicit(ctx, callExpr);
-
-  auto body = BraceStmt::create(ctx, SourceLoc(), {returnStmt}, SourceLoc(),
-                                /*implicit*/ true);
-  return {body, /*isTypeChecked*/ true};
+  return createSingleReturnBody(ctx, callExpr);
 }
 
 clang::CXXMethodDecl *SwiftDeclSynthesizer::synthesizeCXXForwardingMethod(
@@ -2443,28 +2347,8 @@ clang::CXXMethodDecl *SwiftDeclSynthesizer::synthesizeCXXForwardingMethod(
                                   clang::AS_public),
       /*HadMultipleCandidates=*/false, method->getNameInfo(),
       memberExprTy, clang::VK_PRValue, clang::OK_Ordinary);
-  llvm::SmallVector<clang::Expr *, 4> args;
-  for (auto *param : newMethod->parameters()) {
-    auto type = param->getType();
-    clang::Expr *argExpr = new (clangCtx) clang::DeclRefExpr(
-        clangCtx, param, false, type.getNonReferenceType(),
-        clang::ExprValueKind::VK_LValue, clang::SourceLocation());
-    bool isMoveOnly =
-        !type->isReferenceType() &&
-        getCxxValueSemanticsKind(type.getTypePtr(), ImporterImpl) ==
-            CxxValueSemanticsKind::MoveOnly;
-    if (type->isRValueReferenceType() || isMoveOnly) {
-      argExpr = clangSema
-                    .BuildCXXNamedCast(
-                        clang::SourceLocation(), clang::tok::kw_static_cast,
-                        clangCtx.getTrivialTypeSourceInfo(
-                            isMoveOnly ? clangCtx.getRValueReferenceType(type)
-                                       : type),
-                        argExpr, clang::SourceRange(), clang::SourceRange())
-                    .get();
-    }
-    args.push_back(argExpr);
-  }
+  auto args = buildClangForwardingArgs(clangCtx, clangSema,
+                                       newMethod->parameters(), ImporterImpl);
   auto memberCall = clangSema.BuildCallExpr(
       nullptr, memberExpr, clang::SourceLocation(), args,
       clang::SourceLocation());
@@ -2625,10 +2509,7 @@ synthesizeComputedGetterFromCXXMethod(AbstractFunctionDecl *afd,
 
   auto *getterImplCallExpr = createAccessorImplCallExpr(method, selfArg, {});
   auto &ctx = method->getASTContext();
-  auto *returnStmt = ReturnStmt::createImplicit(ctx, getterImplCallExpr);
-  auto *body = BraceStmt::create(ctx, SourceLoc(), {returnStmt}, SourceLoc());
-
-  return {body, /*isTypeChecked*/ true};
+  return createSingleReturnBody(ctx, getterImplCallExpr);
 }
 
 static std::pair<BraceStmt *, bool>
@@ -2749,17 +2630,12 @@ synthesizeDefaultArgumentBody(AbstractFunctionDecl *afd, void *context) {
       clangParamTy, {}, clang::FunctionProtoType::ExtProtoInfo());
 
   // Synthesize `return {default expr};`.
-  auto defaultArgReturnStmt = clang::ReturnStmt::Create(
-      clangCtx, clang::SourceLocation(), defaultArgCallExpr.get(), nullptr);
+  auto defaultArgReturnStmt =
+      createClangReturnStmt(clangCtx, defaultArgCallExpr.get());
 
   // Synthesize `ParamTy __cxx__defaultArg_XYZ() { return {default expr}; }`.
-  auto defaultArgFuncDecl = clang::FunctionDecl::Create(
-      clangCtx, clangDeclContext, clang::SourceLocation(),
-      clang::SourceLocation(), clangDeclName, funcTy,
-      clangCtx.getTrivialTypeSourceInfo(clangParamTy),
-      clang::StorageClass::SC_Static);
-  defaultArgFuncDecl->setImplicit();
-  defaultArgFuncDecl->setImplicitlyInline();
+  auto defaultArgFuncDecl =
+      createClangFunctionDecl(clangCtx, clangDeclContext, clangDeclName, funcTy);
   defaultArgFuncDecl->setAccess(clang::AccessSpecifier::AS_public);
   defaultArgFuncDecl->setBody(defaultArgReturnStmt);
 
@@ -2780,11 +2656,7 @@ synthesizeDefaultArgumentBody(AbstractFunctionDecl *afd, void *context) {
   initCall->setThrows(nullptr);
 
   // Synthesize `return __cxx__defaultArg_XYZ()`.
-  auto *returnStmt = ReturnStmt::createImplicit(ctx, initCall);
-
-  auto body = BraceStmt::create(ctx, SourceLoc(), {returnStmt}, SourceLoc(),
-                                /*implicit=*/true);
-  return {body, /*isTypeChecked=*/true};
+  return createSingleReturnBody(ctx, initCall);
 }
 
 CallExpr *
@@ -2935,9 +2807,8 @@ synthesizeFunctionConstructorBody(AbstractFunctionDecl *afd, void *context) {
       clang::SourceLocation(), clang::SourceLocation(), /*Id*/ nullptr,
       wrapperClangType, clangCtx.getTrivialTypeSourceInfo(wrapperClangType),
       clang::StorageClass::SC_None);
-  auto fakeWrapperRefExpr = new (clangCtx) clang::DeclRefExpr(
-      clangCtx, fakeWrapperVarDecl, false, wrapperClangType,
-      clang::ExprValueKind::VK_LValue, clang::SourceLocation());
+  auto fakeWrapperRefExpr = createClangDeclRefExpr(
+      clangCtx, fakeWrapperVarDecl, wrapperClangType, clang::VK_LValue);
 
   auto functionTypeClangType = clangCtx.getRecordType(functionTypeClangDecl);
   auto functionTypeClangInfo =
@@ -3230,24 +3101,8 @@ SwiftDeclSynthesizer::synthesizeStaticFactoryForCXXForeignRef(
     synthCxxMethodDecl->addAttr(
         clang::SwiftNameAttr::Create(clangCtx, swiftInitStr));
 
-    llvm::SmallVector<clang::Expr *, 4> ctorArgs;
-    for (auto *param : synthParams) {
-      clang::QualType paramTy = param->getType();
-      clang::QualType exprTy = paramTy.getNonReferenceType();
-      clang::Expr *argExpr = clang::DeclRefExpr::Create(
-          clangCtx, clang::NestedNameSpecifierLoc(), param->getBeginLoc(),
-          param, /*RefersToEnclosingVariableOrCapture=*/false,
-          param->getEndLoc(), exprTy, clang::VK_LValue);
-      if (paramTy->isRValueReferenceType()) {
-        argExpr = clangSema
-                      .BuildCXXNamedCast(
-                          clang::SourceLocation(), clang::tok::kw_static_cast,
-                          clangCtx.getTrivialTypeSourceInfo(paramTy), argExpr,
-                          clang::SourceRange(), clang::SourceRange())
-                      .get();
-      }
-      ctorArgs.push_back(argExpr);
-    }
+    auto ctorArgs = buildClangForwardingArgs(clangCtx, clangSema, synthParams,
+                                             ImporterImpl);
     llvm::SmallVector<clang::Expr *, 4> ctorArgsToAdd;
 
     if (clangSema.CompleteConstructorCall(
@@ -3279,8 +3134,7 @@ SwiftDeclSynthesizer::synthesizeStaticFactoryForCXXForeignRef(
     auto *synthNewExpr = cast<clang::CXXNewExpr>(synthNewExprResult.get());
 
     clang::ReturnStmt *synthRetStmt =
-        clang::ReturnStmt::Create(clangCtx, clang::SourceLocation(),
-                                  synthNewExpr, /*NRVOCandidate=*/nullptr);
+        createClangReturnStmt(clangCtx, synthNewExpr);
     assert(synthRetStmt && "Unable to synthesize return statement for "
                            "static factory of c++ foreign reference type");
 
@@ -3318,8 +3172,8 @@ synthesizeAvailabilityDomainPredicateBody(AbstractFunctionDecl *afd,
   // Clang provided the predicate function decl directly, rather than a call
   // expression that must be wrapped in a function.
   // Synthesize `return {domain predicate expression}`.
-  auto clangHelperReturnStmt = clang::ReturnStmt::Create(
-      clangCtx, clang::SourceLocation(), domainInfo.second.Call, nullptr);
+  auto clangHelperReturnStmt =
+      createClangReturnStmt(clangCtx, domainInfo.second.Call);
 
   // Synthesize `int __XYZ_isAvailable() { return {predicate expr}; }`.
   auto clangDeclName = clang::DeclarationName(
@@ -3329,13 +3183,8 @@ synthesizeAvailabilityDomainPredicateBody(AbstractFunctionDecl *afd,
       clangCtx.getFunctionType(domainInfo.second.Call->getType(), {},
                                clang::FunctionProtoType::ExtProtoInfo());
 
-  auto clangHelperFuncDecl = clang::FunctionDecl::Create(
-      clangCtx, clangDeclContext, clang::SourceLocation(),
-      clang::SourceLocation(), clangDeclName, funcTy,
-      clangCtx.getTrivialTypeSourceInfo(funcTy),
-      clang::StorageClass::SC_Static);
-  clangHelperFuncDecl->setImplicit();
-  clangHelperFuncDecl->setImplicitlyInline();
+  auto clangHelperFuncDecl =
+      createClangFunctionDecl(clangCtx, clangDeclContext, clangDeclName, funcTy);
   clangHelperFuncDecl->setBody(clangHelperReturnStmt);
 
   // Import `func __XYZ_isAvailable() -> Bool` into Swift.
@@ -3359,11 +3208,7 @@ synthesizeAvailabilityDomainPredicateBody(AbstractFunctionDecl *afd,
       UnresolvedDotExpr::createImplicit(ctx, helperCall, ctx.Id_value_);
 
   // Synthesize `return __XYZ_isAvailable()._value`.
-  auto *returnStmt = ReturnStmt::createImplicit(ctx, memberRef);
-  auto body = BraceStmt::create(ctx, SourceLoc(), {returnStmt}, SourceLoc(),
-                                /*implicit=*/true);
-
-  return {body, /*isTypeChecked=*/false};
+  return createSingleReturnBody(ctx, memberRef, /*isTypeChecked=*/false);
 }
 
 /// Mark the given declaration as always deprecated for the given reason.


### PR DESCRIPTION
This reduces the code size and also standardizes code. In some cases we fixed a bug at one version of the "inlined helper" but not at the other. Hopefully, the deduplicated code makes it less likely that we run into similar situations.
