### PR TITLE
[Sema] Add experimental feature flag to allow internal bridging header types in stored property layout

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -616,6 +616,10 @@ EXPERIMENTAL_FEATURE(BorrowingSequence, true)
 /// Turns some source breaking access control warnings into errors.
 EXPERIMENTAL_FEATURE(StrictAccessControl, true)
 
+/// Allow stored properties of types from an internal bridging header in
+/// non-resilient modules. Layout will be encoded in the .swiftmodule.
+EXPERIMENTAL_FEATURE(AbstractStoredPropertyLayout, false)
+
 #undef EXPERIMENTAL_FEATURE_EXCLUDED_FROM_MODULE_INTERFACE
 #undef EXPERIMENTAL_FEATURE
 #undef UPCOMING_FEATURE

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -686,6 +686,7 @@ static bool usesFeatureReparenting(Decl *decl) {
 
 UNINTERESTING_FEATURE(StrictAccessControl)
 UNINTERESTING_FEATURE(BorrowingSequence)
+UNINTERESTING_FEATURE(AbstractStoredPropertyLayout)
 
 // ----------------------------------------------------------------------------
 // MARK: - FeatureSet

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -257,10 +257,23 @@ const {
     case DisallowedOriginKind::SPILocal:
       return DiagnosticBehavior::Ignore;
     case DisallowedOriginKind::MissingImport:
-    case DisallowedOriginKind::InternalBridgingHeaderImport:
     case DisallowedOriginKind::ImplementationOnly:
     case DisallowedOriginKind::FragileCxxAPI:
     case DisallowedOriginKind::ImplementationOnlyMemoryLayout:
+      break;
+    case DisallowedOriginKind::InternalBridgingHeaderImport:
+      if (getDeclContext()->getASTContext().LangOpts.hasFeature(
+              Feature::AbstractStoredPropertyLayout)) {
+        if (auto reason = getExportabilityReason()) {
+          switch (*reason) {
+          case ExportabilityReason::ImplicitlyPublicVarDecl:
+          case ExportabilityReason::ImplicitlyPublicVarDeclOpenClass:
+            return DiagnosticBehavior::Ignore;
+          default:
+            break;
+          }
+        }
+      }
       break;
     }
   }

--- a/test/ClangImporter/InternalBridgingHeader/abstract-layout-simple.swift
+++ b/test/ClangImporter/InternalBridgingHeader/abstract-layout-simple.swift
@@ -1,0 +1,30 @@
+// Test that a public struct can have a private stored property of a C type
+// imported via an internal bridging header when AbstractStoredPropertyLayout is enabled.
+
+// REQUIRES: swift_feature_AbstractStoredPropertyLayout
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend \
+// RUN:   -internal-import-bridging-header %t/Utility.h \
+// RUN:   -enable-experimental-feature AbstractStoredPropertyLayout \
+// RUN:   -emit-module -module-name Library \
+// RUN:   -o %t/Library.swiftmodule \
+// RUN:   %t/Library.swift
+
+//--- Utility.h
+
+typedef struct { int value; } Wrapper;
+
+//--- Library.swift
+
+public struct S {
+  private var w: Wrapper
+
+  public init(value: Int32) {
+    self.w = Wrapper(value: value)
+  }
+
+  public var storedValue: Int32 { w.value }
+}


### PR DESCRIPTION
In non-resilient modules, stored properties are implicitly exported for layout purposes, preventing the use of types from an internal bridging header. This adds the AbstractStoredPropertyLayout experimental feature flag that suppresses the exportability diagnostic specifically for layout-contributing stored properties (ImplicitlyPublicVarDecl and ImplicitlyPublicVarDeclOpenClass), enabling a public struct to contain private stored properties of C types imported via -internal-import-bridging-header.

This is the first step toward encoding abstract layout information in the .swiftmodule so that clients can allocate, copy, and destroy values without loading the internal C dependency.

