### PR TITLE
stdlib: Remove superfluous unsafe markers

### DIFF
--- a/stdlib/public/core/StringBridge.swift
+++ b/stdlib/public/core/StringBridge.swift
@@ -292,7 +292,7 @@ internal func _cocoaStringCopyBytes(
   defer {
     remainingRange = cocoaRemainingRange.location ..< cocoaRemainingRange.location + cocoaRemainingRange.length
   }
-  return unsafe withUnsafeMutablePointer(
+  return withUnsafeMutablePointer(
     to: &cocoaRemainingRange
   ) { remainingPtr in
     return unsafe _NSStringCopyBytes(

--- a/stdlib/public/core/StringStorageBridge.swift
+++ b/stdlib/public/core/StringStorageBridge.swift
@@ -674,8 +674,8 @@ fileprivate func isEqual(
   if lhs.byteCount != rhs.byteCount {
     return false
   }
-  return unsafe lhs.withUnsafeBytes { lhsBuffer in
-    return unsafe rhs.withUnsafeBytes { rhsBuffer in
+  return lhs.withUnsafeBytes { lhsBuffer in
+    return rhs.withUnsafeBytes { rhsBuffer in
       return unsafe 0 == _swift_stdlib_memcmp(
         lhsBuffer.baseAddress.unsafelyUnwrapped,
         rhsBuffer.baseAddress.unsafelyUnwrapped,


### PR DESCRIPTION
Resolves warnings introduced by https://github.com/swiftlang/swift/pull/87271.