### PR TITLE
[release/6.3] Add regression test: round-trip-debug-types-pack-expansion (compiler crash)

### DIFF
--- a/test/IRGen/round-trip-debug-types-pack-expansion.swift
+++ b/test/IRGen/round-trip-debug-types-pack-expansion.swift
@@ -1,0 +1,23 @@
+// RUN: %target-swift-frontend -emit-ir -g %s -target %target-swift-5.9-abi-triple
+
+// https://github.com/apple/swift/issues/XXXXX
+// IRGenDebugInfo type reconstruction crash with parameter packs and optional
+// existential types. The combination of:
+// 1. Optional existential type: (any Sendable)?
+// 2. Parameter pack with consuming ownership: consuming (repeat each T)
+// 3. Both in the same function type
+// would cause a crash in getMangledName due to type comparison failure
+// during the debug type round-trip verification.
+
+actor Machine<each Input: Sendable> {
+  typealias Fn = (
+    (any Sendable)?,
+    consuming (repeat each Input)
+  ) -> Void
+
+  private let fn: Fn
+
+  init(fn: @escaping Fn) {
+    self.fn = fn
+  }
+}


### PR DESCRIPTION
## Summary

 IRGenDebugInfo type reconstruction crash with parameter packs and optional existential types. The combination of: 1. Optional existential type: (any Sendable)? 2. Parameter pack with consuming ownership: consuming (repeat each T) 3. Both in the same function type would cause a crash in getMangledName due to type comparison failure during the debug type round-trip verification.

## Failure category

`compiler-crash` — The compiler crashes when processing this source.

## Reproduction

Branch: `test-survey/IRGen_round-trip-debug-types-pack-expansion` (off `release/6.3`).
Test file: `test/IRGen/round-trip-debug-types-pack-expansion.swift`
Run: `lit -v test/IRGen/round-trip-debug-types-pack-expansion.swift`

## Test source (`test/IRGen/round-trip-debug-types-pack-expansion.swift`)

```swift
// RUN: %target-swift-frontend -emit-ir -g %s -target %target-swift-5.9-abi-triple

// IRGenDebugInfo type reconstruction crash with parameter packs and optional
// existential types. The combination of:
// 1. Optional existential type: (any Sendable)?
// 2. Parameter pack with consuming ownership: consuming (repeat each T)
// 3. Both in the same function type
// would cause a crash in getMangledName due to type comparison failure
// during the debug type round-trip verification.

actor Machine<each Input: Sendable> {
 typealias Fn = (
 (any Sendable)?,
 consuming (repeat each Input)
 ) -> Void

 private let fn: Fn

 init(fn: @escaping Fn) {
 self.fn = fn
 }
}
```

## Crash trace

