### PR TITLE
[MoveOnlyPartialConsumption] Drop stale visibility assertion

### DIFF
--- a/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
@@ -1821,13 +1821,6 @@ shouldEmitPartialMutationErrorForType(SILType ty, NominalTypeDecl *nominal,
   if (nominal->getModuleContext() == fn->getModule().getSwiftModule())
     return std::nullopt;
 
-  // It's defined in another module and used here; it has to be visible.
-  assert(nominal
-             ->getFormalAccessScope(
-                 /*useDC=*/fn->getDeclContext(),
-                 /*treatUsableFromInlineAsPublic=*/true)
-             .isPublicOrPackage());
-
   // Partial mutation is supported only for frozen/fixed-layout types from
   // other modules.
   if (hasExplicitFixedLayoutAnnotation(nominal))

--- a/test/SILOptimizer/moveonly_addresschecker_diagnostics_partial_consume_internal_imports.swift
+++ b/test/SILOptimizer/moveonly_addresschecker_diagnostics_partial_consume_internal_imports.swift
@@ -1,0 +1,42 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend                                      \
+// RUN:     %t/Library.swift                                        \
+// RUN:     -emit-module                                            \
+// RUN:     -module-name Library                                    \
+// RUN:     -emit-module-path %t/Library.swiftmodule
+
+// RUN: %target-swift-frontend                                      \
+// RUN:     %t/Downstream.swift                                     \
+// RUN:     -emit-sil -verify                                       \
+// RUN:     -sil-verify-all                                         \
+// RUN:     -enable-upcoming-feature InternalImportsByDefault       \
+// RUN:     -I %t
+
+// REQUIRES: swift_feature_InternalImportsByDefault
+
+//--- Library.swift
+
+public struct Inner: ~Copyable {}
+
+public struct Outer: ~Copyable {
+  public var inner: Inner
+}
+
+@frozen
+public struct OuterFrozen: ~Copyable {
+  public var inner: Inner
+}
+
+//--- Downstream.swift
+
+import Library
+
+func consume_outer(_ o: consuming Outer) -> Inner {
+  o.inner // expected-error{{cannot partially consume 'o' of non-frozen type 'Outer' imported from 'Library'}}
+}
+
+func consume_outer_frozen(_ o: consuming OuterFrozen) -> Inner {
+  o.inner
+}


### PR DESCRIPTION
The assertion at `lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp:1825-1829` checks that a nominal type imported from another module has a public-or-package formal access scope at the use site. Under `InternalImportsByDefault` (SE-0409), `getAccessScopeForFormalAccess` clamps a declaration's effective access to the import access level (`lib/AST/Decl.cpp:5450-5463`), so a default internal import can produce an internal access scope that fails `isPublicOrPackage()`.

The code below the assertion does not depend on that predicate. It only checks whether the imported nominal has explicit fixed layout; fixed-layout imported types are accepted, and other imported non-frozen types produce the existing `nonfrozenImportedType` diagnostic.

> This PR was prepared with AI assistance.

### Test plan

Adds `test/SILOptimizer/moveonly_addresschecker_diagnostics_partial_consume_internal_imports.swift` — the first test combining `-enable-upcoming-feature InternalImportsByDefault` with `MoveOnlyAddressChecker`. Existing `moveonly_addresschecker_*` tests do not exercise the stale IIBD-specific access-scope failure.

The test builds a small library module, imports it under IIBD, and verifies both outcomes after the stale assertion is removed: partial consumption of a non-frozen imported type emits the existing diagnostic, while the same operation on an `@frozen` imported type compiles.

Without this PR, the non-frozen case reaches the stale assertion in +Asserts builds.

Resolves https://github.com/swiftlang/swift/issues/87136