### PR TITLE
[6.4.x] AST: Fix `getAvailabilityConstraintsForDecl()` for members of extensions

### DIFF
--- a/lib/AST/AvailabilityConstraint.cpp
+++ b/lib/AST/AvailabilityConstraint.cpp
@@ -214,38 +214,49 @@ shouldIgnoreConstraintInContext(const Decl *decl,
 static std::optional<AvailabilityConstraint>
 getAvailabilityConstraintForAttr(const Decl *decl,
                                  const SemanticAvailableAttr &attr,
-                                 const AvailabilityContext &context) {
-  // Is the decl unconditionally unavailable?
-  if (attr.isUnconditionallyUnavailable())
-    return AvailabilityConstraint::unavailableUnconditionally(attr);
+                                 const AvailabilityContext &context,
+                                 const AvailabilityConstraintFlags flags) {
+  auto getConstraint = [&]() -> std::optional<AvailabilityConstraint> {
+    // Is the decl unconditionally unavailable?
+    if (attr.isUnconditionallyUnavailable())
+      return AvailabilityConstraint::unavailableUnconditionally(attr);
 
-  auto &ctx = decl->getASTContext();
-  auto domain = attr.getDomain();
-  bool domainSupportsRefinement = domain.supportsContextRefinement();
+    auto &ctx = decl->getASTContext();
+    auto domain = attr.getDomain();
+    bool domainSupportsRefinement = domain.supportsContextRefinement();
 
-  // Compute the available range in the given context. If there is no explicit
-  // range defined by the context, use the deployment range as fallback.
-  std::optional<AvailabilityRange> availableRange;
-  if (domainSupportsRefinement)
-    availableRange = context.getAvailabilityRange(domain, ctx);
-  if (!availableRange)
-    availableRange = domain.getDeploymentRange(ctx);
+    // Compute the available range in the given context. If there is no
+    // explicit range defined by the context, use the deployment range as
+    // fallback.
+    std::optional<AvailabilityRange> availableRange;
+    if (domainSupportsRefinement)
+      availableRange = context.getAvailabilityRange(domain, ctx);
+    if (!availableRange)
+      availableRange = domain.getDeploymentRange(ctx);
 
-  // Is the decl obsoleted in this context?
-  if (auto obsoletedRange = attr.getObsoletedRange(ctx)) {
-    if (availableRange && availableRange->isContainedIn(*obsoletedRange))
-      return AvailabilityConstraint::unavailableObsolete(attr);
-  }
+    // Is the decl obsoleted in this context?
+    if (auto obsoletedRange = attr.getObsoletedRange(ctx)) {
+      if (availableRange && availableRange->isContainedIn(*obsoletedRange))
+        return AvailabilityConstraint::unavailableObsolete(attr);
+    }
 
-  // Is the decl not yet introduced in this context?
-  if (auto introducedRange = attr.getIntroducedRange(ctx)) {
-    if (!availableRange || !availableRange->isContainedIn(*introducedRange))
-      return domainSupportsRefinement
-                 ? AvailabilityConstraint::unintroduced(attr)
-                 : AvailabilityConstraint::unavailableUnintroduced(attr);
-  }
+    // Is the decl not yet introduced in this context?
+    if (auto introducedRange = attr.getIntroducedRange(ctx)) {
+      if (!availableRange || !availableRange->isContainedIn(*introducedRange))
+        return domainSupportsRefinement
+                   ? AvailabilityConstraint::unintroduced(attr)
+                   : AvailabilityConstraint::unavailableUnintroduced(attr);
+    }
 
-  return std::nullopt;
+    return std::nullopt;
+  };
+
+  auto constraint = getConstraint();
+  if (constraint &&
+      shouldIgnoreConstraintInContext(decl, *constraint, context, flags))
+    return std::nullopt;
+
+  return constraint;
 }
 
 /// Returns the most specific platform domain from the availability attributes
@@ -285,16 +296,10 @@ static void getAvailabilityConstraintsForDecl(
         !activePlatformDomain->contains(domain))
       continue;
 
-    if (auto constraint = getAvailabilityConstraintForAttr(decl, attr, context))
+    if (auto constraint =
+            getAvailabilityConstraintForAttr(decl, attr, context, flags))
       addConstraint(constraints, *constraint, ctx);
   }
-
-  // After resolving constraints, remove any constraints that indicate the
-  // declaration is unconditionally unavailable in a domain for which
-  // the context is already unavailable.
-  llvm::erase_if(constraints, [&](const AvailabilityConstraint &constraint) {
-    return shouldIgnoreConstraintInContext(decl, constraint, context, flags);
-  });
 }
 
 DeclAvailabilityConstraints

--- a/test/Availability/availability_swift_language_mode.swift
+++ b/test/Availability/availability_swift_language_mode.swift
@@ -1,364 +1,459 @@
-// RUN: not %target-swift-frontend -typecheck %s -swift-version 4 2> %t.4.txt
-// RUN: %FileCheck -check-prefix=CHECK -check-prefix=CHECK-4 %s < %t.4.txt
-// RUN: %FileCheck -check-prefix=NEGATIVE %s < %t.4.txt
-
-// RUN: not %target-swift-frontend -typecheck %s -swift-version 5 2> %t.5.txt
-// RUN: %FileCheck -check-prefix=CHECK -check-prefix=CHECK-5 %s < %t.5.txt
-// RUN: %FileCheck -check-prefix=NEGATIVE %s < %t.5.txt
+// RUN: %target-swift-frontend -typecheck -verify -verify-additional-prefix swift5- %s -swift-version 5
+// RUN: %target-swift-frontend -typecheck -verify -verify-additional-prefix swift6- %s -swift-version 6
 
 
 class NonOptToOpt {
-  @available(swift, obsoleted: 5.0)
-  @available(*, deprecated, message: "not 5.0")
-  public init() {} // NEGATIVE-NOT: :[[@LINE]]:{{.+}}error
+  @available(swift, obsoleted: 6.0)
+  @available(*, deprecated, message: "not 6.0")
+  public init() {}
 
-  @available(swift 5.0)
-  @available(*, deprecated, message: "yes 5.0")
-  public init?() {} // NEGATIVE-NOT: :[[@LINE]]:{{.+}}error
+  @available(swift 6.0)
+  @available(*, deprecated, message: "yes 6.0")
+  public init?() {}
 }
 
-_ = NonOptToOpt()
-// CHECK-4: :[[@LINE-1]]:{{.+}} not 5.0
-// CHECK-5: :[[@LINE-2]]:{{.+}} yes 5.0
+_ = NonOptToOpt() // expected-swift5-warning {{not 6.0}} expected-swift6-warning {{yes 6.0}}
 
 class NonOptToOptReversed {
-  @available(swift 5.0)
-  @available(*, deprecated, message: "yes 5.0")
-  public init?() {} // NEGATIVE-NOT: :[[@LINE]]:{{.+}}error
+  @available(swift 6.0)
+  @available(*, deprecated, message: "yes 6.0")
+  public init?() {}
 
-  @available(swift, obsoleted: 5.0)
-  @available(*, deprecated, message: "not 5.0")
-  public init() {} // NEGATIVE-NOT: :[[@LINE]]:{{.+}}error
+  @available(swift, obsoleted: 6.0)
+  @available(*, deprecated, message: "not 6.0")
+  public init() {}
 }
 
