### PR TITLE
[stdlib] Add missing conformances to Ref and MutableRef

### DIFF
--- a/stdlib/public/core/MutableRef.swift
+++ b/stdlib/public/core/MutableRef.swift
@@ -51,6 +51,9 @@ public struct MutableRef<Value: ~Copyable>: ~Copyable, ~Escapable {
 }
 
 @available(SwiftStdlib 6.4, *)
+extension MutableRef: @unchecked Sendable where Value: Sendable & ~Copyable {}
+
+@available(SwiftStdlib 6.4, *)
 extension MutableRef where Value: ~Copyable {
   /// Dereferences the mutable reference allowing for in-place reads and writes
   /// to the underlying value.

--- a/stdlib/public/core/Ref.swift
+++ b/stdlib/public/core/Ref.swift
@@ -50,6 +50,13 @@ public struct Ref<Value: ~Copyable & ~Escapable>: Copyable, ~Escapable {
 }
 
 @available(SwiftStdlib 6.4, *)
+extension Ref: @unchecked Sendable
+  where Value: Sendable & ~Copyable & ~Escapable {}
+
+@available(SwiftStdlib 6.4, *)
+extension Ref: BitwiseCopyable {}
+
+@available(SwiftStdlib 6.4, *)
 extension Ref where Value: ~Copyable & ~Escapable {
   /// Dereferences the constant reference allowing for in-place reads to the
   /// underlying value.

--- a/test/stdlib/Noncopyables/RefMutableRef.swift
+++ b/test/stdlib/Noncopyables/RefMutableRef.swift
@@ -172,6 +172,30 @@ suite.test("MutableRef inside a Ref")
 
   expectEqual(a, 128)
 }
+
+suite.test("Sendability")
+.require(.stdlib_6_4).code {
+  guard #available(SwiftStdlib 6.4, *) else { return }
+
+  func isSendable<T: ~Copyable & ~Escapable>(_: T.Type) -> Bool { false }
+  func isSendable<T: Sendable & ~Copyable & ~Escapable>(_: T.Type) -> Bool { true }
+
+  expectTrue(isSendable(Ref<MutableRawSpan>.self))
+  expectTrue(isSendable(MutableRef<Int>.self))
+
+  expectFalse(isSendable(Ref<UnsafeMutableRawPointer>.self))
+  expectFalse(isSendable(MutableRef<UnsafeRawPointer>.self))
+}
+
+suite.test("BitwiseCopyability")
+.require(.stdlib_6_4).code {
+  guard #available(SwiftStdlib 6.4, *) else { return }
+
+  func isBitwiseCopyable<T: ~Copyable & ~Escapable>(_: T.Type) -> Bool { false }
+  func isBitwiseCopyable<T: BitwiseCopyable & ~Escapable>(_: T.Type) -> Bool { true }
+
+  expectTrue(isBitwiseCopyable(Ref<Int>.self))
+  expectFalse(isBitwiseCopyable(MutableRef<Int>.self))
 }
 
 runAllTests()

--- a/test/stdlib/Noncopyables/RefMutableRef.swift
+++ b/test/stdlib/Noncopyables/RefMutableRef.swift
@@ -57,8 +57,10 @@ extension Optional where Wrapped: ~Copyable {
 
 let suite = TestSuite("RefMutableRef")
 
-if #available(SwiftStdlib 6.4, *) {
-suite.test("Ref") {
+suite.test("Ref")
+.require(.stdlib_6_4).code {
+  guard #available(SwiftStdlib 6.4, *) else { return }
+
   var foo = Foo()
 
   do {
@@ -80,10 +82,11 @@ suite.test("Ref") {
 
   expectEqual(int, 321)
 }
-}
 
-if #available(SwiftStdlib 6.4, *) {
-suite.test("Ref inside a Ref") {
+suite.test("Ref inside a Ref")
+.require(.stdlib_6_4).code {
+  guard #available(SwiftStdlib 6.4, *) else { return }
+
   var foo = Foo()
 
   do {
@@ -107,10 +110,11 @@ suite.test("Ref inside a Ref") {
 
   expectEqual(int, 321)
 }
-}
 
-if #available(SwiftStdlib 6.4, *) {
-suite.test("MutableRef") {
+suite.test("MutableRef")
+.require(.stdlib_6_4).code {
+  guard #available(SwiftStdlib 6.4, *) else { return }
+
   var x: _? = 123
 
   var y = x.mutate()!
@@ -134,10 +138,10 @@ suite.test("MutableRef") {
 
   expectEqual(a, 64)
 }
-}
 
-if #available(SwiftStdlib 6.4, *) {
-suite.test("MutableRef inside a Ref") {
+suite.test("MutableRef inside a Ref")
+.require(.stdlib_6_4).code {
+  guard #available(SwiftStdlib 6.4, *) else { return }
   var x: _? = 123
 
   var y = x.mutate()!


### PR DESCRIPTION
SE-0519 introduced `Ref` and `MutableRef`, which are in essence a single-element version of `Span` and `MutableSpan`. They should have the same protocol conformances as `Span` and `MutableSpan`, and we add them here.

The proposal was amended [here](https://github.com/swiftlang/swift-evolution/pull/3297/changes), and accepted [here](https://forums.swift.org/t/86780).

Addresses rdar://177198190