### PR TITLE
AliasAnalysis: correctly handle InlineArray in type-based alias analysis

### DIFF
--- a/SwiftCompilerSources/Sources/SIL/Type.swift
+++ b/SwiftCompilerSources/Sources/SIL/Type.swift
@@ -213,7 +213,9 @@ public struct Type : TypeProperties, CustomStringConvertible, NoReflectionChildr
     return idx >= 0 ? idx : nil
   }
 
-  /// Returns true if this is a struct, enum or tuple and `otherType` is contained in this type - or is the same type.
+  /// Returns true if this is an aggregate containing `otherType` - or is the same type.
+  ///
+  /// Recurses into the element types of structs, tuples, enum payloads, and `Builtin.FixedArray`.
   public func aggregateIsOrContains(_ otherType: Type, in function: Function) -> Bool {
     if self == otherType {
       return true
@@ -232,6 +234,15 @@ public struct Type : TypeProperties, CustomStringConvertible, NoReflectionChildr
         return true
       }
       return cases.contains { $0.payload?.aggregateIsOrContains(otherType, in: function) ?? false }
+    }
+    if isBuiltinFixedArray {
+      // Match the address-ness of `self` so TBAA callers that pass address
+      // types recurse correctly into the element type.
+      var elementType = builtinFixedArrayElementType(in: function)
+      if isAddress {
+        elementType = elementType.addressType
+      }
+      return elementType.aggregateIsOrContains(otherType, in: function)
     }
     return false
   }

--- a/test/SILOptimizer/alias-analysis_unit.sil
+++ b/test/SILOptimizer/alias-analysis_unit.sil
@@ -145,3 +145,32 @@ bb0(%0 : $*Builtin.FixedArray<10, Int>, %1 : $Builtin.Word):
   %99 = tuple ()
   return %99 : $()
 }
+
+struct Container {
+  @_hasStorage var values: InlineArray<3, Int> { get set }
+}
+
+sil_global hidden @g : $Container
+
+// CHECK-LABEL: @testInlineArray
+// CHECK:       PAIR #9.
+// CHECK-NEXT:      %1 = global_addr @g : $*Container
+// CHECK-NEXT:      %4 = vector_base_addr %3 : $*Builtin.FixedArray<3, Int>
+// CHECK-NEXT:    MayAlias
+// CHECK:       PAIR #13.
+// CHECK-NEXT:      %2 = struct_element_addr %1 : $*Container, #Container.values
+// CHECK-NEXT:      %4 = vector_base_addr %3 : $*Builtin.FixedArray<3, Int>
+// CHECK-NEXT:    MayAlias
+sil [ossa] @testInlineArray : $@convention(thin) (Int) -> () {
+bb0(%0 : $Int):
+  specify_test "aliasing"
+  %1 = global_addr @g : $*Container
+  %3 = struct_element_addr %1, #Container.values
+  %4 = struct_element_addr %3, #InlineArray._storage
+  %5 = vector_base_addr %4
+  fix_lifetime %5
+  %10 = tuple ()
+  return %10
+}
+
+

--- a/test/SILOptimizer/inline_array_loop_mutation.swift
+++ b/test/SILOptimizer/inline_array_loop_mutation.swift
@@ -1,0 +1,29 @@
+// RUN: %target-run-simple-swift(-Xfrontend -disable-availability-checking)
+// RUN: %target-run-simple-swift(-O -Xfrontend -disable-availability-checking)
+
+// REQUIRES: executable_test
+
+// UNSUPPORTED: back_deployment_runtime || use_os_stdlib
+
+// Regression test for a miscompile where TBAA failed to recurse into
+// `Builtin.FixedArray`'s element type, allowing LICM to hoist a load out
+// of a loop past an aliasing store. The symptom was that a loop calling
+// a `mutating` method which wrote to an `InlineArray` element via
+// subscript left the effect of only one iteration in the final state.
+
+struct Container {
+  var values: InlineArray<3, Int>
+  mutating func step() {
+    values[0] &+= 1
+  }
+}
+
+var c = Container(values: [0, 0, 0])
+
+for _ in 0 ..< 10 {
+  c.step()
+}
+
+precondition(c.values[0] == 10)
+precondition(c.values[1] == 0)
+precondition(c.values[2] == 0)


### PR DESCRIPTION
- **Explanation**:

Fixes a mis-compile where TBAA failed to recurse into `Builtin.FixedArray`'s element type.

- **Scope**:
Affects code which uses InlineArray

- **Issues**:
rdar://176106882

- **Risk**:
Low. The change makes alias analysis more conservative. Also, it only affects code with InlineArray.

- **Testing**:
Tested by lit tests

- **Reviewers**:
@meg-gupta
