### PR TITLE
[rbi] Treat partial_apply/function_ref with unbound isolated params as disconnected

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -1057,6 +1057,13 @@ NOTE(regionbasedisolation_named_isolated_closure_yields_race, none,
 NOTE(regionbasedisolation_named_isolated_closure_yields_race_mutable, none,
      "%0 closure captures reference to mutable %1 which remains modifiable by %select{%3 code|code in the current task}2", (StringRef, Identifier, bool, StringRef))
 
+NOTE(regionbasedisolation_assume_isolated_closure_capture, none,
+     "%0-isolated closure captures %1 which remains accessible to %select{%3 code|code in the current task}2",
+     (Identifier, Identifier, bool, StringRef))
+NOTE(regionbasedisolation_assume_isolated_callee, none,
+     "passing closure to 'assumeIsolated' here causes closure to become isolated to %0",
+     (Identifier))
+
 NOTE(regionbasedisolation_typed_use_after_sending, none,
       "Passing value of non-Sendable type %0 as a 'sending' argument risks causing races in between local and caller code",
       (Type))

--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -1037,6 +1037,9 @@ NOTE(regionbasedisolation_named_info_send_yields_race, none,
 NOTE(regionbasedisolation_named_info_send_yields_race_callee, none,
      "sending %select{%2 |}0%1 to %3 %kind4 risks causing data races between %3 and local %5 uses",
      (bool, Identifier, StringRef, StringRef, const ValueDecl *, StringRef))
+NOTE(regionbasedisolation_named_info_send_to_actor_init_yields_race, none,
+     "sending %select{%2 |}0%1 to actor %kind3 risks causing data races between actor-isolated and local %4 uses",
+     (bool, Identifier, StringRef, const ValueDecl *, StringRef))
 
 // Use after send closure.
 NOTE(regionbasedisolation_type_isolated_capture_yields_race, none,
@@ -1080,6 +1083,9 @@ NOTE(regionbasedisolation_named_send_never_sendable, none,
 NOTE(regionbasedisolation_named_send_never_sendable_callee, none,
       "sending %select{%2 |}0%1 to %3 %kind4 risks causing data races between %3 and %5 uses",
       (bool, Identifier, StringRef, StringRef, const ValueDecl *, StringRef))
+NOTE(regionbasedisolation_named_send_to_actor_init_never_sendable, none,
+      "sending %select{%2 |}0%1 to actor %kind3 risks causing data races between actor-isolated and %4 uses",
+      (bool, Identifier, StringRef, const ValueDecl *, StringRef))
 
 NOTE(regionbasedisolation_named_send_into_sending_param, none,
      "%select{%1 |}0%2 is passed as a 'sending' parameter; Uses in callee may race with "

--- a/include/swift/Strings.h
+++ b/include/swift/Strings.h
@@ -68,6 +68,18 @@ constexpr static const StringLiteral SEMANTICS_DEFAULT_ACTOR =
 constexpr static const StringLiteral SEMANTICS_UNAVAILABLE_CODE_REACHED =
     "unavailable_code_reached";
 
+/// The mangled name of Actor.assumeIsolated<A>(_:file:line:) — the
+/// @_alwaysEmitIntoClient version with the Sendable constraint on A1.
+constexpr static const StringLiteral MANGLED_ACTOR_ASSUME_ISOLATED =
+    "$sScAsE14assumeIsolated_4file4lineqd__qd__xYiKXE_"
+    "s12StaticStringVSutKs8SendableRd__lF";
+
+/// The mangled name of (extension in Distributed):DistributedActor
+/// .assumeIsolated<A>(_:file:line:) — same shape, different protocol.
+constexpr static const StringLiteral MANGLED_DISTRIBUTED_ACTOR_ASSUME_ISOLATED =
+    "$s11Distributed0A5ActorPAAE14assumeIsolated_4file4lineqd__qd__xYiKXE_"
+    "s12StaticStringVSutKs8SendableRd__lF";
+
 constexpr static const StringLiteral DEFAULT_ACTOR_STORAGE_FIELD_NAME =
     "$defaultActor";
 

--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -31,6 +31,7 @@
 #include "swift/SIL/Test.h"
 #include "swift/SILOptimizer/PassManager/Transforms.h"
 #include "swift/SILOptimizer/Utils/PartitionUtils.h"
+#include "swift/Strings.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/Support/Debug.h"
 
@@ -2849,6 +2850,26 @@ public:
     }
   }
 
+  bool translateAssumeIsolated(FullApplySite fas) {
+    auto *callee = fas.getCalleeFunction();
+    if (!callee)
+      return false;
+    if (callee->getName() != MANGLED_ACTOR_ASSUME_ISOLATED &&
+        callee->getName() != MANGLED_DISTRIBUTED_ACTOR_ASSUME_ISOLATED)
+      return false;
+
+    // assumeIsolated is a nonisolated function that takes in a closure that is
+    // isolated to a passed in actor. We need to be sure that nothing that is
+    // not disconnected (or in the actor's region which can never happen, but
+    // just saying) can get into that closure. So as a special case, we treat
+    // the closure as being moved into the region of the actor.
+    auto &op = fas.getOperandsWithoutIndirectResults()[0];
+    if (auto lookupResult = tryToTrackValue(op.get())) {
+      builder.addSend(lookupResult->value, &op);
+    }
+    return true;
+  }
+
   void translateSILApply(SILInstruction *inst) {
     // Handles normal builtins and async let start.
     if (auto *bi = dyn_cast<BuiltinInst>(inst)) {
@@ -2863,6 +2884,10 @@ public:
       if (f->getName() == "swift_asyncLet_get") {
         return translateAsyncLetGet(cast<ApplyInst>(*fas));
       }
+    }
+
+    if (translateAssumeIsolated(fas)) {
+      return;
     }
 
     // If this apply does not cross isolation domains, it has normal

--- a/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
@@ -43,6 +43,7 @@
 #include "swift/SILOptimizer/Utils/PartitionUtils.h"
 #include "swift/SILOptimizer/Utils/VariableNameUtils.h"
 #include "swift/Sema/Concurrency.h"
+#include "swift/Strings.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/Support/Debug.h"
 
@@ -88,6 +89,21 @@ static SILValue stripFunctionConversions(SILValue val) {
 
     if (auto cvt = dyn_cast<ConvertEscapeToNoEscapeInst>(val)) {
       val = cvt->getOperand();
+      continue;
+    }
+
+    if (auto cvi = dyn_cast<CopyValueInst>(val)) {
+      val = cvi->getOperand();
+      continue;
+    }
+
+    if (auto bbi = dyn_cast<BeginBorrowInst>(val)) {
+      val = bbi->getOperand();
+      continue;
+    }
+
+    if (auto mvi = dyn_cast<MoveValueInst>(val)) {
+      val = mvi->getOperand();
       continue;
     }
 
@@ -1144,6 +1160,21 @@ public:
     emitRequireInstDiagnostics();
   }
 
+  void emitAssumeIsolatedClosure(SILLocation captureLoc,
+                                 SILLocation callSiteLoc, Identifier name,
+                                 Identifier actorName, bool callerIsNonisolated,
+                                 StringRef callerIsolationStr) {
+    diagnoseError(captureLoc, diag::regionbasedisolation_named_send_yields_race,
+                  name)
+        .limitBehaviorIf(getBehaviorLimit());
+    diagnoseNote(captureLoc,
+                 diag::regionbasedisolation_assume_isolated_closure_capture,
+                 actorName, name, callerIsNonisolated, callerIsolationStr);
+    diagnoseNote(callSiteLoc, diag::regionbasedisolation_assume_isolated_callee,
+                 actorName);
+    emitRequireInstDiagnostics();
+  }
+
   void emitUnknownPatternError() {
     EMIT_UNKNOWN_PATTERN_ERROR(UseAfterSendDiagnosticEmitter,
                                sendingOp->getUser(), getBehaviorLimit());
@@ -1237,6 +1268,7 @@ public:
 private:
   bool initForIsolatedPartialApply(Operand *op, AbstractClosureExpr *ace);
   bool initForSendingPartialApply(FullApplySite fas, Operand *callsiteOp);
+  bool initForAssumeIsolated(FullApplySite fas, Operand *op);
 
   void initForApply(Operand *op, ApplyExpr *expr);
   void initForAutoclosure(Operand *op, AutoClosureExpr *expr);
@@ -1310,6 +1342,58 @@ bool UseAfterSendDiagnosticInferrer::initForSendingPartialApply(
   diagnosticEmitter.emitSendingClosureCapturesMultipleValues(
       baseLoc, baseInferredType, capturedValues, isAutoclosure);
   return true;
+}
+
+bool UseAfterSendDiagnosticInferrer::initForAssumeIsolated(FullApplySite fas,
+                                                           Operand *op) {
+  auto *callee = fas.getCalleeFunction();
+  if (!callee)
+    return false;
+
+  if (callee->getName() != MANGLED_ACTOR_ASSUME_ISOLATED &&
+      callee->getName() != MANGLED_DISTRIBUTED_ACTOR_ASSUME_ISOLATED)
+    return false;
+
+  auto *sendingPAI =
+      dyn_cast<PartialApplyInst>(stripFunctionConversions(op->get()));
+  if (!sendingPAI)
+    return false;
+
+  auto argsWithoutIndirectResults = fas.getOperandsWithoutIndirectResults();
+  auto actorArg = argsWithoutIndirectResults.back().get();
+  Identifier actorName;
+  if (auto actorNameAndRoot = inferNameAndRootHelper(actorArg))
+    actorName = actorNameAndRoot->first;
+
+  auto callSiteLoc = fas.getLoc();
+  for (auto &sendingPAIOp : sendingPAI->getArgumentOperands()) {
+    auto trackableValue = valueMap.getTrackableValue(sendingPAIOp.get());
+    if (trackableValue.value.isSendable())
+      continue;
+
+    auto capturedValue = findClosureUse(&sendingPAIOp);
+    if (!capturedValue)
+      continue;
+
+    auto *diagnosticOp = capturedValue->first;
+
+    if (auto rootValueAndName = inferNameAndRootHelper(sendingPAIOp.get())) {
+      auto callerIsolation =
+          SILIsolationInfo::getFunctionIsolation(op->getFunction());
+      bool callerIsNonisolated = !callerIsolation;
+      StringRef callerIsolationStr;
+      if (!callerIsNonisolated)
+        callerIsolationStr =
+            callerIsolation.printForDiagnostics(op->getFunction());
+      diagnosticEmitter.emitAssumeIsolatedClosure(
+          diagnosticOp->getUser()->getLoc(), callSiteLoc,
+          rootValueAndName->first, actorName, callerIsNonisolated,
+          callerIsolationStr);
+      return true;
+    }
+  }
+
+  return false;
 }
 
 void UseAfterSendDiagnosticInferrer::initForApply(Operand *op,
@@ -1505,6 +1589,13 @@ void UseAfterSendDiagnosticInferrer::infer() {
   }
 
   if (auto *sourceApply = loc.getAsASTNode<ApplyExpr>()) {
+    // Check if this is an assumeIsolated call before trying to get the
+    // isolation crossing, since assumeIsolated has no AST-level crossing.
+    if (auto fas = FullApplySite::isa(sendingOp->getUser())) {
+      if (initForAssumeIsolated(fas, sendingOp))
+        return;
+    }
+
     // Before we do anything further, see if we can find a name and emit a name
     // error.
     if (auto rootValueAndName = inferNameAndRootHelper(sendingOp->get())) {
@@ -1758,6 +1849,20 @@ public:
                  diag::regionbasedisolation_named_isolated_closure_yields_race,
                  isDisconnected, descriptiveKindStr, name, calleeIsolationStr,
                  callerIsolationStr);
+  }
+
+  void emitAssumeIsolatedClosure(SILLocation captureLoc,
+                                 SILLocation callSiteLoc, Identifier name,
+                                 Identifier actorName) {
+    emitNamedOnlyError(captureLoc, name);
+    auto isTaskIsolated = getIsolationRegionInfo()->isTaskIsolated();
+    auto callerIsolationStr =
+        getIsolationRegionInfo().printForDiagnostics(getFunction());
+    diagnoseNote(captureLoc,
+                 diag::regionbasedisolation_assume_isolated_closure_capture,
+                 actorName, name, isTaskIsolated, callerIsolationStr);
+    diagnoseNote(callSiteLoc, diag::regionbasedisolation_assume_isolated_callee,
+                 actorName);
   }
 
   void
@@ -2093,6 +2198,8 @@ private:
 
   bool initForSendingPartialApply(FullApplySite fas, Operand *pai);
 
+  bool initForAssumeIsolated(FullApplySite fas, Operand *op);
+
   std::optional<unsigned>
   getIsolatedValuePartialApplyIndex(PartialApplyInst *pai,
                                     SILValue isolatedValue) {
@@ -2206,6 +2313,56 @@ bool SentNeverSendableDiagnosticEmitter::initForSendingPartialApply(
   diagnosticEmitter.emitSendingClosureMultipleCapturedOperandError(
       callsiteOp->getUser()->getLoc(), nonSendableOps);
   return true;
+}
+
+bool SentNeverSendableDiagnosticEmitter::initForAssumeIsolated(
+    FullApplySite fas, Operand *op) {
+  auto *callee = fas.getCalleeFunction();
+  if (!callee)
+    return false;
+
+  if (callee->getName() != MANGLED_ACTOR_ASSUME_ISOLATED &&
+      callee->getName() != MANGLED_DISTRIBUTED_ACTOR_ASSUME_ISOLATED)
+    return false;
+
+  // Get the partial_apply that is the closure being sent into assumeIsolated.
+  auto *sendingPAI =
+      dyn_cast<PartialApplyInst>(stripFunctionConversions(op->get()));
+  if (!sendingPAI)
+    return false;
+
+  // Get the actor name from the self argument of assumeIsolated.
+  auto argsWithoutIndirectResults = fas.getOperandsWithoutIndirectResults();
+  auto actorArg = argsWithoutIndirectResults.back().get();
+  Identifier actorName;
+  if (auto actorNameAndRoot = inferNameAndRootHelper(actorArg))
+    actorName = actorNameAndRoot->first;
+
+  // Emit the error at the capture use site inside the closure body (matching
+  // normal closure capture diagnostics), with a note explaining the capture,
+  // and a second note at the assumeIsolated call site explaining where the
+  // dynamic actor isolation comes from.
+  auto callSiteLoc = fas.getLoc();
+  for (auto &sendingPAIOp : sendingPAI->getArgumentOperands()) {
+    auto trackableValue = valueMap.getTrackableValue(sendingPAIOp.get());
+    if (trackableValue.value.isSendable())
+      continue;
+
+    auto capturedValue = findClosureUse(&sendingPAIOp);
+    if (!capturedValue)
+      continue;
+
+    auto *diagnosticOp = capturedValue->first;
+
+    if (auto rootValueAndName = inferNameAndRootHelper(sendingPAIOp.get())) {
+      diagnosticEmitter.emitAssumeIsolatedClosure(
+          diagnosticOp->getUser()->getLoc(), callSiteLoc,
+          rootValueAndName->first, actorName);
+      return true;
+    }
+  }
+
+  return false;
 }
 
 bool SentNeverSendableDiagnosticEmitter::initForIsolatedPartialApply(
@@ -2354,6 +2511,15 @@ bool SentNeverSendableDiagnosticEmitter::emit() {
 
     // If we could not infer an isolation...
     if (!isolation) {
+      // Check if we are in an assumeIsolated call. If so, we handle the
+      // diagnostics specially since assumeIsolated has no AST-level isolation
+      // crossing but the region analysis treats it as sending the closure
+      // into actor isolation.
+      if (auto fas = FullApplySite::isa(op->getUser())) {
+        if (initForAssumeIsolated(fas, op))
+          return true;
+      }
+
       // Otherwise, emit a "we don't know error" that tells the user to file a
       // bug.
       diagnosticEmitter.emitUnknownPatternError();

--- a/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
@@ -169,6 +169,35 @@ static std::optional<SILDeclRef> getDeclRefForCallee(SILInstruction *inst) {
   }
 }
 
+/// Returns the ConstructorDecl if \p inst is a call to a nonisolated
+/// synchronous actor allocating init, nullptr otherwise. These inits are not
+/// actor-isolated, but SE-0414 specifies a special rule where non-Sendable
+/// arguments are treated as transferred into the actor's isolation domain.
+static ConstructorDecl *
+getNonisolatedSyncActorAllocatingInitCallee(SILInstruction *inst) {
+  auto declRef = getDeclRefForCallee(inst);
+  if (!declRef || declRef->kind != SILDeclRef::Kind::Allocator)
+    return nullptr;
+  auto fas = FullApplySite::isa(inst);
+  if (!fas)
+    return nullptr;
+  auto *fri = dyn_cast<FunctionRefInst>(fas.getCalleeOrigin());
+  if (!fri)
+    return nullptr;
+  auto *callee = fri->getReferencedFunctionOrNull();
+  if (!callee || callee->isAsync())
+    return nullptr;
+  if (!callee->getActorIsolation().isNonisolated())
+    return nullptr;
+  auto *ctorDecl = dyn_cast_or_null<ConstructorDecl>(declRef->getDecl());
+  if (!ctorDecl)
+    return nullptr;
+  auto *nominal = ctorDecl->getDeclContext()->getSelfNominalTypeDecl();
+  if (!nominal || !nominal->isAnyActor())
+    return nullptr;
+  return ctorDecl;
+}
+
 static std::optional<ValueDecl *> getSendingApplyCallee(SILInstruction *inst) {
   auto declRef = getDeclRefForCallee(inst);
   if (!declRef)
@@ -961,6 +990,28 @@ public:
     emitRequireInstDiagnostics();
   }
 
+  void emitNamedActorAsyncInitIsolationCrossingError(
+      SILLocation loc, Identifier name,
+      SILIsolationInfo namedValuesIsolationInfo,
+      ApplyIsolationCrossing isolationCrossing,
+      const ValueDecl *callee) {
+    diagnoseError(loc, diag::regionbasedisolation_named_send_yields_race, name)
+        .limitBehaviorIf(getBehaviorLimit());
+
+    auto descriptiveKindStr =
+        namedValuesIsolationInfo.printForDiagnostics(getFunction());
+    auto callerIsolationStr =
+        SILIsolationInfo::printActorIsolationForDiagnostics(
+            getFunction(), isolationCrossing.getCallerIsolation());
+    bool isDisconnected = namedValuesIsolationInfo.isDisconnected();
+
+    diagnoseNote(
+        loc,
+        diag::regionbasedisolation_named_info_send_to_actor_init_yields_race,
+        isDisconnected, name, descriptiveKindStr, callee, callerIsolationStr);
+    emitRequireInstDiagnostics();
+  }
+
   void emitNamedAsyncLetNoIsolationCrossingError(SILLocation loc,
                                                  Identifier name) {
     // Emit the short error.
@@ -1600,6 +1651,17 @@ void UseAfterSendDiagnosticInferrer::infer() {
     // error.
     if (auto rootValueAndName = inferNameAndRootHelper(sendingOp->get())) {
       auto &state = sendingOpToStateMap.get(sendingOp);
+
+      // Check if this is a call to an actor async allocating init. These
+      // are not actually actor-isolated, but have a special rule that
+      // arguments are treated as crossing into actor isolation.
+      if (auto *ctorDecl =
+              getNonisolatedSyncActorAllocatingInitCallee(sendingOp->getUser())) {
+        return diagnosticEmitter.emitNamedActorAsyncInitIsolationCrossingError(
+            baseLoc, rootValueAndName->first, state.getIsolationInfo(),
+            *sourceApply->getIsolationCrossing(), ctorDecl);
+      }
+
       return diagnosticEmitter.emitNamedIsolationCrossingError(
           baseLoc, rootValueAndName->first, state.getIsolationInfo(),
           *sourceApply->getIsolationCrossing());
@@ -2079,6 +2141,21 @@ public:
     }
   }
 
+  void emitNamedActorAsyncInitIsolation(SILLocation loc, Identifier name,
+                                        ApplyIsolationCrossing isolationCrossing,
+                                        const ValueDecl *callee) {
+    emitNamedOnlyError(loc, name);
+
+    auto descriptiveKindStr =
+        getIsolationRegionInfo().printForDiagnostics(getFunction());
+    bool isDisconnected = getIsolationRegionInfo().isDisconnected();
+
+    diagnoseNote(
+        loc,
+        diag::regionbasedisolation_named_send_to_actor_init_never_sendable,
+        isDisconnected, name, descriptiveKindStr, callee, descriptiveKindStr);
+  }
+
   void emitNamedSendingNeverSendableToSendingParam(SILLocation loc,
                                                    Identifier varName) {
     emitNamedOnlyError(loc, varName);
@@ -2538,6 +2615,13 @@ bool SentNeverSendableDiagnosticEmitter::emit() {
 
     // See if we can infer a name from the value.
     if (auto name = inferNameHelper(op->get())) {
+      // Check if this is a call to an actor async allocating init.
+      if (auto *ctorDecl = getNonisolatedSyncActorAllocatingInitCallee(op->getUser())) {
+        diagnosticEmitter.emitNamedActorAsyncInitIsolation(loc, *name,
+                                                           *isolation,
+                                                           ctorDecl);
+        return true;
+      }
       diagnosticEmitter.emitNamedIsolation(loc, *name, *isolation);
       return true;
     }

--- a/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
@@ -1372,6 +1372,11 @@ bool UseAfterSendDiagnosticInferrer::initForSendingPartialApply(
     auto trackableValue = valueMap.getTrackableValue(sendingPAIOp.get());
     if (trackableValue.value.isSendable())
       continue;
+    // Skip nonisolated(unsafe) captures -- the user has opted out of isolation
+    // checking for these values, so they should not be diagnosed as
+    // non-Sendable captures of a sending closure.
+    if (trackableValue.value.getIsolationRegionInfo().isUnsafeNonIsolated())
+      continue;
     nonSendableOps.push_back(&sendingPAIOp);
   }
 
@@ -2366,6 +2371,8 @@ bool SentNeverSendableDiagnosticEmitter::initForSendingPartialApply(
     // value... then we are done. This is a 'correct' error value to emit.
     auto trackableValue = valueMap.getTrackableValue(sendingPAIOp.get());
     if (trackableValue.value.isSendable())
+      continue;
+    if (trackableValue.value.getIsolationRegionInfo().isUnsafeNonIsolated())
       continue;
 
     auto rep = trackableValue.value.getRepresentative().maybeGetValue();

--- a/lib/SILOptimizer/Utils/SILIsolationInfo.cpp
+++ b/lib/SILOptimizer/Utils/SILIsolationInfo.cpp
@@ -670,6 +670,18 @@ SILIsolationInfo SILIsolationInfo::get(SILInstruction *inst) {
       // TODO: Make sure that synchronous functions that are isolated to an
       // actor always get the isolated parameter.
       if (isolation.getKind() == ActorIsolation::ActorInstance) {
+        // Actor async allocating inits don't have an isolated parameter
+        // (they take a metatype, not an actor instance), but their
+        // parameters conceptually cross into actor isolation.
+        auto *func = fri->getReferencedFunction();
+        if (auto declRef = func->getDeclRef()) {
+          if (declRef.kind == SILDeclRef::Kind::Allocator &&
+              func->isAsync() && isolation.getActor()->isAnyActor()) {
+            return SILIsolationInfo::getActorInstanceIsolated(
+                fri, ActorInstance::getForActorAsyncAllocatingInit(),
+                isolation.getActor());
+          }
+        }
         return SILIsolationInfo::getDisconnected(false /*nonisolated(unsafe)*/);
       }
 

--- a/lib/SILOptimizer/Utils/SILIsolationInfo.cpp
+++ b/lib/SILOptimizer/Utils/SILIsolationInfo.cpp
@@ -595,23 +595,30 @@ SILIsolationInfo SILIsolationInfo::get(SILInstruction *inst) {
               .withUnsafeNonIsolated(partialApplyIsNonIsolatedUnsafe);
         }
 
-        // For now, if we do not have an actor instance, just create an actor
-        // instance isolated without an actor instance.
+        // In this case, we do not have an actor isolated instance, so we do not
+        // know the actual actor that this partial_apply is isolated to. Mark is
+        // as disconnected... when we apply the partial_apply, we will merge in
+        // the actor's isolation as appropriate.
         //
-        // If we do not have an actor instance, that means that we have a
-        // partial apply for which the isolated parameter was not closed over
-        // and is an actual argument that we pass in. This means that the
-        // partial apply is actually flow sensitive in terms of which specific
-        // actor instance we are isolated to.
+        // The real question here is what do we do for things that are captured
+        // within it. Here is what is interesting about this:
         //
-        // TODO: How do we want to resolve this.
-        return SILIsolationInfo::getPartialApplyActorInstanceIsolated(
-                   pai, actorIsolation.getActor())
-            .withUnsafeNonIsolated(partialApplyIsNonIsolatedUnsafe);
+        // 1. If anything captured by the partial_apply is isolated, the
+        // partial_apply becomes isolated and if we apply it to an actor that
+        // has a differing isolation, we will get an error at the apply
+        // site. This also means that if we send the partial_apply or anything
+        // contained within the partial_apply to another isolation domain, we
+        // cannot invoke it again locally as expected no matter the actor unless
+        // that is the same actor as where we sent it to which should just work.
+        //
+        // 2. If everything captured by the partial_apply is disconnected, then
+        // we should be able to send it to another isolation domain. If we do
+        // so, then when it is in that other isolation domain, we should be able
+        // to invoke it there since we will not be using it again locally. So
+        // that should work.
+        return SILIsolationInfo::getDisconnected(
+            partialApplyIsNonIsolatedUnsafe);
       }
-
-      assert(actorIsolation.getKind() != ActorIsolation::Erased &&
-             "Implement this!");
     }
 
     if (partialApplyIsNonIsolatedUnsafe)
@@ -654,14 +661,16 @@ SILIsolationInfo SILIsolationInfo::get(SILInstruction *inst) {
             fri, isolation.getGlobalActor());
       }
 
-      // TODO: We need to be able to support flow sensitive actor instances
-      // like we do for partial apply. Until we do so, just store SILValue()
-      // for this. This could cause a problem if we can construct a function
-      // ref and invoke it with two different actor instances of the same type
-      // and pass in the same parameters to both. We should error and we would
-      // not with this impl since we could not distinguish the two.
+      // If we are actor isolated, we do not know which specific actor
+      // instance we are isolated to. We should be able to figure this out
+      // later based off of the isolated parameter. So we can just return this
+      // as disconnected since when we apply the actor isolation, we should
+      // get the actor isolation.
+      //
+      // TODO: Make sure that synchronous functions that are isolated to an
+      // actor always get the isolated parameter.
       if (isolation.getKind() == ActorIsolation::ActorInstance) {
-        return SILIsolationInfo::getFlowSensitiveActorIsolated(fri, isolation);
+        return SILIsolationInfo::getDisconnected(false /*nonisolated(unsafe)*/);
       }
 
       assert(isolation.getKind() != ActorIsolation::Erased &&
@@ -1718,6 +1727,13 @@ bool SILIsolationInfo::isNonSendableType(SILType type, SILFunction *fn) {
   if (type.getASTType()->is<SILTokenType>()) {
     return false;
   }
+
+  // Treat thin functions as Sendable. They do not contain any State that can
+  // cause anything to escape. Of course, if we make it a thick function this
+  // changes.
+  if (auto *fTy = type.getASTType()->getAs<SILFunctionType>();
+      fTy && fTy->getRepresentation() == SILFunctionType::Representation::Thin)
+    return false;
 
   // First before we do anything, see if we have a Sendable type. In such a
   // case, just return true early.

--- a/test/Concurrency/concurrent_value_checking.swift
+++ b/test/Concurrency/concurrent_value_checking.swift
@@ -67,7 +67,7 @@ actor A2 {
 func testActorCreation(value: NotConcurrent) async {
   _ = A2(value: value)
   // expected-warning @-1 {{sending 'value' risks causing data races}}
-  // expected-note @-2 {{sending task-isolated 'value' to actor-isolated initializer 'init(value:)' risks causing data races between actor-isolated and task-isolated uses}}
+  // expected-note @-2 {{sending task-isolated 'value' to actor initializer 'init(value:)' risks causing data races between actor-isolated and task-isolated uses}}
 
   _ = await A2(valueAsync: value)
   // expected-warning @-1 {{sending 'value' risks causing data races}}
@@ -75,7 +75,7 @@ func testActorCreation(value: NotConcurrent) async {
 
   _ = A2(delegatingSync: value)
   // expected-warning @-1 {{sending 'value' risks causing data races}}
-  // expected-note @-2 {{sending task-isolated 'value' to actor-isolated initializer 'init(delegatingSync:)' risks causing data races between actor-isolated and task-isolated uses}}
+  // expected-note @-2 {{sending task-isolated 'value' to actor initializer 'init(delegatingSync:)' risks causing data races between actor-isolated and task-isolated uses}}
 
   _ = await A2(delegatingAsync: value, 9)
   // expected-warning @-1 {{sending 'value' risks causing data races}}

--- a/test/Concurrency/silisolationinfo_inference.sil
+++ b/test/Concurrency/silisolationinfo_inference.sil
@@ -2081,7 +2081,7 @@ bb0(%0 : @guaranteed $Builtin.ImplicitActor, %1 : @guaranteed $NonSendableKlass)
 // CHECK-LABEL: begin running test 1 of 1 on unapplied_isolated_any_test: sil_isolation_info_inference with: @trace[0]
 // CHECK-NEXT: Input Value:   // function_ref unappliedIsolatedAnyParameter
 // CHECK-NEXT:   %0 = function_ref @unappliedIsolatedAnyParameter : $@convention(method) @async (@sil_isolated @guaranteed Optional<any Actor>, @guaranteed NonSendableKlass) -> @owned NonSendableKlass
-// CHECK-NEXT: Isolation: actor-isolated: unapplied_isolated_any_parameter
+// CHECK-NEXT: Isolation: disconnected
 // CHECK-NEXT: end running test 1 of 1 on unapplied_isolated_any_test: sil_isolation_info_inference with: @trace[0]
 sil [ossa] @unapplied_isolated_any_test : $@convention(thin) () -> () {
 bb0:
@@ -2095,7 +2095,7 @@ bb0:
 // CHECK-LABEL: begin running test 1 of 1 on unapplied_isolated_any_merge_test: sil-isolation-info-merged-inference with: @trace[0], @trace[1]
 // CHECK-NEXT: First Value:   // function_ref unappliedIsolatedAnyParameter
 // CHECK-NEXT:   %2 = function_ref @unappliedIsolatedAnyParameter : $@convention(method) @async (@sil_isolated @guaranteed Optional<any Actor>, @guaranteed NonSendableKlass) -> @owned NonSendableKlass
-// CHECK-NEXT: First Isolation: actor-isolated: unapplied_isolated_any_parameter
+// CHECK-NEXT: First Isolation: disconnected
 // CHECK-NEXT: Second Value: %1 = argument of bb0 : $NonSendableKlass
 // CHECK-NEXT: Second Isolation: task-isolated: task_isolated_from_nonisolated_nonsending_parameter
 // CHECK-NEXT: Merged Isolation: task-isolated: task_isolated_from_nonisolated_nonsending_parameter

--- a/test/Concurrency/transfernonsendable_assume_isolated.sil
+++ b/test/Concurrency/transfernonsendable_assume_isolated.sil
@@ -1,0 +1,138 @@
+// RUN: %target-sil-opt -send-non-sendable -swift-version 6 %s -verify -o /dev/null
+
+// REQUIRES: concurrency
+// REQUIRES: asserts
+
+// Tests that Actor.assumeIsolated and DistributedActor.assumeIsolated are
+// recognized by translateAssumeIsolated in RegionAnalysis and produce send
+// diagnostics for non-sendable captures.
+
+sil_stage raw
+
+import Swift
+import Builtin
+import _Concurrency
+
+class NonSendableKlass {}
+
+actor MyActor {
+  var ns: NonSendableKlass
+}
+
+sil @use_nonsendable : $@convention(thin) (@guaranteed NonSendableKlass) -> ()
+
+// Actor.assumeIsolated<A>(_:file:line:)
+sil hidden_external [serialized] @$sScAsE14assumeIsolated_4file4lineqd__qd__xYiKXE_s12StaticStringVSutKs8SendableRd__lF : $@convention(method) <τ_0_0 where τ_0_0 : Actor><τ_1_0 where τ_1_0 : Sendable> (@guaranteed @noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_0 : AnyObject> (@sil_isolated @guaranteed τ_0_0) -> (@out τ_0_1, @error any Error) for <τ_0_0, τ_1_0>, StaticString, UInt, @guaranteed τ_0_0) -> (@out τ_1_0, @error any Error)
+
+// (extension in Distributed):DistributedActor.assumeIsolated<A>(_:file:line:)
+sil hidden_external [serialized] @$s11Distributed0A5ActorPAAE14assumeIsolated_4file4lineqd__qd__xYiKXE_s12StaticStringVSutKs8SendableRd__lF : $@convention(method) <τ_0_0 where τ_0_0 : Actor><τ_1_0 where τ_1_0 : Sendable> (@guaranteed @noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_0 : AnyObject> (@sil_isolated @guaranteed τ_0_0) -> (@out τ_0_1, @error any Error) for <τ_0_0, τ_1_0>, StaticString, UInt, @guaranteed τ_0_0) -> (@out τ_1_0, @error any Error)
+
+sil [transparent] [serialized] [readonly] @$ss12StaticStringV08_builtinB7Literal17utf8CodeUnitCount7isASCIIABBp_BwBi1_tcfC : $@convention(method) (Builtin.RawPointer, Builtin.Word, Builtin.Int1, @thin StaticString.Type) -> StaticString
+sil [transparent] [serialized] @$sSu22_builtinIntegerLiteralSuBI_tcfC : $@convention(method) (Builtin.IntLiteral, @thin UInt.Type) -> UInt
+
+// =============================================================================
+// Test 1: Actor.assumeIsolated — non-sendable capture triggers send diagnostic
+// =============================================================================
+
+sil private [ossa] @closure_actor : $@convention(thin) @substituted <τ_0_0, τ_0_1 where τ_0_0 : AnyObject> (@sil_isolated @guaranteed τ_0_0, @guaranteed NonSendableKlass) -> (@out τ_0_1, @error any Error) for <MyActor, ()> {
+bb0(%0 : $*(), %1 : @guaranteed $MyActor, %2 : @closureCapture @guaranteed $NonSendableKlass):
+  debug_value %1, let, name "isolatedSelf", argno 1
+  debug_value %2, let, name "nsArg", argno 3
+  %use = function_ref @use_nonsendable : $@convention(thin) (@guaranteed NonSendableKlass) -> ()
+  %call = apply %use(%2) : $@convention(thin) (@guaranteed NonSendableKlass) -> ()
+  %r = tuple ()
+  return %r : $()
+}
+
+sil hidden [ossa] @test_actor_assume_isolated : $@convention(method) (@guaranteed NonSendableKlass, @guaranteed MyActor) -> () {
+bb0(%0 : @guaranteed $NonSendableKlass, %1 : @guaranteed $MyActor):
+  debug_value %0, let, name "nsArg", argno 1
+  debug_value %1, let, name "self", argno 2
+  %4 = alloc_stack $()
+  %5 = function_ref @closure_actor : $@convention(thin) @substituted <τ_0_0, τ_0_1 where τ_0_0 : AnyObject> (@sil_isolated @guaranteed τ_0_0, @guaranteed NonSendableKlass) -> (@out τ_0_1, @error any Error) for <MyActor, ()>
+  %6 = copy_value %0
+  %7 = partial_apply [callee_guaranteed] %5(%6) : $@convention(thin) @substituted <τ_0_0, τ_0_1 where τ_0_0 : AnyObject> (@sil_isolated @guaranteed τ_0_0, @guaranteed NonSendableKlass) -> (@out τ_0_1, @error any Error) for <MyActor, ()>
+  %8 = convert_escape_to_noescape [not_guaranteed] %7 to $@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_0 : AnyObject> (@sil_isolated @guaranteed τ_0_0) -> (@out τ_0_1, @error any Error) for <MyActor, ()>
+  %9 = string_literal utf8 "test.swift"
+  %10 = integer_literal $Builtin.Word, 10
+  %11 = integer_literal $Builtin.Int1, -1
+  %12 = metatype $@thin StaticString.Type
+  %13 = function_ref @$ss12StaticStringV08_builtinB7Literal17utf8CodeUnitCount7isASCIIABBp_BwBi1_tcfC : $@convention(method) (Builtin.RawPointer, Builtin.Word, Builtin.Int1, @thin StaticString.Type) -> StaticString
+  %14 = apply %13(%9, %10, %11, %12) : $@convention(method) (Builtin.RawPointer, Builtin.Word, Builtin.Int1, @thin StaticString.Type) -> StaticString
+  %15 = integer_literal $Builtin.IntLiteral, 10
+  %16 = metatype $@thin UInt.Type
+  %17 = function_ref @$sSu22_builtinIntegerLiteralSuBI_tcfC : $@convention(method) (Builtin.IntLiteral, @thin UInt.Type) -> UInt
+  %18 = apply %17(%15, %16) : $@convention(method) (Builtin.IntLiteral, @thin UInt.Type) -> UInt
+  %19 = function_ref @$sScAsE14assumeIsolated_4file4lineqd__qd__xYiKXE_s12StaticStringVSutKs8SendableRd__lF : $@convention(method) <τ_0_0 where τ_0_0 : Actor><τ_1_0 where τ_1_0 : Sendable> (@guaranteed @noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_0 : AnyObject> (@sil_isolated @guaranteed τ_0_0) -> (@out τ_0_1, @error any Error) for <τ_0_0, τ_1_0>, StaticString, UInt, @guaranteed τ_0_0) -> (@out τ_1_0, @error any Error)
+  try_apply %19<MyActor, ()>(%4, %8, %14, %18, %1) : $@convention(method) <τ_0_0 where τ_0_0 : Actor><τ_1_0 where τ_1_0 : Sendable> (@guaranteed @noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_0 : AnyObject> (@sil_isolated @guaranteed τ_0_0) -> (@out τ_0_1, @error any Error) for <τ_0_0, τ_1_0>, StaticString, UInt, @guaranteed τ_0_0) -> (@out τ_1_0, @error any Error), normal bb1, error bb2 // expected-error {{task or actor-isolated value cannot be sent}}
+
+bb1(%21 : $()):
+  destroy_value %8
+  destroy_value %7
+  %24 = load [trivial] %4
+  dealloc_stack %4
+  %26 = tuple ()
+  return %26 : $()
+
+bb2(%28 : @owned $any Error):
+  destroy_value %28
+  destroy_value %8
+  destroy_value %7
+  dealloc_stack %4
+  unreachable
+}
+
+// =============================================================================
+// Test 2: DistributedActor.assumeIsolated — same pattern, different mangled name
+// =============================================================================
+
+sil private [ossa] @closure_distributed : $@convention(thin) @substituted <τ_0_0, τ_0_1 where τ_0_0 : AnyObject> (@sil_isolated @guaranteed τ_0_0, @guaranteed NonSendableKlass) -> (@out τ_0_1, @error any Error) for <MyActor, ()> {
+bb0(%0 : $*(), %1 : @guaranteed $MyActor, %2 : @closureCapture @guaranteed $NonSendableKlass):
+  debug_value %1, let, name "isolatedSelf", argno 1
+  debug_value %2, let, name "nsArg", argno 3
+  %use = function_ref @use_nonsendable : $@convention(thin) (@guaranteed NonSendableKlass) -> ()
+  %call = apply %use(%2) : $@convention(thin) (@guaranteed NonSendableKlass) -> ()
+  %r = tuple ()
+  return %r : $()
+}
+
+sil hidden [ossa] @test_distributed_actor_assume_isolated : $@convention(method) (@guaranteed NonSendableKlass, @guaranteed MyActor) -> () {
+bb0(%0 : @guaranteed $NonSendableKlass, %1 : @guaranteed $MyActor):
+  debug_value %0, let, name "nsArg", argno 1
+  debug_value %1, let, name "self", argno 2
+  %4 = alloc_stack $()
+  %5 = function_ref @closure_distributed : $@convention(thin) @substituted <τ_0_0, τ_0_1 where τ_0_0 : AnyObject> (@sil_isolated @guaranteed τ_0_0, @guaranteed NonSendableKlass) -> (@out τ_0_1, @error any Error) for <MyActor, ()>
+  %6 = copy_value %0
+  %7 = partial_apply [callee_guaranteed] %5(%6) : $@convention(thin) @substituted <τ_0_0, τ_0_1 where τ_0_0 : AnyObject> (@sil_isolated @guaranteed τ_0_0, @guaranteed NonSendableKlass) -> (@out τ_0_1, @error any Error) for <MyActor, ()>
+  %8 = convert_escape_to_noescape [not_guaranteed] %7 to $@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_0 : AnyObject> (@sil_isolated @guaranteed τ_0_0) -> (@out τ_0_1, @error any Error) for <MyActor, ()>
+  %9 = string_literal utf8 "test.swift"
+  %10 = integer_literal $Builtin.Word, 10
+  %11 = integer_literal $Builtin.Int1, -1
+  %12 = metatype $@thin StaticString.Type
+  %13 = function_ref @$ss12StaticStringV08_builtinB7Literal17utf8CodeUnitCount7isASCIIABBp_BwBi1_tcfC : $@convention(method) (Builtin.RawPointer, Builtin.Word, Builtin.Int1, @thin StaticString.Type) -> StaticString
+  %14 = apply %13(%9, %10, %11, %12) : $@convention(method) (Builtin.RawPointer, Builtin.Word, Builtin.Int1, @thin StaticString.Type) -> StaticString
+  %15 = integer_literal $Builtin.IntLiteral, 10
+  %16 = metatype $@thin UInt.Type
+  %17 = function_ref @$sSu22_builtinIntegerLiteralSuBI_tcfC : $@convention(method) (Builtin.IntLiteral, @thin UInt.Type) -> UInt
+  %18 = apply %17(%15, %16) : $@convention(method) (Builtin.IntLiteral, @thin UInt.Type) -> UInt
+  %19 = function_ref @$s11Distributed0A5ActorPAAE14assumeIsolated_4file4lineqd__qd__xYiKXE_s12StaticStringVSutKs8SendableRd__lF : $@convention(method) <τ_0_0 where τ_0_0 : Actor><τ_1_0 where τ_1_0 : Sendable> (@guaranteed @noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_0 : AnyObject> (@sil_isolated @guaranteed τ_0_0) -> (@out τ_0_1, @error any Error) for <τ_0_0, τ_1_0>, StaticString, UInt, @guaranteed τ_0_0) -> (@out τ_1_0, @error any Error)
+  try_apply %19<MyActor, ()>(%4, %8, %14, %18, %1) : $@convention(method) <τ_0_0 where τ_0_0 : Actor><τ_1_0 where τ_1_0 : Sendable> (@guaranteed @noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_0 : AnyObject> (@sil_isolated @guaranteed τ_0_0) -> (@out τ_0_1, @error any Error) for <τ_0_0, τ_1_0>, StaticString, UInt, @guaranteed τ_0_0) -> (@out τ_1_0, @error any Error), normal bb1, error bb2 // expected-error {{task or actor-isolated value cannot be sent}}
+
+bb1(%21 : $()):
+  destroy_value %8
+  destroy_value %7
+  %24 = load [trivial] %4
+  dealloc_stack %4
+  %26 = tuple ()
+  return %26 : $()
+
+bb2(%28 : @owned $any Error):
+  destroy_value %28
+  destroy_value %8
+  destroy_value %7
+  dealloc_stack %4
+  unreachable
+}
+
+sil_vtable NonSendableKlass {}
+sil_vtable MyActor {}

--- a/test/Concurrency/transfernonsendable_assume_isolated.swift
+++ b/test/Concurrency/transfernonsendable_assume_isolated.swift
@@ -1,0 +1,282 @@
+// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -disable-availability-checking -verify %s -o /dev/null -swift-version 6
+
+// REQUIRES: concurrency
+// REQUIRES: asserts
+
+// Tests for sending diagnostics through Actor.assumeIsolated and
+// MainActor.assumeIsolated.
+
+class NonSendableKlass {
+  var x = 0
+}
+
+func useValue<T>(_ t: T) {}
+
+// =============================================================================
+// MARK: Actor.assumeIsolated — SentNeverSendable
+// =============================================================================
+
+actor ProtectsNonSendable {
+  var ns: NonSendableKlass = .init()
+
+  nonisolated func testParameter(_ nsArg: NonSendableKlass) {
+    self.assumeIsolated { isolatedSelf in // expected-note {{passing closure to 'assumeIsolated' here causes closure to become isolated to 'self'}}
+      isolatedSelf.ns = nsArg // expected-error {{sending 'nsArg' risks causing data races}}
+      // expected-note @-1 {{'self'-isolated closure captures 'nsArg' which remains accessible to code in the current task}}
+    }
+  }
+}
+
+// =============================================================================
+// MARK: Actor.assumeIsolated — UseAfterSend
+// =============================================================================
+
+actor ProtectsNonSendable2 {
+  var ns: NonSendableKlass = .init()
+
+  nonisolated func testUseAfterSend() {
+    let ns2 = NonSendableKlass()
+    self.assumeIsolated { isolatedSelf in // expected-note {{passing closure to 'assumeIsolated' here causes closure to become isolated to 'self'}}
+      isolatedSelf.ns = ns2 // expected-error {{sending 'ns2' risks causing data races}}
+      // expected-note @-1 {{'self'-isolated closure captures 'ns2' which remains accessible to code in the current task}}
+    }
+    print(ns2.x) // expected-note {{access can happen concurrently}}
+  }
+}
+
+// =============================================================================
+// MARK: MainActor.assumeIsolated (static) — SentNeverSendable
+// =============================================================================
+
+func testMainActorAssumeIsolated(_ nsArg: NonSendableKlass) {
+  MainActor.assumeIsolated {
+    print(nsArg) // expected-error {{sending 'nsArg' risks causing data races}}
+    // expected-note @-1 {{task-isolated 'nsArg' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+  }
+}
+
+// =============================================================================
+// MARK: MainActor.assumeIsolated (static) — UseAfterSend
+// =============================================================================
+
+func testMainActorUseAfterSend() {
+  let ns2 = NonSendableKlass()
+  MainActor.assumeIsolated {
+    print(ns2) // expected-error {{sending 'ns2' risks causing data races}}
+    // expected-note @-1 {{'ns2' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+  }
+  print(ns2.x) // expected-note {{access can happen concurrently}}
+}
+
+// =============================================================================
+// MARK: Actor.assumeIsolated — Out-of-line closure, SentNeverSendable
+// =============================================================================
+
+actor ProtectsNonSendable3 {
+  var ns: NonSendableKlass = .init()
+
+  nonisolated func testOutOfLineClosure(_ nsArg: NonSendableKlass) {
+    let closure: (isolated ProtectsNonSendable3) -> () = { isolatedSelf in
+      isolatedSelf.ns = nsArg // expected-error {{sending 'nsArg' risks causing data races}}
+      // expected-note @-1 {{'self'-isolated closure captures 'nsArg' which remains accessible to code in the current task}}
+    }
+    self.assumeIsolated(closure) // expected-note {{passing closure to 'assumeIsolated' here causes closure to become isolated to 'self'}}
+  }
+}
+
+// =============================================================================
+// MARK: Actor.assumeIsolated — Out-of-line closure, UseAfterSend
+// =============================================================================
+
+actor ProtectsNonSendable4 {
+  var ns: NonSendableKlass = .init()
+
+  nonisolated func testOutOfLineClosureUseAfterSend() {
+    let ns2 = NonSendableKlass()
+    let closure: (isolated ProtectsNonSendable4) -> () = { isolatedSelf in
+      isolatedSelf.ns = ns2 // expected-error {{sending 'ns2' risks causing data races}}
+      // expected-note @-1 {{'self'-isolated closure captures 'ns2' which remains accessible to code in the current task}}
+    }
+    self.assumeIsolated(closure) // expected-note {{passing closure to 'assumeIsolated' here causes closure to become isolated to 'self'}}
+    print(ns2.x) // expected-note {{access can happen concurrently}}
+  }
+}
+
+// =============================================================================
+// MARK: Actor.assumeIsolated — UseAfterSend, no use after (safe)
+// =============================================================================
+
+actor ProtectsNonSendable5 {
+  var ns: NonSendableKlass = .init()
+
+  nonisolated func testNoUseAfterSend() {
+    let ns2 = NonSendableKlass()
+    self.assumeIsolated { isolatedSelf in
+      isolatedSelf.ns = ns2
+    }
+  }
+}
+
+// =============================================================================
+// MARK: Actor.assumeIsolated — UseAfterSend, read-only capture
+// =============================================================================
+
+actor ProtectsNonSendable6 {
+  var ns: NonSendableKlass = .init()
+
+  nonisolated func testCaptureReadOnly() {
+    let ns2 = NonSendableKlass()
+    self.assumeIsolated { isolatedSelf in // expected-note {{passing closure to 'assumeIsolated' here causes closure to become isolated to 'self'}}
+      print(ns2) // expected-error {{sending 'ns2' risks causing data races}}
+      // expected-note @-1 {{'self'-isolated closure captures 'ns2' which remains accessible to code in the current task}}
+    }
+    useValue(ns2) // expected-note {{access can happen concurrently}}
+  }
+}
+
+// =============================================================================
+// MARK: Actor.assumeIsolated — UseAfterSend, multiple non-sendable captures
+// =============================================================================
+
+actor ProtectsNonSendable7 {
+  var ns: NonSendableKlass = .init()
+  var ns2: NonSendableKlass = .init()
+
+  nonisolated func testMultipleNonSendableCaptures() {
+    let a = NonSendableKlass()
+    let b = NonSendableKlass()
+    self.assumeIsolated { isolatedSelf in // expected-note {{passing closure to 'assumeIsolated' here causes closure to become isolated to 'self'}}
+      isolatedSelf.ns = a // expected-error {{sending 'a' risks causing data races}}
+      // expected-note @-1 {{'self'-isolated closure captures 'a' which remains accessible to code in the current task}}
+      isolatedSelf.ns2 = b
+    }
+    useValue(a) // expected-note {{access can happen concurrently}}
+  }
+}
+
+// =============================================================================
+// MARK: Actor.assumeIsolated — UseAfterSend, two inline calls
+// =============================================================================
+
+actor ProtectsNonSendable8 {
+  var ns: NonSendableKlass = .init()
+
+  nonisolated func testTwoAssumeIsolatedCalls() {
+    let ns2 = NonSendableKlass()
+    self.assumeIsolated { isolatedSelf in // expected-note {{passing closure to 'assumeIsolated' here causes closure to become isolated to 'self'}}
+      isolatedSelf.ns = ns2 // expected-error {{sending 'ns2' risks causing data races}}
+      // expected-note @-1 {{'self'-isolated closure captures 'ns2' which remains accessible to code in the current task}}
+    }
+    self.assumeIsolated { isolatedSelf in // expected-note {{passing closure to 'assumeIsolated' here causes closure to become isolated to 'self'}}
+      // expected-note @-1 {{access can happen concurrently}}
+      isolatedSelf.ns = ns2 // expected-error {{sending 'ns2' risks causing data races}}
+      // expected-note @-1 {{'self'-isolated closure captures 'ns2' which remains accessible to code in the current task}}
+    }
+    useValue(ns2) // expected-note {{access can happen concurrently}}
+  }
+}
+
+// =============================================================================
+// MARK: Actor.assumeIsolated — UseAfterSend, out-of-line closure used twice
+// =============================================================================
+
+actor ProtectsNonSendable9 {
+  var ns: NonSendableKlass = .init()
+
+  nonisolated func testOutOfLineClosureUsedTwice() {
+    let ns2 = NonSendableKlass()
+    let closure: (isolated ProtectsNonSendable9) -> () = { isolatedSelf in
+      isolatedSelf.ns = ns2 // expected-error 2{{sending 'ns2' risks causing data races}}
+      // expected-note @-1 2{{'self'-isolated closure captures 'ns2' which remains accessible to code in the current task}}
+    }
+    self.assumeIsolated(closure) // expected-note {{passing closure to 'assumeIsolated' here causes closure to become isolated to 'self'}}
+    self.assumeIsolated(closure) // expected-note {{passing closure to 'assumeIsolated' here causes closure to become isolated to 'self'}}
+    // expected-note @-1 {{access can happen concurrently}}
+    useValue(ns2) // expected-note {{access can happen concurrently}}
+  }
+}
+
+// =============================================================================
+// MARK: Cross-actor assumeIsolated — SentNeverSendable
+// =============================================================================
+
+actor CrossActorTarget {
+  var ns: NonSendableKlass = .init()
+}
+
+actor CrossActorSender {
+  func testParameterCrossActor(_ other: CrossActorTarget, _ nsArg: NonSendableKlass) {
+    other.assumeIsolated { isolatedOther in // expected-note {{passing closure to 'assumeIsolated' here causes closure to become isolated to 'other'}}
+      isolatedOther.ns = nsArg // expected-error {{sending 'nsArg' risks causing data races}}
+      // expected-note @-1 {{'other'-isolated closure captures 'nsArg' which remains accessible to 'self'-isolated code}}
+    }
+  }
+}
+
+// =============================================================================
+// MARK: Cross-actor assumeIsolated — UseAfterSend
+// =============================================================================
+
+extension CrossActorSender {
+  func testUseAfterSendCrossActor(_ other: CrossActorTarget) {
+    let ns2 = NonSendableKlass()
+    other.assumeIsolated { isolatedOther in // expected-note {{passing closure to 'assumeIsolated' here causes closure to become isolated to 'other'}}
+      isolatedOther.ns = ns2 // expected-error {{sending 'ns2' risks causing data races}}
+      // expected-note @-1 {{'other'-isolated closure captures 'ns2' which remains accessible to 'self'-isolated code}}
+    }
+    useValue(ns2) // expected-note {{access can happen concurrently}}
+  }
+}
+
+// =============================================================================
+// MARK: Cross-actor assumeIsolated — Out-of-line closure, UseAfterSend
+// =============================================================================
+
+extension CrossActorSender {
+  func testOutOfLineCrossActor(_ other: CrossActorTarget) {
+    let ns2 = NonSendableKlass()
+    let closure: (isolated CrossActorTarget) -> () = { isolatedOther in
+      isolatedOther.ns = ns2 // expected-error {{sending 'ns2' risks causing data races}}
+      // expected-note @-1 {{'other'-isolated closure captures 'ns2' which remains accessible to 'self'-isolated code}}
+    }
+    other.assumeIsolated(closure) // expected-note {{passing closure to 'assumeIsolated' here causes closure to become isolated to 'other'}}
+    useValue(ns2) // expected-note {{access can happen concurrently}}
+  }
+}
+
+// =============================================================================
+// MARK: Cross-actor assumeIsolated — No use after (safe)
+// =============================================================================
+
+extension CrossActorSender {
+  func testNoUseAfterSendCrossActor(_ other: CrossActorTarget) {
+    let ns2 = NonSendableKlass()
+    other.assumeIsolated { isolatedOther in
+      isolatedOther.ns = ns2
+    }
+  }
+}
+
+// =============================================================================
+// MARK: @MainActor to actor assumeIsolated — SentNeverSendable
+// =============================================================================
+
+@MainActor func testMainActorToActorParameter(_ other: CrossActorTarget, _ nsArg: NonSendableKlass) {
+  other.assumeIsolated { isolatedOther in // expected-note {{passing closure to 'assumeIsolated' here causes closure to become isolated to 'other'}}
+    isolatedOther.ns = nsArg // expected-error {{sending 'nsArg' risks causing data races}}
+    // expected-note @-1 {{'other'-isolated closure captures 'nsArg' which remains accessible to main actor-isolated code}}
+  }
+}
+
+// =============================================================================
+// MARK: @MainActor to actor assumeIsolated — UseAfterSend
+// =============================================================================
+
+@MainActor func testMainActorToActorUseAfterSend(_ other: CrossActorTarget) {
+  let ns2 = NonSendableKlass()
+  other.assumeIsolated { isolatedOther in // expected-note {{passing closure to 'assumeIsolated' here causes closure to become isolated to 'other'}}
+    isolatedOther.ns = ns2 // expected-error {{sending 'ns2' risks causing data races}}
+    // expected-note @-1 {{'other'-isolated closure captures 'ns2' which remains accessible to main actor-isolated code}}
+  }
+  useValue(ns2) // expected-note {{access can happen concurrently}}
+}

--- a/test/Concurrency/transfernonsendable_initializers.swift
+++ b/test/Concurrency/transfernonsendable_initializers.swift
@@ -63,18 +63,16 @@ actor ActorWithSynchronousNonIsolatedInit {
 
 func initActorWithSyncNonIsolatedInit() {
   let k = NonSendableKlass()
-  // TODO: This should say actor isolated.
   _ = ActorWithSynchronousNonIsolatedInit(k) // expected-error {{sending 'k' risks causing data races}}
-  // expected-note @-1 {{sending 'k' to actor-isolated initializer 'init(_:)' risks causing data races between actor-isolated and local nonisolated uses}}
+  // expected-note @-1 {{sending 'k' to actor initializer 'init(_:)' risks causing data races between actor-isolated and local nonisolated uses}}
   let _ = { @MainActor in // expected-note {{access can happen concurrently}}
     print(k)
   }
 }
 
 func initActorWithSyncNonIsolatedInit2(_ k: NonSendableKlass) {
-  // TODO: This should say actor isolated.
   _ = ActorWithSynchronousNonIsolatedInit(k) // expected-error {{sending 'k' risks causing data races}}
-  // expected-note @-1 {{sending task-isolated 'k' to actor-isolated initializer 'init(_:)' risks causing data races between actor-isolated and task-isolated uses}}
+  // expected-note @-1 {{sending task-isolated 'k' to actor initializer 'init(_:)' risks causing data races between actor-isolated and task-isolated uses}}
   let _ = { @MainActor in
     print(k) // expected-error {{sending 'k' risks causing data races}}
     // expected-note @-1 {{task-isolated 'k' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
@@ -92,7 +90,6 @@ actor ActorWithAsyncIsolatedInit {
 
 func initActorWithAsyncIsolatedInit() async {
   let k = NonSendableKlass()
-  // TODO: This should say actor isolated.
   _ = await ActorWithAsyncIsolatedInit(k) // expected-error {{sending 'k' risks causing data races}}
   // expected-note @-1 {{sending 'k' to actor-isolated initializer 'init(_:)' risks causing data races between actor-isolated and local nonisolated uses}}
   let _ = { @MainActor in // expected-note {{access can happen concurrently}}
@@ -101,13 +98,80 @@ func initActorWithAsyncIsolatedInit() async {
 }
 
 func initActorWithAsyncIsolatedInit2(_ k: NonSendableKlass) async {
-  // TODO: This should say actor isolated.
   _ = await ActorWithAsyncIsolatedInit(k) // expected-error {{sending 'k' risks causing data races}}
   // expected-note @-1 {{sending task-isolated 'k' to actor-isolated initializer 'init(_:)' risks causing data races between actor-isolated and task-isolated uses}}
   let _ = { @MainActor in
     print(k) // expected-error {{sending 'k' risks causing data races}}
     // expected-note @-1 {{task-isolated 'k' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
   }
+}
+
+// Test with multiple non-sendable arguments.
+actor ActorWithMultiArgAsyncInit {
+  init(_ a: NonSendableKlass, _ b: NonSendableKlass) async {}
+}
+
+func initActorWithMultiArgAsyncInit() async {
+  let a = NonSendableKlass()
+  let b = NonSendableKlass()
+  _ = await ActorWithMultiArgAsyncInit(a, b) // expected-error {{sending 'a' risks causing data races}}
+  // expected-note @-1 {{sending 'a' to actor-isolated initializer 'init(_:_:)' risks causing data races between actor-isolated and local nonisolated uses}}
+  // expected-error @-2 {{sending 'b' risks causing data races}}
+  // expected-note @-3 {{sending 'b' to actor-isolated initializer 'init(_:_:)' risks causing data races between actor-isolated and local nonisolated uses}}
+  let _ = { @MainActor in // expected-note {{access can happen concurrently}}
+    // expected-note @-1 {{access can happen concurrently}}
+    print(a)
+    print(b)
+  }
+}
+
+// Test that sending the same value to two different actor async inits
+// produces errors for both.
+func initActorWithAsyncIsolatedInitTwice() async {
+  let k = NonSendableKlass()
+  _ = await ActorWithAsyncIsolatedInit(k) // expected-error {{sending 'k' risks causing data races}}
+  // expected-note @-1 {{sending 'k' to actor-isolated initializer 'init(_:)' risks causing data races between actor-isolated and local nonisolated uses}}
+  _ = await ActorWithAsyncIsolatedInit(k) // expected-note {{access can happen concurrently}}
+}
+
+// Test use-after-send with actor async init.
+func useAfterSendToActorAsyncInit() async {
+  let k = NonSendableKlass()
+  _ = await ActorWithAsyncIsolatedInit(k) // expected-error {{sending 'k' risks causing data races}}
+  // expected-note @-1 {{sending 'k' to actor-isolated initializer 'init(_:)' risks causing data races between actor-isolated and local nonisolated uses}}
+  print(k) // expected-note {{access can happen concurrently}}
+}
+
+// Test explicit .init(_:) call syntax.
+func initActorWithExplicitInitSyntax() async {
+  let k = NonSendableKlass()
+  _ = await ActorWithAsyncIsolatedInit.init(k) // expected-error {{sending 'k' risks causing data races}}
+  // expected-note @-1 {{sending 'k' to actor-isolated initializer 'init(_:)' risks causing data races between actor-isolated and local nonisolated uses}}
+  let _ = { @MainActor in // expected-note {{access can happen concurrently}}
+    print(k)
+  }
+}
+
+// TODO: The error should be on the use site (f(k)), not the function_ref.
+// Test higher-order: assign init to variable, then call.
+func initActorHigherOrderAssignAndCall() async {
+  let f = ActorWithAsyncIsolatedInit.init // expected-error {{sending 'newK' risks causing data races}}
+  // expected-ni-note @-1 {{sending task-isolated 'newK' to actor-isolated initializer 'init(_:)' risks causing data races between actor-isolated and task-isolated uses}}
+  // expected-ni-ns-note @-2 {{sending @concurrent task-isolated 'newK' to actor-isolated initializer 'init(_:)' risks causing data races between actor-isolated and @concurrent task-isolated uses}}
+  let k = NonSendableKlass()
+  _ = await f(k)
+}
+
+// TODO: The error should be on the use site, not the function_ref.
+// Test higher-order: pass init ref as argument.
+func callWithInit(_ f: (NonSendableKlass) async -> ActorWithAsyncIsolatedInit) async {
+  let k = NonSendableKlass()
+  _ = await f(k)
+}
+
+func initActorHigherOrderPassAsArg() async {
+  await callWithInit(ActorWithAsyncIsolatedInit.init) // expected-error {{sending 'newK' risks causing data races}}
+  // expected-note @-1 {{sending task-isolated 'newK' to actor-isolated initializer 'init(_:)' risks causing data races between actor-isolated and task-isolated uses}}
 }
 
 ////////////////////////////////

--- a/test/Concurrency/transfernonsendable_isolatedparam.sil
+++ b/test/Concurrency/transfernonsendable_isolatedparam.sil
@@ -1,0 +1,1349 @@
+// RUN: %target-sil-opt -send-non-sendable -swift-version 6 %s -verify -o /dev/null
+
+// REQUIRES: concurrency
+// REQUIRES: asserts
+
+// PLEASE READ THIS!
+//
+// This test is specifically meant to test how we handle function_ref and
+// partial_apply with isolated parameters in the send-non-sendable pass
+// (region-based isolation checker).
+//
+// ===== Test Organization =====
+//
+// Group A: Basic function_ref and thick function sends
+//   Test  1: thin_to_thick send + use-after-send
+//   Test  2: Direct function_ref crossing isolation (nonisolated caller)
+//   Test  3: Reverse ordering — use locally first, then send
+//   Test  4: copy_value thick — send copy, use original (region sharing)
+//   Test  5: convert_function tracking
+//
+// Group B: partial_apply isolation tracking
+//   Test  6: BUG — Captures actor field, apply with different actor (not tracked)
+//   Test  7: Captures actor field, apply with same actor (correct: no error)
+//   Test  8: BUG — Region merge with non-@sil_isolated actor (not tracked)
+//   Test  9: 3param merge two klass + actor (correctly caught)
+//   Test 10: BUG — Send closure via partial_apply (not flagged)
+//   Test 11: Independent values not tainted (correct: no false positive)
+//   Test 12: Cross-domain captures ('pattern not understood' error)
+//   Test 13: BUG — @callee_owned same capture bug
+//   Test 14: BUG — Nested closure same capture bug
+//   Test 15: Sendable-only captures, local apply (correct: no error)
+//
+// Group C: Thick vs thin function params and callees
+//   Test 16: Thick closure param as task-isolated callee (correct: error)
+//   Test 17: Thick function param is task-isolated (correct: error)
+//   Test 18: BUG — Thin function param falsely treated as task-isolated
+//   Test 19: Thick callee applied with two actors (correct: callee not tainted)
+//   Test 20: Thin callee applied with two actors (correct: callee not tainted)
+//
+// Group D: Global actor isolation
+//   Test 21: Task-isolated to global actor (correct: error)
+//   Test 22: BUG — Nonisolated to nonisolated falsely flagged as crossing
+//   Test 23: BUG — Actor-isolated to global actor crossing not detected
+//   Test 24: Same global actor (correct: no error)
+//   Test 25: BUG — Global actor A to global actor B crossing not detected
+//
+// Group E: Unannotated applies, crossings, and chains
+//   Test 26: BUG — Apply without [callee_isolation] not detected
+//   Test 27: BUG — Actor-isolated to nonisolated crossing not detected
+//   Test 28: Multiple sends to different domains (correct: all flagged)
+//   Test 29: Chain — receive from actor, send to global actor (correct: errors)
+//
+// ===== Bug Summary =====
+//
+// Tests marked with '// BUG!' document incorrect behavior:
+//   - partial_apply capture isolation not tracked (tests 6, 8, 10, 13, 14)
+//   - Thin function params should be Sendable/disconnected (test 18)
+//   - Nonisolated to nonisolated false positive (test 22)
+//   - Global actor crossings not detected (tests 23, 25)
+//   - Missing [callee_isolation] means no detection (test 34)
+//   - Actor to nonisolated crossing not detected (test 35)
+sil_stage raw
+
+import Swift
+import Builtin
+import _Concurrency
+
+class NonSendableKlass {} // expected-note {{class 'NonSendableKlass' does not conform to the 'Sendable' protocol}}
+
+actor MyActor {
+  var field: NonSendableKlass
+}
+
+actor CustomActorInstance {}
+
+@globalActor
+struct CustomActor {
+  static let shared = CustomActorInstance()
+}
+
+actor CustomActorInstance2 {}
+
+@globalActor
+struct CustomActor2 {
+  static let shared = CustomActorInstance2()
+}
+
+struct NonSendableWrapper {
+  var klass: NonSendableKlass
+}
+
+sil @sync_function_with_isolated : $@convention(thin) (@sil_isolated @guaranteed MyActor) -> ()
+sil @async_function_with_isolated : $@convention(thin) @async (@sil_isolated @guaranteed MyActor) -> ()
+
+sil @sync_function_2param_with_isolated : $@convention(thin) (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+sil @async_function_2param_with_isolated : $@convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+
+sil @async_function_2param_isolated_first : $@convention(thin) @async (@sil_isolated @guaranteed MyActor, @guaranteed NonSendableKlass) -> ()
+
+sil @async_function_actor_and_klass : $@convention(thin) @async (@guaranteed MyActor, @guaranteed NonSendableKlass) -> ()
+
+sil @sync_function_3param_with_isolated : $@convention(thin) (@guaranteed NonSendableKlass, @guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+sil @async_function_3param_with_isolated : $@convention(thin) @async (@guaranteed NonSendableKlass, @guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+
+sil @get_klass : $@convention(thin) () -> @owned NonSendableKlass
+
+sil @use : $@convention(thin) <T> (@guaranteed T, @sil_isolated @guaranteed MyActor) -> ()
+
+sil @take_function : $@convention(thin) @async (@guaranteed @async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> (), @sil_isolated @guaranteed MyActor) -> ()
+
+sil @take_closure_nsk : $@convention(thin) @async (@guaranteed @async @callee_guaranteed (@guaranteed NonSendableKlass) -> (), @sil_isolated @guaranteed MyActor) -> ()
+
+sil [isolation "global_actor(CustomActor)"] @global_actor_function_with_nsk : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
+sil [isolation "global_actor(CustomActor2)"] @global_actor2_function_with_nsk : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
+sil @nonisolated_function_with_nsk : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
+
+sil @async_throwing_2param_with_isolated : $@convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> (@error any Error)
+sil @get_bool : $@convention(thin) () -> Builtin.Int1
+sil @get_wrapper : $@convention(thin) () -> @owned NonSendableWrapper
+
+sil @async_return_nsk_isolated : $@convention(thin) @async (@sil_isolated @guaranteed MyActor) -> @owned NonSendableKlass
+sil @take_noescape_closure : $@convention(thin) @async (@guaranteed @noescape @async @callee_guaranteed (@sil_isolated @guaranteed MyActor) -> (), @sil_isolated @guaranteed MyActor) -> ()
+
+sil @take_thin_fn_isolated : $@convention(thin) @async (@convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> (), @sil_isolated @guaranteed MyActor) -> ()
+sil @get_thin_fn : $@convention(thin) () -> @convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+sil [isolation "global_actor(CustomActor)"] @get_thin_fn_from_global_actor : $@convention(thin) @async () -> @convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+sil [isolation "global_actor(CustomActor)"] @take_thin_fn_global_actor : $@convention(thin) @async (@convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()) -> ()
+sil [isolation "global_actor(CustomActor2)"] @take_thin_fn_global_actor2 : $@convention(thin) @async (@convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()) -> ()
+
+sil @get_thick_fn : $@convention(thin) () -> @owned @async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+sil [isolation "global_actor(CustomActor)"] @get_thick_fn_from_global_actor : $@convention(thin) @async () -> @owned @async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+sil [isolation "global_actor(CustomActor)"] @take_thick_fn_global_actor : $@convention(thin) @async (@guaranteed @async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()) -> ()
+sil [isolation "global_actor(CustomActor2)"] @take_thick_fn_global_actor2 : $@convention(thin) @async (@guaranteed @async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()) -> ()
+
+sil [isolation "global_actor(CustomActor)"] @get_thin_fn_from_global_actor_sending : $@convention(thin) @async () -> @sil_sending @convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+sil [isolation "global_actor(CustomActor)"] @get_thick_fn_from_global_actor_sending : $@convention(thin) @async () -> @sil_sending @owned @async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+
+sil @take_sending_thick_fn_isolated : $@convention(thin) @async (@sil_sending @owned @async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> (), @sil_isolated @guaranteed MyActor) -> ()
+
+///////////////////////////////
+// MARK: Thin Function Tests //
+///////////////////////////////
+
+// Make sure that a non-thick function is sendable. Check for both locally created non-thick functions and functions passed in and returned from functions. Ensure that each thing you are going to error on has a name via debug_value. As part of this, I want you to also pass the non-thick function as an argument to a function that takes an actor isolated parameter and make sure that the function ref is still able to be used locally.
+
+// Test Thin1: Locally created function_ref sent as argument to an actor-isolated
+// function, then used locally as a callee. Thin functions are sendable, so
+// passing one as an argument across isolation should not error, and the
+// function_ref remains usable locally afterward.
+sil [ossa] @test_thin_fn_sent_as_arg_then_used_locally : $@convention(thin) @async (@guaranteed MyActor, @sil_isolated @guaranteed MyActor) -> () {
+bb0(%0 : @guaranteed $MyActor, %1 : @guaranteed $MyActor):
+  %fn = function_ref @async_function_2param_with_isolated : $@convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  debug_value %fn : $@convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> (), let, name "fn"
+
+  // Send thin function as argument to %0's isolation domain.
+  %take = function_ref @take_thin_fn_isolated : $@convention(thin) @async (@convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> (), @sil_isolated @guaranteed MyActor) -> ()
+  apply [callee_isolation=actor_instance] %take(%fn, %0) : $@convention(thin) @async (@convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> (), @sil_isolated @guaranteed MyActor) -> ()
+
+  // Use the same function_ref locally as callee with a fresh klass.
+  %get = function_ref @get_klass : $@convention(thin) () -> @owned NonSendableKlass
+  %klass = apply %get() : $@convention(thin) () -> @owned NonSendableKlass
+  %b = begin_borrow %klass : $NonSendableKlass
+  apply [callee_isolation=actor_instance] %fn(%b, %1) : $@convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  end_borrow %b : $NonSendableKlass
+
+  destroy_value %klass : $NonSendableKlass
+  %r = tuple ()
+  return %r : $()
+}
+
+// Test Thin2: Locally created function_ref used as callee with two different
+// actors, each with a fresh independent klass. The thin function_ref is
+// trivial and not tainted by either use.
+sil [ossa] @test_thin_fn_callee_two_actors_fresh_klass : $@convention(thin) @async (@guaranteed MyActor, @sil_isolated @guaranteed MyActor) -> () {
+bb0(%0 : @guaranteed $MyActor, %1 : @guaranteed $MyActor):
+  %fn = function_ref @async_function_2param_with_isolated : $@convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+
+  %get = function_ref @get_klass : $@convention(thin) () -> @owned NonSendableKlass
+  %klass1 = apply %get() : $@convention(thin) () -> @owned NonSendableKlass
+  debug_value %klass1 : $NonSendableKlass, let, name "klass1"
+  %klass2 = apply %get() : $@convention(thin) () -> @owned NonSendableKlass
+  debug_value %klass2 : $NonSendableKlass, let, name "klass2"
+
+  // Apply with klass1 to %0 (different actor).
+  %b1 = begin_borrow %klass1 : $NonSendableKlass
+  apply [callee_isolation=actor_instance] %fn(%b1, %0) : $@convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  end_borrow %b1 : $NonSendableKlass
+
+  // Apply with klass2 to %1 (local actor). function_ref reused without issue.
+  %b2 = begin_borrow %klass2 : $NonSendableKlass
+  apply [callee_isolation=actor_instance] %fn(%b2, %1) : $@convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  end_borrow %b2 : $NonSendableKlass
+
+  destroy_value %klass2 : $NonSendableKlass
+  destroy_value %klass1 : $NonSendableKlass
+  %r = tuple ()
+  return %r : $()
+}
+
+// Test Thin3: Thin function received as a parameter. Pass it as an argument
+// to an actor-isolated function, then use it locally as a callee. The thin
+// function parameter is disconnected/sendable.
+sil [ossa] @test_thin_fn_param_sent_to_actor_then_used_locally : $@convention(thin) @async (@guaranteed MyActor, @sil_isolated @guaranteed MyActor, @convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()) -> () {
+bb0(%0 : @guaranteed $MyActor, %1 : @guaranteed $MyActor, %2 : $@convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()):
+  debug_value %2 : $@convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> (), let, name "thinFn"
+
+  // Send thin function param to %0's isolation domain.
+  %take = function_ref @take_thin_fn_isolated : $@convention(thin) @async (@convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> (), @sil_isolated @guaranteed MyActor) -> ()
+  apply [callee_isolation=actor_instance] %take(%2, %0) : $@convention(thin) @async (@convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> (), @sil_isolated @guaranteed MyActor) -> ()
+
+  // Use locally as callee with fresh klass.
+  %get = function_ref @get_klass : $@convention(thin) () -> @owned NonSendableKlass
+  %klass = apply %get() : $@convention(thin) () -> @owned NonSendableKlass
+  %b = begin_borrow %klass : $NonSendableKlass
+  apply [callee_isolation=actor_instance] %2(%b, %1) : $@convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  end_borrow %b : $NonSendableKlass
+
+  destroy_value %klass : $NonSendableKlass
+  %r = tuple ()
+  return %r : $()
+}
+
+// Test Thin4: Thin function returned from a function call. The returned thin
+// function is sendable regardless of how it was obtained. Send it to an
+// actor, then use locally.
+sil [ossa] @test_thin_fn_returned_sent_to_actor_then_used_locally : $@convention(thin) @async (@guaranteed MyActor, @sil_isolated @guaranteed MyActor) -> () {
+bb0(%0 : @guaranteed $MyActor, %1 : @guaranteed $MyActor):
+  %getter = function_ref @get_thin_fn : $@convention(thin) () -> @convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  %fn = apply %getter() : $@convention(thin) () -> @convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  debug_value %fn : $@convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> (), let, name "returnedFn"
+
+  // Send to %0's isolation domain.
+  %take = function_ref @take_thin_fn_isolated : $@convention(thin) @async (@convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> (), @sil_isolated @guaranteed MyActor) -> ()
+  apply [callee_isolation=actor_instance] %take(%fn, %0) : $@convention(thin) @async (@convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> (), @sil_isolated @guaranteed MyActor) -> ()
+
+  // Use locally as callee.
+  %get = function_ref @get_klass : $@convention(thin) () -> @owned NonSendableKlass
+  %klass = apply %get() : $@convention(thin) () -> @owned NonSendableKlass
+  %b = begin_borrow %klass : $NonSendableKlass
+  apply [callee_isolation=actor_instance] %fn(%b, %1) : $@convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  end_borrow %b : $NonSendableKlass
+
+  destroy_value %klass : $NonSendableKlass
+  %r = tuple ()
+  return %r : $()
+}
+
+// Test Thin5: Thin function returned from a global-actor-isolated function.
+// Despite originating from a different isolation domain, the thin function
+// is sendable and can be used freely afterward.
+sil [ossa] @test_thin_fn_from_global_actor_used_locally : $@convention(thin) @async (@sil_isolated @guaranteed MyActor) -> () {
+bb0(%0 : @guaranteed $MyActor):
+  %getter = function_ref @get_thin_fn_from_global_actor : $@convention(thin) @async () -> @convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  %fn = apply [callee_isolation=global_actor] %getter() : $@convention(thin) @async () -> @convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  debug_value %fn : $@convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> (), let, name "fnFromGlobalActor"
+
+  // Use locally with %0.
+  %get = function_ref @get_klass : $@convention(thin) () -> @owned NonSendableKlass
+  %klass = apply %get() : $@convention(thin) () -> @owned NonSendableKlass
+  %b = begin_borrow %klass : $NonSendableKlass
+  apply [callee_isolation=actor_instance] %fn(%b, %0) : $@convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  end_borrow %b : $NonSendableKlass
+
+  destroy_value %klass : $NonSendableKlass
+  %r = tuple ()
+  return %r : $()
+}
+
+// Test Thin6: Locally created thin function passed as argument to a
+// global-actor-isolated function. The thin function crosses into the global
+// actor's domain but is sendable. It remains usable locally afterward.
+sil [ossa] @test_thin_fn_passed_to_global_actor : $@convention(thin) @async (@sil_isolated @guaranteed MyActor) -> () {
+bb0(%0 : @guaranteed $MyActor):
+  %fn = function_ref @async_function_2param_with_isolated : $@convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  debug_value %fn : $@convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> (), let, name "fn"
+
+  // Pass thin function to global actor.
+  %take = function_ref @take_thin_fn_global_actor : $@convention(thin) @async (@convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()) -> ()
+  apply [callee_isolation=global_actor] %take(%fn) : $@convention(thin) @async (@convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()) -> ()
+
+  // Use locally as callee.
+  %get = function_ref @get_klass : $@convention(thin) () -> @owned NonSendableKlass
+  %klass = apply %get() : $@convention(thin) () -> @owned NonSendableKlass
+  %b = begin_borrow %klass : $NonSendableKlass
+  apply [callee_isolation=actor_instance] %fn(%b, %0) : $@convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  end_borrow %b : $NonSendableKlass
+
+  destroy_value %klass : $NonSendableKlass
+  %r = tuple ()
+  return %r : $()
+}
+
+// Test Thin7: Thin function returned from global actor A (CustomActor), then
+// passed as argument to global actor B (CustomActor2). The thin function
+// crosses two global actor boundaries but remains sendable throughout.
+sil [ossa] @test_thin_fn_global_actor_a_to_global_actor_b : $@convention(thin) @async (@sil_isolated @guaranteed MyActor) -> () {
+bb0(%0 : @guaranteed $MyActor):
+  // Get thin function from CustomActor.
+  %getter = function_ref @get_thin_fn_from_global_actor : $@convention(thin) @async () -> @convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  %fn = apply [callee_isolation=global_actor] %getter() : $@convention(thin) @async () -> @convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  debug_value %fn : $@convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> (), let, name "fnFromActorA"
+
+  // Pass to CustomActor2.
+  %take = function_ref @take_thin_fn_global_actor2 : $@convention(thin) @async (@convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()) -> ()
+  apply [callee_isolation=global_actor] %take(%fn) : $@convention(thin) @async (@convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()) -> ()
+
+  // Use locally as callee.
+  %get = function_ref @get_klass : $@convention(thin) () -> @owned NonSendableKlass
+  %klass = apply %get() : $@convention(thin) () -> @owned NonSendableKlass
+  %b = begin_borrow %klass : $NonSendableKlass
+  apply [callee_isolation=actor_instance] %fn(%b, %0) : $@convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  end_borrow %b : $NonSendableKlass
+
+  destroy_value %klass : $NonSendableKlass
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// Test Thin8: Thin function returned via @sil_sending from a global-actor-isolated
+// function. The @sil_sending disconnects the value from the callee's isolation.
+// Since thin functions are already sendable, this should definitely not error
+// (contrast with Thin5 which has a BUG without @sil_sending).
+sil [ossa] @test_thin_fn_sil_sending_from_global_actor : $@convention(thin) @async (@sil_isolated @guaranteed MyActor) -> () {
+bb0(%0 : @guaranteed $MyActor):
+  %getter = function_ref @get_thin_fn_from_global_actor_sending : $@convention(thin) @async () -> @sil_sending @convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  %fn = apply [callee_isolation=global_actor] %getter() : $@convention(thin) @async () -> @sil_sending @convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  debug_value %fn : $@convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> (), let, name "fnFromGlobalActorSending"
+
+  // Send to %0's isolation domain — no error.
+  %take = function_ref @take_thin_fn_isolated : $@convention(thin) @async (@convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> (), @sil_isolated @guaranteed MyActor) -> ()
+  apply [callee_isolation=actor_instance] %take(%fn, %0) : $@convention(thin) @async (@convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> (), @sil_isolated @guaranteed MyActor) -> ()
+
+  // Use locally as callee — no error.
+  %get = function_ref @get_klass : $@convention(thin) () -> @owned NonSendableKlass
+  %klass = apply %get() : $@convention(thin) () -> @owned NonSendableKlass
+  %b = begin_borrow %klass : $NonSendableKlass
+  apply [callee_isolation=actor_instance] %fn(%b, %0) : $@convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  end_borrow %b : $NonSendableKlass
+
+  destroy_value %klass : $NonSendableKlass
+  %r = tuple ()
+  return %r : $()
+}
+
+// Test Thin9: Callee receives thin function via @sil_sending parameter.
+// Thin functions are already sendable, so @sil_sending is redundant. The
+// callee should be able to send it to an actor and use it locally without error.
+sil [ossa] @test_thin_fn_sil_sending_param : $@convention(thin) @async (@sil_sending @convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> (), @guaranteed MyActor, @sil_isolated @guaranteed MyActor) -> () {
+bb0(%0 : $@convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> (), %1 : @guaranteed $MyActor, %2 : @guaranteed $MyActor):
+  debug_value %0 : $@convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> (), let, name "sendingThinFn"
+
+  // Send to %1 (different actor).
+  %take = function_ref @take_thin_fn_isolated : $@convention(thin) @async (@convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> (), @sil_isolated @guaranteed MyActor) -> ()
+  apply [callee_isolation=actor_instance] %take(%0, %1) : $@convention(thin) @async (@convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> (), @sil_isolated @guaranteed MyActor) -> ()
+
+  // Use locally as callee with %2 — no error.
+  %get = function_ref @get_klass : $@convention(thin) () -> @owned NonSendableKlass
+  %klass = apply %get() : $@convention(thin) () -> @owned NonSendableKlass
+  %b = begin_borrow %klass : $NonSendableKlass
+  apply [callee_isolation=actor_instance] %0(%b, %2) : $@convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  end_borrow %b : $NonSendableKlass
+
+  destroy_value %klass : $NonSendableKlass
+  %r = tuple ()
+  return %r : $()
+}
+
+////////////////////////////////
+// MARK: Thick Function Tests //
+////////////////////////////////
+
+// Make sure that a thick function is non-Sendable. Check for both locally
+// created thick functions (via thin_to_thick_function), thick functions passed
+// in as parameters, and thick functions returned from functions. Ensure that
+// each thing you are going to error on has a name via debug_value. Verify that
+// passing a thick function as an argument to a function that takes an actor
+// isolated parameter produces an error, and that the thick function cannot be
+// used locally afterward.
+
+// Test Thick1: Locally created thick function (via thin_to_thick_function) sent
+// as argument to an actor-isolated function, then sent again locally. The
+// thick function is non-Sendable, so sending it should error, and sending
+// it again afterward should be flagged as concurrent access.
+sil [ossa] @test_thick_fn_sent_as_arg_then_used_locally : $@convention(thin) @async (@guaranteed MyActor, @sil_isolated @guaranteed MyActor) -> () {
+bb0(%0 : @guaranteed $MyActor, %1 : @guaranteed $MyActor):
+  %fn_ref = function_ref @async_function_2param_with_isolated : $@convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  %thick = thin_to_thick_function %fn_ref : $@convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> () to $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  debug_value %thick : $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> (), let, name "thickFn"
+
+  // Send thick function as argument to %0's isolation domain.
+  %borrow1 = begin_borrow %thick : $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  %take1 = function_ref @take_function : $@convention(thin) @async (@guaranteed @async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> (), @sil_isolated @guaranteed MyActor) -> ()
+  apply [callee_isolation=actor_instance] %take1(%borrow1, %0) : $@convention(thin) @async (@guaranteed @async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> (), @sil_isolated @guaranteed MyActor) -> () // expected-error {{sending value of non-Sendable type '@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()' risks causing data races}}
+  // expected-note @-1 {{sending value of non-Sendable type '@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()' to actor-isolated callee risks causing data races between actor-isolated and local nonisolated uses}}
+  end_borrow %borrow1 : $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+
+  // Use the thick function locally as argument again.
+  %borrow2 = begin_borrow %thick : $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  %take2 = function_ref @take_function : $@convention(thin) @async (@guaranteed @async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> (), @sil_isolated @guaranteed MyActor) -> ()
+  apply [callee_isolation=actor_instance] %take2(%borrow2, %1) : $@convention(thin) @async (@guaranteed @async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> (), @sil_isolated @guaranteed MyActor) -> () // expected-note {{access can happen concurrently}}
+  end_borrow %borrow2 : $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+
+  destroy_value %thick : $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  %r = tuple ()
+  return %r : $()
+}
+
+// Test Thick2: Locally created thick function used as callee with two different
+// actors, each with a fresh independent klass. Using a thick function as a
+// callee does not send it, so no errors are expected.
+sil [ossa] @test_thick_fn_callee_two_actors_fresh_klass : $@convention(thin) @async (@guaranteed MyActor, @sil_isolated @guaranteed MyActor) -> () {
+bb0(%0 : @guaranteed $MyActor, %1 : @guaranteed $MyActor):
+  %fn_ref = function_ref @async_function_2param_with_isolated : $@convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  %thick = thin_to_thick_function %fn_ref : $@convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> () to $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+
+  %get = function_ref @get_klass : $@convention(thin) () -> @owned NonSendableKlass
+  %klass1 = apply %get() : $@convention(thin) () -> @owned NonSendableKlass
+  debug_value %klass1 : $NonSendableKlass, let, name "klass1"
+  %klass2 = apply %get() : $@convention(thin) () -> @owned NonSendableKlass
+  debug_value %klass2 : $NonSendableKlass, let, name "klass2"
+
+  %borrow1 = begin_borrow %thick : $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  %b1 = begin_borrow %klass1 : $NonSendableKlass
+  apply [callee_isolation=actor_instance] %borrow1(%b1, %0) : $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  end_borrow %b1 : $NonSendableKlass
+  end_borrow %borrow1 : $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+
+  %borrow2 = begin_borrow %thick : $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  %b2 = begin_borrow %klass2 : $NonSendableKlass
+  apply [callee_isolation=actor_instance] %borrow2(%b2, %1) : $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  end_borrow %b2 : $NonSendableKlass
+  end_borrow %borrow2 : $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+
+  destroy_value %klass2 : $NonSendableKlass
+  destroy_value %klass1 : $NonSendableKlass
+  destroy_value %thick : $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  %r = tuple ()
+  return %r : $()
+}
+
+// Test Thick3: Thick function received as a parameter. Pass it as an argument
+// to an actor-isolated function, then use it locally as an argument. The thick
+// function is non-Sendable, so sending it should error.
+sil [ossa] @test_thick_fn_param_sent_to_actor_then_used_locally : $@convention(thin) @async (@guaranteed MyActor, @sil_isolated @guaranteed MyActor, @guaranteed @async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()) -> () {
+bb0(%0 : @guaranteed $MyActor, %1 : @guaranteed $MyActor, %2 : @guaranteed $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()):
+  debug_value %2 : $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> (), let, name "thickFn"
+
+  %take1 = function_ref @take_function : $@convention(thin) @async (@guaranteed @async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> (), @sil_isolated @guaranteed MyActor) -> ()
+  apply [callee_isolation=actor_instance] %take1(%2, %0) : $@convention(thin) @async (@guaranteed @async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> (), @sil_isolated @guaranteed MyActor) -> () // expected-error {{sending value of non-Sendable type '@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()' risks causing data races}}
+  // expected-note @-1 {{sending value of non-Sendable type '@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()' to actor-isolated callee risks causing data races between actor-isolated and local nonisolated uses}}
+
+  %take2 = function_ref @take_function : $@convention(thin) @async (@guaranteed @async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> (), @sil_isolated @guaranteed MyActor) -> ()
+  apply [callee_isolation=actor_instance] %take2(%2, %1) : $@convention(thin) @async (@guaranteed @async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> (), @sil_isolated @guaranteed MyActor) -> () // expected-note {{access can happen concurrently}}
+
+  %r = tuple ()
+  return %r : $()
+}
+
+// Test Thick4: Thick function returned from a function call. The returned thick
+// function is non-Sendable. Send it to an actor, then use locally as argument.
+sil [ossa] @test_thick_fn_returned_sent_to_actor_then_used_locally : $@convention(thin) @async (@guaranteed MyActor, @sil_isolated @guaranteed MyActor) -> () {
+bb0(%0 : @guaranteed $MyActor, %1 : @guaranteed $MyActor):
+  %getter = function_ref @get_thick_fn : $@convention(thin) () -> @owned @async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  %thick = apply %getter() : $@convention(thin) () -> @owned @async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  debug_value %thick : $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> (), let, name "thickFn"
+
+  %borrow1 = begin_borrow %thick : $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  %take1 = function_ref @take_function : $@convention(thin) @async (@guaranteed @async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> (), @sil_isolated @guaranteed MyActor) -> ()
+  apply [callee_isolation=actor_instance] %take1(%borrow1, %0) : $@convention(thin) @async (@guaranteed @async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> (), @sil_isolated @guaranteed MyActor) -> () // expected-error {{sending value of non-Sendable type '@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()' risks causing data races}}
+  // expected-note @-1 {{sending value of non-Sendable type '@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()' to actor-isolated callee risks causing data races between actor-isolated and local nonisolated uses}}
+  end_borrow %borrow1 : $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+
+  %borrow2 = begin_borrow %thick : $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  %take2 = function_ref @take_function : $@convention(thin) @async (@guaranteed @async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> (), @sil_isolated @guaranteed MyActor) -> ()
+  apply [callee_isolation=actor_instance] %take2(%borrow2, %1) : $@convention(thin) @async (@guaranteed @async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> (), @sil_isolated @guaranteed MyActor) -> () // expected-note {{access can happen concurrently}}
+  end_borrow %borrow2 : $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+
+  destroy_value %thick : $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  %r = tuple ()
+  return %r : $()
+}
+
+// Test Thick5: Thick function returned from a global-actor-isolated function.
+// The return itself crosses isolation with a non-Sendable value.
+sil [ossa] @test_thick_fn_from_global_actor_used_locally : $@convention(thin) @async (@sil_isolated @guaranteed MyActor) -> () {
+bb0(%0 : @guaranteed $MyActor):
+  %getter = function_ref @get_thick_fn_from_global_actor : $@convention(thin) @async () -> @owned @async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  %thick = apply [callee_isolation=global_actor] %getter() : $@convention(thin) @async () -> @owned @async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> () // expected-error {{non-Sendable '@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()'-typed result can not be returned from global actor '<null>'-isolated function to nonisolated context}}
+  debug_value %thick : $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> (), let, name "thickFn"
+
+  %borrow = begin_borrow %thick : $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  %take = function_ref @take_function : $@convention(thin) @async (@guaranteed @async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> (), @sil_isolated @guaranteed MyActor) -> ()
+  apply [callee_isolation=actor_instance] %take(%borrow, %0) : $@convention(thin) @async (@guaranteed @async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> (), @sil_isolated @guaranteed MyActor) -> () // expected-error {{sending value of non-Sendable type '@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()' risks causing data races}}
+  // expected-note @-1 {{sending global actor '<null>'-isolated value of non-Sendable type '@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()' to actor-isolated callee risks causing races in between global actor '<null>'-isolated and actor-isolated uses}}
+  end_borrow %borrow : $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+
+  destroy_value %thick : $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  %r = tuple ()
+  return %r : $()
+}
+
+// Test Thick6: Locally created thick function passed as argument to a
+// global-actor-isolated function, then used locally. The thick function is
+// non-Sendable, so crossing into the global actor's domain should error.
+sil [ossa] @test_thick_fn_passed_to_global_actor : $@convention(thin) @async (@sil_isolated @guaranteed MyActor) -> () {
+bb0(%0 : @guaranteed $MyActor):
+  %fn_ref = function_ref @async_function_2param_with_isolated : $@convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  %thick = thin_to_thick_function %fn_ref : $@convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> () to $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  debug_value %thick : $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> (), let, name "thickFn"
+
+  %borrow1 = begin_borrow %thick : $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  %take_ga = function_ref @take_thick_fn_global_actor : $@convention(thin) @async (@guaranteed @async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()) -> ()
+  apply [callee_isolation=global_actor] %take_ga(%borrow1) : $@convention(thin) @async (@guaranteed @async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()) -> () // expected-error {{sending value of non-Sendable type '@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()' risks causing data races}}
+  // expected-note @-1 {{sending value of non-Sendable type '@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()' to global actor '<null>'-isolated callee risks causing data races between global actor '<null>'-isolated and local nonisolated uses}}
+  end_borrow %borrow1 : $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+
+  %borrow2 = begin_borrow %thick : $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  %take = function_ref @take_function : $@convention(thin) @async (@guaranteed @async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> (), @sil_isolated @guaranteed MyActor) -> ()
+  apply [callee_isolation=actor_instance] %take(%borrow2, %0) : $@convention(thin) @async (@guaranteed @async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> (), @sil_isolated @guaranteed MyActor) -> () // expected-note {{access can happen concurrently}}
+  end_borrow %borrow2 : $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+
+  destroy_value %thick : $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  %r = tuple ()
+  return %r : $()
+}
+
+// Test Thick7: Thick function returned from global actor A (CustomActor), then
+// passed as argument to global actor B (CustomActor2). The thick function is
+// non-Sendable, so both the return crossing and the send should be flagged.
+sil [ossa] @test_thick_fn_global_actor_a_to_global_actor_b : $@convention(thin) @async (@sil_isolated @guaranteed MyActor) -> () {
+bb0(%0 : @guaranteed $MyActor):
+  %getter = function_ref @get_thick_fn_from_global_actor : $@convention(thin) @async () -> @owned @async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  %thick = apply [callee_isolation=global_actor] %getter() : $@convention(thin) @async () -> @owned @async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> () // expected-error {{non-Sendable '@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()'-typed result can not be returned from global actor '<null>'-isolated function to nonisolated context}}
+  debug_value %thick : $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> (), let, name "thickFn"
+
+  %borrow1 = begin_borrow %thick : $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  %take_ga2 = function_ref @take_thick_fn_global_actor2 : $@convention(thin) @async (@guaranteed @async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()) -> ()
+  apply [callee_isolation=global_actor] %take_ga2(%borrow1) : $@convention(thin) @async (@guaranteed @async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()) -> ()
+  end_borrow %borrow1 : $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+
+  %borrow2 = begin_borrow %thick : $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  %take = function_ref @take_function : $@convention(thin) @async (@guaranteed @async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> (), @sil_isolated @guaranteed MyActor) -> ()
+  apply [callee_isolation=actor_instance] %take(%borrow2, %0) : $@convention(thin) @async (@guaranteed @async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> (), @sil_isolated @guaranteed MyActor) -> () // expected-error {{sending value of non-Sendable type '@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()' risks causing data races}}
+  // expected-note @-1 {{sending global actor '<null>'-isolated value of non-Sendable type '@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()' to actor-isolated callee risks causing races in between global actor '<null>'-isolated and actor-isolated uses}}
+  end_borrow %borrow2 : $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+
+  destroy_value %thick : $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// Test Thick8: Thick function returned via @sil_sending from a global-actor-isolated
+// function. The @sil_sending disconnects the value from the callee's isolation,
+// so unlike Thick5 (which errors on return), this should NOT error on the return.
+// The thick function is disconnected and can be used locally.
+sil [ossa] @test_thick_fn_sil_sending_from_global_actor : $@convention(thin) @async (@sil_isolated @guaranteed MyActor) -> () {
+bb0(%0 : @guaranteed $MyActor):
+  %getter = function_ref @get_thick_fn_from_global_actor_sending : $@convention(thin) @async () -> @sil_sending @owned @async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  %thick = apply [callee_isolation=global_actor] %getter() : $@convention(thin) @async () -> @sil_sending @owned @async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  debug_value %thick : $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> (), let, name "thickFn"
+
+  // Use locally with %0 as argument — no error (value is disconnected).
+  %borrow = begin_borrow %thick : $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  %take = function_ref @take_function : $@convention(thin) @async (@guaranteed @async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> (), @sil_isolated @guaranteed MyActor) -> ()
+  apply [callee_isolation=actor_instance] %take(%borrow, %0) : $@convention(thin) @async (@guaranteed @async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> (), @sil_isolated @guaranteed MyActor) -> ()
+  end_borrow %borrow : $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+
+  destroy_value %thick : $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  %r = tuple ()
+  return %r : $()
+}
+
+// Test Thick9: Thick function returned via @sil_sending from a global-actor-isolated
+// function, then sent to an actor and used locally. The return is fine (@sil_sending
+// disconnects it), but sending to %0 then using locally with %0 again should error
+// (same as Thick1 pattern — send-then-use on a non-Sendable value).
+sil [ossa] @test_thick_fn_sil_sending_from_global_actor_send_then_use : $@convention(thin) @async (@guaranteed MyActor, @sil_isolated @guaranteed MyActor) -> () {
+bb0(%0 : @guaranteed $MyActor, %1 : @guaranteed $MyActor):
+  %getter = function_ref @get_thick_fn_from_global_actor_sending : $@convention(thin) @async () -> @sil_sending @owned @async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  %thick = apply [callee_isolation=global_actor] %getter() : $@convention(thin) @async () -> @sil_sending @owned @async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  debug_value %thick : $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> (), let, name "thickFn"
+
+  // Send to %0's isolation domain.
+  %borrow1 = begin_borrow %thick : $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  %take1 = function_ref @take_function : $@convention(thin) @async (@guaranteed @async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> (), @sil_isolated @guaranteed MyActor) -> ()
+  apply [callee_isolation=actor_instance] %take1(%borrow1, %0) : $@convention(thin) @async (@guaranteed @async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> (), @sil_isolated @guaranteed MyActor) -> () // expected-error {{sending value of non-Sendable type '@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()' risks causing data races}}
+  // expected-note @-1 {{sending value of non-Sendable type '@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()' to actor-isolated callee risks causing data races between actor-isolated and local nonisolated uses}}
+  end_borrow %borrow1 : $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+
+  // Use locally — error expected (use after send).
+  %borrow2 = begin_borrow %thick : $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  %take2 = function_ref @take_function : $@convention(thin) @async (@guaranteed @async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> (), @sil_isolated @guaranteed MyActor) -> ()
+  apply [callee_isolation=actor_instance] %take2(%borrow2, %1) : $@convention(thin) @async (@guaranteed @async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> (), @sil_isolated @guaranteed MyActor) -> () // expected-note {{access can happen concurrently}}
+  end_borrow %borrow2 : $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+
+  destroy_value %thick : $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  %r = tuple ()
+  return %r : $()
+}
+
+// Test Thick10: Callee receives thick function via @sil_sending @owned parameter.
+// The value is disconnected. Using it locally should not error.
+sil [ossa] @test_thick_fn_sil_sending_param_use_locally : $@convention(thin) @async (@sil_sending @owned @async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> (), @sil_isolated @guaranteed MyActor) -> () {
+bb0(%0 : @owned $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> (), %1 : @guaranteed $MyActor):
+  debug_value %0 : $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> (), let, name "sendingThickFn"
+
+  // Use locally as argument — no error (disconnected via @sil_sending).
+  %borrow = begin_borrow %0 : $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  %take = function_ref @take_function : $@convention(thin) @async (@guaranteed @async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> (), @sil_isolated @guaranteed MyActor) -> ()
+  apply [callee_isolation=actor_instance] %take(%borrow, %1) : $@convention(thin) @async (@guaranteed @async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> (), @sil_isolated @guaranteed MyActor) -> ()
+  end_borrow %borrow : $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+
+  destroy_value %0 : $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  %r = tuple ()
+  return %r : $()
+}
+
+// Test Thick11: Callee receives thick function via @sil_sending @owned parameter.
+// The value starts disconnected, but sending to %1 (different actor) then using
+// locally with %2 is the standard send-then-use pattern — error expected.
+sil [ossa] @test_thick_fn_sil_sending_param_send_then_use : $@convention(thin) @async (@sil_sending @owned @async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> (), @guaranteed MyActor, @sil_isolated @guaranteed MyActor) -> () {
+bb0(%0 : @owned $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> (), %1 : @guaranteed $MyActor, %2 : @guaranteed $MyActor):
+  debug_value %0 : $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> (), let, name "sendingThickFn"
+
+  // Send to %1 (different actor).
+  %borrow1 = begin_borrow %0 : $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  %take1 = function_ref @take_function : $@convention(thin) @async (@guaranteed @async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> (), @sil_isolated @guaranteed MyActor) -> ()
+  apply [callee_isolation=actor_instance] %take1(%borrow1, %1) : $@convention(thin) @async (@guaranteed @async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> (), @sil_isolated @guaranteed MyActor) -> () // expected-error {{sending value of non-Sendable type '@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()' risks causing data races}}
+  // expected-note @-1 {{sending value of non-Sendable type '@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()' to actor-isolated callee risks causing data races between actor-isolated and local nonisolated uses}}
+  end_borrow %borrow1 : $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+
+  // Use locally with %2 — error expected (use after send).
+  %borrow2 = begin_borrow %0 : $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  %take2 = function_ref @take_function : $@convention(thin) @async (@guaranteed @async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> (), @sil_isolated @guaranteed MyActor) -> ()
+  apply [callee_isolation=actor_instance] %take2(%borrow2, %2) : $@convention(thin) @async (@guaranteed @async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> (), @sil_isolated @guaranteed MyActor) -> () // expected-note {{access can happen concurrently}}
+  end_borrow %borrow2 : $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+
+  destroy_value %0 : $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  %r = tuple ()
+  return %r : $()
+}
+
+// Test Thick12: Caller creates a thick function, sends it via @sil_sending @owned
+// parameter to an actor-isolated function. The value is consumed by the call.
+// A copy made before sending shares the same region, so using the copy locally
+// after the send should be flagged.
+sil [ossa] @test_thick_fn_caller_sends_via_sil_sending_param : $@convention(thin) @async (@guaranteed MyActor, @sil_isolated @guaranteed MyActor) -> () {
+bb0(%0 : @guaranteed $MyActor, %1 : @guaranteed $MyActor):
+  %fn_ref = function_ref @async_function_2param_with_isolated : $@convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  %thick = thin_to_thick_function %fn_ref : $@convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> () to $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  %copy = copy_value %thick : $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  debug_value %copy : $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> (), let, name "thickFnCopy"
+
+  // Send original via @sil_sending @owned to %0.
+  %take_sending = function_ref @take_sending_thick_fn_isolated : $@convention(thin) @async (@sil_sending @owned @async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> (), @sil_isolated @guaranteed MyActor) -> ()
+  apply [callee_isolation=actor_instance] %take_sending(%thick, %0) : $@convention(thin) @async (@sil_sending @owned @async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> (), @sil_isolated @guaranteed MyActor) -> () // expected-error {{sending value of non-Sendable type '@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()' risks causing data races}}
+  // expected-note @-1 {{Passing value of non-Sendable type '@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()' as a 'sending' argument risks causing races in between local and caller code}}
+
+  // Use copy locally with %1 — the copy shares the original's region.
+  %borrow = begin_borrow %copy : $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  %take = function_ref @take_function : $@convention(thin) @async (@guaranteed @async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> (), @sil_isolated @guaranteed MyActor) -> ()
+  apply [callee_isolation=actor_instance] %take(%borrow, %1) : $@convention(thin) @async (@guaranteed @async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> (), @sil_isolated @guaranteed MyActor) -> () // expected-note {{access can happen concurrently}}
+  end_borrow %borrow : $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+
+  destroy_value %copy : $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  %r = tuple ()
+  return %r : $()
+}
+
+//////////////////////////////////////
+// MARK: Group A — function_ref sends
+//////////////////////////////////////
+
+// Test 1: thin_to_thick send + use-after-send
+//
+// This test makes sure that if we send a thin_to_thick function. We can pass it
+// to MyActor and then if we use it again locally, we emit an error. So it is
+// disconnected, but is not sendable.
+sil [ossa] @test_async_2param_functionref_send_to_nonisolated_actor : $@convention(thin) @async (@guaranteed MyActor, @sil_isolated @guaranteed MyActor) -> () {
+bb0(%0 : @guaranteed $MyActor, %1 : @guaranteed $MyActor):
+  %fn = function_ref @async_function_2param_with_isolated : $@convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  %thick = thin_to_thick_function %fn : $@convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> () to $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+
+  // Send thick function to %0's isolation domain - error expected
+  %borrow1 = begin_borrow %thick : $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  %take = function_ref @take_function : $@convention(thin) @async (@guaranteed @async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> (), @sil_isolated @guaranteed MyActor) -> ()
+  apply [callee_isolation=actor_instance] %take(%borrow1, %0) : $@convention(thin) @async (@guaranteed @async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> (), @sil_isolated @guaranteed MyActor) -> () // expected-error {{sending value of non-Sendable type '@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()' risks causing data races}}
+  // expected-note @-1 {{sending value of non-Sendable type '@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()' to actor-isolated callee risks causing data races between actor-isolated and local nonisolated uses}}
+  end_borrow %borrow1 : $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+
+  // Since we use it here locally after transfer
+  %borrow2 = begin_borrow %thick : $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  %take2 = function_ref @take_function : $@convention(thin) @async (@guaranteed @async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> (), @sil_isolated @guaranteed MyActor) -> ()
+  apply [callee_isolation=actor_instance] %take2(%borrow2, %1) : $@convention(thin) @async (@guaranteed @async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> (), @sil_isolated @guaranteed MyActor) -> () // expected-note {{access can happen concurrently}}
+  end_borrow %borrow2 : $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+
+  destroy_value %thick : $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  %r = tuple ()
+  return %r : $()
+}
+
+// Test 2: Direct function_ref apply crossing isolation from nonisolated context.
+//
+// This makes sure that we properly merge the isolation of MyActor.
+sil [ossa] @test_direct_functionref_apply_crossing_isolation : $@convention(thin) @async (@guaranteed MyActor, @guaranteed NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $MyActor, %1 : @guaranteed $NonSendableKlass):
+  %fn = function_ref @async_function_2param_with_isolated : $@convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  apply [callee_isolation=actor_instance] %fn(%1, %0) : $@convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> () // expected-error {{sending value of non-Sendable type 'NonSendableKlass' risks causing data races}}
+  // expected-note @-1 {{sending task-isolated value of non-Sendable type 'NonSendableKlass' to actor-isolated callee risks causing races in between task-isolated and actor-isolated uses}}
+  %r = tuple ()
+  return %r : $()
+}
+
+// Test 3: Send twice and make sure we catch this.
+//
+// Tests whether the analysis catches the send regardless of ordering.
+sil [ossa] @test_thick_use_locally_then_send : $@convention(thin) @async (@guaranteed MyActor, @sil_isolated @guaranteed MyActor) -> () {
+bb0(%0 : @guaranteed $MyActor, %1 : @guaranteed $MyActor):
+  %fn = function_ref @async_function_2param_with_isolated : $@convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  %thick = thin_to_thick_function %fn : $@convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> () to $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+
+  // Use locally first with %1 (our actor)
+  %borrow1 = begin_borrow %thick : $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  %take1 = function_ref @take_function : $@convention(thin) @async (@guaranteed @async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> (), @sil_isolated @guaranteed MyActor) -> ()
+  apply [callee_isolation=actor_instance] %take1(%borrow1, %1) : $@convention(thin) @async (@guaranteed @async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> (), @sil_isolated @guaranteed MyActor) -> () // expected-error {{sending value of non-Sendable type '@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()' risks causing data races}}
+  // expected-note @-1 {{sending value of non-Sendable type '@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()' to actor-isolated callee risks causing data races between actor-isolated and local nonisolated uses}}
+  end_borrow %borrow1 : $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+
+  // Then send to %0
+  %borrow2 = begin_borrow %thick : $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  %take2 = function_ref @take_function : $@convention(thin) @async (@guaranteed @async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> (), @sil_isolated @guaranteed MyActor) -> ()
+  apply [callee_isolation=actor_instance] %take2(%borrow2, %0) : $@convention(thin) @async (@guaranteed @async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> (), @sil_isolated @guaranteed MyActor) -> () // expected-note {{access can happen concurrently}}
+  end_borrow %borrow2 : $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+
+  destroy_value %thick : $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  %r = tuple ()
+  return %r : $()
+}
+
+// Test 4: copy_value on thick closure, send copy to %0, use original locally.
+// copy and original should share the same region, so original use should error.
+sil [ossa] @test_copy_thick_send_copy_use_original : $@convention(thin) @async (@guaranteed MyActor, @sil_isolated @guaranteed MyActor) -> () {
+bb0(%0 : @guaranteed $MyActor, %1 : @guaranteed $MyActor):
+  %fn = function_ref @async_function_2param_with_isolated : $@convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  %thick = thin_to_thick_function %fn : $@convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> () to $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  %copy = copy_value %thick : $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+
+  // Send copy to %0
+  %borrow_copy = begin_borrow %copy : $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  %take1 = function_ref @take_function : $@convention(thin) @async (@guaranteed @async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> (), @sil_isolated @guaranteed MyActor) -> ()
+  apply [callee_isolation=actor_instance] %take1(%borrow_copy, %0) : $@convention(thin) @async (@guaranteed @async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> (), @sil_isolated @guaranteed MyActor) -> () // expected-error {{sending value of non-Sendable type '@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()' risks causing data races}}
+  // expected-note @-1 {{sending value of non-Sendable type '@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()' to actor-isolated callee risks causing data races between actor-isolated and local nonisolated uses}}
+  end_borrow %borrow_copy : $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+
+  // Use original locally - should error (same region as copy)
+  %borrow_orig = begin_borrow %thick : $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  %take2 = function_ref @take_function : $@convention(thin) @async (@guaranteed @async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> (), @sil_isolated @guaranteed MyActor) -> ()
+  apply [callee_isolation=actor_instance] %take2(%borrow_orig, %1) : $@convention(thin) @async (@guaranteed @async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> (), @sil_isolated @guaranteed MyActor) -> () // expected-note {{access can happen concurrently}}
+  end_borrow %borrow_orig : $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+
+  destroy_value %copy : $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  destroy_value %thick : $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  %r = tuple ()
+  return %r : $()
+}
+
+// Test 5: convert_function tracking. Create a thick function, convert it,
+// then send the converted value and use locally. The analysis should track
+// through the conversion.
+sil [ossa] @test_convert_function_tracking : $@convention(thin) @async (@guaranteed MyActor, @sil_isolated @guaranteed MyActor) -> () {
+bb0(%0 : @guaranteed $MyActor, %1 : @guaranteed $MyActor):
+  %fn = function_ref @async_function_2param_with_isolated : $@convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  %thick = thin_to_thick_function %fn : $@convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> () to $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  %converted = convert_function %thick : $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> () to $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+
+  // Send converted to %0
+  %borrow1 = begin_borrow %converted : $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  %take1 = function_ref @take_function : $@convention(thin) @async (@guaranteed @async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> (), @sil_isolated @guaranteed MyActor) -> ()
+  apply [callee_isolation=actor_instance] %take1(%borrow1, %0) : $@convention(thin) @async (@guaranteed @async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> (), @sil_isolated @guaranteed MyActor) -> () // expected-error {{sending value of non-Sendable type '@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()' risks causing data races}}
+  // expected-note @-1 {{sending value of non-Sendable type '@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()' to actor-isolated callee risks causing data races between actor-isolated and local nonisolated uses}}
+  end_borrow %borrow1 : $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+
+  // Use converted locally - should error (use after send)
+  %borrow2 = begin_borrow %converted : $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  %take2 = function_ref @take_function : $@convention(thin) @async (@guaranteed @async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> (), @sil_isolated @guaranteed MyActor) -> ()
+  apply [callee_isolation=actor_instance] %take2(%borrow2, %1) : $@convention(thin) @async (@guaranteed @async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> (), @sil_isolated @guaranteed MyActor) -> () // expected-note {{access can happen concurrently}}
+  end_borrow %borrow2 : $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+
+  destroy_value %converted : $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  %r4 = tuple ()
+  return %r4 : $()
+}
+
+//////////////////////////////////////////////
+// MARK: Group B — partial_apply isolation
+//////////////////////////////////////////////
+
+// Test 6: BUG — Captures actor field, apply with different actor (not tracked)
+sil [ossa] @test_async_2param_partial_apply_isolated_field : $@convention(thin) @async (@guaranteed MyActor, @sil_isolated @guaranteed MyActor) -> () {
+bb0(%0 : @guaranteed $MyActor, %1 : @guaranteed $MyActor):
+  // Load %1's field - this NonSendableKlass is in %1's isolation domain.
+  %field_addr = ref_element_addr %1 : $MyActor, #MyActor.field
+  %field = load [copy] %field_addr : $*NonSendableKlass
+
+  // partial_apply closing over the field. The isolated param stays free.
+  %fn = function_ref @async_function_2param_isolated_first : $@convention(thin) @async (@sil_isolated @guaranteed MyActor, @guaranteed NonSendableKlass) -> ()
+  %closure = partial_apply [callee_guaranteed] %fn(%field) : $@convention(thin) @async (@sil_isolated @guaranteed MyActor, @guaranteed NonSendableKlass) -> ()
+
+  // BUG! Should error here - closure captures NonSendableKlass from %1's
+  // isolation domain but is applied with %0 (different actor). The analysis
+  // does not track that partial_apply captures carry their isolation domain.
+  %borrow = begin_borrow %closure : $@async @callee_guaranteed (@sil_isolated @guaranteed MyActor) -> ()
+  apply [callee_isolation=actor_instance] %borrow(%0) : $@async @callee_guaranteed (@sil_isolated @guaranteed MyActor) -> ()
+  end_borrow %borrow : $@async @callee_guaranteed (@sil_isolated @guaranteed MyActor) -> ()
+
+  destroy_value %closure : $@async @callee_guaranteed (@sil_isolated @guaranteed MyActor) -> ()
+  %r2 = tuple ()
+  return %r2 : $()
+}
+
+// Test 7: Captures actor field, apply with same actor (correct: no error)
+// No error expected - the closure captures %1's field and we apply with %1,
+// so the captured NonSendableKlass stays in the same isolation domain.
+sil [ossa] @test_async_2param_partial_apply_isolated_field_same_actor : $@convention(thin) @async (@guaranteed MyActor, @sil_isolated @guaranteed MyActor) -> () {
+bb0(%0 : @guaranteed $MyActor, %1 : @guaranteed $MyActor):
+  %field_addr = ref_element_addr %1 : $MyActor, #MyActor.field
+  %field = load [copy] %field_addr : $*NonSendableKlass
+
+  %fn = function_ref @async_function_2param_isolated_first : $@convention(thin) @async (@sil_isolated @guaranteed MyActor, @guaranteed NonSendableKlass) -> ()
+  %closure = partial_apply [callee_guaranteed] %fn(%field) : $@convention(thin) @async (@sil_isolated @guaranteed MyActor, @guaranteed NonSendableKlass) -> ()
+
+  %borrow = begin_borrow %closure : $@async @callee_guaranteed (@sil_isolated @guaranteed MyActor) -> ()
+  apply [callee_isolation=actor_instance] %borrow(%1) : $@async @callee_guaranteed (@sil_isolated @guaranteed MyActor) -> ()
+  end_borrow %borrow : $@async @callee_guaranteed (@sil_isolated @guaranteed MyActor) -> ()
+
+  destroy_value %closure : $@async @callee_guaranteed (@sil_isolated @guaranteed MyActor) -> ()
+  %r = tuple ()
+  return %r : $()
+}
+
+// Test 8: BUG — Region merge with non-@sil_isolated actor (not tracked)
+// The partial_apply closes over %0 (non-isolated actor) and a copy of the
+// klass, merging their regions. Using the original klass locally should error
+// since its region is now associated with %0.
+sil [ossa] @test_partial_apply_nonisolated_actor_use_klass_locally : $@convention(thin) @async (@guaranteed MyActor, @sil_isolated @guaranteed MyActor) -> () {
+bb0(%0 : @guaranteed $MyActor, %1 : @guaranteed $MyActor):
+  %get = function_ref @get_klass : $@convention(thin) () -> @owned NonSendableKlass
+  %klass = apply %get() : $@convention(thin) () -> @owned NonSendableKlass
+
+  %klass_copy = copy_value %klass : $NonSendableKlass
+  %actor_copy = copy_value %0 : $MyActor
+
+  %fn = function_ref @async_function_actor_and_klass : $@convention(thin) @async (@guaranteed MyActor, @guaranteed NonSendableKlass) -> ()
+  %closure = partial_apply [callee_guaranteed] %fn(%actor_copy, %klass_copy) : $@convention(thin) @async (@guaranteed MyActor, @guaranteed NonSendableKlass) -> ()
+
+  // BUG! Should error here - klass's region was merged with %0 via
+  // partial_apply, but the analysis does not track region merging through
+  // partial_apply when the actor param is not @sil_isolated.
+  %klass_borrow = begin_borrow %klass : $NonSendableKlass
+  %use_fn = function_ref @async_function_2param_with_isolated : $@convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  apply [callee_isolation=actor_instance] %use_fn(%klass_borrow, %1) : $@convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  end_borrow %klass_borrow : $NonSendableKlass
+
+  destroy_value %closure : $@async @callee_guaranteed () -> ()
+  destroy_value %klass : $NonSendableKlass
+  %r2 = tuple ()
+  return %r2 : $()
+}
+
+// Test 9: 3param partial_apply merging two klass values with actor.
+// Both klass copies are captured with %0, merging all regions. Using
+// either original locally should error.
+sil [ossa] @test_3param_partial_apply_merge_two_klass_with_actor : $@convention(thin) @async (@guaranteed MyActor, @sil_isolated @guaranteed MyActor) -> () {
+bb0(%0 : @guaranteed $MyActor, %1 : @guaranteed $MyActor):
+  %get = function_ref @get_klass : $@convention(thin) () -> @owned NonSendableKlass
+  %klass1 = apply %get() : $@convention(thin) () -> @owned NonSendableKlass
+  %klass2 = apply %get() : $@convention(thin) () -> @owned NonSendableKlass
+
+  %klass1_copy = copy_value %klass1 : $NonSendableKlass
+  %klass2_copy = copy_value %klass2 : $NonSendableKlass
+  %actor_copy = copy_value %0 : $MyActor
+
+  %fn = function_ref @async_function_3param_with_isolated : $@convention(thin) @async (@guaranteed NonSendableKlass, @guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  %closure = partial_apply [callee_guaranteed] %fn(%klass1_copy, %klass2_copy, %actor_copy) : $@convention(thin) @async (@guaranteed NonSendableKlass, @guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+
+  // Use klass1 locally - error expected (merged with %0).
+  %borrow1 = begin_borrow %klass1 : $NonSendableKlass
+  %use1 = function_ref @async_function_2param_with_isolated : $@convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  apply [callee_isolation=actor_instance] %use1(%borrow1, %1) : $@convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> () // expected-error {{sending value of non-Sendable type 'NonSendableKlass' risks causing data races}}
+  // expected-note @-1 {{sending value of non-Sendable type 'NonSendableKlass' to actor-isolated callee risks causing data races between actor-isolated and local nonisolated uses}}
+  end_borrow %borrow1 : $NonSendableKlass
+
+  // Use klass2 locally - also error expected (also merged with %0).
+  %borrow2 = begin_borrow %klass2 : $NonSendableKlass
+  %use2 = function_ref @async_function_2param_with_isolated : $@convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  apply [callee_isolation=actor_instance] %use2(%borrow2, %1) : $@convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> () // expected-note {{access can happen concurrently}}
+  end_borrow %borrow2 : $NonSendableKlass
+
+  destroy_value %closure : $@async @callee_guaranteed () -> ()
+  destroy_value %klass2 : $NonSendableKlass
+  destroy_value %klass1 : $NonSendableKlass
+  %r2 = tuple ()
+  return %r2 : $()
+}
+
+// Test 10: partial_apply captures our isolated actor, send the closure to %0.
+// The closure is non-Sendable and in %1's region. Sending to %0 should error.
+sil [ossa] @test_partial_apply_captures_isolated_actor_send_closure : $@convention(thin) @async (@guaranteed MyActor, @sil_isolated @guaranteed MyActor) -> () {
+bb0(%0 : @guaranteed $MyActor, %1 : @guaranteed $MyActor):
+  %actor_copy = copy_value %1 : $MyActor
+  %fn = function_ref @async_function_2param_with_isolated : $@convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  %closure = partial_apply [callee_guaranteed] %fn(%actor_copy) : $@convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+
+  %borrow = begin_borrow %closure : $@async @callee_guaranteed (@guaranteed NonSendableKlass) -> ()
+  %take = function_ref @take_closure_nsk : $@convention(thin) @async (@guaranteed @async @callee_guaranteed (@guaranteed NonSendableKlass) -> (), @sil_isolated @guaranteed MyActor) -> ()
+  // BUG! Should error here - closure captures %1 (our isolated actor) and is
+  // non-Sendable, so sending it to %0's domain should be flagged. The analysis
+  // does not flag sending a non-Sendable closure created via partial_apply.
+  apply [callee_isolation=actor_instance] %take(%borrow, %0) : $@convention(thin) @async (@guaranteed @async @callee_guaranteed (@guaranteed NonSendableKlass) -> (), @sil_isolated @guaranteed MyActor) -> ()
+  end_borrow %borrow : $@async @callee_guaranteed (@guaranteed NonSendableKlass) -> ()
+
+  destroy_value %closure : $@async @callee_guaranteed (@guaranteed NonSendableKlass) -> ()
+  %r = tuple ()
+  return %r : $()
+}
+
+// Test 11: Two independent klass values, only one merged with %0 via
+// partial_apply. The un-merged klass should be safe to use locally.
+sil [ossa] @test_partial_apply_independent_klass_not_tainted : $@convention(thin) @async (@guaranteed MyActor, @sil_isolated @guaranteed MyActor) -> () {
+bb0(%0 : @guaranteed $MyActor, %1 : @guaranteed $MyActor):
+  %get = function_ref @get_klass : $@convention(thin) () -> @owned NonSendableKlass
+  %klass1 = apply %get() : $@convention(thin) () -> @owned NonSendableKlass
+  %klass2 = apply %get() : $@convention(thin) () -> @owned NonSendableKlass
+
+  // Only klass1 is captured with %0. klass2 is independent.
+  %klass1_copy = copy_value %klass1 : $NonSendableKlass
+  %actor_copy = copy_value %0 : $MyActor
+
+  %fn = function_ref @async_function_actor_and_klass : $@convention(thin) @async (@guaranteed MyActor, @guaranteed NonSendableKlass) -> ()
+  %closure = partial_apply [callee_guaranteed] %fn(%actor_copy, %klass1_copy) : $@convention(thin) @async (@guaranteed MyActor, @guaranteed NonSendableKlass) -> ()
+
+  // Use klass2 locally - no error expected (independent region).
+  %borrow2 = begin_borrow %klass2 : $NonSendableKlass
+  %use = function_ref @async_function_2param_with_isolated : $@convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  apply [callee_isolation=actor_instance] %use(%borrow2, %1) : $@convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  end_borrow %borrow2 : $NonSendableKlass
+
+  destroy_value %closure : $@async @callee_guaranteed () -> ()
+  destroy_value %klass2 : $NonSendableKlass
+  destroy_value %klass1 : $NonSendableKlass
+  %r = tuple ()
+  return %r : $()
+}
+
+// Test 12: Capture values from two different isolation domains via
+// partial_apply. field0 is from %0's domain, field1 from %1's. After
+// merging, using field1 locally should error since its region now spans %0.
+sil [ossa] @test_partial_apply_captures_from_two_domains : $@convention(thin) @async (@guaranteed MyActor, @sil_isolated @guaranteed MyActor) -> () {
+bb0(%0 : @guaranteed $MyActor, %1 : @guaranteed $MyActor):
+  %field0_addr = ref_element_addr %0 : $MyActor, #MyActor.field
+  %field0 = load [copy] %field0_addr : $*NonSendableKlass
+
+  %field1_addr = ref_element_addr %1 : $MyActor, #MyActor.field
+  %field1 = load [copy] %field1_addr : $*NonSendableKlass
+
+  %field0_copy = copy_value %field0 : $NonSendableKlass
+  %field1_copy = copy_value %field1 : $NonSendableKlass
+  %actor_copy = copy_value %0 : $MyActor
+
+  %fn = function_ref @async_function_3param_with_isolated : $@convention(thin) @async (@guaranteed NonSendableKlass, @guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  %closure = partial_apply [callee_guaranteed] %fn(%field0_copy, %field1_copy, %actor_copy) : $@convention(thin) @async (@guaranteed NonSendableKlass, @guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> () // expected-error {{pattern that the region-based isolation checker does not understand how to check. Please file a bug}}
+
+  // Use field1 locally - error expected (region merged with %0).
+  %borrow = begin_borrow %field1 : $NonSendableKlass
+  %use = function_ref @async_function_2param_with_isolated : $@convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  apply [callee_isolation=actor_instance] %use(%borrow, %1) : $@convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> () // expected-error {{sending value of non-Sendable type 'NonSendableKlass' risks causing data races}}
+  // expected-note @-1 {{sending actor-isolated value of non-Sendable type 'NonSendableKlass' to actor-isolated callee risks causing races in between actor-isolated and actor-isolated uses}}
+  end_borrow %borrow : $NonSendableKlass
+
+  destroy_value %closure : $@async @callee_guaranteed () -> ()
+  destroy_value %field1 : $NonSendableKlass
+  destroy_value %field0 : $NonSendableKlass
+  %r = tuple ()
+  return %r : $()
+}
+
+// Test 13: partial_apply without [callee_guaranteed] producing @callee_owned.
+// Captures %1's field. Apply with %0 - error expected.
+sil [ossa] @test_partial_apply_callee_owned_isolated_field : $@convention(thin) @async (@guaranteed MyActor, @sil_isolated @guaranteed MyActor) -> () {
+bb0(%0 : @guaranteed $MyActor, %1 : @guaranteed $MyActor):
+  %field_addr = ref_element_addr %1 : $MyActor, #MyActor.field
+  %field = load [copy] %field_addr : $*NonSendableKlass
+
+  %fn = function_ref @async_function_2param_isolated_first : $@convention(thin) @async (@sil_isolated @guaranteed MyActor, @guaranteed NonSendableKlass) -> ()
+  %closure = partial_apply %fn(%field) : $@convention(thin) @async (@sil_isolated @guaranteed MyActor, @guaranteed NonSendableKlass) -> ()
+
+  // BUG! Should error here - same as test 2 (partial_apply captures field from
+  // %1's isolation, applied with %0). @callee_owned has the same bug as
+  // [callee_guaranteed] - the analysis doesn't track captures' isolation.
+  apply [callee_isolation=actor_instance] %closure(%0) : $@async @callee_owned (@sil_isolated @guaranteed MyActor) -> ()
+
+  %r6 = tuple ()
+  return %r6 : $()
+}
+
+// Test 14: Nested closure captures. The inner closure captures %1's field.
+// The outer closure captures the inner closure. Apply the outer with %0.
+// The analysis should track that the inner's non-Sendable capture propagates.
+sil [ossa] @test_nested_closure_captures : $@convention(thin) @async (@guaranteed MyActor, @sil_isolated @guaranteed MyActor) -> () {
+bb0(%0 : @guaranteed $MyActor, %1 : @guaranteed $MyActor):
+  // Create inner closure capturing %1's field.
+  %field_addr = ref_element_addr %1 : $MyActor, #MyActor.field
+  %field = load [copy] %field_addr : $*NonSendableKlass
+
+  %inner_fn = function_ref @async_function_2param_isolated_first : $@convention(thin) @async (@sil_isolated @guaranteed MyActor, @guaranteed NonSendableKlass) -> ()
+  %inner = partial_apply [callee_guaranteed] %inner_fn(%field) : $@convention(thin) @async (@sil_isolated @guaranteed MyActor, @guaranteed NonSendableKlass) -> ()
+
+  // Apply the inner closure with %0. The inner carries %1's field.
+  %inner_borrow = begin_borrow %inner : $@async @callee_guaranteed (@sil_isolated @guaranteed MyActor) -> ()
+
+  // BUG! Should error here - the inner closure captures %1's field (non-Sendable)
+  // and is applied with %0 (different actor). Same class of bug as test 2 -
+  // partial_apply captures' isolation domain is not tracked.
+  apply [callee_isolation=actor_instance] %inner_borrow(%0) : $@async @callee_guaranteed (@sil_isolated @guaranteed MyActor) -> ()
+  end_borrow %inner_borrow : $@async @callee_guaranteed (@sil_isolated @guaranteed MyActor) -> ()
+
+  destroy_value %inner : $@async @callee_guaranteed (@sil_isolated @guaranteed MyActor) -> ()
+  %r = tuple ()
+  return %r : $()
+}
+
+// Test 15: partial_apply capturing only Sendable values (the actor). The
+// closure object itself is a thick function (non-Sendable type), but all
+// captures are Sendable. Test whether applying with a different actor is safe.
+// This is the converse of test 2 - no non-Sendable captures means no taint.
+sil [ossa] @test_partial_apply_only_sendable_captures : $@convention(thin) @async (@guaranteed MyActor, @sil_isolated @guaranteed MyActor) -> () {
+bb0(%0 : @guaranteed $MyActor, %1 : @guaranteed $MyActor):
+  %actor_copy = copy_value %1 : $MyActor
+
+  // Capture only the actor (Sendable). No NonSendableKlass captured.
+  %fn = function_ref @async_function_2param_with_isolated : $@convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  %closure = partial_apply [callee_guaranteed] %fn(%actor_copy) : $@convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+
+  // Create a local klass and apply the closure with it and %0.
+  // The closure was created locally (in %1's domain). Even though its captures
+  // are Sendable, the closure object itself is non-Sendable. Sending it to
+  // %0's domain should still be flagged if the analysis tracks the closure value.
+  %get = function_ref @get_klass : $@convention(thin) () -> @owned NonSendableKlass
+  %klass = apply %get() : $@convention(thin) () -> @owned NonSendableKlass
+  %borrow_klass = begin_borrow %klass : $NonSendableKlass
+
+  // Apply locally with %1 - this is safe.
+  %borrow_closure = begin_borrow %closure : $@async @callee_guaranteed (@guaranteed NonSendableKlass) -> ()
+  apply %borrow_closure(%borrow_klass) : $@async @callee_guaranteed (@guaranteed NonSendableKlass) -> ()
+  end_borrow %borrow_closure : $@async @callee_guaranteed (@guaranteed NonSendableKlass) -> ()
+
+  end_borrow %borrow_klass : $NonSendableKlass
+  destroy_value %klass : $NonSendableKlass
+  destroy_value %closure : $@async @callee_guaranteed (@guaranteed NonSendableKlass) -> ()
+  %r = tuple ()
+  return %r : $()
+}
+
+///////////////////////////////////////////////////
+// MARK: Group C — Thick vs thin function params
+///////////////////////////////////////////////////
+
+// Test 16: Thick closure param as task-isolated callee (correct: error)
+// The function is nonisolated so %1 is task-isolated. Calling the closure with
+// %0 as the isolated actor sends the task-isolated klass into %0 - error expected.
+sil [ossa] @test_call_closure_sends_task_isolated_klass_to_actor : $@convention(thin) @async (@guaranteed MyActor, @guaranteed NonSendableKlass, @guaranteed @async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()) -> () {
+bb0(%0 : @guaranteed $MyActor, %1 : @guaranteed $NonSendableKlass, %2 : @guaranteed $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()):
+  apply [callee_isolation=actor_instance] %2(%1, %0) : $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> () // expected-error {{sending value of non-Sendable type 'NonSendableKlass' risks causing data races}}
+  // expected-note @-1 {{sending task-isolated value of non-Sendable type 'NonSendableKlass' to actor-isolated callee risks causing races in between task-isolated and actor-isolated uses}}
+  %r = tuple ()
+  return %r : $()
+}
+
+// Test 17: Nonisolated function receives a thick function (callee_guaranteed)
+// with an isolated param. The thick function could have closed over state in
+// the caller, so it should be considered task-isolated. Invoking it with an
+// actor should error.
+sil [ossa] @test_thick_function_param_is_task_isolated : $@convention(thin) @async (@guaranteed MyActor, @guaranteed @async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> (), @guaranteed NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $MyActor, %1 : @guaranteed $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> (), %2 : @guaranteed $NonSendableKlass):
+  apply [callee_isolation=actor_instance] %1(%2, %0) : $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> () // expected-error {{sending value of non-Sendable type 'NonSendableKlass' risks causing data races}}
+  // expected-note @-1 {{sending task-isolated value of non-Sendable type 'NonSendableKlass' to actor-isolated callee risks causing races in between task-isolated and actor-isolated uses}}
+  %r = tuple ()
+  return %r : $()
+}
+
+// Test 18: Nonisolated function receives a thin function (convention(thin))
+// with an isolated param. A thin function cannot have captures, so it is
+// disconnected and should be safe to invoke with an actor - no error expected.
+sil [ossa] @test_thin_function_param_is_disconnected : $@convention(thin) @async (@guaranteed MyActor, @convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> (), @guaranteed NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $MyActor, %1 : $@convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> (), %2 : @guaranteed $NonSendableKlass):
+  // BUG! Should NOT error here - a thin function has no captures, is
+  // disconnected, and should be considered Sendable. Invoking it with an actor
+  // should be safe. The analysis does not distinguish thin vs thick function
+  // params for isolation.
+  apply [callee_isolation=actor_instance] %1(%2, %0) : $@convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> () // expected-error {{sending value of non-Sendable type 'NonSendableKlass' risks causing data races}}
+  // expected-note @-1 {{sending task-isolated value of non-Sendable type 'NonSendableKlass' to actor-isolated callee risks causing races in between task-isolated and actor-isolated uses}}
+  %r = tuple ()
+  return %r : $()
+}
+
+// Test 19: Thick function param applied with two different actors. The callee
+// is a non-Sendable thick function in %1's domain. Applying it with %0 may
+// taint it, preventing subsequent local use.
+sil [ossa] @test_thick_param_apply_two_actors : $@convention(thin) @async (@guaranteed MyActor, @sil_isolated @guaranteed MyActor, @guaranteed @async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()) -> () {
+bb0(%0 : @guaranteed $MyActor, %1 : @guaranteed $MyActor, %2 : @guaranteed $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()):
+  %get = function_ref @get_klass : $@convention(thin) () -> @owned NonSendableKlass
+  %klass1 = apply %get() : $@convention(thin) () -> @owned NonSendableKlass
+  %klass2 = apply %get() : $@convention(thin) () -> @owned NonSendableKlass
+
+  // Apply thick with klass1 to %0 (crossing)
+  %b1 = begin_borrow %klass1 : $NonSendableKlass
+  apply [callee_isolation=actor_instance] %2(%b1, %0) : $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  end_borrow %b1 : $NonSendableKlass
+
+  // Apply thick with klass2 to %1 (local)
+  %b2 = begin_borrow %klass2 : $NonSendableKlass
+  apply [callee_isolation=actor_instance] %2(%b2, %1) : $@async @callee_guaranteed (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  end_borrow %b2 : $NonSendableKlass
+
+  destroy_value %klass2 : $NonSendableKlass
+  destroy_value %klass1 : $NonSendableKlass
+  %r = tuple ()
+  return %r : $()
+}
+
+// Test 20: Same as test 15 but with thin function param. Thin functions are
+// trivial/Sendable, so both applies should produce the same results as thick.
+// The interesting difference is whether the callee itself gets tainted.
+sil [ossa] @test_thin_param_apply_two_actors : $@convention(thin) @async (@guaranteed MyActor, @sil_isolated @guaranteed MyActor, @convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()) -> () {
+bb0(%0 : @guaranteed $MyActor, %1 : @guaranteed $MyActor, %2 : $@convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()):
+  %get = function_ref @get_klass : $@convention(thin) () -> @owned NonSendableKlass
+  %klass1 = apply %get() : $@convention(thin) () -> @owned NonSendableKlass
+  %klass2 = apply %get() : $@convention(thin) () -> @owned NonSendableKlass
+
+  // Apply thin with klass1 to %0 (crossing)
+  %b1 = begin_borrow %klass1 : $NonSendableKlass
+  apply [callee_isolation=actor_instance] %2(%b1, %0) : $@convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  end_borrow %b1 : $NonSendableKlass
+
+  // Apply thin with klass2 to %1 (local)
+  %b2 = begin_borrow %klass2 : $NonSendableKlass
+  apply [callee_isolation=actor_instance] %2(%b2, %1) : $@convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  end_borrow %b2 : $NonSendableKlass
+
+  destroy_value %klass2 : $NonSendableKlass
+  destroy_value %klass1 : $NonSendableKlass
+  %r = tuple ()
+  return %r : $()
+}
+
+////////////////////////////////////////////
+// MARK: Group D — Global actor isolation
+////////////////////////////////////////////
+
+// Test 21: function_ref to a global-actor-isolated function. The function_ref
+// should carry the global actor isolation, making it non-Sendable. Calling it
+// from a nonisolated context with a task-isolated klass should error since the
+// klass crosses into the global actor's domain.
+sil [ossa] @test_global_actor_functionref_is_non_sendable : $@convention(thin) @async (@guaranteed NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $NonSendableKlass):
+  %fn = function_ref @global_actor_function_with_nsk : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
+  apply [callee_isolation=global_actor] %fn(%0) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> () // expected-error {{sending value of non-Sendable type 'NonSendableKlass' risks causing data races}}
+  // expected-note @-1 {{sending task-isolated value of non-Sendable type 'NonSendableKlass' to global actor '<null>'-isolated callee risks causing races in between task-isolated and global actor '<null>'-isolated uses}}
+  %r = tuple ()
+  return %r : $()
+}
+
+// Test 22: function_ref to a nonisolated function from nonisolated context.
+// Both caller and callee are nonisolated so there should be no crossing.
+sil [ossa] @test_nonisolated_functionref_no_error : $@convention(thin) @async (@guaranteed NonSendableKlass) -> () {
+bb0(%0 : @guaranteed $NonSendableKlass):
+  %fn = function_ref @nonisolated_function_with_nsk : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
+  // BUG! Should NOT error here - both caller and callee are nonisolated, so
+  // there is no isolation crossing. The analysis treats task-isolated and
+  // nonisolated as different domains.
+  apply [callee_isolation=nonisolated] %fn(%0) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> () // expected-error {{sending value of non-Sendable type 'NonSendableKlass' risks causing data races}}
+  // expected-note @-1 {{sending task-isolated value of non-Sendable type 'NonSendableKlass' to nonisolated callee risks causing races in between task-isolated and nonisolated uses}}
+  %r = tuple ()
+  return %r : $()
+}
+
+// Test 23: From an actor-isolated context, call a global-actor-isolated
+// function_ref. The klass is in %0's domain. Sending it to the global actor
+// should error.
+sil [ossa] @test_global_actor_functionref_from_actor_isolated : $@convention(thin) @async (@sil_isolated @guaranteed MyActor) -> () {
+bb0(%0 : @guaranteed $MyActor):
+  %get = function_ref @get_klass : $@convention(thin) () -> @owned NonSendableKlass
+  %klass = apply %get() : $@convention(thin) () -> @owned NonSendableKlass
+  %borrow = begin_borrow %klass : $NonSendableKlass
+
+  %fn = function_ref @global_actor_function_with_nsk : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
+  // BUG! Should error here - klass is in %0's actor-isolated domain and we're
+  // sending it to a global-actor-isolated callee. The analysis does not flag
+  // actor-isolated to global-actor crossings.
+  apply [callee_isolation=global_actor] %fn(%borrow) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
+
+  end_borrow %borrow : $NonSendableKlass
+  destroy_value %klass : $NonSendableKlass
+  %r = tuple ()
+  return %r : $()
+}
+
+// Test 24: From a global-actor-isolated context, call the same global-actor
+// function_ref. Since caller and callee share the same global actor, the klass
+// stays in the same domain - no error expected.
+sil [isolation "global_actor(CustomActor)"] [ossa] @test_global_actor_functionref_same_isolation : $@convention(thin) @async () -> () {
+bb0:
+  %get = function_ref @get_klass : $@convention(thin) () -> @owned NonSendableKlass
+  %klass = apply %get() : $@convention(thin) () -> @owned NonSendableKlass
+  %borrow = begin_borrow %klass : $NonSendableKlass
+
+  %fn = function_ref @global_actor_function_with_nsk : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
+  apply [callee_isolation=global_actor] %fn(%borrow) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
+
+  end_borrow %borrow : $NonSendableKlass
+  destroy_value %klass : $NonSendableKlass
+  %r = tuple ()
+  return %r : $()
+}
+
+// Test 25: Global actor A → Global actor B crossing. The klass is created in
+// CustomActor's domain and sent to CustomActor2. Should error.
+sil [isolation "global_actor(CustomActor)"] [ossa] @test_global_actor_a_to_global_actor_b : $@convention(thin) @async () -> () {
+bb0:
+  %get = function_ref @get_klass : $@convention(thin) () -> @owned NonSendableKlass
+  %klass = apply %get() : $@convention(thin) () -> @owned NonSendableKlass
+  %borrow = begin_borrow %klass : $NonSendableKlass
+
+  %fn = function_ref @global_actor2_function_with_nsk : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
+  // BUG! Should error here - klass is in CustomActor's domain and we're
+  // sending it to CustomActor2. The analysis does not detect global actor A
+  // to global actor B crossings.
+  apply [callee_isolation=global_actor] %fn(%borrow) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
+
+  end_borrow %borrow : $NonSendableKlass
+  destroy_value %klass : $NonSendableKlass
+  %r2 = tuple ()
+  return %r2 : $()
+}
+
+//////////////////////////////////////////////////////////
+// MARK: Group E — Unannotated applies, crossings, chains
+//////////////////////////////////////////////////////////
+
+// Test 26: Apply without [callee_isolation] attribute. The callee has
+// @sil_isolated in its type but the apply has no isolation annotation.
+// Tests whether the analysis infers isolation from the function type or
+// requires the explicit attribute.
+sil [ossa] @test_apply_no_isolation_attribute : $@convention(thin) @async (@guaranteed MyActor, @sil_isolated @guaranteed MyActor) -> () {
+bb0(%0 : @guaranteed $MyActor, %1 : @guaranteed $MyActor):
+  %get = function_ref @get_klass : $@convention(thin) () -> @owned NonSendableKlass
+  %klass = apply %get() : $@convention(thin) () -> @owned NonSendableKlass
+  %borrow = begin_borrow %klass : $NonSendableKlass
+
+  // Apply with %0 but NO [callee_isolation] attribute.
+  %fn = function_ref @async_function_2param_with_isolated : $@convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  // BUG! Should error here - the callee has @sil_isolated on %0 which is a
+  // different actor, but without [callee_isolation=actor_instance] the analysis
+  // does not detect the isolation crossing.
+  apply %fn(%borrow, %0) : $@convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+
+  end_borrow %borrow : $NonSendableKlass
+  destroy_value %klass : $NonSendableKlass
+  %r = tuple ()
+  return %r : $()
+}
+
+// Test 27: Actor-isolated → nonisolated crossing. From actor-isolated context,
+// call a nonisolated function. The klass is in %1's domain. Sending it to a
+// nonisolated callee should be a crossing.
+sil [ossa] @test_actor_to_nonisolated_crossing : $@convention(thin) @async (@guaranteed MyActor, @sil_isolated @guaranteed MyActor) -> () {
+bb0(%0 : @guaranteed $MyActor, %1 : @guaranteed $MyActor):
+  %get = function_ref @get_klass : $@convention(thin) () -> @owned NonSendableKlass
+  %klass = apply %get() : $@convention(thin) () -> @owned NonSendableKlass
+  %borrow = begin_borrow %klass : $NonSendableKlass
+
+  %fn = function_ref @nonisolated_function_with_nsk : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
+  // BUG! Should error here - klass is in %1's actor-isolated domain and we're
+  // sending it to a nonisolated callee. The analysis does not detect
+  // actor-isolated → nonisolated crossings.
+  apply [callee_isolation=nonisolated] %fn(%borrow) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
+
+  end_borrow %borrow : $NonSendableKlass
+  destroy_value %klass : $NonSendableKlass
+  %r = tuple ()
+  return %r : $()
+}
+
+// Test 27: Multiple sends of same value to different isolation domains.
+// First send to %0 (actor), then send to global actor. Both should error.
+sil [ossa] @test_multiple_sends_different_domains : $@convention(thin) @async (@guaranteed MyActor, @sil_isolated @guaranteed MyActor) -> () {
+bb0(%0 : @guaranteed $MyActor, %1 : @guaranteed $MyActor):
+  %get = function_ref @get_klass : $@convention(thin) () -> @owned NonSendableKlass
+  %klass = apply %get() : $@convention(thin) () -> @owned NonSendableKlass
+
+  // First send to %0
+  %borrow1 = begin_borrow %klass : $NonSendableKlass
+  %fn1 = function_ref @async_function_2param_with_isolated : $@convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  apply [callee_isolation=actor_instance] %fn1(%borrow1, %0) : $@convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> () // expected-error {{sending value of non-Sendable type 'NonSendableKlass' risks causing data races}}
+  // expected-note @-1 {{sending value of non-Sendable type 'NonSendableKlass' to actor-isolated callee risks causing data races between actor-isolated and local nonisolated uses}}
+  end_borrow %borrow1 : $NonSendableKlass
+
+  // Second send to global actor — also flagged
+  %borrow2 = begin_borrow %klass : $NonSendableKlass
+  %fn2 = function_ref @global_actor_function_with_nsk : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
+  apply [callee_isolation=global_actor] %fn2(%borrow2) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> () // expected-error {{sending value of non-Sendable type 'NonSendableKlass' risks causing data races}}
+  // expected-note @-1 {{sending value of non-Sendable type 'NonSendableKlass' to global actor '<null>'-isolated callee risks causing data races between global actor '<null>'-isolated and local nonisolated uses}}
+  // expected-note @-2 {{access can happen concurrently}}
+  end_borrow %borrow2 : $NonSendableKlass
+
+  // Use locally — also flagged
+  %borrow3 = begin_borrow %klass : $NonSendableKlass
+  %fn3 = function_ref @async_function_2param_with_isolated : $@convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  apply [callee_isolation=actor_instance] %fn3(%borrow3, %1) : $@convention(thin) @async (@guaranteed NonSendableKlass, @sil_isolated @guaranteed MyActor) -> () // expected-note {{access can happen concurrently}}
+  end_borrow %borrow3 : $NonSendableKlass
+
+  destroy_value %klass : $NonSendableKlass
+  %r = tuple ()
+  return %r : $()
+}
+
+// Test 28: Chain — receive a value from %0's isolation, then send it to a
+// global actor. The value should be in %0's region, and sending it to the
+// global actor is a second crossing.
+sil [ossa] @test_chain_receive_then_send : $@convention(thin) @async (@guaranteed MyActor, @sil_isolated @guaranteed MyActor) -> () {
+bb0(%0 : @guaranteed $MyActor, %1 : @guaranteed $MyActor):
+  // Get klass from %0's isolation domain.
+  %get_fn = function_ref @async_return_nsk_isolated : $@convention(thin) @async (@sil_isolated @guaranteed MyActor) -> @owned NonSendableKlass
+  %klass = apply [callee_isolation=actor_instance] %get_fn(%0) : $@convention(thin) @async (@sil_isolated @guaranteed MyActor) -> @owned NonSendableKlass // expected-error {{non-Sendable 'NonSendableKlass'-typed result can not be returned from actor-isolated function to nonisolated context}}
+
+  // Send to global actor. The klass crossed isolation on return, and now we
+  // send it again to the global actor.
+  %borrow = begin_borrow %klass : $NonSendableKlass
+  %fn = function_ref @global_actor_function_with_nsk : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
+  apply [callee_isolation=global_actor] %fn(%borrow) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> () // expected-error {{sending value of non-Sendable type 'NonSendableKlass' risks causing data races}}
+  // expected-note @-1 {{sending actor-isolated value of non-Sendable type 'NonSendableKlass' to global actor '<null>'-isolated callee risks causing races in between actor-isolated and global actor '<null>'-isolated uses}}
+  end_borrow %borrow : $NonSendableKlass
+
+  destroy_value %klass : $NonSendableKlass
+  %r = tuple ()
+  return %r : $()
+}

--- a/test/Concurrency/transfernonsendable_isolationcrossing_partialapply.swift
+++ b/test/Concurrency/transfernonsendable_isolationcrossing_partialapply.swift
@@ -41,30 +41,27 @@ actor ProtectsNonSendable {
   var ns: NonSendableKlass = .init()
 
   nonisolated func testParameter(_ nsArg: NonSendableKlass) async {
-    self.assumeIsolated { isolatedSelf in
+    self.assumeIsolated { isolatedSelf in // expected-note {{passing closure to 'assumeIsolated' here causes closure to become isolated to 'self'}}
       isolatedSelf.ns = nsArg // expected-warning {{sending 'nsArg' risks causing data races}}
-      // expected-concurrent-note @-1 {{task-isolated 'nsArg' is captured by a actor-isolated closure. actor-isolated uses in closure may race against later nonisolated uses}}
-      // expected-ni-note @-2 {{task-isolated 'nsArg' is captured by a actor-isolated closure. actor-isolated uses in closure may race against later nonisolated uses}}
+      // expected-note @-1 {{'self'-isolated closure captures 'nsArg' which remains accessible to code in the current task}}
     }
   }
 
   nonisolated func testParameterOutOfLine2(_ nsArg: NonSendableKlass) async {
     let closure: (isolated ProtectsNonSendable) -> () = { isolatedSelf in
-      isolatedSelf.ns = nsArg // expected-warning {{sending 'nsArg' risks causing data races}}
-      // expected-concurrent-note @-1 {{task-isolated 'nsArg' is captured by a actor-isolated closure. actor-isolated uses in closure may race against later nonisolated uses}}
-      // expected-ni-note @-2 {{task-isolated 'nsArg' is captured by a actor-isolated closure. actor-isolated uses in closure may race against later nonisolated uses}}
+      isolatedSelf.ns = nsArg // expected-warning 2{{sending 'nsArg' risks causing data races}}
+      // expected-note @-1 2{{'self'-isolated closure captures 'nsArg' which remains accessible to code in the current task}}
     }
-    self.assumeIsolated(closure)
-    self.assumeIsolated(closure)
+    self.assumeIsolated(closure) // expected-note {{passing closure to 'assumeIsolated' here causes closure to become isolated to 'self'}}
+    self.assumeIsolated(closure) // expected-note {{passing closure to 'assumeIsolated' here causes closure to become isolated to 'self'}}
   }
 
   nonisolated func testParameterMergedIntoLocal(_ nsArg: NonSendableKlass) async {
     let l = NonSendableKlass()
     doSomething(l, nsArg)
-    self.assumeIsolated { isolatedSelf in
+    self.assumeIsolated { isolatedSelf in // expected-note {{passing closure to 'assumeIsolated' here causes closure to become isolated to 'self'}}
       isolatedSelf.ns = l // expected-warning {{sending 'l' risks causing data races}}
-      // expected-concurrent-note @-1 {{task-isolated 'l' is captured by a actor-isolated closure. actor-isolated uses in closure may race against later nonisolated uses}}
-      // expected-ni-note @-2 {{task-isolated 'l' is captured by a actor-isolated closure. actor-isolated uses in closure may race against later nonisolated uses}}
+      // expected-note @-1 {{'self'-isolated closure captures 'l' which remains accessible to code in the current task}}
     }
   }
 
@@ -81,10 +78,9 @@ actor ProtectsNonSendable {
     let l = NonSendableKlass()
 
     // This is not safe since we use l later.
-    self.assumeIsolated { isolatedSelf in
+    self.assumeIsolated { isolatedSelf in // expected-note {{passing closure to 'assumeIsolated' here causes closure to become isolated to 'self'}}
       isolatedSelf.ns = l // expected-warning {{sending 'l' risks causing data races}}
-      // expected-concurrent-note @-1 {{'l' is captured by a actor-isolated closure. actor-isolated uses in closure may race against later nonisolated uses}}
-      // expected-ni-note @-2 {{'l' is captured by a actor-isolated closure. actor-isolated uses in closure may race against later nonisolated uses}}
+      // expected-note @-1 {{'self'-isolated closure captures 'l' which remains accessible to code in the current task}}
     }
 
     useValue(l) // expected-note {{access can happen concurrently}}

--- a/test/Concurrency/transfernonsendable_nonisolatedunsafe.swift
+++ b/test/Concurrency/transfernonsendable_nonisolatedunsafe.swift
@@ -898,7 +898,7 @@ func closureTests() async {
     nonisolated(unsafe) let x = NonSendableKlass()
     let y = NonSendableKlass()
     sendingClosure {
-      _ = x // expected-warning {{closure passed as an argument to a 'sending' parameter captures 'x' which is accessed later by code in the current task}}
+      _ = x
       _ = y // expected-warning {{closure passed as an argument to a 'sending' parameter captures 'y' which is accessed later by code in the current task}}
     }
     sendingClosure { // expected-note {{access can happen concurrently}}
@@ -987,7 +987,7 @@ func closureTests() async {
     var y = NonSendableKlass()
     y = NonSendableKlass()
     sendingClosure {
-      _ = x // expected-warning {{closure passed as an argument to a 'sending' parameter captures 'x' which is accessed later by code in the current task}}
+      _ = x
       _ = y // expected-warning {{closure passed as an argument to a 'sending' parameter captures 'y' which is accessed later by code in the current task}}
     }
     sendingClosure { // expected-note {{access can happen concurrently}}
@@ -1028,7 +1028,7 @@ func closureTests() async {
     nonisolated(unsafe) let x4a = NonSendableKlass()
     let x4b = NonSendableKlass()
     Task.detached {
-      _ = x4a; // expected-warning {{closure passed as an argument to a 'sending' parameter captures 'x4a' which is accessed later by code in the current task}}
+      _ = x4a;
       _ = x4b // expected-warning {{closure passed as an argument to a 'sending' parameter captures 'x4b' which is accessed later by code in the current task}}
     }
 
@@ -1044,6 +1044,57 @@ func closureTests() async {
   // not.
   func testNamedClosure() async {
     nonisolated(unsafe) let x = NonSendableKlass()
+    let y = {
+      _ = x
+    }
+    sendingClosure(y) // expected-warning {{sending 'y' risks causing data races}}
+    // expected-note @-1 {{'y' used after being passed as a 'sending' parameter}}
+    sendingClosure(y) // expected-note {{access can happen concurrently}}
+  }
+
+  // Named closure capturing nonisolated(unsafe) + non-sendable. The
+  // nonisolated(unsafe) capture should be skipped, and only the non-sendable
+  // capture should be diagnosed.
+  func testNamedClosureMixedCaptures() async {
+    nonisolated(unsafe) let x = NonSendableKlass()
+    let z = NonSendableKlass()
+    let y = {
+      _ = x
+      _ = z // expected-warning {{closure passed as an argument to a 'sending' parameter captures 'z' which is accessed later by code in the current task}}
+    }
+    sendingClosure(y)
+    sendingClosure(y) // expected-note {{access can happen concurrently}}
+  }
+
+  // Named closure capturing only nonisolated(unsafe) with a single send
+  // should produce no errors.
+  func testNamedClosureNonisolatedUnsafeSingleSend() async {
+    nonisolated(unsafe) let x = NonSendableKlass()
+    let y = {
+      _ = x
+    }
+    sendingClosure(y)
+  }
+
+  // Task-isolated parameter + nonisolated(unsafe) capture. Each send of the
+  // closure triggers a SentNeverSendable error for ns (task-isolated), while
+  // x (nonisolated(unsafe)) is not diagnosed.
+  func testSendingClosureTaskIsolatedAndNonisolatedUnsafe(_ ns: NonSendableKlass) async {
+    nonisolated(unsafe) let x = NonSendableKlass()
+    sendingClosure { // expected-warning {{passing closure as a 'sending' parameter risks causing data races between code in the current task and concurrent execution of the closure}}
+      _ = x
+      _ = ns // expected-note {{closure captures 'ns' which is accessible to code in the current task}}
+    }
+    sendingClosure { // expected-warning {{passing closure as a 'sending' parameter risks causing data races between code in the current task and concurrent execution of the closure}}
+      _ = x
+      _ = ns // expected-note {{closure captures 'ns' which is accessible to code in the current task}}
+    }
+  }
+
+  // var version of testNamedClosure.
+  func testNamedClosureVar() async {
+    nonisolated(unsafe) var x = NonSendableKlass()
+    x = NonSendableKlass()
     let y = {
       _ = x
     }

--- a/test/Concurrency/transfernonsendable_partitionop_translation.sil
+++ b/test/Concurrency/transfernonsendable_partitionop_translation.sil
@@ -3440,11 +3440,11 @@ bb0:
 // MARK: Dynamic Replacement Operations
 //===----------------------------------------------------------------------===//
 
+// This isn't tracked b/c it is Sendable now.
+//
 // CHECK-LABEL: begin running test {{.*}} on test_dynamic_function_ref: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
-// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
 // CHECK-NEXT:     Rep Value:   // dynamic_function_ref dynamic_func
-// CHECK-NEXT:   %0 = dynamic_function_ref @dynamic_func : $@convention(thin) () -> ()
-// CHECK-NEXT: assign_fresh %%0:   // dynamic_function_ref dynamic_func
 // CHECK-NEXT:   %0 = dynamic_function_ref @dynamic_func : $@convention(thin) () -> ()
 // CHECK-NEXT: end running test {{.*}} on test_dynamic_function_ref: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
 sil [ossa] @test_dynamic_function_ref : $@convention(thin) () -> () {

--- a/test/Concurrency/transfernonsendable_unavailable_conformance.swift
+++ b/test/Concurrency/transfernonsendable_unavailable_conformance.swift
@@ -24,7 +24,7 @@ actor Bar {
     _ = Bar(ns) // expected-warning {{sending 'ns' risks causing data races}}
     // TODO: This needs to be:
     // 'ns' is transferred to actor-isolated callee. Later local uses could race with uses in callee.
-    // expected-note @-3 {{sending 'ns' to actor-isolated initializer 'init(_:)' risks causing data races between actor-isolated and local actor-isolated uses}}
+    // expected-note @-3 {{sending 'ns' to actor initializer 'init(_:)' risks causing data races between actor-isolated and local actor-isolated uses}}
     ns.foo() // expected-note {{access can happen concurrently}}
   }
 }

--- a/test/Distributed/distributed_actor_assume_isolated_transfernonsendable.swift
+++ b/test/Distributed/distributed_actor_assume_isolated_transfernonsendable.swift
@@ -1,0 +1,82 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -target %target-swift-5.7-abi-triple %S/Inputs/FakeDistributedActorSystems.swift
+// RUN: %target-swift-frontend -swift-version 6 -verify -verify-ignore-unknown -disable-availability-checking -I %t %s -emit-sil
+
+// REQUIRES: concurrency
+// REQUIRES: distributed
+
+import Distributed
+import FakeDistributedActorSystems
+
+@available(SwiftStdlib 5.5, *)
+typealias DefaultDistributedActorSystem = FakeActorSystem
+
+class NonSendableKlass {
+  var x = 0
+}
+
+// =============================================================================
+// MARK: DistributedActor.assumeIsolated — SentNeverSendable
+// =============================================================================
+
+distributed actor MyDistributedActor {
+  var ns: NonSendableKlass = .init()
+
+  nonisolated func testParameter(_ nsArg: NonSendableKlass) {
+    self.assumeIsolated { isolatedSelf in // expected-note {{passing closure to 'assumeIsolated' here causes closure to become isolated to 'self'}}
+      isolatedSelf.ns = nsArg // expected-error {{sending 'nsArg' risks causing data races}}
+      // expected-note @-1 {{'self'-isolated closure captures 'nsArg' which remains accessible to code in the current task}}
+    }
+  }
+}
+
+// =============================================================================
+// MARK: DistributedActor.assumeIsolated — UseAfterSend
+// =============================================================================
+
+distributed actor MyDistributedActor2 {
+  var ns: NonSendableKlass = .init()
+
+  nonisolated func testUseAfterSend() {
+    let ns2 = NonSendableKlass()
+    self.assumeIsolated { isolatedSelf in // expected-note {{passing closure to 'assumeIsolated' here causes closure to become isolated to 'self'}}
+      isolatedSelf.ns = ns2 // expected-error {{sending 'ns2' risks causing data races}}
+      // expected-note @-1 {{'self'-isolated closure captures 'ns2' which remains accessible to code in the current task}}
+    }
+    print(ns2.x) // expected-note {{access can happen concurrently}}
+  }
+}
+
+// =============================================================================
+// MARK: DistributedActor.assumeIsolated — Out-of-line closure, SentNeverSendable
+// =============================================================================
+
+distributed actor MyDistributedActor3 {
+  var ns: NonSendableKlass = .init()
+
+  nonisolated func testOutOfLineClosure(_ nsArg: NonSendableKlass) {
+    let closure: (isolated MyDistributedActor3) -> () = { isolatedSelf in
+      isolatedSelf.ns = nsArg // expected-error {{sending 'nsArg' risks causing data races}}
+      // expected-note @-1 {{'self'-isolated closure captures 'nsArg' which remains accessible to code in the current task}}
+    }
+    self.assumeIsolated(closure) // expected-note {{passing closure to 'assumeIsolated' here causes closure to become isolated to 'self'}}
+  }
+}
+
+// =============================================================================
+// MARK: DistributedActor.assumeIsolated — Out-of-line closure, UseAfterSend
+// =============================================================================
+
+distributed actor MyDistributedActor4 {
+  var ns: NonSendableKlass = .init()
+
+  nonisolated func testOutOfLineClosureUseAfterSend() {
+    let ns2 = NonSendableKlass()
+    let closure: (isolated MyDistributedActor4) -> () = { isolatedSelf in
+      isolatedSelf.ns = ns2 // expected-error {{sending 'ns2' risks causing data races}}
+      // expected-note @-1 {{'self'-isolated closure captures 'ns2' which remains accessible to code in the current task}}
+    }
+    self.assumeIsolated(closure) // expected-note {{passing closure to 'assumeIsolated' here causes closure to become isolated to 'self'}}
+    print(ns2.x) // expected-note {{access can happen concurrently}}
+  }
+}


### PR DESCRIPTION
This PR contains one main commit and then three follow-on fixes that address issues exposed by the change in isolation modeling.

The core change is that when a partial_apply does not close over its isolated
actor parameter or a function_ref refers to an actor-instance-isolated function,
the actual actor instance is unknown until the full apply site. Previously we
eagerly assigned actor isolation with a flag saying it could merge with another
actor region. This led to problems where we could merge a task-isolated parameter
with a non-applied actor partial apply.

This is needed to enable flow isolation. Flow isolation requires Sema to perform
less strict checking in initializers and delegate that responsibility to
SendNonSendable instead, meaning SendNonSendable now performs significantly more
merge checking. Without these fixes, the additional merging exposes cases where
regions become isolated to multiple different actor regions, breaking region
isolation invariants and producing "pattern unknown" errors.

The fix returns disconnected isolation instead, deferring the actor isolation
merge to the apply site where the concrete actor is known. This correctly
handles:
- Sending closures whose isolation depends on the call-site argument
- Captures that are all disconnected (freely sendable)
- Captures that are isolated (error surfaced at the apply site on mismatch)

The three follow-on commits fix downstream consequences:

1. **assumeIsolated closures**: `assumeIsolated` uses unsafe internals to bind
   the isolated parameter without a normal apply that region analysis can see.
   After the deferral change, non-sendable captures passed through undiagnosed.
   Fix: special-case `Actor.assumeIsolated` and `DistributedActor.assumeIsolated`
   to treat the closure operand as sent into the actor's region.

2. **Actor async allocating inits**: These don't have an isolated parameter at
   the SIL level (they take a metatype). After the deferral change, the
   function_ref returned disconnected, causing send diagnostics to be silently
   dropped. Fix: return actor-instance isolation for async allocating inits.
   Also improves diagnostic wording for nonisolated sync actor inits.

3. **nonisolated(unsafe) captures**: When a closure passed to a `sending`
   parameter captures a `nonisolated(unsafe)` value, the diagnostic inferrer
   incorrectly included it in the non-Sendable capture list, causing wrong
   diagnostics. Fix: skip `nonisolated(unsafe)` captures.

rdar://176044102

----

<!--
The main branch is now in convergence, which means major changes, such as large refactoring or new features, should be avoided. This strategy is intended to maintain the stability of the Swift 6.4 release leading up to the May 4th branch. For any work that requires broad changes or introduces new features, create a feature branch and open a draft pull request. All updates to the swiftlang/swift repository's main branch require approval from the release managers. A pull request targeting swiftlang/swift will automatically add release managers. You can also contact them via @release-managers in the forum group.
-->

<!-- Please fill out the following form: --> 
- **Explanation**:
  Fix region-based isolation to return disconnected isolation for partial_apply/function_ref with unbound isolated parameters, deferring actor isolation to the apply site. This is required for flow isolation, where SendNonSendable performs more merge checking and the old eager isolation model causes regions to become isolated to multiple actors, breaking invariants. Three follow-on fixes address assumeIsolated closures, actor async allocating inits, and nonisolated(unsafe) captures.
- **Scope**:
  Diagnostic-only changes in the SIL optimizer's region-based isolation analysis. No ABI, codegen, or runtime changes. Some previously-silent concurrency violations (e.g., non-sendable captures in assumeIsolated closures) will now be correctly diagnosed. Thin function types are also now treated as Sendable since they carry no captured state.
- **Issues**:
  rdar://176044102
- **Risk**:
  All changes are in diagnostic emission paths within SendNonSendable, RegionAnalysis, and SILIsolationInfo. The risk is limited to producing different diagnostics under strict concurrency checking — any new diagnostics represent previously-missed violations. No codegen or runtime behavior is affected.
- **Testing**:
  ~2000 lines of new SIL and Swift test coverage across 11 test files, including new tests for assumeIsolated, isolated parameter partial applies, actor initializers, nonisolated(unsafe) captures, and distributed actors.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
