### PR TITLE
EagerSpecializer: Emit comparisons for `@specialize`-ing by integer generic parameters properly.

### DIFF
--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -4064,6 +4064,11 @@ public:
     auto MetaTy = MI->getType().castTo<MetatypeType>();
     require(MetaTy->hasRepresentation(),
             "metatype instruction must have a metatype representation");
+
+    require(!MetaTy.getInstanceType()->mapTypeOutOfEnvironment()->isValueParameter()
+            && !MetaTy.getInstanceType()->is<IntegerType>(),
+            "metatype cannot be a value generic argument");
+
     verifyLocalArchetype(MI, MetaTy.getInstanceType());
   }
   void checkValueMetatypeInst(ValueMetatypeInst *MI) {

--- a/lib/SILOptimizer/Transforms/EagerSpecializer.cpp
+++ b/lib/SILOptimizer/Transforms/EagerSpecializer.cpp
@@ -470,26 +470,45 @@ void EagerDispatch::emitDispatchTo(SILFunction *NewFunc) {
 void EagerDispatch::
 emitTypeCheck(SILBasicBlock *FailedTypeCheckBB, SubstitutableType *ParamTy,
               Type SubTy) {
-  // Instantiate a thick metatype for T.Type
+  auto &Ctx = ParamTy->getASTContext();
   auto ContextTy = GenericFunc->mapTypeIntoEnvironment(ParamTy);
-  auto GenericMT = Builder.createMetatype(
-    Loc, getThickMetatypeType(ContextTy->getCanonicalType()));
+  SILValue GenericWord, SpecializedWord;
+  // Collect the value of the generic parameter and the value we're specializing
+  // for.
+  if (ParamTy->isValueParameter()) {
+    auto valueTy = cast<GenericTypeParamType>(ParamTy)->getValueType()->getCanonicalType();
+    auto genericInt = Builder.createTypeValue(Loc,
+      SILType::getPrimitiveObjectType(valueTy), ContextTy->getCanonicalType());
 
-  // Instantiate a thick metatype for <Specialized>.Type
-  auto SpecializedMT = Builder.createMetatype(
-    Loc, getThickMetatypeType(SubTy->getCanonicalType()));
+    auto specializedInt = Builder.createTypeValue(Loc,
+      SILType::getPrimitiveObjectType(valueTy), SubTy->getCanonicalType());
 
-  auto &Ctx = Builder.getASTContext();
-  auto WordTy = SILType::getBuiltinWordType(Ctx);
-  auto GenericMTVal =
-    Builder.createUncheckedBitwiseCast(Loc, GenericMT, WordTy);
-  auto SpecializedMTVal =
-    Builder.createUncheckedBitwiseCast(Loc, SpecializedMT, WordTy);
+    // If we add non-Int value generic parameters in the future, the destructuring
+    // and equality checking logic below will also need to change.
+    GenericWord = Builder.createStructExtract(Loc, genericInt,
+      valueTy->getStructOrBoundGenericStruct()->getStoredProperties().front());
+    SpecializedWord = Builder.createStructExtract(Loc, specializedInt,
+      valueTy->getStructOrBoundGenericStruct()->getStoredProperties().front());
+  } else {
+    auto WordTy = SILType::getBuiltinWordType(Ctx);
+    auto GenericMT = Builder.createMetatype(
+      Loc, getThickMetatypeType(ContextTy->getCanonicalType()));
+
+    // Instantiate a thick metatype for <Specialized>.Type
+    auto SpecializedMT = Builder.createMetatype(
+      Loc, getThickMetatypeType(SubTy->getCanonicalType()));
+
+    GenericWord =
+      Builder.createUncheckedBitwiseCast(Loc, GenericMT, WordTy);
+    SpecializedWord =
+      Builder.createUncheckedBitwiseCast(Loc, SpecializedMT, WordTy);
+  }
+  
 
   auto Cmp =
-    Builder.createBuiltinBinaryFunction(Loc, "cmp_eq", WordTy,
+    Builder.createBuiltinBinaryFunction(Loc, "cmp_eq", GenericWord->getType(),
                                         SILType::getBuiltinIntegerType(1, Ctx),
-                                        {GenericMTVal, SpecializedMTVal});
+                                        {GenericWord, SpecializedWord});
 
   auto *SuccessBB = Builder.getFunction().createBasicBlock();
   auto *FailBB = createSplitBranchTarget(FailedTypeCheckBB, Builder, Loc);

--- a/test/SILOptimizer/specialize_by_integer_parameter.swift
+++ b/test/SILOptimizer/specialize_by_integer_parameter.swift
@@ -1,0 +1,13 @@
+// RUN: %target-swift-frontend -disable-availability-checking -emit-sil -O %s | %FileCheck %s
+// 
+public struct Foo<let count: Int> {
+	// CHECK-LABEL: sil{{.*}} @$s{{.*}}3FooV3bar
+	// CHECK:         [[PARAM_VAL:%.*]] = type_value $Int for count
+	// CHECK:         [[SPEC_INT:%.*]] = integer_literal ${{.*}}, 3
+	// CHECK:         [[PARAM_INT:%.*]] = struct_extract [[PARAM_VAL]], #Int._value
+	// CHECK:         builtin "cmp_eq_Int64"([[PARAM_INT]], [[SPEC_INT]])
+    @specialized(where count == 3)
+    public func bar() -> Int {
+		return count
+    }
+}


### PR DESCRIPTION
We would try to take the `metatype` of the integer value, which doesn't work. If a specialized parameter is an integer generic parameter, emit a code sequence that compares the integer value. Fixes rdar://176876134.