### PR TITLE
Targets and exports in install tree

### DIFF
--- a/SwiftCompilerSources/CMakeLists.txt
+++ b/SwiftCompilerSources/CMakeLists.txt
@@ -331,7 +331,21 @@ function(add_swift_compiler_modules_library name)
     target_link_options(${name} PUBLIC ${public_link_flags})
   endif()
 
-  set_property(GLOBAL APPEND PROPERTY SWIFT_BUILDTREE_EXPORTS ${name})
+  if(NOT LLVM_INSTALL_TOOLCHAIN_ONLY)
+    swift_install_in_component(TARGETS ${name}
+      EXPORT SwiftTargets
+      ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+      LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+      RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+      COMPONENT dev)
+  endif()
+  
+  swift_is_installing_component("compiler" _installing_compiler_modules)
+    if(_installing_compiler_modules)
+      set_property(GLOBAL APPEND PROPERTY SWIFT_EXPORTS ${name})
+    else()
+      set_property(GLOBAL APPEND PROPERTY SWIFT_BUILDTREE_EXPORTS ${name})
+    endif()
 endfunction()
 
 

--- a/cmake/modules/AddPureSwift.cmake
+++ b/cmake/modules/AddPureSwift.cmake
@@ -539,6 +539,7 @@ function(add_pure_swift_host_tool name)
   if(NOT APSHT_SWIFT_COMPONENT STREQUAL no_component)
     add_dependencies(${APSHT_SWIFT_COMPONENT} ${name})
     swift_install_in_component(TARGETS ${name}
+      EXPORT SwiftTargets
       COMPONENT ${APSHT_SWIFT_COMPONENT}
       RUNTIME DESTINATION bin)
     swift_is_installing_component(${APSHT_SWIFT_COMPONENT} is_installing)

--- a/cmake/modules/AddPureSwift.cmake
+++ b/cmake/modules/AddPureSwift.cmake
@@ -402,6 +402,15 @@ function(add_pure_swift_host_library name)
       "SHELL:-Xlinker --build-id=sha1")
   endif()
 
+  if(NOT LLVM_INSTALL_TOOLCHAIN_ONLY)
+    swift_install_in_component(TARGETS ${name}
+      EXPORT SwiftTargets
+      ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+      LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+      RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+      COMPONENT dev)
+  endif()
+
   # Export this target.
   set_property(GLOBAL APPEND PROPERTY SWIFT_EXPORTS ${name})
 endfunction()
@@ -499,11 +508,13 @@ function(add_pure_swift_host_tool name)
     target_link_libraries(${name} PUBLIC swiftSwiftOnoneSupport)
   endif()
 
-  # Make sure we can use the host libraries.
   target_include_directories(${name} PUBLIC
-    "${SWIFT_HOST_LIBRARIES_DEST_DIR}")
+    "$<BUILD_INTERFACE:${SWIFT_HOST_LIBRARIES_DEST_DIR}>"
+    "$<INSTALL_INTERFACE:${CMAKE_INSTALL_LIBDIR}/swift/host>")
+
   target_link_directories(${name} PUBLIC
-    "${SWIFT_HOST_LIBRARIES_DEST_DIR}")
+    "$<BUILD_INTERFACE:${SWIFT_HOST_LIBRARIES_DEST_DIR}>"
+    "$<INSTALL_INTERFACE:${CMAKE_INSTALL_LIBDIR}/swift/host>")
 
   if(LLVM_USE_LINKER)
     target_link_options(${name} PRIVATE

--- a/cmake/modules/AddPureSwift.cmake
+++ b/cmake/modules/AddPureSwift.cmake
@@ -369,7 +369,8 @@ function(add_pure_swift_host_library name)
     # Install the Swift module into the appropriate location.
     Swift_MODULE_DIRECTORY ${module_dir}
     # NOTE: workaround for CMake not setting up include flags.
-    INTERFACE_INCLUDE_DIRECTORIES ${module_dir})
+    INTERFACE_INCLUDE_DIRECTORIES
+      "$<BUILD_INTERFACE:${module_dir}>;$<INSTALL_INTERFACE:lib${LLVM_LIBDIR_SUFFIX}/swift/host>")
 
   # Workaround to touch the library and its objects so that we don't
   # continually rebuild (again, see corresponding change in swift-syntax).

--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -754,7 +754,8 @@ function(add_swift_host_library name)
 
   add_library(${name} ${libkind} ${ASHL_SOURCES})
 
-  target_link_directories(${name} PUBLIC "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}")
+  #target_link_directories(${name} PUBLIC "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}")
+  target_link_directories(${name} PRIVATE "$<BUILD_INTERFACE:${CMAKE_LIBRARY_OUTPUT_DIRECTORY}>")
 
   # Respect LLVM_COMMON_DEPENDS if it is set.
   #

