### PR TITLE
[AST] Print movesAsLike if present on @_rawLayout

### DIFF
--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -1729,6 +1729,8 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
     } else {
       llvm_unreachable("unhandled @_rawLayout form");
     }
+    if (attr->shouldMoveAsLikeType())
+      Printer << ", movesAsLike";
     Printer << ")";
     break;
   }

--- a/test/ModuleInterface/attr-rawlayout.swift
+++ b/test/ModuleInterface/attr-rawlayout.swift
@@ -1,0 +1,25 @@
+// RUN: %target-swift-emit-module-interface(%t.swiftinterface) %s -module-name attrs -enable-experimental-feature RawLayout
+// RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -module-name attrs
+// RUN: %FileCheck %s --input-file %t.swiftinterface
+
+// REQUIRES: swift_feature_RawLayout
+
+// CHECK: @_rawLayout(size: 5, alignment: 4) public struct A_ExplicitSizeAlign
+@_rawLayout(size: 5, alignment: 4)
+public struct A_ExplicitSizeAlign: ~Copyable {}
+
+// CHECK: @_rawLayout(like: T) public struct B_Cell
+@_rawLayout(like: T)
+public struct B_Cell<T>: ~Copyable {}
+
+// CHECK: @_rawLayout(like: T, movesAsLike) public struct B2_CellMovesAsLike
+@_rawLayout(like: T, movesAsLike)
+public struct B2_CellMovesAsLike<T>: ~Copyable {}
+
+// CHECK: @_rawLayout(likeArrayOf: T, count: 8) public struct C_SmallVector
+@_rawLayout(likeArrayOf: T, count: 8)
+public struct C_SmallVector<T>: ~Copyable {}
+
+// CHECK: @_rawLayout(likeArrayOf: T, count: 8, movesAsLike) public struct C2_SmallVectorMovesAsLike
+@_rawLayout(likeArrayOf: T, count: 8, movesAsLike)
+public struct C2_SmallVectorMovesAsLike<T>: ~Copyable {}

--- a/test/Serialization/attr-rawlayout.swift
+++ b/test/Serialization/attr-rawlayout.swift
@@ -5,15 +5,23 @@
 
 // REQUIRES: swift_feature_RawLayout
 
-// BC-CHECK: <RawLayout_DECL_ATTR 
+// BC-CHECK: <RawLayout_DECL_ATTR
 
 // MODULE-CHECK: @_rawLayout(size: 5, alignment: 4) struct A_ExplicitSizeAlign
 @_rawLayout(size: 5, alignment: 4)
 struct A_ExplicitSizeAlign: ~Copyable {}
 
+// MODULE-CHECK: @_rawLayout(like: T, movesAsLike) struct B2_CellMovesAsLike
+@_rawLayout(like: T, movesAsLike)
+struct B2_CellMovesAsLike<T>: ~Copyable {}
+
 // MODULE-CHECK: @_rawLayout(like: T) struct B_Cell
 @_rawLayout(like: T)
 struct B_Cell<T>: ~Copyable {}
+
+// MODULE-CHECK: @_rawLayout(likeArrayOf: T, count: 8, movesAsLike) struct C2_SmallVectorMovesAsLike
+@_rawLayout(likeArrayOf: T, count: 8, movesAsLike)
+struct C2_SmallVectorMovesAsLike<T>: ~Copyable {}
 
 // MODULE-CHECK: @_rawLayout(likeArrayOf: T, count: 8) struct C_SmallVector
 @_rawLayout(likeArrayOf: T, count: 8)


### PR DESCRIPTION
rdar://166720900

A missing movesAsLike on the attribute in an interface file will cause miscompiles.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
