### PR TITLE
[CAS] Store the input index along the compiler results

### DIFF
--- a/include/swift/Frontend/CompileJobCacheResult.h
+++ b/include/swift/Frontend/CompileJobCacheResult.h
@@ -52,6 +52,9 @@ public:
   /// Retrieves a specific output specified by \p Kind, if it exists.
   std::optional<Output> getOutput(file_types::ID Kind) const;
 
+  /// \returns the input index associated with this compiler result.
+  llvm::Expected<unsigned> getInputIndex() const;
+
   /// Print this result to \p OS.
   llvm::Error print(llvm::raw_ostream &OS);
 
@@ -70,7 +73,8 @@ public:
     /// Build a single \c ObjectRef representing the provided outputs. The
     /// result can be used with \c CompileJobResultSchema to retrieve the
     /// original outputs.
-    llvm::Expected<llvm::cas::ObjectRef> build(llvm::cas::ObjectStore &CAS);
+    llvm::Expected<llvm::cas::ObjectRef> build(llvm::cas::ObjectStore &CAS,
+                                               unsigned InputIndex);
 
   private:
     struct PrivateImpl;
@@ -78,6 +82,7 @@ public:
   };
 
 private:
+  ArrayRef<file_types::ID> getOutputKinds() const;
   llvm::cas::ObjectRef getOutputObject(size_t I) const;
   llvm::cas::ObjectRef getPathsListRef() const;
   file_types::ID getOutputKind(size_t I) const;

--- a/lib/DependencyScan/ScanDependencies.cpp
+++ b/lib/DependencyScan/ScanDependencies.cpp
@@ -585,7 +585,7 @@ private:
 
     swift::cas::CompileJobCacheResult::Builder Builder;
     Builder.addOutput(file_types::ID::TY_SwiftModuleFile, *Ref);
