### PR TITLE
[release/6.3] Add regression test: variadic generic tuple init (compiler crash)

### DIFF
--- a/test/Interpreter/Inputs/enum_parameter_pack_lib.swift
+++ b/test/Interpreter/Inputs/enum_parameter_pack_lib.swift
@@ -1,0 +1,26 @@
+// Library for enum_parameter_pack_cross_module test.
+// This must be compiled separately to trigger the cross-module metadata path.
+
+import Foundation
+
+public enum Action<each T: Sendable>: Sendable {
+    case stop(String)
+    case record(RecordAction)
+    case select(SelectAction)
+
+    // Uses Foundation types inside the enum - this is important because
+    // the external types trigger a specific metadata completion path.
+    public struct RecordAction: Sendable {
+        public let date: Date
+        public let uuid: UUID
+        public init(date: Date, uuid: UUID) {
+            self.date = date
+            self.uuid = uuid
+        }
+    }
+
+    // Has pack expansion tuple - required to trigger the bug.
+    public struct SelectAction: @unchecked Sendable {
+        public let input: (repeat each T)
+    }
+}

--- a/test/Interpreter/variadic_generic_tuple_init.swift
+++ b/test/Interpreter/variadic_generic_tuple_init.swift
@@ -1,0 +1,214 @@
+// RUN: %target-run-simple-swift(-target %target-swift-5.9-abi-triple)
+
+// REQUIRES: executable_test
+
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
+// This test verifies runtime behavior of structs with pack expansion tuple
+// properties, ensuring that definite initialization correctly handles
+// the initialization and that values are accessible at runtime.
+
+import StdlibUnittest
+
+var suite = TestSuite("VariadicGenericTupleInit")
+
+// MARK: - Basic struct with pack expansion tuple
+
+struct BasicPackTuple<each T> {
+  let values: (repeat each T)
+
+  init(_ values: repeat each T) {
+    self.values = (repeat each values)
+  }
+}
+
+suite.test("BasicPackTuple single element") {
+  let s = BasicPackTuple(42)
+  expectEqual(42, s.values)
+}
+
+suite.test("BasicPackTuple multiple elements") {
+  let s = BasicPackTuple(1, "hello", true)
+  expectEqual(1, s.values.0)
+  expectEqual("hello", s.values.1)
+  expectEqual(true, s.values.2)
+}
+
+// MARK: - Struct with mixed properties
+
+struct MixedProperties<each T> {
+  let prefix: Int
+  let packed: (repeat each T)
+  let suffix: String
+
+  init(prefix: Int, suffix: String, _ values: repeat each T) {
+    self.prefix = prefix
+    self.packed = (repeat each values)
+    self.suffix = suffix
+  }
+}
+
+suite.test("MixedProperties") {
+  let s = MixedProperties(prefix: 10, suffix: "end", 3.14, "middle")
+  expectEqual(10, s.prefix)
+  expectEqual(3.14, s.packed.0)
+  expectEqual("middle", s.packed.1)
+  expectEqual("end", s.suffix)
+}
+
+// MARK: - Conditional initialization
+
+struct ConditionalInit<each T> {
+  let values: (repeat each T)
+  let flag: Bool
+
+  init(condition: Bool, _ values: repeat each T) {
+    self.flag = condition
+    if condition {
+      self.values = (repeat each values)
+    } else {
+      self.values = (repeat each values)
+    }
+  }
+}
+
+suite.test("ConditionalInit true branch") {
+  let s = ConditionalInit(condition: true, "a", "b")
+  expectTrue(s.flag)
+  expectEqual("a", s.values.0)
+  expectEqual("b", s.values.1)
+}
+
+suite.test("ConditionalInit false branch") {
+  let s = ConditionalInit(condition: false, 1, 2, 3)
+  expectFalse(s.flag)
+  expectEqual(1, s.values.0)
+  expectEqual(2, s.values.1)
+  expectEqual(3, s.values.2)
+}
+
+// MARK: - Nested struct
+
+struct Outer<each T> {
+  struct Inner {
+    let data: (repeat each T)
+
+    init(_ values: repeat each T) {
+      self.data = (repeat each values)
+    }
+  }
+
+  let inner: Inner
+
+  init(_ values: repeat each T) {
+    self.inner = Inner(repeat each values)
+  }
+}
+
+suite.test("Nested struct") {
+  let s = Outer(100, 200)
+  expectEqual(100, s.inner.data.0)
+  expectEqual(200, s.inner.data.1)
+}
+
+// MARK: - Class with pack expansion tuple
+
+class ClassWithPackTuple<each T> {
+  let values: (repeat each T)
+
+  init(_ values: repeat each T) {
+    self.values = (repeat each values)
+  }
+}
+
+suite.test("Class with pack tuple") {
+  let c = ClassWithPackTuple("x", "y", "z")
+  expectEqual("x", c.values.0)
+  expectEqual("y", c.values.1)
+  expectEqual("z", c.values.2)
+}
+
+// MARK: - Failable initializer
+
+struct FailablePackInit<each T> {
+  let values: (repeat each T)
+
+  init?(_ values: repeat each T, shouldFail: Bool) {
+    if shouldFail {
+      return nil
+    }
+    self.values = (repeat each values)
+  }
+}
+
+suite.test("Failable init success") {
+  let s = FailablePackInit(1, 2, shouldFail: false)
+  expectNotNil(s)
+  expectEqual(1, s!.values.0)
+  expectEqual(2, s!.values.1)
+}
+
+suite.test("Failable init failure") {
+  let s = FailablePackInit(1, 2, shouldFail: true)
+  expectNil(s)
+}
+
+// MARK: - Throwing initializer
+
+struct ThrowingPackInit<each T> {
+  let values: (repeat each T)
+
+  init(_ values: repeat each T) throws {
+    self.values = (repeat each values)
+  }
+}
+
+suite.test("Throwing init") {
+  do {
+    let s = try ThrowingPackInit("a", "b")
+    expectEqual("a", s.values.0)
+    expectEqual("b", s.values.1)
+  } catch {
+    expectUnreachable("Should not throw")
+  }
+}
+
+// MARK: - Throwing initializer with pack expansion tuple (crash case)
+// This is a minimal reproducer for the DI crash. The crash occurs when:
+// 1. Struct has multiple properties including a pack expansion tuple
+// 2. Throwing initializer where a throwing call comes AFTER the pack tuple assignment
+// 3. DI generates cleanup code that incorrectly uses tuple_element_addr on the pack tuple
+
+func produceValue<T>(type: T.Type) -> T {
+  fatalError("not called in test")
+}
+
+func produceInt() throws -> Int {
+  return 42
+}
+
+struct ThrowingContainer<each Input> {
+  let inputs: (repeat each Input)
+  let tag: Int
+
+  init() throws {
+    self.inputs = (repeat produceValue(type: (each Input).self))
+    self.tag = try produceInt()
+  }
+
+  init(inputs: repeat each Input, tag: Int) {
+    self.inputs = (repeat each inputs)
+    self.tag = tag
+  }
+}
+
+suite.test("Throwing init with pack tuple - success path") {
+  // Use the non-throwing init for runtime test
+  let c = ThrowingContainer<Int, String>(inputs: 42, "test", tag: 99)
+  expectEqual(42, c.inputs.0)
+  expectEqual("test", c.inputs.1)
+  expectEqual(99, c.tag)
+}
+
+runAllTests()


