### PR TITLE
Fix attached macro role applicability

### DIFF
--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -4759,12 +4759,24 @@ void AttributeChecker::visitCustomAttr(CustomAttr *attr) {
 
     // Try resolving an attached macro attribute.
     if (auto *macro = attr->getResolvedMacro()) {
+      // If any attached role applies, ignore the non-applicable roles.
+      SmallVector<MacroRole, 2> invalidRoles;
       for (auto *roleAttr : macro->getAttrs().getAttributes<MacroRoleAttr>()) {
         auto role = roleAttr->getMacroRole();
-        if (isInvalidAttachedMacro(role, D)) {
-          diagnoseAndRemoveAttr(attr, diag::macro_attached_to_invalid_decl,
-                                getMacroRoleString(role), D);
+        if (!isAttachedMacro(role))
+          continue;
+
+        if (!isInvalidAttachedMacro(role, D)) {
+          invalidRoles.clear();
+          break;
         }
+
+        invalidRoles.push_back(role);
+      }
+
+      for (auto role : invalidRoles) {
+        diagnoseAndRemoveAttr(attr, diag::macro_attached_to_invalid_decl,
+                              getMacroRoleString(role), D);
       }
 
       // Macros can't be attached to ABI-only decls. (If we diagnosed above,

--- a/test/Macros/macro_expand_peers.swift
+++ b/test/Macros/macro_expand_peers.swift
@@ -228,6 +228,36 @@ func testVarPeer() {
 func test(@declareVarValuePeer x: Int) {}
 #endif
 
+#if TEST_DIAGNOSTICS
+protocol MultiRoleMacroMarker {}
+
+@attached(member, names: named(generated))
+@attached(memberAttribute)
+@attached(extension, conformances: MultiRoleMacroMarker)
+@attached(peer)
+macro PeerOnlyUseSite() =
+  #externalMacro(module: "MacroDefinition", type: "EmptyPeerMacro")
+
+@PeerOnlyUseSite
+func multiRoleGlobalFunction() {}
+
+@PeerOnlyUseSite
+let multiRoleGlobalValue = 1
+
+struct MultiRoleContainer {
+  @PeerOnlyUseSite
+  let property = 2
+
+  @PeerOnlyUseSite
+  func method() {}
+}
+
+enum MultiRoleEnum {
+  @PeerOnlyUseSite
+  case value
+}
+#endif
+
 // Stored properties added via peer macros.
 @attached(peer, names: named(_foo))
 macro AddPeerStoredProperty() =


### PR DESCRIPTION
## Summary
- Ignore non-applicable roles for attached macros when another attached role applies to the declaration.
- Add coverage for a multi-role attached macro used on peer-only declaration sites.

Fixes #88877.

## Testing
- `utils/run-test --build-dir /Users/davdroman/Developer/swiftlang/build/verify-issue-88877/swift-macosx-arm64 --build skip --lit-args=-sv test/Macros/macro_expand_peers.swift`
- `xcrun --toolchain org.swift.swift-issue-88877 swift build` in `swift-macro-role-selection-repro`
- `xcrun --toolchain org.swift.swift-issue-88877 swift run Repro` in `swift-macro-role-selection-repro`