### PR TITLE
[Observation] Migrate `ContinuousObservation` off deprecated `withUnsafeContinuation`

### DIFF
--- a/stdlib/public/Observation/Sources/Observation/ContinuousObservation.swift
+++ b/stdlib/public/Observation/Sources/Observation/ContinuousObservation.swift
@@ -161,16 +161,11 @@ extension ContinuousObservation.State {
   }
 
   @diagnose(
-    DeprecatedDeclaration,
-    as: ignored,
-    reason: "https://github.com/swiftlang/swift/issues/89045"
-  )
-  @diagnose(
     ConversionFromIsolatedAnyToSynchronous,
     as: ignored,
     reason: "https://github.com/swiftlang/swift/issues/89361"
   )
-  fileprivate static func track(
+  fileprivate nonisolated(nonsending) static func track(
     _ state: _ManagedCriticalState<ContinuousObservation.State>,
     options: ObservationTracking.Options,
     apply:
@@ -180,7 +175,7 @@ extension ContinuousObservation.State {
   ) async -> Bool {
     return await withTaskCancellationHandler(
       operation: {
-        return await withUnsafeContinuation(isolation: apply.isolation) {
+        return await withUnsafeContinuation {
           continuation in
           guard
             ContinuousObservation.State.populate(state, continuation: continuation)
@@ -213,8 +208,7 @@ extension ContinuousObservation.State {
       },
       onCancel: {
         ContinuousObservation.State.cancel(state)
-      },
-      isolation: apply.isolation
+      }
     )
   }
 }


### PR DESCRIPTION
Closes #89045.

The `withUnsafeContinuation(isolation:_:)` overload was deprecated in favor of a `nonisolated(nonsending)` overload.

The new overload only inherits the intended isolation when its caller is itself `nonisolated(nonsending)`. Migrating just the inner call leaves the intermediate `withTaskCancellationHandler()` operation closure as a plain `async` function, which breaks the chain and causes the user's `apply()` closure to run with the wrong isolation. Migrate `track()` to `nonisolated(nonsending)` and switch `withTaskCancellationHandler()` to its matching new overload so the chain holds from `trackingLoop()` down to the continuation body.

The `test/stdlib/Observation` test suite passes locally with these changes, without the deprecation warning.