### PR TITLE
Add 24 parameter-pack regression tests (bundle)

### DIFF
--- a/test/Concurrency/Runtime/pack_async_dealloc_order.swift
+++ b/test/Concurrency/Runtime/pack_async_dealloc_order.swift
@@ -1,0 +1,56 @@
+// RUN: %target-run-simple-swift(-parse-as-library -Xfrontend -disable-availability-checking)
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+
+// Test that parameter pack temporaries in async contexts are deallocated in LIFO order.
+// https://github.com/swiftlang/swift/issues/XXXXX
+
+protocol Wrapper: Sendable {
+    associatedtype Value: Sendable
+}
+
+struct DefaultWrapper<T: Sendable>: Wrapper {
+    typealias Value = T
+    init() {}
+}
+
+func innerAsync<each Input: Sendable, each W: Wrapper>(
+    wrappers: repeat each W,
+    test: @escaping @Sendable () async -> Void
+) async where (repeat (each W).Value) == (repeat each Input) {
+    await test()
+}
+
+func outerAsync<each Input: Sendable>(
+    seeds: [(repeat each Input)] = [],
+    test: @escaping @Sendable () async -> Void
+) async {
+    // This pattern creates pack temporaries that must be deallocated in LIFO order
+    await innerAsync(
+        wrappers: repeat DefaultWrapper<each Input>(),
+        test: test
+    )
+}
+
+func runTest() async {
+    for _ in 0..<1000 {
+        await outerAsync(seeds: [] as [(Int, Int, Int)]) {
+            // Empty test body
+        }
+    }
+}
+
+@main
+struct Main {
+    static func main() async {
+        await withTaskGroup(of: Void.self) { group in
+            for _ in 0..<100 {
+                group.addTask {
+                    await runTest()
+                }
+            }
+        }
+        print("Done")
+    }
+}

--- a/test/Concurrency/sendable_closure_pack_parameter.swift
+++ b/test/Concurrency/sendable_closure_pack_parameter.swift
@@ -1,0 +1,40 @@
+// RUN: %target-swift-frontend -emit-sil -swift-version 6 %s -o /dev/null -verify
+
+// REQUIRES: concurrency
+
+// This test verifies that we produce a proper diagnostic when a non-@Sendable
+// closure is used where a @Sendable closure is expected, in the context of
+// parameter packs. Previously this would fail with "failed to produce diagnostic
+// for expression" because the constraint system would generate multiple solutions
+// with the same fix kind but at different locators.
+
+public protocol Fuzzable {
+    static var fuzz: [Self] { get }
+}
+
+public protocol Mutator<Value>: Sendable {
+    associatedtype Value: Sendable
+    var seeds: [Value] { get }
+    func mutate(_ value: Value) -> [Value]
+}
+
+public actor FuzzEngine<each Input: Fuzzable & Codable & Sendable> {
+    public typealias MutatorMutate = @Sendable ((repeat each Input)) -> [(repeat each Input)]
+
+    private let mutatorMutate: MutatorMutate?
+
+    public init<each M: Mutator>(
+        mutators: (repeat each M)?,
+        config: Int = 0
+    ) where (repeat (each M).Value) == (repeat each Input) {
+        self.mutatorMutate = mutators.map { mutators in
+            // expected-error@-1 {{converting non-Sendable function value to '@Sendable ((repeat each Input)) -> [(repeat each Input)]' may introduce data races}}
+            { input in
+                let _ = Self.identity(mutators: mutators)
+                return []
+            }
+        }
+    }
+
+    private static func identity<each M: Mutator>(mutators: (repeat each M)) -> Int { 0 }
+}

--- a/test/Constraints/pack_expansion_default_arguments.swift
+++ b/test/Constraints/pack_expansion_default_arguments.swift
@@ -1,0 +1,55 @@
+// RUN: %target-typecheck-verify-swift
+
+// Test that pack expansion types can be inferred from default argument values.
+// This tests the fix for single-element tuple default arguments being flattened
+// to scalars, which previously caused type inference to fail.
+
+// Multi-element tuple default
+func multiElementDefault<each T>(_ input: (repeat each T) = (1, "hello")) {
+  print(input)
+}
+
+// Single-element default - the tuple (1) flattens to Int, but should still
+// allow pack inference by wrapping the scalar in a single-element tuple
+// before matching against the pack expansion tuple type.
+func singleElementDefault<each T>(_ input: (repeat each T) = (1)) {
+  print(input)
+}
+
+// Empty tuple default
+func emptyDefault<each T>(_ input: (repeat each T) = ()) {
+  print(input)
+}
+
+// With constraints
+protocol P {}
+extension Int: P {}
+extension String: P {}
+
+func constrainedMultiElementDefault<each T: P>(_ input: (repeat each T) = (1, 2)) {
+  print(input)
+}
+
+func constrainedSingleElementDefault<each T: P>(_ input: (repeat each T) = (1)) {
+  print(input)
+}
+
+// Test call sites
+func testCallSites() {
+  // Multi-element defaults
+  multiElementDefault()
+  multiElementDefault((1, 2, 3))
+
+  // Single-element defaults
+  singleElementDefault()
+  singleElementDefault((42))
+  singleElementDefault(42)  // equivalent to above
+
+  // Empty defaults
+  emptyDefault()
+  emptyDefault(())
+
+  // Constrained defaults
+  constrainedMultiElementDefault()
+  constrainedSingleElementDefault()
+}

--- a/test/Generics/enum_pack_construction.swift
+++ b/test/Generics/enum_pack_construction.swift
@@ -1,0 +1,47 @@
+// RUN: %target-typecheck-verify-swift
+
+enum Wrapper<each T> {
+    case values(repeat each T)
+    case empty
+}
+
+func testConstruction() {
+    // Explicit type with values
+    let w1 = Wrapper.values(1, "hello", true)
+    let _: Wrapper<Int, String, Bool> = w1
+
+    // Contextual type
+    let w2: Wrapper<Int, String> = .values(42, "world")
+    _ = w2
+
+    // Single element pack
+    let w3 = Wrapper<Int>.values(42)
+    _ = w3
+
+    // Empty case with non-empty pack type
+    let w5: Wrapper<Int, String> = .empty
+    _ = w5
+}
+
+// Test with generic context
+func constructGeneric<each T>(_ values: repeat each T) -> Wrapper<repeat each T> {
+    return .values(repeat each values)
+}
+
+func testGenericConstruction() {
+    let w1 = constructGeneric(1, "hello")
+    let _: Wrapper<Int, String> = w1
+
+    let w2 = constructGeneric(true)
+    let _: Wrapper<Bool> = w2
+}
+
+// Test with constraints
+enum Constrained<each T: Hashable> {
+    case items(repeat each T)
+}
+
+func testConstrainedConstruction() {
+    let c1 = Constrained.items(1, "hello", true)
+    let _: Constrained<Int, String, Bool> = c1
+}

--- a/test/Generics/enum_pack_pattern_matching.swift
+++ b/test/Generics/enum_pack_pattern_matching.swift
@@ -1,0 +1,27 @@
+// RUN: %target-typecheck-verify-swift
+
+enum Wrapper<each T> {
+    case values(repeat each T)
+    case empty
+}
+
+// Basic pattern matching in generic context
+func matchWrapper<each T>(_ w: Wrapper<repeat each T>) {
+    switch w {
+    case let .values(v):
+        // v should have type `repeat each T`
+        let _: (repeat each T) = (repeat each v)
+    case .empty:
+        break
+    }
+}
+
+// Using matched values
+func useMatchedValues<each T>(_ w: Wrapper<repeat each T>) -> (repeat each T)? {
+    switch w {
+    case let .values(v):
+        return (repeat each v)
+    case .empty:
+        return nil
+    }
+}

--- a/test/Generics/enum_with_pack_basic.swift
+++ b/test/Generics/enum_with_pack_basic.swift
@@ -1,0 +1,32 @@
+// RUN: %target-typecheck-verify-swift
+
+// Basic enum with type pack
+enum Wrapper<each T> {
+    case values(repeat each T)
+    case empty
+}
+
+// Enum with type pack and regular generic parameter
+enum Result<each T, E: Error> {
+    case success(repeat each T)
+    case failure(E)
+}
+
+// Enum with type pack and constraints
+enum Constrained<each T: Hashable> {
+    case items(repeat each T)
+}
+
+// Enum with multiple cases using the pack
+enum Multi<each T> {
+    case first(repeat each T)
+    case second(repeat each T)
+    case none
+}
+
+// Nested enum with pack
+struct Container<each T> {
+    enum Inner {
+        case wrapped(repeat each T)
+    }
+}

