### PR TITLE
[6.4][CodeSynthesis] Factor property wrappers into isolation decision for …

### DIFF
--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -394,6 +394,18 @@ createImplicitConstructor(NominalTypeDecl *decl, ImplicitConstructorKind ICK,
         }
 
         auto type = var->getTypeInContext();
+
+        // If a property has a property wrapper, the memberwise initializer
+        // could use a wrapped type instead of a backing storage type depending
+        // on a property wrapper capabilities. Sendable check has to be
+        // performed on the type that would be used by the initializer.
+        if (ICK == ImplicitConstructorKind::Memberwise) {
+          if (auto *property = var->getOriginalVarForBackingStorage()) {
+            if (property->isPropertyMemberwiseInitializedWithWrappedType())
+              type = property->getPropertyWrapperInitValueInterfaceType();
+          }
+        }
+
         auto isolation = getActorIsolation(var);
         if (isolation.isGlobalActor()) {
           if (!type->isSendableType() ||

--- a/test/Concurrency/transfernonsendable_memberwise_init.swift
+++ b/test/Concurrency/transfernonsendable_memberwise_init.swift
@@ -1,0 +1,31 @@
+// RUN: %target-swift-frontend -emit-sil -language-mode 5 -strict-concurrency=complete -target %target-swift-5.1-abi-triple -verify %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-sil -language-mode 6 -target %target-swift-5.1-abi-triple -verify %s | %FileCheck %s
+
+// REQUIRES: concurrency
+
+@MainActor
+@propertyWrapper
+struct Observed<T> {
+  var wrappedValue: T
+  init(wrappedValue: T) {
+    self.wrappedValue = wrappedValue
+  }
+}
+
+@MainActor
+protocol MyView {}
+
+class MyModel {}
+
+struct TestView: MyView {
+  @Observed var model: MyModel
+
+  // CHECK: // TestView.init(model:)
+  // CHECK-NEXT: // Isolation: global_actor. type: MainActor
+  // CHECK-NEXT: sil hidden @$s35transfernonsendable_memberwise_init8TestViewV5modelAcA7MyModelC_tcfC : $@convention(method) (@owned MyModel, @thin TestView.Type) -> @owned TestView
+}
+
+@MainActor
+func test() {
+  _ = TestView(model: MyModel()) // Ok
+}


### PR DESCRIPTION
…memberwise initializers

- Explanation:

  Fixes an incorrect isolation assignment for memberwise initializers when a property has a property wrapper and wrapped and wrapper type differ in sendability.

  If a property has a property wrapper, the memberwise initializer could use a wrapped type instead of a backing storage type depending on a property wrapper capabilities. Sendable check has to be performed on the type that would be used by the initializer.

- Resolves: rdar://175648722

- Main Branch PR: https://github.com/swiftlang/swift/pull/88938

- Risk: Low. A narrow change that only affects isolation computation when a memberwise initializer has a property wrapped property with wrappedValue: initializer.

- Reviewed By: @DougGregor @hamishknight   

- Testing: Added new test-cases to the suite.

(cherry picked from commit 8bb3bf09fbf3017ab75eddb7e9e8fe462947a57c)

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
