### PR TITLE
[6.4] Update SIL utilities for address results from borrow accessors

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/EscapeUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/EscapeUtils.swift
@@ -655,7 +655,8 @@ fileprivate struct EscapeWalker<V: EscapeVisitor> : ValueDefUseWalker,
         if !indirectResultEscapes(of: beginApply, path: path) {
           return .continueWalk
         }
-      } else if !apply.isAddressable(operand: argOp) {
+      } else if !apply.isAddressable(operand: argOp) &&
+                !hasAddressResult(apply) {
         // The result does not depend on the argument's address.
         return .continueWalk
       }
@@ -697,6 +698,12 @@ fileprivate struct EscapeWalker<V: EscapeVisitor> : ValueDefUseWalker,
       }
     }
     return .continueWalk
+  }
+
+  private func hasAddressResult(_ apply: ApplySite) -> Bool {
+    guard let fas = apply as? FullApplySite else { return false }
+    let convention = fas.functionConvention
+    return convention.hasAddressResult
   }
 
   private mutating func indirectResultEscapes(of beginApply: BeginApplyInst, path: Path) -> Bool {

--- a/include/swift/SIL/AddressWalker.h
+++ b/include/swift/SIL/AddressWalker.h
@@ -303,6 +303,11 @@ TransitiveAddressWalker<Impl>::walk(SILValue projectedAddress) {
     }
 
     if (auto fas = FullApplySite::isa(user)) {
+      // Visit transitive uses for borrow and mutate accessors
+      if (fas.hasAddressResult()) {
+        transitiveResultUses(op);
+        continue;
+      }
       callVisitUse(op);
       continue;
     }

--- a/include/swift/SIL/ApplySite.h
+++ b/include/swift/SIL/ApplySite.h
@@ -580,6 +580,18 @@ public:
     llvm_unreachable("covered switch");
   }
 
+  bool hasAddressResult() const {
+    switch (ApplySiteKind(Inst->getKind())) {
+    case ApplySiteKind::ApplyInst:
+      return cast<ApplyInst>(Inst)->hasAddressResult();
+    case ApplySiteKind::BeginApplyInst:
+    case ApplySiteKind::TryApplyInst:
+    case ApplySiteKind::PartialApplyInst:
+      return false;
+    }
+    llvm_unreachable("covered switch");
+  }
+
   /// Returns true if \p op is an operand that passes an indirect
   /// result argument to the apply site.
   bool isIndirectResultOperand(const Operand &op) const;

--- a/lib/SIL/Utils/FieldSensitivePrunedLiveness.cpp
+++ b/lib/SIL/Utils/FieldSensitivePrunedLiveness.cpp
@@ -17,6 +17,7 @@
 #include "swift/Basic/Assertions.h"
 #include "swift/Basic/Defer.h"
 #include "swift/Basic/SmallBitVector.h"
+#include "swift/SIL/ApplySite.h"
 #include "swift/SIL/BasicBlockDatastructures.h"
 #include "swift/SIL/BasicBlockUtils.h"
 #include "swift/SIL/OwnershipUtils.h"

--- a/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
@@ -1656,6 +1656,14 @@ shouldVisitAsEndPointUse(Operand *op) {
       return TransitiveAddressWalkerTransitiveUseVisitation::OnlyUser;
     }
   }
+  // A borrow/mutate accessor apply with an address result should be treated
+  // as an endpoint use. The result address will have its own
+  // mark_unresolved_non_copyable_value that will be checked separately.
+  if (auto fas = FullApplySite::isa(op->getUser())) {
+    if (fas.hasAddressResult()) {
+      return TransitiveAddressWalkerTransitiveUseVisitation::OnlyUser;
+    }
+  }
   // A drop_deinit consumes the deinit bit.
   if (isa<DropDeinitInst>(op->getUser())) {
     return TransitiveAddressWalkerTransitiveUseVisitation::BothUserAndUses;
@@ -2675,6 +2683,7 @@ bool GatherUsesVisitor::visitUse(Operand *op) {
       return true;
     }
   }
