### PR TITLE
[6.4🍒] [SIL] Lower bridged target through TypeConverter in getLoweredBridgedTargetObjectType

### DIFF
--- a/include/swift/SIL/DynamicCasts.h
+++ b/include/swift/SIL/DynamicCasts.h
@@ -439,7 +439,11 @@ public:
     CanType t = getBridgedTargetType();
     if (!t)
       return std::nullopt;
-    return SILType::getPrimitiveObjectType(t);
+    // Lower the bridged target through the TypeConverter so that
+    // DynamicSelfType is stripped consistently with how SIL lowers the
+    // cast instruction's target type. Otherwise `as? Self` in a class
+    // extension of a bridgeable class makes the two sides disagree.
+    return getFunction()->getLoweredType(t).getObjectType();
   }
 
   bool isConditional() const {

--- a/test/SILOptimizer/issue-88767.swift
+++ b/test/SILOptimizer/issue-88767.swift
@@ -1,0 +1,20 @@
+// RUN: %target-swift-frontend -emit-sil -verify %s
+// RUN: %target-swift-frontend -O -emit-sil -verify %s
+
+// REQUIRES: objc_interop
+
+// Regression test for https://github.com/swiftlang/swift/issues/88767
+
+import Foundation
+
+extension NSDecimalNumber {
+  static func roundtrip(_ d: Decimal) -> Self? {
+    return d as? Self
+  }
+}
+
+extension NSString {
+  static func roundtrip(_ s: String) -> Self? {
+    return s as? Self
+  }
+}


### PR DESCRIPTION
Cherry-pick of #88777 to `release/6.4.x`.

- **Explanation**: `SILDynamicCastInst::getLoweredBridgedTargetObjectType` wrapped the formal bridged target via `SILType::getPrimitiveObjectType`, which preserves `DynamicSelfType`; SIL type lowering strips it. The two sides disagree for `as? Self` inside an extension of a bridgeable class (e.g. `NSDecimalNumber`, `NSString`), tripping the assertion in `CastOptimizer::computeFinalCastedValue`. Fix: route the helper through the `SILFunction`'s `TypeConverter`, matching what every other cast-type consumer does. Same pattern as #85128.

- **Scope**: One replaced line in `include/swift/SIL/DynamicCasts.h` plus a regression test. No API changes. Affects any `Self`-returning helper on a bridgeable class — a common Foundation-interop pattern.

- **Issues**: Fixes #88767. Works on 6.3.1 and 6.2; regressed on `main` after the 6.3.1 cut, currently crashes 6.4.

- **Original PRs**: #88777

- **Risk**: Low. Erik approved on #88777 noting the change is safe because `SILType::getPrimitiveObjectType` would have crashed on a non-lowered type anyway, so the new path can't regress previously-working inputs.

- **Testing**: New regression test `test/SILOptimizer/issue-88767.swift` (fails without the patch). The #85128 regression test still passes. CI was green on #88777.

- **Reviewers**: @eeckstein