### PR TITLE
Minimize platform dependencies in the Embedded Swift Concurrency library

### DIFF
--- a/stdlib/public/CompatibilityOverride/CompatibilityOverrideConcurrency.def
+++ b/stdlib/public/CompatibilityOverride/CompatibilityOverrideConcurrency.def
@@ -352,11 +352,13 @@ OVERRIDE_TASK_GROUP(taskGroup_waitAll, void,
                     (resultPointer, callerContext, _group, bodyError,
                         resumeFn, callContext))
 
+#if !SWIFT_CONCURRENCY_EMBEDDED
 OVERRIDE_TASK_LOCAL(task_reportIllegalTaskLocalBindingWithinWithTaskGroup, void,
                     SWIFT_EXPORT_FROM(swift_Concurrency), SWIFT_CC(swift), swift::,
                     (const unsigned char *file, uintptr_t fileLength,
                         bool fileIsASCII, uintptr_t line),
                     (file, fileLength, fileIsASCII, line))
+#endif
 
 OVERRIDE_TASK_LOCAL(task_localValuePush, void,
                     SWIFT_EXPORT_FROM(swift_Concurrency), SWIFT_CC(swift),

--- a/stdlib/public/Concurrency/Actor.cpp
+++ b/stdlib/public/Concurrency/Actor.cpp
@@ -1487,9 +1487,11 @@ static DefaultActor *asAbstract(DefaultActorImpl *actor) {
   return reinterpret_cast<DefaultActor*>(actor);
 }
 
+#if !SWIFT_CONCURRENCY_EMBEDDED
 static NonDefaultDistributedActorImpl *asImpl(NonDefaultDistributedActor *actor) {
   return reinterpret_cast<NonDefaultDistributedActorImpl*>(actor);
 }
+#endif
 
 /*****************************************************************************/
 /******************** NEW DEFAULT ACTOR IMPLEMENTATION ***********************/
@@ -1971,8 +1973,10 @@ void DefaultActorImpl::deallocate() {
 #endif
 }
 
+#if !SWIFT_CONCURRENCY_EMBEDDED
 static size_t
 getDistributedRemoteActorAllocSize(const ClassMetadata *metadata);
+#endif
 
 void DefaultActorImpl::deallocateUnconditional() {
   concurrency::trace::actor_deallocate(this);
@@ -2292,6 +2296,7 @@ void swift::swift_defaultActor_deallocate(DefaultActor *_actor) {
   asImpl(_actor)->deallocate();
 }
 
+#if !SWIFT_CONCURRENCY_EMBEDDED
 static bool isDefaultActorClass(const ClassMetadata *metadata) {
   assert(metadata->isTypeMetadata());
   while (true) {
@@ -2310,6 +2315,7 @@ static bool isDefaultActorClass(const ClassMetadata *metadata) {
     }
   }
 }
+#endif
 
 void swift::swift_defaultActor_deallocateResilient(HeapObject *actor) {
 #if !SWIFT_CONCURRENCY_EMBEDDED
@@ -2799,6 +2805,7 @@ void swift::swift_executor_escalate(SerialExecutorRef executor, AsyncTask *task,
 /***************************** DISTRIBUTED ACTOR *****************************/
 /*****************************************************************************/
 
+#if !SWIFT_CONCURRENCY_EMBEDDED
 void swift::swift_nonDefaultDistributedActor_initialize(NonDefaultDistributedActor *_actor) {
   asImpl(_actor)->initialize();
 }
@@ -2861,6 +2868,7 @@ swift::swift_distributedActor_remote_initialize(const Metadata *actorType) {
     return reinterpret_cast<OpaqueValue*>(actor);
   }
 }
+#endif // !SWIFT_CONCURRENCY_EMBEDDED
 
 bool swift::swift_distributed_actor_is_remote(HeapObject *_actor) {
 #if !SWIFT_CONCURRENCY_EMBEDDED

--- a/stdlib/public/Concurrency/Actor.cpp
+++ b/stdlib/public/Concurrency/Actor.cpp
@@ -424,6 +424,7 @@ __swift_bincompat_useLegacyNonCrashingExecutorChecks() {
   return options;
 }
 
+#if !SWIFT_CONCURRENCY_EMBEDDED
 // Shimming call to Swift runtime because Swift Embedded does not have
 // these symbols defined.
 const char *__swift_runtime_env_useLegacyNonCrashingExecutorChecks() {
@@ -435,6 +436,7 @@ const char *__swift_runtime_env_useLegacyNonCrashingExecutorChecks() {
   return nullptr;
 #endif
 }
+#endif
 
 // Determine the default effective executor checking mode, and apply environment
 // variable overrides of the executor checking mode.
@@ -448,6 +450,7 @@ swift_task_is_current_executor_flag swift_bincompat_selectDefaultIsCurrentExecut
   swift_task_is_current_executor_flag options =
       __swift_bincompat_useLegacyNonCrashingExecutorChecks();
 
+#if !SWIFT_CONCURRENCY_EMBEDDED
   // Potentially, override the platform detected mode, primarily used in tests.
   if (const char *modeStr =
           __swift_runtime_env_useLegacyNonCrashingExecutorChecks()) {
@@ -469,6 +472,7 @@ swift_task_is_current_executor_flag swift_bincompat_selectDefaultIsCurrentExecut
         options | swift_task_is_current_executor_flag::Assert);
     } // else, just use the platform detected mode
   } // no override, use the default mode
+#endif
 
   return options;
 }
@@ -738,6 +742,7 @@ swift_task_isCurrentExecutorImpl(SerialExecutorRef expectedExecutor) {
                                                isCurrentExecutorFlag);
 }
 
+#if !SWIFT_CONCURRENCY_EMBEDDED
 /// Logging level for unexpected executors:
 /// 0 - no logging -- will be IGNORED when Swift6 mode of isCurrentExecutor is used
 /// 1 - warn on each instance -- will be IGNORED when Swift6 mode of isCurrentExecutor is used
@@ -782,11 +787,13 @@ static void checkUnexpectedExecutorLogLevel(void *context) {
   }
 #endif // SWIFT_STDLIB_HAS_ENVIRON
 }
