### PR TITLE
[cxx-interop] Fix assertion for enums of type char32_t

### DIFF
--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -1087,7 +1087,13 @@ namespace {
           return Impl.getNamedSwiftType(Impl.getStdlibModule(), "Int");
 
         // Import the underlying integer type.
-        return Visit(clangDecl->getIntegerType());
+        auto result = Visit(clangDecl->getIntegerType());
+        // Unicode.Scalar (from char32_t or wchar_t) doesn't conform to
+        // _ExpressibleByBuiltinIntegerLiteral, which is required for enum
+        // constant values. Use UInt32 instead.
+        if (result.AbstractType && result.AbstractType->isUnicodeScalar())
+          return Impl.SwiftContext.getUInt32Type();
+        return result;
       }
       case EnumKind::NonFrozenEnum:
       case EnumKind::FrozenEnum:
@@ -1721,6 +1727,12 @@ static ImportedType adjustTypeForConcreteImport(
   }
 
   assert(importedType);
+
+  // When Unicode.Scalar (from char32_t or wchar_t) is used as an enum's
+  // underlying type, import as UInt32 instead. Unicode.Scalar doesn't conform
+  // to _ExpressibleByBuiltinIntegerLiteral, which is required for enum cases.
+  if (importKind == ImportTypeKind::Enum && importedType->isUnicodeScalar())
+    importedType = impl.SwiftContext.getUInt32Type();
 
   if (importKind == ImportTypeKind::RecordField &&
       !importedType->isForeignReferenceType()) {

--- a/test/Interop/Cxx/enum/Inputs/scoped-enums.h
+++ b/test/Interop/Cxx/enum/Inputs/scoped-enums.h
@@ -19,3 +19,16 @@ enum class ScopedEnumInt : int { x, y, z };
 enum class ScopedEnumNegativeElement : int { x = -1, y = 0, z = 2 };
 
 enum class MiddleDefinedScopedEnum { x, y = 42, z };
+
+enum class ScopedEnumChar32 : char32_t { x = 0, y = 42 };
+
+enum class ScopedEnumChar16 : char16_t { a = 0, b = 1 };
+
+enum class ScopedEnumWChar : wchar_t { x = 0, y = 7 };
+
+struct HasChar32Enum {
+  enum : char32_t {
+    ok = 0,
+    error = 1
+  } status;
+};

--- a/test/Interop/Cxx/enum/scoped-enums-module-interface.swift
+++ b/test/Interop/Cxx/enum/scoped-enums-module-interface.swift
@@ -85,3 +85,19 @@
 // CHECK:   case y
 // CHECK:   case z
 // CHECK: }
+
+// CHECK: enum ScopedEnumChar32 : UInt32 {
+// CHECK:   init?(rawValue: UInt32)
+// CHECK:   var rawValue: UInt32 { get }
+// CHECK:   typealias RawValue = UInt32
+// CHECK:   case x
+// CHECK:   case y
+// CHECK: }
+
+// CHECK: enum ScopedEnumChar16 : UInt16 {
+// CHECK:   init?(rawValue: UInt16)
+// CHECK:   var rawValue: UInt16 { get }
+// CHECK:   typealias RawValue = UInt16
+// CHECK:   case a
+// CHECK:   case b
+// CHECK: }

--- a/test/Interop/Cxx/enum/scoped-enums.swift
+++ b/test/Interop/Cxx/enum/scoped-enums.swift
@@ -40,4 +40,26 @@ ScopedEnumsTestSuite.test("Make and compare (MiddleDefinedScopedEnum)") {
   expectEqual(MiddleDefinedScopedEnum(rawValue: 43), .z)
 }
 
+ScopedEnumsTestSuite.test("Make and compare (ScopedEnumChar32)") {
+  let val: ScopedEnumChar32 = .x
+  expectEqual(val.rawValue, 0)
+  expectEqual(ScopedEnumChar32(rawValue: 42), .y)
+  expectNotEqual(ScopedEnumChar32(rawValue: 0), .y)
+}
+
+ScopedEnumsTestSuite.test("Make and compare (ScopedEnumChar16)") {
+  let val: ScopedEnumChar16 = .a
+  expectEqual(val.rawValue, 0)
+  expectEqual(ScopedEnumChar16(rawValue: 1), .b)
+}
+
+#if !os(Windows)
+ScopedEnumsTestSuite.test("Make and compare (ScopedEnumWChar)") {
+  let val: ScopedEnumWChar = .x
+  expectEqual(val.rawValue, 0)
+  expectEqual(ScopedEnumWChar(rawValue: 7), .y)
+  expectNotEqual(ScopedEnumWChar(rawValue: 0), .y)
+}
+#endif
+
 runAllTests()


### PR DESCRIPTION
`enum XYZ : char32_t` was triggering an assertion failure in the Swift compiler. Swift expects all underlying enum types to be `ExpressibleByBuiltinIntegerLiteral`. `char32_t` was imported as `Unicode.Scalar`, which doesn't conform.

This replaces `Unicode.Scalar` with `UInt32` whenever it is used as the underlying type of a C++ enum.

rdar://148336856 / resolves https://github.com/swiftlang/swift/issues/80436

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
