### PR TITLE
Serialization: Statically assert OPTIONS_BLOCK's abbrev-code width

### DIFF
--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 999; // widen OPTIONS_BLOCK abbrev code size to 6 bits
+const uint16_t SWIFTMODULE_VERSION_MINOR = 1000; // Statically assert OPTIONS_BLOCK's abbrev-code width
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -1014,6 +1014,12 @@ namespace options_block {
     OSLOG_STRING_SECTION_NAME,
     AGGRESSIVE_CMO,
     LIBRARY_LEVEL,
+    // Internal sentinel. MUST remain the last enumerator in this block.
+    // Equal to one past the last real record kind. Used by
+    // Serialization.cpp to statically assert that OPTIONS_BLOCK's
+    // abbreviation-code width is wide enough for every possible
+    // BCRecordLayout declared in the block.
+    LAST_RECORD_KIND_MARKER,
   };
 
   using SDKPathLayout = BCRecordLayout<

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1100,7 +1100,22 @@ void Serializer::writeHeader() {
     Channel.emit(ScratchRecord, version::getCurrentCompilerChannel());
 
     {
-      llvm::BCBlockRAII restoreBlock(Out, OPTIONS_BLOCK_ID, 6);
+      // OPTIONS_BLOCK needs an abbrev-code width wide enough to encode
+      // every BCRecordLayout it allocates: 4 reserved IDs plus one per
+      // record kind. If this fires, widen the code size below.
+      constexpr unsigned OptionsBlockCodeSize = 6;
+      constexpr unsigned ReservedAbbrevs =
+        llvm::bitc::FIRST_APPLICATION_ABBREV;
+      constexpr unsigned MaxUserAbbrevsInOptionsBlock =
+        options_block::LAST_RECORD_KIND_MARKER - 1;
+      static_assert(
+        ReservedAbbrevs + MaxUserAbbrevsInOptionsBlock <=
+            (1u << OptionsBlockCodeSize),
+        "OPTIONS_BLOCK abbrev-code size is too small to hold an "
+        "abbreviation for every record kind; widen "
+        "kOptionsBlockCodeSize.");
+      llvm::BCBlockRAII restoreBlock(Out, OPTIONS_BLOCK_ID,
+                                    OptionsBlockCodeSize);
 
       options_block::IsSIBLayout IsSIB(Out);
       IsSIB.emit(ScratchRecord, Options.IsSIB);


### PR DESCRIPTION
Add a LAST_RECORD_KIND_MARKER sentinel at the end of the options_block::RecordKind enum and a static_assert in writeHeader that verifies the block's code width can encode every abbreviation the writer may allocate. A future record kind that would overflow the current code size now fails the build instead of producing a silent malformed-module regression.

rdar://176522412

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
