### PR TITLE
[stdlib] Enable Span<~Escapable>

### DIFF
--- a/Runtimes/Core/cmake/modules/ExperimentalFeatures.cmake
+++ b/Runtimes/Core/cmake/modules/ExperimentalFeatures.cmake
@@ -13,4 +13,5 @@ add_compile_options(
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature AllowUnsafeAttribute>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature ValueGenerics>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature Lifetimes>"
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature PreInverseGenericsExcept>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature Reparenting>")

--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -353,6 +353,7 @@ list(APPEND swift_stdlib_compile_flags "-enable-experimental-feature" "Reparenti
 list(APPEND swift_stdlib_compile_flags "-enable-experimental-feature" "Lifetimes")
 list(APPEND swift_stdlib_compile_flags "-enable-experimental-feature" "BorrowAndMutateAccessors")
 list(APPEND swift_stdlib_compile_flags "-enable-experimental-feature" "BorrowInout")
+list(APPEND swift_stdlib_compile_flags "-enable-experimental-feature" "PreInverseGenericsExcept")
 list(APPEND swift_stdlib_compile_flags "-strict-memory-safety")
 
 if("${SWIFT_NATIVE_SWIFT_TOOLS_PATH}" STREQUAL "")

--- a/stdlib/public/core/Span/RawSpan.swift
+++ b/stdlib/public/core/Span/RawSpan.swift
@@ -325,6 +325,26 @@ extension RawSpan {
     unsafe self = Self.init(unsafeElements: span)
   }
 
+#if hasFeature(PreInverseGenericsExcept)
+  /// Unsafely view a typed span as a raw span.
+  ///
+  /// Creates a `RawSpan` over the memory represented by a `Span<Element>`
+  ///
+  /// - Parameters:
+  ///   - unsafeElements: An existing `Span<Element>`, from which this
+  ///     `RawSpan` will inherit its lifetime.
+  @_alwaysEmitIntoClient
+  @unsafe
+  @_lifetime(copy span)
+  public init<Element: ~Escapable>(unsafeElements span: Span<Element>) {
+    let rawSpan = unsafe RawSpan(
+      _unchecked: unsafe span._pointer,
+      byteCount: span.count == 1 ? MemoryLayout<Element>.size
+                 : span.count &* MemoryLayout<Element>.stride
+    )
+    self = unsafe _overrideLifetime(rawSpan, copying: span)
+  }
+#else
   /// Unsafely view a typed span as a raw span.
   ///
   /// Creates a `RawSpan` over the memory represented by a `Span<Element>`
@@ -343,6 +363,7 @@ extension RawSpan {
     )
     self = unsafe _overrideLifetime(rawSpan, copying: span)
   }
+#endif
 
   /// View a typed span as a raw span.
   ///

--- a/stdlib/public/core/Span/RawSpan.swift
+++ b/stdlib/public/core/Span/RawSpan.swift
@@ -345,6 +345,8 @@ extension RawSpan {
     self = unsafe _overrideLifetime(rawSpan, copying: span)
   }
 #else
+  // TODO: Remove these duplicated symbols for `RawSpan` rdar://177362237
+
   /// Unsafely view a typed span as a raw span.
   ///
   /// Creates a `RawSpan` over the memory represented by a `Span<Element>`

--- a/stdlib/public/core/Span/Span.swift
+++ b/stdlib/public/core/Span/Span.swift
@@ -14,6 +14,9 @@
 import Swift
 #endif
 
+#if hasFeature(PreInverseGenericsExcept)
+// MARK: Span<~Escapable>
+
 /// `Span<Element>` represents a contiguous region of memory
 /// which contains initialized instances of `Element`.
 ///
@@ -34,6 +37,7 @@ public struct Span<Element: ~Copyable & ~Escapable>: ~Escapable, Copyable, Bitwi
   /// but no accesses may be performed through it. Otherwise, `_pointer` must point
   /// to initialized memory containing `_count` instances of `Element`, which must
   /// remain valid and not be mutated during the lifetime of this `Span`.
+  @_preInverseGenerics(except: ~Copyable)
   @usableFromInline
   internal let _pointer: UnsafeRawPointer?
 
@@ -48,6 +52,7 @@ public struct Span<Element: ~Copyable & ~Escapable>: ~Escapable, Copyable, Bitwi
   /// If `_count` equals 0, then `_pointer` may be either `nil` or valid.
   /// Any `_count` greater than 0 indicates a valid non-nil `_pointer`.
   /// Any `_count` less than 0 is invalid and is undefined behaviour.
+  @_preInverseGenerics(except: ~Copyable)
   @usableFromInline
   internal let _count: Int
 
@@ -89,6 +94,7 @@ public struct Span<Element: ~Copyable & ~Escapable>: ~Escapable, Copyable, Bitwi
 @available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension Span: @unchecked Sendable where Element: Sendable & ~Copyable & ~Escapable {}
+#endif // hasFeature(PreInverseGenericsExcept)
 
 @available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
@@ -215,6 +221,7 @@ extension Span /*where Element: Copyable*/ {
   }
 }
 
+#if hasFeature(PreInverseGenericsExcept)
 @available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension Span where Element: BitwiseCopyable & ~Escapable {
@@ -548,6 +555,7 @@ extension Span where Element: Copyable & ~Escapable {
     }
   }
 }
+#endif // hasFeature(PreInverseGenericsExcept)
 
 @available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
@@ -566,6 +574,7 @@ extension Span where Element: ConvertibleToBytes {
   }
 }
 
+#if hasFeature(PreInverseGenericsExcept)
 // MARK: sub-spans
 @available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
@@ -722,6 +731,7 @@ extension Span where Element: ~Copyable & ~Escapable {
     self
   }
 }
+#endif // hasFeature(PreInverseGenericsExcept)
 
 // MARK: UnsafeBufferPointer access hatch
 @available(SwiftCompatibilitySpan 5.0, *)
@@ -756,6 +766,7 @@ extension Span where Element: ~Copyable {
   }
 }
 
+#if hasFeature(PreInverseGenericsExcept)
 @available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension Span where Element: BitwiseCopyable & ~Escapable {
@@ -983,6 +994,803 @@ extension Span where Element: ~Copyable & ~Escapable {
     extracting(droppingFirst: k)
   }
 }
