### PR TITLE
[Runtime] Replace SWIFT_DEBUG_ENABLE_MALLOC_SCRIBBLE with a configurable byte.

### DIFF
--- a/include/swift/Runtime/EnvironmentVariables.h
+++ b/include/swift/Runtime/EnvironmentVariables.h
@@ -19,6 +19,7 @@
 
 #include "swift/Threading/Once.h"
 #include "swift/shims/Visibility.h"
+#include <optional>
 
 namespace swift {
 namespace runtime {
@@ -34,6 +35,7 @@ using boolean = bool;
 using string = const char *;
 using uint8 = uint8_t;
 using uint32 = uint32_t;
+using optional_uint8 = std::optional<uint8_t>;
 } // namespace types
 
 // Declare backing variables.

--- a/stdlib/public/runtime/EnvironmentVariables.cpp
+++ b/stdlib/public/runtime/EnvironmentVariables.cpp
@@ -70,16 +70,14 @@ static bool parse_boolean(const char *name, const char *value,
   }
 }
 
-static uint8_t parse_uint8(const char *name, const char *value,
-                           uint8_t defaultValue) {
+static std::optional<uint8_t>
+parse_optional_uint8(const char *name, const char *value,
+                     std::optional<uint8_t> defaultValue) {
   if (!value)
     return defaultValue;
   char *end;
   long n = strtol(value, &end, 0);
   if (*end != '\0') {
-    swift::warning(RuntimeErrorFlagNone,
-                   "Warning: cannot parse value %s=%s, defaulting to %u.\n",
-                   name, value, defaultValue);
     return defaultValue;
   }
 
@@ -97,6 +95,16 @@ static uint8_t parse_uint8(const char *name, const char *value,
   }
 
   return n;
+}
+
+static uint8_t parse_uint8(const char *name, const char *value,
+                           uint8_t defaultValue) {
+  auto result = parse_optional_uint8(name, value, std::nullopt);
+  if (!result)
+    swift::warning(RuntimeErrorFlagNone,
+                   "Warning: cannot parse value %s=%s, defaulting to %u.\n",
+                   name, value, defaultValue);
+  return result.value_or(defaultValue);
 }
 
 static uint32_t parse_uint32(const char *name, const char *value,

--- a/stdlib/public/runtime/EnvironmentVariables.def
+++ b/stdlib/public/runtime/EnvironmentVariables.def
@@ -41,8 +41,19 @@ VARIABLE(SWIFT_ENABLE_MANGLED_NAME_VERIFICATION, boolean, false,
          "Enable verification that metadata can roundtrip through a mangled "
          "name each time metadata is instantiated.")
 
+// This environment variable was the way to perform scribbling with older
+// runtimes and is kept for compatibility.
 VARIABLE(SWIFT_DEBUG_ENABLE_MALLOC_SCRIBBLE, boolean, false,
+         "Scribble on runtime allocations with 0xaa. Equivalent to "
+         "SWIFT_DEBUG_RUNTIME_ALLOC_SCRIBBLE_BYTE=0xaa.")
+
+#ifndef NDEBUG
+VARIABLE(SWIFT_DEBUG_RUNTIME_ALLOC_SCRIBBLE_BYTE, optional_uint8, 0xaa,
          "Scribble on runtime allocations such as metadata allocations.")
+#else
+VARIABLE(SWIFT_DEBUG_RUNTIME_ALLOC_SCRIBBLE_BYTE, optional_uint8, std::nullopt,
+         "Scribble on runtime allocations such as metadata allocations.")
+#endif
 
 VARIABLE(SWIFT_DEBUG_ENABLE_COW_CHECKS, boolean, false,
          "Enable internal checks for copy-on-write operations.")

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -8211,43 +8211,43 @@ static void recordBacktrace(void *allocation) {
   });
 }
 
