### PR TITLE
Fix generic specialization of functions with lifetime dependencies.

### DIFF
--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -515,6 +515,10 @@ static bool canDropMetatypeArg(ApplySite apply, SILFunction *callee,
   if (isUsedAsDynamicSelf(calleeArg))
     return false;
 
+  // TODO: Adjust LifetimeDependencInfo when dropping the argument.
+  if (apply.getOrigCalleeType()->hasLifetimeDependencies())
+    return false;
+
   if (calleeArg->getType().getASTType()->hasDynamicSelfType())
     return false;
 

--- a/test/SILOptimizer/lifetime_dependence/specialize.sil
+++ b/test/SILOptimizer/lifetime_dependence/specialize.sil
@@ -20,6 +20,8 @@ sil_stage raw
 import Builtin
 import Swift
 
+struct NE: ~Escapable {}
+
 sil @makeSpan : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (UnsafePointer<τ_0_0>, Int, @thin Span<τ_0_0>.Type) -> @lifetime(borrow 0) @owned Span<τ_0_0>
 
 // Ensure that the addressable argument is not deleted.
@@ -53,4 +55,41 @@ bb0(%0 : $*CollectionOfOne<Int>):
 
   %99 = tuple ()
   return %99 : $()
+}
+
+// Ensure that an ununsed metatype is not deleted during specialization.
+//
+// rdar://177185142 (Assertion failed: (indices->getCapacity() <= numFormalParams && "There should be at most 1 index
+// per parameter. SIL functions " "cannot have " "an implicit self parameter."))
+sil [ossa] @unused_metatype : $@convention(thin) <T>(@lifetime(copy 0) @inout NE, @in_guaranteed T, @thin T.Type) -> () {
+bb0(%0 : $*NE, %1 : $*T, %2 : $@thin T.Type):
+  %99 = tuple ()
+  return %99 : $()
+}
+
+sil @takeSpecializedNEClosure : $@convention(method) (@guaranteed @noescape @callee_guaranteed (@lifetime(copy 0) @inout NE) -> ()) -> ()
+
+// CHECK-LABEL: sil [ossa] @test_unused_metatype : $@convention(thin) (@in_guaranteed Int) -> () {
+// CHECK: bb0(%0 : $*Int):
+// CHECK:   [[MT:%[0-9]+]] = metatype $@thin Int.Type
+// CHECK:   [[F:%[0-9]+]] = function_ref @$s15unused_metatypeSi_TG5 : $@convention(thin) (@lifetime(copy 0) @inout NE, @in_guaranteed Int, @thin Int.Type) -> ()
+// CHECK:   [[PA:%[0-9]+]] = partial_apply [callee_guaranteed] [on_stack] [[F]](%0, [[MT]]) : $@convention(thin) (@lifetime(copy 0) @inout NE, @in_guaranteed Int, @thin Int.Type) -> ()
+// CHECK:   [[MD:%[0-9]+]] = mark_dependence [nonescaping] [[PA]] on %0
+// CHECK:   [[CF:%[0-9]+]] = convert_function [[MD]] to $@noescape @callee_guaranteed (@lifetime(copy 0) @inout NE) -> ()
+// CHECK:   [[TC:%[0-9]+]] = function_ref @takeSpecializedNEClosure : $@convention(method) (@guaranteed @noescape @callee_guaranteed (@lifetime(copy 0) @inout NE) -> ()) -> ()
+// CHECK:   {{%[0-9]+}} = apply [[TC]]([[CF]]) : $@convention(method) (@guaranteed @noescape @callee_guaranteed (@lifetime(copy 0) @inout NE) -> ()) -> ()
+// CHECK:   destroy_value [[CF]]
+// CHECK: } // end sil function 'test_unused_metatype'
+sil [ossa] @test_unused_metatype : $@convention(thin) (@in_guaranteed Int) -> () {
+bb0(%0 : $*Int):
+  %mt = metatype $@thin Int.Type
+  %f = function_ref @unused_metatype : $@convention(thin) <T>(@lifetime(copy 0) @inout NE, @in_guaranteed T, @thin T.Type) -> ()
+  %15 = partial_apply [callee_guaranteed] [on_stack] %f<Int>(%0, %mt) : $@convention(thin) <τ_0_0> (@lifetime(copy 0) @inout NE, @in_guaranteed τ_0_0, @thin τ_0_0.Type) -> ()
+  %16 = mark_dependence [nonescaping] %15 on %0
+  %18 = convert_function %16 to $@noescape @callee_guaranteed (@lifetime(copy 0) @inout NE) -> ()
+  %19 = function_ref @takeSpecializedNEClosure : $@convention(method) (@guaranteed @noescape @callee_guaranteed (@lifetime(copy 0) @inout NE) -> ()) -> ()
+  %21 = apply %19(%18) : $@convention(method) (@guaranteed @noescape @callee_guaranteed (@lifetime(copy 0) @inout NE) -> ()) -> ()
+  destroy_value %18
+  %99 = tuple ()
+  return %99
 }


### PR DESCRIPTION
Generic specialization removes dead metatypes, which changes the number of
formal parameters. This requires updating LifetimeDependenceInfo which is not implemented.

Exposed by:
Lifetimes: Replace deps on partial_apply parameters with 'captures'
https://github.com/swiftlang/swift/pull/89053

Fixes rdar://177185142
(Assertion failed: (indices->getCapacity() <= numFormalParams...)
