### PR TITLE
IRGen/Runtime: emit noncopyable field metadata

### DIFF
--- a/include/swift/ABI/InvertibleProtocols.h
+++ b/include/swift/ABI/InvertibleProtocols.h
@@ -55,6 +55,14 @@ public:
       insert(element);
   }
 
+  /// A set containing every invertible protocol the runtime knows about,
+  /// minus the given one.
+  static InvertibleProtocolSet allExcept(InvertibleProtocolKind kind) {
+    InvertibleProtocolSet result(static_cast<StorageType>(~StorageType{0}));
+    result.remove(kind);
+    return result;
+  }
+
   /// Retrieve the raw bits that describe this set.
   StorageType rawBits() const { return bits; }
 

--- a/include/swift/ABI/Metadata.h
+++ b/include/swift/ABI/Metadata.h
@@ -3121,6 +3121,22 @@ struct swift_ptrauth_struct_context_descriptor(ContextDescriptor)
   const InvertibleProtocolSet *
   getInvertedProtocols() const;
 
+  /// Whether this type's primary definition is `~Protocol` and has no
+  /// conditional conformance to the protocol.
+  bool isUnconditionallySuppressing(InvertibleProtocolKind kind) const {
+    auto *inverted = getInvertedProtocols();
+    if (!inverted || !inverted->contains(kind))
+      return false;
+
+    if (auto *genericContext = getGenericContext()) {
+      if (genericContext->hasConditionalInvertedProtocols() &&
+          genericContext->getConditionalInvertedProtocols().contains(kind))
+        return false;
+    }
+
+    return true;
+  }
+
   /// Is this context part of a C-imported module?
   bool isCImportedContext() const;
 

--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -264,6 +264,8 @@ public:
   }
   
   /// True if values of this type can be copied.
