### PR TITLE
[6.4][region-isolation] Fix false-positive errors in NSObject actor initializers

### DIFF
--- a/lib/SILOptimizer/Utils/SILIsolationInfo.cpp
+++ b/lib/SILOptimizer/Utils/SILIsolationInfo.cpp
@@ -330,6 +330,31 @@ static bool isPartialApplyNonisolatedUnsafe(PartialApplyInst *pai) {
   return foundOneNonIsolatedUnsafe;
 }
 
+static const SILFunctionArgument *
+getSelfFunctionArgumentForRefElementAddr(SILValue value) {
+  auto *reai = dyn_cast<RefElementAddrInst>(value);
+  if (!reai)
+    return {};
+
+  auto self = llvm::cast_or_null<SILFunctionArgument>(
+      reai->getFunction()->maybeGetSelfArgument());
+  if (!self || !self->getType().isAnyActor())
+    return {};
+
+  auto declRef = reai->getFunction()->getDeclRef();
+  if (!declRef || declRef.kind != SILDeclRef::Kind::Initializer)
+    return {};
+
+  auto *lbi = dyn_cast<LoadBorrowInst>(reai->getOperand());
+  if (!lbi)
+    return {};
+
+  auto *asi = dyn_cast<AllocStackInst>(lbi->getOperand());
+  if (!asi || !asi->getDecl()->isActorSelf())
+    return {};
+  return self;
+}
+
 /// Return the SILIsolationInfo for a class field for a ref_element_addr or
 /// class_method. Methods that are direct should get their isolation information
 /// from the static function rather than from this function.