### PR DESCRIPTION
## Summary

This test verifies runtime behavior of structs with pack expansion tuple properties, ensuring that definite initialization correctly handles the initialization and that values are accessible at runtime.

## Failure category

`compiler-crash` — The compiler crashes when processing this source.

## Reproduction

Branch: `test-survey/Interpreter_variadic_generic_tuple_init` (off `release/6.3`).
Test file: `test/Interpreter/variadic_generic_tuple_init.swift`
Run: `lit -v test/Interpreter/variadic_generic_tuple_init.swift`

## Test source (`test/Interpreter/variadic_generic_tuple_init.swift`)

```swift
// RUN: %target-run-simple-swift(-target %target-swift-5.9-abi-triple)

// REQUIRES: executable_test

// UNSUPPORTED: use_os_stdlib
// UNSUPPORTED: back_deployment_runtime

// This test verifies runtime behavior of structs with pack expansion tuple
// properties, ensuring that definite initialization correctly handles
// the initialization and that values are accessible at runtime.

import StdlibUnittest

var suite = TestSuite("VariadicGenericTupleInit")

// MARK: - Basic struct with pack expansion tuple

struct BasicPackTuple<each T> {
 let values: (repeat each T)

 init(_ values: repeat each T) {
 self.values = (repeat each values)
 }
}

suite.test("BasicPackTuple single element") {
 let s = BasicPackTuple(42)
 expectEqual(42, s.values)
}

suite.test("BasicPackTuple multiple elements") {
 let s = BasicPackTuple(1, "hello", true)
 expectEqual(1, s.values.0)
 expectEqual("hello", s.values.1)
 expectEqual(true, s.values.2)
}

// MARK: - Struct with mixed properties

struct MixedProperties<each T> {
 let prefix: Int
 let packed: (repeat each T)
 let suffix: String

 init(prefix: Int, suffix: String, _ values: repeat each T) {
 self.prefix = prefix
 self.packed = (repeat each values)
 self.suffix = suffix
 }
}

suite.test("MixedProperties") {
 let s = MixedProperties(prefix: 10, suffix: "end", 3.14, "middle")
 expectEqual(10, s.prefix)
 expectEqual(3.14, s.packed.0)
 expectEqual("middle", s.packed.1)
 expectEqual("end", s.suffix)
}

// MARK: - Conditional initialization

struct ConditionalInit<each T> {
 let values: (repeat each T)
 let flag: Bool

 init(condition: Bool, _ values: repeat each T) {
 self.flag = condition
 if condition {
 self.values = (repeat each values)
 } else {
 self.values = (repeat each values)
 }
 }
}

suite.test("ConditionalInit true branch") {
 let s = ConditionalInit(condition: true, "a", "b")
 expectTrue(s.flag)
 expectEqual("a", s.values.0)
 expectEqual("b", s.values.1)
}

suite.test("ConditionalInit false branch") {
 let s = ConditionalInit(condition: false, 1, 2, 3)
 expectFalse(s.flag)
 expectEqual(1, s.values.0)
 expectEqual(2, s.values.1)
 expectEqual(3, s.values.2)
}

// MARK: - Nested struct

struct Outer<each T> {
 struct Inner {
 let data: (repeat each T)

 init(_ values: repeat each T) {
 self.data = (repeat each values)
 }
 }

 let inner: Inner

 init(_ values: repeat each T) {
 self.inner = Inner(repeat each values)
 }
}

suite.test("Nested struct") {
 let s = Outer(100, 200)
 expectEqual(100, s.inner.data.0)
 expectEqual(200, s.inner.data.1)
}

// MARK: - Class with pack expansion tuple

class ClassWithPackTuple<each T> {
 let values: (repeat each T)

 init(_ values: repeat each T) {
 self.values = (repeat each values)
 }
}

suite.test("Class with pack tuple") {
 let c = ClassWithPackTuple("x", "y", "z")
 expectEqual("x", c.values.0)
 expectEqual("y", c.values.1)
 expectEqual("z", c.values.2)
}

// MARK: - Failable initializer

struct FailablePackInit<each T> {
 let values: (repeat each T)

 init?(_ values: repeat each T, shouldFail: Bool) {
 if shouldFail {
 return nil
 }
 self.values = (repeat each values)
 }
}

suite.test("Failable init success") {
 let s = FailablePackInit(1, 2, shouldFail: false)
 expectNotNil(s)
 expectEqual(1, s!.values.0)
 expectEqual(2, s!.values.1)
}

suite.test("Failable init failure") {
 let s = FailablePackInit(1, 2, shouldFail: true)
 expectNil(s)
}

// MARK: - Throwing initializer

struct ThrowingPackInit<each T> {
 let values: (repeat each T)

 init(_ values: repeat each T) throws {
 self.values = (repeat each values)
 }
}

suite.test("Throwing init") {
 do {
 let s = try ThrowingPackInit("a", "b")
 expectEqual("a", s.values.0)
 expectEqual("b", s.values.1)
 } catch {
 expectUnreachable("Should not throw")
 }
}

// MARK: - Throwing initializer with pack expansion tuple (crash case)
// This is a minimal reproducer for the DI crash. The crash occurs when:
// 1. Struct has multiple properties including a pack expansion tuple
// 2. Throwing initializer where a throwing call comes AFTER the pack tuple assignment
// 3. DI generates cleanup code that incorrectly uses tuple_element_addr on the pack tuple

func produceValue<T>(type: T.Type) -> T {
 fatalError("not called in test")
}

func produceInt() throws -> Int {
 return 42
}

struct ThrowingContainer<each Input> {
 let inputs: (repeat each Input)
 let tag: Int

 init() throws {
 self.inputs = (repeat produceValue(type: (each Input).self))
 self.tag = try produceInt()
 }

 init(inputs: repeat each Input, tag: Int) {
 self.inputs = (repeat each inputs)
 self.tag = tag
 }
}

suite.test("Throwing init with pack tuple - success path") {
 // Use the non-throwing init for runtime test
 let c = ThrowingContainer<Int, String>(inputs: 42, "test", tag: 99)
 expectEqual(42, c.inputs.0)
 expectEqual("test", c.inputs.1)
 expectEqual(99, c.tag)
}

runAllTests()
```