```
Stack dump:
0.	Program arguments: […elided…]
1.	Swift version 6.3.2-dev (LLVM 4e6cdf5caf79efb, Swift d23e82655fe203f)
2.	Compiling with effective version 4.1.50
3.	While evaluating request IRGenRequest(IR Generation for module main)
4.	While emitting IR SIL function "@$s4main7MachineC2fnACyxxQp_QPGys8Sendable_pSg_xxQp_tntc_tcfc".
 for 'init(fn:)' (at /Users/alex.reilly/Documents/OpenSource/swift-6.3-test/test/IRGen/round-trip-debug-types-pack-expansion.swift:20:3)
5.	Abort: function getMangledName at IRGenDebugInfo.cpp:1116
| 	Incorrect reconstructed type for $sys8Sendable_pXSq_xxQp_tntcD
| 	Original type:
| 	(function_type escaping
| 	 (input=function_params num_params=2
| 	 (param
| 	 (optional_type
| 	 (existential_type
| 	 (protocol_type decl="Swift.(file).Sendable"))))
| 	 (param owned
| 	 (tuple_type num_elements=1
| 	 (tuple_type_elt
| 	 (pack_expansion_type
| 	 (pattern=generic_type_param_type depth=0 index=0 name="Input" param_kind=pack)
| 	 (count=generic_type_param_type depth=0 index=0 name="Input" param_kind=pack))))))
| 	 (output=type_alias_type decl="Swift.(file).Void"
| 	 (underlying=tuple_type num_elements=0)))
| 	Reconstructed type:
| 	(function_type escaping
| 	 (input=function_params num_params=2
| 	 (param
| 	 (optional_type
| 	 (protocol_type decl="Swift.(file).Sendable")))
| 	 (param owned
| 	 (tuple_type num_elements=1
| 	 (tuple_type_elt
| 	 (pack_expansion_type
| 	 (pattern=generic_type_param_type depth=0 index=0 param_kind=pack)
| 	 (count=generic_type_param_type depth=0 index=0 param_kind=pack))))))
| 	 (output=tuple_type num_elements=0))
| 	Generic signature: <each Input where repeat each Input : Copyable, repeat each Input : Escapable, repeat each Input : Sendable>
| 	Please submit a bug report (https://swift.org/contributing/#reporting-bugs) and include the crash backtrace.
| 	Pass '-Xfrontend -disable-round-trip-debug-types' to disable this assertion.
 #0 0x0000000108940b30 llvm::sys::PrintStackTrace(llvm::raw_ostream&, int) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x105a80b30)
 #1 0x000000010893ebec llvm::sys::RunSignalHandlers() (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x105a7ebec)
 #2 0x00000001089415d8 SignalHandler(int, __siginfo*, void*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x105a815d8)
 #3 0x000000018f4ed7a4 (/usr/lib/system/libsystem_platform.dylib+0x1804f97a4)
 #4 0x000000018f4e38d8 (/usr/lib/system/libsystem_pthread.dylib+0x1804ef8d8)
 #5 0x000000018f3ea790 (/usr/lib/system/libsystem_c.dylib+0x1803f6790)
 #6 0x00000001049de644 _ABORT(char const*, int, char const*, llvm::function_ref<void (llvm::raw_ostream&)>) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x101b1e644)
 #7 0x00000001049de6f8 _ABORT(char const*, int, char const*, llvm::StringRef) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x101b1e6f8)
 #8 0x0000000103628c88 (anonymous namespace)::IRGenDebugInfoImpl::updateScope(llvm::DIScope*, swift::irgen::DebugTypeInfo) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100768c88)
 #9 0x0000000103625cdc (anonymous namespace)::IRGenDebugInfoImpl::getOrCreateType(swift::irgen::DebugTypeInfo, llvm::DIScope*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100765cdc)
#10 0x0000000103627858 (anonymous namespace)::IRGenDebugInfoImpl::createType(swift::irgen::DebugTypeInfo, llvm::StringRef, llvm::DIScope*, llvm::DIFile*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100767858)
#11 0x0000000103625e34 (anonymous namespace)::IRGenDebugInfoImpl::getOrCreateType(swift::irgen::DebugTypeInfo, llvm::DIScope*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100765e34)
#12 0x0000000103629a14 (anonymous namespace)::IRGenDebugInfoImpl::createSpecializedStructOrClassType(swift::NominalOrBoundGenericNominalType*, llvm::DIScope*, llvm::DIFile*, unsigned int, unsigned int, unsigned int, llvm::DINode::DIFlags, llvm::StringRef, bool) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100769a14)
#13 0x0000000103627904 (anonymous namespace)::IRGenDebugInfoImpl::createType(swift::irgen::DebugTypeInfo, llvm::StringRef, llvm::DIScope*, llvm::DIFile*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100767904)
#14 0x0000000103625e34 (anonymous namespace)::IRGenDebugInfoImpl::getOrCreateType(swift::irgen::DebugTypeInfo, llvm::DIScope*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100765e34)
#15 0x0000000103620e90 (anonymous namespace)::IRGenDebugInfoImpl::emitVariableDeclaration(swift::irgen::IRBuilder&, llvm::ArrayRef<llvm::Value*>, swift::irgen::DebugTypeInfo, swift::SILDebugScope const*, std::__1::optional<swift::SILLocation>, swift::SILDebugVariable, swift::irgen::IndirectionKind, swift::irgen::ArtificialKind, swift::irgen::AddrDbgInstrKind) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100760e90)
#16 0x0000000103620cfc swift::irgen::IRGenDebugInfo::emitVariableDeclaration(swift::irgen::IRBuilder&, llvm::ArrayRef<llvm::Value*>, swift::irgen::DebugTypeInfo, swift::SILDebugScope const*, std::__1::optional<swift::SILLocation>, swift::SILDebugVariable, swift::irgen::IndirectionKind, swift::irgen::ArtificialKind, swift::irgen::AddrDbgInstrKind) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100760cfc)
#17 0x0000000103670264 (anonymous namespace)::IRGenSILFunction::visitSILBasicBlock(swift::SILBasicBlock*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1007b0264)
#18 0x0000000103661b40 (anonymous namespace)::IRGenSILFunction::emitSILFunction() (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1007a1b40)
#19 0x000000010365f254 swift::irgen::IRGenModule::emitSILFunction(swift::SILFunction*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x10079f254)
#20 0x000000010350fb2c swift::irgen::IRGenerator::emitGlobalTopLevel(std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>> const&) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x10064fb2c)
#21 0x0000000103615cb4 swift::IRGenRequest::evaluate(swift::Evaluator&, swift::IRGenDescriptor) const (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100755cb4)
#22 0x000000010365e378 swift::GeneratedModule swift::SimpleRequest<swift::IRGenRequest, swift::GeneratedModule (swift::IRGenDescriptor), (swift::RequestFlags)17>::callDerived<0ul>(swift::Evaluator&, std::__1::integer_sequence<unsigned long, 0ul>) const (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x10079e378)
#23 0x0000000102f1acc4 swift::IRGenRequest::OutputType swift::Evaluator::getResultUncached<swift::IRGenRequest, swift::IRGenRequest::OutputType swift::evaluateOrFatal<swift::IRGenRequest>(swift::Evaluator&, swift::IRGenRequest)::'lambda'()>(swift::IRGenRequest const&, swift::IRGenRequest::OutputType swift::evaluateOrFatal<swift::IRGenRequest>(swift::Evaluator&, swift::IRGenRequest)::'lambda'())::'lambda'()::operator()() const (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAss […truncated…]
#24 0x0000000102f1a91c swift::IRGenRequest::OutputType swift::Evaluator::getResultUncached<swift::IRGenRequest, swift::IRGenRequest::OutputType swift::evaluateOrFatal<swift::IRGenRequest>(swift::Evaluator&, swift::IRGenRequest)::'lambda'()>(swift::IRGenRequest const&, swift::IRGenRequest::OutputType swift::evaluateOrFatal<swift::IRGenRequest>(swift::Evaluator&, swift::IRGenRequest)::'lambda'()) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/ […truncated…]
#25 0x0000000103616b7c swift::performIRGeneration(swift::ModuleDecl*, swift::IRGenOptions const&, swift::TBDGenOptions const&, std::__1::unique_ptr<swift::SILModule, std::__1::default_delete<swift::SILModule>>, llvm::StringRef, swift::PrimarySpecificPaths const&, std::__1::shared_ptr<llvm::cas::ObjectStore>, llvm::ArrayRef<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>, llvm::ArrayRef<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::alloc […truncated…]
#26 0x0000000103167054 generateIR(swift::IRGenOptions const&, swift::TBDGenOptions const&, std::__1::unique_ptr<swift::SILModule, std::__1::default_delete<swift::SILModule>>, swift::PrimarySpecificPaths const&, std::__1::shared_ptr<llvm::cas::ObjectStore>, swift::cas::SwiftCASOutputBackend*, llvm::StringRef, llvm::PointerUnion<swift::ModuleDecl*, swift::SourceFile*>, llvm::GlobalVariable*&, llvm::ArrayRef<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>, llvm […truncated…]
#27 0x0000000103161ae4 performCompileStepsPostSILGen(swift::CompilerInstance&, std::__1::unique_ptr<swift::SILModule, std::__1::default_delete<swift::SILModule>>, llvm::PointerUnion<swift::ModuleDecl*, swift::SourceFile*>, swift::PrimarySpecificPaths const&, int&, swift::FrontendObserver*, llvm::ArrayRef<char const*>) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1002a1ae4)
#28 0x0000000103161394 swift::performCompileStepsPostSema(swift::CompilerInstance&, int&, swift::FrontendObserver*, llvm::ArrayRef<char const*>) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1002a1394)
#29 0x0000000103170ff4 withSemanticAnalysis(swift::CompilerInstance&, swift::FrontendObserver*, llvm::function_ref<bool (swift::CompilerInstance&)>, bool) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1002b0ff4)
#30 0x0000000103164a40 performCompile(swift::CompilerInstance&, int&, swift::FrontendObserver*, llvm::ArrayRef<char const*>) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1002a4a40)
#31 0x00000001031625f4 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1002a25f4)
#32 0x0000000102ef8790 swift::mainEntry(int, char const**) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100038790)
#33 0x000000018f127da4
```
