### PR TITLE
[6.4] Sema: fix crash diagnosing inverse on class-bound-protocol composition

### DIFF
--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -6559,12 +6559,12 @@ TypeResolver::resolveCompositionType(CompositionTypeRepr *repr,
       auto kp = getKnownProtocolKind(ip);
 
       if (layout.requiresClass()) {
-        bool hasExplicitAnyObject = layout.hasExplicitAnyObject;
+        auto superclass = layout.getSuperclass();
         diagnose(repr->getStartLoc(),
                  diag::inverse_with_class_constraint,
-                 hasExplicitAnyObject,
+                 !superclass,
                  getProtocolName(kp),
-                 layout.getSuperclass());
+                 superclass);
         IsInvalid = true;
         break;
       }

--- a/test/Generics/inverse_generics.swift
+++ b/test/Generics/inverse_generics.swift
@@ -413,11 +413,15 @@ public func checkAnyObject<Result>(_ t: Result) where Result: AnyObject {
     checkCopyable(t)
 }
 
+protocol AnyObjectRefining: AnyObject {}
+
 func checkExistentialAndClasses(
     _ a: any AnyObject & ~Copyable, // expected-error {{composition involving 'AnyObject' cannot contain '~Copyable'}}
     _ b: any Soup & Copyable & ~Escapable & ~Copyable,
     // expected-error@-1 {{composition involving class requirement 'Soup' cannot contain '~Copyable'}}
-    _ c: some (~Escapable & Removed) & Soup // expected-error {{composition cannot contain '~Escapable' when another member requires 'Escapable'}}
+    _ c: some (~Escapable & Removed) & Soup, // expected-error {{composition cannot contain '~Escapable' when another member requires 'Escapable'}}
+    _ d: borrowing any AnyObjectRefining & ~Copyable
+    // expected-error@-1 {{composition involving 'AnyObject' cannot contain '~Copyable'}}
     ) {}
 
 protocol HasNCBuddy: ~Copyable {


### PR DESCRIPTION
*6.4 cherry-pick of #88861*

- Explanation: Fixes a crash that could occur when attempting to diagnose an invalid inverse requirement in a class protocol composition
- Scope: Affects diagnostics
- Issue: rdar://161839720
- Risk: Low, only affects invalid code, and the fix is straightforward
- Testing: Added tests to test suite
- Reviewer: Hamish Knight