### PR TITLE
build-script: Add a flag to control pedantic diagnostics 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -863,16 +863,6 @@ endif()
 # Add any extra C++ compilation options that were passed down.
 add_compile_options($<$<COMPILE_LANGUAGE:CXX>:${SWIFT_EXTRA_CXX_FLAGS}>)
 
-if(CMAKE_C_COMPILER_ID MATCHES Clang)
-  add_compile_options($<$<OR:$<COMPILE_LANGUAGE:C>,$<COMPILE_LANGUAGE:CXX>>:-Werror=gnu>)
-endif()
-
-# Make some warnings errors as they are commonly occurring and flood the build
-# with unnecessary noise.
-if(CMAKE_C_COMPILER_ID MATCHES Clang)
-  add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Werror=c++98-compat-extra-semi>)
-endif()
-
 if(CMAKE_CXX_COMPILER_ID MATCHES Clang)
   include(CheckCXXCompilerFlag)
   # Check for '-fsized-deallocation', which we need in IRGen. Clang presumably

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1425,6 +1425,9 @@ swift_get_host_triple(SWIFT_HOST_TRIPLE)
 set(SWIFT_HOST_MODULE_TRIPLE "${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_ARCH_${SWIFT_HOST_VARIANT_ARCH}_MODULE}")
 set(SWIFT_HOST_LIBRARIES_DEST_DIR "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/swift/host")
 
+message(STATUS "Building with pedantic diagnostics: ${SWIFT_PEDANTIC_DIAGNOSTICS}")
+message(STATUS "")
+
 if(SWIFT_INCLUDE_TOOLS)
   message(STATUS "Building host Swift tools for ${SWIFT_HOST_VARIANT_SDK} ${SWIFT_HOST_VARIANT_ARCH}")
   message(STATUS "  Build type:     ${CMAKE_BUILD_TYPE}")

--- a/cmake/modules/SwiftSharedCMakeConfig.cmake
+++ b/cmake/modules/SwiftSharedCMakeConfig.cmake
@@ -275,10 +275,15 @@ macro(swift_common_cxx_warnings)
   # `-Werror` part.
   check_cxx_compiler_flag("-Werror" CXX_SUPPORTS_W_ERROR_OPTION)
 
-  # Make unhandled switch cases be an error in assert builds
-  if(DEFINED LLVM_ENABLE_ASSERTIONS)
-    if (CXX_SUPPORTS_W_ERROR_OPTION)
-      add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:-Werror=switch>)
+  # These are diagnostics that are useful at desk and help to keep our code
+  # clean.
+  if(SWIFT_PEDANTIC_DIAGNOSTICS)
+    if(CXX_SUPPORTS_W_ERROR_OPTION)
+      add_compile_options(
+        $<$<COMPILE_LANGUAGE:C,CXX>:-Werror=switch>
+        $<$<COMPILE_LANGUAGE:C,CXX>:-Werror=unused>
+        $<$<COMPILE_LANGUAGE:C,CXX>:-Werror=uninitialized>
+        $<$<COMPILE_LANGUAGE:C,CXX>:-Werror=implicit-fallthrough>)
     endif()
 
     if(MSVC)

--- a/cmake/modules/SwiftSharedCMakeConfig.cmake
+++ b/cmake/modules/SwiftSharedCMakeConfig.cmake
@@ -268,50 +268,38 @@ endmacro()
 # Common cmake project config for additional warnings.
 #
 macro(swift_common_cxx_warnings)
+  # Check the `-Werror` flag once and use that to guard `-W/-Werror`
+  # additions instead of calling `check_cxx_compiler_flag` for each option.
+  # Compilers that support these will not error on unknown warning groups by
+  # default anyway. What matters is whether the compiler understands the
+  # `-Werror` part.
   check_cxx_compiler_flag("-Werror" CXX_SUPPORTS_W_ERROR_OPTION)
 
   # Make unhandled switch cases be an error in assert builds
   if(DEFINED LLVM_ENABLE_ASSERTIONS)
-    check_cxx_compiler_flag("-Werror=switch" CXX_SUPPORTS_WERROR_SWITCH_FLAG)
-    if(CXX_SUPPORTS_WERROR_SWITCH_FLAG)
-      add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Werror=switch>)
+    if (CXX_SUPPORTS_W_ERROR_OPTION)
+      add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:-Werror=switch>)
     endif()
 
     if(MSVC)
       check_cxx_compiler_flag("/we4062" CXX_SUPPORTS_WE4062)
       if(CXX_SUPPORTS_WE4062)
