### PR TITLE
[release/6.3] Add regression test: enum with pack basic (enum-pack rejected)

### DIFF
--- a/test/Generics/enum_with_pack_basic.swift
+++ b/test/Generics/enum_with_pack_basic.swift
@@ -1,0 +1,32 @@
+// RUN: %target-typecheck-verify-swift
+
+// Basic enum with type pack
+enum Wrapper<each T> {
+    case values(repeat each T)
+    case empty
+}
+
+// Enum with type pack and regular generic parameter
+enum Result<each T, E: Error> {
+    case success(repeat each T)
+    case failure(E)
+}
+
+// Enum with type pack and constraints
+enum Constrained<each T: Hashable> {
+    case items(repeat each T)
+}
+
+// Enum with multiple cases using the pack
+enum Multi<each T> {
+    case first(repeat each T)
+    case second(repeat each T)
+    case none
+}
+
+// Nested enum with pack
+struct Container<each T> {
+    enum Inner {
+        case wrapped(repeat each T)
+    }
+}


### PR DESCRIPTION
## Summary

Basic enum with type pack

## Failure category

`enum-pack-rejected` — The compiler rejects an enum that uses a type parameter pack with diagnostics that look like a parser/availability check leaking into the enum syntax check.

## Reproduction

Branch: `test-survey/Generics_enum_with_pack_basic` (off `release/6.3`).
Test file: `test/Generics/enum_with_pack_basic.swift`
Run: `lit -v test/Generics/enum_with_pack_basic.swift`

## Test source (`test/Generics/enum_with_pack_basic.swift`)

```swift
// RUN: %target-typecheck-verify-swift

// Basic enum with type pack
enum Wrapper<each T> {
 case values(repeat each T)
 case empty
}

// Enum with type pack and regular generic parameter
enum Result<each T, E: Error> {
 case success(repeat each T)
 case failure(E)
}

// Enum with type pack and constraints
enum Constrained<each T: Hashable> {
 case items(repeat each T)
}

// Enum with multiple cases using the pack
enum Multi<each T> {
 case first(repeat each T)
 case second(repeat each T)
 case none
}

// Nested enum with pack
struct Container<each T> {
 enum Inner {
 case wrapped(repeat each T)
 }
}
```

## Compiler diagnostics

```
/Users/alex.reilly/Documents/OpenSource/swift-6.3-test/test/Generics/enum_with_pack_basic.swift:4:6: error: unexpected error produced: enums cannot declare a type pack
enum Wrapper<each T> {
 ^
/Users/alex.reilly/Documents/OpenSource/swift-6.3-test/test/Generics/enum_with_pack_basic.swift:10:6: error: unexpected error produced: enums cannot declare a type pack
enum Result<each T, E: Error> {
 ^
/Users/alex.reilly/Documents/OpenSource/swift-6.3-test/test/Generics/enum_with_pack_basic.swift:16:6: error: unexpected error produced: enums cannot declare a type pack
enum Constrained<each T: Hashable> {
 ^
/Users/alex.reilly/Documents/OpenSource/swift-6.3-test/test/Generics/enum_with_pack_basic.swift:21:6: error: unexpected error produced: enums cannot declare a type pack
enum Multi<each T> {
 ^
/Users/alex.reilly/Documents/OpenSource/swift-6.3-test/test/Generics/enum_with_pack_basic.swift:29:10: error: unexpected error produced: enums cannot declare a type pack
 enum Inner {
 ^

--

********************

2 warning(s) in tests
********************
```
