### PR TITLE
[RemoteInspection] Fix rebuildStorageTypeInfo for unmanaged types

### DIFF
--- a/stdlib/public/RemoteInspection/TypeLowering.cpp
+++ b/stdlib/public/RemoteInspection/TypeLowering.cpp
@@ -2703,6 +2703,13 @@ public:
             RecordTI->isAddressableForDependencies(),
             SubKind, Fields);
       }
+
+      // `Unmanaged` is layout-identical to its referent. A valid referent
+      // always lowers to a single pointer word.
+      if (Kind == ReferenceKind::Unmanaged && SubKind == RecordKind::Struct &&
+          RecordTI->getSize() == TC.targetPointerSize()) {
+        return RecordTI;
+      }
     }
 
     // Anything else -- give up

--- a/test/Reflection/typeref_lowering.swift
+++ b/test/Reflection/typeref_lowering.swift
@@ -1418,3 +1418,15 @@ $1_12TypeLowering10SimpleEnumOBVBW
 // CHECK-32:         (builtin_borrow
 // CHECK-32-NEXT:      (struct TypeLowering.Big))
 // CHECK-32-NEXT:    (borrow size=4 alignment=4 stride=4 num_extra_inhabitants=1 bitwise_takable=1)
+
+// `unmanaged_storage` applied to a single-field pointer-sized struct.
+SpySiGXu
+// CHECK:      (unmanaged_storage
+// CHECK-NEXT:   (bound_generic_struct Swift.UnsafeMutablePointer
+// CHECK-NEXT:     (struct Swift.Int)))
+// CHECK-64-NEXT: (struct size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=1
+// CHECK-64-NEXT:   (field name=_rawValue offset=0
+// CHECK-64-NEXT:     (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=1)))
+// CHECK-32-NEXT: (struct size=4 alignment=4 stride=4 num_extra_inhabitants={{[0-9]+}} bitwise_takable=1
+// CHECK-32-NEXT:   (field name=_rawValue offset=0
+// CHECK-32-NEXT:     (builtin size=4 alignment=4 stride=4 num_extra_inhabitants={{[0-9]+}} bitwise_takable=1)))


### PR DESCRIPTION
- **Explanation:** rebuildStorageTypeInfo only handled ReferenceTypeInfo and RecordKind::ClassExistential inner types for unmanaged_storage, but failed for imported unmanaged types which are imported behind a pointer (which is a struct).
- **Scope:** Affects remote inspection/remote mirrors clients.
- **Issue/Radar:** rdar://175379963
- **Original PR:** https://github.com/swiftlang/swift/pull/88770
- **Risk:** Low. Only affects remote inspection.
- **Testing:** New reflection test, lldb test.
- **Reviewer:** @mikeash, @adrian-prantl 