-_ = NonOptToOptReversed()
-// CHECK-4: :[[@LINE-1]]:{{.+}} not 5.0
-// CHECK-5: :[[@LINE-2]]:{{.+}} yes 5.0
+_ = NonOptToOptReversed() // expected-swift5-warning {{not 6.0}} expected-swift6-warning {{yes 6.0}}
 
 
 class OptToNonOpt {
-  @available(swift, obsoleted: 5.0)
-  @available(*, deprecated, message: "not 5.0")
-  public init!() {} // NEGATIVE-NOT: :[[@LINE]]:{{.+}}error
+  @available(swift, obsoleted: 6.0)
+  @available(*, deprecated, message: "not 6.0")
+  public init!() {}
 
-  @available(swift 5.0)
-  @available(*, deprecated, message: "yes 5.0")
-  public init() {} // NEGATIVE-NOT: :[[@LINE]]:{{.+}}error
+  @available(swift 6.0)
+  @available(*, deprecated, message: "yes 6.0")
+  public init() {}
 }
 
-_ = OptToNonOpt()
-// CHECK-4: :[[@LINE-1]]:{{.+}} not 5.0
-// CHECK-5: :[[@LINE-2]]:{{.+}} yes 5.0
+_ = OptToNonOpt() // expected-swift5-warning {{not 6.0}} expected-swift6-warning {{yes 6.0}}
 
 class OptToNonOptReversed {
-  @available(swift 5.0)
-  @available(*, deprecated, message: "yes 5.0")
-  public init() {} // NEGATIVE-NOT: :[[@LINE]]:{{.+}}error
+  @available(swift 6.0)
+  @available(*, deprecated, message: "yes 6.0")
+  public init() {}
 
-  @available(swift, obsoleted: 5.0)
-  @available(*, deprecated, message: "not 5.0")
-  public init!() {} // NEGATIVE-NOT: :[[@LINE]]:{{.+}}error
+  @available(swift, obsoleted: 6.0)
+  @available(*, deprecated, message: "not 6.0")
+  public init!() {}
 }
 
