### PR TITLE
AST: Fix availability scopes for `if #unavailable` else branches

### DIFF
--- a/lib/AST/AvailabilityScopeBuilder.cpp
+++ b/lib/AST/AvailabilityScopeBuilder.cpp
@@ -1001,6 +1001,7 @@ private:
 
     // Tracks if we're refining for availability or unavailability.
     std::optional<bool> isUnavailability = std::nullopt;
+    bool hasAnyNonAvailabilityCondition = false;
 
     for (StmtConditionElement element : cond) {
       auto *currentScope = getCurrentScope();
@@ -1008,10 +1009,7 @@ private:
 
       // If the element is not a condition, walk it in the current scope.
       if (element.getKind() != StmtConditionElement::CK_Availability) {
-        // Assume any condition element that is not a #available() can
-        // potentially be false, so conservatively make the false flow's
-        // refinement undefined since there is nothing we can prove about it.
-        falseFlowBuilder.setUndefined();
+        hasAnyNonAvailabilityCondition = true;
         element.walk(*this);
         continue;
       }
@@ -1137,44 +1135,53 @@ private:
       ++nestedCount;
     }
 
+    // Determine the availability context for the branch where the availability
+    // conditions hold. If there are any scopes on the stack, it will be the
+    // availability context for the scope at the top. Otherwise, no distinct
+    // context is introduced by the availability conditions.
+    std::optional<AvailabilityContext> trueRefinement = std::nullopt;
+    if (nestedCount > 0)
+      trueRefinement = getCurrentScope()->getAvailabilityContext();
+
+    // Pop the stack.
+    while (nestedCount-- > 0)
+      ContextStack.pop_back();
+
+    DEBUG_ASSERT(getCurrentScope() == startingScope);
+
+    // Determine availability for the branch where the availability conditions
+    // do not hold.
     auto startingContext = startingScope->getAvailabilityContext();
     auto falseFlowContext = falseFlowBuilder.constrainContext(startingContext);
 
-    // The version range for the false branch should never have any versions
-    // that weren't possible when the condition started evaluating.
+    // The availability context for the false flow should either be the same
+    // as the starting context or it should refine it. If not, there's a logic
+    // error.
     DEBUG_ASSERT(falseFlowContext.isContainedIn(startingContext));
 
     // If the starting availability context is not completely contained in the
     // false flow context then it must be the case that false flow context
-    // is strictly smaller than the starting context (because the false flow
-    // context *is* contained in the starting context), so we should introduce a
-    // new availability scope for the false flow.
+    // is strictly contained in the starting context. Introduce a new
+    // availability scope for the false flow in that case.
     std::optional<AvailabilityContext> falseRefinement = std::nullopt;
-    if (!startingScope->getAvailabilityContext().isContainedIn(
-            falseFlowContext)) {
+    if (!startingContext.isContainedIn(falseFlowContext))
       falseRefinement = falseFlowContext;
-    }
 
-    auto makeResult =
-        [isUnavailability](std::optional<AvailabilityContext> trueRefinement,
-                           std::optional<AvailabilityContext> falseRefinement) {
-          if (isUnavailability.has_value() && *isUnavailability) {
-            // If this is an unavailability check, invert the result.
-            return std::make_pair(falseRefinement, trueRefinement);
-          }
-          return std::make_pair(trueRefinement, falseRefinement);
-        };
+    // For #unavailable, the then/else semantics are inverted: the then branch
+    // executes when the availability condition is NOT met, and the else
+    // executes it IS met. So swap the refinements.
+    auto thenRefinement = trueRefinement;
+    auto elseRefinement = falseRefinement;
+    if (isUnavailability && *isUnavailability)
+      std::swap(thenRefinement, elseRefinement);
 
-    if (nestedCount == 0)
-      return makeResult(std::nullopt, falseRefinement);
+    // If there were any non-availability conditions in the if statement then
+    // the else branch cannot be refined at all because it can be reached
+    // regardless of any availability condition.
+    if (hasAnyNonAvailabilityCondition)
+      elseRefinement = std::nullopt;
 
-    AvailabilityScope *nestedScope = getCurrentScope();
-    while (nestedCount-- > 0)
-      ContextStack.pop_back();
-
-    assert(getCurrentScope() == startingScope);
-
-    return makeResult(nestedScope->getAvailabilityContext(), falseRefinement);
+    return {thenRefinement, elseRefinement};
   }
 
   /// Return the best active spec for the target platform or nullptr if no

