### PR TITLE
[release/6.3] Add regression test: variadic generic closure pack expansion (compiler crash)

### DIFF
--- a/test/Interpreter/Inputs/enum_parameter_pack_lib.swift
+++ b/test/Interpreter/Inputs/enum_parameter_pack_lib.swift
@@ -1,0 +1,26 @@
+// Library for enum_parameter_pack_cross_module test.
+// This must be compiled separately to trigger the cross-module metadata path.
+
+import Foundation
+
+public enum Action<each T: Sendable>: Sendable {
+    case stop(String)
+    case record(RecordAction)
+    case select(SelectAction)
+
+    // Uses Foundation types inside the enum - this is important because
+    // the external types trigger a specific metadata completion path.
+    public struct RecordAction: Sendable {
+        public let date: Date
+        public let uuid: UUID
+        public init(date: Date, uuid: UUID) {
+            self.date = date
+            self.uuid = uuid
+        }
+    }
+
+    // Has pack expansion tuple - required to trigger the bug.
+    public struct SelectAction: @unchecked Sendable {
+        public let input: (repeat each T)
+    }
+}

--- a/test/Interpreter/variadic_generic_closure_pack_expansion.swift
+++ b/test/Interpreter/variadic_generic_closure_pack_expansion.swift
@@ -1,0 +1,171 @@
+// RUN: %target-run-simple-swift
+
+// REQUIRES: executable_test
+
+// Test that passing pack expansion tuples to closures works correctly at runtime.
+// This is a regression test for a bug where SILGen incorrectly used pack_element_get
+// to read from an uninitialized pack instead of pack_element_set to store addresses
+// into the pack. This caused the saved frame pointer to be overwritten, resulting
+// in a crash on function return.
+
+import StdlibUnittest
+
+var packExpansionClosureTests = TestSuite("PackExpansionClosure")
+
+// Test 1: Basic pack expansion tuple passed to throwing closure
+packExpansionClosureTests.test("basicPackExpansion") {
+  struct Runner<each Input> {
+    func run(_ input: (repeat each Input), test: ((repeat each Input)) throws -> Void) rethrows {
+      try test(input)
+    }
+  }
+
+  var callCount = 0
+  let runner = Runner<Int, String>()
+  runner.run((42, "hello")) { a, b in
+    expectEqual(a, 42)
+    expectEqual(b, "hello")
+    callCount += 1
+  }
+  expectEqual(callCount, 1)
+}
+
+// Test 2: Iterator pattern - pack expansion tuple from array iteration
+// This specifically tests the bug where iterating over an array of pack expansion
+// tuples and passing each to a closure would crash.
+packExpansionClosureTests.test("iteratorPattern") {
+  struct FuzzEngine<each Input> {
+    func run(inputs: [(repeat each Input)], test: ((repeat each Input)) throws -> Void) rethrows {
+      for input in inputs {
+        try test(input)
+      }
+    }
+  }
+
+  var values: [Int] = []
+  let engine = FuzzEngine<Int>()
+  engine.run(inputs: [(1), (2), (3)]) { value in
+    values.append(value)
+  }
+  expectEqual(values, [1, 2, 3])
+}
+
+// Test 3: Multiple pack parameters
+packExpansionClosureTests.test("multiplePackParameters") {
+  struct MultiEngine<each Input> {
+    func run(inputs: [(repeat each Input)], test: ((repeat each Input)) throws -> Void) rethrows {
+      for input in inputs {
+        try test(input)
+      }
+    }
+  }
+
+  var results: [(Int, String, Double)] = []
+  let engine = MultiEngine<Int, String, Double>()
+  engine.run(inputs: [(1, "a", 1.0), (2, "b", 2.0)]) { i, s, d in
+    results.append((i, s, d))
+  }
+  expectEqual(results.count, 2)
+  expectEqual(results[0].0, 1)
+  expectEqual(results[0].1, "a")
+  expectEqual(results[0].2, 1.0)
+  expectEqual(results[1].0, 2)
+  expectEqual(results[1].1, "b")
+  expectEqual(results[1].2, 2.0)
+}
+
+// Test 4: Single element pack (vanishing tuple case)
+// When instantiated with a single type, the tuple (repeat each T) becomes
+// just T, but the pack handling must still work correctly.
+packExpansionClosureTests.test("singleElementPack") {
+  struct SingleEngine<each Input> {
+    func run(inputs: [(repeat each Input)], test: ((repeat each Input)) throws -> Void) rethrows {
+      for input in inputs {
+        try test(input)
+      }
+    }
+  }
+
+  var sum = 0
+  let engine = SingleEngine<Int>()
+  engine.run(inputs: [(10), (20), (30)]) { value in
+    sum += value
+  }
+  expectEqual(sum, 60)
+}
+
+// Test 5: Nested function calls with pack expansion closures
+// This tests that the stack frame is correctly preserved across multiple
+// levels of pack expansion closure calls.
+packExpansionClosureTests.test("nestedCalls") {
+  struct Nested<each T> {
+    func outer(_ value: (repeat each T), process: ((repeat each T)) throws -> Int) rethrows -> Int {
+      return try inner(value, transform: process)
+    }
+
+    func inner(_ value: (repeat each T), transform: ((repeat each T)) throws -> Int) rethrows -> Int {
+      return try transform(value)
+    }
+  }
+
+  let nested = Nested<Int, Int>()
+  let result = nested.outer((5, 10)) { a, b in
+    return a + b
+  }
+  expectEqual(result, 15)
+}
+
+// Test 6: Throwing closure with pack expansion
+packExpansionClosureTests.test("throwingClosure") {
+  struct ThrowingEngine<each Input> {
+    func run(inputs: [(repeat each Input)], test: ((repeat each Input)) throws -> Void) throws {
+      for input in inputs {
+        try test(input)
+      }
+    }
+  }
+
+  enum TestError: Error { case expected }
+
+  var processedCount = 0
+  let engine = ThrowingEngine<Int>()
+
+  do {
+    try engine.run(inputs: [(1), (2), (3)]) { value in
+      processedCount += 1
+      if value == 2 {
+        throw TestError.expected
+      }
+    }
+    expectUnreachable("Should have thrown")
+  } catch {
+    expectEqual(processedCount, 2)
+  }
+}
+
+// Test 7: Pack expansion with class types (to test reference counting)
+packExpansionClosureTests.test("classTypes") {
+  class Counter {
+    var value: Int
+    init(_ v: Int) { value = v }
+  }
+
+  struct ClassEngine<each Input> {
+    func run(inputs: [(repeat each Input)], test: ((repeat each Input)) throws -> Void) rethrows {
+      for input in inputs {
+        try test(input)
+      }
+    }
+  }
+
+  var sum = 0
+  let engine = ClassEngine<Counter, Counter>()
+  let c1 = Counter(10)
+  let c2 = Counter(20)
+  engine.run(inputs: [(c1, c2)]) { a, b in
+    sum = a.value + b.value
+  }
+  expectEqual(sum, 30)
+}
+
+runAllTests()


