### PR TITLE
[Runtime] Remove redundant semicolon in SwiftRAII copy constructor

### DIFF
--- a/include/swift/Runtime/HeapObject.h
+++ b/include/swift/Runtime/HeapObject.h
@@ -365,7 +365,6 @@ public:
   SwiftRAII(const SwiftRAII &other) {
     swift_retain(*other);
     object = *other;
-    ;
   }
   SwiftRAII(SwiftRAII &&other) : object(*other) {
     other.object = nullptr;


### PR DESCRIPTION
Hi,

This PR removes a redundant semicolon in the SwiftRAII copy constructor.

No functional changes.