### PR TITLE
[release/6.3] Add regression test: pack expansion tuple to closure (compiler crash)

### DIFF
--- a/test/SILGen/pack_expansion_tuple_to_closure.swift
+++ b/test/SILGen/pack_expansion_tuple_to_closure.swift
@@ -1,0 +1,45 @@
+// RUN: %target-swift-emit-silgen %s -target %target-swift-5.9-abi-triple | %FileCheck %s
+
+// Test that passing a pack expansion tuple (from iteration or direct passing)
+// to a closure correctly uses pack_element_set to initialize the pack.
+//
+// This is a regression test for a bug where SILGen used pack_element_get
+// to read from an uninitialized pack, then tried to copy to that garbage
+// address, corrupting the stack frame.
+
+struct FuzzEngine<each Input> {
+  // CHECK-LABEL: sil hidden [ossa] @$s31pack_expansion_tuple_to_closure10FuzzEngineV3run6inputs4testySayxxQp_tG_yxxQp_t_tKXEtKF
+  // The loop body should use pack_element_set to initialize the pack, not pack_element_get.
+  // CHECK: [[PACK:%[0-9]+]] = alloc_pack $Pack{repeat each Input}
+  // CHECK: [[TUPLE_ELT:%[0-9]+]] = tuple_pack_element_addr
+  // CHECK: pack_element_set [[TUPLE_ELT]] into {{%[0-9]+}} of [[PACK]]
+  // CHECK: try_apply {{%[0-9]+}}([[PACK]])
+  func run(inputs: [(repeat each Input)], test: ((repeat each Input)) throws -> Void) rethrows {
+    for input in inputs {
+      try test(input)
+    }
+  }
+}
+
+struct Runner<each Input> {
+  // CHECK-LABEL: sil hidden [ossa] @$s31pack_expansion_tuple_to_closure6RunnerV3run_4testyxxQp_t_yxxQp_t_tKXEtKF
+  // Direct passing should also use pack_element_set.
+  // CHECK: [[PACK2:%[0-9]+]] = alloc_pack $Pack{repeat each Input}
+  // CHECK: pack_element_set {{%[0-9]+}} into {{%[0-9]+}} of [[PACK2]]
+  // CHECK: try_apply {{%[0-9]+}}([[PACK2]])
+  func run(_ input: (repeat each Input), test: ((repeat each Input)) throws -> Void) rethrows {
+    try test(input)
+  }
+}
+
+func useIt() {
+  let engine = FuzzEngine<Int>()
+  engine.run(inputs: [(42)]) { value in
+    print(value)
+  }
+
+  let runner = Runner<Int>()
+  runner.run((99)) { value in
+    print(value)
+  }
+}


### PR DESCRIPTION
## Summary

Test that passing a pack expansion tuple (from iteration or direct passing) to a closure correctly uses pack_element_set to initialize the pack. This is a regression test for a bug where SILGen used pack_element_get to read from an uninitialized pack, then tried to copy to that garbage address, corrupting the stack frame.

## Failure category

`compiler-crash` — The compiler crashes when processing this source.

## Reproduction

Branch: `test-survey/SILGen_pack_expansion_tuple_to_closure` (off `release/6.3`).
Test file: `test/SILGen/pack_expansion_tuple_to_closure.swift`
Run: `lit -v test/SILGen/pack_expansion_tuple_to_closure.swift`

## Test source (`test/SILGen/pack_expansion_tuple_to_closure.swift`)

```swift
// RUN: %target-swift-emit-silgen %s -target %target-swift-5.9-abi-triple | %FileCheck %s

// Test that passing a pack expansion tuple (from iteration or direct passing)
// to a closure correctly uses pack_element_set to initialize the pack.
//
// This is a regression test for a bug where SILGen used pack_element_get
// to read from an uninitialized pack, then tried to copy to that garbage
// address, corrupting the stack frame.

struct FuzzEngine<each Input> {
 // CHECK-LABEL: sil hidden [ossa] @$s31pack_expansion_tuple_to_closure10FuzzEngineV3run6inputs4testySayxxQp_tG_yxxQp_t_tKXEtKF
 // The loop body should use pack_element_set to initialize the pack, not pack_element_get.
 // CHECK: [[PACK:%[0-9]+]] = alloc_pack $Pack{repeat each Input}
 // CHECK: [[TUPLE_ELT:%[0-9]+]] = tuple_pack_element_addr
 // CHECK: pack_element_set [[TUPLE_ELT]] into {{%[0-9]+}} of [[PACK]]
 // CHECK: try_apply {{%[0-9]+}}([[PACK]])
 func run(inputs: [(repeat each Input)], test: ((repeat each Input)) throws -> Void) rethrows {
 for input in inputs {
 try test(input)
 }
 }
}

struct Runner<each Input> {
 // CHECK-LABEL: sil hidden [ossa] @$s31pack_expansion_tuple_to_closure6RunnerV3run_4testyxxQp_t_yxxQp_t_tKXEtKF
 // Direct passing should also use pack_element_set.
 // CHECK: [[PACK2:%[0-9]+]] = alloc_pack $Pack{repeat each Input}
 // CHECK: pack_element_set {{%[0-9]+}} into {{%[0-9]+}} of [[PACK2]]
 // CHECK: try_apply {{%[0-9]+}}([[PACK2]])
 func run(_ input: (repeat each Input), test: ((repeat each Input)) throws -> Void) rethrows {
 try test(input)
 }
}

func useIt() {
 let engine = FuzzEngine<Int>()
 engine.run(inputs: [(42)]) { value in
 print(value)
 }

 let runner = Runner<Int>()
 runner.run((99)) { value in
 print(value)
 }
}
```

