### PR TITLE
[rbi] Diagnose inout sending params returned via indirect out and sending indirect out results

### DIFF
--- a/include/swift/SILOptimizer/Utils/PartitionUtils.h
+++ b/include/swift/SILOptimizer/Utils/PartitionUtils.h
@@ -1742,6 +1742,28 @@ public:
     return SILValue();
   }
 
+  /// If \p region is contains a sending indirect out parameter, return that.
+  std::optional<Element> findSendingOutParameterInRegion(Region region) const {
+    for (const auto &pair : p.range()) {
+      if (pair.second != region)
+        continue;
+      // See if we have an indirect out parameter...
+      if (asImpl().getSendingIndirectOutParameter(pair.first)) {
+        return pair.first;
+      }
+
+      // If this was not an out parameter, return {}.
+      return {};
+    }
+
+    // After going over our loop, if result is not SILValue(), then we found
+    // that our region is not disconnected due only to a single 'indirect out'
+    // parameter. If SILValue() then we had all disconnected values. If we found
+    // multiple non-disconnected things, we would have bailed earlier in the
+    // loop itself.
+    return {};
+  }
+  
   /// Given the region \p regionOfInOutSendingParam containing the 'inout
   /// sending' parameter \p firstInOutSendingParam, see if that region contains
   /// any other 'inout sending' parameters with greater element numbers than \p
@@ -2117,9 +2139,8 @@ public:
              "Require PartitionOp's argument should already be tracked");
 
       // First check if the region of our 'inout sending' element has been
