### PR TITLE
[IRGen] [DebugInfo] Replace IndirectionKind with op_deref

### DIFF
--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -267,7 +267,7 @@ public:
                                DebugTypeInfo Ty, const SILDebugScope *DS,
                                std::optional<SILLocation> VarLoc,
                                SILDebugVariable VarInfo,
-                               IndirectionKind = DirectValue,
+                               bool InCoroContext = false,
                                ArtificialKind = RealValue,
                                AddrDbgInstrKind = AddrDbgInstrKind::DbgDeclare);
 
@@ -3727,7 +3727,7 @@ bool IRGenDebugInfoImpl::buildDebugInfoExpression(
 void IRGenDebugInfoImpl::emitVariableDeclaration(
     IRBuilder &Builder, ArrayRef<llvm::Value *> Storage, DebugTypeInfo DbgTy,
     const SILDebugScope *DS, std::optional<SILLocation> DbgInstLoc,
-    SILDebugVariable VarInfo, IndirectionKind Indirection,
+    SILDebugVariable VarInfo, bool InCoroContext,
     ArtificialKind Artificial, AddrDbgInstrKind AddrDInstrKind) {
   assert(DS && "variable has no scope");
 
@@ -3863,9 +3863,6 @@ void IRGenDebugInfoImpl::emitVariableDeclaration(
     if (DbgTy.getType()->isForeignReferenceType())
       Operands.push_back(llvm::dwarf::DW_OP_deref);
 
-    if (Indirection == IndirectValue || Indirection == CoroIndirectValue)
-      Operands.push_back(llvm::dwarf::DW_OP_deref);
-
     if (IsPiece) {
       // Advance the offset for the next piece.
       OffsetInBits += SizeInBits;
@@ -3899,8 +3896,7 @@ void IRGenDebugInfoImpl::emitVariableDeclaration(
     if (DIExpr)
       emitDbgIntrinsic(
           Builder, Piece, Var, DIExpr, DInstLine, DInstLoc.Column, Scope, DS,
-          Indirection == CoroDirectValue || Indirection == CoroIndirectValue,
-          AddrDInstrKind);
+          InCoroContext, AddrDInstrKind);
   }
 
   // Emit locationless intrinsic for variables that were optimized away.
@@ -3910,13 +3906,22 @@ void IRGenDebugInfoImpl::emitVariableDeclaration(
             appendDIExpression(DBuilder.createExpression(), NoFragment, false))
       emitDbgIntrinsic(Builder, llvm::ConstantInt::get(IGM.Int64Ty, 0), Var,
                        DIExpr, DInstLine, DInstLoc.Column, Scope, DS,
-                       Indirection == CoroDirectValue ||
-                           Indirection == CoroIndirectValue,
-                       AddrDInstrKind);
+                       InCoroContext, AddrDInstrKind);
   }
 }
 
 namespace {
+
+/// Strip the leading DW_OP_deref from the expression.
+/// dbg.declare implicitly provides one level of dereference, so the first
+/// DW_OP_deref is redundant.
+static llvm::DIExpression *stripLeadingDeref(llvm::DIExpression *Expr,
+                                             llvm::LLVMContext &Ctx) {
+  auto Elements = Expr->getElements();
+  if (!Elements.empty() && Elements[0] == llvm::dwarf::DW_OP_deref)
+    return llvm::DIExpression::get(Ctx, Elements.drop_front(1));
+  return Expr;
+}
 
 /// A helper struct that is used by emitDbgIntrinsic to factor redundant code.
 struct DbgIntrinsicEmitter {
@@ -3959,15 +3964,19 @@ struct DbgIntrinsicEmitter {
                           llvm::DIExpression *Expr,
                           const llvm::DILocation *DL,
                           llvm::Instruction *InsertBefore) {
-    if (ForceDbgDeclareOrDeclareValue == AddrDbgInstrKind::DbgDeclare)
+    if (ForceDbgDeclareOrDeclareValue == AddrDbgInstrKind::DbgDeclare) {
+      Expr = stripLeadingDeref(Expr, InsertBefore->getContext());
       return DIBuilder.insertDeclare(Addr, VarInfo, Expr, DL,
                                      InsertBefore->getIterator());
+    }
 
-    if (ForceDbgDeclareOrDeclareValue == AddrDbgInstrKind::DbgDeclareValue)
+    if (ForceDbgDeclareOrDeclareValue == AddrDbgInstrKind::DbgDeclareValue) {
+      Expr = stripLeadingDeref(Expr, InsertBefore->getContext());
       return DIBuilder.insertDeclareValue(Addr, VarInfo, Expr, DL,
                                           InsertBefore->getIterator());
+    }
 
-    Expr = llvm::DIExpression::append(Expr, llvm::dwarf::DW_OP_deref);
+    // DbgValue: keep expression as-is (all derefs are explicit).
     return DIBuilder.insertDbgValueIntrinsic(Addr, VarInfo, Expr, DL,
                                              InsertBefore->getIterator());
   }
@@ -3976,13 +3985,17 @@ struct DbgIntrinsicEmitter {
                           llvm::DIExpression *Expr,
                           const llvm::DILocation *DL,
                           llvm::BasicBlock *Block) {
-    if (ForceDbgDeclareOrDeclareValue == AddrDbgInstrKind::DbgDeclare)
+    if (ForceDbgDeclareOrDeclareValue == AddrDbgInstrKind::DbgDeclare) {
+      Expr = stripLeadingDeref(Expr, Block->getContext());
       return DIBuilder.insertDeclare(Addr, VarInfo, Expr, DL, Block);
+    }
 
-    if (ForceDbgDeclareOrDeclareValue == AddrDbgInstrKind::DbgDeclareValue)
+    if (ForceDbgDeclareOrDeclareValue == AddrDbgInstrKind::DbgDeclareValue) {
+      Expr = stripLeadingDeref(Expr, Block->getContext());
       return DIBuilder.insertDeclareValue(Addr, VarInfo, Expr, DL, Block);
+    }
 
-    Expr = llvm::DIExpression::append(Expr, llvm::dwarf::DW_OP_deref);
+    // DbgValue: keep expression as-is (all derefs are explicit).
     return DIBuilder.insertDbgValueIntrinsic(Addr, VarInfo, Expr, DL, Block);
   }
 };
@@ -4039,9 +4052,9 @@ void IRGenDebugInfoImpl::emitDbgIntrinsic(
 
   bool optimized = DS->getParentFunction()->shouldOptimize();
   if (optimized && (!InCoroContext || !Var->isParameter()))
-    AddrDInstKind = AddrDbgInstrKind::DbgValueDeref;
+    AddrDInstKind = AddrDbgInstrKind::DbgValue;
 
-  if (InCoroContext && AddrDInstKind != AddrDbgInstrKind::DbgValueDeref)
+  if (InCoroContext && AddrDInstKind != AddrDbgInstrKind::DbgValue)
     AddrDInstKind = AddrDbgInstrKind::DbgDeclareValue;
 
   DbgIntrinsicEmitter inserter{Builder, DBuilder, AddrDInstKind};
@@ -4200,10 +4213,7 @@ void IRGenDebugInfoImpl::emitTypeMetadata(IRGenFunction &IGF,
       Alignment(CI.getTargetInfo().getPointerAlign(clang::LangAS::Default)));
   emitVariableDeclaration(IGF.Builder, Metadata, DbgTy, IGF.getDebugScope(),
                           {}, {OS.str().str(), 0, false},
-                          // swift.type is already a pointer type,
-                          // having a shadow copy doesn't add another
-                          // layer of indirection.
-                          IGF.isAsync() ? CoroDirectValue : DirectValue,
+                          /*InCoroContext=*/IGF.isAsync(),
                           ArtificialValue);
 }
 
@@ -4224,7 +4234,7 @@ void IRGenDebugInfoImpl::emitPackCountParameter(IRGenFunction &IGF,
   auto DbgTy = *CompletedDebugTypeInfo::getFromTypeInfo(IntTy, TI, IGM);
   emitVariableDeclaration(
       IGF.Builder, Metadata, DbgTy, IGF.getDebugScope(), {}, VarInfo,
-      IGF.isAsync() ? CoroDirectValue : DirectValue, ArtificialValue);
+      /*InCoroContext=*/IGF.isAsync(), ArtificialValue);
 }
 
 } // anonymous namespace
