### PR TITLE
Avoid deprecated withUnsafeContinuation(isolation:) use

### DIFF
--- a/stdlib/public/Observation/Sources/Observation/ContinuousObservation.swift
+++ b/stdlib/public/Observation/Sources/Observation/ContinuousObservation.swift
@@ -160,6 +160,7 @@ extension ContinuousObservation.State {
     while await track(state, options: options, apply: apply) {}
   }
 
+  @diagnose(DeprecatedDeclaration, as: ignored)
   fileprivate static func track(
     _ state: _ManagedCriticalState<ContinuousObservation.State>,
     options: ObservationTracking.Options,


### PR DESCRIPTION
This can now just use the nonsending(nonisoleted) version instead;

Edit, heh actually, this changes semantics since it's not the surrounding context but the one from the apply... Can we do this change @phausler or was this load bearing (seems tests pass with this)? Technically this was abusing the API tbh a little bit.

resolves rdar://176905516
