### PR TITLE
AST: don't propagate null Type from invalid associated conformance 

### DIFF
--- a/lib/AST/PackConformance.cpp
+++ b/lib/AST/PackConformance.cpp
@@ -135,6 +135,16 @@ PackConformance *PackConformance::getAssociatedConformance(
     Type assocType, ProtocolDecl *protocol) const {
   SmallVector<Type, 4> packElements;
   SmallVector<ProtocolConformanceRef, 4> packConformances;
+  auto &ctx = Protocol->getASTContext();
+
+  // If any pattern's associated conformance lookup fails (e.g. the underlying
+  // conformance is invalid because of a prior diagnostic), fall back to
+  // ErrorType for the corresponding pack element rather than feeding a null
+  // Type into `PackType::get`.
+  auto getAssocType = [&](ProtocolConformanceRef assocConformance) -> Type {
+    return assocConformance ? assocConformance.getType()
+                            : ErrorType::get(ctx);
+  };
 
   auto conformances = getPatternConformances();
   for (unsigned i : indices(conformances)) {
@@ -145,20 +155,18 @@ PackConformance *PackConformance::getAssociatedConformance(
         conformances[i].getAssociatedConformance(assocType, protocol);
       packConformances.push_back(assocConformancePattern);
 
-      auto assocTypePattern = assocConformancePattern.getType();
       packElements.push_back(PackExpansionType::get(
-          assocTypePattern, packExpansion->getCountType()));
+          getAssocType(assocConformancePattern), packExpansion->getCountType()));
     } else {
       auto assocConformanceScalar =
         conformances[i].getAssociatedConformance(assocType, protocol);
       packConformances.push_back(assocConformanceScalar);
 
-      auto assocTypeScalar = assocConformanceScalar.getType();
-      packElements.push_back(assocTypeScalar);
+      packElements.push_back(getAssocType(assocConformanceScalar));
     }
   }
 
-  auto conformingType = PackType::get(Protocol->getASTContext(), packElements);
+  auto conformingType = PackType::get(ctx, packElements);
   return PackConformance::get(conformingType, protocol, packConformances);
 }
 

--- a/test/Generics/pack_conformance_invalid_associated.swift
+++ b/test/Generics/pack_conformance_invalid_associated.swift
@@ -1,0 +1,26 @@
+// RUN: %target-typecheck-verify-swift
+
+// Regression test for a crash in `PackConformance::getAssociatedConformance`
+// when one of the pattern conformances is invalid (here, because `S: P` fails
+// its conformance check after `S` becomes ambiguous). The recursive
+// associated-conformance lookup returned an invalid conformance whose
+// `getType()` is null, and the null leaked into `PackType::get`.
+// See https://github.com/swiftlang/swift/issues/88434.
+
+protocol P {
+  associatedtype A: P // expected-note{{protocol requires nested type 'A'}}
+}
+
+struct S: P { // expected-error{{type 'S' does not conform to protocol 'P'}}
+              // expected-note@-1{{add stubs for conformance}}
+              // expected-note@-2{{found this candidate}}
+              // expected-note@-3{{'S' previously declared here}}
+  typealias A = S // expected-error{{'S' is ambiguous for type lookup in this context}}
+}
+
+func f<each T: P>(_: repeat each T) -> (repeat (each T).A.A.A.A) {}
+
+f(S(), S(), S()) // expected-warning{{result of call to 'f' is unused}}
+
+public struct S {} // expected-note{{found this candidate}}
+                   // expected-error@-1{{invalid redeclaration of 'S'}}

--- a/validation-test/compiler_crashers_fixed/PackType-get-c4a2e5.swift
+++ b/validation-test/compiler_crashers_fixed/PackType-get-c4a2e5.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","original":"ef834ab9","signature":"swift::PackType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>)","signatureAssert":"Assertion failed: (Ptr && \"Cannot dereference a null Type!\"), function operator->","signatureNext":"PackConformance::getAssociatedConformance"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 protocol a {
   associatedtype b
 }


### PR DESCRIPTION
When a pattern conformance in the pack is invalid (e.g. its underlying conformance failed because of a prior diagnostic), `getAssociatedConformance` returned an invalid `ProtocolConformanceRef` whose `getType()` is null. The null type was pushed into `packElements` and tripped an assertion in `PackType::get`. Substitute `ErrorType` for the null so substitution can complete and the existing diagnostics surface to the user. 

Fixes https://github.com/swiftlang/swift/issues/88434.
