### PR TITLE
[6.4] Sema: infer inverses in opaque return types

### DIFF
--- a/include/swift/AST/GenericSignature.h
+++ b/include/swift/AST/GenericSignature.h
@@ -579,6 +579,55 @@ void validateGenericSignature(ASTContext &context,
 /// Verify all of the generic signatures in the given module.
 void validateGenericSignaturesInModule(ModuleDecl *module);
 
+/// Controls how default requirements for invertible protocols such as Copyable
+/// or Escapable are expanded when building a generic signature.
+struct DefaultRequirementOptions {
+  /// If true, default requirements to Copyable/Escapable are
+  /// expanded for generic parameters.
+  const bool expandingDefaults;
+
+  /// If true, generic parameters defined in an outer generic signature that
+  /// are same-type constrained to some generic type X within the current
+  /// generic signature will skip performing expansion of defaults on type X.
+  ///
+  /// At a high-level, it "carries inverses across same-type requirements".
+  const bool inferOutOfScopeImpliedInverses;
+
+  /// Requirements WILL NOT be expanded.
+  static DefaultRequirementOptions none() {
+    return DefaultRequirementOptions(/*expandingDefaults=*/false,
+                                     /*inferOutOfScopeImpliedInverses=*/false);
+  }
+
+  /// Requirements WILL be expanded.
+  static DefaultRequirementOptions expand() {
+    return DefaultRequirementOptions(/*expandingDefaults=*/true,
+                                     /*inferOutOfScopeImpliedInverses=*/false);
+  }
+
+  friend bool operator==(DefaultRequirementOptions lhs,
+                         DefaultRequirementOptions rhs) {
+    return lhs.expandingDefaults == rhs.expandingDefaults &&
+           lhs.inferOutOfScopeImpliedInverses ==
+               rhs.inferOutOfScopeImpliedInverses;
+  }
+
+  friend llvm::hash_code hash_value(DefaultRequirementOptions options) {
+    return llvm::hash_combine(options.expandingDefaults,
+                              options.inferOutOfScopeImpliedInverses);
+  }
+
+private:
+  DefaultRequirementOptions(bool expandingDefaults,
+                            bool inferOutOfScopeImpliedInverses)
+      : expandingDefaults(expandingDefaults),
+        inferOutOfScopeImpliedInverses(inferOutOfScopeImpliedInverses) {
+    assert(!inferOutOfScopeImpliedInverses || expandingDefaults);
+  }
+};
+
+void simple_display(llvm::raw_ostream &out, DefaultRequirementOptions options);
+
 /// Build a generic signature from the given requirements, which are not
 /// required to be minimal or canonical, and may contain unresolved
 /// DependentMemberTypes.
@@ -586,14 +635,14 @@ void validateGenericSignaturesInModule(ModuleDecl *module);
 /// \param baseSignature if non-null, the new parameters and requirements
 ///// are added on; existing requirements of the base signature might become
 ///// redundant. Otherwise if null, build a new signature from scratch.
-/// \param allowInverses if true, default requirements to Copyable/Escapable are
-/// expanded for generic parameters.
+/// \param options provides control over expansion of default requirements for
+/// conforming to Copyable/Escapable for generic parameters.
 GenericSignature buildGenericSignature(
     ASTContext &ctx,
     GenericSignature baseSignature,
     SmallVector<GenericTypeParamType *, 2> addedParameters,
     SmallVector<Requirement, 2> addedRequirements,
-    bool allowInverses);
+    DefaultRequirementOptions options);
 
 /// Summary of error conditions detected by the Requirement Machine.
 enum class GenericSignatureErrorFlags {
@@ -640,7 +689,7 @@ GenericSignatureWithError buildGenericSignatureWithError(
     GenericSignature baseSignature,
     SmallVector<GenericTypeParamType *, 2> addedParameters,
     SmallVector<Requirement, 2> addedRequirements,
-    bool allowInverses);
+    DefaultRequirementOptions options);
 
 } // end namespace swift
 

--- a/include/swift/AST/GenericSignature.h
+++ b/include/swift/AST/GenericSignature.h
@@ -581,50 +581,29 @@ void validateGenericSignaturesInModule(ModuleDecl *module);
 
 /// Controls how default requirements for invertible protocols such as Copyable
 /// or Escapable are expanded when building a generic signature.
-struct DefaultRequirementOptions {
-  /// If true, default requirements to Copyable/Escapable are
+enum DefaultRequirementFlags : uint8_t {
+  /// If set, default requirements to Copyable/Escapable are
   /// expanded for generic parameters.
-  const bool expandingDefaults;
+  ExpandDefaults = 1 << 0,
 
-  /// If true, generic parameters defined in an outer generic signature that
+  /// If set, generic parameters defined in an outer generic signature that
   /// are same-type constrained to some generic type X within the current
   /// generic signature will skip performing expansion of defaults on type X.
   ///
   /// At a high-level, it "carries inverses across same-type requirements".
-  const bool inferOutOfScopeImpliedInverses;
-
-  /// Requirements WILL NOT be expanded.
-  static DefaultRequirementOptions none() {
-    return DefaultRequirementOptions(/*expandingDefaults=*/false,
-                                     /*inferOutOfScopeImpliedInverses=*/false);
-  }
-
-  /// Requirements WILL be expanded.
-  static DefaultRequirementOptions expand() {
-    return DefaultRequirementOptions(/*expandingDefaults=*/true,
-                                     /*inferOutOfScopeImpliedInverses=*/false);
-  }
-
-  friend bool operator==(DefaultRequirementOptions lhs,
-                         DefaultRequirementOptions rhs) {
-    return lhs.expandingDefaults == rhs.expandingDefaults &&
-           lhs.inferOutOfScopeImpliedInverses ==
-               rhs.inferOutOfScopeImpliedInverses;
-  }
-
-  friend llvm::hash_code hash_value(DefaultRequirementOptions options) {
-    return llvm::hash_combine(options.expandingDefaults,
-                              options.inferOutOfScopeImpliedInverses);
-  }
-
-private:
-  DefaultRequirementOptions(bool expandingDefaults,
-                            bool inferOutOfScopeImpliedInverses)
-      : expandingDefaults(expandingDefaults),
-        inferOutOfScopeImpliedInverses(inferOutOfScopeImpliedInverses) {
-    assert(!inferOutOfScopeImpliedInverses || expandingDefaults);
-  }
+  InferOutOfScopeImpliedInverses = 1 << 1,
 };
+
+using DefaultRequirementOptions = OptionSet<DefaultRequirementFlags>;
+
+inline bool operator==(DefaultRequirementOptions lhs,
+                       DefaultRequirementOptions rhs) {
+  return lhs.containsOnly(rhs);
+}
+
+inline llvm::hash_code hash_value(DefaultRequirementOptions options) {
+  return llvm::hash_value(options.toRaw());
+}
 
 void simple_display(llvm::raw_ostream &out, DefaultRequirementOptions options);
 

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -2237,7 +2237,7 @@ class AbstractGenericSignatureRequest :
                          GenericSignatureWithError (const GenericSignatureImpl *,
                                                     SmallVector<GenericTypeParamType *, 2>,
                                                     SmallVector<Requirement, 2>,
-                                                    bool),
+                                                    DefaultRequirementOptions),
                          RequestFlags::Cached> {
 public:
   using SimpleRequest::SimpleRequest;
@@ -2251,7 +2251,7 @@ private:
            const GenericSignatureImpl *baseSignature,
            SmallVector<GenericTypeParamType *, 2> addedParameters,
            SmallVector<Requirement, 2> addedRequirements,
-           bool allowInverses) const;
+           DefaultRequirementOptions options) const;
 
 public:
   // Separate caching.
@@ -2271,7 +2271,7 @@ class InferredGenericSignatureRequest :
                                                     SmallVector<Requirement, 2>,
                                                     SmallVector<TypeBase *, 2>,
                                                     SourceLoc, ExtensionDecl *,
-                                                    bool),
+                                                    DefaultRequirementOptions),
                          RequestFlags::Uncached> {
 public:
   using SimpleRequest::SimpleRequest;
@@ -2288,7 +2288,7 @@ private:
            SmallVector<Requirement, 2> addedRequirements,
            SmallVector<TypeBase *, 2> inferenceSources,
            SourceLoc loc, ExtensionDecl *forExtension,
-           bool allowInverses) const;
+           DefaultRequirementOptions options) const;
 
 public:
   /// Inferred generic signature requests don't have source-location info.

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -19,7 +19,7 @@ SWIFT_REQUEST(TypeChecker, AbstractGenericSignatureRequest,
               GenericSignatureWithError (const GenericSignatureImpl *,
                                          SmallVector<GenericTypeParamType *, 2>,
                                          SmallVector<Requirement, 2>,
-                                         bool),
+                                         DefaultRequirementOptions),
               Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, ApplyAccessNoteRequest,
               evaluator::SideEffect(ValueDecl *), SeparatelyCached, NoLocationInfo)
@@ -201,7 +201,7 @@ SWIFT_REQUEST(TypeChecker, InferredGenericSignatureRequest,
                                          WhereClauseOwner,
                                          SmallVector<Requirement, 2>,
                                          SmallVector<TypeBase *, 2>,
-                                         SourceLoc, ExtensionDecl *, bool),
+                                         SourceLoc, ExtensionDecl *, DefaultRequirementOptions),
               Uncached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, DistributedModuleIsAvailableRequest,
               bool(const ValueDecl *), Cached, NoLocationInfo)

