### PR TITLE
[6.4] Sema: Fix crash when declaring an old-style variadic parameter with nonescaping type

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -8491,9 +8491,8 @@ NOTE(noncopyable_parameter_ownership_suggestion, none,
       "add '%0' %1", (StringRef, StringRef))
 ERROR(ownership_specifier_nonescaping_closure,none,
       "'%0' cannot be applied to nonescaping closure", (StringRef))
-ERROR(noncopyable_generics_variadic, none,
-      "noncopyable type %0 cannot be used within a variadic type yet",
-      (Type))
+NOTE(noncopyable_or_nonescaping_variadic, none,
+     "required because variadic parameter type must be stored inside an 'Array'", ())
 NOTE(noncopyable_generics_implicit_conformance_req, none,
      "'where %noformat0: %noformat1' is implicit here",
      (Type, Type))

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -1698,7 +1698,7 @@ TypeResolver::applyGenericArguments(Type type, DeclRefTypeRepr *repr,
 /// Apply generic arguments to the given type.
 Type TypeResolution::applyUnboundGenericArguments(
     GenericTypeDecl *decl, Type parentTy, SourceLoc loc,
-    ArrayRef<Type> genericArgs) const {
+    ArrayRef<Type> genericArgs, bool *diagnosedRequirementFailure) const {
   assert(genericArgs.size() == decl->getGenericParams()->size() &&
          "invalid arguments, use applyGenericArguments to emit diagnostics "
          "and collect arguments to pack generic parameters");
@@ -1835,6 +1835,8 @@ Type TypeResolution::applyUnboundGenericArguments(
               result.getRequirementFailureInfo(), loc, noteLoc,
               UnboundGenericType::get(decl, parentTy, ctx),
               genericSig.getGenericParams(), substitutions);
+          if (diagnosedRequirementFailure)
+            *diagnosedRequirementFailure = true;
         }
 
         LLVM_FALLTHROUGH;
@@ -6018,11 +6020,11 @@ TypeResolver::resolveDictionaryType(DictionaryTypeRepr *repr,
     return ErrorType::get(getASTContext());
   }
 
-  if (!resolution.applyUnboundGenericArguments(
-          dictDecl, nullptr, repr->getStartLoc(), {keyTy, valueTy})) {
-    assert(getASTContext().Diags.hadAnyError());
+  auto substTy = resolution.applyUnboundGenericArguments(
+          dictDecl, nullptr, repr->getStartLoc(), {keyTy, valueTy});
+  if (substTy->hasError())
     return ErrorType::get(getASTContext());
-  }
+
   return DictionaryType::get(keyTy, valueTy);
 }
 
@@ -6192,17 +6194,28 @@ NeverNullType TypeResolver::resolveVarargType(VarargTypeRepr *repr,
       .highlight(repr->getSourceRange());
   }
 
-  // do not allow move-only types as the element of a vararg
-  // FIXME: This does not correctly handle type variables and unbound generics.
-  if (inStage(TypeResolutionStage::Interface)) {
-    auto contextTy = GenericEnvironment::mapTypeIntoEnvironment(
-        resolution.getGenericSignature().getGenericEnvironment(), element);
-    if (!contextTy->hasError() && contextTy->isNoncopyable()) {
-      diagnoseInvalid(repr, repr->getLoc(), diag::noncopyable_generics_variadic,
-                      element);
-      return ErrorType::get(getASTContext());
-    }
+  auto *const arrayDecl = getASTContext().getArrayDecl();
+  if (!arrayDecl) {
+    diagnose(repr->getStartLoc(), diag::sugar_type_not_found, 0);
+    return ErrorType::get(getASTContext());
   }
+
+  bool diagnosedRequirementFailure = false;
+  auto substTy = resolution.applyUnboundGenericArguments(
+          arrayDecl, nullptr, repr->getStartLoc(), {element},
+          &diagnosedRequirementFailure);
+  if (diagnosedRequirementFailure) {
+    ASSERT(getASTContext().Diags.hadAnyError());
+
+    // If we end up here, we have an element type that cannot be stored in
+    // an Array. Add an additional note to state exactly why this type must
+    // conform to Copyable or Escapable.
+    diagnose(repr->getLoc(), diag::noncopyable_or_nonescaping_variadic);
+    return ErrorType::get(getASTContext());
+  }
+
+  if (substTy->hasError())
+    return ErrorType::get(getASTContext());
 
   return element;
 }

