### PR TITLE
[release/6.3] Add regression test: definite init variadic generics (compiler crash)

### DIFF
--- a/test/SILOptimizer/definite_init_variadic_generics.swift
+++ b/test/SILOptimizer/definite_init_variadic_generics.swift
@@ -1,0 +1,146 @@
+// RUN: %target-swift-frontend -emit-sil %s -target %target-swift-5.9-abi-triple | %FileCheck %s
+
+// This test verifies that definite initialization correctly handles
+// structs with tuple properties containing pack expansions.
+// The DI pass must treat such tuples as single opaque elements rather
+// than trying to flatten them into individual element addresses.
+
+// MARK: - Basic struct with pack expansion tuple
+
+struct BasicPackTuple<each T> {
+  let values: (repeat each T)
+
+  // CHECK-LABEL: sil hidden @$s31definite_init_variadic_generics14BasicPackTupleV
+  // CHECK: tuple_pack_element_addr
+  init(_ values: repeat each T) {
+    self.values = (repeat each values)
+  }
+}
+
+// MARK: - Struct with multiple properties including pack expansion tuple
+
+struct MixedProperties<each T> {
+  let prefix: Int
+  let packed: (repeat each T)
+  let suffix: String
+
+  // CHECK-LABEL: sil hidden @$s31definite_init_variadic_generics15MixedPropertiesV
+  // CHECK: tuple_pack_element_addr
+  init(prefix: Int, suffix: String, _ values: repeat each T) {
+    self.prefix = prefix
+    self.packed = (repeat each values)
+    self.suffix = suffix
+  }
+}
+
+// MARK: - Struct with pack expansion tuple initialized in different branches
+
+struct ConditionalInit<each T> {
+  let values: (repeat each T)
+  let flag: Bool
+
+  // CHECK-LABEL: sil hidden @$s31definite_init_variadic_generics15ConditionalInitV
+  // CHECK: tuple_pack_element_addr
+  init(condition: Bool, _ values: repeat each T) {
+    self.flag = condition
+    if condition {
+      self.values = (repeat each values)
+    } else {
+      self.values = (repeat each values)
+    }
+  }
+}
+
+// MARK: - Nested struct containing pack expansion tuple
+
+struct Outer<each T> {
+  struct Inner {
+    let data: (repeat each T)
+
+    // CHECK-LABEL: sil hidden @$s31definite_init_variadic_generics5OuterV5InnerV
+    // CHECK: tuple_pack_element_addr
+    init(_ values: repeat each T) {
+      self.data = (repeat each values)
+    }
+  }
+
+  let inner: Inner
+
+  init(_ values: repeat each T) {
+    self.inner = Inner(repeat each values)
+  }
+}
+
+// MARK: - Class with pack expansion tuple property
+
+class ClassWithPackTuple<each T> {
+  let values: (repeat each T)
+
+  // CHECK-LABEL: sil hidden {{.*}}@$s31definite_init_variadic_generics18ClassWithPackTupleC
+  // CHECK: tuple_pack_element_addr
+  init(_ values: repeat each T) {
+    self.values = (repeat each values)
+  }
+}
+
+// MARK: - Failable initializer with pack expansion tuple
+
+struct FailablePackInit<each T> {
+  let values: (repeat each T)
+
+  // CHECK-LABEL: sil hidden @$s31definite_init_variadic_generics16FailablePackInitV
+  // CHECK: tuple_pack_element_addr
+  init?(_ values: repeat each T, shouldFail: Bool) {
+    if shouldFail {
+      return nil
+    }
+    self.values = (repeat each values)
+  }
+}
+
+// MARK: - Struct with throwing initializer and pack expansion tuple
+
+struct ThrowingPackInit<each T> {
+  let values: (repeat each T)
+
+  // CHECK-LABEL: sil hidden @$s31definite_init_variadic_generics16ThrowingPackInitV
+  // CHECK: tuple_pack_element_addr
+  init(_ values: repeat each T) throws {
+    self.values = (repeat each values)
+  }
+}
+
+// MARK: - Crash case: throwing call AFTER pack tuple assignment
+// This is the minimal reproducer for the DI crash. The crash occurs when:
+// 1. Struct has multiple properties including a pack expansion tuple
+// 2. Pack tuple is assigned first
+// 3. A throwing call comes AFTER the pack tuple assignment
+// DI must generate cleanup code to destroy the pack tuple if the throw occurs,
+// and was incorrectly using tuple_element_addr instead of treating it as opaque.
+
+func produceValue<T>(type: T.Type) -> T { fatalError() }
+func throwingCall() throws -> Int { return 0 }
+
+struct ThrowingAfterPackInit<each T> {
+  let packed: (repeat each T)
+  let other: Int
+
+  // CHECK-LABEL: sil hidden @$s31definite_init_variadic_generics21ThrowingAfterPackInitV
+  // CHECK: tuple_pack_element_addr
+  init() throws {
+    self.packed = (repeat produceValue(type: (each T).self))
+    self.other = try throwingCall()
+  }
+}
+
+// MARK: - Test instantiations to ensure code generation works
+
+func testInstantiations() {
+  _ = BasicPackTuple(1, "hello", 3.14)
+  _ = MixedProperties(prefix: 42, suffix: "end", true, 2.0)
+  _ = ConditionalInit(condition: true, "a", "b")
+  _ = Outer(1, 2, 3)
+  _ = ClassWithPackTuple("x", "y")
+  _ = FailablePackInit(1, 2, shouldFail: false)
+  _ = try? ThrowingPackInit(true, false)
+}


