### PR TITLE
[release/6.3] Add regression test: variadic generic closures pack expansion arg crash (compiler crash)

### DIFF
--- a/test/SILGen/variadic_generic_closures_pack_expansion_arg_crash.swift
+++ b/test/SILGen/variadic_generic_closures_pack_expansion_arg_crash.swift
@@ -1,0 +1,50 @@
+// RUN: %target-swift-emit-silgen -target %target-swift-5.9-abi-triple %s
+
+// Test that passing a pack expansion tuple to a throwing closure compiles
+// without crashing. This tests the fix for a bug where SILGen would crash
+// when attempting to expand a tuple containing pack expansions (e.g.,
+// `(repeat each T)`) into pack arguments, because the element count is
+// only known at runtime in a generic context.
+
+// Test case 1: Direct parameter passing
+struct S<each Input> {
+    func run(_ input: (repeat each Input), test: ((repeat each Input)) throws -> Void) throws {
+        try test(input)
+    }
+}
+
+// Test case 2: Iterator pattern (from PropertyTestingKit)
+// This tests the case where a pack expansion tuple is obtained from iterating
+// over an array and then passed to a closure.
+struct FuzzEngine<each Input> {
+    func run(inputs: [(repeat each Input)], test: ((repeat each Input)) throws -> Void) throws {
+        for input in inputs {
+            try test(input)
+        }
+    }
+}
+
+// Test case 3: Single-element pack with closure
+// This tests the specific case where the closure's parameter is a single-element
+// pack expansion tuple that vanishes after substitution (e.g., FuzzEngine<Bool>).
+// The closure receives a pack parameter in the lowered representation, but the
+// formal parameter appears as a scalar after the tuple vanishes.
+func testSingleElementPack() throws {
+    let engine = FuzzEngine<Bool>()
+    try engine.run(inputs: []) { _ in }
+}
+
+// Test case 4: Closure with function type parameter
+// This tests that closures with function type parameters still work correctly.
+// This is a regression test to ensure the pack handling fix doesn't incorrectly
+// apply unchecked casts to function types, which require proper reabstraction.
+func withFunctionClosure(_ body: (UnsafeMutablePointer<Int>) -> Void) {
+    var x = 0
+    body(&x)
+}
+
+func testFunctionTypeParameter() {
+    withFunctionClosure { ptr in
+        ptr.pointee = 42
+    }
+}


### PR DESCRIPTION
## Summary

Test that passing a pack expansion tuple to a throwing closure compiles without crashing. This tests the fix for a bug where SILGen would crash when attempting to expand a tuple containing pack expansions (e.g., `(repeat each T)`) into pack arguments, because the element count is only known at runtime in a generic context.

## Failure category

`compiler-crash` — The compiler crashes when processing this source.

## Reproduction

Branch: `test-survey/SILGen_variadic_generic_closures_pack_expansion_arg_crash` (off `release/6.3`).
Test file: `test/SILGen/variadic_generic_closures_pack_expansion_arg_crash.swift`
Run: `lit -v test/SILGen/variadic_generic_closures_pack_expansion_arg_crash.swift`

## Test source (`test/SILGen/variadic_generic_closures_pack_expansion_arg_crash.swift`)

```swift
// RUN: %target-swift-emit-silgen -target %target-swift-5.9-abi-triple %s

// Test that passing a pack expansion tuple to a throwing closure compiles
// without crashing. This tests the fix for a bug where SILGen would crash
// when attempting to expand a tuple containing pack expansions (e.g.,
// `(repeat each T)`) into pack arguments, because the element count is
// only known at runtime in a generic context.

// Test case 1: Direct parameter passing
struct S<each Input> {
 func run(_ input: (repeat each Input), test: ((repeat each Input)) throws -> Void) throws {
 try test(input)
 }
}

// Test case 2: Iterator pattern (from PropertyTestingKit)
// This tests the case where a pack expansion tuple is obtained from iterating
// over an array and then passed to a closure.
struct FuzzEngine<each Input> {
 func run(inputs: [(repeat each Input)], test: ((repeat each Input)) throws -> Void) throws {
 for input in inputs {
 try test(input)
 }
 }
}

// Test case 3: Single-element pack with closure
// This tests the specific case where the closure's parameter is a single-element
// pack expansion tuple that vanishes after substitution (e.g., FuzzEngine<Bool>).
// The closure receives a pack parameter in the lowered representation, but the
// formal parameter appears as a scalar after the tuple vanishes.
func testSingleElementPack() throws {
 let engine = FuzzEngine<Bool>()
 try engine.run(inputs: []) { _ in }
}

// Test case 4: Closure with function type parameter
// This tests that closures with function type parameters still work correctly.
// This is a regression test to ensure the pack handling fix doesn't incorrectly
// apply unchecked casts to function types, which require proper reabstraction.
func withFunctionClosure(_ body: (UnsafeMutablePointer<Int>) -> Void) {
 var x = 0
 body(&x)
}

func testFunctionTypeParameter() {
 withFunctionClosure { ptr in
 ptr.pointee = 42
 }
}
```

