### PR TITLE
[release/6.3] Add regression test: variadic generic pack owned tuple (compiler crash)

### DIFF
--- a/test/Interpreter/Inputs/enum_parameter_pack_lib.swift
+++ b/test/Interpreter/Inputs/enum_parameter_pack_lib.swift
@@ -1,0 +1,26 @@
+// Library for enum_parameter_pack_cross_module test.
+// This must be compiled separately to trigger the cross-module metadata path.
+
+import Foundation
+
+public enum Action<each T: Sendable>: Sendable {
+    case stop(String)
+    case record(RecordAction)
+    case select(SelectAction)
+
+    // Uses Foundation types inside the enum - this is important because
+    // the external types trigger a specific metadata completion path.
+    public struct RecordAction: Sendable {
+        public let date: Date
+        public let uuid: UUID
+        public init(date: Date, uuid: UUID) {
+            self.date = date
+            self.uuid = uuid
+        }
+    }
+
+    // Has pack expansion tuple - required to trigger the bug.
+    public struct SelectAction: @unchecked Sendable {
+        public let input: (repeat each T)
+    }
+}

--- a/test/Interpreter/variadic_generic_pack_owned_tuple.swift
+++ b/test/Interpreter/variadic_generic_pack_owned_tuple.swift
@@ -1,0 +1,221 @@
+// RUN: %target-run-simple-swift
+
+// REQUIRES: executable_test
+
+// Test that passing pack expansion tuples to functions with @pack_owned
+// parameters works correctly, especially when called through a generic wrapper.
+// This is a regression test for a bug where SILGen failed to forward the
+// cleanup of the tuple storage when transferring ownership to the pack,
+// resulting in a double-free crash.
+
+import StdlibUnittest
+
+var packOwnedTupleTests = TestSuite("PackOwnedTuple")
+
+// Protocol with associated type for the full pattern
+protocol Mutator {
+  associatedtype Value
+  var seeds: [Value] { get }
+  func mutate(_ input: Value) -> [Value]
+}
+
+struct SimpleMutator<T>: Mutator {
+  typealias Value = T
+  let seeds: [T]
+  let mutateFn: (T) -> [T]
+
+  init(seeds: [T], mutate: @escaping (T) -> [T] = { _ in [] }) {
+    self.seeds = seeds
+    self.mutateFn = mutate
+  }
+
+  func mutate(_ input: T) -> [T] { mutateFn(input) }
+}
+
+// Class that stores a closure capturing pack expansion tuple array
+final class Box<each Input> {
+  typealias Seeds = () -> [(repeat each Input)]
+  let seedsFn: Seeds
+
+  // Init takes @pack_owned parameter
+  init<each M: Mutator>(
+    mutators: (repeat each M)
+  ) where (repeat (each M).Value) == (repeat each Input) {
+    // Extract seeds eagerly from each mutator
+    let capturedSeeds = Self.extractSeeds(mutators: mutators)
+    self.seedsFn = { capturedSeeds }
+  }
+
+  private static func extractSeeds<each M: Mutator>(
+    mutators: (repeat each M)
+  ) -> [(repeat each Input)] where (repeat (each M).Value) == (repeat each Input) {
+    var result: [(repeat each Input)] = []
+
+    // Collect all seed arrays
+    var allSeeds: [[Any]] = []
+    (repeat allSeeds.append((each mutators).seeds.map { $0 as Any }))
+
+    // For single mutator, just map seeds directly
+    if let seeds = allSeeds.first, allSeeds.count == 1 {
+      for seed in seeds {
+        func cast<V>(_ t: V.Type) -> V { seed as! V }
+        let tuple: (repeat each Input) = (repeat cast((each Input).self))
+        result.append(tuple)
+      }
+    }
+    return result
+  }
+
+  func get() -> [(repeat each Input)] {
+    return seedsFn()
+  }
+}
+
+// Public API that forwards parameter packs
+func api<each Input, each M: Mutator>(
+  using mutators: repeat each M
+) -> [(repeat each Input)] where (repeat (each M).Value) == (repeat each Input) {
+  // Capture the pack - this creates a tuple (repeat each M)
+  let captured: (repeat each M) = (repeat each mutators)
+  // Pass to Box.init which takes @pack_owned
+  let box = Box<repeat each Input>(mutators: captured)
+  return box.get()
+}
+
+// Generic wrapper function to test the wrapped call pattern
+func wrapper<R>(_ op: () -> R) -> R {
+  return op()
+}
+
+// Test 1: Direct call to api function
+packOwnedTupleTests.test("directCall") {
+  let seeds: [String] = api(using: SimpleMutator(seeds: ["a", "b", "c"]))
+  expectEqual(seeds.count, 3)
+  expectEqual(seeds[0], "a")
+  expectEqual(seeds[1], "b")
+  expectEqual(seeds[2], "c")
+}
+
+// Test 2: Call through generic wrapper - this is the pattern that crashed
+packOwnedTupleTests.test("wrappedCall") {
+  let seeds: [String] = wrapper {
+    api(using: SimpleMutator(seeds: ["x", "y", "z"]))
+  }
+  expectEqual(seeds.count, 3)
+  expectEqual(seeds[0], "x")
+  expectEqual(seeds[1], "y")
+  expectEqual(seeds[2], "z")
+}
+
+// Test 3: Multiple wrapped calls in sequence
+packOwnedTupleTests.test("multipleWrappedCalls") {
+  var allSeeds: [[String]] = []
+
+  for i in 0..<3 {
+    let seeds: [String] = wrapper {
+      api(using: SimpleMutator(seeds: ["item\(i)"]))
+    }
+    allSeeds.append(seeds)
+  }
+
+  expectEqual(allSeeds.count, 3)
+  expectEqual(allSeeds[0], ["item0"])
+  expectEqual(allSeeds[1], ["item1"])
+  expectEqual(allSeeds[2], ["item2"])
+}
+
+// Test 4: Nested wrappers
+packOwnedTupleTests.test("nestedWrappers") {
+  let seeds: [Int] = wrapper {
+    wrapper {
+      wrapper {
+        api(using: SimpleMutator(seeds: [1, 2, 3, 4, 5]))
+      }
+    }
+  }
+  expectEqual(seeds, [1, 2, 3, 4, 5])
+}
+
+// Test 5: Class types to verify reference counting
+packOwnedTupleTests.test("classTypeSeeds") {
+  class Ref {
+    let value: Int
+    init(_ v: Int) { value = v }
+  }
+
+  // Create refs outside wrapper to verify they survive
+  let refs = [Ref(10), Ref(20), Ref(30)]
+
+  let seeds: [Ref] = wrapper {
+    api(using: SimpleMutator(seeds: refs))
+  }
+
+  expectEqual(seeds.count, 3)
+  expectEqual(seeds[0].value, 10)
+  expectEqual(seeds[1].value, 20)
+  expectEqual(seeds[2].value, 30)
+}
+
+// Test 6: Throwing wrapper
+packOwnedTupleTests.test("throwingWrapper") {
+  func throwingWrapper<R>(_ op: () throws -> R) rethrows -> R {
+    return try op()
+  }
+
+  // Using rethrows, no actual throws happens here
+  let seeds: [String] = throwingWrapper {
+    api(using: SimpleMutator(seeds: ["success"]))
+  }
+  expectEqual(seeds, ["success"])
+}
+
+// Test 7: Async wrapper (if available)
+#if swift(>=5.5)
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+func asyncTest() async {
+  func asyncWrapper<R>(_ op: () async -> R) async -> R {
+    return await op()
+  }
+
+  let seeds: [String] = await asyncWrapper {
+    api(using: SimpleMutator(seeds: ["async"]))
+  }
+  expectEqual(seeds, ["async"])
+}
+#endif
+
+// Test 8: Escaping closure that captures the result
+packOwnedTupleTests.test("escapingCapture") {
+  var capturedSeeds: [String]? = nil
+
+  func captureInEscaping(_ op: @escaping () -> [String]) {
+    capturedSeeds = op()
+  }
+
+  captureInEscaping {
+    api(using: SimpleMutator(seeds: ["captured"]))
+  }
+
+  expectEqual(capturedSeeds, ["captured"])
+}
+
+// Test 9: Verify cleanup happens correctly by checking for memory issues
+// across many iterations
+packOwnedTupleTests.test("stressTest") {
+  for _ in 0..<1000 {
+    let _: [String] = wrapper {
+      api(using: SimpleMutator(seeds: ["stress", "test"]))
+    }
+  }
+  // If we get here without crashing, the cleanup is working correctly
+}
+
+// Test 10: Empty seeds array
+packOwnedTupleTests.test("emptySeeds") {
+  let seeds: [String] = wrapper {
+    api(using: SimpleMutator<String>(seeds: []))
+  }
+  expectEqual(seeds.count, 0)
+}
+
+runAllTests()


