### PR TITLE
[cxx-interop] Fix incorrect type lowering for closures in some scenarios

### DIFF
--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -1760,6 +1760,26 @@ static ManagedValue emitAnyClosureExpr(SILGenFunction &SGF, Expr *e,
   }
 }
 
+/// Lower a type to SIL, preserving Clang type info that would otherwise be
+/// lost during canonical type computation. getCanonicalType() drops
+/// ClangTypeInfo when UseClangFunctionTypes is off, which causes C function
+/// pointer types with const-ref parameters to lose their conventions.
+static SILType getLoweredTypePreservingClangTypeInfo(SILGenFunction &SGF,
+                                                     Type ty) {
+  if (auto funcTy = ty->lookThroughSingleOptionalType()
+                        ->getAs<AnyFunctionType>()) {
+    if (!funcTy->getClangTypeInfo().empty() &&
+        funcTy->getRepresentation() ==
+            FunctionTypeRepresentation::CFunctionPointer) {
+      auto canTy = ty->getCanonicalType();
+      AbstractionPattern origPattern(canTy,
+                                     funcTy->getClangTypeInfo().getType());
+      return SGF.getLoweredType(origPattern, canTy);
+    }
+  }
+  return SGF.getLoweredType(ty);
+}
+
 static ManagedValue
 convertCFunctionSignature(SILGenFunction &SGF, FunctionConversionExpr *e,
                           SILType loweredResultTy, SGFContext C,
@@ -1772,8 +1792,9 @@ convertCFunctionSignature(SILGenFunction &SGF, FunctionConversionExpr *e,
       loweredDestTy = objTy;
     else
       loweredDestTy = loweredDestOptTy;
-  } else
-    loweredDestTy = SGF.getLoweredType(destTy);
+  } else {
+    loweredDestTy = getLoweredTypePreservingClangTypeInfo(SGF, destTy);
+  }
 
   ManagedValue result;
 
@@ -1859,6 +1880,19 @@ static ManagedValue emitCFunctionPointer(SILGenFunction &SGF,
         auto origParamType = conv.getBridgingOriginalInputType();
         if (origParamType.isClangType())
           destFnType = origParamType.getClangType();
+      }
+    }
+    // When there is no conversion context (e.g., assigning a closure to a
+    // struct member), extract the Clang type from the FunctionConversionExpr's
+    // destination type. The imported @convention(c) FunctionType preserves
+    // the original Clang type (including const-ref parameter types that were
+    // stripped from the Swift representation) in its ClangTypeInfo.
+    if (!destFnType) {
+      if (auto funcTy =
+              conversionExpr->getType()->getAs<FunctionType>()) {
+        if (auto clangTypeInfo = funcTy->getClangTypeInfo();
+            !clangTypeInfo.empty())
+          destFnType = clangTypeInfo.getType();
       }
     }
     (void)emitAnyClosureExpr(
@@ -5733,7 +5767,9 @@ RValue RValueEmitter::visitInjectIntoOptionalExpr(InjectIntoOptionalExpr *E,
   };
 
   auto result =
-    SGF.emitOptionalSome(E, SGF.getLoweredType(E->getType()), helper, C);
+    SGF.emitOptionalSome(E,
+                         getLoweredTypePreservingClangTypeInfo(SGF, E->getType()),
+                         helper, C);
   return RValue(SGF, E, result);
 }
 

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -2997,6 +2997,18 @@ LValue SILGenFunction::emitLValue(Expr *e, SGFAccessKind accessKind,
   // reabstraction component.
   auto substFormalType = r.getSubstFormalType();
   auto loweredSubstType = getLoweredType(substFormalType);
+  // When the LValue's original abstraction pattern carries a Clang type for
+  // a C function pointer (e.g., with const-ref parameters), use it to
+  // preserve parameter conventions. Restrict to CFunctionPointer to avoid
+  // affecting ObjC blocks which have legitimate optionality differences
+  // between their Clang type and Swift representation.
+  if (r.getOrigFormalType().isClangType()) {
+    if (auto fnType = substFormalType->lookThroughSingleOptionalType()
+                          ->getAs<AnyFunctionType>())
+      if (fnType->getRepresentation() ==
+              FunctionTypeRepresentation::CFunctionPointer)
+        loweredSubstType = getLoweredType(r.getOrigFormalType(), substFormalType);
+  }
   if (r.getTypeOfRValue() != loweredSubstType.getObjectType()) {
     // Logical components always re-abstract back to the substituted
     // type.

--- a/test/Interop/Cxx/class/Inputs/closure.h
+++ b/test/Interop/Cxx/class/Inputs/closure.h
@@ -88,4 +88,19 @@ void cfuncConstRefStrong(void (*_Nonnull)(const ARCStrong &));
 void blockConstRefStrong(void (^_Nonnull)(const ARCStrong &));
 #endif
 
+struct ConstRefNonTrivialFPStruct {
+    void (*_Nonnull fp)(const NonTrivial &) = nullptr;
+    void callFp(const NonTrivial &x) { fp(x); }
+};
+
+struct ConstRefTrivialFPStruct {
+    void (*_Nonnull fp)(const Trivial &) = nullptr;
+    void callFp(const Trivial &x) { fp(x); }
+};
+
+struct NullableConstRefNonTrivialFPStruct {
+    void (*_Nullable fp)(const NonTrivial &) = nullptr;
+    void callFp(const NonTrivial &x) { if (fp) fp(x); }
+};
+
 #endif // __CLOSURE__

--- a/test/Interop/Cxx/class/closure-thunk-executable.swift
+++ b/test/Interop/Cxx/class/closure-thunk-executable.swift
@@ -15,4 +15,31 @@ ClosureTestSuite.test("Pass FRT to function pointer") {
   cppGo({N in })
 }
 
+ClosureTestSuite.test("AssignClosureToStructMemberConstRefNonTrivial") {
+  var s = ConstRefNonTrivialFPStruct()
+  s.fp = { nt in }
+  s.callFp(NonTrivial())
+  // Read back and call through the function pointer directly.
+  let f = s.fp
+  f(NonTrivial())
+}
+
+ClosureTestSuite.test("AssignClosureToStructMemberConstRefTrivial") {
+  var s = ConstRefTrivialFPStruct()
+  var t = Trivial()
+  t.i = 42
+  s.fp = { t in }
+  s.callFp(t)
+  let f = s.fp
+  f(t)
+}
+
+ClosureTestSuite.test("AssignClosureToStructMemberNullableConstRef") {
+  var s = NullableConstRefNonTrivialFPStruct()
+  s.fp = { nt in }
+  s.callFp(NonTrivial())
+  let f = s.fp
+  f?(NonTrivial())
+}
+
 runAllTests()

--- a/test/Interop/Cxx/class/closure-thunk-macosx.swift
+++ b/test/Interop/Cxx/class/closure-thunk-macosx.swift
@@ -128,3 +128,30 @@ public func testBlockConstRefTrivial() {
 public func testBlockConstRefStrong() {
   blockConstRefStrong({S in });
 }
+
+// CHECK-LABEL: sil private [thunk] [ossa] @$s4main34testConstRefNonTrivialStructAssign
+// CHECK-SAME: $@convention(c) (@in_guaranteed NonTrivial) -> () {
+// CHECK: bb0(%[[V0:.*]] : $*NonTrivial):
+
+public func testConstRefNonTrivialStructAssign() {
+  var s = ConstRefNonTrivialFPStruct()
+  s.fp = { S in }
+}
+
+// CHECK-LABEL: sil private [thunk] [ossa] @$s4main31testConstRefTrivialStructAssign
+// CHECK-SAME: $@convention(c) (@in_guaranteed Trivial) -> () {
+// CHECK: bb0(%[[V0:.*]] : $*Trivial):
+
+public func testConstRefTrivialStructAssign() {
+  var s = ConstRefTrivialFPStruct()
+  s.fp = { S in }
+}
+
+// CHECK-LABEL: sil private [thunk] [ossa] @$s4main42testNullableConstRefNonTrivialStructAssign
+// CHECK-SAME: $@convention(c) (@in_guaranteed NonTrivial) -> () {
+// CHECK: bb0(%[[V0:.*]] : $*NonTrivial):
+
+public func testNullableConstRefNonTrivialStructAssign() {
+  var s = NullableConstRefNonTrivialFPStruct()
+  s.fp = { S in }
+}


### PR DESCRIPTION
When a closure is passed as a function pointer to C++, we rely on an initializing conversion to plumb the clang type through so we can lower the closure's foreign entry point with the right conventions (lowering without the clang type results in the wrong convention for const T& parameters). Unfortunately, when we assign to a field, we do not have these initializing conversions. This patch adds some extra code to manually keep around clang types as they are dropped every time when we do the canonicalization. The important parts where this information had to be preserved included the emission of the lvalue, the point where we ask for the emission of the foreign entry point for the closure, and the injection of Optional.some when the C function pointer is nullable.

rdar://156635576
