### PR TITLE
[cxx-interop] Fix reverse interop overlay header in Embedded mode

### DIFF
--- a/lib/PrintAsClang/PrintClangValueType.cpp
+++ b/lib/PrintAsClang/PrintClangValueType.cpp
@@ -145,36 +145,45 @@ static void addCppExtensionsToStdlibType(const NominalTypeDecl *typeDecl,
            "#endif\n"
            "return result;\n"
            "}\n";
-    cPrologueOS << "SWIFT_EXTERN void *_Nonnull "
-                   "$sSS10FoundationE19_bridgeToObjectiveCSo8NSStringCyF(swift_interop_stub_"
-                   "Swift_String) SWIFT_NOEXCEPT SWIFT_CALL;\n";
+    bool embedded =
+        typeDecl->getASTContext().LangOpts.hasFeature(Feature::Embedded);
+    const char *manglingPrefix = embedded ? "$e" : "$s";
+    if (!embedded) {
+      cPrologueOS << "SWIFT_EXTERN void *_Nonnull "
+                     "$sSS10FoundationE19_bridgeToObjectiveCSo8NSStringCyF("
+                     "swift_interop_stub_Swift_String) SWIFT_NOEXCEPT "
+                     "SWIFT_CALL;\n";
+      cPrologueOS << "SWIFT_EXTERN swift_interop_stub_Swift_String "
+                     "$sSS10FoundationE36_"
+                     "unconditionallyBridgeFromObjectiveCySSSo8NSStringCSgFZ("
+                     "void * _Nullable) SWIFT_NOEXCEPT SWIFT_CALL;\n";
+    }
     cPrologueOS << "SWIFT_EXTERN swift_interop_stub_Swift_String "
-                   "$sSS10FoundationE36_"
-                   "unconditionallyBridgeFromObjectiveCySSSo8NSStringCSgFZ("
-                   "void * _Nullable) SWIFT_NOEXCEPT SWIFT_CALL;\n";
-    cPrologueOS << "SWIFT_EXTERN swift_interop_stub_Swift_String "
-                   "$sSS7cStringSSSPys4Int8VG_tcfC("
+                << manglingPrefix << "SS7cStringSSSPys4Int8VG_tcfC("
                    "const char * _Nonnull) SWIFT_NOEXCEPT SWIFT_CALL;\n";
-    printer.printObjCBlock([&](raw_ostream &os) {
-      os << "  ";
-      ClangSyntaxPrinter(typeDecl->getASTContext(), os).printInlineForThunk();
-      os << "operator NSString * _Nonnull () const noexcept {\n";
-      os << "    return (__bridge_transfer NSString "
-            "*)(_impl::$sSS10FoundationE19_bridgeToObjectiveCSo8NSStringCyF(_impl::swift_interop_"
-            "passDirect_Swift_String(_getOpaquePointer())));\n";
-      os << "  }\n";
-      os << "static ";
-      ClangSyntaxPrinter(typeDecl->getASTContext(), os).printInlineForThunk();
-      os << "String init(NSString * _Nonnull nsString) noexcept {\n";
-      os << "    auto result = _make();\n";
-      os << "    auto res = "
-            "_impl::$sSS10FoundationE36_"
-            "unconditionallyBridgeFromObjectiveCySSSo8NSStringCSgFZ((__bridge "
-            "void *)nsString);\n";
-      os << "    memcpy(result._getOpaquePointer(), &res, sizeof(res));\n";
-      os << "    return result;\n";
-      os << "  }\n";
-    });
+    if (!embedded) {
+      printer.printObjCBlock([&](raw_ostream &os) {
+        os << "  ";
+        ClangSyntaxPrinter(typeDecl->getASTContext(), os).printInlineForThunk();
+        os << "operator NSString * _Nonnull () const noexcept {\n";
+        os << "    return (__bridge_transfer NSString "
+              "*)(_impl::$sSS10FoundationE19_bridgeToObjectiveCSo8NSStringCyF("
+              "_impl::swift_interop_"
+              "passDirect_Swift_String(_getOpaquePointer())));\n";
+        os << "  }\n";
+        os << "static ";
+        ClangSyntaxPrinter(typeDecl->getASTContext(), os).printInlineForThunk();
+        os << "String init(NSString * _Nonnull nsString) noexcept {\n";
+        os << "    auto result = _make();\n";
+        os << "    auto res = "
+              "_impl::$sSS10FoundationE36_"
+              "unconditionallyBridgeFromObjectiveCySSSo8NSStringCSgFZ((__bridge "
+              "void *)nsString);\n";
+        os << "    memcpy(result._getOpaquePointer(), &res, sizeof(res));\n";
+        os << "    return result;\n";
+        os << "  }\n";
+      });
+    }
     // Add additional methods for the `String` declaration.
     printer.printDefine("SWIFT_CXX_INTEROP_STRING_MIXIN");
     printer.printIncludeForShimHeader("_SwiftStdlibCxxOverlay.h");

--- a/lib/PrintAsClang/_SwiftStdlibCxxOverlay.h
+++ b/lib/PrintAsClang/_SwiftStdlibCxxOverlay.h
@@ -46,13 +46,21 @@ SWIFT_INLINE_THUNK String(const char *cString) noexcept {
     memcpy(_getOpaquePointer(), &res, sizeof(res));
     return;
   }
+#ifdef __EmbeddedSwift__
+  auto res = _impl::$eSS7cStringSSSPys4Int8VG_tcfC(cString);
+#else
   auto res = _impl::$sSS7cStringSSSPys4Int8VG_tcfC(cString);
+#endif
   memcpy(_getOpaquePointer(), &res, sizeof(res));
 }
 
 /// Constructs a Swift string from a C++ string.
 SWIFT_INLINE_THUNK String(const std::string &str) noexcept {
+#ifdef __EmbeddedSwift__
+  auto res = _impl::$eSS7cStringSSSPys4Int8VG_tcfC(str.c_str());
+#else
   auto res = _impl::$sSS7cStringSSSPys4Int8VG_tcfC(str.c_str());
+#endif
   memcpy(_getOpaquePointer(), &res, sizeof(res));
 }
 