### PR DESCRIPTION
## Summary

Test that passing pack expansion tuples to functions with @pack_owned parameters works correctly, especially when called through a generic wrapper. This is a regression test for a bug where SILGen failed to forward the cleanup of the tuple storage when transferring ownership to the pack, resulting in a double-free crash.

## Failure category

`compiler-crash` — The compiler crashes when processing this source.

## Reproduction

Branch: `test-survey/Interpreter_variadic_generic_pack_owned_tuple` (off `release/6.3`).
Test file: `test/Interpreter/variadic_generic_pack_owned_tuple.swift`
Run: `lit -v test/Interpreter/variadic_generic_pack_owned_tuple.swift`

## Test source (`test/Interpreter/variadic_generic_pack_owned_tuple.swift`)

```swift
// RUN: %target-run-simple-swift

// REQUIRES: executable_test

// Test that passing pack expansion tuples to functions with @pack_owned
// parameters works correctly, especially when called through a generic wrapper.
// This is a regression test for a bug where SILGen failed to forward the
// cleanup of the tuple storage when transferring ownership to the pack,
// resulting in a double-free crash.

import StdlibUnittest

var packOwnedTupleTests = TestSuite("PackOwnedTuple")

// Protocol with associated type for the full pattern
protocol Mutator {
 associatedtype Value
 var seeds: [Value] { get }
 func mutate(_ input: Value) -> [Value]
}

struct SimpleMutator<T>: Mutator {
 typealias Value = T
 let seeds: [T]
 let mutateFn: (T) -> [T]

 init(seeds: [T], mutate: @escaping (T) -> [T] = { _ in [] }) {
 self.seeds = seeds
 self.mutateFn = mutate
 }

 func mutate(_ input: T) -> [T] { mutateFn(input) }
}

// Class that stores a closure capturing pack expansion tuple array
final class Box<each Input> {
 typealias Seeds = () -> [(repeat each Input)]
 let seedsFn: Seeds

 // Init takes @pack_owned parameter
 init<each M: Mutator>(
 mutators: (repeat each M)
 ) where (repeat (each M).Value) == (repeat each Input) {
 // Extract seeds eagerly from each mutator
 let capturedSeeds = Self.extractSeeds(mutators: mutators)
 self.seedsFn = { capturedSeeds }
 }

 private static func extractSeeds<each M: Mutator>(
 mutators: (repeat each M)
 ) -> [(repeat each Input)] where (repeat (each M).Value) == (repeat each Input) {
 var result: [(repeat each Input)] = []

 // Collect all seed arrays
 var allSeeds: [[Any]] = []
 (repeat allSeeds.append((each mutators).seeds.map { $0 as Any }))

 // For single mutator, just map seeds directly
 if let seeds = allSeeds.first, allSeeds.count == 1 {
 for seed in seeds {
 func cast<V>(_ t: V.Type) -> V { seed as! V }
 let tuple: (repeat each Input) = (repeat cast((each Input).self))
 result.append(tuple)
 }
 }
 return result
 }

 func get() -> [(repeat each Input)] {
 return seedsFn()
 }
}

// Public API that forwards parameter packs
func api<each Input, each M: Mutator>(
 using mutators: repeat each M
) -> [(repeat each Input)] where (repeat (each M).Value) == (repeat each Input) {
 // Capture the pack - this creates a tuple (repeat each M)
 let captured: (repeat each M) = (repeat each mutators)
 // Pass to Box.init which takes @pack_owned
 let box = Box<repeat each Input>(mutators: captured)
 return box.get()
}

// Generic wrapper function to test the wrapped call pattern
func wrapper<R>(_ op: () -> R) -> R {
 return op()
}

// Test 1: Direct call to api function
packOwnedTupleTests.test("directCall") {
 let seeds: [String] = api(using: SimpleMutator(seeds: ["a", "b", "c"]))
 expectEqual(seeds.count, 3)
 expectEqual(seeds[0], "a")
 expectEqual(seeds[1], "b")
 expectEqual(seeds[2], "c")
}

// Test 2: Call through generic wrapper - this is the pattern that crashed
packOwnedTupleTests.test("wrappedCall") {
 let seeds: [String] = wrapper {
 api(using: SimpleMutator(seeds: ["x", "y", "z"]))
 }
 expectEqual(seeds.count, 3)
 expectEqual(seeds[0], "x")
 expectEqual(seeds[1], "y")
 expectEqual(seeds[2], "z")
}

// Test 3: Multiple wrapped calls in sequence
packOwnedTupleTests.test("multipleWrappedCalls") {
 var allSeeds: [[String]] = []

 for i in 0..<3 {
 let seeds: [String] = wrapper {
 api(using: SimpleMutator(seeds: ["item\(i)"]))
 }
 allSeeds.append(seeds)
 }

 expectEqual(allSeeds.count, 3)
 expectEqual(allSeeds[0], ["item0"])
 expectEqual(allSeeds[1], ["item1"])
 expectEqual(allSeeds[2], ["item2"])
}

// Test 4: Nested wrappers
packOwnedTupleTests.test("nestedWrappers") {
 let seeds: [Int] = wrapper {
 wrapper {
 wrapper {
 api(using: SimpleMutator(seeds: [1, 2, 3, 4, 5]))
 }
 }
 }
 expectEqual(seeds, [1, 2, 3, 4, 5])
}

// Test 5: Class types to verify reference counting
packOwnedTupleTests.test("classTypeSeeds") {
 class Ref {
 let value: Int
 init(_ v: Int) { value = v }
 }

 // Create refs outside wrapper to verify they survive
 let refs = [Ref(10), Ref(20), Ref(30)]

 let seeds: [Ref] = wrapper {
 api(using: SimpleMutator(seeds: refs))
 }

 expectEqual(seeds.count, 3)
 expectEqual(seeds[0].value, 10)
 expectEqual(seeds[1].value, 20)
 expectEqual(seeds[2].value, 30)
}

// Test 6: Throwing wrapper
packOwnedTupleTests.test("throwingWrapper") {
 func throwingWrapper<R>(_ op: () throws -> R) rethrows -> R {
 return try op()
 }

 // Using rethrows, no actual throws happens here
 let seeds: [String] = throwingWrapper {
 api(using: SimpleMutator(seeds: ["success"]))
 }
 expectEqual(seeds, ["success"])
}

// Test 7: Async wrapper (if available)
#if swift(>=5.5)
@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
func asyncTest() async {
 func asyncWrapper<R>(_ op: () async -> R) async -> R {
 return await op()
 }

 let seeds: [String] = await asyncWrapper {
 api(using: SimpleMutator(seeds: ["async"]))
 }
 expectEqual(seeds, ["async"])
}
#endif

// Test 8: Escaping closure that captures the result
packOwnedTupleTests.test("escapingCapture") {
 var capturedSeeds: [String]? = nil

 func captureInEscaping(_ op: @escaping () -> [String]) {
 capturedSeeds = op()
 }

 captureInEscaping {
 api(using: SimpleMutator(seeds: ["captured"]))
 }

 expectEqual(capturedSeeds, ["captured"])
}

// Test 9: Verify cleanup happens correctly by checking for memory issues
// across many iterations
packOwnedTupleTests.test("stressTest") {
 for _ in 0..<1000 {
 let _: [String] = wrapper {
 api(using: SimpleMutator(seeds: ["stress", "test"]))
 }
 }
 // If we get here without crashing, the cleanup is working correctly
}

// Test 10: Empty seeds array
packOwnedTupleTests.test("emptySeeds") {
 let seeds: [String] = wrapper {
 api(using: SimpleMutator<String>(seeds: []))
 }
 expectEqual(seeds.count, 0)
}

runAllTests()
```

