### PR TITLE
[6.4] [stdlib] Let `Ref` reference nonescapable types

### DIFF
--- a/stdlib/public/core/Ref.swift
+++ b/stdlib/public/core/Ref.swift
@@ -13,7 +13,7 @@
 /// A safe reference allowing in-place reads to a shared value.
 @available(SwiftStdlib 6.4, *)
 @frozen
-public struct Ref<Value: ~Copyable>: Copyable, ~Escapable {
+public struct Ref<Value: ~Copyable & ~Escapable>: Copyable, ~Escapable {
   @usableFromInline
   let builtin: Builtin.Borrow<Value>
 
@@ -50,13 +50,14 @@ public struct Ref<Value: ~Copyable>: Copyable, ~Escapable {
 }
 
 @available(SwiftStdlib 6.4, *)
-extension Ref where Value: ~Copyable {
+extension Ref where Value: ~Copyable & ~Escapable {
   /// Dereferences the constant reference allowing for in-place reads to the
   /// underlying value.
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
   @_transparent
   public var value: Value {
+    @_lifetime(copy self)
     borrow {
       Builtin.dereferenceBorrow(builtin)
     }

--- a/test/abi/macOS/arm64/stdlib.swift
+++ b/test/abi/macOS/arm64/stdlib.swift
@@ -1262,7 +1262,7 @@ Added: __ZN5swift26getResilientMetadataBoundsEPKNS_21TargetClassDescriptorINS_9I
 // Ref
 Added: _$ss3RefVMa
 Added: _$ss3RefVMn
-Added: _$ss3RefVsRi_zrlE7builtinxBWvg
+Added: _$ss3RefVsRi_zRi0_zrlE7builtinxBWvg
 
 // MutableRef
 Added: _$ss10MutableRefVMa

--- a/test/abi/macOS/x86_64/stdlib.swift
+++ b/test/abi/macOS/x86_64/stdlib.swift
@@ -1257,7 +1257,7 @@ Added: __ZN5swift26getResilientMetadataBoundsEPKNS_21TargetClassDescriptorINS_9I
 // Ref
 Added: _$ss3RefVMa
 Added: _$ss3RefVMn
-Added: _$ss3RefVsRi_zrlE7builtinxBWvg
+Added: _$ss3RefVsRi_zRi0_zrlE7builtinxBWvg
 
 // MutableRef
 Added: _$ss10MutableRefVMa

--- a/test/stdlib/Noncopyables/RefMutableRef.swift
+++ b/test/stdlib/Noncopyables/RefMutableRef.swift
@@ -83,6 +83,33 @@ suite.test("Ref") {
 }
 
 if #available(SwiftStdlib 6.4, *) {
+suite.test("Ref inside a Ref") {
+  var foo = Foo()
+
+  do {
+    let borrowFoo = Ref(foo)
+    let borrowBorrowFoo = Ref(borrowFoo)
+
+    expectEqual(borrowBorrowFoo.value.value.x, 128)
+  }
+
+  foo.bar()
+
+  let a = Atomic(123)
+  let ba = BorrowingAtomic(a)
+  let borrowBa = Ref(ba)
+  var int = borrowBa.value.load()
+
+  expectEqual(int, 123)
+
+  borrowBa.value.store(321)
+  int = borrowBa.value.load()
+
+  expectEqual(int, 321)
+}
+}
+
+if #available(SwiftStdlib 6.4, *) {
 suite.test("MutableRef") {
   var x: _? = 123
 
@@ -106,6 +133,40 @@ suite.test("MutableRef") {
   expectEqual(b.value, 64)
 
   expectEqual(a, 64)
+}
+}
+
+if #available(SwiftStdlib 6.4, *) {
+suite.test("MutableRef inside a Ref") {
+  var x: _? = 123
+
+  var y = x.mutate()!
+
+  do {
+    let borrowY = Ref(y)
+
+    // The following correctly doesn't compile. We cannot mutate a value within
+    // a `MutableRef` if it is behind a `Ref`.
+    // borrowY.value.value &+= 321
+
+    // But we should be able to read its value though.
+    expectEqual(borrowY.value.value, 123)
+  }
+
+  var a: Int? = nil
+
+  var b = a.insert(128)
+
+  do {
+    let borrowB = Ref(b)
+
+    expectEqual(borrowB.value.value, 128)
+
+    // Again, the following shouldn't compile (it doesn't).
+    // borrowB.value.value &-= 64
+  }
+
+  expectEqual(a, 128)
 }
 }
 


### PR DESCRIPTION
- **Explanation**: https://github.com/swiftlang/swift/pull/88970 unblocked the necessary pieces in the compiler to allow `Ref` to support `~Escapable` elements.
- **Scope**: `Ref`
- **Issues**: rdar://175961540
- **Original PRs**: https://github.com/swiftlang/swift/pull/88990
- **Risk**: Low. If there are any existing clients of `Ref` they were unable to put `~Escapable` referents in them which was a compiler error. This lifts that restriction.
- **Testing**: New tests were added to exercise this functionality and tested in CI.
- **Reviewers**: @airspeedswift @atrick 