### PR TITLE
[Reflection] Support parameter packs in generic substitutions.

### DIFF
--- a/include/swift/Remote/MetadataReader.h
+++ b/include/swift/Remote/MetadataReader.h
@@ -3150,13 +3150,27 @@ private:
     
     auto numGenericArgs =
       generics->getGenericContextHeader().getNumArguments();
-    
+
     auto offsetToGenericArgs = readGenericArgsOffset(metadata, descriptor);
     if (!offsetToGenericArgs)
       return {};
 
-    auto genericArgsAddr = getAddress(metadata)
+    auto genericArgsBaseAddr = getAddress(metadata)
       + sizeof(StoredPointer) * *offsetToGenericArgs;
+
+    // The generic argument layout begins with one StoredSize "shape class"
+    // entry per same-shape equivalence class. These hold pack lengths for
+    // pack-typed key arguments. Skip past them to reach the metadata pointers.
+    auto packShapeHeader = generics->getGenericPackShapeHeader();
+    auto packShapeDescriptors = generics->getGenericPackShapeDescriptors();
+    if (numGenericArgs < packShapeHeader.NumShapeClasses)
+      return {};
+    numGenericArgs -= packShapeHeader.NumShapeClasses;
+
+    auto genericArgsAddr = genericArgsBaseAddr
+      + sizeof(StoredPointer) * packShapeHeader.NumShapeClasses;
+
+    unsigned packIndex = 0;
 
     std::vector<BuiltType> builtSubsts;
     for (auto param : generics->getGenericParams()) {
@@ -3187,10 +3201,65 @@ private:
           return {};
         }
         break;
-        
+
       case GenericParamKind::TypePack:
-        // assert(false && "Packs not supported here yet");
-        return {};
+        if (param.hasKeyArgument()) {
+          if (numGenericArgs == 0)
+            return {};
+          --numGenericArgs;
+
+          // Find the matching pack shape descriptor. By invariant the
+          // metadata pack descriptors come before any witness table pack
+          // descriptors, in the same order as the pack-typed parameters
+          // with key arguments, so the next descriptor is ours.
+          if (packIndex >= packShapeDescriptors.size())
+            return {};
+          const auto &packDescriptor = packShapeDescriptors[packIndex++];
+          if (packDescriptor.Kind != GenericPackKind::Metadata)
+            return {};
+
+          // The pack length is stored in the shape class slot at the
+          // start of the generic argument layout.
+          auto packLengthAddr = genericArgsBaseAddr
+            + sizeof(StoredPointer) * packDescriptor.ShapeClass;
+          StoredSize packLength;
+          if (!Reader->readInteger(packLengthAddr, &packLength))
+            return {};
+
+          // Read the pack pointer. Its low bit indicates heap vs. stack
+          // lifetime; the actual element array is at the address with the
+          // low bit cleared.
+          StoredPointer rawPackPtr;
+          if (!Reader->readInteger(genericArgsAddr, &rawPackPtr))
+            return {};
+          genericArgsAddr += sizeof(StoredPointer);
+
+          auto packElementsAddr = RemoteAddress(
+              rawPackPtr & ~StoredPointer(1),
+              genericArgsAddr.getAddressSpace());
+
+          std::vector<BuiltType> elements;
+          elements.reserve(packLength);
+          for (StoredSize i = 0; i < packLength; ++i) {
+            RemoteAddress elementMetadata;
+            if (!Reader->template readRemoteAddress<StoredPointer>(
+                    packElementsAddr, elementMetadata)) {
+              return {};
+            }
+            packElementsAddr += sizeof(StoredPointer);
+
+            auto builtElement = readTypeFromMetadata(
+                elementMetadata, false, recursion_limit);
+            if (!builtElement)
+              return {};
+            elements.push_back(builtElement);
+          }
+
+          builtSubsts.push_back(Builder.createPackType(elements));
+        } else {
+          return {};
+        }
+        break;
 
       default:
         // We don't know about this kind of parameter.

--- a/validation-test/Reflection/reflect_variadic_generic.swift
+++ b/validation-test/Reflection/reflect_variadic_generic.swift
@@ -1,0 +1,65 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -target %target-swift-5.9-abi-triple -lswiftSwiftReflectionTest %s -o %t/reflect_variadic_generic
+// RUN: %target-codesign %t/reflect_variadic_generic
+
+// RUN: %target-run %target-swift-reflection-test %t/reflect_variadic_generic | tee /dev/stderr | %FileCheck %s --dump-input=fail
+
+// REQUIRES: reflection_test_support
+// REQUIRES: executable_test
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: asan
+
+import SwiftReflectionTest
+
+struct VariadicStruct<each T> {
+  var values: (repeat each T)
+}
+
+class VariadicHolder<each T> {
+  var contents: (repeat each T)
+  init(_ values: repeat each T) {
+    contents = (repeat each values)
+  }
+}
+
+// Empty pack.
+reflect(any: VariadicStruct< >(values: ()))
+
+// CHECK: Reflecting an existential.
+// CHECK: Type reference:
+// CHECK: (bound_generic_struct reflect_variadic_generic.VariadicStruct
+// CHECK-NEXT: (pack))
+
+// One-element pack.
+reflect(any: VariadicStruct<Int>(values: 5))
+
+// CHECK: Reflecting an existential.
+// CHECK: Type reference:
+// CHECK: (bound_generic_struct reflect_variadic_generic.VariadicStruct
+// CHECK-NEXT: (pack
+// CHECK-NEXT: (struct Swift.Int)))
+
+// Multi-element pack with mixed element types.
+reflect(any: VariadicStruct<Int, String, Bool>(values: (1, "two", true)))
+
+// CHECK: Reflecting an existential.
+// CHECK: Type reference:
+// CHECK: (bound_generic_struct reflect_variadic_generic.VariadicStruct
+// CHECK-NEXT: (pack
+// CHECK-NEXT: (struct Swift.Int)
+// CHECK-NEXT: (struct Swift.String)
+// CHECK-NEXT: (struct Swift.Bool)))
+
+// Class with parameter pack.
+reflect(object: VariadicHolder<Int, Double>(7, 3.14))
+
+// CHECK: Reflecting an object.
+// CHECK: Type reference:
+// CHECK: (bound_generic_class reflect_variadic_generic.VariadicHolder
+// CHECK-NEXT: (pack
+// CHECK-NEXT: (struct Swift.Int)
+// CHECK-NEXT: (struct Swift.Double)))
+
+doneReflecting()
+
+// CHECK: Done.


### PR DESCRIPTION
Fill in the GenericParamKind::TypePack case in MetadataReader's getGenericSubst method.

rdar://165872192