### PR TITLE
[6.4] Asynchronous Catching Result initializer

### DIFF
--- a/Runtimes/Core/Concurrency/CMakeLists.txt
+++ b/Runtimes/Core/Concurrency/CMakeLists.txt
@@ -84,6 +84,7 @@ add_library(swift_Concurrency
   PlatformExecutorOpenBSD.swift
   PlatformExecutorWindows.swift
   PriorityQueue.swift
+  Result+AsyncInit.swift
   SourceCompatibilityShims.swift
   SuspendingClock.swift
   Task.swift

--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -167,6 +167,7 @@ set(SWIFT_RUNTIME_CONCURRENCY_SWIFT_SOURCES
   PlatformExecutorWindows.swift
   PlatformExecutorOpenBSD.swift
   PlatformExecutorFreeBSD.swift
+  Result+AsyncInit.swift
 )
 
 set(SWIFT_RUNTIME_CONCURRENCY_NONEMBEDDED_C_SOURCES

--- a/stdlib/public/Concurrency/Result+AsyncInit.swift
+++ b/stdlib/public/Concurrency/Result+AsyncInit.swift
@@ -1,0 +1,33 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Swift
+@_implementationOnly import SwiftConcurrencyInternalShims
+
+@available(SwiftStdlib 5.1, *)
+extension Result where Success: ~Copyable {
+  /// Creates a new result by evaluating an async throwing closure, capturing the
+  /// returned value as a success, or any thrown error as a failure.
+  ///
+  /// - Parameter body: A potentially throwing async closure to evaluate.
+  @_alwaysEmitIntoClient
+  public nonisolated(nonsending) init(
+    catching body: nonisolated(nonsending) () async throws(Failure) -> Success
+  ) async {
+    // FIXME: this may also require similar changes as the synchronous Result.init(catching:) support non-escapable types.
+    do {
+      self = .success(try await body())
+    } catch {
+      self = .failure(error)
+    }
+  }
+}

--- a/test/stdlib/Result.swift
+++ b/test/stdlib/Result.swift
@@ -122,6 +122,43 @@ ResultTests.test("Throwing Initialization and Unwrapping") {
   _ = result5.get() // no need for 'try'
 }
 
+ResultTests.test("Async Initialization") {
+#if os(WASI)
+  // FIXME: https://github.com/swiftlang/swift/issues/89155
+  // wasi-wasm32 traps in Result<T, any Error>'s value-witness copy
+  // after returning from the new Result.init(catching:) async.
+#else
+  func asyncThrowing() async throws -> String {
+    throw Err.err
+  }
+
+  func asyncNotThrowing() async throws -> String {
+    return string
+  }
+
+  let result1 = await Result { try await asyncThrowing() }
+  let result2 = await Result { try await asyncNotThrowing() }
+
+  expectEqual(result1.failure as? Err, Err.err)
+  expectEqual(result2.success, string)
+    
+  do {
+    _ = try result1.get()
+  } catch let error as Err {
+    expectEqual(error, Err.err)
+  } catch {
+    expectUnreachable()
+  }
+    
+  do {
+    let unwrapped = try result2.get()
+    expectEqual(unwrapped, string)
+  } catch {
+    expectUnreachable()
+  }
+#endif
+}
+
 ResultTests.test("Functional Transforms") {
   func transformDouble(_ int: Int) -> Int {
     return 2 * int
@@ -207,4 +244,4 @@ ResultTests.test("Hashable") {
   checkHashable(confusables, equalityOracle: { $0 == $1 })
 }
 
-runAllTests()
+await runAllTestsAsync()


### PR DESCRIPTION
**Explanation**: 
Adds `init(catching:)` with `async` closure to the `Result` type.
This was pitched and accepted in https://github.com/swiftlang/swift-evolution/pull/3234

**Risk**: Low, this is purely additional. 

**Testing**: New test coverage. We'll also tun source compatibility suite.

**Original PR:** https://github.com/swiftlang/swift/pull/88465

**Reviewed by:** @ktoso (original PR by @mattmassicotte)

**Issues**: 
Resolves rdar://102379069