### PR TITLE
[Concurrency] SILGen: Emit special closures that behave like `nonisolated(nonsending)`

### DIFF
--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -268,7 +268,7 @@ protected:
     Kind : 2
   );
 
-  SWIFT_INLINE_BITFIELD(ClosureExpr, AbstractClosureExpr, 1+1+1+1+1+1+1+1+1+1,
+  SWIFT_INLINE_BITFIELD(ClosureExpr, AbstractClosureExpr, 1+1+1+1+1+1+1+1+1+1+1,
     /// True if closure parameters were synthesized from anonymous closure
     /// variables.
     HasAnonymousClosureVars : 1,
@@ -307,7 +307,15 @@ protected:
 
     /// True if this is a closure literal that is passed as an argument to a
     /// call that references `nonisolated(nonsending)` declaration.
-    IsPassedToNonisolatedNonsendingCall : 1
+    IsPassedToNonisolatedNonsendingCall : 1,
+
+    /// True if this closure, even though it has a different static isolation,
+    /// should behave like `nonisolated(nonsending)` when lowered. This is important
+    /// for cases where a closure is passed to a non-sending `nonisolated(nonsending)`
+    /// parameter of a `nonisolated(nonsending)` call and doesn't leave isolation of
+    /// the parent context. It's easier to work with statically known isolation than
+    /// make closure dynamically isolated via assuming `nonisolated(nonsending)`.
+    BehavesLikeNonisolatedNonsending: 1
   );
 
   SWIFT_INLINE_BITFIELD_FULL(BindOptionalExpr, Expr, 16,
@@ -4322,6 +4330,7 @@ public:
     Bits.ClosureExpr.RequiresDynamicIsolationChecking = false;
     Bits.ClosureExpr.IsMacroArgument = false;
     Bits.ClosureExpr.IsPassedToNonisolatedNonsendingCall = false;
+    Bits.ClosureExpr.BehavesLikeNonisolatedNonsending = false;
   }
 
   SourceRange getSourceRange() const;
@@ -4440,6 +4449,21 @@ public:
 
   void setIsPassedToNonisolatedNonsendingCall(bool value = true) {
     Bits.ClosureExpr.IsPassedToNonisolatedNonsendingCall = value;
+  }
+
+  /// Determines whether this closure, even though it has a different static
+  /// isolation, should behave like `nonisolated(nonsending)` when lowered. This
+  /// is important for cases where a closure is passed to a non-sending
+  /// `nonisolated(nonsending)` parameter of a `nonisolated(nonsending)` call
+  /// and doesn't leave isolation of the parent context. It's easier to work with
+  /// statically known isolation than make closure dynamically isolated via
+  /// assuming `nonisolated(nonsending)`.
+  bool behavesLikeNonisolatedNonsending() const {
+    return Bits.ClosureExpr.BehavesLikeNonisolatedNonsending;
+  }
+
+  void setBehavesLikeNonisolatedNonsending(bool value = true) {
+    Bits.ClosureExpr.BehavesLikeNonisolatedNonsending = value;
   }
 
   /// Determine whether this closure expression has an

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -268,7 +268,7 @@ protected:
     Kind : 2
   );
 
-  SWIFT_INLINE_BITFIELD(ClosureExpr, AbstractClosureExpr, 1+1+1+1+1+1+1+1+1+1+1,
+  SWIFT_INLINE_BITFIELD(ClosureExpr, AbstractClosureExpr, 1+1+1+1+1+1+1+1+1+1,
     /// True if closure parameters were synthesized from anonymous closure
     /// variables.
     HasAnonymousClosureVars : 1,
@@ -304,10 +304,6 @@ protected:
     /// is only populated after type-checking, and only exists for diagnostic
     /// logic. Do not add more uses of this.
     IsMacroArgument : 1,
-
-    /// True if this is a closure literal that is passed as an argument to a
-    /// call that references `nonisolated(nonsending)` declaration.
-    IsPassedToNonisolatedNonsendingCall : 1,
 
     /// True if this closure, even though it has a different static isolation,
     /// should behave like `nonisolated(nonsending)` when lowered. This is important
@@ -4329,7 +4325,6 @@ public:
     Bits.ClosureExpr.NoGlobalActorAttribute = false;
     Bits.ClosureExpr.RequiresDynamicIsolationChecking = false;
     Bits.ClosureExpr.IsMacroArgument = false;
-    Bits.ClosureExpr.IsPassedToNonisolatedNonsendingCall = false;
     Bits.ClosureExpr.BehavesLikeNonisolatedNonsending = false;
   }
 
@@ -4439,16 +4434,6 @@ public:
 
   void setIsMacroArgument(bool value = true) {
     Bits.ClosureExpr.IsMacroArgument = value;
-  }
-
-  /// Determines whether this is a closure literal that is passed as an argument
-  /// to a call that references `nonisolated(nonsending)` declaration.
-  bool isPassedToNonisolatedNonsendingCall() const {
-    return Bits.ClosureExpr.IsPassedToNonisolatedNonsendingCall;
-  }
-
-  void setIsPassedToNonisolatedNonsendingCall(bool value = true) {
-    Bits.ClosureExpr.IsPassedToNonisolatedNonsendingCall = value;
   }
 
   /// Determines whether this closure, even though it has a different static

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -268,7 +268,7 @@ protected:
     Kind : 2
   );
 
-  SWIFT_INLINE_BITFIELD(ClosureExpr, AbstractClosureExpr, 1+1+1+1+1+1+1+1+1,
+  SWIFT_INLINE_BITFIELD(ClosureExpr, AbstractClosureExpr, 1+1+1+1+1+1+1+1+1+1,
     /// True if closure parameters were synthesized from anonymous closure
     /// variables.
     HasAnonymousClosureVars : 1,
@@ -303,7 +303,11 @@ protected:
     /// Whether this closure was type-checked as an argument to a macro. This
     /// is only populated after type-checking, and only exists for diagnostic
     /// logic. Do not add more uses of this.
-    IsMacroArgument : 1
+    IsMacroArgument : 1,
+
+    /// True if this is a closure literal that is passed as an argument to a
+    /// call that references `nonisolated(nonsending)` declaration.
+    IsPassedToNonisolatedNonsendingCall : 1
   );
 
   SWIFT_INLINE_BITFIELD_FULL(BindOptionalExpr, Expr, 16,
@@ -4317,6 +4321,7 @@ public:
     Bits.ClosureExpr.NoGlobalActorAttribute = false;
     Bits.ClosureExpr.RequiresDynamicIsolationChecking = false;
     Bits.ClosureExpr.IsMacroArgument = false;
+    Bits.ClosureExpr.IsPassedToNonisolatedNonsendingCall = false;
   }
 
   SourceRange getSourceRange() const;
@@ -4425,6 +4430,16 @@ public:
 
   void setIsMacroArgument(bool value = true) {
     Bits.ClosureExpr.IsMacroArgument = value;
+  }
+
+  /// Determines whether this is a closure literal that is passed as an argument
+  /// to a call that references `nonisolated(nonsending)` declaration.
+  bool isPassedToNonisolatedNonsendingCall() const {
+    return Bits.ClosureExpr.IsPassedToNonisolatedNonsendingCall;
+  }
+
+  void setIsPassedToNonisolatedNonsendingCall(bool value = true) {
+    Bits.ClosureExpr.IsPassedToNonisolatedNonsendingCall = value;
   }
 
   /// Determine whether this closure expression has an

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -1958,6 +1958,22 @@ private:
                    true /*implicit leading parameter*/);
     }
 
+    // If the function is a closure that behaves as if it has
+    // `nonisolated(nonsending)` isolation, add the implicit isolation
+    // parameter but don't mark it as "isolated" because the closure
+    // should maintain it's statically known isolation after prolog.
+    if (Constant) {
+      if (auto *closure = dyn_cast_or_null<ClosureExpr>(
+              Constant->getAbstractClosureExpr())) {
+        if (closure->behavesLikeNonisolatedNonsending()) {
+          addParameter(-1, CanType(TC.Context.TheImplicitActorType),
+                       ParameterConvention::Direct_Guaranteed,
+                       ParameterTypeFlags(),
+                       true /*implicit leading parameter*/);
+        }
+      }
+    }
+
     // Add any foreign parameters that are positioned at the start
     // of the sequence.  visit() will add foreign parameters that are
     // positioned after any parameters it adds.

