### PR TITLE
[6.4][rbi] Fall back to type-based diagnostics when name inference fails for merge region errors

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -1250,7 +1250,7 @@ GROUPED_ERROR(regionbasedisolation_merge_region_failure_error_functionisolation,
       "passing %select{%0|%1 %0}4 to %3 %kind2 risks causing data races",
       (Identifier, StringRef, const ValueDecl *, StringRef, bool))
 GROUPED_ERROR(regionbasedisolation_merge_region_failure_error_functionisolation_type, RegionIsolationCrossIsolationDataRace, none,
-      "passing %select{%0|%1 %0}4 to %3 %kind2 risks causing data races",
+      "passing %select{a value of type %0|%1 value of type %0}4 to %3 %kind2 risks causing data races",
       (Type, StringRef, const ValueDecl *, StringRef, bool))
 GROUPED_ERROR(regionbasedisolation_merge_region_failure_error_functionisolation_sil, RegionIsolationCrossIsolationDataRace, none,
       "passing %1 %0 to %3 %2 risks causing data races",
@@ -1266,6 +1266,65 @@ NOTE(regionbasedisolation_merge_region_failure_error_nonisolatedfunction_note, n
 GROUPED_ERROR(regionbasedisolation_merge_region_failure_error_cast, RegionIsolationCrossIsolationDataRace, none,
       "casting %select{%0|%1 %0}4 to %3 %2 risks causing data races",
       (Identifier, StringRef, Type, StringRef, bool))
+
+// Unknown - typed variants
+GROUPED_ERROR(regionbasedisolation_merge_region_failure_error_unknown_src_type, RegionIsolationCrossIsolationDataRace, none,
+      "allowing references between %select{a value of type %0|%1 value of type %0}4 and %3 %2 risks causing data races",
+      (Type, StringRef, Identifier, StringRef, bool))
+NOTE(regionbasedisolation_merge_region_failure_error_unknown_src_type_note, none,
+     "a value of type %0 could become accessible to %3 code despite remaining accessible to %select{code in the current task|%1 code}4",
+     (Type, StringRef, Identifier, StringRef, bool))
+GROUPED_ERROR(regionbasedisolation_merge_region_failure_error_unknown_dst_type, RegionIsolationCrossIsolationDataRace, none,
+      "allowing references between %select{%0|%1 %0}4 and %3 value of type %2 risks causing data races",
+      (Identifier, StringRef, Type, StringRef, bool))
+NOTE(regionbasedisolation_merge_region_failure_error_unknown_dst_type_note, none,
+     "%0 could become accessible to %3 code despite remaining accessible to %select{code in the current task|%1 code}4",
+     (Identifier, StringRef, Type, StringRef, bool))
+GROUPED_ERROR(regionbasedisolation_merge_region_failure_error_unknown_both_type, RegionIsolationCrossIsolationDataRace, none,
+      "allowing references between %select{a value of type %0|%1 value of type %0}4 and %3 value of type %2 risks causing data races",
+      (Type, StringRef, Type, StringRef, bool))
+NOTE(regionbasedisolation_merge_region_failure_error_unknown_both_type_note, none,
+     "a value of type %0 could become accessible to %3 code despite remaining accessible to %select{code in the current task|%1 code}4",
+     (Type, StringRef, Type, StringRef, bool))
+
+// Assign - typed variants
+GROUPED_ERROR(regionbasedisolation_merge_region_failure_error_assign_src_type, RegionIsolationCrossIsolationDataRace, none,
+      "assigning %select{a value of type %0|%1 value of type %0}4 to %3 %2 risks causing data races",
+      (Type, StringRef, Identifier, StringRef, bool))
+NOTE(regionbasedisolation_merge_region_failure_error_assign_src_type_note, none,
+      "a value of type %0 could become accessible to %2 code despite remaining accessible to %select{code in the current task|%1 code}3",
+      (Type, StringRef, StringRef, bool))
+GROUPED_ERROR(regionbasedisolation_merge_region_failure_error_assign_dst_type, RegionIsolationCrossIsolationDataRace, none,
+      "assigning %select{%0|%1 %0}4 to %3 value of type %2 risks causing data races",
+      (Identifier, StringRef, Type, StringRef, bool))
+GROUPED_ERROR(regionbasedisolation_merge_region_failure_error_assign_both_type, RegionIsolationCrossIsolationDataRace, none,
+      "assigning %select{a value of type %0|%1 value of type %0}4 to %3 value of type %2 risks causing data races",
+      (Type, StringRef, Type, StringRef, bool))
+
+// NonisolatedFunction - typed variants
+GROUPED_ERROR(regionbasedisolation_merge_region_failure_error_nonisolatedfunction_src_type, RegionIsolationCrossIsolationDataRace, none,
+      "passing %select{a value of type %0|%1 value of type %0}5 and %3 %2 as arguments to %kind4 risks causing data races",
+      (Type, StringRef, Identifier, StringRef, const ValueDecl *, bool))
+NOTE(regionbasedisolation_merge_region_failure_error_nonisolatedfunction_src_type_note, none,
+     "%2 could begin referencing a value of type %0 allowing concurrent access to a value of type %0 by %3 code and %select{code in the current task|%1 code}5",
+     (Type, StringRef, Identifier, StringRef, const ValueDecl *, bool))
+GROUPED_ERROR(regionbasedisolation_merge_region_failure_error_nonisolatedfunction_dst_type, RegionIsolationCrossIsolationDataRace, none,
+      "passing %select{%0|%1 %0}5 and %3 value of type %2 as arguments to %kind4 risks causing data races",
+      (Identifier, StringRef, Type, StringRef, const ValueDecl *, bool))
+NOTE(regionbasedisolation_merge_region_failure_error_nonisolatedfunction_dst_type_note, none,
+     "a value of type %2 could begin referencing %0 allowing concurrent access to %0 by %3 code and %select{code in the current task|%1 code}5",
+     (Identifier, StringRef, Type, StringRef, const ValueDecl *, bool))
+GROUPED_ERROR(regionbasedisolation_merge_region_failure_error_nonisolatedfunction_both_type, RegionIsolationCrossIsolationDataRace, none,
+      "passing %select{a value of type %0|%1 value of type %0}5 and %3 value of type %2 as arguments to %kind4 risks causing data races",
+      (Type, StringRef, Type, StringRef, const ValueDecl *, bool))
+NOTE(regionbasedisolation_merge_region_failure_error_nonisolatedfunction_both_type_note, none,
+     "a value of type %2 could begin referencing a value of type %0 allowing concurrent access to a value of type %0 by %3 code and %select{code in the current task|%1 code}5",
+     (Type, StringRef, Type, StringRef, const ValueDecl *, bool))
+
+// Cast - typed variant
+GROUPED_ERROR(regionbasedisolation_merge_region_failure_error_cast_type, RegionIsolationCrossIsolationDataRace, none,
+      "casting %select{a value of type %0|%1 value of type %0}4 to %3 %2 risks causing data races",
+      (Type, StringRef, Type, StringRef, bool))
 
 // Concurrency related diagnostics
 ERROR(cannot_find_executor_factory_type, none,

--- a/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
@@ -70,6 +70,18 @@ static llvm::cl::opt<bool> ForceTypedErrors(
                    "it easier to test typed errors"),
     llvm::cl::Hidden);
 
+static llvm::cl::opt<bool> ForceTypedSrcErrors(
+    "sil-regionbasedisolation-force-use-of-typed-src-errors",
+    llvm::cl::desc("Force the usage of typed instead of named errors for the "
+                   "src side of incompatible region merge diagnostics"),
+    llvm::cl::Hidden);
+
+static llvm::cl::opt<bool> ForceTypedDstErrors(
+    "sil-regionbasedisolation-force-use-of-typed-dst-errors",
+    llvm::cl::desc("Force the usage of typed instead of named errors for the "
+                   "dst side of incompatible region merge diagnostics"),
+    llvm::cl::Hidden);
+
 //===----------------------------------------------------------------------===//
 //                              MARK: Utilities
 //===----------------------------------------------------------------------===//
@@ -217,6 +229,39 @@ inferNameAndRootHelper(SILValue value) {
   if (ForceTypedErrors)
     return {};
   return VariableNameInferrer::inferNameAndRoot(value);
+}
+
+/// Attempt to infer a type for \p value. Used as a fallback when name inference
+/// fails for cross-isolation merge diagnostics. Prefers AST-level types from
+/// expressions or declarations, then falls back to the SIL value's type.
+static std::optional<Type> inferTypeHelper(SILValue value) {
+  if (auto *svi = dyn_cast<SingleValueInstruction>(value)) {
+    if (auto *expr = svi->getLoc().getAsASTNode<Expr>())
+      return expr->findOriginalType();
+  }
+  if (auto *arg = dyn_cast<SILFunctionArgument>(value)) {
+    if (auto *decl = arg->getDecl())
+      return decl->getInterfaceType();
+  }
+  return value->getType().getObjectType().getASTType();
+}
+
+/// Like inferNameHelper but also returns none when ForceTypedSrcErrors is set.
+/// Used for the src (task-isolated) side of incompatible region merge
+/// diagnostics to allow testing the typed-src-only path.
+static std::optional<Identifier> inferMergeSrcNameHelper(SILValue value) {
+  if (ForceTypedErrors || ForceTypedSrcErrors)
+    return {};
+  return VariableNameInferrer::inferName(value);
+}
+
+/// Like inferNameHelper but also returns none when ForceTypedDstErrors is set.
+/// Used for the dst (actor-isolated) side of incompatible region merge
+/// diagnostics to allow testing the typed-dst-only path.
+static std::optional<Identifier> inferMergeDstNameHelper(SILValue value) {
+  if (ForceTypedErrors || ForceTypedDstErrors)
+    return {};
+  return VariableNameInferrer::inferName(value);
 }
 
 /// Sometimes we use a store_borrow + temporary to materialize a borrowed value
@@ -3943,14 +3988,8 @@ void IncompatibleRegionMergeDiagnosticEmitter::emitUnknown() {
 
   // We should always be able to find a name for an inout sending param. If we
   // do not, emit an unknown pattern error.
-  auto srcName = inferNameHelper(srcRegionValue.getValue());
-  if (!srcName) {
-    return emitUnknownPatternError();
-  }
-  auto dstName = inferNameHelper(dstRegionValue.getValue());
-  if (!dstName) {
-    return emitUnknownPatternError();
-  }
+  auto srcName = inferMergeSrcNameHelper(srcRegionValue.getValue());
+  auto dstName = inferMergeDstNameHelper(dstRegionValue.getValue());
 
   if (!srcIsolationInfo)
     return emitUnknownPatternError();
@@ -3960,16 +3999,74 @@ void IncompatibleRegionMergeDiagnosticEmitter::emitUnknown() {
   auto srcIsolationStr = srcIsolation.printForDiagnostics(getFunction());
   auto dstIsolationStr = dstIsolation.printForDiagnostics(getFunction());
 
-  diagnoseError(op->getUser(),
-                diag::regionbasedisolation_merge_region_failure_error_unknown,
-                *srcName, srcIsolationStr, *dstName, dstIsolationStr,
-                !srcIsolation->isTaskIsolated())
-      .limitBehaviorIf(getBehaviorLimit());
-  diagnoseNote(
-      op->getUser(),
-      diag::regionbasedisolation_merge_region_failure_error_unknown_note,
-      *srcName, srcIsolationStr, *dstName, dstIsolationStr,
-      !srcIsolation->isTaskIsolated());
+  if (srcName && dstName) {
+    diagnoseError(op->getUser(),
+                  diag::regionbasedisolation_merge_region_failure_error_unknown,
+                  *srcName, srcIsolationStr, *dstName, dstIsolationStr,
+                  !srcIsolation->isTaskIsolated())
+        .limitBehaviorIf(getBehaviorLimit());
+    diagnoseNote(
+        op->getUser(),
+        diag::regionbasedisolation_merge_region_failure_error_unknown_note,
+        *srcName, srcIsolationStr, *dstName, dstIsolationStr,
+        !srcIsolation->isTaskIsolated());
+    return;
+  }
+
+  auto srcType = srcName ? std::optional<Type>()
+                         : inferTypeHelper(srcRegionValue.getValue());
+  auto dstType = dstName ? std::optional<Type>()
+                         : inferTypeHelper(dstRegionValue.getValue());
+
+  if (srcName && dstType) {
+    diagnoseError(
+        op->getUser(),
+        diag::regionbasedisolation_merge_region_failure_error_unknown_dst_type,
+        *srcName, srcIsolationStr, *dstType, dstIsolationStr,
+        !srcIsolation->isTaskIsolated())
+        .limitBehaviorIf(getBehaviorLimit());
+    diagnoseNote(
+        op->getUser(),
+        diag::
+            regionbasedisolation_merge_region_failure_error_unknown_dst_type_note,
+        *srcName, srcIsolationStr, *dstType, dstIsolationStr,
+        !srcIsolation->isTaskIsolated());
+    return;
+  }
+
+  if (dstName && srcType) {
+    diagnoseError(
+        op->getUser(),
+        diag::regionbasedisolation_merge_region_failure_error_unknown_src_type,
+        *srcType, srcIsolationStr, *dstName, dstIsolationStr,
+        !srcIsolation->isTaskIsolated())
+        .limitBehaviorIf(getBehaviorLimit());
+    diagnoseNote(
+        op->getUser(),
+        diag::
+            regionbasedisolation_merge_region_failure_error_unknown_src_type_note,
+        *srcType, srcIsolationStr, *dstName, dstIsolationStr,
+        !srcIsolation->isTaskIsolated());
+    return;
+  }
+
+  if (srcType && dstType) {
+    diagnoseError(
+        op->getUser(),
+        diag::regionbasedisolation_merge_region_failure_error_unknown_both_type,
+        *srcType, srcIsolationStr, *dstType, dstIsolationStr,
+        !srcIsolation->isTaskIsolated())
+        .limitBehaviorIf(getBehaviorLimit());
+    diagnoseNote(
+        op->getUser(),
+        diag::
+            regionbasedisolation_merge_region_failure_error_unknown_both_type_note,
+        *srcType, srcIsolationStr, *dstType, dstIsolationStr,
+        !srcIsolation->isTaskIsolated());
+    return;
+  }
+
+  return emitUnknownPatternError();
 }
 
 void IncompatibleRegionMergeDiagnosticEmitter::emitAssign() {
@@ -3994,27 +4091,79 @@ void IncompatibleRegionMergeDiagnosticEmitter::emitAssign() {
 
   // We should always be able to find a name for an inout sending param. If we
   // do not, emit an unknown pattern error.
-  auto srcName = inferNameHelper(srcRegionValue.getValue());
-  if (!srcName) {
-    return emitUnknownPatternError();
-  }
-  auto dstName = inferNameHelper(dstRegionValue.getValue());
-  if (!dstName) {
-    return emitUnknownPatternError();
-  }
+  auto srcName = inferMergeSrcNameHelper(srcRegionValue.getValue());
+  auto dstName = inferMergeDstNameHelper(dstRegionValue.getValue());
 
   auto srcIsolationStr = srcIsolationInfo.printForDiagnostics(getFunction());
   auto dstIsolationStr = dstIsolationInfo.printForDiagnostics(getFunction());
-  diagnoseError(op->getUser(),
-                diag::regionbasedisolation_merge_region_failure_error_assign,
-                *srcName, srcIsolationStr, *dstName, dstIsolationStr,
-                !srcIsolation->isTaskIsolated())
-      .limitBehaviorIf(getBehaviorLimit());
-  diagnoseNote(
-      op->getUser(),
-      diag::regionbasedisolation_merge_region_failure_error_assign_note,
-      *srcName, srcIsolationStr, dstIsolationStr,
-      !srcIsolation->isTaskIsolated());
+
+  if (srcName && dstName) {
+    diagnoseError(op->getUser(),
+                  diag::regionbasedisolation_merge_region_failure_error_assign,
+                  *srcName, srcIsolationStr, *dstName, dstIsolationStr,
+                  !srcIsolation->isTaskIsolated())
+        .limitBehaviorIf(getBehaviorLimit());
+    diagnoseNote(
+        op->getUser(),
+        diag::regionbasedisolation_merge_region_failure_error_assign_note,
+        *srcName, srcIsolationStr, dstIsolationStr,
+        !srcIsolation->isTaskIsolated());
+    return;
+  }
+
+  auto srcType = srcName ? std::optional<Type>()
+                         : inferTypeHelper(srcRegionValue.getValue());
+  auto dstType = dstName ? std::optional<Type>()
+                         : inferTypeHelper(dstRegionValue.getValue());
+
+  if (srcName && dstType) {
+    diagnoseError(
+        op->getUser(),
+        diag::regionbasedisolation_merge_region_failure_error_assign_dst_type,
+        *srcName, srcIsolationStr, *dstType, dstIsolationStr,
+        !srcIsolation->isTaskIsolated())
+        .limitBehaviorIf(getBehaviorLimit());
+    diagnoseNote(
+        op->getUser(),
+        diag::regionbasedisolation_merge_region_failure_error_assign_note,
+        *srcName, srcIsolationStr, dstIsolationStr,
+        !srcIsolation->isTaskIsolated());
+    return;
+  }
+
+  if (dstName && srcType) {
+    diagnoseError(
+        op->getUser(),
+        diag::regionbasedisolation_merge_region_failure_error_assign_src_type,
+        *srcType, srcIsolationStr, *dstName, dstIsolationStr,
+        !srcIsolation->isTaskIsolated())
+        .limitBehaviorIf(getBehaviorLimit());
+    diagnoseNote(
+        op->getUser(),
+        diag::
+            regionbasedisolation_merge_region_failure_error_assign_src_type_note,
+        *srcType, srcIsolationStr, dstIsolationStr,
+        !srcIsolation->isTaskIsolated());
+    return;
+  }
+
+  if (srcType && dstType) {
+    diagnoseError(
+        op->getUser(),
+        diag::regionbasedisolation_merge_region_failure_error_assign_both_type,
+        *srcType, srcIsolationStr, *dstType, dstIsolationStr,
+        !srcIsolation->isTaskIsolated())
+        .limitBehaviorIf(getBehaviorLimit());
+    diagnoseNote(
+        op->getUser(),
+        diag::
+            regionbasedisolation_merge_region_failure_error_assign_src_type_note,
+        *srcType, srcIsolationStr, dstIsolationStr,
+        !srcIsolation->isTaskIsolated());
+    return;
+  }
+
+  return emitUnknownPatternError();
 }
 
 void IncompatibleRegionMergeDiagnosticEmitter::emitNonisolatedFunction() {
@@ -4038,14 +4187,8 @@ void IncompatibleRegionMergeDiagnosticEmitter::emitNonisolatedFunction() {
 
   // We should always be able to find a name for an inout sending param. If we
   // do not, emit an unknown pattern error.
-  auto srcName = inferNameHelper(srcRegionValue.getValue());
-  if (!srcName) {
-    return emitUnknownPatternError();
-  }
-  auto dstName = inferNameHelper(dstRegionValue.getValue());
-  if (!dstName) {
-    return emitUnknownPatternError();
-  }
+  auto srcName = inferMergeSrcNameHelper(srcRegionValue.getValue());
+  auto dstName = inferMergeDstNameHelper(dstRegionValue.getValue());
 
   auto srcIsolationStr = srcIsolation.printForDiagnostics(getFunction());
   auto dstIsolationStr = dstIsolation.printForDiagnostics(getFunction());
@@ -4056,18 +4199,79 @@ void IncompatibleRegionMergeDiagnosticEmitter::emitNonisolatedFunction() {
   if (!declRef)
     return emitUnknownPatternError();
 
-  diagnoseError(
-      op->getUser(),
-      diag::regionbasedisolation_merge_region_failure_error_nonisolatedfunction,
-      *srcName, srcIsolationStr, *dstName, dstIsolationStr, declRef.getDecl(),
-      !srcIsolation->isTaskIsolated())
-      .limitBehaviorIf(getBehaviorLimit());
-  diagnoseNote(
-      op->getUser(),
-      diag::
-          regionbasedisolation_merge_region_failure_error_nonisolatedfunction_note,
-      *srcName, srcIsolationStr, *dstName, dstIsolationStr, declRef.getDecl(),
-      !srcIsolation->isTaskIsolated());
+  if (srcName && dstName) {
+    diagnoseError(
+        op->getUser(),
+        diag::regionbasedisolation_merge_region_failure_error_nonisolatedfunction,
+        *srcName, srcIsolationStr, *dstName, dstIsolationStr, declRef.getDecl(),
+        !srcIsolation->isTaskIsolated())
+        .limitBehaviorIf(getBehaviorLimit());
+    diagnoseNote(
+        op->getUser(),
+        diag::
+            regionbasedisolation_merge_region_failure_error_nonisolatedfunction_note,
+        *srcName, srcIsolationStr, *dstName, dstIsolationStr, declRef.getDecl(),
+        !srcIsolation->isTaskIsolated());
+    return;
+  }
+
+  auto srcType = srcName ? std::optional<Type>()
+                         : inferTypeHelper(srcRegionValue.getValue());
+  auto dstType = dstName ? std::optional<Type>()
+                         : inferTypeHelper(dstRegionValue.getValue());
+
+  if (srcName && dstType) {
+    diagnoseError(
+        op->getUser(),
+        diag::
+            regionbasedisolation_merge_region_failure_error_nonisolatedfunction_dst_type,
+        *srcName, srcIsolationStr, *dstType, dstIsolationStr,
+        declRef.getDecl(), !srcIsolation->isTaskIsolated())
+        .limitBehaviorIf(getBehaviorLimit());
+    diagnoseNote(
+        op->getUser(),
+        diag::
+            regionbasedisolation_merge_region_failure_error_nonisolatedfunction_dst_type_note,
+        *srcName, srcIsolationStr, *dstType, dstIsolationStr,
+        declRef.getDecl(), !srcIsolation->isTaskIsolated());
+    return;
+  }
+
+  if (dstName && srcType) {
+    diagnoseError(
+        op->getUser(),
+        diag::
+            regionbasedisolation_merge_region_failure_error_nonisolatedfunction_src_type,
+        *srcType, srcIsolationStr, *dstName, dstIsolationStr,
+        declRef.getDecl(), !srcIsolation->isTaskIsolated())
+        .limitBehaviorIf(getBehaviorLimit());
+    diagnoseNote(
+        op->getUser(),
+        diag::
+            regionbasedisolation_merge_region_failure_error_nonisolatedfunction_src_type_note,
+        *srcType, srcIsolationStr, *dstName, dstIsolationStr,
+        declRef.getDecl(), !srcIsolation->isTaskIsolated());
+    return;
+  }
+
+  if (srcType && dstType) {
+    diagnoseError(
+        op->getUser(),
+        diag::
+            regionbasedisolation_merge_region_failure_error_nonisolatedfunction_both_type,
+        *srcType, srcIsolationStr, *dstType, dstIsolationStr,
+        declRef.getDecl(), !srcIsolation->isTaskIsolated())
+        .limitBehaviorIf(getBehaviorLimit());
+    diagnoseNote(
+        op->getUser(),
+        diag::
+            regionbasedisolation_merge_region_failure_error_nonisolatedfunction_both_type_note,
+        *srcType, srcIsolationStr, *dstType, dstIsolationStr,
+        declRef.getDecl(), !srcIsolation->isTaskIsolated());
+    return;
+  }
+
+  return emitUnknownPatternError();
 }
 
 void IncompatibleRegionMergeDiagnosticEmitter::emitIsolatedFunction() {
@@ -4096,32 +4300,19 @@ void IncompatibleRegionMergeDiagnosticEmitter::emitIsolatedFunction() {
 
   // We should always be able to find a name for an inout sending param. If we
   // do not, emit an unknown pattern error.
-  auto srcName = inferNameHelper(srcRegionValue.getValue());
+  auto srcName = inferMergeSrcNameHelper(srcRegionValue.getValue());
   if (!srcName) {
-    if (auto *svi =
-            dyn_cast<SingleValueInstruction>(srcRegionValue.getValue())) {
-      if (auto *expr = svi->getLoc().getAsASTNode<Expr>()) {
-        diagnoseError(
-            op->getUser(),
-            diag::
-                regionbasedisolation_merge_region_failure_error_functionisolation_type,
-            expr->findOriginalType(), srcIsolationStr, declRef.getDecl(),
-            dstIsolationStr, !srcIsolation->isTaskIsolated())
-            .limitBehaviorIf(getBehaviorLimit());
-        return;
-      }
-    }
-    if (auto *arg = dyn_cast<SILFunctionArgument>(srcRegionValue.getValue())) {
-      diagnoseError(
-          op->getUser(),
-          diag::
-              regionbasedisolation_merge_region_failure_error_functionisolation_type,
-          arg->getDecl()->getInterfaceType(), srcIsolationStr,
-          declRef.getDecl(), dstIsolationStr, !srcIsolation->isTaskIsolated())
-          .limitBehaviorIf(getBehaviorLimit());
-      return;
-    }
-    return emitUnknownPatternError();
+    auto srcType = inferTypeHelper(srcRegionValue.getValue());
+    if (!srcType)
+      return emitUnknownPatternError();
+    diagnoseError(
+        op->getUser(),
+        diag::
+            regionbasedisolation_merge_region_failure_error_functionisolation_type,
+        *srcType, srcIsolationStr, declRef.getDecl(),
+        dstIsolationStr, !srcIsolation->isTaskIsolated())
+        .limitBehaviorIf(getBehaviorLimit());
+    return;
   }
   diagnoseError(
       op->getUser(),
@@ -4169,9 +4360,18 @@ void IncompatibleRegionMergeDiagnosticEmitter::emitCast() {
 
   // We should always be able to find a name for an inout sending param. If we
   // do not, emit an unknown pattern error.
-  auto srcName = inferNameHelper(srcRegionValue.getValue());
-  if (!srcName)
-    return emitUnknownPatternError();
+  auto srcName = inferMergeSrcNameHelper(srcRegionValue.getValue());
+  if (!srcName) {
+    auto srcType = inferTypeHelper(srcRegionValue.getValue());
+    if (!srcType)
+      return emitUnknownPatternError();
+    diagnoseError(op->getUser(),
+                  diag::regionbasedisolation_merge_region_failure_error_cast_type,
+                  *srcType, srcIsolationStr, cast.getTargetFormalType(),
+                  dstIsolationStr, !srcIsolation->isTaskIsolated())
+        .limitBehaviorIf(getBehaviorLimit());
+    return;
+  }
   diagnoseError(op->getUser(),
                 diag::regionbasedisolation_merge_region_failure_error_cast,
                 *srcName, srcIsolationStr, cast.getTargetFormalType(),

--- a/test/Concurrency/transfernonsendable_typed_errors.swift
+++ b/test/Concurrency/transfernonsendable_typed_errors.swift
@@ -83,3 +83,41 @@ func sendingTransferNonSendableError(_ x: NonSendableKlass) async {
   await transferToMain(x) // expected-error {{sending value of non-Sendable type 'NonSendableKlass' risks causing data races}}
   // expected-note @-1 {{sending task-isolated value of non-Sendable type 'NonSendableKlass' to main actor-isolated global function 'transferToMain' risks causing races in between task-isolated and main actor-isolated uses}}
 }
+
+func useNonSendable<T, U>(_ x: T, _ y: U) {}
+
+@globalActor actor CustomActor {
+  static let shared = CustomActor()
+}
+
+// Assign merge: both sides use types (src=CustomActor-type, dst=MainActor-type)
+@MainActor
+struct MainActorWithCustomField {
+  var mainField: NonSendableKlass? = nil
+  @CustomActor var customField: NonSendableKlass? = nil
+
+  init(assign: Void = ()) {
+    mainField = customField // expected-error {{assigning global actor 'CustomActor'-isolated value of type '()' to main actor-isolated value of type '()' risks causing data races}}
+    // expected-note @-1 {{a value of type '()' could become accessible to main actor-isolated code despite remaining accessible to global actor 'CustomActor'-isolated code}}
+  }
+
+  // NonisolatedFunction merge: both sides use types
+  init(nonisolatedFunc: Void = ()) {
+    useNonSendable(mainField, customField) // expected-error {{passing global actor 'CustomActor'-isolated value of type 'NonSendableKlass?' and main actor-isolated value of type 'NonSendableKlass?' as arguments to global function 'useNonSendable' risks causing data races}}
+    // expected-note @-1 {{a value of type 'NonSendableKlass?' could begin referencing a value of type 'NonSendableKlass?' allowing concurrent access to a value of type 'NonSendableKlass?' by main actor-isolated code and global actor 'CustomActor'-isolated code}}
+  }
+}
+
+// FunctionIsolation: src uses type when name inference fails
+actor ActorWithIsolatedInit {
+  var localVar: NonSendableKlass
+  init(value val: NonSendableKlass) { self.localVar = val }
+  init(valueAsync val: NonSendableKlass) async { self.localVar = val }
+  nonisolated init(nonisoAsync val: NonSendableKlass, _ c: Int) async {
+    if c == 0 {
+      await self.init(valueAsync: val) // expected-error {{passing a value of type 'NonSendableKlass' to 'self'-isolated initializer 'init(valueAsync:)' risks causing data races}}
+    } else {
+      self.init(value: val)
+    }
+  }
+}

--- a/test/Concurrency/transfernonsendable_typed_errors_dst_only.swift
+++ b/test/Concurrency/transfernonsendable_typed_errors_dst_only.swift
@@ -1,0 +1,57 @@
+// RUN: %target-swift-frontend -swift-version 6 -Xllvm -sil-regionbasedisolation-force-use-of-typed-dst-errors -emit-sil -o /dev/null %s -verify -target %target-swift-5.1-abi-triple
+
+// REQUIRES: concurrency
+// REQUIRES: asserts
+
+// READ THIS: This test exercises typed errors for the dst (actor-isolated)
+// side of incompatible region merge diagnostics, while the src side still uses
+// name-based diagnostics. This exercises the _dst_type diagnostic variants.
+
+////////////////////////
+// MARK: Declarations //
+////////////////////////
+
+class NonSendableKlass {}
+
+func useNonSendable<T, U>(_ x: T, _ y: U) {}
+
+@globalActor actor CustomActor {
+  static let shared = CustomActor()
+}
+
+/////////////////
+// MARK: Tests //
+/////////////////
+
+// Assign merge: src uses name, dst uses type
+@MainActor
+struct MainActorWithCustomFieldDstOnly {
+  var mainField: NonSendableKlass? = nil
+  @CustomActor var customField: NonSendableKlass? = nil
+
+  init(assign: Void = ()) {
+    mainField = customField // expected-error {{assigning global actor 'CustomActor'-isolated 'self.customField' to main actor-isolated value of type '()' risks causing data races}}
+    // expected-note @-1 {{'self.customField' could become accessible to main actor-isolated code despite remaining accessible to global actor 'CustomActor'-isolated code}}
+  }
+
+  // NonisolatedFunction merge: src uses name, dst uses type
+  init(nonisolatedFunc: Void = ()) {
+    useNonSendable(mainField, customField) // expected-error {{passing global actor 'CustomActor'-isolated 'self.customField' and main actor-isolated value of type 'NonSendableKlass?' as arguments to global function 'useNonSendable' risks causing data races}}
+    // expected-note @-1 {{a value of type 'NonSendableKlass?' could begin referencing 'self.customField' allowing concurrent access to 'self.customField' by main actor-isolated code and global actor 'CustomActor'-isolated code}}
+  }
+}
+
+// FunctionIsolation: ForceTypedDstErrors does not affect the functionisolation
+// diagnostic since it only mentions the src value. The named version fires.
+actor ActorWithIsolatedInitDstOnly {
+  var localVar: NonSendableKlass
+  init(value val: NonSendableKlass) { self.localVar = val }
+  init(valueAsync val: NonSendableKlass) async { self.localVar = val }
+  nonisolated init(nonisoAsync val: NonSendableKlass, _ c: Int) async {
+    if c == 0 {
+      await self.init(valueAsync: val) // expected-error {{passing 'val' to 'self'-isolated initializer 'init(valueAsync:)' risks causing data races}}
+    } else {
+      self.init(value: val)
+    }
+  }
+}

--- a/test/Concurrency/transfernonsendable_typed_errors_src_only.swift
+++ b/test/Concurrency/transfernonsendable_typed_errors_src_only.swift
@@ -1,0 +1,57 @@
+// RUN: %target-swift-frontend -swift-version 6 -Xllvm -sil-regionbasedisolation-force-use-of-typed-src-errors -emit-sil -o /dev/null %s -verify -target %target-swift-5.1-abi-triple
+
+// REQUIRES: concurrency
+// REQUIRES: asserts
+
+// READ THIS: This test exercises typed errors for the src (task-isolated or
+// non-task-isolated) side of incompatible region merge diagnostics, while the
+// dst side still uses name-based diagnostics. This exercises the _src_type
+// diagnostic variants.
+
+////////////////////////
+// MARK: Declarations //
+////////////////////////
+
+class NonSendableKlass {}
+
+func useNonSendable<T, U>(_ x: T, _ y: U) {}
+
+@globalActor actor CustomActor {
+  static let shared = CustomActor()
+}
+
+/////////////////
+// MARK: Tests //
+/////////////////
+
+// Assign merge: src uses type, dst uses name
+@MainActor
+struct MainActorWithCustomFieldSrcOnly {
+  var mainField: NonSendableKlass? = nil
+  @CustomActor var customField: NonSendableKlass? = nil
+
+  init(assign: Void = ()) {
+    mainField = customField // expected-error {{assigning global actor 'CustomActor'-isolated value of type '()' to main actor-isolated 'self.mainField' risks causing data races}}
+    // expected-note @-1 {{a value of type '()' could become accessible to main actor-isolated code despite remaining accessible to global actor 'CustomActor'-isolated code}}
+  }
+
+  // NonisolatedFunction merge: src uses type, dst uses name
+  init(nonisolatedFunc: Void = ()) {
+    useNonSendable(mainField, customField) // expected-error {{passing global actor 'CustomActor'-isolated value of type 'NonSendableKlass?' and main actor-isolated 'self.mainField' as arguments to global function 'useNonSendable' risks causing data races}}
+    // expected-note @-1 {{'self.mainField' could begin referencing a value of type 'NonSendableKlass?' allowing concurrent access to a value of type 'NonSendableKlass?' by main actor-isolated code and global actor 'CustomActor'-isolated code}}
+  }
+}
+
+// FunctionIsolation: src uses type when name inference is suppressed
+actor ActorWithIsolatedInitSrcOnly {
+  var localVar: NonSendableKlass
+  init(value val: NonSendableKlass) { self.localVar = val }
+  init(valueAsync val: NonSendableKlass) async { self.localVar = val }
+  nonisolated init(nonisoAsync val: NonSendableKlass, _ c: Int) async {
+    if c == 0 {
+      await self.init(valueAsync: val) // expected-error {{passing a value of type 'NonSendableKlass' to 'self'-isolated initializer 'init(valueAsync:)' risks causing data races}}
+    } else {
+      self.init(value: val)
+    }
+  }
+}


### PR DESCRIPTION
Previously, when IncompatibleRegionMergeDiagnosticEmitter could not infer a variable name for the src or dst value in an incompatible region merge, it emitted a generic unknown-pattern error. This was especially common for the src (task-isolated) side, which often holds anonymous expressions without obvious names.

This change adds type-based fallback diagnostics ("a value of type T") for all four merge emitters: unknown, assign, nonisolatedFunction, and cast. A 2x2 dispatch (both named / src-typed+dst-named / src-named+dst-typed / both-typed) selects the right diagnostic variant from the new typed error families added to DiagnosticsSIL.def.

I added tests for both dst only and src only.

rdar://175592408
(cherry picked from commit 9ed26ad731e20aab9eb29b3bb8ca53bfed637d8c)

----

- **Explanation**:
  Previously, when `IncompatibleRegionMergeDiagnosticEmitter` could not infer
  a variable name for the src or dst value in an incompatible region merge, it
  emitted a generic unknown-pattern error. This change adds type-based fallback diagnostics ("a value of
  type T") for all four merge emitters: unknown, assign, nonisolatedFunction,
  and cast. A 2x2 dispatch (both named / src-typed+dst-named /
  src-named+dst-typed / both-typed) selects the right diagnostic variant from
  the new typed error families added to DiagnosticsSIL.def.
- **Scope**:
  Diagnostic quality improvement only. No semantic changes to Swift language
  behavior or region isolation rules. Existing code that compiled before will
  still compile; code that errored before will still error, but with better
  messages when name inference fails.
- **Issues**:
  rdar://175592408
- **Original PRs**:
  https://github.com/swiftlang/swift/pull/88876
- **Risk**:
  Low. The change is purely in diagnostic emission logic. No changes to SIL
  analysis, isolation inference, or type checking.
- **Testing**:
  Three new test files added:
  - `test/Concurrency/transfernonsendable_typed_errors.swift`
  - `test/Concurrency/transfernonsendable_typed_errors_dst_only.swift`
  - `test/Concurrency/transfernonsendable_typed_errors_src_only.swift`
- **Reviewers**:
  <!--
  The code owners that GitHub-approved the original changes in the mainline
  branch pull requests. If an original change has not been GitHub-approved by
  a respective code owner, provide a reason. Technical review can be delegated
  by a code owner or otherwise requested as deemed appropriate or useful.
  -->
