### PR TITLE
SILGen: fix reabstraction crash for typed-throws closure into generic @out

### DIFF
--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -4547,6 +4547,48 @@ ResultPlanner::expandInnerTupleOuterIndirect(AbstractionPattern innerOrigType,
 
   auto outerSubstTupleType = dyn_cast<TupleType>(outerSubstType);
 
+  // FIXME: This entire function dispatches on whether `outerSubstType` is a
+  // tuple to decide between "single-slot injection" (optional/existential)
+  // and "parallel tuple walk". That's the wrong dimension: the abstraction
+  // pattern determines how the value is *passed*, not the substituted type.
+  // When `outerOrigType` is opaque (e.g. an archetype) the outer is a
+  // single `@out` slot regardless of whether the substituted type happens
+  // to be a tuple.
+  //
+  // The branch below handles the case where the inner result is a single
+  // tuple-typed indirect slot being injected into the outer's single opaque
+  // slot. This covers the typed-throws reabstraction patterns:
+  //  - closure returning `()` into generic `T ~> ()`
+  //    (https://github.com/swiftlang/swift/issues/77880,
+  //     https://github.com/swiftlang/swift/issues/88027)
+  //  - closure returning `(A, B, ...)` into generic `T ~> (A, B, ...)`
+  // Without it, the parallel tuple walk either under-claims (empty tuple;
+  // `AllInnerResults.empty()` assertion) or over-claims (non-empty tuple;
+  // `claimNext` on empty assertion). The fix only applies when the inner
+  // has a single unclaimed result slot matching the outer single slot; if
+  // the inner has per-element result slots (no single whole-tuple slot),
+  // the parallel walk's per-element claims remain correct.
+  //
+  // A more principled fix dispatches this whole function on
+  // `outerOrigType.isTuple()` and handles 1-to-N result-slot mappings in
+  // `planSingleIntoIndirect` (or a new helper). That's tracked separately.
+  //
+  // Exclude tuples containing pack expansions: the existing parallel walk
+  // handles them correctly (pack-expansion-aware reabstraction), and
+  // `planSingleIntoIndirect` does not — its downstream `Transform` machinery
+  // treats the slot as a single fixed-layout value and would crash on the
+  // dynamic-layout pack-expansion tuple.
+  if (outerSubstTupleType && !outerOrigType.isTuple()
+      && AllInnerResults.size() == 1
+      && !outerSubstTupleType.containsPackExpansionType()) {
+    SILResultInfo innerResult = claimNextInnerResult();
+    planSingleIntoIndirect(innerOrigType, innerSubstType,
+                           outerOrigType, outerSubstType,
+                           innerResult,
+                           outerResultAddrMV.getLValueAddress());
+    return;
+  }
+
   // If the outer type is not a tuple, it must be optional.
   if (!outerSubstTupleType) {
     auto outerResultAddr = outerResultAddrMV.getLValueAddress();

--- a/test/SILGen/typed_throws_tuple_into_opaque_thunk.swift
+++ b/test/SILGen/typed_throws_tuple_into_opaque_thunk.swift
@@ -1,0 +1,112 @@
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
+
+// https://github.com/swiftlang/swift/issues/77880
+// (and related: https://github.com/swiftlang/swift/issues/88027)
+//
+// When passing a `(T) throws(E) -> R` closure to a parameter of type
+// `(T) throws -> U` where `U` is a generic type variable substituted to
+// `R` (which is itself a tuple — possibly `Void`), SILGen must build a
+// reabstraction thunk whose inner result is `@out R` and whose outer
+// result is `@out T` (an opaque archetype that happens to substitute to
+// `R`). The ResultPlanner used to route this through a parallel tuple
+// walk on the substituted types; the walk would either iterate zero
+// times (empty tuple) or mis-align inner/outer slots (non-empty tuple),
+// tripping an assertion during thunk emission (and earlier causing a
+// `SmallVector grow_pod` crash in IRGen).
+//
+// Each case below exercises the reabstraction through a different
+// combination of inner tuple arity, element types, and outer throws
+// convention. Every reabstraction thunk should forward the inner
+// closure's `@out R` slot directly into the outer's `@out T` slot via
+// `try_apply` (the planner's addInPlace optimization), and re-erase
+// the typed error into `any Error` on the failure edge.
+
+enum E: Error { case foo }
+
+struct Holder {
+  // Three distinct entry points, differing only in the outer throws
+  // convention the thunk must target. All three used to crash.
+
+  mutating func rethrowsBytes<T>(_ body: (UnsafeMutableRawPointer) throws -> T) rethrows -> T {
+    fatalError()
+  }
+  mutating func throwsBytes<T>(_ body: (UnsafeMutableRawPointer) throws -> T) throws -> T {
+    fatalError()
+  }
+  mutating func throwsAnyBytes<T>(_ body: (UnsafeMutableRawPointer) throws(any Error) -> T) throws(any Error) -> T {
+    fatalError()
+  }
+}
+
+// ----------------------------------------------------------------------------
+// Case 1: empty tuple (Void) via `rethrows`.
+// Inner:  `@out ()` + `@error E`
+// Outer:  `@out ()` + `@error any Error`
+// ----------------------------------------------------------------------------
+
+// CHECK-LABEL: sil hidden [ossa] @$s36typed_throws_tuple_into_opaque_thunk12compilesVoidyyKF
+// CHECK-LABEL: sil shared [transparent] [serialized] [reabstraction_thunk] [ossa] @$sSvyt36typed_throws_tuple_into_opaque_thunk1EOIetyrzo_Svyts5Error_pIegyrzo_TR
+// CHECK: bb0([[OUT:%.*]] : $*(), [[PTR:%.*]] : $UnsafeMutableRawPointer, [[INNER:%.*]] : $@convention(thin) (UnsafeMutableRawPointer) -> (@out (), @error E)):
+// CHECK-NEXT: try_apply [[INNER]]([[OUT]], [[PTR]]) {{.*}} normal [[NORMAL:bb[0-9]+]], error [[ERROR:bb[0-9]+]]
+// CHECK: [[NORMAL]]
+// CHECK: return
+// CHECK: [[ERROR]]({{%.*}} : $E):
+// CHECK: alloc_existential_box $any Error, $E
+// CHECK: throw
+func compilesVoid() throws {
+  var h = Holder()
+  try h.rethrowsBytes { (p) throws(E) in
+  }
+}
+
+// ----------------------------------------------------------------------------
+// Case 2: trivial 2-tuple via `rethrows`. Same addInPlace thunk shape
+// — regression check that the fix isn't tied to empty tuples.
+// ----------------------------------------------------------------------------
+
+// CHECK-LABEL: sil hidden [ossa] @$s36typed_throws_tuple_into_opaque_thunk14compilesPairOfSi_SitSgyKF
+// CHECK-LABEL: sil shared [transparent] [serialized] [reabstraction_thunk] [ossa] @$sSvSi_Sit36typed_throws_tuple_into_opaque_thunk1EOIetyrzo_SvSi_Sits5Error_pIegyrzo_TR
+// CHECK: bb0([[OUT2:%.*]] : $*(Int, Int), [[PTR2:%.*]] : $UnsafeMutableRawPointer, [[INNER2:%.*]] : $@convention(thin) (UnsafeMutableRawPointer) -> (@out (Int, Int), @error E)):
+// CHECK-NEXT: try_apply [[INNER2]]([[OUT2]], [[PTR2]])
+func compilesPairOf() throws -> (Int, Int)? {
+  var h = Holder()
+  return try h.rethrowsBytes { (p) throws(E) -> (Int, Int) in
+    return (1, 2)
+  }
+}
+
+// ----------------------------------------------------------------------------
+// Case 3: heterogeneous 3-tuple containing a reference-counted element
+// (`String`) via `throws`. The outer convention is `throws` (rather than
+// `rethrows`), and the non-trivial element exercises copy/destroy along
+// the addInPlace path. Crash manifests identically to the other shapes
+// because the planner state is driven by inner-result slot count, not
+// the specific element types.
+// ----------------------------------------------------------------------------
+
+// CHECK-LABEL: sil hidden [ossa] @$s36typed_throws_tuple_into_opaque_thunk14compilesTripleSi_SSSbtSgyKF
+// CHECK-LABEL: sil shared [transparent] [serialized] [reabstraction_thunk] [ossa] @$sSvSi_SSSbt36typed_throws_tuple_into_opaque_thunk1EOIetyrzo_SvSi_SSSbts5Error_pIegyrzo_TR
+// CHECK: bb0([[OUT3:%.*]] : $*(Int, String, Bool), [[PTR3:%.*]] : $UnsafeMutableRawPointer, [[INNER3:%.*]] : $@convention(thin) (UnsafeMutableRawPointer) -> (@out (Int, String, Bool), @error E)):
+// CHECK-NEXT: try_apply [[INNER3]]([[OUT3]], [[PTR3]])
+func compilesTriple() throws -> (Int, String, Bool)? {
+  var h = Holder()
+  return try h.throwsBytes { (p) throws(E) -> (Int, String, Bool) in
+    return (42, "hi", true)
+  }
+}
+
+// ----------------------------------------------------------------------------
+// Case 4: throws(any Error) on the outer function. Reabstraction for
+// `rethrows` and `throws(any Error)` lowers to the same SIL function
+// type, so case 2's thunk is shared here — just confirm the function
+// itself is emitted and references it by the same mangled name.
+// ----------------------------------------------------------------------------
+
+// CHECK-LABEL: sil hidden [ossa] @$s36typed_throws_tuple_into_opaque_thunk20compilesThrowsAnyAllSi_SitSgyKF
+// CHECK: function_ref @$sSvSi_Sit36typed_throws_tuple_into_opaque_thunk1EOIetyrzo_SvSi_Sits5Error_pIegyrzo_TR
+func compilesThrowsAnyAll() throws -> (Int, Int)? {
+  var h = Holder()
+  return try h.throwsAnyBytes { (p) throws(E) -> (Int, Int) in
+    return (3, 4)
+  }
+}


### PR DESCRIPTION
When passing a `(T) throws(E) -> R` closure to a parameter of type `(T) throws -> U` where `U` is a generic type variable substituted to `R` (which is a tuple — possibly `Void`), SILGen builds a reabstraction thunk whose inner result is `@out R` and whose outer result is `@out T` (opaque archetype that happens to substitute to `R`).

`ResultPlanner::expandInnerTupleOuterIndirect` dispatches between "single-slot injection" (optional/existential) and "parallel tuple walk" based on whether `outerSubstType` is a tuple — but that's the wrong dimension. The abstraction pattern determines how the value is *passed*, not the substituted type. When `outerOrigType` is opaque the outer is a single `@out` slot regardless of the substituted type.

Routing to the parallel tuple walk caused:
- Empty-tuple case: the walk iterates 0 times, leaves the inner `@out` slot unclaimed, and trips `assert(AllInnerResults.empty())` in `ResultPlanner::plan`. (Previously crashed in IRGen's `SyncCallEmission::setArgs` as `SmallVector grow_pod` before the IR-level symptom was fixed.)
- Non-empty-tuple case: the walk tries to claim per-element slots that don't exist and trips the `claimNext` assertion.

Detect the "inner has a single whole-tuple indirect slot, outer is opaque" case in `expandInnerTupleOuterIndirect` and dispatch to `planSingleIntoIndirect`. Gate on `AllInnerResults.size() == 1` so the fix does not fire when the inner has per-element slots (where the parallel walk's per-element claims remain correct).

A more principled fix dispatches the whole function on `outerOrigType.isTuple()` and handles 1-to-N result-slot mappings — left as a FIXME for a separate change.

Fixes https://github.com/swiftlang/swift/issues/77880. Fixes https://github.com/swiftlang/swift/issues/88027.