--- a/lib/SILGen/SILGenConcurrency.cpp
+++ b/lib/SILGen/SILGenConcurrency.cpp
@@ -254,11 +254,17 @@ void SILGenFunction::emitExpectedExecutorProlog() {
   if (ExpectedExecutor.isNecessary()) {
     auto executor = ExpectedExecutor.getEager(); // never lazy
     if (F.isAsync()) {
-      // For an async function, hop to the executor.
-      B.createHopToExecutor(
-          RegularLocation::getDebugOnlyLocation(F.getLocation(), getModule()),
-          executor,
-          /*mandatory*/ false);
+      auto *closureExpr = dyn_cast<ClosureExpr>(FunctionDC);
+      if (closureExpr && closureExpr->behavesLikeNonisolatedNonsending()) {
+        // Do nothing if the closure behaves as if it has
+        // `nonisolated(nonsending)` isolation.
+      } else {
+        // For all other async functions, hop to the executor.
+        B.createHopToExecutor(
+            RegularLocation::getDebugOnlyLocation(F.getLocation(), getModule()),
+            executor,
+            /*mandatory*/ false);
+      }
     } else if (wantDataRaceChecks) {
       // For a synchronous function, check that we're on the same executor.
       // Note: if we "know" that the code is completely Sendable-safe, this

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -3299,6 +3299,18 @@ static bool canEmitSpecializedClosureFunction(const AbstractClosureExpr *closure
                                         const FunctionTypeInfo &contextInfo) {
   auto destType = contextInfo.FormalType;
 
+  // This is a closure that is being converted to `nonisolated(nonsending)`
+  // type and is already behaves as such even though its statically known
+  // isolation is different. Such closures are emitted in a special way where
+  // they gain an implicit isolation parameter that gets ignored to avoid
+  // unnecessary hops.
+  if (contextInfo.ExpectedLoweredType->hasNonisolatedNonsendingIsolation()) {
+    if (auto *explicitClosure = dyn_cast<ClosureExpr>(closure)) {
+      if (explicitClosure->behavesLikeNonisolatedNonsending())
+        return true;
+    }
+  }
+
   // Require the closure's formal type to be closely related to the formal
   // type we're trying to convert it to.
   if (!canEmitClosureFunctionUnderConversion(closureType, destType))

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -35,6 +35,7 @@
 #include "swift/AST/DistributedDecl.h"
 #include "swift/AST/ExistentialLayout.h"
 #include "swift/AST/Expr.h"
+#include "swift/AST/ExtInfo.h"
 #include "swift/AST/ForeignErrorConvention.h"
 #include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/InFlightSubstitution.h"
@@ -3307,7 +3308,10 @@ static bool canEmitSpecializedClosureFunction(const AbstractClosureExpr *closure
   if (contextInfo.ExpectedLoweredType->hasNonisolatedNonsendingIsolation()) {
     if (auto *explicitClosure = dyn_cast<ClosureExpr>(closure)) {
       if (explicitClosure->behavesLikeNonisolatedNonsending())
-        return true;
+        closureType = cast<AnyFunctionType>(
+            closureType
+                ->withIsolation(FunctionTypeIsolation::forNonisolatedNonsending())
+                ->getCanonicalType());
     }
   }
 
@@ -3351,31 +3355,41 @@ ManagedValue RValueEmitter::tryEmitConvertedClosure(AbstractClosureExpr *e,
     return emitClosureReference(e, *info);
   }
 
+  // Construct a conversion that just adds requested isolation and doesn't
+  // make any other changes to the closure type.
+  auto adjustClosureIsolation = [&](FunctionTypeIsolation isolation) {
+    // This assertion is why this isn't an infinite recursion.
+    assert(closureType->getIsolation() != isolation &&
+           "closure cannot directly have erased isolation");
+
+    auto newExtInfo = closureType->getExtInfo().withIsolation(isolation);
+    auto newClosureType = closureType.withExtInfo(newExtInfo);
+    auto newInfo = SGF.getFunctionTypeInfo(newClosureType);
+
+    // Emit the closure under that conversion.  This should always succeed.
+    assert(canEmitSpecializedClosureFunction(e, closureType, newInfo));
+    auto result = emitClosureReference(e, newInfo);
+
+    // Narrow the original conversion to start from the updated closure type.
+    auto convAfterIsolationChange = conv.withSourceType(SGF, newClosureType);
+
+    // Apply the narrowed conversion.
+    return convAfterIsolationChange.emit(SGF, e, result, SGFContext());
+  };
+
+  if (info->ExpectedLoweredType->hasNonisolatedNonsendingIsolation()) {
+    if (auto *closure = dyn_cast<ClosureExpr>(e)) {
+      if (closure->behavesLikeNonisolatedNonsending())
+        return adjustClosureIsolation(
+            FunctionTypeIsolation::forNonisolatedNonsending());
+    }
+  }
+
   // If we're converting to an `@isolated(any)` type, at least force the
   // closure to be emitted using the erased-isolation pattern so that
   // we don't lose that information.
-  if (info->ExpectedLoweredType->hasErasedIsolation()) {
-    // This assertion is why this isn't an infinite recursion.
-    assert(!closureType->getIsolation().isErased() &&
-           "closure cannot directly have erased isolation");
-
-    // Construct a conversion that just erases isolation and doesn't make
-    // any other changes to the closure type.
-    auto erasedExtInfo = closureType->getExtInfo()
-      .withIsolation(FunctionTypeIsolation::forErased());
-    auto erasedClosureType = closureType.withExtInfo(erasedExtInfo);
-    auto erasureInfo = SGF.getFunctionTypeInfo(erasedClosureType);
-
-    // Emit the closure under that conversion.  This should always succeed.
-    assert(canEmitSpecializedClosureFunction(e, closureType, erasureInfo));
-    auto erasedResult = emitClosureReference(e, erasureInfo);
-
-    // Narrow the original conversion to start from the erased closure type.
-    auto convAfterErasure = conv.withSourceType(SGF, erasedClosureType);
-
-    // Apply the narrowed conversion.
-    return convAfterErasure.emit(SGF, e, erasedResult, SGFContext());
-  }
+  if (info->ExpectedLoweredType->hasErasedIsolation())
+    return adjustClosureIsolation(FunctionTypeIsolation::forErased());
 
   // Otherwise, give up.
   return ManagedValue();

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -6071,7 +6071,8 @@ static bool hasCurriedSelf(ConstraintSystem &cs, ConcreteDeclRef callee,
 static void applyContextualClosureFlags(Expr *expr, unsigned paramIdx,
                                         const ParameterListInfo &paramInfo,
                                         bool requiresDynamicIsolationChecking,
-                                        bool isMacroArg) {
+                                        bool isMacroArg,
+                                        bool isNonisolatedNonsendingCall) {
   if (auto closure = dyn_cast<ClosureExpr>(expr)) {
     closure->setAllowsImplicitSelfCapture(
         paramInfo.isImplicitSelfCapture(paramIdx));
@@ -6085,18 +6086,21 @@ static void applyContextualClosureFlags(Expr *expr, unsigned paramIdx,
     closure->setRequiresDynamicIsolationChecking(
         requiresDynamicIsolationChecking);
     closure->setIsMacroArgument(isMacroArg);
+    closure->setIsPassedToNonisolatedNonsendingCall(
+        isNonisolatedNonsendingCall);
     return;
   }
 
   if (auto captureList = dyn_cast<CaptureListExpr>(expr)) {
     applyContextualClosureFlags(captureList->getClosureBody(), paramIdx,
                                 paramInfo, requiresDynamicIsolationChecking,
-                                isMacroArg);
+                                isMacroArg, isNonisolatedNonsendingCall);
   }
 
   if (auto identity = dyn_cast<IdentityExpr>(expr)) {
     applyContextualClosureFlags(identity->getSubExpr(), paramIdx, paramInfo,
-                                requiresDynamicIsolationChecking, isMacroArg);
+                                requiresDynamicIsolationChecking, isMacroArg,
+                                isNonisolatedNonsendingCall);
   }
 }
 
@@ -6220,7 +6224,7 @@ ArgumentList *ExprRewriter::coerceCallArguments(
     return true;
   }();
 
-  auto applyFlagsToArgument = [&paramInfo,
+  auto applyFlagsToArgument = [&funcType, &paramInfo,
                                &closuresRequireDynamicIsolationChecking,
                                &locator](unsigned paramIdx, Expr *argument) {
     if (!isClosureLiteralExpr(argument))
@@ -6228,9 +6232,9 @@ ArgumentList *ExprRewriter::coerceCallArguments(
 
     bool isMacroArg = isExpr<MacroExpansionExpr>(locator.getAnchor());
 
-    applyContextualClosureFlags(argument, paramIdx, paramInfo,
-                                closuresRequireDynamicIsolationChecking,
-                                isMacroArg);
+    applyContextualClosureFlags(
+        argument, paramIdx, paramInfo, closuresRequireDynamicIsolationChecking,
+        isMacroArg, funcType->getIsolation().isNonisolatedNonsending());
   };
 
   // Quickly test if any further fix-ups for the argument types are necessary.

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -6071,8 +6071,7 @@ static bool hasCurriedSelf(ConstraintSystem &cs, ConcreteDeclRef callee,
 static void applyContextualClosureFlags(Expr *expr, unsigned paramIdx,
                                         const ParameterListInfo &paramInfo,
                                         bool requiresDynamicIsolationChecking,
-                                        bool isMacroArg,
-                                        bool isNonisolatedNonsendingCall) {
+                                        bool isMacroArg) {
   if (auto closure = dyn_cast<ClosureExpr>(expr)) {
     closure->setAllowsImplicitSelfCapture(
         paramInfo.isImplicitSelfCapture(paramIdx));
@@ -6086,21 +6085,18 @@ static void applyContextualClosureFlags(Expr *expr, unsigned paramIdx,
     closure->setRequiresDynamicIsolationChecking(
         requiresDynamicIsolationChecking);
     closure->setIsMacroArgument(isMacroArg);
-    closure->setIsPassedToNonisolatedNonsendingCall(
-        isNonisolatedNonsendingCall);
     return;
   }
 
   if (auto captureList = dyn_cast<CaptureListExpr>(expr)) {
     applyContextualClosureFlags(captureList->getClosureBody(), paramIdx,
                                 paramInfo, requiresDynamicIsolationChecking,
-                                isMacroArg, isNonisolatedNonsendingCall);
+                                isMacroArg);
   }
 
   if (auto identity = dyn_cast<IdentityExpr>(expr)) {
     applyContextualClosureFlags(identity->getSubExpr(), paramIdx, paramInfo,
-                                requiresDynamicIsolationChecking, isMacroArg,
-                                isNonisolatedNonsendingCall);
+                                requiresDynamicIsolationChecking, isMacroArg);
   }
 }
 
@@ -6224,7 +6220,7 @@ ArgumentList *ExprRewriter::coerceCallArguments(
     return true;
   }();
 
-  auto applyFlagsToArgument = [&funcType, &paramInfo,
+  auto applyFlagsToArgument = [&paramInfo,
                                &closuresRequireDynamicIsolationChecking,
                                &locator](unsigned paramIdx, Expr *argument) {
     if (!isClosureLiteralExpr(argument))
@@ -6232,9 +6228,9 @@ ArgumentList *ExprRewriter::coerceCallArguments(
 
     bool isMacroArg = isExpr<MacroExpansionExpr>(locator.getAnchor());
 
-    applyContextualClosureFlags(
-        argument, paramIdx, paramInfo, closuresRequireDynamicIsolationChecking,
-        isMacroArg, funcType->getIsolation().isNonisolatedNonsending());
+    applyContextualClosureFlags(argument, paramIdx, paramInfo,
+                                closuresRequireDynamicIsolationChecking,
+                                isMacroArg);
   };
 
   // Quickly test if any further fix-ups for the argument types are necessary.

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -4810,28 +4810,36 @@ namespace {
 } // end anonymous namespace
 
 /// Compute the isolation of a closure or local function from its parent
-/// isolation.
+/// isolation. The result indicates whether the isolation was inherited
+/// or not.
 ///
 /// Doesn't apply preconcurrency because it's generally easier for the
 /// caller to do so.
-static ActorIsolation
+static std::pair<ActorIsolation, /*inherited=*/bool>
 computeClosureIsolationFromParent(DeclContext *closure,
                                   ActorIsolation parentIsolation,
                                   bool checkIsolatedCapture) {
+  auto getNonisolatedIsolation =
+      [&](bool inherited) -> std::pair<ActorIsolation, bool> {
+    auto closureFn = AnyFunctionRef::fromFunctionDeclContext(closure);
+    if (closureFn.isAsync())
+      return {ActorIsolation::forNonisolatedConcurrent(), inherited};
+
+    return {ActorIsolation::forNonisolated(parentIsolation ==
+                                           ActorIsolation::NonisolatedUnsafe),
+            inherited};
+  };
+
   // We must have parent isolation determined to get here.
   switch (parentIsolation) {
   case ActorIsolation::NonisolatedNonsending:
+    return getNonisolatedIsolation(/*inferred=*/false);
+
   case ActorIsolation::Nonisolated:
   case ActorIsolation::NonisolatedConcurrent:
   case ActorIsolation::NonisolatedUnsafe:
-  case ActorIsolation::Unspecified: {
-    auto closureFn = AnyFunctionRef::fromFunctionDeclContext(closure);
-    if (closureFn.isAsync())
-      return ActorIsolation::forNonisolatedConcurrent();
-
-    return ActorIsolation::forNonisolated(parentIsolation ==
-                                          ActorIsolation::NonisolatedUnsafe);
-  }
+  case ActorIsolation::Unspecified:
+    return getNonisolatedIsolation(/*inferred=*/true);
 
   case ActorIsolation::Erased:
     llvm_unreachable("context cannot have erased isolation");
@@ -4839,7 +4847,8 @@ computeClosureIsolationFromParent(DeclContext *closure,
   case ActorIsolation::GlobalActor:
     // This should already be an interface type, so we don't need to remap
     // it between the contexts.
-    return ActorIsolation::forGlobalActor(parentIsolation.getGlobalActor());
+    return {ActorIsolation::forGlobalActor(parentIsolation.getGlobalActor()),
+            /*inherited=*/true};
 
   case ActorIsolation::ActorInstance: {
     // In non-@Sendable local functions, we always inherit the enclosing
@@ -4850,34 +4859,34 @@ computeClosureIsolationFromParent(DeclContext *closure,
       // locally within isolation checking.
       auto actor = parentIsolation.getActorInstance();
       assert(actor);
-      return ActorIsolation::forActorInstanceCapture(actor);
+      return {ActorIsolation::forActorInstanceCapture(actor),
+              /*inherited=*/true};
     }
 
     if (checkIsolatedCapture) {
       auto closureAsFn = AnyFunctionRef::fromFunctionDeclContext(closure);
       if (auto param = closureAsFn.getCaptureInfo().getIsolatedParamCapture())
-        return ActorIsolation::forActorInstanceCapture(param);
+        return {ActorIsolation::forActorInstanceCapture(param),
+                /*inherited=*/true};
 
       auto *explicitClosure = dyn_cast<ClosureExpr>(closure);
       // @_inheritActorContext(always) forces the isolation capture.
       if (explicitClosure && explicitClosure->alwaysInheritsActorContext()) {
         if (parentIsolation.isActorInstanceIsolated()) {
           if (auto *param = parentIsolation.getActorInstance())
-            return ActorIsolation::forActorInstanceCapture(param);
+            return {ActorIsolation::forActorInstanceCapture(param),
+                    /*inherited=*/true};
         }
-        return parentIsolation;
+        return {parentIsolation, /*inherited=*/true};
       }
     } else {
       // If we don't have capture information during code completion, assume
       // that the closure captures the `isolated` parameter from the parent
       // context.
-      return parentIsolation;
+      return {parentIsolation, /*inherited=*/true};
     }
 
-    if (AnyFunctionRef::fromFunctionDeclContext(closure).isAsync())
-      return ActorIsolation::forNonisolatedConcurrent();
-
-    return ActorIsolation::forNonisolated(/*unsafe=*/false);
+    return getNonisolatedIsolation(/*inherited=*/false);
   }
   }
 }
@@ -4931,12 +4940,44 @@ ActorIsolationChecker::determineClosureIsolation(AbstractClosureExpr *closure,
         closure->getParent(), getClosureActorIsolation);
     preconcurrency |= parentIsolation.preconcurrency();
 
-    auto normalIsolation = computeClosureIsolationFromParent(
-        closure, parentIsolation, checkIsolatedCapture);
+    ActorIsolation normalIsolation;
+    bool inheritsParentIsolation;
+    std::tie(normalIsolation, inheritsParentIsolation) =
+        computeClosureIsolationFromParent(closure, parentIsolation,
+                                          checkIsolatedCapture);
 
     bool isIsolationBoundary =
         isIsolationInferenceBoundaryClosure(closure,
                                             /*canInheritActorContext=*/true);
+
+    auto canAssumeNonisolatedNonsending = [&]() {
+      // Boundary closures cannot infer isolation from the parent context and
+      // so are always allowed to assume `nonisolated(nonsending)` isolation.
+      if (isIsolationBoundary)
+        return true;
+
+      if (auto *explicitClosure = dyn_cast<ClosureExpr>(closure)) {
+        // If a closure is used as an argument in `nonisolated(nonsending)` call
+        // and it assumes isolation of the parent it doesn't have to assume
+        // `nonisolated(nonsending)` isolation of the parameter because the
+        // `nonisolated(nonsending)` in this case matches isolation of the
+        // context.
+        if (explicitClosure->isPassedToNonisolatedNonsendingCall())
+          return !inheritsParentIsolation;
+      }
+
+      // Since this is not a call to `nonisolated(nonsending)` declaration, the
+      // closure can assume `nonisolated(nonsending)` when it's `@concurrent`,
+      // otherwise it would hop to the generic executor which is unexpected
+      // when isolation is not explicitly specified or inferred to be a
+      // specific actor.
+      if (normalIsolation.isNonisolatedConcurrent())
+        return true;
+
+      // Otherwise closure has to assume isolation inherited from the parent
+      // context.
+      return !inheritsParentIsolation;
+    };
 
     // The solver has to be conservative and produce a conversion to
     // `nonisolated(nonsending)` because at solution application time
@@ -4947,7 +4988,7 @@ ActorIsolationChecker::determineClosureIsolation(AbstractClosureExpr *closure,
     // global actor, nonisolated/@concurrent attributes and doesn't have
     // isolated parameters. If our closure is nonisolated and we have a
     // conversion to nonisolated(nonsending), then we should respect that.
-    if (isIsolationBoundary || normalIsolation.isNonisolatedOrConcurrent()) {
+    if (canAssumeNonisolatedNonsending()) {
       if (auto *fce = dyn_cast_or_null<FunctionConversionExpr>(context)) {
         auto expectedIsolation =
             fce->getType()->castTo<FunctionType>()->getIsolation();
@@ -6595,14 +6636,13 @@ static InferredActorIsolation computeActorIsolation(Evaluator &evaluator,
       }
 
       auto enclosingIsolation = getActorIsolationOfContext(dc);
-      auto isolation =
-        computeClosureIsolationFromParent(func, enclosingIsolation,
-                                          /*checkIsolatedCapture*/true)
-          .withPreconcurrency(enclosingIsolation.preconcurrency());
+      auto [isolation, _] =
+          computeClosureIsolationFromParent(func, enclosingIsolation,
+                                            /*checkIsolatedCapture*/ true);
       return {
-        inferredIsolation(isolation),
-        IsolationSource(inferenceSource, IsolationSource::LexicalContext)
-      };
+          inferredIsolation(isolation).withPreconcurrency(
+              enclosingIsolation.preconcurrency()),
+          IsolationSource(inferenceSource, IsolationSource::LexicalContext)};
     }
   }
 

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -4960,21 +4960,28 @@ ActorIsolationChecker::determineClosureIsolation(AbstractClosureExpr *closure,
         isIsolationInferenceBoundaryClosure(closure,
                                             /*canInheritActorContext=*/true);
 
+    bool isArgumentOfNonisolatedNonsendingApply = false;
+    if (auto *apply = dyn_cast_or_null<CallExpr>(getImmediateApply())) {
+      auto type = apply->getFn()->getType();
+      if (auto *fnType = type->getAs<AnyFunctionType>()) {
+        isArgumentOfNonisolatedNonsendingApply =
+            fnType->getIsolation().isNonisolatedNonsending();
+      }
+    }
+
     auto canAssumeNonisolatedNonsending = [&]() {
       // Boundary closures cannot infer isolation from the parent context and
       // so are always allowed to assume `nonisolated(nonsending)` isolation.
       if (isIsolationBoundary)
         return true;
 
-      if (auto *explicitClosure = dyn_cast<ClosureExpr>(closure)) {
-        // If a closure is used as an argument in `nonisolated(nonsending)` call
-        // and it assumes isolation of the parent it doesn't have to assume
-        // `nonisolated(nonsending)` isolation of the parameter because the
-        // `nonisolated(nonsending)` in this case matches isolation of the
-        // context.
-        if (explicitClosure->isPassedToNonisolatedNonsendingCall())
-          return !inheritsParentIsolation;
-      }
+      // If a closure is used as an argument in `nonisolated(nonsending)` call
+      // and it assumes isolation of the parent it doesn't have to assume
+      // `nonisolated(nonsending)` isolation of the parameter because the
+      // `nonisolated(nonsending)` in this case matches isolation of the
+      // context.
+      if (isArgumentOfNonisolatedNonsendingApply)
+        return !inheritsParentIsolation;
 
       // Since this is not a call to `nonisolated(nonsending)` declaration, the
       // closure can assume `nonisolated(nonsending)` when it's `@concurrent`,
@@ -5014,7 +5021,7 @@ ActorIsolationChecker::determineClosureIsolation(AbstractClosureExpr *closure,
       // because closure doesn't leave parent isolation and we prefer statically
       // known isolation over dynamic one.
       if (auto *explicitClosure = dyn_cast<ClosureExpr>(closure)) {
-        if (explicitClosure->isPassedToNonisolatedNonsendingCall() &&
+        if (isArgumentOfNonisolatedNonsendingApply &&
             inheritsParentIsolation)
           explicitClosure->setBehavesLikeNonisolatedNonsending();
       }

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -3460,9 +3460,19 @@ namespace {
 
       // The constraint solver may not have chosen legal casts.
       if (auto funcConv = dyn_cast<FunctionConversionExpr>(expr)) {
-        checkFunctionConversion(funcConv,
-                                funcConv->getSubExpr()->getType(),
+        auto *subExpr = funcConv->getSubExpr();
+
+        checkFunctionConversion(funcConv, subExpr->getType(),
                                 funcConv->getType());
+
+        // Closures are allowed to assume isolation from function conversion in
+        // some circumstances (currently only when it's
+        // `nonisolated(nonsending)`). If this happens, we can drop the
+        // conversion.
+        if (auto *closure = dyn_cast<AbstractClosureExpr>(subExpr)) {
+          if (funcConv->getType()->isEqual(closure->getType()))
+            return Action::Continue(closure);
+        }
       }
 
       if (auto *isolationErasure = dyn_cast<ActorIsolationErasureExpr>(expr)) {

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -4989,6 +4989,15 @@ ActorIsolationChecker::determineClosureIsolation(AbstractClosureExpr *closure,
       return !inheritsParentIsolation;
     };
 
+    auto isConvertedToNonisolatedNonsending = [&context]() {
+      if (auto *fce = dyn_cast_or_null<FunctionConversionExpr>(context)) {
+        auto expectedIsolation =
+            fce->getType()->castTo<FunctionType>()->getIsolation();
+        return expectedIsolation.isNonisolatedNonsending();
+      }
+      return false;
+    };
+
     // The solver has to be conservative and produce a conversion to
     // `nonisolated(nonsending)` because at solution application time
     // we don't yet know whether there are any captures which would
@@ -4996,14 +5005,18 @@ ActorIsolationChecker::determineClosureIsolation(AbstractClosureExpr *closure,
     //
     // At this point we know that closure is not explicitly annotated with
     // global actor, nonisolated/@concurrent attributes and doesn't have
-    // isolated parameters. If our closure is nonisolated and we have a
-    // conversion to nonisolated(nonsending), then we should respect that.
-    if (canAssumeNonisolatedNonsending()) {
-      if (auto *fce = dyn_cast_or_null<FunctionConversionExpr>(context)) {
-        auto expectedIsolation =
-            fce->getType()->castTo<FunctionType>()->getIsolation();
-        if (expectedIsolation.isNonisolatedNonsending())
-          return ActorIsolation::forNonisolatedNonsending();
+    // isolated parameters.
+    if (isConvertedToNonisolatedNonsending()) {
+      if (canAssumeNonisolatedNonsending())
+        return ActorIsolation::forNonisolatedNonsending();
+
+      // If `nonisolated(nonsending)` cannot be assumed, let's see if it's
+      // because closure doesn't leave parent isolation and we prefer statically
+      // known isolation over dynamic one.
+      if (auto *explicitClosure = dyn_cast<ClosureExpr>(closure)) {
+        if (explicitClosure->isPassedToNonisolatedNonsendingCall() &&
+            inheritsParentIsolation)
+          explicitClosure->setBehavesLikeNonisolatedNonsending();
       }
     }
 

--- a/test/Concurrency/nonisolated_nonsending_specialization.swift
+++ b/test/Concurrency/nonisolated_nonsending_specialization.swift
@@ -1,0 +1,203 @@
+// RUN: %target-swift-frontend -emit-sil -swift-version 6 -target %target-swift-5.1-abi-triple -verify %s | %FileCheck %s
+
+nonisolated(nonsending) func withValue(_ fn: nonisolated(nonsending) () async -> Void) async {
+}
+
+nonisolated(nonsending) func withValueWithArgument<T>(_ fn: nonisolated(nonsending) (T) async throws -> Void) async {
+}
+
+func asyncTest(_ body: () async -> Void) async {
+}
+
+func throwingTest(_ body: () async -> Void) async throws {
+}
+
+func syncTest(_ body: () async -> Void) {
+}
+
+@MainActor func isolatedTest() {
+}
+
+@MainActor func isolatedTest(_ body: () async -> Void) async {
+}
+
+func dynamicIsolation(isolation: isolated (any Actor)? = nil, _ body: () async throws -> Void) async throws {
+}
+
+// CHECK: // testConcurrentIsolation<A>(_:body:)
+// CHECK: // Isolation: unspecified
+// CHECK-LABEL: sil hidden @$s37nonisolated_nonsending_specialization23testConcurrentIsolation_4bodyyx_yyYaXEtYalF : $@convention(thin) @async <U> (@in_guaranteed U, @guaranteed @noescape @async @callee_guaranteed () -> ()) -> () {
+// ---- closure #1-2
+// CHECK:  [[CLOSURE_1:%.*]] = function_ref @$s37nonisolated_nonsending_specialization23testConcurrentIsolation_4bodyyx_yyYaXEtYalFyyYaXEfU_ : $@convention(thin) @async (@sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, @guaranteed @noescape @async @callee_guaranteed () -> ()) -> ()
+// CHECK:  [[CLOSURE_1_WITH_BODY:%.*]] = partial_apply [callee_guaranteed] [on_stack] [[CLOSURE_1]](%1) : $@convention(thin) @async (@sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, @guaranteed @noescape @async @callee_guaranteed () -> ()) -> ()
+// CHECK:  [[CLOSURE_1:%.*]] = mark_dependence [[CLOSURE_1_WITH_BODY]] on %1
+// CHECK:  [[CONVERTED_CLOSURE_1:%.*]] = convert_function [[CLOSURE_1]] to $@caller_isolated @noescape @async @callee_guaranteed (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor) -> ()
+// CHECK:  [[WITH_VALUE:%.*]] = function_ref @$s37nonisolated_nonsending_specialization9withValueyyyyYaYCXEYaF : $@convention(thin) @caller_isolated @async (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, @guaranteed @caller_isolated @noescape @async @callee_guaranteed (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor) -> ()) -> ()
+// CHECK:  apply [[WITH_VALUE]]({{.*}}, [[CONVERTED_CLOSURE_1]])
+// ---- closure #3-5
+// CHECK:  [[CLOSURE_3:%.*]] = function_ref @$s37nonisolated_nonsending_specialization23testConcurrentIsolation_4bodyyx_yyYaXEtYalFySiYaXEfU1_ : $@convention(thin) @async @substituted <τ_0_0> (@sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, @in_guaranteed τ_0_0, @guaranteed @noescape @async @callee_guaranteed () -> ()) -> @error any Error for <Int>
+// CHECK:  [[CLOSURE_3_WITH_BODY:%.*]] = partial_apply [callee_guaranteed] [on_stack] [[CLOSURE_3]](%1) : $@convention(thin) @async @substituted <τ_0_0> (@sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, @in_guaranteed τ_0_0, @guaranteed @noescape @async @callee_guaranteed () -> ()) -> @error any Error for <Int>
+// CHECK:  [[CLOSURE_3:%.*]] = mark_dependence [[CLOSURE_3_WITH_BODY]] on %1
+// CHECK:  [[CONVERTED_CLOSURE_3:%.*]] = convert_function [[CLOSURE_3]] to $@caller_isolated @noescape @async @callee_guaranteed @substituted <τ_0_0> (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, @in_guaranteed τ_0_0) -> @error any Error for <Int>
+// CHECK:  [[WITH_VALUE_WITH_ARGUMENT:%.*]] = function_ref @$s37nonisolated_nonsending_specialization21withValueWithArgumentyyyxYaKYCXEYalF : $@convention(thin) @caller_isolated @async <τ_0_0> (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, @guaranteed @caller_isolated @noescape @async @callee_guaranteed @substituted <τ_0_0> (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, @in_guaranteed τ_0_0) -> @error any Error for <τ_0_0>) -> ()
+// CHECK:  apply [[WITH_VALUE_WITH_ARGUMENT]]<Int>({{.*}}, [[CONVERTED_CLOSURE_3]])
+// CHECK: } // end sil function '$s37nonisolated_nonsending_specialization23testConcurrentIsolation_4bodyyx_yyYaXEtYalF'                                                                                                                                        
+func testConcurrentIsolation<U>(_: U, body: () async -> Void) async {
+  // CHECK: // closure #1 in testConcurrentIsolation<A>(_:body:)
+  // CHECK: // Isolation: @concurrent
+  // CHECK-LABEL: sil private @$s37nonisolated_nonsending_specialization23testConcurrentIsolation_4bodyyx_yyYaXEtYalFyyYaXEfU_ : $@convention(thin) @async (@sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, @guaranteed @noescape @async @callee_guaranteed () -> ()) -> () {
+  // CHECK: bb0([[IGNORED_ISOLATION:%.*]] : $Builtin.ImplicitActor, [[BODY:%.*]] : @closureCapture $@noescape @async @callee_guaranteed () -> ()):
+  // CHECK:   [[ASYNC_TEST:%.*]] = function_ref @$s37nonisolated_nonsending_specialization9asyncTestyyyyYaXEYaF : $@convention(thin) @async (@guaranteed @noescape @async @callee_guaranteed () -> ()) -> ()
+  // CHECK:   apply [[ASYNC_TEST]]([[BODY]]) : $@convention(thin) @async (@guaranteed @noescape @async @callee_guaranteed () -> ()) -> ()
+  // CHECK: } // end sil function '$s37nonisolated_nonsending_specialization23testConcurrentIsolation_4bodyyx_yyYaXEtYalFyyYaXEfU_'
+  await withValue {
+    await asyncTest(body) // Ok
+  }
+
+  // CHECK: // closure #2 in testConcurrentIsolation<A>(_:body:)
+  // CHECK: // Isolation: @concurrent
+  // CHECK-LABEL: sil private @$s37nonisolated_nonsending_specialization23testConcurrentIsolation_4bodyyx_yyYaXEtYalFyyYaXEfU0_ : $@convention(thin) @async (@sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, @guaranteed @noescape @async @callee_guaranteed () -> ()) -> () {
+  // CHECK: bb0([[IGNORED_ISOLATION:%.*]] : $Builtin.ImplicitActor, [[BODY:%.*]] : @closureCapture $@noescape @async @callee_guaranteed () -> ()):
+  // CHECK-NOT: hop_to_executor {{.*}}
+  // CHECK:   [[SYNC_TEST:%.*]] = function_ref @$s37nonisolated_nonsending_specialization8syncTestyyyyYaXEF : $@convention(thin) (@guaranteed @noescape @async @callee_guaranteed () -> ()) -> ()
+  // CHECK:   apply [[SYNC_TEST]]([[BODY]]) : $@convention(thin) (@guaranteed @noescape @async @callee_guaranteed () -> ()) -> ()
+  // CHECK: } // end sil function '$s37nonisolated_nonsending_specialization23testConcurrentIsolation_4bodyyx_yyYaXEtYalFyyYaXEfU0_'
+  await withValue {
+    syncTest(body) // Ok
+  }
+
+  // CHECK: // closure #3 in testConcurrentIsolation<A>(_:body:)
+  // CHECK: // Isolation: @concurrent
+  // CHECK-LABEL: sil private @$s37nonisolated_nonsending_specialization23testConcurrentIsolation_4bodyyx_yyYaXEtYalFySiYaXEfU1_ : $@convention(thin) @async @substituted <τ_0_0> (@sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, @in_guaranteed τ_0_0, @guaranteed @noescape @async @callee_guaranteed () -> ()) -> @error any Error for <Int> {
+  // CHECK: bb0([[IGNORED_ISOLATION:%.*]] : $Builtin.ImplicitActor, [[V:%.*]] : $*Int, [[BODY:%.*]] : @closureCapture $@noescape @async @callee_guaranteed () -> ()):
+  // CHECK-NOT: hop_to_executor {{.*}}
+  // CHECK:   [[ASYNC_TEST:%.*]] = function_ref @$s37nonisolated_nonsending_specialization9asyncTestyyyyYaXEYaF : $@convention(thin) @async (@guaranteed @noescape @async @callee_guaranteed () -> ()) -> ()
+  // CHECK:   apply [[ASYNC_TEST]]([[BODY]]) : $@convention(thin) @async (@guaranteed @noescape @async @callee_guaranteed () -> ()) -> ()
+  // CHECK: } // end sil function '$s37nonisolated_nonsending_specialization23testConcurrentIsolation_4bodyyx_yyYaXEtYalFySiYaXEfU1_'
+  await withValueWithArgument { (v: Int) in
+    await asyncTest(body) // Ok
+  }
+
+  // CHECK: // closure #4 in testConcurrentIsolation<A>(_:body:)
+  // CHECK: // Isolation: @concurrent
+  // CHECK-LABEL: sil private @$s37nonisolated_nonsending_specialization23testConcurrentIsolation_4bodyyx_yyYaXEtYalFyyt_tYaKXEfU2_ : $@convention(thin) @async @substituted <τ_0_0> (@sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, @in_guaranteed τ_0_0, @guaranteed @noescape @async @callee_guaranteed () -> ()) -> @error any Error for <()> {
+  // CHECK: bb0([[IGNORED_ISOLATION:%.*]] : $Builtin.ImplicitActor, [[V:%.*]] : $*(), [[BODY:%.*]] : @closureCapture $@noescape @async @callee_guaranteed () -> ()):
+  // CHECK-NOT: hop_to_executor {{.*}}
+  // CHECK:   [[THROWING_TEST:%.*]] = function_ref @$s37nonisolated_nonsending_specialization12throwingTestyyyyYaXEYaKF : $@convention(thin) @async (@guaranteed @noescape @async @callee_guaranteed () -> ()) -> @error any Error
+  // CHECK:   try_apply [[THROWING_TEST]]([[BODY]]) : $@convention(thin) @async (@guaranteed @noescape @async @callee_guaranteed () -> ()) -> @error any Error, normal bb1, error bb2
+  // CHECK: } // end sil function '$s37nonisolated_nonsending_specialization23testConcurrentIsolation_4bodyyx_yyYaXEtYalFyyt_tYaKXEfU2_'
+  await withValueWithArgument { (v: Void) in
+    try await throwingTest(body) // Ok
+  }
+
+  // CHECK: // closure #5 in testConcurrentIsolation<A>(_:body:)
+  // CHECK: // Isolation: @concurrent
+  // CHECK-LABEL: sil private @$s37nonisolated_nonsending_specialization23testConcurrentIsolation_4bodyyx_yyYaXEtYalFySi_SSxt_tYaXEfU3_ : $@convention(thin) @async <U> (@sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, @in_guaranteed (Int, String, U), @guaranteed @noescape @async @callee_guaranteed () -> ()) -> @error any Error {
+  // CHECK: bb0([[IGNORED_ISOLATION:%.*]] : $Builtin.ImplicitActor, [[V:%.*]] : $*(Int, String, U), [[BODY:%.*]] : @closureCapture $@noescape @async @callee_guaranteed () -> ()):
+  // CHECK-NOT: hop_to_executor {{.*}}
+  // CHECK:   [[SYNC_TEST:%.*]] = function_ref @$s37nonisolated_nonsending_specialization8syncTestyyyyYaXEF : $@convention(thin) (@guaranteed @noescape @async @callee_guaranteed () -> ()) -> ()
+  // CHECK:   apply [[SYNC_TEST]]([[BODY]]) : $@convention(thin) (@guaranteed @noescape @async @callee_guaranteed () -> ()) -> ()
+  // CHECK: } // end sil function '$s37nonisolated_nonsending_specialization23testConcurrentIsolation_4bodyyx_yyYaXEtYalFySi_SSxt_tYaXEfU3_'
+  await withValueWithArgument { (v: (Int, String, U)) in
+    syncTest(body) // Ok
+  }
+
+  // CHECK: // closure #6 in testConcurrentIsolation<A>(_:body:)
+  // CHECK: // Isolation: @concurrent
+  // CHECK-LABEL: sil private @$s37nonisolated_nonsending_specialization23testConcurrentIsolation_4bodyyx_yyYaXEtYalFyyYaXEfU4_ : $@convention(thin) @async (@sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, @guaranteed @noescape @async @callee_guaranteed () -> ()) -> () {
+  // CHECK: bb0([[IGNORED_ISOLATION:%.*]] : $Builtin.ImplicitActor, [[BODY:%.*]] : @closureCapture $@noescape @async @callee_guaranteed () -> ()):
+  // CHECK:   [[ISOLATION:%.*]] = enum $Optional<any Actor>, #Optional.none!enumelt
+  // CHECK-NOT: hop_to_executor {{.*}}
+  // CHECK:   [[ASYNC_TEST:%.*]] = function_ref @$s37nonisolated_nonsending_specialization9asyncTestyyyyYaXEYaF : $@convention(thin) @async (@guaranteed @noescape @async @callee_guaranteed () -> ()) -> ()
+  // CHECK:   apply [[ASYNC_TEST]]([[BODY]]) : $@convention(thin) @async (@guaranteed @noescape @async @callee_guaranteed () -> ()) -> ()
+  // CHECK:   hop_to_executor [[ISOLATION]]
+  // CHECK:   [[ISOLATED_TEST:%.*]] = function_ref @$s37nonisolated_nonsending_specialization12isolatedTestyyF : $@convention(thin) () -> ()
+  // CHECK:   [[MAIN_ACTOR_TYPE:%.*]] = metatype $@thick MainActor.Type
+  // CHECK:   [[MAIN_ACTOR_EXEC_REF:%.*]] = function_ref @$sScM6sharedScMvgZ : $@convention(method) (@thick MainActor.Type) -> @owned MainActor
+  // CHECK:   [[MAIN_ACTOR:%.*]] = apply [[MAIN_ACTOR_EXEC_REF]]([[MAIN_ACTOR_TYPE]]) : $@convention(method) (@thick MainActor.Type) -> @owned MainActor
+  // CHECK:   hop_to_executor [[MAIN_ACTOR]]
+  // CHECK:   apply [[ISOLATED_TEST]]() : $@convention(thin) () -> ()
+  // CHECK: } // end sil function '$s37nonisolated_nonsending_specialization23testConcurrentIsolation_4bodyyx_yyYaXEtYalFyyYaXEfU4_'
+  await withValue {
+    await asyncTest(body) // Ok
+    await isolatedTest()  // Ok
+  }
+
+  // CHECK: // closure #7 in testConcurrentIsolation<A>(_:body:)
+  // CHECK: // Isolation: @concurrent
+  // CHECK: sil private @$s37nonisolated_nonsending_specialization23testConcurrentIsolation_4bodyyx_yyYaXEtYalFyyYaXEfU5_ : $@convention(thin) @async (@sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, @guaranteed @noescape @async @callee_guaranteed () -> ()) -> () {
+  // CHECK: bb0([[IGNORED_ISOLATION:%.*]] : $Builtin.ImplicitActor, [[BODY:%.*]] : @closureCapture $@noescape @async @callee_guaranteed () -> ()):
+  // CHECK:   [[ISOLATION:%.*]] = enum $Optional<any Actor>, #Optional.none!enumelt
+  // CHECK-NOT: hop_to_executor {{.*}}
+  // CHECK:   [[ASYNC_TEST:%.*]] = function_ref @$s37nonisolated_nonsending_specialization9asyncTestyyyyYaXEYaF : $@convention(thin) @async (@guaranteed @noescape @async @callee_guaranteed () -> ()) -> ()
+  // CHECK:   apply [[ASYNC_TEST]]([[BODY]]) : $@convention(thin) @async (@guaranteed @noescape @async @callee_guaranteed () -> ()) -> ()
+  // CHECK:   hop_to_executor [[ISOLATION]]
+  // CHECK:   [[SYNC_TEST:%.*]] = function_ref @$s37nonisolated_nonsending_specialization8syncTestyyyyYaXEF : $@convention(thin) (@guaranteed @noescape @async @callee_guaranteed () -> ()) -> ()
+  // CHECK:   apply [[SYNC_TEST]]([[BODY]]) : $@convention(thin) (@guaranteed @noescape @async @callee_guaranteed () -> ()) -> ()
+  // CHECK: } // end sil function '$s37nonisolated_nonsending_specialization23testConcurrentIsolation_4bodyyx_yyYaXEtYalFyyYaXEfU5_'
+  await withValue {
+    await asyncTest(body) // Ok
+    syncTest(body) // Ok
+  }
+}
+
+// CHECK: // testMainActorIsolation(body:)
+// CHECK: // Isolation: global_actor. type: MainActor
+// CHECK-LABEL: sil hidden @$s37nonisolated_nonsending_specialization22testMainActorIsolation4bodyyyyYaXE_tYaF : $@convention(thin) @async (@guaranteed @noescape @async @callee_guaranteed () -> ()) -> () {
+// CHECK:  [[CLOSURE:%.*]] = function_ref @$s37nonisolated_nonsending_specialization22testMainActorIsolation4bodyyyyYaXE_tYaFyyYaXEfU_ : $@convention(thin) @async (@sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, @guaranteed @noescape @async @callee_guaranteed () -> ()) -> ()
+// CHECK:  [[CLOSURE_WITH_BODY:%.*]] = partial_apply [callee_guaranteed] [on_stack] [[CLOSURE]](%0) : $@convention(thin) @async (@sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, @guaranteed @noescape @async @callee_guaranteed () -> ()) -> ()
+// CHECK:  [[CLOSURE:%.*]] = mark_dependence [[CLOSURE_WITH_BODY]] on %0
+// CHECK:  convert_function [[CLOSURE]] to $@caller_isolated @noescape @async @callee_guaranteed (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor) -> ()
+// CHECK: } // end sil function '$s37nonisolated_nonsending_specialization22testMainActorIsolation4bodyyyyYaXE_tYaF'
+@MainActor func testMainActorIsolation(body: () async -> Void) async {
+  // CHECK: // closure #1 in testMainActorIsolation(body:)
+  // CHECK: // Isolation: global_actor. type: MainActor
+  // CHECK: sil private @$s37nonisolated_nonsending_specialization22testMainActorIsolation4bodyyyyYaXE_tYaFyyYaXEfU_ : $@convention(thin) @async (@sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, @guaranteed @noescape @async @callee_guaranteed () -> ()) -> () {
+  // CHECK: bb0([[IGNORED_ISOLATION:%.*]] : $Builtin.ImplicitActor, [[BODY:%.*]] : @closureCapture $@noescape @async @callee_guaranteed () -> ()):
+  // CHECK-NOT: hop_to_executor {{.*}}
+  // CHECK:   [[MAIN_ACTOR:%.*]] = apply [[MAIN_ACTOR_REF:%.*]]({{.*}}) : $@convention(method) (@thick MainActor.Type) -> @owned MainActor
+  // CHECK:   [[ISOLATED_TEST:%.*]] = function_ref @$s37nonisolated_nonsending_specialization12isolatedTestyyyyYaXEYaF : $@convention(thin) @async (@guaranteed @noescape @async @callee_guaranteed () -> ()) -> ()
+  // CHECK:   apply [[ISOLATED_TEST]]([[BODY]]) : $@convention(thin) @async (@guaranteed @noescape @async @callee_guaranteed () -> ()) -> ()
+  // CHECK:   hop_to_executor [[MAIN_ACTOR]]
+  // CHECK:   [[SYNC_TEST:%.*]] = function_ref @$s37nonisolated_nonsending_specialization8syncTestyyyyYaXEF : $@convention(thin) (@guaranteed @noescape @async @callee_guaranteed () -> ()) -> ()
+  // CHECK:   %11 = apply [[SYNC_TEST]]([[BODY]]) : $@convention(thin) (@guaranteed @noescape @async @callee_guaranteed () -> ()) -> ()
+  // CHECK: } // end sil function '$s37nonisolated_nonsending_specialization22testMainActorIsolation4bodyyyyYaXE_tYaFyyYaXEfU_'
+  await withValue {
+    await isolatedTest(body) // Ok
+    syncTest(body) // Ok
+  }
+}
+
+// CHECK: // testDynamicIsolation(isolation:body:)
+// CHECK: // Isolation: actor_instance. name: 'isolation'
+// CHECK-LABEL: sil hidden @$s37nonisolated_nonsending_specialization20testDynamicIsolation9isolation4bodyyScA_pSgYi_yyYaXEtYaF : $@convention(thin) @async (@sil_isolated @guaranteed Optional<any Actor>, @guaranteed @noescape @async @callee_guaranteed () -> ()) -> () {
+// CHECK: bb0([[ISOLATION:%.*]] : $Optional<any Actor>, [[BODY:%.*]] : $@noescape @async @callee_guaranteed () -> ()):
+// CHECK:  [[CLOSURE:%.*]] = function_ref @$s37nonisolated_nonsending_specialization20testDynamicIsolation9isolation4bodyyScA_pSgYi_yyYaXEtYaFyyt_tYaKXEfU_ : $@convention(thin) @async @substituted <τ_0_0> (@sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, @in_guaranteed τ_0_0, @sil_isolated @guaranteed Optional<any Actor>, @guaranteed @noescape @async @callee_guaranteed () -> ()) -> @error any Error for <()>
+// CHECK:  [[PARTIALLY_APPLIED:%.*]] = partial_apply [callee_guaranteed] [on_stack] [[CLOSURE]]([[ISOLATION]], [[BODY]]) : $@convention(thin) @async @substituted <τ_0_0> (@sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, @in_guaranteed τ_0_0, @sil_isolated @guaranteed Optional<any Actor>, @guaranteed @noescape @async @callee_guaranteed () -> ()) -> @error any Error for <()>
+// CHECK:  [[CLOSURE_REF:%.*]] = mark_dependence [[PARTIALLY_APPLIED]] on [[ISOLATION]]
+// CHECK:  [[COMPLETE_CLOSURE:%.*]] = mark_dependence [[CLOSURE_REF]] on [[BODY]]
+// CHECK:  [[CONVERTED_CLOSURE:%.*]] = convert_function [[COMPLETE_CLOSURE]] to $@caller_isolated @noescape @async @callee_guaranteed @substituted <τ_0_0> (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, @in_guaranteed τ_0_0) -> @error any Error for <()>
+// CHECK:  apply {{.*}}<()>({{.*}}, [[CONVERTED_CLOSURE:%.*]]) : $@convention(thin) @caller_isolated @async <τ_0_0> (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, @guaranteed @caller_isolated @noescape @async @callee_guaranteed @substituted <τ_0_0> (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, @in_guaranteed τ_0_0) -> @error any Error for <τ_0_0>) -> ()
+// CHECK: } // end sil function '$s37nonisolated_nonsending_specialization20testDynamicIsolation9isolation4bodyyScA_pSgYi_yyYaXEtYaF'
+func testDynamicIsolation(isolation: isolated (any Actor)?, body: () async -> Void) async {
+  // CHECK: // closure #1 in testDynamicIsolation(isolation:body:)
+  // CHECK: // Isolation: actor_instance. name: 'isolation'
+  // CHECK: sil private @$s37nonisolated_nonsending_specialization20testDynamicIsolation9isolation4bodyyScA_pSgYi_yyYaXEtYaFyyt_tYaKXEfU_ : $@convention(thin) @async @substituted <τ_0_0> (@sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, @in_guaranteed τ_0_0, @sil_isolated @guaranteed Optional<any Actor>, @guaranteed @noescape @async @callee_guaranteed () -> ()) -> @error any Error for <()> {
+  // CHECK: bb0([[IGNORED_ISOLATION:%.*]] : $Builtin.ImplicitActor, [[V:%.*]] : $*(), [[DYNAMIC_ISOLATION:%.*]] : @closureCapture $Optional<any Actor>, [[BODY:%.*]] : @closureCapture $@noescape @async @callee_guaranteed () -> ()):
+  // CHECK-NOT: hop_to_executor {{.*}}
+  // CHECK:   [[THUNK:%.*]] = function_ref @$sIgH_s5Error_pIegHzo_TR : $@convention(thin) @async (@guaranteed @noescape @async @callee_guaranteed () -> ()) -> @error any Error
+  // CHECK:   [[THUNKED_BODY:%.*]] = partial_apply [callee_guaranteed] [on_stack] [[THUNK]]([[BODY]]) : $@convention(thin) @async (@guaranteed @noescape @async @callee_guaranteed () -> ()) -> @error any Error
+  // CHECK:   [[BODY_WITH_DEPENDENCE:%.*]] = mark_dependence [[THUNKED_BODY]] on [[BODY]]
+  // CHECK:   [[DYNAMIC_ISOLATION_TEST:%.*]] = function_ref @$s37nonisolated_nonsending_specialization16dynamicIsolation9isolation_yScA_pSgYi_yyYaKXEtYaKF : $@convention(thin) @async (@sil_isolated @guaranteed Optional<any Actor>, @guaranteed @noescape @async @callee_guaranteed () -> @error any Error) -> @error any Error
+  // CHECK:   try_apply [[DYNAMIC_ISOLATION_TEST]]([[DYNAMIC_ISOLATION]], [[BODY_WITH_DEPENDENCE]]) : $@convention(thin) @async (@sil_isolated @guaranteed Optional<any Actor>, @guaranteed @noescape @async @callee_guaranteed () -> @error any Error) -> @error any Error, normal bb1, error bb2
+  //
+  // CHECK: bb1({{.*}} : $()):
+  // CHECK:   hop_to_executor [[DYNAMIC_ISOLATION]]
+  //
+  // CHECK: bb2({{.*}} : $any Error):
+  // CHECK:   hop_to_executor [[DYNAMIC_ISOLATION]]
+  // CHECK: } // end sil function '$s37nonisolated_nonsending_specialization20testDynamicIsolation9isolation4bodyyScA_pSgYi_yyYaXEtYaFyyt_tYaKXEfU_'
+  await withValueWithArgument { (v: Void) in
+    try await dynamicIsolation(isolation: isolation, body)
+  }
+}

--- a/test/Concurrency/nonisolated_nonsending_specialization.swift
+++ b/test/Concurrency/nonisolated_nonsending_specialization.swift
@@ -6,6 +6,9 @@ nonisolated(nonsending) func withValue(_ fn: nonisolated(nonsending) () async ->
 nonisolated(nonsending) func withValueWithArgument<T>(_ fn: nonisolated(nonsending) (T) async throws -> Void) async {
 }
 
+nonisolated(nonsending) func withValueGeneric<R>(_ fn: nonisolated(nonsending) () async throws -> R?) async throws {
+}
+
 func asyncTest(_ body: () async -> Void) async {
 }
 
@@ -201,3 +204,24 @@ func testDynamicIsolation(isolation: isolated (any Actor)?, body: () async -> Vo
     try await dynamicIsolation(isolation: isolation, body)
   }
 }
+
+func testReabstraction(body: () async -> Void) async throws {
+  // CHECK: // closure #1 in testReabstraction(body:)
+  // CHECK: // Isolation: @concurrent
+  // CHECK: sil private @$s37nonisolated_nonsending_specialization17testReabstraction4bodyyyyYaXE_tYaKFyyYaKXEfU_ : $@convention(thin) @async (@sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, @guaranteed @noescape @async @callee_guaranteed () -> ()) -> @error any Error {
+  // CHECK-NOT: hop_to_executor {{.*}}
+  // CHECK: } // end sil function '$s37nonisolated_nonsending_specialization17testReabstraction4bodyyyyYaXE_tYaKFyyYaKXEfU_'
+  try await withValueGeneric {
+    _ = 42
+    try await throwingTest(body)
+  }
+}
+
+// Reabstraction thunk for `testReabstraction` closure
+//
+// CHECK: // thunk for @caller_isolated @callee_guaranteed @async (@guaranteed Builtin.ImplicitActor) -> (@error @owned Error)
+// CHECK: sil shared [transparent] [reabstraction_thunk] @$sBAs5Error_pINgHgILzo_BAytSgsAA_pIeNgHgILrzo_TR : $@convention(thin) @caller_isolated @async (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, @guaranteed @caller_isolated @noescape @async @callee_guaranteed (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor) -> @error any Error) -> (@out Optional<()>, @error any Error) {
+// CHECK: bb0(%0 : $*Optional<()>, [[ISOLATION:%.*]] : $Builtin.ImplicitActor, [[CLOSURE:%.*]] : $@caller_isolated @noescape @async @callee_guaranteed (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor) -> @error any Error):
+// CHECK:   hop_to_executor [[ISOLATION]]
+// CHECK:   try_apply [[CLOSURE]]([[ISOLATION]]) : $@caller_isolated @noescape @async @callee_guaranteed (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor) -> @error any Error, normal bb1, error bb2
+// CHECK: } // end sil function '$sBAs5Error_pINgHgILzo_BAytSgsAA_pIeNgHgILrzo_TR'


### PR DESCRIPTION
<!--
The main branch is now in convergence, which means major changes, such as large refactoring or new features, should be avoided. This strategy is intended to maintain the stability of the Swift 6.4 release leading up to the May 4th branch. For any work that requires broad changes or introduces new features, create a feature branch and open a draft pull request. All updates to the swiftlang/swift repository’s main branch require approval from the release managers. A pull request targeting swiftlang/swift will automatically add release managers. You can also contact them via @release-managers in the forum group.
-->

<!-- Please fill out the following form: --> 
- **Explanation**:
  
    A non-Sendable closure passed to a `nonisolated(nonsending)` parameter
    (which isn't `sending`) of a `nonisolated(nonsending)` call can maintain
    the isolation inferred from the context because `nonisolated(nonsending)`
    represents the same dynamic isolation. This change allows us to emit
    closures like that in a special way in SILGen that elides a preamble
    executor hop.

    This primarily helps region-based isolation to make better region assignments
    because the statically known isolation is maintained throughout the body of a closure.

    SILGen treats such closures in a special way where a new implicit leading parameter
    is emitted that is otherwise ignored in the body but used to convert the closure
    to `nonisolated(nonsending)` type directly.

- **Scope**:

   The change is very narrow and applies only to closures  that are allowed to assume isolation of the parent context and passed to non-sending `nonisolated(nonsending)` parameters of `nonisolated(nonsending)` calls.

- **Issues**:

  - rdar://172275339

- **Risk**:
  
   Low. The change is very narrow.

- **Testing**:
  
   Added new test-cases to the Concurrency suite.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
