### PR TITLE
[Concurrency] SILDeclRef: Fix isolation computation for local accessors

### DIFF
--- a/lib/SIL/IR/SILDeclRef.cpp
+++ b/lib/SIL/IR/SILDeclRef.cpp
@@ -2078,5 +2078,31 @@ ActorIsolation SILDeclRef::getActorIsolation() const {
     return cast<VarDecl>(getDecl())->getInitializerIsolation();
   }
 
-  return getActorIsolationOfContext(getInnermostDeclContext());
+  auto isolation = getActorIsolationOfContext(getInnermostDeclContext());
+  if (!isolation.isUnspecified())
+    return isolation;
+
+  // Local computed variable accessors get their isolation from the context.
+  //
+  // TODO: This is a narrow fix for region-based isolation, a proper fix here
+  // would be to set isolation correctly on the variable itself during
+  // type-checking, but that requires significant changes to support closures
+  // because their local declarations are currently type-checked during CSApply.
+  if (auto *accessor = getAccessorDecl()) {
+    auto *dc = accessor->getDeclContext();
+    if (dc->isLocalContext()) {
+      auto contextIsolation =
+          getActorIsolationOfContext(accessor->getDeclContext());
+
+      if (contextIsolation.isNonisolatedOrConcurrent() ||
+          contextIsolation.isNonisolatedNonsending())
+        return accessor->isAsync()
+                   ? ActorIsolation::forNonisolatedConcurrent()
+                   : ActorIsolation::forNonisolated(/*unsafe=*/false);
+
+      return contextIsolation;
+    }
+  }
+
+  return isolation;
 }

