### PR TITLE
[Serialization] Substitute HiddenType for hidden stored-property types when emitting binary modules

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -1501,6 +1501,16 @@ public:
   /// the language options.
   bool shouldPerformTypoCorrection();
 
+  /// Record that, when emitting the current module, references to \p type in
+  /// stored properties of public types should be substituted with a
+  /// \c HiddenType carrying \p mangledName.
+  void recordTypeToHideWhenEmittingModule(CanType type, StringRef mangledName);
+
+  /// If \p type was recorded as needing to be hidden when emitting the current
+  /// module, return its mangled name; otherwise return \c std::nullopt.
+  std::optional<StringRef>
+  lookupTypeToHideWhenEmittingModule(CanType type) const;
+
 private:
   friend class IntrinsicInfo;
   /// Retrieve an LLVMContext that is used for scratch space for intrinsic lookup.

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -662,6 +662,7 @@ struct ASTContext::Implementation {
   llvm::FoldingSet<SILBoxType> SILBoxTypes;
   llvm::FoldingSet<IntegerType> IntegerTypes;
   llvm::FoldingSet<HiddenType> HiddenTypes;
+  llvm::DenseMap<CanType, StringRef> TypesToHideWhenEmittingModule;
   llvm::DenseMap<BuiltinIntegerWidth, BuiltinIntegerType*> BuiltinIntegerTypes;
   llvm::DenseMap<unsigned, BuiltinUnboundGenericType*> BuiltinUnboundGenericTypes;
   llvm::FoldingSet<BuiltinVectorType> BuiltinVectorTypes;
@@ -3899,6 +3900,28 @@ HiddenType *HiddenType::get(const ASTContext &ctx, StringRef mangledName) {
 
   ctx.getImpl().HiddenTypes.InsertNode(hidden, insertPos);
   return hidden;
+}
+
+void ASTContext::recordTypeToHideWhenEmittingModule(CanType type,
+                                                    StringRef mangledName) {
+  // Allocate a stable copy so the StringRef survives even if the caller's
+  // storage for the mangled name is later moved or freed.
+  auto nameCopy = AllocateCopy(mangledName);
+  auto result =
+      getImpl().TypesToHideWhenEmittingModule.try_emplace(type, nameCopy);
+  if (!result.second) {
+    ASSERT(result.first->second == nameCopy &&
+           "conflicting hide-on-emit mangled names for the same type");
+  }
+}
+
+std::optional<StringRef>
+ASTContext::lookupTypeToHideWhenEmittingModule(CanType type) const {
+  auto &map = getImpl().TypesToHideWhenEmittingModule;
+  auto it = map.find(type);
+  if (it == map.end())
+    return std::nullopt;
+  return it->second;
 }
 
 BuiltinIntegerType *BuiltinIntegerType::get(BuiltinIntegerWidth BitWidth,

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -333,8 +333,15 @@ bool ExportContext::encapsulatedAsHiddenStoredProperty(
   // serialized into this module's hidden-type layouts block.
   if (auto *nominal = dyn_cast<NominalTypeDecl>(D)) {
     if (auto layout = computeClangAbstractLayout(nominal)) {
-      getDeclContext()->getParentModule()->recordHiddenTypeLayout(
+      auto *DC = getDeclContext();
+      DC->getParentModule()->recordHiddenTypeLayout(
           layout->mangledName, *layout);
+      // Also record the canonical type so the serializer can substitute a
+      // HiddenType placeholder for stored-property references in the emitted
+      // .swiftmodule, without re-mangling at every VarDecl serialization site.
+      DC->getASTContext().recordTypeToHideWhenEmittingModule(
+          nominal->getDeclaredInterfaceType()->getCanonicalType(),
+          layout->mangledName);
       return true;
     }
   }

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -4863,6 +4863,15 @@ public:
 
     unsigned numBackingProperties = 0;
     Type ty = var->getInterfaceType();
+    // If Sema marked this stored property's type as one to hide on emission
+    // swap in a HiddenType placeholder carrying just the mangled name. Clients of
+    // the emitted .swiftmodule will deserialize the HiddenType instead of the
+    // real type, breaking the link to the internal bridging-header dependency.
+    auto &ctx = var->getASTContext();
+    if (auto mangledName = ctx.lookupTypeToHideWhenEmittingModule(
+            ty->getCanonicalType())) {
+      ty = HiddenType::get(ctx, *mangledName);
+    }
     SmallVector<TypeID, 2> arrayFields;
     for (auto accessor : accessors.Decls)
       arrayFields.push_back(S.addDeclRef(accessor));

--- a/test/ClangImporter/InternalBridgingHeader/hide-type-on-emit.swift
+++ b/test/ClangImporter/InternalBridgingHeader/hide-type-on-emit.swift
@@ -1,0 +1,94 @@
+// REQUIRES: swift_feature_AbstractStoredPropertyLayout
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// 1. Build Library.swiftmodule with the internal bridging header.
+// RUN: %target-swift-frontend \
+// RUN:   -internal-import-bridging-header %t/Utility.h \
+// RUN:   -enable-experimental-feature AbstractStoredPropertyLayout \
+// RUN:   -emit-module -module-name Library \
+// RUN:   -o %t/Library.swiftmodule \
+// RUN:   %t/Library.swift
+
+// 2a. Writer's view (AST level): -print-ast of Library's source must still
+//     show the real Clang-imported types on the stored properties. If the
+//     substitution had mutated the AST in place, these would print as
+//     @_hidden("...") instead.
+// RUN: %target-swift-frontend \
+// RUN:   -internal-import-bridging-header %t/Utility.h \
+// RUN:   -enable-experimental-feature AbstractStoredPropertyLayout \
+// RUN:   -print-ast -module-name Library \
+// RUN:   %t/Library.swift | %FileCheck --check-prefix=AST %s
+
+// 2b. Writer's view (SIL level): emit Library's SILGen and confirm the stored
+//     property types reference the real imported types ($sSo7Wrappera /
+//     $sSo10BigWrappera). If the substitution had mutated the AST, SILGen
+//     would either fail or emit HiddenType references here.
+// RUN: %target-swift-frontend \
+// RUN:   -internal-import-bridging-header %t/Utility.h \
+// RUN:   -enable-experimental-feature AbstractStoredPropertyLayout \
+// RUN:   -emit-silgen -module-name Library \
+// RUN:   %t/Library.swift | %FileCheck --check-prefix=SIL %s
+
+// 3. Reader's view: print Library from a context that imports it without the
+//    bridging header. Stored properties of public types must appear as
+//    @_hidden("...") with the mangled name of the original Clang type.
+// RUN: %target-swift-ide-test -print-module -module-to-print Library \
+// RUN:   -I %t -source-filename=%t/Client.swift \
+// RUN:   | %FileCheck --check-prefix=READER %s
+
+//--- Utility.h
+typedef struct {
+  int value;
+} Wrapper;
+
+typedef struct {
+  double d;
+} BigWrapper;
+
+//--- Library.swift
+public struct S {
+  private var w: Wrapper
+  public init(value: Int32) {
+    w = Wrapper(value: value)
+  }
+}
+
+public struct S2 {
+  private var a: Wrapper
+  private var b: BigWrapper
+  public init() {
+    self.a = Wrapper(value: 0)
+    self.b = BigWrapper(d: 0)
+  }
+}
+
+//--- Client.swift
+import Library
+
+// Writer's view (AST): -print-ast of the source under compilation shows the
+// real imported types on the stored properties, not @_hidden placeholders.
+// AST-NOT: @_hidden
+// AST: public struct S {
+// AST:   private var w: Wrapper
+// AST: public struct S2 {
+// AST:   private var a: Wrapper
+// AST:   private var b: BigWrapper
+
+// Writer's view (SIL): SILGen still references the real Clang struct types via
+// their canonical mangled forms; no @_hidden appears in SIL.
+// SIL-NOT: @_hidden
+// SIL-DAG: $sSo7Wrappera
+// SIL-DAG: $sSo10BigWrappera
+
+// Reader's view: the printed module shows the substituted placeholders for
+// the hidden stored properties, anchored to the correct containing struct.
+// READER:      struct S {
+// READER-NEXT:   var w: @_hidden("$sSo7Wrappera")
+// READER-NEXT:   init(value: Int32)
+// READER-NEXT: }
+// READER:      struct S2 {
+// READER-NEXT:   var a: @_hidden("$sSo7Wrappera")
+// READER-NEXT:   var b: @_hidden("$sSo10BigWrappera")
+// READER-NEXT:   init()
+// READER-NEXT: }


### PR DESCRIPTION
The substitution is driven by a canonical type to mangled name table on ASTContext,
populated by exportability checking at the same site where the corresponding
diagnostics are suppressed. After this change, the module emitter and module
loader see hidden types differently: the emitter still sees the real types
defined in the bridging header, while the loader sees only a mangled name
wrapped in a HiddenType placeholder.