### PR TITLE
WIP: Lifetimes: Generate internal labels for diagnostics if necessary

### DIFF
--- a/include/swift/AST/ASTPrinter.h
+++ b/include/swift/AST/ASTPrinter.h
@@ -368,28 +368,25 @@ public:
     return printedClangDecl.insert(d).second;
   }
 
-  /// Print lifetimeDependence as a SIL lifetime attribute, attached to a
-  /// parameter or result of a function.
-  void printSILLifetimeDependence(
-      std::optional<LifetimeDependenceInfo> lifetimeDependence) {
-    if (!lifetimeDependence.has_value()) {
-      return;
-    }
-    *this << lifetimeDependence->getString();
-  }
+  /// Print a lifetime dependence annotation.
+  ///
+  /// When \p params is provided, Swift-style formatting is used (labels,
+  /// target, '&' for inout). When \p params is \c std::nullopt, SIL-style
+  /// formatting is used (indices only, no target).
+  void printLifetimeDependence(
+      LifetimeDependenceInfo const &info,
+      std::optional<ArrayRef<AnyFunctionType::Param>> params,
+      const PrintOptions &options);
 
   void printLifetimeDependenceAt(
-      ArrayRef<LifetimeDependenceInfo> lifetimeDependencies, unsigned index) {
+      ArrayRef<LifetimeDependenceInfo> lifetimeDependencies, unsigned index,
+      std::optional<ArrayRef<AnyFunctionType::Param>> params,
+      const PrintOptions &options) {
     if (auto lifetimeDependence =
             getLifetimeDependenceFor(lifetimeDependencies, index)) {
-      printSILLifetimeDependence(*lifetimeDependence);
+      printLifetimeDependence(*lifetimeDependence, params, options);
     }
   }
-
-  /// Print lifetimeDependence as a Swift lifetime attribute.
-  void
-  printSwiftLifetimeDependence(LifetimeDependenceInfo const &lifetimeDependence,
-                               ArrayRef<AnyFunctionType::Param> params);
 
 private:
   virtual void anchor();

--- a/include/swift/AST/LifetimeDependence.h
+++ b/include/swift/AST/LifetimeDependence.h
@@ -241,11 +241,11 @@ class LifetimeDependenceInfo {
     return paramIndices ? paramIndices->getCapacity() : 0;
   }
 
+public:
   bool hasDependencySource() const {
     return inheritLifetimeParamIndices || scopeLifetimeParamIndices;
   };
 
-public:
   /// Fully-initialized dependence info.
   LifetimeDependenceInfo(IndexSubset *inheritLifetimeParamIndices,
                          IndexSubset *scopeLifetimeParamIndices,
@@ -384,13 +384,6 @@ public:
       && scopeLifetimeParamIndices->contains(index);
   }
 
-  /// Get a string representation of this LifetimeDependenceInfo suitable for
-  /// printing in SIL. The target is not included, since this is determined by
-  /// the position of the attribute in SIL.
-  ///
-  /// For printing function type lifetimes in Swift, see
-  /// ASTPrinter::printSwiftLifetimeDependence.
-  std::string getString() const;
   void Profile(llvm::FoldingSetNodeID &ID) const;
   void getConcatenatedData(SmallVectorImpl<bool> &concatenatedData) const;
 

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -3526,6 +3526,10 @@ public:
     bool hasInternalLabel() const { return !InternalLabel.empty(); }
     Identifier getInternalLabel() const { return InternalLabel; }
 
