### PR TITLE
[DebugInfo] Add support for Load within Debug Basic Blocks

### DIFF
--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -800,7 +800,8 @@ public:
   LoadInst *createLoad(SILLocation Loc, SILValue LV,
                        LoadOwnershipQualifier Qualifier) {
     ASSERT((Qualifier != LoadOwnershipQualifier::Unqualified) ||
-           !hasOwnership() && "Unqualified inst in qualified function");
+           !hasOwnership() || (BB && BB->isDebugReconstructionBlock()) &&
+           "Unqualified inst in qualified function");
     ASSERT((Qualifier == LoadOwnershipQualifier::Unqualified) ||
            hasOwnership() && "Qualified inst in unqualified function");
     ASSERT(isLoadableOrOpaque(LV->getType()));
@@ -3347,7 +3348,7 @@ private:
 #ifndef NDEBUG
     // A vector instruction can only be in a global initializer. Therefore there
     // is no point in verifying debug info or ownership.
-    if (!isa<VectorInst>(TheInst)) {
+    if (!isa<VectorInst>(TheInst) && !BB->isDebugReconstructionBlock()) {
       // If we are inserting into a specific function (rather than a block for a
       // global_addr), verify that our instruction/the associated location are in
       // sync. We don't care if an instruction is used in global_addr.

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -59,6 +59,7 @@
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/DIBuilder.h"
 #include "llvm/IR/DebugInfo.h"
+#include "llvm/IR/DebugInfoMetadata.h"
 #include "llvm/IR/Function.h"
 #include "llvm/IR/InlineAsm.h"
 #include "llvm/IR/Instructions.h"
@@ -5812,6 +5813,11 @@ void IRGenSILFunction::visitRefTailAddrInst(RefTailAddrInst *i) {
 }
 
 static bool isInvariantAddress(SILValue v) {
+  // Debug reconstruction blocks have standalone block arguments with no
+  // predecessors, which confuses the access path walker.
+  if (v->getParentBlock()->isDebugReconstructionBlock())
+    return false;
+
   SILValue accessedAddress = getTypedAccessAddress(v);
   if (auto *ptrRoot = dyn_cast<PointerToAddressInst>(accessedAddress)) {
     return ptrRoot->isInvariant();
@@ -6166,6 +6172,39 @@ static bool InCoroContext(SILFunction &f, SILInstruction &i) {
   return f.isAsync() && !i.getDebugScope()->InlinedCallSite;
 }
 
+/// Salvage an LLVM instruction emitted within a debug reconstruction block.
+/// Most instructions are handled by llvm::salvageDebugInfo which encodes
+/// their effects into the DWARF expression, but some instructions, such as
+/// loads, need a special case.
+static void salvageDebugReconstructionInst(llvm::Instruction *I) {
+  if (auto *LI = dyn_cast<llvm::LoadInst>(I)) {
+    llvm::SmallVector<llvm::DbgVariableIntrinsic *, 1> DbgInsts;
+    llvm::SmallVector<llvm::DbgVariableRecord *, 2> DbgRecords;
+    llvm::findDbgUsers(DbgInsts, LI, &DbgRecords);
+    llvm::Value *Addr = LI->getPointerOperand();
+    for (llvm::DbgVariableRecord *DVR : DbgRecords) {
+      // Insert DW_OP_deref after each arg that references the load.
+      // This loop works the same way as llvm::salvageDebugInfoForDbgValues.
+      // It iterates over the inputs (`locations`) of the debug record (although
+      // there usually is only one), and when the input is this load instruction,
+      // the DIExpression is updated to add a deref to all uses.
+      auto locations = DVR->location_ops();
+      llvm::DIExpression *expr = DVR->getExpression();
+      auto locationIterator = find(locations, LI);
+      while (locationIterator != locations.end()) {
+        unsigned locationNo = std::distance(locations.begin(), locationIterator);
+        expr = llvm::DIExpression::appendOpsToArg(expr,
+                                                  {llvm::dwarf::DW_OP_deref}, locationNo);
+        locationIterator = std::find(std::next(locationIterator), locations.end(), LI);
+      }
+      DVR->replaceVariableLocationOp(LI, Addr);
+      DVR->setExpression(expr);
+    }
+    return;
+  }
+  llvm::salvageDebugInfo(*I);
+}
+
 void IRGenSILFunction::visitDebugValueInst(DebugValueInst *i) {
   auto SILVal = i->getOperand();
   bool IsAddrVal = SILVal->getType().isAddress();
@@ -6307,7 +6346,7 @@ void IRGenSILFunction::visitDebugValueInst(DebugValueInst *i) {
   // Erase any LLVM instructions emitted by the debug BB. They were only needed
   // to produce the dbg intrinsic; salvage converts references into DWARF exprs.
   for (auto *I : llvm::reverse(DebugBBInsts)) {
-    llvm::salvageDebugInfo(*I);
+    salvageDebugReconstructionInst(I);
     I->eraseFromParent();
   }
 }

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -1828,12 +1828,6 @@ public:
     
     SILType DebugVarTy = varInfo->Type ? *varInfo->Type :
       SSAType.getObjectType();
-    if (!varInfo->DIExpr && !isa<SILBoxType>(SSAType.getASTType())) {
-      // FIXME: Remove getObjectType() below when we fix create/createAddr
-      require(DebugVarTy.removingMoveOnlyWrapper()
-              == SSAType.getObjectType().removingMoveOnlyWrapper(),
-              "debug type mismatch without a DIExpr");
-    }
 
     auto *debugScope = inst->getDebugScope();
     if (varInfo->ArgNo)

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -3015,8 +3015,9 @@ public:
     switch (LI->getOwnershipQualifier()) {
     case LoadOwnershipQualifier::Unqualified:
       // We should not see loads with unqualified ownership when SILOwnership is
-      // enabled.
-      require(!F.hasOwnership(),
+      // enabled, unless they are in a debug reconstruction block.
+      require(!F.hasOwnership() ||
+              LI->getParent()->isDebugReconstructionBlock(),
               "Load with unqualified ownership in a qualified function");
       break;
     case LoadOwnershipQualifier::Copy:

--- a/test/DebugInfo/irgen_debug_reconstruction.sil
+++ b/test/DebugInfo/irgen_debug_reconstruction.sil
@@ -1,0 +1,42 @@
+// RUN: %target-swiftc_driver -Xfrontend -disable-debugger-shadow-copies -O -g -emit-ir %s | %FileCheck %s
+sil_stage canonical
+
+import Swift
+import Builtin
+
+struct MyStruct {
+  var x: Builtin.Int64
+  var y: Builtin.Int64
+}
+
+// CHECK-LABEL: define {{.*}} @load_from_addr
+sil @load_from_addr : $@convention(thin) (@in_guaranteed Builtin.Int64) -> Builtin.Int64 {
+bb0(%0 : $*Builtin.Int64):
+  // CHECK: #dbg_value(ptr %0, ![[LOAD_VAR:[0-9]+]], !DIExpression(DW_OP_deref)
+  debug_value %0 : $*Builtin.Int64, var, name "loaded", transform {
+  bb0(%1 : $*Builtin.Int64):
+    %2 = load %1 : $*Builtin.Int64
+    return %2 : $Builtin.Int64
+  }
+  %v = load %0 : $*Builtin.Int64
+  return %v : $Builtin.Int64
+}
+
+// CHECK-LABEL: define {{.*}} @load_field
+sil @load_field : $@convention(thin) (@in_guaranteed MyStruct) -> Builtin.Int64 {
+bb0(%0 : $*MyStruct):
+  // The struct_element_addr becomes a constant offset, and the load becomes DW_OP_deref.
+  // CHECK: #dbg_value(ptr %0, ![[LOAD_FIELD_VAR:[0-9]+]], !DIExpression(DW_OP_plus_uconst, 8, DW_OP_deref, DW_OP_stack_value)
+  debug_value %0 : $*MyStruct, var, name "field_y", type $Builtin.Int64, transform {
+  bb0(%1 : $*MyStruct):
+    %2 = struct_element_addr %1 : $*MyStruct, #MyStruct.y
+    %3 = load %2 : $*Builtin.Int64
+    return %3 : $Builtin.Int64
+  }
+  %addr = struct_element_addr %0 : $*MyStruct, #MyStruct.x
+  %v = load %addr : $*Builtin.Int64
+  return %v : $Builtin.Int64
+}
+
+// CHECK: ![[LOAD_VAR]] = !DILocalVariable(name: "loaded"
+// CHECK: ![[LOAD_FIELD_VAR]] = !DILocalVariable(name: "field_y"


### PR DESCRIPTION
Load instructions aren't handled in LLVM's salvageDebugInfo due to how unpredictable LLVM's optimization passes can be. In Swift, we only add loads to debug reconstruction blocks if we know it is correct.