## Crash trace

```
Assertion failed: (!tupleTy.containsPackExpansionType() && "can't extract elements from tuples containing pack expansions " "right now"), function extractElements, file RValue.cpp, line 707.
Please submit a bug report (https://swift.org/contributing/#reporting-bugs) and include the crash backtrace.
Stack dump:
0.	Program arguments: […elided…]
1.	Swift version 6.3.2-dev (LLVM 4e6cdf5caf79efb, Swift d23e82655fe203f)
2.	Compiling with effective version 4.1.50
3.	While evaluating request ASTLoweringRequest(Lowering AST to SIL for module pack_expansion_tuple_to_closure)
4.	While silgen emitFunction SIL function "@$s31pack_expansion_tuple_to_closure10FuzzEngineV3run6inputs4testySayxxQp_tG_yxxQp_t_tKXEtKF".
 for 'run(inputs:test:)' (at /Users/alex.reilly/Documents/OpenSource/swift-6.3-test/test/SILGen/pack_expansion_tuple_to_closure.swift:17:3)
 #0 0x000000010a554b30 llvm::sys::PrintStackTrace(llvm::raw_ostream&, int) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x105a80b30)
 #1 0x000000010a552bec llvm::sys::RunSignalHandlers() (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x105a7ebec)
 #2 0x000000010a5555d8 SignalHandler(int, __siginfo*, void*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x105a815d8)
 #3 0x000000018f4ed7a4 (/usr/lib/system/libsystem_platform.dylib+0x1804f97a4)
 #4 0x000000018f4e38d8 (/usr/lib/system/libsystem_pthread.dylib+0x1804ef8d8)
 #5 0x000000018f3ea790 (/usr/lib/system/libsystem_c.dylib+0x1803f6790)
 #6 0x000000018f3e99ec (/usr/lib/system/libsystem_c.dylib+0x1803f59ec)
 #7 0x000000010a5810dc swift::Lowering::RValue::copy(swift::Lowering::SILGenFunction&, swift::SILLocation) const & (.cold.1) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x105aad0dc)
 #8 0x0000000105330654 swift::Lowering::RValue::extractElements(llvm::SmallVectorImpl<swift::Lowering::RValue>&) && (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x10085c654)
 #9 0x00000001053244f4 swift::Lowering::ArgumentSourceExpansion::ArgumentSourceExpansion(swift::Lowering::SILGenFunction&, swift::Lowering::ArgumentSource&&, bool) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1008504f4)
#10 0x0000000105359730 (anonymous namespace)::ArgEmitter::emit(swift::Lowering::ArgumentSource&&, swift::Lowering::AbstractionPattern, bool, std::__1::optional<swift::AnyFunctionType::Param>) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100885730)
#11 0x000000010534af24 (anonymous namespace)::ArgEmitter::emitSingleArg(swift::Lowering::ArgumentSource&&, swift::Lowering::AbstractionPattern, bool, std::__1::optional<swift::AnyFunctionType::Param>) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100876f24)
#12 0x0000000105358a6c (anonymous namespace)::ArgEmitter::emitPreparedArgs(swift::Lowering::PreparedArguments&&, swift::Lowering::AbstractionPattern, llvm::ArrayRef<swift::LifetimeDependenceInfo>) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100884a6c)
#13 0x0000000105363aec (anonymous namespace)::CallSite::emit(swift::Lowering::SILGenFunction&, swift::Lowering::AbstractionPattern, swift::CanTypeWrapper<swift::SILFunctionType>, llvm::ArrayRef<swift::LifetimeDependenceInfo>, (anonymous namespace)::ParamLowering&, llvm::SmallVectorImpl<swift::Lowering::ManagedValue>&, llvm::SmallVectorImpl<(anonymous namespace)::DelayedArgument>&, swift::ForeignInfo const&) && (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swi […truncated…]
#14 0x000000010536342c (anonymous namespace)::CallEmission::emitArgumentsForNormalApply(swift::Lowering::AbstractionPattern, swift::CanTypeWrapper<swift::SILFunctionType>, llvm::ArrayRef<swift::LifetimeDependenceInfo>, swift::ForeignInfo const&, llvm::SmallVectorImpl<swift::Lowering::ManagedValue>&, std::__1::optional<swift::SILLocation>&) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x10088f42c)
#15 0x000000010534e7ec (anonymous namespace)::CallEmission::apply(swift::Lowering::SGFContext) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x10087a7ec)
#16 0x000000010534c784 swift::Lowering::SILGenFunction::emitApplyExpr(swift::ApplyExpr*, swift::Lowering::SGFContext) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100878784)
#17 0x00000001053ab750 swift::Lowering::SILGenFunction::emitIgnoredExpr(swift::Expr*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1008d7750)
#18 0x0000000105439478 swift::ASTVisitor<(anonymous namespace)::StmtEmitter, void, void, void, void, void, void>::visit(swift::Stmt*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100965478)
#19 0x000000010543eb10 std::__1::__function::__func<(anonymous namespace)::StmtEmitter::visitForEachStmt(swift::ForEachStmt*)::$_0, std::__1::allocator<(anonymous namespace)::StmtEmitter::visitForEachStmt(swift::ForEachStmt*)::$_0>, void (swift::Lowering::ManagedValue, swift::Lowering::SwitchCaseFullExpr&&)>::operator()(swift::Lowering::ManagedValue&&, swift::Lowering::SwitchCaseFullExpr&&) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/ […truncated…]
#20 0x0000000105335f6c swift::Lowering::SwitchEnumBuilder::emit() && (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100861f6c)
#21 0x000000010543d938 (anonymous namespace)::StmtEmitter::visitForEachStmt(swift::ForEachStmt*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100969938)
#22 0x00000001054394cc swift::ASTVisitor<(anonymous namespace)::StmtEmitter, void, void, void, void, void, void>::visit(swift::Stmt*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1009654cc)
#23 0x0000000105437f7c swift::Lowering::SILGenFunction::emitStmt(swift::Stmt*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100963f7c)
#24 0x00000001053d0484 swift::Lowering::SILGenFunction::emitFunction(swift::FuncDecl*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1008fc484)
#25 0x000000010533b120 swift::Lowering::SILGenModule::emitFunctionDefinition(swift::SILDeclRef, swift::SILFunction*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100867120)
#26 0x000000010533bf1c swift::Lowering::SILGenModule::emitOrDelayFunction(swift::SILDeclRef) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100867f1c)
#27 0x0000000105339acc swift::Lowering::SILGenModule::emitFunction(swift::FuncDecl*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100865acc)
#28 0x000000010544ccb4 (anonymous namespace)::SILGenType::visitFuncDecl(swift::FuncDecl*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100978cb4)
#29 0x0000000105449ab8 (anonymous namespace)::SILGenType::emitType() (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100975ab8)
#30 0x0000000105449a10 swift::Lowering::SILGenModule::visitNominalTypeDecl(swift::NominalTypeDecl*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100975a10)
#31 0x000000010533e9d0 swift::Lowering::SILGenModule::emitSourceFile(swift::SourceFile*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x10086a9d0)
#32 0x000000010533eebc swift::ASTLoweringRequest::evaluate(swift::Evaluator&, swift::ASTLoweringDescriptor) const (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x10086aebc)
#33 0x00000001054379a0 swift::SimpleRequest<swift::ASTLoweringRequest, std::__1::unique_ptr<swift::SILModule, std::__1::default_delete<swift::SILModule>> (swift::ASTLoweringDescriptor), (swift::RequestFlags)17>::evaluateRequest(swift::ASTLoweringRequest const&, swift::Evaluator&) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1009639a0)
#34 0x0000000105342b50 swift::ASTLoweringRequest::OutputType swift::Evaluator::getResultUncached<swift::ASTLoweringRequest, swift::ASTLoweringRequest::OutputType swift::evaluateOrFatal<swift::ASTLoweringRequest>(swift::Evaluator&, swift::ASTLoweringRequest)::'lambda'()>(swift::ASTLoweringRequest const&, swift::ASTLoweringRequest::OutputType swift::evaluateOrFatal<swift::ASTLoweringRequest>(swift::Evaluator&, swift::ASTLoweringRequest)::'lambda'())::'lambda'()::operator()() const (/Users/alex.rei […truncated…]
 […further frames elided…]
```
