### PR TITLE
[Runtime] Add SWIFT_DEBUG_DISABLE_NONCANONICAL_STATIC_SPECIALIZATIONS environment variable.

### DIFF
--- a/stdlib/public/runtime/EnvironmentVariables.def
+++ b/stdlib/public/runtime/EnvironmentVariables.def
@@ -126,6 +126,13 @@ VARIABLE(SWIFT_DEBUG_LIB_PRESPECIALIZED_ENABLED_PROCESSES, string, "",
 VARIABLE(SWIFT_DEBUG_ENABLE_LIB_PRESPECIALIZED_LOGGING, boolean, false,
          "Enable debug logging of prespecializations library use.")
 
+VARIABLE(SWIFT_DEBUG_DISABLE_NONCANONICAL_STATIC_SPECIALIZATIONS, boolean, false,
+         "Ignore compiler-emitted noncanonical static specialization metadata. "
+         "When set, swift_getCanonicalSpecializedMetadata routes through the "
+         "normal generic-metadata instantiation path instead of canonicalizing "
+         "the static metadata pointer. Lets the prespecializations library win "
+         "for types that also have a noncanonical static spec in some dylib.")
+
 VARIABLE(SWIFT_ROOT, string, "",
          "Overrides the root directory of the Swift installation. "
          "This is used to locate auxiliary files relative to the runtime "

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -764,6 +764,11 @@ cacheCanonicalSpecializedMetadata(const TypeContextDescriptor *description,
       (void *)description);
 }
 
+SWIFT_CC(swift)
+static MetadataResponse
+_swift_getGenericMetadata(MetadataRequest request, const void *const *arguments,
+                          const TypeContextDescriptor *description);
+
 MetadataResponse swift::swift_getCanonicalSpecializedMetadata(
     MetadataRequest request, const Metadata *candidate,
     const Metadata **cacheMetadataPtr) {
@@ -781,6 +786,23 @@ MetadataResponse swift::swift_getCanonicalSpecializedMetadata(
                             MetadataState::Complete};
   }
 
+  const void *const *arguments =
+      reinterpret_cast<const void *const *>(candidate->getGenericArgs());
+
+  if (SWIFT_UNLIKELY(
+          runtime::environment::
+              SWIFT_DEBUG_DISABLE_NONCANONICAL_STATIC_SPECIALIZATIONS())) {
+    // Pretend the noncanonical static specialization isn't there. Route
+    // through the normal generic metadata instantiation path instead.
+    auto response = _swift_getGenericMetadata(request, arguments, description);
+
+    // Don't cache incomplete metadata, since code above assumes cached metadata
+    // is complete.
+    if (response.State == MetadataState::Complete)
+      cachedMetadataAddr->store(response.Value, std::memory_order_release);
+    return response;
+  }
+
   if (auto *token =
           description
               ->getCanonicalMetadataPrespecializationCachingOnceToken()) {
@@ -788,8 +810,6 @@ MetadataResponse swift::swift_getCanonicalSpecializedMetadata(
     // NOTE: If there is no token, then there are no canonical prespecialized
     //       metadata records, either.
   }
-  const void *const *arguments =
-      reinterpret_cast<const void *const *>(candidate->getGenericArgs());
   auto &cache = getCache(*description);
   auto key = MetadataCacheKey(cache.SigLayout, arguments);
   auto result = cache.getOrInsert(key, request, candidate);


### PR DESCRIPTION
Add an environment variable that makes swift_getCanonicalSpecializedMetadata ignore noncanonical specialized metadata, for testing runtime-instantiated metadata.