-static inline bool scribbleEnabled() {
-#ifndef NDEBUG
-  // When DEBUG is defined, always scribble.
-  return true;
-#else
-  // When DEBUG is not defined, only scribble when the
-  // SWIFT_DEBUG_ENABLE_MALLOC_SCRIBBLE environment variable is set.
-  return SWIFT_UNLIKELY(
-          runtime::environment::SWIFT_DEBUG_ENABLE_MALLOC_SCRIBBLE());
-#endif
-}
-
-static constexpr char scribbleByte = 0xAA;
+static std::optional<uint8_t> ScribbleByte;
 
 template <typename Pointee>
 static inline void memsetScribble(Pointee *bytes, size_t totalSize) {
-  if (scribbleEnabled())
-    memset(bytes, scribbleByte, totalSize);
+  if (SWIFT_LIKELY(!ScribbleByte))
+    return;
+
+  memset(bytes, ScribbleByte.value(), totalSize);
 }
 
 /// When scribbling is enabled, check the specified region for the scribble
 /// values to detect overflows. When scribbling is disabled, this is a no-op.
 static inline void checkScribble(char *bytes, size_t totalSize) {
-  if (scribbleEnabled())
-    for (size_t i = 0; i < totalSize; i++)
-      if (bytes[i] != scribbleByte) {
-        const size_t maxToPrint = 16;
-        size_t remaining = totalSize - i;
-        size_t toPrint = std::min(remaining, maxToPrint);
-        std::string hex = toHex(llvm::StringRef{&bytes[i], toPrint});
-        swift::fatalError(
-            0, "corrupt metadata allocation arena detected at %p: %s%s",
-            &bytes[i], hex.c_str(), toPrint < remaining ? "..." : "");
-      }
+  if (SWIFT_LIKELY(!ScribbleByte))
+    return;
+
+  // scribbleByte is unsigned, so do an unsigned comparison here.
+  auto ptr = reinterpret_cast<uint8_t *>(bytes);
+  for (size_t i = 0; i < totalSize; i++)
+    if (ptr[i] != ScribbleByte.value()) {
+      const size_t maxToPrint = 16;
+      size_t remaining = totalSize - i;
+      size_t toPrint = std::min(remaining, maxToPrint);
+      std::string hex = toHex(llvm::StringRef{&bytes[i], toPrint});
+      swift::fatalError(
+          0, "corrupt metadata allocation arena detected at %p: %s%s",
+          &bytes[i], hex.c_str(), toPrint < remaining ? "..." : "");
+    }
 }
 
 static void checkAllocatorDebugEnvironmentVariables(void *context) {
+  // Set our ScribbleByte from the environment variable. If it's not set but
+  // SWIFT_DEBUG_ENABLE_MALLOC_SCRIBBLE is set, then set the byte to 0xaa.
+  ScribbleByte = runtime::environment::SWIFT_DEBUG_RUNTIME_ALLOC_SCRIBBLE_BYTE();
+  if (!ScribbleByte && runtime::environment::SWIFT_DEBUG_ENABLE_MALLOC_SCRIBBLE())
+    ScribbleByte = 0xaa;
+
   memsetScribble(InitialAllocationPool.Pool, InitialPoolSize);
 
   _swift_debug_metadataAllocationIterationEnabled =

--- a/test/Runtime/environment_variables.swift
+++ b/test/Runtime/environment_variables.swift
@@ -6,7 +6,7 @@
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
 
-// RUN: env %env-SWIFT_DEBUG_HELP=YES %env-SWIFT_DEBUG_SOME_UNKNOWN_VARIABLE=42 %env-SWIFT_DEBUG_ENABLE_METADATA_ALLOCATION_ITERATION=YES %env-SWIFT_DEBUG_IMPLICIT_OBJC_ENTRYPOINT=abc %env-SWIFT_DETERMINISTIC_HASHING=whatever %env-SWIFT_ENABLE_MANGLED_NAME_VERIFICATION=YES %env-SWIFT_DEBUG_ENABLE_MALLOC_SCRIBBLE=YES %target-run %t/main >%t.out 2>%t.err
+// RUN: env %env-SWIFT_DEBUG_HELP=YES %env-SWIFT_DEBUG_SOME_UNKNOWN_VARIABLE=42 %env-SWIFT_DEBUG_ENABLE_METADATA_ALLOCATION_ITERATION=YES %env-SWIFT_DEBUG_IMPLICIT_OBJC_ENTRYPOINT=abc %env-SWIFT_DETERMINISTIC_HASHING=whatever %env-SWIFT_ENABLE_MANGLED_NAME_VERIFICATION=YES %env-SWIFT_DEBUG_RUNTIME_ALLOC_SCRIBBLE_BYTE=0xaa %target-run %t/main >%t.out 2>%t.err
 // RUN: cat %t.err %t.out | %FileCheck %s --dump-input fail
 
 // CHECK-DAG: {{Warning: unknown environment variable SWIFT_DEBUG_SOME_UNKNOWN_VARIABLE|Using getenv to read variables. Unknown SWIFT_DEBUG_ variables will not be flagged.}}
@@ -17,7 +17,7 @@
 // CHECK-DAG:   uint8 SWIFT_DEBUG_IMPLICIT_OBJC_ENTRYPOINT [default: 2] - Print warnings when using implicit @objc entrypoints. Set to desired reporting level, 0-3.
 // CHECK-DAG: boolean SWIFT_DETERMINISTIC_HASHING [default: false] - Disable randomized hash seeding.
 // CHECK-DAG: boolean SWIFT_ENABLE_MANGLED_NAME_VERIFICATION [default: false] - Enable verification that metadata can roundtrip through a mangled name each time metadata is instantiated.
-// CHECK-DAG: boolean SWIFT_DEBUG_ENABLE_MALLOC_SCRIBBLE [default: false] - Scribble on runtime allocations such as metadata allocations.
+// CHECK-DAG: optional_uint8 SWIFT_DEBUG_RUNTIME_ALLOC_SCRIBBLE_BYTE [default: {{.*}}] - Scribble on runtime allocations such as metadata allocations.
 // CHECK-DAG:  string SWIFT_ROOT [default: "{{[^"]*}}"] - Overrides the root directory of the Swift installation. This is used to locate auxiliary files relative to the runtime itself.
 
 // We need to do this because the DAG checks require a non-DAG check as an


### PR DESCRIPTION
Replace the boolean SWIFT_DEBUG_ENABLE_MALLOC_SCRIBBLE knob with SWIFT_DEBUG_RUNTIME_ALLOC_SCRIBBLE_BYTE, an optional_uint8 that lets the user pick the actual byte to scribble. An unset value disables scribbling. Default is 0xaa in NDEBUG-off builds and unset in release.

Add an optional_uint8 environment variable type and a parse_optional_uint8 parser so the .def entry can express the new behavior.