@@ -4316,10 +4326,10 @@ void IRGenDebugInfo::emitOutlinedFunction(IRBuilder &Builder,
 void IRGenDebugInfo::emitVariableDeclaration(
     IRBuilder &Builder, ArrayRef<llvm::Value *> Storage, DebugTypeInfo Ty,
     const SILDebugScope *DS, std::optional<SILLocation> VarLoc,
-    SILDebugVariable VarInfo, IndirectionKind Indirection,
+    SILDebugVariable VarInfo, bool InCoroContext,
     ArtificialKind Artificial, AddrDbgInstrKind AddrDInstKind) {
   static_cast<IRGenDebugInfoImpl *>(this)->emitVariableDeclaration(
-      Builder, Storage, Ty, DS, VarLoc, VarInfo, Indirection, Artificial,
+      Builder, Storage, Ty, DS, VarLoc, VarInfo, InCoroContext, Artificial,
       AddrDInstKind);
 }
 

--- a/lib/IRGen/IRGenDebugInfo.h
+++ b/lib/IRGen/IRGenDebugInfo.h
@@ -38,21 +38,19 @@ class IRBuilder;
 class IRGenFunction;
 class IRGenModule;
 
-enum IndirectionKind {
-  DirectValue,
-  IndirectValue,
-  CoroDirectValue,
-  CoroIndirectValue
-};
 enum ArtificialKind : bool { RealValue = false, ArtificialValue = true };
 
-/// Used to signal to emitDbgIntrinsic that we actually want to emit dbg.declare
-/// instead of dbg.value + op_deref. By default, we now emit dbg.value instead of
-/// dbg.declare for normal variables. This is not true for metadata which
-/// truly are function wide and should be llvm.dbg.declare.
+/// Used to signal to emitDbgIntrinsic which kind of debug intrinsic to emit.
+/// - DbgDeclare: llvm.dbg.declare (variable lives at this address for its
+///   entire lifetime). The leading DW_OP_deref is stripped because declare
+///   implicitly provides one level of indirection.
+/// - DbgValue: llvm.dbg.value (expression evaluated as-is; all derefs are
+///   explicit).
+/// - DbgDeclareValue: llvm.dbg.declare_value (coro context variant). The
+///   leading DW_OP_deref is stripped like DbgDeclare.
 enum class AddrDbgInstrKind : uint8_t {
   DbgDeclare,
-  DbgValueDeref,
+  DbgValue,
   DbgDeclareValue,
 };
 
@@ -164,7 +162,7 @@ public:
                                DebugTypeInfo Ty, const SILDebugScope *DS,
                                std::optional<SILLocation> VarLoc,
                                SILDebugVariable VarInfo,
-                               IndirectionKind Indirection = DirectValue,
+                               bool InCoroContext = false,
                                ArtificialKind Artificial = RealValue,
                                AddrDbgInstrKind = AddrDbgInstrKind::DbgDeclare);
 

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -1025,12 +1025,12 @@ public:
   /// register allocator doesn't elide the dbg.value intrinsic when
   /// register pressure is high.  There is a trade-off to this: With
   /// shadow copies, we lose the precise lifetime.