+  /// NOTE: This is NOT accurate for types that are conditionally Copyable.
+  /// You may need to use `checkInvertibleRequirements`.
   bool isCopyable() const { return !(Data & IsNonCopyable); }
   constexpr TargetValueWitnessFlags withCopyable(bool isCopyable) const {
     return TargetValueWitnessFlags((Data & ~IsNonCopyable) |

--- a/include/swift/AST/FeatureAvailability.def
+++ b/include/swift/AST/FeatureAvailability.def
@@ -90,5 +90,6 @@ FEATURE(ClearSensitive,                                 FUTURE)
 FEATURE(UpdatePureObjCClassMetadata,                    FUTURE)
 // TODO: CoroutineAccessors: Change to correct version number.
 FEATURE(CoroutineAccessors,                             FUTURE)
+FEATURE(NoncopyableReflectionSafety,                    FUTURE)
 #undef FEATURE
 #undef FUTURE

--- a/include/swift/Runtime/GenericMetadataBuilder.h
+++ b/include/swift/Runtime/GenericMetadataBuilder.h
@@ -693,6 +693,7 @@ public:
     size_t size = layout.size;
     size_t alignMask = layout.flags.getAlignmentMask();
     bool isPOD = layout.flags.isPOD();
+    bool isCopyable = layout.flags.isCopyable();
     bool isBitwiseTakable = layout.flags.isBitwiseTakable();
 
     auto *fieldOffsetsStart = wordsOffset<StoredPointer>(
@@ -740,6 +741,8 @@ public:
       alignMask = std::max(alignMask, fieldLayout->flags.getAlignmentMask());
       if (!fieldLayout->flags.isPOD())
         isPOD = false;
+      if (!fieldLayout->flags.isCopyable())
+        isCopyable = false;
       if (!fieldLayout->flags.isBitwiseTakable())
         isBitwiseTakable = false;
 
@@ -750,6 +753,11 @@ public:
       }
     }
 
+    // If the struct is always noncopyable, we must honor that.
+    if (isCopyable && description->isUnconditionallySuppressing(
+                          InvertibleProtocolKind::Copyable))
+      isCopyable = false;
+
     bool isInline =
         ValueWitnessTable::isValueInline(isBitwiseTakable, size, alignMask + 1);
 
@@ -757,6 +765,7 @@ public:
     layout.flags = ValueWitnessFlags()
                        .withAlignmentMask(alignMask)
                        .withPOD(isPOD)
+                       .withCopyable(isCopyable)
                        .withBitwiseTakable(isBitwiseTakable)
                        .withInlineStorage(isInline);
     layout.extraInhabitantCount = extraInhabitantCount;

--- a/lib/Basic/Platform.cpp
+++ b/lib/Basic/Platform.cpp
@@ -762,6 +762,11 @@ findSwiftRuntimeVersionHelper(llvm::VersionTuple targetPlatformVersion,
                               ArrayRef<PlatformSwiftRelease> allReleases) {
   #define MAX(a, b) ((a) > (b) ? (a) : (b))
 
+  // If the target release is at least the notional future-release version,
+  // return that we aren't deployment-limited.
+  if (targetPlatformVersion >= llvm::VersionTuple(99, 99))
+    return std::nullopt;
+
   // Scan forward in our filtered platform release array for the given
   // platform.
   for (auto &release : allReleases) {
@@ -774,12 +779,6 @@ findSwiftRuntimeVersionHelper(llvm::VersionTuple targetPlatformVersion,
       return std::max(release.swiftVersion, minimumSwiftVersion);
     }
   }
-
-  // If we didn't find anything, but the target release is at least the
-  // notional future-release version, return that we aren't
-  // deployment-limited.
-  if (targetPlatformVersion >= llvm::VersionTuple(99, 99))
-    return std::nullopt;
 
   // Otherwise, return the minimum Swift version.
   return minimumSwiftVersion;

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -7869,8 +7869,7 @@ GenericArgumentMetadata irgen::addGenericRequirements(
       if (auto invertible = protocol->getInvertibleProtocolKind()) {
         ++metadata.NumRequirements;
 
-        InvertibleProtocolSet mask(0xFFFF);
-        mask.remove(*invertible);
+        auto mask = InvertibleProtocolSet::allExcept(*invertible);
 
         auto flags = GenericRequirementFlags(
             GenericRequirementKind::InvertedProtocols,

--- a/lib/IRGen/GenReflection.cpp
+++ b/lib/IRGen/GenReflection.cpp
@@ -391,7 +391,7 @@ getTypeRefByFunction(IRGenModule &IGM, CanGenericSignature sig, CanType t,
             // updated.
             if (IGM.getSwiftModule()->isStdlibModule()) {
               runtimeSupportsNoncopyableTypesSymbol
-                  = llvm::ConstantInt::get(IGM.Int8Ty, 0);
+                  = llvm::ConstantInt::get(IGM.Int8Ty, 1);
             } else {
               runtimeSupportsNoncopyableTypesSymbol
                   = IGM.Module.getOrInsertGlobal(

--- a/lib/IRGen/GenReflection.cpp
+++ b/lib/IRGen/GenReflection.cpp
@@ -384,11 +384,9 @@ getTypeRefByFunction(IRGenModule &IGM, CanGenericSignature sig, CanType t,
             // This is weird. When building the stdlib, we don't have access to
             // the swift_runtimeSupportsNoncopyableTypes symbol in the Swift.o,
             // so we'll emit an adrp + ldr to resolve the GOT address. However,
-            // this symbol is defined as an abolsute in the runtime object files
-            // to address 0x0 right now and ld doesn't quite understand how to
-            // fixup this GOT address when merging the runtime and stdlib. Just
-            // unconditionally fail the branch.
-            //
+            // this symbol is defined as an absolute in the runtime object files
+            // and ld doesn't quite understand how to fixup this GOT address
+            // when merging the runtime and stdlib. Just hardcode the value.
             // Note: When the value of this symbol changes, this MUST be
             // updated.
             if (IGM.getSwiftModule()->isStdlibModule()) {
@@ -487,49 +485,57 @@ getTypeRefImpl(IRGenModule &IGM,
     break;
     
   case MangledTypeRefRole::FieldMetadata: {
-    // We want to keep fields of noncopyable type from being exposed to
-    // in-process runtime reflection libraries in older Swift runtimes, since
-    // they more than likely assume they can copy field values, and the language
-    // support for noncopyable types as dynamic or generic types isn't yet
-    // implemented as of the writing of this comment. If the type is
-    // noncopyable, use a function to emit the type ref which will look for a
-    // signal from future runtimes whether they support noncopyable types before
-    // exposing their metadata to them.
-    Type contextualTy = type;
-    if (sig) {
-      contextualTy = sig.getGenericEnvironment()->mapTypeIntoEnvironment(type);
+    // If the deployment target's runtime doesn't have the isCopyable guards
+    // for Mirror, we need to hide unconditionally noncopyable fields behind
+    // an accessor function that checks swift_runtimeSupportsNoncopyableTypes
+    // at runtime, to prevent old Mirror implementations from crashing when
+    // they try to copy noncopyable field values.
+    bool needsNoncopyableGuard = false;
+    auto reflectionSafety =
+        IGM.Context.getNoncopyableReflectionSafetyAvailability();
+    if (!AvailabilityRange::forDeploymentTarget(IGM.Context)
+             .isContainedIn(reflectionSafety)) {
+      needsNoncopyableGuard = true;
     }
 
-    bool isAlwaysNoncopyable = false;
-    if (contextualTy->isNoncopyable()) {
-      isAlwaysNoncopyable = true;
+    if (needsNoncopyableGuard) {
+      Type contextualTy = type;
+      if (sig) {
+        contextualTy =
+            sig.getGenericEnvironment()->mapTypeIntoEnvironment(type);
+      }
 
-      // If the contextual type has any archetypes in it, it's plausible that
-      // we could end up with a copyable type in some instances. Look for those
-      // so we can permit unsafe reflection of the field, by assuming it could
-      // be Copyable.
-      if (contextualTy->hasArchetype()) {
-        // If this is a nominal type, check whether it can ever be copyable.
-        if (auto nominal = contextualTy->getAnyNominal()) {
-          // If it's a nominal that can ever be Copyable _and_ it's defined in
-          // the stdlib, assume that we could end up with a Copyable type.
-          if (nominal->canBeCopyable()
-              && nominal->getModuleContext()->isStdlibModule())
+      bool isAlwaysNoncopyable = false;
+      if (contextualTy->isNoncopyable()) {
+        isAlwaysNoncopyable = true;
+
+        // If the contextual type has any archetypes in it, it's plausible that
+        // we could end up with a copyable type in some instances. Look for
+        // those so we can permit unsafe reflection of the field, by assuming it
+        // could be Copyable.
+        if (contextualTy->hasArchetype()) {
+          // If this is a nominal type, check whether it can ever be copyable.
+          if (auto nominal = contextualTy->getAnyNominal()) {
+            // If it's a nominal that can ever be Copyable _and_ it's defined in
+            // the stdlib, assume that we could end up with a Copyable type.
+            if (nominal->canBeCopyable()
+                && nominal->getModuleContext()->isStdlibModule())
+              isAlwaysNoncopyable = false;
+          } else {
+            // Assume that we could end up with a Copyable type somehow.
+            // This allows you to reflect a 'T: ~Copyable' stored in a type.
             isAlwaysNoncopyable = false;
-        } else {
-          // Assume that we could end up with a Copyable type somehow.
-          // This allows you to reflect a 'T: ~Copyable' stored in a type.
-          isAlwaysNoncopyable = false;
+          }
         }
       }
-    }
 
-    // The getTypeRefByFunction strategy will emit a forward-compatible runtime
-    // check to see if the runtime can safely reflect such fields. Otherwise,
-    // the field will be artificially hidden to reflectors.
-    if (isAlwaysNoncopyable) {
-      IGM.IRGen.noteUseOfTypeMetadata(type);
-      return getTypeRefByFunction(IGM, sig, type, role);
+      // The getTypeRefByFunction strategy will emit a forward-compatible
+      // runtime check to see if the runtime can safely reflect such fields.
+      // Otherwise, the field will be artificially hidden to reflectors.
+      if (isAlwaysNoncopyable) {
+        IGM.IRGen.noteUseOfTypeMetadata(type);
+        return getTypeRefByFunction(IGM, sig, type, role);
+      }
     }
   }
   LLVM_FALLTHROUGH;

--- a/stdlib/public/runtime/Enum.cpp
+++ b/stdlib/public/runtime/Enum.cpp
@@ -58,10 +58,16 @@ swift::swift_initEnumMetadataSingleCase(EnumMetadata *self,
                                         const TypeLayout *payloadLayout) {
   auto vwtable = getMutableVWTableForInit(self, layoutFlags);
 
+  bool isCopyable = payloadLayout->flags.isCopyable() &&
+                    !self->getDescription()->isUnconditionallySuppressing(
+                        InvertibleProtocolKind::Copyable);
+
   TypeLayout layout;
   layout.size = payloadLayout->size;
   layout.stride = payloadLayout->stride;
-  layout.flags = payloadLayout->flags.withEnumWitnesses(true);
+  layout.flags = payloadLayout->flags
+      .withCopyable(isCopyable)
+      .withEnumWitnesses(true);
   layout.extraInhabitantCount = payloadLayout->getNumExtraInhabitants();
 
   vwtable->publishLayout(layout);
@@ -75,10 +81,16 @@ static void swift_cvw_initEnumMetadataSingleCaseWithLayoutStringImpl(
   auto payloadLayout = payloadType->getTypeLayout();
   auto vwtable = getMutableVWTableForInit(self, layoutFlags);
 
+  bool isCopyable = payloadLayout->flags.isCopyable() &&
+                    !self->getDescription()->isUnconditionallySuppressing(
+                        InvertibleProtocolKind::Copyable);
+
   TypeLayout layout;
   layout.size = payloadLayout->size;
   layout.stride = payloadLayout->stride;
-  layout.flags = payloadLayout->flags.withEnumWitnesses(true);
+  layout.flags = payloadLayout->flags
+      .withCopyable(isCopyable)
+      .withEnumWitnesses(true);
   layout.extraInhabitantCount = payloadLayout->getNumExtraInhabitants();
 
   auto refCountBytes = _swift_refCountBytesForMetatype(payloadType);
@@ -146,13 +158,18 @@ swift::swift_initEnumMetadataSinglePayload(EnumMetadata *self,
   }
 
   auto vwtable = getMutableVWTableForInit(self, layoutFlags);
-  
+
+  bool isCopyable = payloadLayout->flags.isCopyable() &&
+                    !self->getDescription()->isUnconditionallySuppressing(
+                        InvertibleProtocolKind::Copyable);
+
   size_t align = payloadLayout->flags.getAlignment();
   bool isBT = payloadLayout->flags.isBitwiseTakable();
   TypeLayout layout;
   layout.size = size;
   layout.flags =
       payloadLayout->flags
+          .withCopyable(isCopyable)
           .withEnumWitnesses(true)
           .withInlineStorage(
               ValueWitnessTable::isValueInline(isBT, size, align));
@@ -249,12 +266,19 @@ static void swift_cvw_initEnumMetadataSinglePayloadWithLayoutStringImpl(
 
   auto vwtable = getMutableVWTableForInit(self, layoutFlags);
 
+  bool isCopyable = payloadLayout->flags.isCopyable() &&
+                    !self->getDescription()->isUnconditionallySuppressing(
+                        InvertibleProtocolKind::Copyable);
+
   size_t align = payloadLayout->flags.getAlignment();
   bool isBT = payloadLayout->flags.isBitwiseTakable();
   TypeLayout layout;
   layout.size = size;
-  layout.flags = payloadLayout->flags.withEnumWitnesses(true).withInlineStorage(
-      ValueWitnessTable::isValueInline(isBT, size, align));
+  layout.flags = payloadLayout->flags
+      .withCopyable(isCopyable)
+      .withEnumWitnesses(true)
+      .withInlineStorage(
+          ValueWitnessTable::isValueInline(isBT, size, align));
   layout.extraInhabitantCount = unusedExtraInhabitants;
   auto rawStride = llvm::alignTo(size, align);
   layout.stride = rawStride == 0 ? 1 : rawStride;
@@ -387,7 +411,7 @@ swift::swift_initEnumMetadataMultiPayload(EnumMetadata *enumType,
                                      const TypeLayout * const *payloadLayouts) {
   // Accumulate the layout requirements of the payloads.
   size_t payloadSize = 0, alignMask = 0;
-  bool isPOD = true, isBT = true, isBB = true, isAFD = false;
+  bool isPOD = true, isBT = true, isBB = true, isAFD = false, isCopyable = true;
   for (unsigned i = 0; i < numPayloads; ++i) {
     const TypeLayout *payloadLayout = payloadLayouts[i];
     payloadSize
@@ -397,7 +421,14 @@ swift::swift_initEnumMetadataMultiPayload(EnumMetadata *enumType,
     isBT &= payloadLayout->flags.isBitwiseTakable();
     isBB &= payloadLayout->flags.isBitwiseBorrowable();
     isAFD |= payloadLayout->flags.isAddressableForDependencies();
+    isCopyable &= payloadLayout->flags.isCopyable();
   }
+
+  // If the enum is unconditionally noncopyable, then it doesn't matter if the
+  // payloads are copyable.
+  if (isCopyable && enumType->getDescription()->isUnconditionallySuppressing(
+                        InvertibleProtocolKind::Copyable))
+    isCopyable = false;
   
   // Store the max payload size in the metadata.
   assignUnlessEqual(enumType->getPayloadSize(), payloadSize);
@@ -424,6 +455,7 @@ swift::swift_initEnumMetadataMultiPayload(EnumMetadata *enumType,
                     ValueWitnessFlags()
                      .withAlignmentMask(alignMask)
                      .withPOD(isPOD)
+                     .withCopyable(isCopyable)
                      .withBitwiseTakable(isBT)
                      .withBitwiseBorrowable(isBB)
                      .withAddressableForDependencies(isAFD)
@@ -451,7 +483,7 @@ static void swift_cvw_initEnumMetadataMultiPayloadWithLayoutStringImpl(
 
   // Accumulate the layout requirements of the payloads.
   size_t payloadSize = 0, alignMask = 0;
-  bool isPOD = true, isBT = true, isBB = true, isAFD = false;
+  bool isPOD = true, isBT = true, isBB = true, isAFD = false, isCopyable = true;
 
   size_t payloadRefCountBytes = 0;
   for (unsigned i = 0; i < numPayloads; ++i) {
@@ -463,11 +495,18 @@ static void swift_cvw_initEnumMetadataMultiPayloadWithLayoutStringImpl(
     isBT &= payloadLayout->flags.isBitwiseTakable();
     isBB &= payloadLayout->flags.isBitwiseBorrowable();
     isAFD |= payloadLayout->flags.isAddressableForDependencies();
+    isCopyable &= payloadLayout->flags.isCopyable();
 
     payloadRefCountBytes += _swift_refCountBytesForMetatype(payloadLayouts[i]);
     // NUL terminator
     payloadRefCountBytes += sizeof(uint64_t);
   }
+
+  // If the enum is unconditionally noncopyable, then it doesn't matter if the
+  // payloads are copyable.
+  if (isCopyable && enumType->getDescription()->isUnconditionallySuppressing(
+                        InvertibleProtocolKind::Copyable))
+    isCopyable = false;
 
   // Store the max payload size in the metadata.
   assignUnlessEqual(enumType->getPayloadSize(), payloadSize);
@@ -561,6 +600,7 @@ static void swift_cvw_initEnumMetadataMultiPayloadWithLayoutStringImpl(
                     ValueWitnessFlags()
                      .withAlignmentMask(alignMask)
                      .withPOD(isPOD)
+                     .withCopyable(isCopyable)
                      .withBitwiseTakable(isBT)
                      .withBitwiseBorrowable(isBB)
                      .withAddressableForDependencies(isAFD)

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -88,7 +88,7 @@ using namespace metadataimpl;
 // zero, then the metadata is not exposed to the runtime. Binaries weak-import
 // this symbol so they will resolve it to a zero address on older runtimes too.
 __asm__("  .globl _swift_runtimeSupportsNoncopyableTypes\n");
-__asm__(".set _swift_runtimeSupportsNoncopyableTypes, 0\n");
+__asm__(".set _swift_runtimeSupportsNoncopyableTypes, 1\n");
 #endif
 
 // GenericParamDescriptor is a single byte, so while it's difficult to

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -82,17 +82,11 @@ using namespace swift;
 using namespace metadataimpl;
 
 #if defined(__APPLE__)
-// Binaries using noncopyable types check the address of the symbol
-// `swift_runtimeSupportsNoncopyableTypes` before exposing any noncopyable
-// type metadata through in-process reflection, to prevent existing code
-// that expects all types to be copyable from crashing or causing bad behavior
-// by copying noncopyable types. The runtime does not yet support noncopyable
-// types, so we explicitly define this symbol to be zero for now. Binaries
-// weak-import this symbol so they will resolve it to a zero address on older
-// runtimes as well.
-//
-// Note: If this symbol's value ever gets updated, the corresponding condition
-// handled by IRGen MUST be updated in tandem.
+// Binaries compiled with older deployment targets check the address of the
+// symbol `swift_runtimeSupportsNoncopyableTypes` before exposing any
+// noncopyable type metadata through in-process reflection. If the address is
+// zero, then the metadata is not exposed to the runtime. Binaries weak-import
+// this symbol so they will resolve it to a zero address on older runtimes too.
 __asm__("  .globl _swift_runtimeSupportsNoncopyableTypes\n");
 __asm__(".set _swift_runtimeSupportsNoncopyableTypes, 0\n");
 #endif
@@ -2608,6 +2602,7 @@ static void performBasicLayout(TypeLayout &layout,
   size_t size = layout.size;
   size_t alignMask = layout.flags.getAlignmentMask();
   bool isPOD = layout.flags.isPOD();
+  bool isCopyable = layout.flags.isCopyable();
   bool isBitwiseTakable = layout.flags.isBitwiseTakable();
   bool isBitwiseBorrowable = layout.flags.isBitwiseBorrowable();
   bool isAddressableForDependencies = layout.flags.isAddressableForDependencies();
@@ -2625,6 +2620,7 @@ static void performBasicLayout(TypeLayout &layout,
     size += eltLayout->size;
     alignMask = std::max(alignMask, eltLayout->flags.getAlignmentMask());
     if (!eltLayout->flags.isPOD()) isPOD = false;
+    if (!eltLayout->flags.isCopyable()) isCopyable = false;
     if (!eltLayout->flags.isBitwiseTakable()) isBitwiseTakable = false;
     if (!eltLayout->flags.isBitwiseBorrowable()) isBitwiseBorrowable = false;
     if (eltLayout->flags.isAddressableForDependencies())
@@ -2637,6 +2633,7 @@ static void performBasicLayout(TypeLayout &layout,
   layout.flags = ValueWitnessFlags()
                      .withAlignmentMask(alignMask)
                      .withPOD(isPOD)
+                     .withCopyable(isCopyable)
                      .withBitwiseTakable(isBitwiseTakable)
                      .withBitwiseBorrowable(isBitwiseBorrowable)
                      .withAddressableForDependencies(isAddressableForDependencies)
@@ -3220,6 +3217,12 @@ void swift::swift_initStructMetadata(StructMetadata *structType,
         assignUnlessEqual(fieldOffsets[i], offset);
       });
 
+  // If the struct is always noncopyable, we must honor that.
+  if (layout.flags.isCopyable() &&
+      structType->getDescription()->isUnconditionallySuppressing(
+          InvertibleProtocolKind::Copyable))
+    layout.flags = layout.flags.withCopyable(false);
+
   // We have extra inhabitants if any element does. Use the field with the most.
   unsigned extraInhabitantCount = 0;
   for (unsigned i = 0; i < numFields; ++i) {
@@ -3258,6 +3261,12 @@ static void swift_cvw_initStructMetadataWithLayoutStringImpl(
       [&](size_t i, const uint8_t *fieldType, uint32_t offset) {
         assignUnlessEqual(fieldOffsets[i], offset);
       });
+
+  // If the struct is always noncopyable, we must honor that.
+  if (layout.flags.isCopyable() &&
+        structType->getDescription()->isUnconditionallySuppressing(
+            InvertibleProtocolKind::Copyable))
+    layout.flags = layout.flags.withCopyable(false);
 
   // We have extra inhabitants if any element does. Use the field with the most.
   unsigned extraInhabitantCount = 0;

--- a/stdlib/public/runtime/Private.h
+++ b/stdlib/public/runtime/Private.h
@@ -784,6 +784,12 @@ public:
   id _quickLookObjectForPointer(void *value);
 #endif
 
+  /// Check that the given `type` conforms to all invertible protocols not in
+  /// `ignored`. Returns an error if the type fails to conform to one of them.
+  std::optional<TypeLookupError>
+  checkInvertibleRequirements(const Metadata *type,
+                              InvertibleProtocolSet ignored);
+
   /// Hook function that calls into the concurrency library to check whether
   /// we are currently executing the given global actor.
   SWIFT_RUNTIME_LIBRARY_VISIBILITY

--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -1796,10 +1796,6 @@ bool swift::_swift_class_isSubclass(const Metadata *subclass,
 }
 
 static std::optional<TypeLookupError>
-checkInvertibleRequirements(const Metadata *type,
-                              InvertibleProtocolSet ignored);
-
-static std::optional<TypeLookupError>
 checkGenericRequirement(
     const GenericRequirementDescriptor &req,
     llvm::SmallVectorImpl<const void *> &extraArguments,
@@ -2293,8 +2289,8 @@ checkInvertibleRequirementsStructural(const Metadata *type,
 /// Check that the given `type` meets all invertible protocol requirements
 /// that haven't been explicitly suppressed by `ignored`.
 std::optional<TypeLookupError>
-checkInvertibleRequirements(const Metadata *type, 
-                              InvertibleProtocolSet ignored) {
+swift::checkInvertibleRequirements(const Metadata *type,
+                                   InvertibleProtocolSet ignored) {
   auto contextDescriptor = type->getTypeContextDescriptor();
   if (!contextDescriptor)
     return checkInvertibleRequirementsStructural(type, ignored);

--- a/stdlib/public/runtime/ReflectionMirror.cpp
+++ b/stdlib/public/runtime/ReflectionMirror.cpp
@@ -163,10 +163,30 @@ static void copyUnmanagedFieldContents(OpaqueValue *destContainer, const Metadat
   type->vw_initializeWithCopy(destContainer, fieldData);
 }
 
+/// Whether `type` should be treated as Copyable for Mirror's purposes. The VWT
+/// bit alone is unreliable for conditionally-Copyable types whose layout does
+/// not depend on their generic args (they share one VWT across instantiations).
+static bool isCopyableForReflection(const Metadata *type) {
+  if (!type->getValueWitnesses()->flags.isCopyable())
+    return false;
+  auto *descriptor = type->getTypeContextDescriptor();
+  if (!descriptor || !descriptor->hasInvertibleProtocols())
+    return true;
+  auto mask = InvertibleProtocolSet::allExcept(
+      InvertibleProtocolKind::Copyable);
+  return !checkInvertibleRequirements(type, mask).has_value();
+}
+
 static AnyReturn copyFieldContents(OpaqueValue *fieldData,
                                         const FieldType fieldType) {
   Any outValue;
   auto *type = fieldType.getType();
+
+  if (!isCopyableForReflection(type)) {
+    outValue.Type = &METADATA_SYM(EMPTY_TUPLE_MANGLING);
+    return AnyReturn(outValue);
+  }
+
   outValue.Type = type;
   auto ownership = fieldType.getReferenceOwnership();
   auto *destContainer = type->allocateBoxForExistentialIn(&outValue.Buffer);
@@ -619,6 +639,15 @@ struct EnumImpl : ReflectionMirrorImpl {
 
     auto *caseName = getInfo(&tag, &payloadType, &indirect);
 
+    *outName = caseName;
+    *outFreeFunc = nullptr;
+
+    if (!isCopyableForReflection(type)) {
+      Any result;
+      result.Type = &METADATA_SYM(EMPTY_TUPLE_MANGLING);
+      return AnyReturn(result);
+    }
+
     // Copy the enum itself so that we can project the data without destroying
     // the original.
     Any enumCopy;
@@ -641,10 +670,7 @@ struct EnumImpl : ReflectionMirrorImpl {
       const HeapObject *owner = *reinterpret_cast<HeapObject * const *>(value);
       value = swift_projectBox(const_cast<HeapObject *>(owner));
     }
-    
-    *outName = caseName;
-    *outFreeFunc = nullptr;
-    
+
     Any result;
 
     result.Type = payloadType;

--- a/test/IRGen/noncopyable_field_descriptors.swift
+++ b/test/IRGen/noncopyable_field_descriptors.swift
@@ -11,8 +11,18 @@
 // RUN:   -target %target-cpu-apple-macosx14 \
 // RUN:   > %t/test_old.irgen
 
+// When targeting an OS new enough to ship the runtime with the noncopyable
+// Mirror guards, the accessor function is elided and the field's typeref is
+// referenced directly.
+// RUN: %swift-frontend -emit-ir -o - %s -module-name test \
+// RUN:   -parse-as-library \
+// RUN:   -enable-library-evolution \
+// RUN:   -target %target-future-triple \
+// RUN:   > %t/test_safe_runtime.irgen
+
 // RUN: %FileCheck --check-prefix=NEW %s < %t/test_new.irgen
 // RUN: %FileCheck --check-prefix=OLD %s < %t/test_old.irgen
+// RUN: %FileCheck --check-prefix=SAFE-RUNTIME %s < %t/test_safe_runtime.irgen
 
 // rdar://124401253
 // REQUIRES: OS=macosx
@@ -37,6 +47,8 @@ public struct NonCopyable: ~Copyable { }
 
 // HINT: when debugging this test, you can look for an `i32 2` field in the
 // 'MF' constant as a separator that precedes each field descriptor.
+
+// SAFE-RUNTIME-NOT: get_type_metadata{{.*}}noncopyable
 
 // NEW: @"$s4test8CC_TestsCMF" =
 // NEW-SAME: @"get_type_metadata Ri_zr0_l4test21ConditionallyCopyableOyxG noncopyable

--- a/test/Interpreter/moveonly_reflection.swift
+++ b/test/Interpreter/moveonly_reflection.swift
@@ -1,20 +1,11 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-build-swift -D CRASH %s -o %t/crash
-// RUN: %target-codesign %t/crash
-
 // RUN: %target-build-swift %s -o %t/exe
 // RUN: %target-codesign %t/exe
-
-// RUN: %target-run %t/exe | %FileCheck %s
-// RUN: %target-run not --crash %t/crash
+// RUN: %target-run %t/exe > %t/output.txt
+// RUN: %FileCheck %s < %t/output.txt
 
 // REQUIRES: executable_test
-
-// Simulators and devices don't appear to have the 'not' binary in their PATH
-// to handle tests that intentionally crash such as this.
-// UNSUPPORTED: DARWIN_SIMULATOR={{.*}}
-// UNSUPPORTED: remote_run || device_run
 
 enum Maybe<Wrapped: ~Copyable>: ~Copyable {
   case some(Wrapped)
@@ -26,6 +17,40 @@ struct NC: ~Copyable {
   let data: Int
 }
 
+struct PairNC: ~Copyable {
+  var x: Int
+  var y: NC
+}
+
+enum NCEnum: ~Copyable {
+  case leaf(Int)
+  case pair(NC, Int)
+}
+
+// Conditionally Copyable; no T-typed storage.
+struct FactoryOf<T: ~Copyable>: ~Copyable {
+  var producedCount: Int = 42
+}
+extension FactoryOf: Copyable where T: Copyable {}
+
+// Unconditionally noncopyable generic enum (single-payload).
+enum NCBox<T: ~Copyable>: ~Copyable {
+  case value(T)
+  case empty
+}
+
+// Unconditionally noncopyable generic enum (multi-payload).
+enum NCEither<L: ~Copyable, R: ~Copyable>: ~Copyable {
+  case left(L)
+  case right(R)
+}
+
+// Unconditionally noncopyable generic struct.
+struct NCHolder<T: ~Copyable>: ~Copyable {
+  var value: T
+  var extra: Int
+}
+
 class Protected<T: ~Copyable> {
   var field: Maybe<T>
   init(_ t: consuming T) {
@@ -33,6 +58,7 @@ class Protected<T: ~Copyable> {
   }
 }
 
+// We used to make an exception for stdlib types and permit reflection that can crash Mirror.
 class Dangerous<T: ~Copyable> {
   var field: Optional<T>
   init(_ t: consuming T) {
@@ -40,18 +66,130 @@ class Dangerous<T: ~Copyable> {
   }
 }
 
-func printFields<T: Copyable>(_ val: T) {
-  let mirror = Mirror.init(reflecting: val)
-  mirror.children.forEach { print($0.label ?? "", $0.value) }
+class HoldsNCBox<T: ~Copyable> {
+  var field: NCBox<T>
+  init(_ t: consuming T) {
+    self.field = .value(t)
+  }
+}
+
+class HoldsNCEither<L: ~Copyable, R: ~Copyable> {
+  var field: NCEither<L, R>
+  init(left: consuming L) {
+    self.field = .left(left)
+  }
+  init(right: consuming R) {
+    self.field = .right(right)
+  }
+}
+
+class HoldsNCHolder<T: ~Copyable> {
+  var field: NCHolder<T>
+  init(_ t: consuming T) {
+    self.field = NCHolder(value: t, extra: 7)
+  }
+}
+
+class MultiField {
+  var name: String
+  var value: NC
+  var count: Int
+  init(_ name: String, _ value: consuming NC, _ count: Int) {
+    self.name = name
+    self.value = value
+    self.count = count
+  }
+}
+
+class HoldsFactoryOf<T: ~Copyable> {
+  var field: FactoryOf<T>
+  init(_: consuming T.Type) {
+    self.field = FactoryOf<T>()
+  }
+}
+
+func printMirror<T: Copyable>(_ val: T) {
+  let mirror = Mirror(reflecting: val)
+  print("--- \(mirror.displayStyle.map { "\($0)" } ?? "none") ---")
+  mirror.children.forEach { print($0.label ?? "?", $0.value) }
 }
 
 defer { test() }
 func test() {
-#if CRASH
-  printFields(Dangerous(NC(data: 22)))
-#else
-  printFields(Protected("oreo"))        // CHECK: field ()
-  printFields(Protected(NC(data: 11)))  // CHECK: field ()
-  printFields(Dangerous("spots"))       // CHECK: field Optional("spots")
-#endif
+  // *** Struct/class fields containing noncopyable types
+  // CHECK-LABEL: --- class ---
+  // CHECK-NEXT: field some("oreo")
+  printMirror(Protected("oreo"))
+
+  // CHECK-LABEL: --- class ---
+  // CHECK-NEXT: field ()
+  printMirror(Protected(NC(data: 11)))
+
+  // CHECK-LABEL: --- class ---
+  // CHECK-NEXT: field Optional("spots")
+  printMirror(Dangerous("spots"))
+
+  // CHECK-LABEL: --- class ---
+  // CHECK-NEXT: field ()
+  printMirror(Dangerous(NC(data: 22)))
+
+  // *** Class with multiple fields, some noncopyable.
+  // CHECK-LABEL: --- class ---
+  // CHECK-NEXT: name hello
+  // CHECK-NEXT: value ()
+  // CHECK-NEXT: count 42
+  printMirror(MultiField("hello", NC(data: 7), 42))
+
+  // *** Reflecting a conditionally-copyable struct field that is noncopyable
+  // CHECK-LABEL: --- class ---
+  // CHECK-NEXT: field ()
+  printMirror(Protected(PairNC(x: 1, y: NC(data: 2))))
+
+  // *** Copyable enum with copyable payload
+  // CHECK-LABEL: --- optional ---
+  // CHECK-NEXT: some cat
+  printMirror(Optional<String>.some("cat"))
+
+  // *** Copyable enum (Optional) with noncopyable payload
+  // CHECK-LABEL: --- class ---
+  // CHECK-NEXT: field ()
+  printMirror(Dangerous(NC(data: 99)))
+
+  // *** Noncopyable enum whose payload is copyable
+  // CHECK-LABEL: --- class ---
+  // CHECK-NEXT: field ()
+  printMirror(Protected(NCEnum.leaf(5)))
+
+  // *** Conditionally-copyable enum with copyable payload.
+  // CHECK-LABEL: --- class ---
+  // CHECK-NEXT: field some("hi")
+  printMirror(Protected("hi"))
+
+  // *** Always-noncopyable generic enum with copyable payload
+  // CHECK-LABEL: --- class ---
+  // CHECK-NEXT: field ()
+  printMirror(HoldsNCBox("swift"))
+
+  // *** Always-noncopyable multi-payload generic enum with copyable payloads
+  // CHECK-LABEL: --- class ---
+  // CHECK-NEXT: field ()
+  printMirror(HoldsNCEither<String, Int>(left: "hello"))
+
+  // CHECK-LABEL: --- class ---
+  // CHECK-NEXT: field ()
+  printMirror(HoldsNCEither<String, Int>(right: 42))
+
+  // *** Always-noncopyable generic struct with copyable fields
+  // CHECK-LABEL: --- class ---
+  // CHECK-NEXT: field ()
+  printMirror(HoldsNCHolder("world"))
+
+  // *** Conditionally Copyable struct with no T-typed fields:
+  // FactoryOf<String> is Copyable; FactoryOf<NC> is not.
+  // CHECK-LABEL: --- class ---
+  // CHECK-NEXT: field FactoryOf<String>(producedCount: 42)
+  printMirror(HoldsFactoryOf(String.self))
+  // CHECK-LABEL: --- class ---
+  // CHECK-NEXT: field ()
+  printMirror(HoldsFactoryOf(NC.self))
 }

--- a/test/Reflection/noncopyable_field_typeref.swift
+++ b/test/Reflection/noncopyable_field_typeref.swift
@@ -1,0 +1,60 @@
+// Verify that swift-reflection-dump can decode field type references for
+// types containing noncopyable fields.
+
+// REQUIRES: no_asan
+
+// LC_DYLD_CHAINED_FIXUPS decode not currently supported (default on visionOS)
+// UNSUPPORTED: OS=xros
+
+// rdar://100805115
+// UNSUPPORTED: CPU=arm64e
+
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -target %module-target-future %s -parse-as-library -emit-module -emit-library -module-name NoncopyableFields -o %t/%target-library-name(NoncopyableFields)
+// RUN: %target-swift-reflection-dump %t/%target-library-name(NoncopyableFields) | %FileCheck %s
+
+struct NC: ~Copyable {}
+
+struct AlwaysNoncopyableBox<T>: ~Copyable {
+  var value: T
+}
+
+struct ConditionallyNoncopyableBox<T: ~Copyable>: ~Copyable {
+  var value: T
+}
+extension ConditionallyNoncopyableBox: Copyable where T: Copyable {}
+
+struct Outer<U>: ~Copyable {
+  var box: AlwaysNoncopyableBox<U>
+  var condCopyableBox1: ConditionallyNoncopyableBox<Int>
+  var condCopyableBox2: ConditionallyNoncopyableBox<NC>
+}
+
+// CHECK: FIELDS:
+// CHECK: =======
+// CHECK: NoncopyableFields.NC
+// CHECK: --------------------
+
+// CHECK: NoncopyableFields.AlwaysNoncopyableBox
+// CHECK: --------------------------------------
+// CHECK: value: A
+// CHECK: (generic_type_parameter depth=0 index=0)
+
+// CHECK: NoncopyableFields.ConditionallyNoncopyableBox
+// CHECK: ---------------------------------------------
+// CHECK: value: A
+// CHECK: (generic_type_parameter depth=0 index=0)
+
+// CHECK: NoncopyableFields.Outer
+// CHECK: -----------------------
+// CHECK: box: NoncopyableFields.AlwaysNoncopyableBox<A>
+// CHECK-NEXT: (bound_generic_struct NoncopyableFields.AlwaysNoncopyableBox
+// CHECK-NEXT:   (generic_type_parameter depth=0 index=0))
+
+// CHECK: condCopyableBox1: NoncopyableFields.ConditionallyNoncopyableBox<Swift.Int>
+// CHECK-NEXT: (bound_generic_struct NoncopyableFields.ConditionallyNoncopyableBox
+// CHECK-NEXT:   (struct Swift.Int))
+
+// CHECK: condCopyableBox2: NoncopyableFields.ConditionallyNoncopyableBox<NoncopyableFields.NC>
+// CHECK-NEXT: (bound_generic_struct NoncopyableFields.ConditionallyNoncopyableBox
+// CHECK-NEXT:   (struct NoncopyableFields.NC))


### PR DESCRIPTION
Since Mirror's APIs can only return values of type `Any`, we artificially hid the field metadata are emitted by the compiler so Mirror doesn't see it, in `d755e90`, or else Mirror woud end up crashing at runtime.

The unfortunate consequence of that was that it also prevents lldb's `frame variable` dumping from working via RemoteMirror.

This change instead has the compiler emit the metadata when targeting newer runtimes, and instead pushes the responsibility of the "hiding" of these fields onto the runtime. The runtime functions backing Mirror will now check dynamically if there was a request to copy a noncopyable field, and if so, it instead returns `()` like we were doing statically in the compiler.

rdar://176282041

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
