### PR TITLE
Nfc use interleaveComma 

### DIFF
--- a/lib/IDE/CompletionLookup.cpp
+++ b/lib/IDE/CompletionLookup.cpp
@@ -1471,7 +1471,7 @@ static StringRef getTypeAnnotationString(const NominalTypeDecl *NTD,
 
   assert(stash.empty());
   llvm::raw_svector_ostream OS(stash);
-  llvm::interleave(attrRoleStrs, OS, ", ");
+  llvm::interleaveComma(attrRoleStrs, OS);
   return {stash.data(), stash.size()};
 }
 
@@ -1695,7 +1695,7 @@ static StringRef getTypeAnnotationString(const MacroDecl *MD,
 
   assert(stash.empty());
   llvm::raw_svector_ostream OS(stash);
-  llvm::interleave(roleStrs, OS, ", ");
+  llvm::interleaveComma(roleStrs, OS);
   return {stash.data(), stash.size()};
 }
 

--- a/lib/SILOptimizer/Utils/PartitionUtils.cpp
+++ b/lib/SILOptimizer/Utils/PartitionUtils.cpp
@@ -708,7 +708,7 @@ void Partition::printHistory(llvm::raw_ostream &os) const {
       auto extraArgs = head->getAdditionalElementArgs();
       if (extraArgs.empty())
         break;
-      llvm::interleave(extraArgs, os, ", ");
+      llvm::interleaveComma(extraArgs, os);
       break;
     }
     case IsolationHistory::Node::MergeElementRegions: {
@@ -717,7 +717,7 @@ void Partition::printHistory(llvm::raw_ostream &os) const {
       if (extraArgs.empty())
         break;
       os << ", ";
-      llvm::interleave(extraArgs, os, ", ");
+      llvm::interleaveComma(extraArgs, os);
       break;
     }
     case IsolationHistory::Node::CFGHistoryJoin:

--- a/lib/SILOptimizer/Utils/SILIsolationInfo.cpp
+++ b/lib/SILOptimizer/Utils/SILIsolationInfo.cpp
@@ -1284,7 +1284,7 @@ void SILIsolationInfo::printOptions(llvm::raw_ostream &os) const {
          "Please update MaxNumBits so that we can avoid heap allocations in "
          "this SmallVector");
 
-  llvm::interleave(data, os, ", ");
+  llvm::interleaveComma(data, os);
 }
 
 StringRef SILIsolationInfo::printActorIsolationForDiagnostics(

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -3210,7 +3210,7 @@ void BindingSet::dump(llvm::raw_ostream &out, unsigned indent) const {
     attributes.push_back("conflicting");
   if (!attributes.empty()) {
     out << "[attributes: ";
-    interleave(attributes, out, ", ");
+    interleaveComma(attributes, out);
   }
   
   auto literalKind = getLiteralForScore();
@@ -3234,7 +3234,7 @@ void BindingSet::dump(llvm::raw_ostream &out, unsigned indent) const {
         collectionLiterals.push_back(
             getCollectionLiteralAsString(protocolKind));
       });
-      interleave(collectionLiterals, out, ", ");
+      interleaveComma(collectionLiterals, out);
       break;
     }
     case LiteralBindingKind::Float:


### PR DESCRIPTION
`interleaveComma` is a convenience wrapper that hardcodes `", "` as the separator. I have replaced all call sites in the codebase where `interleave` was being passed `", "` explicitly:

- `lib/Sema/CSBindings.cpp` (2 sites)
- `lib/SILOptimizer/Utils/PartitionUtils.cpp` (2 sites)
- `lib/SILOptimizer/Utils/SILIsolationInfo.cpp` (1 site)
- `lib/IDE/CompletionLookup.cpp` (2 sites)

No functional change.