### PR TITLE
[release/6.3] Add regression test: variadic generic tuple assign crash (compiler crash)

### DIFF
--- a/test/SILOptimizer/variadic_generic_tuple_assign_crash.swift
+++ b/test/SILOptimizer/variadic_generic_tuple_assign_crash.swift
@@ -1,0 +1,27 @@
+// RUN: %target-swift-frontend -emit-sil %s -target %target-swift-5.9-abi-triple
+// RUN: %target-swift-frontend -emit-ir %s -target %target-swift-5.9-abi-triple
+
+// This test case reproduces a crash in DefiniteInitialization when initializing
+// a struct property that is a tuple containing a pack expansion.
+//
+// The crash occurs when:
+// 1. Struct has multiple properties including a pack expansion tuple
+// 2. Pack tuple is assigned first
+// 3. A throwing call comes AFTER the pack tuple assignment
+//
+// DI must generate cleanup code to destroy the pack tuple if the throw occurs.
+// The bug was that DI incorrectly used tuple_element_addr (which requires static
+// indices) instead of treating the pack tuple as a single opaque element.
+
+func produceValue<T>(type: T.Type) -> T { fatalError() }
+func throwingCall() throws -> Int { return 0 }
+
+public struct CrashCase<each Input> {
+    public let input: (repeat each Input)
+    public let foo: Int
+
+    public init() throws {
+        self.input = (repeat produceValue(type: (each Input).self))
+        self.foo = try throwingCall()
+    }
+}


### PR DESCRIPTION
## Summary

This test case reproduces a crash in DefiniteInitialization when initializing a struct property that is a tuple containing a pack expansion. The crash occurs when: 1. Struct has multiple properties including a pack expansion tuple 2. Pack tuple is assigned first 3. A throwing call comes AFTER the pack tuple assignment DI must generate cleanup code to destroy the pack tuple if the throw occurs. The bug was that DI incorrectly used tuple_element_addr (which requires static indices) instead of treating the pack tuple as a single opaque element.

## Failure category

`compiler-crash` — The compiler crashes when processing this source.

## Reproduction

Branch: `test-survey/SILOptimizer_variadic_generic_tuple_assign_crash` (off `release/6.3`).
Test file: `test/SILOptimizer/variadic_generic_tuple_assign_crash.swift`
Run: `lit -v test/SILOptimizer/variadic_generic_tuple_assign_crash.swift`

## Test source (`test/SILOptimizer/variadic_generic_tuple_assign_crash.swift`)

```swift
// RUN: %target-swift-frontend -emit-sil %s -target %target-swift-5.9-abi-triple
// RUN: %target-swift-frontend -emit-ir %s -target %target-swift-5.9-abi-triple

// This test case reproduces a crash in DefiniteInitialization when initializing
// a struct property that is a tuple containing a pack expansion.
//
// The crash occurs when:
// 1. Struct has multiple properties including a pack expansion tuple
// 2. Pack tuple is assigned first
// 3. A throwing call comes AFTER the pack tuple assignment
//
// DI must generate cleanup code to destroy the pack tuple if the throw occurs.
// The bug was that DI incorrectly used tuple_element_addr (which requires static
// indices) instead of treating the pack tuple as a single opaque element.

func produceValue<T>(type: T.Type) -> T { fatalError() }
func throwingCall() throws -> Int { return 0 }

public struct CrashCase<each Input> {
 public let input: (repeat each Input)
 public let foo: Int

 public init() throws {
 self.input = (repeat produceValue(type: (each Input).self))
 self.foo = try throwingCall()
 }
}
```

## Crash trace

```
Stack dump:
0.	Program arguments: […elided…]
1.	Swift version 6.3.2-dev (LLVM 4e6cdf5caf79efb, Swift d23e82655fe203f)
2.	Compiling with effective version 4.1.50
3.	While verifying SIL function "@$s35variadic_generic_tuple_assign_crash9CrashCaseVACyxxQp_QPGyKcfC".
 for 'init()' (at /Users/alex.reilly/Documents/OpenSource/swift-6.3-test/test/SILOptimizer/variadic_generic_tuple_assign_crash.swift:23:12)
 #0 0x0000000107fa4b30 llvm::sys::PrintStackTrace(llvm::raw_ostream&, int) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x105a80b30)
 #1 0x0000000107fa2bec llvm::sys::RunSignalHandlers() (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x105a7ebec)
 #2 0x0000000107fa55d8 SignalHandler(int, __siginfo*, void*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x105a815d8)
 #3 0x000000018f4ed7a4 (/usr/lib/system/libsystem_platform.dylib+0x1804f97a4)
 #4 0x000000018f4e38d8 (/usr/lib/system/libsystem_pthread.dylib+0x1804ef8d8)
 #5 0x000000018f3ea790 (/usr/lib/system/libsystem_c.dylib+0x1803f6790)
 #6 0x00000001031c34dc swift::verificationFailure(llvm::Twine const&, swift::SILInstruction const*, llvm::function_ref<void (swift::SILPrintContext&)>) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100c9f4dc)
 #7 0x00000001031cbe30 swift::SILVisitorBase<(anonymous namespace)::SILVerifier, void>::visitSILBasicBlock(swift::SILBasicBlock*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100ca7e30)
 #8 0x00000001031ca8c4 (anonymous namespace)::SILVerifier::visitSILBasicBlock(swift::SILBasicBlock*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100ca68c4)
 #9 0x00000001031c600c swift::SILFunction::verify(swift::CalleeCache*, bool, bool, bool) const (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100ca200c)
#10 0x00000001031c95dc swift::SILModule::verify(swift::CalleeCache*, bool, bool) const (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100ca55dc)
#11 0x00000001031c94e0 swift::SILModule::verify(bool, bool) const (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100ca54e0)
#12 0x0000000102a1ba50 swift::CompilerInstance::performSILProcessing(swift::SILModule*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1004f7a50)
#13 0x00000001027c57ec performCompileStepsPostSILGen(swift::CompilerInstance&, std::__1::unique_ptr<swift::SILModule, std::__1::default_delete<swift::SILModule>>, llvm::PointerUnion<swift::ModuleDecl*, swift::SourceFile*>, swift::PrimarySpecificPaths const&, int&, swift::FrontendObserver*, llvm::ArrayRef<char const*>) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1002a17ec)
#14 0x00000001027c5394 swift::performCompileStepsPostSema(swift::CompilerInstance&, int&, swift::FrontendObserver*, llvm::ArrayRef<char const*>) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1002a1394)
#15 0x00000001027d4ff4 withSemanticAnalysis(swift::CompilerInstance&, swift::FrontendObserver*, llvm::function_ref<bool (swift::CompilerInstance&)>, bool) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1002b0ff4)
#16 0x00000001027c8a40 performCompile(swift::CompilerInstance&, int&, swift::FrontendObserver*, llvm::ArrayRef<char const*>) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1002a4a40)
#17 0x00000001027c65f4 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x1002a25f4)
#18 0x000000010255c790 swift::mainEntry(int, char const**) (/Users/alex.reilly/Documents/OpenSource/build/Ninja-RelWithDebInfoAssert-6.3-test/swift-macosx-arm64/bin/swift-frontend+0x100038790)
#19 0x000000018f127da4
```
