### PR TITLE
[release/6.3] Add regression test: pack default argument inlinable (type inference fails)

### DIFF
--- a/test/Sema/pack_default_argument_inlinable.swift
+++ b/test/Sema/pack_default_argument_inlinable.swift
@@ -1,0 +1,59 @@
+// RUN: %target-swift-frontend -typecheck %s
+
+// Test that @inlinable functions with parameter pack default arguments
+// work correctly. This tests SameShape requirement handling in
+// TypeCheckConstraints.cpp for default argument expressions.
+
+public protocol Plugin {
+    func handle()
+}
+
+public struct DefaultPlugin: Plugin {
+    public init() {}
+    public func handle() {}
+}
+
+public struct OtherPlugin: Plugin {
+    public init() {}
+    public func handle() {}
+}
+
+@usableFromInline
+struct Processor<each P: Plugin> {
+    @usableFromInline let plugins: (repeat each P)
+    @usableFromInline init(plugins: (repeat each P)) { self.plugins = plugins }
+}
+
+// Test @inlinable with parameter pack default arguments
+@inlinable
+public func process<each D: Plugin, each P: Plugin>(
+    defaults: (repeat each D) = (DefaultPlugin()),
+    plugins: (repeat each P) = ()
+) {
+    let _ = Processor(plugins: defaults)
+    let _ = Processor(plugins: plugins)
+}
+
+// Test with multiple pack parameters having defaults
+@inlinable
+public func multiProcess<each A: Plugin, each B: Plugin, each C: Plugin>(
+    first: (repeat each A) = (DefaultPlugin()),
+    second: (repeat each B) = (DefaultPlugin(), OtherPlugin()),
+    third: (repeat each C) = ()
+) {
+    let _ = Processor(plugins: first)
+    let _ = Processor(plugins: second)
+    let _ = Processor(plugins: third)
+}
+
+// Verify calling works
+public func testCalls() {
+    process()
+    process(defaults: (DefaultPlugin(), OtherPlugin()))
+    process(plugins: (DefaultPlugin(),))
+    process(defaults: (DefaultPlugin(),), plugins: (OtherPlugin(),))
+
+    multiProcess()
+    multiProcess(first: (OtherPlugin(),))
+    multiProcess(second: (DefaultPlugin(),))
+}


### PR DESCRIPTION
## Summary

Test that @inlinable functions with parameter pack default arguments work correctly. This tests SameShape requirement handling in TypeCheckConstraints.cpp for default argument expressions.

## Failure category

`type-inference-fail` — The type checker fails to infer types for a parameter-pack-using construct that should be valid.

## Reproduction

Branch: `test-survey/Sema_pack_default_argument_inlinable` (off `release/6.3`).
Test file: `test/Sema/pack_default_argument_inlinable.swift`
Run: `lit -v test/Sema/pack_default_argument_inlinable.swift`

## Test source (`test/Sema/pack_default_argument_inlinable.swift`)

```swift
// RUN: %target-swift-frontend -typecheck %s

// Test that @inlinable functions with parameter pack default arguments
// work correctly. This tests SameShape requirement handling in
// TypeCheckConstraints.cpp for default argument expressions.

public protocol Plugin {
 func handle()
}

public struct DefaultPlugin: Plugin {
 public init() {}
 public func handle() {}
}

public struct OtherPlugin: Plugin {
 public init() {}
 public func handle() {}
}

@usableFromInline
struct Processor<each P: Plugin> {
 @usableFromInline let plugins: (repeat each P)
 @usableFromInline init(plugins: (repeat each P)) { self.plugins = plugins }
}

// Test @inlinable with parameter pack default arguments
@inlinable
public func process<each D: Plugin, each P: Plugin>(
 defaults: (repeat each D) = (DefaultPlugin()),
 plugins: (repeat each P) = ()
) {
 let _ = Processor(plugins: defaults)
 let _ = Processor(plugins: plugins)
}

// Test with multiple pack parameters having defaults
@inlinable
public func multiProcess<each A: Plugin, each B: Plugin, each C: Plugin>(
 first: (repeat each A) = (DefaultPlugin()),
 second: (repeat each B) = (DefaultPlugin(), OtherPlugin()),
 third: (repeat each C) = ()
) {
 let _ = Processor(plugins: first)
 let _ = Processor(plugins: second)
 let _ = Processor(plugins: third)
}

// Verify calling works
public func testCalls() {
 process()
 process(defaults: (DefaultPlugin(), OtherPlugin()))
 process(plugins: (DefaultPlugin(),))
 process(defaults: (DefaultPlugin(),), plugins: (OtherPlugin(),))

 multiProcess()
 multiProcess(first: (OtherPlugin(),))
 multiProcess(second: (DefaultPlugin(),))
}
```

## Compiler diagnostics

```
/Users/alex.reilly/Documents/OpenSource/swift-6.3-test/test/Sema/pack_default_argument_inlinable.swift:30:34: error: default argument value of type 'DefaultPlugin' cannot be converted to type '(repeat each D)'
28 | @inlinable
29 | public func process<each D: Plugin, each P: Plugin>(
30 | defaults: (repeat each D) = (DefaultPlugin()),
 | `- error: default argument value of type 'DefaultPlugin' cannot be converted to type '(repeat each D)'
