### PR TITLE
[cxx-interop] Add cycle warning test (NFC)

### DIFF
--- a/test/Interop/Cxx/stdlib/Inputs/iterator-cycle-unrelated-operator.h
+++ b/test/Interop/Cxx/stdlib/Inputs/iterator-cycle-unrelated-operator.h
@@ -1,0 +1,37 @@
+// Reproducer for a cycle warning during iterator conformance derivation.
+// The cycle requires three structural properties:
+// 1. A class-template iterator with a free-function operator==
+// 2. An unrelated nested class with a member operator==
+// 3. The nested class's parent has a field of a different specialization
+//    of the same iterator template
+//
+// When all three are present, a module-wide operator== scan during
+// conformance derivation for one specialization can re-enter a mid-import
+// context for the other, triggering a cycle warning.
+
+namespace std {
+struct input_iterator_tag {};
+} // namespace std
+
+namespace llvm {
+
+template <class T>
+struct Iter {
+  using iterator_category = std::input_iterator_tag;
+  T operator*() const;
+  Iter &operator++();
+};
+template <class T>
+bool operator==(Iter<T>, Iter<T>);
+
+struct R {
+  Iter<char> Name;
+};
+struct MC {
+  Iter<int> Cache;
+  struct It {
+    bool operator==(It) const;
+  };
+};
+
+} // namespace llvm

--- a/test/Interop/Cxx/stdlib/Inputs/module.modulemap
+++ b/test/Interop/Cxx/stdlib/Inputs/module.modulemap
@@ -134,3 +134,9 @@ module StdSingleFieldAggregate {
   requires cplusplus
   export *
 }
+
+module IteratorCycleUnrelatedOperator {
+  header "iterator-cycle-unrelated-operator.h"
+  requires cplusplus
+  export *
+}

--- a/test/Interop/Cxx/stdlib/iterator-cycle-unrelated-operator.swift
+++ b/test/Interop/Cxx/stdlib/iterator-cycle-unrelated-operator.swift
@@ -1,0 +1,10 @@
+// Verify that importing a module where an unrelated nested class has its own
+// operator== does not produce a cycle warning during iterator conformance
+// derivation.
+
+// RUN: %target-typecheck-verify-swift -I %S/Inputs -cxx-interoperability-mode=default -Xcc -std=c++17
+// expected-no-diagnostics
+
+import IteratorCycleUnrelatedOperator
+
+typealias X = llvm.R


### PR DESCRIPTION
Reproducer for a cycle warning during iterator conformance derivation. The cycle requires three structural properties:
1. A class-template iterator with a free-function operator==
2. An unrelated nested class with a member operator==
3. The nested class's parent has a field of a different specialization of the same iterator template

When all three are present, a module-wide operator== scan during conformance derivation for one specialization can re-enter a mid-import context for the other, triggering a cycle warning.