### PR TITLE
[AST] Surface local types from attached-macro expansion

### DIFF
--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -15,6 +15,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "swift/AST/Module.h"
+#include "swift/AST/AnyFunctionRef.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/ASTMangler.h"
 #include "swift/AST/ASTPrinter.h"
@@ -3912,16 +3913,20 @@ std::optional<DefaultIsolation> SourceFile::getDefaultIsolation() const {
 namespace {
 class LocalTypeDeclCollector : public ASTWalker {
   SmallVectorImpl<TypeDecl *> &results;
+  SmallVectorImpl<Decl *> &visitedDecls;
 
 public:
-  LocalTypeDeclCollector(SmallVectorImpl<TypeDecl *> &results)
-      : results(results) {}
+  LocalTypeDeclCollector(SmallVectorImpl<TypeDecl *> &results,
+                         SmallVectorImpl<Decl *> &visitedDecls)
+      : results(results), visitedDecls(visitedDecls) {}
 
   MacroWalking getMacroWalkingBehavior() const override {
     return MacroWalking::Expansion;
   }
 
   PreWalkAction walkToDeclPre(Decl *D) override {
+    visitedDecls.push_back(D);
+    
     switch (D->getKind()) {
     case DeclKind::Enum:
     case DeclKind::Struct:
@@ -3937,13 +3942,79 @@ public:
     return Action::Continue();
   }
 };
+
+/// Append the local type decls reachable through attached-macro 
+/// expansion buffers anchored at \p anchor to \p results, recursing 
+/// into each expansion SourceFile via LocalTypeDeclsRequest. 
+/// \p visitedSFs deduplicates expansion buffers across the recursion.
+static void collectLocalTypeDeclsFromAttachedMacroExpansions(
+    Decl *anchor, SmallPtrSetImpl<SourceFile *> &visitedSFs,
+    SmallVectorImpl<TypeDecl *> &results) {
+  ASTContext &ctx = anchor->getASTContext();
+  ModuleDecl *module = anchor->getModuleContext();
+  SourceManager &sourceMgr = ctx.SourceMgr;
+
+  auto appendFromBuffer = [&](unsigned bufferID) {
+    auto startLoc = sourceMgr.getLocForBufferStart(bufferID);
+    auto *expansionSF = module->getSourceFileContainingLocation(startLoc);
+    if (!expansionSF || !visitedSFs.insert(expansionSF).second)
+      return;
+    auto locals = expansionSF->getLocalTypeDecls();
+    results.append(locals.begin(), locals.end());
+  };
+
+  // Peer macros: Produce sibling decls whose bodies may contain local types.
+  for (unsigned bufferID : evaluateOrDefault(
+           ctx.evaluator, ExpandPeerMacroRequest{anchor}, {})) {
+    appendFromBuffer(bufferID);
+  }
+
+  // Member macros: Produce members of a nominal/extension whose bodies 
+  // may contain local types.
+  for (unsigned bufferID : evaluateOrDefault(
+           ctx.evaluator, ExpandSynthesizedMemberMacroRequest{anchor}, {})) {
+    appendFromBuffer(bufferID);
+  }
+
+  // Preamble and body macros are anchored at functions and replace or 
+  // prepend body content, which may declare local types.
+  if (auto *afd = dyn_cast<AbstractFunctionDecl>(anchor)) {
+    for (unsigned bufferID : evaluateOrDefault(
+             ctx.evaluator, ExpandPreambleMacroRequest{afd}, {})) {
+      appendFromBuffer(bufferID);
+    }
+    if (auto bufferID = evaluateOrDefault(
+            ctx.evaluator, ExpandBodyMacroRequest{AnyFunctionRef(afd)},
+            std::optional<unsigned>{})) {
+      appendFromBuffer(*bufferID);
+    }
+  }
+}
 } // namespace
 
 ArrayRef<TypeDecl *> LocalTypeDeclsRequest::evaluate(Evaluator &evaluator,
                                                      SourceFile *sf) const {
   SmallVector<TypeDecl *> results;
-  LocalTypeDeclCollector collector(results);
+  SmallVector<Decl *> visitedDecls;
+  LocalTypeDeclCollector collector(results, visitedDecls);
   sf->walk(collector);
+
+  // The walker descends into freestanding macro expansions (using
+  // MacroWalking::Expansion) but cannot reach attached-macro expansion
+  // buffers, since those live in separate SourceFiles not connected to 
+  // the walker's tree. Surface local types from those buffers explicitly 
+  // so consumers (SILGen, IRGen, debug-info type reconstruction) see a
+  // complete view.
+  //
+  // Note: visitAuxiliaryDecls only covers peer/freestanding expansions, 
+  // so we cannot reuse it here. Member, preamble, and body roles 
+  // require their own request invocations.
+  SmallPtrSet<SourceFile *, 4> visitedSFs;
+  visitedSFs.insert(sf);
+  for (auto *D : visitedDecls) {
+    collectLocalTypeDeclsFromAttachedMacroExpansions(D, visitedSFs, results);
+  }
+  
   return sf->getASTContext().AllocateCopy(results);
 }
 

--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -1224,6 +1224,39 @@ public struct AddCompletionHandler: PeerMacro {
   }
 }
 
+public struct RemoveAsyncMacro: PeerMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingPeersOf declaration: some DeclSyntaxProtocol,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    guard var function = declaration.as(FunctionDeclSyntax.self) else {
+      throw CustomError.message("@RemoveAsync only works on functions")
+    }
+
+    if function.signature.effectSpecifiers?.asyncSpecifier == nil {
+      throw CustomError.message("@RemoveAsync requires an async function")
+    }
+
+    // Drop the peer macro attribute from the new declaration.
+    function.attributes = function.attributes.filter { element in
+      guard case let .attribute(attr) = element else {
+        return true
+      }
+      if let attrType = attr.attributeName.as(IdentifierTypeSyntax.self),
+         let nodeType = node.attributeName.as(IdentifierTypeSyntax.self) {
+        return attrType.name.text != nodeType.name.text
+      }
+      return true
+    }
+
+    // Remove the 'async' specifier.
+    function.signature.effectSpecifiers?.asyncSpecifier = nil
+
+    return [DeclSyntax(function)]
+  }
+}
+
 public struct ExpandTypeErrorMacro: PeerMacro {
   public static func expansion<
     Context: MacroExpansionContext,

--- a/test/Macros/macro_expand_peer_local_types.swift
+++ b/test/Macros/macro_expand_peer_local_types.swift
@@ -1,0 +1,72 @@
+// REQUIRES: swift_swift_parser, executable_test
+
+// RUN: %empty-directory(%t)
+// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -parse-as-library -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath
+
+// Verify that local types declared inside the body of a function 
+// expanded from an attached peer macro are surfaced through 
+// SourceFile::getLocalTypeDecls(), allowing SILGen, IRGen, and 
+// debug-info type reconstruction to see them.
+//
+// Without this, the synchronous peer's nested 'Local' type would be 
+// missing SIL functions (causing a link error), missing type metadata 
+// (causing runtime failures for any operation requiring metadata), and 
+// could trigger an IRGenDebugInfo crash when compiling with -g.
+//
+// https://github.com/swiftlang/swift/issues/88174
+
+// Symptom 1: link and run.
+// RUN: %target-build-swift -swift-version 5 -Xfrontend -disable-availability-checking -load-plugin-library %t/%target-library-name(MacroDefinition) -parse-as-library %s -o %t/main -module-name MacroUser
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main | %FileCheck %s --check-prefix=CHECK-EXEC
+
+// Symptom 2: IRGen emits full type metadata (Mn / Ma / Mf) for the
+// synchronous peer's local type, not just SIL functions for it.
+// RUN: %target-swift-frontend -swift-version 5 -emit-ir -load-plugin-library %t/%target-library-name(MacroDefinition) -parse-as-library -module-name MacroUser -disable-availability-checking %s | %FileCheck %s --check-prefix=CHECK-IR
+
+// Symptom 3: -g compiles cleanly. The successful RUN line is the assertion;
+// before the fix, IRGenDebugInfo would fail to round-trip the synchronous
+// peer's local type and crash.
+// RUN: %target-swift-frontend -swift-version 5 -c -g -load-plugin-library %t/%target-library-name(MacroDefinition) -parse-as-library -module-name MacroUser -disable-availability-checking -o %t/dbg.o %s
+
+@attached(peer, names: overloaded)
+macro RemoveAsync() = #externalMacro(module: "MacroDefinition", type: "RemoveAsyncMacro")
+
+// Top-level case: Peer macro on a free function.
+@RemoveAsync
+func example() async -> Int {
+  struct Local {
+    let x: Int
+  }
+  return Local(x: 1).x
+}
+
+// Peer-on-nested-method case: Peer macro on a method of a nominal type.
+// Verifies the AST walker reaches members of nominal types and the 
+// request fires on them.
+struct Container {
+  @RemoveAsync
+  func nested() async -> Int {
+    struct NestedLocal {
+      let y: Int
+    }
+    return NestedLocal(y: 2).y
+  }
+}
+
+// CHECK-IR-DAG: $s9MacroUser7exampleSiyF5LocalL_VMn
+// CHECK-IR-DAG: $s9MacroUser7exampleSiyF5LocalL_VMa
+// CHECK-IR-DAG: $s9MacroUser7exampleSiyF5LocalL_VMf
+// CHECK-IR-DAG: $s9MacroUser9ContainerV6nestedSiyF11NestedLocalL_VMn
+// CHECK-IR-DAG: $s9MacroUser9ContainerV6nestedSiyF11NestedLocalL_VMa
+// CHECK-IR-DAG: $s9MacroUser9ContainerV6nestedSiyF11NestedLocalL_VMf
+
+@main
+struct Driver {
+  static func main() {
+    print(example())
+    print(Container().nested())
+    // CHECK-EXEC: 1
+    // CHECK-EXEC: 2
+  }
+}


### PR DESCRIPTION
Closes #88174.

Local types declared inside a function body that has been generated by an attached peer macro are silently invisible to consumers of `SourceFile::getLocalTypeDecls()`. This produces linker errors at the use site, missing IR metadata, and `-g` crashes.

`LocalTypeDeclsRequest::evaluate()` walks a `SourceFile` with `LocalTypeDeclCollector`, which opts into `MacroWalking::Expansion`. The AST walker honors that opt-in for freestanding macros, but not for attached macros, which are separate `SourceFile`s that the walker cannot reach.

This PR adjusts `LocalTypeDeclCollector` to record every declaration visited during the walk, and changes `LocalTypeDeclsRequest::evaluate()` to locate the expansion `SourceFile`s for each visited declaration's peer/member/preamble/body macros and recursively call `getLocalTypeDecls()` on each. Member-attribute/accessor/extension/conformance macros do not need to be enumerated since they do not declare local types.