### PR TITLE
Fix AllocBoxToStack to recognize mark_dependence

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/AllocBoxToStack.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/AllocBoxToStack.swift
@@ -146,7 +146,13 @@ private func canPromote(allocBox: AllocBoxInst) -> (promotableArguments: [Functi
       // Note: all instructions which are handled here must also be handled in `FunctionSpecializations.rewriteUses`!
       switch use.instruction {
       case is StrongRetainInst, is StrongReleaseInst, is ProjectBoxInst, is DestroyValueInst,
-           is EndBorrowInst, is DebugValueInst, is DeallocStackInst:
+           is EndBorrowInst, is DebugValueInst, is DeallocStackInst, is MarkDependenceAddrInst:
+        break
+      case let mdi as MarkDependenceInst:
+        if mdi.valueOperand == use {
+          worklist.pushIfNotVisited(mdi)
+        }
+        // If the use is the base operand, it can be ignored.
         break
       case let deallocBox as DeallocBoxInst where deallocBox.parentFunction == allocBox.parentFunction:
         break
@@ -224,6 +230,21 @@ private struct FunctionSpecializations {
       switch user {
       case is StrongRetainInst, is StrongReleaseInst, is DestroyValueInst, is EndBorrowInst, is DeallocBoxInst:
         context.erase(instruction: user)
+      case let mdi as MarkDependenceInst:
+        if mdi.valueOperand == use {
+          convert(markDependenceInst: mdi, address: stack, context)
+          mdi.replace(with: box, context)
+          // Users of the original mark_dependence will be replaced with the stack address in subsequent iterations.
+          break
+        }
+        // Replace the MarkDependenceInst base operand, which can be either a value or an address.
+        mdi.baseOperand.set(to: stack, context)
+        break
+      case let mdai as MarkDependenceAddrInst:
+        assert(mdai.baseOperand == use)
+        // Replace the MarkDependenceAddrInst base operand, which can be either a value or an address.
+        mdai.baseOperand.set(to: stack, context)
+        break
       case let projectBox as ProjectBoxInst:
         assert(projectBox.fieldIndex == 0, "only single-field boxes are handled")
         if isMandatory {
@@ -243,6 +264,13 @@ private struct FunctionSpecializations {
         fatalError("unhandled box user")
       }
     }
+  }
+
+  /// Replace `mark_dependence` with `mark_dependence_addr`
+  private func convert(markDependenceInst: MarkDependenceInst, address: Value, _ context: FunctionPassContext) {
+    let builder = Builder(before: markDependenceInst, context)
+    _ = builder.createMarkDependenceAddr(value: address, base: markDependenceInst.base,
+                                         kind: markDependenceInst.dependenceKind)
   }
 
   /// Replaces `apply` with a new apply of the specialized callee.

--- a/test/SILOptimizer/allocbox_to_stack_dependence.sil
+++ b/test/SILOptimizer/allocbox_to_stack_dependence.sil
@@ -1,0 +1,127 @@
+// RUN: %target-sil-opt -sil-print-types %s -mandatory-allocbox-to-stack -enable-experimental-feature Lifetimes | %FileCheck %s
+
+// REQUIRES: swift_feature_Lifetimes
+
+sil_stage raw
+
+import Builtin
+import Swift
+
+struct A {}
+
+struct B: ~Escapable {}
+
+sil @makeB : $@convention(thin) (@in_guaranteed A) -> @lifetime(borrow 0) @owned B
+sil @useB : $@convention(thin) (@guaranteed B) -> ()
+sil @makeBAddress : $@convention(thin) (@in_guaranteed A) -> @lifetime(borrow 0) @out B
+sil @useBAddress : $@convention(thin) (@in_guaranteed B) -> ()
+sil @makeA : $@convention(thin) () -> @owned A
+sil @useA : $@convention(thin) (@in_guaranteed B) -> ()
+sil @makeAAddress : $@convention(thin) () -> @out A
+
+// CHECK-LABEL: sil hidden [ossa] @testDependenceBaseToValue :
+// CHECK:   [[STK:%.*]] = alloc_stack
+// CHECK:   [[B:%.*]] = apply
+// CHECK:   [[MD:%.*]] = mark_dependence [unresolved] [[B]] : $B on [[STK]] : $*A
+// CHECK:   apply {{.*}}([[MD]])
+// CHECK-LABEL: } // end sil function 'testDependenceBaseToValue'
+sil hidden [ossa] @testDependenceBaseToValue : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_box ${ let A }, let
+  %1 = begin_borrow [lexical] [var_decl] %0
+  %2 = project_box %1, 0
+  %a = struct $A ()
+  store %a to [trivial] %2
+  %f = function_ref @makeB : $@convention(thin) (@in_guaranteed A) -> @lifetime(borrow 0) @owned B
+  %b = apply %f(%2) : $@convention(thin) (@in_guaranteed A) -> @lifetime(borrow 0) @owned B
+  %md = mark_dependence [unresolved] %b on %1
+  %g = function_ref @useB : $@convention(thin) (@guaranteed B) -> ()
+  %r1 = apply %g(%md) : $@convention(thin) (@guaranteed B) -> ()
+  destroy_value %md
+  end_borrow %1
+  destroy_value %0
+  %r = tuple ()
+  return %r
+}
+
+// CHECK-LABEL: sil hidden [ossa] @testDependenceBaseToAddress :
+// CHECK:   [[STK:%.*]] = alloc_stack {{.*}} $A
+// CHECK:   [[OUT:%.*]] = alloc_stack $B
+// CHECK:   apply {{.*}}([[OUT]], [[STK]])
+// CHECK:   mark_dependence_addr [unresolved] [[OUT]] : $*B on [[STK]] : $*A
+// CHECK:   apply {{.*}}([[OUT]])
+// CHECK-LABEL: } // end sil function 'testDependenceBaseToAddress'
+sil hidden [ossa] @testDependenceBaseToAddress : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_box ${ let A }, let
+  %1 = begin_borrow [lexical] [var_decl] %0
+  %2 = project_box %1, 0
+  %a = struct $A ()
+  store %a to [trivial] %2
+  %out = alloc_stack $B
+  %f = function_ref @makeBAddress : $@convention(thin) (@in_guaranteed A) -> @lifetime(borrow 0) @out B
+  %c = apply %f(%out, %2) : $@convention(thin) (@in_guaranteed A) -> @lifetime(borrow 0) @out B
+  mark_dependence_addr [unresolved] %out on %1
+  %g = function_ref @useBAddress : $@convention(thin) (@in_guaranteed B) -> ()
+  %r1 = apply %g(%out) : $@convention(thin) (@in_guaranteed B) -> ()
+  destroy_addr %out
+  dealloc_stack %out
+  end_borrow %1
+  destroy_value %0
+  %r = tuple ()
+  return %r
+}
+
+// CHECK-LABEL: sil hidden [ossa] @testDependenceValueOnValue :
+// CHECK:   [[STK:%.*]] = alloc_stack {{.*}} $B
+// CHECK:   [[A:%.*]] = apply
+// CHECK:   mark_dependence_addr [unresolved] [[STK]] : $*B on [[A]] : $A
+// CHECK:   apply {{.*}}([[STK]])
+// CHECK-LABEL: } // end sil function 'testDependenceValueOnValue'
+sil hidden [ossa] @testDependenceValueOnValue : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_box ${ let B }, let
+  %1 = begin_borrow [lexical] [var_decl] %0
+  %2 = project_box %1, 0
+  %b = struct $B ()
+  store %b to [trivial] %2
+  %f = function_ref @makeA : $@convention(thin) () -> @owned A
+  %a = apply %f() : $@convention(thin) () -> @owned A
+  %md = mark_dependence [unresolved] %1 on %a
+  %pb = project_box %md, 0
+  %g = function_ref @useA : $@convention(thin) (@in_guaranteed B) -> ()
+  %r1 = apply %g(%pb) : $@convention(thin) (@in_guaranteed B) -> ()
+  end_borrow %1
+  destroy_value %0
+  %r = tuple ()
+  return %r
+}
+
+// CHECK-LABEL: sil hidden [ossa] @testDependenceValueOnAddress :
+// CHECK:   [[STK:%.*]] = alloc_stack {{.*}} $B
+// CHECK:   [[AOUT:%.*]] = alloc_stack $A
+// CHECK:   apply {{.*}}([[AOUT]])
+// CHECK:   mark_dependence_addr [unresolved] [[STK]] : $*B on [[AOUT]] : $*A
+// CHECK:   apply {{.*}}([[STK]])
+// CHECK-LABEL: } // end sil function 'testDependenceValueOnAddress'
+sil hidden [ossa] @testDependenceValueOnAddress : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_box ${ let B }, let
+  %1 = begin_borrow [lexical] [var_decl] %0
+  %2 = project_box %1, 0
+  %b = struct $B ()
+  store %b to [trivial] %2
+  %aout = alloc_stack $A
+  %f = function_ref @makeAAddress : $@convention(thin) () -> @out A
+  %c = apply %f(%aout) : $@convention(thin) () -> @out A
+  %md = mark_dependence [unresolved] %1 on %aout
+  %pb = project_box %md, 0
+  %g = function_ref @useA : $@convention(thin) (@in_guaranteed B) -> ()
+  %r1 = apply %g(%pb) : $@convention(thin) (@in_guaranteed B) -> ()
+  end_borrow %1
+  destroy_addr %aout
+  dealloc_stack %aout
+  destroy_value %0
+  %r = tuple ()
+  return %r
+}

