### PR TITLE
[release/6.3] Add regression test: sendnonsendable tasklocal crash (compiler crash)

### DIFF
--- a/test/Concurrency/sendnonsendable_tasklocal_crash.swift
+++ b/test/Concurrency/sendnonsendable_tasklocal_crash.swift
@@ -1,0 +1,11 @@
+// RUN: %target-swift-frontend -emit-sil -swift-version 6 -verify %s
+// REQUIRES: asserts
+
+// Crash in SendNonSendable: "Require PartitionOp's argument should
+// already be tracked" when a @convention(thin) closure captures a local.
+
+func f() {
+  let x = 0
+  let g: @convention(thin) () -> Void = { _ = x } // expected-error {{nontrivial thin function reference}}
+  _ = g
+}


### PR DESCRIPTION
## Summary

Crash in SendNonSendable: "Require PartitionOp's argument should already be tracked" when a @convention(thin) closure captures a local.

## Failure category

`compiler-crash` — The compiler crashes when processing this source.

## Reproduction

Branch: `test-survey/Concurrency_sendnonsendable_tasklocal_crash` (off `release/6.3`).
Test file: `test/Concurrency/sendnonsendable_tasklocal_crash.swift`
Run: `lit -v test/Concurrency/sendnonsendable_tasklocal_crash.swift`

## Test source (`test/Concurrency/sendnonsendable_tasklocal_crash.swift`)

```swift
// RUN: %target-swift-frontend -emit-sil -swift-version 6 -verify %s
// REQUIRES: asserts

// Crash in SendNonSendable: "Require PartitionOp's argument should
// already be tracked" when a @convention(thin) closure captures a local.

func f() {
 let x = 0
 let g: @convention(thin) () -> Void = { _ = x } // expected-error {{nontrivial thin function reference}}
 _ = g
}
```

## Crash trace

