### PR TITLE
Sema: Enforce IPI library level for Clang modules

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -468,6 +468,9 @@ namespace swift {
     /// Access or distribution level of the whole module being parsed.
     LibraryLevel LibraryLevel = LibraryLevel::Other;
 
+    /// Clang modules explicitly marked as IPI by the build system.
+    std::vector<std::string> IPIClangModuleNames;
+
     /// The name of the package this module belongs to.
     std::string PackageName;
 

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -641,6 +641,12 @@ def library_level_EQ : Joined<["-"], "library-level=">,
   Flags<[HelpHidden, FrontendOption, ModuleInterfaceOption]>,
   Alias<library_level>;
 
+def ipi_clang_module : Separate<["-"], "ipi-clang-module">,
+  MetaVarName<"<name>">,
+  Flags<[HelpHidden, FrontendOption]>,
+  HelpText<"Mark a Clang module by name as project-internal (IPI). "
+           "Public imports of the named module will be diagnosed.">;
+
 def module_name : Separate<["-"], "module-name">,
   Flags<[FrontendOption, ModuleInterfaceOption,
          SwiftSymbolGraphExtractOption, SwiftSynthesizeInterfaceOption]>,

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -3320,6 +3320,10 @@ ModuleLibraryLevelRequest::evaluate(Evaluator &evaluator,
 
   if (module->isNonSwiftModule()) {
     if (auto *underlying = module->findUnderlyingClangModule()) {
+      if (llvm::is_contained(ctx.LangOpts.IPIClangModuleNames,
+                             module->getName().str()))
+        return LibraryLevel::IPI;
+
       // Imported clangmodules are SPI if they are defined by a private
       // modulemap or from the PrivateFrameworks folder in the SDK.
       bool moduleIsSPI = underlying->ModuleMapIsPrivate ||

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1401,6 +1401,8 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
     }
   }
 
+  Opts.IPIClangModuleNames = Args.getAllArgValues(OPT_ipi_clang_module);
+
   if (const Arg *A = Args.getLastArg(OPT_package_name)) {
     auto pkgName = A->getValue();
     if (StringRef(pkgName).empty())

--- a/lib/Option/features.json
+++ b/lib/Option/features.json
@@ -59,6 +59,9 @@
     },
     {
        "name": "debug-info-explicit-dependency"
+    },
+    {
+       "name": "ipi-clang-module"
     }
   ]
 }

--- a/test/Sema/report-public-import-of-private-module.swift
+++ b/test/Sema/report-public-import-of-private-module.swift
@@ -263,3 +263,46 @@ public import IPISwift // expected-error {{Project internal module 'IPISwift' ca
 
 //--- IPIBareImportIIBD.swift
 import IPISwift
+
+/// Clang IPI: modules listed via -ipi-clang-module are diagnosed.
+// RUN: %target-swift-frontend -typecheck -sdk %t/sdk %t/ClangIPIFromAPI.swift \
+// RUN:   -F %t/sdk/System/Library/PrivateFrameworks/ \
+// RUN:   -module-cache-path %t -library-level api -verify -module-name MainLib \
+// RUN:   -ipi-clang-module PublicClang -ipi-clang-module FullyPrivateClang
+
+/// Clang IPI: unlisted Clang modules use the existing path heuristic.
+// RUN: %target-swift-frontend -typecheck -sdk %t/sdk %t/ClangIPIUnlisted.swift \
+// RUN:   -F %t/sdk/System/Library/PrivateFrameworks/ \
+// RUN:   -module-cache-path %t -library-level api -verify -module-name MainLib \
+// RUN:   -ipi-clang-module SomeOtherModule
+
+/// Clang IPI: import from an IPI module is allowed.
+// RUN: %target-swift-frontend -typecheck -sdk %t/sdk %t/ClangIPIFromIPI.swift \
+// RUN:   -module-cache-path %t -library-level ipi -module-name MainLib \
+// RUN:   -ipi-clang-module PublicClang
+
+/// Clang IPI: non-public imports are allowed.
+// RUN: %target-swift-frontend -typecheck -sdk %t/sdk %t/ClangIPINonPublic.swift \
+// RUN:   -F %t/sdk/System/Library/PrivateFrameworks/ \
+// RUN:   -module-cache-path %t -library-level api -module-name MainLib \
+// RUN:   -ipi-clang-module PublicClang -ipi-clang-module FullyPrivateClang
+
+//--- ClangIPIFromAPI.swift
+import PublicClang // expected-error {{Project internal module 'PublicClang' cannot be imported publicly from non-internal module 'MainLib'}}
+import FullyPrivateClang // expected-error {{Project internal module 'FullyPrivateClang' cannot be imported publicly from non-internal module 'MainLib'}}
+
+//--- ClangIPIUnlisted.swift
+import PublicClang
+
+//--- ClangIPIFromIPI.swift
+import PublicClang
+
+//--- ClangIPINonPublic.swift
+@_implementationOnly import PublicClang
+internal import FullyPrivateClang
+
+//--- ClangIPIFromPath.swift
+import PublicClang // expected-error {{Project internal module 'PublicClang' cannot be imported publicly from non-internal module 'MainLib'}}
+
+//--- ClangIPIPathMiss.swift
+import PublicClang


### PR DESCRIPTION
Add -ipi-clang-module flag to enforce IPI library level for Clang modules. Compiler stores names of those modules and checks them during typechecking.

rdar://177196788

