### PR TITLE
[cxx-interop] Add target-run-simple-swift-split-file

### DIFF
--- a/docs/Testing.md
+++ b/docs/Testing.md
@@ -284,6 +284,15 @@ code for the target that is not the build machine:
 
   Add ``REQUIRES: executable_test`` to the test.
 
+* ``%target-run-simple-swift-split-file(`` *source-file* [*compiler arguments*] ``)``:
+  like ``%target-run-simple-swift()``, but for tests whose
+  source lives in ``%s`` as ``split-file``.
+
+  Runs ``split-file %s %t`` before building. The *source-file* is the bare filename 
+  produced by ``split-file`` (no ``%t/`` prefix).
+ 
+  Add ``REQUIRES: executable_test`` to the test.
+
 * ``%target-run-simple-swiftgyb``: build a one-file Swift `.gyb` program and
   run it on the target machine.
 

--- a/test/Interop/Cxx/class/access/non-public-inheritance-executable.swift
+++ b/test/Interop/Cxx/class/access/non-public-inheritance-executable.swift
@@ -1,10 +1,7 @@
 //--- blessed.swift
 // Test that all accessible inherited methods can be called.
 //
-// RUN: split-file %s %t
-// RUN: %target-build-swift -module-name main %t/blessed.swift -I %S/Inputs -o %t/out -Xfrontend -cxx-interoperability-mode=default
-// RUN: %target-codesign %t/out
-// RUN: %target-run %t/out
+// RUN: %target-run-simple-swift-split-file(blessed.swift -I %S/Inputs -Xfrontend -cxx-interoperability-mode=default)
 //
 // REQUIRES: executable_test
 

--- a/test/Interop/Cxx/class/access/non-public-nested-enum-executable.swift
+++ b/test/Interop/Cxx/class/access/non-public-nested-enum-executable.swift
@@ -1,20 +1,7 @@
-// RUN: split-file %s %t
-
-// RUN: %target-build-swift -module-name main %t/base.swift -I %t/Inputs -o %t/base -Xfrontend -cxx-interoperability-mode=default -enable-experimental-feature ImportNonPublicCxxMembers
-// RUN: %target-codesign %t/base
-// RUN: %target-run %t/base
-
-// RUN: %target-build-swift -module-name main %t/not-base.swift -I %t/Inputs -o %t/not-base -Xfrontend -cxx-interoperability-mode=default -enable-experimental-feature ImportNonPublicCxxMembers
-// RUN: %target-codesign %t/not-base
-// RUN: %target-run %t/not-base
-
-// RUN: %target-build-swift -module-name main %t/derived.swift -I %t/Inputs -o %t/derived -Xfrontend -cxx-interoperability-mode=default -enable-experimental-feature ImportNonPublicCxxMembers
-// RUN: %target-codesign %t/derived
-// RUN: %target-run %t/derived
-
-// RUN: %target-build-swift -module-name main %t/not-derived.swift -I %t/Inputs -o %t/not-derived -Xfrontend -cxx-interoperability-mode=default -enable-experimental-feature ImportNonPublicCxxMembers
-// RUN: %target-codesign %t/not-derived
-// RUN: %target-run %t/not-derived
+// RUN: %target-run-simple-swift-split-file(base.swift -I %t/Inputs -Xfrontend -cxx-interoperability-mode=default -enable-experimental-feature ImportNonPublicCxxMembers)
+// RUN: %target-run-simple-swift-split-file(not-base.swift -I %t/Inputs -Xfrontend -cxx-interoperability-mode=default -enable-experimental-feature ImportNonPublicCxxMembers)
+// RUN: %target-run-simple-swift-split-file(derived.swift -I %t/Inputs -Xfrontend -cxx-interoperability-mode=default -enable-experimental-feature ImportNonPublicCxxMembers)
+// RUN: %target-run-simple-swift-split-file(not-derived.swift -I %t/Inputs -Xfrontend -cxx-interoperability-mode=default -enable-experimental-feature ImportNonPublicCxxMembers)
 
 // REQUIRES: executable_test
 // REQUIRES: swift_feature_ImportNonPublicCxxMembers

--- a/test/Interop/Cxx/class/noncopyable.swift
+++ b/test/Interop/Cxx/class/noncopyable.swift
@@ -1,8 +1,4 @@
-// RUN: %empty-directory(%t)
-// RUN: split-file %s %t
-// RUN: %target-build-swift %t%{fs-sep}test.swift -I %t%{fs-sep}Inputs -o %t%{fs-sep}out -cxx-interoperability-mode=default
-// RUN: %target-codesign %t%{fs-sep}out
-// RUN: %target-run %t%{fs-sep}out
+// RUN: %target-run-simple-swift-split-file(test.swift -I %t%{fs-sep}Inputs -cxx-interoperability-mode=default)
 //
 // REQUIRES: executable_test
 

