### PR TITLE
Replace opened Pack Element types with concrete types when statically known in SILCloner

### DIFF
--- a/SwiftCompilerSources/Sources/AST/Type.swift
+++ b/SwiftCompilerSources/Sources/AST/Type.swift
@@ -330,6 +330,10 @@ extension TypeProperties {
       bridged: rawType.canonical.bridged.SILFunctionType_getSubstGenericSignature())
   }
 
+  public var tupleContainsPackExpansionType: Bool {
+    return rawType.bridged.Tuple_containsPackExpansionType()
+  }
+
   public var containsSILPackExpansionType: Bool {
     return rawType.bridged.containsSILPackExpansionType()
   }

--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/CMakeLists.txt
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/CMakeLists.txt
@@ -46,6 +46,7 @@ swift_compiler_sources(Optimizer
   SimplifySwitchEnum.swift
   SimplifyTuple.swift
   SimplifyTupleExtract.swift
+  SimplifyTuplePackElementAddr.swift
   SimplifyTypeValue.swift
   SimplifyUncheckedAddrCast.swift
   SimplifyUncheckedEnumData.swift

--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyTuplePackElementAddr.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyTuplePackElementAddr.swift
@@ -1,0 +1,40 @@
+//===--- SimplifyTuple.swift ---------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import AST
+import SIL
+
+// Replace a tuple_pack_element_addr_inst with a scalar_pack_index index operand
+// with tuple_element_addr, if its tuple type contains no pack expansions.
+//
+// %tuple = alloc_stack $(Int, Int)
+// %idx = scalar_pack_index 0 of $Pack{Int, Int}
+// %addr = tuple_pack_element_addr %idx of %tuple as $*Int
+//
+// is transformed to:
+//
+// %tuple = alloc_stack $(Int, Int)
+// %addr = tuple_element_addr 0 of %tuple as $*Int
+//
+extension TuplePackElementAddrInst : Simplifiable, SILCombineSimplifiable {
+  func simplify(_ context: SimplifyContext) {
+    guard !self.tupleOperand.value.type.tupleContainsPackExpansionType,
+          let scalarIndex = self.indexOperand.value as? ScalarPackIndexInst
+    else {
+      return
+    }
+
+    let builder = Builder(before: self, context)
+    let tupleElementAddr = builder.createTupleElementAddr(tupleAddress: self.tupleOperand.value, elementIndex: scalarIndex.componentIndex)
+    self.replace(with: tupleElementAddr, context)
+  }
+}

--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -3146,6 +3146,7 @@ struct BridgedASTType {
   BRIDGED_INLINE SwiftInt GenericTypeParam_getIndex() const;
   BRIDGED_INLINE swift::GenericTypeParamKind
   GenericTypeParam_getParamKind() const;
+  BRIDGED_INLINE bool Tuple_containsPackExpansionType() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedConformance checkConformance(BridgedDeclObj proto) const;
   BRIDGED_INLINE bool containsSILPackExpansionType() const;
   BRIDGED_INLINE bool isSILPackElementAddress() const;

--- a/include/swift/AST/ASTBridgingImpl.h
+++ b/include/swift/AST/ASTBridgingImpl.h
@@ -838,6 +838,10 @@ BridgedASTType::GenericTypeParam_getParamKind() const {
   return llvm::cast<swift::GenericTypeParamType>(type)->getParamKind();
 }
 
+bool BridgedASTType::Tuple_containsPackExpansionType() const {
+  return llvm::cast<swift::TupleType>(type)->containsPackExpansionType();
+}
+
 BridgedASTTypeArray BridgedASTType::BoundGenericType_getGenericArgs() const {
   return {llvm::cast<swift::BoundGenericType>(type)->getGenericArgs()};
 }

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -34,11 +34,14 @@ namespace swift {
 struct SubstitutionMapWithLocalArchetypes {
   std::optional<SubstitutionMap> SubsMap;
   llvm::DenseMap<GenericEnvironment *, GenericEnvironment *> LocalArchetypeSubs;
+  llvm::DenseMap<GenericEnvironment *, SubstitutionMap>
+      ConcreteLocalArchetypeSubs;
   GenericSignature BaseGenericSig;
   llvm::ArrayRef<GenericEnvironment *> CapturedEnvs;
 
   bool hasLocalArchetypes() const {
-    return !LocalArchetypeSubs.empty() || !CapturedEnvs.empty();
+    return !LocalArchetypeSubs.empty() || !CapturedEnvs.empty() ||
+           !ConcreteLocalArchetypeSubs.empty();
   }
 
   SubstitutionMapWithLocalArchetypes() {}
@@ -47,6 +50,14 @@ struct SubstitutionMapWithLocalArchetypes {
   Type operator()(SubstitutableType *type) {
     if (auto *local = dyn_cast<LocalArchetypeType>(type)) {
       auto *origEnv = local->getGenericEnvironment();
+
+      // Check for concrete pack element substitution from eliminated
+      // open_pack_element instructions.
+      auto concreteIt = ConcreteLocalArchetypeSubs.find(origEnv);
+      if (concreteIt != ConcreteLocalArchetypeSubs.end()) {
+        auto interfaceTy = local->getInterfaceType();
+        return interfaceTy.subst(concreteIt->second);
+      }
 
       // Special handling of captured environments, which don't appear in
       // LocalArchetypeSubs. This only happens with the LocalArchetypeTransform
@@ -272,6 +283,15 @@ public:
            == To->getGenericSignature().getPointer());
 
     auto result = Functor.LocalArchetypeSubs.insert(std::make_pair(From, To));
+    ASSERT(result.second);
+    (void)result;
+  }
+
+  /// Register a concrete type mapping for local archetypes from an opened
+  /// element environment that is being eliminated.
+  void registerConcreteLocalArchetypeMapping(GenericEnvironment *origEnv,
+                                             SubstitutionMap subs) {
+    auto result = Functor.ConcreteLocalArchetypeSubs.insert({origEnv, subs});
     ASSERT(result.second);
     (void)result;
   }
@@ -3078,11 +3098,46 @@ void SILCloner<ImplClass>::visitDynamicPackIndexInst(
 
   auto newIndexValue = getOpValue(Inst->getOperand());
   auto loc = getOpLocation(Inst->getLoc());
-  auto newPackType = cast<PackType>(getOpASTType(Inst->getIndexedPackType()));
+  CanPackType newPackType =
+      cast<PackType>(getOpASTType(Inst->getIndexedPackType()));
 
-  recordClonedInstruction(
-      Inst, getBuilder().createDynamicPackIndex(loc, newIndexValue,
-                                                newPackType));
+  // Attempt to simplify to a scalar_pack_index.
+  auto simplifyToScalar = [&]() -> bool {
+    auto *intLiteral = dyn_cast<IntegerLiteralInst>(newIndexValue);
+    if (!intLiteral)
+      return false;
+
+    APInt value = intLiteral->getValue();
+
+    auto zextValue = value.tryZExtValue();
+    if (!zextValue)
+      return false;
+
+    unsigned flattenedIndex = *zextValue;
+
+    // Determine whether flattenedIndex can be treated as a structural index.
+    //
+    // A dynamic pack index counts the elements of pack expansions
+    // individually. It is equal to the structural index if it is in bounds,
+    // and none of the elements up to and including that index are pack
+    // expansions.
+    if (flattenedIndex >= newPackType->getNumElements())
+      return false;
+
+    for (auto type :
+         newPackType->getElementTypes().take_front(flattenedIndex + 1)) {
+      if (type->is<PackExpansionType>())
+        return false;
+    }
+
+    recordClonedInstruction(Inst, getBuilder().createScalarPackIndex(
+                                      loc, flattenedIndex, newPackType));
+    return true;
+  };
+
+  if (!simplifyToScalar())
+    recordClonedInstruction(Inst, getBuilder().createDynamicPackIndex(
+                                      loc, newIndexValue, newPackType));
 }
 
 template <typename ImplClass>
@@ -3096,6 +3151,21 @@ void SILCloner<ImplClass>::visitPackPackIndexInst(PackPackIndexInst *Inst) {
   auto newComponentStartIndex =
     getOpStructuralPackIndex(Inst->getIndexedPackType(),
                              Inst->getComponentStartIndex());
+
+  // Attempt to simplify to a scalar_pack_index.
+  if (auto *spi = dyn_cast<ScalarPackIndexInst>(newIndexValue)) {
+
+    // The new pack index operand is scalar. We can add the offset of the start
+    // of the slice to get an index into the full pack. This will refer to the
+    // same (scalar) pack element, because the index operand instruction indexes
+    // a pack that is guaranteed to have the same elements as the slice.
+
+    recordClonedInstruction(
+        Inst, getBuilder().createScalarPackIndex(
+                  loc, newComponentStartIndex + spi->getComponentIndex(),
+                  newPackType));
+    return;
+  }
 
   recordClonedInstruction(
       Inst, getBuilder().createPackPackIndex(loc, newComponentStartIndex,
@@ -3125,13 +3195,70 @@ void SILCloner<ImplClass>::visitOpenPackElementInst(
   getBuilder().setCurrentDebugScope(getOpScope(Inst->getDebugScope()));
 
   auto newIndexValue = getOpValue(Inst->getIndexOperand());
-  auto loc = getOpLocation(Inst->getLoc());
+  auto origEnv = Inst->getOpenedGenericEnvironment();
+
+  // If the structural pack index is statically known, and the pack element at
+  // that index is scalar, we can resolve element archetypes to concrete types
+  // and eliminate this instruction entirely.
+  if (auto *scalarPackIndex = dyn_cast<ScalarPackIndexInst>(
+          newIndexValue.getDefiningInstruction())) {
+    unsigned index = scalarPackIndex->getComponentIndex();
+
+    // Collect concrete element types for each pack element binding.
+    //
+    // If the element at a structural index in a pack is concrete (not an
+    // expansion), we know that the opened @pack_element archetype will always
+    // be equivalent to that type. This means we can replace it with that
+    // concrete type.
+    llvm::SmallDenseMap<CanType, CanType, 4> elementReplacements;
+
+    origEnv->forEachPackElementBinding(
+        [&](ElementArchetypeType *elementArchetype, PackType *origPack) {
+          CanPackType pack =
+              cast<PackType>(getOpASTType(origPack->getCanonicalType()));
+
+          ASSERT(pack->getNumElements() > index &&
+                 !pack->getElementType(index)->is<PackExpansionType>() &&
+                 "open_pack_element only binds archetypes for packs with the "
+                 "same shape as the pack indexed by the instruction we got the "
+                 "index from, so the opened packs must all have a scalar "
+                 "element at the supplied index.");
+          // NOTE: we can safely use this index to access the scalar pack
+          // element for each opened pack because they must all have the same
+          // shape as the pack type referenced by the pack indexing instruction.
+          auto element = pack->getElementType(index);
+          auto interfaceTy =
+              elementArchetype->getInterfaceType()->getCanonicalType();
+          elementReplacements[interfaceTy] = element->getCanonicalType();
+        });
+
+    // Build a SubstitutionMap for the full opened element signature that
+    // maps outer params via origContextSubs and element params to concrete
+    // types.
+    auto genericSig = origEnv->getGenericSignature();
+    auto newContextSubs =
+        getOpSubstitutionMap(origEnv->getOuterSubstitutions());
+    auto subsMap = SubstitutionMap::get(
+        genericSig,
+        [&](SubstitutableType *type) -> Type {
+          auto *gp = cast<GenericTypeParamType>(type);
+          auto canGP = gp->getCanonicalType();
+          auto it = elementReplacements.find(canGP);
+          if (it != elementReplacements.end())
+            return it->second;
+          return Type(type).subst(newContextSubs);
+        },
+        LookUpConformanceInModule());
+    registerConcreteLocalArchetypeMapping(origEnv, subsMap);
+    return;
+  }
 
   // We need to make a new opened-element environment.  This is *not*
   // a refinement of the contextual environment of the new insertion
   // site; we just substitute the contextual substitutions in the
   // opened environment and build a new one.
-  auto origEnv = Inst->getOpenedGenericEnvironment();
+
+  auto loc = getOpLocation(Inst->getLoc());
 
   // Substitute the contextual substitutions.
   auto newContextSubs =

--- a/test/SILOptimizer/pack_specialization.swift
+++ b/test/SILOptimizer/pack_specialization.swift
@@ -21,15 +21,13 @@ public func copyPackCaller(two: UnsafePointer<Int16>) -> (Int32, UnsafePointer<I
   return copyPack(xs: 1, two, 3.0)
 }
 
-// The pack specialization pass alone is not enough to eliminate packs when witness methods are called.
-// CHECK: define {{.*}} i32 @"$s19pack_specialization11addTogether2xsxxQp_txxQp_tRvzSjRzlFs5Int32V_QP_Tg5Tf8xx_n"(i32 %0)
+// With open_pack_element elimination, witness methods on pack elements resolve
+// to concrete types, enabling full devirtualization and optimization.
+// CHECK:       define {{.*}} i32 @"$s19pack_specialization11addTogether2xsxxQp_txxQp_tRvzSjRzlFs5Int32V_QP_Tg5Tf8xx_n"(i32 %0)
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[IN_STACK:%[0-9]+]] = alloca %Ts5Int32V, align 4
-// CHECK-NEXT:    [[OUT_STACK:%[0-9]+]] = alloca %Ts5Int32V, align 4
-// CHECK:         store i32 %0, ptr [[IN_STACK]], align 4
-// CHECK:         call swiftcc void @"$ss18AdditiveArithmeticP1poiyxx_xtFZTj"
-// CHECK:         [[RESULT:%[0-9]+]] = load i32, ptr [[OUT_STACK]]
-// CHECK:         ret i32 [[RESULT]]
+// CHECK-NOT:     call {{.*}} @"$ss18AdditiveArithmeticP1poiyxx_xtFZTj"
+// CHECK:         call { i32, i1 } @llvm.sadd.with.overflow.i32(i32 %0, i32 %0)
+// CHECK:         ret i32
 @inline(never)
 func addTogether<each A: Numeric>(xs: repeat each A) -> (repeat each A) {
   return (repeat (each xs + each xs))
@@ -37,4 +35,113 @@ func addTogether<each A: Numeric>(xs: repeat each A) -> (repeat each A) {
 
 public func addTogetherCaller() -> Int32 {
   return addTogether(xs: 1)
+}
+
+// Dependent/member types (e.g. each T.IntegerLiteralType) must also resolve to
+// concrete types when the open_pack_element is eliminated.
+// CHECK-LABEL: define {{.*}} double @"$s19pack_specialization8addOneTo4argsxxQp_txxQp_tRvzSjRzlFSd_QP_Tg5Tf8xx_n"(double %0) {{.*}} {
+// CHECK-NEXT:  entry:
+// CHECK-NOT:     call{{.*}}@"$ss18AdditiveArithmeticP1poiyxx_xtFZTj"
+// CHECK:         [[RESULT:%[0-9]+]] = fadd double %0, 1.000000e+00
+// CHECK:         ret double
+// CHECK: }
+
+// CHECK-LABEL: define {{.*}} { i64, double, i8 } @"$s19pack_specialization8addOneTo4argsxxQp_txxQp_tRvzSjRzlFSi_Sds4Int8VQP_Tg5Tf8xx_n"(i64 %0, double %1, i8 %2) {{.*}} {
+// CHECK:         @llvm.sadd.with.overflow.i64(i64 %0, i64 1)
+// CHECK:         @llvm.sadd.with.overflow.i8(i8 %2, i8 1)
+// CHECK:         fadd double %1, 1.000000e+00
+// CHECK: }
+@inline(never)
+func addOneTo<each T: Numeric>(args arg: repeat each T) -> (repeat each T) {
+  return (repeat 1 + each arg)
+}
+
+public func addOneToCaller(y: Double) -> Double {
+  return addOneTo(args: y)
+}
+
+public func addOneToMultiCaller(x: Int, y: Double, z: Int8) -> (Int, Double, Int8) {
+  return addOneTo(args: x, y, z)
+}
+
+// Iterating over multiple packs simultaneously.
+// CHECK: define {{.*}} { i64, i64 } @"$s19pack_specialization8zipPacks2xs2zsx_q_txQp_txxQp_q_xQptRvzRv_SzRzq_RhzSzR_r0_lFs5Int32V_s6UInt32VQP_s4Int8V_s5Int16VQPTg5Tf8xxx_n"(i32 %0, i32 %1, i8 %2, i16 %3)
+// CHECK-NOT: alloca
+// CHECK:   shl nsw i16 %3, 1
+// CHECK:   shl nuw i32 %1, 1
+// CHECK:   shl nsw i8 %2, 1
+// CHECK:   shl nsw i32 %0, 1
+// CHECK: }
+@inline(never)
+func zipPacks<each A: BinaryInteger, each B: BinaryInteger>(xs: repeat each A, zs: repeat each B) -> (repeat (each A, each B)) {
+  return (repeat (each xs * 2, each zs * 2))
+}
+
+public func zipAddPacksCaller(x: Int32, y: UInt32, a: Int8, b: Int16)
+  -> ((Int32, Int8), (UInt32, Int16)) {
+  return zipPacks(xs: x, y, zs: a, b)
+}
+
+// When applying a generic function to each element of a pack, the callee can be
+// specialized if the (variadic generic) caller is specialized.
+func numericOp<T: BinaryInteger>(_ x: T) -> T {
+  if x <= 1 {
+    return x
+  } else {
+    let (p, q) = numericLoop(x - 1, x - 2)
+    return p + q
+  }
+}
+
+// CHECK: define {{.*}} i64 @"$s19pack_specialization11numericLoopyxxQp_txxQpRvzSzRzlFs5Int32V_ADQP_Tg5Tf8xx_n"(i32 %0, i32 %1) {{.*}} {
+// CHECK: [[SP1:%[0-9]+]] = add nsw i32 %0, -1
+// CHECK: [[SP2:%[0-9]+]] = add nsw i32 %0, -2
+// CHECK: [[SP_RESULT:%[0-9]+]] = tail call {{.*}} @"$s19pack_specialization11numericLoopyxxQp_txxQpRvzSzRzlFs5Int32V_ADQP_Tg5Tf8xx_n"(i32 [[SP1]], i32 [[SP2]])
+// CHECK-NEXT: [[SP_RESULT1:%[^ ]+]] = trunc i64 [[SP_RESULT]] to i32
+// CHECK-NEXT: [[SP_RESULT2_64:%[^ ]+]] = lshr i64 [[SP_RESULT]], 32
+// CHECK-NEXT: [[SP_RESULT2:%[^ ]+]] = trunc nuw i64 [[SP_RESULT2_64]] to i32
+// CHECK: tail call { i32, i1 } @llvm.sadd.with.overflow.i32(i32 [[SP_RESULT1]], i32 [[SP_RESULT2]])
+// CHECK: }
+@inline(never)
+func numericLoop<each T: BinaryInteger>(_ xs: repeat each T) -> (repeat each T) {
+  return (repeat numericOp(each xs))
+}
+
+// CHECK: define {{.*}} i64 @"$s19pack_specialization15callNumericLoops5Int32V_ADtyF"() {{.*}} {
+// CHECK: tail call
+// CHECK: }
+public func callNumericLoop() -> (Int32, Int32) {
+  numericLoop(39, 39)
+}
+
+// Issue #82000: Combining pointers and parameter packs.
+
+// CHECK: define {{.*}} i32 @"$s19pack_specialization12applyPointer5input2ops5Int32VSPyxGxQp_AFxxQpXEtRvzlF"(ptr noalias readonly captures(none) %0, ptr readonly captures(none) %1, ptr %2, i64 %3, ptr %"each T") {{.*}} {
+// CHECK: }
+public func applyPointer<each T>(input: repeat UnsafePointer<each T>, op: (repeat each T) -> Int32) -> Int32 {
+  op(repeat (each input).pointee)
+}
+
+// CHECK: define {{.*}} i32 @"$s19pack_specialization4tests5Int32VyF"() {{.*}} {
+// CHECK-NEXT: "$s19pack_specialization4tests5Int32VyFADSPyADGXEfU_.exit":
+// CHECK-NEXT:   ret i32 54
+// CHECK-NEXT: }
+public func test() -> Int32 {
+    withUnsafePointer(to: 27) {
+        applyPointer(input: $0, $0) { ($0 + $1) }
+    }
+}
+
+// CHECK: define {{.*}} i32 @"$s19pack_specialization11applyDirect5input2ops5Int32VxxQp_AFxxQpXEtRvzlF"(ptr noalias readonly captures(none) %0, ptr readonly captures(none) %1, ptr %2, i64 %3, ptr %"each T") {{.*}} {
+// CHECK: }
+public func applyDirect<each T>(input: repeat each T, op: (repeat each T) -> Int32) -> Int32 {
+  op(repeat (each input))
+}
+
+// CHECK: define {{.*}} i32 @"$s19pack_specialization10testDirects5Int32VyF"() {{.*}} {
+// CHECK-NEXT: entry:
+// CHECK-NEXT:   ret i32 54
+// CHECK-NEXT: }
+public func testDirect() -> Int32 {
+    applyDirect(input: 27, 27) { ($0 + $1) }
 }

--- a/test/SILOptimizer/simplify_tuple_pack_element_addr.sil
+++ b/test/SILOptimizer/simplify_tuple_pack_element_addr.sil
@@ -1,0 +1,73 @@
+// RUN: %target-sil-opt -enable-sil-verify-all %s -simplification -simplify-instruction=tuple_pack_element_addr | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+
+import Swift
+import Builtin
+
+struct A {}
+struct B {}
+
+sil @use : $@convention(thin) <T> (@in_guaranteed T) -> ()
+
+// CHECK-LABEL: sil @simplify_scalar_index_zero
+// CHECK-NOT:     tuple_pack_element_addr
+// CHECK:         [[ADDR:%[^,]+]] = tuple_element_addr %0, 0
+// CHECK:         apply {{.*}}<A>([[ADDR]])
+// CHECK:       } // end sil function 'simplify_scalar_index_zero'
+sil @simplify_scalar_index_zero : $@convention(thin) (@inout (A, B)) -> () {
+bb0(%tuple : $*(A, B)):
+  %idx = scalar_pack_index 0 of $Pack{A, B}
+  %addr = tuple_pack_element_addr %idx of %tuple : $*(A, B) as $*A
+  %use = function_ref @use : $@convention(thin) <T> (@in_guaranteed T) -> ()
+  apply %use<A>(%addr) : $@convention(thin) <T> (@in_guaranteed T) -> ()
+  %ret = tuple ()
+  return %ret : $()
+}
+
+// CHECK-LABEL: sil @simplify_scalar_index_one
+// CHECK-NOT:     tuple_pack_element_addr
+// CHECK:         [[ADDR:%[^,]+]] = tuple_element_addr %0, 1
+// CHECK:         apply {{.*}}<B>([[ADDR]])
+// CHECK:       } // end sil function 'simplify_scalar_index_one'
+sil @simplify_scalar_index_one : $@convention(thin) (@inout (A, B)) -> () {
+bb0(%tuple : $*(A, B)):
+  %idx = scalar_pack_index 1 of $Pack{A, B}
+  %addr = tuple_pack_element_addr %idx of %tuple : $*(A, B) as $*B
+  %use = function_ref @use : $@convention(thin) <T> (@in_guaranteed T) -> ()
+  apply %use<B>(%addr) : $@convention(thin) <T> (@in_guaranteed T) -> ()
+  %ret = tuple ()
+  return %ret : $()
+}
+
+// A dynamic_pack_index does not get simplified, since the indexed
+// component is not statically known.
+// CHECK-LABEL: sil @dont_simplify_dynamic_pack_index
+// CHECK:         tuple_pack_element_addr
+// CHECK:       } // end sil function 'dont_simplify_dynamic_pack_index'
+sil @dont_simplify_dynamic_pack_index : $@convention(thin) (@inout (A, B), Builtin.Word) -> () {
+bb0(%tuple : $*(A, B), %i : $Builtin.Word):
+  %idx = dynamic_pack_index %i of $Pack{A, B}
+  %tok = open_pack_element %idx of <each Z> at <Pack{A, B}>, shape $Z, uuid "01234567-89AB-CDEF-0123-000000000000"
+  %addr = tuple_pack_element_addr %idx of %tuple : $*(A, B) as $*@pack_element("01234567-89AB-CDEF-0123-000000000000") Z
+  %use = function_ref @use : $@convention(thin) <T> (@in_guaranteed T) -> ()
+  apply %use<@pack_element("01234567-89AB-CDEF-0123-000000000000") Z>(%addr) : $@convention(thin) <T> (@in_guaranteed T) -> ()
+  %ret = tuple ()
+  return %ret : $()
+}
+
+// A scalar_pack_index over a tuple containing a pack expansion does not
+// get simplified, since tuple_element_addr cannot index past the
+// expansion at compile time.
+// CHECK-LABEL: sil @dont_simplify_pack_expansion_tuple
+// CHECK:         tuple_pack_element_addr
+// CHECK:       } // end sil function 'dont_simplify_pack_expansion_tuple'
+sil @dont_simplify_pack_expansion_tuple : $@convention(thin) <each T> (@inout (A, repeat each T, B)) -> () {
+bb0(%tuple : $*(A, repeat each T, B)):
+  %idx = scalar_pack_index 0 of $Pack{A, repeat each T, B}
+  %addr = tuple_pack_element_addr %idx of %tuple : $*(A, repeat each T, B) as $*A
+  %use = function_ref @use : $@convention(thin) <T> (@in_guaranteed T) -> ()
+  apply %use<A>(%addr) : $@convention(thin) <T> (@in_guaranteed T) -> ()
+  %ret = tuple ()
+  return %ret : $()
+}

--- a/test/SILOptimizer/variadic_generics.sil
+++ b/test/SILOptimizer/variadic_generics.sil
@@ -92,10 +92,8 @@ bb0(%i: $Builtin.Word, %tuple : $*(repeat each U)):
 
 // CHECK-LABEL: sil @test_tuple_pack_element_2
 // CHECK:         [[TEMP:%.*]] = alloc_stack $Float
-// CHECK-NEXT:    [[I:%.*]] = integer_literal $Builtin.Word, 0
-// CHECK-NEXT:    [[INDEX:%.*]] = dynamic_pack_index [[I]] of $Pack{Float}
-// CHECK-NEXT:    open_pack_element [[INDEX]] of <each Z> at <Pack{Float}>, shape $each Z, uuid [[UUID:".*"]]
-// CHECK-NEXT:    unchecked_addr_cast [[TEMP]] : $*Float to $*@pack_element([[UUID]]) each Z
+// CHECK-NOT:     open_pack_element
+// CHECK:         unchecked_addr_cast [[TEMP]] : $*Float to $*Float
 sil @test_tuple_pack_element_2 : $() -> () {
 bb0:
   %tuple = alloc_stack $Float
@@ -103,6 +101,93 @@ bb0:
   %fn = function_ref @tuple_pack_element : $@convention(thin) <each T> (Builtin.Word, @inout (repeat each T)) -> ()
   apply %fn<Pack{Float}>(%i, %tuple) : $@convention(thin) <each T> (Builtin.Word, @inout (repeat each T)) -> ()
   dealloc_stack %tuple : $*Float
+  %ret = tuple ()
+  return %ret : $()
+}
+
+sil [ossa] [heuristic_always_inline] @scalar_open_pack_element : $<each T> () -> () {
+bb0:
+  %index = scalar_pack_index 0 of $Pack{Int, repeat each T}
+  %tok = open_pack_element %index of <each Z> at <Pack{Int, repeat each T}>, shape $Z, uuid "01234567-89AB-CDEF-0123-000000000010"
+  %slot = alloc_stack $@pack_element("01234567-89AB-CDEF-0123-000000000010") Z
+  dealloc_stack %slot : $*@pack_element("01234567-89AB-CDEF-0123-000000000010") Z
+  %ret = tuple ()
+  return %ret : $()
+}
+
+// CHECK-LABEL: sil @test_scalar_open_pack_element
+// CHECK-NOT:     open_pack_element
+// CHECK:         alloc_stack $Int
+sil @test_scalar_open_pack_element : $() -> () {
+bb0:
+  %fn = function_ref @scalar_open_pack_element : $@convention(thin) <each T> () -> ()
+  apply %fn<Pack{Float}>() : $@convention(thin) <each T> () -> ()
+  %ret = tuple ()
+  return %ret : $()
+}
+
+sil [ossa] [heuristic_always_inline] @pack_pack_open_element : $<each T> () -> () {
+bb0:
+  %zero = integer_literal $Builtin.Word, 0
+  %inner = dynamic_pack_index %zero of $Pack{repeat each T}
+  %index = pack_pack_index 1, %inner of $Pack{Int, repeat each T}
+  %tok = open_pack_element %index of <each Z> at <Pack{Int, repeat each T}>, shape $Z, uuid "01234567-89AB-CDEF-0123-000000000011"
+  %slot = alloc_stack $@pack_element("01234567-89AB-CDEF-0123-000000000011") Z
+  dealloc_stack %slot : $*@pack_element("01234567-89AB-CDEF-0123-000000000011") Z
+  %ret = tuple ()
+  return %ret : $()
+}
+
+// CHECK-LABEL: sil @test_pack_pack_open_element
+// CHECK-NOT:     open_pack_element
+// CHECK:         alloc_stack $String
+sil @test_pack_pack_open_element : $() -> () {
+bb0:
+  %fn = function_ref @pack_pack_open_element : $@convention(thin) <each T> () -> ()
+  apply %fn<Pack{String}>() : $@convention(thin) <each T> () -> ()
+  %ret = tuple ()
+  return %ret : $()
+}
+
+// CHECK-LABEL: sil @test_dynamic_open_pack_element_runtime
+// CHECK:         [[INDEX:%.*]] = dynamic_pack_index %0 of $Pack{Int, Float}
+// CHECK:         open_pack_element [[INDEX]] of <each Z> at <Pack{Int, Float}>, shape $each Z, uuid
+sil @test_dynamic_open_pack_element_runtime : $(Builtin.Word) -> () {
+bb0(%i : $Builtin.Word):
+  %tuple = alloc_stack $(Int, Float)
+  %fn = function_ref @tuple_pack_element : $@convention(thin) <each T> (Builtin.Word, @inout (repeat each T)) -> ()
+  apply %fn<Pack{Int, Float}>(%i, %tuple) : $@convention(thin) <each T> (Builtin.Word, @inout (repeat each T)) -> ()
+  dealloc_stack %tuple : $*(Int, Float)
+  %ret = tuple ()
+  return %ret : $()
+}
+
+sil [ossa] [heuristic_always_inline] @dynamic_literal_open_pack_element : $<each T> () -> () {
+bb0:
+  %two = integer_literal $Builtin.Word, 2
+  %index = dynamic_pack_index %two of $Pack{repeat each T}
+  %tok = open_pack_element %index of <each Z> at <Pack{repeat each T}>, shape $Z, uuid "01234567-89AB-CDEF-0123-000000000012"
+  %slot = alloc_stack $@pack_element("01234567-89AB-CDEF-0123-000000000012") Z
+  dealloc_stack %slot : $*@pack_element("01234567-89AB-CDEF-0123-000000000012") Z
+  %ret = tuple ()
+  return %ret : $()
+}
+
+// `dynamic_pack_index` fed by an integer literal is a flattened (runtime)
+// offset into the pack. When the caller substitutes `repeat each T` with
+// `Pack{Int, repeat each U, Float}`, structural component 2 is `Float`, but
+// runtime offset 2 lands inside the `repeat each U` expansion if it has 2 or
+// more elements, so the flattened and structural indices can disagree. The
+// cloner must detect this and preserve `open_pack_element` rather than
+// substituting `@pack_element(...) Z` with `Float`.
+//
+// CHECK-LABEL: sil @test_dynamic_literal_expansion_before_index
+// CHECK:         open_pack_element {{.*}} of <each Z> at <Pack{Int, repeat each U, Float}>
+// CHECK:         alloc_stack $@pack_element({{.*}}) each Z
+sil @test_dynamic_literal_expansion_before_index : $<each U> () -> () {
+bb0:
+  %fn = function_ref @dynamic_literal_open_pack_element : $@convention(thin) <each T> () -> ()
+  apply %fn<Pack{Int, repeat each U, Float}>() : $@convention(thin) <each T> () -> ()
   %ret = tuple ()
   return %ret : $()
 }


### PR DESCRIPTION
When using a `@pack_element` type to refer to an element of a concrete pack type at a compile-time-known index, we can replace the `@pack_element` with the concrete type of the element at that index. This enables many further optimisations.

Notably, witness table lookups can be resolved statically, and generic function calls can be specialised.

Resolves:
- #82000
- rdar://163046681 (Eliminate @pack_element types (pack optimization part 2))

This PR was written with the assistance of Claude.
<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
