### PR TITLE
AST: introduce the AbstractTypeLayout struct and computeAbstractLayout() function

### DIFF
--- a/include/swift/AST/AbstractLayout.h
+++ b/include/swift/AST/AbstractLayout.h
@@ -1,0 +1,41 @@
+//===--- AbstractLayout.h - Abstract type layout information ----*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines data structures for abstract type layout information,
+// used to encode the layout of hidden C types in .swiftmodule files.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_AST_ABSTRACTLAYOUT_H
+#define SWIFT_AST_ABSTRACTLAYOUT_H
+
+#include <cstdint>
+#include <optional>
+
+namespace swift {
+
+class NominalTypeDecl;
+
+struct AbstractTypeLayout {
+  uint64_t size;
+  uint64_t alignment;
+  uint64_t stride;
+  bool bitwiseCopyable;
+  bool isOpaque;
+};
+
+std::optional<AbstractTypeLayout>
+computeAbstractLayout(const NominalTypeDecl *decl);
+
+} // namespace swift
+
+#endif // SWIFT_AST_ABSTRACTLAYOUT_H

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -49,6 +49,8 @@ struct CompilerDebuggingOptions {
   /// Indicates whether or not the Clang importer should dump lookup tables
   /// upon termination.
   bool DumpClangLookupTables = false;
+
+  bool DumpAbstractLayout = false;
 };
 
 /// Options for controlling the behavior of the frontend.

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -722,6 +722,9 @@ def dump_clang_lookup_tables : Flag<["-"], "dump-clang-lookup-tables">,
   HelpText<"Dump the importer's Swift-name-to-Clang-name lookup tables to "
            "stderr">;
 
+def dump_abstract_layout : Flag<["-"], "dump-abstract-layout">,
+  HelpText<"Dump abstract layout information for Clang-backed types">;
+
 def dump_availability_scopes : Flag<["-"], "dump-availability-scopes">,
                                HelpText<"Dump availability scopes to stderr">;
 

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -19,6 +19,7 @@
 #include "ClangDerivedConformances.h"
 #include "ImporterImpl.h"
 #include "SwiftDeclSynthesizer.h"
+#include "swift/AST/AbstractLayout.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/Attr.h"
 #include "swift/AST/AvailabilityInference.h"
@@ -91,6 +92,7 @@
 #include "llvm/ADT/TinyPtrVector.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/MathExtras.h"
 #include "llvm/Support/Path.h"
 
 #include <algorithm>
@@ -11199,6 +11201,43 @@ struct ClangDeclTraceFormatter : public UnifiedStatsReporter::TraceFormatter {
 };
 
 static ClangDeclTraceFormatter TF;
