### PR TITLE
[gardening] eliminate an unnecessary-unsafe warning

### DIFF
--- a/stdlib/public/core/StringStorageBridge.swift
+++ b/stdlib/public/core/StringStorageBridge.swift
@@ -835,7 +835,7 @@ fileprivate func isEqual(
      */
     let chunkSize = Swift.min(64, remainingOtherByteCount)
     // nil = keep looping; .some(equal) = terminate with that equality result
-    let chunkResult: Bool? = unsafe withUnsafeTemporaryAllocation(
+    let chunkResult: Bool? = withUnsafeTemporaryAllocation(
       of: UInt8.self,
       capacity: chunkSize
     ) { tmpBuffer in


### PR DESCRIPTION
We recently adjusted the unsafe annotations for many closure-taking functions, including `withUnsafeTemporaryAllocation`. This unsafe keyword was merged in a PR that ran concurrently with the annotation adjustment. Removing it eliminates a warning when building the standard library.