### PR TITLE
[6.4][Concurrency] Implement Continuation (SE-0528)

### DIFF
--- a/Runtimes/Core/Concurrency/CMakeLists.txt
+++ b/Runtimes/Core/Concurrency/CMakeLists.txt
@@ -46,6 +46,7 @@ add_library(swift_Concurrency
   AsyncThrowingPrefixWhileSequence.swift
   AsyncThrowingStream.swift
   CheckedContinuation.swift
+  Continuation.swift
   Clock.swift
   ContinuousClock.swift
   CooperativeExecutor.swift

--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -1735,7 +1735,11 @@ static ValueDecl *getDistributedActorInitializeRemote(ASTContext &ctx,
 static ValueDecl *getResumeContinuationReturning(ASTContext &ctx,
                                                  Identifier id) {
   return getBuiltinFunction(ctx, id, _thin,
-                            _generics(_unrestricted, _conformsToDefaults(0)),
+                            _generics(_unrestricted,
+                                      _conformsTo(
+                                        _typeparam(0), _escapable)
+                                        // we allow ~Copyable, so we do not require Copyable conformance
+                                      ),
                             _parameters(_rawUnsafeContinuation,
                                         _owned(_typeparam(0))),
                             _void);

--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -99,6 +99,7 @@ set(SWIFT_RUNTIME_CONCURRENCY_SWIFT_SOURCES
   Actor.swift
   AsyncLet.swift
   CheckedContinuation.swift
+  Continuation.swift
   Errors.swift
   Executor.swift
   ExecutorBridge.swift

--- a/stdlib/public/Concurrency/Continuation.swift
+++ b/stdlib/public/Concurrency/Continuation.swift
@@ -1,0 +1,228 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Swift
+
+/// A mechanism to interface between synchronous and asynchronous code,
+/// which enforces that the continuation is resumed exactly once.
+///
+/// Unlike `CheckedContinuation`, which detects misuse at runtime,
+/// `Continuation` uses non-copyable semantics to enforce correct usage.
+///
+/// The continuation must only ever be resumed **exactly-once**.
+/// The compiler will prevent attempts from resuming the continuation more than once.
+///
+/// If a `Continuation` is destroyed without being
+/// resumed, the program traps with a diagnostic message indicating where
+/// the continuation was created. Because it is noncopyable, the compiler
+/// prevents accidental copies, and the `consuming` resume methods ensure
+/// the continuation can only be used once.
+///
+/// To create a continuation
+/// call ``withContinuation(of:throwing:_:)``.
+///
+/// To resume the task, suspended on a continuation, call ``resume(returning:)``,
+/// ``resume(throwing:)``, ``resume(with:)``, or ``resume()``.
+///
+/// - SeeAlso: ``CheckedContinuation``
+@safe
+@frozen
+@available(SwiftStdlib 6.4, *)
+public struct Continuation<Success: ~Copyable, Failure: Error>: ~Copyable, @unchecked Sendable {
+
+  // Implementation note: we're using raw continuation here since UnsafeContinuation
+  // did not yet adopt ~Copyable, and doing so is a bit more involved.
+  // TODO: Once UnsafeContinuation supports ~Copyable Success, we can use it here.
+  @usableFromInline
+  let context: Builtin.RawUnsafeContinuation
+
+  @inlinable
+  init(_ context: Builtin.RawUnsafeContinuation) {
+    unsafe self.context = context
+  }
+
+  deinit {
+    fatalError("Continuation was deinitialized without being resumed.")
+  }
+
+  /// Extract the underlying raw continuation and discard `self`
+  /// without firing the deinit trap
+  @_alwaysEmitIntoClient
+  consuming func _takeContext() -> Builtin.RawUnsafeContinuation {
+    let ctx = unsafe self.context
+    discard self
+    return unsafe ctx
+  }
+
+  /// Resume the task awaiting the continuation by having it return
+  /// from its suspension point
+  ///
+  /// - Parameter value: The value to return from the continuation
+  @_alwaysEmitIntoClient
+  public consuming func resume(returning value: consuming sending Success) where Failure == Never {
+    unsafe Builtin.resumeNonThrowingContinuationReturning(context, value)
+    discard self // prevent deinit from firing
+  }
+
+  /// Resume the task awaiting the continuation by having it return
+  /// from its suspension point
+  ///
+  /// - Parameter value: The value to return from the continuation
+  @_alwaysEmitIntoClient
+  public consuming func resume(returning value: consuming sending Success) {
+    unsafe Builtin.resumeThrowingContinuationReturning(context, value)
+    discard self // prevent deinit from firing
+  }
+
+  /// Resume the task awaiting the continuation by having it throw an error
+  /// from its suspension point
+  ///
+  /// - Parameter error: The error to throw from the continuation
+  @_alwaysEmitIntoClient
+  public consuming func resume(throwing error: __owned Failure) {
+    unsafe Builtin.resumeThrowingContinuationThrowing(context, error)
+    discard self // prevent deinit from firing
+  }
+
+  /// Resume the task awaiting the continuation by having it either
+  /// return or throw an error based on the state of the given
+  /// `Result` value
+  ///
+  /// - Parameter result: A value to either return or throw from the
+  ///   continuation
+  @_alwaysEmitIntoClient
+  public consuming func resume(
+    with result: consuming sending Result<Success, Failure>
+  ) {
+    switch consume result {
+    case .success(let val):
+      unsafe Builtin.resumeThrowingContinuationReturning(context, val)
+    case .failure(let err):
+      unsafe Builtin.resumeThrowingContinuationThrowing(context, err)
+    }
+    discard self // prevent deinit from firing
+  }
+
+  /// Resume the task awaiting the continuation by having it return
+  /// from its suspension point
+  @_alwaysEmitIntoClient
+  public consuming func resume() where Success == Void {
+    self.resume(returning: ())
+  }
+
+}
+
+// ==== -----------------------------------------------------------------------
+// MARK: withContinuation
+
+/// Invokes the passed in closure with a non-copyable continuation for the current task.
+///
+/// The body of the closure executes synchronously on the calling task, and
+/// once it returns the calling task is suspended. It is possible to
+/// immediately resume the task, or escape the continuation in order to
+/// complete it afterwards, which will then resume the suspended task.
+///
+/// You must invoke the continuation's `resume` method exactly once.
+/// The continuation is a noncopyable type, and therefore multiple resume
+/// calls are prevented at compile time (as resuming the continuation
+/// consumes it). However, if the continuation is dropped without being
+/// resumed, the program traps.
+///
+/// - Parameters:
+///   - of: The `Success` type returned by the continuation
+///   - throwing: The `Failure` type that may be thrown
+///   - body: A closure that takes a `Continuation` parameter
+/// - Returns: The value the continuation is resumed with
+@_alwaysEmitIntoClient
+@available(SwiftStdlib 6.4, *)
+public nonisolated(nonsending) func withContinuation<Success: ~Copyable, Failure: Error>(
+  of: Success.Type = Success.self,
+  throwing: Failure.Type,
+  _ body: (consuming Continuation<Success, Failure>) -> Void
+) async throws(Failure) -> sending Success {
+  do {
+    return try await Builtin.withUnsafeThrowingContinuation {
+      body(unsafe Continuation($0))
+    }
+  } catch {
+    throw error as! Failure
+  }
+}
+
+/// Invokes the passed in closure with a non-copyable continuation for the current task.
+///
+/// The body of the closure executes synchronously on the calling task, and
+/// once it returns the calling task is suspended. It is possible to
+/// immediately resume the task, or escape the continuation in order to
+/// complete it afterwards, which will then resume the suspended task.
+///
+/// You must invoke the continuation's `resume` method exactly once.
+/// The continuation is a noncopyable type, and therefore multiple resume
+/// calls are prevented at compile time (as resuming the continuation
+/// consumes it). However, if the continuation is dropped without being
+/// resumed, the program traps.
+///
+/// - Parameters:
+///   - of: The `Success` type returned by the continuation
+///   - body: A closure that takes a `Continuation` parameter
+/// - Returns: The value the continuation is resumed with
+@_alwaysEmitIntoClient
+@available(SwiftStdlib 6.4, *)
+public nonisolated(nonsending) func withContinuation<Success: ~Copyable>(
+  of: Success.Type = Success.self,
+  _ body: (consuming Continuation<Success, Never>) -> Void
+) async -> sending Success {
+  return await Builtin.withUnsafeContinuation {
+    body(unsafe Continuation($0))
+  }
+}
+
+// ==== -----------------------------------------------------------------------
+// MARK: Convert to CheckedContinuation
+
+@available(SwiftStdlib 6.4, *)
+extension CheckedContinuation {
+  /// Convert a non-copyable continuation to a ``CheckedContinuation``
+  ///
+  /// A checked continuation may be escaped into contexts where
+  /// the non-copyable semantics would not be able to statically enforce
+  /// the resume-once semantics, however the correct use of the
+  /// continuation is enforced in some way at runtime.
+  @_alwaysEmitIntoClient
+  public init(
+    _ continuation: consuming Continuation<T, E>,
+    function: String = #function
+  ) {
+    unsafe self.init(
+      continuation: UnsafeContinuation(continuation._takeContext()),
+      function: function)
+  }
+}
+
+// ==== -----------------------------------------------------------------------
+// MARK: Convert to UnsafeContinuation
+
+@available(SwiftStdlib 6.4, *)
+extension UnsafeContinuation {
+  /// Convert a non-copyable continuation to an ``UnsafeContinuation``.
+  ///
+  /// An unsafe continuation may be escaped into contexts where
+  /// the non-copyable semantics would not be able to statically enforce
+  /// the resume-once semantics, however the correct use of the
+  /// continuation is enforced in some way at runtime.
+  @_alwaysEmitIntoClient
+  public init(
+    _ continuation: consuming Continuation<T, E>
+  ) {
+    unsafe self = UnsafeContinuation(continuation._takeContext())
+  }
+}

--- a/test/Concurrency/Runtime/noncopyable_continuation.swift
+++ b/test/Concurrency/Runtime/noncopyable_continuation.swift
@@ -1,0 +1,256 @@
+// RUN: %target-run-simple-swift( -target %target-swift-5.1-abi-triple -parse-as-library) 2>&1 | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: concurrency_runtime
+// UNSUPPORTED: back_deployment_runtime
+
+import _Concurrency
+import StdlibUnittest
+
+struct TestError: Error {}
+
+struct UniqueResource: ~Copyable {
+  let value: Int
+  init(_ value: Int) {
+    self.value = value
+  }
+
+  deinit {
+    print("UniqueResource(\(value)).deinit")
+  }
+}
+
+@main struct Main {
+  static func main() async {
+    let tests = TestSuite("Continuation: ~Copyable")
+
+    if #available(SwiftStdlib 6.4, *) {
+      #if !os(WASI)
+      tests.test("trap on dropped continuation") {
+        expectCrashLater()
+
+        let task = Task.detached {
+          let _: Void = await withContinuation { c in
+            _ = consume c // don't do this
+          }
+        }
+        await task.value
+      }
+
+      tests.test("trap on dropped throwing continuation") {
+        expectCrashLater()
+
+        do {
+          let _: Void = try await withContinuation(of: Void.self, throwing: (any Error).self) { c in
+            _ = consume c // bad! should have resumed
+          }
+        } catch {}
+      }
+      #endif
+
+      tests.test("resume returning value") {
+        let value: Int = await withContinuation { c in
+          c.resume(returning: 42)
+        }
+        expectEqual(42, value)
+      }
+
+      tests.test("resume void") {
+        await withContinuation { c in
+          c.resume()
+        }
+      }
+
+      tests.test("throwing continuation resume returning") {
+        do {
+          let value: Int = try await withContinuation(of: Int.self, throwing: (any Error).self) { c in
+            c.resume(returning: 42)
+          }
+          expectEqual(42, value)
+        } catch {
+          expectUnreachable()
+        }
+      }
+
+      tests.test("throwing continuation resume throwing") {
+        do {
+          let _: Int = try await withContinuation(of: Int.self, throwing: (any Error).self) { c in
+            c.resume(throwing: TestError())
+          }
+          expectUnreachable()
+        } catch {
+          // Expected
+        }
+      }
+
+      tests.test("resume with result success") {
+        let value: Int = try! await withContinuation(of: Int.self, throwing: (any Error).self) { c in
+          c.resume(with: .success(17))
+        }
+        expectEqual(17, value)
+      }
+
+      tests.test("resume with result failure") {
+        do {
+          let _: Int = try await withContinuation(of: Int.self, throwing: (any Error).self) { c in
+            c.resume(with: .failure(TestError()))
+          }
+          expectUnreachable()
+        } catch {
+          // Expected
+        }
+      }
+
+      // MARK: Conversion to CheckedContinuation
+
+      tests.test("convert to CheckedContinuation and resume returning") {
+        let value: Int = await withContinuation { c in
+          let checked = CheckedContinuation(c)
+          checked.resume(returning: 42)
+        }
+        expectEqual(42, value)
+      }
+
+      tests.test("convert throwing to CheckedContinuation and resume returning") {
+        do {
+          let value: Int = try await withContinuation(of: Int.self, throwing: (any Error).self) { c in
+            let checked = CheckedContinuation(c)
+            checked.resume(returning: 99)
+          }
+          expectEqual(99, value)
+        } catch {
+          expectUnreachable()
+        }
+      }
+
+      tests.test("convert throwing to CheckedContinuation and resume throwing") {
+        do {
+          let _: Int = try await withContinuation(of: Int.self, throwing: (any Error).self) { c in
+            let checked = CheckedContinuation(c)
+            checked.resume(throwing: TestError())
+          }
+          expectUnreachable()
+        } catch {
+          // Expected
+        }
+      }
+
+      tests.test("convert typed-throws to CheckedContinuation and resume throwing") {
+        struct MyCoolError: Error, Equatable {}
+        do {
+          try await withContinuation(of: Void.self, throwing: MyCoolError.self) { c in
+            let checked = CheckedContinuation(c)
+            checked.resume(throwing: MyCoolError())
+          }
+          expectUnreachable()
+        } catch let error as MyCoolError {
+          expectEqual(MyCoolError(), error)
+        } catch {
+          expectUnreachable()
+        }
+      }
+
+      // MARK: Conversion to UnsafeContinuation
+
+      tests.test("convert to UnsafeContinuation and resume returning") {
+        let value: Int = await withContinuation { c in
+          let uc = UnsafeContinuation(c)
+          uc.resume(returning: 7)
+        }
+        expectEqual(7, value)
+      }
+
+      tests.test("convert throwing to UnsafeContinuation and resume returning") {
+        do {
+          let value: Int = try await withContinuation(of: Int.self, throwing: (any Error).self) { c in
+            let uc = UnsafeContinuation(c)
+            uc.resume(returning: 55)
+          }
+          expectEqual(55, value)
+        } catch {
+          expectUnreachable()
+        }
+      }
+
+      tests.test("convert throwing to UnsafeContinuation and resume throwing") {
+        do {
+          let _: Int = try await withContinuation(of: Int.self, throwing: (any Error).self) { c in
+            let uc = UnsafeContinuation(c)
+            uc.resume(throwing: TestError())
+          }
+          expectUnreachable()
+        } catch {
+          // Expected
+        }
+      }
+
+      tests.test("noncopyable resume returning value") {
+        let resource: UniqueResource = await withContinuation { c in
+          c.resume(returning: UniqueResource(99))
+          print("non-throwing resume done")
+          // CHECK: non-throwing resume done
+        }
+        print("non-throwing resumed with: \(resource.value)")
+        // CHECK: non-throwing resumed with: 99
+        expectEqual(99, resource.value)
+        _ = consume resource
+        // CHECK: UniqueResource(99).deinit
+      }
+
+      tests.test("noncopyable throwing continuation resume returning") {
+        do {
+          let resource: UniqueResource = try await withContinuation(of: UniqueResource.self, throwing: (any Error).self) { c in
+            c.resume(returning: UniqueResource(77))
+            print("throwing resume done")
+            // CHECK: throwing resume done
+          }
+          print("throwing resumed with: \(resource.value)")
+          // CHECK: throwing resumed with: 77
+          expectEqual(77, resource.value)
+          _ = consume resource
+          // CHECK: UniqueResource(77).deinit
+        } catch {
+          expectUnreachable()
+        }
+      }
+
+      tests.test("noncopyable throwing continuation resume throwing") {
+        do {
+          let _: UniqueResource = try await withContinuation(of: UniqueResource.self, throwing: (any Error).self) { c in
+            c.resume(throwing: TestError())
+          }
+          expectUnreachable()
+        } catch {
+          // Expected
+        }
+      }
+
+      tests.test("noncopyable resume with result success") {
+        let resource: UniqueResource = try! await withContinuation(of: UniqueResource.self, throwing: (any Error).self) { c in
+          c.resume(with: .success(UniqueResource(55)))
+          print("result resume done")
+          // CHECK: result resume done
+        }
+        print("result resumed with: \(resource.value)")
+        // CHECK: result resumed with: 55
+        expectEqual(55, resource.value)
+        _ = consume resource
+        // CHECK: UniqueResource(55).deinit
+      }
+
+      tests.test("noncopyable resume with result failure") {
+        do {
+          let _: UniqueResource = try await withContinuation(of: UniqueResource.self, throwing: (any Error).self) { c in
+            c.resume(with: .failure(TestError()))
+          }
+          expectUnreachable()
+        } catch {
+          // Expected
+        }
+      }
+    }
+
+    await runAllTestsAsync()
+  }
+}

--- a/test/Concurrency/noncopyable_continuation_misuse.swift
+++ b/test/Concurrency/noncopyable_continuation_misuse.swift
@@ -1,0 +1,71 @@
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -emit-sil -verify %s
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -emit-sil -verify %s -strict-concurrency=complete
+
+// REQUIRES: concurrency
+
+struct UniqueResource: ~Copyable {
+  let value: Int
+}
+
+func consumeIt(_ resource: consuming UniqueResource) {}
+
+@available(SwiftStdlib 6.4, *)
+func doubleResumeReturning() async {
+  let _: Int = await withContinuation { c in // expected-error{{'c' consumed more than once}}
+    c.resume(returning: 1) // expected-note{{consumed here}}
+    c.resume(returning: 2) // expected-note{{consumed again here}}
+  }
+}
+
+@available(SwiftStdlib 6.4, *)
+func doubleResumeVoid() async {
+  let _: Void = await withContinuation { c in // expected-error{{'c' consumed more than once}}
+    c.resume(returning: ()) // expected-note{{consumed here}}
+    c.resume(returning: ()) // expected-note{{consumed again here}}
+  }
+}
+
+@available(SwiftStdlib 6.4, *)
+func doubleResumeThrowing() async throws {
+  let _: Int = try await withContinuation(of: Int.self, throwing: (any Error).self) { c in // expected-error{{'c' consumed more than once}}
+    c.resume(returning: 1) // expected-note{{consumed here}}
+    c.resume(returning: 2) // expected-note{{consumed again here}}
+  }
+}
+
+@available(SwiftStdlib 6.4, *)
+func doubleResumeMixed() async throws {
+  struct MyError: Error {}
+  let _: Int = try await withContinuation(of: Int.self, throwing: (any Error).self) { c in // expected-error{{'c' consumed more than once}}
+    c.resume(returning: 1) // expected-note{{consumed here}}
+    c.resume(throwing: MyError()) // expected-note{{consumed again here}}
+  }
+}
+
+@available(SwiftStdlib 6.4, *)
+func cannotCopyContinuation() async {
+  let _: Int = await withContinuation { c in // expected-error{{'c' consumed more than once}}
+    let c2 = c // expected-note{{consumed here}}
+    c2.resume(returning: 1)
+    c.resume(returning: 2) // expected-note{{consumed again here}}
+  }
+}
+
+@available(SwiftStdlib 6.4, *)
+func resumeAfterBranch(_ condition: Bool) async {
+  let _: Int = await withContinuation { c in // expected-error{{'c' consumed more than once}}
+    if condition {
+      c.resume(returning: 1) // expected-note{{consumed here}}
+    }
+    c.resume(returning: 2) // expected-note{{consumed again here}}
+  }
+}
+
+@available(SwiftStdlib 6.4, *)
+func noncopyableDoubleResumeThrowing() async throws {
+  let _: UniqueResource = try await withContinuation(of: UniqueResource.self, throwing: (any Error).self) { c in
+    let resource = UniqueResource(value: 1) // expected-error{{'resource' consumed more than once}}
+    c.resume(returning: resource) // expected-note{{consumed here}}
+    consumeIt(resource) // expected-note{{consumed again here}}
+  }
+}

--- a/test/abi/macOS/arm64/concurrency.swift
+++ b/test/abi/macOS/arm64/concurrency.swift
@@ -430,3 +430,10 @@ Added: _$sScT4nameSSSgvg
 Added: _$sScT4nameSSSgvpMV
 Added: _$sSct4nameSSSgvg
 Added: _$sSct4nameSSSgvpMV
+
+// Continuation (noncopyable, ~Copyable Success)
+Added: _$ss12ContinuationVMa
+Added: _$ss12ContinuationVMn
+Added: _$ss12ContinuationVsRi_zrlE7contextBcvg
+Added: _$ss12ContinuationVsRi_zrlEfD
+Added: _$ss12ContinuationVsRi_zrlEyAByxq_GBccfC

--- a/test/abi/macOS/x86_64/concurrency.swift
+++ b/test/abi/macOS/x86_64/concurrency.swift
@@ -430,3 +430,10 @@ Added: _$sScT4nameSSSgvg
 Added: _$sScT4nameSSSgvpMV
 Added: _$sSct4nameSSSgvg
 Added: _$sSct4nameSSSgvpMV
+
+// Continuation (noncopyable, ~Copyable Success)
+Added: _$ss12ContinuationVMa
+Added: _$ss12ContinuationVMn
+Added: _$ss12ContinuationVsRi_zrlE7contextBcvg
+Added: _$ss12ContinuationVsRi_zrlEfD
+Added: _$ss12ContinuationVsRi_zrlEyAByxq_GBccfC


### PR DESCRIPTION
6.4 pick of https://github.com/swiftlang/swift/pull/88182

**Explanation**: 
Implementation of ~Copyable `Continuation` as proposed in SE: https://github.com/swiftlang/swift-evolution/pull/3246

This is a ~Copyable Continuation with much stronger safety guarantees and no runtime overhead. Refer to proposal for details.

Initial work by @fabianfett.

**Scope**: Adds a new continuation type.

**Risk**: Low, adds new type, allows `~Copyable` into existing builtin

**Testing**: Added lots of tests covering problems this aims to prevent.

**Issues**: 
resolves rdar://174826360
Somewhat relevant to rdar://139975911

**Reviewed by**: @rjmccall (on main)


**Original PR**: https://github.com/swiftlang/swift/pull/88182