### PR TITLE
Cherry-pick static hosting options for stdlib docs to release/6.3

### DIFF
--- a/utils/build_swift/build_swift/driver_arguments.py
+++ b/utils/build_swift/build_swift/driver_arguments.py
@@ -1252,6 +1252,12 @@ def create_argument_parser():
            default=False,
            help='Build and preview standard library documentation with Swift-DocC.'
                 'Note: this builds Swift-DocC to perform the docs build.')
+    option('--stdlib-docs-static-hosting', toggle_true,
+           default=False,
+           help='Build the standard library documentation for static hosting.')
+    option('--stdlib-docs-hosting-base-path', store,
+           default='/',
+           help='The base path for hosting the standard library documentation.')
 
     option('--build-swift-clang-overlays', toggle_true,
            default=True,

--- a/utils/build_swift/tests/expected_options.py
+++ b/utils/build_swift/tests/expected_options.py
@@ -293,6 +293,8 @@ EXPECTED_DEFAULTS = {
     'swift_user_visible_version': defaults.SWIFT_USER_VISIBLE_VERSION,
     'build_stdlib_docs': False,
     'preview_stdlib_docs': False,
+    'stdlib_docs_static_hosting': False,
+    'stdlib_docs_hosting_base_path': '/',
     'symbols_package': None,
     'clean_libdispatch': True,
     'clean_foundation': True,
@@ -609,6 +611,7 @@ EXPECTED_OPTIONS = [
     SetTrueOption('--wasmkit', dest='build_wasmkit'),
     SetTrueOption('--build-stdlib-docs'),
     SetTrueOption('--preview-stdlib-docs'),
+    SetTrueOption('--stdlib-docs-static-hosting'),
     SetTrueOption('-B', dest='benchmark'),
     SetTrueOption('-S', dest='skip_build'),
     SetTrueOption('-b', dest='build_llbuild'),
@@ -838,6 +841,8 @@ EXPECTED_OPTIONS = [
     StrOption('--swift-darwin-supported-archs'),
     SetTrueOption('--swift-freestanding-is-darwin'),
     AppendOption('--extra-swift-cmake-options'),
+
+    StrOption('--stdlib-docs-hosting-base-path'),
 
     StrOption('--linux-archs'),
     StrOption('--linux-static-archs'),


### PR DESCRIPTION
## Summary
- Cherry-picks commit 33edfface7b from main which adds `--stdlib-docs-static-hosting` and `--stdlib-docs-hosting-base-path` options to the build-script
- These options are referenced by `stdlib_docs.py` but were never registered in `driver_arguments.py` on this branch, causing an `AttributeError` when running `--build-stdlib-docs` on CI

## Test plan
- [ ] Run `utils/build-script --build-stdlib-docs` and verify no `AttributeError` on `stdlib_docs_static_hosting`
- [ ] Run `utils/build_swift/tests/test_driver_arguments.py` to verify expected options are registered