### PR TITLE
tests: fix flaky many_struct_properties_scale_test.swift.gyb and alias_analysis_scale_test.swift.gyb

### DIFF
--- a/validation-test/SILOptimizer/alias_analysis_scale_test.swift.gyb
+++ b/validation-test/SILOptimizer/alias_analysis_scale_test.swift.gyb
@@ -1,9 +1,10 @@
-// RUN: %timer-scale-test --begin 50 --end 800 --superlinear-threshold 4 --trace --select SIL-processing.user -O %s
+// RUN: %timer-scale-test --begin 50 --end 800 --superlinear-threshold 3 --trace --select SIL-processing.instr -O %s
 
 // TODO: there are still compile time problems in CopyPropagation and OSSACanonicalizationOwned (inside SILCombine): rdar://176255056
 //       Once those problems are fixed the threshold should be closer to 1.
 
 // REQUIRES: asserts
+// REQUIRES: OS=macosx
 
 public class Entry {
   private let a: String

--- a/validation-test/SILOptimizer/many_struct_properties_scale_test.swift.gyb
+++ b/validation-test/SILOptimizer/many_struct_properties_scale_test.swift.gyb
@@ -1,9 +1,10 @@
-// RUN: %timer-scale-test --begin 50 --end 1000 --superlinear-threshold 5 --trace --select SIL-processing.user -O %s
+// RUN: %timer-scale-test --begin 100 --end 1000 --superlinear-threshold 4 --trace --select SIL-processing.instr -O %s
 
 // TODO: there are still compile time problems in CopyPropagation and OSSACanonicalizationOwned (inside SILCombine): rdar://176255056
 //       Once those problems are fixed the threshold should be closer to 1.
 
 // REQUIRES: asserts
+// REQUIRES: OS=macosx
 
 public typealias Handler = ((Int) -> Int)
 


### PR DESCRIPTION
Measure instruction count instead of user time, because this is more reliable. Unfortunately it's not available on all OSes.
So let's run the tests only on macos.

rdar://176507830