--- a/test/Availability/availability_custom_domains.swift
+++ b/test/Availability/availability_custom_domains.swift
@@ -64,7 +64,7 @@ func testDeployment() { // expected-note 3 {{add '@available' attribute to enclo
 
 // FIXME: [availability] Test @inlinable functions.
 
-func testIfAvailable(_ truthy: Bool) { // expected-note 9 {{add '@available' attribute to enclosing global function}}
+func testIfAvailable(_ truthy: Bool) { // expected-note 11 {{add '@available' attribute to enclosing global function}}
   if #available(EnabledDomain) { // expected-note {{enclosing scope here}}
     availableInEnabledDomain()
     availableInAlwaysEnabledDomain()
@@ -139,6 +139,18 @@ func testIfAvailable(_ truthy: Bool) { // expected-note 9 {{add '@available' att
     unavailableInEnabledDomain()
   } else {
     availableInEnabledDomain()
+    unavailableInEnabledDomain() // expected-error {{'unavailableInEnabledDomain()' is unavailable}}
+  }
+
+  if #unavailable(EnabledDomain), truthy {
+    availableInEnabledDomain() // expected-error {{'availableInEnabledDomain()' is only available in EnabledDomain}}
+    // expected-note@-1 {{add 'if #available' version check}}
+    unavailableInEnabledDomain()
+  } else {
+    // In this branch, the state of EnabledDomain remains unknown since
+    // execution will reach here if "truthy" is false.
+    availableInEnabledDomain() // expected-error {{'availableInEnabledDomain()' is only available in EnabledDomain}}
+    // expected-note@-1 {{add 'if #available' version check}}
     unavailableInEnabledDomain() // expected-error {{'unavailableInEnabledDomain()' is unavailable}}
   }
 
@@ -242,8 +254,8 @@ func testAlwaysEnabledDomainUnavailable() {
 
 @available(*, unavailable)
 func testUniversallyUnavailable() {
-  // expected-note@-1 {{add '@available' attribute to enclosing global function}}{{243:1-1=@available(EnabledDomain)\n}}
-  // expected-note@-2 {{add '@available' attribute to enclosing global function}}{{243:1-1=@available(DynamicDomain)\n}}
+  // expected-note@-1 {{add '@available' attribute to enclosing global function}}{{-1:1-1=@available(EnabledDomain)\n}}
+  // expected-note@-2 {{add '@available' attribute to enclosing global function}}{{-1:1-1=@available(DynamicDomain)\n}}
   alwaysAvailable()
   // FIXME: [availability] Diagnostic consistency: potentially unavailable declaration shouldn't be diagnosed
   // in contexts that are unavailable to broader domains

--- a/test/Availability/availability_scopes.swift
+++ b/test/Availability/availability_scopes.swift
@@ -1,477 +1,84 @@
-// RUN: %target-swift-frontend -typecheck -dump-availability-scopes %s -target %target-cpu-apple-macos50 -swift-version 5 > %t.dump 2>&1
+// RUN: %target-swift-frontend -typecheck -dump-availability-scopes %s -swift-version 5 > %t.dump 2>&1
 // RUN: %FileCheck --strict-whitespace %s < %t.dump
 
-// REQUIRES: OS=macosx
+// CHECK: {{^}}(root
 
-// CHECK: {{^}}(root version=50
-
-// CHECK-NEXT: {{^}}  (decl version=51 decl=SomeClass
-// CHECK-NEXT: {{^}}    (decl version=52 decl=someMethod()
-// CHECK-NEXT: {{^}}      (decl version=53 decl=someInnerFunc()
-// CHECK-NEXT: {{^}}      (decl version=53 decl=InnerClass
-// CHECK-NEXT: {{^}}        (decl version=54 decl=innerClassMethod
-// CHECK-NEXT: {{^}}    (decl_implicit version=51 decl=someStaticProperty
-// CHECK-NEXT: {{^}}      (decl version=52 decl=someStaticProperty
-// CHECK-NEXT: {{^}}    (decl_implicit version=51 decl=someStaticPropertyInferredType
-// CHECK-NEXT: {{^}}      (decl version=52 decl=someStaticPropertyInferredType
-// CHECK-NEXT: {{^}}    (decl_implicit version=51 decl=multiPatternStaticPropertyA
-// CHECK-NEXT: {{^}}      (decl version=52 decl=multiPatternStaticPropertyA
-// CHECK-NEXT: {{^}}    (decl_implicit version=51 decl=someComputedProperty
-// CHECK-NEXT: {{^}}      (decl version=52 decl=someComputedProperty
-// CHECK-NEXT: {{^}}    (decl version=52 decl=someOtherMethod()
-@available(OSX 51, *)
-class SomeClass {
-  @available(OSX 52, *)
-  func someMethod() {
-
-    @available(OSX 53, *)
-    func someInnerFunc() { }
-
-    @available(OSX 53, *)
-    class InnerClass {
-      @available(OSX 54, *)
-      func innerClassMethod() { }
-    }
-  }
-  
-  func someUnrefinedMethod() { }
-
-  @available(OSX 52, *)
-  static var someStaticProperty: Int = 7
-
-  @available(OSX 52, *)
-  static var someStaticPropertyInferredType = 7
-
-  @available(OSX 52, *)
-  static var multiPatternStaticPropertyA = 7,
-             multiPatternStaticPropertyB = 8
-
-  @available(OSX 52, *)
-  var someComputedProperty: Int {
-    get { }
-    set(v) { }
-  }
-
-  @available(OSX 52, *)
-  func someOtherMethod() { }
-}
-
-// CHECK-NEXT: {{^}}  (decl version=51 decl=someFunction()
-@available(OSX 51, *)
-func someFunction() { }
-
-// CHECK-NEXT: {{^}}  (decl version=51 decl=SomeProtocol
-// CHECK-NEXT: {{^}}    (decl version=52 decl=protoMethod()
-// CHECK-NEXT: {{^}}    (decl_implicit version=51 decl=protoProperty
-// CHECK-NEXT: {{^}}      (decl version=52 decl=protoProperty
-@available(OSX 51, *)
-protocol SomeProtocol {
-  @available(OSX 52, *)
-  func protoMethod() -> Int
-
-  @available(OSX 52, *)
-  var protoProperty: Int { get }
-}
-
-// CHECK-NEXT: {{^}}  (decl_implicit version=50 decl=extension.SomeClass
-// CHECK-NEXT: {{^}}    (decl version=51 decl=extension.SomeClass
-// CHECK-NEXT: {{^}}      (decl version=52 decl=someExtensionFunction()
-@available(OSX 51, *)
-extension SomeClass {
-  @available(OSX 52, *)
-  func someExtensionFunction() { }
-}
-
-// CHECK-NEXT: {{^}}  (decl version=51 decl=functionWithStmtCondition
-// CHECK-NEXT: {{^}}    (condition_following_availability version=52
-// CHECK-NEXT: {{^}}      (condition_following_availability version=53
-// CHECK-NEXT: {{^}}    (if_then version=53
-// CHECK-NEXT: {{^}}      (condition_following_availability version=54
-// CHECK-NEXT: {{^}}      (if_then version=54
-// CHECK-NEXT: {{^}}        (condition_following_availability version=55
-// CHECK-NEXT: {{^}}        (decl version=55 decl=funcInGuardElse()
-// CHECK-NEXT: {{^}}        (guard_fallthrough version=55
-// CHECK-NEXT: {{^}}          (condition_following_availability version=56
-// CHECK-NEXT: {{^}}          (guard_fallthrough version=56
-// CHECK-NEXT: {{^}}      (decl version=57 decl=funcInInnerIfElse()
-// CHECK-NEXT: {{^}}    (decl version=53 decl=funcInOuterIfElse()
-@available(OSX 51, *)
-func functionWithStmtCondition() {
-  if #available(OSX 52, *),
-     let x = (nil as Int?),
-     #available(OSX 53, *) {
-    if #available(OSX 54, *) {
-      guard #available(OSX 55, *) else {
-        @available(OSX 55, *)
-        func funcInGuardElse() { }
-      }
-      guard #available(OSX 56, *) else { }
-    } else {
-      @available(OSX 57, *)
-      func funcInInnerIfElse() { }
-    }
-  } else {
-    @available(OSX 53, *)
-    func funcInOuterIfElse() { }
-  }
-}
-
-// CHECK-NEXT: {{^}}  (decl version=51 decl=functionWithUnnecessaryStmtCondition
-// CHECK-NEXT: {{^}}    (condition_following_availability version=53
-// CHECK-NEXT: {{^}}    (if_then version=53
-// CHECK-NEXT: {{^}}    (condition_following_availability version=54
-// CHECK-NEXT: {{^}}    (if_then version=54
-
-@available(OSX 51, *)
-func functionWithUnnecessaryStmtCondition() {
-  // Shouldn't introduce availability scope for then branch when unnecessary
-  if #available(OSX 51, *) {
-  }
-
-  if #available(OSX 10.9, *) {
-  }
-
-  // Nested in conjunctive statement condition
-  if #available(OSX 53, *),
-     let x = (nil as Int?),
-     #available(OSX 52, *) {
-  }
-
-  if #available(OSX 54, *),
-     #available(OSX 54, *) {
-  }
-
-  // Wildcard is same as minimum deployment target
-  if #available(iOS 7.0, *) {
-  }
-}
-
-// CHECK-NEXT: {{^}}  (decl version=51 decl=functionWithUnnecessaryStmtConditionsHavingElseBranch
-// CHECK-NEXT: {{^}}    (if_else version=none
-// CHECK-NEXT: {{^}}      (decl version=none decl=funcInInnerIfElse()
-// CHECK-NEXT: {{^}}    (if_else version=none
-// CHECK-NEXT: {{^}}    (guard_else version=none
-// CHECK-NEXT: {{^}}    (guard_else version=none
-// CHECK-NEXT: {{^}}    (if_else version=none
-
-@available(OSX 51, *)
-func functionWithUnnecessaryStmtConditionsHavingElseBranch(p: Int?) {
-  // Else branch context version is bottom when check is unnecessary
-  if #available(OSX 51, *) {
-  } else {
-    if #available(OSX 52, *) {
-    }
-
-    @available(OSX 52, *)
-    func funcInInnerIfElse() { }
-
-    if #available(iOS 7.0, *) {
-    } else {
-    }
-  }
-
-  if #available(iOS 7.0, *) {
-  } else {
-  }
-
-  guard #available(iOS 8.0, *) else { }
-
-  // Else branch will execute if p is nil, so it is not dead.
-  if #available(iOS 7.0, *),
-     let x = p {
-  } else {
-  }
-
-  if #available(iOS 7.0, *),
-     let x = p,
-     #available(iOS 7.0, *) {
-  } else {
-  }
-
-  // Else branch is dead
-  guard #available(iOS 7.0, *),
-        #available(iOS 8.0, *) else { }
-
-  if #available(OSX 51, *),
-     #available(OSX 51, *) {
-  } else {
-  }
-
-}
-
-// CHECK-NEXT: {{^}}  (decl version=51 decl=functionWithWhile()
-// CHECK-NEXT: {{^}}    (condition_following_availability version=52
-// CHECK-NEXT: {{^}}    (while_body version=52
-// CHECK-NEXT: {{^}}      (decl version=54 decl=funcInWhileBody()
-@available(OSX 51, *)
-func functionWithWhile() {
-  while #available(OSX 52, *),
-        let x = (nil as Int?) {
-    @available(OSX 54, *)
-    func funcInWhileBody() { }
-  }
-}
-
-// CHECK-NEXT: {{^}}  (decl version=51 decl=functionWithDefer()
-// CHECK-NEXT: {{^}}    (condition_following_availability version=52
-// CHECK-NEXT: {{^}}    (if_then version=52
-@available(OSX 51, *)
-func functionWithDefer() {
-  defer {
-    if #available(OSX 52, *) {}
-  }
-}
-
-// CHECK-NEXT: {{^}}  (decl_implicit version=50 decl=extension.SomeClass
-// CHECK-NEXT: {{^}}    (decl version=51 decl=extension.SomeClass
-// CHECK-NEXT: {{^}}      (decl_implicit version=51 decl=someStaticPropertyWithClosureInit
-// CHECK-NEXT: {{^}}        (decl version=52 decl=someStaticPropertyWithClosureInit
-// CHECK-NEXT: {{^}}          (condition_following_availability version=54
-// CHECK-NEXT: {{^}}          (if_then version=54
-// CHECK-NEXT: {{^}}      (decl_implicit version=51 decl=someStaticPropertyWithClosureInitInferred
-// CHECK-NEXT: {{^}}        (decl version=52 decl=someStaticPropertyWithClosureInitInferred
-// CHECK-NEXT: {{^}}          (condition_following_availability version=54
-// CHECK-NEXT: {{^}}          (if_then version=54
-@available(OSX 51, *)
-extension SomeClass {
-  @available(OSX 52, *)
-  static var someStaticPropertyWithClosureInit: Int = {
-    if #available(OSX 54, *) {
-      return 54
-    }
-    return 53
-  }()
-
-  @available(OSX 52, *)
-  static var someStaticPropertyWithClosureInitInferred = {
-    if #available(OSX 54, *) {
-      return 54
-    }
-    return 53
-  }()
-}
-
-// CHECK-NEXT: {{^}}  (decl_implicit version=50 decl=extension.SomeClass
-// CHECK-NEXT: {{^}}    (decl version=50 unavailable=macOS decl=extension.SomeClass
-// CHECK-NEXT: {{^}}      (decl version=50 unavailable=macOS decl=functionWithStmtConditionsInUnavailableExt()
-// CHECK-NEXT: {{^}}        (condition_following_availability version=52 unavailable=macOS
-// CHECK-NEXT: {{^}}          (condition_following_availability version=53 unavailable=macOS
-// CHECK-NEXT: {{^}}        (if_then version=53 unavailable=macOS
-// CHECK-NEXT: {{^}}          (condition_following_availability version=54 unavailable=macOS
-// CHECK-NEXT: {{^}}          (if_then version=54 unavailable=macOS
-// CHECK-NEXT: {{^}}            (condition_following_availability version=55 unavailable=macOS
-// CHECK-NEXT: {{^}}            (decl version=54 unavailable=macOS decl=funcInGuardElse()
-// CHECK-NEXT: {{^}}            (guard_fallthrough version=55 unavailable=macOS
-// CHECK-NEXT: {{^}}              (condition_following_availability version=56 unavailable=macOS
-// CHECK-NEXT: {{^}}              (guard_fallthrough version=56 unavailable=macOS
-// CHECK-NEXT: {{^}}          (decl version=53 unavailable=macOS decl=funcInInnerIfElse()
-// CHECK-NEXT: {{^}}        (decl version=50 unavailable=macOS decl=funcInOuterIfElse()
-@available(OSX, unavailable)
-extension SomeClass {
-  @available(OSX 51, *)
-  func functionWithStmtConditionsInUnavailableExt() {
-    if #available(OSX 52, *),
-       let x = (nil as Int?),
-       #available(OSX 53, *) {
-      if #available(OSX 54, *) {
-        guard #available(OSX 55, *) else {
-          @available(OSX 55, *)
-          func funcInGuardElse() { }
-        }
-        guard #available(OSX 56, *) else { }
-      } else {
-        @available(OSX 57, *)
-        func funcInInnerIfElse() { }
-      }
-    } else {
-      @available(OSX 53, *)
-      func funcInOuterIfElse() { }
-    }
-  }
-}
-
-// CHECK-NEXT: {{^}}  (decl_implicit version=50 decl=wrappedValue
-
-@propertyWrapper
-struct Wrapper<T> {
-  var wrappedValue: T
-}
-
-// CHECK-NEXT: {{^}}  (decl version=51 decl=SomeStruct
-// CHECK-NEXT: {{^}}    (decl_implicit version=51 decl=someLazyVar
-// CHECK-NEXT: {{^}}      (condition_following_availability version=52
-// CHECK-NEXT: {{^}}      (guard_fallthrough version=52
-// CHECK-NEXT: {{^}}    (decl_implicit version=51 decl=someWrappedVar
-// CHECK-NEXT: {{^}}      (condition_following_availability version=52
-// CHECK-NEXT: {{^}}      (guard_fallthrough version=52
-// CHECK-NEXT: {{^}}    (decl version=52 decl=someMethodAvailable52()
-@available(OSX 51, *)
-struct SomeStruct {
-  lazy var someLazyVar = {
-    guard #available(OSX 52, *) else {
-      return someMethod()
-    }
-    return someMethodAvailable52()
-  }()
-
-  @Wrapper var someWrappedVar = {
-    guard #available(OSX 52, *) else {
-      return 51
-    }
-    return 52
-  }()
-
-  func someMethod() -> Int { return 51 }
-
-  @available(OSX 52, *)
-  func someMethodAvailable52() -> Int { return 52 }
-}
-
-// CHECK-NEXT: {{^}}  (decl version=51 decl=SomeEnum
-// CHECK-NEXT: {{^}}    (decl version=52 decl=a
-// CHECK-NEXT: {{^}}    (decl version=53 decl=b
-
-@available(OSX 51, *)
-enum SomeEnum {
-  @available(OSX 52, *)
-  case a
-
-  @available(OSX 53, *)
-  case b, c
-}
-
-// CHECK-NEXT: {{^}}  (decl_implicit version=50 decl=someComputedGlobalVar
-// CHECK-NEXT: {{^}}    (decl version=51 decl=_
-// CHECK-NEXT: {{^}}    (decl version=52 decl=_
-
-var someComputedGlobalVar: Int {
-  @available(OSX 51, *)
-  get { 1 }
-
-  @available(OSX 52, *)
-  set { }
-}
-
-// CHECK-NEXT: {{^}}  (decl_implicit version=50 decl=interpolated
-// CHECK-NEXT: {{^}}    (decl_implicit version=50 decl=string
-
-func testStringInterpolation() {
-  let interpolated = """
-    \([""].map {
-      let string = $0
-      return string
-    })
-    """
-}
-
-// CHECK-NEXT: {{^}}  (decl_implicit version=50 decl=result
-// CHECK-NEXT: {{^}}    (decl_implicit version=50 decl=unusedA
-// CHECK-NEXT: {{^}}    (decl_implicit version=50 decl=unusedB
-
-func testSequenceExprs(b: Bool, x: Int?) {
-  let result = b
-    ? x.map {
-        let unusedA: Int
-        return $0
-      }
-    : x.map {
-        let unusedB: Int
-        return $0
-      }
-}
-
-// CHECK-NEXT: {{^}}  (decl version=50 unavailable=macOS decl=unavailableOnMacOS()
-// CHECK-NEXT: {{^}}    (decl_implicit version=50 unavailable=macOS decl=x
-
-@available(macOS, unavailable)
-func unavailableOnMacOS() {
-  let x = 1
-}
-
-// CHECK-NEXT: {{^}}  (decl_implicit version=50 decl=extension.SomeEnum
-// CHECK-NEXT: {{^}}    (decl version=51 decl=extension.SomeEnum
-// CHECK-NEXT: {{^}}      (decl_implicit version=51 decl=unavailableOnMacOS
-// CHECK-NEXT: {{^}}        (decl version=51 unavailable=macOS decl=unavailableOnMacOS
-@available(OSX 51, *)
-extension SomeEnum {
-  @available(macOS, unavailable)
-  var unavailableOnMacOS: Int { 1 }
-}
-
-// CHECK-NEXT: {{^}}  (decl_implicit version=50 decl=extension.SomeEnum
-// CHECK-NEXT: {{^}}    (decl version=50 unavailable=macOS decl=extension.SomeEnum
-// CHECK-NEXT: {{^}}      (decl_implicit version=50 unavailable=macOS decl=availableMacOS_52
-// CHECK-NEXT: {{^}}        (decl version=50 unavailable=macOS decl=availableMacOS_52
-// CHECK-NEXT: {{^}}      (decl version=50 unavailable=*,macOS decl=neverAvailable()
-
-@available(macOS, unavailable)
-extension SomeEnum {
-  @available(OSX 52, *)
-  var availableMacOS_52: Int { 1 }
-
-  @available(macOSApplicationExtension, unavailable)
-  func unavailableInAppExtensions() {}
-
-  @available(*, unavailable)
-  func neverAvailable() {}
-}
-
-// CHECK-NEXT: {{^}}  (decl version=50 unavailable=macOS decl=unavailableOnMacOSAndIntroduced()
-
-@available(macOS, unavailable)
-@available(macOS, introduced: 52)
-func unavailableOnMacOSAndIntroduced() {
-}
-
-// CHECK-NEXT: {{^}}  (decl version=50 unavailable=macOS decl=introducedOnMacOSAndUnavailable()
-
-@available(macOS, introduced: 53)
-@available(macOS, unavailable)
-func introducedOnMacOSAndUnavailable() {
-}
-
-
-// CHECK-NEXT: {{^}}  (decl version=50 unavailable=macOS decl=unavailableOnMacOSAndIntroducedSameAttr()
-
-@available(macOS, unavailable, introduced: 54)
-func unavailableOnMacOSAndIntroducedSameAttr() {
-}
-
-// CHECK-NEXT: {{^}}  (decl version=50 unavailable=* decl=NeverAvailable
-// CHECK-NEXT: {{^}}    (decl version=50 unavailable=* decl=unavailableOnMacOS()
-
+// CHECK-NEXT: {{^}}  (decl version={{.*}} unavailable=* decl=universallyUnavailable()
 @available(*, unavailable)
