### PR TITLE
[6.4] [cxx-interop] Guard Span-referencing declarations in Cxx module interface behind version check

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3828,6 +3828,39 @@ static bool isCxxBorrowingSequenceOrIterator(Decl *decl) {
   return false;
 }
 
+// Returns true if the given nominal type is Span or MutableSpan from the Swift
+// stdlib.
+static bool isStdlibSpanType(const NominalTypeDecl *nominal) {
+  if (!nominal)
+    return false;
+  if (!nominal->getParentModule()->isStdlibModule())
+    return false;
+  auto name = nominal->getNameStr();
+  return name == "Span" || name == "MutableSpan";
+}
+
+// Returns true if a declaration in the Cxx overlay module references Span or
+// MutableSpan from the Swift stdlib in its type signature, or is an extension
+// of Span/MutableSpan.
+static bool isCxxDeclReferencingSpan(const Decl *decl) {
+  if (decl->getModuleContext()->getNameStr() != "Cxx")
+    return false;
+
+  if (const auto *ext = dyn_cast<ExtensionDecl>(decl)) {
+    if (isStdlibSpanType(ext->getExtendedNominal()))
+      return true;
+  }
+
+  if (const auto *vd = dyn_cast<ValueDecl>(decl)) {
+    if (auto ty = vd->getInterfaceType()) {
+      return ty.findIf(
+          [](Type t) -> bool { return isStdlibSpanType(t->getAnyNominal()); });
+    }
+  }
+
+  return false;
+}
+
 /// Generate the appropriate #if block(s) necessary to protect the use
 /// of compiler-version-dependent features in the given function.
 ///
@@ -3870,9 +3903,22 @@ void swift::printWithCompatibilityFeatureChecks(ASTPrinter &printer,
     return;
   }
 
+  // Span and MutableSpan were introduced in Swift 6.2. When a newer toolchain
+  // is used with an older SDK whose stdlib predates 6.2, references to these
+  // types in the Cxx module interface will fail to resolve. Guard individual
+  // declarations that reference Span/MutableSpan behind a version check.
+  bool needsSpanGuard = isCxxDeclReferencingSpan(decl);
+  if (needsSpanGuard) {
+    printer << "#if canImport(Swift, _version: 6.2)\n";
+  }
+
   FeatureSet features = getUniqueFeaturesUsed(decl);
   if (features.empty()) {
     printBody();
+    if (needsSpanGuard) {
+      printer.printNewline();
+      printer << "#endif";
+    }
     return;
   }
 
@@ -3903,6 +3949,11 @@ void swift::printWithCompatibilityFeatureChecks(ASTPrinter &printer,
 
   // Close the `#if` for the required features.
   if (hasRequiredFeatures) {
+    printer.printNewline();
+    printer << "#endif";
+  }
+
+  if (needsSpanGuard) {
     printer.printNewline();
     printer << "#endif";
   }

--- a/test/Interop/Cxx/stdlib/overlay/Inputs/span_interface_guard.swift
+++ b/test/Interop/Cxx/stdlib/overlay/Inputs/span_interface_guard.swift
@@ -1,0 +1,8 @@
+@available(SwiftCompatibilitySpan 5.0, *)
+public func takeSpan(_ s: Span<Int>) -> Int {
+  s.isEmpty ? 0 : s[0]
+}
+
+public func noSpan(_ x: Int) -> Int {
+  x + 1
+}

--- a/test/Interop/Cxx/stdlib/overlay/span-version-guard-module-interface.swift
+++ b/test/Interop/Cxx/stdlib/overlay/span-version-guard-module-interface.swift
@@ -1,0 +1,28 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend \
+// RUN:   -swift-version 5 \
+// RUN:   -enable-library-evolution \
+// RUN:   -emit-module \
+// RUN:   -module-name Cxx \
+// RUN:   -o %t/Cxx.swiftmodule \
+// RUN:   -emit-module-interface-path %t/Cxx.swiftinterface \
+// RUN:   %S/Inputs/span_interface_guard.swift
+
+// RUN: %FileCheck %s < %t/Cxx.swiftinterface
+
+// Verify the interface can be compiled back.
+// RUN: %target-swift-frontend \
+// RUN:   -compile-module-from-interface \
+// RUN:   -o %t/Cxx.swiftmodule \
+// RUN:   %t/Cxx.swiftinterface
+
+// Declarations that reference Span in the Cxx module should be guarded.
+// CHECK:       #if canImport(Swift, _version: 6.2)
+// CHECK-NEXT:  @available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, visionOS 1.0, *)
+// CHECK-NEXT:  public func takeSpan(_ s: Swift::Span<Swift::Int>) -> Swift::Int
+// CHECK-NEXT:  #endif
+
+// Non-Span declarations should NOT be guarded.
+// CHECK:       public func noSpan(_ x: Swift::Int) -> Swift::Int
+// CHECK-NOT:   #endif


### PR DESCRIPTION
- **Explanation**: When a newer toolchain (Swift >=6.2) is used with an older SDK whose stdlib predates Swift 6.2, the Cxx module interface references `Swift.Span` and `Swift.MutableSpan` which don't exist in the older stdlib, causing build failures. The fix adds `#if canImport(Swift, _version: 6.2)` guards around individual declarations in the Cxx overlay that reference Span/MutableSpan, so they're skipped when the SDK's stdlib is too old.
- **Scope**: Only the Cxx overlay module's `.swiftinterface` output is affected. The guard is scoped to declarations in modules named Cxx via `isCxxDeclReferencingSpan`. Other modules are unchanged.
- **Issue**: rdar://176312542
- **Original PRs**: https://github.com/swiftlang/swift/pull/89149
- **Risk**: Low. The change adds a compile-time `#if` guard that's a no-op for SDKs that already have Span (6.2+). The mechanism mirrors the existing `isCxxBorrowingSequenceOrIterator` pattern (which guards `BorrowingSequence` behind `canImport(Swift, _version: 6.4.0.12)`).
- **Testing**:
  - New test `test/Interop/Cxx/stdlib/overlay/span-version-guard-module-interface.swift`, which emits a module interface named Cxx with Span and non-Span declarations, verifies the guard appears only on the Span one.
  - Manual verification whether Cxx overlay interface has correct guards and compiles in an older SDK.
- **Reviewers**: @egorzhdan @Xazax-hun @tshortli



(cherry picked from commit 9e057e5c14a3d992eef21203c0915d7b88b261e8)