### PR TITLE
[release/6.3] Add regression test: coverage isolated deinit skipped body (compiler crash)

### DIFF
--- a/test/Profiler/coverage_isolated_deinit_skipped_body.swift
+++ b/test/Profiler/coverage_isolated_deinit_skipped_body.swift
@@ -1,0 +1,17 @@
+// Make sure we don't crash when an isolated deinit body is skipped but
+// coverage instrumentation is enabled.
+// RUN: %target-swift-frontend -emit-module -experimental-skip-non-inlinable-function-bodies-without-types -profile-generate -profile-coverage-mapping %s
+
+// REQUIRES: concurrency
+
+final class Resource {
+    func cleanup() {}
+}
+
+public actor MyActor {
+    private let resource = Resource()
+
+    isolated deinit {
+        resource.cleanup()
+    }
+}


### PR DESCRIPTION
## Summary

Make sure we don't crash when an isolated deinit body is skipped but coverage instrumentation is enabled.

## Failure category

`compiler-crash` — The compiler crashes when processing this source.

## Reproduction

Branch: `test-survey/Profiler_coverage_isolated_deinit_skipped_body` (off `release/6.3`).
Test file: `test/Profiler/coverage_isolated_deinit_skipped_body.swift`
Run: `lit -v test/Profiler/coverage_isolated_deinit_skipped_body.swift`

## Test source (`test/Profiler/coverage_isolated_deinit_skipped_body.swift`)

```swift
// Make sure we don't crash when an isolated deinit body is skipped but
// coverage instrumentation is enabled.
// RUN: %target-swift-frontend -emit-module -experimental-skip-non-inlinable-function-bodies-without-types -profile-generate -profile-coverage-mapping %s

// REQUIRES: concurrency

final class Resource {
 func cleanup() {}
}

public actor MyActor {
 private let resource = Resource()

 isolated deinit {
 resource.cleanup()
 }
}
```

## Crash trace

