### PR TITLE
Windows: split preparatory work for bootstrapping

### DIFF
--- a/Runtimes/Overlay/Android/Android/CMakeLists.txt
+++ b/Runtimes/Overlay/Android/Android/CMakeLists.txt
@@ -27,5 +27,3 @@ install(TARGETS swiftAndroid
   RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
 emit_swift_interface(swiftAndroid)
 install_swift_interface(swiftAndroid)
-
-embed_manifest(swiftAndroid)

--- a/Runtimes/Overlay/Android/Math/CMakeLists.txt
+++ b/Runtimes/Overlay/Android/Math/CMakeLists.txt
@@ -15,5 +15,3 @@ install(TARGETS swift_math
   RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
 emit_swift_interface(swift_math)
 install_swift_interface(swift_math)
-
-embed_manifest(swift_math)

--- a/Runtimes/Overlay/Linux/glibc/CMakeLists.txt
+++ b/Runtimes/Overlay/Linux/glibc/CMakeLists.txt
@@ -32,4 +32,3 @@ install(TARGETS swiftGlibc
   RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
 emit_swift_interface(swiftGlibc)
 install_swift_interface(swiftGlibc)
-embed_manifest(swiftGlibc)

--- a/Runtimes/Supplemental/StackWalker/CMakeLists.txt
+++ b/Runtimes/Supplemental/StackWalker/CMakeLists.txt
@@ -30,6 +30,7 @@ find_package(SwiftDarwin)
 endif()
 
 include(GNUInstallDirs)
+include(ResourceEmbedding)
 
 # NOTE: we disable availability checking because we need to use code from the
 # RuntimeModule, but we also need to build with an availability version below
@@ -92,3 +93,4 @@ target_link_libraries(swift-backtrace PRIVATE
 
 install(TARGETS swift-backtrace
   RUNTIME DESTINATION "${CMAKE_INSTALL_LIBEXECDIR}/swift")
+embed_version_info(swift-backtrace)

--- a/Runtimes/cmake/modules/ResourceEmbedding.cmake
+++ b/Runtimes/cmake/modules/ResourceEmbedding.cmake
@@ -30,41 +30,186 @@ function(generate_plist project_name project_version target)
   endif()
 endfunction()
 
-# FIXME: it appears that `CMAKE_MT` evaluates to an empty string which prevents
-# the use of the variable. This aliases `MT` to `CMAKE_MT` and tries to fallback
-# to known spellings for the tool.
-if(WIN32 AND BUILD_SHARED_LIBS)
-  find_program(MT HINTS ${CMAKE_MT} NAMES mt llvm-mt REQUIRED)
-endif()
+function(embed_version_info target)
+  if(NOT WIN32)
+    return()
+  endif()
 
-function(embed_manifest target)
   get_target_property(_EM_TARGET_TYPE ${target} TYPE)
   if(NOT "${_EM_TARGET_TYPE}" MATCHES "SHARED_LIBRARY|EXECUTABLE")
     return()
   endif()
 
+  cmake_parse_arguments(PARSE_ARGV 1 _EVI
+    ""
+    "FILE_DESCRIPTION;INTERNAL_NAME;ORIGINAL_FILENAME;PRODUCT_NAME"
+    "")
+
+  if(NOT _EVI_INTERNAL_NAME)
+    set(_EVI_INTERNAL_NAME "${target}")
+  endif()
+  if(NOT _EVI_FILE_DESCRIPTION)
+    set(_EVI_FILE_DESCRIPTION "${_EVI_INTERNAL_NAME}")
+  endif()
+  if(NOT _EVI_PRODUCT_NAME)
+    set(_EVI_PRODUCT_NAME "Swift")
+  endif()
+  if(NOT _EVI_ORIGINAL_FILENAME)
+    set(_EVI_ORIGINAL_FILENAME "$<TARGET_FILE_NAME:${target}>")
+  endif()
+
+  get_target_property(_EVI_BINARY_DIR ${target} BINARY_DIR)
+  get_target_property(_EVI_NAME ${target} NAME)
+
+  # Pad the project version to a four-part `MAJOR.MINOR.PATCH.TWEAK`
+  string(REGEX MATCHALL "[0-9]+" version_parts "${PROJECT_VERSION}")
+  list(LENGTH version_parts version_part_count)
+  while(version_part_count LESS 4)
+    list(APPEND version_parts "0")
+    math(EXPR version_part_count "${version_part_count} + 1")
+  endwhile()
+  list(GET version_parts 0 _EVI_VERSION_MAJOR)
+  list(GET version_parts 1 _EVI_VERSION_MINOR)
+  list(GET version_parts 2 _EVI_VERSION_PATCH)
+  list(GET version_parts 3 _EVI_VERSION_TWEAK)
+  set(_EVI_VERSION_STRING "${_EVI_VERSION_MAJOR}.${_EVI_VERSION_MINOR}.${_EVI_VERSION_PATCH}.${_EVI_VERSION_TWEAK}")
+
+  file(CONFIGURE
+    OUTPUT ${_EVI_BINARY_DIR}/${_EVI_NAME}.rc.in
+    CONTENT [[
+1 VERSIONINFO
+FILEVERSION    @_EVI_VERSION_MAJOR@,@_EVI_VERSION_MINOR@,@_EVI_VERSION_PATCH@,@_EVI_VERSION_TWEAK@
+PRODUCTVERSION @_EVI_VERSION_MAJOR@,@_EVI_VERSION_MINOR@,@_EVI_VERSION_PATCH@,@_EVI_VERSION_TWEAK@
+BEGIN
+  BLOCK "StringFileInfo"
+  BEGIN
+    // U.S. English (LangID 0x0409), UTF-8 (CP 65001)
+    BLOCK "0409FDE9"
+    BEGIN
+      VALUE "CompanyName",      "Swift Open Source Project"
+      VALUE "FileDescription",  "@_EVI_FILE_DESCRIPTION@"
+      VALUE "FileVersion",      "@_EVI_VERSION_STRING@"
+      VALUE "InternalName",     "@_EVI_INTERNAL_NAME@"
+      VALUE "LegalCopyright",   "Copyright (c) Apple Inc. and the Swift project authors. Licensed under Apache License v2.0 with Runtime Library Exception."
+      VALUE "OriginalFilename", "@_EVI_ORIGINAL_FILENAME@"
+      VALUE "ProductName",      "@_EVI_PRODUCT_NAME@"
+      VALUE "ProductVersion",   "@_EVI_VERSION_STRING@"
+    END
+  END
+
+  BLOCK "VarFileInfo"
+  BEGIN
+    // Translation must match the StringFileInfo BLOCK key above.
+    VALUE "Translation", 0x0409, 0xFDE9
+  END
+END
+    ]])
+  file(GENERATE
+    OUTPUT ${_EVI_BINARY_DIR}/${_EVI_NAME}.rc
+    INPUT ${_EVI_BINARY_DIR}/${_EVI_NAME}.rc.in)
+  target_sources(${target} PRIVATE
+    ${_EVI_BINARY_DIR}/${_EVI_NAME}.rc)
+endfunction()
+
+function(embed_manifest target)
+  if(NOT WIN32)
+    return()
+  endif()
+
+  get_target_property(_EM_TARGET_TYPE ${target} TYPE)
+  if(NOT "${_EM_TARGET_TYPE}" MATCHES "SHARED_LIBRARY|EXECUTABLE")
+    return()
+  endif()
+
+  cmake_parse_arguments(PARSE_ARGV 1 _EM
+    ""
+    "FILE_DESCRIPTION;INTERNAL_NAME;ORIGINAL_FILENAME;PRODUCT_NAME"
+    "")
+
+  if(NOT _EM_INTERNAL_NAME)
+    set(_EM_INTERNAL_NAME "${target}")
+  endif()
+  if(NOT _EM_FILE_DESCRIPTION)
+    set(_EM_FILE_DESCRIPTION "${_EM_INTERNAL_NAME}")
+  endif()
+  if(NOT _EM_PRODUCT_NAME)
+    set(_EM_PRODUCT_NAME "Swift")
+  endif()
+  if(NOT _EM_ORIGINAL_FILENAME)
+    set(_EM_ORIGINAL_FILENAME "$<TARGET_FILE_NAME:${target}>")
+  endif()
+
   get_target_property(_EM_BINARY_DIR ${target} BINARY_DIR)
   get_target_property(_EM_NAME ${target} NAME)
 
+  # Pad the project version to a four-part `MAJOR.MINOR.PATCH.TWEAK`
+  string(REGEX MATCHALL "[0-9]+" version_parts "${PROJECT_VERSION}")
+  list(LENGTH version_parts version_part_count)
+  while(version_part_count LESS 4)
+    list(APPEND version_parts "0")
+    math(EXPR version_part_count "${version_part_count} + 1")
+  endwhile()
+  list(GET version_parts 0 _EM_VERSION_MAJOR)
+  list(GET version_parts 1 _EM_VERSION_MINOR)
+  list(GET version_parts 2 _EM_VERSION_PATCH)
+  list(GET version_parts 3 _EM_VERSION_TWEAK)
+  set(_EM_VERSION_STRING "${_EM_VERSION_MAJOR}.${_EM_VERSION_MINOR}.${_EM_VERSION_PATCH}.${_EM_VERSION_TWEAK}")
+
   # Evaluate variables
   file(CONFIGURE
-    OUTPUT ${_EM_BINARY_DIR}/${_EM_NAME}-${PROJECT_VERSION}.1.manifest.in
+    OUTPUT ${_EM_BINARY_DIR}/${_EM_NAME}-${_EM_VERSION_STRING}.1.manifest.in
     CONTENT [[<?xml version="1.0" encoding="utf-8" standalone="yes"?>
-<assembly manifestversion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
   <assemblyIdentity
     name="$<TARGET_NAME:@target@>"
     processorArchitecture="@CMAKE_SYSTEM_PROCESSOR@"
     type="win32"
-    version="@PROJECT_VERSION@" />
+    version="@_EM_VERSION_STRING@" />
   <file name="$<TARGET_FILE_NAME:@target@>" />
 </assembly>]])
   # Evaluate generator expression
   file(GENERATE
-    OUTPUT ${_EM_BINARY_DIR}/${_EM_NAME}-${PROJECT_VERSION}.1.manifest
-    INPUT ${_EM_BINARY_DIR}/${_EM_NAME}-${PROJECT_VERSION}.1.manifest.in)
+    OUTPUT ${_EM_BINARY_DIR}/${_EM_NAME}-${_EM_VERSION_STRING}.1.manifest
+    INPUT ${_EM_BINARY_DIR}/${_EM_NAME}-${_EM_VERSION_STRING}.1.manifest.in)
 
-  if(WIN32)
-    add_custom_command(TARGET ${target} POST_BUILD
-      COMMAND "${MT}" -nologo -manifest "${_EM_BINARY_DIR}/${_EM_NAME}-${PROJECT_VERSION}.1.manifest" "-outputresource:$<TARGET_FILE:${target}>;#1")
-  endif()
+  file(CONFIGURE
+    OUTPUT ${_EM_BINARY_DIR}/${_EM_NAME}.rc.in
+    CONTENT [[
+1 VERSIONINFO
+FILEVERSION    @_EM_VERSION_MAJOR@,@_EM_VERSION_MINOR@,@_EM_VERSION_PATCH@,@_EM_VERSION_TWEAK@
+PRODUCTVERSION @_EM_VERSION_MAJOR@,@_EM_VERSION_MINOR@,@_EM_VERSION_PATCH@,@_EM_VERSION_TWEAK@
+BEGIN
+  BLOCK "StringFileInfo"
+  BEGIN
+    // U.S. English (LangID 0x0409), UTF-8 (CP 65001)
+    BLOCK "0409FDE9"
+    BEGIN
+      VALUE "CompanyName",      "Swift Open Source Project"
+      VALUE "FileDescription",  "@_EM_FILE_DESCRIPTION@"
+      VALUE "FileVersion",      "@_EM_VERSION_STRING@"
+      VALUE "InternalName",     "@_EM_INTERNAL_NAME@"
+      VALUE "LegalCopyright",   "Copyright (c) Apple Inc. and the Swift project authors. Licensed under Apache License v2.0 with Runtime Library Exception."
+      VALUE "OriginalFilename", "@_EM_ORIGINAL_FILENAME@"
+      VALUE "ProductName",      "@_EM_PRODUCT_NAME@"
+      VALUE "ProductVersion",   "@_EM_VERSION_STRING@"
+    END
+  END
+
+  BLOCK "VarFileInfo"
+  BEGIN
+    // Translation must match the StringFileInfo BLOCK key above.
+    VALUE "Translation", 0x0409, 0xFDE9
+  END
+END
+
+LANGUAGE 0, 0
+1 RT_MANIFEST "@_EM_NAME@-@_EM_VERSION_STRING@.1.manifest"
+    ]])
+  file(GENERATE
+    OUTPUT ${_EM_BINARY_DIR}/${_EM_NAME}.rc
+    INPUT ${_EM_BINARY_DIR}/${_EM_NAME}.rc.in)
+  target_sources(${target} PRIVATE
+    ${_EM_BINARY_DIR}/${_EM_NAME}.rc)
+  target_link_options(${target} PRIVATE
+    $<$<PLATFORM_ID:Windows>:LINKER:/MANIFEST:NO>)
 endfunction()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -343,8 +343,10 @@ normalize_boolean_spelling(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB_CROSS_COMPILING)
 normalize_boolean_spelling(SWIFT_BUILD_REMOTE_MIRROR)
 is_build_type_optimized("${SWIFT_STDLIB_BUILD_TYPE}" SWIFT_OPTIMIZED)
 
-# Get 'SWIFT_HOST_SDKROOT' for lit.site.cfg.in
-set(SWIFT_HOST_SDKROOT "${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_ARCH_${SWIFT_HOST_VARIANT_ARCH}_PATH}")
+# Allow callers to pin the host SDK used by lit.site.cfg.in.
+if(NOT SWIFT_HOST_SDKROOT)
+  set(SWIFT_HOST_SDKROOT "${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_ARCH_${SWIFT_HOST_VARIANT_ARCH}_PATH}")
+endif()
 
 set(profdata_merge_worker
     "${CMAKE_CURRENT_SOURCE_DIR}/../utils/profdata_merge/main.py")

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -127,9 +127,6 @@ Build and include the no-assert toolchain variant in the output.
 .PARAMETER Summary
 Display a build time summary at the end of the build. Helpful for performance analysis.
 
-.PARAMETER TraceExpand
-Enable trace-expand mode for CMake.
-
 .EXAMPLE
 PS> .\Build.ps1
 
@@ -212,8 +209,7 @@ param
   [ValidateSet("debug", "release")]
   [string] $FoundationTestConfiguration = "debug",
 
-  [switch] $Summary,
-  [switch] $TraceExpand
+  [switch] $Summary
 )
 
 ## Prepare the build environment.
@@ -1863,10 +1859,6 @@ function Build-CMakeProject {
       }
 
       $cmakeGenerateArgs += @("-D", "$($Define.Key)=$Value")
-    }
-
-    if ($TraceExpand) {
-      $cmakeGenerateArgs += @("--trace-expand")
     }
 
     if ($UseBuiltCompilers.Contains("Swift")) {

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -2182,14 +2182,17 @@ function Load-LitTestOverrides($Filename) {
   }
 }
 
-function Build-CDispatch([Hashtable] $Platform, [switch] $Static = $false) {
+function Build-CDispatch([Hashtable] $Platform,
+                         [Hashtable] $CCompiler   = $script:Compilers.Pinned.C,
+                         [Hashtable] $CXXCompiler = $script:Compilers.Pinned.CXX,
+                         [switch]    $Static      = $false) {
   Build-CMakeProject `
     -Src $SourceCache\swift-corelibs-libdispatch `
     -Bin (Get-ProjectBinaryCache $Platform CDispatch) `
     -BuildTargets default `
     -Platform $Platform `
-    -CCompiler $Compilers.Pinned.C `
-    -CXXCompiler $Compilers.Pinned.CXX `
+    -CCompiler $CCompiler `
+    -CXXCompiler $CXXCompiler `
     -Defines @{
       BUILD_SHARED_LIBS = "YES";
       BUILD_TESTING = "NO";
@@ -2558,12 +2561,13 @@ function Build-CompilerRuntime([Hashtable] $Platform) {
     }
 }
 
-function Build-Brotli([Hashtable] $Platform) {
+function Build-Brotli([Hashtable] $Platform,
+                      [Hashtable] $CCompiler = $script:Compilers.Host.C) {
   Build-CMakeProject `
     -Src $SourceCache\brotli `
     -Bin "$(Get-ProjectBinaryCache $Platform brotli)" `
     -Platform $Platform `
-    -CCompiler $Compilers.Host.C `
+    -CCompiler $CCompiler `
     -BuildTargets default `
     -Defines @{
       BUILD_SHARED_LIBS = "NO";
@@ -2573,27 +2577,30 @@ function Build-Brotli([Hashtable] $Platform) {
 }
 
 
-function Build-ZLib([Hashtable] $Platform) {
+function Build-ZLib([Hashtable] $Platform,
+                    [Hashtable] $CCompiler = $script:Compilers.Host.C) {
   Build-CMakeProject `
     -Src $SourceCache\zlib `
     -Bin "$BinaryCache\$($Platform.Triple)\zlib" `
     -InstallTo "$BinaryCache\$($Platform.Triple)\usr" `
     -Platform $Platform `
-    -CCompiler $Compilers.Host.C `
+    -CCompiler $CCompiler `
     -Defines @{
       BUILD_SHARED_LIBS = "NO";
       CMAKE_POSITION_INDEPENDENT_CODE = "YES";
     }
 }
 
-function Build-XML2([Hashtable] $Platform) {
+function Build-XML2([Hashtable] $Platform,
+                    [Hashtable] $CCompiler   = $script:Compilers.Host.C,
+                    [Hashtable] $CXXCompiler = $script:Compilers.Host.CXX) {
   Build-CMakeProject `
     -Src $SourceCache\libxml2 `
     -Bin "$BinaryCache\$($Platform.Triple)\libxml2-2.11.5" `
     -InstallTo "$BinaryCache\$($Platform.Triple)\usr" `
     -Platform $Platform `
-    -CCompiler $Compilers.Host.C `
-    -CXXCompiler $Compilers.Host.CXX `
+    -CCompiler $CCompiler `
+    -CXXCompiler $CXXCompiler `
     -Defines @{
       BUILD_SHARED_LIBS = "NO";
       CMAKE_POSITION_INDEPENDENT_CODE = "YES";
@@ -2665,7 +2672,8 @@ function Build-DS2([Hashtable] $Platform) {
     }
 }
 
-function Build-CURL([Hashtable] $Platform) {
+function Build-CURL([Hashtable] $Platform,
+                    [Hashtable] $CCompiler = $script:Compilers.Host.C) {
   $PlatformDefines = @{}
   if ($Platform.OS -eq [OS]::Android) {
     $PlatformDefines += @{
@@ -2678,7 +2686,7 @@ function Build-CURL([Hashtable] $Platform) {
     -Bin "$BinaryCache\$($Platform.Triple)\curl" `
     -InstallTo "$BinaryCache\$($Platform.Triple)\usr" `
     -Platform $Platform `
-    -CCompiler $Compilers.Host.C `
+    -CCompiler $CCompiler `
     -Defines ($PlatformDefines + @{
       BUILD_SHARED_LIBS = "NO";
       BUILD_TESTING = "NO";

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1293,16 +1293,9 @@ function Get-Dependencies {
 }
 
 function Get-PinnedToolchainToolsDir() {
-  $ToolchainsRoot = [IO.Path]::Combine("$BinaryCache\toolchains", "$ToolchainVersionIdentifier", "LocalApp", "Programs", "Swift", "Toolchains")
-  $VariantToolchainPath = [IO.Path]::Combine($ToolchainsRoot, "$PinnedVersion+Asserts", "usr", "bin")
-
-  if (Test-Path $VariantToolchainPath) {
-    return $VariantToolchainPath
-  }
-
-  return [IO.Path]::Combine("$BinaryCache\", "toolchains", $ToolchainName,
-    "Library", "Developer", "Toolchains",
-    "unknown-Asserts-development.xctoolchain", "usr", "bin")
+  return [IO.Path]::Combine("$BinaryCache\toolchains", "$ToolchainVersionIdentifier",
+    "LocalApp", "Programs", "Swift", "Toolchains", "$PinnedVersion+Asserts",
+    "usr", "bin")
 }
 
 function Get-PinnedToolchainSDK([OS] $OS = $BuildPlatform.OS, [string] $Identifier = $OS.ToString()) {
@@ -1324,8 +1317,13 @@ function Add-KeyValueIfNew([hashtable]$Hashtable, [string]$Key, [string]$Value) 
 }
 
 function Add-FlagsDefine([hashtable]$Defines, [string]$Name, [string[]]$Value) {
+  $Value = @($Value | Where-Object { $null -ne $_ })
+  if ($Value.Count -eq 0) {
+    return
+  }
+
   if ($Defines.Contains($Name)) {
-    $Defines[$name] = @($Defines[$name]) + $Value
+    $Defines[$name] = @($Defines[$name] | Where-Object { $null -ne $_ }) + $Value
   } else {
     $Defines.Add($Name, $Value)
   }
@@ -1339,6 +1337,158 @@ function Get-SwiftSDK([OS] $OS, [string] $Identifier = $OS.ToString()) {
   return ([IO.Path]::Combine((Get-PlatformRoot $OS), "Developer", "SDKs", "$Identifier.sdk"))
 }
 
+enum DriverStyle {
+  CL
+  ClangCL
+  GNU
+  Swift
+}
+
+# Compiler Configurations
+$Compilers = @{
+  MSVC = @{
+    C = @{
+      Executable        = "cl.exe"
+      DriverStyle       = [DriverStyle]::CL
+      Flags             = @("/GS-", "/Gw", "/Gy", "/Oy", "/Oi", "/Zc:inline", "/Zc:preprocessor")
+      DebugFlags        = { param([string] $Format)
+        @()
+      }
+      AssumeFunctional  = $false
+    }
+    CXX = @{
+      Executable        = "cl.exe"
+      DriverStyle       = [DriverStyle]::CL
+      Flags             = @("/GS-", "/Gw", "/Gy", "/Oy", "/Oi", "/Zc:inline", "/Zc:preprocessor", "/Zc:__cplusplus")
+      DebugFlags        = { param([string] $Format)
+        @()
+      }
+      AssumeFunctional  = $false
+    }
+  }
+
+  Pinned = @{
+    C = @{
+      Executable        = Join-Path -Path (Get-PinnedToolchainToolsDir) -ChildPath "clang-cl.exe"
+      DriverStyle       = [DriverStyle]::ClangCL
+      Flags             = @("/GS-", "/Gw", "/Gy", "/Oy", "/Oi", "/Zc:inline")
+      DebugFlags        = { param([string] $Format)
+        if ($Format -eq "dwarf") { @("-clang:-gdwarf") } else { @() }
+      }
+      AssumeFunctional  = $false
+    }
+
+    CXX = @{
+      Executable        = Join-Path -Path (Get-PinnedToolchainToolsDir) -ChildPath "clang-cl.exe"
+      DriverStyle       = [DriverStyle]::ClangCL
+      Flags             = @("/GS-", "/Gw", "/Gy", "/Oy", "/Oi", "/Zc:inline", "/Zc:__cplusplus")
+      DebugFlags        = { param([string] $Format)
+        if ($Format -eq "dwarf") { @("-clang:-gdwarf") } else { @() }
+      }
+      AssumeFunctional  = $false
+    }
+
+    Swift = @{
+      Executable        = Join-Path -Path (Get-PinnedToolchainToolsDir) -ChildPath "swiftc.exe"
+      DriverStyle       = [DriverStyle]::Swift
+      Flags             = @()
+      DebugFlags        = { param([string] $Format)
+        if ($Format -eq "dwarf") {
+          return @("-g", "-debug-info-format=dwarf", "-use-ld=lld-link", "-Xlinker", "/DEBUG:DWARF")
+        }
+        return @("-g", "-debug-info-format=codeview", "-Xlinker", "/DEBUG")
+      }
+      AssumeFunctional  = $false
+
+      Runtime           = Get-PinnedToolchainRuntime
+    }
+  }
+
+  Built = @{
+    C = @{
+      Executable        = [IO.Path]::Combine((Get-ProjectBinaryCache $BuildPlatform Compilers), "bin", "clang-cl.exe")
+      DriverStyle       = [DriverStyle]::ClangCL
+      Flags             = @("/GS-", "/Gw", "/Gy", "/Oy", "/Oi", "/Zc:inline")
+      DebugFlags        = { param([string] $Format)
+        if ($Format -eq "dwarf") { @("-clang:-gdwarf") } else { @() }
+      }
+      AssumeFunctional  = $true
+    }
+
+    CXX = @{
+      Executable        = [IO.Path]::Combine((Get-ProjectBinaryCache $BuildPlatform Compilers), "bin", "clang-cl.exe")
+      DriverStyle       = [DriverStyle]::ClangCL
+      Flags             = @("/GS-", "/Gw", "/Gy", "/Oy", "/Oi", "/Zc:inline", "/Zc:__cplusplus")
+      DebugFlags        = { param([string] $Format)
+        if ($Format -eq "dwarf") { @("-clang:-gdwarf") } else { @() }
+      }
+      AssumeFunctional  = $true
+    }
+
+    GNUC = @{
+      Executable        = [IO.Path]::Combine((Get-ProjectBinaryCache $BuildPlatform Compilers), "bin", "clang.exe")
+      DriverStyle       = [DriverStyle]::GNU
+      Flags             = @("-fno-stack-protector", "-ffunction-sections", "-fdata-sections", "-fomit-frame-pointer", "-finline-functions")
+      DebugFlags        = { param([string] $Format)
+        if ($Format -eq "dwarf") { @("-gdwarf") } else { @("-gcodeview") }
+      }
+      AssumeFunctional  = $true
+    }
+
+    GNUCXX = @{
+      Executable        = [IO.Path]::Combine((Get-ProjectBinaryCache $BuildPlatform Compilers), "bin", "clang++.exe")
+      DriverStyle       = [DriverStyle]::GNU
+      Flags             = @("-fno-stack-protector", "-ffunction-sections", "-fdata-sections", "-fomit-frame-pointer", "-finline-functions")
+      DebugFlags        = { param([string] $Format)
+        if ($Format -eq "dwarf") { @("-gdwarf") } else { @("-gcodeview") }
+      }
+      AssumeFunctional  = $true
+    }
+
+    Swift = @{
+      Executable        = [IO.Path]::Combine((Get-ProjectBinaryCache $BuildPlatform Compilers), "bin", "swiftc.exe")
+      DriverStyle       = [DriverStyle]::Swift
+      Flags             = @()
+      DebugFlags        = { param([string] $Format)
+        if ($Format -eq "dwarf") {
+          return @("-g", "-debug-info-format=dwarf", "-use-ld=lld-link", "-Xlinker", "/DEBUG:DWARF")
+        }
+        return @("-g", "-debug-info-format=codeview", "-Xlinker", "/DEBUG")
+      }
+      AssumeFunctional  = $true
+
+      Runtime           = Get-PinnedToolchainRuntime
+    }
+  }
+}
+
+$Compilers.Host = @{
+  C = if ($UseHostToolchain) { $Compilers.MSVC.C } else { $Compilers.Pinned.C }
+  CXX = if ($UseHostToolchain) { $Compilers.MSVC.CXX } else { $Compilers.Pinned.CXX }
+}
+
+$Assemblers = @{
+  Built = @{
+    Executable        = [IO.Path]::Combine((Get-ProjectBinaryCache $BuildPlatform Compilers), "bin", "clang-cl.exe")
+    DriverStyle       = [DriverStyle]::ClangCL
+    Flags             = @()
+    DebugFlags        = { param([string] $Format)
+      if ($Format -eq "dwarf") { @("-clang:-gdwarf") } else { @("-clang:-gcodeview") }
+    }
+    AssumeFunctional  = $true
+  }
+
+  Pinned = @{
+    Executable        = Join-Path -Path (Get-PinnedToolchainToolsDir) -ChildPath "clang-cl.exe"
+    DriverStyle       = [DriverStyle]::ClangCL
+    Flags             = @()
+    DebugFlags        = { param([string] $Format)
+      if ($Format -eq "dwarf") { @("-clang:-gdwarf") } else { @("-clang:-gcodeview") }
+    }
+    AssumeFunctional  = $false
+  }
+}
+
 function Build-CMakeProject {
   [CmdletBinding(PositionalBinding = $false)]
   param
@@ -1349,14 +1499,12 @@ function Build-CMakeProject {
     [hashtable] $Platform,
     [string] $Generator = "Ninja",
     [string] $CacheScript = "",
-    [ValidateSet("", "ASM_MASM", "C", "CXX")]
-    [string[]] $UseMSVCCompilers = @(),
-    [ValidateSet("", "ASM", "C", "CXX", "Swift")]
-    [string[]] $UseBuiltCompilers = @(),
-    [ValidateSet("", "ASM", "C", "CXX", "Swift")]
-    [string[]] $UsePinnedCompilers = @(),
+    [Hashtable] $Assembler = $null,
+    [Hashtable] $CCompiler = $null,
+    [Hashtable] $CXXCompiler = $null,
+    [Hashtable] $SwiftCompiler = $null,
+    [switch] $UseASMMASM = $false,
     [switch] $AddAndroidCMakeEnv = $false,
-    [switch] $UseGNUDriver = $false,
     [string] $SwiftSDK = $null,
     [hashtable] $Defines = @{}, # Values are either single strings or arrays of flags
     [string[]] $BuildTargets = @()
@@ -1380,11 +1528,12 @@ function Build-CMakeProject {
       $env:NDKPATH = Get-AndroidNDKPath
     }
 
-    $UseASM = $UseBuiltCompilers.Contains("ASM") -or $UsePinnedCompilers.Contains("ASM")
-    $UseASM_MASM = $UseMSVCCompilers.Contains("ASM_MASM")
-    $UseC = $UseBuiltCompilers.Contains("C") -or $UseMSVCCompilers.Contains("C") -or $UsePinnedCompilers.Contains("C")
-    $UseCXX = $UseBuiltCompilers.Contains("CXX") -or $UseMSVCCompilers.Contains("CXX") -or $UsePinnedCompilers.Contains("CXX")
-    $UseSwift = $UseBuiltCompilers.Contains("Swift") -or $UsePinnedCompilers.Contains("Swift")
+    $UseASM = $Assembler -ne $null
+    $UseASM_MASM = [bool]$UseASMMASM
+    $UseC = $CCompiler -ne $null
+    $UseCXX = $CXXCompiler -ne $null
+    $UseSwift = $SwiftCompiler -ne $null
+    $UseMSVC = ($UseC -and $CCompiler.DriverStyle -eq [DriverStyle]::CL) -or ($UseCXX -and $CXXCompiler.DriverStyle -eq [DriverStyle]::CL)
 
     # Starting with CMake 3.30, CMake propagates linker flags to Swift.
     $CMakePassesSwiftLinkerFlags = $CMakeVersion -ge [version]'3.30'
@@ -1401,15 +1550,24 @@ function Build-CMakeProject {
       XLinkerPrefix
       None
     }
+    # Whether CMake invokes the linker directly with MSVC-style flags (true
+    # for both `cl.exe` and `clang-cl.exe` since CMake detects clang-cl as
+    # MSVC-like and bypasses the compiler driver for the link step).
+    $UsesDirectMSVCLinker =
+      ($UseC   -and $CCompiler.DriverStyle   -in @([DriverStyle]::CL, [DriverStyle]::ClangCL)) -or
+      ($UseCXX -and $CXXCompiler.DriverStyle -in @([DriverStyle]::CL, [DriverStyle]::ClangCL))
+
     $FlagHandling = if ($CMakeSupportsCMP0181) {
       # With CMP0181, the `LINKER:` generator expression can always be used.
       [LinkerFlagHandling]::CMP0181
-    } elseif ($UseMSVCCompilers.Contains("C") -or $UseMSVCCompilers.Contains("CXX")) {
-      # MSVC's link.exe does not require any special handling for linker flags.
+    } elseif ($UsesDirectMSVCLinker) {
+      # `link.exe` / `lld-link.exe` invoked directly does not understand the
+      # `-Xlinker` prefix.  MSVC-style flags (`/INCREMENTAL:NO`, etc.) pass
+      # through verbatim.
       [LinkerFlagHandling]::None
     } else {
-      # Otherwise, we are probably using clang, clang-cl and/or swift, prefix
-      # the linker flags with `-Xlinker`.
+      # Otherwise, we are probably using clang and/or swift as the link
+      # driver; prefix the linker flags with `-Xlinker`.
       [LinkerFlagHandling]::XLinkerPrefix
     }
 
@@ -1464,28 +1622,17 @@ function Build-CMakeProject {
     switch ($Platform.OS) {
       Windows {
         if ($UseASM) {
-          $Driver = $(if ($UseGNUDriver) { "clang.exe" } else { "clang-cl.exe" })
-          $ASM = if ($UseBuiltCompilers.Contains("ASM")) {
-            [IO.Path]::Combine((Get-ProjectBinaryCache $BuildPlatform Compilers), "bin", $Driver)
-          } elseif ($UsePinnedCompilers.Contains("ASM")) {
-            Join-Path -Path (Get-PinnedToolchainToolsDir) -ChildPath $Driver
-          }
-
-          Add-KeyValueIfNew $Defines CMAKE_ASM_COMPILER $ASM
+          Add-KeyValueIfNew $Defines CMAKE_ASM_COMPILER $Assembler.Executable
           Add-KeyValueIfNew $Defines CMAKE_ASM_FLAGS @("--target=$($Platform.Triple)")
           Add-KeyValueIfNew $Defines CMAKE_ASM_COMPILE_OPTIONS_MSVC_RUNTIME_LIBRARY_MultiThreadedDLL "/MD"
 
           if ($DebugInfo) {
-            $ASMDebugFlags = if ($DebugFormat -eq "dwarf") {
-              if ($UseGNUDriver) { @("-gdwarf") } else { @("-clang:-gdwarf") }
-            } else {
-              if ($UseGNUDriver) { @("-gcodeview") } else { @("-clang:-gcodeview") }
-            }
-
-            # CMake does not set a default value for the ASM compiler debug
-            # information format flags with non-MSVC compilers, so we explicitly
-            # set a default here.
-            Add-FlagsDefine $Defines CMAKE_ASM_COMPILE_OPTIONS_MSVC_DEBUG_INFORMATION_FORMAT_Embedded $ASMDebugFlags
+            # CMake's MSVC_DEBUG_INFORMATION_FORMAT support also applies to ASM
+            # targets, but clang-cl-as-ASM does not get a built-in mapping for
+            # the Embedded format. Provide the mapping before setting the global
+            # CMAKE_MSVC_DEBUG_INFORMATION_FORMAT below.
+            Add-FlagsDefine $Defines CMAKE_ASM_COMPILE_OPTIONS_MSVC_DEBUG_INFORMATION_FORMAT_Embedded `
+              $(& $Assembler.DebugFlags $DebugFormat)
           }
         }
 
@@ -1501,117 +1648,43 @@ function Build-CMakeProject {
         }
 
         if ($UseC) {
-          $CC = if ($UseMSVCCompilers.Contains("C")) {
-            "cl.exe"
-          } else {
-            $Driver = $(if ($UseGNUDriver) { "clang.exe" } else { "clang-cl.exe" })
-            if ($UseBuiltCompilers.Contains("C")) {
-              [IO.Path]::Combine((Get-ProjectBinaryCache $BuildPlatform Compilers), "bin", $Driver)
-            } elseif ($UsePinnedCompilers.Contains("C")) {
-              Join-Path -Path (Get-PinnedToolchainToolsDir) -ChildPath $Driver
-            }
-          }
-
-          Add-KeyValueIfNew $Defines CMAKE_C_COMPILER $CC
+          Add-KeyValueIfNew $Defines CMAKE_C_COMPILER $CCompiler.Executable
           Add-KeyValueIfNew $Defines CMAKE_C_COMPILER_TARGET $Platform.Triple
-
-          $CFLAGS = if ($UseGNUDriver) {
-            # TODO(compnerd) we should consider enabling stack protector usage for standard libraries.
-            @("-fno-stack-protector", "-ffunction-sections", "-fdata-sections", "-fomit-frame-pointer", "-finline-functions")
-          } elseif ($UseMSVCCompilers.Contains("C")) {
-            @("/GS-", "/Gw", "/Gy", "/Oy", "/Oi", "/Zc:preprocessor", "/Zc:inline")
-          } else {
-            # clang-cl does not support the /Zc:preprocessor flag.
-            @("/GS-", "/Gw", "/Gy", "/Oy", "/Oi", "/Zc:inline")
-          }
+          Add-FlagsDefine $Defines CMAKE_C_FLAGS $CCompiler.Flags
 
           if ($DebugInfo) {
-            if ($UsePinnedCompilers.Contains("C") -or $UseBuiltCompilers.Contains("C")) {
-              if ($DebugFormat -eq "dwarf") {
-                $CFLAGS += if ($UseGNUDriver) {
-                  @("-gdwarf")
-                } else {
-                  @("-clang:-gdwarf")
-                }
-              }
-            }
+            Add-FlagsDefine $Defines CMAKE_C_FLAGS $(& $CCompiler.DebugFlags $DebugFormat)
           }
-
-          Add-FlagsDefine $Defines CMAKE_C_FLAGS $CFLAGS
         }
 
         if ($UseCXX) {
-          $CXX = if ($UseMSVCCompilers.Contains("CXX")) {
-            "cl.exe"
-          } else {
-            $Driver = $(if ($UseGNUDriver) { "clang++.exe" } else { "clang-cl.exe" })
-            if ($UseBuiltCompilers.Contains("CXX")) {
-              [IO.Path]::Combine((Get-ProjectBinaryCache $BuildPlatform Compilers), "bin", $Driver)
-            } elseif ($UsePinnedCompilers.Contains("CXX")) {
-              Join-Path -Path (Get-PinnedToolchainToolsDir) -ChildPath $Driver
-            }
-          }
-
-          Add-KeyValueIfNew $Defines CMAKE_CXX_COMPILER $CXX
+          Add-KeyValueIfNew $Defines CMAKE_CXX_COMPILER $CXXCompiler.Executable
           Add-KeyValueIfNew $Defines CMAKE_CXX_COMPILER_TARGET $Platform.Triple
-
-          $CXXFLAGS = if ($UseGNUDriver) {
-            # TODO(compnerd) we should consider enabling stack protector usage for standard libraries.
-            @("-fno-stack-protector", "-ffunction-sections", "-fdata-sections", "-fomit-frame-pointer", "-finline-functions")
-          } elseif ($UseMSVCCompilers.Contains("CXX")) {
-            @("/GS-", "/Gw", "/Gy", "/Oy", "/Oi", "/Zc:preprocessor", "/Zc:inline", "/Zc:__cplusplus")
-          } else {
-            # clang-cl does not support the /Zc:preprocessor flag.
-            @("/GS-", "/Gw", "/Gy", "/Oy", "/Oi", "/Zc:inline", "/Zc:__cplusplus")
-          }
+          Add-FlagsDefine $Defines CMAKE_CXX_FLAGS $CXXCompiler.Flags
 
           if ($DebugInfo) {
-            if ($UsePinnedCompilers.Contains("CXX") -or $UseBuiltCompilers.Contains("CXX")) {
-              if ($DebugFormat -eq "dwarf") {
-                $CXXFLAGS += if ($UseGNUDriver) {
-                  @("-gdwarf")
-                } else {
-                  @("-clang:-gdwarf")
-                }
-              }
-            }
+            Add-FlagsDefine $Defines CMAKE_CXX_FLAGS $(& $CXXCompiler.DebugFlags $DebugFormat)
           }
-
-          Add-FlagsDefine $Defines CMAKE_CXX_FLAGS $CXXFLAGS
         }
 
         if ($UseSwift) {
-          if ($UseBuiltCompilers.Contains("Swift")) {
+          if ($SwiftCompiler.AssumeFunctional) {
             Add-KeyValueIfNew $Defines CMAKE_Swift_COMPILER_WORKS "YES"
           }
 
-          $SWIFTC = if ($UseBuiltCompilers.Contains("Swift")) {
-            [IO.Path]::Combine((Get-ProjectBinaryCache $BuildPlatform Compilers), "bin", "swiftc.exe")
-          } elseif ($UsePinnedCompilers.Contains("Swift")) {
-            Join-Path -Path (Get-PinnedToolchainToolsDir) -ChildPath "swiftc.exe"
-          }
-
-          Add-KeyValueIfNew $Defines CMAKE_Swift_COMPILER $SWIFTC
+          Add-KeyValueIfNew $Defines CMAKE_Swift_COMPILER $SwiftCompiler.Executable
           Add-KeyValueIfNew $Defines CMAKE_Swift_COMPILER_TARGET $Platform.Triple
           # Skip compiler ID detection: avoids compiling+scanning a multi-MB test binary on every configure.
           Add-KeyValueIfNew $Defines CMAKE_Swift_COMPILER_ID "Apple"
 
-          [string[]] $SwiftFlags = @();
-
-          $SwiftFlags += if ($SwiftSDK) {
-            @("-sdk", $SwiftSDK)
-          } else {
-            @()
+          Add-FlagsDefine $Defines CMAKE_Swift_FLAGS $SwiftCompiler.Flags
+          if ($SwiftSDK) {
+            Add-FlagsDefine $Defines CMAKE_Swift_FLAGS @("-sdk", $SwiftSDK)
           }
-
-          $SwiftFlags += if ($DebugInfo) {
-            if ($DebugFormat -eq "dwarf") {
-              @("-g", "-debug-info-format=dwarf", "-use-ld=lld-link", "-Xlinker", "/DEBUG:DWARF")
-            } else {
-              @("-g", "-debug-info-format=codeview", "-Xlinker", "/DEBUG")
-            }
+          if ($DebugInfo) {
+            Add-FlagsDefine $Defines CMAKE_Swift_FLAGS $(& $SwiftCompiler.DebugFlags $DebugFormat)
           } else {
-            @("-gnone")
+            Add-FlagsDefine $Defines CMAKE_Swift_FLAGS @("-gnone")
           }
 
           if ($CMakePassesSwiftLinkerFlags) {
@@ -1624,12 +1697,12 @@ function Build-CMakeProject {
             Add-KeyValueIfNew $Defines CMAKE_SHARED_LINKER_FLAGS_RELEASE ""
           } else {
             # Disable EnC as that introduces padding in the conformance tables
-            $SwiftFlags += @("-Xlinker", "/INCREMENTAL:NO")
+            Add-FlagsDefine $Defines CMAKE_Swift_FLAGS @("-Xlinker", "/INCREMENTAL:NO")
             # Swift requires COMDAT folding and de-duplication
-            $SwiftFlags += @("-Xlinker", "/OPT:REF", "-Xlinker", "/OPT:ICF")
+            Add-FlagsDefine $Defines CMAKE_Swift_FLAGS @("-Xlinker", "/OPT:REF", "-Xlinker", "/OPT:ICF")
           }
 
-          Add-FlagsDefine $Defines CMAKE_Swift_FLAGS $SwiftFlags
+          Add-FlagsDefine $Defines CMAKE_Swift_FLAGS $SwiftCompiler.Flags
           # Workaround CMake 3.26+ enabling `-wmo` by default on release builds
           Add-FlagsDefine $Defines CMAKE_Swift_FLAGS_RELEASE "-O"
           Add-FlagsDefine $Defines CMAKE_Swift_FLAGS_RELWITHDEBINFO "-O"
@@ -1652,7 +1725,7 @@ function Build-CMakeProject {
             # `lld-link.exe` argument, not `link.exe`, so this can only be enabled when we use
             # `lld-link.exe` for linking.
             # TODO: Investigate supporting fission with PE/COFF, this should avoid this warning.
-            if ($DebugFormat -eq "dwarf" -and -not ($UseMSVCCompilers.Contains("C") -or $UseMSVCCompilers.Contains("CXX"))) {
+            if ($DebugFormat -eq "dwarf" -and -not $UseMSVC) {
               Add-LinkerFlagsDefine $Defines @("/IGNORE:longsections")
             }
           }
@@ -1674,75 +1747,70 @@ function Build-CMakeProject {
 
         if ($UseC) {
           Add-KeyValueIfNew $Defines CMAKE_C_COMPILER_TARGET $Platform.Triple
-
-          $CFLAGS = @("-ffunction-sections", "-fdata-sections")
+          Add-FlagsDefine $Defines CMAKE_C_FLAGS $CCompiler.Flags
           if ($DebugInfo) {
-            $CFLAGS += @("-gdwarf")
+            Add-FlagsDefine $Defines CMAKE_C_FLAGS $(& $CCompiler.DebugFlags $DebugFormat)
           }
-          Add-FlagsDefine $Defines CMAKE_C_FLAGS $CFLAGS
         }
 
         if ($UseCXX) {
           Add-KeyValueIfNew $Defines CMAKE_CXX_COMPILER_TARGET $Platform.Triple
-
-          $CXXFLAGS = @("-ffunction-sections", "-fdata-sections")
+          Add-FlagsDefine $Defines CMAKE_CXX_FLAGS $CXXCompiler.Flags
           if ($DebugInfo) {
-            $CXXFLAGS += @("-gdwarf")
+            Add-FlagsDefine $Defines CMAKE_CXX_FLAGS $(& $CXXCompiler.DebugFlags $DebugFormat)
           }
-          Add-FlagsDefine $Defines CMAKE_CXX_FLAGS $CXXFLAGS
         }
 
         if ($UseSwift) {
-          if ($UseBuiltCompilers.Contains("Swift")) {
+          if ($SwiftCompiler.AssumeFunctional) {
             Add-KeyValueIfNew $Defines CMAKE_Swift_COMPILER_WORKS "YES"
           }
 
           # FIXME(compnerd) remove this once the old runtimes build path is removed.
           Add-KeyValueIfNew $Defines SWIFT_ANDROID_NDK_PATH "$AndroidNDKPath"
 
-          $SWIFTC = if ($UseBuiltCompilers.Contains("Swift")) {
-            [IO.Path]::Combine((Get-ProjectBinaryCache $BuildPlatform Compilers), "bin", "swiftc.exe")
-          } else {
-            Join-Path -Path (Get-PinnedToolchainToolsDir) -ChildPath  "swiftc.exe"
-          }
-          Add-KeyValueIfNew $Defines CMAKE_Swift_COMPILER $SWIFTC
+          Add-KeyValueIfNew $Defines CMAKE_Swift_COMPILER $SwiftCompiler.Executable
           Add-KeyValueIfNew $Defines CMAKE_Swift_COMPILER_TARGET $Platform.Triple
           # Skip compiler ID detection: avoids compiling+scanning a multi-MB test binary on every configure.
           Add-KeyValueIfNew $Defines CMAKE_Swift_COMPILER_ID "Apple"
 
-          [string[]] $SwiftFlags = @()
-
-          $SwiftFlags += if ($SwiftSDK) {
-            # TODO: CMake does not yet have support for passing `CMAKE_SYSROOT` to the Swift compiler yet.
-            #       Once we have that, we can drop `-sysroot $AndroidSysroot` here.
-            @("-sdk", $SwiftSDK, "-sysroot", $AndroidSysroot)
-          } else {
-            @()
+          Add-FlagsDefine $Defines CMAKE_Swift_FLAGS $SwiftCompiler.Flags
+          if ($SwiftSDK) {
+            # TODO: CMake does not yet have support for passing `CMAKE_SYSROOT`
+            # to the Swift compiler yet.  Once we have that, we can drop
+            # `-sysroot $AndroidSysroot` here.
+            Add-FlagsDefine $Defines CMAKE_Swift_FLAGS @("-sdk", $SwiftSDK, "-sysroot", $AndroidSysroot)
           }
 
-          $SwiftFlags += @(
+          Add-FlagsDefine $Defines CMAKE_Swift_FLAGS @(
             "-Xclang-linker", "-target", "-Xclang-linker", $Platform.Triple,
             "-Xclang-linker", "--sysroot", "-Xclang-linker", $AndroidSysroot,
             "-Xclang-linker", "-resource-dir", "-Xclang-linker", "${AndroidPrebuiltRoot}\lib\clang\$($(Get-AndroidNDK).ClangVersion)"
           )
 
-          $SwiftFlags += if ($DebugInfo) { @("-g") } else { @("-gnone") }
+          if ($DebugInfo) {
+            Add-FlagsDefine $Defines CMAKE_Swift_FLAGS (& $SwiftCompiler.DebugFlags $DebugFormat)
+          } else {
+            Add-FlagsDefine $Defines CMAKE_Swift_FLAGS @("-gnone")
+          }
 
-          Add-FlagsDefine $Defines CMAKE_Swift_FLAGS $SwiftFlags
           # Workaround CMake 3.26+ enabling `-wmo` by default on release builds
           Add-FlagsDefine $Defines CMAKE_Swift_FLAGS_RELEASE "-O"
           Add-FlagsDefine $Defines CMAKE_Swift_FLAGS_RELWITHDEBINFO "-O"
         }
 
-        $UseBuiltASMCompiler = $UseBuiltCompilers.Contains("ASM")
-        $UseBuiltCCompiler = $UseBuiltCompilers.Contains("C")
-        $UseBuiltCXXCompiler = $UseBuiltCompilers.Contains("CXX")
-
-        if ($UseBuiltASMCompiler -or $UseBuiltCCompiler -or $UseBuiltCXXCompiler) {
+        if (($UseASM -and $Assembler.AssumeFunctional) -or ($UseC -and $CCompiler.AssumeFunctional) -or ($UseCXX -and $CXXCompiler.AssumeFunctional)) {
           # Use a built lld linker as the Android's NDK linker might be too old
           # and not support all required relocations needed by the Swift
           # runtime.
-          $ld = ([IO.Path]::Combine((Get-ProjectBinaryCache $BuildPlatform Compilers), "bin", "ld.lld"))
+          $Executable = if ($UseC) {
+            $CCompiler.Executable
+          } elseif ($UseCXX) {
+            $CXXCompiler.Executable
+          } elseif ($UseASM) {
+            $Assembler.Executable
+          }
+          $ld = Join-Path -Path (Split-Path $Executable) -ChildPath "ld.lld"
           if ($UseSwift) {
             # The Android NDK injects `-Wl,<arg>` flags into
             # `CMAKE_*_LINKER_FLAGS` via `CMAKE_*_LINKER_FLAGS_INIT` variables.
@@ -1790,22 +1858,14 @@ function Build-CMakeProject {
     if ($EnableCaching) {
       $env:LLVM_CACHE_CAS_PATH = "$Cache"
 
-      if ($UseC) {
-        $ClangCache = if ($UsePinnedCompilers.Contains("C")) {
-          $(Join-Path -Path (Get-PinnedToolchainToolsDir) -ChildPath "clang-cache.exe")
-        } elseif ($UseBuiltCompilers.Contains("C")) {
-          [IO.Path]::Combine((Get-ProjectBinaryCache $BuildPlatform Compilers), "bin", "clang-cache.exe")
-        }
-        Add-KeyValueIfNew $Defines CMAKE_C_COMPILER_LAUNCHER $ClangCache
+      if ($UseC -and $CCompiler.DriverStyle -ne [DriverStyle]::CL) {
+        Add-KeyValueIfNew $Defines CMAKE_C_COMPILER_LAUNCHER `
+            (Join-Path -Path (Split-Path $CCompiler.Executable) -ChildPath "clang-cache.exe")
       }
 
-      if ($UseCXX) {
-        $ClangCache = if ($UsePinnedCompilers.Contains("CXX")) {
-          $(Join-Path -Path (Get-PinnedToolchainToolsDir) -ChildPath "clang-cache.exe")
-        } elseif ($UseBuiltCompilers.Contains("CXX")) {
-          [IO.Path]::Combine((Get-ProjectBinaryCache $BuildPlatform Compilers), "bin", "clang-cache.exe")
-        }
-        Add-KeyValueIfNew $Defines CMAKE_CXX_COMPILER_LAUNCHER $ClangCache
+      if ($UseCXX -and $CXXCompiler.DriverStyle -ne [DriverStyle]::CL) {
+        Add-KeyValueIfNew $Defines CMAKE_CXX_COMPILER_LAUNCHER `
+            (Join-Path -Path (Split-Path $CXXCompiler.Executable) -ChildPath "clang-cache.exe")
       }
 
       if ($UseSwift) {
@@ -1860,9 +1920,9 @@ function Build-CMakeProject {
       $cmakeGenerateArgs += @("-D", "$($Define.Key)=$Value")
     }
 
-    if ($UseBuiltCompilers.Contains("Swift")) {
-      $env:Path = "$([IO.Path]::Combine((Get-InstallDir $BuildPlatform), "Runtimes", $ProductVersion, "usr", "bin"));$(Get-CMarkBinaryCache $BuildPlatform)\src;$($BuildPlatform.ToolchainInstallRoot)\usr\bin;$(Get-PinnedToolchainRuntime);${env:Path}"
-    } elseif ($UsePinnedCompilers.Contains("Swift")) {
+    if ($SwiftCompiler -ne $null -and $SwiftCompiler.AssumeFunctional) {
+      $env:Path = "$([IO.Path]::Combine((Get-InstallDir $BuildPlatform), "Runtimes", $ProductVersion, "usr", "bin"));$(Get-CMarkBinaryCache $BuildPlatform)\src;$($BuildPlatform.ToolchainInstallRoot)\usr\bin;$($SwiftCompiler.Runtime);${env:Path}"
+    } elseif ($UseSwift) {
       $env:Path = "$(Get-PinnedToolchainRuntime);${env:Path}"
     }
 
@@ -2013,8 +2073,8 @@ function Build-CMark([Hashtable] $Platform) {
     -Bin (Get-CMarkBinaryCache $Platform) `
     -InstallTo "$(Get-InstallDir $Platform)\Toolchains\$ProductVersion+Asserts\usr" `
     -Platform $Platform `
-    -UseMSVCCompilers $(if ($UseHostToolchain) { @("C", "CXX") } else { @("") }) `
-    -UsePinnedCompilers $(if ($UseHostToolchain) { @("") } else { @("C", "CXX") }) `
+    -CCompiler $Compilers.Host.C `
+    -CXXCompiler $Compilers.Host.CXX `
     -Defines @{
       BUILD_SHARED_LIBS = "YES";
       BUILD_TESTING = "NO";
@@ -2027,8 +2087,10 @@ function Build-BuildTools([Hashtable] $Platform) {
     -Src $SourceCache\llvm-project\llvm `
     -Bin (Get-ProjectBinaryCache $Platform BuildTools) `
     -Platform $Platform `
-    -UseMSVCCompilers $(if ($UseHostToolchain) { @("ASM_MASM", "C", "CXX") } else { @("") }) `
-    -UsePinnedCompilers $(if ($UseHostToolchain) { @("") } else { @("ASM", "C", "CXX") }) `
+    -Assembler $(if ($UseHostToolchain) { $null } else { $Assemblers.Pinned }) `
+    -UseASMMASM:$UseHostToolchain `
+    -CCompiler $Compilers.Host.C `
+    -CXXCompiler $Compilers.Host.CXX `
     -BuildTargets llvm-tblgen,clang-tblgen,clang-tidy-confusable-chars-gen,lldb-tblgen,llvm-config,swift-def-to-strings-converter,swift-serialize-diagnostics,swift-compatibility-symbols `
     -Defines @{
       CMAKE_CROSSCOMPILING = "NO";
@@ -2066,7 +2128,9 @@ function Build-EarlySwiftDriver([Hashtable] $Platform) {
     -Src $SourceCache\swift-driver `
     -Bin (Get-ProjectBinaryCache $Platform EarlySwiftDriver) `
     -Platform $Platform `
-    -UsePinnedCompilers C,CXX,Swift `
+    -CCompiler $Compilers.Pinned.C `
+    -CXXCompiler $Compilers.Pinned.CXX `
+    -SwiftCompiler $Compilers.Pinned.Swift `
     -SwiftSDK (Get-PinnedToolchainSDK -OS $Platform.OS -Identifier "$($Platform.OS)Experimental") `
     -BuildTargets default `
     -Defines @{
@@ -2124,7 +2188,8 @@ function Build-CDispatch([Hashtable] $Platform, [switch] $Static = $false) {
     -Bin (Get-ProjectBinaryCache $Platform CDispatch) `
     -BuildTargets default `
     -Platform $Platform `
-    -UsePinnedCompilers C,CXX `
+    -CCompiler $Compilers.Pinned.C `
+    -CXXCompiler $Compilers.Pinned.CXX `
     -Defines @{
       BUILD_SHARED_LIBS = "YES";
       BUILD_TESTING = "NO";
@@ -2163,16 +2228,11 @@ function Get-CompilersDefines([Hashtable] $Platform, [string] $Variant, [switch]
     @{}
   }
 
-  $SwiftFlags = @();
-  if ($LTO -ne "none") {
-    $SwiftFlags += @("-use-ld=lld");
-  }
-
   return $TestDefines + $DebugDefines + @{
     CLANG_TABLEGEN = (Join-Path -Path $BuildTools -ChildPath "clang-tblgen.exe");
     CLANG_TIDY_CONFUSABLE_CHARS_GEN = (Join-Path -Path $BuildTools -ChildPath "clang-tidy-confusable-chars-gen.exe");
     CMAKE_STATIC_LIBRARY_PREFIX_Swift = "lib";
-    CMAKE_Swift_FLAGS = $SwiftFlags;
+    CMAKE_Swift_FLAGS = if ($LTO -ne "none") { @("-use-ld=lld") } else { @() };
     LibXml2_DIR = "$BinaryCache\$($Platform.Triple)\usr\lib\cmake\libxml2-2.11.5";
     LLDB_LIBXML2_VERSION = "2.11.5";
     LLDB_PYTHON_EXE_RELATIVE_PATH = "python.exe";
@@ -2248,8 +2308,9 @@ function Build-Compilers([Hashtable] $Platform, [string] $Variant) {
     -Bin (Get-ProjectBinaryCache $Platform Compilers) `
     -InstallTo "$(Get-InstallDir $Platform)\Toolchains\$ProductVersion+$Variant\usr" `
     -Platform $Platform `
-    -UseMSVCCompilers $(if ($UseHostToolchain) { @("C", "CXX") } else { @("") }) `
-    -UsePinnedCompilers $(if ($UseHostToolchain) { @("Swift") } else { @("C", "CXX", "Swift") }) `
+    -CCompiler $Compilers.Host.C `
+    -CXXCompiler $Compilers.Host.CXX `
+    -SwiftCompiler $Compilers.Pinned.Swift `
     -SwiftSDK (Get-PinnedToolchainSDK -OS $Platform.OS) `
     -BuildTargets @("install-distribution") `
     -CacheScript $SourceCache\swift\cmake\caches\Windows-$($Platform.Architecture.LLVMName).cmake `
@@ -2333,8 +2394,9 @@ function Test-Compilers([Hashtable] $Platform, [string] $Variant, [switch] $Test
       -Bin $(Get-ProjectBinaryCache $Platform Compilers) `
       -InstallTo "$($Platform.ToolchainInstallRoot)\usr" `
       -Platform $Platform `
-      -UseMSVCCompilers $(if ($UseHostToolchain) { @("C", "CXX") } else { @("") }) `
-      -UsePinnedCompilers $(if ($UseHostToolchain) { @("Swift") } else { @("C", "CXX", "Swift") }) `
+      -CCompiler $Compilers.Host.C `
+      -CXXCompiler $Compilers.Host.CXX `
+      -SwiftCompiler $Compilers.Pinned.Swift `
       -SwiftSDK (Get-PinnedToolchainSDK -OS $Platform.OS) `
       -BuildTargets $Targets `
       -CacheScript $SourceCache\swift\cmake\caches\Windows-$($Platform.Architecture.LLVMName).cmake `
@@ -2440,7 +2502,8 @@ function Build-LLVM([Hashtable] $Platform) {
     -Src $SourceCache\llvm-project\llvm `
     -Bin (Get-ProjectBinaryCache $Platform LLVM) `
     -Platform $Platform `
-    -UseBuiltCompilers C,CXX `
+    -CCompiler $Compilers.Built.C `
+    -CXXCompiler $Compilers.Built.CXX `
     -Defines @{
       LLVM_HOST_TRIPLE = $Platform.Triple;
     }
@@ -2462,7 +2525,9 @@ function Build-CompilerRuntime([Hashtable] $Platform) {
     -Bin "$(Get-ProjectBinaryCache $Platform ClangBuiltins)" `
     -InstallTo $InstallRoot `
     -Platform $Platform `
-    -UseBuiltCompilers ASM,C,CXX `
+    -Assembler $Assemblers.Built `
+    -CCompiler $Compilers.Built.C `
+    -CXXCompiler $Compilers.Built.CXX `
     -BuildTargets "install-compiler-rt" `
     -Defines @{
       LLVM_DIR = "$LLVMBinaryCache\lib\cmake\llvm";
@@ -2475,7 +2540,9 @@ function Build-CompilerRuntime([Hashtable] $Platform) {
     -Bin "$(Get-ProjectBinaryCache $Platform ClangRuntime)" `
     -InstallTo $InstallRoot `
     -Platform $Platform `
-    -UseBuiltCompilers ASM,C,CXX `
+    -Assembler $Assemblers.Built `
+    -CCompiler $Compilers.Built.C `
+    -CXXCompiler $Compilers.Built.CXX `
     -BuildTargets "install-compiler-rt" `
     -Defines @{
       LLVM_DIR = "$LLVMBinaryCache\lib\cmake\llvm";
@@ -2496,8 +2563,7 @@ function Build-Brotli([Hashtable] $Platform) {
     -Src $SourceCache\brotli `
     -Bin "$(Get-ProjectBinaryCache $Platform brotli)" `
     -Platform $Platform `
-    -UseMSVCCompilers $(if ($UseHostToolchain) { @("C") } else { @("") }) `
-    -UsePinnedCompilers $(if ($UseHostToolchain) { @("") } else { @("C") }) `
+    -CCompiler $Compilers.Host.C `
     -BuildTargets default `
     -Defines @{
       BUILD_SHARED_LIBS = "NO";
@@ -2513,8 +2579,7 @@ function Build-ZLib([Hashtable] $Platform) {
     -Bin "$BinaryCache\$($Platform.Triple)\zlib" `
     -InstallTo "$BinaryCache\$($Platform.Triple)\usr" `
     -Platform $Platform `
-    -UseMSVCCompilers $(if ($UseHostToolchain) { @("C") } else { @("") }) `
-    -UsePinnedCompilers $(if ($UseHostToolchain) { @("") } else { @("C") }) `
+    -CCompiler $Compilers.Host.C `
     -Defines @{
       BUILD_SHARED_LIBS = "NO";
       CMAKE_POSITION_INDEPENDENT_CODE = "YES";
@@ -2527,8 +2592,8 @@ function Build-XML2([Hashtable] $Platform) {
     -Bin "$BinaryCache\$($Platform.Triple)\libxml2-2.11.5" `
     -InstallTo "$BinaryCache\$($Platform.Triple)\usr" `
     -Platform $Platform `
-    -UseMSVCCompilers $(if ($UseHostToolchain) { @("C", "CXX") } else { @("") }) `
-    -UsePinnedCompilers $(if ($UseHostToolchain) { @("") } else { @("C", "CXX") }) `
+    -CCompiler $Compilers.Host.C `
+    -CXXCompiler $Compilers.Host.CXX `
     -Defines @{
       BUILD_SHARED_LIBS = "NO";
       CMAKE_POSITION_INDEPENDENT_CODE = "YES";
@@ -2576,8 +2641,8 @@ function Build-RegsGen2([Hashtable] $Platform) {
     -Bin (Get-ProjectBinaryCache $Platform RegsGen2) `
     -Platform $Platform `
     -BuildTargets default `
-    -UseMSVCCompilers $(if ($UseHostToolchain) { @("C", "CXX") } else { @("") }) `
-    -UsePinnedCompilers $(if ($UseHostToolchain) { @("") } else { @("C", "CXX") }) `
+    -CCompiler $Compilers.Host.C `
+    -CXXCompiler $Compilers.Host.CXX `
     -Defines @{
       BISON_EXECUTABLE = "$(Get-BisonExecutable)";
       FLEX_EXECUTABLE = "$(Get-FlexExecutable)";
@@ -2590,6 +2655,8 @@ function Build-DS2([Hashtable] $Platform) {
     -Bin "$BinaryCache\$($Platform.Triple)\ds2" `
     -InstallTo "$(Get-PlatformRoot $Platform.OS)\Developer\Library\ds2\usr" `
     -Platform $Platform `
+    -CCompiler $Compilers.Host.C `
+    -CXXCompiler $Compilers.Host.CXX `
     -Defines @{
       DS2_REGSGEN2 = "$(Get-ProjectBinaryCache $BuildPlatform RegsGen2)/regsgen2.exe";
       DS2_PROGRAM_PREFIX = "$(Get-ModuleTriple $Platform)-";
@@ -2611,8 +2678,7 @@ function Build-CURL([Hashtable] $Platform) {
     -Bin "$BinaryCache\$($Platform.Triple)\curl" `
     -InstallTo "$BinaryCache\$($Platform.Triple)\usr" `
     -Platform $Platform `
-    -UseMSVCCompilers $(if ($UseHostToolchain) { @("C") } else { @("") }) `
-    -UsePinnedCompilers $(if ($UseHostToolchain) { @("") } else { @("C") }) `
+    -CCompiler $Compilers.Host.C `
     -Defines ($PlatformDefines + @{
       BUILD_SHARED_LIBS = "NO";
       BUILD_TESTING = "NO";
@@ -2735,7 +2801,9 @@ function Build-Runtime([Hashtable] $Platform) {
     -Bin (Get-ProjectBinaryCache $Platform Runtime) `
     -InstallTo "$(Get-SwiftSDK -OS $Platform.OS -Identifier $Platform.DefaultSDK)\usr" `
     -Platform $Platform `
-    -UseBuiltCompilers C,CXX,Swift `
+    -CCompiler $Compilers.Built.C `
+    -CXXCompiler $Compilers.Built.CXX `
+    -SwiftCompiler $Compilers.Built.Swift `
     -SwiftSDK $null `
     -CacheScript $SourceCache\swift\cmake\caches\Runtime-$($Platform.OS.ToString())-$($Platform.Architecture.LLVMName).cmake `
     -Defines ($PlatformDefines + @{
@@ -2801,7 +2869,9 @@ function Test-Runtime([Hashtable] $Platform) {
       -Src $SourceCache\swift `
       -Bin (Get-ProjectBinaryCache $Platform Runtime) `
       -Platform $Platform `
-      -UseBuiltCompilers C,CXX,Swift `
+      -CCompiler $Compilers.Built.C `
+      -CXXCompiler $Compilers.Built.CXX `
+      -SwiftCompiler $Compilers.Built.Swift `
       -SwiftSDK $null `
       -BuildTargets check-swift-validation-only_non_executable `
       -Defines ($PlatformDefines + @{
@@ -2889,9 +2959,10 @@ function Build-ExperimentalRuntime([Hashtable] $Platform, [switch] $Static = $fa
       -Bin $RuntimeBinaryCache `
       -InstallTo "${SDKRoot}\usr" `
       -Platform $Platform `
-      -UseBuiltCompilers C,CXX,Swift `
+      -CCompiler $Compilers.Built.GNUC `
+      -CXXCompiler $Compilers.Built.GNUCXX `
+      -SwiftCompiler $Compilers.Built.Swift `
       -SwiftSDK $null `
-      -UseGNUDriver `
       -Defines @{
         BUILD_SHARED_LIBS = if ($Static) { "NO" } else { "YES" };
         CMAKE_STATIC_LIBRARY_PREFIX_Swift = "lib";
@@ -2918,9 +2989,10 @@ function Build-ExperimentalRuntime([Hashtable] $Platform, [switch] $Static = $fa
       -Bin $OverlayBinaryCache `
       -InstallTo "${SDKRoot}\usr" `
       -Platform $Platform `
-      -UseBuiltCompilers C,CXX,Swift `
+      -CCompiler $Compilers.Built.GNUC `
+      -CXXCompiler $Compilers.Built.GNUCXX `
+      -SwiftCompiler $Compilers.Built.Swift `
       -SwiftSDK $null `
-      -UseGNUDriver `
       -Defines @{
         BUILD_SHARED_LIBS = if ($Static) { "NO" } else { "YES" };
         CMAKE_STATIC_LIBRARY_PREFIX_Swift = "lib";
@@ -2938,9 +3010,9 @@ function Build-ExperimentalRuntime([Hashtable] $Platform, [switch] $Static = $fa
       -Bin $StringProcessingBinaryCache `
       -InstallTo "${SDKRoot}\usr" `
       -Platform $Platform `
-      -UseBuiltCompilers C,Swift `
+      -CCompiler $Compilers.Built.GNUC `
+      -SwiftCompiler $Compilers.Built.Swift `
       -SwiftSDK $null `
-      -UseGNUDriver `
       -Defines @{
         BUILD_SHARED_LIBS = if ($Static) { "NO" } else { "YES" };
         CMAKE_STATIC_LIBRARY_PREFIX_Swift = "lib";
@@ -2957,9 +3029,9 @@ function Build-ExperimentalRuntime([Hashtable] $Platform, [switch] $Static = $fa
       -Bin $SynchronizationBinaryCache `
       -InstallTo "${SDKRoot}\usr" `
       -Platform $Platform `
-      -UseBuiltCompilers C,Swift `
+      -CCompiler $Compilers.Built.GNUC `
+      -SwiftCompiler $Compilers.Built.Swift `
       -SwiftSDK $null `
-      -UseGNUDriver `
       -Defines @{
         BUILD_SHARED_LIBS = if ($Static) { "NO" } else { "YES" };
         CMAKE_STATIC_LIBRARY_PREFIX_Swift = "lib";
@@ -2977,9 +3049,10 @@ function Build-ExperimentalRuntime([Hashtable] $Platform, [switch] $Static = $fa
       -Bin $DistributedBinaryCache `
       -InstallTo "${SDKRoot}\usr" `
       -Platform $Platform `
-      -UseBuiltCompilers C,CXX,Swift `
+      -CCompiler $Compilers.Built.GNUC `
+      -CXXCompiler $Compilers.Built.GNUCXX `
+      -SwiftCompiler $Compilers.Built.Swift `
       -SwiftSDK $null `
-      -UseGNUDriver `
       -Defines @{
         BUILD_SHARED_LIBS = if ($Static) { "NO" } else { "YES" };
         # FIXME(#83449): avoid using `SwiftCMakeConfig.h`
@@ -2999,9 +3072,9 @@ function Build-ExperimentalRuntime([Hashtable] $Platform, [switch] $Static = $fa
       -Bin $ObservationBinaryCache `
       -InstallTo "${SDKRoot}\usr" `
       -Platform $Platform `
-      -UseBuiltCompilers CXX,Swift `
+      -CXXCompiler $Compilers.Built.GNUCXX `
+      -SwiftCompiler $Compilers.Built.Swift `
       -SwiftSDK $null `
-      -UseGNUDriver `
       -Defines @{
         BUILD_SHARED_LIBS = if ($Static) { "NO" } else { "YES" };
         # FIXME(#83449): avoid using `SwiftCMakeConfig.h`
@@ -3021,9 +3094,10 @@ function Build-ExperimentalRuntime([Hashtable] $Platform, [switch] $Static = $fa
       -Bin $DifferentiationBinaryCache `
       -InstallTo "${SDKRoot}\usr" `
       -Platform $Platform `
-      -UseBuiltCompilers C,CXX,Swift `
+      -CCompiler $Compilers.Built.GNUC `
+      -CXXCompiler $Compilers.Built.GNUCXX `
+      -SwiftCompiler $Compilers.Built.Swift `
       -SwiftSDK $null `
-      -UseGNUDriver `
       -Defines @{
         BUILD_SHARED_LIBS = if ($Static) { "NO" } else { "YES" };
         CMAKE_STATIC_LIBRARY_PREFIX_Swift = "lib";
@@ -3041,9 +3115,10 @@ function Build-ExperimentalRuntime([Hashtable] $Platform, [switch] $Static = $fa
       -Bin $VolatileBinaryCache `
       -InstallTo "${SDKROOT}\usr" `
       -Platform $Platform `
-      -UseBuiltCompilers C,Swift `
+      -CCompiler $Compilers.Built.GNUC `
+      -CXXCompiler $Compilers.Built.GNUCXX `
+      -SwiftCompiler $Compilers.Built.Swift `
       -SwiftSDK $null `
-      -UseGNUDriver `
       -Defines @{
         BUILD_SHARED_LIBS = if ($Static) { "NO" } else { "YES" };
         CMAKE_FIND_PACKAGE_PREFER_CONFIG = "YES";
@@ -3066,9 +3141,10 @@ function Build-ExperimentalRuntime([Hashtable] $Platform, [switch] $Static = $fa
       -Bin $RuntimeModuleBinaryCache `
       -InstallTo "${SDKROOT}\usr" `
       -Platform $Platform `
-      -UseBuiltCompilers C,CXX,Swift `
+      -CCompiler $Compilers.Built.GNUC `
+      -CXXCompiler $Compilers.Built.GNUCXX `
+      -SwiftCompiler $Compilers.Built.Swift `
       -SwiftSDK $null `
-      -UseGNUDriver `
       -Defines @{
         BUILD_SHARED_LIBS = if ($Static) { "NO" } else { "YES" };
         CMAKE_FIND_PACKAGE_PREFER_CONFIG = "YES";
@@ -3132,7 +3208,9 @@ function Build-Dispatch([Hashtable] $Platform) {
     -Bin (Get-ProjectBinaryCache $Platform Dispatch) `
     -InstallTo "${SwiftSDK}\usr" `
     -Platform $Platform `
-    -UseBuiltCompilers C,CXX,Swift `
+    -CCompiler $Compilers.Built.C `
+    -CXXCompiler $Compilers.Built.CXX `
+    -SwiftCompiler $Compilers.Built.Swift `
     -SwiftSDK $SwiftSDK `
     -Defines @{
       BUILD_TESTING = "NO";
@@ -3149,7 +3227,9 @@ function Test-Dispatch {
       -Src $SourceCache\swift-corelibs-libdispatch `
       -Bin (Get-ProjectBinaryCache $BuildPlatform Dispatch) `
       -Platform $BuildPlatform `
-      -UseBuiltCompilers C,CXX,Swift `
+      -CCompiler $Compilers.Built.C `
+      -CXXCompiler $Compilers.Built.CXX `
+      -SwiftCompiler $Compilers.Built.Swift `
       -SwiftSDK (Get-SwiftSDK -OS $BuildPlatform.OS -Identifier $BuildPlatform.DefaultSDK) `
       -BuildTargets default,ExperimentalTest `
       -Defines @{
@@ -3166,7 +3246,9 @@ function Build-Foundation([Hashtable] $Platform) {
     -Bin (Get-ProjectBinaryCache $Platform DynamicFoundation) `
     -InstallTo "${SwiftSDK}\usr" `
     -Platform $Platform `
-    -UseBuiltCompilers C,CXX,Swift `
+    -CCompiler $Compilers.Built.C `
+    -CXXCompiler $Compilers.Built.CXX `
+    -SwiftCompiler $Compilers.Built.Swift `
     -SwiftSDK $SwiftSDK `
     -Defines @{
       BUILD_SHARED_LIBS = "YES";
@@ -3244,7 +3326,7 @@ function Build-FoundationMacros([Hashtable] $Platform) {
     -Bin (Get-ProjectBinaryCache $Platform FoundationMacros) `
     -InstallTo "$($Platform.ToolchainInstallRoot)\usr" `
     -Platform $Platform `
-    -UseBuiltCompilers Swift `
+    -SwiftCompiler $Compilers.Built.Swift `
     -SwiftSDK (Get-SwiftSDK -OS $Platform.OS -Identifier $Platform.DefaultSDK) `
     -Defines @{
       SwiftSyntax_DIR = $SwiftSyntaxDir;
@@ -3263,7 +3345,7 @@ function Build-XCTest([Hashtable] $Platform) {
     -Bin (Get-ProjectBinaryCache $Platform XCTest) `
     -InstallTo "$([IO.Path]::Combine((Get-PlatformRoot $Platform.OS), "Developer", "Library", "XCTest-$ProductVersion", "usr"))" `
     -Platform $Platform `
-    -UseBuiltCompilers Swift `
+    -SwiftCompiler $Compilers.Built.Swift `
     -SwiftSDK (Get-SwiftSDK -OS $Platform.OS -Identifier $Platform.DefaultSDK) `
     -Defines @{
       BUILD_SHARED_LIBS = "YES";
@@ -3303,7 +3385,9 @@ function Test-XCTest {
       -Src $SourceCache\swift-corelibs-xctest `
       -Bin (Get-ProjectBinaryCache $BuildPlatform XCTest) `
       -Platform $BuildPlatform `
-      -UseBuiltCompilers C,CXX,Swift `
+      -CCompiler $Compilers.Built.C `
+      -CXXCompiler $Compilers.Built.CXX `
+      -SwiftCompiler $Compilers.Built.Swift `
       -SwiftSDK (Get-SwiftSDK -OS $Platform.OS -Identifier $Platform.DefaultSDK) `
       -BuildTargets default,check-xctest `
       -Defines @{
@@ -3328,7 +3412,8 @@ function Build-Testing([Hashtable] $Platform) {
     -Bin (Get-ProjectBinaryCache $Platform Testing) `
     -InstallTo "$([IO.Path]::Combine((Get-PlatformRoot $Platform.OS), "Developer", "Library", "Testing-$ProductVersion", "usr"))" `
     -Platform $Platform `
-    -UseBuiltCompilers CXX,Swift `
+    -CXXCompiler $Compilers.Built.CXX `
+    -SwiftCompiler $Compilers.Built.Swift `
     -SwiftSDK (Get-SwiftSDK -OS $Platform.OS -Identifier $Platform.DefaultSDK) `
     -Defines @{
       BUILD_SHARED_LIBS = "YES";
@@ -3438,9 +3523,9 @@ function Build-ExperimentalSDK([Hashtable] $Platform) {
             -Bin (Get-ProjectBinaryCache $Platform ExperimentalBacktrace) `
             -InstallTo "${SDKRoot}\usr" `
             -Platform $Platform `
-            -UseBuiltCompilers CXX,Swift `
+            -CXXCompiler $Compilers.Built.GNUCXX `
+            -SwiftCompiler $Compilers.Built.Swift `
             -SwiftSDK $null `
-            -UseGNUDriver `
             -Defines @{
               CMAKE_Swift_FLAGS = @("-static-stdlib");
               SwiftCore_DIR = "$(Get-ProjectBinaryCache $Platform ExperimentalStaticRuntime)\cmake\SwiftCore";
@@ -3462,7 +3547,9 @@ function Build-ExperimentalSDK([Hashtable] $Platform) {
         -Bin (Get-ProjectBinaryCache $Platform ExperimentalDynamicDispatch) `
         -InstallTo "${SDKROOT}\usr" `
         -Platform $Platform `
-        -UseBuiltCompilers C,CXX,Swift `
+        -CCompiler $Compilers.Built.C `
+        -CXXCompiler $Compilers.Built.CXX `
+        -SwiftCompiler $Compilers.Built.Swift `
         -SwiftSDK "${SDKROOT}" `
         -Defines @{
           BUILD_TESTING = "NO";
@@ -3480,7 +3567,10 @@ function Build-ExperimentalSDK([Hashtable] $Platform) {
         -Bin (Get-ProjectBinaryCache $Platform ExperimentalDynamicFoundation) `
         -InstallTo "${SDKROOT}\usr" `
         -Platform $Platform `
-        -UseBuiltCompilers ASM,C,CXX,Swift `
+        -Assembler $Assemblers.Built `
+        -CCompiler $Compilers.Built.C `
+        -CXXCompiler $Compilers.Built.CXX `
+        -SwiftCompiler $Compilers.Built.Swift `
         -SwiftSDK "${SDKROOT}" `
         -Defines @{
           BUILD_SHARED_LIBS = "YES";
@@ -3515,7 +3605,9 @@ function Build-ExperimentalSDK([Hashtable] $Platform) {
         -Bin (Get-ProjectBinaryCache $Platform ExperimentalStaticDispatch) `
         -InstallTo "${SDKROOT}\usr" `
         -Platform $Platform `
-        -UseBuiltCompilers C,CXX,Swift `
+        -CCompiler $Compilers.Built.C `
+        -CXXCompiler $Compilers.Built.CXX `
+        -SwiftCompiler $Compilers.Built.Swift `
         -SwiftSDK "${SDKROOT}" `
         -Defines @{
           BUILD_TESTING = "NO";
@@ -3533,7 +3625,10 @@ function Build-ExperimentalSDK([Hashtable] $Platform) {
         -Bin (Get-ProjectBinaryCache $Platform ExperimentalStaticFoundation) `
         -InstallTo "${SDKROOT}\usr" `
         -Platform $Platform `
-        -UseBuiltCompilers ASM,C,CXX,Swift `
+        -Assembler $Assemblers.Built `
+        -CCompiler $Compilers.Built.C `
+        -CXXCompiler $Compilers.Built.CXX `
+        -SwiftCompiler $Compilers.Built.Swift `
         -SwiftSDK ${SDKROOT} `
         -Defines @{
           BUILD_SHARED_LIBS = "NO";
@@ -3567,8 +3662,7 @@ function Build-SQLite([Hashtable] $Platform) {
     -Src $SourceCache\swift-toolchain-sqlite `
     -Bin (Get-ProjectBinaryCache $Platform SQLite) `
     -Platform $Platform `
-    -UseMSVCCompilers $(if ($UseHostToolchain) { @("C") } else { @("") }) `
-    -UsePinnedCompilers $(if ($UseHostToolchain) { @("") } else { @("C") }) `
+    -CCompiler $Compilers.Host.C `
     -BuildTargets default `
     -Defines @{
       BUILD_SHARED_LIBS = "NO";
@@ -3580,7 +3674,8 @@ function Build-System([Hashtable] $Platform) {
     -Src $SourceCache\swift-system `
     -Bin (Get-ProjectBinaryCache $Platform System) `
     -Platform $Platform `
-    -UseBuiltCompilers C,Swift `
+    -CCompiler $Compilers.Built.C `
+    -SwiftCompiler $Compilers.Built.Swift `
     -SwiftSDK (Get-SwiftSDK -OS $Platform.OS -Identifier $Platform.DefaultSDK) `
     -BuildTargets default `
     -Defines @{
@@ -3594,7 +3689,8 @@ function Build-Subprocess([Hashtable] $Platform) {
     -Src $sourceCache\swift-subprocess `
     -Bin (Get-ProjectBinaryCache $Platform Subprocess) `
     -Platform $Platform `
-    -UseBuiltCompilers C,Swift `
+    -CCompiler $Compilers.Built.C `
+    -SwiftCompiler $Compilers.Built.Swift `
     -SwiftSDK (Get-SwiftSDK -OS $Platform.OS -Identifier $Platform.DefaultSDK) `
     -BuildTargets default `
     -Defines @{
@@ -3610,7 +3706,9 @@ function Build-ToolsProtocols([Hashtable] $Platform) {
     -Bin (Get-ProjectBinaryCache $Platform ToolsProtocols) `
     -InstallTo "$($Platform.ToolchainInstallRoot)\usr" `
     -Platform $Platform `
-    -UseBuiltCompilers C,CXX,Swift `
+    -CCompiler $Compilers.Built.C `
+    -CXXCompiler $Compilers.Built.CXX `
+    -SwiftCompiler $Compilers.Built.Swift `
     -SwiftSDK (Get-SwiftSDK -OS $Platform.OS -Identifier $Platform.DefaultSDK) `
     -Defines @{
       BUILD_SHARED_LIBS = "YES";
@@ -3627,7 +3725,9 @@ function Build-Build([Hashtable] $Platform) {
     -Bin (Get-ProjectBinaryCache $Platform Build) `
     -InstallTo "$($Platform.ToolchainInstallRoot)\usr" `
     -Platform $Platform `
-    -UseBuiltCompilers C,CXX,Swift `
+    -CCompiler $Compilers.Built.C `
+    -CXXCompiler $Compilers.Built.CXX `
+    -SwiftCompiler $Compilers.Built.Swift `
     -SwiftSDK (Get-SwiftSDK -OS $Platform.OS -Identifier $Platform.DefaultSDK) `
     -Defines (@{
       BUILD_SHARED_LIBS = "YES";
@@ -3649,7 +3749,8 @@ function Build-ToolsSupportCore([Hashtable] $Platform) {
     -Bin (Get-ProjectBinaryCache $Platform ToolsSupportCore) `
     -InstallTo "$($Platform.ToolchainInstallRoot)\usr" `
     -Platform $Platform `
-    -UseBuiltCompilers C,Swift `
+    -CCompiler $Compilers.Built.C `
+    -SwiftCompiler $Compilers.Built.Swift `
     -SwiftSDK (Get-SwiftSDK -OS $Platform.OS -Identifier $Platform.DefaultSDK) `
     -Defines @{
       BUILD_SHARED_LIBS = "YES";
@@ -3666,9 +3767,8 @@ function Build-LLBuild([Hashtable] $Platform) {
     -Bin (Get-ProjectBinaryCache $Platform LLBuild) `
     -InstallTo "$($Platform.ToolchainInstallRoot)\usr" `
     -Platform $Platform `
-    -UseMSVCCompilers $(if ($UseHostToolchain) { @("CXX") } else { @("") }) `
-    -UsePinnedCompilers $(if ($UseHostToolchain) { @("") } else { @("CXX") }) `
-    -UseBuiltCompilers Swift `
+    -CXXCompiler $Compilers.Host.CXX `
+    -SwiftCompiler $Compilers.Built.Swift `
     -SwiftSDK (Get-SwiftSDK -OS $Platform.OS -Identifier $Platform.DefaultSDK) `
     -Defines @{
       BUILD_SHARED_LIBS = "YES";
@@ -3695,9 +3795,8 @@ function Test-LLBuild {
       -Src $SourceCache\llbuild `
       -Bin (Get-ProjectBinaryCache $BuildPlatform LLBuild) `
       -Platform $Platform `
-      -UseMSVCCompilers $(if ($UseHostToolchain) { @("CXX") } else { @("") }) `
-      -UsePinnedCompilers $(if ($UseHostToolchain) { @("") } else { @("CXX") }) `
-      -UseBuiltCompilers Swift `
+      -CXXCompiler $Compilers.Host.CXX `
+      -SwiftCompiler $Compilers.Built.Swift `
       -SwiftSDK (Get-SwiftSDK -OS $BuildPlatform.OS -Identifier $BuildPlatform.DefaultSDK) `
       -BuildTargets default,test-llbuild `
       -Defines = @{
@@ -3717,8 +3816,8 @@ function Build-ArgumentParser([Hashtable] $Platform) {
     -Bin (Get-ProjectBinaryCache $Platform ArgumentParser) `
     -InstallTo "$($Platform.ToolchainInstallRoot)\usr" `
     -Platform $Platform `
-    -UseBuiltCompilers Swift `
-    -UseMSVCCompilers C `
+    -CCompiler $Compilers.Host.C `
+    -SwiftCompiler $Compilers.Built.Swift `
     -SwiftSDK (Get-SwiftSDK -OS $Platform.OS -Identifier $Platform.DefaultSDK) `
     -Defines @{
       BUILD_SHARED_LIBS = "YES";
@@ -3734,7 +3833,9 @@ function Build-Driver([Hashtable] $Platform) {
     -Bin (Get-ProjectBinaryCache $Platform Driver) `
     -InstallTo "$($Platform.ToolchainInstallRoot)\usr" `
     -Platform $Platform `
-    -UseBuiltCompilers C,CXX,Swift `
+    -CCompiler $Compilers.Built.C `
+    -CXXCompiler $Compilers.Built.CXX `
+    -SwiftCompiler $Compilers.Built.Swift `
     -SwiftSDK (Get-SwiftSDK -OS $Platform.OS -Identifier $Platform.DefaultSDK) `
     -Defines @{
       BUILD_SHARED_LIBS = "YES";
@@ -3756,7 +3857,10 @@ function Build-Crypto([Hashtable] $Platform) {
     -Src $SourceCache\swift-crypto `
     -Bin (Get-ProjectBinaryCache $Platform Crypto) `
     -Platform $Platform `
-    -UseBuiltCompilers ASM, C, CXX, Swift `
+    -Assembler $Assemblers.Built `
+    -CCompiler $Compilers.Built.C `
+    -CXXCompiler $Compilers.Built.CXX `
+    -SwiftCompiler $Compilers.Built.Swift `
     -SwiftSDK (Get-SwiftSDK -OS $Platform.OS -Identifier $Platform.DefaultSDK) `
     -BuildTargets default `
     -Defines @{
@@ -3772,7 +3876,8 @@ function Build-Collections([Hashtable] $Platform) {
     -Bin (Get-ProjectBinaryCache $Platform Collections) `
     -InstallTo "$($Platform.ToolchainInstallRoot)\usr" `
     -Platform $Platform `
-    -UseBuiltCompilers C,Swift `
+    -CCompiler $Compilers.Built.C `
+    -SwiftCompiler $Compilers.Built.Swift `
     -SwiftSDK (Get-SwiftSDK -OS $Platform.OS -Identifier $Platform.DefaultSDK) `
     -Defines @{
       BUILD_SHARED_LIBS = "YES";
@@ -3785,7 +3890,7 @@ function Build-ASN1([Hashtable] $Platform) {
     -Src $SourceCache\swift-asn1 `
     -Bin (Get-ProjectBinaryCache $Platform ASN1) `
     -Platform $Platform `
-    -UseBuiltCompilers Swift `
+    -SwiftCompiler $Compilers.Built.Swift `
     -SwiftSDK (Get-SwiftSDK -OS $Platform.OS -Identifier $Platform.DefaultSDK) `
     -BuildTargets default `
     -Defines @{
@@ -3799,7 +3904,7 @@ function Build-Certificates([Hashtable] $Platform) {
     -Src $SourceCache\swift-certificates `
     -Bin (Get-ProjectBinaryCache $Platform Certificates) `
     -Platform $Platform `
-    -UseBuiltCompilers Swift `
+    -SwiftCompiler $Compilers.Built.Swift `
     -SwiftSDK (Get-SwiftSDK -OS $Platform.OS -Identifier $Platform.DefaultSDK) `
     -BuildTargets default `
     -Defines @{
@@ -3822,7 +3927,8 @@ function Build-PackageManager([Hashtable] $Platform) {
     -Bin (Get-ProjectBinaryCache $Platform PackageManager) `
     -InstallTo "$($Platform.ToolchainInstallRoot)\usr" `
     -Platform $Platform `
-    -UseBuiltCompilers C,Swift `
+    -CCompiler $Compilers.Built.C `
+    -SwiftCompiler $Compilers.Built.Swift `
     -SwiftSDK (Get-SwiftSDK -OS $Platform.OS -Identifier $Platform.DefaultSDK) `
     -Defines @{
       BUILD_SHARED_LIBS = "YES";
@@ -3857,9 +3963,10 @@ function Build-PackageManagerRuntime([Hashtable] $Platform) {
     -Bin (Get-ProjectBinaryCache $Platform PackageManagerRuntime) `
     -InstallTo "$($Platform.ToolchainInstallRoot)\usr" `
     -Platform $Platform `
-    -UseBuiltCompilers C,CXX,Swift `
+    -CCompiler $Compilers.Built.GNUC `
+    -CXXCompiler $Compilers.Built.GNUCXX `
+    -SwiftCompiler $Compilers.Built.Swift `
     -SwiftSDK (Get-SwiftSDK -OS $Platform.OS -Identifier $Platform.DefaultSDK) `
-    -UseGNUDriver `
     -Defines @{
       BUILD_SHARED_LIBS = "YES";
       SwiftPM_ENABLE_RUNTIME = "NO";
@@ -3872,7 +3979,8 @@ function Build-Markdown([Hashtable] $Platform) {
     -Bin (Get-ProjectBinaryCache $Platform Markdown) `
     -InstallTo "$($Platform.ToolchainInstallRoot)\usr" `
     -Platform $Platform `
-    -UseBuiltCompilers C,Swift `
+    -CCompiler $Compilers.Built.C `
+    -SwiftCompiler $Compilers.Built.Swift `
     -SwiftSDK (Get-SwiftSDK -OS $Platform.OS -Identifier $Platform.DefaultSDK) `
     -Defines @{
       BUILD_SHARED_LIBS = "NO";
@@ -3888,9 +3996,8 @@ function Build-Format([Hashtable] $Platform) {
     -Bin (Get-ProjectBinaryCache $Platform Format) `
     -InstallTo "$($Platform.ToolchainInstallRoot)\usr" `
     -Platform $Platform `
-    -UseMSVCCompilers $(if ($UseHostToolchain) { @("C") } else { @("") }) `
-    -UsePinnedCompilers $(if ($UseHostToolchain) { @("") } else { @("C") }) `
-    -UseBuiltCompilers Swift `
+    -CCompiler $Compilers.Host.C `
+    -SwiftCompiler $Compilers.Built.Swift `
     -SwiftSDK (Get-SwiftSDK -OS $Platform.OS -Identifier $Platform.DefaultSDK) `
     -Defines @{
       BUILD_SHARED_LIBS = "YES";
@@ -3944,8 +4051,7 @@ function Build-LMDB([Hashtable] $Platform) {
     -Src $SourceCache\swift-lmdb `
     -Bin (Get-ProjectBinaryCache $Platform LMDB) `
     -Platform $Platform `
-    -UseMSVCCompilers $(if ($UseHostToolchain) { @("C") } else { @("") }) `
-    -UsePinnedCompilers $(if ($UseHostToolchain) { @("") } else { @("C") }) `
+    -CCompiler $Compilers.Host.C `
     -BuildTargets default
 }
 
@@ -3955,7 +4061,9 @@ function Build-IndexStoreDB([Hashtable] $Platform) {
     -Src $SourceCache\indexstore-db `
     -Bin (Get-ProjectBinaryCache $Platform IndexStoreDB) `
     -Platform $Platform `
-    -UseBuiltCompilers C,CXX,Swift `
+    -CCompiler $Compilers.Built.C `
+    -CXXCompiler $Compilers.Built.CXX `
+    -SwiftCompiler $Compilers.Built.Swift `
     -SwiftSDK $SDKROOT `
     -BuildTargets default `
     -Defines @{
@@ -3973,7 +4081,8 @@ function Build-SourceKitLSP([Hashtable] $Platform) {
     -Bin (Get-ProjectBinaryCache $Platform SourceKitLSP) `
     -InstallTo "$($Platform.ToolchainInstallRoot)\usr" `
     -Platform $Platform `
-    -UseBuiltCompilers C,Swift `
+    -CCompiler $Compilers.Built.C `
+    -SwiftCompiler $Compilers.Built.Swift `
     -SwiftSDK (Get-SwiftSDK -OS $Platform.OS -Identifier $Platform.DefaultSDK) `
     -Defines @{
       CMAKE_STATIC_LIBRARY_PREFIX_Swift = "lib";
@@ -4090,7 +4199,7 @@ function Build-BootstrapFoundationMacros([Hashtable] $Platform) {
     -Bin (Get-ProjectBinaryCache $Platform BootstrapFoundationMacros) `
     -BuildTargets default `
     -Platform $Platform `
-    -UsePinnedCompilers Swift `
+    -SwiftCompiler $Compilers.Built.Swift `
     -SwiftSDK (Get-PinnedToolchainSDK -OS $Platform.OS) `
     -Defines @{
       SwiftSyntax_DIR = (Get-ProjectCMakeModules $Platform Compilers);
@@ -4103,7 +4212,7 @@ function Build-BootstrapTestingMacros([Hashtable] $Platform) {
     -Bin (Get-ProjectBinaryCache $Platform BootstrapTestingMacros) `
     -BuildTargets default `
     -Platform $Platform `
-    -UsePinnedCompilers Swift `
+    -SwiftCompiler $Compilers.Built.Swift `
     -SwiftSDK (Get-PinnedToolchainSDK -OS $Platform.OS) `
     -Defines @{
       SwiftSyntax_DIR = (Get-ProjectCMakeModules $Platform Compilers);
@@ -4116,7 +4225,7 @@ function Build-TestingMacros([Hashtable] $Platform) {
     -Bin (Get-ProjectBinaryCache $Platform TestingMacros) `
     -InstallTo "$($Platform.ToolchainInstallRoot)\usr"  `
     -Platform $Platform `
-    -UseBuiltCompilers Swift `
+    -SwiftCompiler $Compilers.Built.Swift `
     -SwiftSDK (Get-SwiftSDK -OS $Platform.OS -Identifier $Platform.DefaultSDK) `
     -Defines @{
       SwiftSyntax_DIR = (Get-ProjectCMakeModules $Platform Compilers);
@@ -4174,7 +4283,9 @@ function Build-Inspect([Hashtable] $Platform) {
     -Bin (Get-ProjectBinaryCache $Platform SwiftInspect)`
     -InstallTo $InstallPath `
     -Platform $Platform `
-    -UseBuiltCompilers C,CXX,Swift `
+    -CCompiler $Compilers.Built.C `
+    -CXXCompiler $Compilers.Built.CXX `
+    -SwiftCompiler $Compilers.Built.Swift `
     -SwiftSDK $SDKROOT `
     -Defines @{
       CMAKE_Swift_FLAGS = @(

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -2242,8 +2242,8 @@ function Get-CompilersDefines([Hashtable] $Platform, [string] $Variant, [switch]
 }
 
 function Build-Compilers([Hashtable] $Platform, [string] $Variant) {
-  New-Item -ItemType Directory -Path $BinaryCache\$($HostPlatform.Triple) -ErrorAction Ignore
-  New-Item -ItemType SymbolicLink -Path "$BinaryCache\$($HostPlatform.Triple)\compilers" -Target "$BinaryCache\5" -ErrorAction Ignore
+  New-Item -ItemType Directory -Path $BinaryCache\$($HostPlatform.Triple) -ErrorAction Ignore | Out-Null
+  New-Item -ItemType SymbolicLink -Path "$BinaryCache\$($HostPlatform.Triple)\compilers" -Target "$BinaryCache\5" -ErrorAction Ignore | Out-Null
   Build-CMakeProject `
     -Src $SourceCache\llvm-project\llvm `
     -Bin (Get-ProjectBinaryCache $Platform Compilers) `

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -103,8 +103,7 @@ An array of architectures for which the Windows Swift SDK should be built.
 Default: @("X64","X86","ARM64")
 
 .PARAMETER Clean
-Clean non-compiler builds while building. Use this for a fresh build when
-experiencing issues.
+Remove selected build outputs before building.
 
 .PARAMETER SkipBuild
 Skip the build phase entirely. Useful for testing packaging or other post-build
@@ -4301,21 +4300,31 @@ try {
 Get-Dependencies
 
 if ($Clean) {
-  Remove-Item -Force -Recurse -Path "$BinaryCache\$($BuildPlatform.Triple)\" -ErrorAction Ignore
-  Remove-Item -Force -Recurse -Path "$BinaryCache\$($HostPlatform.Triple)\" -ErrorAction Ignore
+  # Fail instead of leaving a partially-cleaned tree behind.
+  function Clean-Path([string] $Path) {
+    if (-not (Test-Path -LiteralPath $Path)) { return }
+    try {
+      [System.IO.Directory]::Delete("\\?\$Path", $true)
+    } catch {
+      throw "Failed to clean '$Path': $_"
+    }
+  }
+
+  Clean-Path "$BinaryCache\$($BuildPlatform.Triple)"
+  Clean-Path "$BinaryCache\$($HostPlatform.Triple)"
   foreach ($Build in $WindowsSDKBuilds) {
-    Remove-Item -Force -Recurse -Path "$BinaryCache\$($Build.Triple)\" -ErrorAction Ignore
+    Clean-Path "$BinaryCache\$($Build.Triple)"
   }
   foreach ($Build in $AndroidSDKBuilds) {
-    Remove-Item -Force -Recurse -Path "$BinaryCache\$($Build.Triple)\" -ErrorAction Ignore
+    Clean-Path "$BinaryCache\$($Build.Triple)"
   }
-  Remove-Item -Force -Recurse -Path "$BinaryCache\1" -ErrorAction Ignore
-  Remove-Item -Force -Recurse -Path "$BinaryCache\5" -ErrorAction Ignore
-  Remove-Item -Force -Recurse -Path (Get-InstallDir $HostPlatform) -ErrorAction Ignore
+  Clean-Path "$BinaryCache\1"
+  Clean-Path "$BinaryCache\5"
+  Clean-Path (Get-InstallDir $HostPlatform)
 
   Get-SelectedSDKBuilds | ForEach-Object {
-    Remove-Item -Force -Recurse -Path (Get-ProjectBinaryCache $_ ClangBuiltins) -ErrorAction Ignore
-    Remove-Item -Force -Recurse -Path (Get-ProjectBinaryCache $_ ClangRuntime) -ErrorAction Ignore
+    Clean-Path (Get-ProjectBinaryCache $_ ClangBuiltins)
+    Clean-Path (Get-ProjectBinaryCache $_ ClangRuntime)
   }
 }
 


### PR DESCRIPTION
This pull request adds support for embedding Windows version resources into various Swift runtime and overlay libraries by invoking the `swift_add_windows_version_resource` function in their respective CMake build scripts. This ensures that when building these components for Windows, the resulting binaries will have appropriate version information embedded, improving compatibility and maintainability.

The most important changes are:

**Core Runtime and Overlay Libraries:**

* Added `swift_add_windows_version_resource` to the CMake build scripts for core libraries such as `swiftCore`, `swift_Concurrency`, `swiftSwiftOnoneSupport`, and `swiftRemoteMirror`, ensuring Windows version resources are embedded in these binaries. [[1]](diffhunk://#diff-58cf1b348980556a26ac2e00976d5dcd6d69264a438140dee54244b8f3d201f7R49) [[2]](diffhunk://#diff-6df2a5ca96732047d449133c8783eeaaa9100476ad80ca6fb055c7984ba75339R100) [[3]](diffhunk://#diff-9645135885f0422d03d572e70e2c78058bd1c5ce0a7347008d0b007a08195840R267) [[4]](diffhunk://#diff-266aba15da3a017bb20d6194f24813fc3c67d30708f05ad1921f80c963917460R4) [[5]](diffhunk://#diff-e730e2320e130a3672c6dc08a4724606d5bf4b1fc34f7e4e1ae89bd1501a90e4R4)

**Supplemental Libraries and Tools:**

* Applied `swift_add_windows_version_resource` to supplemental libraries including `swift_Differentiation`, `swiftDistributed`, `swiftObservation`, `swiftRuntime`, and the `swift-backtrace` executable, embedding version resources for improved Windows support. [[1]](diffhunk://#diff-b2a2b0af4bffd95deea5e05b9d54c3a0b94c71dfd19d6e1eeb7e3d3a773109bdR119) [[2]](diffhunk://#diff-3879e4d805c34fadd71b258389f54c89ade20d0b16197d4a21e737dfb3d01bbcR110) [[3]](diffhunk://#diff-ea6acf92d454b341b351455bf17b8c75cc20c5499c7701ece35994928983ef5eR107) [[4]](diffhunk://#diff-4fbe4077ff301d7280fa8f746ad2993dbd3997772140703d3ee4d45bd4e4856eR133) [[5]](diffhunk://#diff-6cb1065f121d885f15dcda2aa10a69932fefb35b29ae5100799d68b545f26d2aR79)

**Platform-specific Overlays:**

* Updated platform overlays for Android (`swiftAndroid`, `swift_math`), Linux (`swiftGlibc`), WASI (`swiftWASILibc`), and Windows (`swiftCRT`, `swiftWinSDK`) to embed Windows version resources. [[1]](diffhunk://#diff-941f859134c9549b239869c7a98e093229e724348a6965716a0749e43415eaaeR10) [[2]](diffhunk://#diff-496aff7eca19cdc4f80da85571ffce0c1e536e9fccff08306311d04431e46d77R4) [[3]](diffhunk://#diff-8a1b44791e0f2fcfc5cc24a784e569e2716a160fb40fe1b986fe2bc58bf301a9R12) [[4]](diffhunk://#diff-b40fef1e298206026c1ed5799c35f6587060c644106249f63221590106022d2eR11) [[5]](diffhunk://#diff-a4ffe43f8fd49dafb36f2800044cea7c71454f6fd837a77a97ba37e937ee797bR10) [[6]](diffhunk://#diff-0b07162c0db87c303dfd08a7a52868532d62181a55a007642796bd62c7e42b12R4)

**CMake Configuration Enhancements:**

* Included the `SwiftAddWindowsVersionResource` module in the CMake configuration for all affected projects, making the new function available where needed. [[1]](diffhunk://#diff-58cf1b348980556a26ac2e00976d5dcd6d69264a438140dee54244b8f3d201f7R49) [[2]](diffhunk://#diff-01953a5c55e5c9471252dcf73833a6196d2f65a6a46daa291fec1ef343053cd7R22) [[3]](diffhunk://#diff-b2a2b0af4bffd95deea5e05b9d54c3a0b94c71dfd19d6e1eeb7e3d3a773109bdR17) [[4]](diffhunk://#diff-3879e4d805c34fadd71b258389f54c89ade20d0b16197d4a21e737dfb3d01bbcR18) [[5]](diffhunk://#diff-ea6acf92d454b341b351455bf17b8c75cc20c5499c7701ece35994928983ef5eR18) [[6]](diffhunk://#diff-4fbe4077ff301d7280fa8f746ad2993dbd3997772140703d3ee4d45bd4e4856eR17) [[7]](diffhunk://#diff-6cb1065f121d885f15dcda2aa10a69932fefb35b29ae5100799d68b545f26d2aR11) [[8]](diffhunk://#diff-db72d5f1f93843c15321ef32248b99f1d58e9ea8db1ede6ad00fad4abfe39a5aR19)

**Other Overlays:**

* Added version resource embedding to additional overlays such as `swift_Builtin_float` and `swiftRegexBuilder`. [[1]](diffhunk://#diff-428178e7ea4267eff2ac1565d52b4b0e41e5e209af627dd35de7d9e2cf008c3dR8) [[2]](diffhunk://#diff-bf8883e0c2a3c49937f60c15217be948cf823bd78379a538db4883f9869b9229R8)