### PR TITLE
Lifetimes: Add a regression test for partial apply result types

### DIFF
--- a/test/SILOptimizer/lifetime_dependence/rdar177002500.swift
+++ b/test/SILOptimizer/lifetime_dependence/rdar177002500.swift
@@ -1,0 +1,17 @@
+// RUN: %target-swift-frontend -emit-sil -O -enable-experimental-feature Lifetimes %s
+
+// REQUIRES: swift_feature_Lifetimes
+
+// Minimal reproducer for SIL optimizer crash: rdar://177002500
+
+func foo(x: Int) {
+    bar { (_: consuming A<Void>) -> B in
+        _ = x
+        fatalError()
+    }
+}
+
+func bar<T>(_: @_lifetime(copy a) (_ a: consuming A<T>) -> B) {}
+
+struct A<T>: ~Escapable {}
+struct B: ~Escapable {}


### PR DESCRIPTION
Add a minimal reproducer for the crash caused by the lifetimes of a partial_apply's result not matching what was expected.

This is a follow-up to #89053, which fixes the crash.
This reproducer is much more minimal than the one we used in that PR, making it a valuable addition to the regression test suite.

Fixes:  rdar://177002500
<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