+#endif
 
 SWIFT_CC(swift)
 void swift::swift_task_reportUnexpectedExecutor(
     const unsigned char *file, uintptr_t fileLength, bool fileIsASCII,
     uintptr_t line, SerialExecutorRef executor) {
+#if !SWIFT_CONCURRENCY_EMBEDDED
   SWIFT_TASK_DEBUG_LOG("CHECKING swift_task_reportUnexpectedExecutor %s", "");
   // Make sure we have an appropriate log level.
   static swift::once_t logLevelToken;
@@ -823,7 +830,6 @@ void swift::swift_task_reportUnexpectedExecutor(
       isFatalError ? "error" : "warning", functionIsolation,
       (int)fileLength, file, (int)line, whereExpected);
 
-#if !SWIFT_CONCURRENCY_EMBEDDED
   if (_swift_shouldReportFatalErrorsToDebugger()) {
     RuntimeErrorDetails details = {
         .version = RuntimeErrorDetails::currentVersion,
@@ -842,16 +848,13 @@ void swift::swift_task_reportUnexpectedExecutor(
         isFatalError ? RuntimeErrorFlagFatal : RuntimeErrorFlagNone, message,
         &details);
   }
-#endif
 
-#if defined(_WIN32) && !SWIFT_CONCURRENCY_EMBEDDED
+#if defined(_WIN32)
 #define STDERR_FILENO 2
   _write(STDERR_FILENO, message, strlen(message));
-#elif !SWIFT_CONCURRENCY_EMBEDDED
+#else
   fputs(message, stderr);
   fflush(stderr);
-#else
-  puts(message);
 #endif
 #if SWIFT_STDLIB_HAS_ASL
 #pragma clang diagnostic push
@@ -866,6 +869,9 @@ void swift::swift_task_reportUnexpectedExecutor(
 
   if (isFatalError)
     abort();
+#else
+  swift_Concurrency_fatalError(0, "running on unexpected executor");
+#endif
 }
 
 /*****************************************************************************/

--- a/stdlib/public/Concurrency/Actor.cpp
+++ b/stdlib/public/Concurrency/Actor.cpp
@@ -823,6 +823,7 @@ void swift::swift_task_reportUnexpectedExecutor(
       isFatalError ? "error" : "warning", functionIsolation,
       (int)fileLength, file, (int)line, whereExpected);
 
+#if !SWIFT_CONCURRENCY_EMBEDDED
   if (_swift_shouldReportFatalErrorsToDebugger()) {
     RuntimeErrorDetails details = {
         .version = RuntimeErrorDetails::currentVersion,
@@ -841,6 +842,7 @@ void swift::swift_task_reportUnexpectedExecutor(
         isFatalError ? RuntimeErrorFlagFatal : RuntimeErrorFlagNone, message,
         &details);
   }
+#endif
 
 #if defined(_WIN32) && !SWIFT_CONCURRENCY_EMBEDDED
 #define STDERR_FILENO 2

--- a/stdlib/public/Concurrency/Error.cpp
+++ b/stdlib/public/Concurrency/Error.cpp
@@ -15,18 +15,27 @@
 
 #include "Error.h"
 
-// swift::fatalError is not exported from libswiftCore and not shared, so define another
-// internal function instead.
+#if SWIFT_CONCURRENCY_EMBEDDED
+/// In Embedded Swift, this entrypoint is provided to produce a fatal error. It
+/// allows hooking of the fatal error operation at the Swift level and avoids
+/// any dependencies on the C standard library to abort.
+extern "C" SWIFT_NORETURN void _swift_fatalError(const char *message);
+#endif
+
+// swift::fatalError is not exported from libswiftCore and not shared, so define
+// another internal function instead. In Embedded Swift, we do have a
+// `swift_fatalError` that we can call with a string. It does not formatting,
+// however.
 SWIFT_NORETURN
 SWIFT_VFORMAT(2)
 void swift::swift_Concurrency_fatalErrorv(uint32_t flags, const char *format,
                                           va_list val) {
 #if !SWIFT_CONCURRENCY_EMBEDDED
   vfprintf(stderr, format, val);
-#else
-  vprintf(format, val);
-#endif
   abort();
+#else
+  _swift_fatalError(format);
+#endif
 }
 
 SWIFT_NORETURN

--- a/stdlib/public/Concurrency/ExecutorBridge.cpp
+++ b/stdlib/public/Concurrency/ExecutorBridge.cpp
@@ -25,10 +25,14 @@ using namespace swift;
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wreturn-type-c-linkage"
 
-extern "C" SWIFT_CC(swift)
+#if !SWIFT_CONCURRENCY_EMBEDDED || !SWIFT_USE_EMBEDDED_SWIFT_PLATFORM
+// When using the Embedded Swift Platform Abstraction Layer, _swift_exit is
+// provided by the platform, so we don't define it here.
+extern "C"
 void _swift_exit(int result) {
   exit(result);
 }
+#endif
 
 extern "C" SWIFT_CC(swift)
 void swift_createDefaultExecutorsOnce() {

--- a/stdlib/public/Concurrency/ExecutorBridge.swift
+++ b/stdlib/public/Concurrency/ExecutorBridge.swift
@@ -18,7 +18,7 @@
 import Swift
 
 @available(StdlibDeploymentTarget 6.3, *)
-@_silgen_name("_swift_exit")
+@_extern(c, "_swift_exit")
 internal func _exit(result: CInt)
 
 #if !$Embedded

--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -1884,10 +1884,12 @@ swift_task_createNullaryContinuationJobImpl(
   return job;
 }
 
+#if !SWIFT_CONCURRENCY_EMBEDDED
 SWIFT_CC(swift)
 void swift::swift_continuation_logFailedCheck(const char *message) {
   swift_reportError(0, message);
 }
+#endif
 
 // This has moved; the implementation is now in the executor; the declaration
 // needs to be here because unlike other things implemented by the executor,

--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -376,7 +376,7 @@ static void destroyTask(SWIFT_CONTEXT HeapObject *obj) {
   // here.
 
   SWIFT_TASK_DEBUG_LOG("Destroyed task %p", task);
-  free(task);
+  swift_slowDealloc(task, 0, alignof(AsyncTask) - 1);
 }
 
 #if !SWIFT_CONCURRENCY_EMBEDDED
@@ -963,7 +963,7 @@ swift_task_create_commonImpl(size_t rawTaskCreateFlags,
     allocation = runInlineOption->getAllocation();
     initialSlabSize = runInlineBufferBytes - amountToAllocate;
   } else {
-    allocation = malloc(amountToAllocate);
+    allocation = swift_slowAlloc(amountToAllocate, alignof(AsyncTask) - 1);
   }
   SWIFT_TASK_DEBUG_LOG("allocate task %p, parent = %p, slab %u", allocation,
                        parent, initialSlabSize);

--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -1985,7 +1985,7 @@ SWIFT_ALLOWED_RUNTIME_GLOBAL_CTOR_END
       swift_##name##_hook(COMPATIBILITY_UNPAREN_WITH_COMMA(namedArgs)          \
                               swift_##name##Impl,                              \
                           Override);                                           \
-      abort();                                                                 \
+      swift_unreachable("returned from noreturn hook");                        \
     }                                                                          \
     if (Override != nullptr)                                                   \
       Override(COMPATIBILITY_UNPAREN_WITH_COMMA(namedArgs)                     \
@@ -2001,7 +2001,7 @@ SWIFT_ALLOWED_RUNTIME_GLOBAL_CTOR_END
   attrs ccAttrs void namespace swift_##name COMPATIBILITY_PAREN(typedArgs) {   \
     if (swift_##name##_hook) {                                                 \
       swift_##name##_hook(swift_##name##Impl, nullptr);                        \
-      abort();                                                                 \
+      swift_unreachable("returned from noreturn hook");                        \
     }                                                                          \
     swift_##name##Impl COMPATIBILITY_PAREN(namedArgs);                         \
   }

--- a/stdlib/public/Concurrency/TaskAlloc.cpp
+++ b/stdlib/public/Concurrency/TaskAlloc.cpp
@@ -47,8 +47,7 @@ static TaskAllocator &allocator(AsyncTask *task) {
   static GlobalAllocator global;
   return global.allocator;
 #else
-  puts("global allocator fallback not available\n");
-  abort();
+  swift_Concurrency_fatalError(0, "global allocator fallback not available");
 #endif
 }
 

--- a/stdlib/public/Concurrency/TaskGroup.cpp
+++ b/stdlib/public/Concurrency/TaskGroup.cpp
@@ -590,19 +590,18 @@ struct TaskGroupStatus {
   }
 
   static void reportPendingTaskOverflow(TaskGroupBase* group, TaskGroupStatus status) {
+#if SWIFT_CONCURRENCY_EMBEDDED
+    // For Embedded Swift, don't burn code size on providing details.
+    swift_Concurrency_fatalError(0, "TaskGroup: pending task count overflow");
+#else
     char *message;
     swift_asprintf(
         &message,
         "error: %sTaskGroup: detected pending task count overflow, in task group %p! Status: %s",
         group->isDiscardingResults() ? "Discarding" : "", group,
-#if !SWIFT_CONCURRENCY_EMBEDDED
         status.to_string(group).c_str()
-#else
-        "<status unavailable in embedded>"
-#endif
-                   );
+    );
 
-#if !SWIFT_CONCURRENCY_EMBEDDED
     if (_swift_shouldReportFatalErrorsToDebugger()) {
       RuntimeErrorDetails details = {
           .version = RuntimeErrorDetails::currentVersion,
@@ -619,12 +618,11 @@ struct TaskGroupStatus {
       };
       _swift_reportToDebugger(RuntimeErrorFlagFatal, message, &details);
     }
-#endif
 
-#if defined(_WIN32) && !SWIFT_CONCURRENCY_EMBEDDED
+#if defined(_WIN32)
     #define STDERR_FILENO 2
    _write(STDERR_FILENO, message, strlen(message));
-#elif defined(STDERR_FILENO) && !SWIFT_CONCURRENCY_EMBEDDED
+#elif defined(STDERR_FILENO)
     write(STDERR_FILENO, message, strlen(message));
 #else
     puts(message);
@@ -640,6 +638,7 @@ struct TaskGroupStatus {
 
     free(message);
     abort();
+#endif
   }
 
 #if !SWIFT_CONCURRENCY_EMBEDDED

--- a/stdlib/public/Concurrency/TaskGroup.cpp
+++ b/stdlib/public/Concurrency/TaskGroup.cpp
@@ -359,12 +359,12 @@ public:
   }
 
   /// Destroy the storage associated with the group.
-  virtual void destroy() = 0;
+  SWIFT_CONCURRENCY_ABSTRACT(virtual void destroy());
 
   bool isAccumulatingResults() const {
     return !isDiscardingResults();
   }
-  virtual bool isDiscardingResults() const = 0;
+  SWIFT_CONCURRENCY_ABSTRACT(virtual bool isDiscardingResults() const);
 
   /// Any TaskGroup always IS its own TaskRecord.
   /// This allows us to easily get the group while cancellation is propagated throughout the task tree.
@@ -379,7 +379,7 @@ public:
   /// If possible, and an existing task is already waiting on next(), this will
   /// schedule it immediately. If not, the result is enqueued and will be picked
   /// up whenever a task calls next() the next time.
-  virtual void offer(AsyncTask *completed, AsyncContext *context) = 0;
+  SWIFT_CONCURRENCY_ABSTRACT(virtual void offer(AsyncTask *completed, AsyncContext *context));
 
   /// Attempt to park the `waitingTask` in the waiting queue.
   ///
@@ -405,7 +405,7 @@ public:
                      AsyncContext *rawContext);
 
   // Enqueue the completed task onto ready queue if there are no waiting tasks yet
-  virtual void enqueueCompletedTask(AsyncTask *completedTask, bool hadErrorResult) = 0;
+  SWIFT_CONCURRENCY_ABSTRACT(virtual void enqueueCompletedTask(AsyncTask *completedTask, bool hadErrorResult));
 
   /// Resume waiting task with result from `completedTask`
   PreparedWaitingTask prepareWaitingTaskWithTask(AsyncTask *waitingTask,

--- a/stdlib/public/Concurrency/TaskLocal.cpp
+++ b/stdlib/public/Concurrency/TaskLocal.cpp
@@ -285,6 +285,7 @@ void TaskLocal::ValueItem::copyTo(AsyncTask *target) {
   target->_private().Local.head = item;
 }
 
+#if !SWIFT_CONCURRENCY_EMBEDDED
 // =============================================================================
 // ==== checks -----------------------------------------------------------------
 
@@ -373,6 +374,7 @@ static void swift_task_reportIllegalTaskLocalBindingWithinWithTaskGroupImpl(
   free(message);
   abort();
 }
+#endif
 
 // =============================================================================
 // ==== destroy ----------------------------------------------------------------

--- a/stdlib/public/Concurrency/TaskLocal.cpp
+++ b/stdlib/public/Concurrency/TaskLocal.cpp
@@ -96,7 +96,7 @@ static void swift_task_localValuePushImpl(const HeapObject *key,
   if (auto storage = FallbackTaskLocalStorage::get()) {
     Local = storage;
   } else {
-    void *allocation = malloc(sizeof(TaskLocal::Storage));
+    void *allocation = swift_slowAlloc(sizeof(TaskLocal::Storage), alignof(TaskLocal::Storage) - 1);
     auto *freshStorage = new(allocation) TaskLocal::Storage();
 
     FallbackTaskLocalStorage::set(freshStorage);
@@ -140,7 +140,7 @@ static void swift_task_localValuePopImpl() {
       // We clean up eagerly, it may be that this non-swift-concurrency thread
       // never again will use task-locals, and as such we better remove the storage.
       FallbackTaskLocalStorage::set(nullptr);
-      free(Local);
+      swift_slowDealloc(Local, sizeof(TaskLocal::Storage), alignof(TaskLocal::Storage) - 1);
     }
     return;
   }
@@ -255,7 +255,7 @@ TaskLocal::MarkerItem *TaskLocal::MarkerItem::create(AsyncTask *task,
   // If we have a task, allocate from that task. If not, use malloc. This must
   // mirror the corresponding dealloc/free call in Item::destroy.
   if (task) allocation = _swift_task_alloc_specific(task, amountToAllocate);
-  else allocation = malloc(amountToAllocate);
+  else allocation = swift_slowAlloc(amountToAllocate, alignof(MarkerItem) - 1);
   return new (allocation) MarkerItem(next, kind);
 }
 
@@ -268,7 +268,7 @@ TaskLocal::ValueItem *TaskLocal::ValueItem::create(AsyncTask *task,
 
   size_t amountToAllocate = ValueItem::itemSize(valueType);
   void *allocation = task ? _swift_task_alloc_specific(task, amountToAllocate)
-                          : malloc(amountToAllocate);
+                          : swift_slowAlloc(amountToAllocate, alignof(ValueItem) - 1);
   return ::new (allocation) ValueItem(next, key, valueType, inTaskGroupBody);
 }
 
@@ -397,9 +397,9 @@ bool TaskLocal::Item::destroy(AsyncTask *task) {
   }
 
   // if task is available, we must have used the task allocator to allocate this item,
-  // so we must deallocate it using the same. Otherwise, we must have used malloc.
+  // so we must deallocate it using the same. Otherwise, we must have used swift_slowAlloc.
   if (task) _swift_task_dealloc_specific(task, this);
-  else free(this);
+  else swift_slowDealloc(this, 0, alignof(TaskLocal::Item) - 1);
 
   return stop;
 }

--- a/stdlib/public/Concurrency/TaskPrivate.h
+++ b/stdlib/public/Concurrency/TaskPrivate.h
@@ -39,6 +39,14 @@
 #define SWIFT_FATAL_ERROR swift_Concurrency_fatalError
 #include "../runtime/StackAllocator.h"
 
+// In embedded builds, pure virtual methods are replaced with
+// __builtin_unreachable() stubs to avoid pulling in __cxa_pure_virtual.
+#if SWIFT_CONCURRENCY_EMBEDDED
+#define SWIFT_CONCURRENCY_ABSTRACT(decl) decl { __builtin_unreachable(); }
+#else
+#define SWIFT_CONCURRENCY_ABSTRACT(decl) decl = 0
+#endif
+
 namespace swift {
 
 // Set to 1 to enable helpful debug spew to stderr

--- a/stdlib/public/Concurrency/TaskPrivate.h
+++ b/stdlib/public/Concurrency/TaskPrivate.h
@@ -780,6 +780,26 @@ public:
 static_assert(sizeof(ActiveTaskStatus) == ACTIVE_TASK_STATUS_SIZE,
   "ActiveTaskStatus is of incorrect size");
 
+/// Global allocator that goes through swift_slowAlloc/swift_slowDealloc.
+struct SwiftGlobalAllocator {
+  void *allocateGlobal(size_t size, size_t alignMask) {
+    return swift_slowAlloc(size, alignMask);
+  }
+
+  void deallocateGlobal(void* ptr, size_t size, size_t alignMask) {
+    swift_slowDealloc(ptr, size, alignMask);
+  }
+};
+
+/// Select the global allocator differently for Embedded Swift (where we always
+/// want to go through swift_slow(Alloc|Dealloc)) or non-embedded (where we
+/// continue using malloc/free).
+#if SWIFT_CONCURRENCY_EMBEDDED
+typedef SwiftGlobalAllocator TaskGlobalAllocator;
+#else
+typedef MallocFreeAllocator TaskGlobalAllocator;
+#endif
+
 struct TaskAllocatorConfiguration {
 #if SWIFT_CONCURRENCY_EMBEDDED
 
@@ -817,11 +837,13 @@ struct TaskAllocatorConfiguration {
 /// malloc stack logging.
 static constexpr size_t SlabCapacity =
     1024 - 8 -
-    StackAllocator<0, nullptr, TaskAllocatorConfiguration>::slabHeaderSize();
+  StackAllocator<0, nullptr, TaskAllocatorConfiguration, TaskGlobalAllocator>
+    ::slabHeaderSize();
 extern Metadata TaskAllocatorSlabMetadata;
 
 using TaskAllocator = StackAllocator<SlabCapacity, &TaskAllocatorSlabMetadata,
-                                     TaskAllocatorConfiguration>;
+                                     TaskAllocatorConfiguration,
+                                     TaskGlobalAllocator>;
 
 /// Private storage in an AsyncTask object.
 struct AsyncTask::PrivateStorage {

--- a/stdlib/public/Concurrency/TaskStatus.cpp
+++ b/stdlib/public/Concurrency/TaskStatus.cpp
@@ -643,6 +643,31 @@ void AsyncTask::dropInitialTaskExecutorPreferenceRecord() {
 /************************** TASK NAMING ***************************************/
 /******************************************************************************/
 
+#if SWIFT_CONCURRENCY_EMBEDDED
+// Disabling optimizations on this function prevents LLVM from translating it
+// into a strlen() call.
+__attribute__((noinline, optnone))
+static size_t swift_strlen(const char *text) {
+  size_t count = 0;
+  for (auto p = text; *p != 0; ++p) {
+    ++count;
+  }
+  return count;
+}
+
+static void swift_strcpy(char *dst, const char *src) {
+  while (*src != 0) {
+    *dst++ = *src++;
+  }
+  *dst = 0;
+}
+
+#else
+static size_t swift_strlen(const char *text) {
+  return strlen(text);
+}
+#endif
+
 void AsyncTask::pushInitialTaskName(const char* _taskName) {
   assert(_taskName && "Task name must not be null!");
   assert(hasInitialTaskNameRecord() && "Attempted pushing name but task has no initial task name flag!");
@@ -651,10 +676,12 @@ void AsyncTask::pushInitialTaskName(const char* _taskName) {
       this, sizeof(class TaskNameStatusRecord));
 
   // TODO: Copy the string maybe into the same allocation at an offset or retain the swift string?
-  auto taskNameLen = strlen(_taskName);
+  auto taskNameLen = swift_strlen(_taskName);
   char* taskNameCopy = reinterpret_cast<char*>(
       _swift_task_alloc_specific(this, taskNameLen + 1/*null terminator*/));
-#if defined(_WIN32)
+#if SWIFT_CONCURRENCY_EMBEDDED
+  swift_strcpy(taskNameCopy, _taskName);
+#elif defined(_WIN32)
   static_cast<void>(strncpy_s(taskNameCopy, taskNameLen + 1,
                               _taskName, _TRUNCATE));
 #else

--- a/stdlib/public/EmbeddedPlatform/EmbeddedPlatformPOSIX.swift
+++ b/stdlib/public/EmbeddedPlatform/EmbeddedPlatformPOSIX.swift
@@ -11,6 +11,9 @@ func arc4random_buf(_ buf: UnsafeMutableRawPointer, _ nbytes: Int)
 @_extern(c, "putchar")
 func putchar(_: CInt) -> CInt
 
+@_extern(c, "exit")
+func exit(_: CInt)
+
 // Implementations of the Embedded Swift Platform layer on top of the POSIX dependencies.
 @implementation @c
 public func _swift_alignedAllocate(_ pointer: UnsafeMutablePointer<UnsafeMutableRawPointer?>, _ alignment: Int, _ size: Int) -> CInt {
@@ -35,6 +38,11 @@ public func _swift_generateRandomHashSeed(_ buf: UnsafeMutableRawPointer, _ nbyt
 @implementation @c
 public func _swift_writeCharToStandardOutput(_ c: CInt) -> CInt {
   putchar(c)
+}
+
+@implementation @c
+public func _swift_exit(_ code: CInt) {
+  exit(code)
 }
 
 @implementation @c

--- a/stdlib/public/EmbeddedPlatform/swift/EmbeddedPlatform.h
+++ b/stdlib/public/EmbeddedPlatform/swift/EmbeddedPlatform.h
@@ -194,4 +194,17 @@ void * EMBEDDED_SWIFT_NULLABLE _swift_getExclusivityTLS(void);
  */
 void _swift_setExclusivityTLS(void * EMBEDDED_SWIFT_NULLABLE ptr);
 
+/**
+ * Exit the program.
+ *
+ * Parameters:
+ * - `code`: the exit code, which is typically 0 for normal termination.
+ *
+ * This function must not return.
+ *
+ * This function can be implemented directly with a call to the POSIX exit()
+ * function.
+ */
+void _swift_exit(int code);
+
 #endif

--- a/stdlib/public/core/EmbeddedPrint.swift
+++ b/stdlib/public/core/EmbeddedPrint.swift
@@ -170,3 +170,21 @@ public func print(_ boolean: Bool, terminator: StaticString = "\n") {
     print("false", terminator: terminator)
   }
 }
+
+/// Hook used to print a fatal error from C code, e.g., parts of the Swift
+/// Concurrency runtime.
+@c @used
+public func _swift_fatalError(_ message: UnsafePointer<UInt8>) -> Never {
+  if _isDebugAssertConfiguration() {
+    print("fatal error", terminator: ": ")
+
+    var pointer = unsafe message
+    while unsafe pointer.pointee != 0 {
+      unsafe writeSingleChar(CInt(pointer.pointee))
+      unsafe pointer += 1
+    }
+  } else {
+    Builtin.condfail_message(true._value, message._rawValue)
+  }
+  Builtin.unreachable()
+}

--- a/stdlib/public/core/EmbeddedRuntime.swift
+++ b/stdlib/public/core/EmbeddedRuntime.swift
@@ -352,6 +352,22 @@ public func swift_deallocBox(_ pointer: UnsafeMutableRawPointer) {
   )
 }
 
+/// Extracts the type metadata out of a heap object.
+@c
+public func swift_getObjectType(_ pointer: UnsafeMutableRawPointer) -> UnsafeRawPointer {
+  let object = unsafe pointer.bindMemory(to: HeapObject.self, capacity: 1)
+  return unsafe _swift_embedded_get_heap_object_metadata_pointer(object)
+}
+
+/// Determines whether two witness tables are the same.
+///
+/// The only way this can be true in Embedded Swift is if they refer to the same
+/// address in memory.
+@c
+public func swift_compareWitnessTables(_ lhs: UnsafeRawPointer, _ rhs: UnsafeRawPointer) -> Bool {
+  unsafe lhs == rhs
+}
+
 // MARK: - Error boxing (swift_allocError / swift_deallocError / swift_getErrorValue)
 
 /// Error box layout: [HeapObject header] [type ptr] [errorConformance ptr] [alignment padding] [value]

--- a/stdlib/public/runtime/StackAllocator.h
+++ b/stdlib/public/runtime/StackAllocator.h
@@ -35,6 +35,19 @@
 
 namespace swift {
 
+/// malloc/free-based allocator to be used with the StackAllocator to allocate
+/// the slabs themselves.
+class MallocFreeAllocator {
+public:
+  void *allocateGlobal(size_t size, size_t alignMask) {
+    return malloc(size);
+  }
+
+  void deallocateGlobal(void* ptr, size_t size, size_t alignMask) {
+    free(ptr);
+  }
+};
+
 /// A bump-pointer allocator that obeys a stack discipline.
 ///
 /// StackAllocator performs fast allocation and deallocation of memory by
@@ -64,9 +77,12 @@ namespace swift {
 ///   returns true - the slab allocator is used
 /// This function MUST return the same value throughout the lifetime the stack
 /// allocator.
+///
+/// UnderlyingAllocator 
 template <size_t SlabCapacity, Metadata *SlabMetadataPtr,
-          typename SlabAllocatorConfiguration>
-class StackAllocator {
+          typename SlabAllocatorConfiguration,
+          typename UnderlyingAllocator = MallocFreeAllocator>
+class StackAllocator: public UnderlyingAllocator {
 private:
 
   struct Allocation;
@@ -273,7 +289,8 @@ private:
 
     size_t capacity = std::max(SlabCapacity,
                                Allocation::includingHeader(size));
-    void *slabBuffer = malloc(Slab::includingHeader(capacity));
+    void *slabBuffer = this->allocateGlobal(Slab::includingHeader(capacity),
+                                            alignof(Slab) - 1);
     Slab *newSlab = ::new (slabBuffer) Slab(capacity);
     if (slab)
       slab->next = newSlab;
@@ -292,7 +309,7 @@ private:
       Slab *next = slab->next;
       freedCapacity += slab->capacity;
       slab->clearMetadata();
-      free(slab);
+      this->deallocateGlobal(slab, slab->capacity, alignof(Slab) - 1);
       numAllocatedSlabs--;
       slab = next;
     }
@@ -303,6 +320,12 @@ public:
   /// Construct a StackAllocator without a pre-allocated first slab.
   StackAllocator()
       : firstSlab(nullptr), firstSlabIsPreallocated(false),
+        numAllocatedSlabs(0), configuration() {}
+
+  /// Construct a StackAllocator given an underlying allocator.
+  StackAllocator(const UnderlyingAllocator &underlying)
+      : UnderlyingAllocator(underlying),
+        firstSlab(nullptr), firstSlabIsPreallocated(false),
         numAllocatedSlabs(0), configuration() {}
 
   /// Construct a StackAllocator with a pre-allocated first slab.
@@ -350,7 +373,7 @@ public:
     // getting folded into its enableSlabAllocator() call, and the fast path
     // where `slab` is non-null ends up with no extra conditionals at all.
     if (SWIFT_UNLIKELY(!slab))
-      return malloc(size);
+      return this->allocateGlobal(size, alignment - 1);
 
     Allocation *allocation = slab->allocate(alignedSize, lastAllocation);
     lastAllocation = allocation;
@@ -364,7 +387,8 @@ public:
     if (SWIFT_UNLIKELY(!lastAllocation ||
                        lastAllocation->getAllocatedMemory() != ptr)) {
       if (!configuration.enableSlabAllocator())
-        return free(ptr);
+        return this->deallocateGlobal(ptr, -1, 0);
+
       SWIFT_FATAL_ERROR(0, "freed pointer was not the last allocation");
     }
 

--- a/test/Misc/verify-swift-feature-testing.test-sh
+++ b/test/Misc/verify-swift-feature-testing.test-sh
@@ -35,6 +35,7 @@ EXCEPTIONAL_FILES = [
     pathlib.Path("validation-test/Evolution/test_protocol_add_reparented_seq.swift"),
     # Needs Embedded but without any command lines that enable it for the compiler.
     pathlib.Path("test/embedded/concurrency-non-symbols.swift"),
+    pathlib.Path("test/embedded/concurrency-non-symbols-nonassert.swift"),
 ]
 
 ENABLE_FEATURE_RE = re.compile(

--- a/test/Misc/verify-swift-feature-testing.test-sh
+++ b/test/Misc/verify-swift-feature-testing.test-sh
@@ -33,6 +33,8 @@ EXCEPTIONAL_FILES = [
     pathlib.Path("validation-test/Evolution/test_coroutine_accessors.swift"),
     # Uses a special -experimental-features flag for the rth utility
     pathlib.Path("validation-test/Evolution/test_protocol_add_reparented_seq.swift"),
+    # Needs Embedded but without any command lines that enable it for the compiler.
+    pathlib.Path("test/embedded/concurrency-non-symbols.swift"),
 ]
 
 ENABLE_FEATURE_RE = re.compile(

--- a/test/embedded/concurrency-non-symbols-nonassert.swift
+++ b/test/embedded/concurrency-non-symbols-nonassert.swift
@@ -3,6 +3,7 @@
 // REQUIRES: swift_in_compiler
 // REQUIRES: swift_feature_Embedded
 // REQUIRES: swift_stdlib_no_asserts
+// REQUIRES: no_asserts
 // REQUIRES: optimized_stdlib
 
 // Check for symbols that we explicitly don't want in the Embedded Swift

--- a/test/embedded/concurrency-non-symbols-nonassert.swift
+++ b/test/embedded/concurrency-non-symbols-nonassert.swift
@@ -2,21 +2,13 @@
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: swift_feature_Embedded
+// REQUIRES: swift_stdlib_no_asserts
+// REQUIRES: optimized_stdlib
 
 // Check for symbols that we explicitly don't want in the Embedded Swift
 // concurrency library.
 
-// CHECK-NOT: swift_reportToDebugger
-// CHECK-NOT: swift_shouldReportFatalErrorsToDebugger
-// CHECK-NOT: swift_reportError
-// CHECK-NOT: getResilientMetadataBounds
-// CHECK-NOT: puts
-// CHECK-NOT: strlen
-// CHECK-NOT: strncpy
-// CHECK-NOT: vprintf
-// CHECK-NOT: vsnprintf
-// CHECK-NOT: malloc
-// CHECK-NOT: free
+// CHECK-NOT: abort
 
 // CHECK-DAG: swift_fatalError
 // CHECK-DAG: swift_slowAlloc

--- a/test/embedded/concurrency-non-symbols-nonassert.swift
+++ b/test/embedded/concurrency-non-symbols-nonassert.swift
@@ -1,4 +1,4 @@
-// RUN: %llvm-nm -a %swift_obj_root/lib/swift/embedded/%module-target-triple/libswift_Concurrency.a | %FileCheck %s
+// RUN: %llvm-nm -a %swift_obj_root/lib/swift/embedded/%module-target-triple/libswift_Concurrency.a | %FileCheck %s --dump-input fail
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: swift_feature_Embedded

--- a/test/embedded/concurrency-non-symbols.swift
+++ b/test/embedded/concurrency-non-symbols.swift
@@ -11,6 +11,10 @@
 // CHECK-NOT: swift_reportError
 // CHECK-NOT: getResilientMetadataBounds
 // CHECK-NOT: abort
+// CHECK-NOT: puts
+// CHECK-NOT: strlen
+// CHECK-NOT: strncpy
+// CHECK-NOT: vprintf
+// CHECK-NOT: vsnprintf
 
 // CHECK-DAG: swift_fatalError
-

--- a/test/embedded/concurrency-non-symbols.swift
+++ b/test/embedded/concurrency-non-symbols.swift
@@ -8,4 +8,4 @@
 
 // CHECK-NOT: swift_reportToDebugger
 // CHECK-NOT: swift_shouldReportFatalErrorsToDebugger
-
+// CHECK-NOT: swift_reportError

--- a/test/embedded/concurrency-non-symbols.swift
+++ b/test/embedded/concurrency-non-symbols.swift
@@ -1,0 +1,11 @@
+// RUN: %llvm-nm -a %swift_obj_root/lib/swift/embedded/%module-target-triple/libswift_Concurrency.a | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: swift_feature_Embedded
+
+// Check for symbols that we explicitly don't want in the Embedded Swift
+// concurrency library.
+
+// CHECK-NOT: swift_reportToDebugger
+// CHECK-NOT: swift_shouldReportFatalErrorsToDebugger
+

--- a/test/embedded/concurrency-non-symbols.swift
+++ b/test/embedded/concurrency-non-symbols.swift
@@ -9,3 +9,4 @@
 // CHECK-NOT: swift_reportToDebugger
 // CHECK-NOT: swift_shouldReportFatalErrorsToDebugger
 // CHECK-NOT: swift_reportError
+// CHECK-NOT: getResilientMetadataBounds

--- a/test/embedded/concurrency-non-symbols.swift
+++ b/test/embedded/concurrency-non-symbols.swift
@@ -10,3 +10,7 @@
 // CHECK-NOT: swift_shouldReportFatalErrorsToDebugger
 // CHECK-NOT: swift_reportError
 // CHECK-NOT: getResilientMetadataBounds
+// CHECK-NOT: abort
+
+// CHECK-DAG: swift_fatalError
+

--- a/test/embedded/concurrency-non-symbols.swift
+++ b/test/embedded/concurrency-non-symbols.swift
@@ -17,6 +17,7 @@
 // CHECK-NOT: vsnprintf
 // CHECK-NOT: malloc
 // CHECK-NOT: free
+// CHECK-NOT: __cxa_pure_virtual
 
 // CHECK-DAG: swift_fatalError
 // CHECK-DAG: swift_slowAlloc


### PR DESCRIPTION
Embedded Swift seeks to minimize its dependencies on the underlying platform as much as is possible, and to document and access those necessary dependencies through the Platform Abstraction Layer. Apply that principle to the Embedded Concurrency library, reducing its dependencies significantly (but not completely):

* Eliminate the use of debugging hooks, because there never are any
* Eliminate distributed-actor-specific functionality that is not available
* Don't pretty-print fatal error messages; it costs too much in code size and standard library dependencies
* Route fatal errors through a new swift_fatalError entrypoint defined in the Embedded runtime, so we get the same trapping from the C++ code as we would in Swift
* Introduce `_swift_exit` to the Platform Abstraction Layer, which can be implemented by a call to the POSIX/C `exit`. This is only needed for `async` main
* Drop dependencies on `puts`, `v(sn)printf`, `strlen`, `strncpy` from the C standard library.
* Implement `swift_getObjectType` and `swift_compareWitnessTables` in the Embedded runtime; they're reasonable for the concurrency library to use.
* Eliminate C++ abstract methods so we don't reference `__cxa_pure_virtual`.
* Eliminate direct uses of `malloc`/`free`, and instead always go through `swift_slow(Alloc|Dealloc)`, which sits on top of the platform abstraction layer.

Implements most of rdar://176300169, which seeks to minimize platform dependencies. There are still open questions about dealing with clocks.