-struct NeverAvailable {
-  @available(macOS, unavailable)
-  func unavailableOnMacOS() {}
-}
+func universallyUnavailable() { }
 
-// CHECK-NEXT: {{^}}  (decl version=50 deprecated decl=deprecatedOnMacOS()
-// CHECK-NEXT: {{^}}    (decl_implicit version=50 deprecated decl=x
+// CHECK-NEXT: {{^}}  (decl version={{.*}} deprecated decl=universallyDeprecated()
+@available(*, deprecated)
+func universallyDeprecated() { }
 
-@available(macOS, deprecated)
-func deprecatedOnMacOS() {
-  let x = 1
-}
-
-// Since availableOniOS() doesn't have any active @available attributes it
-// shouldn't create a scope.
-// CHECK-NOT: availableOniOS
-
-@available(iOS, introduced: 53)
-func availableOniOS() { }
-
-// CHECK-NEXT: {{^}}  (decl version=50 decl=availableInSwift5
-
+// CHECK-NEXT: {{^}}  (decl version={{.*}} decl=introducedInSwift5()
 @available(swift 5)
-func availableInSwift5() { }
+func introducedInSwift5() { }
 
-// CHECK-NEXT: {{^}}  (decl version=50 unavailable=swift decl=availableInSwift6
-
+// CHECK-NEXT: {{^}}  (decl version={{.*}} unavailable=swift decl=introducedInSwift6()
 @available(swift 6)
