### PR TITLE
Distributed docs: Editorial pass on DistributedActorSystem article

### DIFF
--- a/stdlib/stdlib.docc/Distributed-collection.md
+++ b/stdlib/stdlib.docc/Distributed-collection.md
@@ -43,17 +43,13 @@ You use three main parts when writing code with distributed actors:
 
 ## Topics
 
-
-### Articles
-
-- <doc:implementing-a-custom-distributed-actor-system>
-
 ### Distributed Actors
 
 - ``Distributed/DistributedActor``
 - ``Distributed/DistributedActorSystem``
 - ``Distributed/Resolvable()``
 - ``Distributed/buildDefaultDistributedRemoteActorExecutor(_:)``
+- <doc:implementing-a-custom-distributed-actor-system>
 
 ### Remote Calls
 

--- a/stdlib/stdlib.docc/Distributed-collection.md
+++ b/stdlib/stdlib.docc/Distributed-collection.md
@@ -14,18 +14,18 @@ that runs across multiple computers.
 
 You use three main parts when writing code with distributed actors:
 
-- Swift language support for distributed actors, and building Distributed/RPC systems integrated into the language. 
+- Swift language support for distributed actors and for building distributed or RPC systems integrated into the language.
   For more information,
   see [Concurrency][concurrency] in [The Swift Programming Language][tspl].
 
 - The Distributed module, which includes the types and protocols you need
-  to declare and use distribute actors.
+  to declare and use distributed actors.
   For example, it has
   protocols to which distributed actors and distributed actor systems conform,
   and structures that encapsulate information about calls to a distributed actor.
 
-- A *distributed actor system*, also called a cluster runtime,
-  provides an implementation of the ``Distributed/DistributedActorSystem`` protocol
+- A *distributed actor system* provides an implementation of the
+  ``Distributed/DistributedActorSystem`` protocol
   and coordinates between the cluster's nodes.
   A distributed actor is always part of some distributed actor system;
   that distributed actor system handles the serialization and networking
@@ -39,7 +39,7 @@ You use three main parts when writing code with distributed actors:
 
 [concurrency]: https://docs.swift.org/swift-book/LanguageGuide/Concurrency.html
 [tspl]: https://docs.swift.org/swift-book/
-[runtime]: https://github.com/apple/swift-distributed-actors/
+[cluster]: https://github.com/apple/swift-distributed-actors/
 
 ## Topics
 

--- a/stdlib/stdlib.docc/Distributed-collection.md
+++ b/stdlib/stdlib.docc/Distributed-collection.md
@@ -46,18 +46,19 @@ You use three main parts when writing code with distributed actors:
 ### Distributed actors
 
 - ``Distributed/DistributedActor``
-- ``Distributed/DistributedActorSystem``
 - ``Distributed/Resolvable()``
 - ``Distributed/buildDefaultDistributedRemoteActorExecutor(_:)``
+
+### Distributed actor system
+
 - <doc:implementing-a-custom-distributed-actor-system>
-
-### Remote calls
-
+- ``Distributed/DistributedActorSystem``
 - ``Distributed/RemoteCallTarget``
 - ``Distributed/RemoteCallArgument``
 - ``Distributed/DistributedTargetInvocationEncoder``
 - ``Distributed/DistributedTargetInvocationDecoder``
 - ``Distributed/DistributedTargetInvocationResultHandler``
+
 
 ### Local testing
 

--- a/stdlib/stdlib.docc/Distributed-collection.md
+++ b/stdlib/stdlib.docc/Distributed-collection.md
@@ -43,7 +43,7 @@ You use three main parts when writing code with distributed actors:
 
 ## Topics
 
-### Distributed Actors
+### Distributed actors
 
 - ``Distributed/DistributedActor``
 - ``Distributed/DistributedActorSystem``
@@ -51,7 +51,7 @@ You use three main parts when writing code with distributed actors:
 - ``Distributed/buildDefaultDistributedRemoteActorExecutor(_:)``
 - <doc:implementing-a-custom-distributed-actor-system>
 
-### Remote Calls
+### Remote calls
 
 - ``Distributed/RemoteCallTarget``
 - ``Distributed/RemoteCallArgument``
@@ -59,7 +59,7 @@ You use three main parts when writing code with distributed actors:
 - ``Distributed/DistributedTargetInvocationDecoder``
 - ``Distributed/DistributedTargetInvocationResultHandler``
 
-### Local Testing
+### Local testing
 
 - ``Distributed/LocalTestingDistributedActorSystem``
 - ``Distributed/LocalTestingActorID``

--- a/stdlib/stdlib.docc/implementing-a-custom-distributed-actor-system.md
+++ b/stdlib/stdlib.docc/implementing-a-custom-distributed-actor-system.md
@@ -9,22 +9,13 @@ A ``Distributed/DistributedActor`` is always associated with a *distributed acto
 which determines how `distributed func` calls on a *remote* actor are executed.
 
 To declare a distributed actor, use the `distributed actor` keywords and choose
-the actor system it belongs to. The actor system effectively acts as a "transport" —
-for example, a network or interprocess channel — for your actor.
+the actor system it belongs to. The actor system provides the "transport" —
+such as a network or interprocess channel — to an actor, regardless of where that actor runs.
 
-Various actor system implementations exist in the Swift ecosystem,
-and this article provides a guide for you
-to implement your own to make remote procedure calls over a transport.
-
-You don't need in-depth knowledge of an actor system's implementation to use distributed
-actors — abstracting and hiding the transport details is the point. When you need a new
-transport, you can implement the ``Distributed/DistributedActorSystem`` protocol yourself
-and provide a new way for distributed actors to communicate.
-
-Code that *uses* distributed actors doesn't need to interact with this protocol
-directly. You implement a `DistributedActorSystem` when you're
-building a transport — for example, a cluster, a WebSocket client or server, or
-some other interprocess communication (IPC) system.
+Code that *uses* distributed actors doesn't need to interact with this protocol directly —
+that abstraction is the point. Implement a `DistributedActorSystem` when you're
+providing a new transport implementation, such as a cluster, a WebSocket client or server,
+or an interprocess communication (IPC) system.
 
 > Tip: In other words, ``Distributed/DistributedActorSystem`` provides the expected interface for your
 > own RPC frameworks that integrate with the Swift runtime and concurrency model.
@@ -41,7 +32,7 @@ These responsibilities map to specific methods on the `DistributedActorSystem` p
 - **Report** the results and errors.
 
 The rest of this article walks through each responsibility, providing examples
-that build to a minimal in-memory transport. For the deeper language
+that build to a minimal in-memory transport. For deeper coverage of the language
 and runtime semantics, see [SE-0336: Distributed Actor Isolation][SE-0336] and
 [SE-0344: Distributed Actor Runtime][SE-0344].
 
@@ -56,7 +47,7 @@ components reference it by identity.
 
 To implement a distributed actor system, declare a new type that conforms to the
 ``Distributed/DistributedActorSystem`` protocol. Then provide witnesses for the five
