### PR TITLE
[test] add a required availability guard

### DIFF
--- a/test/stdlib/TemporaryAllocation.swift
+++ b/test/stdlib/TemporaryAllocation.swift
@@ -7,29 +7,34 @@ import SwiftShims
 var TemporaryAllocationTestSuite = TestSuite("TemporaryAllocation")
 
 func isStackAllocated(_ pointer: UnsafeRawPointer) -> Bool? {
-    var stackBegin: UInt = 0
-    var stackEnd: UInt = 0
-    if unsafe _swift_stdlib_getCurrentStackBounds(&stackBegin, &stackEnd) {
-        let pointerValue = UInt(bitPattern: pointer)
-        return pointerValue >= stackBegin && pointerValue < stackEnd
-    }
+  guard #available(SwiftStdlib 5.6, *)
+  else {
     return nil
+  }
+
+  var stackBegin: UInt = 0
+  var stackEnd: UInt = 0
+  if unsafe _swift_stdlib_getCurrentStackBounds(&stackBegin, &stackEnd) {
+    let pointerValue = UInt(bitPattern: pointer)
+    return pointerValue >= stackBegin && pointerValue < stackEnd
+  }
+  return nil
 }
 
 func expectStackAllocated(_ pointer: UnsafeRawPointer) {
-    if let stackAllocated = unsafe isStackAllocated(pointer) {
-        expectTrue(stackAllocated)
-    } else {
-        // Could not read stack bounds. Skip.
-    }
+  if let stackAllocated = unsafe isStackAllocated(pointer) {
+    expectTrue(stackAllocated)
+  } else {
+    // Could not read stack bounds. Skip.
+  }
 }
 
 func expectNotStackAllocated(_ pointer: UnsafeRawPointer) {
-    if let stackAllocated = unsafe isStackAllocated(pointer) {
-        expectFalse(stackAllocated)
-    } else {
-        // Could not read stack bounds. Skip.
-    }
+  if let stackAllocated = unsafe isStackAllocated(pointer) {
+    expectFalse(stackAllocated)
+  } else {
+    // Could not read stack bounds. Skip.
+  }
 }
 
 // MARK: Untyped buffers


### PR DESCRIPTION
When testing `withTemporaryAllocation()` on back-deployed targets, an availability guard is needed in one of the utility test functions. This has been a discrepancy between the GitHub repo and the internal branch for years, and there is no reason for this discrepancy to exist.

- **Scope**:
Just this test file.

- **Issues**:
rdar://176162287

- **Risk**:
Low.

- **Testing**:
The test still passes