### PR TITLE
[AutoDiff] Allow more VJP inlining decisions

### DIFF
--- a/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
+++ b/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
@@ -431,7 +431,7 @@ bool SILPerformanceInliner::isTupleWithAllocsOrPartialApplies(SILValue val) {
 // TODO: VJPs of differentiable functions with custom silgen names are not
 // recognized as VJPs by this function. However, this is not a hard limitation
 // and can be fixed.
-bool isFunctionAutodiffVJP(SILFunction *callee) {
+static bool isFunctionAutodiffVJP(SILFunction *callee) {
   swift::Demangle::Context Ctx;
   if (auto *Root = Ctx.demangleSymbolAsNode(callee->getName())) {
     if (auto *node = Root->findByKind(
@@ -446,6 +446,14 @@ bool isFunctionAutodiffVJP(SILFunction *callee) {
     }
   }
 
+  // Best-effort attempt to detect an explicit VJP
+  if (auto *afd = callee->getDeclRef().getAbstractFunctionDecl()) {
+    if (auto *derivativeAttr = afd->getAttrs().getAttribute<DerivativeAttr>()) {
+      return derivativeAttr->getDerivativeKind() ==
+             AutoDiffDerivativeFunctionKind::VJP;
+    }
+  }
+
   return false;
 }
 
@@ -457,13 +465,116 @@ bool isAllocator(SILFunction *callee) {
   return false;
 }
 
-bool isProfitableToInlineAutodiffVJP(SILFunction *vjp, SILFunction *caller,
-                                     InlineSelection whatToInline,
-                                     StringRef stageName) {
+// Check if we match one of the following patterns:
+// (I):
+//   %resAndPb = apply %vjp(...)
+//   (..., %pb) = destructure_tuple %resAndPb
+//   %topPb = partial_apply(..., %pb, ...)
+//   %tuple = tuple(..., %topPb)
+//   return %tuple
+// (II):
+//   %resAndPb = apply %vjp(...)
+//   %pb = tuple_extract %resAndPb, lastTupleIndex
+//   %topPb = partial_apply(..., %pb, ...)
+//   %tuple = tuple(..., %topPb)
+//   return %tuple
+// (III):
+//   %pb = apply %vjp(...)
+//   %topPb = partial_apply(..., %pb, ...)
+//   %tuple = tuple(..., %topPb)
+//   return %tuple
+static bool hasPullbackOnlyDirectUses(FullApplySite applySiteOfVJP) {
+  auto *applyOfVJP = dyn_cast<ApplyInst>(applySiteOfVJP.getInstruction());
+  if (applyOfVJP == nullptr)
+    return false;
+
+  SILValue calleePullback = nullptr;
+  if (applyOfVJP->getType().isTuple()) {
+    auto numTupleElements = applyOfVJP->getType().getNumTupleElements();
+    assert(numTupleElements > 0);
+    for (auto user : applyOfVJP->getUsers()) {
+      if (auto *tei = dyn_cast<TupleExtractInst>(user)) {
+        if (tei->getFieldIndex() + 1 == numTupleElements) {
+          calleePullback = tei;
+          break;
+        }
+      } else if (auto *dti = dyn_cast<DestructureTupleInst>(user)) {
+        calleePullback = dti->getResult(numTupleElements - 1);
+        break;
+      } else {
+        return false;
+      }
+    }
+  } else {
+    calleePullback = applyOfVJP;
+  }
+  assert(calleePullback != nullptr);
+  assert(calleePullback->getType().isFunction());
+
+  auto getSingleUser = [](SILValue val) -> SILInstruction * {
+    auto *use = val->getSingleUse();
+    return use ? use->getUser() : nullptr;
+  };
+
+  auto *pai = dyn_cast_or_null<PartialApplyInst>(getSingleUser(calleePullback));
+  if (!pai)
+    return false;
+
+  auto *ti = dyn_cast_or_null<TupleInst>(getSingleUser(pai));
+  if (!ti)
+    return false;
+
+  auto *ri = dyn_cast_or_null<ReturnInst>(getSingleUser(ti));
+  if (!ri)
+    return false;
+
+  return true;
+}
+
+// Treat VJP as trivial if both statements below hold.
+// 1. Callees for all full apply sites are known and are not VJPs.
+// 2. The only partial_apply is the one for top-level pullback.
+static bool isTrivialVJP(SILFunction *vjp) {
+  auto getSingleUser = [](SILValue val) -> SILInstruction * {
+    auto *use = val->getSingleUse();
+    return use ? use->getUser() : nullptr;
+  };
+
+  for (auto &bb : *vjp) {
+    for (auto &inst : bb) {
+      if (auto applySite = FullApplySite::isa(&inst)) {
+        SILFunction *callee = applySite.getCalleeFunction();
+        if (!callee)
+          return false;
+        if (isFunctionAutodiffVJP(callee))
+          return false;
+        continue;
+      }
+
+      auto *pai = dyn_cast<PartialApplyInst>(&inst);
+      if (!pai)
+        continue;
+
+      auto *ti = dyn_cast_or_null<TupleInst>(getSingleUser(pai));
+      if (!ti)
+        return false;
+
+      auto *ri = dyn_cast_or_null<ReturnInst>(getSingleUser(ti));
+      if (!ri)
+        return false;
+    }
+  }
+
+  return true;
+}
+
+static bool isProfitableToInlineAutodiffVJP(FullApplySite applySiteOfVJP,
+                                            StringRef stageName) {
+  SILFunction *caller = applySiteOfVJP.getFunction();
+  SILFunction *calleeVJP = applySiteOfVJP.getReferencedFunctionOrNull();
+  assert(calleeVJP);
+
   bool isLowLevelFunctionPassPipeline = stageName == "LowLevel,Function";
-  auto isHighLevelFunctionPassPipeline =
-      stageName == "HighLevel,Function+EarlyLoopOpt";
-  auto calleeHasControlFlow = vjp->size() > 1;
   auto isCallerVJP = isFunctionAutodiffVJP(caller);
   auto callerHasControlFlow = caller->size() > 1;
 
@@ -474,23 +585,36 @@ bool isProfitableToInlineAutodiffVJP(SILFunction *vjp, SILFunction *caller,
     return true;
   }
 
-  // If callee has control-flow it will definitely not be handled by the
-  // Autodiff closure-spec optimization. Therefore, we should consider it for
-  // inlining.
-  if (calleeHasControlFlow) {
+  // Always consider derivative thunks for inlining. It does not harm ADCS since
+  // explicit derivative is by itself subject for ADCS optimization.
+  if (calleeVJP->isThunk() == IsThunk_t::IsThunk) {
     return true;
   }
 
-  // If this is the EarlyPerfInline pass we want to have the Autodiff
-  // closure-spec optimization pass optimize VJPs in isolation before they are
-  // inlined into other VJPs.
-  if (isHighLevelFunctionPassPipeline) {
+  // Inlining of VJPs which are guaranteed to gain no optimization effect from
+  // ADCS does not harm ADCS effectiveness (we know in advance that it would not
+  // be effective). Always consider for inlining.
+  if (isTrivialVJP(calleeVJP)) {
+    return true;
+  }
+
+  // After inlining to a non-VJP caller, we can no longer run ADCS for the
+  // callee VJP. Skip inlining for now.
+  if (!isCallerVJP) {
     return false;
   }
 
-  // If this is not the EarlyPerfInline pass, VJPs should only be inlined into
-  // other VJPs that do not contain any control-flow.
-  if (!isCallerVJP || (isCallerVJP && callerHasControlFlow)) {
+  if (isCallerVJP && callerHasControlFlow) {
+    // If pullback extracted from this VJP call result is only passed to
+    // top-level pullback of caller VJP, consider this callee VJP for inlining.
+    // It does not harm ADCS effectiveness since it properly handles nested
+    // inlining by running multiple specialization rounds and immediately
+    // folding partial_apply+apply pairs in the specialized caller pullback.
+    if (hasPullbackOnlyDirectUses(applySiteOfVJP))
+      return true;
+
+    // TODO: allow inlining into VJP callers with control flow when ADCS handles
+    // this properly.
     return false;
   }
 
@@ -541,8 +665,7 @@ bool SILPerformanceInliner::isProfitableToInline(
   bool IsGeneric = AI.hasSubstitutions();
 
   if (isFunctionAutodiffVJP(Callee) &&
-      !isProfitableToInlineAutodiffVJP(Callee, AI.getFunction(), WhatToInline,
-                                       this->pm->getStageName())) {
+      !isProfitableToInlineAutodiffVJP(AI, this->pm->getStageName())) {
     return false;
   }
 

--- a/test/AutoDiff/SILOptimizer/vjp_early_inlining.swift
+++ b/test/AutoDiff/SILOptimizer/vjp_early_inlining.swift
@@ -1,0 +1,68 @@
+// REQUIRES: asserts
+
+// RUN: %target-swift-frontend -O -emit-sil -Xllvm -debug-only=sil-inliner -Xllvm -sil-print-pass-name %s -o %t.sil 2> %t.log
+
+// RUN: cat %t.log | %FileCheck %s --check-prefix=CHECK1
+// RUN: cat %t.log | %FileCheck %s --check-prefix=CHECK2
+
+// RUN: cat %t.sil | %FileCheck %s --check-prefix=CHECK3
+
+import _Differentiation
+
+/// Only top-level pullback => VJP is assumed trivial in terms of VJP inlining decision taking
+@differentiable(reverse)
+func trivial(_ x: Float) -> Float { x * x }
+
+public func nonVjpCallerOfTrivial(_ x: Float) -> Float {
+    gradient(at: x, of: trivial)
+}
+
+// CHECK1:       Run #[[#]], stage MidLevel,Function, pass [[#]]: PerfInliner (inline), Function: $s4main21nonVjpCallerOfTrivialyS2fF
+// CHECK1:       Inlining calls into $s4main21nonVjpCallerOfTrivialyS2fF
+// CHECK1-EMPTY:
+// CHECK1-NEXT:  Inline into caller: $s4main21nonVjpCallerOfTrivialyS2fF
+// CHECK1-NOT:   Run #[[#]], stage LowLevel,Function, pass [[#]]: PerfInliner (inline), Function: $s4main21nonVjpCallerOfTrivialyS2fF
+// CHECK1:           decision {{.*}} $s4main7trivialyS2fFTJrSpSr
+// CHECK1-NEXT:  "reverse-mode derivative of main.trivial(_:)" inlined into "main.nonVjpCallerOfTrivial(_:)"
+
+
+@differentiable(reverse)
+@inline(never)
+func mul2(_ x: Float, _ y: Float) -> Float { x * y }
+
+/// Make VJP of `square` non-trivial by forcing call to `@inline(never)` VJP of `mul2`
+/// in order to test further inlining decision logic.
+@differentiable(reverse)
+func square(_ x: Float) -> Float { mul2(x, x) }
+
+@differentiable(reverse)
+public func vjpCallerWithControlFlow(_ x: Float) -> Float {
+    let y: Float
+    if x > 0 {
+      y = 37
+    } else {
+      y = 42
+    }
+    return y * square(x)
+}
+
+// CHECK2:       Run #[[#]], stage HighLevel,Function+EarlyLoopOpt, pass [[#]]: EarlyPerfInliner (early-inline), Function: $s4main24vjpCallerWithControlFlowyS2fFTJrSpSr
+// CHECK2:       Inlining calls into $s4main24vjpCallerWithControlFlowyS2fFTJrSpSr
+// CHECK2-EMPTY:
+// CHECK2-NEXT:  Inline into caller: $s4main24vjpCallerWithControlFlowyS2fFTJrSpSr
+// CHECK2-NOT:   Run #[[#]], stage MidLevel,Function, pass [[#]]: PerfInliner (inline), Function: $s4main24vjpCallerWithControlFlowyS2fFTJrSpSr
+// CHECK2-NOT:   Run #[[#]], stage LowLevel,Function, pass [[#]]: PerfInliner (inline), Function: $s4main24vjpCallerWithControlFlowyS2fFTJrSpSr
+// CHECK2:           decision {{.*}} $s4main6squareyS2fFTJrSpSr
+// CHECK2-NEXT:  "reverse-mode derivative of main.square(_:)" inlined into "reverse-mode derivative of main.vjpCallerWithControlFlow(_:)"
+
+
+/// Ensure that early inlining of VJP of `square` into VJP of `vjpCallerWithControlFlow` unblocks ADCS and
+/// no nested pullback closure is passed to the specialized pullback of `vjpCallerWithControlFlow`
+
+// CHECK3:      // reverse-mode derivative of vjpCallerWithControlFlow(_:)
+// CHECK3-NEXT: // Isolation: unspecified
+// CHECK3-NEXT: sil @$s4main24vjpCallerWithControlFlowyS2fFTJrSpSr : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float) {
+// CHECK3:        // function_ref specialized pullback of vjpCallerWithControlFlow(_:)
+// CHECK3-NEXT:   %[[#F:]] = function_ref @$s4main24vjpCallerWithControlFlowyS2fFTJpSpSr26$s4main6squareyS2fFTJpSpSrS3fIegydd_026$sSf16_DifferentiationE12_b44Multiply3lhs3rhsSf5value_Sf_SftSfc8pullbacktr1_s5FZSf_S6SfcfU_S2fTf1nncc_n013$s4main4mul2yh1_si3SSpK0S3fIegydd_Tf1nncnn_nADS2fTf1nnnnc_n : $@convention(thin) (Float, @owned _AD__$s4main24vjpCallerWithControlFlowyS2fF_bb3__Pred__src_0_wrt_0, Float, Float, Float, Float) -> Float
+// CHECK3-NEXT:   partial_apply [callee_guaranteed] %[[#F]](%[[#]], %[[#]], %[[#]], %0, %0) : $@convention(thin) (Float, @owned _AD__$s4main24vjpCallerWithControlFlowyS2fF_bb3__Pred__src_0_wrt_0, Float, Float, Float, Float) -> Float
+// CHECK3:      } // end sil function '$s4main24vjpCallerWithControlFlowyS2fFTJrSpSr'

--- a/test/AutoDiff/SILOptimizer/vjp_early_inlining.swift
+++ b/test/AutoDiff/SILOptimizer/vjp_early_inlining.swift
@@ -63,6 +63,6 @@ public func vjpCallerWithControlFlow(_ x: Float) -> Float {
 // CHECK3-NEXT: // Isolation: unspecified
 // CHECK3-NEXT: sil @$s4main24vjpCallerWithControlFlowyS2fFTJrSpSr : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float) {
 // CHECK3:        // function_ref specialized pullback of vjpCallerWithControlFlow(_:)
-// CHECK3-NEXT:   %[[#F:]] = function_ref @$s4main24vjpCallerWithControlFlowyS2fFTJpSpSr26$s4main6squareyS2fFTJpSpSrS3fIegydd_026$sSf16_DifferentiationE12_b44Multiply3lhs3rhsSf5value_Sf_SftSfc8pullbacktr1_s5FZSf_S6SfcfU_S2fTf1nncc_n013$s4main4mul2yh1_si3SSpK0S3fIegydd_Tf1nncnn_nADS2fTf1nnnnc_n : $@convention(thin) (Float, @owned _AD__$s4main24vjpCallerWithControlFlowyS2fF_bb3__Pred__src_0_wrt_0, Float, Float, Float, Float) -> Float
+// CHECK3-NEXT:   %[[#F:]] = function_ref @$s4main24vjpCallerWithControlFlowyS2fFTJpSpSr26$s4main6squareyS2fFTJpSpSrS3fIegydd_026$sSf16_DifferentiationE12_b44Multiply3lhs3rhsSf5value_Sf_SftSfc8pullbacktr1_s5FZSf_S6SfcfU_S2fTf1nnEE_n013$s4main4mul2yh1_si3SSpK0S3fIegydd_Tf1nnEnn_nADS2fTf1nnnnE_n : $@convention(thin) (Float, @owned _AD__$s4main24vjpCallerWithControlFlowyS2fF_bb3__Pred__src_0_wrt_0, Float, Float, Float, Float) -> Float
 // CHECK3-NEXT:   partial_apply [callee_guaranteed] %[[#F]](%[[#]], %[[#]], %[[#]], %0, %0) : $@convention(thin) (Float, @owned _AD__$s4main24vjpCallerWithControlFlowyS2fF_bb3__Pred__src_0_wrt_0, Float, Float, Float, Float) -> Float
 // CHECK3:      } // end sil function '$s4main24vjpCallerWithControlFlowyS2fFTJrSpSr'

--- a/test/AutoDiff/SILOptimizer/vjp_inlining.swift
+++ b/test/AutoDiff/SILOptimizer/vjp_inlining.swift
@@ -32,8 +32,6 @@ func with_control_flow(_ x: Float) -> Float {
 func caller_of_with_control_flow(x: Float) -> Float {
     gradient(at: x, of: with_control_flow)
 }
-// CHECK-LABEL: decision {{.*}} $s12vjp_inlining17with_control_flowyS2fFTJrSpSr
-// CHECK-NEXT: "reverse-mode derivative of vjp_inlining.with_control_flow(_:)" inlined into "caller_of_with_control_flow"
 
 // =============================================================== //
 // VJPs with control-flow are inlined into VJP callers
@@ -45,6 +43,9 @@ func wrapperOnWithControlFlow(x: Float) -> Float {
 }
 // CHECK-LABEL: decision {{.*}} $s12vjp_inlining17with_control_flowyS2fFTJrSpSr
 // CHECK-NEXT: "reverse-mode derivative of vjp_inlining.with_control_flow(_:)" inlined into "reverse-mode derivative of vjp_inlining.wrapperOnWithControlFlow(x:)"
+
+// CHECK-LABEL: decision {{.*}} $s12vjp_inlining17with_control_flowyS2fFTJrSpSr
+// CHECK-NEXT: "reverse-mode derivative of vjp_inlining.with_control_flow(_:)" inlined into "caller_of_with_control_flow"
 
 // =============================================================== //
 // VJPs without control-flow are not inlined into non-VJP callers

--- a/test/AutoDiff/validation-test/closure_specialization/multi_bb_no_bte.swift
+++ b/test/AutoDiff/validation-test/closure_specialization/multi_bb_no_bte.swift
@@ -117,7 +117,7 @@ AutoDiffClosureSpecMultiBBNoBTETests.testWithLeakChecking("Test3") {
   // CHECK3:       {{^}}// reverse-mode derivative of multiply #1 (_:)
   // CHECK3-NEXT: {{^}}// Isolation: nonisolated
   // CHECK3-NEXT:  sil private @$s3outyycfU1_8multiplyL_ySfAAyycfU1_20RealPropertyWrappersL_VFTJrSpSr : $@convention(thin) (RealPropertyWrappers) -> (Float, @owned @callee_guaranteed (Float) -> RealPropertyWrappers.TangentVector) {
-  // CHECK3:         %[[#A22:]] = function_ref @$s3outyycfU1_8multiplyL_ySfAAyycfU1_20RealPropertyWrappersL_VFTJpSpSr073$sSf16_DifferentiationE12_vjpMultiply3lhs3rhsSf5value_Sf_SftSfc8pullbacktm1_n5FZSf_N6SfcfU_S2fTf1nnE_n015$s3outyycfU1_20cdE16L_V1xSfvgTJpSpSrTf1ncnn_n : $@convention(thin) (Float, Float, Float) -> RealPropertyWrappers.TangentVector
+  // CHECK3:         %[[#A22:]] = function_ref @$s3outyycfU1_8multiplyL_ySfAAyycfU1_20RealPropertyWrappersL_VFTJpSpSr015$s3outyycfU1_20cdE16L_V1xSfvgTJpSpSr073$sSf16_DifferentiationE12_vjpMultiply3lhs3rhsSf5value_Sf_SftSfc8pullbacktt1_u5FZSf_U6SfcfU_S2fTf1ncE_n : $@convention(thin) (Float, Float, Float) -> RealPropertyWrappers.TangentVector
   // CHECK3:         %[[#A23:]] = partial_apply [callee_guaranteed] %[[#A22]](%[[#]], %[[#]]) : $@convention(thin) (Float, Float, Float) -> RealPropertyWrappers.TangentVector
   // CHECK3:         %[[#A24:]] = tuple (%[[#]], %[[#A23]])
   // CHECK3:         return %[[#A24]]
@@ -125,7 +125,7 @@ AutoDiffClosureSpecMultiBBNoBTETests.testWithLeakChecking("Test3") {
 
   // CHECK3-NONE:  {{^}}// pullback of multiply
   // CHECK3:       {{^}}// specialized pullback of multiply
-  // CHECK3:       sil private @$s3outyycfU1_8multiplyL_ySfAAyycfU1_20RealPropertyWrappersL_VFTJpSpSr073$sSf16_DifferentiationE12_vjpMultiply3lhs3rhsSf5value_Sf_SftSfc8pullbacktm1_n5FZSf_N6SfcfU_S2fTf1nnE_n015$s3outyycfU1_20cdE16L_V1xSfvgTJpSpSrTf1ncnn_n : $@convention(thin) (Float, Float, Float) -> RealPropertyWrappers.TangentVector {
+  // CHECK3:       sil private @$s3outyycfU1_8multiplyL_ySfAAyycfU1_20RealPropertyWrappersL_VFTJpSpSr015$s3outyycfU1_20cdE16L_V1xSfvgTJpSpSr073$sSf16_DifferentiationE12_vjpMultiply3lhs3rhsSf5value_Sf_SftSfc8pullbacktt1_u5FZSf_U6SfcfU_S2fTf1ncE_n : $@convention(thin) (Float, Float, Float) -> RealPropertyWrappers.TangentVector {
 
   @differentiable(reverse)
   func multiply(_ s: RealPropertyWrappers) -> Float {

--- a/test/AutoDiff/validation-test/closure_specialization/single_bb2.swift
+++ b/test/AutoDiff/validation-test/closure_specialization/single_bb2.swift
@@ -33,7 +33,7 @@ AutoDiffClosureSpecSingleBBTests.testWithLeakChecking("Test4") {
   // CHECK4-LABEL: {{^}}// reverse-mode derivative of test4 #1 (_:)
   // CHECK4-NEXT: {{^}}// Isolation: nonisolated
   // CHECK4-NEXT:  sil private @$s3outyycfU_5test4L_yS2fFTJrSpSr : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float) {
-  // CHECK4:         %[[#D9:]] = function_ref @$s3outyycfU_5test4L_yS2fFTJpSpSr128$s3outyycfU_6doubleL_yS2fFTJpSpSr067$sSf16_DifferentiationE7_vjpAdd3lhs3rhsSf5value_Sf_SftSfc8pullbacktj1_k5FZSf_K6SfcfU_Tf1nc_n0c12U_6squareL_yefg7Sr073$si1_j4E12_l16Multiply3lhs3rhsn1_o1_pq1_rs1_tu2U_E7Tf1nE_nS2fTf1ncE_n : $@convention(thin) (Float, Float, Float) -> Float
+  // CHECK4:         %[[#D9:]] = function_ref @$s3outyycfU_5test4L_yS2fFTJpSpSr33$s3outyycfU_6doubleL_yS2fFTJpSpSrS3fIegydd_0c12U_6squareL_yefgH0S3fIegydd_Tf1nEE_n067$sSf16_DifferentiationE7_vjpAdd3lhs3rhsSf5value_Sf_SftSfc8pullbacktq1_r5FZSf_R6SfcfU_0jk1_l4E12_n16Multiply3lhs3rhsp1_q1_rsq1_rt1_rU2U_S2fTf1ncE_n : $@convention(thin) (Float, Float, Float) -> Float
   // CHECK4:         %[[#D10:]] = partial_apply [callee_guaranteed] %[[#D9]](%[[#]], %[[#]]) : $@convention(thin) (Float, Float, Float) -> Float
   // CHECK4:         %[[#D11:]] = tuple (%[[#]], %[[#D10]])
   // CHECK4:         return %[[#D11]]
@@ -41,7 +41,7 @@ AutoDiffClosureSpecSingleBBTests.testWithLeakChecking("Test4") {
 
   // CHECK4-NONE:  {{^}}// pullback of test4 #1 (_:)
   // CHECK4:       {{^}}// specialized pullback of test4 #1 (_:)
-  // CHECK4:       sil private @$s3outyycfU_5test4L_yS2fFTJpSpSr128$s3outyycfU_6doubleL_yS2fFTJpSpSr067$sSf16_DifferentiationE7_vjpAdd3lhs3rhsSf5value_Sf_SftSfc8pullbacktj1_k5FZSf_K6SfcfU_Tf1nc_n0c12U_6squareL_yefg7Sr073$si1_j4E12_l16Multiply3lhs3rhsn1_o1_pq1_rs1_tu2U_E7Tf1nE_nS2fTf1ncE_n : $@convention(thin) (Float, Float, Float) -> Float {
+  // CHECK4:       sil private @$s3outyycfU_5test4L_yS2fFTJpSpSr33$s3outyycfU_6doubleL_yS2fFTJpSpSrS3fIegydd_0c12U_6squareL_yefgH0S3fIegydd_Tf1nEE_n067$sSf16_DifferentiationE7_vjpAdd3lhs3rhsSf5value_Sf_SftSfc8pullbacktq1_r5FZSf_R6SfcfU_0jk1_l4E12_n16Multiply3lhs3rhsp1_q1_rsq1_rt1_rU2U_S2fTf1ncE_n : $@convention(thin) (Float, Float, Float) -> Float {
 
   @differentiable(reverse)
   func test4(_ x: Float) -> Float {


### PR DESCRIPTION
Prior to regular inlining decision logic, VJP callees have additional checks since some inlining might harm further AutoDiff Closure Specialization (ADCS) pass logic. This patch relaxes some of these restrictions, allowing more VJP inlining decisions to be taken while still not harming the ADCS optimizations.

VJP inlining decisions newly allowed:

1) potential inlining during HighLevel pass pipeline (previously - hard no);

2) derivative thunks callees to any callers;

3) trivial VJPs (no other VJPs called, only top-level pullback) to any callers;

4) any VJPs to VJP callers with control flow which only use the pullback
   from current apply site directly in their top-level pullback.

This patch also introduces best-effort attempt of detection of explicit derivatives by looking at the corresponding `AbstractFunctionDecl` and looking for a `derivative` attr with reverse-mode.
