### PR TITLE
[AutoDiff] Run AutoDiff Closure Specialization for explicit VJPs

### DIFF
--- a/lib/SIL/Utils/SILBridging.cpp
+++ b/lib/SIL/Utils/SILBridging.cpp
@@ -341,11 +341,9 @@ bool BridgedFunction::isAutodiffVJP() const {
 
   // Best-effort attempt to detect an explicit VJP
   if (auto *afd = getFunction()->getDeclRef().getAbstractFunctionDecl()) {
-    for (auto *attr : afd->getAttrs()) {
-      if (auto *derivativeAttr = dyn_cast<DerivativeAttr>(attr)) {
-        return derivativeAttr->getDerivativeKind() ==
-               AutoDiffDerivativeFunctionKind::VJP;
-      }
+    if (auto *derivativeAttr = afd->getAttrs().getAttribute<DerivativeAttr>()) {
+      return derivativeAttr->getDerivativeKind() ==
+             AutoDiffDerivativeFunctionKind::VJP;
     }
   }
 

--- a/lib/SIL/Utils/SILBridging.cpp
+++ b/lib/SIL/Utils/SILBridging.cpp
@@ -339,6 +339,16 @@ bool BridgedFunction::isAutodiffVJP() const {
     }
   }
 
+  // Best-effort attempt to detect an explicit VJP
+  if (auto *afd = getFunction()->getDeclRef().getAbstractFunctionDecl()) {
+    for (auto *attr : afd->getAttrs()) {
+      if (auto *derivativeAttr = dyn_cast<DerivativeAttr>(attr)) {
+        return derivativeAttr->getDerivativeKind() ==
+               AutoDiffDerivativeFunctionKind::VJP;
+      }
+    }
+  }
+
   return false;
 }
 

--- a/test/AutoDiff/validation-test/closure_specialization/single_bb1.swift
+++ b/test/AutoDiff/validation-test/closure_specialization/single_bb1.swift
@@ -15,6 +15,7 @@
 // RUN: cat %t/out.sil | %FileCheck %s --check-prefix=CHECK1
 // RUN: cat %t/out.sil | %FileCheck %s --check-prefix=CHECK2
 // RUN: cat %t/out.sil | %FileCheck %s --check-prefix=CHECK3
+// RUN: cat %t/out.sil | %FileCheck %s --check-prefix=CHECK4
 
 import DifferentiationUnittest
 import StdlibUnittest
@@ -118,6 +119,54 @@ AutoDiffClosureSpecSingleBBTests.testWithLeakChecking("Test3") {
         expectEqual((10000 * der3).rounded(), (10000 * (-(tan(Float(z)) * tan(Float(z)) + 1))).rounded())
       }
     }
+  }
+}
+
+public func test4(_ x: Float) -> Float {
+  return sin(x) * cos(x)
+}
+
+@derivative(of: test4)
+public func test4Vjp(_ x: Float) -> (value: Float, pullback: (Float) -> Float) {
+  let vjpSinRes = valueWithPullback(at: x, of: sin)
+  let vjpCosRes = valueWithPullback(at: x, of: cos)
+  let pbSin = vjpSinRes.1
+  let pbCos = vjpCosRes.1
+  func pullback(t: Float) -> Float {
+    return pbSin(t) * cos(x) + sin(x) * pbCos(t)
+  }
+  return (value: test4(x), pullback)
+}
+
+AutoDiffClosureSpecSingleBBTests.testWithLeakChecking("Test4") {
+  // CHECK4-LABEL: {{^}}// test4Vjp(_:)
+  // CHECK4-NEXT:  // Isolation: unspecified
+  // CHECK4-NEXT:  sil @$s3out8test4VjpySf5value_S2fc8pullbacktSfF : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float) {
+  // CHECK4:         %[[#D10:]] = function_ref @$s3out8test4VjpySf5value_S2fc8pullbacktSfFADL_1tS2f_tF62$s16_Differentiation7_vjpSinySf5value_S2fc8pullbacktSfFS2fcfU_Sf0f1_g1_h4Cosyj1_klM2U_SfTf1ncnc_n : $@convention(thin) (Float, Float, Float, Float) -> Float
+  // CHECK4:         %[[#D11:]] = partial_apply [callee_guaranteed] %[[#D10]](%0, %0, %0) : $@convention(thin) (Float, Float, Float, Float) -> Float
+  // CHECK4:         %[[#D12:]] = tuple (%[[#]], %[[#D11]])
+  // CHECK4:         return %[[#D12]]
+  // CHECK4:       } // end sil function '$s3out8test4VjpySf5value_S2fc8pullbacktSfF'
+
+  // CHECK4-LABEL: {{^}}// reverse-mode derivative of test4
+  // CHECK4-NEXT:  // Isolation: unspecified
+  // CHECK4-NEXT:  sil [thunk] [heuristic_always_inline] @$s3out5test4yS2fFTJrSpSr : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float) {
+  // CHECK4:         %[[#E10:]] = function_ref @$s3out8test4VjpySf5value_S2fc8pullbacktSfFADL_1tS2f_tF62$s16_Differentiation7_vjpSinySf5value_S2fc8pullbacktSfFS2fcfU_Sf0f1_g1_h4Cosyj1_klM2U_SfTf1ncnc_n : $@convention(thin) (Float, Float, Float, Float) -> Float
+  // CHECK4:         %[[#E11:]] = partial_apply [callee_guaranteed] %[[#E10]](%0, %0, %0) : $@convention(thin) (Float, Float, Float, Float) -> Float
+  // CHECK4:         %[[#E12:]] = tuple (%[[#]], %[[#E11]])
+  // CHECK4:         return %[[#E12]]
+  // CHECK4:       } // end sil function '$s3out5test4yS2fFTJrSpSr'
+
+  // CHECK4-NONE:  {{^}}// pullback #1 (t:) in test4Vjp(_:)
+  // CHECK4:       {{^}}// specialized pullback #1 (t:) in test4Vjp(_:)
+  // CHECK4:       sil private @$s3out8test4VjpySf5value_S2fc8pullbacktSfFADL_1tS2f_tF62$s16_Differentiation7_vjpSinySf5value_S2fc8pullbacktSfFS2fcfU_Sf0f1_g1_h4Cosyj1_klM2U_SfTf1ncnc_n : $@convention(thin) (Float, Float, Float, Float) -> Float {
+
+  func test4Derivative(_ x: Float) -> Float {
+    return cos(x) * cos(x) - sin(x) * sin(x)
+  }
+
+  for x in -100...100 {
+    expectEqual((1000 * gradient(at: Float(x), of: test4)).rounded(), (1000 * test4Derivative(Float(x))).rounded())
   }
 }
 


### PR DESCRIPTION
Try to detect explcicit AutoDiff VJPs by looking at corresponding `AbstractFunctionDecl` and looking for a `derivative` attr with reverse-mode.

This patch resolves the following issue for explicit VJPs. The differentiability witness table contains derivative thunks calling the user-provided VJPs. Previously, ADCS was only running on thunks, not the explicit user-provided VJPs. So, if the derivative thunk got inlined somewhere before the explicit VJP call was inlined into the thunk, we failed to run ADCS for this derivative.