--- a/test/Interop/Cxx/class/safe-use-of-returned-reference-with-borrowing.swift
+++ b/test/Interop/Cxx/class/safe-use-of-returned-reference-with-borrowing.swift
@@ -1,8 +1,4 @@
-// RUN: rm -rf %t
-// RUN: split-file %s %t
-// RUN: %target-build-swift %t/test.swift -I %t/Inputs -o %t/out -Xfrontend -enable-experimental-cxx-interop -O
-// RUN: %target-codesign %t/out
-// RUN: %target-run %t/out
+// RUN: %target-run-simple-swift-split-file(test.swift -I %t/Inputs -Xfrontend -enable-experimental-cxx-interop -O)
 
 // Verify that a non-const ref value parameter can't implicitly receive
 // aborrowed value.

--- a/test/Interop/Cxx/stdlib/use-std-vector-of-string-cross-module.swift
+++ b/test/Interop/Cxx/stdlib/use-std-vector-of-string-cross-module.swift
@@ -1,8 +1,4 @@
-// RUN: %empty-directory(%t)
-// RUN: split-file %s %t
-// RUN: %target-build-swift %t/test.swift -I %t/Inputs -o %t/out -cxx-interoperability-mode=swift-6
-// RUN: %target-codesign %t/out
-// RUN: %target-run %t/out
+// RUN: %target-run-simple-swift-split-file(test.swift -I %t/Inputs -cxx-interoperability-mode=swift-6)
 
 // REQUIRES: executable_test
 

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1304,12 +1304,15 @@ else:
 swift_reflection_test_name = 'swift-reflection-test' + variant_suffix
 
 def use_interpreter_for_simple_runs():
-    def make_simple_target_run(gyb=False, stdlib=False, parameterized=False):
+    def make_simple_target_run(gyb=False, stdlib=False, parameterized=False, split_file=False):
         result = ''
         if gyb:
             result += ('%empty-directory(%t) && '
                        '%gyb %s -o %t/main.swift && '
                        '%line-directive %t/main.swift -- ')
+        elif split_file:
+            result += ('%empty-directory(%t) && '
+                        'split-file %s %t && ')
         # FIXME: SWIFT_INTERPRETER needs to be a set of arguments, not just a
         # path.
         result += (
@@ -1326,11 +1329,13 @@ def use_interpreter_for_simple_runs():
         )
         if stdlib:
             result += '-Xfrontend -disable-access-control '
-        if parameterized:
+        if parameterized and split_file:
+            result += r' %t%{fs-sep}\1 '
+        elif parameterized:
             result += r' \1 '
         if gyb:
             result += '%t/main.swift'
-        else:
+        elif not split_file:
             result += '%s'
         return SubstituteCaptures(result)
 
@@ -1341,6 +1346,7 @@ def use_interpreter_for_simple_runs():
     config.target_run_simple_swift_parameterized = make_simple_target_run(parameterized=True)
     config.target_run_stdlib_swift_parameterized = make_simple_target_run(stdlib=True, parameterized=True)
     config.target_run_simple_swiftgyb_parameterized = make_simple_target_run(gyb=True, parameterized=True)
+    config.target_run_simple_swift_split_file = make_simple_target_run(split_file=True, parameterized=True)
     config.available_features.add('interpret')
 
 target_specific_module_triple = config.variant_module_triple
@@ -2868,6 +2874,17 @@ if not getattr(config, 'target_run_simple_swift', None):
            escape_for_substitute_captures(config.target_codesign),
            escape_for_substitute_captures(config.target_run))
     )
+    config.target_run_simple_swift_split_file = SubstituteCaptures(
+        r"%%empty-directory(%%t) && "
+        r"split-file %%s %%t && "
+        r"%s %s %%t%%{fs-sep}\1 -o %%t%%{fs-sep}a.out -module-name main  && "
+        r"%s %%t%%{fs-sep}a.out && "
+        r"%s %%t%%{fs-sep}a.out"
+        % (escape_for_substitute_captures(config.target_build_swift),
+           escape_for_substitute_captures(mcp_opt),
+           escape_for_substitute_captures(config.target_codesign),
+           escape_for_substitute_captures(config.target_run))
+    )
 
     config.target_run_simple_swift = (
         '%%empty-directory(%%t) && '
@@ -3018,6 +3035,8 @@ config.substitutions.append((r'%target-fail-simple-swift\(([^)]+)\)',
                             config.target_fail_simple_swift_parameterized))
 config.substitutions.append((r'%target-run-stdlib-swift\(([^)]+)\)',
                             config.target_run_stdlib_swift_parameterized))
+config.substitutions.append((r'%target-run-simple-swift-split-file\(([^)]+)\)',
+                            config.target_run_simple_swift_split_file))
 
 config.substitutions.append(('%target-run-simple-swift', config.target_run_simple_swift))
 config.substitutions.append(('%target-run-stdlib-swiftgyb', config.target_run_stdlib_swiftgyb))


### PR DESCRIPTION
Adds a new lit target `%target-run-simple-swift-split-file`, useful for C++ interop tests that have the Swift source and the C++ header in the same file. It collapses this recurring pattern

```
// RUN: %empty-directory(%t)
// RUN: split-file %s %t
// RUN: %target-build-swift %t/test.swift (...)
// RUN: %target-codesign %t/a.out
// RUN: %target-run %t/a.out
```

into one line:

```
// RUN: %target-run-simple-swift-split-file(test.swift (...))
```