### PR TITLE
[cxx-interop] Fix incorrect type lowering for closures in some scenarios

### DIFF
--- a/lib/SILGen/LValue.h
+++ b/lib/SILGen/LValue.h
@@ -21,6 +21,7 @@
 #ifndef SWIFT_LOWERING_LVALUE_H
 #define SWIFT_LOWERING_LVALUE_H
 
+#include "Conversion.h"
 #include "FormalEvaluation.h"
 #include "SILGenFunction.h"
 #include "Scope.h"
@@ -343,7 +344,23 @@ public:
   virtual RValue untranslate(SILGenFunction &SGF, SILLocation loc,
                              RValue &&value,
                              SGFContext ctx = SGFContext()) && = 0;
-  
+
+  /// Untranslation expressed as a Conversion applicable at the source of an
+  /// r-value (via ArgumentSource::getConverted). Returns nullopt if the
+  /// component can't be expressed this way; the caller falls back to calling
+  /// untranslate().
+  virtual std::optional<Conversion>
+  getUntranslationConversion(SILGenFunction &SGF) const {
+    return std::nullopt;
+  }
+
+  /// True if this component can be dropped on read, exposing the underlying
+  /// physical component's SIL type directly to consumers. Used when no
+  /// conversion exists between the component's outer (subst)
+  /// lowering and the inner (orig) lowering — e.g. Clang-typed C function
+  /// pointer fields where Swift's subst lowering disagrees with the C ABI
+  /// and no SIL instruction can bridge between them.
+  virtual bool canDropForRead(SILGenFunction &SGF) const { return false; }
 };
 
 inline TranslationPathComponent &PathComponent::asTranslation() {

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -2760,6 +2760,36 @@ namespace {
                                       getSubstFormalType(), c);
     }
 
