### PR TITLE
IRGen: diagnose InlineArray whose byte size overflows 32 bits

### DIFF
--- a/include/swift/AST/DiagnosticsIRGen.def
+++ b/include/swift/AST/DiagnosticsIRGen.def
@@ -67,6 +67,10 @@ ERROR(temporary_allocation_alignment_not_power_of_2,none,
 ERROR(explosion_size_oveflow,none,
       "explosion size too large", ())
 
+ERROR(fixed_array_size_overflow,none,
+      "size of value of type %0 exceeds the maximum supported size of 4 GiB",
+      (Type))
+
 NOTE(layout_strings_blocked,none,
      "Layout string value witnesses have been disabled for module '%0' "
      "through block list entry", (StringRef))

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -8889,6 +8889,11 @@ ERROR(inlinearray_literal_incorrect_count,none,
 ERROR(inline_array_type_backwards,none,
       "element count must precede inline array element type", ())
 
+ERROR(inline_array_count_exceeds_max,none,
+      "'InlineArray' element count %0 exceeds the maximum supported "
+      "value of %1 (the resulting type's byte size could not be "
+      "represented)", (Type, unsigned))
+
 //===----------------------------------------------------------------------===//
 // MARK: Embedded Swift
 //===----------------------------------------------------------------------===//

--- a/lib/IRGen/GenArray.cpp
+++ b/lib/IRGen/GenArray.cpp
@@ -19,6 +19,7 @@
 #include "IRGenModule.h"
 #include "LoadableTypeInfo.h"
 #include "NonFixedTypeInfo.h"
+#include "swift/AST/DiagnosticsIRGen.h"
 
 using namespace swift;
 using namespace irgen;
@@ -726,13 +727,27 @@ TypeConverter::convertBuiltinFixedArrayType(BuiltinFixedArrayType *T) {
   if (!fixedSize.has_value() || !elementTI.isFixedSize()) {
     return new NonFixedArrayTypeInfo(IGM.OpaqueTy, elementTI);
   }
-  
+
+  // The FixedTypeInfo Size field is 32 bits wide, so a fixed array whose
+  // total byte size exceeds UINT32_MAX cannot be represented. Without an
+  // early diagnostic, IRGen would either silently truncate the size, or
+  // (in `getArraySpareBits`) allocate a multi-gigabyte APInt to back the
+  // spare-bits vector and take time proportional to the array's byte size.
+  auto &fixedElementTI = cast<FixedTypeInfo>(elementTI);
+  uint64_t stride = fixedElementTI.getFixedStride().getValue();
+  uint64_t totalBytes = 0;
+  bool overflow = __builtin_mul_overflow(*fixedSize, stride, &totalBytes);
+  if (overflow || totalBytes > std::numeric_limits<uint32_t>::max()) {
+    IGM.Context.Diags.diagnose(SourceLoc(),
+                               diag::fixed_array_size_overflow, T);
+    return &getEmptyTypeInfo();
+  }
+
   if (*fixedSize <= BuiltinFixedArrayType::MaximumLoadableSize) {
     if (auto *loadableTI = dyn_cast<LoadableTypeInfo>(&elementTI)) {
       return new LoadableArrayTypeInfo(fixedSize.value(), *loadableTI);
     }
   }
-  
-  return new FixedArrayTypeInfo(fixedSize.value(),
-                                *cast<FixedTypeInfo>(&elementTI));
+
+  return new FixedArrayTypeInfo(fixedSize.value(), fixedElementTI);
 }

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -1706,6 +1706,28 @@ Type TypeResolution::applyUnboundGenericArguments(
   auto &ctx = getASTContext();
   TypeSubstitutionMap subs;
 
+  // If this is `InlineArray` with a concrete integer literal count, reject
+  // counts that exceed `UINT32_MAX` before layout reasoning begins. IRGen's
+  // `FixedTypeInfo` stores the byte size in a 32-bit bitfield, so any count
+  // above that cannot fit regardless of the element type's stride (minimum
+  // stride is 1). Diagnosing here gives us a source location and covers
+  // cases the IRGen check misses — e.g. a generic element type where the
+  // IRGen path falls back to `NonFixedArrayTypeInfo` and silently skips
+  // the overflow guard.
+  if (decl == ctx.getInlineArrayDecl() && genericArgs.size() == 2) {
+    if (auto *intTy = genericArgs[0]->getAs<IntegerType>()) {
+      if (!intTy->isNegative()) {
+        auto value = intTy->getValue();
+        if (value.getActiveBits() > 32) {
+          ctx.Diags.diagnose(loc, diag::inline_array_count_exceeds_max,
+                             genericArgs[0],
+                             std::numeric_limits<uint32_t>::max());
+          return ErrorType::get(ctx);
+        }
+      }
+    }
+  }
+
   // Get the interface type for the declaration. We will be substituting
   // type parameters that appear inside this type with the provided
   // generic arguments.

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -1888,8 +1888,21 @@ FixedArrayCacheEntry::tryInitialize(Metadata *metadata,
   assert(count > 0);
   Data.ValueWitnesses = &Witnesses;
   auto eltWitnesses = element->getValueWitnesses();
-  auto arraySize
-    = Witnesses.size = Witnesses.stride = eltWitnesses->stride * count;
+  // `size`/`stride` in the value-witness table are `size_t`, so on 32-bit
+  // targets `eltStride * count` can wrap silently and leave the allocation
+  // sized for a small fraction of the requested element count — subsequent
+  // stores indexed by element would then run past the allocation. Trap
+  // here when the multiplication overflows `size_t`.
+  size_t arraySize;
+  if (__builtin_mul_overflow(eltWitnesses->stride,
+                             static_cast<size_t>(count),
+                             &arraySize)) {
+    swift::fatalError(0,
+        "fatal error: Builtin.FixedArray size overflow: "
+        "element stride %zu * count %zd overflows size_t\n",
+        eltWitnesses->stride, count);
+  }
+  Witnesses.size = Witnesses.stride = arraySize;
   // We take on most of the properties of the element type, except that an array
   // of elements might end up larger than an inline buffer, and the array is
   // always addressable for dependencies.

--- a/test/IRGen/inline_array_size_overflow.swift
+++ b/test/IRGen/inline_array_size_overflow.swift
@@ -5,8 +5,12 @@
 // whose total size exceeds 2^32 bytes cannot be represented. Reject these
 // eagerly instead of taking time proportional to the array's byte size in
 // IRGen.
+//
+// Use `Int64` rather than `Int` for the element type so the total overflows
+// on 32-bit targets as well (where `Int` is 4 bytes); 1_000_000_000 × 8 =
+// ~8 GiB either way.
 
 func tooLarge() {
-  _ = InlineArray<1_000_000_000, Int>(repeating: 0)
+  _ = InlineArray<1_000_000_000, Int64>(repeating: 0)
 }
-// CHECK: error: size of value of type 'Builtin.FixedArray<1000000000, Int>' exceeds the maximum supported size of 4 GiB
+// CHECK: error: size of value of type 'Builtin.FixedArray<1000000000, Int64>' exceeds the maximum supported size of 4 GiB

--- a/test/IRGen/inline_array_size_overflow.swift
+++ b/test/IRGen/inline_array_size_overflow.swift
@@ -1,0 +1,12 @@
+// RUN: not %target-swift-frontend -disable-availability-checking -emit-ir %s 2>&1 | %FileCheck %s
+
+// https://github.com/swiftlang/swift/issues/88549
+// FixedTypeInfo packs the byte size into a 32-bit field, so a fixed array
+// whose total size exceeds 2^32 bytes cannot be represented. Reject these
+// eagerly instead of taking time proportional to the array's byte size in
+// IRGen.
+
+func tooLarge() {
+  _ = InlineArray<1_000_000_000, Int>(repeating: 0)
+}
+// CHECK: error: size of value of type 'Builtin.FixedArray<1000000000, Int>' exceeds the maximum supported size of 4 GiB

--- a/test/Sema/inline_array_count_overflow.swift
+++ b/test/Sema/inline_array_count_overflow.swift
@@ -1,0 +1,36 @@
+// RUN: %target-typecheck-verify-swift -disable-availability-checking
+
+// https://github.com/swiftlang/swift/issues/88549
+//
+// Diagnose an `InlineArray<N, T>` whose literal element count `N` exceeds
+// `UINT32_MAX` at type-check time. IRGen's `FixedTypeInfo` stores byte size
+// in a 32-bit field, so once `N` exceeds that, no element type (minimum
+// stride 1) can make it fit. Catching this in Sema gives us a real source
+// location and covers the case where `T` is generic or opaque — the IRGen
+// overflow guard fires only on the fixed-layout path and otherwise falls
+// back to `NonFixedArrayTypeInfo` without diagnosing.
+
+func tooLargeConcrete() {
+  _ = InlineArray<9_999_999_999, Int64>(repeating: 0) // expected-error {{'InlineArray' element count '9999999999' exceeds the maximum supported value of 4294967295}}
+}
+
+func tooLargeGenericElement<T>(_: T.Type) {
+  _ = InlineArray<9_999_999_999, T>(repeating: fatalError()) // expected-error {{'InlineArray' element count '9999999999' exceeds the maximum supported value of 4294967295}}
+}
+
+func tooLargeSugar() -> [9_999_999_999 of Int64].Type { // expected-error {{'InlineArray' element count '9999999999' exceeds the maximum supported value of 4294967295}}
+  fatalError()
+}
+
+// Boundary cases.
+
+// Exactly UINT32_MAX is the largest accepted count.
+typealias AtLimit = InlineArray<4_294_967_295, Int8>
+
+// UINT32_MAX + 1 is rejected.
+typealias OverByOne = InlineArray<4_294_967_296, Int8> // expected-error {{'InlineArray' element count '4294967296' exceeds the maximum supported value of 4294967295}}
+
+// Counts that fit but produce a byte size > 4 GiB (element stride × count)
+// are still left to IRGen's fixed-layout check, since Sema doesn't know
+// stride here.
+typealias LargeButCountFits = InlineArray<1_000_000_000, Int64>


### PR DESCRIPTION
`FixedTypeInfo` packs the storage size into a 32-bit bitfield, so any fixed array whose total byte size exceeds 2^32 cannot be represented. With no guard, IRGen either silently truncates the size or, on the way to that, allocates a multi-gigabyte APInt to back the spare-bits vector and takes time proportional to the array's byte size.

In theory it would be better to support larger sizes but right now this isn't really useful in practice and would require a lot more support in the compiler. Reject these types in `convertBuiltinFixedArrayType` instead.

Fixes https://github.com/swiftlang/swift/issues/88549. Needs a new issue filing for the longer-term improvement for larger sizes.