### PR TITLE
[RemoteInspection] Fix generic typealiases in DemanglingForTypeRef

### DIFF
--- a/stdlib/public/RemoteInspection/TypeRef.cpp
+++ b/stdlib/public/RemoteInspection/TypeRef.cpp
@@ -638,26 +638,63 @@ class DemanglingForTypeRef
 
   /// Produce the node to install as a nominal's context when swapping in the
   /// richer parent stored on the TypeRef.
-  ///
-  /// Extensions are special because they're the only node that can appear
-  /// instead of the parent (and contain it). For an Extension, the richer
-  /// parent replaces the extended-type slot, preserving the module and any
-  /// generic signature. For every other context kind, the richer parent
-  /// replaces the context wholesale.
-  ///
-  /// Returns nullptr if originalContext is a malformed Extension.
   Demangle::NodePointer
   substituteParentIntoContext(Demangle::NodePointer originalContext,
                               Demangle::NodePointer parentNode) {
-    if (originalContext->getKind() != Node::Kind::Extension)
-      return parentNode;
-    if (originalContext->getNumChildren() < 2 ||
-        originalContext->getNumChildren() > 3) {
-      assert(false && "Extension node should have 2 or 3 children.");
-      return nullptr;
+    switch (originalContext->getKind()) {
+    case Node::Kind::Extension: {
+      // For a type nested in an extension vs a type nested in a parent type
+      // directly, the mangling trees looks like this:
+      //
+      //   Class                                    Class
+      //     Extension                                Structure
+      //       Module: ModExt           vs.             Module: ModBase
+      //       Structure                                Identifier: Outer
+      //         Module: ModBase                      Identifier: Inner
+      //         Identifier: Outer
+      //     Identifier: Inner
+      //
+      if (originalContext->getNumChildren() < 2 ||
+          originalContext->getNumChildren() > 3) {
+        assert(false && "Extension node should have 2 or 3 children.");
+        return nullptr;
+      }
+      originalContext->replaceChild(1, parentNode);
+      return originalContext;
     }
-    originalContext->replaceChild(1, parentNode);
-    return originalContext;
+    case Node::Kind::Protocol: {
+      // Nominal members of a protocol are mangled with a BoundGenericProtocol
+      // wrapping the protocol, where the generic argument slot holds the
+      // relevant Self type (see the matching comment in TypeDecoder's
+      // BoundGenericProtocol case). For example, accessing the typealias A from
+      // protocol P through a conforming type S produces:
+      //
+      //   protocol P { typealias A = ... }
+      //   struct S : P {}
+      //   let x: S.A = ...
+      //
+      //   BoundGenericProtocol
+      //   |
+      //   --> Protocol: P
+      //   |
+      //   --> TypeList:
+      //       |
+      //       --> Structure: S
+      auto bgp = Dem.createNode(Node::Kind::BoundGenericProtocol);
+      auto typeProto = Dem.createNode(Node::Kind::Type);
+      typeProto->addChild(originalContext, Dem);
+      bgp->addChild(typeProto, Dem);
+
+      auto typeList = Dem.createNode(Node::Kind::TypeList);
+      auto typeSelf = Dem.createNode(Node::Kind::Type);
+      typeSelf->addChild(parentNode, Dem);
+      typeList->addChild(typeSelf, Dem);
+      bgp->addChild(typeList, Dem);
+      return bgp;
+    }
+    default:
+      return parentNode;
+    }
   }
 
 public:

--- a/validation-test/Reflection/reflect_generic_typealias_in_extension.swift
+++ b/validation-test/Reflection/reflect_generic_typealias_in_extension.swift
@@ -1,0 +1,42 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_generic_typealias_in_extension
+// RUN: %target-codesign %t/reflect_generic_typealias_in_extension
+
+// RUN: %target-run %target-swift-reflection-test %t/reflect_generic_typealias_in_extension | %FileCheck %s
+
+// REQUIRES: reflection_test_support
+// REQUIRES: executable_test
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: asan
+
+import SwiftReflectionTest
+
+struct Outer<T> {}
+
+extension Outer {
+  typealias Pair<U> = (T, U)
+}
+
+class TypealiasHolder {
+  var pair: Outer<Int>.Pair<String> = (1, "hi")
+}
+
+reflect(object: TypealiasHolder())
+
+// CHECK: Reflecting an object.
+// CHECK: Type reference:
+// CHECK: (class {{.*}}TypealiasHolder
+// CHECK: Type info:
+// CHECK: (class_instance
+// CHECK: (field name=pair
+// CHECK: (tuple
+// CHECK: (field offset=0
+// CHECK: (struct size=8
+// CHECK: (field name=_value
+// CHECK: (field offset=8
+// CHECK: (struct size=16
+// CHECK: (field name=_guts
+
+doneReflecting()
+
+// CHECK: Done.


### PR DESCRIPTION
When a typealias or associated type is declared inside a protocol, the mangling of an access like S.A (for `typealias A` in `protocol P` and `struct S : P`) wraps the protocol in a BoundGenericProtocol whose single generic argument is the conforming Self type:

  BoundGenericProtocol
  |
  --> Protocol: P
  |
  --> TypeList:
      |
      --> Structure: S

DemanglingForTypeRef was substituting the richer parent wholesale in place of the Protocol, losing the BoundGenericProtocol entirely and producing a mangled tree that looks as if A were declared directly on S rather than inside P.

Assisted-by: claude

rdar://176571422

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
