### PR TITLE
[Embedded] Extend @export(interface) to non-generic types and protocol conformances

### DIFF
--- a/include/swift/AST/DeclAttr.def
+++ b/include/swift/AST/DeclAttr.def
@@ -559,7 +559,7 @@ SIMPLE_DECL_ATTR(noDerivative, NoDerivative,
   100)
 
 DECL_ATTR(export, Export,
-    OnVar | OnSubscript | OnAbstractFunction | OnStruct | OnEnum | OnClass,
+    OnVar | OnSubscript | OnAbstractFunction | OnStruct | OnEnum | OnClass | OnExtension,
     ABIBreakingToAdd | ABIBreakingToRemove | APIStableToAdd | APIStableToRemove | ForbiddenInABIAttr,
     101)
 

--- a/include/swift/AST/DeclAttr.def
+++ b/include/swift/AST/DeclAttr.def
@@ -559,7 +559,7 @@ SIMPLE_DECL_ATTR(noDerivative, NoDerivative,
   100)
 
 DECL_ATTR(export, Export,
-    OnVar | OnSubscript | OnAbstractFunction,
+    OnVar | OnSubscript | OnAbstractFunction | OnStruct | OnEnum | OnClass,
     ABIBreakingToAdd | ABIBreakingToRemove | APIStableToAdd | APIStableToRemove | ForbiddenInABIAttr,
     101)
 

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -8915,6 +8915,12 @@ GROUPED_ERROR(self_referential_superclass_in_embedded_swift,
               "creating a circular metadata dependency",
               (Type, Type))
 
+GROUPED_ERROR(export_interface_on_generic_in_embedded_swift,
+              EmbeddedRestrictions, none,
+              "'@export(interface)' cannot be applied to a "
+              "%kind0 in Embedded Swift",
+              (const Decl *))
+
 //===----------------------------------------------------------------------===//
 // MARK: @abi Attribute
 //===----------------------------------------------------------------------===//

--- a/include/swift/AST/ProtocolConformance.h
+++ b/include/swift/AST/ProtocolConformance.h
@@ -810,6 +810,13 @@ public:
   /// modules, but in a manner that ensures that all copies are equivalent.
   bool isSynthesizedNonUnique() const;
 
+  /// Retrieve the code generation model explicitly requested for this
+  /// conformance, inherited from the @export attribute on the declaring
+  /// nominal type or extension. Returns nullopt if the declaring context
+  /// does not specify an explicit code generation model.
+  std::optional<CodeGenerationModel>
+  getExplicitCodeGenerationModel() const;
+
   /// Whether this conformance represents the conformance of one protocol's
   /// conforming types to another protocol.
   ///

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -420,6 +420,18 @@ bool NormalProtocolConformance::isSynthesizedNonUnique() const {
   return false;
 }
 
+std::optional<CodeGenerationModel>
+NormalProtocolConformance::getExplicitCodeGenerationModel() const {
+  // Inherit the code generation model from the declaring nominal type or
+  // extension. @export(interface) on either one implies the conformances
+  // defined directly on that declaration are also @export(interface).
+  if (auto *ext = dyn_cast<ExtensionDecl>(getDeclContext()))
+    return ext->getExplicitCodeGenerationModel();
+  if (auto *nominal = dyn_cast<NominalTypeDecl>(getDeclContext()))
+    return nominal->getExplicitCodeGenerationModel();
+  return std::nullopt;
+}
+
 bool NormalProtocolConformance::isConformanceOfProtocol() const {
   return getDeclContext()->getSelfProtocolDecl() != nullptr;
 }

--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -29,6 +29,7 @@
 #include "swift/AST/TypeMemberVisitor.h"
 #include "swift/AST/Types.h"
 #include "swift/Basic/Assertions.h"
+#include "swift/Basic/CodeGenerationModel.h"
 #include "swift/Basic/Defer.h"
 #include "swift/ClangImporter/ClangModule.h"
 #include "swift/IRGen/Linking.h"
