### PR TITLE
allow partially specializing a typealias to fully concrete types at h…

### DIFF
--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -3021,6 +3021,37 @@ AllMembersRequest::evaluate(
   return evaluateMembersRequest(idc, MembersRequestKind::All);
 }
 
+static bool isBoundToFullyConcreteType(TypeAliasDecl *typealias,
+                                       NominalTypeDecl *nominal) {
+  if (!nominal->hasGenericParamList()) {
+    return false;
+  }
+
+  auto nominalBound =
+      nominal->getDeclaredInterfaceType()->getAs<BoundGenericType>();
+  auto typealiasBound =
+      typealias->getUnderlyingType()->getAs<BoundGenericType>();
+
+  if ((nominalBound == nullptr) || (typealiasBound == nullptr))
+    return false;
+
+  auto nominalGenericArguments = nominalBound->getGenericArgs();
+  auto typealiasGenericArguments = typealiasBound->getGenericArgs();
+
+  for (size_t i = 0; i < nominalGenericArguments.size(); i++) {
+    auto nominalBoundGenericType = nominalGenericArguments[i];
+    auto typealiasBoundGenericType = typealiasGenericArguments[i];
+    if (nominalBoundGenericType->isEqual(typealiasBoundGenericType)) {
+      continue;
+    }
+
+    if (typealiasBoundGenericType->hasTypeParameter())
+      return false;
+  }
+
+  return true;
+}
+
 bool TypeChecker::isPassThroughTypealias(TypeAliasDecl *typealias,
                                          NominalTypeDecl *nominal) {
   // Pass-through only makes sense when the typealias refers to a nominal
@@ -3041,17 +3072,37 @@ bool TypeChecker::isPassThroughTypealias(TypeAliasDecl *typealias,
   // If neither is generic, we're done: it's a pass-through alias.
   if (!nominalSig) return true;
 
-  // Check that the type parameters are the same the whole way through.
   auto nominalGenericParams = nominalSig.getGenericParams();
   auto typealiasGenericParams = typealiasSig.getGenericParams();
+
+  if (typealiasGenericParams.size() > nominalGenericParams.size())
+    return false;
+
+  if (nominalGenericParams.size() != typealiasGenericParams.size()) {
+    while (!nominalGenericParams.empty() &&
+           nominalGenericParams.front()->getDepth() == 0U) {
+      nominalGenericParams = nominalGenericParams.drop_front();
+    }
+
+    while (!typealiasGenericParams.empty() &&
+           typealiasGenericParams.front()->getDepth() == 0U) {
+      typealiasGenericParams = typealiasGenericParams.drop_front();
+    }
+  }
+
   if (nominalGenericParams.size() != typealiasGenericParams.size())
     return false;
+
   if (!std::equal(nominalGenericParams.begin(), nominalGenericParams.end(),
                   typealiasGenericParams.begin(),
                   [](GenericTypeParamType *gp1, GenericTypeParamType *gp2) {
                     return gp1->isEqual(gp2);
-                  }))
+                  })) {
     return false;
+  }
+
+  if (isBoundToFullyConcreteType(typealias, nominal))
+    return true;
 
   // If neither is generic at this level, we have a pass-through typealias.
   if (!typealias->hasGenericParamList())

--- a/test/decl/ext/specialize.swift
+++ b/test/decl/ext/specialize.swift
@@ -32,6 +32,106 @@ extension IntFoo where U == Int {
 
 Foo(x: "test", y: 1).hello()
 
+
+struct Field<Tag,Value> {
+  let tag: Tag
+  let value: Value
+}
+
+typealias IntField<Tag> = Field<Tag,Int>
+
+extension IntField {
+  func adding(_ value: Int) -> Self {
+    Field(tag: tag, value: self.value + value)
+  }
+}
+
+struct S10<X, Y> {}
+typealias InferredSpecializedNestedTypes<X> = S10<X, (Int, [Int]?)>
+extension InferredSpecializedNestedTypes {
+    func returnTuple(value: Y) -> (Int, [Int]?) {
+        return value
+    }
+}
+
+
+struct S2<X,Y,Z> {
+  let x: X
+  let y: Y
+  let z: Z
+}
+
+typealias A2<Y,X> = S2<Int,X,Y>
+
+extension A2 {
+  func test() {
+    let int: Int
+    let _: X = int // expected-error {{cannot convert value of type 'Int' to specified type 'X'}}
+  }
+}
+
+
+struct S4<A, B> {
+  // Generic parameters: <A, B, C>
+  // Depth:               0  0  1
+  struct Nested<C> {
+      let c: C
+  }
+}
+
+struct S5<A> {
+  // Generic parameters: <A, B, C>
+  // Depth:               0  1  1
+  typealias Alias<B, C> = S4<A, B>.Nested<C> where A == Int
+}
+
+extension S5.Alias{
+  func test() {
+    let int: Int
+    let _: A = int // expected-error {{cannot convert value of type 'Int' to specified type 'A'}}
+  }
+}
+
+
+struct S11<T> {
+  struct Inner<U> {}
+}
+
+struct S12<T> {
+  struct Inner<U> {}
+  typealias A1<U> = S11<T>.Inner<U>
+  typealias A2<U> = S12<T>.Inner<U> where T == Int
+}
+
+extension S12<Int>.A1 {
+  func foo1() {
+    let int: Int
+    let _: T = int
+  }
+}
+
+extension S12.A2 {
+  func foo2() {
+    let int: Int
+    let _: T = int
+  }
+}
+
+
+struct S13<T> {
+  struct Inner<U> {}
+}
+struct S14 {
+  typealias A<T> = S13<T>.Inner<Int>
+}
+extension S14.A {
+  func test() {
+    let int: Int
+    let _: U = int // expected-error {{cannot convert value of type 'Int' to specified type 'U'}}
+  }
+}
+
+
 struct MyType<TyA, TyB> {
   var a : TyA, b : TyB
 }


### PR DESCRIPTION
…ighest level

Resolves https://github.com/swiftlang/swift/issues/88835.
Relax the fall-through type alias criteria a little bit by allowing a mismatch in the number of generic parameters at the greatest depth, in case that difference is due to some of those generic parameters being bound to fully concrete types.

Added new test cases.
