### PR TITLE
Empty failable init override produces misleading error

### DIFF
--- a/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
+++ b/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
@@ -2379,7 +2379,7 @@ void LifetimeChecker::handleLoadUseFailure(const DIMemoryUse &Use,
       }
     }
   }
-  
+
   // If this is a copy_addr into the 'self' argument, and the memory object is a
   // rootself struct/enum or a non-delegating initializer, then we're looking at
   // the implicit "return self" in an address-only initializer.  Emit a specific
@@ -2393,6 +2393,24 @@ void LifetimeChecker::handleLoadUseFailure(const DIMemoryUse &Use,
                                                             Use)) {
         return;
       }
+    }
+  }
+
+  // Check if the superclass initializer is called
+  // in an failable initializer of a class that inherits from another class.
+  if (auto *EI = dyn_cast<EnumInst>(Inst)) {
+    if (isFailableInitReturnUseOfEnum(EI) && TheMemory.isNonRootClassSelf()) {
+      if (!shouldEmitError(Inst)) return;
+      if (!SuperInitDone) {
+        diagnose(Module, Inst->getLoc(),
+                 diag::superselfinit_not_called_before_return,
+                 (unsigned)TheMemory.isDelegatingInit());
+      } else {
+        diagnose(Module, Inst->getLoc(),
+                 diag::return_from_init_without_initing_stored_properties);
+        noteUninitializedMembers(Use);
+      }
+      return;
     }
   }
 

--- a/test/SILOptimizer/definite_init_diagnostics.swift
+++ b/test/SILOptimizer/definite_init_diagnostics.swift
@@ -1716,3 +1716,12 @@ extension P_74478 where A == (Int, (Bool, Never)) {
     switch x {} // expected-error {{constant 'x.0' used before being initialized}}
   }
 }
+
+// failable init override that not call super.init should report missing error
+class BaseForFailableOverrideInit {
+  init?(fail: String) {}
+}
+
+class DerivedFailableOverrideInit: BaseForFailableOverrideInit {
+  override init?(fail: String) {} // expected-error {{'super.init' isn't called on all paths before returning from initializer}}
+}


### PR DESCRIPTION
When a derived class overrides a failable initializer with an empty body, the definite initialization pass was emitting 
**'self' used before 'super.init' call** instead of  **'super.init' isn't called on all paths before returning from initializer** 


Other similar checks are performed in `LifetimeChecker` by looking `SIL` code, so this way this patch improve the error message in `LifetimeChecker::handleLoadUseFailure` by checking whether a failable initializer does not call `super.init().` 

This can be done by checking for an `EnumInst` that represents the optional return value from the failable initializer and verifying that `super.init()`  was not called.

#61483 