### PR TITLE
[6.4] PackSpecialization: Handle error result separately, propagate apply nothrow & async flags

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ConstantCapturePropagation.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ConstantCapturePropagation.swift
@@ -156,7 +156,7 @@ private func specializeClosure(specializedName: String,
   newParams.append(contentsOf: nonConstantArguments.map { partialApply.parameter(for: $0)! })
 
   let isGeneric = newParams.contains { $0.type.hasTypeParameter } ||
-                  callee.convention.results.contains { $0.type.hasTypeParameter } ||
+                  callee.convention.resultsWithError.contains { $0.type.hasTypeParameter } ||
                   callee.convention.errorResult?.type.hasTypeParameter ?? false
 
   let representation = partialApply.callee.type.functionTypeRepresentation

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LoopInvariantCodeMotion.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LoopInvariantCodeMotion.swift
@@ -1134,7 +1134,7 @@ private extension LoadInst {
 private extension FullApplySite {
   /// Returns `true` if this apply inst could be safely hoisted.
   func isSafeReadOnlyApply(_ calleeAnalysis: CalleeAnalysis) -> Bool {
-    guard functionConvention.results.allSatisfy({ $0.convention == .unowned }) else {
+    guard functionConvention.resultsWithError.allSatisfy({ $0.convention == .unowned }) else {
       return false
     }
 

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/PackSpecialization.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/PackSpecialization.swift
@@ -259,7 +259,8 @@ private struct CallSiteSpecializer {
     // Emit a call to the specialized function
     let specializedFunctionRef = builder.createFunctionRef(self.callee.specialized)
     let specializedApply = builder.createApply(
-      function: specializedFunctionRef, self.apply.substitutionMap, arguments: arguments)
+      function: specializedFunctionRef, self.apply.substitutionMap, arguments: arguments,
+      isNonThrowing: self.apply.isNonThrowing, isNonAsync: self.apply.isNonAsync)
     return specializedApply
   }
 
@@ -355,7 +356,7 @@ private struct CallSiteSpecializer {
     var mappedResultPacks = self.callee.resultMap.makeIterator()
     var indirectResultIterator = self.apply.indirectResultOperands.makeIterator()
 
-    for resultInfo in self.apply.functionConvention.results {
+    for resultInfo in self.apply.functionConvention.formalResults {
       // We only need to handle direct and pack results, since indirect results are handled above
       if !resultInfo.isSILIndirect {
         // Direct results of the original function are mapped to direct results of the specialized function.
@@ -651,7 +652,7 @@ private struct PackExplodedFunction {
     var indirectResultIterator = function.arguments[0..<function.convention.indirectSILResultCount]
       .lazy.enumerated().makeIterator()
 
-    for (resultIndex, resultInfo) in function.convention.results.enumerated() {
+    for (resultIndex, resultInfo) in function.convention.formalResults.enumerated() {
       assert(
         !resultInfo.isSILIndirect || !indirectResultIterator.isEmpty,
         "There must be exactly as many indirect results in the function convention and argument list."
@@ -770,7 +771,7 @@ private struct PackExplodedFunction {
 
         // Collect any direct results before the next mappedResult.
         while resultIndex < mappedResult.resultIndex {
-          if !self.original.convention.results[resultIndex].isSILIndirect {
+          if !self.original.convention.formalResults[resultIndex].isSILIndirect {
             returnValues.append(originalDirectResultIterator.next()!)
           }
           resultIndex += 1

--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyApply.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyApply.swift
@@ -95,7 +95,7 @@ private func tryRemoveArrayCast(apply: ApplyInst, _ context: SimplifyContext) ->
           // Check if the cast function has the expected calling convention
         apply.arguments.count == 1,
         apply.convention(of: apply.argumentOperands[0]) == .directGuaranteed,
-        apply.functionConvention.results[0].convention == .owned,
+        apply.functionConvention.resultsWithError[0].convention == .owned,
         apply.type.isOptional,
 
         // Check if the source and target type of the cast is identical.

--- a/SwiftCompilerSources/Sources/SIL/FunctionConvention.swift
+++ b/SwiftCompilerSources/Sources/SIL/FunctionConvention.swift
@@ -36,9 +36,17 @@ public struct FunctionConvention : CustomStringConvertible {
     self.hasLoweredAddresses = hasLoweredAddresses
   }
 
-  /// All results including the error.
+  /// All results including the error. Most callers want `formalResults`;
+  /// reach for this only when the error result should be processed alongside
+  /// the formal ones.
   public var results: Results {
     Results(bridged: SILFunctionType_getResultsWithError(functionType.bridged),
+      hasLoweredAddresses: hasLoweredAddresses)
+  }
+
+  /// The formal results, excluding the error result.
+  public var formalResults: Results {
+    Results(bridged: SILFunctionType_getResults(functionType.bridged),
       hasLoweredAddresses: hasLoweredAddresses)
   }
 

--- a/SwiftCompilerSources/Sources/SIL/FunctionConvention.swift
+++ b/SwiftCompilerSources/Sources/SIL/FunctionConvention.swift
@@ -39,7 +39,7 @@ public struct FunctionConvention : CustomStringConvertible {
   /// All results including the error. Most callers want `formalResults`;
   /// reach for this only when the error result should be processed alongside
   /// the formal ones.
-  public var results: Results {
+  public var resultsWithError: Results {
     Results(bridged: SILFunctionType_getResultsWithError(functionType.bridged),
       hasLoweredAddresses: hasLoweredAddresses)
   }
@@ -67,7 +67,7 @@ public struct FunctionConvention : CustomStringConvertible {
 
   /// Returns the indirect result - including the error - at `index`.
   public func indirectSILResult(at index: Int) -> ResultInfo {
-    let indirectResults = results.lazy.filter {
+    let indirectResults = resultsWithError.lazy.filter {
       hasLoweredAddresses ? $0.isSILIndirect : $0.convention == .pack
     }
     // Note that subscripting a LazyFilterCollection (with the base index, e.g. `Int`) does not work
@@ -107,23 +107,23 @@ public struct FunctionConvention : CustomStringConvertible {
   }
 
   public var hasGuaranteedResult: Bool {
-    if results.count != 1 {
+    if resultsWithError.count != 1 {
       return false
     }
     if hasLoweredAddresses {
-      return results[0].convention == .guaranteed
+      return resultsWithError[0].convention == .guaranteed
     }
-    return results[0].convention == .guaranteed || results[0].convention == .guaranteedAddress
+    return resultsWithError[0].convention == .guaranteed || resultsWithError[0].convention == .guaranteedAddress
   }
 
   public var hasAddressResult: Bool {
-    if results.count != 1 {
+    if resultsWithError.count != 1 {
       return false
     }
     if hasLoweredAddresses {
-      return results[0].convention == .guaranteedAddress || results[0].convention == .inout
+      return resultsWithError[0].convention == .guaranteedAddress || resultsWithError[0].convention == .inout
     }
-    return results[0].convention == .inout
+    return resultsWithError[0].convention == .inout
   }
 
   public var description: String {
@@ -134,7 +134,7 @@ public struct FunctionConvention : CustomStringConvertible {
         str += "\n lifetime: \(deps)"
       }
     }
-    results.forEach { str += "\n   result: " + $0.description }
+    resultsWithError.forEach { str += "\n   result: " + $0.description }
     if let deps = resultDependencies {
       str += "\n lifetime: \(deps)"
     }

--- a/SwiftCompilerSources/Sources/SIL/Utilities/BorrowUtils.swift
+++ b/SwiftCompilerSources/Sources/SIL/Utilities/BorrowUtils.swift
@@ -640,7 +640,7 @@ extension Value {
     guard apply.singleDirectResult != nil else {
       return false
     }
-    return apply.functionConvention.results[0].convention == .guaranteed
+    return apply.functionConvention.resultsWithError[0].convention == .guaranteed
   }
 }
 

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -239,6 +239,9 @@ enum class BridgedLinkage {
 //                              SILFunctionType
 // =========================================================================//
 
+SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedResultInfoArray
+    SILFunctionType_getResults(BridgedCanType);
+
 SWIFT_IMPORT_UNSAFE BRIDGED_INLINE
 BridgedResultInfoArray SILFunctionType_getResultsWithError(BridgedCanType);
 

--- a/include/swift/SIL/SILBridgingImpl.h
+++ b/include/swift/SIL/SILBridgingImpl.h
@@ -253,6 +253,10 @@ BridgedOwnedString BridgedLifetimeDependenceInfo::getDebugDescription() const {
 //                               SILFunctionType
 //===----------------------------------------------------------------------===//
 
+BridgedResultInfoArray SILFunctionType_getResults(BridgedCanType funcTy) {
+  return {funcTy.unbridged()->castTo<swift::SILFunctionType>()->getResults()};
+}
+
 BridgedResultInfoArray
 SILFunctionType_getResultsWithError(BridgedCanType funcTy) {
   return {funcTy.unbridged()->castTo<swift::SILFunctionType>()->getResultsWithError()};

--- a/test/SILOptimizer/issue-88987.swift
+++ b/test/SILOptimizer/issue-88987.swift
@@ -1,0 +1,70 @@
+// RUN: %target-swift-frontend %s -emit-sil -O -swift-version 6 -target %target-swift-5.9-abi-triple -o /dev/null
+
+// REQUIRES: swift_in_compiler
+
+// Regression tests for:
+// * https://github.com/swiftlang/swift/issues/88987
+// * https://github.com/swiftlang/swift/issues/88985
+// see also rdar://176675014&176674961
+//
+// PackSpecialization built the new function signature by iterating
+// `convention.results`, which includes the error result. After
+// GenericSpecializer converted `@error_indirect E` to `@error E` (E =
+// Never), the error slot got appended to the new direct results while
+// `createSpecializedFunctionDeclaration` separately preserved it as
+// `@error`, producing `(@owned Result, @owned Never, @error Never)`.
+
+// #88987
+
+public struct Product<each Element> {
+    public let values: (repeat each Element)
+
+    @inlinable
+    public init(_ values: repeat each Element) {
+        self.values = (repeat each values)
+    }
+}
+
+extension Product {
+    @inlinable
+    public consuming func map<each NewElement, E: Swift.Error>(
+        _ transforms: repeat (each Element) throws(E) -> each NewElement
+    ) throws(E) -> Product<repeat each NewElement> {
+        Product<repeat each NewElement>(
+            repeat try (each transforms)(each values)
+        )
+    }
+}
+
+@inlinable
+public func _instantiate88987() -> Product<Int, String, Bool>? {
+    let triple = Product(1, "hi", true)
+    return try? triple.map(
+        { (x: Int) -> Int in x + 1 },
+        { (s: String) -> String in s.uppercased() },
+        { (b: Bool) -> Bool in !b }
+    )
+}
+
+// #88985
+
+extension Product {
+    @inlinable
+    public static func mapCrash<each NewElement, E: Swift.Error>(
+        _ product: consuming Product,
+        _ transforms: repeat (each Element) throws(E) -> each NewElement
+    ) throws(E) -> Product<repeat each NewElement> {
+        Product<repeat each NewElement>(
+            repeat try (each transforms)(each product.values)
+        )
+    }
+}
+
+@inlinable
+public func _instantiate88985() -> Product<Int, String>? {
+    try? Product.mapCrash(
+        Product(1, "hi"),
+        { (x: Int) -> Int in x + 1 },
+        { (s: String) -> String in s.uppercased() }
+    )
+}

--- a/test/SILOptimizer/pack_specialization.sil
+++ b/test/SILOptimizer/pack_specialization.sil
@@ -995,3 +995,32 @@ bb0(%0 : $*Pack{Box<T>}, %1 : $*Pack{Box<T>}):
   return %4
 
 }
+
+// THROWING PACK FUNCTION TESTS:
+
+// The specialized function should have a single direct result plus the
+// preserved @error result — not the error type duplicated as a direct result.
+//
+// CHECK-LABEL: sil shared [ossa] @$s28throwing_pack_id_error_neverTf8xx_n : $@convention(thin) (Int) -> (Int, @error Never) {
+// CHECK-NOT:   Never, @error Never
+// CHECK-LABEL: } // end sil function '$s28throwing_pack_id_error_neverTf8xx_n'
+sil [ossa] @throwing_pack_id_error_never : $@convention(thin) (@pack_guaranteed Pack{Int}) -> (@pack_out Pack{Int}, @error Never) {
+bb0(%0 : $*Pack{Int}, %1 : $*Pack{Int}):
+  copy_addr %1 to [init] %0
+  %9 = tuple ()
+  return %9
+}
+
+// The apply at the call site must preserve the original `[nothrow]` flag, or
+// SIL verification rejects a plain apply of a function with an error result.
+//
+// CHECK-LABEL: sil [ossa] @call_throwing_pack_id_error_never : $@convention(thin) (@pack_guaranteed Pack{Int}) -> (@pack_out Pack{Int}, @error Never) {
+// CHECK:         [[FN_REF:%[0-9]+]] = function_ref @$s28throwing_pack_id_error_neverTf8xx_n : $@convention(thin) (Int) -> (Int, @error Never)
+// CHECK:         apply [nothrow] [[FN_REF]]
+// CHECK-LABEL: } // end sil function 'call_throwing_pack_id_error_never'
+sil [ossa] @call_throwing_pack_id_error_never : $@convention(thin) (@pack_guaranteed Pack{Int}) -> (@pack_out Pack{Int}, @error Never) {
+bb0(%0 : $*Pack{Int}, %1 : $*Pack{Int}):
+  %10 = function_ref @throwing_pack_id_error_never : $@convention(thin) (@pack_guaranteed Pack{Int}) -> (@pack_out Pack{Int}, @error Never)
+  %11 = apply [nothrow] %10(%0, %1) : $@convention(thin) (@pack_guaranteed Pack{Int}) -> (@pack_out Pack{Int}, @error Never)
+  return %11
+}


### PR DESCRIPTION
- **Explanation**: The C++ `SILFunctionType` exposes both `getResults()` (formal results only) and `getResultsWithError()` (formal + error). The Swift mirror previously only had `results`, bridging to the with-error variant. Add `formalResults` for the formal-only view, matching the C++ split. Also rename the existing `results` member to `resultsWithError` to prevent further issues caused by the original, ambiguous name.

  Switch PackSpecialization's three result-iteration sites to `formalResults`. The bridged `createSpecializedFunctionDeclaration` preserves the error result on its own, so iterating with-error included it twice in the new function's signature.

  Also forward the original apply's `nothrow`/`noasync` flags to the specialized apply, required for SIL verification of a plain apply calling a function with an error result.

  <!--
  A description of the changes. This can be brief, but it should be clear.
  -->
- **Scope**: This fixes a compiler crash regression, so it is essential. It allows specializations of throwing variadic generics that never throw (i.e. `nothrow`) to be optimized correctly by the PackSpecialization pass. This should not break existing code.
  <!--
  An assessment of the impact and importance of the changes. For example, can
  the changes break existing code?
  -->
- **Issues**:
  - #88985
  - #88987
  - rdar://176674961
  - rdar://176675014 
  <!--
  References to issues the changes resolve, if any.
  -->
- **Original PRs**: https://github.com/swiftlang/swift/pull/89123
  <!--
  Links to mainline branch pull requests in which the changes originated.
  -->
- **Risk**: This could unmask other issues with running PackSpecialization for `nothrow` throwing functions. This is unlikely, since such functions are mostly the same as non-throwing functions, which PackSpecialization has transformed without issue for some time.
  <!--
  The (specific) risk to the release for taking the changes.
  -->
- **Testing**: Unit tests, integration tests based on the original bug reports.
  <!--
  The specific testing that has been done or needs to be done to further
  validate any impact of the changes.
  -->
- **Reviewers**: @atrick @meg-gupta
  <!--
  The code owners that GitHub-approved the original changes in the mainline
  branch pull requests. If an original change has not been GitHub-approved by
  a respective code owner, provide a reason. Technical review can be delegated
  by a code owner or otherwise requested as deemed appropriate or useful.
  -->
<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