## Crash trace

```
Assertion failed: (!tupleTy.containsPackExpansionType() && "can't extract elements from tuples containing pack expansions " "right now"), function extractElements, file RValue.cpp, line 707.
Please submit a bug report (https://swift.org/contributing/#reporting-bugs) and include the crash backtrace.
Stack dump:
0.	Program arguments: […elided…]
1.	Swift version 6.3.2-dev (LLVM 4e6cdf5caf79efb, Swift d23e82655fe203f)
2.	Compiling with effective version 4.1.50
3.	While evaluating request ASTLoweringRequest(Lowering AST to SIL for file "/Users/alex.reilly/Documents/OpenSource/swift-6.3-test/test/Interpreter/variadic_generic_pack_owned_tuple.swift")
4.	While silgen constructor initializer SIL function "@$s4main3BoxC8mutatorsACyxxQp_QPGqd__xQp_t_tcRvd__5ValueQyd__RszAA7MutatorRd__lufc".
 for 'init(mutators:)' (at /Users/alex.reilly/Documents/OpenSource/swift-6.3-test/test/Interpreter/variadic_generic_pack_owned_tuple.swift:41:3)
 #0 0x000000010a670b30 llvm::sys::PrintStackTrace(llvm::raw_ostream&, int) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x105a80b30)
 #1 0x000000010a66ebec llvm::sys::RunSignalHandlers() (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x105a7ebec)
 #2 0x000000010a6715d8 SignalHandler(int, __siginfo*, void*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x105a815d8)
 #3 0x000000018f4ed7a4 (/usr/lib/system/libsystem_platform.dylib+0x1804f97a4)
 #4 0x000000018f4e38d8 (/usr/lib/system/libsystem_pthread.dylib+0x1804ef8d8)
 #5 0x000000018f3ea790 (/usr/lib/system/libsystem_c.dylib+0x1803f6790)
 #6 0x000000018f3e99ec (/usr/lib/system/libsystem_c.dylib+0x1803f59ec)
 #7 0x000000010a69d0dc swift::Lowering::RValue::copy(swift::Lowering::SILGenFunction&, swift::SILLocation) const & (.cold.1) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x105aad0dc)
 #8 0x000000010544c654 swift::Lowering::RValue::extractElements(llvm::SmallVectorImpl<swift::Lowering::RValue>&) && (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x10085c654)
 #9 0x00000001054404f4 swift::Lowering::ArgumentSourceExpansion::ArgumentSourceExpansion(swift::Lowering::SILGenFunction&, swift::Lowering::ArgumentSource&&, bool) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1008504f4)
#10 0x0000000105475730 (anonymous namespace)::ArgEmitter::emit(swift::Lowering::ArgumentSource&&, swift::Lowering::AbstractionPattern, bool, std::__1::optional<swift::AnyFunctionType::Param>) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100885730)
#11 0x0000000105466f24 (anonymous namespace)::ArgEmitter::emitSingleArg(swift::Lowering::ArgumentSource&&, swift::Lowering::AbstractionPattern, bool, std::__1::optional<swift::AnyFunctionType::Param>) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100876f24)
#12 0x0000000105474a6c (anonymous namespace)::ArgEmitter::emitPreparedArgs(swift::Lowering::PreparedArguments&&, swift::Lowering::AbstractionPattern, llvm::ArrayRef<swift::LifetimeDependenceInfo>) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100884a6c)
#13 0x000000010547faec (anonymous namespace)::CallSite::emit(swift::Lowering::SILGenFunction&, swift::Lowering::AbstractionPattern, swift::CanTypeWrapper<swift::SILFunctionType>, llvm::ArrayRef<swift::LifetimeDependenceInfo>, (anonymous namespace)::ParamLowering&, llvm::SmallVectorImpl<swift::Lowering::ManagedValue>&, llvm::SmallVectorImpl<(anonymous namespace)::DelayedArgument>&, swift::ForeignInfo const&) && (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swi […truncated…]
#14 0x000000010547f42c (anonymous namespace)::CallEmission::emitArgumentsForNormalApply(swift::Lowering::AbstractionPattern, swift::CanTypeWrapper<swift::SILFunctionType>, llvm::ArrayRef<swift::LifetimeDependenceInfo>, swift::ForeignInfo const&, llvm::SmallVectorImpl<swift::Lowering::ManagedValue>&, std::__1::optional<swift::SILLocation>&) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x10088f42c)
#15 0x000000010546a7ec (anonymous namespace)::CallEmission::apply(swift::Lowering::SGFContext) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x10087a7ec)
#16 0x0000000105468784 swift::Lowering::SILGenFunction::emitApplyExpr(swift::ApplyExpr*, swift::Lowering::SGFContext) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100878784)
#17 0x00000001054c44a0 swift::Lowering::SILGenFunction::emitExprInto(swift::Expr*, swift::Lowering::Initialization*, std::__1::optional<swift::SILLocation>) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1008d44a0)
#18 0x00000001054b193c swift::Lowering::SILGenFunction::emitPatternBinding(swift::PatternBindingDecl*, unsigned int, bool) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1008c193c)
#19 0x00000001054b8288 swift::ASTVisitor<swift::Lowering::SILGenFunction, void, void, void, void, void, void>::visit(swift::Decl*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1008c8288)
#20 0x0000000105555554 swift::ASTVisitor<(anonymous namespace)::StmtEmitter, void, void, void, void, void, void>::visit(swift::Stmt*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100965554)
#21 0x0000000105553f7c swift::Lowering::SILGenFunction::emitStmt(swift::Stmt*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100963f7c)
#22 0x00000001054a3d80 swift::Lowering::SILGenFunction::emitClassConstructorInitializer(swift::ConstructorDecl*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1008b3d80)
#23 0x000000010545672c swift::Lowering::SILGenModule::emitFunctionDefinition(swift::SILDeclRef, swift::SILFunction*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x10086672c)
#24 0x0000000105457f1c swift::Lowering::SILGenModule::emitOrDelayFunction(swift::SILDeclRef) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100867f1c)
#25 0x0000000105459068 swift::Lowering::SILGenModule::emitConstructor(swift::ConstructorDecl*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100869068)
#26 0x0000000105565b54 (anonymous namespace)::SILGenType::emitType() (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100975b54)
#27 0x0000000105565a10 swift::Lowering::SILGenModule::visitNominalTypeDecl(swift::NominalTypeDecl*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100975a10)
#28 0x000000010545a9d0 swift::Lowering::SILGenModule::emitSourceFile(swift::SourceFile*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x10086a9d0)
#29 0x000000010545aebc swift::ASTLoweringRequest::evaluate(swift::Evaluator&, swift::ASTLoweringDescriptor) const (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x10086aebc)
#30 0x00000001055539a0 swift::SimpleRequest<swift::ASTLoweringRequest, std::__1::unique_ptr<swift::SILModule, std::__1::default_delete<swift::SILModule>> (swift::ASTLoweringDescriptor), (swift::RequestFlags)17>::evaluateRequest(swift::ASTLoweringRequest const&, swift::Evaluator&) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1009639a0)
#31 0x000000010545eb50 swift::ASTLoweringRequest::OutputType swift::Evaluator::getResultUncached<swift::ASTLoweringRequest, swift::ASTLoweringRequest::OutputType swift::evaluateOrFatal<swift::ASTLoweringRequest>(swift::Evaluator&, swift::ASTLoweringRequest)::'lambda'()>(swift::ASTLoweringRequest const&, swift::ASTLoweringRequest::OutputType swift::evaluateOrFatal<swift::ASTLoweringRequest>(swift::Evaluator&, swift::ASTLoweringRequest)::'lambda'())::'lambda'()::operator()() const (/Users/alex.rei […truncated…]
#32 0x000000010545ea6c swift::ASTLoweringRequest::OutputType swift::Evaluator::getResultUncached<swift::ASTLoweringRequest, swift::ASTLoweringRequest::OutputType swift::evaluateOrFatal<swift::ASTLoweringRequest>(swift::Evaluator&, swift::ASTLoweringRequest)::'lambda'()>(swift::ASTLoweringRequest const&, swift::ASTLoweringRequest::OutputType swift::evaluateOrFatal<swift::ASTLoweringRequest>(swift::Evaluator&, swift::ASTLoweringRequest)::'lambda'()) (/Users/alex.reilly/Documents/OpenSource/build/N […truncated…]
#33 0x000000010545b3f4 swift::performASTLowering(swift::FileUnit&, swift::Lowering::TypeConverter&, swift::SILOptions const&, swift::IRGenOptions const*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x10086b3f4)
#34 0x0000000104e90c30 swift::performCompileStepsPostSema(swift::CompilerInstance&, int&, swift::FrontendObserver*, llvm::ArrayRef<char const*>) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1002a0c30)
 […further frames elided…]
```