-_ = OptToNonOptReversed()
-// CHECK-4: :[[@LINE-1]]:{{.+}} not 5.0
-// CHECK-5: :[[@LINE-2]]:{{.+}} yes 5.0
+_ = OptToNonOptReversed() // expected-swift5-warning {{not 6.0}} expected-swift6-warning {{yes 6.0}}
 
 
 class NoChange {
-  @available(swift, obsoleted: 5.0)
-  @available(*, deprecated, message: "not 5.0")
-  public init() {}
+  @available(swift, obsoleted: 6.0)
+  @available(*, deprecated, message: "not 6.0")
+  public init() {} // expected-note {{'init()' previously declared here}}
 
-  @available(swift 5.0)
-  @available(*, deprecated, message: "yes 5.0")
-  public init() {} // CHECK: :[[@LINE]]:{{.+}} error: invalid redeclaration of 'init()'
+  @available(swift 6.0)
+  @available(*, deprecated, message: "yes 6.0")
+  public init() {} // expected-error {{invalid redeclaration of 'init()'}}
 }
 
 class NoChangeReversed {
-  @available(swift 5.0)
-  @available(*, deprecated, message: "yes 5.0")
-  public init() {}
+  @available(swift 6.0)
+  @available(*, deprecated, message: "yes 6.0")
+  public init() {} // expected-note {{'init()' previously declared here}}
 
-  @available(swift, obsoleted: 5.0)
-  @available(*, deprecated, message: "not 5.0")
-  public init() {} // CHECK: :[[@LINE]]:{{.+}} error: invalid redeclaration of 'init()'
+  @available(swift, obsoleted: 6.0)
+  @available(*, deprecated, message: "not 6.0")
+  public init() {} // expected-error {{invalid redeclaration of 'init()'}}
 }
 
 class OptToOpt {
-  @available(swift, obsoleted: 5.0)
-  @available(*, deprecated, message: "not 5.0")
-  public init!() {}
+  @available(swift, obsoleted: 6.0)
+  @available(*, deprecated, message: "not 6.0")
+  public init!() {} // expected-note {{'init()' previously declared here}}
 
-  @available(swift 5.0)
-  @available(*, deprecated, message: "yes 5.0")
-  public init?() {} // CHECK: :[[@LINE]]:{{.+}} error: invalid redeclaration of 'init()'
+  @available(swift 6.0)
+  @available(*, deprecated, message: "yes 6.0")
+  public init?() {} // expected-error {{invalid redeclaration of 'init()'}}
 }
 
 class OptToOptReversed {
-  @available(swift 5.0)
-  @available(*, deprecated, message: "yes 5.0")
-  public init?() {}
+  @available(swift 6.0)
+  @available(*, deprecated, message: "yes 6.0")
+  public init?() {} // expected-note {{'init()' previously declared here}}
 
-  @available(swift, obsoleted: 5.0)
-  @available(*, deprecated, message: "not 5.0")
-  public init!() {} // CHECK: :[[@LINE]]:{{.+}} error: invalid redeclaration of 'init()'
+  @available(swift, obsoleted: 6.0)
+  @available(*, deprecated, message: "not 6.0")
+  public init!() {} // expected-error {{invalid redeclaration of 'init()'}}
 }
 
 class ThreeWayA {
-  @available(swift, obsoleted: 5.0)
-  public init() {} // NEGATIVE-NOT: :[[@LINE]]:{{.+}}error
+  @available(swift, obsoleted: 6.0)
+  public init() {}
 
-  @available(swift, introduced: 5.0, obsoleted: 6.0)
-  public init?() {} // NEGATIVE-NOT: :[[@LINE]]:{{.+}}error
+  @available(swift, introduced: 6.0, obsoleted: 7.0)
+  public init?() {}
 
-  @available(swift, introduced: 6.0)
-  public init() throws {} // NEGATIVE-NOT: :[[@LINE]]:{{.+}}error
+  @available(swift, introduced: 7.0)
+  public init() throws {}
 }
 
 class ThreeWayB {
-  @available(swift, obsoleted: 5.0)
-  public init() {} // NEGATIVE-NOT: :[[@LINE]]:{{.+}}error
+  @available(swift, obsoleted: 6.0)
+  public init() {}
 
-  @available(swift, introduced: 6.0)
-  public init() throws {} // NEGATIVE-NOT: :[[@LINE]]:{{.+}}error
+  @available(swift, introduced: 7.0)
+  public init() throws {}
 
-  @available(swift, introduced: 5.0, obsoleted: 6.0)
-  public init?() {} // NEGATIVE-NOT: :[[@LINE]]:{{.+}}error
+  @available(swift, introduced: 6.0, obsoleted: 7.0)
+  public init?() {}
 }
 
 class ThreeWayC {
-  @available(swift, introduced: 6.0)
-  public init() throws {} // NEGATIVE-NOT: :[[@LINE]]:{{.+}}error
+  @available(swift, introduced: 7.0)
+  public init() throws {}
 
-  @available(swift, obsoleted: 5.0)
-  public init() {} // NEGATIVE-NOT: :[[@LINE]]:{{.+}}error
+  @available(swift, obsoleted: 6.0)
+  public init() {}
 
-  @available(swift, introduced: 5.0, obsoleted: 6.0)
-  public init?() {} // NEGATIVE-NOT: :[[@LINE]]:{{.+}}error
+  @available(swift, introduced: 6.0, obsoleted: 7.0)
+  public init?() {}
 }
 
 class ThreeWayD {
-  @available(swift, introduced: 6.0)
-  public init() throws {} // NEGATIVE-NOT: :[[@LINE]]:{{.+}}error
+  @available(swift, introduced: 7.0)
+  public init() throws {}
 
-  @available(swift, introduced: 5.0, obsoleted: 6.0)
-  public init?() {} // NEGATIVE-NOT: :[[@LINE]]:{{.+}}error
+  @available(swift, introduced: 6.0, obsoleted: 7.0)
+  public init?() {}
 
-  @available(swift, obsoleted: 5.0)
-  public init() {} // NEGATIVE-NOT: :[[@LINE]]:{{.+}}error
+  @available(swift, obsoleted: 6.0)
+  public init() {}
 }
 
 class ThreeWayE {
-  @available(swift, introduced: 5.0, obsoleted: 6.0)
-  public init?() {} // NEGATIVE-NOT: :[[@LINE]]:{{.+}}error
+  @available(swift, introduced: 6.0, obsoleted: 7.0)
+  public init?() {}
 
-  @available(swift, introduced: 6.0)
-  public init() throws {} // NEGATIVE-NOT: :[[@LINE]]:{{.+}}error
+  @available(swift, introduced: 7.0)
+  public init() throws {}
 
-  @available(swift, obsoleted: 5.0)
-  public init() {} // NEGATIVE-NOT: :[[@LINE]]:{{.+}}error
+  @available(swift, obsoleted: 6.0)
+  public init() {}
 }
 
 class ThreeWayF {
-  @available(swift, introduced: 5.0, obsoleted: 6.0)
-  public init?() {} // NEGATIVE-NOT: :[[@LINE]]:{{.+}}error
+  @available(swift, introduced: 6.0, obsoleted: 7.0)
+  public init?() {}
 
-  @available(swift, obsoleted: 5.0)
-  public init() {} // NEGATIVE-NOT: :[[@LINE]]:{{.+}}error
+  @available(swift, obsoleted: 6.0)
+  public init() {}
 
-  @available(swift, introduced: 6.0)
-  public init() throws {} // NEGATIVE-NOT: :[[@LINE]]:{{.+}}error
+  @available(swift, introduced: 7.0)
+  public init() throws {}
 }
 
 class DisjointThreeWay {
-  @available(swift, obsoleted: 5.0)
-  public init() {} // NEGATIVE-NOT: :[[@LINE]]:{{.+}}error
+  @available(swift, obsoleted: 6.0)
+  public init() {}
 
-  @available(swift, introduced: 5.1, obsoleted: 6.0)
-  public init?() {} // NEGATIVE-NOT: :[[@LINE]]:{{.+}}error
+  @available(swift, introduced: 6.1, obsoleted: 7.0)
+  public init?() {}
 
-  @available(swift, introduced: 6.1)
-  public init() throws {} // NEGATIVE-NOT: :[[@LINE]]:{{.+}}error
+  @available(swift, introduced: 7.1)
+  public init() throws {}
 }
 
 class OverlappingVersions {
+  @available(swift, obsoleted: 7.0)
+  public init(a: ()) {} // expected-note {{'init(a:)' previously declared here}}
+
+  @available(swift 6.0)
+  public init?(a: ()) {} // expected-error {{invalid redeclaration of 'init(a:)'}}
+
+  @available(swift 6.0)
+  public init?(b: ()) {} // expected-note {{'init(b:)' previously declared here}}
+
+  @available(swift, obsoleted: 6.1)
+  public init(b: ()) {} // expected-error {{invalid redeclaration of 'init(b:)'}}
+
+  public init(c: ()) {} // expected-note {{'init(c:)' previously declared here}}
+
+  @available(swift 6.0)
+  public init?(c: ()) {} // expected-error {{invalid redeclaration of 'init(c:)'}}
+
+  @available(swift 6.0)
+  public init(c2: ()) {} // expected-note {{'init(c2:)' previously declared here}}
+
+  public init?(c2: ()) {} // expected-error {{invalid redeclaration of 'init(c2:)'}}
+
   @available(swift, obsoleted: 6.0)
-  public init(a: ()) {}
+  public init(d: ()) {} // expected-note {{'init(d:)' previously declared here}}
 
-  @available(swift 5.0)
-  public init?(a: ()) {} // CHECK: :[[@LINE]]:{{.+}} error: invalid redeclaration of 'init(a:)'
+  public init?(d: ()) {} // expected-error {{invalid redeclaration of 'init(d:)'}}
 
-  @available(swift 5.0)
-  public init?(b: ()) {}
+  public init(d2: ()) {} // expected-note {{'init(d2:)' previously declared here}}
 
-  @available(swift, obsoleted: 5.1)
-  public init(b: ()) {} // CHECK: :[[@LINE]]:{{.+}} error: invalid redeclaration of 'init(b:)'
+  @available(swift, obsoleted: 6.0)
+  public init?(d2: ()) {} // expected-error {{invalid redeclaration of 'init(d2:)'}}
 
-  public init(c: ()) {}
-
-  @available(swift 5.0)
-  public init?(c: ()) {} // CHECK: :[[@LINE]]:{{.+}} error: invalid redeclaration of 'init(c:)'
-
-  @available(swift 5.0)
-  public init(c2: ()) {}
-
-  public init?(c2: ()) {} // CHECK: :[[@LINE]]:{{.+}} error: invalid redeclaration of 'init(c2:)'
-
-  @available(swift, obsoleted: 5.0)
-  public init(d: ()) {}
-
-  public init?(d: ()) {} // CHECK: :[[@LINE]]:{{.+}} error: invalid redeclaration of 'init(d:)'
-
-  public init(d2: ()) {}
-
-  @available(swift, obsoleted: 5.0)
-  public init?(d2: ()) {} // CHECK: :[[@LINE]]:{{.+}} error: invalid redeclaration of 'init(d2:)'
-
-  @available(swift, obsoleted: 5.0)
+  @available(swift, obsoleted: 6.0)
   public init(e: ()) {}
 
-  @available(swift 5.0)
-  public init?(e: ()) {}
+  @available(swift 6.0)
+  public init?(e: ()) {} // expected-note {{'init(e:)' previously declared here}}
 
-  @available(swift 5.0)
-  public init!(e: ()) {} // CHECK: :[[@LINE]]:{{.+}} error: invalid redeclaration of 'init(e:)'
+  @available(swift 6.0)
+  public init!(e: ()) {} // expected-error {{invalid redeclaration of 'init(e:)'}}
 
-  @available(swift, obsoleted: 5.0)
-  public init(f: ()) {}
+  @available(swift, obsoleted: 6.0)
+  public init(f: ()) {} // expected-note {{'init(f:)' previously declared here}}
 
-  @available(swift 5.0)
+  @available(swift 6.0)
   public init?(f: ()) {}
 
-  @available(swift, obsoleted: 5.0)
-  public init!(f: ()) {} // CHECK: :[[@LINE]]:{{.+}} error: invalid redeclaration of 'init(f:)'
+  @available(swift, obsoleted: 6.0)
+  public init!(f: ()) {} // expected-error {{invalid redeclaration of 'init(f:)'}}
 }
 
 
 class NonThrowingToThrowing {
-  @available(swift, obsoleted: 5.0)
-  @available(*, deprecated, message: "not 5.0")
-  public init() {} // NEGATIVE-NOT: :[[@LINE]]:{{.+}}error
+  @available(swift, obsoleted: 6.0)
+  @available(*, deprecated, message: "not 6.0")
+  public init() {}
 
-  @available(swift 5.0)
-  @available(*, deprecated, message: "yes 5.0")
-  public init() throws {} // NEGATIVE-NOT: :[[@LINE]]:{{.+}}error
+  @available(swift 6.0)
+  @available(*, deprecated, message: "yes 6.0")
+  public init() throws {}
 
-  @available(swift, obsoleted: 5.0)
-  @available(*, deprecated, message: "not 5.0")
-  public static func foo() {} // NEGATIVE-NOT: :[[@LINE]]:{{.+}}error
+  @available(swift, obsoleted: 6.0)
+  @available(*, deprecated, message: "not 6.0")
+  public static func foo() {}
 
-  @available(swift 5.0)
-  @available(*, deprecated, message: "yes 5.0")
-  public static func foo() throws {} // NEGATIVE-NOT: :[[@LINE]]:{{.+}}error
+  @available(swift 6.0)
+  @available(*, deprecated, message: "yes 6.0")
+  public static func foo() throws {}
+
+  static func test() throws {
+    _ = NonThrowingToThrowing() // expected-swift5-warning {{not 6.0}} expected-swift6-warning {{yes 6.0}}
+    // expected-swift6-error@-1 {{call can throw but is not marked with 'try'}}
+    // expected-swift6-note@-2 {{did you mean to use 'try'?}}
+    // expected-swift6-note@-3 {{did you mean to handle error as optional value?}}
+    // expected-swift6-note@-4 {{did you mean to disable error propagation?}}
+    _ = NonThrowingToThrowing.foo() // expected-warning {{using '_' to ignore the result of a Void-returning function is redundant}} expected-swift5-warning {{not 6.0}} expected-swift6-warning {{yes 6.0}}
+    // expected-swift6-error@-1 {{call can throw but is not marked with 'try'}}
+    // expected-swift6-note@-2 {{did you mean to use 'try'?}}
+    // expected-swift6-note@-3 {{did you mean to handle error as optional value?}}
+    // expected-swift6-note@-4 {{did you mean to disable error propagation?}}
+  }
+
+  @available(swift, obsoleted: 6.0)
+  func testObsoleted() throws {
+    _ = NonThrowingToThrowing() // expected-swift5-warning {{not 6.0}} expected-swift6-warning {{yes 6.0}}
+    // expected-swift6-error@-1 {{call can throw but is not marked with 'try'}}
+    // expected-swift6-note@-2 {{did you mean to use 'try'?}}
+    // expected-swift6-note@-3 {{did you mean to handle error as optional value?}}
+    // expected-swift6-note@-4 {{did you mean to disable error propagation?}}
+    _ = NonThrowingToThrowing.foo() // expected-warning {{using '_' to ignore the result of a Void-returning function is redundant}} expected-swift5-warning {{not 6.0}} expected-swift6-warning {{yes 6.0}}
+    // expected-swift6-error@-1 {{call can throw but is not marked with 'try'}}
+    // expected-swift6-note@-2 {{did you mean to use 'try'?}}
+    // expected-swift6-note@-3 {{did you mean to handle error as optional value?}}
+    // expected-swift6-note@-4 {{did you mean to disable error propagation?}}
+  }
+
 }
