### PR TITLE
[ModuleTrace] Macro plugin path in trace file should be real path

### DIFF
--- a/lib/FrontendTool/LoadedModuleTrace.cpp
+++ b/lib/FrontendTool/LoadedModuleTrace.cpp
@@ -950,9 +950,10 @@ bool swift::emitLoadedModuleTraceIfNeeded(const ModuleDependencyID &mainModule,
 
   std::vector<SwiftMacroTraceInfo> swiftMacros;
   for (auto &macro : info->macroDependencies) {
-    swiftMacros.push_back({macro.first, macro.second.LibraryPath.empty()
-                                            ? macro.second.ExecutablePath
-                                            : macro.second.LibraryPath});
+    swiftMacros.push_back(
+        {macro.first, macro.second.LibraryPath.empty()
+                          ? realPath(macro.second.ExecutablePath)
+                          : realPath(macro.second.LibraryPath)});
   }
 
   return writeLoadedModuleOutput(

--- a/test/ScanDependencies/loaded_module_trace.swift
+++ b/test/ScanDependencies/loaded_module_trace.swift
@@ -3,6 +3,7 @@
 
 // RUN: %empty-directory(%t)
 // RUN: %empty-directory(%t/cache)
+// RUN: %empty-directory(%t/macro)
 // RUN: split-file %s %t
 // RUN: ln -s %t/C_real.swiftinterface %t/C.swiftinterface
 
@@ -11,7 +12,8 @@
 // RUN: %target-build-swift -emit-module -module-name Module2 %S/../Driver/Inputs/loaded_module_trace_imports_module.swift \
 // RUN:   -o %t/Module2.swiftmodule -I %t -module-cache-path %t/cache -strict-memory-safety
 // RUN: %target-build-swift -emit-library -module-name Plugin %S/../Driver/Inputs/loaded_module_trace_compiler_plugin.swift \
-// RUN:   -o %t/%target-library-name(Plugin) -module-cache-path %t/cache
+// RUN:   -o %t/macro/%target-library-name(PluginReal) -module-cache-path %t/cache
+// RUN: ln -s %t/macro/%target-library-name(PluginReal) %t/%target-library-name(Plugin)
 
 // RUN: %target-swift-frontend -scan-dependencies %t/test.swift -emit-loaded-module-trace -emit-loaded-module-trace-path %t/trace.json \
 // RUN:   -enable-upcoming-feature RegionBasedIsolation -strict-memory-safety -module-name Test -dependency-only-import B \
@@ -36,7 +38,7 @@
 // CHECK-DAG: {"name":"C","path":"{{[^"]*\\[/\\]}}C_real.swiftinterface","isImportedDirectly":true,"supportsLibraryEvolution":true,"strictMemorySafety":false}
 // CHECK: ],
 // CHECK: "swiftmacros":[
-// CHECK-DAG: {"name":"Plugin","path":"{{[^"]*\\[/\\]}}{{libPlugin.dylib|libPlugin.so|Plugin.dll}}"}
+// CHECK-DAG: {"name":"Plugin","path":"{{[^"]*\\[/\\]}}{{libPluginReal.dylib|libPluginReal.so|PluginReal.dll}}"}
 // CHECK: ]
 // CHECK: }
 // CHECK-NOT: "B"


### PR DESCRIPTION
A followup to #88200. The macro plugin path should be real path to match the old output.

rdar://176985241

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
