### PR TITLE
[Sema] Tailor for-in loop diagnostics for unhandled throws

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5688,9 +5688,6 @@ NOTE(because_rethrows_default_argument_throws,none,
 NOTE(because_rethrows_conformance_throws,none,
      "call is to 'rethrows' function, but a conformance has a throwing witness", ())
 
-ERROR(for_throw_without_try,none,
-      "for-in loop can throw, but is not marked with 'try'", ())
-
 ERROR(throwing_call_in_nonthrowing_autoclosure,none,
       "%0 can throw, but it is executed in a non-throwing "
       "autoclosure",(StringRef))
@@ -5715,6 +5712,18 @@ ERROR(throw_in_defer_body,none,
       "errors cannot be thrown out of a defer body", ())
 ERROR(throwing_op_in_defer_body,none,
       "%0 can throw, but errors cannot be thrown out of a defer body", (StringRef))
+ERROR(for_each_throwing_without_try,none,
+      "'for-in' loop can throw, but is not marked with 'try'", ())
+ERROR(for_each_throwing_unhandled,none,
+      "errors thrown from 'for-in' loop are not handled", ())
+ERROR(for_each_throwing_in_rethrows_function,none,
+      "errors thrown from 'for-in' loop are not handled; a function declared "
+      "'rethrows' may only throw if its parameter does", ())
+ERROR(for_each_throwing_in_nonexhaustive_catch,none,
+      "errors thrown from 'for-in' loop are not handled because the "
+      "enclosing catch is not exhaustive", ())
+ERROR(for_each_throwing_in_defer_body,none,
+      "errors thrown from 'for-in' loop cannot be thrown out of a defer body", ())
 ERROR(async_defer_in_non_async_context,none,
       "'async' defer must appear within an 'async' context", ())
 

--- a/lib/Sema/TypeCheckEffects.cpp
+++ b/lib/Sema/TypeCheckEffects.cpp
@@ -792,7 +792,11 @@ public:
 
     /// The function accesses an unconditionally throws/async property.
     PropertyAccess,
-    SubscriptAccess
+    SubscriptAccess,
+
+    /// A 'for await' statement's underlying iterator can throw or
+    /// is async.
+    ForEachAwait
   };
 
   static StringRef kindToString(Kind k) {
@@ -811,6 +815,8 @@ public:
         return "ByConformance";
       case Kind::AsyncLet:
         return "AsyncLet";
+      case Kind::ForEachAwait:
+      return "ForEachAwait";
     }
   }
 
@@ -842,6 +848,9 @@ public:
   }
   static PotentialEffectReason forAsyncLet() {
     return PotentialEffectReason(Kind::AsyncLet);
+  }
+  static PotentialEffectReason forForEachAwait() {
+    return PotentialEffectReason(Kind::ForEachAwait);
   }
 
   Kind getKind() const { return TheKind; }
@@ -3143,6 +3152,7 @@ public:
     case PotentialEffectReason::Kind::PropertyAccess:
     case PotentialEffectReason::Kind::SubscriptAccess:
     case PotentialEffectReason::Kind::AsyncLet:
+    case PotentialEffectReason::Kind::ForEachAwait:
       // Already fully diagnosed.
       return;
     case PotentialEffectReason::Kind::ByClosure:
@@ -3173,6 +3183,9 @@ public:
       return "property access";
     case PotentialEffectReason::Kind::SubscriptAccess:
       return "subscript access";
+
+    case PotentialEffectReason::Kind::ForEachAwait:
+      return "for-in loop";
     }
   }
 
