### PR TITLE
SILGen: skip $error debug_value when the closure's SIL has no error result

### DIFF
--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -1806,6 +1806,27 @@ public:
     if (!varInfo)
       return;
 
+    // The `$error` debug variable is a placeholder for the function's
+    // error-result slot so the debugger can display the in-flight error.
+    // It only makes sense in a function whose SIL type actually has an
+    // error result; see `SILGenFunction::emitBasicProlog`. Downstream
+    // consumers (IRGen's `visitDebugValueInst`) call `getErrorResult()`
+    // on it, which asserts when no such result exists.
+    //
+    // For an inlined occurrence the variable belongs to the function it
+    // was originally declared in (which must itself have an error
+    // result), not the function it was inlined into. Look through the
+    // debug scope to that function rather than checking the containing
+    // function.
+    if (isa<DebugValueInst>(inst) && varInfo->Name == "$error") {
+      auto *scope = varInfo->Scope ? varInfo->Scope : inst->getDebugScope();
+      auto *owningFn = scope ? scope->getInlinedFunction()
+                             : inst->getFunction();
+      require(owningFn->getLoweredFunctionType()->hasErrorResult(),
+              "'$error' debug_value may only appear in a function whose "
+              "SIL type has an error result");
+    }
+
     SILType DebugVarTy = *varInfo->Type;
 
     auto *debugScope = inst->getDebugScope();

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -1743,8 +1743,18 @@ uint16_t SILGenFunction::emitBasicProlog(
                        std::move(scopedDependencyParams))
       .emitParams(origClosureType, paramList, selfParam);
 
