### PR TITLE
[NFC][SILGen]: dead code removal and other minor cleanups

### DIFF
--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -279,7 +279,7 @@ const SILDebugScope *SILGenFunction::getScopeOrNull(SILLocation Loc,
   }
 
   SourceLoc SLoc = Loc.getSourceLoc();
-  if (!SF || LastSourceLoc == SLoc)
+  if (!SF || !SLoc)
     return nullptr;
   if (ForMetaInstruction)
     if (ValueDecl *ValDecl = Loc.getAsASTNode<ValueDecl>()) {

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -411,7 +411,6 @@ public:
   std::vector<SingleValueStmtInitialization> SingleValueStmtInitStack;
 
   SourceFile *SF;
-  SourceLoc LastSourceLoc;
   using ASTScopeTy = ast_scope::ASTScopeImpl;
   const ASTScopeTy *FnASTScope = nullptr;
   using VarDeclScopeMapTy =

--- a/lib/SILGen/SILGenStmt.cpp
+++ b/lib/SILGen/SILGenStmt.cpp
@@ -596,8 +596,7 @@ prepareIndirectResultInit(SILGenFunction &SGF, SILLocation loc,
     if (!vanishes) {
       auto resultTupleType = cast<TupleType>(resultType);
       tupleInit = new TupleInitialization(resultTupleType);
-      tupleInit->SubInitializations.reserve(
-        cast<TupleType>(resultType)->getNumElements());
+      tupleInit->SubInitializations.reserve(resultTupleType->getNumElements());
     }
 
     // The list of element initializers to build into.
@@ -869,8 +868,8 @@ bool SILGenFunction::emitBorrowOrMutateAccessorResult(
 void SILGenFunction::emitReturnExpr(SILLocation branchLoc,
                                     Expr *ret) {
   SmallVector<SILValue, 4> directResults;
-  auto retTy = ret->getType()->getCanonicalType();
-  
+  const auto retTy = ret->getType()->getCanonicalType();
+
   AbstractionPattern origRetTy = TypeContext
     ? TypeContext->OrigType.getFunctionResultType()
     : AbstractionPattern(retTy);
@@ -881,10 +880,8 @@ void SILGenFunction::emitReturnExpr(SILLocation branchLoc,
 
     // Build an initialization which recursively destructures the tuple.
     SmallVector<CleanupHandle, 4> resultCleanups;
-    InitializationPtr resultInit =
-      prepareIndirectResultInit(ret, origRetTy,
-                                ret->getType()->getCanonicalType(),
-                                directResults, resultCleanups);
+    InitializationPtr resultInit = prepareIndirectResultInit(
+        ret, origRetTy, retTy, directResults, resultCleanups);
 
     // Emit the result expression into the initialization.
     emitExprInto(ret, resultInit.get());
@@ -1492,7 +1489,7 @@ void StmtEmitter::visitOpaqueStmt(OpaqueStmt *S) {
   if (P && P->hasCounterFor(ref))
     SGF.emitProfilerIncrement(ref);
 
-  visit(SGF.OpaqueStmts[S]);
+  visit(stmt);
 }
 
 void StmtEmitter::visitForEachStmt(ForEachStmt *S) {


### PR DESCRIPTION
Removes some dead code and cleans up a few minor duplicated expressions found with LLM-assistance when looking over some SILGen code.