### PR TITLE
[region-isolation] Fix false positive for init_existential_addr with opened archetype concrete type

### DIFF
--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -3739,8 +3739,6 @@ CONSTANT_TRANSLATION(CopyBlockInst, AssignDirect)
 CONSTANT_TRANSLATION(CopyBlockWithoutEscapingInst, AssignDirect)
 CONSTANT_TRANSLATION(IndexAddrInst, AssignDirect)
 CONSTANT_TRANSLATION(InitBlockStorageHeaderInst, AssignDirect)
-CONSTANT_TRANSLATION(InitExistentialAddrInst, AssignDirect)
-CONSTANT_TRANSLATION(InitExistentialRefInst, AssignDirect)
 CONSTANT_TRANSLATION(OpenExistentialBoxInst, AssignDirect)
 CONSTANT_TRANSLATION(OpenExistentialRefInst, AssignDirect)
 CONSTANT_TRANSLATION(TailAddrInst, AssignDirect)
@@ -4515,10 +4513,56 @@ PartitionOpTranslator::visitPartialApplyInst(PartialApplyInst *pai) {
 }
 
 TranslationSemantics
+PartitionOpTranslator::visitInitExistentialAddrInst(
+    InitExistentialAddrInst *ieai) {
+  // If the formal concrete type involves an opened archetype, the conformance
+  // is abstract — derived from an existing existential that was already
+  // validated at its formation site. SE-0470's dependent conformance rule
+  // guarantees the associated conformance can never be more isolated than the
+  // parent, so no new isolated-conformance region should be introduced.
+  //
+  // Instead, merge the result into the region of the opened existential (the
+  // type-dependent operand) along with the primary operand (the existential
+  // buffer), without passing a conformance isolation override.
+  if (ieai->getFormalConcreteType()->hasOpenedExistential()) {
+    translateSILMultiAssign(
+        ieai->getResults(),
+        ArrayRef<Operand *>(),
+        makeOperandRefRange(ieai->getAllOperands()),
+        RegionMergeReason::Assign);
+    return TranslationSemantics::Special;
+  }
+  return TranslationSemantics::AssignDirect;
+}
+
+TranslationSemantics
 PartitionOpTranslator::visitInitExistentialValueInst(InitExistentialValueInst *ievi) {
   if (isStaticallyLookThroughInst(ievi))
     return TranslationSemantics::LookThrough;
 
+  if (ievi->getFormalConcreteType()->hasOpenedExistential()) {
+    translateSILMultiAssign(
+        ievi->getResults(),
+        ArrayRef<Operand *>(),
+        makeOperandRefRange(ievi->getAllOperands()),
+        RegionMergeReason::Assign);
+    return TranslationSemantics::Special;
+  }
+
+  return TranslationSemantics::AssignDirect;
+}
+
+TranslationSemantics
+PartitionOpTranslator::visitInitExistentialRefInst(
+    InitExistentialRefInst *ieri) {
+  if (ieri->getFormalConcreteType()->hasOpenedExistential()) {
+    translateSILMultiAssign(
+        ieri->getResults(),
+        ArrayRef<Operand *>(),
+        makeOperandRefRange(ieri->getAllOperands()),
+        RegionMergeReason::Assign);
+    return TranslationSemantics::Special;
+  }
   return TranslationSemantics::AssignDirect;
 }
 

--- a/test/Concurrency/transfernonsendable.swift
+++ b/test/Concurrency/transfernonsendable.swift
@@ -2417,3 +2417,13 @@ enum rdar169803154_Seq {
     AsyncThrowingStream(Float.self) { $0.finish() }
   }
 }
+
+// Iterating over an existential sequence parameter in a nonisolated method on
+// an actor must not produce a false positive RBI error.
+actor ActorWithNonisolatedExistentialSequenceMethod {
+  nonisolated func process(sequence: any Sequence<Int>) {
+    for element in sequence {
+      _ = element
+    }
+  }
+}

