### PR TITLE
🍒 [6.4] [cxx-interop] Bring back ClangImporter request caching

### DIFF
--- a/include/swift/ClangImporter/ClangImporterRequests.h
+++ b/include/swift/ClangImporter/ClangImporterRequests.h
@@ -626,9 +626,12 @@ class CustomRefCountingOperation
     : public SimpleRequest<CustomRefCountingOperation,
                            CustomRefCountingOperationResult(
                                CustomRefCountingOperationDescriptor),
-                           RequestFlags::Uncached> {
+                           RequestFlags::Cached> {
 public:
   using SimpleRequest::SimpleRequest;
+
+  // Caching
+  bool isCached() const { return true; }
 
   // Source location
   SourceLoc getNearestLoc() const { return SourceLoc(); };
@@ -759,12 +762,13 @@ SourceLoc extractNearestSourceLoc(ClangDeclExplicitSafetyDescriptor desc);
 class ClangDeclExplicitSafety
     : public SimpleRequest<ClangDeclExplicitSafety,
                            ExplicitSafety(ClangDeclExplicitSafetyDescriptor),
-                           RequestFlags::Uncached> {
+                           RequestFlags::Cached> {
 public:
   using SimpleRequest::SimpleRequest;
 
   // Source location
   SourceLoc getNearestLoc() const { return SourceLoc(); };
+  bool isCached() const;
 
 private:
   friend SimpleRequest;
@@ -805,12 +809,13 @@ class ClangRefCountedSmartPointer
     : public SimpleRequest<ClangRefCountedSmartPointer,
                            importer::RefCountedPtrRequestResult(
                                ClangRefCountedSmartPointerDescriptor),
-                           RequestFlags::Uncached> {
+                           RequestFlags::Cached> {
 public:
   using SimpleRequest::SimpleRequest;
 
   // Source location
   SourceLoc getNearestLoc() const { return SourceLoc(); };
+  bool isCached() const { return true; }
 
 private:
   friend SimpleRequest;
@@ -857,9 +862,10 @@ class CxxIteratorInfoRequest
     : public SimpleRequest<CxxIteratorInfoRequest,
                            std::optional<importer::CxxIteratorCategory>(
                                CxxRecordDeclDescriptor),
-                           RequestFlags::Uncached> {
+                           RequestFlags::Cached> {
 public:
   using SimpleRequest::SimpleRequest;
+  bool isCached() const { return true; }
 
 private:
   friend SimpleRequest;

--- a/include/swift/ClangImporter/ClangImporterTypeIDZone.def
+++ b/include/swift/ClangImporter/ClangImporterTypeIDZone.def
@@ -34,16 +34,16 @@ SWIFT_REQUEST(ClangImporter, ForeignReferenceTypeInfoRequest,
               ForeignReferenceTypeInfo(ForeignReferenceTypeInfoDescriptor), Uncached,
               NoLocationInfo)
 SWIFT_REQUEST(ClangImporter, CxxRecordSemantics,
-              CxxRecordSemanticsKind(CxxRecordSemanticsDescriptor), Uncached,
+              CxxRecordSemanticsKind(CxxRecordSemanticsDescriptor), Cached,
               NoLocationInfo)
 SWIFT_REQUEST(ClangImporter, CxxRecordAsSwiftType,
-              ValueDecl *(CxxRecordSemanticsDescriptor), Uncached,
+              ValueDecl *(CxxRecordSemanticsDescriptor), Cached,
               NoLocationInfo)
 SWIFT_REQUEST(ClangImporter, IsSafeUseOfCxxDecl,
-              bool(SafeUseOfCxxRecordDescriptor), Uncached,
+              bool(SafeUseOfCxxRecordDescriptor), Cached,
               NoLocationInfo)
 SWIFT_REQUEST(ClangImporter, CustomRefCountingOperation,
-              CustomRefCountingOperationResult(CustomRefCountingOperationDescriptor), Uncached,
+              CustomRefCountingOperationResult(CustomRefCountingOperationDescriptor), Cached,
               NoLocationInfo)
 SWIFT_REQUEST(ClangImporter, ClangTypeEscapability,
               CxxEscapability(EscapabilityLookupDescriptor), Cached,
@@ -52,11 +52,11 @@ SWIFT_REQUEST(ClangImporter, CxxValueSemantics,
               CxxValueSemanticsKind(CxxValueSemanticsDescriptor), Cached,
               NoLocationInfo)
 SWIFT_REQUEST(ClangImporter, ClangDeclExplicitSafety,
-              ExplicitSafety(ClangDeclExplicitSafetyDescriptor), Uncached,
+              ExplicitSafety(ClangDeclExplicitSafetyDescriptor), Cached,
               NoLocationInfo)
 SWIFT_REQUEST(ClangImporter, ClangRefCountedSmartPointer,
               RefCountedPtrRequestResult(ClangRefCountedSmartPointerDescriptor),
-              Uncached, NoLocationInfo)
+              Cached, NoLocationInfo)
 SWIFT_REQUEST(ClangImporter, CxxIteratorInfoRequest,
               std::optional<CxxIteratorCategory>(CxxRecordDeclDescriptor),
-              Uncached, NoLocationInfo)
+              Cached, NoLocationInfo)

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -8880,6 +8880,10 @@ ExplicitSafety ClangDeclExplicitSafety::evaluate(
   return ExplicitSafety::Safe;
 }
 
+bool ClangDeclExplicitSafety::isCached() const {
+  return isa<clang::RecordDecl>(std::get<0>(getStorage()).decl);
+}
+
 void swift::simple_display(llvm::raw_ostream &out,
                            ClangRefCountedSmartPointerDescriptor desc) {
   out << "Validating SWIFT_REFCOUNTED_PTR for '";


### PR DESCRIPTION
- **Explanation**: I previously disabled all caching in https://github.com/swiftlang/swift/pull/88727, when I discovered it is possible for Clang nodes to be deallocated and their memory addresses reused. It turns out disabling all caches was unnecessary; only ForeignReferenceTypeInfoRequest needs to have caching disabled, since that is the only request used on Clang nodes allocated from temporary Clang sub-instances while populating the SwiftLookupTable. This patch re-enables caching for all requests other than `ForeignReferenceTypeInfoRequest`.
- **Scope**: ClangImporter. These requests are either pure or idempotent, so caching should not change their behavior.
- **Issues**: rdar://175540597
- **Original PRs**: https://github.com/swiftlang/swift/pull/88903
- **Risk**: Low. There was no evidence that requests other than ForeignReferenceTypeInfoRequest had dangling cache keys.
- **Testing**: Existing test suite already exercises all requests; they should continue to pass.
- **Reviewers**: TBD.

----

SwiftLookupTableWriter runs during module loading in a Clang sub-instance that is later deallocated, invalidating all Clang AST nodes from that context. It calls NameImporter to determine Swift names for Clang declarations, and NameImporter evaluates two requests: IsSafeUseOfCxxDecl and ForeignReferenceTypeInfoRequest. Both use Clang node addresses as cache keys that become dangling after the sub-instance is torn down.

IsSafeUseOfCxxDecl already has caching disabled. This patch disables caching for ForeignReferenceTypeInfoRequest as well, and re-enables caching for all other ClangImporter requests.

This reverts most of 0699fd2cfe736eb5ead380767eb4c45ac93a1128, preserving only the change that disables caching for ForeignReferenceTypeInfoRequest.

rdar://175540597
(cherry picked from commit e91f6e2b7edeb3e2b088b01922f8c46da8a9b1f8)
