### PR TITLE
Coalesce large homogeneous tuples in IDE quick help

### DIFF
--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -897,6 +897,7 @@ public:
     PO.SkipImplicit = true;
     PO.AlwaysPrintNonSendableExtensions = false;
     PO.AlwaysTryPrintParameterLabels = true;
+    PO.PrintHomogeneousTuplesCompactly = true;
     return PO;
   }
 

--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -38,6 +38,7 @@ class TypeBase;
 class DeclContext;
 class Type;
 class ModuleDecl;
+class TupleType;
 enum class DeclAttrKind : unsigned;
 class DeclAttribute;
 class CustomAttr;
@@ -659,6 +660,15 @@ public:
   /// (e.g. `(Int /* ... repeated 5 times ... */)` instead of 
   /// `(Int, Int, Int, Int, Int)`).
   bool PrintHomogeneousTuplesCompactly = false;
+
+  /// When non-`null`, this is the resolved type corresponding to the 
+  /// `TupleTypeRepr` about to be printed in the `TypeRepr` path. 
+  ///  
+  /// This is set transiently by the printer when delegating to a 
+  /// `TupleTypeRepr`'s print method, so printing has access to resolved 
+  /// types when deciding whether to coalesce a homogeneous tuple, 
+  /// matching the criterion used by the `Type` printing path.
+  TupleType *CurrentTupleTypeReprResolvedType = nullptr;
 
   /// Whether to always desugar array types from `[base_type]` to `Array<base_type>`
   bool AlwaysDesugarArraySliceTypes = false;

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -1134,6 +1134,27 @@ class PrintAST : public ASTVisitor<PrintAST> {
     printType(T, outermostOptions);
   }
 
