### PR TITLE
[Observation] Use absolute path in synthesized #sourceLocation

### DIFF
--- a/lib/Macros/Sources/ObservationMacros/ObservableMacro.swift
+++ b/lib/Macros/Sources/ObservationMacros/ObservableMacro.swift
@@ -196,7 +196,15 @@ extension TokenSyntax {
 
 extension CodeBlockSyntax {
   func locationAnnotated(in context: LocalMacroExpansionContext<some MacroExpansionContext>) -> CodeBlockSyntax {
-    guard let firstStatement = statements.first, let loc = context.context.location(of: firstStatement) else {
+    // Use `.filePath` (absolute path) rather than the default `.fileID`
+    // (`Module/file.swift`) so SourceKit/Xcode can resolve diagnostics
+    // remapped through the synthesized `#sourceLocation` directive.
+    guard let firstStatement = statements.first,
+          let loc = context.context.location(
+            of: firstStatement,
+            at: .afterLeadingTrivia,
+            filePathMode: .filePath
+          ) else {
       return self
     }
     

--- a/test/stdlib/Observation/Macros/observation_macro_expansion_observable.swift
+++ b/test/stdlib/Observation/Macros/observation_macro_expansion_observable.swift
@@ -67,3 +67,21 @@ final class CommentOnSameLineNoAnnotation {
 // CHECK-NEXT:  @ObservationIgnored
 // CHECK-NEXT:  private final /*2*/ var _it /*4*/ /*4*/ = 0
 _ = 0
+
+// `#sourceLocation` directives synthesized to forward the spelled location of
+// `didSet`/`willSet` bodies must use an absolute filesystem path (`.filePath`)
+// rather than `#fileID`-style `Module/file.swift` — the latter cannot be
+// resolved by SourceKit/Xcode when navigating remapped diagnostics.
+@available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
+@Observable
+final class DidSetSourceLocationUsesAbsolutePath {
+  var value = 0 {
+    didSet {
+      _ = value
+    }
+  }
+}
+
+// CHECK-LABEL: @__swiftmacro{{.*}}DidSetSourceLocationUsesAbsolutePath{{.*}}ObservationTracked{{.*}}.swift
+// CHECK:       #sourceLocation(file: "{{.*}}Macros{{.*}}observation_macro_expansion_observable.swift",
+_ = 0

--- a/test/stdlib/Observation/Macros/observation_macro_expansion_observable.swift
+++ b/test/stdlib/Observation/Macros/observation_macro_expansion_observable.swift
@@ -83,5 +83,7 @@ final class DidSetSourceLocationUsesAbsolutePath {
 }
 
 // CHECK-LABEL: @__swiftmacro{{.*}}DidSetSourceLocationUsesAbsolutePath{{.*}}ObservationTracked{{.*}}.swift
-// CHECK:       #sourceLocation(file: "{{.*}}Macros{{.*}}observation_macro_expansion_observable.swift",
+// On Windows the path contains backslashes, so swift-syntax emits a raw
+// string literal (`#"..."#`) instead of a plain `"..."`. Allow either form.
+// CHECK:       #sourceLocation(file: {{#?}}"{{.*}}Macros{{.*}}observation_macro_expansion_observable.swift"{{#?}},
 _ = 0

--- a/test/stdlib/Observation/ObservableDidSetWillSet.swift
+++ b/test/stdlib/Observation/ObservableDidSetWillSet.swift
@@ -40,3 +40,20 @@ m.state = .running
 // CHECK: new state=complete
 // CHECK: old state=running
 m.state = .complete
+
+// The macro wraps `didSet`/`willSet` bodies in a synthesized
+// `#sourceLocation(file: "/absolute/path.swift", ...)` directive. Verify that
+// `#fileID` evaluated inside such a body still produces the short
+// `Module/file.swift` form rather than the absolute path.
+@Observable
+public class FileIDModel {
+  public var value = 0 {
+    didSet {
+      print("fileID=\(#fileID)")
+    }
+  }
+}
+
+let f = FileIDModel()
+// CHECK: fileID=main/ObservableDidSetWillSet.swift
+f.value = 1


### PR DESCRIPTION
The `@Observable` macro's `locationAnnotated` helper wraps relocated `didSet`/`willSet` bodies in a `#sourceLocation` directive so diagnostics point back to the user's spelled location. It was using the default `location(of:)` overload, which produces `#fileID`-style paths (`Module/file.swift`) — not a filesystem path.

When SourceKit or Xcode tries to resolve a diagnostic or index entry whose location was remapped through that directive, the relative identifier doesn't open as a file. The user-visible symptom is "the file couldn't be opened because there is no such file" in the editor, with diagnostics and error navigation breaking for the file.

Pass `filePathMode: .filePath` to use the absolute path.

fixes rdar://174093766