### PR TITLE
Emit a copy for borrow accessor results when needed 

### DIFF
--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -5667,9 +5667,12 @@ RValue SILGenFunction::emitLoadOfLValue(SILLocation loc, LValue &&src,
             emitLoad(loc, projection.getValue(), origFormalType,
                      substFormalType, rvalueTL, C, IsNotTake, isBaseGuaranteed);
       } else {
+        bool isPlusZeroOk = isBaseGuaranteed ? C.isGuaranteedPlusZeroOk()
+                                             : C.isImmediatePlusZeroOk();
         if (!projection.isPlusOneOrTrivial(*this) &&
-            isReadAccessResultOwned(src.getAccessKind())) {
-
+            (isReadAccessResultOwned(src.getAccessKind()) ||
+             (src.getAccessKind() == SGFAccessKind::BorrowedAddressRead &&
+              !isPlusZeroOk))) {
           // Before we copy, if we have a move only wrapped value, unwrap the
           // value using a guaranteed moveonlywrapper_to_copyable.
           if (projection.getType().isMoveOnlyWrapped()) {

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -5666,22 +5666,24 @@ RValue SILGenFunction::emitLoadOfLValue(SILLocation loc, LValue &&src,
         projection =
             emitLoad(loc, projection.getValue(), origFormalType,
                      substFormalType, rvalueTL, C, IsNotTake, isBaseGuaranteed);
-      } else if (isReadAccessResultOwned(src.getAccessKind()) &&
-          !projection.isPlusOneOrTrivial(*this)) {
+      } else {
+        if (!projection.isPlusOneOrTrivial(*this) &&
+            isReadAccessResultOwned(src.getAccessKind())) {
 
-        // Before we copy, if we have a move only wrapped value, unwrap the
-        // value using a guaranteed moveonlywrapper_to_copyable.
-        if (projection.getType().isMoveOnlyWrapped()) {
-          // We are assuming we always get a guaranteed value here.
-          assert(projection.getValue()->getOwnershipKind() ==
-                 OwnershipKind::Guaranteed);
-          // We use SILValues here to ensure we get a tight scope around our
-          // copy.
-          projection =
-              B.createGuaranteedMoveOnlyWrapperToCopyableValue(loc, projection);
+          // Before we copy, if we have a move only wrapped value, unwrap the
+          // value using a guaranteed moveonlywrapper_to_copyable.
+          if (projection.getType().isMoveOnlyWrapped()) {
+            // We are assuming we always get a guaranteed value here.
+            assert(projection.getValue()->getOwnershipKind() ==
+                   OwnershipKind::Guaranteed);
+            // We use SILValues here to ensure we get a tight scope around our
+            // copy.
+            projection = B.createGuaranteedMoveOnlyWrapperToCopyableValue(
+                loc, projection);
+          }
+
+          projection = projection.copy(*this, loc);
         }
-
-        projection = projection.copy(*this, loc);
       }
 
       result = RValue(*this, loc, substFormalType, projection);

--- a/test/SILGen/borrow_accessor_mutable_base.swift
+++ b/test/SILGen/borrow_accessor_mutable_base.swift
@@ -1,0 +1,72 @@
+// RUN: %target-swift-frontend -emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen -enable-library-evolution %s | %FileCheck %s --check-prefix=CHECK-EVOLUTION
+// RUN: %target-swift-frontend -emit-sil %s -verify
+// RUN: %target-swift-frontend -emit-sil -enable-library-evolution %s -verify
+
+public final class Klass {
+  var x: Int = 0
+}
+
+public struct S {
+  var _k: Klass
+
+  public var k: Klass {
+    borrow {
+      return _k
+    }
+    mutate {
+      return &_k
+    }
+  }
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s{{.*}}7testVaryyF : $@convention(thin) () -> () {
+// CHECK:   [[ACCESS:%.*]] = begin_access [read] [unknown]
+// CHECK:   [[BORROW:%.*]] = load_borrow [[ACCESS]]
+// CHECK:   [[BORROW_FN:%.*]] = function_ref @$s{{.*}}1SV1k{{.*}}vb
+// CHECK:   [[RESULT:%.*]] = apply [[BORROW_FN]]([[BORROW]])
+// CHECK:   [[COPY:%.*]] = copy_value [[RESULT]]
+// CHECK:   end_borrow [[BORROW]]
+// CHECK:   end_access [[ACCESS]]
+// CHECK: } // end sil function '$s{{.*}}7testVaryyF'
+
+// CHECK-EVOLUTION-LABEL: sil hidden [ossa] @$s{{.*}}7testVaryyF : $@convention(thin) () -> () {
+// CHECK-EVOLUTION:   [[ACCESS:%.*]] = begin_access [read] [unknown]
+// CHECK-EVOLUTION:   [[BORROW_FN:%.*]] = function_ref @$s{{.*}}1SV1k{{.*}}vb
+// CHECK-EVOLUTION:   [[RESULT:%.*]] = apply [[BORROW_FN]]([[ACCESS]])
+// CHECK-EVOLUTION:   [[COPY:%.*]] = copy_value [[RESULT]]
+// CHECK-EVOLUTION:   end_access [[ACCESS]]
+// CHECK-EVOLUTION: } // end sil function '$s{{.*}}7testVaryyF'
+func testVar() {
+  var s = S(_k: Klass()) // expected-warning {{variable 's' was never mutated}}
+  let b = s.k
+  _ = b
+  _ = s
+}
+
+
+// CHECK-LABEL: sil hidden [ossa] @$s{{.*}}9testInout{{.*}} : $@convention(thin) (@inout S) -> @owned Klass {
+// CHECK: bb0([[ADDR:%.*]] : $*S):
+// CHECK:   [[ACCESS:%.*]] = begin_access [read] [unknown] [[ADDR]]
+// CHECK:   [[BORROW:%.*]] = load_borrow [[ACCESS]]
+// CHECK:   [[BORROW_FN:%.*]] = function_ref @$s{{.*}}1SV1k{{.*}}vb
+// CHECK:   [[RESULT:%.*]] = apply [[BORROW_FN]]([[BORROW]])
+// CHECK:   [[COPY:%.*]] = copy_value [[RESULT]]
+// CHECK:   end_borrow [[BORROW]]
+// CHECK:   end_access [[ACCESS]]
+// CHECK:   return [[COPY]]
+// CHECK: } // end sil function '$s{{.*}}9testInout{{.*}}'
+
+// CHECK-EVOLUTION-LABEL: sil hidden [ossa] @$s{{.*}}9testInout{{.*}} : $@convention(thin) (@inout S) -> @owned Klass {
+// CHECK-EVOLUTION: bb0([[ADDR:%.*]] : $*S):
+// CHECK-EVOLUTION:   [[ACCESS:%.*]] = begin_access [read] [unknown] [[ADDR]]
+// CHECK-EVOLUTION:   [[BORROW_FN:%.*]] = function_ref @$s{{.*}}1SV1k{{.*}}vb
+// CHECK-EVOLUTION:   [[RESULT:%.*]] = apply [[BORROW_FN]]([[ACCESS]])
+// CHECK-EVOLUTION:   [[COPY:%.*]] = copy_value [[RESULT]]
+// CHECK-EVOLUTION:   end_access [[ACCESS]]
+// CHECK-EVOLUTION:   return [[COPY]]
+// CHECK-EVOLUTION: } // end sil function '$s{{.*}}9testInout{{.*}}'
+func testInout(_ s: inout S) -> Klass {
+  return s.k
+}
+


### PR DESCRIPTION
- **Explanation**: When the SGFContext does not accept +0 for BorrowedAddressRead, create a copy.
This ensures we create valid SIL when we copy borrow accessor results.
- **Scope**: Borrow accessors
- **Issues**: rdar://176046353
- **Risk**: Low
- **Testing**: Added unit test, CI testing

