### PR TITLE
utils: avoid re-cloning the sources for EarlySwiftDriver

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -2087,6 +2087,11 @@ function Build-EarlySwiftDriver([Hashtable] $Platform) {
       SWIFT_DRIVER_BUILD_TOOLS = "NO";
       SQLite3_INCLUDE_DIR = "$SourceCache\swift-toolchain-sqlite\Sources\CSQLite\include";
       SQLite3_LIBRARY = "$(Get-ProjectBinaryCache $Platform SQLite)\SQLite3.lib";
+
+      # Prevent re-cloning the soruces
+      FETCHCONTENT_SOURCE_DIR_ARGUMENTPARSER = "$SourceCache\swift-argument-parser";
+      FETCHCONTENT_SOURCE_DIR_LLBUILD = "$SourceCache\llbuild";
+      FETCHCONTENT_SOURCE_DIR_TOOLSSUPPORTCORE = "$SourceCache\swift-tools-support-core";
     }
 }
 


### PR DESCRIPTION
We already have a checkout for the dependencies of early-swift-driver. Reuse the existing sources rather than checking them out from git again.