### PR TITLE
[release/6.3] Add regression test: pack expansion default arguments (type inference fails)

### DIFF
--- a/test/Constraints/pack_expansion_default_arguments.swift
+++ b/test/Constraints/pack_expansion_default_arguments.swift
@@ -1,0 +1,55 @@
+// RUN: %target-typecheck-verify-swift
+
+// Test that pack expansion types can be inferred from default argument values.
+// This tests the fix for single-element tuple default arguments being flattened
+// to scalars, which previously caused type inference to fail.
+
+// Multi-element tuple default
+func multiElementDefault<each T>(_ input: (repeat each T) = (1, "hello")) {
+  print(input)
+}
+
+// Single-element default - the tuple (1) flattens to Int, but should still
+// allow pack inference by wrapping the scalar in a single-element tuple
+// before matching against the pack expansion tuple type.
+func singleElementDefault<each T>(_ input: (repeat each T) = (1)) {
+  print(input)
+}
+
+// Empty tuple default
+func emptyDefault<each T>(_ input: (repeat each T) = ()) {
+  print(input)
+}
+
+// With constraints
+protocol P {}
+extension Int: P {}
+extension String: P {}
+
+func constrainedMultiElementDefault<each T: P>(_ input: (repeat each T) = (1, 2)) {
+  print(input)
+}
+
+func constrainedSingleElementDefault<each T: P>(_ input: (repeat each T) = (1)) {
+  print(input)
+}
+
+// Test call sites
+func testCallSites() {
+  // Multi-element defaults
+  multiElementDefault()
+  multiElementDefault((1, 2, 3))
+
+  // Single-element defaults
+  singleElementDefault()
+  singleElementDefault((42))
+  singleElementDefault(42)  // equivalent to above
+
+  // Empty defaults
+  emptyDefault()
+  emptyDefault(())
+
+  // Constrained defaults
+  constrainedMultiElementDefault()
+  constrainedSingleElementDefault()
+}


### PR DESCRIPTION
## Summary

Test that pack expansion types can be inferred from default argument values. This tests the fix for single-element tuple default arguments being flattened to scalars, which previously caused type inference to fail.

## Failure category

`type-inference-fail` — The type checker fails to infer types for a parameter-pack-using construct that should be valid.

## Reproduction

Branch: `test-survey/Constraints_pack_expansion_default_arguments` (off `release/6.3`).
Test file: `test/Constraints/pack_expansion_default_arguments.swift`
Run: `lit -v test/Constraints/pack_expansion_default_arguments.swift`

## Test source (`test/Constraints/pack_expansion_default_arguments.swift`)

```swift
// RUN: %target-typecheck-verify-swift

// Test that pack expansion types can be inferred from default argument values.
// This tests the fix for single-element tuple default arguments being flattened
// to scalars, which previously caused type inference to fail.

// Multi-element tuple default
func multiElementDefault<each T>(_ input: (repeat each T) = (1, "hello")) {
 print(input)
}

// Single-element default - the tuple (1) flattens to Int, but should still
// allow pack inference by wrapping the scalar in a single-element tuple
// before matching against the pack expansion tuple type.
func singleElementDefault<each T>(_ input: (repeat each T) = (1)) {
 print(input)
}

// Empty tuple default
func emptyDefault<each T>(_ input: (repeat each T) = ()) {
 print(input)
}

// With constraints
protocol P {}
extension Int: P {}
extension String: P {}

func constrainedMultiElementDefault<each T: P>(_ input: (repeat each T) = (1, 2)) {
 print(input)
}

func constrainedSingleElementDefault<each T: P>(_ input: (repeat each T) = (1)) {
 print(input)
}

// Test call sites
func testCallSites() {
 // Multi-element defaults
 multiElementDefault()
 multiElementDefault((1, 2, 3))

 // Single-element defaults
 singleElementDefault()
 singleElementDefault((42))
 singleElementDefault(42) // equivalent to above

 // Empty defaults
 emptyDefault()
 emptyDefault(())

 // Constrained defaults
 constrainedMultiElementDefault()
 constrainedSingleElementDefault()
}
```

## Compiler diagnostics

```
/Users/alex.reilly/Documents/OpenSource/swift-6.3-test/test/Constraints/pack_expansion_default_arguments.swift:15:6: error: unexpected note produced: in call to function 'singleElementDefault'
func singleElementDefault<each T>(_ input: (repeat each T) = (1)) {
 ^
/Users/alex.reilly/Documents/OpenSource/swift-6.3-test/test/Constraints/pack_expansion_default_arguments.swift:15:6: error: unexpected note produced: in call to function 'singleElementDefault'
func singleElementDefault<each T>(_ input: (repeat each T) = (1)) {
 ^
/Users/alex.reilly/Documents/OpenSource/swift-6.3-test/test/Constraints/pack_expansion_default_arguments.swift:15:63: error: unexpected error produced: default argument value of type 'Int' cannot be converted to type '(repeat each T)'
func singleElementDefault<each T>(_ input: (repeat each T) = (1)) {
 ^
/Users/alex.reilly/Documents/OpenSource/swift-6.3-test/test/Constraints/pack_expansion_default_arguments.swift:15:63: error: unexpected error produced: generic parameter 'each T' could not be inferred
func singleElementDefault<each T>(_ input: (repeat each T) = (1)) {
 ^
/Users/alex.reilly/Documents/OpenSource/swift-6.3-test/test/Constraints/pack_expansion_default_arguments.swift:33:6: error: unexpected note produced: in call to function 'constrainedSingleElementDefault'
func constrainedSingleElementDefault<each T: P>(_ input: (repeat each T) = (1)) {
 ^
/Users/alex.reilly/Documents/OpenSource/swift-6.3-test/test/Constraints/pack_expansion_default_arguments.swift:33:6: error: unexpected note produced: in call to function 'constrainedSingleElementDefault'
func constrainedSingleElementDefault<each T: P>(_ input: (repeat each T) = (1)) {
 ^
/Users/alex.reilly/Documents/OpenSource/swift-6.3-test/test/Constraints/pack_expansion_default_arguments.swift:33:77: error: unexpected error produced: default argument value of type 'Int' cannot be converted to type '(repeat each T)'
func constrainedSingleElementDefault<each T: P>(_ input: (repeat each T) = (1)) {
 ^
/Users/alex.reilly/Documents/OpenSource/swift-6.3-test/test/Constraints/pack_expansion_default_arguments.swift:33:77: error: unexpected error produced: generic parameter 'each T' could not be inferred
func constrainedSingleElementDefault<each T: P>(_ input: (repeat each T) = (1)) {
 ^
/Users/alex.reilly/Documents/OpenSource/swift-6.3-test/test/Constraints/pack_expansion_default_arguments.swift:44:3: error: unexpected error produced: generic parameter 'each T' could not be inferred
 singleElementDefault()
 ^
/Users/alex.reilly/Documents/OpenSource/swift-6.3-test/test/Constraints/pack_expansion_default_arguments.swift:54:3: error: unexpected error produced: generic parameter 'each T' could not be inferred
 constrainedSingleElementDefault()
 ^

--

********************

2 warning(s) in tests
********************
```
