### PR TITLE
[test] Add timeouts for a couple of crasher test cases

### DIFF
--- a/validation-test/compiler_crashers/CxxInterop/InFlightSubstitution-lookupConformance-577ddb.swift
+++ b/validation-test/compiler_crashers/CxxInterop/InFlightSubstitution-lookupConformance-577ddb.swift
@@ -1,4 +1,7 @@
 // {"extraArgs":["-experimental-allow-module-with-compiler-errors","-cxx-interoperability-mode=default","-emit-clang-header-min-access","internal","-emit-clang-header-path","/dev/null"],"kind":"typecheck","original":"001bd4a5","signature":"swift::InFlightSubstitution::lookupConformance(swift::Type, swift::ProtocolDecl*, unsigned int)","stackOverflow":true}
+// This test crashes by overflowing the stack, set a suitable timeout to ensure it doesn't take too long.
+// RUN: not %{python} %swift_src_root/test/Inputs/timeout.py 60 \
+// RUN:             %target-swift-frontend -typecheck -experimental-allow-module-with-compiler-errors -cxx-interoperability-mode=default -emit-clang-header-min-access internal -emit-clang-header-path /dev/null %s || \
 // RUN: not --crash %target-swift-frontend -typecheck -experimental-allow-module-with-compiler-errors -cxx-interoperability-mode=default -emit-clang-header-min-access internal -emit-clang-header-path /dev/null %s
 enum a<b: Hashable> {
   case (a<[b]>)

--- a/validation-test/compiler_crashers/TypeTransform-doIt-594e36.swift
+++ b/validation-test/compiler_crashers/TypeTransform-doIt-594e36.swift
@@ -1,4 +1,7 @@
 // {"kind":"typecheck","original":"2e27326c","signature":"swift::TypeTransform<swift::Type::transformRec(llvm::function_ref<std::__1::optional<swift::Type> (swift::TypeBase*)>) const::Transform>::doIt(swift::Type, swift::TypePosition)","stackOverflow":true}
+// This test crashes by overflowing the stack, set a suitable timeout to ensure it doesn't take too long.
+// RUN: not %{python} %swift_src_root/test/Inputs/timeout.py 60 \
+// RUN:             %target-swift-frontend -typecheck %s || \
 // RUN: not --crash %target-swift-frontend -typecheck %s
 @resultBuilder enum a {
   static  buildPartialBlock< b >(first : b) ->[b]static func buildPartialBlock(


### PR DESCRIPTION
- Explanation: Adds timeouts for a couple of crasher test cases, ensuring they either crash or timeout
- Scope: Test-only change
- Issue: rdar://175483165
- Risk: None
- Testing: N/A