--- a/test/IRGen/keypath_parameter_pack.swift
+++ b/test/IRGen/keypath_parameter_pack.swift
@@ -1,0 +1,19 @@
+// RUN: %target-swift-frontend -emit-ir %s -target %target-swift-5.9-abi-triple | %FileCheck %s
+
+// REQUIRES: swift_feature_ParameterPacks
+
+// Test that key paths on types containing parameter packs compile successfully.
+
+struct Entry<each T> {
+    let input: (repeat each T)
+}
+
+struct Container<each T> {
+    let entries: [Entry<repeat each T>]
+
+    var inputs: [(repeat each T)] {
+        entries.map(\.input)
+    }
+}
+
+// CHECK: @keypath = private global

--- a/test/IRGen/round-trip-debug-types-pack-expansion.swift
+++ b/test/IRGen/round-trip-debug-types-pack-expansion.swift
@@ -1,0 +1,23 @@
+// RUN: %target-swift-frontend -emit-ir -g %s -target %target-swift-5.9-abi-triple
+
+// https://github.com/apple/swift/issues/XXXXX
+// IRGenDebugInfo type reconstruction crash with parameter packs and optional
+// existential types. The combination of:
+// 1. Optional existential type: (any Sendable)?
+// 2. Parameter pack with consuming ownership: consuming (repeat each T)
+// 3. Both in the same function type
+// would cause a crash in getMangledName due to type comparison failure
+// during the debug type round-trip verification.
+
+actor Machine<each Input: Sendable> {
+  typealias Fn = (
+    (any Sendable)?,
+    consuming (repeat each Input)
+  ) -> Void
+
+  private let fn: Fn
+
+  init(fn: @escaping Fn) {
+    self.fn = fn
+  }
+}

--- a/test/Interpreter/Inputs/enum_parameter_pack_lib.swift
+++ b/test/Interpreter/Inputs/enum_parameter_pack_lib.swift
@@ -1,0 +1,26 @@
+// Library for enum_parameter_pack_cross_module test.
+// This must be compiled separately to trigger the cross-module metadata path.
+
+import Foundation
+
+public enum Action<each T: Sendable>: Sendable {
+    case stop(String)
+    case record(RecordAction)
+    case select(SelectAction)
+
+    // Uses Foundation types inside the enum - this is important because
+    // the external types trigger a specific metadata completion path.
+    public struct RecordAction: Sendable {
+        public let date: Date
+        public let uuid: UUID
+        public init(date: Date, uuid: UUID) {
+            self.date = date
+            self.uuid = uuid
+        }
+    }
+
+    // Has pack expansion tuple - required to trigger the bug.
+    public struct SelectAction: @unchecked Sendable {
+        public let input: (repeat each T)
+    }
+}

--- a/test/Interpreter/enum_parameter_pack_cross_module.swift
+++ b/test/Interpreter/enum_parameter_pack_cross_module.swift
@@ -1,0 +1,30 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift-dylib(%t/%target-library-name(Lib)) -target %target-swift-5.9-abi-triple -enable-library-evolution %S/Inputs/enum_parameter_pack_lib.swift -emit-module -emit-module-path %t/Lib.swiftmodule -module-name Lib
+// RUN: %target-codesign %t/%target-library-name(Lib)
+// RUN: %target-build-swift %s -target %target-swift-5.9-abi-triple -lLib -I %t -L %t -o %t/main %target-rpath(%t)
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main %t/%target-library-name(Lib)
+
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
+// This test validates that cross-module instantiation of generic enums with
+// parameter packs works correctly when the enum contains nested structs that
+// reference types from external frameworks like Foundation.
+//
+// The bug (now fixed) was that pack metadata pointers were incorrectly passed
+// to swift_checkMetadataState during metadata completion, causing a crash
+// because pack pointers are arrays of metadata pointers, not actual metadata.
+
+import Lib
+
+let actions: [Action<Int>] = []
+print("Empty array:", actions)
+
+let moreActions: [Action<Int, String>] = []
+print("Two-element pack array:", moreActions)
+
+print("Success - no crash")

--- a/test/Interpreter/keypath_parameter_pack.swift
+++ b/test/Interpreter/keypath_parameter_pack.swift
@@ -1,0 +1,88 @@
+// RUN: %target-run-simple-swift(-target %target-swift-5.9-abi-triple)
+
+// REQUIRES: executable_test
+// REQUIRES: swift_feature_ParameterPacks
+
+// Test that key paths on types containing parameter packs work at runtime
+// for both concrete type specializations and abstract pack contexts.
+
+struct Entry<each T> {
+    let input: (repeat each T)
+    let name: String
+}
+
+// Container that uses keypaths on pack types in a generic context
+struct Container<each T> {
+    let entries: [Entry<repeat each T>]
+
+    // Keypath to pack tuple property - tests abstract pack keypath
+    var inputs: [(repeat each T)] {
+        entries.map(\.input)
+    }
+
+    // Keypath to non-pack property for comparison
+    var names: [String] {
+        entries.map(\.name)
+    }
+}
+
+// Test direct keypath usage with concrete type specialization
+func testDirectKeyPath() {
+    // Single-element pack case
+    let entry1 = Entry<Int>(input: 42, name: "e1")
+    let keyPath1 = \Entry<Int>.input
+    let value1 = entry1[keyPath: keyPath1]
+    assert(value1 == 42)
+    print("testDirectKeyPath single: PASS")
+
+    // Two-element pack case
+    let entry2 = Entry<Int, String>(input: (42, "hello"), name: "e2")
+    let keyPath2 = \Entry<Int, String>.input
+    let value2 = entry2[keyPath: keyPath2]
+    assert(value2.0 == 42)
+    assert(value2.1 == "hello")
+    print("testDirectKeyPath double: PASS")
+
+    // Three-element pack case
+    let entry3 = Entry<Int, String, Double>(input: (42, "hello", 3.14), name: "e3")
+    let keyPath3 = \Entry<Int, String, Double>.input
+    let value3 = entry3[keyPath: keyPath3]
+    assert(value3.0 == 42)
+    assert(value3.1 == "hello")
+    assert(value3.2 == 3.14)
+    print("testDirectKeyPath triple: PASS")
+}
+
+// Test keypaths used inside generic contexts with abstract packs
+func testAbstractPackKeyPath() {
+    // Test with single-element pack
+    let container1 = Container(entries: [
+        Entry<Int>(input: 1, name: "first"),
+        Entry<Int>(input: 2, name: "second")
+    ])
+    let inputs1 = container1.inputs
+    assert(inputs1.count == 2)
+    assert(inputs1[0] == 1)
+    assert(inputs1[1] == 2)
+    let names1 = container1.names
+    assert(names1[0] == "first")
+    assert(names1[1] == "second")
+    print("testAbstractPackKeyPath single: PASS")
+
+    // Test with two-element pack
+    let container2 = Container(entries: [
+        Entry<Int, String>(input: (1, "a"), name: "entry1"),
+        Entry<Int, String>(input: (2, "b"), name: "entry2")
+    ])
+    let inputs2 = container2.inputs
+    assert(inputs2.count == 2)
+    assert(inputs2[0].0 == 1)
+    assert(inputs2[0].1 == "a")
+    assert(inputs2[1].0 == 2)
+    assert(inputs2[1].1 == "b")
+    print("testAbstractPackKeyPath double: PASS")
+}
+
+testDirectKeyPath()
+testAbstractPackKeyPath()
+print("All tests passed!")

--- a/test/Interpreter/keypath_parameter_pack_generic.swift
+++ b/test/Interpreter/keypath_parameter_pack_generic.swift
@@ -1,0 +1,69 @@
+// RUN: %target-run-simple-swift(-target %target-swift-5.9-abi-triple)
+
+// REQUIRES: executable_test
+// REQUIRES: swift_feature_ParameterPacks
+
+// Test that key paths on types containing parameter packs work at runtime
+// in generic contexts where the pack is not yet concretely specialized.
+
+struct Entry<each T> {
+    let input: (repeat each T)
+}
+
+struct Container<each T> {
+    let entries: [Entry<repeat each T>]
+
+    var inputs: [(repeat each T)] {
+        entries.map(\.input)
+    }
+}
+
+// Test with single type parameter
+func testSingleParam() {
+    let entries = [
+        Entry<Int>(input: 42),
+        Entry<Int>(input: 17)
+    ]
+    let container = Container(entries: entries)
+    let inputs = container.inputs
+
+    assert(inputs.count == 2)
+    assert(inputs[0] == 42)
+    assert(inputs[1] == 17)
+    print("testSingleParam: PASS")
+}
+
+// Test with multiple type parameters
+func testMultipleParams() {
+    let entries = [
+        Entry<Int, String>(input: (1, "one")),
+        Entry<Int, String>(input: (2, "two"))
+    ]
+    let container = Container(entries: entries)
+    let inputs = container.inputs
+
+    assert(inputs.count == 2)
+    assert(inputs[0] == (1, "one"))
+    assert(inputs[1] == (2, "two"))
+    print("testMultipleParams: PASS")
+}
+
+// Test with three type parameters
+func testTripleParams() {
+    let entries = [
+        Entry<Int, String, Double>(input: (1, "one", 1.0)),
+        Entry<Int, String, Double>(input: (2, "two", 2.0))
+    ]
+    let container = Container(entries: entries)
+    let inputs = container.inputs
+
+    assert(inputs.count == 2)
+    assert(inputs[0] == (1, "one", 1.0))
+    assert(inputs[1] == (2, "two", 2.0))
+    print("testTripleParams: PASS")
+}
+
+testSingleParam()
+testMultipleParams()
+testTripleParams()
+print("All tests passed!")

