### PR TITLE
[stdlib] Simplify count(where:) implementation

### DIFF
--- a/stdlib/public/core/SequenceAlgorithms.swift
+++ b/stdlib/public/core/SequenceAlgorithms.swift
@@ -609,8 +609,8 @@ extension Sequence {
     where predicate: (Element) throws(E) -> Bool
   ) throws(E) -> Int {
     var count = 0
-    for e in self {
-      count += try predicate(e) ? 1 : 0
+    for e in self where try predicate(e) {
+      count += 1
     }
     return count
   }


### PR DESCRIPTION
## Summary

This simplifies the implementation of `Sequence.count(where:)` by replacing ternary accumulation with a `for` loop `where` clause.

Before:

```swift
for e in self {
  count += try predicate(e) ? 1 : 0
}
```

After:

```swift
for e in self where try predicate(e) {
  count += 1
}
```

Behavior is unchanged, but the control flow is clearer and avoids adding `0` for non-matching elements.

Fixes #75675.

## Testing

Ran a standalone equivalence check with the system Swift 6.2 toolchain covering matching elements, no matches, all matches, an empty sequence, and typed-throw propagation.

I did not run the full Swift stdlib validation test suite locally because it requires a full Swift toolchain build.