### PR TITLE
[DebugInfo] Add op_deref to all alloc_stacks and debug_value pointing to alloc_stacks

### DIFF
--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -46,6 +46,7 @@
 #include "swift/Strings.h"
 #include "llvm/ADT/APFloat.h"
 #include "llvm/ADT/APInt.h"
+#include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/ilist.h"
@@ -2202,8 +2203,16 @@ public:
     else if (complete)
       VarDeclScope = getDebugScope();
 
+    // An alloc_stack always has a single implicit op_deref.
+    // It is not returned with complete = false, so that it isn't printed.
+    static const SILDIExprElement SingleDeref[] = {
+        SILDIExprElement::createOperator(SILDIExprOperator::Dereference)};
+    llvm::ArrayRef<SILDIExprElement> VarDIExpr = {};
+    if (complete)
+      VarDIExpr = SingleDeref;
+
     return VarInfo.get(getDecl(), getTrailingObjects<char>(), AuxVarType,
-                       VarDeclLoc, VarDeclScope, {});
+                       VarDeclLoc, VarDeclScope, VarDIExpr);
   }
 
   /// True if this AllocStack has var info that a pass purposely invalidated.

--- a/lib/IRGen/AllocStackHoisting.cpp
+++ b/lib/IRGen/AllocStackHoisting.cpp
@@ -199,8 +199,8 @@ void Partition::assignStackLocation(
     AllocStack->replaceAllUsesWith(AssignedLoc);
     if (auto VarInfo = AllocStack->getVarInfo()) {
       SILBuilder Builder(AllocStack, AllocStack->getDebugScope());
-      auto *DVI = Builder.createDebugValueAddr(AllocStack->getLoc(),
-                                               AssignedLoc, *VarInfo);
+      auto *DVI = Builder.createDebugValue(AllocStack->getLoc(),
+                                           AssignedLoc, *VarInfo);
       if (hasAtLeastOneMovedElt) {
         DVI->setUsesMoveableValueDebugInfo();
       }

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -6264,12 +6264,21 @@ void IRGenSILFunction::visitDebugValueInst(DebugValueInst *i) {
                            i->usesMoveableValueDebugInfo(), Copy);
   }
 
+  // For alloc_stack operands, createAddr now adds op_deref for SIL-level
+  // uniformity, but IRGen still handles alloc_stack addresses the same as
+  // before (no op_deref in the LLVM expression). Strip the op_deref here
+  // so the emitted LLVM IR is unchanged.
+  SILDebugVariable AdjustedVarInfo = *VarInfo;
+  if (IsAddrVal && isa<AllocStackInst>(SILVal) &&
+      AdjustedVarInfo.DIExpr.startsWithDeref())
+    AdjustedVarInfo.DIExpr.eraseElement(AdjustedVarInfo.DIExpr.element_begin());
+
   bindArchetypes(DbgTy.getType());
   if (!IGM.DebugInfo)
     return;
 
   emitDebugVariableDeclaration(
-      Copy, DbgTy, SILTy, i->getDebugScope(), i->getLoc(), *VarInfo,
+      Copy, DbgTy, SILTy, i->getDebugScope(), i->getLoc(), AdjustedVarInfo,
       Indirection, AddrDbgInstrKind(i->usesMoveableValueDebugInfo()));
 }
 

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -6694,6 +6694,11 @@ void IRGenSILFunction::emitDebugInfoAfterAllocStack(AllocStackInst *i,
       i->getDebugScope()->getInlinedFunction()->isTransparent())
     return;
 
+  // The alloc_stack's VarInfo is a single op_deref, but for IRGen the
+  // indirection is already expressed by using llvm.dbg.declare on the
+  // alloca address. Strip the op_deref to avoid a double-dereference.
+  VarInfo->DIExpr = {};
+
   VarDecl *Decl = i->getDecl();
   auto *DS = i->getDebugScope();
 

--- a/lib/SIL/IR/SILInstructions.cpp
+++ b/lib/SIL/IR/SILInstructions.cpp
@@ -475,11 +475,8 @@ DebugValueInst *
 DebugValueInst::createAddr(SILDebugLocation DebugLoc, SILValue Operand,
                            SILModule &M, SILDebugVariable Var,
                            UsesMoveableValueDebugInfo_t wasMoved, bool trace) {
-  // For alloc_stack, debug_value is used to annotate the associated
-  // memory location, so we shouldn't attach op_deref.
-  if (!isa<AllocStackInst>(Operand))
-    Var.DIExpr.prependElements(
-      {SILDIExprElement::createOperator(SILDIExprOperator::Dereference)});
+  Var.DIExpr.prependElements(
+    {SILDIExprElement::createOperator(SILDIExprOperator::Dereference)});
   return DebugValueInst::create(DebugLoc, Operand, M, Var, DontPoisonRefs,
                                 wasMoved, trace);
 }

--- a/lib/SILOptimizer/Mandatory/CapturePromotion.cpp
+++ b/lib/SILOptimizer/Mandatory/CapturePromotion.cpp
@@ -592,6 +592,12 @@ void ClosureCloner::visitDebugValueInst(DebugValueInst *inst) {
       auto varInfo = *inst->getVarInfo();
       if (varInfo.Scope)
         varInfo.Scope = getOpScope(inst->getDebugScope());
+      // The promoted value is now an object, strip the op_deref.
+      // If there is no op_deref, the variable is unsalvageable and dropped.
+      // This should never happen, as it is invalid debug info.
+      if (!varInfo.DIExpr.startsWithDeref())
+        return;
+      varInfo.DIExpr.eraseElement(varInfo.DIExpr.element_begin());
       getBuilder().createDebugValue(inst->getLoc(), value, varInfo);
       return;
     }

--- a/lib/SILOptimizer/Transforms/DeadObjectElimination.cpp
+++ b/lib/SILOptimizer/Transforms/DeadObjectElimination.cpp
@@ -865,6 +865,8 @@ void DeadObjectElimination::salvageDebugInfo(SILInstruction *toBeRemoved) {
   if (!SI)
     return;
 
+  // TODO: this logic should be merged with the regular salvageDebugInfo.
+  // debug_value on the alloc_stack are not handled?
   auto *parent = SI->getDest()->getDefiningInstruction();
   auto varInfo = buildDIExpression(parent);
   if (!varInfo)
@@ -887,6 +889,10 @@ DeadObjectElimination::buildDIExpression(SILInstruction *current) {
       return {};
     if (!var->Type)
       var->Type = dvci->getElementType();
+    // Strip op_deref: we are salvaging an element being stored.
+    // Note: as this is an AllocStackInst, the DIExpr is always
+    // a single op_deref.
+    var->DIExpr = {};
     return var;
   }
   if (auto *tupleAddr = dyn_cast<TupleElementAddrInst>(current)) {

--- a/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
+++ b/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
@@ -1982,10 +1982,9 @@ void MemoryToRegisters::removeSingleBlockAllocation(AllocStackInst *asi) {
                                   /*replacement=*/initialValue),
             /*isStorageValid=*/!doesLoadInvalidateStorage(inst)};
         if (auto var = asi->getVarInfo()) {
-          SILBuilder Builder(inst, ctx);
-          // Force the debug_value to be in the same scope as the alloc_stack
-          // so it refers to the correct variable.
-          Builder.setCurrentDebugScope(asi->getDebugScope());
+          // Remove the implicit op_deref, as it is no longer on the stack.
+          var->DIExpr = {};
+          SILBuilder Builder(inst, ctx, asi->getDebugScope());
           Builder.createDebugValue(inst->getLoc(), initialValue, *var);
         }
       }

