### PR TITLE
[release/6.3] Add regression test: keypath parameter pack (compiler crash)

### DIFF
--- a/test/Interpreter/Inputs/enum_parameter_pack_lib.swift
+++ b/test/Interpreter/Inputs/enum_parameter_pack_lib.swift
@@ -1,0 +1,26 @@
+// Library for enum_parameter_pack_cross_module test.
+// This must be compiled separately to trigger the cross-module metadata path.
+
+import Foundation
+
+public enum Action<each T: Sendable>: Sendable {
+    case stop(String)
+    case record(RecordAction)
+    case select(SelectAction)
+
+    // Uses Foundation types inside the enum - this is important because
+    // the external types trigger a specific metadata completion path.
+    public struct RecordAction: Sendable {
+        public let date: Date
+        public let uuid: UUID
+        public init(date: Date, uuid: UUID) {
+            self.date = date
+            self.uuid = uuid
+        }
+    }
+
+    // Has pack expansion tuple - required to trigger the bug.
+    public struct SelectAction: @unchecked Sendable {
+        public let input: (repeat each T)
+    }
+}

--- a/test/Interpreter/keypath_parameter_pack.swift
+++ b/test/Interpreter/keypath_parameter_pack.swift
@@ -1,0 +1,88 @@
+// RUN: %target-run-simple-swift(-target %target-swift-5.9-abi-triple)
+
+// REQUIRES: executable_test
+// REQUIRES: swift_feature_ParameterPacks
+
+// Test that key paths on types containing parameter packs work at runtime
+// for both concrete type specializations and abstract pack contexts.
+
+struct Entry<each T> {
+    let input: (repeat each T)
+    let name: String
+}
+
+// Container that uses keypaths on pack types in a generic context
+struct Container<each T> {
+    let entries: [Entry<repeat each T>]
+
+    // Keypath to pack tuple property - tests abstract pack keypath
+    var inputs: [(repeat each T)] {
+        entries.map(\.input)
+    }
+
+    // Keypath to non-pack property for comparison
+    var names: [String] {
+        entries.map(\.name)
+    }
+}
+
+// Test direct keypath usage with concrete type specialization
+func testDirectKeyPath() {
+    // Single-element pack case
+    let entry1 = Entry<Int>(input: 42, name: "e1")
+    let keyPath1 = \Entry<Int>.input
+    let value1 = entry1[keyPath: keyPath1]
+    assert(value1 == 42)
+    print("testDirectKeyPath single: PASS")
+
+    // Two-element pack case
+    let entry2 = Entry<Int, String>(input: (42, "hello"), name: "e2")
+    let keyPath2 = \Entry<Int, String>.input
+    let value2 = entry2[keyPath: keyPath2]
+    assert(value2.0 == 42)
+    assert(value2.1 == "hello")
+    print("testDirectKeyPath double: PASS")
+
+    // Three-element pack case
+    let entry3 = Entry<Int, String, Double>(input: (42, "hello", 3.14), name: "e3")
+    let keyPath3 = \Entry<Int, String, Double>.input
+    let value3 = entry3[keyPath: keyPath3]
+    assert(value3.0 == 42)
+    assert(value3.1 == "hello")
+    assert(value3.2 == 3.14)
+    print("testDirectKeyPath triple: PASS")
+}
+
+// Test keypaths used inside generic contexts with abstract packs
+func testAbstractPackKeyPath() {
+    // Test with single-element pack
+    let container1 = Container(entries: [
+        Entry<Int>(input: 1, name: "first"),
+        Entry<Int>(input: 2, name: "second")
+    ])
+    let inputs1 = container1.inputs
+    assert(inputs1.count == 2)
+    assert(inputs1[0] == 1)
+    assert(inputs1[1] == 2)
+    let names1 = container1.names
+    assert(names1[0] == "first")
+    assert(names1[1] == "second")
+    print("testAbstractPackKeyPath single: PASS")
+
+    // Test with two-element pack
+    let container2 = Container(entries: [
+        Entry<Int, String>(input: (1, "a"), name: "entry1"),
+        Entry<Int, String>(input: (2, "b"), name: "entry2")
+    ])
+    let inputs2 = container2.inputs
+    assert(inputs2.count == 2)
+    assert(inputs2[0].0 == 1)
+    assert(inputs2[0].1 == "a")
+    assert(inputs2[1].0 == 2)
+    assert(inputs2[1].1 == "b")
+    print("testAbstractPackKeyPath double: PASS")
+}
+
+testDirectKeyPath()
+testAbstractPackKeyPath()
+print("All tests passed!")


