### PR TITLE
[Swiftify][Embedded] always return primary IGM for swiftify macros

### DIFF
--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -2277,7 +2277,12 @@ IRGenModule *IRGenerator::getGenModule(SourceFile *SF) {
     return getPrimaryIGM();
 
  IRGenModule *IGM = GenModules[SF];
- assert(IGM);
+
+ if (!IGM) {
+   ASSERT(SF->getParentModule()->findUnderlyingClangModule());
+   return getPrimaryIGM();
+ }
+
  return IGM;
 }
 
@@ -2290,9 +2295,7 @@ IRGenModule *IRGenerator::getGenModule(DeclContext *ctxt) {
     return getPrimaryIGM();
   }
 
-  IRGenModule *IGM = GenModules[SF];
-  assert(IGM);
-  return IGM;
+  return getGenModule(SF);
 }
 
 IRGenModule *IRGenerator::getGenModule(SILFunction *f) {

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -2276,7 +2276,7 @@ IRGenModule *IRGenerator::getGenModule(SourceFile *SF) {
   if (GenModules.size() == 1)
     return getPrimaryIGM();
 
- IRGenModule *IGM = GenModules[SF];
+ IRGenModule *IGM = GenModules.lookup(SF);
 
  if (!IGM) {
    ASSERT(SF->getParentModule()->findUnderlyingClangModule());

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -2279,6 +2279,10 @@ IRGenModule *IRGenerator::getGenModule(SourceFile *SF) {
  IRGenModule *IGM = GenModules.lookup(SF);
 
  if (!IGM) {
+   // SF is a macro expansion buffer from a _SwiftifyImport macro attached
+   // to a function imported from clang module, so it doesn't have a mapping
+   // in GenModule. The contents are @_alwaysEmitIntoClient, so for all intents
+   // and purposes they belong to the primary module.
    ASSERT(SF->getParentModule()->findUnderlyingClangModule());
    return getPrimaryIGM();
  }

--- a/test/embedded/safe-interop-multiple-outputs.swift
+++ b/test/embedded/safe-interop-multiple-outputs.swift
@@ -1,11 +1,9 @@
-// Regression test: compiler crashes in IRGenerator::getGenModule
-// when calling a safe wrapper from an Embedded module compiled
-// with multiple source files and multiple threads, without WMO.
-// https://github.com/swiftlang/swift/issues/88864
+// Regression test: this used to trigger a compiler crash in IRGenerator::getGenModule
+// since the SourceFile for the _SwiftifyImport macro expansion had no corresponding
+// IRGenModule. This would only trigger with multiple outputs and multiple threads
+// since there's only a single IRGenModule to return otherwise.
 
 // REQUIRES: swift_feature_Embedded
-
-// XFAIL: *
 
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t

--- a/test/embedded/safe-interop-multiple-outputs.swift
+++ b/test/embedded/safe-interop-multiple-outputs.swift
@@ -1,0 +1,40 @@
+// Regression test: compiler crashes in IRGenerator::getGenModule
+// when calling a safe wrapper from an Embedded module compiled
+// with multiple source files and multiple threads, without WMO.
+// https://github.com/swiftlang/swift/issues/88864
+
+// REQUIRES: swift_feature_Embedded
+
+// XFAIL: *
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -c -plugin-path %swift-plugin-dir -I %t \
+// RUN:   -enable-experimental-feature Embedded \
+// RUN:   -parse-as-library -num-threads 2 \
+// RUN:   %t/A.swift %t/B.swift \
+// RUN:   -o %t/A.swift.o -o %t/B.swift.o
+
+//--- test.h
+#pragma once
+
+#define __counted_by(x) __attribute__((__counted_by__(x)))
+#define __noescape __attribute__((noescape))
+
+void foo(const int *__counted_by(len) p __noescape, int len);
+
+//--- module.modulemap
+module Test {
+  header "test.h"
+}
+
+//--- A.swift
+import Test
+
+public func bar(_ s: Span<Int32>) {
+    foo(s)
+}
+
+//--- B.swift
+public struct Baz {}


### PR DESCRIPTION
This fixes a crash where no IRGenModule was found for the macro
expansion SourceFile of a macro attached to a node imported from clang.
Normally this would not trigger since there's an early exit when only a
single IGM exists, so it requires multiple outputs and threads to
trigger.

Resolves #88864

rdar://176347021