### PR TITLE
[StdlibUnittest] Skip crash testing based on test runner feature rather than platform

### DIFF
--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift
@@ -2142,6 +2142,13 @@ public final class TestSuite {
       return self
     }
 
+    public func requireCapability(
+      _ capability: TestRunnerCapability
+    ) -> _TestBuilder {
+      _data._skip.append(.missingCapability(capability))
+      return self
+    }
+
     public func stdin(_ stdinText: String, eof: Bool = false) -> _TestBuilder {
       _data._stdinText = stdinText
       _data._stdinEndsWithEOF = eof
@@ -2264,6 +2271,22 @@ public enum StdLibVersion: String {
       return if #available(SwiftStdlib 6.3, *)  { true } else { false }
     case .stdlib_6_4:
       return if #available(SwiftStdlib 6.4, *)  { true } else { false }
+    }
+  }
+}
+
+public enum TestRunnerCapability: String {
+  case crashTesting = "crash testing"
+
+  var isMissing: Bool {
+    switch self {
+    case .crashTesting:
+      switch _getRunningOSVersion() {
+      case .wasi:
+        return true
+      default:
+        return false
+      }
     }
   }
 }
@@ -2481,6 +2504,8 @@ public enum TestRunPredicate : CustomStringConvertible {
   case nativeRuntime(/*reason:*/ String)
 
   case minimumStdlib(StdLibVersion)
+
+  case missingCapability(TestRunnerCapability)
   
   public var description: String {
     switch self {
@@ -2608,6 +2633,9 @@ public enum TestRunPredicate : CustomStringConvertible {
       
     case .minimumStdlib(let version):
       return "Requires Swift \(version.rawValue)'s standard library"
+
+    case .missingCapability(let capability):
+      return "Requires \(capability.rawValue)"
     }
   }
 
@@ -3007,6 +3035,9 @@ public enum TestRunPredicate : CustomStringConvertible {
       
     case .minimumStdlib(let version):
       return !version.isAvailable
+
+    case .missingCapability(let capability):
+      return capability.isMissing
     }
   }
 }

--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift
@@ -2137,15 +2137,14 @@ public final class TestSuite {
       return self
     }
 
