### PR TITLE
[6.4🍒] Serialization: Fix silent abbreviation-ID overflow in OPTIONS_BLOCK

### DIFF
--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 997; // ActorIsolation::Kind: split Nonisolated from NonisolatedConcurrent
+const uint16_t SWIFTMODULE_VERSION_MINOR = 999; // widen OPTIONS_BLOCK abbrev code size to 6 bits
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1100,7 +1100,7 @@ void Serializer::writeHeader() {
     Channel.emit(ScratchRecord, version::getCurrentCompilerChannel());
 
     {
-      llvm::BCBlockRAII restoreBlock(Out, OPTIONS_BLOCK_ID, 4);
+      llvm::BCBlockRAII restoreBlock(Out, OPTIONS_BLOCK_ID, 6);
 
       options_block::IsSIBLayout IsSIB(Out);
       IsSIB.emit(ScratchRecord, Options.IsSIB);


### PR DESCRIPTION
## Cherry-pick of #88896

- Explanation: OPTIONS_BLOCK's 4-bit abbreviation code size caps user abbreviations at 12 (IDs 4–15); once enough conditionally-emitted records push the count to 13, the 13th abbreviation's ID (16) silently truncates to 0, which the reader reads as END_BLOCK and the module fails to load with error: malformed compiled module. Widening the code size to 6 bits raises the cap to 60 (IDs 4–63), fitting all currently-emitted records with some headroom.
- Scope: Affects serialization in presence of more than 12 compiler flags
- Issue: rdar://176281964
- Risk: Low, affects newly generated swiftmodules, reader is backward-compatible (can detect modules with id size 4 and 6)
- Original PR: [Serialization: Fix silent abbreviation-ID overflow in OPTIONS_BLOCK](https://github.com/swiftlang/swift/pull/88896)
- Testing: Manually tested on 2 different projects
- Reviewers: @nkcsgexi , @tshortli 

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