--- a/test/Concurrency/transfernonsendable_initializers.swift
+++ b/test/Concurrency/transfernonsendable_initializers.swift
@@ -176,3 +176,71 @@ func initClassWithAsyncIsolatedInit2(_ k: NonSendableKlass) async {
     // expected-note @-1 {{task-isolated 'k' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
   }
 }
+
+// Iterating over an existential sequence parameter must not produce false
+// positive RBI errors in any of these isolation contexts.
+
+actor ActorWithExistentialSequenceInit {
+  init(sequence: any Sequence<Int>) {
+    for element in sequence {
+      _ = element
+    }
+  }
+}
+
+@MainActor
+class MainActorClassWithExistentialSequenceInit {
+  init(sequence: any Sequence<Int>) {
+    for element in sequence {
+      _ = element
+    }
+  }
+}
+
+@CustomActor
+class CustomActorClassWithExistentialSequenceInit {
+  init(sequence: any Sequence<Int>) async {
+    for element in sequence {
+      _ = element
+    }
+  }
+}
+
+func nonisolatedFuncWithExistentialSequence(sequence: any Sequence<Int>) {
+  for element in sequence {
+    _ = element
+  }
+}
+
+// Class-constrained variant: the iterator associated type is AnyObject-constrained,
+// so erasing it into an existential uses init_existential_ref (not init_existential_addr).
+// This exercises the visitInitExistentialRefInst fix path.
+
+protocol FakeClassIterator: AnyObject {
+  func nextElement()
+}
+
+protocol FakeClassSequence {
+  associatedtype Iterator: FakeClassIterator
+  func makeIterator() -> Iterator
+}
+
+actor ActorWithClassExistentialSequenceInit {
+  init(sequence: any FakeClassSequence) {
+    let iter: any FakeClassIterator = sequence.makeIterator()
+    iter.nextElement()
+  }
+}
+
+@MainActor
+class MainActorClassWithClassExistentialSequenceInit {
+  init(sequence: any FakeClassSequence) {
+    let iter: any FakeClassIterator = sequence.makeIterator()
+    iter.nextElement()
+  }
+}
+
+func nonisolatedFuncWithClassExistentialSequence(sequence: any FakeClassSequence) {
+  let iter: any FakeClassIterator = sequence.makeIterator()
+  iter.nextElement()
+}

--- a/test/Concurrency/transfernonsendable_initializers_opaquevalues.swift
+++ b/test/Concurrency/transfernonsendable_initializers_opaquevalues.swift
@@ -1,0 +1,49 @@
+// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -target %target-swift-5.1-abi-triple -swift-version 6 -verify -enable-sil-opaque-values %s -o /dev/null
+
+// REQUIRES: concurrency
+// REQUIRES: asserts
+
+// Test that init_existential_value with an opened archetype concrete type does
+// not produce a false positive in the region-based isolation analysis under the
+// opaque-values SIL lowering. The fake protocols below mimic the
+// Sequence/IteratorProtocol shape without depending on the standard library,
+// which does not compile with -enable-sil-opaque-values.
+
+////////////////////////
+// MARK: Declarations //
+////////////////////////
+
+public protocol FakeIteratorProtocol {
+  mutating func nextElement()
+}
+
+public protocol FakeSequence {
+  associatedtype Iterator: FakeIteratorProtocol
+  func makeIterator() -> Iterator
+}
+
+/////////////////
+// MARK: Tests //
+/////////////////
+
+// Iterating over an existential sequence parameter in a nonisolated actor init
+// must not produce a false positive RBI error in opaque-values mode.
+public actor ActorWithFakeSequenceInit {
+  public init(sequence: any FakeSequence) {
+    var iter: any FakeIteratorProtocol = sequence.makeIterator()
+    iter.nextElement()
+  }
+}
+
+@MainActor
+public class MainActorClassWithFakeSequenceInit {
+  public init(sequence: any FakeSequence) {
+    var iter: any FakeIteratorProtocol = sequence.makeIterator()
+    iter.nextElement()
+  }
+}
+
+public func nonisolatedFuncWithFakeSequence(sequence: any FakeSequence) {
+  var iter: any FakeIteratorProtocol = sequence.makeIterator()
+  iter.nextElement()
+}

