### PR TITLE
[6.4] LifetimeDependenceDiagnostics: calls with no deps are immortal

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceDiagnostics.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceDiagnostics.swift
@@ -72,21 +72,6 @@ let lifetimeDependenceDiagnosticsPass = FunctionPass(
       markDep.settleToEscaping(context)
       continue
     }
-    if let apply = instruction as? FullApplySite, !apply.hasResultDependence {
-      // Handle ~Escapable results that do not have a lifetime dependence. This includes implicit initializers, calls to
-      // closures, and @_unsafeNonescapableResult.
-      apply.resultOrYields.forEach {
-        if let lifetimeDep = LifetimeDependence(unsafeApplyResult: $0, apply: apply, context) {
-          _ = analyze(dependence: lifetimeDep, context)
-        }
-      }
-      apply.indirectResultOperands.forEach {
-        if let lifetimeDep = LifetimeDependence(unsafeApplyResult: $0.value, apply: apply, context) {
-          _ = analyze(dependence: lifetimeDep, context)
-        }
-      }
-      continue
-    }
   }
 }
 

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_closure.swift
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_closure.swift
@@ -51,37 +51,43 @@ func ncint_get_neint_mutable_local() {
 }
 
 struct NE: ~Escapable {
+  let p: UnsafeRawPointer?
+
   public func condition() -> Bool {
     return true
   }
 }
 
+func getLocalPointer() -> UnsafeRawPointer? {
+  return nil
+}
+
 func takePicker(picker: @_lifetime(copy ne0, copy ne1) (_ ne0: NE, _ ne1: NE) -> NE) {
-    let x = NE()
-    let y = NE()
+    let x = NE(p: getLocalPointer())
+    let y = NE(p: getLocalPointer())
     _ = picker(x, y)
 }
 
 func takeOnePicker(picker: @_lifetime(copy ne0) (_ ne0: NE, NE) -> NE) {
-    let x = NE()
-    let y = NE()
+    let x = NE(p: getLocalPointer())
+    let y = NE(p: getLocalPointer())
     _ = picker(x, y)
 }
 
 func takeCapturePicker(picker: /* DEFAULT: @_lifetime(captures, copy ne0, copy ne1) */ (_ ne0: NE, _ ne1: NE) -> NE) {
-    let x = NE()
-    let y = NE()
+    let x = NE(p: getLocalPointer())
+    let y = NE(p: getLocalPointer())
     _ = picker(x, y)
 }
 
 func takeMutator(mutator: @_lifetime(ne: copy ne) (_ ne: inout NE) -> ()) {
-  var ne = NE()
+  var ne = NE(p: getLocalPointer())
   mutator(&ne)
   let _ = ne
 }
 
 func takeCaptureMutator(mutator: @_lifetime(ne: captures, copy ne) (_ ne: inout NE) -> ()) {
-  var ne = NE()
+  var ne = NE(p: getLocalPointer())
   mutator(&ne)
   let _ = ne
 }
