### PR TITLE
[6.4 🍒][Source Warning Control] Ensure we do not attempt to serialize `@diagnose` attributes

### DIFF
--- a/include/swift/AST/DeclAttr.def
+++ b/include/swift/AST/DeclAttr.def
@@ -919,7 +919,7 @@ SIMPLE_DECL_ATTR(_unsafeSelfDependentResult, UnsafeSelfDependentResult,
 
 DECL_ATTR(diagnose, Diagnose,
   OnFunc | OnConstructor | OnDestructor | OnSubscript | OnVar | OnNominalType | OnExtension | OnEnumElement | OnAccessor | OnImport | OnTypeAlias | OnAssociatedType | OnMacro,
-  AllowMultipleAttributes | ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIStableToRemove | ForbiddenInABIAttr,
+  AllowMultipleAttributes | NotSerialized | ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIStableToRemove | ForbiddenInABIAttr,
   174)
 LAST_DECL_ATTR(Diagnose)
 

--- a/test/Serialization/attr-diagnose.swift
+++ b/test/Serialization/attr-diagnose.swift
@@ -1,0 +1,19 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -parse-as-library -emit-module-path %t/a.swiftmodule -module-name a %s
+// RUN: %llvm-bcanalyzer -dump %t/a.swiftmodule | %FileCheck --check-prefix BC-CHECK --implicit-check-not UnknownCode %s
+// RUN: %target-swift-ide-test -print-module -module-to-print a -source-filename x -I %t | %FileCheck --check-prefix MODULE-CHECK %s
+
+// @diagnose is a source-local diagnostic control and should not be serialized into the binary module (matching how it is excluded from textual interfaces).
+
+// BC-CHECK-NOT: Diagnose_DECL_ATTR
+// MODULE-CHECK-NOT: @diagnose
+// MODULE-CHECK: func callsDeprecated()
+
+@available(*, deprecated)
+public func deprecated() {}
+
+@inlinable
+@diagnose(DeprecatedDeclaration, as: ignored)
+public func callsDeprecated() {
+  deprecated()
+}


### PR DESCRIPTION
Cherry-pick of https://github.com/swiftlang/swift/pull/89049
------------------------

- **Explanation**: `@diagnose` is already not printed into textual interfaces and we forgot to also ensure it never gets serialized into binary modules. This change ensures this attribute is marked to not be serialized into binary modules.
- **Scope**: `@diagnose` attribute on a `public` declaration in code which is built for distribution as a module.
- **Issue**: rdar://176893559
- **Risk**: Low, simply strips the attribute from binary module serialization, which previously resulted in a crash. 
- **Original PR**: https://github.com/swiftlang/swift/pull/89049
- **Testing**: Test added to the test suite to validate emission of modules and that emitted modules are consumable.
- **Reviewers**: @tshortli 


