### PR TITLE
[SILOptimizer] Enable iterative specialization of nested closure chains

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ClosureSpecialization.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ClosureSpecialization.swift
@@ -58,18 +58,36 @@ private func log(prefix: Bool = true, _ message: @autoclosure () -> String) {
 let closureSpecialization = FunctionPass(name: "closure-specialization") {
   (function: Function, context: FunctionPassContext) in
 
+  closureSpecializationImpl(function: function, context: context)
+}
+
+func closureSpecializationImpl(function: Function, context: FunctionPassContext) {
   guard function.hasOwnership else {
     return
   }
 
-  for inst in function.instructions {
-    if let apply = inst as? FullApplySite {
-      _ = trySpecialize(apply: apply, context)
+  var remainingSpecializationRounds = 5
+
+  repeat {
+    var changed = false
+
+    for inst in function.instructions {
+      if let apply = inst as? FullApplySite {
+        if trySpecialize(apply: apply, context) {
+          changed = true
+        }
+      }
     }
-  }
-  if context.needFixStackNesting {
-    context.fixStackNesting(in: function)
-  }
+
+    if context.needFixStackNesting {
+      context.fixStackNesting(in: function)
+    }
+    if !changed {
+      break
+    }
+
+    remainingSpecializationRounds -= 1
+  } while remainingSpecializationRounds > 0
 }
 
 /// AutoDiff Closure Specialization
@@ -520,10 +538,77 @@ private struct SpecializationInfo {
 
     addMissingDestroysAtFunctionExits(for: clonedClosureArguments, cloner.context)
 
+    /// When we have several partial_apply instructions capturing each other in a chain,
+    /// we might be able to perform several specialization rounds.
+    /// The decision whether to specialize a closure depends on if it's fully applied in the callee.
+    /// So, we need to fold partial_apply+apply of "less nested" already specialized closure
+    /// to allow specialization of "more nested" not yet specialized closure.
+    ///
+    /// === BEFORE SPECIALIZATION ===
+    /// // VJP of bar(Float) -> Float
+    /// bb0(%0: Float)
+    ///   %4 = apply %sinf(%0)
+    ///   %6 = partial_apply %pb_sinf(%0)
+    ///   %8 = partial_apply %pb_foo(%6)
+    ///   %10 = partial_apply %pb_bar(%8)
+    ///   return (%4, %10)
+    ///
+    /// // pb_bar: pullback of bar(Float) -> Float
+    /// bb0(%0 : Float, %1 : (Float) -> Float):
+    ///   %2 = apply %1(%0)
+    ///   return %2
+    ///
+    /// // pb_foo: pullback of foo(Float) -> Float
+    /// bb0(%0 : Float, %1 : (Float) -> Float):
+    ///   %2 = apply %1(%0)
+    ///   return %2
+    ///
+    /// === AFTER SPECIALIZATION ROUND 1 ===
+    /// // VJP of bar(Float) -> Float
+    /// bb0(%0: Float)
+    ///   %4 = apply %sinf(%0)
+    ///   %6 = partial_apply %pb_sinf(%0)
+    ///   %10 = partial_apply %pb_bar_spec_round1(%6)
+    ///   return (%4, %10)
+    ///
+    /// // pb_bar_spec_round1: specialized pullback of bar(Float) -> Float
+    /// bb0(%0 : Float, %1 : (Float) -> Float):
+    ///   %2 = function_ref @pb_foo : (Float, (Float) -> Float) -> Float
+    ///   %4 = apply %2(%0, %1) // <-- folded from _/ %3 = partial_apply %2(%1)
+    ///                         //                  \ %4 = apply %3(%0)
+    ///   return %4
+    ///
+    /// // pb_foo: pullback of foo(Float) -> Float: unchanged
+
     for rootClosure in rootClosures {
       let clonedRootClosure = cloner.getClonedValue(of: rootClosure) as! PartialApplyInst
       let _ = cloner.context.tryOptimizeApplyOfPartialApply(closure: clonedRootClosure)
     }
+
+    /// Further specialization rounds might leave the specialized callee in a state where
+    /// it contains a specializable closure with an apply taking the closure as an argument.
+    /// Run closure specialization pass for the callee we've just specialized.
+    ///
+    /// === AFTER SPECIALIZATION ROUND 2 ===
+    /// // VJP of bar(Float) -> Float
+    /// bb0(%0: Float)
+    ///   %4 = apply %sinf(%0)
+    ///   %10 = partial_apply %pb_bar_spec_round2(%0)
+    ///   return (%4, %10)
+    ///
+    /// // pb_bar_spec_round2: specialized pullback of bar(Float) -> Float
+    /// bb0(%0 : Float, %1 : Float):
+    ///   %8 = apply %pb_foo_spec(%0, %0) // <-- specialized _/ %6 = partial_apply %pb_sinf(%0)
+    ///                                   //                  \ %8 = apply %pb_foo(%0, %6)
+    ///   return %8
+    ///
+    /// // pb_foo_spec: specialized pullback of foo(Float) -> Float
+    /// bb0(%0 : Float, %1 : Float):
+    ///   %7 = apply %pb_sinf(%0, %1) // <-- folded from _/ %6 = partial_apply %pb_sinf(%1)
+    ///                               //                  \ %7 = apply %6(%0)
+    ///   return %7
+
+    closureSpecializationImpl(function: cloner.targetFunction, context: cloner.context)
   }
 
   private func addFunctionArgumentsWithoutClosures(using cloner: inout Cloner) {

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ClosureSpecialization.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ClosureSpecialization.swift
@@ -519,6 +519,11 @@ private struct SpecializationInfo {
     cloner.cloneFunctionBody(from: callee)
 
     addMissingDestroysAtFunctionExits(for: clonedClosureArguments, cloner.context)
+
+    for rootClosure in rootClosures {
+      let clonedRootClosure = cloner.getClonedValue(of: rootClosure) as! PartialApplyInst
+      let _ = cloner.context.tryOptimizeApplyOfPartialApply(closure: clonedRootClosure)
+    }
   }
 
   private func addFunctionArgumentsWithoutClosures(using cloner: inout Cloner) {

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ClosureSpecialization.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ClosureSpecialization.swift
@@ -58,10 +58,10 @@ private func log(prefix: Bool = true, _ message: @autoclosure () -> String) {
 let closureSpecialization = FunctionPass(name: "closure-specialization") {
   (function: Function, context: FunctionPassContext) in
 
-  closureSpecializationImpl(function: function, context: context)
+  runClosureSpecialization(function: function, context: context)
 }
 
-func closureSpecializationImpl(function: Function, context: FunctionPassContext) {
+func runClosureSpecialization(function: Function, context: FunctionPassContext) {
   guard function.hasOwnership else {
     return
   }
@@ -539,76 +539,122 @@ private struct SpecializationInfo {
     addMissingDestroysAtFunctionExits(for: clonedClosureArguments, cloner.context)
 
     /// When we have several partial_apply instructions capturing each other in a chain,
-    /// we might be able to perform several specialization rounds.
-    /// The decision whether to specialize a closure depends on if it's fully applied in the callee.
-    /// So, we need to fold partial_apply+apply of "less nested" already specialized closure
-    /// to allow specialization of "more nested" not yet specialized closure.
+    /// we might be able to perform several specialization rounds. See also test/SILOptimizer/closure_specialization_nested.sil.
     ///
-    /// === BEFORE SPECIALIZATION ===
-    /// // VJP of bar(Float) -> Float
-    /// bb0(%0: Float)
-    ///   %4 = apply %sinf(%0)
-    ///   %6 = partial_apply %pb_sinf(%0)
-    ///   %8 = partial_apply %pb_foo(%6)
-    ///   %10 = partial_apply %pb_bar(%8)
-    ///   return (%4, %10)
+    /// Whether a closure gets specialized depends on whether it is fully applied, possibly
+    /// transitively, in the callee (the gate is in `analyzeArguments` via `isClosureApplied`).
+    /// The goal across all rounds is to leave no specializable closures left in the caller.
     ///
-    /// // pb_bar: pullback of bar(Float) -> Float
-    /// bb0(%0 : Float, %1 : (Float) -> Float):
-    ///   %2 = apply %1(%0)
-    ///   return %2
+    /// When `%15 = partial_apply @closure2(%12)` from caller is cloned into the specialized callee it comes back as a
+    /// `partial_apply @closure2(%1)` serving as a callee of the further `apply`, so specialized callee argument `%1`
+    /// which is by itself a closure `%12 = partial_apply @closure1(%9)` coming from caller is only a `partial_apply`
+    /// operand and is therefore invisible to the applied-check.
     ///
-    /// // pb_foo: pullback of foo(Float) -> Float
-    /// bb0(%0 : Float, %1 : (Float) -> Float):
-    ///   %2 = apply %1(%0)
-    ///   return %2
+    /// Folding `partial_apply`+`apply` into a single `apply` (via `tryOptimizeApplyOfPartialApply`) turns `partial_apply`
+    /// of `closure1` in caller into a direct full-apply operand, so the next specialization round on `caller` can see
+    /// that this closure is transitively applied in `closure2`. Without the fold the `partial_apply` of `closure1`
+    /// closure is never recognized as applied and its `partial_apply` stays behind.
     ///
-    /// === AFTER SPECIALIZATION ROUND 1 ===
-    /// // VJP of bar(Float) -> Float
-    /// bb0(%0: Float)
-    ///   %4 = apply %sinf(%0)
-    ///   %6 = partial_apply %pb_sinf(%0)
-    ///   %10 = partial_apply %pb_bar_spec_round1(%6)
-    ///   return (%4, %10)
+    /// We fold now rather than defer to separate sil-combiner run: the caller's specialization loop does revisit its
+    /// apply each round, but unless we mutate the cloned callee now the applied-check still fails and the loop makes no
+    /// progress. So, by the time the sil-combiner reaches the specialized callee (it's added to pass manager worklist
+    /// via `notifyNewFunction`) and does the fold inside it, the caller's specialization has already finished and its
+    /// apply of callee is never revisited at all - stranding the `partial_apply` of `closure1`.
     ///
-    /// // pb_bar_spec_round1: specialized pullback of bar(Float) -> Float
-    /// bb0(%0 : Float, %1 : (Float) -> Float):
-    ///   %2 = function_ref @pb_foo : (Float, (Float) -> Float) -> Float
-    ///   %4 = apply %2(%0, %1) // <-- folded from _/ %3 = partial_apply %2(%1)
-    ///                         //                  \ %4 = apply %3(%0)
-    ///   return %4
+    ///   sil @closure0 : (Float, Float) -> Float             // leaf
+    ///   sil @closure1 : (Float, (Float) -> Float) -> Float  // bb0(%x, %f): return apply %f(%x)
+    ///   sil @closure2 : (Float, (Float) -> Float) -> Float  // bb0(%x, %f): return apply %f(%x)
+    ///   sil @callee   : (Float, (Float) -> Float) -> Float  // bb0(%x, %f): return apply %f(%x)
     ///
-    /// // pb_foo: pullback of foo(Float) -> Float: unchanged
+    ///   caller(%0 : Float, %1 : Float) -> Float:
+    ///     %9  = partial_apply @closure0(%0)  : (Float) -> Float
+    ///     %12 = partial_apply @closure1(%9)  : (Float) -> Float
+    ///     %15 = partial_apply @closure2(%12) : (Float) -> Float
+    ///     return apply @callee(%1, %15)
+    ///
+    /// Round 1 for caller: specialize apply of callee
+    ///
+    ///   caller(%0 : Float, %1 : Float) -> Float:
+    ///     %9  = partial_apply @closure0(%0)  : (Float) -> Float
+    ///     %12 = partial_apply @closure1(%9)  : (Float) -> Float
+    ///     return apply @specialized_callee_r1(%1, %12)
+    ///
+    ///   specialized_callee_r1(%0 : Float, %1 : (Float) -> Float) -> Float:
+    ///     return apply @closure2(%0, %1) // <-- folded from _/ %3 = partial_apply @closure2(%1)
+    ///                                    //                  \ %9 = apply %3(%0)
+    ///
+    /// Now `%12 = partial_apply @closure1(%9)` in caller is recognized as transitively applied in
+    /// `specialized_callee_r1`->`closure2`, making it subject for specialization during the 2nd round.
 
     for rootClosure in rootClosures {
       let clonedRootClosure = cloner.getClonedValue(of: rootClosure) as! PartialApplyInst
       let _ = cloner.context.tryOptimizeApplyOfPartialApply(closure: clonedRootClosure)
     }
 
-    /// Further specialization rounds might leave the specialized callee in a state where
-    /// it contains a specializable closure with an apply taking the closure as an argument.
-    /// Run closure specialization pass for the callee we've just specialized.
+    /// Further specialization rounds can leave the cloned callee holding a specializable closure and an `apply` which
+    /// takes this closure as an argument. Consider the case when this specializable closure captures an argument from
+    /// the cloned callee, and this argument by itself is a specializable closure constructed in caller and passed to
+    /// the cloned callee as a parameter. Since the applied-check stops at `partial_apply` operands, a closure still
+    /// sitting in the caller (`partial_apply` of `closure0` in example) only becomes specializable once the callee it
+    /// is passed to has itself been specialized deeply enough for that closure to appear transitively full-applied.
     ///
-    /// === AFTER SPECIALIZATION ROUND 2 ===
-    /// // VJP of bar(Float) -> Float
-    /// bb0(%0: Float)
-    ///   %4 = apply %sinf(%0)
-    ///   %10 = partial_apply %pb_bar_spec_round2(%0)
-    ///   return (%4, %10)
+    /// We specialze now rather than defer to separate closure specialization run: the caller's specialization loop does
+    /// revisit its apply each round, but unless we mutate the cloned callee now the applied-check still fails and the
+    /// loop makes no progress. So, by the time the closure specialization pass reaches the specialized callee (it's
+    /// added to pass manager worklist via `notifyNewFunction`) and does specialization for it, the caller's specialization
+    /// has already finished and its apply of callee is never revisited at all - stranding the `partial_apply` of `closure0`.
     ///
-    /// // pb_bar_spec_round2: specialized pullback of bar(Float) -> Float
-    /// bb0(%0 : Float, %1 : Float):
-    ///   %8 = apply %pb_foo_spec(%0, %0) // <-- specialized _/ %6 = partial_apply %pb_sinf(%0)
-    ///                                   //                  \ %8 = apply %pb_foo(%0, %6)
-    ///   return %8
+    /// Running `runClosureSpecialization` synchronously on the cloned callee we've just produced fully specializes it
+    /// before the caller's next specialization round, so the caller re-inspects the same apply, now sees `closure0` as
+    /// transitively applied, and specializes it - leaving no `partial_apply` of a specializable closure in the caller.
+    /// This recursion terminates: `runClosureSpecialization` performs at most 5 rounds per function, and
+    /// `findSpecializableClosure` only specializes closures whose callee has `specializationLevel <= 2`.
     ///
-    /// // pb_foo_spec: specialized pullback of foo(Float) -> Float
-    /// bb0(%0 : Float, %1 : Float):
-    ///   %7 = apply %pb_sinf(%0, %1) // <-- folded from _/ %6 = partial_apply %pb_sinf(%1)
-    ///                               //                  \ %7 = apply %6(%0)
-    ///   return %7
+    /// Round 2 for caller: specialize apply of specialized_callee_r1.
+    ///
+    ///   caller(%0 : Float, %1 : Float) -> Float:
+    ///     %9  = partial_apply @closure0(%0)  : (Float) -> Float
+    ///     return apply @specialized_callee_r2(%1, %9)
+    ///
+    ///   specialized_callee_r2(%0 : Float, %1 : (Float) -> Float) -> Float:
+    ///     %15 = partial_apply @closure1(%1) : (Float) -> Float
+    ///     return apply @closure2(%0, %15)
+    ///
+    /// Recursive round 1 for specialized_callee_r2: specialize apply of closure2.
+    ///
+    ///   specialized_callee_r2(%0 : Float, %1 : (Float) -> Float) -> Float:
+    ///     return apply @specialized_closure2_r1(%0, %1)
+    ///
+    ///   specialized_closure2_r1(%0 : Float, %1 : (Float) -> Float) -> Float:
+    ///     %9 = apply @closure1(%0, %1) // <-- folded from _/ %3 = partial_apply @closure1(%1)
+    ///                                  //                  \ %9 = apply %3(%0)
+    ///     return %9
+    ///
+    /// Now `%9 = partial_apply @closure0(%0)` in caller is recognized as transitively applied in
+    /// `specialized_callee_r2`->`closure1`, making it subject for specialization during the 3rd round.
+    ///
+    /// Round 3 for caller: specialize apply of specialized_callee_r2.
+    ///
+    ///   caller(%0 : Float, %1 : Float) -> Float:
+    ///     return apply @specialized_callee_r3(%1, %0)
+    ///
+    ///   specialized_callee_r3(%0 : Float, %1 : Float) -> Float:
+    ///     %9  = partial_apply @closure0(%1)  : (Float) -> Float
+    ///     return apply @specialized_closure2_r1(%0, %9)
+    ///
+    /// Further specialization rounds of `specialized_callee_r3` and other functions are omitted.
+    /// Final specialization result contains no `partial_apply` left:
+    ///
+    ///   caller(%0 : Float, %1 : Float) -> Float:
+    ///     return apply @specialized_callee_final(%1, %0)
+    ///   specialized_callee_final(%0 : Float, %1 : Float) -> Float:
+    ///     return apply @specialized_closure2_final(%0, %1)
+    ///   specialized_closure2_final(%0 : Float, %1 : Float) -> Float:
+    ///     return apply @specialized_closure1_final(%0, %1)
+    ///   specialized_closure1_final(%0 : Float, %1 : Float) -> Float:
+    ///     return apply @closure0(%0, %1)
 
-    closureSpecializationImpl(function: cloner.targetFunction, context: cloner.context)
+    runClosureSpecialization(function: cloner.targetFunction, context: cloner.context)
   }
 
   private func addFunctionArgumentsWithoutClosures(using cloner: inout Cloner) {

--- a/lib/SILOptimizer/Utils/PartialApplyCombiner.cpp
+++ b/lib/SILOptimizer/Utils/PartialApplyCombiner.cpp
@@ -201,6 +201,9 @@ void PartialApplyCombiner::processSingleApply(FullApplySite paiAI) {
   }
 
   SILValue callee = pai->getCallee();
+  // Apply might consume pai not directly, but after some conversions. If
+  // destroy_value would be needed, it must consume effective callee of AI.
+  SILValue effectiveCallee = paiAI.getCallee();
   SubstitutionMap subs = pai->getSubstitutionMap();
 
   if (auto *tai = dyn_cast<TryApplyInst>(paiAI)) {
@@ -221,7 +224,7 @@ void PartialApplyCombiner::processSingleApply(FullApplySite paiAI) {
   // consumed by the apply_instruction.
   if (!pai->hasCalleeGuaranteedContext()) {
     paiAI.insertAfterApplication([&](SILBuilder &builder) {
-      builder.emitDestroyValueOperation(destroyloc, pai);
+      builder.emitDestroyValueOperation(destroyloc, effectiveCallee);
     });
   }
   callbacks.deleteInst(paiAI.getInstruction());

--- a/test/AutoDiff/SILOptimizer/closure_specialization/single_bb_nested.sil
+++ b/test/AutoDiff/SILOptimizer/closure_specialization/single_bb_nested.sil
@@ -1,0 +1,98 @@
+// RUN: %target-sil-opt -sil-print-types -enable-sil-verify-all -autodiff-closure-specialization %s | %FileCheck %s
+
+// The SIL corresponds to the following Swift source:
+//
+// func foo(_ x: Float) -> Float {
+//   return sin(x)
+// }
+//
+// @differentiable(reverse)
+// func bar(_ x: Float) -> Float {
+//   return foo(x)
+// }
+
+sil_stage canonical
+
+import Builtin
+import Swift
+import SwiftShims
+
+import _Differentiation
+
+// CHECK: // reverse-mode derivative of bar(_:)
+// CHECK: sil hidden [ossa] @$s3src3baryS2fFTJrSpSr : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float) {
+// CHECK: bb0(%0 : $Float):
+// CHECK:   %[[#A3:]] = function_ref @$sSo4sinfyS2fFTo : $@convention(c) (Float) -> Float
+// CHECK:   %[[#A4:]] = apply %[[#A3]](%0) : $@convention(c) (Float) -> Float
+// CHECK:   %[[#A9:]] = function_ref @$s3src3baryS2fFTJpSpSr22$s3src3fooyS2fFTJpSpSrS2fIegyd_Tf1nc_n62$s16_Differentiation7_vjpSinySf5value_S2fc8pullbacktSfFS2fcfU_SfTf1nc_n : $@convention(thin) (Float, Float) -> Float
+// CHECK:   %[[#A10:]] = partial_apply [callee_guaranteed] %[[#A9]](%0) : $@convention(thin) (Float, Float) -> Float
+// CHECK:   %[[#A11:]] = tuple (%[[#A4]] : $Float, %[[#A10]] : $@callee_guaranteed (Float) -> Float)
+// CHECK:   return %[[#A11]] : $(Float, @callee_guaranteed (Float) -> Float)
+// CHECK: } // end sil function '$s3src3baryS2fFTJrSpSr'
+
+// reverse-mode derivative of bar(_:)
+sil hidden [ossa] @$s3src3baryS2fFTJrSpSr : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float) {
+bb0(%0 : $Float):
+  // function_ref @objc sinf(_:)
+  %3 = function_ref @$sSo4sinfyS2fFTo : $@convention(c) (Float) -> Float
+  %4 = apply %3(%0) : $@convention(c) (Float) -> Float
+  // function_ref closure #1 in _vjpSin(_:)
+  %5 = function_ref @$s16_Differentiation7_vjpSinySf5value_S2fc8pullbacktSfFS2fcfU_ : $@convention(thin) (Float, Float) -> Float
+  %6 = partial_apply [callee_guaranteed] %5(%0) : $@convention(thin) (Float, Float) -> Float
+  // function_ref pullback of foo(_:)
+  %7 = function_ref @$s3src3fooyS2fFTJpSpSr : $@convention(thin) (Float, @owned @callee_guaranteed (Float) -> Float) -> Float
+  %8 = partial_apply [callee_guaranteed] %7(%6) : $@convention(thin) (Float, @owned @callee_guaranteed (Float) -> Float) -> Float
+  // function_ref pullback of bar(_:)
+  %9 = function_ref @$s3src3baryS2fFTJpSpSr : $@convention(thin) (Float, @owned @callee_guaranteed (Float) -> Float) -> Float
+  %10 = partial_apply [callee_guaranteed] %9(%8) : $@convention(thin) (Float, @owned @callee_guaranteed (Float) -> Float) -> Float
+  %11 = tuple (%4, %10)
+  return %11
+} // end sil function '$s3src3baryS2fFTJrSpSr'
+
+// CHECK: // specialized pullback of bar(_:)
+// CHECK: sil private [ossa] @$s3src3baryS2fFTJpSpSr22$s3src3fooyS2fFTJpSpSrS2fIegyd_Tf1nc_n62$s16_Differentiation7_vjpSinySf5value_S2fc8pullbacktSfFS2fcfU_SfTf1nc_n : $@convention(thin) (Float, Float) -> Float {
+// CHECK: bb0(%0 : $Float, %1 : $Float):
+// CHECK:   %[[#B10:]] = function_ref @$s3src3fooyS2fFTJpSpSr62$s16_Differentiation7_vjpSinySf5value_S2fc8pullbacktSfFS2fcfU_SfTf1nc_n : $@convention(thin) (Float, Float) -> Float
+// CHECK:   %[[#B11:]] = apply %[[#B10]](%0, %1) : $@convention(thin) (Float, Float) -> Float
+// CHECK:   return %[[#B11]] : $Float
+// CHECK: } // end sil function '$s3src3baryS2fFTJpSpSr22$s3src3fooyS2fFTJpSpSrS2fIegyd_Tf1nc_n62$s16_Differentiation7_vjpSinySf5value_S2fc8pullbacktSfFS2fcfU_SfTf1nc_n'
+
+// pullback of bar(_:)
+sil private [ossa] @$s3src3baryS2fFTJpSpSr : $@convention(thin) (Float, @owned @callee_guaranteed (Float) -> Float) -> Float {
+bb0(%0 : $Float, %1 : @owned $@callee_guaranteed (Float) -> Float):
+  %2 = apply %1(%0) : $@callee_guaranteed (Float) -> Float
+  destroy_value %1
+  return %2
+} // end sil function '$s3src3baryS2fFTJpSpSr'
+
+// CHECK: // specialized pullback of foo(_:)
+// CHECK: sil private [ossa] @$s3src3fooyS2fFTJpSpSr62$s16_Differentiation7_vjpSinySf5value_S2fc8pullbacktSfFS2fcfU_SfTf1nc_n : $@convention(thin) (Float, Float) -> Float {
+// CHECK: bb0(%0 : $Float, %1 : $Float):
+// CHECK:   %[[#C2:]] = function_ref @$s16_Differentiation7_vjpSinySf5value_S2fc8pullbacktSfFS2fcfU_ : $@convention(thin) (Float, Float) -> Float
+// CHECK:   %[[#C7:]] = apply %[[#C2]](%0, %1) : $@convention(thin) (Float, Float) -> Float
+// CHECK:   return %[[#C7]] : $Float
+// CHECK: } // end sil function '$s3src3fooyS2fFTJpSpSr62$s16_Differentiation7_vjpSinySf5value_S2fc8pullbacktSfFS2fcfU_SfTf1nc_n'
+
+// pullback of foo(_:)
+sil private [ossa] @$s3src3fooyS2fFTJpSpSr : $@convention(thin) (Float, @owned @callee_guaranteed (Float) -> Float) -> Float {
+bb0(%0 : $Float, %1 : @owned $@callee_guaranteed (Float) -> Float):
+  %2 = apply %1(%0) : $@callee_guaranteed (Float) -> Float
+  destroy_value %1
+  return %2
+} // end sil function '$s3src3fooyS2fFTJpSpSr'
+
+// closure #1 in _vjpSin(_:)
+sil shared [ossa] @$s16_Differentiation7_vjpSinySf5value_S2fc8pullbacktSfFS2fcfU_ : $@convention(thin) (Float, Float) -> Float {
+bb0(%0 : $Float, %1 : @closureCapture $Float):
+  // function_ref @objc cosf(_:)
+  %2 = function_ref @$sSo4cosfyS2fFTo : $@convention(c) (Float) -> Float
+  %3 = apply %2(%1) : $@convention(c) (Float) -> Float
+  %4 = struct_extract %0, #Float._value
+  %5 = struct_extract %3, #Float._value
+  %6 = builtin "fmul_FPIEEE32"(%4, %5) : $Builtin.FPIEEE32
+  %7 = struct $Float (%6)
+  return %7
+} // end sil function '$s16_Differentiation7_vjpSinySf5value_S2fc8pullbacktSfFS2fcfU_'
+
+sil @$sSo4cosfyS2fFTo : $@convention(c) (Float) -> Float
+sil @$sSo4sinfyS2fFTo : $@convention(c) (Float) -> Float

--- a/test/SILOptimizer/closure_specialization.sil
+++ b/test/SILOptimizer/closure_specialization.sil
@@ -364,10 +364,10 @@ bb4:
 // CHECK-LABEL: sil shared [noinline] [ossa] @$s4main5inneryys5Int32Vz_yADctF25closure_with_box_argumentxz_Bi32__lXXTf1nc_n : $@convention(thin) (@inout Builtin.Int32, @owned <τ_0_0> { var τ_0_0 } <Builtin.Int32>) -> ()
 // CHECK: bb0
 // CHECK: [[FN:%.*]] = function_ref @closure_with_box_argument
-// CHECK: [[PARTIAL:%.*]] = partial_apply [[FN]](%1)
-// CHECK: [[C:%.*]] = copy_value [[PARTIAL]]
+// CHECK: [[C1:%.*]] = copy_value %1
 // CHECK: [[ARG:%.*]] = load [trivial] %0
-// CHECK: apply [[C]]([[ARG]])
+// CHECK: [[C2:%.*]] = copy_value [[C1]]
+// CHECK: apply [[FN]]([[ARG]], [[C2]])
 
 // CHECK-LABEL: {{.*}} @$s4main5inneryys5Int32Vz_yADctF
 sil hidden [ossa] [noinline] @$s4main5inneryys5Int32Vz_yADctF : $@convention(thin) (@inout Builtin.Int32, @owned @callee_owned (Builtin.Int32) -> ()) -> () {
@@ -567,7 +567,7 @@ bb0(%0 : @guaranteed $@noescape @callee_guaranteed () -> ()):
 // CHECK:   [[PA:%.*]] = partial_apply [callee_guaranteed] [[F]]([[ARG]]) : $@convention(thin) (Int) -> ()
 // CHECK:   [[E:%.*]] = convert_escape_to_noescape [[PA]] : $@callee_guaranteed () -> () to $@noescape @callee_guaranteed () -> ()
 // CHECK:   [[BB:%.*]] = begin_borrow [[E]]
-// CHECK:   apply [[BB]]() : $@noescape @callee_guaranteed () -> ()
+// CHECK:   apply [[F]]([[ARG]]) : $@convention(thin) (Int) -> ()
 // CHECK:   destroy_value [[E]]
 // CHECK:   destroy_value [[PA]]
 // CHECK:   return
@@ -1019,9 +1019,8 @@ bb0(%0 : $Int):
 }
 
 // CHECK-LABEL: sil shared [ossa] @$s20need_borrow_argument15pointer_and_intSiTf1c_n :
-// CHECK:         [[P:%.*]] = partial_apply
-// CHECK:         [[BB:%.*]] = begin_borrow [[P]]
-// CHECK:         apply [[BB]](undef)
+// CHECK:         [[F:%.*]] = function_ref @pointer_and_int
+// CHECK:         apply [[F]](undef, %0)
 // CHECK-LABEL: } // end sil function '$s20need_borrow_argument15pointer_and_intSiTf1c_n'
 sil [ossa] @need_borrow_argument : $@convention(thin) (@guaranteed @callee_guaranteed (UnsafeRawBufferPointer) -> ()) -> () {
 bb0(%2 : @closureCapture @guaranteed $@callee_guaranteed (UnsafeRawBufferPointer) -> ()):

--- a/test/SILOptimizer/closure_specialization_consolidated.sil
+++ b/test/SILOptimizer/closure_specialization_consolidated.sil
@@ -512,7 +512,7 @@ bb0(%0 : @unowned $Builtin.NativeObject, %1 : $Builtin.Int32, %2 : @owned $Built
 // CHECK: [[FUN:%.*]] = function_ref @large_closure_callee : $@convention(thin) (Builtin.NativeObject, Builtin.Int32, @owned Builtin.NativeObject, @guaranteed Builtin.NativeObject, Builtin.NativeObject, Builtin.Int32, @owned Builtin.NativeObject, @guaranteed Builtin.NativeObject) -> ()
 // CHECK: [[CLOSURE:%.*]] = partial_apply [[FUN]](
 // CHECK: [[C:%.*]] = copy_value [[CLOSURE]]
-// CHECK: apply [[C]](
+// CHECK: apply [[FUN]](
 
 // CHECK-LABEL: sil shared [ossa] @$s18owned_apply_callee014small_closure_C0Tf1cnnnn_n : $@convention(thin) (Builtin.NativeObject, Builtin.Int32, @owned Builtin.NativeObject, @guaranteed Builtin.NativeObject) -> () {
 // CHECK: bb0
@@ -536,7 +536,7 @@ bb0(%0 : @owned $@callee_owned (Builtin.NativeObject, Builtin.Int32, @owned Buil
 // CHECK: [[CLOSURE:%.*]] = partial_apply [[FUN]](
 // CHECK: [[BB:%.*]] = begin_borrow [[CLOSURE]]
 // CHECK: [[C:%.*]] = copy_value [[BB]]
-// CHECK: apply [[C]](
+// CHECK: apply [[FUN]](
 // CHECK: destroy_value [[CLOSURE]]
 
 // CHECK-LABEL: sil shared [ossa] @$s23guaranteed_apply_callee014small_closure_C0Tf1cnnnn_n : $@convention(thin) (Builtin.NativeObject, Builtin.Int32, @owned Builtin.NativeObject, @guaranteed Builtin.NativeObject) -> () {

--- a/test/SILOptimizer/closure_specialization_nested.sil
+++ b/test/SILOptimizer/closure_specialization_nested.sil
@@ -1,0 +1,125 @@
+// RUN: %target-sil-opt -sil-print-types -enable-sil-verify-all -closure-specialization %s | %FileCheck %s
+
+// The SIL corresponds to the following Swift source:
+//
+// func wrapper0(_ x: Float) -> ((Float) -> Float) {
+//   func closure0(_ t: Float) -> Float {
+//     return t * x
+//   }
+//   return closure0
+// }
+//
+// func wrapper1(_ x: Float) -> ((Float) -> Float) {
+//   let closure0 = wrapper0(x)
+//   func closure1(_ t: Float) -> Float {
+//     return closure0(t)
+//   }
+//   return closure1
+// }
+//
+// func wrapper2(_ x: Float) -> ((Float) -> Float) {
+//   let closure1 = wrapper1(x)
+//   func closure2(_ t: Float) -> Float {
+//     return closure1(t)
+//   }
+//   return closure2
+// }
+//
+// public func caller(_ x: Float, _ y: Float) -> Float {
+//   let closure2 = wrapper2(x)
+//   return callee(y, closure2)
+// }
+//
+// @inline(never)
+// func callee(_ y: Float, _ closure: (Float) -> Float) -> Float {
+//   return closure(y)
+// }
+
+sil_stage canonical
+
+import Builtin
+import Swift
+
+// CHECK-LABEL: {{^}}// caller(_:_:)
+// CHECK:       sil [ossa] @$s7closure6calleryS2f_SftF : $@convention(thin) (Float, Float) -> Float {
+// CHECK:       bb0(%0 : $Float, %1 : $Float):
+// CHECK:         %[[#A8:]] = function_ref @$s7closure6calleeyS2f_S2fXEtF43$s7closure8wrapper2yS2fcSfF8closure2L_yS2fFS2fIegyd_Tf1nc_n020$s7closure8wrapper1yde13F8closure1L_yG1FS2fIegyd_Tf1nc_n020$s7closure8wrapper0yde13F8closure0L_yG1FSfTf1nc_n : $@convention(thin) (Float, Float) -> Float
+// CHECK-NEXT:    %[[#A9:]] = apply %[[#A8]](%1, %0) : $@convention(thin) (Float, Float) -> Float
+// CHECK-NEXT:    return %[[#A9]] : $Float
+// CHECK-NEXT:  } // end sil function '$s7closure6calleryS2f_SftF'
+
+// caller(_:_:)
+sil [ossa] @$s7closure6calleryS2f_SftF : $@convention(thin) (Float, Float) -> Float {
+bb0(%0 : $Float, %1 : $Float):
+  // function_ref closure0 #1 (_:) in wrapper0(_:)
+  %7 = function_ref @$s7closure8wrapper0yS2fcSfF8closure0L_yS2fF : $@convention(thin) (Float, Float) -> Float
+  %8 = partial_apply [callee_guaranteed] %7(%0) : $@convention(thin) (Float, Float) -> Float
+  // function_ref closure1 #1 (_:) in wrapper1(_:)
+  %10 = function_ref @$s7closure8wrapper1yS2fcSfF8closure1L_yS2fF : $@convention(thin) (Float, @guaranteed @callee_guaranteed (Float) -> Float) -> Float
+  %11 = partial_apply [callee_guaranteed] %10(%8) : $@convention(thin) (Float, @guaranteed @callee_guaranteed (Float) -> Float) -> Float
+  // function_ref closure2 #1 (_:) in wrapper2(_:)
+  %13 = function_ref @$s7closure8wrapper2yS2fcSfF8closure2L_yS2fF : $@convention(thin) (Float, @guaranteed @callee_guaranteed (Float) -> Float) -> Float
+  %14 = partial_apply [callee_guaranteed] %13(%11) : $@convention(thin) (Float, @guaranteed @callee_guaranteed (Float) -> Float) -> Float
+  %16 = convert_escape_to_noescape %14 to $@noescape @callee_guaranteed (Float) -> Float
+  // function_ref callee(_:_:)
+  %17 = function_ref @$s7closure6calleeyS2f_S2fXEtF : $@convention(thin) (Float, @guaranteed @noescape @callee_guaranteed (Float) -> Float) -> Float
+  %18 = apply %17(%1, %16) : $@convention(thin) (Float, @guaranteed @noescape @callee_guaranteed (Float) -> Float) -> Float
+  destroy_value %16
+  destroy_value %14
+  return %18
+} // end sil function '$s7closure6calleryS2f_SftF'
+
+// CHECK-LABEL: {{^}}// specialized callee(_:_:)
+// CHECK:       sil private [ossa] @$s7closure6calleeyS2f_S2fXEtF43$s7closure8wrapper2yS2fcSfF8closure2L_yS2fFS2fIegyd_Tf1nc_n020$s7closure8wrapper1yde13F8closure1L_yG1FS2fIegyd_Tf1nc_n020$s7closure8wrapper0yde13F8closure0L_yG1FSfTf1nc_n : $@convention(thin) (Float, Float) -> Float {
+// CHECK:       bb0(%0 : $Float, %1 : $Float):
+// CHECK:         %[[#B16:]] = function_ref @$s7closure8wrapper2yS2fcSfF8closure2L_yS2fF43$s7closure8wrapper1yS2fcSfF8closure1L_yS2fFS2fIegyd_Tf1nc_n020$s7closure8wrapper0yef13F8closure0L_yH1FSfTf1nc_n : $@convention(thin) (Float, Float) -> Float
+// CHECK-NEXT:    %[[#B17:]] = apply %[[#B16]](%0, %1) : $@convention(thin) (Float, Float) -> Float
+// CHECK:         return %[[#B17]] : $Float
+// CHECK-NEXT:  } // end sil function '$s7closure6calleeyS2f_S2fXEtF43$s7closure8wrapper2yS2fcSfF8closure2L_yS2fFS2fIegyd_Tf1nc_n020$s7closure8wrapper1yde13F8closure1L_yG1FS2fIegyd_Tf1nc_n020$s7closure8wrapper0yde13F8closure0L_yG1FSfTf1nc_n'
+
+// callee(_:_:)
+sil private [ossa] @$s7closure6calleeyS2f_S2fXEtF : $@convention(thin) (Float, @guaranteed @noescape @callee_guaranteed (Float) -> Float) -> Float {
+bb0(%0 : $Float, %1 : @guaranteed $@noescape @callee_guaranteed (Float) -> Float):
+  %4 = apply %1(%0) : $@noescape @callee_guaranteed (Float) -> Float
+  return %4
+} // end sil function '$s7closure6calleeyS2f_S2fXEtF'
+
+// CHECK-LABEL: {{^}}// specialized closure2 #1 (_:) in wrapper2(_:)
+// CHECK:       sil private [ossa] @$s7closure8wrapper2yS2fcSfF8closure2L_yS2fF43$s7closure8wrapper1yS2fcSfF8closure1L_yS2fFS2fIegyd_Tf1nc_n020$s7closure8wrapper0yef13F8closure0L_yH1FSfTf1nc_n : $@convention(thin) (Float, Float) -> Float {
+// CHECK:       bb0(%0 : $Float, %1 : $Float):
+// CHECK:         %[[#C12:]] = function_ref @$s7closure8wrapper1yS2fcSfF8closure1L_yS2fF43$s7closure8wrapper0yS2fcSfF8closure0L_yS2fFSfTf1nc_n : $@convention(thin) (Float, Float) -> Float
+// CHECK-NEXT:    %[[#C13:]] = apply %[[#C12]](%0, %1) : $@convention(thin) (Float, Float) -> Float
+// CHECK:         return %[[#C13]] : $Float
+// CHECK-NEXT:  } // end sil function '$s7closure8wrapper2yS2fcSfF8closure2L_yS2fF43$s7closure8wrapper1yS2fcSfF8closure1L_yS2fFS2fIegyd_Tf1nc_n020$s7closure8wrapper0yef13F8closure0L_yH1FSfTf1nc_n'
+
+// closure2 #1 (_:) in wrapper2(_:)
+sil private [ossa] @$s7closure8wrapper2yS2fcSfF8closure2L_yS2fF : $@convention(thin) (Float, @guaranteed @callee_guaranteed (Float) -> Float) -> Float {
+bb0(%0 : $Float, %1 : @closureCapture @guaranteed $@callee_guaranteed (Float) -> Float):
+  %4 = apply %1(%0) : $@callee_guaranteed (Float) -> Float
+  return %4
+} // end sil function '$s7closure8wrapper2yS2fcSfF8closure2L_yS2fF'
+
+// CHECK-LABEL: {{^}}// specialized closure1 #1 (_:) in wrapper1(_:)
+// CHECK:       sil private [ossa] @$s7closure8wrapper1yS2fcSfF8closure1L_yS2fF43$s7closure8wrapper0yS2fcSfF8closure0L_yS2fFSfTf1nc_n : $@convention(thin) (Float, Float) -> Float {
+// CHECK:       bb0(%0 : $Float, %1 : $Float):
+// CHECK:         %[[#D2:]] = function_ref @$s7closure8wrapper0yS2fcSfF8closure0L_yS2fF : $@convention(thin) (Float, Float) -> Float
+// CHECK:         %[[#D8:]] = apply %[[#D2]](%0, %1) : $@convention(thin) (Float, Float) -> Float
+// CHECK:         return %[[#D8]] : $Float
+// CHECK-NEXT:  } // end sil function '$s7closure8wrapper1yS2fcSfF8closure1L_yS2fF43$s7closure8wrapper0yS2fcSfF8closure0L_yS2fFSfTf1nc_n'
+
+// closure1 #1 (_:) in wrapper1(_:)
+sil private [ossa] @$s7closure8wrapper1yS2fcSfF8closure1L_yS2fF : $@convention(thin) (Float, @guaranteed @callee_guaranteed (Float) -> Float) -> Float {
+bb0(%0 : $Float, %1 : @closureCapture @guaranteed $@callee_guaranteed (Float) -> Float):
+  %4 = apply %1(%0) : $@callee_guaranteed (Float) -> Float
+  return %4
+} // end sil function '$s7closure8wrapper1yS2fcSfF8closure1L_yS2fF'
+
+// closure0 #1 (_:) in wrapper0(_:)
+sil private [ossa] @$s7closure8wrapper0yS2fcSfF8closure0L_yS2fF : $@convention(thin) (Float, Float) -> Float {
+bb0(%0 : $Float, %1 : @closureCapture $Float):
+  %4 = struct_extract %0, #Float._value
+  %5 = struct_extract %1, #Float._value
+  %6 = builtin "fmul_FPIEEE32"(%4, %5) : $Builtin.FPIEEE32
+  %7 = struct $Float (%6)
+  return %7
+} // end sil function '$s7closure8wrapper0yS2fcSfF8closure0L_yS2fF'

--- a/test/SILOptimizer/closure_specialization_simple.sil
+++ b/test/SILOptimizer/closure_specialization_simple.sil
@@ -63,8 +63,8 @@ sil @simple_partial_apply_caller_decl : $@convention(thin) (@owned @callee_owned
 // CHECK-LABEL: sil shared [ossa] @$s36simple_multiple_partial_apply_caller19closure_with_stringSSTf1cC0_n : $@convention(thin) (@owned String) -> Builtin.Int1 {
 // %0                                             // user: %2
 // CHECK:         %1 = function_ref @closure_with_string : $@convention(thin) (Builtin.Int1, @guaranteed String) -> Builtin.Int1
-// CHECK:         %2 = partial_apply %1(%0) : $@convention(thin) (Builtin.Int1, @guaranteed String) -> Builtin.Int1
-// CHECK:         %3 = copy_value %2
+// CHECK:         [[P:%.*]] = partial_apply %1(%0) : $@convention(thin) (Builtin.Int1, @guaranteed String) -> Builtin.Int1
+// CHECK:         copy_value [[P]]
 // CHECK:         br bb1
 // CHECK:       } // end sil function '$s36simple_multiple_partial_apply_caller19closure_with_stringSSTf1cC0_n'
 sil [ossa] @simple_multiple_partial_apply_caller : $@convention(thin) (@owned @callee_owned (Builtin.Int1) -> Builtin.Int1, @owned @callee_owned (Builtin.Int1) -> Builtin.Int1) -> Builtin.Int1 {

--- a/test/SILOptimizer/closure_specialize_loop.swift
+++ b/test/SILOptimizer/closure_specialize_loop.swift
@@ -37,7 +37,11 @@ public func testit(c: @escaping () -> Bool) {
 //       kind=FunctionSignatureSpecializationParamKind, index=0
 //       kind=FunctionSignatureSpecializationParamPayload, text="$s4test10ExpressionO8contains5whereS3bXE_tFSbACXEfU_S2bXEfU_36$s4test12IndirectEnumVACycfcS2bXEfU_Tf3npf_n"
 //
-// CHECK-LABEL: $s23closure_specialize_loop10ExpressionO8contains5whereS3bXE_tFSbACXEfU_S2bXEfU_012$s23closure_b7_loop10d44O8contains5whereS3bXE_tFSbACXEfU_S2bXEfU_012g13_b7_loop10d44ijk2_tlm2U_no52U_012g30_B34_loop12IndirectEnumVACycfcnO10U_Tf3npf_nY2_nTf3npf_n
+
+// FIXME: the test becomes now failing since the ClosureSpecialization pass does all
+// the optimizations w/o CapturePropagation involved for this particular case now.
+// Need to design a new test case for ensuring that ClosureSpecialization/CapturePropagation optimization loop is converging.
+// FIXME-LABEL: $s23closure_specialize_loop10ExpressionO8contains5whereS3bXE_tFSbACXEfU_S2bXEfU_012$s23closure_b7_loop10d44O8contains5whereS3bXE_tFSbACXEfU_S2bXEfU_012g13_b7_loop10d44ijk2_tlm2U_no52U_012g30_B34_loop12IndirectEnumVACycfcnO10U_Tf3npf_nY2_nTf3npf_n
 // ---> function signature specialization
 //     <Arg[1] = [Constant Propagated Function : function signature specialization
 //                <Arg[1] = [Constant Propagated Function : function signature specialization


### PR DESCRIPTION
Enhance both ClosureSpecialization and AutoDiffClosureSpecialization passes to specialize chains of `partial_apply`s that capture each other, instead of stopping after the outermost closure.

Whether a closure gets specialized depends on it being fully applied in the callee. In a chain of nested closures, only the least-nested one is fully applied at first; specializing it exposes the next. This pattern is common in AutoDiff pullbacks (see `pb_bar` -> `pb_foo` -> `pb_sin` in test/AutoDiff/SILOptimizer/closure_specialization/single_bb_nested.sil) and in plain nested capturing closures (see `wrapper2` -> `wrapper1` -> `wrapper0` in test/SILOptimizer/closure_specialization_nested.sil).

This patch introduces the following logic.

1. Fold `partial_apply`+`apply` after `partial_apply` movement to the specialized callee. Previously, it was expected that SILCombiner does this job. Do the fold early to allow further specialization rounds since specialization is only happening when full apply in callee is detected.

2. Run specialization logic recursively for the callee just after it is specialized. This handles nested closures chains.

3. Run up to 5 rounds of ClosureSpecialization pass while changes keep occurring (mirroring the AutoDiffClosureSpecialization pass)

**Note 1.** One CHECK in `closure_specialize_loop.swift` is now a FIXME. The enhanced ClosureSpecialization pass handles that test case without the ClosureSpecialization/CapturePropagation ping-pong it was guarding.

**Note 2.** This patch is a prerequisite for a subsequent patch allowing for more AutoDiff VJP inlining decisions.