### PR TITLE
[6.4][Concurrency] SILGen: A few fixes to isolation inference

### DIFF
--- a/lib/SIL/IR/SILDeclRef.cpp
+++ b/lib/SIL/IR/SILDeclRef.cpp
@@ -2078,5 +2078,31 @@ ActorIsolation SILDeclRef::getActorIsolation() const {
     return cast<VarDecl>(getDecl())->getInitializerIsolation();
   }
 
-  return getActorIsolationOfContext(getInnermostDeclContext());
+  auto isolation = getActorIsolationOfContext(getInnermostDeclContext());
+  if (!isolation.isUnspecified())
+    return isolation;
+
+  // Local computed variable accessors get their isolation from the context.
+  //
+  // TODO: This is a narrow fix for region-based isolation, a proper fix here
+  // would be to set isolation correctly on the variable itself during
+  // type-checking, but that requires significant changes to support closures
+  // because their local declarations are currently type-checked during CSApply.
+  if (auto *accessor = getAccessorDecl()) {
+    auto *dc = accessor->getDeclContext();
+    if (dc->isLocalContext()) {
+      auto contextIsolation =
+          getActorIsolationOfContext(accessor->getDeclContext());
+
+      if (contextIsolation.isNonisolatedOrConcurrent() ||
+          contextIsolation.isNonisolatedNonsending())
+        return accessor->isAsync()
+                   ? ActorIsolation::forNonisolatedConcurrent()
+                   : ActorIsolation::forNonisolated(/*unsafe=*/false);
+
+      return contextIsolation;
+    }
+  }
+
+  return isolation;
 }

--- a/lib/SILGen/SILGenThunk.cpp
+++ b/lib/SILGen/SILGenThunk.cpp
@@ -647,11 +647,18 @@ getOrCreateReabstractionThunk(CanSILFunctionType thunkType,
       ? IsSerialized : IsNotSerialized;
   }
 
