### PR TITLE
[SILOpt] Remove unnecessary pack operations where possible

### DIFF
--- a/lib/SILOptimizer/SILCombiner/SILCombiner.h
+++ b/lib/SILOptimizer/SILCombiner/SILCombiner.h
@@ -291,7 +291,10 @@ public:
   visitDifferentiableFunctionExtractInst(DifferentiableFunctionExtractInst *DFEI);
   
   SILInstruction *visitPackLengthInst(PackLengthInst *PLI);
+  SILInstruction *visitDynamicPackIndexInst(DynamicPackIndexInst *DPII);
+  SILInstruction *visitOpenPackElementInst(OpenPackElementInst *OPEI);
   SILInstruction *visitPackElementGetInst(PackElementGetInst *PEGI);
+  SILInstruction *visitAllocPackInst(AllocPackInst *AP);
   SILInstruction *visitTuplePackElementAddrInst(TuplePackElementAddrInst *TPEAI);
   SILInstruction *visitCopyAddrInst(CopyAddrInst *CAI);
 

--- a/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
@@ -1681,21 +1681,169 @@ SILInstruction *SILCombiner::visitPackLengthInst(PackLengthInst *PLI) {
   return nullptr;
 }
 
-// Simplify `pack_element_get` where the index is a `dynamic_pack_index` with
-// a constant operand.
+// Simplify `dynamic_pack_index` with a constant operand to
+// `scalar_pack_index` when all users can handle the concrete index.
 //
 // Before:
 // %idx = integer_literal Builtin.Word, N
 // %pack_idx = dynamic_pack_index %Pack{Int, String, Float}, %idx
-// %pack_elt = pack_element_get %pack_value, %pack_idx, @element("...")
 //
 // After:
