### PR TITLE
Lifetimes: Replace deps on partial_apply parameters with 'captures'

### DIFF
--- a/include/swift/AST/LifetimeDependence.h
+++ b/include/swift/AST/LifetimeDependence.h
@@ -418,6 +418,21 @@ public:
   uncurry(ASTContext &ctx, ArrayRef<LifetimeDependenceInfo> inner,
           unsigned numInnerParams, unsigned numOuterParams);
 
+  /// Compute the lifetime dependencies for the result of a partial application
+  /// of a SIL function with the given lifetimes and number of parameters,
+  /// binding the given number of arguments.
+  ///
+  /// Dependencies on parameters that are bound by the partial_apply are
+  /// replaced with 'captures' dependencies.
+  ///
+  /// Example: binding 1 argument of a 2-argument function.
+  /// %b = ... : B
+  /// %f = function_ref @closure : (A, B) -> @lifetime(borrow 1) C
+  /// %c = partial_apply %f(%b) : (A) -> @lifetime(captures) C
+  static ArrayRef<LifetimeDependenceInfo>
+  partialApply(ASTContext &ctx, ArrayRef<LifetimeDependenceInfo> lifetimes,
+               unsigned numFormalParams, unsigned numBoundParams);
+
   bool operator==(const LifetimeDependenceInfo &other) const {
     return this->hasImmortalSpecifier() == other.hasImmortalSpecifier() &&
            this->hasCaptures() == other.hasCaptures() &&

--- a/lib/AST/LifetimeDependence.cpp
+++ b/lib/AST/LifetimeDependence.cpp
@@ -2064,6 +2064,83 @@ ArrayRef<LifetimeDependenceInfo> LifetimeDependenceInfo::uncurry(
   return ctx.AllocateCopy(uncurried);
 }
 
+ArrayRef<LifetimeDependenceInfo> LifetimeDependenceInfo::partialApply(
+    ASTContext &ctx, ArrayRef<LifetimeDependenceInfo> lifetimes,
+    unsigned numFormalParams, unsigned numBoundParams) {
+
+  ASSERT(numBoundParams > 0 &&
+         "A partial application must bind at least 1 argument");
+  ASSERT(numBoundParams <= numFormalParams &&
+         "A partial application can only bind as many parameters as the "
+         "function has.");
+
+  // How many parameters the resulting closure will have.
+  const unsigned numClosureParams = numFormalParams - numBoundParams;
+
+  SmallVector<LifetimeDependenceInfo, 2> curried;
+
+  for (const auto &dep : lifetimes) {
+    // Determine the new target index.
+    unsigned targetIndex;
+    if (dep.getTargetIndex() == numFormalParams) {
+      // The target is the result.
+      // Its index is the number of parameters.
+      targetIndex = numClosureParams;
+    } else if (dep.getTargetIndex() >= numClosureParams) {
+      // The target is a captured parameter.
+      // The resulting closure does not need a lifetime dependence entry for it.
+      continue;
+    } else {
+      // The target is an uncaptured parameter.
+      // Its index remains the same.
+      targetIndex = dep.getTargetIndex();
+    }
+
+    auto flags = dep.flags;
+
+    const auto captureBoundParams = [&](IndexSubset *indices) -> IndexSubset * {
+      if (!indices)
+        return nullptr;
+
+      ASSERT(indices->getCapacity() == numFormalParams &&
+             "There should be 1 index per parameter. SIL functions cannot have "
+             "an implicit self parameter.");
+
+      auto bits = indices->getBitVector();
+
+      if (bits.find_last() >= int(numClosureParams)) {
+        // One of the lifetime source parameters is bound by the partial_apply.
+        // This becomes a captures dependence in the resulting closure.
+        flags.setCaptures(true);
+      }
+
+      // Remove the indices of the captured parameters.
+
+      if (bits.find_first() >= int(numClosureParams)) {
+        // All lifetime sources are captured. The resulting empty list of
+        // indices should be represented with a nullptr.
+        return nullptr;
+      }
+
+      bits.resize(numClosureParams);
+
+      return IndexSubset::get(ctx, bits);
+    };
+
+    auto inherit = captureBoundParams(dep.getInheritIndices());
+    auto scope = captureBoundParams(dep.getScopeIndices());
+    auto addressable = captureBoundParams(dep.getAddressableIndices());
+    auto conditionallyAddressable =
+        captureBoundParams(dep.getConditionallyAddressableIndices());
+
+    curried.push_back(LifetimeDependenceInfo(inherit, scope, targetIndex,
+                                             addressable,
+                                             conditionallyAddressable, flags));
+  }
+
+  return ctx.AllocateCopy(curried);
+}
+
 void LifetimeDependenceInfo::dump() const {
   llvm::errs() << "target: " << getTargetIndex() << '\n';
   if (hasImmortalSpecifier()) {

--- a/lib/AST/LifetimeDependence.cpp
+++ b/lib/AST/LifetimeDependence.cpp
@@ -2068,8 +2068,9 @@ ArrayRef<LifetimeDependenceInfo> LifetimeDependenceInfo::partialApply(
     ASTContext &ctx, ArrayRef<LifetimeDependenceInfo> lifetimes,
     unsigned numFormalParams, unsigned numBoundParams) {
 
-  ASSERT(numBoundParams > 0 &&
-         "A partial application must bind at least 1 argument");
+  if (numBoundParams == 0)
+    return lifetimes;
+
   ASSERT(numBoundParams <= numFormalParams &&
          "A partial application can only bind as many parameters as the "
          "function has.");

--- a/lib/AST/LifetimeDependence.cpp
+++ b/lib/AST/LifetimeDependence.cpp
@@ -2139,6 +2139,9 @@ ArrayRef<LifetimeDependenceInfo> LifetimeDependenceInfo::partialApply(
                                              conditionallyAddressable, flags));
   }
 
+  // FIXME: Avoid allocating context memory for every partial apply. Instead,
+  // cache a single uniqueLifetimeDependenceInfo array for each combination
+  // of FunctionType + numBoundParams.
   return ctx.AllocateCopy(curried);
 }
 

--- a/lib/AST/LifetimeDependence.cpp
+++ b/lib/AST/LifetimeDependence.cpp
@@ -2103,8 +2103,9 @@ ArrayRef<LifetimeDependenceInfo> LifetimeDependenceInfo::partialApply(
       if (!indices)
         return nullptr;
 
-      ASSERT(indices->getCapacity() == numFormalParams &&
-             "There should be 1 index per parameter. SIL functions cannot have "
+      ASSERT(indices->getCapacity() <= numFormalParams &&
+             "There should be at most 1 index per parameter. SIL functions "
+             "cannot have "
              "an implicit self parameter.");
 
       auto bits = indices->getBitVector();
@@ -2115,7 +2116,8 @@ ArrayRef<LifetimeDependenceInfo> LifetimeDependenceInfo::partialApply(
         flags.setCaptures(true);
       }
 
-      // Remove the indices of the captured parameters.
+      // Remove the indices of the captured parameters, leaving only those of
+      // the closure parameters.
 
       if (bits.find_first() >= int(numClosureParams)) {
         // All lifetime sources are captured. The resulting empty list of
@@ -2123,7 +2125,8 @@ ArrayRef<LifetimeDependenceInfo> LifetimeDependenceInfo::partialApply(
         return nullptr;
       }
 
-      bits.resize(numClosureParams);
+      if (bits.size() > numClosureParams)
+        bits.resize(numClosureParams);
 
       return IndexSubset::get(ctx, bits);
     };

--- a/lib/SIL/IR/SILBuilder.cpp
+++ b/lib/SIL/IR/SILBuilder.cpp
@@ -72,7 +72,11 @@ SILType SILBuilder::getPartialApplyResultType(
           .intoBuilder()
           .withRepresentation(SILFunctionType::Representation::Thick)
           .withIsolation(resultIsolation)
-          .withIsPseudogeneric(false);
+          .withIsPseudogeneric(false)
+          .withLifetimeDependencies(LifetimeDependenceInfo::partialApply(
+              context.getContext()->getASTContext(),
+              FTI->getLifetimeDependencies(), FTI->getNumParameters(),
+              argCount));
   if (onStack)
     extInfoBuilder = extInfoBuilder.withNoEscape();
   auto extInfo = extInfoBuilder.build();

--- a/test/IRGen/rdar176795176.swift
+++ b/test/IRGen/rdar176795176.swift
@@ -1,4 +1,6 @@
-// RUN: %target-swift-frontend -emit-ir -O %s
+// RUN: %target-swift-frontend -emit-ir -O -enable-experimental-feature Lifetimes %s
+
+// REQUIRES: swift_feature_Lifetimes
 
 // Minimal reproducer for IRGen crash: rdar://176795176
 

--- a/test/IRGen/rdar176795176.swift
+++ b/test/IRGen/rdar176795176.swift
@@ -1,0 +1,136 @@
+// RUN: %target-swift-frontend -emit-ir -O %s
+
+// Minimal reproducer for IRGen crash: rdar://176795176
+
+// MARK: - NE
+
+public struct NE: ~Escapable {
+    @_lifetime(immortal)
+    public init() {}
+}
+
+// MARK: - INES
+
+public protocol INES: ~Escapable {
+    @_lifetime(copy self)
+    consuming func f(at indices: Range<Int>) -> NE
+}
+
+// MARK: - NES
+
+public protocol NES: ~Copyable {
+    associatedtype Bytes: INES & ~Escapable
+}
+
+// MARK: - IRef
+
+public protocol IRef<PR>: ~Copyable {
+    associatedtype PR: ~Copyable
+    associatedtype P: BitwiseCopyable
+
+    static func a(of p: P) -> UnsafePointer<PR>
+}
+
+// MARK: - Ref
+
+@frozen
+public struct Ref<L, C, PR>: ~Escapable & ~Copyable
+where
+    L: ~Escapable,
+    C: ~Copyable & IRef<PR>,
+    PR: ~Copyable
+{
+    @usableFromInline
+    let p: C.P
+
+    @_lifetime(immortal)
+    @usableFromInline
+    init(immortal p: C.P) {
+        self.p = p
+    }
+}
+
+extension Ref: Copyable
+where
+    L: ~Escapable,
+    C: Copyable
+{}
+
+extension Ref: BitwiseCopyable
+where
+    L: ~Escapable,
+    C: Copyable
+{}
+
+// MARK: - The crashing extension
+
+extension Ref: INES
+where
+    L: ~Escapable,
+    C: Copyable,
+    PR: NES & ~Copyable
+{
+    @_lifetime(copy self)
+    public consuming func f(
+        at indices: Range<Int>
+    ) -> NE {
+        let bytes = self.fromPR {
+            return _overrideL(immortal: $0[bytes: indices])
+        }
+        return _overrideL(bytes, copy: self)
+    }
+}
+
+extension Ref
+where
+    L: ~Escapable,
+    C: ~Copyable,
+    PR: ~Copyable
+{
+    @_lifetime(copy self)
+    fileprivate func fromPR<Thrown, Output: ~Escapable>(
+        body: (borrowing PR) throws(Thrown) -> Output
+    ) throws(Thrown) -> Output
+    where
+        Thrown: Error,
+        Output: ~Copyable
+    {
+        return _overrideL(
+            try body(C.a(of: self.p).pointee),
+            copy: self
+        )
+    }
+}
+
+// Subscripts used by f
+extension NES where Self: ~Copyable {
+    subscript(bytes indices: Range<Int>) -> NE {
+        @_lifetime(borrow self)
+        get {
+            NE()
+        }
+    }
+}
+
+// _overrideL stubs — mimicking stdlib
+
+@_unsafeNonescapableResult
+@_lifetime(immortal)
+@_alwaysEmitIntoClient
+@_transparent
+public func _overrideL<T: ~Copyable & ~Escapable>(
+    immortal value: consuming T
+) -> T {
+    value
+}
+
+@_unsafeNonescapableResult
+@_lifetime(copy source)
+@_alwaysEmitIntoClient
+@_transparent
+public func _overrideL<T: ~Copyable & ~Escapable, U: ~Copyable & ~Escapable>(
+    _ value: consuming T,
+    copy source: borrowing U
+) -> T {
+    value
+}

--- a/test/SILGen/partial_apply_lifetime.swift
+++ b/test/SILGen/partial_apply_lifetime.swift
@@ -1,5 +1,7 @@
 // RUN: %target-swift-emit-silgen -module-name partial_apply_lifetime -enable-experimental-feature Lifetimes %s | %FileCheck %s
 
+// REQUIRES: swift_feature_Lifetimes
+
 // These tests exercise the lifetime dependencies computed for partial_apply
 // result types by LifetimeDependenceInfo::partialApply. Each case pins down
 // exactly what partialApply must produce by declaring an explicit

--- a/test/SILGen/partial_apply_lifetime.swift
+++ b/test/SILGen/partial_apply_lifetime.swift
@@ -1,0 +1,218 @@
+// RUN: %target-swift-emit-silgen -module-name partial_apply_lifetime -enable-experimental-feature Lifetimes %s | %FileCheck %s
+
+// These tests exercise the lifetime dependencies computed for partial_apply
+// result types by LifetimeDependenceInfo::partialApply. Each case pins down
+// exactly what partialApply must produce by declaring an explicit
+// @_lifetime(...) on the callee's closure parameter and then checking the
+// convert_escape_to_noescape target type (which is the partial_apply's result
+// type, minus the @noescape attribute). A convert_function between the
+// partial_apply and the consuming apply would mean partialApply disagreed with
+// the callee's expected type, so `CHECK-NOT: convert_function` is added as an
+// extra guard.
+
+struct NE: ~Escapable {
+  @_lifetime(immortal)
+  init() {}
+}
+
+// -----------------------------------------------------------------------------
+// Baseline: a single-capture closure with a borrow-on-capture result.
+// Lifted closure: (NE) -> @lifetime(borrow 0) NE
+// Bind 1 captured NE -> () -> @lifetime(captures) NE
+// Verifies: target=result is remapped, all-bound scope source collapses to
+// nullptr, and the captures flag is set.
+// -----------------------------------------------------------------------------
+
+@_lifetime(copy f)
+func copyNE(f: () -> NE) -> NE {
+  f()
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s22partial_apply_lifetime9callGetNE3ne1AA0F0VAE_tF : $@convention(thin) (@guaranteed NE) -> @lifetime(copy 0) @owned NE {
+// CHECK: [[FNREF:%[0-9]+]] = function_ref @$s22partial_apply_lifetime9callGetNE3ne1AA0F0VAE_tFAEyXEfU_ : $@convention(thin) (@guaranteed NE) -> @lifetime(borrow 0) @owned NE
+// CHECK: [[CLOSURE:%[0-9]+]] = partial_apply [callee_guaranteed] [[FNREF]]
+// CHECK-NOT: convert_function
+// CHECK: [[NECLOSURE:%[0-9]+]] = convert_escape_to_noescape [not_guaranteed] [[CLOSURE]] to $@noescape @callee_guaranteed () -> @lifetime(captures) @owned NE
+// CHECK: [[GETNE:%[0-9]+]] = function_ref @$s22partial_apply_lifetime6copyNE1fAA0E0VAEyXE_tF
+// CHECK: apply [[GETNE]]([[NECLOSURE]])
+// CHECK-LABEL: } // end sil function '$s22partial_apply_lifetime9callGetNE3ne1AA0F0VAE_tF'
+func callGetNE(ne1: NE) -> NE {
+  copyNE { ne1 }
+}
+
+// -----------------------------------------------------------------------------
+// Dependency on an unbound formal parameter: the source index is kept and no
+// captures flag is added.
+//
+// Lifted closure: (NE, Bool) -> @lifetime(borrow 0) NE
+// Bind 1 (the captured Bool) -> (NE) -> @lifetime(borrow 0) NE
+// -----------------------------------------------------------------------------
+
+@_lifetime(copy f)
+func eatOneBorrow(f: @_lifetime(borrow ne) (_ ne: NE) -> NE) -> NE {
+  let local = NE()
+  return f(local)
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s22partial_apply_lifetime19callBorrowOnUnbound4condAA2NEVSb_tF :
+// CHECK: [[FNREF:%[0-9]+]] = function_ref @$s22partial_apply_lifetime19callBorrowOnUnbound4condAA2NEVSb_tFA2EXEfU_ : $@convention(thin) (@guaranteed NE, Bool) -> @lifetime(borrow 0) @owned NE
+// CHECK: [[CLOSURE:%[0-9]+]] = partial_apply [callee_guaranteed] [[FNREF]]
+// CHECK-NOT: convert_function
+// CHECK: convert_escape_to_noescape [not_guaranteed] [[CLOSURE]] to $@noescape @callee_guaranteed (@guaranteed NE) -> @lifetime(borrow 0) @owned NE
+// CHECK-LABEL: } // end sil function '$s22partial_apply_lifetime19callBorrowOnUnbound4condAA2NEVSb_tF'
+func callBorrowOnUnbound(cond: Bool) -> NE {
+  eatOneBorrow { n in if cond { return n } else { return n } }
+}
+
+// -----------------------------------------------------------------------------
+// Dependency on a bound-only source: the index list collapses to nullptr and
+// the captures flag is set.
+//
+// Lifted closure: (NE, NE) -> @lifetime(borrow 1) NE
+// Bind 1 (the captured NE) -> (NE) -> @lifetime(captures) NE
+// -----------------------------------------------------------------------------
+
+@_lifetime(copy f)
+func eatOneCaptures(f: @_lifetime(captures) (NE) -> NE) -> NE {
+  let local = NE()
+  return f(local)
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s22partial_apply_lifetime14callDepOnBound5boundAA2NEVAE_tF :
+// CHECK: [[FNREF:%[0-9]+]] = function_ref @$s22partial_apply_lifetime14callDepOnBound5boundAA2NEVAE_tFA2EXEfU_ : $@convention(thin) (@guaranteed NE, @guaranteed NE) -> @lifetime(borrow 1) @owned NE
+// CHECK: [[CLOSURE:%[0-9]+]] = partial_apply [callee_guaranteed] [[FNREF]]
+// CHECK-NOT: convert_function
+// CHECK: convert_escape_to_noescape [not_guaranteed] [[CLOSURE]] to $@noescape @callee_guaranteed (@guaranteed NE) -> @lifetime(captures) @owned NE
+// CHECK-LABEL: } // end sil function '$s22partial_apply_lifetime14callDepOnBound5boundAA2NEVAE_tF'
+@_lifetime(copy bound)
+func callDepOnBound(bound: NE) -> NE {
+  eatOneCaptures { _ in bound }
+}
+
+// -----------------------------------------------------------------------------
+// Dependency on a mix of bound and unbound sources: the bound bits are trimmed
+// off and the captures flag is set, while the unbound bits remain.
+//
+// Lifted closure: (NE, Bool, NE) -> @lifetime(borrow 0, borrow 1, borrow 2) NE
+// Bind 2 (the captured Bool and NE) ->
+//   (NE) -> @lifetime(captures, borrow 0) NE
+// -----------------------------------------------------------------------------
+
+@_lifetime(copy f)
+func eatOneCapturesAndBorrow(f: @_lifetime(captures, borrow ne) (_ ne: NE) -> NE) -> NE {
+  let local = NE()
+  return f(local)
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s22partial_apply_lifetime9callMixed5bound4condAA2NEVAF_SbtF :
+// CHECK: [[FNREF:%[0-9]+]] = function_ref @$s22partial_apply_lifetime9callMixed5bound4condAA2NEVAF_SbtFA2FXEfU_ : $@convention(thin) (@guaranteed NE, Bool, @guaranteed NE) -> @lifetime(borrow 0, borrow 1, borrow 2) @owned NE
+// CHECK: [[CLOSURE:%[0-9]+]] = partial_apply [callee_guaranteed] [[FNREF]]
+// CHECK-NOT: convert_function
+// CHECK: convert_escape_to_noescape [not_guaranteed] [[CLOSURE]] to $@noescape @callee_guaranteed (@guaranteed NE) -> @lifetime(captures, borrow 0) @owned NE
+// CHECK-LABEL: } // end sil function '$s22partial_apply_lifetime9callMixed5bound4condAA2NEVAF_SbtF'
+@_lifetime(copy bound)
+func callMixed(bound: NE, cond: Bool) -> NE {
+  eatOneCapturesAndBorrow { n in cond ? n : bound }
+}
+
+// -----------------------------------------------------------------------------
+// Multiple bound parameters with every source bound: exercises
+// numBoundParams > 1 in combination with the all-bound collapse path. Every
+// captured parameter contributes a source, so the result ends up as a pure
+// captures-only dependency.
+//
+// Lifted closure: (Bool, NE, NE) -> @lifetime(borrow 0, borrow 1, borrow 2) NE
+// Bind 3 (the three captures) -> () -> @lifetime(captures) NE
+// -----------------------------------------------------------------------------
+
+@_lifetime(copy f)
+func eatZeroCaptures(f: @_lifetime(captures) () -> NE) -> NE {
+  f()
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s22partial_apply_lifetime18callBindMultiBound1a1b4condAA2NEVAG_AGSbtF :
+// CHECK: [[FNREF:%[0-9]+]] = function_ref @$s22partial_apply_lifetime18callBindMultiBound1a1b4condAA2NEVAG_AGSbtFAGyXEfU_ : $@convention(thin) (Bool, @guaranteed NE, @guaranteed NE) -> @lifetime(borrow 0, borrow 1, borrow 2) @owned NE
+// CHECK: [[CLOSURE:%[0-9]+]] = partial_apply [callee_guaranteed] [[FNREF]]
+// CHECK-NOT: convert_function
+// CHECK: convert_escape_to_noescape [not_guaranteed] [[CLOSURE]] to $@noescape @callee_guaranteed () -> @lifetime(captures) @owned NE
+// CHECK-LABEL: } // end sil function '$s22partial_apply_lifetime18callBindMultiBound1a1b4condAA2NEVAG_AGSbtF'
+@_lifetime(copy a, copy b)
+func callBindMultiBound(a: NE, b: NE, cond: Bool) -> NE {
+  eatZeroCaptures { cond ? a : b }
+}
+
+// -----------------------------------------------------------------------------
+// Multiple bound parameters with the dependency on the unbound formal: the
+// partialApply transform should leave the source index untouched and not set
+// captures.
+//
+// Lifted closure: (NE, Bool, Int) -> @lifetime(borrow 0) NE
+// Bind 2 (cond and tag) -> (NE) -> @lifetime(borrow 0) NE
+// -----------------------------------------------------------------------------
+
+// CHECK-LABEL: sil hidden [ossa] @$s22partial_apply_lifetime20callBindMultiUnbound4cond3tagAA2NEVSb_SitF :
+// CHECK: [[FNREF:%[0-9]+]] = function_ref @$s22partial_apply_lifetime20callBindMultiUnbound4cond3tagAA2NEVSb_SitFA2FXEfU_ : $@convention(thin) (@guaranteed NE, Bool, Int) -> @lifetime(borrow 0) @owned NE
+// CHECK: [[CLOSURE:%[0-9]+]] = partial_apply [callee_guaranteed] [[FNREF]]
+// CHECK-NOT: convert_function
+// CHECK: convert_escape_to_noescape [not_guaranteed] [[CLOSURE]] to $@noescape @callee_guaranteed (@guaranteed NE) -> @lifetime(borrow 0) @owned NE
+// CHECK-LABEL: } // end sil function '$s22partial_apply_lifetime20callBindMultiUnbound4cond3tagAA2NEVSb_SitF'
+@_lifetime(immortal)
+func callBindMultiUnbound(cond: Bool, tag: Int) -> NE {
+  eatOneBorrow { n in
+    if cond && tag > 0 { return n } else { return n }
+  }
+}
+
+// -----------------------------------------------------------------------------
+// @_lifetime(immortal) should round-trip through partialApply unchanged. The
+// immortal entry has no source index lists (all nullptr), so the captures
+// flag must not be set.
+//
+// Lifted closure: (Int) -> @lifetime(immortal) NE
+// Bind 1 -> () -> @lifetime(immortal) NE
+// -----------------------------------------------------------------------------
+
+@_lifetime(copy f)
+func eatImmortal(f: @_lifetime(immortal) () -> NE) -> NE {
+  f()
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s22partial_apply_lifetime12callImmortal5extraAA2NEVSi_tF :
+// CHECK: [[FNREF:%[0-9]+]] = function_ref @$s22partial_apply_lifetime12callImmortal5extraAA2NEVSi_tFAEyXEfU_ : $@convention(thin) (Int) -> @lifetime(immortal) @owned NE
+// CHECK: [[CLOSURE:%[0-9]+]] = partial_apply [callee_guaranteed] [[FNREF]]
+// CHECK-NOT: convert_function
+// CHECK: convert_escape_to_noescape [not_guaranteed] [[CLOSURE]] to $@noescape @callee_guaranteed () -> @lifetime(immortal) @owned NE
+// CHECK-NOT: captures
+// CHECK-LABEL: } // end sil function '$s22partial_apply_lifetime12callImmortal5extraAA2NEVSi_tF'
+@_lifetime(immortal)
+func callImmortal(extra: Int) -> NE {
+  eatImmortal { let _ = extra; return NE() }
+}
+
+// -----------------------------------------------------------------------------
+// Mixed dependency kinds (inherit + scope) within a single entry: exercises
+// that captureBoundParams is applied independently to each index list so that
+// an unbound inherit index is preserved while the corresponding scope list
+// collapses and sets the captures flag.
+//
+// Lifted closure: (NE, Bool, NE) -> @lifetime(copy 0, borrow 1, borrow 2) NE
+// Bind 2 (cond and the captured NE) ->
+//   (NE) -> @lifetime(captures, copy 0) NE
+// -----------------------------------------------------------------------------
+
+@_lifetime(copy f)
+func eatOneCapturesCopy(f: @_lifetime(captures, copy ne) (_ ne: NE) -> NE) -> NE {
+  let local = NE()
+  return f(local)
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s22partial_apply_lifetime14callMixedKinds5bound4condAA2NEVAF_SbtF :
+// CHECK: [[FNREF:%[0-9]+]] = function_ref @$s22partial_apply_lifetime14callMixedKinds5bound4condAA2NEVAF_SbtFA2FXEfU_ : $@convention(thin) (@guaranteed NE, Bool, @guaranteed NE) -> @lifetime(copy 0, borrow 1, borrow 2) @owned NE
+// CHECK: [[CLOSURE:%[0-9]+]] = partial_apply [callee_guaranteed] [[FNREF]]
+// CHECK-NOT: convert_function
+// CHECK: convert_escape_to_noescape [not_guaranteed] [[CLOSURE]] to $@noescape @callee_guaranteed (@guaranteed NE) -> @lifetime(captures, copy 0) @owned NE
+// CHECK-LABEL: } // end sil function '$s22partial_apply_lifetime14callMixedKinds5bound4condAA2NEVAF_SbtF'
+@_lifetime(copy bound)
+func callMixedKinds(bound: NE, cond: Bool) -> NE {
+  eatOneCapturesCopy { n in cond ? n : bound }
+}

--- a/test/SILGen/partial_apply_lifetime.swift
+++ b/test/SILGen/partial_apply_lifetime.swift
@@ -17,13 +17,7 @@ struct NE: ~Escapable {
   init() {}
 }
 
-// -----------------------------------------------------------------------------
 // Baseline: a single-capture closure with a borrow-on-capture result.
-// Lifted closure: (NE) -> @lifetime(borrow 0) NE
-// Bind 1 captured NE -> () -> @lifetime(captures) NE
-// Verifies: target=result is remapped, all-bound scope source collapses to
-// nullptr, and the captures flag is set.
-// -----------------------------------------------------------------------------
 
 @_lifetime(copy f)
 func copyNE(f: () -> NE) -> NE {
@@ -42,13 +36,8 @@ func callGetNE(ne1: NE) -> NE {
   copyNE { ne1 }
 }
 
-// -----------------------------------------------------------------------------
 // Dependency on an unbound formal parameter: the source index is kept and no
 // captures flag is added.
-//
-// Lifted closure: (NE, Bool) -> @lifetime(borrow 0) NE
-// Bind 1 (the captured Bool) -> (NE) -> @lifetime(borrow 0) NE
-// -----------------------------------------------------------------------------
 
 @_lifetime(copy f)
 func eatOneBorrow(f: @_lifetime(borrow ne) (_ ne: NE) -> NE) -> NE {
@@ -66,13 +55,7 @@ func callBorrowOnUnbound(cond: Bool) -> NE {
   eatOneBorrow { n in if cond { return n } else { return n } }
 }
 
-// -----------------------------------------------------------------------------
-// Dependency on a bound-only source: the index list collapses to nullptr and
-// the captures flag is set.
-//
-// Lifted closure: (NE, NE) -> @lifetime(borrow 1) NE
-// Bind 1 (the captured NE) -> (NE) -> @lifetime(captures) NE
-// -----------------------------------------------------------------------------
+// Dependency on a borrowed source: replaced with captures.
 
 @_lifetime(copy f)
 func eatOneCaptures(f: @_lifetime(captures) (NE) -> NE) -> NE {
@@ -91,14 +74,9 @@ func callDepOnBound(bound: NE) -> NE {
   eatOneCaptures { _ in bound }
 }
 
-// -----------------------------------------------------------------------------
-// Dependency on a mix of bound and unbound sources: the bound bits are trimmed
-// off and the captures flag is set, while the unbound bits remain.
-//
-// Lifted closure: (NE, Bool, NE) -> @lifetime(borrow 0, borrow 1, borrow 2) NE
-// Bind 2 (the captured Bool and NE) ->
-//   (NE) -> @lifetime(captures, borrow 0) NE
-// -----------------------------------------------------------------------------
+// Dependency on a mix of captured and uncaptured sources: only the dependencies
+// on captured parameters (those bound by the partial apply) are replaced with
+// the captures dependency source.
 
 @_lifetime(copy f)
 func eatOneCapturesAndBorrow(f: @_lifetime(captures, borrow ne) (_ ne: NE) -> NE) -> NE {
@@ -117,15 +95,7 @@ func callMixed(bound: NE, cond: Bool) -> NE {
   eatOneCapturesAndBorrow { n in cond ? n : bound }
 }
 
-// -----------------------------------------------------------------------------
-// Multiple bound parameters with every source bound: exercises
-// numBoundParams > 1 in combination with the all-bound collapse path. Every
-// captured parameter contributes a source, so the result ends up as a pure
-// captures-only dependency.
-//
-// Lifted closure: (Bool, NE, NE) -> @lifetime(borrow 0, borrow 1, borrow 2) NE
-// Bind 3 (the three captures) -> () -> @lifetime(captures) NE
-// -----------------------------------------------------------------------------
+// Multiple parameters, all captured.
 
 @_lifetime(copy f)
 func eatZeroCaptures(f: @_lifetime(captures) () -> NE) -> NE {
@@ -143,14 +113,7 @@ func callBindMultiBound(a: NE, b: NE, cond: Bool) -> NE {
   eatZeroCaptures { cond ? a : b }
 }
 
-// -----------------------------------------------------------------------------
-// Multiple bound parameters with the dependency on the unbound formal: the
-// partialApply transform should leave the source index untouched and not set
-// captures.
-//
-// Lifted closure: (NE, Bool, Int) -> @lifetime(borrow 0) NE
-// Bind 2 (cond and tag) -> (NE) -> @lifetime(borrow 0) NE
-// -----------------------------------------------------------------------------
+// Multiple parameters: some captured, some not.
 
 // CHECK-LABEL: sil hidden [ossa] @$s22partial_apply_lifetime20callBindMultiUnbound4cond3tagAA2NEVSb_SitF :
 // CHECK: [[FNREF:%[0-9]+]] = function_ref @$s22partial_apply_lifetime20callBindMultiUnbound4cond3tagAA2NEVSb_SitFA2FXEfU_ : $@convention(thin) (@guaranteed NE, Bool, Int) -> @lifetime(borrow 0) @owned NE
@@ -165,14 +128,7 @@ func callBindMultiUnbound(cond: Bool, tag: Int) -> NE {
   }
 }
 
-// -----------------------------------------------------------------------------
-// @_lifetime(immortal) should round-trip through partialApply unchanged. The
-// immortal entry has no source index lists (all nullptr), so the captures
-// flag must not be set.
-//
-// Lifted closure: (Int) -> @lifetime(immortal) NE
-// Bind 1 -> () -> @lifetime(immortal) NE
-// -----------------------------------------------------------------------------
+// No lifetime sources: unaffected.
 
 @_lifetime(copy f)
 func eatImmortal(f: @_lifetime(immortal) () -> NE) -> NE {
@@ -191,16 +147,7 @@ func callImmortal(extra: Int) -> NE {
   eatImmortal { let _ = extra; return NE() }
 }
 
-// -----------------------------------------------------------------------------
-// Mixed dependency kinds (inherit + scope) within a single entry: exercises
-// that captureBoundParams is applied independently to each index list so that
-// an unbound inherit index is preserved while the corresponding scope list
-// collapses and sets the captures flag.
-//
-// Lifted closure: (NE, Bool, NE) -> @lifetime(copy 0, borrow 1, borrow 2) NE
-// Bind 2 (cond and the captured NE) ->
-//   (NE) -> @lifetime(captures, copy 0) NE
-// -----------------------------------------------------------------------------
+// Mixed dependency kinds (inherit + scope) within a single entry.
 
 @_lifetime(copy f)
 func eatOneCapturesCopy(f: @_lifetime(captures, copy ne) (_ ne: NE) -> NE) -> NE {
@@ -217,4 +164,67 @@ func eatOneCapturesCopy(f: @_lifetime(captures, copy ne) (_ ne: NE) -> NE) -> NE
 @_lifetime(copy bound)
 func callMixedKinds(bound: NE, cond: Bool) -> NE {
   eatOneCapturesCopy { n in cond ? n : bound }
+}
+
+// Converting a non-throwing function to typed-throws: this legitimately requires a
+// convert_function.
+
+func takeTypedThrowingNEReturning<E: Error>(_ f: (NE) throws(E) -> NE) {}
+
+// CHECK-LABEL: sil hidden [ossa] @$s22partial_apply_lifetime34reabstractToTypedThrowsNEReturningyyAA2NEVADXEF :
+// CHECK: [[THUNK:%[0-9]+]] = function_ref @$s22partial_apply_lifetime2NEVACIggo_A2Cs5NeverOIeggozr_TR : $@convention(thin) (@guaranteed NE, @lifetime(captures, copy 0) @guaranteed @noescape @callee_guaranteed (@guaranteed NE) -> @lifetime(captures, copy 0) @owned NE) -> (@owned NE, @error_indirect Never)
+// CHECK: [[CLOSURE:%[0-9]+]] = partial_apply [callee_guaranteed] [[THUNK]]
+// CHECK: convert_function [[CLOSURE]] to $@callee_guaranteed @substituted <τ_0_0> (@guaranteed NE) -> @lifetime(captures, copy 0) (@owned NE, @error_indirect τ_0_0) for <Never>
+// CHECK-LABEL: } // end sil function '$s22partial_apply_lifetime34reabstractToTypedThrowsNEReturningyyAA2NEVADXEF'
+func reabstractToTypedThrowsNEReturning(_ f: (NE) -> NE) {
+  takeTypedThrowingNEReturning(f)
+}
+
+// Typed throws with inout parameter.
+
+func takeTypedThrowingInout<E: Error>(_ f: (inout NE) throws(E) -> Void) {}
+
+// CHECK-LABEL: sil hidden [ossa] @$s22partial_apply_lifetime28reabstractToTypedThrowsInoutyyyAA2NEVzXEF :
+// CHECK: [[THUNK:%[0-9]+]] = function_ref @$s22partial_apply_lifetime2NEVIgl_ACs5NeverOIeglzr_TR : $@convention(thin) (@lifetime(copy 0) @inout NE, @guaranteed @noescape @callee_guaranteed (@lifetime(copy 0) @inout NE) -> ()) -> @error_indirect Never
+// CHECK: [[CLOSURE:%[0-9]+]] = partial_apply [callee_guaranteed] [[THUNK]]
+// CHECK: convert_function [[CLOSURE]] to $@callee_guaranteed @substituted <τ_0_0> (@lifetime(copy 0) @inout NE) -> @error_indirect τ_0_0 for <Never>
+// CHECK-LABEL: } // end sil function '$s22partial_apply_lifetime28reabstractToTypedThrowsInoutyyyAA2NEVzXEF'
+func reabstractToTypedThrowsInout(_ f: (inout NE) -> Void) {
+  takeTypedThrowingInout(f)
+}
+
+// Inout parameter, without a legitimate need for a convert_function:
+// No convert_function is emitted.
+
+struct Holder: ~Escapable {
+  @_lifetime(immortal)
+  init() {}
+
+  @_lifetime(self: copy other)
+  mutating func mut(other: NE) {}
+}
+
+func consumeInout(_ f: (inout Holder) -> ()) {}
+
+// CHECK-LABEL: sil hidden [ossa] @$s22partial_apply_lifetime13driveMutation5otheryAA2NEV_tF :
+// CHECK: [[FNREF:%[0-9]+]] = function_ref @$s22partial_apply_lifetime13driveMutation5otheryAA2NEV_tFyAA6HolderVzXEfU_ : $@convention(thin) (@lifetime(copy 0) @inout Holder, @guaranteed NE) -> ()
+// CHECK: [[CLOSURE:%[0-9]+]] = partial_apply [callee_guaranteed] [[FNREF]]
+// CHECK-NOT: convert_function
+// CHECK: convert_escape_to_noescape [not_guaranteed] [[CLOSURE]] to $@noescape @callee_guaranteed (@lifetime(copy 0) @inout Holder) -> ()
+// CHECK-LABEL: } // end sil function '$s22partial_apply_lifetime13driveMutation5otheryAA2NEV_tF'
+func driveMutation(other: NE) {
+  consumeInout { (h: inout Holder) in h.mut(other: other) }
+}
+
+// Captured inout parameter.
+
+// CHECK-LABEL: sil hidden [ossa] @$s22partial_apply_lifetime21callWithCapturedInoutyAA2NEVADzF : $@convention(thin) (@lifetime(copy 0) @inout NE) -> @lifetime(borrow 0) @owned NE {
+// CHECK: [[FNREF:%[0-9]+]] = function_ref @$s22partial_apply_lifetime21callWithCapturedInoutyAA2NEVADzFADyXEfU_ : $@convention(thin) (@inout_aliasable NE) -> @lifetime(borrow 0) @owned NE
+// CHECK: [[CLOSURE:%[0-9]+]] = partial_apply [callee_guaranteed] [[FNREF]]
+// CHECK-NOT: convert_function
+// CHECK: convert_escape_to_noescape [not_guaranteed] [[CLOSURE]] to $@noescape @callee_guaranteed () -> @lifetime(captures) @owned NE
+// CHECK-LABEL: } // end sil function '$s22partial_apply_lifetime21callWithCapturedInoutyAA2NEVADzF'
+@_lifetime(&ne)
+func callWithCapturedInout(_ ne: inout NE) -> NE {
+  copyNE { ne }
 }


### PR DESCRIPTION
When forming a closure with `partial_apply`, replace any lifetime dependencies on specific captured parameters with the opaque `captures` dependence. Also omit any lifetime dependence with a target parameter that is bound by the `partial_apply`, since the closure will have no corresponding parameter to mark as the target of the dependence.

Until now, the compiler would emit a `convert_function` instruction after every `partial_apply` of a function with lifetime dependencies, to give the closure its expected lifetimes. This should no longer be necessary in cases where the lifetimes were the only mismatched aspect of the resulting type.

Fixes: rdar://176795176 (While emitting IR SIL function)
<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