--- a/test/Interpreter/variadic_generic_closure_pack_expansion.swift
+++ b/test/Interpreter/variadic_generic_closure_pack_expansion.swift
@@ -1,0 +1,171 @@
+// RUN: %target-run-simple-swift
+
+// REQUIRES: executable_test
+
+// Test that passing pack expansion tuples to closures works correctly at runtime.
+// This is a regression test for a bug where SILGen incorrectly used pack_element_get
+// to read from an uninitialized pack instead of pack_element_set to store addresses
+// into the pack. This caused the saved frame pointer to be overwritten, resulting
+// in a crash on function return.
+
+import StdlibUnittest
+
+var packExpansionClosureTests = TestSuite("PackExpansionClosure")
+
+// Test 1: Basic pack expansion tuple passed to throwing closure
+packExpansionClosureTests.test("basicPackExpansion") {
+  struct Runner<each Input> {
+    func run(_ input: (repeat each Input), test: ((repeat each Input)) throws -> Void) rethrows {
+      try test(input)
+    }
+  }
+
+  var callCount = 0
+  let runner = Runner<Int, String>()
+  runner.run((42, "hello")) { a, b in
+    expectEqual(a, 42)
+    expectEqual(b, "hello")
+    callCount += 1
+  }
+  expectEqual(callCount, 1)
+}
+
+// Test 2: Iterator pattern - pack expansion tuple from array iteration
+// This specifically tests the bug where iterating over an array of pack expansion
+// tuples and passing each to a closure would crash.
+packExpansionClosureTests.test("iteratorPattern") {
+  struct FuzzEngine<each Input> {
+    func run(inputs: [(repeat each Input)], test: ((repeat each Input)) throws -> Void) rethrows {
+      for input in inputs {
+        try test(input)
+      }
+    }
+  }
+
+  var values: [Int] = []
+  let engine = FuzzEngine<Int>()
+  engine.run(inputs: [(1), (2), (3)]) { value in
+    values.append(value)
+  }
+  expectEqual(values, [1, 2, 3])
+}
+
+// Test 3: Multiple pack parameters
+packExpansionClosureTests.test("multiplePackParameters") {
+  struct MultiEngine<each Input> {
+    func run(inputs: [(repeat each Input)], test: ((repeat each Input)) throws -> Void) rethrows {
+      for input in inputs {
+        try test(input)
+      }
+    }
+  }
+
+  var results: [(Int, String, Double)] = []
+  let engine = MultiEngine<Int, String, Double>()
+  engine.run(inputs: [(1, "a", 1.0), (2, "b", 2.0)]) { i, s, d in
+    results.append((i, s, d))
+  }
+  expectEqual(results.count, 2)
+  expectEqual(results[0].0, 1)
+  expectEqual(results[0].1, "a")
+  expectEqual(results[0].2, 1.0)
+  expectEqual(results[1].0, 2)
+  expectEqual(results[1].1, "b")
+  expectEqual(results[1].2, 2.0)
+}
+
+// Test 4: Single element pack (vanishing tuple case)
+// When instantiated with a single type, the tuple (repeat each T) becomes
+// just T, but the pack handling must still work correctly.
+packExpansionClosureTests.test("singleElementPack") {
+  struct SingleEngine<each Input> {
+    func run(inputs: [(repeat each Input)], test: ((repeat each Input)) throws -> Void) rethrows {
+      for input in inputs {
+        try test(input)
+      }
+    }
+  }
+
+  var sum = 0
+  let engine = SingleEngine<Int>()
+  engine.run(inputs: [(10), (20), (30)]) { value in
+    sum += value
+  }
+  expectEqual(sum, 60)
+}
+
+// Test 5: Nested function calls with pack expansion closures
+// This tests that the stack frame is correctly preserved across multiple
+// levels of pack expansion closure calls.
+packExpansionClosureTests.test("nestedCalls") {
+  struct Nested<each T> {
+    func outer(_ value: (repeat each T), process: ((repeat each T)) throws -> Int) rethrows -> Int {
+      return try inner(value, transform: process)
+    }
+
+    func inner(_ value: (repeat each T), transform: ((repeat each T)) throws -> Int) rethrows -> Int {
+      return try transform(value)
+    }
+  }
+
+  let nested = Nested<Int, Int>()
+  let result = nested.outer((5, 10)) { a, b in
+    return a + b
+  }
+  expectEqual(result, 15)
+}
+
+// Test 6: Throwing closure with pack expansion
+packExpansionClosureTests.test("throwingClosure") {
+  struct ThrowingEngine<each Input> {
+    func run(inputs: [(repeat each Input)], test: ((repeat each Input)) throws -> Void) throws {
+      for input in inputs {
+        try test(input)
+      }
+    }
+  }
+
+  enum TestError: Error { case expected }
+
+  var processedCount = 0
+  let engine = ThrowingEngine<Int>()
+
+  do {
+    try engine.run(inputs: [(1), (2), (3)]) { value in
+      processedCount += 1
+      if value == 2 {
+        throw TestError.expected
+      }
+    }
+    expectUnreachable("Should have thrown")
+  } catch {
+    expectEqual(processedCount, 2)
+  }
+}
+
+// Test 7: Pack expansion with class types (to test reference counting)
+packExpansionClosureTests.test("classTypes") {
+  class Counter {
+    var value: Int
+    init(_ v: Int) { value = v }
+  }
+
+  struct ClassEngine<each Input> {
+    func run(inputs: [(repeat each Input)], test: ((repeat each Input)) throws -> Void) rethrows {
+      for input in inputs {
+        try test(input)
+      }
+    }
+  }
+
+  var sum = 0
+  let engine = ClassEngine<Counter, Counter>()
+  let c1 = Counter(10)
+  let c2 = Counter(20)
+  engine.run(inputs: [(c1, c2)]) { a, b in
+    sum = a.value + b.value
+  }
+  expectEqual(sum, 30)
+}
+
+runAllTests()

