### PR TITLE
stdlib/Runtimes: Address a few warnings

### DIFF
--- a/Runtimes/Supplemental/StringProcessing/CMakeLists.txt
+++ b/Runtimes/Supplemental/StringProcessing/CMakeLists.txt
@@ -62,6 +62,8 @@ add_compile_options(
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature LifetimeDependence>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature InoutLifetimeDependence>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature LifetimeDependenceMutableAccessors>"
+  # For swift_getTupleTypeMetadata().
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature AllowRuntimeSymbolDeclarations>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-upcoming-feature MemberImportVisibility>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -enforce-exclusivity=unchecked>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -target-min-inlining-version -Xfrontend min>"
@@ -69,6 +71,9 @@ add_compile_options(
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -disable-implicit-string-processing-module-import>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Werror StrictMemorySafety>"
   "$<$<COMPILE_LANGUAGE:Swift>:-warn-implicit-overrides>"
+  # Pass a flag to the build indicating that _StringProcessing's modules
+  # will be built with library evolution.
+  "$<$<AND:$<BOOL:${${PROJECT_NAME}_ENABLE_LIBRARY_EVOLUTION}>,$<COMPILE_LANGUAGE:Swift>>:-DRESILIENT_LIBRARIES>"
   "$<$<AND:$<BOOL:${${PROJECT_NAME}_ENABLE_LIBRARY_EVOLUTION}>,$<COMPILE_LANGUAGE:Swift>>:-enable-library-evolution>"
   "$<$<AND:$<BOOL:${${PROJECT_NAME}_ENABLE_PRESPECIALIZATION}>,$<COMPILE_LANGUAGE:Swift>>:SHELL:-Xfrontend -prespecialize-generic-metadata>")
 

--- a/stdlib/public/Observation/Sources/Observation/ObservationRegistrar.swift
+++ b/stdlib/public/Observation/Sources/Observation/ObservationRegistrar.swift
@@ -214,7 +214,7 @@ public struct ObservationRegistrar: Sendable {
 
     func clearTracking(_ tracking: UnsafeRawPointer) {
       state.withCriticalRegion { state in
-        state.trackingLists.remove(tracking)
+        _ = state.trackingLists.remove(tracking)
       }
     }
     

--- a/stdlib/public/StringProcessing/CMakeLists.txt
+++ b/stdlib/public/StringProcessing/CMakeLists.txt
@@ -21,6 +21,10 @@ set(swift_string_processing_compile_flags)
 list(APPEND swift_string_processing_compile_flags
   "-DRESILIENT_LIBRARIES")
 
+# For swift_getTupleTypeMetadata().
+list(APPEND swift_string_processing_compile_flags
+  "-enable-experimental-feature" "AllowRuntimeSymbolDeclarations")
+
 if(SWIFT_BUILD_STATIC_STDLIB)
   # Explicitly autolink swift_RegexParser because it's imported with @_implementationOnly
   list(APPEND swift_string_processing_compile_flags

--- a/stdlib/public/core/StringStorageBridge.swift
+++ b/stdlib/public/core/StringStorageBridge.swift
@@ -835,7 +835,7 @@ fileprivate func isEqual(
      */
     let chunkSize = Swift.min(64, remainingOtherByteCount)
     // nil = keep looping; .some(equal) = terminate with that equality result
-    let chunkResult: Bool? = unsafe withUnsafeTemporaryAllocation(
+    let chunkResult: Bool? = withUnsafeTemporaryAllocation(
       of: UInt8.self,
       capacity: chunkSize
     ) { tmpBuffer in


### PR DESCRIPTION
- Remove a spurious `unsafe` in [StringStorageBridge.swift.](https://github.com/swiftlang/swift/commit/0a8918c31713da7d3e9775ba4432ca2572fcb43b).
- Suppress a `#NoUsage` warning in [ObservationRegistrar.swift](https://github.com/swiftlang/swift/compare/main...tshortli:warnings?expand=1#diff-b824e8d6f2a9d4c217d42ac8ef67d7628dafda2e86321ac23c4dc2e90545f13b).
- Allow `_StringProcessing` to declare runtime symbols and make its Runtimes CMake build consistent with the default build by passing `-DRESILIENT_LIBRARIES`.