+    bool hasValidInternalLabel() const {
+      return hasInternalLabel() && !InternalLabel.hasDollarPrefix();
+    }
+
     /// Return true if argument name is valid and matches \c paramName.
     ///
     /// The three tests to check if argument name is valid are:

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -6692,6 +6692,17 @@ namespace {
       if (auto sendableTy = T->getSendableDependentType())
         printRec(sendableTy, Label::always("sendable_dep"));
 
+      if (T->hasLifetimeDependencies()) {
+        for (auto &dep : T->getLifetimeDependencies()) {
+          std::string str;
+          llvm::raw_string_ostream os(str);
+          StreamPrinter sp(os);
+          sp.printLifetimeDependence(dep, T->getParams(),
+                                     PrintOptions::forDebugging());
+          printFieldQuoted(str, Label::always("lifetime"));
+        }
+      }
+
       printClangTypeRec(T->getClangTypeInfo(), T->getASTContext(),
                         Label::optional("clang_type_info"));
       printAnyFunctionParamsRec(T->getParams(), Label::always("input"));

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -538,8 +538,13 @@ formatLifetimeDependence(LifetimeDependenceInfo const &info,
   // Get a string identifier for a parameter at the given index.
   auto getIdentifier = [&](unsigned index) -> std::string {
     if (params) {
-      if (index < params->size() && (*params)[index].hasInternalLabel()) {
-        return (*params)[index].getInternalLabel().get();
+      if (index < params->size()) {
+        auto &param = (*params)[index];
+        if (param.hasValidInternalLabel())
+          return param.getInternalLabel().get();
+        if (param.hasLabel())
+          return param.getLabel().get();
+        return "$" + std::to_string(index);
       }
       if (index == selfIndex) {
         return "self";
@@ -7351,8 +7356,7 @@ public:
         Printer.printStructurePost(PrintStructureKind::FunctionParameter);
       };
 
-      bool hasValidInternalLabel = Param.hasInternalLabel() &&
-                                   !Param.getInternalLabel().hasDollarPrefix();
+      bool hasValidInternalLabel = Param.hasValidInternalLabel();
 
       if ((Options.AlwaysTryPrintParameterLabels || printExternalLabels ||
            printAllLabels) &&
@@ -7377,6 +7381,8 @@ public:
         Printer.printName(Param.getInternalLabel(),
                           PrintNameContext::FunctionParameterLocal);
         Printer << ": ";
+      } else if (printAllLabels && !Options.IsForSwiftInterface) {
+        Printer << "_ $" << i << ": ";
       }
 
       if (Options.PrintInSILBody) {
@@ -7398,10 +7404,10 @@ public:
     Printer << ")";
   }
 
-  static bool shouldPrintLabelsForLifetimeAttributes(AnyFunctionType const *T) {
-    // If the type has explicit lifetime dependencies, print the labels, because
-    // explicit lifetimes use them to describe their sources and targets.
-    return T->hasExplicitLifetimeDependencies();
+  bool shouldPrintLabelsForLifetimeAttributes(AnyFunctionType const *T) const {
+    if (Options.IsForSwiftInterface)
+      return T->hasExplicitLifetimeDependencies();
+    return T->hasLifetimeDependencies();
   }
 
   void visitFunctionType(FunctionType *T,

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -518,12 +518,11 @@ formatLifetimeDependence(LifetimeDependenceInfo const &info,
                          std::optional<ArrayRef<AnyFunctionType::Param>> params,
                          const PrintOptions &options) {
   bool isSIL = !params;
+  bool isDump = options.PrintTypesForDebugging;
 
   std::string result;
-  if (isSIL) {
-    result = "@lifetime(";
-  } else {
-    result = "@_lifetime(";
+  if (!isDump) {
+    result = isSIL ? "@lifetime(" : "@_lifetime(";
   }
 
   // Determine whether implicit self is present by comparing the param indices
@@ -616,7 +615,8 @@ formatLifetimeDependence(LifetimeDependenceInfo const &info,
     appendSources(scope, LifetimeDependenceKind::Scope);
   }
 
-  result += ") ";
+  if (!isDump)
+    result += ") ";
   return result;
 }
 

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -506,133 +506,125 @@ bool TypeTransformContext::isPrintingSynthesizedExtension() const {
   return !Decl.isNull();
 }
 
-/// Get a string representation of the parameter at params[index]. This will be
-/// the label or internal label of a normal parameter, or the string form of
-/// index. We cannot currently print lifetimes with indices in swiftinterface
-/// files because SwiftSyntax cannot parse lifetime entries that use them.
-static std::string
-getLifetimeDependenceIdentifier(unsigned index,
-                                ArrayRef<AnyFunctionType::Param> params) {
-  // NOTE: Does not handle the implicit self parameter, since this is only used
-  // for function types.
-  if (index < params.size() && params[index].hasInternalLabel()) {
-    return params[index].getInternalLabel().get();
-  }
-
-  return std::to_string(index);
-}
-
-static std::string_view
-getLifetimeDependenceSpecifier(unsigned index,
-                               ArrayRef<AnyFunctionType::Param> params,
-                               LifetimeDependenceKind kind) {
-  // NOTE: Does not handle the implicit self parameter, since this is only used
-  // for function types.
-  switch (kind) {
-  case LifetimeDependenceKind::Inherit:
-    return "copy ";
-  case LifetimeDependenceKind::Scope:
-    if (params[index].isInOut()) {
-      return "&";
-    }
-    return "borrow ";
-  }
-}
-
-/// Get a string representation for the list of sources of the given
-/// LifetimeDependenceInfo, if they can be printed.
+/// Format a lifetime dependence annotation as a string.
 ///
-/// See getLifetimeDependenceIdentifier.
-static std::string getLifetimeDependenceInfoSourceListString(
-    LifetimeDependenceInfo const &info,
-    ArrayRef<AnyFunctionType::Param> params) {
+/// When \p params is provided, Swift-style formatting is used: parameter
+/// labels are printed when available, the target is included when it is not
+/// the result, and scope dependencies on inout parameters use '&'. When
+/// \p params is \c std::nullopt, SIL-style formatting is used: sources and
+/// targets are always identified by numeric index.
+static std::string
+formatLifetimeDependence(LifetimeDependenceInfo const &info,
+                         std::optional<ArrayRef<AnyFunctionType::Param>> params,
+                         const PrintOptions &options) {
+  bool isSIL = !params;
 
-  std::string lifetimeDependenceString = "";
+  std::string result;
+  if (isSIL) {
+    result = "@lifetime(";
+  } else {
+    result = "@_lifetime(";
+  }
+
+  // Determine whether implicit self is present by comparing the param indices
+  // length (which includes self) against the params array size (which doesn't).
+  std::optional<unsigned> selfIndex;
+  if (params && info.hasDependencySource()) {
+    unsigned indicesLen = info.getParamIndicesLength();
+    if (indicesLen > params->size()) {
+      selfIndex = params->size();
+    }
+  }
+
+  // Get a string identifier for a parameter at the given index.
+  auto getIdentifier = [&](unsigned index) -> std::string {
+    if (params) {
+      if (index < params->size() && (*params)[index].hasInternalLabel()) {
+        return (*params)[index].getInternalLabel().get();
+      }
+      if (index == selfIndex) {
+        return "self";
+      }
+    }
+    return std::to_string(index);
+  };
+
+  // In Swift mode, print the target if it is not the result.
+  if (!isSIL && params) {
+    const auto resultIndex =
+        selfIndex ? params->size() + 1 : params->size();
+    if (info.getTargetIndex() != resultIndex) {
+      result += getIdentifier(info.getTargetIndex());
+      result += ": ";
+    }
+  }
+
   auto addressable = info.getAddressableIndices();
   auto condAddressable = info.getConditionallyAddressableIndices();
 
-  bool isFirstSpecifier = true;
-  auto getSourceString = [&](IndexSubset *bitvector,
-                             LifetimeDependenceKind kind) -> std::string {
-    std::string result;
+  bool isFirst = true;
+  auto appendSources = [&](IndexSubset *bitvector, LifetimeDependenceKind kind) {
     for (unsigned i = 0; i < bitvector->getCapacity(); i++) {
-      if (bitvector->contains(i)) {
-        if (!isFirstSpecifier) {
-          result += ", ";
+      if (!bitvector->contains(i))
+        continue;
+      if (!isFirst)
+        result += ", ";
+
+      switch (kind) {
+      case LifetimeDependenceKind::Inherit:
+        result += "copy ";
+        break;
+      case LifetimeDependenceKind::Scope:
+        // In Swift mode, scope+inout uses "&".
+        if (!isSIL && params && i < params->size() &&
+            (*params)[i].isInOut()) {
+          result += "&";
+        } else {
+          result += "borrow ";
         }
-        result += getLifetimeDependenceSpecifier(i, params, kind);
-        if (addressable && addressable->contains(i)) {
-          result += "address ";
-        } else if (condAddressable && condAddressable->contains(i)) {
-          result += "address_for_deps ";
-        }
-        // Print source labels for explicit lifetime annotations. Otherwise,
-        // print the index. Indices should ideally never be used in Swift
-        // lifetime annotations, especially in module interfaces.
-        result += getLifetimeDependenceIdentifier(i, params);
-        isFirstSpecifier = false;
+        break;
       }
+
+      if (addressable && addressable->contains(i))
+        result += "address ";
+      else if (condAddressable && condAddressable->contains(i))
+        result += "address_for_deps ";
+
+      result += isSIL ? std::to_string(i) : getIdentifier(i);
+      isFirst = false;
     }
-    return result;
   };
+
   if (info.hasCaptures()) {
-    if (!isFirstSpecifier) {
-      lifetimeDependenceString += ", ";
-    }
-    lifetimeDependenceString += LifetimeDescriptor::CapturesContextSpecifier;
-    isFirstSpecifier = false;
+    if (!isFirst)
+      result += ", ";
+    result += LifetimeDescriptor::CapturesContextSpecifier;
+    isFirst = false;
   }
   if (info.hasImmortalSpecifier()) {
-    if (!isFirstSpecifier) {
-      lifetimeDependenceString += ", ";
-    }
-    lifetimeDependenceString += "immortal";
-    isFirstSpecifier = false;
+    if (!isFirst)
+      result += ", ";
+    result += "immortal";
+    isFirst = false;
   }
-  auto inheritLifetimeParamIndices = info.getInheritIndices();
-  if (inheritLifetimeParamIndices) {
-    assert(!inheritLifetimeParamIndices->isEmpty());
-    lifetimeDependenceString += getSourceString(
-        inheritLifetimeParamIndices, LifetimeDependenceKind::Inherit);
+  if (auto *inherit = info.getInheritIndices()) {
+    assert(!inherit->isEmpty());
+    appendSources(inherit, LifetimeDependenceKind::Inherit);
   }
-  if (auto scopeLifetimeParamIndices = info.getScopeIndices()) {
-    assert(!scopeLifetimeParamIndices->isEmpty());
-    lifetimeDependenceString += getSourceString(scopeLifetimeParamIndices,
-                                                LifetimeDependenceKind::Scope);
+  if (auto *scope = info.getScopeIndices()) {
+    assert(!scope->isEmpty());
+    appendSources(scope, LifetimeDependenceKind::Scope);
   }
-  return lifetimeDependenceString;
+
+  result += ") ";
+  return result;
 }
 
-/// Get a string representation for this dependence info as a Swift lifetime
-/// attribute (for a type or decl). The target and sources are referred to by
-/// their labels if possible (see getLifetimeDependenceIdentifier).
-///
-/// TODO: Factor this with LifetimeDependenceInfo::getString.
-static std::string
-getLifetimeDependenceInfoSwiftString(LifetimeDependenceInfo const &info,
-                                     ArrayRef<AnyFunctionType::Param> params) {
-  std::string lifetimeDependenceString = "@_lifetime(";
-
-  // Only print the target if it is a parameter or self.
-  const auto resultIndex = params.size();
-  const auto targetIndex = info.getTargetIndex();
-  if (targetIndex != resultIndex) {
-    lifetimeDependenceString +=
-        getLifetimeDependenceIdentifier(targetIndex, params);
-    lifetimeDependenceString += ": ";
-  }
-
-  lifetimeDependenceString +=
-      getLifetimeDependenceInfoSourceListString(info, params);
-  lifetimeDependenceString += ") ";
-  return lifetimeDependenceString;
-}
-
-void ASTPrinter::printSwiftLifetimeDependence(
-    LifetimeDependenceInfo const &lifetimeDependence,
-    ArrayRef<AnyFunctionType::Param> params) {
-
-  *this << getLifetimeDependenceInfoSwiftString(lifetimeDependence, params);
+void ASTPrinter::printLifetimeDependence(
+    LifetimeDependenceInfo const &info,
+    std::optional<ArrayRef<AnyFunctionType::Param>> params,
+    const PrintOptions &options) {
+  *this << formatLifetimeDependence(info, params, options);
 }
 
 void ASTPrinter::anchor() {}
@@ -7142,7 +7134,7 @@ public:
         // originated from explicit @lifetime annotations.
         if (!Options.IsForSwiftInterface ||
             lifetimeDependence.isFromAnnotation()) {
-          Printer.printSwiftLifetimeDependence(lifetimeDependence, params);
+          Printer.printLifetimeDependence(lifetimeDependence, params, Options);
         }
       }
     }
@@ -7388,7 +7380,8 @@ public:
       }
 
       if (Options.PrintInSILBody) {
-        Printer.printLifetimeDependenceAt(lifetimeDependencies, i);
+        Printer.printLifetimeDependenceAt(lifetimeDependencies, i,
+                                                 std::nullopt, Options);
       }
 
       auto type = Param.getPlainType();
@@ -7452,7 +7445,8 @@ public:
 
     if (Options.PrintInSILBody) {
       Printer.printLifetimeDependenceAt(T->getLifetimeDependencies(),
-                                        T->getParams().size());
+                                        T->getParams().size(),
+                                        std::nullopt, Options);
     }
 
     Printer.callPrintStructurePre(PrintStructureKind::FunctionReturnType);
@@ -7514,7 +7508,8 @@ public:
 
     if (Options.PrintInSILBody) {
       Printer.printLifetimeDependenceAt(T->getLifetimeDependencies(),
-                                        T->getParams().size());
+                                        T->getParams().size(),
+                                        std::nullopt, Options);
     }
 
     Printer.callPrintStructurePre(PrintStructureKind::FunctionReturnType);
@@ -7620,7 +7615,8 @@ public:
       }
       Printer << ") -> ";
 
-      Printer.printSILLifetimeDependence(T->getLifetimeDependenceForResult());
+      if (auto dep = T->getLifetimeDependenceForResult())
+        Printer.printLifetimeDependence(*dep, std::nullopt, Options);
 
       bool parenthesizeResults = mustParenthesizeResults(T);
       if (parenthesizeResults)
@@ -8469,7 +8465,7 @@ void SILParameterInfo::print(
   }
 
   if (lifetimeDependence) {
-    Printer.printSILLifetimeDependence(*lifetimeDependence);
+    Printer.printLifetimeDependence(*lifetimeDependence, std::nullopt, Opts);
   }
 
   if (options.contains(SILParameterInfo::ImplicitLeading)) {

--- a/lib/AST/LifetimeDependence.cpp
+++ b/lib/AST/LifetimeDependence.cpp
@@ -166,61 +166,6 @@ getNameForParsedLifetimeDependenceKind(ParsedLifetimeDependenceKind kind) {
 
 } // namespace swift
 
-std::string LifetimeDependenceInfo::getString() const {
-  std::string lifetimeDependenceString = "@lifetime(";
-  auto addressable = getAddressableIndices();
-  auto condAddressable = getConditionallyAddressableIndices();
-  
-  bool isFirstSpecifier = true;
-  auto getSourceString = [&](IndexSubset *bitvector, StringRef kind) {
-    std::string result;
-    for (unsigned i = 0; i < bitvector->getCapacity(); i++) {
-      if (bitvector->contains(i)) {
-        if (!isFirstSpecifier) {
-          result += ", ";
-        }
-        result += kind;
-        if (addressable && addressable->contains(i)) {
-          result += "address ";
-        } else if (condAddressable && condAddressable->contains(i)) {
-          result += "address_for_deps ";
-        }
-        result += std::to_string(i);
-        isFirstSpecifier = false;
-      }
-    }
-    return result;
-  };
-  // Unlike the AST printer, there is no need check isDefaultSuppressed() for
-  // SIL printing because SIL does not assume any defaults.
-  if (hasCaptures()) {
-    if (!isFirstSpecifier) {
-      lifetimeDependenceString += ", ";
-    }
-    lifetimeDependenceString += LifetimeDescriptor::CapturesContextSpecifier;
-    isFirstSpecifier = false;
-  }
-  if (hasImmortalSpecifier()) {
-    if (!isFirstSpecifier) {
-      lifetimeDependenceString += ", ";
-    }
-    lifetimeDependenceString += "immortal";
-    isFirstSpecifier = false;
-  }
-  if (inheritLifetimeParamIndices) {
-    assert(!inheritLifetimeParamIndices->isEmpty());
-    lifetimeDependenceString +=
-        getSourceString(inheritLifetimeParamIndices, "copy ");
-  }
-  if (scopeLifetimeParamIndices) {
-    assert(!scopeLifetimeParamIndices->isEmpty());
-    lifetimeDependenceString +=
-        getSourceString(scopeLifetimeParamIndices, "borrow ");
-  }
-  lifetimeDependenceString += ") ";
-  return lifetimeDependenceString;
-}
-
 void LifetimeDependenceInfo::Profile(llvm::FoldingSetNodeID &ID) const {
   ID.AddBoolean(hasImmortalSpecifier());
   ID.AddBoolean(isFromAnnotation());

--- a/test/Sema/lifetime_attr.swift
+++ b/test/Sema/lifetime_attr.swift
@@ -299,7 +299,7 @@ class Holder {
 }
 
 func bar(_ span: Span<Int>) {
-  _ = foo(Holder.incorrect, span) // expected-error{{cannot convert value of type '@_lifetime(borrow 0) (Span<Int>) -> Span<Int>' to expected argument type '@_lifetime(copy span) (_ span: Span<Int>) -> Span<Int>'}}
+  _ = foo(Holder.incorrect, span) // expected-error{{cannot convert value of type '@_lifetime(borrow $0) (_ $0: Span<Int>) -> Span<Int>' to expected argument type '@_lifetime(copy span) (_ span: Span<Int>) -> Span<Int>'}}
   _ = foo(Holder.correct, span) // OK
 }
 
@@ -308,7 +308,7 @@ func baz1() -> @_lifetime(copy span) (_ span: Span<Int>) -> Span<Int> {
 }
 
 func baz2() -> @_lifetime(copy span) (_ span: Span<Int>) -> Span<Int> {
-  return Holder.incorrect  // expected-error{{cannot convert return expression of type '@_lifetime(borrow 0) (Span<Int>) -> Span<Int>' to return type '@_lifetime(copy span) (_ span: Span<Int>) -> Span<Int>'}}
+  return Holder.incorrect  // expected-error{{cannot convert return expression of type '@_lifetime(borrow $0) (_ $0: Span<Int>) -> Span<Int>' to return type '@_lifetime(copy span) (_ span: Span<Int>) -> Span<Int>'}}
 }
 
 struct StaticIOMethods {
@@ -324,5 +324,5 @@ do {
   typealias IOTransfer = @_lifetime(ne0: copy ne0, borrow ne1) (_ ne0: inout NE, _ ne1: borrowing NE) -> ()
   let _: IOTransfer = StaticIOMethods.staticInoutCopying0 // OK
   let _: IOTransfer = StaticIOMethods.staticInoutCopying0Borrowing1 // OK
-  let _: IOTransfer = StaticIOMethods.staticInoutCopying0Copying1 // expected-error {{cannot convert value of type '@_lifetime(0: copy 0, copy 1) (inout NE, borrowing NE) -> ()' to specified type 'IOTransfer' (aka '@_lifetime(ne0: copy ne0, borrow ne1) (_ ne0: inout NE, _ ne1: borrowing NE) -> ()')}}
+  let _: IOTransfer = StaticIOMethods.staticInoutCopying0Copying1 // expected-error {{cannot convert value of type '@_lifetime($0: copy $0, copy $1) (_ $0: inout NE, _ $1: borrowing NE) -> ()' to specified type 'IOTransfer' (aka '@_lifetime(ne0: copy ne0, borrow ne1) (_ ne0: inout NE, _ ne1: borrowing NE) -> ()')}}
 }

--- a/test/Sema/lifetime_dependence_functype.swift
+++ b/test/Sema/lifetime_dependence_functype.swift
@@ -50,7 +50,7 @@ func applyBorrow(nc: borrowing NC, borrow: (borrowing NC) -> NE) -> NE {
 }
 
 func testBorrow(nc: consuming NC) {
-  let borrowed = applyBorrow(nc: nc, borrow: borrow) // expected-error{{cannot convert value of type '@_lifetime(borrow 0) (borrowing NC) -> NE' to expected argument type '@_lifetime(captures) (borrowing NC) -> NE'}}
+  let borrowed = applyBorrow(nc: nc, borrow: borrow) // expected-error{{cannot convert value of type '@_lifetime(borrow $0) (_ $0: borrowing NC) -> NE' to expected argument type '@_lifetime(captures) (_ $0: borrowing NC) -> NE'}}
   _ = consume nc
   _ = transfer(borrowed)
 }
@@ -336,12 +336,12 @@ func takeCopying0Captures(
 
 func callLifetimeFunctions() {
   takeCopying0(f: copying0) // OK
-  takeCopying0(f: copying1) // expected-error{{cannot convert value of type '@_lifetime(copy 1) @_lifetime(4: copy 4) (NE, NE, borrowing NE, borrowing NE, inout NE) -> NE' to expected argument type '@_lifetime(copy ne0) @_lifetime(ne4: copy ne4) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
-  takeCopying0(f: copying01) // expected-error{{cannot convert value of type '@_lifetime(copy 0, copy 1) @_lifetime(4: copy 4) (NE, NE, borrowing NE, borrowing NE, inout NE) -> NE' to expected argument type '@_lifetime(copy ne0) @_lifetime(ne4: copy ne4) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
+  takeCopying0(f: copying1) // expected-error{{cannot convert value of type '@_lifetime(copy $1) @_lifetime($4: copy $4) (_ $0: NE, _ $1: NE, _ $2: borrowing NE, _ $3: borrowing NE, _ $4: inout NE) -> NE' to expected argument type '@_lifetime(copy ne0) @_lifetime(ne4: copy ne4) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
+  takeCopying0(f: copying01) // expected-error{{cannot convert value of type '@_lifetime(copy $0, copy $1) @_lifetime($4: copy $4) (_ $0: NE, _ $1: NE, _ $2: borrowing NE, _ $3: borrowing NE, _ $4: inout NE) -> NE' to expected argument type '@_lifetime(copy ne0) @_lifetime(ne4: copy ne4) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
 
-  takeCopying1(f: copying0) // expected-error{{cannot convert value of type '@_lifetime(copy 0) @_lifetime(4: copy 4) (NE, NE, borrowing NE, borrowing NE, inout NE) -> NE' to expected argument type '@_lifetime(copy ne1) @_lifetime(ne4: copy ne4) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
+  takeCopying1(f: copying0) // expected-error{{cannot convert value of type '@_lifetime(copy $0) @_lifetime($4: copy $4) (_ $0: NE, _ $1: NE, _ $2: borrowing NE, _ $3: borrowing NE, _ $4: inout NE) -> NE' to expected argument type '@_lifetime(copy ne1) @_lifetime(ne4: copy ne4) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
   takeCopying1(f: copying1) // OK
-  takeCopying1(f: copying01) // expected-error{{cannot convert value of type '@_lifetime(copy 0, copy 1) @_lifetime(4: copy 4) (NE, NE, borrowing NE, borrowing NE, inout NE) -> NE' to expected argument type '@_lifetime(copy ne1) @_lifetime(ne4: copy ne4) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
+  takeCopying1(f: copying01) // expected-error{{cannot convert value of type '@_lifetime(copy $0, copy $1) @_lifetime($4: copy $4) (_ $0: NE, _ $1: NE, _ $2: borrowing NE, _ $3: borrowing NE, _ $4: inout NE) -> NE' to expected argument type '@_lifetime(copy ne1) @_lifetime(ne4: copy ne4) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
 
   takeCopying01(f: copying0) // OK
   takeCopying01(f: copying1) // OK
@@ -349,33 +349,33 @@ func callLifetimeFunctions() {
 
 
   takeBorrowing2(f: borrowing2) // OK
-  takeBorrowing2(f: borrowing3) // expected-error{{cannot convert value of type '@_lifetime(borrow 3) @_lifetime(4: copy 4) (NE, NE, borrowing NE, borrowing NE, inout NE) -> NE' to expected argument type '@_lifetime(borrow ne2) @_lifetime(ne4: copy ne4) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
-  takeBorrowing2(f: borrowing23) // expected-error{{cannot convert value of type '@_lifetime(borrow 2, borrow 3) @_lifetime(4: copy 4) (NE, NE, borrowing NE, borrowing NE, inout NE) -> NE' to expected argument type '@_lifetime(borrow ne2) @_lifetime(ne4: copy ne4) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
+  takeBorrowing2(f: borrowing3) // expected-error{{cannot convert value of type '@_lifetime(borrow $3) @_lifetime($4: copy $4) (_ $0: NE, _ $1: NE, _ $2: borrowing NE, _ $3: borrowing NE, _ $4: inout NE) -> NE' to expected argument type '@_lifetime(borrow ne2) @_lifetime(ne4: copy ne4) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
+  takeBorrowing2(f: borrowing23) // expected-error{{cannot convert value of type '@_lifetime(borrow $2, borrow $3) @_lifetime($4: copy $4) (_ $0: NE, _ $1: NE, _ $2: borrowing NE, _ $3: borrowing NE, _ $4: inout NE) -> NE' to expected argument type '@_lifetime(borrow ne2) @_lifetime(ne4: copy ne4) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
 
-  takeBorrowing3(f: borrowing2) // expected-error{{cannot convert value of type '@_lifetime(borrow 2) @_lifetime(4: copy 4) (NE, NE, borrowing NE, borrowing NE, inout NE) -> NE' to expected argument type '@_lifetime(borrow ne3) @_lifetime(ne4: copy ne4) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
+  takeBorrowing3(f: borrowing2) // expected-error{{cannot convert value of type '@_lifetime(borrow $2) @_lifetime($4: copy $4) (_ $0: NE, _ $1: NE, _ $2: borrowing NE, _ $3: borrowing NE, _ $4: inout NE) -> NE' to expected argument type '@_lifetime(borrow ne3) @_lifetime(ne4: copy ne4) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
   takeBorrowing3(f: borrowing3) // OK
-  takeBorrowing3(f: borrowing23) // expected-error{{cannot convert value of type '@_lifetime(borrow 2, borrow 3) @_lifetime(4: copy 4) (NE, NE, borrowing NE, borrowing NE, inout NE) -> NE' to expected argument type '@_lifetime(borrow ne3) @_lifetime(ne4: copy ne4) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
+  takeBorrowing3(f: borrowing23) // expected-error{{cannot convert value of type '@_lifetime(borrow $2, borrow $3) @_lifetime($4: copy $4) (_ $0: NE, _ $1: NE, _ $2: borrowing NE, _ $3: borrowing NE, _ $4: inout NE) -> NE' to expected argument type '@_lifetime(borrow ne3) @_lifetime(ne4: copy ne4) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
 
   takeBorrowing23(f: borrowing2) // OK
   takeBorrowing23(f: borrowing3) // OK
   takeBorrowing23(f: borrowing23) // OK
 
 
-  takeCopying0(f: copying0borrowing2) // expected-error{{cannot convert value of type '@_lifetime(copy 0, borrow 2) @_lifetime(4: copy 4) (NE, NE, borrowing NE, borrowing NE, inout NE) -> NE' to expected argument type '@_lifetime(copy ne0) @_lifetime(ne4: copy ne4) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
-  takeBorrowing2(f: copying0borrowing2) // expected-error{{cannot convert value of type '@_lifetime(copy 0, borrow 2) @_lifetime(4: copy 4) (NE, NE, borrowing NE, borrowing NE, inout NE) -> NE' to expected argument type '@_lifetime(borrow ne2) @_lifetime(ne4: copy ne4) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
+  takeCopying0(f: copying0borrowing2) // expected-error{{cannot convert value of type '@_lifetime(copy $0, borrow $2) @_lifetime($4: copy $4) (_ $0: NE, _ $1: NE, _ $2: borrowing NE, _ $3: borrowing NE, _ $4: inout NE) -> NE' to expected argument type '@_lifetime(copy ne0) @_lifetime(ne4: copy ne4) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
+  takeBorrowing2(f: copying0borrowing2) // expected-error{{cannot convert value of type '@_lifetime(copy $0, borrow $2) @_lifetime($4: copy $4) (_ $0: NE, _ $1: NE, _ $2: borrowing NE, _ $3: borrowing NE, _ $4: inout NE) -> NE' to expected argument type '@_lifetime(borrow ne2) @_lifetime(ne4: copy ne4) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
 
   takeCopying0Borrowing2(f: copying0) // OK
   takeCopying0Borrowing2(f: borrowing2) // OK
   takeCopying0Borrowing2(f: copying0borrowing2) // OK
-  takeCopying0Borrowing2(f: copying0borrowing2borrowing3) // expected-error{{cannot convert value of type '@_lifetime(copy 0, borrow 2, borrow 3) @_lifetime(4: copy 4) (NE, NE, borrowing NE, borrowing NE, inout NE) -> NE' to expected argument type '@_lifetime(copy ne0, borrow ne2) @_lifetime(ne4: copy ne4) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
-  takeCopying0Borrowing2(f: copying0copying1borrowing2) // expected-error{{cannot convert value of type '@_lifetime(copy 0, copy 1, borrow 2) @_lifetime(4: copy 4) (NE, NE, borrowing NE, borrowing NE, inout NE) -> NE' to expected argument type '@_lifetime(copy ne0, borrow ne2) @_lifetime(ne4: copy ne4) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
-  takeCopying0Borrowing2(f: copying0copying1borrowing2borrowing3) // expected-error{{cannot convert value of type '@_lifetime(copy 0, copy 1, borrow 2, borrow 3) @_lifetime(4: copy 4) (NE, NE, borrowing NE, borrowing NE, inout NE) -> NE' to expected argument type '@_lifetime(copy ne0, borrow ne2) @_lifetime(ne4: copy ne4) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
+  takeCopying0Borrowing2(f: copying0borrowing2borrowing3) // expected-error{{cannot convert value of type '@_lifetime(copy $0, borrow $2, borrow $3) @_lifetime($4: copy $4) (_ $0: NE, _ $1: NE, _ $2: borrowing NE, _ $3: borrowing NE, _ $4: inout NE) -> NE' to expected argument type '@_lifetime(copy ne0, borrow ne2) @_lifetime(ne4: copy ne4) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
+  takeCopying0Borrowing2(f: copying0copying1borrowing2) // expected-error{{cannot convert value of type '@_lifetime(copy $0, copy $1, borrow $2) @_lifetime($4: copy $4) (_ $0: NE, _ $1: NE, _ $2: borrowing NE, _ $3: borrowing NE, _ $4: inout NE) -> NE' to expected argument type '@_lifetime(copy ne0, borrow ne2) @_lifetime(ne4: copy ne4) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
+  takeCopying0Borrowing2(f: copying0copying1borrowing2borrowing3) // expected-error{{cannot convert value of type '@_lifetime(copy $0, copy $1, borrow $2, borrow $3) @_lifetime($4: copy $4) (_ $0: NE, _ $1: NE, _ $2: borrowing NE, _ $3: borrowing NE, _ $4: inout NE) -> NE' to expected argument type '@_lifetime(copy ne0, borrow ne2) @_lifetime(ne4: copy ne4) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
 
 
   takeMutborrowing4(f: mutborrowing4) // OK
-  takeMutborrowing4(f: copying0) // expected-error{{cannot convert value of type '@_lifetime(copy 0) @_lifetime(4: copy 4) (NE, NE, borrowing NE, borrowing NE, inout NE) -> NE' to expected argument type '@_lifetime(&ne4) @_lifetime(ne4: copy ne4) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
-  takeCopying0(f: mutborrowing4) // expected-error{{cannot convert value of type '@_lifetime(&4) @_lifetime(4: copy 4) (NE, NE, borrowing NE, borrowing NE, inout NE) -> NE' to expected argument type '@_lifetime(copy ne0) @_lifetime(ne4: copy ne4) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
-  takeBorrowing2(f: mutborrowing4) // expected-error{{cannot convert value of type '@_lifetime(&4) @_lifetime(4: copy 4) (NE, NE, borrowing NE, borrowing NE, inout NE) -> NE' to expected argument type '@_lifetime(borrow ne2) @_lifetime(ne4: copy ne4) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
+  takeMutborrowing4(f: copying0) // expected-error{{cannot convert value of type '@_lifetime(copy $0) @_lifetime($4: copy $4) (_ $0: NE, _ $1: NE, _ $2: borrowing NE, _ $3: borrowing NE, _ $4: inout NE) -> NE' to expected argument type '@_lifetime(&ne4) @_lifetime(ne4: copy ne4) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
+  takeCopying0(f: mutborrowing4) // expected-error{{cannot convert value of type '@_lifetime(&$4) @_lifetime($4: copy $4) (_ $0: NE, _ $1: NE, _ $2: borrowing NE, _ $3: borrowing NE, _ $4: inout NE) -> NE' to expected argument type '@_lifetime(copy ne0) @_lifetime(ne4: copy ne4) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
+  takeBorrowing2(f: mutborrowing4) // expected-error{{cannot convert value of type '@_lifetime(&$4) @_lifetime($4: copy $4) (_ $0: NE, _ $1: NE, _ $2: borrowing NE, _ $3: borrowing NE, _ $4: inout NE) -> NE' to expected argument type '@_lifetime(borrow ne2) @_lifetime(ne4: copy ne4) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
 
 
   takeCopying0(f: immortalFn) // OK
@@ -387,18 +387,18 @@ func callLifetimeFunctions() {
   takeCopying0Borrowing2(f: immortalFn) // OK
   takeMutborrowing4(f: immortalFn) // OK
 
-  takeImmortal(f: copying0) // expected-error{{cannot convert value of type '@_lifetime(copy 0) @_lifetime(4: copy 4) (NE, NE, borrowing NE, borrowing NE, inout NE) -> NE' to expected argument type '@_lifetime(immortal) @_lifetime(ne4: copy ne4) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
-  takeImmortal(f: copying1) // expected-error{{cannot convert value of type '@_lifetime(copy 1) @_lifetime(4: copy 4) (NE, NE, borrowing NE, borrowing NE, inout NE) -> NE' to expected argument type '@_lifetime(immortal) @_lifetime(ne4: copy ne4) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
-  takeImmortal(f: copying01) // expected-error{{cannot convert value of type '@_lifetime(copy 0, copy 1) @_lifetime(4: copy 4) (NE, NE, borrowing NE, borrowing NE, inout NE) -> NE' to expected argument type '@_lifetime(immortal) @_lifetime(ne4: copy ne4) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
-  takeImmortal(f: borrowing2) // expected-error{{cannot convert value of type '@_lifetime(borrow 2) @_lifetime(4: copy 4) (NE, NE, borrowing NE, borrowing NE, inout NE) -> NE' to expected argument type '@_lifetime(immortal) @_lifetime(ne4: copy ne4) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
-  takeImmortal(f: borrowing3) // expected-error{{cannot convert value of type '@_lifetime(borrow 3) @_lifetime(4: copy 4) (NE, NE, borrowing NE, borrowing NE, inout NE) -> NE' to expected argument type '@_lifetime(immortal) @_lifetime(ne4: copy ne4) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
-  takeImmortal(f: borrowing23) // expected-error{{cannot convert value of type '@_lifetime(borrow 2, borrow 3) @_lifetime(4: copy 4) (NE, NE, borrowing NE, borrowing NE, inout NE) -> NE' to expected argument type '@_lifetime(immortal) @_lifetime(ne4: copy ne4) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
-  takeImmortal(f: copying0borrowing2) // expected-error{{cannot convert value of type '@_lifetime(copy 0, borrow 2) @_lifetime(4: copy 4) (NE, NE, borrowing NE, borrowing NE, inout NE) -> NE' to expected argument type '@_lifetime(immortal) @_lifetime(ne4: copy ne4) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
-  takeImmortal(f: mutborrowing4) // expected-error{{cannot convert value of type '@_lifetime(&4) @_lifetime(4: copy 4) (NE, NE, borrowing NE, borrowing NE, inout NE) -> NE' to expected argument type '@_lifetime(immortal) @_lifetime(ne4: copy ne4) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
+  takeImmortal(f: copying0) // expected-error{{cannot convert value of type '@_lifetime(copy $0) @_lifetime($4: copy $4) (_ $0: NE, _ $1: NE, _ $2: borrowing NE, _ $3: borrowing NE, _ $4: inout NE) -> NE' to expected argument type '@_lifetime(immortal) @_lifetime(ne4: copy ne4) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
+  takeImmortal(f: copying1) // expected-error{{cannot convert value of type '@_lifetime(copy $1) @_lifetime($4: copy $4) (_ $0: NE, _ $1: NE, _ $2: borrowing NE, _ $3: borrowing NE, _ $4: inout NE) -> NE' to expected argument type '@_lifetime(immortal) @_lifetime(ne4: copy ne4) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
+  takeImmortal(f: copying01) // expected-error{{cannot convert value of type '@_lifetime(copy $0, copy $1) @_lifetime($4: copy $4) (_ $0: NE, _ $1: NE, _ $2: borrowing NE, _ $3: borrowing NE, _ $4: inout NE) -> NE' to expected argument type '@_lifetime(immortal) @_lifetime(ne4: copy ne4) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
+  takeImmortal(f: borrowing2) // expected-error{{cannot convert value of type '@_lifetime(borrow $2) @_lifetime($4: copy $4) (_ $0: NE, _ $1: NE, _ $2: borrowing NE, _ $3: borrowing NE, _ $4: inout NE) -> NE' to expected argument type '@_lifetime(immortal) @_lifetime(ne4: copy ne4) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
+  takeImmortal(f: borrowing3) // expected-error{{cannot convert value of type '@_lifetime(borrow $3) @_lifetime($4: copy $4) (_ $0: NE, _ $1: NE, _ $2: borrowing NE, _ $3: borrowing NE, _ $4: inout NE) -> NE' to expected argument type '@_lifetime(immortal) @_lifetime(ne4: copy ne4) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
+  takeImmortal(f: borrowing23) // expected-error{{cannot convert value of type '@_lifetime(borrow $2, borrow $3) @_lifetime($4: copy $4) (_ $0: NE, _ $1: NE, _ $2: borrowing NE, _ $3: borrowing NE, _ $4: inout NE) -> NE' to expected argument type '@_lifetime(immortal) @_lifetime(ne4: copy ne4) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
+  takeImmortal(f: copying0borrowing2) // expected-error{{cannot convert value of type '@_lifetime(copy $0, borrow $2) @_lifetime($4: copy $4) (_ $0: NE, _ $1: NE, _ $2: borrowing NE, _ $3: borrowing NE, _ $4: inout NE) -> NE' to expected argument type '@_lifetime(immortal) @_lifetime(ne4: copy ne4) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
+  takeImmortal(f: mutborrowing4) // expected-error{{cannot convert value of type '@_lifetime(&$4) @_lifetime($4: copy $4) (_ $0: NE, _ $1: NE, _ $2: borrowing NE, _ $3: borrowing NE, _ $4: inout NE) -> NE' to expected argument type '@_lifetime(immortal) @_lifetime(ne4: copy ne4) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
   takeImmortal(f: immortalFn) // OK
 
   takeInout0(f: inout0) // OK
-  takeInout0(f: inout01) // expected-error{{cannot convert value of type '@_lifetime(0: copy 0, copy 1) (inout NE, NE) -> ()' to expected argument type '@_lifetime(ne0: copy ne0) (_ ne0: inout NE, _ ne1: NE) -> ()'}}
+  takeInout0(f: inout01) // expected-error{{cannot convert value of type '@_lifetime($0: copy $0, copy $1) (_ $0: inout NE, _ $1: NE) -> ()' to expected argument type '@_lifetime(ne0: copy ne0) (_ ne0: inout NE, _ ne1: NE) -> ()'}}
   takeInout01(f: inout01) // OK
   takeInout01(f: inout0) // OK
 
@@ -412,4 +412,72 @@ func callLifetimeFunctions() {
   takeCopying0(f: copying0Captures) // expected-error{{cannot convert value of type '@_lifetime(captures, copy ne0) @_lifetime(ne4: copy ne4) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE' to expected argument type '@_lifetime(copy ne0) @_lifetime(ne4: copy ne4) (_ ne0: NE, _ ne1: NE, _ ne2: borrowing NE, _ ne3: borrowing NE, _ ne4: inout NE) -> NE'}}
   takeCopying0Captures(f: copying0) // OK
   takeCopying0Captures(f: copying0Captures) // OK
+}
+
+// ============================================================================
+// Tests for synthetic $N labels on unlabeled function type parameters
+// ============================================================================
+
+// Single unlabeled parameter
+@_lifetime(borrow x)
+func singleParam(x: borrowing NE) -> NE { x }
+
+func takeSingleCopy(f: @_lifetime(copy x) (_ x: borrowing NE) -> NE) {}
+
+do {
+  takeSingleCopy(f: singleParam) // expected-error{{cannot convert value of type '@_lifetime(borrow $0) (_ $0: borrowing NE) -> NE' to expected argument type '@_lifetime(copy x) (_ x: borrowing NE) -> NE'}}
+}
+
+// Mixed labeled and unlabeled parameters: labeled type on LHS, unlabeled function on RHS
+@_lifetime(copy a)
+func mixedUnlabeled(a: NE, b: borrowing NE) -> NE { a }
+
+func takeMixedLabeled(f: @_lifetime(borrow b) (_ a: NE, _ b: borrowing NE) -> NE) {}
+
+do {
+  takeMixedLabeled(f: mixedUnlabeled) // expected-error{{cannot convert value of type '@_lifetime(copy $0) (_ $0: NE, _ $1: borrowing NE) -> NE' to expected argument type '@_lifetime(borrow b) (_ a: NE, _ b: borrowing NE) -> NE'}}
+}
+
+// Instance method with self: self should print as 'self', not a synthetic label
+struct NEContainer: ~Escapable {
+  @_lifetime(copy self)
+  borrowing func getView() -> NE { NE() }
+}
+
+func takeFreeNE(f: @_lifetime(copy ne) (_ ne: borrowing NE) -> NE) {}
+
+// Inferred lifetime with inout target: synthetic labels for target and source
+@_lifetime(a: copy a, copy b)
+func inoutMixed(a: inout NE, b: NE) {}
+
+func takeInoutSingle(f: @_lifetime(a: copy a) (_ a: inout NE, _ b: NE) -> ()) {}
+
+do {
+  takeInoutSingle(f: inoutMixed) // expected-error{{cannot convert value of type '@_lifetime($0: copy $0, copy $1) (_ $0: inout NE, _ $1: NE) -> ()' to expected argument type '@_lifetime(a: copy a) (_ a: inout NE, _ b: NE) -> ()'}}
+}
+
+// Inout scope dep with synthetic label: &$N syntax
+@_lifetime(&a)
+func inoutScope(a: inout NE) -> NE { a }
+
+func takeInoutCopy(f: @_lifetime(copy a) (_ a: inout NE) -> NE) {}
+
+do {
+  takeInoutCopy(f: inoutScope) // expected-error{{cannot convert value of type '@_lifetime(&$0) @_lifetime($0: copy $0) (_ $0: inout NE) -> NE' to expected argument type '@_lifetime(copy a) @_lifetime(a: copy a) (_ a: inout NE) -> NE'}}
+}
+
+// Immortal function passed where specific source is expected: synthetic labels in param list
+@_lifetime(immortal)
+func immortalSingle(x: borrowing NE) -> NE { NE() }
+
+// immortal is a superset of any dependency, so this should be OK
+do {
+  takeSingleCopy(f: immortalSingle) // OK
+}
+
+// Captures-dependent closure passed where copy is expected
+do {
+  let captured = NE()
+  let closure: @_lifetime(captures) (_ x: borrowing NE) -> NE = { _ in captured }
+  takeSingleCopy(f: closure) // expected-error{{cannot convert value of type '@_lifetime(captures) (_ x: borrowing NE) -> NE' to expected argument type '@_lifetime(copy x) (_ x: borrowing NE) -> NE'}}
 }

--- a/validation-test/compiler_crashers_fixed/getLifetimeDependenceInfoSourceListString-fac202.swift
+++ b/validation-test/compiler_crashers_fixed/getLifetimeDependenceInfoSourceListString-fac202.swift
@@ -1,3 +1,3 @@
 // {"kind":"typecheck","original":"729ec36f","signature":"getLifetimeDependenceInfoSourceListString(swift::LifetimeDependenceInfo const&, llvm::ArrayRef<swift::AnyFunctionType::Param>)::$_0::operator()(swift::IndexSubset*, swift::LifetimeDependenceKind) const","signatureAssert":"Assertion failed: (Index < Length && \"Invalid index!\"), function operator[]","signatureNext":"ASTPrinter::printSwiftLifetimeDependence"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 MutableSpan.extracting(


### PR DESCRIPTION
WIP, follow-up to https://github.com/swiftlang/swift/pull/88768.
Solves: rdar://171065528 (Never print indices in function type lifetime annotations and fix other lifetime printing issues.)
<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