--- a/test/Interop/SwiftToCxx/stdlib/string/string-conversions-embedded.cpp
+++ b/test/Interop/SwiftToCxx/stdlib/string/string-conversions-embedded.cpp
@@ -1,0 +1,20 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %S/string-conversions.cpp %t
+
+// RUN: %target-swift-frontend -enable-experimental-feature Embedded %t/print-string.swift -target arm64-apple-macos15.0 -module-name Stringer -enable-experimental-cxx-interop -typecheck -verify -emit-clang-header-path %t/Stringer.h
+
+// Verify the generated header uses embedded mangling ($e prefix, not $s).
+// RUN: %FileCheck %s --check-prefix=CHECK-HEADER < %t/Stringer.h
+
+// Verify the generated header compiles as valid C++.
+// RUN: %target-interop-build-clangxx -target arm64-apple-macos15.0 -std=gnu++20 -c %t/string-conversions.cpp -I %t -o %t/swift-stdlib-execution.o
+
+// REQUIRES: OS=macosx
+// REQUIRES: executable_test
+// REQUIRES: embedded_stdlib
+// REQUIRES: swift_feature_Embedded
+
+// CHECK-HEADER: __EmbeddedSwift__
+// CHECK-HEADER: $eSS7cStringSSSPys4Int8VG_tcfC
+// CHECK-HEADER-NOT: $sSS7cStringSSSPys4Int8VG_tcfC
+// CHECK-HEADER-NOT: $sSS10FoundationE


### PR DESCRIPTION
When targeting Embedded Swift and using reverse C++ interop to generate a C++ interface for a Swift module, the compiler was emitting mangled names of Swift stdlib symbols that began with `$s`. This is incorrect in Embedded Swift: the mangling uses `$e` as the prefix.

Swift was also emitting references to Foundation symbols which are not available in Embedded Swift. This change removes those references.

rdar://154738972

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