-      // sent. In that case, we emit a special use after free error so that the
-      // user knows that they need to reinitialize the 'inout sending'
-      // parameter.
+      // sent. In that case, we emit a special error so that the user knows that
+      // they need to reinitialize the 'inout sending' parameter.
       if (auto *sentOperandSet = p.getSentOperandSet(op.getOpArg1())) {
         for (auto sentOperand : sentOperandSet->data()) {
           handleError(InOutSendingNotInitializedAtExitError(op, op.getOpArg1(),
@@ -2179,6 +2200,8 @@ public:
         // exit error... check if our dynamic region isolation is not
         // disconnected since it is in the same region an out parameter. In that
         // case we want to emit a special 'cannot return value' error.
+        //
+        // This handles task-isolated captures.
         if (auto outParam =
                 findNonDisconnectedOutParameterInRegion(inoutSendingRegion)) {
           handleError(InOutSendingReturnedError(op, op.getOpArg1(),
@@ -2209,7 +2232,7 @@ public:
         return;
       }
 
-      // Finally We could still be returning a disconnected value in the same
+      // Finally we could still be returning a disconnected value in the same
       // region as an 'inout sending' parameter. We cannot allow that since the
       // caller considers 'inout sending' values to be in their own region on
       // function return. So it would assume that it could potentially send the
@@ -2224,6 +2247,21 @@ public:
         dynamicRegionIsolation = {isolation};
       }
 
+      // Then check if we have a sending out parameter. This will actually be
+      // disconnected unlike most other out parameters that are
+      // task-isolated. So it will look like we have a disconnected value, but
+      // we do not want to allow for an 'inout sending' parameter to also be
+      // returned as a 'sending' result since it would potentially allow for
+      // them to be send separately.
+      if (auto outParam =
+          findSendingOutParameterInRegion(inoutSendingRegion)) {
+        handleError(InOutSendingReturnedError(op, op.getOpArg1(),
+                                              outParam.value(),
+                                              dynamicRegionIsolation));
+        return;
+      }
+
+      // If we did not, then handle the direct return case.
       handleDirectReturn();
       return;
     }
@@ -2422,6 +2460,10 @@ struct PartitionOpEvaluatorBaseImpl : PartitionOpEvaluator<Subclass> {
   /// return that value.
   SILValue getIndirectOutParameter(Element elt) const { return {}; }
 
+  /// If \p elt maps to a representative that is a sending indirect out parameter,
+  /// return that value.
+  SILValue getSendingIndirectOutParameter(Element elt) const { return {}; }
+  
   /// If \p elt maps to a representative that is an 'inout sending' parameter
   /// that returns that value.
   SILValue getInOutSendingParameter(Element elt) const { return {}; }

--- a/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
@@ -757,6 +757,19 @@ struct DiagnosticEvaluator final
     return {};
   }
 
+  /// If \p element's representative is an indirect out parameter, return
+  /// that parameter.
+  SILValue getSendingIndirectOutParameter(Element element) const {
+    auto rep = info->getValueMap().getRepresentativeValue(element);
+    if (!rep)
+      return {};
+    if (auto value = dyn_cast_or_null<SILFunctionArgument>(rep.maybeGetValue());
+        value && value->getArgumentConvention().isIndirectOutParameter() &&
+        value->isSending())
+      return value;
+    return {};
+  }
+  
   SILValue getInOutSendingParameter(Element elt) const {
     auto rep = info->getValueMap().getRepresentativeValue(elt);
     if (!rep)

--- a/test/Concurrency/transfernonsendable_inout_sending_indirect_out.swift
+++ b/test/Concurrency/transfernonsendable_inout_sending_indirect_out.swift
@@ -1,0 +1,203 @@
+// RUN: %target-swift-frontend -emit-sil -swift-version 6 -target %target-swift-5.1-abi-triple -verify %s -o /dev/null -parse-as-library
+
+// This test verifies that the region isolation pass correctly detects when an
+// 'inout sending' parameter is returned via an indirect @out result parameter
+// (both normal and sending). This is distinct from the direct-return case tested
+// in transfernonsendable_inout_sending_params.swift, because the return value
+// flows through a copy_addr to an @out parameter rather than through a direct
+// 'return' instruction in SIL.
+
+// REQUIRES: concurrency
+
+////////////////////////
+// MARK: Declarations //
+////////////////////////
+
+class NonSendableKlass {}
+
+func useValue<T>(_ t: T) {}
+
+///////////////////////////////////////////////////////
+// MARK: Closures with inout sending indirect return //
+///////////////////////////////////////////////////////
+
+// A generic higher-order function whose closure takes an inout sending param.
+// Because the result type T is generic, the closure's return is indirect (@out).
+func takeClosure<T>(_ fn: (inout sending NonSendableKlass) -> T) -> T {
+  fatalError()
+}
+
+func takeClosureThrowing<T>(_ fn: (inout sending NonSendableKlass) throws -> T) rethrows -> T {
+  fatalError()
+}
+
+// The closure { $0 } directly returns the inout sending parameter via @out.
+func testClosureReturnsInOutSendingParam() {
+  let _ = takeClosure { $0 } // expected-error {{'inout sending' parameter '$0' cannot be returned}}
+  // expected-note @-1 {{returning 'inout sending' parameter '$0' risks concurrent access as caller assumes '$0' and result can be sent to different isolation domains}}
+}
+
+// Same pattern but with an explicit closure body.
+func testClosureExplicitReturn() {
+  let _ = takeClosure { (x: inout sending NonSendableKlass) -> NonSendableKlass in
+    return x // expected-error {{'inout sending' parameter 'x' cannot be returned}}
+    // expected-note @-1 {{returning 'inout sending' parameter 'x' risks concurrent access as caller assumes 'x' and result can be sent to different isolation domains}}
+  }
+}
+
+// Returning a value derived from the inout sending parameter.
+func testClosureReturnsDerivedValue() {
+  let _ = takeClosure { (x: inout sending NonSendableKlass) -> NonSendableKlass in
+    let y = x
+    return y // expected-error {{'y' cannot be returned}}
+    // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' and result can be sent to different isolation domains}}
+  }
+}
+
+// Safe case: closure returns a fresh value (should NOT produce an error).
+func testClosureReturnsFreshValue() {
+  let _ = takeClosure { (x: inout sending NonSendableKlass) -> NonSendableKlass in
+    x = NonSendableKlass()
+    return NonSendableKlass()
+  }
+}
+
+func testClosureAssignsOverButStillReturnsIt() {
+  let _ = takeClosure { (state: inout sending NonSendableKlass) -> NonSendableKlass in
+    state = NonSendableKlass()
+    return state // expected-error {{'inout sending' parameter 'state' cannot be returned}}
+    // expected-note @-1 {{returning 'inout sending' parameter 'state' risks concurrent access as caller assumes 'state' and result can be sent to different isolation domains}}
+  }
+}
+
+func testClosureAssignsToCapture() {
+  let m2 = NonSendableKlass()
+  let _ = takeClosure { (state: inout sending NonSendableKlass) -> NonSendableKlass in
+    state = m2
+    return state // expected-error {{'inout sending' parameter 'state' cannot be returned}}
+    // expected-note @-1 {{returning 'inout sending' parameter 'state' risks concurrent access as caller assumes 'state' and result can be sent to different isolation domains}}
+  }
+}
+
+/////////////////////////////////////////////////////////
+// MARK: Functions with inout sending indirect return  //
+/////////////////////////////////////////////////////////
+
+// A function returning 'some Any' has an indirect @out result in SIL.
+func returnInOutSendingViaOpaqueResult(_ x: inout sending NonSendableKlass) -> some Any {
+  return x // expected-error {{'inout sending' parameter 'x' cannot be returned}}
+  // expected-note @-1 {{returning 'inout sending' parameter 'x' risks concurrent access as caller assumes 'x' and result can be sent to different isolation domains}}
+}
+
+// A generic function returning T also has an indirect @out result.
+func returnInOutSendingGeneric<T: AnyObject>(_ x: inout sending T) -> T {
+  return x // expected-error {{'inout sending' parameter 'x' cannot be returned}}
+  // expected-note @-1 {{returning 'inout sending' parameter 'x' risks concurrent access as caller assumes 'x' and result can be sent to different isolation domains}}
+}
+
+// Returning a derived value through indirect out.
+func returnDerivedViaOpaqueResult(_ x: inout sending NonSendableKlass) -> some Any {
+  let y = x
+  return y // expected-error {{'y' cannot be returned}}
+  // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' and result can be sent to different isolation domains}}
+}
+
+// Safe case: function returns a fresh value via opaque result (should NOT produce an error).
+func returnFreshViaOpaqueResult(_ x: inout sending NonSendableKlass) -> some Any {
+  x = NonSendableKlass()
+  return NonSendableKlass()
+}
+
+/////////////////////////////////////////////////////////////////
+// MARK: Closures with inout sending and sending indirect return //
+/////////////////////////////////////////////////////////////////
+
+// A generic higher-order function whose closure takes an inout sending param
+// and returns a sending result. Because the result type T is generic, the
+// closure's return is indirect (@out) AND marked sending.
+func takeSendingClosure<T>(_ fn: (inout sending NonSendableKlass) -> sending T) -> T {
+  fatalError()
+}
+
+func takeSendingClosureThrowing<T>(_ fn: (inout sending NonSendableKlass) throws -> sending T) rethrows -> T {
+  fatalError()
+}
+
+// The closure { $0 } directly returns the inout sending parameter via sending @out.
+func testSendingClosureReturnsInOutSendingParam() {
+  let _ = takeSendingClosure { $0 } // expected-error {{'inout sending' parameter '$0' cannot be returned}}
+  // expected-note @-1 {{returning 'inout sending' parameter '$0' risks concurrent access as caller assumes '$0' and result can be sent to different isolation domains}}
+}
+
+// Same pattern but with an explicit closure body.
+func testSendingClosureExplicitReturn() {
+  let _ = takeSendingClosure { (x: inout sending NonSendableKlass) -> NonSendableKlass in
+    return x // expected-error {{'inout sending' parameter 'x' cannot be returned}}
+    // expected-note @-1 {{returning 'inout sending' parameter 'x' risks concurrent access as caller assumes 'x' and result can be sent to different isolation domains}}
+  }
+}
+
+// Returning a value derived from the inout sending parameter.
+func testSendingClosureReturnsDerivedValue() {
+  let _ = takeSendingClosure { (x: inout sending NonSendableKlass) -> NonSendableKlass in
+    let y = x
+    return y // expected-error {{'y' cannot be returned}}
+    // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' and result can be sent to different isolation domains}}
+  }
+}
+
+// Safe case: closure returns a fresh value (should NOT produce an error).
+func testSendingClosureReturnsFreshValue() {
+  let _ = takeSendingClosure { (x: inout sending NonSendableKlass) -> NonSendableKlass in
+    x = NonSendableKlass()
+    return NonSendableKlass()
+  }
+}
+
+func testSendingClosureAssignsOverButStillReturnsIt() {
+  let _ = takeSendingClosure { (state: inout sending NonSendableKlass) -> NonSendableKlass in
+    state = NonSendableKlass()
+    return state // expected-error {{'inout sending' parameter 'state' cannot be returned}}
+    // expected-note @-1 {{returning 'inout sending' parameter 'state' risks concurrent access as caller assumes 'state' and result can be sent to different isolation domains}}
+  }
+}
+
+func testSendingClosureAssignsToCapture() {
+  let m2 = NonSendableKlass()
+  let _ = takeSendingClosure { (state: inout sending NonSendableKlass) -> NonSendableKlass in
+    state = m2
+    return state // expected-error {{returning task-isolated 'state' as a 'sending' result risks causing data races}}
+    // expected-note @-1 {{returning task-isolated 'state' risks causing data races since the caller assumes that 'state' can be safely sent to other isolation domains}}
+    // expected-error @-2 {{'inout sending' parameter 'state' cannot be task-isolated at end of function}}
+    // expected-note @-3 {{task-isolated 'state' risks causing races in between task-isolated uses and caller uses since caller assumes value is not actor isolated}}
+  }
+}
+
+///////////////////////////////////////////////////////////////
+// MARK: Functions with inout sending and sending indirect return //
+///////////////////////////////////////////////////////////////
+
+// A function returning 'sending some Any' has an indirect @out sending result in SIL.
+func returnInOutSendingViaSendingOpaqueResult(_ x: inout sending NonSendableKlass) -> sending some Any {
+  return x // expected-error {{'inout sending' parameter 'x' cannot be returned}}
+  // expected-note @-1 {{returning 'inout sending' parameter 'x' risks concurrent access as caller assumes 'x' and result can be sent to different isolation domains}}
+}
+
+// A generic function returning sending T also has an indirect @out sending result.
+func returnInOutSendingGenericSending<T: AnyObject>(_ x: inout sending T) -> sending T {
+  return x // expected-error {{'inout sending' parameter 'x' cannot be returned}}
+  // expected-note @-1 {{returning 'inout sending' parameter 'x' risks concurrent access as caller assumes 'x' and result can be sent to different isolation domains}}
+}
+
+// Returning a derived value through sending indirect out.
+func returnDerivedViaSendingOpaqueResult(_ x: inout sending NonSendableKlass) -> sending some Any {
+  let y = x
+  return y // expected-error {{'y' cannot be returned}}
+  // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' and result can be sent to different isolation domains}}
+}
+
+// Safe case: function returns a fresh value via sending opaque result (should NOT produce an error).
+func returnFreshViaSendingOpaqueResult(_ x: inout sending NonSendableKlass) -> sending some Any {
+  x = NonSendableKlass()
+  return NonSendableKlass()
+}

--- a/test/Concurrency/transfernonsendable_inout_sending_mutex.swift
+++ b/test/Concurrency/transfernonsendable_inout_sending_mutex.swift
@@ -1,0 +1,73 @@
+// RUN: %target-swift-frontend -emit-sil -swift-version 6 -disable-availability-checking -verify %s -o /dev/null
+
+// This test verifies that the region isolation pass correctly detects the
+// 'inout sending' return violation when using Mutex.withLock, which passes
+// a closure taking an 'inout sending' parameter and returning via an
+// indirect @out result.
+
+// REQUIRES: concurrency
+// REQUIRES: synchronization
+
+import Synchronization
+
+class NonSendableKlass {
+  var name = "Fred"
+}
+
+// The fundamental pattern: Mutex.withLock { $0 } attempts to return the
+// inout sending parameter directly, which would allow the caller to hold
+// a reference that aliases the Mutex's protected state.
+func testMutexWithLockReturnsParam() {
+  let m = Mutex(NonSendableKlass())
+  let _ = m.withLock { $0 } // expected-error {{'inout sending' parameter '$0' cannot be returned}}
+  // expected-note @-1 {{returning 'inout sending' parameter '$0' risks concurrent access as caller assumes '$0' and result can be sent to different isolation domains}}
+}
+
+// Explicit closure with named parameter.
+func testMutexWithLockExplicitClosure() {
+  let m = Mutex(NonSendableKlass())
+  let _ = m.withLock { (state: inout sending NonSendableKlass) -> NonSendableKlass in
+    return state // expected-error {{'inout sending' parameter 'state' cannot be returned}}
+    // expected-note @-1 {{returning 'inout sending' parameter 'state' risks concurrent access as caller assumes 'state' and result can be sent to different isolation domains}}
+  }
+}
+
+// Returning a derived value from the mutex state.
+func testMutexWithLockReturnsDerived() {
+  let m = Mutex(NonSendableKlass())
+  let _ = m.withLock { (state: inout sending NonSendableKlass) -> NonSendableKlass in
+    let copy = state
+    return copy // expected-error {{'copy' cannot be returned}}
+    // expected-note @-1 {{returning 'copy' risks concurrent access to 'inout sending' parameter 'state' as caller assumes 'state' and result can be sent to different isolation domains}}
+  }
+}
+
+// Safe pattern: extract a Sendable value from the mutex state.
+func testMutexWithLockReturnsSendableValue() {
+  let m = Mutex(NonSendableKlass())
+  let name: String = m.withLock { (state: inout sending NonSendableKlass) -> String in
+    return state.name // OK - String is Sendable
+  }
+  _ = name
+}
+
+func testMutexWithLockAssignsOverButStillReturnsIt() {
+  let m = Mutex(NonSendableKlass())
+  let _ = m.withLock { (state: inout sending NonSendableKlass) -> NonSendableKlass in
+    state = NonSendableKlass()
+    return state // expected-error {{'inout sending' parameter 'state' cannot be returned}}
+    // expected-note @-1 {{returning 'inout sending' parameter 'state' risks concurrent access as caller assumes 'state' and result can be sent to different isolation domains}}
+  }
+}
+
+func testMutexWithLockAssignsToCapture() {
+  let m = Mutex(NonSendableKlass())
+  let m2 = NonSendableKlass()
+  let _ = m.withLock { (state: inout sending NonSendableKlass) -> NonSendableKlass in
+    state = m2
+    return state // expected-error {{'inout sending' parameter 'state' cannot be task-isolated at end of function}}
+    // expected-note @-1 {{task-isolated 'state' risks causing races in between task-isolated uses and caller uses since caller assumes value is not actor isolated}}
+    // expected-error @-2 {{returning task-isolated 'state' as a 'sending' result risks causing data races}}
+    // expected-note @-3 {{returning task-isolated 'state' risks causing data races since the caller assumes that 'state' can be safely sent to other isolation domains}}
+  }
+}


### PR DESCRIPTION
Previously we missed diagnosing inout sending parameters returned through indirect out results when the result was marked sending. Unlike normal indirect out parameters which are task-isolated, a sending indirect out parameter is disconnected. This edge case was missed by our normal handling which only checked for task-isolated indirect out parameters.

rdar://171853077