## Crash trace

```
Assertion failed: (!tupleTy.containsPackExpansionType() && "can't extract elements from tuples containing pack expansions " "right now"), function extractElements, file RValue.cpp, line 707.
Please submit a bug report (https://swift.org/contributing/#reporting-bugs) and include the crash backtrace.
Stack dump:
0.	Program arguments: […elided…]
1.	Swift version 6.3.2-dev (LLVM 4e6cdf5caf79efb, Swift d23e82655fe203f)
2.	Compiling with effective version 4.1.50
3.	While evaluating request ASTLoweringRequest(Lowering AST to SIL for module variadic_generic_closures_pack_expansion_arg_crash)
4.	While silgen emitFunction SIL function "@$s50variadic_generic_closures_pack_expansion_arg_crash1SV3run_4testyxxQp_t_yxxQp_t_tKXEtKF".
 for 'run(_:test:)' (at /Users/alex.reilly/Documents/OpenSource/swift-6.3-test/test/SILGen/variadic_generic_closures_pack_expansion_arg_crash.swift:11:5)
 #0 0x0000000105c5cb30 llvm::sys::PrintStackTrace(llvm::raw_ostream&, int) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x105a80b30)
 #1 0x0000000105c5abec llvm::sys::RunSignalHandlers() (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x105a7ebec)
 #2 0x0000000105c5d5d8 SignalHandler(int, __siginfo*, void*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x105a815d8)
 #3 0x000000018f4ed7a4 (/usr/lib/system/libsystem_platform.dylib+0x1804f97a4)
 #4 0x000000018f4e38d8 (/usr/lib/system/libsystem_pthread.dylib+0x1804ef8d8)
 #5 0x000000018f3ea790 (/usr/lib/system/libsystem_c.dylib+0x1803f6790)
 #6 0x000000018f3e99ec (/usr/lib/system/libsystem_c.dylib+0x1803f59ec)
 #7 0x0000000105c890dc swift::Lowering::RValue::copy(swift::Lowering::SILGenFunction&, swift::SILLocation) const & (.cold.1) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x105aad0dc)
 #8 0x0000000100a38654 swift::Lowering::RValue::extractElements(llvm::SmallVectorImpl<swift::Lowering::RValue>&) && (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x10085c654)
 #9 0x0000000100a2c4f4 swift::Lowering::ArgumentSourceExpansion::ArgumentSourceExpansion(swift::Lowering::SILGenFunction&, swift::Lowering::ArgumentSource&&, bool) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1008504f4)
#10 0x0000000100a61730 (anonymous namespace)::ArgEmitter::emit(swift::Lowering::ArgumentSource&&, swift::Lowering::AbstractionPattern, bool, std::__1::optional<swift::AnyFunctionType::Param>) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100885730)
#11 0x0000000100a52f24 (anonymous namespace)::ArgEmitter::emitSingleArg(swift::Lowering::ArgumentSource&&, swift::Lowering::AbstractionPattern, bool, std::__1::optional<swift::AnyFunctionType::Param>) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100876f24)
#12 0x0000000100a60a6c (anonymous namespace)::ArgEmitter::emitPreparedArgs(swift::Lowering::PreparedArguments&&, swift::Lowering::AbstractionPattern, llvm::ArrayRef<swift::LifetimeDependenceInfo>) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100884a6c)
#13 0x0000000100a6baec (anonymous namespace)::CallSite::emit(swift::Lowering::SILGenFunction&, swift::Lowering::AbstractionPattern, swift::CanTypeWrapper<swift::SILFunctionType>, llvm::ArrayRef<swift::LifetimeDependenceInfo>, (anonymous namespace)::ParamLowering&, llvm::SmallVectorImpl<swift::Lowering::ManagedValue>&, llvm::SmallVectorImpl<(anonymous namespace)::DelayedArgument>&, swift::ForeignInfo const&) && (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swi […truncated…]
#14 0x0000000100a6b42c (anonymous namespace)::CallEmission::emitArgumentsForNormalApply(swift::Lowering::AbstractionPattern, swift::CanTypeWrapper<swift::SILFunctionType>, llvm::ArrayRef<swift::LifetimeDependenceInfo>, swift::ForeignInfo const&, llvm::SmallVectorImpl<swift::Lowering::ManagedValue>&, std::__1::optional<swift::SILLocation>&) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x10088f42c)
#15 0x0000000100a567ec (anonymous namespace)::CallEmission::apply(swift::Lowering::SGFContext) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x10087a7ec)
#16 0x0000000100a54784 swift::Lowering::SILGenFunction::emitApplyExpr(swift::ApplyExpr*, swift::Lowering::SGFContext) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100878784)
#17 0x0000000100ab3750 swift::Lowering::SILGenFunction::emitIgnoredExpr(swift::Expr*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1008d7750)
#18 0x0000000100b41478 swift::ASTVisitor<(anonymous namespace)::StmtEmitter, void, void, void, void, void, void>::visit(swift::Stmt*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100965478)
#19 0x0000000100b3ff7c swift::Lowering::SILGenFunction::emitStmt(swift::Stmt*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100963f7c)
#20 0x0000000100ad8484 swift::Lowering::SILGenFunction::emitFunction(swift::FuncDecl*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1008fc484)
#21 0x0000000100a43120 swift::Lowering::SILGenModule::emitFunctionDefinition(swift::SILDeclRef, swift::SILFunction*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100867120)
#22 0x0000000100a43f1c swift::Lowering::SILGenModule::emitOrDelayFunction(swift::SILDeclRef) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100867f1c)
#23 0x0000000100a41acc swift::Lowering::SILGenModule::emitFunction(swift::FuncDecl*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100865acc)
#24 0x0000000100b54cb4 (anonymous namespace)::SILGenType::visitFuncDecl(swift::FuncDecl*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100978cb4)
#25 0x0000000100b51ab8 (anonymous namespace)::SILGenType::emitType() (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100975ab8)
#26 0x0000000100b51a10 swift::Lowering::SILGenModule::visitNominalTypeDecl(swift::NominalTypeDecl*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100975a10)
#27 0x0000000100a469d0 swift::Lowering::SILGenModule::emitSourceFile(swift::SourceFile*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x10086a9d0)
#28 0x0000000100a46ebc swift::ASTLoweringRequest::evaluate(swift::Evaluator&, swift::ASTLoweringDescriptor) const (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x10086aebc)
#29 0x0000000100b3f9a0 swift::SimpleRequest<swift::ASTLoweringRequest, std::__1::unique_ptr<swift::SILModule, std::__1::default_delete<swift::SILModule>> (swift::ASTLoweringDescriptor), (swift::RequestFlags)17>::evaluateRequest(swift::ASTLoweringRequest const&, swift::Evaluator&) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1009639a0)
#30 0x0000000100a4ab50 swift::ASTLoweringRequest::OutputType swift::Evaluator::getResultUncached<swift::ASTLoweringRequest, swift::ASTLoweringRequest::OutputType swift::evaluateOrFatal<swift::ASTLoweringRequest>(swift::Evaluator&, swift::ASTLoweringRequest)::'lambda'()>(swift::ASTLoweringRequest const&, swift::ASTLoweringRequest::OutputType swift::evaluateOrFatal<swift::ASTLoweringRequest>(swift::Evaluator&, swift::ASTLoweringRequest)::'lambda'())::'lambda'()::operator()() const (/Users/alex.rei […truncated…]
#31 0x0000000100a4aa6c swift::ASTLoweringRequest::OutputType swift::Evaluator::getResultUncached<swift::ASTLoweringRequest, swift::ASTLoweringRequest::OutputType swift::evaluateOrFatal<swift::ASTLoweringRequest>(swift::Evaluator&, swift::ASTLoweringRequest)::'lambda'()>(swift::ASTLoweringRequest const&, swift::ASTLoweringRequest::OutputType swift::evaluateOrFatal<swift::ASTLoweringRequest>(swift::Evaluator&, swift::ASTLoweringRequest)::'lambda'()) (/Users/alex.reilly/Documents/OpenSource/build/N […truncated…]
#32 0x0000000100a47190 swift::performASTLowering(swift::ModuleDecl*, swift::Lowering::TypeConverter&, swift::SILOptions const&, swift::IRGenOptions const*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x10086b190)
#33 0x000000010047d368 swift::performCompileStepsPostSema(swift::CompilerInstance&, int&, swift::FrontendObserver*, llvm::ArrayRef<char const*>) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1002a1368)
#34 0x000000010048cff4 withSemanticAnalysis(swift::CompilerInstance&, swift::FrontendObserver*, llvm::function_ref<bool (swift::CompilerInstance&)>, bool) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1002b0ff4)
 […further frames elided…]
```