+
+#else  // hasFeature(PreInverseGenericsExcept)
+// MARK: Span<Non-escapable>
+
+/// `Span<Element>` represents a contiguous region of memory
+/// which contains initialized instances of `Element`.
+///
+/// A `Span` instance is a non-owning, non-escaping view into memory.
+/// When a `Span` is created, it inherits the lifetime of the container
+/// owning the contiguous memory, ensuring temporal safety and avoiding
+/// use-after-free errors. Operations on `Span` are bounds-checked,
+/// ensuring spatial safety and avoiding buffer overflow errors.
+@frozen
+@safe
+@available(SwiftCompatibilitySpan 5.0, *)
+@_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
+public struct Span<Element: ~Copyable>: ~Escapable, Copyable, BitwiseCopyable {
+
+  /// The starting address of this `Span`.
+  ///
+  /// If `_count` is zero, `_pointer` may point to valid memory or it may be `nil`,
+  /// but no accesses may be performed through it. Otherwise, `_pointer` must point
+  /// to initialized memory containing `_count` instances of `Element`, which must
+  /// remain valid and not be mutated during the lifetime of this `Span`.
+  @usableFromInline
+  internal let _pointer: UnsafeRawPointer?
+
+  @unsafe
+  @_alwaysEmitIntoClient
+  internal func _start() -> UnsafeRawPointer {
+    unsafe _pointer._unsafelyUnwrappedUnchecked
+  }
+
+  /// The number of elements in this `Span`.
+  ///
+  /// If `_count` equals 0, then `_pointer` may be either `nil` or valid.
+  /// Any `_count` greater than 0 indicates a valid non-nil `_pointer`.
+  /// Any `_count` less than 0 is invalid and is undefined behaviour.
+  @usableFromInline
+  internal let _count: Int
+
+  /// Create an empty span.
+  @_alwaysEmitIntoClient
+  @inline(__always)
+  @lifetime(immortal)
+  public init() {
+    unsafe _pointer = nil
+    _count = 0
+  }
+
+  /// Unsafely create a `Span` over initialized memory.
+  ///
+  /// `pointer` must point to a region of `count` initialized instances,
+  /// or may be `nil` if `count` is 0.
+  ///
+  /// The region of memory representing `count` instances starting at `pointer`
+  /// must remain valid, initialized and immutable
+  /// throughout the lifetime of the newly-created `Span`.
+  /// Failure to maintain this invariant results in undefined behaviour.
+  ///
+  /// - Parameters:
+  ///   - pointer: a pointer to the first initialized element.
+  ///   - count: the number of initialized elements in the span.
+  @unsafe
+  @_alwaysEmitIntoClient
+  @inline(__always)
+  @lifetime(borrow pointer)
+  internal init(
+    _unchecked pointer: UnsafeRawPointer?,
+    count: Int
+  ) {
+    unsafe _pointer = pointer
+    _count = count
+  }
+}
+
+@available(SwiftCompatibilitySpan 5.0, *)
+@_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
+extension Span: @unchecked Sendable where Element: Sendable & ~Copyable {}
+
+
+@available(SwiftCompatibilitySpan 5.0, *)
+@_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
+extension Span where Element: BitwiseCopyable {
+
+  /// Unsafely create a `Span` over initialized memory.
+  ///
+  /// The memory in `buffer` must remain valid, initialized and immutable
+  /// throughout the lifetime of the newly-created `Span`.
+  /// Failure to maintain this invariant results in undefined behaviour.
+  ///
+  /// `buffer` must be correctly aligned for accessing
+  /// an element of type `Element`, and must contain a number of bytes
+  /// that is an exact multiple of `Element`'s stride.
+  ///
+  /// - Parameters:
+  ///   - buffer: a buffer to initialized elements.
+  @_alwaysEmitIntoClient
+  @lifetime(borrow buffer)
+  @unsafe
+  public init(
+    _unsafeBytes buffer: UnsafeRawBufferPointer
+  ) {
+    //FIXME: Workaround for https://github.com/swiftlang/swift/issues/77235
+    let baseAddress = buffer.baseAddress
+    _precondition(
+      ((Int(bitPattern: baseAddress) &
+        (MemoryLayout<Element>.alignment &- 1)) == 0),
+      "baseAddress must be properly aligned to access Element"
+    )
+    let (byteCount, stride) = (buffer.count, MemoryLayout<Element>.stride)
+    let (count, remainder) = byteCount.quotientAndRemainder(dividingBy: stride)
+    _precondition(
+      remainder == 0, "Span must contain a whole number of elements"
+    )
+    let span = unsafe Span(_unchecked: baseAddress, count: count)
+    // As a trivial value, 'baseAddress' does not formally depend on the
+    // lifetime of 'buffer'. Make the dependence explicit.
+    self = unsafe _overrideLifetime(span, borrowing: buffer)
+  }
+
+  /// Unsafely create a `Span` over initialized memory.
+  ///
+  /// The memory in `buffer` must remain valid, initialized and immutable
+  /// throughout the lifetime of the newly-created `Span`.
+  /// Failure to maintain this invariant results in undefined behaviour.
+  ///
+  /// `buffer` must be correctly aligned for accessing
+  /// an element of type `Element`, and must contain a number of bytes
+  /// that is an exact multiple of `Element`'s stride.
+  ///
+  /// - Parameters:
+  ///   - buffer: a buffer to initialized elements.
+  @_alwaysEmitIntoClient
+  @lifetime(borrow buffer)
+  @unsafe
+  public init(
+    _unsafeBytes buffer: UnsafeMutableRawBufferPointer
+  ) {
+    let rawBuffer = UnsafeRawBufferPointer(buffer)
+    let span = unsafe Span(_unsafeBytes: rawBuffer)
+    // As a trivial value, 'buf' does not formally depend on the
+    // lifetime of 'buffer'. Make the dependence explicit.
+    self = unsafe _overrideLifetime(span, borrowing: buffer)
+  }
+
+  /// Unsafely create a `Span` over initialized memory.
+  ///
+  /// The region of memory representing the instances starting at `pointer`
+  /// must remain valid, initialized and immutable
+  /// throughout the lifetime of the newly-created `Span`.
+  /// Failure to maintain this invariant results in undefined behaviour.
+  ///
+  /// `pointer` must be correctly aligned for accessing
+  /// an element of type `Element`, and `byteCount`
+  /// must be an exact multiple of `Element`'s stride.
+  ///
+  /// - Parameters:
+  ///   - pointer: a pointer to the first initialized element.
+  ///   - byteCount: the number of bytes in the span.
+  @_alwaysEmitIntoClient
+  @lifetime(borrow pointer)
+  @unsafe
+  public init(
+    _unsafeStart pointer: UnsafeRawPointer,
+    byteCount: Int
+  ) {
+    _precondition(byteCount >= 0, "Count must not be negative")
+    let rawBuffer = unsafe UnsafeRawBufferPointer(
+      start: pointer, count: byteCount
+    )
+    let span = unsafe Span(_unsafeBytes: rawBuffer)
+    // As a trivial value, 'rawBuffer' does not formally depend on the
+    // lifetime of 'pointer'. Make the dependence explicit.
+    self = unsafe _overrideLifetime(span, borrowing: pointer)
+  }
+
+  /// Unsafely create a `Span` over initialized memory.
+  ///
+  /// The memory in `buffer` must remain valid, initialized and immutable
+  /// throughout the lifetime of the newly-created `Span`.
+  /// Failure to maintain this invariant results in undefined behaviour.
+  ///
+  /// `buffer` must be correctly aligned for accessing
+  /// an element of type `Element`, and must contain a number of bytes
+  /// that is an exact multiple of `Element`'s stride.
+  ///
+  /// - Parameters:
+  ///   - buffer: a buffer to initialized elements.
+  @_alwaysEmitIntoClient
+  @lifetime(borrow buffer)
+  @unsafe
+  public init(
+    _unsafeBytes buffer: borrowing Slice<UnsafeRawBufferPointer>
+  ) {
+    let rawBuffer = unsafe UnsafeRawBufferPointer(rebasing: buffer)
+    let span = unsafe Span(_unsafeBytes: rawBuffer)
+    // As a trivial value, 'rawBuffer' does not formally depend on the
+    // lifetime of 'buffer'. Make the dependence explicit.
+    self = unsafe _overrideLifetime(span, borrowing: buffer)
+  }
+
+  /// Unsafely create a `Span` over initialized memory.
+  ///
+  /// The memory in `buffer` must remain valid, initialized and immutable
+  /// throughout the lifetime of the newly-created `Span`.
+  /// Failure to maintain this invariant results in undefined behaviour.
+  ///
+  /// `buffer` must be correctly aligned for accessing
+  /// an element of type `Element`, and must contain a number of bytes
+  /// that is an exact multiple of `Element`'s stride.
+  ///
+  /// - Parameters:
+  ///   - buffer: a buffer to initialized elements.
+  @_alwaysEmitIntoClient
+  @lifetime(borrow buffer)
+  @unsafe
+  public init(
+    _unsafeBytes buffer: borrowing Slice<UnsafeMutableRawBufferPointer>
+  ) {
+    let rawBuffer = unsafe UnsafeRawBufferPointer(rebasing: buffer)
+    let span = unsafe Span(_unsafeBytes: rawBuffer)
+    // As a trivial value, 'rawBuffer' does not formally depend on the
+    // lifetime of 'buffer'. Make the dependence explicit.
+    self = unsafe _overrideLifetime(span, borrowing: buffer)
+  }
+
+  /// Create a `Span` over the bytes represented by a `RawSpan`.
+  ///
+  /// - Parameters:
+  ///   - bytes: An existing `RawSpan`, which will define both this
+  ///            `Span`'s lifetime and the memory it represents.
+  @_alwaysEmitIntoClient
+  @unsafe
+  @lifetime(copy bytes)
+  public init(_bytes bytes: consuming RawSpan) {
+    let rawBuffer = unsafe UnsafeRawBufferPointer(
+      start: bytes._pointer, count: bytes.byteCount
+    )
+    let span = unsafe Span(_unsafeBytes: rawBuffer)
+    // As a trivial value, 'rawBuffer' does not formally depend on the
+    // lifetime of 'bytes'. Make the dependence explicit.
+    self = unsafe _overrideLifetime(span, copying: bytes)
+  }
+
+  /// View initialized raw memory as a typed span.
+  ///
+  /// The `byteCount` of `bytes` must be a multiple of `Element`'s stride,
+  /// and the starting address of `bytes` must be well-aligned for the type
+  /// of `Element`. If either of these requirements is not met, this initializer
+  /// will trap at runtime.
+  ///
+  /// - Parameters:
+  ///   - bytes: An existing `RawSpan`, which will define both this
+  ///            `Span`'s lifetime and the memory it represents.
+  @_alwaysEmitIntoClient
+  @_lifetime(copy bytes)
+  public init(viewing bytes: RawSpan) where Element: ConvertibleFromBytes {
+    let rawBuffer = unsafe UnsafeRawBufferPointer(
+      start: bytes._pointer, count: bytes.byteCount
+    )
+    let span = unsafe Span(_unsafeBytes: rawBuffer)
+    self = unsafe _overrideLifetime(span, copying: bytes)
+  }
+}
+
+@available(SwiftCompatibilitySpan 5.0, *)
+@_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
+extension Span where Element: ~Copyable {
+
+  /// The number of elements in the span.
+  ///
+  /// To check whether the span is empty, use its `isEmpty` property
+  /// instead of comparing `count` to zero.
+  ///
+  /// - Complexity: O(1)
+  @_alwaysEmitIntoClient
+  @_semantics("fixed_storage.get_count")
+  public var count: Int { _assumeNonNegative(_count) }
+
+  /// A Boolean value indicating whether the span is empty.
+  ///
+  /// - Complexity: O(1)
+  @_alwaysEmitIntoClient
+  @_transparent
+  public var isEmpty: Bool { _count == 0 }
+
+  /// The representation for an index in `Span`.
+  public typealias Index = Int
+
+  /// The indices that are valid for subscripting the span, in ascending
+  /// order.
+  ///
+  /// - Complexity: O(1)
+  @_alwaysEmitIntoClient
+  public var indices: Range<Index> {
+    unsafe Range(_uncheckedBounds: (0, count))
+  }
+}
+
+@available(SwiftCompatibilitySpan 5.0, *)
+@_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
+extension Span where Element: ~Copyable {
+  // SILOptimizer looks for fixed_storage.check_index semantics for bounds check optimizations.
+  @_semantics("fixed_storage.check_index")
+  @inline(__always)
+  @_alwaysEmitIntoClient
+  internal func _checkIndex(_ position: Index) {
+    _precondition(indices.contains(position), "Index out of bounds")
+  }
+
+  /// Accesses the element at the specified index in the `Span`.
+  ///
+  /// - Parameter position: The offset of the element to access. `position`
+  ///     must be greater or equal to zero, and less than `count`.
+  ///
+  /// - Complexity: O(1)
+  @_alwaysEmitIntoClient
+  public subscript(_ position: Index) -> Element {
+    //FIXME: change to unsafeRawAddress when ready
+    unsafeAddress {
+      _checkIndex(position)
+      return unsafe _unsafeAddressOfElement(unchecked: position)
+    }
+  }
+
+  /// Accesses the element at the specified index in the `Span`.
+  ///
+  /// This subscript does not validate `position`. Using this subscript
+  /// with an invalid `position` results in undefined behaviour.
+  ///
+  /// - Parameter position: The offset of the element to access. `position`
+  ///     must be greater or equal to zero, and less than `count`.
+  ///
+  /// - Complexity: O(1)
+  @unsafe
+  @_alwaysEmitIntoClient
+  public subscript(unchecked position: Index) -> Element {
+    //FIXME: change to unsafeRawAddress when ready
+    unsafeAddress {
+      unsafe _unsafeAddressOfElement(unchecked: position)
+    }
+  }
+
+  @unsafe
+  @_alwaysEmitIntoClient
+  internal func _unsafeAddressOfElement(
+    unchecked position: Index
+  ) -> UnsafePointer<Element> {
+    let elementOffset = position &* MemoryLayout<Element>.stride
+    let address = unsafe _start().advanced(by: elementOffset)
+    return unsafe address.assumingMemoryBound(to: Element.self)
+  }
+}
+
+@available(SwiftCompatibilitySpan 5.0, *)
+@_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
+extension Span where Element: BitwiseCopyable {
+  /// Accesses the element at the specified index in the `Span`.
+  ///
+  /// - Parameter position: The offset of the element to access. `position`
+  ///     must be greater or equal to zero, and less than `count`.
+  ///
+  /// - Complexity: O(1)
+  @_alwaysEmitIntoClient
+  public subscript(_ position: Index) -> Element {
+    get {
+      _checkIndex(position)
+      return unsafe self[unchecked: position]
+    }
+  }
+
+  /// Accesses the element at the specified index in the `Span`.
+  ///
+  /// This subscript does not validate `position`. Using this subscript
+  /// with an invalid `position` results in undefined behaviour.
+  ///
+  /// - Parameter position: The offset of the element to access. `position`
+  ///     must be greater or equal to zero, and less than `count`.
+  ///
+  /// - Complexity: O(1)
+  @unsafe
+  @_alwaysEmitIntoClient
+  public subscript(unchecked position: Index) -> Element {
+    get {
+      let elementOffset = position &* MemoryLayout<Element>.stride
+      let address = unsafe _start().advanced(by: elementOffset)
+      return unsafe address.loadUnaligned(as: Element.self)
+    }
+  }
+}
+
+@available(SwiftCompatibilitySpan 5.0, *)
+@_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
+extension Span where Element: Copyable {
+
+  /// Construct a raw span over the memory represented by this span.
+  ///
+  /// - Returns: A `RawSpan` over the memory represented by this span.
+  @_alwaysEmitIntoClient
+  @_transparent
+  @unsafe
+  public var bytes: RawSpan {
+    @_lifetime(copy self)
+    get {
+      let rawSpan = unsafe RawSpan(unsafeElements: self)
+      return unsafe _overrideLifetime(rawSpan, copying: self)
+    }
+  }
+}
+
+// MARK: sub-spans
+@available(SwiftCompatibilitySpan 5.0, *)
+@_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
+extension Span where Element: ~Copyable {
+
+  /// Constructs a new span over the items within the supplied range of
+  /// indices within this span.
+  ///
+  /// The returned span's first item is always at offset 0; unlike buffer
+  /// slices, extracted spans do not share their indices with the
+  /// span from which they are extracted.
+  ///
+  /// - Parameter bounds: A valid range of indices. Every index in
+  ///     this range must be within the bounds of this `Span`.
+  ///
+  /// - Returns: A `Span` over the items within `bounds`.
+  ///
+  /// - Complexity: O(1)
+  @_alwaysEmitIntoClient
+  @lifetime(copy self)
+  public func extracting(_ bounds: Range<Index>) -> Self {
+    _precondition(
+      UInt(bitPattern: bounds.lowerBound) <= UInt(bitPattern: _count) &&
+      UInt(bitPattern: bounds.upperBound) <= UInt(bitPattern: _count),
+      "Index range out of bounds"
+    )
+    return unsafe extracting(unchecked: bounds)
+  }
+
+  @available(*, deprecated, renamed: "extracting(_:)")
+  @_alwaysEmitIntoClient
+  @lifetime(copy self)
+  public func _extracting(_ bounds: Range<Index>) -> Self {
+    extracting(bounds)
+  }
+
+  /// Constructs a new span over the items within the supplied range of
+  /// indices within this span.
+  ///
+  /// The returned span's first item is always at offset 0; unlike buffer
+  /// slices, extracted spans do not share their indices with the
+  /// span from which they are extracted.
+  ///
+  /// This function does not validate `bounds`; this is an unsafe operation.
+  ///
+  /// - Parameter bounds: A valid range of indices. Every index in
+  ///     this range must be within the bounds of this `Span`.
+  ///
+  /// - Returns: A `Span` over the items within `bounds`.
+  ///
+  /// - Complexity: O(1)
+  @unsafe
+  @_alwaysEmitIntoClient
+  @lifetime(copy self)
+  public func extracting(unchecked bounds: Range<Index>) -> Self {
+    let delta = bounds.lowerBound &* MemoryLayout<Element>.stride
+    let newStart = unsafe _pointer?.advanced(by: delta)
+    let newSpan = unsafe Span(_unchecked: newStart, count: bounds.count)
+    // As a trivial value, 'newStart' does not formally depend on the
+    // lifetime of 'self'. Make the dependence explicit.
+    return unsafe _overrideLifetime(newSpan, copying: self)
+  }
+
+  @unsafe
+  @available(*, deprecated, renamed: "extracting(unchecked:)")
+  @_alwaysEmitIntoClient
+  @lifetime(copy self)
+  public func _extracting(unchecked bounds: Range<Index>) -> Self {
+    unsafe extracting(unchecked: bounds)
+  }
+
+  /// Constructs a new span over the items within the supplied range of
+  /// indices within this span.
+  ///
+  /// The returned span's first item is always at offset 0; unlike buffer
+  /// slices, extracted spans do not share their indices with the
+  /// span from which they are extracted.
+  ///
+  /// - Parameter bounds: A valid range of indices. Every index in
+  ///     this range must be within the bounds of this `Span`.
+  ///
+  /// - Returns: A `Span` over the items within `bounds`.
+  ///
+  /// - Complexity: O(1)
+  @_alwaysEmitIntoClient
+  @lifetime(copy self)
+  public func extracting(
+    _ bounds: some RangeExpression<Index>
+  ) -> Self {
+    extracting(bounds.relative(to: indices))
+  }
+
+  @available(*, deprecated, renamed: "extracting(_:)")
+  @_alwaysEmitIntoClient
+  @lifetime(copy self)
+  public func _extracting(_ bounds: some RangeExpression<Index>) -> Self {
+    extracting(bounds)
+  }
+
+  /// Constructs a new span over the items within the supplied range of
+  /// indices within this span.
+  ///
+  /// The returned span's first item is always at offset 0; unlike buffer
+  /// slices, extracted spans do not share their indices with the
+  /// span from which they are extracted.
+  ///
+  /// This function does not validate `bounds`; this is an unsafe operation.
+  ///
+  /// - Parameter bounds: A valid range of indices. Every index in
+  ///     this range must be within the bounds of this `Span`.
+  ///
+  /// - Returns: A `Span` over the items within `bounds`.
+  ///
+  /// - Complexity: O(1)
+  @unsafe
+  @_alwaysEmitIntoClient
+  @lifetime(copy self)
+  public func extracting(
+    unchecked bounds: ClosedRange<Index>
+  ) -> Self {
+    let range = unsafe Range(
+      _uncheckedBounds: (bounds.lowerBound, bounds.upperBound + 1)
+    )
+    return unsafe extracting(unchecked: range)
+  }
+
+  @unsafe
+  @available(*, deprecated, renamed: "extracting(unchecked:)")
+  @_alwaysEmitIntoClient
+  @lifetime(copy self)
+  public func _extracting(unchecked bounds: ClosedRange<Index>) -> Self {
+    unsafe extracting(unchecked: bounds)
+  }
+
+  /// Constructs a new span over all the items of this span.
+  ///
+  /// The returned span's first item is always at offset 0; unlike buffer
+  /// slices, extracted spans do not share their indices with the
+  /// span from which they are extracted.
+  ///
+  /// - Returns: A `Span` over all the items of this span.
+  ///
+  /// - Complexity: O(1)
+  @_alwaysEmitIntoClient
+  @lifetime(copy self)
+  public func extracting(_: UnboundedRange) -> Self {
+    self
+  }
+
+  @available(*, deprecated, renamed: "extracting(_:)")
+  @_alwaysEmitIntoClient
+  @lifetime(copy self)
+  public func _extracting(_: UnboundedRange) -> Self {
+    self
+  }
+}
+
+@available(SwiftCompatibilitySpan 5.0, *)
+@_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
+extension Span where Element: BitwiseCopyable {
+
+  /// Calls the given closure with a pointer to the underlying bytes of
+  /// the viewed contiguous storage.
+  ///
+  /// The buffer pointer passed as an argument to `body` is valid only
+  /// during the execution of `withUnsafeBytes(_:)`.
+  /// Do not store or return the pointer for later use.
+  ///
+  /// - Parameter body: A closure with an `UnsafeRawBufferPointer`
+  ///   parameter that points to the viewed contiguous storage.
+  ///   If `body` has a return value, that value is also
+  ///   used as the return value for the `withUnsafeBytes(_:)` method.
+  ///   The closure's parameter is valid only for the duration of
+  ///   its execution.
+  /// - Returns: The return value of the `body` closure parameter.
+  @_alwaysEmitIntoClient
+  @_transparent
+  @safe
+  public func withUnsafeBytes<E: Error, Result: ~Copyable>(
+    _ body: (_ buffer: UnsafeRawBufferPointer) throws(E) -> Result
+  ) throws(E) -> Result {
+    let bytes = unsafe UnsafeRawBufferPointer(
+      start: _pointer, count: _count &* MemoryLayout<Element>.stride
+    )
+    return try unsafe body(bytes)
+  }
+}
+
+@available(SwiftCompatibilitySpan 5.0, *)
+@_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
+extension Span where Element: ~Copyable {
+  /// Returns a Boolean value indicating whether two instances refer to the same
+  /// memory region.
+  ///
+  /// Two spans are identical if they reference the same starting address
+  /// and have the same number of elements.
+  ///
+  /// - Parameter other: A span to compare with this one.
+  /// - Returns: Whether `self` and `other` reference the same region
+  ///     in memory.
+  ///
+  /// - Complexity: O(1)
+  @_alwaysEmitIntoClient
+  public func isIdentical(to other: Self) -> Bool {
+    unsafe (self._pointer == other._pointer) && (self._count == other._count)
+  }
+
+  /// Returns a Boolean value indicating whether two instances refer to the same
+  /// memory region.
+  ///
+  /// Two spans are identical if they reference the same starting address
+  /// and have the same number of elements.
+  ///
+  /// - Parameter other: A span to compare with this one.
+  /// - Returns: Whether `self` and `other` reference the same region
+  ///     in memory.
+  ///
+  /// - Complexity: O(1)
+  @_alwaysEmitIntoClient
+  public func isTriviallyIdentical(to other: Self) -> Bool {
+    unsafe (self._pointer == other._pointer) && (self._count == other._count)
+  }
+
+  /// Returns the indices within this span where the memory represented
+  /// by other is located, or nil if other is not located within this span.
+  ///
+  /// - Parameters:
+  ///   - other: a span that may be a subrange of `self`
+  /// - Returns: A range of indices within `self`, or `nil`.
+  @_alwaysEmitIntoClient
+  public func indices(of other: borrowing Self) -> Range<Index>? {
+    if other._count > _count { return nil }
+    guard let spanStart = unsafe other._pointer, _count > 0 else {
+      return unsafe _pointer == other._pointer ? 0..<0 : nil
+    }
+    let start = unsafe _start()
+    let stride = MemoryLayout<Element>.stride
+    let spanEnd = unsafe spanStart + stride &* other._count
+    if unsafe spanStart < start || spanEnd > (start + stride &* _count) {
+      return nil
+    }
+    let byteOffset = unsafe start.distance(to: spanStart)
+    let (lower, r) = byteOffset.quotientAndRemainder(dividingBy: stride)
+    guard r == 0 else { return nil }
+    return unsafe Range(_uncheckedBounds: (lower, lower &+ other._count))
+  }
+}
+
+// MARK: prefixes and suffixes
+@available(SwiftCompatibilitySpan 5.0, *)
+@_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
+extension Span where Element: ~Copyable {
+
+  /// Returns a span containing the initial elements of this span,
+  /// up to the specified maximum length.
+  ///
+  /// If the maximum length exceeds the length of this span,
+  /// the result contains all the elements.
+  ///
+  /// The returned span's first item is always at offset 0; unlike buffer
+  /// slices, extracted spans do not share their indices with the
+  /// span from which they are extracted.
+  ///
+  /// - Parameter maxLength: The maximum number of elements to return.
+  ///   `maxLength` must be greater than or equal to zero.
+  /// - Returns: A span with at most `maxLength` elements.
+  ///
+  /// - Complexity: O(1)
+  @_alwaysEmitIntoClient
+  @lifetime(copy self)
+  public func extracting(first maxLength: Int) -> Self {
+    _precondition(maxLength >= 0, "Can't have a prefix of negative length")
+    let newCount = min(maxLength, count)
+    let newSpan = unsafe Self(_unchecked: _pointer, count: newCount)
+    return unsafe _overrideLifetime(newSpan, copying: self)
+  }
+
+  @available(*, deprecated, renamed: "extracting(first:)")
+  @_alwaysEmitIntoClient
+  @lifetime(copy self)
+  public func _extracting(first maxLength: Int) -> Self {
+    extracting(first: maxLength)
+  }
+
+  /// Returns a span over all but the given number of trailing elements.
+  ///
+  /// If the number of elements to drop exceeds the number of elements in
+  /// the span, the result is an empty span.
+  ///
+  /// The returned span's first item is always at offset 0; unlike buffer
+  /// slices, extracted spans do not share their indices with the
+  /// span from which they are extracted.
+  ///
+  /// - Parameter k: The number of elements to drop off the end of
+  ///   the span. `k` must be greater than or equal to zero.
+  /// - Returns: A span leaving off the specified number of elements at the end.
+  ///
+  /// - Complexity: O(1)
+  @_alwaysEmitIntoClient
+  @lifetime(copy self)
+  public func extracting(droppingLast k: Int) -> Self {
+    _precondition(k >= 0, "Can't drop a negative number of elements")
+    let droppedCount = min(k, count)
+    let newSpan = unsafe Self(_unchecked: _pointer, count: count &- droppedCount)
+    return unsafe _overrideLifetime(newSpan, copying: self)
+  }
+
+  @available(*, deprecated, renamed: "extracting(droppingLast:)")
+  @_alwaysEmitIntoClient
+  @lifetime(copy self)
+  public func _extracting(droppingLast k: Int) -> Self {
+    extracting(droppingLast: k)
+  }
+
+  /// Returns a span containing the trailing elements of the span,
+  /// up to the given maximum length.
+  ///
+  /// If the maximum length exceeds the length of this span,
+  /// the result contains all the elements.
+  ///
+  /// The returned span's first item is always at offset 0; unlike buffer
+  /// slices, extracted spans do not share their indices with the
+  /// span from which they are extracted.
+  ///
+  /// - Parameter maxLength: The maximum number of elements to return.
+  ///   `maxLength` must be greater than or equal to zero.
+  /// - Returns: A span with at most `maxLength` elements.
+  ///
+  /// - Complexity: O(1)
+  @_alwaysEmitIntoClient
+  @lifetime(copy self)
+  public func extracting(last maxLength: Int) -> Self {
+    _precondition(maxLength >= 0, "Can't have a suffix of negative length")
+    let newCount = min(maxLength, count)
+    let offset = (count &- newCount) * MemoryLayout<Element>.stride
+    let newStart = unsafe _pointer?.advanced(by: offset)
+    let newSpan = unsafe Span(_unchecked: newStart, count: newCount)
+    // As a trivial value, 'newStart' does not formally depend on the
+    // lifetime of 'buffer'. Make the dependence explicit.
+    return unsafe _overrideLifetime(newSpan, copying: self)
+  }
+
+  @available(*, deprecated, renamed: "extracting(last:)")
+  @_alwaysEmitIntoClient
+  @lifetime(copy self)
+  public func _extracting(last maxLength: Int) -> Self {
+    extracting(last: maxLength)
+  }
+
+  /// Returns a span over all but the given number of initial elements.
+  ///
+  /// If the number of elements to drop exceeds the number of elements in
+  /// the span, the result is an empty span.
+  ///
+  /// The returned span's first item is always at offset 0; unlike buffer
+  /// slices, extracted spans do not share their indices with the
+  /// span from which they are extracted.
+  ///
+  /// - Parameter k: The number of elements to drop from the beginning of
+  ///   the span. `k` must be greater than or equal to zero.
+  /// - Returns: A span starting after the specified number of elements.
+  ///
+  /// - Complexity: O(1)
+  @_alwaysEmitIntoClient
+  @lifetime(copy self)
+  public func extracting(droppingFirst k: Int) -> Self {
+    _precondition(k >= 0, "Can't drop a negative number of elements")
+    let droppedCount = min(k, count)
+    let offset = droppedCount &* MemoryLayout<Element>.stride
+    let newStart = unsafe _pointer?.advanced(by: offset)
+    let newCount = count &- droppedCount
+    let newSpan = unsafe Span(_unchecked: newStart, count: newCount)
+    // As a trivial value, 'newStart' does not formally depend on the
+    // lifetime of 'buffer'. Make the dependence explicit.
+    return unsafe _overrideLifetime(newSpan, copying: self)
+  }
+
+  @available(*, deprecated, renamed: "extracting(droppingFirst:)")
+  @_alwaysEmitIntoClient
+  @lifetime(copy self)
+  public func _extracting(droppingFirst k: Int) -> Self {
+    extracting(droppingFirst: k)
+  }
+}
+
+#endif  // hasFeature(PreInverseGenericsExcept)
 
 @available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)