-func availableInSwift6() { }
+func introducedInSwift6() { }
 
-// CHECK-NEXT: {{^}}  (decl version=51 decl=FinalDecl
+// CHECK-NEXT: {{^}}  (decl version={{.*}} unavailable=swift decl=obsoletedInSwift5()
+@available(swift, obsoleted: 5)
+func obsoletedInSwift5() { }
 
-@available(OSX 51, *)
-typealias FinalDecl = Int
+// CHECK-NEXT: {{^}}  (decl version={{.*}} decl=obsoletedInSwift6()
+@available(swift, obsoleted: 6)
+func obsoletedInSwift6() { }
+
+// CHECK-NEXT: {{^}}  (decl version={{.*}} unavailable=* decl=UniversallyUnavailable
+// CHECK-NEXT: {{^}}    (decl version={{.*}} unavailable=* decl=universallyUnavailable()
+// CHECK-NEXT: {{^}}    (decl version={{.*}} unavailable=* deprecated decl=universallyDeprecated()
+// CHECK-NEXT: {{^}}    (decl version={{.*}} unavailable=* decl=introducedInSwift5()
+// CHECK-NEXT: {{^}}    (decl version={{.*}} unavailable=*,swift decl=introducedInSwift6()
+// CHECK-NEXT: {{^}}    (decl version={{.*}} unavailable=*,swift decl=obsoletedInSwift5
+// CHECK-NEXT: {{^}}    (decl version={{.*}} unavailable=* decl=obsoletedInSwift6()
+@available(*, unavailable)
+struct UniversallyUnavailable {
+  @available(*, unavailable)
+  func universallyUnavailable() { }
+
+  @available(*, deprecated)
+  func universallyDeprecated() { }
+
+  @available(swift 5)
+  func introducedInSwift5() { }
+
+  @available(swift 6)
+  func introducedInSwift6() { }
+
+  @available(swift, obsoleted: 5)
+  func obsoletedInSwift5() { }
+
+  @available(swift, obsoleted: 6)
+  func obsoletedInSwift6() { }
+}
+
+// CHECK-NEXT: {{^}}  (decl version={{.*}} unavailable=swift decl=IntroducedInSwift6
+// CHECK-NEXT: {{^}}    (decl version={{.*}} unavailable=*,swift decl=universallyUnavailable()
+// CHECK-NEXT: {{^}}    (decl version={{.*}} unavailable=swift deprecated decl=universallyDeprecated()
+// CHECK-NEXT: {{^}}    (decl version={{.*}} unavailable=swift decl=introducedInSwift5()
+// CHECK-NEXT: {{^}}    (decl version={{.*}} unavailable=swift decl=introducedInSwift6()
+// CHECK-NEXT: {{^}}    (decl version={{.*}} unavailable=swift decl=obsoletedInSwift5
+// CHECK-NEXT: {{^}}    (decl version={{.*}} unavailable=swift decl=obsoletedInSwift6()
+@available(swift 6)
+struct IntroducedInSwift6 {
+  @available(*, unavailable)
+  func universallyUnavailable() { }
+
+  @available(*, deprecated)
+  func universallyDeprecated() { }
+
+  @available(swift 5)
+  func introducedInSwift5() { }
+
+  @available(swift 6)
+  func introducedInSwift6() { }
+
+  @available(swift, obsoleted: 5)
+  func obsoletedInSwift5() { }
+
+  @available(swift, obsoleted: 6)
+  func obsoletedInSwift6() { }
+}

