### PR TITLE
[cxx-interop] Never copy trivial move-only C++ types

### DIFF
--- a/include/swift/AST/ClangModuleLoader.h
+++ b/include/swift/AST/ClangModuleLoader.h
@@ -315,6 +315,10 @@ public:
 
   virtual bool isCXXMethodMutating(const clang::CXXMethodDecl *method) = 0;
 
+  /// Determine whether the given C++ record is non-copyable (move-only) as
+  /// imported into Swift.
+  virtual bool isCxxMoveOnlyType(const clang::CXXRecordDecl *decl) = 0;
+
   virtual bool isUnsafeCXXMethod(const FuncDecl *func) = 0;
 
   virtual FuncDecl *getDefaultArgGenerator(const clang::ParmVarDecl *param) = 0;

--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -657,6 +657,8 @@ public:
 
   bool isCXXMethodMutating(const clang::CXXMethodDecl *method) override;
 
+  bool isCxxMoveOnlyType(const clang::CXXRecordDecl *decl) override;
+
   bool isUnsafeCXXMethod(const FuncDecl *func) override;
 
   FuncDecl *getDefaultArgGenerator(const clang::ParmVarDecl *param) override;

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -7834,6 +7834,11 @@ bool ClangImporter::isCXXMethodMutating(const clang::CXXMethodDecl *method) {
   return false;
 }
 