-// %pack_idx = scalar_pack_index %Pack{Int, String, Float}, N
-// %concrete_elt = pack_element_get %pack_value, %pack_idx, <<concrete type>>
-// %pack_elt = unchecked_addr_cast %concrete_elt, @element("...")
+// %pack_idx = scalar_pack_index N of $Pack{Int, String, Float}
+SILInstruction *
+SILCombiner::visitDynamicPackIndexInst(DynamicPackIndexInst *DPII) {
+  auto PackTy = DPII->getIndexedPackType();
+  if (PackTy->containsPackExpansionType())
+    return nullptr;
+
+  auto *Op = dyn_cast<IntegerLiteralInst>(DPII->getOperand());
+  if (!Op)
+    return nullptr;
+
+  if (Op->getValue().uge(PackTy->getNumElements()))
+    return nullptr;
+
+  unsigned Index = Op->getValue().getZExtValue();
+
+  // Verify all users are safe with a scalar index. The verifier requires that
+  // pack_element_set values match the concrete element type when using scalar
+  // indices, and open_pack_element introduces archetypes that violate this.
+  for (auto *use : DPII->getUses()) {
+    auto *user = use->getUser();
+    if (isa<PackElementGetInst>(user) || isa<TuplePackElementAddrInst>(user))
+      continue;
+    if (auto *PESI = dyn_cast<PackElementSetInst>(user)) {
+      auto expectedTy =
+          SILType::getPrimitiveAddressType(PackTy.getElementType(Index));
+      if (PESI->getValue()->getType() == expectedTy)
+        continue;
+    }
+    return nullptr;
+  }
+
+  return Builder.createScalarPackIndex(DPII->getLoc(), Index,
+                                       DPII->getIndexedPackType());
+}
+
+// Eliminate `open_pack_element` when the pack index resolves to a constant,
+// by substituting concrete element types for the opened element archetypes.
+// After this fires, visitDynamicPackIndexInst can convert the index to scalar.
+SILInstruction *
+SILCombiner::visitOpenPackElementInst(OpenPackElementInst *OPEI) {
+  // Resolve the component index.
+  unsigned componentIndex;
+  CanPackType indexedPackType;
+  if (auto *SPII = dyn_cast<ScalarPackIndexInst>(OPEI->getIndexOperand())) {
+    componentIndex = SPII->getComponentIndex();
+    indexedPackType = SPII->getIndexedPackType();
+  } else if (auto *DPII =
+                 dyn_cast<DynamicPackIndexInst>(OPEI->getIndexOperand())) {
+    auto PackTy = DPII->getIndexedPackType();
+    if (PackTy->containsPackExpansionType())
+      return nullptr;
+    auto *Op = dyn_cast<IntegerLiteralInst>(DPII->getOperand());
+    if (!Op)
+      return nullptr;
+    if (Op->getValue().uge(PackTy->getNumElements()))
+      return nullptr;
+    componentIndex = Op->getValue().getZExtValue();
+    indexedPackType = PackTy;
+  } else {
+    return nullptr;
+  }
+
+  // Verify all users of the token are PackElementGetInst (type-dep users).
+  SmallVector<PackElementGetInst *, 4> packElementGets;
+  for (auto *use : OPEI->getUses()) {
+    auto *PEGI = dyn_cast<PackElementGetInst>(use->getUser());
+    if (!PEGI)
+      return nullptr;
+    packElementGets.push_back(PEGI);
+  }
+
+  // Create a scalar pack index for the concrete-typed replacements.
+  Builder.setInsertionPoint(OPEI->getNextInstruction());
+  auto *newScalarIdx = Builder.createScalarPackIndex(
+      OPEI->getLoc(), componentIndex, indexedPackType);
+
+  // Replace each PackElementGetInst with a concrete-typed version.
+  for (auto *PEGI : packElementGets) {
+    auto PackTy = PEGI->getPackType();
+    if (PackTy->containsPackExpansionType())
+      return nullptr;
+    auto concreteElementTy =
+        SILType::getPrimitiveAddressType(PackTy.getElementType(componentIndex));
+
+    Builder.setInsertionPoint(PEGI);
+    auto *newPEGI = Builder.createPackElementGet(
+        PEGI->getLoc(), newScalarIdx, PEGI->getPack(), concreteElementTy);
+
+    replaceInstUsesWith(*PEGI, newPEGI);
+    eraseInstFromFunction(*PEGI);
+  }
+
+  return eraseInstFromFunction(*OPEI);
+}
+
+// Simplify `pack_element_get` when the index is a `scalar_pack_index`, or
+// when a `dynamic_pack_index` with a constant operand can be resolved.
+//
+// Case 1 (scalar index): The pack is a local alloc_pack — forward the value
+// stored by the matching pack_element_set.
+//
+// Case 2 (scalar or dynamic index): The element type is an archetype but can
+// be resolved to a concrete type from the pack type — create a new
+// pack_element_get with the concrete type and cast back.
 SILInstruction *SILCombiner::visitPackElementGetInst(PackElementGetInst *PEGI) {
+  if (auto *SPII = dyn_cast<ScalarPackIndexInst>(PEGI->getIndex())) {
+    // Forward through a local alloc_pack.
+    if (auto *AP = dyn_cast<AllocPackInst>(PEGI->getPack())) {
+      PackElementSetInst *matchingSet = nullptr;
+      for (auto *use : AP->getUses()) {
+        auto *PESI = dyn_cast<PackElementSetInst>(use->getUser());
+        if (!PESI)
+          continue;
+        auto *setIndex = dyn_cast<ScalarPackIndexInst>(PESI->getIndex());
+        if (!setIndex)
+          continue;
+        if (setIndex->getComponentIndex() != SPII->getComponentIndex())
+          continue;
+        if (matchingSet)
+          return nullptr;
+        matchingSet = PESI;
+      }
+
+      if (matchingSet) {
+        SILValue forwardedValue = matchingSet->getValue();
+        if (forwardedValue->getType() == PEGI->getType()) {
+          replaceInstUsesWith(*PEGI, forwardedValue);
+          return eraseInstFromFunction(*PEGI);
+        }
+      }
+    }
+
+    // Resolve to concrete element type.
+    auto PackTy = PEGI->getPackType();
+    if (PackTy->containsPackExpansionType())
+      return nullptr;
+
+    unsigned Index = SPII->getComponentIndex();
+    auto ElementTy =
+        SILType::getPrimitiveAddressType(PackTy.getElementType(Index));
+    if (ElementTy == PEGI->getElementType())
+      return nullptr;
+
+    auto *NewPEGI = Builder.createPackElementGet(PEGI->getLoc(), SPII,
+                                                 PEGI->getPack(), ElementTy);
+    return Builder.createUncheckedAddrCast(PEGI->getLoc(), NewPEGI,
+                                           PEGI->getElementType());
+  }
+
+  // Handle dynamic_pack_index with a constant operand by creating a local
+  // scalar index for this pack_element_get only (other users of the dynamic
+  // index, like open_pack_element or pack_element_set, keep the dynamic index).
   auto *DPII = dyn_cast<DynamicPackIndexInst>(PEGI->getIndex());
-  if (DPII == nullptr)
+  if (!DPII)
     return nullptr;
 
   auto PackTy = PEGI->getPackType();
@@ -1703,60 +1851,71 @@ SILInstruction *SILCombiner::visitPackElementGetInst(PackElementGetInst *PEGI) {
     return nullptr;
 
   auto *Op = dyn_cast<IntegerLiteralInst>(DPII->getOperand());
-  if (Op == nullptr)
+  if (!Op)
     return nullptr;
 
   if (Op->getValue().uge(PackTy->getNumElements()))
     return nullptr;
 
   unsigned Index = Op->getValue().getZExtValue();
-  auto *SPII = Builder.createScalarPackIndex(
-      DPII->getLoc(), Index, DPII->getIndexedPackType());
+  auto *SPII = Builder.createScalarPackIndex(DPII->getLoc(), Index,
+                                             DPII->getIndexedPackType());
 
-  auto ElementTy = SILType::getPrimitiveAddressType(
-      PEGI->getPackType().getElementType(Index));
-  auto *NewPEGI = Builder.createPackElementGet(
-      PEGI->getLoc(), SPII, PEGI->getPack(),
-      ElementTy);
-
-  return Builder.createUncheckedAddrCast(
-      PEGI->getLoc(), NewPEGI, PEGI->getElementType());
+  auto ElementTy =
+      SILType::getPrimitiveAddressType(PackTy.getElementType(Index));
+  auto *NewPEGI = Builder.createPackElementGet(PEGI->getLoc(), SPII,
+                                               PEGI->getPack(), ElementTy);
+  return Builder.createUncheckedAddrCast(PEGI->getLoc(), NewPEGI,
+                                         PEGI->getElementType());
 }
 
-// Simplify `tuple_pack_element_addr` where the index is a `dynamic_pack_index`
-//with a constant operand.
-//
-// Before:
-// %idx = integer_literal Builtin.Word, N
-// %pack_idx = dynamic_pack_index %Pack{Int, String, Float}, %idx
-// %tuple_elt = tuple_pack_element_addr %tuple_value, %pack_idx, @element("...")
-//
-// After:
-// %concrete_elt = tuple_element_addr %tuple_value, N
-// %tuple_elt = unchecked_addr_cast %concrete_elt, @element("...")
+// Eliminate dead alloc_pack instructions whose only users are
+// pack_element_set (dead stores), dealloc_pack, and debug instructions.
+SILInstruction *SILCombiner::visitAllocPackInst(AllocPackInst *AP) {
+  SmallVector<SILInstruction *, 8> toDelete;
+  for (auto *use : AP->getUses()) {
+    auto *user = use->getUser();
+    if (isa<PackElementSetInst>(user) || isa<DeallocPackInst>(user) ||
+        user->isDebugInstruction()) {
+      toDelete.push_back(user);
+    } else {
+      return nullptr;
+    }
+  }
+  for (auto *inst : toDelete)
+    eraseInstFromFunction(*inst);
+  return eraseInstFromFunction(*AP);
+}
+
+// Simplify `tuple_pack_element_addr` when the index is a `scalar_pack_index`
+// or a `dynamic_pack_index` with a constant operand.
 SILInstruction *
 SILCombiner::visitTuplePackElementAddrInst(TuplePackElementAddrInst *TPEAI) {
-  auto *DPII = dyn_cast<DynamicPackIndexInst>(TPEAI->getIndex());
-  if (DPII == nullptr)
+  unsigned Index;
+
+  if (auto *SPII = dyn_cast<ScalarPackIndexInst>(TPEAI->getIndex())) {
+    Index = SPII->getComponentIndex();
+  } else if (auto *DPII = dyn_cast<DynamicPackIndexInst>(TPEAI->getIndex())) {
+    auto PackTy = DPII->getIndexedPackType();
+    if (PackTy->containsPackExpansionType())
+      return nullptr;
+    auto *Op = dyn_cast<IntegerLiteralInst>(DPII->getOperand());
+    if (!Op)
+      return nullptr;
+    if (Op->getValue().uge(PackTy->getNumElements()))
+      return nullptr;
+    Index = Op->getValue().getZExtValue();
+  } else {
     return nullptr;
+  }
 
-  auto PackTy = DPII->getIndexedPackType();
-  if (PackTy->containsPackExpansionType())
-    return nullptr;
+  auto *TEAI =
+      Builder.createTupleElementAddr(TPEAI->getLoc(), TPEAI->getTuple(), Index);
+  if (TEAI->getType() == TPEAI->getType())
+    return TEAI;
 
-  auto *Op = dyn_cast<IntegerLiteralInst>(DPII->getOperand());
-  if (Op == nullptr)
-    return nullptr;
-
-  if (Op->getValue().uge(PackTy->getNumElements()))
-    return nullptr;
-
-  unsigned Index = Op->getValue().getZExtValue();
-
-  auto *TEAI = Builder.createTupleElementAddr(
-      TPEAI->getLoc(), TPEAI->getTuple(), Index);
-  return Builder.createUncheckedAddrCast(
-      TPEAI->getLoc(), TEAI, TPEAI->getElementType());
+  return Builder.createUncheckedAddrCast(TPEAI->getLoc(), TEAI,
+                                         TPEAI->getElementType());
 }
 
 // This is a hack. When optimizing a simple pack expansion expression which

--- a/test/SILOptimizer/pack_element_forwarding_test.swift
+++ b/test/SILOptimizer/pack_element_forwarding_test.swift
@@ -1,0 +1,57 @@
+// RUN: %target-swift-frontend -parse-as-library -O -target %module-target-future -emit-sil %s | %FileCheck %s
+
+@resultBuilder
+struct ViewBuilderParameterPack {
+    @inline(always)
+    static func buildExpression<Content: View>(_ content: Content) -> Content {
+       content
+    }
+
+    @inline(always)
+    static func buildBlock<Content: View>(_ content: Content) -> Content {
+        content
+    }
+
+    @_disfavoredOverload
+    @inline(always)
+    static func buildBlock<each Content: View>(_ content: repeat each Content) -> TupleView<(repeat each Content)> {
+        TupleView((repeat each content))
+    }
+}
+
+public struct TupleView<each Content>: View {
+    var content: (repeat each Content)
+
+    @inline(always)
+    init(_ content: (repeat each Content)) {
+        self.content = content
+    }
+
+    @_disfavoredOverload
+    @inline(always)
+    init(_ content: repeat each Content) {
+        self.init((repeat each content))
+    }
+}
+
+@ViewBuilderParameterPack
+public func bodyParameterPacks2() -> some View {
+    MyView()
+    MyView()
+}
+
+final class MyClass {}
+
+public protocol View {}
+public struct MyView: View {
+    var storage: InlineArray<10, MyClass> = .init(repeating: MyClass())
+    @inline(never)
+    init() {}
+}
+
+// CHECK-LABEL: sil @$s28pack_element_forwarding_test19bodyParameterPacks2QryF
+// CHECK-NOT: alloc_pack
+// CHECK-NOT: pack_element_set
+// CHECK-NOT: pack_element_get
+// CHECK-NOT: dealloc_pack
+// CHECK: } // end sil function '$s28pack_element_forwarding_test19bodyParameterPacks2QryF'

--- a/test/SILOptimizer/tuples_from_packs.swift
+++ b/test/SILOptimizer/tuples_from_packs.swift
@@ -4,74 +4,29 @@
   return (repeat each t)
 }
 