--- a/test/Availability/availability_scopes_macos.swift
+++ b/test/Availability/availability_scopes_macos.swift
@@ -1,0 +1,467 @@
+// RUN: %target-swift-frontend -typecheck -dump-availability-scopes %s -target %target-cpu-apple-macos50 -swift-version 5 > %t.dump 2>&1
+// RUN: %FileCheck --strict-whitespace %s < %t.dump
+
+// REQUIRES: OS=macosx
+
+// CHECK: {{^}}(root version=50
+
+// CHECK-NEXT: {{^}}  (decl version=51 decl=SomeClass
+// CHECK-NEXT: {{^}}    (decl version=52 decl=someMethod()
+// CHECK-NEXT: {{^}}      (decl version=53 decl=someInnerFunc()
+// CHECK-NEXT: {{^}}      (decl version=53 decl=InnerClass
+// CHECK-NEXT: {{^}}        (decl version=54 decl=innerClassMethod
+// CHECK-NEXT: {{^}}    (decl_implicit version=51 decl=someStaticProperty
+// CHECK-NEXT: {{^}}      (decl version=52 decl=someStaticProperty
+// CHECK-NEXT: {{^}}    (decl_implicit version=51 decl=someStaticPropertyInferredType
+// CHECK-NEXT: {{^}}      (decl version=52 decl=someStaticPropertyInferredType
+// CHECK-NEXT: {{^}}    (decl_implicit version=51 decl=multiPatternStaticPropertyA
+// CHECK-NEXT: {{^}}      (decl version=52 decl=multiPatternStaticPropertyA
+// CHECK-NEXT: {{^}}    (decl_implicit version=51 decl=someComputedProperty
+// CHECK-NEXT: {{^}}      (decl version=52 decl=someComputedProperty
+// CHECK-NEXT: {{^}}    (decl version=52 decl=someOtherMethod()
+@available(OSX 51, *)
+class SomeClass {
+  @available(OSX 52, *)
+  func someMethod() {
+
+    @available(OSX 53, *)
+    func someInnerFunc() { }
+
+    @available(OSX 53, *)
+    class InnerClass {
+      @available(OSX 54, *)
+      func innerClassMethod() { }
+    }
+  }
+
+  func someUnrefinedMethod() { }
+
+  @available(OSX 52, *)
+  static var someStaticProperty: Int = 7
+
+  @available(OSX 52, *)
+  static var someStaticPropertyInferredType = 7
+
+  @available(OSX 52, *)
+  static var multiPatternStaticPropertyA = 7,
+             multiPatternStaticPropertyB = 8
+
+  @available(OSX 52, *)
+  var someComputedProperty: Int {
+    get { }
+    set(v) { }
+  }
+
+  @available(OSX 52, *)
+  func someOtherMethod() { }
+}
+
+// CHECK-NEXT: {{^}}  (decl version=51 decl=someFunction()
+@available(OSX 51, *)
+func someFunction() { }
+
+// CHECK-NEXT: {{^}}  (decl version=51 decl=SomeProtocol
+// CHECK-NEXT: {{^}}    (decl version=52 decl=protoMethod()
+// CHECK-NEXT: {{^}}    (decl_implicit version=51 decl=protoProperty
+// CHECK-NEXT: {{^}}      (decl version=52 decl=protoProperty
+@available(OSX 51, *)
+protocol SomeProtocol {
+  @available(OSX 52, *)
+  func protoMethod() -> Int
+
+  @available(OSX 52, *)
+  var protoProperty: Int { get }
+}
+
+// CHECK-NEXT: {{^}}  (decl_implicit version=50 decl=extension.SomeClass
+// CHECK-NEXT: {{^}}    (decl version=51 decl=extension.SomeClass
+// CHECK-NEXT: {{^}}      (decl version=52 decl=someExtensionFunction()
+@available(OSX 51, *)
+extension SomeClass {
+  @available(OSX 52, *)
+  func someExtensionFunction() { }
+}
+
+// CHECK-NEXT: {{^}}  (decl version=51 decl=functionWithStmtCondition
+// CHECK-NEXT: {{^}}    (condition_following_availability version=52
+// CHECK-NEXT: {{^}}      (condition_following_availability version=53
+// CHECK-NEXT: {{^}}    (if_then version=53
+// CHECK-NEXT: {{^}}      (condition_following_availability version=54
+// CHECK-NEXT: {{^}}      (if_then version=54
+// CHECK-NEXT: {{^}}        (condition_following_availability version=55
+// CHECK-NEXT: {{^}}        (decl version=55 decl=funcInGuardElse()
+// CHECK-NEXT: {{^}}        (guard_fallthrough version=55
+// CHECK-NEXT: {{^}}          (condition_following_availability version=56
+// CHECK-NEXT: {{^}}          (guard_fallthrough version=56
+// CHECK-NEXT: {{^}}      (decl version=57 decl=funcInInnerIfElse()
+// CHECK-NEXT: {{^}}    (decl version=53 decl=funcInOuterIfElse()
+@available(OSX 51, *)
+func functionWithStmtCondition() {
+  if #available(OSX 52, *),
+     let x = (nil as Int?),
+     #available(OSX 53, *) {
+    if #available(OSX 54, *) {
+      guard #available(OSX 55, *) else {
+        @available(OSX 55, *)
+        func funcInGuardElse() { }
+      }
+      guard #available(OSX 56, *) else { }
+    } else {
+      @available(OSX 57, *)
+      func funcInInnerIfElse() { }
+    }
+  } else {
+    @available(OSX 53, *)
+    func funcInOuterIfElse() { }
+  }
+}
+
+// CHECK-NEXT: {{^}}  (decl version=51 decl=functionWithUnnecessaryStmtCondition
+// CHECK-NEXT: {{^}}    (condition_following_availability version=53
+// CHECK-NEXT: {{^}}    (if_then version=53
+// CHECK-NEXT: {{^}}    (condition_following_availability version=54
+// CHECK-NEXT: {{^}}    (if_then version=54
+
+@available(OSX 51, *)
+func functionWithUnnecessaryStmtCondition() {
+  // Shouldn't introduce availability scope for then branch when unnecessary
+  if #available(OSX 51, *) {
+  }
+
+  if #available(OSX 10.9, *) {
+  }
+
+  // Nested in conjunctive statement condition
+  if #available(OSX 53, *),
+     let x = (nil as Int?),
+     #available(OSX 52, *) {
+  }
+
+  if #available(OSX 54, *),
+     #available(OSX 54, *) {
+  }
+
+  // Wildcard is same as minimum deployment target
+  if #available(iOS 7.0, *) {
+  }
+}
+
+// CHECK-NEXT: {{^}}  (decl version=51 decl=functionWithUnnecessaryStmtConditionsHavingElseBranch
+// CHECK-NEXT: {{^}}    (if_else version=none
+// CHECK-NEXT: {{^}}      (decl version=none decl=funcInInnerIfElse()
+// CHECK-NEXT: {{^}}    (if_else version=none
+// CHECK-NEXT: {{^}}    (guard_else version=none
+// CHECK-NEXT: {{^}}    (guard_else version=none
+// CHECK-NEXT: {{^}}    (if_else version=none
+
+@available(OSX 51, *)
+func functionWithUnnecessaryStmtConditionsHavingElseBranch(p: Int?) {
+  // Else branch context version is bottom when check is unnecessary
+  if #available(OSX 51, *) {
+  } else {
+    if #available(OSX 52, *) {
+    }
+
+    @available(OSX 52, *)
+    func funcInInnerIfElse() { }
+
+    if #available(iOS 7.0, *) {
+    } else {
+    }
+  }
+
+  if #available(iOS 7.0, *) {
+  } else {
+  }
+
+  guard #available(iOS 8.0, *) else { }
+
+  // Else branch will execute if p is nil, so it is not dead.
+  if #available(iOS 7.0, *),
+     let x = p {
+  } else {
+  }
+
+  if #available(iOS 7.0, *),
+     let x = p,
+     #available(iOS 7.0, *) {
+  } else {
+  }
+
+  // Else branch is dead
+  guard #available(iOS 7.0, *),
+        #available(iOS 8.0, *) else { }
+
+  if #available(OSX 51, *),
+     #available(OSX 51, *) {
+  } else {
+  }
+
+}
+
+// CHECK-NEXT: {{^}}  (decl version=51 decl=functionWithWhile()
+// CHECK-NEXT: {{^}}    (condition_following_availability version=52
+// CHECK-NEXT: {{^}}    (while_body version=52
+// CHECK-NEXT: {{^}}      (decl version=54 decl=funcInWhileBody()
+@available(OSX 51, *)
+func functionWithWhile() {
+  while #available(OSX 52, *),
+        let x = (nil as Int?) {
+    @available(OSX 54, *)
+    func funcInWhileBody() { }
+  }
+}
+
+// CHECK-NEXT: {{^}}  (decl version=51 decl=functionWithDefer()
+// CHECK-NEXT: {{^}}    (condition_following_availability version=52
+// CHECK-NEXT: {{^}}    (if_then version=52
+@available(OSX 51, *)
+func functionWithDefer() {
+  defer {
+    if #available(OSX 52, *) {}
+  }
+}
+
+// CHECK-NEXT: {{^}}  (decl_implicit version=50 decl=extension.SomeClass
+// CHECK-NEXT: {{^}}    (decl version=51 decl=extension.SomeClass
+// CHECK-NEXT: {{^}}      (decl_implicit version=51 decl=someStaticPropertyWithClosureInit
+// CHECK-NEXT: {{^}}        (decl version=52 decl=someStaticPropertyWithClosureInit
+// CHECK-NEXT: {{^}}          (condition_following_availability version=54
+// CHECK-NEXT: {{^}}          (if_then version=54
+// CHECK-NEXT: {{^}}      (decl_implicit version=51 decl=someStaticPropertyWithClosureInitInferred
+// CHECK-NEXT: {{^}}        (decl version=52 decl=someStaticPropertyWithClosureInitInferred
+// CHECK-NEXT: {{^}}          (condition_following_availability version=54
+// CHECK-NEXT: {{^}}          (if_then version=54
+@available(OSX 51, *)
+extension SomeClass {
+  @available(OSX 52, *)
+  static var someStaticPropertyWithClosureInit: Int = {
+    if #available(OSX 54, *) {
+      return 54
+    }
+    return 53
+  }()
+
+  @available(OSX 52, *)
+  static var someStaticPropertyWithClosureInitInferred = {
+    if #available(OSX 54, *) {
+      return 54
+    }
+    return 53
+  }()
+}
+
+// CHECK-NEXT: {{^}}  (decl_implicit version=50 decl=extension.SomeClass
+// CHECK-NEXT: {{^}}    (decl version=50 unavailable=macOS decl=extension.SomeClass
+// CHECK-NEXT: {{^}}      (decl version=50 unavailable=macOS decl=functionWithStmtConditionsInUnavailableExt()
+// CHECK-NEXT: {{^}}        (condition_following_availability version=52 unavailable=macOS
+// CHECK-NEXT: {{^}}          (condition_following_availability version=53 unavailable=macOS
+// CHECK-NEXT: {{^}}        (if_then version=53 unavailable=macOS
+// CHECK-NEXT: {{^}}          (condition_following_availability version=54 unavailable=macOS
+// CHECK-NEXT: {{^}}          (if_then version=54 unavailable=macOS
+// CHECK-NEXT: {{^}}            (condition_following_availability version=55 unavailable=macOS
+// CHECK-NEXT: {{^}}            (decl version=54 unavailable=macOS decl=funcInGuardElse()
+// CHECK-NEXT: {{^}}            (guard_fallthrough version=55 unavailable=macOS
+// CHECK-NEXT: {{^}}              (condition_following_availability version=56 unavailable=macOS
+// CHECK-NEXT: {{^}}              (guard_fallthrough version=56 unavailable=macOS
+// CHECK-NEXT: {{^}}          (decl version=53 unavailable=macOS decl=funcInInnerIfElse()
+// CHECK-NEXT: {{^}}        (decl version=50 unavailable=macOS decl=funcInOuterIfElse()
+@available(OSX, unavailable)
+extension SomeClass {
+  @available(OSX 51, *)
+  func functionWithStmtConditionsInUnavailableExt() {
+    if #available(OSX 52, *),
+       let x = (nil as Int?),
+       #available(OSX 53, *) {
+      if #available(OSX 54, *) {
+        guard #available(OSX 55, *) else {
+          @available(OSX 55, *)
+          func funcInGuardElse() { }
+        }
+        guard #available(OSX 56, *) else { }
+      } else {
+        @available(OSX 57, *)
+        func funcInInnerIfElse() { }
+      }
+    } else {
+      @available(OSX 53, *)
+      func funcInOuterIfElse() { }
+    }
+  }
+}
+
+// CHECK-NEXT: {{^}}  (decl_implicit version=50 decl=wrappedValue
+
+@propertyWrapper
+struct Wrapper<T> {
+  var wrappedValue: T
+}
+
+// CHECK-NEXT: {{^}}  (decl version=51 decl=SomeStruct
+// CHECK-NEXT: {{^}}    (decl_implicit version=51 decl=someLazyVar
+// CHECK-NEXT: {{^}}      (condition_following_availability version=52
+// CHECK-NEXT: {{^}}      (guard_fallthrough version=52
+// CHECK-NEXT: {{^}}    (decl_implicit version=51 decl=someWrappedVar
+// CHECK-NEXT: {{^}}      (condition_following_availability version=52
+// CHECK-NEXT: {{^}}      (guard_fallthrough version=52
+// CHECK-NEXT: {{^}}    (decl version=52 decl=someMethodAvailable52()
+@available(OSX 51, *)
+struct SomeStruct {
+  lazy var someLazyVar = {
+    guard #available(OSX 52, *) else {
+      return someMethod()
+    }
+    return someMethodAvailable52()
+  }()
+
+  @Wrapper var someWrappedVar = {
+    guard #available(OSX 52, *) else {
+      return 51
+    }
+    return 52
+  }()
+
+  func someMethod() -> Int { return 51 }
+
+  @available(OSX 52, *)
+  func someMethodAvailable52() -> Int { return 52 }
+}
+
+// CHECK-NEXT: {{^}}  (decl version=51 decl=SomeEnum
+// CHECK-NEXT: {{^}}    (decl version=52 decl=a
+// CHECK-NEXT: {{^}}    (decl version=53 decl=b
+
+@available(OSX 51, *)
+enum SomeEnum {
+  @available(OSX 52, *)
+  case a
+
+  @available(OSX 53, *)
+  case b, c
+}
+
+// CHECK-NEXT: {{^}}  (decl_implicit version=50 decl=someComputedGlobalVar
+// CHECK-NEXT: {{^}}    (decl version=51 decl=_
+// CHECK-NEXT: {{^}}    (decl version=52 decl=_
+
+var someComputedGlobalVar: Int {
+  @available(OSX 51, *)
+  get { 1 }
+
+  @available(OSX 52, *)
+  set { }
+}
+
+// CHECK-NEXT: {{^}}  (decl_implicit version=50 decl=interpolated
+// CHECK-NEXT: {{^}}    (decl_implicit version=50 decl=string
+
+func testStringInterpolation() {
+  let interpolated = """
+    \([""].map {
+      let string = $0
+      return string
+    })
+    """
+}
+
+// CHECK-NEXT: {{^}}  (decl_implicit version=50 decl=result
+// CHECK-NEXT: {{^}}    (decl_implicit version=50 decl=unusedA
+// CHECK-NEXT: {{^}}    (decl_implicit version=50 decl=unusedB
+
+func testSequenceExprs(b: Bool, x: Int?) {
+  let result = b
+    ? x.map {
+        let unusedA: Int
+        return $0
+      }
+    : x.map {
+        let unusedB: Int
+        return $0
+      }
+}
+
+// CHECK-NEXT: {{^}}  (decl version=50 unavailable=macOS decl=unavailableOnMacOS()
+// CHECK-NEXT: {{^}}    (decl_implicit version=50 unavailable=macOS decl=x
+
+@available(macOS, unavailable)
+func unavailableOnMacOS() {
+  let x = 1
+}
+
+// CHECK-NEXT: {{^}}  (decl_implicit version=50 decl=extension.SomeEnum
+// CHECK-NEXT: {{^}}    (decl version=51 decl=extension.SomeEnum
+// CHECK-NEXT: {{^}}      (decl_implicit version=51 decl=unavailableOnMacOS
+// CHECK-NEXT: {{^}}        (decl version=51 unavailable=macOS decl=unavailableOnMacOS
+@available(OSX 51, *)
+extension SomeEnum {
+  @available(macOS, unavailable)
+  var unavailableOnMacOS: Int { 1 }
+}
+
+// CHECK-NEXT: {{^}}  (decl_implicit version=50 decl=extension.SomeEnum
+// CHECK-NEXT: {{^}}    (decl version=50 unavailable=macOS decl=extension.SomeEnum
+// CHECK-NEXT: {{^}}      (decl_implicit version=50 unavailable=macOS decl=availableMacOS_52
+// CHECK-NEXT: {{^}}        (decl version=50 unavailable=macOS decl=availableMacOS_52
+// CHECK-NEXT: {{^}}      (decl version=50 unavailable=*,macOS decl=neverAvailable()
+
+@available(macOS, unavailable)
+extension SomeEnum {
+  @available(OSX 52, *)
+  var availableMacOS_52: Int { 1 }
+
+  @available(macOSApplicationExtension, unavailable)
+  func unavailableInAppExtensions() {}
+
+  @available(*, unavailable)
+  func neverAvailable() {}
+}
+
+// CHECK-NEXT: {{^}}  (decl version=50 unavailable=macOS decl=unavailableOnMacOSAndIntroduced()
+
+@available(macOS, unavailable)
+@available(macOS, introduced: 52)
+func unavailableOnMacOSAndIntroduced() {
+}
+
+// CHECK-NEXT: {{^}}  (decl version=50 unavailable=macOS decl=introducedOnMacOSAndUnavailable()
+
+@available(macOS, introduced: 53)
+@available(macOS, unavailable)
+func introducedOnMacOSAndUnavailable() {
+}
+
+
+// CHECK-NEXT: {{^}}  (decl version=50 unavailable=macOS decl=unavailableOnMacOSAndIntroducedSameAttr()
+
+@available(macOS, unavailable, introduced: 54)
+func unavailableOnMacOSAndIntroducedSameAttr() {
+}
+
+// CHECK-NEXT: {{^}}  (decl version=50 unavailable=* decl=NeverAvailable
+// CHECK-NEXT: {{^}}    (decl version=50 unavailable=* decl=unavailableOnMacOS()
+
+@available(*, unavailable)
+struct NeverAvailable {
+  @available(macOS, unavailable)
+  func unavailableOnMacOS() {}
+}
+
+// CHECK-NEXT: {{^}}  (decl version=50 deprecated decl=deprecatedOnMacOS()
+// CHECK-NEXT: {{^}}    (decl_implicit version=50 deprecated decl=x
+
+@available(macOS, deprecated)
+func deprecatedOnMacOS() {
+  let x = 1
+}
+
+// Since availableOniOS() doesn't have any active @available attributes it
+// shouldn't create a scope.
+// CHECK-NOT: availableOniOS
+
+@available(iOS, introduced: 53)
+func availableOniOS() { }
+
+// CHECK-NEXT: {{^}}  (decl version=51 decl=FinalDecl
+
+@available(OSX 51, *)
+typealias FinalDecl = Int