-  ///
-  /// Returns the shadow copy, or nullptr if no shadow copy was needed.
-  llvm::Value *emitShadowCopyIfNeededOrNull(
-      llvm::Value *Storage, llvm::Type *StorageType, const SILDebugScope *Scope,
-      SILDebugVariable VarInfo, bool IsAnonymous, bool WasMoved,
-      std::optional<Alignment> Align = std::nullopt) {
+  llvm::Value *
+  emitShadowCopyIfNeeded(llvm::Value *Storage, llvm::Type *StorageType,
+                         const SILDebugScope *Scope, SILDebugVariable VarInfo,
+                         bool IsAnonymous, bool WasMoved,
+                         SILDebugInfoExpression *ExprToExtend = nullptr,
+                         std::optional<Alignment> Align = std::nullopt) {
     // Never emit shadow copies when optimizing, or if already on the stack.  No
     // debug info is emitted for refcounts either
 
@@ -1048,12 +1048,17 @@ public:
     // generating extra shadow copies for debug_value [poison].
     if (!shouldShadowVariable(VarInfo, IsAnonymous)
         || !shouldShadowStorage(Storage, StorageType)) {
-      return nullptr;
+      return Storage;
     }
 
     // Emit a shadow copy.
     auto shadow = emitShadowCopy(Storage, Scope, VarInfo, Align, true, WasMoved)
                       .getAddress();
+
+    // The shadow copy adds an extra layer of indirection.
+    if (ExprToExtend)
+      ExprToExtend->prependElements(
+          {SILDIExprElement::createOperator(SILDIExprOperator::Dereference)});
 
     // Mark variables in async functions for lifetime extension, so they get
     // spilled into the async context.
@@ -1068,36 +1073,25 @@ public:
     return shadow;
   }
 
-  /// Like \c emitShadowCopyIfNeededOrNull() but returns the original storage
-  /// when no shadow copy is needed (never returns nullptr).
-  llvm::Value *
-  emitShadowCopyIfNeeded(llvm::Value *Storage, llvm::Type *StorageType,
-                         const SILDebugScope *Scope, SILDebugVariable VarInfo,
-                         bool IsAnonymous, bool WasMoved,
-                         std::optional<Alignment> Align = std::nullopt) {
-    if (auto *shadow = emitShadowCopyIfNeededOrNull(
-            Storage, StorageType, Scope, VarInfo, IsAnonymous, WasMoved, Align))
-      return shadow;
-    return Storage;
-  }
-
   /// Like \c emitShadowCopyIfNeeded() but takes an \c Address instead of an
   /// \c llvm::Value.
   llvm::Value *emitShadowCopyIfNeeded(Address Storage,
                                       llvm::Type *StorageType,
                                       const SILDebugScope *Scope,
                                       SILDebugVariable VarInfo,
-                                      bool IsAnonymous, bool WasMoved) {
+                                      bool IsAnonymous, bool WasMoved,
+                                      SILDebugInfoExpression *ExprToExtend = nullptr) {
     return emitShadowCopyIfNeeded(Storage.getAddress(), StorageType, Scope,
                                   VarInfo, IsAnonymous, WasMoved,
-                                  Storage.getAlignment());
+                                  ExprToExtend, Storage.getAlignment());
   }
 
   /// Like \c emitShadowCopyIfNeeded() but takes an exploded value.
   void emitShadowCopyIfNeeded(SILValue &SILVal, const SILDebugScope *Scope,
                               SILDebugVariable VarInfo, bool IsAnonymous,
                               bool WasMoved,
-                              llvm::SmallVectorImpl<llvm::Value *> &copy) {
+                              llvm::SmallVectorImpl<llvm::Value *> &copy,
+                              SILDebugInfoExpression *ExprToExtend = nullptr) {
     Explosion e = getLoweredExplosion(SILVal);
 
     // Only do this at -O0.
@@ -1127,7 +1121,8 @@ public:
       auto &ti = getTypeInfo(SILVal->getType());
       copy.push_back(emitShadowCopyIfNeeded(e.claimNext(), ti.getStorageType(),
                                             Scope, VarInfo,
-                                            IsAnonymous, WasMoved));
+                                            IsAnonymous, WasMoved,
+                                            ExprToExtend));
       return;
     }
 