@@ -98,31 +104,31 @@ func testClosureLifetimes(cond: Bool) {
   // annotation.
   
   // OK, ne2 is captured but its lifetime is not related
-  let ne2 = NE()
+  let ne2 = NE(p: getLocalPointer())
   takePicker { ne0, ne1 in
     if ne2.condition() { return ne0 } else { return ne1 }
   }
 
-  let ne3 = NE()
+  let ne3 = NE(p: getLocalPointer())
   // expected-error@-1{{lifetime-dependent variable 'ne3' escapes its scope}}
   // expected-note@-2{{it depends on a closure capture; this is not yet supported}}
   takePicker { ne0, ne1 in ne3 }
   // expected-note@-1{{this use causes the lifetime-dependent value to escape}}
 
-  var ne4 = NE() // expected-error{{lifetime-dependent variable 'ne4' escapes its scope}}
+  var ne4 = NE(p: getLocalPointer()) // expected-error{{lifetime-dependent variable 'ne4' escapes its scope}}
   takePicker { ne0, ne1 in
-    ne4 = NE()   // expected-note{{it depends on the lifetime of this parent value}}
+    ne4 = NE(p: getLocalPointer())   // expected-note{{it depends on the lifetime of this parent value}}
     return ne0   // expected-note{{this use causes the lifetime-dependent value to escape}}
   }
   let _ = ne4
 
-  let ne5 = NE() // expected-note{{it depends on a closure capture; this is not yet supported}}
+  let ne5 = NE(p: getLocalPointer()) // expected-note{{it depends on a closure capture; this is not yet supported}}
   takePicker { ne0, ne1 in
     let ne = ne5 // expected-error{{lifetime-dependent variable 'ne' escapes its scope}}
     return ne    // expected-note{{this use causes the lifetime-dependent value to escape}}
   }
 
-  var ne6 = NE()           // expected-error{{lifetime-dependent variable 'ne6' escapes its scope}}
+  var ne6 = NE(p: getLocalPointer())           // expected-error{{lifetime-dependent variable 'ne6' escapes its scope}}
   takePicker { ne0, ne1 in // expected-note{{it depends on the lifetime of argument 'ne1'}}
     ne6 = ne1
     return ne0             // expected-note{{this use causes the lifetime-dependent value to escape}}
@@ -134,7 +140,7 @@ func testClosureLifetimes(cond: Bool) {
     ne0 = neLocal
   }
 
-  let ne8 = NE()       // expected-note{{it depends on a closure capture; this is not yet supported}}
+  let ne8 = NE(p: getLocalPointer())       // expected-note{{it depends on a closure capture; this is not yet supported}}
   takeMutator { ne0 in // expected-error{{lifetime-dependent variable 'ne0' escapes its scope}}
     ne0 = ne8
   }                    // expected-note{{this use causes the lifetime-dependent value to escape}}
@@ -160,7 +166,7 @@ func testClosureLifetimes(cond: Bool) {
 
   takeCapturePicker { ne0, ne1 in ne0 } // OK
   takeCapturePicker { ne0, ne1 in ne1 } // OK
-  let ne9 = NE()
+  let ne9 = NE(p: getLocalPointer())
   takeCapturePicker { ne0, ne1 in ne9 } // OK
 
 
@@ -169,7 +175,7 @@ func testClosureLifetimes(cond: Bool) {
     ne0 = neLocal
   }
 
-  let ne10 = NE()
+  let ne10 = NE(p: getLocalPointer())
   takeCaptureMutator { ne0 in // OK
     ne0 = ne10
   }

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_param_fail.swift
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_param_fail.swift
@@ -124,7 +124,13 @@ func take_bvmut_assign_inout(bv: inout BV, other: inout BV,
   f(&bv, &other) // OK
 }
 
-struct NE2: ~Escapable {}
+struct NE2: ~Escapable {
+  let p: UnsafeRawPointer?
+}
+
+func getLocalPointer() -> UnsafeRawPointer? {
+  return nil
+}
 
 @_lifetime(oNE: copy ne)
 func succeed_transfer_ne(ne: consuming NE2, oNE: inout NE2, f: (NE2) -> NE2) {
@@ -133,7 +139,7 @@ func succeed_transfer_ne(ne: consuming NE2, oNE: inout NE2, f: (NE2) -> NE2) {
 
 func fail_smuggle_ne(oNE: inout NE2, f: (NE2) -> NE2) {
   // expected-error @-1 {{lifetime-dependent variable 'oNE' escapes its scope}}
-  let ne = NE2()
+  let ne = NE2(p: getLocalPointer())
   // expected-note @-1 {{it depends on the lifetime of this parent value}}
   oNE = f(ne)
   // expected-note @+1 {{this use causes the lifetime-dependent value to escape}}

--- a/test/SILOptimizer/lifetime_dependence/semantics.swift
+++ b/test/SILOptimizer/lifetime_dependence/semantics.swift
@@ -15,9 +15,17 @@
 
 import Builtin
 
-struct NotEscapable: ~Escapable {}
+struct NotEscapable: ~Escapable {
+  let p: UnsafeRawPointer?
+}
 
-public struct NE: ~Escapable {}
+public struct NE: ~Escapable {
+  let p: UnsafeRawPointer?
+}
+
+func getLocalPointer() -> UnsafeRawPointer? {
+  return nil
+}
 
 // Lifetime dependence semantics by example.
 public struct Span<T>: ~Escapable {
@@ -263,7 +271,7 @@ struct Container<T> {
 // Dependence on an empty initialized value should be scoped to variable decl.
 @_lifetime(copy x)
 func f(x: NotEscapable) -> NotEscapable {
-  let local = NotEscapable() // expected-error {{lifetime-dependent variable 'local' escapes its scope}}
+  let local = NotEscapable(p: getLocalPointer()) // expected-error {{lifetime-dependent variable 'local' escapes its scope}}
   // expected-note @-1{{it depends on the lifetime of this parent value}}
   return local // expected-note {{this use causes the lifetime-dependent value to escape}}
 }
@@ -621,9 +629,7 @@ func testNoEscapClosureCaptureHasEscaped(spanArg: Span<Int>, array: consuming [I
   let escapedSpan = {
     spanBox = array.span() // expected-error{{lifetime-dependent value escapes its scope}}
     // expected-note@-1{{this use causes the lifetime-dependent value to escape}}
-    return closure() // expected-error{{lifetime-dependent value escapes its scope}}
-    // expected-note@-1{{it depends on the lifetime of this parent value}}
-    // expected-note@-2{{this use causes the lifetime-dependent value to escape}}
+    return closure()
   }()
   _ = consume array
   _ = escapedSpan

--- a/test/SILOptimizer/lifetime_dependence/semantics.swift
+++ b/test/SILOptimizer/lifetime_dependence/semantics.swift
@@ -268,6 +268,18 @@ func f(x: NotEscapable) -> NotEscapable {
   return local // expected-note {{this use causes the lifetime-dependent value to escape}}
 }
 
+// Test Optional<~E> 'var' properties.
+// The initializer expressions (which return 'nil') should be considered immortal.
+struct OptionalVarInit<Element: ~Escapable>: ~Escapable {
+  var e1: Element? = nil
+  var e2: Element? = nil
+
+  @_lifetime(copy e)
+  init(e: Element) {
+    e1 = e
+  }
+}
+
 // =============================================================================
 // Scoped dependence on values
 // =============================================================================


### PR DESCRIPTION

- **Explanation**: Fix lifetime diagnostics so that the result of a call with no dependencies is immortal. This is done by simply removing a temporary safeguard that made diagnostics too conservative. The safeguard is no longer needed now that we have support for closure lifetimes.
- **Scope**: The only possible effect is that lifetime diagnostics now will trigger less often. This only affects a few corner cases that don't have normal @_lifetime dependencies.
- **Issues**: rdar://176561897 ([nonescapable] initialization of Optional fields reports a lifetime escape)
- **Original PRs**: https://github.com/swiftlang/swift/pull/88980
- **Risk**: Minimal
- **Testing**: Added a source level unit test.
- **Reviewers**: @meg-gupta 

--- details ---

- **LifetimeDependenceDiagnostics: calls with no deps are immortal**
  Fix lifetime diagnostics to consider an implicit initializer of a ~Escapable
  type to be implicitly immortal. Required to handle Optional<~Escapable> stored
  properties, such as:
  
```
  struct Foo<Element: ~Escapable>: ~Escapable {
    var element: Element?
  
    @_lifetime(borrow c)
    init<C>(c: borrowing C) {
      // error: Lifetime-dependent variable 'self' escapes its scope
    }
  }
  ```
  The fix is simply to remove a temporary safeguard that I put in place to
  compensate for our incomplete closure lifetimes. We now have the complete
  representation of lifetimes on closures, so don't need the safeguard.
  
  Representationally, a function that returns a ~Escapable value but has no
  dependendencies is immortal. This was always the intended design, but the
  temporary safeguard treated these cases as implicitly bound to some local scope.
  
  Removing this safeguard has the effect of:
  
  - Variable intialization is immortal (it cannot depend on anything by
    definition). The safety of the initializer is checked inside the implementation
    of those expressions rather than the caller.
  
  - Empty ~Escapable types have an implicit immortal initializer (why not?)
  
  - Calls to a function with @_unsafeNonescapableResult but no @_lifetime
    annotation produce an immortal value. This is reasonable, and we want to
    deprecate this attribute as soon as possible anyway. It is not for general use.
  
  This is currently blocking usage of BorrowingSequence, such as a hypothetical BorrowingSequenceMapSequenceIterator.
  
  Fixes rdar://176561897 ([nonescapable] initialization of Optional fields reports
  a lifetime escape)
  
  (cherry picked from commit 4845b0bf4d38a2aad91680daa792b5a855b38d81)
  

- **[NFC] Update test cases for immortal empty initializers**
  Some tests used empty initializers as a way to express a locally non-escapable
  value. This is improper.
  
  (cherry picked from commit 6610763f017cf9ade86272560b89377a93c3bcc4)
