### PR TITLE
[6.4] Fix DestroyAddrHoisting miscompilation with @guaranteed results 

### DIFF
--- a/include/swift/SIL/MemAccessUtils.h
+++ b/include/swift/SIL/MemAccessUtils.h
@@ -164,7 +164,7 @@ inline SILValue stripAccessMarkers(SILValue v) {
   return v;
 }
 
-inline bool isGuaranteedAddressReturn(SILValue value) {
+inline bool isAddressReturn(SILValue value) {
   auto *defInst = dyn_cast_or_null<ApplyInst>(value->getDefiningInstruction());
   if (!defInst) {
     return false;
@@ -1803,7 +1803,7 @@ Result AccessUseDefChainVisitor<Impl, Result>::visit(SILValue sourceAddr) {
     if (isExternalGlobalAddressor(cast<ApplyInst>(sourceAddr)))
       return asImpl().visitUnidentified(sourceAddr);
 
-    if (isGuaranteedAddressReturn(sourceAddr)) {
+    if (isAddressReturn(sourceAddr)) {
       auto *selfOp = &cast<ApplyInst>(sourceAddr)->getSelfArgumentOperand();
       if (selfOp->get()->getType().isObject()) {
         return asImpl().visitUnidentified(sourceAddr);

--- a/lib/SIL/Utils/MemAccessUtils.cpp
+++ b/lib/SIL/Utils/MemAccessUtils.cpp
@@ -2189,7 +2189,19 @@ visitApplyOperand(Operand *use, UniqueStorageUseVisitor &visitor,
     }
     return true;
   }
-  return (visitor.*visit)(use);
+  if (!(visitor.*visit)(use))
+    return false;
+
+  if (auto *applyInst = dyn_cast<ApplyInst>(user)) {
+    if (applyInst->hasGuaranteedResult()) {
+      for (auto *resultUse : applyInst->getUses()) {
+        if (!(visitor.*visit)(resultUse)) {
+          return false;
+        }
+      }
+    }
+  }
+  return true;
 }
 
 bool GatherUniqueStorageUses::visitUse(Operand *use, AccessUseType useTy) {

--- a/lib/SIL/Utils/MemAccessUtils.cpp
+++ b/lib/SIL/Utils/MemAccessUtils.cpp
@@ -1417,7 +1417,7 @@ public:
              // we see it
              || isa<MoveOnlyWrapperToCopyableAddrInst>(projectedAddr) ||
              isa<CopyableToMoveOnlyWrapperAddrInst>(projectedAddr) ||
-             isGuaranteedAddressReturn(projectedAddr));
+             isAddressReturn(projectedAddr));
     }
     return sourceAddr->get();
   }
@@ -2032,7 +2032,7 @@ bool AccessPathDefUseTraversal::visitUser(DFSEntry dfs) {
         && visitSingleValueUser(svi, dfs) == IgnoredUse) {
       return true;
     }
-    if (isGuaranteedAddressReturn(svi)) {
+    if (isAddressReturn(svi)) {
       pushUsers(svi, dfs);
     }
   }

--- a/test/SILOptimizer/hoist_destroy_addr.sil
+++ b/test/SILOptimizer/hoist_destroy_addr.sil
@@ -1394,7 +1394,7 @@ bb0(%0 : $*Vector, %1 : @owned $AnyObject):
   return %4
 }
 
-sil [ossa] @borrow_data : $@convention(method) (@in_guaranteed S) -> @guaranteed X {
+sil [ossa] @borrow_data1 : $@convention(method) (@in_guaranteed S) -> @guaranteed X {
 bb0(%0 : $*S):
   %2 = struct_element_addr %0 : $*S, #S.x
   %3 = load_borrow %2 : $*X
@@ -1411,7 +1411,7 @@ bb0(%0 : $*S):
 sil shared [noinline] [ossa] @test_borrow1 : $@convention(thin) (@inout S, Int) -> () {
 bb0(%0 : $*S, %1 : $Int):
   %2 = alloc_stack $X
-  %3 = function_ref @borrow_data : $@convention(method) (@in_guaranteed S) -> @guaranteed X
+  %3 = function_ref @borrow_data1 : $@convention(method) (@in_guaranteed S) -> @guaranteed X
   %4 = apply %3(%0) : $@convention(method) (@in_guaranteed S) -> @guaranteed X
   %5 = copy_value %4
   store %5 to [init] %2
@@ -1421,5 +1421,31 @@ bb0(%0 : $*S, %1 : $Int):
   dealloc_stack %2
   %11 = tuple ()
   return %11
+}
+
+sil [ossa] @borrow_data2 : $@convention(method) (@in_guaranteed S) -> @guaranteed_address X {
+bb0(%0 : $*S):
+  %1 = struct_element_addr %0 : $*S, #S.x
+  return %1
+}
+
+// CHECK-LABEL: sil [ossa] @test_borrow2 :
+// CHECK:         [[RESULT:%[0-9]+]] = apply {{%[0-9]+}}(%0)
+// CHECK-NEXT:    [[COPY:%[0-9]+]] = load [copy] [[RESULT]]
+// CHECK:         destroy_addr %0
+// CHECK-LABEL: } // end sil function 'test_borrow2'
+sil [ossa] @test_borrow2 : $@convention(thin) (@inout S) -> () {
+bb0(%0 : $*S):
+  %1 = alloc_stack $X
+  %2 = function_ref @borrow_data2 : $@convention(method) (@in_guaranteed S) -> @guaranteed_address X
+  %3 = apply %2(%0) : $@convention(method) (@in_guaranteed S) -> @guaranteed_address X
+  %4 = load [copy] %3 : $*X
+  store %4 to [init] %1 : $*X
+  %6 = load [take] %1 : $*X
+  %7 = struct $S (%6 : $X)
+  store %7 to [assign] %0 : $*S
+  dealloc_stack %1 : $*X
+  %10 = tuple ()
+  return %10 : $()
 }
 

--- a/test/SILOptimizer/hoist_destroy_addr.sil
+++ b/test/SILOptimizer/hoist_destroy_addr.sil
@@ -1394,3 +1394,32 @@ bb0(%0 : $*Vector, %1 : @owned $AnyObject):
   return %4
 }
 
+sil [ossa] @borrow_data : $@convention(method) (@in_guaranteed S) -> @guaranteed X {
+bb0(%0 : $*S):
+  %2 = struct_element_addr %0 : $*S, #S.x
+  %3 = load_borrow %2 : $*X
+  return_borrow %3 from_scopes (%3)
+}
+
+// CHECK-LABEL: sil shared [noinline] [ossa] @test_borrow1 :
+// CHECK:         [[BORROW:%[0-9]+]] = apply {{%[0-9]+}}(%0)
+// CHECK-NEXT:    [[COPY:%[0-9]+]] = copy_value [[BORROW]]
+// CHECK-NEXT:    destroy_addr %0
+// CHECK-NEXT:    store [[COPY]] to [init] [[TMP:%[0-9]+]]
+// CHECK:         store {{%[0-9]+}} to [init] %0
+// CHECK-LABEL: } // end sil function 'test_borrow1'
+sil shared [noinline] [ossa] @test_borrow1 : $@convention(thin) (@inout S, Int) -> () {
+bb0(%0 : $*S, %1 : $Int):
+  %2 = alloc_stack $X
+  %3 = function_ref @borrow_data : $@convention(method) (@in_guaranteed S) -> @guaranteed X
+  %4 = apply %3(%0) : $@convention(method) (@in_guaranteed S) -> @guaranteed X
+  %5 = copy_value %4
+  store %5 to [init] %2
+  %7 = load [take] %2
+  %8 = struct $S (%7)
+  store %8 to [assign] %0
+  dealloc_stack %2
+  %11 = tuple ()
+  return %11
+}
+


### PR DESCRIPTION
- **Explanation**: When an ApplyInst produces a @guaranteed result, the result's lifetime
depends on the self parameter. DestroyAddrHoisting was incorrectly hoisting
destroy_addr above uses of the @guaranteed result, destroying self while
the borrowed value was still live. In visitApplyOperand used by GatherUniqueStorageUses, check hasGuaranteedResult() and record all uses of the @guaranteed result as storage users. This prevents destroy_addr from being hoisted above any use of the @guaranteed result.

- **Scope**: Affects borrow accessors

- **Issues**: rdar://176311903

- **Original PRs**: https://github.com/swiftlang/swift/pull/88821

- **Risk**: Low

- **Testing**: Added unit test, CI testing

- **Reviewers**: @eeckstein 