@@ -1205,20 +1200,20 @@ public:
   void emitDebugVariableDeclaration(
       StorageType Storage, DebugTypeInfo Ty, SILType SILTy,
       const SILDebugScope *DS, SILLocation VarLoc, SILDebugVariable VarInfo,
-      IndirectionKind Indirection,
+      bool InCoroContext = false,
       AddrDbgInstrKind DbgInstrKind = AddrDbgInstrKind::DbgDeclare) {
     assert(IGM.DebugInfo && "debug info not enabled");
 
     if (VarInfo.ArgNo) {
       PrologueLocation AutoRestore(IGM.DebugInfo.get(), Builder);
       IGM.DebugInfo->emitVariableDeclaration(
-          Builder, Storage, Ty, DS, VarLoc, VarInfo, Indirection,
+          Builder, Storage, Ty, DS, VarLoc, VarInfo, InCoroContext,
           ArtificialKind::RealValue, DbgInstrKind);
       return;
     }
 
     IGM.DebugInfo->emitVariableDeclaration(
-        Builder, Storage, Ty, DS, VarLoc, VarInfo, Indirection,
+        Builder, Storage, Ty, DS, VarLoc, VarInfo, InCoroContext,
         ArtificialKind::RealValue, DbgInstrKind);
   }
 
@@ -6043,15 +6038,22 @@ void IRGenSILFunction::emitErrorResultVar(CanSILFunctionType FnTy,
   assert(Var && "error result without debug info");
   auto Storage =
       emitShadowCopyIfNeeded(ErrorResultSlot.getAddress(), nullptr, getDebugScope(),
-                             *Var, false, false /*was move*/);
+                             *Var, false, false /*was move*/, &Var->DIExpr);
   if (!IGM.DebugInfo)
     return;
