### PR TITLE
[release/6.3] Add regression test: pack element member capture (compiler crash)

### DIFF
--- a/test/SILGen/pack_element_member_capture.swift
+++ b/test/SILGen/pack_element_member_capture.swift
@@ -1,0 +1,44 @@
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
+
+// Test that pack element captures that reference member expressions correctly
+// capture the base variable (e.g., self) in enclosing closures.
+
+protocol P {
+    associatedtype Value
+    func get() -> Value
+}
+
+struct S: P {
+    typealias Value = Int
+    func get() -> Int { 42 }
+}
+
+final class Ops<each M: P> {
+    let items: (repeat each M)
+
+    init(items: (repeat each M)) {
+        self.items = items
+    }
+
+    // This test case verifies that when a pack element capture `(each self.items)`
+    // is used inside an immediately-invoked closure within a pack expansion,
+    // the outer closure correctly captures `self` so it's available when emitting
+    // the inner closure's captures.
+    func test() -> [(repeat (each M).Value)] {
+        return (0..<2).map { index in
+            var counter = 0
+            return (repeat {
+                counter += 1
+                return (each self.items).get()
+            }())
+        }
+    }
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s27pack_element_member_capture3OpsC4testSay5ValueQzxQp_tGyF
+// CHECK: function_ref @$s27pack_element_member_capture3OpsC4testSay5ValueQzxQp_tGyFAFxQp_tSiXEfU_
+// The outer closure should capture self
+// CHECK-LABEL: sil private [ossa] @$s27pack_element_member_capture3OpsC4testSay5ValueQzxQp_tGyFAFxQp_tSiXEfU_
+// The closure captures both index and self
+// CHECK: bb0({{.*}}, {{.*}}, {{.*}}, [[SELF:%[0-9]+]] : @closureCapture @guaranteed $Ops<repeat each M>):
+// CHECK: debug_value [[SELF]], let, name "self"


### PR DESCRIPTION
## Summary

Test that pack element captures that reference member expressions correctly capture the base variable (e.g., self) in enclosing closures.

## Failure category

`compiler-crash` — The compiler crashes when processing this source.

## Reproduction

Branch: `test-survey/SILGen_pack_element_member_capture` (off `release/6.3`).
Test file: `test/SILGen/pack_element_member_capture.swift`
Run: `lit -v test/SILGen/pack_element_member_capture.swift`

## Test source (`test/SILGen/pack_element_member_capture.swift`)

```swift
// RUN: %target-swift-emit-silgen %s | %FileCheck %s

// Test that pack element captures that reference member expressions correctly
// capture the base variable (e.g., self) in enclosing closures.

protocol P {
 associatedtype Value
 func get() -> Value
}

struct S: P {
 typealias Value = Int
 func get() -> Int { 42 }
}

final class Ops<each M: P> {
 let items: (repeat each M)

 init(items: (repeat each M)) {
 self.items = items
 }

 // This test case verifies that when a pack element capture `(each self.items)`
 // is used inside an immediately-invoked closure within a pack expansion,
 // the outer closure correctly captures `self` so it's available when emitting
 // the inner closure's captures.
 func test() -> [(repeat (each M).Value)] {
 return (0..<2).map { index in
 var counter = 0
 return (repeat {
 counter += 1
 return (each self.items).get()
 }())
 }
 }
}

// CHECK-LABEL: sil hidden [ossa] @$s27pack_element_member_capture3OpsC4testSay5ValueQzxQp_tGyF
// CHECK: function_ref @$s27pack_element_member_capture3OpsC4testSay5ValueQzxQp_tGyFAFxQp_tSiXEfU_
// The outer closure should capture self
// CHECK-LABEL: sil private [ossa] @$s27pack_element_member_capture3OpsC4testSay5ValueQzxQp_tGyFAFxQp_tSiXEfU_
// The closure captures both index and self
// CHECK: bb0({{.*}}, {{.*}}, {{.*}}, [[SELF:%[0-9]+]] : @closureCapture @guaranteed $Ops<repeat each M>):
// CHECK: debug_value [[SELF]], let, name "self"
```

## Crash trace

```
Assertion failed: (!getDeclContext()->isLocalContext() && "not a global variable!"), function isLazilyInitializedGlobal, file Decl.cpp, line 8178.
Please submit a bug report (https://swift.org/contributing/#reporting-bugs) and include the crash backtrace.
Stack dump:
0.	Program arguments: […elided…]
1.	Swift version 6.3.2-dev (LLVM 4e6cdf5caf79efb, Swift d23e82655fe203f)
2.	Compiling with effective version 4.1.50
3.	While evaluating request ASTLoweringRequest(Lowering AST to SIL for module pack_element_member_capture)
4.	While silgen emitFunction SIL function "@$s27pack_element_member_capture3OpsC4testSay5ValueQzxQp_tGyF".
 for 'test()' (at /Users/alex.reilly/Documents/OpenSource/swift-6.3-test/test/SILGen/pack_element_member_capture.swift:27:5)
5.	While silgen closureexpr SIL function "@$s27pack_element_member_capture3OpsC4testSay5ValueQzxQp_tGyFAFxQp_tSiXEfU_".
 for expression at [/Users/alex.reilly/Documents/OpenSource/swift-6.3-test/test/SILGen/pack_element_member_capture.swift:28:28 - line:34:9] RangeText="{ index in
 var counter = 0
 return (repeat {
 counter += 1
 return (each self.items).get()
 }())
 "
 #0 0x0000000108090b30 llvm::sys::PrintStackTrace(llvm::raw_ostream&, int) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x105a80b30)
 #1 0x000000010808ebec llvm::sys::RunSignalHandlers() (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x105a7ebec)
 #2 0x00000001080915d8 SignalHandler(int, __siginfo*, void*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x105a815d8)
 #3 0x000000018f4ed7a4 (/usr/lib/system/libsystem_platform.dylib+0x1804f97a4)
 #4 0x000000018f4e38d8 (/usr/lib/system/libsystem_pthread.dylib+0x1804ef8d8)
 #5 0x000000018f3ea790 (/usr/lib/system/libsystem_c.dylib+0x1803f6790)
 #6 0x000000018f3e99ec (/usr/lib/system/libsystem_c.dylib+0x1803f59ec)
 #7 0x0000000108128974 swift::VarDecl::getCanonicalVarDecl() const (.cold.1) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x105b18974)
 #8 0x0000000103e20a48 swift::VarDecl::isLazilyInitializedGlobal() const (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x101810a48)
 #9 0x0000000102f117a0 swift::Lowering::SILGenFunction::emitGlobalVariableRef(swift::SILLocation, swift::VarDecl*, std::__1::optional<swift::ActorIsolation>) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1009017a0)
#10 0x0000000102f2899c swift::Lowering::LValue::addNonMemberVarComponent(swift::Lowering::SILGenFunction&, swift::SILLocation, swift::VarDecl*, swift::SubstitutionMap, swift::Lowering::LValueOptions, swift::Lowering::SGFAccessKind, swift::AccessStrategy, swift::CanType, std::__1::optional<swift::ActorIsolation>) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x10091899c)
#11 0x0000000102f29b28 emitLValueForNonMemberVarDecl(swift::Lowering::SILGenFunction&, swift::SILLocation, swift::ConcreteDeclRef, swift::CanType, swift::Lowering::SGFAccessKind, swift::Lowering::LValueOptions, swift::AccessSemantics, std::__1::optional<swift::ActorIsolation>) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100919b28)
#12 0x0000000102f29238 swift::Lowering::SILGenFunction::emitRValueForNonMemberVarDecl(swift::SILLocation, swift::ConcreteDeclRef, swift::CanType, swift::AccessSemantics, swift::Lowering::SGFContext) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100919238)
#13 0x0000000102ef32c8 (anonymous namespace)::RValueEmitter::visitDeclRefExpr(swift::DeclRefExpr*, swift::Lowering::SGFContext) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1008e32c8)
#14 0x0000000102ee7168 swift::Lowering::SILGenFunction::emitRValueAsSingleValue(swift::Expr*, swift::Lowering::SGFContext) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1008d7168)
#15 0x0000000102f28170 SILGenLValue::visitRec(swift::Expr*, swift::Lowering::SGFAccessKind, swift::Lowering::LValueOptions, swift::Lowering::AbstractionPattern) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100918170)
#16 0x0000000102f2b484 SILGenLValue::visitMemberRefExpr(swift::MemberRefExpr*, swift::Lowering::SGFAccessKind, swift::Lowering::LValueOptions) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x10091b484)
#17 0x0000000102f27610 swift::Lowering::SILGenFunction::emitLValue(swift::Expr*, swift::Lowering::SGFAccessKind, swift::Lowering::LValueOptions) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100917610)
#18 0x0000000102ef3690 (anonymous namespace)::RValueEmitter::visitMemberRefExpr(swift::MemberRefExpr*, swift::Lowering::SGFContext) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1008e3690)
#19 0x0000000102ee44a0 swift::Lowering::SILGenFunction::emitExprInto(swift::Expr*, swift::Lowering::Initialization*, std::__1::optional<swift::SILLocation>) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1008d44a0)
#20 0x0000000102f3ee90 (anonymous namespace)::MaterializePackEmitter::walkToExprPre(swift::Expr*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x10092ee90)
#21 0x0000000103d95f14 (anonymous namespace)::Traversal::doIt(swift::Expr*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x101785f14)
#22 0x0000000103d95fcc (anonymous namespace)::Traversal::doIt(swift::Expr*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x101785fcc)
#23 0x0000000103d95f90 (anonymous namespace)::Traversal::doIt(swift::Expr*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x101785f90)
#24 0x0000000103d97bdc (anonymous namespace)::Traversal::visitSelfApplyExpr(swift::SelfApplyExpr*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x101787bdc)
#25 0x0000000103d95fe4 (anonymous namespace)::Traversal::doIt(swift::Expr*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x101785fe4)
#26 0x0000000103d97b48 (anonymous namespace)::Traversal::visitApplyExpr(swift::ApplyExpr*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x101787b48)
#27 0x0000000103d95fb0 (anonymous namespace)::Traversal::doIt(swift::Expr*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x101785fb0)
#28 0x0000000103d98310 swift::Stmt* llvm::function_ref<swift::Stmt* (swift::Stmt*)>::callback_fn<(anonymous namespace)::Traversal::doIt(swift::Stmt*)::'lambda'(swift::Stmt*)>(long, swift::Stmt*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x101788310)
#29 0x0000000103d97c78 swift::Stmt* (anonymous namespace)::Traversal::traverse<swift::Stmt>(swift::ASTWalker::PreWalkResult<swift::Stmt*>, llvm::function_ref<swift::Stmt* (swift::Stmt*)>, llvm::function_ref<swift::ASTWalker::PostWalkResult<swift::Stmt*> (swift::Stmt*)>) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x101787c78)
#30 0x0000000103d97fa4 swift::Stmt* llvm::function_ref<swift::Stmt* (swift::Stmt*)>::callback_fn<(anonymous namespace)::Traversal::doIt(swift::Stmt*)::'lambda'(swift::Stmt*)>(long, swift::Stmt*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x101787fa4)
#31 0x0000000103d97c78 swift::Stmt* (anonymous namespace)::Traversal::traverse<swift::Stmt>(swift::ASTWalker::PreWalkResult<swift::Stmt*>, llvm::function_ref<swift::Stmt* (swift::Stmt*)>, llvm::function_ref<swift::ASTWalker::PostWalkResult<swift::Stmt*> (swift::Stmt*)>) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x101787c78)
#32 0x0000000103d97088 (anonymous namespace)::Traversal::visitClosureExpr(swift::ClosureExpr*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x101787088)
#33 0x0000000103d96118 (anonymous namespace)::Traversal::doIt(swift::Expr*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x101786118)
#34 0x0000000103d97b48 (anonymous namespace)::Traversal::visitApplyExpr(swift::ApplyExpr*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x101787b48)
 […further frames elided…]
```
