### PR TITLE
[6.4][Concurrency] NFC: Rename `FunctionTypeIsolation::forIsolatedCaller` …

### DIFF
--- a/include/swift/AST/ExtInfo.h
+++ b/include/swift/AST/ExtInfo.h
@@ -102,10 +102,11 @@ public:
   static FunctionTypeIsolation forErased() {
     return { Kind::Erased };
   }
-  static FunctionTypeIsolation forNonIsolatedCaller() {
+  static FunctionTypeIsolation forNonisolatedNonsending() {
     return { Kind::NonIsolatedNonsending };
   }
 
+  
   Kind getKind() const { return value.getInt(); }
   bool isNonIsolated() const {
     return getKind() == Kind::NonIsolated;

--- a/lib/AST/ASTDemangler.cpp
+++ b/lib/AST/ASTDemangler.cpp
@@ -585,7 +585,7 @@ Type ASTBuilder::createFunctionType(
   } else if (extFlags.isIsolatedAny()) {
     isolation = FunctionTypeIsolation::forErased();
   } else if (extFlags.isNonisolatedNonsending()) {
-    isolation = FunctionTypeIsolation::forNonIsolatedCaller();
+    isolation = FunctionTypeIsolation::forNonisolatedNonsending();
   }
 
   auto noescape =

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -1750,7 +1750,7 @@ public:
         // See if setting isolation of old type to nonisolated(nonsending)
         // yields the new type.
         auto addedNonIsolatedNonSending = oldFnTy->getExtInfo().withIsolation(
-            FunctionTypeIsolation::forNonIsolatedCaller());
+            FunctionTypeIsolation::forNonisolatedNonsending());
 
         return oldFnTy->withExtInfo(addedNonIsolatedNonSending) == newFnTy;
       }

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -3238,7 +3238,7 @@ namespace {
               auto fnType = closure->getType()->castTo<AnyFunctionType>();
               if (!fnType->getIsolation().isNonisolatedNonsending()) {
                 fnType = fnType->withIsolation(
-                    FunctionTypeIsolation::forNonIsolatedCaller());
+                    FunctionTypeIsolation::forNonisolatedNonsending());
                 closure->setType(fnType);
               }
             }
@@ -8028,7 +8028,7 @@ AnyFunctionType *swift::adjustFunctionTypeForConcurrency(
 
     case ActorIsolation::NonisolatedNonsending:
       assert(fnType->getIsolation().isNonIsolated());
-      funcIsolation = FunctionTypeIsolation::forNonIsolatedCaller();
+      funcIsolation = FunctionTypeIsolation::forNonisolatedNonsending();
       break;
 
     case ActorIsolation::Nonisolated:

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -4648,7 +4648,7 @@ NeverNullType TypeResolver::resolveASTFunctionType(
     // is nonisolated.
     if (ctx.LangOpts.hasFeature(Feature::NonisolatedNonsendingByDefault) &&
         repr->isAsync() && isolation.isNonIsolated()) {
-      isolation = FunctionTypeIsolation::forNonIsolatedCaller();
+      isolation = FunctionTypeIsolation::forNonisolatedNonsending();
     } else if (ctx.LangOpts
                    .getFeatureState(Feature::NonisolatedNonsendingByDefault)
                    .isEnabledForMigration()) {
@@ -5787,7 +5787,7 @@ TypeResolver::resolveNonisolatedNonsendingTypeRepr(NonisolatedNonsendingTypeRepr
   if (repr->isInvalid())
     return ErrorType::get(getASTContext());
 
-  return fnType->withIsolation(FunctionTypeIsolation::forNonIsolatedCaller());
+  return fnType->withIsolation(FunctionTypeIsolation::forNonisolatedNonsending());
 }
 
 NeverNullType

--- a/lib/Sema/TypeOfReference.cpp
+++ b/lib/Sema/TypeOfReference.cpp
@@ -2736,7 +2736,7 @@ static Type getTypeOfReferenceWithSpecialTypeCheckingSemantics(
     auto bodyParamIsolation = FunctionTypeIsolation::forNonIsolated();
     if (CS.getASTContext().LangOpts.hasFeature(
             Feature::NonisolatedNonsendingByDefault)) {
-      bodyParamIsolation = FunctionTypeIsolation::forNonIsolatedCaller();
+      bodyParamIsolation = FunctionTypeIsolation::forNonisolatedNonsending();
     }
 
     auto bodyClosure = FunctionType::get(arg, result,
@@ -2754,7 +2754,7 @@ static Type getTypeOfReferenceWithSpecialTypeCheckingSemantics(
     auto withoutEscapingIsolation = FunctionTypeIsolation::forNonIsolated();
     if (CS.getASTContext().LangOpts.hasFeature(
             Feature::NonisolatedNonsendingByDefault)) {
-      withoutEscapingIsolation = FunctionTypeIsolation::forNonIsolatedCaller();
+      withoutEscapingIsolation = FunctionTypeIsolation::forNonisolatedNonsending();
     }
 
     return FunctionType::get(args, result,
@@ -2788,7 +2788,7 @@ static Type getTypeOfReferenceWithSpecialTypeCheckingSemantics(
     auto bodyParamIsolation = FunctionTypeIsolation::forNonIsolated();
     if (CS.getASTContext().LangOpts.hasFeature(
             Feature::NonisolatedNonsendingByDefault)) {
-      bodyParamIsolation = FunctionTypeIsolation::forNonIsolatedCaller();
+      bodyParamIsolation = FunctionTypeIsolation::forNonisolatedNonsending();
     }
 
     auto bodyClosure = FunctionType::get(bodyArgs, result,
@@ -2806,7 +2806,7 @@ static Type getTypeOfReferenceWithSpecialTypeCheckingSemantics(
     auto openExistentialIsolation = FunctionTypeIsolation::forNonIsolated();
     if (CS.getASTContext().LangOpts.hasFeature(
             Feature::NonisolatedNonsendingByDefault)) {
-      openExistentialIsolation = FunctionTypeIsolation::forNonIsolatedCaller();
+      openExistentialIsolation = FunctionTypeIsolation::forNonisolatedNonsending();
     }
 
     return FunctionType::get(args, result,

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -7434,7 +7434,7 @@ detail::function_deserializer::deserialize(ModuleFile &MF,
   if (rawIsolation == unsigned(FunctionTypeIsolation::NonIsolated)) {
     // do nothing
   } else if (rawIsolation == unsigned(FunctionTypeIsolation::NonIsolatedNonsending)) {
-    isolation = swift::FunctionTypeIsolation::forNonIsolatedCaller();
+    isolation = swift::FunctionTypeIsolation::forNonisolatedNonsending();
   } else if (rawIsolation == unsigned(FunctionTypeIsolation::Parameter)) {
     isolation = swift::FunctionTypeIsolation::forParameter();
   } else if (rawIsolation == unsigned(FunctionTypeIsolation::Erased)) {


### PR DESCRIPTION
…into `forNonisolatedNonsending`

- Explanation:

  Previous refactoring missed this method when the `FunctionTypeIsolation::Kind` was renamed to `NonisolatedNonsending`. Bringing this to 6.4 to avoid conflicts while cherry-picking other changes.

- Main Branch PR: https://github.com/swiftlang/swift/pull/88839

- Risk: No risk, it's just a renaming.

- Reviewed By: @AnthonyLatsis 

- Testing: This is a non-functional change.

(cherry picked from commit b79a05179778e1c623de28cbfae9e9765e69ef0d)

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