-  // Record the ArgNo of the artificial $error inout argument. 
-  if (errorType && IndirectErrorResult == nullptr) {
+  // Record the ArgNo of the artificial $error inout argument.
+  //
+  // The abstraction pattern's `errorType` can describe a throwing closure
+  // while the emitted SIL function is non-throwing — this happens when a
+  // non-throwing literal is stored into a `throws(E)` position and the
+  // outer conversion adds the error result externally. The indirect error
+  // parameter emission above already guards on the lowered SIL function's
+  // conventions; do the same for the `$error` debug placeholder, which
+  // must only appear in a function whose SIL type has an error result
+  // (SIL verifier enforces this invariant).
+  if (errorType && IndirectErrorResult == nullptr &&
+      F.getLoweredFunctionType()->hasErrorResult()) {
     CanType errorTypeInContext =
       DC->mapTypeIntoEnvironment(*errorType)->getCanonicalType();
     auto loweredErrorTy = getLoweredType(*origErrorType, errorTypeInContext);

--- a/test/IRGen/typed_throws_nested_error_closure_87030.swift
+++ b/test/IRGen/typed_throws_nested_error_closure_87030.swift
@@ -1,0 +1,53 @@
+// RUN: %target-swift-emit-ir %s | %FileCheck %s
+
+// https://github.com/swiftlang/swift/issues/87030
+//
+// When a non-throwing closure literal `{ $0 }` is stored into a property of
+// type `(T) throws(E) -> T` where `E` is a nested error type of a generic
+// container, SILGen emits the closure with a non-throwing SIL function type
+// (its body doesn't throw) and wraps it in an outer `convert_function` that
+// adds the error result. But SILGen's prolog used to emit the artificial
+// `debug_value undef, name "$error"` because the *abstracted* closure type
+// throws. IRGen's handling of that `$error` debug var calls
+// `funcTy->getErrorResult()` unconditionally — which asserted because the
+// closure's own SIL function type has no error result.
+//
+// Fix: only emit the `$error` debug placeholder when the closure's own SIL
+// function type actually has an error result. Also related: issue #73641
+// (same pattern with a generic class).
+//
+// Regression: both reproducers must compile cleanly through IRGen.
+
+// --- Issue #87030: generic struct -----------------------------------------
+
+public struct Box<T> {
+    public var f: (T) throws(Error) -> T
+    public enum Error: Swift.Error { case e }
+}
+
+public enum E { case a }
+
+extension Box where T == E {
+    public static var id: Self { .init(f: { $0 }) }
+}
+
+// The static `id` getter and its non-throwing closure literal must both be
+// emitted. The closure's IR signature has no swifterror register — it
+// returns void and writes to its sret, matching the non-throwing SIL type.
+// CHECK-LABEL: define {{.*}} @"$s39typed_throws_nested_error_closure_870303BoxVA2A1EORszlE2idACyAEGvgZ"
+// CHECK-LABEL: define internal swiftcc void @"$s39typed_throws_nested_error_closure_870303BoxVA2A1EORszlE2idACyAEGvgZA2EcfU_"(ptr noalias sret(%T39typed_throws_nested_error_closure_870301EO) captures(none) {{%.*}}, ptr noalias captures(none) {{%.*}})
+
+// --- Issue #73641 sibling: generic class ----------------------------------
+
+public class Container<T> {
+  public enum Err: Error { case bad }
+  public var action: () throws(Err) -> T
+  public init(_ a: @escaping () throws(Err) -> T) { self.action = a }
+}
+
+extension Container where T == Int {
+  public static var noop: Container<Int> { Container { 0 } }
+}
+
+// CHECK-LABEL: define {{.*}} @"$s39typed_throws_nested_error_closure_870309ContainerCAASiRszlE4noopACySiGvgZ"
+// CHECK-LABEL: define internal swiftcc void @"$s39typed_throws_nested_error_closure_870309ContainerCAASiRszlE4noopACySiGvgZSiycfU_"(ptr noalias sret(%TSi) captures(none) {{%.*}})

--- a/test/SIL/verifier_dollar_error_requires_error_result.sil
+++ b/test/SIL/verifier_dollar_error_requires_error_result.sil
@@ -1,0 +1,28 @@
+// RUN: %empty-directory(%t)
+// RUN: not --crash %target-sil-opt -enable-sil-verify-all %s 2> %t/err.txt
+// RUN: %FileCheck %s < %t/err.txt
+
+// REQUIRES: asserts
+
+// The SIL verifier rejects a `debug_value undef, name "$error"` in a
+// function whose SIL type has no error result. `$error` is a placeholder
+// for the function's error-result slot; IRGen's `visitDebugValueInst`
+// reads `getErrorResult()` on it unconditionally.
+//
+// An inlined occurrence (`inlined_at` debug scope) is allowed — IRGen
+// skips emission in that case, and this SIL shape can legitimately
+// persist after a throwing function is inlined into a non-throwing one.
+
+// CHECK: SIL verification failed: '$error' debug_value may only appear in a function whose SIL type has an error result
+
+sil_stage canonical
+
+import Builtin
+import Swift
+
+sil @stray_error_debug_value : $@convention(thin) () -> () {
+bb0:
+  debug_value undef : $any Error, var, name "$error", argno 1
+  %0 = tuple ()
+  return %0 : $()
+}

--- a/validation-test/compiler_crashers_fixed/IRGenSILFunction-visitDebugValueInst-a038f9.swift
+++ b/validation-test/compiler_crashers_fixed/IRGenSILFunction-visitDebugValueInst-a038f9.swift
@@ -1,5 +1,5 @@
 // {"kind":"emit-ir","original":"eeed16fc","signature":"(anonymous namespace)::IRGenSILFunction::visitDebugValueInst(swift::DebugValueInst*)","signatureAssert":"Assertion failed: (hasErrorResult()), function getMutableErrorResult","signatureNext":"IRGenSILFunction::emitSILFunction"}
-// RUN: not --crash %target-swift-frontend -emit-ir %s
+// RUN: %target-swift-emit-ir %s
 protocol a {
   associatedtype b: c where b.d == Self
   associatedtype e: Collection where e.Element == Self


### PR DESCRIPTION
When a non-throwing closure literal (e.g. `{ $0 }`) is stored into a property typed `(T) throws(E) -> T` where `E` is a nested error type of a generic container, SILGen lowers the closure to a non-throwing SIL function type (its body can't throw) and wraps it in an outer `convert_function` that adds the error result.

The prolog, however, emitted the artificial `debug_value undef, name "$error"` unconditionally whenever the *abstracted* closure type threw — regardless of whether the emitted SIL function actually has an error result. IRGen's `visitDebugValueInst` handling of the `$error` debug var then called `funcTy->getErrorResult()` unconditionally, tripping the `hasErrorResult()` assertion in `Types.h`.

Gate the `$error` debug placeholder on `F.getLoweredFunctionType()-> hasErrorResult()`: if the SIL function has no error storage, there is nothing for the debug var to point at.

Fixes https://github.com/swiftlang/swift/issues/87030.