### PR TITLE
Sema: pre-reserve DenseMap capacity in ConstraintSystem::finalize

### DIFF
--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -97,6 +97,7 @@ Solution ConstraintSystem::finalize() {
   }
 
   // Copy over the resolved overloads.
+  solution.overloadChoices.reserve(ResolvedOverloads.size());
   solution.overloadChoices.insert(ResolvedOverloads.begin(),
                                   ResolvedOverloads.end());
 
@@ -145,6 +146,7 @@ Solution ConstraintSystem::finalize() {
   }
 
   // Remember all of the argument/parameter matching choices we made.
+  solution.argumentMatchingChoices.reserve(argumentMatchingChoices.size());
   for (auto &argumentMatch : argumentMatchingChoices) {
     auto inserted = solution.argumentMatchingChoices.insert(argumentMatch);
     assert(inserted.second || inserted.first->second == argumentMatch.second);
@@ -194,9 +196,11 @@ Solution ConstraintSystem::finalize() {
   solution.DefaultedConstraints.insert(DefaultedConstraints.begin(),
                                        DefaultedConstraints.end());
 
+  solution.nodeTypes.reserve(NodeTypes.size());
   for (auto &nodeType : NodeTypes) {
     solution.nodeTypes.insert(nodeType);
   }
+  solution.keyPathComponentTypes.reserve(KeyPathComponentTypes.size());
   for (auto &keyPathComponentType : KeyPathComponentTypes) {
     solution.keyPathComponentTypes.insert(keyPathComponentType);
   }


### PR DESCRIPTION
`ConstraintSystem::finalize` copies several maps from the constraint system into the fresh `Solution`: `overloadChoices`, `argumentMatchingChoices`, `nodeTypes`, `keyPathComponentTypes`, etc. All are populated by single-element inserts that grow the destination DenseMap incrementally, producing a cascade of rehashes. Pre-size the destination maps to their source's size before inserting. The loops are otherwise unchanged.                                                              

Measured on a synthetic stress test (N-element `[UV(u: Float(bitPattern: 0xX), v: Float(bitPattern: 0xY)), ...]`, 2-run averages, baseline vs patched):                
                                                            
  | N    | baseline | patched | speedup |                                                                                                                                
  |-----:|---------:|--------:|--------:|                   
  | 1000 |   1.06s  |  0.72s  |  1.47×  |                                                                                                                                
  | 2000 |   5.82s  |  3.06s  |  1.90×  |                                                                                                                                
  | 4000 |  22.89s  | 15.41s  |  1.49×  |                                                                                                                                
                                                                                                                                                                         
Memory impact is negligible (same final map sizes; we just avoid intermediate doublings). This is a pure CPU win from a behavior-preserving change. This doesn't solve the O(N²) memory problem, just makes smaller cases faster.