### PR TITLE
[CSOptimizer] Don't favor candidates with unavailable conformances

### DIFF
--- a/lib/Sema/CSOptimizer.cpp
+++ b/lib/Sema/CSOptimizer.cpp
@@ -22,11 +22,12 @@
 #include "swift/AST/ExistentialLayout.h"
 #include "swift/AST/Expr.h"
 #include "swift/AST/GenericSignature.h"
+#include "swift/AST/Type.h"
 #include "swift/Basic/Defer.h"
 #include "swift/Basic/OptionSet.h"
+#include "swift/Sema/CSDisjunction.h"
 #include "swift/Sema/ConstraintGraph.h"
 #include "swift/Sema/ConstraintSystem.h"
-#include "swift/Sema/CSDisjunction.h"
 #include "swift/Sema/TypeVariableType.h"
 #include "llvm/ADT/BitVector.h"
 #include "llvm/ADT/DenseMap.h"
@@ -880,10 +881,10 @@ using MatchOptions = OptionSet<MatchFlag>;
 // types are matched) this function is going to produce \c std::nullopt
 // instead of `0` that indicates "not a match".
 static std::optional<unsigned>
-scoreCandidateMatch(ConstraintSystem &cs,
-                    GenericSignature genericSig, ValueDecl *choice,
-                    std::optional<unsigned> paramIdx, Type candidateType,
-                    Type paramType, MatchOptions options) {
+scoreCandidateMatch(ConstraintSystem &cs, GenericSignature genericSig,
+                    ValueDecl *choice, std::optional<unsigned> paramIdx,
+                    Type candidateType, Type paramType, MatchOptions options,
+                    ConstraintLocator *locator) {
   auto isCGFloatDoubleConversionSupported = [&options]() {
     // CGFloat <-> Double conversion is supposed only while
     // match argument candidates to parameters.
@@ -932,7 +933,7 @@ scoreCandidateMatch(ConstraintSystem &cs,
       // overloads that are a possible match.
       auto score =
           scoreCandidateMatch(cs, genericSig, choice, paramIdx, candidateType,
-                              paramType, options - MatchFlag::Literal);
+                              paramType, options - MatchFlag::Literal, locator);
       if (score == 0)
         return 0;
 
@@ -1011,8 +1012,9 @@ scoreCandidateMatch(ConstraintSystem &cs,
       if ((paramOptionals.empty() &&
            paramType->is<GenericTypeParamType>()) ||
           paramOptionals.size() >= candidateOptionals.size()) {
-        auto score = scoreCandidateMatch(cs, genericSig, choice, paramIdx,
-                                         candidateType, paramType, options);
+        auto score =
+            scoreCandidateMatch(cs, genericSig, choice, paramIdx, candidateType,
+                                paramType, options, locator);
 
         if (score > 0) {
           // Injection lowers the score slightly to comply with
@@ -1102,7 +1104,9 @@ scoreCandidateMatch(ConstraintSystem &cs,
       auto protocolRequirements =
           genericSig->getRequiredProtocols(paramType);
       if (llvm::all_of(protocolRequirements, [&](ProtocolDecl *protocol) {
-            return bool(cs.lookupConformance(candidateType, protocol));
+            auto conformance = cs.lookupConformance(candidateType, protocol);
+            return conformance &&
+                   !cs.isConformanceUnavailable(conformance, locator);
           })) {
         if (auto *GP = paramType->getAs<GenericTypeParamType>()) {
           auto *paramDecl = GP->getDecl();
@@ -1186,12 +1190,27 @@ scoreCandidateMatch(ConstraintSystem &cs,
         },
         SubstOptions(std::nullopt));
 
-    // Concrete operator overloads are always more preferable to
-    // generic ones if there are exact or subtype matches, for
-    // everything else the solver should try both concrete and
-    // generic and disambiguate during ranking.
-    if (result == CheckRequirementsResult::Success)
+    if (result == CheckRequirementsResult::Success) {
+      // Check whether there are any unavailable conformances involved. Just
+      // like unavailable declarations, they shouldn't be considered during
+      // normal/non-diagnostic mode.
+      if (llvm::any_of(requirements, [&](const auto &req) {
+            if (req.getFirstType()->isEqual(paramType) &&
+                req.getKind() == RequirementKind::Conformance) {
+              auto conformance =
+                  cs.lookupConformance(candidateType, req.getProtocolDecl());
+              return cs.isConformanceUnavailable(conformance, locator);
+            }
+            return false;
+          }))
+        return 0;
+
+      // Concrete operator overloads are always more preferable to
+      // generic ones if there are exact or subtype matches, for
+      // everything else the solver should try both concrete and
+      // generic and disambiguate during ranking.
       return choice->isOperator() ? 90 : 100;
+    }
 
     return 0;
   }
@@ -1690,10 +1709,10 @@ static DisjunctionInfo computeDisjunctionInfo(
               options |= MatchFlag::StringInterpolation;
 
             // The specifier for a candidate only matters for `inout` check.
-            auto candidateScore =
-                scoreCandidateMatch(cs, genericSig, decl, paramIdx,
-                                    candidate.type->getWithoutSpecifierType(),
-                                    paramType, options);
+            auto candidateScore = scoreCandidateMatch(
+                cs, genericSig, decl, paramIdx,
+                candidate.type->getWithoutSpecifierType(), paramType, options,
+                disjunction->getLocator());
 
             if (!candidateScore) {
               ASSERT(false);
@@ -1737,11 +1756,11 @@ static DisjunctionInfo computeDisjunctionInfo(
         if (canUseContextualResultTypes &&
             (score > 0 || !hasArgumentCandidates)) {
           if (llvm::any_of(resultTypes, [&](const Type candidateResultTy) {
-                return scoreCandidateMatch(cs, genericSig, decl,
-                                           /*paramIdx=*/std::nullopt,
-                                           overloadType->getResult(),
-                                           candidateResultTy,
-                                           /*options=*/{}) > 0;
+                return scoreCandidateMatch(
+                           cs, genericSig, decl,
+                           /*paramIdx=*/std::nullopt, overloadType->getResult(),
+                           candidateResultTy,
+                           /*options=*/{}, disjunction->getLocator()) > 0;
               })) {
             score += 100;
           }

--- a/validation-test/Sema/type_checker_perf/fast/unavailable_conformance_filtering.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/unavailable_conformance_filtering.swift.gyb
@@ -1,0 +1,32 @@
+// RUN: %scale-test --begin 1 --end 30  --step 1 --select NumLeafScopes --polynomial-threshold 1 %s
+
+// REQUIRES: OS=macosx
+// REQUIRES: asserts,no_asan
+
+protocol P {}
+
+struct G<A> {}
+struct S<A> {}
+
+@available(macOS 1000.0, *)
+extension G: P where G: P {}
+
+@available(macOS 1000.0, *)
+extension Int: P {}
+
+extension S: P where A: P {}
+
+func test<T>(v: T) -> G<T> { fatalError() }
+func test<U: P>(v: U) -> S<U> { fatalError() }
+
+func test(value: Int) {
+    let _ =
+% for i in range(N):
+    test(v:
+% end
+    value
+% for i in range(N):
+    )
+% end
+}
+


### PR DESCRIPTION
<!--
The main branch is now in convergence, which means major changes, such as large refactoring or new features, should be avoided. This strategy is intended to maintain the stability of the Swift 6.4 release leading up to the May 4th branch. For any work that requires broad changes or introduces new features, create a feature branch and open a draft pull request. All updates to the swiftlang/swift repository’s main branch require approval from the release managers. A pull request targeting swiftlang/swift will automatically add release managers. You can also contact them via @release-managers in the forum group.
-->

<!-- Please fill out the following form: --> 
- **Explanation**:

   Neither direct protocol conformance checking nor `checkRequirements` verifies that produced conformance is available. The optimizer shouldn't be favoring overload choices that would result in use of unavailable conformances (just like it doesn't for unavailable declarations).

- **Scope**:

   Applies only to generic overload choices that have generic type parameter types in parameter positions and at least partially resolved candidate types.

- **Issues**:

  - rdar://175981146

- **Risk**:

   Very low. This change fixes over-favoring situation were the solver would attempt choices that would be rejected during normal type-checking without favoring.

- **Testing**:

  Added a new scale test to the performance suite.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
