### PR TITLE
NFC] Replace interleave(..., ", ") with interleaveComma

### DIFF
--- a/lib/SILOptimizer/Utils/PartitionUtils.cpp
+++ b/lib/SILOptimizer/Utils/PartitionUtils.cpp
@@ -708,7 +708,7 @@ void Partition::printHistory(llvm::raw_ostream &os) const {
       auto extraArgs = head->getAdditionalElementArgs();
       if (extraArgs.empty())
         break;
-      llvm::interleave(extraArgs, os, ", ");
+      llvm::interleaveComma(extraArgs, os);
       break;
     }
     case IsolationHistory::Node::MergeElementRegions: {
@@ -717,7 +717,7 @@ void Partition::printHistory(llvm::raw_ostream &os) const {
       if (extraArgs.empty())
         break;
       os << ", ";
-      llvm::interleave(extraArgs, os, ", ");
+      llvm::interleaveComma(extraArgs, os);
       break;
     }
     case IsolationHistory::Node::CFGHistoryJoin:

--- a/lib/SILOptimizer/Utils/SILIsolationInfo.cpp
+++ b/lib/SILOptimizer/Utils/SILIsolationInfo.cpp
@@ -1284,7 +1284,7 @@ void SILIsolationInfo::printOptions(llvm::raw_ostream &os) const {
          "Please update MaxNumBits so that we can avoid heap allocations in "
          "this SmallVector");
 
-  llvm::interleave(data, os, ", ");
+  llvm::interleaveComma(data, os);
 }
 
 StringRef SILIsolationInfo::printActorIsolationForDiagnostics(


### PR DESCRIPTION
`interleaveComma` is a convenience wrapper that hardcodes `", "` as the separator. It is used in 1 call site in
`lib/SILOptimizer/Utils/SILIsolationInfo.cpp` where the separator was
being passed explicitly.

No functional change.
