### PR TITLE
[6.4] [CMake] Put the creation of .swiftsourceinfo files behind SWIFT_STDLIB_ENABLE_SOURCE_INFO

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -244,6 +244,10 @@ option(SWIFT_STDLIB_ENABLE_UNICODE_DATA
     NOTE: Disabling this will cause many String methods to crash."
     TRUE)
 
+option(SWIFT_STDLIB_ENABLE_SOURCE_INFO
+    "Build .swiftsourceinfo files for the standard library to provide a link back to the standard library sources"
+    FALSE)
+
 option(SWIFT_BUILD_CLANG_OVERLAYS
   "Build Swift overlays for the clang builtin modules"
   TRUE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1730,6 +1730,7 @@ if(SWIFT_ENABLE_NEW_RUNTIME_BUILD)
           -DCMAKE_MAKE_PROGRAM=${CMAKE_MAKE_PROGRAM}
           -DSwiftCore_INSTALL_NESTED_SUBDIR=YES
           -DSwiftCore_ENABLE_CONCURRENCY=${build_concurrency}
+          -DSwiftCore_ENABLE_SOURCE_INFO=${SWIFT_STDLIB_ENABLE_SOURCE_INFO}
           -DCMAKE_OSX_SYSROOT:PATH=${SWIFT_SDK_${sdk}_ARCH_${arch}_PATH})
       if(NOT ${CMAKE_CROSSCOMPILING})
         add_dependencies("${stdlib_target}-core" swift-frontend)

--- a/Runtimes/Core/CMakeLists.txt
+++ b/Runtimes/Core/CMakeLists.txt
@@ -112,6 +112,7 @@ defaulted_option(SwiftCore_ENABLE_OVERRIDABLE_RETAIN_RELEASE "Enable override ho
 defaulted_option(SwiftCore_ENABLE_RUNTIME_OS_VERSIONING "Enable runtime OS version detection")
 defaulted_option(SwiftCore_ENABLE_STATIC_PRINT "Disable full print")
 defaulted_option(SwiftCore_ENABLE_COMPACT_ABSOLUTE_FUNCTION_POINTERS "Resolve absolute function pointer as identity")
+defaulted_option(SwiftCore_ENABLE_SOURCE_INFO "Enable generation of .swiftsourceinfo files")
 defaulted_option(SwiftCore_ENABLE_BACKDEPLOYMENT_SUPPORT "Add symbols for runtime backdeployment")
 defaulted_option(SwiftCore_ENABLE_CONCURRENCY "Enable Concurrency runtime support")
 defaulted_option(SwiftCore_ENABLE_REMOTE_MIRROR "Enable RemoteMirror runtime support")

--- a/Runtimes/Core/cmake/modules/EmitSwiftInterface.cmake
+++ b/Runtimes/Core/cmake/modules/EmitSwiftInterface.cmake
@@ -27,8 +27,7 @@ function(emit_swift_interface target)
   endif()
 
   target_compile_options(${target} PRIVATE
-    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-module-path ${module_directory}/${SwiftCore_MODULE_TRIPLE}.swiftmodule>"
-    $<IF:$<AND:$<BOOL:${SwiftCore_ENABLE_SOURCE_INFO}>,$<COMPILE_LANGUAGE:Swift>>,"-emit-module-source-info-path $<SHELL_PATH:${module_directory}/${SwiftCore_MODULE_TRIPLE}.swiftsourceinfo>","-avoid-emit-module-source-info">)
+    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-module-path ${module_directory}/${SwiftCore_MODULE_TRIPLE}.swiftmodule>")
   set_property(TARGET "${target}" APPEND PROPERTY ADDITIONAL_CLEAN_FILES
     "${module_directory}/${SwiftCore_MODULE_TRIPLE}.swiftmodule"
     "${module_directory}/${SwiftCore_MODULE_TRIPLE}.swiftdoc"

--- a/Runtimes/Core/cmake/modules/EmitSwiftInterface.cmake
+++ b/Runtimes/Core/cmake/modules/EmitSwiftInterface.cmake
@@ -26,47 +26,29 @@ function(emit_swift_interface target)
     file(REMOVE "${module_directory}")
   endif()
 
-  set(source_info_file)
-  set(source_info_compile_options)
-  set(source_info_clean_files)
-  set(variant_source_info_file)
-  set(variant_source_info_compile_options)
-  set(variant_source_info_clean_files)
-  if(SWIFT_STDLIB_ENABLE_SOURCE_INFO)
-    set(source_info_file "${module_directory}/${SwiftCore_MODULE_TRIPLE}.swiftsourceinfo")
-    set(source_info_clean_files "${source_info_file}")
-    set(source_info_compile_options "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-module-source-info-path ${source_info_file}>")
-
-    if(SwiftCore_VARIANT_MODULE_TRIPLE)
-      set(variant_source_info_file "${module_directory}/${SwiftCore_VARIANT_MODULE_TRIPLE}.swiftsourceinfo")
-      set(variant_source_info_clean_files "${variant_source_info_file}")
-      set(variant_source_info_compile_options "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-module-source-info-path ${variant_source_info_file}>")
-    else()
-      set(variant_source_info_compile_options "-avoid-emit-module-source-info")
-    endif()
-  else()
-    set(source_info_compile_options "-avoid-emit-module-source-info")
-    if(SwiftCore_VARIANT_MODULE_TRIPLE)
-      set(variant_source_info_compile_options "-avoid-emit-module-source-info")
-    endif()
-  endif()
-
   target_compile_options(${target} PRIVATE
     "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-module-path ${module_directory}/${SwiftCore_MODULE_TRIPLE}.swiftmodule>"
-    ${source_info_compile_options}
-    )
+    $<IF:$<AND:$<BOOL:${SwiftCore_ENABLE_SOURCE_INFO}>,$<COMPILE_LANGUAGE:Swift>>,"-emit-module-source-info-path $<SHELL_PATH:${module_directory}/${SwiftCore_MODULE_TRIPLE}.swiftsourceinfo>","-avoid-emit-module-source-info">)
   set_property(TARGET "${target}" APPEND PROPERTY ADDITIONAL_CLEAN_FILES
     "${module_directory}/${SwiftCore_MODULE_TRIPLE}.swiftmodule"
     "${module_directory}/${SwiftCore_MODULE_TRIPLE}.swiftdoc"
-    ${source_info_clean_files})
+    "${module_directory}/${SwiftCore_MODULE_TRIPLE}.swiftsourceinfo")
+
+  if(SwiftCore_ENABLE_SOURCE_INFO)
+    target_compile_options(${target} PRIVATE
+      "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-module-source-info-path "$<SHELL_PATH:${module_directory}/${SwiftCore_MODULE_TRIPLE}.swiftsourceinfo>">")
+  else()
+    target_compile_options(${target} PRIVATE
+      "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-avoid-emit-module-source-info>")
+  endif()
+
   if(SwiftCore_VARIANT_MODULE_TRIPLE)
     target_compile_options(${target} PRIVATE
-      "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-variant-module-path ${module_directory}/${SwiftCore_VARIANT_MODULE_TRIPLE}.swiftmodule>"
-      ${variant_source_info_compile_options})
+      "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-variant-module-path ${module_directory}/${SwiftCore_VARIANT_MODULE_TRIPLE}.swiftmodule>")
     set_property(TARGET "${target}" APPEND PROPERTY ADDITIONAL_CLEAN_FILES
       "${module_directory}/${SwiftCore_VARIANT_MODULE_TRIPLE}.swiftmodule"
       "${module_directory}/${SwiftCore_VARIANT_MODULE_TRIPLE}.swiftdoc"
-      ${variant_source_info_clean_files}
+      "${module_directory}/${SwiftCore_VARIANT_MODULE_TRIPLE}.swiftsourceinfo"
     )
   endif()
 

