### PR TITLE
[6.4] [Sema] Fix missing async sequence `for` loop throwing diagnostic

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5654,6 +5654,9 @@ NOTE(because_rethrows_default_argument_throws,none,
 NOTE(because_rethrows_conformance_throws,none,
      "call is to 'rethrows' function, but a conformance has a throwing witness", ())
 
+ERROR(for_throw_without_try,none,
+      "for-in loop can throw, but is not marked with 'try'", ())
+
 ERROR(throwing_call_in_nonthrowing_autoclosure,none,
       "%0 can throw, but it is executed in a non-throwing "
       "autoclosure",(StringRef))

--- a/lib/Sema/TypeCheckEffects.cpp
+++ b/lib/Sema/TypeCheckEffects.cpp
@@ -4651,11 +4651,16 @@ private:
       if (throwsKind != ConditionalEffectKind::None)
         Flags.set(ContextFlags::HasAnyThrowSite);
 
+      // TODO: We ought to have a custom throws reason for this and unify the
+      // diagnostic handling (https://github.com/swiftlang/swift/issues/89124).
+      auto tryLoc = S->getTryLoc();
       if (!CurContext.handlesThrows(throwsKind)) {
-        auto tryLoc = S->getTryLoc();
         CurContext.diagnoseUnhandledThrowSite(Ctx.Diags, S, tryLoc.isValid(),
                                               classification.getThrowReason());
         CurContext.diagnoseUnhandledTry(Ctx.Diags, tryLoc);
+      } else if (!tryLoc) {
+        Ctx.Diags.diagnose(S->getForLoc(), diag::for_throw_without_try)
+          .fixItInsertAfter(S->getForLoc(), " try");
       }
     }
 

--- a/test/Concurrency/async_sequence_syntax.swift
+++ b/test/Concurrency/async_sequence_syntax.swift
@@ -18,6 +18,19 @@ func missingThrows<T : AsyncSequence>(_ seq: T) async {
 }
 
 @available(SwiftStdlib 5.1, *)
+func missingTry<T : AsyncSequence>(_ seq: T) async throws {
+  for await _ in seq { }
+  // expected-error@-1 {{for-in loop can throw, but is not marked with 'try'}} {{6-6= try}}
+}
+
+@available(SwiftStdlib 5.1, *)
+func missingTryAndThrows<T : AsyncSequence>(_ seq: T) async {
+  // FIXME: Improve this diagnostic
+  for await _ in seq { }
+  // expected-error@-1 {{call can throw, but it is not marked with 'try' and the error is not handled}}
+}
+
+@available(SwiftStdlib 5.1, *)
 func executeAsync(_ work: () async -> Void) { }
 @available(SwiftStdlib 5.1, *)
 func execute(_ work: () -> Void) { }


### PR DESCRIPTION
*6.4 cherry-pick of https://github.com/swiftlang/swift/pull/89126*

- Explanation: Restores a missing diagnostic where a throwing async sequence in a `for` loop could allow omitting the `try` keyword
- Scope: Affects effects checking for async `for` loops 
- Issue: rdar://177062849
- Risk: Low, this is already rejected in 6.3, and the fix to restore the diagnostic is simple
- Testing: Added tests to test suite
- Reviewer: Konrad Malawski, Elsa Keirouz