-
-_ = NonThrowingToThrowing()
-// CHECK-4: :[[@LINE-1]]:{{.+}} not 5.0
-// CHECK-5: :[[@LINE-2]]:{{.+}} yes 5.0
-_ = NonThrowingToThrowing.foo()
-// CHECK-4: :[[@LINE-1]]:{{.+}} not 5.0
-// CHECK-5: :[[@LINE-2]]:{{.+}} yes 5.0
 
 class NonThrowingToThrowingReversed {
-  @available(swift 5.0)
-  @available(*, deprecated, message: "yes 5.0")
-  public init() throws {} // NEGATIVE-NOT: :[[@LINE]]:{{.+}}error
+  @available(swift 6.0)
+  @available(*, deprecated, message: "yes 6.0")
+  public init() throws {}
 
-  @available(swift, obsoleted: 5.0)
-  @available(*, deprecated, message: "not 5.0")
-  public init() {} // NEGATIVE-NOT: :[[@LINE]]:{{.+}}error
+  @available(swift, obsoleted: 6.0)
+  @available(*, deprecated, message: "not 6.0")
+  public init() {}
 
-  @available(swift 5.0)
-  @available(*, deprecated, message: "yes 5.0")
-  public static func foo() throws {} // NEGATIVE-NOT: :[[@LINE]]:{{.+}}error
+  @available(swift 6.0)
+  @available(*, deprecated, message: "yes 6.0")
+  public static func foo() throws {}
 
-  @available(swift, obsoleted: 5.0)
-  @available(*, deprecated, message: "not 5.0")
-  public static func foo() {} // NEGATIVE-NOT: :[[@LINE]]:{{.+}}error
+  @available(swift, obsoleted: 6.0)
+  @available(*, deprecated, message: "not 6.0")
+  public static func foo() {}
+
+  static func test() throws {
+    _ = NonThrowingToThrowingReversed() // expected-swift5-warning {{not 6.0}} expected-swift6-warning {{yes 6.0}}
+    // expected-swift6-error@-1 {{call can throw but is not marked with 'try'}}
+    // expected-swift6-note@-2 {{did you mean to use 'try'?}}
+    // expected-swift6-note@-3 {{did you mean to handle error as optional value?}}
+    // expected-swift6-note@-4 {{did you mean to disable error propagation?}}
+    _ = NonThrowingToThrowingReversed.foo() // expected-warning {{using '_' to ignore the result of a Void-returning function is redundant}} expected-swift5-warning {{not 6.0}} expected-swift6-warning {{yes 6.0}}
+    // expected-swift6-error@-1 {{call can throw but is not marked with 'try'}}
+    // expected-swift6-note@-2 {{did you mean to use 'try'?}}
+    // expected-swift6-note@-3 {{did you mean to handle error as optional value?}}
+    // expected-swift6-note@-4 {{did you mean to disable error propagation?}}
+  }
+
+  @available(swift, obsoleted: 6.0)
+  func testObsoleted() throws {
+    _ = NonThrowingToThrowingReversed() // expected-swift5-warning {{not 6.0}} expected-swift6-warning {{yes 6.0}}
+    // expected-swift6-error@-1 {{call can throw but is not marked with 'try'}}
+    // expected-swift6-note@-2 {{did you mean to use 'try'?}}
+    // expected-swift6-note@-3 {{did you mean to handle error as optional value?}}
+    // expected-swift6-note@-4 {{did you mean to disable error propagation?}}
+    _ = NonThrowingToThrowingReversed.foo() // expected-warning {{using '_' to ignore the result of a Void-returning function is redundant}} expected-swift5-warning {{not 6.0}} expected-swift6-warning {{yes 6.0}}
+    // expected-swift6-error@-1 {{call can throw but is not marked with 'try'}}
+    // expected-swift6-note@-2 {{did you mean to use 'try'?}}
+    // expected-swift6-note@-3 {{did you mean to handle error as optional value?}}
+    // expected-swift6-note@-4 {{did you mean to disable error propagation?}}
+  }
 }