--- a/test/Availability/result_builder_availability.swift
+++ b/test/Availability/result_builder_availability.swift
@@ -100,9 +100,11 @@ tuplify(true) { cond in
         globalFuncAvailableOn52() // expected-error{{'globalFuncAvailableOn52()' is only available in macOS 52 or newer}}
         // expected-note@-1{{add 'if #available' version check}}
       } else if true {
-        globalFuncAvailableOn52()
+        globalFuncAvailableOn52() // expected-error{{'globalFuncAvailableOn52()' is only available in macOS 52 or newer}}
+        // expected-note@-1{{add 'if #available' version check}}
       } else if false {
-        globalFuncAvailableOn52()
+        globalFuncAvailableOn52() // expected-error{{'globalFuncAvailableOn52()' is only available in macOS 52 or newer}}
+        // expected-note@-1{{add 'if #available' version check}}
       }
     }
   }
@@ -162,7 +164,8 @@ tuplifyWithAvailabilityErasure(true) { cond in
   if cond, #unavailable(OSX 52) {
     cond
   } else {
-    globalFuncAvailableOn52()
+    globalFuncAvailableOn52() // expected-error{{'globalFuncAvailableOn52()' is only available in macOS 52 or newer}}
+    // expected-note@-1{{add 'if #available' version check}}
   }
 
   // https://github.com/apple/swift/issues/63764