### PR DESCRIPTION
## Summary

Test that key paths on types containing parameter packs work at runtime for both concrete type specializations and abstract pack contexts.

## Failure category

`compiler-crash` — The compiler crashes when processing this source.

## Reproduction

Branch: `test-survey/Interpreter_keypath_parameter_pack` (off `release/6.3`).
Test file: `test/Interpreter/keypath_parameter_pack.swift`
Run: `lit -v test/Interpreter/keypath_parameter_pack.swift`

## Test source (`test/Interpreter/keypath_parameter_pack.swift`)

```swift
// RUN: %target-run-simple-swift(-target %target-swift-5.9-abi-triple)

// REQUIRES: executable_test
// REQUIRES: swift_feature_ParameterPacks

// Test that key paths on types containing parameter packs work at runtime
// for both concrete type specializations and abstract pack contexts.

struct Entry<each T> {
 let input: (repeat each T)
 let name: String
}

// Container that uses keypaths on pack types in a generic context
struct Container<each T> {
 let entries: [Entry<repeat each T>]

 // Keypath to pack tuple property - tests abstract pack keypath
 var inputs: [(repeat each T)] {
 entries.map(\.input)
 }

 // Keypath to non-pack property for comparison
 var names: [String] {
 entries.map(\.name)
 }
}

// Test direct keypath usage with concrete type specialization
func testDirectKeyPath() {
 // Single-element pack case
 let entry1 = Entry<Int>(input: 42, name: "e1")
 let keyPath1 = \Entry<Int>.input
 let value1 = entry1[keyPath: keyPath1]
 assert(value1 == 42)
 print("testDirectKeyPath single: PASS")

 // Two-element pack case
 let entry2 = Entry<Int, String>(input: (42, "hello"), name: "e2")
 let keyPath2 = \Entry<Int, String>.input
 let value2 = entry2[keyPath: keyPath2]
 assert(value2.0 == 42)
 assert(value2.1 == "hello")
 print("testDirectKeyPath double: PASS")

 // Three-element pack case
 let entry3 = Entry<Int, String, Double>(input: (42, "hello", 3.14), name: "e3")
 let keyPath3 = \Entry<Int, String, Double>.input
 let value3 = entry3[keyPath: keyPath3]
 assert(value3.0 == 42)
 assert(value3.1 == "hello")
 assert(value3.2 == 3.14)
 print("testDirectKeyPath triple: PASS")
}

// Test keypaths used inside generic contexts with abstract packs
func testAbstractPackKeyPath() {
 // Test with single-element pack
 let container1 = Container(entries: [
 Entry<Int>(input: 1, name: "first"),
 Entry<Int>(input: 2, name: "second")
 ])
 let inputs1 = container1.inputs
 assert(inputs1.count == 2)
 assert(inputs1[0] == 1)
 assert(inputs1[1] == 2)
 let names1 = container1.names
 assert(names1[0] == "first")
 assert(names1[1] == "second")
 print("testAbstractPackKeyPath single: PASS")

 // Test with two-element pack
 let container2 = Container(entries: [
 Entry<Int, String>(input: (1, "a"), name: "entry1"),
 Entry<Int, String>(input: (2, "b"), name: "entry2")
 ])
 let inputs2 = container2.inputs
 assert(inputs2.count == 2)
 assert(inputs2[0].0 == 1)
 assert(inputs2[0].1 == "a")
 assert(inputs2[1].0 == 2)
 assert(inputs2[1].1 == "b")
 print("testAbstractPackKeyPath double: PASS")
}

testDirectKeyPath()
testAbstractPackKeyPath()
print("All tests passed!")
```

