### PR TITLE
[6.4][TypeChecker] PropertyWrappers: When setting projected value setter a…

### DIFF
--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -3433,8 +3433,13 @@ static VarDecl *synthesizePropertyWrapperProjectionVar(
   // Determine the access level for the property.
   property->overwriteAccess(var->getFormalAccess());
 
-  // Determine setter access.
-  property->overwriteSetterAccess(var->getSetterFormalAccess());
+  // Determine setter access. `projectedValue` setter could be less
+  // accessible than the variable itself and vice versa, we need to
+  // account for that and take the less permitting access of the two.
+  property->overwriteSetterAccess(
+      wrapperVar ? std::min(var->getSetterFormalAccess(),
+                            wrapperVar->getSetterFormalAccess())
+                 : var->getSetterFormalAccess());
 
   // Add the accessors we need.
   if (var->hasImplicitPropertyWrapper()) {

--- a/test/ModuleInterface/property_wrapper_with_internal_set_projected_value.swift
+++ b/test/ModuleInterface/property_wrapper_with_internal_set_projected_value.swift
@@ -1,0 +1,113 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-emit-module-interface(%t/TestResilient.swiftinterface) %s -module-name TestResilient
+// RUN: %target-swift-typecheck-module-from-interface(%t/TestResilient.swiftinterface) -module-name TestResilient
+// RUN: %FileCheck %s < %t/TestResilient.swiftinterface
+
+// RUN: %target-swift-frontend -compile-module-from-interface %t/TestResilient.swiftinterface -o %t/TestResilient.swiftmodule
+
+// CHECK: @propertyWrapper public struct WrapperWithInternalSet<T> {
+// CHECK:   public var wrappedValue: T
+// CHECK:   public var projectedValue: Swift::Bool {
+// CHECK:     get
+// CHECK:   }
+// CHECK:   public init(wrappedValue: T)
+// CHECK: }
+@propertyWrapper
+public struct WrapperWithInternalSet<T> {
+  public var wrappedValue: T
+  public internal(set) var projectedValue: Bool = true
+  public init(wrappedValue: T) { self.wrappedValue = wrappedValue }
+}
+
+// CHECK: @propertyWrapper public struct WrapperWithPrivateSet<T> {
+// CHECK:   public var wrappedValue: T
+// CHECK:   public var projectedValue: Swift::Bool {
+// CHECK:     get
+// CHECK:   }
+// CHECK:   public init(wrappedValue: T)
+// CHECK: }
+@propertyWrapper
+public struct WrapperWithPrivateSet<T> {
+  public var wrappedValue: T
+  public private(set) var projectedValue: Bool = true
+  public init(wrappedValue: T) { self.wrappedValue = wrappedValue }
+}
+
+// CHECK: @propertyWrapper public struct WrapperWithImmutable<T> {
+// CHECK:   public var wrappedValue: T
+// CHECK:   public let projectedValue: Swift::Bool
+// CHECK:   public init(wrappedValue: T)
+// CHECK: }
+@propertyWrapper
+public struct WrapperWithImmutable<T> {
+  public var wrappedValue: T
+  public let projectedValue: Bool = true
+  public init(wrappedValue: T) { self.wrappedValue = wrappedValue }
+}
+
+// CHECK: @propertyWrapper public struct WrapperWithComputedPublic<T> {
+// CHECK:   public var wrappedValue: T
+// CHECK:   public var projectedValue: Swift::Bool {
+// CHECK:     get
+// CHECK:     set
+// CHECK:   }
+// CHECK: }
+@propertyWrapper
+public struct WrapperWithComputedPublic<T> {
+  public var wrappedValue: T
+  public var projectedValue: Bool {
+    get { false }
+    set { }
+  }
+  public init(wrappedValue: T) { self.wrappedValue = wrappedValue }
+}
+
+// CHECK: @propertyWrapper public struct WrapperWithComputedImmutable<T> {
+// CHECK:   public var wrappedValue: T
+// CHECK:   public var projectedValue: Swift::Bool {
+// CHECK:     get
+// CHECK:   }
+// CHECK:   public init(wrappedValue: T)
+// CHECK: }
+@propertyWrapper
+public struct WrapperWithComputedImmutable<T> {
+  public var wrappedValue: T
+  public var projectedValue: Bool {
+    get { false }
+  }
+  public init(wrappedValue: T) { self.wrappedValue = wrappedValue }
+}
+
+public struct Test {
+  // CHECK: public var $v1: Swift::Bool {
+  // CHECK:   get
+  // CHECK: }
+  @WrapperWithInternalSet public var v1: Int
+
+  // CHECK: public var $v2: Swift::Bool {
+  // CHECK:   get
+  // CHECK: }
+  @WrapperWithPrivateSet public var v2: String
+
+  // CHECK: public var $v3: Swift::Bool {
+  // CHECK:   get
+  // CHECK: }
+  @WrapperWithImmutable public var v3: Bool
+
+  // CHECK: public var $v4: Swift::Bool {
+  // CHECK:   get
+  // CHECK:   set
+  // CHECK: }
+  @WrapperWithComputedPublic public var v4: Double
+
+  // CHECK: public var $v5: Swift::Bool {
+  // CHECK:   get
+  // CHECK: }
+  @WrapperWithComputedImmutable public var v5: Int?
+
+  // CHECK: public var $v6: Swift::Bool {
+  // CHECK:   get
+  // CHECK: }
+  @WrapperWithComputedPublic public private(set) var v6: Bool?
+}


### PR DESCRIPTION
…ccess account for `projectedValue` setter

- Explanation:

  Previously, the synthesis set the access of the setter of a newly synthesized projected value property to match that of the parent property setter, but `projectedValue` of the property wrapper could be less accessible than that and the synthesis needs to account for that. Otherwise, the interface file might get a setter printed even though it's not part of the ABI.

- Resolves: rdar://176978806

- Main Branch PR: https://github.com/swiftlang/swift/pull/89122

- Risk: Very Low. The change should only have effect on printing/swift interfaces, cannot reference the synthesized property directly.

- Reviewed By: @tshortli 

- Testing: Added new test-cases to the suite.

(cherry picked from commit c296d3fb47d0c83d63f36503d6559287fc3e00b5)

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
