### PR TITLE
[stdlib] improve doc-comments for span and bytes properties

### DIFF
--- a/stdlib/public/core/Array.swift
+++ b/stdlib/public/core/Array.swift
@@ -1745,6 +1745,16 @@ extension Array {
     return try _buffer.withUnsafeBufferPointer(body)
   }
 
+  /// A span over the elements of this array.
+  ///
+  /// - Note: On Apple platforms, bridged `NSArray` instances are copied into
+  ///   contiguous storage the first time this property is called.
+  ///   The contiguous copy is cached, and subsequent calls
+  ///   to `span` can reuse this copy.
+  ///
+  /// - Returns: A `Span` over the elements of this array.
+  ///
+  /// - Complexity: O(1) for native arrays, amortized O(1) for bridged arrays.
   @available(SwiftStdlib 6.2, *)
   public var span: Span<Element> {
     @lifetime(borrow self)
@@ -1865,6 +1875,12 @@ extension Array {
     return try unsafe body(&inoutBufferPointer)
   }
 
+  /// A mutable span over the elements of this array.
+  ///
+  /// - Returns: A `MutableSpan` over the elements of this array.
+  ///
+  /// - Complexity: O(1) when the array's storage is uniquely referenced,
+  ///   O(*n*) otherwise.
   @available(SwiftStdlib 6.2, *)
   @_alwaysEmitIntoClient
   public var mutableSpan: MutableSpan<Element> {

--- a/stdlib/public/core/Array.swift
+++ b/stdlib/public/core/Array.swift
@@ -1747,10 +1747,9 @@ extension Array {
 
   /// A span over the elements of this array.
   ///
-  /// - Note: On Apple platforms, bridged `NSArray` instances are copied into
-  ///   contiguous storage the first time this property is called.
-  ///   The contiguous copy is cached, and subsequent calls
-  ///   to `span` can reuse this copy.
+  /// - Note: On Apple platforms, this property copies bridged `NSArray`
+  ///   instances into contiguous storage on first access and caches
+  ///   the result. Subsequent calls can reuse the cached copy.
   ///
   /// - Returns: A `Span` over the elements of this array.
   ///

--- a/stdlib/public/core/ArraySlice.swift
+++ b/stdlib/public/core/ArraySlice.swift
@@ -1228,6 +1228,11 @@ extension ArraySlice {
 @available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension ArraySlice {
+  /// A span over the elements of this array slice.
+  ///
+  /// - Returns: A `Span` over the elements of this array.
+  ///
+  /// - Complexity: O(1)
   @available(SwiftCompatibilitySpan 5.0, *)
   @_alwaysEmitIntoClient
   public var span: Span<Element> {
@@ -1325,6 +1330,12 @@ extension ArraySlice {
 @available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension ArraySlice {
+  /// A mutable span over the elements of this array slice.
+  ///
+  /// - Returns: A `MutableSpan` over the elements of this array.
+  ///
+  /// - Complexity: O(1) when the array's storage is uniquely referenced,
+  ///   O(*n*) otherwise.
   @_alwaysEmitIntoClient
   public var mutableSpan: MutableSpan<Element> {
     @lifetime(&self)

--- a/stdlib/public/core/CollectionOfOne.swift
+++ b/stdlib/public/core/CollectionOfOne.swift
@@ -163,6 +163,11 @@ extension CollectionOfOne: RandomAccessCollection, MutableCollection {
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension CollectionOfOne {
 
+  /// A span over the single element of this collection.
+  ///
+  /// - Returns: A `Span` over the element of this collection.
+  ///
+  /// - Complexity: O(1)
   @_alwaysEmitIntoClient
   public var span: Span<Element> {
     @lifetime(borrow self)
@@ -173,6 +178,11 @@ extension CollectionOfOne {
     }
   }
 
+  /// A mutable span over the single element of this collection.
+  ///
+  /// - Returns: A `MutableSpan` over the element of this collection.
+  ///
+  /// - Complexity: O(1)
   @_alwaysEmitIntoClient
   public var mutableSpan: MutableSpan<Element> {
     @lifetime(&self)

--- a/stdlib/public/core/ContiguousArray.swift
+++ b/stdlib/public/core/ContiguousArray.swift
@@ -1293,6 +1293,11 @@ extension ContiguousArray {
 @available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension ContiguousArray {
+  /// A span over the elements of this array.
+  ///
+  /// - Returns: A `Span` over the elements of this array.
+  ///
+  /// - Complexity: O(1)
   @_alwaysEmitIntoClient
   public var span: Span<Element> {
     @lifetime(borrow self)
@@ -1389,6 +1394,12 @@ extension ContiguousArray {
 @available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension ContiguousArray {
+  /// A mutable span over the elements of this array.
+  ///
+  /// - Returns: A `MutableSpan` over the elements of this array.
+  ///
+  /// - Complexity: O(1) when the array's storage is uniquely referenced,
+  ///   O(*n*) otherwise.
   @_alwaysEmitIntoClient
   public var mutableSpan: MutableSpan<Element> {
     @lifetime(&self)

--- a/stdlib/public/core/InlineArray.swift
+++ b/stdlib/public/core/InlineArray.swift
@@ -583,6 +583,11 @@ extension InlineArray where Element: ~Copyable {
 
 @available(SwiftStdlib 6.2, *)
 extension InlineArray where Element: ~Copyable {
+  /// A span over the elements of this array.
+  ///
+  /// - Returns: A `Span` over the elements of this array.
+  ///
+  /// - Complexity: O(1)
   @available(SwiftStdlib 6.2, *)
   @_alwaysEmitIntoClient
   public var span: Span<Element> {
@@ -598,6 +603,11 @@ extension InlineArray where Element: ~Copyable {
     }
   }
 
+  /// A mutable span over the elements of this array.
+  ///
+  /// - Returns: A `MutableSpan` over the elements of this array.
+  ///
+  /// - Complexity: O(1)
   @available(SwiftStdlib 6.2, *)
   @_alwaysEmitIntoClient
   public var mutableSpan: MutableSpan<Element> {

--- a/stdlib/public/core/KeyValuePairs.swift
+++ b/stdlib/public/core/KeyValuePairs.swift
@@ -128,6 +128,11 @@ extension KeyValuePairs: RandomAccessCollection {
 @available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension KeyValuePairs {
+  /// A span over the key-value pairs of this collection.
+  ///
+  /// - Returns: A `Span` over the elements of this collection.
+  ///
+  /// - Complexity: O(1)
   @available(SwiftCompatibilitySpan 5.0, *)
   @_alwaysEmitIntoClient
   public var span: Span<Element> {

--- a/stdlib/public/core/StringUTF8View.swift
+++ b/stdlib/public/core/StringUTF8View.swift
@@ -348,10 +348,9 @@ extension String.UTF8View {
 #if !(os(watchOS) && _pointerBitWidth(_32))
   /// A span over the UTF-8 code units that make up this string.
   ///
-  /// - Note: In the case of bridged UTF-16 `String` instances (on Apple
-  ///   platforms) this property transcodes the code units the first time
-  ///   it is called. The transcoded buffer is cached, and subsequent calls
-  ///   to `span` can reuse the buffer.
+  /// - Note: On Apple platforms, this property transcodes the code units
+  ///   of bridged UTF-16 `String` instances on first access and caches
+  ///   the result. Subsequent calls can reuse the cached buffer.
   ///
   /// - Returns: A `Span` over the UTF-8 code units of this `String`.
   ///
@@ -367,10 +366,9 @@ extension String.UTF8View {
 
   /// A span over the UTF-8 code units that make up this string.
   ///
-  /// - Note: In the case of bridged UTF-16 `String` instances (on Apple
-  ///   platforms) this property transcodes the code units the first time
-  ///   it is called. The transcoded buffer is cached, and subsequent calls
-  ///   to `span` can reuse the buffer.
+  /// - Note: On Apple platforms, this property transcodes the code units
+  ///   of bridged UTF-16 `String` instances on first access and caches
+  ///   the result. Subsequent calls can reuse the cached buffer.
   ///
   /// - Returns: A `Span` over the UTF-8 code units of this `String`.
   ///
@@ -395,10 +393,9 @@ extension String.UTF8View {
 
   /// A span over the UTF-8 code units that make up this string.
   ///
-  /// - Note: In the case of bridged UTF-16 `String` instances (on Apple
-  ///   platforms) this property transcodes the code units the first time
-  ///   it is called. The transcoded buffer is cached, and subsequent calls
-  ///   to `span` can reuse the buffer.
+  /// - Note: On Apple platforms, this property transcodes the code units
+  ///   of bridged UTF-16 `String` instances on first access and caches
+  ///   the result. Subsequent calls can reuse the cached buffer.
   ///
   /// - Returns: A `Span` over the UTF-8 code units of this `String`, or `nil`
   ///   if the `String`'s representation is non-contiguous.

--- a/stdlib/public/core/StringUTF8View.swift
+++ b/stdlib/public/core/StringUTF8View.swift
@@ -346,17 +346,17 @@ extension String.UTF8View {
   }
 
 #if !(os(watchOS) && _pointerBitWidth(_32))
-  /// A span over the UTF8 code units that make up this string.
+  /// A span over the UTF-8 code units that make up this string.
   ///
-  /// - Note: In the case of bridged UTF16 String instances (on Apple
-  /// platforms,) this property transcodes the code units the first time
-  /// it is called. The transcoded buffer is cached, and subsequent calls
-  /// to `span` can reuse the buffer.
+  /// - Note: In the case of bridged UTF-16 `String` instances (on Apple
+  ///   platforms) this property transcodes the code units the first time
+  ///   it is called. The transcoded buffer is cached, and subsequent calls
+  ///   to `span` can reuse the buffer.
   ///
-  ///  Returns: a `Span` over the UTF8 code units of this String.
+  /// - Returns: A `Span` over the UTF-8 code units of this `String`.
   ///
-  ///  Complexity: O(1) for native UTF8 Strings,
-  ///  amortized O(1) for bridged UTF16 Strings.
+  /// - Complexity: O(1) for native UTF-8 strings, amortized O(1) for bridged
+  ///   UTF-16 strings.
   @available(SwiftStdlib 6.2, *)
   public var span: Span<UTF8.CodeUnit> {
     @lifetime(borrow self)
@@ -365,17 +365,17 @@ extension String.UTF8View {
     }
   }
 
-  /// A span over the UTF8 code units that make up this string.
+  /// A span over the UTF-8 code units that make up this string.
   ///
-  /// - Note: In the case of bridged UTF16 String instances (on Apple
-  /// platforms,) this property transcodes the code units the first time
-  /// it is called. The transcoded buffer is cached, and subsequent calls
-  /// to `span` can reuse the buffer.
+  /// - Note: In the case of bridged UTF-16 `String` instances (on Apple
+  ///   platforms) this property transcodes the code units the first time
+  ///   it is called. The transcoded buffer is cached, and subsequent calls
+  ///   to `span` can reuse the buffer.
   ///
-  ///  Returns: a `Span` over the UTF8 code units of this String.
+  /// - Returns: A `Span` over the UTF-8 code units of this `String`.
   ///
-  ///  Complexity: O(1) for native UTF8 Strings,
-  ///  amortized O(1) for bridged UTF16 Strings.
+  /// - Complexity: O(1) for native UTF-8 strings, amortized O(1) for bridged
+  ///   UTF-16 strings.
   @available(SwiftStdlib 6.2, *)
   public var _span: Span<UTF8.CodeUnit>? {
     @_alwaysEmitIntoClient @inline(__always)
@@ -393,18 +393,18 @@ extension String.UTF8View {
     }
   }
 
-  /// A span over the UTF8 code units that make up this string.
+  /// A span over the UTF-8 code units that make up this string.
   ///
-  /// - Note: In the case of bridged UTF16 String instances (on Apple
-  /// platforms,) this property transcodes the code units the first time
-  /// it is called. The transcoded buffer is cached, and subsequent calls
-  /// to `span` can reuse the buffer.
+  /// - Note: In the case of bridged UTF-16 `String` instances (on Apple
+  ///   platforms) this property transcodes the code units the first time
+  ///   it is called. The transcoded buffer is cached, and subsequent calls
+  ///   to `span` can reuse the buffer.
   ///
-  ///  Returns: a `Span` over the UTF8 code units of this String, or `nil`
-  ///           if the String does not have a contiguous representation.
+  /// - Returns: A `Span` over the UTF-8 code units of this `String`, or `nil`
+  ///   if the `String`'s representation is non-contiguous.
   ///
-  ///  Complexity: O(1) for native UTF8 Strings,
-  ///  amortized O(1) for bridged UTF16 Strings.
+  /// - Complexity: O(1) for native UTF-8 strings, amortized O(1) for bridged
+  ///   UTF-16 strings.
   @available(SwiftStdlib 6.2, *)
   public var _span: Span<UTF8.CodeUnit>? {
     @lifetime(borrow self)

--- a/stdlib/public/core/Substring.swift
+++ b/stdlib/public/core/Substring.swift
@@ -823,18 +823,22 @@ extension Substring.UTF8View {
   ///
   ///   For example, if `string` has the bridged UTF-16 representation,
   ///
-  ///       for word in string.split(separator: " ") {
-  ///           useSpan(word.span)
-  ///       }
+  /// ```swift
+  ///   for word in string.split(separator: " ") {
+  ///       useSpan(word.span)
+  ///   }
+  /// ```
   ///
   ///   is accidentally quadratic because of this issue. A workaround is to
   ///   explicitly convert the string into its native UTF-8 representation:
   ///
-  ///       var nativeString = consume string
-  ///       nativeString.makeContiguousUTF8()
-  ///       for word in nativeString.split(separator: " ") {
-  ///           useSpan(word.span)
-  ///       }
+  /// ```swift
+  ///   var nativeString = consume string
+  ///   nativeString.makeContiguousUTF8()
+  ///   for word in nativeString.split(separator: " ") {
+  ///       useSpan(word.span)
+  ///   }
+  /// ```
   ///
   ///   This second option has linear time complexity, as expected.
   ///
@@ -858,18 +862,22 @@ extension Substring.UTF8View {
   ///
   ///   For example, if `string` has the bridged UTF-16 representation,
   ///
-  ///       for word in string.split(separator: " ") {
-  ///           useSpan(word.span)
-  ///       }
+  /// ```swift
+  ///   for word in string.split(separator: " ") {
+  ///       useSpan(word.span)
+  ///   }
+  /// ```
   ///
   ///   is accidentally quadratic because of this issue. A workaround is to
   ///   explicitly convert the string into its native UTF-8 representation:
   ///
-  ///       var nativeString = consume string
-  ///       nativeString.makeContiguousUTF8()
-  ///       for word in nativeString.split(separator: " ") {
-  ///           useSpan(word.span)
-  ///       }
+  /// ```swift
+  ///   var nativeString = consume string
+  ///   nativeString.makeContiguousUTF8()
+  ///   for word in nativeString.split(separator: " ") {
+  ///       useSpan(word.span)
+  ///   }
+  /// ```
   ///
   ///   This second option has linear time complexity, as expected.
   ///
@@ -899,18 +907,22 @@ extension Substring.UTF8View {
   ///
   ///   For example, if `string` has the bridged UTF-16 representation,
   ///
-  ///       for word in string.split(separator: " ") {
-  ///           useSpan(word.span)
-  ///       }
+  /// ```swift
+  ///   for word in string.split(separator: " ") {
+  ///       useSpan(word.span)
+  ///   }
+  /// ```
   ///
   ///   is accidentally quadratic because of this issue. A workaround is to
   ///   explicitly convert the string into its native UTF-8 representation:
   ///
-  ///       var nativeString = consume string
-  ///       nativeString.makeContiguousUTF8()
-  ///       for word in nativeString.split(separator: " ") {
-  ///           useSpan(word.span)
-  ///       }
+  /// ```swift
+  ///   var nativeString = consume string
+  ///   nativeString.makeContiguousUTF8()
+  ///   for word in nativeString.split(separator: " ") {
+  ///       useSpan(word.span)
+  ///   }
+  /// ```
   ///
   ///   This second option has linear time complexity, as expected.
   ///

--- a/stdlib/public/core/Substring.swift
+++ b/stdlib/public/core/Substring.swift
@@ -817,9 +817,8 @@ extension Substring.UTF8View {
 #if !(os(watchOS) && _pointerBitWidth(_32))
   /// A span over the UTF-8 code units that make up this substring.
   ///
-  /// - Note: In the case of bridged UTF-16 `String` instances (on Apple
-  ///   platforms) this property needs to transcode the code units every time
-  ///   it is called.
+  /// - Note: On Apple platforms, this property must transcode the code
+  ///   units of bridged UTF-16 `String` instances on every access.
   ///
   ///   For example, if `string` has the bridged UTF-16 representation,
   ///
@@ -856,9 +855,8 @@ extension Substring.UTF8View {
 
   /// A span over the UTF-8 code units that make up this substring.
   ///
-  /// - Note: In the case of bridged UTF-16 `String` instances (on Apple
-  ///   platforms) this property needs to transcode the code units every time
-  ///   it is called.
+  /// - Note: On Apple platforms, this property must transcode the code
+  ///   units of bridged UTF-16 `String` instances on every access.
   ///
   ///   For example, if `string` has the bridged UTF-16 representation,
   ///
@@ -901,9 +899,8 @@ extension Substring.UTF8View {
 
   /// A span over the UTF-8 code units that make up this substring.
   ///
-  /// - Note: In the case of bridged UTF-16 `String` instances (on Apple
-  ///   platforms) this property needs to transcode the code units every time
-  ///   it is called.
+  /// - Note: On Apple platforms, this property must transcode the code
+  ///   units of bridged UTF-16 `String` instances on every access.
   ///
   ///   For example, if `string` has the bridged UTF-16 representation,
   ///

--- a/stdlib/public/core/Substring.swift
+++ b/stdlib/public/core/Substring.swift
@@ -815,27 +815,33 @@ extension Substring.UTF8View {
   }
 
 #if !(os(watchOS) && _pointerBitWidth(_32))
-  /// A span over the UTF8 code units that make up this substring.
+  /// A span over the UTF-8 code units that make up this substring.
   ///
-  /// - Note: In the case of bridged UTF16 String instances (on Apple
-  /// platforms,) this property needs to transcode the code units every time
-  /// it is called.
-  /// For example, if `string` has the bridged UTF16 representation,
-  ///     for word in string.split(separator: " ") {
-  ///         useSpan(word.span)
-  ///     }
-  ///  is accidentally quadratic because of this issue. A workaround is to
-  ///  explicitly convert the string into its native UTF8 representation:
-  ///      var nativeString = consume string
-  ///      nativeString.makeContiguousUTF8()
-  ///      for word in nativeString.split(separator: " ") {
-  ///          useSpan(word.span)
-  ///      }
-  ///  This second option has linear time complexity, as expected.
+  /// - Note: In the case of bridged UTF-16 `String` instances (on Apple
+  ///   platforms) this property needs to transcode the code units every time
+  ///   it is called.
   ///
-  ///  Returns: a `Span` over the UTF8 code units of this Substring.
+  ///   For example, if `string` has the bridged UTF-16 representation,
   ///
-  ///  Complexity: O(1) for native UTF8 Strings, O(n) for bridged UTF16 Strings.
+  ///       for word in string.split(separator: " ") {
+  ///           useSpan(word.span)
+  ///       }
+  ///
+  ///   is accidentally quadratic because of this issue. A workaround is to
+  ///   explicitly convert the string into its native UTF-8 representation:
+  ///
+  ///       var nativeString = consume string
+  ///       nativeString.makeContiguousUTF8()
+  ///       for word in nativeString.split(separator: " ") {
+  ///           useSpan(word.span)
+  ///       }
+  ///
+  ///   This second option has linear time complexity, as expected.
+  ///
+  /// - Returns: A `Span` over the UTF-8 code units of this `Substring`.
+  ///
+  /// - Complexity: O(1) for native UTF-8 strings, O(*n*) for bridged UTF-16
+  ///   strings.
   @available(SwiftStdlib 6.2, *)
   public var span: Span<UTF8.CodeUnit> {
     @lifetime(borrow self)
@@ -844,27 +850,33 @@ extension Substring.UTF8View {
     }
   }
 
-  /// A span over the UTF8 code units that make up this substring.
+  /// A span over the UTF-8 code units that make up this substring.
   ///
-  /// - Note: In the case of bridged UTF16 String instances (on Apple
-  /// platforms,) this property needs to transcode the code units every time
-  /// it is called.
-  /// For example, if `string` has the bridged UTF16 representation,
-  ///     for word in string.split(separator: " ") {
-  ///         useSpan(word.span)
-  ///     }
-  ///  is accidentally quadratic because of this issue. A workaround is to
-  ///  explicitly convert the string into its native UTF8 representation:
-  ///      var nativeString = consume string
-  ///      nativeString.makeContiguousUTF8()
-  ///      for word in nativeString.split(separator: " ") {
-  ///          useSpan(word.span)
-  ///      }
-  ///  This second option has linear time complexity, as expected.
+  /// - Note: In the case of bridged UTF-16 `String` instances (on Apple
+  ///   platforms) this property needs to transcode the code units every time
+  ///   it is called.
   ///
-  ///  Returns: a `Span` over the UTF8 code units of this Substring.
+  ///   For example, if `string` has the bridged UTF-16 representation,
   ///
-  ///  Complexity: O(1) for native UTF8 Strings, O(n) for bridged UTF16 Strings.
+  ///       for word in string.split(separator: " ") {
+  ///           useSpan(word.span)
+  ///       }
+  ///
+  ///   is accidentally quadratic because of this issue. A workaround is to
+  ///   explicitly convert the string into its native UTF-8 representation:
+  ///
+  ///       var nativeString = consume string
+  ///       nativeString.makeContiguousUTF8()
+  ///       for word in nativeString.split(separator: " ") {
+  ///           useSpan(word.span)
+  ///       }
+  ///
+  ///   This second option has linear time complexity, as expected.
+  ///
+  /// - Returns: A `Span` over the UTF-8 code units of this `Substring`.
+  ///
+  /// - Complexity: O(1) for native UTF-8 strings, O(*n*) for bridged UTF-16
+  ///   strings.
   @available(SwiftStdlib 6.2, *)
   public var _span: Span<UTF8.CodeUnit>? {
     @_alwaysEmitIntoClient @inline(__always)
@@ -879,28 +891,34 @@ extension Substring.UTF8View {
     fatalError("\(#function) unavailable on 32-bit watchOS")
   }
 
-  /// A span over the UTF8 code units that make up this substring.
+  /// A span over the UTF-8 code units that make up this substring.
   ///
-  /// - Note: In the case of bridged UTF16 String instances (on Apple
-  /// platforms,) this property needs to transcode the code units every time
-  /// it is called.
-  /// For example, if `string` has the bridged UTF16 representation,
-  ///     for word in string.split(separator: " ") {
-  ///         useSpan(word.span)
-  ///     }
-  ///  is accidentally quadratic because of this issue. A workaround is to
-  ///  explicitly convert the string into its native UTF8 representation:
-  ///      var nativeString = consume string
-  ///      nativeString.makeContiguousUTF8()
-  ///      for word in nativeString.split(separator: " ") {
-  ///          useSpan(word.span)
-  ///      }
-  ///  This second option has linear time complexity, as expected.
+  /// - Note: In the case of bridged UTF-16 `String` instances (on Apple
+  ///   platforms) this property needs to transcode the code units every time
+  ///   it is called.
   ///
-  ///  Returns: a `Span` over the UTF8 code units of this Substring, or `nil`
-  ///           if the Substring does not have a contiguous representation.
+  ///   For example, if `string` has the bridged UTF-16 representation,
   ///
-  ///  Complexity: O(1) for native UTF8 Strings, O(n) for bridged UTF16 Strings.
+  ///       for word in string.split(separator: " ") {
+  ///           useSpan(word.span)
+  ///       }
+  ///
+  ///   is accidentally quadratic because of this issue. A workaround is to
+  ///   explicitly convert the string into its native UTF-8 representation:
+  ///
+  ///       var nativeString = consume string
+  ///       nativeString.makeContiguousUTF8()
+  ///       for word in nativeString.split(separator: " ") {
+  ///           useSpan(word.span)
+  ///       }
+  ///
+  ///   This second option has linear time complexity, as expected.
+  ///
+  /// - Returns: A `Span` over the UTF-8 code units of this `Substring`, or
+  ///   `nil` if the `Substring`'s representation is non-contiguous.
+  ///
+  /// - Complexity: O(1) for native UTF-8 strings, O(*n*) for bridged UTF-16
+  ///   strings.
   @available(SwiftStdlib 6.2, *)
   public var _span: Span<UTF8.CodeUnit>? {
     @lifetime(borrow self)

--- a/stdlib/public/core/UTF8Span.swift
+++ b/stdlib/public/core/UTF8Span.swift
@@ -195,6 +195,8 @@ extension UTF8Span {
 
   /// A span used to access the code units.
   ///
+  /// - Returns: A `Span` over the UTF-8 code units of this `UTF8Span`.
+  ///
   /// - Complexity: O(1)
   public var span: Span<UInt8> {
     @lifetime(copy self)
@@ -254,12 +256,12 @@ extension String {
 #if !(os(watchOS) && _pointerBitWidth(_32))
   /// A UTF-8 span over the code units that make up this string.
   ///
-  /// - Note: In the case of bridged UTF-16 string instances (on Apple
+  /// - Note: In the case of bridged UTF-16 `String` instances (on Apple
   ///   platforms) this property transcodes the code units the first time
-  ///   it's called. The transcoded buffer is cached, and subsequent calls
+  ///   it is called. The transcoded buffer is cached, and subsequent calls
   ///   can reuse the buffer.
   ///
-  /// - Returns: A `UTF8Span` over the code units of this string.
+  /// - Returns: A `UTF8Span` over the code units of this `String`.
   ///
   /// - Complexity: O(1) for native UTF-8 strings, amortized O(1) for bridged
   ///   UTF-16 strings.
@@ -275,12 +277,12 @@ extension String {
 
   /// A UTF-8 span over the code units that make up this string.
   ///
-  /// - Note: In the case of bridged UTF-16 string instances (on Apple
+  /// - Note: In the case of bridged UTF-16 `String` instances (on Apple
   ///   platforms) this property transcodes the code units the first time
-  ///   it's called. The transcoded buffer is cached, and subsequent calls
+  ///   it is called. The transcoded buffer is cached, and subsequent calls
   ///   can reuse the buffer.
   ///
-  /// - Returns: A `UTF8Span` over the code units of this string.
+  /// - Returns: A `UTF8Span` over the code units of this `String`.
   ///
   /// - Complexity: O(1) for native UTF-8 strings, amortized O(1) for bridged
   ///   UTF-16 strings.
@@ -300,13 +302,13 @@ extension String {
 
   /// A UTF-8 span over the code units that make up this string.
   ///
-  /// - Note: In the case of bridged UTF-16 string instances (on Apple
+  /// - Note: In the case of bridged UTF-16 `String` instances (on Apple
   ///   platforms) this property transcodes the code units the first time
-  ///   it's called. The transcoded buffer is cached, and subsequent calls
+  ///   it is called. The transcoded buffer is cached, and subsequent calls
   ///   can reuse the buffer.
   ///
-  /// - Returns: A `UTF8Span` over the code units of this string, or `nil`
-  ///   if the string does not have a contiguous representation.
+  /// - Returns: A `UTF8Span` over the code units of this `String`, or `nil`
+  ///   if the `String`'s representation is non-contiguous.
   ///
   /// - Complexity: O(1) for native UTF-8 strings, amortized O(1) for bridged
   ///   UTF-16 strings.
@@ -359,31 +361,30 @@ extension Substring {
 #if !(os(watchOS) && _pointerBitWidth(_32))
   /// A UTF-8 span over the code units that make up this substring.
   ///
-  /// - Note: In the case of bridged UTF-16 string instances (on Apple
+  /// - Note: In the case of bridged UTF-16 `String` instances (on Apple
   ///   platforms) this property needs to transcode the code units every time
-  ///   it's called.
+  ///   it is called.
   ///
-  /// For example, if `string` has the bridged UTF-16 representation,
-  /// the following code is accidentally quadratic because of this issue:
+  ///   For example, if `string` has the bridged UTF-16 representation,
   ///
-  ///     for word in string.split(separator: " ") {
-  ///         useSpan(word.span)
-  ///     }
+  ///       for word in string.split(separator: " ") {
+  ///           useSpan(word.span)
+  ///       }
   ///
-  /// A workaround is to explicitly convert the string into its native UTF-8
-  /// representation:
+  ///   is accidentally quadratic because of this issue. A workaround is to
+  ///   explicitly convert the string into its native UTF-8 representation:
   ///
-  ///     var nativeString = consume string
-  ///     nativeString.makeContiguousUTF8()
-  ///     for word in nativeString.split(separator: " ") {
-  ///         useSpan(word.span)
-  ///     }
+  ///       var nativeString = consume string
+  ///       nativeString.makeContiguousUTF8()
+  ///       for word in nativeString.split(separator: " ") {
+  ///           useSpan(word.span)
+  ///       }
   ///
-  /// This second option has linear time complexity, as expected.
+  ///   This second option has linear time complexity, as expected.
   ///
-  /// - Returns: A `UTF8Span` over the code units of this substring.
+  /// - Returns: A `UTF8Span` over the code units of this `Substring`.
   ///
-  /// - Complexity: O(1) for native UTF-8 strings, O(n) for bridged UTF-16
+  /// - Complexity: O(1) for native UTF-8 strings, O(*n*) for bridged UTF-16
   ///   strings.
   @available(SwiftStdlib 6.2, *)
   public var utf8Span: UTF8Span {
@@ -397,31 +398,30 @@ extension Substring {
 
   /// A UTF-8 span over the code units that make up this substring.
   ///
-  /// - Note: In the case of bridged UTF-16 string instances (on Apple
+  /// - Note: In the case of bridged UTF-16 `String` instances (on Apple
   ///   platforms) this property needs to transcode the code units every time
-  ///   it's called.
+  ///   it is called.
   ///
-  /// For example, if `string` has the bridged UTF-16 representation,
-  /// the following code is accidentally quadratic because of this issue:
+  ///   For example, if `string` has the bridged UTF-16 representation,
   ///
-  ///     for word in string.split(separator: " ") {
-  ///         useSpan(word.span)
-  ///     }
+  ///       for word in string.split(separator: " ") {
+  ///           useSpan(word.span)
+  ///       }
   ///
-  /// A workaround is to explicitly convert the string into its native UTF-8
-  /// representation:
+  ///   is accidentally quadratic because of this issue. A workaround is to
+  ///   explicitly convert the string into its native UTF-8 representation:
   ///
-  ///     var nativeString = consume string
-  ///     nativeString.makeContiguousUTF8()
-  ///     for word in nativeString.split(separator: " ") {
-  ///         useSpan(word.span)
-  ///     }
+  ///       var nativeString = consume string
+  ///       nativeString.makeContiguousUTF8()
+  ///       for word in nativeString.split(separator: " ") {
+  ///           useSpan(word.span)
+  ///       }
   ///
-  /// This second option has linear time complexity, as expected.
+  ///   This second option has linear time complexity, as expected.
   ///
-  /// - Returns: A `UTF8Span` over the code units of this substring.
+  /// - Returns: A `UTF8Span` over the code units of this `Substring`.
   ///
-  /// - Complexity: O(1) for native UTF-8 strings, O(n) for bridged UTF-16
+  /// - Complexity: O(1) for native UTF-8 strings, O(*n*) for bridged UTF-16
   ///   strings.
   @available(SwiftStdlib 6.2, *)
   public var _utf8Span: UTF8Span? {
@@ -439,32 +439,31 @@ extension Substring {
 
   /// A UTF-8 span over the code units that make up this substring.
   ///
-  /// - Note: In the case of bridged UTF-16 string instances (on Apple
+  /// - Note: In the case of bridged UTF-16 `String` instances (on Apple
   ///   platforms) this property needs to transcode the code units every time
-  ///   it's called.
+  ///   it is called.
   ///
-  /// For example, if `string` has the bridged UTF-16 representation,
-  /// the following code is accidentally quadratic because of this issue:
+  ///   For example, if `string` has the bridged UTF-16 representation,
   ///
-  ///     for word in string.split(separator: " ") {
-  ///         useSpan(word.span)
-  ///     }
+  ///       for word in string.split(separator: " ") {
+  ///           useSpan(word.span)
+  ///       }
   ///
-  /// A workaround is to explicitly convert the string into its native UTF-8
-  /// representation:
+  ///   is accidentally quadratic because of this issue. A workaround is to
+  ///   explicitly convert the string into its native UTF-8 representation:
   ///
-  ///     var nativeString = consume string
-  ///     nativeString.makeContiguousUTF8()
-  ///     for word in nativeString.split(separator: " ") {
-  ///         useSpan(word.span)
-  ///     }
+  ///       var nativeString = consume string
+  ///       nativeString.makeContiguousUTF8()
+  ///       for word in nativeString.split(separator: " ") {
+  ///           useSpan(word.span)
+  ///       }
   ///
-  /// This second option has linear time complexity, as expected.
+  ///   This second option has linear time complexity, as expected.
   ///
-  /// - Returns: A `UTF8Span` over the code units of this substring, or `nil`
-  ///   if the substring does not have a contiguous representation.
+  /// - Returns: A `UTF8Span` over the code units of this `Substring`, or `nil`
+  ///   if the `Substring`'s representation is non-contiguous.
   ///
-  /// - Complexity: O(1) for native UTF-8 strings, O(n) for bridged UTF-16
+  /// - Complexity: O(1) for native UTF-8 strings, O(*n*) for bridged UTF-16
   ///   strings.
   @available(SwiftStdlib 6.2, *)
   public var _utf8Span: UTF8Span? {

--- a/stdlib/public/core/UTF8Span.swift
+++ b/stdlib/public/core/UTF8Span.swift
@@ -256,10 +256,9 @@ extension String {
 #if !(os(watchOS) && _pointerBitWidth(_32))
   /// A UTF-8 span over the code units that make up this string.
   ///
-  /// - Note: In the case of bridged UTF-16 `String` instances (on Apple
-  ///   platforms) this property transcodes the code units the first time
-  ///   it is called. The transcoded buffer is cached, and subsequent calls
-  ///   can reuse the buffer.
+  /// - Note: On Apple platforms, this property transcodes the code units
+  ///   of bridged UTF-16 `String` instances on first access and caches
+  ///   the result. Subsequent calls can reuse the cached buffer.
   ///
   /// - Returns: A `UTF8Span` over the code units of this `String`.
   ///
@@ -277,10 +276,9 @@ extension String {
 
   /// A UTF-8 span over the code units that make up this string.
   ///
-  /// - Note: In the case of bridged UTF-16 `String` instances (on Apple
-  ///   platforms) this property transcodes the code units the first time
-  ///   it is called. The transcoded buffer is cached, and subsequent calls
-  ///   can reuse the buffer.
+  /// - Note: On Apple platforms, this property transcodes the code units
+  ///   of bridged UTF-16 `String` instances on first access and caches
+  ///   the result. Subsequent calls can reuse the cached buffer.
   ///
   /// - Returns: A `UTF8Span` over the code units of this `String`.
   ///
@@ -302,10 +300,9 @@ extension String {
 
   /// A UTF-8 span over the code units that make up this string.
   ///
-  /// - Note: In the case of bridged UTF-16 `String` instances (on Apple
-  ///   platforms) this property transcodes the code units the first time
-  ///   it is called. The transcoded buffer is cached, and subsequent calls
-  ///   can reuse the buffer.
+  /// - Note: On Apple platforms, this property transcodes the code units
+  ///   of bridged UTF-16 `String` instances on first access and caches
+  ///   the result. Subsequent calls can reuse the cached buffer.
   ///
   /// - Returns: A `UTF8Span` over the code units of this `String`, or `nil`
   ///   if the `String`'s representation is non-contiguous.
@@ -361,9 +358,8 @@ extension Substring {
 #if !(os(watchOS) && _pointerBitWidth(_32))
   /// A UTF-8 span over the code units that make up this substring.
   ///
-  /// - Note: In the case of bridged UTF-16 `String` instances (on Apple
-  ///   platforms) this property needs to transcode the code units every time
-  ///   it is called.
+  /// - Note: On Apple platforms, this property must transcode the code
+  ///   units of bridged UTF-16 `String` instances on every access.
   ///
   ///   For example, if `string` has the bridged UTF-16 representation,
   ///
@@ -402,9 +398,8 @@ extension Substring {
 
   /// A UTF-8 span over the code units that make up this substring.
   ///
-  /// - Note: In the case of bridged UTF-16 `String` instances (on Apple
-  ///   platforms) this property needs to transcode the code units every time
-  ///   it is called.
+  /// - Note: On Apple platforms, this property must transcode the code
+  ///   units of bridged UTF-16 `String` instances on every access.
   ///
   ///   For example, if `string` has the bridged UTF-16 representation,
   ///
@@ -447,9 +442,8 @@ extension Substring {
 
   /// A UTF-8 span over the code units that make up this substring.
   ///
-  /// - Note: In the case of bridged UTF-16 `String` instances (on Apple
-  ///   platforms) this property needs to transcode the code units every time
-  ///   it is called.
+  /// - Note: On Apple platforms, this property must transcode the code
+  ///   units of bridged UTF-16 `String` instances on every access.
   ///
   ///   For example, if `string` has the bridged UTF-16 representation,
   ///

--- a/stdlib/public/core/UTF8Span.swift
+++ b/stdlib/public/core/UTF8Span.swift
@@ -367,18 +367,22 @@ extension Substring {
   ///
   ///   For example, if `string` has the bridged UTF-16 representation,
   ///
-  ///       for word in string.split(separator: " ") {
-  ///           useSpan(word.span)
-  ///       }
+  /// ```swift
+  ///   for word in string.split(separator: " ") {
+  ///       useSpan(word.span)
+  ///   }
+  /// ```
   ///
   ///   is accidentally quadratic because of this issue. A workaround is to
   ///   explicitly convert the string into its native UTF-8 representation:
   ///
-  ///       var nativeString = consume string
-  ///       nativeString.makeContiguousUTF8()
-  ///       for word in nativeString.split(separator: " ") {
-  ///           useSpan(word.span)
-  ///       }
+  /// ```swift
+  ///   var nativeString = consume string
+  ///   nativeString.makeContiguousUTF8()
+  ///   for word in nativeString.split(separator: " ") {
+  ///       useSpan(word.span)
+  ///   }
+  /// ```
   ///
   ///   This second option has linear time complexity, as expected.
   ///
@@ -404,18 +408,22 @@ extension Substring {
   ///
   ///   For example, if `string` has the bridged UTF-16 representation,
   ///
-  ///       for word in string.split(separator: " ") {
-  ///           useSpan(word.span)
-  ///       }
+  /// ```swift
+  ///   for word in string.split(separator: " ") {
+  ///       useSpan(word.span)
+  ///   }
+  /// ```
   ///
   ///   is accidentally quadratic because of this issue. A workaround is to
   ///   explicitly convert the string into its native UTF-8 representation:
   ///
-  ///       var nativeString = consume string
-  ///       nativeString.makeContiguousUTF8()
-  ///       for word in nativeString.split(separator: " ") {
-  ///           useSpan(word.span)
-  ///       }
+  /// ```swift
+  ///   var nativeString = consume string
+  ///   nativeString.makeContiguousUTF8()
+  ///   for word in nativeString.split(separator: " ") {
+  ///       useSpan(word.span)
+  ///   }
+  /// ```
   ///
   ///   This second option has linear time complexity, as expected.
   ///
@@ -445,18 +453,22 @@ extension Substring {
   ///
   ///   For example, if `string` has the bridged UTF-16 representation,
   ///
-  ///       for word in string.split(separator: " ") {
-  ///           useSpan(word.span)
-  ///       }
+  /// ```swift
+  ///   for word in string.split(separator: " ") {
+  ///       useSpan(word.span)
+  ///   }
+  /// ```
   ///
   ///   is accidentally quadratic because of this issue. A workaround is to
   ///   explicitly convert the string into its native UTF-8 representation:
   ///
-  ///       var nativeString = consume string
-  ///       nativeString.makeContiguousUTF8()
-  ///       for word in nativeString.split(separator: " ") {
-  ///           useSpan(word.span)
-  ///       }
+  /// ```swift
+  ///   var nativeString = consume string
+  ///   nativeString.makeContiguousUTF8()
+  ///   for word in nativeString.split(separator: " ") {
+  ///       useSpan(word.span)
+  ///   }
+  /// ```
   ///
   ///   This second option has linear time complexity, as expected.
   ///

--- a/stdlib/public/core/UniqueBox.swift
+++ b/stdlib/public/core/UniqueBox.swift
@@ -76,8 +76,11 @@ extension UniqueBox where Value: ~Copyable {
 
 @available(SwiftStdlib 6.4, *)
 extension UniqueBox where Value: ~Copyable {
-  /// Returns a single element span reference to the instance of `Value` stored
-  /// within this unqiue box.
+  /// A span over the single element stored in this box.
+  ///
+  /// - Returns: A `Span` over the element stored in this box.
+  ///
+  /// - Complexity: O(1)
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
   public var span: Span<Value> {
@@ -88,8 +91,11 @@ extension UniqueBox where Value: ~Copyable {
     }
   }
 
-  /// Returns a single element mutable span reference to the instance of `Value`
-  /// stored within this unqiue box.
+  /// A mutable span over the single element stored in this box.
+  ///
+  /// - Returns: A `MutableSpan` over the element stored in this box.
+  ///
+  /// - Complexity: O(1)
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
   public var mutableSpan: MutableSpan<Value> {

--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -577,6 +577,21 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
 @available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
+  /// A span over the elements of this buffer.
+  ///
+  /// The lifetime of the returned span matches the lifetime of the binding
+  /// which returns it. This lifetime is a convenience, as there can be
+  /// no enforcement that there is no concurrent write to the underlying memory.
+  /// The programmer must ensure that the memory remains allocated, initialized
+  /// and immutable for the lifetime of the returned span.
+  ///
+  /// - Note: This property is unsafe because it cannot guarantee that the
+  ///   underlying memory remains valid and immutable for the lifetime of
+  ///   the returned span.
+  ///
+  /// - Returns: A `Span` over the elements of this buffer.
+  ///
+  /// - Complexity: O(1)
   @unsafe
   @_alwaysEmitIntoClient
   public var span: Span<Element> {
@@ -588,6 +603,21 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
   }
 %if Mutable:
 
+  /// A mutable span over the elements of this buffer.
+  ///
+  /// The lifetime of the returned span matches the lifetime of the binding
+  /// which returns it. This lifetime is a convenience, as there can be no
+  /// enforcement that there is no concurrent access to the underlying memory.
+  /// The programmer must ensure that the memory remains allocated, initialized
+  /// and exclusively accessed for the lifetime of the returned span.
+  ///
+  /// - Note: This property is unsafe because it cannot guarantee that the
+  ///   underlying memory remains valid and exclusively accessed for the
+  ///   lifetime of the returned span.
+  ///
+  /// - Returns: A `MutableSpan` over the elements of this buffer.
+  ///
+  /// - Complexity: O(1)
   @unsafe
   @_alwaysEmitIntoClient
   public var mutableSpan: MutableSpan<Element> {

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -1196,6 +1196,21 @@ extension Unsafe${Mutable}RawBufferPointer {
 @available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension Unsafe${Mutable}RawBufferPointer {
+  /// A span over the bytes of this buffer.
+  ///
+  /// The lifetime of the returned span matches the lifetime of the binding
+  /// which returns it. This lifetime is a convenience, as there can be
+  /// no enforcement that there is no concurrent write to the underlying memory.
+  /// The programmer must ensure that the memory remains allocated, initialized
+  /// and immutable for the lifetime of the returned span.
+  ///
+  /// - Note: This property is unsafe because it cannot guarantee that the
+  ///   underlying memory remains valid and immutable for the lifetime of
+  ///   the returned span.
+  ///
+  /// - Returns: A `RawSpan` over the bytes of this buffer.
+  ///
+  /// - Complexity: O(1)
   @unsafe
   @_alwaysEmitIntoClient
   public var bytes: RawSpan {
@@ -1207,6 +1222,21 @@ extension Unsafe${Mutable}RawBufferPointer {
   }
 %  if Mutable:
 
+  /// A mutable span over the bytes of this buffer.
+  ///
+  /// The lifetime of the returned span matches the lifetime of the binding
+  /// which returns it. This lifetime is a convenience, as there can be no
+  /// enforcement that there is no concurrent access to the underlying memory.
+  /// The programmer must ensure that the memory remains allocated, initialized
+  /// and exclusively accessed for the lifetime of the returned span.
+  ///
+  /// - Note: This property is unsafe because it cannot guarantee that the
+  ///   underlying memory remains valid and exclusively accessed for the
+  ///   lifetime of the returned span.
+  ///
+  /// - Returns: A `MutableRawSpan` over the bytes of this buffer.
+  ///
+  /// - Complexity: O(1)
   @unsafe
   @_alwaysEmitIntoClient
   public var mutableBytes: MutableRawSpan {


### PR DESCRIPTION
The `span`, `bytes`, `mutableSpan` and `mutableBytes` properties of several types have been missing their doc-comments, while others had overly terse ones. This rounds them out, also making them consistent with each other.

Addresses rdar://147935102