-        add_compile_options($<$<COMPILE_LANGUAGE:CXX>:/we4062>)
+        add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:/we4062>)
       endif()
     endif()
   endif()
 
-  # Make some warnings errors as they are commonly occurring and flood the build
-  # with unnecessary noise.
   if(CXX_SUPPORTS_W_ERROR_OPTION)
-    add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:-Werror=c++98-compat-extra-semi>)
-    add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:-Werror=gnu>)
-  endif()
+    add_compile_options(
+      # Make some warnings errors as they are commonly occurring and flood the
+      # build with unnecessary noise.
+      $<$<COMPILE_LANGUAGE:C,CXX>:-Werror=c++98-compat-extra-semi>
+      $<$<COMPILE_LANGUAGE:C,CXX>:-Werror=gnu>
 
-  check_cxx_compiler_flag("-Werror -Wimplicit-fallthrough" CXX_SUPPORTS_IMPLICIT_FALLTHROUGH_FLAG)
-  if(CXX_SUPPORTS_IMPLICIT_FALLTHROUGH_FLAG)
-    add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wimplicit-fallthrough>)
-  endif()
-
-  # Check for -Wunreachable-code-aggressive instead of -Wunreachable-code, as that indicates
-  # that we have the newer -Wunreachable-code implementation.
-  check_cxx_compiler_flag("-Werror -Wunreachable-code-aggressive" CXX_SUPPORTS_UNREACHABLE_CODE_FLAG)
-  if(CXX_SUPPORTS_UNREACHABLE_CODE_FLAG)
-    add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wunreachable-code>)
-  endif()
-
-  check_cxx_compiler_flag("-Werror -Woverloaded-virtual" CXX_SUPPORTS_OVERLOADED_VIRTUAL)
-  if(CXX_SUPPORTS_OVERLOADED_VIRTUAL)
-    add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Woverloaded-virtual>)
-  endif()
-
-  check_cxx_compiler_flag("-Werror -Wnested-anon-types" CXX_SUPPORTS_NO_NESTED_ANON_TYPES_FLAG)
-  if(CXX_SUPPORTS_NO_NESTED_ANON_TYPES_FLAG)
-    add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wno-nested-anon-types>)
+      $<$<COMPILE_LANGUAGE:С,CXX>:-Wimplicit-fallthrough>
+      $<$<COMPILE_LANGUAGE:C,CXX>:-Wunreachable-code>
+      $<$<COMPILE_LANGUAGE:C,CXX>:-Woverloaded-virtual>
+      $<$<COMPILE_LANGUAGE:C,CXX>:-Wno-nested-anon-types>)
   endif()
 
   # Check for '-fapplication-extension'.  On OS X/iOS we wish to link all

--- a/cmake/modules/SwiftSharedCMakeConfig.cmake
+++ b/cmake/modules/SwiftSharedCMakeConfig.cmake
@@ -283,6 +283,7 @@ macro(swift_common_cxx_warnings)
         $<$<COMPILE_LANGUAGE:C,CXX>:-Werror=switch>
         $<$<COMPILE_LANGUAGE:C,CXX>:-Werror=unused>
         $<$<COMPILE_LANGUAGE:C,CXX>:-Werror=uninitialized>
+        $<$<COMPILE_LANGUAGE:C,CXX>:-Werror=unreachable-code>
         $<$<COMPILE_LANGUAGE:C,CXX>:-Werror=implicit-fallthrough>)
     endif()
 

--- a/cmake/modules/SwiftSharedCMakeConfig.cmake
+++ b/cmake/modules/SwiftSharedCMakeConfig.cmake
@@ -268,6 +268,8 @@ endmacro()
 # Common cmake project config for additional warnings.
 #
 macro(swift_common_cxx_warnings)
+  check_cxx_compiler_flag("-Werror" CXX_SUPPORTS_W_ERROR_OPTION)
+
   # Make unhandled switch cases be an error in assert builds
   if(DEFINED LLVM_ENABLE_ASSERTIONS)
     check_cxx_compiler_flag("-Werror=switch" CXX_SUPPORTS_WERROR_SWITCH_FLAG)
@@ -281,6 +283,13 @@ macro(swift_common_cxx_warnings)
         add_compile_options($<$<COMPILE_LANGUAGE:CXX>:/we4062>)
       endif()
     endif()
+  endif()
+
+  # Make some warnings errors as they are commonly occurring and flood the build
+  # with unnecessary noise.
+  if(CXX_SUPPORTS_W_ERROR_OPTION)
+    add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:-Werror=c++98-compat-extra-semi>)
+    add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:-Werror=gnu>)
   endif()
 
   check_cxx_compiler_flag("-Werror -Wimplicit-fallthrough" CXX_SUPPORTS_IMPLICIT_FALLTHROUGH_FLAG)