--- a/test/attr/attr_availability.swift
+++ b/test/attr/attr_availability.swift
@@ -1217,9 +1217,17 @@ struct BadRename {
   init(range: Range<Int>, step: Int) { }
 }
 
+func log(message: String) { }
+
+@available(*, unavailable, renamed: "log(message:)")
+func log(format: String, _ args: Any...) { fatalError() } // expected-note {{'log(format:_:)' has been explicitly marked unavailable here}}
+
 func testBadRename() {
   _ = BadRename(from: 5, to: 17) // expected-warning{{'init(from:to:step:)' is deprecated: replaced by 'init(range:step:)'}}{{documentation-file=deprecated-declaration}}
   // expected-note@-1{{use 'init(range:step:)' instead}}
+
+  // Regression test for https://github.com/apple/swift/issues/64694
+  log(format: "") // expected-error{{'log(format:_:)' has been renamed to 'log(message:)'}}
 }
 
 struct AvailableGenericParam<@available(*, deprecated) T> {}

--- a/test/attr/attr_availability_unavailable_query.swift
+++ b/test/attr/attr_availability_unavailable_query.swift
@@ -59,13 +59,3 @@ func testUnavailableExpandAllElsePaths() {
     foo()
   }
 }
-
-func log(message: String) {}
-
-@available(*, unavailable, renamed: "log(message:)")
-func log(format: String, _ args: Any...) { fatalError() } // expected-note {{'log(format:_:)' has been explicitly marked unavailable here}}
-
-// Regression test for https://github.com/apple/swift/issues/64694
-func testUnavailableRenamedFromVariadicDoesntAssert() {
-  log(format: "") // expected-error{{'log(format:_:)' has been renamed to 'log(message:)'}}
-}

