### PR TITLE
ClangImporter: don't assert when synthesizing a constant whose literal type lacks an integer/float literal initializer  

### DIFF
--- a/lib/ClangImporter/ImportMacro.cpp
+++ b/lib/ClangImporter/ImportMacro.cpp
@@ -120,7 +120,6 @@ static ValueDecl *importNumericLiteral(ClangImporter::Implementation &Impl,
         return nullptr;
     }
 
-    auto &ctx = DC->getASTContext();
     auto *constantTyNominal = constantType->getAnyNominal();
     if (!constantTyNominal)
       return nullptr;
@@ -140,17 +139,6 @@ static ValueDecl *importNumericLiteral(ClangImporter::Implementation &Impl,
         }
       }
 
-      // Make sure the destination type actually conforms to the builtin literal
-      // protocol or is Bool before attempting to import, otherwise we'll crash
-      // since `createConstant` expects it to.
-      // FIXME: We ought to be careful checking conformance here since it can
-      // result in cycles. Additionally we ought to consider checking for the
-      // non-builtin literal protocol to allow any ExpressibleByIntegerLiteral
-      // type to be supported.
-      if (!isBoolOrBoolEnumType(constantType) &&
-          !ctx.getIntBuiltinInitDecl(constantTyNominal)) {
-        return nullptr;
-      }
       return createMacroConstant(Impl, MI, name, DC, constantType,
                                  clang::APValue(value),
                                  ConstantConvertKind::None,
@@ -168,16 +156,6 @@ static ValueDecl *importNumericLiteral(ClangImporter::Implementation &Impl,
       if (signTok && signTok->is(clang::tok::minus)) {
         value.changeSign();
       }
-
-      // Make sure the destination type actually conforms to the builtin literal
-      // protocol before attempting to import, otherwise we'll crash since
-      // `createConstant` expects it to.
-      // FIXME: We ought to be careful checking conformance here since it can
-      // result in cycles. Additionally we ought to consider checking for the
-      // non-builtin literal protocol to allow any ExpressibleByFloatLiteral
-      // type to be supported.
-      if (!ctx.getFloatBuiltinInitDecl(constantTyNominal))
-        return nullptr;
 
       return createMacroConstant(Impl, MI, name, DC, constantType,
                                  clang::APValue(value),

--- a/lib/ClangImporter/SwiftDeclSynthesizer.cpp
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.cpp
@@ -340,12 +340,7 @@ ValueDecl *SwiftDeclSynthesizer::createConstant(Identifier name,
 
         expr = boolExpr;
       } else {
-        auto *intExpr =
-            new (context) IntegerLiteralExpr(printedValueCopy, SourceLoc(),
-                                             /*Implicit=*/true);
-
         auto *intDecl = literalType->getAnyNominal();
-        auto initRef = context.getIntBuiltinInitDecl(intDecl);
         // The resolved literal type may not be a primitive integer — for
         // example, when a `swift_wrapper(struct)` is layered on a typedef
         // whose underlying type is itself imported as a wrapper struct
@@ -353,14 +348,27 @@ ValueDecl *SwiftDeclSynthesizer::createConstant(Identifier name,
         // `ExpressibleByBuiltinIntegerLiteral` conformance to look up.
         // Bail out and let the caller import the constant as an external
         // declaration instead of asserting.
+        auto initRef = context.getIntBuiltinInitDecl(intDecl);
         if (!initRef)
           return nullptr;
+
+        auto *intExpr =
+            new (context) IntegerLiteralExpr(printedValueCopy, SourceLoc(),
+                                             /*Implicit=*/true);
+
         intExpr->setBuiltinInitializer(initRef);
         intExpr->setType(literalType);
 
         expr = intExpr;
       }
     } else {
+      auto *floatDecl = literalType->getAnyNominal();
+      // See the integer case above: the resolved literal type may not have
+      // an `ExpressibleByBuiltinFloatLiteral` conformance.
+      auto initRef = context.getFloatBuiltinInitDecl(floatDecl);
+      if (!initRef)
+        return nullptr;
+
       auto *floatExpr =
           new (context) FloatLiteralExpr(printedValueCopy, SourceLoc(),
                                          /*Implicit=*/true);
@@ -368,12 +376,6 @@ ValueDecl *SwiftDeclSynthesizer::createConstant(Identifier name,
       auto maxFloatTypeDecl = context.get_MaxBuiltinFloatTypeDecl();
       floatExpr->setBuiltinType(maxFloatTypeDecl->getUnderlyingType());
 
-      auto *floatDecl = literalType->getAnyNominal();
-      auto initRef = context.getFloatBuiltinInitDecl(floatDecl);
-      // See the integer case above: the resolved literal type may not have
-      // an `ExpressibleByBuiltinFloatLiteral` conformance.
-      if (!initRef)
-        return nullptr;
       floatExpr->setBuiltinInitializer(initRef);
       floatExpr->setType(literalType);
 

--- a/lib/ClangImporter/SwiftDeclSynthesizer.cpp
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.cpp
@@ -330,7 +330,6 @@ ValueDecl *SwiftDeclSynthesizer::createConstant(Identifier name,
     StringRef printedValueCopy(context.AllocateCopy(printedValue));
     if (value.getKind() == clang::APValue::Int) {
       // Check if "type" is Bool or a C++ enum with an underlying type of Bool.
-      // NOTE: This must match the condition in `importNumericLiteral`.
       if (isBoolOrBoolEnumType(type)) {
         auto *boolExpr = new (context)
             BooleanLiteralExpr(value.getInt().getBoolValue(), SourceLoc(),
@@ -346,7 +345,17 @@ ValueDecl *SwiftDeclSynthesizer::createConstant(Identifier name,
                                              /*Implicit=*/true);
 
         auto *intDecl = literalType->getAnyNominal();
-        intExpr->setBuiltinInitializer(context.getIntBuiltinInitDecl(intDecl));
+        auto initRef = context.getIntBuiltinInitDecl(intDecl);
+        // The resolved literal type may not be a primitive integer — for
+        // example, when a `swift_wrapper(struct)` is layered on a typedef
+        // whose underlying type is itself imported as a wrapper struct
+        // (rather than a primitive integer). In that case there is no
+        // `ExpressibleByBuiltinIntegerLiteral` conformance to look up.
+        // Bail out and let the caller import the constant as an external
+        // declaration instead of asserting.
+        if (!initRef)
+          return nullptr;
+        intExpr->setBuiltinInitializer(initRef);
         intExpr->setType(literalType);
 
         expr = intExpr;
@@ -360,8 +369,12 @@ ValueDecl *SwiftDeclSynthesizer::createConstant(Identifier name,
       floatExpr->setBuiltinType(maxFloatTypeDecl->getUnderlyingType());
 
       auto *floatDecl = literalType->getAnyNominal();
-      floatExpr->setBuiltinInitializer(
-          context.getFloatBuiltinInitDecl(floatDecl));
+      auto initRef = context.getFloatBuiltinInitDecl(floatDecl);
+      // See the integer case above: the resolved literal type may not have
+      // an `ExpressibleByBuiltinFloatLiteral` conformance.
+      if (!initRef)
+        return nullptr;
+      floatExpr->setBuiltinInitializer(initRef);
       floatExpr->setType(literalType);
 
       expr = floatExpr;

--- a/test/ClangImporter/const_values_wrapper_of_wrapper.swift
+++ b/test/ClangImporter/const_values_wrapper_of_wrapper.swift
@@ -1,0 +1,36 @@
+// RUN: %empty-directory(%t/src)
+// RUN: split-file %s %t/src
+
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) %t/src/main.swift \
+// RUN:   -import-bridging-header %t/src/test.h \
+// RUN:   -module-name main -emit-sil | %FileCheck %s
+
+// Regression: previously, importing a `static const` whose declared C type
+// is a `swift_wrapper(struct)` typedef'd over an enum that itself imports
+// as a wrapper struct (rather than a primitive integer) tripped an
+// assertion in `BuiltinLiteralExpr::setBuiltinInitializer`. The literal
+// synthesizer in `SwiftDeclSynthesizer::createConstant` looked up
+// `ExpressibleByBuiltinIntegerLiteral` on the resolved literal type
+// (the inner wrapper struct), which has no such conformance. The witness
+// was empty and the assertion fired.
+//
+// Fix: bail out of the inlined-literal synthesis path when the witness
+// is empty; the variable is then imported as an external declaration that
+// resolves to the C global at link time.
+
+//--- test.h
+typedef enum { _MyKind_Z = 0 } _MyKind;
+typedef _MyKind MyKind __attribute__((swift_wrapper(struct)));
+static const MyKind MyKind_None __attribute__((swift_name("none"))) = _MyKind_Z;
+
+//--- main.swift
+public func access() -> MyKind {
+    return MyKind.none
+}
+
+// The constant must be imported as an external sil_global rather than
+// synthesized as an inlined literal getter.
+// CHECK: sil_global public_external [let] @MyKind_None : $MyKind
+
+// CHECK-LABEL: sil {{.*}}@$s4main6access{{.*}}() -> MyKind
+// CHECK: global_addr @MyKind_None : $*MyKind


### PR DESCRIPTION
An imported `static const` whose declared type is a `swift_wrapper(struct)` over a typedef that itself imports as a wrapper struct (e.g. `CF_TYPED_EXTENSIBLE_ENUM` over an enum, two layers of `RawValue`) crashed at `setBuiltinInitializer` in `Expr.cpp`. `SwiftDeclSynthesizer::createConstant` resolved the literal type via `RawTypes[wrapper]` to the inner wrapper struct, then unconditionally called `setBuiltinInitializer(getIntBuiltinInitDecl(intDecl))` — the witness lookup returns empty for the inner wrapper because it has no `ExpressibleByBuiltinIntegerLiteral` conformance, and the setter asserts on null.

Three-line repro:                                                                                                                                                                                  

  ```c                                                                                                                                                                                               
  typedef enum { _MyKind_Z = 0 } _MyKind;                   
  typedef _MyKind MyKind __attribute__((swift_wrapper(struct)));                                                                                                                                     
  static const MyKind MyKind_None __attribute__((swift_name("none"))) = _MyKind_Z;                                                                                                                   
  ```                                                                                                                                                                                                
                                                                                                                                                                                                     
  ```swift                                                                                                                                                                                           
  let a = MyKind.none  // crashes pre-fix                                                                                                                                                            
  ```                                                                                                                                                                                                

Fix: when the witness lookup returns empty, return `nullptr` from `createConstant` for both the integer and float paths. `VisitVarDecl` already handles `nullptr` by falling through to "import as external declaration," so the constant is still accessible from Swift — it just resolves to the C global at link time instead of being inlined.

Also drops the matching pre-checks at `ImportMacro.cpp:150-153` and `:179-180`, whose explicit "since `createConstant` expects it to" comments documented exactly the precondition we no longer require. One subtle behavior improvement falls out: the `ImportedMacroConstants` map is now populated for macros whose Swift binding fails to synthesize, which lets chained macro definitions like `#define BAR (INNER_CONST + 1)` resolve `INNER_CONST` even when `INNER_CONST` isn't itself representable as a Swift constant. The inner macro still doesn't get a Swift binding; only its compile-time value contributes to the outer.              

Adds `test/ClangImporter/const_values_wrapper_of_wrapper.swift` covering the reduced reproducer.

fixes rdar://164599503