### PR TITLE
[release/6.3] Add regression test: keypath parameter pack (compiler crash)

### DIFF
--- a/test/IRGen/keypath_parameter_pack.swift
+++ b/test/IRGen/keypath_parameter_pack.swift
@@ -1,0 +1,19 @@
+// RUN: %target-swift-frontend -emit-ir %s -target %target-swift-5.9-abi-triple | %FileCheck %s
+
+// REQUIRES: swift_feature_ParameterPacks
+
+// Test that key paths on types containing parameter packs compile successfully.
+
+struct Entry<each T> {
+    let input: (repeat each T)
+}
+
+struct Container<each T> {
+    let entries: [Entry<repeat each T>]
+
+    var inputs: [(repeat each T)] {
+        entries.map(\.input)
+    }
+}
+
+// CHECK: @keypath = private global


### PR DESCRIPTION
## Summary

Test that key paths on types containing parameter packs compile successfully.

## Failure category

`compiler-crash` — The compiler crashes when processing this source.

## Reproduction

Branch: `test-survey/IRGen_keypath_parameter_pack` (off `release/6.3`).
Test file: `test/IRGen/keypath_parameter_pack.swift`
Run: `lit -v test/IRGen/keypath_parameter_pack.swift`

## Test source (`test/IRGen/keypath_parameter_pack.swift`)

```swift
// RUN: %target-swift-frontend -emit-ir %s -target %target-swift-5.9-abi-triple | %FileCheck %s

// REQUIRES: swift_feature_ParameterPacks

// Test that key paths on types containing parameter packs compile successfully.

struct Entry<each T> {
 let input: (repeat each T)
}

struct Container<each T> {
 let entries: [Entry<repeat each T>]

 var inputs: [(repeat each T)] {
 entries.map(\.input)
 }
}

// CHECK: @keypath = private global
```

## Crash trace