--- a/stdlib/public/core/Span/Span.swift
+++ b/stdlib/public/core/Span/Span.swift
@@ -26,7 +26,7 @@ import Swift
 @safe
 @available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
-public struct Span<Element: ~Copyable>: ~Escapable, Copyable, BitwiseCopyable {
+public struct Span<Element: ~Copyable & ~Escapable>: ~Escapable, Copyable, BitwiseCopyable {
 
   /// The starting address of this `Span`.
   ///
@@ -88,7 +88,7 @@ public struct Span<Element: ~Copyable>: ~Escapable, Copyable, BitwiseCopyable {
 
 @available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
-extension Span: @unchecked Sendable where Element: Sendable & ~Copyable {}
+extension Span: @unchecked Sendable where Element: Sendable & ~Copyable & ~Escapable {}
 
 @available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
@@ -217,7 +217,7 @@ extension Span /*where Element: Copyable*/ {
 
 @available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
-extension Span where Element: BitwiseCopyable {
+extension Span where Element: BitwiseCopyable & ~Escapable {
 
   /// Unsafely create a `Span` over initialized memory.
   ///
@@ -402,7 +402,7 @@ extension Span where Element: BitwiseCopyable {
 
 @available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
-extension Span where Element: ~Copyable {
+extension Span where Element: ~Copyable & ~Escapable {
 
   /// The number of elements in the span.
   ///
@@ -436,7 +436,7 @@ extension Span where Element: ~Copyable {
 
 @available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
-extension Span where Element: ~Copyable {
+extension Span where Element: ~Copyable & ~Escapable {
   // SILOptimizer looks for fixed_storage.check_index semantics for bounds check optimizations.
   @_semantics("fixed_storage.check_index")
   @inline(__always)
@@ -454,6 +454,7 @@ extension Span where Element: ~Copyable {
   @_alwaysEmitIntoClient
   public subscript(_ position: Index) -> Element {
     @_transparent
+    @_lifetime(copy self)
     borrow {
       _checkIndex(position)
       return unsafe self[unchecked: position]
@@ -472,6 +473,7 @@ extension Span where Element: ~Copyable {
   @unsafe
   @_alwaysEmitIntoClient
   public subscript(unchecked position: Index) -> Element {
+    @_lifetime(copy self)
     @_unsafeSelfDependentResult
     borrow {
       Builtin.borrowAt(unsafe _unsafeAddressOfElement(unchecked: position))
@@ -490,7 +492,7 @@ extension Span where Element: ~Copyable {
 
 @available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
-extension Span where Element: BitwiseCopyable {
+extension Span where Element: BitwiseCopyable & ~Escapable {
   /// Accesses the element at the specified index in the `Span`.
   ///
   /// - Parameter position: The offset of the element to access. `position`
@@ -500,6 +502,7 @@ extension Span where Element: BitwiseCopyable {
   @_alwaysEmitIntoClient
   public subscript(_ position: Index) -> Element {
     @_transparent
+    @_lifetime(copy self)
     get {
       _checkIndex(position)
       return unsafe self[unchecked: position]
@@ -518,16 +521,18 @@ extension Span where Element: BitwiseCopyable {
   @unsafe
   @_alwaysEmitIntoClient
   public subscript(unchecked position: Index) -> Element {
+    @_lifetime(copy self)
     get {
-      let address = unsafe _unsafeAddressOfElement(unchecked: position)
-      return unsafe UnsafeRawPointer(address).loadUnaligned(as: Element.self)
+      let ptr = unsafe _unsafeAddressOfElement(unchecked: position)
+      let element = unsafe UnsafeRawPointer(ptr).loadUnaligned(as: Element.self)
+      return unsafe _overrideLifetime(element, copying: self)
     }
   }
 }
 
 @available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
-extension Span where Element: Copyable {
+extension Span where Element: Copyable & ~Escapable {
 
   /// Construct a raw span over the memory represented by this span.
   ///
@@ -564,7 +569,7 @@ extension Span where Element: ConvertibleToBytes {
 // MARK: sub-spans
 @available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
-extension Span where Element: ~Copyable {
+extension Span where Element: ~Copyable & ~Escapable {
 
   /// Constructs a new span over the items within the supplied range of
   /// indices within this span.
@@ -721,7 +726,7 @@ extension Span where Element: ~Copyable {
 // MARK: UnsafeBufferPointer access hatch
 @available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
-extension Span where Element: ~Copyable  {
+extension Span where Element: ~Copyable {
 
   /// Calls a closure with a pointer to the viewed contiguous storage.
   ///
@@ -753,7 +758,7 @@ extension Span where Element: ~Copyable  {
 
 @available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
-extension Span where Element: BitwiseCopyable {
+extension Span where Element: BitwiseCopyable & ~Escapable {
 
   /// Calls the given closure with a pointer to the underlying bytes of
   /// the viewed contiguous storage.
@@ -784,7 +789,7 @@ extension Span where Element: BitwiseCopyable {
 
 @available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
-extension Span where Element: ~Copyable {
+extension Span where Element: ~Copyable & ~Escapable {
   /// Returns a Boolean value indicating whether two instances refer to the same
   /// memory region.
   ///
@@ -845,7 +850,7 @@ extension Span where Element: ~Copyable {
 // MARK: prefixes and suffixes
 @available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
-extension Span where Element: ~Copyable {
+extension Span where Element: ~Copyable & ~Escapable {
 
   /// Returns a span containing the initial elements of this span,
   /// up to the specified maximum length.

--- a/stdlib/public/core/Span/Span.swift
+++ b/stdlib/public/core/Span/Span.swift
@@ -998,6 +998,8 @@ extension Span where Element: ~Copyable & ~Escapable {
 #else  // hasFeature(PreInverseGenericsExcept)
 // MARK: Span<Non-escapable>
 
+// TODO: Remove this duplicated version of `Span` rdar://177362237
+
 /// `Span<Element>` represents a contiguous region of memory
 /// which contains initialized instances of `Element`.
 ///

--- a/test/SILGen/foreach_borrowing.swift
+++ b/test/SILGen/foreach_borrowing.swift
@@ -23,7 +23,7 @@ func testNonCopyableBorrowingSequence(seq: borrowing Span<NoncopyableInt>) {
   // With borrowing feature enabled, we expect makeBorrowingIterator and nextSpan to be called
   // CHECK: = function_ref @$ss4SpanVsRi_zrlE21makeBorrowingIterators0aD0VyxGyF : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (@guaranteed Span<τ_0_0>) -> @lifetime(borrow 0) @out SpanIterator<τ_0_0>
   // CHECK: = function_ref @$ss12SpanIteratorVsRi_zrlE04nextA012maximumCounts0A0VyxGSi_tF : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (Int, @lifetime(copy 1) @inout SpanIterator<τ_0_0>) -> @lifetime(borrow address_for_deps 1) @owned Span<τ_0_0>
-  // CHECK: [[IS_EMPTY_CHECK:%.*]] = function_ref @$ss4SpanVsRi_zrlE7isEmptySbvg : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (@guaranteed Span<τ_0_0>) -> Bool
+  // CHECK: [[IS_EMPTY_CHECK:%.*]] = function_ref @$ss4SpanVsRi_zRi0_zrlE7isEmptySbvg : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable, τ_0_0 : ~Escapable> (@guaranteed Span<τ_0_0>) -> Bool
   // CHECK: [[IS_EMPTY_CALL:%.*]] = apply [[IS_EMPTY_CHECK]]
   // CHECK: [[NOT_EMPTY:%.*]] = function_ref @$sSb1nopyS2bFZ : $@convention(method) (Bool, @thin Bool.Type) -> Bool
   // CHECK: [[NOT_EMPTY_CALL:%.*]] = apply [[NOT_EMPTY]]([[IS_EMPTY_CALL]]
@@ -45,7 +45,7 @@ func testCopyableBorrowingSequence(seq: borrowing Span<Int>) {
   // With borrowing feature enabled, we expect makeBorrowingIterator and nextSpan to be called
   // CHECK: = function_ref @$ss4SpanVsRi_zrlE21makeBorrowingIterators0aD0VyxGyF : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (@guaranteed Span<τ_0_0>) -> @lifetime(borrow 0) @out SpanIterator<τ_0_0>
   // CHECK: = function_ref @$ss12SpanIteratorVsRi_zrlE04nextA012maximumCounts0A0VyxGSi_tF : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (Int, @lifetime(copy 1) @inout SpanIterator<τ_0_0>) -> @lifetime(borrow address_for_deps 1) @owned Span<τ_0_0>
-  // CHECK: [[IS_EMPTY_CHECK:%.*]] = function_ref @$ss4SpanVsRi_zrlE7isEmptySbvg : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (@guaranteed Span<τ_0_0>) -> Bool
+  // CHECK: [[IS_EMPTY_CHECK:%.*]] = function_ref @$ss4SpanVsRi_zRi0_zrlE7isEmptySbvg : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable, τ_0_0 : ~Escapable> (@guaranteed Span<τ_0_0>) -> Bool
   // CHECK: [[IS_EMPTY_CALL:%.*]] = apply [[IS_EMPTY_CHECK]]
   // CHECK: [[NOT_EMPTY:%.*]] = function_ref @$sSb1nopyS2bFZ : $@convention(method) (Bool, @thin Bool.Type) -> Bool
   // CHECK: [[NOT_EMPTY_CALL:%.*]] = apply [[NOT_EMPTY]]([[IS_EMPTY_CALL]]

--- a/test/SILGen/foreach_borrowing.swift
+++ b/test/SILGen/foreach_borrowing.swift
@@ -2,10 +2,12 @@
 // RUN:     -g -Xllvm -sil-print-debuginfo-verbose \
 // RUN:     -enable-experimental-feature BorrowingForLoop \
 // RUN:     -enable-experimental-feature BorrowingSequence \
+// RUN:     -enable-experimental-feature PreInverseGenericsExcept \
 // RUN:     %s | %FileCheck %s
 
 // REQUIRES: swift_feature_BorrowingForLoop
 // REQUIRES: swift_feature_BorrowingSequence
+// REQUIRES: swift_feature_PreInverseGenericsExcept
 
 struct NoncopyableInt: ~Copyable {
   var value: Int

--- a/test/SILGen/foreach_borrowing.swift
+++ b/test/SILGen/foreach_borrowing.swift
@@ -21,9 +21,9 @@ extension NoncopyableInt: Equatable {
 @available(SwiftStdlib 6.4, *)
 func testNonCopyableBorrowingSequence(seq: borrowing Span<NoncopyableInt>) {
   // With borrowing feature enabled, we expect makeBorrowingIterator and nextSpan to be called
-  // CHECK: = function_ref @$ss4SpanVsRi_zRi0_zrlE21makeBorrowingIterators0aD0VyxGyF : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable, τ_0_0 : ~Escapable> (@guaranteed Span<τ_0_0>) -> @lifetime(borrow 0) @out SpanIterator<τ_0_0>
-  // CHECK: function_ref @$ss12SpanIteratorVsRi_zRi0_zrlE04nextA012maximumCounts0A0VyxGSi_tF : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable, τ_0_0 : ~Escapable> (Int, @lifetime(copy 1) @inout SpanIterator<τ_0_0>) -> @lifetime(borrow address_for_deps 1) @owned Span<τ_0_0>
-  // CHECK: [[IS_EMPTY_CHECK:%.*]] = function_ref @$ss4SpanVsRi_zRi0_zrlE7isEmptySbvg : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable, τ_0_0 : ~Escapable> (@guaranteed Span<τ_0_0>) -> Bool
+  // CHECK: = function_ref @$ss4SpanVsRi_zrlE21makeBorrowingIterators0aD0VyxGyF : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (@guaranteed Span<τ_0_0>) -> @lifetime(borrow 0) @out SpanIterator<τ_0_0>
+  // CHECK: = function_ref @$ss12SpanIteratorVsRi_zrlE04nextA012maximumCounts0A0VyxGSi_tF : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (Int, @lifetime(copy 1) @inout SpanIterator<τ_0_0>) -> @lifetime(borrow address_for_deps 1) @owned Span<τ_0_0>
+  // CHECK: [[IS_EMPTY_CHECK:%.*]] = function_ref @$ss4SpanVsRi_zrlE7isEmptySbvg : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (@guaranteed Span<τ_0_0>) -> Bool
   // CHECK: [[IS_EMPTY_CALL:%.*]] = apply [[IS_EMPTY_CHECK]]
   // CHECK: [[NOT_EMPTY:%.*]] = function_ref @$sSb1nopyS2bFZ : $@convention(method) (Bool, @thin Bool.Type) -> Bool
   // CHECK: [[NOT_EMPTY_CALL:%.*]] = apply [[NOT_EMPTY]]([[IS_EMPTY_CALL]]
@@ -43,9 +43,9 @@ func testNonCopyableBorrowingSequence(seq: borrowing Span<NoncopyableInt>) {
 @available(SwiftStdlib 6.4, *)
 func testCopyableBorrowingSequence(seq: borrowing Span<Int>) {
   // With borrowing feature enabled, we expect makeBorrowingIterator and nextSpan to be called
-  // CHECK: function_ref @$ss4SpanVsRi_zRi0_zrlE21makeBorrowingIterators0aD0VyxGyF : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable, τ_0_0 : ~Escapable> (@guaranteed Span<τ_0_0>) -> @lifetime(borrow 0) @out SpanIterator<τ_0_0>
-  // CHECK: = function_ref @$ss12SpanIteratorVsRi_zRi0_zrlE04nextA012maximumCounts0A0VyxGSi_tF : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable, τ_0_0 : ~Escapable> (Int, @lifetime(copy 1) @inout SpanIterator<τ_0_0>) -> @lifetime(borrow address_for_deps 1) @owned Span<τ_0_0>
-  // CHECK: [[IS_EMPTY_CHECK:%.*]] = function_ref @$ss4SpanVsRi_zRi0_zrlE7isEmptySbvg : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable, τ_0_0 : ~Escapable> (@guaranteed Span<τ_0_0>) -> Bool
+  // CHECK: = function_ref @$ss4SpanVsRi_zrlE21makeBorrowingIterators0aD0VyxGyF : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (@guaranteed Span<τ_0_0>) -> @lifetime(borrow 0) @out SpanIterator<τ_0_0>
+  // CHECK: = function_ref @$ss12SpanIteratorVsRi_zrlE04nextA012maximumCounts0A0VyxGSi_tF : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (Int, @lifetime(copy 1) @inout SpanIterator<τ_0_0>) -> @lifetime(borrow address_for_deps 1) @owned Span<τ_0_0>
+  // CHECK: [[IS_EMPTY_CHECK:%.*]] = function_ref @$ss4SpanVsRi_zrlE7isEmptySbvg : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (@guaranteed Span<τ_0_0>) -> Bool
   // CHECK: [[IS_EMPTY_CALL:%.*]] = apply [[IS_EMPTY_CHECK]]
   // CHECK: [[NOT_EMPTY:%.*]] = function_ref @$sSb1nopyS2bFZ : $@convention(method) (Bool, @thin Bool.Type) -> Bool
   // CHECK: [[NOT_EMPTY_CALL:%.*]] = apply [[NOT_EMPTY]]([[IS_EMPTY_CALL]]
@@ -143,11 +143,11 @@ func testForEachLocations(seq: borrowing Span<Int>, val: Int) {
   //   }
 
   // makeBorrowingIterator() function_ref should be at "for" keyword location (172:3)
-  // CHECK: [[MAKE_BORROWING_IT:%.*]] = function_ref @$ss4SpanVsRi_zRi0_zrlE21makeBorrowingIterators0aD0VyxGyF {{.*}}, loc "{{.*}}":[[@LINE+31]]:3
+  // CHECK: [[MAKE_BORROWING_IT:%.*]] = function_ref @$ss4SpanVsRi_zrlE21makeBorrowingIterators0aD0VyxGyF {{.*}}, loc "{{.*}}":[[@LINE+31]]:3
   // CHECK: apply [[MAKE_BORROWING_IT]]{{.*}}, loc "{{.*}}":[[@LINE+30]]:18
 
   // nextSpan() function_ref should be at "for" keyword location
-  // CHECK: [[NEXT_SPAN:%.*]] = function_ref @$ss12SpanIteratorVsRi_zRi0_zrlE04nextA012maximumCounts0A0VyxGSi_tF {{.*}}, loc "{{.*}}":[[@LINE+27]]:3
+  // CHECK: [[NEXT_SPAN:%.*]] = function_ref @$ss12SpanIteratorVsRi_zrlE04nextA012maximumCounts0A0VyxGSi_tF {{.*}}, loc "{{.*}}":[[@LINE+27]]:3
   // CHECK: apply [[NEXT_SPAN]]{{.*}}, loc "{{.*}}":[[@LINE+26]]:3
 
   // $span debug_value should be at "for" keyword location

--- a/test/SILGen/foreach_borrowing.swift
+++ b/test/SILGen/foreach_borrowing.swift
@@ -21,9 +21,9 @@ extension NoncopyableInt: Equatable {
 @available(SwiftStdlib 6.4, *)
 func testNonCopyableBorrowingSequence(seq: borrowing Span<NoncopyableInt>) {
   // With borrowing feature enabled, we expect makeBorrowingIterator and nextSpan to be called
-  // CHECK: = function_ref @$ss4SpanVsRi_zrlE21makeBorrowingIterators0aD0VyxGyF : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (@guaranteed Span<τ_0_0>) -> @lifetime(borrow 0) @out SpanIterator<τ_0_0>
-  // CHECK: = function_ref @$ss12SpanIteratorVsRi_zrlE04nextA012maximumCounts0A0VyxGSi_tF : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (Int, @lifetime(copy 1) @inout SpanIterator<τ_0_0>) -> @lifetime(borrow address_for_deps 1) @owned Span<τ_0_0>
-  // CHECK: [[IS_EMPTY_CHECK:%.*]] = function_ref @$ss4SpanVsRi_zrlE7isEmptySbvg : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (@guaranteed Span<τ_0_0>) -> Bool
+  // CHECK: = function_ref @$ss4SpanVsRi_zRi0_zrlE21makeBorrowingIterators0aD0VyxGyF : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable, τ_0_0 : ~Escapable> (@guaranteed Span<τ_0_0>) -> @lifetime(borrow 0) @out SpanIterator<τ_0_0>
+  // CHECK: function_ref @$ss12SpanIteratorVsRi_zRi0_zrlE04nextA012maximumCounts0A0VyxGSi_tF : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable, τ_0_0 : ~Escapable> (Int, @lifetime(copy 1) @inout SpanIterator<τ_0_0>) -> @lifetime(borrow address_for_deps 1) @owned Span<τ_0_0>
+  // CHECK: [[IS_EMPTY_CHECK:%.*]] = function_ref @$ss4SpanVsRi_zRi0_zrlE7isEmptySbvg : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable, τ_0_0 : ~Escapable> (@guaranteed Span<τ_0_0>) -> Bool
   // CHECK: [[IS_EMPTY_CALL:%.*]] = apply [[IS_EMPTY_CHECK]]
   // CHECK: [[NOT_EMPTY:%.*]] = function_ref @$sSb1nopyS2bFZ : $@convention(method) (Bool, @thin Bool.Type) -> Bool
   // CHECK: [[NOT_EMPTY_CALL:%.*]] = apply [[NOT_EMPTY]]([[IS_EMPTY_CALL]]
@@ -43,9 +43,9 @@ func testNonCopyableBorrowingSequence(seq: borrowing Span<NoncopyableInt>) {
 @available(SwiftStdlib 6.4, *)
 func testCopyableBorrowingSequence(seq: borrowing Span<Int>) {
   // With borrowing feature enabled, we expect makeBorrowingIterator and nextSpan to be called
-  // CHECK: = function_ref @$ss4SpanVsRi_zrlE21makeBorrowingIterators0aD0VyxGyF : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (@guaranteed Span<τ_0_0>) -> @lifetime(borrow 0) @out SpanIterator<τ_0_0>
-  // CHECK: = function_ref @$ss12SpanIteratorVsRi_zrlE04nextA012maximumCounts0A0VyxGSi_tF : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (Int, @lifetime(copy 1) @inout SpanIterator<τ_0_0>) -> @lifetime(borrow address_for_deps 1) @owned Span<τ_0_0>
-  // CHECK: [[IS_EMPTY_CHECK:%.*]] = function_ref @$ss4SpanVsRi_zrlE7isEmptySbvg : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (@guaranteed Span<τ_0_0>) -> Bool
+  // CHECK: function_ref @$ss4SpanVsRi_zRi0_zrlE21makeBorrowingIterators0aD0VyxGyF : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable, τ_0_0 : ~Escapable> (@guaranteed Span<τ_0_0>) -> @lifetime(borrow 0) @out SpanIterator<τ_0_0>
+  // CHECK: = function_ref @$ss12SpanIteratorVsRi_zRi0_zrlE04nextA012maximumCounts0A0VyxGSi_tF : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable, τ_0_0 : ~Escapable> (Int, @lifetime(copy 1) @inout SpanIterator<τ_0_0>) -> @lifetime(borrow address_for_deps 1) @owned Span<τ_0_0>
+  // CHECK: [[IS_EMPTY_CHECK:%.*]] = function_ref @$ss4SpanVsRi_zRi0_zrlE7isEmptySbvg : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable, τ_0_0 : ~Escapable> (@guaranteed Span<τ_0_0>) -> Bool
   // CHECK: [[IS_EMPTY_CALL:%.*]] = apply [[IS_EMPTY_CHECK]]
   // CHECK: [[NOT_EMPTY:%.*]] = function_ref @$sSb1nopyS2bFZ : $@convention(method) (Bool, @thin Bool.Type) -> Bool
   // CHECK: [[NOT_EMPTY_CALL:%.*]] = apply [[NOT_EMPTY]]([[IS_EMPTY_CALL]]
@@ -143,11 +143,11 @@ func testForEachLocations(seq: borrowing Span<Int>, val: Int) {
   //   }
 
   // makeBorrowingIterator() function_ref should be at "for" keyword location (172:3)
-  // CHECK: [[MAKE_BORROWING_IT:%.*]] = function_ref @$ss4SpanVsRi_zrlE21makeBorrowingIterators0aD0VyxGyF {{.*}}, loc "{{.*}}":[[@LINE+31]]:3
+  // CHECK: [[MAKE_BORROWING_IT:%.*]] = function_ref @$ss4SpanVsRi_zRi0_zrlE21makeBorrowingIterators0aD0VyxGyF {{.*}}, loc "{{.*}}":[[@LINE+31]]:3
   // CHECK: apply [[MAKE_BORROWING_IT]]{{.*}}, loc "{{.*}}":[[@LINE+30]]:18
 
   // nextSpan() function_ref should be at "for" keyword location
-  // CHECK: [[NEXT_SPAN:%.*]] = function_ref @$ss12SpanIteratorVsRi_zrlE04nextA012maximumCounts0A0VyxGSi_tF {{.*}}, loc "{{.*}}":[[@LINE+27]]:3
+  // CHECK: [[NEXT_SPAN:%.*]] = function_ref @$ss12SpanIteratorVsRi_zRi0_zrlE04nextA012maximumCounts0A0VyxGSi_tF {{.*}}, loc "{{.*}}":[[@LINE+27]]:3
   // CHECK: apply [[NEXT_SPAN]]{{.*}}, loc "{{.*}}":[[@LINE+26]]:3
 
   // $span debug_value should be at "for" keyword location


### PR DESCRIPTION
Allows `Span` of `~Escapable` types, dependent on the new `PreInverseGenericsExcept` feature flag to maintain ABI stability.