--- a/test/attr/attr_availability_unavailable_query.swift
+++ b/test/attr/attr_availability_unavailable_query.swift
@@ -59,3 +59,39 @@ func testUnavailableExpandAllElsePaths() {
     foo()
   }
 }
+
+// Verify that secondary (non-availability) conditions prevent the else branch
+// from being refined. The else branch can fire because the secondary condition
+// failed, in which case the platform may still be unavailable.
+// expected-note@+1 *{{add '@available' attribute to enclosing global function}}
+func testUnavailableWithSecondaryConditions() {
+  let x: Int? = 0
+
+  // With a secondary condition, the else branch is not refined because it
+  // could be reached when the secondary condition fails (not because the
+  // platform became available).
+  if #unavailable(macOS 998.0), let x {
+    _ = x
+  } else {
+    foo() // expected-error{{'foo()' is only available in macOS 998.0 or newer}}
+    // expected-note@-1 {{add 'if #available' version check}}
+  }
+
+  // Same with a boolean secondary condition.
+  if #unavailable(macOS 998.0), x != nil {
+  } else {
+    foo() // expected-error{{'foo()' is only available in macOS 998.0 or newer}}
+    // expected-note@-1 {{add 'if #available' version check}}
+  }
+
+  // Else-if chains are also not refined.
+  if #unavailable(macOS 998.0), let x {
+    _ = x
+  } else if x == nil {
+    foo() // expected-error{{'foo()' is only available in macOS 998.0 or newer}}
+    // expected-note@-1 {{add 'if #available' version check}}
+  } else {
+    foo() // expected-error{{'foo()' is only available in macOS 998.0 or newer}}
+    // expected-note@-1 {{add 'if #available' version check}}
+  }
+}


### PR DESCRIPTION
When an `if #unavalable` statement also includes a secondary (non-availability) condition, the availability scope for the else branch should not be refined. The else branch can be reached because the secondary condition failed, in which case the availability condition may not hold.

Resolves rdar://165863221.