### PR TITLE
[CastOptimizer] Strip DynamicSelfType from bridged target before comparing

### DIFF
--- a/lib/SILOptimizer/Utils/CastOptimizer.cpp
+++ b/lib/SILOptimizer/Utils/CastOptimizer.cpp
@@ -551,7 +551,13 @@ static SILValue computeFinalCastedValue(SILBuilderWithScope &builder,
   auto sourceFormalTy = dynamicCast.getSourceFormalType();
   auto destLoweredTy = dynamicCast.getTargetLoweredType().getObjectType();
   auto destFormalTy = dynamicCast.getTargetFormalType();
-  assert(destLoweredTy == dynamicCast.getLoweredBridgedTargetObjectType() &&
+  // Lower the bridged target type through the TypeConverter so that
+  // DynamicSelfType is stripped consistently with destLoweredTy. Otherwise
+  // the comparison trips when casting to `Self` in a class extension.
+  auto *F = dynamicCast.getFunction();
+  auto bridgedLoweredTy =
+      F->getLoweredType(dynamicCast.getBridgedTargetType()).getObjectType();
+  assert(destLoweredTy == bridgedLoweredTy &&
          "Expected Dest Type to be the same as BridgedTargetTy");
 
   if (convTy == destLoweredTy) {

--- a/test/SILOptimizer/issue-88767.swift
+++ b/test/SILOptimizer/issue-88767.swift
@@ -1,0 +1,20 @@
+// RUN: %target-swift-frontend -emit-sil -verify %s
+// RUN: %target-swift-frontend -O -emit-sil -verify %s
+
+// REQUIRES: objc_interop
+
+// Regression test for https://github.com/swiftlang/swift/issues/88767
+
+import Foundation
+
+extension NSDecimalNumber {
+  static func roundtrip(_ d: Decimal) -> Self? {
+    return d as? Self
+  }
+}
+
+extension NSString {
+  static func roundtrip(_ s: String) -> Self? {
+    return s as? Self
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #88767. Alternative PR: #88777 (same bug, helper-level fix with wider blast radius).

`SILDynamicCastInst::getLoweredBridgedTargetObjectType` wraps the formal bridged target via `SILType::getPrimitiveObjectType` (see `include/swift/SIL/DynamicCasts.h:438`), which preserves `DynamicSelfType`. `computeFinalCastedValue` compares it against `destLoweredTy`, which went through SIL type lowering and has `DynamicSelfType` stripped (see `LoweredRValueTypeVisitor::visitDynamicSelfType`). The two disagree whenever an `as?` cast's target is `Self` inside an extension of a bridgeable class, and the assertion fires.

This PR routes the bridged target through the function's `TypeConverter` at the assertion site only, mirroring the fix from #85128 which addressed the same class of inconsistency in `canOptimizeCast` and `optimizeBridgedObjCToSwiftCast`.

## Reproducer

```swift
import Foundation

extension NSDecimalNumber {
    static func roundtrip(_ d: Decimal) -> Self? {
        return d as? Self
    }
}
```

```
Assertion failed: (destLoweredTy == dynamicCast.getLoweredBridgedTargetObjectType() &&
  "Expected Dest Type to be the same as BridgedTargetTy"),
  function computeFinalCastedValue, file CastOptimizer.cpp, line 555.
```

Also reproduces with `NSString` / `String`. Fires at `-Onone` and `-O` (`DiagnosticConstantPropagation` runs in the Mandatory pipeline). Regressed sometime after Swift 6.3.1.

## #88777 vs this PR

- **This PR** patches the assertion in `computeFinalCastedValue`. Narrower; mirrors #85128's call-site approach exactly.
- **#88777** patches `getLoweredBridgedTargetObjectType` itself. Fixes the other call site too (today benign — no `DynamicSelfType` target reaches it — but latent), and the method now does what its name implies.

I'd prefer #88777; this PR exists for reviewers who prefer call-site scope.

## Testing

- New regression test: `test/SILOptimizer/issue-88767.swift`. Fails on `main`, passes with this patch.
- SILOptimizer primary suite: 1268 discovered, 1170 passed, 96 unsupported, 2 expectedly failed, 0 failures.
- SILOptimizer validation suite: 50 discovered, 36 passed, 14 unsupported, 0 failures. Includes `rdar162922634.swift` (the #85128 regression test).

## Related

- #88777 — alternative helper-level fix for the same issue.
- #85128 — `[CastOptimizer] Use TypeConverter to lower type.` (rdar://162922634). Prior fix for the same class of bug; this PR addresses the sibling site.
- #54750 (SR-12320) — `as? Self` returning `nil` at `-O`. Same area, different symptom.
