### PR TITLE
[Runtime] Group environment variable types into a types namespace.

### DIFF
--- a/include/swift/Runtime/EnvironmentVariables.h
+++ b/include/swift/Runtime/EnvironmentVariables.h
@@ -28,13 +28,17 @@ void initialize(void *);
 
 extern swift::once_t initializeToken;
 
-// Define a typedef "string" in swift::runtime::environment to make string
-// environment variables work
+// Types that can be used for environment variables.
+namespace types {
+using boolean = bool;
 using string = const char *;
+using uint8 = uint8_t;
+using uint32 = uint32_t;
+} // namespace types
 
 // Declare backing variables.
 #define VARIABLE(name, type, defaultValue, help)                               \
-  extern type name##_variable;                                                 \
+  extern swift::runtime::environment::types::type name##_variable;             \
   extern bool name##_isSet_variable;
 #include "../../../stdlib/public/runtime/EnvironmentVariables.def"
 
@@ -44,7 +48,7 @@ using string = const char *;
 // set at all, to allow detecting when the variable was explicitly set to the
 // same value as the default.
 #define VARIABLE(name, type, defaultValue, help)                               \
-  inline type name() {                                                         \
+  inline swift::runtime::environment::types::type name() {                     \
     swift::once(initializeToken, initialize, nullptr);                         \
     return name##_variable;                                                    \
   }                                                                            \

--- a/stdlib/public/runtime/EnvironmentVariables.cpp
+++ b/stdlib/public/runtime/EnvironmentVariables.cpp
@@ -29,12 +29,6 @@ using namespace swift;
 
 namespace {
 
-// This is required to make the macro machinery work correctly; we can't
-// declare a VARIABLE(..., const char *, ...) because then the token-pasted
-// names won't work properly.  It *does* mean that if you want to use std::string
-// somewhere in this file, you'll have to fully qualify the name.
-typedef const char *string;
-
 // Require all environment variable names to start with SWIFT_
 static constexpr bool hasSwiftPrefix(const char *str) {
   const char prefix[] = "SWIFT_";
@@ -51,7 +45,8 @@ static constexpr bool hasSwiftPrefix(const char *str) {
 
 // Value parsers. Add new functions named parse_<type> to accommodate more
 // debug variable types.
-static bool parse_bool(const char *name, const char *value, bool defaultValue) {
+static bool parse_boolean(const char *name, const char *value,
+                          bool defaultValue) {
   if (!value)
     return defaultValue;
   switch (value[0]) {
@@ -75,9 +70,8 @@ static bool parse_bool(const char *name, const char *value, bool defaultValue) {
   }
 }
 
-static uint8_t parse_uint8_t(const char *name,
-                             const char *value,
-                             uint8_t defaultValue) {
+static uint8_t parse_uint8(const char *name, const char *value,
+                           uint8_t defaultValue) {
   if (!value)
     return defaultValue;
   char *end;
@@ -105,9 +99,8 @@ static uint8_t parse_uint8_t(const char *name,
   return n;
 }
 
-static uint32_t parse_uint32_t(const char *name,
-                               const char *value,
-                               uint32_t defaultValue) {
+static uint32_t parse_uint32(const char *name, const char *value,
+                             uint32_t defaultValue) {
   if (!value)
     return defaultValue;
   char *end;
@@ -135,9 +128,8 @@ static uint32_t parse_uint32_t(const char *name,
   return n;
 }
 
-static string parse_string(const char *name,
-                           const char *value,
-                           string defaultValue) {
+static const char *parse_string(const char *name, const char *value,
+                                const char *defaultValue) {
   if (!value || value[0] == 0)
     return strdup(defaultValue);
   return strdup(value);
@@ -166,7 +158,8 @@ void printHelp(const char *extra) {
 
 // Define backing variables.
 #define VARIABLE(name, type, defaultValue, help)                               \
-  type swift::runtime::environment::name##_variable = defaultValue;            \
+  swift::runtime::environment::types::type                                     \
+      swift::runtime::environment::name##_variable = defaultValue;             \
   bool swift::runtime::environment::name##_isSet_variable = false;
 #include "EnvironmentVariables.def"
 
@@ -251,7 +244,7 @@ void swift::runtime::environment::initialize(void *context) {
   }
     // SWIFT_DEBUG_HELP is not in the variables list. Parse it like the other
     // variables.
-    VARIABLE(SWIFT_DEBUG_HELP, bool, false, )
+    VARIABLE(SWIFT_DEBUG_HELP, boolean, false, )
 #include "EnvironmentVariables.def"
 
     // Flag unknown SWIFT_DEBUG_ variables to catch misspellings. We don't flag
@@ -291,7 +284,7 @@ void swift::runtime::environment::initialize(void *context) {
   platformInitialize(context);
 
   // Print help if requested.
-  if (parse_bool("SWIFT_DEBUG_HELP", getenv("SWIFT_DEBUG_HELP"), false))
+  if (parse_boolean("SWIFT_DEBUG_HELP", getenv("SWIFT_DEBUG_HELP"), false))
     printHelp("Using getenv to read variables. Unknown SWIFT_DEBUG_ variables "
               "will not be flagged.");
 }

--- a/stdlib/public/runtime/EnvironmentVariables.def
+++ b/stdlib/public/runtime/EnvironmentVariables.def
@@ -22,78 +22,78 @@
 #error "Must define VARIABLE to include EnvironmentVariables.def"
 #endif
 
-VARIABLE(SWIFT_DEBUG_ENABLE_METADATA_ALLOCATION_ITERATION, bool, false,
+VARIABLE(SWIFT_DEBUG_ENABLE_METADATA_ALLOCATION_ITERATION, boolean, false,
          "Enable additional metadata allocation tracking for swift-inspect to "
          "use.")
 
-VARIABLE(SWIFT_DEBUG_ENABLE_METADATA_BACKTRACE_LOGGING, bool, false,
+VARIABLE(SWIFT_DEBUG_ENABLE_METADATA_BACKTRACE_LOGGING, boolean, false,
          "Enable logging of backtraces for each metadata allocation. Requires "
          "SWIFT_DEBUG_ENABLE_METADATA_ALLOCATION_ITERATION to be enabled.")
 
-VARIABLE(SWIFT_DEBUG_IMPLICIT_OBJC_ENTRYPOINT, uint8_t, 2,
+VARIABLE(SWIFT_DEBUG_IMPLICIT_OBJC_ENTRYPOINT, uint8, 2,
          "Print warnings when using implicit @objc entrypoints. Set to "
          "desired reporting level, 0-3.")
 
-VARIABLE(SWIFT_DETERMINISTIC_HASHING, bool, false,
+VARIABLE(SWIFT_DETERMINISTIC_HASHING, boolean, false,
          "Disable randomized hash seeding.")
 
-VARIABLE(SWIFT_ENABLE_MANGLED_NAME_VERIFICATION, bool, false,
+VARIABLE(SWIFT_ENABLE_MANGLED_NAME_VERIFICATION, boolean, false,
          "Enable verification that metadata can roundtrip through a mangled "
          "name each time metadata is instantiated.")
 
-VARIABLE(SWIFT_DEBUG_ENABLE_MALLOC_SCRIBBLE, bool, false,
+VARIABLE(SWIFT_DEBUG_ENABLE_MALLOC_SCRIBBLE, boolean, false,
          "Scribble on runtime allocations such as metadata allocations.")
 
-VARIABLE(SWIFT_DEBUG_ENABLE_COW_CHECKS, bool, false,
+VARIABLE(SWIFT_DEBUG_ENABLE_COW_CHECKS, boolean, false,
          "Enable internal checks for copy-on-write operations.")
 
-VARIABLE(SWIFT_DEBUG_VALIDATE_UNCHECKED_CONTINUATIONS, bool, false,
+VARIABLE(SWIFT_DEBUG_VALIDATE_UNCHECKED_CONTINUATIONS, boolean, false,
          "Check for and error on double-calls of unchecked continuations.")
 
 #if defined(__APPLE__) && defined(__MACH__)
 
-VARIABLE(SWIFT_DEBUG_VALIDATE_SHARED_CACHE_PROTOCOL_CONFORMANCES, bool, false,
+VARIABLE(SWIFT_DEBUG_VALIDATE_SHARED_CACHE_PROTOCOL_CONFORMANCES, boolean, false,
          "Validate shared cache protocol conformance results against the "
          "lists of conformances in the shared cache images.")
 
-VARIABLE(SWIFT_DEBUG_ENABLE_SHARED_CACHE_PROTOCOL_CONFORMANCES, bool, true,
+VARIABLE(SWIFT_DEBUG_ENABLE_SHARED_CACHE_PROTOCOL_CONFORMANCES, boolean, true,
          "Enable querying precomputed protocol conformances in the shared "
          "cache.")
 
 #endif
 
 VARIABLE(SWIFT_DEBUG_ENABLE_CACHE_PROTOCOL_CONFORMANCES_BY_TYPE_DESCRIPTOR,
-         bool, true,
+         boolean, true,
          "Enable caching protocol conformances by type descriptor in addition "
          "to the cache by metadata.")
 
-VARIABLE(SWIFT_DEBUG_CONCURRENCY_ENABLE_COOPERATIVE_QUEUES, bool, true,
+VARIABLE(SWIFT_DEBUG_CONCURRENCY_ENABLE_COOPERATIVE_QUEUES, boolean, true,
          "Enable dispatch cooperative queues in the global executor.")
 
 #ifndef NDEBUG
 
-VARIABLE(SWIFT_DEBUG_RUNTIME_EXCLUSIVITY_LOGGING, bool, false,
+VARIABLE(SWIFT_DEBUG_RUNTIME_EXCLUSIVITY_LOGGING, boolean, false,
          "Enable the an asserts runtime to emit logging as it works.")
 
 VARIABLE(SWIFT_DEBUG_ENABLE_PROTOCOL_CONFORMANCES_LOOKUP_LOG,
-         bool, false,
+         boolean, false,
          "Enable logs for the conformance lookup routine.")
 
 #endif
 
-VARIABLE(SWIFT_BINARY_COMPATIBILITY_VERSION, uint32_t, 0,
+VARIABLE(SWIFT_BINARY_COMPATIBILITY_VERSION, uint32, 0,
         "Set the binary compatibility level of the Swift Standard Library")
 
-VARIABLE(SWIFT_DEBUG_FAILED_TYPE_LOOKUP, bool, false,
+VARIABLE(SWIFT_DEBUG_FAILED_TYPE_LOOKUP, boolean, false,
          "Enable warnings when we fail to look up a type by name.")
 
-VARIABLE(SWIFT_DEBUG_ENABLE_LIB_PRESPECIALIZED_METADATA, bool, true,
+VARIABLE(SWIFT_DEBUG_ENABLE_LIB_PRESPECIALIZED_METADATA, boolean, true,
          "Enable use of metadata in prespecializations library.")
 
-VARIABLE(SWIFT_DEBUG_ENABLE_LIB_PRESPECIALIZED_DESCRIPTOR_LOOKUP, bool, true,
+VARIABLE(SWIFT_DEBUG_ENABLE_LIB_PRESPECIALIZED_DESCRIPTOR_LOOKUP, boolean, true,
          "Enable use of descriptor map in prespecializations library.")
 
-VARIABLE(SWIFT_DEBUG_VALIDATE_LIB_PRESPECIALIZED_DESCRIPTOR_LOOKUP, bool, false,
+VARIABLE(SWIFT_DEBUG_VALIDATE_LIB_PRESPECIALIZED_DESCRIPTOR_LOOKUP, boolean, false,
          "Validate results from the prespecializations map descriptor map by "
          "comparing to a full scan.")
 
@@ -112,7 +112,7 @@ VARIABLE(SWIFT_DEBUG_LIB_PRESPECIALIZED_ENABLED_PROCESSES, string, "",
          "processes list in the prespecializations library, as well as the "
          "list in SWIFT_DEBUG_LIB_PRESPECIALIZED_DISABLED_PROCESSES.")
 
-VARIABLE(SWIFT_DEBUG_ENABLE_LIB_PRESPECIALIZED_LOGGING, bool, false,
+VARIABLE(SWIFT_DEBUG_ENABLE_LIB_PRESPECIALIZED_LOGGING, boolean, false,
          "Enable debug logging of prespecializations library use.")
 
 VARIABLE(SWIFT_ROOT, string, "",
@@ -125,7 +125,7 @@ VARIABLE(SWIFT_BACKTRACE, string, "",
          "crash catching and backtracing support in the runtime. "
          "See docs/Backtracing.rst in the Swift repository for details.")
 
-VARIABLE(SWIFT_IS_BACKTRACING, bool, false,
+VARIABLE(SWIFT_IS_BACKTRACING, boolean, false,
          "Set to `true` if we are running the backtracer.")
 
 VARIABLE(SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE, string, "",
@@ -144,13 +144,13 @@ VARIABLE(SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE, string, "",
          " 'swift6' (Swift 6.0-6.1 behavior)"
          " 'isIsolatingCurrentContext' (Swift 6.2 behavior)")
 
-VARIABLE(SWIFT_DUMP_ACCESSIBLE_FUNCTIONS, bool, false,
+VARIABLE(SWIFT_DUMP_ACCESSIBLE_FUNCTIONS, boolean, false,
          "Dump a listing of all 'AccessibleFunctionRecord's upon first access. "
          "These are used to obtain function pointers from accessible function "
          "record names, e.g. by the Distributed runtime to invoke distributed "
          "functions.")
 
-VARIABLE(SWIFT_DEBUG_ENABLE_TASK_SLAB_ALLOCATOR, bool, true,
+VARIABLE(SWIFT_DEBUG_ENABLE_TASK_SLAB_ALLOCATOR, boolean, true,
          "Use a slab allocator for the async stack. If not enabled, directly "
          "call malloc/free. Direct use of malloc/free enables use of memory "
          "debugging tools for async stack allocations.")

--- a/test/Runtime/environment_variables.swift
+++ b/test/Runtime/environment_variables.swift
@@ -13,11 +13,11 @@
 // CHECK-DAG: Warning: cannot parse value SWIFT_DEBUG_IMPLICIT_OBJC_ENTRYPOINT=abc, defaulting to 2.
 // CHECK-DAG: Warning: cannot parse value SWIFT_DETERMINISTIC_HASHING=whatever, defaulting to false.
 // CHECK-DAG: Swift runtime debugging:
-// CHECK-DAG:    bool SWIFT_DEBUG_ENABLE_METADATA_ALLOCATION_ITERATION [default: false] - Enable additional metadata allocation tracking for swift-inspect to use.
-// CHECK-DAG: uint8_t SWIFT_DEBUG_IMPLICIT_OBJC_ENTRYPOINT [default: 2] - Print warnings when using implicit @objc entrypoints. Set to desired reporting level, 0-3.
-// CHECK-DAG:    bool SWIFT_DETERMINISTIC_HASHING [default: false] - Disable randomized hash seeding.
-// CHECK-DAG:    bool SWIFT_ENABLE_MANGLED_NAME_VERIFICATION [default: false] - Enable verification that metadata can roundtrip through a mangled name each time metadata is instantiated.
-// CHECK-DAG:    bool SWIFT_DEBUG_ENABLE_MALLOC_SCRIBBLE [default: false] - Scribble on runtime allocations such as metadata allocations.
+// CHECK-DAG: boolean SWIFT_DEBUG_ENABLE_METADATA_ALLOCATION_ITERATION [default: false] - Enable additional metadata allocation tracking for swift-inspect to use.
+// CHECK-DAG:   uint8 SWIFT_DEBUG_IMPLICIT_OBJC_ENTRYPOINT [default: 2] - Print warnings when using implicit @objc entrypoints. Set to desired reporting level, 0-3.
+// CHECK-DAG: boolean SWIFT_DETERMINISTIC_HASHING [default: false] - Disable randomized hash seeding.
+// CHECK-DAG: boolean SWIFT_ENABLE_MANGLED_NAME_VERIFICATION [default: false] - Enable verification that metadata can roundtrip through a mangled name each time metadata is instantiated.
+// CHECK-DAG: boolean SWIFT_DEBUG_ENABLE_MALLOC_SCRIBBLE [default: false] - Scribble on runtime allocations such as metadata allocations.
 // CHECK-DAG:  string SWIFT_ROOT [default: "{{[^"]*}}"] - Overrides the root directory of the Swift installation. This is used to locate auxiliary files relative to the runtime itself.
 
 // We need to do this because the DAG checks require a non-DAG check as an


### PR DESCRIPTION
Wrap the type aliases used by the EnvironmentVariables x-macros in a swift::runtime::environment::types namespace and rename them to use shorter, consistent names (boolean, uint8, uint32, string). Update the backing variable, getter macros, parser functions, and the .def entries to match. No functional change.