## Crash trace

```
Assertion failed: (metadata.GenericPackArguments.empty() && "We don't support packs here yet"), function operator(), file GenProto.cpp, line 4655.
Please submit a bug report (https://swift.org/contributing/#reporting-bugs) and include the crash backtrace.
Stack dump:
0.	Program arguments: […elided…]
1.	Swift version 6.3.2-dev (LLVM 4e6cdf5caf79efb, Swift d23e82655fe203f)
2.	Compiling with effective version 4.1.50
3.	While evaluating request IRGenRequest(IR Generation for file "/Users/alex.reilly/Documents/OpenSource/swift-6.3-test/test/Interpreter/keypath_parameter_pack.swift")
4.	While emitting IR SIL function "@$s4main9ContainerV6inputsSayxxQp_tGvg".
 for getter for inputs (at /Users/alex.reilly/Documents/OpenSource/swift-6.3-test/test/Interpreter/keypath_parameter_pack.swift:19:9)
 #0 0x0000000105d48b30 llvm::sys::PrintStackTrace(llvm::raw_ostream&, int) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x105a80b30)
 #1 0x0000000105d46bec llvm::sys::RunSignalHandlers() (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x105a7ebec)
 #2 0x0000000105d495d8 SignalHandler(int, __siginfo*, void*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x105a815d8)
 #3 0x000000018f4ed7a4 (/usr/lib/system/libsystem_platform.dylib+0x1804f97a4)
 #4 0x000000018f4e38d8 (/usr/lib/system/libsystem_pthread.dylib+0x1804ef8d8)
 #5 0x000000018f3ea790 (/usr/lib/system/libsystem_c.dylib+0x1803f6790)
 #6 0x000000018f3e99ec (/usr/lib/system/libsystem_c.dylib+0x1803f59ec)
 #7 0x0000000105d67f5c ReflectionMetadataBuilder::~ReflectionMetadataBuilder() (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x105a9ff5c)
 #8 0x00000001009d4d6c clang::CodeGen::ConstantInitFuture llvm::function_ref<clang::CodeGen::ConstantInitFuture (swift::irgen::ConstantInitBuilder&)>::callback_fn<swift::irgen::IRGenModule::getAddrOfGenericEnvironment(swift::CanGenericSignature)::$_0>(long, swift::irgen::ConstantInitBuilder&) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x10070cd6c)
 #9 0x0000000100acce78 swift::irgen::IRGenModule::getAddrOfStringForMetadataRef(llvm::StringRef, unsigned int, bool, llvm::function_ref<clang::CodeGen::ConstantInitFuture (swift::irgen::ConstantInitBuilder&)>) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100804e78)
#10 0x00000001009cefa4 swift::irgen::IRGenModule::getAddrOfGenericEnvironment(swift::CanGenericSignature) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100706fa4)
#11 0x0000000100989838 swift::irgen::IRGenModule::getAddrOfKeyPathPattern(swift::KeyPathPattern*, swift::SILLocation) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1006c1838)
#12 0x0000000100a6d9e8 (anonymous namespace)::IRGenSILFunction::visitSILBasicBlock(swift::SILBasicBlock*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1007a59e8)
#13 0x0000000100a69b40 (anonymous namespace)::IRGenSILFunction::emitSILFunction() (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1007a1b40)
#14 0x0000000100a67254 swift::irgen::IRGenModule::emitSILFunction(swift::SILFunction*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x10079f254)
#15 0x0000000100917b2c swift::irgen::IRGenerator::emitGlobalTopLevel(std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>> const&) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x10064fb2c)
#16 0x0000000100a1dcb4 swift::IRGenRequest::evaluate(swift::Evaluator&, swift::IRGenDescriptor) const (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100755cb4)
#17 0x0000000100a66378 swift::GeneratedModule swift::SimpleRequest<swift::IRGenRequest, swift::GeneratedModule (swift::IRGenDescriptor), (swift::RequestFlags)17>::callDerived<0ul>(swift::Evaluator&, std::__1::integer_sequence<unsigned long, 0ul>) const (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x10079e378)
#18 0x0000000100322cc4 swift::IRGenRequest::OutputType swift::Evaluator::getResultUncached<swift::IRGenRequest, swift::IRGenRequest::OutputType swift::evaluateOrFatal<swift::IRGenRequest>(swift::Evaluator&, swift::IRGenRequest)::'lambda'()>(swift::IRGenRequest const&, swift::IRGenRequest::OutputType swift::evaluateOrFatal<swift::IRGenRequest>(swift::Evaluator&, swift::IRGenRequest)::'lambda'())::'lambda'()::operator()() const (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAss […truncated…]
#19 0x000000010032291c swift::IRGenRequest::OutputType swift::Evaluator::getResultUncached<swift::IRGenRequest, swift::IRGenRequest::OutputType swift::evaluateOrFatal<swift::IRGenRequest>(swift::Evaluator&, swift::IRGenRequest)::'lambda'()>(swift::IRGenRequest const&, swift::IRGenRequest::OutputType swift::evaluateOrFatal<swift::IRGenRequest>(swift::Evaluator&, swift::IRGenRequest)::'lambda'()) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/ […truncated…]
#20 0x0000000100a2050c swift::performIRGeneration(swift::FileUnit*, swift::IRGenOptions const&, swift::TBDGenOptions const&, std::__1::unique_ptr<swift::SILModule, std::__1::default_delete<swift::SILModule>>, llvm::StringRef, swift::PrimarySpecificPaths const&, std::__1::shared_ptr<llvm::cas::ObjectStore>, llvm::StringRef, llvm::GlobalVariable**, swift::cas::SwiftCASOutputBackend*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-fro […truncated…]
#21 0x000000010056ef98 generateIR(swift::IRGenOptions const&, swift::TBDGenOptions const&, std::__1::unique_ptr<swift::SILModule, std::__1::default_delete<swift::SILModule>>, swift::PrimarySpecificPaths const&, std::__1::shared_ptr<llvm::cas::ObjectStore>, swift::cas::SwiftCASOutputBackend*, llvm::StringRef, llvm::PointerUnion<swift::ModuleDecl*, swift::SourceFile*>, llvm::GlobalVariable*&, llvm::ArrayRef<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>, llvm […truncated…]
#22 0x0000000100569ae4 performCompileStepsPostSILGen(swift::CompilerInstance&, std::__1::unique_ptr<swift::SILModule, std::__1::default_delete<swift::SILModule>>, llvm::PointerUnion<swift::ModuleDecl*, swift::SourceFile*>, swift::PrimarySpecificPaths const&, int&, swift::FrontendObserver*, llvm::ArrayRef<char const*>) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1002a1ae4)
#23 0x0000000100568c60 swift::performCompileStepsPostSema(swift::CompilerInstance&, int&, swift::FrontendObserver*, llvm::ArrayRef<char const*>) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1002a0c60)
#24 0x0000000100578ff4 withSemanticAnalysis(swift::CompilerInstance&, swift::FrontendObserver*, llvm::function_ref<bool (swift::CompilerInstance&)>, bool) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1002b0ff4)
#25 0x000000010056ca40 performCompile(swift::CompilerInstance&, int&, swift::FrontendObserver*, llvm::ArrayRef<char const*>) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1002a4a40)
#26 0x000000010056a5f4 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1002a25f4)
#27 0x0000000100300790 swift::mainEntry(int, char const**) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100038790)
#28 0x000000018f127da4
<unknown>:0: error: unable to execute command: Abort trap: 6
<unknown>:0: error: compile command failed due to signal 6 (use -v to see invocation)

--

********************

2 warning(s) in tests
********************
```
