### PR TITLE
[DebugInfo] Remove createDebugFragments function

### DIFF
--- a/include/swift/SILOptimizer/Utils/DebugOptUtils.h
+++ b/include/swift/SILOptimizer/Utils/DebugOptUtils.h
@@ -19,7 +19,6 @@
 #define SWIFT_SILOPTIMIZER_DEBUGOPTUTILS_H
 
 #include "swift/SIL/DebugUtils.h"
-#include "swift/SIL/Projection.h"
 #include "swift/SIL/SILValue.h"
 #include "swift/SILOptimizer/Utils/InstOptUtils.h"
 
@@ -62,13 +61,6 @@ void salvageStoreDebugInfo(SILInstruction *SI,
 /// TODO: combine this with salvageDebugInfo when it is supported by
 /// optimizations.
 void salvageLoadDebugInfo(LoadOperation load);
-
-/// Create debug_value fragment for a new partial value.
-///
-/// Precondition: \p oldValue is a struct or class aggregate. \p proj projects a
-/// field from the aggregate into \p newValue corresponding to struct_extract.
-void createDebugFragments(SILValue oldValue, Projection proj,
-                          SILValue newValue);
 
 /// Erases the instruction \p I from it's parent block and deletes it, including
 /// all debug instructions which use \p I.

--- a/lib/SILOptimizer/Utils/InstOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/InstOptUtils.cpp
@@ -2074,32 +2074,6 @@ void swift::salvageLoadDebugInfo(LoadOperation load) {
   }
 }
 
-// TODO: this currently fails to notify the pass with notifyNewInstruction.
-void swift::createDebugFragments(SILValue oldValue, Projection proj,
-                                 SILValue newValue) {
-  if (proj.getKind() != ProjectionKind::Struct)
-    return;
-
-  for (auto *use : getDebugUses(oldValue)) {
-    auto debugVal = dyn_cast<DebugValueInst>(use->getUser());
-    if (!debugVal)
-      continue;
-
-    auto varInfo = debugVal->getCompleteVarInfo();
-
-    SILType baseType = oldValue->getType();
-
-    // Copy VarInfo and add the corresponding fragment DIExpression.
-    SILDebugVariable newVarInfo = varInfo;
-    newVarInfo.DIExpr.append(
-        SILDebugInfoExpression::createFragment(proj.getVarDecl(baseType)));
-
-    // Create a new debug_value
-    SILBuilder(debugVal, debugVal->getDebugScope())
-        .createDebugValue(debugVal->getLoc(), newValue, newVarInfo);
-  }
-}
-
 IntegerLiteralInst *swift::optimizeBuiltinCanBeObjCClass(BuiltinInst *bi,
                                                          SILBuilder &builder) {
   assert(bi->getBuiltinInfo().ID == BuiltinValueKind::CanBeObjCClass);


### PR DESCRIPTION
This function used to be called by CanonicalizeInstruction, but it hasn't been called since #65929.
Fragments are currently created directly by SROA, DeadObjectElimination , and salvageDebugInfo, and don't use this function.