### PR TITLE
[Backtracing][Win32] Scan the global symbol stream and deduplicate.

### DIFF
--- a/stdlib/public/RuntimeModule/PDB/FunctionInfo.swift
+++ b/stdlib/public/RuntimeModule/PDB/FunctionInfo.swift
@@ -25,7 +25,7 @@ struct FunctionInfo {
   var rawName: String?
   var name: String
   var address: UInt32
-  var length: UInt32
-  var scope: Scope
-  var moduleIndex: Int
+  var length: UInt32?
+  var scope: Scope?
+  var moduleIndex: Int?
 }

--- a/stdlib/public/RuntimeModule/PDB/PDBFile.swift
+++ b/stdlib/public/RuntimeModule/PDB/PDBFile.swift
@@ -436,6 +436,10 @@ public class PDBFile {
               let address = sections[Int(info.seg) - 1].virtualAddress + info.off
 
               rawNames[address] = rawName
+
+              functions.append(FunctionInfo(rawName: rawName,
+                                            name: rawName,
+                                            address: address))
             }
           }
 
@@ -502,7 +506,23 @@ public class PDBFile {
       return nil
     }
 
-    functions.sort { $0.address < $1.address }
+    functions.sort { $0.address < $1.address
+                       || ($0.address == $1.address
+                             && (($0.scope != nil && $1.scope == nil)
+                                   || $0.name < $1.name)) }
+
+    // Remove any duplicates
+    var read = 0, write = 0
+    while read < functions.count {
+      let address = functions[read].address
+      functions[write] = functions[read]
+      read += 1
+      write += 1
+      while read < functions.count && functions[read].address == address {
+        read += 1
+      }
+    }
+    functions.removeLast(functions.count - write)
   }
 
   enum StreamId {
@@ -888,13 +908,19 @@ public class PDBFile {
     }
 
     let function = functions[funcIndex]
-    let module = modules[function.moduleIndex]
 
-    let sourceLocation = lookup(address: address, in: module)
+    if let moduleIndex = function.moduleIndex {
+      let module = modules[moduleIndex]
+      let sourceLocation = lookup(address: address, in: module)
 
-    return SymbolLookup(rawName: function.rawName,
-                        name: function.name,
-                        offset: address - function.address,
-                        sourceLocation: sourceLocation)
+      return SymbolLookup(rawName: function.rawName,
+                          name: function.name,
+                          offset: address - function.address,
+                          sourceLocation: sourceLocation)
+    } else {
+      return SymbolLookup(rawName: function.rawName,
+                          name: function.name,
+                          offset: address - function.address)
+    }
   }
 }


### PR DESCRIPTION
While for Swift symbols, they always exist in the module streams, the PDBs that Microsoft serves from its symbol servers don't work that way, and contain symbols that don't show up in the module streams.

Thus we need to add function data for each of those.

That then creates a problem where the symbol is in both places, so we need to de-duplicate as well.

rdar://176547291
