### PR TITLE
[test][android] Temporarily disable new Reflection/availability_custom_domains.swift test

### DIFF
--- a/test/Reflection/availability_custom_domains.swift
+++ b/test/Reflection/availability_custom_domains.swift
@@ -18,6 +18,7 @@
 // RUN: %FileCheck %s --check-prefix=CHECK-NEGATIVE --input-file=%t/reflection.txt
 
 // REQUIRES: swift_feature_CustomAvailability
+// UNSUPPORTED: OS=linux-android, OS=linux-androideabi
 
 // Every type/member that should be absent from the reflection dump has
 // "Disabled" or "disabled" in its name.


### PR DESCRIPTION
- **Explanation**: #88764 just introduced this test, [which fails on the Android CI](https://ci.swift.org/job/oss-swift-package-swift-sdk-for-android/429/console), likely related to linker issues we've seen with the older lld in NDK 28, #88056, so I'll check this locally with the upcoming NDK 30 beta and re-enable with those other Reflection tests once we update the CI to the next NDK 30 beta in the coming month.
- **Scope**: just one test
- **Issues**: none
- **Risk**: zero
- **Testing**: none

