### PR TITLE
[windows] install PDB files in the usr/bin directory

### DIFF
--- a/cmake/modules/AddPureSwift.cmake
+++ b/cmake/modules/AddPureSwift.cmake
@@ -506,6 +506,12 @@ function(add_pure_swift_host_tool name)
     swift_install_in_component(TARGETS ${name}
       COMPONENT ${APSHT_SWIFT_COMPONENT}
       RUNTIME DESTINATION bin)
+    if(MSVC)
+      swift_install_in_component(FILES $<TARGET_FILE_DIR:${name}>/$<TARGET_FILE_BASE_NAME:${name}>.pdb
+        DESTINATION bin
+        COMPONENT ${APSHT_SWIFT_COMPONENT}
+        OPTIONAL)
+    endif()
     swift_is_installing_component(${APSHT_SWIFT_COMPONENT} is_installing)
   endif()
 

--- a/cmake/modules/AddPureSwift.cmake
+++ b/cmake/modules/AddPureSwift.cmake
@@ -541,6 +541,12 @@ function(add_pure_swift_host_tool name)
     swift_install_in_component(TARGETS ${name}
       COMPONENT ${APSHT_SWIFT_COMPONENT}
       RUNTIME DESTINATION bin)
+    if(CMAKE_Swift_LINKER_SUPPORTS_PDB)
+      swift_install_in_component(FILES $<TARGET_PDB_FILE:${name}>
+        DESTINATION bin
+        COMPONENT ${APSHT_SWIFT_COMPONENT}
+        OPTIONAL)
+    endif()
     swift_is_installing_component(${APSHT_SWIFT_COMPONENT} is_installing)
   endif()
 

--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -865,6 +865,12 @@ function(add_swift_host_library name)
       ARCHIVE DESTINATION lib${LLVM_LIBDIR_SUFFIX} COMPONENT dev
       LIBRARY DESTINATION lib${LLVM_LIBDIR_SUFFIX} COMPONENT dev
       RUNTIME DESTINATION bin COMPONENT dev)
+    if(MSVC)
+      swift_install_in_component(FILES $<TARGET_FILE_DIR:${name}>/$<TARGET_FILE_BASE_NAME:${name}>.pdb
+        DESTINATION bin
+        COMPONENT dev
+        OPTIONAL)
+    endif()
   endif()
 
   swift_is_installing_component(dev is_installing)
@@ -1059,6 +1065,12 @@ function(add_swift_host_tool executable)
                                  DESTINATION bin
                                  COMPONENT ${ASHT_SWIFT_COMPONENT}
     )
+    if(MSVC)
+      swift_install_in_component(FILES $<TARGET_FILE_DIR:${executable}>/$<TARGET_FILE_BASE_NAME:${executable}>.pdb
+                                 DESTINATION bin
+                                 COMPONENT ${ASHT_SWIFT_COMPONENT}
+                                 OPTIONAL)
+    endif()
 
     swift_is_installing_component(${ASHT_SWIFT_COMPONENT} is_installing)
   endif()

--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -877,6 +877,12 @@ function(add_swift_host_library name)
       ARCHIVE DESTINATION lib${LLVM_LIBDIR_SUFFIX} COMPONENT dev
       LIBRARY DESTINATION lib${LLVM_LIBDIR_SUFFIX} COMPONENT dev
       RUNTIME DESTINATION bin COMPONENT dev)
+    if(ASHL_SHARED AND CMAKE_CXX_LINKER_SUPPORTS_PDB)
+      swift_install_in_component(FILES $<TARGET_PDB_FILE:${name}>
+        DESTINATION bin
+        COMPONENT dev
+        OPTIONAL)
+    endif()
   endif()
 
   swift_is_installing_component(dev is_installing)
@@ -1071,6 +1077,12 @@ function(add_swift_host_tool executable)
                                  DESTINATION bin
                                  COMPONENT ${ASHT_SWIFT_COMPONENT}
     )
