### PR TITLE
[6.4][AST] Print movesAsLike if present on @_rawLayout

### DIFF
--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -1729,6 +1729,8 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
     } else {
       llvm_unreachable("unhandled @_rawLayout form");
     }
+    if (attr->shouldMoveAsLikeType())
+      Printer << ", movesAsLike";
     Printer << ")";
     break;
   }

--- a/test/ModuleInterface/attr-rawlayout.swift
+++ b/test/ModuleInterface/attr-rawlayout.swift
@@ -1,0 +1,25 @@
+// RUN: %target-swift-emit-module-interface(%t.swiftinterface) %s -module-name attrs -enable-experimental-feature RawLayout
+// RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -module-name attrs
+// RUN: %FileCheck %s --input-file %t.swiftinterface
+
+// REQUIRES: swift_feature_RawLayout
+
+// CHECK: @_rawLayout(size: 5, alignment: 4) public struct A_ExplicitSizeAlign
+@_rawLayout(size: 5, alignment: 4)
+public struct A_ExplicitSizeAlign: ~Copyable {}
+
+// CHECK: @_rawLayout(like: T) public struct B_Cell
+@_rawLayout(like: T)
+public struct B_Cell<T>: ~Copyable {}
+
+// CHECK: @_rawLayout(like: T, movesAsLike) public struct B2_CellMovesAsLike
+@_rawLayout(like: T, movesAsLike)
+public struct B2_CellMovesAsLike<T>: ~Copyable {}
+
+// CHECK: @_rawLayout(likeArrayOf: T, count: 8) public struct C_SmallVector
+@_rawLayout(likeArrayOf: T, count: 8)
+public struct C_SmallVector<T>: ~Copyable {}
+
+// CHECK: @_rawLayout(likeArrayOf: T, count: 8, movesAsLike) public struct C2_SmallVectorMovesAsLike
+@_rawLayout(likeArrayOf: T, count: 8, movesAsLike)
+public struct C2_SmallVectorMovesAsLike<T>: ~Copyable {}

--- a/test/Serialization/attr-rawlayout.swift
+++ b/test/Serialization/attr-rawlayout.swift
@@ -5,15 +5,23 @@
 
 // REQUIRES: swift_feature_RawLayout
 
-// BC-CHECK: <RawLayout_DECL_ATTR 
+// BC-CHECK: <RawLayout_DECL_ATTR
 
 // MODULE-CHECK: @_rawLayout(size: 5, alignment: 4) struct A_ExplicitSizeAlign
 @_rawLayout(size: 5, alignment: 4)
 struct A_ExplicitSizeAlign: ~Copyable {}
 
+// MODULE-CHECK: @_rawLayout(like: T, movesAsLike) struct B2_CellMovesAsLike
+@_rawLayout(like: T, movesAsLike)
+struct B2_CellMovesAsLike<T>: ~Copyable {}
+
 // MODULE-CHECK: @_rawLayout(like: T) struct B_Cell
 @_rawLayout(like: T)
 struct B_Cell<T>: ~Copyable {}
+
+// MODULE-CHECK: @_rawLayout(likeArrayOf: T, count: 8, movesAsLike) struct C2_SmallVectorMovesAsLike
+@_rawLayout(likeArrayOf: T, count: 8, movesAsLike)
+struct C2_SmallVectorMovesAsLike<T>: ~Copyable {}
 
 // MODULE-CHECK: @_rawLayout(likeArrayOf: T, count: 8) struct C_SmallVector
 @_rawLayout(likeArrayOf: T, count: 8)


### PR DESCRIPTION
- **Explanation**:
    The `movesAsLike` flag on `@_rawLayout` attributes was not being printed
    into `.swiftinterface` files. This caused types like `Synchronization._Cell`
    to lose their move semantics when compiled from a textual interface, resulting
    in the compiler incorrectly treating them as bitwise-takable. For types
    containing weak references, this leads to miscompilation where weak references
    are bitwise-copied instead of being properly moved via runtime calls,
    potentially causing memory corruption.

- **Scope**:
    This is a serialization fix only — it adds printing of an already-parsed and
    binary-serialized attribute flag to the textual module interface. No behavioral
    change for code compiled from binary `.swiftmodule` files. Code compiled from
    `.swiftinterface` files that uses `@_rawLayout(like: T, movesAsLike)` types
    (e.g. `Mutex` from the Synchronization module) will now correctly preserve
    move semantics.

- **Issues**: rdar://166720900

- **Original PRs**: https://github.com/swiftlang/swift/pull/89069

- **Risk**:
    Very low. The fix is a single conditional print statement in attribute
    serialization. It cannot break existing code — it only adds information that
    was previously missing, restoring intended behavior.

- **Testing**:
    Updated `test/Serialization/attr-rawlayout.swift` to verify `movesAsLike` is
    present in both binary module and `.swiftinterface` output for scalar and
    array raw layout variants.

- **Reviewers**: @Azoy 