### PR TITLE
[release/6.3] Add regression test: enum pack construction (enum-pack rejected)

### DIFF
--- a/test/Generics/enum_pack_construction.swift
+++ b/test/Generics/enum_pack_construction.swift
@@ -1,0 +1,47 @@
+// RUN: %target-typecheck-verify-swift
+
+enum Wrapper<each T> {
+    case values(repeat each T)
+    case empty
+}
+
+func testConstruction() {
+    // Explicit type with values
+    let w1 = Wrapper.values(1, "hello", true)
+    let _: Wrapper<Int, String, Bool> = w1
+
+    // Contextual type
+    let w2: Wrapper<Int, String> = .values(42, "world")
+    _ = w2
+
+    // Single element pack
+    let w3 = Wrapper<Int>.values(42)
+    _ = w3
+
+    // Empty case with non-empty pack type
+    let w5: Wrapper<Int, String> = .empty
+    _ = w5
+}
+
+// Test with generic context
+func constructGeneric<each T>(_ values: repeat each T) -> Wrapper<repeat each T> {
+    return .values(repeat each values)
+}
+
+func testGenericConstruction() {
+    let w1 = constructGeneric(1, "hello")
+    let _: Wrapper<Int, String> = w1
+
+    let w2 = constructGeneric(true)
+    let _: Wrapper<Bool> = w2
+}
+
+// Test with constraints
+enum Constrained<each T: Hashable> {
+    case items(repeat each T)
+}
+
+func testConstrainedConstruction() {
+    let c1 = Constrained.items(1, "hello", true)
+    let _: Constrained<Int, String, Bool> = c1
+}


### PR DESCRIPTION
## Summary

The compiler rejects an enum that uses a type parameter pack with diagnostics that look like a parser/availability check leaking into the enum syntax check.

## Failure category

`enum-pack-rejected` — The compiler rejects an enum that uses a type parameter pack with diagnostics that look like a parser/availability check leaking into the enum syntax check.

## Reproduction

Branch: `test-survey/Generics_enum_pack_construction` (off `release/6.3`).
Test file: `test/Generics/enum_pack_construction.swift`
Run: `lit -v test/Generics/enum_pack_construction.swift`

## Test source (`test/Generics/enum_pack_construction.swift`)

```swift
// RUN: %target-typecheck-verify-swift

enum Wrapper<each T> {
 case values(repeat each T)
 case empty
}

func testConstruction() {
 // Explicit type with values
 let w1 = Wrapper.values(1, "hello", true)
 let _: Wrapper<Int, String, Bool> = w1

 // Contextual type
 let w2: Wrapper<Int, String> = .values(42, "world")
 _ = w2

 // Single element pack
 let w3 = Wrapper<Int>.values(42)
 _ = w3

 // Empty case with non-empty pack type
 let w5: Wrapper<Int, String> = .empty
 _ = w5
}

// Test with generic context
func constructGeneric<each T>(_ values: repeat each T) -> Wrapper<repeat each T> {
 return .values(repeat each values)
}

func testGenericConstruction() {
 let w1 = constructGeneric(1, "hello")
 let _: Wrapper<Int, String> = w1

 let w2 = constructGeneric(true)
 let _: Wrapper<Bool> = w2
}

// Test with constraints
enum Constrained<each T: Hashable> {
 case items(repeat each T)
}

func testConstrainedConstruction() {
 let c1 = Constrained.items(1, "hello", true)
 let _: Constrained<Int, String, Bool> = c1
}
```

## Compiler diagnostics

```
/Users/alex.reilly/Documents/OpenSource/swift-6.3-test/test/Generics/enum_pack_construction.swift:3:6: error: unexpected error produced: enums cannot declare a type pack
enum Wrapper<each T> {
 ^
/Users/alex.reilly/Documents/OpenSource/swift-6.3-test/test/Generics/enum_pack_construction.swift:40:6: error: unexpected error produced: enums cannot declare a type pack
enum Constrained<each T: Hashable> {
 ^

--

********************

2 warning(s) in tests
********************
```