```
Assertion failed: (p.isTrackingElement(op.getOpArg1()) && "Require PartitionOp's argument should already be tracked"), function apply, file PartitionUtils.h, line 1691.
Please submit a bug report (https://swift.org/contributing/#reporting-bugs) and include the crash backtrace.
Stack dump:
0.	Program arguments: […elided…]
1.	Swift version 6.3.2-dev (LLVM 4e6cdf5caf79efb, Swift d23e82655fe203f)
2.	Compiling with the current language version
3.	While evaluating request ExecuteSILPipelineRequest(Run pipelines { Mandatory Diagnostic Passes + Enabling Optimization Passes } on SIL for sendnonsendable_tasklocal_crash)
4.	While running pass #36 SILFunctionTransform "SendNonSendable" on SILFunction "@$s31sendnonsendable_tasklocal_crash1fyyF".
 for 'f()' (at /Users/alex.reilly/Documents/OpenSource/swift-6.3-test/test/Concurrency/sendnonsendable_tasklocal_crash.swift:7:1)
 #0 0x0000000107f74b30 llvm::sys::PrintStackTrace(llvm::raw_ostream&, int) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x105a80b30)
 #1 0x0000000107f72bec llvm::sys::RunSignalHandlers() (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x105a7ebec)
 #2 0x0000000107f755d8 SignalHandler(int, __siginfo*, void*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x105a815d8)
 #3 0x000000018f4ed7a4 (/usr/lib/system/libsystem_platform.dylib+0x1804f97a4)
 #4 0x000000018f4e38d8 (/usr/lib/system/libsystem_pthread.dylib+0x1804ef8d8)
 #5 0x000000018f3ea790 (/usr/lib/system/libsystem_c.dylib+0x1803f6790)
 #6 0x000000018f3e99ec (/usr/lib/system/libsystem_c.dylib+0x1803f59ec)
 #7 0x0000000107fcedec swift::regionanalysisimpl::BlockPartitionState::recomputeExitFromEntry(swift::regionanalysisimpl::PartitionOpTranslator&) (.cold.6) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x105adadec)
 #8 0x000000010323b918 swift::regionanalysisimpl::BlockPartitionState::recomputeExitFromEntry(swift::regionanalysisimpl::PartitionOpTranslator&) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100d47918)
 #9 0x000000010323c4d0 swift::RegionAnalysisFunctionInfo::runDataflow() (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100d484d0)
#10 0x000000010323be34 swift::RegionAnalysisFunctionInfo::RegionAnalysisFunctionInfo(swift::SILFunction*, swift::PostOrderFunctionInfo*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100d47e34)
#11 0x000000010323d02c swift::RegionAnalysis::newFunctionAnalysis(swift::SILFunction*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100d4902c)
#12 0x0000000103437bc8 swift::FunctionAnalysisBase<swift::RegionAnalysisFunctionInfo>::get(swift::SILFunction*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100f43bc8)
#13 0x0000000103437360 (anonymous namespace)::SendNonSendable::run() (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100f43360)
#14 0x000000010345ec4c swift::SILPassManager::runPassOnFunction(unsigned int, swift::SILFunction*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100f6ac4c)
#15 0x000000010345fa10 swift::SILPassManager::runFunctionPasses(unsigned int, unsigned int) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100f6ba10)
#16 0x0000000103462724 swift::SILPassManager::execute() (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100f6e724)
#17 0x000000010345cac8 swift::SILPassManager::executePassPipelinePlan(swift::SILPassPipelinePlan const&) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100f68ac8)
#18 0x000000010345ca64 swift::ExecuteSILPipelineRequest::evaluate(swift::Evaluator&, swift::SILPipelineExecutionDescriptor) const (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100f68a64)
#19 0x0000000103472ee8 swift::SimpleRequest<swift::ExecuteSILPipelineRequest, std::__1::tuple<> (swift::SILPipelineExecutionDescriptor), (swift::RequestFlags)1>::evaluateRequest(swift::ExecuteSILPipelineRequest const&, swift::Evaluator&) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100f7eee8)
#20 0x0000000103464218 swift::ExecuteSILPipelineRequest::OutputType swift::Evaluator::getResultUncached<swift::ExecuteSILPipelineRequest, swift::ExecuteSILPipelineRequest::OutputType swift::evaluateOrFatal<swift::ExecuteSILPipelineRequest>(swift::Evaluator&, swift::ExecuteSILPipelineRequest)::'lambda'()>(swift::ExecuteSILPipelineRequest const&, swift::ExecuteSILPipelineRequest::OutputType swift::evaluateOrFatal<swift::ExecuteSILPipelineRequest>(swift::Evaluator&, swift::ExecuteSILPipelineRequest […truncated…]
#21 0x000000010346418c swift::ExecuteSILPipelineRequest::OutputType swift::Evaluator::getResultUncached<swift::ExecuteSILPipelineRequest, swift::ExecuteSILPipelineRequest::OutputType swift::evaluateOrFatal<swift::ExecuteSILPipelineRequest>(swift::Evaluator&, swift::ExecuteSILPipelineRequest)::'lambda'()>(swift::ExecuteSILPipelineRequest const&, swift::ExecuteSILPipelineRequest::OutputType swift::evaluateOrFatal<swift::ExecuteSILPipelineRequest>(swift::Evaluator&, swift::ExecuteSILPipelineRequest […truncated…]
#22 0x000000010345ccc0 swift::executePassPipelinePlan(swift::SILModule*, swift::SILPassPipelinePlan const&, bool, swift::irgen::IRGenModule*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100f68cc0)
#23 0x00000001034655d0 swift::runSILDiagnosticPasses(swift::SILModule&) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100f715d0)
#24 0x00000001029ebb14 swift::CompilerInstance::performSILProcessing(swift::SILModule*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1004f7b14)
#25 0x00000001027957ec performCompileStepsPostSILGen(swift::CompilerInstance&, std::__1::unique_ptr<swift::SILModule, std::__1::default_delete<swift::SILModule>>, llvm::PointerUnion<swift::ModuleDecl*, swift::SourceFile*>, swift::PrimarySpecificPaths const&, int&, swift::FrontendObserver*, llvm::ArrayRef<char const*>) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1002a17ec)
#26 0x0000000102795394 swift::performCompileStepsPostSema(swift::CompilerInstance&, int&, swift::FrontendObserver*, llvm::ArrayRef<char const*>) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1002a1394)
#27 0x00000001027a4ff4 withSemanticAnalysis(swift::CompilerInstance&, swift::FrontendObserver*, llvm::function_ref<bool (swift::CompilerInstance&)>, bool) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1002b0ff4)
#28 0x0000000102798a40 performCompile(swift::CompilerInstance&, int&, swift::FrontendObserver*, llvm::ArrayRef<char const*>) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1002a4a40)
#29 0x00000001027965f4 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1002a25f4)
#30 0x000000010252c790 swift::mainEntry(int, char const**) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100038790)
#31 0x000000018f127da4
```
