### PR TITLE
large_inline_array.swift.gyb: Increase timeout and re-enable

### DIFF
--- a/validation-test/SILOptimizer/large_inline_array.swift.gyb
+++ b/validation-test/SILOptimizer/large_inline_array.swift.gyb
@@ -12,15 +12,13 @@
 // We emit assembly rather than SIL because the bottleneck in rdar://175803465
 // was LLVM machine code generation.
 
-// RUN: %{python} %S/../../test/Inputs/timeout.py 15 %target-swift-frontend -O -parse-as-library -disable-availability-checking -S %t/main.swift | %FileCheck %s
+// RUN: %{python} %S/../../test/Inputs/timeout.py 60 %target-swift-frontend -O -parse-as-library -disable-availability-checking -S %t/main.swift | %FileCheck %s
 
 // There is a separate test for an assert-enabled stdlib
 // REQUIRES: swift_stdlib_no_asserts,optimized_stdlib
 
 // REQUIRES: long_test
 // REQUIRES: CPU=arm64 || CPU=x86_64 || CPU=aarch64
-
-// REQUIRES: rdar176849287
 
 // Check if the optimizer can optimize the whole array into a statically
 // initialized global


### PR DESCRIPTION
Increase the timeout to 60 seconds, the originally-intended value.

This test was temporarily disabled in #89022, because its unintentionally short timeout was exceeded in some test suites.

Fixes: rdar://176632682
<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
