### PR TITLE
[release/6.3] Add regression test: enum parameter pack cross module (enum-pack rejected)

### DIFF
--- a/test/Interpreter/Inputs/enum_parameter_pack_lib.swift
+++ b/test/Interpreter/Inputs/enum_parameter_pack_lib.swift
@@ -1,0 +1,26 @@
+// Library for enum_parameter_pack_cross_module test.
+// This must be compiled separately to trigger the cross-module metadata path.
+
+import Foundation
+
+public enum Action<each T: Sendable>: Sendable {
+    case stop(String)
+    case record(RecordAction)
+    case select(SelectAction)
+
+    // Uses Foundation types inside the enum - this is important because
+    // the external types trigger a specific metadata completion path.
+    public struct RecordAction: Sendable {
+        public let date: Date
+        public let uuid: UUID
+        public init(date: Date, uuid: UUID) {
+            self.date = date
+            self.uuid = uuid
+        }
+    }
+
+    // Has pack expansion tuple - required to trigger the bug.
+    public struct SelectAction: @unchecked Sendable {
+        public let input: (repeat each T)
+    }
+}

--- a/test/Interpreter/enum_parameter_pack_cross_module.swift
+++ b/test/Interpreter/enum_parameter_pack_cross_module.swift
@@ -1,0 +1,30 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift-dylib(%t/%target-library-name(Lib)) -target %target-swift-5.9-abi-triple -enable-library-evolution %S/Inputs/enum_parameter_pack_lib.swift -emit-module -emit-module-path %t/Lib.swiftmodule -module-name Lib
+// RUN: %target-codesign %t/%target-library-name(Lib)
+// RUN: %target-build-swift %s -target %target-swift-5.9-abi-triple -lLib -I %t -L %t -o %t/main %target-rpath(%t)
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main %t/%target-library-name(Lib)
+
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
+// This test validates that cross-module instantiation of generic enums with
+// parameter packs works correctly when the enum contains nested structs that
+// reference types from external frameworks like Foundation.
+//
+// The bug (now fixed) was that pack metadata pointers were incorrectly passed
+// to swift_checkMetadataState during metadata completion, causing a crash
+// because pack pointers are arrays of metadata pointers, not actual metadata.
+
+import Lib
+
+let actions: [Action<Int>] = []
+print("Empty array:", actions)
+
+let moreActions: [Action<Int, String>] = []
+print("Two-element pack array:", moreActions)
+
+print("Success - no crash")


### PR DESCRIPTION
## Summary

This test validates that cross-module instantiation of generic enums with parameter packs works correctly when the enum contains nested structs that reference types from external frameworks like Foundation. The bug (now fixed) was that pack metadata pointers were incorrectly passed to swift_checkMetadataState during metadata completion, causing a crash because pack pointers are arrays of metadata pointers, not actual metadata.

## Failure category

`enum-pack-rejected` — The compiler rejects an enum that uses a type parameter pack with diagnostics that look like a parser/availability check leaking into the enum syntax check.

## Reproduction

Branch: `test-survey/Interpreter_enum_parameter_pack_cross_module` (off `release/6.3`).
Test file: `test/Interpreter/enum_parameter_pack_cross_module.swift`
Run: `lit -v test/Interpreter/enum_parameter_pack_cross_module.swift`

## Test source (`test/Interpreter/enum_parameter_pack_cross_module.swift`)

```swift
// RUN: %empty-directory(%t)
// RUN: %target-build-swift-dylib(%t/%target-library-name(Lib)) -target %target-swift-5.9-abi-triple -enable-library-evolution %S/Inputs/enum_parameter_pack_lib.swift -emit-module -emit-module-path %t/Lib.swiftmodule -module-name Lib
// RUN: %target-codesign %t/%target-library-name(Lib)
// RUN: %target-build-swift %s -target %target-swift-5.9-abi-triple -lLib -I %t -L %t -o %t/main %target-rpath(%t)
// RUN: %target-codesign %t/main
// RUN: %target-run %t/main %t/%target-library-name(Lib)

// REQUIRES: executable_test
// REQUIRES: objc_interop

// UNSUPPORTED: use_os_stdlib
// UNSUPPORTED: back_deployment_runtime

// This test validates that cross-module instantiation of generic enums with
// parameter packs works correctly when the enum contains nested structs that
// reference types from external frameworks like Foundation.
//
// The bug (now fixed) was that pack metadata pointers were incorrectly passed
// to swift_checkMetadataState during metadata completion, causing a crash
// because pack pointers are arrays of metadata pointers, not actual metadata.

import Lib

let actions: [Action<Int>] = []
print("Empty array:", actions)

let moreActions: [Action<Int, String>] = []
print("Two-element pack array:", moreActions)

print("Success - no crash")
```

## Compiler diagnostics

```
/Users/alex.reilly/Documents/OpenSource/swift-6.3-test/test/Interpreter/Inputs/enum_parameter_pack_lib.swift:6:13: error: enums cannot declare a type pack
 4 | import Foundation
 5 |
 6 | public enum Action<each T: Sendable>: Sendable {
 | `- error: enums cannot declare a type pack
 7 | case stop(String)
 8 | case record(RecordAction)

--

********************

2 warning(s) in tests
********************
```