### PR DESCRIPTION
## Summary

This test verifies that definite initialization correctly handles structs with tuple properties containing pack expansions. The DI pass must treat such tuples as single opaque elements rather than trying to flatten them into individual element addresses.

## Failure category

`compiler-crash` — The compiler crashes when processing this source.

## Reproduction

Branch: `test-survey/SILOptimizer_definite_init_variadic_generics` (off `release/6.3`).
Test file: `test/SILOptimizer/definite_init_variadic_generics.swift`
Run: `lit -v test/SILOptimizer/definite_init_variadic_generics.swift`

## Test source (`test/SILOptimizer/definite_init_variadic_generics.swift`)

```swift
// RUN: %target-swift-frontend -emit-sil %s -target %target-swift-5.9-abi-triple | %FileCheck %s

// This test verifies that definite initialization correctly handles
// structs with tuple properties containing pack expansions.
// The DI pass must treat such tuples as single opaque elements rather
// than trying to flatten them into individual element addresses.

// MARK: - Basic struct with pack expansion tuple

struct BasicPackTuple<each T> {
 let values: (repeat each T)

 // CHECK-LABEL: sil hidden @$s31definite_init_variadic_generics14BasicPackTupleV
 // CHECK: tuple_pack_element_addr
 init(_ values: repeat each T) {
 self.values = (repeat each values)
 }
}

// MARK: - Struct with multiple properties including pack expansion tuple

struct MixedProperties<each T> {
 let prefix: Int
 let packed: (repeat each T)
 let suffix: String

 // CHECK-LABEL: sil hidden @$s31definite_init_variadic_generics15MixedPropertiesV
 // CHECK: tuple_pack_element_addr
 init(prefix: Int, suffix: String, _ values: repeat each T) {
 self.prefix = prefix
 self.packed = (repeat each values)
 self.suffix = suffix
 }
}

// MARK: - Struct with pack expansion tuple initialized in different branches

struct ConditionalInit<each T> {
 let values: (repeat each T)
 let flag: Bool

 // CHECK-LABEL: sil hidden @$s31definite_init_variadic_generics15ConditionalInitV
 // CHECK: tuple_pack_element_addr
 init(condition: Bool, _ values: repeat each T) {
 self.flag = condition
 if condition {
 self.values = (repeat each values)
 } else {
 self.values = (repeat each values)
 }
 }
}

// MARK: - Nested struct containing pack expansion tuple

struct Outer<each T> {
 struct Inner {
 let data: (repeat each T)

 // CHECK-LABEL: sil hidden @$s31definite_init_variadic_generics5OuterV5InnerV
 // CHECK: tuple_pack_element_addr
 init(_ values: repeat each T) {
 self.data = (repeat each values)
 }
 }

 let inner: Inner

 init(_ values: repeat each T) {
 self.inner = Inner(repeat each values)
 }
}

// MARK: - Class with pack expansion tuple property

class ClassWithPackTuple<each T> {
 let values: (repeat each T)

 // CHECK-LABEL: sil hidden {{.*}}@$s31definite_init_variadic_generics18ClassWithPackTupleC
 // CHECK: tuple_pack_element_addr
 init(_ values: repeat each T) {
 self.values = (repeat each values)
 }
}

// MARK: - Failable initializer with pack expansion tuple

struct FailablePackInit<each T> {
 let values: (repeat each T)

 // CHECK-LABEL: sil hidden @$s31definite_init_variadic_generics16FailablePackInitV
 // CHECK: tuple_pack_element_addr
 init?(_ values: repeat each T, shouldFail: Bool) {
 if shouldFail {
 return nil
 }
 self.values = (repeat each values)
 }
}

// MARK: - Struct with throwing initializer and pack expansion tuple

struct ThrowingPackInit<each T> {
 let values: (repeat each T)

 // CHECK-LABEL: sil hidden @$s31definite_init_variadic_generics16ThrowingPackInitV
 // CHECK: tuple_pack_element_addr
 init(_ values: repeat each T) throws {
 self.values = (repeat each values)
 }
}

// MARK: - Crash case: throwing call AFTER pack tuple assignment
// This is the minimal reproducer for the DI crash. The crash occurs when:
// 1. Struct has multiple properties including a pack expansion tuple
// 2. Pack tuple is assigned first
// 3. A throwing call comes AFTER the pack tuple assignment
// DI must generate cleanup code to destroy the pack tuple if the throw occurs,
// and was incorrectly using tuple_element_addr instead of treating it as opaque.

func produceValue<T>(type: T.Type) -> T { fatalError() }
func throwingCall() throws -> Int { return 0 }

struct ThrowingAfterPackInit<each T> {
 let packed: (repeat each T)
 let other: Int

 // CHECK-LABEL: sil hidden @$s31definite_init_variadic_generics21ThrowingAfterPackInitV
 // CHECK: tuple_pack_element_addr
 init() throws {
 self.packed = (repeat produceValue(type: (each T).self))
 self.other = try throwingCall()
 }
}

// MARK: - Test instantiations to ensure code generation works

func testInstantiations() {
 _ = BasicPackTuple(1, "hello", 3.14)
 _ = MixedProperties(prefix: 42, suffix: "end", true, 2.0)
 _ = ConditionalInit(condition: true, "a", "b")
 _ = Outer(1, 2, 3)
 _ = ClassWithPackTuple("x", "y")
 _ = FailablePackInit(1, 2, shouldFail: false)
 _ = try? ThrowingPackInit(true, false)
}
```