@@ -371,6 +396,14 @@ static SILIsolationInfo computeIsolationForClassField(SILValue queriedValue,
   if (varIsolation.isNonisolatedOrConcurrent())
     return SILIsolationInfo::getDisconnected(
         varIsolation.isNonisolatedUnsafe());
+
+  // See if we have a load from a box in an objc actor initializer where we need
+  // to identify our actor instance (which would be a box otherwise) with self.
+  if (auto newValue = getSelfFunctionArgumentForRefElementAddr(queriedValue)) {
+    if (auto info =
+            SILIsolationInfo::getActorInstanceIsolated(queriedValue, newValue))
+      return info;
+  }
 
   // Check if we actually have an actor as our class value. First see if we have
   // an actor instance value from an isolated SILFunctionArgument.

--- a/test/Concurrency/transfernonsendable_initializers_objc.swift
+++ b/test/Concurrency/transfernonsendable_initializers_objc.swift
@@ -1,0 +1,316 @@
+// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -target %target-swift-5.1-abi-triple -swift-version 6 -verify %s -o /dev/null
+
+// REQUIRES: concurrency
+// REQUIRES: objc_interop
+
+// This test validates the behavior of transfernonsendable around NSObject-subclassing
+// actor initializers. NSObject actors have a distinctive SIL codegen: properties are
+// assigned *before* the objc_super_method call to NSObject.init, and `self` is held
+// on a stack slot that is updated with the result of super.init. The region isolation
+// analysis recognizes the stack slot as the self box and marks any ref_element_addr
+// derived from it as actor-instance-isolated.
+
+import Foundation
+
+////////////////////////
+// MARK: Declarations //
+////////////////////////
+
+class NonSendableKlass {}
+struct NoncopyableAccount: ~Copyable {}
+
+// Copyable struct and enum containers that embed a non-sendable reference.
+struct StructWrapper { var account: NonSendableKlass }
+enum EnumWrapper { case some(NonSendableKlass), none }
+indirect enum IndirectEnumWrapper { case leaf(NonSendableKlass), branch(IndirectEnumWrapper, IndirectEnumWrapper) }
+
+// Noncopyable struct and enum containers that embed a non-sendable reference.
+struct NoncopyableStructWrapper: ~Copyable { var account: NonSendableKlass }
+enum NoncopyableEnumWrapper: ~Copyable { case some(NonSendableKlass), none }
+
+/////////////////
+// MARK: Tests //
+/////////////////
+
+// MARK: - let properties
+
+actor Task1: NSObject {
+  let account: NonSendableKlass
+  init(account: NonSendableKlass) {
+    self.account = account
+  }
+}
+
+actor Task2<T>: NSObject {
+  let account: T
+  init(account: T) {
+    self.account = account
+  }
+}
+
+actor Task3: NSObject {
+  let account: NoncopyableAccount
+  init(account: consuming NoncopyableAccount) {
+    self.account = account
+  }
+}
+
+actor Task4<T: ~Copyable>: NSObject {
+  let account: T
+  init(account: consuming T) {
+    self.account = account
+  }
+}
+
+actor Task5<T: AnyObject>: NSObject {
+  let account: T
+  init(account: T) {
+    self.account = account
+  }
+}
+
+// Multiple let properties assigned in reversed declaration order.
+actor Task6: NSObject {
+  let a: NonSendableKlass
+  let b: NonSendableKlass
+  init(a: NonSendableKlass, b: NonSendableKlass) {
+    self.b = b
+    self.a = a
+  }
+}
+
+// Sendable default-initialized property alongside a non-sendable let.
+actor Task7: NSObject {
+  var count: Int = 0
+  let account: NonSendableKlass
+  init(account: NonSendableKlass) {
+    self.account = account
+  }
+}
+
+// Multiple generic type parameters with distinct constraints.
+actor Task8<T: ~Copyable, U: AnyObject>: NSObject {
+  let item: T
+  let ref: U
+  init(item: consuming T, ref: U) {
+    self.item = item
+    self.ref = ref
+  }
+}
+
+// MARK: - var, optional, weak, and failable-init properties
+
+actor Task9: NSObject {
+  var account: NonSendableKlass
+  init(account: NonSendableKlass) {
+    self.account = account
+  }
+}
+
+actor Task10: NSObject {
+  var account: NonSendableKlass?
+  init(account: NonSendableKlass?) {
+    self.account = account
+  }
+}
+
+actor Task11: NSObject {
+  let account: NonSendableKlass
+  init?(account: NonSendableKlass?) {
+    guard let account else { return nil }
+    self.account = account
+  }
+}
+
+actor Task12: NSObject {
+  weak var account: NonSendableKlass?
+  init(account: NonSendableKlass?) {
+    self.account = account
+  }
+}
+
+// MARK: - Struct field types
+
+// Copyable struct wrapping a non-sendable.
+actor Task13: NSObject {
+  let w: StructWrapper
+  init(w: StructWrapper) {
+    self.w = w
+  }
+}
+
+// Generic copyable.
+actor Task14<T>: NSObject {
+  let w: T
+  init(w: T) {
+    self.w = w
+  }
+}
+
+// Generic noncopyable.
+actor Task15<T: ~Copyable>: NSObject {
+  let w: T
+  init(w: consuming T) {
+    self.w = w
+  }
+}
+
+// Concrete noncopyable struct with a non-sendable field.
+actor Task16: NSObject {
+  let w: NoncopyableStructWrapper
+  init(w: consuming NoncopyableStructWrapper) {
+    self.w = w
+  }
+}
+
+// MARK: - Enum field types
+
+// Copyable enum with non-sendable payload.
+actor Task17: NSObject {
+  let status: EnumWrapper
+  init(status: EnumWrapper) {
+    self.status = status
+  }
+}
+
+// Generic copyable.
+actor Task18<T>: NSObject {
+  let status: T
+  init(status: T) {
+    self.status = status
+  }
+}
+
+// Generic noncopyable.
+actor Task19<T: ~Copyable>: NSObject {
+  let status: T
+  init(status: consuming T) {
+    self.status = status
+  }
+}
+
+// Concrete noncopyable enum with a non-sendable payload.
+actor Task20: NSObject {
+  let status: NoncopyableEnumWrapper
+  init(status: consuming NoncopyableEnumWrapper) {
+    self.status = status
+  }
+}
+
+// MARK: - Indirect enum field types
+
+// Indirect enum with non-sendable payload.
+actor Task21: NSObject {
+  let tree: IndirectEnumWrapper
+  init(tree: IndirectEnumWrapper) {
+    self.tree = tree
+  }
+}
+
+// MARK: - Tuple field types
+
+// Both elements non-sendable.
+actor Task22: NSObject {
+  let pair: (NonSendableKlass, NonSendableKlass)
+  init(pair: (NonSendableKlass, NonSendableKlass)) {
+    self.pair = pair
+  }
+}
+
+// One non-sendable element, one Sendable.
+actor Task23: NSObject {
+  let pair: (NonSendableKlass, Int)
+  init(pair: (NonSendableKlass, Int)) {
+    self.pair = pair
+  }
+}
+
+// Three non-sendable elements.
+actor Task25: NSObject {
+  let triple: (NonSendableKlass, NonSendableKlass, NonSendableKlass)
+  init(triple: (NonSendableKlass, NonSendableKlass, NonSendableKlass)) {
+    self.triple = triple
+  }
+}
+
+// Three elements, mixed sendable.
+actor Task26: NSObject {
+  let triple: (NonSendableKlass, Int, NonSendableKlass)
+  init(triple: (NonSendableKlass, Int, NonSendableKlass)) {
+    self.triple = triple
+  }
+}
+
+// sending tuple parameter.
+actor Task28: NSObject {
+  let pair: (NonSendableKlass, NonSendableKlass)
+  init(pair: sending (NonSendableKlass, NonSendableKlass)) {
+    self.pair = pair
+  }
+}
+
+// Tuple field assigned from freshly-allocated objects.
+actor Task30: NSObject {
+  let pair: (NonSendableKlass, NonSendableKlass)
+  override init() {
+    self.pair = (NonSendableKlass(), NonSendableKlass())
+  }
+}
+
+// Swapped assignment `self.pair = (b, a)`.
+actor Task27: NSObject {
+  let pair: (NonSendableKlass, NonSendableKlass)
+  init(a: NonSendableKlass, b: NonSendableKlass) {
+    self.pair = (b, a)
+  }
+}
+
+// Nested tuple literal `((a, b), c)`.
+actor Task31: NSObject {
+  let nested: ((NonSendableKlass, NonSendableKlass), NonSendableKlass)
+  init(a: NonSendableKlass, b: NonSendableKlass, c: NonSendableKlass) {
+    self.nested = ((a, b), c)
+  }
+}
+
+// Deeply nested tuple literal `((a, b), (c, d))`.
+actor Task32: NSObject {
+  let deep: ((NonSendableKlass, NonSendableKlass), (NonSendableKlass, NonSendableKlass))
+  init(a: NonSendableKlass, b: NonSendableKlass, c: NonSendableKlass, d: NonSendableKlass) {
+    self.deep = ((a, b), (c, d))
+  }
+}
+
+// inout tuple parameter.
+actor Task29: NSObject {
+  let pair: (NonSendableKlass, NonSendableKlass)
+  init(pair: inout (NonSendableKlass, NonSendableKlass)) {
+    self.pair = pair
+  }
+}
+
+// Generic tuple (A, B).
+actor Task24<A, B>: NSObject {
+  let pair: (A, B)
+  init(pair: (A, B)) {
+    self.pair = pair
+  }
+}
+
+// MARK: - More generic tuple variants
+
+// One generic element, one concrete non-sendable.
+actor Task36<T>: NSObject {
+  let pair: (T, NonSendableKlass)
+  init(t: T, ns: NonSendableKlass) {
+    self.pair = (t, ns)
+  }
+}
+
+// Homogeneous generic pair.
+actor Task37<T>: NSObject {
+  let pair: (T, T)
+  init(a: T, b: T) {
+    self.pair = (a, b)
+  }
+}


### PR DESCRIPTION
NSObject-subclassing actor initializers use a distinctive SIL layout: the `self` parameter is stored into an `alloc_stack` before any field assignments, and `ref_element_addr` instructions are derived from a `load_borrow` of that stack slot rather than directly from the function argument.

The region isolation analysis did not recognise this pattern, so the `ref_element_addr` for each field was not identified as belonging to the actor instance.  This caused spurious "self-isolated → self-isolated cross-isolation" errors for virtually every property kind: `var`, optional `var`, `weak var`, failable initializers, noncopyable struct and enum fields, and all tuple field variants.

Fix: add `getSelfFunctionArgumentForRefElementAddr`, which walks the `ref_element_addr → load_borrow → alloc_stack` chain and uses the AST (`VarDecl::isActorSelf`) to confirm the stack slot is the self box. When confirmed, the field is given actor-instance isolation with respect to the self function argument, the same isolation already assigned to non-Sendable parameters by the nonisolated-sync-actor-init rule.  The two sides therefore agree on the actor instance and no false-positive is emitted.

rdar://177309273
(cherry picked from commit 995ca7d086834424346fd13db87b76b7f29ecc6e)


----

- **Explanation**: `@objc` class initializers codegen by putting `self` into a stack box at entry. This confused region isolation, which thought the stack box was a different actor instance from the one the initializer's parameters were isolated to, causing region isolation errors. This commit changes the isolation of the stack box to match `self`.
- **Scope**: Narrow. Changes are confined to region isolation's SIL pattern matching in `SILIsolationInfo.cpp` and only affect diagnostic emission for actor initializers that subclass NSObject. No code generation or runtime behavior changes; existing valid code continues to compile, and previously-emitted false-positive diagnostics in NSObject actor initializers are now correctly suppressed.
- **Issues**: rdar://177309273
- **Original PRs**: https://github.com/swiftlang/swift/pull/89205
- **Risk**: Low. The change only loosens diagnostics in a specific, recognisable SIL pattern (NSObject actor `init` with the alloc_stack/load_borrow chain confirmed via `VarDecl::isActorSelf`). It cannot cause previously-rejected code to be miscompiled, and any regression would manifest as a missing diagnostic rather than a runtime failure.
- **Testing**: New lit test `transfernonsendable_initializers_objc.swift` exercises the affected property kinds (var, optional var, weak var, failable inits, noncopyable struct/enum fields, tuple variants). Full Swift test suite passes locally. Pre-merge CI to validate on supported platforms.
- **Reviewers**: @xedin
  <!--
  The code owners that GitHub-approved the original changes in the mainline
  branch pull requests. If an original change has not been GitHub-approved by
  a respective code owner, provide a reason. Technical review can be delegated
  by a code owner or otherwise requested as deemed appropriate or useful.
  -->