### PR TITLE
[IRGen] Include addressableForDependencies in FixedLayoutKey.

### DIFF
--- a/lib/IRGen/GenValueWitness.cpp
+++ b/lib/IRGen/GenValueWitness.cpp
@@ -1622,7 +1622,11 @@ llvm::Constant *IRGenModule::emitFixedTypeLayout(CanType t,
 
   // Otherwise, see if a layout has been emitted with these characteristics
   // already.
-  FixedLayoutKey key{size, numExtraInhabitants, align, pod, unsigned(bt)};
+  bool addressableForDependencies =
+      getTypeProperties(silTy, TypeExpansionContext::minimal())
+          .isAddressableForDependencies();
+  FixedLayoutKey key{size, numExtraInhabitants, align,
+                     pod,  unsigned(bt),        addressableForDependencies};
 
   auto found = PrivateFixedLayouts.find(key);
   if (found != PrivateFixedLayouts.end())
@@ -1657,7 +1661,8 @@ llvm::Constant *IRGenModule::emitFixedTypeLayout(CanType t,
         "type_layout_" + llvm::Twine(size)
                        + "_" + llvm::Twine(align)
                        + "_" + llvm::Twine::utohexstr(numExtraInhabitants)
-                       + pod_bt_string(pod, bt),
+                       + pod_bt_string(pod, bt)
+                       + (addressableForDependencies ? "_afd" : ""),
         getPointerAlignment(),
         /*constant*/ true,
         llvm::GlobalValue::PrivateLinkage);

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -1454,6 +1454,7 @@ private:
     unsigned align: 16;
     unsigned pod: 1;
     unsigned bitwiseTakable: 2;
+    unsigned addressableForDependencies: 1;
   };
   friend struct ::llvm::DenseMapInfo<swift::irgen::IRGenModule::FixedLayoutKey>;
   llvm::DenseMap<FixedLayoutKey, llvm::Constant *> PrivateFixedLayouts;
@@ -2162,23 +2163,25 @@ struct DenseMapInfo<swift::irgen::IRGenModule::FixedLayoutKey> {
   using FixedLayoutKey = swift::irgen::IRGenModule::FixedLayoutKey;
 
   static inline FixedLayoutKey getEmptyKey() {
-    return {0, 0xFFFFFFFFu, 0, 0, 0};
+    return {0, 0xFFFFFFFFu, 0, 0, 0, 0};
   }
 
   static inline FixedLayoutKey getTombstoneKey() {
-    return {0, 0xFFFFFFFEu, 0, 0, 0};
+    return {0, 0xFFFFFFFEu, 0, 0, 0, 0};
   }
 
   static unsigned getHashValue(const FixedLayoutKey &key) {
     return hash_combine(key.size, key.numExtraInhabitants, key.align,
-                        (bool)key.pod, (bool)key.bitwiseTakable);
+                        (bool)key.pod, (bool)key.bitwiseTakable,
+                        (bool)key.addressableForDependencies);
   }
   static bool isEqual(const FixedLayoutKey &a, const FixedLayoutKey &b) {
     return a.size == b.size
       && a.numExtraInhabitants == b.numExtraInhabitants
       && a.align == b.align
       && a.pod == b.pod
-      && a.bitwiseTakable == b.bitwiseTakable;
+      && a.bitwiseTakable == b.bitwiseTakable
+      && a.addressableForDependencies == b.addressableForDependencies;
   }
 };
 

--- a/test/IRGen/type_layout_addressable_for_dependencies_dedup.swift
+++ b/test/IRGen/type_layout_addressable_for_dependencies_dedup.swift
@@ -1,0 +1,34 @@
+// RUN: %target-swift-frontend -enable-experimental-feature AddressableTypes -emit-ir %s | %FileCheck %s
+
+// REQUIRES: swift_feature_AddressableTypes
+
+// Two types with identical {size, EI, align, pod, bitwiseTakable} but
+// differing IsAddressableForDependencies must NOT share a single private
+// type_layout_* global. The Flags word inside the global encodes AFD, so
+// sharing causes the second-emitted type's runtime VWT to silently inherit
+// the first type's AFD bit (after the runtime-side patch that ORs each
+// field's TypeLayout AFD into the aggregate VWT during instantiation).
+
+@_addressableForDependencies
+struct AFD { var x: UInt16; var y: UInt16 }
+
+struct NotAFD { var x: UInt16; var y: UInt16 }
+
+struct G<T> {
+  var t: T
+  var afd: AFD
+  var notAFD: NotAFD
+}
+
+func use<T>(_ g: G<T>) {
+  _ = g
+}
+
+// AFD field: alignment mask 1 (align=2) + IsAddressableForDependencies
+// (0x02000000) = 0x02000001 = 33554433.
+//
+// CHECK-DAG: @type_layout_4_2_0_pod_afd = private constant {{.*}} {{i64|i32}} 4, {{i64|i32}} 4, i32 33554433, i32 0 }
+//
+// Non-AFD field: alignment mask 1 = 0x00000001 = 1.
+//
+// CHECK-DAG: @type_layout_4_2_0_pod = private constant {{.*}} {{i64|i32}} 4, {{i64|i32}} 4, i32 1, i32 0 }


### PR DESCRIPTION
This key is used for deduping data, so this is needed to avoid coalescing the info from two types that are have identical info except for this flag.

rdar://177075642