--- a/test/Concurrency/transfernonsendable_partitionop_translation.sil
+++ b/test/Concurrency/transfernonsendable_partitionop_translation.sil
@@ -66,6 +66,9 @@ enum SendableEnum : @unchecked Sendable {
 protocol NonSendableProtocol {
 }
 
+protocol NonSendableClassProtocol : AnyObject {
+}
+
 class DerivedKlass : NonSendableKlass {}
 
 class KlassWithField {
@@ -597,6 +600,30 @@ bb0(%0 : @guaranteed $NonSendableKlass):
   %2 = init_existential_ref %1 : $NonSendableKlass : $NonSendableKlass, $AnyObject
   specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
   destroy_value %2
+  %r = tuple ()
+  return %r : $()
+}
+
+// When init_existential_ref has a formal concrete type with an opened archetype,
+// the fix merges the result into the operand regions instead of creating a new
+// isolated-conformance region.
+//
+// CHECK-LABEL: begin running test {{.*}} on test_init_existential_ref_opened_archetype: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $any NonSendableClassProtocol
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %1 = open_existential_ref %0 : $any NonSendableClassProtocol to $@opened("00000000-0000-0000-0000-000000000021", any NonSendableClassProtocol) Self
+// CHECK-NEXT: %%2: TrackableValue. State: TrackableValueState[id: 2][is_no_alias: no][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %2 = init_existential_ref %1 : $@opened("00000000-0000-0000-0000-000000000021", any NonSendableClassProtocol) Self : $@opened("00000000-0000-0000-0000-000000000021", any NonSendableClassProtocol) Self, $any NonSendableClassProtocol
+// CHECK-NEXT: require %%1:   %2 = init_existential_ref %1 : $@opened("00000000-0000-0000-0000-000000000021", any NonSendableClassProtocol) Self : $@opened("00000000-0000-0000-0000-000000000021", any NonSendableClassProtocol) Self, $any NonSendableClassProtocol
+// CHECK-NEXT: require %%1:   %2 = init_existential_ref %1 : $@opened("00000000-0000-0000-0000-000000000021", any NonSendableClassProtocol) Self : $@opened("00000000-0000-0000-0000-000000000021", any NonSendableClassProtocol) Self, $any NonSendableClassProtocol
+// CHECK-NEXT: assign_direct %%2 = %%1:   %2 = init_existential_ref %1 : $@opened("00000000-0000-0000-0000-000000000021", any NonSendableClassProtocol) Self : $@opened("00000000-0000-0000-0000-000000000021", any NonSendableClassProtocol) Self, $any NonSendableClassProtocol
+// CHECK-NEXT: end running test {{.*}} on test_init_existential_ref_opened_archetype: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_init_existential_ref_opened_archetype : $@convention(thin) (@guaranteed any NonSendableClassProtocol) -> () {
+bb0(%0 : @guaranteed $any NonSendableClassProtocol):
+  %1 = open_existential_ref %0 : $any NonSendableClassProtocol to $@opened("00000000-0000-0000-0000-000000000021", any NonSendableClassProtocol) Self
+  %2 = init_existential_ref %1 : $@opened("00000000-0000-0000-0000-000000000021", any NonSendableClassProtocol) Self : $@opened("00000000-0000-0000-0000-000000000021", any NonSendableClassProtocol) Self, $any NonSendableClassProtocol
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
   %r = tuple ()
   return %r : $()
 }
@@ -2394,6 +2421,35 @@ bb0(%0 : @guaranteed $NonSendableKlass):
   store %copy to [init] %addr
   destroy_addr %exist
   dealloc_stack %exist
