### PR TITLE
[cxx-interop] Do not allow `swift_name` to add a method to a different struct

### DIFF
--- a/include/swift/AST/DiagnosticsClangImporter.def
+++ b/include/swift/AST/DiagnosticsClangImporter.def
@@ -66,6 +66,10 @@ ERROR(swift_name_protocol_static, none, "swift_name cannot be used to define "
       (bool))
 ERROR(swift_name_no_prototype, none,
       "swift_name cannot be used on a non-prototyped function declaration", ())
+WARNING(swift_name_method_different_context, none,
+        "swift_name cannot be used to import a non-static C++ method as a "
+        "member of a different type",
+        ())
 
 GROUPED_WARNING(inconsistent_swift_name, ClangDeclarationImport, none,
         "inconsistent Swift name for Objective-C %select{method|property}0 "

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4086,6 +4086,21 @@ namespace {
       if (!dc)
         return nullptr;
 
+      // A non-static C++ method cannot be imported as a member of a different
+      // type via swift_name attribute.
+      if (auto method = dyn_cast<clang::CXXMethodDecl>(decl)) {
+        if (auto nominal = dc->getSelfNominalTypeDecl()) {
+          if (!method->isStatic() && importedName.importAsMember() &&
+              nominal->getClangDecl() != method->getParent()) {
+            Impl.diagnose(HeaderLoc(decl->getLocation()),
+                          diag::swift_name_method_different_context);
+            Impl.diagnose(HeaderLoc(decl->getLocation()),
+                          diag::note_while_importing, decl->getName());
+            return nullptr;
+          }
+        }
+      }
+
       // We may have already imported this function decl while importing its
       // decl context. Check decl cache to make sure we don't import twice.
       auto known = Impl.ImportedDecls.find({decl, getVersion()});

--- a/test/Interop/Cxx/class/method/Inputs/module.modulemap
+++ b/test/Interop/Cxx/class/method/Inputs/module.modulemap
@@ -29,3 +29,8 @@ module InRegSRet {
   header "inreg-sret.h"
   requires cplusplus
 }
+
+module SwiftNameDifferentType {
+  header "swift-name-different-type.h"
+  requires cplusplus
+}

--- a/test/Interop/Cxx/class/method/Inputs/swift-name-different-type.h
+++ b/test/Interop/Cxx/class/method/Inputs/swift-name-different-type.h
@@ -1,0 +1,7 @@
+struct A {};
+
+struct B {
+  void b(A &a, int e) const // expected-warning {{swift_name cannot be used to import a non-static C++ method as a member of a different type}} expected-note {{while importing 'b'}}
+    __attribute__((swift_name("A.c(self:d:)")));
+  void other() const;
+};

--- a/test/Interop/Cxx/class/method/swift-name-different-type.swift
+++ b/test/Interop/Cxx/class/method/swift-name-different-type.swift
@@ -1,0 +1,7 @@
+// RUN: %target-typecheck-verify-swift -I %S%{fs-sep}Inputs -cxx-interoperability-mode=default -verify-additional-file %S%{fs-sep}Inputs%{fs-sep}swift-name-different-type.h
+
+import SwiftNameDifferentType
+
+func testB(_ b: B) {
+  b.other()
+}


### PR DESCRIPTION
If a C++ method is not static, let's not allow changing its parent struct type to a different type, since the implicit `this` parameter would have an incompatible type.

This fixes an assertion that would previously fire for this scenario.

rdar://161208348

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