-
-_ = NonThrowingToThrowingReversed()
-// CHECK-4: :[[@LINE-1]]:{{.+}} not 5.0
-// CHECK-5: :[[@LINE-2]]:{{.+}} yes 5.0
-_ = NonThrowingToThrowingReversed.foo()
-// CHECK-4: :[[@LINE-1]]:{{.+}} not 5.0
-// CHECK-5: :[[@LINE-2]]:{{.+}} yes 5.0
-
 
 class ThrowingToNonThrowing {
-  @available(swift, obsoleted: 5.0)
-  @available(*, deprecated, message: "not 5.0")
-  public init() throws {} // NEGATIVE-NOT: :[[@LINE]]:{{.+}}error
+  @available(swift, obsoleted: 6.0)
+  @available(*, deprecated, message: "not 6.0")
+  public init() throws {}
 
-  @available(swift 5.0)
-  @available(*, deprecated, message: "yes 5.0")
-  public init() {} // NEGATIVE-NOT: :[[@LINE]]:{{.+}}error
+  @available(swift 6.0)
+  @available(*, deprecated, message: "yes 6.0")
+  public init() {}
 
-  @available(swift, obsoleted: 5.0)
-  @available(*, deprecated, message: "not 5.0")
-  public static func foo() throws {} // NEGATIVE-NOT: :[[@LINE]]:{{.+}}error
+  @available(swift, obsoleted: 6.0)
+  @available(*, deprecated, message: "not 6.0")
+  public static func foo() throws {}
 
-  @available(swift 5.0)
-  @available(*, deprecated, message: "yes 5.0")
-  public static func foo() {} // NEGATIVE-NOT: :[[@LINE]]:{{.+}}error
+  @available(swift 6.0)
+  @available(*, deprecated, message: "yes 6.0")
+  public static func foo() {}
+
+  static func test() throws {
+    _ = ThrowingToNonThrowing() // expected-swift5-warning {{not 6.0}} expected-swift6-warning {{yes 6.0}}
+    // expected-swift5-error@-1 {{call can throw but is not marked with 'try'}}
+    // expected-swift5-note@-2 {{did you mean to use 'try'?}}
+    // expected-swift5-note@-3 {{did you mean to handle error as optional value?}}
+    // expected-swift5-note@-4 {{did you mean to disable error propagation?}}
+    _ = ThrowingToNonThrowing.foo() // expected-warning {{using '_' to ignore the result of a Void-returning function is redundant}} expected-swift5-warning {{not 6.0}} expected-swift6-warning {{yes 6.0}}
+    // expected-swift5-error@-1 {{call can throw but is not marked with 'try'}}
+    // expected-swift5-note@-2 {{did you mean to use 'try'?}}
+    // expected-swift5-note@-3 {{did you mean to handle error as optional value?}}
+    // expected-swift5-note@-4 {{did you mean to disable error propagation?}}
+  }
+
+  @available(swift, obsoleted: 6.0)
+  func testObsoleted() throws {
+    _ = ThrowingToNonThrowing() // expected-swift5-warning {{not 6.0}} expected-swift6-warning {{yes 6.0}}
+    // expected-swift5-error@-1 {{call can throw but is not marked with 'try'}}
+    // expected-swift5-note@-2 {{did you mean to use 'try'?}}
+    // expected-swift5-note@-3 {{did you mean to handle error as optional value?}}
+    // expected-swift5-note@-4 {{did you mean to disable error propagation?}}
+    _ = ThrowingToNonThrowing.foo() // expected-warning {{using '_' to ignore the result of a Void-returning function is redundant}} expected-swift5-warning {{not 6.0}} expected-swift6-warning {{yes 6.0}}
+    // expected-swift5-error@-1 {{call can throw but is not marked with 'try'}}
+    // expected-swift5-note@-2 {{did you mean to use 'try'?}}
+    // expected-swift5-note@-3 {{did you mean to handle error as optional value?}}
+    // expected-swift5-note@-4 {{did you mean to disable error propagation?}}
+  }
 }
-
-_ = ThrowingToNonThrowing()
-// CHECK-4: :[[@LINE-1]]:{{.+}} not 5.0
-// CHECK-5: :[[@LINE-2]]:{{.+}} yes 5.0
-_ = ThrowingToNonThrowing.foo()
-// CHECK-4: :[[@LINE-1]]:{{.+}} not 5.0
-// CHECK-5: :[[@LINE-2]]:{{.+}} yes 5.0
 
 class ThrowingToNonThrowingReversed {
-  @available(swift 5.0)
-  @available(*, deprecated, message: "yes 5.0")
-  public init() {} // NEGATIVE-NOT: :[[@LINE]]:{{.+}}error
+  @available(swift 6.0)
+  @available(*, deprecated, message: "yes 6.0")
+  public init() {}
 
-  @available(swift, obsoleted: 5.0)
-  @available(*, deprecated, message: "not 5.0")
-  public init() throws {} // NEGATIVE-NOT: :[[@LINE]]:{{.+}}error
+  @available(swift, obsoleted: 6.0)
+  @available(*, deprecated, message: "not 6.0")
+  public init() throws {}
 
-  @available(swift 5.0)
-  @available(*, deprecated, message: "yes 5.0")
-  public static func foo() {} // NEGATIVE-NOT: :[[@LINE]]:{{.+}}error
+  @available(swift 6.0)
+  @available(*, deprecated, message: "yes 6.0")
+  public static func foo() {}
 
-  @available(swift, obsoleted: 5.0)
-  @available(*, deprecated, message: "not 5.0")
-  public static func foo() throws {} // NEGATIVE-NOT: :[[@LINE]]:{{.+}}error
+  @available(swift, obsoleted: 6.0)
+  @available(*, deprecated, message: "not 6.0")
+  public static func foo() throws {}
+
+  static func test() throws {
+    _ = ThrowingToNonThrowingReversed() // expected-swift5-warning {{not 6.0}} expected-swift6-warning {{yes 6.0}}
+    // expected-swift5-error@-1 {{call can throw but is not marked with 'try'}}
+    // expected-swift5-note@-2 {{did you mean to use 'try'?}}
+    // expected-swift5-note@-3 {{did you mean to handle error as optional value?}}
+    // expected-swift5-note@-4 {{did you mean to disable error propagation?}}
+    _ = ThrowingToNonThrowingReversed.foo() // expected-warning {{using '_' to ignore the result of a Void-returning function is redundant}} expected-swift5-warning {{not 6.0}} expected-swift6-warning {{yes 6.0}}
+    // expected-swift5-error@-1 {{call can throw but is not marked with 'try'}}
+    // expected-swift5-note@-2 {{did you mean to use 'try'?}}
+    // expected-swift5-note@-3 {{did you mean to handle error as optional value?}}
+    // expected-swift5-note@-4 {{did you mean to disable error propagation?}}
+  }
+
+  @available(swift, obsoleted: 6.0)
+  func testObsoleted() throws {
+    _ = ThrowingToNonThrowingReversed() // expected-swift5-warning {{not 6.0}} expected-swift6-warning {{yes 6.0}}
+    // expected-swift5-error@-1 {{call can throw but is not marked with 'try'}}
+    // expected-swift5-note@-2 {{did you mean to use 'try'?}}
+    // expected-swift5-note@-3 {{did you mean to handle error as optional value?}}
+    // expected-swift5-note@-4 {{did you mean to disable error propagation?}}
+    _ = ThrowingToNonThrowingReversed.foo() // expected-warning {{using '_' to ignore the result of a Void-returning function is redundant}} expected-swift5-warning {{not 6.0}} expected-swift6-warning {{yes 6.0}}
+    // expected-swift5-error@-1 {{call can throw but is not marked with 'try'}}
+    // expected-swift5-note@-2 {{did you mean to use 'try'?}}
+    // expected-swift5-note@-3 {{did you mean to handle error as optional value?}}
+    // expected-swift5-note@-4 {{did you mean to disable error propagation?}}
+  }
 }
