### PR TITLE
[SILVerifier] [DebugInfo] Add optional verification of debug_value type 

### DIFF
--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -5732,6 +5732,13 @@ public:
   /// with `op_deref`.
   bool exprStartsWithDeref() const;
 
+  /// Validates the type chain of the DIExpr.
+  /// Starting from VarType, narrows through fragments (outermost first)
+  /// and checks that the result matches the SSA operand type, and that there
+  /// is the right amount of op_deref.
+  /// Returns false if the type chain is invalid, true otherwise.
+  bool isExprTypeValid() const;
+
   /// True if all references within this debug value will be overwritten with a
   /// poison sentinel at this point in the program. This is used in debug builds
   /// when shortening non-trivial value lifetimes to ensure the debugger cannot

--- a/lib/SIL/IR/SILInstructions.cpp
+++ b/lib/SIL/IR/SILInstructions.cpp
@@ -487,6 +487,53 @@ bool DebugValueInst::exprStartsWithDeref() const {
           == SILDIExprOperator::Dereference;
 }
 
+bool DebugValueInst::isExprTypeValid() const {
+  auto varInfo = getCompleteVarInfo();
+
+  // Ignore trace debug values.
+  if (hasTrace())
+    return true;
+
+  SILFunction *F = getFunction();
+  if (!F)
+    return false;
+
+  SILType SSAType = getOperand()->getType();
+  SILType TargetType = SSAType.getObjectType();
+  SILType VarType = *varInfo.Type;
+  SILType RunningType = VarType;
+
+  unsigned derefCount = 0;
+
+  for (const SILDIExprOperand &Operand : varInfo.DIExpr.operands()) {
+    switch (Operand.getOperator()) {
+    case SILDIExprOperator::Dereference:
+      ++derefCount;
+      break;
+    case SILDIExprOperator::Fragment: {
+      auto *Field = cast<VarDecl>(Operand.args()[0].getAsDecl());
+      RunningType = RunningType.getFieldType(Field, F);
+      break;
+    }
+    case SILDIExprOperator::TupleFragment: {
+      unsigned Idx = Operand.args()[1].getAsConstInt().value();
+      RunningType = RunningType.getTupleElementType(Idx);
+      break;
+    }
+    default:
+      break;
+    }
+  }
+
+  // There must be as many op_derefs as SIL type indirection levels.
+  // SIL only supports one level of indirection, so op_deref too.
+  if (derefCount != SSAType.isAddress())
+    return false;
+
+  return RunningType.removingMoveOnlyWrapper() ==
+         TargetType.removingMoveOnlyWrapper();
+}
+
 VarDecl *DebugValueInst::getDecl() const {
   return getVarLoc().getAsASTNode<VarDecl>();
 }

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -87,6 +87,11 @@ static llvm::cl::opt<bool> VerifyDIHoles("verify-di-holes", llvm::cl::init(
 #endif
                                                                 ));
 
+// Verify the type chain of debug_value instructions. Disabled by default
+// while we fix all root causes.
+static llvm::cl::opt<bool> VerifyDebugValueExpr("verify-debug-value-expr",
+                                                llvm::cl::init(false));
+
 static llvm::cl::opt<bool> SkipConvertEscapeToNoescapeAttributes(
     "verify-skip-convert-escape-to-noescape-attributes", llvm::cl::init(false));
 
@@ -1937,6 +1942,11 @@ public:
                   " in a di-expression");
       }
     }
+
+    if (VerifyDebugValueExpr)
+      if (auto *DVI = dyn_cast<DebugValueInst>(inst))
+        require(DVI->isExprTypeValid(),
+                "debug_value type chain should hold");
   }
 
   void checkInstructionsDebugInfo(SILInstruction *inst) {


### PR DESCRIPTION
This check is disabled by default, and enabled with `-Xllvm -verify-debug-value-expr`, while we fix the remaining problems that are creating wrongly typed debug info (rdar://176463223).

This PR requires #88870 to be merged to make sense, as op_deref isn't required on debug_value before then.