### PR TITLE
[Distributed] Fix leaks in failure paths of swift_getFunctionFullNameFromMangledName.

### DIFF
--- a/stdlib/public/runtime/Casting.cpp
+++ b/stdlib/public/runtime/Casting.cpp
@@ -267,12 +267,7 @@ swift::swift_getFunctionFullNameFromMangledName(
       return TypeNamePair{nullptr, 0};
   }
 
-  // Read-only lookup failed, we may need to demangle and cache the entry.
-  // We have to copy the string to be able to refer to it "forever":
-  auto copy = (char *)malloc(mangledNameLength);
-  memcpy(copy, mangledNameStart, mangledNameLength);
-  mangledName = StringRef(copy, mangledNameLength);
-
+  // Read-only lookup failed. Demangle and cache the entry.
   std::string demangled;
   StackAllocatedDemangler<1024> Dem;
   NodePointer node = Dem.demangleSymbol(mangledName);
@@ -361,6 +356,11 @@ swift::swift_getFunctionFullNameFromMangledName(
   }
   demangled += ")";
 
+  // We have to copy the string to be able to refer to it "forever":
+  auto copy = (char *)malloc(mangledNameLength);
+  memcpy(copy, mangledNameStart, mangledNameLength);
+  llvm::StringRef copiedMangledName(copy, mangledNameLength);
+
   // We have to copy the string to be able to refer to it;
   auto size = demangled.size();
   auto result = (char *)malloc(size + 1);
@@ -370,7 +370,15 @@ swift::swift_getFunctionFullNameFromMangledName(
   {
     LazyMutex::ScopedLock guard(MangledToPrettyFunctionNameCacheLock);
 
-    cache.insert({mangledName, {result, size}});
+    auto [it, inserted] = cache.insert({copiedMangledName, {result, size}});
+    if (!inserted) {
+      // We raced with another thread and lost. Free our data and return theirs.
+      free(copy);
+      free(result);
+      return {it->second.first, it->second.second};
+    }
+
+    // Successfully inserted into the cache. Return our cached value.
     return TypeNamePair{result, size};
   }
 }


### PR DESCRIPTION
Fix several early returns which didn't free the string copy made earlier in the function. Fix most of them by doing the string copy only at the very end where it's needed. When we race to insert into the cache and we lose that race, then free the copies before returning the other thread's cached entry.

rdar://170736413