+  auto isolation = ActorIsolation::forUnspecified();
+
+  // The isolation of the thunk should match that of its type
+  // otherwise it could lead to incorrect decision optimizations.
+  if (thunkType->hasNonisolatedNonsendingIsolation())
+    isolation = ActorIsolation::forNonisolatedNonsending();
+
   SILGenFunctionBuilder builder(*this);
   return builder.getOrCreateSharedFunction(
-      loc, name, thunkDeclType, ActorIsolation::forUnspecified(), IsBare,
-      IsTransparent, serializable, ProfileCounter(), IsReabstractionThunk,
-      IsNotDynamic, IsNotDistributed, IsNotRuntimeAccessible);
+      loc, name, thunkDeclType, isolation, IsBare, IsTransparent, serializable,
+      ProfileCounter(), IsReabstractionThunk, IsNotDynamic, IsNotDistributed,
+      IsNotRuntimeAccessible);
 }
 
 SILFunction *SILGenModule::getOrCreateDerivativeVTableThunk(

--- a/test/Concurrency/local_computed_properties.swift
+++ b/test/Concurrency/local_computed_properties.swift
@@ -1,0 +1,199 @@
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple %s -emit-sil -o - -verify -strict-concurrency=complete -enable-actor-data-race-checks -disable-availability-checking | %FileCheck %s
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple %s -emit-module -o /dev/null -strict-concurrency=complete -disable-availability-checking
+
+// REQUIRES: concurrency
+
+// Test that local computed properties and lazy vars inherit actor isolation
+// from their enclosing context, just like local functions.
+
+class NS {}
+
+// =============================================================================
+// @MainActor class
+// =============================================================================
+
+@MainActor
+class MainActorClass {
+  var field = NS()
+  func getNS() -> NS { NS() }
+
+  // CHECK-LABEL: // getter of y #1 in MainActorClass.testComputedGetOnly()
+  // CHECK-NEXT:  // Isolation: global_actor. type: MainActor
+  func testComputedGetOnly() {
+    var y: NS {
+      return field
+    }
+    _ = y
+  }
+
+  // CHECK-LABEL: // getter of z #1 in MainActorClass.testComputedGetSet()
+  // CHECK-NEXT:  // Isolation: global_actor. type: MainActor
+  // CHECK-LABEL: // setter of z #1 in MainActorClass.testComputedGetSet()
+  // CHECK-NEXT:  // Isolation: global_actor. type: MainActor
+  func testComputedGetSet() {
+    var holder = field
+    var z: NS {
+      get { return holder }
+      set { holder = newValue }
+    }
+    z = NS()
+    _ = z
+  }
+
+  // CHECK-LABEL: // getter of x #1 in MainActorClass.testLazyVar()
+  // CHECK-NEXT:  // Isolation: global_actor. type: MainActor
+  // CHECK-LABEL: // setter of x #1 in MainActorClass.testLazyVar()
+  // CHECK-NEXT:  // Isolation: global_actor. type: MainActor
+  func testLazyVar() {
+    lazy var x = getNS()
+    _ = x
+  }
+}
+
+@MainActor
+func testMainActorClosure() {
+  _ = {
+    // CHECK-LABEL: // getter of v1 #1 in closure #1 in testMainActorClosure()
+    // CHECK-NEXT: // Isolation: global_actor. type: MainActor
+    var v1: Int {
+      42
+    }
+    _ = v1
+
+    // CHECK-LABEL: // getter of v2 #1 in closure #1 in testMainActorClosure()
+    // CHECK-NEXT: // Isolation: global_actor. type: MainActor
+    lazy var v2 = 42
+    _ = v2
+  }
+}
+
+// =============================================================================
+// actor
+// =============================================================================
+
+actor TestActor {
+  var field = NS()
+
+  // CHECK-LABEL: // getter of y #1 in TestActor.testComputedVar()
+  // CHECK-NEXT:  // Isolation: actor_instance. name: 'self'
+  func testComputedVar() {
+    var y: NS {
+      return field
+    }
+    _ = y
+  }
+}
+
+func testParameterIsolation(isolation: isolated (any Actor)? = nil) async {
+  // CHECK-LABEL: // getter of v1 #1 in testParameterIsolation(isolation:)
+  // CHECK-NEXT: // Isolation: actor_instance. name: 'isolation'
+  var v1: Int {
+    return 42
+  }
+
+  // CHECK-LABEL: // getter of v2 #1 in testParameterIsolation(isolation:)
+  // CHECK-NEXT: // Isolation: actor_instance. name: 'isolation'
+  var v2: Int {
+    get async { 42 }
+  }
+
+  _ = v1
+  _ = await v2
+
+  _ = {
+    // CHECK-LABEL: // getter of v1 #1 in closure #1 in testParameterIsolation(isolation:)
+    // CHECK-NEXT: // Isolation: nonisolated
+    var v1: Int {
+      42
+    }
+  }
+
+  _ = {
+    _ = isolation
+    // CHECK-LABEL: // getter of v1 #1 in closure #2 in testParameterIsolation(isolation:)
+    // CHECK-NEXT: // Isolation: actor_instance. name: 'isolation'
+    var v1: Int {
+      42
+    }
+  }
+}
+
+// =============================================================================
+// nonisolated
+// =============================================================================
+
+// CHECK-LABEL: // getter of counter #1 in testNonisolated()
+// CHECK-NEXT:  // Isolation: nonisolated
+nonisolated func testNonisolated() {
+  var counter: Int {
+    return 42
+  }
+  _ = counter
+}
+
+@concurrent func testConcurrent() async {
+  // CHECK-LABEL: // getter of v1 #1 in testConcurrent()
+  // CHECK-NEXT:  // Isolation: nonisolated
+  var v1: Int {
+    return 42
+  }
+
+  // CHECK-LABEL: // getter of v2 #1 in testConcurrent()
+  // CHECK-NEXT:  // Isolation: @concurrent
+  var v2: Int {
+    get async { 42 }
+  }
+
+  _ = v1
+  _ = await v2
+}
+
+// =============================================================================
+// if #available
+// =============================================================================
+
+// Local accessors inside if #available inherit isolation from the enclosing
+// context. Regression test: NonisolatedAttr must not be added to AccessorDecl
+// (it is invalid there per DeclAttr.def), which previously caused a crash
+// during -emit-module serialization. rdar://175548302
+
+// CHECK-LABEL: // getter of prop #1 in withAvailability()
+// CHECK-NEXT:  // Isolation: unspecified
+func withAvailability() {
+  if #available(macOS 10.15, *) {
+    var prop: some Equatable { 0 }
+    _ = prop
+  }
+}
+
+extension MainActorClass {
+  // CHECK-LABEL: // getter of prop #1 in MainActorClass.withMainActorAndAvailability()
+  // CHECK-NEXT:  // Isolation: global_actor. type: MainActor
+  func withMainActorAndAvailability() {
+    if #available(macOS 10.15, *) {
+      var prop: NS { NS() }
+      _ = prop
+    }
+  }
+}
+
+// =============================================================================
+// nonisolated(nonsending)
+// =============================================================================
+
+nonisolated(nonsending) func testNonisolatedNonsending() async {
+  // CHECK-LABEL: // getter of v1 #1 in testNonisolatedNonsending()
+  // CHECK-NEXT // Isolation: nonisolated
+  var v1: Int {
+    return 42
+  }
+
+  // CHECK-LABEL: // getter of v2 #1 in testNonisolatedNonsending()
+  // CHECK-NEXT: // Isolation: @concurrent
+  var v2: Int {
+    get async { 42 }
+  }
+
+  _ = v1
+  _ = await v2
+}

