### PR TITLE
[RemoteInspection] Fix handling of extensions in DemanglingForTypeRef

### DIFF
--- a/stdlib/public/RemoteInspection/TypeRef.cpp
+++ b/stdlib/public/RemoteInspection/TypeRef.cpp
@@ -636,6 +636,30 @@ class DemanglingForTypeRef
     return node;
   }
 
+  /// Produce the node to install as a nominal's context when swapping in the
+  /// richer parent stored on the TypeRef.
+  ///
+  /// Extensions are special because they're the only node that can appear
+  /// instead of the parent (and contain it). For an Extension, the richer
+  /// parent replaces the extended-type slot, preserving the module and any
+  /// generic signature. For every other context kind, the richer parent
+  /// replaces the context wholesale.
+  ///
+  /// Returns nullptr if originalContext is a malformed Extension.
+  Demangle::NodePointer
+  substituteParentIntoContext(Demangle::NodePointer originalContext,
+                              Demangle::NodePointer parentNode) {
+    if (originalContext->getKind() != Node::Kind::Extension)
+      return parentNode;
+    if (originalContext->getNumChildren() < 2 ||
+        originalContext->getNumChildren() > 3) {
+      assert(false && "Extension node should have 2 or 3 children.");
+      return nullptr;
+    }
+    originalContext->replaceChild(1, parentNode);
+    return originalContext;
+  }
+
 public:
   DemanglingForTypeRef(Demangle::Demangler &Dem) : Dem(Dem) {}
 
@@ -674,8 +698,13 @@ public:
         parentNode->getNumChildren())
       parentNode = parentNode->getFirstChild();
 
+    auto originalContext = node->getChild(0);
     auto contextualizedNode = Dem.createNode(node->getKind());
-    contextualizedNode->addChild(parentNode, Dem);
+    auto newContext = substituteParentIntoContext(originalContext, parentNode);
+    if (!newContext)
+      return nullptr;
+
+    contextualizedNode->addChild(newContext, Dem);
     contextualizedNode->addChild(node->getChild(1), Dem);
     return contextualizedNode;
   }
@@ -723,13 +752,16 @@ public:
     // Save identifier for reinsertion later, we have to remove it
     // so we can insert the parent node as the first child.
     auto identifierNode = nominalNode->getLastChild();
+    auto originalContext = nominalNode->getFirstChild();
 
     // Remove all children.
     nominalNode->removeChildAt(1);
     nominalNode->removeChildAt(0);
 
-    // Add the parent we just visited back in, followed by the identifier.
-    nominalNode->addChild(parentNode, Dem);
+    auto newContext = substituteParentIntoContext(originalContext, parentNode);
+    if (!newContext)
+      return nullptr;
+    nominalNode->addChild(newContext, Dem);
     nominalNode->addChild(identifierNode, Dem);
 
     return genericNode;

--- a/validation-test/Reflection/reflect_extension_parent_class.swift
+++ b/validation-test/Reflection/reflect_extension_parent_class.swift
@@ -1,0 +1,60 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-build-swift-dylib(%t/%target-library-name(Base)) %t/base.swift -emit-module -emit-module-path %t/Base.swiftmodule -module-name Base
+// RUN: %target-codesign %t/%target-library-name(Base)
+
+// RUN: %target-build-swift -lswiftSwiftReflectionTest %t/main.swift -L %t -I %t -lBase -o %t/reflect_extension_parent_class %target-rpath(%t)
+// RUN: %target-codesign %t/reflect_extension_parent_class
+
+// RUN: %target-run %target-swift-reflection-test %t/reflect_extension_parent_class | tee /dev/stderr | %FileCheck %s --dump-input=fail
+
+// REQUIRES: executable_test
+// REQUIRES: reflection_test_support
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: asan
+
+// Verifies that reflection can resolve types declared inside a cross-module
+// extension — i.e., types whose parent (the extended type) lives in a
+// different module than the extension itself.
+
+//--- base.swift
+
+public struct Outer {
+  public init() {}
+}
+
+//--- main.swift
+
+import Base
+import SwiftReflectionTest
+
+extension Outer {
+  public class Inner<Content> {
+    public let field: Content
+    public init(_ v: Content) { self.field = v }
+  }
+
+  // Non-generic struct in an unconstrained cross-module extension.
+  public struct Plain {
+    public let flag: Int = 99
+  }
+}
+
+reflect(any: Outer.Inner<Int>(42))
+
+// CHECK: Reflecting an existential.
+// CHECK: Type reference:
+// CHECK: (bound_generic_class (extension in reflect_extension_parent_class):Base.Outer.Inner
+// CHECK: Mangled name: $s4Base5OuterV{{.*}}extension_parent_classE5InnerC{{.*}}
+// CHECK: Demangled name: (extension in reflect_extension_parent_class):Base.Outer.Inner<Swift.Int>
+
+reflect(any: Outer.Plain())
+
+// CHECK: Reflecting an existential.
+// CHECK: Type reference:
+// CHECK: (struct (extension in reflect_extension_parent_class):Base.Outer.Plain
+// CHECK: Mangled name: $s4Base5OuterV{{.*}}extension_parent_classE5PlainV{{.*}}
+// CHECK: Demangled name: (extension in reflect_extension_parent_class):Base.Outer.Plain
+
+doneReflecting()


### PR DESCRIPTION
Typically, the first node of a nested type is the type that contains it. For example:

```
Demangling for $s7ModBase5OuterV5InnerC
kind=Global
  kind=Class
    kind=Structure
      kind=Module, text="ModBase"
      kind=Identifier, text="Outer"
    kind=Identifier, text="Inner"
$s7ModBase5OuterV5InnerC ---> ModBase.Outer.Inner
```

However, when a type is declared inside an extension of "Outer", that becomes part of the mangled name too. For example:

```
Demangling for $s7ModBase5OuterV6ModExtE5InnerC
kind=Global
  kind=Class
    kind=Extension
      kind=Module, text="ModExt"
      kind=Structure
        kind=Module, text="ModBase"
        kind=Identifier, text="Outer"
    kind=Identifier, text="Inner"
$s7ModBase5OuterV6ModExtE5InnerC ---> (extension in ModExt):ModBase.Outer.Inner
````

DemanglingForTypeRef did not treat the extension case correctly, and was losing the extension information. This patch fixes it.

Assisted-by: claude

rdar://176586425
