### PR TITLE
[6.4.x] ModuleInterface: Remove warning about types shadowing modules

### DIFF
--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -427,13 +427,6 @@ ERROR(unsupported_version_of_module_interface,none,
       (StringRef, llvm::VersionTuple))
 ERROR(error_opening_explicit_module_file,none,
       "failed to open explicit Swift module: %0", (StringRef))
-WARNING(warning_module_shadowing_may_break_module_interface,none,
-        "public %0 %1 shadows module %2, which may cause failures when "
-        "importing %3 or its clients in some configurations; please rename "
-        "either the %0 %1 or the module %2, or see "
-        "https://github.com/apple/swift/issues/56573 for workarounds",
-        (DescriptiveDeclKind, FullyQualified<Type>,
-        /*shadowedModule=*/ModuleDecl *, /*interfaceModule*/ModuleDecl *))
 REMARK(rebuilding_module_from_interface,none,
        "rebuilding module '%0' from interface '%1'", (StringRef, StringRef))
 NOTE(sdk_version_pbm_version,none,

--- a/lib/Frontend/ModuleInterfaceSupport.cpp
+++ b/lib/Frontend/ModuleInterfaceSupport.cpp
@@ -155,89 +155,6 @@ llvm::Regex swift::getSwiftInterfaceCompilerToolsVersionRegex() {
   return llvm::Regex("Swift version ([0-9\\.]+)", llvm::Regex::Newline);
 }
 
-// MARK(https://github.com/apple/swift/issues/43510): Module name shadowing warnings
-//
-// When swiftc emits a module interface, it qualifies most types with their
-// module name. This usually makes the interface less ambiguous, but if a type
-// exists with the same name as a module, then references to that module will
-// incorrectly look inside the type instead. This breakage is not obvious until
-// someone tries to load the module interface, and may sometimes only occur in
-// clients' module interfaces.
-//
-// Truly fixing this will require a new module-qualification syntax which
-// completely ignores shadowing. In lieu of that, we detect and warn about three
-// common examples which are relatively actionable:
-//
-// 1. An `import` statement written into the module interface will
-//    (transitively) import a type with the module interface's name.
-//
-// 2. The module interface declares a type with the same name as the module the
-//    interface is for.
-//
-// 3. The module interface declares a type with the same name as a module it has
-//     (transitively) imported without `@_implementationOnly`.
-//
-// We do not check for shadowing between imported module names and imported
-// declarations; this is both much rarer and much more difficult to solve.
-// We silence these warnings if you use the temporary workaround flag,
-// '-module-interface-preserve-types-as-written'.
-
-/// Emit a warning explaining that \p shadowingDecl will interfere with
-/// references to types in \p shadowedModule in the module interfaces of
-/// \p brokenModule and its clients.
-static void
-diagnoseDeclShadowsModule(ModuleInterfaceOptions const &Opts,
-                          TypeDecl *shadowingDecl, ModuleDecl *shadowedModule,
-                          ModuleDecl *brokenModule) {
-  if (Opts.PreserveTypesAsWritten || Opts.AliasModuleNames ||
-      shadowingDecl == shadowedModule)
-    return;
-
-  shadowingDecl->diagnose(
-      diag::warning_module_shadowing_may_break_module_interface,
-      shadowingDecl->getDescriptiveKind(),
-      FullyQualified<Type>(shadowingDecl->getDeclaredInterfaceType()),
-      shadowedModule, brokenModule);
-}
-
-/// Check whether importing \p importedModule will bring in any declarations
-/// that will shadow \p importingModule, and diagnose them if so.
-static void
-diagnoseIfModuleImportsShadowingDecl(ModuleInterfaceOptions const &Opts,
-                                     ModuleDecl *importedModule,
-                                     ModuleDecl *importingModule) {
-  using namespace namelookup;
-
-  SmallVector<ValueDecl *, 4> decls;
-  lookupInModule(importedModule, importingModule->getName(),
-                 /*hasModuleSelector=*/false, decls,
-                 NLKind::UnqualifiedLookup, ResolutionKind::TypesOnly,
-                 importedModule, SourceLoc(),
-                 NL_UnqualifiedDefault | NL_IncludeUsableFromInline);
-  for (auto decl : decls)
-    diagnoseDeclShadowsModule(Opts, cast<TypeDecl>(decl), importingModule,
-                              importingModule);
-}
-
-/// Check whether \p D will shadow any modules imported by \p M, and diagnose
-/// them if so.
-static void diagnoseIfDeclShadowsKnownModule(ModuleInterfaceOptions const &Opts,
-                                             Decl *D, ModuleDecl *M) {
-  ASTContext &ctx = M->getASTContext();
-
-  // We only care about types (and modules, which are a subclass of TypeDecl);
-  // when the grammar expects a type name, it ignores non-types during lookup.
-  TypeDecl *TD = dyn_cast<TypeDecl>(D);
-  if (!TD)
-    return;
-
-  ModuleDecl *shadowedModule = ctx.getLoadedModule(TD->getName());
-  if (!shadowedModule || M->isImportedImplementationOnly(shadowedModule))
-    return;
-
-  diagnoseDeclShadowsModule(Opts, TD, shadowedModule, M);
-}
-
 // MARK: Import statements
 
 /// Diagnose any scoped imports in \p imports, i.e. those with a non-empty
@@ -387,8 +304,6 @@ static void printImports(raw_ostream &out,
     }
 
     out << "\n";
-
-    diagnoseIfModuleImportsShadowingDecl(Opts, importedModule, M);
   }
 }
 
