### PR TITLE
[diagnostic] Convert swift-diagnostics-assert-on-{error,warning} from llvm::cl::opt globals to Swift frontend flags

### DIFF
--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -31,6 +31,7 @@
 #include "swift/Localization/LocalizationFormat.h"
 #include "llvm/ADT/BitVector.h"
 #include "llvm/ADT/MapVector.h"
+#include "llvm/ADT/SmallSet.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/StringSet.h"
 #include "llvm/Support/Allocator.h"
@@ -619,6 +620,15 @@ namespace swift {
     /// fatal error
     bool showDiagnosticsAfterFatalError = false;
 
+    /// Trap when any error diagnostic is emitted.
+    bool assertOnError = false;
+
+    /// Trap when any warning diagnostic is emitted.
+    bool assertOnWarning = false;
+
+    /// Trap when a diagnostic belonging to one of these groups is emitted.
+    llvm::SmallSet<DiagGroupID, 1> assertOnGroupIDs;
+
     /// Don't emit any warnings
     bool suppressWarnings = false;
 
@@ -671,6 +681,14 @@ namespace swift {
     }
     bool getShowDiagnosticsAfterFatalError() {
       return showDiagnosticsAfterFatalError;
+    }
+
+    void setAssertOnError(bool val = true) { assertOnError = val; }
+    void setAssertOnWarning(bool val = true) { assertOnWarning = val; }
+    void addAssertOnGroupID(DiagGroupID id) { assertOnGroupIDs.insert(id); }
+
+    bool shouldAssertOnGroup(DiagGroupID id) const {
+      return assertOnGroupIDs.count(id);
     }
 
     /// Whether to skip emitting warnings
@@ -728,6 +746,8 @@ namespace swift {
     void swap(DiagnosticState &other) {
       std::swap(showDiagnosticsAfterFatalError,
                 other.showDiagnosticsAfterFatalError);
+      std::swap(assertOnError, other.assertOnError);
+      std::swap(assertOnWarning, other.assertOnWarning);
       std::swap(suppressWarnings, other.suppressWarnings);
       std::swap(suppressNotes, other.suppressNotes);
       std::swap(suppressRemarks, other.suppressRemarks);
@@ -923,6 +943,10 @@ namespace swift {
     bool getShowDiagnosticsAfterFatalError() {
       return state.getShowDiagnosticsAfterFatalError();
     }
+
+    void setAssertOnError(bool val = true) { state.setAssertOnError(val); }
+    void setAssertOnWarning(bool val = true) { state.setAssertOnWarning(val); }
+    void addAssertOnGroupID(DiagGroupID id) { state.addAssertOnGroupID(id); }
 
     void flushConsumers() {
       ASSERT(NumActiveDiags == 0 && "Expected in-flight diags to be flushed");

--- a/include/swift/AST/SILOptions.h
+++ b/include/swift/AST/SILOptions.h
@@ -330,6 +330,10 @@ public:
   /// CoroutineAccessors feature (i.e. yielding borrow/mutate).
   bool CoroutineAccessorsUseYieldOnce2 = false;
 
+  /// Abort if SIL region isolation detects an unknown pattern.
+  /// For compiler developers only.
+  bool AbortOnUnknownRegionIsolationPatternError = false;
+
   SILOptions() {}
 
   /// Return a hash code of any components from these options that should

--- a/include/swift/Basic/DiagnosticOptions.h
+++ b/include/swift/Basic/DiagnosticOptions.h
@@ -16,6 +16,7 @@
 #include "swift/Basic/PrintDiagnosticNamesMode.h"
 #include "swift/Basic/WarningGroupBehaviorRule.h"
 #include "llvm/ADT/Hashing.h"
+#include "llvm/ADT/SmallSet.h"
 #include <vector>
 
 namespace swift {
@@ -61,6 +62,25 @@ public:
 
   /// Keep emitting subsequent diagnostics after a fatal error.
   bool ShowDiagnosticsAfterFatalError = false;
+
+  /// Trap when any error diagnostic is emitted. For compiler developers only.
+  ///
+  /// These flags are intentionally separate from the normal diagnostic
+  /// suppression and escalation machinery. That separation is deliberate:
+  /// they are useful precisely when *other* diagnostics are being emitted (e.g.
+  /// when debugging a miscompile by setting an lldb breakpoint on the trap), so
+  /// they must not be suppressed by -suppress-warnings or similar options.
+  bool AssertOnError = false;
+
+  /// Trap when any warning diagnostic is emitted. For compiler developers only.
+  /// See AssertOnError for why this is separate from the normal machinery.
+  bool AssertOnWarning = false;
+
+  /// Trap when any diagnostic belonging to one of these groups is emitted.
+  /// Allows targeting a single diagnostic group rather than all errors or all
+  /// warnings. For compiler developers only.
+  /// See AssertOnError for why this is separate from the normal machinery.
+  llvm::SmallSet<DiagGroupID, 1> AssertOnGroupIDs;
 
   /// When emitting fixits as code edits, apply all fixits from diagnostics
   /// without any filtering.

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -196,6 +196,17 @@ def expansion_remarks:  Flag<["-"], "Rmacro-expansions">,
 def show_diagnostics_after_fatal : Flag<["-"], "show-diagnostics-after-fatal">,
   HelpText<"Keep emitting subsequent diagnostics after a fatal error">;
 
+def swift_diagnostics_assert_on_error : Flag<["-"], "diagnostics-assert-on-error">,
+  HelpText<"Trap when an error diagnostic is emitted. For compiler developers only.">;
+
+def swift_diagnostics_assert_on_warning : Flag<["-"], "diagnostics-assert-on-warning">,
+  HelpText<"Trap when a warning diagnostic is emitted. For compiler developers only.">;
+
+def swift_diagnostics_assert_on_group : Separate<["-"], "diagnostics-assert-on-group">,
+  MetaVarName<"<diagnostic_group>">,
+  HelpText<"Trap when any diagnostic in the given group is emitted. "
+           "For compiler developers only.">;
+
 def enable_cross_import_overlays : Flag<["-"], "enable-cross-import-overlays">,
   HelpText<"Automatically import declared cross-import overlays.">;
 def disable_cross_import_overlays : Flag<["-"], "disable-cross-import-overlays">,
@@ -1090,6 +1101,11 @@ def sil_verify_none : Flag<["-"], "sil-verify-none">,
 
 def sil_ownership_verify_all : Flag<["-"], "sil-ownership-verify-all">,
   HelpText<"Verify ownership after each transform">;
+
+def sil_region_isolation_assert_on_unknown_pattern :
+  Flag<["-"], "sil-region-isolation-assert-on-unknown-pattern">,
+  HelpText<"Abort if SIL region isolation detects an unknown pattern. "
+           "For compiler developers only.">;
 
 def verify_all_substitution_maps : Flag<["-"], "verify-all-substitution-maps">,
   HelpText<"Verify all SubstitutionMaps on construction">;

--- a/include/swift/SILOptimizer/Analysis/RegionAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/RegionAnalysis.h
@@ -28,14 +28,6 @@ class RegionAnalysisValueMap;
 
 namespace regionanalysisimpl {
 
-/// Global bool set only when asserts are enabled to ease debugging by causing
-/// unknown pattern errors to cause an assert so we drop into the debugger.
-extern bool AbortOnUnknownPatternMatchError;
-
-static inline bool shouldAbortOnUnknownPatternMatchError() {
-  return AbortOnUnknownPatternMatchError;
-}
-
 using SendingOperandSetFactory = Partition::SendingOperandSetFactory;
 using Element = PartitionPrimitives::Element;
 using Region = PartitionPrimitives::Region;

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -1327,15 +1327,6 @@ DiagnosticBehavior toDiagnosticBehavior(DiagnosticKind kind, bool isFatal) {
   llvm_unreachable("Unhandled DiagnosticKind in switch.");
 }
 
-// A special option only for compiler writers that causes Diagnostics to assert
-// when a failure diagnostic is emitted. Intended for use in the debugger.
-llvm::cl::opt<bool> AssertOnError("swift-diagnostics-assert-on-error",
-                                  llvm::cl::init(false));
-// A special option only for compiler writers that causes Diagnostics to assert
-// when a warning diagnostic is emitted. Intended for use in the debugger.
-llvm::cl::opt<bool> AssertOnWarning("swift-diagnostics-assert-on-warning",
-                                    llvm::cl::init(false));
-
 std::optional<DiagnosticBehavior>
 DiagnosticState::determineUserControlledWarningBehavior(
     const Diagnostic &diag, SourceManager &sourceMgr) const {
@@ -1472,8 +1463,8 @@ void DiagnosticState::updateFor(DiagnosticBehavior behavior) {
     anyErrorOccurred = true;
   }
 
-  ASSERT((!AssertOnError || !anyErrorOccurred) && "We emitted an error?!");
-  ASSERT((!AssertOnWarning || (behavior != DiagnosticBehavior::Warning)) &&
+  ASSERT((!assertOnError || !anyErrorOccurred) && "We emitted an error?!");
+  ASSERT((!assertOnWarning || (behavior != DiagnosticBehavior::Warning)) &&
          "We emitted a warning?!");
 
   previousBehavior = behavior;
@@ -1538,6 +1529,15 @@ DiagnosticEngine::diagnosticInfoForDiagnostic(const Diagnostic &diagnostic,
                                               bool includeDiagnosticName) {
   auto behavior = state.determineBehavior(diagnostic, SourceMgr);
   state.updateFor(behavior);
+
+  if (behavior != DiagnosticBehavior::Ignore) {
+    auto groupID = diagnostic.getGroupID();
+    if (groupID != DiagGroupID::no_group &&
+        state.shouldAssertOnGroup(groupID)) {
+      ASSERT(false && "Trapping on diagnostic group (see "
+                      "-diagnostics-assert-on-group)");
+    }
+  }
 
   if (behavior == DiagnosticBehavior::Ignore)
     return std::nullopt;

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -2750,6 +2750,15 @@ static bool ParseDiagnosticArgs(DiagnosticOptions &Opts, ArgList &Args,
   Opts.SkipDiagnosticPasses |= Args.hasArg(OPT_disable_diagnostic_passes);
   Opts.ShowDiagnosticsAfterFatalError |=
     Args.hasArg(OPT_show_diagnostics_after_fatal);
+  Opts.AssertOnError |= Args.hasArg(OPT_swift_diagnostics_assert_on_error);
+  Opts.AssertOnWarning |= Args.hasArg(OPT_swift_diagnostics_assert_on_warning);
+  for (const Arg *A : Args.filtered(OPT_swift_diagnostics_assert_on_group)) {
+    if (auto groupID = getDiagGroupIDByName(A->getValue())) {
+      Opts.AssertOnGroupIDs.insert(*groupID);
+    } else {
+      Opts.UnknownWarningGroups.push_back(A->getValue());
+    }
+  }
 
   for (Arg *A : Args.filtered(OPT_verify_additional_file))
     Opts.AdditionalVerifierFiles.push_back(A->getValue());
@@ -2907,6 +2916,15 @@ static void configureDiagnosticEngine(
     StringRef mainExecutablePath, DiagnosticEngine &Diagnostics) {
   if (Options.ShowDiagnosticsAfterFatalError) {
     Diagnostics.setShowDiagnosticsAfterFatalError();
+  }
+  if (Options.AssertOnError) {
+    Diagnostics.setAssertOnError();
+  }
+  if (Options.AssertOnWarning) {
+    Diagnostics.setAssertOnWarning();
+  }
+  for (auto groupID : Options.AssertOnGroupIDs) {
+    Diagnostics.addAssertOnGroupID(groupID);
   }
   if (Options.SuppressWarnings) {
     Diagnostics.setSuppressWarnings(true);
@@ -3297,6 +3315,8 @@ static bool ParseSILArgs(SILOptions &Opts, ArgList &Args,
   Opts.VerifyAll |= Args.hasArg(OPT_sil_verify_all);
   Opts.VerifyNone |= Args.hasArg(OPT_sil_verify_none);
   Opts.VerifyOwnershipAll |= Args.hasArg(OPT_sil_ownership_verify_all);
+  Opts.AbortOnUnknownRegionIsolationPatternError |=
+      Args.hasArg(OPT_sil_region_isolation_assert_on_unknown_pattern);
   Opts.DebugSerialization |= Args.hasArg(OPT_sil_debug_serialization);
   Opts.EmitVerboseSIL |= Args.hasArg(OPT_emit_verbose_sil);
   Opts.EmitSortedSIL |= Args.hasArg(OPT_emit_sorted_sil);

--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -39,16 +39,6 @@ using namespace swift::PartitionPrimitives;
 using namespace swift::PatternMatch;
 using namespace swift::regionanalysisimpl;
 
-bool swift::regionanalysisimpl::AbortOnUnknownPatternMatchError = false;
-
-static llvm::cl::opt<bool, true> AbortOnUnknownPatternMatchErrorCmdLine(
-    "sil-region-isolation-assert-on-unknown-pattern",
-    llvm::cl::desc("Abort if SIL region isolation detects an unknown pattern. "
-                   "Intended only to be used when debugging the compiler!"),
-    llvm::cl::Hidden,
-    llvm::cl::location(
-        swift::regionanalysisimpl::AbortOnUnknownPatternMatchError));
-
 //===----------------------------------------------------------------------===//
 //                              MARK: Utilities
 //===----------------------------------------------------------------------===//
@@ -1948,9 +1938,11 @@ public:
   }
 
   void addUnknownPatternError(SILValue value) {
-    if (shouldAbortOnUnknownPatternMatchError()) {
+    if (currentInst->getFunction()->getModule().getOptions()
+            .AbortOnUnknownRegionIsolationPatternError) {
       llvm::report_fatal_error(
-          "RegionIsolation: Aborting on unknown pattern match error");
+          "RegionIsolation: Found unknown SIL pattern in PartitionOpBuilder. "
+          "See -sil-region-isolation-assert-on-unknown-pattern");
     }
     currentInstPartitionOps->emplace_back(
         PartitionOp::UnknownPatternError(lookupValueID(value), currentInst));

--- a/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
@@ -396,9 +396,11 @@ static void
 emitUnknownPatternErrorHelper(const char *emitterName, SILInstruction *inst,
                               std::optional<DiagnosticBehavior> behaviorLimit,
                               const char *file, int line) {
-  if (shouldAbortOnUnknownPatternMatchError()) {
+  if (inst->getFunction()->getModule().getOptions()
+          .AbortOnUnknownRegionIsolationPatternError) {
     llvm::report_fatal_error(
-        "RegionIsolation: Aborting on unknown pattern match error");
+        "RegionIsolation: Found unknown SIL pattern in diagnostic emitter. "
+        "See -sil-region-isolation-assert-on-unknown-pattern");
   }
 
   REGIONBASEDISOLATION_LOG(llvm::dbgs()
@@ -3888,9 +3890,11 @@ public:
       : inst(error.op->getSourceInst()) {}
 
   void emit() {
-    if (shouldAbortOnUnknownPatternMatchError()) {
+    if (inst->getFunction()->getModule().getOptions()
+            .AbortOnUnknownRegionIsolationPatternError) {
       llvm::report_fatal_error(
-          "RegionIsolation: Aborting on unknown pattern match error");
+          "RegionIsolation: Found unknown SIL pattern in verbatim emitter. "
+          "See -sil-region-isolation-assert-on-unknown-pattern");
     }
 
     REGIONBASEDISOLATION_LOG(llvm::dbgs() << "Emitting Error. Verbatim Error: "

--- a/test/Concurrency/sil_region_isolation_assert_on_unknown_pattern.swift
+++ b/test/Concurrency/sil_region_isolation_assert_on_unknown_pattern.swift
@@ -1,0 +1,14 @@
+// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -sil-region-isolation-assert-on-unknown-pattern -target %target-swift-5.1-abi-triple %s -o /dev/null
+
+// REQUIRES: concurrency
+
+// Verify that -sil-region-isolation-assert-on-unknown-pattern is accepted and
+// does not abort when region isolation completes without hitting an unknown
+// pattern. We cannot really test it since we are trying to fix those issues.
+
+func takesInt(_ x: Int) async {}
+
+func test() async {
+  let x = 1
+  await takesInt(x)
+}

--- a/test/diagnostics/assert_on_error.swift
+++ b/test/diagnostics/assert_on_error.swift
@@ -1,0 +1,11 @@
+// RUN: not --crash %target-swift-frontend -typecheck -diagnostics-assert-on-error %s 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -typecheck -diagnostics-assert-on-error -DNO_ERROR %s 2>&1
+
+// Verify that -diagnostics-assert-on-error traps when an error is emitted
+// and does nothing when no errors are emitted.
+
+// CHECK: We emitted an error?!
+
+#if !NO_ERROR
+let _: Int = "not an int"
+#endif

--- a/test/diagnostics/assert_on_group.swift
+++ b/test/diagnostics/assert_on_group.swift
@@ -1,0 +1,17 @@
+// RUN: not --crash %target-swift-frontend -typecheck -diagnostics-assert-on-group DeprecatedDeclaration %s 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -typecheck -diagnostics-assert-on-group DeprecatedDeclaration -DNO_DEPRECATED %s 2>&1
+// RUN: %target-swift-frontend -typecheck -diagnostic-style llvm -diagnostics-assert-on-group UnknownGroup %s 2>&1 | %FileCheck %s --check-prefix=CHECK-UNKNOWN
+
+// Verify that -diagnostics-assert-on-group traps when any diagnostic
+// belonging to the given group is emitted, does nothing when no such diagnostic
+// is emitted, and reports an error for an unknown group name.
+
+// CHECK: Trapping on diagnostic group
+// CHECK-UNKNOWN: unknown warning group: 'UnknownGroup'
+
+@available(*, deprecated)
+func deprecated() {}
+
+#if !NO_DEPRECATED
+deprecated()
+#endif

--- a/test/diagnostics/assert_on_warning.swift
+++ b/test/diagnostics/assert_on_warning.swift
@@ -1,0 +1,14 @@
+// RUN: not --crash %target-swift-frontend -typecheck -diagnostics-assert-on-warning %s 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -typecheck -diagnostics-assert-on-warning -DNO_WARNING %s 2>&1
+
+// Verify that -diagnostics-assert-on-warning traps when a warning is
+// emitted and does nothing when no warnings are emitted.
+
+// CHECK: We emitted a warning?!
+
+@available(*, deprecated)
+func deprecated() {}
+
+#if !NO_WARNING
+deprecated()
+#endif


### PR DESCRIPTION
I also added support for emitting error for diagnostic groups.

llvm::cl::opt flags are compiled out in non-asserts builds, making these debug flags unavailable in an important category of use cases — debugging a release compiler in lldb. By promoting them to Swift frontend flags stored in DiagnosticOptions/SILOptions, they are available in all build configurations.

The three existing flags are migrated:
  -swift-diagnostics-assert-on-error
  -swift-diagnostics-assert-on-warning
  -sil-region-isolation-assert-on-unknown-pattern
    (backing field renamed to AbortOnUnknownRegionIsolationPatternError)

A new flag is added:
  -swift-diagnostics-assert-on-group <group>
    Traps when any diagnostic belonging to the named group is emitted,
    allowing targeted breakpoints on a single diagnostic group rather than
    all errors or all warnings.

The assert-on-{error,warning,group} flags are intentionally kept separate from the normal diagnostic suppression/escalation machinery so that they remain useful while other diagnostics are also being emitted.

Tests are added for all four flags.

rdar://176471347

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
