### PR TITLE
[IRGen] Emit deinit call if present in AlignedGroupEntry::destroy

### DIFF
--- a/lib/IRGen/TypeLayout.cpp
+++ b/lib/IRGen/TypeLayout.cpp
@@ -1906,39 +1906,41 @@ static Address addOffset(IRGenFunction &IGF, Address addr,
 }
 
 void AlignedGroupEntry::destroy(IRGenFunction &IGF, Address addr) const {
-  if (isFixedSize(IGF.IGM)) {
-    Size offset(0);
-    for (auto entry : entries) {
-      uint64_t aligned = offset.getValue();
-      // Align the offset
-      aligned += entry->fixedAlignment(IGF.IGM)->getMaskValue();
-      aligned &= ~(entry->fixedAlignment(IGF.IGM)->getMaskValue());
-      offset = Size(aligned);
-      auto projected = IGF.emitByteOffsetGEP(
-          addr.getAddress(),
-          llvm::ConstantInt::get(IGF.IGM.Int32Ty, offset.getValue()));
-      entry->destroy(IGF, Address(projected, IGF.IGM.OpaquePtrTy,
-                                  *entry->fixedAlignment(IGF.IGM)));
-      offset += *entry->fixedSize(IGF.IGM);
-    }
-  } else {
-    Address currentDest = addr;
-    auto remainingEntries = entries.size();
-    for (auto *entry : entries) {
-      if (currentDest.getAddress() != addr.getAddress()) {
-        // Align upto the current entry's requirement.
-        auto entryMask = entry->alignmentMask(IGF);
-        currentDest = alignAddress(IGF, currentDest, entryMask);
+  if (!tryEmitDestroyUsingDeinit(IGF, addr, ty)) {
+    if (isFixedSize(IGF.IGM)) {
+      Size offset(0);
+      for (auto entry : entries) {
+        uint64_t aligned = offset.getValue();
+        // Align the offset
+        aligned += entry->fixedAlignment(IGF.IGM)->getMaskValue();
+        aligned &= ~(entry->fixedAlignment(IGF.IGM)->getMaskValue());
+        offset = Size(aligned);
+        auto projected = IGF.emitByteOffsetGEP(
+            addr.getAddress(),
+            llvm::ConstantInt::get(IGF.IGM.Int32Ty, offset.getValue()));
+        entry->destroy(IGF, Address(projected, IGF.IGM.OpaquePtrTy,
+                                    *entry->fixedAlignment(IGF.IGM)));
+        offset += *entry->fixedSize(IGF.IGM);
       }
+    } else {
+      Address currentDest = addr;
+      auto remainingEntries = entries.size();
+      for (auto *entry : entries) {
+        if (currentDest.getAddress() != addr.getAddress()) {
+          // Align upto the current entry's requirement.
+          auto entryMask = entry->alignmentMask(IGF);
+          currentDest = alignAddress(IGF, currentDest, entryMask);
+        }
 
-      entry->destroy(IGF, currentDest);
+        entry->destroy(IGF, currentDest);
 
-      --remainingEntries;
-      if (remainingEntries == 0)
-        continue;
+        --remainingEntries;
+        if (remainingEntries == 0)
+          continue;
 
-      auto entrySize = entry->size(IGF);
-      currentDest = addOffset(IGF, currentDest, entrySize);
+        auto entrySize = entry->size(IGF);
+        currentDest = addOffset(IGF, currentDest, entrySize);
+      }
     }
   }
 }

--- a/test/IRGen/noncopyable_struct_deinit_value_witness.swift
+++ b/test/IRGen/noncopyable_struct_deinit_value_witness.swift
@@ -1,0 +1,18 @@
+// RUN: %swift-frontend -O -emit-ir -module-name foo %s -o - | %FileCheck %s
+
+// CHECK-LABEL: define internal void @"$s3foo3FooVwxx"(ptr noalias %object, ptr readonly captures(none) %"Foo<T>")
+// CHECK-NEXT: entry:
+// CHECK-NEXT:   tail call swiftcc void @"$s3foo3FooVfD"(ptr %"Foo<T>", ptr noalias swiftself %object)
+// CHECK-NEXT:   ret void
+// CHECK-NEXT: }
+
+public struct Foo<T> : ~Copyable {
+    var t: T
+
+    public init(t: T) {
+        self.t = t
+    }
+    deinit {
+        print("Deinit")
+    }
+}


### PR DESCRIPTION
rdar://166921106

When generating destroy witnesses in AlignedGroupEntry, we have to check if the type has a deinit defined and if so, emit a call to that, instead of emitting e regular destroy witness body.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
