### PR TITLE
Runtimes: Add Windows version resources

### DIFF
--- a/Runtimes/Core/CMakeLists.txt
+++ b/Runtimes/Core/CMakeLists.txt
@@ -46,6 +46,7 @@ list(APPEND CMAKE_MODULE_PATH
 include(CMakeWorkarounds)
 
 include(SwiftProjectVersion)
+include(SwiftAddWindowsVersionResource)
 project(SwiftCore
   LANGUAGES C CXX Swift
   VERSION ${SWIFT_RUNTIME_VERSION})

--- a/Runtimes/Core/Concurrency/CMakeLists.txt
+++ b/Runtimes/Core/Concurrency/CMakeLists.txt
@@ -97,6 +97,7 @@ add_library(swift_Concurrency
   "${CMAKE_CURRENT_BINARY_DIR}/Task+init.swift"
   "${CMAKE_CURRENT_BINARY_DIR}/TaskGroup+addTask.swift"
   "${CMAKE_CURRENT_BINARY_DIR}/Task+immediate.swift")
+swift_add_windows_version_resource(swift_Concurrency)
 
 if(SwiftCore_ENABLE_STDLIB_TRACING)
   target_compile_definitions(swift_Concurrency

--- a/Runtimes/Core/Core/CMakeLists.txt
+++ b/Runtimes/Core/Core/CMakeLists.txt
@@ -264,6 +264,7 @@ add_library(swiftCore
   "${CMAKE_CURRENT_BINARY_DIR}/UnsafeBufferPointer.swift"
   "${CMAKE_CURRENT_BINARY_DIR}/UnsafeRawBufferPointer.swift"
   "${CMAKE_CURRENT_BINARY_DIR}/Tuple.swift")
+swift_add_windows_version_resource(swiftCore)
 
 # https://github.com/swiftlang/swift/issues/77705 - Freestanding and Linux/Android builds both have failures to resolve.
 if(NOT LINUX AND NOT ANDROID)

--- a/Runtimes/Core/SwiftOnoneSupport/CMakeLists.txt
+++ b/Runtimes/Core/SwiftOnoneSupport/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library(swiftSwiftOnoneSupport
   SwiftOnoneSupport.swift
   "${PROJECT_SOURCE_DIR}/linker-support/magic-symbols-for-install-name.c")
+swift_add_windows_version_resource(swiftSwiftOnoneSupport)
 
 set_target_properties(swiftSwiftOnoneSupport PROPERTIES
  Swift_MODULE_NAME SwiftOnoneSupport)

--- a/Runtimes/Core/SwiftRemoteMirror/CMakeLists.txt
+++ b/Runtimes/Core/SwiftRemoteMirror/CMakeLists.txt
@@ -1,6 +1,7 @@
 
 add_library(swiftRemoteMirror
   SwiftRemoteMirror.cpp)
+swift_add_windows_version_resource(swiftRemoteMirror)
 target_compile_definitions(swiftRemoteMirror PUBLIC
   $<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:swiftRemoteMirror_STATIC>)
 target_link_libraries(swiftRemoteMirror PRIVATE

--- a/Runtimes/Overlay/Android/Android/CMakeLists.txt
+++ b/Runtimes/Overlay/Android/Android/CMakeLists.txt
@@ -7,6 +7,7 @@ add_library(swiftAndroid
   Platform.swift
   POSIXError.swift
   TiocConstants.swift)
+swift_add_windows_version_resource(swiftAndroid)
 set_target_properties(swiftAndroid PROPERTIES
   Swift_MODULE_NAME Android)
 target_compile_definitions(swiftAndroid PRIVATE

--- a/Runtimes/Overlay/Android/Math/CMakeLists.txt
+++ b/Runtimes/Overlay/Android/Math/CMakeLists.txt
@@ -1,6 +1,7 @@
 
 add_library(swift_math
   Math.swift)
+swift_add_windows_version_resource(swift_math)
 set_target_properties(swift_math PROPERTIES
   Swift_MODULE_NAME _math)
 target_link_libraries(swift_math PRIVATE

--- a/Runtimes/Overlay/CMakeLists.txt
+++ b/Runtimes/Overlay/CMakeLists.txt
@@ -19,6 +19,7 @@ if(POLICY CMP0157 AND CMAKE_Swift_COMPILER_USE_OLD_DRIVER)
 endif()
 
 include(SwiftProjectVersion)
+include(SwiftAddWindowsVersionResource)
 project(SwiftOverlay
   LANGUAGES C CXX Swift
   VERSION ${SWIFT_RUNTIME_VERSION})

--- a/Runtimes/Overlay/Linux/glibc/CMakeLists.txt
+++ b/Runtimes/Overlay/Linux/glibc/CMakeLists.txt
@@ -9,6 +9,7 @@ add_library(swiftGlibc
   Platform.swift
   TiocConstants.swift
   tgmath.swift)
+swift_add_windows_version_resource(swiftGlibc)
 
 target_link_libraries(swiftGlibc
   PRIVATE

--- a/Runtimes/Overlay/WASI/WASILibc/CMakeLists.txt
+++ b/Runtimes/Overlay/WASI/WASILibc/CMakeLists.txt
@@ -8,6 +8,7 @@ add_library(swiftWASILibc
   tgmath.swift
   TiocConstants.swift
   WASILibc.swift)
+swift_add_windows_version_resource(swiftWASILibc)
 set_target_properties(swiftWASILibc PROPERTIES
   Swift_MODULE_NAME WASILibc)
 target_compile_definitions(swiftWASILibc PRIVATE

--- a/Runtimes/Overlay/Windows/CRT/CMakeLists.txt
+++ b/Runtimes/Overlay/Windows/CRT/CMakeLists.txt
@@ -7,6 +7,7 @@ add_library(swiftCRT
   Platform.swift
   POSIXError.swift
   TiocConstants.swift)
+swift_add_windows_version_resource(swiftCRT)
 set_target_properties(swiftCRT PROPERTIES
   Swift_MODULE_NAME CRT)
 target_compile_definitions(swiftCRT PRIVATE

--- a/Runtimes/Overlay/Windows/WinSDK/CMakeLists.txt
+++ b/Runtimes/Overlay/Windows/WinSDK/CMakeLists.txt
@@ -1,6 +1,7 @@
 
 add_library(swiftWinSDK
   WinSDK.swift)
+swift_add_windows_version_resource(swiftWinSDK)
 set_target_properties(swiftWinSDK PROPERTIES
   Swift_MODULE_NAME WinSDK)
 target_compile_definitions(swiftWinSDK PRIVATE

--- a/Runtimes/Overlay/clang/CMakeLists.txt
+++ b/Runtimes/Overlay/clang/CMakeLists.txt
@@ -5,6 +5,7 @@ gyb_expand(float.swift.gyb float.swift)
 add_library(swift_Builtin_float
   float.swift
   "${PROJECT_SOURCE_DIR}/linker-support/magic-symbols-for-install-name.c")
+swift_add_windows_version_resource(swift_Builtin_float)
 set_target_properties(swift_Builtin_float PROPERTIES
   Swift_MODULE_NAME _Builtin_float)
 target_compile_options(swift_Builtin_float PRIVATE

--- a/Runtimes/Supplemental/Differentiation/CMakeLists.txt
+++ b/Runtimes/Supplemental/Differentiation/CMakeLists.txt
@@ -14,6 +14,7 @@ list(APPEND CMAKE_MODULE_PATH
   "${CMAKE_SOURCE_DIR}/../../cmake/modules")
 
 include(SwiftProjectVersion)
+include(SwiftAddWindowsVersionResource)
 project(SwiftDifferentiation
   LANGUAGES Swift C
   VERSION ${SWIFT_RUNTIME_VERSION})
@@ -115,6 +116,7 @@ add_library(swift_Differentiation
   TgmathDerivatives.swift
   FloatingPointDifferentiation.swift
   linker-support/magic-symbols-for-install-name.c)
+swift_add_windows_version_resource(swift_Differentiation)
 
 if(APPLE AND BUILD_SHARED_LIBS)
   target_link_options(swift_Differentiation PRIVATE

--- a/Runtimes/Supplemental/Distributed/CMakeLists.txt
+++ b/Runtimes/Supplemental/Distributed/CMakeLists.txt
@@ -15,6 +15,7 @@ list(APPEND CMAKE_MODULE_PATH
 
 include(LanguageVersions)
 include(SwiftProjectVersion)
+include(SwiftAddWindowsVersionResource)
 project(SwiftDistributed
   LANGUAGES C CXX Swift
   VERSION ${SWIFT_RUNTIME_VERSION})
@@ -106,6 +107,7 @@ add_library(swiftDistributed
   DistributedMacros.swift
   DistributedMetadata.swift
   LocalTestingDistributedActorSystem.swift)
+swift_add_windows_version_resource(swiftDistributed)
 
 set_target_properties(swiftDistributed PROPERTIES
   Swift_MODULE_NAME Distributed)

--- a/Runtimes/Supplemental/Observation/CMakeLists.txt
+++ b/Runtimes/Supplemental/Observation/CMakeLists.txt
@@ -15,6 +15,7 @@ list(APPEND CMAKE_MODULE_PATH
 
 include(LanguageVersions)
 include(SwiftProjectVersion)
+include(SwiftAddWindowsVersionResource)
 project(SwiftObservation
   LANGUAGES Swift CXX
   VERSION ${SWIFT_RUNTIME_VERSION})
@@ -103,6 +104,7 @@ add_library(swiftObservation
   Sources/Observation/Observations.swift
   Sources/Observation/ThreadLocal.swift
   Sources/Observation/ThreadLocal.cpp)
+swift_add_windows_version_resource(swiftObservation)
 set_target_properties(swiftObservation PROPERTIES
   Swift_MODULE_NAME Observation)
 # FIXME: We should split out the parts that are needed by the runtime to avoid

--- a/Runtimes/Supplemental/Runtime/CMakeLists.txt
+++ b/Runtimes/Supplemental/Runtime/CMakeLists.txt
@@ -14,6 +14,7 @@ list(APPEND CMAKE_MODULE_PATH
   "${CMAKE_SOURCE_DIR}/../../cmake/modules")
 
 include(SwiftProjectVersion)
+include(SwiftAddWindowsVersionResource)
 project(SwiftRuntime
   LANGUAGES Swift CXX
   VERSION ${SWIFT_RUNTIME_VERSION})
@@ -129,6 +130,7 @@ add_link_options($<$<PLATFORM_ID:Linux>:LINKER:-z,defs>)
 
 add_library(swiftRuntime
   Mangling.swift)
+swift_add_windows_version_resource(swiftRuntime)
 
 # Optionally add backtracing sources
 if(${PROJECT_NAME}_ENABLE_BACKTRACING)

--- a/Runtimes/Supplemental/StackWalker/CMakeLists.txt
+++ b/Runtimes/Supplemental/StackWalker/CMakeLists.txt
@@ -8,6 +8,7 @@ list(APPEND CMAKE_MODULE_PATH
   "${CMAKE_SOURCE_DIR}/../../cmake/modules")
 
 include(SwiftProjectVersion)
+include(SwiftAddWindowsVersionResource)
 project(SwiftBacktrace
   LANGUAGES CXX Swift
   VERSION ${SWIFT_RUNTIME_VERSION})
@@ -75,6 +76,7 @@ add_executable(swift-backtrace
   Themes.swift
   Timing.swift
   Utils.swift)
+swift_add_windows_version_resource(swift-backtrace)
 set_target_properties(swift-backtrace PROPERTIES
   Swift_MODULE_NAME swift_backtrace)
 target_compile_options(swift-backtrace PRIVATE

--- a/Runtimes/Supplemental/StringProcessing/CMakeLists.txt
+++ b/Runtimes/Supplemental/StringProcessing/CMakeLists.txt
@@ -16,6 +16,7 @@ list(APPEND CMAKE_MODULE_PATH
 
 include(LanguageVersions)
 include(SwiftProjectVersion)
+include(SwiftAddWindowsVersionResource)
 project(SwiftStringProcessing
   LANGUAGES Swift C
   VERSION ${SWIFT_RUNTIME_VERSION})

--- a/Runtimes/Supplemental/StringProcessing/RegexBuilder/CMakeLists.txt
+++ b/Runtimes/Supplemental/StringProcessing/RegexBuilder/CMakeLists.txt
@@ -5,6 +5,7 @@ add_library(swiftRegexBuilder
   Algorithms.swift
   Variadics.swift
   DSL.swift)
+swift_add_windows_version_resource(swiftRegexBuilder)
 
 set_target_properties(swiftRegexBuilder PROPERTIES
   Swift_MODULE_NAME RegexBuilder)

--- a/Runtimes/Supplemental/StringProcessing/_RegexParser/CMakeLists.txt
+++ b/Runtimes/Supplemental/StringProcessing/_RegexParser/CMakeLists.txt
@@ -30,6 +30,7 @@ add_library(swift_RegexParser
   Utility/AllScalars.swift
   Utility/Errors.swift
   Utility/MissingUnicode.swift)
+swift_add_windows_version_resource(swift_RegexParser)
 
 target_link_libraries(swift_RegexParser PRIVATE
   swiftCore

--- a/Runtimes/Supplemental/StringProcessing/_StringProcessing/CMakeLists.txt
+++ b/Runtimes/Supplemental/StringProcessing/_StringProcessing/CMakeLists.txt
@@ -74,6 +74,7 @@ add_library(swift_StringProcessing
   Utility/TypeVerification.swift
   Utility/RegexFactory.swift
   Utility/ASTBuilder.swift)
+swift_add_windows_version_resource(swift_StringProcessing)
 
 set_target_properties(swift_StringProcessing PROPERTIES
   Swift_MODULE_NAME _StringProcessing)

--- a/Runtimes/Supplemental/Synchronization/CMakeLists.txt
+++ b/Runtimes/Supplemental/Synchronization/CMakeLists.txt
@@ -15,6 +15,7 @@ list(APPEND CMAKE_MODULE_PATH
 
 include(LanguageVersions)
 include(SwiftProjectVersion)
+include(SwiftAddWindowsVersionResource)
 project(SwiftSynchronization
   LANGUAGES Swift
   VERSION ${SWIFT_RUNTIME_VERSION})
@@ -131,6 +132,7 @@ add_library(swiftSynchronization
   Atomics/AtomicStorage.swift
   Atomics/AtomicIntegers.swift
   Cell.swift)
+swift_add_windows_version_resource(swiftSynchronization)
 
 # Determine Mutex definition
 if(${PROJECT_NAME}_SINGLE_THREADED_MODE)

--- a/Runtimes/Supplemental/Volatile/CMakeLists.txt
+++ b/Runtimes/Supplemental/Volatile/CMakeLists.txt
@@ -15,6 +15,7 @@ list(APPEND CMAKE_MODULE_PATH
 
 include(LanguageVersions)
 include(SwiftProjectVersion)
+include(SwiftAddWindowsVersionResource)
 project(SwiftVolatile
   LANGUAGES Swift
   VERSION ${SWIFT_RUNTIME_VERSION})
@@ -86,6 +87,7 @@ add_link_options($<$<PLATFORM_ID:Android,Linux>:LINKER:-z,defs>)
 
 add_library(swift_Volatile
   Volatile.swift)
+swift_add_windows_version_resource(swift_Volatile)
 set_target_properties(swift_Volatile PROPERTIES
   Swift_MODULE_NAME _Volatile)
 target_compile_options(swift_Volatile PRIVATE

--- a/Runtimes/cmake/modules/SwiftAddWindowsVersionResource.cmake
+++ b/Runtimes/cmake/modules/SwiftAddWindowsVersionResource.cmake
@@ -1,0 +1,112 @@
+#===--- SwiftAddWindowsVersionResource.cmake ---------------------------===#
+#
+# This source file is part of the Swift open source project
+#
+# Copyright (c) 2026 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+#===---------------------------------------------------------------------===#
+#
+# Embeds an `RT_VERSION` (`VS_VERSIONINFO`) resource into a Windows
+# shared library or executable target so the resulting PE carries
+# readable version metadata in its resource section.  Also satisfies
+# WiX's "versioned keypath" criterion for multi-file `<Component>`
+# definitions.
+#
+# Usage:
+#
+#   swift_add_windows_version_resource(<target>
+#     [FILE_DESCRIPTION  <string>]    # default: <INTERNAL_NAME>
+#     [INTERNAL_NAME     <string>]    # default: <target>
+#     [ORIGINAL_FILENAME <string>]    # default: <target>{.dll,.exe}
+#     [PRODUCT_NAME      <string>]    # default: "Swift"
+#   )
+#
+# Version numbers are taken from `${SWIFT_RUNTIME_VERSION}` if set,
+# falling back to `${PROJECT_VERSION}`.  No-op on non-Windows targets.
+
+include_guard(GLOBAL)
+
+function(swift_add_windows_version_resource target)
+  if(NOT WIN32)
+    return()
+  endif()
+  if(NOT TARGET ${target})
+    message(FATAL_ERROR
+      "swift_add_windows_version_resource: '${target}' is not a target")
+  endif()
+
+  cmake_parse_arguments(PARSE_ARGV 1 ARG
+    ""
+    "FILE_DESCRIPTION;INTERNAL_NAME;ORIGINAL_FILENAME;PRODUCT_NAME"
+    "")
+
+  # Resolve defaults.
+  if(NOT ARG_INTERNAL_NAME)
+    set(ARG_INTERNAL_NAME "${target}")
+  endif()
+  if(NOT ARG_FILE_DESCRIPTION)
+    set(ARG_FILE_DESCRIPTION "${ARG_INTERNAL_NAME}")
+  endif()
+  if(NOT ARG_PRODUCT_NAME)
+    set(ARG_PRODUCT_NAME "Swift")
+  endif()
+  if(NOT ARG_ORIGINAL_FILENAME)
+    get_target_property(target_type ${target} TYPE)
+    if(target_type STREQUAL "EXECUTABLE")
+      set(ARG_ORIGINAL_FILENAME "${target}.exe")
+    else()
+      set(ARG_ORIGINAL_FILENAME "${target}.dll")
+    endif()
+  endif()
+
+  # Pad the project version to a four-part `MAJOR.MINOR.PATCH.TWEAK`
+  # value here rather than at the source: `SwiftProjectVersion` emits
+  # `SWIFT_RUNTIME_VERSION` as a 1-3 part value (e.g. "6.4.0") because
+  # other consumers across the Swift runtime projects depend on that
+  # shape, and Windows `VS_VERSIONINFO` /
+  # `<assemblyIdentity version="...">` is the only consumer that
+  # requires a quad.  Containing the normalisation in this helper keeps
+  # the change to `SwiftProjectVersion` zero.
+  if(SWIFT_RUNTIME_VERSION)
+    set(version "${SWIFT_RUNTIME_VERSION}")
+  elseif(PROJECT_VERSION)
+    set(version "${PROJECT_VERSION}")
+  else()
+    set(version "0.0.0.0")
+  endif()
+  string(REGEX MATCHALL "[0-9]+" version_parts "${version}")
+  list(LENGTH version_parts version_part_count)
+  while(version_part_count LESS 4)
+    list(APPEND version_parts "0")
+    math(EXPR version_part_count "${version_part_count} + 1")
+  endwhile()
+  list(GET version_parts 0 SWIFT_RC_VERSION_MAJOR)
+  list(GET version_parts 1 SWIFT_RC_VERSION_MINOR)
+  list(GET version_parts 2 SWIFT_RC_VERSION_PATCH)
+  list(GET version_parts 3 SWIFT_RC_VERSION_TWEAK)
+  set(SWIFT_RC_VERSION_STRING
+    "${SWIFT_RC_VERSION_MAJOR}.${SWIFT_RC_VERSION_MINOR}.${SWIFT_RC_VERSION_PATCH}.${SWIFT_RC_VERSION_TWEAK}")
+
+  # Map argument values to template variables for `configure_file` to
+  # substitute.  These names match the `@VAR@` placeholders in the
+  # `.rc.in` template.
+  set(SWIFT_RC_FILE_DESCRIPTION  "${ARG_FILE_DESCRIPTION}")
+  set(SWIFT_RC_INTERNAL_NAME     "${ARG_INTERNAL_NAME}")
+  set(SWIFT_RC_ORIGINAL_FILENAME "${ARG_ORIGINAL_FILENAME}")
+  set(SWIFT_RC_PRODUCT_NAME      "${ARG_PRODUCT_NAME}")
+
+  # Stage a per-target .rc with all values baked in.  Using
+  # `CMAKE_CURRENT_FUNCTION_LIST_DIR` so the template is found relative
+  # to *this* module file regardless of where the function is invoked.
+  configure_file(
+    "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/../resources/swift_runtime_version_resource.rc.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/${target}_version_resource.rc"
+    @ONLY)
+
+  target_sources(${target}
+    PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/${target}_version_resource.rc")
+endfunction()

--- a/Runtimes/cmake/resources/swift_runtime_version_resource.rc.in
+++ b/Runtimes/cmake/resources/swift_runtime_version_resource.rc.in
@@ -1,0 +1,46 @@
+//===--- swift_runtime_version_resource.rc.in ---------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===---------------------------------------------------------------------===//
+//
+// Microsoft VC resource script template embedding `VS_VERSIONINFO` into
+// the PE binaries built by `swift_add_windows_version_resource()`.
+// Configured (via `configure_file(... @ONLY)`) into a per-target staged
+// .rc by `cmake/modules/SwiftAddWindowsVersionResource.cmake`.
+//
+// VS_VERSIONINFO format reference:
+//   https://learn.microsoft.com/windows/win32/menurc/vs-versioninfo
+
+1 VERSIONINFO
+FILEVERSION    @SWIFT_RC_VERSION_MAJOR@,@SWIFT_RC_VERSION_MINOR@,@SWIFT_RC_VERSION_PATCH@,@SWIFT_RC_VERSION_TWEAK@
+PRODUCTVERSION @SWIFT_RC_VERSION_MAJOR@,@SWIFT_RC_VERSION_MINOR@,@SWIFT_RC_VERSION_PATCH@,@SWIFT_RC_VERSION_TWEAK@
+BEGIN
+  BLOCK "StringFileInfo"
+  BEGIN
+    // U.S. English (langID 0x0409), UTF-8 (codepage 0xFDE9 == 65001)
+    BLOCK "0409FDE9"
+    BEGIN
+      VALUE "CompanyName",      "Swift Open Source Project"
+      VALUE "FileDescription",  "@SWIFT_RC_FILE_DESCRIPTION@"
+      VALUE "FileVersion",      "@SWIFT_RC_VERSION_STRING@"
+      VALUE "InternalName",     "@SWIFT_RC_INTERNAL_NAME@"
+      VALUE "LegalCopyright",   "Copyright (c) Apple Inc. and the Swift project authors. Licensed under Apache License v2.0 with Runtime Library Exception."
+      VALUE "OriginalFilename", "@SWIFT_RC_ORIGINAL_FILENAME@"
+      VALUE "ProductName",      "@SWIFT_RC_PRODUCT_NAME@"
+      VALUE "ProductVersion",   "@SWIFT_RC_VERSION_STRING@"
+    END
+  END
+
+  BLOCK "VarFileInfo"
+  BEGIN
+    // Translation must match the StringFileInfo BLOCK key above.
+    VALUE "Translation", 0x0409, 0xFDE9
+  END
+END


### PR DESCRIPTION
Add a CMake helper and resource template for embedding VS_VERSIONINFO metadata in Swift runtime DLLs and executables built for Windows.

The helper stages the resource file per target, fills in Swift runtime version fields, and attaches the resource to runtime libraries and tools. This gives the PE binaries file/product version metadata and satisfies WiX's versioned-keypath handling for runtime installer components.