### PR TITLE
[6.4] Optimizer: use a complexity limits in AliasAnalysis.getApplyEffect and the ComputeEscapeEffects pass

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/Analysis/AliasAnalysis.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Analysis/AliasAnalysis.swift
@@ -410,6 +410,7 @@ struct AliasAnalysis {
     // First try to figure out to which argument(s) the address "escapes" to.
     if let result = memLoc.addressWithPath.visit(using: visitor,
                                                  initialWalkingDirection: memLoc.walkingDirection,
+                                                 complexityBudget: getComplexityBudget(for: apply.parentFunction),
                                                  context)
     {
       // The resulting effects are the argument effects to which `address` escapes to.

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ComputeEscapeEffects.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ComputeEscapeEffects.swift
@@ -32,6 +32,7 @@ let computeEscapeEffects = FunctionPass(name: "compute-escape-effects") {
 
   let returnInst = function.returnInstruction
   let argsWithDefinedEffects = getArgIndicesWithDefinedEscapingEffects(of: function)
+  let complexityBudget = getComplexityBudget(for: function)
 
   for arg in function.arguments {
     // We are not interested in arguments with trivial types.
@@ -59,10 +60,10 @@ let computeEscapeEffects = FunctionPass(name: "compute-escape-effects") {
   
     // Now compute effects for two important cases:
     //   * the argument itself + any value projections, and...
-    if addArgEffects(arg, argPath: SmallProjectionPath(), to: &newEffects, returnInst, context) {
+    if addArgEffects(arg, argPath: SmallProjectionPath(), to: &newEffects, returnInst, complexityBudget, context) {
       //   * single class indirections
       _ = addArgEffects(arg, argPath: SmallProjectionPath(.anyValueFields).push(.anyClassField),
-                        to: &newEffects, returnInst, context)
+                        to: &newEffects, returnInst, complexityBudget, context)
     }
   }
 
@@ -81,12 +82,18 @@ let computeEscapeEffects = FunctionPass(name: "compute-escape-effects") {
 private
 func addArgEffects(_ arg: FunctionArgument, argPath ap: SmallProjectionPath,
                    to newEffects: inout [EscapeEffects.ArgumentEffect],
-                   _ returnInst: ReturnInstruction?, _ context: FunctionPassContext) -> Bool {
+                   _ returnInst: ReturnInstruction?,
+                   _ complexityBudget: Int,
+                   _ context: FunctionPassContext) -> Bool {
   // Correct the path if the argument is not a class reference itself, but a value type
   // containing one or more references.
   let argPath = arg.type.isClass ? ap : ap.push(.anyValueFields)
   
-  guard let result = arg.at(argPath).visit(using: ArgEffectsVisitor(), initialWalkingDirection: .down, context) else {
+  guard let result = arg.at(argPath).visit(using: ArgEffectsVisitor(),
+                                           initialWalkingDirection: .down,
+                                           complexityBudget: complexityBudget,
+                                           context)
+  else {
     return false
   }
   
@@ -146,6 +153,12 @@ private func isOperandOfRecursiveCall(_ op: Operand) -> Bool {
     return true
   }
   return false
+}
+
+private func getComplexityBudget(for function: Function) -> Int {
+  var numInsts = 0
+  for _ in function.instructions { numInsts += 1 }
+  return 1_000_000 / numInsts
 }
 
 private struct ArgEffectsVisitor : EscapeVisitorWithResult {

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -1833,6 +1833,8 @@ void CompilerInstance::freeASTContext() {
 /// Perform "stable" optimizations that are invariant across compiler versions.
 static bool performMandatorySILPasses(CompilerInvocation &Invocation,
                                       SILModule *SM) {
+  FrontendStatsTracer tracer(SM->getASTContext().Stats,
+                             "SIL-mandatory-passes");
   // Don't run diagnostic passes at all when merging modules.
   if (Invocation.getFrontendOptions().RequestedAction ==
       FrontendOptions::ActionType::MergeModules) {
@@ -1887,6 +1889,9 @@ static void countStatsPostSILOpt(UnifiedStatsReporter &Stats,
 }
 
 bool CompilerInstance::performSILProcessing(SILModule *silModule) {
+  FrontendStatsTracer tracer(silModule->getASTContext().Stats,
+                             "SIL-processing");
+
   if (performMandatorySILPasses(Invocation, silModule) &&
       !Invocation.getFrontendOptions().AllowModuleWithCompilerErrors)
     return true;

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -2106,6 +2106,10 @@ static bool performCompileStepsPostSILGen(
     ModuleOrSourceFile MSF, const PrimarySpecificPaths &PSPs, int &ReturnValue,
     FrontendObserver *observer, ArrayRef<const char *> CommandLineArgs,
     ArrayRef<PrimarySpecificPaths> auxPSPs) {
+
+  FrontendStatsTracer tracer(SM->getASTContext().Stats,
+                             "SIL-and-LLVM-processing");
+
   const auto &Invocation = Instance.getInvocation();
   const auto &opts = Invocation.getFrontendOptions();
   FrontendOptions::ActionType Action = opts.RequestedAction;

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -3061,6 +3061,10 @@ config.substitutions.append(('%scale-test',
                              '{} {} --swiftc-binary={} --tmpdir=%t --exclude-timers'.format(
                                  shell_quote(sys.executable), config.scale_test,
                                  config.swiftc)))
+config.substitutions.append(('%timer-scale-test',
+                             '{} {} --swiftc-binary={} --tmpdir=%t'.format(
+                                 shell_quote(sys.executable), config.scale_test,
+                                 config.swiftc)))
 config.substitutions.append(('%abi-symbol-checker', '%s %s' % (shell_quote(sys.executable), config.abi_symbol_checker)))
 config.substitutions.append((r'%target-sil-opt\(mock-sdk:([^)]+)\)',
                              SubstituteCaptures(r'%s \1 %s' % (

--- a/utils/scale-test
+++ b/utils/scale-test
@@ -224,7 +224,10 @@ def run_many(args):
     else:
         with io.open(args.file, 'r', encoding='utf-8') as f:
             ast = gyb.parse_template(args.file, f.read())
-    rng = range(args.begin, args.end, args.step)
+    if args.superlinear_threshold:
+        rng = [0, args.begin, args.end]
+    else:
+        rng = range(args.begin, args.end, args.step)
     if args.step > (args.end - args.begin):
         print("Step value", args.step,
               "is too large for the range", str((args.begin, args.end)) + ".",
@@ -638,10 +641,19 @@ def report(args, rng, runs):
     rows = []
     for k in keys:
         vals = [r[k] for r in runs]
+        if args.trace:
+            print("values: " + repr(vals))
+
         if all(v == 0 for v in vals):
             print("Missing data")
             return True
         bounded = [max(v, 1) for v in vals]
+
+        if args.superlinear_threshold:
+            if check_superlinear_threshold(args, rng, bounded):
+              bad = True
+            continue
+
         one_fit = False
         perfect_fit = False
         fit_r2_thresh = 0.99
@@ -704,6 +716,27 @@ def report(args, rng, runs):
     return bad
 
 
+def check_superlinear_threshold(args, rng, values):
+    assert len(rng) == 3
+    assert len(values) == 3
+
+    c = values[0]
+    y1 = values[1] - c
+    y2 = values[2] - c
+    x1 = rng[1]
+    x2 = rng[2]
+    f = y2 / y1
+    normalized = f / (x2 / x1)
+
+    if args.trace:
+        print("factor: " + str(normalized))
+    if normalized > args.superlinear_threshold:
+        print("superlinear threshold exceeded: " +
+              str(normalized) + " > " + str(args.superlinear_threshold))
+        return True
+    return False
+
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -727,6 +760,10 @@ def main():
         '--exponential-threshold', type=float,
         default=1.2,
         help='minimum base for exponential fit to consider "bad scaling"')
+    parser.add_argument(
+        '--superlinear-threshold', type=float,
+        default=None,
+        help='maximum superlinear factor with 3 data points at [0, begin, end]')
     parser.add_argument(
         '-parse', '--parse', action='store_true',
         default=False, help='only run compiler with -parse')

--- a/validation-test/SILOptimizer/alias_analysis_scale_test.swift.gyb
+++ b/validation-test/SILOptimizer/alias_analysis_scale_test.swift.gyb
@@ -1,0 +1,23 @@
+// RUN: %timer-scale-test --begin 50 --end 800 --superlinear-threshold 4 --trace --select SIL-processing.user -O %s
+
+// TODO: there are still compile time problems in CopyPropagation and OSSACanonicalizationOwned (inside SILCombine): rdar://176255056
+//       Once those problems are fixed the threshold should be closer to 1.
+
+// REQUIRES: asserts
+
+public class Entry {
+  private let a: String
+  private let b: String
+  init(_ a: String, _ b: String) {
+    self.a = a
+    self.b = b
+  }
+}
+
+public func test() -> [Entry] {
+  var list = [Entry]()
+%for i in range(0, N):
+  list.append(Entry("a", "b"))
+%end
+  return list
+}

--- a/validation-test/SILOptimizer/many_struct_properties_scale_test.swift.gyb
+++ b/validation-test/SILOptimizer/many_struct_properties_scale_test.swift.gyb
@@ -1,0 +1,27 @@
+// RUN: %timer-scale-test --begin 50 --end 1000 --superlinear-threshold 5 --trace --select SIL-processing.user -O %s
+
+// TODO: there are still compile time problems in CopyPropagation and OSSACanonicalizationOwned (inside SILCombine): rdar://176255056
+//       Once those problems are fixed the threshold should be closer to 1.
+
+// REQUIRES: asserts
+
+public typealias Handler = ((Int) -> Int)
+
+public struct LargeStruct {
+    let error: Int
+%for i in range(0, N):
+    let prop${i}: Handler?
+%end
+
+    public init(
+        error: Int,
+%for i in range(0, N):
+        prop${i}: Handler? = nil${"," if i < N-1 else ""}
+%end
+    ) {
+        self.error = error
+%for i in range(0, N):
+        self.prop${i} = prop${i}
+%end
+    }
+}


### PR DESCRIPTION
* **Explanation**: Those complexity limits fix compile time problems for very large functions. We already do this in various places in alias analysis. This change adds such checks in some more places.
The PR also includes improvements to the `scale-test` utility. This is needed to implement regression test for the changes.
* **Risk**: Low. The change only makes escape analysis more conservative for very large functions
* **Testing**: Tested by lit tests
* **Issue**: rdar://175937160, rdar://175999887
* **Reviewers**: @meg-gupta
* **Main branch PR**: https://github.com/swiftlang/swift/pull/88825
