### PR TITLE
[DebugInfo] Remove unused SILDIExpr operators

### DIFF
--- a/docs/HowToUpdateDebugInfo.md
+++ b/docs/HowToUpdateDebugInfo.md
@@ -137,19 +137,9 @@ SILGen should always use `SILBuilder::emitDebugDescription` to create debug
 values, which will automatically add an op_deref depending on the type of the
 SSA value. As there are no pointers in Swift, this will always do the right
 thing. In SIL passes, use `SILBuilder::createDebugValue` to create debug values,
-or `SILBuilder::createDebugValueAddr` to add an op_deref.
+or `SILBuilder::createDebugValueAddr` to prepend an op_deref.
 
-> [!Warning]
-> At the optimizer level, Swift `Unsafe*Pointer` types can be simplified
-> to address types. As such, a `debug_value` with an address type without an
-> `op_deref` can be valid. SIL passes must not assume that `op_deref` and
-> address types correlate.
-
-Even if `op_deref` is usually at the beginning, it doesn't have to be:
-```
-debug_value %0 : $*UInt8, let, name "hello", expr op_constu:3:op_plus:op_deref
-```
-This will add `3` to the pointer contained in `%0`, then dereference the result.
+For any computation more complex than a simple dereference, [Debug Reconstruction Basic Blocks](SIL/DebugBasicBlocks.md) should be used.
 
 #### Fragments
 
@@ -201,29 +191,18 @@ and, except fragments, no debug expression operator take a struct as input.
 > When multiple fragments are present, they are evaluated in the reverse way —
 > from the field within the variable first, to the SSA's type at the end
 
-#### Arithmetic
-
-An expression can add or subtract a constant offset to a value. To do so, an
-`op_constu` or `op_consts` can be used to push a constant integer to the stack,
-respectively unsigned and signed. Then, the `op_plus` and `op_minus` operators
-can be used to sum or subtract the two values on the stack.
-
-```
-debug_value %0 : $Builtin.Int64, var, name "previous", type $Int, expr op_consts:1:op_minus:op_fragment:#Int._value
-debug_value %0 : $Builtin.Int64, var, name "next", type $Int, expr op_consts:1:op_plus:op_fragment:#Int._value
-```
-
-> [!Caution]
-> This currently doesn't work if a fragment is present.
-
 #### Constants
 
 If a `debug_value` is describing a constant, such as in `let x = 1`, and the
-value is optimized out, we can keep it, using a constant expression, and no SSA
-value.
+value is optimized out, it must be preserved using a constant debug
+reconstruction block (see [DebugBasicBlocks.md](SIL/DebugBasicBlocks.md)):
 
 ```
-debug_value undef : $Int, let, name "x", expr op_consts:1:op_fragment:#Int._value
+debug_value undef : $Int, let, name "x", expr op_fragment:#Int._value, transform {
+bb0:
+  %0 = integer_literal $Builtin.Int64, 1
+  return %0 : $Builtin.Int64
+}
 ```
 
 ### Undef variables

