### PR TITLE
[ci] limit parallel link jobs in buildbot_linux_base to 4

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -940,6 +940,10 @@ llvm-cmake-options=
   -DCROSS_TOOLCHAIN_FLAGS_LLVM_NATIVE='-DCMAKE_C_COMPILER=clang;-DCMAKE_CXX_COMPILER=clang++'
   -DCLANG_DEFAULT_LINKER=gold
 
+# Limit link jobs to prevent OOM on newer linux platforms when building lldb tests
+lldb-extra-cmake-args=
+  -DLLVM_PARALLEL_LINK_JOBS=4
+
 [preset: buildbot_linux]
 mixin-preset=
     mixin_lightweight_assertions,no-stdlib-asserts


### PR DESCRIPTION
* limit `LLVM_PARALLEL_LINK_JOBS` to 4 on CI to prevent OOM

Seems to fail during the link phase of
```
FAILED: [code=1] unittests/Disassembler/DisassemblerTests 
```

Seen on both ubuntu 2604 and Debian 13