--- a/lib/SILOptimizer/Utils/InstOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/InstOptUtils.cpp
@@ -1923,12 +1923,19 @@ static void transferStoreDebugValue(DebugVarCarryingInst DefiningInst,
   auto VarInfo = DefiningInst.getVarInfo();
   if (!VarInfo)
     return;
-  // Fix the op_deref.
-  if (!isa<CopyAddrInst>(SI) && VarInfo->DIExpr.startsWithDeref())
+  // The debug variable being stored to must describe an address, and have an
+  // op_deref. This creates a debug_value for the stored value itself:
+  // strip the leading op_deref.
+  if (VarInfo->DIExpr.startsWithDeref()) {
     VarInfo->DIExpr.eraseElement(VarInfo->DIExpr.element_begin());
-  else if (isa<CopyAddrInst>(SI) && !VarInfo->DIExpr.startsWithDeref())
-    VarInfo->DIExpr.prependElements({
-      SILDIExprElement::createOperator(SILDIExprOperator::Dereference)});
+  } else if (isa<DebugValueInst>(*DefiningInst)) {
+    // If there is no op_deref, drop the debug_value as unsalvageable: the
+    // address is unknown, only the value remains.
+    // This would only happen if salvaging pointer types was supported, which
+    // is not the case. The verifier should catch invalid debug info,
+    // so this should be unreachable.
+    return;
+  }
   // Note: The instruction should logically be in the SI's scope.
   // However, LLVM does not support variables and stores in different scopes,
   // so we use the variable's scope.

--- a/test/Concurrency/silisolationinfo_inference.sil
+++ b/test/Concurrency/silisolationinfo_inference.sil
@@ -1184,7 +1184,7 @@ bb0(%0 : @guaranteed $MainActorIsolatedStruct):
 sil [ossa] @test_globalactor_inference_on_nominal_field_globalactorstruct_addr : $@convention(thin) (@in_guaranteed MainActorIsolatedStruct) -> () {
 bb0(%0 : $*MainActorIsolatedStruct):
   specify_test "sil_isolation_info_inference @trace[0]"
-  debug_value %0 : $*MainActorIsolatedStruct, let, name "self"
+  debug_value %0 : $*MainActorIsolatedStruct, let, name "self", expr op_deref
   %1 = struct_element_addr %0 : $*MainActorIsolatedStruct, #MainActorIsolatedStruct.ns
   debug_value [trace] %1
   %9999 = tuple ()
@@ -1198,7 +1198,7 @@ bb0(%0 : $*MainActorIsolatedStruct):
 sil [ossa] @test_globalactor_inference_on_nominal_field_globalactorstruct_addr_globalactor : $@convention(thin) (@in_guaranteed MainActorIsolatedStruct) -> () {
 bb0(%0 : $*MainActorIsolatedStruct):
   specify_test "sil_isolation_info_inference @trace[0]"
-  debug_value %0 : $*MainActorIsolatedStruct, let, name "self"
+  debug_value %0 : $*MainActorIsolatedStruct, let, name "self", expr op_deref
   %1 = struct_element_addr %0 : $*MainActorIsolatedStruct, #MainActorIsolatedStruct.globalActorNS
   debug_value [trace] %1
   %9999 = tuple ()
@@ -1212,7 +1212,7 @@ bb0(%0 : $*MainActorIsolatedStruct):
 sil [ossa] @test_globalactor_inference_on_nominal_field_globalactorstruct_addr_nonisolated_unsafe : $@convention(thin) (@in_guaranteed MainActorIsolatedStruct) -> () {
 bb0(%0 : $*MainActorIsolatedStruct):
   specify_test "sil_isolation_info_inference @trace[0]"
-  debug_value %0 : $*MainActorIsolatedStruct, let, name "self"
+  debug_value %0 : $*MainActorIsolatedStruct, let, name "self", expr op_deref
   %1 = struct_element_addr %0 : $*MainActorIsolatedStruct, #MainActorIsolatedStruct.nsNonisolatedUnsafe
   debug_value [trace] %1
   %9999 = tuple ()
@@ -1268,7 +1268,7 @@ bb0(%0 : @guaranteed $NonisolatedStruct):
 sil [ossa] @test_globalactor_inference_on_nominal_field_nonisolatedstruct_addr : $@convention(thin) (@in_guaranteed NonisolatedStruct) -> () {
 bb0(%0 : $*NonisolatedStruct):
   specify_test "sil_isolation_info_inference @trace[0]"
-  debug_value %0 : $*NonisolatedStruct, let, name "self"
+  debug_value %0 : $*NonisolatedStruct, let, name "self", expr op_deref
   %1 = struct_element_addr %0 : $*NonisolatedStruct, #NonisolatedStruct.ns
   debug_value [trace] %1
   %9999 = tuple ()
@@ -1282,7 +1282,7 @@ bb0(%0 : $*NonisolatedStruct):
 sil [ossa] @test_globalactor_inference_on_nominal_field_nonisolatedstruct_addr_globalactor : $@convention(thin) (@in_guaranteed NonisolatedStruct) -> () {
 bb0(%0 : $*NonisolatedStruct):
   specify_test "sil_isolation_info_inference @trace[0]"
-  debug_value %0 : $*NonisolatedStruct, let, name "self"
+  debug_value %0 : $*NonisolatedStruct, let, name "self", expr op_deref
   %1 = struct_element_addr %0 : $*NonisolatedStruct, #NonisolatedStruct.globalActorNS
   debug_value [trace] %1
   %9999 = tuple ()
@@ -1296,7 +1296,7 @@ bb0(%0 : $*NonisolatedStruct):
 sil [ossa] @test_globalactor_inference_on_nominal_field_nonisolatedstruct_addr_nonisolated_unsafe : $@convention(thin) (@in_guaranteed NonisolatedStruct) -> () {
 bb0(%0 : $*NonisolatedStruct):
   specify_test "sil_isolation_info_inference @trace[0]"
-  debug_value %0 : $*NonisolatedStruct, let, name "self"
+  debug_value %0 : $*NonisolatedStruct, let, name "self", expr op_deref
   %1 = struct_element_addr %0 : $*NonisolatedStruct, #NonisolatedStruct.nsNonisolatedUnsafe
   debug_value [trace] %1
   %9999 = tuple ()
@@ -2266,7 +2266,7 @@ bb0(%0 : @guaranteed $Builtin.ImplicitActor, %1 : @guaranteed $NonSendableKlass)
 sil [isolation "global_actor(CustomActor)"] [ossa] @init_existential_addr_get_conformance_test : $@convention(method) <Self where Self : MyProtocol> (@in_guaranteed Self) -> () {
 bb0(%0 : $*Self):
   specify_test "sil_isolation_info_get_conformance_isolation_inferrence @trace[0]"
-  debug_value %0, let, name "self", argno 1
+  debug_value %0, let, name "self", argno 1, expr op_deref
   %alloc = alloc_stack $any MyProtocol
   %addr = init_existential_addr %alloc : $*any MyProtocol, $Self
   debug_value [trace] %addr

--- a/test/Concurrency/transfernonsendable.sil
+++ b/test/Concurrency/transfernonsendable.sil
@@ -233,7 +233,7 @@ bb0(%0 : @guaranteed $MainActorIsolatedStruct):
 
 sil [ossa] @synchronous_returns_transferring_globalactor_struct_structelementaddr : $@convention(method) (@in_guaranteed MainActorIsolatedStruct) -> @sil_sending @owned NonSendableKlass {
 bb0(%0 : $*MainActorIsolatedStruct):
-  debug_value %0 : $*MainActorIsolatedStruct, var, name "myname"
+  debug_value %0 : $*MainActorIsolatedStruct, var, name "myname", expr op_deref
   %2 = struct_element_addr %0 : $*MainActorIsolatedStruct, #MainActorIsolatedStruct.ns
   %3 = load [copy] %2 : $*NonSendableKlass
   return %3 : $NonSendableKlass // expected-warning {{sending 'myname.ns' risks causing data races}}
@@ -251,7 +251,7 @@ bb0(%0 : @guaranteed $MainActorIsolatedEnum):
 
 sil [ossa] @synchronous_returns_transferring_globalactor_enum_uncheckedtakeenumdataaddr : $@convention(method) (@in MainActorIsolatedEnum) -> @sil_sending @owned NonSendableKlass {
 bb0(%0 : $*MainActorIsolatedEnum):
-  debug_value %0 : $*MainActorIsolatedEnum, var, name "myname"
+  debug_value %0 : $*MainActorIsolatedEnum, var, name "myname", expr op_deref
   %2 = unchecked_take_enum_data_addr %0 : $*MainActorIsolatedEnum, #MainActorIsolatedEnum.second!enumelt
   %3 = load [take] %2 : $*NonSendableKlass
   return %3 : $NonSendableKlass // expected-warning {{sending 'myname.second' risks causing data races}}

--- a/test/DebugInfo/irgen_void_tuple.sil
+++ b/test/DebugInfo/irgen_void_tuple.sil
@@ -9,7 +9,7 @@ sil hidden @couple_of_voids : $@convention(thin) () -> () {
 bb0:
   %3 = tuple ()
   // CHECK-NOT: #dbg_value
-  debug_value %3 : $(), let, (name "success", loc "void.swift":3:1), type $*((), ()), expr op_tuple_fragment:$((), ()):0
+  debug_value %3 : $(), let, (name "success", loc "void.swift":3:1), type $((), ()), expr op_tuple_fragment:$((), ()):0
   return %3 : $()
 } // end sil function 'couple_of_voids'
 
@@ -19,7 +19,7 @@ bb0:
   %1 = integer_literal $Builtin.Int64, 0
   // CHECK: #dbg_value
   // CHECK-SAME: ![[RESULT_VAR:[0-9]+]]
-  debug_value %1 : $Builtin.Int64, let, (name "result", loc "void.swift":3:1), type $*(Builtin.Int64, ()), expr op_tuple_fragment:$(Builtin.Int64, ()):0
+  debug_value %1 : $Builtin.Int64, let, (name "result", loc "void.swift":3:1), type $(Builtin.Int64, ()), expr op_tuple_fragment:$(Builtin.Int64, ()):0
   return %1 : $Builtin.Int64
 } // end sil function 'one_existing'
 
@@ -28,7 +28,7 @@ sil hidden @one_empty : $@convention(thin) () -> () {
 bb0:
   %3 = tuple ()
   // CHECK-NOT: #dbg_value
-  debug_value %3 : $(), let, (name "failure", loc "void.swift":3:1), type $*(Builtin.Int64, ()), expr op_tuple_fragment:$(Builtin.Int64, ()):1
+  debug_value %3 : $(), let, (name "failure", loc "void.swift":3:1), type $(Builtin.Int64, ()), expr op_tuple_fragment:$(Builtin.Int64, ()):1
   return %3 : $()
 } // end sil function 'one_empty'
 

--- a/test/DebugInfo/move_function_dbginfo.swift
+++ b/test/DebugInfo/move_function_dbginfo.swift
@@ -129,8 +129,7 @@ public func copyableArgTest(_ k: __owned Klass) {
 // CHECK-LABEL: define swiftcc void @"$s21move_function_dbginfo15copyableVarTestyyF"()
 // CHECK: #dbg_declare(ptr %m.debug,
 // CHECK: #dbg_value(ptr [[VAR:%.*]], ![[K_COPYABLE_VAR_METADATA:[0-9]+]], !DIExpression(DW_OP_deref), ![[ADDR_LOC:[0-9]*]]
-// CHECK: #dbg_value(ptr undef, ![[K_COPYABLE_VAR_METADATA]], !DIExpression(), ![[ADDR_LOC]]
-// TODO: Should this be a deref like the original?
+// CHECK: #dbg_value(ptr undef, ![[K_COPYABLE_VAR_METADATA]], !DIExpression(DW_OP_deref), ![[ADDR_LOC]]
 // CHECK: #dbg_value(ptr [[VAR]], ![[K_COPYABLE_VAR_METADATA]], !DIExpression(DW_OP_deref), ![[ADDR_LOC]]
 // CHECK: ret void
 // CHECK-NEXT: }
@@ -212,7 +211,7 @@ public func copyableVarArgTest(_ k: inout Klass) {
 
 // CHECK-LABEL: define swiftcc void @"$s21move_function_dbginfo20addressOnlyValueTestyyxAA1PRzlF"(ptr noalias %0, ptr %T, ptr %T.P)
 // CHECK: #dbg_value(ptr %{{.*}}, ![[K_ADDR_LET_METADATA:[0-9]+]], !DIExpression(DW_OP_deref, DW_OP_deref), ![[ADDR_LOC:[0-9]*]]
-// CHECK: #dbg_value(ptr undef, ![[K_ADDR_LET_METADATA]], !DIExpression(), ![[ADDR_LOC]]
+// CHECK: #dbg_value(ptr undef, ![[K_ADDR_LET_METADATA]], !DIExpression(DW_OP_deref), ![[ADDR_LOC]]
 // CHECK: ret void
 // CHECK-NEXT: }
 //
@@ -301,7 +300,7 @@ public func addressOnlyValueArgTest<T : P>(_ k: __owned T) {
 // CHECK-LABEL: define swiftcc void @"$s21move_function_dbginfo18addressOnlyVarTestyyxAA1PRzlF"(ptr noalias %0, ptr %T, ptr %T.P)
 // CHECK: #dbg_value(ptr %{{.*}}, ![[K_ADDRONLY_VAR_METADATA:[0-9]+]], !DIExpression(DW_OP_deref, DW_OP_deref), ![[ADDR_LOC:[0-9]*]]
 // CHECK-NEXT: br
-// CHECK: #dbg_value(ptr undef, ![[K_ADDRONLY_VAR_METADATA]], !DIExpression(), ![[ADDR_LOC]]
+// CHECK: #dbg_value(ptr undef, ![[K_ADDRONLY_VAR_METADATA]], !DIExpression(DW_OP_deref), ![[ADDR_LOC]]
 // CHECK: #dbg_value(ptr %{{.*}}, ![[K_ADDRONLY_VAR_METADATA]], !DIExpression(DW_OP_deref, DW_OP_deref), ![[ADDR_LOC]]
 // CHECK: ret void
 // CHECK-NEXT: }
@@ -429,7 +428,7 @@ public func copyableValueArgCCFlowTest(_ k: __owned Klass) {
 // CHECK:      br i1 %{{[0-9]+}}, label %[[LHS:[0-9]+]], label %[[RHS:[0-9]+]],
 //
 // CHECK: [[LHS]]:
-// CHECK:      #dbg_value(ptr undef, ![[K_COPYABLE_VAR_CCFLOW_REINIT_OUT_BLOCK_METADATA]], !DIExpression(), ![[ADDR_LOC]]
+// CHECK:      #dbg_value(ptr undef, ![[K_COPYABLE_VAR_CCFLOW_REINIT_OUT_BLOCK_METADATA]], !DIExpression(DW_OP_deref), ![[ADDR_LOC]]
 // CHECK:      br label %[[CONT_BB:[0-9]+]],
 //
 // CHECK: [[RHS]]:
@@ -486,8 +485,7 @@ public func copyableVarArgTestCCFlowReinitOutOfBlockTest(_ k: inout Klass) {
 // CHECK:      br i1 %{{[0-9]+}}, label %[[LHS:[0-9]+]], label %[[RHS:[0-9]+]],
 //
 // CHECK: [[LHS]]:
-// CHECK:      #dbg_value(ptr undef, ![[K_COPYABLE_VAR_CCFLOW_REINIT_IN_BLOCK_METADATA]], !DIExpression(), ![[ADDR_LOC]]
-// TODO: Should this be a deref like the original?
+// CHECK:      #dbg_value(ptr undef, ![[K_COPYABLE_VAR_CCFLOW_REINIT_IN_BLOCK_METADATA]], !DIExpression(DW_OP_deref), ![[ADDR_LOC]]
 // CHECK:      #dbg_value(ptr [[VAR]], ![[K_COPYABLE_VAR_CCFLOW_REINIT_IN_BLOCK_METADATA]], !DIExpression(DW_OP_deref), ![[ADDR_LOC]]
 //
 // CHECK:      br label %[[CONT_BB:[a-z\.0-9]+]],
@@ -546,7 +544,7 @@ public func copyableVarArgTestCCFlowReinitInBlockTest(_ k: inout Klass) {
 // CHECK:      br i1 %{{[0-9]+}}, label %[[LHS:[0-9]+]], label %[[RHS:[0-9]+]],
 //
 // CHECK: [[LHS]]:
-// CHECK:      #dbg_value(ptr undef, ![[K_ADDRESSONLY_VAR_CCFLOW_REINIT_OUT_BLOCK_METADATA]], !DIExpression(), ![[ADDR_LOC]]
+// CHECK:      #dbg_value(ptr undef, ![[K_ADDRESSONLY_VAR_CCFLOW_REINIT_OUT_BLOCK_METADATA]], !DIExpression(DW_OP_deref), ![[ADDR_LOC]]
 // CHECK:      br label %[[CONT_BB:[a-z\.0-9]+]],
 //
 // CHECK: [[RHS]]:
@@ -603,8 +601,7 @@ public func addressOnlyVarArgTestCCFlowReinitOutOfBlockTest<T : P>(_ k: inout (a
 // CHECK:      br i1 %{{[0-9]+}}, label %[[LHS:[0-9]+]], label %[[RHS:[0-9]+]],
 //
 // CHECK: [[LHS]]:
-// CHECK:      #dbg_value(ptr undef, ![[K_ADDRESSONLY_VAR_CCFLOW_REINIT_IN_BLOCK_METADATA]], !DIExpression(), ![[ADDR_LOC]]
-// TODO: Should this be a deref like the original?
+// CHECK:      #dbg_value(ptr undef, ![[K_ADDRESSONLY_VAR_CCFLOW_REINIT_IN_BLOCK_METADATA]], !DIExpression(DW_OP_deref), ![[ADDR_LOC]]
 // CHECK:      #dbg_value(ptr [[VAR]], ![[K_ADDRESSONLY_VAR_CCFLOW_REINIT_IN_BLOCK_METADATA]], !DIExpression(DW_OP_deref), ![[ADDR_LOC]]
 //
 // CHECK:      br label %[[CONT_BB:[a-z\.0-9]+]],

--- a/test/DebugInfo/move_function_dbginfo_async.swift
+++ b/test/DebugInfo/move_function_dbginfo_async.swift
@@ -215,7 +215,7 @@ public func varSimpleTest<T>(_ msg: inout T, _ msg2: T) async {
 
 // CHECK-LABEL: define internal swifttailcc void @"$s27move_function_dbginfo_async16varSimpleTestVaryyYaFTY2_"(ptr swiftasync %0)
 // CHECK: #dbg_value(ptr %{{[0-9]+}}, ![[METADATA:[0-9]+]], !DIExpression(DW_OP_LLVM_entry_value, 1, DW_OP_plus_uconst, 24, DW_OP_deref), ![[ADDR_LOC:[0-9]+]]
-// CHECK: #dbg_value(ptr undef, ![[METADATA]], !DIExpression(), ![[ADDR_LOC]]
+// CHECK: #dbg_value(ptr undef, ![[METADATA]], !DIExpression(DW_OP_deref), ![[ADDR_LOC]]
 
 // CHECK-LABEL: define internal swifttailcc void @"$s27move_function_dbginfo_async16varSimpleTestVaryyYaFTQ3_"(ptr swiftasync %0)
 // CHECK: #dbg_value(ptr undef,
@@ -224,7 +224,7 @@ public func varSimpleTest<T>(_ msg: inout T, _ msg2: T) async {
 // we should see a #dbg_value to reinit.
 //
 // CHECK-LABEL: define internal swifttailcc void @"$s27move_function_dbginfo_async16varSimpleTestVaryyYaFTY4_"(ptr swiftasync %0)
-// CHECK: #dbg_value(ptr undef, ![[METADATA:[0-9]+]], !DIExpression(), ![[ADDR_LOC:[0-9]+]]
+// CHECK: #dbg_value(ptr undef, ![[METADATA:[0-9]+]], !DIExpression(DW_OP_deref), ![[ADDR_LOC:[0-9]+]]
 // CHECK: #dbg_value(ptr %{{[0-9]+}}, ![[METADATA]], !DIExpression(DW_OP_LLVM_entry_value, 1, DW_OP_plus_uconst, 24, DW_OP_deref), ![[ADDR_LOC]]
 
 // We are not an argument, so no problem here.

--- a/test/DebugInfo/noncopyable_shadow_copy_deref.swift
+++ b/test/DebugInfo/noncopyable_shadow_copy_deref.swift
@@ -21,7 +21,7 @@ public protocol P {
 //
 // CHECK-LABEL: define {{.*}} @"$s{{.*}}9testLocal{{.*}}"(
 // CHECK: #dbg_value(ptr %k.debug, ![[LOCAL_K:[0-9]+]], !DIExpression(DW_OP_deref, DW_OP_deref), ![[LOCAL_LOC:[0-9]+]]
-// CHECK: #dbg_value(ptr undef, ![[LOCAL_K]], !DIExpression(), ![[LOCAL_LOC]]
+// CHECK: #dbg_value(ptr undef, ![[LOCAL_K]], !DIExpression(DW_OP_deref), ![[LOCAL_LOC]]
 // CHECK: ret void
 // CHECK-NEXT: }
 public func testLocal<T: P>(_ x: T) {

--- a/test/DebugInfo/resilient_debug_value.sil
+++ b/test/DebugInfo/resilient_debug_value.sil
@@ -16,7 +16,7 @@ import resilient_struct
 sil @test_debug_value_resilient : $@convention(thin) () -> () {
 bb0:
   %0 = alloc_stack $Size, var, name "assertions"
-  debug_value %0 : $*Size, var, name "assertions"
+  debug_value %0 : $*Size, var, name "assertions", expr op_deref
   dealloc_stack %0: $*Size
   %1 = tuple ()
   return %1 : $()

--- a/test/DebugInfo/sil_combine.sil
+++ b/test/DebugInfo/sil_combine.sil
@@ -38,7 +38,7 @@ enum MP {
 // CHECK-LABEL: sil @expand_alloc_stack_of_enum_without_take
 // CHECK:        [[A:%[0-9]+]] = alloc_stack $S
 // CHECK-NOT:      name "a"
-// CHECK-NEXT:   debug_value undef : $*MP, let, name "a", expr op_fragment:#C.x
+// CHECK-NEXT:   debug_value undef : $*MP, let, name "a", expr op_deref:op_fragment:#C.x
 // CHECK-NEXT:   debug_value undef : $*MP, let, name "b"
 // CHECK:      bb1:
 // CHECK-NEXT:   store %0 to [[A]]
@@ -50,8 +50,8 @@ enum MP {
 sil @expand_alloc_stack_of_enum_without_take : $@convention(method) (S) -> () {
 bb0(%0 : $S):
   %1 = alloc_stack $MP
-  debug_value %1 : $*MP, let, name "a", expr op_fragment:#C.x
-  debug_value %1 : $*MP, let, name "b"
+  debug_value %1 : $*MP, let, name "a", expr op_deref:op_fragment:#C.x
+  debug_value %1 : $*MP, let, name "b", expr op_deref
   cond_br undef, bb1, bb2
 bb1:
   %2 = init_enum_data_addr %1 : $*MP, #MP.A!enumelt

--- a/test/DebugInfo/sroa_debug_value.sil
+++ b/test/DebugInfo/sroa_debug_value.sil
@@ -33,12 +33,12 @@ bb0(%0 : $Int64, %1 : $Int64):
   // CHECK-SROA-SAME:        loc * "<compiler-generated>":0:0
   // CHECK-SROA: debug_value %[[ALLOC_X]] : $*Int64, var
   // CHECK-SROA-SAME:        (name "my_struct", loc "sroa.swift":8:9
-  // CHECK-SROA-SAME:        type $MyStruct, expr op_fragment:#MyStruct.x
+  // CHECK-SROA-SAME:        type $MyStruct, expr op_deref:op_fragment:#MyStruct.x
   // CHECK-SROA: %[[ALLOC_Y:[0-9]+]] = alloc_stack $Int64
   // CHECK-SROA-SAME:        loc * "<compiler-generated>":0:0
   // CHECK-SROA: debug_value %[[ALLOC_Y]] : $*Int64, var
   // CHECK-SROA-SAME:        (name "my_struct", loc "sroa.swift":8:9
-  // CHECK-SROA-SAME:        type $MyStruct, expr op_fragment:#MyStruct.y
+  // CHECK-SROA-SAME:        type $MyStruct, expr op_deref:op_fragment:#MyStruct.y
   // CHECK-SROA: debug_value %[[ALLOC_X]] : $*Int64, let
   // CHECK-SROA-SAME:        name "my_copy",
   // CHECK-SROA-SAME:        type $MyStruct, expr op_deref:op_fragment:#MyStruct.x

--- a/test/DebugInfo/sroa_mem2reg.sil
+++ b/test/DebugInfo/sroa_mem2reg.sil
@@ -37,12 +37,12 @@ bb0(%0 : $Int64, %1 : $Int64):
   // CHECK-SROA-SAME:        loc * "<compiler-generated>":0:0
   // CHECK-SROA: debug_value %[[ALLOC_X]] : $*Int64, var
   // CHECK-SROA-SAME:        (name "my_struct", loc "sroa.swift":8:9
-  // CHECK-SROA-SAME:        type $MyStruct, expr op_fragment:#MyStruct.x
+  // CHECK-SROA-SAME:        type $MyStruct, expr op_deref:op_fragment:#MyStruct.x
   // CHECK-SROA: %[[ALLOC_Y:[0-9]+]] = alloc_stack $Int64
   // CHECK-SROA-SAME:        loc * "<compiler-generated>":0:0
   // CHECK-SROA: debug_value %[[ALLOC_Y]] : $*Int64, var
   // CHECK-SROA-SAME:        (name "my_struct", loc "sroa.swift":8:9
-  // CHECK-SROA-SAME:        type $MyStruct, expr op_fragment:#MyStruct.y
+  // CHECK-SROA-SAME:        type $MyStruct, expr op_deref:op_fragment:#MyStruct.y
   %5 = metatype $@thin MyStruct.Type, loc "sroa.swift":8:21, scope 2
   %6 = integer_literal $Builtin.Int64, 0, loc "sroa.swift":8:33, scope 2
   %7 = struct $Int64 (%6 : $Builtin.Int64), loc "sroa.swift":8:33, scope 2

--- a/test/DebugInfo/sroa_mem2reg_tuple.sil
+++ b/test/DebugInfo/sroa_mem2reg_tuple.sil
@@ -25,13 +25,13 @@ bb0(%0 : $Int64, %1 : $Int64):
   // CHECK-SROA-SAME:        loc * "<compiler-generated>":0:0
   // CHECK-SROA: debug_value %[[ALLOC_X]] : $*Builtin.Int64, var
   // CHECK-SROA-SAME:        (name "my_tup", loc "sroa.swift":2:7
-  // CHECK-SROA-SAME:        type $(x: Int64, y: Int64), expr op_tuple_fragment:$(x: Int64, y: Int64):0:op_fragment:#Int64._value
+  // CHECK-SROA-SAME:        type $(x: Int64, y: Int64), expr op_deref:op_tuple_fragment:$(x: Int64, y: Int64):0:op_fragment:#Int64._value
   // CHECK-SROA-SAME:        loc * "<compiler-generated>":0:0
   // CHECK-SROA: %[[ALLOC_Y:[0-9]+]] = alloc_stack $Builtin.Int64
   // CHECK-SROA-SAME:        loc * "<compiler-generated>":0:0
   // CHECK-SROA: debug_value %[[ALLOC_Y]] : $*Builtin.Int64, var
   // CHECK-SROA-SAME:        (name "my_tup", loc "sroa.swift":2:7
-  // CHECK-SROA-SAME:        type $(x: Int64, y: Int64), expr op_tuple_fragment:$(x: Int64, y: Int64):1:op_fragment:#Int64._value
+  // CHECK-SROA-SAME:        type $(x: Int64, y: Int64), expr op_deref:op_tuple_fragment:$(x: Int64, y: Int64):1:op_fragment:#Int64._value
   // CHECK-SROA-SAME:        loc * "<compiler-generated>":0:0
 
   // Make sure the struct fields' SSA values are properly connected to the source variables via op_fragment

--- a/test/DebugInfo/srosroa_mem2reg.sil
+++ b/test/DebugInfo/srosroa_mem2reg.sil
@@ -31,11 +31,11 @@ bb0(%0 : $Int64, %1 : $Int64):
   debug_value %0 : $Int64, let, name "in_x", argno 1, loc "sroa.swift":7:10, scope 2
   debug_value %1 : $Int64, let, name "in_y", argno 2, loc "sroa.swift":7:21, scope 2
   %4 = alloc_stack $MyStruct, loc "sroa.swift":8:9, scope 2
-  debug_value %4 : $*MyStruct, var, name "my_struct", type $*MyContainer, expr op_fragment:#MyContainer.z, loc "sroa.swift":8:9, scope 2
+  debug_value %4 : $*MyStruct, var, name "my_struct", type $MyContainer, expr op_deref:op_fragment:#MyContainer.z, loc "sroa.swift":8:9, scope 2
   // CHECK-SROA: %[[ALLOC_X:[0-9]+]] = alloc_stack $Int64
   // CHECK-SROA: %[[ALLOC_Y:[0-9]+]] = alloc_stack $Int64
-  // CHECK-SROA: debug_value %[[ALLOC_X]]{{.*}}, var, name "my_struct", type $*MyContainer, expr op_fragment:#MyContainer.z:op_fragment:#MyStruct.x
-  // CHECK-SROA: debug_value %[[ALLOC_Y]]{{.*}}, var, name "my_struct", type $*MyContainer, expr op_fragment:#MyContainer.z:op_fragment:#MyStruct.y
+  // CHECK-SROA: debug_value %[[ALLOC_X]]{{.*}}, var, name "my_struct", type $MyContainer, expr op_deref:op_fragment:#MyContainer.z:op_fragment:#MyStruct.x
+  // CHECK-SROA: debug_value %[[ALLOC_Y]]{{.*}}, var, name "my_struct", type $MyContainer, expr op_deref:op_fragment:#MyContainer.z:op_fragment:#MyStruct.y
   // CHECK-SROA: metatype
   %5 = metatype $@thin MyStruct.Type, loc "sroa.swift":8:21, scope 2
   %6 = integer_literal $Builtin.Int64, 0, loc "sroa.swift":8:33, scope 2

--- a/test/IRGen/debug_fragment_merge.sil
+++ b/test/IRGen/debug_fragment_merge.sil
@@ -56,8 +56,8 @@ bb1:                                              // Preds: bb0
   %16 = load %15 : $*String, loc "debug_fragment_merge.swift":19:28, scope 13 // users: %19, %22
   %17 = struct_element_addr %11 : $*Data, #Data.b, loc "debug_fragment_merge.swift":19:28, scope 13 // user: %18
   %18 = load %17 : $*String, loc "debug_fragment_merge.swift":19:28, scope 13 // users: %22, %20
-  debug_value %16 : $String, let, (name "data", loc "debug_fragment_merge.swift":16:7, scope 10), type $*Data, expr op_fragment:#Data.a, loc "debug_fragment_merge.swift":19:17, scope 12 // id: %19
-  debug_value %18 : $String, let, (name "data", loc "debug_fragment_merge.swift":16:7, scope 10), type $*Data, expr op_fragment:#Data.b, loc "debug_fragment_merge.swift":19:17, scope 12 // id: %20
+  debug_value %16 : $String, let, (name "data", loc "debug_fragment_merge.swift":16:7, scope 10), type $Data, expr op_fragment:#Data.a, loc "debug_fragment_merge.swift":19:17, scope 12 // id: %19
+  debug_value %18 : $String, let, (name "data", loc "debug_fragment_merge.swift":16:7, scope 10), type $Data, expr op_fragment:#Data.b, loc "debug_fragment_merge.swift":19:17, scope 12 // id: %20
   dealloc_stack %11 : $*Data, loc "debug_fragment_merge.swift":19:44, scope 13 // id: %21
   br bb3(%18 : $String, %16 : $String), loc * "debug_fragment_merge.swift":19:44, scope 13 // id: %22
 

--- a/test/SILOptimizer/allocstack_hoisting.sil
+++ b/test/SILOptimizer/allocstack_hoisting.sil
@@ -291,10 +291,10 @@ bb3:
 sil @merging : $@convention(thin) <T> (@in T) -> () {
 bb0(%0 : $*T):
   %1 = alloc_stack $T
-  debug_value %1 : $*T, name "x"
+  debug_value %1 : $*T, name "x", expr op_deref
   dealloc_stack %1 : $*T
   %2 = alloc_stack $T
-  debug_value %2 : $*T, name "y"
+  debug_value %2 : $*T, name "y", expr op_deref
   dealloc_stack %2 : $*T
   %r = tuple ()
   return %r : $()
@@ -311,9 +311,9 @@ bb0(%0 : $*T):
 sil @dont_merge : $@convention(thin) <T> (@in T) -> () {
 bb0(%0 : $*T):
   %1 = alloc_stack $T
-  debug_value %1 : $*T, name "x"
+  debug_value %1 : $*T, name "x", expr op_deref
   %3 = alloc_stack $T
-  debug_value %3 : $*T, name "y"
+  debug_value %3 : $*T, name "y", expr op_deref
   dealloc_stack %3 : $*T
   dealloc_stack %1 : $*T
   %r = tuple ()

--- a/test/SILOptimizer/dead-access-scope-elimination.sil
+++ b/test/SILOptimizer/dead-access-scope-elimination.sil
@@ -25,7 +25,7 @@ bb0:
   %0 = global_addr @g1 : $*Int
   %2 = begin_access [modify] [dynamic] %0
   fix_lifetime %2
-  debug_value %2 : $*Int, name "g1"
+  debug_value %2 : $*Int, name "g1", expr op_deref
   end_access %2
   %r = tuple ()
   return %r

--- a/test/SILOptimizer/dead_store_elim.sil
+++ b/test/SILOptimizer/dead_store_elim.sil
@@ -389,7 +389,7 @@ bb0:
   %1 = integer_literal $Builtin.Int64, 1
   %2 = struct $Int (%1 : $Builtin.Int64)
   store %2 to %0 : $*Int
-  debug_value %0 : $*Int
+  debug_value %0 : $*Int, expr op_deref
   %4 = tuple ()
   dealloc_stack %0 : $*Int
   return %4 : $()

--- a/test/SILOptimizer/escape_info_unit.sil
+++ b/test/SILOptimizer/escape_info_unit.sil
@@ -1421,7 +1421,7 @@ bb0:
   %2 = ref_element_addr %1 : $Z, #Z.y
   store %0 to %2 : $*Y
   debug_value %0 : $Y
-  debug_value %2 : $*Y
+  debug_value %2 : $*Y, expr op_deref
   %11 = tuple ()
   return %11 : $()
 }

--- a/test/SILOptimizer/hoist_destroy_addr.sil
+++ b/test/SILOptimizer/hoist_destroy_addr.sil
@@ -252,7 +252,7 @@ bb1:
   br bb3
 
 bb2:
-  debug_value %4 : $*T, let, name "t"
+  debug_value %4 : $*T, let, name "t", expr op_deref
   br bb3
 
 bb3:
@@ -299,7 +299,7 @@ bb1:
   br bb3
 
 bb2:
-  debug_value %4 : $*T, let, name "t"
+  debug_value %4 : $*T, let, name "t", expr op_deref
   br bb3
 
 bb3:
@@ -338,7 +338,7 @@ bb2:
   br bb1
 
 bb3:
-  debug_value %a : $*T, let, name "t"
+  debug_value %a : $*T, let, name "t", expr op_deref
   destroy_addr %a : $*T
   dealloc_stack %a : $*T
   %16 = tuple ()
@@ -375,7 +375,7 @@ bb2:
   br bb1
 
 bb3:
-  debug_value %a : $*T, let, name "t"
+  debug_value %a : $*T, let, name "t", expr op_deref
   destroy_addr %a : $*T
   dealloc_stack %a : $*T
   %16 = tuple ()

--- a/test/SILOptimizer/mem2reg_ossa.sil
+++ b/test/SILOptimizer/mem2reg_ossa.sil
@@ -696,7 +696,7 @@ header:
   %lifetime = begin_borrow %instance : $S
   %stack = alloc_stack $S
   %stack_borrow = store_borrow %lifetime to %stack : $*S
-  debug_value %stack_borrow : $*S
+  debug_value %stack_borrow : $*S, expr op_deref
   br body
 
 body:
@@ -730,7 +730,7 @@ header:
   %lifetime = begin_borrow %instance : $S
   %stack = alloc_stack $S
   %stack_borrow = store_borrow %lifetime to %stack : $*S
-  debug_value %stack_borrow : $*S
+  debug_value %stack_borrow : $*S, expr op_deref
   %field_addr = struct_element_addr %stack_borrow : $*S, #S.field
   %field = load [copy] %field_addr : $*C
   end_borrow %stack_borrow : $*S

--- a/test/SILOptimizer/memory-effects_unit.sil
+++ b/test/SILOptimizer/memory-effects_unit.sil
@@ -1321,8 +1321,8 @@ bb0:
   specify_test "memory_effects"
   %0 = alloc_stack $Int
   %1 = alloc_stack $Int
-  debug_value %0 : $*Int, let, name "x"
-  debug_value undef : $*Int, let, name "y"
+  debug_value %0 : $*Int, let, name "x", expr op_deref
+  debug_value undef : $*Int, let, name "y", expr op_deref
   dealloc_stack %1 : $*Int
   dealloc_stack %0 : $*Int
   %r = tuple ()

--- a/test/SILOptimizer/moveonly_addresschecker_debuginfo.sil
+++ b/test/SILOptimizer/moveonly_addresschecker_debuginfo.sil
@@ -21,7 +21,7 @@ sil @consume_nontrivial_struct_addr : $@convention(thin) (@in NonTrivialStruct) 
 // CHECK: [[BORROW:%.*]] = load_borrow [[STACK]]
 // CHECK: apply {{%.*}}([[BORROW]])
 // CHECK-NEXT: end_borrow [[BORROW]]
-// CHECK-NEXT: debug_value undef : $*NonTrivialStruct, let, name "v" // {{.*}}; line:[[DEBUG_LOC]]
+// CHECK-NEXT: debug_value undef : $*NonTrivialStruct, let, name "v", expr op_deref // {{.*}}; line:[[DEBUG_LOC]]
 // CHECK: } // end sil function 'non_lifetime_ending_use_test_inst'
 sil [ossa] @non_lifetime_ending_use_test_inst : $@convention(thin) () -> () {
   %f = function_ref @get_nontrivial_struct : $@convention(thin) () -> @owned NonTrivialStruct
@@ -56,7 +56,7 @@ bb1:
 // CHECK: bb2:
 // CHECK-NEXT:   br bb3
 // CHECK: bb3:
-// CHECK-NEXT: debug_value undef : $*NonTrivialStruct, let, name "v" // {{.*}}; line:[[DEBUG_LOC]]
+// CHECK-NEXT: debug_value undef : $*NonTrivialStruct, let, name "v", expr op_deref // {{.*}}; line:[[DEBUG_LOC]]
 // CHECK-NEXT: destroy_addr [[STACK]]
 // CHECK: } // end sil function 'non_lifetime_ending_use_test_boundary_edge'
 sil [ossa] @non_lifetime_ending_use_test_boundary_edge : $@convention(thin) () -> () {
@@ -96,7 +96,7 @@ bb3:
 // debug_value undef.
 //
 // CHECK:   [[TAKE:%.*]] = load [take] [[STACK]]
-// CHECK-NEXT: debug_value undef : $*NonTrivialStruct, let, name "v" // {{.*}}; line:[[DEBUG_LOC]]
+// CHECK-NEXT: debug_value undef : $*NonTrivialStruct, let, name "v", expr op_deref // {{.*}}; line:[[DEBUG_LOC]]
 // CHECK-NEXT: // function_ref
 // CHECK-NEXT: function_ref
 // CHECK-NEXT:   apply {{%.*}}([[TAKE]])
@@ -104,7 +104,7 @@ bb3:
 //
 // CHECK: bb2:
 // CHECK-NEXT:   destroy_addr [[STACK]]
-// CHECK-NEXT: debug_value undef : $*NonTrivialStruct, let, name "v" // {{.*}}; line:[[DEBUG_LOC]]
+// CHECK-NEXT: debug_value undef : $*NonTrivialStruct, let, name "v", expr op_deref // {{.*}}; line:[[DEBUG_LOC]]
 // CHECK: } // end sil function 'lifetime_ending_use'
 sil [ossa] @lifetime_ending_use : $@convention(thin) () -> () {
   %f = function_ref @get_nontrivial_struct : $@convention(thin) () -> @owned NonTrivialStruct
@@ -137,12 +137,12 @@ bb3:
 
 // CHECK: bb1:
 // CHECK:   apply {{%.*}}([[STACK]])
-// CHECK-NEXT: debug_value undef : $*NonTrivialStruct, let, name "v" // {{.*}}; line:[[DEBUG_LOC]]
+// CHECK-NEXT: debug_value undef : $*NonTrivialStruct, let, name "v", expr op_deref // {{.*}}; line:[[DEBUG_LOC]]
 // CHECK: br bb3
 //
 // CHECK: bb2:
 // CHECK-NEXT:   destroy_addr [[STACK]]
-// CHECK-NEXT: debug_value undef : $*NonTrivialStruct, let, name "v" // {{.*}}; line:[[DEBUG_LOC]]
+// CHECK-NEXT: debug_value undef : $*NonTrivialStruct, let, name "v", expr op_deref // {{.*}}; line:[[DEBUG_LOC]]
 // CHECK: } // end sil function 'lifetime_ending_use_addr'
 sil [ossa] @lifetime_ending_use_addr : $@convention(thin) () -> () {
   %f = function_ref @get_nontrivial_struct : $@convention(thin) () -> @owned NonTrivialStruct
@@ -174,19 +174,19 @@ bb3:
 //
 // CHECK: bb1:
 // CHECK:   apply {{%.*}}([[STACK]])
-// CHECK-NEXT: debug_value undef : $*NonTrivialStruct, let, name "v" // {{.*}}; line:[[DEBUG_LOC]]
+// CHECK-NEXT: debug_value undef : $*NonTrivialStruct, let, name "v", expr op_deref // {{.*}}; line:[[DEBUG_LOC]]
 // CHECK-NEXT: br bb2
 //
 // CHECK: bb2:
 // CHECK: [[NEW_VAL:%.*]] = apply {{%.*}}() :
 // CHECK-NEXT: store [[NEW_VAL]] to [init] [[STACK]]
 // CHECK-NEXT: destroy_addr [[STACK]]
-// CHECK-NEXT: debug_value undef : $*NonTrivialStruct, let, name "v" // {{.*}}; line:[[DEBUG_LOC]]
+// CHECK-NEXT: debug_value undef : $*NonTrivialStruct, let, name "v", expr op_deref // {{.*}}; line:[[DEBUG_LOC]]
 // CHECK-NEXT: br bb4
 //
 // CHECK: bb3:
 // CHECK-NEXT:   destroy_addr [[STACK]]
-// CHECK-NEXT: debug_value undef : $*NonTrivialStruct, let, name "v" // {{.*}}; line:[[DEBUG_LOC]]
+// CHECK-NEXT: debug_value undef : $*NonTrivialStruct, let, name "v", expr op_deref // {{.*}}; line:[[DEBUG_LOC]]
 // CHECK: br bb4
 // CHECK: } // end sil function 'dead_def_test_inst'
 sil [ossa] @dead_def_test_inst : $@convention(thin) () -> () {

--- a/test/SILOptimizer/moveonly_deinit_devirtualization_library_evolution.sil
+++ b/test/SILOptimizer/moveonly_deinit_devirtualization_library_evolution.sil
@@ -217,7 +217,7 @@ bb0(%0 : $*ThreeNonTrivialNoDeinit):
 
 sil hidden [ossa] @$s4main12StructDeinitVfD : $@convention(method) (@in StructDeinit) -> () {
 bb0(%0 : $*StructDeinit):
-  debug_value %0 : $*StructDeinit, let, name "self", argno 1
+  debug_value %0 : $*StructDeinit, let, name "self", argno 1, expr op_deref
   %2 = drop_deinit %0 : $*StructDeinit
   %3 = tuple ()
   return %3 : $()
@@ -225,7 +225,7 @@ bb0(%0 : $*StructDeinit):
 
 sil hidden [ossa] @$s4main21SingleFieldNonTrivialVfD : $@convention(method) (@in SingleFieldNonTrivial) -> () {
 bb0(%0 : $*SingleFieldNonTrivial):
-  debug_value %0 : $*SingleFieldNonTrivial, let, name "self", argno 1
+  debug_value %0 : $*SingleFieldNonTrivial, let, name "self", argno 1, expr op_deref
   %2 = struct_element_addr %0 : $*SingleFieldNonTrivial, #SingleFieldNonTrivial.k
   destroy_addr %2 : $*Klass
   %4 = tuple ()
@@ -234,7 +234,7 @@ bb0(%0 : $*SingleFieldNonTrivial):
 
 sil hidden [ossa] @$s4main15ThreeNonTrivialVfD : $@convention(method) (@in ThreeNonTrivial) -> () {
 bb0(%0 : $*ThreeNonTrivial):
-  debug_value %0 : $*ThreeNonTrivial, let, name "self", argno 1
+  debug_value %0 : $*ThreeNonTrivial, let, name "self", argno 1, expr op_deref
   %2 = struct_element_addr %0 : $*ThreeNonTrivial, #ThreeNonTrivial.k
   %3 = struct_element_addr %0 : $*ThreeNonTrivial, #ThreeNonTrivial.k2
   destroy_addr %2 : $*Klass
@@ -245,7 +245,7 @@ bb0(%0 : $*ThreeNonTrivial):
 
 sil hidden [ossa] @$s4main19TrivialMoveOnlyEnumOfD : $@convention(method) (@in TrivialMoveOnlyEnum) -> () {
 bb0(%0 : $*TrivialMoveOnlyEnum):
-  debug_value %0 : $*TrivialMoveOnlyEnum, let, name "self", argno 1
+  debug_value %0 : $*TrivialMoveOnlyEnum, let, name "self", argno 1, expr op_deref
   switch_enum_addr %0 : $*TrivialMoveOnlyEnum, case #TrivialMoveOnlyEnum.first!enumelt: bb1, case #TrivialMoveOnlyEnum.second!enumelt: bb2, case #TrivialMoveOnlyEnum.third!enumelt: bb3
 
 bb1:
@@ -271,7 +271,7 @@ bb4:
 // CHECK: } // end sil function '$s4main22NonTrivialMoveOnlyEnumOfD'
 sil hidden [ossa] @$s4main22NonTrivialMoveOnlyEnumOfD : $@convention(method) (@in NonTrivialMoveOnlyEnum) -> () {
 bb0(%0 : $*NonTrivialMoveOnlyEnum):
-  debug_value %0 : $*NonTrivialMoveOnlyEnum, let, name "self", argno 1
+  debug_value %0 : $*NonTrivialMoveOnlyEnum, let, name "self", argno 1, expr op_deref
   switch_enum_addr %0 : $*NonTrivialMoveOnlyEnum, case #NonTrivialMoveOnlyEnum.first!enumelt: bb1, case #NonTrivialMoveOnlyEnum.second!enumelt: bb2, case #NonTrivialMoveOnlyEnum.third!enumelt: bb3, case #NonTrivialMoveOnlyEnum.fourth!enumelt: bb4, case #NonTrivialMoveOnlyEnum.fifth!enumelt: bb5
 
 bb1:

--- a/test/SILOptimizer/side_effects.sil
+++ b/test/SILOptimizer/side_effects.sil
@@ -1228,7 +1228,7 @@ bb3:
 sil @test_debug_value_address : $@convention(thin) <T> (@in T, @inout T) -> () {
 bb0(%0 : $*T, %1 : $*T):
   destroy_addr %0 : $*T
-  debug_value %1 : $*T
+  debug_value %1 : $*T, expr op_deref
   %4 = tuple ()
   return %4 : $()
 }

--- a/test/SILOptimizer/sil_combine.sil
+++ b/test/SILOptimizer/sil_combine.sil
@@ -1228,7 +1228,7 @@ sil @unchecked_addr_cast_forwarding : $@convention(thin) (@inout Builtin.NativeO
 bb0(%0 : $*Builtin.NativeObject):
   %1 = unchecked_addr_cast %0 : $*Builtin.NativeObject to $*Builtin.RawPointer
   %2 = unchecked_addr_cast %1 : $*Builtin.RawPointer to $*Builtin.Word
-  debug_value %2 : $*Builtin.Word // should not prevent the optimization
+  debug_value %2 : $*Builtin.Word, expr op_deref // should not prevent the optimization
   %3 = load %2 : $*Builtin.Word
   return %3 : $Builtin.Word
 }
@@ -1312,7 +1312,7 @@ bb0(%0 : $*FakeOptional<B>):
 
 bb1:
   %2 = unchecked_inplace_enum_data_addr %0 : $*FakeOptional<B>, #FakeOptional.some!enumelt
-  debug_value %2 : $*B  // should not prevent the optimization
+  debug_value %2 : $*B, expr op_deref  // should not prevent the optimization
   %3 = load %2 : $*B
   return %3 : $B
 

--- a/test/SILOptimizer/sil_combine_ossa.sil
+++ b/test/SILOptimizer/sil_combine_ossa.sil
@@ -1542,7 +1542,7 @@ sil [ossa] @unchecked_addr_cast_forwarding : $@convention(thin) (@inout Builtin.
 bb0(%0 : $*Builtin.NativeObject):
   %1 = unchecked_addr_cast %0 : $*Builtin.NativeObject to $*Builtin.RawPointer
   %2 = unchecked_addr_cast %1 : $*Builtin.RawPointer to $*Builtin.Word
-  debug_value %2 : $*Builtin.Word // should not prevent the optimization
+  debug_value %2 : $*Builtin.Word, expr op_deref // should not prevent the optimization
   %3 = load [trivial] %2 : $*Builtin.Word
   return %3 : $Builtin.Word
 }
@@ -1647,7 +1647,7 @@ bb0(%0 : $*FakeOptional<B>):
 
 bb1:
   %2 = unchecked_inplace_enum_data_addr %0 : $*FakeOptional<B>, #FakeOptional.some!enumelt
-  debug_value %2 : $*B  // should not prevent the optimization
+  debug_value %2 : $*B, expr op_deref  // should not prevent the optimization
   %3 = load [copy] %2 : $*B
   return %3 : $B
 

--- a/test/SILOptimizer/silgen_cleanup_debug.sil
+++ b/test/SILOptimizer/silgen_cleanup_debug.sil
@@ -50,7 +50,7 @@ sil_scope 21 { loc "./loadFromStack.swift":1:1 parent 20 }
 // CHECK:   [[STACK:%.*]] = alloc_stack $Int
 // CHECK:   struct_element_addr [[STACK]] : $*Int, #Int._value
 // CHECK:   load [trivial] %{{.*}} : $*Builtin.Int32, loc "./loadFromStack.swift":2:1, scope [[STACKSCOPE1]]
-// CHECK:   debug_value [[STACK]] : $*Int, let, name "sVar", loc "./loadFromStack.swift":3:1, scope [[STACKSCOPE2]]
+// CHECK:   debug_value [[STACK]] : $*Int, let, name "sVar", expr op_deref, loc "./loadFromStack.swift":3:1, scope [[STACKSCOPE2]]
 // CHECK-LABEL: } // end sil function 'loadFromStack'
 sil [ossa] @loadFromStack : $@convention(thin) (Int) -> Builtin.Int32 {
 bb0(%0 : $Int):

--- a/test/SILOptimizer/simplify_alloc_stack.sil
+++ b/test/SILOptimizer/simplify_alloc_stack.sil
@@ -618,7 +618,7 @@ bb0(%0 : @owned $T):
   %2 = init_existential_metatype %1, $@thick P.Type
   %3 = open_existential_metatype %2 to $@thick (@opened("82105EE0-DCB0-11E5-865D-C8E0EB309913", P) Self).Type
   %4 = alloc_stack [lexical] $@opened("82105EE0-DCB0-11E5-865D-C8E0EB309913", P) Self
-  debug_value %4, var, name "x"
+  debug_value %4, var, name "x", expr op_deref
   %5 = unchecked_addr_cast %4 to $*T
   store %0 to [init] %5
   destroy_addr %4
@@ -700,7 +700,7 @@ sil_scope 2 { loc "inlined.swift":1:1 parent @$inlined :  $@convention(thin) <τ
 sil [ossa] @replace_existential_with_concrete_type3 : $@convention(thin) (@owned T) -> () {
 bb0(%0 : @owned $T):
   %5 = alloc_stack $any P
-  debug_value %5, let, name "value1", loc "inlined.swift":1:1, scope 2
+  debug_value %5, let, name "value1", expr op_deref, loc "inlined.swift":1:1, scope 2
   %6 = init_existential_addr %5, $T
   store %0 to [init] %6
   %8 = open_existential_addr mutable_access %5 to $*@opened("83DE9694-7315-11E8-955C-ACDE48001122", P) Self

--- a/test/SILOptimizer/simplify_builtin.sil
+++ b/test/SILOptimizer/simplify_builtin.sil
@@ -350,7 +350,7 @@ bb0:
   %2 = integer_literal $Builtin.Int32, 10
   %3 = struct $Int32 (%2 : $Builtin.Int32)
   debug_step
-  debug_value %1 : $*Int32
+  debug_value %1 : $*Int32, expr op_deref
   %6 = tuple ()
   return %6 : $()
 }

--- a/test/SILOptimizer/temp_rvalue_opt_ossa.sil
+++ b/test/SILOptimizer/temp_rvalue_opt_ossa.sil
@@ -119,7 +119,7 @@ bb0(%0 : $*GS<B>, %1 : $*GS<B>):
   %3 = load [trivial] %2 : $*Builtin.Int64
   %4 = alloc_stack $GS<B>
   copy_addr %1 to [init] %4 : $*GS<B>
-  debug_value %4, let, name "x"
+  debug_value %4, let, name "x", expr op_deref
   %6 = struct_element_addr %4 : $*GS<B>, #GS._value
   %7 = load [trivial] %6 : $*Builtin.Int64
   %8 = builtin "cmp_slt_Int64"(%3 : $Builtin.Int64, %7 : $Builtin.Int64) : $Builtin.Int1
@@ -1868,7 +1868,7 @@ bb0(%0 : $*NonTrivialStruct):
   br bb1
 
 bb1:
-  debug_value %1, let, name "x"
+  debug_value %1, let, name "x", expr op_deref
   %3 = struct_element_addr %0, #NonTrivialStruct.val
   copy_addr %3 to [init] %1
   %4 = apply undef(%1) : $@convention(thin) (@in_guaranteed Klass) -> ()
@@ -1933,7 +1933,7 @@ bb1:
   destroy_value %0
   %10 = struct_element_addr %5, #S2.ntv
   %11 = struct_element_addr %10, #NonTrivialStruct.val
-  debug_value %11, let, name "x"
+  debug_value %11, let, name "x", expr op_deref
   destroy_value [dead_end] %6
   unreachable
 

--- a/test/SILOptimizer/variable_name_inference.sil
+++ b/test/SILOptimizer/variable_name_inference.sil
@@ -445,7 +445,7 @@ bb0(%0 : @guaranteed $FakeOptional<Klass>):
 sil [ossa] @function_argument_inference_through_uncheckedtakeenumdataaddr : $@convention(thin) (@in FakeOptional<Klass>) -> @owned Klass {
 bb0(%0 : $*FakeOptional<Klass>):
   specify_test "variable_name_inference @trace[0]"
-  debug_value %0 : $*FakeOptional<Klass>, let, name "self", argno 1
+  debug_value %0 : $*FakeOptional<Klass>, let, name "self", argno 1, expr op_deref
   %2 = unchecked_inplace_enum_data_addr %0 : $*FakeOptional<Klass>, #FakeOptional.some!enumelt
   %3 = load [take] %2 : $*Klass
   debug_value [trace] %3 : $Klass
@@ -460,7 +460,7 @@ bb0(%0 : $*FakeOptional<Klass>):
 sil [ossa] @function_argument_inference_through_uncheckedtakeenumdataaddr_2 : $@convention(thin) (@in FakeOptional<Klass>) -> @owned Klass {
 bb0(%0 : $*FakeOptional<Klass>):
   specify_test "variable_name_inference @trace[0]"
-  debug_value %0 : $*FakeOptional<Klass>, let, name "self", argno 1
+  debug_value %0 : $*FakeOptional<Klass>, let, name "self", argno 1, expr op_deref
   %2 = unchecked_inplace_enum_data_addr %0 : $*FakeOptional<Klass>, #FakeOptional.some!enumelt
   debug_value [trace] %2 : $*Klass
   %3 = load [take] %2 : $*Klass
@@ -764,7 +764,7 @@ bb0(%0 : @owned $Klass):
 sil [ossa] @init_existential_addr_temporary_copy_addr : $@convention(thin) (@in Klass) -> () {
 bb0(%0 : $*Klass):
   specify_test "variable_name_inference @trace[0]"
-  debug_value %0 : $*Klass, var, name "my arg"
+  debug_value %0 : $*Klass, var, name "my arg", expr op_deref
   %1 = alloc_stack $Any
   %2 = init_existential_addr %1 : $*Any, $Klass
   copy_addr [take] %0 to [init] %2 : $*Klass


### PR DESCRIPTION
For consistency within SIL, we want all debug_values with address types to include an op_deref.

The first commit adds op_deref to debug_values pointing to an alloc_stack. The second commit adds op_deref to alloc_stack's VarInfo directly, which fixes some passes (including ones written in Swift) that are copying the VarInfo from an alloc_stack to a debug_value without adding the necessary op_deref.

The only change at the LLVM IR level with this PR, is for undef values derived from an address, that get their missing op_deref. It should not change anything at the DWARF level.