### PR TITLE
Sema: reword a confusing error message about `@inline(always)`

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -9200,11 +9200,8 @@ NOTE(invalid_redecl_of_file_isolation_prev,none,
 //===----------------------------------------------------------------------===//
 ERROR(attr_inline_always_experimental,none,
       "'@inline(always)' is an experimental feature", ())
-ERROR(attr_inline_always_requires_inlinable,none,
-      "'@inline(always)' on public or package declarations must be used "
-      "together with '@inlinable'", ())
 ERROR(attr_inline_always_no_usable_from_inline,none,
-      "cannot use '@inline(always)' together with '@usableFromInline'", ())
+      "'@inline(always)' implies '@usableFromInline'; do not use both", ())
 ERROR(attr_inline_always_requires_final_method,none,
       "'@inline(always)' on class %select{methods|vars}1 requires %0 to be "
       "marked 'final'", (DeclName, bool))

--- a/test/Sema/inline_always.swift
+++ b/test/Sema/inline_always.swift
@@ -57,7 +57,7 @@ func internalUsingInternal() {
 @inline(always) // okay
 package func packageFunc() {}
 
-@inline(always) // expected-error{{cannot use '@inline(always)' together with '@usableFromInline'}}
+@inline(always) // expected-error{{'@inline(always)' implies '@usableFromInline'; do not use both}}
 @usableFromInline
 func internalUFI() {}
 


### PR DESCRIPTION
- **Explanation**:
The old error message "cannot use '@inline(always)' together with '@usableFromInline'" does not tell the reason.
The new message "'@inline(always)' implies '@usableFromInline'; do not use both" makes this clear.
Also, remove an unused error message.

- **Scope**:
Affects code which uses `@inline(always)`

- **Issues**:
rdar://176028537

- **Risk**:
Very low. Just rewords an error message.

- **Testing**:
Tested by a lit test

- **Reviewers**:
@tbkka





