### PR TITLE
[DebugInfo] Add getCompleteVarInfo to DebugValueInst to include the vartype (NFC)

### DIFF
--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -5662,35 +5662,36 @@ public:
 
   /// Return the debug variable information attached to this instruction.
   ///
-  /// \param complete If true, always retrieve the complete variable with
-  /// location and scope, and the type if possible. If false, only return the
-  /// values if they are stored (if they are different from the instruction's
-  /// location, scope, and type). This should only be set to false in
-  /// SILPrinter. Incomplete var info is unpredictable, as it will sometimes
-  /// have location and scope and sometimes not.
-  ///
-  /// \note The type is not included because it can change during a pass.
-  /// Passes must make sure to not lose the type information.
-  std::optional<SILDebugVariable> getVarInfo(bool complete = true) const {
+  /// \param includeLoc If true (by default), always return a variable with
+  ///   location and scope. If false, only return the stored values (if they
+  ///   are different from the instruction's location, scope, and type). This
+  ///   should only be set to false in SILPrinter. Incomplete var info is
+  ///   unpredictable, as it will sometimes have location and scope and
+  ///   sometimes not.
+  /// \param includeType If true, fills in the variable type from the SSA
+  ///   operand when not explicitly stored. Off by default because passes
+  ///   that copy VarInfo into new debug_values may get a stale type.
+  ///   Passes must make sure to not lose the type information.
+  /// \note Use `getCompleteVarInfo()` to include everything.
+  std::optional<SILDebugVariable>
+  getVarInfo(bool includeLoc = true, bool includeType = false) const {
     std::optional<SILType> AuxVarType;
     std::optional<SILLocation> VarDeclLoc;
     const SILDebugScope *VarDeclScope = nullptr;
 
     if (HasAuxDebugVariableType)
       AuxVarType = *getTrailingObjects<SILType>();
-    // TODO: passes break if we set the type here, as the type of the operand
-    // can be changed during a pass.
-    // else if (complete)
-    //   AuxVarType = getOperand()->getType().getObjectType();
+    else if (includeType)
+      AuxVarType = getOperand()->getType().getObjectType();
 
     if (hasAuxDebugLocation())
       VarDeclLoc = *getTrailingObjects<SILLocation>();
-    else if (complete)
+    else if (includeLoc)
       VarDeclLoc = getLoc().strippedForDebugVariable();
 
     if (hasAuxDebugScope())
       VarDeclScope = *getTrailingObjects<const SILDebugScope *>();
-    else if (complete)
+    else if (includeLoc)
       VarDeclScope = getDebugScope();
 
     llvm::ArrayRef<SILDIExprElement> DIExprElements(
@@ -5698,6 +5699,15 @@ public:
 
     return VarInfo.get(getDecl(), getTrailingObjects<char>(), AuxVarType,
                        VarDeclLoc, VarDeclScope, DIExprElements);
+  }
+
+  /// Like getVarInfo, but always includes the variable type (falling back
+  /// to the SSA operand type), location and scope. Should always be used
+  /// when adding a DIExpr that affects the type.
+  SILDebugVariable getCompleteVarInfo() const {
+    auto info = getVarInfo(/*includeLoc*/ true, /*includeType*/ true);
+    assert(info && "DebugValueInst must always have debug variable info");
+    return *info;
   }
 
   void setDebugVarScope(const SILDebugScope *NewDS) {

--- a/lib/SILOptimizer/Transforms/SILSROA.cpp
+++ b/lib/SILOptimizer/Transforms/SILSROA.cpp
@@ -300,12 +300,11 @@ void SROAMemoryUseAnalyzer::chopUpAlloca(std::vector<AllocStackInst *> &Worklist
     auto *DVI = dyn_cast<DebugValueInst>(User);
     assert(DVI && "getDebugUses should only return DebugValueInst");
     SILBuilder B(DVI, DVI->getDebugScope());
-    std::optional<SILDebugVariable> DVIVarInfo = DVI->getVarInfo();
-    assert(DVIVarInfo && "debug_value without debug info");
+    SILDebugVariable DVIVarInfo = DVI->getCompleteVarInfo();
 
     for (size_t i : indices(NewAllocations)) {
       auto *NewAI = NewAllocations[i];
-      SILDebugVariable VarInfo = *DVIVarInfo;
+      SILDebugVariable VarInfo = DVIVarInfo;
       if (TT) {
         VarInfo.DIExpr.append(
           SILDebugInfoExpression::createTupleFragment(TT, i));
@@ -313,13 +312,11 @@ void SROAMemoryUseAnalyzer::chopUpAlloca(std::vector<AllocStackInst *> &Worklist
         VarInfo.DIExpr.append(
           SILDebugInfoExpression::createFragment(SD->getStoredProperties()[i]));
       }
-      if (!VarInfo.Type)
-        VarInfo.Type = AI->getElementType();
       B.createDebugValue(DVI->getLoc(), NewAI, VarInfo);
     }
     if (NewAllocations.empty()) {
       // Don't eliminate empty structs, we can use undef as there is no data
-      B.createDebugValue(DVI->getLoc(), SILUndef::get(AI), *DVIVarInfo);
+      B.createDebugValue(DVI->getLoc(), SILUndef::get(AI), DVIVarInfo);
     }
     ToRemove.push_back(DVI);
   }

--- a/lib/SILOptimizer/Utils/InstOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/InstOptUtils.cpp
@@ -1983,18 +1983,13 @@ void swift::salvageDebugInfo(SILInstruction *I) {
       STI->getStructDecl()->getStoredProperties();
     for (Operand *U : getDebugUses(STVal)) {
       auto *DbgInst = cast<DebugValueInst>(U->getUser());
-      auto VarInfo = DbgInst->getVarInfo();
-      if (!VarInfo)
-        continue;
+      auto VarInfo = DbgInst->getCompleteVarInfo();
       for (VarDecl *FD : FieldDecls) {
-        SILDebugVariable NewVarInfo = *VarInfo;
+        SILDebugVariable NewVarInfo = VarInfo;
         auto FieldVal = STI->getFieldValue(FD);
         // Build the corresponding fragment DIExpression
         auto FragDIExpr = SILDebugInfoExpression::createFragment(FD);
         NewVarInfo.DIExpr.append(FragDIExpr);
-
-        if (!NewVarInfo.Type)
-          NewVarInfo.Type = STI->getType();
 
         // Create a new debug_value
         SILBuilder(STI, DbgInst->getDebugScope())
@@ -2009,17 +2004,12 @@ void swift::salvageDebugInfo(SILInstruction *I) {
     auto TTVal = TTI->getResult(0);
     for (Operand *U : getDebugUses(TTVal)) {
       auto *DbgInst = cast<DebugValueInst>(U->getUser());
-      auto VarInfo = DbgInst->getVarInfo();
-      if (!VarInfo)
-        continue;
+      auto VarInfo = DbgInst->getCompleteVarInfo();
       TupleType *TT = TTI->getTupleType();
       for (auto i : indices(TT->getElements())) {
-        SILDebugVariable NewVarInfo = *VarInfo;
+        SILDebugVariable NewVarInfo = VarInfo;
         auto FragDIExpr = SILDebugInfoExpression::createTupleFragment(TT, i);
         NewVarInfo.DIExpr.append(FragDIExpr);
-
-        if (!NewVarInfo.Type)
-          NewVarInfo.Type = TTI->getType();
 
         // Create a new debug_value
         SILBuilder(TTI, DbgInst->getDebugScope())
@@ -2103,17 +2093,14 @@ void swift::createDebugFragments(SILValue oldValue, Projection proj,
     if (!debugVal)
       continue;
 
-    auto varInfo = debugVal->getVarInfo();
+    auto varInfo = debugVal->getCompleteVarInfo();
 
     SILType baseType = oldValue->getType();
 
     // Copy VarInfo and add the corresponding fragment DIExpression.
-    SILDebugVariable newVarInfo = *varInfo;
+    SILDebugVariable newVarInfo = varInfo;
     newVarInfo.DIExpr.append(
         SILDebugInfoExpression::createFragment(proj.getVarDecl(baseType)));
-
-    if (!newVarInfo.Type)
-      newVarInfo.Type = baseType;
 
     // Create a new debug_value
     SILBuilder(debugVal, debugVal->getDebugScope())


### PR DESCRIPTION
Currently, `DebugValueInst->getVarInfo()` returns a debug variable with its type set to null, unless the type was set explicitly during construction.

We cannot return the type of the operand within it without breaking a lot of passes, when types change with generic type substitutions, specialisations, move-only wrapper, ownership attributes, etc.

But in other passes, we do need to keep the type within the debug variables, when we create fragments etc.

This PR adds a `getCompleteVarInfo` which returns a VarInfo with a type, for those uses only. It simplifies the code as we don't need to unwrap an optional (getCompleteVarInfo is only defined on debug_value, which always has a VarInfo) and we don't need to copy the type information into the variable at each use.