-
-_ = ThrowingToNonThrowingReversed()
-// CHECK-4: :[[@LINE-1]]:{{.+}} not 5.0
-// CHECK-5: :[[@LINE-2]]:{{.+}} yes 5.0
-_ = ThrowingToNonThrowingReversed.foo()
-// CHECK-4: :[[@LINE-1]]:{{.+}} not 5.0
-// CHECK-5: :[[@LINE-2]]:{{.+}} yes 5.0
 
 class ChangePropertyType {
 
   // We don't allow this for stored properties.
 
-  @available(swift 5.0)
-  @available(*, deprecated, message: "yes 5.0")
-  public var stored: Int16 = 0
+  @available(swift 6.0) // expected-swift5-error {{stored properties cannot be marked unavailable with '@available'}}
+  @available(*, deprecated, message: "yes 6.0")
+  public var stored: Int16 = 0 // expected-note {{'stored' previously declared here}}
 
-  @available(swift, obsoleted: 5.0)
-  @available(*, deprecated, message: "not 5.0")
-  public var stored: Int8 = 0 // CHECK: :[[@LINE]]:{{.+}} error: invalid redeclaration of 'stored'
+  @available(swift, obsoleted: 6.0) // expected-swift6-error {{stored properties cannot be marked unavailable with '@available'}}
+  @available(*, deprecated, message: "not 6.0")
+  public var stored: Int8 = 0 // expected-error {{invalid redeclaration of 'stored'}}
 
   // OK for computed properties.
 
-  @available(swift 5.0)
-  @available(*, deprecated, message: "yes 5.0")
+  @available(swift 6.0)
+  @available(*, deprecated, message: "yes 6.0")
   public var computed: Int16 { get { } set { } }
 
-  @available(swift, obsoleted: 5.0)
-  @available(*, deprecated, message: "not 5.0")
-  public var computed: Int8 { get { } set { } } // NEGATIVE-NOT: :[[@LINE]]:{{.+}}error
+  @available(swift, obsoleted: 6.0)
+  @available(*, deprecated, message: "not 6.0")
+  public var computed: Int8 { get { } set { } }
+
+  func test() {
+    _ = computed // expected-swift5-warning {{not 6.0}} expected-swift6-warning {{yes 6.0}}
+  }
+
+  @available(swift, obsoleted: 6.0)
+  func testObsoleted() {
+    _ = computed // expected-swift5-warning {{not 6.0}} expected-swift6-warning {{yes 6.0}}
+  }
 }
 
-_ = ChangePropertyType().computed
-// CHECK-4: :[[@LINE-1]]:{{.+}} not 5.0
-// CHECK-5: :[[@LINE-2]]:{{.+}} yes 5.0
+class ExtendMe { }
+
+extension ExtendMe {
+  @available(swift 6.0)
+  @available(*, deprecated, message: "yes 6.0")
+  public func bar() -> Int16 {} // expected-swift6-note {{found this candidate}}
+
+  @available(swift, obsoleted: 6.0)
+  @available(*, deprecated, message: "not 6.0")
+  public func bar() -> Int8 {} // expected-swift6-note {{found this candidate}}
+
+  func test() {
+    _ = bar() // expected-swift5-warning {{not 6.0}} expected-swift6-warning {{yes 6.0}}
+  }
+
+  @available(swift, obsoleted: 6.0)
+  func testObsoleted() {
+    _ = bar() // expected-swift5-warning {{not 6.0}}
+    // FIXME: This should not be ambiguous
+    // expected-swift6-error@-2 {{ambiguous use of 'bar()'}}
+  }
+}

