### PR TITLE
SILGen: handle non-Error destinations in emitThrow

### DIFF
--- a/lib/SILGen/SILGenStmt.cpp
+++ b/lib/SILGen/SILGenStmt.cpp
@@ -24,6 +24,7 @@
 #include "SwitchEnumBuilder.h"
 #include "swift/AST/ConformanceLookup.h"
 #include "swift/AST/DiagnosticsSIL.h"
+#include "swift/AST/ExistentialLayout.h"
 #include "swift/Basic/Assertions.h"
 #include "swift/Basic/Defer.h"
 #include "swift/Basic/ProfileCounter.h"
@@ -32,6 +33,7 @@
 #include "swift/SIL/InstructionUtils.h"
 #include "swift/SIL/SILArgument.h"
 #include "swift/SIL/SILProfiler.h"
+#include "swift/SIL/SILUndef.h"
 #include "llvm/Support/SaveAndRestore.h"
 
 using namespace swift;
@@ -1752,31 +1754,73 @@ void SILGenFunction::emitThrow(SILLocation loc, ManagedValue exnMV,
         : exnType;
 
   // If the thrown error type differs from what the throw destination expects,
-  // perform the conversion.
-  // FIXME: Can the AST tell us what to do here?
+  // perform the conversion. The shape of the conversion depends on the
+  // destination type: existential erasure for `any P` (including `any Error`),
+  // a class upcast when the destination is a superclass of the in-flight
+  // error.
   if (exnType != destErrorType) {
-    assert(destErrorType == SILType::getExceptionType(getASTContext()));
+    CanType destASTType = destErrorType.getASTType();
+    auto &exnTL = getTypeLowering(exnType);
 
-    ProtocolConformanceRef conformances[1] = {
-      checkConformance(
-        exn->getType().getASTType(), getASTContext().getErrorDecl())
-    };
+    if (destASTType->isExistentialType()) {
+      // Erase to the destination existential. The conformances we look up
+      // are dictated by the existential's layout, not always `Error`: for
+      // `do throws(any P) { ... }` where `P` refines `Error`, the layout
+      // contains `P`, and the inner thrown value must be convertible to
+      // `any P`.
+      //
+      // FIXME: Parameterized protocols (`any P<X>`) and class-bound
+      // composition existentials (`any (BaseClass & P)`) are not handled
+      // here — the former drops the parameter constraint and the latter
+      // skips the implicit superclass upcast that would be needed before
+      // the erasure. Sema does not currently surface either shape as a
+      // typed-throws destination, but if it ever does this code will need
+      // to look at `getParameterizedProtocols()` and `explicitSuperclass`.
+      auto layout = destASTType->getExistentialLayout();
+      SmallVector<ProtocolConformanceRef, 4> conformances;
+      conformances.reserve(layout.getProtocols().size());
+      for (auto *proto : layout.getProtocols()) {
+        conformances.push_back(
+            checkConformance(exn->getType().getASTType(), proto));
+      }
 
-    exn = emitExistentialErasure(
-        loc,
-        exnType.getASTType(),
-        getTypeLowering(exnType),
-        getTypeLowering(destErrorType),
-        getASTContext().AllocateCopy(conformances),
-        SGFContext(),
-        [&](SGFContext C) -> ManagedValue {
-          if (exn->getType().isAddress()) {
-            return emitLoad(loc, exn, getTypeLowering(exnType), SGFContext(),
-                            IsTake);
-          }
+      // The lambda passed to `emitExistentialErasure` is invoked once,
+      // before the outer `exn` is reassigned with the erasure result.
+      exn = emitExistentialErasure(
+          loc,
+          exnType.getASTType(),
+          exnTL,
+          getTypeLowering(destErrorType),
+          getASTContext().AllocateCopy(llvm::ArrayRef<ProtocolConformanceRef>(
+              conformances)),
+          SGFContext(),
+          [&](SGFContext C) -> ManagedValue {
+            if (exn->getType().isAddress()) {
+              return emitLoad(loc, exn, exnTL, SGFContext(), IsTake);
+            }
 
-          return ManagedValue::forForwardedRValue(*this, exn);
-        }).forward(*this);
+            return ManagedValue::forForwardedRValue(*this, exn);
+          }).forward(*this);
+    } else if (destASTType->getClassOrBoundGenericClass()) {
+      // Class upcast: the in-flight error is a reference to a subclass of
+      // the destination. SIL's `upcast` instruction additionally verifies
+      // the subclass relationship in asserts builds; release builds rely
+      // on Sema having rejected unrelated classes upstream.
+      if (exn->getType().isAddress()) {
+        exn = emitLoad(loc, exn, exnTL, SGFContext(), IsTake).forward(*this);
+      }
+      exn = B.createUpcast(loc, exn, destErrorType);
+    } else {
+      // We don't have a SILGen lowering for this conversion shape today.
+      // Diagnose and substitute an undef of the destination type so the
+      // rest of the function can lower; the diagnostic ensures the
+      // compilation as a whole fails.
+      SGM.diagnose(loc, diag::not_implemented,
+                   "throw conversion from '" +
+                       exnType.getASTType()->getString() + "' to '" +
+                       destASTType->getString() + "'");
+      exn = SILUndef::get(F, destErrorType);
+    }
   }
   assert(exn->getType().getObjectType() == destErrorType);
 

--- a/test/Interpreter/typed_throws_destination_conversion_83826.swift
+++ b/test/Interpreter/typed_throws_destination_conversion_83826.swift
@@ -1,0 +1,95 @@
+// RUN: %target-run-simple-swift | %FileCheck %s
+// REQUIRES: executable_test
+
+// https://github.com/swiftlang/swift/issues/83826
+//
+// `do throws(T) { try inner() }` where `inner` throws a different type that's
+// implicitly convertible to T must run the appropriate conversion in SILGen
+// rather than asserting that the destination is `any Error`. Two concrete
+// shapes flow through the same `emitThrow` site:
+//
+//   1. The inner thrown type is concrete and `T` is `any P` for some protocol
+//      `P` that refines `Error` — needs existential erasure to `any P` (not
+//      `any Error`), with a conformance to `P`.
+//   2. The inner thrown type is a subclass of `T` — needs an `upcast`.
+
+protocol AbstractError: Error {
+  var message: String { get }
+}
+
+struct ConcreteError: AbstractError {
+  let message: String
+}
+
+func throwsConcrete() throws(ConcreteError) {
+  throw ConcreteError(message: "from concrete")
+}
+
+func testProtocolErasure() {
+  do throws(any AbstractError) {
+    try throwsConcrete()
+  } catch {
+    print("erased:", error.message)
+  }
+}
+testProtocolErasure()
+// CHECK: erased: from concrete
+
+class BaseError: Error, CustomStringConvertible {
+  var description: String { "base" }
+}
+class SubError: BaseError {
+  override var description: String { "sub" }
+}
+
+func throwsSub() throws(SubError) {
+  throw SubError()
+}
+
+func testClassUpcast() {
+  do throws(BaseError) {
+    try throwsSub()
+  } catch {
+    print("upcast:", error)
+  }
+}
+testClassUpcast()
+// CHECK: upcast: sub
+
+// Composed existential — destination is `any (P & Q)`. Both protocol
+// conformances must be looked up, not just `Error`.
+protocol Tag {}
+struct ConcreteTagged: AbstractError, Tag {
+  let message: String
+}
+func throwsTagged() throws(ConcreteTagged) {
+  throw ConcreteTagged(message: "from tagged")
+}
+func testComposedExistential() {
+  do throws(any AbstractError & Tag) {
+    try throwsTagged()
+  } catch {
+    print("composed:", error.message)
+  }
+}
+testComposedExistential()
+// CHECK: composed: from tagged
+
+// Marker-protocol composition: `Sendable` is a marker protocol so its
+// conformance lookup produces an abstract conformance. The existential
+// erasure should still complete cleanly.
+struct SendableConcreteError: Error, Sendable {
+  var description: String { "sendable" }
+}
+func throwsSendable() throws(SendableConcreteError) {
+  throw SendableConcreteError()
+}
+func testMarkerComposition() {
+  do throws(any Error & Sendable) {
+    try throwsSendable()
+  } catch {
+    print("marker:", type(of: error))
+  }
+}
+testMarkerComposition()
+// CHECK: marker: SendableConcreteError

--- a/test/SILGen/typed_throws_destination_conversion_83826.swift
+++ b/test/SILGen/typed_throws_destination_conversion_83826.swift
@@ -1,0 +1,105 @@
+// RUN: %target-swift-emit-silgen -module-name main %s | %FileCheck %s
+
+// https://github.com/swiftlang/swift/issues/83826
+//
+// `do throws(T) { try inner() }` where `inner` throws a different (compatible)
+// type lowers to a conversion before branching to the catch's error block.
+// Lock down the SIL shape so future refactors don't accidentally lose the
+// erasure / upcast.
+
+protocol AbstractError: Error {
+    var message: String { get }
+}
+
+struct ConcreteError: AbstractError {
+    let message: String
+}
+
+func throwsConcrete() throws(ConcreteError) {
+    throw ConcreteError(message: "x")
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s4main19testProtocolErasureyyF
+// `do throws(any AbstractError) { try throwsConcrete() }` should erase the
+// concrete struct to the destination existential. The alloc_stack is for
+// `any AbstractError` (NOT `any Error`), and the init_existential_addr
+// places the in-flight $ConcreteError into it.
+// CHECK: alloc_stack $any AbstractError
+// CHECK: init_existential_addr {{.*}}, $ConcreteError
+// CHECK-NOT: alloc_stack $any Error
+// CHECK: end sil function '$s4main19testProtocolErasureyyF'
+func testProtocolErasure() {
+    do throws(any AbstractError) {
+        try throwsConcrete()
+    } catch {
+        _ = error.message
+    }
+}
+
+class BaseError: Error {}
+class SubError: BaseError {}
+
+func throwsSub() throws(SubError) {
+    throw SubError()
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s4main15testClassUpcastyyF
+// `do throws(BaseError) { try throwsSub() }` should upcast the in-flight
+// $SubError to $BaseError before branching to the catch's error block.
+// The class path must NOT route through existential erasure.
+// CHECK: upcast {{.*}} to $BaseError
+// CHECK-NOT: init_existential_addr
+// CHECK-NOT: alloc_existential_box
+// CHECK: end sil function '$s4main15testClassUpcastyyF'
+func testClassUpcast() {
+    do throws(BaseError) {
+        try throwsSub()
+    } catch {
+        _ = error
+    }
+}
+
+// Composed existential: `any (P & Q)` requires conformances to both protocols.
+// The erasure should look up both, not just one.
+protocol Tag {}
+struct ConcreteTagged: AbstractError, Tag {
+    let message: String
+}
+
+func throwsTagged() throws(ConcreteTagged) {
+    throw ConcreteTagged(message: "y")
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s4main23testComposedExistentialyyF
+// CHECK: alloc_stack $any AbstractError & Tag
+// CHECK: init_existential_addr {{.*}}, $ConcreteTagged
+// CHECK-NOT: alloc_stack $any Error
+// CHECK: end sil function '$s4main23testComposedExistentialyyF'
+func testComposedExistential() {
+    do throws(any AbstractError & Tag) {
+        try throwsTagged()
+    } catch {
+        _ = error.message
+    }
+}
+
+// `do throws(any Error)` (the path that was previously the only one allowed)
+// must still produce existential erasure to `any Error`.
+struct PlainError: Error {}
+func throwsPlain() throws(PlainError) { throw PlainError() }
+
+// CHECK-LABEL: sil hidden [ossa] @$s4main12testAnyErroryyF
+// `any Error` uses the boxed-error representation rather than a generic
+// existential container; verify the box machinery still kicks in via the
+// new dispatch and that we don't accidentally switch to the generic
+// existential path.
+// CHECK: alloc_existential_box $any Error, $PlainError
+// CHECK-NOT: init_existential_addr {{.*}}, $PlainError
+// CHECK: end sil function '$s4main12testAnyErroryyF'
+func testAnyError() {
+    do throws(any Error) {
+        try throwsPlain()
+    } catch {
+        _ = error
+    }
+}


### PR DESCRIPTION
`emitThrow` previously asserted that the only legal mismatch between the in-flight error type and the throw destination was `any Error`, then existential-erased to `Error`. Anything else Sema accepted — `do throws(any P) where P: Error`, or a class subtype of the destination — crashed the assertion (or, before that was tightened, miscompiled at runtime).

Dispatch on the destination type:
- existential: erase, looking up conformance to each protocol in the destination's existential layout (so `any P` works, not just `any Error`);
- class: emit an `upcast`.

Anything else still hits an `unreachable` — Sema rejects those today, so hitting it would indicate a Sema regression rather than a missing SILGen path.

Fixes https://github.com/swiftlang/swift/issues/83826.