### PR TITLE
[release/6.3] Add regression test: pack expansion multi tuple (compiler crash)

### DIFF
--- a/test/SILGen/pack_expansion_multi_tuple.swift
+++ b/test/SILGen/pack_expansion_multi_tuple.swift
@@ -1,0 +1,53 @@
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
+
+// Test that tuples containing multiple pack expansions can be passed to
+// functions expecting a single pack expansion tuple parameter.
+// This tests the fix for the SILGen assertion "only single pack expansion
+// tuples are currently supported" when combining two packs into one tuple.
+
+protocol P {}
+struct A: P {}
+
+struct Holder<each T: P> {
+    let values: (repeat each T)
+}
+
+// Test 1: Direct inline construction of multi-pack tuple
+// CHECK-LABEL: sil hidden [ossa] @$s26pack_expansion_multi_tuple10testInline
+func testInline<each X: P, each Y: P>(_ x: (repeat each X), _ y: (repeat each Y)) {
+    // This creates a tuple (repeat each X, repeat each Y) with two pack expansions
+    // and passes it to Holder which expects (repeat each T)
+    let h = Holder(values: (repeat each x, repeat each y))
+    print(h)
+}
+
+// Test 2: Store multi-pack tuple in variable first, then pass it
+// This tests the case where the tuple is an RValue, not an inline expression
+// CHECK-LABEL: sil hidden [ossa] @$s26pack_expansion_multi_tuple10testStored
+func testStored<each X: P, each Y: P>(_ x: (repeat each X), _ y: (repeat each Y)) {
+    let combined: (repeat each X, repeat each Y) = (repeat each x, repeat each y)
+    let h = Holder(values: combined)
+    print(h)
+}
+
+// Test 3: Multi-pack tuple returned from helper function
+// CHECK-LABEL: sil hidden [ossa] @$s26pack_expansion_multi_tuple6concat
+func concat<each X: P, each Y: P>(
+    _ x: (repeat each X),
+    _ y: (repeat each Y)
+) -> (repeat each X, repeat each Y) {
+    return (repeat each x, repeat each y)
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s26pack_expansion_multi_tuple14testFromHelper
+func testFromHelper<each X: P, each Y: P>(_ x: (repeat each X), _ y: (repeat each Y)) {
+    let combined = concat(x, y)
+    let h = Holder(values: combined)
+    print(h)
+}
+
+func callTests() {
+    testInline((A(),), (A(),))
+    testStored((A(),), (A(),))
+    testFromHelper((A(),), (A(),))
+}


### PR DESCRIPTION
## Summary

Test that tuples containing multiple pack expansions can be passed to functions expecting a single pack expansion tuple parameter. This tests the fix for the SILGen assertion "only single pack expansion tuples are currently supported" when combining two packs into one tuple.

## Failure category

`compiler-crash` — The compiler crashes when processing this source.

## Reproduction

Branch: `test-survey/SILGen_pack_expansion_multi_tuple` (off `release/6.3`).
Test file: `test/SILGen/pack_expansion_multi_tuple.swift`
Run: `lit -v test/SILGen/pack_expansion_multi_tuple.swift`

## Test source (`test/SILGen/pack_expansion_multi_tuple.swift`)

```swift
// RUN: %target-swift-emit-silgen %s | %FileCheck %s

// Test that tuples containing multiple pack expansions can be passed to
// functions expecting a single pack expansion tuple parameter.
// This tests the fix for the SILGen assertion "only single pack expansion
// tuples are currently supported" when combining two packs into one tuple.

protocol P {}
struct A: P {}

struct Holder<each T: P> {
 let values: (repeat each T)
}

// Test 1: Direct inline construction of multi-pack tuple
// CHECK-LABEL: sil hidden [ossa] @$s26pack_expansion_multi_tuple10testInline
func testInline<each X: P, each Y: P>(_ x: (repeat each X), _ y: (repeat each Y)) {
 // This creates a tuple (repeat each X, repeat each Y) with two pack expansions
 // and passes it to Holder which expects (repeat each T)
 let h = Holder(values: (repeat each x, repeat each y))
 print(h)
}

// Test 2: Store multi-pack tuple in variable first, then pass it
// This tests the case where the tuple is an RValue, not an inline expression
// CHECK-LABEL: sil hidden [ossa] @$s26pack_expansion_multi_tuple10testStored
func testStored<each X: P, each Y: P>(_ x: (repeat each X), _ y: (repeat each Y)) {
 let combined: (repeat each X, repeat each Y) = (repeat each x, repeat each y)
 let h = Holder(values: combined)
 print(h)
}

// Test 3: Multi-pack tuple returned from helper function
// CHECK-LABEL: sil hidden [ossa] @$s26pack_expansion_multi_tuple6concat
func concat<each X: P, each Y: P>(
 _ x: (repeat each X),
 _ y: (repeat each Y)
) -> (repeat each X, repeat each Y) {
 return (repeat each x, repeat each y)
}

// CHECK-LABEL: sil hidden [ossa] @$s26pack_expansion_multi_tuple14testFromHelper
func testFromHelper<each X: P, each Y: P>(_ x: (repeat each X), _ y: (repeat each Y)) {
 let combined = concat(x, y)
 let h = Holder(values: combined)
 print(h)
}

func callTests() {
 testInline((A(),), (A(),))
 testStored((A(),), (A(),))
 testFromHelper((A(),), (A(),))
}
```

## Crash trace

```
Assertion failed: (!tupleTy.containsPackExpansionType() && "can't extract elements from tuples containing pack expansions " "right now"), function extractElements, file RValue.cpp, line 707.
Please submit a bug report (https://swift.org/contributing/#reporting-bugs) and include the crash backtrace.
Stack dump:
0.	Program arguments: […elided…]
1.	Swift version 6.3.2-dev (LLVM 4e6cdf5caf79efb, Swift d23e82655fe203f)
2.	Compiling with effective version 4.1.50
3.	While evaluating request ASTLoweringRequest(Lowering AST to SIL for module pack_expansion_multi_tuple)
4.	While silgen emitFunction SIL function "@$s26pack_expansion_multi_tuple10testStoredyyxxQp_t_q_q_Qp_ttRvzRv_AA1PRzAaCR_r0_lF".
 for 'testStored(_:_:)' (at /Users/alex.reilly/Documents/OpenSource/swift-6.3-test/test/SILGen/pack_expansion_multi_tuple.swift:27:1)
 #0 0x0000000105d28b30 llvm::sys::PrintStackTrace(llvm::raw_ostream&, int) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x105a80b30)
 #1 0x0000000105d26bec llvm::sys::RunSignalHandlers() (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x105a7ebec)
 #2 0x0000000105d295d8 SignalHandler(int, __siginfo*, void*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x105a815d8)
 #3 0x000000018f4ed7a4 (/usr/lib/system/libsystem_platform.dylib+0x1804f97a4)
 #4 0x000000018f4e38d8 (/usr/lib/system/libsystem_pthread.dylib+0x1804ef8d8)
 #5 0x000000018f3ea790 (/usr/lib/system/libsystem_c.dylib+0x1803f6790)
 #6 0x000000018f3e99ec (/usr/lib/system/libsystem_c.dylib+0x1803f59ec)
 #7 0x0000000105d550dc swift::Lowering::RValue::copy(swift::Lowering::SILGenFunction&, swift::SILLocation) const & (.cold.1) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x105aad0dc)
 #8 0x0000000100b04654 swift::Lowering::RValue::extractElements(llvm::SmallVectorImpl<swift::Lowering::RValue>&) && (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x10085c654)
 #9 0x0000000100af84f4 swift::Lowering::ArgumentSourceExpansion::ArgumentSourceExpansion(swift::Lowering::SILGenFunction&, swift::Lowering::ArgumentSource&&, bool) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1008504f4)
#10 0x0000000100b2d730 (anonymous namespace)::ArgEmitter::emit(swift::Lowering::ArgumentSource&&, swift::Lowering::AbstractionPattern, bool, std::__1::optional<swift::AnyFunctionType::Param>) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100885730)
#11 0x0000000100b1ef24 (anonymous namespace)::ArgEmitter::emitSingleArg(swift::Lowering::ArgumentSource&&, swift::Lowering::AbstractionPattern, bool, std::__1::optional<swift::AnyFunctionType::Param>) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100876f24)
#12 0x0000000100b2ca6c (anonymous namespace)::ArgEmitter::emitPreparedArgs(swift::Lowering::PreparedArguments&&, swift::Lowering::AbstractionPattern, llvm::ArrayRef<swift::LifetimeDependenceInfo>) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100884a6c)
#13 0x0000000100b37aec (anonymous namespace)::CallSite::emit(swift::Lowering::SILGenFunction&, swift::Lowering::AbstractionPattern, swift::CanTypeWrapper<swift::SILFunctionType>, llvm::ArrayRef<swift::LifetimeDependenceInfo>, (anonymous namespace)::ParamLowering&, llvm::SmallVectorImpl<swift::Lowering::ManagedValue>&, llvm::SmallVectorImpl<(anonymous namespace)::DelayedArgument>&, swift::ForeignInfo const&) && (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swi […truncated…]
#14 0x0000000100b3742c (anonymous namespace)::CallEmission::emitArgumentsForNormalApply(swift::Lowering::AbstractionPattern, swift::CanTypeWrapper<swift::SILFunctionType>, llvm::ArrayRef<swift::LifetimeDependenceInfo>, swift::ForeignInfo const&, llvm::SmallVectorImpl<swift::Lowering::ManagedValue>&, std::__1::optional<swift::SILLocation>&) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x10088f42c)
#15 0x0000000100b227ec (anonymous namespace)::CallEmission::apply(swift::Lowering::SGFContext) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x10087a7ec)
#16 0x0000000100b20784 swift::Lowering::SILGenFunction::emitApplyExpr(swift::ApplyExpr*, swift::Lowering::SGFContext) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100878784)
#17 0x0000000100b7c4a0 swift::Lowering::SILGenFunction::emitExprInto(swift::Expr*, swift::Lowering::Initialization*, std::__1::optional<swift::SILLocation>) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1008d44a0)
#18 0x0000000100b6993c swift::Lowering::SILGenFunction::emitPatternBinding(swift::PatternBindingDecl*, unsigned int, bool) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1008c193c)
#19 0x0000000100b70288 swift::ASTVisitor<swift::Lowering::SILGenFunction, void, void, void, void, void, void>::visit(swift::Decl*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1008c8288)
#20 0x0000000100c0d554 swift::ASTVisitor<(anonymous namespace)::StmtEmitter, void, void, void, void, void, void>::visit(swift::Stmt*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100965554)
#21 0x0000000100c0bf7c swift::Lowering::SILGenFunction::emitStmt(swift::Stmt*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100963f7c)
#22 0x0000000100ba4484 swift::Lowering::SILGenFunction::emitFunction(swift::FuncDecl*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1008fc484)
#23 0x0000000100b0f120 swift::Lowering::SILGenModule::emitFunctionDefinition(swift::SILDeclRef, swift::SILFunction*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100867120)
#24 0x0000000100b0ff1c swift::Lowering::SILGenModule::emitOrDelayFunction(swift::SILDeclRef) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100867f1c)
#25 0x0000000100b0dacc swift::Lowering::SILGenModule::emitFunction(swift::FuncDecl*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100865acc)
#26 0x0000000100b129d0 swift::Lowering::SILGenModule::emitSourceFile(swift::SourceFile*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x10086a9d0)
#27 0x0000000100b12ebc swift::ASTLoweringRequest::evaluate(swift::Evaluator&, swift::ASTLoweringDescriptor) const (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x10086aebc)
#28 0x0000000100c0b9a0 swift::SimpleRequest<swift::ASTLoweringRequest, std::__1::unique_ptr<swift::SILModule, std::__1::default_delete<swift::SILModule>> (swift::ASTLoweringDescriptor), (swift::RequestFlags)17>::evaluateRequest(swift::ASTLoweringRequest const&, swift::Evaluator&) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1009639a0)
#29 0x0000000100b16b50 swift::ASTLoweringRequest::OutputType swift::Evaluator::getResultUncached<swift::ASTLoweringRequest, swift::ASTLoweringRequest::OutputType swift::evaluateOrFatal<swift::ASTLoweringRequest>(swift::Evaluator&, swift::ASTLoweringRequest)::'lambda'()>(swift::ASTLoweringRequest const&, swift::ASTLoweringRequest::OutputType swift::evaluateOrFatal<swift::ASTLoweringRequest>(swift::Evaluator&, swift::ASTLoweringRequest)::'lambda'())::'lambda'()::operator()() const (/Users/alex.rei […truncated…]
#30 0x0000000100b16a6c swift::ASTLoweringRequest::OutputType swift::Evaluator::getResultUncached<swift::ASTLoweringRequest, swift::ASTLoweringRequest::OutputType swift::evaluateOrFatal<swift::ASTLoweringRequest>(swift::Evaluator&, swift::ASTLoweringRequest)::'lambda'()>(swift::ASTLoweringRequest const&, swift::ASTLoweringRequest::OutputType swift::evaluateOrFatal<swift::ASTLoweringRequest>(swift::Evaluator&, swift::ASTLoweringRequest)::'lambda'()) (/Users/alex.reilly/Documents/OpenSource/build/N […truncated…]
#31 0x0000000100b13190 swift::performASTLowering(swift::ModuleDecl*, swift::Lowering::TypeConverter&, swift::SILOptions const&, swift::IRGenOptions const*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x10086b190)
#32 0x0000000100549368 swift::performCompileStepsPostSema(swift::CompilerInstance&, int&, swift::FrontendObserver*, llvm::ArrayRef<char const*>) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1002a1368)
#33 0x0000000100558ff4 withSemanticAnalysis(swift::CompilerInstance&, swift::FrontendObserver*, llvm::function_ref<bool (swift::CompilerInstance&)>, bool) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1002b0ff4)
#34 0x000000010054ca40 performCompile(swift::CompilerInstance&, int&, swift::FrontendObserver*, llvm::ArrayRef<char const*>) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1002a4a40)
 […further frames elided…]
```
