### PR TITLE
Revert "Update the pull request template and require release managers"

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,14 +6,328 @@
 # Please mirror the repository's file hierarchy in case-sensitive lexicographic
 # order.
 
-# The main branch is now in convergence, which means major changes, such as
-# large refactoring or new features, should be avoided. This strategy is
-# intended to maintain the stability of the Swift 6.4 release leading up to
-# the May 4th branch. For any work that requires broad changes or introduces
-# new features, create a feature branch and open a draft pull request.
-# All updates to the swiftlang/swift repository’s main branch require
-# approval from the release managers. A pull request targeting swiftlang/swift
-# will automatically add release managers. You can also contact them
-# via @release-managers in the forum group.
+# TODO: /.clang-format
 
-* @swiftlang/swift-branch-managers
+/.clang-tidy      @egorzhdan
+
+/.dir-locals.el   @al45tair
+/.editorconfig    @hamishknight
+# TODO: /.flake8
+/.gitattributes   @shahmishal
+
+# .github
+/.github/                                 @shahmishal
+/.github/CODEOWNERS                       @AnthonyLatsis @shahmishal
+/.github/ISSUE_TEMPLATE/                  @AnthonyLatsis @hborla @shahmishal @xedin
+/.github/PULL_REQUEST_TEMPLATE.md         @AnthonyLatsis @hborla @shahmishal @xedin
+
+/.gitignore           @shahmishal
+# TODO: /.mailmap
+# TODO: /Brewfile
+/CHANGELOG.md         @hborla
+# TODO: /CMakeLists.txt
+/CODE_OF_CONDUCT.md   @swiftlang/core-team
+/CODE_OWNERS.TXT      @swiftlang/core-team
+/CONTRIBUTING.md      @AnthonyLatsis @xedin
+/LICENSE.txt          @swiftlang/core-team
+# TODO: /README.md
+
+# Runtimes
+/Runtimes/**/*.cmake                                    @etcwilde @compnerd @edymtt @justice-adams-apple
+/Runtimes/**/CMakeLists.txt                             @etcwilde @compnerd @edymtt @justice-adams-apple
+/Runtimes/Core/cmake/caches/Vendors/Apple/              @etcwilde @shahmishal @edymtt @justice-adams-apple
+/Runtimes/*/cmake/modules/ExperimentalFeatures.cmake @tshortli @etcwilde @compnerd @edymtt @justice-adams-apple
+
+# SwiftCompilerSources
+/SwiftCompilerSources                     @eeckstein
+
+# apinotes
+# TODO: /apinotes
+
+# benchmark
+/benchmark                                @eeckstein
+
+# bindings
+# TODO: /bindings
+
+# cmake
+/cmake/**/*Windows*                       @compnerd
+
+# docs
+/docs/ABI/                                @rjmccall
+/docs/ABI/*Mangling*                      @eeckstein
+/docs/ABI/GenericSignature.md             @slavapestov
+/docs/ABI/KeyPaths.md                     @jckarter
+/docs/ABI/RegisterUsage.md                @al45tair
+/docs/CrossCompilationModel.md            @MaxDesiatov
+/docs/Generics                            @slavapestov
+/docs/HowToGuides/                        @AnthonyLatsis @xedin
+/docs/Optimizer*                          @eeckstein
+/docs/SIL*                                @jckarter
+/docs/Windows*                            @compnerd
+
+# include
+/include/swift-c/DependencyScan/                   @artemcm @cachemeifyoucan
+/include/swift/*Demangl*/                          @rjmccall
+/include/swift/AST/                                @hborla @slavapestov @xedin @hamishknight
+/include/swift/AST/*Availability*                  @tshortli
+/include/swift/AST/*Conformance*                   @slavapestov
+/include/swift/AST/*Demangl*                       @rjmccall
+/include/swift/AST/*Distributed*                   @ktoso
+/include/swift/AST/*Generic*                       @hborla @slavapestov
+/include/swift/AST/*Protocol*                      @hborla @slavapestov
+/include/swift/AST/*Requirement*                   @hborla @slavapestov
+/include/swift/AST/*Substitution*                  @slavapestov
+/include/swift/AST/DiagnosticGroup*                @DougGregor
+/include/swift/AST/DiagnosticsClangImporter.def    @egorzhdan @beccadax @ian-twilightcoder @Xazax-hun @j-hui @susmonteiro
+/include/swift/AST/DiagnosticsDriver.def           @artemcm
+/include/swift/AST/DiagnosticsFrontend.def         @artemcm @tshortli
+/include/swift/AST/DiagnosticsIDE.def              @hamishknight @rintaro
+/include/swift/AST/DiagnosticsIRGen.def            @rjmccall
+/include/swift/AST/DiagnosticsModuleDiffer.def     @nkcsgexi
+/include/swift/AST/DiagnosticsParse.def            @CodaFi @DougGregor @hamishknight @rintaro
+/include/swift/AST/DiagnosticsRefactoring.def      @hamishknight @rintaro
+/include/swift/AST/DiagnosticsSIL.def              @jckarter
+/include/swift/AST/Evaluator*                      @CodaFi @slavapestov
+/include/swift/Basic/                              @DougGregor
+/include/swift/Basic/Features.def                  @DougGregor @hborla
+/include/swift/ClangImporter                       @egorzhdan @beccadax @ian-twilightcoder @Xazax-hun @j-hui @susmonteiro @hnrklssn
+/include/swift/DependencyScan                      @artemcm @cachemeifyoucan
+/include/swift/Driver*/                            @artemcm
+/include/swift/Frontend*/                          @artemcm @tshortli
+/include/swift/IDE/                                @hamishknight @rintaro
+/include/swift/IRGen/                              @rjmccall
+/include/swift/Index/                              @hamishknight @rintaro
+/include/swift/Markup/                             @nkcsgexi
+/include/swift/Migrator/                           @nkcsgexi
+/include/swift/Option/*Options*                    @tshortli
+/include/swift/Parse/                              @CodaFi @DougGregor @hamishknight @rintaro
+/include/swift/PrintAsClang                        @egorzhdan @Xazax-hun @j-hui @susmonteiro
+/include/swift/Refactoring                         @hamishknight @rintaro
+/include/swift/Runtime/                            @rjmccall @compnerd
+/include/swift/SIL/                                @jckarter
+/include/swift/SIL/*Coverage*                      @hamishknight @rintaro
+/include/swift/SIL/*DebugInfo*                     @adrian-prantl
+/include/swift/SIL/SILDebug*                       @adrian-prantl
+/include/swift/SIL/SILProfiler.h                   @hamishknight @rintaro
+/include/swift/SILOptimizer/                       @eeckstein
+/include/swift/SILOptimizer/Utils/Distributed*     @ktoso
+/include/swift/Sema/                               @hborla @slavapestov @xedin @hamishknight @kathygray-pl
+/include/swift/Sema/CS*                            @hborla @xedin @hamishknight @kathygray-pl
+/include/swift/Sema/Constraint*                    @hborla @xedin @hamishknight @kathygray-pl
+/include/swift/Serialization/                      @xymus
+/include/swift/Serialization/SerializedModuleLoader* @artemcm
+/include/swift/SwiftRemoteMirror/                  @slavapestov
+/include/swift/SymbolGraphGen/                     @QuietMisdreavus
+/include/swift/Threading                           @al45tair
+
+# lib
+/lib/*Demangl*/                                     @rjmccall
+/lib/AST/                                           @hborla @slavapestov @xedin @hamishknight
+/lib/AST/*Availability*                             @tshortli
+/lib/AST/*Conformance*                              @slavapestov
+/lib/AST/*Demangl*                                  @rjmccall
+/lib/AST/*Generic*                                  @hborla @slavapestov
+/lib/AST/*Requirement*                              @hborla @slavapestov
+/lib/AST/*Substitution                              @slavapestov
+/lib/AST/ASTPrinter.cpp                             @hborla @slavapestov @xedin @tshortli
+/lib/AST/Evaluator*                                 @CodaFi @slavapestov
+/lib/AST/ModuleLoader.cpp                           @artemcm
+/lib/AST/RequirementMachine/                        @slavapestov
+/lib/ASTGen/                                        @CodaFi @hamishknight @rintaro
+/lib/Basic/                                         @DougGregor
+/lib/Basic/Windows                                  @compnerd
+/lib/ClangImporter                                  @egorzhdan @beccadax @ian-twilightcoder @Xazax-hun @j-hui @susmonteiro @hnrklssn
+/lib/ClangImporter/DWARFImporter*                   @adrian-prantl
+/lib/DependencyScan                                 @artemcm @cachemeifyoucan
+/lib/Driver*/                                       @artemcm
+/lib/DriverTool/autolink_extract_main.cpp           @MaxDesiatov @etcwilde
+/lib/DriverTool/sil*                                @jckarter
+/lib/DriverTool/sil_opt*                            @eeckstein
+/lib/DriverTool/swift_symbolgraph_extract_main.cpp  @QuietMisdreavus
+/lib/Frontend*/                                     @artemcm @tshortli
+/lib/IDE/                                           @hamishknight @rintaro
+/lib/IDETool/                                       @hamishknight @rintaro
+/lib/IRGen/                                         @rjmccall
+/lib/IRGen/*Coverage*                               @hamishknight @rintaro
+/lib/IRGen/*Debug*                                  @adrian-prantl
+/lib/IRGen/*Distributed*                            @ktoso
+/lib/Index/                                         @hamishknight @rintaro
+/lib/Macros/Sources/SwiftMacros/Swiftify*           @hnrklssn @Xazax-hun
+/lib/Markup/                                        @nkcsgexi
+/lib/Migrator/                                      @nkcsgexi
+/lib/Parse/                                         @CodaFi @DougGregor @hamishknight @rintaro
+/lib/PrintAsClang                                   @egorzhdan @Xazax-hun @j-hui @susmonteiro
+/lib/Refactoring/                                   @hamishknight @rintaro
+/lib/SIL/                                           @jckarter
+/lib/SIL/**/*DebugInfo*                             @adrian-prantl
+/lib/SIL/IR/*Coverage*                              @hamishknight @rintaro
+/lib/SIL/IR/SILDebug*                               @adrian-prantl
+/lib/SIL/IR/SILLocation*                            @adrian-prantl
+/lib/SIL/IR/SILProfiler.cpp                         @hamishknight @rintaro
+/lib/SILGen/                                        @jckarter @kavon
+/lib/SILGen/*Availability*                          @tshortli
+/lib/SILGen/*Distributed*                           @ktoso
+/lib/SILOptimizer/                                  @eeckstein
+/lib/SILOptimizer/**/*DebugInfo*                    @adrian-prantl
+/lib/SILOptimizer/Mandatory/ConsumeOperator*        @kavon
+/lib/SILOptimizer/Mandatory/FlowIsolation.cpp       @kavon
+/lib/SILOptimizer/Mandatory/MoveOnly*               @kavon
+/lib/SILOptimizer/Mandatory/AddressLowering*        @kavon
+/lib/SILOptimizer/Utils/Distributed*                @ktoso
+/lib/Sema/                                          @hborla @slavapestov @xedin @hamishknight
+/lib/Sema/*Availability*                            @tshortli
+/lib/Sema/CS*                                       @hborla @xedin @hamishknight @kathygray-pl
+/lib/Sema/CodeSynthesisDistributed*                 @hborla @ktoso
+/lib/Sema/Constraint*                               @hborla @xedin @hamishknight @kathygray-pl
+/lib/Sema/DerivedConformance*                       @slavapestov
+/lib/Sema/DerivedConformanceDistributed*            @ktoso @slavapestov
+/lib/Sema/OpenedExistentials*                       @AnthonyLatsis @slavapestov
+/lib/Sema/PreCheckTarget.cpp                        @hborla @slavapestov @xedin @hamishknight @kathygray-pl
+/lib/Sema/TypeCheckDistributed*                     @hborla @ktoso @xedin
+/lib/Sema/TypeCheckProtocol*                        @AnthonyLatsis @hborla @slavapestov
+/lib/Sema/TypeCheckType*                            @AnthonyLatsis @hborla @slavapestov @xedin @hamishknight
+/lib/Serialization/                                 @xymus
+/lib/Serialization/SerializedModuleLoader*          @artemcm
+/lib/SwiftRemoteMirror/                             @slavapestov
+/lib/SymbolGraphGen                                 @QuietMisdreavus
+/lib/Threading                                      @al45tair
+
+# localization
+# TODO: /localization
+
+# stdlib
+/stdlib/                                  @swiftlang/standard-librarians
+/stdlib/private/*Runtime*/                @rjmccall
+/stdlib/private/DifferentiationUnittest/  @asl
+/stdlib/private/SwiftReflectionTest/      @slavapestov
+/stdlib/public/core/Swiftify*             @hnrklssn @Xazax-hun
+/stdlib/public/*Demangl*/                 @rjmccall
+/stdlib/public/Concurrency/               @ktoso
+/stdlib/public/Cxx/                       @egorzhdan @Xazax-hun @j-hui @susmonteiro
+/stdlib/public/Differentiation/           @asl
+/stdlib/public/Distributed/               @ktoso
+/stdlib/public/Observation/               @phausler
+/stdlib/public/RuntimeModule/             @al45tair @mikeash
+/stdlib/public/SwiftRemoteMirror/         @slavapestov
+/stdlib/public/Threading/                 @al45tair
+/stdlib/public/Windows/                   @compnerd
+/stdlib/public/libexec/swift-backtrace/   @al45tair
+/stdlib/public/runtime/                   @mikeash @al45tair
+/stdlib/tools/swift-reflection-test/      @slavapestov
+
+# test
+/test/*Demangl*/                                    @rjmccall
+/test/Availability/                                 @tshortli
+/test/ASTGen/                                       @CodaFi @hamishknight @rintaro
+/test/AutoDiff/                                     @asl
+/test/Concurrency/                                  @ktoso
+/test/Constraints/                                  @hborla @xedin @hamishknight @kathygray-pl
+/test/DebugInfo/                                    @adrian-prantl
+/test/Distributed/                                  @ktoso
+/test/Driver/                                       @artemcm
+/test/Driver/static*                                @MaxDesiatov @etcwilde
+/test/Frontend/                                     @artemcm @tshortli
+/test/Generics/                                     @hborla @slavapestov
+/test/Generics/inverse*                             @kavon
+/test/IDE/                                          @hamishknight @rintaro
+/test/IRGen/                                        @rjmccall
+/test/Index/                                        @hamishknight @rintaro
+/test/Interop/                                      @egorzhdan @Xazax-hun @j-hui @susmonteiro @hnrklssn
+/test/Macros/SwiftifyImport                         @hnrklssn @Xazax-hun
+/test/Migrator/                                     @nkcsgexi
+/test/Parse/                                        @CodaFi @DougGregor @hamishknight @rintaro
+/test/Profiler                                      @hamishknight @rintaro
+/test/Reflection/                                   @slavapestov
+/test/Runtime/                                      @rjmccall
+/test/SIL/                                          @jckarter
+/test/SILGen/                                       @jckarter
+/test/SILOptimizer/                                 @eeckstein
+/test/SILOptimizer/moveonly*                        @kavon
+/test/SILOptimizer/noimplicitcopy*                  @kavon
+/test/ScanDependencies/                             @artemcm
+/test/Sema/                                         @hborla @slavapestov @xedin @hamishknight
+/test/Sema/moveonly*                                @kavon
+/test/Serialization/                                @xymus
+/test/SourceKit/                                    @hamishknight @rintaro
+/test/SymbolGraph/                                  @QuietMisdreavus
+/test/abi/                                          @swiftlang/standard-librarians
+/test/decl/                                         @hborla @slavapestov
+/test/decl/protocol/                                @AnthonyLatsis @hborla @slavapestov
+# FIXME: This file could have a dedicated directory.
+/test/decl/protocol/special/DistributedActor.swift  @ktoso
+/test/expr/                                         @hborla @slavapestov @xedin @hamishknight
+/test/refactoring/                                  @hamishknight @rintaro
+/test/sil*                                          @jckarter
+/test/sil-opt*                                      @eeckstein
+/test/stdlib/                                       @swiftlang/standard-librarians
+/test/stmt/                                         @hborla @xedin
+/test/type/                                         @hborla @slavapestov @xedin @hamishknight
+
+# tools
+# TODO: /tools
+/tools/*reflection/                                 @slavapestov
+/tools/SourceKit                                    @hamishknight @rintaro
+/tools/driver/                                      @artemcm
+/tools/lldb-moduleimport-test/                      @adrian-prantl
+/tools/swift-demangle*                              @rjmccall
+/tools/swift-ide-test                               @hamishknight @rintaro
+/tools/swift-inspect                                @mikeash @al45tair @compnerd
+/tools/swift-refactor                               @hamishknight @rintaro
+
+# unittests
+/unittests/*Demangl*/                     @rjmccall
+/unittests/AST/                           @hborla @slavapestov @xedin @hamishknight
+/unittests/AST/*Evaluator*                @CodaFi @slavapestov
+/unittests/DependencyScan/                @artemcm @cachemeifyoucan
+/unittests/Frontend*/                     @artemcm @tshortli
+/unittests/Parse/                         @CodaFi @DougGregor @hamishknight @rintaro
+/unittests/Reflection/                    @slavapestov
+/unittests/SIL/                           @jckarter
+/unittests/Sema/                          @hborla @xedin @hamishknight
+/unittests/SourceKit/                     @rintaro @hamishknight
+/unittests/runtime/                       @rjmccall
+
+# userdocs
+# TODO: /userdocs
+
+# utils
+/utils/*windows*                                              @compnerd
+/utils/availability-macros.def                                @swiftlang/standard-librarians
+/utils/build.ps1                                              @compnerd
+/utils/build_swift/                                           @etcwilde @justice-adams-apple @shahmishal @edymtt
+/utils/generate-xcode                                         @hamishknight
+/utils/gen-unicode-data                                       @swiftlang/standard-librarians
+/utils/gyb                                                    @swiftlang/standard-librarians
+/utils/gyb_foundation_support.py                              @swiftlang/standard-librarians
+/utils/gyb_sourcekit_support/                                 @hamishknight @rintaro
+/utils/gyb_stdlib_support.py                                  @swiftlang/standard-librarians
+/utils/gyb.py                                                 @swiftlang/standard-librarians
+/utils/sourcekit_fuzzer/                                      @hamishknight @rintaro
+/utils/swift-dev-utils/                                       @hamishknight
+/utils/swift_build_support/                                   @etcwilde @justice-adams-apple @shahmishal @edymtt
+/utils/swift_build_support/products/earlyswiftsyntax.py       @hamishknight @rintaro
+/utils/swift_build_support/products/skstresstester.py         @hamishknight @rintaro
+/utils/swift_build_support/products/sourcekitlsp.py           @hamishknight @rintaro
+/utils/swift_build_support/products/swiftformat.py            @allevato @hamishknight @rintaro
+/utils/swift_build_support/products/swiftsyntax.py            @hamishknight @rintaro
+/utils/swift_build_support/products/wasm*                     @MaxDesiatov @kateinoigakukun
+/utils/swift_build_support/products/wasi*                     @MaxDesiatov @kateinoigakukun
+/utils/update-checkout*                                       @etcwilde @justice-adams-apple @shahmishal
+/utils/update_checkout/                                       @etcwilde @justice-adams-apple @shahmishal
+/utils/update_checkout/update-checkout-config.json            @shahmishal
+/utils/vim/                                                   @compnerd
+
+# validation-test
+/validation-test/Driver/                  @artemcm
+/validation-test/IDE/                     @rintaro @hamishknight
+/validation-test/IRGen/                   @rjmccall
+/validation-test/Parse/                   @CodaFi @DougGregor @hamishknight @rintaro
+/validation-test/Reflection/              @slavapestov
+/validation-test/Runtime/                 @rjmccall
+/validation-test/SIL/                     @jckarter
+/validation-test/SILGen/                  @jckarter
+/validation-test/SILOptimizer/            @eeckstein
+/validation-test/Sema/                    @hborla @slavapestov @xedin @hamishknight
+/validation-test/Serialization/           @xymus
+/validation-test/stdlib/                  @swiftlang/standard-librarians

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,30 +1,17 @@
 <!--
-The main branch is now in convergence, which means major changes, such as large refactoring or new features, should be avoided. This strategy is intended to maintain the stability of the Swift 6.4 release leading up to the May 4th branch. For any work that requires broad changes or introduces new features, create a feature branch and open a draft pull request. All updates to the swiftlang/swift repository’s main branch require approval from the release managers. A pull request targeting swiftlang/swift will automatically add release managers. You can also contact them via @release-managers in the forum group.
--->
+If this pull request is targeting a release branch, please fill out the
+following form:
+https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1
 
-<!-- Please fill out the following form: --> 
-- **Explanation**:
-  <!--
-  A description of the changes. This can be brief, but it should be clear.
-  -->
-- **Scope**:
-  <!--
-  An assessment of the impact and importance of the changes. For example, can
-  the changes break existing code?
-  -->
-- **Issues**:
-  <!--
-  References to issues the changes resolve, if any.
-  -->
-- **Risk**:
-  <!--
-  The (specific) risk to the release for taking the changes.
-  -->
-- **Testing**:
-  <!--
-  The specific testing that has been done or needs to be done to further
-  validate any impact of the changes.
-  -->
+Otherwise, replace this comment with a description of your changes and
+rationale. Provide links to external references/discussions if appropriate.
+If this pull request resolves any GitHub issues, link them like so:
+
+  Resolves <link to issue>, resolves <link to another issue>.
+
+For more information about linking a pull request to an issue, see:
+https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
+-->
 
 <!--
 Before merging this pull request, you must run the Swift continuous integration tests.


### PR DESCRIPTION
This reverts commit f81cae9defe771775162636dfaaa7ae6db0e2330.

We no longer require @swiftlang/swift-branch-managers approval for `main` branch. 