### PR TITLE
[6.4][IRGen] Emit deinit call if present in AlignedGroupEntry::destroy

### DIFF
--- a/lib/IRGen/TypeLayout.cpp
+++ b/lib/IRGen/TypeLayout.cpp
@@ -1906,39 +1906,41 @@ static Address addOffset(IRGenFunction &IGF, Address addr,
 }
 
 void AlignedGroupEntry::destroy(IRGenFunction &IGF, Address addr) const {
-  if (isFixedSize(IGF.IGM)) {
-    Size offset(0);
-    for (auto entry : entries) {
-      uint64_t aligned = offset.getValue();
-      // Align the offset
-      aligned += entry->fixedAlignment(IGF.IGM)->getMaskValue();
-      aligned &= ~(entry->fixedAlignment(IGF.IGM)->getMaskValue());
-      offset = Size(aligned);
-      auto projected = IGF.emitByteOffsetGEP(
-          addr.getAddress(),
-          llvm::ConstantInt::get(IGF.IGM.Int32Ty, offset.getValue()));
-      entry->destroy(IGF, Address(projected, IGF.IGM.OpaquePtrTy,
-                                  *entry->fixedAlignment(IGF.IGM)));
-      offset += *entry->fixedSize(IGF.IGM);
-    }
-  } else {
-    Address currentDest = addr;
-    auto remainingEntries = entries.size();
-    for (auto *entry : entries) {
-      if (currentDest.getAddress() != addr.getAddress()) {
-        // Align upto the current entry's requirement.
-        auto entryMask = entry->alignmentMask(IGF);
-        currentDest = alignAddress(IGF, currentDest, entryMask);
+  if (!tryEmitDestroyUsingDeinit(IGF, addr, ty)) {
+    if (isFixedSize(IGF.IGM)) {
+      Size offset(0);
+      for (auto entry : entries) {
+        uint64_t aligned = offset.getValue();
+        // Align the offset
+        aligned += entry->fixedAlignment(IGF.IGM)->getMaskValue();
+        aligned &= ~(entry->fixedAlignment(IGF.IGM)->getMaskValue());
+        offset = Size(aligned);
+        auto projected = IGF.emitByteOffsetGEP(
+            addr.getAddress(),
+            llvm::ConstantInt::get(IGF.IGM.Int32Ty, offset.getValue()));
+        entry->destroy(IGF, Address(projected, IGF.IGM.OpaquePtrTy,
+                                    *entry->fixedAlignment(IGF.IGM)));
+        offset += *entry->fixedSize(IGF.IGM);
       }
+    } else {
+      Address currentDest = addr;
+      auto remainingEntries = entries.size();
+      for (auto *entry : entries) {
+        if (currentDest.getAddress() != addr.getAddress()) {
+          // Align upto the current entry's requirement.
+          auto entryMask = entry->alignmentMask(IGF);
+          currentDest = alignAddress(IGF, currentDest, entryMask);
+        }
 
-      entry->destroy(IGF, currentDest);
+        entry->destroy(IGF, currentDest);
 
-      --remainingEntries;
-      if (remainingEntries == 0)
-        continue;
+        --remainingEntries;
+        if (remainingEntries == 0)
+          continue;
 
-      auto entrySize = entry->size(IGF);
-      currentDest = addOffset(IGF, currentDest, entrySize);
+        auto entrySize = entry->size(IGF);
+        currentDest = addOffset(IGF, currentDest, entrySize);
+      }
     }
   }
 }

--- a/test/IRGen/noncopyable_struct_deinit_value_witness.swift
+++ b/test/IRGen/noncopyable_struct_deinit_value_witness.swift
@@ -1,0 +1,18 @@
+// RUN: %swift-frontend -O -emit-ir -module-name foo %s -o - | %FileCheck %s
+
+// CHECK-LABEL: define internal void @"$s3foo3FooVwxx"(ptr noalias %object, ptr readonly captures(none) %"Foo<T>")
+// CHECK-NEXT: entry:
+// CHECK-NEXT:   tail call swiftcc void @"$s3foo3FooVfD"(ptr %"Foo<T>", ptr noalias swiftself %object)
+// CHECK-NEXT:   ret void
+// CHECK-NEXT: }
+
+public struct Foo<T> : ~Copyable {
+    var t: T
+
+    public init(t: T) {
+        self.t = t
+    }
+    deinit {
+        print("Deinit")
+    }
+}


### PR DESCRIPTION
- **Explanation**:
    When generating destroy witnesses in `AlignedGroupEntry::destroy`, check
    whether the type has a user-defined `deinit` and, if so, emit a call to that
    deinit instead of emitting a regular field-by-field destroy witness body.
    Without this, the deinit was silently skipped for noncopyable aggregates
    destroyed via the value witness table.

- **Scope**:
    Narrow. Affects IRGen of the destroy value witness for noncopyable
    aggregates with a user-defined `deinit`. Code that previously hit this path
    was leaking the deinit's side effects; behavior for types without a deinit
    is unchanged.

- **Issues**:
    rdar://166921106

- **Original PRs**: https://github.com/swiftlang/swift/pull/89117

- **Risk**:
    Low. The change is gated on the type having a deinit, and reuses the
    existing `tryEmitDestroyUsingDeinit` helper already used elsewhere in
    IRGen. The pre-existing destroy code path is preserved verbatim for the
    no-deinit case.

- **Testing**:
    Added `test/IRGen/noncopyable_struct_deinit_value_witness.swift` which
    FileChecks that the destroy value witness for a generic noncopyable struct
    with a `deinit` tail-calls the deinit. Local IRGen test suite passes.

- **Reviewers**: @jckarter 