--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -347,11 +347,6 @@ skip-test-cmark
 
 build-embedded-stdlib-cross-compiling
 
-# Escalate certain C++ warnings to errors for Swift.
-extra-swift-cmake-options=
-   -DSWIFT_EXTRA_CXX_FLAGS="-Werror=unused -Werror=uninitialized -Werror=implicit-fallthrough"
-
-
 [preset: buildbot_incremental_base_all_platforms]
 mixin-preset=buildbot_incremental_base
 

--- a/utils/build_swift/build_swift/driver_arguments.py
+++ b/utils/build_swift/build_swift/driver_arguments.py
@@ -173,6 +173,13 @@ def _apply_default_arguments(args):
     if not args.android or not args.build_android:
         args.build_android = False
 
+    # By default, pedantic diagnostics are enabled only when assertions in
+    # the Swift project are also enabled. Otherwise we risk breaking
+    # no-assertions builds, which are not among the required pull request
+    # checks.
+    if args.swift_pedantic_diagnostics is None:
+        args.swift_pedantic_diagnostics = args.swift_assertions
+
     # By default use the same number of lit workers as build jobs.
     if not args.lit_jobs:
         args.lit_jobs = args.build_jobs
@@ -1116,6 +1123,18 @@ def create_argument_parser():
            store('swift_stdlib_strict_availability'),
            const=False,
            help='disable strict availability checking in the Swift standard library (you want this OFF for CI or at-desk builds)')
+
+    # -------------------------------------------------------------------------
+    in_group('Diagnostics')
+
+    option('--swift-pedantic-diagnostics', store,
+           const=True,
+           help='Enable and escalate certain compiler warnings for code health '
+                '(e.g. unused code) to errors when building the Swift project '
+                '(default: enabled when assertions in the Swift project are '
+                'enabled)')
+    option('--no-swift-pedantic-diagnostics', store('swift_pedantic_diagnostics'),
+           const=False)
 
     # -------------------------------------------------------------------------
     in_group('Select the CMake generator')