--- a/lib/Sema/TypeCheckType.h
+++ b/lib/Sema/TypeCheckType.h
@@ -749,7 +749,8 @@ public:
   /// \see applyGenericArguments
   Type applyUnboundGenericArguments(GenericTypeDecl *decl, Type parentTy,
                                     SourceLoc loc,
-                                    ArrayRef<Type> genericArgs) const;
+                                    ArrayRef<Type> genericArgs,
+                                    bool *diagnosedRequirementFailure=nullptr) const;
 };
 
 void diagnoseInvalidGenericArguments(SourceLoc loc, ValueDecl *decl,

--- a/test/Constraints/invalid_stdlib.swift
+++ b/test/Constraints/invalid_stdlib.swift
@@ -3,5 +3,5 @@
 // This file is for tests that used to cause the type checker to crash.
 
 class DictStringInt {
-  init(dictionaryLiteral xs: ()...) {} // expected-error{{broken standard library: cannot find Array type}}
+  init(dictionaryLiteral xs: ()...) {} // expected-error 2{{broken standard library: cannot find Array type}}
 }

--- a/test/Generics/inverse_copyable_requirement.swift
+++ b/test/Generics/inverse_copyable_requirement.swift
@@ -239,7 +239,7 @@ func checkStdlibTypes(_ mo: borrowing MO) {
   let _: [MO] = // expected-error {{type 'MO' does not conform to protocol 'Copyable'}}
       []
   let _: [String: MO] = // expected-error {{type 'MO' does not conform to protocol 'Copyable'}}
-      ["hello" : MO()]  // expected-error{{type '(String, MO)' containing noncopyable element is not supported}}
+      ["hello" : MO()]
 
   _ = [MO()] // expected-error {{generic struct 'Array' requires that 'MO' conform to 'Copyable'}}
 

--- a/test/IDE/complete_ambiguous.swift
+++ b/test/IDE/complete_ambiguous.swift
@@ -1,6 +1,6 @@
 // RUN: %batch-code-completion
 
-struct A {
+struct A: Hashable {
   func doAThings() -> A { return self }
 }
 
@@ -56,20 +56,24 @@ func testCallAsFunctionDeduplication() {
 
 givenErrorExpr(undefined).#^ERROR_IN_BASE?check=SIMPLE^#
 
-// SIMPLE: Begin completions, 4 items
+// SIMPLE: Begin completions, 6 items
 // SIMPLE-DAG: Keyword[self]/CurrNominal:          self[#A#]{{; name=.+$}}
 // SIMPLE-DAG: Decl[InstanceMethod]/CurrNominal:   doAThings()[#A#]{{; name=.+$}}
 // SIMPLE-DAG: Keyword[self]/CurrNominal:          self[#B#]{{; name=.+$}}
 // SIMPLE-DAG: Decl[InstanceMethod]/CurrNominal:   doBThings()[#Void#]{{; name=.+$}}
+// SIMPLE-DAG: Decl[InstanceMethod]/CurrNominal: hash({#into: &Hasher#})[#Void#]{{; name=.+$}}
+// SIMPLE-DAG: Decl[InstanceVar]/CurrNominal: hashValue[#Int#]{{; name=.+$}}
 
 let x2: A = overloadedReturn().#^RELATED^#
 let x3: A = overloadedReturn(1).#^RELATED_EXTRAARG?check=RELATED^#
 
-// RELATED: Begin completions, 4 items
+// RELATED: Begin completions, 6 items
 // RELATED-DAG: Keyword[self]/CurrNominal:          self[#A#]{{; name=.+$}}
 // RELATED-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Convertible]: doAThings()[#A#]{{; name=.+$}}
 // RELATED-DAG: Keyword[self]/CurrNominal:          self[#B#]{{; name=.+$}}
 // RELATED-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: doBThings()[#Void#]{{; name=.+$}}
+// RELATED-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: hash({#into: &Hasher#})[#Void#]{{; name=.+$}}
+// RELATED-DAG: Decl[InstanceVar]/CurrNominal: hashValue[#Int#]{{; name=.+$}}
 
 func takesClosureGivingA(_ callback: () -> A) -> B {}
 func takesB(_ item: B) {}
@@ -81,11 +85,12 @@ func overloadedArg(_ arg: B) -> B {}
 
 overloadedArg(.#^UNRESOLVED_AMBIGUOUS^#)
 
-// UNRESOLVED_AMBIGUOUS: Begin completions, 4 items
+// UNRESOLVED_AMBIGUOUS: Begin completions, 5 items
 // UNRESOLVED_AMBIGUOUS-DAG: Decl[InstanceMethod]/CurrNominal: doAThings({#(self): A#})[#() -> A#]{{; name=.+$}}
 // UNRESOLVED_AMBIGUOUS-DAG: Decl[Constructor]/CurrNominal/TypeRelation[Convertible]: init()[#A#]{{; name=.+$}}
 // UNRESOLVED_AMBIGUOUS-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: doBThings({#(self): B#})[#() -> Void#]{{; name=.+$}}
 // UNRESOLVED_AMBIGUOUS-DAG: Decl[Constructor]/CurrNominal/TypeRelation[Convertible]: init()[#B#]{{; name=.+$}}
+// UNRESOLVED_AMBIGUOUS-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: hash({#(self): A#})[#(into: inout Hasher) -> Void#]{{; name=.+$}}
 
 // Make sure we still offer A and B members as the user may intend to add a member on the end of the overloadedArg call later that has type B.
 takesB(overloadedArg(.#^UNRESOLVED_STILLAMBIGUOUS?check=UNRESOLVED_AMBIGUOUS^#))
@@ -132,16 +137,20 @@ struct TestRelations {
 
 // test we consider both overloads as $0 or $1 may have just not been written yet
 takesAnonClosure { $1.#^UNAMBIGUOUSCLOSURE_ARG^# }
-// UNAMBIGUOUSCLOSURE_ARG: Begin completions, 2 items
+// UNAMBIGUOUSCLOSURE_ARG: Begin completions, 4 items
 // UNAMBIGUOUSCLOSURE_ARG-DAG: Keyword[self]/CurrNominal: self[#A#]{{; name=.+$}}
 // UNAMBIGUOUSCLOSURE_ARG-DAG: Decl[InstanceMethod]/CurrNominal: doAThings()[#A#]{{; name=.+$}}
+// UNAMBIGUOUSCLOSURE_ARG-DAG: Decl[InstanceMethod]/CurrNominal: hash({#into: &Hasher#})[#Void#]{{; name=.+$}}
+// UNAMBIGUOUSCLOSURE_ARG-DAG: Decl[InstanceVar]/CurrNominal: hashValue[#Int#]{{; name=.+$}}
 
 takesAnonClosure { $0.#^AMBIGUOUSCLOSURE_ARG^# }
-// AMBIGUOUSCLOSURE_ARG: Begin completions, 4 items
+// AMBIGUOUSCLOSURE_ARG: Begin completions, 6 items
 // AMBIGUOUSCLOSURE_ARG-DAG: Keyword[self]/CurrNominal: self[#A#]{{; name=.+$}}
 // AMBIGUOUSCLOSURE_ARG-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Convertible]: doAThings()[#A#]{{; name=.+$}}
 // AMBIGUOUSCLOSURE_ARG-DAG: Keyword[self]/CurrNominal: self[#B#]{{; name=.+$}}
 // AMBIGUOUSCLOSURE_ARG-DAG: Decl[InstanceMethod]/CurrNominal: doBThings()[#Void#]{{; name=.+$}}
+// AMBIGUOUSCLOSURE_ARG-DAG: Decl[InstanceMethod]/CurrNominal: hash({#into: &Hasher#})[#Void#]{{; name=.+$}}
+// AMBIGUOUSCLOSURE_ARG-DAG: Decl[InstanceVar]/CurrNominal: hashValue[#Int#]{{; name=.+$}}
 
 takesAnonClosure { TestRelations.#^AMBIGUOUSCLOSURE_ARG_RETURN^# }
 // AMBIGUOUSCLOSURE_ARG_RETURN: Begin completions, 6 items
@@ -179,7 +188,6 @@ func arrayLiteralDictionaryMismatch<T>(a: inout T) where T: ExpressibleByDiction
 // PARSED_AS_ARRAY_KEY-DAG: Decl[StaticVar]/CurrNominal: ab[#(A, B)#]{{; name=.+$}}
 // PARSED_AS_ARRAY_KEY-DAG: Decl[Constructor]/CurrNominal: init()[#TestRelations#]{{; name=.+$}}
 
-let _: [(A, B) : B] = [TestRelations.#^PARSED_AS_ARRAY_TUPLE^#]
 let _: [(A, B)] = [TestRelations.#^PARSED_AS_ARRAY_ARRAY?check=PARSED_AS_ARRAY_TUPLE^#]
 // PARSED_AS_ARRAY_TUPLE: Begin completions, 6 items
 // PARSED_AS_ARRAY_TUPLE-DAG: Keyword[self]/CurrNominal: self[#TestRelations.Type#]{{; name=.+$}}
@@ -321,11 +329,13 @@ func genericReturn<T:D, U>(_ x: T) -> U where U == T.Item {
 
 genericReturn(CDStruct()).#^GENERIC^#
 
-// GENERIC: Begin completions, 4 items
+// GENERIC: Begin completions, 6 items
 // GENERIC-DAG: Keyword[self]/CurrNominal:          self[#B#]{{; name=.+$}}
 // GENERIC-DAG: Decl[InstanceMethod]/CurrNominal:   doBThings()[#Void#]{{; name=.+$}}
 // GENERIC-DAG: Keyword[self]/CurrNominal:          self[#A#]{{; name=.+$}}
 // GENERIC-DAG: Decl[InstanceMethod]/CurrNominal:   doAThings()[#A#]{{; name=.+$}}
+// GENERIC-DAG: Decl[InstanceMethod]/CurrNominal:   hash({#into: &Hasher#})[#Void#]{{; name=.+$}}
+// GENERIC-DAG: Decl[InstanceVar]/CurrNominal:      hashValue[#Int#]{{; name=.+$}}
 
 genericReturn().#^GENERIC_MISSINGARG?check=NORESULTS^#
 

--- a/test/Parse/inverses.swift
+++ b/test/Parse/inverses.swift
@@ -88,12 +88,18 @@ func ownership2(_ t: ~ borrowing Int) {} // expected-error {{cannot find type 'b
 
 func ownership3(_ t: consuming some ~Clone) {}
 
-func what(one: ~Copyable..., // expected-error {{noncopyable type '~Copyable' cannot be used within a variadic type yet}}
-          two: ~(Copyable...) // expected-error {{variadic parameter cannot appear outside of a function parameter list}}
-                              // expected-error@-1 {{parameter of noncopyable type '~Copyable' must specify ownership}}
+func what1(one: ~Copyable...,  // expected-error {{type '~Copyable' does not conform to protocol 'Copyable'}}
+                               // expected-note@-1 {{required because variadic parameter type must be stored inside an 'Array'}}
+           two: ~(Copyable...) // expected-error {{variadic parameter cannot appear outside of a function parameter list}}
+                               // expected-error@-1 {{parameter of noncopyable type '~Copyable' must specify ownership}}
               // expected-note@-2{{add 'borrowing' for an immutable reference}}
               // expected-note@-3{{add 'inout' for a mutable reference}}
               // expected-note@-4{{add 'consuming' to take the value from the caller}}
+          ) {}
+
+func what2(one: ~Escapable...,  // expected-error {{type '~Escapable' does not conform to protocol 'Escapable'}}
+                                // expected-note@-1 {{required because variadic parameter type must be stored inside an 'Array'}}
+           two: ~(Escapable...) // expected-error {{variadic parameter cannot appear outside of a function parameter list}}
           ) {}
 
 struct A { struct B { struct C {} } }

--- a/test/Sema/contextual-conversion-error-for-structural-position.swift
+++ b/test/Sema/contextual-conversion-error-for-structural-position.swift
@@ -5,5 +5,4 @@ let _: AnyObject = "a" // expected-error {{value of type 'String' expected to be
 let _: [AnyObject] = ["a"] // expected-error {{cannot convert value of type 'String' to expected element type 'AnyObject'}}
 let _: [String: AnyObject] = ["a": "a"] // expected-error {{cannot convert value of type 'String' to expected dictionary value type 'AnyObject'}}
 let _: [AnyObject: String] = ["a": "a"] // expected-error {{type 'AnyObject' does not conform to protocol 'Hashable'}}
-// expected-error@-1 {{cannot convert value of type 'String' to expected dictionary key type 'AnyObject'}}
 let _: (AnyObject, Void) = ("a", ()) // expected-error {{value of type 'String' expected to be instance of class or class-constrained type}}

--- a/test/Sema/moveonly_illegal_types.swift
+++ b/test/Sema/moveonly_illegal_types.swift
@@ -47,7 +47,14 @@ struct CerebralValley<T> {
 // --- now some tests ---
 // ----------------------
 
-func basic_vararg(_ va: MO...) {} // expected-error {{noncopyable type 'MO' cannot be used within a variadic type yet}}
+func basic_vararg1(_ va: MO...) {} // expected-error {{type 'MO' does not conform to protocol 'Copyable'}}
+// expected-note@-1 {{required because variadic parameter type must be stored inside an 'Array'}}
+
+// Make sure we perform this check for all inverse requirements, not just Copyable!
+struct MOO: ~Escapable {}  // expected-error {{an implicit initializer cannot return a ~Escapable result}}
+
+func basic_vararg2(_ va: MOO...) {} // expected-error {{type 'MOO' does not conform to protocol 'Escapable'}}
+// expected-note@-1 {{required because variadic parameter type must be stored inside an 'Array'}}
 
 func illegalTypes<T>(_ t: T) {
   let _: Array<MO> // expected-error {{type 'MO' does not conform to protocol 'Copyable'}}

--- a/validation-test/IDE/crashers_fixed/TypeDecl-getName-52988c.swift
+++ b/validation-test/IDE/crashers_fixed/TypeDecl-getName-52988c.swift
@@ -1,4 +1,4 @@
 // {"kind":"complete","original":"44e94bb2","signature":"swift::TypeDecl::getName() const","signatureAssert":"Assertion failed: (!canType->hasUnboundGenericType()), function computeInvertibleConformances"}
-// RUN: not --crash %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -source-filename %s
+// RUN: %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -source-filename %s
 extension {
   extension Optional ...{== { #^^#

--- a/validation-test/IDE/crashers_fixed/TypeResolver-resolveVarargType-32fa0d.swift
+++ b/validation-test/IDE/crashers_fixed/TypeResolver-resolveVarargType-32fa0d.swift
@@ -1,5 +1,5 @@
 // {"kind":"complete","original":"95ab8e45","signature":"(anonymous namespace)::TypeResolver::resolveVarargType(swift::VarargTypeRepr*, swift::TypeResolutionOptions)","signatureAssert":"Assertion failed: (!type->hasTypeParameter() && \"no generic environment provided for type with type parameters\"), function mapTypeIntoEnvironment","signatureNext":"TypeResolver::resolveType"}
-// RUN: not --crash %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -source-filename %s
+// RUN: %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -source-filename %s
 struct a<b
   protocol c: a<Self
 ... >#^^#

--- a/validation-test/compiler_crashers_fixed/Decl-getResolvedCustomAttrType-922c20.swift
+++ b/validation-test/compiler_crashers_fixed/Decl-getResolvedCustomAttrType-922c20.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","original":"65735e17","signature":"swift::Decl::getResolvedCustomAttrType(swift::CustomAttr*) const","signatureAssert":"Assertion failed: (!canType->hasUnboundGenericType()), function computeInvertibleConformances"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 @propertyWrapper struct a<b
   struct c {
     @a    ...var d

--- a/validation-test/compiler_crashers_fixed/TypeBase-computeInvertibleConformances-2e9f8c.swift
+++ b/validation-test/compiler_crashers_fixed/TypeBase-computeInvertibleConformances-2e9f8c.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","original":"3a7e17d4","signature":"swift::TypeBase::computeInvertibleConformances()","signatureAssert":"Assertion failed: (!canType->hasUnboundGenericType()), function computeInvertibleConformances","signatureNext":"TypeBase::isNoncopyable"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 struct a<b
   extension a
 ...

--- a/validation-test/compiler_crashers_fixed/TypeBase-computeInvertibleConformances-877192.swift
+++ b/validation-test/compiler_crashers_fixed/TypeBase-computeInvertibleConformances-877192.swift
@@ -1,3 +1,3 @@
 // {"kind":"typecheck","signature":"swift::TypeBase::computeInvertibleConformances()","signatureAssert":"Assertion failed: (!canType->hasUnboundGenericType()), function computeInvertibleConformances","signatureNext":"TypeBase::isNoncopyable"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 typealias a = FlattenCollection...

--- a/validation-test/compiler_crashers_fixed/checkRequirementsImpl-ff5963.swift
+++ b/validation-test/compiler_crashers_fixed/checkRequirementsImpl-ff5963.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","signature":"checkRequirementsImpl(llvm::ArrayRef<swift::Requirement>, bool)","signatureAssert":"Assertion failed: (!firstType->hasTypeVariable()), function checkRequirementsImpl","signatureNext":"checkConformance"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 struct a<b: ~Copyable
   extension a: Copyable where b: Copyable
     let c  0 as a

--- a/validation-test/compiler_crashers_fixed/createPropertyStoreOrCallSuperclassSetter-b15cc1.swift
+++ b/validation-test/compiler_crashers_fixed/createPropertyStoreOrCallSuperclassSetter-b15cc1.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","original":"1098007b","signature":"createPropertyStoreOrCallSuperclassSetter(swift::AccessorDecl*, swift::Expr*, swift::AbstractStorageDecl*, (anonymous namespace)::TargetImpl, llvm::SmallVectorImpl<swift::ASTNode>&, swift::ASTContext&)","signatureAssert":"Assertion failed: (destType->getOptionalObjectType()->isEqual(value->getType())), function createPropertyStoreOrCallSuperclassSetter","signatureNext":"synthesizeTrivialSetterBodyWithStorage"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 @propertyWrapper struct a<b, c> {
   wrappedValue: [c: b]  static subscript<d>(_enclosingInstance e: d, wrapped f: ReferenceWritableKeyPath<d, [c: b]>,
     storage g: ReferenceWritableKeyPath<d, Self>


### PR DESCRIPTION
6.4 cherry-pick of https://github.com/swiftlang/swift/pull/89167

* **Description:** Variadic parameters with nonescaping type are not supported for the same reason you can't have a noncopyable variadic parameter, but the code was hard-coded to check for copyability only. Generalize this to apply the generic signature for Array via the common code path, and add a custom note to explain why those requirements are checked in the first place.

* **Scope of the issue:** A crash-on-invalid that has been there since `~Escaping` was added to the language.

* **Origination:** Reported on the forums:
https://forums.swift.org/t/variadic-escapable-arguments-crash-the-compiler/86727/2

* **Risk:** Low, this only changes the existing error path.

* **Reviewed by:** @kavon 