@@ -925,9 +840,6 @@ bool swift::emitSwiftInterface(raw_ostream &out,
 
     D->print(out, printOptions);
     out << "\n";
-
-    if (!useModuleSelectors)
-      diagnoseIfDeclShadowsKnownModule(Opts, const_cast<Decl *>(D), M);
   }
 
   // Print dummy extensions for any protocols that were indirectly conformed to.

--- a/test/ModuleInterface/module_shadowing.swift
+++ b/test/ModuleInterface/module_shadowing.swift
@@ -1,49 +1,20 @@
-// RUN: %empty-directory(%t/mcp)
-
-// Build modules imported by this file.
 // RUN: %empty-directory(%t/lib)
-// RUN: %target-swift-emit-module-interface(%t/lib/ShadowyHorror.swiftinterface) %S/Inputs/ShadowyHorror.swift -parse-stdlib -module-cache-path %t/mcp -module-name ShadowyHorror
+
+// Build the ShadowyHorror module (contains 'public class module_shadowing').
+// RUN: %target-swift-emit-module-interface(%t/lib/ShadowyHorror.swiftinterface) %S/Inputs/ShadowyHorror.swift -module-name ShadowyHorror
 // RUN: %target-swift-typecheck-module-from-interface(%t/lib/ShadowyHorror.swiftinterface) -module-name ShadowyHorror
-// RUN: %target-swift-emit-module-interface(%t/lib/TestModule.swiftinterface) %S/Inputs/TestModule.swift -parse-stdlib -module-name TestModule
-// RUN: %target-swift-typecheck-module-from-interface(%t/lib/TestModule.swiftinterface) -module-name TestModule
 
-// Build this file as a module and check that it emits the expected warnings.
-// RUN: %empty-directory(%t/subtest-1)
-// RUN: %target-swift-frontend -typecheck -parse-stdlib -module-cache-path %t/mcp -emit-module-interface-path %t/subtest-1/module_shadowing.swiftinterface %s -enable-library-evolution -module-name module_shadowing -I %t/lib -disable-module-selectors-in-module-interface -swift-version 5 2>&1 | %FileCheck --check-prefix OTHER --implicit-check-not TestModule %s
+// Build this file as a module interface. Verify that no warnings are emitted
+// when a typename shadows an imported module name.
+// RUN: %target-swift-emit-module-interface(%t/module_shadowing.swiftinterface) %s -module-name module_shadowing -I %t/lib -verify
 
-// Make sure that preserve-types-as-written disables this warning.
-// RUN: %empty-directory(%t/subtest-2)
-// RUN: %target-swift-frontend -typecheck -parse-stdlib -module-cache-path %t/mcp -emit-module-interface-path %t/subtest-2/module_shadowing.swiftinterface %s -enable-library-evolution -module-name module_shadowing -I %t/lib -disable-module-selectors-in-module-interface -module-interface-preserve-types-as-written -swift-version 5 -verify
+// Verify the generated .swiftinterface typechecks successfully.
+// RUN: %target-swift-typecheck-module-from-interface(%t/module_shadowing.swiftinterface) -module-name module_shadowing -I %t/lib
 