31 | plugins: (repeat each P) = ()
32 | ) {

/Users/alex.reilly/Documents/OpenSource/swift-6.3-test/test/Sema/pack_default_argument_inlinable.swift:30:34: error: generic parameter 'each D' could not be inferred
27 | // Test @inlinable with parameter pack default arguments
28 | @inlinable
29 | public func process<each D: Plugin, each P: Plugin>(
 | `- note: in call to function 'process(defaults:plugins:)'
30 | defaults: (repeat each D) = (DefaultPlugin()),
 | `- error: generic parameter 'each D' could not be inferred
31 | plugins: (repeat each P) = ()
32 | ) {

/Users/alex.reilly/Documents/OpenSource/swift-6.3-test/test/Sema/pack_default_argument_inlinable.swift:40:31: error: default argument value of type 'DefaultPlugin' cannot be converted to type '(repeat each A)'
38 | @inlinable
39 | public func multiProcess<each A: Plugin, each B: Plugin, each C: Plugin>(
40 | first: (repeat each A) = (DefaultPlugin()),
 | `- error: default argument value of type 'DefaultPlugin' cannot be converted to type '(repeat each A)'
41 | second: (repeat each B) = (DefaultPlugin(), OtherPlugin()),
42 | third: (repeat each C) = ()

/Users/alex.reilly/Documents/OpenSource/swift-6.3-test/test/Sema/pack_default_argument_inlinable.swift:40:31: error: generic parameter 'each A' could not be inferred
37 | // Test with multiple pack parameters having defaults
38 | @inlinable
39 | public func multiProcess<each A: Plugin, each B: Plugin, each C: Plugin>(
 | `- note: in call to function 'multiProcess(first:second:third:)'
40 | first: (repeat each A) = (DefaultPlugin()),
 | `- error: generic parameter 'each A' could not be inferred
41 | second: (repeat each B) = (DefaultPlugin(), OtherPlugin()),
42 | third: (repeat each C) = ()

/Users/alex.reilly/Documents/OpenSource/swift-6.3-test/test/Sema/pack_default_argument_inlinable.swift:51:5: error: generic parameter 'each D' could not be inferred
27 | // Test @inlinable with parameter pack default arguments
28 | @inlinable
29 | public func process<each D: Plugin, each P: Plugin>(
 | `- note: in call to function 'process(defaults:plugins:)'
30 | defaults: (repeat each D) = (DefaultPlugin()),
31 | plugins: (repeat each P) = ()
 :
49 | // Verify calling works
50 | public func testCalls() {
51 | process()
 | `- error: generic parameter 'each D' could not be inferred
52 | process(defaults: (DefaultPlugin(), OtherPlugin()))
53 | process(plugins: (DefaultPlugin(),))

/Users/alex.reilly/Documents/OpenSource/swift-6.3-test/test/Sema/pack_default_argument_inlinable.swift:53:5: error: generic parameter 'each D' could not be inferred
27 | // Test @inlinable with parameter pack default arguments
28 | @inlinable
29 | public func process<each D: Plugin, each P: Plugin>(
 | `- note: in call to function 'process(defaults:plugins:)'
30 | defaults: (repeat each D) = (DefaultPlugin()),
31 | plugins: (repeat each P) = ()
 :
51 | process()
52 | process(defaults: (DefaultPlugin(), OtherPlugin()))
53 | process(plugins: (DefaultPlugin(),))
 | `- error: generic parameter 'each D' could not be inferred
54 | process(defaults: (DefaultPlugin(),), plugins: (OtherPlugin(),))
55 |

/Users/alex.reilly/Documents/OpenSource/swift-6.3-test/test/Sema/pack_default_argument_inlinable.swift:56:5: error: generic parameter 'each A' could not be inferred
37 | // Test with multiple pack parameters having defaults
38 | @inlinable
39 | public func multiProcess<each A: Plugin, each B: Plugin, each C: Plugin>(
 | `- note: in call to function 'multiProcess(first:second:third:)'
40 | first: (repeat each A) = (DefaultPlugin()),
41 | second: (repeat each B) = (DefaultPlugin(), OtherPlugin()),
 :
54 | process(defaults: (DefaultPlugin(),), plugins: (OtherPlugin(),))
55 |
56 | multiProcess()
 | `- error: generic parameter 'each A' could not be inferred
57 | multiProcess(first: (OtherPlugin(),))
58 | multiProcess(second: (DefaultPlugin(),))

/Users/alex.reilly/Documents/OpenSource/swift-6.3-test/test/Sema/pack_default_argument_inlinable.swift:58:5: error: generic parameter 'each A' could not be inferred
37 | // Test with multiple pack parameters having defaults
38 | @inlinable
39 | public func multiProcess<each A: Plugin, each B: Plugin, each C: Plugin>(
 | `- note: in call to function 'multiProcess(first:second:third:)'
40 | first: (repeat each A) = (DefaultPlugin()),
41 | second: (repeat each B) = (DefaultPlugin(), OtherPlugin()),
 :
56 | multiProcess()
57 | multiProcess(first: (OtherPlugin(),))
58 | multiProcess(second: (DefaultPlugin(),))
 | `- error: generic parameter 'each A' could not be inferred
59 | }
60 |

--

********************

2 warning(s) in tests
********************
```
