### PR TITLE
utils: rename `Build-SDK` to `Build-LegacySDK`

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -3399,7 +3399,7 @@ function Install-SDK([Hashtable[]] $Platforms, [OS] $OS = $Platforms[0].OS, [str
   }
 }
 
-function Build-SDK([Hashtable] $Platform) {
+function Build-LegacySDK([Hashtable] $Platform) {
   # Third Party Dependencies
   Invoke-BuildStep Build-LLVM $Platform
 
@@ -4356,7 +4356,7 @@ if (-not $SkipBuild) {
         Windows {
           $SDKROOT = Get-SwiftSDK -OS Windows -Identifier Windows
           foreach ($Build in $WindowsSDKBuilds) {
-            Invoke-BuildStep Build-SDK $Build
+            Invoke-BuildStep Build-LegacySDK $Build
 
             ConvertTo-ThickLayout -Platform $Build -Resources "${SDKROOT}\usr\lib\swift\windows" -Filter @("*.lib")
 
@@ -4418,7 +4418,7 @@ if (-not $SkipBuild) {
         Android {
           $SDKROOT = Get-SwiftSDK -OS Android -Identifier Android
           foreach ($Build in $AndroidSDKBuilds) {
-            Invoke-BuildStep Build-SDK $Build
+            Invoke-BuildStep Build-LegacySDK $Build
 
             ConvertTo-ThickLayout -Platform $Build -Resources "${SDKROOT}\usr\lib\swift\android" -Filter @("*.a", "*.so")
           }


### PR DESCRIPTION
This is preparatory work to allow us to build multiple "experimental"-style SDKs for bootstrapping.

- **Explanation**: Mark the legacy SDK to allow us to stage the path forward for the experimental SDK promotion
- **Scope**: Jut changes the function name to clean up the namespace
- **Issues**:
- **Risk**: very low, this just is a naming change in the build script
- **Testing**: built a toolchain