+  %r = tuple ()
+  return %r : $()
+}
+
+// When init_existential_addr has a formal concrete type with an opened
+// archetype, the fix merges the result into the operand regions instead of
+// creating a new isolated-conformance region.
+//
+// CHECK-LABEL: begin running test {{.*}} on test_init_existential_addr_opened_archetype: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: yes][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $*any NonSendableProtocol
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %1 = alloc_stack $any NonSendableProtocol
+// CHECK-NEXT: %%2: TrackableValue. State: TrackableValueState[id: 2][is_no_alias: no][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %3 = init_existential_addr %1 : $*any NonSendableProtocol, $@opened("00000000-0000-0000-0000-000000000020", any NonSendableProtocol) Self
+// CHECK-NEXT: require %%1:   %3 = init_existential_addr %1 : $*any NonSendableProtocol, $@opened("00000000-0000-0000-0000-000000000020", any NonSendableProtocol) Self
+// CHECK-NEXT: require %%0:   %3 = init_existential_addr %1 : $*any NonSendableProtocol, $@opened("00000000-0000-0000-0000-000000000020", any NonSendableProtocol) Self
+// CHECK-NEXT: merge %%1 with %%0:   %3 = init_existential_addr %1 : $*any NonSendableProtocol, $@opened("00000000-0000-0000-0000-000000000020", any NonSendableProtocol) Self
+// CHECK-NEXT: assign_direct %%2 = %%1:   %3 = init_existential_addr %1 : $*any NonSendableProtocol, $@opened("00000000-0000-0000-0000-000000000020", any NonSendableProtocol) Self
+// CHECK-NEXT: end running test {{.*}} on test_init_existential_addr_opened_archetype: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_init_existential_addr_opened_archetype : $@convention(thin) (@in_guaranteed any NonSendableProtocol) -> () {
+bb0(%0 : $*any NonSendableProtocol):
+  %1 = alloc_stack $any NonSendableProtocol
+  %2 = open_existential_addr immutable_access %0 : $*any NonSendableProtocol to $*@opened("00000000-0000-0000-0000-000000000020", any NonSendableProtocol) Self
+  %3 = init_existential_addr %1 : $*any NonSendableProtocol, $@opened("00000000-0000-0000-0000-000000000020", any NonSendableProtocol) Self
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  copy_addr %2 to [init] %3
+  destroy_addr %1
+  dealloc_stack %1
   %r = tuple ()
   return %r : $()
 }