--- a/test/Interpreter/variadic_generic_pack_owned_tuple.swift
+++ b/test/Interpreter/variadic_generic_pack_owned_tuple.swift
@@ -1,0 +1,221 @@
+// RUN: %target-run-simple-swift
+
+// REQUIRES: executable_test
+
+// Test that passing pack expansion tuples to functions with @pack_owned
+// parameters works correctly, especially when called through a generic wrapper.
+// This is a regression test for a bug where SILGen failed to forward the
+// cleanup of the tuple storage when transferring ownership to the pack,
+// resulting in a double-free crash.
+
+import StdlibUnittest
+
+var packOwnedTupleTests = TestSuite("PackOwnedTuple")
+
+// Protocol with associated type for the full pattern
+protocol Mutator {
+  associatedtype Value
+  var seeds: [Value] { get }
+  func mutate(_ input: Value) -> [Value]
+}
+
+struct SimpleMutator<T>: Mutator {
+  typealias Value = T
+  let seeds: [T]
+  let mutateFn: (T) -> [T]
+
+  init(seeds: [T], mutate: @escaping (T) -> [T] = { _ in [] }) {
+    self.seeds = seeds
+    self.mutateFn = mutate
+  }
+
+  func mutate(_ input: T) -> [T] { mutateFn(input) }
+}
+
+// Class that stores a closure capturing pack expansion tuple array
+final class Box<each Input> {
+  typealias Seeds = () -> [(repeat each Input)]
+  let seedsFn: Seeds
+
+  // Init takes @pack_owned parameter
+  init<each M: Mutator>(
+    mutators: (repeat each M)
+  ) where (repeat (each M).Value) == (repeat each Input) {
+    // Extract seeds eagerly from each mutator
+    let capturedSeeds = Self.extractSeeds(mutators: mutators)
+    self.seedsFn = { capturedSeeds }
+  }
+
+  private static func extractSeeds<each M: Mutator>(
+    mutators: (repeat each M)
+  ) -> [(repeat each Input)] where (repeat (each M).Value) == (repeat each Input) {
+    var result: [(repeat each Input)] = []
+
+    // Collect all seed arrays
+    var allSeeds: [[Any]] = []
+    (repeat allSeeds.append((each mutators).seeds.map { $0 as Any }))
+
+    // For single mutator, just map seeds directly
+    if let seeds = allSeeds.first, allSeeds.count == 1 {
+      for seed in seeds {
+        func cast<V>(_ t: V.Type) -> V { seed as! V }
+        let tuple: (repeat each Input) = (repeat cast((each Input).self))
+        result.append(tuple)
+      }
+    }
+    return result
+  }
+
+  func get() -> [(repeat each Input)] {
+    return seedsFn()
+  }
+}
+
+// Public API that forwards parameter packs
+func api<each Input, each M: Mutator>(
+  using mutators: repeat each M
+) -> [(repeat each Input)] where (repeat (each M).Value) == (repeat each Input) {
+  // Capture the pack - this creates a tuple (repeat each M)
+  let captured: (repeat each M) = (repeat each mutators)
+  // Pass to Box.init which takes @pack_owned
+  let box = Box<repeat each Input>(mutators: captured)
+  return box.get()
+}
+
+// Generic wrapper function to test the wrapped call pattern
+func wrapper<R>(_ op: () -> R) -> R {
+  return op()
+}
+
+// Test 1: Direct call to api function
+packOwnedTupleTests.test("directCall") {
+  let seeds: [String] = api(using: SimpleMutator(seeds: ["a", "b", "c"]))
+  expectEqual(seeds.count, 3)
+  expectEqual(seeds[0], "a")
+  expectEqual(seeds[1], "b")
+  expectEqual(seeds[2], "c")
+}
+
+// Test 2: Call through generic wrapper - this is the pattern that crashed
+packOwnedTupleTests.test("wrappedCall") {
+  let seeds: [String] = wrapper {
+    api(using: SimpleMutator(seeds: ["x", "y", "z"]))
+  }
+  expectEqual(seeds.count, 3)
+  expectEqual(seeds[0], "x")
+  expectEqual(seeds[1], "y")
+  expectEqual(seeds[2], "z")
+}
+
+// Test 3: Multiple wrapped calls in sequence
+packOwnedTupleTests.test("multipleWrappedCalls") {
+  var allSeeds: [[String]] = []
+
+  for i in 0..<3 {
+    let seeds: [String] = wrapper {
+      api(using: SimpleMutator(seeds: ["item\(i)"]))
+    }
+    allSeeds.append(seeds)
+  }
+
+  expectEqual(allSeeds.count, 3)
+  expectEqual(allSeeds[0], ["item0"])
+  expectEqual(allSeeds[1], ["item1"])
+  expectEqual(allSeeds[2], ["item2"])
+}
+
+// Test 4: Nested wrappers
+packOwnedTupleTests.test("nestedWrappers") {
+  let seeds: [Int] = wrapper {
+    wrapper {
+      wrapper {
+        api(using: SimpleMutator(seeds: [1, 2, 3, 4, 5]))
+      }
+    }
+  }
+  expectEqual(seeds, [1, 2, 3, 4, 5])
+}
+
+// Test 5: Class types to verify reference counting
+packOwnedTupleTests.test("classTypeSeeds") {
+  class Ref {
+    let value: Int
+    init(_ v: Int) { value = v }
+  }
+
+  // Create refs outside wrapper to verify they survive
+  let refs = [Ref(10), Ref(20), Ref(30)]
+
+  let seeds: [Ref] = wrapper {
+    api(using: SimpleMutator(seeds: refs))
+  }
+
+  expectEqual(seeds.count, 3)
+  expectEqual(seeds[0].value, 10)
+  expectEqual(seeds[1].value, 20)
+  expectEqual(seeds[2].value, 30)
+}
+
+// Test 6: Throwing wrapper
+packOwnedTupleTests.test("throwingWrapper") {
+  func throwingWrapper<R>(_ op: () throws -> R) rethrows -> R {
+    return try op()
+  }
+
+  // Using rethrows, no actual throws happens here
+  let seeds: [String] = throwingWrapper {
+    api(using: SimpleMutator(seeds: ["success"]))
+  }
+  expectEqual(seeds, ["success"])
+}
+
+// Test 7: Async wrapper (if available)
+#if swift(>=5.5)
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+func asyncTest() async {
+  func asyncWrapper<R>(_ op: () async -> R) async -> R {
+    return await op()
+  }
+
+  let seeds: [String] = await asyncWrapper {
+    api(using: SimpleMutator(seeds: ["async"]))
+  }
+  expectEqual(seeds, ["async"])
+}
+#endif
+
+// Test 8: Escaping closure that captures the result
+packOwnedTupleTests.test("escapingCapture") {
+  var capturedSeeds: [String]? = nil
+
+  func captureInEscaping(_ op: @escaping () -> [String]) {
+    capturedSeeds = op()
+  }
+
+  captureInEscaping {
+    api(using: SimpleMutator(seeds: ["captured"]))
+  }
+
+  expectEqual(capturedSeeds, ["captured"])
+}
+
+// Test 9: Verify cleanup happens correctly by checking for memory issues
+// across many iterations
+packOwnedTupleTests.test("stressTest") {
+  for _ in 0..<1000 {
+    let _: [String] = wrapper {
+      api(using: SimpleMutator(seeds: ["stress", "test"]))
+    }
+  }
+  // If we get here without crashing, the cleanup is working correctly
+}
+
+// Test 10: Empty seeds array
+packOwnedTupleTests.test("emptySeeds") {
+  let seeds: [String] = wrapper {
+    api(using: SimpleMutator<String>(seeds: []))
+  }
+  expectEqual(seeds.count, 0)
+}
+
+runAllTests()

--- a/test/Interpreter/variadic_generic_tuple_init.swift
+++ b/test/Interpreter/variadic_generic_tuple_init.swift
@@ -1,0 +1,214 @@
+// RUN: %target-run-simple-swift(-target %target-swift-5.9-abi-triple)
+
+// REQUIRES: executable_test
+
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
+// This test verifies runtime behavior of structs with pack expansion tuple
+// properties, ensuring that definite initialization correctly handles
+// the initialization and that values are accessible at runtime.
+
+import StdlibUnittest
+
+var suite = TestSuite("VariadicGenericTupleInit")
+
+// MARK: - Basic struct with pack expansion tuple
+
+struct BasicPackTuple<each T> {
+  let values: (repeat each T)
+
+  init(_ values: repeat each T) {
+    self.values = (repeat each values)
+  }
+}
+
+suite.test("BasicPackTuple single element") {
+  let s = BasicPackTuple(42)
+  expectEqual(42, s.values)
+}
+
+suite.test("BasicPackTuple multiple elements") {
+  let s = BasicPackTuple(1, "hello", true)
+  expectEqual(1, s.values.0)
+  expectEqual("hello", s.values.1)
+  expectEqual(true, s.values.2)
+}
+
+// MARK: - Struct with mixed properties
+
+struct MixedProperties<each T> {
+  let prefix: Int
+  let packed: (repeat each T)
+  let suffix: String
+
+  init(prefix: Int, suffix: String, _ values: repeat each T) {
+    self.prefix = prefix
+    self.packed = (repeat each values)
+    self.suffix = suffix
+  }
+}
+
+suite.test("MixedProperties") {
+  let s = MixedProperties(prefix: 10, suffix: "end", 3.14, "middle")
+  expectEqual(10, s.prefix)
+  expectEqual(3.14, s.packed.0)
+  expectEqual("middle", s.packed.1)
+  expectEqual("end", s.suffix)
+}
+
+// MARK: - Conditional initialization
+
+struct ConditionalInit<each T> {
+  let values: (repeat each T)
+  let flag: Bool
+
+  init(condition: Bool, _ values: repeat each T) {
+    self.flag = condition
+    if condition {
+      self.values = (repeat each values)
+    } else {
+      self.values = (repeat each values)
+    }
+  }
+}
+
+suite.test("ConditionalInit true branch") {
+  let s = ConditionalInit(condition: true, "a", "b")
+  expectTrue(s.flag)
+  expectEqual("a", s.values.0)
+  expectEqual("b", s.values.1)
+}
+
+suite.test("ConditionalInit false branch") {
+  let s = ConditionalInit(condition: false, 1, 2, 3)
+  expectFalse(s.flag)
+  expectEqual(1, s.values.0)
+  expectEqual(2, s.values.1)
+  expectEqual(3, s.values.2)
+}
+
+// MARK: - Nested struct
+
+struct Outer<each T> {
+  struct Inner {
+    let data: (repeat each T)
+
+    init(_ values: repeat each T) {
+      self.data = (repeat each values)
+    }
+  }
+
+  let inner: Inner
+
+  init(_ values: repeat each T) {
+    self.inner = Inner(repeat each values)
+  }
+}
+
+suite.test("Nested struct") {
+  let s = Outer(100, 200)
+  expectEqual(100, s.inner.data.0)
+  expectEqual(200, s.inner.data.1)
+}
+
+// MARK: - Class with pack expansion tuple
+
+class ClassWithPackTuple<each T> {
+  let values: (repeat each T)
+
+  init(_ values: repeat each T) {
+    self.values = (repeat each values)
+  }
+}
+
+suite.test("Class with pack tuple") {
+  let c = ClassWithPackTuple("x", "y", "z")
+  expectEqual("x", c.values.0)
+  expectEqual("y", c.values.1)
+  expectEqual("z", c.values.2)
+}
+
+// MARK: - Failable initializer
+
+struct FailablePackInit<each T> {
+  let values: (repeat each T)
+
+  init?(_ values: repeat each T, shouldFail: Bool) {
+    if shouldFail {
+      return nil
+    }
+    self.values = (repeat each values)
+  }
+}
+
+suite.test("Failable init success") {
+  let s = FailablePackInit(1, 2, shouldFail: false)
+  expectNotNil(s)
+  expectEqual(1, s!.values.0)
+  expectEqual(2, s!.values.1)
+}
+
+suite.test("Failable init failure") {
+  let s = FailablePackInit(1, 2, shouldFail: true)
+  expectNil(s)
+}
+
+// MARK: - Throwing initializer
+
+struct ThrowingPackInit<each T> {
+  let values: (repeat each T)
+
+  init(_ values: repeat each T) throws {
+    self.values = (repeat each values)
+  }
+}
+
+suite.test("Throwing init") {
+  do {
+    let s = try ThrowingPackInit("a", "b")
+    expectEqual("a", s.values.0)
+    expectEqual("b", s.values.1)
+  } catch {
+    expectUnreachable("Should not throw")
+  }
+}
+
+// MARK: - Throwing initializer with pack expansion tuple (crash case)
+// This is a minimal reproducer for the DI crash. The crash occurs when:
+// 1. Struct has multiple properties including a pack expansion tuple
+// 2. Throwing initializer where a throwing call comes AFTER the pack tuple assignment
+// 3. DI generates cleanup code that incorrectly uses tuple_element_addr on the pack tuple
+
+func produceValue<T>(type: T.Type) -> T {
+  fatalError("not called in test")
+}
+
+func produceInt() throws -> Int {
+  return 42
+}
+
+struct ThrowingContainer<each Input> {
+  let inputs: (repeat each Input)
+  let tag: Int
+
+  init() throws {
+    self.inputs = (repeat produceValue(type: (each Input).self))
+    self.tag = try produceInt()
+  }
+
+  init(inputs: repeat each Input, tag: Int) {
+    self.inputs = (repeat each inputs)
+    self.tag = tag
+  }
+}
+
+suite.test("Throwing init with pack tuple - success path") {
+  // Use the non-throwing init for runtime test
+  let c = ThrowingContainer<Int, String>(inputs: 42, "test", tag: 99)
+  expectEqual(42, c.inputs.0)
+  expectEqual("test", c.inputs.1)
+  expectEqual(99, c.tag)
+}
+
+runAllTests()

