### PR TITLE
Implement withContiguousStorageIfAvailable for EmptyCollection and CollectionOfOne

### DIFF
--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift
@@ -2249,6 +2249,7 @@ public enum StdlibVersion: String {
   case stdlib_6_2  = "6.2"
   case stdlib_6_3  = "6.3"
   case stdlib_6_4  = "6.4"
+  case stdlib_6_5  = "6.5"
 
   var isAvailable: Bool {
     switch self {
@@ -2270,6 +2271,8 @@ public enum StdlibVersion: String {
       return if #available(SwiftStdlib 6.3, *)  { true } else { false }
     case .stdlib_6_4:
       return if #available(SwiftStdlib 6.4, *)  { true } else { false }
+    case .stdlib_6_5:
+      return if #available(SwiftStdlib 6.5, *)  { true } else { false }
     }
   }
 }

--- a/stdlib/public/core/CollectionOfOne.swift
+++ b/stdlib/public/core/CollectionOfOne.swift
@@ -160,9 +160,9 @@ extension CollectionOfOne: RandomAccessCollection, MutableCollection {
 
   @_alwaysEmitIntoClient
   @available(SwiftCompatibilitySpan 5.0, *)
-  public func withContiguousStorageIfAvailable<R>(
-    _ body: (UnsafeBufferPointer<Element>) throws -> R
-  ) rethrows -> R? {
+  public func withContiguousStorageIfAvailable<R, E>(
+    _ body: (UnsafeBufferPointer<Element>) throws(E) -> R
+  ) throws(E) -> R? {
     return try self.span.withUnsafeBufferPointer(body)
   }
 }

--- a/stdlib/public/core/CollectionOfOne.swift
+++ b/stdlib/public/core/CollectionOfOne.swift
@@ -157,13 +157,15 @@ extension CollectionOfOne: RandomAccessCollection, MutableCollection {
   public var count: Int {
     return 1
   }
+}
 
+extension CollectionOfOne {
   @_alwaysEmitIntoClient
   @available(SwiftCompatibilitySpan 5.0, *)
-  public func withContiguousStorageIfAvailable<R, E>(
+  public func withContiguousStorageIfAvailable<R: ~Copyable, E: Error>(
     _ body: (UnsafeBufferPointer<Element>) throws(E) -> R
   ) throws(E) -> R? {
-    return try self.span.withUnsafeBufferPointer(body)
+    try self.span.withUnsafeBufferPointer(body)
   }
 }
 

--- a/stdlib/public/core/CollectionOfOne.swift
+++ b/stdlib/public/core/CollectionOfOne.swift
@@ -161,11 +161,12 @@ extension CollectionOfOne: RandomAccessCollection, MutableCollection {
 
 extension CollectionOfOne {
   @_alwaysEmitIntoClient
-  @available(SwiftCompatibilitySpan 5.0, *)
   public func withContiguousStorageIfAvailable<R: ~Copyable, E: Error>(
     _ body: (UnsafeBufferPointer<Element>) throws(E) -> R
   ) throws(E) -> R? {
-    try self.span.withUnsafeBufferPointer(body)
+    try withUnsafePointer(to: _element) { pointer throws(E) -> R in
+      try unsafe body(UnsafeBufferPointer(start: pointer, count: 1))
+    }
   }
 }
 

--- a/stdlib/public/core/CollectionOfOne.swift
+++ b/stdlib/public/core/CollectionOfOne.swift
@@ -157,6 +157,14 @@ extension CollectionOfOne: RandomAccessCollection, MutableCollection {
   public var count: Int {
     return 1
   }
+
+  @_alwaysEmitIntoClient
+  @available(SwiftCompatibilitySpan 5.0, *)
+  public func withContiguousStorageIfAvailable<R>(
+    _ body: (UnsafeBufferPointer<Element>) throws -> R
+  ) rethrows -> R? {
+    return try self.span.withUnsafeBufferPointer(body)
+  }
 }
 
 @available(SwiftCompatibilitySpan 5.0, *)

--- a/stdlib/public/core/EmptyCollection.swift
+++ b/stdlib/public/core/EmptyCollection.swift
@@ -162,6 +162,13 @@ extension EmptyCollection: RandomAccessCollection, MutableCollection {
     _debugPrecondition(range == indices, "invalid range for an empty collection")
     _debugPrecondition(bounds == indices, "invalid bounds for an empty collection")
   }
+
+  @_alwaysEmitIntoClient
+  public func withContiguousStorageIfAvailable<R>(
+    _ body: (UnsafeBufferPointer<Element>) throws -> R
+  ) rethrows -> R? {
+    return try body(UnsafeBufferPointer<Element>(start: nil, count: 0))
+  }
 }
 
 extension EmptyCollection: Equatable {

--- a/stdlib/public/core/EmptyCollection.swift
+++ b/stdlib/public/core/EmptyCollection.swift
@@ -164,9 +164,9 @@ extension EmptyCollection: RandomAccessCollection, MutableCollection {
   }
 
   @_alwaysEmitIntoClient
-  public func withContiguousStorageIfAvailable<R>(
-    _ body: (UnsafeBufferPointer<Element>) throws -> R
-  ) rethrows -> R? {
+  public func withContiguousStorageIfAvailable<R, E>(
+    _ body: (UnsafeBufferPointer<Element>) throws(E) -> R
+  ) throws(E) -> R? {
     return try body(UnsafeBufferPointer<Element>(start: nil, count: 0))
   }
 }

--- a/stdlib/public/core/EmptyCollection.swift
+++ b/stdlib/public/core/EmptyCollection.swift
@@ -162,12 +162,14 @@ extension EmptyCollection: RandomAccessCollection, MutableCollection {
     _debugPrecondition(range == indices, "invalid range for an empty collection")
     _debugPrecondition(bounds == indices, "invalid bounds for an empty collection")
   }
+}
 
+extension EmptyCollection {
   @_alwaysEmitIntoClient
-  public func withContiguousStorageIfAvailable<R, E>(
+  public func withContiguousStorageIfAvailable<R: ~Copyable, E: Error>(
     _ body: (UnsafeBufferPointer<Element>) throws(E) -> R
   ) throws(E) -> R? {
-    return try body(UnsafeBufferPointer<Element>(start: nil, count: 0))
+    unsafe try body(UnsafeBufferPointer<Element>(start: nil, count: 0))
   }
 }
 

--- a/test/stdlib/CollectionOfOne.swift
+++ b/test/stdlib/CollectionOfOne.swift
@@ -30,4 +30,16 @@ if #available(SwiftStdlib 6.4, *) {
   }
 }
 
+OneTests.test("withContigousStorageIfAvailable")
+.require(.stdlib_6_5).code {
+
+  struct W: ~Copyable { let i: Int }
+
+  let one = CollectionOfOne(42)
+  let wrapped = one.withContiguousStorageIfAvailable({ W(i: $0.count + $0[0]) })
+  if let count = expectNotNil(wrapped) {
+    expectEqual(43, count.i)
+  }
+}
+
 runAllTests()

--- a/test/stdlib/EmptyCollection.swift
+++ b/test/stdlib/EmptyCollection.swift
@@ -26,5 +26,16 @@ if #available(SwiftStdlib 6.4, *) {
   }
 }
 
-runAllTests()
+testSuite.test("withContigousStorageIfAvailable")
+.require(.stdlib_6_5).code {
 
+  struct W: ~Copyable { let i: Int }
+
+  let zero = EmptyCollection<Int>()
+  let wrapped = zero.withContiguousStorageIfAvailable({ W(i: $0.count) })
+  if let count = expectNotNil(wrapped) {
+    expectEqual(0, count.i)
+  }
+}
+
+runAllTests()


### PR DESCRIPTION
`EmptyCollection` and `CollectionOfOne`, in addition to being used directly by some client code, are used in a variety of default implementations of `RangeReplaceableCollection` and similar protocol APIs. It's also common for APIs accepting a generic sequence (like some RRC APIs) to call `withContiguousStorageIfAvailable` in their implementations to provide a fast-path for contiguous storage.

Unfortunately, neither `EmptyCollection` nor `CollectionOfOne` implement `withContiguousStorageIfAvailable` today. `EmptyCollection` can trivially provide an empty buffer, and `CollectionOfOne` can use its `span` property to utilize compiler functionality that prevents a copy (if the value were not originally on the stack). With these additions, generic implementations can use these specialized fast paths for these trivial sequence types.