--- a/Runtimes/Core/cmake/modules/EmitSwiftInterface.cmake
+++ b/Runtimes/Core/cmake/modules/EmitSwiftInterface.cmake
@@ -25,21 +25,49 @@ function(emit_swift_interface target)
     message(STATUS "Removing regular file ${module_directory} to support nested swiftmodule generation")
     file(REMOVE "${module_directory}")
   endif()
+
+  set(source_info_file)
+  set(source_info_compile_options)
+  set(source_info_clean_files)
+  set(variant_source_info_file)
+  set(variant_source_info_compile_options)
+  set(variant_source_info_clean_files)
+  if(SWIFT_STDLIB_ENABLE_SOURCE_INFO)
+    set(source_info_file "${module_directory}/${SwiftCore_MODULE_TRIPLE}.swiftsourceinfo")
+    set(source_info_clean_files "${source_info_file}")
+    set(source_info_compile_options "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-module-source-info-path ${source_info_file}>")
+
+    if(SwiftCore_VARIANT_MODULE_TRIPLE)
+      set(variant_source_info_file "${module_directory}/${SwiftCore_VARIANT_MODULE_TRIPLE}.swiftsourceinfo")
+      set(variant_source_info_clean_files "${variant_source_info_file}")
+      set(variant_source_info_compile_options "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-module-source-info-path ${variant_source_info_file}>")
+    else()
+      set(variant_source_info_compile_options "-avoid-emit-module-source-info")
+    endif()
+  else()
+    set(source_info_compile_options "-avoid-emit-module-source-info")
+    if(SwiftCore_VARIANT_MODULE_TRIPLE)
+      set(variant_source_info_compile_options "-avoid-emit-module-source-info")
+    endif()
+  endif()
+
   target_compile_options(${target} PRIVATE
     "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-module-path ${module_directory}/${SwiftCore_MODULE_TRIPLE}.swiftmodule>"
-    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-module-source-info-path ${module_directory}/${SwiftCore_MODULE_TRIPLE}.swiftsourceinfo>")
+    ${source_info_compile_options}
+    )
   set_property(TARGET "${target}" APPEND PROPERTY ADDITIONAL_CLEAN_FILES
     "${module_directory}/${SwiftCore_MODULE_TRIPLE}.swiftmodule"
     "${module_directory}/${SwiftCore_MODULE_TRIPLE}.swiftdoc"
-    "${module_directory}/${SwiftCore_MODULE_TRIPLE}.swiftsourceinfo")
+    ${source_info_clean_files})
   if(SwiftCore_VARIANT_MODULE_TRIPLE)
     target_compile_options(${target} PRIVATE
       "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-variant-module-path ${module_directory}/${SwiftCore_VARIANT_MODULE_TRIPLE}.swiftmodule>"
-      "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-variant-module-source-info-path ${module_directory}/${SwiftCore_VARIANT_MODULE_TRIPLE}.swiftsourceinfo>")
+      ${variant_source_info_compile_options})
     set_property(TARGET "${target}" APPEND PROPERTY ADDITIONAL_CLEAN_FILES
       "${module_directory}/${SwiftCore_VARIANT_MODULE_TRIPLE}.swiftmodule"
       "${module_directory}/${SwiftCore_VARIANT_MODULE_TRIPLE}.swiftdoc"
-      "${module_directory}/${SwiftCore_VARIANT_MODULE_TRIPLE}.swiftsourceinfo")
+      ${variant_source_info_clean_files}
+    )
   endif()
 
   add_custom_command(OUTPUT "${module_directory}/${SwiftCore_MODULE_TRIPLE}.swiftmodule"

--- a/stdlib/cmake/modules/SwiftSource.cmake
+++ b/stdlib/cmake/modules/SwiftSource.cmake
@@ -727,11 +727,15 @@ function(_compile_swift_files
     set(module_base_static "${module_base_static}.swiftmodule/${module_triple}")
     set(module_file "${module_base}.swiftmodule")
     set(module_doc_file "${module_base}.swiftdoc")
-    set(module_location_file "${module_base}.swiftsourceinfo")
+
+    # If we want *.sourceinfo files, figure out their names.
+    if(SWIFT_STDLIB_ENABLE_SOURCE_INFO)
+      set(module_location_file "${module_base}.swiftsourceinfo")
+      set(module_location_file_static "${module_base_static}.swiftsourceinfo")
+    endif()
 
     set(module_file_static "${module_base_static}.swiftmodule")
     set(module_doc_file_static "${module_base_static}.swiftdoc")
-    set(module_location_file_static "${module_base_static}.swiftsourceinfo")
 
     # FIXME: These don't really belong inside the swiftmodule, but there's not
     # an obvious alternate place to put them.
@@ -762,7 +766,11 @@ function(_compile_swift_files
            "-Xfrontend" "-experimental-skip-non-inlinable-function-bodies")
     endif()
 
-    set(module_outputs "${module_file}" "${module_doc_file}" "${module_location_file}")
+    set(module_outputs "${module_file}" "${module_doc_file}")
+
+    if (module_location_file)
+      list(APPEND module_outputs "${module_location_file}")
+    endif()
 
     if(interface_file)
       list(APPEND module_outputs "${interface_file}" "${private_interface_file}")
@@ -858,8 +866,12 @@ function(_compile_swift_files
     endif()
   endif()
 
-  set(module_outputs "${module_file}" "${module_doc_file}" "${module_location_file}")
-  set(module_outputs_static "${module_file_static}" "${module_doc_file_static}" "${module_location_file_static}")
+  set(module_outputs "${module_file}" "${module_doc_file}")
+  set(module_outputs_static "${module_file_static}" "${module_doc_file_static}")
+  if(module_location_file)
+    list(APPEND module_outputs "${module_location_file}")
+    list(APPEND module_outputs_static "${module_location_file_static}")
+  endif()
   if(interface_file)
     list(APPEND module_outputs "${interface_file}" "${private_interface_file}")
     list(APPEND module_outputs_static "${interface_file_static}" "${private_interface_file_static}")
@@ -1095,13 +1107,20 @@ function(_compile_swift_files
   # 6. *.O.sib
   # 7. *.sibgen
   #
-  # Only 1,2,3,4 are built by default. 5,6,7 are utility targets for use by
+  # Only 1,2,3 are built by default. 5,6,7 are utility targets for use by
   # engineers and thus even though the targets are generated, the targets are
-  # not built by default.
+  # not built by default. 4 is optional, and enabled where one is expected
+  # to have the standard library sources around.
   #
   # We only build these when we are not producing a main file. We could do this
   # with sib/sibgen, but it is useful for looking at the stdlib.
   if (NOT SWIFTFILE_IS_MAIN AND NOT SWIFTFILE_NO_SWIFTMODULE)
+    if(module_location_file)
+      set(emit_module_source_info "-emit-module-source-info-path" "${module_location_file}")
+    else()
+      set(emit_module_source_info "-avoid-emit-module-source-info")
+    endif()
+
     add_custom_command_target(
         module_dependency_target
         COMMAND
@@ -1115,7 +1134,7 @@ function(_compile_swift_files
           ${set_environment_args}
           "$<TARGET_FILE:Python3::Interpreter>" "${line_directive_tool}" "@${file_path}" --
           "${swift_compiler_tool}" "-emit-module" "-o" "${module_file}"
-          "-emit-module-source-info-path" "${module_location_file}"
+          ${emit_module_source_info}
           ${swift_flags} ${swift_module_flags} "@${file_path}"
         ${command_touch_module_outputs}
         OUTPUT ${module_outputs}
@@ -1129,6 +1148,13 @@ function(_compile_swift_files
         COMMENT "Generating ${module_file}")
 
     if(SWIFTFILE_STATIC)
+      set(command_copy_location_file)
+      if(module_location_file_static)
+        set(command_copy_location_file
+          COMMAND
+            "${CMAKE_COMMAND}" "-E" "copy" ${module_location_file} ${module_location_file_static})
+      endif()
+
       set(command_copy_interface_file)
       if(interface_file)
         set(command_copy_interface_file
@@ -1145,8 +1171,7 @@ function(_compile_swift_files
           "${CMAKE_COMMAND}" "-E" "copy" ${module_file} ${module_file_static}
         COMMAND
           "${CMAKE_COMMAND}" "-E" "copy" ${module_doc_file} ${module_doc_file_static}
-        COMMAND
-          "${CMAKE_COMMAND}" "-E" "copy" ${module_location_file} ${module_location_file_static}
+        ${command_copy_location_file}
         ${command_copy_interface_file}
         OUTPUT ${module_outputs_static}
         DEPENDS

--- a/stdlib/cmake/modules/SwiftSource.cmake
+++ b/stdlib/cmake/modules/SwiftSource.cmake
@@ -1115,12 +1115,6 @@ function(_compile_swift_files
   # We only build these when we are not producing a main file. We could do this
   # with sib/sibgen, but it is useful for looking at the stdlib.
   if (NOT SWIFTFILE_IS_MAIN AND NOT SWIFTFILE_NO_SWIFTMODULE)
-    if(module_location_file)
-      set(emit_module_source_info "-emit-module-source-info-path" "${module_location_file}")
-    else()
-      set(emit_module_source_info "-avoid-emit-module-source-info")
-    endif()
-
     add_custom_command_target(
         module_dependency_target
         COMMAND
@@ -1134,7 +1128,9 @@ function(_compile_swift_files
           ${set_environment_args}
           "$<TARGET_FILE:Python3::Interpreter>" "${line_directive_tool}" "@${file_path}" --
           "${swift_compiler_tool}" "-emit-module" "-o" "${module_file}"
-          ${emit_module_source_info}
+          "$<$<BOOL:${SWIFT_STDLIB_ENABLE_SOURCE_INFO}>:-emit-module-source-info-path>"
+          "$<$<BOOL:${SWIFT_STDLIB_ENABLE_SOURCE_INFO}>:$<SHELL_PATH:${module_location_file}>>"
+          "$<$<NOT:$<BOOL:${SWIFT_STDLIB_ENABLE_SOURCE_INFO}>>:-avoid-emit-module-source-info>"
           ${swift_flags} ${swift_module_flags} "@${file_path}"
         ${command_touch_module_outputs}
         OUTPUT ${module_outputs}


### PR DESCRIPTION
- **Explanation**: We've been hitting some issues where having the .swiftsourceinfo files in the toolchain can cause hangs on macOS. Provide CMake-level control for their generation so we can selectively enable them.
- **Scope**: Limited to the CMake build for the standard library & friends.
- **Issues**: rdar://176894222
- **Original PRs**: https://github.com/swiftlang/swift/pull/89068
- **Risk**: Relatively low. Stops producing .swiftsourceinfo files in the default configuration.
- **Testing**: Normal CI suffices.
- **Reviewers**:
