### PR TITLE
[cxx-interop] Fix crash in dyld conformance lookup for foreign types

### DIFF
--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -1288,9 +1288,28 @@ findConformanceWithDyld(ConformanceState &C, const Metadata *type,
             dyldResult.value);
 
     assert(conformanceDescriptor->getProtocol() == protocol);
-    assert(std::get<const Metadata *>(
+
+    auto *matchingType = std::get<const Metadata *>(
         ConformanceCandidate{*conformanceDescriptor}.getMatchingType(
-            type, instantiateSuperclassMetadata)));
+            type, instantiateSuperclassMetadata));
+    auto *descriptor = type->getTypeContextDescriptor();
+
+    if (!matchingType && descriptor &&
+        descriptor->hasForeignMetadataInitialization()) {
+      // For foreign types, dyld looks up conformances by identity string. For
+      // C++ class template specializations, this string does not include the
+      // namespace, so dyld may return a conformance from a different
+      // namespace. When that happens, equalContexts() rejects the match and
+      // getMatchingType() returns null. Treat this as not found so the caller
+      // falls through to section scanning.
+      DYLD_CONFORMANCES_LOG(
+          "DYLD found foreign type conformance descriptor %p "
+          "for %s, but the type metadata doesn't match the descriptor",
+          conformanceDescriptor, protocol->Name.get());
+      return std::make_tuple(nullptr, nullptr, false);
+    }
+
+    assert(matchingType);
 
     if (conformanceDescriptor->getGenericWitnessTable()) {
       DYLD_CONFORMANCES_LOG(


### PR DESCRIPTION
When checking protocol conformance of a C++ class template specialization at runtime, the dyld shared cache conformance lookup can return a conformance descriptor from a different namespace. This happens because the foreign type identity string used as the dyld cache key does not include the namespace for template specializations. When the runtime then verifies the match via `equalContexts()`, the parent context descriptors differ and `getMatchingType()` returns null, causing a crash.

We should use the qualified name as the identity string for all C++ types, but this may be ABI breaking. For now,  we detect the mismatch early, allowing the runtime to fall through to section scanning for foreign types.

rdar://165150073