### PR TITLE
[PrintAsClang] Don't assert renamed decl is includable in Cxx header printer

### DIFF
--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -1977,9 +1977,7 @@ private:
     assert(!AvAttr.getRename().empty());
 
     auto *renamedDecl = D->getRenamedDecl(AvAttr.getParsedAttr());
-    if (renamedDecl) {
-      assert(shouldInclude(renamedDecl) &&
-             "ObjC printer logic mismatch with renamed decl");
+    if (renamedDecl && shouldInclude(renamedDecl)) {
       SmallString<128> scratch;
       auto renamedObjCRuntimeName =
           renamedDecl->getObjCRuntimeName()->getString(scratch);

--- a/test/Interop/SwiftToCxx/functions/function-renamed-non-exportable.swift
+++ b/test/Interop/SwiftToCxx/functions/function-renamed-non-exportable.swift
@@ -1,0 +1,35 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -module-name Functions -clang-header-expose-decls=all-public -emit-module -emit-clang-header-path %t/functions.h -enable-library-evolution -experimental-skip-non-exportable-decls
+// RUN: %FileCheck %s < %t/functions.h
+
+// Verify that a deprecated method with @available(*, renamed:) pointing to
+// a non-exportable target does not crash the Cxx header printer.
+// The printer should fall back to using the raw rename string from the
+// attribute when the renamed decl is not includable.
+// rdar://176190799
+
+public enum ExportFormat {
+    case string
+    case file
+}
+
+public struct MyStruct {
+    public init() {}
+
+    // The renamed target `export(to:addSourceFileComment:)` throws, making it
+    // non-exportable with -experimental-skip-non-exportable-decls. The printer
+    // should not crash and should emit the raw rename string.
+    //
+    // CHECK: SWIFT_DEPRECATED_MSG("", "export(to:addSourceFileComment:)")
+    @available(*, deprecated, renamed: "export(to:addSourceFileComment:)")
+    public func exportToString(addSourceFileComment: Bool = true) -> String? {
+        return nil
+    }
+
+    public func export(
+        to format: ExportFormat,
+        addSourceFileComment: Bool = true
+    ) throws -> String {
+        return ""
+    }
+}

--- a/validation-test/compiler_crashers/CxxInterop/Implementation-printAvailability-3684b9.swift
+++ b/validation-test/compiler_crashers/CxxInterop/Implementation-printAvailability-3684b9.swift
@@ -1,5 +1,5 @@
 // {"extraArgs":["-experimental-allow-module-with-compiler-errors","-cxx-interoperability-mode=default","-emit-clang-header-min-access","internal","-emit-clang-header-path","/dev/null"],"kind":"typecheck","original":"2e3e8371","signature":"swift::DeclAndTypePrinter::Implementation::printAvailability(llvm::raw_ostream&, swift::Decl const*, swift::DeclAndTypePrinter::Implementation::PrintLeadingSpace)","signatureAssert":"Assertion failed: (shouldInclude(renamedDecl) && \"ObjC printer logic mismatch with renamed decl\"), function printRenameForDecl","signatureNext":"DeclAndTypePrinter::printAvailability"}
-// RUN: not --crash %target-swift-frontend -typecheck -experimental-allow-module-with-compiler-errors -cxx-interoperability-mode=default -emit-clang-header-min-access internal -emit-clang-header-path /dev/null %s
+// RUN: not %target-swift-frontend -typecheck -experimental-allow-module-with-compiler-errors -cxx-interoperability-mode=default -emit-clang-header-min-access internal -emit-clang-header-path /dev/null %s
 struct a {
   @available(*, deprecated, renamed: "c") var b: String
   var c


### PR DESCRIPTION
When generating C++ interop headers with -experimental-skip-non-exportable-decls, a deprecated method's @available(*, renamed:) target may not pass shouldInclude(), e.g., because the target uses `throws` or types that otherwise can't be exposed to C++.

Instead of asserting, fall through to print the raw rename string from the attribute (same behavior as when getRenamedDecl() returns null).

rdar://151425131