### PR TITLE
Sema: Don't record bogus trail changes in salvage()

### DIFF
--- a/include/swift/Sema/CSBindings.h
+++ b/include/swift/Sema/CSBindings.h
@@ -329,7 +329,7 @@ struct PotentialBindings {
     return Protocols;
   }
 
-  void inferFromLiteral(Constraint *literal);
+  void inferFromLiteral(Constraint *literal, bool recordChange=true);
 
   /// Attempt to infer a new binding and other useful information
   /// (i.e. whether bindings should be delayed) from the given

--- a/include/swift/Sema/CSTrail.h
+++ b/include/swift/Sema/CSTrail.h
@@ -295,7 +295,19 @@ public:
   SolverTrail(const SolverTrail &) = delete;
   SolverTrail &operator=(const SolverTrail &) = delete;
 
-  bool isUndoActive() const { return UndoActive; }
+  bool isClosed() const {
+    return Closed;
+  }
+
+  void close() {
+    ASSERT(!Closed);
+    Closed = true;
+  }
+
+  void open() {
+    ASSERT(Closed);
+    Closed = false;
+  }
 
   void recordChange(Change change);
 
@@ -321,7 +333,11 @@ private:
 
   uint64_t Profile[unsigned(ChangeKind::Last) + 1];
 
-  bool UndoActive = false;
+  /// If true, new changes cannot be recorded, either because we're inside undo(),
+  /// or we've finished solving, but we're still inspecting the solver state for
+  /// diagnostics in salvage().
+  bool Closed = false;
+
   unsigned Total = 0;
   unsigned Max = 0;
 };

--- a/include/swift/Sema/TypeVariableType.h
+++ b/include/swift/Sema/TypeVariableType.h
@@ -249,7 +249,7 @@ public:
       impl = &nextTV->getImpl();
     }
 
-    if (impl == this || !trail || trail->isUndoActive())
+    if (impl == this || !trail || trail->isClosed())
       return result;
 
     // Perform path compression.

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -1744,7 +1744,8 @@ void BindingSet::coalesceIntegerAndFloatLiteralRequirements() {
   }
 }
 