+    if(CMAKE_CXX_LINKER_SUPPORTS_PDB)
+      swift_install_in_component(FILES $<TARGET_PDB_FILE:${executable}>
+                                  DESTINATION bin
+                                  COMPONENT ${ASHT_SWIFT_COMPONENT}
+                                  OPTIONAL)
+    endif()
 
     swift_is_installing_component(${ASHT_SWIFT_COMPONENT} is_installing)
   endif()

--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -2813,6 +2813,12 @@ function(add_swift_target_library name)
                                      DESTINATION "lib${LLVM_LIBDIR_SUFFIX}/${resource_dir}/${resource_dir_sdk_subdir}/${SWIFT_PRIMARY_VARIANT_ARCH}"
                                      COMPONENT "${SWIFTLIB_INSTALL_IN_COMPONENT}"
                                    PERMISSIONS ${file_permissions})
+        if(MSVC)
+          swift_install_in_component(FILES $<TARGET_FILE_DIR:${name}-windows-${SWIFT_PRIMARY_VARIANT_ARCH}>/$<TARGET_FILE_BASE_NAME:${name}-windows-${SWIFT_PRIMARY_VARIANT_ARCH}>.pdb
+                                     DESTINATION "bin"
+                                     COMPONENT "${SWIFTLIB_INSTALL_IN_COMPONENT}"
+                                     OPTIONAL)
+        endif()
       else()
         # NOTE: ${UNIVERSAL_LIBRARY_NAME} is the output associated with the target
         # ${lipo_target}
@@ -3515,6 +3521,14 @@ function(add_swift_target_executable name)
                                  OWNER_READ OWNER_WRITE OWNER_EXECUTE
                                  GROUP_READ GROUP_EXECUTE
                                  WORLD_READ WORLD_EXECUTE)
+    if(MSVC AND "${sdk}" STREQUAL "WINDOWS")
+      get_filename_component(_pdb_dir ${UNIVERSAL_NAME} DIRECTORY)
+      get_filename_component(_pdb_base ${UNIVERSAL_NAME} NAME_WE)
+      swift_install_in_component(FILES "${_pdb_dir}/${_pdb_base}.pdb"
+                                 DESTINATION ${install_dest}
+                                 COMPONENT "${install_in_component}"
+                                 OPTIONAL)
+    endif()
 
     swift_is_installing_component(
       "${install_in_component}"

--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -2968,6 +2968,13 @@ function(add_swift_target_library name)
                                      DESTINATION "lib${LLVM_LIBDIR_SUFFIX}/${resource_dir}/${resource_dir_sdk_subdir}/${SWIFT_PRIMARY_VARIANT_ARCH}"
                                      COMPONENT "${SWIFTLIB_INSTALL_IN_COMPONENT}"
                                    PERMISSIONS ${file_permissions})
+        if(SWIFTLIB_SHARED AND NOT SWIFT_SDK_${sdk}_STATIC_ONLY AND
+           CMAKE_CXX_LINKER_SUPPORTS_PDB)
+          swift_install_in_component(FILES $<TARGET_PDB_FILE:${name}-windows-${SWIFT_PRIMARY_VARIANT_ARCH}>
+                                     DESTINATION "bin"
+                                     COMPONENT "${SWIFTLIB_INSTALL_IN_COMPONENT}"
+                                     OPTIONAL)
+        endif()
       else()
         # NOTE: ${UNIVERSAL_LIBRARY_NAME} is the output associated with the target
         # ${lipo_target}
@@ -3674,6 +3681,14 @@ function(add_swift_target_executable name)
                                  OWNER_READ OWNER_WRITE OWNER_EXECUTE
                                  GROUP_READ GROUP_EXECUTE
                                  WORLD_READ WORLD_EXECUTE)
+    set(primary_variant_name "${name}-${SWIFT_SDK_${sdk}_LIB_SUBDIR}-${SWIFT_PRIMARY_VARIANT_ARCH}")
+    if(sdk STREQUAL "WINDOWS" AND TARGET ${primary_variant_name} AND
+       CMAKE_CXX_LINKER_SUPPORTS_PDB)
+      swift_install_in_component(FILES $<TARGET_PDB_FILE:${primary_variant_name}>
+                                 DESTINATION ${install_dest}
+                                 COMPONENT "${install_in_component}"
+                                 OPTIONAL)
+    endif()
 
     swift_is_installing_component(
       "${install_in_component}"

--- a/tools/SourceKit/cmake/modules/AddSwiftSourceKit.cmake
+++ b/tools/SourceKit/cmake/modules/AddSwiftSourceKit.cmake
@@ -314,6 +314,12 @@ macro(add_sourcekit_library name)
     RUNTIME
       DESTINATION "bin"
       COMPONENT "${SOURCEKITLIB_INSTALL_IN_COMPONENT}")
