### PR TITLE
[Sema] Bad diagnostic for deinit in non-copyable type extension 

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -541,6 +541,9 @@ NOTE(generic_argument_mismatch,none,
 
 ERROR(destructor_not_accessible,none,
       "deinitializers cannot be accessed", ())
+ERROR(destructor_decl_in_noncopyable_extension,none,
+      "deinitializer must be declared directly in noncopyable type %0 "
+      "(not in an extension)", (Type))
 
 // Array Element
 ERROR(cannot_convert_array_element,none,

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -10458,8 +10458,8 @@ parseDeclDeinit(ParseDeclOptions Flags, DeclAttributes &Attributes) {
         isa<ClassDecl>(dc))
       return false;
 
-    if (auto *ED = dyn_cast<ExtensionDecl>(dc))
-      return !ED->isObjCImplementation();
+    if (isa<ExtensionDecl>(dc))
+      return false;
 
     return true;
   };

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -4208,16 +4208,30 @@ public:
     // Only check again for destructor decl outside of a struct/enum/class
     // if our destructor is not marked as invalid.
     if (!DD->isInvalid()) {
-      auto *nom = dyn_cast<NominalTypeDecl>(
-                             DD->getDeclContext()->getImplementedObjCContext());
+      auto *DC = DD->getDeclContext();
+      auto *nom = dyn_cast<NominalTypeDecl>(DC->getImplementedObjCContext());
       if (!nom || !isa<ClassDecl, StructDecl, EnumDecl>(nom)) {
-        DD->diagnose(diag::destructor_decl_outside_class_or_noncopyable);
+        // Check if the deinit is in an extension of a noncopyable type
+        bool emittedSpecificDiag = false;
+        if (auto *ED = dyn_cast<ExtensionDecl>(DC)) {
+          if (!ED->isObjCImplementation()) {
+            if (auto *extNom = ED->getExtendedNominal()) {
+              if (!extNom->canBeCopyable()) {
+                DD->diagnose(diag::destructor_decl_in_noncopyable_extension,
+                             extNom->getDeclaredType());
+                emittedSpecificDiag = true;
+              }
+            }
+          }
+        }
+        if (!emittedSpecificDiag)
+          DD->diagnose(diag::destructor_decl_outside_class_or_noncopyable);
       }
 
       // Temporarily ban deinit on noncopyable enums, unless the experimental
       // feature flag is set.
       if (!Ctx.LangOpts.hasFeature(Feature::MoveOnlyEnumDeinits)
-          && isa<EnumDecl>(nom)
+          && isa_and_nonnull<EnumDecl>(nom)
           && !nom->canBeCopyable()) {
         DD->diagnose(diag::destructor_decl_on_noncopyable_enum);
       }

--- a/test/Parse/init_deinit.swift
+++ b/test/Parse/init_deinit.swift
@@ -117,3 +117,12 @@ func barFunc() {
     return
   } ()
 }
+
+// deinit in an extension of a noncopyable type should give a specific error
+struct NoncopyableStruct: ~Copyable {
+  var x: Int
+}
+
+extension NoncopyableStruct {
+  deinit {} // expected-error {{deinitializer must be declared directly in noncopyable type 'NoncopyableStruct' (not in an extension)}}
+}


### PR DESCRIPTION
Present a better error message when deinit is used in an extension for no-copyable type.

#83847
