### PR TITLE
embedded: fix a compiler crash due to not de-virtualized InlineArray element deinits

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/Devirtualization.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/Devirtualization.swift
@@ -53,6 +53,10 @@ private func devirtualize(destroy: some DevirtualizableDestroy,
     return true
   }
 
+  if type.isBuiltinFixedArray {
+    return devirtualizeFixedSizeArray(destroy: destroy, isMandatory: isMandatory, context)
+  }
+
   guard let nominal = type.nominal else {
     // E.g. a non-copyable generic function parameter
     return true
@@ -99,6 +103,32 @@ private func devirtualize(destroy: some DevirtualizableDestroy,
   return true
 }
 
+private func devirtualizeFixedSizeArray(destroy: some DevirtualizableDestroy,
+                                        isMandatory: Bool,
+                                        _ context: some MutatingContext
+) -> Bool {
+  guard let arraySize = destroy.type.builtinFixedArraySizeType.valueOfInteger else {
+    return false
+  }
+  let elementType = destroy.type.builtinFixedArrayElementType(in: destroy.parentFunction)
+
+  let destroyAddr = destroy.materializeAsDestroyAddr(context)
+
+  let builder = Builder(before: destroyAddr, context)
+  let base = builder.createVectorBaseAddr(vector: destroyAddr.destroyedAddress)
+  let count = builder.createIntegerLiteral(arraySize, type: context.getBuiltinWordType())
+
+  let success = createArrayDestroyLoop(baseAddress: base,
+                                       arrayCount: count,
+                                       elementType: elementType,
+                                       insertionPoint: destroyAddr,
+                                       isMandatory: isMandatory,
+                                       context)
+
+  context.erase(instruction: destroyAddr)
+  return success
+}
+
 // Used to dispatch devirtualization tasks to `destroy_value` and `destroy_addr`.
 private protocol DevirtualizableDestroy : UnaryInstruction {
   var shouldDropDeinit: Bool { get }
@@ -109,6 +139,7 @@ private protocol DevirtualizableDestroy : UnaryInstruction {
                                isMandatory: Bool,
                                _ context: some MutatingContext) -> Bool
   func createSwitchEnum(atEndOf block: BasicBlock, cases: [(Int, BasicBlock)], _ context: some MutatingContext)
+  func materializeAsDestroyAddr(_ context: some MutatingContext) -> DestroyAddrInst
 }
 
 private extension DevirtualizableDestroy {
@@ -215,6 +246,16 @@ extension DestroyValueInst : DevirtualizableDestroy {
     let builder = Builder(atEndOf: block, location: location, context)
     builder.createSwitchEnum(enum: destroyedValue, cases: cases)
   }
+
+  fileprivate func materializeAsDestroyAddr(_ context: some MutatingContext) -> DestroyAddrInst {
+    let builder = Builder(before: self, context)
+    let allocStack = builder.createAllocStack(destroyedValue.type)
+    builder.createStore(source: destroyedValue, destination: allocStack, ownership: .initialize)
+    let destroyAddr = builder.createDestroyAddr(address: allocStack)
+    builder.createDeallocStack(allocStack)
+    context.erase(instruction: self)
+    return destroyAddr
+  }
 }
 
 extension DestroyAddrInst : DevirtualizableDestroy {
@@ -286,6 +327,10 @@ extension DestroyAddrInst : DevirtualizableDestroy {
     let builder = Builder(atEndOf: block, location: location, context)
     builder.createSwitchEnumAddr(enumAddress: destroyedAddress, cases: cases)
   }
+
+  fileprivate func materializeAsDestroyAddr(_ context: some MutatingContext) -> DestroyAddrInst {
+    return self
+  }
 }
 
 private func devirtualize(builtinDestroyArray: BuiltinInst,
@@ -296,50 +341,66 @@ private func devirtualize(builtinDestroyArray: BuiltinInst,
   let elementType = builtinDestroyArray.substitutionMap.replacementType.loweredType(in: function)
   guard elementType.isMoveOnly,
         // This avoids lowering the loop if the element is a non-copyable generic type.
-        (elementType.isStruct || elementType.isEnum)
+        (elementType.isStruct || elementType.isEnum || elementType.isBuiltinFixedArray)
   else {
     return true
   }
 
   // Lower the `builtin "destroyArray" to a loop which destroys all elements
 
-  let basePointer = builtinDestroyArray.arguments[1]
-  let arrayCount = builtinDestroyArray.arguments[2]
+  let builder = Builder(before: builtinDestroyArray, context)
+  let baseAddress = builder.createPointerToAddress(pointer: builtinDestroyArray.arguments[1],
+                                                   addressType: elementType.addressType,
+                                                   isStrict: true, isInvariant: false)
+
+  let success = createArrayDestroyLoop(baseAddress: baseAddress,
+                                       arrayCount: builtinDestroyArray.arguments[2],
+                                       elementType: elementType,
+                                       insertionPoint: builtinDestroyArray,
+                                       isMandatory: isMandatory,
+                                       context)
+
+  context.erase(instruction: builtinDestroyArray)
+  return success
+}
+
+private func createArrayDestroyLoop(baseAddress: Value,
+                                    arrayCount: Value,
+                                    elementType: Type,
+                                    insertionPoint: Instruction,
+                                    isMandatory: Bool,
+                                    _ context: some MutatingContext
+) -> Bool {
   let indexType = arrayCount.type
   let boolType = context.getBuiltinIntegerType(bitWidth: 1)
 
-  let preheaderBlock = builtinDestroyArray.parentBlock
-  let exitBlock = context.splitBlock(after: builtinDestroyArray)
+  let preheaderBlock = insertionPoint.parentBlock
+  let exitBlock = context.splitBlock(after: insertionPoint)
   let headerBlock = context.createBlock(after: preheaderBlock)
   let bodyBlock = context.createBlock(after: headerBlock)
 
-  let preheaderBuilder = Builder(atEndOf: preheaderBlock, location: builtinDestroyArray.location, context)
+  let preheaderBuilder = Builder(atEndOf: preheaderBlock, location: insertionPoint.location, context)
   let zero = preheaderBuilder.createIntegerLiteral(0, type: indexType)
   let one = preheaderBuilder.createIntegerLiteral(1, type: indexType)
   let falseValue = preheaderBuilder.createBoolLiteral(false);
-  let baseAddress = preheaderBuilder.createPointerToAddress(pointer: basePointer,
-                                                            addressType: elementType.addressType,
-                                                            isStrict: true, isInvariant: false)
   preheaderBuilder.createBranch(to: headerBlock, arguments: [zero])
 
   let inductionVariable = headerBlock.addArgument(type: indexType, ownership: .none, context)
-  let headerBuilder = Builder(atEndOf: headerBlock, location: builtinDestroyArray.location, context)
+  let headerBuilder = Builder(atEndOf: headerBlock, location: insertionPoint.location, context)
   let cmp = headerBuilder.createBuiltinBinaryFunction(name: "cmp_slt", operandType: indexType, resultType: boolType,
                                                       arguments: [inductionVariable, arrayCount])
   headerBuilder.createCondBranch(condition: cmp, trueBlock: bodyBlock, falseBlock: exitBlock)
 
-  let bodyBuilder = Builder(atEndOf: bodyBlock, location: builtinDestroyArray.location, context)
+  let bodyBuilder = Builder(atEndOf: bodyBlock, location: insertionPoint.location, context)
   let elementAddr = bodyBuilder.createIndexAddr(base: baseAddress, index: inductionVariable,
                                                 needStackProtection: false)
   let destroy = bodyBuilder.createDestroyAddr(address: elementAddr)
-  let resultType = context.getTupleType(elements: [indexType, boolType]).loweredType(in: function)
+  let resultType = context.getTupleType(elements: [indexType, boolType]).loweredType(in: insertionPoint.parentFunction)
   let increment = bodyBuilder.createBuiltinBinaryFunction(name: "sadd_with_overflow", operandType: indexType,
                                                           resultType: resultType,
                                                           arguments: [inductionVariable, one, falseValue])
   let incrResult = bodyBuilder.createTupleExtract(tuple: increment, elementIndex: 0)
   bodyBuilder.createBranch(to: headerBlock, arguments: [incrResult])
-
-  context.erase(instruction: builtinDestroyArray)
 
   return devirtualize(destroy: destroy, isMandatory: isMandatory, context)
 }

--- a/SwiftCompilerSources/Sources/SIL/Context.swift
+++ b/SwiftCompilerSources/Sources/SIL/Context.swift
@@ -48,6 +48,8 @@ extension Context {
 
   public func getBuiltinIntegerType(bitWidth: Int) -> Type { _bridged.getBuiltinIntegerType(bitWidth).type }
 
+  public func getBuiltinWordType() -> Type { _bridged.getBuiltinWordType().type }
+
   public func getTupleType(elements: [Type]) -> AST.`Type` {
     return getTupleType(elements: elements.map{ $0.rawType })
   }

--- a/include/swift/AST/ASTBridgingImpl.h
+++ b/include/swift/AST/ASTBridgingImpl.h
@@ -764,7 +764,9 @@ BridgedASTType::MetatypeRepresentation BridgedASTType::getRepresentationOfMetaty
 }
 
 BridgedOptionalInt BridgedASTType::getValueOfIntegerType() const {
-  return getFromAPInt(unbridged()->getAs<swift::IntegerType>()->getValue());
+  if (auto *intType = unbridged()->getAs<swift::IntegerType>())
+    return getFromAPInt(intType->getValue());
+  return BridgedOptionalInt();
 }
 
 BridgedSubstitutionMap BridgedASTType::getContextSubstitutionMap() const {

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -1545,6 +1545,7 @@ struct BridgedContext {
   SWIFT_IMPORT_UNSAFE OptionalBridgedFunction lookUpNominalDeinitFunction(BridgedDeclObj nominal) const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedSubstitutionMap getContextSubstitutionMap(BridgedType type) const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedType getBuiltinIntegerType(SwiftInt bitWidth) const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedType getBuiltinWordType() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedASTType getTupleType(BridgedArrayRef elementTypes) const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedASTType getTupleTypeWithLabels(
       BridgedArrayRef elementTypes, BridgedArrayRef labels) const;

--- a/include/swift/SIL/SILBridgingImpl.h
+++ b/include/swift/SIL/SILBridgingImpl.h
@@ -3214,6 +3214,10 @@ BridgedType BridgedContext::getBuiltinIntegerType(SwiftInt bitWidth) const {
   return swift::SILType::getBuiltinIntegerType(bitWidth, context->getModule()->getASTContext());
 }
 
+BridgedType BridgedContext::getBuiltinWordType() const {
+  return swift::SILType::getBuiltinWordType(context->getModule()->getASTContext());
+}
+
 BridgedASTType BridgedContext::getTupleType(BridgedArrayRef elementTypes) const {
   llvm::SmallVector<swift::TupleTypeElt, 8> elements;
   for (auto bridgedElmtTy :  elementTypes.unbridged<BridgedASTType>()) {

--- a/test/SILOptimizer/devirt_deinits.sil
+++ b/test/SILOptimizer/devirt_deinits.sil
@@ -319,10 +319,10 @@ bb0(%0 : $*S1):
 }
 
 // CHECK-LABEL: sil [ossa] @test_destroyArray :
+// CHECK:         [[PTA:%.*]] = pointer_to_address %0 : $Builtin.RawPointer to [strict] $*S1
 // CHECK:         [[ZERO:%.*]] = integer_literal $Builtin.Word, 0
 // CHECK:         [[ONE:%.*]] = integer_literal $Builtin.Word, 1
 // CHECK:         [[FALSE:%.*]] = integer_literal $Builtin.Int1, 0
-// CHECK:         [[PTA:%.*]] = pointer_to_address %0 : $Builtin.RawPointer to [strict] $*S1
 // CHECK:         br bb1([[ZERO]] : $Builtin.Word)
 // CHECK:       bb1([[IV:%.*]] : $Builtin.Word):
 // CHECK:         [[CMP:%.*]] = builtin "cmp_slt_Word"([[IV]] : $Builtin.Word, %1 : $Builtin.Word)
@@ -335,7 +335,7 @@ bb0(%0 : $*S1):
 // CHECK:         [[ADD:%.*]] = builtin "sadd_with_overflow_Word"([[IV]] : $Builtin.Word, [[ONE]] : $Builtin.Word, [[FALSE]] : $Builtin.Int1)
 // CHECK:         [[INCR:%.*]] = tuple_extract [[ADD]] : $(Builtin.Word, Builtin.Int1), 0
 // CHECK:         br bb1([[INCR]] : $Builtin.Word)
-// CHECKL       bb3:
+// CHECK:       bb3:
 // CHECK:       } // end sil function 'test_destroyArray'
 sil [ossa] @test_destroyArray : $@convention(thin) (Builtin.RawPointer, Builtin.Word) -> () {
 bb0(%0 : $Builtin.RawPointer, %1 : $Builtin.Word):
@@ -344,6 +344,78 @@ bb0(%0 : $Builtin.RawPointer, %1 : $Builtin.Word):
   %r = tuple ()
   return %r
 }
+
+// CHECK-LABEL: sil [ossa] @testDestroyInlineArray :
+// CHECK:         [[DS:%.*]] = destructure_struct %0
+// CHECK:         [[AS:%.*]] = alloc_stack $Builtin.FixedArray<20, S1>
+// CHECK:         store [[DS]] to [init] [[AS]]
+// CHECK:         [[VB:%.*]] = vector_base_addr [[AS]]
+// CHECK:         [[COUNT:%.*]] = integer_literal $Builtin.Word, 20
+// CHECK:         [[ZERO:%.*]] = integer_literal $Builtin.Word, 0
+// CHECK:         [[ONE:%.*]] = integer_literal $Builtin.Word, 1
+// CHECK:         [[FALSE:%.*]] = integer_literal $Builtin.Int1, 0
+// CHECK:         br bb1([[ZERO]] : $Builtin.Word)
+// CHECK:       bb1([[IV:%.*]] : $Builtin.Word):
+// CHECK:         [[CMP:%.*]] = builtin "cmp_slt_Word"([[IV]] : $Builtin.Word, [[COUNT]] : $Builtin.Word)
+// CHECK:         cond_br [[CMP]], bb2, bb3
+// CHECK:       bb2:
+// CHECK:         [[ADDR:%.*]] = index_addr [[VB]] :  $*S1, [[IV]]
+// CHECK:         [[DEINIT:%.*]] = function_ref @s1_deinit :
+// CHECK:         [[ELEMENT:%.*]] = load [take] [[ADDR]]
+// CHECK:         apply [[DEINIT]]([[ELEMENT]])
+// CHECK:         [[ADD:%.*]] = builtin "sadd_with_overflow_Word"([[IV]] : $Builtin.Word, [[ONE]] : $Builtin.Word, [[FALSE]] : $Builtin.Int1)
+// CHECK:         [[INCR:%.*]] = tuple_extract [[ADD]] : $(Builtin.Word, Builtin.Int1), 0
+// CHECK:         br bb1([[INCR]] : $Builtin.Word)
+// CHECK:       bb3:
+// CHECK:         dealloc_stack [[AS]]
+// CHECK:       } // end sil function 'testDestroyInlineArray'
+sil [ossa] @testDestroyInlineArray : $@convention(thin) (@owned InlineArray<20, S1>) -> () {
+bb0(%0 : @owned $InlineArray<20, S1>):
+  %1 = destructure_struct %0
+  destroy_value %1
+  %3 = tuple ()
+  return %3
+}
+
+// CHECK-LABEL: sil [ossa] @testDestroyAddrInlineArray :
+// CHECK:         [[VB:%.*]] = vector_base_addr %1
+// CHECK:         [[COUNT:%.*]] = integer_literal $Builtin.Word, 20
+// CHECK:         [[ZERO:%.*]] = integer_literal $Builtin.Word, 0
+// CHECK:         [[ONE:%.*]] = integer_literal $Builtin.Word, 1
+// CHECK:         [[FALSE:%.*]] = integer_literal $Builtin.Int1, 0
+// CHECK:         br bb1([[ZERO]] : $Builtin.Word)
+// CHECK:       bb1([[IV:%.*]] : $Builtin.Word):
+// CHECK:         [[CMP:%.*]] = builtin "cmp_slt_Word"([[IV]] : $Builtin.Word, [[COUNT]] : $Builtin.Word)
+// CHECK:         cond_br [[CMP]], bb2, bb3
+// CHECK:       bb2:
+// CHECK:         [[ADDR:%.*]] = index_addr [[VB]] :  $*S1, [[IV]]
+// CHECK:         [[DEINIT:%.*]] = function_ref @s1_deinit :
+// CHECK:         [[ELEMENT:%.*]] = load [take] [[ADDR]]
+// CHECK:         apply [[DEINIT]]([[ELEMENT]])
+// CHECK:         [[ADD:%.*]] = builtin "sadd_with_overflow_Word"([[IV]] : $Builtin.Word, [[ONE]] : $Builtin.Word, [[FALSE]] : $Builtin.Int1)
+// CHECK:         [[INCR:%.*]] = tuple_extract [[ADD]] : $(Builtin.Word, Builtin.Int1), 0
+// CHECK:         br bb1([[INCR]] : $Builtin.Word)
+// CHECK:       bb3:
+// CHECK:       } // end sil function 'testDestroyAddrInlineArray'
+sil [ossa] @testDestroyAddrInlineArray : $@convention(thin) (@in InlineArray<20, S1>) -> () {
+bb0(%0 : $*InlineArray<20, S1>):
+  %1 = struct_element_addr %0, #InlineArray._storage
+  destroy_addr %1
+  %3 = tuple ()
+  return %3
+}
+
+// CHECK-LABEL: sil [ossa] @testNonConstInlineArray :
+// CHECK:         destroy_addr %1
+// CHECK:       } // end sil function 'testNonConstInlineArray'
+sil [ossa] @testNonConstInlineArray : $@convention(thin) <let N: Int> (@in InlineArray<N, S1>) -> () {
+bb0(%0 : $*InlineArray<N, S1>):
+  %1 = struct_element_addr %0, #InlineArray._storage
+  destroy_addr %1
+  %3 = tuple ()
+  return %3
+}
+
 
 // CHECK-LABEL: sil [serialized] [ossa] @dont_create_non_public_function_ref_in_serialized_func :
 // CHECK-NOT:     function_ref

--- a/test/SILOptimizer/devirt_deinits.swift
+++ b/test/SILOptimizer/devirt_deinits.swift
@@ -1,14 +1,13 @@
-// RUN: %target-swift-frontend -target %target-cpu-apple-macos14 -primary-file %s -parse-as-library -O -sil-verify-all -module-name=test -Xllvm -sil-disable-pass=function-signature-opts -emit-sil | %FileCheck %s
+// RUN: %target-swift-frontend -primary-file %s -disable-availability-checking -parse-as-library -O -sil-verify-all -module-name=test -Xllvm -sil-disable-pass=function-signature-opts -emit-sil | %FileCheck %s
 
 // Also do an end-to-end test and check if the compiled executable works as expected.
-// RUN: %target-run-simple-swift(-target %target-cpu-apple-macos14 -parse-as-library -O -Xllvm -sil-disable-pass=function-signature-opts) | %FileCheck -check-prefix CHECK-OUTPUT %s
+// RUN: %target-run-simple-swift(-parse-as-library -O -disable-availability-checking -Xllvm -sil-disable-pass=function-signature-opts) | %FileCheck -check-prefix CHECK-OUTPUT %s
 
 // Check if it works in embedded mode.
 // RUN: %target-run-simple-swift(-target %target-cpu-apple-macos14 -enable-experimental-feature Embedded -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck -check-prefix CHECK-OUTPUT %s
 
 // Run without the deinit-devirtualizer to verify that our CHECK-OUTPUT lines are correct.
-// TODO: currently disabled because of rdar://118449507
-// RUNx: %target-run-simple-swift(-target %target-cpu-apple-macos14 -Xllvm -sil-disable-pass=deinit-devirtualizer -parse-as-library) | %FileCheck -check-prefix CHECK-OUTPUT %s
+// RUN: %target-run-simple-swift(-disable-availability-checking -Xllvm -sil-disable-pass=deinit-devirtualizer -parse-as-library) | %FileCheck -check-prefix CHECK-OUTPUT %s
 
 
 // REQUIRES: swift_in_compiler
@@ -22,6 +21,7 @@
 // REQUIRES: swift_feature_Embedded
 
 // UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
 
 @inline(never)
 func log(_ s: StaticString) {
@@ -157,6 +157,17 @@ func testDestroyArray(_ p: UnsafeMutableBufferPointer<S4>) {
   p.deinitialize()
 }
 
+// CHECK-LABEL: sil hidden [noinline] @$s4test0A11InlineArrayyys0bC0Vy$2_AA2S1VGnF :
+// CHECK:         [[D:%.*]] = function_ref @$s4test2S1VfD :
+// CHECK:         apply [[D]]
+// CHECK-NOT:     destroy
+// CHECK:       } // end sil function '$s4test0A11InlineArrayyys0bC0Vy$2_AA2S1VGnF'
+@inline(never)
+func testInlineArray(_ a: consuming InlineArray<3, S1>) {
+  log("### testInlineArray")
+}
+
+
 
 @main
 struct Main {
@@ -218,6 +229,14 @@ struct Main {
     log("### testDestroyArray")
     testDestroyArray(b)
     b.deallocate()
+    log("---")
+
+    // CHECK-OUTPUT-LABEL: ### testInlineArray
+    // CHECK-OUTPUT-NEXT:  deinit S1
+    // CHECK-OUTPUT-NEXT:  deinit S1
+    // CHECK-OUTPUT-NEXT:  deinit S1
+    // CHECK-OUTPUT-NEXT:  ---
+    testInlineArray([S1(), S1(), S1()])
     log("---")
   }
 }


### PR DESCRIPTION
- **Explanation**:
Deinit-devirtualization is especially important for Embedded Swift because non de-virtualized deinits result in IRGen crashes.
This change adds support for de-virtualize deinits of non-copyable InlineArray elements. It reuses existing code for de-virtualizing `destroyArray` builtins.

- **Scope**:
Affects code which uses InlineArray with non-copyable elements which have a deinit

- **Issues**:
rdar://175984319

- **Risk**:
Low. The change only affects code which uses InlineArray with non-copyable elements which have a deinit.

- **Testing**:
Tested by lit tests

- **Reviewers**:
@meg-gupta
