### PR TITLE
[6.4] LifetimeDependenceDiagnostics: add Builtin.makeBorrow support

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/AddressUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/AddressUtils.swift
@@ -101,6 +101,14 @@ extension AddressUseVisitor {
     case let pai as PartialApplyInst where !pai.mayEscape:
       return dependentAddressUse(of: operand, dependentValue: pai)
 
+    case let iba as InitBorrowAddrInst where iba.borrow == operand.value:
+      // Initialize the Builtin.Borrow with operand.
+      return leafAddressUse(of: operand)
+
+    case let iba as InitBorrowAddrInst where iba.referent == operand.value:
+      // Store a new Builtin.Borrow value that depends on 'referent'.
+      return dependentAddressUse(of: operand, dependentAddress: iba.borrow)
+
     case let pai as PartialApplyInst where pai.mayEscape:
       return escapingAddressUse(of: operand)
 

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/LocalVariableUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/LocalVariableUtils.swift
@@ -521,6 +521,9 @@ extension LocalVariableAccessWalker: AddressUseVisitor {
       // the local variable's address, then this fully kills operand liveness. The original value in operand's address
       // cannot be used in any way.
       visit(LocalVariableAccess(.store, operand))
+    case let iba as InitBorrowAddrInst:
+      assert(iba.borrow == operand.value)
+      visit(LocalVariableAccess(.store, operand))
     case let md as MarkDependenceAddrInst:
       assert(operand == md.addressOperand)
       visit(LocalVariableAccess(.dependenceDest, operand))

--- a/test/SILOptimizer/lifetime_dependence/verify_diagnostics.sil
+++ b/test/SILOptimizer/lifetime_dependence/verify_diagnostics.sil
@@ -44,6 +44,13 @@ struct NCWrapper : ~Copyable, ~Escapable {
   deinit
 }
 
+struct BorrowWrapper<T: ~Copyable & ~Escapable>: ~Escapable {
+  private let ref: Builtin.Borrow<T>
+
+  @_lifetime(borrow target)
+  init(_ target: borrowing T)
+}
+
 sil @getNEPointer : $@convention(thin) (@guaranteed NE) -> Builtin.RawPointer
 sil @useA : $@convention(thin) (A) -> ()
 sil @makeNE : $@convention(thin) () -> @lifetime(immortal) @owned NE
@@ -421,4 +428,25 @@ bb4(%error : @owned $any Error):
 
 bb5:
   unreachable
+}
+
+// rdar://176564359 ([nonescapable] support Builtin.makeBorrow in lifetime diagnostics)
+//
+// Test that lifetime def-use walkers can follow the initialization of a local using init_borrow_addr.
+sil hidden [ossa] @testInitBorrowAddr : $@convention(method) <T where T : ~Copyable, T : ~Escapable> (@in_guaranteed T, @thin BorrowWrapper<T>.Type) -> @lifetime(borrow address_for_deps 0) @out BorrowWrapper<T> {
+bb0(%0 : $*BorrowWrapper<T>, %1 : $*T, %2 : $@thin BorrowWrapper<T>.Type):
+  %3 = alloc_stack [lexical] [var_decl] $BorrowWrapper<T>, var, name "self", type $BorrowWrapper<T>
+  debug_value %1, let, name "target", argno 1, expr op_deref
+  %5 = alloc_stack $Builtin.Borrow<T>
+  init_borrow_addr %5 with %1
+  %7 = begin_access [modify] [static] %3
+  %8 = struct_element_addr %7, #BorrowWrapper.ref
+  copy_addr %5 to [init] %8
+  end_access %7
+  dealloc_stack %5
+  copy_addr %3 to [init] %0
+  destroy_addr %3
+  dealloc_stack %3
+  %15 = tuple ()
+  return %15
 }

--- a/test/SILOptimizer/lifetime_dependence/verify_diagnostics.swift
+++ b/test/SILOptimizer/lifetime_dependence/verify_diagnostics.swift
@@ -527,3 +527,17 @@ class TestStaticClassProperty {
 
   static let staticSpan = staticArray.span
 }
+
+// =============================================================================
+// Builtin.Borrow
+// =============================================================================
+
+// rdar://176564359 ([nonescapable] support Builtin.makeBorrow in lifetime diagnostics)
+struct TestBuiltinBorrowInit<T: ~Copyable & ~Escapable>: ~Escapable {
+  private let ref: Builtin.Borrow<T>
+
+  @_lifetime(borrow target)
+  init(_ target: borrowing T) {
+    self.ref = Builtin.makeBorrow(target)
+  }
+}


### PR DESCRIPTION
Code like this currently looks like a lifetime escape:

  struct Ref<T: ~Copyable & ~Escapable>: ~Escapable {
    private let ref: Builtin.Borrow<T>

    @_lifetime(borrow target)
    init(_ target: borrowing T) {
      self.ref = Builtin.makeBorrow(target)
    }
  }

This is blocking the implementation of `Ref<~Escapable>`.

Fixes rdar://176564359 ([nonescapable] support Builtin.makeBorrow in
lifetime diagnostics)

(cherry picked from commit 1ed083be0ce43abcf251813c871598af99859bda)

---
- **Explanation**: In lifetime diagnostics, recognize the SIL pattern generated by Builtin.makeBorrow so it does not appear to be an escape.
- **Scope**: Only affects code the uses Builtin.makeBorrow with a ~Escapable type.
- **Issues**: rdar://176564359 ([nonescapable] support Builtin.makeBorrow in lifetime diagnostics)
- **Original PRs**: https://github.com/swiftlang/swift/pull/88968
- **Risk**: Minimal
- **Testing**: Added source and SIL level unit tests.
- **Reviewers**: @jckarter 
