### PR TITLE
Use `std::uninitialized_copy` instead of memcpy for `LifetimeDependenceInfo`

### DIFF
--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -5472,9 +5472,9 @@ SILFunctionType::SILFunctionType(
 
   if (!ext.getLifetimeDependencies().empty()) {
     NumLifetimeDependencies = ext.getLifetimeDependencies().size();
-    memcpy(getMutableLifetimeDependenceInfo().data(),
-           ext.getLifetimeDependencies().data(),
-           NumLifetimeDependencies * sizeof(LifetimeDependenceInfo));
+    auto src = ext.getLifetimeDependencies();
+    std::uninitialized_copy(src.begin(), src.end(),
+                            getMutableLifetimeDependenceInfo().begin());
   }
 #ifndef NDEBUG
   if (ext.getRepresentation() == Representation::WitnessMethod)


### PR DESCRIPTION
Resolves the following warning:
```
ASTContext.cpp:5475:47: warning: first argument in call to 'memcpy' is a pointer to non-trivially copyable type 'swift::LifetimeDependenceInfo' [-Wnontrivial-memcall]
```

Fixes a regression from https://github.com/swiftlang/swift/pull/87217.
