### PR TITLE
Sema: Fix type parameter/archetype mixup in createImplicitConstructor() [6.4]

### DIFF
--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -393,7 +393,7 @@ createImplicitConstructor(NominalTypeDecl *decl, ImplicitConstructorKind ICK,
           initIsolation = var->getInitializerIsolation();
         }
 
-        auto type = var->getTypeInContext();
+        auto type = var->getInterfaceType();
 
         // If a property has a property wrapper, the memberwise initializer
         // could use a wrapped type instead of a backing storage type depending
@@ -405,6 +405,8 @@ createImplicitConstructor(NominalTypeDecl *decl, ImplicitConstructorKind ICK,
               type = property->getPropertyWrapperInitValueInterfaceType();
           }
         }
+
+        type = decl->mapTypeIntoEnvironment(type);
 
         auto isolation = getActorIsolation(var);
         if (isolation.isGlobalActor()) {

--- a/test/Concurrency/transfernonsendable_memberwise_init.swift
+++ b/test/Concurrency/transfernonsendable_memberwise_init.swift
@@ -29,3 +29,11 @@ struct TestView: MyView {
 func test() {
   _ = TestView(model: MyModel()) // Ok
 }
+
+@propertyWrapper struct Unobserved<T> {
+  var wrappedValue: T
+}
+
+@MainActor struct Generic<T> {
+  @Unobserved var model: T
+}


### PR DESCRIPTION
6.4 cherry-pick of https://github.com/swiftlang/swift/pull/89215

* **Description:** Some new logic was added in 8bb3bf09fbf3017ab75eddb7e9e8fe462947a57c but it would overwrite a contextual type stored in the 'type' local variable with an interface type. Instead, let's only map the type into the generic environment after we figure out what's going on with the property wrapper.

* **Scope of the issue:** Fixes a crash on  valid code discovered by the fuzzer.

* **Risk:** Virtually none, this should be a no-op in the common non-generic case that already worked.

* **Reviewed by:** @hamishknight 