### PR TITLE
IRGen: Skip emitting reflection metadata for enum elements that don't exist at runtime

### DIFF
--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -6429,6 +6429,7 @@ EnumImplStrategy::get(TypeConverter &TC, SILType type, EnumDecl *theEnum) {
   // fixed-size from this resilience scope.
   ResilienceExpansion layoutScope =
       TC.IGM.getResilienceExpansionForLayout(theEnum);
+  // TODO: [availability] Only enumerate the elements available during lowering.
   for (auto elt : theEnum->getAllElements()) {
     ++numElements;
 

--- a/lib/IRGen/GenReflection.cpp
+++ b/lib/IRGen/GenReflection.cpp
@@ -916,8 +916,8 @@ public:
 private:
   const NominalTypeDecl *NTD;
 
-  void addField(reflection::FieldRecordFlags flags,
-                Type type, StringRef name) {
+  void addField(reflection::FieldRecordFlags flags, Type type,
+                std::optional<StringRef> name) {
     B.addInt32(flags.getRawValue());
 
     if (!type) {
@@ -940,8 +940,8 @@ private:
       }
     }
 
-    if (IGM.IRGen.Opts.EnableReflectionNames) {
-      auto fieldName = IGM.getAddrOfFieldName(name);
+    if (IGM.IRGen.Opts.EnableReflectionNames && name) {
+      auto fieldName = IGM.getAddrOfFieldName(*name);
       B.addRelativeAddress(fieldName);
     } else {
       B.addInt32(0);
@@ -1003,11 +1003,13 @@ private:
     if (hasPayload && (decl->isIndirect() || enumDecl->isIndirect()))
       flags.setIsIndirectCase();
 
-    Type interfaceType = decl->isAvailableDuringLowering()
-                             ? decl->getPayloadInterfaceType()
-                             : nullptr;
-
-    addField(flags, interfaceType, decl->getBaseIdentifier().str());
+    // TODO: [availability] Unavailable elements should be skipped entirely.
+    if (decl->isAvailableDuringLowering()) {
+      addField(flags, decl->getPayloadInterfaceType(),
+               decl->getBaseIdentifier().str());
+    } else {
+      addField(flags, Type(), std::nullopt);
+    }
   }
 
   void layoutEnum() {

--- a/test/IRGen/availability_custom_domains_metadata.swift
+++ b/test/IRGen/availability_custom_domains_metadata.swift
@@ -1,0 +1,220 @@
+// DEFINE: %{frontend-flags} = \
+// DEFINE:   -module-name Test \
+// DEFINE:   -enable-experimental-feature CustomAvailability \
+// DEFINE:   -define-enabled-availability-domain EnabledDomain \
+// DEFINE:   -define-disabled-availability-domain DisabledDomain \
+// DEFINE:   -define-dynamic-availability-domain DynamicDomain
+
+// RUN: %target-swift-emit-irgen %{frontend-flags} %s -verify \
+// RUN:   -Onone > %t.Onone.ir
+
+// RUN: %target-swift-emit-irgen %{frontend-flags} %s -verify \
+// RUN:   -Onone -enable-library-evolution > %t.Onone-evo.ir
+
+// RUN: %target-swift-emit-irgen %{frontend-flags} %s -verify \
+// RUN:   -O > %t.O.ir
+
+// RUN: %FileCheck %s --check-prefixes=CHECK-REFLECTION --input-file=%t.Onone.ir
+// RUN: %FileCheck %s --check-prefixes=CHECK-REFLECTION --input-file=%t.Onone-evo.ir
+// RUN: %FileCheck %s --check-prefixes=CHECK-REFLECTION --input-file=%t.O.ir
+
+// RUN: %FileCheck %s --check-prefixes=CHECK-NEGATIVE --input-file=%t.Onone.ir
+// RUN: %FileCheck %s --check-prefixes=CHECK-NEGATIVE --input-file=%t.Onone-evo.ir
+// RUN: %FileCheck %s --check-prefixes=CHECK-NEGATIVE --input-file=%t.O.ir
+
+// RUN: %FileCheck %s --check-prefixes=CHECK-METADATA --input-file=%t.Onone.ir
+// RUN: %FileCheck %s --check-prefixes=CHECK-METADATA --input-file=%t.Onone-evo.ir
+// RUN: %FileCheck %s --check-prefixes=CHECK-METADATA --input-file=%t.O.ir
+
+// RUN: %FileCheck %s --check-prefixes=CHECK-WITNESS --input-file=%t.Onone.ir
+// RUN: %FileCheck %s --check-prefixes=CHECK-WITNESS --input-file=%t.Onone-evo.ir
+// RUN: %FileCheck %s --check-prefixes=CHECK-WITNESS --input-file=%t.O.ir
+
+// RUN: %FileCheck %s --check-prefixes=CHECK-DESCRIPTOR --input-file=%t.Onone.ir
+// RUN: %FileCheck %s --check-prefixes=CHECK-DESCRIPTOR --input-file=%t.Onone-evo.ir
+// RUN: %FileCheck %s --check-prefixes=CHECK-DESCRIPTOR --input-file=%t.O.ir
+
+// RUN: %FileCheck %s --check-prefixes=CHECK-DESCRIPTOR-STORED --input-file=%t.Onone.ir
+// RUN: %FileCheck %s --check-prefixes=CHECK-DESCRIPTOR-STORED --input-file=%t.Onone-evo.ir
+// RUN: %FileCheck %s --check-prefixes=CHECK-DESCRIPTOR-STORED --input-file=%t.O.ir
+
+// REQUIRES: swift_feature_CustomAvailability
+
+// Every type/member in this test that should be skipped during codegen has
+// either "disabled" or "Disabled" in the name.
+// CHECK-NEGATIVE-NOT: disabled
+// CHECK-NEGATIVE-NOT: Disabled
+
+// CHECK-METADATA: @"$s4Test19AlwaysAvailableEnumOMf" = internal constant
+// CHECK-WITNESS: @"$s4Test19AlwaysAvailableEnumOWV" = internal constant
+public enum AlwaysAvailableEnum {
+  // CHECK-REFLECTION: constant [15 x i8] c"enabledElement\00"
+  @available(EnabledDomain)
+  case enabledElement
+
+  // CHECK-REFLECTION-NOT: constant [16 x i8] c"disabledElement\00"
+  @available(DisabledDomain)
+  case disabledElement
+
+  // CHECK-REFLECTION: constant [15 x i8] c"dynamicElement\00"
+  @available(DynamicDomain)
+  case dynamicElement
+
+  // CHECK-REFLECTION-NOT: constant [26 x i8] c"disabledAndEnabledElement\00"
+  @available(EnabledDomain)
+  @available(DisabledDomain)
+  case disabledAndEnabledElement
+}
+
+// CHECK-METADATA: @"$s4Test11EnabledEnumOMf" = internal constant
+// CHECK-WITNESS: @"$s4Test11EnabledEnumOWV" = internal constant
+@available(EnabledDomain)
+public enum EnabledEnum {
+  // CHECK-REFLECTION: constant [19 x i8] c"enabledEnumElement\00"
+  case enabledEnumElement
+}
+
+// CHECK-METADATA-NOT: @"$s4Test12DisabledEnumO
+// CHECK-WITNESS-NOT: @"$s4Test12DisabledEnumO
+@available(DisabledDomain)
+public enum DisabledEnum {
+  // CHECK-REFLECTION-NOT: constant [20 x i8] c"disabledEnumElement\00"
+  case disabledEnumElement
+}
+
+// CHECK-METADATA: @"$s4Test11DynamicEnumOMf" = internal constant
+// CHECK-WITNESS: @"$s4Test11DynamicEnumOWV" = internal constant
+@available(DynamicDomain)
+public enum DynamicEnum {
+  // CHECK-REFLECTION: constant [19 x i8] c"dynamicEnumElement\00"
+  case dynamicEnumElement
+}
+
+// CHECK-METADATA-NOT: @"$s4Test22DisabledAndEnabledEnumO
+// CHECK-WITNESS-NOT: @"$s4Test22DisabledAndEnabledEnumO
+@available(EnabledDomain)
+@available(DisabledDomain)
+public enum DisabledAndEnabledEnum {
+  // CHECK-REFLECTION-NOT: constant [30 x i8] c"disabledAndEnabledEnumElement\00"
+  case disabledAndEnabledEnumElement
+}
+
+// CHECK-METADATA: @"$s4Test21AlwaysAvailableStructVMf" = internal constant
+// CHECK-WITNESS: @"$s4Test21AlwaysAvailableStructVWV" = internal constant
+public struct AlwaysAvailableStruct {
+  // CHECK-REFLECTION: constant [32 x i8] c"alwaysAvailableStructStoredProp\00"
+  // CHECK-DESCRIPTOR-STORED: @"$s4Test21AlwaysAvailableStructV06alwayscD10StoredPropSiSgvpMV"
+  public var alwaysAvailableStructStoredProp: Int? = nil
+
+  // CHECK-DESCRIPTOR: @"$s4Test21AlwaysAvailableStructV07enabledD12ComputedPropSivpMV"
+  @available(EnabledDomain)
+  public var enabledStructComputedProp: Int { 0 }
+
+  // CHECK-DESCRIPTOR-NOT: @"$s4Test21AlwaysAvailableStructV08disabledD12ComputedProp
+  @available(DisabledDomain)
+  public var disabledStructComputedProp: Int { 0 }
+
+  // CHECK-DESCRIPTOR: @"$s4Test21AlwaysAvailableStructV07dynamicD12ComputedPropSivpMV"
+  @available(DynamicDomain)
+  public var dynamicStructComputedProp: Int { 0 }
+}
+
+// CHECK-METADATA: @"$s4Test13EnabledStructVMf" = internal constant
+// CHECK-WITNESS: @"$s4Test13EnabledStructVWV" = internal constant
+@available(EnabledDomain)
+public struct EnabledStruct {
+  // CHECK-REFLECTION: constant [24 x i8] c"enabledStructStoredProp\00"
+  // CHECK-DESCRIPTOR-STORED: @"$s4Test13EnabledStructV07enabledC10StoredPropSiSgvpMV"
+  public var enabledStructStoredProp: Int? = nil
+}
+
+// CHECK-METADATA-NOT: @"$s4Test14DisabledStructV
+// CHECK-WITNESS-NOT: @"$s4Test14DisabledStructV
+// CHECK-DESCRIPTOR-STORED-NOT: @"$s4Test14DisabledStructV
+@available(DisabledDomain)
+public struct DisabledStruct {
+  // CHECK-REFLECTION-NOT: constant [25 x i8] c"disabledStructStoredProp\00"
+  public var disabledStructStoredProp: Int? = nil
+}
+
+// CHECK-METADATA: @"$s4Test13DynamicStructVMf" = internal constant
+// CHECK-WITNESS: @"$s4Test13DynamicStructVWV" = internal constant
+@available(DynamicDomain)
+public struct DynamicStruct {
+  // CHECK-REFLECTION: constant [24 x i8] c"dynamicStructStoredProp\00"
+  // CHECK-DESCRIPTOR-STORED: @"$s4Test13DynamicStructV07dynamicC10StoredPropSiSgvpMV"
+  public var dynamicStructStoredProp: Int? = nil
+}
+
+// CHECK-METADATA-NOT: @"$s4Test24DisabledAndEnabledStructV
+// CHECK-WITNESS-NOT: @"$s4Test24DisabledAndEnabledStructV
+// CHECK-DESCRIPTOR-STORED-NOT: @"$s4Test24DisabledAndEnabledStructV
+@available(EnabledDomain)
+@available(DisabledDomain)
+public struct DisabledAndEnabledStruct {
+  // CHECK-REFLECTION-NOT: constant [35 x i8] c"disabledAndEnabledStructStoredProp\00"
+  public var disabledAndEnabledStructStoredProp: Int? = nil
+}
+
+// CHECK-METADATA: @"$s4Test20AlwaysAvailableClassCMf" = internal global
+// CHECK-WITNESS: define {{.*}}@"$s4Test20AlwaysAvailableClassCfD"
+// CHECK-DESCRIPTOR-STORED: @"$s4Test20AlwaysAvailableClassC06alwayscD10StoredPropSivpMV"
+public class AlwaysAvailableClass {
+  // CHECK-REFLECTION: constant [31 x i8] c"alwaysAvailableClassStoredProp\00"
+  public var alwaysAvailableClassStoredProp: Int = 0
+
+  // CHECK-DESCRIPTOR: @"$s4Test20AlwaysAvailableClassC07enabledD12ComputedPropSivpMV"
+  @available(EnabledDomain)
+  public var enabledClassComputedProp: Int { 0 }
+
+  // CHECK-DESCRIPTOR-NOT: @"$s4Test20AlwaysAvailableClassC08disabledD12ComputedProp
+  @available(DisabledDomain)
+  public var disabledClassComputedProp: Int { 0 }
+
+  // CHECK-DESCRIPTOR: @"$s4Test20AlwaysAvailableClassC07dynamicD12ComputedPropSivpMV"
+  @available(DynamicDomain)
+  public var dynamicClassComputedProp: Int { 0 }
+
+  public init() { }
+}
+
+// CHECK-METADATA: @"$s4Test12EnabledClassCMf" = internal global
+// CHECK-WITNESS: define {{.*}}@"$s4Test12EnabledClassCfD"
+// CHECK-DESCRIPTOR-STORED: @"$s4Test12EnabledClassC07enabledC10StoredPropSivpMV"
+@available(EnabledDomain)
+public class EnabledClass {
+  // CHECK-REFLECTION: constant [23 x i8] c"enabledClassStoredProp\00"
+  public var enabledClassStoredProp: Int = 0
+  public init() { }
+}
+
+// CHECK-METADATA-NOT: @"$s4Test13DisabledClassC
+// CHECK-WITNESS-NOT: @"$s4Test13DisabledClassCfD"
+// CHECK-DESCRIPTOR-STORED-NOT: @"$s4Test13DisabledClassC
+@available(DisabledDomain)
+public class DisabledClass {
+  // CHECK-REFLECTION-NOT: constant [24 x i8] c"disabledClassStoredProp\00"
+  public var disabledClassStoredProp: Int = 0
+  public init() { }
+}
+
+// CHECK-METADATA: @"$s4Test12DynamicClassCMf" = internal global
+// CHECK-WITNESS: define {{.*}}@"$s4Test12DynamicClassCfD"
+// CHECK-DESCRIPTOR-STORED: @"$s4Test12DynamicClassC07dynamicC10StoredPropSivpMV"
+@available(DynamicDomain)
+public class DynamicClass {
+  // CHECK-REFLECTION: constant [23 x i8] c"dynamicClassStoredProp\00"
+  public var dynamicClassStoredProp: Int = 0
+  public init() { }
+}
+
+// CHECK-METADATA-NOT: @"$s4Test23DisabledAndEnabledClassC
+// CHECK-WITNESS-NOT: @"$s4Test23DisabledAndEnabledClassCfD"
+// CHECK-DESCRIPTOR-STORED-NOT: @"$s4Test23DisabledAndEnabledClassC
+@available(EnabledDomain)
+@available(DisabledDomain)
+public class DisabledAndEnabledClass {
+  // CHECK-REFLECTION-NOT: constant [34 x i8] c"disabledAndEnabledClassStoredProp\00"
+  public var disabledAndEnabledClassStoredProp: Int = 0
+  public init() { }
+}

--- a/test/IRGen/unavailable_decl_optimization_complete_enum.swift
+++ b/test/IRGen/unavailable_decl_optimization_complete_enum.swift
@@ -6,8 +6,8 @@
 
 // CHECK: private constant [27 x i8] c"availableEnumAvailableCase\00"
 
-// FIXME: Should this reflection metadata for an unavailable case be stripped?
-// CHECK: private constant [29 x i8] c"availableEnumUnavailableCase\00"
+// CHECK-NO-STRIP-RESILIENT: private constant [29 x i8] c"availableEnumUnavailableCase\00"
+// CHECK-STRIP-RESILIENT-NOT: availableEnumUnavailableCase
 
 // CHECK-NO-STRIP-RESILIENT: @"$s4Test13AvailableEnumO09availableC34UnavailableCaseWithAssociatedValueyAcA0E6StructVcACmFWC" = {{.*}}constant
 // CHECK-STRIP-RESILIENT-NOT: @"$s4Test13AvailableEnumO09availableC34UnavailableCaseWithAssociatedValueyAcA0E6StructVcACmFWC" =

--- a/test/Misc/verify-swift-feature-testing.test-sh
+++ b/test/Misc/verify-swift-feature-testing.test-sh
@@ -102,7 +102,7 @@ def check_test_file(file_path, lines, existing_swift_features):
 def find_matches(swift_src_root):
     # Look for every `REQUIRES` line that mentions `swift_feature_` in the
     # test directories.
-    # Look for every `RUN` line that mentions `-enable-experimental-feature` or
+    # Look for every `RUN` or `DEFINE` line that mentions `-enable-experimental-feature` or
     # `-enable-upcoming-feature` in the test directories.
     output = subprocess.check_output(
         [
@@ -120,6 +120,10 @@ def find_matches(swift_src_root):
             # Be careful to not use RUN with a colon after it or Lit will pick
             # it up.
             "RUN[:].*-enable-(experimental|upcoming)-feature",
+            "-e",
+            # Be careful to not use DEFINE with a colon after it or Lit will pick
+            # it up.
+            "DEFINE[:].*-enable-(experimental|upcoming)-feature",
             "--",
             "test",
             "validation-test",

--- a/test/Reflection/availability_custom_domains.swift
+++ b/test/Reflection/availability_custom_domains.swift
@@ -1,0 +1,148 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-build-swift \
+// RUN:   -target %target-swift-5.2-abi-triple \
+// RUN:   -parse-as-library -emit-module -emit-library \
+// RUN:   -module-name Test \
+// RUN:   -enable-experimental-feature CustomAvailability \
+// RUN:   -Xfrontend -define-enabled-availability-domain -Xfrontend EnabledDomain \
+// RUN:   -Xfrontend -define-disabled-availability-domain -Xfrontend DisabledDomain \
+// RUN:   -Xfrontend -define-dynamic-availability-domain -Xfrontend DynamicDomain \
+// RUN:   %no-fixup-chains %s \
+// RUN:   -o %t/%target-library-name(Test)
+
+// RUN: %target-swift-reflection-dump %t/%target-library-name(Test) \
+// RUN:   > %t/reflection.txt
+
+// RUN: %FileCheck %s --check-prefix=CHECK --input-file=%t/reflection.txt
+// RUN: %FileCheck %s --check-prefix=CHECK-NEGATIVE --input-file=%t/reflection.txt
+
+// REQUIRES: swift_feature_CustomAvailability
+
+// Every type/member that should be absent from the reflection dump has
+// "Disabled" or "disabled" in its name.
+// CHECK-NEGATIVE-NOT: Disabled
+// CHECK-NEGATIVE-NOT: disabled
+
+// Types and cases appear in declaration order; disabled types and their cases
+// are absent so their declaration positions are simply skipped.
+
+// CHECK: FIELDS:
+// CHECK-NEXT: =======
+// CHECK-NEXT: Test.EnabledEnum
+// CHECK-NEXT: ----------------
+// CHECK-NEXT: enabledEnumElement
+
+// CHECK: Test.DynamicEnum
+// CHECK-NEXT: ----------------
+// CHECK-NEXT: dynamicEnumElement
+
+// CHECK: Test.AlwaysAvailableEnum
+// CHECK-NEXT: ------------------------
+// CHECK-NEXT: enabledElement
+// FIXME: Blank lines here represent the absent element
+// CHECK-EMPTY:
+// CHECK-EMPTY:
+// CHECK-EMPTY:
+// CHECK-NEXT: dynamicElement
+
+// CHECK: Test.EnabledStruct
+// CHECK-NEXT: ------------------
+// CHECK-NEXT: enabledStructProp: Swift.Bool
+// CHECK-NEXT: (struct Swift.Bool)
+
+// CHECK: Test.DynamicStruct
+// CHECK-NEXT: ------------------
+// CHECK-NEXT: dynamicStructProp: Swift.Bool
+// CHECK-NEXT: (struct Swift.Bool)
+
+// CHECK: Test.EnabledClass
+// CHECK-NEXT: -----------------
+// CHECK-NEXT: enabledClassProp: Swift.Bool
+// CHECK-NEXT: (struct Swift.Bool)
+
+// CHECK: Test.DynamicClass
+// CHECK-NEXT: -----------------
+// CHECK-NEXT: dynamicClassProp: Swift.Bool
+// CHECK-NEXT: (struct Swift.Bool)
+
+public enum EnabledEnum {
+  case enabledEnumElement
+}
+
+@available(DisabledDomain)
+public enum DisabledEnum {
+  case disabledEnumElement
+}
+
+@available(DynamicDomain)
+public enum DynamicEnum {
+  case dynamicEnumElement
+}
+
+@available(EnabledDomain)
+@available(DisabledDomain)
+public enum DisabledAndEnabledEnum {
+  case disabledAndEnabledEnumElement
+}
+
+public enum AlwaysAvailableEnum {
+  @available(EnabledDomain)
+  case enabledElement
+
+  @available(DisabledDomain)
+  case disabledElement
+
+  @available(DynamicDomain)
+  case dynamicElement
+
+  @available(EnabledDomain)
+  @available(DisabledDomain)
+  case disabledAndEnabledElement
+}
+
+@available(EnabledDomain)
+public struct EnabledStruct {
+  public var enabledStructProp: Bool = false
+}
+
+@available(DisabledDomain)
+public struct DisabledStruct {
+  public var disabledStructProp: Bool = false
+}
+
+@available(DynamicDomain)
+public struct DynamicStruct {
+  public var dynamicStructProp: Bool = false
+}
+
+@available(EnabledDomain)
+@available(DisabledDomain)
+public struct DisabledAndEnabledStruct {
+  public var disabledAndEnabledStructProp: Bool = false
+}
+
+@available(EnabledDomain)
+public class EnabledClass {
+  public var enabledClassProp: Bool = false
+  public init() {}
+}
+
+@available(DisabledDomain)
+public class DisabledClass {
+  public var disabledClassProp: Bool = false
+  public init() {}
+}
+
+@available(DynamicDomain)
+public class DynamicClass {
+  public var dynamicClassProp: Bool = false
+  public init() {}
+}
+
+@available(EnabledDomain)
+@available(DisabledDomain)
+public class DisabledAndEnabledClass {
+  public var disabledAndEnabledClassProp: Bool = false
+  public init() {}
+}


### PR DESCRIPTION
- **Explanation**: The names of enum elements that are made unavailable at runtime via custom availability conditions were leaking through Swift's reflection metadata. These enum elements should really be
skipped entirely for layout and tag generation, but that's a riskier change that will need to come later.
- **Scope**: Affects projects that use the `CustomAvailability` feature.
- **Issues**: rdar://175803941
- **Risk**: Low. The new behavior only applies to the very few projects use the `CustomAvailability` feature and omitting enum element names from reflection metadata should be very safe regardless.
- **Testing**: New compiler tests.