## Crash trace

```
Stack dump:
0.	Program arguments: […elided…]
1.	Swift version 6.3.2-dev (LLVM 4e6cdf5caf79efb, Swift d23e82655fe203f)
2.	Compiling with effective version 4.1.50
3.	While verifying SIL function "@$s31definite_init_variadic_generics21ThrowingAfterPackInitVACyxxQp_QPGyKcfC".
 for 'init()' (at /Users/alex.reilly/Documents/OpenSource/swift-6.3-test/test/SILOptimizer/definite_init_variadic_generics.swift:130:3)
 #0 0x0000000107edcb30 llvm::sys::PrintStackTrace(llvm::raw_ostream&, int) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x105a80b30)
 #1 0x0000000107edabec llvm::sys::RunSignalHandlers() (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x105a7ebec)
 #2 0x0000000107edd5d8 SignalHandler(int, __siginfo*, void*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x105a815d8)
 #3 0x000000018f4ed7a4 (/usr/lib/system/libsystem_platform.dylib+0x1804f97a4)
 #4 0x000000018f4e38d8 (/usr/lib/system/libsystem_pthread.dylib+0x1804ef8d8)
 #5 0x000000018f3ea790 (/usr/lib/system/libsystem_c.dylib+0x1803f6790)
 #6 0x00000001030fb4dc swift::verificationFailure(llvm::Twine const&, swift::SILInstruction const*, llvm::function_ref<void (swift::SILPrintContext&)>) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100c9f4dc)
 #7 0x0000000103103e30 swift::SILVisitorBase<(anonymous namespace)::SILVerifier, void>::visitSILBasicBlock(swift::SILBasicBlock*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100ca7e30)
 #8 0x00000001031028c4 (anonymous namespace)::SILVerifier::visitSILBasicBlock(swift::SILBasicBlock*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100ca68c4)
 #9 0x00000001030fe00c swift::SILFunction::verify(swift::CalleeCache*, bool, bool, bool) const (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100ca200c)
#10 0x00000001031015dc swift::SILModule::verify(swift::CalleeCache*, bool, bool) const (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100ca55dc)
#11 0x00000001031014e0 swift::SILModule::verify(bool, bool) const (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100ca54e0)
#12 0x0000000102953a50 swift::CompilerInstance::performSILProcessing(swift::SILModule*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1004f7a50)
#13 0x00000001026fd7ec performCompileStepsPostSILGen(swift::CompilerInstance&, std::__1::unique_ptr<swift::SILModule, std::__1::default_delete<swift::SILModule>>, llvm::PointerUnion<swift::ModuleDecl*, swift::SourceFile*>, swift::PrimarySpecificPaths const&, int&, swift::FrontendObserver*, llvm::ArrayRef<char const*>) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1002a17ec)
#14 0x00000001026fd394 swift::performCompileStepsPostSema(swift::CompilerInstance&, int&, swift::FrontendObserver*, llvm::ArrayRef<char const*>) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1002a1394)
#15 0x000000010270cff4 withSemanticAnalysis(swift::CompilerInstance&, swift::FrontendObserver*, llvm::function_ref<bool (swift::CompilerInstance&)>, bool) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1002b0ff4)
#16 0x0000000102700a40 performCompile(swift::CompilerInstance&, int&, swift::FrontendObserver*, llvm::ArrayRef<char const*>) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1002a4a40)
#17 0x00000001026fe5f4 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1002a25f4)
#18 0x0000000102494790 swift::mainEntry(int, char const**) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100038790)
#19 0x000000018f127da4
FileCheck error: '<stdin>' is empty.
FileCheck command line: /Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/llvm-macosx-arm64/bin/FileCheck --allow-unused-prefixes /Users/alex.reilly/Documents/OpenSource/swift-6.3-test/test/SILOptimizer/definite_init_variadic_generics.swift

--

********************

2 warning(s) in tests
********************
```
