### PR TITLE
Fix cubic compile time in DefiniteInitialization.

### DIFF
--- a/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.cpp
+++ b/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.cpp
@@ -131,8 +131,29 @@ computeMemorySILType(MarkUninitializedInst *MUI, SILValue Address) {
   return {MemorySILType, VDecl->isLet()};
 }
 
+static SingleValueInstruction *
+findUninitializedValue(MarkUninitializedInst *MemoryInst) {
+  SingleValueInstruction *inst = MemoryInst;
+  SILValue projectBoxUser = inst;
+
+  // Check for a project_box instruction (possibly via a borrow).
+  if (auto *bbi = projectBoxUser->getSingleUserOfType<BeginBorrowInst>()) {
+    projectBoxUser = bbi;
+  }
+  if (auto pbi = projectBoxUser->getSingleUserOfType<ProjectBoxInst>()) {
+    inst = pbi;
+  }
+
+  // Access move-only values through their marker.
+  if (auto mui = inst->getSingleUserOfType<MarkUnresolvedNonCopyableValueInst>()) {
+    inst = mui;
+  }
+
+  return inst;
+}
+
 DIMemoryObjectInfo::DIMemoryObjectInfo(MarkUninitializedInst *MI)
-    : MemoryInst(MI) {
+    : MemoryInst(MI), uninitializedValue(findUninitializedValue(MI)) {
   auto &Module = MI->getModule();
 
   SILValue Address = MemoryInst;
@@ -184,29 +205,8 @@ SILInstruction *DIMemoryObjectInfo::getFunctionEntryPoint() const {
   return &*getFunction().begin()->begin();
 }
 
-static SingleValueInstruction *
-getUninitializedValue(MarkUninitializedInst *MemoryInst) {
-  SingleValueInstruction *inst = MemoryInst;
-  SILValue projectBoxUser = inst;
-  
-  // Check for a project_box instruction (possibly via a borrow).
-  if (auto *bbi = projectBoxUser->getSingleUserOfType<BeginBorrowInst>()) {
-    projectBoxUser = bbi;
-  }
-  if (auto pbi = projectBoxUser->getSingleUserOfType<ProjectBoxInst>()) {
-    inst = pbi;
-  }
-
-  // Access move-only values through their marker.
-  if (auto mui = inst->getSingleUserOfType<MarkUnresolvedNonCopyableValueInst>()) {
-    inst = mui;
-  }
-
-  return inst;
-}
-
 SingleValueInstruction *DIMemoryObjectInfo::getUninitializedValue() const {
-  return ::getUninitializedValue(MemoryInst);
+  return uninitializedValue;
 }
 
 /// Given a symbolic element number, return the type of the element.
@@ -563,7 +563,7 @@ SingleValueInstruction *DIMemoryObjectInfo::findUninitializedSelfValue() const {
       // be some kind of `self` (root, delegating, derived etc.)
       // see \c MarkUninitializedInst::Kind for more details.
       if (!isVariableOrResult(MUI))
-        return ::getUninitializedValue(MUI);
+        return findUninitializedValue(MUI);
     }
   }
   return nullptr;

--- a/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.h
+++ b/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.h
@@ -54,6 +54,8 @@ struct DIElementUseInfo;
 class DIMemoryObjectInfo {
   /// The uninitialized memory that we are analyzing.
   MarkUninitializedInst *MemoryInst;
+  // The uninitialized value representing that memory
+  SingleValueInstruction *uninitializedValue;
 
   /// This is the base type of the memory allocation.
   SILType MemorySILType;


### PR DESCRIPTION
For large structs, most of the compile time is spent in
DIMemoryObjectInfo::getUninitializedValue.

This commit introduced the cubic behavior:

commit ba6763ac10c3e1b55db6a5134e20bdd938ad5384
Date:   Fri Dec 27 19:56:01 2019 -0800

    [di] Instead of accessing TheMemory.MemoryInst directly, use the helper
    getUninitializedValue().

There was no good reason to traverse all the uses of every variable repeatedly
when visiting every other unrelated instruction.

Fixes rdar://170587495 BUILD TIME REGRESSION

For a struct with 1k fields fixing this problem decreases compile time by 86% (7x)
Before: 15s
After:   2s

Now other, downstream quadratic compiler code paths will be exposed by large structs. The biggest is: SemanticARCOptVisitor::visitCopyValueInst.
rdar://175999887 (-Onone compile time: quadratic behavior in SemanticARCOptVisitor::visitCopyValueInst.)

I tested with a script that generates a struct with 1k fields:

`$ time swift-frontend -emit-sil LargeStructInit.swift -o /dev/null`

```
public typealias Handler = ((Int) -> Int)

public struct LargeStruct {
    let prop0000: Handler?
    let prop0001: Handler?
//...
    let prop0997: Handler?
    let prop0998: Handler?
    public init(
            error: Int,
            prop0000: Handler? = nil,
            prop0001: Handler? = nil,
            //...
            prop0997: Handler? = nil,
            prop0998: Handler? = nil
    ) {
        self.error = error
        self.prop0000 = prop0000
        self.prop0001 = prop0001
        self.prop0002 = prop0002
        // ...
        self.prop0997 = prop0997
        self.prop0998 = prop0998
    }
}
```
