### PR TITLE
SILOptimizer: skip pack-specialization for callees with an error result

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/PackSpecialization.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/PackSpecialization.swift
@@ -437,6 +437,15 @@ private func specializeCallee(apply: ApplySite, context: FunctionPassContext)
     return nil
   }
 
+  // FIXME: PackSpecialization does not yet preserve the typed-throws error
+  // result when computing the new function signature, producing a
+  // multi-direct-result return that downstream passes can't lower (e.g.
+  // CSE/SILCombine then trip a `cast<>` assertion). Skip such callees
+  // until the pass is updated to carry the error result through.
+  if callee.hasErrorResult {
+    return nil
+  }
+
   let exploded = PackExplodedFunction(from: callee, context)
 
   return exploded

--- a/SwiftCompilerSources/Sources/SIL/Function.swift
+++ b/SwiftCompilerSources/Sources/SIL/Function.swift
@@ -413,6 +413,8 @@ extension Function {
 
   public var hasIndirectErrorArgument: Bool { bridged.hasIndirectErrorResult() }
 
+  public var hasErrorResult: Bool { bridged.hasErrorResult() }
+
   /// The number of arguments which correspond to parameters (and not to indirect results).
   public var numParameterArguments: Int { convention.parameters.count }
 

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -555,6 +555,7 @@ struct BridgedFunction {
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedDeclRef getDeclRef() const;
   BRIDGED_INLINE SwiftInt getNumIndirectFormalResults() const;
   BRIDGED_INLINE bool hasIndirectErrorResult() const;
+  BRIDGED_INLINE bool hasErrorResult() const;
   BRIDGED_INLINE SwiftInt getNumSILArguments() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedType getSILArgumentType(SwiftInt idx) const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedType getSILResultType() const;

--- a/include/swift/SIL/SILBridgingImpl.h
+++ b/include/swift/SIL/SILBridgingImpl.h
@@ -846,6 +846,10 @@ bool BridgedFunction::hasIndirectErrorResult() const {
   return (SwiftInt)getFunction()->getLoweredFunctionType()->hasIndirectErrorResult();
 }
 
+bool BridgedFunction::hasErrorResult() const {
+  return (SwiftInt)getFunction()->getLoweredFunctionType()->hasErrorResult();
+}
+
 SwiftInt BridgedFunction::getNumSILArguments() const {
   return swift::SILFunctionConventions(getFunction()->getConventionsInContext()).getNumSILArguments();
 }

--- a/test/SILOptimizer/pack_specialization_typed_throws.swift
+++ b/test/SILOptimizer/pack_specialization_typed_throws.swift
@@ -1,0 +1,46 @@
+// RUN: %target-swift-frontend %s -emit-sil -O -swift-version 6 -target %target-swift-5.9-abi-triple -o /dev/null
+
+// REQUIRES: swift_in_compiler
+
+// rdar://(typed-throws-pack-spec) — bug-3-instance-pack-expand-release.
+//
+// PackSpecialization didn't account for the typed-throws error result when
+// computing the new function signature. After GenericSpecializer converted
+// `@error_indirect E` to `@error E` (E = Never), PackSpecialization
+// produced a function whose signature claimed multiple direct results
+// (`(@owned Result, @owned Never, @error Never)`) but whose body returned
+// only the Result. Downstream passes (CSE, SILCombine, depending on
+// function shape) tripped the `cast<Ty>()` assertion in `Casting.h:578`.
+//
+// Skipping pack-specialization for callees with an error result avoids the
+// crash. The throw-aware version of the pass is left as future work.
+
+public struct Product<each Element> {
+    public let values: (repeat each Element)
+
+    @inlinable
+    public init(_ values: repeat each Element) {
+        self.values = (repeat each values)
+    }
+}
+
+extension Product {
+    @inlinable
+    public consuming func map<each NewElement, E: Swift.Error>(
+        _ transforms: repeat (each Element) throws(E) -> each NewElement
+    ) throws(E) -> Product<repeat each NewElement> {
+        Product<repeat each NewElement>(
+            repeat try (each transforms)(each values)
+        )
+    }
+}
+
+@inlinable
+public func _instantiate() -> Product<Int, String, Bool>? {
+    let triple = Product(1, "hi", true)
+    return try? triple.map(
+        { (x: Int) -> Int in x + 1 },
+        { (s: String) -> String in s.uppercased() },
+        { (b: Bool) -> Bool in !b }
+    )
+}


### PR DESCRIPTION
PackSpecialization computes a new function signature when exploding pack arguments, but doesn't account for the typed-throws error result. After GenericSpecializer converted `@error_indirect E` to `@error E` (E = Never) on the user's `Product.map`, PackSpecialization produced a function whose signature claimed an extra direct result alongside the real one but whose body returned only the original. Downstream passes (CSE on the minimal repro, SILCombine on the production case) tripped the `cast<Ty>()` assertion in `Casting.h:578` walking the malformed SIL.

Skip pack-specialization when the callee has an error result, with a FIXME pointing at the throw-aware version of the pass.

Bridges `BridgedFunction::hasErrorResult` (the existing `hasIndirectErrorResult` doesn't catch the post-GenericSpecializer direct-error shape).

Addresses https://github.com/swiftlang/swift/issues/88987