--- a/test/Concurrency/local_computed_properties.swift
+++ b/test/Concurrency/local_computed_properties.swift
@@ -1,0 +1,199 @@
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple %s -emit-sil -o - -verify -strict-concurrency=complete -enable-actor-data-race-checks -disable-availability-checking | %FileCheck %s
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple %s -emit-module -o /dev/null -strict-concurrency=complete -disable-availability-checking
+
+// REQUIRES: concurrency
+
+// Test that local computed properties and lazy vars inherit actor isolation
+// from their enclosing context, just like local functions.
+
+class NS {}
+
+// =============================================================================
+// @MainActor class
+// =============================================================================
+
+@MainActor
+class MainActorClass {
+  var field = NS()
+  func getNS() -> NS { NS() }
+
+  // CHECK-LABEL: // getter of y #1 in MainActorClass.testComputedGetOnly()
+  // CHECK-NEXT:  // Isolation: global_actor. type: MainActor
+  func testComputedGetOnly() {
+    var y: NS {
+      return field
+    }
+    _ = y
+  }
+
+  // CHECK-LABEL: // getter of z #1 in MainActorClass.testComputedGetSet()
+  // CHECK-NEXT:  // Isolation: global_actor. type: MainActor
+  // CHECK-LABEL: // setter of z #1 in MainActorClass.testComputedGetSet()
+  // CHECK-NEXT:  // Isolation: global_actor. type: MainActor
+  func testComputedGetSet() {
+    var holder = field
+    var z: NS {
+      get { return holder }
+      set { holder = newValue }
+    }
+    z = NS()
+    _ = z
+  }
+
+  // CHECK-LABEL: // getter of x #1 in MainActorClass.testLazyVar()
+  // CHECK-NEXT:  // Isolation: global_actor. type: MainActor
+  // CHECK-LABEL: // setter of x #1 in MainActorClass.testLazyVar()
+  // CHECK-NEXT:  // Isolation: global_actor. type: MainActor
+  func testLazyVar() {
+    lazy var x = getNS()
+    _ = x
+  }
+}
+
+@MainActor
+func testMainActorClosure() {
+  _ = {
+    // CHECK-LABEL: // getter of v1 #1 in closure #1 in testMainActorClosure()
+    // CHECK-NEXT: // Isolation: global_actor. type: MainActor
+    var v1: Int {
+      42
+    }
+    _ = v1
+
+    // CHECK-LABEL: // getter of v2 #1 in closure #1 in testMainActorClosure()
+    // CHECK-NEXT: // Isolation: global_actor. type: MainActor
+    lazy var v2 = 42
+    _ = v2
+  }
+}
+
+// =============================================================================
+// actor
+// =============================================================================
+
+actor TestActor {
+  var field = NS()
+
+  // CHECK-LABEL: // getter of y #1 in TestActor.testComputedVar()
+  // CHECK-NEXT:  // Isolation: actor_instance. name: 'self'
+  func testComputedVar() {
+    var y: NS {
+      return field
+    }
+    _ = y
+  }
+}
+
+func testParameterIsolation(isolation: isolated (any Actor)? = nil) async {
+  // CHECK-LABEL: // getter of v1 #1 in testParameterIsolation(isolation:)
+  // CHECK-NEXT: // Isolation: actor_instance. name: 'isolation'
+  var v1: Int {
+    return 42
+  }
+
+  // CHECK-LABEL: // getter of v2 #1 in testParameterIsolation(isolation:)
+  // CHECK-NEXT: // Isolation: actor_instance. name: 'isolation'
+  var v2: Int {
+    get async { 42 }
+  }
+
+  _ = v1
+  _ = await v2
+
+  _ = {
+    // CHECK-LABEL: // getter of v1 #1 in closure #1 in testParameterIsolation(isolation:)
+    // CHECK-NEXT: // Isolation: nonisolated
+    var v1: Int {
+      42
+    }
+  }
+
+  _ = {
+    _ = isolation
+    // CHECK-LABEL: // getter of v1 #1 in closure #2 in testParameterIsolation(isolation:)
+    // CHECK-NEXT: // Isolation: actor_instance. name: 'isolation'
+    var v1: Int {
+      42
+    }
+  }
+}
+
+// =============================================================================
+// nonisolated
+// =============================================================================
+
+// CHECK-LABEL: // getter of counter #1 in testNonisolated()
+// CHECK-NEXT:  // Isolation: nonisolated
+nonisolated func testNonisolated() {
+  var counter: Int {
+    return 42
+  }
+  _ = counter
+}
+
+@concurrent func testConcurrent() async {
+  // CHECK-LABEL: // getter of v1 #1 in testConcurrent()
+  // CHECK-NEXT:  // Isolation: nonisolated
+  var v1: Int {
+    return 42
+  }
+
+  // CHECK-LABEL: // getter of v2 #1 in testConcurrent()
+  // CHECK-NEXT:  // Isolation: @concurrent
+  var v2: Int {
+    get async { 42 }
+  }
+
+  _ = v1
+  _ = await v2
+}
+
+// =============================================================================
+// if #available
+// =============================================================================
+
+// Local accessors inside if #available inherit isolation from the enclosing
+// context. Regression test: NonisolatedAttr must not be added to AccessorDecl
+// (it is invalid there per DeclAttr.def), which previously caused a crash
+// during -emit-module serialization. rdar://175548302
+
+// CHECK-LABEL: // getter of prop #1 in withAvailability()
+// CHECK-NEXT:  // Isolation: unspecified
+func withAvailability() {
+  if #available(macOS 10.15, *) {
+    var prop: some Equatable { 0 }
+    _ = prop
+  }
+}
+
+extension MainActorClass {
+  // CHECK-LABEL: // getter of prop #1 in MainActorClass.withMainActorAndAvailability()
+  // CHECK-NEXT:  // Isolation: global_actor. type: MainActor
+  func withMainActorAndAvailability() {
+    if #available(macOS 10.15, *) {
+      var prop: NS { NS() }
+      _ = prop
+    }
+  }
+}
+
+// =============================================================================
+// nonisolated(nonsending)
+// =============================================================================
+
+nonisolated(nonsending) func testNonisolatedNonsending() async {
+  // CHECK-LABEL: // getter of v1 #1 in testNonisolatedNonsending()
+  // CHECK-NEXT // Isolation: nonisolated
+  var v1: Int {
+    return 42
+  }
+
+  // CHECK-LABEL: // getter of v2 #1 in testNonisolatedNonsending()
+  // CHECK-NEXT: // Isolation: @concurrent
+  var v2: Int {
+    get async { 42 }
+  }
+
+  _ = v1
+  _ = await v2
+}


### PR DESCRIPTION
Local computed variable accessors should get their isolation from the context unless otherwise specified. This is a narrow fix to address some "uknown pattern" failures in region-based isolation. A proper fix would be to set the isolation correctly during type-checking but that is a major change due to how closures are currently type-checked.

Resolves: rdar://175548302

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