--- a/utils/build_swift/tests/build_swift/test_driver_arguments.py
+++ b/utils/build_swift/tests/build_swift/test_driver_arguments.py
@@ -519,6 +519,36 @@ class TestDriverArgumentParser(
         self.parse_default_args('--swift-stdlib-strict-availability')
         self.parse_default_args('--no-swift-stdlib-strict-availability')
 
+    def test_swift_pedantic_diagnostics(self):
+        def expectation(args, expected_value):
+            namespace = self.parse_default_args(args)
+            self.assertEqual(expected_value, namespace.swift_pedantic_diagnostics)
+
+        expectation(
+            ['--no-swift-pedantic-diagnostics', '--swift-pedantic-diagnostics'],
+            True)
+        expectation(
+            ['--swift-pedantic-diagnostics', '--no-swift-pedantic-diagnostics'],
+            False)
+        expectation(
+            ['--swift-assertions'],
+            True)
+        expectation(
+            ['--swift-assertions', '--swift-pedantic-diagnostics'],
+            True)
+        expectation(
+            ['--swift-assertions', '--no-swift-pedantic-diagnostics'],
+            False)
+        expectation(
+            ['--no-swift-assertions'],
+            False)
+        expectation(
+            ['--no-swift-assertions', '--swift-pedantic-diagnostics'],
+            True)
+        expectation(
+            [ '--no-swift-assertions', '--no-swift-pedantic-diagnostics'],
+            False)
+
     # -------------------------------------------------------------------------
     # Implied defaults tests
 

--- a/utils/build_swift/tests/expected_options.py
+++ b/utils/build_swift/tests/expected_options.py
@@ -303,6 +303,7 @@ EXPECTED_DEFAULTS = {
     'stdlib_docs_static_hosting': False,
     'stdlib_docs_hosting_base_path': '/',
     'symbols_package': None,
+    'swift_pedantic_diagnostics': True,
     'clean_libdispatch': True,
     'clean_foundation': True,
     'clean_xctest': True,
@@ -581,6 +582,10 @@ EXPECTED_OPTIONS = [
     SetOption('--swift-stdlib-strict-availability', value=True),
     SetOption('--no-swift-stdlib-strict-availability',
               dest='swift_stdlib_strict_availability', value=False),
+
+    SetOption('--swift-pedantic-diagnostics', value=True),
+    SetOption('--no-swift-pedantic-diagnostics',
+              dest='swift_pedantic_diagnostics', value=False),
 
     DisableOption('--no-llvm-include-tests', dest='llvm_include_tests'),
     EnableOption('--llvm-include-tests', dest='llvm_include_tests'),

--- a/utils/swift_build_support/swift_build_support/products/swift.py
+++ b/utils/swift_build_support/swift_build_support/products/swift.py
@@ -95,6 +95,9 @@ class Swift(product.Product):
 
         self.cmake_options.extend(self._enable_stdlib_symbol_graphs)
 
+        # Add pedantic diagnostics flag.
+        self.cmake_options.extend(self._swift_pedantic_diagnostics)
+
         self.cmake_options.extend(
             self._swift_tools_ld64_lto_codegen_only_for_supporting_targets)
 
@@ -311,6 +314,11 @@ updated without updating swift.py?")
     def _enable_new_runtime_build(self):
         return [('SWIFT_ENABLE_NEW_RUNTIME_BUILD:BOOL',
                  self.args.enable_new_runtime_build)]
+
+    @property
+    def _swift_pedantic_diagnostics(self):
+        return [('SWIFT_PEDANTIC_DIAGNOSTICS:BOOL',
+                  self.args.swift_pedantic_diagnostics)]
 
     @property
     def _darwin_test_deployment_versions(self):

--- a/utils/swift_build_support/tests/products/test_swift.py
+++ b/utils/swift_build_support/tests/products/test_swift.py
@@ -41,6 +41,7 @@ class SwiftTestCase(unittest.TestCase):
 
         # Setup args
         self.args = argparse.Namespace(
+            swift_pedantic_diagnostics=True,
             enable_tsan_runtime=False,
             compiler_vendor='none',
             swift_compiler_version=None,
@@ -138,6 +139,7 @@ class SwiftTestCase(unittest.TestCase):
             '-DSWIFT_DARWIN_TEST_DEPLOYMENT_VERSION_WATCHOS:STRING=6.0',
             '-DSWIFT_DARWIN_TEST_DEPLOYMENT_VERSION_XROS:STRING=1.0',
             '-DHELLO=YES',
+            '-DSWIFT_PEDANTIC_DIAGNOSTICS:BOOL=TRUE',
         ]
         self.assertEqual(set(swift.cmake_options), set(expected))
 
@@ -180,6 +182,7 @@ class SwiftTestCase(unittest.TestCase):
             '-DSWIFT_DARWIN_TEST_DEPLOYMENT_VERSION_WATCHOS:STRING=6.0',
             '-DSWIFT_DARWIN_TEST_DEPLOYMENT_VERSION_XROS:STRING=1.0',
             '-DHELLO=YES',
+            '-DSWIFT_PEDANTIC_DIAGNOSTICS:BOOL=TRUE',
         ]
         self.assertEqual(set(swift.cmake_options), set(flags_set))
 
@@ -605,3 +608,24 @@ class SwiftTestCase(unittest.TestCase):
              'TRUE'],
             [x for x in swift.cmake_options
              if 'DSWIFT_STDLIB_BUILD_SYMBOL_GRAPHS' in x])
+
+    def test_swift_pedantic_diagnostics(self):
+        self.args.swift_pedantic_diagnostics = True
+        swift = Swift(
+            args=self.args,
+            toolchain=self.toolchain,
+            source_dir='/path/to/src',
+            build_dir='/path/to/build')
+        self.assertIn(
+            '-DSWIFT_PEDANTIC_DIAGNOSTICS:BOOL=TRUE',
+            swift.cmake_options)
+
+        self.args.swift_pedantic_diagnostics = False
+        swift = Swift(
+            args=self.args,
+            toolchain=self.toolchain,
+            source_dir='/path/to/src',
+            build_dir='/path/to/build')
+        self.assertIn(
+            '-DSWIFT_PEDANTIC_DIAGNOSTICS:BOOL=FALSE',
+            swift.cmake_options)


### PR DESCRIPTION
Move the extra diagnostic options that are passed to some builds from build presets to the build system, and add a pair of `build-script` flags to control their inclusion: `--(no-)swift-pedantic-diagnostics`. By default, pedantic diagnostics are enabled whenever assertions in the Swift project are enabled.
    
This ensures that, by default, engineers get the same behavior with respect to these flags at desk and in pull request checks, and that the default is reliably tied to the `--swift-assertions` setting.

While we are here, tidy up some code and add `unreachable-code` to the lot.

Context: https://github.com/swiftlang/swift/pull/81284