### PR TITLE
Adapt borrowing foreach iteration

### DIFF
--- a/stdlib/public/Cxx/CxxBorrowingSequence.swift
+++ b/stdlib/public/Cxx/CxxBorrowingSequence.swift
@@ -22,7 +22,7 @@
 @available(SwiftStdlib 6.4, *)
 public protocol CxxBorrowingSequence<Element> : BorrowingSequence, ~Copyable, ~Escapable {
   override associatedtype Element: ~Copyable
-  override associatedtype BorrowingIterator: BorrowingIteratorProtocol<Element> & ~Copyable & ~Escapable = CxxBorrowingIterator<Self>
+  override associatedtype BorrowingIterator: BorrowingIteratorProtocol<Element, Never> & ~Copyable & ~Escapable = CxxBorrowingIterator<Self>
   associatedtype RawIterator: UnsafeCxxInputIterator
     where RawIterator.Pointee == Element,
           RawIterator.DereferenceResult: _Pointer,
@@ -37,7 +37,7 @@ public protocol CxxBorrowingSequence<Element> : BorrowingSequence, ~Copyable, ~E
 
 @frozen
 @available(SwiftStdlib 6.4, *)
-public struct CxxBorrowingIterator<T>: BorrowingIteratorProtocol<T.Element>, ~Escapable, ~Copyable where T: CxxBorrowingSequence & ~Copyable & ~Escapable, T.Element: ~Copyable {
+public struct CxxBorrowingIterator<T>: BorrowingIteratorProtocol<T.Element, Never>, ~Escapable, ~Copyable where T: CxxBorrowingSequence & ~Copyable & ~Escapable, T.Element: ~Copyable {
 
   @usableFromInline
   internal var current: T.RawIterator

--- a/stdlib/public/core/BorrowingSequence.swift
+++ b/stdlib/public/core/BorrowingSequence.swift
@@ -12,9 +12,12 @@
 
 /// A type that provides borrowed access to the values of a borrowing sequence.
 @available(SwiftStdlib 6.4, *)
-public protocol BorrowingIteratorProtocol<Element>: ~Copyable, ~Escapable {
+public protocol BorrowingIteratorProtocol<Element, Failure>: ~Copyable, ~Escapable {
   associatedtype Element: ~Copyable & ~Escapable
 
+  /// A type representing an error that can occur during iteration.
+  associatedtype Failure: Error = Never
+  
   /// Returns a span over the next group of elements that are ready to by visited,
   /// up to the specifed maximum.
   ///
@@ -55,7 +58,7 @@ public protocol BorrowingIteratorProtocol<Element>: ~Copyable, ~Escapable {
   /// example to repeat their contents.
   @_lifetime(&self)
   @_lifetime(self: copy self)
-  mutating func nextSpan(maximumCount: Int) -> Span<Element>
+  mutating func nextSpan(maximumCount: Int) throws(Failure) -> Span<Element>
 
   /// Advances the position of this iterator by the specified offset, or until
   /// the end of the underlying type's elements.
@@ -68,7 +71,7 @@ public protocol BorrowingIteratorProtocol<Element>: ~Copyable, ~Escapable {
   ///   enough elements left to skip the requested number of items.
   ///   In that case, the iterator's position is set to the end of the underlying type.
   @_lifetime(self: copy self)
-  mutating func skip(by maximumOffset: Int) -> Int
+  mutating func skip(by maximumOffset: Int) throws(Failure) -> Int
 }
 
 @available(SwiftStdlib 6.4, *)
@@ -79,16 +82,16 @@ extension BorrowingIteratorProtocol where Self: ~Copyable & ~Escapable, Element:
   @_lifetime(&self)
   @_lifetime(self: copy self)
   @_transparent
-  public mutating func nextSpan() -> Span<Element> {
-    nextSpan(maximumCount: Int.max)
+  public mutating func nextSpan() throws(Failure) -> Span<Element> {
+    try nextSpan(maximumCount: Int.max)
   }
   
   @_alwaysEmitIntoClient
   @_lifetime(self: copy self)
-  public mutating func skip(by offset: Int) -> Int {
+  public mutating func skip(by offset: Int) throws(Failure) -> Int {
     var remainder = offset
     while remainder > 0 {
-      let span = nextSpan(maximumCount: remainder)
+      let span = try nextSpan(maximumCount: remainder)
       if span.isEmpty { break }
       remainder &-= span.count
     }
@@ -100,6 +103,8 @@ extension BorrowingIteratorProtocol where Self: ~Copyable & ~Escapable, Element:
 public struct SpanIterator<Element>: BorrowingIteratorProtocol, ~Copyable, ~Escapable
   where Element: ~Copyable & ~Escapable
 {
+  public typealias Failure = Never
+  
   @usableFromInline
   internal var _span: Span<Element>
   @usableFromInline
@@ -142,13 +147,16 @@ public struct SpanIterator<Element>: BorrowingIteratorProtocol, ~Copyable, ~Esca
 /// A type that provides sequential, borrowing access to its elements.
 @available(SwiftStdlib 6.4, *)
 @reparentable
-public protocol BorrowingSequence<Element>: ~Copyable, ~Escapable {
+public protocol BorrowingSequence<Element, Failure>: ~Copyable, ~Escapable {
   /// A type representing the sequence's elements.
   associatedtype Element: ~Copyable & ~Escapable
 
+  /// A type representing an error that can occur during iteration.
+  associatedtype Failure: Error = Never
+  
   /// A type that provides the sequence's iteration interface and
   /// encapsulates its iteration state.
-  associatedtype BorrowingIterator: BorrowingIteratorProtocol<Element> & ~Copyable & ~Escapable
+  associatedtype BorrowingIterator: BorrowingIteratorProtocol<Element, Failure> & ~Copyable & ~Escapable
 
   /// Returns a borrowing iterator over the elements of this sequence.
   @lifetime(borrow self)

--- a/stdlib/public/core/BorrowingSequence.swift
+++ b/stdlib/public/core/BorrowingSequence.swift
@@ -13,7 +13,7 @@
 /// A type that provides borrowed access to the values of a borrowing sequence.
 @available(SwiftStdlib 6.4, *)
 public protocol BorrowingIteratorProtocol<Element>: ~Copyable, ~Escapable {
-  associatedtype Element: ~Copyable
+  associatedtype Element: ~Copyable & ~Escapable
 
   /// Returns a span over the next group of elements that are ready to by visited,
   /// up to the specifed maximum.
@@ -72,7 +72,7 @@ public protocol BorrowingIteratorProtocol<Element>: ~Copyable, ~Escapable {
 }
 
 @available(SwiftStdlib 6.4, *)
-extension BorrowingIteratorProtocol where Self: ~Copyable & ~Escapable, Element: ~Copyable {
+extension BorrowingIteratorProtocol where Self: ~Copyable & ~Escapable, Element: ~Copyable & ~Escapable {
   /// Returns a span over the next group of elements that are ready to by visited,
   /// up to the specifed maximum.
   @_alwaysEmitIntoClient
@@ -98,7 +98,7 @@ extension BorrowingIteratorProtocol where Self: ~Copyable & ~Escapable, Element:
 
 @available(SwiftStdlib 6.4, *)
 public struct SpanIterator<Element>: BorrowingIteratorProtocol, ~Copyable, ~Escapable
-  where Element: ~Copyable
+  where Element: ~Copyable & ~Escapable
 {
   @usableFromInline
   internal var _span: Span<Element>
@@ -144,7 +144,7 @@ public struct SpanIterator<Element>: BorrowingIteratorProtocol, ~Copyable, ~Esca
 @reparentable
 public protocol BorrowingSequence<Element>: ~Copyable, ~Escapable {
   /// A type representing the sequence's elements.
-  associatedtype Element: ~Copyable
+  associatedtype Element: ~Copyable & ~Escapable
 
   /// A type that provides the sequence's iteration interface and
   /// encapsulates its iteration state.
@@ -163,7 +163,7 @@ public protocol BorrowingSequence<Element>: ~Copyable, ~Escapable {
 }
 
 @available(SwiftStdlib 6.4, *)
-extension BorrowingSequence where Self: ~Copyable & ~Escapable, Element: ~Copyable {
+extension BorrowingSequence where Self: ~Copyable & ~Escapable, Element: ~Copyable & ~Escapable {
   @inlinable
   public var underestimatedCount: Int { 0 }
   @inlinable

--- a/stdlib/public/core/InlineArray.swift
+++ b/stdlib/public/core/InlineArray.swift
@@ -621,7 +621,9 @@ extension InlineArray where Element: ~Copyable {
 extension InlineArray: BorrowingSequence where Element: ~Copyable {
   @available(SwiftStdlib 6.4, *)
   public typealias BorrowingIterator = SpanIterator<Element>
-  
+  @available(SwiftStdlib 6.4, *)
+  public typealias Failure = Never
+
   @available(SwiftStdlib 6.4, *)
   @inlinable
   @lifetime(borrow self)

--- a/stdlib/public/core/Span/RawSpan.swift
+++ b/stdlib/public/core/Span/RawSpan.swift
@@ -321,7 +321,7 @@ extension RawSpan {
   @_alwaysEmitIntoClient
   @unsafe
   @lifetime(copy span)
-  public init<Element>(_elements span: Span<Element>) {
+  public init<Element: ~Escapable>(_elements span: Span<Element>) {
     unsafe self = Self.init(unsafeElements: span)
   }
 
@@ -335,7 +335,7 @@ extension RawSpan {
   @_alwaysEmitIntoClient
   @unsafe
   @_lifetime(copy span)
-  public init<Element>(unsafeElements span: Span<Element>) {
+  public init<Element: ~Escapable>(unsafeElements span: Span<Element>) {
     let rawSpan = unsafe RawSpan(
       _unchecked: unsafe span._pointer,
       byteCount: span.count == 1 ? MemoryLayout<Element>.size
@@ -625,7 +625,7 @@ extension RawSpan {
   @unsafe
   @_alwaysEmitIntoClient
   @lifetime(copy self)
-  consuming public func _unsafeView<T: BitwiseCopyable>(
+  consuming public func _unsafeView<T: BitwiseCopyable & ~Escapable>(
     as type: T.Type
   ) -> Span<T> {
     let rawBuffer = unsafe UnsafeRawBufferPointer(start: _pointer, count: _count)
@@ -715,7 +715,8 @@ extension RawSpan {
   ///     with the value in the range of memory referenced by this pointer.
   @unsafe
   @_alwaysEmitIntoClient
-  public func unsafeLoadUnaligned<T: BitwiseCopyable>(
+  @_lifetime(borrow self)
+  public func unsafeLoadUnaligned<T: BitwiseCopyable & ~Escapable>(
     fromByteOffset offset: Int = 0, as type: T.Type
   ) -> T {
     _precondition(
@@ -747,10 +748,12 @@ extension RawSpan {
   ///     with the value in the range of memory referenced by this pointer.
   @unsafe
   @_alwaysEmitIntoClient
-  public func unsafeLoadUnaligned<T: BitwiseCopyable>(
+  @_lifetime(borrow self)
+  public func unsafeLoadUnaligned<T: BitwiseCopyable & ~Escapable>(
     fromUncheckedByteOffset offset: Int, as type: T.Type
   ) -> T {
-    unsafe _start().loadUnaligned(fromByteOffset: offset, as: T.self)
+    let element = unsafe _start().loadUnaligned(fromByteOffset: offset, as: T.self)
+    return unsafe _overrideLifetime(element, borrowing: self)
   }
 
   /// Returns a value constructed from the raw memory at the specified offset.

--- a/stdlib/public/core/Span/Span.swift
+++ b/stdlib/public/core/Span/Span.swift
@@ -1004,7 +1004,7 @@ extension Span where Element == UInt8 {
 
 #if !SPAN_COMPATIBILITY_STUB
 @available(SwiftStdlib 6.4, *)
-extension Span: BorrowingSequence where Element: ~Copyable {
+extension Span: BorrowingSequence where Element: ~Copyable & ~Escapable {
   @available(SwiftStdlib 6.4, *)
   @inlinable
   @lifetime(borrow self)

--- a/stdlib/public/core/Span/Span.swift
+++ b/stdlib/public/core/Span/Span.swift
@@ -26,7 +26,7 @@ import Swift
 @safe
 @available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
-public struct Span<Element: ~Copyable>: ~Escapable, Copyable, BitwiseCopyable {
+public struct Span<Element: ~Copyable & ~Escapable>: ~Escapable, Copyable, BitwiseCopyable {
 
   /// The starting address of this `Span`.
   ///
@@ -88,7 +88,7 @@ public struct Span<Element: ~Copyable>: ~Escapable, Copyable, BitwiseCopyable {
 
 @available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
-extension Span: @unchecked Sendable where Element: Sendable & ~Copyable {}
+extension Span: @unchecked Sendable where Element: Sendable & ~Copyable & ~Escapable {}
 
 @available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
@@ -217,7 +217,7 @@ extension Span /*where Element: Copyable*/ {
 
 @available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
-extension Span where Element: BitwiseCopyable {
+extension Span where Element: BitwiseCopyable & ~Escapable {
 
   /// Unsafely create a `Span` over initialized memory.
   ///
@@ -402,7 +402,7 @@ extension Span where Element: BitwiseCopyable {
 
 @available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
-extension Span where Element: ~Copyable {
+extension Span where Element: ~Copyable & ~Escapable {
 
   /// The number of elements in the span.
   ///
@@ -436,7 +436,7 @@ extension Span where Element: ~Copyable {
 
 @available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
-extension Span where Element: ~Copyable {
+extension Span where Element: ~Copyable & ~Escapable {
   // SILOptimizer looks for fixed_storage.check_index semantics for bounds check optimizations.
   @_semantics("fixed_storage.check_index")
   @inline(__always)
@@ -453,10 +453,12 @@ extension Span where Element: ~Copyable {
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
   public subscript(_ position: Index) -> Element {
-    //FIXME: change to unsafeRawAddress when ready
-    unsafeAddress {
+    @_lifetime(copy self)
+    @_unsafeSelfDependentResult
+    borrow {
       _checkIndex(position)
-      return unsafe _unsafeAddressOfElement(unchecked: position)
+      let pointer = unsafe _unsafeAddressOfElement(unchecked: position)
+      return Builtin.borrowAt(pointer._rawValue)
     }
   }
 
@@ -472,9 +474,11 @@ extension Span where Element: ~Copyable {
   @unsafe
   @_alwaysEmitIntoClient
   public subscript(unchecked position: Index) -> Element {
-    //FIXME: change to unsafeRawAddress when ready
-    unsafeAddress {
-      unsafe _unsafeAddressOfElement(unchecked: position)
+    @_lifetime(copy self)
+    @_unsafeSelfDependentResult
+    borrow {
+      let pointer = unsafe _unsafeAddressOfElement(unchecked: position)
+      return Builtin.borrowAt(pointer._rawValue)
     }
   }
 
@@ -482,16 +486,15 @@ extension Span where Element: ~Copyable {
   @_alwaysEmitIntoClient
   internal func _unsafeAddressOfElement(
     unchecked position: Index
-  ) -> UnsafePointer<Element> {
+  ) -> UnsafeRawPointer {
     let elementOffset = position &* MemoryLayout<Element>.stride
-    let address = unsafe _start().advanced(by: elementOffset)
-    return unsafe address.assumingMemoryBound(to: Element.self)
+    return unsafe _start().advanced(by: elementOffset)
   }
 }
 
 @available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
-extension Span where Element: BitwiseCopyable {
+extension Span where Element: BitwiseCopyable & ~Escapable {
   /// Accesses the element at the specified index in the `Span`.
   ///
   /// - Parameter position: The offset of the element to access. `position`
@@ -500,6 +503,7 @@ extension Span where Element: BitwiseCopyable {
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
   public subscript(_ position: Index) -> Element {
+    @_lifetime(copy self)
     get {
       _checkIndex(position)
       return unsafe self[unchecked: position]
@@ -518,17 +522,19 @@ extension Span where Element: BitwiseCopyable {
   @unsafe
   @_alwaysEmitIntoClient
   public subscript(unchecked position: Index) -> Element {
+    @_lifetime(copy self)
     get {
       let elementOffset = position &* MemoryLayout<Element>.stride
       let address = unsafe _start().advanced(by: elementOffset)
-      return unsafe address.loadUnaligned(as: Element.self)
+      let element = unsafe address.loadUnaligned(as: Element.self)
+      return unsafe _overrideLifetime(element, copying: self)
     }
   }
 }
 
 @available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
-extension Span where Element: Copyable {
+extension Span where Element: Copyable & ~Escapable {
 
   /// Construct a raw span over the memory represented by this span.
   ///
@@ -565,7 +571,7 @@ extension Span where Element: ConvertibleToBytes {
 // MARK: sub-spans
 @available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
-extension Span where Element: ~Copyable {
+extension Span where Element: ~Copyable & ~Escapable {
 
   /// Constructs a new span over the items within the supplied range of
   /// indices within this span.
@@ -722,7 +728,7 @@ extension Span where Element: ~Copyable {
 // MARK: UnsafeBufferPointer access hatch
 @available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
-extension Span where Element: ~Copyable  {
+extension Span where Element: ~Copyable {
 
   /// Calls a closure with a pointer to the viewed contiguous storage.
   ///
@@ -754,7 +760,7 @@ extension Span where Element: ~Copyable  {
 
 @available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
-extension Span where Element: BitwiseCopyable {
+extension Span where Element: BitwiseCopyable & ~Escapable {
 
   /// Calls the given closure with a pointer to the underlying bytes of
   /// the viewed contiguous storage.
@@ -785,7 +791,7 @@ extension Span where Element: BitwiseCopyable {
 
 @available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
-extension Span where Element: ~Copyable {
+extension Span where Element: ~Copyable & ~Escapable {
   /// Returns a Boolean value indicating whether two instances refer to the same
   /// memory region.
   ///
@@ -846,7 +852,7 @@ extension Span where Element: ~Copyable {
 // MARK: prefixes and suffixes
 @available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
-extension Span where Element: ~Copyable {
+extension Span where Element: ~Copyable & ~Escapable {
 
   /// Returns a span containing the initial elements of this span,
   /// up to the specified maximum length.

--- a/stdlib/public/core/Span/Span.swift
+++ b/stdlib/public/core/Span/Span.swift
@@ -88,6 +88,22 @@ public struct Span<Element: ~Copyable & ~Escapable>: ~Escapable, Copyable, Bitwi
 
 @available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
+@usableFromInline
+@_silgen_name("$ss4SpanVsRi_zrlE6_countSivg")
+internal func _oldCountGetter<T: ~Copyable>(_ span: Span<T>) -> Int {
+  span._count
+}
+
+@available(SwiftCompatibilitySpan 5.0, *)
+@_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
+@usableFromInline
+@_silgen_name("$ss4SpanVsRi_zrlE8_pointerSVSgvg")
+internal func _oldPointerGetter<T: ~Copyable>(_ span: Span<T>) -> UnsafeRawPointer? {
+  unsafe span._pointer
+}
+
+@available(SwiftCompatibilitySpan 5.0, *)
+@_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension Span: @unchecked Sendable where Element: Sendable & ~Copyable & ~Escapable {}
 
 @available(SwiftCompatibilitySpan 5.0, *)

--- a/test/Interop/CxxToSwiftToCxx/bridge-cxx-enum-back-to-cxx-execution.cpp
+++ b/test/Interop/CxxToSwiftToCxx/bridge-cxx-enum-back-to-cxx-execution.cpp
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 
-// RUN: %target-swift-frontend -parse-as-library %stdlib_dir/Swift.swiftmodule/%module-target-triple.swiftinterface -enable-library-evolution -disable-objc-attr-requires-foundation-module -typecheck -module-name Swift -parse-stdlib -enable-experimental-cxx-interop -clang-header-expose-decls=has-expose-attr -emit-clang-header-path %t/Swift.h  -experimental-skip-all-function-bodies -enable-experimental-feature LifetimeDependence -enable-experimental-feature BorrowingSequence -enable-experimental-feature Reparenting -enable-experimental-feature AddressableParameters
+// RUN: %target-swift-frontend -parse-as-library %stdlib_dir/Swift.swiftmodule/%module-target-triple.swiftinterface -enable-library-evolution -disable-objc-attr-requires-foundation-module -typecheck -module-name Swift -parse-stdlib -enable-experimental-cxx-interop -clang-header-expose-decls=has-expose-attr -emit-clang-header-path %t/Swift.h  -experimental-skip-all-function-bodies -enable-experimental-feature LifetimeDependence -enable-experimental-feature Lifetimes -enable-experimental-feature BorrowingSequence -enable-experimental-feature Reparenting -enable-experimental-feature AddressableParameters
 // RUN: %target-swift-frontend -typecheck %t/use-cxx-types.swift -typecheck -module-name UseCxx -emit-clang-header-path %t/UseCxx.h -I %t -enable-experimental-cxx-interop -clang-header-expose-decls=all-public
 
 // RUN: %target-interop-build-clangxx -std=c++20 -c %t/use-swift-cxx-types.cpp -I %t -o %t/swift-cxx-execution.o -g
@@ -12,6 +12,7 @@
 
 // REQUIRES: executable_test
 // REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_Lifetimes
 // REQUIRES: swift_feature_BorrowingSequence
 // REQUIRES: swift_feature_Reparenting
 // REQUIRES: swift_feature_AddressableParameters

--- a/test/Interop/CxxToSwiftToCxx/bridge-cxx-struct-back-to-cxx-execution.cpp
+++ b/test/Interop/CxxToSwiftToCxx/bridge-cxx-struct-back-to-cxx-execution.cpp
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 
-// RUN: %target-swift-frontend -parse-as-library %platform-module-dir/Swift.swiftmodule/%module-target-triple.swiftinterface -enable-library-evolution -disable-objc-attr-requires-foundation-module -typecheck -module-name Swift -parse-stdlib -enable-experimental-cxx-interop -clang-header-expose-decls=has-expose-attr -emit-clang-header-path %t/Swift.h  -experimental-skip-all-function-bodies -enable-experimental-feature LifetimeDependence -enable-experimental-feature BorrowingSequence -enable-experimental-feature Reparenting -enable-experimental-feature AddressableParameters
+// RUN: %target-swift-frontend -parse-as-library %platform-module-dir/Swift.swiftmodule/%module-target-triple.swiftinterface -enable-library-evolution -disable-objc-attr-requires-foundation-module -typecheck -module-name Swift -parse-stdlib -enable-experimental-cxx-interop -clang-header-expose-decls=has-expose-attr -emit-clang-header-path %t/Swift.h  -experimental-skip-all-function-bodies -enable-experimental-feature LifetimeDependence -enable-experimental-feature Lifetimes -enable-experimental-feature BorrowingSequence -enable-experimental-feature Reparenting -enable-experimental-feature AddressableParameters
 
 // RUN: %target-swift-frontend -typecheck %t/use-cxx-types.swift -typecheck -module-name UseCxx -emit-clang-header-path %t/UseCxx.h -I %t -enable-experimental-cxx-interop -clang-header-expose-decls=all-public
 
@@ -13,6 +13,7 @@
 
 // REQUIRES: executable_test
 // REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_Lifetimes
 // REQUIRES: swift_feature_BorrowingSequence
 // REQUIRES: swift_feature_Reparenting
 // REQUIRES: swift_feature_AddressableParameters

--- a/test/Interop/SwiftToCxx/stdlib/swift-stdlib-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/stdlib/swift-stdlib-in-cxx.swift
@@ -1,11 +1,12 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -parse-as-library %platform-module-dir/Swift.swiftmodule/%module-target-triple.swiftinterface -enable-library-evolution -disable-objc-attr-requires-foundation-module -typecheck -module-name Swift -parse-stdlib -enable-experimental-cxx-interop -clang-header-expose-decls=has-expose-attr-or-stdlib -emit-clang-header-path %t/Swift.h  -experimental-skip-all-function-bodies -enable-experimental-feature LifetimeDependence  -enable-experimental-feature BorrowingSequence -enable-experimental-feature Reparenting -enable-experimental-feature AddressableParameters
+// RUN: %target-swift-frontend -parse-as-library %platform-module-dir/Swift.swiftmodule/%module-target-triple.swiftinterface -enable-library-evolution -disable-objc-attr-requires-foundation-module -typecheck -module-name Swift -parse-stdlib -enable-experimental-cxx-interop -clang-header-expose-decls=has-expose-attr-or-stdlib -emit-clang-header-path %t/Swift.h  -experimental-skip-all-function-bodies -enable-experimental-feature LifetimeDependence -enable-experimental-feature Lifetimes -enable-experimental-feature BorrowingSequence -enable-experimental-feature Reparenting -enable-experimental-feature AddressableParameters
 // RUN: %FileCheck %s < %t/Swift.h
 
 // RUN: %check-interop-cxx-header-in-clang(%t/Swift.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY -Wno-unused-private-field -Wno-unused-function -Wc++98-compat-extra-semi)
 // RUN: %check-interop-cxx-header-in-clang(%t/Swift.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY -Wno-unused-private-field -Wno-unused-function -Wc++98-compat-extra-semi -DDEBUG=1)
 
 // REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_Lifetimes
 // REQUIRES: swift_feature_BorrowingSequence
 // REQUIRES: swift_feature_Reparenting
 // REQUIRES: swift_feature_AddressableParameters

--- a/test/Interpreter/foreach_borrowing_typed_throws.swift
+++ b/test/Interpreter/foreach_borrowing_typed_throws.swift
@@ -1,0 +1,264 @@
+// RUN: %target-run-simple-swift(-enable-experimental-feature BorrowingForLoop \
+// RUN: -enable-experimental-feature BorrowingSequence \
+// RUN: -enable-experimental-feature Lifetimes \
+// RUN: -Xfrontend -disable-availability-checking) \
+// RUN: %s | %FileCheck %s
+
+// REQUIRES: swift_feature_BorrowingForLoop
+// REQUIRES: swift_feature_BorrowingSequence
+// REQUIRES: swift_feature_Lifetimes
+// REQUIRES: executable_test
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
+enum IterationError: Error, CustomStringConvertible {
+  case reachedLimit(Int)
+  case corrupted
+
+  var description: String {
+    switch self {
+    case .reachedLimit(let n): return "reachedLimit(\(n))"
+    case .corrupted: return "corrupted"
+    }
+  }
+}
+
+// A throwing BorrowingIteratorProtocol that throws after yielding a certain
+// number of elements.
+@available(SwiftStdlib 6.4, *)
+struct LimitedThrowingIterator: BorrowingIteratorProtocol, ~Copyable, ~Escapable {
+  typealias Element = Int
+  typealias Failure = IterationError
+
+  var _inner: SpanIterator<Int>
+  var _remaining: Int
+
+  @_lifetime(copy inner)
+  init(_inner inner: consuming SpanIterator<Int>, _remaining remaining: Int) {
+    self._inner = inner
+    self._remaining = remaining
+  }
+
+  @_lifetime(&self)
+  @_lifetime(self: copy self)
+  mutating func nextSpan(maximumCount: Int) throws(IterationError) -> Span<Int> {
+    if _remaining <= 0 {
+      throw .reachedLimit(_remaining)
+    }
+    let span = _inner.nextSpan(maximumCount: Swift.min(maximumCount, _remaining))
+    _remaining -= span.count
+    return span
+  }
+}
+
+@available(SwiftStdlib 6.4, *)
+struct LimitedThrowingSeq: BorrowingSequence, ~Copyable, ~Escapable {
+  typealias Element = Int
+  typealias Failure = IterationError
+  typealias BorrowingIterator = LimitedThrowingIterator
+
+  var _span: Span<Int>
+  var _limit: Int
+
+  @_lifetime(copy span)
+  init(_span span: Span<Int>, _limit limit: Int) {
+    self._span = span
+    self._limit = limit
+  }
+
+  @_lifetime(borrow self)
+  func makeBorrowingIterator() -> LimitedThrowingIterator {
+    LimitedThrowingIterator(_inner: SpanIterator(_span), _remaining: _limit)
+  }
+}
+
+// An iterator that always throws immediately.
+@available(SwiftStdlib 6.4, *)
+struct ImmediatelyThrowingIterator: BorrowingIteratorProtocol, ~Copyable, ~Escapable {
+  typealias Element = Int
+  typealias Failure = IterationError
+
+  @_lifetime(immortal)
+  init() {}
+
+  @_lifetime(&self)
+  @_lifetime(self: copy self)
+  mutating func nextSpan(maximumCount: Int) throws(IterationError) -> Span<Int> {
+    throw .corrupted
+  }
+}
+
+@available(SwiftStdlib 6.4, *)
+struct ImmediatelyThrowingSeq: BorrowingSequence, ~Copyable, ~Escapable {
+  typealias Element = Int
+  typealias Failure = IterationError
+  typealias BorrowingIterator = ImmediatelyThrowingIterator
+
+  var _span: Span<Int>
+
+  @_lifetime(copy span)
+  init(_span span: Span<Int>) {
+    self._span = span
+  }
+
+  @_lifetime(borrow self)
+  func makeBorrowingIterator() -> ImmediatelyThrowingIterator {
+    ImmediatelyThrowingIterator()
+  }
+}
+
+@available(SwiftStdlib 6.4, *)
+func testThrowAfterElements(seq: borrowing LimitedThrowingSeq) {
+  do {
+    for try element in seq {
+      // CHECK: element = 0
+      // CHECK: element = 1
+      print("element = \(element)")
+    }
+  } catch {
+    // CHECK: caught: reachedLimit(0)
+    print("caught: \(error)")
+  }
+}
+
+@available(SwiftStdlib 6.4, *)
+func testNoThrowWhenUnderLimit(seq: borrowing LimitedThrowingSeq) {
+  do {
+    for try element in seq {
+      // CHECK: ok = 0
+      // CHECK: ok = 1
+      // CHECK: ok = 2
+      // CHECK: ok = 3
+      print("ok = \(element)")
+    }
+    // CHECK: completed without error
+    print("completed without error")
+  } catch {
+    print("unexpected: \(error)")
+  }
+}
+
+@available(SwiftStdlib 6.4, *)
+func testImmediateThrow(seq: borrowing ImmediatelyThrowingSeq) {
+  var count = 0
+  do {
+    for try element in seq {
+      count += 1
+      _ = element
+    }
+  } catch {
+    // CHECK: immediate error: corrupted, count: 0
+    print("immediate error: \(error), count: \(count)")
+  }
+}
+
+@available(SwiftStdlib 6.4, *)
+func iterateAndRethrow(seq: borrowing LimitedThrowingSeq) throws(IterationError) -> Int {
+  var sum = 0
+  for try element in seq {
+    sum += element
+  }
+  return sum
+}
+
+@available(SwiftStdlib 6.4, *)
+func testRethrow(seq: borrowing LimitedThrowingSeq) {
+  do {
+    let result = try iterateAndRethrow(seq: seq)
+    print("sum = \(result)")
+  } catch {
+    // CHECK: rethrown: reachedLimit(0)
+    print("rethrown: \(error)")
+  }
+}
+
+@available(SwiftStdlib 6.4, *)
+func testBreakBeforeThrow(seq: borrowing LimitedThrowingSeq) {
+  do {
+    for try element in seq {
+      if element == 1 {
+        break
+      }
+      // CHECK: before-break = 0
+      print("before-break = \(element)")
+    }
+    // CHECK: break exited cleanly
+    print("break exited cleanly")
+  } catch {
+    print("unexpected error: \(error)")
+  }
+}
+
+@available(SwiftStdlib 6.4, *)
+func testContinueInThrowingLoop(seq: borrowing LimitedThrowingSeq) {
+  do {
+    for try element in seq {
+      if element == 1 {
+        continue
+      }
+      // CHECK: not-skipped = 0
+      // CHECK: not-skipped = 2
+      // CHECK: not-skipped = 3
+      print("not-skipped = \(element)")
+    }
+    // CHECK: continue loop done
+    print("continue loop done")
+  } catch {
+    print("unexpected: \(error)")
+  }
+}
+
+@available(SwiftStdlib 6.4, *)
+func testNestedThrowingLoops(outer: borrowing LimitedThrowingSeq, inner: borrowing Span<Int>) {
+  do {
+    for try element in outer {
+      var innerSum = 0
+      for x in inner {
+        innerSum += x
+      }
+      // CHECK: outer=0, innerSum=6
+      // CHECK: outer=1, innerSum=6
+      print("outer=\(element), innerSum=\(innerSum)")
+    }
+  } catch {
+    // CHECK: nested caught: reachedLimit(0)
+    print("nested caught: \(error)")
+  }
+}
+
+// Entry point
+let arr = [0, 1, 2, 3]
+let innerArr = [1, 2, 3]
+
+if #available(SwiftStdlib 6.4, *) {
+  let span = arr.span
+  let innerSpan = innerArr.span
+
+  // Limit of 2: will throw after yielding elements 0 and 1
+  let throwingSeq = LimitedThrowingSeq(_span: span, _limit: 2)
+  testThrowAfterElements(seq: throwingSeq)
+
+  // Limit of 10: more than enough, no throw
+  let nonThrowingSeq = LimitedThrowingSeq(_span: span, _limit: 10)
+  testNoThrowWhenUnderLimit(seq: nonThrowingSeq)
+
+  // Immediate throw
+  let immediateSeq = ImmediatelyThrowingSeq(_span: span)
+  testImmediateThrow(seq: immediateSeq)
+
+  // Rethrow test with limit 2
+  let rethrowSeq = LimitedThrowingSeq(_span: span, _limit: 2)
+  testRethrow(seq: rethrowSeq)
+
+  // Break before the throw triggers (limit=3, break at element 1)
+  let breakSeq = LimitedThrowingSeq(_span: span, _limit: 3)
+  testBreakBeforeThrow(seq: breakSeq)
+
+  // Continue with limit high enough to not throw
+  let continueSeq = LimitedThrowingSeq(_span: span, _limit: 10)
+  testContinueInThrowingLoop(seq: continueSeq)
+
+  // Nested loops: outer throws after 2 elements
+  let nestedOuterSeq = LimitedThrowingSeq(_span: span, _limit: 2)
+  testNestedThrowingLoops(outer: nestedOuterSeq, inner: innerSpan)
+}

--- a/test/SILGen/foreach_borrowing.swift
+++ b/test/SILGen/foreach_borrowing.swift
@@ -21,9 +21,9 @@ extension NoncopyableInt: Equatable {
 @available(SwiftStdlib 6.4, *)
 func testNonCopyableBorrowingSequence(seq: borrowing Span<NoncopyableInt>) {
   // With borrowing feature enabled, we expect makeBorrowingIterator and nextSpan to be called
-  // CHECK: = function_ref @$ss4SpanVsRi_zrlE21makeBorrowingIterators0aD0VyxGyF : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (@guaranteed Span<τ_0_0>) -> @lifetime(borrow 0) @out SpanIterator<τ_0_0>
-  // CHECK: = function_ref @$ss12SpanIteratorVsRi_zrlE04nextA012maximumCounts0A0VyxGSi_tF : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (Int, @lifetime(copy 1) @inout SpanIterator<τ_0_0>) -> @lifetime(borrow address_for_deps 1) @owned Span<τ_0_0>
-  // CHECK: [[IS_EMPTY_CHECK:%.*]] = function_ref @$ss4SpanVsRi_zrlE7isEmptySbvg : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (@guaranteed Span<τ_0_0>) -> Bool
+  // CHECK: = function_ref @$ss4SpanVsRi_zRi0_zrlE21makeBorrowingIterators0aD0VyxGyF : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable, τ_0_0 : ~Escapable> (@guaranteed Span<τ_0_0>) -> @lifetime(borrow 0) @out SpanIterator<τ_0_0>
+  // CHECK: function_ref @$ss12SpanIteratorVsRi_zRi0_zrlE04nextA012maximumCounts0A0VyxGSi_tF : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable, τ_0_0 : ~Escapable> (Int, @lifetime(copy 1) @inout SpanIterator<τ_0_0>) -> @lifetime(borrow address_for_deps 1) @owned Span<τ_0_0>
+  // CHECK: [[IS_EMPTY_CHECK:%.*]] = function_ref @$ss4SpanVsRi_zRi0_zrlE7isEmptySbvg : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable, τ_0_0 : ~Escapable> (@guaranteed Span<τ_0_0>) -> Bool
   // CHECK: [[IS_EMPTY_CALL:%.*]] = apply [[IS_EMPTY_CHECK]]
   // CHECK: [[NOT_EMPTY:%.*]] = function_ref @$sSb1nopyS2bFZ : $@convention(method) (Bool, @thin Bool.Type) -> Bool
   // CHECK: [[NOT_EMPTY_CALL:%.*]] = apply [[NOT_EMPTY]]([[IS_EMPTY_CALL]]
@@ -43,9 +43,9 @@ func testNonCopyableBorrowingSequence(seq: borrowing Span<NoncopyableInt>) {
 @available(SwiftStdlib 6.4, *)
 func testCopyableBorrowingSequence(seq: borrowing Span<Int>) {
   // With borrowing feature enabled, we expect makeBorrowingIterator and nextSpan to be called
-  // CHECK: = function_ref @$ss4SpanVsRi_zrlE21makeBorrowingIterators0aD0VyxGyF : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (@guaranteed Span<τ_0_0>) -> @lifetime(borrow 0) @out SpanIterator<τ_0_0>
-  // CHECK: = function_ref @$ss12SpanIteratorVsRi_zrlE04nextA012maximumCounts0A0VyxGSi_tF : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (Int, @lifetime(copy 1) @inout SpanIterator<τ_0_0>) -> @lifetime(borrow address_for_deps 1) @owned Span<τ_0_0>
-  // CHECK: [[IS_EMPTY_CHECK:%.*]] = function_ref @$ss4SpanVsRi_zrlE7isEmptySbvg : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (@guaranteed Span<τ_0_0>) -> Bool
+  // CHECK: function_ref @$ss4SpanVsRi_zRi0_zrlE21makeBorrowingIterators0aD0VyxGyF : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable, τ_0_0 : ~Escapable> (@guaranteed Span<τ_0_0>) -> @lifetime(borrow 0) @out SpanIterator<τ_0_0>
+  // CHECK: = function_ref @$ss12SpanIteratorVsRi_zRi0_zrlE04nextA012maximumCounts0A0VyxGSi_tF : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable, τ_0_0 : ~Escapable> (Int, @lifetime(copy 1) @inout SpanIterator<τ_0_0>) -> @lifetime(borrow address_for_deps 1) @owned Span<τ_0_0>
+  // CHECK: [[IS_EMPTY_CHECK:%.*]] = function_ref @$ss4SpanVsRi_zRi0_zrlE7isEmptySbvg : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable, τ_0_0 : ~Escapable> (@guaranteed Span<τ_0_0>) -> Bool
   // CHECK: [[IS_EMPTY_CALL:%.*]] = apply [[IS_EMPTY_CHECK]]
   // CHECK: [[NOT_EMPTY:%.*]] = function_ref @$sSb1nopyS2bFZ : $@convention(method) (Bool, @thin Bool.Type) -> Bool
   // CHECK: [[NOT_EMPTY_CALL:%.*]] = apply [[NOT_EMPTY]]([[IS_EMPTY_CALL]]
@@ -143,11 +143,11 @@ func testForEachLocations(seq: borrowing Span<Int>, val: Int) {
   //   }
 
   // makeBorrowingIterator() function_ref should be at "for" keyword location (172:3)
-  // CHECK: [[MAKE_BORROWING_IT:%.*]] = function_ref @$ss4SpanVsRi_zrlE21makeBorrowingIterators0aD0VyxGyF {{.*}}, loc "{{.*}}":[[@LINE+31]]:3
+  // CHECK: [[MAKE_BORROWING_IT:%.*]] = function_ref @$ss4SpanVsRi_zRi0_zrlE21makeBorrowingIterators0aD0VyxGyF {{.*}}, loc "{{.*}}":[[@LINE+31]]:3
   // CHECK: apply [[MAKE_BORROWING_IT]]{{.*}}, loc "{{.*}}":[[@LINE+30]]:18
 
   // nextSpan() function_ref should be at "for" keyword location
-  // CHECK: [[NEXT_SPAN:%.*]] = function_ref @$ss12SpanIteratorVsRi_zrlE04nextA012maximumCounts0A0VyxGSi_tF {{.*}}, loc "{{.*}}":[[@LINE+27]]:3
+  // CHECK: [[NEXT_SPAN:%.*]] = function_ref @$ss12SpanIteratorVsRi_zRi0_zrlE04nextA012maximumCounts0A0VyxGSi_tF {{.*}}, loc "{{.*}}":[[@LINE+27]]:3
   // CHECK: apply [[NEXT_SPAN]]{{.*}}, loc "{{.*}}":[[@LINE+26]]:3
 
   // $span debug_value should be at "for" keyword location

--- a/test/SILGen/foreach_borrowing_typed_throws.swift
+++ b/test/SILGen/foreach_borrowing_typed_throws.swift
@@ -1,0 +1,157 @@
+// RUN: %target-swift-emit-silgen -Xllvm -sil-print-types \
+// RUN:     -enable-experimental-feature BorrowingForLoop \
+// RUN:     -enable-experimental-feature BorrowingSequence \
+// RUN:     -enable-experimental-feature Lifetimes \
+// RUN:     -module-name test \
+// RUN:     %s | %FileCheck %s
+
+// REQUIRES: swift_feature_BorrowingForLoop
+// REQUIRES: swift_feature_BorrowingSequence
+// REQUIRES: swift_feature_Lifetimes
+
+enum IterationError: Error {
+  case exhausted
+}
+
+@available(SwiftStdlib 6.4, *)
+struct ThrowingSpanIterator: BorrowingIteratorProtocol, ~Copyable, ~Escapable {
+  typealias Element = Int
+  typealias Failure = IterationError
+
+  var _inner: SpanIterator<Int>
+
+  @_lifetime(&self)
+  @_lifetime(self: copy self)
+  mutating func nextSpan(maximumCount: Int) throws(IterationError) -> Span<Int> {
+    _inner.nextSpan(maximumCount: maximumCount)
+  }
+}
+
+@available(SwiftStdlib 6.4, *)
+struct ThrowingBorrowingSeq: BorrowingSequence, ~Copyable, ~Escapable {
+  typealias Element = Int
+  typealias Failure = IterationError
+  typealias BorrowingIterator = ThrowingSpanIterator
+
+  var _span: Span<Int>
+
+  @_lifetime(borrow self)
+  func makeBorrowingIterator() -> ThrowingSpanIterator {
+    ThrowingSpanIterator(_inner: SpanIterator(_span))
+  }
+}
+
+// CHECK-LABEL: sil hidden {{.*}}@$s4test{{.*}}ThrowingBorrowingLoop{{.*}} : $@convention(thin) (@guaranteed ThrowingBorrowingSeq) -> @error IterationError {
+@available(SwiftStdlib 6.4, *)
+func testThrowingBorrowingLoop(seq: borrowing ThrowingBorrowingSeq) throws(IterationError) {
+  // CHECK: [[REF:%.*]] = function_ref @$s4test20ThrowingBorrowingSeqV04makeC8IteratorAA0b4SpanF0VyF
+  // CHECK: apply [[REF]]
+
+  // The nextSpan call should be a try_apply since it can throw
+  // CHECK: [[NEXT_SPAN:%.*]] = function_ref @$s4test20ThrowingSpanIteratorV04nextC012maximumCounts0C0VySiGSi_tAA14IterationErrorOYKF
+  // CHECK: try_apply [[NEXT_SPAN]]{{.*}}, normal [[NORMAL_BB:bb.*]], error [[ERROR_BB:bb.*]] //
+
+  // Normal path continues with isEmpty check
+  // CHECK: [[NORMAL_BB]]({{.*}}):
+  // CHECK: function_ref @$ss4SpanVsRi_zRi0_zrlE7isEmptySbvg
+
+  // Error path receives the typed IterationError
+  // CHECK: [[ERROR_BB]]({{.*}} : $IterationError):
+  for try element in seq {
+    _ = element
+  }
+}
+
+// CHECK-LABEL: sil hidden {{.*}}@$s4test{{.*}}DoCatch{{.*}} : $@convention(thin) (@guaranteed ThrowingBorrowingSeq) -> () {
+@available(SwiftStdlib 6.4, *)
+func testThrowingInDoCatch(seq: borrowing ThrowingBorrowingSeq) {
+  // CHECK: [[NEXT_SPAN:%.*]] = function_ref @$s4test20ThrowingSpanIteratorV04nextC012maximumCounts0C0VySiGSi_tAA14IterationErrorOYKF
+  // CHECK: try_apply [[NEXT_SPAN]]{{.*}}, normal [[NORMAL_BB:bb.*]], error [[ERROR_BB:bb.*]] //
+  // CHECK: [[NORMAL_BB]]({{.*}}):
+  // CHECK: function_ref @$ss4SpanVsRi_zRi0_zrlE7isEmptySbvg
+  // CHECK: [[ERROR_BB]]({{.*}} : $IterationError):
+  do {
+    for try element in seq {
+      _ = element
+    }
+  } catch {
+    _ = error
+  }
+}
+
+// CHECK-LABEL: sil hidden {{.*}}@$s4test{{.*}}NonThrowing{{.*}} : $@convention(thin) (@guaranteed Span<Int>) -> () {
+@available(SwiftStdlib 6.4, *)
+func testNonThrowingLoop(seq: borrowing Span<Int>) {
+  // SpanIterator.nextSpan with Failure == Never uses apply
+  // CHECK: [[NEXT_SPAN:%.*]] = function_ref @$ss12SpanIteratorVsRi_zRi0_zrlE04nextA012maximumCounts0A0VyxGSi_tF
+  // CHECK-NOT: try_apply
+  // CHECK: apply [[NEXT_SPAN]]
+  for element in seq {
+    _ = element
+  }
+}
+
+// CHECK-LABEL: sil hidden {{.*}}@$s4test{{.*}}TypedError{{.*}} : $@convention(thin) (@guaranteed ThrowingBorrowingSeq) -> @error IterationError {
+@available(SwiftStdlib 6.4, *)
+func testTypedErrorPropagation(seq: borrowing ThrowingBorrowingSeq) throws(IterationError) {
+  // CHECK: [[NEXT_SPAN:%.*]] = function_ref @$s4test20ThrowingSpanIteratorV04nextC012maximumCounts0C0VySiGSi_tAA14IterationErrorOYKF
+  // CHECK: try_apply [[NEXT_SPAN]]{{.*}}, normal [[NORMAL_BB:bb.*]], error [[ERROR_BB:bb.*]] //
+  // CHECK: [[NORMAL_BB]]({{.*}}):
+  // CHECK: function_ref @$ss4SpanVsRi_zRi0_zrlE7isEmptySbvg
+  // CHECK: [[ERROR_BB]]({{.*}} : $IterationError):
+  for try element in seq {
+    _ = element
+  }
+}
+
+// CHECK-LABEL: sil hidden {{.*}}@$s4test{{.*}}GenericThrowingLoop{{.*}} : $@convention(thin) <S where S : BorrowingSequence, S.Element == Int, S.Failure == IterationError>{{.*}} -> @error IterationError {
+@available(SwiftStdlib 6.4, *)
+func testGenericThrowingLoop<S: BorrowingSequence>(
+  seq: borrowing S
+) throws(S.Failure) where S.Element == Int, S.Failure == IterationError {
+  // CHECK: [[NEXT_SPAN:%.*]] = witness_method $S.BorrowingIterator, #BorrowingIteratorProtocol.nextSpan
+  // CHECK: [[ERROR:%.*]] = alloc_stack $IterationError
+  // CHECK: try_apply [[NEXT_SPAN]]{{.*}}, normal [[NORMAL_BB:bb.*]], error [[ERROR_BB:bb.*]] //
+  // CHECK: [[NORMAL_BB]]({{.*}}):
+  // CHECK: function_ref @$ss4SpanVsRi_zRi0_zrlE7isEmptySbvg
+  // CHECK: [[ERROR_BB]]:
+  // CHECK: load{{.*}} [[ERROR]] : $*IterationError
+  for try element in seq {
+    _ = element
+  }
+}
+
+// CHECK-LABEL: sil hidden {{.*}}@$s4test{{.*}}GenericDoCatch{{.*}} : $@convention(thin) <S where S : BorrowingSequence, S.Element == Int, S.Failure == IterationError>{{.*}} -> () {
+@available(SwiftStdlib 6.4, *)
+func testGenericDoCatch<S: BorrowingSequence>(
+  seq: borrowing S
+) where S.Element == Int, S.Failure == IterationError {
+  // CHECK: [[NEXT_SPAN:%.*]] = witness_method $S.BorrowingIterator, #BorrowingIteratorProtocol.nextSpan
+  // CHECK: [[ERROR:%.*]] = alloc_stack $IterationError
+  // CHECK: try_apply [[NEXT_SPAN]]{{.*}}, normal [[NORMAL_BB:bb.*]], error [[ERROR_BB:bb.*]] //
+  // CHECK: [[NORMAL_BB]]({{.*}}):
+  // CHECK: function_ref @$ss4SpanVsRi_zRi0_zrlE7isEmptySbvg
+  // CHECK: [[ERROR_BB]]:
+  // CHECK: load{{.*}} [[ERROR]] : $*IterationError
+  do {
+    for try element in seq {
+      _ = element
+    }
+  } catch {
+    _ = error
+  }
+}
+
+// CHECK-LABEL: sil hidden {{.*}}@$s4test{{.*}}GenericNeverFailure{{.*}} : $@convention(thin) <S where S : BorrowingSequence, S.Element == Int, S.Failure == Never>{{.*}} -> () {
+@available(SwiftStdlib 6.4, *)
+func testGenericNeverFailure<S: BorrowingSequence>(
+  seq: borrowing S
+) where S.Element == Int, S.Failure == Never {
+  // When Failure == Never, no try_apply should be needed
+  // CHECK: [[NEXT_SPAN:%.*]] = witness_method $S.BorrowingIterator, #BorrowingIteratorProtocol.nextSpan
+  // CHECK-NOT: try_apply
+  // CHECK: apply [[NEXT_SPAN]]
+  for element in seq {
+    _ = element
+  }
+}

--- a/test/SILOptimizer/lifetime_dependence/foreach_borrowing_nonescapable.swift
+++ b/test/SILOptimizer/lifetime_dependence/foreach_borrowing_nonescapable.swift
@@ -1,0 +1,82 @@
+// RUN: %target-swift-frontend %s -emit-sil -verify \
+// RUN:     -enable-experimental-feature BorrowingForLoop \
+// RUN:     -enable-experimental-feature BorrowingSequence \
+// RUN:     -enable-experimental-feature Lifetimes \
+// RUN:     -verify-ignore-unrelated
+
+// REQUIRES: swift_feature_BorrowingForLoop
+// REQUIRES: swift_feature_BorrowingSequence
+// REQUIRES: swift_feature_Lifetimes
+
+struct NE: ~Escapable {
+  var value: Int
+  @_lifetime(immortal)
+  init(value: Int) { self.value = value }
+}
+
+@available(SwiftStdlib 6.4, *)
+func testEscapeFromForLoop(span: borrowing Span<NE>) {
+  var escaped: NE = NE(value: 0) // expected-error {{lifetime-dependent variable 'escaped' escapes its scope}}
+  for el in span {  // expected-note {{it depends on this scoped access to variable '$el$generator'}}
+      escaped = el
+  }
+  _ = escaped // expected-note {{this use of the lifetime-dependent value is out of scope}}
+}
+
+@available(SwiftStdlib 6.4, *)
+func testEscapeNoUseOutsideForLoop(span: borrowing Span<NE>) {
+  var escaped: NE = NE(value: 0)
+  for el in span {
+      escaped = el
+      _ = escaped
+  }
+}
+
+func takeEscaping(_ f: @escaping () -> NE) {}
+
+@available(SwiftStdlib 6.4, *)
+func testEscapeViaClosure(span: borrowing Span<NE>) { // expected-note 2 {{it depends on the lifetime of argument 'span'}}
+  for el in span {  // expected-note {{it depends on this scoped access to variable '$el$generator'}}
+    // expected-error@-1 3 {{lifetime-dependent variable 'el' escapes its scope}}
+    takeEscaping { el } // expected-note 3 {{this use causes the lifetime-dependent value to escape}}
+  }
+}
+
+@available(SwiftStdlib 6.4, *)
+func testNestedLoopEscape(outer: borrowing Span<Int>, inner: borrowing Span<NE>) {
+  var saved: NE = NE(value: 0) // expected-error {{lifetime-dependent variable 'saved' escapes its scope}}
+  for _ in outer {
+    for el in inner { // expected-note {{it depends on this scoped access to variable '$el$generator'}}
+      saved = el
+    }
+    _ = saved // expected-note {{this use of the lifetime-dependent value is out of scope}}
+  }
+}
+
+@available(SwiftStdlib 6.4, *)
+@_lifetime(borrow span)
+func testReturnFromLoop(span: borrowing Span<NE>) -> NE {
+  for el in span { // expected-error {{lifetime-dependent variable 'el' escapes its scope}}
+    // expected-note@-1 {{it depends on this scoped access to variable '$el$generator'}}
+    return el // expected-note {{this use causes the lifetime-dependent value to escape}}
+  }
+  return NE(value: -1)
+}
+
+@available(SwiftStdlib 6.4, *)
+func testEscapeWithWhereClause(span: borrowing Span<NE>) {
+  var saved: NE = NE(value: 0) // expected-error {{lifetime-dependent variable 'saved' escapes its scope}}
+  for el in span where el.value > 0 { // expected-note {{it depends on this scoped access to variable '$el$generator'}}
+    saved = el
+  }
+  _ = saved // expected-note {{this use of the lifetime-dependent value is out of scope}}
+}
+
+@available(SwiftStdlib 6.4, *)
+func testNoEscapeWithWhereClause(span: borrowing Span<NE>) {
+  var saved: NE = NE(value: 0)
+  for el in span where el.value > 0 {
+    saved = el
+    _ = saved
+  }
+}

--- a/test/Sema/foreach_borrowing_typed_throws.swift
+++ b/test/Sema/foreach_borrowing_typed_throws.swift
@@ -1,0 +1,181 @@
+// RUN: %target-typecheck-verify-swift \
+// RUN:     -enable-experimental-feature BorrowingForLoop \
+// RUN:     -enable-experimental-feature BorrowingSequence \
+// RUN:     -enable-experimental-feature Lifetimes \
+// RUN:     -verify-ignore-unrelated
+
+// REQUIRES: swift_feature_BorrowingForLoop
+// REQUIRES: swift_feature_BorrowingSequence
+// REQUIRES: swift_feature_Lifetimes
+
+@available(SwiftStdlib 6.4, *)
+func testProtocolConstraintThrows<S: BorrowingSequence>(
+  seq: borrowing S
+) throws(S.Failure) where S.Element == Int {
+  for try element in seq {
+    _ = element
+  }
+}
+
+@available(SwiftStdlib 6.4, *)
+func testProtocolConstraintInDoCatch<S: BorrowingSequence>(
+  seq: borrowing S
+) where S.Element == Int {
+  do {
+    for try element in seq {
+      _ = element
+    }
+  } catch {
+    _ = error
+  }
+}
+
+@available(SwiftStdlib 6.4, *)
+func testProtocolConstraintMismatch<S: BorrowingSequence>(
+  seq: borrowing S
+) throws(OtherError) where S.Element == Int, S.Failure == IterationError {
+  for try element in seq { // expected-error {{thrown expression type 'IterationError' cannot be converted to error type 'OtherError'}}
+    _ = element
+  }
+}
+
+@available(SwiftStdlib 6.4, *)
+func testProtocolConstraintNeverFailure<S: BorrowingSequence>(
+  seq: borrowing S
+) where S.Element == Int, S.Failure == Never {
+  for element in seq {
+    _ = element
+  }
+}
+
+@available(SwiftStdlib 6.4, *)
+func testProtocolConstraintMissingTry<S: BorrowingSequence>(
+  seq: borrowing S
+) where S.Element == Int, S.Failure == IterationError {
+  for element in seq { // expected-error {{call can throw, but it is not marked with 'try' and the error is not handled}}
+    _ = element
+  }
+}
+
+enum IterationError: Error {
+  case exhausted
+}
+
+enum OtherError: Error {
+  case other
+}
+
+// A throwing BorrowingIteratorProtocol conformer with Failure != Never.
+@available(SwiftStdlib 6.4, *)
+struct ThrowingSpanIterator: BorrowingIteratorProtocol, ~Copyable, ~Escapable {
+  typealias Element = Int
+  typealias Failure = IterationError
+
+  var _inner: SpanIterator<Int>
+
+  @_lifetime(&self)
+  @_lifetime(self: copy self)
+  mutating func nextSpan(maximumCount: Int) throws(IterationError) -> Span<Int> {
+    _inner.nextSpan(maximumCount: maximumCount)
+  }
+}
+
+// A throwing BorrowingSequence conformer.
+@available(SwiftStdlib 6.4, *)
+struct ThrowingBorrowingSeq: BorrowingSequence, ~Copyable, ~Escapable {
+  typealias Element = Int
+  typealias Failure = IterationError
+  typealias BorrowingIterator = ThrowingSpanIterator
+
+  var _span: Span<Int>
+
+  @_lifetime(borrow self)
+  func makeBorrowingIterator() -> ThrowingSpanIterator {
+    ThrowingSpanIterator(_inner: SpanIterator(_span))
+  }
+}
+
+@available(SwiftStdlib 6.4, *)
+func testMissingTry(seq: borrowing ThrowingBorrowingSeq) {
+  for element in seq { // expected-error {{call can throw, but it is not marked with 'try' and the error is not handled}}
+    _ = element
+  }
+}
+
+@available(SwiftStdlib 6.4, *)
+func testForTryInThrowsFunc(seq: borrowing ThrowingBorrowingSeq) throws {
+  for try element in seq {
+    _ = element
+  }
+}
+
+@available(SwiftStdlib 6.4, *)
+func testForInDoCatch(seq: borrowing ThrowingBorrowingSeq) {
+  do {
+    for element in seq {
+      _ = element
+    }
+  } catch {
+    _ = error
+  }
+}
+
+@available(SwiftStdlib 6.4, *)
+func testForTryInDoCatch(seq: borrowing ThrowingBorrowingSeq) {
+  do {
+    for try element in seq {
+      _ = element
+    }
+  } catch {
+    _ = error
+  }
+}
+
+@available(SwiftStdlib 6.4, *)
+func testForTryUnhandled(seq: borrowing ThrowingBorrowingSeq) {
+  for try element in seq { // expected-error {{errors thrown from here are not handled}}
+    _ = element
+  }
+}
+
+@available(SwiftStdlib 6.4, *)
+func testNonThrowingNoTryNeeded(seq: borrowing Span<Int>) {
+  for element in seq {
+    _ = element
+  }
+}
+
+@available(SwiftStdlib 6.4, *)
+func testTypedThrowsMismatch(seq: borrowing ThrowingBorrowingSeq) throws(OtherError) {
+  for try element in seq { // expected-error {{thrown expression type 'IterationError' cannot be converted to error type 'OtherError'}}
+    _ = element
+  }
+}
+
+@available(SwiftStdlib 6.4, *)
+func testForTryWithWhereClause(seq: borrowing ThrowingBorrowingSeq) throws(IterationError) {
+  for try element in seq where element > 0 {
+    _ = element
+  }
+}
+
+@available(SwiftStdlib 6.4, *)
+func testForTryWithWhereClauseMissingTry(seq: borrowing ThrowingBorrowingSeq) {
+  for element in seq where element > 0 { // expected-error {{call can throw, but it is not marked with 'try' and the error is not handled}}
+    _ = element
+  }
+}
+
+@available(SwiftStdlib 6.4, *)
+func testTypedThrowsWithAnyErrorFunc(seq: borrowing ThrowingBorrowingSeq) throws {
+  for try element in seq {
+    _ = element
+  }
+}
+
+@available(SwiftStdlib 6.4, *)
+func testNeverFailureNoTryNeeded(seq: borrowing Span<Int>) throws(IterationError) {
+  for element in seq {
+    _ = element
+  }
+}

--- a/test/abi/macOS/arm64/stdlib.swift
+++ b/test/abi/macOS/arm64/stdlib.swift
@@ -1220,7 +1220,7 @@ Added: _$ss25BorrowingIteratorProtocolP4skip2byS2i_tFTq
 Added: _$ss25BorrowingIteratorProtocolP8nextSpan12maximumCounts0E0Vy7ElementQzGSi_tFTj
 Added: _$ss25BorrowingIteratorProtocolP8nextSpan12maximumCounts0E0Vy7ElementQzGSi_tFTq
 Added: _$ss25BorrowingIteratorProtocolTL
-Added: _$ss4SpanVyxGs17BorrowingSequencesRi_zrlMc
+Added: _$ss4SpanVyxGs17BorrowingSequencesRi_zRi0_zrlMc
 Added: _$ss7RawSpanV5_spans0B0Vys5UInt8VGvg
 Added: _$ss7RawSpanVs17BorrowingSequencesMc
 Added: _$ss7RawSpanVs17BorrowingSequencesWP
@@ -1228,26 +1228,26 @@ Added: _$ss11InlineArrayVsRi__rlE21makeBorrowingIterators04SpanE0Vyq_GyF
 Added: _$ss11MutableSpanVsRi_zrlE21makeBorrowingIterators0bE0VyxGyF
 Added: _$ss12SpanIteratorVMa
 Added: _$ss12SpanIteratorVMn
-Added: _$ss12SpanIteratorVsRi_zrlE5_spans0A0VyxGvM
-Added: _$ss12SpanIteratorVsRi_zrlE5_spans0A0VyxGvg
-Added: _$ss12SpanIteratorVsRi_zrlE5_spans0A0VyxGvs
-Added: _$ss12SpanIteratorVsRi_zrlE6_countSivM
-Added: _$ss12SpanIteratorVsRi_zrlE6_countSivg
-Added: _$ss12SpanIteratorVsRi_zrlE6_countSivs
-Added: _$ss12SpanIteratorVsRi_zrlE6_startSivM
-Added: _$ss12SpanIteratorVsRi_zrlE6_startSivg
-Added: _$ss12SpanIteratorVsRi_zrlE6_startSivs
-Added: _$ss12SpanIteratorVsRi_zrlEyAByxGs0A0VyxGcfC
-Added: _$ss12SpanIteratorVyxGs09BorrowingB8ProtocolsRi_zrlMc
+Added: _$ss12SpanIteratorVsRi_zRi0_zrlE5_spans0A0VyxGvM
+Added: _$ss12SpanIteratorVsRi_zRi0_zrlE5_spans0A0VyxGvg
+Added: _$ss12SpanIteratorVsRi_zRi0_zrlE5_spans0A0VyxGvs
+Added: _$ss12SpanIteratorVsRi_zRi0_zrlE6_countSivM
+Added: _$ss12SpanIteratorVsRi_zRi0_zrlE6_countSivg
+Added: _$ss12SpanIteratorVsRi_zRi0_zrlE6_countSivs
+Added: _$ss12SpanIteratorVsRi_zRi0_zrlE6_startSivM
+Added: _$ss12SpanIteratorVsRi_zRi0_zrlE6_startSivg
+Added: _$ss12SpanIteratorVsRi_zRi0_zrlE6_startSivs
+Added: _$ss12SpanIteratorVsRi_zRi0_zrlEyAByxGs0A0VyxGcfC
+Added: _$ss12SpanIteratorVyxGs09BorrowingB8ProtocolsRi_zRi0_zrlMc
 Added: _$ss14MutableRawSpanV21makeBorrowingIterators0cF0Vys5UInt8VGyF
 Added: _$ss17BorrowingSequenceP19underestimatedCountSivgTj
 Added: _$ss17BorrowingSequenceP19underestimatedCountSivgTq
 Added: _$ss17BorrowingSequenceP31_customContainsEquatableElementySbSg0F0QzFTj
 Added: _$ss17BorrowingSequenceP31_customContainsEquatableElementySbSg0F0QzFTq
-Added: _$ss17BorrowingSequencePsRi_zRi0_z7ElementRj_zrlE024_customContainsEquatableC0ySbSgADF
-Added: _$ss17BorrowingSequencePsRi_zRi0_z7ElementRj_zrlE19underestimatedCountSivg
-Added: _$ss17BorrowingSequencePsRi_zRi0_z7ElementRj_zrlE19underestimatedCountSivpMV
-Added: _$ss4SpanVsRi_zrlE21makeBorrowingIterators0aD0VyxGyF
+Added: _$ss17BorrowingSequencePsRi_zRi0_z7ElementRj_zADRI0_rlE024_customContainsEquatableC0ySbSgADF
+Added: _$ss17BorrowingSequencePsRi_zRi0_z7ElementRj_zADRI0_rlE19underestimatedCountSivg
+Added: _$ss17BorrowingSequencePsRi_zRi0_z7ElementRj_zADRI0_rlE19underestimatedCountSivpMV
+Added: _$ss4SpanVsRi_zRi0_zrlE21makeBorrowingIterators0aD0VyxGyF
 Added: _$ss7RawSpanV21makeBorrowingIterators0bE0Vys5UInt8VGyF
 Added: _$sSTss17BorrowingSequenceRzrlE19underestimatedCountSivg
 Added: _$sSTss17BorrowingSequenceRzrlE19underestimatedCountSivpMV
@@ -1307,3 +1307,9 @@ Added: _$ss9UniqueBoxVsRi_zrlE7pointerSpyxGvg
 
 // Cross-encoding strcmp for Foundation
 Added: __swift_unicodeBuffersEqual_nonNormalizing
+
+// New manglings of Span._count and _pointer for ~Escapable elements
+Added: $ld$previous$@rpath/libswiftCompatibilitySpan.dylib$$1$1.0$26.0$_$ss4SpanVsRi_zRi0_zrlE6_countSivg$
+Added: $ld$previous$@rpath/libswiftCompatibilitySpan.dylib$$1$1.0$26.0$_$ss4SpanVsRi_zRi0_zrlE8_pointerSVSgvg$
+Added: _$ss4SpanVsRi_zRi0_zrlE6_countSivg
+Added: _$ss4SpanVsRi_zRi0_zrlE8_pointerSVSgvg

--- a/test/abi/macOS/x86_64/stdlib.swift
+++ b/test/abi/macOS/x86_64/stdlib.swift
@@ -1215,7 +1215,7 @@ Added: _$ss25BorrowingIteratorProtocolP4skip2byS2i_tFTq
 Added: _$ss25BorrowingIteratorProtocolP8nextSpan12maximumCounts0E0Vy7ElementQzGSi_tFTj
 Added: _$ss25BorrowingIteratorProtocolP8nextSpan12maximumCounts0E0Vy7ElementQzGSi_tFTq
 Added: _$ss25BorrowingIteratorProtocolTL
-Added: _$ss4SpanVyxGs17BorrowingSequencesRi_zrlMc
+Added: _$ss4SpanVyxGs17BorrowingSequencesRi_zRi0_zrlMc
 Added: _$ss7RawSpanV5_spans0B0Vys5UInt8VGvg
 Added: _$ss7RawSpanVs17BorrowingSequencesMc
 Added: _$ss7RawSpanVs17BorrowingSequencesWP
@@ -1223,26 +1223,26 @@ Added: _$ss11InlineArrayVsRi__rlE21makeBorrowingIterators04SpanE0Vyq_GyF
 Added: _$ss11MutableSpanVsRi_zrlE21makeBorrowingIterators0bE0VyxGyF
 Added: _$ss12SpanIteratorVMa
 Added: _$ss12SpanIteratorVMn
-Added: _$ss12SpanIteratorVsRi_zrlE5_spans0A0VyxGvM
-Added: _$ss12SpanIteratorVsRi_zrlE5_spans0A0VyxGvg
-Added: _$ss12SpanIteratorVsRi_zrlE5_spans0A0VyxGvs
-Added: _$ss12SpanIteratorVsRi_zrlE6_countSivM
-Added: _$ss12SpanIteratorVsRi_zrlE6_countSivg
-Added: _$ss12SpanIteratorVsRi_zrlE6_countSivs
-Added: _$ss12SpanIteratorVsRi_zrlE6_startSivM
-Added: _$ss12SpanIteratorVsRi_zrlE6_startSivg
-Added: _$ss12SpanIteratorVsRi_zrlE6_startSivs
-Added: _$ss12SpanIteratorVsRi_zrlEyAByxGs0A0VyxGcfC
-Added: _$ss12SpanIteratorVyxGs09BorrowingB8ProtocolsRi_zrlMc
+Added: _$ss12SpanIteratorVsRi_zRi0_zrlE5_spans0A0VyxGvM
+Added: _$ss12SpanIteratorVsRi_zRi0_zrlE5_spans0A0VyxGvg
+Added: _$ss12SpanIteratorVsRi_zRi0_zrlE5_spans0A0VyxGvs
+Added: _$ss12SpanIteratorVsRi_zRi0_zrlE6_countSivM
+Added: _$ss12SpanIteratorVsRi_zRi0_zrlE6_countSivg
+Added: _$ss12SpanIteratorVsRi_zRi0_zrlE6_countSivs
+Added: _$ss12SpanIteratorVsRi_zRi0_zrlE6_startSivM
+Added: _$ss12SpanIteratorVsRi_zRi0_zrlE6_startSivg
+Added: _$ss12SpanIteratorVsRi_zRi0_zrlE6_startSivs
+Added: _$ss12SpanIteratorVsRi_zRi0_zrlEyAByxGs0A0VyxGcfC
+Added: _$ss12SpanIteratorVyxGs09BorrowingB8ProtocolsRi_zRi0_zrlMc
 Added: _$ss14MutableRawSpanV21makeBorrowingIterators0cF0Vys5UInt8VGyF
 Added: _$ss17BorrowingSequenceP19underestimatedCountSivgTj
 Added: _$ss17BorrowingSequenceP19underestimatedCountSivgTq
 Added: _$ss17BorrowingSequenceP31_customContainsEquatableElementySbSg0F0QzFTj
 Added: _$ss17BorrowingSequenceP31_customContainsEquatableElementySbSg0F0QzFTq
-Added: _$ss17BorrowingSequencePsRi_zRi0_z7ElementRj_zrlE024_customContainsEquatableC0ySbSgADF
-Added: _$ss17BorrowingSequencePsRi_zRi0_z7ElementRj_zrlE19underestimatedCountSivg
-Added: _$ss17BorrowingSequencePsRi_zRi0_z7ElementRj_zrlE19underestimatedCountSivpMV
-Added: _$ss4SpanVsRi_zrlE21makeBorrowingIterators0aD0VyxGyF
+Added: _$ss17BorrowingSequencePsRi_zRi0_z7ElementRj_zADRI0_rlE024_customContainsEquatableC0ySbSgADF
+Added: _$ss17BorrowingSequencePsRi_zRi0_z7ElementRj_zADRI0_rlE19underestimatedCountSivg
+Added: _$ss17BorrowingSequencePsRi_zRi0_z7ElementRj_zADRI0_rlE19underestimatedCountSivpMV
+Added: _$ss4SpanVsRi_zRi0_zrlE21makeBorrowingIterators0aD0VyxGyF
 Added: _$ss7RawSpanV21makeBorrowingIterators0bE0Vys5UInt8VGyF
 Added: _$sSTss17BorrowingSequenceRzrlE19underestimatedCountSivg
 Added: _$sSTss17BorrowingSequenceRzrlE19underestimatedCountSivpMV
@@ -1303,3 +1303,9 @@ Added: _$ss9UniqueBoxVsRi_zrlE7pointerSpyxGvg
 
 // Cross-encoding strcmp for Foundation
 Added: __swift_unicodeBuffersEqual_nonNormalizing
+
+// New manglings of Span._count and _pointer for ~Escapable elements
+Added: $ld$previous$@rpath/libswiftCompatibilitySpan.dylib$$1$1.0$26.0$_$ss4SpanVsRi_zRi0_zrlE6_countSivg$
+Added: $ld$previous$@rpath/libswiftCompatibilitySpan.dylib$$1$1.0$26.0$_$ss4SpanVsRi_zRi0_zrlE8_pointerSVSgvg$
+Added: _$ss4SpanVsRi_zRi0_zrlE6_countSivg
+Added: _$ss4SpanVsRi_zRi0_zrlE8_pointerSVSgvg

--- a/test/stdlib/BorrowingSequence.swift
+++ b/test/stdlib/BorrowingSequence.swift
@@ -21,19 +21,24 @@ import StdlibUnittest
 var suite = TestSuite("BorrowingSequence Tests")
 defer { runAllTests() }
 
+enum EE<A: Error, B: Error>: Error {
+  case a(A)
+  case b(B)
+}
+
 @available(SwiftStdlib 6.4, *)
-extension BorrowingSequence where Self: ~Copyable & ~Escapable, Element: ~Copyable {
+extension BorrowingSequence where Self: ~Copyable & ~Escapable, Element: ~Copyable & ~Escapable {
   func reduce<T: ~Copyable>(
     _ initial: consuming T,
-    _ nextPartialResult: @escaping (consuming T, borrowing Element) -> T
-  ) -> T {
+    _ nextPartialResult: @escaping (consuming T, borrowing Element) throws(Failure) -> T
+  ) throws(Failure) -> T {
     var borrowIterator = makeBorrowingIterator()
     var result = initial
     while true {
-      let span = borrowIterator.nextSpan(maximumCount: .max)
+      let span = try borrowIterator.nextSpan(maximumCount: .max)
       if span.isEmpty { break }
       for i in span.indices {
-        result = nextPartialResult(result, span[i])
+        result = try nextPartialResult(result, span[i])
       }
     }
     return result
@@ -41,15 +46,15 @@ extension BorrowingSequence where Self: ~Copyable & ~Escapable, Element: ~Copyab
   
   func reduce<T: ~Copyable>(
     into initial: consuming T,
-    _ nextPartialResult: (inout T, borrowing Element) -> Void
-  ) -> T {
+    _ nextPartialResult: (inout T, borrowing Element) throws(Failure) -> Void
+  ) throws(Failure) -> T {
     var borrowIterator = makeBorrowingIterator()
     var result = initial
     while true {
-      let span = borrowIterator.nextSpan(maximumCount: .max)
+      let span = try borrowIterator.nextSpan(maximumCount: .max)
       if span.isEmpty { break }
       for i in span.indices {
-        nextPartialResult(&result, span[i])
+        try nextPartialResult(&result, span[i])
       }
     }
     return result
@@ -58,11 +63,11 @@ extension BorrowingSequence where Self: ~Copyable & ~Escapable, Element: ~Copyab
 
 @available(SwiftStdlib 6.4, *)
 extension BorrowingSequence where Self: ~Copyable & ~Escapable, Element: Copyable {
-  func collectViaBorrowing() -> [Element] {
+  func collectViaBorrowing() throws(Failure) -> [Element] {
     var borrowIterator = makeBorrowingIterator()
     var result: [Element] = []
     while true {
-      let span = borrowIterator.nextSpan(maximumCount: .max)
+      let span = try borrowIterator.nextSpan(maximumCount: .max)
       if span.isEmpty { break }
       for i in span.indices {
         result.append(span[i])
@@ -81,25 +86,25 @@ struct NoncopyableInt: ~Copyable, Equatable {
 }
 
 @available(SwiftStdlib 6.4, *)
-extension BorrowingSequence where Self: ~Escapable & ~Copyable, Element: Equatable & ~Copyable {
-  func elementsEqual<S: BorrowingSequence<Element>>(
+extension BorrowingSequence where Self: ~Escapable & ~Copyable, Element: Equatable & ~Copyable & ~Escapable {
+  func elementsEqual<S: BorrowingSequence<Element, Failure>>(
     _ rhs: borrowing S
-  ) -> Bool
-    where S: ~Escapable & ~Copyable, S.Element: ~Copyable
+  ) throws(Failure) -> Bool
+    where S: ~Copyable & ~Escapable, S.Element: ~Copyable & ~Escapable
   {
     var iter1 = makeBorrowingIterator()
     var iter2 = rhs.makeBorrowingIterator()
     while true {
-      var el1 = iter1.nextSpan(maximumCount: .max)
-
+      var el1 = try iter1.nextSpan(maximumCount: .max)
+      
       if el1.isEmpty {
         // LHS is empty - sequences are equal iff RHS is also empty
-        let el2 = iter2.nextSpan(maximumCount: 1)
+        let el2 = try iter2.nextSpan(maximumCount: 1)
         return el2.isEmpty
       }
-
+      
       while el1.count > 0 {
-        let el2 = iter2.nextSpan(maximumCount: el1.count)
+        let el2 = try iter2.nextSpan(maximumCount: el1.count)
         if el2.isEmpty { return false }
         for i in 0..<el2.count {
           if el1[i] != el2[i] { return false }


### PR DESCRIPTION
Resolves rdar://176968520.

BorrowingSequence is being updated to handle Throwing, as well as ~Escapable elements. The new ForEach desugaring, enabling borrowing iteration, needs to be adapted to account for these changes and test that the behavior is as expected.

Rebased atop of #89009.