### PR TITLE
[6.4] Lifetimes: Replace deps on partial_apply parameters with 'captures'

### DIFF
--- a/include/swift/AST/LifetimeDependence.h
+++ b/include/swift/AST/LifetimeDependence.h
@@ -425,6 +425,21 @@ public:
   uncurry(ASTContext &ctx, ArrayRef<LifetimeDependenceInfo> inner,
           unsigned numInnerParams, unsigned numOuterParams);
 
+  /// Compute the lifetime dependencies for the result of a partial application
+  /// of a SIL function with the given lifetimes and number of parameters,
+  /// binding the given number of arguments.
+  ///
+  /// Dependencies on parameters that are bound by the partial_apply are
+  /// replaced with 'captures' dependencies.
+  ///
+  /// Example: binding 1 argument of a 2-argument function.
+  /// %b = ... : B
+  /// %f = function_ref @closure : (A, B) -> @lifetime(borrow 1) C
+  /// %c = partial_apply %f(%b) : (A) -> @lifetime(captures) C
+  static ArrayRef<LifetimeDependenceInfo>
+  partialApply(ASTContext &ctx, ArrayRef<LifetimeDependenceInfo> lifetimes,
+               unsigned numFormalParams, unsigned numBoundParams);
+
   bool operator==(const LifetimeDependenceInfo &other) const {
     return this->hasImmortalSpecifier() == other.hasImmortalSpecifier() &&
            this->hasCaptures() == other.hasCaptures() &&

--- a/lib/AST/LifetimeDependence.cpp
+++ b/lib/AST/LifetimeDependence.cpp
@@ -2119,6 +2119,90 @@ ArrayRef<LifetimeDependenceInfo> LifetimeDependenceInfo::uncurry(
   return ctx.AllocateCopy(uncurried);
 }
 
+ArrayRef<LifetimeDependenceInfo> LifetimeDependenceInfo::partialApply(
+    ASTContext &ctx, ArrayRef<LifetimeDependenceInfo> lifetimes,
+    unsigned numFormalParams, unsigned numBoundParams) {
+
+  if (numBoundParams == 0)
+    return lifetimes;
+
+  ASSERT(numBoundParams <= numFormalParams &&
+         "A partial application can only bind as many parameters as the "
+         "function has.");
+
+  // How many parameters the resulting closure will have.
+  const unsigned numClosureParams = numFormalParams - numBoundParams;
+
+  SmallVector<LifetimeDependenceInfo, 2> curried;
+
+  for (const auto &dep : lifetimes) {
+    // Determine the new target index.
+    unsigned targetIndex;
+    if (dep.getTargetIndex() == numFormalParams) {
+      // The target is the result.
+      // Its index is the number of parameters.
+      targetIndex = numClosureParams;
+    } else if (dep.getTargetIndex() >= numClosureParams) {
+      // The target is a captured parameter.
+      // The resulting closure does not need a lifetime dependence entry for it.
+      continue;
+    } else {
+      // The target is an uncaptured parameter.
+      // Its index remains the same.
+      targetIndex = dep.getTargetIndex();
+    }
+
+    auto flags = dep.flags;
+
+    const auto captureBoundParams = [&](IndexSubset *indices) -> IndexSubset * {
+      if (!indices)
+        return nullptr;
+
+      ASSERT(indices->getCapacity() <= numFormalParams &&
+             "There should be at most 1 index per parameter. SIL functions "
+             "cannot have "
+             "an implicit self parameter.");
+
+      auto bits = indices->getBitVector();
+
+      if (bits.find_last() >= int(numClosureParams)) {
+        // One of the lifetime source parameters is bound by the partial_apply.
+        // This becomes a captures dependence in the resulting closure.
+        flags.setCaptures(true);
+      }
+
+      // Remove the indices of the captured parameters, leaving only those of
+      // the closure parameters.
+
+      if (bits.find_first() >= int(numClosureParams)) {
+        // All lifetime sources are captured. The resulting empty list of
+        // indices should be represented with a nullptr.
+        return nullptr;
+      }
+
+      if (bits.size() > numClosureParams)
+        bits.resize(numClosureParams);
+
+      return IndexSubset::get(ctx, bits);
+    };
+
+    auto inherit = captureBoundParams(dep.getInheritIndices());
+    auto scope = captureBoundParams(dep.getScopeIndices());
+    auto addressable = captureBoundParams(dep.getAddressableIndices());
+    auto conditionallyAddressable =
+        captureBoundParams(dep.getConditionallyAddressableIndices());
+
+    curried.push_back(LifetimeDependenceInfo(inherit, scope, targetIndex,
+                                             addressable,
+                                             conditionallyAddressable, flags));
+  }
+
+  // FIXME: Avoid allocating context memory for every partial apply. Instead,
+  // cache a single uniqueLifetimeDependenceInfo array for each combination
+  // of FunctionType + numBoundParams.
+  return ctx.AllocateCopy(curried);
+}
+
 void LifetimeDependenceInfo::dump() const {
   llvm::errs() << "target: " << getTargetIndex() << '\n';
   if (hasImmortalSpecifier()) {

--- a/lib/SIL/IR/SILBuilder.cpp
+++ b/lib/SIL/IR/SILBuilder.cpp
@@ -72,7 +72,11 @@ SILType SILBuilder::getPartialApplyResultType(
           .intoBuilder()
           .withRepresentation(SILFunctionType::Representation::Thick)
           .withIsolation(resultIsolation)
-          .withIsPseudogeneric(false);
+          .withIsPseudogeneric(false)
+          .withLifetimeDependencies(LifetimeDependenceInfo::partialApply(
+              context.getContext()->getASTContext(),
+              FTI->getLifetimeDependencies(), FTI->getNumParameters(),
+              argCount));
   if (onStack)
     extInfoBuilder = extInfoBuilder.withNoEscape();
   auto extInfo = extInfoBuilder.build();

--- a/test/IRGen/rdar176795176.swift
+++ b/test/IRGen/rdar176795176.swift
@@ -1,0 +1,138 @@
+// RUN: %target-swift-frontend -emit-ir -O -enable-experimental-feature Lifetimes %s
+
+// REQUIRES: swift_feature_Lifetimes
+
+// Minimal reproducer for IRGen crash: rdar://176795176
+
+// MARK: - NE
+
+public struct NE: ~Escapable {
+    @_lifetime(immortal)
+    public init() {}
+}
+
+// MARK: - INES
+
+public protocol INES: ~Escapable {
+    @_lifetime(copy self)
+    consuming func f(at indices: Range<Int>) -> NE
+}
+
+// MARK: - NES
+
+public protocol NES: ~Copyable {
+    associatedtype Bytes: INES & ~Escapable
+}
+
+// MARK: - IRef
+
+public protocol IRef<PR>: ~Copyable {
+    associatedtype PR: ~Copyable
+    associatedtype P: BitwiseCopyable
+
+    static func a(of p: P) -> UnsafePointer<PR>
+}
+
+// MARK: - Ref
+
+@frozen
+public struct Ref<L, C, PR>: ~Escapable & ~Copyable
+where
+    L: ~Escapable,
+    C: ~Copyable & IRef<PR>,
+    PR: ~Copyable
+{
+    @usableFromInline
+    let p: C.P
+
+    @_lifetime(immortal)
+    @usableFromInline
+    init(immortal p: C.P) {
+        self.p = p
+    }
+}
+
+extension Ref: Copyable
+where
+    L: ~Escapable,
+    C: Copyable
+{}
+
+extension Ref: BitwiseCopyable
+where
+    L: ~Escapable,
+    C: Copyable
+{}
+
+// MARK: - The crashing extension
+
+extension Ref: INES
+where
+    L: ~Escapable,
+    C: Copyable,
+    PR: NES & ~Copyable
+{
+    @_lifetime(copy self)
+    public consuming func f(
+        at indices: Range<Int>
+    ) -> NE {
+        let bytes = self.fromPR {
+            return _overrideL(immortal: $0[bytes: indices])
+        }
+        return _overrideL(bytes, copy: self)
+    }
+}
+
+extension Ref
+where
+    L: ~Escapable,
+    C: ~Copyable,
+    PR: ~Copyable
+{
+    @_lifetime(copy self)
+    fileprivate func fromPR<Thrown, Output: ~Escapable>(
+        body: (borrowing PR) throws(Thrown) -> Output
+    ) throws(Thrown) -> Output
+    where
+        Thrown: Error,
+        Output: ~Copyable
+    {
+        return _overrideL(
+            try body(C.a(of: self.p).pointee),
+            copy: self
+        )
+    }
+}
+
+// Subscripts used by f
+extension NES where Self: ~Copyable {
+    subscript(bytes indices: Range<Int>) -> NE {
+        @_lifetime(borrow self)
+        get {
+            NE()
+        }
+    }
+}
+
+// _overrideL stubs — mimicking stdlib
+
+@_unsafeNonescapableResult
+@_lifetime(immortal)
+@_alwaysEmitIntoClient
+@_transparent
+public func _overrideL<T: ~Copyable & ~Escapable>(
+    immortal value: consuming T
+) -> T {
+    value
+}
+
+@_unsafeNonescapableResult
+@_lifetime(copy source)
+@_alwaysEmitIntoClient
+@_transparent
+public func _overrideL<T: ~Copyable & ~Escapable, U: ~Copyable & ~Escapable>(
+    _ value: consuming T,
+    copy source: borrowing U
+) -> T {
+    value
+}


### PR DESCRIPTION
- **Explanation**: When forming a closure with `partial_apply`, replace any lifetime dependencies on specific captured parameters with the opaque `captures` dependence. Also omit any lifetime dependence with a target parameter that is bound by the `partial_apply`, since the closure will have no corresponding parameter to mark as the target of the dependence.

  Until now, the compiler would emit a `convert_function` instruction after every `partial_apply` of a function with lifetime dependencies, to give the closure its expected lifetimes. This should no longer be necessary in cases where the lifetimes were the only mismatched aspect of the resulting type.
  <!--
  A description of the changes. This can be brief, but it should be clear.
  -->
- **Scope**: High importance: this fixes a regression from 6.3. Low-impact; this should not break existing code.
  <!--
  An assessment of the impact and importance of the changes. For example, can
  the changes break existing code?
  -->
- **Issues**: rdar://176795176
  <!--
  References to issues the changes resolve, if any.
  -->
- **Original PRs**: https://github.com/swiftlang/swift/pull/89053
  <!--
  Links to mainline branch pull requests in which the changes originated.
  -->
- **Risk**: This fix allocates a new LifetimeDependenceInfo array in the AST context for each `partial_apply` instruction where it introduces a `captures` dependence. This could introduce a linear memory overhead.
  <!--
  The (specific) risk to the release for taking the changes.
  -->
- **Testing**: Regression test added, extensive unit testing on main branch.
  <!--
  The specific testing that has been done or needs to be done to further
  validate any impact of the changes.
  -->
- **Reviewers**: @atrick
  <!--
  The code owners that GitHub-approved the original changes in the mainline
  branch pull requests. If an original change has not been GitHub-approved by
  a respective code owner, provide a reason. Technical review can be delegated
  by a code owner or otherwise requested as deemed appropriate or useful.
  -->
<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