```
Assertion failed: (metadata.GenericPackArguments.empty() && "We don't support packs here yet"), function operator(), file GenProto.cpp, line 4655.
Please submit a bug report (https://swift.org/contributing/#reporting-bugs) and include the crash backtrace.
Stack dump:
0.	Program arguments: […elided…]
1.	Swift version 6.3.2-dev (LLVM 4e6cdf5caf79efb, Swift d23e82655fe203f)
2.	Compiling with effective version 4.1.50
3.	While evaluating request IRGenRequest(IR Generation for module keypath_parameter_pack)
4.	While emitting IR SIL function "@$s22keypath_parameter_pack9ContainerV6inputsSayxxQp_tGvg".
 for getter for inputs (at /Users/alex.reilly/Documents/OpenSource/swift-6.3-test/test/IRGen/keypath_parameter_pack.swift:14:9)
 #0 0x00000001089ecb30 llvm::sys::PrintStackTrace(llvm::raw_ostream&, int) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x105a80b30)
 #1 0x00000001089eabec llvm::sys::RunSignalHandlers() (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x105a7ebec)
 #2 0x00000001089ed5d8 SignalHandler(int, __siginfo*, void*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x105a815d8)
 #3 0x000000018f4ed7a4 (/usr/lib/system/libsystem_platform.dylib+0x1804f97a4)
 #4 0x000000018f4e38d8 (/usr/lib/system/libsystem_pthread.dylib+0x1804ef8d8)
 #5 0x000000018f3ea790 (/usr/lib/system/libsystem_c.dylib+0x1803f6790)
 #6 0x000000018f3e99ec (/usr/lib/system/libsystem_c.dylib+0x1803f59ec)
 #7 0x0000000108a0bf5c ReflectionMetadataBuilder::~ReflectionMetadataBuilder() (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x105a9ff5c)
 #8 0x0000000103678d6c clang::CodeGen::ConstantInitFuture llvm::function_ref<clang::CodeGen::ConstantInitFuture (swift::irgen::ConstantInitBuilder&)>::callback_fn<swift::irgen::IRGenModule::getAddrOfGenericEnvironment(swift::CanGenericSignature)::$_0>(long, swift::irgen::ConstantInitBuilder&) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x10070cd6c)
 #9 0x0000000103770e78 swift::irgen::IRGenModule::getAddrOfStringForMetadataRef(llvm::StringRef, unsigned int, bool, llvm::function_ref<clang::CodeGen::ConstantInitFuture (swift::irgen::ConstantInitBuilder&)>) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100804e78)
#10 0x0000000103672fa4 swift::irgen::IRGenModule::getAddrOfGenericEnvironment(swift::CanGenericSignature) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100706fa4)
#11 0x000000010362d838 swift::irgen::IRGenModule::getAddrOfKeyPathPattern(swift::KeyPathPattern*, swift::SILLocation) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1006c1838)
#12 0x00000001037119e8 (anonymous namespace)::IRGenSILFunction::visitSILBasicBlock(swift::SILBasicBlock*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1007a59e8)
#13 0x000000010370db40 (anonymous namespace)::IRGenSILFunction::emitSILFunction() (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1007a1b40)
#14 0x000000010370b254 swift::irgen::IRGenModule::emitSILFunction(swift::SILFunction*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x10079f254)
#15 0x00000001035bbb2c swift::irgen::IRGenerator::emitGlobalTopLevel(std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>> const&) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x10064fb2c)
#16 0x00000001036c1cb4 swift::IRGenRequest::evaluate(swift::Evaluator&, swift::IRGenDescriptor) const (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100755cb4)
#17 0x000000010370a378 swift::GeneratedModule swift::SimpleRequest<swift::IRGenRequest, swift::GeneratedModule (swift::IRGenDescriptor), (swift::RequestFlags)17>::callDerived<0ul>(swift::Evaluator&, std::__1::integer_sequence<unsigned long, 0ul>) const (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x10079e378)
#18 0x0000000102fc6cc4 swift::IRGenRequest::OutputType swift::Evaluator::getResultUncached<swift::IRGenRequest, swift::IRGenRequest::OutputType swift::evaluateOrFatal<swift::IRGenRequest>(swift::Evaluator&, swift::IRGenRequest)::'lambda'()>(swift::IRGenRequest const&, swift::IRGenRequest::OutputType swift::evaluateOrFatal<swift::IRGenRequest>(swift::Evaluator&, swift::IRGenRequest)::'lambda'())::'lambda'()::operator()() const (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAss […truncated…]
#19 0x0000000102fc691c swift::IRGenRequest::OutputType swift::Evaluator::getResultUncached<swift::IRGenRequest, swift::IRGenRequest::OutputType swift::evaluateOrFatal<swift::IRGenRequest>(swift::Evaluator&, swift::IRGenRequest)::'lambda'()>(swift::IRGenRequest const&, swift::IRGenRequest::OutputType swift::evaluateOrFatal<swift::IRGenRequest>(swift::Evaluator&, swift::IRGenRequest)::'lambda'()) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/ […truncated…]
#20 0x00000001036c2b7c swift::performIRGeneration(swift::ModuleDecl*, swift::IRGenOptions const&, swift::TBDGenOptions const&, std::__1::unique_ptr<swift::SILModule, std::__1::default_delete<swift::SILModule>>, llvm::StringRef, swift::PrimarySpecificPaths const&, std::__1::shared_ptr<llvm::cas::ObjectStore>, llvm::ArrayRef<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>, llvm::ArrayRef<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::alloc […truncated…]
#21 0x0000000103213054 generateIR(swift::IRGenOptions const&, swift::TBDGenOptions const&, std::__1::unique_ptr<swift::SILModule, std::__1::default_delete<swift::SILModule>>, swift::PrimarySpecificPaths const&, std::__1::shared_ptr<llvm::cas::ObjectStore>, swift::cas::SwiftCASOutputBackend*, llvm::StringRef, llvm::PointerUnion<swift::ModuleDecl*, swift::SourceFile*>, llvm::GlobalVariable*&, llvm::ArrayRef<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>, llvm […truncated…]
#22 0x000000010320dae4 performCompileStepsPostSILGen(swift::CompilerInstance&, std::__1::unique_ptr<swift::SILModule, std::__1::default_delete<swift::SILModule>>, llvm::PointerUnion<swift::ModuleDecl*, swift::SourceFile*>, swift::PrimarySpecificPaths const&, int&, swift::FrontendObserver*, llvm::ArrayRef<char const*>) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1002a1ae4)
#23 0x000000010320d394 swift::performCompileStepsPostSema(swift::CompilerInstance&, int&, swift::FrontendObserver*, llvm::ArrayRef<char const*>) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1002a1394)
#24 0x000000010321cff4 withSemanticAnalysis(swift::CompilerInstance&, swift::FrontendObserver*, llvm::function_ref<bool (swift::CompilerInstance&)>, bool) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1002b0ff4)
#25 0x0000000103210a40 performCompile(swift::CompilerInstance&, int&, swift::FrontendObserver*, llvm::ArrayRef<char const*>) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1002a4a40)
#26 0x000000010320e5f4 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1002a25f4)
#27 0x0000000102fa4790 swift::mainEntry(int, char const**) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100038790)
#28 0x000000018f127da4
FileCheck error: '<stdin>' is empty.
FileCheck command line: /Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/llvm-macosx-arm64/bin/FileCheck --allow-unused-prefixes /Users/alex.reilly/Documents/OpenSource/swift-6.3-test/test/IRGen/keypath_parameter_pack.swift

--

********************

2 warning(s) in tests
********************
```