### PR DESCRIPTION
## Summary

Test that passing pack expansion tuples to closures works correctly at runtime. This is a regression test for a bug where SILGen incorrectly used pack_element_get to read from an uninitialized pack instead of pack_element_set to store addresses into the pack. This caused the saved frame pointer to be overwritten, resulting in a crash on function return.

## Failure category

`compiler-crash` — The compiler crashes when processing this source.

## Reproduction

Branch: `test-survey/Interpreter_variadic_generic_closure_pack_expansion` (off `release/6.3`).
Test file: `test/Interpreter/variadic_generic_closure_pack_expansion.swift`
Run: `lit -v test/Interpreter/variadic_generic_closure_pack_expansion.swift`

## Test source (`test/Interpreter/variadic_generic_closure_pack_expansion.swift`)

```swift
// RUN: %target-run-simple-swift

// REQUIRES: executable_test

// Test that passing pack expansion tuples to closures works correctly at runtime.
// This is a regression test for a bug where SILGen incorrectly used pack_element_get
// to read from an uninitialized pack instead of pack_element_set to store addresses
// into the pack. This caused the saved frame pointer to be overwritten, resulting
// in a crash on function return.

import StdlibUnittest

var packExpansionClosureTests = TestSuite("PackExpansionClosure")

// Test 1: Basic pack expansion tuple passed to throwing closure
packExpansionClosureTests.test("basicPackExpansion") {
 struct Runner<each Input> {
 func run(_ input: (repeat each Input), test: ((repeat each Input)) throws -> Void) rethrows {
 try test(input)
 }
 }

 var callCount = 0
 let runner = Runner<Int, String>()
 runner.run((42, "hello")) { a, b in
 expectEqual(a, 42)
 expectEqual(b, "hello")
 callCount += 1
 }
 expectEqual(callCount, 1)
}

// Test 2: Iterator pattern - pack expansion tuple from array iteration
// This specifically tests the bug where iterating over an array of pack expansion
// tuples and passing each to a closure would crash.
packExpansionClosureTests.test("iteratorPattern") {
 struct FuzzEngine<each Input> {
 func run(inputs: [(repeat each Input)], test: ((repeat each Input)) throws -> Void) rethrows {
 for input in inputs {
 try test(input)
 }
 }
 }

 var values: [Int] = []
 let engine = FuzzEngine<Int>()
 engine.run(inputs: [(1), (2), (3)]) { value in
 values.append(value)
 }
 expectEqual(values, [1, 2, 3])
}

// Test 3: Multiple pack parameters
packExpansionClosureTests.test("multiplePackParameters") {
 struct MultiEngine<each Input> {
 func run(inputs: [(repeat each Input)], test: ((repeat each Input)) throws -> Void) rethrows {
 for input in inputs {
 try test(input)
 }
 }
 }

 var results: [(Int, String, Double)] = []
 let engine = MultiEngine<Int, String, Double>()
 engine.run(inputs: [(1, "a", 1.0), (2, "b", 2.0)]) { i, s, d in
 results.append((i, s, d))
 }
 expectEqual(results.count, 2)
 expectEqual(results[0].0, 1)
 expectEqual(results[0].1, "a")
 expectEqual(results[0].2, 1.0)
 expectEqual(results[1].0, 2)
 expectEqual(results[1].1, "b")
 expectEqual(results[1].2, 2.0)
}

// Test 4: Single element pack (vanishing tuple case)
// When instantiated with a single type, the tuple (repeat each T) becomes
// just T, but the pack handling must still work correctly.
packExpansionClosureTests.test("singleElementPack") {
 struct SingleEngine<each Input> {
 func run(inputs: [(repeat each Input)], test: ((repeat each Input)) throws -> Void) rethrows {
 for input in inputs {
 try test(input)
 }
 }
 }

 var sum = 0
 let engine = SingleEngine<Int>()
 engine.run(inputs: [(10), (20), (30)]) { value in
 sum += value
 }
 expectEqual(sum, 60)
}

// Test 5: Nested function calls with pack expansion closures
// This tests that the stack frame is correctly preserved across multiple
// levels of pack expansion closure calls.
packExpansionClosureTests.test("nestedCalls") {
 struct Nested<each T> {
 func outer(_ value: (repeat each T), process: ((repeat each T)) throws -> Int) rethrows -> Int {
 return try inner(value, transform: process)
 }

 func inner(_ value: (repeat each T), transform: ((repeat each T)) throws -> Int) rethrows -> Int {
 return try transform(value)
 }
 }

 let nested = Nested<Int, Int>()
 let result = nested.outer((5, 10)) { a, b in
 return a + b
 }
 expectEqual(result, 15)
}

// Test 6: Throwing closure with pack expansion
packExpansionClosureTests.test("throwingClosure") {
 struct ThrowingEngine<each Input> {
 func run(inputs: [(repeat each Input)], test: ((repeat each Input)) throws -> Void) throws {
 for input in inputs {
 try test(input)
 }
 }
 }

 enum TestError: Error { case expected }

 var processedCount = 0
 let engine = ThrowingEngine<Int>()

 do {
 try engine.run(inputs: [(1), (2), (3)]) { value in
 processedCount += 1
 if value == 2 {
 throw TestError.expected
 }
 }
 expectUnreachable("Should have thrown")
 } catch {
 expectEqual(processedCount, 2)
 }
}

// Test 7: Pack expansion with class types (to test reference counting)
packExpansionClosureTests.test("classTypes") {
 class Counter {
 var value: Int
 init(_ v: Int) { value = v }
 }

 struct ClassEngine<each Input> {
 func run(inputs: [(repeat each Input)], test: ((repeat each Input)) throws -> Void) rethrows {
 for input in inputs {
 try test(input)
 }
 }
 }

 var sum = 0
 let engine = ClassEngine<Counter, Counter>()
 let c1 = Counter(10)
 let c2 = Counter(20)
 engine.run(inputs: [(c1, c2)]) { a, b in
 sum = a.value + b.value
 }
 expectEqual(sum, 30)
}

runAllTests()
```