+  // The error result slot is an alloca storing a pointer to the error.
+  // We need two layers of indirection.
+  // The VarInfo initially has an empty DIExpr and undef value, so we need
+  // to recreate the whole DIExpr.
+  Var->DIExpr.prependElements(
+      {SILDIExprElement::createOperator(SILDIExprOperator::Dereference),
+       SILDIExprElement::createOperator(SILDIExprOperator::Dereference)});
   auto DbgTy = DebugTypeInfo::getErrorResult(
       ErrorInfo.getReturnValueType(IGM.getSILModule(), FnTy,
                                    IGM.getMaximalTypeExpansionContext()),IGM);
   IGM.DebugInfo->emitVariableDeclaration(Builder, Storage, DbgTy,
                                          getDebugScope(), {}, *Var,
-                                         IndirectValue, ArtificialValue);
+                                         /*InCoroContext=*/false, ArtificialValue);
 }
 
 void IRGenSILFunction::emitPoisonDebugValueInst(DebugValueInst *i) {
@@ -6232,10 +6234,6 @@ void IRGenSILFunction::visitDebugValueInst(DebugValueInst *i) {
   } else
     return;
 
-  // Since debug_value is expressing indirection explicitly via op_deref,
-  // we're not using either IndirectValue or CoroIndirectValue here.
-  IndirectionKind Indirection = IsInCoro? CoroDirectValue : DirectValue;
-
   // Put the value into a shadow-copy stack slot at -Onone.
   llvm::SmallVector<llvm::Value *, 8> Copy;
   if (IsAddrVal) {
@@ -6243,43 +6241,23 @@ void IRGenSILFunction::visitDebugValueInst(DebugValueInst *i) {
     auto Addr = getLoweredAddress(SILVal);
     auto *Storage = Addr.getAddress();
 
-    if (auto *ShadowCopy = emitShadowCopyIfNeededOrNull(
-            Storage, TI.getStorageType(), i->getDebugScope(), *VarInfo,
-            IsAnonymous, i->usesMoveableValueDebugInfo())) {
-      Copy.emplace_back(ShadowCopy);
-      // The shadow alloca stores a pointer to the original storage,
-      // adding a level of indirection. For non-moveable values this is
-      // fine because dbg_declare inherently treats its argument as an
-      // address. Moveable values use dbg_value instead, which doesn't
-      // imply that indirection, so we set IndirectValue.
-      if (!IsInCoro && i->usesMoveableValueDebugInfo()) {
-        assert(Indirection != IndirectValue && "IndirectValue already set!");
-        Indirection = IndirectValue;
-      }
-    } else {
-      Copy.emplace_back(Storage);
-    }
+    Copy.emplace_back(emitShadowCopyIfNeeded(
+        Storage, TI.getStorageType(),
+        i->getDebugScope(), *VarInfo, IsAnonymous,
+        i->usesMoveableValueDebugInfo(), &VarInfo->DIExpr));
   } else {
     emitShadowCopyIfNeeded(SILVal, i->getDebugScope(), *VarInfo, IsAnonymous,
-                           i->usesMoveableValueDebugInfo(), Copy);
+                           i->usesMoveableValueDebugInfo(), Copy,
+                           &VarInfo->DIExpr);
   }
-
-  // For alloc_stack operands, createAddr now adds op_deref for SIL-level
-  // uniformity, but IRGen still handles alloc_stack addresses the same as
-  // before (no op_deref in the LLVM expression). Strip the op_deref here
-  // so the emitted LLVM IR is unchanged.
-  SILDebugVariable AdjustedVarInfo = *VarInfo;
-  if (IsAddrVal && isa<AllocStackInst>(SILVal) &&
-      AdjustedVarInfo.DIExpr.startsWithDeref())
-    AdjustedVarInfo.DIExpr.eraseElement(AdjustedVarInfo.DIExpr.element_begin());
 
   bindArchetypes(DbgTy.getType());
   if (!IGM.DebugInfo)
     return;
 
   emitDebugVariableDeclaration(
-      Copy, DbgTy, SILTy, i->getDebugScope(), i->getLoc(), AdjustedVarInfo,
-      Indirection, AddrDbgInstrKind(i->usesMoveableValueDebugInfo()));
+      Copy, DbgTy, SILTy, i->getDebugScope(), i->getLoc(), *VarInfo,
+      IsInCoro, AddrDbgInstrKind(i->usesMoveableValueDebugInfo()));
 }
 
 void IRGenSILFunction::visitDebugStepInst(DebugStepInst *i) {
@@ -6694,11 +6672,6 @@ void IRGenSILFunction::emitDebugInfoAfterAllocStack(AllocStackInst *i,
       i->getDebugScope()->getInlinedFunction()->isTransparent())
     return;
 
-  // The alloc_stack's VarInfo is a single op_deref, but for IRGen the
-  // indirection is already expressed by using llvm.dbg.declare on the
-  // alloca address. Strip the op_deref to avoid a double-dereference.
-  VarInfo->DIExpr = {};
-
   VarDecl *Decl = i->getDecl();
   auto *DS = i->getDebugScope();
 
@@ -6727,10 +6700,13 @@ void IRGenSILFunction::emitDebugInfoAfterAllocStack(AllocStackInst *i,
          isa<llvm::IntrinsicInst>(addr) || isCallToSwiftTaskAlloc(addr) ||
          isCallToMalloc(addr));
 
-  auto Indirection = DirectValue;
-  if (InCoroContext(*CurSILFn, *i))
-    Indirection =
-        isCallToSwiftTaskAlloc(addr) ? CoroIndirectValue : CoroDirectValue;
+  bool IsInCoro = InCoroContext(*CurSILFn, *i);
+
+  // For task alloc (swift_task_alloc), the address is itself behind a pointer,
+  // so prepend an extra op_deref.
+  if (isCallToSwiftTaskAlloc(addr))
+    VarInfo->DIExpr.prependElements(
+        {SILDIExprElement::createOperator(SILDIExprOperator::Dereference)});
 
   if (!IGM.IRGen.Opts.DisableDebuggerShadowCopies &&
       !IGM.IRGen.Opts.shouldOptimize())
@@ -6740,8 +6716,9 @@ void IRGenSILFunction::emitDebugInfoAfterAllocStack(AllocStackInst *i,
         addr = emitShadowCopy(addr, DS, *VarInfo, IGM.getPointerAlignment(),
                               /*init*/ true, i->usesMoveableValueDebugInfo())
                    .getAddress();
-        Indirection =
-            InCoroContext(*CurSILFn, *i) ? CoroIndirectValue : IndirectValue;
+        // This adds a layer of indirection to the debug variable.
+        VarInfo->DIExpr.prependElements(
+            {SILDIExprElement::createOperator(SILDIExprOperator::Dereference)});
       }
 
   // Ignore compiler-generated patterns but not optional bindings.
@@ -6763,7 +6740,7 @@ void IRGenSILFunction::emitDebugInfoAfterAllocStack(AllocStackInst *i,
     }
 
     emitDebugVariableDeclaration(
-        addr, DbgTy, SILTy, DS, i->getLoc(), *VarInfo, Indirection,
+        addr, DbgTy, SILTy, DS, i->getLoc(), *VarInfo, IsInCoro,
         AddrDbgInstrKind(i->usesMoveableValueDebugInfo()));
   }
 }
