### PR TITLE
[Backtracing] [Windows] Bugfixes for windows image crash logs

### DIFF
--- a/stdlib/public/RuntimeModule/CrashLog.swift
+++ b/stdlib/public/RuntimeModule/CrashLog.swift
@@ -366,7 +366,8 @@ extension CrashLog.Image {
         return .init(
             name: name,
             path: path,
-            uniqueID: CrashLog.bytesFromHexString(buildId ?? ""),
+            uniqueID:
+                (buildId != nil) ? CrashLog.bytesFromHexString(buildId!) : nil,
             baseAddress: ImageMap.Address(CrashLog.addressFromString(baseAddress) ?? 0),
             endOfText: ImageMap.Address(CrashLog.addressFromString(endOfText) ?? 0)
             )

--- a/stdlib/public/RuntimeModule/DefaultSymbolLocator.swift
+++ b/stdlib/public/RuntimeModule/DefaultSymbolLocator.swift
@@ -316,11 +316,12 @@ open class DefaultSymbolLocator: SymbolLocator {
         result = pdbFile
       }
 
-      if result == nil,
-         let sourcePath = image.path,
-         let imagePath = realPath(sourcePath) {
+      for sourcePath in findPeCoffSymbolPaths(image: image) {
+        if result != nil { break }
+
         // Break apart the image name
-        let (imageDir, imageName) = splitpath(imagePath)
+        let (rawDir, imageName) = splitpath(sourcePath)
+        let imageDir = realPath(String(rawDir)) ?? String(rawDir)
         let pdbName: String
         let ext: Substring?
         if let dotNdx = imageName.lastIndex(of: ".") {

--- a/stdlib/public/RuntimeModule/ImageMap+Win32.swift
+++ b/stdlib/public/RuntimeModule/ImageMap+Win32.swift
@@ -244,7 +244,7 @@ extension ImageMap {
       print("path: \(modulePath)")
       #endif
 
-      guard GetModuleInformation(hProcess, hModule!, &moduleInfo,
+      guard GetModuleInformation(hProcess, hModule, &moduleInfo,
                                  DWORD(MemoryLayout<MODULEINFO>.size))
       else {
         #if DEBUG_WIN32_IMAGEMAP_CAPTURE

--- a/stdlib/public/RuntimeModule/ImageMap+Win32.swift
+++ b/stdlib/public/RuntimeModule/ImageMap+Win32.swift
@@ -224,12 +224,19 @@ extension ImageMap {
     // Turn that into a list of Images
     var images: [Image] = []
     for hModule in hModules {
+      guard let hModule else {
+        #if DEBUG_WIN32_IMAGEMAP_CAPTURE
+        print("Windows backtracing - Null module should not be possible.")
+        #endif
+        continue
+      }
+
       #if DEBUG_WIN32_IMAGEMAP_CAPTURE
       print("hModule: \(String(describing: hModule))")
       #endif
 
-      let moduleName = GetModuleBaseName(hProcess, hModule!)
-      let modulePath = GetModuleFileNameEx(hProcess, hModule!)
+      let moduleName = GetModuleBaseName(hProcess, hModule)
+      let modulePath = GetModuleFileNameEx(hProcess, hModule)
       var moduleInfo = MODULEINFO()
 
       #if DEBUG_WIN32_IMAGEMAP_CAPTURE
@@ -241,7 +248,7 @@ extension ImageMap {
                                  DWORD(MemoryLayout<MODULEINFO>.size))
       else {
         #if DEBUG_WIN32_IMAGEMAP_CAPTURE
-        print("GetModuleInformation() failed for \(hModule!)")
+        print("GetModuleInformation() failed for \(hModule)")
         #endif
         continue
       }
@@ -255,6 +262,7 @@ extension ImageMap {
       let endOfText: Address
       var debugEntry = IMAGE_DATA_DIRECTORY()
       var exceptionEntry = IMAGE_DATA_DIRECTORY()
+      var sizeOfImage: DWORD = 0
 
       var wMagic: WORD = 0
       var dwOffset: DWORD = 0
@@ -322,8 +330,10 @@ extension ImageMap {
         continue
       }
 
+      let timeDateStamp = header.TimeDateStamp
+
       if (header.Characteristics & WORD(IMAGE_FILE_32BIT_MACHINE)) != 0 {
-        // 32-bit
+        // 32-bit (from winnt.h see typedef struct _IMAGE_OPTIONAL_HEADER)
         var optionalHeader = IMAGE_OPTIONAL_HEADER32()
 
         #if DEBUG_WIN32_IMAGEMAP_CAPTURE
@@ -346,14 +356,16 @@ extension ImageMap {
 
         endOfText = baseAddress + Address(optionalHeader.BaseOfCode
                                           + optionalHeader.SizeOfCode)
+        sizeOfImage = optionalHeader.SizeOfImage
 
+        // from winnt.h see typedef struct _IMAGE_DATA_DIRECTORY
         // 3 is IMAGE_DIRECTORY_ENTRY_EXCEPTION
         exceptionEntry = optionalHeader.DataDirectory.3
 
         // 6 is IMAGE_DIRECTORY_ENTRY_DEBUG
         debugEntry = optionalHeader.DataDirectory.6
       } else {
-        // 64-bit
+        // 64-bit (from winnt.h - see typedef struct _IMAGE_OPTIONAL_HEADER64)
         var optionalHeader = IMAGE_OPTIONAL_HEADER64()
 
         #if DEBUG_WIN32_IMAGEMAP_CAPTURE
@@ -376,6 +388,7 @@ extension ImageMap {
 
         endOfText = baseAddress + Address(optionalHeader.BaseOfCode
                                           + optionalHeader.SizeOfCode)
+        sizeOfImage = optionalHeader.SizeOfImage
 
         // 3 is IMAGE_DIRECTORY_ENTRY_EXCEPTION
         exceptionEntry = optionalHeader.DataDirectory.3
@@ -435,6 +448,9 @@ extension ImageMap {
                   }
                   withUnsafeBytes(of: pdbInfo.dwAge) {
                     theUUID!.append(contentsOf: $0)
+                  }
+                  if theUUID!.allSatisfy({ $0 == 0 }) {
+                    theUUID = nil
                   }
                 }
               }
@@ -504,7 +520,9 @@ extension ImageMap {
                           uniqueID: theUUID,
                           baseAddress: baseAddress,
                           endOfText: endOfText,
-                          exceptionTable: exceptionTable))
+                          exceptionTable: exceptionTable,
+                          timeDateStamp: UInt32(timeDateStamp),
+                          sizeOfImage: UInt32(sizeOfImage)))
     }
 
     images.sort(by: { $0.baseAddress < $1.baseAddress })

--- a/stdlib/public/RuntimeModule/ImageMap.swift
+++ b/stdlib/public/RuntimeModule/ImageMap.swift
@@ -75,6 +75,10 @@ public struct ImageMap: Collection, Sendable, Hashable {
     #if os(Windows)
     @_spi(Testing)
     var exceptionTable: ExceptionTable?
+    @_spi(Testing)
+    public var timeDateStamp: UInt32 = 0
+    @_spi(Testing)
+    public var sizeOfImage: UInt32 = 0
     #endif
   }
 

--- a/stdlib/public/RuntimeModule/SymbolicatedBacktrace.swift
+++ b/stdlib/public/RuntimeModule/SymbolicatedBacktrace.swift
@@ -32,6 +32,21 @@ internal import Musl
 #endif
 internal import BacktracingImpl.Runtime
 
+@available(BacktracingDT 6.2, *)
+struct SimpleImageRef: SymbolLoader.Image {
+  var name: String?
+  var path: String?
+  var uuid: [UInt8]?
+  var age: UInt32?
+
+  init(name: String?, path: String?, uniqueID: [UInt8]?) {
+    self.name = name
+    self.path = path
+    self.uuid = uniqueID
+    self.age = nil
+  }
+}
+
 /// A symbolicated backtrace
 @available(BacktracingDT 6.2, *)
 public struct SymbolicatedBacktrace: CustomStringConvertible {
@@ -615,8 +630,6 @@ public struct SymbolicatedBacktrace: CustomStringConvertible {
       }
 
     case .Windows:
-      let cache = PeImageCache.threadLocal
-
       for frame in backtrace.frames {
         let address = frame.adjustedProgramCounter
         if let imageNdx = theImages.indexOfImage(at: address) {
@@ -628,20 +641,22 @@ public struct SymbolicatedBacktrace: CustomStringConvertible {
                                       offset: 0,
                                       sourceLocation: nil)
 
-          if let imagePath = symbolLocator.find(image: theImages[imageNdx]),
-             let image = cache.lookup(path: imagePath) {
-            let symbolSource = symbolLocator.findSymbols(for: image)
-            let relativeAddress = ImageSource.Address(
-              address - theImages[imageNdx].baseAddress
-            ) + image.baseAddress
-            if let theSymbol = lookupSymbol(symbolSource: symbolSource,
-                                            image: imageNdx,
-                                            named: name,
-                                            frame: frame,
-                                            address: relativeAddress,
-                                            options: options) {
-              symbol = theSymbol
-            }
+          let imageRef = SimpleImageRef(
+            name: theImages[imageNdx].name,
+            path: theImages[imageNdx].path,
+            uniqueID: theImages[imageNdx].uniqueID
+          )
+          let symbolSource = symbolLocator.findSymbols(for: imageRef)
+          let relativeAddress = ImageSource.Address(
+            address - theImages[imageNdx].baseAddress
+          )
+          if let theSymbol = lookupSymbol(symbolSource: symbolSource,
+                                          image: imageNdx,
+                                          named: name,
+                                          frame: frame,
+                                          address: relativeAddress,
+                                          options: options) {
+            symbol = theSymbol
           }
 
           frames.append(Frame(captured: frame, symbol: symbol))


### PR DESCRIPTION
- Fix issue with no build id showing up as `000000`... (e.g. no debug info), now shows as `<no build id>` as intended.
- Try to avoid loading PE file unless it's necessary on Windows symbolicating backtraces.
- DefaultSymbolLocator: PDB file finding now respects the overridable path for use in the offline symbolicator (no effect on standard backtracing).
- Record timestamp/size in Image Info on windows for possible future use in offline symbolicator
