### PR TITLE
MiscDiagnostics: handle implicit callee in fixItEncloseTrailingClosure

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -8218,8 +8218,16 @@ static Expr *buildCallAsFunctionMethodRef(
     rewriter.ExprStack.pop_back();
   };
 
+  // Anchor the implicit `.callAsFunction` name. Usually `args->getStartLoc()`
+  // is fine — for `foo(x)` that's the `(`, a sensible anchor. But for a bare
+  // trailing closure (`foo { ... }`) it's the `{`, which bleeds into the
+  // member ref's end loc and breaks downstream fix-its
+  // (see fixItEncloseTrailingClosure). Fall back to the end of the base in
+  // that case.
+  auto nameLoc = args->getLParenLoc().isValid() ? args->getStartLoc()
+                                                : fn->getEndLoc();
   auto *declRef = rewriter.buildMemberRef(
-      fn, /*dotLoc*/ SourceLoc(), selected, DeclNameLoc(args->getStartLoc()),
+      fn, /*dotLoc*/ SourceLoc(), selected, DeclNameLoc(nameLoc),
       calleeLoc, calleeLoc, /*implicit*/ true, AccessSemantics::Ordinary);
   if (!declRef)
     return nullptr;

--- a/test/expr/closure/trailing_in_if_let_callasfunction_regression.swift
+++ b/test/expr/closure/trailing_in_if_let_callasfunction_regression.swift
@@ -1,0 +1,30 @@
+// RUN: %target-typecheck-verify-swift
+
+// Regression test: the C++-side trailing-closure-in-stmt-condition fix-it
+// produced range endpoints that, after mapping through the Swift syntax
+// bridge in `swift_ASTGen_addQueuedDiagnostic`, were ordered start > end.
+// Root cause: the implicit `callAsFunction` member ref synthesized in
+// CSApply was anchored at `args->getStartLoc()`, which for a bare trailing
+// closure is the `{` of the closure. That bled into
+// `fixItEncloseTrailingClosure`'s `lastLoc` calculation and produced a
+// replacement range landing inside the closure, which trapped during
+// diagnostic emission.
+
+struct Lock {
+    @discardableResult
+    func callAsFunction<T>(_ block: () throws -> T) rethrows -> T {
+        try block()
+    }
+}
+
+class Foo {
+    private let lock = Lock()
+    private var cache: [String: Int] = [:]
+
+    func lookup(key: String) -> Int? {
+        if let value = lock { self.cache[key] } { // expected-warning {{trailing closure in this context is confusable with the body of the statement}} {{28-29=(}} {{48-48=)}}
+            return value
+        }
+        return nil
+    }
+}


### PR DESCRIPTION
When a CallExpr's callee is implicit (e.g. `callAsFunction`), `fn->getEndLoc()` collapses to the call site's location, so the bare-trailing-closure path could compute `lastLoc` at or past the closure's start. The resulting `fixItReplaceChars(lastLoc, closureRange.Start, ...)` produced a degenerate SourceRange that crashed the Swift-syntax-aware diagnostic renderer when constructing `Range<AbsolutePosition>`. Detect that case and fall back to a plain insertion at the closure's start.

fixes rdar://170779809