### PR TITLE
[release/6.3] Add regression test: pack closure parameter crash (compiler crash)

### DIFF
--- a/test/SILGen/pack_closure_parameter_crash.swift
+++ b/test/SILGen/pack_closure_parameter_crash.swift
@@ -1,0 +1,50 @@
+// RUN: %target-swift-frontend -emit-silgen %s | %FileCheck %s
+
+// This test verifies that closures with parameter types using pack generics
+// from an enclosing context compile without crashing.
+//
+// Previously, this would crash with:
+// Assertion failed: (origPackType.matchesPack(substPackType)),
+// function PackElementGenerator, file AbstractionPattern.cpp
+
+struct Box<each T> {}
+
+func takeClosure<each U>(_: (repeat each U), _: (Box<repeat each U>) -> Void) {}
+
+// CHECK-LABEL: sil hidden [ossa] @$s28pack_closure_parameter_crash4testyyF
+// CHECK: function_ref
+// CHECK: } // end sil function '$s28pack_closure_parameter_crash4testyyF'
+func test() {
+    takeClosure((1, ""), { _ in })
+}
+
+// More complex case with protocol method returning pack-parameterized type
+protocol Plugin {
+    func handle<each T>(event: Box<repeat each T>) -> [Box<repeat each T>]
+}
+
+struct MyPlugin: Plugin {
+    func handle<each T>(event: Box<repeat each T>) -> [Box<repeat each T>] { [] }
+}
+
+struct Processor<each P: Plugin> {
+    let plugins: (repeat each P)
+
+    func process<each Input>(
+        event: Box<repeat each Input>,
+        execute: (Box<repeat each Input>) -> Void
+    ) {
+        for plugin in repeat each plugins {
+            for action in plugin.handle(event: event) {
+                execute(action)
+            }
+        }
+    }
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s28pack_closure_parameter_crash12testComplexyyF
+// CHECK: } // end sil function '$s28pack_closure_parameter_crash12testComplexyyF'
+func testComplex() {
+    let p = Processor(plugins: (MyPlugin(),))
+    p.process(event: Box<Int, String>()) { _ in }
+}


### PR DESCRIPTION
## Summary

This test verifies that closures with parameter types using pack generics from an enclosing context compile without crashing. Previously, this would crash with: Assertion failed: (origPackType.matchesPack(substPackType)), function PackElementGenerator, file AbstractionPattern.cpp

## Failure category

`compiler-crash` — The compiler crashes when processing this source.

## Reproduction

Branch: `test-survey/SILGen_pack_closure_parameter_crash` (off `release/6.3`).
Test file: `test/SILGen/pack_closure_parameter_crash.swift`
Run: `lit -v test/SILGen/pack_closure_parameter_crash.swift`

## Test source (`test/SILGen/pack_closure_parameter_crash.swift`)

```swift
// RUN: %target-swift-frontend -emit-silgen %s | %FileCheck %s

// This test verifies that closures with parameter types using pack generics
// from an enclosing context compile without crashing.
//
// Previously, this would crash with:
// Assertion failed: (origPackType.matchesPack(substPackType)),
// function PackElementGenerator, file AbstractionPattern.cpp

struct Box<each T> {}

func takeClosure<each U>(_: (repeat each U), _: (Box<repeat each U>) -> Void) {}

// CHECK-LABEL: sil hidden [ossa] @$s28pack_closure_parameter_crash4testyyF
// CHECK: function_ref
// CHECK: } // end sil function '$s28pack_closure_parameter_crash4testyyF'
func test() {
 takeClosure((1, ""), { _ in })
}

// More complex case with protocol method returning pack-parameterized type
protocol Plugin {
 func handle<each T>(event: Box<repeat each T>) -> [Box<repeat each T>]
}

struct MyPlugin: Plugin {
 func handle<each T>(event: Box<repeat each T>) -> [Box<repeat each T>] { [] }
}

struct Processor<each P: Plugin> {
 let plugins: (repeat each P)

 func process<each Input>(
 event: Box<repeat each Input>,
 execute: (Box<repeat each Input>) -> Void
 ) {
 for plugin in repeat each plugins {
 for action in plugin.handle(event: event) {
 execute(action)
 }
 }
 }
}

// CHECK-LABEL: sil hidden [ossa] @$s28pack_closure_parameter_crash12testComplexyyF
// CHECK: } // end sil function '$s28pack_closure_parameter_crash12testComplexyyF'
func testComplex() {
 let p = Processor(plugins: (MyPlugin(),))
 p.process(event: Box<Int, String>()) { _ in }
}
```

## Crash trace

```
Assertion failed: (origPackType.matchesPack(substPackType)), function PackElementGenerator, file AbstractionPattern.cpp, line 895.
Please submit a bug report (https://swift.org/contributing/#reporting-bugs) and include the crash backtrace.
Stack dump:
0.	Program arguments: […elided…]
1.	Swift version 6.3.2-dev (LLVM 4e6cdf5caf79efb, Swift d23e82655fe203f)
2.	Compiling with effective version 4.1.50
3.	While evaluating request ASTLoweringRequest(Lowering AST to SIL for module pack_closure_parameter_crash)
4.	While silgen emitFunction SIL function "@$s28pack_closure_parameter_crash4testyyF".
 for 'test()' (at /Users/alex.reilly/Documents/OpenSource/swift-6.3-test/test/SILGen/pack_closure_parameter_crash.swift:17:1)
 #0 0x0000000105b58b30 llvm::sys::PrintStackTrace(llvm::raw_ostream&, int) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x105a80b30)
 #1 0x0000000105b56bec llvm::sys::RunSignalHandlers() (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x105a7ebec)
 #2 0x0000000105b595d8 SignalHandler(int, __siginfo*, void*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x105a815d8)
 #3 0x000000018f4ed7a4 (/usr/lib/system/libsystem_platform.dylib+0x1804f97a4)
 #4 0x000000018f4e38d8 (/usr/lib/system/libsystem_pthread.dylib+0x1804ef8d8)
 #5 0x000000018f3ea790 (/usr/lib/system/libsystem_c.dylib+0x1803f6790)
 #6 0x000000018f3e99ec (/usr/lib/system/libsystem_c.dylib+0x1803f59ec)
 #7 0x0000000105b9f504 swift::Lowering::PackElementGenerator::PackElementGenerator(swift::Lowering::AbstractionPattern, swift::CanTypeWrapper<swift::PackType>) (.cold.3) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x105ac7504)
 #8 0x0000000100bdc3e4 swift::Lowering::PackElementGenerator::PackElementGenerator(swift::Lowering::AbstractionPattern, swift::CanTypeWrapper<swift::PackType>) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100b043e4)
 #9 0x0000000100bdbef8 swift::Lowering::AbstractionPattern::forEachPackElement(swift::CanTypeWrapper<swift::PackType>, llvm::function_ref<void (swift::Lowering::PackElementGenerator&)>) const (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100b03ef8)
#10 0x0000000100be3b44 (anonymous namespace)::SubstFunctionTypePatternVisitor::visitPackType(swift::CanTypeWrapper<swift::PackType>, swift::Lowering::AbstractionPattern) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100b0bb44)
#11 0x0000000100be241c (anonymous namespace)::SubstFunctionTypePatternVisitor::visit(swift::CanType, swift::Lowering::AbstractionPattern) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100b0a41c)
#12 0x0000000100be4064 (anonymous namespace)::SubstFunctionTypePatternVisitor::handleGenericNominalType(swift::Lowering::AbstractionPattern, swift::CanType) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100b0c064)
#13 0x0000000100be25d4 (anonymous namespace)::SubstFunctionTypePatternVisitor::visit(swift::CanType, swift::Lowering::AbstractionPattern) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100b0a5d4)
#14 0x0000000100be2aa8 void llvm::function_ref<void (swift::Lowering::FunctionParamGenerator&)>::callback_fn<(anonymous namespace)::SubstFunctionTypePatternVisitor::handleUnabstractedFunctionType(swift::CanTypeWrapper<swift::AnyFunctionType>, swift::Lowering::AbstractionPattern, swift::CanType, swift::Lowering::AbstractionPattern)::'lambda'(swift::Lowering::FunctionParamGenerator&)>(long, swift::Lowering::FunctionParamGenerator&) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInf […truncated…]
#15 0x0000000100bdf08c swift::Lowering::AbstractionPattern::forEachFunctionParam(swift::ArrayRefView<swift::AnyFunctionType::Param, swift::AnyFunctionType::CanParam, swift::AnyFunctionType::CanParam::getFromParam(swift::AnyFunctionType::Param const&), true>, bool, llvm::function_ref<void (swift::Lowering::FunctionParamGenerator&)>) const (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100b0708c)
#16 0x0000000100be18c8 (anonymous namespace)::SubstFunctionTypePatternVisitor::handleUnabstractedFunctionType(swift::CanTypeWrapper<swift::AnyFunctionType>, swift::Lowering::AbstractionPattern, swift::CanType, swift::Lowering::AbstractionPattern) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100b098c8)
#17 0x0000000100be15d0 swift::Lowering::AbstractionPattern::getSubstFunctionTypePattern(swift::CanTypeWrapper<swift::AnyFunctionType>, swift::Lowering::TypeConverter&, swift::Lowering::AbstractionPattern, swift::CanType, bool&) const (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100b095d0)
#18 0x0000000100c2b34c getSILFunctionType(swift::Lowering::TypeConverter&, swift::TypeExpansionContext, swift::Lowering::AbstractionPattern, swift::CanTypeWrapper<swift::AnyFunctionType>, swift::SILExtInfoBuilder, (anonymous namespace)::Conventions const&, swift::ForeignInfo const&, std::__1::optional<swift::SILDeclRef>, std::__1::optional<swift::SILDeclRef>, std::__1::optional<swift::SubstitutionMap>, swift::ProtocolConformanceRef) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDeb […truncated…]
#19 0x0000000100c238dc getNativeSILFunctionType(swift::Lowering::TypeConverter&, swift::TypeExpansionContext, swift::Lowering::AbstractionPattern, swift::CanTypeWrapper<swift::AnyFunctionType>, swift::SILExtInfoBuilder, std::__1::optional<swift::SILDeclRef>, std::__1::optional<swift::SILDeclRef>, std::__1::optional<swift::SubstitutionMap>, swift::ProtocolConformanceRef) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100b […truncated…]
#20 0x0000000100c25cf4 getUncachedSILFunctionTypeForConstant(swift::Lowering::TypeConverter&, swift::TypeExpansionContext, swift::SILDeclRef, swift::Lowering::TypeConverter::LoweredFormalTypes) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100b4dcf4)
#21 0x0000000100c269e0 swift::Lowering::TypeConverter::getConstantInfo(swift::TypeExpansionContext, swift::SILDeclRef) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100b4e9e0)
#22 0x0000000100c1cf84 swift::SILFunctionBuilder::getOrCreateFunction(swift::SILLocation, swift::SILDeclRef, swift::ForDefinition_t, llvm::function_ref<swift::SILFunction* (swift::SILLocation, swift::SILDeclRef)>, swift::ProfileCounter) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100b44f84)
#23 0x000000010093cf24 swift::Lowering::SILGenModule::getFunction(swift::SILDeclRef, swift::ForDefinition_t) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100864f24)
#24 0x0000000100946220 void llvm::function_ref<void ()>::callback_fn<swift::Lowering::SILGenModule::emitClosure(swift::AbstractClosureExpr*, swift::Lowering::FunctionTypeInfo const&)::$_0>(long) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x10086e220)
#25 0x0000000100cbf8b8 swift::Lowering::TypeConverter::withClosureTypeInfo(swift::AbstractClosureExpr*, swift::Lowering::FunctionTypeInfo const&, llvm::function_ref<void ()>) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100be78b8)
#26 0x0000000100941108 swift::Lowering::SILGenModule::emitClosure(swift::AbstractClosureExpr*, swift::Lowering::FunctionTypeInfo const&) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100869108)
#27 0x00000001009c9758 (anonymous namespace)::RValueEmitter::emitClosureReference(swift::AbstractClosureExpr*, swift::Lowering::FunctionTypeInfo const&) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1008f1758)
#28 0x00000001009c9488 (anonymous namespace)::RValueEmitter::visitAbstractClosureExpr(swift::AbstractClosureExpr*, swift::Lowering::SGFContext) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1008f1488)
#29 0x00000001009af168 swift::Lowering::SILGenFunction::emitRValueAsSingleValue(swift::Expr*, swift::Lowering::SGFContext) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1008d7168)
#30 0x0000000100992fa0 swift::Lowering::SILGenFunction::emitConvertedRValue(swift::SILLocation, swift::Lowering::Conversion const&, swift::Lowering::SGFContext, llvm::function_ref<swift::Lowering::ManagedValue (swift::Lowering::SILGenFunction&, swift::SILLocation, swift::Lowering::SGFContext)>) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1008bafa0)
#31 0x00000001009270e0 swift::Lowering::ArgumentSource::getConverted(swift::Lowering::SILGenFunction&, swift::Lowering::Conversion const&, swift::Lowering::SGFContext) && (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x10084f0e0)
#32 0x000000010095e4c8 (anonymous namespace)::ArgEmitter::emit(swift::Lowering::ArgumentSource&&, swift::Lowering::AbstractionPattern, bool, std::__1::optional<swift::AnyFunctionType::Param>) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1008864c8)
#33 0x000000010094ef24 (anonymous namespace)::ArgEmitter::emitSingleArg(swift::Lowering::ArgumentSource&&, swift::Lowering::AbstractionPattern, bool, std::__1::optional<swift::AnyFunctionType::Param>) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100876f24)
#34 0x000000010095ca6c (anonymous namespace)::ArgEmitter::emitPreparedArgs(swift::Lowering::PreparedArguments&&, swift::Lowering::AbstractionPattern, llvm::ArrayRef<swift::LifetimeDependenceInfo>) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100884a6c)
 […further frames elided…]
```
