### PR TITLE
[release/6.3] Add regression test: variadic generic closure pack arg (compiler crash)

### DIFF
--- a/test/SILGen/variadic_generic_closure_pack_arg.swift
+++ b/test/SILGen/variadic_generic_closure_pack_arg.swift
@@ -1,0 +1,19 @@
+// RUN: %target-swift-emit-silgen -target %target-swift-5.9-abi-triple %s
+
+// Test that passing a pack expansion tuple to a closure compiles without
+// crashing. This tests the fix for a bug where SILGenProlog.cpp would only
+// check the substituted type for pack expansions when deciding whether to
+// create a temporary initialization, but the original abstraction pattern
+// could still have pack expansions even when the substituted type doesn't.
+
+func processValues<each T>(_ values: repeat each T, test: ((repeat each T)) throws -> Void) rethrows {
+    try test((repeat each values))
+}
+
+func useIt() {
+    // When specialized with concrete types like (Int, Int, Int), the substituted
+    // tuple type doesn't contain pack expansions, but the abstraction pattern does.
+    processValues(1, 2, 3) { values in
+        print(values)
+    }
+}


### PR DESCRIPTION
## Summary

Test that passing a pack expansion tuple to a closure compiles without crashing. This tests the fix for a bug where SILGenProlog.cpp would only check the substituted type for pack expansions when deciding whether to create a temporary initialization, but the original abstraction pattern could still have pack expansions even when the substituted type doesn't.

## Failure category

`compiler-crash` — The compiler crashes when processing this source.

## Reproduction

Branch: `test-survey/SILGen_variadic_generic_closure_pack_arg` (off `release/6.3`).
Test file: `test/SILGen/variadic_generic_closure_pack_arg.swift`
Run: `lit -v test/SILGen/variadic_generic_closure_pack_arg.swift`

## Test source (`test/SILGen/variadic_generic_closure_pack_arg.swift`)

```swift
// RUN: %target-swift-emit-silgen -target %target-swift-5.9-abi-triple %s

// Test that passing a pack expansion tuple to a closure compiles without
// crashing. This tests the fix for a bug where SILGenProlog.cpp would only
// check the substituted type for pack expansions when deciding whether to
// create a temporary initialization, but the original abstraction pattern
// could still have pack expansions even when the substituted type doesn't.

func processValues<each T>(_ values: repeat each T, test: ((repeat each T)) throws -> Void) rethrows {
 try test((repeat each values))
}

func useIt() {
 // When specialized with concrete types like (Int, Int, Int), the substituted
 // tuple type doesn't contain pack expansions, but the abstraction pattern does.
 processValues(1, 2, 3) { values in
 print(values)
 }
}
```

## Crash trace