--- a/include/swift/Subsystems.h
+++ b/include/swift/Subsystems.h
@@ -202,9 +202,9 @@ namespace swift {
                              DeclContext *DC, bool ProduceDiagnostics = true);
 
   /// Expose TypeChecker's handling of GenericParamList to SIL parsing.
-  GenericSignature handleSILGenericParams(GenericParamList *genericParams,
-                                          DeclContext *DC,
-                                          bool allowInverses=true);
+  GenericSignature handleSILGenericParams(
+      GenericParamList *genericParams, DeclContext *DC,
+      DefaultRequirementOptions options = DefaultRequirementOptions::expand());
 
   /// Turn the given module into SIL IR.
   ///

--- a/include/swift/Subsystems.h
+++ b/include/swift/Subsystems.h
@@ -204,7 +204,7 @@ namespace swift {
   /// Expose TypeChecker's handling of GenericParamList to SIL parsing.
   GenericSignature handleSILGenericParams(
       GenericParamList *genericParams, DeclContext *DC,
-      DefaultRequirementOptions options = DefaultRequirementOptions::expand());
+      DefaultRequirementOptions options = ExpandDefaults);
 
   /// Turn the given module into SIL IR.
   ///

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -6934,7 +6934,7 @@ ASTContext::getOpenedExistentialSignature(Type type) {
   collector.addOpenedExistential(gen.Shape);
   existentialSig.OpenedSig = buildGenericSignature(
       *this, collector.OuterSig, collector.Params, collector.Requirements,
-      DefaultRequirementOptions::expand()).getCanonicalSignature();
+      ExpandDefaults).getCanonicalSignature();
 
   // Stash the `Self` type.
   existentialSig.SelfType =
@@ -6962,7 +6962,7 @@ ASTContext::getOpenedElementSignature(CanGenericSignature baseGenericSig,
   collector.addOpenedElement(shapeClass);
   auto elementSig = buildGenericSignature(
       *this, collector.OuterSig, collector.Params, collector.Requirements,
-      DefaultRequirementOptions::none()).getCanonicalSignature();
+      DefaultRequirementOptions()).getCanonicalSignature();
 
   sigs[key] = elementSig;
   return elementSig;
@@ -7037,7 +7037,7 @@ ASTContext::getOverrideGenericSignature(const NominalTypeDecl *baseNominal,
   auto genericSig = buildGenericSignature(*this, derivedNominalSig,
                                           std::move(addedGenericParams),
                                           std::move(addedRequirements),
-                                          DefaultRequirementOptions::none());
+                                          DefaultRequirementOptions());
   getImpl().overrideSigCache.insert(std::make_pair(key, genericSig));
   return genericSig;
 }

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -6934,7 +6934,7 @@ ASTContext::getOpenedExistentialSignature(Type type) {
   collector.addOpenedExistential(gen.Shape);
   existentialSig.OpenedSig = buildGenericSignature(
       *this, collector.OuterSig, collector.Params, collector.Requirements,
-      /*allowInverses=*/true).getCanonicalSignature();
+      DefaultRequirementOptions::expand()).getCanonicalSignature();
 
   // Stash the `Self` type.
   existentialSig.SelfType =
@@ -6962,7 +6962,7 @@ ASTContext::getOpenedElementSignature(CanGenericSignature baseGenericSig,
   collector.addOpenedElement(shapeClass);
   auto elementSig = buildGenericSignature(
       *this, collector.OuterSig, collector.Params, collector.Requirements,
-      /*allowInverses=*/false).getCanonicalSignature();
+      DefaultRequirementOptions::none()).getCanonicalSignature();
 
   sigs[key] = elementSig;
   return elementSig;
@@ -7037,7 +7037,7 @@ ASTContext::getOverrideGenericSignature(const NominalTypeDecl *baseNominal,
   auto genericSig = buildGenericSignature(*this, derivedNominalSig,
                                           std::move(addedGenericParams),
                                           std::move(addedRequirements),
-                                          /*allowInverses=*/false);
+                                          DefaultRequirementOptions::none());
   getImpl().overrideSigCache.insert(std::make_pair(key, genericSig));
   return genericSig;
 }

--- a/lib/AST/ASTDemangler.cpp
+++ b/lib/AST/ASTDemangler.cpp
@@ -1132,7 +1132,7 @@ Type ASTBuilder::createSILBoxTypeWithLayout(
     appendInversesAsRequirements(InverseRequirements, RequirementsVec);
     signature = swift::buildGenericSignature(
         Ctx, signature, genericTypeParams, std::move(RequirementsVec),
-        DefaultRequirementOptions::expand());
+        ExpandDefaults);
   }
   SmallVector<SILField, 4> silFields;
   for (auto field: fields)
@@ -1427,7 +1427,7 @@ CanGenericSignature ASTBuilder::demangleGenericSignature(
   appendInversesAsRequirements(inverseRequirements, requirements);
 
   return buildGenericSignature(Ctx, baseGenericSig, {}, std::move(requirements),
-                               DefaultRequirementOptions::expand())
+                               ExpandDefaults)
       .getCanonicalSignature();
 }
 

--- a/lib/AST/ASTDemangler.cpp
+++ b/lib/AST/ASTDemangler.cpp
@@ -1130,11 +1130,9 @@ Type ASTBuilder::createSILBoxTypeWithLayout(
   if (!genericTypeParams.empty()) {
     SmallVector<BuiltRequirement, 2> RequirementsVec(Requirements);
     appendInversesAsRequirements(InverseRequirements, RequirementsVec);
-    signature = swift::buildGenericSignature(Ctx,
-                                             signature,
-                                             genericTypeParams,
-                                             std::move(RequirementsVec),
-                                             /*allowInverses=*/true);
+    signature = swift::buildGenericSignature(
+        Ctx, signature, genericTypeParams, std::move(RequirementsVec),
+        DefaultRequirementOptions::expand());
   }
   SmallVector<SILField, 4> silFields;
   for (auto field: fields)
@@ -1429,7 +1427,7 @@ CanGenericSignature ASTBuilder::demangleGenericSignature(
   appendInversesAsRequirements(inverseRequirements, requirements);
 
   return buildGenericSignature(Ctx, baseGenericSig, {}, std::move(requirements),
-                               /*allowInverses=*/true)
+                               DefaultRequirementOptions::expand())
       .getCanonicalSignature();
 }
 

--- a/lib/AST/AutoDiff.cpp
+++ b/lib/AST/AutoDiff.cpp
@@ -388,7 +388,7 @@ GenericSignature autodiff::getConstrainedDerivativeGenericSignature(
   return buildGenericSignature(ctx, derivativeGenSig,
                                /*addedGenericParams*/ {},
                                std::move(requirements),
-                               /*allowInverses=*/true);
+                               DefaultRequirementOptions::expand());
 }
 
 // Given the rest of a `Builtin.applyDerivative_{jvp|vjp}` or

--- a/lib/AST/AutoDiff.cpp
+++ b/lib/AST/AutoDiff.cpp
@@ -388,7 +388,7 @@ GenericSignature autodiff::getConstrainedDerivativeGenericSignature(
   return buildGenericSignature(ctx, derivativeGenSig,
                                /*addedGenericParams*/ {},
                                std::move(requirements),
-                               DefaultRequirementOptions::expand());
+                               ExpandDefaults);
 }
 
 // Given the rest of a `Builtin.applyDerivative_{jvp|vjp}` or

--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -378,7 +378,7 @@ synthesizeGenericSignature(SynthesisContext &SC,
                                GenericSignature(),
                                std::move(collector.GenericParamTypes),
                                std::move(collector.AddedRequirements),
-                               /*allowInverses=*/false);
+                               DefaultRequirementOptions::none());
 }
 
 /// Build a builtin function declaration.
@@ -819,7 +819,7 @@ namespace {
           Context, GenericSignature(),
           std::move(genericParamTypes),
           std::move(addedRequirements),
-          /*allowInverses=*/false);
+          DefaultRequirementOptions::none());
       return getBuiltinGenericFunction(name, InterfaceParams, InterfaceResult,
                                        TheGenericParamList, GenericSig, Async,
                                        Throws, ThrownError, SendingResult);

--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -378,7 +378,7 @@ synthesizeGenericSignature(SynthesisContext &SC,
                                GenericSignature(),
                                std::move(collector.GenericParamTypes),
                                std::move(collector.AddedRequirements),
-                               DefaultRequirementOptions::none());
+                               DefaultRequirementOptions());
 }
 
 /// Build a builtin function declaration.
@@ -819,7 +819,7 @@ namespace {
           Context, GenericSignature(),
           std::move(genericParamTypes),
           std::move(addedRequirements),
-          DefaultRequirementOptions::none());
+          DefaultRequirementOptions());
       return getBuiltinGenericFunction(name, InterfaceParams, InterfaceResult,
                                        TheGenericParamList, GenericSig, Async,
                                        Throws, ThrownError, SendingResult);

--- a/lib/AST/ExistentialGeneralization.cpp
+++ b/lib/AST/ExistentialGeneralization.cpp
@@ -58,7 +58,7 @@ public:
     auto sig = buildGenericSignature(ctx, GenericSignature(),
                                      addedParameters,
                                      addedRequirements,
-                                     DefaultRequirementOptions::none());
+                                     DefaultRequirementOptions());
 
     // TODO: minimize the signature by removing redundant generic
     // parameters.