--- a/test/SILOptimizer/lifetime_dependence/verify_diagnostics.swift
+++ b/test/SILOptimizer/lifetime_dependence/verify_diagnostics.swift
@@ -231,6 +231,26 @@ public struct InlineInt: BitwiseCopyable {
   }
 }
 
+// Noncopyable, vends nonescapable P.
+struct NCParent: ~Copyable {
+    var view: NEView { NEView(parent: self) }
+}
+
+// Nonescapable, bound to O.
+struct NEView: ~Escapable {
+    @_lifetime(borrow parent)
+    init(parent: borrowing NCParent) {}
+
+    func getNC() -> NC { NC(x: 0) }
+}
+
+// Noncopyable, but escapable. You get one from a non-escapable, but then not lifetime-bound.
+struct NC: ~Copyable {
+  x: Int
+}
+
+func consumeParent(_: consuming NCParent) {}
+
 // =============================================================================
 // Indirect ~Escapable results
 // =============================================================================
@@ -539,4 +559,17 @@ struct TestBuiltinBorrowInit<T: ~Copyable & ~Escapable>: ~Escapable {
   init(_ target: borrowing T) {
     self.ref = Builtin.makeBorrow(target)
   }
+}
+
+// =============================================================================
+// Move-only consume lifetime
+// =============================================================================
+
+// consumeParent should end the lifetime of the parent and the view. This requires AllocBoxToStack on parent so that the
+// move-checker can shrink its lifetime.
+func testNonCopyableParent() {
+  let parent = NCParent()
+  let nc = parent.view.getNC()
+  _ = consumeParent(parent)
+  _ = consume nc
 }


### PR DESCRIPTION
This supports non-Copyable containers that vend a non-Escapable view such as a Span:

  let parent = NonCopyableParent()
  let value = parent.view.getNonCopyableValue()
  _ = consumeParent(parent)
  _ = consume value

Without this, the move-checker completely fails to analyze the lifetime of 'parent' and reports a non-Copyable violation:

ERROR: noncopyable 'parent' cannot be consumed when captured by an escaping closure or borrowed by a non-Escapable type

Fixes rdar://171519871 (Cannot consume noncopyable because value still borrowed by unreachable nonescapable)
