### PR TITLE
[SIL] Lower bridged target through TypeConverter in getLoweredBridgedTargetObjectType

### DIFF
--- a/include/swift/SIL/DynamicCasts.h
+++ b/include/swift/SIL/DynamicCasts.h
@@ -439,7 +439,11 @@ public:
     CanType t = getBridgedTargetType();
     if (!t)
       return std::nullopt;
-    return SILType::getPrimitiveObjectType(t);
+    // Lower the bridged target through the TypeConverter so that
+    // DynamicSelfType is stripped consistently with how SIL lowers the
+    // cast instruction's target type. Otherwise `as? Self` in a class
+    // extension of a bridgeable class makes the two sides disagree.
+    return getFunction()->getLoweredType(t).getObjectType();
   }
 
   bool isConditional() const {

--- a/test/SILOptimizer/issue-88767.swift
+++ b/test/SILOptimizer/issue-88767.swift
@@ -1,0 +1,20 @@
+// RUN: %target-swift-frontend -emit-sil -verify %s
+// RUN: %target-swift-frontend -O -emit-sil -verify %s
+
+// REQUIRES: objc_interop
+
+// Regression test for https://github.com/swiftlang/swift/issues/88767
+
+import Foundation
+
+extension NSDecimalNumber {
+  static func roundtrip(_ d: Decimal) -> Self? {
+    return d as? Self
+  }
+}
+
+extension NSString {
+  static func roundtrip(_ s: String) -> Self? {
+    return s as? Self
+  }
+}


### PR DESCRIPTION
## Summary

Alternative fix for #88767. This is a sibling PR to #88771 — same bug, wider (and I think cleaner) fix.

`SILDynamicCastInst::getLoweredBridgedTargetObjectType` wraps the formal bridged target via `SILType::getPrimitiveObjectType`, which preserves `DynamicSelfType`. SIL type lowering strips it. Consumers that compare the helper's result against a lowered SIL type disagree whenever an `as?` cast's target is `Self` inside an extension of a bridgeable class, and `CastOptimizer::computeFinalCastedValue`'s assertion fires.

This PR routes the helper through the containing `SILFunction`'s `TypeConverter`, so `DynamicSelfType` is stripped consistently with other cast-type consumers. Both current call sites (`computeFinalCastedValue` and `convertObjectToLoadableBridgeableType`) get the fix without further changes, and future callers inherit the correct behavior.

## #88771 vs this PR

- **#88771** patches the assertion in `computeFinalCastedValue`. Narrower; mirrors #85128's call-site approach exactly.
- **This PR** patches `getLoweredBridgedTargetObjectType` itself. Fixes the other call site too (today benign — no `DynamicSelfType` target reaches it — but latent), and the method now does what its name implies.

I'd prefer this PR; #88771 exists for reviewers who prefer call-site scope.

## Reproducer

```swift
import Foundation

extension NSDecimalNumber {
    static func roundtrip(_ d: Decimal) -> Self? {
        return d as? Self
    }
}
```

```
Assertion failed: (destLoweredTy == dynamicCast.getLoweredBridgedTargetObjectType() &&
  "Expected Dest Type to be the same as BridgedTargetTy"),
  function computeFinalCastedValue, file CastOptimizer.cpp, line 555.
```

Fires at `-Onone` and `-O` (the assertion lives inside a pass in the Mandatory pipeline). Regressed sometime after Swift 6.3.1.

## Testing

Locally-built compiler at this PR's commit, `+assertions` on. Running against `main` at `6a6e574eac9`.

- New regression test: `test/SILOptimizer/issue-88767.swift`. Fails on `main`, passes with this patch.
- `validation-test/SILOptimizer/rdar162922634.swift` (the #85128 regression test) still passes.

## Related

- #88771 — narrower alternative fix for the same issue.
- #85128 — `[CastOptimizer] Use TypeConverter to lower type.` (rdar://162922634). The pattern this fix follows, applied at the helper level instead of the call site.
