### PR TITLE
[SILGen] Set correct isolation on thunks that reabstract into `noniso…

### DIFF
--- a/lib/SILGen/SILGenThunk.cpp
+++ b/lib/SILGen/SILGenThunk.cpp
@@ -647,11 +647,18 @@ getOrCreateReabstractionThunk(CanSILFunctionType thunkType,
       ? IsSerialized : IsNotSerialized;
   }
 
+  auto isolation = ActorIsolation::forUnspecified();
+
+  // The isolation of the thunk should match that of its type
+  // otherwise it could lead to incorrect decision optimizations.
+  if (thunkType->hasNonisolatedNonsendingIsolation())
+    isolation = ActorIsolation::forNonisolatedNonsending();
+
   SILGenFunctionBuilder builder(*this);
   return builder.getOrCreateSharedFunction(
-      loc, name, thunkDeclType, ActorIsolation::forUnspecified(), IsBare,
-      IsTransparent, serializable, ProfileCounter(), IsReabstractionThunk,
-      IsNotDynamic, IsNotDistributed, IsNotRuntimeAccessible);
+      loc, name, thunkDeclType, isolation, IsBare, IsTransparent, serializable,
+      ProfileCounter(), IsReabstractionThunk, IsNotDynamic, IsNotDistributed,
+      IsNotRuntimeAccessible);
 }
 
 SILFunction *SILGenModule::getOrCreateDerivativeVTableThunk(

--- a/test/Concurrency/nonisolated_nonsending.swift
+++ b/test/Concurrency/nonisolated_nonsending.swift
@@ -26,7 +26,8 @@ func testPartialApplication(p: [any P]) async {
 //   Reabstraction thunk from caller-isolated () -> () to caller-isolated () -> T
 // CHECK-LABEL: sil shared [transparent] [reabstraction_thunk] @$sBAIeNghHgIL_BAytIeNghHgILr_TR : $@convention(thin) @caller_isolated @Sendable @async (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, @guaranteed @caller_isolated @Sendable @async @callee_guaranteed (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor) -> ()) -> @out () {
 // CHECK:       bb0(%0 : $*(), %1 : $Builtin.ImplicitActor, %2 : $@caller_isolated @Sendable @async @callee_guaranteed (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor) -> ()):
-// CHECK-NEXT:    hop_to_executor %1
+// The hop is eliminated because the argument is `nonisolated(nonsending)`
+// CHECK-NOT:    hop_to_executor %1
 // CHECK-NEXT:    apply %2(%1) :
 
 func takesGenericAsyncFunction<T>(_ fn: nonisolated(nonsending) (T) async -> Void) {}
@@ -45,11 +46,50 @@ func testReabstractionPreservingCallerIsolation(fn: nonisolated(nonsending) (Int
 // CHECK-LABEL: sil shared [transparent] [reabstraction_thunk] @$sBASiINgHgILy_BASiIeNgHgILn_TR : $@convention(thin) @caller_isolated @async (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, @in_guaranteed Int, @guaranteed @caller_isolated @noescape @async @callee_guaranteed (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, Int) -> ()) -> () {
 // CHECK:       bb0(%0 : $Builtin.ImplicitActor, %1 : $*Int, %2 : $@caller_isolated @noescape @async @callee_guaranteed (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, Int) -> ()):
 // CHECK-NEXT:    %3 = load %1
-// CHECK-NEXT:    hop_to_executor %0
+// The hop is eliminated because the argument is `nonisolated(nonsending)`
+// CHECK-NOT:    hop_to_executor %0
 // CHECK-NEXT:    apply %2(%0, %3)
 
 func takesAsyncIsolatedAnyFunction(_ fn: @isolated(any) () async -> Void) {}
 func takesGenericAsyncIsolatedAnyFunction<T>(_ fn: @isolated(any) (T) async -> Void) {}
+
+func testReabstractionHopsBack() async throws {
+  func compute<T, R>(_ fn: nonisolated(nonsending) (T) async -> R?) async {
+  }
+
+  func computeThrowing(_ fn: nonisolated(nonsending) () async throws -> Void) async throws {
+  }
+
+  // CHECK: // thunk for @callee_guaranteed @async (@unowned Int) -> (@unowned ()?)
+  // CHECK: // Isolation: nonisolated(nonsending)
+  // CHECK: sil shared [transparent] [reabstraction_thunk] @$sSiytSgIgHyd_BASiAAIeNgHgILnr_TR : $@convention(thin) @caller_isolated @async (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, @in_guaranteed Int, @guaranteed @noescape @async @callee_guaranteed (Int) -> Optional<()>) -> @out Optional<()> {
+  // CHECK: bb0([[RESULT:%.*]] : $*Optional<()>, [[ISOLATION:%.*]] : $Builtin.ImplicitActor, [[X_REF:%.*]] : $*Int, [[CLOSURE:%.*]] : $@noescape @async @callee_guaranteed (Int) -> Optional<()>):
+  // CHECK:   [[X:%.*]] = load [[X_REF]]
+  // CHECK:   [[CLOSURE_RESULT:%.*]] = apply [[CLOSURE]]([[X]]) : $@noescape @async @callee_guaranteed (Int) -> Optional<()>
+  // CHECK:   store [[CLOSURE_RESULT]] to [[RESULT]]
+  // CHECK:   hop_to_executor [[ISOLATION]]
+  // CHECK: } // end sil function '$sSiytSgIgHyd_BASiAAIeNgHgILnr_TR'
+  await compute { @concurrent (x: Int) in
+      _ = x
+  }
+
+  struct MyError: Error {
+  }
+
+  // CHECK: // thunk for @callee_guaranteed @Sendable @async () -> (@error @owned Error)
+  // CHECK: // Isolation: nonisolated(nonsending)
+  // CHECK: sil shared [transparent] [reabstraction_thunk] @$ss5Error_pIghHzo_BAsAA_pIeNgHgILzo_TR : $@convention(thin) @caller_isolated @async (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, @guaranteed @noescape @Sendable @async @callee_guaranteed () -> @error any Error) -> @error any Error {
+  // CHECK: bb0([[ISOLATION:%.*]] : $Builtin.ImplicitActor, [[CLOSURE:%.*]] : $@noescape @Sendable @async @callee_guaranteed () -> @error any Error):
+  // CHECK:   try_apply [[CLOSURE]]() : $@noescape @Sendable @async @callee_guaranteed () -> @error any Error, normal bb1, error bb2
+  // CHECK: bb1({{.*}} : $()):
+  // CHECK:   hop_to_executor [[ISOLATION]]
+  // CHECK: bb2({{.*}} : $any Error):
+  // CHECK:   hop_to_executor [[ISOLATION]]
+  // CHECK: } // end sil function '$ss5Error_pIghHzo_BAsAA_pIeNgHgILzo_TR'
+  try await computeThrowing { @MainActor in
+      throw MyError()
+  }
+}
 
 // These would be good to test, but we apparently reject this conversion.
 #if false

--- a/test/Concurrency/nonisolated_nonsending_specialization.swift
+++ b/test/Concurrency/nonisolated_nonsending_specialization.swift
@@ -220,8 +220,10 @@ func testReabstraction(body: () async -> Void) async throws {
 // Reabstraction thunk for `testReabstraction` closure
 //
 // CHECK: // thunk for @caller_isolated @callee_guaranteed @async (@guaranteed Builtin.ImplicitActor) -> (@error @owned Error)
+// CHECK: // Isolation: nonisolated(nonsending)
 // CHECK: sil shared [transparent] [reabstraction_thunk] @$sBAs5Error_pINgHgILzo_BAytSgsAA_pIeNgHgILrzo_TR : $@convention(thin) @caller_isolated @async (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, @guaranteed @caller_isolated @noescape @async @callee_guaranteed (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor) -> @error any Error) -> (@out Optional<()>, @error any Error) {
 // CHECK: bb0(%0 : $*Optional<()>, [[ISOLATION:%.*]] : $Builtin.ImplicitActor, [[CLOSURE:%.*]] : $@caller_isolated @noescape @async @callee_guaranteed (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor) -> @error any Error):
-// CHECK:   hop_to_executor [[ISOLATION]]
+// The hop gets eliminated because the parameter is also `nonisolated(nonsending)`
+// CHECK-NOT:   hop_to_executor [[ISOLATION]]
 // CHECK:   try_apply [[CLOSURE]]([[ISOLATION]]) : $@caller_isolated @noescape @async @callee_guaranteed (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor) -> @error any Error, normal bb1, error bb2
 // CHECK: } // end sil function '$sBAs5Error_pINgHgILzo_BAytSgsAA_pIeNgHgILrzo_TR'

--- a/test/Interpreter/issue88731.swift
+++ b/test/Interpreter/issue88731.swift
@@ -1,0 +1,36 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -language-mode 6 -target %target-swift-5.1-abi-triple %s -parse-as-library -module-name main -o %t/main
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main | %FileCheck %s
+
+// REQUIRES: concurrency
+// REQUIRES: concurrency_runtime
+// REQUIRES: executable_test
+
+// UNSUPPORTED: back_deployment_runtime
+
+// https://github.com/swiftlang/swift/issues/88731
+
+@MainActor
+func compute(_ fn: nonisolated(nonsending) @Sendable () async throws -> Void) async throws {
+  try await fn()
+  assertIsMainActor()
+}
+
+func assertIsMainActor() {
+    MainActor.assumeIsolated {}
+}
+
+func performComputation() async throws {
+  let x: Int = 42
+  try await compute { [x] in
+    print(x)
+  }
+}
+
+@main struct Main {
+  static func main() async throws {
+    try await performComputation()
+    // CHECK: 42
+  }
+}

--- a/test/Interpreter/issue88993.swift
+++ b/test/Interpreter/issue88993.swift
@@ -1,0 +1,43 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -language-mode 5 -strict-concurrency=complete -target %target-swift-5.1-abi-triple %s -parse-as-library -module-name main -o %t/main
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main
+
+// REQUIRES: concurrency
+// REQUIRES: concurrency_runtime
+// REQUIRES: executable_test
+
+// UNSUPPORTED: back_deployment_runtime
+
+// https://github.com/swiftlang/swift/issues/88993
+
+actor MyActor {
+  nonisolated func perform<E: Error>(_ work: @escaping @Sendable (isolated MyActor) async throws(E) -> ()) async throws(E) {
+    try await work(self)
+  }
+}
+
+// The bug only happens if this closure is `nonisolated(nonsending)`
+typealias MigrationWorkBlock = nonisolated(nonsending) () async -> Void
+
+nonisolated struct MyOperation {
+  let actor = MyActor()
+  let migrationWork: MigrationWorkBlock
+
+  nonisolated func run() async {
+    await self.actor.perform { actor in
+      actor.assertIsolated()
+
+      await migrationWork() // nonisolated(nonsending) should hop back to the context were it was executed
+
+      actor.assertIsolated() // Ok
+    }
+  }
+}
+
+@main struct Main {
+  static func main() async throws {
+    let operation = MyOperation(migrationWork: { }) // closure here is @MainActor isolated
+    await operation.run()
+  }
+}


### PR DESCRIPTION
…lated(nonsending)`

Since SILFunctionType doesn't support a full range of isolation kinds not setting the isolation of the thunk that reabstracts a function value into a `nonisolated(nonsending)` one, results in `OptimizeHopToExecutor` incorrectly removing hops from the thunk.

In turn, at the call site, synchronous code that follows a call to `nonisolated(nonseding)` function value through a reabstraction thunk, would be executed on the isolation of the function value called by the thunk instead of returning to the caller's context.

Resolves: rdar://176709091
Resolves: https://github.com/swiftlang/swift/issues/88993

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
