### PR TITLE
Frontend: Add computeAbstractStructLayout for full struct layout computation

### DIFF
--- a/include/swift/AST/AbstractLayout.h
+++ b/include/swift/AST/AbstractLayout.h
@@ -20,12 +20,14 @@
 
 #include <cstdint>
 #include <optional>
+#include <string>
 
 namespace swift {
 
 class NominalTypeDecl;
 
 struct AbstractTypeLayout {
+  std::string mangledName;
   uint64_t size;
   uint64_t alignment;
   uint64_t stride;
@@ -34,7 +36,7 @@ struct AbstractTypeLayout {
 };
 
 std::optional<AbstractTypeLayout>
-computeAbstractLayout(const NominalTypeDecl *decl);
+computeClangAbstractLayout(const NominalTypeDecl *decl);
 
 } // namespace swift
 

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -18,6 +18,7 @@
 #ifndef SWIFT_FRONTEND_H
 #define SWIFT_FRONTEND_H
 
+#include "swift/AST/AbstractLayout.h"
 #include "swift/AST/DiagnosticConsumer.h"
 #include "swift/AST/DiagnosticEngine.h"
 #include "swift/AST/IRGenOptions.h"
@@ -64,10 +65,26 @@ class FrontendObserver;
 class SerializedModuleLoaderBase;
 class MemoryBufferSerializedModuleLoader;
 class SILModule;
+class StructDecl;
 
 namespace Lowering {
 class TypeConverter;
 }
+
+struct AbstractFieldLayout {
+  uint64_t offset;
+  llvm::StringRef name;
+  AbstractTypeLayout typeLayout;
+};
+
+struct AbstractStructLayout {
+  AbstractTypeLayout typeLayout;
+  llvm::SmallVector<AbstractFieldLayout, 4> fields;
+};
+
+std::optional<AbstractStructLayout>
+computeAbstractStructLayout(const StructDecl *decl,
+                            const IRGenOptions &irgenOpts);
 
 struct ModuleBuffers {
   std::unique_ptr<llvm::MemoryBuffer> ModuleBuffer;

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -21,6 +21,7 @@
 #include "SwiftDeclSynthesizer.h"
 #include "swift/AST/AbstractLayout.h"
 #include "swift/AST/ASTContext.h"
+#include "swift/AST/ASTMangler.h"
 #include "swift/AST/Attr.h"
 #include "swift/AST/AvailabilityInference.h"
 #include "swift/AST/Builtins.h"
@@ -11205,7 +11206,7 @@ static ClangDeclTraceFormatter TF;
 // MARK: - Abstract Layout Computation
 
 std::optional<AbstractTypeLayout>
-swift::computeAbstractLayout(const NominalTypeDecl *decl) {
+swift::computeClangAbstractLayout(const NominalTypeDecl *decl) {
   auto *clangDecl =
       dyn_cast_or_null<clang::RecordDecl>(decl->getClangDecl());
   if (!clangDecl)
@@ -11224,6 +11225,7 @@ swift::computeAbstractLayout(const NominalTypeDecl *decl) {
   const auto &recordLayout = clangCtx.getASTRecordLayout(clangDecl);
 
   AbstractTypeLayout result;
+  result.mangledName = Mangle::ASTMangler(ctx).mangleNominalType(decl);
   result.size = recordLayout.getSize().getQuantity();
   result.alignment = recordLayout.getAlignment().getQuantity();
   result.stride = llvm::alignTo(result.size, result.alignment);

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -16,8 +16,8 @@
 //===----------------------------------------------------------------------===//
 
 #include "swift/Frontend/Frontend.h"
-#include "swift/AST/AbstractLayout.h"
 #include "swift/AST/ASTContext.h"
+#include "swift/AST/ASTMangler.h"
 #include "swift/AST/AvailabilityDomain.h"
 #include "swift/AST/AvailabilityScope.h"
 #include "swift/AST/DiagnosticsFrontend.h"
@@ -37,6 +37,7 @@
 #include "swift/Frontend/CachingUtils.h"
 #include "swift/Frontend/CompileJobCacheKey.h"
 #include "swift/Frontend/ModuleInterfaceLoader.h"
+#include "swift/IRGen/IRABIDetailsProvider.h"
 #include "swift/Parse/Lexer.h"
 #include "swift/SIL/SILModule.h"
 #include "swift/SILOptimizer/PassManager/Passes.h"
@@ -1936,23 +1937,33 @@ void CompilerInstance::emitEndOfPipelineDebuggingOutput() {
 
   if (opts.DumpAbstractLayout) {
     auto &sf = getPrimaryOrMainSourceFile();
+
     for (auto *decl : sf.getTopLevelDecls()) {
-      auto *nominal = dyn_cast<NominalTypeDecl>(decl);
-      if (!nominal)
+      auto *structDecl = dyn_cast<StructDecl>(decl);
+      if (!structDecl)
         continue;
-      for (auto *field : nominal->getStoredProperties()) {
-        auto fieldType = field->getInterfaceType();
-        if (auto *fieldNominal = fieldType->getAnyNominal()) {
-          if (auto layout = computeAbstractLayout(fieldNominal)) {
-            llvm::outs() << fieldNominal->getName() << ":\n";
-            llvm::outs() << "  size: " << layout->size << "\n";
-            llvm::outs() << "  alignment: " << layout->alignment << "\n";
-            llvm::outs() << "  stride: " << layout->stride << "\n";
-            llvm::outs() << "  bitwiseCopyable: "
-                         << (layout->bitwiseCopyable ? "true" : "false") << "\n";
-            llvm::outs() << "  isOpaque: "
-                         << (layout->isOpaque ? "true" : "false") << "\n";
-          }
+      if (auto layout = computeAbstractStructLayout(
+              structDecl, Invocation.getIRGenOptions())) {
+        llvm::outs() << structDecl->getName() << ":\n";
+        llvm::outs() << "  size: " << layout->typeLayout.size << "\n";
+        llvm::outs() << "  alignment: " << layout->typeLayout.alignment << "\n";
+        llvm::outs() << "  stride: " << layout->typeLayout.stride << "\n";
+        llvm::outs() << "  bitwiseCopyable: "
+                     << (layout->typeLayout.bitwiseCopyable ? "true" : "false")
+                     << "\n";
+        llvm::outs() << "  isOpaque: "
+                     << (layout->typeLayout.isOpaque ? "true" : "false") << "\n";
+        llvm::outs() << "  fields:\n";
+        for (auto &field : layout->fields) {
+          llvm::outs() << "    " << field.name << ": "
+                       << field.typeLayout.mangledName
+                       << ", offset=" << field.offset
+                       << ", size=" << field.typeLayout.size
+                       << ", isOpaque="
+                       << (field.typeLayout.isOpaque ? "true" : "false")
+                       << ", bitwiseCopyable="
+                       << (field.typeLayout.bitwiseCopyable ? "true" : "false")
+                       << "\n";
         }
       }
     }
@@ -1981,4 +1992,66 @@ const PrimarySpecificPaths &
 CompilerInstance::getPrimarySpecificPathsForSourceFile(
     const SourceFile &SF) const {
   return Invocation.getPrimarySpecificPathsForSourceFile(SF);
+}
+
+std::optional<AbstractStructLayout>
+swift::computeAbstractStructLayout(const StructDecl *decl,
+                                   const IRGenOptions &irgenOpts) {
+  auto *mod = decl->getModuleContext();
+  IRABIDetailsProvider abiProvider(*mod, irgenOpts);
+
+  uint64_t currentOffset = 0;
+  uint64_t maxAlignment = 1;
+  bool allBitwiseCopyable = true;
+  bool anyOpaque = false;
+  AbstractStructLayout result;
+
+  for (auto *field : decl->getStoredProperties()) {
+    auto fieldType = field->getInterfaceType();
+    auto *fieldNominal = fieldType->getAnyNominal();
+    if (!fieldNominal)
+      return std::nullopt;
+
+    AbstractFieldLayout entry;
+    entry.offset = 0;
+    entry.name = field->getName().str();
+
+    if (auto clangLayout = computeClangAbstractLayout(fieldNominal)) {
+      entry.typeLayout = *clangLayout;
+      if (!clangLayout->bitwiseCopyable)
+        allBitwiseCopyable = false;
+      if (clangLayout->isOpaque)
+        anyOpaque = true;
+    } else if (auto sizeAlign = abiProvider.getTypeSizeAlignment(fieldNominal)) {
+      entry.typeLayout.mangledName =
+          Mangle::ASTMangler(fieldNominal->getASTContext())
+              .mangleNominalType(fieldNominal);
+      entry.typeLayout.size = (uint64_t)sizeAlign->size;
+      entry.typeLayout.alignment = (uint64_t)sizeAlign->alignment;
+      entry.typeLayout.stride = llvm::alignTo(sizeAlign->size, sizeAlign->alignment);
+      entry.typeLayout.bitwiseCopyable = fieldType->isBitwiseCopyable();
+      // Hiding fields of Swift types isn't currently supported, so the layout
+      // can never be opaque.
+      entry.typeLayout.isOpaque = false;
+      if (!entry.typeLayout.bitwiseCopyable)
+        allBitwiseCopyable = false;
+    } else {
+      return std::nullopt;
+    }
+
+    uint64_t fieldOffset = llvm::alignTo(currentOffset, entry.typeLayout.alignment);
+    entry.offset = fieldOffset;
+    result.fields.push_back(entry);
+
+    currentOffset = fieldOffset + entry.typeLayout.size;
+    maxAlignment = std::max(maxAlignment, entry.typeLayout.alignment);
+  }
+
+  result.typeLayout.size = llvm::alignTo(currentOffset, maxAlignment);
+  result.typeLayout.alignment = maxAlignment;
+  result.typeLayout.stride = llvm::alignTo(result.typeLayout.size, maxAlignment);
+  result.typeLayout.bitwiseCopyable = allBitwiseCopyable;
+  result.typeLayout.isOpaque = anyOpaque;
+
+  return result;
 }

--- a/test/ClangImporter/InternalBridgingHeader/abstract-layout-simple.swift
+++ b/test/ClangImporter/InternalBridgingHeader/abstract-layout-simple.swift
@@ -20,16 +20,48 @@
 // RUN:   -dump-abstract-layout \
 // RUN:   %t/Library.swift | %FileCheck %s
 
-// CHECK: Wrapper:
+// CHECK: S:
 // CHECK:   size: 4
 // CHECK:   alignment: 4
 // CHECK:   stride: 4
 // CHECK:   bitwiseCopyable: true
 // CHECK:   isOpaque: false
+// CHECK:   fields:
+// CHECK:     w: $sSo7Wrappera, offset=0, size=4, isOpaque=false, bitwiseCopyable=true
+
+// CHECK: S2:
+// CHECK:   size: 16
+// CHECK:   alignment: 8
+// CHECK:   stride: 16
+// CHECK:   bitwiseCopyable: true
+// CHECK:   isOpaque: false
+// CHECK:   fields:
+// CHECK:     a: $sSo7Wrappera, offset=0, size=4, isOpaque=false, bitwiseCopyable=true
+// CHECK:     b: $sSo10BigWrappera, offset=8, size=8, isOpaque=false, bitwiseCopyable=true
+
+// CHECK: S3:
+// CHECK:   size: 16
+// CHECK:   alignment: 8
+// CHECK:   stride: 16
+// CHECK:   bitwiseCopyable: true
+// CHECK:   isOpaque: false
+// CHECK:   fields:
+// CHECK:     w: $sSo7Wrappera, offset=0, size=4, isOpaque=false, bitwiseCopyable=true
+// CHECK:     x: $sSi, offset=8, size=8, isOpaque=false, bitwiseCopyable=true
+
+// CHECK: S4:
+// CHECK:   size: 16
+// CHECK:   alignment: 8
+// CHECK:   stride: 16
+// CHECK:   bitwiseCopyable: false
+// CHECK:   isOpaque: false
+// CHECK:   fields:
+// CHECK:     s: $sSS, offset=0, size=16, isOpaque=false, bitwiseCopyable=false
 
 //--- Utility.h
 
 typedef struct { int value; } Wrapper;
+typedef struct { double d; } BigWrapper;
 
 //--- Library.swift
 
@@ -41,4 +73,32 @@ public struct S {
   }
 
   public var storedValue: Int32 { w.value }
+}
+
+public struct S2 {
+  private var a: Wrapper
+  private var b: BigWrapper
+
+  public init() {
+    self.a = Wrapper(value: 0)
+    self.b = BigWrapper(d: 0.0)
+  }
+}
+
+public struct S3 {
+  private var w: Wrapper
+  public var x: Int
+
+  public init(value: Int32, x: Int) {
+    self.w = Wrapper(value: value)
+    self.x = x
+  }
+}
+
+public struct S4 {
+  public var s: String
+
+  public init(s: String) {
+    self.s = s
+  }
 }


### PR DESCRIPTION
Computes per-field abstract layout (offset, size, alignment, mangled name, bitwiseCopyable, isOpaque) for structs with both Clang-imported and Swift-native fields.

This API will be used from the library-side to serialize layout information to binary modules.