-// FIXME: Useless alloc_pack/dealloc_pack
-
 // CHECK-LABEL: sil @$s17tuples_from_packs14makeEmptyTupleyyF : $@convention(thin) () -> () {
 // CHECK: bb0:
-// CHECK-NEXT: %0 = alloc_pack $Pack{}
-// CHECK-NEXT: %1 = alloc_pack $Pack{}
-// CHECK-NEXT: dealloc_pack %1 : $*Pack{}
-// CHECK-NEXT: dealloc_pack %0 : $*Pack{}
 // CHECK-NEXT: [[RET:%.*]] = tuple ()
 // CHECK-NEXT: return [[RET]] : $()
 public func makeEmptyTuple() {
   return makeTuple()
 }
 
-// FIXME: Useless pack_element_set/pack_element_get
-
 // CHECK-LABEL: sil @$s17tuples_from_packs7makeOneyxxlF : $@convention(thin) <T> (@in_guaranteed T) -> @out T {
 // CHECK: bb0(%0 : $*T, %1 : $*T):
-// CHECK: [[PACK:%.*]] = alloc_pack $Pack{T}
-// CHECK-NEXT: [[IDX:%.*]] = scalar_pack_index 0 of $Pack{T}
-// CHECK-NEXT: pack_element_set %0 : $*T into [[IDX]] of [[PACK]] : $*Pack{T}
-// CHECK-NEXT: [[PACK2:%.*]] = alloc_pack $Pack{T}
-// CHECK-NEXT: [[BOX:%.*]] = alloc_stack $T
-// CHECK-NEXT: copy_addr %1 to [init] [[BOX]] : $*T
-// CHECK-NEXT: pack_element_set [[BOX]] : $*T into [[IDX]] of [[PACK2]] : $*Pack{T}
-// CHECK-NEXT: [[ELT:%.*]] = pack_element_get [[IDX]] of [[PACK]] : $*Pack{T} as $*T
-// CHECK-NEXT: [[ELT2:%.*]] = pack_element_get [[IDX]] of [[PACK2]] : $*Pack{T} as $*T
-// CHECK-NEXT: copy_addr [[ELT2]] to [init] [[ELT]] : $*T
-// CHECK-NEXT: destroy_addr [[BOX]] : $*T
-// CHECK-NEXT: dealloc_stack [[BOX]] : $*T
-// CHECK-NEXT: dealloc_pack [[PACK2]] : $*Pack{T}
-// CHECK-NEXT: dealloc_pack [[PACK]] : $*Pack{T}
+// CHECK: copy_addr %1 to [init] %0 : $*T
 // CHECK-NEXT: [[RET:%.*]] = tuple ()
 // CHECK-NEXT: return [[RET]] : $()
 public func makeOne<T>(_ t: T) -> T {
   return makeTuple(t)
 }
 