--- a/test/Concurrency/nonisolated_nonsending.swift
+++ b/test/Concurrency/nonisolated_nonsending.swift
@@ -26,7 +26,8 @@ func testPartialApplication(p: [any P]) async {
 //   Reabstraction thunk from caller-isolated () -> () to caller-isolated () -> T
 // CHECK-LABEL: sil shared [transparent] [reabstraction_thunk] @$sBAIeNghHgIL_BAytIeNghHgILr_TR : $@convention(thin) @caller_isolated @Sendable @async (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, @guaranteed @caller_isolated @Sendable @async @callee_guaranteed (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor) -> ()) -> @out () {
 // CHECK:       bb0(%0 : $*(), %1 : $Builtin.ImplicitActor, %2 : $@caller_isolated @Sendable @async @callee_guaranteed (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor) -> ()):
-// CHECK-NEXT:    hop_to_executor %1
+// The hop is eliminated because the argument is `nonisolated(nonsending)`
+// CHECK-NOT:    hop_to_executor %1
 // CHECK-NEXT:    apply %2(%1) :
 
 func takesGenericAsyncFunction<T>(_ fn: nonisolated(nonsending) (T) async -> Void) {}
@@ -45,11 +46,50 @@ func testReabstractionPreservingCallerIsolation(fn: nonisolated(nonsending) (Int
 // CHECK-LABEL: sil shared [transparent] [reabstraction_thunk] @$sBASiINgHgILy_BASiIeNgHgILn_TR : $@convention(thin) @caller_isolated @async (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, @in_guaranteed Int, @guaranteed @caller_isolated @noescape @async @callee_guaranteed (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, Int) -> ()) -> () {
 // CHECK:       bb0(%0 : $Builtin.ImplicitActor, %1 : $*Int, %2 : $@caller_isolated @noescape @async @callee_guaranteed (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, Int) -> ()):
 // CHECK-NEXT:    %3 = load %1
-// CHECK-NEXT:    hop_to_executor %0
+// The hop is eliminated because the argument is `nonisolated(nonsending)`
+// CHECK-NOT:    hop_to_executor %0
 // CHECK-NEXT:    apply %2(%0, %3)
 
 func takesAsyncIsolatedAnyFunction(_ fn: @isolated(any) () async -> Void) {}
 func takesGenericAsyncIsolatedAnyFunction<T>(_ fn: @isolated(any) (T) async -> Void) {}
+
+func testReabstractionHopsBack() async throws {
+  func compute<T, R>(_ fn: nonisolated(nonsending) (T) async -> R?) async {
+  }
+
+  func computeThrowing(_ fn: nonisolated(nonsending) () async throws -> Void) async throws {
+  }
+
+  // CHECK: // thunk for @callee_guaranteed @async (@unowned Int) -> (@unowned ()?)
+  // CHECK: // Isolation: nonisolated(nonsending)
+  // CHECK: sil shared [transparent] [reabstraction_thunk] @$sSiytSgIgHyd_BASiAAIeNgHgILnr_TR : $@convention(thin) @caller_isolated @async (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, @in_guaranteed Int, @guaranteed @noescape @async @callee_guaranteed (Int) -> Optional<()>) -> @out Optional<()> {
+  // CHECK: bb0([[RESULT:%.*]] : $*Optional<()>, [[ISOLATION:%.*]] : $Builtin.ImplicitActor, [[X_REF:%.*]] : $*Int, [[CLOSURE:%.*]] : $@noescape @async @callee_guaranteed (Int) -> Optional<()>):
+  // CHECK:   [[X:%.*]] = load [[X_REF]]
+  // CHECK:   [[CLOSURE_RESULT:%.*]] = apply [[CLOSURE]]([[X]]) : $@noescape @async @callee_guaranteed (Int) -> Optional<()>
+  // CHECK:   store [[CLOSURE_RESULT]] to [[RESULT]]
+  // CHECK:   hop_to_executor [[ISOLATION]]
+  // CHECK: } // end sil function '$sSiytSgIgHyd_BASiAAIeNgHgILnr_TR'
+  await compute { @concurrent (x: Int) in
+      _ = x
+  }
+
+  struct MyError: Error {
+  }
+
+  // CHECK: // thunk for @callee_guaranteed @Sendable @async () -> (@error @owned Error)
+  // CHECK: // Isolation: nonisolated(nonsending)
+  // CHECK: sil shared [transparent] [reabstraction_thunk] @$ss5Error_pIghHzo_BAsAA_pIeNgHgILzo_TR : $@convention(thin) @caller_isolated @async (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, @guaranteed @noescape @Sendable @async @callee_guaranteed () -> @error any Error) -> @error any Error {
+  // CHECK: bb0([[ISOLATION:%.*]] : $Builtin.ImplicitActor, [[CLOSURE:%.*]] : $@noescape @Sendable @async @callee_guaranteed () -> @error any Error):
+  // CHECK:   try_apply [[CLOSURE]]() : $@noescape @Sendable @async @callee_guaranteed () -> @error any Error, normal bb1, error bb2
+  // CHECK: bb1({{.*}} : $()):
+  // CHECK:   hop_to_executor [[ISOLATION]]
+  // CHECK: bb2({{.*}} : $any Error):
+  // CHECK:   hop_to_executor [[ISOLATION]]
+  // CHECK: } // end sil function '$ss5Error_pIghHzo_BAsAA_pIeNgHgILzo_TR'
+  try await computeThrowing { @MainActor in
+      throw MyError()
+  }
+}
 
 // These would be good to test, but we apparently reject this conversion.
 #if false

--- a/test/Interpreter/issue88731.swift
+++ b/test/Interpreter/issue88731.swift
@@ -1,0 +1,36 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -language-mode 6 -target %target-swift-5.1-abi-triple %s -parse-as-library -module-name main -o %t/main
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main | %FileCheck %s
+
+// REQUIRES: concurrency
+// REQUIRES: concurrency_runtime
+// REQUIRES: executable_test
+
+// UNSUPPORTED: back_deployment_runtime
+
+// https://github.com/swiftlang/swift/issues/88731
+
+@MainActor
+func compute(_ fn: nonisolated(nonsending) @Sendable () async throws -> Void) async throws {
+  try await fn()
+  assertIsMainActor()
+}
+
+func assertIsMainActor() {
+    MainActor.assumeIsolated {}
+}
+
+func performComputation() async throws {
+  let x: Int = 42
+  try await compute { [x] in
+    print(x)
+  }
+}
+
+@main struct Main {
+  static func main() async throws {
+    try await performComputation()
+    // CHECK: 42
+  }
+}

--- a/test/Interpreter/issue88993.swift
+++ b/test/Interpreter/issue88993.swift
@@ -1,0 +1,43 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -language-mode 5 -strict-concurrency=complete -target %target-swift-5.1-abi-triple %s -parse-as-library -module-name main -o %t/main
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main
+
+// REQUIRES: concurrency
+// REQUIRES: concurrency_runtime
+// REQUIRES: executable_test
+
+// UNSUPPORTED: back_deployment_runtime
+
+// https://github.com/swiftlang/swift/issues/88993
+
+actor MyActor {
+  nonisolated func perform<E: Error>(_ work: @escaping @Sendable (isolated MyActor) async throws(E) -> ()) async throws(E) {
+    try await work(self)
+  }
+}
+
+// The bug only happens if this closure is `nonisolated(nonsending)`
+typealias MigrationWorkBlock = nonisolated(nonsending) () async -> Void
+
+nonisolated struct MyOperation {
+  let actor = MyActor()
+  let migrationWork: MigrationWorkBlock
+
+  nonisolated func run() async {
+    await self.actor.perform { actor in
+      actor.assertIsolated()
+
+      await migrationWork() // nonisolated(nonsending) should hop back to the context were it was executed
+
+      actor.assertIsolated() // Ok
+    }
+  }
+}
+
+@main struct Main {
+  static func main() async throws {
+    let operation = MyOperation(migrationWork: { }) // closure here is @MainActor isolated
+    await operation.run()
+  }
+}


### PR DESCRIPTION
- Explanation:

  This is a cherry-pick of two recent fixes for how isolation is set for reabstraction thunks and computed/lazy properties.

  -  Set correct isolation on thunks that reabstract into `nonisolated(nonsending)`. The thunk function itself should be marked as `nonisolated(nonsending)` otherwise `OptimizeHopToExecutor` would remove valid hops.

  -  SILDeclRef: Fix isolation computation for local accessors. They should get isolation of the enclosing context.

- Resolves: rdar://176709091, rdar://175548302

- Main Branch PRs: https://github.com/swiftlang/swift/pull/89015, https://github.com/swiftlang/swift/pull/88958

- Risk: Low. Both changes have limited scope. `nonisolated(nonsending)` change carries very low risk since it only sets the isolation on the thunk, SILDeclRef affects only local accessor functions and let's more valid code compile.

- Reviewed By: @ktoso @gottesmm 

- Testing: Added new test-cases to the suite.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