+bool ClangImporter::isCxxMoveOnlyType(const clang::CXXRecordDecl *decl) {
+  return importer::getCxxValueSemanticsKind(decl->getTypeForDecl(), Impl) ==
+         CxxValueSemanticsKind::MoveOnly;
+}
+
 bool ClangImporter::isUnsafeCXXMethod(const FuncDecl *func) {
   if (!func->hasClangNode())
     return false;

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -3853,12 +3853,41 @@ getIndirectCParameterConvention(const clang::ParmVarDecl *param) {
 /// directly, deduce the convention for it.
 ///
 /// Generally, whether the parameter is +1 is handled before this.
-static ParameterConvention getDirectCParameterConvention(clang::QualType type) {
+static ParameterConvention
+getDirectCParameterConvention(clang::QualType type,
+                              ClangModuleLoader *clangModuleLoader) {
   if (auto *cxxRecord = type->getAsCXXRecordDecl()) {
     // Directly passed non-trivially destroyed C++ record is consumed by the
     // callee.
     if (!cxxRecord->hasTrivialDestructor())
       return ParameterConvention::Direct_Owned;
+    // A move-only C++ record passed by value is semantically consumed: C++
+    // would require move-construction at the call site, and Swift's
+    // no-implicit-copy rules should apply. Mirror pure-Swift noncopyable
+    // by-value parameters, which are always @owned regardless of triviality.
+    //
+    // FIXME: C/C++ types annotated with a Swift `destroy:` attribute are
+    // classified as move-only but rely on a non-consuming by-value
+    // convention here so that their synthesized `deinit` (which forwards
+    // `self` to the destroy function) does not trip the "self cannot be
+    // consumed during 'deinit'" diagnostic. Skip the flip for those; ideally
+    // the deinit synthesizer would mark that call site specially so we can
+    // drop this exception.
+    if (clangModuleLoader && clangModuleLoader->isCxxMoveOnlyType(cxxRecord)) {
+      bool hasDestroyAttr = false;
+      if (cxxRecord->hasAttrs()) {
+        for (const clang::Attr *attr : cxxRecord->getAttrs()) {
+          if (auto *swiftAttr = dyn_cast<clang::SwiftAttrAttr>(attr)) {
+            if (swiftAttr->getAttribute().starts_with("destroy:")) {
+              hasDestroyAttr = true;
+              break;
+            }
+          }
+        }
+      }
+      if (!hasDestroyAttr)
+        return ParameterConvention::Direct_Owned;
+    }
   }
   return ParameterConvention::Direct_Unowned;
 }
@@ -3866,11 +3895,12 @@ static ParameterConvention getDirectCParameterConvention(clang::QualType type) {
 /// Given a C parameter declaration whose type is passed directly,
 /// deduce the convention for it.
 static ParameterConvention
-getDirectCParameterConvention(const clang::ParmVarDecl *param) {
+getDirectCParameterConvention(const clang::ParmVarDecl *param,
+                              ClangModuleLoader *clangModuleLoader) {
   if (param->hasAttr<clang::NSConsumedAttr>() ||
       param->hasAttr<clang::CFConsumedAttr>())
     return ParameterConvention::Direct_Owned;
-  return getDirectCParameterConvention(param->getType());
+  return getDirectCParameterConvention(param->getType(), clangModuleLoader);
 }
 
 // FIXME: that should be Direct_Guaranteed
@@ -3896,7 +3926,11 @@ public:
   ParameterConvention getDirectParameter(unsigned index,
                            const AbstractionPattern &type,
                            const TypeLowering &substTL) const override {
-    return getDirectCParameterConvention(Method->param_begin()[index]);
+    auto *cml = substTL.getLoweredType()
+                    .getASTType()
+                    ->getASTContext()
+                    .getClangModuleLoader();
+    return getDirectCParameterConvention(Method->param_begin()[index], cml);
   }
 
   ParameterConvention getPackParameter(unsigned index) const override {
@@ -4080,7 +4114,11 @@ public:
                            const TypeLowering &substTL) const override {
     if (cast<clang::FunctionProtoType>(FnType)->isParamConsumed(index))
       return ParameterConvention::Direct_Owned;
-    return getDirectCParameterConvention(getParamType(index));
+    auto *cml = substTL.getLoweredType()
+                    .getASTType()
+                    ->getASTContext()
+                    .getClangModuleLoader();
+    return getDirectCParameterConvention(getParamType(index), cml);
   }
 
   ParameterConvention getPackParameter(unsigned index) const override {

--- a/test/Interop/Cxx/class/move-only/move-only-trivial-cxx-value-type-borrowing.swift
+++ b/test/Interop/Cxx/class/move-only/move-only-trivial-cxx-value-type-borrowing.swift
@@ -1,0 +1,44 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: %target-swift-frontend -emit-sil -I %t/Inputs %t/test.swift -cxx-interoperability-mode=default -verify -o /dev/null
+
+//--- Inputs/module.modulemap
+module Test {
+    header "test.h"
+    requires cplusplus
+}
+
+//--- Inputs/test.h
+
+// A trivial move-only C++ type: deleted copy ctor, defaulted move ctor,
+// trivial destructor (only has int members).
+struct TrivialNonCopyable {
+    int x = 0;
+    TrivialNonCopyable() = default;
+    TrivialNonCopyable(int x) : x(x) {}
+    TrivialNonCopyable(const TrivialNonCopyable &) = delete;
+    TrivialNonCopyable(TrivialNonCopyable &&) = default;
+};
+
+inline void takeByValue(TrivialNonCopyable t) { (void)t; }
+
+inline int borrowConstRef(const TrivialNonCopyable &t) { return t.x; }
+
+//--- test.swift
+import Test
+
+// Passing a borrowed trivial noncopyable C++ value to a function that takes it
+// by value should be rejected, because by-value requires a copy.
+func testBorrowingPassToByValue(_ t: borrowing TrivialNonCopyable) { // expected-error {{'t' is borrowed and cannot be consumed}}
+    takeByValue(t) // expected-note {{consumed here}}
+}
+
+// Passing by const-ref should be fine.
+func testBorrowingPassToConstRef(_ t: borrowing TrivialNonCopyable) {
+    let _ = borrowConstRef(t) // ok
+}
+
+// Consuming parameter should be able to pass to by-value.
+func testConsumingPassToByValue(_ t: consuming TrivialNonCopyable) {
+    takeByValue(t)
+}


### PR DESCRIPTION
We used unowned calling convention for all trivial C++ types, as a result the move checker never diagnosed when an unintentional copy is happened through a call. This PR changes move only types to use @owned calling convention, matching what we do for native Swift types.

Now, we can no longer get away with these copies! Unfortunately, the fix for now is turned off for types with the "destroy" attribute because the synthesized code is triggering some errors. This can be fixed as a follow-up.

rdar://135615824