-required associated types, described in the sections that follow.
+required associated types, shown below and explored in the sections that follow.
 
 ```swift
 import Distributed
@@ -102,7 +93,7 @@ distributed actor Worker {
 let remoteWorker: Worker = ... // A worker located in a different process.
 let charlie: Worker = Worker(actorSystem: ...) // A worker located in this process.
 
-// Remote call forwarding a reference to a local worker, to a different process.
+// Remote call forwarding a reference to a local worker to a different process.
 try await remoteWorker.introduce(another: charlie)
 ```
 
@@ -117,7 +108,7 @@ identity later:
 extension SampleActorSystem {
     public func assignID<Act>(_ actorType: Act.Type) -> ActorID
       where Act: DistributedActor, Act.ID == ActorID {
-        // Produce a unique ID for a freshly-initializing actor.
+        // Produce a unique ID for a freshly initializing actor.
         SampleActorID(node: self.node, instance: UUID())
     }
 
@@ -151,14 +142,14 @@ into a distributed actor of a specific type you can call distributed methods on.
 runtime resolves actors transparently when you pass distributed actor references as
 parameters in distributed function calls, but you can also resolve them manually.
 
-When you call `try Worker.resolve(id:using:)`, the runtime calls into
-``Distributed/DistributedActorSystem/resolve(id:as:)`` of the actor system associated
-with the `Worker` type.
+When you call `try Worker.resolve(id:using:)`, the runtime calls the
+``Distributed/DistributedActorSystem/resolve(id:as:)`` method on the actor system
+associated with the `Worker` type.
 
 The user-facing `DistributedActor.resolve` function returns a local actor instance if
 the identifier refers to an actor in the same process, or a remote proxy object if the
-identifier points to a remote process. It can also throw an error if the identifier is
-expired, invalid, or otherwise illegal.
+identifier points to a remote process. It can also throw an error if the identifier has
+expired, is invalid, or is otherwise illegal.
 
 The actor system's `resolve` implementation should return one of:
 
@@ -190,7 +181,7 @@ The `resolve` function is synchronous; don't perform long blocking operations su
 communicating with a remote node to confirm the actor exists. Instead, return a reference
 (or `nil`) quickly. If the remote target doesn't exist, the caller's first remote call
 fails. This approach is preferable because the remote node could terminate between lookup
-and first call, so a pre-flight check provides no real safety guarantee.
+and first call, so a preflight check provides no real safety guarantee.
 
 You can use `resolve` to initiate a remote connection, but don't block and wait for the
 connection to fully establish before returning the reference.
@@ -228,7 +219,7 @@ public struct SampleInvocationEncoder: DistributedTargetInvocationEncoder {
     public mutating func recordArgument<Value: Codable>(
         _ argument: RemoteCallArgument<Value>
     ) throws {
-        // Naive implementation, just encode every parameter independently.
+        // Naive implementation — just encode every parameter independently.
         argumentData.append(try JSONEncoder().encode(argument.value))
     }
 
@@ -241,7 +232,7 @@ public struct SampleInvocationEncoder: DistributedTargetInvocationEncoder {
     }
 
     public mutating func doneRecording() throws {
-        // Finalize the envelope, for example, compute a checksum or sign the payload.
+        // Finalize the envelope — for example, compute a checksum or sign the payload.
     }
 }
 ```
@@ -289,8 +280,8 @@ extension SampleActorSystem {
             substitutions: invocation.genericSubstitutions
         )
 
-        // Here you can do any additional tasks, such as timeouts,
-        // task-local or distributed-trace propagation.
+        // Here you can do additional work, such as enforcing timeouts or
+        // propagating task-local values and distributed traces.
 
         return try await withCheckedThrowingContinuation { cc in
             // Your networking code here:
@@ -307,7 +298,7 @@ extension SampleActorSystem {
         }
     }
 
-    // Invoked when the called 'distributed func' returns 'Void'.
+    // Invoked when the target 'distributed func' returns 'Void'.
     public func remoteCallVoid<Act, Err>(
         on actor: Act,
         target: RemoteCallTarget,
@@ -322,8 +313,8 @@ extension SampleActorSystem {
             substitutions: invocation.genericSubstitutions
         )
 
-        // Here you can do any additional tasks, such as timeouts,
-        // task-local or distributed-trace propagation.
+        // Here you can do additional work, such as enforcing timeouts or
+        // propagating task-local values and distributed traces.
 
         return try await withCheckedThrowingContinuation { cc in
             // Your networking code here:
@@ -348,7 +339,7 @@ protocol lets developers distinguish transport-level failures from errors that a
 distributed method throws itself, and the protocol documentation requires this
 conformance for failures outside the caller's control.
 
-> Tip: Typed throws aren't supported in distributed function calls.
+> Note: Typed throws aren't supported in distributed function calls.
 
 ```swift
 public enum SampleTransportError: DistributedActorSystemError {
@@ -370,7 +361,7 @@ Prepare a few simple types to make the call on the local distributed actor:
   method on your managed actors.
 - Prepare an instance of your `DistributedTargetInvocationDecoder` type. Swift calls it
   when decoding the call's parameters.
-- Prepare a callback wrapper `ResultHandler` that the runtime invokes when the call
+- Prepare a callback wrapper `ResultHandler` that the runtime calls when the call
   completes.
   - The runtime calls this handler with the appropriate generic type.
 
@@ -381,7 +372,7 @@ extension SampleActorSystem {
             // Resolve the local target actor for which the invocation was intended.
             let actor: any DistributedActor = try self.myResolveLocal(id: envelope.actorID)
 
-            // Prepare a decoder from the network format into a Decoder the Swift runtime will invoke.
+            // Prepare a decoder over the network format that the Swift runtime calls.
             var decoder = SampleInvocationDecoder(envelope: envelope)
 
             // Prepare a handler that the runtime calls when the remote call completes.
@@ -408,7 +399,7 @@ The Swift distributed runtime calls the decoder with the appropriate generic typ
 each argument. A `distributed` method with `String` and `Int` parameters causes the
 runtime to invoke `decodeNextArgument` twice — once with `Argument` bound to `String`,
 and once with `Argument` bound to `Int`. This lets the implementation rely on `Codable`
-for decoding without any unsafe casting or guessing types.
+for decoding without unsafe casting or type guessing.
 You can also use any other serialization scheme here, as long as it matches how the
 values were originally encoded on the sending side.
 
@@ -481,9 +472,8 @@ public struct SampleResultHandler: DistributedTargetInvocationResultHandler {
 
 ### Use the actor system
 
-The actor system hides serialization and networking details so the use-site code can
-focus on its business domain. Define the typealias `ActorSystem` of a distributed actor
-to assign the system it uses.
+The actor system abstracts the serialization and networking details so the use-site code can
+focus on its business domain. Specify the `ActorSystem` typealias inside a distributed actor.
 
 ```swift
 distributed actor Greeter {

--- a/stdlib/stdlib.docc/implementing-a-custom-distributed-actor-system.md
+++ b/stdlib/stdlib.docc/implementing-a-custom-distributed-actor-system.md
@@ -5,49 +5,50 @@ for distributed actors.
 
 ## Overview
 
-A ``Distributed/DistributedActor`` is always associated with a *distributed actor system*
+A ``Distributed/DistributedActor`` is always associated with a *distributed actor system*,
 which determines how `distributed func` calls on a *remote* actor are executed.
 
 To declare a distributed actor, use the `distributed actor` keywords and choose
 the actor system it belongs to. The actor system effectively acts as a "transport" —
 for example, a network or interprocess channel — for your actor.
 
-Various actor system implementations exist in the Swift ecosystem, but you can also
-implement your own if you need to make remote procedure calls over a transport that
-no existing library supports.
+Various actor system implementations exist in the Swift ecosystem,
+and this article provides a guide for you
+to implement your own to make remote procedure calls over a transport.
 
 You don't need in-depth knowledge of an actor system's implementation to use distributed
 actors — abstracting and hiding the transport details is the point. When you need a new
 transport, you can implement the ``Distributed/DistributedActorSystem`` protocol yourself
 and provide a new way for distributed actors to communicate.
 
-Most code that *uses* distributed actors never interacts with this protocol
-directly. You only need to implement a `DistributedActorSystem` when you're
+Code that *uses* distributed actors doesn't need to interact with this protocol
+directly. You implement a `DistributedActorSystem` when you're
 building a transport — for example, a cluster, a WebSocket client or server, or
 some other interprocess communication (IPC) system.
 
-> TIP: In other words, ``Distributed/DistributedActorSystem`` lets you write your
-> own RPC frameworks that integrate deeply with the Swift runtime and concurrency model.
+> Tip: In other words, ``Distributed/DistributedActorSystem`` provides the expected interface for your
+> own RPC frameworks that integrate with the Swift runtime and concurrency model.
 
 An actor system manages the lifecycle and remote interactions of distributed actors.
 These responsibilities map to specific methods on the `DistributedActorSystem` protocol:
 
+- **Define** the actor system and its associated types.
 - **Assign**, track, and release actor identities.
 - **Resolve** an actor identity to either a local instance or a remote reference.
-- **Call** a remote distributed actor.
+- **Call** a remote method on a distributed actor.
 - **Encode** an outgoing invocation, send it to the remote peer, and await a reply.
-- **Decode** an incoming invocation, dispatch it to the target actor, and send
-  the result back.
+- **Decode** an incoming invocation and dispatch it to the target actor.
+- **Report** the results and errors.
 
-The rest of this article walks through each responsibility and ends with a
-minimal in-memory transport. For the deeper language
+The rest of this article walks through each responsibility, providing examples
+that build to a minimal in-memory transport. For the deeper language
 and runtime semantics, see [SE-0336: Distributed Actor Isolation][SE-0336] and
 [SE-0344: Distributed Actor Runtime][SE-0344].
 
 [SE-0336]: https://github.com/apple/swift-evolution/blob/main/proposals/0336-distributed-actor-isolation.md
 [SE-0344]: https://github.com/apple/swift-evolution/blob/main/proposals/0344-distributed-actor-runtime.md
 
-### The distributed actor system and associated types
+### Define the actor system and associated types
 
 A `DistributedActorSystem` is typically a final class — or a struct that wraps a class —
 because it holds internal state such as the mapping from identifiers to actors, and other
@@ -71,7 +72,7 @@ public final class SampleActorSystem: DistributedActorSystem {
 }
 ```
 
-### Manage actor identity
+### Assign, track, and release actor identities
 
 An `ActorID` identifies a distributed actor from the moment it's created. The actor system
 serializes and sends this identifier to remote peers during network calls.
@@ -105,7 +106,8 @@ let charlie: Worker = Worker(actorSystem: ...) // A worker located in this proce
 try await remoteWorker.introduce(another: charlie)
 ```
 
-Three methods drive the lifecycle of every distributed actor that your system manages.
+Three methods drive the lifecycle (`assignID`, `actorReady`, and `resignID`)
+of every distributed actor that your system manages.
 
 The Swift runtime calls these methods whenever a local distributed actor is initialized
 or deinitialized. Implement these methods so the actor system can find actors by their
@@ -126,7 +128,7 @@ extension SampleActorSystem {
     }
 
     public func resignID(_ id: ActorID) {
-        // Called when the actor is deinitialized or failed to initialize.
+        // Called when the actor is deinitialized or fails to initialize.
         activeActors.withLock { $0.removeValue(forKey: id) }
     }
 }
@@ -193,7 +195,7 @@ and first call, so a pre-flight check provides no real safety guarantee.
 You can use `resolve` to initiate a remote connection, but don't block and wait for the
 connection to fully establish before returning the reference.
 
-### Encode a remote invocation
+### Encode an outgoing invocation
 
 When you call a `distributed func` on a remote actor reference, the Swift runtime
 creates a new `InvocationEncoder` by calling the system's
@@ -249,7 +251,7 @@ in the `record...` methods — whichever fits your serialization mechanism best.
 If a later step needs the encoded arguments — for example, to compute a length prefix —
 produce them in `doneRecording`.
 
-### Perform a remote call
+### Call a remote method
 
 After encoding the invocation, the runtime passes it to
 ``Distributed/DistributedActorSystem/remoteCall(on:target:invocation:throwing:returning:)``
@@ -355,8 +357,9 @@ public enum SampleTransportError: DistributedActorSystemError {
 }
 ```
 
-### Receive and execute a remote invocation
+### Decode and execute a remote invocation
 
+Assemble a `receive` flow that dispatches incoming invocations to local actors.
 On the receiving "remote" side of a call, decode the envelope into a matching
 ``Distributed/DistributedTargetInvocationDecoder``, locate the local actor, and hand both
 to the runtime's ``Distributed/DistributedActorSystem/executeDistributedTarget(on:target:invocationDecoder:handler:)`` method.
@@ -402,7 +405,7 @@ extension SampleActorSystem {
 ```
 
 The Swift distributed runtime calls the decoder with the appropriate generic type for
-each argument. A `distributed` method with a `String` and an `Int` parameter causes the
+each argument. A `distributed` method with `String` and `Int` parameters causes the
 runtime to invoke `decodeNextArgument` twice — once with `Argument` bound to `String`,
 and once with `Argument` bound to `Int`. This lets the implementation rely on `Codable`
 for decoding without any unsafe casting or guessing types.
@@ -440,7 +443,8 @@ the recipient.
 
 ### Report results and errors
 
-The final step of a remote call chain is the ``Distributed/DistributedTargetInvocationResultHandler``.
+The final step of a remote call chain is the ``Distributed/DistributedTargetInvocationResultHandler``
+that you use to return results and errors.
 
 This works similarly to the encoder and decoder, and gives you a type-safe way to obtain
 the result with its correct `Success` type, as declared by the distributed method.
@@ -475,13 +479,11 @@ public struct SampleResultHandler: DistributedTargetInvocationResultHandler {
 }
 ```
 
-### Putting it all together
-
-Once everything's wired together, you can make your first remote call using your new
-actor system.
+### Use the actor system
 
 The actor system hides serialization and networking details so the use-site code can
-focus on its business domain:
+focus on its business domain. Define the typealias `ActorSystem` of a distributed actor
+to assign the system it uses.
 
 ```swift
 distributed actor Greeter {
@@ -493,28 +495,20 @@ distributed actor Greeter {
 }
 ```
 
+Initialize the system and distributed actor, use `resolve` to get a reference, and
+make asynchronous calls that you defined on the distributed actor:
+
 ```swift
 let system = SampleActorSystem(localNode: "node-a")
 let local = Greeter(actorSystem: system)
 
-// In a real deployment, resolving an ID owned by a remote node returns a remote
-// reference. Here, both sides share one in-process system, so this returns the
-// local instance.
+// In a remote deployment, resolving an ID owned by a remote node returns a remote
+// reference. Here, both sides share one in-process system, so this example returns
+// a local instance.
 let remote = try Greeter.resolve(id: local.id, using: system)
 let reply = try await remote.hello(name: "world")
 print(reply) // "Hello, world!"
 ```
-
-You've now built the parts of a custom distributed actor system:
-
-- An `ActorID` type and lifecycle methods (`assignID`, `actorReady`, `resignID`) that
-  manage actor identity.
-- A `resolve` implementation that distinguishes local actors from remote references.
-- A `DistributedTargetInvocationEncoder` and matching `remoteCall` and `remoteCallVoid`
-  methods for sending invocations.
-- A `DistributedTargetInvocationDecoder` and `receive` flow that dispatches incoming
-  invocations to local actors.
-- A `DistributedTargetInvocationResultHandler` for returning results and errors.
 
 For more information, see ``Distributed/DistributedActorSystem`` and
 ``Distributed/LocalTestingDistributedActorSystem``.

--- a/stdlib/stdlib.docc/implementing-a-custom-distributed-actor-system.md
+++ b/stdlib/stdlib.docc/implementing-a-custom-distributed-actor-system.md
@@ -29,7 +29,7 @@ These responsibilities map to specific methods on the `DistributedActorSystem` p
 - **Call** a remote method on a distributed actor.
 - **Encode** an outgoing invocation, send it to the remote peer, and await a reply.
 - **Decode** an incoming invocation and dispatch it to the target actor.
-- **Report** the results and errors.
+- **Reply** with the results and errors.
 
 The rest of this article walks through each responsibility, providing examples
 that build to a minimal in-memory transport. For deeper coverage of the language
@@ -432,7 +432,7 @@ the recipient.
 > Tip: If you support generic distributed calls, don't trust incoming types. Validate
 > them against a known allow-list before decoding.
 
-### Report results and errors
+### Reply with the results and errors
 
 The final step of a remote call chain is the ``Distributed/DistributedTargetInvocationResultHandler``
 that you use to return results and errors.

--- a/stdlib/stdlib.docc/implementing-a-custom-distributed-actor-system.md
+++ b/stdlib/stdlib.docc/implementing-a-custom-distributed-actor-system.md
@@ -1,42 +1,40 @@
 # Implementing a Custom Distributed Actor System
 
-Implement a `DistributedActorSystem` to provide a custom transport layer 
+Implement a `DistributedActorSystem` to provide a custom transport layer
 for distributed actors.
 
 ## Overview
 
-A ``Distributed/DistributedActor`` is always associated with a *distributed actor system* 
-which determines how `distributed func` calls on a _remote_ actor are executed.
+A ``Distributed/DistributedActor`` is always associated with a *distributed actor system*
+which determines how `distributed func` calls on a *remote* actor are executed.
 
-To declare a distributed actor you can use the `distributed actor` pair of keywords,
-and you will have to determine what actor system it is associated with. This effectively
-means choosing a "transport", such as a network or inter-process transport, for your actor.
+To declare a distributed actor, use the `distributed actor` keywords and choose
+the actor system it belongs to. The actor system effectively acts as a "transport" —
+for example, a network or interprocess channel — for your actor.
 
-Various actor system implementations exist in the Swift ecosystem, but you are also able
-to implement your own, in case you'd like to make remote procedure calls over some transport
-mechanism that doesn't have an implementation available yet.
+Various actor system implementations exist in the Swift ecosystem, but you can also
+implement your own if you need to make remote procedure calls over a transport that
+no existing library supports.
 
-You do not need in-depth knowledge about an actor system's implementation to
-just use distributed actors -- that is their point, to abstract and hide away the transport details --
-you can implement the ``Distributed/DistributedActorSystem`` protocol yourself and provide
-a new way for distributed actors to communicate.
+You don't need in-depth knowledge of an actor system's implementation to use distributed
+actors — abstracting and hiding the transport details is the point. When you need a new
+transport, you can implement the ``Distributed/DistributedActorSystem`` protocol yourself
+and provide a new way for distributed actors to communicate.
 
 Most code that *uses* distributed actors never interacts with this protocol
-directly. You only need to implement a `DistributedActorSystem` when you are
-building a transport - for example, a cluster, a WebSocket client/server, or
-some other inter-process communication (IPC) system. 
+directly. You only need to implement a `DistributedActorSystem` when you're
+building a transport — for example, a cluster, a WebSocket client or server, or
+some other interprocess communication (IPC) system.
 
-> TIP: In other words, ``Distributed/DistributedActorSystem``
-> is a way to write your own RPC frameworks, that are deeply 
-> integrated in the Swift runtime and concurrency model.
+> TIP: In other words, ``Distributed/DistributedActorSystem`` lets you write your
+> own RPC frameworks that integrate deeply with the Swift runtime and concurrency model.
 
-An actor system is responsible for lifecycle management and remote interactions of distributed actors.
-These responsibilities roughly fall into one of the following categories, which have their corresponding 
-methods on the `DistributedActorSystem` protocol:
+An actor system manages the lifecycle and remote interactions of distributed actors.
+These responsibilities map to specific methods on the `DistributedActorSystem` protocol:
 
 - **Assign**, track, and release actor identities.
 - **Resolve** an actor identity to either a local instance or a remote reference.
-- Perform a **remote call** on a remote distributed actor. 
+- **Call** a remote distributed actor.
 - **Encode** an outgoing invocation, send it to the remote peer, and await a reply.
 - **Decode** an incoming invocation, dispatch it to the target actor, and send
   the result back.
@@ -49,14 +47,15 @@ and runtime semantics, see [SE-0336: Distributed Actor Isolation][SE-0336] and
 [SE-0336]: https://github.com/apple/swift-evolution/blob/main/proposals/0336-distributed-actor-isolation.md
 [SE-0344]: https://github.com/apple/swift-evolution/blob/main/proposals/0344-distributed-actor-runtime.md
 
-### The Distributed Actor System and Associated Types
+### The distributed actor system and associated types
 
-A `DistributedActorSystem` is usually a final class (or struct, wrapping a class), 
-because it is an inherently stateful object referenced by identity and retains internal
-state such as identifier-to-actor mappings. 
+A `DistributedActorSystem` is typically a final class — or a struct that wraps a class —
+because it holds internal state such as the mapping from identifiers to actors, and other
+components reference it by identity.
 
-To implement a distributed actor system declare a new type and conform it to the ``Distributed/DistributedActorSystem`` protocol.
-Then, provide witnesses for the five required associated types, which we will discuss one by one next. 
+To implement a distributed actor system, declare a new type that conforms to the
+``Distributed/DistributedActorSystem`` protocol. Then provide witnesses for the five
+required associated types, described in the sections that follow.
 
 ```swift
 import Distributed
@@ -68,16 +67,17 @@ public final class SampleActorSystem: DistributedActorSystem {
     public typealias InvocationDecoder = SampleInvocationDecoder
     public typealias ResultHandler = SampleResultHandler
 
-    // Internal state filled in below
+    // Internal state filled in below.
 }
 ```
 
-### Manage Actor Identity
+### Manage actor identity
 
-The `ActorID` serves as an identifier that a distributed actor is assigned at creation time,
-and is going to be serialized and sent to other remote peers when making network calls involving distributed actors.
-This identifier is what enables sending "references" to an actor to other nodes or processes, as the recipient will then
-``Distributed/DistributedActor/resolve(id:using:)`` the identifier to obtain as _remote reference_ to the actor.
+An `ActorID` identifies a distributed actor from the moment it's created. The actor system
+serializes and sends this identifier to remote peers during network calls.
+This identifier lets you send "references" to an actor to other nodes or processes; the
+recipient calls ``Distributed/DistributedActor/resolve(id:using:)`` on the identifier to
+obtain a *remote reference* to the actor.
 
 ```swift
 public struct SampleActorID: Hashable, Sendable, Codable {
@@ -86,93 +86,91 @@ public struct SampleActorID: Hashable, Sendable, Codable {
 }
 ```
 
-By making the `SampleActorID` conform to `Codable`, we have made it compatible with the actor system's
+Conforming `SampleActorID` to `Codable` makes it compatible with the actor system's
 `SerializationRequirement`.
 
-Because ``Distributed/DistributedActor`` is ``Codable`` whenever its `ID` is,
-choosing a `Codable` `ActorID` is what makes distributed actors serializable
-as arguments to other distributed calls, in other words, we will be able to make remote calls like this:
+Because ``Distributed/DistributedActor`` is `Codable` whenever its `ID` is, choosing a
+`Codable` `ActorID` makes distributed actors serializable as arguments to other distributed
+calls. For example, you can make a remote call like this:
 
 ```swift
-distributed actor Worker { 
+distributed actor Worker {
   distributed func introduce(another: Worker) { ... }
 }
 
-let remoteWorker: Worker = ... // worker located in different process
-let charlie: Worker = Worker(actorSystem: ...) // worker located in this process
+let remoteWorker: Worker = ... // A worker located in a different process.
+let charlie: Worker = Worker(actorSystem: ...) // A worker located in this process.
 
-// Remote call forwarding a reference to a local worker, to a different process
+// Remote call forwarding a reference to a local worker, to a different process.
 try await remoteWorker.introduce(another: charlie)
 ```
 
-Three methods drive the lifecycle of every distributed actor that your system
-manages. 
+Three methods drive the lifecycle of every distributed actor that your system manages.
 
-The Swift runtime will call these methods whenever a local distributed actor is initialized (or deinitialized).
-We need to implement these methods in a way that will enable the actor system to find those actors by their identity
-in the future:
+The Swift runtime calls these methods whenever a local distributed actor is initialized
+or deinitialized. Implement these methods so the actor system can find actors by their
+identity later:
 
 ```swift
 extension SampleActorSystem {
     public func assignID<Act>(_ actorType: Act.Type) -> ActorID
       where Act: DistributedActor, Act.ID == ActorID {
-        // Produce a unique id for a freshly-initializing actor
+        // Produce a unique ID for a freshly-initializing actor.
         SampleActorID(node: self.node, instance: UUID())
     }
 
     public func actorReady<Act>(_ actor: Act)
       where Act: DistributedActor, Act.ID == ActorID {
-        // Store a weak reference so the system does not keep the actor alive
+        // Store a weak reference so the system does not keep the actor alive.
         activeActors.withLock { $0[actor.id] = WeakActorRef(actor) }
     }
 
     public func resignID(_ id: ActorID) {
-        // Called when the actor is deinitialized or failed to initialize
+        // Called when the actor is deinitialized or failed to initialize.
         activeActors.withLock { $0.removeValue(forKey: id) }
     }
 }
 ```
 
-Retain readied actors *weakly* so that they can be deinitialized when no
-remaining reference holds them. You may also choose to retain some actors 
-strongly, if they are going to be valid for the entire lifetime of this actor system,
-but weakly retaining actors is by far the more common practice. 
+Hold readied actors with weak references so they deinitialize when no other reference
+remains. You can also hold some actors strongly if they remain valid for the entire
+lifetime of the actor system, but weak retention is the common practice.
 
-The system is notified when a distributed actor is deinitialized through the
-``Distributed/DistributedActorSystem/resignID(_:)`` call, invoked from a distributed 
-actor's deinit automatically by the Swift runtime.
+The Swift runtime automatically calls ``Distributed/DistributedActorSystem/resignID(_:)``
+from a distributed actor's `deinit` to notify the system.
 
-Typical tasks to perform inside `resignID` are tearing down no-longer used connections and 
-freeing up resources associated with an actor, such as caches or timers.
+Inside `resignID`, typical work includes tearing down unused connections and freeing
+per-actor resources such as caches or timers.
 
-### Resolve Local and Remote Actors
+### Resolve local and remote actors
 
-Resolving actor identifiers, or resolving actors for short, is the primary way 
-to convert an `ActorID` into a distributed actor of some specific type, 
-that you can call distributed methods on. Often, this is done transparently
-as you pass distributed actor references as parameters in distributed function calls,
-but it is possible to perform this manually as well.
+Resolving actor identifiers — or *resolving actors* for short — converts an `ActorID`
+into a distributed actor of a specific type you can call distributed methods on. The
+runtime resolves actors transparently when you pass distributed actor references as
+parameters in distributed function calls, but you can also resolve them manually.
 
 When you call `try Worker.resolve(id:using:)`, the runtime calls into
-``Distributed/DistributedActorSystem/resolve(id:as:)`` of the actor system associated with the `Worker` type.
+``Distributed/DistributedActorSystem/resolve(id:as:)`` of the actor system associated
+with the `Worker` type.
 
-The user-facing `DistributedActor.resolve` function is defined to return either a local actor instance,
-if the identifier is of an actor in the same process, or it will return a remote proxy object
-if the identifier points at a remote process. It may also throw, if the identifier is in any way expired,
-invalid, or illegal in any way.
+The user-facing `DistributedActor.resolve` function returns a local actor instance if
+the identifier refers to an actor in the same process, or a remote proxy object if the
+identifier points to a remote process. It can also throw an error if the identifier is
+expired, invalid, or otherwise illegal.
 
-The actor system's resolve implementation however should return either: 
-- the local instance if the id identifies an actor that was created with, and is managed by, 
-  this actor system.
-- or `nil`, if the actor is not known to the system locally, 
-  and the Swift runtime should construct a remote _proxy object pointing at an actor identified by this id_ instead.
+The actor system's `resolve` implementation should return one of:
+
+- The local instance, if the `ID` identifies an actor that this actor system created
+  and manages.
+- `nil`, if the actor isn't known to the system locally. In this case, the Swift runtime
+  constructs a remote *proxy object pointing at an actor identified by this `ID`* instead.
 
 ```swift
 extension SampleActorSystem {
     public func resolve<Act>(id: ActorID, as actorType: Act.Type) throws -> Act?
     where Act: DistributedActor, Act.ID == ActorID {
         guard let anyActor = activeActors.withLock({ $0[id]?.actor }) else {
-            // Not local, but we have a connection to this node, form remote reference
+            // Not local; if you have a connection to this node, form a remote reference.
             guard knownNodes.contains(id.node) else {
                 throw SampleTransportError.unknownNode(id.node)
             }
@@ -186,31 +184,31 @@ extension SampleActorSystem {
 }
 ```
 
-The `resolve` function is synchronous and should not perform long blocking operations, 
-such as actually communicating with a remote node or process it that actor truly exists remotely. 
-Instead, it should quickly return a reference (or nil), and if the remote target happens to not exist
-the caller will be notified about this during their first remote call, which will fail. 
-This approach is better, because the remote node may terminate between the time of lookup an first 
-call, so we did not really gain any safety by doing these pre-flight checks.
+The `resolve` function is synchronous; don't perform long blocking operations such as
+communicating with a remote node to confirm the actor exists. Instead, return a reference
+(or `nil`) quickly. If the remote target doesn't exist, the caller's first remote call
+fails. This approach is preferable because the remote node could terminate between lookup
+and first call, so a pre-flight check provides no real safety guarantee.
 
-You may use the resolve to initiate a remote connection, however it is not recommended to block and
-wait for that connection to establish fully before returning the reference.
+You can use `resolve` to initiate a remote connection, but don't block and wait for the
+connection to fully establish before returning the reference.
 
-### Encode a Remote Invocation
+### Encode a remote invocation
 
-Whenever a `distributed func` is called on a remote actor reference, the Swift runtime
-will create a new `InvocationEncoder` by calling its system's 
-``DistributedActorSystem/makeInvocationEncoder()`` method, 
-and encode all the arguments of the method call into it.
+When you call a `distributed func` on a remote actor reference, the Swift runtime
+creates a new `InvocationEncoder` by calling the system's
+``Distributed/DistributedActorSystem/makeInvocationEncoder()`` method, then encodes the
+arguments of the method call into it.
 
-Then this invocation encoder is passed to the `remoteCall` which will perform the actual remote procedure call.
+The runtime then passes the invocation encoder to `remoteCall`, which performs the remote
+procedure call.
 
-This ``Distributed/DistributedTargetInvocationEncoder`` must implement five
-recording methods, which the runtime will then invoke in order to record a method 
-invocation into the actor system's specific serialization format.
+This ``Distributed/DistributedTargetInvocationEncoder`` must implement five recording
+methods that the runtime invokes to record a method invocation into the actor system's
+specific serialization format.
 
-This simple sample implementation uses mangled names and just JSON serialization per element,
-however you can perform all kinds of serialization here, including efficient binary encodings.
+This sample implementation serializes each argument independently with `JSONEncoder`.
+You can perform any kind of serialization here, including efficient binary encodings.
 
 ```swift
 public struct SampleInvocationEncoder: DistributedTargetInvocationEncoder {
@@ -222,55 +220,54 @@ public struct SampleInvocationEncoder: DistributedTargetInvocationEncoder {
     var errorType: String?
 
     public mutating func recordGenericSubstitution<T>(_ type: T.Type) throws {
-        // you may choose to throw here to ban generic distributed calls
+        // You may choose to throw here to ban generic distributed calls.
     }
 
     public mutating func recordArgument<Value: Codable>(
         _ argument: RemoteCallArgument<Value>
     ) throws {
-        // Naive implementation, just encode every parameter independently
+        // Naive implementation, just encode every parameter independently.
         argumentData.append(try JSONEncoder().encode(argument.value))
     }
 
     public mutating func recordReturnType<R: Codable>(_ type: R.Type) throws {
-        // not required to encode, however you can validate the return type here
+        // Encoding the return type isn't required, but you can validate it here.
     }
 
     public mutating func recordErrorType<E: Error>(_ type: E.Type) throws {
-        // not required to encode, however you can inspect the declared thrown type of the distributed func
+        // Encoding the error type isn't required, but you can inspect the declared thrown type of the distributed func.
     }
 
     public mutating func doneRecording() throws {
-        // Finalize the envelope, e.g. compute a checksum or sign the payload
+        // Finalize the envelope, for example, compute a checksum or sign the payload.
     }
 }
 ```
 
-You can delay any actual serialization work until the `doneRecording` call, 
-or you may eagerly serialize each parameter inside the `record...` calls, 
-whichever fits your serialization mechanism of choice better.
-If a subsequent step needs the encoded arguments (for example, a length
-prefix), compute it here.
+You can defer all serialization until `doneRecording`, or eagerly serialize each parameter
+in the `record...` methods — whichever fits your serialization mechanism best.
+If a later step needs the encoded arguments — for example, to compute a length prefix —
+produce them in `doneRecording`.
 
-### Perform a Remote Call
+### Perform a remote call
 
-Once all this is done, the invocation is encoded and will be passed to the 
+After encoding the invocation, the runtime passes it to
 ``Distributed/DistributedActorSystem/remoteCall(on:target:invocation:throwing:returning:)``
 (or the `Void` overload,
 ``Distributed/DistributedActorSystem/remoteCallVoid(on:target:invocation:throwing:)``).
 
-Here, the actor system should perform the remote message send, 
-and suspend the caller with a continuation until a reply arrives.
+In this method, the actor system sends the remote message and suspends the caller with
+a continuation until a reply arrives.
 
-The implementation of this method is inherently tied to the exact transport layer details
-of the underlying transport mechanism. For example, you may serialize the invocation
-into a websocket message, use some cross-process communication mechanism on the same device,
-or use something else entirely to make the remote invocation. The language feature and runtime
-have no opinion on how a remote call is to be implemented, and you are free to use your
-favorite networking libraries here, as long as when the call completes, the `remoteCall` returns.
+The implementation of this method depends entirely on your transport. For example, you
+can serialize the invocation into a WebSocket message, use an interprocess communication
+mechanism on the same device, or send it over any other channel. The language feature
+and runtime have no opinion on how you implement a remote call. You can use any networking
+library, as long as `remoteCall` returns once the remote call completes.
 
-Typically, an implementation would use invocation identifiers, or per invocation streams,
-and then associate a continuation with it. Resuming it when a reply arrives.
+A typical implementation associates each invocation with a continuation — keyed by an
+invocation identifier or per-invocation stream — and resumes the continuation when a
+reply arrives.
 
 ```swift
 extension SampleActorSystem {
@@ -289,26 +286,26 @@ extension SampleActorSystem {
             arguments: invocation.argumentData,
             substitutions: invocation.genericSubstitutions
         )
-      
-        // Here you can do any additional tasks, such as timeouts, 
+
+        // Here you can do any additional tasks, such as timeouts,
         // task-local or distributed-trace propagation.
-      
-        return try await withCheckedContinuation { cc in
-          // Your networking code here:
-          someNetworkingLibrary.lowLevelSend(envelope) { reply in
-            switch reply {
-              case .success(let response):
-                cc.resume(returning: response.getAs(Res.self))
-        
-              case .error(let error):
-                // e.g. network failures or timeouts
-                cc.resume(throwing: error)
+
+        return try await withCheckedThrowingContinuation { cc in
+            // Your networking code here:
+            someNetworkingLibrary.lowLevelSend(envelope) { reply in
+                switch reply {
+                case .success(let response):
+                    cc.resume(returning: response.getAs(Res.self))
+
+                case .error(let error):
+                    // For example, network failures or timeouts.
+                    cc.resume(throwing: error)
+                }
             }
-          }
         }
     }
 
-    // Invoked when the called 'distributed func' returns 'Void'
+    // Invoked when the called 'distributed func' returns 'Void'.
     public func remoteCallVoid<Act, Err>(
         on actor: Act,
         target: RemoteCallTarget,
@@ -323,70 +320,72 @@ extension SampleActorSystem {
             substitutions: invocation.genericSubstitutions
         )
 
-      // Here you can do any additional tasks, such as timeouts, 
-      // task-local or distributed-trace propagation.
+        // Here you can do any additional tasks, such as timeouts,
+        // task-local or distributed-trace propagation.
 
-      return try await withCheckedContinuation { cc in
-        // Your networking code here:
-        someNetworkingLibrary.lowLevelSend(envelope) { reply in
-          switch reply {
-          case .success:
-            cc.resume() 
+        return try await withCheckedThrowingContinuation { cc in
+            // Your networking code here:
+            someNetworkingLibrary.lowLevelSend(envelope) { reply in
+                switch reply {
+                case .success:
+                    cc.resume()
 
-          case .error(let error):
-            // e.g. network failures or timeouts
-            cc.resume(throwing: error)
-          }
+                case .error(let error):
+                    // For example, network failures or timeouts.
+                    cc.resume(throwing: error)
+                }
+            }
         }
-      }
     }
 }
 ```
 
-If your actor system injects failures, such as timeouts or network failures, 
-it is recommended to make them conform to the 
-``Distributed/DistributedActorSystemError`` protocol. This marker protocol lets users
-distinguish transport-level failures from errors a distributed method threw
-itself, and it is the conformance the protocol documentation asks you to adopt
-for "outside the user's control" failures.
+When your actor system surfaces transport failures such as timeouts or network errors,
+conform those error types to ``Distributed/DistributedActorSystemError``. This marker
+protocol lets developers distinguish transport-level failures from errors that a
+distributed method throws itself, and the protocol documentation requires this
+conformance for failures outside the caller's control.
 
-> Tip: Typed throws are currently not supported in distributed function calls.
+> Tip: Typed throws aren't supported in distributed function calls.
 
 ```swift
 public enum SampleTransportError: DistributedActorSystemError {
-  case processTerminated(node: String)
-  case versionMismatch(remote: String)
+    case processTerminated(node: String)
+    case versionMismatch(remote: String)
 }
 ```
 
-### Receive and Execute an RemoteInvocation
+### Receive and execute a remote invocation
 
-Next, on the receiving "remote" side of a call, decode the envelope into a matching
-``Distributed/DistributedTargetInvocationDecoder`` and hand it to the runtime's
-`executeDistributedTarget`. 
+On the receiving "remote" side of a call, decode the envelope into a matching
+``Distributed/DistributedTargetInvocationDecoder``, locate the local actor, and hand both
+to the runtime's ``Distributed/DistributedActorSystem/executeDistributedTarget(on:target:invocationDecoder:handler:)`` method.
 
-Finally, you need to prepare a few simple types to make the call on the local distributed actor:
+Prepare a few simple types to make the call on the local distributed actor:
 
-- Locate the **local actor** the distributed call was intended to; this is where you'd use a `resolve()` style method on your managed actors.
-- Prepare an instance of your `DistributedTargetInvocationDecoder` type, it will be called by Swift when decoding call parameters.
-- Prepare a simple callback wrapper `ResultHandler` which will be invoked when the distributed function call completes,
-  - this result handler will be called with the correct generic type
+- Locate the **local actor** the call targets; this is where you use a `resolve()`-style
+  method on your managed actors.
+- Prepare an instance of your `DistributedTargetInvocationDecoder` type. Swift calls it
+  when decoding the call's parameters.
+- Prepare a callback wrapper `ResultHandler` that the runtime invokes when the call
+  completes.
+  - The runtime calls this handler with the appropriate generic type.
 
 ```swift
 extension SampleActorSystem {
     func receive(_ envelope: SampleEnvelope) async {
         do {
-            // Resolve the local target actor for which the invocation was intended
-            let actor: any DistributedAtor = try self.myResolveLocal(id: envelope.actorID)
-          
-            // Prepare a decoder from the network format into a Decoder the Swift runtime will invoke
+            // Resolve the local target actor for which the invocation was intended.
+            let actor: any DistributedActor = try self.myResolveLocal(id: envelope.actorID)
+
+            // Prepare a decoder from the network format into a Decoder the Swift runtime will invoke.
             var decoder = SampleInvocationDecoder(envelope: envelope)
-          
-            // Prepare a handler which will be called when the remote call completes
+
+            // Prepare a handler that the runtime calls when the remote call completes.
             let handler = SampleResultHandler(replyTo: envelope.replyID)
 
             // Execute the 'distributed func' on the located target,
-            // identified by the target identifier, that we encoded during 'remoteCall' 
+            // identified by the target identifier encoded during 'remoteCall'.
             try await executeDistributedTarget(
                 on: actor,
                 target: RemoteCallTarget(envelope.target),
@@ -394,19 +393,21 @@ extension SampleActorSystem {
                 handler: handler
             )
         } catch {
-            // If able to, you may be able to send an error back, 
-            // or just terminate the connection due to the error - depends on your specific transport.
+            // Send an error back if your transport supports it,
+            // or terminate the connection. The choice depends on your transport.
             await envelope.errorChannel.fail(error)
         }
     }
 }
 ```
 
-The decoder is going to be called by the Swift distributed runtime with the appropriate generic type arguments
-for every argument. A `distributed` method with a `String` and `Int` parameter will cause the runtime
-to invoke the `decodeNextArgument` twice, once with the `Argument` type bound to `String`, and once to `Int`.
-Thanks to this, the implementation can just rely on `Codable` for decoding easily, without any unsafe casting or guessing types.
-You can also use any other serialization scheme here, as long as it matches how the values were originally encoded on the sending side.
+The Swift distributed runtime calls the decoder with the appropriate generic type for
+each argument. A `distributed` method with a `String` and an `Int` parameter causes the
+runtime to invoke `decodeNextArgument` twice — once with `Argument` bound to `String`,
+and once with `Argument` bound to `Int`. This lets the implementation rely on `Codable`
+for decoding without any unsafe casting or guessing types.
+You can also use any other serialization scheme here, as long as it matches how the
+values were originally encoded on the sending side.
 
 ```swift
 public struct SampleInvocationDecoder: DistributedTargetInvocationDecoder {
@@ -416,7 +417,7 @@ public struct SampleInvocationDecoder: DistributedTargetInvocationDecoder {
     var nextArgumentIndex = 0
 
     public mutating func decodeGenericSubstitutions() throws -> [Any.Type] {
-        [] // only implement if you plan on supporting generic calls
+        [] // Implement only if you plan to support generic calls.
     }
 
     public mutating func decodeNextArgument<Argument: Codable>() throws -> Argument {
@@ -429,26 +430,25 @@ public struct SampleInvocationDecoder: DistributedTargetInvocationDecoder {
 }
 ```
 
-You can ignore the generic substitutions and return/error type decoding, 
-unless you intend to support generic distributed function calls. These are supported by the runtime,
-but you would need to rely either on mangling type names, or on another mechanism to transport the
-intended generic arguments to the recipient. 
+You can ignore the generic substitutions and return/error type decoding unless you support
+generic distributed function calls. The runtime supports them, but you need to rely on
+mangled type names or another mechanism to transport the intended generic arguments to
+the recipient.
 
-> Tip: If you do decide to support generic distributed calls,
-> please be aware that the types may not entirely be trusted, 
-> and you should validate the to-be-decoded types against a known allow-list.
+> Tip: If you support generic distributed calls, don't trust incoming types. Validate
+> them against a known allow-list before decoding.
 
-### Report Results and Errors
+### Report results and errors
 
-The final step of a remote call chain is the result handler.
+The final step of a remote call chain is the ``Distributed/DistributedTargetInvocationResultHandler``.
 
-This functions similar to the encoder and decoder we discussed before, but is intended to give you a type-safe
-way to obtain the correct result `Success` type that a distributed method has returned.
+This works similarly to the encoder and decoder, and gives you a type-safe way to obtain
+the result with its correct `Success` type, as declared by the distributed method.
 
-If the method returns void, the specialized `onReturnVoid()` is called instead. 
-If the target method throws an error, the handler will receive that error in the `onThrow(error:)` callback,
-and you may choose how to act on the error accordingly to your preferences (e.g. shutdown the connection, or
-send back some form of "remote call failed" error).
+If the method returns `Void`, the runtime calls the specialized `onReturnVoid()` instead.
+If the target method throws an error, the handler receives that error in the
+`onThrow(error:)` callback, where you decide how to respond — for example, shut down the
+connection, or send back a "remote call failed" error.
 
 ```swift
 public struct SampleResultHandler: DistributedTargetInvocationResultHandler {
@@ -465,7 +465,7 @@ public struct SampleResultHandler: DistributedTargetInvocationResultHandler {
     }
 
     public func onThrow<Err: Error>(error: Err) async throws {
-        // Not every Error is Codable; surface what we can and fall back otherwise
+        // Not every Error is Codable; encode it when possible, and fall back otherwise.
         if let codable = error as? (any Codable & Error) {
             try await replyTo.fail(encoded: JSONEncoder().encode(codable))
         } else {
@@ -475,13 +475,13 @@ public struct SampleResultHandler: DistributedTargetInvocationResultHandler {
 }
 ```
 
-### Putting It All Together
+### Putting it all together
 
-Once everything is wired together, you should be able to make your first remot ecall using
-your newly built actor system.
+Once everything's wired together, you can make your first remote call using your new
+actor system.
 
-We have greatly simplified and abstracted away any serialization and nerworking details
-from the use-site code, which now can focus on your business comains and concepts:
+The actor system hides serialization and networking details so the use-site code can
+focus on its business domain:
 
 ```swift
 distributed actor Greeter {
@@ -497,20 +497,24 @@ distributed actor Greeter {
 let system = SampleActorSystem(localNode: "node-a")
 let local = Greeter(actorSystem: system)
 
-// Resolving the same id through the system returns a remote reference
+// In a real deployment, resolving an ID owned by a remote node returns a remote
+// reference. Here, both sides share one in-process system, so this returns the
+// local instance.
 let remote = try Greeter.resolve(id: local.id, using: system)
 let reply = try await remote.hello(name: "world")
 print(reply) // "Hello, world!"
 ```
 
-It's worth experimenting and trying different ideas how to model your distributed, or client/server applications
-using distributed actors! You might find that by sharing a lot of the underlying infrastructure, you'll free
-up your application from un-necessary low level details.
+You've now built the parts of a custom distributed actor system:
 
-In some application, where fine grained control over every byte and detail of every single request is necessary,
-you may still choose to reach for raw low level networking primitives, use existing RPC systems, 
-or design your own network protocols, however we encourage to embrace the Swift-first nature of actors when it suits your application.
+- An `ActorID` type and lifecycle methods (`assignID`, `actorReady`, `resignID`) that
+  manage actor identity.
+- A `resolve` implementation that distinguishes local actors from remote references.
+- A `DistributedTargetInvocationEncoder` and matching `remoteCall` and `remoteCallVoid`
+  methods for sending invocations.
+- A `DistributedTargetInvocationDecoder` and `receive` flow that dispatches incoming
+  invocations to local actors.
+- A `DistributedTargetInvocationResultHandler` for returning results and errors.
 
-Distributed actor systems have the benefit that once implemented, reusing them becomes simple. And you can even implement entire
-distributed algorithms against the abstract notion of a distributed actor system, without specifying which exact transport
-it is required to utilize.
+For more information, see ``Distributed/DistributedActorSystem`` and
+``Distributed/LocalTestingDistributedActorSystem``.


### PR DESCRIPTION
Editorial follow-up to #88605.

The PR applies the conventions used in the rest of the Swift core docs and standard library to the  "Implementing a Custom Distributed Actor System" article and the Distributed module edits.

Much of the updates was voice and tense related - removing passive voice, making sentences more direct and removing any "you may" or equivalent phrasing, and cleaning up grammar and typo issues.

The biggest change is a quick stab at the "Putting it all together" - as I wasn't entirely sure of intent there, so I focused an initial change on integrating it into existing docs in this section.

(Note: I haven't yet done a full build of the stdlib docs that include this section to verify that the symbol links work as expected, but I'm thinking they do - I need to vet that, and touch base on the changes with Konrad, before I switch this over to a non-draft PR)