## Crash trace

```
Stack dump:
0.	Program arguments: […elided…]
1.	Swift version 6.3.2-dev (LLVM 4e6cdf5caf79efb, Swift d23e82655fe203f)
2.	Compiling with effective version 4.1.50
3.	While verifying SIL function "@$s4main17ThrowingContainerVACyxxQp_QPGyKcfC".
 for 'init()' (at /Users/alex.reilly/Documents/OpenSource/swift-6.3-test/test/Interpreter/variadic_generic_tuple_init.swift:195:3)
 #0 0x0000000106a7cb30 llvm::sys::PrintStackTrace(llvm::raw_ostream&, int) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x105a80b30)
 #1 0x0000000106a7abec llvm::sys::RunSignalHandlers() (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x105a7ebec)
 #2 0x0000000106a7d5d8 SignalHandler(int, __siginfo*, void*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x105a815d8)
 #3 0x000000018f4ed7a4 (/usr/lib/system/libsystem_platform.dylib+0x1804f97a4)
 #4 0x000000018f4e38d8 (/usr/lib/system/libsystem_pthread.dylib+0x1804ef8d8)
 #5 0x000000018f3ea790 (/usr/lib/system/libsystem_c.dylib+0x1803f6790)
 #6 0x0000000101c9b4dc swift::verificationFailure(llvm::Twine const&, swift::SILInstruction const*, llvm::function_ref<void (swift::SILPrintContext&)>) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100c9f4dc)
 #7 0x0000000101ca3e30 swift::SILVisitorBase<(anonymous namespace)::SILVerifier, void>::visitSILBasicBlock(swift::SILBasicBlock*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100ca7e30)
 #8 0x0000000101ca28c4 (anonymous namespace)::SILVerifier::visitSILBasicBlock(swift::SILBasicBlock*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100ca68c4)
 #9 0x0000000101c9e00c swift::SILFunction::verify(swift::CalleeCache*, bool, bool, bool) const (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100ca200c)
#10 0x0000000101ca15dc swift::SILModule::verify(swift::CalleeCache*, bool, bool) const (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100ca55dc)
#11 0x0000000101ca14e0 swift::SILModule::verify(bool, bool) const (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100ca54e0)
#12 0x00000001014f3a50 swift::CompilerInstance::performSILProcessing(swift::SILModule*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1004f7a50)
#13 0x000000010129d7ec performCompileStepsPostSILGen(swift::CompilerInstance&, std::__1::unique_ptr<swift::SILModule, std::__1::default_delete<swift::SILModule>>, llvm::PointerUnion<swift::ModuleDecl*, swift::SourceFile*>, swift::PrimarySpecificPaths const&, int&, swift::FrontendObserver*, llvm::ArrayRef<char const*>) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1002a17ec)
#14 0x000000010129cc60 swift::performCompileStepsPostSema(swift::CompilerInstance&, int&, swift::FrontendObserver*, llvm::ArrayRef<char const*>) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1002a0c60)
#15 0x00000001012acff4 withSemanticAnalysis(swift::CompilerInstance&, swift::FrontendObserver*, llvm::function_ref<bool (swift::CompilerInstance&)>, bool) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1002b0ff4)
#16 0x00000001012a0a40 performCompile(swift::CompilerInstance&, int&, swift::FrontendObserver*, llvm::ArrayRef<char const*>) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1002a4a40)
#17 0x000000010129e5f4 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1002a25f4)
#18 0x0000000101034790 swift::mainEntry(int, char const**) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100038790)
#19 0x000000018f127da4
<unknown>:0: error: unable to execute command: Abort trap: 6
<unknown>:0: error: compile command failed due to signal 6 (use -v to see invocation)

--

********************

2 warning(s) in tests
********************
```