--- a/test/Profiler/coverage_isolated_deinit_skipped_body.swift
+++ b/test/Profiler/coverage_isolated_deinit_skipped_body.swift
@@ -1,0 +1,17 @@
+// Make sure we don't crash when an isolated deinit body is skipped but
+// coverage instrumentation is enabled.
+// RUN: %target-swift-frontend -emit-module -experimental-skip-non-inlinable-function-bodies-without-types -profile-generate -profile-coverage-mapping %s
+
+// REQUIRES: concurrency
+
+final class Resource {
+    func cleanup() {}
+}
+
+public actor MyActor {
+    private let resource = Resource()
+
+    isolated deinit {
+        resource.cleanup()
+    }
+}

--- a/test/SILGen/pack_closure_parameter_crash.swift
+++ b/test/SILGen/pack_closure_parameter_crash.swift
@@ -1,0 +1,50 @@
+// RUN: %target-swift-frontend -emit-silgen %s | %FileCheck %s
+
+// This test verifies that closures with parameter types using pack generics
+// from an enclosing context compile without crashing.
+//
+// Previously, this would crash with:
+// Assertion failed: (origPackType.matchesPack(substPackType)),
+// function PackElementGenerator, file AbstractionPattern.cpp
+
+struct Box<each T> {}
+
+func takeClosure<each U>(_: (repeat each U), _: (Box<repeat each U>) -> Void) {}
+
+// CHECK-LABEL: sil hidden [ossa] @$s28pack_closure_parameter_crash4testyyF
+// CHECK: function_ref
+// CHECK: } // end sil function '$s28pack_closure_parameter_crash4testyyF'
+func test() {
+    takeClosure((1, ""), { _ in })
+}
+
+// More complex case with protocol method returning pack-parameterized type
+protocol Plugin {
+    func handle<each T>(event: Box<repeat each T>) -> [Box<repeat each T>]
+}
+
+struct MyPlugin: Plugin {
+    func handle<each T>(event: Box<repeat each T>) -> [Box<repeat each T>] { [] }
+}
+
+struct Processor<each P: Plugin> {
+    let plugins: (repeat each P)
+
+    func process<each Input>(
+        event: Box<repeat each Input>,
+        execute: (Box<repeat each Input>) -> Void
+    ) {
+        for plugin in repeat each plugins {
+            for action in plugin.handle(event: event) {
+                execute(action)
+            }
+        }
+    }
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s28pack_closure_parameter_crash12testComplexyyF
+// CHECK: } // end sil function '$s28pack_closure_parameter_crash12testComplexyyF'
+func testComplex() {
+    let p = Processor(plugins: (MyPlugin(),))
+    p.process(event: Box<Int, String>()) { _ in }
+}

--- a/test/SILGen/pack_element_member_capture.swift
+++ b/test/SILGen/pack_element_member_capture.swift
@@ -1,0 +1,44 @@
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
+
+// Test that pack element captures that reference member expressions correctly
+// capture the base variable (e.g., self) in enclosing closures.
+
+protocol P {
+    associatedtype Value
+    func get() -> Value
+}
+
+struct S: P {
+    typealias Value = Int
+    func get() -> Int { 42 }
+}
+
+final class Ops<each M: P> {
+    let items: (repeat each M)
+
+    init(items: (repeat each M)) {
+        self.items = items
+    }
+
+    // This test case verifies that when a pack element capture `(each self.items)`
+    // is used inside an immediately-invoked closure within a pack expansion,
+    // the outer closure correctly captures `self` so it's available when emitting
+    // the inner closure's captures.
+    func test() -> [(repeat (each M).Value)] {
+        return (0..<2).map { index in
+            var counter = 0
+            return (repeat {
+                counter += 1
+                return (each self.items).get()
+            }())
+        }
+    }
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s27pack_element_member_capture3OpsC4testSay5ValueQzxQp_tGyF
+// CHECK: function_ref @$s27pack_element_member_capture3OpsC4testSay5ValueQzxQp_tGyFAFxQp_tSiXEfU_
+// The outer closure should capture self
+// CHECK-LABEL: sil private [ossa] @$s27pack_element_member_capture3OpsC4testSay5ValueQzxQp_tGyFAFxQp_tSiXEfU_
+// The closure captures both index and self
+// CHECK: bb0({{.*}}, {{.*}}, {{.*}}, [[SELF:%[0-9]+]] : @closureCapture @guaranteed $Ops<repeat each M>):
+// CHECK: debug_value [[SELF]], let, name "self"

--- a/test/SILGen/pack_expansion_multi_tuple.swift
+++ b/test/SILGen/pack_expansion_multi_tuple.swift
@@ -1,0 +1,53 @@
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
+
+// Test that tuples containing multiple pack expansions can be passed to
+// functions expecting a single pack expansion tuple parameter.
+// This tests the fix for the SILGen assertion "only single pack expansion
+// tuples are currently supported" when combining two packs into one tuple.
+
+protocol P {}
+struct A: P {}
+
+struct Holder<each T: P> {
+    let values: (repeat each T)
+}
+
+// Test 1: Direct inline construction of multi-pack tuple
+// CHECK-LABEL: sil hidden [ossa] @$s26pack_expansion_multi_tuple10testInline
+func testInline<each X: P, each Y: P>(_ x: (repeat each X), _ y: (repeat each Y)) {
+    // This creates a tuple (repeat each X, repeat each Y) with two pack expansions
+    // and passes it to Holder which expects (repeat each T)
+    let h = Holder(values: (repeat each x, repeat each y))
+    print(h)
+}
+
+// Test 2: Store multi-pack tuple in variable first, then pass it
+// This tests the case where the tuple is an RValue, not an inline expression
+// CHECK-LABEL: sil hidden [ossa] @$s26pack_expansion_multi_tuple10testStored
+func testStored<each X: P, each Y: P>(_ x: (repeat each X), _ y: (repeat each Y)) {
+    let combined: (repeat each X, repeat each Y) = (repeat each x, repeat each y)
+    let h = Holder(values: combined)
+    print(h)
+}
+
+// Test 3: Multi-pack tuple returned from helper function
+// CHECK-LABEL: sil hidden [ossa] @$s26pack_expansion_multi_tuple6concat
+func concat<each X: P, each Y: P>(
+    _ x: (repeat each X),
+    _ y: (repeat each Y)
+) -> (repeat each X, repeat each Y) {
+    return (repeat each x, repeat each y)
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s26pack_expansion_multi_tuple14testFromHelper
+func testFromHelper<each X: P, each Y: P>(_ x: (repeat each X), _ y: (repeat each Y)) {
+    let combined = concat(x, y)
+    let h = Holder(values: combined)
+    print(h)
+}
+
+func callTests() {
+    testInline((A(),), (A(),))
+    testStored((A(),), (A(),))
+    testFromHelper((A(),), (A(),))
+}

--- a/test/SILGen/pack_expansion_multi_tuple_concurrent.swift
+++ b/test/SILGen/pack_expansion_multi_tuple_concurrent.swift
@@ -1,0 +1,57 @@
+// RUN: %target-build-swift -parse-as-library %s -o %t
+// RUN: %target-run %t | %FileCheck %s
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+
+// This test verifies that structs containing multi-pack expansion tuples
+// can be captured in Task closures without memory corruption.
+//
+// The issue: When a struct has a field of type (repeat each P) and P is
+// instantiated from multiple pack parameters (e.g., Wrapper<repeat each D, repeat each P>),
+// capturing that struct in a Task closure causes "freed pointer was not the last allocation"
+// errors in the task allocator.
+//
+// Related patterns that DO work:
+// - Plain multi-pack tuples captured in Tasks (without struct wrapper)
+// - Structs with single-pack tuples captured in Tasks
+// - Structs with multi-pack tuples captured in regular @Sendable closures (not Tasks)
+
+protocol Plugin: Sendable {}
+struct DefaultPlugin: Plugin { let id: Int }
+struct CustomPlugin: Plugin { let name: String }
+
+struct Wrapper<each P: Plugin>: Sendable {
+    let items: (repeat each P)
+
+    func count() -> Int {
+        var c = 0
+        for _ in repeat each items { c += 1 }
+        return c
+    }
+}
+
+// This function creates a Wrapper with a multi-pack tuple and captures it in a Task
+func runEngine<each D: Plugin, each P: Plugin>(
+    defaults: (repeat each D),
+    custom: (repeat each P)
+) async -> Int {
+    let wrapper = Wrapper(items: (repeat each defaults, repeat each custom))
+
+    let task = Task { @Sendable in
+        wrapper.count()
+    }
+
+    return await task.value
+}
+
+@main
+struct Main {
+    static func main() async {
+        let result = await runEngine(
+            defaults: (DefaultPlugin(id: 1), DefaultPlugin(id: 2)),
+            custom: (CustomPlugin(name: "a"),)
+        )
+        // CHECK: Result: 3
+        print("Result: \(result)")
+    }
+}

--- a/test/SILGen/pack_expansion_tuple_to_closure.swift
+++ b/test/SILGen/pack_expansion_tuple_to_closure.swift
@@ -1,0 +1,45 @@
+// RUN: %target-swift-emit-silgen %s -target %target-swift-5.9-abi-triple | %FileCheck %s
+
+// Test that passing a pack expansion tuple (from iteration or direct passing)
+// to a closure correctly uses pack_element_set to initialize the pack.
+//
+// This is a regression test for a bug where SILGen used pack_element_get
+// to read from an uninitialized pack, then tried to copy to that garbage
+// address, corrupting the stack frame.
+
+struct FuzzEngine<each Input> {
+  // CHECK-LABEL: sil hidden [ossa] @$s31pack_expansion_tuple_to_closure10FuzzEngineV3run6inputs4testySayxxQp_tG_yxxQp_t_tKXEtKF
+  // The loop body should use pack_element_set to initialize the pack, not pack_element_get.
+  // CHECK: [[PACK:%[0-9]+]] = alloc_pack $Pack{repeat each Input}
+  // CHECK: [[TUPLE_ELT:%[0-9]+]] = tuple_pack_element_addr
+  // CHECK: pack_element_set [[TUPLE_ELT]] into {{%[0-9]+}} of [[PACK]]
+  // CHECK: try_apply {{%[0-9]+}}([[PACK]])
+  func run(inputs: [(repeat each Input)], test: ((repeat each Input)) throws -> Void) rethrows {
+    for input in inputs {
+      try test(input)
+    }
+  }
+}
+
+struct Runner<each Input> {
+  // CHECK-LABEL: sil hidden [ossa] @$s31pack_expansion_tuple_to_closure6RunnerV3run_4testyxxQp_t_yxxQp_t_tKXEtKF
+  // Direct passing should also use pack_element_set.
+  // CHECK: [[PACK2:%[0-9]+]] = alloc_pack $Pack{repeat each Input}
+  // CHECK: pack_element_set {{%[0-9]+}} into {{%[0-9]+}} of [[PACK2]]
+  // CHECK: try_apply {{%[0-9]+}}([[PACK2]])
+  func run(_ input: (repeat each Input), test: ((repeat each Input)) throws -> Void) rethrows {
+    try test(input)
+  }
+}
+
+func useIt() {
+  let engine = FuzzEngine<Int>()
+  engine.run(inputs: [(42)]) { value in
+    print(value)
+  }
+
+  let runner = Runner<Int>()
+  runner.run((99)) { value in
+    print(value)
+  }
+}

--- a/test/SILGen/variadic_generic_closures_pack_expansion_arg_crash.swift
+++ b/test/SILGen/variadic_generic_closures_pack_expansion_arg_crash.swift
@@ -1,0 +1,50 @@
+// RUN: %target-swift-emit-silgen -target %target-swift-5.9-abi-triple %s
+
+// Test that passing a pack expansion tuple to a throwing closure compiles
+// without crashing. This tests the fix for a bug where SILGen would crash
+// when attempting to expand a tuple containing pack expansions (e.g.,
+// `(repeat each T)`) into pack arguments, because the element count is
+// only known at runtime in a generic context.
+
+// Test case 1: Direct parameter passing
+struct S<each Input> {
+    func run(_ input: (repeat each Input), test: ((repeat each Input)) throws -> Void) throws {
+        try test(input)
+    }
+}
+
+// Test case 2: Iterator pattern (from PropertyTestingKit)
+// This tests the case where a pack expansion tuple is obtained from iterating
+// over an array and then passed to a closure.
+struct FuzzEngine<each Input> {
+    func run(inputs: [(repeat each Input)], test: ((repeat each Input)) throws -> Void) throws {
+        for input in inputs {
+            try test(input)
+        }
+    }
+}
+
+// Test case 3: Single-element pack with closure
+// This tests the specific case where the closure's parameter is a single-element
+// pack expansion tuple that vanishes after substitution (e.g., FuzzEngine<Bool>).
+// The closure receives a pack parameter in the lowered representation, but the
+// formal parameter appears as a scalar after the tuple vanishes.
+func testSingleElementPack() throws {
+    let engine = FuzzEngine<Bool>()
+    try engine.run(inputs: []) { _ in }
+}
+
+// Test case 4: Closure with function type parameter
+// This tests that closures with function type parameters still work correctly.
+// This is a regression test to ensure the pack handling fix doesn't incorrectly
+// apply unchecked casts to function types, which require proper reabstraction.
+func withFunctionClosure(_ body: (UnsafeMutablePointer<Int>) -> Void) {
+    var x = 0
+    body(&x)
+}
+
+func testFunctionTypeParameter() {
+    withFunctionClosure { ptr in
+        ptr.pointee = 42
+    }
+}

--- a/test/SILOptimizer/definite_init_variadic_generics.swift
+++ b/test/SILOptimizer/definite_init_variadic_generics.swift
@@ -1,0 +1,146 @@
+// RUN: %target-swift-frontend -emit-sil %s -target %target-swift-5.9-abi-triple | %FileCheck %s
+
+// This test verifies that definite initialization correctly handles
+// structs with tuple properties containing pack expansions.
+// The DI pass must treat such tuples as single opaque elements rather
+// than trying to flatten them into individual element addresses.
+
+// MARK: - Basic struct with pack expansion tuple
+
+struct BasicPackTuple<each T> {
+  let values: (repeat each T)
+
+  // CHECK-LABEL: sil hidden @$s31definite_init_variadic_generics14BasicPackTupleV
+  // CHECK: tuple_pack_element_addr
+  init(_ values: repeat each T) {
+    self.values = (repeat each values)
+  }
+}
+
+// MARK: - Struct with multiple properties including pack expansion tuple
+
+struct MixedProperties<each T> {
+  let prefix: Int
+  let packed: (repeat each T)
+  let suffix: String
+
+  // CHECK-LABEL: sil hidden @$s31definite_init_variadic_generics15MixedPropertiesV
+  // CHECK: tuple_pack_element_addr
+  init(prefix: Int, suffix: String, _ values: repeat each T) {
+    self.prefix = prefix
+    self.packed = (repeat each values)
+    self.suffix = suffix
+  }
+}
+
+// MARK: - Struct with pack expansion tuple initialized in different branches
+
+struct ConditionalInit<each T> {
+  let values: (repeat each T)
+  let flag: Bool
+
+  // CHECK-LABEL: sil hidden @$s31definite_init_variadic_generics15ConditionalInitV
+  // CHECK: tuple_pack_element_addr
+  init(condition: Bool, _ values: repeat each T) {
+    self.flag = condition
+    if condition {
+      self.values = (repeat each values)
+    } else {
+      self.values = (repeat each values)
+    }
+  }
+}
+
+// MARK: - Nested struct containing pack expansion tuple
+
+struct Outer<each T> {
+  struct Inner {
+    let data: (repeat each T)
+
+    // CHECK-LABEL: sil hidden @$s31definite_init_variadic_generics5OuterV5InnerV
+    // CHECK: tuple_pack_element_addr
+    init(_ values: repeat each T) {
+      self.data = (repeat each values)
+    }
+  }
+
+  let inner: Inner
+
+  init(_ values: repeat each T) {
+    self.inner = Inner(repeat each values)
+  }
+}
+
+// MARK: - Class with pack expansion tuple property
+
+class ClassWithPackTuple<each T> {
+  let values: (repeat each T)
+
+  // CHECK-LABEL: sil hidden {{.*}}@$s31definite_init_variadic_generics18ClassWithPackTupleC
+  // CHECK: tuple_pack_element_addr
+  init(_ values: repeat each T) {
+    self.values = (repeat each values)
+  }
+}
+
+// MARK: - Failable initializer with pack expansion tuple
+
+struct FailablePackInit<each T> {
+  let values: (repeat each T)
+
+  // CHECK-LABEL: sil hidden @$s31definite_init_variadic_generics16FailablePackInitV
+  // CHECK: tuple_pack_element_addr
+  init?(_ values: repeat each T, shouldFail: Bool) {
+    if shouldFail {
+      return nil
+    }
+    self.values = (repeat each values)
+  }
+}
+
+// MARK: - Struct with throwing initializer and pack expansion tuple
+
+struct ThrowingPackInit<each T> {
+  let values: (repeat each T)
+
+  // CHECK-LABEL: sil hidden @$s31definite_init_variadic_generics16ThrowingPackInitV
+  // CHECK: tuple_pack_element_addr
+  init(_ values: repeat each T) throws {
+    self.values = (repeat each values)
+  }
+}
+
+// MARK: - Crash case: throwing call AFTER pack tuple assignment
+// This is the minimal reproducer for the DI crash. The crash occurs when:
+// 1. Struct has multiple properties including a pack expansion tuple
+// 2. Pack tuple is assigned first
+// 3. A throwing call comes AFTER the pack tuple assignment
+// DI must generate cleanup code to destroy the pack tuple if the throw occurs,
+// and was incorrectly using tuple_element_addr instead of treating it as opaque.
+
+func produceValue<T>(type: T.Type) -> T { fatalError() }
+func throwingCall() throws -> Int { return 0 }
+
+struct ThrowingAfterPackInit<each T> {
+  let packed: (repeat each T)
+  let other: Int
+
+  // CHECK-LABEL: sil hidden @$s31definite_init_variadic_generics21ThrowingAfterPackInitV
+  // CHECK: tuple_pack_element_addr
+  init() throws {
+    self.packed = (repeat produceValue(type: (each T).self))
+    self.other = try throwingCall()
+  }
+}
+
+// MARK: - Test instantiations to ensure code generation works
+
+func testInstantiations() {
+  _ = BasicPackTuple(1, "hello", 3.14)
+  _ = MixedProperties(prefix: 42, suffix: "end", true, 2.0)
+  _ = ConditionalInit(condition: true, "a", "b")
+  _ = Outer(1, 2, 3)
+  _ = ClassWithPackTuple("x", "y")
+  _ = FailablePackInit(1, 2, shouldFail: false)
+  _ = try? ThrowingPackInit(true, false)
+}

--- a/test/SILOptimizer/variadic_generic_tuple_assign_crash.swift
+++ b/test/SILOptimizer/variadic_generic_tuple_assign_crash.swift
@@ -1,0 +1,27 @@
+// RUN: %target-swift-frontend -emit-sil %s -target %target-swift-5.9-abi-triple
+// RUN: %target-swift-frontend -emit-ir %s -target %target-swift-5.9-abi-triple
+
+// This test case reproduces a crash in DefiniteInitialization when initializing
+// a struct property that is a tuple containing a pack expansion.
+//
+// The crash occurs when:
+// 1. Struct has multiple properties including a pack expansion tuple
+// 2. Pack tuple is assigned first
+// 3. A throwing call comes AFTER the pack tuple assignment
+//
+// DI must generate cleanup code to destroy the pack tuple if the throw occurs.
+// The bug was that DI incorrectly used tuple_element_addr (which requires static
+// indices) instead of treating the pack tuple as a single opaque element.
+
+func produceValue<T>(type: T.Type) -> T { fatalError() }
+func throwingCall() throws -> Int { return 0 }
+
+public struct CrashCase<each Input> {
+    public let input: (repeat each Input)
+    public let foo: Int
+
+    public init() throws {
+        self.input = (repeat produceValue(type: (each Input).self))
+        self.foo = try throwingCall()
+    }
+}

--- a/test/Sema/pack_default_argument_inlinable.swift
+++ b/test/Sema/pack_default_argument_inlinable.swift
@@ -1,0 +1,59 @@
+// RUN: %target-swift-frontend -typecheck %s
+
+// Test that @inlinable functions with parameter pack default arguments
+// work correctly. This tests SameShape requirement handling in
+// TypeCheckConstraints.cpp for default argument expressions.
+
+public protocol Plugin {
+    func handle()
+}
+
+public struct DefaultPlugin: Plugin {
+    public init() {}
+    public func handle() {}
+}
+
+public struct OtherPlugin: Plugin {
+    public init() {}
+    public func handle() {}
+}
+
+@usableFromInline
+struct Processor<each P: Plugin> {
+    @usableFromInline let plugins: (repeat each P)
+    @usableFromInline init(plugins: (repeat each P)) { self.plugins = plugins }
+}
+
+// Test @inlinable with parameter pack default arguments
+@inlinable
+public func process<each D: Plugin, each P: Plugin>(
+    defaults: (repeat each D) = (DefaultPlugin()),
+    plugins: (repeat each P) = ()
+) {
+    let _ = Processor(plugins: defaults)
+    let _ = Processor(plugins: plugins)
+}
+
+// Test with multiple pack parameters having defaults
+@inlinable
+public func multiProcess<each A: Plugin, each B: Plugin, each C: Plugin>(
+    first: (repeat each A) = (DefaultPlugin()),
+    second: (repeat each B) = (DefaultPlugin(), OtherPlugin()),
+    third: (repeat each C) = ()
+) {
+    let _ = Processor(plugins: first)
+    let _ = Processor(plugins: second)
+    let _ = Processor(plugins: third)
+}
+
+// Verify calling works
+public func testCalls() {
+    process()
+    process(defaults: (DefaultPlugin(), OtherPlugin()))
+    process(plugins: (DefaultPlugin(),))
+    process(defaults: (DefaultPlugin(),), plugins: (OtherPlugin(),))
+
+    multiProcess()
+    multiProcess(first: (OtherPlugin(),))
+    multiProcess(second: (DefaultPlugin(),))
+}


### PR DESCRIPTION
## Summary

Bundles 24 regression tests covering parameter-pack bugs that still reproduce on `main` (survey commit `f0d8239caee`). Each test is its own commit, so individual tests can be cherry-picked, dropped, or fixed up independently. Each test's full lit failure log is linked as a gist below.

Tests were derived from a fork branch where 26 tests were originally added alongside compiler fixes. Each test was applied alone onto a clean checkout of `origin/main` and run against a freshly-built `main` toolchain (`--bootstrapping=hosttools --darwin-deployment-version-osx=14.0`, lit `variant_triple` patched to `arm64-apple-macosx14.0`). 24 of 26 still fail; the other 2 already pass on `main` and are not included here.

### Already fixed on `main` (excluded)

- `test/Concurrency/sendnonsendable_tasklocal_crash.swift` — was a SendNonSendable region-analysis assertion crash on `release/6.3`; passes on `main`.
- `test/SILGen/variadic_generic_closure_pack_arg.swift` — was a SILGenProlog crash on `release/6.3`; passes on `main`.

### Failure breakdown on `main`

| Category | Count | What it means |
|---|---|---|
| `compiler-crash` | 15 | swift-frontend crashes (assertion failure or unreachable executed). |
| `enum-pack-rejected` | 4 | enum declarations using type parameter packs are rejected with `enums cannot declare a type pack`. |
| `runtime-dealloc-bug` | 2 | runtime aborts with deallocation-order error (`freed pointer was not the last allocation` or equivalent). |
| `diagnostic-mismatch` | 2 | expected diagnostics not produced (or extra/unexpected diagnostics produced) for a pack-using construct. |
| `compile-error` | 1 | compiler emits an error for code that should compile. |

### Tests

| # | Category | Test | Headline | Log |
|---|---|---|---|---|
| 1 | `compiler-crash` | `test/IRGen/keypath_parameter_pack.swift` | Assertion failed: (metadata.GenericPackArguments.empty() && "We don't support packs here yet"), function operator(), file GenProto.cpp, line 4773. | [gist](https://gist.github.com/alex-reilly-dd/c09f7df225ad12cb298e64db6c1c69d1) |
| 2 | `compiler-crash` | `test/IRGen/round-trip-debug-types-pack-expansion.swift` | Crash (no assertion): While emitting IR SIL function "@$s4main7MachineC2fnACyxxQp_QPGys8Sendable_pSg_xxQp_tntc_tcfc". | [gist](https://gist.github.com/alex-reilly-dd/867d96ce301cac30542b961523708923) |
| 3 | `compiler-crash` | `test/Interpreter/keypath_parameter_pack.swift` | Assertion failed: (metadata.GenericPackArguments.empty() && "We don't support packs here yet"), function operator(), file GenProto.cpp, line 4773. | [gist](https://gist.github.com/alex-reilly-dd/27749296d1df3ea9b0fac56c39a803e2) |
| 4 | `compiler-crash` | `test/Interpreter/keypath_parameter_pack_generic.swift` | Assertion failed: (metadata.GenericPackArguments.empty() && "We don't support packs here yet"), function operator(), file GenProto.cpp, line 4773. | [gist](https://gist.github.com/alex-reilly-dd/8ee64aeec5a385acbf645bb6be6aaf05) |
| 5 | `compiler-crash` | `test/Interpreter/variadic_generic_closure_pack_expansion.swift` | Assertion failed: (!tupleTy.containsPackExpansionType() && "can't extract elements from tuples containing pack expansions " "right now"), function extractElements, file RValue.cpp, line 707. | [gist](https://gist.github.com/alex-reilly-dd/734fd5950fed7ba4fff955afbdb49e9d) |
| 6 | `compiler-crash` | `test/Interpreter/variadic_generic_pack_owned_tuple.swift` | Assertion failed: (!tupleTy.containsPackExpansionType() && "can't extract elements from tuples containing pack expansions " "right now"), function extractElements, file RValue.cpp, line 707. | [gist](https://gist.github.com/alex-reilly-dd/4d4ba6a6c82cd5a580f30d7977fcf054) |
| 7 | `compiler-crash` | `test/Interpreter/variadic_generic_tuple_init.swift` | Crash (no assertion): While verifying SIL function "@$s4main17ThrowingContainerVACyxxQp_QPGyKcfC". | [gist](https://gist.github.com/alex-reilly-dd/e4611c092c5be2625f53b960b4675441) |
| 8 | `compiler-crash` | `test/Profiler/coverage_isolated_deinit_skipped_body.swift` | Assertion failed: (Bits.ApplyExpr.ThrowsIsSet), function throws, file Expr.h, line 5014. | [gist](https://gist.github.com/alex-reilly-dd/e23d9dd87b2df3e76d69523e0f6d8fae) |
| 9 | `compiler-crash` | `test/SILGen/pack_closure_parameter_crash.swift` | Assertion failed: (origPackType.matchesPack(substPackType)), function PackElementGenerator, file AbstractionPattern.cpp, line 938. | [gist](https://gist.github.com/alex-reilly-dd/532e1b7b865b14bc8d02dc3b43774a61) |
| 10 | `compiler-crash` | `test/SILGen/pack_element_member_capture.swift` | Assertion failed: (!getDeclContext()->isLocalContext() && "not a global variable!"), function isLazilyInitializedGlobal, file Decl.cpp, line 8396. | [gist](https://gist.github.com/alex-reilly-dd/4d538fff46052bee5385f3149af08c77) |
| 11 | `compiler-crash` | `test/SILGen/pack_expansion_multi_tuple.swift` | Assertion failed: (!tupleTy.containsPackExpansionType() && "can't extract elements from tuples containing pack expansions " "right now"), function extractElements, file RValue.cpp, line 707. | [gist](https://gist.github.com/alex-reilly-dd/611c808fb3cd634c6e01a59d3a7ba170) |
| 12 | `compiler-crash` | `test/SILGen/pack_expansion_tuple_to_closure.swift` | Assertion failed: (!tupleTy.containsPackExpansionType() && "can't extract elements from tuples containing pack expansions " "right now"), function extractElements, file RValue.cpp, line 707. | [gist](https://gist.github.com/alex-reilly-dd/5f3dd38ec924e574a327df8370372deb) |
| 13 | `compiler-crash` | `test/SILGen/variadic_generic_closures_pack_expansion_arg_crash.swift` | Assertion failed: (!tupleTy.containsPackExpansionType() && "can't extract elements from tuples containing pack expansions " "right now"), function extractElements, file RValue.cpp, line 707. | [gist](https://gist.github.com/alex-reilly-dd/1f4e557f5f038ff53ed0ac12be8ea942) |
| 14 | `compiler-crash` | `test/SILOptimizer/definite_init_variadic_generics.swift` | Crash (no assertion): While verifying SIL function "@$s31definite_init_variadic_generics21ThrowingAfterPackInitVACyxxQp_QPGyKcfC". | [gist](https://gist.github.com/alex-reilly-dd/0f11041c38552289c39bb3ea8a62c7d0) |
| 15 | `compiler-crash` | `test/SILOptimizer/variadic_generic_tuple_assign_crash.swift` | Crash (no assertion): While verifying SIL function "@$s35variadic_generic_tuple_assign_crash9CrashCaseVACyxxQp_QPGyKcfC". | [gist](https://gist.github.com/alex-reilly-dd/95142a5248cebbe54ce9f819493df59d) |
| 16 | `enum-pack-rejected` | `test/Generics/enum_pack_construction.swift` | unexpected error produced: enums cannot declare a type pack | [gist](https://gist.github.com/alex-reilly-dd/7cda368e51a784af0cf1b89a1d4e25d9) |
| 17 | `enum-pack-rejected` | `test/Generics/enum_pack_pattern_matching.swift` | unexpected error produced: enums cannot declare a type pack | [gist](https://gist.github.com/alex-reilly-dd/36226e0dd7fd1e0c3147851f7284917d) |
| 18 | `enum-pack-rejected` | `test/Generics/enum_with_pack_basic.swift` | unexpected error produced: enums cannot declare a type pack | [gist](https://gist.github.com/alex-reilly-dd/7f6da72b859581954a1015dbab057e92) |
| 19 | `enum-pack-rejected` | `test/Interpreter/enum_parameter_pack_cross_module.swift` | enums cannot declare a type pack | [gist](https://gist.github.com/alex-reilly-dd/b817dee3fcc75bb4eab33cd3e1e78b06) |
| 20 | `runtime-dealloc-bug` | `test/Concurrency/Runtime/pack_async_dealloc_order.swift` | freed pointer was not the last allocation | [gist](https://gist.github.com/alex-reilly-dd/43894468cdad6e7d403f1fd4409d66b0) |
| 21 | `runtime-dealloc-bug` | `test/SILGen/pack_expansion_multi_tuple_concurrent.swift` | freed pointer was not the last allocation | [gist](https://gist.github.com/alex-reilly-dd/62110bad5f196c0cfde68e4dccad7999) |
| 22 | `diagnostic-mismatch` | `test/Concurrency/sendable_closure_pack_parameter.swift` | incorrect message found | [gist](https://gist.github.com/alex-reilly-dd/79442334ec0694509de9f2704faca263) |
| 23 | `diagnostic-mismatch` | `test/Constraints/pack_expansion_default_arguments.swift` | unexpected note produced: in call to function 'singleElementDefault' | [gist](https://gist.github.com/alex-reilly-dd/2b5ee1289319b440c3ed3a188f216fb2) |
| 24 | `compile-error` | `test/Sema/pack_default_argument_inlinable.swift` | default argument value of type 'DefaultPlugin' cannot be converted to type '(repeat each D)' | [gist](https://gist.github.com/alex-reilly-dd/f9ab22d5507c3eaa0084e5cdb657b482) |

Each gist contains the full lit log captured against the `main` toolchain at survey time (assertion message, `While …` request context, complete stack frames, and any subsequent test runner output). Stack-frame addresses are from the survey machine.

