### PR TITLE
[6.4] Add support for dispatch thunk emission for borrow/mutate accessor requirements under library evolution

### DIFF
--- a/lib/IRGen/GenThunk.cpp
+++ b/lib/IRGen/GenThunk.cpp
@@ -192,10 +192,12 @@ void IRGenThunk::prepareArguments() {
 
   // Prepare indirect results, if any.
   SILType directResultType = conv.getSILResultType(expansionContext);
-  auto &directResultTL = IGF.IGM.getTypeInfo(directResultType);
-  auto &schema = directResultTL.nativeReturnValueSchema(IGF.IGM);
-  if (schema.requiresIndirect()) {
-    indirectReturnSlot = original.claimNext();
+  if (!conv.hasAddressResult()) {
+    auto &directResultTL = IGF.IGM.getTypeInfo(directResultType);
+    auto &schema = directResultTL.nativeReturnValueSchema(IGF.IGM);
+    if (schema.requiresIndirect()) {
+      indirectReturnSlot = original.claimNext();
+    }
   }
 
   original.transferInto(params, conv.getNumIndirectSILResults());
@@ -344,7 +346,7 @@ void IRGenThunk::emit() {
   SILType directResultType = conv.getSILResultType(expansionContext);
   auto &directResultTL = IGF.IGM.getTypeInfo(directResultType);
   auto &schema = directResultTL.nativeReturnValueSchema(IGF.IGM);
-  if (schema.requiresIndirect()) {
+  if (!conv.hasAddressResult() && schema.requiresIndirect()) {
     Address indirectReturnAddr(indirectReturnSlot,
                                IGF.IGM.getStorageType(directResultType),
                                directResultTL.getBestKnownAlignment());
@@ -553,6 +555,13 @@ void IRGenThunk::emit() {
   }
 
   // Return the result.
+  if (conv.hasAddressResult()) {
+    // Address results return a pointer directly.
+    assert(!result.empty() && "address result should produce a value");
+    IGF.Builder.CreateRet(result.claimNext());
+    return;
+  }
+
   if (result.empty()) {
     if (emission->getTypedErrorExplosion() &&
         !IGF.CurFn->getReturnType()->isVoidTy()) {

--- a/test/IRGen/borrow_accessor_protocol.swift
+++ b/test/IRGen/borrow_accessor_protocol.swift
@@ -1,0 +1,52 @@
+// RUN: %target-swift-frontend -emit-irgen -enable-library-evolution %s | %FileCheck %s --check-prefixes=CHECK-EVO
+// REQUIRES: PTRSIZE=64
+
+public protocol Proto {
+    associatedtype Body
+    var body: Body { borrow mutate }
+}
+
+// CHECK-EVO-LABEL: define{{.*}} swiftcc ptr @"$s24borrow_accessor_protocol5ProtoP4body4BodyQzvbTj"
+// CHECK-EVO:         [[WITNESS_ADDR:%.*]] = getelementptr inbounds ptr, ptr %2,
+// CHECK-EVO:         [[WITNESS:%.*]] = load ptr, ptr [[WITNESS_ADDR]]
+// CHECK-EVO:         [[RESULT:%.*]] = call swiftcc ptr [[WITNESS]](ptr noalias swiftself %0, ptr %1, ptr %2)
+// CHECK-EVO:         ret ptr [[RESULT]]
+
+// CHECK-EVO-LABEL: define{{.*}} swiftcc ptr @"$s24borrow_accessor_protocol5ProtoP4body4BodyQzvzTj"
+// CHECK-EVO:         [[WITNESS_ADDR:%.*]] = getelementptr inbounds ptr, ptr %2,
+// CHECK-EVO:         [[WITNESS:%.*]] = load ptr, ptr [[WITNESS_ADDR]]
+// CHECK-EVO:         [[RESULT:%.*]] = call swiftcc ptr [[WITNESS]](ptr swiftself %0, ptr %1, ptr %2)
+// CHECK-EVO:         ret ptr [[RESULT]]
+
+public protocol ConcreteProto {
+    var value: Int { borrow mutate }
+}
+
+// CHECK-EVO-LABEL: define{{.*}} swiftcc i64 @"$s24borrow_accessor_protocol13ConcreteProtoP5valueSivbTj"
+// CHECK-EVO:         [[WITNESS_ADDR:%.*]] = getelementptr inbounds ptr, ptr %2,
+// CHECK-EVO:         [[WITNESS:%.*]] = load ptr, ptr [[WITNESS_ADDR]]
+// CHECK-EVO:         [[RESULT:%.*]] = call swiftcc i64 [[WITNESS]](ptr noalias swiftself %0, ptr %1, ptr %2)
+// CHECK-EVO:         ret i64 [[RESULT]]
+
+// CHECK-EVO-LABEL: define{{.*}} swiftcc ptr @"$s24borrow_accessor_protocol13ConcreteProtoP5valueSivzTj"
+// CHECK-EVO:         [[WITNESS_ADDR:%.*]] = getelementptr inbounds ptr, ptr %2,
+// CHECK-EVO:         [[WITNESS:%.*]] = load ptr, ptr [[WITNESS_ADDR]]
+// CHECK-EVO:         [[RESULT:%.*]] = call swiftcc ptr [[WITNESS]](ptr swiftself %0, ptr %1, ptr %2)
+// CHECK-EVO:         ret ptr [[RESULT]]
+
+public protocol SubscriptProto {
+    associatedtype Element
+    subscript(index: Int) -> Element { borrow mutate }
+}
+
+// CHECK-EVO-LABEL: define{{.*}} swiftcc ptr @"$s24borrow_accessor_protocol14SubscriptProtoP{{[^"]*}}icibTj"
+// CHECK-EVO:         [[WITNESS_ADDR:%.*]] = getelementptr inbounds ptr, ptr %3,
+// CHECK-EVO:         [[WITNESS:%.*]] = load ptr, ptr [[WITNESS_ADDR]]
+// CHECK-EVO:         [[RESULT:%.*]] = call swiftcc ptr [[WITNESS]](i64 %0, ptr noalias swiftself %1, ptr %2, ptr %3)
+// CHECK-EVO:         ret ptr [[RESULT]]
+
+// CHECK-EVO-LABEL: define{{.*}} swiftcc ptr @"$s24borrow_accessor_protocol14SubscriptProtoP{{[^"]*}}icizTj"
+// CHECK-EVO:         [[WITNESS_ADDR:%.*]] = getelementptr inbounds ptr, ptr %3,
+// CHECK-EVO:         [[WITNESS:%.*]] = load ptr, ptr [[WITNESS_ADDR]]
+// CHECK-EVO:         [[RESULT:%.*]] = call swiftcc ptr [[WITNESS]](i64 %0, ptr swiftself %1, ptr %2, ptr %3)
+// CHECK-EVO:         ret ptr [[RESULT]]


### PR DESCRIPTION
Explanation: Dispatch thunks for protocol borrow/mutate accessor requirements with address results crashed under -enable-library-evolution. Address result functions return a pointer directly with no indirect return slot, but the thunk incorrectly tried to claim one from the IR parameters.

Scope: Affects borrow and mutate protocol requirements under library evolution

Issues: rdar://176144620

Risk: Low

Testing: Unit test, CI testing

Reviewers: @drexin 

Main PR: https://github.com/swiftlang/swift/pull/88812