### PR TITLE
MemoryLifetimeVerifier: correctly handle `apply [nothrow]` with indirect error results

### DIFF
--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -743,6 +743,14 @@ static bool hasUnusualResultOwnership(const SILInstruction *inst) {
 
 namespace swift {
 
+static bool hasValidControlFlow(const SILFunction *f) {
+  for (auto &block : *f) {
+    if (!isa<TermInst>(&block.back()))
+      return false;
+  }
+  return true;
+}
+
 /// SILPrinter class - This holds the internal implementation details of
 /// printing SIL structures.
 class SILPrinter : public SILInstructionVisitor<SILPrinter> {
@@ -915,7 +923,7 @@ public:
   //===--------------------------------------------------------------------===//
   // Big entrypoints.
   void print(const SILFunction *F) {
-    if (SILPrintLoopHeaders) {
+    if (SILPrintLoopHeaders && hasValidControlFlow(F)) {
       findLoopHeaders(*const_cast<SILFunction *>(F), loopHeaders);
     }
 

--- a/lib/SIL/Verifier/LinearLifetimeCheckerPrivate.h
+++ b/lib/SIL/Verifier/LinearLifetimeCheckerPrivate.h
@@ -91,7 +91,7 @@ public:
 };
 
 class LLVM_LIBRARY_VISIBILITY LinearLifetimeChecker::ErrorBuilder {
-  StringRef functionName;
+  const SILFunction *function;
   ErrorBehaviorKind behavior;
   std::optional<Error> error;
   unsigned *errorMessageCounter;
@@ -100,7 +100,7 @@ public:
   ErrorBuilder(const SILFunction &fn,
                LinearLifetimeChecker::ErrorBehaviorKind behavior,
                unsigned *errorMessageCounter = nullptr)
-      : functionName(fn.getName()), behavior(behavior), error(Error()),
+      : function(&fn), behavior(behavior), error(Error()),
         errorMessageCounter(errorMessageCounter) {}
 
   ErrorBuilder(const SILFunction &fn,
@@ -110,11 +110,11 @@ public:
                      errorMessageCounter) {}
 
   ErrorBuilder(const ErrorBuilder &other)
-      : functionName(other.functionName), behavior(other.behavior),
+      : function(other.function), behavior(other.behavior),
         error(other.error), errorMessageCounter(other.errorMessageCounter) {}
 
   ErrorBuilder &operator=(const ErrorBuilder &other) {
-    functionName = other.functionName;
+    function = other.function;
     behavior = other.behavior;
     error = other.error;
     errorMessageCounter = other.errorMessageCounter;
@@ -147,10 +147,11 @@ public:
 
     if (behavior.shouldPrintMessage()) {
       tryDumpErrorCounter();
-      llvm::errs() << "Begin Error in Function: '" << functionName << "'\n";
+      llvm::errs() << "Begin Error in Function: '" << function->getName() << "'\n";
       messagePrinterFunc();
       tryDumpErrorCounter();
-      llvm::errs() << "End Error in Function: '" << functionName << "'\n";
+      llvm::errs() << "End Error in Function: '" << function->getName() << "'\n";
+      function->print(llvm::errs());
       tryIncrementErrorCounter();
     }
 
@@ -192,12 +193,13 @@ private:
     if (behavior.shouldPrintMessage()) {
       if (!quiet) {
         tryDumpErrorCounter();
-        llvm::errs() << "Begin Error in Function: '" << functionName << "'\n";
+        llvm::errs() << "Begin Error in Function: '" << function->getName() << "'\n";
       }
       messagePrinterFunc();
       if (!quiet) {
         tryDumpErrorCounter();
-        llvm::errs() << "End Error in Function: '" << functionName << "'\n";
+        llvm::errs() << "End Error in Function: '" << function->getName() << "'\n";
+        function->print(llvm::errs());
         auto *self = const_cast<ErrorBuilder *>(this);
         self->tryIncrementErrorCounter();
       }

--- a/lib/SIL/Verifier/MemoryLifetimeVerifier.cpp
+++ b/lib/SIL/Verifier/MemoryLifetimeVerifier.cpp
@@ -117,7 +117,7 @@ class MemoryLifetimeVerifier {
   /// Helper function to set bits for function arguments and returns.
   void setFuncOperandBits(BlockState &state, Operand &op,
                           SILArgumentConvention convention,
-                          bool isTryApply);
+                          SILInstruction *applyInst);
 
   /// Perform all checks in the function after the data flow has been computed.
   void checkFunction(BitDataflow &dataFlow);
@@ -482,8 +482,7 @@ void MemoryLifetimeVerifier::initDataflowInBlock(SILBasicBlock *block,
         ApplySite AS(&I);
         for (Operand &op : I.getAllOperands()) {
           if (AS.isArgumentOperand(op)) {
-            setFuncOperandBits(state, op, AS.getCaptureConvention(op),
-                              isa<TryApplyInst>(&I));
+            setFuncOperandBits(state, op, AS.getCaptureConvention(op), &I);
           }
         }
         break;
@@ -524,8 +523,7 @@ void MemoryLifetimeVerifier::initDataflowInBlock(SILBasicBlock *block,
       case SILInstructionKind::YieldInst: {
         auto *YI = cast<YieldInst>(&I);
         for (Operand &op : YI->getAllOperands()) {
-          setFuncOperandBits(state, op, YI->getArgumentConventionForOperand(op),
-                             /*isTryApply=*/ false);
+          setFuncOperandBits(state, op, YI->getArgumentConventionForOperand(op), &I);
         }
         break;
       }
@@ -582,19 +580,30 @@ void MemoryLifetimeVerifier::setBitsOfPredecessor(Bits &getSet, Bits &killSet,
   }
 }
 
+static bool isNoThrowApply(SILInstruction *applyInst) {
+  if (auto *apply = dyn_cast<ApplyInst>(applyInst)) {
+    return apply->isNonThrowing();
+  }
+  return false;
+}
+
 void MemoryLifetimeVerifier::setFuncOperandBits(BlockState &state, Operand &op,
                                         SILArgumentConvention convention,
-                                        bool isTryApply) {
+                                        SILInstruction *applyInst) {
   switch (convention) {
     case SILArgumentConvention::Indirect_In_CXX:
     case SILArgumentConvention::Indirect_In:
       killBits(state, op.get());
       break;
     case SILArgumentConvention::Indirect_Out:
+      // An `apply [nothrow]` does not initialize the indirect error result.
+      if (ApplySite(applyInst).isIndirectErrorResultOperand(op) && isNoThrowApply(applyInst))
+        break;
+
       // try_apply is special, because an @out result is only initialized
       // in the normal-block, but not in the throw-block.
       // We handle the @out result of try_apply in setBitsOfPredecessor.
-      if (!isTryApply)
+      if (!isa<TryApplyInst>(applyInst))
         genBits(state, op.get());
       break;
     case SILArgumentConvention::Indirect_In_Guaranteed:
@@ -942,6 +951,8 @@ void MemoryLifetimeVerifier::checkFuncArgument(Bits &bits, Operand &argumentOp,
     case SILArgumentConvention::Indirect_Out:
       requireBitsClear(bits & locations.getNonTrivialLocations(),
                        argumentOp.get(), applyInst);
+      if (ApplySite(applyInst).isIndirectErrorResultOperand(argumentOp) && isNoThrowApply(applyInst))
+        break;
       locations.setBits(bits, argumentOp.get());
       break;
     case SILArgumentConvention::Indirect_In_Guaranteed:

--- a/test/SIL/memory_lifetime.sil
+++ b/test/SIL/memory_lifetime.sil
@@ -40,6 +40,10 @@ struct IntPair {
   var b: Int
 }
 
+struct MyError : Error {
+  var x: AnyObject
+}
+
 
 sil [ossa] @test_struct : $@convention(thin) (@in Outer) -> @owned T {
 bb0(%0 : $*Outer):
@@ -977,3 +981,13 @@ bb4:
   return %r : $()
 }
 
+sil @not_throwing : $@convention(thin) (Int) -> (Int, @error_indirect MyError)
+
+sil [ossa] @apply_nothrow_with_indirect_error : $@convention(thin) (Int) -> Int {
+bb0(%0 : $Int):
+  %2 = function_ref @not_throwing : $@convention(thin) (Int) -> (Int, @error_indirect MyError)
+  %3 = alloc_stack $MyError
+  %4 = apply [nothrow] %2(%3, %0) : $@convention(thin) (Int) -> (Int, @error_indirect MyError)
+  dealloc_stack %3
+  return %4
+}

--- a/test/SILOptimizer/specialize_reabstraction_ossa.sil
+++ b/test/SILOptimizer/specialize_reabstraction_ossa.sil
@@ -217,7 +217,6 @@ bb0(%0 : $*NonLoadableErr):
   %7 = alloc_stack $Int
   apply [nothrow] %5<NonLoadableErr>(%7, %6, %0) : $@convention(thin) <τ_0_0 where τ_0_0 : Error> (@in_guaranteed τ_0_0) -> (@out Int, @error_indirect τ_0_0)
   dealloc_stack %7 : $*Int
-  destroy_addr %6 : $*NonLoadableErr
   dealloc_stack %6 : $*NonLoadableErr
   %11 = tuple ()
   return %11 : $()


### PR DESCRIPTION
An `apply [nothrow]` does not initialize the indirect error result.
Fixes a wrong verification error

This PR also contains two related improvements/fixes:

* Print the whole function if the ownership verifier encounters an error. Like the SILVerifier does for all other kind of SIL verification errors.
* Don't crash when printing an incomplete SIL function. Getting the loop header information requires that all blocks have terminators. This is not necessarily true when printing a function which is e.g. currently under construction.