--- a/include/swift/SIL/SILDebugInfoExpression.h
+++ b/include/swift/SIL/SILDebugInfoExpression.h
@@ -42,16 +42,6 @@ enum class SILDIExprOperator : unsigned {
   /// Note that this directive can only appear at the end of an
   /// expression, along with `TupleFragment`.
   Fragment,
-  /// Perform arithmetic addition on the top two elements of the
-  /// expression stack and push the result back to the stack.
-  Plus,
-  /// Subtract the top element in expression stack by the second
-  /// element. Then push the result back to the stack.
-  Minus,
-  /// Push an unsigned integer constant onto the stack.
-  ConstUInt,
-  /// Push a signed integer constant onto the stack.
-  ConstSInt,
   /// Specifies that the SSA value is an element of the
   /// associated tuple. This operator takes a TupleType
   /// operand pointing to the tuple type, and the index of the element.

--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -3701,20 +3701,6 @@ bool IRGenDebugInfoImpl::buildDebugInfoExpression(
     case SILDIExprOperator::Dereference:
       Operands.push_back(llvm::dwarf::DW_OP_deref);
       break;
-    case SILDIExprOperator::Plus:
-      Operands.push_back(llvm::dwarf::DW_OP_plus);
-      break;
-    case SILDIExprOperator::Minus:
-      Operands.push_back(llvm::dwarf::DW_OP_minus);
-      break;
-    case SILDIExprOperator::ConstUInt:
-      Operands.push_back(llvm::dwarf::DW_OP_constu);
-      Operands.push_back(*ExprOperand[1].getAsConstInt());
-      break;
-    case SILDIExprOperator::ConstSInt:
-      Operands.push_back(llvm::dwarf::DW_OP_consts);
-      Operands.push_back(*ExprOperand[1].getAsConstInt());
-      break;
     case SILDIExprOperator::INVALID:
       return false;
     }
@@ -4037,16 +4023,6 @@ void IRGenDebugInfoImpl::emitDbgIntrinsic(
   // /always/ emit an llvm.dbg.value of undef.
   // If we have undef, always emit a llvm.dbg.value in the current position.
   if (isa<llvm::UndefValue>(Storage)) {
-    if (Expr->getNumElements() &&
-        (Expr->getElement(0) == llvm::dwarf::DW_OP_consts
-         || Expr->getElement(0) == llvm::dwarf::DW_OP_constu)) {
-      /// Convert `undef, expr op_consts:N:...` to `N, expr ...`
-      Storage = llvm::ConstantInt::get(
-          llvm::IntegerType::getInt64Ty(Builder.getContext()),
-          Expr->getElement(1));
-      Expr = llvm::DIExpression::get(Builder.getContext(),
-                                     Expr->getElements().drop_front(2));
-    }
     DBuilder.insertDbgValueIntrinsic(Storage, Var, Expr, DL, ParentBlock);
     return;
   }

--- a/lib/SIL/IR/SILDebugInfoExpression.cpp
+++ b/lib/SIL/IR/SILDebugInfoExpression.cpp
@@ -41,13 +41,7 @@ const SILDIExprInfo *SILDIExprInfo::get(SILDIExprOperator Op) {
       {SILDIExprOperator::TupleFragment,
        {"op_tuple_fragment",
          {SILDIExprElement::TypeKind, SILDIExprElement::ConstIntKind}}},
-      {SILDIExprOperator::Dereference, {"op_deref", {}}},
-      {SILDIExprOperator::Plus, {"op_plus", {}}},
-      {SILDIExprOperator::Minus, {"op_minus", {}}},
-      {SILDIExprOperator::ConstUInt,
-       {"op_constu", {SILDIExprElement::ConstIntKind}}},
-      {SILDIExprOperator::ConstSInt,
-       {"op_consts", {SILDIExprElement::ConstIntKind}}}};
+      {SILDIExprOperator::Dereference, {"op_deref", {}}}};
 
   return Infos.count(Op) ? &Infos.at(Op) : nullptr;
 }

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -1629,10 +1629,7 @@ public:
         }
         case SILDIExprElement::ConstIntKind: {
           uint64_t V = *Arg.getAsConstInt();
-          if (Op == SILDIExprOperator::ConstSInt)
-            *this << static_cast<int64_t>(V);
-          else
-            *this << V;
+          *this << V;
           break;
         }
         case SILDIExprElement::TypeKind: {

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -1631,10 +1631,6 @@ bool SILParser::parseSILDebugInfoExpression(SILDebugInfoExpression &DIExpr) {
   static const SILDIExprOperator AllOps[] = {
     SILDIExprOperator::Dereference,
     SILDIExprOperator::Fragment,
-    SILDIExprOperator::Plus,
-    SILDIExprOperator::Minus,
-    SILDIExprOperator::ConstUInt,
-    SILDIExprOperator::ConstSInt,
     SILDIExprOperator::TupleFragment
   };
 

--- a/test/DebugInfo/debug_info_expression.sil
+++ b/test/DebugInfo/debug_info_expression.sil
@@ -42,26 +42,3 @@ bb0:
   return %r : $()
 }
 
-
-sil_scope 3 { loc "file.swift":16:7 parent @test_op_const : $@convention(thin) (Int64, Int64) -> () }
-
-// Testing op_constu and op_consts
-sil hidden @test_op_const : $@convention(thin) (Int64, Int64) -> () {
-bb0(%arg : $Int64, %arg2 : $Int64):
-  debug_value %arg : $Int64, let, name "the_arg", argno 1, expr op_constu:77, loc "file.swift":17:2, scope 3
-  debug_value %arg2 : $Int64, let, name "the_2nd_arg", argno 2, expr op_consts:-87, loc "file.swift":17:4, scope 3
-  %r = tuple()
-  return %r : $()
-}
-
-sil_scope 4 { loc "file.swift":18:8 parent @test_arithmetic : $@convention(thin) (Int64, Int64) -> () }
-
-// Testing basic arithmetic operators like op_plus and op_minus
-sil hidden @test_arithmetic : $@convention(thin) (Int64, Int64) -> () {
-bb0(%arg : $Int64, %arg2 : $Int64):
-  debug_value %arg : $Int64, let, name "the_arg", argno 1, expr op_constu:3:op_plus, loc "file.swift":19:2, scope 4
-  debug_value %arg2 : $Int64, let, name "the_2nd_arg", argno 2, expr op_constu:5:op_minus, loc "file.swift":19:4, scope 4
-  %r = tuple()
-  return %r : $()
-}
-

--- a/test/DebugInfo/irgen_undef.sil
+++ b/test/DebugInfo/irgen_undef.sil
@@ -17,24 +17,44 @@ sil @arithmetic : $@convention(thin) (Builtin.Int64) -> (Builtin.Int64) {
 bb0(%0 : $Builtin.Int64):
 // CHECK: #dbg_value(i64 %0, ![[CURRENT_VAR:[0-9]+]], !DIExpression()
 debug_value %0 : $Builtin.Int64, var, name "current", type $Int64, expr op_fragment:#Int64._value
-// FIXME: It should work with the fragment, as it should be noop.
-// CHECK: #dbg_value(i64 %0, ![[PREVIOUS_VAR:[0-9]+]], !DIExpression(DW_OP_consts, 1, DW_OP_minus, DW_OP_stack_value)
-debug_value %0 : $Builtin.Int64, var, name "previous", type $Int64, expr op_consts:1:op_minus //:op_fragment:#Int64._value
+// CHECK: #dbg_value(i64 %0, ![[PREVIOUS_VAR:[0-9]+]], !DIExpression(DW_OP_constu, 1, DW_OP_minus, DW_OP_stack_value)
+debug_value %0 : $Builtin.Int64, var, name "previous", type $Int64, expr op_fragment:#Int64._value, transform {
+bb0(%1 : $Builtin.Int64):
+  %2 = integer_literal $Builtin.Int64, 1
+  %3 = builtin "sub_Int64"(%1 : $Builtin.Int64, %2 : $Builtin.Int64) : $Builtin.Int64
+  return %3 : $Builtin.Int64
+}
 // CHECK: #dbg_value(i64 %0, ![[NEXT_VAR:[0-9]+]], !DIExpression(DW_OP_plus_uconst, 12, DW_OP_stack_value)
-debug_value %0 : $Builtin.Int64, var, name "next", type $Int64, expr op_constu:12:op_plus //:op_fragment:#Int64._value
+debug_value %0 : $Builtin.Int64, var, name "next", type $Int64, expr op_fragment:#Int64._value, transform {
+bb0(%1 : $Builtin.Int64):
+  %2 = integer_literal $Builtin.Int64, 12
+  %3 = builtin "add_Int64"(%1 : $Builtin.Int64, %2 : $Builtin.Int64) : $Builtin.Int64
+  return %3 : $Builtin.Int64
+}
 return %0 : $Builtin.Int64
 }
 
 // CHECK-LABEL: define {{.*}} @constant
 sil @constant : $@convention(thin) (Builtin.Int64) -> (Builtin.Int64) {
 bb0(%0 : $Builtin.Int64):
-// CHECK: #dbg_value(i64 42, ![[CONST_VAR:[0-9]+]], !DIExpression(DW_OP_stack_value)
-debug_value undef : $Builtin.Int64, var, name "const", expr op_consts:42
-// CHECK: #dbg_value(i64 3645, ![[CONSTINT_VAR:[0-9]+]], !DIExpression(DW_OP_stack_value)
-debug_value undef : $Builtin.Int64, var, name "constint", type $Int64, expr op_constu:3645:op_fragment:#Int64._value
+// CHECK: #dbg_value(i64 42, ![[CONST_VAR:[0-9]+]], !DIExpression()
+debug_value undef : $Builtin.Int64, var, name "const", transform {
+bb0:
+  %1 = integer_literal $Builtin.Int64, 42
+  return %1 : $Builtin.Int64
+}
+// CHECK: #dbg_value(i64 3645, ![[CONSTINT_VAR:[0-9]+]], !DIExpression()
+debug_value undef : $Builtin.Int64, var, name "constint", type $Int64, expr op_fragment:#Int64._value, transform {
+bb0:
+  %1 = integer_literal $Builtin.Int64, 3645
+  return %1 : $Builtin.Int64
+}
 // CHECK: #dbg_value(i64 6, ![[CONSTUPLE_VAR:[0-9]+]], !DIExpression(DW_OP_LLVM_fragment, 0, 64)