@@ -1066,7 +1067,9 @@ void IRGenModule::emitClassDecl(ClassDecl *D) {
     emitClassMetadata(*this, D, fragileLayout, resilientLayout);
     emitFieldDescriptor(D);
   } else {
-    if (!hasEmbeddedWithExistentials && !D->isGenericContext()) {
+    bool isExportInterface = !D->isGenericContext() &&
+        D->getExplicitCodeGenerationModel() == CodeGenerationModel::Interface;
+    if (isExportInterface) {
       emitEmbeddedClassMetadata(*this, D);
     } else {
       // We create all metadata lazily in embedded with existentials mode.

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -29,6 +29,7 @@
 #include "swift/AST/TypeMemberVisitor.h"
 #include "swift/AST/Types.h"
 #include "swift/Basic/Assertions.h"
+#include "swift/Basic/CodeGenerationModel.h"
 #include "swift/Basic/Mangler.h"
 #include "swift/ClangImporter/ClangModule.h"
 #include "swift/Demangling/ManglingMacros.h"
@@ -1589,10 +1590,19 @@ bool IRGenerator::hasLazyMetadata(TypeDecl *type) {
   auto &langOpts = SIL.getASTContext().LangOpts;
   if (langOpts.hasFeature(Feature::Embedded) &&
       (isa<StructDecl>(type) || isa<EnumDecl>(type))) {
-    bool isGeneric = cast<NominalTypeDecl>(type)->isGenericContext();
-    HasLazyMetadata[type] = !isGeneric;
-
-    return !isGeneric;
+    auto *nominal = cast<NominalTypeDecl>(type);
+    bool isGeneric = nominal->isGenericContext();
+    // @export(interface) types have a unique definition in their defining
+    // module; importing modules reference them as external symbols rather than
+    // lazily emitting their own copy.
+    bool isExportInterface = false;
+    if (!isGeneric) {
+      if (auto model = nominal->getExplicitCodeGenerationModel())
+        isExportInterface = *model == CodeGenerationModel::Interface;
+    }
+    bool isLazy = !isGeneric && !isExportInterface;
+    HasLazyMetadata[type] = isLazy;
+    return isLazy;
   }
 
   auto canBeLazy = [&]() -> bool {

--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -7466,10 +7466,15 @@ const TypeInfo *TypeConverter::convertEnumType(TypeBase *key, CanType type,
 }
 
 void IRGenModule::emitEnumDecl(EnumDecl *theEnum) {
-  if (!IRGen.hasLazyMetadata(theEnum) &&
-      !theEnum->getASTContext().LangOpts.hasFeature(Feature::Embedded)) {
+  bool isEmbedded = theEnum->getASTContext().LangOpts.hasFeature(Feature::Embedded);
+  // In embedded mode, generic types are handled via specialization, not
+  // eagerly emitted here.
+  bool shouldEmit = !IRGen.hasLazyMetadata(theEnum) &&
+                    !(isEmbedded && theEnum->isGenericContext());
+  if (shouldEmit) {
     emitEnumMetadata(*this, theEnum);
-    emitFieldDescriptor(theEnum);
+    if (!isEmbedded)
+      emitFieldDescriptor(theEnum);
   }
 
   emitNestedTypeDecls(theEnum->getMembers());

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -29,6 +29,7 @@
 #include "swift/AST/SubstitutionMap.h"
 #include "swift/AST/Types.h"
 #include "swift/Basic/Assertions.h"
+#include "swift/Basic/CodeGenerationModel.h"
 #include "swift/Basic/Mangler.h"
 #include "swift/ClangImporter/ClangModule.h"
 #include "swift/IRGen/Linking.h"
@@ -5712,6 +5713,17 @@ void irgen::emitEmbeddedClassMetadata(IRGenModule &IGM, ClassDecl *classDecl) {
 }
 
 void irgen::emitLazyClassMetadata(IRGenModule &IGM, CanType classTy) {
+  // @export(interface) classes have a unique definition in their defining
+  // module; importing modules reference them as external symbols rather than
+  // lazily emitting their own copy.
+  if (IGM.isEmbeddedWithExistentials()) {
+    if (auto *classDecl = classTy->getClassOrBoundGenericClass()) {
+      if (auto model = classDecl->getExplicitCodeGenerationModel())
+        if (*model == CodeGenerationModel::Interface)
+          return;
+    }
+  }
+
   // Might already be emitted, skip if that's the case.
   auto entity =
       LinkEntity::forTypeMetadata(classTy, TypeMetadataAddress::AddressPoint);

--- a/lib/IRGen/GenStruct.cpp
+++ b/lib/IRGen/GenStruct.cpp
@@ -1746,10 +1746,15 @@ const TypeInfo *irgen::getPhysicalStructFieldTypeInfo(IRGenModule &IGM,
 }
 
 void IRGenModule::emitStructDecl(StructDecl *st) {
-  if (!IRGen.hasLazyMetadata(st) &&
-      !st->getASTContext().LangOpts.hasFeature(Feature::Embedded)) {
+  bool isEmbedded = st->getASTContext().LangOpts.hasFeature(Feature::Embedded);
+  // In embedded mode, generic types are handled via specialization, not
+  // eagerly emitted here.
+  bool shouldEmit = !IRGen.hasLazyMetadata(st) &&
+                    !(isEmbedded && st->isGenericContext());
+  if (shouldEmit) {
     emitStructMetadata(*this, st);
-    emitFieldDescriptor(st);
+    if (!isEmbedded)
+      emitFieldDescriptor(st);
   }
 
   emitNestedTypeDecls(st->getMembers());

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -22,7 +22,9 @@
 #include "swift/AST/IRGenRequests.h"
 #include "swift/AST/Module.h"
 #include "swift/AST/ModuleDependencies.h"
+#include "swift/AST/ProtocolConformance.h"
 #include "swift/Basic/Assertions.h"
+#include "swift/Basic/CodeGenerationModel.h"
 #include "swift/Basic/LLVMExtras.h"
 #include "swift/ClangImporter/ClangImporter.h"
 #include "swift/Demangling/ManglingMacros.h"
@@ -1437,9 +1439,16 @@ bool IRGenerator::canEmitWitnessTableLazily(SILWitnessTable *wt) {
   if (Opts.UseJIT)
     return false;
 
-  // witness tables are always emitted lazily in embedded swift.
-  if (SIL.getASTContext().LangOpts.hasFeature(Feature::Embedded))
+  // witness tables are always emitted lazily in embedded swift, except for
+  // @export(interface) conformances, which have a unique strong definition
+  // in the owning module.
+  if (SIL.getASTContext().LangOpts.hasFeature(Feature::Embedded)) {
+    if (auto *normal = dyn_cast<NormalProtocolConformance>(wt->getConformance()))
+      if (auto model = normal->getExplicitCodeGenerationModel())
+        if (*model == CodeGenerationModel::Interface)
+          return false;
     return true;
+  }
 
   // Regardless of the access level, if the witness table is shared it means
   // we can safely not emit it. Every other module which needs it will generate

--- a/lib/IRGen/Linking.cpp
+++ b/lib/IRGen/Linking.cpp
@@ -20,6 +20,7 @@
 #include "swift/AST/ASTMangler.h"
 #include "swift/AST/IRGenOptions.h"
 #include "swift/Basic/Assertions.h"
+#include "swift/Basic/CodeGenerationModel.h"
 #include "swift/ClangImporter/ClangModule.h"
 #include "swift/SIL/SILGlobalVariable.h"
 #include "swift/SIL/FormalLinkage.h"
@@ -724,19 +725,32 @@ SILLinkage LinkEntity::getLinkage(ForDefinition_t forDefinition) const {
 
     auto *nominal = getType().getAnyNominal();
     switch (getMetadataAddress()) {
-    case TypeMetadataAddress::FullMetadata:
+    case TypeMetadataAddress::FullMetadata: {
       // For imported types, the full metadata object is a candidate
       // for uniquing.
       if (getDeclLinkage(nominal) == FormalLinkage::PublicNonUnique)
         return SILLinkage::Shared;
 
-      // Prespecialization of the same generic metadata may be requested 
+      // Prespecialization of the same generic metadata may be requested
       // multiple times within the same module, so it needs to be uniqued.
       if (nominal->isGenericContext())
         return SILLinkage::Shared;
 
+      // @export(interface) types have a unique definition in their defining
+      // module, so the FullMetadata must be externally linkable.
+      bool isEmbedded =
+        nominal->getASTContext().LangOpts.hasFeature(Feature::Embedded);
+      if (isEmbedded && !nominal->isGenericContext()) {
+        if (auto model = nominal->getExplicitCodeGenerationModel()) {
+          if (*model == CodeGenerationModel::Interface) {
+            return getSILLinkage(FormalLinkage::PublicUnique, forDefinition);
+          }
+        }
+      }
+
       // The full metadata object is private to the containing module.
       return SILLinkage::Private;
+    }
     case TypeMetadataAddress::AddressPoint: {
       return getSILLinkage(nominal
                            ? getDeclLinkage(nominal)

--- a/lib/IRGen/Linking.cpp
+++ b/lib/IRGen/Linking.cpp
@@ -1826,11 +1826,22 @@ bool LinkEntity::hasNonUniqueDefinition() const {
     return true;
   }
 
-  // Always treat witness tables as having non-unique definitions.
+  // In embedded Swift, witness tables are treated as having non-unique
+  // definitions (so they get linkonce_odr linkage) unless the underlying
+  // conformance was explicitly marked @export(interface).
   if (getKind() == Kind::ProtocolWitnessTable) {
-    if (auto context = getDeclContextForEmission())
-      if (context->getParentModule()->getASTContext().LangOpts.hasFeature(Feature::Embedded))
+    if (auto context = getDeclContextForEmission()) {
+      if (context->getParentModule()->getASTContext().LangOpts.hasFeature(
+              Feature::Embedded)) {
+        if (auto *normal = dyn_cast<NormalProtocolConformance>(
+                getProtocolConformance()->getRootConformance())) {
+          if (auto model = normal->getExplicitCodeGenerationModel())
+            if (*model == CodeGenerationModel::Interface)
+              return false;
+        }
         return true;
+      }
+    }
   }
 
   return false;

--- a/lib/SIL/IR/SIL.cpp
+++ b/lib/SIL/IR/SIL.cpp
@@ -94,6 +94,13 @@ swift::getLinkageForProtocolConformance(const ProtocolConformance *C,
     return SILLinkage::Shared;
 
   auto typeDecl = C->getDeclContext()->getSelfNominalTypeDecl();
+
+  // In embedded Swift, witness tables are always emitted lazily with shared
+  // linkage, so that each importing module emits its own local copy.
+  auto &ctx = typeDecl->getASTContext();
+  if (ctx.LangOpts.hasFeature(Feature::Embedded))
+    return SILLinkage::Shared;
+
   AccessLevel access = std::min(C->getProtocol()->getEffectiveAccess(),
                                 typeDecl->getEffectiveAccess());
 

--- a/lib/SIL/IR/SIL.cpp
+++ b/lib/SIL/IR/SIL.cpp
@@ -25,6 +25,7 @@
 #include "swift/AST/ParameterList.h"
 #include "swift/AST/ProtocolConformance.h"
 #include "swift/Basic/Assertions.h"
+#include "swift/Basic/CodeGenerationModel.h"
 #include "swift/ClangImporter/ClangModule.h"
 #include "clang/AST/Attr.h"
 #include "clang/AST/Decl.h"
@@ -95,11 +96,23 @@ swift::getLinkageForProtocolConformance(const ProtocolConformance *C,
 
   auto typeDecl = C->getDeclContext()->getSelfNominalTypeDecl();
 
-  // In embedded Swift, witness tables are always emitted lazily with shared
-  // linkage, so that each importing module emits its own local copy.
+  // In embedded Swift, conformances get special treatment.
   auto &ctx = typeDecl->getASTContext();
-  if (ctx.LangOpts.hasFeature(Feature::Embedded))
+  if (ctx.LangOpts.hasFeature(Feature::Embedded)) {
+    // @export(interface) conformances have a unique strong definition in
+    // the module that declares them; importing modules reference them
+    // externally.
+    if (auto *normal = dyn_cast<NormalProtocolConformance>(
+            C->getRootConformance())) {
+      if (auto model = normal->getExplicitCodeGenerationModel())
+        if (*model == CodeGenerationModel::Interface)
+          return (definition ? SILLinkage::Public : SILLinkage::PublicExternal);
+    }
+
+    // Other embedded conformances are emitted lazily with shared linkage,
+    // so each importing module emits its own local copy.
     return SILLinkage::Shared;
+  }
 
   AccessLevel access = std::min(C->getProtocol()->getEffectiveAccess(),
                                 typeDecl->getEffectiveAccess());

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -3929,6 +3929,24 @@ void AttributeChecker::visitExportAttr(ExportAttr *attr) {
     diagnoseAndRemoveAttr(attr, diag::attr_incompatible_with_attr, attr, other);
   if (auto other = D->getAttrs().getAttribute<ExternAttr>())
     diagnoseAndRemoveAttr(attr, diag::attr_incompatible_with_attr, attr, other);
+
+  // In Embedded Swift, @export(interface) is not supported on generic types
+  // or on extensions of generic types: IRGen emits a unique strong definition
+  // of the type metadata / conformance witness tables, and per-specialization
+  // emission of those globals is not compatible with that.
+  if (attr->exportKind == ExportKind::Interface &&
+      Ctx.LangOpts.hasFeature(Feature::Embedded)) {
+    bool isGeneric = false;
+    if (auto *nominal = dyn_cast<NominalTypeDecl>(D))
+      isGeneric = nominal->isGenericContext();
+    else if (auto *ext = dyn_cast<ExtensionDecl>(D))
+      isGeneric = ext->isGenericContext();
+    if (isGeneric) {
+      diagnoseAndRemoveAttr(attr,
+                            diag::export_interface_on_generic_in_embedded_swift,
+                            D);
+    }
+  }
 }
 
 void AttributeChecker::visitNeverEmitIntoClientAttr(NeverEmitIntoClientAttr *attr) {

--- a/test/IDE/complete_decl_attribute.swift
+++ b/test/IDE/complete_decl_attribute.swift
@@ -149,6 +149,7 @@ actor MyGenericGlobalActor<T> {
 // KEYWORD3-NEXT:             Keyword/None:                       usableFromInline[#Class Attribute#]; name=usableFromInline
 // KEYWORD3-NEXT:             Keyword/None:                       propertyWrapper[#Class Attribute#]; name=propertyWrapper
 // KEYWORD3-NEXT:             Keyword/None:                       resultBuilder[#Class Attribute#]; name=resultBuilder
+// KEYWORD3-NEXT:             Keyword/None:                       export[#Class Attribute#]; name=export
 // KEYWORD3-NEXT:             Keyword/None:                       globalActor[#Class Attribute#]; name=globalActor
 // KEYWORD3-NEXT:             Keyword/None:                       preconcurrency[#Class Attribute#]; name=preconcurrency
 
@@ -167,6 +168,7 @@ actor MyGenericGlobalActor<T> {
 // KEYWORD4-NEXT:             Keyword/None:                       frozen[#Enum Attribute#]; name=frozen
 // KEYWORD4-NEXT:             Keyword/None:                       propertyWrapper[#Enum Attribute#]; name=propertyWrapper
 // KEYWORD4-NEXT:             Keyword/None:                       resultBuilder[#Enum Attribute#]; name=resultBuilder
+// KEYWORD4-NEXT:             Keyword/None:                       export[#Enum Attribute#]; name=export
 // KEYWORD4-NEXT:             Keyword/None:                       globalActor[#Enum Attribute#]; name=globalActor
 // KEYWORD4-NEXT:             Keyword/None:                       preconcurrency[#Enum Attribute#]; name=preconcurrency
 
@@ -180,6 +182,7 @@ actor MyGenericGlobalActor<T> {
 // KEYWORD5-NEXT:             Keyword/None:                       frozen[#Struct Attribute#]; name=frozen
 // KEYWORD5-NEXT:             Keyword/None:                       propertyWrapper[#Struct Attribute#]; name=propertyWrapper
 // KEYWORD5-NEXT:             Keyword/None:                       resultBuilder[#Struct Attribute#]; name=resultBuilder
+// KEYWORD5-NEXT:             Keyword/None:                       export[#Struct Attribute#]; name=export
 // KEYWORD5-NEXT:             Keyword/None:                       globalActor[#Struct Attribute#]; name=globalActor
 // KEYWORD5-NEXT:             Keyword/None:                       preconcurrency[#Struct Attribute#]; name=preconcurrency
 

--- a/test/embedded/export_interface_generic.swift
+++ b/test/embedded/export_interface_generic.swift
@@ -1,0 +1,51 @@
+// RUN: %target-typecheck-verify-swift -parse-as-library -enable-experimental-feature Embedded -enable-experimental-feature Extern
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: swift_feature_Embedded
+// REQUIRES: swift_feature_Extern
+
+// In Embedded Swift, @export(interface) cannot be used on generic types or on
+// extensions that introduce generics, because IRGen emits a unique strong
+// definition of the type metadata / conformance witness tables, which is
+// incompatible with per-specialization emission.
+
+public protocol P {}
+
+// Non-generic types are allowed.
+@export(interface)
+public struct NonGenericStruct {}
+
+@export(interface)
+public class NonGenericClass {}
+
+@export(interface)
+public enum NonGenericEnum {}
+
+// Generic types are rejected.
+@export(interface) // expected-error {{'@export(interface)' cannot be applied to a generic struct 'GenericStruct' in Embedded Swift}}
+public struct GenericStruct<T> {}
+
+@export(interface) // expected-error {{'@export(interface)' cannot be applied to a generic class 'GenericClass' in Embedded Swift}}
+public class GenericClass<T> {}
+
+@export(interface) // expected-error {{'@export(interface)' cannot be applied to a generic enum 'GenericEnum' in Embedded Swift}}
+public enum GenericEnum<T> {
+  case a(T)
+}
+
+// An extension of a non-generic type is allowed.
+public struct PlainStruct {}
+
+@export(interface)
+extension PlainStruct: P {}
+
+// An extension of a generic type is rejected (the extension inherits the
+// generic context from the extended type).
+public struct GenericHolder<T> {}
+
+@export(interface) // expected-error {{'@export(interface)' cannot be applied to a extension of generic struct 'GenericHolder' in Embedded Swift}}
+extension GenericHolder: P {}
+
+// @export(implementation) does not have this restriction.
+@export(implementation)
+public struct GenericImplStruct<T> {}

--- a/test/embedded/linkage/export_interface_types.swift
+++ b/test/embedded/linkage/export_interface_types.swift
@@ -54,15 +54,16 @@ extension PlainStruct: Greeter {
 }
 
 // Library IR:
-//  - @export(interface) type metadata: strong public definition (`constant`).
+//  - @export(interface) type metadata: strong public definition (`constant`,
+//    or `protected constant` on ELF).
 //  - @export(interface) conformances (whether declared on the type itself or
 //    on an @export(interface) extension): strong public witness tables
-//    (`constant`).
-// LIBRARY-IR-DAG: @"$e7Library11ExportedFooVMf" = constant
-// LIBRARY-IR-DAG: @"$e7Library13ExportedClassCMf" = constant
-// LIBRARY-IR-DAG: @"$e7Library11ExportedFooVAA7GreeterAAWP" = constant
-// LIBRARY-IR-DAG: @"$e7Library13ExportedClassCAA7GreeterAAWP" = constant
-// LIBRARY-IR-DAG: @"$e7Library11PlainStructVAA7GreeterAAWP" = constant
+//    (`constant`, or `protected constant` on ELF).
+// LIBRARY-IR-DAG: @"$e7Library11ExportedFooVMf" = {{(protected )?}}constant
+// LIBRARY-IR-DAG: @"$e7Library13ExportedClassCMf" = {{(protected )?}}constant
+// LIBRARY-IR-DAG: @"$e7Library11ExportedFooVAA7GreeterAAWP" = {{(protected )?}}constant
+// LIBRARY-IR-DAG: @"$e7Library13ExportedClassCAA7GreeterAAWP" = {{(protected )?}}constant
+// LIBRARY-IR-DAG: @"$e7Library11PlainStructVAA7GreeterAAWP" = {{(protected )?}}constant
 
 // Non-@export(interface) type metadata and conformances are NOT eagerly
 // emitted in the Library (they stay lazy/shared per importing module).

--- a/test/embedded/linkage/export_interface_types.swift
+++ b/test/embedded/linkage/export_interface_types.swift
@@ -19,9 +19,6 @@
 
 public protocol Greeter { func greet() }
 
-// @export(interface) struct: FullMetadata should be a strong public
-// definition (ExternalLinkage), not linkonce_odr or private.
-// LIBRARY-IR: @"$e7Library11ExportedFooVMf" = constant
 @export(interface)
 public struct ExportedFoo: Greeter {
   public var x: Int
@@ -29,17 +26,12 @@ public struct ExportedFoo: Greeter {
   public func greet() { print("foo") }
 }
 
-// Non-@export(interface) struct: FullMetadata is lazily emitted per module;
-// the Library module should NOT define it eagerly.
-// LIBRARY-IR-NOT: @"$e7Library14NonExportedBarVMf"
 public struct NonExportedBar: Greeter {
   public var y: Int
   public init(y: Int) { self.y = y }
   public func greet() { print("bar") }
 }
 
-// @export(interface) class: FullMetadata should be a strong public definition.
-// LIBRARY-IR: @"$e7Library13ExportedClassCMf" = constant
 @export(interface)
 public class ExportedClass: Greeter {
   public var z: Int
@@ -47,30 +39,51 @@ public class ExportedClass: Greeter {
   public func greet() { print("class") }
 }
 
-// In embedded Swift, protocol witness tables always get shared SIL linkage
-// regardless of whether the conforming type has @export(interface). Shared
-// linkage lets each importing module emit its own linkonce_odr copy.
-// LIBRARY-SIL-DAG: sil_witness_table shared ExportedFoo: Greeter module Library
+// A plain type with its conformance declared on an @export(interface)
+// extension: the extension's attribute makes the conformance
+// @export(interface), but does NOT make the type's metadata @export(interface)
+// (the type itself has no @export attribute).
+public struct PlainStruct {
+  public var w: Int
+  public init(w: Int) { self.w = w }
+}
+
+@export(interface)
+extension PlainStruct: Greeter {
+  public func greet() { print("plain") }
+}
+
+// Library IR:
+//  - @export(interface) type metadata: strong public definition (`constant`).
+//  - @export(interface) conformances (whether declared on the type itself or
+//    on an @export(interface) extension): strong public witness tables
+//    (`constant`).
+// LIBRARY-IR-DAG: @"$e7Library11ExportedFooVMf" = constant
+// LIBRARY-IR-DAG: @"$e7Library13ExportedClassCMf" = constant
+// LIBRARY-IR-DAG: @"$e7Library11ExportedFooVAA7GreeterAAWP" = constant
+// LIBRARY-IR-DAG: @"$e7Library13ExportedClassCAA7GreeterAAWP" = constant
+// LIBRARY-IR-DAG: @"$e7Library11PlainStructVAA7GreeterAAWP" = constant
+
+// Non-@export(interface) type metadata and conformances are NOT eagerly
+// emitted in the Library (they stay lazy/shared per importing module).
+// PlainStruct's type metadata is also not emitted here (the type itself is
+// not @export(interface); only its conformance is).
+// LIBRARY-IR-NOT: @"$e7Library14NonExportedBarVMf"
+// LIBRARY-IR-NOT: @"$e7Library11PlainStructVMf"
+// LIBRARY-IR-NOT: @"$e7Library14NonExportedBarVAA7GreeterAAWP"
+
+// SIL-level linkage:
+//  - @export(interface) conformances have "public" SIL linkage (shown with
+//    no prefix) so they are owned by this module.
+//  - Non-@export(interface) conformances have "shared" SIL linkage so every
+//    importing module emits its own linkonce_odr copy.
+// LIBRARY-SIL-DAG: sil_witness_table ExportedFoo: Greeter module Library
 // LIBRARY-SIL-DAG: sil_witness_table shared NonExportedBar: Greeter module Library
-// LIBRARY-SIL-DAG: sil_witness_table shared ExportedClass: Greeter module Library
+// LIBRARY-SIL-DAG: sil_witness_table ExportedClass: Greeter module Library
+// LIBRARY-SIL-DAG: sil_witness_table PlainStruct: Greeter module Library
 
 //--- Application.swift
 import Library
-
-// @export(interface) types: Application references their metadata from Library
-// as external declarations, not local copies. External declarations appear
-// before linkonce_odr definitions in the IR, so check them in IR order.
-// APPLICATION-IR: @"$e7Library11ExportedFooVMf" = external global
-// APPLICATION-IR: @"$e7Library13ExportedClassCMf" = external global
-
-// Non-@export(interface) struct: Application emits its own linkonce_odr copy.
-// APPLICATION-IR: @"$e7Library14NonExportedBarVMf" = linkonce_odr hidden constant
-
-// Witness tables remain shared in the importing module as well, so the
-// application emits its own local copy.
-// APPLICATION-SIL-DAG: sil_witness_table shared ExportedFoo: Greeter module Library
-// APPLICATION-SIL-DAG: sil_witness_table shared NonExportedBar: Greeter module Library
-// APPLICATION-SIL-DAG: sil_witness_table shared ExportedClass: Greeter module Library
 
 public func useExportedFoo() -> Any {
   return ExportedFoo(x: 42)
@@ -88,3 +101,26 @@ public func useAsGreeter(_ g: any Greeter) { g.greet() }
 public func formGreeterFoo() { useAsGreeter(ExportedFoo(x: 1)) }
 public func formGreeterBar() { useAsGreeter(NonExportedBar(y: 2)) }
 public func formGreeterClass() { useAsGreeter(ExportedClass(z: 3)) }
+public func formGreeterPlain() { useAsGreeter(PlainStruct(w: 4)) }
+
+// Application IR:
+//  - @export(interface) type metadata: referenced as external declarations.
+//  - @export(interface) conformances: referenced as external declarations
+//    (the owning module provides the definition).
+//  - Non-@export(interface) type metadata: linkonce_odr hidden local copy.
+//  - Non-@export(interface) conformances: linkonce_odr hidden local copy.
+// APPLICATION-IR-DAG: @"$e7Library11ExportedFooVMf" = external global
+// APPLICATION-IR-DAG: @"$e7Library13ExportedClassCMf" = external global
+// APPLICATION-IR-DAG: @"$e7Library11ExportedFooVAA7GreeterAAWP" = external global
+// APPLICATION-IR-DAG: @"$e7Library13ExportedClassCAA7GreeterAAWP" = external global
+// APPLICATION-IR-DAG: @"$e7Library11PlainStructVAA7GreeterAAWP" = external global
+// APPLICATION-IR-DAG: @"$e7Library14NonExportedBarVMf" = linkonce_odr hidden constant
+// APPLICATION-IR-DAG: @"$e7Library14NonExportedBarVAA7GreeterAAWP" = linkonce_odr hidden constant
+
+// At the SIL level, the application does not own the @export(interface)
+// conformances — they aren't added to the SIL witness_table list here. It
+// does own a shared copy of the non-@export(interface) conformance.
+// APPLICATION-SIL-NOT: sil_witness_table {{.*}} ExportedFoo: Greeter
+// APPLICATION-SIL-NOT: sil_witness_table {{.*}} ExportedClass: Greeter
+// APPLICATION-SIL-NOT: sil_witness_table {{.*}} PlainStruct: Greeter
+// APPLICATION-SIL: sil_witness_table shared NonExportedBar: Greeter module Library

--- a/test/embedded/linkage/export_interface_types.swift
+++ b/test/embedded/linkage/export_interface_types.swift
@@ -1,0 +1,65 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// Library module
+
+// RUN: %target-swift-frontend %t/Library.swift -parse-as-library -enable-experimental-feature Embedded -enable-experimental-feature Extern -emit-module-path %t/Library.swiftmodule -emit-ir -o - | %FileCheck -check-prefix LIBRARY-IR %s
+
+// Application module
+
+// RUN: %target-swift-frontend %t/Application.swift -I %t -parse-as-library -enable-experimental-feature Embedded -enable-experimental-feature Extern -emit-ir -o - | %FileCheck -check-prefix APPLICATION-IR %s
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: swift_feature_Embedded
+// REQUIRES: swift_feature_Extern
+
+//--- Library.swift
+
+// @export(interface) struct: FullMetadata should be a strong public
+// definition (ExternalLinkage), not linkonce_odr or private.
+// LIBRARY-IR: @"$e7Library11ExportedFooVMf" = constant
+@export(interface)
+public struct ExportedFoo {
+  public var x: Int
+  public init(x: Int) { self.x = x }
+}
+
+// Non-@export(interface) struct: FullMetadata is lazily emitted per module;
+// the Library module should NOT define it eagerly.
+// LIBRARY-IR-NOT: @"$e7Library14NonExportedBarVMf"
+public struct NonExportedBar {
+  public var y: Int
+  public init(y: Int) { self.y = y }
+}
+
+// @export(interface) class: FullMetadata should be a strong public definition.
+// LIBRARY-IR: @"$e7Library13ExportedClassCMf" = constant
+@export(interface)
+public class ExportedClass {
+  public var z: Int
+  public init(z: Int) { self.z = z }
+}
+
+//--- Application.swift
+import Library
+
+// @export(interface) types: Application references their metadata from Library
+// as external declarations, not local copies. External declarations appear
+// before linkonce_odr definitions in the IR, so check them in IR order.
+// APPLICATION-IR: @"$e7Library11ExportedFooVMf" = external global
+// APPLICATION-IR: @"$e7Library13ExportedClassCMf" = external global
+
+// Non-@export(interface) struct: Application emits its own linkonce_odr copy.
+// APPLICATION-IR: @"$e7Library14NonExportedBarVMf" = linkonce_odr hidden constant
+
+public func useExportedFoo() -> Any {
+  return ExportedFoo(x: 42)
+}
+
+public func useNonExportedBar() -> Any {
+  return NonExportedBar(y: 99)
+}
+
+public func useExportedClass() -> Any {
+  return ExportedClass(z: 7)
+}

--- a/test/embedded/linkage/export_interface_types.swift
+++ b/test/embedded/linkage/export_interface_types.swift
@@ -3,10 +3,12 @@
 
 // Library module
 
-// RUN: %target-swift-frontend %t/Library.swift -parse-as-library -enable-experimental-feature Embedded -enable-experimental-feature Extern -emit-module-path %t/Library.swiftmodule -emit-ir -o - | %FileCheck -check-prefix LIBRARY-IR %s
+// RUN: %target-swift-frontend %t/Library.swift -parse-as-library -enable-experimental-feature Embedded -enable-experimental-feature Extern -emit-module-path %t/Library.swiftmodule -emit-sil -o - | %FileCheck -check-prefix LIBRARY-SIL %s
+// RUN: %target-swift-frontend %t/Library.swift -parse-as-library -enable-experimental-feature Embedded -enable-experimental-feature Extern -emit-ir -o - | %FileCheck -check-prefix LIBRARY-IR %s
 
 // Application module
 
+// RUN: %target-swift-frontend %t/Application.swift -I %t -parse-as-library -enable-experimental-feature Embedded -enable-experimental-feature Extern -emit-sil -o - | %FileCheck -check-prefix APPLICATION-SIL %s
 // RUN: %target-swift-frontend %t/Application.swift -I %t -parse-as-library -enable-experimental-feature Embedded -enable-experimental-feature Extern -emit-ir -o - | %FileCheck -check-prefix APPLICATION-IR %s
 
 // REQUIRES: swift_in_compiler
@@ -15,30 +17,42 @@
 
 //--- Library.swift
 
+public protocol Greeter { func greet() }
+
 // @export(interface) struct: FullMetadata should be a strong public
 // definition (ExternalLinkage), not linkonce_odr or private.
 // LIBRARY-IR: @"$e7Library11ExportedFooVMf" = constant
 @export(interface)
-public struct ExportedFoo {
+public struct ExportedFoo: Greeter {
   public var x: Int
   public init(x: Int) { self.x = x }
+  public func greet() { print("foo") }
 }
 
 // Non-@export(interface) struct: FullMetadata is lazily emitted per module;
 // the Library module should NOT define it eagerly.
 // LIBRARY-IR-NOT: @"$e7Library14NonExportedBarVMf"
-public struct NonExportedBar {
+public struct NonExportedBar: Greeter {
   public var y: Int
   public init(y: Int) { self.y = y }
+  public func greet() { print("bar") }
 }
 
 // @export(interface) class: FullMetadata should be a strong public definition.
 // LIBRARY-IR: @"$e7Library13ExportedClassCMf" = constant
 @export(interface)
-public class ExportedClass {
+public class ExportedClass: Greeter {
   public var z: Int
   public init(z: Int) { self.z = z }
+  public func greet() { print("class") }
 }
+
+// In embedded Swift, protocol witness tables always get shared SIL linkage
+// regardless of whether the conforming type has @export(interface). Shared
+// linkage lets each importing module emit its own linkonce_odr copy.
+// LIBRARY-SIL-DAG: sil_witness_table shared ExportedFoo: Greeter module Library
+// LIBRARY-SIL-DAG: sil_witness_table shared NonExportedBar: Greeter module Library
+// LIBRARY-SIL-DAG: sil_witness_table shared ExportedClass: Greeter module Library
 
 //--- Application.swift
 import Library
@@ -52,6 +66,12 @@ import Library
 // Non-@export(interface) struct: Application emits its own linkonce_odr copy.
 // APPLICATION-IR: @"$e7Library14NonExportedBarVMf" = linkonce_odr hidden constant
 
+// Witness tables remain shared in the importing module as well, so the
+// application emits its own local copy.
+// APPLICATION-SIL-DAG: sil_witness_table shared ExportedFoo: Greeter module Library
+// APPLICATION-SIL-DAG: sil_witness_table shared NonExportedBar: Greeter module Library
+// APPLICATION-SIL-DAG: sil_witness_table shared ExportedClass: Greeter module Library
+
 public func useExportedFoo() -> Any {
   return ExportedFoo(x: 42)
 }
@@ -63,3 +83,8 @@ public func useNonExportedBar() -> Any {
 public func useExportedClass() -> Any {
   return ExportedClass(z: 7)
 }
+
+public func useAsGreeter(_ g: any Greeter) { g.greet() }
+public func formGreeterFoo() { useAsGreeter(ExportedFoo(x: 1)) }
+public func formGreeterBar() { useAsGreeter(NonExportedBar(y: 2)) }
+public func formGreeterClass() { useAsGreeter(ExportedClass(z: 3)) }

--- a/test/embedded/linkage/export_interface_types_exec.swift
+++ b/test/embedded/linkage/export_interface_types_exec.swift
@@ -1,0 +1,56 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// Build the library module (defines @export(interface) types) and the
+// application, then link and run the resulting binary. This ensures that
+// type metadata for @export(interface) struct/class types has the right
+// cross-module linkage to form existentials from the importing module.
+
+// RUN: %target-swift-frontend -c -emit-module -o %t/Library.o %t/Library.swift -enable-experimental-feature Embedded -enable-experimental-feature Extern -parse-as-library
+// RUN: %target-swift-frontend -c -I %t -emit-module -o %t/Application.o %t/Application.swift -enable-experimental-feature Embedded -enable-experimental-feature Extern -parse-as-library
+// RUN: %target-clang %target-clang-resource-dir-opt %t/Library.o %t/Application.o %target-embedded-posix-shim -o %t/Application
+// RUN: %target-run %t/Application | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: executable_test
+// REQUIRES: swift_feature_Embedded
+// REQUIRES: swift_feature_Extern
+
+//--- Library.swift
+
+@export(interface)
+public struct ExportedStruct {
+  public var x: Int
+  public init(x: Int) { self.x = x }
+  public func describe() { print("ExportedStruct(x: \(x))") }
+}
+
+@export(interface)
+public class ExportedClass {
+  public var y: Int
+  public init(y: Int) { self.y = y }
+  public func describe() { print("ExportedClass(y: \(y))") }
+}
+
+//--- Application.swift
+import Library
+
+@main
+struct Main {
+  static func main() {
+    // Wrap imported @export(interface) values in Any existentials, which
+    // requires the type metadata for ExportedStruct / ExportedClass to be
+    // visible across the module boundary.
+    let values: [Any] = [
+      ExportedStruct(x: 42),
+      ExportedClass(y: 99),
+    ]
+
+    // CHECK: ExportedStruct(x: 42)
+    (values[0] as! ExportedStruct).describe()
+    // CHECK-NEXT: ExportedClass(y: 99)
+    (values[1] as! ExportedClass).describe()
+    // CHECK-NEXT: DONE
+    print("DONE")
+  }
+}

--- a/test/embedded/linkage/export_interface_types_exec.swift
+++ b/test/embedded/linkage/export_interface_types_exec.swift
@@ -18,38 +18,50 @@
 
 //--- Library.swift
 
-@export(interface)
-public struct ExportedStruct {
-  public var x: Int
-  public init(x: Int) { self.x = x }
-  public func describe() { print("ExportedStruct(x: \(x))") }
+public protocol Greeter {
+  func greet()
 }
 
 @export(interface)
-public class ExportedClass {
-  public var y: Int
-  public init(y: Int) { self.y = y }
-  public func describe() { print("ExportedClass(y: \(y))") }
+public struct ExportedStruct: Greeter {
+  public var name: StaticString
+  public init(name: StaticString) { self.name = name }
+  public func greet() { print("struct greeting from \(name)") }
+}
+
+@export(interface)
+public class ExportedClass: Greeter {
+  public var name: StaticString
+  public init(name: StaticString) { self.name = name }
+  public func greet() { print("class greeting from \(name)") }
 }
 
 //--- Application.swift
 import Library
 
+func callThroughExistential(_ g: any Greeter) {
+  g.greet()
+}
+
 @main
 struct Main {
   static func main() {
-    // Wrap imported @export(interface) values in Any existentials, which
-    // requires the type metadata for ExportedStruct / ExportedClass to be
-    // visible across the module boundary.
-    let values: [Any] = [
-      ExportedStruct(x: 42),
-      ExportedClass(y: 99),
-    ]
+    // Wrap imported @export(interface) values in `any Greeter` existentials.
+    // This requires both the type metadata AND the protocol witness table
+    // for ExportedStruct/ExportedClass to be available in this module.
 
-    // CHECK: ExportedStruct(x: 42)
-    (values[0] as! ExportedStruct).describe()
-    // CHECK-NEXT: ExportedClass(y: 99)
-    (values[1] as! ExportedClass).describe()
+    // CHECK: struct greeting from S
+    callThroughExistential(ExportedStruct(name: "S"))
+    // CHECK-NEXT: class greeting from C
+    callThroughExistential(ExportedClass(name: "C"))
+
+    // Also check casting out of Any still works end-to-end.
+    let anys: [Any] = [ExportedStruct(name: "S2"), ExportedClass(name: "C2")]
+    // CHECK-NEXT: struct greeting from S2
+    (anys[0] as! ExportedStruct).greet()
+    // CHECK-NEXT: class greeting from C2
+    (anys[1] as! ExportedClass).greet()
+
     // CHECK-NEXT: DONE
     print("DONE")
   }


### PR DESCRIPTION
@export(interface) makes it so that Embedded Swift will emit a strong definition of a symbol in its defining module, and use that symbol in other modules. Extend this notion to non-generic types, where we will emit a strong definition for the full type metadata, and let it be referenced from other modules rather than the lazy, shared emission. Do the same for witness tables.

Implements rdar://176392354.