+
 
   if (auto *pas = dyn_cast<PartialApplyInst>(user)) {
     if (auto *fArg = dyn_cast<SILFunctionArgument>(

--- a/test/SILOptimizer/addr_escape_info_unit.sil
+++ b/test/SILOptimizer/addr_escape_info_unit.sil
@@ -1042,4 +1042,55 @@ bb0(%0 : $Int):
   return %7
 }
 
+struct Inner {
+  @_hasStorage var value: Builtin.NativeObject
+}
 
+struct Outer {
+  @_hasStorage var inner: Inner
+}
+
+// CHECK-LABEL: Address escape information for test_struct_element_addr_aliases_with_store_borrow:
+// CHECK:       pair 0 - 1
+// CHECK-NEXT:    %{{.*}} = struct_element_addr %{{.*}} : $*Outer, #Outer.inner
+// CHECK-NEXT:    %{{.*}} = store_borrow %{{.*}} to %{{.*}} : $*Outer
+// CHECK-NEXT:  may alias
+// CHECK:       End function test_struct_element_addr_aliases_with_store_borrow
+sil [ossa] @test_struct_element_addr_aliases_with_store_borrow : $@convention(thin) (@guaranteed Outer) -> () {
+bb0(%0 : @guaranteed $Outer):
+  specify_test "address_escape_info"
+  %1 = alloc_stack $Outer
+  %sb = store_borrow %0 to %1 : $*Outer
+  %addr = struct_element_addr %sb : $*Outer, #Outer.inner
+  fix_lifetime %addr : $*Inner
+  fix_lifetime %sb : $*Outer
+  end_borrow %sb : $*Outer
+  dealloc_stack %1 : $*Outer
+  %ret = tuple ()
+  return %ret : $()
+}
+
+sil @get_inner_addr : $@convention(thin) (@in_guaranteed Outer) -> @guaranteed_address Inner
+
+sil @use_inner : $@convention(thin) (@guaranteed Inner) -> ()
+
+// CHECK-LABEL: Address escape information for test_guaranteed_address_aliases_with_in_guaranteed:
+// CHECK:       pair 0 - 1
+// CHECK-NEXT:    %{{.*}} = apply %{{.*}}(%{{.*}}) : $@convention(thin) (@in_guaranteed Outer) -> @guaranteed_address Inner
+// CHECK-NEXT:    %{{.*}} = store_borrow %{{.*}} to %{{.*}} : $*Outer
+// CHECK-NEXT:  may alias
+// CHECK:       End function test_guaranteed_address_aliases_with_in_guaranteed
+sil [ossa] @test_guaranteed_address_aliases_with_in_guaranteed : $@convention(thin) (@guaranteed Outer) -> () {
+bb0(%0 : @guaranteed $Outer):
+  specify_test "address_escape_info"
+  %1 = alloc_stack $Outer
+  %sb = store_borrow %0 to %1 : $*Outer
+  %get_fn = function_ref @get_inner_addr : $@convention(thin) (@in_guaranteed Outer) -> @guaranteed_address Inner
+  %addr = apply %get_fn(%sb) : $@convention(thin) (@in_guaranteed Outer) -> @guaranteed_address Inner
+  fix_lifetime %addr : $*Inner
+  fix_lifetime %sb : $*Outer
+  end_borrow %sb : $*Outer
+  dealloc_stack %1 : $*Outer
+  %ret = tuple ()
+  return %ret : $()
+}

--- a/test/SILOptimizer/copy-to-borrow-optimization.sil
+++ b/test/SILOptimizer/copy-to-borrow-optimization.sil
@@ -2312,3 +2312,33 @@ bb1(%5 : @reborrow $Klass):
   return %9 : $()
 }
 
+struct Inner {
+  var value: Builtin.NativeObject
+}
+
+struct Outer {
+  var inner: Inner
+}
+
+sil @get_inner_addr : $@convention(thin) (@in_guaranteed Outer) -> @guaranteed_address Inner
+
+sil @use_inner : $@convention(thin) (@guaranteed Inner) -> ()
+
+// CHECK-LABEL: sil [ossa] @do_not_promote_load_from_guaranteed_address_result :
+// CHECK:         load [copy]
+// CHECK-LABEL: } // end sil function 'do_not_promote_load_from_guaranteed_address_result'
+sil [ossa] @do_not_promote_load_from_guaranteed_address_result : $@convention(thin) (@guaranteed Outer) -> () {
+bb0(%0 : @guaranteed $Outer):
+  %stack = alloc_stack $Outer
+  %sb = store_borrow %0 to %stack : $*Outer
+  %get_fn = function_ref @get_inner_addr : $@convention(thin) (@in_guaranteed Outer) -> @guaranteed_address Inner
+  %addr = apply %get_fn(%sb) : $@convention(thin) (@in_guaranteed Outer) -> @guaranteed_address Inner
+  %loaded = load [copy] %addr : $*Inner
+  end_borrow %sb : $*Outer
+  %use_fn = function_ref @use_inner : $@convention(thin) (@guaranteed Inner) -> ()
+  apply %use_fn(%loaded) : $@convention(thin) (@guaranteed Inner) -> ()
+  destroy_value %loaded : $Inner
+  dealloc_stack %stack : $*Outer
+  %ret = tuple ()
+  return %ret : $()
+}

--- a/test/SILOptimizer/moveonly_addresschecker_diagnostics.sil
+++ b/test/SILOptimizer/moveonly_addresschecker_diagnostics.sil
@@ -635,3 +635,30 @@ bb0(%0 : @guaranteed $NonTrivialStruct):
   %9999 = tuple ()
   return %9999 : $()
 }
