### PR TITLE
[release/6.3] Add regression test: enum pack pattern matching (enum-pack rejected)

### DIFF
--- a/test/Generics/enum_pack_pattern_matching.swift
+++ b/test/Generics/enum_pack_pattern_matching.swift
@@ -1,0 +1,27 @@
+// RUN: %target-typecheck-verify-swift
+
+enum Wrapper<each T> {
+    case values(repeat each T)
+    case empty
+}
+
+// Basic pattern matching in generic context
+func matchWrapper<each T>(_ w: Wrapper<repeat each T>) {
+    switch w {
+    case let .values(v):
+        // v should have type `repeat each T`
+        let _: (repeat each T) = (repeat each v)
+    case .empty:
+        break
+    }
+}
+
+// Using matched values
+func useMatchedValues<each T>(_ w: Wrapper<repeat each T>) -> (repeat each T)? {
+    switch w {
+    case let .values(v):
+        return (repeat each v)
+    case .empty:
+        return nil
+    }
+}


### PR DESCRIPTION
## Summary

The compiler rejects an enum that uses a type parameter pack with diagnostics that look like a parser/availability check leaking into the enum syntax check.

## Failure category

`enum-pack-rejected` — The compiler rejects an enum that uses a type parameter pack with diagnostics that look like a parser/availability check leaking into the enum syntax check.

## Reproduction

Branch: `test-survey/Generics_enum_pack_pattern_matching` (off `release/6.3`).
Test file: `test/Generics/enum_pack_pattern_matching.swift`
Run: `lit -v test/Generics/enum_pack_pattern_matching.swift`

## Test source (`test/Generics/enum_pack_pattern_matching.swift`)

```swift
// RUN: %target-typecheck-verify-swift

enum Wrapper<each T> {
 case values(repeat each T)
 case empty
}

// Basic pattern matching in generic context
func matchWrapper<each T>(_ w: Wrapper<repeat each T>) {
 switch w {
 case let .values(v):
 // v should have type `repeat each T`
 let _: (repeat each T) = (repeat each v)
 case .empty:
 break
 }
}

// Using matched values
func useMatchedValues<each T>(_ w: Wrapper<repeat each T>) -> (repeat each T)? {
 switch w {
 case let .values(v):
 return (repeat each v)
 case .empty:
 return nil
 }
}
```

## Compiler diagnostics

```
/Users/alex.reilly/Documents/OpenSource/swift-6.3-test/test/Generics/enum_pack_pattern_matching.swift:3:6: error: unexpected error produced: enums cannot declare a type pack
enum Wrapper<each T> {
 ^

--

********************

2 warning(s) in tests
********************
```