+  if(MSVC)
+    swift_install_in_component(FILES $<TARGET_FILE_DIR:${name}>/$<TARGET_FILE_BASE_NAME:${name}>.pdb
+                               DESTINATION bin
+                               COMPONENT "${SOURCEKITLIB_INSTALL_IN_COMPONENT}"
+                               OPTIONAL)
+  endif()
 
   swift_install_in_component(FILES ${SOURCEKITLIB_HEADERS}
                              DESTINATION "include/SourceKit"

--- a/tools/SourceKit/cmake/modules/AddSwiftSourceKit.cmake
+++ b/tools/SourceKit/cmake/modules/AddSwiftSourceKit.cmake
@@ -314,6 +314,12 @@ macro(add_sourcekit_library name)
     RUNTIME
       DESTINATION "bin"
       COMPONENT "${SOURCEKITLIB_INSTALL_IN_COMPONENT}")
+  if((SOURCEKITLIB_SHARED OR SOURCEKITLIB_MODULE) AND CMAKE_CXX_LINKER_SUPPORTS_PDB)
+    swift_install_in_component(FILES $<TARGET_PDB_FILE:${name}>
+                               DESTINATION bin
+                               COMPONENT "${SOURCEKITLIB_INSTALL_IN_COMPONENT}"
+                               OPTIONAL)
+  endif()
 
   swift_install_in_component(FILES ${SOURCEKITLIB_HEADERS}
                              DESTINATION "include/SourceKit"

--- a/tools/swift-inspect/CMakeLists.txt
+++ b/tools/swift-inspect/CMakeLists.txt
@@ -110,7 +110,17 @@ endif()
 
 install(TARGETS swift-inspect
   DESTINATION bin)
+if(MSVC)
+  install(FILES $<TARGET_FILE_DIR:swift-inspect>/$<TARGET_FILE_BASE_NAME:swift-inspect>.pdb
+    DESTINATION bin
+    OPTIONAL)
+endif()
 if(WIN32)
   install(TARGETS SwiftInspectClient
     RUNTIME DESTINATION bin)
+  if(MSVC)
+    install(FILES $<TARGET_FILE_DIR:SwiftInspectClient>/$<TARGET_FILE_BASE_NAME:SwiftInspectClient>.pdb
+      DESTINATION bin
+      OPTIONAL)
+  endif()
 endif()

--- a/tools/swift-inspect/CMakeLists.txt
+++ b/tools/swift-inspect/CMakeLists.txt
@@ -110,7 +110,17 @@ endif()
 
 install(TARGETS swift-inspect
   DESTINATION bin)
+if(CMAKE_Swift_LINKER_SUPPORTS_PDB)
+  install(FILES $<TARGET_PDB_FILE:swift-inspect>
+    DESTINATION bin
+    OPTIONAL)
+endif()
 if(WIN32)
   install(TARGETS SwiftInspectClient
     RUNTIME DESTINATION bin)
+  if(CMAKE_CXX_LINKER_SUPPORTS_PDB)
+    install(FILES $<TARGET_PDB_FILE:SwiftInspectClient>
+      DESTINATION bin
+      OPTIONAL)
+  endif()
 endif()


### PR DESCRIPTION
Currently, toolchain PDB files are emitted in the `T:\5\bin` directory. This patch edits the `install` target to install the files alongside their binaries instead: `T:\Program Files\Swift\Toolchains\0.0.0+Asserts\usr\bin`.

This is the first of a series of patches which will group all PDB files in the `usr/bin` directory, allowing us to easily host the PDBs on a debug symbol server.

This is part of https://github.com/swiftlang/swift/issues/88869.