### PR TITLE
Sema: fix crash diagnosing inverse on class-bound-protocol composition

### DIFF
--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -6559,12 +6559,12 @@ TypeResolver::resolveCompositionType(CompositionTypeRepr *repr,
       auto kp = getKnownProtocolKind(ip);
 
       if (layout.requiresClass()) {
-        bool hasExplicitAnyObject = layout.hasExplicitAnyObject;
+        auto superclass = layout.getSuperclass();
         diagnose(repr->getStartLoc(),
                  diag::inverse_with_class_constraint,
-                 hasExplicitAnyObject,
+                 !superclass,
                  getProtocolName(kp),
-                 layout.getSuperclass());
+                 superclass);
         IsInvalid = true;
         break;
       }

--- a/test/Generics/inverse_generics.swift
+++ b/test/Generics/inverse_generics.swift
@@ -413,11 +413,15 @@ public func checkAnyObject<Result>(_ t: Result) where Result: AnyObject {
     checkCopyable(t)
 }
 
+protocol AnyObjectRefining: AnyObject {}
+
 func checkExistentialAndClasses(
     _ a: any AnyObject & ~Copyable, // expected-error {{composition involving 'AnyObject' cannot contain '~Copyable'}}
     _ b: any Soup & Copyable & ~Escapable & ~Copyable,
     // expected-error@-1 {{composition involving class requirement 'Soup' cannot contain '~Copyable'}}
-    _ c: some (~Escapable & Removed) & Soup // expected-error {{composition cannot contain '~Escapable' when another member requires 'Escapable'}}
+    _ c: some (~Escapable & Removed) & Soup, // expected-error {{composition cannot contain '~Escapable' when another member requires 'Escapable'}}
+    _ d: borrowing any AnyObjectRefining & ~Copyable
+    // expected-error@-1 {{composition involving 'AnyObject' cannot contain '~Copyable'}}
     ) {}
 
 protocol HasNCBuddy: ~Copyable {


### PR DESCRIPTION
`any Foo & ~Copyable` where `Foo: AnyObject` triggered a null Type in the `inverse_with_class_constraint` diagnostic: the layout requires a class via protocol refinement, but `getSuperclass()` is null with no explicit superclass term. Select the "AnyObject" branch when there's no concrete superclass.

resolves rdar://161839720 (Type checker crash on illegal existential type)