+
+sil hidden [ossa] @nontrivialstruct_borrow : $@convention(method) (@in_guaranteed NonTrivialStructPair) -> @guaranteed_address NonTrivialStruct {
+bb0(%0 : $*NonTrivialStructPair):
+  %1 = mark_unresolved_non_copyable_value [no_consume_or_assign] %0 : $*NonTrivialStructPair
+  %2 = struct_element_addr %1 : $*NonTrivialStructPair, #NonTrivialStructPair.lhs
+  return %2 : $*NonTrivialStruct
+}
+
+// CHECK-LABEL: sil [ossa] @testGetCallsBorrowAccessor :
+// CHECK:         struct_element_addr
+// CHECK:         apply
+// CHECK:         explicit_copy_addr
+// CHECK: } // end sil function 'testGetCallsBorrowAccessor'
+sil [ossa] @testGetCallsBorrowAccessor : $@convention(method) (@in_guaranteed NonTrivialStructPair) -> @out NonTrivialStruct {
+bb0(%0 : $*NonTrivialStruct, %1 : $*NonTrivialStructPair):
+  debug_value %1 : $*NonTrivialStructPair, let, name "self", argno 1, expr op_deref
+  %3 = mark_unresolved_non_copyable_value [no_consume_or_assign] %1 : $*NonTrivialStructPair
+  %4 = struct_element_addr %3 : $*NonTrivialStructPair, #NonTrivialStructPair.lhs
+  %5 = function_ref @nontrivialstruct_borrow : $@convention(method) (@in_guaranteed NonTrivialStructPair) -> @guaranteed_address NonTrivialStruct
+  %6 = apply %5(%3) : $@convention(method) (@in_guaranteed NonTrivialStructPair) -> @guaranteed_address NonTrivialStruct
+  %7 = mark_unresolved_non_copyable_value [no_consume_or_assign] %6 : $*NonTrivialStruct
+  // expected-error @-1 {{'unknown' is borrowed and cannot be consumed}}
+  copy_addr %7 to [init] %0 : $*NonTrivialStruct
+  // expected-note @-1 {{consumed here}}
+  %9 = tuple ()
+  return %9 : $()
+}

--- a/test/SILOptimizer/specialize_ossa.sil
+++ b/test/SILOptimizer/specialize_ossa.sil
@@ -1771,3 +1771,40 @@ bb0(%0 : @guaranteed $String):
   %13 = tuple ()
   return %13
 }
+
+struct Wrapper {
+  @_hasStorage var value: String { get set }
+}
+
+sil @get_value_addr : $@convention(thin) (@in_guaranteed Wrapper) -> @guaranteed_address String {
+bb0(%0 : $*Wrapper):
+  %1 = struct_element_addr %0, #Wrapper.value
+  return %1 : $*String
+}
+
+// CHECK-LABEL: sil shared [noinline] [ossa] @$s11test_borrow4main7WrapperV_Tg5 :
+// CHECK:         store_borrow
+// CHECK:         apply
+// CHECK:         load [copy]
+// CHECK:         end_borrow
+// CHECK-LABEL: } // end sil function '$s11test_borrow4main7WrapperV_Tg5'
+sil hidden [noinline] [ossa] @test_borrow : $@convention(thin) <T> (@in_guaranteed T) -> @owned String {
+bb0(%0 : $*T):
+  %1 = unchecked_addr_cast %0 : $*T to $*Wrapper
+  %2 = function_ref @get_value_addr : $@convention(thin) (@in_guaranteed Wrapper) -> @guaranteed_address String
+  %3 = apply %2(%1) : $@convention(thin) (@in_guaranteed Wrapper) -> @guaranteed_address String
+  %4 = load [copy] %3 : $*String
+  return %4 : $String
+}
+
+sil [ossa] @borrow_caller : $@convention(thin) (@guaranteed Wrapper) -> @owned String {
+bb0(%0 : @guaranteed $Wrapper):
+  %1 = alloc_stack $Wrapper
+  %2 = store_borrow %0 to %1 : $*Wrapper
+  %3 = function_ref @test_borrow : $@convention(thin) <T> (@in_guaranteed T) -> @owned String
+  %4 = apply %3<Wrapper>(%2) : $@convention(thin) <T> (@in_guaranteed T) -> @owned String
+  end_borrow %2 : $*Wrapper
+  dealloc_stack %1 : $*Wrapper
+  return %4 : $String
+}
+


### PR DESCRIPTION
- **Explanation**: Borrow accessors return an address that's lifetime-dependent on self. Update some SIL utilities that exposed problems by not considering the transitive users for liveness.
- **Scope**: Borrow accessors with address results
- **Issues**: rdar://176312886
- **Original PRs**: https://github.com/swiftlang/swift/pull/88847
- **Risk**: Low
- **Testing**: Added unit tests, CI testing
- **Reviewers**: @atrick 