-// FIXME: Useless pack_element_set/pack_element_get
-
 // CHECK-LABEL: sil @$s17tuples_from_packs8makePairyx_q_tx_q_tr0_lF : $@convention(thin) <T, U> (@in_guaranteed T, @in_guaranteed U) -> (@out T, @out U) {
 // CHECK: bb0(%0 : $*T, %1 : $*U, %2 : $*T, %3 : $*U):
-// CHECK:      [[PACK:%.*]] = alloc_pack $Pack{T, U}
-// CHECK-NEXT: [[IDX0:%.*]] = scalar_pack_index 0 of $Pack{T, U}
-// CHECK-NEXT: pack_element_set %0 : $*T into [[IDX0]] of [[PACK]] : $*Pack{T, U}
-// CHECK-NEXT: [[IDX1:%.*]] = scalar_pack_index 1 of $Pack{T, U}
-// CHECK-NEXT: pack_element_set %1 : $*U into [[IDX1]] of [[PACK]] : $*Pack{T, U}
-// CHECK-NEXT: [[PACK2:%.*]] = alloc_pack $Pack{T, U}
-// CHECK-NEXT: [[T:%.*]] = alloc_stack $T
-// CHECK-NEXT: copy_addr %2 to [init] [[T]] : $*T
-// CHECK-NEXT: pack_element_set [[T]] : $*T into [[IDX0]] of [[PACK2]] : $*Pack{T, U}
-// CHECK-NEXT: [[U:%.*]] = alloc_stack $U
-// CHECK-NEXT: copy_addr %3 to [init] [[U]] : $*U
-// CHECK-NEXT: pack_element_set [[U]] : $*U into [[IDX1]] of [[PACK2]] : $*Pack{T, U}
-// CHECK-NEXT: [[ELT0:%.*]] = pack_element_get [[IDX0]] of [[PACK]] : $*Pack{T, U} as $*T
-// CHECK-NEXT: [[ELT02:%.*]] = pack_element_get [[IDX0]] of [[PACK2]] : $*Pack{T, U} as $*T
-// CHECK-NEXT: copy_addr [[ELT02]] to [init] [[ELT0]] : $*T
-// CHECK-NEXT: [[ELT1:%.*]] = pack_element_get [[IDX1]] of [[PACK]] : $*Pack{T, U} as $*U
-// CHECK-NEXT: [[ELT12:%.*]] = pack_element_get [[IDX1]] of [[PACK2]] : $*Pack{T, U} as $*U
-// CHECK-NEXT: copy_addr [[ELT12]] to [init] [[ELT1]] : $*U
-// CHECK-NEXT: destroy_addr [[U]] : $*U
-// CHECK-NEXT: dealloc_stack [[U]] : $*U
-// CHECK-NEXT: destroy_addr [[T]] : $*T
-// CHECK-NEXT: dealloc_stack [[T]] : $*T
-// CHECK-NEXT: dealloc_pack [[PACK2]] : $*Pack{T, U}
-// CHECK-NEXT: dealloc_pack [[PACK]] : $*Pack{T, U}
-// CHECK-NEXT: %30 = tuple ()
-// CHECK-NEXT: return %30 : $()
+// CHECK: copy_addr %2 to [init] %0 : $*T
+// CHECK-NEXT: copy_addr %3 to [init] %1 : $*U
+// CHECK-NEXT: [[RET:%.*]] = tuple ()
+// CHECK-NEXT: return [[RET]] : $()
 
 public func makePair<T, U>(_ t: T, _ u: U) -> (T, U) {
   return makeTuple(t, u)


### PR DESCRIPTION
rdar://175417934

After specializing parameter packs, the call site still allocated, wrote to and then read again from parameter packs. This change adds two optimizations to SILCombiner:

1. Pack element forwarding: When pack_element_get reads from an alloc_pack at a scalar_pack_index, find the unique matching pack_element_set and forward the stored value directly, eliminating the pack as intermediary.

2. Dead pack elimination: After forwarding removes all reads, eliminate alloc_pack instructions whose only remaining users are dead stores (pack_element_set), dealloc_pack, and debug instructions.

The resulting code should be equivalent to calling a manually specialized version of the function directly.
