### PR TITLE
Lifetimes: Infer copy dependence kind on `@noescape` closures

### DIFF
--- a/lib/AST/LifetimeDependence.cpp
+++ b/lib/AST/LifetimeDependence.cpp
@@ -1125,6 +1125,11 @@ protected:
 
     switch (parsedLifetimeKind) {
     case ParsedLifetimeDependenceKind::Default: {
+      // Infer copy dependence on @noescape function types by default.
+      if (type->isNoEscape()) {
+        return LifetimeDependenceKind::Inherit;
+      }
+
       if (type->isEscapable()) {
         if (loweredOwnership == ValueOwnership::Shared ||
             loweredOwnership == ValueOwnership::InOut) {
@@ -1823,13 +1828,19 @@ protected:
       // The usual diagnostic check is sufficient.
       return;
     }
-    // Do not infer non-escapable dependence kind -- it is ambiguous.
+    // Do not infer non-escapable dependence kind -- it is ambiguous, except for
+    // noescape function types, for which we should always infer a copy dependence.
     auto const &paramInfo = parameterInfos[0];
     Type paramTypeInContext = paramInfo.typeInContext;
     if (paramTypeInContext->hasError()) {
       return;
     }
     if (!paramTypeInContext->isEscapable()) {
+      if (paramTypeInContext->isNoEscape()) {
+        resultDeps->addIfNew(/*paramIndex*/ 0, LifetimeDependenceKind::Inherit);
+        return;
+      }
+      
       diagnose(returnLoc, diag::lifetime_dependence_cannot_infer_kind,
                diagnosticQualifier(), paramInfo.name());
       return;

--- a/test/ModuleInterface/Inputs/lifetime_underscored_dependence.swift
+++ b/test/ModuleInterface/Inputs/lifetime_underscored_dependence.swift
@@ -160,23 +160,27 @@ public func takeReadBorrower(f: @_lifetime(borrow a) (_ a: AnotherView) -> Anoth
 @inlinable
 public func takeWriteBorrower(f: @_lifetime(&a) (_ a: inout AnotherView) -> AnotherView) {}
 
+// Infer @_lifetime(copy f)
 @inlinable
 public func takeClosureImplicitDependence(f: () -> AnotherView) -> AnotherView {
   f()
 }
 
-@_lifetime(f)
+@_lifetime(f) // Infer @_lifetime(copy f)
 @inlinable
 public func takeClosureImplicitDependenceKind(f: () -> AnotherView) -> AnotherView {
   f()
 }
 
 @inlinable
-public func takeTakeImplicitCopyClosure(f: @_lifetime(copy f) (_ f: () -> AnotherView) -> AnotherView) {
+public func takeTakeImplicitCopyClosure(g: @_lifetime(copy f) (_ f: () -> AnotherView) -> AnotherView) {
 }
 
+// Verify that takeClosureImplicitDependenceKind and takeClosureImplicitDependence
+// are both inferred as @_lifetime(copy f). It is illegal to pass a function that
+// borrows its context into a function-type parameter that copies its context.
 @inlinable
 public func callTTICC() {
-  takeTakeImplicitCopyClosure(f: takeClosureImplicitDependenceKind)
-  takeTakeImplicitCopyClosure(f: takeClosureImplicitDependence)
+  takeTakeImplicitCopyClosure(g: takeClosureImplicitDependenceKind)
+  takeTakeImplicitCopyClosure(g: takeClosureImplicitDependence)
 }

--- a/test/ModuleInterface/Inputs/lifetime_underscored_dependence.swift
+++ b/test/ModuleInterface/Inputs/lifetime_underscored_dependence.swift
@@ -159,3 +159,24 @@ public func takeReadBorrower(f: @_lifetime(borrow a) (_ a: AnotherView) -> Anoth
 
 @inlinable
 public func takeWriteBorrower(f: @_lifetime(&a) (_ a: inout AnotherView) -> AnotherView) {}
+
+@inlinable
+public func takeClosureImplicitDependence(f: () -> AnotherView) -> AnotherView {
+  f()
+}
+
+@_lifetime(f)
+@inlinable
+public func takeClosureImplicitDependenceKind(f: () -> AnotherView) -> AnotherView {
+  f()
+}
+
+@inlinable
+public func takeTakeImplicitCopyClosure(f: @_lifetime(copy f) (_ f: () -> AnotherView) -> AnotherView) {
+}
+
+@inlinable
+public func callTTICC() {
+  takeTakeImplicitCopyClosure(f: takeClosureImplicitDependenceKind)
+  takeTakeImplicitCopyClosure(f: takeClosureImplicitDependence)
+}

--- a/test/ModuleInterface/lifetime_underscored_dependence_test.swift
+++ b/test/ModuleInterface/lifetime_underscored_dependence_test.swift
@@ -259,11 +259,11 @@ import lifetime_underscored_dependence
 // CHECK-NEXT: #endif
 
 // CHECK:      #if compiler(>=5.3) && $ClosureLifetimes
-// CHECK-NEXT: @inlinable public func takeTakeImplicitCopyClosure(f: @_lifetime(copy f) (_ f: () -> lifetime_underscored_dependence::AnotherView) -> lifetime_underscored_dependence::AnotherView) {
+// CHECK-NEXT: @inlinable public func takeTakeImplicitCopyClosure(g: @_lifetime(copy f) (_ f: () -> lifetime_underscored_dependence::AnotherView) -> lifetime_underscored_dependence::AnotherView) {
 // CHECK-NEXT: }
 // CHECK-NEXT: #endif
 
 // CHECK:      @inlinable public func callTTICC() {
-// CHECK-NEXT:   takeTakeImplicitCopyClosure(f: takeClosureImplicitDependenceKind)
-// CHECK-NEXT:   takeTakeImplicitCopyClosure(f: takeClosureImplicitDependence)
+// CHECK-NEXT:   takeTakeImplicitCopyClosure(g: takeClosureImplicitDependenceKind)
+// CHECK-NEXT:   takeTakeImplicitCopyClosure(g: takeClosureImplicitDependence)
 // CHECK-NEXT: }

--- a/test/ModuleInterface/lifetime_underscored_dependence_test.swift
+++ b/test/ModuleInterface/lifetime_underscored_dependence_test.swift
@@ -235,3 +235,35 @@ import lifetime_underscored_dependence
 // CHECK-NEXT: #if compiler(>=5.3) && $ClosureLifetimes
 // CHECK-NEXT: @inlinable public func takeWriteBorrower(f: @_lifetime(&a) (_ a: inout lifetime_underscored_dependence::AnotherView) -> lifetime_underscored_dependence::AnotherView) {}
 // CHECK-NEXT: #endif
+
+// CHECK-NEXT: #if compiler(>=5.3) && $Lifetimes
+// CHECK-NEXT: @inlinable public func takeClosureImplicitDependence(f: () -> lifetime_underscored_dependence::AnotherView) -> lifetime_underscored_dependence::AnotherView {
+// CHECK-NEXT:   f()
+// CHECK-NEXT: }
+// CHECK-NEXT: #else
+// CHECK-NEXT: @inlinable public func takeClosureImplicitDependence(f: () -> lifetime_underscored_dependence::AnotherView) -> lifetime_underscored_dependence::AnotherView {
+// CHECK-NEXT:   f()
+// CHECK-NEXT: }
+// CHECK-NEXT: #endif
+
+// CHECK-NEXT: #if compiler(>=5.3) && $Lifetimes
+// CHECK-NEXT: @_lifetime(f)
+// CHECK-NEXT: @inlinable public func takeClosureImplicitDependenceKind(f: () -> lifetime_underscored_dependence::AnotherView) -> lifetime_underscored_dependence::AnotherView {
+// CHECK-NEXT:   f()
+// CHECK-NEXT: }
+// CHECK-NEXT: #else
+// CHECK-NEXT: @lifetime(f)
+// CHECK-NEXT: @inlinable public func takeClosureImplicitDependenceKind(f: () -> lifetime_underscored_dependence::AnotherView) -> lifetime_underscored_dependence::AnotherView {
+// CHECK-NEXT:   f()
+// CHECK-NEXT: }
+// CHECK-NEXT: #endif
+
+// CHECK:      #if compiler(>=5.3) && $ClosureLifetimes
+// CHECK-NEXT: @inlinable public func takeTakeImplicitCopyClosure(f: @_lifetime(copy f) (_ f: () -> lifetime_underscored_dependence::AnotherView) -> lifetime_underscored_dependence::AnotherView) {
+// CHECK-NEXT: }
+// CHECK-NEXT: #endif
+
+// CHECK:      @inlinable public func callTTICC() {
+// CHECK-NEXT:   takeTakeImplicitCopyClosure(f: takeClosureImplicitDependenceKind)
+// CHECK-NEXT:   takeTakeImplicitCopyClosure(f: takeClosureImplicitDependence)
+// CHECK-NEXT: }

--- a/test/SIL/closure_lifetime_dependence.swift
+++ b/test/SIL/closure_lifetime_dependence.swift
@@ -113,3 +113,13 @@ func callContextAndArgDependentPicker() {
 func copyClosureNE(body: () -> NE) -> NE {
   body()
 }
+
+// CHECK-LABEL: sil hidden @$s27closure_lifetime_dependence23implicitDependClosureNE4bodyAA0G0VAEyXE_tF : $@convention(thin) (@guaranteed @noescape @callee_guaranteed () -> @lifetime(captures) @owned NE) -> @lifetime(copy 0) @owned NE {
+// CHECK: bb0(%0 : $@noescape @callee_guaranteed () -> @lifetime(captures) @owned NE):
+// CHECK: [[RESULT:%[0-9]+]] = apply %0() : $@noescape @callee_guaranteed () -> @lifetime(captures) @owned NE
+// CHECK-NEXT: return [[RESULT]]
+// CHECK-LABEL: } // end sil function '$s27closure_lifetime_dependence23implicitDependClosureNE4bodyAA0G0VAEyXE_tF'
+@_lifetime(body)
+func implicitDependClosureNE(body: () -> NE) -> NE {
+  body()
+}

--- a/test/SILOptimizer/lifetime_dependence/verify_diagnostics.swift
+++ b/test/SILOptimizer/lifetime_dependence/verify_diagnostics.swift
@@ -450,18 +450,19 @@ func testMutableCapture(arg: consuming NCE, action: @escaping (inout NCE) -> ())
   }
 }
 
+// Explicit dependence on a nonescaping closure context.
+@_lifetime(body)
+func testBasicExplicitClosureDependency(body: () -> NE) -> NE {
+  return body()
+}
+
 // Implicit dependence on a nonescaping closure context.
-//
-// TODO: remove the _overrideLifetime when context dependencies are tracked and
-// non-escaping function types can be used as (copy) dependence sources (rdar://172511809).
-@_lifetime(borrow value)
-func testBasicClosureDependency(value: AnyObject, body: () -> NE) -> NE {
-  return _overrideLifetime(body(), borrowing: value)
+func testBasicClosureDependency(body: () -> NE) -> NE {
+  return body()
 }
 
 // Implicit dependence on a nonescaping closure context. The result is escaping in the current generic context, so
 // should not be diagnosed as an escape.
-@_lifetime(copy f)
 func testIndirectClosureResult<T>(f: () -> CNE<T>) -> CNE<T> {
   return f()
 }

--- a/test/Sema/lifetime_dependence_functype.swift
+++ b/test/Sema/lifetime_dependence_functype.swift
@@ -429,9 +429,24 @@ func callLifetimeFunctions() {
 }
 
 // ~Escapable function types
-@_lifetime(body) // expected-error{{cannot infer the lifetime dependence scope on a function with a ~Escapable parameter, specify '@_lifetime(borrow body)' or '@_lifetime(copy body)'}}
+@_lifetime(body) // OK: Infer copy
+func implicitDependKindClosureNE(body: () -> NE) -> NE {
+  body()
+}
+
+func callImplicitDependKindClosureNE(ne: NE) -> NE {
+  let neo = implicitDependClosureNE { ne }
+  return neo
+}
+
 func implicitDependClosureNE(body: () -> NE) -> NE {
   body()
+}
+
+func callImplicitDependClosureNE(ne: NE) -> NE {
+  // OK: Infer copy
+  let neo = implicitDependClosureNE { ne }
+  return neo
 }
 
 @_lifetime(copy body)


### PR DESCRIPTION
Follow-up to https://github.com/swiftlang/swift/pull/88733,
enabling the example in rdar://172511809 ([nonescapable] Allow a nonescaping function to be a lifetime dependency source):

```swift
@_lifetime(body) // Inferred dependence kind: copy
func foo(body: () -> Span<Int>) { body() }
```

or

```swift
// Inferred: @_lifetime(copy body)
func foo(body: () -> Span<Int>) { body() }
```

Follow-up: Consider also disallowing borrow dependence on `@noescape` closures.
<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
