### PR TITLE
[cxx-interop] SWIFT_REFCOUNTED_PTR improvements

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -8935,25 +8935,52 @@ RefCountedPtrRequestResult ClangRefCountedSmartPointer::evaluate(
 
       auto ctors =
           desc.smartPtr->lookupDirect(DeclBaseName::createConstructor());
-      // We should have a single constructor taking a foreign reference
-      // types. This is relied on during SILGen to introduce implicit
-      // bridging.
+      // We accept a constructor whose parameter imports as the foreign
+      // reference type. In C++ that means a raw pointer (T*, possibly
+      // const-qualified) or an lvalue reference (T&, possibly
+      // const-qualified). We rank candidates so that more-specific
+      // forms win when several are available:
+      //   T*  >  const T*  >  T&  >  const T&
+      // Per-rank duplicates are still ambiguous. Rvalue-reference and
+      // deleted ctors aren't bridgeable. The selected constructor is
+      // relied on during SILGen to introduce implicit bridging.
       ConstructorDecl *selected = nullptr;
-      Type selectedCtorParamType = nullptr;
+      std::optional<int> selectedRank;
       for (auto result : ctors) {
         auto ctor = cast<ConstructorDecl>(result);
         if (ctor->getParameters()->size() != 1)
           continue;
         Type ctorParamType = ctor->getParameters()->get(0)->getInterfaceType();
-        if (ctorParamType->isForeignReferenceType()) {
-          if (selected != nullptr)
-            return {RefCountedPtrError::CtorLookupAmbiguity, toRawPtrFunc};
+        if (!ctorParamType->isForeignReferenceType())
+          continue;
+
+        auto *clangCtor =
+            dyn_cast_or_null<clang::CXXConstructorDecl>(ctor->getClangDecl());
+        if (!clangCtor || clangCtor->isDeleted())
+          continue;
+
+        clang::QualType paramTy = clangCtor->getParamDecl(0)->getType();
+        int rank;
+        if (paramTy->isLValueReferenceType()) {
+          rank = paramTy->getPointeeType().isConstQualified() ? 3 : 2;
+        } else if (paramTy->isPointerType()) {
+          rank = paramTy->getPointeeType().isConstQualified() ? 1 : 0;
+        } else {
+          // Not a pointer or lvalue reference (e.g., rvalue ref).
+          continue;
+        }
+
+        if (!selectedRank || rank < *selectedRank) {
           selected = ctor;
-          selectedCtorParamType = ctorParamType;
+          selectedRank = rank;
+        } else if (rank == *selectedRank) {
+          return {RefCountedPtrError::CtorLookupAmbiguity, toRawPtrFunc};
         }
       }
       if (!selected)
         return {RefCountedPtrError::CtorLookupFailure, toRawPtrFunc};
+      Type selectedCtorParamType =
+          selected->getParameters()->get(0)->getInterfaceType();
       if (!selectedCtorParamType->lookThroughSingleOptionalType()->isEqual(
               pointeeType))
         return {RefCountedPtrError::CtorWrongParamType, toRawPtrFunc};

--- a/lib/ClangImporter/ClangLookup.cpp
+++ b/lib/ClangImporter/ClangLookup.cpp
@@ -335,13 +335,35 @@ TinyPtrVector<ValueDecl *> ClangRecordMemberLookup::evaluate(
     // For inherited members, add members that are synthesized eagerly, such as
     // operators. This is not necessary for non-inherited members because those
     // should already be in the lookup table.
+
+    // If the derived class already has its own directly-synthesized
+    // property with the looked-up name, don't clone a same-named
+    // synthesized property from the base on top of it. This is the case
+    // e.g. when SWIFT_REFCOUNTED_PTR is applied to both a base and a
+    // derived smart pointer: each gets its own `asReference` and
+    // surfacing the base's clone too would leave the derived with two
+    // copies.
+    bool derivedHasOwnSynthesizedVar = false;
+    for (auto m : inheritingDecl->getCurrentMembersWithoutLoading()) {
+      auto ownVD = dyn_cast<VarDecl>(m);
+      if (ownVD && ownVD->hasName() && ownVD->getBaseName() == name &&
+          !ownVD->hasClangNode() &&
+          !clangModuleLoader->getOriginalForClonedMember(ownVD)) {
+        derivedHasOwnSynthesizedVar = true;
+        break;
+      }
+    }
+
     for (auto member :
          cast<NominalTypeDecl>(recordDecl)->getCurrentMembersWithoutLoading()) {
       auto namedMember = dyn_cast<ValueDecl>(member);
       if (!namedMember || !namedMember->hasName() ||
-          namedMember->getName().getBaseName() != name ||
+          namedMember->getBaseName() != name ||
           clangModuleLoader->isMemberSynthesizedPerType(namedMember) ||
           clangModuleLoader->getOriginalForClonedMember(namedMember))
+        continue;
+
+      if (derivedHasOwnSynthesizedVar && isa<VarDecl>(namedMember))
         continue;
 
       auto *imported = clangModuleLoader->importBaseMemberDecl(

--- a/lib/ClangImporter/SwiftBridging/swift/bridging
+++ b/lib/ClangImporter/SwiftBridging/swift/bridging
@@ -137,18 +137,21 @@
 /// type as long as the concrete instantiations used in your C++ interface
 /// all have determinable underlying reference types.)
 ///
-/// The smart pointer type is required to have a constructor that takes a raw
-/// pointer. This constructor is expected to perform a retain of the object.
-/// (In the +0 / +1 language of Objective-C reference counting, it would be
-/// said to take the object at +0: it does not take responsibility for a retain
-/// performed by its caller.) Generally, this kind of constructor matches with
-/// object models where the object constructor initializes the reference
-/// count to 0.
+/// The smart pointer type is required to have a constructor that takes
+/// either a raw pointer (`T*`) or an lvalue reference (`T&`) to the
+/// underlying reference type. If both forms are provided, the
+/// pointer-taking constructor is preferred. This constructor is
+/// expected to perform a retain of the object. (In the +0 / +1 language
+/// of Objective-C reference counting, it would be said to take the
+/// object at +0: it does not take responsibility for a retain
+/// performed by its caller.) Generally, this kind of constructor matches
+/// with object models where the object constructor initializes the
+/// reference count to 0.
 ///
 /// The argument of this annotation is required to be the name of an
-/// "accessor" method that returns a raw-pointer to the object. This method
-/// is required to return a raw pointer to the object without changing the
-/// reference count.
+/// "accessor" method that returns either a raw pointer or an lvalue
+/// reference to the object. This method is required to return without
+/// changing the reference count.
 ///
 /// Swift will define conversion operations using these functions to
 /// convert between the raw pointer and the smart pointer representations.

--- a/test/Interop/Cxx/foreign-reference/Inputs/refcounted-smartptrs.h
+++ b/test/Interop/Cxx/foreign-reference/Inputs/refcounted-smartptrs.h
@@ -64,18 +64,30 @@ struct SWIFT_REFCOUNTED_PTR(.getPtr) Ref {
 
 template <class T>
 struct SWIFT_REFCOUNTED_PTR(.get) Ptr {
-  Ptr(T *_Nullable ptr) : ptr(ptr) { retainSharedFRT(ptr); }
-  ~Ptr() { releaseSharedFRT(ptr); }
-  Ptr(const Ptr &other) : ptr(other.ptr) { retainSharedFRT(ptr); }
+  Ptr(T *_Nullable ptr) : ptr(ptr) {
+    if (ptr)
+      retainSharedFRT(ptr);
+  }
+  ~Ptr() {
+    if (ptr)
+      releaseSharedFRT(ptr);
+  }
+  Ptr(const Ptr &other) : ptr(other.ptr) {
+    if (ptr)
+      retainSharedFRT(ptr);
+  }
   Ptr(Ptr &&other) : ptr(other.ptr) { other.ptr = nullptr; }
   Ptr &operator=(const Ptr &other) {
-    releaseSharedFRT(ptr);
+    if (ptr)
+      releaseSharedFRT(ptr);
     ptr = other.ptr;
-    retainSharedFRT(ptr);
+    if (ptr)
+      retainSharedFRT(ptr);
     return *this;
   }
   Ptr &operator=(Ptr &&other) {
-    releaseSharedFRT(ptr);
+    if (ptr)
+      releaseSharedFRT(ptr);
     ptr = other.ptr;
     other.ptr = nullptr;
     return *this;
@@ -128,6 +140,103 @@ inline void notBridgedFunction(RefOfBase &ptr) {}
 inline void notBridgedFunction2(const RefOfBase &ptr) {}
 inline void notBridgedFunction3(RefOfBase &&ptr) {}
 
+struct PairWithPtr {
+  PtrOfBase ptr;
+  int otherValue;
+  PairWithPtr(RefCountedBase *_Nullable p) : ptr(p), otherValue(42) {}
+
+  PtrOfBase loadPtr() const { return ptr; }
+  void storePtr(PtrOfBase newPtr) { ptr = newPtr; }
+};
+
+struct PairWithConstRef {
+  const RefOfBase ref;
+  int otherValue;
+  PairWithConstRef(RefCountedBase *_Nonnull p) : ref(p), otherValue(42) {}
+
+  RefOfBase loadRef() const { return ref; }
+};
+
+inline PairWithPtr makePairWithPtr() {
+  return PairWithPtr(RefCountedBase::forSmartPtr());
+}
+inline PairWithPtr makePairWithNullPtr() { return PairWithPtr(nullptr); }
+inline PairWithConstRef makePairWithConstRef() {
+  return PairWithConstRef(RefCountedBase::forSmartPtr());
+}
+inline void takesPairWithPtr(PairWithPtr p) {}
+
+// A non-nullable smart pointer that, in addition to the usual T*
+// constructor, has a constructor taking a T&.
+template <class T>
+struct SWIFT_REFCOUNTED_PTR(.getPtr) RefR : Ref<T> {
+  RefR(T *_Nonnull ptr) : Ref<T>(ptr) { printf("RefR ptr ctor\n"); }
+  RefR(T &ref) : Ref<T>(&ref) { printf("RefR ref ctor\n"); }
+};
+
+using RefROfBase = RefR<RefCountedBase>;
+
+inline void bridgedFunctionR(RefROfBase ptr) {}
+inline RefROfBase bridgedFunctionR_returns() {
+  return RefROfBase(RefCountedBase::forSmartPtr());
+}
+
+// A non-nullable smart pointer that has both a T* and a const T*
+// constructor. The non-const T* ctor must be the one selected for
+// implicit bridging.
+template <class T>
+struct SWIFT_REFCOUNTED_PTR(.getPtr) RefConstPtr : Ref<T> {
+  RefConstPtr(T *_Nonnull ptr) : Ref<T>(ptr) {
+    printf("RefConstPtr ptr ctor\n");
+  }
+  RefConstPtr(const T *_Nonnull ptr) : Ref<T>(const_cast<T *>(ptr)) {
+    printf("RefConstPtr const-ptr ctor\n");
+  }
+};
+
+using RefConstPtrOfBase = RefConstPtr<RefCountedBase>;
+
+inline void bridgedFunctionConstPtr(RefConstPtrOfBase ptr) {}
+inline RefConstPtrOfBase bridgedFunctionConstPtr_returns() {
+  return RefConstPtrOfBase(RefCountedBase::forSmartPtr());
+}
+
+// A non-nullable smart pointer whose only constructor takes a const
+// T& and whose raw-pointer accessor returns a T& (rather than a T*).
+template <class T>
+struct SWIFT_REFCOUNTED_PTR(.getRef) RefRefOnly : Ref<T> {
+  RefRefOnly(const T &ref) : Ref<T>(const_cast<T *>(&ref)) {
+    printf("RefRefOnly ref ctor\n");
+  }
+  __attribute__((swift_attr("returns_unretained"))) T &getRef() const {
+    return *this->getPtr();
+  }
+};
+
+using RefRefOnlyOfBase = RefRefOnly<RefCountedBase>;
+
+inline void bridgedFunctionRefOnly(RefRefOnlyOfBase ptr) {}
+inline RefRefOnlyOfBase bridgedFunctionRefOnly_returns() {
+  return RefRefOnlyOfBase(*RefCountedBase::forSmartPtr());
+}
+
+// A derived smart pointer that itself is *not* annotated with
+// SWIFT_REFCOUNTED_PTR. Inheriting from the annotated Ref<T> means the
+// bridging `asReference` property is cloned onto this class via the
+// inheritance lookup, so the user can convert to the FRT explicitly.
+// No implicit bridging happens at function boundaries because this
+// type itself doesn't carry the macro.
+template <class T>
+struct UnannotatedRef : Ref<T> {
+  using Ref<T>::Ref;
+};
+
+using UnannotatedRefOfBase = UnannotatedRef<RefCountedBase>;
+
+inline UnannotatedRefOfBase makeUnannotatedRef() {
+  return UnannotatedRefOfBase(RefCountedBase::forSmartPtr());
+}
+
 namespace errors { // expected-note * {{'errors' declared here}}
 struct __attribute__((
     swift_attr("@_refCountedPtr(Nullability: \"Nullable\")"))) MissingToRawPtr {};
@@ -169,6 +278,24 @@ struct SWIFT_REFCOUNTED_PTR(.getPtr) AmbiguousCtors {
 struct SWIFT_REFCOUNTED_PTR(.getPtr) MismatchingPointerTypes {
   // expected-note@-1 * {{the constructor's parameter to create smart pointer from a raw pointer does not match the return type of the raw pointer accessor in 'MismatchingPointerTypes'}}
   MismatchingPointerTypes(RefCounted* _Nullable);
+  RefCountedBase *_Nonnull getPtr();
+};
+
+// Two T& ctors should still be ambiguous: per-kind ambiguity is
+// preserved (we only fall back to the reference slot when there is no
+// pointer slot).
+struct SWIFT_REFCOUNTED_PTR(.getPtr) AmbiguousRefCtors {
+  // expected-note@-1 * {{there are multiple constructors to create smart pointer from a raw pointer to a shared reference 'AmbiguousRefCtors'}}
+  AmbiguousRefCtors(RefCountedBase &);
+  AmbiguousRefCtors(RefCounted &);
+  RefCountedBase *_Nonnull getPtr();
+};
+
+// An rvalue-reference ctor isn't a valid bridging ctor; if it's the
+// only one we fail to find a suitable ctor.
+struct SWIFT_REFCOUNTED_PTR(.getPtr) RvalueRefCtor {
+  // expected-note@-1 * {{cannot find constructor to create smart pointer from a raw pointer to a shared reference 'RvalueRefCtor'}}
+  RvalueRefCtor(RefCountedBase &&);
   RefCountedBase *_Nonnull getPtr();
 };
 } // namespace errors

--- a/test/Interop/Cxx/foreign-reference/refcounted-smartpointer-fields.swift
+++ b/test/Interop/Cxx/foreign-reference/refcounted-smartpointer-fields.swift
@@ -1,0 +1,75 @@
+// RUN: %target-run-simple-swift(-I %swift_src_root/lib/ClangImporter/SwiftBridging -I %S/Inputs -cxx-interoperability-mode=default -Xfrontend -disable-availability-checking -Onone) | %FileCheck %s
+
+// REQUIRES: executable_test
+
+import RefCountedSmartPtrs
+
+func readPtrField() {
+  print("readPtrField")
+  let pair = makePairWithPtr()
+  if let frt = pair.ptr.asReference {
+    print(frt.method())
+  }
+  let nullPair = makePairWithNullPtr()
+  if nullPair.ptr.asReference == nil {
+    print("nil")
+  }
+}
+
+func readConstRefField() {
+  print("readConstRefField")
+  let pair = makePairWithConstRef()
+  let frt = pair.ref.asReference
+  print(frt.method())
+  print(pair.loadRef().method())
+}
+
+func passFieldImplicitlyBridged() {
+  print("passFieldImplicitlyBridged")
+  let pair = makePairWithConstRef()
+  bridgedFunction(pair.ref.asReference)
+}
+
+func writePtrField(_ r: RefCountedBase) {
+  print("writePtrField")
+  var pair = makePairWithNullPtr()
+  pair.ptr = PtrOfBase(r)
+  print(pair.ptr.asReference!.method())
+}
+
+func writePtrViaSetter(_ r: RefCountedBase) {
+  print("writePtrViaSetter")
+  var pair = makePairWithNullPtr()
+  pair.storePtr(r)
+  print(pair.loadPtr()!.method())
+}
+
+func passStructWithSmartPtrField() {
+  print("passStructWithSmartPtrField")
+  let pair = makePairWithPtr()
+  takesPairWithPtr(pair)
+}
+
+readPtrField()
+// CHECK: readPtrField
+// CHECK: 42
+// CHECK: nil
+
+readConstRefField()
+// CHECK: readConstRefField
+// CHECK: 42
+// CHECK: 42
+
+passFieldImplicitlyBridged()
+// CHECK: passFieldImplicitlyBridged
+
+writePtrField(RefCountedBase())
+// CHECK: writePtrField
+// CHECK: 42
+
+writePtrViaSetter(RefCountedBase())
+// CHECK: writePtrViaSetter
+// CHECK: 42
+
+passStructWithSmartPtrField()
+// CHECK: passStructWithSmartPtrField

--- a/test/Interop/Cxx/foreign-reference/refcounted-smartpointers.swift
+++ b/test/Interop/Cxx/foreign-reference/refcounted-smartpointers.swift
@@ -39,6 +39,39 @@ func notBridgedFunctions(_ r: RefCountedBase) {
     notBridgedFunction3(consuming: RefOfBase(r))
 }
 
+func bridgedFunctionsWithRefAndPtrCtor(_ r: RefCountedBase) {
+    print("withRefCtor")
+    bridgedFunctionR(r)
+    let returned = bridgedFunctionR_returns()
+    print(returned.method())
+}
+
+// A smart pointer with both a T* and a const T* ctor. The non-const
+// pointer ctor must be the one selected for implicit bridging.
+func bridgedFunctionsWithConstPtrCtor(_ r: RefCountedBase) {
+    print("withConstPtrCtor")
+    bridgedFunctionConstPtr(r)
+    let returned = bridgedFunctionConstPtr_returns()
+    print(returned.method())
+}
+
+func bridgedFunctionsRefOnly(_ r: RefCountedBase) {
+    print("refOnly")
+    bridgedFunctionRefOnly(r)
+    let returned = bridgedFunctionRefOnly_returns()
+    print(returned.method())
+}
+
+// An unannotated derived smart pointer (no SWIFT_REFCOUNTED_PTR of its
+// own) inheriting from the annotated Ref<T>. No implicit bridging but
+// the inherited `asReference` property still works.
+func unannotatedDerived() {
+    print("unannotatedDerived")
+    let smartPtr = makeUnannotatedRef()
+    let frt = smartPtr.asReference
+    print(frt.method())
+}
+
 conversions(RefCountedBase())
 // CHECK: created
 // CHECK: conversions
@@ -61,3 +94,34 @@ notBridgedFunctions(RefCountedBase())
 // CHECK: created
 // CHECK: noBridging
 // CHECK: destroyed
+
+bridgedFunctionsWithRefAndPtrCtor(RefCountedBase())
+// CHECK: created
+// CHECK: withRefCtor
+// The pointer ctor must be the one selected for implicit bridging,
+// even though a T& ctor is also available on RefR<T>.
+// CHECK-NOT: RefR ref ctor
+// CHECK: RefR ptr ctor
+// CHECK-NOT: RefR ref ctor
+// CHECK: RefR ptr ctor
+// CHECK-NOT: RefR ref ctor
+// CHECK: 42
+
+bridgedFunctionsWithConstPtrCtor(RefCountedBase())
+// CHECK: withConstPtrCtor
+// The non-const T* ctor must be the one selected, never the const T* ctor.
+// CHECK-NOT: RefConstPtr const-ptr ctor
+// CHECK: RefConstPtr ptr ctor
+// CHECK-NOT: RefConstPtr const-ptr ctor
+// CHECK: RefConstPtr ptr ctor
+// CHECK-NOT: RefConstPtr const-ptr ctor
+// CHECK: 42
+
+bridgedFunctionsRefOnly(RefCountedBase())
+// CHECK: refOnly
+// CHECK: RefRefOnly ref ctor
+// CHECK: 42
+
+unannotatedDerived()
+// CHECK: unannotatedDerived
+// CHECK: 42


### PR DESCRIPTION
If a smart pointer type had both T& and T* taking constructors, we had no way to figure out which one to pick for bridging and failed to import the type. This PR makes sure we handle those scenarios and also support references in the bridging operations. Moreover, it also handles overloading based on const-ness of the ptrs/references. And makes sure we do not create bridging operations (for now) from rvalue references.

The PR also fixes an assertion failure for types derived from SWIFT_REFCOUNTED_PTR annotated types.

The PR also extends the test cases with more tests for fields.

rdar://177334824
