### PR TITLE
[release/6.3] Add regression test: pack async dealloc order (runtime dealloc bug)

### DIFF
--- a/test/Concurrency/Runtime/pack_async_dealloc_order.swift
+++ b/test/Concurrency/Runtime/pack_async_dealloc_order.swift
@@ -1,0 +1,56 @@
+// RUN: %target-run-simple-swift(-parse-as-library -Xfrontend -disable-availability-checking)
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+
+// Test that parameter pack temporaries in async contexts are deallocated in LIFO order.
+// https://github.com/swiftlang/swift/issues/XXXXX
+
+protocol Wrapper: Sendable {
+    associatedtype Value: Sendable
+}
+
+struct DefaultWrapper<T: Sendable>: Wrapper {
+    typealias Value = T
+    init() {}
+}
+
+func innerAsync<each Input: Sendable, each W: Wrapper>(
+    wrappers: repeat each W,
+    test: @escaping @Sendable () async -> Void
+) async where (repeat (each W).Value) == (repeat each Input) {
+    await test()
+}
+
+func outerAsync<each Input: Sendable>(
+    seeds: [(repeat each Input)] = [],
+    test: @escaping @Sendable () async -> Void
+) async {
+    // This pattern creates pack temporaries that must be deallocated in LIFO order
+    await innerAsync(
+        wrappers: repeat DefaultWrapper<each Input>(),
+        test: test
+    )
+}
+
+func runTest() async {
+    for _ in 0..<1000 {
+        await outerAsync(seeds: [] as [(Int, Int, Int)]) {
+            // Empty test body
+        }
+    }
+}
+
+@main
+struct Main {
+    static func main() async {
+        await withTaskGroup(of: Void.self) { group in
+            for _ in 0..<100 {
+                group.addTask {
+                    await runTest()
+                }
+            }
+        }
+        print("Done")
+    }
+}


### PR DESCRIPTION
## Summary

Test that parameter pack temporaries in async contexts are deallocated in LIFO order.

## Failure category

`runtime-dealloc-bug` — Runtime deallocation order differs from what the test expects when parameter packs interact with deinit/async.

## Reproduction

Branch: `test-survey/Concurrency_Runtime_pack_async_dealloc_order` (off `release/6.3`).
Test file: `test/Concurrency/Runtime/pack_async_dealloc_order.swift`
Run: `lit -v test/Concurrency/Runtime/pack_async_dealloc_order.swift`

## Test source (`test/Concurrency/Runtime/pack_async_dealloc_order.swift`)

```swift
// RUN: %target-run-simple-swift(-parse-as-library -Xfrontend -disable-availability-checking)

// REQUIRES: executable_test
// REQUIRES: concurrency

// Test that parameter pack temporaries in async contexts are deallocated in LIFO order.

protocol Wrapper: Sendable {
 associatedtype Value: Sendable
}

struct DefaultWrapper<T: Sendable>: Wrapper {
 typealias Value = T
 init() {}
}

func innerAsync<each Input: Sendable, each W: Wrapper>(
 wrappers: repeat each W,
 test: @escaping @Sendable () async -> Void
) async where (repeat (each W).Value) == (repeat each Input) {
 await test()
}

func outerAsync<each Input: Sendable>(
 seeds: [(repeat each Input)] = [],
 test: @escaping @Sendable () async -> Void
) async {
 // This pattern creates pack temporaries that must be deallocated in LIFO order
 await innerAsync(
 wrappers: repeat DefaultWrapper<each Input>(),
 test: test
 )
}

func runTest() async {
 for _ in 0..<1000 {
 await outerAsync(seeds: [] as [(Int, Int, Int)]) {
 // Empty test body
 }
 }
}

@main
struct Main {
 static func main() async {
 await withTaskGroup(of: Void.self) { group in
 for _ in 0..<100 {
 group.addTask {
 await runTest()
 }
 }
 }
 print("Done")
 }
}
```

## Failure output

```
freed pointer was not the last allocation
(shell verdict: Abort trap:)
```
