### PR TITLE
[cxx-interop] Fix incorrect type lowering for closures in some scenarios

### DIFF
--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -2997,6 +2997,16 @@ LValue SILGenFunction::emitLValue(Expr *e, SGFAccessKind accessKind,
   // reabstraction component.
   auto substFormalType = r.getSubstFormalType();
   auto loweredSubstType = getLoweredType(substFormalType);
+  // For C function pointer fields with Clang type info, use the LValue's
+  // orig formal type to prevent a spurious OrigToSubstComponent that trigger
+  // reabstraction.
+  if (r.getOrigFormalType().isClangType()) {
+    if (auto fnType = substFormalType->lookThroughSingleOptionalType()
+                          ->getAs<AnyFunctionType>())
+      if (fnType->getRepresentation() ==
+              FunctionTypeRepresentation::CFunctionPointer)
+        loweredSubstType = getLoweredType(r.getOrigFormalType(), substFormalType);
+  }
   if (r.getTypeOfRValue() != loweredSubstType.getObjectType()) {
     // Logical components always re-abstract back to the substituted
     // type.
@@ -6063,7 +6073,34 @@ void SILGenFunction::emitAssignToLValue(SILLocation loc,
 
   // Otherwise, force the RHS now to preserve evaluation order.
   auto srcLoc = src.getLocation();
-  RValue srcValue = std::move(src).getAsRValue(*this);
+  RValue srcValue = [&]() -> RValue {
+    // When assigning to a C function pointer field, emit the RHS with a
+    // conversion context carrying the Clang type. This allows
+    // emitCFunctionPointer to use the correct conventions.
+    if (dest.getOrigFormalType().isClangType()) {
+      auto substType = dest.getSubstFormalType();
+      if (auto fnType = substType->lookThroughSingleOptionalType()
+                            ->getAs<AnyFunctionType>()) {
+        if (fnType->getRepresentation() ==
+            FunctionTypeRepresentation::CFunctionPointer) {
+          auto origType = dest.getOrigFormalType();
+          auto loweredTy = getLoweredType(origType, substType);
+          auto conversion = Conversion::getBridging(
+              Conversion::BridgeToObjC, src.getSubstRValueType(), substType,
+              loweredTy, origType);
+          // Use a ConvertingInitialization to carry the Clang type info
+          // through SGFContext to emitCFunctionPointer.
+          ConvertingInitialization init(conversion, SGFContext());
+          ManagedValue mv =
+              std::move(src).getAsSingleValue(*this, SGFContext(&init));
+          if (mv.isInContext())
+            mv = init.finishEmission(*this, srcLoc, mv);
+          return RValue(*this, srcLoc, substType, mv);
+        }
+      }
+    }
+    return std::move(src).getAsRValue(*this);
+  }();
 
   // Peephole: instead of materializing and then assigning into a
   // translation component, untransform the value first.

--- a/test/Interop/Cxx/class/Inputs/closure.h
+++ b/test/Interop/Cxx/class/Inputs/closure.h
@@ -88,4 +88,19 @@ void cfuncConstRefStrong(void (*_Nonnull)(const ARCStrong &));
 void blockConstRefStrong(void (^_Nonnull)(const ARCStrong &));
 #endif
 
+struct ConstRefNonTrivialFPStruct {
+    void (*_Nonnull fp)(const NonTrivial &) = nullptr;
+    void callFp(const NonTrivial &x) { fp(x); }
+};
+
+struct ConstRefTrivialFPStruct {
+    void (*_Nonnull fp)(const Trivial &) = nullptr;
+    void callFp(const Trivial &x) { fp(x); }
+};
+
+struct NullableConstRefNonTrivialFPStruct {
+    void (*_Nullable fp)(const NonTrivial &) = nullptr;
+    void callFp(const NonTrivial &x) { if (fp) fp(x); }
+};
+
 #endif // __CLOSURE__

--- a/test/Interop/Cxx/class/closure-thunk-executable.swift
+++ b/test/Interop/Cxx/class/closure-thunk-executable.swift
@@ -15,4 +15,31 @@ ClosureTestSuite.test("Pass FRT to function pointer") {
   cppGo({N in })
 }
 
+ClosureTestSuite.test("AssignClosureToStructMemberConstRefNonTrivial") {
+  var s = ConstRefNonTrivialFPStruct()
+  s.fp = { nt in }
+  s.callFp(NonTrivial())
+  // Read back and call through the function pointer directly.
+  let f = s.fp
+  f(NonTrivial())
+}
+
+ClosureTestSuite.test("AssignClosureToStructMemberConstRefTrivial") {
+  var s = ConstRefTrivialFPStruct()
+  var t = Trivial()
+  t.i = 42
+  s.fp = { t in }
+  s.callFp(t)
+  let f = s.fp
+  f(t)
+}
+
+ClosureTestSuite.test("AssignClosureToStructMemberNullableConstRef") {
+  var s = NullableConstRefNonTrivialFPStruct()
+  s.fp = { nt in }
+  s.callFp(NonTrivial())
+  let f = s.fp
+  f?(NonTrivial())
+}
+
 runAllTests()

--- a/test/Interop/Cxx/class/closure-thunk-macosx.swift
+++ b/test/Interop/Cxx/class/closure-thunk-macosx.swift
@@ -128,3 +128,30 @@ public func testBlockConstRefTrivial() {
 public func testBlockConstRefStrong() {
   blockConstRefStrong({S in });
 }
+
+// CHECK-LABEL: sil private [thunk] [ossa] @$s4main34testConstRefNonTrivialStructAssign
+// CHECK-SAME: $@convention(c) (@in_guaranteed NonTrivial) -> () {
+// CHECK: bb0(%[[V0:.*]] : $*NonTrivial):
+
+public func testConstRefNonTrivialStructAssign() {
+  var s = ConstRefNonTrivialFPStruct()
+  s.fp = { S in }
+}
+
+// CHECK-LABEL: sil private [thunk] [ossa] @$s4main31testConstRefTrivialStructAssign
+// CHECK-SAME: $@convention(c) (@in_guaranteed Trivial) -> () {
+// CHECK: bb0(%[[V0:.*]] : $*Trivial):
+
+public func testConstRefTrivialStructAssign() {
+  var s = ConstRefTrivialFPStruct()
+  s.fp = { S in }
+}
+
+// CHECK-LABEL: sil private [thunk] [ossa] @$s4main42testNullableConstRefNonTrivialStructAssign
+// CHECK-SAME: $@convention(c) (@in_guaranteed NonTrivial) -> () {
+// CHECK: bb0(%[[V0:.*]] : $*NonTrivial):
+
+public func testNullableConstRefNonTrivialStructAssign() {
+  var s = NullableConstRefNonTrivialFPStruct()
+  s.fp = { S in }
+}


### PR DESCRIPTION
When a closure is passed as a function pointer to C++, we rely on an initializing conversion to plumb the clang type through so we can lower the closure's foreign entry point with the right conventions (lowering without the clang type results in the wrong convention for const T& parameters). Unfortunately, when we assign to a field, we did not have these initializing conversions. This patch sets up an initializing conversion, does the silgen into that context and assigns the initialized value into the lvalue. I also had to make some changes to how the lvalue components are being added to avoid some spurious reabstractions.

rdar://156635576
