### PR TITLE
[6.4][ModuleTrace] Macro plugin path in trace file should be real path

### DIFF
--- a/lib/FrontendTool/LoadedModuleTrace.cpp
+++ b/lib/FrontendTool/LoadedModuleTrace.cpp
@@ -950,9 +950,10 @@ bool swift::emitLoadedModuleTraceIfNeeded(const ModuleDependencyID &mainModule,
 
   std::vector<SwiftMacroTraceInfo> swiftMacros;
   for (auto &macro : info->macroDependencies) {
-    swiftMacros.push_back({macro.first, macro.second.LibraryPath.empty()
-                                            ? macro.second.ExecutablePath
-                                            : macro.second.LibraryPath});
+    swiftMacros.push_back(
+        {macro.first, macro.second.LibraryPath.empty()
+                          ? realPath(macro.second.ExecutablePath)
+                          : realPath(macro.second.LibraryPath)});
   }
 
   return writeLoadedModuleOutput(

--- a/test/ScanDependencies/loaded_module_trace.swift
+++ b/test/ScanDependencies/loaded_module_trace.swift
@@ -3,6 +3,7 @@
 
 // RUN: %empty-directory(%t)
 // RUN: %empty-directory(%t/cache)
+// RUN: %empty-directory(%t/macro)
 // RUN: split-file %s %t
 // RUN: ln -s %t/C_real.swiftinterface %t/C.swiftinterface
 
@@ -11,7 +12,8 @@
 // RUN: %target-build-swift -emit-module -module-name Module2 %S/../Driver/Inputs/loaded_module_trace_imports_module.swift \
 // RUN:   -o %t/Module2.swiftmodule -I %t -module-cache-path %t/cache -strict-memory-safety
 // RUN: %target-build-swift -emit-library -module-name Plugin %S/../Driver/Inputs/loaded_module_trace_compiler_plugin.swift \
-// RUN:   -o %t/%target-library-name(Plugin) -module-cache-path %t/cache
+// RUN:   -o %t/macro/%target-library-name(PluginReal) -module-cache-path %t/cache
+// RUN: ln -s %t/macro/%target-library-name(PluginReal) %t/%target-library-name(Plugin)
 
 // RUN: %target-swift-frontend -scan-dependencies %t/test.swift -emit-loaded-module-trace -emit-loaded-module-trace-path %t/trace.json \
 // RUN:   -enable-upcoming-feature RegionBasedIsolation -strict-memory-safety -module-name Test -dependency-only-import B \
@@ -36,7 +38,7 @@
 // CHECK-DAG: {"name":"C","path":"{{[^"]*\\[/\\]}}C_real.swiftinterface","isImportedDirectly":true,"supportsLibraryEvolution":true,"strictMemorySafety":false}
 // CHECK: ],
 // CHECK: "swiftmacros":[
-// CHECK-DAG: {"name":"Plugin","path":"{{[^"]*\\[/\\]}}{{libPlugin.dylib|libPlugin.so|Plugin.dll}}"}
+// CHECK-DAG: {"name":"Plugin","path":"{{[^"]*\\[/\\]}}{{libPluginReal.dylib|libPluginReal.so|PluginReal.dll}}"}
 // CHECK: ]
 // CHECK: }
 // CHECK-NOT: "B"


### PR DESCRIPTION
A followup to #88200. The macro plugin path should be real path to match the old output.



- **Explanation**: Match the macro path emitted from new dependency scanner based path to the old code path, and emit the path to swift macro plugins as real path.
  <!--
  A description of the changes. This can be brief, but it should be clear.
  -->
- **Scope**: Only affects the build that relies on loaded swift module trace to be real path.
  <!--
  An assessment of the impact and importance of the changes. For example, can
  the changes break existing code?
  -->
- **Issues**: rdar://176985241
  <!--
  References to issues the changes resolve, if any.
  -->
- **Original PRs**: https://github.com/swiftlang/swift/pull/89080
  <!--
  Links to mainline branch pull requests in which the changes originated.
  -->
- **Risk**: Low. Just call real path on macro path.
  <!--
  The (specific) risk to the release for taking the changes.
  -->
- **Testing**: Unit test
  <!--
  The specific testing that has been done or needs to be done to further
  validate any impact of the changes.
  -->
- **Reviewers**: @tshortli 
  <!--
  The code owners that GitHub-approved the original changes in the mainline
  branch pull requests. If an original change has not been GitHub-approved by
  a respective code owner, provide a reason. Technical review can be delegated
  by a code owner or otherwise requested as deemed appropriate or useful.
  -->