+    bool canDropForRead(SILGenFunction &SGF) const override {
+      // For Clang-typed C function pointer fields, the orig-pattern lowering
+      // (e.g. @in_guaranteed) is what callers must use.
+      return isClangCFunctionPointerOrigToSubst();
+    }
+
+    std::optional<Conversion>
+    getUntranslationConversion(SILGenFunction &SGF) const override {
+      if (!isClangCFunctionPointerOrigToSubst())
+        return std::nullopt;
+      auto substType = getSubstFormalType();
+      SILType loweredTy = SGF.getLoweredType(OrigType, substType);
+      return Conversion::getBridging(Conversion::BridgeToObjC, substType,
+                                     substType, loweredTy, OrigType);
+    }
+
+  private:
+    /// True if this OrigToSubst reabstracts a Clang-typed C function pointer
+    /// field.
+    bool isClangCFunctionPointerOrigToSubst() const {
+      if (!OrigType.isClangType())
+        return false;
+      auto fnType = getSubstFormalType()
+                        ->lookThroughSingleOptionalType()
+                        ->getAs<AnyFunctionType>();
+      return fnType && fnType->getRepresentation() ==
+                           FunctionTypeRepresentation::CFunctionPointer;
+    }
+
+  public:
     std::unique_ptr<LogicalPathComponent>
     clone(SILGenFunction &SGF, SILLocation loc) const override {
       LogicalPathComponent *clone
@@ -5667,6 +5697,17 @@ static ArgumentSource emitBaseValueForAccessor(SILGenFunction &SGF,
 RValue SILGenFunction::emitLoadOfLValue(SILLocation loc, LValue &&src,
                                         SGFContext C, bool isBaseGuaranteed) {
   assert(isReadAccess(src.getAccessKind()));
+
+  // If the trailing translation component can be dropped on read — e.g. a
+  // Clang-typed C function pointer field whose ABI lives in the orig-pattern
+  // lowering — drop it before loading. The underlying physical component
+  // produces a value with the orig-pattern SIL type, which is the right
+  // type for callers (no value-level conversion exists to a different one).
+  if (src.isLastComponentTranslation() &&
+      src.getLastTranslationComponent().canDropForRead(*this)) {
+    src.dropLastTranslationComponent();
+  }
+
   ExecutorBreadcrumb prevExecutor;
   RValue result;
   {
@@ -6095,8 +6136,25 @@ void SILGenFunction::emitAssignToLValue(SILLocation loc,
   }
 
   // Otherwise, force the RHS now to preserve evaluation order.
+  // Try to peel a trailing translation component off the LValue and apply
+  // it as a Conversion during RHS emission, rather than untranslating an
+  // already-materialized value below.
+  std::optional<Conversion> srcConversion;
+  if (dest.isLastComponentTranslation()) {
+    srcConversion =
+        dest.getLastTranslationComponent().getUntranslationConversion(*this);
+    if (srcConversion)
+      dest.dropLastTranslationComponent();
+  }
+
   auto srcLoc = src.getLocation();
-  RValue srcValue = std::move(src).getAsRValue(*this);
+  RValue srcValue = [&]() -> RValue {
+    if (srcConversion) {
+      ManagedValue mv = std::move(src).getConverted(*this, *srcConversion);
+      return RValue(*this, srcLoc, srcConversion->getResultType(), mv);
+    }
+    return std::move(src).getAsRValue(*this);
+  }();
 
   // Peephole: instead of materializing and then assigning into a
   // translation component, untransform the value first.

--- a/test/Interop/Cxx/class/Inputs/closure.h
+++ b/test/Interop/Cxx/class/Inputs/closure.h
@@ -88,4 +88,19 @@ void cfuncConstRefStrong(void (*_Nonnull)(const ARCStrong &));
 void blockConstRefStrong(void (^_Nonnull)(const ARCStrong &));
 #endif
 
+struct ConstRefNonTrivialFPStruct {
+    void (*_Nonnull fp)(const NonTrivial &) = nullptr;
+    void callFp(const NonTrivial &x) { fp(x); }
+};
+
+struct ConstRefTrivialFPStruct {
+    void (*_Nonnull fp)(const Trivial &) = nullptr;
+    void callFp(const Trivial &x) { fp(x); }
+};
+
+struct NullableConstRefNonTrivialFPStruct {
+    void (*_Nullable fp)(const NonTrivial &) = nullptr;
+    void callFp(const NonTrivial &x) { if (fp) fp(x); }
+};
+
 #endif // __CLOSURE__

--- a/test/Interop/Cxx/class/closure-thunk-executable.swift
+++ b/test/Interop/Cxx/class/closure-thunk-executable.swift
@@ -15,4 +15,57 @@ ClosureTestSuite.test("Pass FRT to function pointer") {
   cppGo({N in })
 }
 
+ClosureTestSuite.test("AssignClosureToStructMemberConstRefNonTrivial") {
+  var s = ConstRefNonTrivialFPStruct()
+  s.fp = { nt in }
+  s.callFp(NonTrivial())
+  // Read back and call through the function pointer directly.
+  let f = s.fp
+  f(NonTrivial())
+}
+
+ClosureTestSuite.test("AssignClosureToStructMemberConstRefTrivial") {
+  var s = ConstRefTrivialFPStruct()
+  var t = Trivial()
+  t.i = 42
+  s.fp = { t in }
+  s.callFp(t)
+  let f = s.fp
+  f(t)
+}
+
+ClosureTestSuite.test("AssignClosureToStructMemberNullableConstRef") {
+  var s = NullableConstRefNonTrivialFPStruct()
+  s.fp = { nt in }
+  s.callFp(NonTrivial())
+  let f = s.fp
+  f?(NonTrivial())
+}
+
+ClosureTestSuite.test("LValueCopyConstRefNonTrivial") {
+  var s1 = ConstRefNonTrivialFPStruct()
+  var s2 = ConstRefNonTrivialFPStruct()
+  s1.fp = { _ in }
+  s2.fp = s1.fp
+  s2.callFp(NonTrivial())
+}
+
+ClosureTestSuite.test("LValueCopyConstRefTrivial") {
+  var s1 = ConstRefTrivialFPStruct()
+  var s2 = ConstRefTrivialFPStruct()
+  var t = Trivial()
+  t.i = 42
+  s1.fp = { _ in }
+  s2.fp = s1.fp
+  s2.callFp(t)
+}
+
+ClosureTestSuite.test("LValueCopyNullableConstRef") {
+  var s1 = NullableConstRefNonTrivialFPStruct()
+  var s2 = NullableConstRefNonTrivialFPStruct()
+  s1.fp = { _ in }
+  s2.fp = s1.fp
+  s2.callFp(NonTrivial())
+}
+
 runAllTests()

--- a/test/Interop/Cxx/class/closure-thunk-macosx.swift
+++ b/test/Interop/Cxx/class/closure-thunk-macosx.swift
@@ -128,3 +128,30 @@ public func testBlockConstRefTrivial() {
 public func testBlockConstRefStrong() {
   blockConstRefStrong({S in });
 }
+
+// CHECK-LABEL: sil private [thunk] [ossa] @$s4main34testConstRefNonTrivialStructAssign
+// CHECK-SAME: $@convention(c) (@in_guaranteed NonTrivial) -> () {
+// CHECK: bb0(%[[V0:.*]] : $*NonTrivial):
+
+public func testConstRefNonTrivialStructAssign() {
+  var s = ConstRefNonTrivialFPStruct()
+  s.fp = { S in }
+}
+
+// CHECK-LABEL: sil private [thunk] [ossa] @$s4main31testConstRefTrivialStructAssign
+// CHECK-SAME: $@convention(c) (@in_guaranteed Trivial) -> () {
+// CHECK: bb0(%[[V0:.*]] : $*Trivial):
+
+public func testConstRefTrivialStructAssign() {
+  var s = ConstRefTrivialFPStruct()
+  s.fp = { S in }
+}
+
+// CHECK-LABEL: sil private [thunk] [ossa] @$s4main42testNullableConstRefNonTrivialStructAssign
+// CHECK-SAME: $@convention(c) (@in_guaranteed NonTrivial) -> () {
+// CHECK: bb0(%[[V0:.*]] : $*NonTrivial):
+
+public func testNullableConstRefNonTrivialStructAssign() {
+  var s = NullableConstRefNonTrivialFPStruct()
+  s.fp = { S in }
+}


### PR DESCRIPTION
When a closure is passed as a function pointer to C++, we rely on an initializing conversion to plumb the clang type through so we can lower the closure's foreign entry point with the right conventions (lowering without the clang type results in the wrong convention for const T& parameters). Unfortunately, when we assign to a field, we did not have these initializing conversions. This patch creates a new way to handle OrigToSubstComponent for l-values that have a Clang function pointer type. When these values are written, we peel the path component we set up a conversion to get a converted RValue. When the l-value is read we just do the peeling.

rdar://156635576

