### PR TITLE
MoveOnlyChecker: relax partial-consume assertion for restricted imports

### DIFF
--- a/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
@@ -1821,12 +1821,11 @@ shouldEmitPartialMutationErrorForType(SILType ty, NominalTypeDecl *nominal,
   if (nominal->getModuleContext() == fn->getModule().getSwiftModule())
     return std::nullopt;
 
-  // It's defined in another module and used here; it has to be visible.
-  assert(nominal
-             ->getFormalAccessScope(
-                 /*useDC=*/fn->getDeclContext(),
-                 /*treatUsableFromInlineAsPublic=*/true)
-             .isPublicOrPackage());
+  // It's defined in another module and used here, so we've established the
+  // type is visible. Historically the access scope was expected to be public
+  // or package; with `InternalImportsByDefault` a public type reached via an
+  // internal import has `Internal` scope in the importing module, which is
+  // also valid.
 
   // Partial mutation is supported only for frozen/fixed-layout types from
   // other modules.

--- a/test/SILOptimizer/moveonly_addresschecker_diagnostics_partial_consume_internal_imports.swift
+++ b/test/SILOptimizer/moveonly_addresschecker_diagnostics_partial_consume_internal_imports.swift
@@ -1,0 +1,55 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend                                      \
+// RUN:     %t/Library.swift                                        \
+// RUN:     -emit-module                                            \
+// RUN:     -module-name Library                                    \
+// RUN:     -emit-module-path %t/Library.swiftmodule
+
+// Regression: an `internal import` of another module gives that
+// module's public types `Internal` access scope from the client's
+// perspective. The MoveOnlyChecker's partial-consumption legality
+// analysis previously asserted that the type's formal access scope was
+// public-or-package at this point, which no longer holds. The
+// assertion has been relaxed; the downstream frozen-vs-nonfrozen check
+// is unchanged.
+
+// RUN: %target-swift-frontend                                      \
+// RUN:     %t/Downstream.swift                                     \
+// RUN:     -emit-sil -verify                                       \
+// RUN:     -sil-verify-all                                         \
+// RUN:     -I %t
+
+//--- Library.swift
+
+public struct Source: ~Copyable {
+    public init() {}
+}
+
+@frozen public struct FrozenWrapper: ~Copyable {
+    public var source: Source
+    public init(source: consuming Source) { self.source = source }
+}
+
+public struct NonFrozenWrapper: ~Copyable {
+    public var source: Source
+    public init(source: consuming Source) { self.source = source }
+}
+
+//--- Downstream.swift
+
+internal import Library
+
+// @frozen: partial consume across module boundaries is allowed.
+func frozenPartialConsume() {
+    let w = FrozenWrapper(source: Source())
+    _ = consume w.source
+}
+
+// Non-@frozen: partial consume is rejected with the imported-nonfrozen
+// diagnostic.
+func nonfrozenPartialConsume() {
+    let w = NonFrozenWrapper(source: Source())
+    _ = consume w.source // expected-error {{cannot partially consume 'w' of non-frozen type 'NonFrozenWrapper' imported from 'Library'}}
+}


### PR DESCRIPTION
`shouldEmitPartialMutationErrorForType` asserted that a nominal type reaching its cross-module-use branch had formal access scope public-or-package from the calling function's DeclContext:

    assert(nominal
               ->getFormalAccessScope(fn->getDeclContext(),
                                      /*treatUsableFromInlineAsPublic=*/true)
               .isPublicOrPackage());

That check was correct when added (in `da968dbd58d`, "Ban exported partial consumption"), but breaks whenever a public type from another module is imported with restricted access. Two cases trip it:

  - `internal import Library` (the assertion fires with no feature flags at all)
  - `-enable-upcoming-feature InternalImportsByDefault`, which is the originally-reported manifestation

In both cases a partial consume of a `@frozen public ~Copyable` field hits the assertion. The downstream logic
(`hasExplicitFixedLayoutAnnotation` → allow/reject) doesn't depend on the scope value — the assertion is purely informational. Replace the over-strict check with a comment explaining the invariant (the type is visible from `fn`'s DC; access scope may be `Internal` when the client's import is internal).

Adds `test/SILOptimizer/moveonly_addresschecker_diagnostics_partial_consume_internal_imports.swift` which uses a plain `internal import Library` (no feature flags) and covers both the `@frozen` (compiles cleanly) and non-`@frozen` (diagnosed as `cannot partially consume ... of non-frozen type ... imported from 'Library'`) cases. Verified by reverting the relaxation: the test triggers exactly the original assertion at MoveOnlyAddressCheckerUtils.cpp:1829.
