### PR TITLE
Disable test that timed out

### DIFF
--- a/validation-test/SILOptimizer/large_inline_array.swift.gyb
+++ b/validation-test/SILOptimizer/large_inline_array.swift.gyb
@@ -20,6 +20,8 @@
 // REQUIRES: long_test
 // REQUIRES: CPU=arm64 || CPU=x86_64 || CPU=aarch64
 
+// REQUIRES: rdar176849287
+
 // Check if the optimizer can optimize the whole array into a statically
 // initialized global
 


### PR DESCRIPTION
`validation-test/SILOptimizer/large_inline_array.swift.gyb` timed out in CI. Disable it while we investigate