### PR TITLE
SILGen: don't emit executor precondition in @objc isolated-deinit thunk

### DIFF
--- a/lib/SILGen/SILGenBridging.cpp
+++ b/lib/SILGen/SILGenBridging.cpp
@@ -1653,15 +1653,27 @@ void SILGenFunction::emitNativeToForeignThunk(SILDeclRef thunk) {
   // A hop/check is only needed in the thunk if it is global-actor isolated.
   // Native, instance-isolated async methods will hop in the prologue.
   if (isolation && isolation->isGlobalActor()) {
-    if (F.isAsync()) {
-      // Hop to the actor for the method's actor constraint.
-      // Note that, since an async native-to-foreign thunk only ever runs in a
-      // task purpose-built for running the Swift async code triggering the
-      // completion handler, there is no need for us to hop back to the existing
-      // executor, since the task will end after we invoke the completion handler.
-      emitPrologGlobalActorHop(loc, isolation->getGlobalActor());
-    } else {
-      emitPreconditionCheckExpectedExecutor(loc, *isolation, std::nullopt);
+    // For an isolated `deinit`, the native `__deallocating_deinit` already
+    // performs the hop via `swift_task_deinitOnExecutor`. The @objc thunk
+    // must not assert or hop, because ObjC `release` can run from any
+    // thread; dropping the last reference from a non-isolated context would
+    // otherwise crash in `_checkExpectedExecutor`.
+    bool isIsolatingDeinitThunk = false;
+    if (thunk.hasDecl()) {
+      if (auto *dd = dyn_cast<DestructorDecl>(thunk.getDecl()))
+        isIsolatingDeinitThunk = needsIsolatingDestructor(dd);
+    }
+    if (!isIsolatingDeinitThunk) {
+      if (F.isAsync()) {
+        // Hop to the actor for the method's actor constraint.
+        // Note that, since an async native-to-foreign thunk only ever runs in a
+        // task purpose-built for running the Swift async code triggering the
+        // completion handler, there is no need for us to hop back to the existing
+        // executor, since the task will end after we invoke the completion handler.
+        emitPrologGlobalActorHop(loc, isolation->getGlobalActor());
+      } else {
+        emitPreconditionCheckExpectedExecutor(loc, *isolation, std::nullopt);
+      }
     }
   }
 

--- a/test/SILGen/objc_isolated_deinit_thunk.swift
+++ b/test/SILGen/objc_isolated_deinit_thunk.swift
@@ -1,0 +1,37 @@
+// RUN: %target-swift-frontend -emit-silgen -target %target-future-triple -swift-version 6 -module-name main %s | %FileCheck %s
+
+// REQUIRES: concurrency
+// REQUIRES: objc_interop
+
+// rdar://175957720
+//
+// For a global-actor-isolated `isolated deinit` on an @objc class, the native
+// `__deallocating_deinit` already hops to the expected executor via
+// `swift_task_deinitOnExecutor`. The @objc thunk (invoked by ObjC `release`
+// from any thread) must NOT emit `_checkExpectedExecutor`: releasing the
+// last reference from a non-isolated context would otherwise crash in
+// `_dispatch_assert_queue_fail`.
+
+import Foundation
+
+@MainActor
+@objc final class MainActorIsolated: NSObject {
+  nonisolated override init() {}
+  isolated deinit {}
+}
+
+// CHECK-LABEL: sil private [thunk] [ossa] @$s4main17MainActorIsolatedCfDTo
+// CHECK-NOT: _checkExpectedExecutor
+// CHECK: end sil function '$s4main17MainActorIsolatedCfDTo'
+
+// Non-deinit @objc methods on the same class must continue to receive the
+// precondition check in their thunk — isolation enforcement for ordinary
+// method dispatch is unchanged.
+extension MainActorIsolated {
+  @objc func method() {}
+}
+
+// CHECK-LABEL: sil private [thunk] [ossa] @$s4main17MainActorIsolatedC6methodyyFTo
+// CHECK: _checkExpectedExecutor
+// CHECK: end sil function '$s4main17MainActorIsolatedC6methodyyFTo'
+


### PR DESCRIPTION
The native `__deallocating_deinit` for an isolated destructor already hops to the expected executor via `swift_task_deinitOnExecutor`. The @objc thunk is invoked by ObjC `release`, which can run from any thread, so asserting the current executor in the thunk crashes `_dispatch_assert_queue_fail` whenever the last reference is dropped from a non-isolated context.

Skip the precondition (and the async hop, which can't apply here since deinits aren't async) when the thunked decl is an isolating destructor. Non-deinit @objc methods still get the check.