@@ -3278,9 +3291,53 @@ public:
   void diagnoseUnhandledThrowSite(DiagnosticEngine &Diags, ASTNode E,
                                   bool isTryCovered,
                                   const PotentialEffectReason &reason) {
+    bool isForEach =
+      reason.getKind() == PotentialEffectReason::Kind::ForEachAwait;
+
+    // Helper for emitting a for-each-statement-level diagnostic with
+    // the loop-tailored fix-it (insert ` try` after `for`).
+    auto emitForEach = [&](Diag<> diagID) {
+      auto *forStmt = cast<ForEachStmt>(cast<Stmt *>(E));
+      auto diag = Diags.diagnose(forStmt->getForLoc(), diagID);
+      if (!isTryCovered)
+        diag.fixItInsertAfter(forStmt->getForLoc(), " try");
+    };
+
     switch (getKind()) {
     case Kind::PotentiallyHandled:
+      if (isDeferBody()) {
+        if (isForEach) {
+          emitForEach(diag::for_each_throwing_in_defer_body);
+          return;
+        }
+        Diags.diagnose(E.getStartLoc(), diag::throwing_op_in_defer_body,
+                       getEffectSourceName(reason));
+        return;
+      }
+
+      // try is covered and the throw doesn't require special handling.
+      if (isTryCovered &&
+          !reason.hasPolymorphicEffect() &&
+          !hasPolymorphicEffect(EffectKind::Throws) &&
+          !isAutoClosure()) {
+        if (isForEach) {
+          auto *forStmt = cast<ForEachStmt>(cast<Stmt *>(E));
+          Diags.diagnose(forStmt->getTryLoc(),
+                        IsNonExhaustiveCatch
+                          ? diag::try_unhandled_in_nonexhaustive_catch
+                          : diag::try_unhandled);
+          return;
+        }
+        DiagnoseErrorOnTry = true;
+        return;
+      }
+
       if (IsNonExhaustiveCatch) {
+        if (isForEach) {
+          emitForEach(diag::for_each_throwing_in_nonexhaustive_catch);
+          maybeAddRethrowsNote(Diags, E.getStartLoc(), reason);
+          return;
+        }
         diagnoseThrowInLegalContext(Diags, E, isTryCovered, reason,
                                     diag::throwing_call_in_nonexhaustive_catch,
                             diag::tryless_throwing_call_in_nonexhaustive_catch);
@@ -3294,19 +3351,22 @@ public:
         return;
       }
 
-      if (isDeferBody()) {
-        Diags.diagnose(E.getStartLoc(), diag::throwing_op_in_defer_body,
-                       getEffectSourceName(reason));
-        return;
-      }
-
       if (hasPolymorphicEffect(EffectKind::Throws)) {
+        if (isForEach) {
+          emitForEach(diag::for_each_throwing_in_rethrows_function);
+          maybeAddRethrowsNote(Diags, E.getStartLoc(), reason);
+          return;
+        }
         diagnoseThrowInLegalContext(Diags, E, isTryCovered, reason,
                                     diag::throwing_call_in_rethrows_function,
                             diag::tryless_throwing_call_in_rethrows_function);
         return;
       }
 
+      if (isForEach) {
+        emitForEach(diag::for_each_throwing_unhandled);
+        return;
+      }
       diagnoseThrowInLegalContext(Diags, E, isTryCovered, reason,
                                   diag::throwing_call_unhandled,
                                   diag::tryless_throwing_call_unhandled);
@@ -3409,6 +3469,7 @@ public:
     case PotentialEffectReason::Kind::ByDefaultClosure:
     case PotentialEffectReason::Kind::ByConformance:
     case PotentialEffectReason::Kind::Apply:
+    case PotentialEffectReason::Kind::ForEachAwait:
       return 1;
 
     case PotentialEffectReason::Kind::AsyncLet:
@@ -3585,6 +3646,14 @@ class CheckEffectsCoverage : public EffectsHandlingWalker<CheckEffectsCoverage> 
 
       /// Does an enclosing 'if' or 'switch' expr have an 'unsafe'?
       StmtExprCoversUnsafe = 0x4000,
+
+      /// Are we walking the desugared body of a `ForEachStmt`? When 
+      /// set, throwing diagnostics on synthesized iterator calls are 
+      /// suppressed. The for-each-statement-level diagnostic (emitted 
+      /// from `checkForEach()`) provides loop-tailored wording instead.
+      /// Async, unsafe, and try-coverage diagnostics on those 
+      /// synthesized calls continue to fire normally.
+      InForEachDesugar = 0x8000,
     };
   private:
     unsigned Bits;
@@ -3794,6 +3863,7 @@ class CheckEffectsCoverage : public EffectsHandlingWalker<CheckEffectsCoverage> 
       Self.Flags.set(ContextFlags::IsTryCovered);
       Self.Flags.set(ContextFlags::IsAsyncCovered);
       Self.Flags.set(ContextFlags::IsUnsafeCovered);
+      Self.Flags.set(ContextFlags::InForEachDesugar);
     }
 
     void refineLocalContext(Context newContext) {
@@ -4463,6 +4533,20 @@ private:
       bool isTryCovered =
         (!requiresTry || Flags.has(ContextFlags::IsTryCovered) ||
          Flags.has(ContextFlags::InAsyncLet));
+
+      // Inside the desugared body of a `for-in` loop, suppress throwing
+      // diagnostics on synthesized iterator calls. The for-each-statement-
+      // level diagnostic from `checkForEach` provides loop-tailored wording.
+      // We still compute and return the thrown error destination so SILGen
+      // and IRGen see the correct typed-throws bookkeeping.
+      if (Flags.has(ContextFlags::InForEachDesugar)) {
+        if (CurContext.handlesThrows(throwsKind) && isTryCovered) {
+          return checkThrownErrorType(
+              E.getStartLoc(), classification.getThrownError());
+        }
+        break;
+      }
+
       if (!CurContext.handlesThrows(throwsKind)) {
         CurContext.diagnoseUnhandledThrowSite(Ctx.Diags, E, isTryCovered,
                                               classification.getThrowReason());
@@ -4651,15 +4735,12 @@ private:
       if (throwsKind != ConditionalEffectKind::None)
         Flags.set(ContextFlags::HasAnyThrowSite);
 
-      // TODO: We ought to have a custom throws reason for this and unify the
-      // diagnostic handling (https://github.com/swiftlang/swift/issues/89124).
       auto tryLoc = S->getTryLoc();
       if (!CurContext.handlesThrows(throwsKind)) {
-        CurContext.diagnoseUnhandledThrowSite(Ctx.Diags, S, tryLoc.isValid(),
-                                              classification.getThrowReason());
-        CurContext.diagnoseUnhandledTry(Ctx.Diags, tryLoc);
-      } else if (!tryLoc) {
-        Ctx.Diags.diagnose(S->getForLoc(), diag::for_throw_without_try)
+        CurContext.diagnoseUnhandledThrowSite(
+            Ctx.Diags, S, tryLoc.isValid(), PotentialEffectReason::forForEachAwait());
+      } else if (!tryLoc.isValid()) {
+        Ctx.Diags.diagnose(S->getForLoc(), diag::for_each_throwing_without_try)
           .fixItInsertAfter(S->getForLoc(), " try");
       }
     }
@@ -4856,7 +4937,8 @@ private:
         case PotentialEffectReason::Kind::ByClosure:
         case PotentialEffectReason::Kind::ByDefaultClosure:
         case PotentialEffectReason::Kind::ByConformance:
-        case PotentialEffectReason::Kind::Apply: {
+        case PotentialEffectReason::Kind::Apply:
+        case PotentialEffectReason::Kind::ForEachAwait: {
          if (auto autoclosure = dyn_cast<AutoClosureExpr>(anchor)) {
            switch(autoclosure->getThunkKind()) {
              case AutoClosureExpr::Kind::None:
@@ -4972,6 +5054,7 @@ private:
     case PotentialEffectReason::Kind::ByClosure:
     case PotentialEffectReason::Kind::ByDefaultClosure:
     case PotentialEffectReason::Kind::ByConformance:
+    case PotentialEffectReason::Kind::ForEachAwait:
       break;
     }
 

--- a/test/Concurrency/async_sequence_syntax.swift
+++ b/test/Concurrency/async_sequence_syntax.swift
@@ -20,14 +20,13 @@ func missingThrows<T : AsyncSequence>(_ seq: T) async {
 @available(SwiftStdlib 5.1, *)
 func missingTry<T : AsyncSequence>(_ seq: T) async throws {
   for await _ in seq { }
-  // expected-error@-1 {{for-in loop can throw, but is not marked with 'try'}} {{6-6= try}}
+  // expected-error@-1 {{'for-in' loop can throw, but is not marked with 'try'}} {{6-6= try}}
 }
 
 @available(SwiftStdlib 5.1, *)
 func missingTryAndThrows<T : AsyncSequence>(_ seq: T) async {
-  // FIXME: Improve this diagnostic
   for await _ in seq { }
-  // expected-error@-1 {{call can throw, but it is not marked with 'try' and the error is not handled}}
+  // expected-error@-1 {{errors thrown from 'for-in' loop are not handled}} {{6-6= try}}
 }
 
 @available(SwiftStdlib 5.1, *)
@@ -46,7 +45,7 @@ func missingThrowingInBlock<T : AsyncSequence>(_ seq: T) {
 func missingTryInBlock<T : AsyncSequence>(_ seq: T) { 
   executeAsync { 
     for await _ in seq { } 
-    // expected-error@-1{{call can throw, but it is not marked with 'try' and the error is not handled}}
+    // expected-error@-1{{errors thrown from 'for-in' loop are not handled}}
   }
 }
 

--- a/test/Concurrency/for_each_throwing_diagnostics.swift
+++ b/test/Concurrency/for_each_throwing_diagnostics.swift
@@ -1,0 +1,76 @@
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple %s -emit-sil -o /dev/null -verify
+
+// REQUIRES: concurrency
+// REQUIRES: asserts
+
+struct MyError: Error {
+  let code: Int
+}
+
+@available(SwiftStdlib 5.1, *)
+struct ThrowingSeq: AsyncSequence, AsyncIteratorProtocol {
+  typealias Element = Int
+  mutating func next() async throws -> Int? { nil }
+  func makeAsyncIterator() -> Self { self }
+}
+
+@available(SwiftStdlib 5.1, *)
+struct TypedThrowingSeq: AsyncSequence, AsyncIteratorProtocol {
+  typealias Element = Int
+  typealias Failure = MyError
+  mutating func next() async throws(MyError) -> Int? { nil }
+  func makeAsyncIterator() -> Self { self }
+}
+
+// Default case: 'for await' in a non-throwing async function.
+@available(SwiftStdlib 5.1, *)
+func defaultCase(_ seq: ThrowingSeq) async {
+  for await _ in seq { }
+  // expected-error@-1 {{errors thrown from 'for-in' loop are not handled}} {{6-6= try}}
+}
+
+// 'try' is already present but the context cannot handle throws.
+@available(SwiftStdlib 5.1, *)
+func tryButNoThrows(_ seq: ThrowingSeq) async {
+  for try await _ in seq { }
+  // expected-error@-1 {{errors thrown from here are not handled}}
+}
+
+@available(SwiftStdlib 5.1, *)
+func properlyHandled(_ seq: ThrowingSeq) async throws {
+  for try await _ in seq { } // no diagnostic
+}
+
+@available(SwiftStdlib 5.1, *)
+func rethrowsContext(
+  _ seq: ThrowingSeq, _ body: () throws -> Void
+) async rethrows {
+  try body()
+  for await _ in seq { }
+  // expected-error@-1 {{errors thrown from 'for-in' loop are not handled; a function declared 'rethrows' may only throw if its parameter does}} {{6-6= try}}
+}
+
+@available(SwiftStdlib 5.1, *)
+func nonExhaustiveCatch(_ seq: TypedThrowingSeq) async {
+  do {
+    for await _ in seq { }
+    // expected-error@-1 {{errors thrown from 'for-in' loop are not handled because the enclosing catch is not exhaustive}} {{8-8= try}}
+  } catch let e where e.code == 0 {}
+}
+
+// 'defer' body in an async context.
+@available(SwiftStdlib 5.1, *)
+func deferContext(_ seq: ThrowingSeq) async {
+  defer {
+    for await _ in seq { }
+    // expected-error@-1 {{errors thrown from 'for-in' loop cannot be thrown out of a defer body}}
+  }
+  _ = seq
+}
+
+// 'try' missing in a context that handles throws.
+@available(SwiftStdlib 5.1, *)
+func missingTryHandled(_ seq: ThrowingSeq) async throws {
+  for await _ in seq { }
+  // expected-error@-1 {{'for-in' loop can throw, but is not marked with 'try'}} {{6-6= try}}
+}


### PR DESCRIPTION
Closes #89124.

Swift currently emits "call can throw, but it is not marked with 'try' and the error is not handled" for an unhandled-throw in a `for await` loop. The "call" wording leaks an implementation detail: for-in loops are desugared into calls to `next()`/`makeAsyncIterator()`, and the generic throwing-call diagnostic fires from inside the desugared-statement walk in `CheckEffectsCoverage`.

This PR adds loop-tailored diagnostics for the four reachable context branches (default, rethrows function, non-exhaustive catch, defer body), with fix-its that produce `for try await x in xs`.

## Testing

Added `test/Concurrency/for_each_throwing_diagnostics.swift`, and updated one expectation in `test/Concurrency/async_sequence_syntax.swift`.

The full test suite passes locally (no new failures relative to a pre-change baseline).