```
Assertion failed: (init), function operator(), file SILGenProlog.cpp, line 479.
Please submit a bug report (https://swift.org/contributing/#reporting-bugs) and include the crash backtrace.
Stack dump:
0.	Program arguments: […elided…]
1.	Swift version 6.3.2-dev (LLVM 4e6cdf5caf79efb, Swift d23e82655fe203f)
2.	Compiling with effective version 4.1.50
3.	While evaluating request ASTLoweringRequest(Lowering AST to SIL for module variadic_generic_closure_pack_arg)
4.	While silgen emitFunction SIL function "@$s33variadic_generic_closure_pack_arg5useItyyF".
 for 'useIt()' (at /Users/alex.reilly/Documents/OpenSource/swift-6.3-test/test/SILGen/variadic_generic_closure_pack_arg.swift:13:1)
5.	While silgen closureexpr SIL function "@$s33variadic_generic_closure_pack_arg5useItyyFySi_S2it_tXEfU_".
 for expression at [/Users/alex.reilly/Documents/OpenSource/swift-6.3-test/test/SILGen/variadic_generic_closure_pack_arg.swift:16:28 - line:18:5] RangeText="{ values in
 print(values)
 "
 #0 0x00000001082f0b30 llvm::sys::PrintStackTrace(llvm::raw_ostream&, int) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x105a80b30)
 #1 0x00000001082eebec llvm::sys::RunSignalHandlers() (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x105a7ebec)
 #2 0x00000001082f15d8 SignalHandler(int, __siginfo*, void*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x105a815d8)
 #3 0x000000018f4ed7a4 (/usr/lib/system/libsystem_platform.dylib+0x1804f97a4)
 #4 0x000000018f4e38d8 (/usr/lib/system/libsystem_pthread.dylib+0x1804ef8d8)
 #5 0x000000018f3ea790 (/usr/lib/system/libsystem_c.dylib+0x1803f6790)
 #6 0x000000018f3e99ec (/usr/lib/system/libsystem_c.dylib+0x1803f59ec)
 #7 0x000000010832c0a0 void llvm::function_ref<void (swift::Lowering::Initialization*)>::callback_fn<(anonymous namespace)::EmitBBArguments::expandPack(swift::Lowering::AbstractionPattern, swift::ArrayRefView<swift::TupleTypeElt, swift::CanType, swift::getCanTupleEltType(swift::TupleTypeElt const&), false>, unsigned long, llvm::MutableArrayRef<swift::PossiblyUniquePtr<swift::Lowering::Initialization, llvm::PointerLikeTypeTraits<swift::Lowering::Initialization*>>>, llvm::SmallVectorImpl<swift::Lo […truncated…]
 #8 0x00000001031d32e4 void llvm::function_ref<void (swift::Lowering::TupleElementGenerator&)>::callback_fn<(anonymous namespace)::EmitBBArguments::expandTuple(swift::Lowering::AbstractionPattern, swift::CanTypeWrapper<swift::TupleType>, swift::Lowering::TypeLowering const&, swift::Lowering::Initialization*)::'lambda'(swift::Lowering::TupleElementGenerator&)>(long, swift::Lowering::TupleElementGenerator&) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-ma […truncated…]
 #9 0x00000001033733a8 swift::Lowering::AbstractionPattern::forEachTupleElement(swift::CanType, llvm::function_ref<void (swift::Lowering::TupleElementGenerator&)>) const (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100b033a8)
#10 0x00000001031d2914 (anonymous namespace)::EmitBBArguments::expandTuple(swift::Lowering::AbstractionPattern, swift::CanTypeWrapper<swift::TupleType>, swift::Lowering::TypeLowering const&, swift::Lowering::Initialization*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100962914)
#11 0x00000001031d2720 (anonymous namespace)::EmitBBArguments::visitTupleType(swift::CanTypeWrapper<swift::TupleType>, swift::Lowering::AbstractionPattern, swift::Lowering::Initialization*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100962720)
#12 0x00000001031d1b74 swift::CanTypeVisitor<(anonymous namespace)::EmitBBArguments, swift::Lowering::ManagedValue, swift::Lowering::AbstractionPattern, swift::Lowering::Initialization*>::visit(swift::CanType, swift::Lowering::AbstractionPattern, swift::Lowering::Initialization*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100961b74)
#13 0x00000001031d0cb8 (anonymous namespace)::ArgumentInitHelper::makeArgument(swift::SILLocation, swift::ParamDecl*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100960cb8)
#14 0x00000001031cf804 (anonymous namespace)::ArgumentInitHelper::emitParam(swift::ParamDecl*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x10095f804)
#15 0x00000001031ce540 swift::Lowering::SILGenFunction::emitBasicProlog(swift::DeclContext*, swift::ParameterList*, swift::ParamDecl*, swift::Type, std::__1::optional<swift::Type>, swift::SourceLoc, unsigned int) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x10095e540)
#16 0x00000001031ccec4 swift::Lowering::SILGenFunction::emitProlog(swift::DeclContext*, swift::CaptureInfo, swift::ParameterList*, swift::ParamDecl*, swift::Type, std::__1::optional<swift::Type>, swift::SourceLoc) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x10095cec4)
#17 0x000000010316c658 swift::Lowering::SILGenFunction::emitClosure(swift::AbstractClosureExpr*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1008fc658)
#18 0x00000001030d6968 swift::Lowering::SILGenModule::emitFunctionDefinition(swift::SILDeclRef, swift::SILFunction*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100866968)
#19 0x00000001030de284 void llvm::function_ref<void ()>::callback_fn<swift::Lowering::SILGenModule::emitClosure(swift::AbstractClosureExpr*, swift::Lowering::FunctionTypeInfo const&)::$_0>(long) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x10086e284)
#20 0x00000001034578b8 swift::Lowering::TypeConverter::withClosureTypeInfo(swift::AbstractClosureExpr*, swift::Lowering::FunctionTypeInfo const&, llvm::function_ref<void ()>) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100be78b8)
#21 0x00000001030d9108 swift::Lowering::SILGenModule::emitClosure(swift::AbstractClosureExpr*, swift::Lowering::FunctionTypeInfo const&) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100869108)
#22 0x0000000103161758 (anonymous namespace)::RValueEmitter::emitClosureReference(swift::AbstractClosureExpr*, swift::Lowering::FunctionTypeInfo const&) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1008f1758)
#23 0x0000000103161488 (anonymous namespace)::RValueEmitter::visitAbstractClosureExpr(swift::AbstractClosureExpr*, swift::Lowering::SGFContext) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1008f1488)
#24 0x0000000103147168 swift::Lowering::SILGenFunction::emitRValueAsSingleValue(swift::Expr*, swift::Lowering::SGFContext) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1008d7168)
#25 0x000000010312afa0 swift::Lowering::SILGenFunction::emitConvertedRValue(swift::SILLocation, swift::Lowering::Conversion const&, swift::Lowering::SGFContext, llvm::function_ref<swift::Lowering::ManagedValue (swift::Lowering::SILGenFunction&, swift::SILLocation, swift::Lowering::SGFContext)>) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1008bafa0)
#26 0x000000010312b16c swift::Lowering::ConvertingInitialization::tryPeephole(swift::Lowering::SILGenFunction&, swift::SILLocation, swift::Lowering::Conversion, llvm::function_ref<swift::Lowering::ManagedValue (swift::Lowering::SILGenFunction&, swift::SILLocation, swift::Lowering::SGFContext)>) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1008bb16c)
#27 0x000000010312af14 swift::Lowering::SILGenFunction::emitConvertedRValue(swift::SILLocation, swift::Lowering::Conversion const&, swift::Lowering::SGFContext, llvm::function_ref<swift::Lowering::ManagedValue (swift::Lowering::SILGenFunction&, swift::SILLocation, swift::Lowering::SGFContext)>) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1008baf14)
#28 0x000000010312b080 swift::Lowering::SILGenFunction::emitConvertedRValue(swift::Expr*, swift::Lowering::Conversion const&, swift::Lowering::SGFContext) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1008bb080)
#29 0x0000000103159404 (anonymous namespace)::RValueEmitter::visitFunctionConversionExpr(swift::FunctionConversionExpr*, swift::Lowering::SGFContext) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1008e9404)
#30 0x0000000103147168 swift::Lowering::SILGenFunction::emitRValueAsSingleValue(swift::Expr*, swift::Lowering::SGFContext) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1008d7168)
#31 0x000000010312afa0 swift::Lowering::SILGenFunction::emitConvertedRValue(swift::SILLocation, swift::Lowering::Conversion const&, swift::Lowering::SGFContext, llvm::function_ref<swift::Lowering::ManagedValue (swift::Lowering::SILGenFunction&, swift::SILLocation, swift::Lowering::SGFContext)>) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1008bafa0)
#32 0x00000001030bf0e0 swift::Lowering::ArgumentSource::getConverted(swift::Lowering::SILGenFunction&, swift::Lowering::Conversion const&, swift::Lowering::SGFContext) && (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x10084f0e0)
#33 0x00000001030f64c8 (anonymous namespace)::ArgEmitter::emit(swift::Lowering::ArgumentSource&&, swift::Lowering::AbstractionPattern, bool, std::__1::optional<swift::AnyFunctionType::Param>) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1008864c8)
#34 0x00000001030e6f24 (anonymous namespace)::ArgEmitter::emitSingleArg(swift::Lowering::ArgumentSource&&, swift::Lowering::AbstractionPattern, bool, std::__1::optional<swift::AnyFunctionType::Param>) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100876f24)
 […further frames elided…]
```
