### PR TITLE
Adopt nonisolated(nonsending) on `Clock.measure` and `withValue` concurrency APIs

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2973,13 +2973,16 @@ ConstraintSystem::matchFunctionIsolations(FunctionType *func1,
   // function-conversion score to make sure this solution is worse than
   // an exact match.
   // FIXME: there may be a better way. see https://github.com/apple/swift/pull/62514
-  auto matchIfConversion = [&](bool isErasure = false) -> bool {
+  auto matchIfConversion = [&](bool isErasure = false,
+                               bool shouldIncreaseScore = true) -> bool {
     // We generally require a conversion here, but allow some lassitude
     // if we're doing witness-matching.
     if (kind < ConstraintKind::Subtype &&
         !(isErasure && isWitnessMatching(locator)))
       return false;
-    increaseScore(SK_FunctionConversion, locator);
+
+    if (shouldIncreaseScore)
+      increaseScore(SK_FunctionConversion, locator);
     return true;
   };
 
@@ -3041,7 +3044,40 @@ ConstraintSystem::matchFunctionIsolations(FunctionType *func1,
     // For synchronous: Thunk would call the function without
     // a hop.
     case FunctionTypeIsolation::Kind::NonIsolated:
-      return matchIfConversion();
+      // When a nonisolated/@concurrent closure is passed to a
+      // nonisolated(nonsending) parameter the solver has to be conservative
+      // and produce a conversion that could be dissolved by actor
+      // isolation checker when it determines that nonisolated(nonsending)
+      // could be assumed onto the closure direct (i.e. when there are no
+      // isolated captures involved), so let's not increase a score unless
+      // closure states it's isolation explicitly to avoid picking a subpar
+      // solution.
+      bool shouldIncreaseScore = true;
+      if (func1->isAsync()) {
+        auto *expr = locator.trySimplifyToExpr();
+
+        if (expr)
+          expr = expr->getSemanticsProvidingExpr();
+
+        if (auto *cast = getAsExpr<ExplicitCastExpr>(expr))
+          expr = cast->getSubExpr();
+
+        // Look through captures, we only care about the closure itself.
+        if (auto *captureList = getAsExpr<CaptureListExpr>(expr))
+          expr = captureList->getClosureBody();
+
+        if (auto *closure = getAsExpr<ClosureExpr>(expr)) {
+          shouldIncreaseScore =
+              closure->getAttrs().hasAttribute<ConcurrentAttr>();
+        }
+      } else {
+        // Converting a sync function to nonisolated(nonsending) async one
+        // doesn't require a thunk.
+        shouldIncreaseScore = false;
+      }
+
+      return matchIfConversion(
+          /*isErasure=*/false, shouldIncreaseScore);
     }
     llvm_unreachable("bad kind");
 

--- a/stdlib/public/Concurrency/Clock.swift
+++ b/stdlib/public/Concurrency/Clock.swift
@@ -78,7 +78,6 @@ extension Clock {
 
   @available(StdlibDeploymentTarget 5.7, *)
   @_alwaysEmitIntoClient
-  @_disfavoredOverload
   @available(*, deprecated, message: "Replaced by nonisolated(nonsending) overload")
   public func measure(
     isolation: isolated (any Actor)? = #isolation,

--- a/stdlib/public/Concurrency/Clock.swift
+++ b/stdlib/public/Concurrency/Clock.swift
@@ -67,7 +67,7 @@ extension Clock {
   ///       }
   @available(StdlibDeploymentTarget 5.7, *)
   @_alwaysEmitIntoClient
-  public func measure(
+  public nonisolated(nonsending) func measure(
     _ work: nonisolated(nonsending) () async throws -> Void
   ) async rethrows -> Instant.Duration {
     let start = now

--- a/stdlib/public/Concurrency/Clock.swift
+++ b/stdlib/public/Concurrency/Clock.swift
@@ -68,6 +68,19 @@ extension Clock {
   @available(StdlibDeploymentTarget 5.7, *)
   @_alwaysEmitIntoClient
   public func measure(
+    _ work: nonisolated(nonsending) () async throws -> Void
+  ) async rethrows -> Instant.Duration {
+    let start = now
+    try await work()
+    let end = now
+    return start.duration(to: end)
+  }
+
+  @available(StdlibDeploymentTarget 5.7, *)
+  @_alwaysEmitIntoClient
+  @_disfavoredOverload
+  @available(*, deprecated, message: "Replaced by nonisolated(nonsending) overload")
+  public func measure(
     isolation: isolated (any Actor)? = #isolation,
     _ work: () async throws -> Void
   ) async rethrows -> Instant.Duration {

--- a/stdlib/public/Concurrency/TaskGroup.swift
+++ b/stdlib/public/Concurrency/TaskGroup.swift
@@ -451,6 +451,14 @@ public struct TaskGroup<ChildTaskResult: Sendable> {
 
   /// Wait for all of the group's remaining tasks to complete.
   @_alwaysEmitIntoClient
+  public nonisolated(nonsending) mutating func waitForAll() async {
+    await awaitAllRemainingTasks(isolation: #isolation)
+  }
+
+  /// Wait for all of the group's remaining tasks to complete.
+  @_alwaysEmitIntoClient
+  @_disfavoredOverload
+  @available(*, deprecated, message: "Replaced by nonisolated(nonsending) overload")
   public mutating func waitForAll(isolation: isolated (any Actor)? = #isolation) async {
     await awaitAllRemainingTasks(isolation: isolation)
   }
@@ -641,6 +649,29 @@ public struct ThrowingTaskGroup<ChildTaskResult: Sendable, Failure: Error> {
   /// - Throws: The *first* error that was thrown by a child task during draining all the tasks.
   ///           This first error is stored until all other tasks have completed, and is re-thrown afterwards.
   @_alwaysEmitIntoClient
+  public nonisolated(nonsending) mutating func waitForAll() async throws {
+    var firstError: Error? = nil
+
+    // Make sure we loop until all child tasks have completed
+    while !isEmpty {
+      do {
+        while let _ = try await next() {}
+      } catch {
+        // Upon error throws, capture the first one
+        if firstError == nil {
+          firstError = error
+        }
+      }
+    }
+
+    if let firstError {
+      throw firstError
+    }
+  }
+
+  @_alwaysEmitIntoClient
+  @_disfavoredOverload
+  @available(*, deprecated, message: "Replaced by nonisolated(nonsending) overload")
   public mutating func waitForAll(isolation: isolated (any Actor)? = #isolation) async throws {
     var firstError: Error? = nil
 
@@ -780,6 +811,13 @@ public struct ThrowingTaskGroup<ChildTaskResult: Sendable, Failure: Error> {
   ///
   /// - SeeAlso: `next()`
   @_alwaysEmitIntoClient
+  public nonisolated(nonsending) mutating func nextResult() async -> Result<ChildTaskResult, Failure>? {
+    return try! await nextResultForABI()
+  }
+
+  @_alwaysEmitIntoClient
+  @_disfavoredOverload
+  @available(*, deprecated, message: "Replaced by nonisolated(nonsending) overload")
   public mutating func nextResult(isolation: isolated (any Actor)? = #isolation) async -> Result<ChildTaskResult, Failure>? {
     return try! await nextResultForABI()
   }

--- a/stdlib/public/Concurrency/TaskGroup.swift
+++ b/stdlib/public/Concurrency/TaskGroup.swift
@@ -457,7 +457,6 @@ public struct TaskGroup<ChildTaskResult: Sendable> {
 
   /// Wait for all of the group's remaining tasks to complete.
   @_alwaysEmitIntoClient
-  @_disfavoredOverload
   @available(*, deprecated, message: "Replaced by nonisolated(nonsending) overload")
   public mutating func waitForAll(isolation: isolated (any Actor)? = #isolation) async {
     await awaitAllRemainingTasks(isolation: isolation)
@@ -670,7 +669,6 @@ public struct ThrowingTaskGroup<ChildTaskResult: Sendable, Failure: Error> {
   }
 
   @_alwaysEmitIntoClient
-  @_disfavoredOverload
   @available(*, deprecated, message: "Replaced by nonisolated(nonsending) overload")
   public mutating func waitForAll(isolation: isolated (any Actor)? = #isolation) async throws {
     var firstError: Error? = nil
@@ -816,7 +814,6 @@ public struct ThrowingTaskGroup<ChildTaskResult: Sendable, Failure: Error> {
   }
 
   @_alwaysEmitIntoClient
-  @_disfavoredOverload
   @available(*, deprecated, message: "Replaced by nonisolated(nonsending) overload")
   public mutating func nextResult(isolation: isolated (any Actor)? = #isolation) async -> Result<ChildTaskResult, Failure>? {
     return try! await nextResultForABI()

--- a/stdlib/public/Concurrency/TaskLocal.swift
+++ b/stdlib/public/Concurrency/TaskLocal.swift
@@ -262,7 +262,6 @@ public final class TaskLocal<Value: Sendable>: Sendable, CustomStringConvertible
   @available(SwiftStdlib 5.1, *)
   @backDeployed(before: SwiftStdlib 6.0)
   @available(*, deprecated, message: "Prefer the 'nonisolated(nonsending)' overload with stricter execution on caller context semantics: withValue(_:operation:file:line:)")
-  @_disfavoredOverload
   public func withValue<R>( // for source compatibility
     _ valueDuringOperation: Value,
     operation: () async throws -> R,

--- a/stdlib/public/Concurrency/TaskLocal.swift
+++ b/stdlib/public/Concurrency/TaskLocal.swift
@@ -226,20 +226,49 @@ public final class TaskLocal<Value: Sendable>: Sendable, CustomStringConvertible
   /// in specific child tasks, the more specific (i.e. "deeper") binding is
   /// returned when the value is read.
   ///
+  /// The operation is guaranteed to execute in the calling context.
+  ///
   /// If the value is a reference type, it will be retained for the duration of
   /// the operation closure.
   ///
   /// If this method is called form a context where no current Swift concurrency task
   /// is available, a fallback thread-local is used to manage the task locals and
   /// all existing semantics of task-locals are upheld as-if a task was actually available.
+  @_alwaysEmitIntoClient
+  @discardableResult
+  @available(SwiftStdlib 5.1, *)
+  // ABI Note: @abi needed because the mangling otherwise conflicts with the
+  // legacy @_unsafeInheritExecutor declaration.
+  @abi(
+    nonisolated(nonsending) func withValueNonisolatedNonsending<R>(
+      _ valueDuringOperation: Value,
+      operation: nonisolated(nonsending) () async throws -> R,
+      file: String, line: UInt
+    ) async throws -> R
+  )
+  public nonisolated(nonsending) func withValue<R>(
+    _ valueDuringOperation: Value,
+    operation: nonisolated(nonsending) () async throws -> R,
+    file: String = #fileID, line: UInt = #line
+  ) async rethrows -> R {
+    return try await withValueImpl(
+      valueDuringOperation,
+      operation: operation,
+      file: file, line: line)
+  }
+
   @inlinable
   @discardableResult
   @available(SwiftStdlib 5.1, *)
   @backDeployed(before: SwiftStdlib 6.0)
-  public func withValue<R>(_ valueDuringOperation: Value,
-                           operation: () async throws -> R,
-                           isolation: isolated (any Actor)? = #isolation,
-                           file: String = #fileID, line: UInt = #line) async rethrows -> R {
+  @available(*, deprecated, message: "Prefer the 'nonisolated(nonsending)' overload with stricter execution on caller context semantics: withValue(_:operation:file:line:)")
+  @_disfavoredOverload
+  public func withValue<R>( // for source compatibility
+    _ valueDuringOperation: Value,
+    operation: () async throws -> R,
+    isolation: isolated (any Actor)? = #isolation,
+    file: String = #fileID, line: UInt = #line
+  ) async rethrows -> R {
     return try await withValueImpl(
       valueDuringOperation,
       operation: operation,
@@ -283,6 +312,24 @@ public final class TaskLocal<Value: Sendable>: Sendable, CustomStringConvertible
   /// calls to swift_task_de/alloc for the copy as follows:
   /// - withValue contains the compiler-emitted calls swift_task_de/alloc.
   /// - withValueImpl contains the calls to Builtin.{add,remove}TaskLocalValue
+  @_alwaysEmitIntoClient
+  @discardableResult
+  @available(SwiftStdlib 5.1, *)
+  internal nonisolated(nonsending) func withValueImpl<R>(
+    _ valueDuringOperation: __owned Value,
+    operation: nonisolated(nonsending) () async throws -> R,
+    file: String = #fileID, line: UInt = #line
+  ) async rethrows -> R {
+#if $BuiltinAddTaskLocalValue
+    let binding = Builtin.addTaskLocalValue(key, consume valueDuringOperation)
+    defer { Builtin.removeTaskLocalValue(binding) }
+#else
+    _taskLocalValuePush(key: key, value: consume valueDuringOperation)
+    defer { _taskLocalValuePop() }
+#endif
+    return try await operation()
+  }
+
   @inlinable
   @discardableResult
   @available(SwiftStdlib 5.1, *)
@@ -298,7 +345,6 @@ public final class TaskLocal<Value: Sendable>: Sendable, CustomStringConvertible
     _taskLocalValuePush(key: key, value: consume valueDuringOperation)
     defer { _taskLocalValuePop() }
 #endif
-
     return try await operation()
   }
 

--- a/test/Concurrency/transfernonsendable_nonisolated.swift
+++ b/test/Concurrency/transfernonsendable_nonisolated.swift
@@ -134,16 +134,24 @@ func callMainActorIsolatedFunction() async {
 }
 
 public final class LoggingScope {
-  fileprivate static let _subsystem: TaskLocal<String?>! = nil
-  fileprivate static let _scope: TaskLocal<String?>! = nil
+  static let _subsystem: TaskLocal<String?>! = nil
 }
 
-public func withLoggingSubsystemAndScope<Result>(
-  subsystem: String,
-  scope: String?,
-  @_inheritActorContext _ operation: @Sendable @concurrent () async throws -> Result
-) async rethrows -> Result {
-  return try await LoggingScope._subsystem.withValue(subsystem) {
-    return try await LoggingScope._scope.withValue(scope, operation: operation)
+func withCancellationHandling<R>(_ body: () async throws -> R) async rethrows -> R {
+  try await body()
+}
+
+func withLoggingSubsystemAndScope<R>(
+    perform body: () async throws -> R
+) async rethrows -> R {
+  return try await LoggingScope._subsystem.withValue(nil) {
+    try await withCancellationHandling(body)
+  }
+}
+func withLoggingSubsystemAndScopeNonsending<R>(
+  perform body: nonisolated(nonsending) () async throws -> R
+) async rethrows -> R {
+  return try await LoggingScope._subsystem.withValue(nil) {
+    try await withCancellationHandling(body)
   }
 }

--- a/test/api-digester/stability-concurrency-abi.test
+++ b/test/api-digester/stability-concurrency-abi.test
@@ -109,13 +109,15 @@ Func SerialExecutor.enqueue(_:) has been added as a protocol requirement
 Func Executor.enqueue(_:) is a new API without '@available'
 
 // Adopt #isolation in TaskLocal.withValue APIs
-Func TaskLocal.withValue(_:operation:file:line:) has been renamed to Func withValue(_:operation:isolation:file:line:)
+Func TaskLocal.withValue(_:operation:file:line:) has been renamed to Func withValueImpl(_:operation:isolation:file:line:)
 Func TaskLocal.withValue(_:operation:file:line:) has mangled name changing from '_Concurrency.TaskLocal.withValue<A>(_: A, operation: () async throws -> A1, file: Swift.String, line: Swift.UInt) async throws -> A1' to '_Concurrency.TaskLocal.withValue<A>(_: A, operation: () throws -> A1, file: Swift.String, line: Swift.UInt) throws -> A1'
-Func TaskLocal.withValue(_:operation:file:line:) has mangled name changing from '_Concurrency.TaskLocal.withValue<A>(_: A, operation: () throws -> A1, file: Swift.String, line: Swift.UInt) throws -> A1' to '_Concurrency.TaskLocal.withValue<A>(_: A, operation: () async throws -> A1, isolation: isolated Swift.Optional<Swift.Actor>, file: Swift.String, line: Swift.UInt) async throws -> A1'
+Func TaskLocal.withValue(_:operation:file:line:) has mangled name changing from '_Concurrency.TaskLocal.withValue<A>(_: A, operation: () throws -> A1, file: Swift.String, line: Swift.UInt) throws -> A1' to '_Concurrency.TaskLocal.withValueImpl<A>(_: __owned A, operation: () async throws -> A1, isolation: isolated Swift.Optional<Swift.Actor>, file: Swift.String, line: Swift.UInt) async throws -> A1'
+Func TaskLocal.withValue(_:operation:file:line:) has parameter 0 changing from Default to Owned
 Func TaskLocal.withValue(_:operation:file:line:) has parameter 1 type change from () async throws -> τ_1_0 to () throws -> τ_1_0
 Func TaskLocal.withValue(_:operation:file:line:) has parameter 1 type change from () throws -> τ_1_0 to () async throws -> τ_1_0
 Func TaskLocal.withValue(_:operation:file:line:) has parameter 2 type change from Swift.String to (any _Concurrency.Actor)?
 Func TaskLocal.withValue(_:operation:file:line:) has parameter 3 type change from Swift.UInt to Swift.String
+Func TaskLocal.withValue(_:operation:file:line:) has removed default argument from parameter 2
 Func withTaskGroup(of:returning:body:) has parameter 2 type change from (inout _Concurrency.TaskGroup<τ_0_0>) async -> τ_0_1 to (any _Concurrency.Actor)?
 Func withThrowingTaskGroup(of:returning:body:) has been renamed to Func withThrowingTaskGroup(of:returning:isolation:body:)
 Func withThrowingTaskGroup(of:returning:body:) has mangled name changing from '_Concurrency.withThrowingTaskGroup<A, B where A: Swift.Sendable>(of: A.Type, returning: B.Type, body: (inout Swift.ThrowingTaskGroup<A, Swift.Error>) async throws -> B) async throws -> B' to '_Concurrency.withThrowingTaskGroup<A, B where A: Swift.Sendable>(of: A.Type, returning: B.Type, isolation: isolated Swift.Optional<Swift.Actor>, body: (inout Swift.ThrowingTaskGroup<A, Swift.Error>) async throws -> B) async throws -> B'


### PR DESCRIPTION
Makes the methods themselves and their async function value parameters  `nonisolated(nonsending)`.

Maintains source compatibility by preserving old versions of the API.

Resolves: rdar://177390104
Resolves: rdar://177390199

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