+  /// Print a `TypeRepr` directly while threading a resolved tuple type 
+  /// into `PrintOptions::CurrentTupleTypeReprResolvedType` for the 
+  /// duration of the print, mirroring what `printTypeLoc` does. 
+  /// 
+  /// Use this for the rare sites that bypass `printTypeLoc()` and 
+  // call `TypeRepr::print()` themselves.
+  void printTypeReprWithResolvedTuple(
+      TypeRepr *repr, Type resolvedTy,
+      NonRecursivePrintOptions nrOptions = std::nullopt) {
+    PrintOptions::OverrideScope scope(Options);
+    if (isa<TupleTypeRepr>(repr)) {
+      if (resolvedTy) {
+        if (auto tupleTy = resolvedTy->getAs<TupleType>()) {
+          OVERRIDE_PRINT_OPTION_UNCONDITIONAL(
+            scope, CurrentTupleTypeReprResolvedType, tupleTy);
+        }
+      }
+    }
+    repr->print(Printer, Options, nrOptions);
+  }
+
   void printTypeLoc(const TypeLoc &TL,
         NonRecursivePrintOptions outermostOptions = std::nullopt,
         std::optional<llvm::function_ref<void()>> printBeforeType = std::nullopt) {
@@ -1147,7 +1168,7 @@ class PrintAST : public ASTVisitor<PrintAST> {
     // is null.
     if (willUseTypeReprPrinting(TL, CurrentType, Options)) {
       if (auto repr = TL.getTypeRepr())
-        repr->print(Printer, Options, outermostOptions);
+        printTypeReprWithResolvedTuple(repr, TL.getType(), outermostOptions);
       return;
     }
 
@@ -4850,7 +4871,7 @@ void PrintAST::visitFuncDecl(FuncDecl *decl) {
           if (auto *sendingRepr = dyn_cast<SendingTypeRepr>(repr)) {
             repr = sendingRepr->getBase();
           }
-          repr->print(Printer, Options, nrOptions);
+          printTypeReprWithResolvedTuple(repr, ResultTyLoc.getType(), nrOptions);
           usedTypeReprPrinting = true;
         }
       }

--- a/lib/AST/TypeRepr.cpp
+++ b/lib/AST/TypeRepr.cpp
@@ -795,7 +795,54 @@ void TupleTypeRepr::printImpl(ASTPrinter &Printer,
 
   Printer << "(";
 
-  for (unsigned i = 0, e = Bits.TupleTypeRepr.NumElements; i != e; ++i) {
+  unsigned NumElements = Bits.TupleTypeRepr.NumElements;
+
+  // Compact printing for homogeneous unlabeled tuples with 5+ elements.
+  // Mirrors the compaction in TypePrinter::visitTupleType, but operates 
+  // on the syntactic TypeRepr rather than the resolved Type. Two 
+  // unlabeled elements are considered homogeneous if their printed 
+  // forms match exactly. This is stricter than the Type-based check, 
+  // which uses isEqual and coalesces differently-sugared-but-equal 
+  // types. The stricter form is appropriate here since the TypeRepr 
+  // path appears in contexts where resolved types are not available.
+  if (Opts.PrintHomogeneousTuplesCompactly && NumElements > 4) {
+    bool AllUnlabeled = true;
+    for (unsigned i = 0; i != NumElements; ++i) {
+      if (!getElementName(i).empty() || isNamedParameter(i)) {
+        AllUnlabeled = false;
+        break;
+      }
+    }
+
+    if (AllUnlabeled) {
+      SmallString<32> FirstStr;
+      {
+        llvm::raw_svector_ostream OS(FirstStr);
+        StreamPrinter SP(OS);
+        printTypeRepr(getElementType(0), SP, Opts);
+      }
+
+      bool IsHomogeneous = true;
+      for (unsigned i = 1; i != NumElements; ++i) {
+        SmallString<32> EltStr;
+        llvm::raw_svector_ostream OS(EltStr);
+        StreamPrinter SP(OS);
+        printTypeRepr(getElementType(i), SP, Opts);
+        if (StringRef(EltStr) != StringRef(FirstStr)) {
+          IsHomogeneous = false;
+          break;
+        }
+      }
+
+      if (IsHomogeneous) {
+        printTypeRepr(getElementType(0), Printer, Opts);
+        Printer << " /* ... repeated " << NumElements << " times ... */)";
+        return;
+      }
+    }
+  }
+
+  for (unsigned i = 0, e = NumElements; i != e; ++i) {
     if (i) Printer << ", ";
     Printer.callPrintStructurePre(PrintStructureKind::TupleElement);
     auto name = getElementName(i);

--- a/lib/AST/TypeRepr.cpp
+++ b/lib/AST/TypeRepr.cpp
@@ -793,54 +793,54 @@ void TupleTypeRepr::printImpl(ASTPrinter &Printer,
   Printer.callPrintStructurePre(PrintStructureKind::TupleType);
   SWIFT_DEFER { Printer.printStructurePost(PrintStructureKind::TupleType); };
 
-  Printer << "(";
-
   unsigned NumElements = Bits.TupleTypeRepr.NumElements;
 
   // Compact printing for homogeneous unlabeled tuples with 5+ elements.
-  // Mirrors the compaction in TypePrinter::visitTupleType, but operates 
-  // on the syntactic TypeRepr rather than the resolved Type. Two 
-  // unlabeled elements are considered homogeneous if their printed 
-  // forms match exactly. This is stricter than the Type-based check, 
-  // which uses isEqual and coalesces differently-sugared-but-equal 
-  // types. The stricter form is appropriate here since the TypeRepr 
-  // path appears in contexts where resolved types are not available.
+  // We rely on the resolved `TupleType` threaded through `PrintOptions` 
+  // by `ASTPrinter::printTypeLoc()` so we can compare element types 
+  // using `Type::isEqual()`, matching the criterion used on the `Type` 
+  // printing path in `TypePrinter::visitTupleType()`.
   if (Opts.PrintHomogeneousTuplesCompactly && NumElements > 4) {
-    bool AllUnlabeled = true;
-    for (unsigned i = 0; i != NumElements; ++i) {
-      if (!getElementName(i).empty() || isNamedParameter(i)) {
-        AllUnlabeled = false;
-        break;
-      }
-    }
-
-    if (AllUnlabeled) {
-      SmallString<32> FirstStr;
-      {
-        llvm::raw_svector_ostream OS(FirstStr);
-        StreamPrinter SP(OS);
-        printTypeRepr(getElementType(0), SP, Opts);
-      }
-
-      bool IsHomogeneous = true;
-      for (unsigned i = 1; i != NumElements; ++i) {
-        SmallString<32> EltStr;
-        llvm::raw_svector_ostream OS(EltStr);
-        StreamPrinter SP(OS);
-        printTypeRepr(getElementType(i), SP, Opts);
-        if (StringRef(EltStr) != StringRef(FirstStr)) {
-          IsHomogeneous = false;
-          break;
+    if (auto *ResolvedTuple = Opts.CurrentTupleTypeReprResolvedType) {
+      auto ResolvedElts = ResolvedTuple->getElements();
+      if (ResolvedElts.size() == NumElements) {
+        Type FirstEltType = ResolvedElts[0].getType();
+        bool IsHomogeneous = true;
+        for (unsigned i = 0; i != NumElements; ++i) {
+          if (isNamedParameter(i) || !getElementName(i).empty() ||
+              !ResolvedElts[i].getType()->isEqual(FirstEltType)) {
+            IsHomogeneous = false;
+            break;
+          }
         }
-      }
 
-      if (IsHomogeneous) {
-        printTypeRepr(getElementType(0), Printer, Opts);
-        Printer << " /* ... repeated " << NumElements << " times ... */)";
-        return;
+        if (IsHomogeneous) {
+          // Clear the resolved-type field for the element print so a 
+          // nested `TupleTypeRepr` cannot incorrectly inherit this 
+          // tuple's resolved type.
+          PrintOptions::OverrideScope scope(Opts);
+          OVERRIDE_PRINT_OPTION_UNCONDITIONAL(
+              scope, CurrentTupleTypeReprResolvedType, nullptr);
+
+          Printer << "(";
+          Printer.callPrintStructurePre(PrintStructureKind::TupleElement);
+          printTypeRepr(getElementType(0), Printer, Opts);
+          Printer.printStructurePost(PrintStructureKind::TupleElement);
+          Printer << " /* ... repeated " << NumElements << " times ... */)";
+          return;
+        }
       }
     }
   }
+
+  // Clear the outer-tuple resolved type for the duration of element 
+  // prints, so a nested `TupleTypeRepr` doesn't pick up this tuple's 
+  // `TupleType`.
+  PrintOptions::OverrideScope scope(Opts);
+  OVERRIDE_PRINT_OPTION_UNCONDITIONAL(
+    scope, CurrentTupleTypeReprResolvedType, nullptr);
+
+  Printer << "(";
 
   for (unsigned i = 0, e = NumElements; i != e; ++i) {
     if (i) Printer << ", ";

--- a/test/SourceKit/CursorInfo/cursor_info_homogeneous_tuple.swift
+++ b/test/SourceKit/CursorInfo/cursor_info_homogeneous_tuple.swift
@@ -1,0 +1,39 @@
+// RUN: %sourcekitd-test -req=cursor -pos=9:6 %s -- %s | %FileCheck -check-prefix=CHECK_HOMOGENEOUS_PARAM %s
+// RUN: %sourcekitd-test -req=cursor -pos=12:6 %s -- %s | %FileCheck -check-prefix=CHECK_HOMOGENEOUS_RETURN %s
+// RUN: %sourcekitd-test -req=cursor -pos=15:5 %s -- %s | %FileCheck -check-prefix=CHECK_HOMOGENEOUS_GLOBAL %s
+// RUN: %sourcekitd-test -req=cursor -pos=18:6 %s -- %s | %FileCheck -check-prefix=CHECK_SMALL %s
+// RUN: %sourcekitd-test -req=cursor -pos=21:6 %s -- %s | %FileCheck -check-prefix=CHECK_LABELED %s
+// RUN: %sourcekitd-test -req=cursor -pos=24:6 %s -- %s | %FileCheck -check-prefix=CHECK_HETEROGENEOUS %s
+
+// 5-element homogeneous unlabeled tuple as a parameter type compacts.
+func homogeneousParam(_ x: (Int, Int, Int, Int, Int)) {}
+
+// 5-element homogeneous unlabeled tuple as a return type compacts.
+func homogeneousReturn() -> (Int, Int, Int, Int, Int) { fatalError() }
+
+// 5-element homogeneous unlabeled tuple as a global var type compacts.
+let homogeneousGlobal: (Int, Int, Int, Int, Int) = (0, 0, 0, 0, 0)
+
+// 4-element homogeneous unlabeled tuple does not compact (below threshold).
+func smallTuple(_ x: (Int, Int, Int, Int)) {}
+
+// 5-element labeled homogeneous tuple does not compact (labels disqualify).
+func labeledTuple(_ x: (a: Int, b: Int, c: Int, d: Int, e: Int)) {}
+
+// 5-element heterogeneous tuple does not compact (not homogeneous).
+func heterogeneousTuple(_ x: (Int, Int, Int, Int, String)) {}
+
+// CHECK_HOMOGENEOUS_PARAM: <Declaration>func homogeneousParam(_ x: (<Type usr="s:Si">Int</Type> /* ... repeated 5 times ... */))</Declaration>
+// CHECK_HOMOGENEOUS_PARAM: <decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>homogeneousParam</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>x</decl.var.parameter.name>: <decl.var.parameter.type><tuple>(<ref.struct usr="s:Si">Int</ref.struct> /* ... repeated 5 times ... */)</tuple></decl.var.parameter.type></decl.var.parameter>)</decl.function.free>
+
+// CHECK_HOMOGENEOUS_RETURN: <Declaration>func homogeneousReturn() -&gt; (<Type usr="s:Si">Int</Type> /* ... repeated 5 times ... */)</Declaration>
+// CHECK_HOMOGENEOUS_RETURN: <decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>homogeneousReturn</decl.name>() -&gt; <decl.function.returntype><tuple>(<ref.struct usr="s:Si">Int</ref.struct> /* ... repeated 5 times ... */)</tuple></decl.function.returntype></decl.function.free>
+
+// CHECK_HOMOGENEOUS_GLOBAL: <Declaration>let homogeneousGlobal: (<Type usr="s:Si">Int</Type> /* ... repeated 5 times ... */)</Declaration>
+// CHECK_HOMOGENEOUS_GLOBAL: <decl.var.global><syntaxtype.keyword>let</syntaxtype.keyword> <decl.name>homogeneousGlobal</decl.name>: <decl.var.type><tuple>(<ref.struct usr="s:Si">Int</ref.struct> /* ... repeated 5 times ... */)</tuple></decl.var.type></decl.var.global>
+
+// CHECK_SMALL: <Declaration>func smallTuple(_ x: (<Type usr="s:Si">Int</Type>, <Type usr="s:Si">Int</Type>, <Type usr="s:Si">Int</Type>, <Type usr="s:Si">Int</Type>))</Declaration>
+
+// CHECK_LABELED: <Declaration>func labeledTuple(_ x: (a: <Type usr="s:Si">Int</Type>, b: <Type usr="s:Si">Int</Type>, c: <Type usr="s:Si">Int</Type>, d: <Type usr="s:Si">Int</Type>, e: <Type usr="s:Si">Int</Type>))</Declaration>
+
+// CHECK_HETEROGENEOUS: <Declaration>func heterogeneousTuple(_ x: (<Type usr="s:Si">Int</Type>, <Type usr="s:Si">Int</Type>, <Type usr="s:Si">Int</Type>, <Type usr="s:Si">Int</Type>, <Type usr="s:SS">String</Type>))</Declaration>

--- a/test/SourceKit/CursorInfo/cursor_info_homogeneous_tuple.swift
+++ b/test/SourceKit/CursorInfo/cursor_info_homogeneous_tuple.swift
@@ -24,13 +24,13 @@ func labeledTuple(_ x: (a: Int, b: Int, c: Int, d: Int, e: Int)) {}
 func heterogeneousTuple(_ x: (Int, Int, Int, Int, String)) {}
 
 // CHECK_HOMOGENEOUS_PARAM: <Declaration>func homogeneousParam(_ x: (<Type usr="s:Si">Int</Type> /* ... repeated 5 times ... */))</Declaration>
-// CHECK_HOMOGENEOUS_PARAM: <decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>homogeneousParam</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>x</decl.var.parameter.name>: <decl.var.parameter.type><tuple>(<ref.struct usr="s:Si">Int</ref.struct> /* ... repeated 5 times ... */)</tuple></decl.var.parameter.type></decl.var.parameter>)</decl.function.free>
+// CHECK_HOMOGENEOUS_PARAM: <decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>homogeneousParam</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>x</decl.var.parameter.name>: <decl.var.parameter.type><tuple>(<tuple.element><tuple.element.type><ref.struct usr="s:Si">Int</ref.struct></tuple.element.type></tuple.element> /* ... repeated 5 times ... */)</tuple></decl.var.parameter.type></decl.var.parameter>)</decl.function.free>
 
 // CHECK_HOMOGENEOUS_RETURN: <Declaration>func homogeneousReturn() -&gt; (<Type usr="s:Si">Int</Type> /* ... repeated 5 times ... */)</Declaration>
-// CHECK_HOMOGENEOUS_RETURN: <decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>homogeneousReturn</decl.name>() -&gt; <decl.function.returntype><tuple>(<ref.struct usr="s:Si">Int</ref.struct> /* ... repeated 5 times ... */)</tuple></decl.function.returntype></decl.function.free>
+// CHECK_HOMOGENEOUS_RETURN: <decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>homogeneousReturn</decl.name>() -&gt; <decl.function.returntype><tuple>(<tuple.element><tuple.element.type><ref.struct usr="s:Si">Int</ref.struct></tuple.element.type></tuple.element> /* ... repeated 5 times ... */)</tuple></decl.function.returntype></decl.function.free>
 
 // CHECK_HOMOGENEOUS_GLOBAL: <Declaration>let homogeneousGlobal: (<Type usr="s:Si">Int</Type> /* ... repeated 5 times ... */)</Declaration>
-// CHECK_HOMOGENEOUS_GLOBAL: <decl.var.global><syntaxtype.keyword>let</syntaxtype.keyword> <decl.name>homogeneousGlobal</decl.name>: <decl.var.type><tuple>(<ref.struct usr="s:Si">Int</ref.struct> /* ... repeated 5 times ... */)</tuple></decl.var.type></decl.var.global>
+// CHECK_HOMOGENEOUS_GLOBAL: <decl.var.global><syntaxtype.keyword>let</syntaxtype.keyword> <decl.name>homogeneousGlobal</decl.name>: <decl.var.type><tuple>(<tuple.element><tuple.element.type><ref.struct usr="s:Si">Int</ref.struct></tuple.element.type></tuple.element> /* ... repeated 5 times ... */)</tuple></decl.var.type></decl.var.global>
 
 // CHECK_SMALL: <Declaration>func smallTuple(_ x: (<Type usr="s:Si">Int</Type>, <Type usr="s:Si">Int</Type>, <Type usr="s:Si">Int</Type>, <Type usr="s:Si">Int</Type>))</Declaration>
 


### PR DESCRIPTION
Follow-up to #88179, which enabled compact printing of large homogeneous unlabeled tuples in compiler diagnostics. The same readability problem appears in IDE quick help and cursor info.

After this PR, large homogeneous unlabeled tuples such as the one in the image below will be shown in the compact form `(T /* ... repeated N times ... */)` instead of `(T, T, T, T, T, ...)`.

<img width="1035" height="145" alt="Screenshot 2026-04-27 at 2 05 42 PM" src="https://github.com/user-attachments/assets/55f4fca5-3f38-4509-a2d0-07423b3968f9" />

## Design

Cursor info reaches the type printer through a different path than diagnostics. This PR enables `PrintOptions.PrintHomogeneousTuplesCompactly` in `PrintOptions::printQuickHelpDeclaration()`, and implements the same compaction logic from `TypePrinter::visitTupleType()` in `TupleTypeRepr::printImpl()`.

The diagnostic path uses `Type::isEqual()` for the homogeneity check. The new `TypeRepr` path uses syntactic comparison, where two unlabeled elements are considered homogeneous if their printed forms match exactly.

`TypeRepr` printing happens in contexts where resolved types are not readily available. This means that `(Int, IntAlias, Int, Int, Int)` where `IntAlias = Int` will compact in diagnostics but not in cursor info. This is a deliberate decision, since in cursor info contexts, the user is reading source, where preserving the typealias spelling has meaningful benefits. Additionally, the primary motivating case is C-imported fixed-size arrays, which are unaffected by this difference since all elements have identical spelling.

`PrintHomogeneousTuplesCompactly` now flows through `forDiagnosticArguments()` and `printForDiagnostics()` (via #88179), `printQuickHelpDeclaration()` (this PR), and is inherited by the descendants of `printForDiagnostics()`. Since `printSwiftInterfaceFile()` constructs its options independently, `.swiftinterface` is unaffected.

## Testing

Added a new test file at `test/SourceKit/CursorInfo/cursor_info_homogeneous_tuple.swift`.

I ran the full test suite locally, which passed with no existing tests requiring updates.