--- a/lib/AST/ExistentialGeneralization.cpp
+++ b/lib/AST/ExistentialGeneralization.cpp
@@ -58,7 +58,7 @@ public:
     auto sig = buildGenericSignature(ctx, GenericSignature(),
                                      addedParameters,
                                      addedRequirements,
-                                     /*allowInverses=*/false);
+                                     DefaultRequirementOptions::none());
 
     // TODO: minimize the signature by removing redundant generic
     // parameters.

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -792,6 +792,14 @@ void GenericSignature::Profile(llvm::FoldingSetNodeID &ID,
   return GenericSignatureImpl::Profile(ID, genericParams, requirements);
 }
 
+void swift::simple_display(raw_ostream &out,
+                           DefaultRequirementOptions options) {
+  out << "DefaultRequirementOptions(expandingDefaults="
+      << options.expandingDefaults
+      << ", inferOutOfScopeImpliedInverses="
+      << options.inferOutOfScopeImpliedInverses << ")";
+}
+
 void swift::simple_display(raw_ostream &out, GenericSignature sig) {
   if (sig)
     sig->print(out);
@@ -1179,11 +1187,9 @@ void swift::validateGenericSignature(ASTContext &context,
   {
     PrettyStackTraceGenericSignature debugStack("verifying", sig);
 
-    auto newSigWithError = buildGenericSignatureWithError(context,
-                                                      GenericSignature(),
-                                                      genericParams,
-                                                      requirements,
-                                                      /*allowInverses*/ false);
+    auto newSigWithError = buildGenericSignatureWithError(
+        context, GenericSignature(), genericParams, requirements,
+        DefaultRequirementOptions::none());
     // If there were any errors, the signature was invalid.
     auto errorFlags = newSigWithError.getInt();
     if (errorFlags.contains(GenericSignatureErrorFlags::HasInvalidRequirements) ||
@@ -1218,7 +1224,7 @@ void swift::validateGenericSignature(ASTContext &context,
           nullptr,
           genericParams,
           newRequirements,
-          /*allowInverses=*/false},
+          DefaultRequirementOptions::none()},
         GenericSignatureWithError());
 
     // If there were any errors, we formed an invalid signature, so
@@ -1308,14 +1314,14 @@ swift::buildGenericSignatureWithError(ASTContext &ctx,
                              GenericSignature baseSignature,
                              SmallVector<GenericTypeParamType *, 2> addedParameters,
                              SmallVector<Requirement, 2> addedRequirements,
-                             bool allowInverses) {
+                             DefaultRequirementOptions options) {
   return evaluateOrDefault(
       ctx.evaluator,
       AbstractGenericSignatureRequest{
         baseSignature.getPointer(),
         addedParameters,
         addedRequirements,
-        allowInverses},
+        options},
       GenericSignatureWithError());
 }
 
@@ -1324,10 +1330,10 @@ swift::buildGenericSignature(ASTContext &ctx,
                              GenericSignature baseSignature,
                              SmallVector<GenericTypeParamType *, 2> addedParameters,
                              SmallVector<Requirement, 2> addedRequirements,
-                             bool allowInverses) {
+                             DefaultRequirementOptions options) {
   return buildGenericSignatureWithError(ctx, baseSignature,
                                         addedParameters, addedRequirements,
-                                        allowInverses).getPointer();
+                                        options).getPointer();
 }
 
 GenericSignature GenericSignature::withoutMarkerProtocols() const {

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -795,9 +795,9 @@ void GenericSignature::Profile(llvm::FoldingSetNodeID &ID,
 void swift::simple_display(raw_ostream &out,
                            DefaultRequirementOptions options) {
   out << "DefaultRequirementOptions(expandingDefaults="
-      << options.expandingDefaults
+      << options.contains(ExpandDefaults)
       << ", inferOutOfScopeImpliedInverses="
-      << options.inferOutOfScopeImpliedInverses << ")";
+      << options.contains(InferOutOfScopeImpliedInverses) << ")";
 }
 
 void swift::simple_display(raw_ostream &out, GenericSignature sig) {
@@ -1189,7 +1189,7 @@ void swift::validateGenericSignature(ASTContext &context,
 
     auto newSigWithError = buildGenericSignatureWithError(
         context, GenericSignature(), genericParams, requirements,
-        DefaultRequirementOptions::none());
+        DefaultRequirementOptions());
     // If there were any errors, the signature was invalid.
     auto errorFlags = newSigWithError.getInt();
     if (errorFlags.contains(GenericSignatureErrorFlags::HasInvalidRequirements) ||
@@ -1224,7 +1224,7 @@ void swift::validateGenericSignature(ASTContext &context,
           nullptr,
           genericParams,
           newRequirements,
-          DefaultRequirementOptions::none()},
+          DefaultRequirementOptions()},
         GenericSignatureWithError());
 
     // If there were any errors, we formed an invalid signature, so

--- a/lib/AST/LocalArchetypeRequirementCollector.cpp
+++ b/lib/AST/LocalArchetypeRequirementCollector.cpp
@@ -156,7 +156,7 @@ GenericSignature swift::buildGenericSignatureWithCapturedEnvironments(
                                collector.OuterSig,
                                collector.Params,
                                collector.Requirements,
-                               DefaultRequirementOptions::none());
+                               DefaultRequirementOptions());
 }
 
 Type MapLocalArchetypesOutOfContext::getInterfaceType(

--- a/lib/AST/LocalArchetypeRequirementCollector.cpp
+++ b/lib/AST/LocalArchetypeRequirementCollector.cpp
@@ -156,7 +156,7 @@ GenericSignature swift::buildGenericSignatureWithCapturedEnvironments(
                                collector.OuterSig,
                                collector.Params,
                                collector.Requirements,
-                               /*allowInverses=*/false);
+                               DefaultRequirementOptions::none());
 }
 
 Type MapLocalArchetypesOutOfContext::getInterfaceType(

--- a/lib/AST/RequirementEnvironment.cpp
+++ b/lib/AST/RequirementEnvironment.cpp
@@ -218,7 +218,7 @@ RequirementEnvironment::RequirementEnvironment(
   witnessThunkSig = buildGenericSignature(ctx, GenericSignature(),
                                           std::move(genericParamTypes),
                                           std::move(requirements),
-                                          DefaultRequirementOptions::none());
+                                          DefaultRequirementOptions());
   reqToWitnessThunkSigMap = reqToWitnessThunkSigMap.subst(
       witnessThunkSig.getGenericEnvironment()
           ->getForwardingSubstitutionMap());

--- a/lib/AST/RequirementEnvironment.cpp
+++ b/lib/AST/RequirementEnvironment.cpp
@@ -218,7 +218,7 @@ RequirementEnvironment::RequirementEnvironment(
   witnessThunkSig = buildGenericSignature(ctx, GenericSignature(),
                                           std::move(genericParamTypes),
                                           std::move(requirements),
-                                          /*allowInverses=*/false);
+                                          DefaultRequirementOptions::none());
   reqToWitnessThunkSigMap = reqToWitnessThunkSigMap.subst(
       witnessThunkSig.getGenericEnvironment()
           ->getForwardingSubstitutionMap());

--- a/lib/AST/RequirementMachine/ApplyInverses.cpp
+++ b/lib/AST/RequirementMachine/ApplyInverses.cpp
@@ -45,6 +45,7 @@ void swift::rewriting::applyInverses(
     ArrayRef<Type> gps,
     ArrayRef<InverseRequirement> inverseList,
     ArrayRef<StructuralRequirement> explicitRequirements,
+    DefaultRequirementOptions options,
     SmallVectorImpl<StructuralRequirement> &result,
     SmallVectorImpl<RequirementError> &errors) {
 

--- a/lib/AST/RequirementMachine/ApplyInverses.cpp
+++ b/lib/AST/RequirementMachine/ApplyInverses.cpp
@@ -155,7 +155,8 @@ void swift::rewriting::applyInverses(
     // It would probably have been more principled to suppress any defaulting
     // in this case, but this behavior shipped in Swift 6.0 and 6.1, so we
     // need to maintain source compatibility.
-    if (typeOutOfScope->isTypeParameter()) {
+    if (typeOutOfScope->isTypeParameter() &&
+        !options.contains(InferOutOfScopeImpliedInverses)) {
       continue;
     }
     

--- a/lib/AST/RequirementMachine/ApplyInverses.cpp
+++ b/lib/AST/RequirementMachine/ApplyInverses.cpp
@@ -103,8 +103,11 @@ void swift::rewriting::applyInverses(
     auto secondTy =
         stripBoundDependentMemberTypes(explicitReqt.req.getSecondType())
             ->getCanonicalType();
-    if (!representativeGPs.count(firstTy)
-        && !representativeGPs.count(secondTy)) {
+
+    const bool foundFirst = representativeGPs.count(firstTy);
+    const bool foundSecond = representativeGPs.count(secondTy);
+
+    if (!foundFirst && !foundSecond) {
       // Same type constraint doesn't involve any in-scope generic parameters.
       continue;
     }
@@ -112,13 +115,11 @@ void swift::rewriting::applyInverses(
     CanType typeInScope;
     CanType typeOutOfScope;
 
-    if (representativeGPs.count(firstTy)
-        && !representativeGPs.count(secondTy)){
+    if (foundFirst && !foundSecond){
       // First type is constrained out of scope.
       typeInScope = firstTy;
       typeOutOfScope = secondTy;
-    } else if (!representativeGPs.count(firstTy)
-               && representativeGPs.count(secondTy)) {
+    } else if (!foundFirst && foundSecond) {
       // Second type is constrained out of scope.
       typeInScope = secondTy;
       typeOutOfScope = firstTy;

--- a/lib/AST/RequirementMachine/RequirementLowering.cpp
+++ b/lib/AST/RequirementMachine/RequirementLowering.cpp
@@ -928,7 +928,7 @@ StructuralRequirementsRequest::evaluate(Evaluator &evaluator,
     InverseRequirement::expandDefaults(ctx, needsDefaultRequirements, result,
                                        defaults, expandedGPs);
     applyInverses(ctx, expandedGPs, inverses, result,
-                  DefaultRequirementOptions::none(), defaults, errors);
+                  DefaultRequirementOptions(), defaults, errors);
     result.append(defaults);
 
     diagnoseRequirementErrors(ctx, errors,
@@ -1009,7 +1009,7 @@ StructuralRequirementsRequest::evaluate(Evaluator &evaluator,
   }
 
   applyInverses(ctx, expandedGPs, inverses, result,
-                DefaultRequirementOptions::none(), defaults, errors);
+                DefaultRequirementOptions(), defaults, errors);
   result.append(defaults);
 
   diagnoseRequirementErrors(ctx, errors,

--- a/lib/AST/RequirementMachine/RequirementLowering.cpp
+++ b/lib/AST/RequirementMachine/RequirementLowering.cpp
@@ -928,7 +928,7 @@ StructuralRequirementsRequest::evaluate(Evaluator &evaluator,
     InverseRequirement::expandDefaults(ctx, needsDefaultRequirements, result,
                                        defaults, expandedGPs);
     applyInverses(ctx, expandedGPs, inverses, result,
-                  defaults, errors);
+                  DefaultRequirementOptions::none(), defaults, errors);
     result.append(defaults);
 
     diagnoseRequirementErrors(ctx, errors,
@@ -1009,7 +1009,7 @@ StructuralRequirementsRequest::evaluate(Evaluator &evaluator,
   }
 
   applyInverses(ctx, expandedGPs, inverses, result,
-                defaults, errors);
+                DefaultRequirementOptions::none(), defaults, errors);
   result.append(defaults);
 
   diagnoseRequirementErrors(ctx, errors,

--- a/lib/AST/RequirementMachine/RequirementLowering.h
+++ b/lib/AST/RequirementMachine/RequirementLowering.h
@@ -73,6 +73,7 @@ void applyInverses(ASTContext &ctx,
                    ArrayRef<Type> gps,
                    ArrayRef<InverseRequirement> inverseList,
                    ArrayRef<StructuralRequirement> explicitRequirements,
+                   DefaultRequirementOptions options,
                    SmallVectorImpl<StructuralRequirement> &result,
                    SmallVectorImpl<RequirementError> &errors);
 

--- a/lib/AST/RequirementMachine/RequirementMachineRequests.cpp
+++ b/lib/AST/RequirementMachine/RequirementMachineRequests.cpp
@@ -551,7 +551,7 @@ AbstractGenericSignatureRequest::evaluate(
          const GenericSignatureImpl *baseSignatureImpl,
          SmallVector<GenericTypeParamType *, 2> addedParameters,
          SmallVector<Requirement, 2> addedRequirements,
-         bool allowInverses) const {
+         DefaultRequirementOptions options) const {
   GenericSignature baseSignature = GenericSignature{baseSignatureImpl};
   // If nothing is added to the base signature, just return the base
   // signature.
@@ -571,7 +571,7 @@ AbstractGenericSignatureRequest::evaluate(
 
   // If there are no added requirements, we can form the signature directly
   // with the added parameters.
-  if (addedRequirements.empty() && !allowInverses) {
+  if (addedRequirements.empty() && !options.expandingDefaults) {
     auto result = GenericSignature::get(genericParams,
                                         baseSignature.getRequirements());
     return GenericSignatureWithError(result, GenericSignatureErrors());
@@ -602,7 +602,7 @@ AbstractGenericSignatureRequest::evaluate(
         AbstractGenericSignatureRequest{
           canBaseSignature.getPointer(), std::move(canAddedParameters),
           std::move(canAddedRequirements),
-          allowInverses},
+          options},
         GenericSignatureWithError());
     if (!canSignatureResult.getPointer())
       return GenericSignatureWithError();
@@ -667,7 +667,7 @@ AbstractGenericSignatureRequest::evaluate(
 
   /// Next, we need to expand default requirements and then apply inverses.
   SmallVector<Type, 2> paramsAsTypes;
-  if (allowInverses) {
+  if (options.expandingDefaults) {
     for (auto *gtpt : addedParameters)
       paramsAsTypes.push_back(gtpt);
   }
@@ -676,8 +676,8 @@ AbstractGenericSignatureRequest::evaluate(
   SmallVector<Type, 2> expandedGPs;
   InverseRequirement::expandDefaults(ctx, paramsAsTypes, requirements, defaults,
                                      expandedGPs);
-  applyInverses(ctx, expandedGPs, inverses, requirements,
-                defaults, errors);
+  applyInverses(ctx, expandedGPs, inverses, requirements, options, defaults,
+                errors);
   requirements.append(defaults);
 
   auto &rewriteCtx = ctx.getRewriteContext();
@@ -762,7 +762,7 @@ InferredGenericSignatureRequest::evaluate(
         WhereClauseOwner whereClause,
         SmallVector<Requirement, 2> addedRequirements,
         SmallVector<TypeBase *, 2> inferenceSources,
-        SourceLoc loc, ExtensionDecl *forExtension, bool allowInverses) const {
+        SourceLoc loc, ExtensionDecl *forExtension, DefaultRequirementOptions options) const {
   GenericSignature parentSig(parentSigImpl);
 
   SmallVector<GenericTypeParamType *, 4> genericParams(
@@ -863,7 +863,7 @@ InferredGenericSignatureRequest::evaluate(
   // After realizing requirements, expand default requirements only for local
   // generic parameters, as the outer parameters have already been expanded.
   SmallVector<Type, 4> paramTypes;
-  if (allowInverses) {
+  if (options.expandingDefaults) {
     paramTypes.append(genericParams.begin() + numOuterParams,
                       genericParams.end());
   }
@@ -871,8 +871,8 @@ InferredGenericSignatureRequest::evaluate(
   SmallVector<StructuralRequirement, 2> defaults;
   SmallVector<Type, 2> expandedGPs;
   InverseRequirement::expandDefaults(ctx, paramTypes, requirements, defaults, expandedGPs);
-  applyInverses(ctx, expandedGPs, inverses, requirements,
-                defaults, errors);
+  applyInverses(ctx, expandedGPs, inverses, requirements, options, defaults,
+                errors);
   
   // Any remaining implicit defaults in a conditional inverse requirement
   // extension must be made explicit.

--- a/lib/AST/RequirementMachine/RequirementMachineRequests.cpp
+++ b/lib/AST/RequirementMachine/RequirementMachineRequests.cpp
@@ -571,7 +571,7 @@ AbstractGenericSignatureRequest::evaluate(
 
   // If there are no added requirements, we can form the signature directly
   // with the added parameters.
-  if (addedRequirements.empty() && !options.expandingDefaults) {
+  if (addedRequirements.empty() && !options.contains(ExpandDefaults)) {
     auto result = GenericSignature::get(genericParams,
                                         baseSignature.getRequirements());
     return GenericSignatureWithError(result, GenericSignatureErrors());
@@ -667,7 +667,7 @@ AbstractGenericSignatureRequest::evaluate(
 
   /// Next, we need to expand default requirements and then apply inverses.
   SmallVector<Type, 2> paramsAsTypes;
-  if (options.expandingDefaults) {
+  if (options.contains(ExpandDefaults)) {
     for (auto *gtpt : addedParameters)
       paramsAsTypes.push_back(gtpt);
   }
@@ -863,7 +863,7 @@ InferredGenericSignatureRequest::evaluate(
   // After realizing requirements, expand default requirements only for local
   // generic parameters, as the outer parameters have already been expanded.
   SmallVector<Type, 4> paramTypes;
-  if (options.expandingDefaults) {
+  if (options.contains(ExpandDefaults)) {
     paramTypes.append(genericParams.begin() + numOuterParams,
                       genericParams.end());
   }

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -10409,7 +10409,7 @@ GenericSignature ClangImporter::Implementation::buildGenericSignature(
       SwiftContext, GenericSignature(),
       std::move(genericParamTypes),
       std::move(requirements),
-      /*allowInverses=*/true);
+      DefaultRequirementOptions::expand());
 }
 
 Decl *

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -10409,7 +10409,7 @@ GenericSignature ClangImporter::Implementation::buildGenericSignature(
       SwiftContext, GenericSignature(),
       std::move(genericParamTypes),
       std::move(requirements),
-      DefaultRequirementOptions::expand());
+      ExpandDefaults);
 }
 
 Decl *

--- a/lib/IRGen/GenDistributed.cpp
+++ b/lib/IRGen/GenDistributed.cpp
@@ -327,7 +327,7 @@ static CanSILFunctionType getAccessorType(IRGenModule &IGM) {
     signature = buildGenericSignature(Context, GenericSignature(),
                                       std::move(genericParams),
                                       std::move(genericRequirements),
-                                      /*allowInverses=*/true);
+                                      DefaultRequirementOptions::expand());
   }
 
   auto accessorTy = GenericFunctionType::get(

--- a/lib/IRGen/GenDistributed.cpp
+++ b/lib/IRGen/GenDistributed.cpp
@@ -327,7 +327,7 @@ static CanSILFunctionType getAccessorType(IRGenModule &IGM) {
     signature = buildGenericSignature(Context, GenericSignature(),
                                       std::move(genericParams),
                                       std::move(genericRequirements),
-                                      DefaultRequirementOptions::expand());
+                                      ExpandDefaults);
   }
 
   auto accessorTy = GenericFunctionType::get(

--- a/lib/SIL/IR/AbstractionPattern.cpp
+++ b/lib/SIL/IR/AbstractionPattern.cpp
@@ -3067,7 +3067,7 @@ const {
   auto substSig = buildGenericSignature(TC.Context, GenericSignature(),
                                         std::move(visitor.substGenericParams),
                                         std::move(visitor.substRequirements),
-                                        /*allowInverses=*/false)
+                                        DefaultRequirementOptions::none())
     .getCanonicalSignature();
   
   auto subMap = SubstitutionMap::get(substSig,

--- a/lib/SIL/IR/AbstractionPattern.cpp
+++ b/lib/SIL/IR/AbstractionPattern.cpp
@@ -3067,7 +3067,7 @@ const {
   auto substSig = buildGenericSignature(TC.Context, GenericSignature(),
                                         std::move(visitor.substGenericParams),
                                         std::move(visitor.substRequirements),
-                                        DefaultRequirementOptions::none())
+                                        DefaultRequirementOptions())
     .getCanonicalSignature();
   
   auto subMap = SubstitutionMap::get(substSig,

--- a/lib/SIL/IR/SIL.cpp
+++ b/lib/SIL/IR/SIL.cpp
@@ -390,7 +390,7 @@ getKeyPathSupportingGenericSignature(Type ty, GenericSignature contextSig) {
                                                contextSig,
                                                {},
                                                std::move(ceRequirements),
-                                               DefaultRequirementOptions::none());
+                                               DefaultRequirementOptions());
   
   // If the resulting signature has conflicting requirements, then it is
   // impossible for the type to be copyable and equatable.

--- a/lib/SIL/IR/SIL.cpp
+++ b/lib/SIL/IR/SIL.cpp
@@ -390,7 +390,7 @@ getKeyPathSupportingGenericSignature(Type ty, GenericSignature contextSig) {
                                                contextSig,
                                                {},
                                                std::move(ceRequirements),
-                                               /*allowInverses*/ false);
+                                               DefaultRequirementOptions::none());
   
   // If the resulting signature has conflicting requirements, then it is
   // impossible for the type to be copyable and equatable.

--- a/lib/SIL/IR/SILFunction.cpp
+++ b/lib/SIL/IR/SILFunction.cpp
@@ -91,7 +91,7 @@ GenericSignature SILSpecializeAttr::buildTypeErasedSignature(
         C, GenericSignature(),
         SmallVector<GenericTypeParamType *>(sig.getGenericParams()),
         requirementsErased,
-        DefaultRequirementOptions::none());
+        DefaultRequirementOptions());
   }
 
   return sig;

--- a/lib/SIL/IR/SILFunction.cpp
+++ b/lib/SIL/IR/SILFunction.cpp
@@ -91,7 +91,7 @@ GenericSignature SILSpecializeAttr::buildTypeErasedSignature(
         C, GenericSignature(),
         SmallVector<GenericTypeParamType *>(sig.getGenericParams()),
         requirementsErased,
-        /*allowInverses=*/false);
+        DefaultRequirementOptions::none());
   }
 
   return sig;

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -501,7 +501,8 @@ static CanGenericSignature buildDifferentiableGenericSignature(CanGenericSignatu
     });
   }
 
-  return buildGenericSignature(ctx, sig, {}, reqs, /*allowInverses=*/false)
+  return buildGenericSignature(ctx, sig, {}, reqs,
+                               DefaultRequirementOptions::none())
       .getCanonicalSignature();
 }
 

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -502,7 +502,7 @@ static CanGenericSignature buildDifferentiableGenericSignature(CanGenericSignatu
   }
 
   return buildGenericSignature(ctx, sig, {}, reqs,
-                               DefaultRequirementOptions::none())
+                               DefaultRequirementOptions())
       .getCanonicalSignature();
 }
 

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -1187,7 +1187,7 @@ void SILParser::bindSILGenericParams(TypeRepr *TyR) {
 
         if (auto *genericParams = fnType->getPatternGenericParams()) {
           auto sig = handleSILGenericParams(genericParams, SF,
-                                            DefaultRequirementOptions::none());
+                                            DefaultRequirementOptions());
           fnType->setPatternGenericSignature(sig);
         }
       }
@@ -2267,7 +2267,7 @@ static bool parseSILDifferentiabilityWitnessConfigAndFunction(
         P.Context, origGenSig,
         /*addedGenericParams=*/{},
         std::move(witnessRequirements),
-        DefaultRequirementOptions::none());
+        DefaultRequirementOptions());
   }
   auto origFnType = resultOrigFn->getLoweredFunctionType();
   auto *parameterIndices = IndexSubset::get(
@@ -7608,7 +7608,7 @@ bool SILParserState::parseDeclSIL(Parser &P) {
                                                     fenv->getGenericSignature(),
                                                     /*addedGenericParams=*/{ },
                                                     std::move(requirements),
-                                                    DefaultRequirementOptions::none());
+                                                    DefaultRequirementOptions());
             FunctionState.F->addSpecializeAttr(SILSpecializeAttr::create(
                 FunctionState.F->getModule(), genericSig, typeErasedParams, Attr.exported,
                 Attr.kind, Attr.target, Attr.spiGroupID, Attr.spiModule, Attr.availability));

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -1187,7 +1187,7 @@ void SILParser::bindSILGenericParams(TypeRepr *TyR) {
 
         if (auto *genericParams = fnType->getPatternGenericParams()) {
           auto sig = handleSILGenericParams(genericParams, SF,
-                                            /*allowInverses=*/false);
+                                            DefaultRequirementOptions::none());
           fnType->setPatternGenericSignature(sig);
         }
       }
@@ -2267,7 +2267,7 @@ static bool parseSILDifferentiabilityWitnessConfigAndFunction(
         P.Context, origGenSig,
         /*addedGenericParams=*/{},
         std::move(witnessRequirements),
-        /*allowInverses=*/false);
+        DefaultRequirementOptions::none());
   }
   auto origFnType = resultOrigFn->getLoweredFunctionType();
   auto *parameterIndices = IndexSubset::get(
@@ -7608,7 +7608,7 @@ bool SILParserState::parseDeclSIL(Parser &P) {
                                                     fenv->getGenericSignature(),
                                                     /*addedGenericParams=*/{ },
                                                     std::move(requirements),
-                                                    /*allowInverses=*/false);
+                                                    DefaultRequirementOptions::none());
             FunctionState.F->addSpecializeAttr(SILSpecializeAttr::create(
                 FunctionState.F->getModule(), genericSig, typeErasedParams, Attr.exported,
                 Attr.kind, Attr.target, Attr.spiGroupID, Attr.spiModule, Attr.availability));

--- a/lib/SILOptimizer/FunctionSignatureTransforms/ExistentialTransform.cpp
+++ b/lib/SILOptimizer/FunctionSignatureTransforms/ExistentialTransform.cpp
@@ -336,7 +336,7 @@ ExistentialTransform::createExistentialSpecializedFunctionType() {
   NewGenericSig = buildGenericSignature(Ctx, OrigGenericSig,
                                         std::move(GenericParams),
                                         std::move(Requirements),
-                                        DefaultRequirementOptions::expand());
+                                        ExpandDefaults);
 
   /// Original list of parameters
   SmallVector<SILParameterInfo, 4> params;

--- a/lib/SILOptimizer/FunctionSignatureTransforms/ExistentialTransform.cpp
+++ b/lib/SILOptimizer/FunctionSignatureTransforms/ExistentialTransform.cpp
@@ -336,7 +336,7 @@ ExistentialTransform::createExistentialSpecializedFunctionType() {
   NewGenericSig = buildGenericSignature(Ctx, OrigGenericSig,
                                         std::move(GenericParams),
                                         std::move(Requirements),
-                                        /*allowInverses=*/true);
+                                        DefaultRequirementOptions::expand());
 
   /// Original list of parameters
   SmallVector<SILParameterInfo, 4> params;

--- a/lib/SILOptimizer/Utils/Existential.cpp
+++ b/lib/SILOptimizer/Utils/Existential.cpp
@@ -246,7 +246,7 @@ void ConcreteExistentialInfo::initializeSubstitutionMap(
   collector.addOpenedExistential(ExistentialType);
   auto ExistentialSig = buildGenericSignature(
       ctx, collector.OuterSig, collector.Params, collector.Requirements,
-      /*allowInverses=*/true).getCanonicalSignature();
+      DefaultRequirementOptions::expand()).getCanonicalSignature();
 
   ExistentialSubs = SubstitutionMap::get(
       ExistentialSig, [&](SubstitutableType *type) { return ConcreteType; },

--- a/lib/SILOptimizer/Utils/Existential.cpp
+++ b/lib/SILOptimizer/Utils/Existential.cpp
@@ -246,7 +246,7 @@ void ConcreteExistentialInfo::initializeSubstitutionMap(
   collector.addOpenedExistential(ExistentialType);
   auto ExistentialSig = buildGenericSignature(
       ctx, collector.OuterSig, collector.Params, collector.Requirements,
-      DefaultRequirementOptions::expand()).getCanonicalSignature();
+      ExpandDefaults).getCanonicalSignature();
 
   ExistentialSubs = SubstitutionMap::get(
       ExistentialSig, [&](SubstitutableType *type) { return ConcreteType; },

--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -1139,7 +1139,7 @@ getGenericEnvironmentAndSignatureWithRequirements(
   auto NewGenSig = buildGenericSignature(M.getASTContext(),
                                          OrigGenSig, { },
                                          std::move(RequirementsCopy),
-                                         /*allowInverses=*/false);
+                                         DefaultRequirementOptions::none());
   auto NewGenEnv = NewGenSig.getGenericEnvironment();
   return { NewGenEnv, NewGenSig };
 }
@@ -1817,7 +1817,7 @@ FunctionSignaturePartialSpecializer::
   // Finalize the archetype builder.
   auto GenSig = buildGenericSignature(Ctx, GenericSignature(),
                                       AllGenericParams, AllRequirements,
-                                      /*allowInverses=*/false);
+                                      DefaultRequirementOptions::none());
   auto *GenEnv = GenSig.getGenericEnvironment();
   return { GenEnv, GenSig };
 }

--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -1139,7 +1139,7 @@ getGenericEnvironmentAndSignatureWithRequirements(
   auto NewGenSig = buildGenericSignature(M.getASTContext(),
                                          OrigGenSig, { },
                                          std::move(RequirementsCopy),
-                                         DefaultRequirementOptions::none());
+                                         DefaultRequirementOptions());
   auto NewGenEnv = NewGenSig.getGenericEnvironment();
   return { NewGenEnv, NewGenSig };
 }
@@ -1817,7 +1817,7 @@ FunctionSignaturePartialSpecializer::
   // Finalize the archetype builder.
   auto GenSig = buildGenericSignature(Ctx, GenericSignature(),
                                       AllGenericParams, AllRequirements,
-                                      DefaultRequirementOptions::none());
+                                      DefaultRequirementOptions());
   auto *GenEnv = GenSig.getGenericEnvironment();
   return { GenEnv, GenSig };
 }

--- a/lib/Sema/DerivedConformance/DerivedConformanceDistributedActor.cpp
+++ b/lib/Sema/DerivedConformance/DerivedConformanceDistributedActor.cpp
@@ -251,7 +251,7 @@ static FuncDecl* createLocalFunc_doInvokeOnReturn(
                             {resultGenericParamDecl->getDeclaredInterfaceType()
                                  ->castTo<GenericTypeParamType>()},
                             std::move(requirements),
-                            DefaultRequirementOptions::expand());
+                            ExpandDefaults);
 
   FuncDecl *doInvokeOnReturnFunc = FuncDecl::createImplicit(
       C, swift::StaticSpellingKind::None,

--- a/lib/Sema/DerivedConformance/DerivedConformanceDistributedActor.cpp
+++ b/lib/Sema/DerivedConformance/DerivedConformanceDistributedActor.cpp
@@ -251,7 +251,7 @@ static FuncDecl* createLocalFunc_doInvokeOnReturn(
                             {resultGenericParamDecl->getDeclaredInterfaceType()
                                  ->castTo<GenericTypeParamType>()},
                             std::move(requirements),
-                            /*allowInverses=*/true);
+                            DefaultRequirementOptions::expand());
 
   FuncDecl *doInvokeOnReturnFunc = FuncDecl::createImplicit(
       C, swift::StaticSpellingKind::None,

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -3691,7 +3691,7 @@ SerializeAttrGenericSignatureRequest::evaluate(Evaluator &evaluator,
       /*inferenceSources=*/{},
       attr->getLocation(),
       /*forExtension=*/nullptr,
-      /*allowInverses=*/true};
+      DefaultRequirementOptions::expand()};
 
   auto specializedSig = evaluateOrDefault(Ctx.evaluator, request,
                                           GenericSignatureWithError())
@@ -6903,7 +6903,7 @@ bool resolveDifferentiableAttrDerivativeGenericSignature(
         /*inferenceSources=*/{},
         attr->getLocation(),
         /*forExtension=*/nullptr,
-        /*allowInverses=*/true};
+        DefaultRequirementOptions::expand()};
 
     // Compute generic signature for derivative functions.
     derivativeGenSig = evaluateOrDefault(ctx.evaluator, request,

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -3691,7 +3691,7 @@ SerializeAttrGenericSignatureRequest::evaluate(Evaluator &evaluator,
       /*inferenceSources=*/{},
       attr->getLocation(),
       /*forExtension=*/nullptr,
-      DefaultRequirementOptions::expand()};
+      ExpandDefaults};
 
   auto specializedSig = evaluateOrDefault(Ctx.evaluator, request,
                                           GenericSignatureWithError())
@@ -6903,7 +6903,7 @@ bool resolveDifferentiableAttrDerivativeGenericSignature(
         /*inferenceSources=*/{},
         attr->getLocation(),
         /*forExtension=*/nullptr,
-        DefaultRequirementOptions::expand()};
+        ExpandDefaults};
 
     // Compute generic signature for derivative functions.
     derivativeGenSig = evaluateOrDefault(ctx.evaluator, request,

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -2183,25 +2183,46 @@ static void checkProtocolRefinementRequirements(ProtocolDecl *proto) {
 }
 
 static void dumpGenericSignature(ASTContext &ctx, GenericContext *GC) {
-  if (ctx.TypeCheckerOpts.DebugGenericSignatures) {
-    if (auto sig = GC->getGenericSignature()) {
+  if (!ctx.TypeCheckerOpts.DebugGenericSignatures)
+    return;
+
+  auto *VD = dyn_cast_or_null<ValueDecl>(GC->getAsDecl());
+
+  auto dumpSig = [&](GenericSignature sig, bool isOpaque) {
+    llvm::errs() << "\n";
+    if (isOpaque) {
+      llvm::errs() << "Opaque result type of ";
+    }
+    if (VD) {
+      VD->dumpRef(llvm::errs());
       llvm::errs() << "\n";
-      if (auto *VD = dyn_cast_or_null<ValueDecl>(GC->getAsDecl())) {
-        VD->dumpRef(llvm::errs());
-        llvm::errs() << "\n";
-      } else {
-        GC->printContext(llvm::errs());
+    } else {
+      GC->printContext(llvm::errs());
+    }
+    llvm::errs() << (isOpaque ? "Opaque result signature: "
+                              : "Generic signature: ");
+    PrintOptions Opts = PrintOptions::forDebugging();
+    Opts.ProtocolQualifiedDependentMemberTypes = true;
+    Opts.PrintInverseRequirements =
+        !ctx.TypeCheckerOpts.DebugInverseRequirements;
+    sig->print(llvm::errs(), Opts);
+    llvm::errs() << "\n";
+    llvm::errs() << (isOpaque ? "Canonical opaque result signature: "
+                              : "Canonical generic signature: ");
+    sig.getCanonicalSignature()->print(llvm::errs(), Opts);
+    llvm::errs() << "\n";
+  };
+
+  if (auto sig = GC->getGenericSignature())
+    dumpSig(sig, /*isOpaque=*/false);
+
+  // If we have a ValueDecl, also visit its opaque result type and
+  // dump its signature.
+  if (VD) {
+    if (auto *OTD = VD->getOpaqueResultTypeDecl()) {
+      if (auto sig = OTD->getOpaqueInterfaceGenericSignature()) {
+        dumpSig(sig, /*isOpaque=*/true);
       }
-      llvm::errs() << "Generic signature: ";
-      PrintOptions Opts = PrintOptions::forDebugging();
-      Opts.ProtocolQualifiedDependentMemberTypes = true;
-      Opts.PrintInverseRequirements =
-          !ctx.TypeCheckerOpts.DebugInverseRequirements;
-      sig->print(llvm::errs(), Opts);
-      llvm::errs() << "\n";
-      llvm::errs() << "Canonical generic signature: ";
-      sig.getCanonicalSignature()->print(llvm::errs(), Opts);
-      llvm::errs() << "\n";
     }
   }
 }

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -122,7 +122,7 @@ OpaqueResultTypeRequest::evaluate(Evaluator &evaluator,
         /*inferenceSources=*/{},
         repr->getLoc(),
         /*forExtension=*/nullptr,
-        DefaultRequirementOptions::expand()};
+        ExpandDefaults};
 
     interfaceSignature = evaluateOrDefault(
         ctx.evaluator, request, GenericSignatureWithError())
@@ -207,7 +207,7 @@ OpaqueResultTypeRequest::evaluate(Evaluator &evaluator,
 
     interfaceSignature = buildGenericSignature(
         ctx, outerGenericSignature, genericParamTypes, std::move(requirements),
-        DefaultRequirementOptions::expand());
+        {ExpandDefaults, InferOutOfScopeImpliedInverses});
     genericParams = originatingGenericContext
         ? originatingGenericContext->getGenericParams()
         : nullptr;
@@ -468,7 +468,7 @@ void TypeChecker::checkProtocolSelfRequirements(ValueDecl *decl) {
 
     auto weightedSig =
         buildGenericSignature(ctx, GenericSignature(), params, reqs,
-                              DefaultRequirementOptions::none());
+                              DefaultRequirementOptions());
 
     // Repeat the check with the new signature.
     checkProtocolSelfRequirementsImpl(ctx, proto, decl, sig, weightedSig,
@@ -988,7 +988,7 @@ GenericSignatureRequest::evaluate(Evaluator &evaluator,
       genericParams, WhereClauseOwner(GC),
       extraReqs, inferenceSources, loc,
       /*forExtension=*/dyn_cast<ExtensionDecl>(GC),
-      DefaultRequirementOptions::expand()};
+      ExpandDefaults};
   return evaluateOrDefault(ctx.evaluator, request,
                            GenericSignatureWithError()).getPointer();
 }

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -122,7 +122,7 @@ OpaqueResultTypeRequest::evaluate(Evaluator &evaluator,
         /*inferenceSources=*/{},
         repr->getLoc(),
         /*forExtension=*/nullptr,
-        /*allowInverses=*/true};
+        DefaultRequirementOptions::expand()};
 
     interfaceSignature = evaluateOrDefault(
         ctx.evaluator, request, GenericSignatureWithError())
@@ -205,10 +205,9 @@ OpaqueResultTypeRequest::evaluate(Evaluator &evaluator,
       requirements.emplace_back(kind, paramType, constraintType);
     }
 
-    interfaceSignature = buildGenericSignature(ctx, outerGenericSignature,
-                                               genericParamTypes,
-                                               std::move(requirements),
-                                               /*allowInverses=*/true);
+    interfaceSignature = buildGenericSignature(
+        ctx, outerGenericSignature, genericParamTypes, std::move(requirements),
+        DefaultRequirementOptions::expand());
     genericParams = originatingGenericContext
         ? originatingGenericContext->getGenericParams()
         : nullptr;
@@ -467,8 +466,9 @@ void TypeChecker::checkProtocolSelfRequirements(ValueDecl *decl) {
       }
     }
 
-    auto weightedSig = buildGenericSignature(
-        ctx, GenericSignature(), params, reqs, /*allowInverses=*/false);
+    auto weightedSig =
+        buildGenericSignature(ctx, GenericSignature(), params, reqs,
+                              DefaultRequirementOptions::none());
 
     // Repeat the check with the new signature.
     checkProtocolSelfRequirementsImpl(ctx, proto, decl, sig, weightedSig,
@@ -988,7 +988,7 @@ GenericSignatureRequest::evaluate(Evaluator &evaluator,
       genericParams, WhereClauseOwner(GC),
       extraReqs, inferenceSources, loc,
       /*forExtension=*/dyn_cast<ExtensionDecl>(GC),
-      /*allowInverses=*/true};
+      DefaultRequirementOptions::expand()};
   return evaluateOrDefault(ctx.evaluator, request,
                            GenericSignatureWithError()).getPointer();
 }

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -329,8 +329,9 @@ static GenericSignature maybeAddDifferentiableFromContext(DeclContext *dc,
                   return protoKind && *protoKind == KnownProtocolKind::Differentiable;
                 });
 
-  return buildGenericSignature(dc->getASTContext(), derivativeGenSig,
-                               {}, std::move(diffRequirements), /*allowInverses=*/true);
+  return buildGenericSignature(dc->getASTContext(), derivativeGenSig, {},
+                               std::move(diffRequirements),
+                               DefaultRequirementOptions::expand());
 }
 
 /// Given a witness, a requirement, and an existing `RequirementMatch` result,

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -331,7 +331,7 @@ static GenericSignature maybeAddDifferentiableFromContext(DeclContext *dc,
 
   return buildGenericSignature(dc->getASTContext(), derivativeGenSig, {},
                                std::move(diffRequirements),
-                               DefaultRequirementOptions::expand());
+                               ExpandDefaults);
 }
 
 /// Given a witness, a requirement, and an existing `RequirementMatch` result,

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -556,8 +556,8 @@ namespace {
 
 /// Expose TypeChecker's handling of GenericParamList to SIL parsing.
 GenericSignature
-swift::handleSILGenericParams(GenericParamList *genericParams,
-                              DeclContext *DC, bool allowInverses) {
+swift::handleSILGenericParams(GenericParamList *genericParams, DeclContext *DC,
+                              DefaultRequirementOptions options) {
   if (genericParams == nullptr)
     return nullptr;
 
@@ -584,7 +584,7 @@ swift::handleSILGenericParams(GenericParamList *genericParams,
       nestedList.back(), WhereClauseOwner(),
       {}, {}, genericParams->getLAngleLoc(),
       /*forExtension=*/nullptr,
-      allowInverses};
+      options};
   return evaluateOrDefault(DC->getASTContext().evaluator, request,
                            GenericSignatureWithError()).getPointer();
 }

--- a/test/Generics/inverse_assoc_types.swift
+++ b/test/Generics/inverse_assoc_types.swift
@@ -202,3 +202,92 @@ protocol Dog {
     associatedtype A
 }
 protocol Hotdog: Dog where Self.A: ~Copyable {} // expected-error {{'Self.A' required to be 'Copyable' but is marked with '~Copyable'}}
+
+
+protocol Foo<Inner>: ~Copyable {
+  associatedtype Inner: ~Copyable
+  func getInner() -> Inner
+}
+
+struct NC: ~Copyable {}
+
+struct WitnessFoo<Inner: ~Copyable>: Foo {
+  func getInner() -> Inner { fatalError("todo") }
+}
+
+extension WitnessFoo where Inner: ~Copyable {
+  func asFoo() -> some Foo<Inner> {
+    return self
+  }
+}
+
+func createNCInner<Inner: ~Copyable>(_ t: Inner.Type) -> some Foo<Inner> {
+    return WitnessFoo<Inner>()
+}
+
+func createCopyableInner<Inner>(_ t: Inner.Type) -> some Foo<Inner> {  // expected-note {{'where Inner: Copyable' is implicit here}}
+  return WitnessFoo<Inner>()
+}
+
+func requireCopyableInnerMeta<X: Foo>(_ t: X.Type) -> some Foo<X.Inner> { // expected-note {{where 'X.Inner' = 'NC'}}
+  return WitnessFoo<X.Inner>()
+}
+
+func permitNCInnerMeta<X: Foo>(_ t: X.Type) -> some Foo<X.Inner> where X.Inner: ~Copyable {
+  return WitnessFoo<X.Inner>()
+}
+
+func expectC<T>(_ t: T) {} // expected-note {{'where T: Copyable' is implicit here}}
+func permitNC<T: ~Copyable>(_ t: borrowing T) {}
+
+func test() {
+  _ = createCopyableInner(Int.self)
+  _ = createCopyableInner(NC.self) // expected-error {{global function 'createCopyableInner' requires that 'NC' conform to 'Copyable'}}
+
+  expectC(createNCInner(Int.self).getInner())
+  expectC(createNCInner(NC.self).getInner()) // expected-error {{global function 'expectC' requires that 'NC' conform to 'Copyable'}}
+
+  permitNC(createNCInner(Int.self).getInner())
+  permitNC(createNCInner(NC.self).getInner())
+
+
+  requireCopyableInnerMeta(WitnessFoo<NC>.self) // expected-error {{global function 'requireCopyableInnerMeta' requires that 'NC' conform to 'Copyable'}}
+  permitNC(permitNCInnerMeta(WitnessFoo<NC>.self).getInner())
+}
+
+
+protocol Multi<A, B, C> {
+  associatedtype A: ~Copyable
+  associatedtype B: ~Copyable
+  associatedtype C
+}
+
+struct MultiTest<A: ~Copyable, B: ~Copyable, C>: Multi {}
+
+func testMulti1<T: ~Copyable>(_ t: T.Type) -> some Multi<T, T, Int> {
+  return MultiTest<T, T, Int>()
+}
+
+func testMulti2<T: ~Copyable, V>(_ t: T.Type, _ v: ReqC<V>) -> some Multi<T, V, V> {
+  return MultiTest<T, V, V>()
+}
+
+func testMulti3<T: ~Copyable, V>(_ t: T.Type, _ v: ReqC<V>) -> some Multi<T, V, T> { // expected-note {{opaque return type declared here}}
+  if 1 == 2 {
+    return MultiTest<T, V, T>()  // expected-error {{type 'T' does not conform to protocol 'Copyable'}}
+  } else {
+    return MultiTest<T, V, V>() // expected-error {{return type of global function 'testMulti3' requires the types 'T' and 'V' be equivalent}}
+  }
+}
+
+func testMulti4<X: Multi>(_ x: X) -> some Multi<X.A, X.B, X.C> {
+  return x
+}
+
+func testMulti5<X: Multi>(_ x: X) -> some Multi<X.C, X.B, X.A> {
+  return MultiTest<X.C, X.B, X.A>()
+}
+
+func testMulti6<X: Multi>(_ x: X) -> some Multi<X.C, X.B, X.A> where X.A: ~Copyable, X.B: ~Copyable {
+  return MultiTest<X.C, X.B, X.A>() // expected-error {{type 'X.A' does not conform to protocol 'Copyable'}}
+}

--- a/test/Generics/inverse_scoping_assoc_types_old.swift
+++ b/test/Generics/inverse_scoping_assoc_types_old.swift
@@ -26,3 +26,43 @@ extension Q {
 func genericFunc<T: Q>(_ t: T,
                        _ a: T.Primary, // expected-error {{parameter of noncopyable type 'T.Primary}} // expected-note 3{{}}
                        _ b: T.Secondary) {} // expected-error {{parameter of noncopyable type 'T.Secondary}} // expected-note 3{{}}
+
+
+protocol Foo<Inner>: ~Copyable {
+  associatedtype Inner: ~Copyable  // expected-warning {{experimental feature 'SuppressedAssociatedTypes' is deprecated}}
+  func getInner() -> Inner
+}
+
+struct NC: ~Copyable {}
+
+struct WitnessFoo<Inner: ~Copyable>: Foo {
+  func getInner() -> Inner { fatalError("todo") }
+}
+
+extension WitnessFoo where Inner: ~Copyable {
+  func asFoo() -> some Foo<Inner> {
+    return self
+  }
+}
+
+func createNCInner<Inner: ~Copyable>(_ t: Inner.Type) -> some Foo<Inner> {
+    return WitnessFoo<Inner>()
+}
+
+func createCopyableInner<Inner>(_ t: Inner.Type) -> some Foo<Inner> { // expected-note {{'where Inner: Copyable' is implicit here}}
+  return WitnessFoo<Inner>()
+}
+
+func expectC<T>(_ t: T) {} // expected-note {{'where T: Copyable' is implicit here}}
+func permitNC<T: ~Copyable>(_ t: borrowing T) {}
+
+func test() {
+  _ = createCopyableInner(Int.self)
+  _ = createCopyableInner(NC.self) // expected-error {{global function 'createCopyableInner' requires that 'NC' conform to 'Copyable'}}
+
+  expectC(createNCInner(Int.self).getInner())
+  expectC(createNCInner(NC.self).getInner()) // expected-error {{global function 'expectC' requires that 'NC' conform to 'Copyable'}}
+
+  permitNC(createNCInner(Int.self).getInner())
+  permitNC(createNCInner(NC.self).getInner())
+}

--- a/test/Generics/inverse_signatures_assoc_types.swift
+++ b/test/Generics/inverse_signatures_assoc_types.swift
@@ -79,6 +79,27 @@ extension Pri_IIII {}
 func test2<X, Y, Z>(_ x: X, y: Y, z: Z) where
   X: Pri_CI, Y: Pri_II, Z: Pri_IIII {}
 
+// For testing opaque return types
+struct OpRet<A: ~Copyable>: Pri_CI, Pri_II {
+  init(_ a: A.Type) {}
+}
+
+// CHECK-LABEL: Opaque result type of {{.*}}.test_opaque1@
+// CHECK-NEXT: Opaque result signature: <X, τ_1_0 where X : Copyable, X == τ_1_0.[Pri_CI]A, τ_1_0 : Pri_CI>
+func test_opaque1<X>(_ x: X.Type) -> some Pri_CI<X> { return OpRet(x) }
+
+// CHECK-LABEL: Opaque result type of {{.*}}.test_opaque2@
+// CHECK-NEXT: Opaque result signature: <X, τ_1_0 where X == τ_1_0.[Pri_CI]A, τ_1_0 : Pri_CI>
+func test_opaque2<X: ~Copyable>(_ x: X.Type) -> some Pri_CI<X> { return OpRet(x) }
+
+// CHECK-LABEL: Opaque result type of {{.*}}.test_opaque3@
+// CHECK-NEXT: Opaque result signature: <X, τ_1_0 where X : Copyable, X == τ_1_0.[Pri_II]A, τ_1_0 : Copyable, τ_1_0 : Pri_II>
+func test_opaque3<X>(_ x: X.Type) -> some Pri_II<X> { return OpRet(x) }
+
+// CHECK-LABEL: Opaque result type of {{.*}}.test_opaque4@
+// CHECK-NEXT: Opaque result signature: <X, τ_1_0 where X == τ_1_0.[Pri_II]A, τ_1_0 : Copyable, τ_1_0 : Pri_II>
+func test_opaque4<X: ~Copyable>(_ x: X.Type) -> some Pri_II<X> { return OpRet(x) }
+
 struct RequireCopy<X: Copyable> {}
 
 // CHECK-LABEL: .ImplyP@

--- a/test/Interpreter/moveonly_generics_opaque.swift
+++ b/test/Interpreter/moveonly_generics_opaque.swift
@@ -23,7 +23,29 @@ func makeWrapper<P>(wrapping _: P.Type) -> some Marked {
     ConcreteWrapper<Hello<P>>()
 }
 
+protocol StringConstructable: ~Copyable {
+  init(_ s: String)
+}
+protocol Keeper<Message> {
+  associatedtype Message: ~Copyable & StringConstructable
+  func getMessage() -> Message
+}
+struct ConcreteKeeper<Message: ~Copyable & StringConstructable>: Keeper {
+  func getMessage() -> Message { return Message("ConcreteKeeper") }
+}
+struct UniqString: ~Copyable, StringConstructable {
+  let str: String
+  init(_ str: String) { self.str = str + " as UniqString!" }
+}
+
+func makeKeeper<M: ~Copyable & StringConstructable>(with _: M.Type) -> some Keeper<M> {
+  return ConcreteKeeper<M>()
+}
+
 do {
   let markedVal = makeWrapper(wrapping: String.self)
   markedVal.announce() // CHECK: ConcreteWrapper<Hello<String>> is Marked
+
+  let keeper = makeKeeper(with: UniqString.self)
+  print(keeper.getMessage().str) // CHECK: ConcreteKeeper as UniqString!
 }

--- a/test/type/opaque_signature.swift
+++ b/test/type/opaque_signature.swift
@@ -1,0 +1,36 @@
+// RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures 2>&1 | %FileCheck %s
+
+protocol P<A> {
+  associatedtype A
+}
+protocol Q<A> {
+  associatedtype A
+}
+
+struct G<T>: Q, P {
+  typealias A = T
+}
+
+struct ConcreteTest {
+  // CHECK: Opaque result type of opaque_signature.(file).ConcreteTest.f1()@
+  // CHECK-NEXT: Opaque result signature: <τ_0_0 where τ_0_0 : Q>
+  func f1() -> some Q { return G<Int>() }
+
+  // CHECK: Opaque result type of opaque_signature.(file).ConcreteTest.f2()@
+  // CHECK-NEXT: Opaque result signature: <τ_0_0 where τ_0_0 : Q, τ_0_0.[Q]A == Int>
+  func f2() -> some Q<Int> { return G<Int>() }
+
+  // CHECK: Opaque result type of opaque_signature.(file).ConcreteTest.f3()@
+  // CHECK-NEXT: Opaque result signature: <τ_0_0 where τ_0_0 : P, τ_0_0 : Q>
+  func f3() -> some P & Q { return G<Int>() }
+}
+
+struct GenericTest<T: P> {
+  // CHECK: Opaque result type of opaque_signature.(file).GenericTest.f1()@
+  // CHECK-NEXT: Opaque result signature: <T, τ_1_0 where T : P, τ_1_0 : Q>
+  func f1() -> some Q { return G<T.A>() }
+
+  // CHECK: Opaque result type of opaque_signature.(file).GenericTest.f2()@
+  // CHECK-NEXT: Opaque result signature: <T, τ_1_0 where T : P, T.[P]A == τ_1_0.[Q]A, τ_1_0 : Q>
+  func f2() -> some Q<T.A> { return G<T.A>() }
+}

--- a/unittests/AST/ASTDumperTests.cpp
+++ b/unittests/AST/ASTDumperTests.cpp
@@ -27,7 +27,7 @@ TEST(ASTDumper, ArchetypeType) {
   auto &ctx = C.Ctx;
 
   auto sig = buildGenericSignature(ctx, nullptr, {ctx.TheSelfType}, {},
-                                   /*allowInverses=*/true);
+                                   DefaultRequirementOptions::expand());
 
   TypeBase *archetype = nullptr;
   {

--- a/unittests/AST/ASTDumperTests.cpp
+++ b/unittests/AST/ASTDumperTests.cpp
@@ -27,7 +27,7 @@ TEST(ASTDumper, ArchetypeType) {
   auto &ctx = C.Ctx;
 
   auto sig = buildGenericSignature(ctx, nullptr, {ctx.TheSelfType}, {},
-                                   DefaultRequirementOptions::expand());
+                                   ExpandDefaults);
 
   TypeBase *archetype = nullptr;
   {


### PR DESCRIPTION
- Explanation: Opaque return types of the form some Proto<T> where Proto has a suppressed primary associated type (e.g., ~Copyable) was accidentially forcing T to always be Copyable, despite there being a T: ~Copyable in the function's signature. This made it impossible to migrate code like this from the legacy SuppressedAssociatedTypes to [SE-503](https://swiftlang.github.io/swift-evolution/#?proposal=SE-503).
- Scope: Beyond the NFC refactoring, this is a limited change to permit inference of inverse requirements appearing in outer generic signatures when building the little nested generic signature of a opaque return type aka -> some Proto<T>.
- Issues: rdar://175500824
- Risk: Low. This suppression wasn't needed before by users of the legacy implementation, as no default would be inferred for the dependent member types within the signature of the opaque return type. Only those trying to use the new suppressed associated types experimental feature would run into this need.
- Testing: Added testing for both legacy and official versions of suppressed associated types.
- Reviewers: @slavapestov 
- Original PR: https://github.com/swiftlang/swift/pull/88743