### PR TITLE
[rbi] Skip nonisolated(unsafe) captures when diagnosing sending closure params

### DIFF
--- a/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
@@ -1289,6 +1289,11 @@ bool UseAfterSendDiagnosticInferrer::initForSendingPartialApply(
     auto trackableValue = valueMap.getTrackableValue(sendingPAIOp.get());
     if (trackableValue.value.isSendable())
       continue;
+    // Skip nonisolated(unsafe) captures -- the user has opted out of isolation
+    // checking for these values, so they should not be diagnosed as
+    // non-Sendable captures of a sending closure.
+    if (trackableValue.value.getIsolationRegionInfo().isUnsafeNonIsolated())
+      continue;
     nonSendableOps.push_back(&sendingPAIOp);
   }
 
@@ -2182,6 +2187,8 @@ bool SentNeverSendableDiagnosticEmitter::initForSendingPartialApply(
     // value... then we are done. This is a 'correct' error value to emit.
     auto trackableValue = valueMap.getTrackableValue(sendingPAIOp.get());
     if (trackableValue.value.isSendable())
+      continue;
+    if (trackableValue.value.getIsolationRegionInfo().isUnsafeNonIsolated())
       continue;
 
     auto rep = trackableValue.value.getRepresentative().maybeGetValue();

--- a/test/Concurrency/transfernonsendable_nonisolatedunsafe.swift
+++ b/test/Concurrency/transfernonsendable_nonisolatedunsafe.swift
@@ -948,7 +948,7 @@ func closureTests() async {
     nonisolated(unsafe) let x = NonSendableKlass()
     let y = NonSendableKlass()
     sendingClosure {
-      _ = x // expected-warning {{closure passed as an argument to a 'sending' parameter captures 'x' which is accessed later by code in the current task}}
+      _ = x
       _ = y // expected-warning {{closure passed as an argument to a 'sending' parameter captures 'y' which is accessed later by code in the current task}}
     }
     sendingClosure { // expected-note {{access can happen concurrently}}
@@ -1037,7 +1037,7 @@ func closureTests() async {
     var y = NonSendableKlass()
     y = NonSendableKlass()
     sendingClosure {
-      _ = x // expected-warning {{closure passed as an argument to a 'sending' parameter captures 'x' which is accessed later by code in the current task}}
+      _ = x
       _ = y // expected-warning {{closure passed as an argument to a 'sending' parameter captures 'y' which is accessed later by code in the current task}}
     }
     sendingClosure { // expected-note {{access can happen concurrently}}
@@ -1078,7 +1078,7 @@ func closureTests() async {
     nonisolated(unsafe) let x4a = NonSendableKlass()
     let x4b = NonSendableKlass()
     Task.detached {
-      _ = x4a; // expected-warning {{closure passed as an argument to a 'sending' parameter captures 'x4a' which is accessed later by code in the current task}}
+      _ = x4a;
       _ = x4b // expected-warning {{closure passed as an argument to a 'sending' parameter captures 'x4b' which is accessed later by code in the current task}}
     }
 
@@ -1094,6 +1094,58 @@ func closureTests() async {
   // not.
   func testNamedClosure() async {
     nonisolated(unsafe) let x = NonSendableKlass()
+    let y = {
+      _ = x
+    }
+    sendingClosure(y) // expected-warning {{sending 'y' risks causing data races}}
+    // expected-note @-1 {{'y' used after being passed as a 'sending' parameter}}
+    sendingClosure(y) // expected-note {{access can happen concurrently}}
+  }
+
+  // Named closure capturing nonisolated(unsafe) + non-sendable. The
+  // nonisolated(unsafe) capture should be skipped, and only the non-sendable
+  // capture should be diagnosed.
+  func testNamedClosureMixedCaptures() async {
+    nonisolated(unsafe) let x = NonSendableKlass()
+    let z = NonSendableKlass()
+    let y = {
+      _ = x
+      _ = z
+    }
+    sendingClosure(y) // expected-warning {{sending 'y' risks causing data races}}
+    // expected-note @-1 {{'y' used after being passed as a 'sending' parameter; Later uses could race}}
+    sendingClosure(y) // expected-note {{access can happen concurrently}}
+  }
+
+  // Named closure capturing only nonisolated(unsafe) with a single send
+  // should produce no errors.
+  func testNamedClosureNonisolatedUnsafeSingleSend() async {
+    nonisolated(unsafe) let x = NonSendableKlass()
+    let y = {
+      _ = x
+    }
+    sendingClosure(y)
+  }
+
+  // Task-isolated parameter + nonisolated(unsafe) capture. Each send of the
+  // closure triggers a SentNeverSendable error for ns (task-isolated), while
+  // x (nonisolated(unsafe)) is not diagnosed.
+  func testSendingClosureTaskIsolatedAndNonisolatedUnsafe(_ ns: NonSendableKlass) async {
+    nonisolated(unsafe) let x = NonSendableKlass()
+    sendingClosure { // expected-warning {{passing closure as a 'sending' parameter risks causing data races between code in the current task and concurrent execution of the closure}}
+      _ = x
+      _ = ns // expected-note {{closure captures 'ns' which is accessible to code in the current task}}
+    }
+    sendingClosure { // expected-warning {{passing closure as a 'sending' parameter risks causing data races between code in the current task and concurrent execution of the closure}}
+      _ = x
+      _ = ns // expected-note {{closure captures 'ns' which is accessible to code in the current task}}
+    }
+  }
+
+  // var version of testNamedClosure.
+  func testNamedClosureVar() async {
+    nonisolated(unsafe) var x = NonSendableKlass()
+    x = NonSendableKlass()
     let y = {
       _ = x
     }


### PR DESCRIPTION
When a closure passed to a `sending` parameter captures a `nonisolated(unsafe)` value, the diagnostic inferrer was incorrectly including it in the list of non-Sendable captures. This caused the wrong diagnostic to fire (e.g. "closure captures 'x'" instead of "sending 'y' risks causing data races") because the inferrer believed the closure had problematic captures when it did not.

Add an `isUnsafeNonIsolated()` guard in both
`UseAfterSendDiagnosticInferrer::initForSendingPartialApply` and `SentNeverSendableDiagnosticEmitter::initForSendingPartialApply` so that `nonisolated(unsafe)` captures are skipped, matching the user's intent to opt out of isolation checking for those values.

rdar://176385586

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
