### PR TITLE
Fix false 'nonisolated' error on lazy var in nonisolated struct

### DIFF
--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -8235,10 +8235,12 @@ void AttributeChecker::visitNonisolatedAttr(NonisolatedAttr *attr) {
                 .fixItInsertAfter(attr->getRange().End, "(unsafe)");
             return;
           } else if (var->getAttrs().hasAttribute<LazyAttr>()) {
-            diagnoseAndRemoveAttr(attr, diag::nonisolated_mutable_storage)
-                .warnUntilLanguageMode(LanguageMode::v6)
-                .fixItInsertAfter(attr->getRange().End, "(unsafe)");
-            return;
+            if (!attr->isImplicit()) {
+              diagnoseAndRemoveAttr(attr, diag::nonisolated_mutable_storage)
+                  .warnUntilLanguageMode(LanguageMode::v6)
+                  .fixItInsertAfter(attr->getRange().End, "(unsafe)");
+              return;
+            }
           } else {
             diagnoseAndRemoveAttr(attr, diag::nonisolated_mutable_storage)
               .fixItInsertAfter(attr->getRange().End, "(unsafe)");

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -8235,6 +8235,8 @@ void AttributeChecker::visitNonisolatedAttr(NonisolatedAttr *attr) {
                 .fixItInsertAfter(attr->getRange().End, "(unsafe)");
             return;
           } else if (var->getAttrs().hasAttribute<LazyAttr>()) {
+            if(attr->isImplicit())
+              return;
             diagnoseAndRemoveAttr(attr, diag::nonisolated_mutable_storage)
                 .warnUntilLanguageMode(LanguageMode::v6)
                 .fixItInsertAfter(attr->getRange().End, "(unsafe)");

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -8235,8 +8235,6 @@ void AttributeChecker::visitNonisolatedAttr(NonisolatedAttr *attr) {
                 .fixItInsertAfter(attr->getRange().End, "(unsafe)");
             return;
           } else if (var->getAttrs().hasAttribute<LazyAttr>()) {
-            if(attr->isImplicit())
-              return;
             diagnoseAndRemoveAttr(attr, diag::nonisolated_mutable_storage)
                 .warnUntilLanguageMode(LanguageMode::v6)
                 .fixItInsertAfter(attr->getRange().End, "(unsafe)");

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -8235,12 +8235,10 @@ void AttributeChecker::visitNonisolatedAttr(NonisolatedAttr *attr) {
                 .fixItInsertAfter(attr->getRange().End, "(unsafe)");
             return;
           } else if (var->getAttrs().hasAttribute<LazyAttr>()) {
-            if (!attr->isImplicit()) {
-              diagnoseAndRemoveAttr(attr, diag::nonisolated_mutable_storage)
-                  .warnUntilLanguageMode(LanguageMode::v6)
-                  .fixItInsertAfter(attr->getRange().End, "(unsafe)");
-              return;
-            }
+            diagnoseAndRemoveAttr(attr, diag::nonisolated_mutable_storage)
+                .warnUntilLanguageMode(LanguageMode::v6)
+                .fixItInsertAfter(attr->getRange().End, "(unsafe)");
+            return;
           } else {
             diagnoseAndRemoveAttr(attr, diag::nonisolated_mutable_storage)
               .fixItInsertAfter(attr->getRange().End, "(unsafe)");

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -6527,7 +6527,8 @@ static InferredActorIsolation computeActorIsolation(Evaluator &evaluator,
     case ActorIsolation::NonisolatedUnsafe:
       // Stored properties cannot be non-isolated, so don't infer it.
       if (auto var = dyn_cast<VarDecl>(value)) {
-        if (!var->isStatic() && var->hasStorage())
+        if (!var->isStatic() &&
+            (var->hasStorage() || var->getAttrs().hasAttribute<LazyAttr>()))
           return ActorIsolation::forUnspecified().withPreconcurrency(
               inferred.preconcurrency());
       }

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -6527,8 +6527,7 @@ static InferredActorIsolation computeActorIsolation(Evaluator &evaluator,
     case ActorIsolation::NonisolatedUnsafe:
       // Stored properties cannot be non-isolated, so don't infer it.
       if (auto var = dyn_cast<VarDecl>(value)) {
-        if (!var->isStatic() &&
-            (var->hasStorage() || var->getAttrs().hasAttribute<LazyAttr>()))
+        if (!var->isStatic() && var->hasStorage())
           return ActorIsolation::forUnspecified().withPreconcurrency(
               inferred.preconcurrency());
       }
@@ -6578,7 +6577,13 @@ static InferredActorIsolation computeActorIsolation(Evaluator &evaluator,
     if (var->isLazyStorageProperty()) {
       if (auto originalVar = var->getOriginalVarForBackingStorage()) {
         auto inferred = getInferredActorIsolation(originalVar);
-        return {inferredIsolation(inferred.isolation), inferred.source};
+        auto isolation = inferred.isolation;
+        // Lazy backing storage should not inherit nonisolated-family isolation
+        // from the visible lazy property.
+        if (isolation.isNonisolatedOrConcurrent())
+          isolation = ActorIsolation::forUnspecified().withPreconcurrency(
+              isolation.preconcurrency());
+        return {inferredIsolation(isolation), inferred.source};
       }
     }
   }

--- a/test/Concurrency/lazy-vars-actor.swift
+++ b/test/Concurrency/lazy-vars-actor.swift
@@ -64,7 +64,7 @@ public struct MainActorHasLazyVars {
 // CHECK-NEXT:   mutating get
 // CHECK-NEXT:   set
 // CHECK-NEXT: }
-// NONRESILIENT: {{^}}@_hasInitialValue private var $__lazy_storage_$_foo: Swift::Int?
+// NONRESILIENT: {{^}} @_hasInitialValue private var $__lazy_storage_$_foo: Swift::Int?
 // CHECK-NEXT: }
 nonisolated public struct NonisolatedHasLazyVars {
   public lazy var foo: Int = 0

--- a/test/Concurrency/lazy-vars-actor.swift
+++ b/test/Concurrency/lazy-vars-actor.swift
@@ -59,6 +59,19 @@ public struct MainActorHasLazyVars {
 }
 
 
+// CHECK: nonisolated public struct NonisolatedHasLazyVars {
+// CHECK-NOT: nonisolated public var foo
+// CHECK-NEXT: public var foo: Swift::Int {
+// CHECK-NEXT:   mutating get
+// CHECK-NEXT:   set
+// CHECK-NEXT: }
+// NONRESILIENT: @_hasInitialValue private var {{.*}}foo: Swift::Int?
+// CHECK-NEXT: }
+nonisolated public struct NonisolatedHasLazyVars {
+  public lazy var foo: Int = 0
+}
+
+
 // CHECK: {{(@preconcurrency @_Concurrency::MainActor|@_Concurrency::MainActor @preconcurrency)}} public struct PreconcurrencyMainActorHasLazyVars {
 // CHECK-NEXT: {{(@preconcurrency @_Concurrency::MainActor|@_Concurrency::MainActor @preconcurrency)}} public var foo: Swift::Int {
 // CHECK-NEXT:   mutating get

--- a/test/Concurrency/lazy-vars-actor.swift
+++ b/test/Concurrency/lazy-vars-actor.swift
@@ -59,13 +59,12 @@ public struct MainActorHasLazyVars {
 }
 
 
-// CHECK: nonisolated public struct NonisolatedHasLazyVars {
-// CHECK-NOT: nonisolated public var foo
-// CHECK-NEXT: public var foo: Swift::Int {
+// CHECK-LABEL: nonisolated public struct NonisolatedHasLazyVars {
+// CHECK-NEXT: nonisolated public var foo: Swift::Int {
 // CHECK-NEXT:   mutating get
 // CHECK-NEXT:   set
 // CHECK-NEXT: }
-// NONRESILIENT: @_hasInitialValue private var {{.*}}foo: Swift::Int?
+// NONRESILIENT: {{^}}@_hasInitialValue private var $__lazy_storage_$_foo: Swift::Int?
 // CHECK-NEXT: }
 nonisolated public struct NonisolatedHasLazyVars {
   public lazy var foo: Int = 0

--- a/test/Concurrency/nonisolated_rules.swift
+++ b/test/Concurrency/nonisolated_rules.swift
@@ -103,6 +103,10 @@ nonisolated struct StructRemovesGlobalActor: GloballyIsolated {
 // expected-note@+1 {{calls to global function 'requireMain()' from outside of its actor context are implicitly asynchronous}}
 @MainActor func requireMain() {}
 
+nonisolated struct NonisolatedStructWithLazyVar {
+  lazy var x = 0 // okay
+}
+
 nonisolated struct S1: GloballyIsolated {
   var x: NonSendable
   @P nonisolated var y = 0 // okay

--- a/test/Concurrency/nonisolated_rules.swift
+++ b/test/Concurrency/nonisolated_rules.swift
@@ -79,6 +79,7 @@ public struct PublicNonSendable {
 nonisolated struct StructRemovesGlobalActor: GloballyIsolated {
   var x: NonSendable
   var y: Int = 1
+  lazy var w: Int = 0 // okay
 
   init(x: NonSendable) {
     self.x = x // okay


### PR DESCRIPTION
## Fix `nonisolated` + `lazy var` handling

A `lazy var` inside a `nonisolated` struct should compile.

This keeps `nonisolated` on the visible lazy property, but does not apply it to the hidden lazy backing storage. Explicit `nonisolated lazy var` errors stay unchanged.

Added tests for the issue case and module interface output.

Resolves https://github.com/swiftlang/swift/issues/88925