## Crash trace

```
Assertion failed: (isLoadableOrOpaque(LV->getType())), function createLoad at SILBuilder.h:800.
(to display assertion configuration options: -Xllvm -assert-help)

Please submit a bug report (https://swift.org/contributing/#reporting-bugs) and include the crash backtrace.
Stack dump:
0.	Program arguments: […elided…]
1.	Swift version 6.3.2-dev (LLVM 4e6cdf5caf79efb, Swift d23e82655fe203f)
2.	Compiling with effective version 4.1.50
3.	While evaluating request ASTLoweringRequest(Lowering AST to SIL for file "/Users/alex.reilly/Documents/OpenSource/swift-6.3-test/test/Interpreter/variadic_generic_closure_pack_expansion.swift")
4.	While silgen closureexpr SIL function "@$s4mainyycfU0_".
 for expression at [/Users/alex.reilly/Documents/OpenSource/swift-6.3-test/test/Interpreter/variadic_generic_closure_pack_expansion.swift:36:51 - line:51:1] RangeText="{
 struct FuzzEngine<each Input> {
 func run(inputs: [(repeat each Input)], test: ((repeat each Input)) throws -> Void) rethrows {
 for input in inputs {
 try test(input)
 }
 }
 }

 var values: [Int] = []
 let engine = FuzzEngine<Int>()
 engine.run(inputs: [(1), (2), (3)]) { value in
 values.append(value)
 }
 expectEqual(values, [1, 2, 3])
"
5.	While silgen closureexpr SIL function "@$s4mainyycfU0_ySiXEfU_".
 for expression at [/Users/alex.reilly/Documents/OpenSource/swift-6.3-test/test/Interpreter/variadic_generic_closure_pack_expansion.swift:47:39 - line:49:3] RangeText="{ value in
 values.append(value)
 "
6.	Assertion failed: (isLoadableOrOpaque(LV->getType())), function createLoad at SILBuilder.h:800.
| 	(to display assertion configuration options: -Xllvm -assert-help)
 #0 0x0000000107e5cb30 llvm::sys::PrintStackTrace(llvm::raw_ostream&, int) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x105a80b30)
 #1 0x0000000107e5abec llvm::sys::RunSignalHandlers() (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x105a7ebec)
 #2 0x0000000107e5d5d8 SignalHandler(int, __siginfo*, void*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x105a815d8)
 #3 0x000000018f4ed7a4 (/usr/lib/system/libsystem_platform.dylib+0x1804f97a4)
 #4 0x000000018f4e38d8 (/usr/lib/system/libsystem_pthread.dylib+0x1804ef8d8)
 #5 0x000000018f3ea790 (/usr/lib/system/libsystem_c.dylib+0x1803f6790)
 #6 0x0000000103efa644 _ABORT(char const*, int, char const*, llvm::function_ref<void (llvm::raw_ostream&)>) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x101b1e644)
 #7 0x0000000103efa600 _abortWithMessage(llvm::StringRef) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x101b1e600)
 #8 0x0000000102bc2ef0 swift::SILBuilder::createLoad(swift::SILLocation, swift::SILValue, swift::LoadOwnershipQualifier) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1007e6ef0)
 #9 0x0000000102c7b1c8 swift::Lowering::SILGenBuilder::createLoadBorrow(swift::SILLocation, swift::Lowering::ManagedValue) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x10089f1c8)
#10 0x0000000102c7be80 swift::Lowering::SILGenBuilder::createLoadWithSameOwnership(swift::SILLocation, swift::Lowering::ManagedValue) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x10089fe80)
#11 0x0000000102d3d32c (anonymous namespace)::EmitBBArguments::handleScalar(swift::Lowering::ManagedValue, swift::Lowering::AbstractionPattern, swift::CanType, swift::Lowering::Initialization*, bool, bool) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x10096132c)
#12 0x0000000102d3e5a0 swift::CanTypeVisitor<(anonymous namespace)::EmitBBArguments, swift::Lowering::ManagedValue, swift::Lowering::AbstractionPattern, swift::Lowering::Initialization*>::visitErrorType(swift::CanTypeWrapper<swift::ErrorType>, swift::Lowering::AbstractionPattern, swift::Lowering::Initialization*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1009625a0)
#13 0x0000000102d3dd54 swift::CanTypeVisitor<(anonymous namespace)::EmitBBArguments, swift::Lowering::ManagedValue, swift::Lowering::AbstractionPattern, swift::Lowering::Initialization*>::visit(swift::CanType, swift::Lowering::AbstractionPattern, swift::Lowering::Initialization*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100961d54)
#14 0x0000000102d3ccb8 (anonymous namespace)::ArgumentInitHelper::makeArgument(swift::SILLocation, swift::ParamDecl*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100960cb8)
#15 0x0000000102d3b804 (anonymous namespace)::ArgumentInitHelper::emitParam(swift::ParamDecl*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x10095f804)
#16 0x0000000102d3a540 swift::Lowering::SILGenFunction::emitBasicProlog(swift::DeclContext*, swift::ParameterList*, swift::ParamDecl*, swift::Type, std::__1::optional<swift::Type>, swift::SourceLoc, unsigned int) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x10095e540)
#17 0x0000000102d38ec4 swift::Lowering::SILGenFunction::emitProlog(swift::DeclContext*, swift::CaptureInfo, swift::ParameterList*, swift::ParamDecl*, swift::Type, std::__1::optional<swift::Type>, swift::SourceLoc) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x10095cec4)
#18 0x0000000102cd8658 swift::Lowering::SILGenFunction::emitClosure(swift::AbstractClosureExpr*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1008fc658)
#19 0x0000000102c42968 swift::Lowering::SILGenModule::emitFunctionDefinition(swift::SILDeclRef, swift::SILFunction*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100866968)
#20 0x0000000102c4a284 void llvm::function_ref<void ()>::callback_fn<swift::Lowering::SILGenModule::emitClosure(swift::AbstractClosureExpr*, swift::Lowering::FunctionTypeInfo const&)::$_0>(long) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x10086e284)
#21 0x0000000102fc38b8 swift::Lowering::TypeConverter::withClosureTypeInfo(swift::AbstractClosureExpr*, swift::Lowering::FunctionTypeInfo const&, llvm::function_ref<void ()>) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100be78b8)
#22 0x0000000102c45108 swift::Lowering::SILGenModule::emitClosure(swift::AbstractClosureExpr*, swift::Lowering::FunctionTypeInfo const&) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100869108)
#23 0x0000000102ccd758 (anonymous namespace)::RValueEmitter::emitClosureReference(swift::AbstractClosureExpr*, swift::Lowering::FunctionTypeInfo const&) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1008f1758)
#24 0x0000000102ccd488 (anonymous namespace)::RValueEmitter::visitAbstractClosureExpr(swift::AbstractClosureExpr*, swift::Lowering::SGFContext) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1008f1488)
#25 0x0000000102cb3168 swift::Lowering::SILGenFunction::emitRValueAsSingleValue(swift::Expr*, swift::Lowering::SGFContext) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1008d7168)
#26 0x0000000102c96fa0 swift::Lowering::SILGenFunction::emitConvertedRValue(swift::SILLocation, swift::Lowering::Conversion const&, swift::Lowering::SGFContext, llvm::function_ref<swift::Lowering::ManagedValue (swift::Lowering::SILGenFunction&, swift::SILLocation, swift::Lowering::SGFContext)>) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1008bafa0)
#27 0x0000000102c9716c swift::Lowering::ConvertingInitialization::tryPeephole(swift::Lowering::SILGenFunction&, swift::SILLocation, swift::Lowering::Conversion, llvm::function_ref<swift::Lowering::ManagedValue (swift::Lowering::SILGenFunction&, swift::SILLocation, swift::Lowering::SGFContext)>) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1008bb16c)
#28 0x0000000102c96f14 swift::Lowering::SILGenFunction::emitConvertedRValue(swift::SILLocation, swift::Lowering::Conversion const&, swift::Lowering::SGFContext, llvm::function_ref<swift::Lowering::ManagedValue (swift::Lowering::SILGenFunction&, swift::SILLocation, swift::Lowering::SGFContext)>) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1008baf14)
#29 0x0000000102c97080 swift::Lowering::SILGenFunction::emitConvertedRValue(swift::Expr*, swift::Lowering::Conversion const&, swift::Lowering::SGFContext) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1008bb080)
#30 0x0000000102cc5404 (anonymous namespace)::RValueEmitter::visitFunctionConversionExpr(swift::FunctionConversionExpr*, swift::Lowering::SGFContext) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1008e9404)
#31 0x0000000102cb3168 swift::Lowering::SILGenFunction::emitRValueAsSingleValue(swift::Expr*, swift::Lowering::SGFContext) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1008d7168)
#32 0x0000000102c96fa0 swift::Lowering::SILGenFunction::emitConvertedRValue(swift::SILLocation, swift::Lowering::Conversion const&, swift::Lowering::SGFContext, llvm::function_ref<swift::Lowering::ManagedValue (swift::Lowering::SILGenFunction&, swift::SILLocation, swift::Lowering::SGFContext)>) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1008bafa0)
#33 0x0000000102c2b0e0 swift::Lowering::ArgumentSource::getConverted(swift::Lowering::SILGenFunction&, swift::Lowering::Conversion const&, swift::Lowering::SGFContext) && (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x10084f0e0)
#34 0x0000000102c624c8 (anonymous namespace)::ArgEmitter::emit(swift::Lowering::ArgumentSource&&, swift::Lowering::AbstractionPattern, bool, std::__1::optional<swift::AnyFunctionType::Param>) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1008864c8)
 […further frames elided…]
```
