### PR TITLE
Sema: Print opaque result generic signatures when -debug-generic-signatures is passed in

### DIFF
--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -2183,25 +2183,46 @@ static void checkProtocolRefinementRequirements(ProtocolDecl *proto) {
 }
 
 static void dumpGenericSignature(ASTContext &ctx, GenericContext *GC) {
-  if (ctx.TypeCheckerOpts.DebugGenericSignatures) {
-    if (auto sig = GC->getGenericSignature()) {
+  if (!ctx.TypeCheckerOpts.DebugGenericSignatures)
+    return;
+
+  auto *VD = dyn_cast_or_null<ValueDecl>(GC->getAsDecl());
+
+  auto dumpSig = [&](GenericSignature sig, bool isOpaque) {
+    llvm::errs() << "\n";
+    if (isOpaque) {
+      llvm::errs() << "Opaque result type of ";
+    }
+    if (VD) {
+      VD->dumpRef(llvm::errs());
       llvm::errs() << "\n";
-      if (auto *VD = dyn_cast_or_null<ValueDecl>(GC->getAsDecl())) {
-        VD->dumpRef(llvm::errs());
-        llvm::errs() << "\n";
-      } else {
-        GC->printContext(llvm::errs());
+    } else {
+      GC->printContext(llvm::errs());
+    }
+    llvm::errs() << (isOpaque ? "Opaque result signature: "
+                              : "Generic signature: ");
+    PrintOptions Opts = PrintOptions::forDebugging();
+    Opts.ProtocolQualifiedDependentMemberTypes = true;
+    Opts.PrintInverseRequirements =
+        !ctx.TypeCheckerOpts.DebugInverseRequirements;
+    sig->print(llvm::errs(), Opts);
+    llvm::errs() << "\n";
+    llvm::errs() << (isOpaque ? "Canonical opaque result signature: "
+                              : "Canonical generic signature: ");
+    sig.getCanonicalSignature()->print(llvm::errs(), Opts);
+    llvm::errs() << "\n";
+  };
+
+  if (auto sig = GC->getGenericSignature())
+    dumpSig(sig, /*isOpaque=*/false);
+
+  // If we have a ValueDecl, also visit its opaque result type and
+  // dump its signature.
+  if (VD) {
+    if (auto *OTD = VD->getOpaqueResultTypeDecl()) {
+      if (auto sig = OTD->getOpaqueInterfaceGenericSignature()) {
+        dumpSig(sig, /*isOpaque=*/true);
       }
-      llvm::errs() << "Generic signature: ";
-      PrintOptions Opts = PrintOptions::forDebugging();
-      Opts.ProtocolQualifiedDependentMemberTypes = true;
-      Opts.PrintInverseRequirements =
-          !ctx.TypeCheckerOpts.DebugInverseRequirements;
-      sig->print(llvm::errs(), Opts);
-      llvm::errs() << "\n";
-      llvm::errs() << "Canonical generic signature: ";
-      sig.getCanonicalSignature()->print(llvm::errs(), Opts);
-      llvm::errs() << "\n";
     }
   }
 }

--- a/test/type/opaque_signature.swift
+++ b/test/type/opaque_signature.swift
@@ -1,0 +1,36 @@
+// RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures 2>&1 | %FileCheck %s
+
+protocol P<A> {
+  associatedtype A
+}
+protocol Q<A> {
+  associatedtype A
+}
+
+struct G<T>: Q, P {
+  typealias A = T
+}
+
+struct ConcreteTest {
+  // CHECK: Opaque result type of opaque_signature.(file).ConcreteTest.f1()@
+  // CHECK-NEXT: Opaque result signature: <τ_0_0 where τ_0_0 : Q>
+  func f1() -> some Q { return G<Int>() }
+
+  // CHECK: Opaque result type of opaque_signature.(file).ConcreteTest.f2()@
+  // CHECK-NEXT: Opaque result signature: <τ_0_0 where τ_0_0 : Q, τ_0_0.[Q]A == Int>
+  func f2() -> some Q<Int> { return G<Int>() }
+
+  // CHECK: Opaque result type of opaque_signature.(file).ConcreteTest.f3()@
+  // CHECK-NEXT: Opaque result signature: <τ_0_0 where τ_0_0 : P, τ_0_0 : Q>
+  func f3() -> some P & Q { return G<Int>() }
+}
+
+struct GenericTest<T: P> {
+  // CHECK: Opaque result type of opaque_signature.(file).GenericTest.f1()@
+  // CHECK-NEXT: Opaque result signature: <T, τ_1_0 where T : P, τ_1_0 : Q>
+  func f1() -> some Q { return G<T.A>() }
+
+  // CHECK: Opaque result type of opaque_signature.(file).GenericTest.f2()@
+  // CHECK-NEXT: Opaque result signature: <T, τ_1_0 where T : P, T.[P]A == τ_1_0.[Q]A, τ_1_0 : Q>
+  func f2() -> some Q<T.A> { return G<T.A>() }
+}


### PR DESCRIPTION
By popular demand.

* **Risk:** None, this changes a code path that is behind a debug flag that is only enabled for tests.

* **Reviewed by:** @kavon