### PR TITLE
tests: don't fail if instruction counts are not available for scale tests

### DIFF
--- a/utils/scale-test
+++ b/utils/scale-test
@@ -637,6 +637,8 @@ def report(args, rng, runs):
         print("No data found")
         if len(args.select) != 0:
             "(perhaps try a different --select?)"
+        if args.ignore_no_data:
+            return False
         return True
     rows = []
     for k in keys:
@@ -749,6 +751,9 @@ def main():
     parser.add_argument(
         '--trace', action='store_true',
         default=False, help='trace compiler invocations')
+    parser.add_argument(
+        '--ignore-no-data', action='store_true',
+        default=False, help='do not exit with a failure if there is no data')
     parser.add_argument(
         '--quiet', action='store_true',
         default=False, help='only print superlinear stats')

--- a/validation-test/SILOptimizer/alias_analysis_scale_test.swift.gyb
+++ b/validation-test/SILOptimizer/alias_analysis_scale_test.swift.gyb
@@ -1,10 +1,9 @@
-// RUN: %timer-scale-test --begin 50 --end 800 --superlinear-threshold 3 --trace --select SIL-processing.instr -O %s
+// RUN: %timer-scale-test --begin 50 --end 800 --superlinear-threshold 3 --ignore-no-data --trace --select SIL-processing.instr -O %s
 
 // TODO: there are still compile time problems in CopyPropagation and OSSACanonicalizationOwned (inside SILCombine): rdar://176255056
 //       Once those problems are fixed the threshold should be closer to 1.
 
 // REQUIRES: asserts
-// REQUIRES: OS=macosx
 
 public class Entry {
   private let a: String

--- a/validation-test/SILOptimizer/many_struct_properties_scale_test.swift.gyb
+++ b/validation-test/SILOptimizer/many_struct_properties_scale_test.swift.gyb
@@ -1,10 +1,9 @@
-// RUN: %timer-scale-test --begin 100 --end 1000 --superlinear-threshold 4 --trace --select SIL-processing.instr -O %s
+// RUN: %timer-scale-test --begin 100 --end 1000 --superlinear-threshold 4 --ignore-no-data --trace --select SIL-processing.instr -O %s
 
 // TODO: there are still compile time problems in CopyPropagation and OSSACanonicalizationOwned (inside SILCombine): rdar://176255056
 //       Once those problems are fixed the threshold should be closer to 1.
 
 // REQUIRES: asserts
-// REQUIRES: OS=macosx
 
 public typealias Handler = ((Int) -> Int)
 


### PR DESCRIPTION
Instead of explicitly limiting those tests to specific platforms, just ignore "No data" results.

rdar://176820820