+
+// MARK: - Abstract Layout Computation
+
+std::optional<AbstractTypeLayout>
+swift::computeAbstractLayout(const NominalTypeDecl *decl) {
+  auto *clangDecl =
+      dyn_cast_or_null<clang::RecordDecl>(decl->getClangDecl());
+  if (!clangDecl)
+    return std::nullopt;
+
+  clangDecl = clangDecl->getDefinition();
+  if (!clangDecl)
+    return std::nullopt;
+
+  auto &ctx = decl->getASTContext();
+  auto *clangLoader = ctx.getClangModuleLoader();
+  if (!clangLoader)
+    return std::nullopt;
+
+  auto &clangCtx = clangLoader->getClangASTContext();
+  const auto &recordLayout = clangCtx.getASTRecordLayout(clangDecl);
+
+  AbstractTypeLayout result;
+  result.size = recordLayout.getSize().getQuantity();
+  result.alignment = recordLayout.getAlignment().getQuantity();
+  result.stride = llvm::alignTo(result.size, result.alignment);
+
+  Type swiftType = decl->getDeclaredInterfaceType();
+  result.bitwiseCopyable = swiftType->isBitwiseCopyable();
+
+  if (auto *structDecl = dyn_cast<StructDecl>(decl))
+    result.isOpaque = structDecl->isCxxNonTrivial();
+  else
+    result.isOpaque = false;
+
+  return result;
+}
 
 template<>
 const UnifiedStatsReporter::TraceFormatter*

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -204,6 +204,9 @@ bool ArgsToFrontendOptionsConverter::convert(
   Opts.CompilerDebuggingOpts.DumpClangLookupTables |=
       Args.hasArg(OPT_dump_clang_lookup_tables);
 
+  Opts.CompilerDebuggingOpts.DumpAbstractLayout |=
+      Args.hasArg(OPT_dump_abstract_layout);
+
   Opts.CheckOnoneSupportCompleteness = Args.hasArg(OPT_check_onone_completeness);
 
   Opts.ParseStdlib |= Args.hasArg(OPT_parse_stdlib);

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -16,6 +16,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "swift/Frontend/Frontend.h"
+#include "swift/AST/AbstractLayout.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/AvailabilityDomain.h"
 #include "swift/AST/AvailabilityScope.h"
@@ -1927,6 +1928,30 @@ void CompilerInstance::emitEndOfPipelineDebuggingOutput() {
 
   if (opts.DumpClangLookupTables && ctx.getClangModuleLoader())
     ctx.getClangModuleLoader()->dumpSwiftLookupTables();
+
+  if (opts.DumpAbstractLayout) {
+    auto &sf = getPrimaryOrMainSourceFile();
+    for (auto *decl : sf.getTopLevelDecls()) {
+      auto *nominal = dyn_cast<NominalTypeDecl>(decl);
+      if (!nominal)
+        continue;
+      for (auto *field : nominal->getStoredProperties()) {
+        auto fieldType = field->getInterfaceType();
+        if (auto *fieldNominal = fieldType->getAnyNominal()) {
+          if (auto layout = computeAbstractLayout(fieldNominal)) {
+            llvm::outs() << fieldNominal->getName() << ":\n";
+            llvm::outs() << "  size: " << layout->size << "\n";
+            llvm::outs() << "  alignment: " << layout->alignment << "\n";
+            llvm::outs() << "  stride: " << layout->stride << "\n";
+            llvm::outs() << "  bitwiseCopyable: "
+                         << (layout->bitwiseCopyable ? "true" : "false") << "\n";
+            llvm::outs() << "  isOpaque: "
+                         << (layout->isOpaque ? "true" : "false") << "\n";
+          }
+        }
+      }
+    }
+  }
 }
 
 bool CompilerInstance::isCancellationRequested() const {

--- a/test/ClangImporter/InternalBridgingHeader/abstract-layout-simple.swift
+++ b/test/ClangImporter/InternalBridgingHeader/abstract-layout-simple.swift
@@ -13,6 +13,20 @@
 // RUN:   -o %t/Library.swiftmodule \
 // RUN:   %t/Library.swift
 
+// RUN: %target-swift-frontend \
+// RUN:   -internal-import-bridging-header %t/Utility.h \
+// RUN:   -enable-experimental-feature AbstractStoredPropertyLayout \
+// RUN:   -typecheck -module-name Library \
+// RUN:   -dump-abstract-layout \
+// RUN:   %t/Library.swift | %FileCheck %s
+
+// CHECK: Wrapper:
+// CHECK:   size: 4
+// CHECK:   alignment: 4
+// CHECK:   stride: 4
+// CHECK:   bitwiseCopyable: true
+// CHECK:   isOpaque: false
+
 //--- Utility.h
 
 typedef struct { int value; } Wrapper;


### PR DESCRIPTION
This function queries Clang's ASTRecordLayout to extract size, alignment, stride, bitwiseCopyable, and isOpaque for C-backed nominal types.

This also adds a -dump-abstract-layout frontend debugging flag that prints layout info for Clang-backed stored property types in the primary source file.
