### PR TITLE
[android][test] Fix new SILOptimizer test for 32-bit platforms like Android armv7

### DIFF
--- a/test/SILOptimizer/specialize_by_integer_parameter.swift
+++ b/test/SILOptimizer/specialize_by_integer_parameter.swift
@@ -5,7 +5,7 @@ public struct Foo<let count: Int> {
 	// CHECK:         [[PARAM_VAL:%.*]] = type_value $Int for count
 	// CHECK:         [[SPEC_INT:%.*]] = integer_literal ${{.*}}, 3
 	// CHECK:         [[PARAM_INT:%.*]] = struct_extract [[PARAM_VAL]], #Int._value
-	// CHECK:         builtin "cmp_eq_Int64"([[PARAM_INT]], [[SPEC_INT]])
+	// CHECK:         builtin "cmp_eq_Int{{64|32}}"([[PARAM_INT]], [[SPEC_INT]])
     @specialized(where count == 3)
     public func bar() -> Int {
 		return count


### PR DESCRIPTION
Otherwise, it is [failing like this on the Android CI](https://ci.swift.org/job/oss-swift-package-swift-sdk-for-android/456/console):
```
14:48:34  # executed command: /home/build-user/build/swift-project/Ninja-Release/swift-linux-x86_64/bin/swift-frontend -target armv7-unknown-linux-android -sdk /home/build-user/build/ndk/android-ndk-r28c/toolchains/llvm/prebuilt/linux-x86_64/sysroot -resource-dir /home/build-user/build/swift-project/Ninja-Release/swift-linux-x86_64/lib/swift -module-cache-path /home/build-user/build/swift-project/Ninja-Release/swift-linux-x86_64/swift-test-results/armv7-unknown-linux-androideabi/clang-module-cache -swift-version 4 -define-availability 'SwiftStdlib 9999:macOS 9999, iOS 9999, watchOS 9999, tvOS 9999' -define-availability 'SwiftStdlib 5.0:macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2' -define-availability 'SwiftStdlib 5.1:macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0' -define-availability 'SwiftStdlib 5.2:macOS 10.15.4, iOS 13.4, watchOS 6.2, tvOS 13.4' -define-availability 'SwiftStdlib 5.3:macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0' -define-availability 'SwiftStdlib 5.4:macOS 11.3, iOS 14.5, watchOS 7.4, tvOS 14.5' -define-availability 'SwiftStdlib 5.5:macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0' -define-availability 'SwiftStdlib 5.6:macOS 12.3, iOS 15.4, watchOS 8.5, tvOS 15.4' -define-availability 'SwiftStdlib 5.7:macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0' -define-availability 'SwiftStdlib 5.8:macOS 13.3, iOS 16.4, watchOS 9.4, tvOS 16.4' -define-availability 'SwiftStdlib 5.9:macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0' -define-availability 'SwiftStdlib 5.10:macOS 14.4, iOS 17.4, watchOS 10.4, tvOS 17.4, visionOS 1.1' -define-availability 'SwiftStdlib 6.0:macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0' -define-availability 'SwiftStdlib 6.1:macOS 15.4, iOS 18.4, watchOS 11.4, tvOS 18.4, visionOS 2.4' -define-availability 'SwiftStdlib 6.2:anyAppleOS 26.0' -define-availability 'SwiftStdlib 6.3:anyAppleOS 26.4' -define-availability 'SwiftStdlib 6.4:anyAppleOS 9999' -define-availability 'SwiftStdlib 6.5:anyAppleOS 9999' -define-availability 'SwiftCompatibilitySpan 5.0:macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, visionOS 1.0' -define-availability 'SwiftCompatibilitySpan 6.2:macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0' -define-availability 'Backtracing 6.2: macOS 26.0' -typo-correction-limit 10 -solver-enable-crash-on-valid-salvage -disable-availability-checking -emit-sil -O /source/swift-project/swift/test/SILOptimizer/specialize_by_integer_parameter.swift
14:48:34  # executed command: /usr/bin/python3.12 /source/swift-project/swift/utils/PathSanitizingFileCheck --allow-unused-prefixes --sanitize TMP_DIR=/home/build-user/build/swift-project/Ninja-Release/swift-linux-x86_64/test-android-armv7/SILOptimizer/Output/specialize_by_integer_parameter.swift.tmp --sanitize BUILD_DIR=/home/build-user/build/swift-project/Ninja-Release/swift-linux-x86_64 --sanitize SOURCE_DIR=/source/swift-project/swift --ignore-runtime-warnings --use-filecheck /home/build-user/build/swift-project/Ninja-Release/llvm-linux-x86_64/bin/FileCheck /source/swift-project/swift/test/SILOptimizer/specialize_by_integer_parameter.swift
14:48:34  # .---command stderr------------
14:48:34  # | /source/swift-project/swift/test/SILOptimizer/specialize_by_integer_parameter.swift:8:12: error: CHECK: expected string not found in input
14:48:34  # |  // CHECK: builtin "cmp_eq_Int64"([[PARAM_INT]], [[SPEC_INT]])
14:48:34  # |            ^
14:48:34  # | <stdin>:32:37: note: scanning from here
14:48:34  # |  %3 = struct_extract %1, #Int._value // user: %4
14:48:34  # |                                     ^
14:48:34  # | <stdin>:32:37: note: with "PARAM_INT" equal to "%3"
14:48:34  # |  %3 = struct_extract %1, #Int._value // user: %4
14:48:34  # |                                     ^
14:48:34  # | <stdin>:32:37: note: with "SPEC_INT" equal to "%2"
14:48:34  # |  %3 = struct_extract %1, #Int._value // user: %4
14:48:34  # |                                     ^
14:48:34  # | <stdin>:33:7: note: possible intended match here
14:48:34  # |  %4 = builtin "cmp_eq_Int32"(%3, %2) : $Builtin.Int1 // user: %5
14:48:34  # |       ^