### PR TITLE
[cxx-interop] Add remaining C++23 headers into libstdc++ modulemap

### DIFF
--- a/lib/ClangImporter/ClangIncludePaths.cpp
+++ b/lib/ClangImporter/ClangIncludePaths.cpp
@@ -384,7 +384,7 @@ static void getLibStdCxxFileMapping(
     return;
   }
 
-  constexpr StringRef additionalFiles[] = {
+  std::vector<StringRef> additionalFiles = {
       // libstdc++ 4.8.5 bundled with CentOS 7 does not include corecvt.
       "codecvt",
       // C++17 and newer:
@@ -444,12 +444,28 @@ static void getLibStdCxxFileMapping(
       "span",
       "stop_token",
       "syncstream",
+      "version",
       // C++23 and newer:
       "expected",
       "flat_map",
       "flat_set",
       "mdspan",
-    };
+      "print",
+      "spanstream",
+      "stacktrace",
+      "stdfloat",
+  };
+  // <coroutine> in libstdc++ has an #error that fires if coroutines were not
+  // enabled via a compile time flag. This prevents us from listing <coroutine>
+  // in the modulemap unconditionally.
+  // <generator> relies on <coroutine>.
+  if (parsedStdlibArgs.hasFlag(clang::driver::options::OPT_fcoroutines,
+                               clang::driver::options::OPT_fno_coroutines,
+                               /*default*/ false)) {
+    additionalFiles.push_back("coroutine");
+    additionalFiles.push_back("generator");
+  }
+
   std::string additionalHeaderDirectives;
   llvm::raw_string_ostream os(additionalHeaderDirectives);
   os << contents.substr(0, headerInjectionPoint);

--- a/test/Interop/Cxx/stdlib/Inputs/module.modulemap
+++ b/test/Interop/Cxx/stdlib/Inputs/module.modulemap
@@ -140,3 +140,9 @@ module IteratorCycleUnrelatedOperator {
   requires cplusplus
   export *
 }
+
+module StdCoroutine {
+  header "std-coroutine.h"
+  requires cplusplus
+  export *
+}

--- a/test/Interop/Cxx/stdlib/Inputs/std-coroutine.h
+++ b/test/Interop/Cxx/stdlib/Inputs/std-coroutine.h
@@ -1,0 +1,10 @@
+#include <coroutine>
+
+struct CoroutineHandleHolder {
+  std::coroutine_handle<> handle;
+};
+
+inline bool isSuspendNeverReady() {
+  std::suspend_never s;
+  return s.await_ready();
+}

--- a/test/Interop/Cxx/stdlib/use-std-coroutine-typechecker.swift
+++ b/test/Interop/Cxx/stdlib/use-std-coroutine-typechecker.swift
@@ -1,0 +1,11 @@
+// RUN: %target-typecheck-verify-swift -I %S/Inputs -cxx-interoperability-mode=default -Xcc -std=c++20 -Xcc -fcoroutines
+// RUN: %target-typecheck-verify-swift -I %S/Inputs -cxx-interoperability-mode=default -Xcc -std=c++23 -Xcc -fcoroutines
+
+// Verify that C++ headers including <coroutine> can be imported into Swift,
+// even though C++ coroutines themselves are not usable from Swift.
+
+// REQUIRES: std_coroutine
+
+import StdCoroutine
+
+let _ = isSuspendNeverReady()

--- a/test/Interop/lit.local.cfg
+++ b/test/Interop/lit.local.cfg
@@ -76,6 +76,8 @@ if has_cxx_stdlib_header('span'):
     config.available_features.add('std_span')
 if has_cxx_stdlib_header('expected'):
     config.available_features.add('std_expected')
+if has_cxx_stdlib_header('coroutine'):
+    config.available_features.add('std_coroutine')
 
 # Enable C++ interop when compiling Swift sources.
 config.substitutions.insert(0, ('%target-interop-build-swift',


### PR DESCRIPTION
This adds all of the remaining C++ standard library headers that weren't added to the generated libstdc++ modulemap on Linux.

rdar://175928621

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
