### PR TITLE
[Concurrency] Update Actor, GlobalActor, and MainActor documentation to reference the Concurrency chapter

### DIFF
--- a/stdlib/public/Concurrency/Actor.swift
+++ b/stdlib/public/Concurrency/Actor.swift
@@ -32,8 +32,9 @@ public typealias AnyActor = AnyObject & Sendable
 
 /// Common protocol to which all actors conform.
 ///
-/// The `Actor` protocol generalizes over all `actor` types. Actor types
-/// implicitly conform to this protocol.
+/// The `Actor` protocol generalizes over all `actor` types.
+/// Define a new actor with the `actor` keyword.
+/// Only types declared with the `actor` keyword conform to the `Actor` protocol.
 ///
 /// ### Actors and SerialExecutors
 /// By default, actors execute tasks on a shared global concurrency thread pool.
@@ -46,6 +47,12 @@ public typealias AnyActor = AnyObject & Sendable
 ///
 /// - SeeAlso: ``SerialExecutor``
 /// - SeeAlso: ``TaskExecutor``
+///
+/// For information about the language-level concurrency model that `Actor` is part of,
+/// see [Concurrency][concurrency] in [The Swift Programming Language][tspl].
+///
+/// [concurrency]: https://docs.swift.org/swift-book/documentation/the-swift-programming-language/concurrency#Actors
+/// [tspl]: https://docs.swift.org/swift-book/documentation/the-swift-programming-language/
 @available(SwiftStdlib 5.1, *)
 public protocol Actor: AnyObject, Sendable {
 

--- a/stdlib/public/Concurrency/GlobalActor.swift
+++ b/stdlib/public/Concurrency/GlobalActor.swift
@@ -41,6 +41,12 @@ import Swift
 /// ``SerialExecutor`` protocol's documentation.
 ///
 /// - SeeAlso: ``SerialExecutor``
+///
+/// For information about the language-level concurrency model that `GlobalActor` is part of,
+/// see [Concurrency][concurrency] in [The Swift Programming Language][tspl].
+///
+/// [concurrency]: https://docs.swift.org/swift-book/documentation/the-swift-programming-language/concurrency#Global-Actors
+/// [tspl]: https://docs.swift.org/swift-book/documentation/the-swift-programming-language/
 @available(SwiftStdlib 5.1, *)
 public protocol GlobalActor {
   /// The type of the shared actor instance that will be used to provide

--- a/stdlib/public/Concurrency/MainActor.swift
+++ b/stdlib/public/Concurrency/MainActor.swift
@@ -36,8 +36,13 @@ import Swift
   }
 }
 #else
-/// A singleton actor whose executor is equivalent to the main
-/// dispatch queue.
+/// A global actor whose executor is equivalent to the main thread.
+///
+/// - Note: For additional information about the main actor,
+/// see [Concurrency][concurrency] in [The Swift Programming Language][tspl].
+///
+/// [concurrency]: https://docs.swift.org/swift-book/documentation/the-swift-programming-language/concurrency/#The-Main-Actor
+/// [tspl]: https://docs.swift.org/swift-book/documentation/the-swift-programming-language/
 @available(SwiftStdlib 5.1, *)
 @globalActor public final actor MainActor: GlobalActor {
   public static let shared = MainActor()


### PR DESCRIPTION
Update the Actor, GlobalActor, and MainActor documentation to reference the Concurrency chapter in TSPL, along with other minor wording changes.