### PR TITLE
[Embedded] Only build tests with an optimized standard library

### DIFF
--- a/test/embedded/availability-macos.swift
+++ b/test/embedded/availability-macos.swift
@@ -9,6 +9,7 @@
 // REQUIRES: swift_feature_Embedded
 // REQUIRES: OS=macosx
 // REQUIRES: concurrency
+// REQUIRES: optimized_stdlib
 
 import _Concurrency
 

--- a/test/embedded/concurrency-non-symbols.swift
+++ b/test/embedded/concurrency-non-symbols.swift
@@ -2,6 +2,7 @@
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: swift_feature_Embedded
+// REQUIRES: optimized_stdlib
 
 // Check for symbols that we explicitly don't want in the Embedded Swift
 // concurrency library.


### PR DESCRIPTION
Fixes rdar://176819678, where a debug standard library meant that the embedded tests would fail.
