### PR TITLE
[DebugInfo] Remove salvage for IndexAddrInst

### DIFF
--- a/lib/SILOptimizer/Utils/InstOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/InstOptUtils.cpp
@@ -2010,33 +2010,6 @@ void swift::salvageDebugInfo(SILInstruction *I) {
     }
   }
 
-  if (auto *IA = dyn_cast<IndexAddrInst>(I)) {
-    if (IA->getBase() && IA->getIndex())
-      // Only handle cases where offset is constant.
-      if (const auto *LiteralInst =
-            dyn_cast<IntegerLiteralInst>(IA->getIndex())) {
-        SILValue Base = IA->getBase();
-        SILValue ResultAddr = IA->getResult(0);
-        APInt OffsetVal = LiteralInst->getValue();
-        const SILDIExprElement ExprElements[3] = {
-          SILDIExprElement::createOperator(OffsetVal.isNegative() ?
-            SILDIExprOperator::ConstSInt : SILDIExprOperator::ConstUInt),
-          SILDIExprElement::createConstInt(OffsetVal.getLimitedValue()),
-          SILDIExprElement::createOperator(SILDIExprOperator::Plus)
-        };
-        for (Operand *U : getDebugUses(ResultAddr)) {
-          auto *DbgInst = cast<DebugValueInst>(U->getUser());
-          auto VarInfo = DbgInst->getVarInfo();
-          if (!VarInfo)
-            continue;
-          VarInfo->DIExpr.prependElements(ExprElements);
-          // Create a new debug_value
-          SILBuilder(IA, DbgInst->getDebugScope())
-            .createDebugValue(DbgInst->getLoc(), Base, *VarInfo);
-        }
-      }
-  }
-
   if (auto *IL = dyn_cast<IntegerLiteralInst>(I)) {
     APInt value = IL->getValue();
     const SILDIExprElement ExprElements[2] = {

--- a/test/DebugInfo/sil_combine.sil
+++ b/test/DebugInfo/sil_combine.sil
@@ -1,29 +1,9 @@
 // RUN: %target-sil-opt -sil-print-types -sil-verify-all -sil-combine %s | %FileCheck %s
-// RUN: %target-swift-frontend -g -O -emit-ir -primary-file %s | %FileCheck --check-prefix=CHECK-IR %s
 
 sil_stage canonical
 
 import Builtin
 import Swift
-
-// CHECK-LABEL: sil {{.*}} @test_nested_index_addr
-// CHECK-IR-LABEL: define {{.*}} @test_nested_index_addr
-sil hidden @test_nested_index_addr : $@convention(thin) (Builtin.RawPointer) -> Builtin.RawPointer {
-bb0(%0 : $Builtin.RawPointer):
-  %offset1 = integer_literal $Builtin.Word, 3
-  %offset2 = integer_literal $Builtin.Word, 7
-  // CHECK: %[[ADDR:.+]] = pointer_to_address %0
-  %addr = pointer_to_address %0 : $Builtin.RawPointer to [strict] $*UInt8
-  %addr1 = index_addr %addr : $*UInt8, %offset1 : $Builtin.Word
-  // CHECK: debug_value %[[ADDR]] : $*UInt8, let, name "hello"
-  // CHECK-SAME: expr op_constu:3:op_plus:op_deref
-  // CHECK-IR: #dbg_value(ptr %0, ![[DBG_VAR:[0-9]+]],
-  // CHECK-IR-SAME: !DIExpression(DW_OP_plus_uconst, 3, DW_OP_deref)
-  debug_value %addr1 : $*UInt8, let, name "hello", expr op_deref
-  %addr2 = index_addr %addr1 : $*UInt8, %offset2 : $Builtin.Word
-  %ptr = address_to_pointer %addr2 : $*UInt8 to $Builtin.RawPointer
-  return %ptr : $Builtin.RawPointer
-}
 
 public struct S {}
 public struct C {
@@ -70,8 +50,6 @@ bb3:
   return %11 : $()
 }
 
-
-// CHECK-IR: ![[DBG_VAR]] = !DILocalVariable(name: "hello"
 
 struct T {
   @_hasStorage let x: Builtin.Int32 { get }


### PR DESCRIPTION
The salvage for this instruction was wrong as it didn't multiply the index by the element stride.
As this salvage is rare, only was correct for byte sized elements, and will be rewritten in the future, remove it rather than fix it.
