### PR TITLE
[NFC] Replace interleave(..., ", ") with interleaveComma in Partition…

### DIFF
--- a/lib/SILOptimizer/Utils/PartitionUtils.cpp
+++ b/lib/SILOptimizer/Utils/PartitionUtils.cpp
@@ -708,7 +708,7 @@ void Partition::printHistory(llvm::raw_ostream &os) const {
       auto extraArgs = head->getAdditionalElementArgs();
       if (extraArgs.empty())
         break;
-      llvm::interleave(extraArgs, os, ", ");
+      llvm::interleaveComma(extraArgs, os);
       break;
     }
     case IsolationHistory::Node::MergeElementRegions: {
@@ -717,7 +717,7 @@ void Partition::printHistory(llvm::raw_ostream &os) const {
       if (extraArgs.empty())
         break;
       os << ", ";
-      llvm::interleave(extraArgs, os, ", ");
+      llvm::interleaveComma(extraArgs, os);
       break;
     }
     case IsolationHistory::Node::CFGHistoryJoin:


### PR DESCRIPTION
`interleaveComma` is a convenience wrapper that hardcodes `\", \"` as the separator. It is used in the 2 call sites in `lib/SILOptimizer/Utils/PartitionUtils.cpp` where the separator was being passed explicitly.

No functional change.