### PR TITLE
Add large InlineArray validation test

### DIFF
--- a/validation-test/SILOptimizer/large_inline_array.swift.gyb
+++ b/validation-test/SILOptimizer/large_inline_array.swift.gyb
@@ -1,0 +1,37 @@
+// RUN: %empty-directory(%t)
+// RUN: %gyb %s > %t/main.swift
+
+// rdar://175803465 (Large InlineArray compilation takes forever)
+// UNSUPPORTED: OS=linux-gnu
+
+// The compiler should finish in less than 15 seconds. To give some slack,
+// specify a timeout of 1 minute.
+// If the compiler needs more than 1 minute, there is probably a real problem.
+// So please don't just increase the timeout in case this fails.
+
+// We emit assembly rather than SIL because the bottleneck in rdar://175803465
+// was LLVM machine code generation.
+
+// RUN: %{python} %S/../../test/Inputs/timeout.py 15 %target-swift-frontend -O -parse-as-library -disable-availability-checking -S %t/main.swift | %FileCheck %s
+
+// There is a separate test for an assert-enabled stdlib
+// REQUIRES: swift_stdlib_no_asserts,optimized_stdlib
+
+// REQUIRES: long_test
+// REQUIRES: CPU=arm64 || CPU=x86_64 || CPU=aarch64
+
+// Check if the optimizer can optimize the whole array into a statically
+// initialized global
+
+// CHECK: $s4main3arrs11InlineArrayVy$99999_SiGvp:
+// CHECK-NEXT: 8
+// CHECK-NEXT: 1
+// CHECK-NEXT: 2
+
+public let arr: InlineArray<100000, Int> = [
+
+% for i in range(100000):
+  ${i},
+%end
+
+]


### PR DESCRIPTION
This validates that InitializeStaticGlobals correctly folds an initializer list for a global InlineArray to a static value.

Validate that a slow compilation reported in 6.2.3 is fixed in 6.3 (thanks to https://github.com/swiftlang/swift/pull/81649):
rdar://175803465 (Large InlineArray compilation takes forever)
<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