-debug_value undef : $Builtin.Int64, var, name "constuple", type $(Int64, Int64), expr op_consts:6:op_tuple_fragment:$(Int64, Int64):0:op_fragment:#Int64._value
-
+debug_value undef : $Builtin.Int64, var, name "constuple", type $(Int64, Int64), expr op_tuple_fragment:$(Int64, Int64):0:op_fragment:#Int64._value, transform {
+bb0:
+  %1 = integer_literal $Builtin.Int64, 6
+  return %1 : $Builtin.Int64
+}
 return %0 : $Builtin.Int64
 }
 

--- a/test/DebugInfo/verifier_debug_info_expression_start_fragment.sil
+++ b/test/DebugInfo/verifier_debug_info_expression_start_fragment.sil
@@ -14,7 +14,7 @@ bb0:
   %0 = alloc_stack $MyStruct, var, name "my_struct", loc "file.swift":8:9, scope 1
   %1 = struct_element_addr %0 : $*MyStruct, #MyStruct.x, loc "file.swift":9:17, scope 1
   // every op_fragment should be the last di-expression operand
-  debug_value %1 : $*Builtin.Int64, var, name "my_struct", expr op_deref:op_fragment:#MyStruct.y:op_constu:42:op_plus
+  debug_value %1 : $*Builtin.Int64, var, name "my_struct", expr op_deref:op_fragment:#MyStruct.y:op_deref
   dealloc_stack %0 : $*MyStruct
   %r = tuple()
   return %r : $()


### PR DESCRIPTION
Since salvageDebugInfo now uses debug reconstruction basic blocks, the plus, minus, and constant SILDebugInfoExpression operators were left unused. This PR removes them, and updates some of their tests to use debug basic blocks