### PR TITLE
Handle raw identifiers correctly in renamed APIs.

### DIFF
--- a/include/swift/AST/ASTPrinter.h
+++ b/include/swift/AST/ASTPrinter.h
@@ -458,6 +458,18 @@ void printWithCompatibilityFeatureChecks(ASTPrinter &printer,
 bool escapeIdentifierInContext(Identifier name, PrintNameContext context,
                                bool isSpecializedCxxType = false);
 
+/// Escape a raw identifier (keyword or containing spaces/special characters)
+/// using backticks if needed, and write it to the output stream.
+void printIdentifierEscapingIfNeeded(
+    StringRef identifier, llvm::raw_ostream &os,
+    PrintNameContext context = PrintNameContext::Normal);
+
+/// Escape a raw identifier (keyword or containing spaces/special characters)
+/// using backticks if needed, and return it as a string.
+std::string
+identifierEscapingIfNeeded(StringRef identifier,
+                           PrintNameContext context = PrintNameContext::Normal);
+
 } // namespace swift
 
 #endif // LLVM_SWIFT_AST_ASTPRINTER_H

--- a/include/swift/Basic/StringExtras.h
+++ b/include/swift/Basic/StringExtras.h
@@ -39,6 +39,19 @@ namespace swift {
   /// Determine whether the given string can be the name of a member.
   bool canBeMemberName(StringRef identifier);
 
+  /// Split a string at the first occurrence of a separator character, but do
+  /// not split within backticks (e.g. `A.B`).
+  std::pair<StringRef, StringRef> backtickAwareSplit(StringRef text,
+                                                     char separator);
+
+  /// Split a string at the last occurrence of a separator character, but do not
+  /// split within backticks.
+  std::pair<StringRef, StringRef> backtickAwareRSplit(StringRef text,
+                                                      char separator);
+
+  /// Strip surrounding backticks from a string if present.
+  StringRef stripBackticks(StringRef name);
+
   /// Returns true if the given word is one of Swift's known prepositions.
   ///
   /// This can be faster than getPartOfSpeech(StringRef).

--- a/include/swift/Parse/ParseDeclName.h
+++ b/include/swift/Parse/ParseDeclName.h
@@ -13,20 +13,36 @@
 #ifndef SWIFT_PARSE_PARSEDECLNAME_H
 #define SWIFT_PARSE_PARSEDECLNAME_H
 
+#include "swift/AST/ASTPrinter.h"
 #include "swift/AST/Identifier.h"
 #include "swift/Basic/LLVM.h"
 #include "swift/Parse/Lexer.h"
 
+#include <string>
+
 namespace swift {
 
 /// Describes a parsed declaration name.
+///
+/// This type maintains the property that if any of the components is a raw
+/// identifier, it will be stored *without* surrounding backticks (for example,
+/// a basename of `has a space` will be stored as "has a space"), since this
+/// matches how they are stored when forming `Identifier` values.
 struct ParsedDeclName {
   /// The name of the context of which the corresponding entity should
-  /// become a member.
-  StringRef ContextName;
+  /// become a member, represented as a list of components.
+  SmallVector<StringRef, 2> ContextNames;
 
   /// The base name of the declaration.
   StringRef BaseName;
+
+  /// The kind of the base name.
+  DeclBaseName::Kind BaseNameKind = DeclBaseName::Kind::Normal;
+
+  /// Get the spelling of the base name, escaping it if it is a normal
+  /// identifier and needs escaping in the given context.
+  std::string
+  baseNameSpelling(PrintNameContext context = PrintNameContext::Normal) const;
 
   /// The argument labels for a function declaration.
   SmallVector<StringRef, 4> ArgumentLabels;
@@ -46,12 +62,16 @@ struct ParsedDeclName {
   /// instance member, the index of the "Self" parameter.
   std::optional<unsigned> SelfIndex;
 
+  /// Reconstruct the full dot-delimited context name as a string, placing
+  /// backticks around any components that require escaping.
+  std::string fullContextName() const;
+
   /// Determine whether this is a valid name.
   explicit operator bool() const { return !BaseName.empty(); }
 
   /// Whether this declaration name turns the declaration into a
   /// member of some named context.
-  bool isMember() const { return !ContextName.empty(); }
+  bool isMember() const { return !ContextNames.empty(); }
 
   /// Whether the result is translated into an instance member.
   bool isInstanceMember() const {
@@ -70,11 +90,11 @@ struct ParsedDeclName {
   bool isOperator() const { return Lexer::isOperator(BaseName); }
 
   /// Form a declaration name from this parsed declaration name.
-  DeclName formDeclName(ASTContext &ctx, bool isSubscript = false,
+  DeclName formDeclName(ASTContext &ctx,
                         bool isCxxClassTemplateSpec = false) const;
 
   /// Form a declaration name from this parsed declaration name.
-  DeclNameRef formDeclNameRef(ASTContext &ctx, bool isSubscript = false,
+  DeclNameRef formDeclNameRef(ASTContext &ctx,
                               bool isCxxClassTemplateSpec = false) const;
 };
 
@@ -85,14 +105,14 @@ ParsedDeclName parseDeclName(StringRef name) LLVM_READONLY;
 /// Form a Swift declaration name from its constituent parts.
 DeclName formDeclName(ASTContext &ctx, StringRef baseName,
                       ArrayRef<StringRef> argumentLabels, bool isFunctionName,
-                      bool isInitializer, bool isSubscript = false,
+                      DeclBaseName::Kind baseNameKind,
                       bool isCxxClassTemplateSpec = false);
 
 /// Form a Swift declaration name reference from its constituent parts.
 DeclNameRef formDeclNameRef(ASTContext &ctx, StringRef baseName,
                             ArrayRef<StringRef> argumentLabels,
-                            bool isFunctionName, bool isInitializer,
-                            bool isSubscript = false,
+                            bool isFunctionName,
+                            DeclBaseName::Kind baseNameKind,
                             bool isCxxClassTemplateSpec = false);
 
 } // namespace swift

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -781,15 +781,16 @@ ASTPrinter &operator<<(ASTPrinter &printer, tok keyword) {
   return printer;
 }
 
+namespace swift {
+
 /// Determine whether to escape the given keyword in the given context.
-bool swift::escapeIdentifierInContext(Identifier name, PrintNameContext context,
+static bool escapeIdentifierInContext(StringRef name, PrintNameContext context,
                                       bool isSpecializedCxxTemplate) {
-  StringRef keyword = name.str();
-  bool isKeyword = llvm::StringSwitch<bool>(keyword)
+  bool isKeyword = llvm::StringSwitch<bool>(name)
 #define KEYWORD(KW) \
       .Case(#KW, true)
 #include "swift/AST/TokenKinds.def"
-      .Default(false);
+                       .Default(false);
 
   // NB: ClangImporter synthesizes C++ template specializations with Identifiers
   // that contain the full type signature; e.g., a type named literally
@@ -799,29 +800,61 @@ bool swift::escapeIdentifierInContext(Identifier name, PrintNameContext context,
   switch (context) {
   case PrintNameContext::Normal:
   case PrintNameContext::Attribute:
-    return isKeyword ||
-           (!isSpecializedCxxTemplate && name.mustAlwaysBeEscaped());
+    return isKeyword || (!isSpecializedCxxTemplate &&
+                         Lexer::identifierMustAlwaysBeEscaped(name));
   case PrintNameContext::Keyword:
   case PrintNameContext::IntroducerKeyword:
     return false;
 
   case PrintNameContext::ClassDynamicSelf:
   case PrintNameContext::GenericParameter:
-    return isKeyword && keyword != "Self";
+    return isKeyword && name != "Self";
 
   case PrintNameContext::TypeMember:
-    return isKeyword || !canBeMemberName(keyword) ||
-           (!isSpecializedCxxTemplate && name.mustAlwaysBeEscaped());
+    return isKeyword || !canBeMemberName(name) ||
+           (!isSpecializedCxxTemplate &&
+            Lexer::identifierMustAlwaysBeEscaped(name));
 
   case PrintNameContext::FunctionParameterExternal:
   case PrintNameContext::FunctionParameterLocal:
   case PrintNameContext::TupleElement:
-    return !canBeArgumentLabel(keyword) ||
-           (!isSpecializedCxxTemplate && name.mustAlwaysBeEscaped());
+    return !canBeArgumentLabel(name) ||
+           (!isSpecializedCxxTemplate &&
+            Lexer::identifierMustAlwaysBeEscaped(name));
   }
 
   llvm_unreachable("Unhandled PrintNameContext in switch.");
 }
+
+bool escapeIdentifierInContext(Identifier name, PrintNameContext context,
+                               bool isSpecializedCxxTemplate) {
+  return escapeIdentifierInContext(name.str(), context,
+                                   isSpecializedCxxTemplate);
+}
+
+void printIdentifierEscapingIfNeeded(StringRef identifier,
+                                     llvm::raw_ostream &os,
+                                     PrintNameContext context) {
+  bool mustEscape = escapeIdentifierInContext(
+      identifier, context, /*isSpecializedCxxTemplate=*/false);
+  if (mustEscape) {
+    os << '`';
+  }
+  os << identifier;
+  if (mustEscape) {
+    os << '`';
+  }
+}
+
+std::string identifierEscapingIfNeeded(StringRef identifier,
+                                       PrintNameContext context) {
+  std::string result;
+  llvm::raw_string_ostream os(result);
+  printIdentifierEscapingIfNeeded(identifier, os, context);
+  return result;
+}
+
+} // namespace swift
 
 void ASTPrinter::printName(Identifier Name, PrintNameContext Context,
                            bool IsSpecializedCxxTemplate) {

--- a/lib/AST/AccessNotes.cpp
+++ b/lib/AST/AccessNotes.cpp
@@ -35,10 +35,8 @@ AccessNoteDeclName::AccessNoteDeclName()
 AccessNoteDeclName::AccessNoteDeclName(ASTContext &ctx, StringRef str) {
   auto parsedName = parseDeclName(str);
 
-  StringRef first, rest = parsedName.ContextName;
-  while (!rest.empty()) {
-    std::tie(first, rest) = rest.split('.');
-    parentNames.push_back(ctx.getIdentifier(first));
+  for (auto component : parsedName.ContextNames) {
+    parentNames.push_back(ctx.getIdentifier(component));
   }
 
   if (parsedName.IsGetter)
@@ -48,7 +46,7 @@ AccessNoteDeclName::AccessNoteDeclName(ASTContext &ctx, StringRef str) {
   else
     accessorKind = std::nullopt;
 
-  name = parsedName.formDeclName(ctx, /*isSubscript=*/true);
+  name = parsedName.formDeclName(ctx);
 }
 
 bool AccessNoteDeclName::matches(ValueDecl *VD) const {

--- a/lib/Basic/StringExtras.cpp
+++ b/lib/Basic/StringExtras.cpp
@@ -1467,3 +1467,37 @@ bool swift::pathStartsWith(StringRef prefix, StringRef path) {
   }
   return prefixIt == prefixEnd;
 }
+
+std::pair<StringRef, StringRef> swift::backtickAwareSplit(StringRef text,
+                                                          char separator) {
+  bool inBackticks = false;
+  for (size_t i = 0; i < text.size(); ++i) {
+    char c = text[i];
+    if (c == '`') {
+      inBackticks = !inBackticks;
+    } else if (c == separator && !inBackticks) {
+      return {text.substr(0, i), text.substr(i + 1)};
+    }
+  }
+  return {text, StringRef()};
+}
+
+std::pair<StringRef, StringRef> swift::backtickAwareRSplit(StringRef text,
+                                                           char separator) {
+  bool inBackticks = false;
+  for (size_t i = text.size(); i > 0; --i) {
+    char c = text[i - 1];
+    if (c == '`') {
+      inBackticks = !inBackticks;
+    } else if (c == separator && !inBackticks) {
+      return {text.substr(0, i - 1), text.substr(i)};
+    }
+  }
+  return {text, StringRef()};
+}
+
+StringRef swift::stripBackticks(StringRef name) {
+  if (name.size() > 2 && name.front() == '`' && name.back() == '`')
+    return name.drop_front().drop_back();
+  return name;
+}

--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -20,6 +20,7 @@
 #include "ImportEnumInfo.h"
 #include "ImporterImpl.h"
 #include "swift/AST/ASTContext.h"
+#include "swift/AST/ASTPrinter.h"
 #include "swift/AST/ClangSwiftTypeCorrespondence.h"
 #include "swift/AST/DiagnosticEngine.h"
 #include "swift/AST/DiagnosticsClangImporter.h"
@@ -324,7 +325,10 @@ static void printFullContextPrefix(ImportedName name, ImportNameVersion version,
   assert(newDeclContextNamed && "should of been set");
   auto parentName = Impl.importFullName(newDeclContextNamed, version);
   printFullContextPrefix(parentName, version, os, Impl);
-  os << parentName.getDeclName() << ".";
+  auto baseNameStr = parentName.getDeclName().getBaseName().userFacingName();
+  printIdentifierEscapingIfNeeded(baseNameStr, os,
+                                  PrintNameContext::TypeMember);
+  os << ".";
 }
 
 void ClangImporter::Implementation::printSwiftName(ImportedName name,
@@ -357,7 +361,13 @@ void ClangImporter::Implementation::printSwiftName(ImportedName name,
     printFullContextPrefix(name, version, os, *this);
 
   // Base name.
-  os << name.getDeclName().getBaseName();
+  auto baseName = name.getDeclName().getBaseName();
+  if (baseName.isSpecial()) {
+    os << baseName.userFacingName();
+  } else {
+    printIdentifierEscapingIfNeeded(baseName.userFacingName(), os,
+                                    PrintNameContext::Normal);
+  }
 
   // Determine the number of argument labels we'll be producing.
   auto argumentNames = name.getDeclName().getArgumentNames();
@@ -380,10 +390,13 @@ void ClangImporter::Implementation::printSwiftName(ImportedName name,
     }
 
     if (currentArgName < argumentNames.size()) {
-      if (argumentNames[currentArgName].empty())
+      if (argumentNames[currentArgName].empty()) {
         os << "_";
-      else
-        os << argumentNames[currentArgName].str();
+      } else {
+        auto labelStr = argumentNames[currentArgName].str();
+        printIdentifierEscapingIfNeeded(
+            labelStr, os, PrintNameContext::FunctionParameterExternal);
+      }
       os << ":";
       ++currentArgName;
       continue;
@@ -1672,7 +1685,8 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
     auto method = dyn_cast<clang::ObjCMethodDecl>(D);
     if (method) {
       unsigned initPrefixLength;
-      if (parsedName.BaseName == "init" && parsedName.IsFunctionName) {
+      if (parsedName.BaseNameKind == DeclBaseName::Kind::Constructor &&
+          parsedName.IsFunctionName) {
         if (!shouldImportAsInitializer(method, version, initPrefixLength)) {
           // We cannot import this as an initializer anyway.
           return ImportedName();
@@ -1708,20 +1722,20 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
     if (!skipCustomName) {
       result.info.hasCustomName = true;
       result.declName = parsedName.formDeclName(
-          swiftCtx, /*isSubscript=*/false,
-          isa<clang::ClassTemplateSpecializationDecl>(D));
+          swiftCtx, isa<clang::ClassTemplateSpecializationDecl>(D));
 
       // Handle globals treated as members.
       if (parsedName.isMember()) {
         // FIXME: Make sure this thing is global.
-        result.effectiveContext = parsedName.ContextName;
+        result.effectiveContext =
+            swiftCtx.AllocateCopy(parsedName.fullContextName());
         if (parsedName.SelfIndex) {
           result.info.hasSelfIndex = true;
           result.info.selfIndex = *parsedName.SelfIndex;
         }
         result.info.importAsMember = true;
 
-        if (parsedName.BaseName == "init")
+        if (parsedName.BaseNameKind == DeclBaseName::Kind::Constructor)
           result.info.initKind = CtorInitializerKind::Factory;
       }
 
@@ -1764,7 +1778,9 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
             // Update the name to reflect the new parameter labels.
             result.declName = formDeclName(
                 swiftCtx, parsedName.BaseName, parsedName.ArgumentLabels,
-                /*isFunction=*/true, isInitializer, /*isSubscript=*/false,
+                /*isFunction=*/true,
+                isInitializer ? DeclBaseName::Kind::Constructor
+                              : DeclBaseName::Kind::Normal,
                 isa<clang::ClassTemplateSpecializationDecl>(D));
           } else if (nameAttr->isAsync) {
             // The custom name was for an async import, but we didn't in fact
@@ -2462,9 +2478,11 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
 
   baseName = renameUnsafeMethod(swiftCtx, D, baseName);
 
-  result.declName = formDeclName(swiftCtx, baseName, argumentNames, isFunction,
-                                 isInitializer, /*isSubscript=*/false,
-                                 isa<clang::ClassTemplateSpecializationDecl>(D));
+  result.declName =
+      formDeclName(swiftCtx, baseName, argumentNames, isFunction,
+                   isInitializer ? DeclBaseName::Kind::Constructor
+                                 : DeclBaseName::Kind::Normal,
+                   isa<clang::ClassTemplateSpecializationDecl>(D));
   return result;
 }
 

--- a/lib/Parse/ParseDeclName.cpp
+++ b/lib/Parse/ParseDeclName.cpp
@@ -12,8 +12,19 @@
 
 #include "swift/Parse/ParseDeclName.h"
 #include "swift/AST/ASTContext.h"
+#include "swift/AST/ASTPrinter.h"
+#include "swift/Basic/StringExtras.h"
+#include "swift/Parse/Lexer.h"
 
 using namespace swift;
+
+static bool isValidIdentifierInDeclName(StringRef text, bool allowUnderscore) {
+  if (Lexer::isIdentifier(text) && (allowUnderscore || text != "_"))
+    return true;
+  if (text.size() > 2 && text.front() == '`' && text.back() == '`')
+    return Lexer::isValidAsEscapedIdentifier(stripBackticks(text));
+  return false;
+}
 
 ParsedDeclName swift::parseDeclName(StringRef name) {
   if (name.empty())
@@ -26,7 +37,7 @@ ParsedDeclName swift::parseDeclName(StringRef name) {
   auto parseBaseName = [&](StringRef text) -> bool {
     // Split the text into context name and base name.
     StringRef contextName, baseName;
-    std::tie(contextName, baseName) = text.rsplit('.');
+    std::tie(contextName, baseName) = backtickAwareRSplit(text, '.');
     if (baseName.empty()) {
       baseName = contextName;
       contextName = StringRef();
@@ -35,7 +46,7 @@ ParsedDeclName swift::parseDeclName(StringRef name) {
     }
 
     auto isValidIdentifier = [](StringRef text) -> bool {
-      return Lexer::isIdentifier(text) && text != "_";
+      return isValidIdentifierInDeclName(text, /*allowUnderscore=*/false);
     };
 
     // Make sure we have an identifier for the base name.
@@ -49,24 +60,34 @@ ParsedDeclName swift::parseDeclName(StringRef name) {
       StringRef first;
       StringRef rest = contextName;
       do {
-        std::tie(first, rest) = rest.split('.');
+        std::tie(first, rest) = backtickAwareSplit(rest, '.');
         if (!isValidIdentifier(first))
           return true;
+        result.ContextNames.push_back(stripBackticks(first));
       } while (!rest.empty());
     }
 
     // Record the results.
-    result.ContextName = contextName;
-    result.BaseName = baseName;
+    if (baseName == "init") {
+      result.BaseNameKind = DeclBaseName::Kind::Constructor;
+    } else if (baseName == "deinit") {
+      result.BaseNameKind = DeclBaseName::Kind::Destructor;
+    } else if (result.IsSubscript || baseName == "subscript") {
+      result.BaseNameKind = DeclBaseName::Kind::Subscript;
+    } else {
+      result.BaseNameKind = DeclBaseName::Kind::Normal;
+    }
+    result.BaseName = stripBackticks(baseName);
     return false;
   };
 
   // If this is not a function name, just parse the base name and
   // we're done.
   if (name.back() != ')') {
-    if (Lexer::isOperator(name))
+    if (Lexer::isOperator(name)) {
       result.BaseName = name;
-    else if (parseBaseName(name))
+      result.BaseNameKind = DeclBaseName::Kind::Normal;
+    } else if (parseBaseName(name))
       return ParsedDeclName();
     return result;
   }
@@ -76,7 +97,7 @@ ParsedDeclName swift::parseDeclName(StringRef name) {
 
   // Split the base name from the parameters.
   StringRef baseName, parameters;
-  std::tie(baseName, parameters) = name.split('(');
+  std::tie(baseName, parameters) = backtickAwareSplit(name, '(');
   if (parameters.empty())
     return ParsedDeclName();
 
@@ -108,12 +129,12 @@ ParsedDeclName swift::parseDeclName(StringRef name) {
   if (parameters.back() != ':')
     return ParsedDeclName();
 
-  bool isMember = !result.ContextName.empty();
+  bool isMember = !result.ContextNames.empty();
   do {
     StringRef NextParam;
-    std::tie(NextParam, parameters) = parameters.split(':');
+    std::tie(NextParam, parameters) = backtickAwareSplit(parameters, ':');
 
-    if (!Lexer::isIdentifier(NextParam))
+    if (!isValidIdentifierInDeclName(NextParam, /*allowUnderscore=*/true))
       return ParsedDeclName();
     if (NextParam == "_") {
       result.ArgumentLabels.push_back("");
@@ -124,56 +145,97 @@ ParsedDeclName swift::parseDeclName(StringRef name) {
         return ParsedDeclName();
       result.SelfIndex = result.ArgumentLabels.size();
     } else {
-      result.ArgumentLabels.push_back(NextParam);
+      result.ArgumentLabels.push_back(stripBackticks(NextParam));
     }
   } while (!parameters.empty());
 
   return result;
 }
 
-DeclName ParsedDeclName::formDeclName(ASTContext &ctx, bool isSubscript,
-                                      bool isCxxClassTemplateSpec) const {
-  return formDeclNameRef(ctx, isSubscript, isCxxClassTemplateSpec)
-      .getFullName();
+std::string ParsedDeclName::fullContextName() const {
+  std::string result;
+  llvm::raw_string_ostream os(result);
+  bool first = true;
+  for (auto component : ContextNames) {
+    if (!first)
+      os << '.';
+    printIdentifierEscapingIfNeeded(component, os,
+                                    first ? PrintNameContext::Normal
+                                          : PrintNameContext::TypeMember);
+    first = false;
+  }
+  return result;
 }
 
-DeclNameRef ParsedDeclName::formDeclNameRef(ASTContext &ctx, bool isSubscript,
+std::string ParsedDeclName::baseNameSpelling(PrintNameContext context) const {
+  switch (BaseNameKind) {
+  case DeclBaseName::Kind::Subscript:
+    return "subscript";
+  case DeclBaseName::Kind::Constructor:
+    return "init";
+  case DeclBaseName::Kind::Destructor:
+    return "deinit";
+  case DeclBaseName::Kind::Normal:
+    return identifierEscapingIfNeeded(BaseName, context);
+  }
+  llvm_unreachable("Unhandled DeclBaseName::Kind in switch.");
+}
+
+DeclName ParsedDeclName::formDeclName(ASTContext &ctx,
+                                      bool isCxxClassTemplateSpec) const {
+  return formDeclNameRef(ctx, isCxxClassTemplateSpec).getFullName();
+}
+
+DeclNameRef ParsedDeclName::formDeclNameRef(ASTContext &ctx,
                                             bool isCxxClassTemplateSpec) const {
   return swift::formDeclNameRef(ctx, BaseName, ArgumentLabels, IsFunctionName,
-                                /*IsInitializer=*/true, isSubscript,
-                                isCxxClassTemplateSpec);
+                                BaseNameKind, isCxxClassTemplateSpec);
 }
 
 DeclName swift::formDeclName(ASTContext &ctx, StringRef baseName,
                              ArrayRef<StringRef> argumentLabels,
-                             bool isFunctionName, bool isInitializer,
-                             bool isSubscript, bool isCxxClassTemplateSpec) {
+                             bool isFunctionName,
+                             DeclBaseName::Kind baseNameKind,
+                             bool isCxxClassTemplateSpec) {
   return formDeclNameRef(ctx, baseName, argumentLabels, isFunctionName,
-                         isInitializer, isSubscript, isCxxClassTemplateSpec)
+                         baseNameKind, isCxxClassTemplateSpec)
       .getFullName();
 }
 
 DeclNameRef swift::formDeclNameRef(ASTContext &ctx, StringRef baseName,
                                    ArrayRef<StringRef> argumentLabels,
-                                   bool isFunctionName, bool isInitializer,
-                                   bool isSubscript,
+                                   bool isFunctionName,
+                                   DeclBaseName::Kind baseNameKind,
                                    bool isCxxClassTemplateSpec) {
   // We cannot import when the base name is not an identifier.
   if (baseName.empty())
     return DeclNameRef();
 
-  if (!Lexer::isIdentifier(baseName) && !Lexer::isOperator(baseName) &&
-      !isCxxClassTemplateSpec)
+  // This function receives identifiers that, if they were raw identifiers,
+  // have had their backticks stripped. Thus, we use
+  // `Lexer::isValidAsEscapedIdentifier` here and below instead of
+  // `isValidIdentifierInDeclName`, which expects that the only valid raw
+  // identifiers it sees will have their backticks.
+  if (!Lexer::isValidAsEscapedIdentifier(baseName) &&
+      !Lexer::isOperator(baseName) && !isCxxClassTemplateSpec)
     return DeclNameRef();
 
-  // Get the identifier for the base name. Special-case `init`.
+  // Get the identifier for the base name. Special-case init/subscript/deinit.
   DeclBaseName baseNameId;
-  if (isInitializer && baseName == "init")
+  switch (baseNameKind) {
+  case DeclBaseName::Kind::Constructor:
     baseNameId = DeclBaseName::createConstructor();
-  else if (isSubscript && baseName == "subscript")
+    break;
+  case DeclBaseName::Kind::Subscript:
     baseNameId = DeclBaseName::createSubscript();
-  else
-    baseNameId = ctx.getIdentifier(baseName);
+    break;
+  case DeclBaseName::Kind::Destructor:
+    baseNameId = DeclBaseName::createDestructor();
+    break;
+  case DeclBaseName::Kind::Normal:
+    baseNameId = ctx.getIdentifier(stripBackticks(baseName));
+    break;
+  }
 
   // For non-functions, just use the base name.
   if (!isFunctionName && !baseNameId.isSubscript())
@@ -184,12 +246,12 @@ DeclNameRef swift::formDeclNameRef(ASTContext &ctx, StringRef baseName,
   // Convert the argument names.
   SmallVector<Identifier, 4> argumentLabelIds;
   for (auto argName : argumentLabels) {
-    if (argumentLabels.empty() || !Lexer::isIdentifier(argName)) {
+    if (argumentLabels.empty() || !Lexer::isValidAsEscapedIdentifier(argName)) {
       argumentLabelIds.push_back(Identifier());
       continue;
     }
 
-    argumentLabelIds.push_back(ctx.getIdentifier(argName));
+    argumentLabelIds.push_back(ctx.getIdentifier(stripBackticks(argName)));
   }
 
   // Build the result.

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -21,6 +21,7 @@
 #include "TypeCheckInvertible.h"
 #include "TypeChecker.h"
 #include "swift/AST/ASTBridging.h"
+#include "swift/AST/ASTPrinter.h"
 #include "swift/AST/ASTWalker.h"
 #include "swift/AST/AvailabilitySpec.h"
 #include "swift/AST/ClangModuleLoader.h"
@@ -46,6 +47,7 @@
 #include "swift/ClangImporter/ClangImporter.h"
 #include "swift/ClangImporter/ClangImporterRequests.h"
 #include "swift/Parse/Lexer.h"
+#include "swift/Parse/ParseDeclName.h"
 #include "swift/Sema/ConstraintSystem.h"
 #include "swift/Sema/IDETypeChecking.h"
 #include "clang/AST/DeclObjC.h"
@@ -2949,20 +2951,24 @@ bool swift::diagnoseArgumentLabelError(ASTContext &ctx,
 
     if (!oldName.has_value() && newName.has_value()) {
       ++numMissing;
-      missingBuffer += newName->str();
+      missingBuffer += identifierEscapingIfNeeded(
+          newName->str(), PrintNameContext::FunctionParameterExternal);
       missingBuffer += ':';
     } else if (oldName.has_value() && !newName.has_value()) {
       ++numExtra;
-      extraBuffer += oldName->str();
+      extraBuffer += identifierEscapingIfNeeded(
+          oldName->str(), PrintNameContext::FunctionParameterExternal);
       extraBuffer += ':';
     } else if (oldName->empty()) {
       // In the cases from here onwards oldValue and newValue are not null
       ++numMissing;
-      missingBuffer += newName->str();
+      missingBuffer += identifierEscapingIfNeeded(
+          newName->str(), PrintNameContext::FunctionParameterExternal);
       missingBuffer += ":";
     } else if (newName->empty()) {
       ++numExtra;
-      extraBuffer += oldName->str();
+      extraBuffer += identifierEscapingIfNeeded(
+          oldName->str(), PrintNameContext::FunctionParameterExternal);
       extraBuffer += ':';
     } else {
       ++numWrong;
@@ -2986,7 +2992,8 @@ bool swift::diagnoseArgumentLabelError(ASTContext &ctx,
         if (haveName.empty())
           haveBuffer += '_';
         else
-          haveBuffer += haveName.str();
+          haveBuffer += identifierEscapingIfNeeded(
+              haveName.str(), PrintNameContext::FunctionParameterExternal);
         haveBuffer += ':';
       }
 
@@ -2994,7 +3001,8 @@ bool swift::diagnoseArgumentLabelError(ASTContext &ctx,
         if (expected.empty())
           expectedBuffer += '_';
         else
-          expectedBuffer += expected.str();
+          expectedBuffer += identifierEscapingIfNeeded(
+              expected.str(), PrintNameContext::FunctionParameterExternal);
         expectedBuffer += ':';
       }
 
@@ -3044,13 +3052,9 @@ bool swift::diagnoseArgumentLabelError(ASTContext &ctx,
       continue;
     }
 
-    bool newNameIsReserved = !canBeArgumentLabel(newName.str());
     llvm::SmallString<16> newStr;
-    if (newNameIsReserved)
-      newStr += "`";
-    newStr += newName.str();
-    if (newNameIsReserved)
-      newStr += "`";
+    newStr = identifierEscapingIfNeeded(
+        newName.str(), PrintNameContext::FunctionParameterExternal);
 
     // If the argument was previously unlabeled, insert the new label. Note that
     // we don't do this for labeled trailing closures as they write unlabeled

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -9110,7 +9110,7 @@ ValueDecl *RenamedDeclRequest::evaluate(Evaluator &evaluator,
 
   // Handle types separately
   if (isa<NominalTypeDecl>(attached)) {
-    if (!parsedName.ContextName.empty())
+    if (parsedName.isMember())
       return nullptr;
 
     SmallVector<ValueDecl *, 1> lookupResults;

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -22,8 +22,9 @@
 #include "TypeCheckType.h"
 #include "TypeCheckUnsafe.h"
 #include "TypeChecker.h"
-#include "swift/AST/AbstractLayout.h"
+#include "swift/AST/ASTPrinter.h"
 #include "swift/AST/ASTWalker.h"
+#include "swift/AST/AbstractLayout.h"
 #include "swift/AST/AvailabilityConstraint.h"
 #include "swift/AST/AvailabilityDomain.h"
 #include "swift/AST/AvailabilityScope.h"
@@ -1323,7 +1324,7 @@ static void fixItAvailableAttrRename(InFlightDiagnostic &diag,
       selfReplace.push_back(')');
 
     selfReplace.push_back('.');
-    selfReplace += parsed.BaseName;
+    selfReplace += parsed.baseNameSpelling(PrintNameContext::TypeMember);
 
     diag.fixItReplace(CE->getFn()->getSourceRange(), selfReplace);
 
@@ -1332,14 +1333,16 @@ static void fixItAvailableAttrRename(InFlightDiagnostic &diag,
 
     // Continue on to diagnose any argument label renames.
 
-  } else if (parsed.BaseName == "init" && isa_and_nonnull<CallExpr>(call)) {
+  } else if (parsed.BaseNameKind == DeclBaseName::Kind::Constructor &&
+             isa_and_nonnull<CallExpr>(call)) {
     auto *CE = cast<CallExpr>(call);
 
     // If it is a call to an initializer (rather than a first-class reference):
 
     if (parsed.isMember()) {
       // replace with a "call" to the type (instead of writing `.init`)
-      diag.fixItReplace(CE->getFn()->getSourceRange(), parsed.ContextName);
+      diag.fixItReplace(CE->getFn()->getSourceRange(),
+                        parsed.fullContextName());
     } else if (auto *dotCall = dyn_cast<DotSyntaxCallExpr>(CE->getFn())) {
       // if it's a dot call, and the left side is a type (and not `self` or 
       // `super`, for example), just remove the dot and the right side, again 
@@ -1376,11 +1379,11 @@ static void fixItAvailableAttrRename(InFlightDiagnostic &diag,
     // Just replace the base name.
     SmallString<64> baseReplace;
 
-    if (!parsed.ContextName.empty()) {
-      baseReplace += parsed.ContextName;
+    if (parsed.isMember()) {
+      baseReplace += parsed.fullContextName();
       baseReplace += '.';
     }
-    baseReplace += parsed.BaseName;
+    baseReplace += parsed.baseNameSpelling(PrintNameContext::Normal);
 
     if (parsed.IsFunctionName && isa_and_nonnull<SubscriptExpr>(call)) {
       auto *SE = cast<SubscriptExpr>(call);
@@ -1398,7 +1401,7 @@ static void fixItAvailableAttrRename(InFlightDiagnostic &diag,
         if (auto *DCE = dyn_cast<DotSyntaxCallExpr>(CE->getDirectCallee())) {
           if (auto *TE = dyn_cast<TypeExpr>(DCE->getBase())) {
             TE->getTypeRepr()->print(name);
-            if (!parsed.ContextName.empty()) {
+            if (parsed.isMember()) {
               // If there is a context in rename function e.g.
               // `Context.function()` and call context is a `DotSyntaxCallExpr`
               // adjust the range so it replaces the base as well.
@@ -1410,8 +1413,8 @@ static void fixItAvailableAttrRename(InFlightDiagnostic &diag,
         // Function names are the same (including context if applicable), so
         // renaming fix-it doesn't need do be produced.
         auto calledValue = CE->getCalledValue(/*skipFunctionConversions=*/true);
-        if ((parsed.ContextName.empty() ||
-             parsed.ContextName == callContextName) &&
+        if ((!parsed.isMember() ||
+             parsed.fullContextName() == callContextName.str()) &&
             calledValue && calledValue->getBaseName() == parsed.BaseName) {
           shouldEmitRenameFixit = false;
         }
@@ -1553,6 +1556,36 @@ namespace {
   };
 } // end anonymous namespace
 
+static std::string formatEscapedRename(ASTContext &ctx, StringRef renameStr,
+                                       const ValueDecl *D) {
+  ParsedDeclName parsed = swift::parseDeclName(renameStr);
+  if (!parsed)
+    return renameStr.str();
+
+  std::string result;
+  llvm::raw_string_ostream os(result);
+  if (parsed.isMember()) {
+    os << parsed.fullContextName() << '.';
+  }
+  if (parsed.IsFunctionName) {
+    os << parsed.baseNameSpelling(PrintNameContext::Normal);
+    os << '(';
+    for (auto label : parsed.ArgumentLabels) {
+      if (label.empty()) {
+        os << "_:";
+      } else {
+        printIdentifierEscapingIfNeeded(
+            label, os, PrintNameContext::FunctionParameterExternal);
+        os << ":";
+      }
+    }
+    os << ')';
+  } else {
+    os << parsed.baseNameSpelling(PrintNameContext::Normal);
+  }
+  return result;
+}
+
 static std::optional<ReplacementDeclKind>
 describeRename(ASTContext &ctx, StringRef newName, const ValueDecl *D,
                SmallVectorImpl<char> &nameBuf) {
@@ -1569,21 +1602,13 @@ describeRename(ASTContext &ctx, StringRef newName, const ValueDecl *D,
   // and bindings to member types and class/static properties.
   if (!(parsed.isInstanceMember() || parsed.isPropertyAccessor() ||
         (parsed.isMember() && parsed.IsFunctionName) ||
-        (parsed.BaseName == "init" &&
+        (parsed.BaseNameKind == DeclBaseName::Kind::Constructor &&
          !dyn_cast_or_null<ConstructorDecl>(D)))) {
     return std::nullopt;
   }
 
-  llvm::raw_svector_ostream name(nameBuf);
-
-  if (!parsed.ContextName.empty())
-    name << parsed.ContextName << '.';
-
-  if (parsed.IsFunctionName) {
-    name << parsed.formDeclName(ctx, (D && isa<SubscriptDecl>(D)));
-  } else {
-    name << parsed.BaseName;
-  }
+  std::string formatted = formatEscapedRename(ctx, newName, D);
+  nameBuf.append(formatted.begin(), formatted.end());
 
   if (parsed.isMember() && parsed.isPropertyAccessor())
     return ReplacementDeclKind::Property;
@@ -1645,8 +1670,10 @@ static void diagnoseIfDeprecated(SourceRange ReferenceRange,
 
   SmallString<32> newNameBuf;
   std::optional<ReplacementDeclKind> replacementDeclKind =
-      describeRename(Context, NewName, /*decl*/ nullptr, newNameBuf);
-  StringRef newName = replacementDeclKind ? newNameBuf.str() : NewName;
+      describeRename(Context, NewName, DeprecatedDecl, newNameBuf);
+  std::string escapedFallback =
+      formatEscapedRename(Context, NewName, DeprecatedDecl);
+  StringRef newName = replacementDeclKind ? newNameBuf.str() : escapedFallback;
 
   if (!Message.empty()) {
     EncodedDiagnosticMessage EncodedMessage(Message);
@@ -1766,12 +1793,15 @@ void swift::diagnoseOverrideOfUnavailableDecl(ValueDecl *override,
         }
 
         // Only initializers should be named 'init'.
-        if (isa<ConstructorDecl>(override) ^ (parsedName.BaseName == "init")) {
+        if (isa<ConstructorDecl>(override) ^
+            (parsedName.BaseNameKind == DeclBaseName::Kind::Constructor)) {
           return;
         }
 
         if (!parsedName.IsFunctionName) {
-          diag.fixItReplace(override->getNameLoc(), parsedName.BaseName);
+          diag.fixItReplace(
+              override->getNameLoc(),
+              parsedName.baseNameSpelling(PrintNameContext::Normal));
           return;
         }
 
@@ -2258,7 +2288,8 @@ bool diagnoseExplicitUnavailability(
         describeRename(ctx, Attr.getRename(), D, newNameBuf);
     unsigned rawReplaceKind = static_cast<unsigned>(
         replaceKind.value_or(ReplacementDeclKind::None));
-    StringRef newName = replaceKind ? newNameBuf.str() : rename;
+    std::string escapedFallback = formatEscapedRename(ctx, rename, D);
+    StringRef newName = replaceKind ? newNameBuf.str() : escapedFallback;
     EncodedDiagnosticMessage EncodedMessage(message);
     auto diag = diags.diagnose(Loc, diag::availability_decl_unavailable_rename,
                                D, replaceKind.has_value(), rawReplaceKind,

--- a/test/APINotes/Inputs/custom-modules/APINotesTest.apinotes
+++ b/test/APINotes/Inputs/custom-modules/APINotesTest.apinotes
@@ -2,9 +2,19 @@ Name: APINotesTest
 Functions:
   - Name: moveToPoint
     SwiftName: 'moveTo(x:y:z:)'
+  - Name: jumpToPoint
+    SwiftName: '`jump to`(x:)'
 Globals:
   - Name: ANTGlobalValue
     SwiftName: global
+  - Name: ANTGlobalValue2
+    SwiftName: '`test raw`'
+  - Name: ANTGlobalValue3
+    SwiftName: '`Complex.Name`'
+  - Name: ANTGlobalValue4
+    SwiftName: '`class`'
+  - Name: ANTGlobalValue5
+    SwiftName: '`3test raw`'
   - Name: will_be_private
     SwiftPrivate: true
 Tags:

--- a/test/APINotes/Inputs/custom-modules/APINotesTest.h
+++ b/test/APINotes/Inputs/custom-modules/APINotesTest.h
@@ -1,5 +1,11 @@
 void moveToPoint(int, int, int);
+void jumpToPoint(double x);
+
 extern int ANTGlobalValue;
+extern int ANTGlobalValue2;
+extern int ANTGlobalValue3;
+extern int ANTGlobalValue4;
+extern int ANTGlobalValue5;
 
 struct PointStruct {
   double x, y;

--- a/test/APINotes/basic.swift
+++ b/test/APINotes/basic.swift
@@ -28,6 +28,16 @@ func testSwiftName() {
 
   _ = global
   _ = ANTGlobalValue // expected-error{{'ANTGlobalValue' has been renamed to 'global'}}
+  _ = `test raw`
+  _ = ANTGlobalValue2 // expected-error{{'ANTGlobalValue2' has been renamed to '`test raw`'}}
+  _ = `Complex.Name`
+  _ = ANTGlobalValue3 // expected-error{{'ANTGlobalValue3' has been renamed to '`Complex.Name`'}}
+  _ = `class`
+  _ = ANTGlobalValue4 // expected-error{{'ANTGlobalValue4' has been renamed to '`class`'}}
+  `jump to`(x: 0.0)
+  jumpToPoint(0.0) // expected-error{{'jumpToPoint' has been renamed to '`jump to`(x:)'}}
+  _ = `3test raw`
+  _ = ANTGlobalValue5 // expected-error{{'ANTGlobalValue5' has been renamed to '`3test raw`'}}
 
   let ps = Point(x: 0.0, y: 0.0)
   let ps2 = PointStruct(x: 0.0, y: 0.0) // expected-error{{'PointStruct' has been renamed to 'Point'}}

--- a/test/ASTGen/availability.swift
+++ b/test/ASTGen/availability.swift
@@ -72,3 +72,18 @@ public class ClassWithMembers {
   @_spi_available(macOS 10.15, *)
   public func spiFunc() {}
 }
+
+@available(*, unavailable, renamed: "`class`")
+func keyword_renamed() {} // expected-note {{'keyword_renamed()' has been explicitly marked unavailable here}}
+
+@available(*, unavailable, renamed: "`foo bar`")
+func spaces_renamed() {} // expected-note {{'spaces_renamed()' has been explicitly marked unavailable here}}
+
+@available(*, unavailable, renamed: "foo(`3bar baz`:)")
+func keywords_in_arguments(x: Int) {} // expected-note {{'keywords_in_arguments(x:)' has been explicitly marked unavailable here}}
+
+func testEscapedRenamed() {
+  keyword_renamed() // expected-error {{'keyword_renamed()' has been renamed to '`class`'}}
+  spaces_renamed() // expected-error {{'spaces_renamed()' has been renamed to '`foo bar`'}}
+  keywords_in_arguments(x: 0) // expected-error {{'keywords_in_arguments(x:)' has been renamed to 'foo(`3bar baz`:)'}}
+}

--- a/test/ClangImporter/Inputs/custom-modules/RawIdentifierSwiftNames.h
+++ b/test/ClangImporter/Inputs/custom-modules/RawIdentifierSwiftNames.h
@@ -1,0 +1,14 @@
+@import Foundation;
+@import SwiftName;
+
+#pragma clang assume_nonnull begin
+@interface RawIdentifierTest : NSObject
+- (void)methodWithRawIdentifier:(NSInteger)value
+    SWIFT_NAME(`do something`(`with value `:));
+@property(readonly) int rawIdentifierProp SWIFT_NAME(`raw prop`);
+@end
+#pragma clang assume_nonnull end
+
+extern int test_raw SWIFT_NAME(`test raw`);
+extern int global_raw SWIFT_NAME(`3global raw`);
+extern int fooWithUnnecessaryBackticks SWIFT_NAME(`foo`);

--- a/test/ClangImporter/Inputs/custom-modules/module.modulemap
+++ b/test/ClangImporter/Inputs/custom-modules/module.modulemap
@@ -302,3 +302,8 @@ module SystemModuleWithWarnings {
   header "SystemModuleWithWarnings.h"
   export *
 }
+
+module RawIdentifierSwiftNames {
+  header "RawIdentifierSwiftNames.h"
+  export *
+}

--- a/test/ClangImporter/attr-swift_name-raw.swift
+++ b/test/ClangImporter/attr-swift_name-raw.swift
@@ -1,0 +1,28 @@
+// RUN: %empty-directory(%t.mcp)
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %S/Inputs/custom-modules -typecheck -verify -verify-ignore-unrelated %s -module-cache-path %t.mcp 2>&1
+// | %FileCheck %s
+
+// REQUIRES: objc_interop
+
+import RawIdentifierSwiftNames
+
+func testRawIdentifiers() {
+  let t = RawIdentifierTest()
+
+  t.`do something`(`with value`: 0) // expected-error {{incorrect argument label in call (have '`with value`:', expected '`with value `:')}}
+  t.`do something`(`with value `: 0)
+  t.methodWithRawIdentifier(0) // expected-error {{'methodWithRawIdentifier' has been renamed to '`do something`(`with value `:)'}}
+
+  _ = t.`raw prop`
+  _ = t.rawIdentifierProp // expected-error {{'rawIdentifierProp' has been renamed to '`raw prop`'}}
+
+  _ = `test raw`
+  _ = test_raw // expected-error {{'test_raw' has been renamed to '`test raw`'}}
+
+  _ = `3global raw`
+  _ = global_raw // expected-error {{'global_raw' has been renamed to '`3global raw`'}}
+
+  _ = `foo`
+  _ = foo
+  _ = fooWithUnnecessaryBackticks // expected-error {{'fooWithUnnecessaryBackticks' has been renamed to 'foo'}}
+}

--- a/test/Migrator/Inputs/RawMigration.apinotes
+++ b/test/Migrator/Inputs/RawMigration.apinotes
@@ -1,0 +1,12 @@
+Name: RawMigration
+Globals:
+  - Name: ANTOldGlobalValue
+    SwiftName: "`global value`"
+  - Name: ANTOldGlobalWithSpace
+    SwiftName: "`global with space`"
+Functions:
+  - Name: oldGlobalWithArgs
+    SwiftName: "`global function`(`with arg`:)"
+Typedefs:
+  - Name: OldStruct
+    SwiftName: "`Old Struct`"

--- a/test/Migrator/Inputs/RawMigration.h
+++ b/test/Migrator/Inputs/RawMigration.h
@@ -1,0 +1,8 @@
+void oldGlobalWithArgs(int x);
+
+extern int ANTOldGlobalValue;
+extern int ANTOldGlobalWithSpace;
+
+typedef struct {
+  int x;
+} OldStruct;

--- a/test/Migrator/Inputs/module.modulemap
+++ b/test/Migrator/Inputs/module.modulemap
@@ -1,0 +1,4 @@
+module RawMigration {
+  header "RawMigration.h"
+  export *
+}

--- a/test/Migrator/raw_identifier_migration.swift
+++ b/test/Migrator/raw_identifier_migration.swift
@@ -1,0 +1,35 @@
+// RUN: %empty-directory(%t)
+// RUN: not %target-swift-frontend -typecheck -update-code -primary-file %s -I %S/Inputs -emit-migrated-file-path %t/result.swift
+// RUN: diff -u %S/raw_identifier_migration.swift.expected %t/result.swift
+
+import RawMigration
+
+@available(*, unavailable, renamed: "`new swift name`")
+func oldSwiftFunc() {}
+
+@available(*, unavailable, renamed: "test(`with raw`:)")
+func oldSwiftFuncArgs(`raw`: Int) {}
+
+struct SomeStruct {
+  @available(*, unavailable, renamed: "`new member`")
+  func oldMember() {}
+  func `new member`() {}
+}
+
+func testMigration() {
+  _ = ANTOldGlobalValue
+  _ = ANTOldGlobalWithSpace
+  oldGlobalWithArgs(1)
+  let _ : OldStruct
+  
+  oldSwiftFunc()
+  oldSwiftFuncArgs(`raw`: 1)
+}
+
+func testMember(s: SomeStruct) {
+  s.oldMember()
+}
+
+func `new swift name`() {}
+func test(`with raw`: Int) {}
+

--- a/test/Migrator/raw_identifier_migration.swift.expected
+++ b/test/Migrator/raw_identifier_migration.swift.expected
@@ -1,0 +1,35 @@
+// RUN: %empty-directory(%t)
+// RUN: not %target-swift-frontend -typecheck -update-code -primary-file %s -I %S/Inputs -emit-migrated-file-path %t/result.swift
+// RUN: diff -u %S/raw_identifier_migration.swift.expected %t/result.swift
+
+import RawMigration
+
+@available(*, unavailable, renamed: "`new swift name`")
+func oldSwiftFunc() {}
+
+@available(*, unavailable, renamed: "test(`with raw`:)")
+func oldSwiftFuncArgs(`raw`: Int) {}
+
+struct SomeStruct {
+  @available(*, unavailable, renamed: "`new member`")
+  func oldMember() {}
+  func `new member`() {}
+}
+
+func testMigration() {
+  _ = `global value`
+  _ = `global with space`
+  `global function`(`with arg`: 1)
+  let _ : `Old Struct`
+  
+  `new swift name`()
+  test(`with raw`: 1)
+}
+
+func testMember(s: SomeStruct) {
+  s.`new member`()
+}
+
+func `new swift name`() {}
+func test(`with raw`: Int) {}
+

--- a/test/attr/attr_availability.swift
+++ b/test/attr/attr_availability.swift
@@ -62,6 +62,21 @@ protocol MyOlderProtocol {} // expected-note {{'MyOlderProtocol' has been explic
 
 extension Int: MyOlderProtocol {} // expected-error {{'MyOlderProtocol' has been renamed to 'MyNewerProtocol'}} 
 
+@available(*, unavailable, renamed: "`class`")
+func keyword_renamed() {} // expected-note {{'keyword_renamed()' has been explicitly marked unavailable here}}
+
+@available(*, unavailable, renamed: "`foo bar`")
+func spaces_renamed() {} // expected-note {{'spaces_renamed()' has been explicitly marked unavailable here}}
+
+@available(*, unavailable, renamed: "foo(`3bar baz`:)")
+func keywords_in_arguments(x: Int) {} // expected-note {{'keywords_in_arguments(x:)' has been explicitly marked unavailable here}}
+
+func testEscapedRenamed() {
+  keyword_renamed() // expected-error {{'keyword_renamed()' has been renamed to '`class`'}}
+  spaces_renamed() // expected-error {{'spaces_renamed()' has been renamed to '`foo bar`'}}
+  keywords_in_arguments(x: 0) // expected-error {{'keywords_in_arguments(x:)' has been renamed to 'foo(`3bar baz`:)'}}
+}
+
 struct MyCollection<Element> {
   @available(*, unavailable, renamed: "Element")
   typealias T = Element // expected-note 2{{'T' has been explicitly marked unavailable here}}
@@ -656,7 +671,7 @@ class DeprecatedInitBase {
   convenience init(testSelf: Int) {
     // https://github.com/apple/swift/issues/57354
     // The fix-it should not remove `.init`
-    self.init(old: testSelf) // expected-warning {{'init(old:)' is deprecated: replaced by 'init(new:)'}}{{documentation-file=deprecated-declaration}} expected-note {{use 'init(new:)' instead}} {{15-18=new}}
+    self.init(old: testSelf) // expected-warning {{'init(old:)' is deprecated: renamed to 'init(new:)'}}{{documentation-file=deprecated-declaration}} expected-note {{use 'init(new:)' instead}} {{15-18=new}}
   }
 
   init(testSuper: Int) {}
@@ -675,32 +690,32 @@ class DeprecatedInitSub1: DeprecatedInitBase {
   override init(testSuper: Int) {
     // https://github.com/apple/swift/issues/57354
     // The fix-it should not remove `.init`
-    super.init(old: testSuper) // expected-warning {{'init(old:)' is deprecated: replaced by 'init(new:)'}}{{documentation-file=deprecated-declaration}} expected-note {{use 'init(new:)' instead}} {{16-19=new}}
+    super.init(old: testSuper) // expected-warning {{'init(old:)' is deprecated: renamed to 'init(new:)'}}{{documentation-file=deprecated-declaration}} expected-note {{use 'init(new:)' instead}} {{16-19=new}}
   }
 }
 
 class DeprecatedInitSub2: DeprecatedInitBase { }
 
-_ = DeprecatedInitBase(old: 0) // expected-warning {{'init(old:)' is deprecated: replaced by 'init(new:)'}}{{documentation-file=deprecated-declaration}} expected-note {{use 'init(new:)' instead}} {{24-27=new}}
-_ = DeprecatedInitBase.init(old: 0) // expected-warning {{'init(old:)' is deprecated: replaced by 'init(new:)'}}{{documentation-file=deprecated-declaration}} expected-note {{use 'init(new:)' instead}} {{29-32=new}}
-let _: DeprecatedInitBase = .init(old: 0) // expected-warning {{'init(old:)' is deprecated: replaced by 'init(new:)'}}{{documentation-file=deprecated-declaration}} expected-note {{use 'init(new:)' instead}} {{35-38=new}}
-_ = DeprecatedInitSub2(old: 0) // expected-warning {{'init(old:)' is deprecated: replaced by 'init(new:)'}}{{documentation-file=deprecated-declaration}} expected-note {{use 'init(new:)' instead}} {{24-27=new}}
-_ = DeprecatedInitSub2.init(old: 0) // expected-warning {{'init(old:)' is deprecated: replaced by 'init(new:)'}}{{documentation-file=deprecated-declaration}} expected-note {{use 'init(new:)' instead}} {{29-32=new}}
-let _: DeprecatedInitSub2 = .init(old: 0) // expected-warning {{'init(old:)' is deprecated: replaced by 'init(new:)'}}{{documentation-file=deprecated-declaration}} expected-note {{use 'init(new:)' instead}} {{35-38=new}}
+_ = DeprecatedInitBase(old: 0) // expected-warning {{'init(old:)' is deprecated: renamed to 'init(new:)'}}{{documentation-file=deprecated-declaration}} expected-note {{use 'init(new:)' instead}} {{24-27=new}}
+_ = DeprecatedInitBase.init(old: 0) // expected-warning {{'init(old:)' is deprecated: renamed to 'init(new:)'}}{{documentation-file=deprecated-declaration}} expected-note {{use 'init(new:)' instead}} {{29-32=new}}
+let _: DeprecatedInitBase = .init(old: 0) // expected-warning {{'init(old:)' is deprecated: renamed to 'init(new:)'}}{{documentation-file=deprecated-declaration}} expected-note {{use 'init(new:)' instead}} {{35-38=new}}
+_ = DeprecatedInitSub2(old: 0) // expected-warning {{'init(old:)' is deprecated: renamed to 'init(new:)'}}{{documentation-file=deprecated-declaration}} expected-note {{use 'init(new:)' instead}} {{24-27=new}}
+_ = DeprecatedInitSub2.init(old: 0) // expected-warning {{'init(old:)' is deprecated: renamed to 'init(new:)'}}{{documentation-file=deprecated-declaration}} expected-note {{use 'init(new:)' instead}} {{29-32=new}}
+let _: DeprecatedInitSub2 = .init(old: 0) // expected-warning {{'init(old:)' is deprecated: renamed to 'init(new:)'}}{{documentation-file=deprecated-declaration}} expected-note {{use 'init(new:)' instead}} {{35-38=new}}
 
-_ = DeprecatedInitBase(multipleEqualAvailabilityAttributes: 0) // expected-warning {{'init(multipleEqualAvailabilityAttributes:)' is deprecated: replaced by 'init(new:)'}}{{documentation-file=deprecated-declaration}} expected-note {{use 'init(new:)' instead}} {{24-59=new}}
-_ = DeprecatedInitBase.init(multipleEqualAvailabilityAttributes: 0) // expected-warning {{'init(multipleEqualAvailabilityAttributes:)' is deprecated: replaced by 'init(new:)'}}{{documentation-file=deprecated-declaration}} expected-note {{use 'init(new:)' instead}} {{29-64=new}}
-let _: DeprecatedInitBase = .init(multipleEqualAvailabilityAttributes: 0) // expected-warning {{'init(multipleEqualAvailabilityAttributes:)' is deprecated: replaced by 'init(new:)'}}{{documentation-file=deprecated-declaration}} expected-note {{use 'init(new:)' instead}} {{35-70=new}}
-_ = DeprecatedInitSub2(multipleEqualAvailabilityAttributes: 0) // expected-warning {{'init(multipleEqualAvailabilityAttributes:)' is deprecated: replaced by 'init(new:)'}}{{documentation-file=deprecated-declaration}} expected-note {{use 'init(new:)' instead}} {{24-59=new}}
-_ = DeprecatedInitSub2.init(multipleEqualAvailabilityAttributes: 0) // expected-warning {{'init(multipleEqualAvailabilityAttributes:)' is deprecated: replaced by 'init(new:)'}}{{documentation-file=deprecated-declaration}} expected-note {{use 'init(new:)' instead}} {{29-64=new}}
-let _: DeprecatedInitSub2 = .init(multipleEqualAvailabilityAttributes: 0) // expected-warning {{'init(multipleEqualAvailabilityAttributes:)' is deprecated: replaced by 'init(new:)'}}{{documentation-file=deprecated-declaration}} expected-note {{use 'init(new:)' instead}} {{35-70=new}}
+_ = DeprecatedInitBase(multipleEqualAvailabilityAttributes: 0) // expected-warning {{'init(multipleEqualAvailabilityAttributes:)' is deprecated: renamed to 'init(new:)'}}{{documentation-file=deprecated-declaration}} expected-note {{use 'init(new:)' instead}} {{24-59=new}}
+_ = DeprecatedInitBase.init(multipleEqualAvailabilityAttributes: 0) // expected-warning {{'init(multipleEqualAvailabilityAttributes:)' is deprecated: renamed to 'init(new:)'}}{{documentation-file=deprecated-declaration}} expected-note {{use 'init(new:)' instead}} {{29-64=new}}
+let _: DeprecatedInitBase = .init(multipleEqualAvailabilityAttributes: 0) // expected-warning {{'init(multipleEqualAvailabilityAttributes:)' is deprecated: renamed to 'init(new:)'}}{{documentation-file=deprecated-declaration}} expected-note {{use 'init(new:)' instead}} {{35-70=new}}
+_ = DeprecatedInitSub2(multipleEqualAvailabilityAttributes: 0) // expected-warning {{'init(multipleEqualAvailabilityAttributes:)' is deprecated: renamed to 'init(new:)'}}{{documentation-file=deprecated-declaration}} expected-note {{use 'init(new:)' instead}} {{24-59=new}}
+_ = DeprecatedInitSub2.init(multipleEqualAvailabilityAttributes: 0) // expected-warning {{'init(multipleEqualAvailabilityAttributes:)' is deprecated: renamed to 'init(new:)'}}{{documentation-file=deprecated-declaration}} expected-note {{use 'init(new:)' instead}} {{29-64=new}}
+let _: DeprecatedInitSub2 = .init(multipleEqualAvailabilityAttributes: 0) // expected-warning {{'init(multipleEqualAvailabilityAttributes:)' is deprecated: renamed to 'init(new:)'}}{{documentation-file=deprecated-declaration}} expected-note {{use 'init(new:)' instead}} {{35-70=new}}
 
-_ = DeprecatedInitBase(multipleUnequalAvailabilityAttributes: 0) // expected-warning {{'init(multipleUnequalAvailabilityAttributes:)' is deprecated: replaced by 'init(new:)'}}{{documentation-file=deprecated-declaration}} expected-note {{use 'init(new:)' instead}} {{24-61=new}}
-_ = DeprecatedInitBase.init(multipleUnequalAvailabilityAttributes: 0) // expected-warning {{'init(multipleUnequalAvailabilityAttributes:)' is deprecated: replaced by 'init(new:)'}}{{documentation-file=deprecated-declaration}} expected-note {{use 'init(new:)' instead}} {{29-66=new}}
-let _: DeprecatedInitBase = .init(multipleUnequalAvailabilityAttributes: 0) // expected-warning {{'init(multipleUnequalAvailabilityAttributes:)' is deprecated: replaced by 'init(new:)'}}{{documentation-file=deprecated-declaration}} expected-note {{use 'init(new:)' instead}} {{35-72=new}}
-_ = DeprecatedInitSub2(multipleUnequalAvailabilityAttributes: 0) // expected-warning {{'init(multipleUnequalAvailabilityAttributes:)' is deprecated: replaced by 'init(new:)'}}{{documentation-file=deprecated-declaration}} expected-note {{use 'init(new:)' instead}} {{24-61=new}}
-_ = DeprecatedInitSub2.init(multipleUnequalAvailabilityAttributes: 0) // expected-warning {{'init(multipleUnequalAvailabilityAttributes:)' is deprecated: replaced by 'init(new:)'}}{{documentation-file=deprecated-declaration}} expected-note {{use 'init(new:)' instead}} {{29-66=new}}
-let _: DeprecatedInitSub2 = .init(multipleUnequalAvailabilityAttributes: 0) // expected-warning {{'init(multipleUnequalAvailabilityAttributes:)' is deprecated: replaced by 'init(new:)'}}{{documentation-file=deprecated-declaration}} expected-note {{use 'init(new:)' instead}} {{35-72=new}}
+_ = DeprecatedInitBase(multipleUnequalAvailabilityAttributes: 0) // expected-warning {{'init(multipleUnequalAvailabilityAttributes:)' is deprecated: renamed to 'init(new:)'}}{{documentation-file=deprecated-declaration}} expected-note {{use 'init(new:)' instead}} {{24-61=new}}
+_ = DeprecatedInitBase.init(multipleUnequalAvailabilityAttributes: 0) // expected-warning {{'init(multipleUnequalAvailabilityAttributes:)' is deprecated: renamed to 'init(new:)'}}{{documentation-file=deprecated-declaration}} expected-note {{use 'init(new:)' instead}} {{29-66=new}}
+let _: DeprecatedInitBase = .init(multipleUnequalAvailabilityAttributes: 0) // expected-warning {{'init(multipleUnequalAvailabilityAttributes:)' is deprecated: renamed to 'init(new:)'}}{{documentation-file=deprecated-declaration}} expected-note {{use 'init(new:)' instead}} {{35-72=new}}
+_ = DeprecatedInitSub2(multipleUnequalAvailabilityAttributes: 0) // expected-warning {{'init(multipleUnequalAvailabilityAttributes:)' is deprecated: renamed to 'init(new:)'}}{{documentation-file=deprecated-declaration}} expected-note {{use 'init(new:)' instead}} {{24-61=new}}
+_ = DeprecatedInitSub2.init(multipleUnequalAvailabilityAttributes: 0) // expected-warning {{'init(multipleUnequalAvailabilityAttributes:)' is deprecated: renamed to 'init(new:)'}}{{documentation-file=deprecated-declaration}} expected-note {{use 'init(new:)' instead}} {{29-66=new}}
+let _: DeprecatedInitSub2 = .init(multipleUnequalAvailabilityAttributes: 0) // expected-warning {{'init(multipleUnequalAvailabilityAttributes:)' is deprecated: renamed to 'init(new:)'}}{{documentation-file=deprecated-declaration}} expected-note {{use 'init(new:)' instead}} {{35-72=new}}
 
 
 class Base {
@@ -1223,7 +1238,7 @@ func log(message: String) { }
 func log(format: String, _ args: Any...) { fatalError() } // expected-note {{'log(format:_:)' has been explicitly marked unavailable here}}
 
 func testBadRename() {
-  _ = BadRename(from: 5, to: 17) // expected-warning{{'init(from:to:step:)' is deprecated: replaced by 'init(range:step:)'}}{{documentation-file=deprecated-declaration}}
+  _ = BadRename(from: 5, to: 17) // expected-warning{{'init(from:to:step:)' is deprecated: renamed to 'init(range:step:)'}}{{documentation-file=deprecated-declaration}}
   // expected-note@-1{{use 'init(range:step:)' instead}}
 
   // Regression test for https://github.com/apple/swift/issues/64694


### PR DESCRIPTION
This change adds support for raw identifiers when renaming APIs in Swift. This includes APIs defined in Swift (using the `@availability(..., renamed: ...)` attribute), as well as C/Objective-C (using either the `swift_name` attribute or APINotes). All of these take decl names as strings, and so the parsing for these requires that any decl name components (the base name or the argument labels) must have surrounding backticks in order to be treated correctly as a raw identifier.

Getting this working required some refactoring of `ParsedDeclName` since it previously assumed that it could just split around delimiters like `.`, `(`, and `:`. That's no longer guaranteed to work, so I've introduced backtick-aware split helpers to deal with this. Likewise, `ParsedDeclName` now keeps track of special decl base names (like `init` and `subscript`) to ensure that they're handled properly and not incorrectly escaped under the new logic.

This pairs with https://github.com/swiftlang/llvm-project/pull/12995 for the `swift_name` attribute and APINotes support.