--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -862,6 +862,7 @@ function(add_swift_host_library name)
   add_dependencies(dev ${name})
   if(NOT LLVM_INSTALL_TOOLCHAIN_ONLY)
     swift_install_in_component(TARGETS ${name}
+      EXPORT SwiftTargets
       ARCHIVE DESTINATION lib${LLVM_LIBDIR_SUFFIX} COMPONENT dev
       LIBRARY DESTINATION lib${LLVM_LIBDIR_SUFFIX} COMPONENT dev
       RUNTIME DESTINATION bin COMPONENT dev)
@@ -1055,6 +1056,7 @@ function(add_swift_host_tool executable)
   if(NOT ASHT_SWIFT_COMPONENT STREQUAL "no_component")
     add_dependencies(${ASHT_SWIFT_COMPONENT} ${executable})
     swift_install_in_component(TARGETS ${executable}
+                               EXPORT SwiftTargets
                                RUNTIME
                                  DESTINATION bin
                                  COMPONENT ${ASHT_SWIFT_COMPONENT}

--- a/cmake/modules/CMakeLists.txt
+++ b/cmake/modules/CMakeLists.txt
@@ -21,6 +21,7 @@ set(swift_cmake_builddir "${SWIFT_BINARY_DIR}/${SWIFT_INSTALL_PACKAGE_DIR}")
 # -----------------------------------------------------------------------------
 
 set(SWIFT_EXPORTS_FILE "${swift_cmake_builddir}/SwiftExports.cmake")
+set(SWIFT_EXPORTS_INSTALL_FILE "${swift_cmake_builddir}/SwiftExports-install.cmake")
 get_property(SWIFT_EXPORTS GLOBAL PROPERTY SWIFT_EXPORTS)
 get_property(SWIFT_BUILDTREE_EXPORTS GLOBAL PROPERTY SWIFT_BUILDTREE_EXPORTS)
 
@@ -28,6 +29,18 @@ get_property(SWIFT_BUILDTREE_EXPORTS GLOBAL PROPERTY SWIFT_BUILDTREE_EXPORTS)
 set(SWIFT_CONFIG_EXPORTS ${SWIFT_EXPORTS} ${SWIFT_BUILDTREE_EXPORTS})
 if(SWIFT_CONFIG_EXPORTS)
   export(TARGETS ${SWIFT_CONFIG_EXPORTS} FILE "${SWIFT_EXPORTS_FILE}")
+endif()
+
+# -----------------------------------------------------------------------------
+# Install-tree exports file (generated in build dir, installed as a normal file)
+# -----------------------------------------------------------------------------
+#
+# Avoid install(CODE ...) to generate this file: install-time code does not
+# automatically respect DESTDIR staging. By generating it in the build tree and
+# installing it via swift_install_in_component(FILES ...), it will be staged
+# correctly under DESTDIR.
+if(SWIFT_EXPORTS)
+  export(TARGETS ${SWIFT_EXPORTS} FILE "${SWIFT_EXPORTS_INSTALL_FILE}")
 endif()
 
 # Generate a build-tree SwiftConfig.cmake as well (useful for in-tree consumers).
@@ -72,6 +85,7 @@ write_basic_package_version_file(
 # Install config + version.
 swift_install_in_component(
   FILES
+    "${SWIFT_EXPORTS_INSTALL_FILE}"
     "${swift_cmake_builddir}/SwiftConfig.cmake.install"
     "${swift_cmake_builddir}/SwiftConfigVersion.cmake"
   DESTINATION "${SWIFT_INSTALL_PACKAGE_DIR}"
@@ -86,29 +100,11 @@ swift_install_in_component(
   COMPONENT dev
   RENAME "SwiftConfig.cmake")
 
-# 2) Install-tree SwiftExports.cmake:
-# We cannot use install(EXPORT ...) because Swift's targets are not installed into
-# a single export set. Instead, generate the exports file during installation.
-#
-# This writes directly into: ${CMAKE_INSTALL_PREFIX}/${SWIFT_INSTALL_PACKAGE_DIR}/SwiftExports.cmake
-#
-# It exports only the targets recorded in the global SWIFT_EXPORTS property
-# (i.e. those meant to be part of the install).
-if(SWIFT_EXPORTS)
-  # Escape the list for embedding into install(CODE).
-  # We pass it as a CMake list literal.
-  string(REPLACE ";" "\\;" _SWIFT_EXPORTS_ESCAPED "${SWIFT_EXPORTS}")
-
-  swift_install_in_component(
-    CODE
-      "set(_swift_exports \"${_SWIFT_EXPORTS_ESCAPED}\")\n"
-      "if(_swift_exports)\n"
-      "  set(_dest \"\")\n"
-      "  if(DEFINED ENV{DESTDIR})\n"
-      "    set(_dest \"$ENV{DESTDIR}\")\n"
-      "  endif()\n"
-      "  file(MAKE_DIRECTORY \"\${_dest}\${CMAKE_INSTALL_PREFIX}/${SWIFT_INSTALL_PACKAGE_DIR}\")\n"
-      "  export(TARGETS \${_swift_exports} FILE \"\${_dest}\${CMAKE_INSTALL_PREFIX}/${SWIFT_INSTALL_PACKAGE_DIR}/SwiftExports.cmake\")\n"
-      "endif()\n"
-    COMPONENT dev)
-endif()
+# Rename SwiftExports.cmake.install -> SwiftExports.cmake on install.
+# (CMake's install(FILES) does not rename, so install twice: once with RENAME.)
+swift_install_in_component(
+  FILES
+    "${SWIFT_EXPORTS_INSTALL_FILE}"
+  DESTINATION "${SWIFT_INSTALL_PACKAGE_DIR}"
+  COMPONENT dev
+  RENAME "SwiftExports.cmake")

--- a/cmake/modules/CMakeLists.txt
+++ b/cmake/modules/CMakeLists.txt
@@ -1,19 +1,109 @@
-set(SWIFT_INSTALL_PACKAGE_DIR lib${LLVM_LIBDIR_SUFFIX}/cmake/swift)
+# NOTE: This file is responsible for producing the Swift CMake package files.
+# Historically it only generated build-tree exports/config. This version:
+#   - keeps the build-tree SwiftExports.cmake (useful for in-tree builds)
+#   - installs a relocatable SwiftConfig.cmake + SwiftConfigVersion.cmake
+#   - generates an install-tree SwiftExports.cmake at install time so that
+#     find_package(Swift CONFIG) works from an installed Swift build, without
+#     requiring targets to have been installed into a single CMake export set.
+
+include(GNUInstallDirs)
+include(CMakePackageConfigHelpers)
+
+# Install location for the Swift CMake package (matches existing intent, but
+# uses CMAKE_INSTALL_LIBDIR for cross-platform correctness).
+set(SWIFT_INSTALL_PACKAGE_DIR "${CMAKE_INSTALL_LIBDIR}/cmake/swift")
+
+# Directory in the build tree where we stage the generated package files.
 set(swift_cmake_builddir "${SWIFT_BINARY_DIR}/${SWIFT_INSTALL_PACKAGE_DIR}")
 
-# Generate build-tree exports list only
-set(SWIFT_EXPORTS_FILE ${swift_cmake_builddir}/SwiftExports.cmake)
+# -----------------------------------------------------------------------------
+# Build-tree exports/config (kept for compatibility with existing behavior)
+# -----------------------------------------------------------------------------
+
+set(SWIFT_EXPORTS_FILE "${swift_cmake_builddir}/SwiftExports.cmake")
 get_property(SWIFT_EXPORTS GLOBAL PROPERTY SWIFT_EXPORTS)
 get_property(SWIFT_BUILDTREE_EXPORTS GLOBAL PROPERTY SWIFT_BUILDTREE_EXPORTS)
 
+# Export both "installing" and "build-tree-only" targets for build-tree usage.
 set(SWIFT_CONFIG_EXPORTS ${SWIFT_EXPORTS} ${SWIFT_BUILDTREE_EXPORTS})
-export(TARGETS ${SWIFT_CONFIG_EXPORTS} FILE ${SWIFT_EXPORTS_FILE})
+if(SWIFT_CONFIG_EXPORTS)
+  export(TARGETS ${SWIFT_CONFIG_EXPORTS} FILE "${SWIFT_EXPORTS_FILE}")
+endif()
 
-
-set(SWIFT_INCLUDE_DIRS ${SWIFT_INCLUDE_DIR} ${SWIFT_MAIN_INCLUDE_DIR} ${SWIFT_SHIMS_INCLUDE_DIR})
+# Generate a build-tree SwiftConfig.cmake as well (useful for in-tree consumers).
+# Keep existing SWIFT_CONFIG_CODE + version variables, but avoid hardcoding build
+# include/lib dirs into the installed package (the installed one is generated
+# separately below).
+#
+# For build-tree config, we preserve the previous values.
+set(SWIFT_INCLUDE_DIRS
+  ${SWIFT_INCLUDE_DIR}
+  ${SWIFT_MAIN_INCLUDE_DIR}
+  ${SWIFT_SHIMS_INCLUDE_DIR})
 set(SWIFT_LIBRARY_DIRS ${SWIFT_LIBRARY_OUTPUT_INTDIR})
 
 configure_file(
-  SwiftConfig.cmake.in
-  ${swift_cmake_builddir}/SwiftConfig.cmake
+  "${CMAKE_CURRENT_SOURCE_DIR}/SwiftConfig.cmake.in"
+  "${swift_cmake_builddir}/SwiftConfig.cmake"
   @ONLY)
+
+# -----------------------------------------------------------------------------
+# Install-tree package: SwiftConfig.cmake, SwiftConfigVersion.cmake, SwiftExports.cmake
+# -----------------------------------------------------------------------------
+
+# 1) Install-tree SwiftConfig.cmake must be relocatable.
+# We generate it into the build staging dir, then install it.
+#
+# IMPORTANT: This assumes SwiftConfig.cmake.in contains @PACKAGE_INIT@ and uses
+# PACKAGE_PREFIX_DIR for installed include/lib dirs, and includes
+# "${CMAKE_CURRENT_LIST_DIR}/SwiftExports.cmake".
+configure_package_config_file(
+  "${CMAKE_CURRENT_SOURCE_DIR}/SwiftConfig.cmake.in"
+  "${swift_cmake_builddir}/SwiftConfig.cmake.install"
+  INSTALL_DESTINATION "${SWIFT_INSTALL_PACKAGE_DIR}"
+  NO_SET_AND_CHECK_MACRO
+  NO_CHECK_REQUIRED_COMPONENTS_MACRO)
+
+write_basic_package_version_file(
+  "${swift_cmake_builddir}/SwiftConfigVersion.cmake"
+  VERSION "${SWIFT_VERSION}"
+  COMPATIBILITY SameMajorVersion)
+
+# Install config + version.
+swift_install_in_component(
+  FILES
+    "${swift_cmake_builddir}/SwiftConfig.cmake.install"
+    "${swift_cmake_builddir}/SwiftConfigVersion.cmake"
+  DESTINATION "${SWIFT_INSTALL_PACKAGE_DIR}"
+  COMPONENT dev)
+
+# Rename SwiftConfig.cmake.install -> SwiftConfig.cmake on install.
+# (CMake's install(FILES) does not rename, so install twice: once with RENAME.)
+swift_install_in_component(
+  FILES
+    "${swift_cmake_builddir}/SwiftConfig.cmake.install"
+  DESTINATION "${SWIFT_INSTALL_PACKAGE_DIR}"
+  COMPONENT dev
+  RENAME "SwiftConfig.cmake")
+
+# 2) Install-tree SwiftExports.cmake:
+# We cannot use install(EXPORT ...) because Swift's targets are not installed into
+# a single export set. Instead, generate the exports file during installation.
+#
+# This writes directly into: ${CMAKE_INSTALL_PREFIX}/${SWIFT_INSTALL_PACKAGE_DIR}/SwiftExports.cmake
+#
+# It exports only the targets recorded in the global SWIFT_EXPORTS property
+# (i.e. those meant to be part of the install).
+if(SWIFT_EXPORTS)
+  # Escape the list for embedding into install(CODE).
+  # We pass it as a CMake list literal.
+  string(REPLACE ";" "\\;" _SWIFT_EXPORTS_ESCAPED "${SWIFT_EXPORTS}")
+
+  swift_install_in_component(
+    CODE
+      "set(_swift_exports \"${_SWIFT_EXPORTS_ESCAPED}\")\n"
+      "if(_swift_exports)\n"
+      "  export(TARGETS \${_swift_exports} FILE \"\${CMAKE_INSTALL_PREFIX}/${SWIFT_INSTALL_PACKAGE_DIR}/SwiftExports.cmake\")\n"
+      "endif()\n"
+    COMPONENT dev)
+endif()

--- a/cmake/modules/CMakeLists.txt
+++ b/cmake/modules/CMakeLists.txt
@@ -29,24 +29,15 @@ if(SWIFT_CONFIG_EXPORTS)
   export(TARGETS ${SWIFT_CONFIG_EXPORTS} FILE "${SWIFT_EXPORTS_FILE}")
 endif()
 
-# -----------------------------------------------------------------------------
-# Install-tree exports file (generated in build dir, installed as a normal file)
-# -----------------------------------------------------------------------------
-set(SWIFT_EXPORTS_INSTALL_FILE "${swift_cmake_builddir}/SwiftExports.cmake")
-if(SWIFT_EXPORTS)
-  export(TARGETS ${SWIFT_EXPORTS} FILE "${SWIFT_EXPORTS_INSTALL_FILE}")
-  swift_install_in_component(
-      CODE
-        "set(_dest \"\")\n"
-        "if(DEFINED ENV{DESTDIR})\n"
-        "  set(_dest \"$ENV{DESTDIR}\")\n"
-        "endif()\n"
-        "set(_src \"${SWIFT_EXPORTS_INSTALL_FILE}\")\n"
-        "set(_dst \"\${_dest}\${CMAKE_INSTALL_PREFIX}/${SWIFT_INSTALL_PACKAGE_DIR}\")\n"
-        "file(MAKE_DIRECTORY \"\${_dst}\")\n"
-        "file(COPY \"\${_src}\" DESTINATION \"\${_dst_dir}\")\n"
-      COMPONENT dev)
-endif()
+# -------------------------
+# Install-tree exports file
+# -------------------------
+
+swift_install_in_component(
+  EXPORT SwiftTargets
+  DESTINATION "${SWIFT_INSTALL_PACKAGE_DIR}"
+  FILE "SwiftExports.cmake"
+  COMPONENT dev)
 
 # Generate a build-tree SwiftConfig.cmake as well (useful for in-tree consumers).
 # Keep existing SWIFT_CONFIG_CODE + version variables, but avoid hardcoding build

--- a/cmake/modules/CMakeLists.txt
+++ b/cmake/modules/CMakeLists.txt
@@ -103,7 +103,12 @@ if(SWIFT_EXPORTS)
     CODE
       "set(_swift_exports \"${_SWIFT_EXPORTS_ESCAPED}\")\n"
       "if(_swift_exports)\n"
-      "  export(TARGETS \${_swift_exports} FILE \"\${CMAKE_INSTALL_PREFIX}/${SWIFT_INSTALL_PACKAGE_DIR}/SwiftExports.cmake\")\n"
+      "  set(_dest \"\")\n"
+      "  if(DEFINED ENV{DESTDIR})\n"
+      "    set(_dest \"$ENV{DESTDIR}\")\n"
+      "  endif()\n"
+      "  file(MAKE_DIRECTORY \"\${_dest}\${CMAKE_INSTALL_PREFIX}/${SWIFT_INSTALL_PACKAGE_DIR}\")\n"
+      "  export(TARGETS \${_swift_exports} FILE \"\${_dest}\${CMAKE_INSTALL_PREFIX}/${SWIFT_INSTALL_PACKAGE_DIR}/SwiftExports.cmake\")\n"
       "endif()\n"
     COMPONENT dev)
 endif()

--- a/cmake/modules/CMakeLists.txt
+++ b/cmake/modules/CMakeLists.txt
@@ -20,12 +20,10 @@ set(swift_cmake_builddir "${SWIFT_BINARY_DIR}/${SWIFT_INSTALL_PACKAGE_DIR}")
 # Build-tree exports/config (kept for compatibility with existing behavior)
 # -----------------------------------------------------------------------------
 
-set(SWIFT_EXPORTS_FILE "${swift_cmake_builddir}/SwiftExports.cmake")
-set(SWIFT_EXPORTS_INSTALL_FILE "${swift_cmake_builddir}/SwiftExports-install.cmake")
+set(SWIFT_EXPORTS_FILE "${swift_cmake_builddir}/SwiftBuildTreeExports.cmake")
 get_property(SWIFT_EXPORTS GLOBAL PROPERTY SWIFT_EXPORTS)
 get_property(SWIFT_BUILDTREE_EXPORTS GLOBAL PROPERTY SWIFT_BUILDTREE_EXPORTS)
 
-# Export both "installing" and "build-tree-only" targets for build-tree usage.
 set(SWIFT_CONFIG_EXPORTS ${SWIFT_EXPORTS} ${SWIFT_BUILDTREE_EXPORTS})
 if(SWIFT_CONFIG_EXPORTS)
   export(TARGETS ${SWIFT_CONFIG_EXPORTS} FILE "${SWIFT_EXPORTS_FILE}")
@@ -34,13 +32,20 @@ endif()
 # -----------------------------------------------------------------------------
 # Install-tree exports file (generated in build dir, installed as a normal file)
 # -----------------------------------------------------------------------------
-#
-# Avoid install(CODE ...) to generate this file: install-time code does not
-# automatically respect DESTDIR staging. By generating it in the build tree and
-# installing it via swift_install_in_component(FILES ...), it will be staged
-# correctly under DESTDIR.
+set(SWIFT_EXPORTS_INSTALL_FILE "${swift_cmake_builddir}/SwiftExports.cmake")
 if(SWIFT_EXPORTS)
   export(TARGETS ${SWIFT_EXPORTS} FILE "${SWIFT_EXPORTS_INSTALL_FILE}")
+  swift_install_in_component(
+      CODE
+        "set(_dest \"\")\n"
+        "if(DEFINED ENV{DESTDIR})\n"
+        "  set(_dest \"$ENV{DESTDIR}\")\n"
+        "endif()\n"
+        "set(_src \"${SWIFT_EXPORTS_INSTALL_FILE}\")\n"
+        "set(_dst \"\${_dest}\${CMAKE_INSTALL_PREFIX}/${SWIFT_INSTALL_PACKAGE_DIR}\")\n"
+        "file(MAKE_DIRECTORY \"\${_dst}\")\n"
+        "file(COPY \"\${_src}\" DESTINATION \"\${_dst_dir}\")\n"
+      COMPONENT dev)
 endif()
 
 # Generate a build-tree SwiftConfig.cmake as well (useful for in-tree consumers).
@@ -60,9 +65,9 @@ configure_file(
   "${swift_cmake_builddir}/SwiftConfig.cmake"
   @ONLY)
 
-# -----------------------------------------------------------------------------
-# Install-tree package: SwiftConfig.cmake, SwiftConfigVersion.cmake, SwiftExports.cmake
-# -----------------------------------------------------------------------------
+# -----------------------------------------------------------------
+# Install-tree package: SwiftConfig.cmake, SwiftConfigVersion.cmake
+# -----------------------------------------------------------------
 
 # 1) Install-tree SwiftConfig.cmake must be relocatable.
 # We generate it into the build staging dir, then install it.
@@ -85,7 +90,6 @@ write_basic_package_version_file(
 # Install config + version.
 swift_install_in_component(
   FILES
-    "${SWIFT_EXPORTS_INSTALL_FILE}"
     "${swift_cmake_builddir}/SwiftConfig.cmake.install"
     "${swift_cmake_builddir}/SwiftConfigVersion.cmake"
   DESTINATION "${SWIFT_INSTALL_PACKAGE_DIR}"
@@ -100,11 +104,3 @@ swift_install_in_component(
   COMPONENT dev
   RENAME "SwiftConfig.cmake")
 
-# Rename SwiftExports.cmake.install -> SwiftExports.cmake on install.
-# (CMake's install(FILES) does not rename, so install twice: once with RENAME.)
-swift_install_in_component(
-  FILES
-    "${SWIFT_EXPORTS_INSTALL_FILE}"
-  DESTINATION "${SWIFT_INSTALL_PACKAGE_DIR}"
-  COMPONENT dev
-  RENAME "SwiftExports.cmake")

--- a/cmake/modules/SwiftConfig.cmake.in
+++ b/cmake/modules/SwiftConfig.cmake.in
@@ -1,5 +1,10 @@
 # This file provides information and services to the final user.
 
+# When this file is generated for installation using CMakePackageConfigHelpers,
+# @PACKAGE_INIT@ sets up PACKAGE_PREFIX_DIR and other helpers so the package is
+# relocatable.
+@PACKAGE_INIT@
+
 @SWIFT_CONFIG_CODE@
 
 set(SWIFT_VERSION_MAJOR @SWIFT_VERSION_MAJOR@)
@@ -7,28 +12,73 @@ set(SWIFT_VERSION_MINOR @SWIFT_VERSION_MINOR@)
 set(SWIFT_VERSION_PATCH @SWIFT_VERSION_PATCHLEVEL@)
 
 set(SWIFT_VERSION @SWIFT_VERSION@)
-set(SWIFT_MAIN_SRC_DIR @SWIFT_SOURCE_DIR@)
 
-set(SWIFT_INCLUDE_DIRS "@SWIFT_INCLUDE_DIRS@")
-set(SWIFT_LIBRARY_DIRS "@SWIFT_LIBRARY_DIRS@")
+# NOTE:
+# - In the build tree, SWIFT_MAIN_SRC_DIR is meaningful.
+# - In an installed package, pointing to the original source dir is usually not
+#   useful and may not exist. Keep it only for build-tree usage.
+if(DEFINED SWIFT_SOURCE_DIR AND EXISTS "@SWIFT_SOURCE_DIR@")
+  set(SWIFT_MAIN_SRC_DIR @SWIFT_SOURCE_DIR@)
+endif()
+
+# -----------------------------------------------------------------------------
+# Include / library directories
+# -----------------------------------------------------------------------------
+# Build-tree generation (configure_file) will substitute @SWIFT_INCLUDE_DIRS@ and
+# @SWIFT_LIBRARY_DIRS@ with build paths.
+#
+# Install-tree generation (configure_package_config_file) should be relocatable,
+# so prefer PACKAGE_PREFIX_DIR-based paths when PACKAGE_PREFIX_DIR is available.
+if(DEFINED PACKAGE_PREFIX_DIR)
+  set(SWIFT_INCLUDE_DIRS "${PACKAGE_PREFIX_DIR}/@CMAKE_INSTALL_INCLUDEDIR@")
+  set(SWIFT_LIBRARY_DIRS "${PACKAGE_PREFIX_DIR}/@CMAKE_INSTALL_LIBDIR@")
+else()
+  set(SWIFT_INCLUDE_DIRS "@SWIFT_INCLUDE_DIRS@")
+  set(SWIFT_LIBRARY_DIRS "@SWIFT_LIBRARY_DIRS@")
+endif()
 
 # These variables are duplicated, but they must match the LLVM variables of the
 # same name. The variables ending in "S" could some day become lists, and are
 # preserved for convention and compatibility.
-set(SWIFT_INCLUDE_DIR "@SWIFT_INCLUDE_DIRS@")
-set(SWIFT_LIBRARY_DIR "@SWIFT_LIBRARY_DIRS@")
+set(SWIFT_INCLUDE_DIR "${SWIFT_INCLUDE_DIRS}")
+set(SWIFT_LIBRARY_DIR "${SWIFT_LIBRARY_DIRS}")
 
-set(SWIFT_CMAKE_DIR "@SWIFT_CMAKE_DIR@")
+# -----------------------------------------------------------------------------
+# Misc metadata
+# -----------------------------------------------------------------------------
+# For installed packages, the canonical "cmake dir" is the directory containing
+# this file.
+set(SWIFT_CMAKE_DIR "${CMAKE_CURRENT_LIST_DIR}")
+
+# SWIFT_BINARY_DIR is only meaningful for build-tree usage; keep the old value
+# for build-tree config generation, but do not rely on it when installed.
 set(SWIFT_BINARY_DIR "@SWIFT_BINARY_DIR@")
 
 set(BOOTSTRAPPING_MODE "@BOOTSTRAPPING_MODE@")
 
+# -----------------------------------------------------------------------------
+# Optional dependency: cmark targets from the build tree (only if present)
+# -----------------------------------------------------------------------------
 set(CMARK_TARGETS_FILE @SWIFT_PATH_TO_CMARK_BUILD@/src/cmarkTargets.cmake)
 if(NOT TARGET libcmark_static AND EXISTS ${CMARK_TARGETS_FILE})
   include(${CMARK_TARGETS_FILE})
 endif()
 
+# -----------------------------------------------------------------------------
+# Swift exported targets
+# -----------------------------------------------------------------------------
+# Build-tree config: @SWIFT_EXPORTS_FILE@ points at the build-tree generated file.
+# Install-tree config: SwiftExports.cmake is installed next to this config file.
+#
+# Keep the "if(NOT TARGET swift)" behavior to avoid re-importing.
 if(NOT TARGET swift)
+  # Maintain compatibility variable used by some consumers.
   set(SWIFT_EXPORTED_TARGETS "@SWIFT_CONFIG_EXPORTS@")
-  include("@SWIFT_EXPORTS_FILE@")
+
+  if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/SwiftExports.cmake")
+    include("${CMAKE_CURRENT_LIST_DIR}/SwiftExports.cmake")
+  else()
+    include("@SWIFT_EXPORTS_FILE@")
+  endif()
 endif()
+

--- a/cmake/modules/SwiftConfig.cmake.in
+++ b/cmake/modules/SwiftConfig.cmake.in
@@ -17,7 +17,7 @@ set(SWIFT_VERSION @SWIFT_VERSION@)
 # - In the build tree, SWIFT_MAIN_SRC_DIR is meaningful.
 # - In an installed package, pointing to the original source dir is usually not
 #   useful and may not exist. Keep it only for build-tree usage.
-if(DEFINED SWIFT_SOURCE_DIR AND EXISTS "@SWIFT_SOURCE_DIR@")
+if(NOT DEFINED PACKAGE_PREFIX_DIR AND DEFINED SWIFT_SOURCE_DIR AND EXISTS "@SWIFT_SOURCE_DIR@")
   set(SWIFT_MAIN_SRC_DIR @SWIFT_SOURCE_DIR@)
 endif()
 
@@ -52,16 +52,20 @@ set(SWIFT_CMAKE_DIR "${CMAKE_CURRENT_LIST_DIR}")
 
 # SWIFT_BINARY_DIR is only meaningful for build-tree usage; keep the old value
 # for build-tree config generation, but do not rely on it when installed.
-set(SWIFT_BINARY_DIR "@SWIFT_BINARY_DIR@")
+if(NOT DEFINED PACKAGE_PREFIX_DIR)
+  set(SWIFT_BINARY_DIR "@SWIFT_BINARY_DIR@")
+endif()
 
 set(BOOTSTRAPPING_MODE "@BOOTSTRAPPING_MODE@")
 
 # -----------------------------------------------------------------------------
 # Optional dependency: cmark targets from the build tree (only if present)
 # -----------------------------------------------------------------------------
-set(CMARK_TARGETS_FILE @SWIFT_PATH_TO_CMARK_BUILD@/src/cmarkTargets.cmake)
-if(NOT TARGET libcmark_static AND EXISTS ${CMARK_TARGETS_FILE})
-  include(${CMARK_TARGETS_FILE})
+if(NOT DEFINED PACKAGE_PREFIX_DIR)
+  set(CMARK_TARGETS_FILE @SWIFT_PATH_TO_CMARK_BUILD@/src/cmarkTargets.cmake)
+  if(NOT TARGET libcmark_static AND EXISTS ${CMARK_TARGETS_FILE})
+    include(${CMARK_TARGETS_FILE})
+  endif()
 endif()
 
 # -----------------------------------------------------------------------------
@@ -77,7 +81,7 @@ if(NOT TARGET swift)
 
   if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/SwiftExports.cmake")
     include("${CMAKE_CURRENT_LIST_DIR}/SwiftExports.cmake")
-  else()
+  elseif(NOT DEFINED PACKAGE_PREFIX_DIR)
     include("@SWIFT_EXPORTS_FILE@")
   endif()
 endif()

--- a/lib/CompilerSwiftSyntax/CMakeLists.txt
+++ b/lib/CompilerSwiftSyntax/CMakeLists.txt
@@ -59,7 +59,14 @@ foreach(lib ${compiler_swiftsyntax_libs})
 endforeach()
 
 swift_install_in_component(TARGETS ${compiler_swiftsyntax_libs}
+  EXPORT SwiftTargets
   ARCHIVE DESTINATION "lib${LLVM_LIBDIR_SUFFIX}/swift/host/compiler" COMPONENT compiler-swift-syntax-lib
   LIBRARY DESTINATION "lib${LLVM_LIBDIR_SUFFIX}/swift/host/compiler" COMPONENT compiler-swift-syntax-lib
   RUNTIME DESTINATION "bin" COMPONENT compiler-swift-syntax-lib)
+
+# Also register them in SWIFT_EXPORTS so the build-tree export includes them:
+foreach(_lib ${compiler_swiftsyntax_libs})
+  set_property(GLOBAL APPEND PROPERTY SWIFT_EXPORTS ${_lib})
+endforeach()
+
 add_dependencies(compiler-swift-syntax-lib ${compiler_swiftsyntax_libs})

--- a/lib/SwiftSyntax/CMakeLists.txt
+++ b/lib/SwiftSyntax/CMakeLists.txt
@@ -66,9 +66,13 @@ if(CMAKE_SYSTEM_NAME MATCHES Windows)
                              COMPONENT swift-syntax-lib)
 else()
   swift_install_in_component(TARGETS ${SWIFT_SYNTAX_MODULES}
+                             EXPORT SwiftTargets
                              LIBRARY
                              DESTINATION "lib${LLVM_LIBDIR_SUFFIX}/swift/host"
                              COMPONENT swift-syntax-lib)
+  foreach(_mod ${SWIFT_SYNTAX_MODULES})
+    set_property(GLOBAL APPEND PROPERTY SWIFT_EXPORTS ${_mod})
+  endforeach()
 endif()
 
 # Install import libraries in Windows.


### PR DESCRIPTION
We are currently integrating the Swift compiler as a library in a project. However, the CMake configuration files and targets, while generated and installed in the build tree, are not installed in the install tree. This prevents find_package from locating the Swift compiler in the install tree.

When creating a Swift package for a package manager, we could enable downstream projects to use find_package on the installed package, eliminating the need to build Swift from source and rely on the build tree.

The current setup makes it quite cumbersome to iterate on a build in a Docker image:
- The Swift and llvm-project repositories are huge (more than 6G to clone for the latter) and GitHub applies IP-based throttling when it detects excessive cloning of large repositories, often leading to timeouts.
- The build takes almost 1 hour to complete on a recent computer
- The final image is huge (around 90G), making it hard to ship.

This PR is an on-going work to address these issues by generating targets and exports in the install-tree. This will:
 - Simplify Swift packaging, allowing downstream projects to require it directly.
 - Reduce iteration time by eliminating the need to:
   - Clone large repositories.
   - Build LLVM, Clang, and Swift from source.
 - Eventually remove the need for a Docker image, as the package can be consumed directly from a package manager.

cc @SylvainCorlay @bigsur0
