### PR TITLE
IRGen: guard against null clang type when emitting lazy ObjC protocol metadata

### DIFF
--- a/lib/IRGen/GenObjC.cpp
+++ b/lib/IRGen/GenObjC.cpp
@@ -1268,8 +1268,10 @@ void irgen::getObjCEncodingForPropertyType(IRGenModule &IGM,
                                            VarDecl *property, std::string &s) {
   // FIXME: Property encoding differs in slight ways that aren't publicly
   // exposed from Clang.
-  IGM.getClangASTContext()
-    .getObjCEncodingForPropertyType(getObjCPropertyType(IGM, property), s);
+  auto clangType = getObjCPropertyType(IGM, property);
+  if (clangType.isNull())
+    return;
+  IGM.getClangASTContext().getObjCEncodingForPropertyType(clangType, s);
 }
 
 static void
@@ -1428,6 +1430,7 @@ irgen::emitObjCGetterDescriptorParts(IRGenModule &IGM, VarDecl *property) {
   auto clangType = getObjCPropertyType(IGM, property);
   if (clangType.isNull()) {
     descriptor.typeEncoding = llvm::ConstantPointerNull::get(IGM.Int8PtrTy);
+    descriptor.impl = llvm::ConstantPointerNull::get(IGM.Int8PtrTy);
     descriptor.silFunction = nullptr;
     return descriptor;
   }
@@ -1508,6 +1511,7 @@ irgen::emitObjCSetterDescriptorParts(IRGenModule &IGM,
   clangType = getObjCPropertyType(IGM, property);
   if (clangType.isNull()) {
     descriptor.typeEncoding = llvm::ConstantPointerNull::get(IGM.Int8PtrTy);
+    descriptor.impl = llvm::ConstantPointerNull::get(IGM.Int8PtrTy);
     descriptor.silFunction = nullptr;
     return descriptor;
   }

--- a/test/IRGen/objc_protocol_lazy_definition_null_clang_type.swift
+++ b/test/IRGen/objc_protocol_lazy_definition_null_clang_type.swift
@@ -1,0 +1,35 @@
+// RUN: %target-swift-frontend -emit-ir -swift-version 6 -parse-as-library %s | %FileCheck %s
+
+// REQUIRES: objc_interop
+
+// Regression test: compiling any source that triggers emission of
+// lazy ObjC protocol metadata for `NSObjectProtocol` (in this case,
+// holding a `DispatchSourceTimer?` forces that emission) previously
+// crashed in `buildMethodDescriptor` /
+// `buildPropertyAttributes` / `buildProperty` with
+// `Assertion failed: (detail::isPresent(Val) && "dyn_cast on a non-existent value")`
+// or `Assertion failed: (!isNull() && "Cannot retrieve a NULL type pointer")`.
+//
+// The root cause: `NSObjectProtocol`'s `description`/`debugDescription`
+// properties are typed `Swift.String` in the SIL accessor lowering
+// path taken here, and `IRGenModule::getClangType(Swift.String)` has
+// no direct Clang mapping (the NSString bridging is handled elsewhere),
+// so `getObjCPropertyType` returned a null `clang::CanQualType`. Three
+// sites that consumed it dereferenced the null: two early-returns in
+// `emitObjC{Getter,Setter}DescriptorParts` left
+// `descriptor.impl` unset (nullptr), and
+// `getObjCEncodingForPropertyType` forwarded a null type into Clang's
+// `getObjCEncodingForType`.
+//
+// This test just needs to reach `emitLazyObjCProtocolDefinitions` for
+// `NSObjectProtocol` without crashing.
+
+import Dispatch
+
+internal class MyClass {
+    fileprivate var timer: DispatchSourceTimer?
+
+    init() {}
+}
+
+// CHECK: define {{.*}}swiftcc {{.*}} @"$s{{.*}}7MyClassC{{.*}}timer{{.*}}vg"


### PR DESCRIPTION
  - **Explanation**: Fix a compiler crash when a module imports `Dispatch` (without `Foundation`) and holds a `DispatchSourceTimer?`-typed property under Swift 6 mode. IRGen was dereferencing a null `clang::CanQualType` when emitting lazy metadata for `NSObjectProtocol.description` /             
  `.debugDescription`.                                      

  - **Scope**: Three local null-guards in `lib/IRGen/GenObjC.cpp` (`emitObjCGetterDescriptorParts(VarDecl *)`, `emitObjCSetterDescriptorParts(VarDecl *)`, `getObjCEncodingForPropertyType`). No change when `getObjCPropertyType` returns a valid type. 
 
  - **Issues**: Reported against Xcode 6.0, 6.1, and 6.2 toolchains on macOS. Does not reproduce on Linux or with `.swiftLanguageMode(.v5)`. Minimal repro: `import Dispatch` + `class C { fileprivate var timer: DispatchSourceTimer? }`.                                                               

  - **Risk**: Very low. Local null-guards on a known-fragile path. Full IRGen suite (1031 tests) passes. The placeholder metadata emitted in the guarded case is never dispatched through at runtime (the real `NSObjectProtocol` comes from Objective-C).
                                     
  - **Testing**: New `test/IRGen/objc_protocol_lazy_definition_null_clang_type.swift` compiles the reproducer under `-swift-version 6` and checks `MyClass.timer.getter`'s IR is emitted. Verified the crash reproduces without the fix and is gone with it. 

The root cause sits in SIL type lowering: for `NSObjectProtocol.description`'s foreign getter, `TypeConverter::getLoweredCBridgedType` looks up `String: _ObjectiveCBridgeable` through the user's module, and the conformance (defined in Foundation) isn't visible when Foundation isn't imported. The principled fix (widen the bridging-conformance lookup for well-known bridged Swift types will be a follow-up that doesn't need to go to 6.4.