### PR TITLE
[DebugInfo] Remove DIExpr from AllocStackInst

### DIFF
--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -2052,8 +2052,7 @@ class AllocStackInst final
                              AllocationInst>,
       private SILDebugVariableSupplement,
       private llvm::TrailingObjects<AllocStackInst, SILType, SILLocation,
-                                    const SILDebugScope *, SILDIExprElement,
-                                    Operand, char> {
+                                    const SILDebugScope *, Operand, char> {
   friend TrailingObjects;
   friend SILBuilder;
 
@@ -2203,11 +2202,8 @@ public:
     else if (complete)
       VarDeclScope = getDebugScope();
 
-    llvm::ArrayRef<SILDIExprElement> DIExprElements(
-        getTrailingObjects<SILDIExprElement>(), NumDIExprOperands);
-
     return VarInfo.get(getDecl(), getTrailingObjects<char>(), AuxVarType,
-                       VarDeclLoc, VarDeclScope, DIExprElements);
+                       VarDeclLoc, VarDeclScope, {});
   }
 
   /// True if this AllocStack has var info that a pass purposely invalidated.

--- a/lib/SIL/IR/SILInstructions.cpp
+++ b/lib/SIL/IR/SILInstructions.cpp
@@ -219,7 +219,7 @@ AllocStackInst::AllocStackInst(
     IsFromVarDecl_t isFromVarDecl,
     UsesMoveableValueDebugInfo_t usesMoveableValueDebugInfo)
     : InstructionBase(Loc, elementType.getAddressType()),
-      SILDebugVariableSupplement(Var ? Var->DIExpr.getNumElements() : 0,
+      SILDebugVariableSupplement(0,
                                  Var ? Var->Type.has_value() : false,
                                  Var ? Var->Loc.has_value() : false,
                                  Var ? Var->Scope != nullptr : false),
@@ -241,7 +241,7 @@ AllocStackInst::AllocStackInst(
       Var, getTrailingObjects<char>(), getTrailingObjects<SILType>(),
       getTrailingObjects<SILLocation>(),
       getTrailingObjects<const SILDebugScope *>(),
-      getTrailingObjects<SILDIExprElement>());
+      nullptr);
 
   assert(sharedUInt32().AllocStackInst.numOperands ==
              TypeDependentOperands.size() &&
@@ -265,6 +265,13 @@ AllocStackInst *AllocStackInst::create(SILDebugLocation Loc,
       Var->Scope = nullptr;
     if (Var->Type == elementType)
       Var->Type = {};
+    if (Var->DIExpr) {
+      // alloc_stack cannot carry a DIExpression.
+      // Strip a single implied op_deref. Anything else is an error.
+      assert(Var->DIExpr.getNumElements() == 1 && Var->DIExpr.startsWithDeref()
+             && "alloc_stack cannot have a DIExpr; use debug_value instead");
+      Var->DIExpr = {};
+    }
   }
   SmallVector<SILValue, 8> TypeDependentOperands;
   collectTypeDependentOperands(TypeDependentOperands, F,

--- a/test/DebugInfo/debug_info_expression.sil
+++ b/test/DebugInfo/debug_info_expression.sil
@@ -42,26 +42,6 @@ bb0:
   return %r : $()
 }
 
-sil_scope 2 { loc "file.swift":14:6 parent @test_alloc_stack : $@convention(thin) () -> () }
-
-// Testing di-expression w/ alloc_stack
-sil hidden @test_alloc_stack : $@convention(thin) () -> () {
-bb0:
-  %my_struct = alloc_stack $MyStruct, var, name "my_struct", loc "file.swift":15:9, scope 2
-  // CHECK: %[[MY_STRUCT:.+]] = alloca %{{.*}}MyStruct
-  // CHECK: #dbg_declare(ptr %[[MY_STRUCT]], ![[VAR_DECL_MD:[0-9]+]]
-  // CHECK-SIL: alloc_stack $Int, var
-  // CHECK-SIL-SAME:        (name "my_struct", loc "file.swift":15:9)
-  // CHECK-SIL-SAME:        type $MyStruct, expr op_fragment:#MyStruct.x
-  %field_x = alloc_stack $Int, var, (name "my_struct", loc "file.swift":15:9, scope 2), type $MyStruct, expr op_fragment:#MyStruct.x, loc "file.swift":16:17, scope 2
-  // CHECK: %[[FIELD_X:.+]] = alloca %TSi
-  // CHECK: #dbg_declare(ptr %[[FIELD_X]], ![[VAR_DECL_MD]]
-  // CHECK-SAME:             !DIExpression(DW_OP_LLVM_fragment, 0, 64)
-  dealloc_stack %field_x : $*Int
-  dealloc_stack %my_struct: $*MyStruct
-  %r = tuple()
-  return %r : $()
-}
 
 sil_scope 3 { loc "file.swift":16:7 parent @test_op_const : $@convention(thin) (Int64, Int64) -> () }
 

--- a/test/DebugInfo/sil_combine.sil
+++ b/test/DebugInfo/sil_combine.sil
@@ -49,8 +49,9 @@ enum MP {
 // CHECK: } // end sil function 'expand_alloc_stack_of_enum_without_take'
 sil @expand_alloc_stack_of_enum_without_take : $@convention(method) (S) -> () {
 bb0(%0 : $S):
-  %1 = alloc_stack $MP, let, name "a", expr op_fragment:#C.x
-  debug_value %1 : $*MP, let, name "b", expr op_deref
+  %1 = alloc_stack $MP
+  debug_value %1 : $*MP, let, name "a", expr op_fragment:#C.x
+  debug_value %1 : $*MP, let, name "b"
   cond_br undef, bb1, bb2
 bb1:
   %2 = init_enum_data_addr %1 : $*MP, #MP.A!enumelt


### PR DESCRIPTION
A VarInfo within an AllocStackInst should only be used when the variable is fully in the stack slot. Otherwise, a debug_value should be used.

This PR removes all support for DIExpr from AllocStackInst. AllocBoxInst already doesn't support DIExpr.