### PR TITLE
🍒[cxx-interop] Do not crash on references to global non-copyable non-movable variables

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -10524,7 +10524,10 @@ performMemberLookup(ConstraintKind constraintKind, DeclNameRef memberName,
     // For code completion include the result because we can partially match
     // against function types that only have one parameter with error type.
     if (decl->isInvalid() && !isForCodeCompletion()) {
-      result.markErrorAlreadyDiagnosed();
+      // Clang import failures emit notes rather than errors, so the error
+      // hasn't actually been emitted yet.
+      if (!decl->hasClangNode())
+        result.markErrorAlreadyDiagnosed();
       return;
     }
 
@@ -11030,7 +11033,8 @@ performMemberLookup(ConstraintKind constraintKind, DeclNameRef memberName,
 
         // If the result is invalid, skip it.
         if (cand->isInvalid()) {
-          result.markErrorAlreadyDiagnosed();
+          if (!cand->hasClangNode())
+            result.markErrorAlreadyDiagnosed();
           break;
         }
 

--- a/test/Interop/Cxx/class/Inputs/module.modulemap
+++ b/test/Interop/Cxx/class/Inputs/module.modulemap
@@ -184,3 +184,8 @@ module FriendFunction {
   requires cplusplus
   export *
 }
+
+module NoncopyableNonmovableGlobal {
+  header "noncopyable-nonmovable-global.h"
+  requires cplusplus
+}

--- a/test/Interop/Cxx/class/Inputs/noncopyable-nonmovable-global.h
+++ b/test/Interop/Cxx/class/Inputs/noncopyable-nonmovable-global.h
@@ -1,0 +1,19 @@
+template <typename T>
+struct StaticData {
+    StaticData() {}
+    StaticData(const StaticData &) = delete;
+    StaticData(StaticData &&) = delete;
+    StaticData &operator=(const StaticData &) = delete;
+    StaticData &operator=(StaticData &&) = delete;
+
+    T *operator->() const { return &value; }
+    mutable T value;
+};
+
+struct TokensType {
+    int token;
+};
+
+namespace ns {
+StaticData<TokensType> Tokens;
+}

--- a/test/Interop/Cxx/class/noncopyable-nonmovable-global-typechecker.swift
+++ b/test/Interop/Cxx/class/noncopyable-nonmovable-global-typechecker.swift
@@ -1,0 +1,7 @@
+// RUN: %target-typecheck-verify-swift -I %S/Inputs -cxx-interoperability-mode=default %s -verify-ignore-unrelated
+
+import NoncopyableNonmovableGlobal
+
+func useTokens() {
+    let _ = ns.Tokens // expected-error {{type 'ns' has no member 'Tokens'}}
+}


### PR DESCRIPTION
- **Explanation**:
C++ types that are non-copyable and non-movable are not imported into Swift.
Variables of such types are marked as invalid in Swift by ClangImporter, however, compilation still proceeds without emitting any errors, unless the user attempts to use the problematic type from Swift. This differs from pure-Swift where having invalid decls are not allowed.
This adjusts the typechecker to account for the fact that a declaration coming from Clang might be invalid and not diagnosed at the same time. Instead of crashing in SILGen, let's emit a typechecking error.
- **Scope**: This only touches the typechecker logic that diagnoses decls imported from Clang.
- **Issues**: rdar://137880350
- **Original PRs**: https://github.com/swiftlang/swift/pull/88832
- **Risk**: Low, only affects diagnostics for invalid code.
- **Testing**: Added a compiler test.
- **Reviewers**: @hamishknight @j-hui @Xazax-hun @hnrklssn 

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