```
Assertion failed: (Bits.ApplyExpr.ThrowsIsSet), function throws, file Expr.h, line 4987.
Please submit a bug report (https://swift.org/contributing/#reporting-bugs) and include the crash backtrace.
Stack dump:
0.	Program arguments: […elided…]
1.	Swift version 6.3.2-dev (LLVM 4e6cdf5caf79efb, Swift d23e82655fe203f)
2.	Compiling with effective version 4.1.50
3.	While evaluating request ASTLoweringRequest(Lowering AST to SIL for module coverage_isolated_deinit_skipped_body)
4.	While silgen emitIsolatingDestructor SIL function "@$s37coverage_isolated_deinit_skipped_body7MyActorCfD".
 for 'deinit' (at /Users/alex.reilly/Documents/OpenSource/swift-6.3-test/test/Profiler/coverage_isolated_deinit_skipped_body.swift:14:14)
5.	While walking into body of 'deinit' (at /Users/alex.reilly/Documents/OpenSource/swift-6.3-test/test/Profiler/coverage_isolated_deinit_skipped_body.swift:14:14)
 #0 0x0000000109b70b30 llvm::sys::PrintStackTrace(llvm::raw_ostream&, int) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x105a80b30)
 #1 0x0000000109b6ebec llvm::sys::RunSignalHandlers() (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x105a7ebec)
 #2 0x0000000109b715d8 SignalHandler(int, __siginfo*, void*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x105a815d8)
 #3 0x000000018f4ed7a4 (/usr/lib/system/libsystem_platform.dylib+0x1804f97a4)
 #4 0x000000018f4e38d8 (/usr/lib/system/libsystem_pthread.dylib+0x1804ef8d8)
 #5 0x000000018f3ea790 (/usr/lib/system/libsystem_c.dylib+0x1803f6790)
 #6 0x000000018f3e99ec (/usr/lib/system/libsystem_c.dylib+0x1803f59ec)
 #7 0x0000000109b9e9ec (anonymous namespace)::CallEmission::apply(swift::Lowering::SGFContext) (.cold.2) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x105aae9ec)
 #8 0x0000000104cbd3b8 (anonymous namespace)::mayExpressionThrow(swift::Expr const*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100bcd3b8)
 #9 0x0000000104cbcae0 (anonymous namespace)::MapRegionCounters::walkToExprPost(swift::Expr*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100bccae0)
#10 0x00000001058762c8 (anonymous namespace)::Traversal::doIt(swift::Expr*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1017862c8)
#11 0x0000000105877f60 swift::Stmt* llvm::function_ref<swift::Stmt* (swift::Stmt*)>::callback_fn<(anonymous namespace)::Traversal::doIt(swift::Stmt*)::'lambda'(swift::Stmt*)>(long, swift::Stmt*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x101787f60)
#12 0x0000000105877c78 swift::Stmt* (anonymous namespace)::Traversal::traverse<swift::Stmt>(swift::ASTWalker::PreWalkResult<swift::Stmt*>, llvm::function_ref<swift::Stmt* (swift::Stmt*)>, llvm::function_ref<swift::ASTWalker::PostWalkResult<swift::Stmt*> (swift::Stmt*)>) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x101787c78)
#13 0x000000010587a3f8 (anonymous namespace)::Traversal::visitAbstractFunctionDecl(swift::AbstractFunctionDecl*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x10178a3f8)
#14 0x00000001058790e8 (anonymous namespace)::Traversal::visit(swift::Decl*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1017890e8)
#15 0x0000000105876910 (anonymous namespace)::Traversal::doIt(swift::Decl*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x101786910)
#16 0x00000001058767e8 swift::Decl::walk(swift::ASTWalker&) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1017867e8)
#17 0x0000000104cbb98c swift::SILProfiler::assignRegionCounters() (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100bcb98c)
#18 0x0000000104cbb5c0 swift::SILProfiler::create(swift::SILModule&, swift::SILDeclRef) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100bcb5c0)
#19 0x0000000104c1b8ec swift::SILFunction::createProfiler(swift::SILDeclRef) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100b2b8ec)
#20 0x0000000104956b38 swift::Lowering::SILGenModule::emitFunctionDefinition(swift::SILDeclRef, swift::SILFunction*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100866b38)
#21 0x00000001049598bc swift::Lowering::SILGenModule::emitDestructor(swift::ClassDecl*, swift::DestructorDecl*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1008698bc)
#22 0x0000000104a65bf8 (anonymous namespace)::SILGenType::emitType() (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100975bf8)
#23 0x0000000104a65a10 swift::Lowering::SILGenModule::visitNominalTypeDecl(swift::NominalTypeDecl*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100975a10)
#24 0x000000010495a9d0 swift::Lowering::SILGenModule::emitSourceFile(swift::SourceFile*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x10086a9d0)
#25 0x000000010495aebc swift::ASTLoweringRequest::evaluate(swift::Evaluator&, swift::ASTLoweringDescriptor) const (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x10086aebc)
#26 0x0000000104a539a0 swift::SimpleRequest<swift::ASTLoweringRequest, std::__1::unique_ptr<swift::SILModule, std::__1::default_delete<swift::SILModule>> (swift::ASTLoweringDescriptor), (swift::RequestFlags)17>::evaluateRequest(swift::ASTLoweringRequest const&, swift::Evaluator&) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1009639a0)
#27 0x000000010495eb50 swift::ASTLoweringRequest::OutputType swift::Evaluator::getResultUncached<swift::ASTLoweringRequest, swift::ASTLoweringRequest::OutputType swift::evaluateOrFatal<swift::ASTLoweringRequest>(swift::Evaluator&, swift::ASTLoweringRequest)::'lambda'()>(swift::ASTLoweringRequest const&, swift::ASTLoweringRequest::OutputType swift::evaluateOrFatal<swift::ASTLoweringRequest>(swift::Evaluator&, swift::ASTLoweringRequest)::'lambda'())::'lambda'()::operator()() const (/Users/alex.rei […truncated…]
#28 0x000000010495ea6c swift::ASTLoweringRequest::OutputType swift::Evaluator::getResultUncached<swift::ASTLoweringRequest, swift::ASTLoweringRequest::OutputType swift::evaluateOrFatal<swift::ASTLoweringRequest>(swift::Evaluator&, swift::ASTLoweringRequest)::'lambda'()>(swift::ASTLoweringRequest const&, swift::ASTLoweringRequest::OutputType swift::evaluateOrFatal<swift::ASTLoweringRequest>(swift::Evaluator&, swift::ASTLoweringRequest)::'lambda'()) (/Users/alex.reilly/Documents/OpenSource/build/N […truncated…]
#29 0x000000010495b190 swift::performASTLowering(swift::ModuleDecl*, swift::Lowering::TypeConverter&, swift::SILOptions const&, swift::IRGenOptions const*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x10086b190)
#30 0x0000000104391368 swift::performCompileStepsPostSema(swift::CompilerInstance&, int&, swift::FrontendObserver*, llvm::ArrayRef<char const*>) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1002a1368)
#31 0x00000001043a0ff4 withSemanticAnalysis(swift::CompilerInstance&, swift::FrontendObserver*, llvm::function_ref<bool (swift::CompilerInstance&)>, bool) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1002b0ff4)
#32 0x0000000104394a40 performCompile(swift::CompilerInstance&, int&, swift::FrontendObserver*, llvm::ArrayRef<char const*>) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1002a4a40)
#33 0x00000001043925f4 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1002a25f4)
#34 0x0000000104128790 swift::mainEntry(int, char const**) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100038790)
 […further frames elided…]
```
