### PR TITLE
[6.4] SIL: fix handling of `index_addr` in AccessUtils

### DIFF
--- a/SwiftCompilerSources/Sources/SIL/Utilities/AccessUtils.swift
+++ b/SwiftCompilerSources/Sources/SIL/Utilities/AccessUtils.swift
@@ -428,7 +428,7 @@ public struct AccessPath : CustomStringConvertible, Hashable {
     }
     if let resultPath = projectionPath.subtract(from: other.projectionPath),
        // Indexing is not a projection where the base overlaps the projected address.
-       !resultPath.pop().kind.isIndexedElement
+       !resultPath.pop().kind.mayBeIndexedElement
     {
       return resultPath
     }

--- a/SwiftCompilerSources/Sources/SIL/Utilities/SmallProjectionPath.swift
+++ b/SwiftCompilerSources/Sources/SIL/Utilities/SmallProjectionPath.swift
@@ -118,6 +118,15 @@ public struct SmallProjectionPath : Hashable, CustomStringConvertible, NoReflect
         return false
       }
     }
+
+    public var mayBeIndexedElement: Bool {
+      switch self {
+      case .anyIndexedElement, .indexedElement, .anything, .anyValueFields:
+        return true
+      default:
+        return false
+      }
+    }
   }
 
   public init() { self.bytes = 0 }

--- a/test/SILOptimizer/dead_store_elim.sil
+++ b/test/SILOptimizer/dead_store_elim.sil
@@ -1721,3 +1721,18 @@ bb0(%0 : $Int):
   return %r
 }
 
+// CHECK-LABEL: sil [ossa] @negative_index_addr :
+// CHECK:         store %1 to [trivial] %4
+// CHECK:         store %1 to [trivial] %2
+// CHECK:       end sil function 'negative_index_addr'
+sil [ossa] @negative_index_addr : $@convention(thin) (Builtin.RawPointer, Int) -> () {
+bb0(%0 : $Builtin.RawPointer, %1 : $Int):
+  %2 = pointer_to_address %0 to [strict] $*Int
+  %3 = integer_literal $Builtin.Word, -1
+  %4 = index_addr [stack_protection] %2, %3
+  store %1 to [trivial] %4
+  store %1 to [trivial] %2
+  %r = tuple ()
+  return %r
+}
+


### PR DESCRIPTION
* **Explanation**: Fixes a miscompile when the index of `index_addr` is a negative integer constant. This can happen when using unsafe pointer arithmetic with negative offsets, e.g.  `pointer.advanced(by: -1)`. In this case two access paths were considered overlapping while in reality they reference two different array elements. The miscompile manifested in the dead-store-elimination pass, but could potentially also show up in other passes, which use this utility.
* **Risk**: Low. It's a simple change which makes the affected optimizations more conservative
* **Testing**: Tested by a lit test
* **Issue**: https://github.com/swiftlang/swift/issues/77558, rdar://176820188
* **Reviewers**: @atrick 
* **Main branch PR**: https://github.com/swiftlang/swift/pull/89048
