### PR TITLE
[cxx-interop] Speed up test, disable for ASAN

### DIFF
--- a/test/Interop/Cxx/stdlib/foundation-and-std-module.swift
+++ b/test/Interop/Cxx/stdlib/foundation-and-std-module.swift
@@ -1,13 +1,15 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -c -enable-experimental-cxx-interop -Xcc -std=c++17 -module-cache-path %t
-// RUN: %target-swift-frontend %s -c -enable-experimental-cxx-interop -Xcc -std=c++20 -module-cache-path %t
+// RUN: %target-swift-frontend %s -c -enable-experimental-cxx-interop -Xcc -std=c++17
+// RUN: %target-swift-frontend %s -c -enable-experimental-cxx-interop -Xcc -std=c++20
 
 // RUN: %empty-directory(%t)
 
 // RUN: %target-swift-frontend %s -c -enable-experimental-cxx-interop -Xcc -std=c++17 -module-cache-path %t -DADD_CXXSTDLIB
-// RUN: %target-swift-frontend %s -c -enable-experimental-cxx-interop -Xcc -std=c++20 -module-cache-path %t -DADD_CXXSTDLIB
+// RUN: %target-swift-frontend %s -c -enable-experimental-cxx-interop -Xcc -std=c++20 -DADD_CXXSTDLIB
 
 // RUN: ls -R %/t | %FileCheck %s
+
+// REQUIRES: no_asan
 
 #if canImport(Foundation)
 import Foundation


### PR DESCRIPTION
The test in this PR is one of the slowest running tests that we have because it rebuilds foundation and the standard library modules in a new module cache directory. This PR attempts to speed this test up by making only one of the 4 invocations do the rebuild from scratch. This is sufficient for the FileCheck invocation to test if the expected files are present.

Moreover, we disable this test for ASAN builds for now where this test was reliably timing out. Since we have other tests importing foundation, the overlay, and the C++ standard library, we should not lose code coverage in ASAN builds.

rdar://176484441