@@ -7042,16 +7019,21 @@ void IRGenSILFunction::visitAllocBoxInst(swift::AllocBoxInst *i) {
     return;
   auto &ti = getTypeInfo(SILTy);
   auto Storage =
-      emitShadowCopyIfNeeded(boxWithAddr.getAddress(), ti.getStorageType(),
+      emitShadowCopyIfNeeded(boxWithAddr.getAddressPointer(), ti.getStorageType(),
                              i->getDebugScope(),
-                             *VarInfo, IsAnonymous, false /*was moved*/);
+                             *VarInfo, IsAnonymous, false /*was moved*/,
+                             &VarInfo->DIExpr);
 
   if (!IGM.DebugInfo)
     return;
 
+  // The box content address points to the variable — one level of indirection.
+  VarInfo->DIExpr.prependElements(
+      {SILDIExprElement::createOperator(SILDIExprOperator::Dereference)});
+
   IGM.DebugInfo->emitVariableDeclaration(
       Builder, Storage, DbgTy, i->getDebugScope(), i->getLoc(), *VarInfo,
-      InCoroContext(*CurSILFn, *i) ? CoroIndirectValue : IndirectValue);
+      InCoroContext(*CurSILFn, *i));
 }
 
 void IRGenSILFunction::visitProjectBoxInst(swift::ProjectBoxInst *i) {

--- a/test/DebugInfo/move_function_dbginfo.swift
+++ b/test/DebugInfo/move_function_dbginfo.swift
@@ -170,10 +170,10 @@ public func copyableVarTest() {
 
 // CHECK-LABEL: define swiftcc void @"$s21move_function_dbginfo18copyableVarArgTestyyAA5KlassCzF"(
 // CHECK: #dbg_declare(ptr %m.debug,
-// CHECK: #dbg_value(ptr [[VAR:%.*]], ![[K_COPYABLE_VAR_METADATA:[0-9]+]], !DIExpression(DW_OP_deref, DW_OP_deref, DW_OP_deref), ![[ADDR_LOC:[0-9]*]]
+// CHECK: #dbg_value(ptr [[VAR:%.*]], ![[K_COPYABLE_VAR_METADATA:[0-9]+]], !DIExpression(DW_OP_deref, DW_OP_deref), ![[ADDR_LOC:[0-9]*]]
 // CHECK: #dbg_value(ptr undef, ![[K_COPYABLE_VAR_METADATA]], !DIExpression(DW_OP_deref), ![[ADDR_LOC]]
 // TODO: Should this be a deref like the original?
-// CHECK: #dbg_value(ptr [[VAR]], ![[K_COPYABLE_VAR_METADATA]], !DIExpression(DW_OP_deref, DW_OP_deref, DW_OP_deref), ![[ADDR_LOC]]
+// CHECK: #dbg_value(ptr [[VAR]], ![[K_COPYABLE_VAR_METADATA]], !DIExpression(DW_OP_deref, DW_OP_deref), ![[ADDR_LOC]]
 // CHECK: ret void
 // CHECK-NEXT: }
 //
@@ -259,7 +259,7 @@ public func addressOnlyValueTest<T : P>(_ x: T) {
 // CHECK-LABEL: define swiftcc void @"$s21move_function_dbginfo23addressOnlyValueArgTestyyxnAA1PRzlF"(
 // CHECK: #dbg_declare(ptr %T1,
 // CHECK: #dbg_declare(ptr %m.debug,
-// CHECK: #dbg_value(ptr %k.debug, ![[K_ADDR_LET_METADATA:[0-9]+]], !DIExpression(DW_OP_deref, DW_OP_deref, DW_OP_deref), ![[ADDR_LOC:[0-9]*]]
+// CHECK: #dbg_value(ptr %k.debug, ![[K_ADDR_LET_METADATA:[0-9]+]], !DIExpression(DW_OP_deref, DW_OP_deref), ![[ADDR_LOC:[0-9]*]]
 // CHECK: #dbg_value(ptr undef, ![[K_ADDR_LET_METADATA]], !DIExpression(DW_OP_deref), ![[ADDR_LOC]]
 // CHECK: ret void
 // CHECK-NEXT: }
@@ -344,9 +344,9 @@ public func addressOnlyVarTest<T : P>(_ x: T) {
 }
 
 // CHECK-LABEL: define swiftcc void @"$s21move_function_dbginfo21addressOnlyVarArgTestyyxz_xtAA1PRzlF"(
-// CHECK: #dbg_value(ptr %k.debug, ![[K_ADDRONLY_VAR_METADATA:[0-9]+]], !DIExpression(DW_OP_deref, DW_OP_deref, DW_OP_deref), ![[ADDR_LOC:[0-9]*]]
+// CHECK: #dbg_value(ptr %k.debug, ![[K_ADDRONLY_VAR_METADATA:[0-9]+]], !DIExpression(DW_OP_deref, DW_OP_deref), ![[ADDR_LOC:[0-9]*]]
 // CHECK: #dbg_value(ptr undef, ![[K_ADDRONLY_VAR_METADATA]], !DIExpression(DW_OP_deref), ![[ADDR_LOC]]
-// CHECK: #dbg_value(ptr %k.debug, ![[K_ADDRONLY_VAR_METADATA]], !DIExpression(DW_OP_deref, DW_OP_deref, DW_OP_deref), ![[ADDR_LOC]]
+// CHECK: #dbg_value(ptr %k.debug, ![[K_ADDRONLY_VAR_METADATA]], !DIExpression(DW_OP_deref, DW_OP_deref), ![[ADDR_LOC]]
 // CHECK: ret void
 // CHECK-NEXT: }
 //
@@ -452,7 +452,7 @@ public func copyableVarTestCCFlowReinitOutOfBlockTest() {
 
 // CHECK-LABEL: define swiftcc void @"$s21move_function_dbginfo040copyableVarArgTestCCFlowReinitOutOfBlockG0yyAA5KlassCzF"(
 // CHECK: #dbg_declare(ptr %m.debug,
-// CHECK: #dbg_value(ptr [[VAR:%.*]], ![[K_COPYABLE_VAR_CCFLOW_REINIT_OUT_BLOCK_METADATA:[0-9]+]], !DIExpression(DW_OP_deref, DW_OP_deref, DW_OP_deref), ![[ADDR_LOC:[0-9]*]]
+// CHECK: #dbg_value(ptr [[VAR:%.*]], ![[K_COPYABLE_VAR_CCFLOW_REINIT_OUT_BLOCK_METADATA:[0-9]+]], !DIExpression(DW_OP_deref, DW_OP_deref), ![[ADDR_LOC:[0-9]*]]
 //
 // CHECK:      br i1 %{{[0-9]+}}, label %[[LHS:[0-9]+]], label %[[RHS:[0-9]+]],
 //
@@ -464,7 +464,7 @@ public func copyableVarTestCCFlowReinitOutOfBlockTest() {
 // CHECK:      br label %[[CONT_BB]],
 //
 // CHECK: [[CONT_BB]]:
-// CHECK: #dbg_value(ptr [[VAR]], ![[K_COPYABLE_VAR_CCFLOW_REINIT_OUT_BLOCK_METADATA]], !DIExpression(DW_OP_deref, DW_OP_deref, DW_OP_deref), ![[ADDR_LOC]]
+// CHECK: #dbg_value(ptr [[VAR]], ![[K_COPYABLE_VAR_CCFLOW_REINIT_OUT_BLOCK_METADATA]], !DIExpression(DW_OP_deref, DW_OP_deref), ![[ADDR_LOC]]
 // CHECK: ret void
 // CHECK-NEXT: }
 public func copyableVarArgTestCCFlowReinitOutOfBlockTest(_ k: inout Klass) {
@@ -510,14 +510,14 @@ public func copyableVarTestCCFlowReinitInBlockTest() {
 // CHECK-LABEL: define swiftcc void @"$s21move_function_dbginfo037copyableVarArgTestCCFlowReinitInBlockG0yyAA5KlassCzF"(
 // CHECK: entry:
 // CHECK: #dbg_declare(ptr %m.debug,
-// CHECK: #dbg_value(ptr [[VAR:%.*]], ![[K_COPYABLE_VAR_CCFLOW_REINIT_IN_BLOCK_METADATA:[0-9]+]], !DIExpression(DW_OP_deref, DW_OP_deref, DW_OP_deref), ![[ADDR_LOC:[0-9]*]]
+// CHECK: #dbg_value(ptr [[VAR:%.*]], ![[K_COPYABLE_VAR_CCFLOW_REINIT_IN_BLOCK_METADATA:[0-9]+]], !DIExpression(DW_OP_deref, DW_OP_deref), ![[ADDR_LOC:[0-9]*]]
 //
 // CHECK:      br i1 %{{[0-9]+}}, label %[[LHS:[0-9]+]], label %[[RHS:[0-9]+]],
 //
 // CHECK: [[LHS]]:
 // CHECK:      #dbg_value(ptr undef, ![[K_COPYABLE_VAR_CCFLOW_REINIT_IN_BLOCK_METADATA]], !DIExpression(DW_OP_deref), ![[ADDR_LOC]]
 // TODO: Should this be a deref like the original?
-// CHECK:      #dbg_value(ptr [[VAR]], ![[K_COPYABLE_VAR_CCFLOW_REINIT_IN_BLOCK_METADATA]], !DIExpression(DW_OP_deref, DW_OP_deref, DW_OP_deref), ![[ADDR_LOC]]
+// CHECK:      #dbg_value(ptr [[VAR]], ![[K_COPYABLE_VAR_CCFLOW_REINIT_IN_BLOCK_METADATA]], !DIExpression(DW_OP_deref, DW_OP_deref), ![[ADDR_LOC]]
 //
 // CHECK:      br label %[[CONT_BB:[a-z\.0-9]+]],
 //
@@ -568,7 +568,7 @@ public func addressOnlyVarTestCCFlowReinitOutOfBlockTest<T : P>(_ x: T.Type) {
 
 // CHECK-LABEL: define swiftcc void @"$s21move_function_dbginfo043addressOnlyVarArgTestCCFlowReinitOutOfBlockH0yyAA1P_pz_xmtAaCRzlF"(
 // CHECK: entry:
-// CHECK: #dbg_value(ptr [[VAR:%.*]], ![[K_ADDRESSONLY_VAR_CCFLOW_REINIT_OUT_BLOCK_METADATA:[0-9]+]], !DIExpression(DW_OP_deref, DW_OP_deref, DW_OP_deref), ![[ADDR_LOC:[0-9]*]]
+// CHECK: #dbg_value(ptr [[VAR:%.*]], ![[K_ADDRESSONLY_VAR_CCFLOW_REINIT_OUT_BLOCK_METADATA:[0-9]+]], !DIExpression(DW_OP_deref, DW_OP_deref), ![[ADDR_LOC:[0-9]*]]
 //
 // CHECK:      br i1 %{{[0-9]+}}, label %[[LHS:[0-9]+]], label %[[RHS:[0-9]+]],
 //
@@ -581,7 +581,7 @@ public func addressOnlyVarTestCCFlowReinitOutOfBlockTest<T : P>(_ x: T.Type) {
 //
 // CHECK: [[CONT_BB]]:
 // TODO: Should this be a deref like the original?
-// CHECK: #dbg_value(ptr [[VAR]], ![[K_ADDRESSONLY_VAR_CCFLOW_REINIT_OUT_BLOCK_METADATA]], !DIExpression(DW_OP_deref, DW_OP_deref, DW_OP_deref), ![[ADDR_LOC]]
+// CHECK: #dbg_value(ptr [[VAR]], ![[K_ADDRESSONLY_VAR_CCFLOW_REINIT_OUT_BLOCK_METADATA]], !DIExpression(DW_OP_deref, DW_OP_deref), ![[ADDR_LOC]]
 // CHECK: ret void
 // CHECK-NEXT: }
 public func addressOnlyVarArgTestCCFlowReinitOutOfBlockTest<T : P>(_ k: inout (any P), _ x: T.Type) {
@@ -625,14 +625,14 @@ public func addressOnlyVarTestCCFlowReinitInBlockTest<T : P>(_ x: T.Type) {
 
 // CHECK-LABEL: define swiftcc void @"$s21move_function_dbginfo040addressOnlyVarArgTestCCFlowReinitInBlockH0yyAA1P_pz_xmtAaCRzlF"(
 // CHECK: entry:
-// CHECK: #dbg_value(ptr [[VAR:%.*]], ![[K_ADDRESSONLY_VAR_CCFLOW_REINIT_IN_BLOCK_METADATA:[0-9]+]], !DIExpression(DW_OP_deref, DW_OP_deref, DW_OP_deref), ![[ADDR_LOC:[0-9]*]]
+// CHECK: #dbg_value(ptr [[VAR:%.*]], ![[K_ADDRESSONLY_VAR_CCFLOW_REINIT_IN_BLOCK_METADATA:[0-9]+]], !DIExpression(DW_OP_deref, DW_OP_deref), ![[ADDR_LOC:[0-9]*]]
 //
 // CHECK:      br i1 %{{[0-9]+}}, label %[[LHS:[0-9]+]], label %[[RHS:[0-9]+]],
 //
 // CHECK: [[LHS]]:
 // CHECK:      #dbg_value(ptr undef, ![[K_ADDRESSONLY_VAR_CCFLOW_REINIT_IN_BLOCK_METADATA]], !DIExpression(DW_OP_deref), ![[ADDR_LOC]]
 // TODO: Should this be a deref like the original?
-// CHECK:      #dbg_value(ptr [[VAR]], ![[K_ADDRESSONLY_VAR_CCFLOW_REINIT_IN_BLOCK_METADATA]], !DIExpression(DW_OP_deref, DW_OP_deref, DW_OP_deref), ![[ADDR_LOC]]
+// CHECK:      #dbg_value(ptr [[VAR]], ![[K_ADDRESSONLY_VAR_CCFLOW_REINIT_IN_BLOCK_METADATA]], !DIExpression(DW_OP_deref, DW_OP_deref), ![[ADDR_LOC]]
 //
 // CHECK:      br label %[[CONT_BB:[a-z\.0-9]+]],
 //

--- a/test/DebugInfo/noncopyable_shadow_copy_deref.swift
+++ b/test/DebugInfo/noncopyable_shadow_copy_deref.swift
@@ -17,7 +17,7 @@ public protocol P {
 
 // Case 1: local address-only variable (hoisted alloc_stack, no op_deref).
 // The alloc_stack for `k` gets [moveable_value_debuginfo] and is hoisted
-// to a dynamic alloca. The shadow copy adds IndirectValue.
+// to a dynamic alloca. The shadow copy adds an op_deref.
 //
 // CHECK-LABEL: define {{.*}} @"$s{{.*}}9testLocal{{.*}}"(
 // CHECK: #dbg_value(ptr %k.debug, ![[LOCAL_K:[0-9]+]], !DIExpression(DW_OP_deref, DW_OP_deref), ![[LOCAL_LOC:[0-9]+]]
@@ -32,10 +32,10 @@ public func testLocal<T: P>(_ x: T) {
 
 // Case 2: inout address-only parameter (has op_deref).
 // The debug_value's operand is the indirect parameter (not an
-// AllocStackInst), so op_deref is prepended. IndirectValue adds another.
+// AllocStackInst), so op_deref is prepended. The shadow copy adds an op_deref.
 //
 // CHECK-LABEL: define {{.*}} @"$s{{.*}}12testInoutArg{{.*}}"(
-// CHECK: #dbg_value(ptr %k.debug, ![[ARG_K:[0-9]+]], !DIExpression(DW_OP_deref, DW_OP_deref, DW_OP_deref), ![[ARG_LOC:[0-9]+]]
+// CHECK: #dbg_value(ptr %k.debug, ![[ARG_K:[0-9]+]], !DIExpression(DW_OP_deref, DW_OP_deref), ![[ARG_LOC:[0-9]+]]
 // CHECK: #dbg_value(ptr undef, ![[ARG_K]], !DIExpression(DW_OP_deref), ![[ARG_LOC]]
 // CHECK: ret void
 // CHECK-NEXT: }


### PR DESCRIPTION
Instead of using a single DirectValue/IndirectValue enum with duplicate values for coro context, indirect values are now represented with an extra op_deref throughout.

This makes the code simpler: Coro context is now a boolean throughout, and the intent behind indirection is clearer. It also cleanly supports multiple layers of indirection: if two consecutive paths set the indirection kind to IndirectValue, it would only insert one DW_OP_deref instead of two.

This fixes the move_function_dbginfo.swift test file with the deref behaviour (rdar://176552243). All changed test cases have been tested manually in LLDB to make sure it is the correct behaviour.