-void PotentialBindings::inferFromLiteral(Constraint *constraint) {
+void PotentialBindings::inferFromLiteral(Constraint *constraint,
+                                         bool recordChange) {
   ASSERT(TypeVar);
   ASSERT(isDirectRequirement(CS, TypeVar, constraint));
 
@@ -1762,10 +1763,9 @@ void PotentialBindings::inferFromLiteral(Constraint *constraint) {
     defaultType = TypeChecker::getDefaultType(protocol, CS.DC);
   }
 
-  // "undo" check is necessary here because this method is called
-  // from `Change::undo`, that's necessary because we only record
-  // a constraint.
-  if (CS.solverState && !CS.solverState->Trail.isUndoActive())
+  // "recordChange" flag is necessary here because this method is also called
+  // from Change::undo().
+  if (CS.solverState && recordChange)
     CS.recordChange(SolverTrail::Change::AddedLiteral(TypeVar, constraint));
 
   Literals.emplace_back(protocol, constraint, defaultType, /*isDirect=*/true);

--- a/lib/Sema/CSTrail.cpp
+++ b/lib/Sema/CSTrail.cpp
@@ -43,8 +43,14 @@ SolverTrail::~SolverTrail() {
   // If constraint system is in an invalid state, it's
   // possible that constraint graph is corrupted as well
   // so let's not attempt to check change log.
-  if (!CS.inInvalidState())
-    ASSERT(Changes.empty() && "Trail corrupted");
+  if (!CS.inInvalidState()) {
+    if (!Changes.empty()) {
+      ABORT([&](llvm::raw_ostream &out) {
+        out << "Trail corrupted; all changes should have been undone by now:\n";
+        dump(out);
+      });
+    }
+  }
 }
 
 #define LOCATOR_CHANGE(Name, _) \
@@ -619,7 +625,7 @@ void SolverTrail::Change::undo(ConstraintSystem &cs) const {
 
   case ChangeKind::RetractedLiteral: {
     auto &bindings = cg[TheConstraint.TypeVar].getPotentialBindings();
-    bindings.inferFromLiteral(TheConstraint.Constraint);
+    bindings.inferFromLiteral(TheConstraint.Constraint, /*recordChange=*/false);
     ++bindings.GenerationNumber;
     break;
   }
@@ -904,7 +910,7 @@ void SolverTrail::Change::dump(llvm::raw_ostream &out,
 
 void SolverTrail::recordChange(Change change) {
   LLVM_DEBUG(llvm::dbgs() << "+ "; change.dump(llvm::dbgs(), CS, 0););
-  ASSERT(!UndoActive);
+  ASSERT(!Closed);
 
   Changes.push_back(change);
 
@@ -915,6 +921,8 @@ void SolverTrail::recordChange(Change change) {
 }
 
 void SolverTrail::undo(unsigned toIndex) {
+  ASSERT(!Closed);
+
   // Don't attempt to rollback if constraint system ended up
   // in an invalid state.
   if (CS.inInvalidState())
@@ -934,8 +942,7 @@ void SolverTrail::undo(unsigned toIndex) {
              llvm::dbgs() << "\n");
 
   ASSERT(Changes.size() >= toIndex && "Trail corrupted");
-  ASSERT(!UndoActive);
-  UndoActive = true;
+  close();
 
   for (unsigned i = Changes.size(); i > toIndex; i--) {
     auto change = Changes[i - 1];
@@ -944,7 +951,7 @@ void SolverTrail::undo(unsigned toIndex) {
   }
 
   Changes.resize(toIndex);
-  UndoActive = false;
+  open();
 }
 
 void SolverTrail::dumpActiveScopeChanges(llvm::raw_ostream &out,

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2062,6 +2062,10 @@ SolutionResult ConstraintSystem::salvage() {
     // Solve the system.
     solveImpl(viable);
 
+    // We have to keep solverState around for diagnoseAmbiguityWithFixes(),
+    // but we should not record any more changes from this point on.
+    state.Trail.close();
+
     // If we hit a threshold, we're done.
     if (isTooComplex(viable))
       return SolutionResult::forTooComplex(getTooComplexRange());

--- a/test/Sema/inlinearray.swift
+++ b/test/Sema/inlinearray.swift
@@ -159,3 +159,12 @@ func testPointerConversion() {
 }
 
 func acceptPointer(_ pointer: UnsafeMutablePointer<Int>) {}
+
+// rdar://152143989
+struct Test3<let count1: Int> {
+  init(value1: InlineArray<count1, Int>) {}
+}
+struct Test1<T> { init(test2: T) {} }
+
+let _ = Test1<Test3>(test2: Test3(value1: ["x"]))
+// expected-error@-1 {{cannot convert value of type 'String' to expected element type 'Int'}}

--- a/validation-test/Sema/type_checker_crashers_fixed/issue-81801.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/issue-81801.swift
@@ -1,0 +1,100 @@
+// RUN: not %target-swift-frontend -typecheck %s
+
+let test1 = try Test1<Test2>(
+    test2: Test2(
+        test3_1: Test3(
+            value1: [],
+            value2: ["1"],
+            value3: ["2", "2"],
+            value4: ["3"],
+            value5: ["\"9\", \"9\", \"9\""],
+            value6: [],
+            value7: ["UInt8(7)"]
+        ),
+        test3_2: Test3(
+            value1: ["3, 3, 3"],
+            value2: ["4 4, 4 4"],
+            value3: [StaticString("5, 5, 5, 5, 5")],
+            value4: [],
+            value5: ["6"],
+            value6: ["\"8\", 8"],
+            value7: []
+        )
+    )
+)
+
+public protocol Test1Protocol: Sendable {
+}
+public final class Test1<ConcreteTest2: Test2Protocol>: Test1Protocol {
+    public var test2:ConcreteTest2
+    
+    public init(test2: ConcreteTest2) throws {
+        self.test2 = test2
+    }
+}
+
+public protocol Test2Protocol: Sendable {
+}
+public struct Test2<
+        ConcreteTest3_1: Test3Protocol,
+        ConcreteTest3_2: Test3Protocol
+    >: Test2Protocol {
+    public private(set) var test3_1:ConcreteTest3_1
+    public private(set) var test3_2:ConcreteTest3_2
+
+    public init(
+        test3_1: ConcreteTest3_1,
+        test3_2: ConcreteTest3_2
+    ) {
+        self.test3_1 = test3_1
+        self.test3_2 = test3_2
+    }
+}
+
+public protocol Test3Protocol: CustomDebugStringConvertible, Sendable {
+}
+public struct Test3<
+        let count1: Int,
+        let count2: Int,
+        let count3: Int,
+        let count4: Int,
+        let count5: Int,
+        let count6: Int,
+        let count7: Int
+    >: Test3Protocol {
+    public let value1:InlineArray<count1, Value<StaticString>>
+    public let value2:InlineArray<count2, Value<StaticString>>
+    public let value3:InlineArray<count3, Value<StaticString>>
+    public let value4:InlineArray<count4, Value<StaticString>>
+    public let value5:InlineArray<count5, Value<StaticString>>
+    public let value6:InlineArray<count6, Value<StaticString>>
+    public let value7:InlineArray<count7, Value<StaticString>>
+
+    public init(
+        value1: InlineArray<count1, Value<StaticString>>,
+        value2: InlineArray<count2, Value<StaticString>>,
+        value3: InlineArray<count3, Value<StaticString>>,
+        value4: InlineArray<count4, Value<StaticString>>,
+        value5: InlineArray<count5, Value<StaticString>>,
+        value6: InlineArray<count6, Value<StaticString>>,
+        value7: InlineArray<count7, Value<StaticString>>
+    ) {
+        self.value1 = value1
+        self.value2 = value2
+        self.value3 = value3
+        self.value4 = value4
+        self.value5 = value5
+        self.value6 = value6
+        self.value7 = value7
+    }
+
+    public var debugDescription: String { "" }
+
+    public struct Value<T: Sendable>: Sendable {
+        public let value:T
+
+        public init(_ value: T) {
+            self.value = value
+        }
+    }
+}

--- a/validation-test/Sema/type_checker_crashers_fixed/issue-84884.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/issue-84884.swift
@@ -1,0 +1,34 @@
+// RUN: %target-typecheck-verify-swift
+
+protocol Proto<Assoc> {
+  associatedtype Assoc
+}
+
+struct Generic<Assoc>: Proto {
+  static func foo(_: Generic<Assoc>) -> Generic<Assoc> {}
+  static func bar(_: some Proto<Assoc>) -> Generic<Assoc> {}
+}
+
+struct S1 {}
+struct S2 {}
+
+extension Proto {
+  func overload() -> some Proto<S1> where Assoc == S1 {
+    Generic()
+  }
+  func overload() -> some Proto<S1> where Assoc == Generic<Generic<S1>> {
+    Generic()
+  }
+}
+
+struct Struct: Proto {
+  typealias Assoc = Generic<Generic<S2>>
+  init(_: Int) {}
+}
+
+func test() {
+  // FIXME: This used to crash, but it still produces a bogus diagnostic.
+  let _ = Generic.foo(Generic.bar(Struct(0).overload()))
+  // expected-error@-1 {{failed to produce diagnostic for expression; please submit a bug report}}
+}
+

--- a/validation-test/compiler_crashers_fixed/SolverTrail-0e9a3e.swift
+++ b/validation-test/compiler_crashers_fixed/SolverTrail-0e9a3e.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","original":"cbf69c52","signature":"swift::constraints::SolverTrail::~SolverTrail()","signatureAssert":"Assertion failed: (Changes.empty() && \"Trail corrupted\"), function ~SolverTrail","signatureNext":"ConstraintSystem::SolverState"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 @propertyWrapper struct a<b> {
   init(wrappedValue: a)
   var wrappedValue: b

--- a/validation-test/compiler_crashers_fixed/a956308a078fc27f.swift
+++ b/validation-test/compiler_crashers_fixed/a956308a078fc27f.swift
@@ -1,5 +1,5 @@
 // https://github.com/swiftlang/swift/issues/84884
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 
 protocol Proto<Assoc> {
   associatedtype Assoc


### PR DESCRIPTION
In salvage(), there is a point where we're done solving, but we haven't yet torn down ConstraintSystem::solverState, so the trail is still active.

It was possible to cause a change to be recorded, because of the path compression we do in TypeVariableType::getRepresentative().

We have a similar situation where we don't want to do path compression when we're looking up a type variable's representative in the middle of undo(). Generalize the existing UndoActive flag to Closed, and set it after solving in salvage() as well.

While we're here, clean up an existing place where we would check isUndoActive() to not do that anymore, so now getRepresentative() is the only place that checks the state of the trail.

A better cleanup would be to try to refactor or eliminate SolverState entirely, but this fix is pretty clean.

Note that the test cases are somewhat random because the exact scenario is hard to trigger; you need to set up an invalid expression where the type variables are set up in just the right way so that path compression kicks in.

- Fixes rdar://152143989.
- Fixes https://github.com/swiftlang/swift/issues/81801.
- Fixes https://github.com/swiftlang/swift/issues/84884.