-    public func require(_ stdlibVersion: StdLibVersion) -> _TestBuilder {
-      _data._skip.append(.minimumStdlib(stdlibVersion))
-      return self
+    public func require(_ stdlibVersion: StdlibVersion) -> _TestBuilder {
+      require(TestRequirement.minimumStdlib(stdlibVersion))
     }
 
-    public func requireCapability(
-      _ capability: TestRunnerCapability
+    public func require(
+      _ requirement: TestRequirement
     ) -> _TestBuilder {
-      _data._skip.append(.missingCapability(capability))
+      _data._skip.append(.missingRequirement(requirement))
       return self
     }
 
@@ -2240,7 +2239,7 @@ func _getSystemVersionPlistProperty(_ propertyName: String) -> String? {
 #endif
 #endif
 
-public enum StdLibVersion: String {
+public enum StdlibVersion: String {
   case stdlib_5_7  = "5.7"
   case stdlib_5_8  = "5.8"
   case stdlib_5_9  = "5.9"
@@ -2275,18 +2274,28 @@ public enum StdLibVersion: String {
   }
 }
 
-public enum TestRunnerCapability: String {
-  case crashTesting = "crash testing"
+public enum TestRequirement: CustomStringConvertible {
+  case minimumStdlib(StdlibVersion)
+  case crashTesting
 
   var isMissing: Bool {
     switch self {
+    case .minimumStdlib(let version):
+      !version.isAvailable
     case .crashTesting:
       switch _getRunningOSVersion() {
       case .wasi:
-        return true
+        true
       default:
-        return false
+        false
       }
+    }
+  }
+
+  public var description: String {
+    switch self {
+    case .crashTesting: "crash testing"
+    case .minimumStdlib(let version): "standard library version \(version)"
     }
   }
 }
@@ -2503,10 +2512,10 @@ public enum TestRunPredicate : CustomStringConvertible {
   case objCRuntime(/*reason:*/ String)
   case nativeRuntime(/*reason:*/ String)
 
-  case minimumStdlib(StdLibVersion)
+  case minimumStdlib(StdlibVersion)
 
-  case missingCapability(TestRunnerCapability)
-  
+  case missingRequirement(TestRequirement)
+
   public var description: String {
     switch self {
     case .custom(_, let reason):
@@ -2634,8 +2643,8 @@ public enum TestRunPredicate : CustomStringConvertible {
     case .minimumStdlib(let version):
       return "Requires Swift \(version.rawValue)'s standard library"
 
-    case .missingCapability(let capability):
-      return "Requires \(capability.rawValue)"
+    case .missingRequirement(let requirement):
+      return "Requires \(requirement)"
     }
   }
 
@@ -3036,8 +3045,8 @@ public enum TestRunPredicate : CustomStringConvertible {
     case .minimumStdlib(let version):
       return !version.isAvailable
 
-    case .missingCapability(let capability):
-      return capability.isMissing
+    case .missingRequirement(let requirement):
+      return requirement.isMissing
     }
   }
 }

--- a/test/Concurrency/Runtime/actor_assert_precondition_executor.swift
+++ b/test/Concurrency/Runtime/actor_assert_precondition_executor.swift
@@ -102,7 +102,7 @@ struct TestStaticVar {
       }
 
       tests.test("precondition on actor (main): wrongly assume the main executor, from actor on other executor")
-      .skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+      .requireCapability(.crashTesting)
       .code {
         expectCrashLater(withMessage: "Incorrect actor executor assumption; Expected 'MainActor' executor.")
         await Someone().callCheckMainActor()

--- a/test/Concurrency/Runtime/actor_assert_precondition_executor.swift
+++ b/test/Concurrency/Runtime/actor_assert_precondition_executor.swift
@@ -101,12 +101,12 @@ struct TestStaticVar {
         _ = await global
       }
 
-      #if !os(WASI)
-      tests.test("precondition on actor (main): wrongly assume the main executor, from actor on other executor") {
+      tests.test("precondition on actor (main): wrongly assume the main executor, from actor on other executor")
+      .skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+      .code {
         expectCrashLater(withMessage: "Incorrect actor executor assumption; Expected 'MainActor' executor.")
         await Someone().callCheckMainActor()
       }
-      #endif
 
       // === Global actor -----------------------------------------------------
 

--- a/test/Concurrency/Runtime/actor_assert_precondition_executor.swift
+++ b/test/Concurrency/Runtime/actor_assert_precondition_executor.swift
@@ -102,7 +102,7 @@ struct TestStaticVar {
       }
 
       tests.test("precondition on actor (main): wrongly assume the main executor, from actor on other executor")
-      .requireCapability(.crashTesting)
+      .require(.crashTesting)
       .code {
         expectCrashLater(withMessage: "Incorrect actor executor assumption; Expected 'MainActor' executor.")
         await Someone().callCheckMainActor()

--- a/test/Concurrency/Runtime/actor_assume_executor.swift
+++ b/test/Concurrency/Runtime/actor_assume_executor.swift
@@ -118,7 +118,7 @@ final class MainActorEcho {
       }
 
       tests.test("MainActor.assumeIsolated: wrongly assume the main executor, from actor on other executor")
-      .requireCapability(.crashTesting)
+      .require(.crashTesting)
       .code {
         expectCrashLater(withMessage: "Incorrect actor executor assumption; Expected 'MainActor' executor.")
         await SomeoneOnDefaultExecutor().callCheckMainActor(echo: echo)
@@ -128,14 +128,14 @@ final class MainActorEcho {
 
       let someone = SomeoneOnDefaultExecutor()
       tests.test("assumeOnActorExecutor: wrongly assume someone's executor, from 'main() async'")
-      .requireCapability(.crashTesting)
+      .require(.crashTesting)
       .code {
         expectCrashLater(withMessage: "Incorrect actor executor assumption; Expected same executor as a.SomeoneOnDefaultExecutor.")
         checkAssumeSomeone(someone: someone)
       }
 
       tests.test("assumeOnActorExecutor: wrongly assume someone's executor, from MainActor method")
-      .requireCapability(.crashTesting)
+      .require(.crashTesting)
       .code {
         expectCrashLater(withMessage: "Incorrect actor executor assumption; Expected same executor as a.SomeoneOnDefaultExecutor.")
         checkAssumeSomeone(someone: someone)
@@ -150,7 +150,7 @@ final class MainActorEcho {
       }
 
       tests.test("assumeOnActorExecutor: wrongly assume the main executor, from actor on other executor")
-      .requireCapability(.crashTesting)
+      .require(.crashTesting)
       .code {
         expectCrashLater(withMessage: "Incorrect actor executor assumption; Expected same executor as a.SomeoneOnDefaultExecutor.")
         await CompleteStranger(someone: someone).callCheckSomeone()

--- a/test/Concurrency/Runtime/actor_assume_executor.swift
+++ b/test/Concurrency/Runtime/actor_assume_executor.swift
@@ -117,27 +117,29 @@ final class MainActorEcho {
         await MainFriend().callCheck(echo: echo)
       }
 
-      #if !os(WASI)
-      tests.test("MainActor.assumeIsolated: wrongly assume the main executor, from actor on other executor") {
+      tests.test("MainActor.assumeIsolated: wrongly assume the main executor, from actor on other executor")
+      .skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+      .code {
         expectCrashLater(withMessage: "Incorrect actor executor assumption; Expected 'MainActor' executor.")
         await SomeoneOnDefaultExecutor().callCheckMainActor(echo: echo)
       }
-      #endif
 
       // === some Actor -------------------------------------------------------
 
       let someone = SomeoneOnDefaultExecutor()
-      #if !os(WASI)
-      tests.test("assumeOnActorExecutor: wrongly assume someone's executor, from 'main() async'") {
+      tests.test("assumeOnActorExecutor: wrongly assume someone's executor, from 'main() async'")
+      .skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+      .code {
         expectCrashLater(withMessage: "Incorrect actor executor assumption; Expected same executor as a.SomeoneOnDefaultExecutor.")
         checkAssumeSomeone(someone: someone)
       }
 
-      tests.test("assumeOnActorExecutor: wrongly assume someone's executor, from MainActor method") {
+      tests.test("assumeOnActorExecutor: wrongly assume someone's executor, from MainActor method")
+      .skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+      .code {
         expectCrashLater(withMessage: "Incorrect actor executor assumption; Expected same executor as a.SomeoneOnDefaultExecutor.")
         checkAssumeSomeone(someone: someone)
       }
-      #endif
 
       tests.test("assumeOnActorExecutor: assume someone's executor, from SomeoneOnDefaultExecutor") {
         await someone.callCheckSomeone()
@@ -147,12 +149,12 @@ final class MainActorEcho {
         await SomeonesFriend(someone: someone).callCheckSomeone()
       }
 
-      #if !os(WASI)
-      tests.test("assumeOnActorExecutor: wrongly assume the main executor, from actor on other executor") {
+      tests.test("assumeOnActorExecutor: wrongly assume the main executor, from actor on other executor")
+      .skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+      .code {
         expectCrashLater(withMessage: "Incorrect actor executor assumption; Expected same executor as a.SomeoneOnDefaultExecutor.")
         await CompleteStranger(someone: someone).callCheckSomeone()
       }
-      #endif
 
     }
 

--- a/test/Concurrency/Runtime/actor_assume_executor.swift
+++ b/test/Concurrency/Runtime/actor_assume_executor.swift
@@ -118,7 +118,7 @@ final class MainActorEcho {
       }
 
       tests.test("MainActor.assumeIsolated: wrongly assume the main executor, from actor on other executor")
-      .skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+      .requireCapability(.crashTesting)
       .code {
         expectCrashLater(withMessage: "Incorrect actor executor assumption; Expected 'MainActor' executor.")
         await SomeoneOnDefaultExecutor().callCheckMainActor(echo: echo)
@@ -128,14 +128,14 @@ final class MainActorEcho {
 
       let someone = SomeoneOnDefaultExecutor()
       tests.test("assumeOnActorExecutor: wrongly assume someone's executor, from 'main() async'")
-      .skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+      .requireCapability(.crashTesting)
       .code {
         expectCrashLater(withMessage: "Incorrect actor executor assumption; Expected same executor as a.SomeoneOnDefaultExecutor.")
         checkAssumeSomeone(someone: someone)
       }
 
       tests.test("assumeOnActorExecutor: wrongly assume someone's executor, from MainActor method")
-      .skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+      .requireCapability(.crashTesting)
       .code {
         expectCrashLater(withMessage: "Incorrect actor executor assumption; Expected same executor as a.SomeoneOnDefaultExecutor.")
         checkAssumeSomeone(someone: someone)
@@ -150,7 +150,7 @@ final class MainActorEcho {
       }
 
       tests.test("assumeOnActorExecutor: wrongly assume the main executor, from actor on other executor")
-      .skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+      .requireCapability(.crashTesting)
       .code {
         expectCrashLater(withMessage: "Incorrect actor executor assumption; Expected same executor as a.SomeoneOnDefaultExecutor.")
         await CompleteStranger(someone: someone).callCheckSomeone()

--- a/test/Concurrency/Runtime/checked_continuation.swift
+++ b/test/Concurrency/Runtime/checked_continuation.swift
@@ -19,7 +19,7 @@ struct TestError: Error {}
 
     if #available(SwiftStdlib 5.1, *) {
       tests.test("trap on double resume non-throwing continuation")
-      .skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+      .requireCapability(.crashTesting)
       .code {
         expectCrashLater()
 
@@ -33,7 +33,7 @@ struct TestError: Error {}
       }
 
       tests.test("trap on double resume throwing continuation")
-      .skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+      .requireCapability(.crashTesting)
       .code {
         expectCrashLater()
 

--- a/test/Concurrency/Runtime/checked_continuation.swift
+++ b/test/Concurrency/Runtime/checked_continuation.swift
@@ -18,8 +18,9 @@ struct TestError: Error {}
     var tests = TestSuite("CheckedContinuation")
 
     if #available(SwiftStdlib 5.1, *) {
-      #if !os(WASI)
-      tests.test("trap on double resume non-throwing continuation") {
+      tests.test("trap on double resume non-throwing continuation")
+      .skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+      .code {
         expectCrashLater()
 
         let task = detach {
@@ -31,7 +32,9 @@ struct TestError: Error {}
         await task.get()
       }
 
-      tests.test("trap on double resume throwing continuation") {
+      tests.test("trap on double resume throwing continuation")
+      .skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+      .code {
         expectCrashLater()
 
         let task = detach {
@@ -45,7 +48,6 @@ struct TestError: Error {}
         }
         await task.get()
       }
-      #endif
 
       tests.test("test withCheckedThrowingContinuation") {
         let task2 = detach {

--- a/test/Concurrency/Runtime/checked_continuation.swift
+++ b/test/Concurrency/Runtime/checked_continuation.swift
@@ -19,7 +19,7 @@ struct TestError: Error {}
 
     if #available(SwiftStdlib 5.1, *) {
       tests.test("trap on double resume non-throwing continuation")
-      .requireCapability(.crashTesting)
+      .require(.crashTesting)
       .code {
         expectCrashLater()
 
@@ -33,7 +33,7 @@ struct TestError: Error {}
       }
 
       tests.test("trap on double resume throwing continuation")
-      .requireCapability(.crashTesting)
+      .require(.crashTesting)
       .code {
         expectCrashLater()
 

--- a/test/stdlib/BitCastTests.swift
+++ b/test/stdlib/BitCastTests.swift
@@ -53,7 +53,7 @@ suite.test("bitCast UInt64 to Int64")
 }
 
 suite.test("bitCast size mismatch precondition")
-.requireCapability(.crashTesting)
+.require(.crashTesting)
 .require(.stdlib_6_4).code {
   let u = Int32.zero
   expectCrashLater()

--- a/test/stdlib/BitCastTests.swift
+++ b/test/stdlib/BitCastTests.swift
@@ -53,7 +53,7 @@ suite.test("bitCast UInt64 to Int64")
 }
 
 suite.test("bitCast size mismatch precondition")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.requireCapability(.crashTesting)
 .require(.stdlib_6_4).code {
   let u = Int32.zero
   expectCrashLater()

--- a/test/stdlib/Character.swift
+++ b/test/stdlib/Character.swift
@@ -360,7 +360,7 @@ UnicodeScalarTests.test("UInt8(ascii: UnicodeScalar)") {
 }
 
 UnicodeScalarTests.test("UInt8(ascii: UnicodeScalar)/non-ASCII should trap")
-  .skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+  .requireCapability(.crashTesting)
   .skip(.custom(
     { _isFastAssertConfiguration() },
     reason: "this trap is not guaranteed to happen in -Ounchecked"))

--- a/test/stdlib/Character.swift
+++ b/test/stdlib/Character.swift
@@ -359,9 +359,8 @@ UnicodeScalarTests.test("UInt8(ascii: UnicodeScalar)") {
   }
 }
 
-#if !os(WASI)
-// Trap tests aren't available on WASI.
 UnicodeScalarTests.test("UInt8(ascii: UnicodeScalar)/non-ASCII should trap")
+  .skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
   .skip(.custom(
     { _isFastAssertConfiguration() },
     reason: "this trap is not guaranteed to happen in -Ounchecked"))
@@ -370,7 +369,6 @@ UnicodeScalarTests.test("UInt8(ascii: UnicodeScalar)/non-ASCII should trap")
   expectCrashLater()
   _blackHole(UInt8(ascii: us))
 }
-#endif
 
 UnicodeScalarTests.test("UInt32(_: UnicodeScalar),UInt64(_: UnicodeScalar)") {
   for us in baseScalars {

--- a/test/stdlib/Character.swift
+++ b/test/stdlib/Character.swift
@@ -360,7 +360,7 @@ UnicodeScalarTests.test("UInt8(ascii: UnicodeScalar)") {
 }
 
 UnicodeScalarTests.test("UInt8(ascii: UnicodeScalar)/non-ASCII should trap")
-  .requireCapability(.crashTesting)
+  .require(.crashTesting)
   .skip(.custom(
     { _isFastAssertConfiguration() },
     reason: "this trap is not guaranteed to happen in -Ounchecked"))

--- a/test/stdlib/Duration.swift
+++ b/test/stdlib/Duration.swift
@@ -31,7 +31,7 @@ if #available(SwiftStdlib 5.7, *) {
   }
 
   suite.test("seconds from Double, overflow")
-  .skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+  .requireCapability(.crashTesting)
   .code {
     let huge: Double = 1.7e20
     let duration = Duration.seconds(huge)
@@ -175,7 +175,7 @@ if #available(SwiftStdlib 6.0, *) {
   }
 
   suite.test("seconds from Int128, overflow")
-  .skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+  .requireCapability(.crashTesting)
   .code {
     expectCrashLater()
     let _ = Duration.seconds( 170141183460469231732 as Int128)
@@ -197,7 +197,7 @@ if #available(SwiftStdlib 6.0, *) {
   }
 
   suite.test("milliseconds from Int128, overflow")
-  .skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+  .requireCapability(.crashTesting)
   .code {
     expectCrashLater()
     let _ = Duration.milliseconds( 170141183460469231731689 as Int128)
@@ -219,7 +219,7 @@ if #available(SwiftStdlib 6.0, *) {
   }
 
   suite.test("microseconds from Int128, overflow")
-  .skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+  .requireCapability(.crashTesting)
   .code {
     expectCrashLater()
     let _ = Duration.microseconds( 170141183460469231731687304 as Int128)
@@ -241,7 +241,7 @@ if #available(SwiftStdlib 6.0, *) {
   }
 
   suite.test("nanoseconds from Int128, overflow")
-  .skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+  .requireCapability(.crashTesting)
   .code {
     expectCrashLater()
     let _ = Duration.nanoseconds( 170141183460469231731687303716 as Int128)

--- a/test/stdlib/Duration.swift
+++ b/test/stdlib/Duration.swift
@@ -28,11 +28,15 @@ if #available(SwiftStdlib 5.7, *) {
     // Divide by 1000 to get back to a duration with representable components:
     let smallerDuration = duration / 1000
     expectEqual(smallerDuration.components, (170_000_000_000_000_000, 0))
-#if !os(WASI)
-    // Now check that the components of the original value trap:
+  }
+
+  suite.test("seconds from Double, overflow")
+  .skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+  .code {
+    let huge: Double = 1.7e20
+    let duration = Duration.seconds(huge)
     expectCrashLater()
     let _ = duration.components
-#endif
   }
   
   suite.test("milliseconds from Double") {
@@ -168,11 +172,13 @@ if #available(SwiftStdlib 6.0, *) {
     let minRep = Duration.seconds(-166020696663385964544 as Int128)
     expectEqual(minRep._high,-9_000_000_000_000_000_000)
     expectEqual(minRep._low, 0)
-    #if !os(WASI)
-    //  Check just above the overflow boundary
+  }
+
+  suite.test("seconds from Int128, overflow")
+  .skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+  .code {
     expectCrashLater()
     let _ = Duration.seconds( 170141183460469231732 as Int128)
-    #endif
   }
   
   suite.test("milliseconds from Int128") {
@@ -188,13 +194,15 @@ if #available(SwiftStdlib 6.0, *) {
     let minRep = Duration.milliseconds(-170134320591823194554368 as Int128)
     expectEqual(minRep._high,-9_223_000_000_000_000_000)
     expectEqual(minRep._low, 0)
-    #if !os(WASI)
-    //  Check just above the overflow boundary
+  }
+
+  suite.test("milliseconds from Int128, overflow")
+  .skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+  .code {
     expectCrashLater()
     let _ = Duration.milliseconds( 170141183460469231731689 as Int128)
-    #endif
   }
-  
+
   suite.test("microseconds from Int128") {
     let one = Duration.microseconds(1 as Int128)
     expectEqual(one._high, 0)
@@ -208,11 +216,13 @@ if #available(SwiftStdlib 6.0, *) {
     let minRep = Duration.microseconds(-170141182780618614507569152 as Int128)
     expectEqual(minRep._high,-9_223_372_000_000_000_000)
     expectEqual(minRep._low, 0)
-    #if !os(WASI)
-    //  Check just above the overflow boundary
+  }
+
+  suite.test("microseconds from Int128, overflow")
+  .skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+  .code {
     expectCrashLater()
     let _ = Duration.microseconds( 170141183460469231731687304 as Int128)
-    #endif
   }
   
   suite.test("nanoseconds from Int128") {
@@ -228,11 +238,13 @@ if #available(SwiftStdlib 6.0, *) {
     let minRep = Duration.nanoseconds(-170141183444701401161113010176 as Int128)
     expectEqual(minRep._high,-9_223_372_036_000_000_000)
     expectEqual(minRep._low, 0)
-    #if !os(WASI)
-    //  Check just above the overflow boundary
+  }
+
+  suite.test("nanoseconds from Int128, overflow")
+  .skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+  .code {
     expectCrashLater()
     let _ = Duration.nanoseconds( 170141183460469231731687303716 as Int128)
-    #endif
   }
   
   suite.test("attoseconds init") {

--- a/test/stdlib/Duration.swift
+++ b/test/stdlib/Duration.swift
@@ -31,7 +31,7 @@ if #available(SwiftStdlib 5.7, *) {
   }
 
   suite.test("seconds from Double, overflow")
-  .requireCapability(.crashTesting)
+  .require(.crashTesting)
   .code {
     let huge: Double = 1.7e20
     let duration = Duration.seconds(huge)
@@ -175,7 +175,7 @@ if #available(SwiftStdlib 6.0, *) {
   }
 
   suite.test("seconds from Int128, overflow")
-  .requireCapability(.crashTesting)
+  .require(.crashTesting)
   .code {
     expectCrashLater()
     let _ = Duration.seconds( 170141183460469231732 as Int128)
@@ -197,7 +197,7 @@ if #available(SwiftStdlib 6.0, *) {
   }
 
   suite.test("milliseconds from Int128, overflow")
-  .requireCapability(.crashTesting)
+  .require(.crashTesting)
   .code {
     expectCrashLater()
     let _ = Duration.milliseconds( 170141183460469231731689 as Int128)
@@ -219,7 +219,7 @@ if #available(SwiftStdlib 6.0, *) {
   }
 
   suite.test("microseconds from Int128, overflow")
-  .requireCapability(.crashTesting)
+  .require(.crashTesting)
   .code {
     expectCrashLater()
     let _ = Duration.microseconds( 170141183460469231731687304 as Int128)
@@ -241,7 +241,7 @@ if #available(SwiftStdlib 6.0, *) {
   }
 
   suite.test("nanoseconds from Int128, overflow")
-  .requireCapability(.crashTesting)
+  .require(.crashTesting)
   .code {
     expectCrashLater()
     let _ = Duration.nanoseconds( 170141183460469231731687303716 as Int128)

--- a/test/stdlib/Error.swift
+++ b/test/stdlib/Error.swift
@@ -119,7 +119,7 @@ ErrorTests.test("default domain and code") {
 enum SillyError: Error { case JazzHands }
 
 ErrorTests.test("try!")
-  .requireCapability(.crashTesting)
+  .require(.crashTesting)
   .skip(.custom({ _isFastAssertConfiguration() },
                 reason: "trap is not guaranteed to happen in -Ounchecked"))
   .crashOutputMatches(shouldCheckErrorLocation()
@@ -132,7 +132,7 @@ ErrorTests.test("try!")
 }
 
 ErrorTests.test("try!/location")
-  .requireCapability(.crashTesting)
+  .require(.crashTesting)
   .skip(.custom({ _isFastAssertConfiguration() },
                 reason: "trap is not guaranteed to happen in -Ounchecked"))
   .crashOutputMatches(shouldCheckErrorLocation()

--- a/test/stdlib/Error.swift
+++ b/test/stdlib/Error.swift
@@ -118,9 +118,8 @@ ErrorTests.test("default domain and code") {
 
 enum SillyError: Error { case JazzHands }
 
-#if !os(WASI)
-// Trap tests aren't available on WASI.
 ErrorTests.test("try!")
+  .skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
   .skip(.custom({ _isFastAssertConfiguration() },
                 reason: "trap is not guaranteed to happen in -Ounchecked"))
   .crashOutputMatches(shouldCheckErrorLocation()
@@ -133,6 +132,7 @@ ErrorTests.test("try!")
 }
 
 ErrorTests.test("try!/location")
+  .skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
   .skip(.custom({ _isFastAssertConfiguration() },
                 reason: "trap is not guaranteed to happen in -Ounchecked"))
   .crashOutputMatches(shouldCheckErrorLocation()
@@ -142,7 +142,6 @@ ErrorTests.test("try!/location")
     expectCrashLater()
     let _: () = try! { throw SillyError.JazzHands }()
 }
-#endif
 
 ErrorTests.test("try?") {
   var value = try? { () throws -> Int in return 1 }()

--- a/test/stdlib/Error.swift
+++ b/test/stdlib/Error.swift
@@ -119,7 +119,7 @@ ErrorTests.test("default domain and code") {
 enum SillyError: Error { case JazzHands }
 
 ErrorTests.test("try!")
-  .skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+  .requireCapability(.crashTesting)
   .skip(.custom({ _isFastAssertConfiguration() },
                 reason: "trap is not guaranteed to happen in -Ounchecked"))
   .crashOutputMatches(shouldCheckErrorLocation()
@@ -132,7 +132,7 @@ ErrorTests.test("try!")
 }
 
 ErrorTests.test("try!/location")
-  .skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+  .requireCapability(.crashTesting)
   .skip(.custom({ _isFastAssertConfiguration() },
                 reason: "trap is not guaranteed to happen in -Ounchecked"))
   .crashOutputMatches(shouldCheckErrorLocation()

--- a/test/stdlib/FloatingPoint.swift.gyb
+++ b/test/stdlib/FloatingPoint.swift.gyb
@@ -335,7 +335,7 @@ FloatingPoint.test("Float/Int16") {
 }
 
 FloatingPoint.test("Float/UInt32")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.requireCapability(.crashTesting)
 .code {
   expectEqual(UInt32.min, UInt32(Float(UInt32.min)))
   expectCrashLater()
@@ -343,7 +343,7 @@ FloatingPoint.test("Float/UInt32")
 }
 
 FloatingPoint.test("Float/Int32")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.requireCapability(.crashTesting)
 .code {
   expectEqual(Int32.min, Int32(Float(Int32.min)))
   expectCrashLater()
@@ -351,7 +351,7 @@ FloatingPoint.test("Float/Int32")
 }
 
 FloatingPoint.test("Float/UInt64")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.requireCapability(.crashTesting)
 .code {
   expectEqual(UInt64.min, UInt64(Float(UInt64.min)))
   expectCrashLater()
@@ -359,7 +359,7 @@ FloatingPoint.test("Float/UInt64")
 }
 
 FloatingPoint.test("Float/Int64")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.requireCapability(.crashTesting)
 .code {
   expectEqual(Int64.min, Int64(Float(Int64.min)))
   expectCrashLater()
@@ -431,7 +431,7 @@ FloatingPoint.test("Double/Int32") {
 }
 
 FloatingPoint.test("Double/UInt64")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.requireCapability(.crashTesting)
 .code {
   expectEqual(UInt64.min, UInt64(Double(UInt64.min)))
   expectCrashLater()
@@ -439,7 +439,7 @@ FloatingPoint.test("Double/UInt64")
 }
 
 FloatingPoint.test("Double/Int64")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.requireCapability(.crashTesting)
 .code {
   expectEqual(Int64.min, Int64(Double(Int64.min)))
   expectCrashLater()
@@ -1193,7 +1193,7 @@ FloatingPoint.test("Float32/quietNaN") {
 }
 
 FloatingPoint.test("Float32/quietNaN overflow")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.requireCapability(.crashTesting)
 .code {
   // Payload overflow
   expectCrashLater()
@@ -1225,7 +1225,7 @@ FloatingPoint.test("Float64/quietNaN") {
 }
 
 FloatingPoint.test("Float64/quietNaN overflow")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.requireCapability(.crashTesting)
 .code {
   // Payload overflow
   expectCrashLater()
@@ -1259,7 +1259,7 @@ FloatingPoint.test("Float80/quietNaN") {
 }
 
 FloatingPoint.test("Float80/quietNaN overflow")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.requireCapability(.crashTesting)
 .code {
   // Payload overflow
   expectCrashLater()
@@ -1295,7 +1295,7 @@ FloatingPoint.test("Float32/signalingNaN") {
 }
 
 FloatingPoint.test("Float32/signalingNaN overflow")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.requireCapability(.crashTesting)
 .code {
   // payload overflow
   expectCrashLater()
@@ -1327,7 +1327,7 @@ FloatingPoint.test("Float64/signalingNaN") {
 }
 
 FloatingPoint.test("Float64/signalingNaN overflow")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.requireCapability(.crashTesting)
 .code {
   // payload overflow
   expectCrashLater()
@@ -1363,7 +1363,7 @@ FloatingPoint.test("Float80/signalingNaN") {
 }
 
 FloatingPoint.test("Float80/signalingNaN overflow")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.requireCapability(.crashTesting)
 .code {
   // payload overflow
   expectCrashLater()

--- a/test/stdlib/FloatingPoint.swift.gyb
+++ b/test/stdlib/FloatingPoint.swift.gyb
@@ -334,32 +334,37 @@ FloatingPoint.test("Float/Int16") {
   expectEqual(Int16.max, Int16(Float(Int16.max)))
 }
 
-#if !os(WASI)
-// Trap tests aren't available on WASI.
-FloatingPoint.test("Float/UInt32") {
+FloatingPoint.test("Float/UInt32")
+.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.code {
   expectEqual(UInt32.min, UInt32(Float(UInt32.min)))
   expectCrashLater()
   expectEqual(UInt32.max, UInt32(Float(UInt32.max)))
 }
 
-FloatingPoint.test("Float/Int32") {
+FloatingPoint.test("Float/Int32")
+.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.code {
   expectEqual(Int32.min, Int32(Float(Int32.min)))
   expectCrashLater()
   expectEqual(Int32.max, Int32(Float(Int32.max)))
 }
 
-FloatingPoint.test("Float/UInt64") {
+FloatingPoint.test("Float/UInt64")
+.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.code {
   expectEqual(UInt64.min, UInt64(Float(UInt64.min)))
   expectCrashLater()
   expectEqual(UInt64.max, UInt64(Float(UInt64.max)))
 }
 
-FloatingPoint.test("Float/Int64") {
+FloatingPoint.test("Float/Int64")
+.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.code {
   expectEqual(Int64.min, Int64(Float(Int64.min)))
   expectCrashLater()
   expectEqual(Int64.max, Int64(Float(Int64.max)))
 }
-#endif
 
 FloatingPoint.test("Double/ExpressibleByIntegerLiteral") {
   expectEqual(positiveOne(),  1.0 as Double)
@@ -425,20 +430,21 @@ FloatingPoint.test("Double/Int32") {
   expectEqual(Int32.max, Int32(Double(Int32.max)))
 }
 
-#if !os(WASI)
-// Trap tests aren't available on WASI.
-FloatingPoint.test("Double/UInt64") {
+FloatingPoint.test("Double/UInt64")
+.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.code {
   expectEqual(UInt64.min, UInt64(Double(UInt64.min)))
   expectCrashLater()
   expectEqual(UInt64.max, UInt64(Double(UInt64.max)))
 }
 
-FloatingPoint.test("Double/Int64") {
+FloatingPoint.test("Double/Int64")
+.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.code {
   expectEqual(Int64.min, Int64(Double(Int64.min)))
   expectCrashLater()
   expectEqual(Int64.max, Int64(Double(Int64.max)))
 }
-#endif
 
 FloatingPoint.test("Float/HashValueZero") {
   let zero: Float = getFloat32(0.0)
@@ -1184,14 +1190,14 @@ FloatingPoint.test("Float32/quietNaN") {
     expectTrue(f.isNaN && !f.isSignalingNaN)
     expectEqual(0x7fdf_ffff, f.bitPattern)
   }
-#if !os(WASI)
-// Trap tests aren't available on WASI.
-  do {
-    // Payload overflow
-    expectCrashLater()
-    _ = Float32(nan: 0x20_0000, signaling: false)
-  }
-#endif
+}
+
+FloatingPoint.test("Float32/quietNaN overflow")
+.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.code {
+  // Payload overflow
+  expectCrashLater()
+  _ = Float32(nan: 0x20_0000, signaling: false)
 }
 
 FloatingPoint.test("Float64/quietNaN") {
@@ -1216,14 +1222,14 @@ FloatingPoint.test("Float64/quietNaN") {
     expectTrue(f.isNaN && !f.isSignalingNaN)
     expectEqual(0x7ffb_ffff_ffff_ffff, f.bitPattern)
   }
-#if !os(WASI)
-// Trap tests aren't available on WASI.
-  do {
-    // Payload overflow
-    expectCrashLater()
-    _ = Float64(nan: 0x4_0000_0000_0000, signaling: false)
-  }
-#endif
+}
+
+FloatingPoint.test("Float64/quietNaN overflow")
+.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.code {
+  // Payload overflow
+  expectCrashLater()
+  _ = Float64(nan: 0x4_0000_0000_0000, signaling: false)
 }
 
 #if !os(Windows) && (arch(i386) || arch(x86_64))
@@ -1250,14 +1256,14 @@ FloatingPoint.test("Float80/quietNaN") {
     expectTrue(f.isNaN && !f.isSignalingNaN)
     expectEqual(Float80Bits(0x7fff, 0xdfff_ffff_ffff_ffff), f.bitPattern)
   }
-#if !os(WASI)
-// Trap tests aren't available on WASI.
-  do {
-    // Payload overflow
-    expectCrashLater()
-    _ = Float80(nan: 0x2000_0000_0000_0000, signaling: false)
-  }
-#endif
+}
+
+FloatingPoint.test("Float80/quietNaN overflow")
+.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.code {
+  // Payload overflow
+  expectCrashLater()
+  _ = Float80(nan: 0x2000_0000_0000_0000, signaling: false)
 }
 
 #endif
@@ -1286,14 +1292,14 @@ FloatingPoint.test("Float32/signalingNaN") {
     expectTrue(f.isNaN && f.isSignalingNaN)
     expectEqual(0x7fbf_ffff, f.bitPattern)
   }
-#if !os(WASI)
-// Trap tests aren't available on WASI.
-  do {
-    // payload overflow
-    expectCrashLater()
-    _ = Float32(nan: 0x20_0000, signaling: true)
-  }
-#endif
+}
+
+FloatingPoint.test("Float32/signalingNaN overflow")
+.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.code {
+  // payload overflow
+  expectCrashLater()
+  _ = Float32(nan: 0x20_0000, signaling: true)
 }
 
 FloatingPoint.test("Float64/signalingNaN") {
@@ -1318,14 +1324,14 @@ FloatingPoint.test("Float64/signalingNaN") {
     expectTrue(f.isNaN && f.isSignalingNaN)
     expectEqual(0x7ff7_ffff_ffff_ffff, f.bitPattern)
   }
-#if !os(WASI)
-// Trap tests aren't available on WASI.
-  do {
-    // payload overflow
-    expectCrashLater()
-    _ = Float64(nan: 0x4_0000_0000_0000, signaling: true)
-  }
-#endif
+}
+
+FloatingPoint.test("Float64/signalingNaN overflow")
+.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.code {
+  // payload overflow
+  expectCrashLater()
+  _ = Float64(nan: 0x4_0000_0000_0000, signaling: true)
 }
 
 #endif
@@ -1354,14 +1360,14 @@ FloatingPoint.test("Float80/signalingNaN") {
     expectTrue(f.isNaN && f.isSignalingNaN)
     expectEqual(Float80Bits(0x7fff, 0xbfff_ffff_ffff_ffff), f.bitPattern)
   }
-#if !os(WASI)
-// Trap tests aren't available on WASI.
-  do {
-    // payload overflow
-    expectCrashLater()
-    _ = Float80(nan: 0x2000_0000_0000_0000, signaling: true)
-  }
-#endif
+}
+
+FloatingPoint.test("Float80/signalingNaN overflow")
+.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.code {
+  // payload overflow
+  expectCrashLater()
+  _ = Float80(nan: 0x2000_0000_0000_0000, signaling: true)
 }
 
 #endif

--- a/test/stdlib/FloatingPoint.swift.gyb
+++ b/test/stdlib/FloatingPoint.swift.gyb
@@ -335,7 +335,7 @@ FloatingPoint.test("Float/Int16") {
 }
 
 FloatingPoint.test("Float/UInt32")
-.requireCapability(.crashTesting)
+.require(.crashTesting)
 .code {
   expectEqual(UInt32.min, UInt32(Float(UInt32.min)))
   expectCrashLater()
@@ -343,7 +343,7 @@ FloatingPoint.test("Float/UInt32")
 }
 
 FloatingPoint.test("Float/Int32")
-.requireCapability(.crashTesting)
+.require(.crashTesting)
 .code {
   expectEqual(Int32.min, Int32(Float(Int32.min)))
   expectCrashLater()
@@ -351,7 +351,7 @@ FloatingPoint.test("Float/Int32")
 }
 
 FloatingPoint.test("Float/UInt64")
-.requireCapability(.crashTesting)
+.require(.crashTesting)
 .code {
   expectEqual(UInt64.min, UInt64(Float(UInt64.min)))
   expectCrashLater()
@@ -359,7 +359,7 @@ FloatingPoint.test("Float/UInt64")
 }
 
 FloatingPoint.test("Float/Int64")
-.requireCapability(.crashTesting)
+.require(.crashTesting)
 .code {
   expectEqual(Int64.min, Int64(Float(Int64.min)))
   expectCrashLater()
@@ -431,7 +431,7 @@ FloatingPoint.test("Double/Int32") {
 }
 
 FloatingPoint.test("Double/UInt64")
-.requireCapability(.crashTesting)
+.require(.crashTesting)
 .code {
   expectEqual(UInt64.min, UInt64(Double(UInt64.min)))
   expectCrashLater()
@@ -439,7 +439,7 @@ FloatingPoint.test("Double/UInt64")
 }
 
 FloatingPoint.test("Double/Int64")
-.requireCapability(.crashTesting)
+.require(.crashTesting)
 .code {
   expectEqual(Int64.min, Int64(Double(Int64.min)))
   expectCrashLater()
@@ -1193,7 +1193,7 @@ FloatingPoint.test("Float32/quietNaN") {
 }
 
 FloatingPoint.test("Float32/quietNaN overflow")
-.requireCapability(.crashTesting)
+.require(.crashTesting)
 .code {
   // Payload overflow
   expectCrashLater()
@@ -1225,7 +1225,7 @@ FloatingPoint.test("Float64/quietNaN") {
 }
 
 FloatingPoint.test("Float64/quietNaN overflow")
-.requireCapability(.crashTesting)
+.require(.crashTesting)
 .code {
   // Payload overflow
   expectCrashLater()
@@ -1259,7 +1259,7 @@ FloatingPoint.test("Float80/quietNaN") {
 }
 
 FloatingPoint.test("Float80/quietNaN overflow")
-.requireCapability(.crashTesting)
+.require(.crashTesting)
 .code {
   // Payload overflow
   expectCrashLater()
@@ -1295,7 +1295,7 @@ FloatingPoint.test("Float32/signalingNaN") {
 }
 
 FloatingPoint.test("Float32/signalingNaN overflow")
-.requireCapability(.crashTesting)
+.require(.crashTesting)
 .code {
   // payload overflow
   expectCrashLater()
@@ -1327,7 +1327,7 @@ FloatingPoint.test("Float64/signalingNaN") {
 }
 
 FloatingPoint.test("Float64/signalingNaN overflow")
-.requireCapability(.crashTesting)
+.require(.crashTesting)
 .code {
   // payload overflow
   expectCrashLater()
@@ -1363,7 +1363,7 @@ FloatingPoint.test("Float80/signalingNaN") {
 }
 
 FloatingPoint.test("Float80/signalingNaN overflow")
-.requireCapability(.crashTesting)
+.require(.crashTesting)
 .code {
   // payload overflow
   expectCrashLater()

--- a/test/stdlib/KeyPath.swift
+++ b/test/stdlib/KeyPath.swift
@@ -443,7 +443,7 @@ keyPath.test("optional force-unwrapping") {
 }
 
 keyPath.test("optional force-unwrapping trap")
-.requireCapability(.crashTesting)
+.require(.crashTesting)
 .code {
   let origin_x = \TestOptional.origin!.x
   var value = TestOptional(origin: nil)

--- a/test/stdlib/KeyPath.swift
+++ b/test/stdlib/KeyPath.swift
@@ -443,7 +443,7 @@ keyPath.test("optional force-unwrapping") {
 }
 
 keyPath.test("optional force-unwrapping trap")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.requireCapability(.crashTesting)
 .code {
   let origin_x = \TestOptional.origin!.x
   var value = TestOptional(origin: nil)

--- a/test/stdlib/KeyPath.swift
+++ b/test/stdlib/KeyPath.swift
@@ -442,16 +442,15 @@ keyPath.test("optional force-unwrapping") {
   expectTrue(value.questionableCanary === newCanary)
 }
 
-#if !os(WASI)
-// Trap tests aren't available on WASI.
-keyPath.test("optional force-unwrapping trap") {
+keyPath.test("optional force-unwrapping trap")
+.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.code {
   let origin_x = \TestOptional.origin!.x
   var value = TestOptional(origin: nil)
 
   expectCrashLater()
   _ = value[keyPath: origin_x]
 }
-#endif
 
 struct TestOptional2 {
   var optional: TestOptional?

--- a/test/stdlib/Mirror.swift
+++ b/test/stdlib/Mirror.swift
@@ -1027,7 +1027,7 @@ mirrors.test("Addressing") {
 }
 
 mirrors.test("Invalid Path Type")
-  .skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+  .requireCapability(.crashTesting)
   .skip(.custom(
     { _isFastAssertConfiguration() },
     reason: "this trap is not guaranteed to happen in -Ounchecked"))

--- a/test/stdlib/Mirror.swift
+++ b/test/stdlib/Mirror.swift
@@ -1027,7 +1027,7 @@ mirrors.test("Addressing") {
 }
 
 mirrors.test("Invalid Path Type")
-  .requireCapability(.crashTesting)
+  .require(.crashTesting)
   .skip(.custom(
     { _isFastAssertConfiguration() },
     reason: "this trap is not guaranteed to happen in -Ounchecked"))

--- a/test/stdlib/Mirror.swift
+++ b/test/stdlib/Mirror.swift
@@ -1026,9 +1026,8 @@ mirrors.test("Addressing") {
   expectNil(m.descendant(1, 1, "bork"))
 }
 
-#if !os(WASI)
-// Trap tests aren't available on WASI.
 mirrors.test("Invalid Path Type")
+  .skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
   .skip(.custom(
     { _isFastAssertConfiguration() },
     reason: "this trap is not guaranteed to happen in -Ounchecked"))
@@ -1039,7 +1038,6 @@ mirrors.test("Invalid Path Type")
   expectCrashLater()
   _ = m.descendant(X())
 }
-#endif
 
 mirrors.test("PlaygroundQuickLook") {
   // Customization works.

--- a/test/stdlib/NumericParsing.swift.gyb
+++ b/test/stdlib/NumericParsing.swift.gyb
@@ -108,7 +108,7 @@ tests.test("${Self}/success") {
 }
 
 tests.test("${Self}/radixTooLow")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.requireCapability(.crashTesting)
 .code {
   ${Self}("0", radix: 2)
   expectCrashLater()
@@ -116,7 +116,7 @@ tests.test("${Self}/radixTooLow")
 }
 
 tests.test("${Self}/radixTooHigh")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.requireCapability(.crashTesting)
 .code {
   let maxRadix = ${ord('z') - ord('a') + 1 + 10}
   ${Self}("0", radix: maxRadix)

--- a/test/stdlib/NumericParsing.swift.gyb
+++ b/test/stdlib/NumericParsing.swift.gyb
@@ -107,21 +107,22 @@ tests.test("${Self}/success") {
   % end
 }
 
-#if !os(WASI)
-// Trap tests aren't available on WASI.
-tests.test("${Self}/radixTooLow") {
+tests.test("${Self}/radixTooLow")
+.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.code {
   ${Self}("0", radix: 2)
   expectCrashLater()
   ${Self}("0", radix: 1)
 }
 
-tests.test("${Self}/radixTooHigh") {
+tests.test("${Self}/radixTooHigh")
+.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.code {
   let maxRadix = ${ord('z') - ord('a') + 1 + 10}
   ${Self}("0", radix: maxRadix)
   expectCrashLater()
   let y = ${Self}("0", radix: maxRadix + 1)
 }
-#endif
 
 % end
 

--- a/test/stdlib/NumericParsing.swift.gyb
+++ b/test/stdlib/NumericParsing.swift.gyb
@@ -108,7 +108,7 @@ tests.test("${Self}/success") {
 }
 
 tests.test("${Self}/radixTooLow")
-.requireCapability(.crashTesting)
+.require(.crashTesting)
 .code {
   ${Self}("0", radix: 2)
   expectCrashLater()
@@ -116,7 +116,7 @@ tests.test("${Self}/radixTooLow")
 }
 
 tests.test("${Self}/radixTooHigh")
-.requireCapability(.crashTesting)
+.require(.crashTesting)
 .code {
   let maxRadix = ${ord('z') - ord('a') + 1 + 10}
   ${Self}("0", radix: maxRadix)

--- a/test/stdlib/Optional.swift
+++ b/test/stdlib/Optional.swift
@@ -343,13 +343,13 @@ OptionalTests.test("Casting Optional") {
 }
 
 OptionalTests.test("Casting Optional Traps")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.requireCapability(.crashTesting)
 .code {
   let nx: C? = nil
   expectCrash { _blackHole(anyToAny(nx, Int.self)) }
 }
 OptionalTests.test("Casting Optional Any Traps")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.requireCapability(.crashTesting)
 .code {
   let nx: X? = X()
   expectCrash { _blackHole(anyToAny(nx as Any, Optional<Int>.self)) }
@@ -416,7 +416,7 @@ OptionalTests.test("unsafelyUnwrapped") {
 }
 
 OptionalTests.test("unsafelyUnwrapped nil")
-  .skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+  .requireCapability(.crashTesting)
   .xfail(.custom(
     { !_isDebugAssertConfiguration() },
     reason: "assertions are disabled in Release and Unchecked mode"))

--- a/test/stdlib/Optional.swift
+++ b/test/stdlib/Optional.swift
@@ -343,13 +343,13 @@ OptionalTests.test("Casting Optional") {
 }
 
 OptionalTests.test("Casting Optional Traps")
-.requireCapability(.crashTesting)
+.require(.crashTesting)
 .code {
   let nx: C? = nil
   expectCrash { _blackHole(anyToAny(nx, Int.self)) }
 }
 OptionalTests.test("Casting Optional Any Traps")
-.requireCapability(.crashTesting)
+.require(.crashTesting)
 .code {
   let nx: X? = X()
   expectCrash { _blackHole(anyToAny(nx as Any, Optional<Int>.self)) }
@@ -416,7 +416,7 @@ OptionalTests.test("unsafelyUnwrapped") {
 }
 
 OptionalTests.test("unsafelyUnwrapped nil")
-  .requireCapability(.crashTesting)
+  .require(.crashTesting)
   .xfail(.custom(
     { !_isDebugAssertConfiguration() },
     reason: "assertions are disabled in Release and Unchecked mode"))

--- a/test/stdlib/Optional.swift
+++ b/test/stdlib/Optional.swift
@@ -342,17 +342,18 @@ OptionalTests.test("Casting Optional") {
   expectTrue(anyToAnyIsOptional(Optional<(String, String)>.none, Bool.self))
 }
 
-#if !os(WASI)
-// Trap tests aren't available on WASI.
-OptionalTests.test("Casting Optional Traps") {
+OptionalTests.test("Casting Optional Traps")
+.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.code {
   let nx: C? = nil
   expectCrash { _blackHole(anyToAny(nx, Int.self)) }
 }
-OptionalTests.test("Casting Optional Any Traps") {
+OptionalTests.test("Casting Optional Any Traps")
+.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.code {
   let nx: X? = X()
   expectCrash { _blackHole(anyToAny(nx as Any, Optional<Int>.self)) }
 }
-#endif
 
 class TestNoString {}
 class TestString : CustomStringConvertible, CustomDebugStringConvertible {
@@ -414,9 +415,8 @@ OptionalTests.test("unsafelyUnwrapped") {
   expectEqual(3, nonEmpty.unsafelyUnwrapped)
 }
 
-#if !os(WASI)
-// Trap tests aren't available on WASI.
 OptionalTests.test("unsafelyUnwrapped nil")
+  .skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
   .xfail(.custom(
     { !_isDebugAssertConfiguration() },
     reason: "assertions are disabled in Release and Unchecked mode"))
@@ -425,7 +425,6 @@ OptionalTests.test("unsafelyUnwrapped nil")
   expectCrashLater()
   _blackHole(empty.unsafelyUnwrapped)
 }
-#endif
 
 OptionalTests.test("_span() from Optional.none")
 .require(.stdlib_6_2).code {

--- a/test/stdlib/Repeat.swift
+++ b/test/stdlib/Repeat.swift
@@ -23,13 +23,12 @@ RepeatTests.test("associated-types") {
       indicesType: CountableRange<Int>.self)
 }
 
-#if !os(WASI)
-// Trap tests aren't available on WASI.
-RepeatTests.test("out-of-bounds") {
+RepeatTests.test("out-of-bounds")
+.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.code {
   let sequence = repeatElement(0, count: 1)
   expectCrashLater()
   _ = sequence[sequence.count]
 }
-#endif
 
 runAllTests()

--- a/test/stdlib/Repeat.swift
+++ b/test/stdlib/Repeat.swift
@@ -24,7 +24,7 @@ RepeatTests.test("associated-types") {
 }
 
 RepeatTests.test("out-of-bounds")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.requireCapability(.crashTesting)
 .code {
   let sequence = repeatElement(0, count: 1)
   expectCrashLater()

--- a/test/stdlib/Repeat.swift
+++ b/test/stdlib/Repeat.swift
@@ -24,7 +24,7 @@ RepeatTests.test("associated-types") {
 }
 
 RepeatTests.test("out-of-bounds")
-.requireCapability(.crashTesting)
+.require(.crashTesting)
 .code {
   let sequence = repeatElement(0, count: 1)
   expectCrashLater()

--- a/test/stdlib/Span/MutableRawSpanTests.swift
+++ b/test/stdlib/Span/MutableRawSpanTests.swift
@@ -336,7 +336,7 @@ suite.test("storeBytes(repeating:count:as:) count zero")
 }
 
 suite.test("storeBytes(repeating:count:as:) negative count")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.requireCapability(.crashTesting)
 .require(.stdlib_6_4).code {
 
   var array = ContiguousArray(repeating: UInt8.zero, count: 16)
@@ -677,7 +677,7 @@ suite.test("MutableRawSpan subscript")
 }
 
 suite.test("MutableRawSpan subscript bounds underflow")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.requireCapability(.crashTesting)
 .require(.stdlib_6_4).code {
 
   var array = ContiguousArray<UInt8>([10, 20, 30, 40])
@@ -688,7 +688,7 @@ suite.test("MutableRawSpan subscript bounds underflow")
 }
 
 suite.test("MutableRawSpan subscript bounds overflow")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.requireCapability(.crashTesting)
 .require(.stdlib_6_4).code {
 
   var array = ContiguousArray<UInt8>([10, 20, 30, 40])

--- a/test/stdlib/Span/MutableRawSpanTests.swift
+++ b/test/stdlib/Span/MutableRawSpanTests.swift
@@ -336,7 +336,7 @@ suite.test("storeBytes(repeating:count:as:) count zero")
 }
 
 suite.test("storeBytes(repeating:count:as:) negative count")
-.requireCapability(.crashTesting)
+.require(.crashTesting)
 .require(.stdlib_6_4).code {
 
   var array = ContiguousArray(repeating: UInt8.zero, count: 16)
@@ -677,7 +677,7 @@ suite.test("MutableRawSpan subscript")
 }
 
 suite.test("MutableRawSpan subscript bounds underflow")
-.requireCapability(.crashTesting)
+.require(.crashTesting)
 .require(.stdlib_6_4).code {
 
   var array = ContiguousArray<UInt8>([10, 20, 30, 40])
@@ -688,7 +688,7 @@ suite.test("MutableRawSpan subscript bounds underflow")
 }
 
 suite.test("MutableRawSpan subscript bounds overflow")
-.requireCapability(.crashTesting)
+.require(.crashTesting)
 .require(.stdlib_6_4).code {
 
   var array = ContiguousArray<UInt8>([10, 20, 30, 40])

--- a/test/stdlib/Span/MutableSpanTests.swift
+++ b/test/stdlib/Span/MutableSpanTests.swift
@@ -663,7 +663,7 @@ suite.test("init(mutating:)")
 }
 
 suite.test("init(mutating:) traps on misaligned pointer")
-.requireCapability(.crashTesting)
+.require(.crashTesting)
 .require(.stdlib_6_4).code {
   let buffer = UnsafeMutableRawBufferPointer.allocate(
     byteCount: MemoryLayout<Int>.stride * 2 + 1,
@@ -684,7 +684,7 @@ suite.test("init(mutating:) traps on misaligned pointer")
 }
 
 suite.test("init(mutating:) traps on byteCount not multiple of stride")
-.requireCapability(.crashTesting)
+.require(.crashTesting)
 .require(.stdlib_6_4).code {
   let buffer = UnsafeMutableRawBufferPointer.allocate(
     byteCount: MemoryLayout<Int>.stride + 1,
@@ -719,7 +719,7 @@ suite.test("init(mutableBytes:)")
 }
 
 suite.test("init(mutableBytes:) traps on misaligned pointer")
-.requireCapability(.crashTesting)
+.require(.crashTesting)
 .require(.stdlib_6_4).code {
   let buffer = UnsafeMutableRawBufferPointer.allocate(
     byteCount: MemoryLayout<Int>.stride * 2 + 1,
@@ -740,7 +740,7 @@ suite.test("init(mutableBytes:) traps on misaligned pointer")
 }
 
 suite.test("init(mutableBytes:) traps on byteCount not multiple of stride")
-.requireCapability(.crashTesting)
+.require(.crashTesting)
 .require(.stdlib_6_4).code {
   let buffer = UnsafeMutableRawBufferPointer.allocate(
     byteCount: MemoryLayout<Int>.stride + 1,

--- a/test/stdlib/Span/MutableSpanTests.swift
+++ b/test/stdlib/Span/MutableSpanTests.swift
@@ -663,7 +663,7 @@ suite.test("init(mutating:)")
 }
 
 suite.test("init(mutating:) traps on misaligned pointer")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.requireCapability(.crashTesting)
 .require(.stdlib_6_4).code {
   let buffer = UnsafeMutableRawBufferPointer.allocate(
     byteCount: MemoryLayout<Int>.stride * 2 + 1,
@@ -684,7 +684,7 @@ suite.test("init(mutating:) traps on misaligned pointer")
 }
 
 suite.test("init(mutating:) traps on byteCount not multiple of stride")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.requireCapability(.crashTesting)
 .require(.stdlib_6_4).code {
   let buffer = UnsafeMutableRawBufferPointer.allocate(
     byteCount: MemoryLayout<Int>.stride + 1,
@@ -719,7 +719,7 @@ suite.test("init(mutableBytes:)")
 }
 
 suite.test("init(mutableBytes:) traps on misaligned pointer")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.requireCapability(.crashTesting)
 .require(.stdlib_6_4).code {
   let buffer = UnsafeMutableRawBufferPointer.allocate(
     byteCount: MemoryLayout<Int>.stride * 2 + 1,
@@ -740,7 +740,7 @@ suite.test("init(mutableBytes:) traps on misaligned pointer")
 }
 
 suite.test("init(mutableBytes:) traps on byteCount not multiple of stride")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.requireCapability(.crashTesting)
 .require(.stdlib_6_4).code {
   let buffer = UnsafeMutableRawBufferPointer.allocate(
     byteCount: MemoryLayout<Int>.stride + 1,

--- a/test/stdlib/Span/OutputRawSpanTests.swift
+++ b/test/stdlib/Span/OutputRawSpanTests.swift
@@ -292,7 +292,7 @@ suite.test("append one safe")
 }
 
 suite.test("append one overflow")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.requireCapability(.crashTesting)
 .require(.stdlib_6_4).code {
 
   var a = Allocation(byteCount: 1)
@@ -356,7 +356,7 @@ suite.test("append repeating safe")
 }
 
 suite.test("append repeating negative count")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.requireCapability(.crashTesting)
 .require(.stdlib_6_4).code {
 
   var a = Allocation(byteCount: 16)
@@ -443,7 +443,7 @@ suite.test("append(upTo:as:initializingWith:) partial fill")
 }
 
 suite.test("append(upTo:as:initializingWith:) overflow")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.requireCapability(.crashTesting)
 .require(.stdlib_6_4).code {
 
   var a = Allocation(byteCount: 16)
@@ -456,7 +456,7 @@ suite.test("append(upTo:as:initializingWith:) overflow")
 }
 
 suite.test("append(upTo:as:initializingWith:) negative count")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.requireCapability(.crashTesting)
 .require(.stdlib_6_4).code {
 
   var a = Allocation(byteCount: 16)
@@ -467,7 +467,7 @@ suite.test("append(upTo:as:initializingWith:) negative count")
 }
 
 suite.test("append(upTo:as:initializingWith:) misaligned")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.requireCapability(.crashTesting)
 .require(.stdlib_6_4).code {
 
   var a = Allocation(byteCount: 16)
@@ -511,7 +511,7 @@ suite.test("subscript setter")
 }
 
 suite.test("subscript bounds underflow")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.requireCapability(.crashTesting)
 .require(.stdlib_6_4).code {
 
   var a = Allocation(byteCount: 16)
@@ -523,7 +523,7 @@ suite.test("subscript bounds underflow")
 }
 
 suite.test("subscript bounds overflow")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.requireCapability(.crashTesting)
 .require(.stdlib_6_4).code {
 
   var a = Allocation(byteCount: 16)

--- a/test/stdlib/Span/OutputRawSpanTests.swift
+++ b/test/stdlib/Span/OutputRawSpanTests.swift
@@ -292,7 +292,7 @@ suite.test("append one safe")
 }
 
 suite.test("append one overflow")
-.requireCapability(.crashTesting)
+.require(.crashTesting)
 .require(.stdlib_6_4).code {
 
   var a = Allocation(byteCount: 1)
@@ -356,7 +356,7 @@ suite.test("append repeating safe")
 }
 
 suite.test("append repeating negative count")
-.requireCapability(.crashTesting)
+.require(.crashTesting)
 .require(.stdlib_6_4).code {
 
   var a = Allocation(byteCount: 16)
@@ -443,7 +443,7 @@ suite.test("append(upTo:as:initializingWith:) partial fill")
 }
 
 suite.test("append(upTo:as:initializingWith:) overflow")
-.requireCapability(.crashTesting)
+.require(.crashTesting)
 .require(.stdlib_6_4).code {
 
   var a = Allocation(byteCount: 16)
@@ -456,7 +456,7 @@ suite.test("append(upTo:as:initializingWith:) overflow")
 }
 
 suite.test("append(upTo:as:initializingWith:) negative count")
-.requireCapability(.crashTesting)
+.require(.crashTesting)
 .require(.stdlib_6_4).code {
 
   var a = Allocation(byteCount: 16)
@@ -467,7 +467,7 @@ suite.test("append(upTo:as:initializingWith:) negative count")
 }
 
 suite.test("append(upTo:as:initializingWith:) misaligned")
-.requireCapability(.crashTesting)
+.require(.crashTesting)
 .require(.stdlib_6_4).code {
 
   var a = Allocation(byteCount: 16)
@@ -511,7 +511,7 @@ suite.test("subscript setter")
 }
 
 suite.test("subscript bounds underflow")
-.requireCapability(.crashTesting)
+.require(.crashTesting)
 .require(.stdlib_6_4).code {
 
   var a = Allocation(byteCount: 16)
@@ -523,7 +523,7 @@ suite.test("subscript bounds underflow")
 }
 
 suite.test("subscript bounds overflow")
-.requireCapability(.crashTesting)
+.require(.crashTesting)
 .require(.stdlib_6_4).code {
 
   var a = Allocation(byteCount: 16)

--- a/test/stdlib/Span/OutputSpanTests.swift
+++ b/test/stdlib/Span/OutputSpanTests.swift
@@ -223,7 +223,7 @@ suite.test("InlineArray initialization")
 }
 
 suite.test("InlineArray initialization underflow")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.requireCapability(.crashTesting)
 .require(.stdlib_6_2).code {
   guard #available(SwiftStdlib 6.2, *) else { return }
 
@@ -354,7 +354,7 @@ suite.test("Array initialization throws")
 }
 
 suite.test("Array initialization overflow")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.requireCapability(.crashTesting)
 .require(.stdlib_6_2).code {
 
   expectCrashLater()
@@ -367,7 +367,7 @@ suite.test("Array initialization overflow")
 }
 
 suite.test("Array initialization underflow")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.requireCapability(.crashTesting)
 .require(.stdlib_6_2).code {
 
   expectCrashLater()
@@ -433,7 +433,7 @@ suite.test("Array append throws")
 }
 
 suite.test("Array append overflow")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.requireCapability(.crashTesting)
 .require(.stdlib_6_2).code {
 
   expectCrashLater()
@@ -447,7 +447,7 @@ suite.test("Array append overflow")
 }
 
 suite.test("Array append underflow")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.requireCapability(.crashTesting)
 .require(.stdlib_6_2).code {
 
   expectCrashLater()
@@ -507,7 +507,7 @@ suite.test("ContiguousArray initialization")
 }
 
 suite.test("ContiguousArray initialization overflow")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.requireCapability(.crashTesting)
 .require(.stdlib_6_2).code {
 
   expectCrashLater()
@@ -520,7 +520,7 @@ suite.test("ContiguousArray initialization overflow")
 }
 
 suite.test("ContiguousArray initialization underflow")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.requireCapability(.crashTesting)
 .require(.stdlib_6_2).code {
 
   expectCrashLater()
@@ -586,7 +586,7 @@ suite.test("ContiguousArray append throws")
 }
 
 suite.test("ContiguousArray append overflow")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.requireCapability(.crashTesting)
 .require(.stdlib_6_2).code {
 
   expectCrashLater()
@@ -600,7 +600,7 @@ suite.test("ContiguousArray append overflow")
 }
 
 suite.test("ContiguousArray.append underflow")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.requireCapability(.crashTesting)
 .require(.stdlib_6_2).code {
 
   expectCrashLater()
@@ -679,7 +679,7 @@ suite.test("append(upTo:initializingWith:) appends to existing")
 }
 
 suite.test("append(upTo:initializingWith:) negative count")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.requireCapability(.crashTesting)
 .require(.stdlib_6_4).code {
   var a = ContiguousArray<Int>()
   a.append(addingCapacity: 4) { span in
@@ -690,7 +690,7 @@ suite.test("append(upTo:initializingWith:) negative count")
 }
 
 suite.test("append(upTo:initializingWith:) traps on capacity overflow")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.requireCapability(.crashTesting)
 .require(.stdlib_6_4).code {
   var a = ContiguousArray<Int>()
   a.append(addingCapacity: 2) { span in

--- a/test/stdlib/Span/OutputSpanTests.swift
+++ b/test/stdlib/Span/OutputSpanTests.swift
@@ -223,7 +223,7 @@ suite.test("InlineArray initialization")
 }
 
 suite.test("InlineArray initialization underflow")
-.requireCapability(.crashTesting)
+.require(.crashTesting)
 .require(.stdlib_6_2).code {
   guard #available(SwiftStdlib 6.2, *) else { return }
 
@@ -354,7 +354,7 @@ suite.test("Array initialization throws")
 }
 
 suite.test("Array initialization overflow")
-.requireCapability(.crashTesting)
+.require(.crashTesting)
 .require(.stdlib_6_2).code {
 
   expectCrashLater()
@@ -367,7 +367,7 @@ suite.test("Array initialization overflow")
 }
 
 suite.test("Array initialization underflow")
-.requireCapability(.crashTesting)
+.require(.crashTesting)
 .require(.stdlib_6_2).code {
 
   expectCrashLater()
@@ -433,7 +433,7 @@ suite.test("Array append throws")
 }
 
 suite.test("Array append overflow")
-.requireCapability(.crashTesting)
+.require(.crashTesting)
 .require(.stdlib_6_2).code {
 
   expectCrashLater()
@@ -447,7 +447,7 @@ suite.test("Array append overflow")
 }
 
 suite.test("Array append underflow")
-.requireCapability(.crashTesting)
+.require(.crashTesting)
 .require(.stdlib_6_2).code {
 
   expectCrashLater()
@@ -507,7 +507,7 @@ suite.test("ContiguousArray initialization")
 }
 
 suite.test("ContiguousArray initialization overflow")
-.requireCapability(.crashTesting)
+.require(.crashTesting)
 .require(.stdlib_6_2).code {
 
   expectCrashLater()
@@ -520,7 +520,7 @@ suite.test("ContiguousArray initialization overflow")
 }
 
 suite.test("ContiguousArray initialization underflow")
-.requireCapability(.crashTesting)
+.require(.crashTesting)
 .require(.stdlib_6_2).code {
 
   expectCrashLater()
@@ -586,7 +586,7 @@ suite.test("ContiguousArray append throws")
 }
 
 suite.test("ContiguousArray append overflow")
-.requireCapability(.crashTesting)
+.require(.crashTesting)
 .require(.stdlib_6_2).code {
 
   expectCrashLater()
@@ -600,7 +600,7 @@ suite.test("ContiguousArray append overflow")
 }
 
 suite.test("ContiguousArray.append underflow")
-.requireCapability(.crashTesting)
+.require(.crashTesting)
 .require(.stdlib_6_2).code {
 
   expectCrashLater()
@@ -679,7 +679,7 @@ suite.test("append(upTo:initializingWith:) appends to existing")
 }
 
 suite.test("append(upTo:initializingWith:) negative count")
-.requireCapability(.crashTesting)
+.require(.crashTesting)
 .require(.stdlib_6_4).code {
   var a = ContiguousArray<Int>()
   a.append(addingCapacity: 4) { span in
@@ -690,7 +690,7 @@ suite.test("append(upTo:initializingWith:) negative count")
 }
 
 suite.test("append(upTo:initializingWith:) traps on capacity overflow")
-.requireCapability(.crashTesting)
+.require(.crashTesting)
 .require(.stdlib_6_4).code {
   var a = ContiguousArray<Int>()
   a.append(addingCapacity: 2) { span in

--- a/test/stdlib/Span/RawSpanTests.swift
+++ b/test/stdlib/Span/RawSpanTests.swift
@@ -361,7 +361,7 @@ suite.test("RawSpan safe loading")
 }
 
 suite.test("RawSpan safe loading bounds underflow")
-.requireCapability(.crashTesting)
+.require(.crashTesting)
 .require(.stdlib_6_4).code {
 
   let array = ContiguousArray(repeating: UInt8.zero, count: 64)
@@ -372,7 +372,7 @@ suite.test("RawSpan safe loading bounds underflow")
 }
 
 suite.test("RawSpan safe loading bounds overflow")
-.requireCapability(.crashTesting)
+.require(.crashTesting)
 .require(.stdlib_6_4).code {
 
   let array = ContiguousArray(repeating: UInt8.zero, count: 64)
@@ -412,7 +412,7 @@ suite.test("RawSpan subscript")
 }
 
 suite.test("RawSpan subscript bounds underflow")
-.requireCapability(.crashTesting)
+.require(.crashTesting)
 .require(.stdlib_6_4).code {
   let array: ContiguousArray<UInt8> = [10, 20, 30, 40]
   let bytes = array.span.bytes
@@ -422,7 +422,7 @@ suite.test("RawSpan subscript bounds underflow")
 }
 
 suite.test("RawSpan subscript bounds overflow")
-.requireCapability(.crashTesting)
+.require(.crashTesting)
 .require(.stdlib_6_4).code {
   let array: ContiguousArray<UInt8> = [10, 20, 30, 40]
   let bytes = array.span.bytes

--- a/test/stdlib/Span/RawSpanTests.swift
+++ b/test/stdlib/Span/RawSpanTests.swift
@@ -361,7 +361,7 @@ suite.test("RawSpan safe loading")
 }
 
 suite.test("RawSpan safe loading bounds underflow")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.requireCapability(.crashTesting)
 .require(.stdlib_6_4).code {
 
   let array = ContiguousArray(repeating: UInt8.zero, count: 64)
@@ -372,7 +372,7 @@ suite.test("RawSpan safe loading bounds underflow")
 }
 
 suite.test("RawSpan safe loading bounds overflow")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.requireCapability(.crashTesting)
 .require(.stdlib_6_4).code {
 
   let array = ContiguousArray(repeating: UInt8.zero, count: 64)
@@ -412,7 +412,7 @@ suite.test("RawSpan subscript")
 }
 
 suite.test("RawSpan subscript bounds underflow")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.requireCapability(.crashTesting)
 .require(.stdlib_6_4).code {
   let array: ContiguousArray<UInt8> = [10, 20, 30, 40]
   let bytes = array.span.bytes
@@ -422,7 +422,7 @@ suite.test("RawSpan subscript bounds underflow")
 }
 
 suite.test("RawSpan subscript bounds overflow")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.requireCapability(.crashTesting)
 .require(.stdlib_6_4).code {
   let array: ContiguousArray<UInt8> = [10, 20, 30, 40]
   let bytes = array.span.bytes

--- a/test/stdlib/Span/SpanTests.swift
+++ b/test/stdlib/Span/SpanTests.swift
@@ -667,7 +667,7 @@ suite.test("init(viewing:)")
 }
 
 suite.test("init(viewing:) traps on misaligned pointer")
-.requireCapability(.crashTesting)
+.require(.crashTesting)
 .require(.stdlib_6_4).code {
   let buffer = UnsafeMutableRawBufferPointer.allocate(
     byteCount: MemoryLayout<Int>.stride * 2 + 1,
@@ -687,7 +687,7 @@ suite.test("init(viewing:) traps on misaligned pointer")
 }
 
 suite.test("init(viewing:) traps on non-stride byteCount")
-.requireCapability(.crashTesting)
+.require(.crashTesting)
 .require(.stdlib_6_4).code {
   let buffer = UnsafeMutableRawBufferPointer.allocate(
     byteCount: MemoryLayout<Int>.stride + 1,

--- a/test/stdlib/Span/SpanTests.swift
+++ b/test/stdlib/Span/SpanTests.swift
@@ -667,7 +667,7 @@ suite.test("init(viewing:)")
 }
 
 suite.test("init(viewing:) traps on misaligned pointer")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.requireCapability(.crashTesting)
 .require(.stdlib_6_4).code {
   let buffer = UnsafeMutableRawBufferPointer.allocate(
     byteCount: MemoryLayout<Int>.stride * 2 + 1,
@@ -687,7 +687,7 @@ suite.test("init(viewing:) traps on misaligned pointer")
 }
 
 suite.test("init(viewing:) traps on non-stride byteCount")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.requireCapability(.crashTesting)
 .require(.stdlib_6_4).code {
   let buffer = UnsafeMutableRawBufferPointer.allocate(
     byteCount: MemoryLayout<Int>.stride + 1,

--- a/test/stdlib/StaticString.swift
+++ b/test/stdlib/StaticString.swift
@@ -74,7 +74,7 @@ StaticStringTestSuite.test("PointerRepresentation/NonASCII") {
 }
 
 StaticStringTestSuite.test("PointerRepresentation/unicodeScalar")
-  .skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+  .requireCapability(.crashTesting)
   .skip(.custom(
     { _isFastAssertConfiguration() },
     reason: "this trap is not guaranteed to happen in -Ounchecked"))
@@ -125,7 +125,7 @@ StaticStringTestSuite.test("UnicodeScalarRepresentation/NonASCII") {
 }
 
 StaticStringTestSuite.test("UnicodeScalarRepresentation/utf8Start")
-  .skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+  .requireCapability(.crashTesting)
   .skip(.custom(
     { _isFastAssertConfiguration() },
     reason: "this trap is not guaranteed to happen in -Ounchecked"))
@@ -139,7 +139,7 @@ StaticStringTestSuite.test("UnicodeScalarRepresentation/utf8Start")
 }
 
 StaticStringTestSuite.test("UnicodeScalarRepresentation/utf8CodeUnitCount")
-  .skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+  .requireCapability(.crashTesting)
   .skip(.custom(
     { _isFastAssertConfiguration() },
     reason: "this trap is not guaranteed to happen in -Ounchecked"))

--- a/test/stdlib/StaticString.swift
+++ b/test/stdlib/StaticString.swift
@@ -74,7 +74,7 @@ StaticStringTestSuite.test("PointerRepresentation/NonASCII") {
 }
 
 StaticStringTestSuite.test("PointerRepresentation/unicodeScalar")
-  .requireCapability(.crashTesting)
+  .require(.crashTesting)
   .skip(.custom(
     { _isFastAssertConfiguration() },
     reason: "this trap is not guaranteed to happen in -Ounchecked"))
@@ -125,7 +125,7 @@ StaticStringTestSuite.test("UnicodeScalarRepresentation/NonASCII") {
 }
 
 StaticStringTestSuite.test("UnicodeScalarRepresentation/utf8Start")
-  .requireCapability(.crashTesting)
+  .require(.crashTesting)
   .skip(.custom(
     { _isFastAssertConfiguration() },
     reason: "this trap is not guaranteed to happen in -Ounchecked"))
@@ -139,7 +139,7 @@ StaticStringTestSuite.test("UnicodeScalarRepresentation/utf8Start")
 }
 
 StaticStringTestSuite.test("UnicodeScalarRepresentation/utf8CodeUnitCount")
-  .requireCapability(.crashTesting)
+  .require(.crashTesting)
   .skip(.custom(
     { _isFastAssertConfiguration() },
     reason: "this trap is not guaranteed to happen in -Ounchecked"))

--- a/test/stdlib/StaticString.swift
+++ b/test/stdlib/StaticString.swift
@@ -73,9 +73,8 @@ StaticStringTestSuite.test("PointerRepresentation/NonASCII") {
   expectDebugPrinted("\"абв\"", str)
 }
 
-#if !os(WASI)
-// Trap tests aren't available on WASI.
 StaticStringTestSuite.test("PointerRepresentation/unicodeScalar")
+  .skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
   .skip(.custom(
     { _isFastAssertConfiguration() },
     reason: "this trap is not guaranteed to happen in -Ounchecked"))
@@ -87,7 +86,6 @@ StaticStringTestSuite.test("PointerRepresentation/unicodeScalar")
   expectCrashLater()
   strOpaque.unicodeScalar
 }
-#endif
 
 StaticStringTestSuite.test("UnicodeScalarRepresentation/ASCII") {
   // The type checker does not call the UnicodeScalar initializer even if
@@ -126,9 +124,8 @@ StaticStringTestSuite.test("UnicodeScalarRepresentation/NonASCII") {
   expectDebugPrinted("\"Ы\"", str)
 }
 
-#if !os(WASI)
-// Trap tests aren't available on WASI.
 StaticStringTestSuite.test("UnicodeScalarRepresentation/utf8Start")
+  .skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
   .skip(.custom(
     { _isFastAssertConfiguration() },
     reason: "this trap is not guaranteed to happen in -Ounchecked"))
@@ -142,6 +139,7 @@ StaticStringTestSuite.test("UnicodeScalarRepresentation/utf8Start")
 }
 
 StaticStringTestSuite.test("UnicodeScalarRepresentation/utf8CodeUnitCount")
+  .skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
   .skip(.custom(
     { _isFastAssertConfiguration() },
     reason: "this trap is not guaranteed to happen in -Ounchecked"))
@@ -153,7 +151,6 @@ StaticStringTestSuite.test("UnicodeScalarRepresentation/utf8CodeUnitCount")
   expectCrashLater()
   strOpaque.utf8CodeUnitCount
 }
-#endif
 
 runAllTests()
 

--- a/test/stdlib/StringAPI.swift
+++ b/test/stdlib/StringAPI.swift
@@ -332,8 +332,8 @@ StringTests.test("SameTypeComparisons") {
   expectFalse(xs != xs)
 }
 
-#if !os(WASI)
 StringTests.test("CompareStringsWithUnpairedSurrogates")
+  .skip(.wasiAny(reason: "Not supported on WASI."))
   .xfail(
     .always("<rdar://problem/18029104> Strings referring to underlying " +
       "storage with unpaired surrogates compare unequal"))
@@ -348,7 +348,6 @@ StringTests.test("CompareStringsWithUnpairedSurrogates")
     ]
   )
 }
-#endif
 
 StringTests.test("[String].joined() -> String") {
   let s = ["hello", "world"].joined()

--- a/test/stdlib/StringAPICString.swift
+++ b/test/stdlib/StringAPICString.swift
@@ -242,7 +242,7 @@ CStringTests.test("String.cString.with.Array.UInt8.input") {
 }
 
 CStringTests.test("String.cString.with.Array.UInt8.input/trap")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.requireCapability(.crashTesting)
 .code {
   guard #available(SwiftStdlib 5.7, *) else { return }
   expectCrashLater(
@@ -271,7 +271,7 @@ CStringTests.test("String.cString.with.Array.CChar.input") {
 }
 
 CStringTests.test("String.cString.with.Array.CChar.input/trap")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.requireCapability(.crashTesting)
 .code {
   guard #available(SwiftStdlib 5.7, *) else { return }
   expectCrashLater(
@@ -304,7 +304,7 @@ CStringTests.test("String.cString.with.inout.UInt8.conversion") {
 }
 
 CStringTests.test("String.cString.with.inout.UInt8.conversion/trap")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.requireCapability(.crashTesting)
 .code {
   guard #available(SwiftStdlib 5.7, *) else { return }
   var c: UInt8 = 100
@@ -324,7 +324,7 @@ CStringTests.test("String.cString.with.inout.CChar.conversion") {
 }
 
 CStringTests.test("String.cString.with.inout.CChar.conversion/trap")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.requireCapability(.crashTesting)
 .code {
   guard #available(SwiftStdlib 5.7, *) else { return }
   var c: CChar = 100
@@ -355,7 +355,7 @@ CStringTests.test("String.validatingCString.with.Array.input") {
 }
 
 CStringTests.test("String.validatingCString.with.Array.input/trap")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.requireCapability(.crashTesting)
 .code {
   guard #available(SwiftStdlib 5.7, *) else { return }
   expectCrashLater(
@@ -391,7 +391,7 @@ CStringTests.test("String.validatingCString.with.inout.conversion") {
 }
 
 CStringTests.test("String.validatingCString.with.inout.conversion/trap")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.requireCapability(.crashTesting)
 .code {
   guard #available(SwiftStdlib 5.7, *) else { return }
   var c: CChar = 100
@@ -423,7 +423,7 @@ CStringTests.test("String.decodeCString.with.Array.input") {
 }
 
 CStringTests.test("String.decodeCString.with.Array.input/trap")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.requireCapability(.crashTesting)
 .code {
   guard #available(SwiftStdlib 5.7, *) else { return }
   expectCrashLater(
@@ -466,7 +466,7 @@ CStringTests.test("String.decodeCString.with.inout.conversion") {
 }
 
 CStringTests.test("String.decodeCString.with.inout.conversion/trap")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.requireCapability(.crashTesting)
 .code {
   guard #available(SwiftStdlib 5.7, *) else { return }
   var c: Unicode.UTF8.CodeUnit = 100
@@ -496,7 +496,7 @@ CStringTests.test("String.init.decodingCString.with.Array.input") {
 }
 
 CStringTests.test("String.init.decodingCString.with.Array.input/trap")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.requireCapability(.crashTesting)
 .code {
   guard #available(SwiftStdlib 5.7, *) else { return }
   expectCrashLater(
@@ -529,7 +529,7 @@ CStringTests.test("String.init.decodingCString.with.inout.conversion") {
 }
 
 CStringTests.test("String.init.decodingCString.with.inout.conversion/trap")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.requireCapability(.crashTesting)
 .code {
   guard #available(SwiftStdlib 5.7, *) else { return }
   var c: Unicode.UTF8.CodeUnit = 100

--- a/test/stdlib/StringAPICString.swift
+++ b/test/stdlib/StringAPICString.swift
@@ -7,12 +7,6 @@
 
 import StdlibUnittest
 
-#if os(WASI)
-let enableCrashTests = false
-#else
-let enableCrashTests = true
-#endif
-
 var CStringTests = TestSuite("CStringTests")
 
 func getNullUTF8() -> UnsafeMutablePointer<UInt8>? {
@@ -245,8 +239,12 @@ CStringTests.test("String.cString.with.Array.UInt8.input") {
       }
     }
   }
-  guard enableCrashTests else { return }
-  // no need to test every case; that is covered in other tests
+}
+
+CStringTests.test("String.cString.with.Array.UInt8.input/trap")
+.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.code {
+  guard #available(SwiftStdlib 5.7, *) else { return }
   expectCrashLater(
     // Workaround for https://github.com/apple/swift/issues/58362 (rdar://91365967)
     // withMessage: "input of String.init(cString:) must be null-terminated"
@@ -270,8 +268,12 @@ CStringTests.test("String.cString.with.Array.CChar.input") {
       }
     }
   }
-  guard enableCrashTests else { return }
-  // no need to test every case; that is covered in other tests
+}
+
+CStringTests.test("String.cString.with.Array.CChar.input/trap")
+.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.code {
+  guard #available(SwiftStdlib 5.7, *) else { return }
   expectCrashLater(
     // Workaround for https://github.com/apple/swift/issues/58362 (rdar://91365967)
     // withMessage: "input of String.init(cString:) must be null-terminated"
@@ -299,13 +301,18 @@ CStringTests.test("String.cString.with.inout.UInt8.conversion") {
   var c = UInt8.zero
   var str = String(cString: &c)
   expectTrue(str.isEmpty)
-  c = 100
-  guard enableCrashTests else { return }
+}
+
+CStringTests.test("String.cString.with.inout.UInt8.conversion/trap")
+.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.code {
+  guard #available(SwiftStdlib 5.7, *) else { return }
+  var c: UInt8 = 100
   expectCrashLater(
     // Workaround for https://github.com/apple/swift/issues/58362 (rdar://91365967)
     // withMessage: "input of String.init(cString:) must be null-terminated"
   )
-  str = String(cString: &c)
+  let str = String(cString: &c)
   expectUnreachable()
 }
 
@@ -314,13 +321,18 @@ CStringTests.test("String.cString.with.inout.CChar.conversion") {
   var c = CChar.zero
   var str = String(cString: &c)
   expectTrue(str.isEmpty)
-  c = 100
-  guard enableCrashTests else { return }
+}
+
+CStringTests.test("String.cString.with.inout.CChar.conversion/trap")
+.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.code {
+  guard #available(SwiftStdlib 5.7, *) else { return }
+  var c: CChar = 100
   expectCrashLater(
     // Workaround for https://github.com/apple/swift/issues/58362 (rdar://91365967)
     // withMessage: "input of String.init(cString:) must be null-terminated"
   )
-  str = String(cString: &c)
+  let str = String(cString: &c)
   expectUnreachable()
 }
 
@@ -340,8 +352,12 @@ CStringTests.test("String.validatingCString.with.Array.input") {
       }
     }
   }
-  guard enableCrashTests else { return }
-  // no need to test every case; that is covered in other tests
+}
+
+CStringTests.test("String.validatingCString.with.Array.input/trap")
+.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.code {
+  guard #available(SwiftStdlib 5.7, *) else { return }
   expectCrashLater(
     // Workaround for https://github.com/apple/swift/issues/58362 (rdar://91365967)
     // withMessage: "input of String.init(validatingCString:) must be null-terminated"
@@ -372,13 +388,18 @@ CStringTests.test("String.validatingCString.with.inout.conversion") {
   var str = String(validatingCString: &c)
   expectNotNil(str)
   expectEqual(str?.isEmpty, true)
-  c = 100
-  guard enableCrashTests else { return }
+}
+
+CStringTests.test("String.validatingCString.with.inout.conversion/trap")
+.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.code {
+  guard #available(SwiftStdlib 5.7, *) else { return }
+  var c: CChar = 100
   expectCrashLater(
     // Workaround for https://github.com/apple/swift/issues/58362 (rdar://91365967)
     // withMessage: "input of String.init(validatingCString:) must be null-terminated"
   )
-  str = String(validatingCString: &c)
+  let str = String(validatingCString: &c)
   expectUnreachable()
 }
 
@@ -399,8 +420,12 @@ CStringTests.test("String.decodeCString.with.Array.input") {
       }
     }
   }
-  guard enableCrashTests else { return }
-  // no need to test every case; that is covered in other tests
+}
+
+CStringTests.test("String.decodeCString.with.Array.input/trap")
+.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.code {
+  guard #available(SwiftStdlib 5.7, *) else { return }
   expectCrashLater(
     // Workaround for https://github.com/apple/swift/issues/58362 (rdar://91365967)
     // withMessage: "input of decodeCString(_:as:repairingInvalidCodeUnits:) must be null-terminated"
@@ -438,13 +463,18 @@ CStringTests.test("String.decodeCString.with.inout.conversion") {
   expectNotNil(result)
   expectEqual(result?.result.isEmpty, true)
   expectEqual(result?.repairsMade, false)
-  c = 100
-  guard enableCrashTests else { return }
+}
+
+CStringTests.test("String.decodeCString.with.inout.conversion/trap")
+.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.code {
+  guard #available(SwiftStdlib 5.7, *) else { return }
+  var c: Unicode.UTF8.CodeUnit = 100
   expectCrashLater(
     // Workaround for https://github.com/apple/swift/issues/58362 (rdar://91365967)
     // withMessage: "input of decodeCString(_:as:repairingInvalidCodeUnits:) must be null-terminated"
   )
-  result = String.decodeCString(&c, as: Unicode.UTF8.self)
+  let result = String.decodeCString(&c, as: Unicode.UTF8.self)
   expectUnreachable()
 }
 
@@ -463,8 +493,12 @@ CStringTests.test("String.init.decodingCString.with.Array.input") {
       }
     }
   }
-  guard enableCrashTests else { return }
-  // no need to test every case; that is covered in other tests
+}
+
+CStringTests.test("String.init.decodingCString.with.Array.input/trap")
+.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.code {
+  guard #available(SwiftStdlib 5.7, *) else { return }
   expectCrashLater(
     // Workaround for https://github.com/apple/swift/issues/58362 (rdar://91365967)
     // withMessage: "input of decodeCString(_:as:repairingInvalidCodeUnits:) must be null-terminated"
@@ -492,13 +526,18 @@ CStringTests.test("String.init.decodingCString.with.inout.conversion") {
   var c = Unicode.UTF8.CodeUnit.zero
   var str = String(decodingCString: &c, as: Unicode.UTF8.self)
   expectEqual(str.isEmpty, true)
-  c = 100
-  guard enableCrashTests else { return }
+}
+
+CStringTests.test("String.init.decodingCString.with.inout.conversion/trap")
+.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.code {
+  guard #available(SwiftStdlib 5.7, *) else { return }
+  var c: Unicode.UTF8.CodeUnit = 100
   expectCrashLater(
     // Workaround for https://github.com/apple/swift/issues/58362 (rdar://91365967)
     // withMessage: "input of String.init(decodingCString:as:) must be null-terminated"
   )
-  str = String(decodingCString: &c, as: Unicode.UTF8.self)
+  let str = String(decodingCString: &c, as: Unicode.UTF8.self)
   expectUnreachable()
 }
 

--- a/test/stdlib/StringAPICString.swift
+++ b/test/stdlib/StringAPICString.swift
@@ -242,7 +242,7 @@ CStringTests.test("String.cString.with.Array.UInt8.input") {
 }
 
 CStringTests.test("String.cString.with.Array.UInt8.input/trap")
-.requireCapability(.crashTesting)
+.require(.crashTesting)
 .code {
   guard #available(SwiftStdlib 5.7, *) else { return }
   expectCrashLater(
@@ -271,7 +271,7 @@ CStringTests.test("String.cString.with.Array.CChar.input") {
 }
 
 CStringTests.test("String.cString.with.Array.CChar.input/trap")
-.requireCapability(.crashTesting)
+.require(.crashTesting)
 .code {
   guard #available(SwiftStdlib 5.7, *) else { return }
   expectCrashLater(
@@ -304,7 +304,7 @@ CStringTests.test("String.cString.with.inout.UInt8.conversion") {
 }
 
 CStringTests.test("String.cString.with.inout.UInt8.conversion/trap")
-.requireCapability(.crashTesting)
+.require(.crashTesting)
 .code {
   guard #available(SwiftStdlib 5.7, *) else { return }
   var c: UInt8 = 100
@@ -324,7 +324,7 @@ CStringTests.test("String.cString.with.inout.CChar.conversion") {
 }
 
 CStringTests.test("String.cString.with.inout.CChar.conversion/trap")
-.requireCapability(.crashTesting)
+.require(.crashTesting)
 .code {
   guard #available(SwiftStdlib 5.7, *) else { return }
   var c: CChar = 100
@@ -355,7 +355,7 @@ CStringTests.test("String.validatingCString.with.Array.input") {
 }
 
 CStringTests.test("String.validatingCString.with.Array.input/trap")
-.requireCapability(.crashTesting)
+.require(.crashTesting)
 .code {
   guard #available(SwiftStdlib 5.7, *) else { return }
   expectCrashLater(
@@ -391,7 +391,7 @@ CStringTests.test("String.validatingCString.with.inout.conversion") {
 }
 
 CStringTests.test("String.validatingCString.with.inout.conversion/trap")
-.requireCapability(.crashTesting)
+.require(.crashTesting)
 .code {
   guard #available(SwiftStdlib 5.7, *) else { return }
   var c: CChar = 100
@@ -423,7 +423,7 @@ CStringTests.test("String.decodeCString.with.Array.input") {
 }
 
 CStringTests.test("String.decodeCString.with.Array.input/trap")
-.requireCapability(.crashTesting)
+.require(.crashTesting)
 .code {
   guard #available(SwiftStdlib 5.7, *) else { return }
   expectCrashLater(
@@ -466,7 +466,7 @@ CStringTests.test("String.decodeCString.with.inout.conversion") {
 }
 
 CStringTests.test("String.decodeCString.with.inout.conversion/trap")
-.requireCapability(.crashTesting)
+.require(.crashTesting)
 .code {
   guard #available(SwiftStdlib 5.7, *) else { return }
   var c: Unicode.UTF8.CodeUnit = 100
@@ -496,7 +496,7 @@ CStringTests.test("String.init.decodingCString.with.Array.input") {
 }
 
 CStringTests.test("String.init.decodingCString.with.Array.input/trap")
-.requireCapability(.crashTesting)
+.require(.crashTesting)
 .code {
   guard #available(SwiftStdlib 5.7, *) else { return }
   expectCrashLater(
@@ -529,7 +529,7 @@ CStringTests.test("String.init.decodingCString.with.inout.conversion") {
 }
 
 CStringTests.test("String.init.decodingCString.with.inout.conversion/trap")
-.requireCapability(.crashTesting)
+.require(.crashTesting)
 .code {
   guard #available(SwiftStdlib 5.7, *) else { return }
   var c: Unicode.UTF8.CodeUnit = 100

--- a/test/stdlib/TemporaryAllocation.swift
+++ b/test/stdlib/TemporaryAllocation.swift
@@ -74,7 +74,8 @@ TemporaryAllocationTestSuite.test("untypedEmptyAllocationIsStackAllocated") {
 }
 
 TemporaryAllocationTestSuite.test("crashOnNegativeByteCount")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI.")).code {
+.requireCapability(.crashTesting)
+.code {
   expectCrash {
     let byteCount = Int.random(in: -2 ..< -1)
     withUnsafeTemporaryAllocation(byteCount: byteCount, alignment: 1) { _ in }
@@ -82,7 +83,8 @@ TemporaryAllocationTestSuite.test("crashOnNegativeByteCount")
 }
 
 TemporaryAllocationTestSuite.test("crashOnNegativeAlignment")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI.")).code {
+.requireCapability(.crashTesting)
+.code {
   expectCrash {
     let alignment = Int.random(in: -2 ..< -1)
     withUnsafeTemporaryAllocation(byteCount: 16, alignment: alignment) { _ in }
@@ -176,7 +178,8 @@ TemporaryAllocationTestSuite.test("voidSpanIsStackAllocated") {
 }
 
 TemporaryAllocationTestSuite.test("crashOnNegativeValueCount")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI.")).code {
+.requireCapability(.crashTesting)
+.code {
   expectCrash {
     let capacity = Int.random(in: -2 ..< -1)
     withUnsafeTemporaryAllocation(of: Int.self, capacity: capacity) { _ in }
@@ -184,7 +187,8 @@ TemporaryAllocationTestSuite.test("crashOnNegativeValueCount")
 }
 
 TemporaryAllocationTestSuite.test("spanCrashOnNegativeValueCount")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI.")).code {
+.requireCapability(.crashTesting)
+.code {
   expectCrash {
     let capacity = Int.random(in: -2 ..< -1)
     withTemporaryAllocation(of: Int.self, capacity: capacity) { _ in }
@@ -294,7 +298,8 @@ TemporaryAllocationTestSuite.test("rawSpanAppendAndByteCount") {
 }
 
 TemporaryAllocationTestSuite.test("rawSpanCrashOnNegativeByteCount")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI.")).code {
+.requireCapability(.crashTesting)
+.code {
   expectCrash {
     let byteCount = Int.random(in: -2 ..< -1)
     withTemporaryAllocation(byteCount: byteCount, alignment: 1) { _ in }
@@ -302,7 +307,8 @@ TemporaryAllocationTestSuite.test("rawSpanCrashOnNegativeByteCount")
 }
 
 TemporaryAllocationTestSuite.test("rawSpanCrashOnNegativeAlignment")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI.")).code {
+.requireCapability(.crashTesting)
+.code {
   expectCrash {
     let alignment = Int.random(in: -2 ..< -1)
     withTemporaryAllocation(byteCount: 16, alignment: alignment) { _ in }

--- a/test/stdlib/TemporaryAllocation.swift
+++ b/test/stdlib/TemporaryAllocation.swift
@@ -74,7 +74,7 @@ TemporaryAllocationTestSuite.test("untypedEmptyAllocationIsStackAllocated") {
 }
 
 TemporaryAllocationTestSuite.test("crashOnNegativeByteCount")
-.requireCapability(.crashTesting)
+.require(.crashTesting)
 .code {
   expectCrash {
     let byteCount = Int.random(in: -2 ..< -1)
@@ -83,7 +83,7 @@ TemporaryAllocationTestSuite.test("crashOnNegativeByteCount")
 }
 
 TemporaryAllocationTestSuite.test("crashOnNegativeAlignment")
-.requireCapability(.crashTesting)
+.require(.crashTesting)
 .code {
   expectCrash {
     let alignment = Int.random(in: -2 ..< -1)
@@ -178,7 +178,7 @@ TemporaryAllocationTestSuite.test("voidSpanIsStackAllocated") {
 }
 
 TemporaryAllocationTestSuite.test("crashOnNegativeValueCount")
-.requireCapability(.crashTesting)
+.require(.crashTesting)
 .code {
   expectCrash {
     let capacity = Int.random(in: -2 ..< -1)
@@ -187,7 +187,7 @@ TemporaryAllocationTestSuite.test("crashOnNegativeValueCount")
 }
 
 TemporaryAllocationTestSuite.test("spanCrashOnNegativeValueCount")
-.requireCapability(.crashTesting)
+.require(.crashTesting)
 .code {
   expectCrash {
     let capacity = Int.random(in: -2 ..< -1)
@@ -298,7 +298,7 @@ TemporaryAllocationTestSuite.test("rawSpanAppendAndByteCount") {
 }
 
 TemporaryAllocationTestSuite.test("rawSpanCrashOnNegativeByteCount")
-.requireCapability(.crashTesting)
+.require(.crashTesting)
 .code {
   expectCrash {
     let byteCount = Int.random(in: -2 ..< -1)
@@ -307,7 +307,7 @@ TemporaryAllocationTestSuite.test("rawSpanCrashOnNegativeByteCount")
 }
 
 TemporaryAllocationTestSuite.test("rawSpanCrashOnNegativeAlignment")
-.requireCapability(.crashTesting)
+.require(.crashTesting)
 .code {
   expectCrash {
     let alignment = Int.random(in: -2 ..< -1)

--- a/test/stdlib/UnsafePointer.swift.gyb
+++ b/test/stdlib/UnsafePointer.swift.gyb
@@ -306,7 +306,7 @@ func checkPtr(
 }
 
 UnsafeMutablePointerTestSuite.test("moveAssign:from:")
-.requireCapability(.crashTesting)
+.require(.crashTesting)
 .code {
   let check = checkPtr(UnsafeMutablePointer.moveAssign, true)
   check(Check.Disjoint)
@@ -318,7 +318,7 @@ UnsafeMutablePointerTestSuite.test("moveAssign:from:")
 }
 
 UnsafeMutablePointerTestSuite.test("moveAssign:from:.Right")
-.requireCapability(.crashTesting)
+.require(.crashTesting)
 .code {
   let check = checkPtr(UnsafeMutablePointer.moveAssign, true)
   // This check relies on _debugPrecondition() so will only trigger in -Onone mode.
@@ -343,7 +343,7 @@ UnsafeMutablePointerTestSuite.test("moveInitialize:from:") {
 }
 
 UnsafeMutablePointerTestSuite.test("initialize:from:")
-.requireCapability(.crashTesting)
+.require(.crashTesting)
 .code {
   let check = checkPtr(UnsafeMutablePointer.initialize(from:count:), false)
   check(Check.Disjoint)
@@ -355,7 +355,7 @@ UnsafeMutablePointerTestSuite.test("initialize:from:")
 }
 
 UnsafeMutablePointerTestSuite.test("initialize:from:.Right")
-.requireCapability(.crashTesting)
+.require(.crashTesting)
 .code {
   let check = checkPtr(UnsafeMutablePointer.initialize(from:count:), false)
   // This check relies on _debugPrecondition() so will only trigger in -Onone mode.
@@ -540,7 +540,7 @@ ${SelfName}TestSuite.test("pointer(to:)") {
 }
 
 ${SelfName}TestSuite.test("pointer(to:).overflow")
-.requireCapability(.crashTesting)
+.require(.crashTesting)
 .code {
   struct Example {
     var a = false

--- a/test/stdlib/UnsafePointer.swift.gyb
+++ b/test/stdlib/UnsafePointer.swift.gyb
@@ -305,9 +305,9 @@ func checkPtr(
   }
 }
 
-#if !os(WASI)
-// Trap tests aren't available on WASI.
-UnsafeMutablePointerTestSuite.test("moveAssign:from:") {
+UnsafeMutablePointerTestSuite.test("moveAssign:from:")
+.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.code {
   let check = checkPtr(UnsafeMutablePointer.moveAssign, true)
   check(Check.Disjoint)
   // This check relies on _debugPrecondition() so will only trigger in -Onone mode.
@@ -317,7 +317,9 @@ UnsafeMutablePointerTestSuite.test("moveAssign:from:") {
   }
 }
 
-UnsafeMutablePointerTestSuite.test("moveAssign:from:.Right") {
+UnsafeMutablePointerTestSuite.test("moveAssign:from:.Right")
+.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.code {
   let check = checkPtr(UnsafeMutablePointer.moveAssign, true)
   // This check relies on _debugPrecondition() so will only trigger in -Onone mode.
   if _isDebugAssertConfiguration() {
@@ -325,7 +327,6 @@ UnsafeMutablePointerTestSuite.test("moveAssign:from:.Right") {
     check(Check.RightOverlap)
   }
 }
-#endif
 
 UnsafeMutablePointerTestSuite.test("assign:from:") {
   let check = checkPtr(UnsafeMutablePointer.assign, true)
@@ -341,9 +342,9 @@ UnsafeMutablePointerTestSuite.test("moveInitialize:from:") {
   check(Check.RightOverlap)
 }
 
-#if !os(WASI)
-// Trap tests aren't available on WASI.
-UnsafeMutablePointerTestSuite.test("initialize:from:") {
+UnsafeMutablePointerTestSuite.test("initialize:from:")
+.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.code {
   let check = checkPtr(UnsafeMutablePointer.initialize(from:count:), false)
   check(Check.Disjoint)
   // This check relies on _debugPrecondition() so will only trigger in -Onone mode.
@@ -353,7 +354,9 @@ UnsafeMutablePointerTestSuite.test("initialize:from:") {
   }
 }
 
-UnsafeMutablePointerTestSuite.test("initialize:from:.Right") {
+UnsafeMutablePointerTestSuite.test("initialize:from:.Right")
+.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.code {
   let check = checkPtr(UnsafeMutablePointer.initialize(from:count:), false)
   // This check relies on _debugPrecondition() so will only trigger in -Onone mode.
   if _isDebugAssertConfiguration() {
@@ -361,7 +364,6 @@ UnsafeMutablePointerTestSuite.test("initialize:from:.Right") {
     check(Check.RightOverlap)
   }
 }
-#endif
 
 UnsafeMutablePointerTestSuite.test("initialize:from:/immutable") {
   let ptr = UnsafeMutablePointer<Missile>.allocate(capacity: 3)
@@ -537,8 +539,9 @@ ${SelfName}TestSuite.test("pointer(to:)") {
 % end
 }
 
-#if !os(WASI)
-${SelfName}TestSuite.test("pointer(to:).overflow") {
+${SelfName}TestSuite.test("pointer(to:).overflow")
+.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.code {
   struct Example {
     var a = false
     var b = 0
@@ -559,7 +562,6 @@ ${SelfName}TestSuite.test("pointer(to:).overflow") {
   let doublePointer = p.pointer(to: \.d)
   expectNotNil(doublePointer)
 }
-#endif
 
 % end
 

--- a/test/stdlib/UnsafePointer.swift.gyb
+++ b/test/stdlib/UnsafePointer.swift.gyb
@@ -306,7 +306,7 @@ func checkPtr(
 }
 
 UnsafeMutablePointerTestSuite.test("moveAssign:from:")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.requireCapability(.crashTesting)
 .code {
   let check = checkPtr(UnsafeMutablePointer.moveAssign, true)
   check(Check.Disjoint)
@@ -318,7 +318,7 @@ UnsafeMutablePointerTestSuite.test("moveAssign:from:")
 }
 
 UnsafeMutablePointerTestSuite.test("moveAssign:from:.Right")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.requireCapability(.crashTesting)
 .code {
   let check = checkPtr(UnsafeMutablePointer.moveAssign, true)
   // This check relies on _debugPrecondition() so will only trigger in -Onone mode.
@@ -343,7 +343,7 @@ UnsafeMutablePointerTestSuite.test("moveInitialize:from:") {
 }
 
 UnsafeMutablePointerTestSuite.test("initialize:from:")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.requireCapability(.crashTesting)
 .code {
   let check = checkPtr(UnsafeMutablePointer.initialize(from:count:), false)
   check(Check.Disjoint)
@@ -355,7 +355,7 @@ UnsafeMutablePointerTestSuite.test("initialize:from:")
 }
 
 UnsafeMutablePointerTestSuite.test("initialize:from:.Right")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.requireCapability(.crashTesting)
 .code {
   let check = checkPtr(UnsafeMutablePointer.initialize(from:count:), false)
   // This check relies on _debugPrecondition() so will only trigger in -Onone mode.
@@ -540,7 +540,7 @@ ${SelfName}TestSuite.test("pointer(to:)") {
 }
 
 ${SelfName}TestSuite.test("pointer(to:).overflow")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.requireCapability(.crashTesting)
 .code {
   struct Example {
     var a = false

--- a/test/stdlib/UnsafeRawBufferPointer.swift
+++ b/test/stdlib/UnsafeRawBufferPointer.swift
@@ -132,7 +132,7 @@ UnsafeRawBufferPointerTestSuite.test("initFromArray") {
 }
 
 UnsafeRawBufferPointerTestSuite.test("initializeMemory(as:from:).underflow")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI.")).code {
+.requireCapability(.crashTesting).code {
   let buffer = UnsafeMutableRawBufferPointer.allocate(
     byteCount: 30,
     alignment: MemoryLayout<UInt64>.alignment
@@ -152,7 +152,7 @@ UnsafeRawBufferPointerTestSuite.test("initializeMemory(as:from:).underflow")
 }
 
 UnsafeRawBufferPointerTestSuite.test("initializeMemory(as:from:).overflow")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI.")).code {
+.requireCapability(.crashTesting).code {
   let buffer = UnsafeMutableRawBufferPointer.allocate(
     byteCount: 30,
     alignment: MemoryLayout<UInt64>.alignment
@@ -187,7 +187,7 @@ UnsafeRawBufferPointerTestSuite.test("initializeMemory(as:from:).exact") {
 }
 
 UnsafeRawBufferPointerTestSuite.test("initializeMemory(as:from:).invalidNilPtr")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI.")).code {
+.requireCapability(.crashTesting).code {
   let buffer = UnsafeMutableRawBufferPointer(start: nil, count: 0)
   let source: [Int64] = [5, 4, 3, 2, 1]
   expectCrashLater()
@@ -303,7 +303,7 @@ UnsafeRawBufferPointerTestSuite.test("inBounds") {
 }
 
 UnsafeRawBufferPointerTestSuite.test("subscript.get.underflow")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI.")).code {
+.requireCapability(.crashTesting).code {
   let buffer = UnsafeMutableRawBufferPointer.allocate(
     byteCount: 2,
     alignment: MemoryLayout<UInt>.alignment
@@ -320,7 +320,7 @@ UnsafeRawBufferPointerTestSuite.test("subscript.get.underflow")
 }
 
 UnsafeRawBufferPointerTestSuite.test("subscript.get.overflow")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI.")).code {
+.requireCapability(.crashTesting).code {
   let buffer = UnsafeMutableRawBufferPointer.allocate(
     byteCount: 2,
     alignment: MemoryLayout<UInt>.alignment
@@ -337,7 +337,7 @@ UnsafeRawBufferPointerTestSuite.test("subscript.get.overflow")
 }
 
 UnsafeRawBufferPointerTestSuite.test("subscript.set.underflow")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI.")).code {
+.requireCapability(.crashTesting).code {
   let buffer = UnsafeMutableRawBufferPointer.allocate(
     byteCount: 2,
     alignment: MemoryLayout<UInt>.alignment
@@ -354,7 +354,7 @@ UnsafeRawBufferPointerTestSuite.test("subscript.set.underflow")
 }
 
 UnsafeRawBufferPointerTestSuite.test("subscript.set.overflow")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI.")).code {
+.requireCapability(.crashTesting).code {
   let buffer = UnsafeMutableRawBufferPointer.allocate(
     byteCount: 2,
     alignment: MemoryLayout<UInt>.alignment
@@ -371,7 +371,7 @@ UnsafeRawBufferPointerTestSuite.test("subscript.set.overflow")
 }
 
 UnsafeRawBufferPointerTestSuite.test("subscript.range.get.underflow")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI.")).code {
+.requireCapability(.crashTesting).code {
   let buffer = UnsafeMutableRawBufferPointer.allocate(
     byteCount: 3,
     alignment: MemoryLayout<UInt>.alignment
@@ -388,7 +388,7 @@ UnsafeRawBufferPointerTestSuite.test("subscript.range.get.underflow")
 }
 
 UnsafeRawBufferPointerTestSuite.test("subscript.range.get.overflow")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI.")).code {
+.requireCapability(.crashTesting).code {
   let buffer = UnsafeMutableRawBufferPointer.allocate(
     byteCount: 3,
     alignment: MemoryLayout<UInt>.alignment
@@ -405,7 +405,7 @@ UnsafeRawBufferPointerTestSuite.test("subscript.range.get.overflow")
 }
 
 UnsafeRawBufferPointerTestSuite.test("subscript.range.set.underflow")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI.")).code {
+.requireCapability(.crashTesting).code {
   let buffer = UnsafeMutableRawBufferPointer.allocate(
     byteCount: 3,
     alignment: MemoryLayout<UInt>.alignment
@@ -422,7 +422,7 @@ UnsafeRawBufferPointerTestSuite.test("subscript.range.set.underflow")
 }
 
 UnsafeRawBufferPointerTestSuite.test("subscript.range.set.overflow")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI.")).code {
+.requireCapability(.crashTesting).code {
   let buffer = UnsafeMutableRawBufferPointer.allocate(
     byteCount: 3,
     alignment: MemoryLayout<UInt>.alignment
@@ -440,7 +440,7 @@ UnsafeRawBufferPointerTestSuite.test("subscript.range.set.overflow")
 }
 
 UnsafeRawBufferPointerTestSuite.test("subscript.range.narrow")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI.")).code {
+.requireCapability(.crashTesting).code {
   let buffer = UnsafeMutableRawBufferPointer.allocate(
     byteCount: 3,
     alignment: MemoryLayout<UInt>.alignment
@@ -455,7 +455,7 @@ UnsafeRawBufferPointerTestSuite.test("subscript.range.narrow")
 }
 
 UnsafeRawBufferPointerTestSuite.test("subscript.range.wide")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI.")).code {
+.requireCapability(.crashTesting).code {
   let buffer = UnsafeMutableRawBufferPointer.allocate(
     byteCount: 3,
     alignment: MemoryLayout<UInt>.alignment
@@ -482,7 +482,7 @@ UnsafeRawBufferPointerTestSuite.test("_copyContents") {
 }
 
 UnsafeRawBufferPointerTestSuite.test("copyMemory.overflow")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI.")).code {
+.requireCapability(.crashTesting).code {
   let buffer = UnsafeMutableRawBufferPointer.allocate(
     byteCount: 3,
     alignment: MemoryLayout<UInt>.alignment
@@ -513,7 +513,7 @@ UnsafeRawBufferPointerTestSuite.test("copyBytes.withoutContiguousStorage") {
 }
 
 UnsafeRawBufferPointerTestSuite.test("copyBytes.sequence.overflow")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI.")).code {
+.requireCapability(.crashTesting).code {
   let buffer = UnsafeMutableRawBufferPointer.allocate(
     byteCount: 3,
     alignment: MemoryLayout<UInt>.alignment
@@ -531,7 +531,7 @@ UnsafeRawBufferPointerTestSuite.test("copyBytes.sequence.overflow")
 }
 
 UnsafeRawBufferPointerTestSuite.test("load.before")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.requireCapability(.crashTesting)
 .skip(.custom(
     { !_isDebugAssertConfiguration() },
     reason: "This tests a debug precondition."))
@@ -544,7 +544,7 @@ UnsafeRawBufferPointerTestSuite.test("load.before")
 }
 
 UnsafeRawBufferPointerTestSuite.test("load.after")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.requireCapability(.crashTesting)
 .skip(.custom(
     { !_isDebugAssertConfiguration() },
     reason: "This tests a debug precondition.."))
@@ -569,7 +569,7 @@ UnsafeRawBufferPointerTestSuite.test("load.aligned") {
 }
 
 UnsafeRawBufferPointerTestSuite.test("load.invalid")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.requireCapability(.crashTesting)
 .skip(.custom({ !_isDebugAssertConfiguration() }, // require debugAssert
               reason: "This tests a debug precondition.."))
 .code {
@@ -598,7 +598,7 @@ UnsafeRawBufferPointerTestSuite.test("load.unaligned")
 }
 
 UnsafeRawBufferPointerTestSuite.test("store.before")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.requireCapability(.crashTesting)
 .skip(.custom(
     { !_isDebugAssertConfiguration() },
     reason: "This tests a debug precondition.."))
@@ -610,7 +610,7 @@ UnsafeRawBufferPointerTestSuite.test("store.before")
   }
 }
 UnsafeRawBufferPointerTestSuite.test("store.after")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.requireCapability(.crashTesting)
 .skip(.custom(
     { !_isDebugAssertConfiguration() },
     reason: "This tests a debug precondition.."))
@@ -647,7 +647,7 @@ UnsafeRawBufferPointerTestSuite.test("store.unaligned")
 }
 
 UnsafeRawBufferPointerTestSuite.test("store.invalid")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.requireCapability(.crashTesting)
 .skip(.custom({ !_isDebugAssertConfiguration() }, // require debugAssert
               reason: "This tests a debug precondition.."))
 .require(.stdlib_5_7)
@@ -673,7 +673,7 @@ UnsafeRawBufferPointerTestSuite.test("store.valid") {
 }
 
 UnsafeRawBufferPointerTestSuite.test("copy.bytes.overflow")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.requireCapability(.crashTesting)
 .skip(.custom(
     { !_isDebugAssertConfiguration() },
     reason: "This tests a debug precondition.."))
@@ -690,7 +690,7 @@ UnsafeRawBufferPointerTestSuite.test("copy.bytes.overflow")
 }
 
 UnsafeRawBufferPointerTestSuite.test("copy.sequence.overflow")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.requireCapability(.crashTesting)
 .skip(.custom(
     { !_isDebugAssertConfiguration() },
     reason: "This tests a debug precondition.."))

--- a/test/stdlib/UnsafeRawBufferPointer.swift
+++ b/test/stdlib/UnsafeRawBufferPointer.swift
@@ -132,7 +132,7 @@ UnsafeRawBufferPointerTestSuite.test("initFromArray") {
 }
 
 UnsafeRawBufferPointerTestSuite.test("initializeMemory(as:from:).underflow")
-.requireCapability(.crashTesting).code {
+.require(.crashTesting).code {
   let buffer = UnsafeMutableRawBufferPointer.allocate(
     byteCount: 30,
     alignment: MemoryLayout<UInt64>.alignment
@@ -152,7 +152,7 @@ UnsafeRawBufferPointerTestSuite.test("initializeMemory(as:from:).underflow")
 }
 
 UnsafeRawBufferPointerTestSuite.test("initializeMemory(as:from:).overflow")
-.requireCapability(.crashTesting).code {
+.require(.crashTesting).code {
   let buffer = UnsafeMutableRawBufferPointer.allocate(
     byteCount: 30,
     alignment: MemoryLayout<UInt64>.alignment
@@ -187,7 +187,7 @@ UnsafeRawBufferPointerTestSuite.test("initializeMemory(as:from:).exact") {
 }
 
 UnsafeRawBufferPointerTestSuite.test("initializeMemory(as:from:).invalidNilPtr")
-.requireCapability(.crashTesting).code {
+.require(.crashTesting).code {
   let buffer = UnsafeMutableRawBufferPointer(start: nil, count: 0)
   let source: [Int64] = [5, 4, 3, 2, 1]
   expectCrashLater()
@@ -303,7 +303,7 @@ UnsafeRawBufferPointerTestSuite.test("inBounds") {
 }
 
 UnsafeRawBufferPointerTestSuite.test("subscript.get.underflow")
-.requireCapability(.crashTesting).code {
+.require(.crashTesting).code {
   let buffer = UnsafeMutableRawBufferPointer.allocate(
     byteCount: 2,
     alignment: MemoryLayout<UInt>.alignment
@@ -320,7 +320,7 @@ UnsafeRawBufferPointerTestSuite.test("subscript.get.underflow")
 }
 
 UnsafeRawBufferPointerTestSuite.test("subscript.get.overflow")
-.requireCapability(.crashTesting).code {
+.require(.crashTesting).code {
   let buffer = UnsafeMutableRawBufferPointer.allocate(
     byteCount: 2,
     alignment: MemoryLayout<UInt>.alignment
@@ -337,7 +337,7 @@ UnsafeRawBufferPointerTestSuite.test("subscript.get.overflow")
 }
 
 UnsafeRawBufferPointerTestSuite.test("subscript.set.underflow")
-.requireCapability(.crashTesting).code {
+.require(.crashTesting).code {
   let buffer = UnsafeMutableRawBufferPointer.allocate(
     byteCount: 2,
     alignment: MemoryLayout<UInt>.alignment
@@ -354,7 +354,7 @@ UnsafeRawBufferPointerTestSuite.test("subscript.set.underflow")
 }
 
 UnsafeRawBufferPointerTestSuite.test("subscript.set.overflow")
-.requireCapability(.crashTesting).code {
+.require(.crashTesting).code {
   let buffer = UnsafeMutableRawBufferPointer.allocate(
     byteCount: 2,
     alignment: MemoryLayout<UInt>.alignment
@@ -371,7 +371,7 @@ UnsafeRawBufferPointerTestSuite.test("subscript.set.overflow")
 }
 
 UnsafeRawBufferPointerTestSuite.test("subscript.range.get.underflow")
-.requireCapability(.crashTesting).code {
+.require(.crashTesting).code {
   let buffer = UnsafeMutableRawBufferPointer.allocate(
     byteCount: 3,
     alignment: MemoryLayout<UInt>.alignment
@@ -388,7 +388,7 @@ UnsafeRawBufferPointerTestSuite.test("subscript.range.get.underflow")
 }
 
 UnsafeRawBufferPointerTestSuite.test("subscript.range.get.overflow")
-.requireCapability(.crashTesting).code {
+.require(.crashTesting).code {
   let buffer = UnsafeMutableRawBufferPointer.allocate(
     byteCount: 3,
     alignment: MemoryLayout<UInt>.alignment
@@ -405,7 +405,7 @@ UnsafeRawBufferPointerTestSuite.test("subscript.range.get.overflow")
 }
 
 UnsafeRawBufferPointerTestSuite.test("subscript.range.set.underflow")
-.requireCapability(.crashTesting).code {
+.require(.crashTesting).code {
   let buffer = UnsafeMutableRawBufferPointer.allocate(
     byteCount: 3,
     alignment: MemoryLayout<UInt>.alignment
@@ -422,7 +422,7 @@ UnsafeRawBufferPointerTestSuite.test("subscript.range.set.underflow")
 }
 
 UnsafeRawBufferPointerTestSuite.test("subscript.range.set.overflow")
-.requireCapability(.crashTesting).code {
+.require(.crashTesting).code {
   let buffer = UnsafeMutableRawBufferPointer.allocate(
     byteCount: 3,
     alignment: MemoryLayout<UInt>.alignment
@@ -440,7 +440,7 @@ UnsafeRawBufferPointerTestSuite.test("subscript.range.set.overflow")
 }
 
 UnsafeRawBufferPointerTestSuite.test("subscript.range.narrow")
-.requireCapability(.crashTesting).code {
+.require(.crashTesting).code {
   let buffer = UnsafeMutableRawBufferPointer.allocate(
     byteCount: 3,
     alignment: MemoryLayout<UInt>.alignment
@@ -455,7 +455,7 @@ UnsafeRawBufferPointerTestSuite.test("subscript.range.narrow")
 }
 
 UnsafeRawBufferPointerTestSuite.test("subscript.range.wide")
-.requireCapability(.crashTesting).code {
+.require(.crashTesting).code {
   let buffer = UnsafeMutableRawBufferPointer.allocate(
     byteCount: 3,
     alignment: MemoryLayout<UInt>.alignment
@@ -482,7 +482,7 @@ UnsafeRawBufferPointerTestSuite.test("_copyContents") {
 }
 
 UnsafeRawBufferPointerTestSuite.test("copyMemory.overflow")
-.requireCapability(.crashTesting).code {
+.require(.crashTesting).code {
   let buffer = UnsafeMutableRawBufferPointer.allocate(
     byteCount: 3,
     alignment: MemoryLayout<UInt>.alignment
@@ -513,7 +513,7 @@ UnsafeRawBufferPointerTestSuite.test("copyBytes.withoutContiguousStorage") {
 }
 
 UnsafeRawBufferPointerTestSuite.test("copyBytes.sequence.overflow")
-.requireCapability(.crashTesting).code {
+.require(.crashTesting).code {
   let buffer = UnsafeMutableRawBufferPointer.allocate(
     byteCount: 3,
     alignment: MemoryLayout<UInt>.alignment
@@ -531,7 +531,7 @@ UnsafeRawBufferPointerTestSuite.test("copyBytes.sequence.overflow")
 }
 
 UnsafeRawBufferPointerTestSuite.test("load.before")
-.requireCapability(.crashTesting)
+.require(.crashTesting)
 .skip(.custom(
     { !_isDebugAssertConfiguration() },
     reason: "This tests a debug precondition."))
@@ -544,7 +544,7 @@ UnsafeRawBufferPointerTestSuite.test("load.before")
 }
 
 UnsafeRawBufferPointerTestSuite.test("load.after")
-.requireCapability(.crashTesting)
+.require(.crashTesting)
 .skip(.custom(
     { !_isDebugAssertConfiguration() },
     reason: "This tests a debug precondition.."))
@@ -569,7 +569,7 @@ UnsafeRawBufferPointerTestSuite.test("load.aligned") {
 }
 
 UnsafeRawBufferPointerTestSuite.test("load.invalid")
-.requireCapability(.crashTesting)
+.require(.crashTesting)
 .skip(.custom({ !_isDebugAssertConfiguration() }, // require debugAssert
               reason: "This tests a debug precondition.."))
 .code {
@@ -598,7 +598,7 @@ UnsafeRawBufferPointerTestSuite.test("load.unaligned")
 }
 
 UnsafeRawBufferPointerTestSuite.test("store.before")
-.requireCapability(.crashTesting)
+.require(.crashTesting)
 .skip(.custom(
     { !_isDebugAssertConfiguration() },
     reason: "This tests a debug precondition.."))
@@ -610,7 +610,7 @@ UnsafeRawBufferPointerTestSuite.test("store.before")
   }
 }
 UnsafeRawBufferPointerTestSuite.test("store.after")
-.requireCapability(.crashTesting)
+.require(.crashTesting)
 .skip(.custom(
     { !_isDebugAssertConfiguration() },
     reason: "This tests a debug precondition.."))
@@ -647,7 +647,7 @@ UnsafeRawBufferPointerTestSuite.test("store.unaligned")
 }
 
 UnsafeRawBufferPointerTestSuite.test("store.invalid")
-.requireCapability(.crashTesting)
+.require(.crashTesting)
 .skip(.custom({ !_isDebugAssertConfiguration() }, // require debugAssert
               reason: "This tests a debug precondition.."))
 .require(.stdlib_5_7)
@@ -673,7 +673,7 @@ UnsafeRawBufferPointerTestSuite.test("store.valid") {
 }
 
 UnsafeRawBufferPointerTestSuite.test("copy.bytes.overflow")
-.requireCapability(.crashTesting)
+.require(.crashTesting)
 .skip(.custom(
     { !_isDebugAssertConfiguration() },
     reason: "This tests a debug precondition.."))
@@ -690,7 +690,7 @@ UnsafeRawBufferPointerTestSuite.test("copy.bytes.overflow")
 }
 
 UnsafeRawBufferPointerTestSuite.test("copy.sequence.overflow")
-.requireCapability(.crashTesting)
+.require(.crashTesting)
 .skip(.custom(
     { !_isDebugAssertConfiguration() },
     reason: "This tests a debug precondition.."))

--- a/test/stdlib/UnsafeRawPointer.swift
+++ b/test/stdlib/UnsafeRawPointer.swift
@@ -127,7 +127,7 @@ UnsafeMutableRawPointerExtraTestSuite.test("load.unaligned")
 }
 
 UnsafeMutableRawPointerExtraTestSuite.test("load.invalid")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.requireCapability(.crashTesting)
 .skip(.custom({ !_isDebugAssertConfiguration() },
               reason: "This tests a debug precondition.."))
 .code {
@@ -140,7 +140,7 @@ UnsafeMutableRawPointerExtraTestSuite.test("load.invalid")
 }
 
 UnsafeMutableRawPointerExtraTestSuite.test("load.invalid.mutable")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.requireCapability(.crashTesting)
 .skip(.custom({ !_isDebugAssertConfiguration() },
               reason: "This tests a debug precondition.."))
 .code {
@@ -179,7 +179,7 @@ UnsafeMutableRawPointerExtraTestSuite.test("store.unaligned")
 }
 
 UnsafeMutableRawPointerExtraTestSuite.test("store.invalid")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.requireCapability(.crashTesting)
 .skip(.custom({ !_isDebugAssertConfiguration() },
               reason: "This tests a debug precondition.."))
 .require(.stdlib_5_7)
@@ -303,7 +303,7 @@ func checkPtr(
 }
 
 UnsafeMutableRawPointerExtraTestSuite.test("initializeMemory:as:from:count:")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.requireCapability(.crashTesting)
 .code {
   let check = checkPtr(UnsafeMutableRawPointer.initializeMemory(as:from:count:))
   check(Check.Disjoint)
@@ -316,7 +316,7 @@ UnsafeMutableRawPointerExtraTestSuite.test("initializeMemory:as:from:count:")
 }
 
 UnsafeMutableRawPointerExtraTestSuite.test("initializeMemory:as:from:count:.Right")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.requireCapability(.crashTesting)
 .code {
   let check = checkPtr(UnsafeMutableRawPointer.initializeMemory(as:from:count:))
   // This check relies on _debugPrecondition() so will only trigger in

--- a/test/stdlib/UnsafeRawPointer.swift
+++ b/test/stdlib/UnsafeRawPointer.swift
@@ -127,7 +127,7 @@ UnsafeMutableRawPointerExtraTestSuite.test("load.unaligned")
 }
 
 UnsafeMutableRawPointerExtraTestSuite.test("load.invalid")
-.requireCapability(.crashTesting)
+.require(.crashTesting)
 .skip(.custom({ !_isDebugAssertConfiguration() },
               reason: "This tests a debug precondition.."))
 .code {
@@ -140,7 +140,7 @@ UnsafeMutableRawPointerExtraTestSuite.test("load.invalid")
 }
 
 UnsafeMutableRawPointerExtraTestSuite.test("load.invalid.mutable")
-.requireCapability(.crashTesting)
+.require(.crashTesting)
 .skip(.custom({ !_isDebugAssertConfiguration() },
               reason: "This tests a debug precondition.."))
 .code {
@@ -179,7 +179,7 @@ UnsafeMutableRawPointerExtraTestSuite.test("store.unaligned")
 }
 
 UnsafeMutableRawPointerExtraTestSuite.test("store.invalid")
-.requireCapability(.crashTesting)
+.require(.crashTesting)
 .skip(.custom({ !_isDebugAssertConfiguration() },
               reason: "This tests a debug precondition.."))
 .require(.stdlib_5_7)
@@ -303,7 +303,7 @@ func checkPtr(
 }
 
 UnsafeMutableRawPointerExtraTestSuite.test("initializeMemory:as:from:count:")
-.requireCapability(.crashTesting)
+.require(.crashTesting)
 .code {
   let check = checkPtr(UnsafeMutableRawPointer.initializeMemory(as:from:count:))
   check(Check.Disjoint)
@@ -316,7 +316,7 @@ UnsafeMutableRawPointerExtraTestSuite.test("initializeMemory:as:from:count:")
 }
 
 UnsafeMutableRawPointerExtraTestSuite.test("initializeMemory:as:from:count:.Right")
-.requireCapability(.crashTesting)
+.require(.crashTesting)
 .code {
   let check = checkPtr(UnsafeMutableRawPointer.initializeMemory(as:from:count:))
   // This check relies on _debugPrecondition() so will only trigger in

--- a/test/stdlib/UnsafeRawPointer.swift
+++ b/test/stdlib/UnsafeRawPointer.swift
@@ -126,8 +126,8 @@ UnsafeMutableRawPointerExtraTestSuite.test("load.unaligned")
   expectEqual(result, 0xffff_0000)
 }
 
-#if !os(WASI)
 UnsafeMutableRawPointerExtraTestSuite.test("load.invalid")
+.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
 .skip(.custom({ !_isDebugAssertConfiguration() },
               reason: "This tests a debug precondition.."))
 .code {
@@ -140,6 +140,7 @@ UnsafeMutableRawPointerExtraTestSuite.test("load.invalid")
 }
 
 UnsafeMutableRawPointerExtraTestSuite.test("load.invalid.mutable")
+.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
 .skip(.custom({ !_isDebugAssertConfiguration() },
               reason: "This tests a debug precondition.."))
 .code {
@@ -150,7 +151,6 @@ UnsafeMutableRawPointerExtraTestSuite.test("load.invalid.mutable")
   }
   expectUnreachable()
 }
-#endif
 
 UnsafeMutableRawPointerExtraTestSuite.test("store.unaligned")
 .require(.stdlib_5_7)
@@ -178,8 +178,8 @@ UnsafeMutableRawPointerExtraTestSuite.test("store.unaligned")
               0)
 }
 
-#if !os(WASI)
 UnsafeMutableRawPointerExtraTestSuite.test("store.invalid")
+.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
 .skip(.custom({ !_isDebugAssertConfiguration() },
               reason: "This tests a debug precondition.."))
 .require(.stdlib_5_7)
@@ -195,7 +195,6 @@ UnsafeMutableRawPointerExtraTestSuite.test("store.invalid")
   p1.storeBytes(of: m, as: Missile.self)
   expectUnreachable()
 }
-#endif
 
 UnsafeMutableRawPointerExtraTestSuite.test("copyMemory") {
   let sizeInBytes = 4 * MemoryLayout<Int>.stride
@@ -303,9 +302,9 @@ func checkPtr(
   }
 }
 
-#if !os(WASI)
-// Trap tests aren't available on WASI.
-UnsafeMutableRawPointerExtraTestSuite.test("initializeMemory:as:from:count:") {
+UnsafeMutableRawPointerExtraTestSuite.test("initializeMemory:as:from:count:")
+.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.code {
   let check = checkPtr(UnsafeMutableRawPointer.initializeMemory(as:from:count:))
   check(Check.Disjoint)
   // This check relies on _debugPrecondition() so will only trigger in
@@ -316,7 +315,9 @@ UnsafeMutableRawPointerExtraTestSuite.test("initializeMemory:as:from:count:") {
   }
 }
 
-UnsafeMutableRawPointerExtraTestSuite.test("initializeMemory:as:from:count:.Right") {
+UnsafeMutableRawPointerExtraTestSuite.test("initializeMemory:as:from:count:.Right")
+.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
+.code {
   let check = checkPtr(UnsafeMutableRawPointer.initializeMemory(as:from:count:))
   // This check relies on _debugPrecondition() so will only trigger in
   // -Onone mode.
@@ -325,7 +326,6 @@ UnsafeMutableRawPointerExtraTestSuite.test("initializeMemory:as:from:count:.Righ
     check(Check.RightOverlap)
   }
 }
-#endif
 
 UnsafeMutableRawPointerExtraTestSuite.test("moveInitialize:from:") {
   let check =


### PR DESCRIPTION
When testing on WASI, crash testing is not available. These tests have been historically skipped by conditional compilation, which is error-prone and silent – indeed some tests were once skipped that shouldn't have been.

In the last year I've written `expectCrashLater()` tests with a `skip()` test modifier based on the platform. At least we see which tests are skipped in outputs, but listing platforms doesn't look great. The correct approach is to say that a test requires crash testing, and let the test runner skip it when the tested platform doesn't support it.

Taking inspiration from @natecook1000's availability-requiring `.require()` (20ff51d41,) this adds a `TestRequirement` enum, with a matching `.require()` test modifier.

We then change all the WASI crash test skips to `.require(.crashTesting)`, and so they are skipped.

I plan to later update the availability-based conditions to be based on `TestRequirement`, and to add cases to `TestRequirement` for debug builds, release builds, etc.