### PR TITLE
Correctly apply LIT timeout in test/CMakeLists.txt

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -280,9 +280,8 @@ function(setup_lit_args ARGS_VAR_OUT tested_sdk test_results_dir resource_dir_ov
     list(APPEND swift_lit_args_result "--param" "backtrace_on_crash")
   endif()
 
-  get_target_property(_python3_exe Python3::Interpreter IMPORTED_LOCATION)
   execute_process(COMMAND
-      "${_python3_exe}" "-c" "import psutil"
+      "${Python3_EXECUTABLE}" "-c" "import psutil"
       RESULT_VARIABLE python_psutil_status
       TIMEOUT 1 # second
       ERROR_QUIET)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -280,8 +280,9 @@ function(setup_lit_args ARGS_VAR_OUT tested_sdk test_results_dir resource_dir_ov
     list(APPEND swift_lit_args_result "--param" "backtrace_on_crash")
   endif()
 
+  get_target_property(_python3_exe Python3::Interpreter IMPORTED_LOCATION)
   execute_process(COMMAND
-      $<TARGET_FILE:Python3::Interpreter> "-c" "import psutil"
+      "${_python3_exe}" "-c" "import psutil"
       RESULT_VARIABLE python_psutil_status
       TIMEOUT 1 # second
       ERROR_QUIET)


### PR DESCRIPTION
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->

`test/CMakeLists.txt` currently checks the availability of `psutil` and specifies a LIT timeout if it is available. However, `cmake` cannot correctly expand `$<TARGET_FILE:Python3::Interpreter>` at this point of execution, causing the check to always fail and the timeout never to be applied.

This PR fixes that issue by correctly retrieving the path of the Python interpreter.
