### PR TITLE
[test] Set default per-test timeout

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -149,6 +149,22 @@ def escape_for_substitute_captures(s):
 
 ###
 
+# Set a default per-test timeout. Tests that exceed this time limit will fail,
+# preventing a parent script from timing out without revealing the problematic
+# test.
+def configure_individual_test_timeout():
+  supported, errormsg = lit_config.maxIndividualTestTimeIsSupported
+
+  # Lit will error if the value is set but not supported.
+  if supported:
+      lit_config.maxIndividualTestTime = 60 * 40 # seconds
+      lit_config.note(
+          "default per-test timeout: {}s".format(lit_config.maxIndividualTestTime))
+  else:
+      lit_config.warning("could not set a default per-test timeout. " + errormsg)
+
+configure_individual_test_timeout()
+
 # Check that the object root is known.
 if config.test_exec_root is None:
     # Otherwise, we haven't loaded the site specific configuration (the user is


### PR DESCRIPTION
Tests that exceed this time limit will fail, preventing a parent script from timing out with no indication of the problematic test(s).