### PR TITLE
[cxx-interop] Import __int128 as CInt128

### DIFF
--- a/lib/IRGen/IRABIDetailsProvider.cpp
+++ b/lib/IRGen/IRABIDetailsProvider.cpp
@@ -57,6 +57,8 @@ getPrimitiveTypeFromLLVMType(ASTContext &ctx, const llvm::Type *type) {
       return ctx.getUInt32Type();
     case 64:
       return ctx.getUInt64Type();
+    case 128:
+      return ctx.getUInt128Type();
     default:
       return std::nullopt;
     }

--- a/lib/PrintAsClang/PrimitiveTypeMapping.cpp
+++ b/lib/PrintAsClang/PrimitiveTypeMapping.cpp
@@ -112,10 +112,12 @@ void PrimitiveTypeMapping::initialize(ASTContext &ctx) {
   MAP(Int16, "int16_t", false);
   MAP(Int32, "int32_t", false);
   MAP(Int64, "int64_t", false);
+  MAP(Int128, "__int128", false);
   MAP(UInt8, "uint8_t", false);
   MAP(UInt16, "uint16_t", false);
   MAP(UInt32, "uint32_t", false);
   MAP(UInt64, "uint64_t", false);
+  MAP(UInt128, "unsigned __int128", false);
 
   MAP(Float, "float", false);
   MAP(Double, "double", false);

--- a/stdlib/public/core/CTypes.swift
+++ b/stdlib/public/core/CTypes.swift
@@ -41,6 +41,10 @@ public typealias CUnsignedLong = UInt
 /// The C 'unsigned long long' type.
 public typealias CUnsignedLongLong = UInt64
 
+/// The C 'unsigned __int128' type.
+@available(SwiftStdlib 6.0, *)
+public typealias CUnsignedInt128 = UInt128
+
 /// The C 'signed char' type.
 public typealias CSignedChar = Int8
 
@@ -63,6 +67,10 @@ public typealias CLong = Int
 
 /// The C 'long long' type.
 public typealias CLongLong = Int64
+
+/// The C '__int128' type.
+@available(SwiftStdlib 6.0, *)
+public typealias CInt128 = Int128
 
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
 /// The C '_Float16' type.

--- a/test/ClangImporter/Inputs/ctypes_int128.h
+++ b/test/ClangImporter/Inputs/ctypes_int128.h
@@ -1,0 +1,10 @@
+#ifndef CTYPES_INT128_H
+#define CTYPES_INT128_H
+
+__int128 returns_int128(void);
+void takes_int128(__int128);
+
+unsigned __int128 returns_uint128(void);
+void takes_uint128(unsigned __int128);
+
+#endif

--- a/test/ClangImporter/ctypes_int128.swift
+++ b/test/ClangImporter/ctypes_int128.swift
@@ -1,0 +1,18 @@
+// RUN: %target-swift-frontend -enable-objc-interop -import-objc-header %S/Inputs/ctypes_int128.h -typecheck -verify %s
+// RUN: %target-swift-frontend -cxx-interoperability-mode=default -import-objc-header %S/Inputs/ctypes_int128.h -typecheck -verify %s
+
+// REQUIRES: PTRSIZE=64
+
+@available(SwiftStdlib 6.0, *)
+func test_int128() {
+  let x: CInt128 = returns_int128()
+  let _: Int128 = x
+  takes_int128(x)
+}
+
+@available(SwiftStdlib 6.0, *)
+func test_uint128() {
+  let x: CUnsignedInt128 = returns_uint128()
+  let _: UInt128 = x
+  takes_uint128(x)
+}

--- a/test/Interop/SwiftToCxx/functions/swift-int128-functions-cxx-bridging.swift
+++ b/test/Interop/SwiftToCxx/functions/swift-int128-functions-cxx-bridging.swift
@@ -1,0 +1,21 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -module-name Int128Module -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/int128.h
+// RUN: %FileCheck %s < %t/int128.h
+
+// RUN: %check-interop-cxx-header-in-clang(%t/int128.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
+
+// REQUIRES: PTRSIZE=64
+
+// CHECK:      SWIFT_INLINE_THUNK __int128 passThroughInt128(__int128 x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT{{.*}} {
+// CHECK-NEXT:   return Int128Module::_impl::{{.*}}(x);
+// CHECK-NEXT: }
+
+// CHECK:      SWIFT_INLINE_THUNK unsigned __int128 passThroughUInt128(unsigned __int128 x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT{{.*}} {
+// CHECK-NEXT:   return Int128Module::_impl::{{.*}}(x);
+// CHECK-NEXT: }
+
+@available(SwiftStdlib 6.0, *)
+public func passThroughInt128(_ x: Int128) -> Int128 { return x }
+
+@available(SwiftStdlib 6.0, *)
+public func passThroughUInt128(_ x: UInt128) -> UInt128 { return x }


### PR DESCRIPTION
Swift gained native Int128 / UInt128 types in SE-0425, but the plumbing for bridging them across the C/C++ boundary was incomplete. CInt128 and CUnsignedInt128 were never added to CTypes.swift, even though BuiltinMappedTypes.def has been mapping __int128 / unsigned __int128 to those names since 2013. Without the typealiases, every C declaration mentioning __int128 was silently dropped at import time.

This patch adds the CInt128 and CUInt128 type aliases to CTypes.swift for forward interop, and also adds the Int128 -> __int128 mapping in PrintAsClang and IRABIDetailsProvider for reverse interop.

rdar://177111210