-    auto Result = Builder.build(CAS);
+    auto Result = Builder.build(CAS, 0);
     if (!Result) {
       instance.getDiags().diagnose(SourceLoc(), diag::error_cas,
                                    "adding binary module dependencies",

--- a/lib/Frontend/CASOutputBackends.cpp
+++ b/lib/Frontend/CASOutputBackends.cpp
@@ -344,7 +344,7 @@ Error SwiftCASOutputBackend::Implementation::finalizeCacheKeysFor(
     for (auto &Outs : OutputsForInput)
       Builder.addOutput(Outs.first, Outs.second);
 
-    if (auto Err = Builder.build(CAS).moveInto(Result))
+    if (auto Err = Builder.build(CAS, InputIndex).moveInto(Result))
       return Err;
   }
 

--- a/lib/Frontend/CompileJobCacheResult.cpp
+++ b/lib/Frontend/CompileJobCacheResult.cpp
@@ -16,6 +16,7 @@
 
 #include "swift/Frontend/CompileJobCacheResult.h"
 #include "swift/Basic/FileTypes.h"
+#include "llvm/Support/EndianStream.h"
 
 using namespace swift;
 using namespace swift::cas;
@@ -85,6 +86,16 @@ CompileJobCacheResult::getOutput(file_types::ID Kind) const {
   return {};
 }
 
+Expected<unsigned> CompileJobCacheResult::getInputIndex() const {
+  if (getData().size() < sizeof(uint32_t)) {
+    return llvm::createStringError(llvm::inconvertibleErrorCode(),
+                                   "invalid CompileJobCacheResult data");
+  }
+  StringRef IndexData = getData().take_back(sizeof(uint32_t));
+  return llvm::support::endian::read<uint32_t>(IndexData.data(),
+                                               llvm::endianness::little);
+}
+
 Error CompileJobCacheResult::print(llvm::raw_ostream &OS) {
   return forEachOutput([&](Output O) -> Error {
     OS << file_types::getTypeName(O.Kind) << "    " << getCAS().getID(O.Object)
@@ -93,14 +104,24 @@ Error CompileJobCacheResult::print(llvm::raw_ostream &OS) {
   });
 }
 
-size_t CompileJobCacheResult::getNumOutputs() const { return getData().size(); }
+size_t CompileJobCacheResult::getNumOutputs() const {
+  // " - 1" because the last reference is the node kind.
+  return getNumReferences() - 1;
+}
 ObjectRef CompileJobCacheResult::getOutputObject(size_t I) const {
   return getReference(I);
 }
 
 file_types::ID
 CompileJobCacheResult::getOutputKind(size_t I) const {
-  return static_cast<file_types::ID>(getData()[I]);
+  return getOutputKinds()[I];
+}
+
+ArrayRef<file_types::ID> CompileJobCacheResult::getOutputKinds() const {
+  assert(getData().size() >= sizeof(uint32_t));
+  StringRef KindsData = getData().drop_back(sizeof(uint32_t));
+  return ArrayRef(reinterpret_cast<const file_types::ID *>(KindsData.data()),
+                  KindsData.size());
 }
 
 CompileJobCacheResult::CompileJobCacheResult(const ObjectProxy &Obj)
@@ -143,14 +164,23 @@ Error CompileJobCacheResult::Builder::addOutput(StringRef Path,
                                      Path + "'");
 }
 
-Expected<ObjectRef> CompileJobCacheResult::Builder::build(ObjectStore &CAS) {
+Expected<ObjectRef> CompileJobCacheResult::Builder::build(ObjectStore &CAS,
+                                                          unsigned InputIndex) {
   CompileJobResultSchema Schema(CAS);
   // The resulting Refs contents are:
   // Object 0...N, SchemaKind
   SmallVector<ObjectRef> Refs;
   std::swap(Impl.Objects, Refs);
   Refs.push_back(Schema.getKindRef());
-  return CAS.store(Refs, {(char *)Impl.Kinds.begin(), Impl.Kinds.size()});
+
+  SmallString<10> Buffer(
+      StringRef((char *)Impl.Kinds.begin(), Impl.Kinds.size()));
+  {
+    llvm::raw_svector_ostream OS(Buffer);
+    llvm::support::endian::write<uint32_t>(OS, InputIndex,
+                                           llvm::endianness::little);
+  }
+  return CAS.store(Refs, Buffer);
 }
 
 static constexpr llvm::StringLiteral CompileJobResultSchemaName =

--- a/lib/Tooling/libSwiftScan/SwiftCaching.cpp
+++ b/lib/Tooling/libSwiftScan/SwiftCaching.cpp
@@ -471,23 +471,21 @@ createCachedCompilation(SwiftScanCAS &CAS, const llvm::cas::CASID &ID,
   if (!Proxy)
     return Proxy.takeError();
 
-  // Load input file name from the key CAS object. Input file name is the data
-  // blob in the root node.
-  auto KeyProxy = CAS.getCAS().getProxy(Key);
-  if (!KeyProxy)
-    return KeyProxy.takeError();
-  auto Input = KeyProxy->getData();
+  auto KeyRef = CAS.getCAS().getReference(Key);
+  if (!KeyRef)
+    return nullptr;
 
-  unsigned Index = llvm::support::endian::read<uint32_t>(
-      Input.data(), llvm::endianness::little);
   {
     swift::cas::CompileJobResultSchema Schema(CAS.getCAS());
     if (Schema.isRootNode(*Proxy)) {
       auto Result = Schema.load(Proxy->getRef());
       if (!Result)
         return Result.takeError();
-      return new SwiftCachedCompilationHandle(KeyProxy->getRef(), *Ref,
-                                              std::move(*Result), Index, CAS);
+      auto Index = Result->getInputIndex();
+      if (!Index)
+        return Index.takeError();
+      return new SwiftCachedCompilationHandle(*KeyRef, *Ref, std::move(*Result),
+                                              *Index, CAS);
     }
   }
   {
@@ -496,8 +494,8 @@ createCachedCompilation(SwiftScanCAS &CAS, const llvm::cas::CASID &ID,
       auto Result = Schema.load(Proxy->getRef());
       if (!Result)
         return Result.takeError();
-      return new SwiftCachedCompilationHandle(KeyProxy->getRef(), *Ref,
-                                              std::move(*Result), Index, CAS);
+      return new SwiftCachedCompilationHandle(*KeyRef, *Ref, std::move(*Result),
+                                              0, CAS);
     }
   }
   return createUnsupportedSchemaError();

--- a/test/CAS/cache_replay_direct_from_upstream.swift
+++ b/test/CAS/cache_replay_direct_from_upstream.swift
@@ -1,0 +1,33 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -scan-dependencies -module-name Test -O \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
+// RUN:   %s -o %t/deps.json -cache-compile-job -cas-path %t/cas-plugin -cas-plugin-path %plugin(CASPluginTest)
+
+// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json Test > %t/MyApp.cmd
+// RUN: echo "\"-disable-implicit-string-processing-module-import\"" >> %t/MyApp.cmd
+// RUN: echo "\"-disable-implicit-concurrency-module-import\"" >> %t/MyApp.cmd
+// RUN: echo "\"-parse-stdlib\"" >> %t/MyApp.cmd
+
+// Get cache key.
+// RUN: %swift-scan-test -action compute_cache_key_from_index -cas-path %t/cas-plugin -cas-plugin-path %plugin(CASPluginTest) -input 0 -- \
+// RUN:   %target-swift-frontend-plain -cache-compile-job -Rcache-compile-job %s -emit-module -o %t/Test.swiftmodule -module-name Test \
+// RUN:    -cas-path %t/cas-plugin -cas-plugin-path %plugin(CASPluginTest) @%t/MyApp.cmd > %t/key.casid
+
+// Upload compiler results to upstream.
+// RUN: %target-swift-frontend-plain -cache-compile-job -Rcache-compile-job %s -emit-module -o %t/Test.swiftmodule -module-name Test \
+// RUN:  -cas-path %t/cas-plugin -cas-plugin-path %plugin(CASPluginTest) -cas-plugin-option upstream-path=%t/cas-upstream @%t/MyApp.cmd 2>&1 | %FileCheck --check-prefix=CACHE-MISS %s
+
+// Download compiler results from upstream without having access to the input CAS tree.
+// RUN: %swift-scan-test -action replay_result -id @%t/key.casid \
+// RUN:   -cas-path %t/cas-plugin2 -cas-plugin-path %plugin(CASPluginTest) -cas-plugin-option upstream-path=%t/cas-upstream -- \
+// RUN:    %target-swift-frontend-plain -cache-compile-job -Rcache-compile-job %s -emit-module -o %t/Test2.swiftmodule \
+// RUN:     -module-name Test -cas-path %t/cas-plugin -cas-plugin-path %plugin(CASPluginTest) @%t/MyApp.cmd 2>&1 | %FileCheck --check-prefix=CACHE-HIT %s
+// RUN: diff %t/Test.swiftmodule %t/Test2.swiftmodule
+
+func testFunc() {}
+
+// CACHE-MISS: remark: cache miss for input
+// CACHE-MISS-NOT: remark: replay output file
+// CACHE-HIT: remark: replay output file
+// CACHE-HIT-NOT: remark: cache miss for input

--- a/tools/swift-scan-test/swift-scan-test.cpp
+++ b/tools/swift-scan-test/swift-scan-test.cpp
@@ -44,6 +44,11 @@ enum Actions {
 llvm::cl::OptionCategory Category("swift-scan-test Options");
 llvm::cl::opt<std::string> CASPath("cas-path", llvm::cl::desc("<path>"),
                                    llvm::cl::cat(Category));
+llvm::cl::opt<std::string> CASPluginPath("cas-plugin-path",
+                                         llvm::cl::desc("<path>"),
+                                         llvm::cl::cat(Category));
+llvm::cl::list<std::string> CASPluginOpts("cas-plugin-option",
+                                          cl::desc("Plugin CAS Options"));
 llvm::cl::opt<std::string> CASID("id", llvm::cl::desc("<casid>"),
                                  llvm::cl::cat(Category));
 llvm::cl::opt<std::string> Input("input", llvm::cl::desc("<file|index>"),
@@ -150,7 +155,7 @@ static int print_cached_compilation(swiftscan_cached_compilation_t comp,
 static int action_cache_query(swiftscan_cas_t cas, const char *key,
                               llvm::raw_ostream &os) {
   swiftscan_string_ref_t err_msg;
-  auto comp = swiftscan_cache_query(cas, key, /*globally=*/false, &err_msg);
+  auto comp = swiftscan_cache_query(cas, key, /*globally=*/true, &err_msg);
   if (err_msg.length != 0)
     return printError(err_msg);
 
@@ -167,7 +172,7 @@ static int action_replay_result(swiftscan_cas_t cas, const char *key,
                                 std::vector<const char *> &Args,
                                 raw_ostream &os) {
   swiftscan_string_ref_t err_msg;
-  auto comp = swiftscan_cache_query(cas, key, /*globally=*/false, &err_msg);
+  auto comp = swiftscan_cache_query(cas, key, /*globally=*/true, &err_msg);
   if (!comp) {
     if (err_msg.length != 0)
       return printError(err_msg);
@@ -338,6 +343,15 @@ int main(int argc, char *argv[]) {
   auto option = swiftscan_cas_options_create();
   SWIFT_DEFER { swiftscan_cas_options_dispose(option); };
   swiftscan_cas_options_set_ondisk_path(option, CASPath.c_str());
+  if (!CASPluginPath.empty())
+    swiftscan_cas_options_set_plugin_path(option, CASPluginPath.c_str());
+  for (const auto &PluginOpt : CASPluginOpts) {
+    auto [Name, Val] = StringRef(PluginOpt).split('=');
+    swiftscan_string_ref_t err_msg;
+    if (swiftscan_cas_options_set_plugin_option(option, Name.str().c_str(),
+                                                Val.str().c_str(), &err_msg))
+      return printError(err_msg);
+  }
 
   swiftscan_string_ref_t err_msg;
   auto cas = swiftscan_cas_create_from_options(option, &err_msg);


### PR DESCRIPTION
This allows replaying the cached compiler results from an upstream CAS, if we know the key, without needing access to the caching key input CAS tree.