### PR TITLE
[6.4][flow-isolation] Allow same-actor-isolated apply uses of self in init…

### DIFF
--- a/lib/SILOptimizer/Mandatory/FlowIsolation.cpp
+++ b/lib/SILOptimizer/Mandatory/FlowIsolation.cpp
@@ -464,7 +464,7 @@ public:
     //
     auto funcIsolation = rafi->getFunction()->getActorIsolation();
     if (funcIsolation.isActorIsolated()) {
-      // If our use is Non-Sendable, then we can rely on region isolation.
+      // If our value is Non-Sendable, then we can rely on region isolation.
       if (SILIsolationInfo::isNonSendable(i->get())) {
         if (auto iso = isolationInfoCache.getIsolationInfoAtInst(i->getUser(),
                                                                  i->get())) {
@@ -495,6 +495,22 @@ public:
                          << ". User: " << *i->getUser());
               return;
             }
+          }
+        }
+
+        // If we are passing self to a partial_apply or a function, we could end
+        // up here. In that case, we want to look at the use in terms of whether
+        // or not the partial_apply or function has a callee that is isolated to
+        // our function.
+        if (ApplySite as = ApplySite::isa(i->getUser())) {
+          if (auto *calleeFunction = as.getCalleeFunction();
+              calleeFunction &&
+              calleeFunction->getActorIsolation() == funcIsolation) {
+            LLVM_DEBUG(llvm::dbgs()
+                       << "isolated use that is safe b/c user is "
+                          "isolated to same as constructor. Op Num: "
+                       << i->getOperandNumber() << ". User: " << *i->getUser());
+            return;
           }
         }
       }

--- a/test/Concurrency/flow_isolation_basic.swift
+++ b/test/Concurrency/flow_isolation_basic.swift
@@ -841,6 +841,129 @@ actor TestNonisolatedUnsafe {
   }
 }
 
+// In a global-actor isolated init, after self has been captured by a @Sendable
+// closure that escapes to a nonisolated context, a subsequent setter call on a
+// property with an init accessor is lowered as `assign_or_init` with a
+// partial_apply binding self to the setter. The partial_apply's callee shares
+// the same global-actor isolation as the init, so this is not a flow-isolation
+// violation.
+@available(SwiftStdlib 5.1, *)
+func testGlobalActorClassWithInitAccessorAndSendableEscape() {
+  nonisolated func makeObserver(handler: @Sendable (Int) -> Void) -> Int { 0 }
+
+  @MainActor
+  class Foo {
+    private var _token: Int?
+    var token: Int? {
+      @storageRestrictions(initializes: _token)
+      init(initialValue) {
+        _token = initialValue
+      }
+      get { _token }
+      set { _token = newValue }
+    }
+
+    init() {
+      token = makeObserver { [weak self] _ in
+        _ = self
+      }
+    }
+  }
+}
+
+// Same scenario as above, but using a `nonisolated` trigger method instead of
+// a @Sendable closure escape to push self to a nonisolated state.
+@available(SwiftStdlib 5.1, *)
+func testGlobalActorClassWithInitAccessorAndNonisolatedTrigger() {
+  @MainActor
+  class Foo {
+    nonisolated func trigger() {}
+    private var _x: Int?
+    var x: Int? {
+      @storageRestrictions(initializes: _x)
+      init(initialValue) {
+        _x = initialValue
+      }
+      get { _x }
+      set { _x = newValue }
+    }
+    init() {
+      trigger()
+      x = 1
+    }
+  }
+}
+
+// Same scenario as above, but using a custom global actor instead of MainActor
+// to confirm the same-isolation match isn't MainActor-specific.
+@available(SwiftStdlib 5.1, *)
+@globalActor actor MyActorForFlowIsolation {
+  static let shared = MyActorForFlowIsolation()
+}
+
+@available(SwiftStdlib 5.1, *)
+func testCustomGlobalActorClassWithInitAccessorAndSendableEscape() {
+  nonisolated func makeObserver(handler: @Sendable (Int) -> Void) -> Int { 0 }
+
+  @MyActorForFlowIsolation
+  class Foo {
+    private var _token: Int?
+    var token: Int? {
+      @storageRestrictions(initializes: _token)
+      init(initialValue) {
+        _token = initialValue
+      }
+      get { _token }
+      set { _token = newValue }
+    }
+
+    init() {
+      token = makeObserver { [weak self] _ in
+        _ = self
+      }
+    }
+  }
+}
+
+// Multiple sequential init-accessor setters in a single init: each
+// `assign_or_init` binds self to a same-actor-isolated setter via a
+// partial_apply, and each must be accepted independently.
+@available(SwiftStdlib 5.1, *)
+func testGlobalActorClassWithMultipleInitAccessorSetters() {
+  nonisolated func makeObserver(handler: @Sendable (Int) -> Void) -> Int { 0 }
+
+  @MainActor
+  class Foo {
+    private var _a: Int?
+    private var _b: Int?
+    var a: Int? {
+      @storageRestrictions(initializes: _a)
+      init(initialValue) {
+        _a = initialValue
+      }
+      get { _a }
+      set { _a = newValue }
+    }
+    var b: Int? {
+      @storageRestrictions(initializes: _b)
+      init(initialValue) {
+        _b = initialValue
+      }
+      get { _b }
+      set { _b = newValue }
+    }
+
+    init() {
+      a = makeObserver { [weak self] _ in
+        _ = self
+      }
+      b = makeObserver { [weak self] _ in
+        _ = self
+      }
+    }
+  }
+}
+
 @available(SwiftStdlib 5.1, *)
 actor OtherActor {
   unowned nonisolated let parent: any Actor


### PR DESCRIPTION
…ializers

When analyzing uses of `self` in a global-actor-isolated initializer, treat a partial_apply or function call whose callee shares the same actor isolation as a safe use rather than as a flow-isolation property access.

This fixes a spurious "actor-isolated property can not be mutated from a nonisolated context" warning for `@MainActor` classes whose properties use an init accessor (e.g., a property emitted by `@Observable`) when their setter is invoked after `self` has been captured by an escaping `@Sendable` closure: SILGen lowers that setter call as `assign_or_init`, which binds `self` to the setter via a partial_apply, and the prior closure capture had already pushed `self` to a nonisolated state under the existing dataflow.

rdar://177318745
(cherry picked from commit 07bc4f91901a97dc1e03e05a0b414e50f8ec2b69)

----

Will fill out template in a bit.

- **Explanation**:
  <!--
  A description of the changes. This can be brief, but it should be clear.
  -->
- **Scope**:
  <!--
  An assessment of the impact and importance of the changes. For example, can
  the changes break existing code?
  -->
- **Issues**:
  <!--
  References to issues the changes resolve, if any.
  -->
- **Original PRs**: https://github.com/swiftlang/swift/pull/89208
  <!--
  Links to mainline branch pull requests in which the changes originated.
  -->
- **Risk**:
  <!--
  The (specific) risk to the release for taking the changes.
  -->
- **Testing**:
  <!--
  The specific testing that has been done or needs to be done to further
  validate any impact of the changes.
  -->
- **Reviewers**:
  <!--
  The code owners that GitHub-approved the original changes in the mainline
  branch pull requests. If an original change has not been GitHub-approved by
  a respective code owner, provide a reason. Technical review can be delegated
  by a code owner or otherwise requested as deemed appropriate or useful.
  -->