--- a/test/Availability/availability_swift_language_mode.swift
+++ b/test/Availability/availability_swift_language_mode.swift
@@ -440,11 +440,11 @@ class ExtendMe { }
 extension ExtendMe {
   @available(swift 6.0)
   @available(*, deprecated, message: "yes 6.0")
-  public func bar() -> Int16 {} // expected-swift6-note {{found this candidate}}
+  public func bar() -> Int16 {}
 
   @available(swift, obsoleted: 6.0)
   @available(*, deprecated, message: "not 6.0")
-  public func bar() -> Int8 {} // expected-swift6-note {{found this candidate}}
+  public func bar() -> Int8 {}
 
   func test() {
     _ = bar() // expected-swift5-warning {{not 6.0}} expected-swift6-warning {{yes 6.0}}
@@ -452,8 +452,6 @@ extension ExtendMe {
 
   @available(swift, obsoleted: 6.0)
   func testObsoleted() {
-    _ = bar() // expected-swift5-warning {{not 6.0}}
-    // FIXME: This should not be ambiguous
-    // expected-swift6-error@-2 {{ambiguous use of 'bar()'}}
+    _ = bar() // expected-swift5-warning {{not 6.0}} expected-swift6-warning {{yes 6.0}}
   }
 }

--- a/test/SILGen/Inputs/availability_overloads_other.swift
+++ b/test/SILGen/Inputs/availability_overloads_other.swift
@@ -1,31 +1,39 @@
 public class BeforeAndAfterOther {
-  @available(swift, obsoleted: 5.0)
+  @available(swift, obsoleted: 6.0)
   public init(foo: ()) {}
 
-  @available(swift 5.0)
+  @available(swift 6.0)
   public init?(foo: ()) {}
 
-  @available(swift, obsoleted: 5.0)
+  @available(swift, obsoleted: 6.0)
   public init() {}
 
-  @available(swift 5.0)
+  @available(swift 6.0)
   public init() throws {}
 
-  @available(swift, obsoleted: 5.0)
+  @available(swift, obsoleted: 6.0)
   public static func foo() {}
 
-  @available(swift 5.0)
+  @available(swift 6.0)
   public static func foo() throws {}
 
-  @available(swift 5.0)
+  @available(swift 6.0)
   public var computed: Int16 { get { return 0 } set { } }
 
-  @available(swift, obsoleted: 5.0)
+  @available(swift, obsoleted: 6.0)
   public var computed: Int8 { get { return 0 } set { } }
 
-  @available(swift 5.0)
+  @available(swift 6.0)
   public static var computed: Int16 { get { return 0 } set { } }
 
-  @available(swift, obsoleted: 5.0)
+  @available(swift, obsoleted: 6.0)
   public static var computed: Int8 { get { return 0 } set { } }
+}
+
+extension BeforeAndAfterOther {
+  @available(swift, obsoleted: 6.0)
+  public func bar() {}
+
+  @available(swift 6.0)
+  public func bar() throws {}
 }

--- a/test/SILGen/availability_overloads.swift
+++ b/test/SILGen/availability_overloads.swift
@@ -114,8 +114,9 @@ public func testLocalObsoleted(_ b: BeforeAndAfter) throws {
   // CHECK-SWIFT-5:  class_method {{.*}}, #BeforeAndAfter.computed!setter : (BeforeAndAfter) -> (Int8) -> ()
   // CHECK-SWIFT-6:  class_method {{.*}}, #BeforeAndAfter.computed!setter : (BeforeAndAfter) -> (Int16) -> ()
   try BeforeAndAfter().computed = 10
-  // FIXME: Should not be diagnosed as ambiguous
-//  try b.bar()
+  // CHECK-SWIFT-5:  function_ref @$s22availability_overloads14BeforeAndAfterC3baryyF
+  // CHECK-SWIFT-6:  function_ref @$s22availability_overloads14BeforeAndAfterC3baryyKF
+  try b.bar()
 }
 // CHECK: } // end sil function '$s22availability_overloads18testLocalObsoletedyyAA14BeforeAndAfterCKF'
 

--- a/test/SILGen/availability_overloads.swift
+++ b/test/SILGen/availability_overloads.swift
@@ -1,14 +1,14 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module-path %t/availability_overloads_other.swiftmodule -emit-module -primary-file %S/Inputs/availability_overloads_other.swift
 
-// RUN: %target-swift-emit-silgen -swift-version 4 -I %t -primary-file %s
-// RUN: %target-swift-emit-ir -swift-version 4 -I %t %s
-
-// RUN: %target-swift-emit-silgen -swift-version 5 -I %t -primary-file %s
+// RUN: %target-swift-emit-silgen -swift-version 5 -I %t -primary-file %s | %FileCheck %s --check-prefixes=CHECK,CHECK-SWIFT-5
 // RUN: %target-swift-emit-ir -swift-version 5 -I %t %s
 
-// RUN: %target-swift-frontend -swift-version 4 -I %t -emit-module -emit-module-path /dev/null -primary-file %s
+// RUN: %target-swift-emit-silgen -swift-version 6 -I %t -primary-file %s | %FileCheck %s --check-prefixes=CHECK,CHECK-SWIFT-6
+// RUN: %target-swift-emit-ir -swift-version 6 -I %t %s
+
 // RUN: %target-swift-frontend -swift-version 5 -I %t -emit-module -emit-module-path /dev/null -primary-file %s
+// RUN: %target-swift-frontend -swift-version 6 -I %t -emit-module -emit-module-path /dev/null -primary-file %s
 
 // This is a "don't crash with duplicate definition errors" test.
 // We care about being able to express each of these "redeclarations" when the
@@ -19,67 +19,132 @@ import availability_overloads_other
 // FIXME: What about method overrides and protocol witnesses?
 
 public class BeforeAndAfter {
-  @available(swift, obsoleted: 4.0)
+  @available(swift, obsoleted: 6.0)
   public init(foo: ()) {}
 
-  @available(swift 4.0)
+  @available(swift 6.0)
   public init?(foo: ()) {}
 
-  @available(swift, obsoleted: 4.0)
+  @available(swift, obsoleted: 6.0)
   public init() {}
 
-  @available(swift 4.0)
+  @available(swift 6.0)
   public init() throws {}
 
-  @available(swift, obsoleted: 4.0)
+  @available(swift, obsoleted: 6.0)
   public static func foo() {}
 
-  @available(swift 4.0)
+  @available(swift 6.0)
   public static func foo() throws {}
 
-  @available(swift 4.0)
+  @available(swift 6.0)
   public var computed: Int16 { get { return 0 } set { } }
 
-  @available(swift, obsoleted: 4.0)
+  @available(swift, obsoleted: 6.0)
   public var computed: Int8 { get { return 0 } set { } }
 
-  @available(swift 4.0)
+  @available(swift 6.0)
   public static var computed: Int16 { get { return 0 } set { } }
 
-  @available(swift, obsoleted: 4.0)
+  @available(swift, obsoleted: 6.0)
   public static var computed: Int8 { get { return 0 } set { } }
 }
 
+extension BeforeAndAfter {
+  @available(swift, obsoleted: 6.0)
+  public func bar() {}
+
+  @available(swift 6.0)
+  public func bar() throws {}
+}
 
 // Make sure we can generate calls to these overloads, too
-public func testLocal() throws {
+// CHECK-LABEL: sil{{.*}} @$s22availability_overloads9testLocalyyAA14BeforeAndAfterCKF
+public func testLocal(_ b: BeforeAndAfter) throws {
+  // CHECK-SWIFT-5:  function_ref @$s22availability_overloads14BeforeAndAfterC3fooACyt_tcfC
+  // CHECK-SWIFT-6:  function_ref @$s22availability_overloads14BeforeAndAfterC3fooACSgyt_tcfC
   _ = BeforeAndAfter(foo: ())
+  // CHECK-SWIFT-5:  function_ref @$s22availability_overloads14BeforeAndAfterCACycfC
+  // CHECK-SWIFT-6:  function_ref @$s22availability_overloads14BeforeAndAfterCACyKcfC
   _ = try BeforeAndAfter()
+  // CHECK-SWIFT-5:  function_ref @$s22availability_overloads14BeforeAndAfterC3fooyyFZ
+  // CHECK-SWIFT-6:  function_ref @$s22availability_overloads14BeforeAndAfterC3fooyyKFZ
   _ = try BeforeAndAfter.foo()
+  // CHECK-SWIFT-5:  function_ref @$s22availability_overloads14BeforeAndAfterC8computeds4Int8VvgZ
+  // CHECK-SWIFT-6:  function_ref @$s22availability_overloads14BeforeAndAfterC8computeds5Int16VvgZ
   _ = BeforeAndAfter.computed
+  // CHECK-SWIFT-5:  function_ref @$s22availability_overloads14BeforeAndAfterC8computeds4Int8VvsZ
+  // CHECK-SWIFT-6:  function_ref @$s22availability_overloads14BeforeAndAfterC8computeds5Int16VvsZ
   BeforeAndAfter.computed = 10
+  // CHECK-SWIFT-5:  class_method {{.*}}, #BeforeAndAfter.computed!getter : (BeforeAndAfter) -> () -> Int8
+  // CHECK-SWIFT-6:  class_method {{.*}}, #BeforeAndAfter.computed!getter : (BeforeAndAfter) -> () -> Int16
   _ = try BeforeAndAfter().computed
+  // CHECK-SWIFT-5:  class_method {{.*}}, #BeforeAndAfter.computed!setter : (BeforeAndAfter) -> (Int8) -> ()
+  // CHECK-SWIFT-6:  class_method {{.*}}, #BeforeAndAfter.computed!setter : (BeforeAndAfter) -> (Int16) -> ()
   try BeforeAndAfter().computed = 10
+  // CHECK-SWIFT-5:  function_ref @$s22availability_overloads14BeforeAndAfterC3baryyF
+  // CHECK-SWIFT-6:  function_ref @$s22availability_overloads14BeforeAndAfterC3baryyKF
+  try b.bar()
 }
+// CHECK: } // end sil function '$s22availability_overloads9testLocalyyAA14BeforeAndAfterCKF'
 
-@available(swift, obsoleted: 4.0)
-public func testLocalObsoleted() throws {
+// Overload selection in a function that is itself obsoleted in swift 6.0 should
+// still be based on the current swift version.
+// CHECK-LABEL: sil{{.*}} @$s22availability_overloads18testLocalObsoletedyyAA14BeforeAndAfterCKF
+@available(swift, obsoleted: 6.0)
+public func testLocalObsoleted(_ b: BeforeAndAfter) throws {
+  // CHECK-SWIFT-5:  function_ref @$s22availability_overloads14BeforeAndAfterC3fooACyt_tcfC
+  // CHECK-SWIFT-6:  function_ref @$s22availability_overloads14BeforeAndAfterC3fooACSgyt_tcfC
   _ = BeforeAndAfter(foo: ())
+  // CHECK-SWIFT-5:  function_ref @$s22availability_overloads14BeforeAndAfterCACycfC
+  // CHECK-SWIFT-6:  function_ref @$s22availability_overloads14BeforeAndAfterCACyKcfC
   _ = try BeforeAndAfter()
+  // CHECK-SWIFT-5:  function_ref @$s22availability_overloads14BeforeAndAfterC3fooyyFZ
+  // CHECK-SWIFT-6:  function_ref @$s22availability_overloads14BeforeAndAfterC3fooyyKFZ
   _ = try BeforeAndAfter.foo()
+  // CHECK-SWIFT-5:  function_ref @$s22availability_overloads14BeforeAndAfterC8computeds4Int8VvgZ
+  // CHECK-SWIFT-6:  function_ref @$s22availability_overloads14BeforeAndAfterC8computeds5Int16VvgZ
   _ = BeforeAndAfter.computed
+  // CHECK-SWIFT-5:  function_ref @$s22availability_overloads14BeforeAndAfterC8computeds4Int8VvsZ
+  // CHECK-SWIFT-6:  function_ref @$s22availability_overloads14BeforeAndAfterC8computeds5Int16VvsZ
   BeforeAndAfter.computed = 10
+  // CHECK-SWIFT-5:  class_method {{.*}}, #BeforeAndAfter.computed!getter : (BeforeAndAfter) -> () -> Int8
+  // CHECK-SWIFT-6:  class_method {{.*}}, #BeforeAndAfter.computed!getter : (BeforeAndAfter) -> () -> Int16
   _ = try BeforeAndAfter().computed
+  // CHECK-SWIFT-5:  class_method {{.*}}, #BeforeAndAfter.computed!setter : (BeforeAndAfter) -> (Int8) -> ()
+  // CHECK-SWIFT-6:  class_method {{.*}}, #BeforeAndAfter.computed!setter : (BeforeAndAfter) -> (Int16) -> ()
   try BeforeAndAfter().computed = 10
+  // FIXME: Should not be diagnosed as ambiguous
+//  try b.bar()
 }
+// CHECK: } // end sil function '$s22availability_overloads18testLocalObsoletedyyAA14BeforeAndAfterCKF'
 
 // Same thing but in a different module
-public func testOtherModule() throws {
+// CHECK-LABEL: sil{{.*}} @$s22availability_overloads15testOtherModuleyy0a1_B6_other014BeforeAndAfterD0CKF
+public func testOtherModule(_ b: BeforeAndAfterOther) throws {
+  // CHECK-SWIFT-5:  function_ref @$s28availability_overloads_other19BeforeAndAfterOtherC3fooACyt_tcfC
+  // CHECK-SWIFT-6:  function_ref @$s28availability_overloads_other19BeforeAndAfterOtherC3fooACSgyt_tcfC
   _ = BeforeAndAfterOther(foo: ())
+  // CHECK-SWIFT-5:  function_ref @$s28availability_overloads_other19BeforeAndAfterOtherCACycfC
+  // CHECK-SWIFT-6:  function_ref @$s28availability_overloads_other19BeforeAndAfterOtherCACyKcfC
   _ = try BeforeAndAfterOther()
+  // CHECK-SWIFT-5:  function_ref @$s28availability_overloads_other19BeforeAndAfterOtherC3fooyyFZ
+  // CHECK-SWIFT-6:  function_ref @$s28availability_overloads_other19BeforeAndAfterOtherC3fooyyKFZ
   _ = try BeforeAndAfterOther.foo()
+  // CHECK-SWIFT-5:  function_ref @$s28availability_overloads_other19BeforeAndAfterOtherC8computeds4Int8VvgZ
+  // CHECK-SWIFT-6:  function_ref @$s28availability_overloads_other19BeforeAndAfterOtherC8computeds5Int16VvgZ
   _ = BeforeAndAfterOther.computed
+  // CHECK-SWIFT-5:  function_ref @$s28availability_overloads_other19BeforeAndAfterOtherC8computeds4Int8VvsZ
+  // CHECK-SWIFT-6:  function_ref @$s28availability_overloads_other19BeforeAndAfterOtherC8computeds5Int16VvsZ
   BeforeAndAfterOther.computed = 10
+  // CHECK-SWIFT-5:  class_method {{.*}}, #BeforeAndAfterOther.computed!getter : (BeforeAndAfterOther) -> () -> Int8, $@convention(method) (@guaranteed BeforeAndAfterOther) -> Int8
+  // CHECK-SWIFT-6:  class_method {{.*}}, #BeforeAndAfterOther.computed!getter : (BeforeAndAfterOther) -> () -> Int16, $@convention(method) (@guaranteed BeforeAndAfterOther) -> Int16
   _ = try BeforeAndAfterOther().computed
+  // CHECK-SWIFT-5:  class_method {{.*}}, #BeforeAndAfterOther.computed!setter : (BeforeAndAfterOther) -> (Int8) -> ()
+  // CHECK-SWIFT-6:  class_method {{.*}}, #BeforeAndAfterOther.computed!setter : (BeforeAndAfterOther) -> (Int16) -> ()
   try BeforeAndAfterOther().computed = 10
+  // CHECK-SWIFT-5:  function_ref @$s28availability_overloads_other19BeforeAndAfterOtherC3baryyF
+  // CHECK-SWIFT-6:  function_ref @$s28availability_overloads_other19BeforeAndAfterOtherC3baryyKF
+  try b.bar()
 }
+// CHECK: } // end sil function '$s22availability_overloads15testOtherModuleyy0a1_B6_other014BeforeAndAfterD0CKF'


### PR DESCRIPTION
- **Explanation:** Fixes a Swift 6.3 regression in which extension members that are obsolete in the current Swift language version were considered available in contexts that are also obsolete in the current Swift language version. This could lead to surprising behavior, like infinite recursion, in some source code.
- **Scope:** Affects code that marks members of extensions unavailable universally or in a specific Swift language mode, e.g. `@available(*, unavailable)` or `@available(swift, obsoleted: 4)`.
- **Issue/Radar:** rdar://165942115 
- **Original PR:** https://github.com/swiftlang/swift/pull/88942
- **Risk:** Since this closes  could break source compatibility.
- **Testing:** New compiler tests.
- **Reviewer:** @xedin 