### PR TITLE
[Test] Have async_task_sleep_cancel.swift sleep longer when testing cancellation.

### DIFF
--- a/test/Concurrency/Runtime/async_task_sleep_cancel.swift
+++ b/test/Concurrency/Runtime/async_task_sleep_cancel.swift
@@ -15,7 +15,13 @@ import Dispatch
 
 @available(SwiftStdlib 5.1, *)
 @main struct Main {
-  static let pause = 500_000_000 // 500ms
+  // Duration for testing a sleep that we intend to run to completion.
+  static let normalPause = 500_000_000 // 500ms
+
+  // Duration for testing a sleep that will be cancelled. This should not run to
+  // completion, so we make it longer in order to minimize the chance of some
+  // delay making the test fail spuriously.
+  static let cancelledPause = 15_000_000_000 // 15s
 
   static func main() async {
     // CHECK: Starting!
@@ -32,12 +38,12 @@ import Dispatch
     let start = DispatchTime.now()
 
     // try! will fail if the task got cancelled (which shouldn't happen).
-    try! await Task.sleep(nanoseconds: UInt64(pause))
+    try! await Task.sleep(nanoseconds: UInt64(normalPause))
 
     let stop = DispatchTime.now()
 
     // assert that at least the specified time passed since calling `sleep`
-    assert(stop >= (start + .nanoseconds(pause)))
+    assert(stop >= (start + .nanoseconds(normalPause)))
 
     // CHECK-NEXT: Wakey wakey!
     print("Wakey wakey!")
@@ -58,7 +64,7 @@ import Dispatch
     // CHECK-NEXT: Testing sleep that gets cancelled before it starts
     print("Testing sleep that gets cancelled before it starts")
     let sleepyTask = Task {
-      try await Task.sleep(nanoseconds: UInt64(pause))
+      try await Task.sleep(nanoseconds: UInt64(cancelledPause))
     }
 
     do {
@@ -82,7 +88,7 @@ import Dispatch
     let start = DispatchTime.now()
 
     let sleepyTask = Task {
-      try await Task.sleep(nanoseconds: UInt64(pause))
+      try await Task.sleep(nanoseconds: UInt64(cancelledPause))
     }
 
     do {
@@ -91,7 +97,7 @@ import Dispatch
       }
 
       let cancellerTask = Task {
-        await Task.sleep(UInt64(pause / 2))
+        await Task.sleep(UInt64(normalPause / 2))
         sleepyTask.cancel()
       }
 
@@ -105,7 +111,7 @@ import Dispatch
       let stop = DispatchTime.now()
 
       // assert that we stopped early.
-      assert(stop < (start + .nanoseconds(pause)))
+      assert(stop < (start + .nanoseconds(cancelledPause)))
     } catch {
       fatalError("sleep(nanoseconds:) threw some other error: \(error)")
     }


### PR DESCRIPTION
Extend the cancelled sleeps to 15 seconds to make spurious failures less likely. Previously the test would sleep for 500ms, then cancel and assert that less than 500ms had elapsed, which could pretty easily fail due to system load or similar. Extending the sleep duration doesn't make the test take any longer when it's successful so we can do this without slowing things down.

rdar://176869497