--- a/test/Concurrency/transfernonsendable_partitionop_translation_opaque_values.sil
+++ b/test/Concurrency/transfernonsendable_partitionop_translation_opaque_values.sil
@@ -1,0 +1,45 @@
+// RUN: %target-sil-opt -enable-sil-opaque-values -module-name partop_translation --test-runner %s 2>&1 | %FileCheck %s
+
+// REQUIRES: concurrency
+// REQUIRES: asserts
+
+// Test partition op translation for init_existential_value under the
+// opaque-values SIL lowering. When the formal concrete type involves an opened
+// archetype, init_existential_value must not create a spurious
+// isolated-conformance region. The result must merge into the region of its
+// operand (which is LookThrough of the original existential argument).
+
+sil_stage raw
+
+import Builtin
+import Swift
+
+////////////////////////
+// MARK: Declarations //
+////////////////////////
+
+protocol NonSendableProtocol {}
+
+/////////////////////////////////////////////////////
+// MARK: init_existential_value opened archetype  //
+/////////////////////////////////////////////////////
+
+// CHECK-LABEL: begin running test {{.*}} on test_init_existential_value_opened_archetype: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+// CHECK-NEXT: %%0: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: task-isolated].
+// CHECK-NEXT:     Rep Value: %0 = argument of bb0 : $any NonSendableProtocol
+// CHECK-NEXT: %%1: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: no][region_value_kind: disconnected].
+// CHECK-NEXT:     Rep Value:   %3 = init_existential_value %2 : $@opened("00000000-0000-0000-0000-000000000023", any NonSendableProtocol) Self, $@opened("00000000-0000-0000-0000-000000000023", any NonSendableProtocol) Self, $any NonSendableProtocol
+// CHECK-NEXT: require %%0:   %3 = init_existential_value %2 : $@opened("00000000-0000-0000-0000-000000000023", any NonSendableProtocol) Self, $@opened("00000000-0000-0000-0000-000000000023", any NonSendableProtocol) Self, $any NonSendableProtocol
+// CHECK-NEXT: require %%0:   %3 = init_existential_value %2 : $@opened("00000000-0000-0000-0000-000000000023", any NonSendableProtocol) Self, $@opened("00000000-0000-0000-0000-000000000023", any NonSendableProtocol) Self, $any NonSendableProtocol
+// CHECK-NEXT: assign_direct %%1 = %%0:   %3 = init_existential_value %2 : $@opened("00000000-0000-0000-0000-000000000023", any NonSendableProtocol) Self, $@opened("00000000-0000-0000-0000-000000000023", any NonSendableProtocol) Self, $any NonSendableProtocol
+// CHECK-NEXT: end running test {{.*}} on test_init_existential_value_opened_archetype: sil_regionanalysis_partitionoptranslation with: @instruction[-1]
+sil [ossa] @test_init_existential_value_opened_archetype : $@convention(thin) (@in_guaranteed any NonSendableProtocol) -> () {
+bb0(%0 : @guaranteed $any NonSendableProtocol):
+  %1 = open_existential_value %0 : $any NonSendableProtocol to $@opened("00000000-0000-0000-0000-000000000023", any NonSendableProtocol) Self
+  %2 = copy_value %1 : $@opened("00000000-0000-0000-0000-000000000023", any NonSendableProtocol) Self
+  %3 = init_existential_value %2 : $@opened("00000000-0000-0000-0000-000000000023", any NonSendableProtocol) Self, $@opened("00000000-0000-0000-0000-000000000023", any NonSendableProtocol) Self, $any NonSendableProtocol
+  specify_test "sil_regionanalysis_partitionoptranslation @instruction[-1]"
+  destroy_value %3 : $any NonSendableProtocol
+  %r = tuple ()
+  return %r : $()
+}


### PR DESCRIPTION
When init_existential_addr has a formal concrete type involving an opened archetype (e.g., the iterator type in a nonisolated actor init that iterates over any Sequence<Int>), the AssignDirect path calls getConformanceIsolation() and introduces a task-isolated isolated-conformance region. In a nonisolated actor init, parameters are 'self'-isolated, and merging 'self'-isolated with task-isolated-conformance triggers a RegionIsolationUnknownPattern false positive ("pattern that the region-based isolation checker does not understand how to check").

The reproducer is:

```swift
  actor Foo {
    init(sequence: any Sequence<Int>) {
      for element in sequence { // error: pattern that the region-based
        _ = element             // isolation checker does not understand
      }
    }
  }
```

Treating the conformance as an independent task-isolated conformance is incorrect. According to SE-0470, the iterator's conformance to IteratorProtocol is a dependent conformance on the conformance to Sequence which implies that the former conformance must be isolated to the same isolation domain as the latter conformance.

The fix detects this situation by calling
getFormalConcreteType()->hasOpenedExistential() and calls translateSILMultiAssign over all operands (primary + type-dependent) without a conformance isolation override. This places the init_existential_addr in the same region as its type-dependent operand producing value (the open_existential_addr), reflecting the dependent conformance relationship.

Found the same issue in init_existential_ref (class-bound existentials) and init_existential_value (opaque-values mode) and applied the same fix.

Tests cover all three instruction variants at the Swift level and as partition op translation SIL tests.

rdar://176882987