-// alias-module-names-in-module-interface also disables this warning.
-// RUN: %empty-directory(%t/subtest-2)
-// RUN: %target-swift-frontend -typecheck -parse-stdlib -module-cache-path %t/mcp -emit-module-interface-path %t/subtest-2/module_shadowing.swiftinterface %s -enable-library-evolution -module-name module_shadowing -I %t/lib -disable-module-selectors-in-module-interface -alias-module-names-in-module-interface -swift-version 5 -verify
-
-// Build this module in a different configuration where it will shadow itself.
-// RUN: %empty-directory(%t/subtest-3)
-// RUN: %target-swift-frontend -typecheck -parse-stdlib -module-cache-path %t/mcp -emit-module-interface-path %t/subtest-3/ShadowyHorror.swiftinterface %s -enable-library-evolution -module-name ShadowyHorror -DSELF_SHADOW -disable-module-selectors-in-module-interface -swift-version 5 2>&1 | %FileCheck --check-prefix SELF --implicit-check-not TestModule %s
-
-// FIXME: Verify that the module-shadowing bugs we're trying to address haven't
-// been fixed (https://github.com/apple/swift/issues/43510).
-// RUN: not %target-swift-frontend -typecheck-module-from-interface %t/subtest-1/module_shadowing.swiftinterface -module-cache-path %t/mcp -I %t/lib -module-name module_shadowing 2>&1 | %FileCheck --check-prefix VERIFICATION %s
-// RUN: %target-swift-frontend -typecheck-module-from-interface %t/subtest-2/module_shadowing.swiftinterface -module-cache-path %t/mcp -I %t/lib -module-name module_shadowing
-// RUN: not %target-swift-frontend -typecheck-module-from-interface %t/subtest-3/ShadowyHorror.swiftinterface -module-cache-path %t/mcp -I %t/lib -module-name ShadowyHorror 2>&1 | %FileCheck --check-prefix VERIFICATION %s
-
-#if !SELF_SHADOW
 import ShadowyHorror
-// OTHER-DAG: ShadowyHorror.module_shadowing:{{[0-9]+:[0-9]+}}: warning: public class 'ShadowyHorror.module_shadowing' shadows module 'module_shadowing', which may cause failures when importing 'module_shadowing' or its clients in some configurations; please rename either the class 'ShadowyHorror.module_shadowing' or the module 'module_shadowing', or see https://github.com/apple/swift/issues/56573 for workarounds{{$}}
 
-internal import TestModule
-#endif
-
+// 'ShadowyHorror' shadows the imported module of the same name.
 public struct ShadowyHorror {
-  // OTHER-DAG: module_shadowing.swift:[[@LINE-1]]:15: warning: public struct 'module_shadowing.ShadowyHorror' shadows module 'ShadowyHorror', which may cause failures when importing 'module_shadowing' or its clients in some configurations; please rename either the struct 'module_shadowing.ShadowyHorror' or the module 'ShadowyHorror', or see https://github.com/apple/swift/issues/56573 for workarounds{{$}}
-  // SELF: module_shadowing.swift:[[@LINE-2]]:15: warning: public struct 'ShadowyHorror.ShadowyHorror' shadows module 'ShadowyHorror', which may cause failures when importing 'ShadowyHorror' or its clients in some configurations; please rename either the struct 'ShadowyHorror.ShadowyHorror' or the module 'ShadowyHorror', or see https://github.com/apple/swift/issues/56573 for workarounds{{$}}
-
-  init() {}
+  public init() {}
   public var property: ShadowyHorror { ShadowyHorror() }
-  // VERIFICATION: error: 'ShadowyHorror' is not a member type of {{class|struct}} 'ShadowyHorror.{{ShadowyHorror|module_shadowing}}'
-  // VERIFICATION: error: failed to verify module interface of '{{ShadowyHorror|module_shadowing}}' due to the errors above;
 }
-
-public struct TestModule {}


### PR DESCRIPTION
- **Explanation:** Now that module selectors (SE-0491) are used by default when printing .swiftinterface files, the following warning is unnecessary: `public struct <name> shadows module <name>, which may cause failures...`. Remove the implementation of the warning entirely. Technically, we could keep diagnosing the issue when use of module selectors in .swiftinterface files is disabled via the `-disable-module-selectors-in-module-interface` flag, but on balance it does not seem worth it since we don't anticipate any uses of that flag aside from temporarily working around compiler bugs.
- **Scope:** Removes a diagnostic that used to be emitted for modules that enable library evolution.
- **Issue/Radar:** rdar://176476640
- **Original PR:** https://github.com/swiftlang/swift/pull/89109
- **Risk:** Extremely low since this is just the removal of a diagnostic.
- **Testing:** Modified the existing test to verify that the diagnostic is no longer emitted and that the interface type checks unambiguously by default.
- **Reviewer:** @beccadax 