### PR TITLE
[Sema] Handle invalid @_specialize generic signatures

### DIFF
--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -1395,6 +1395,20 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
     if (Options.printPublicInterface() && !attr->getSPIGroups().empty())
       return false;
 
+    SmallVector<Requirement, 4> requirementsScratch;
+    auto *FnDecl = dyn_cast_or_null<AbstractFunctionDecl>(D);
+    auto specializedSig = attr->getSpecializedSignature(FnDecl);
+    if (!specializedSig)
+      return false;
+
+    auto requirements = specializedSig.getRequirements();
+    if (FnDecl && FnDecl->getGenericSignature()) {
+      auto genericSig = FnDecl->getGenericSignature();
+
+      requirementsScratch = specializedSig.requirementsNotSatisfiedBy(genericSig);
+      requirements = requirementsScratch;
+    }
+
     Printer << "@" << getAttrName() << "(";
 
     // The non-underscored @specialize attribute currently does not support
@@ -1426,18 +1440,6 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
                                   true /*forAtSpecialize*/);
           Printer << "; ";
         }
-      }
-    }
-    SmallVector<Requirement, 4> requirementsScratch;
-    auto *FnDecl = dyn_cast_or_null<AbstractFunctionDecl>(D);
-    auto specializedSig = attr->getSpecializedSignature(FnDecl);
-    auto requirements = specializedSig.getRequirements();
-    if (FnDecl && FnDecl->getGenericSignature()) {
-      auto genericSig = FnDecl->getGenericSignature();
-
-      if (auto sig = specializedSig) {
-        requirementsScratch = sig.requirementsNotSatisfiedBy(genericSig);
-        requirements = requirementsScratch;
       }
     }
 

--- a/lib/AST/RequirementMachine/ConcreteTypeWitness.cpp
+++ b/lib/AST/RequirementMachine/ConcreteTypeWitness.cpp
@@ -181,6 +181,15 @@ void PropertyMap::concretizeNestedTypesFromConcreteParent(
       continue;
     }
 
+    if (conformance.isConcrete() && conformance.getConcrete()->isInvalid()) {
+      if (Debug.contains(DebugFlags::ConcretizeNestedTypes)) {
+        llvm::dbgs() << "^^ " << concreteType << " has an invalid conformance "
+                     << "to " << proto->getName() << "\n";
+      }
+
+      continue;
+    }
+
     auto concreteConformanceSymbol = Symbol::forConcreteConformance(
         concreteType, substitutions, proto, Context);
 
@@ -201,18 +210,11 @@ void PropertyMap::concretizeNestedTypesFromConcreteParent(
       continue;
     }
 
-    bool invalidTypeWitness = false;
     for (auto *assocType : proto->getAssociatedTypeMembers()) {
-      if (!concretizeTypeWitnessInConformance(key, requirementKind,
-                                              concreteConformanceSymbol,
-                                              concreteRuleID, conformanceRuleID,
-                                              conformance, assocType)) {
-        invalidTypeWitness = true;
-        break;
-      }
+      concretizeTypeWitnessInConformance(key, requirementKind,
+                                         concreteConformanceSymbol,
+                                         conformance, assocType);
     }
-    if (invalidTypeWitness)
-      continue;
 
     // We only infer conditional requirements in top-level generic signatures,
     // not in protocol requirement signatures.
@@ -222,11 +224,9 @@ void PropertyMap::concretizeNestedTypesFromConcreteParent(
   }
 }
 
-bool PropertyMap::concretizeTypeWitnessInConformance(
+void PropertyMap::concretizeTypeWitnessInConformance(
     Term key, RequirementKind requirementKind,
     Symbol concreteConformanceSymbol,
-    unsigned concreteRuleID,
-    unsigned conformanceRuleID,
     ProtocolConformanceRef conformance,
     AssociatedTypeDecl *assocType) const {
   auto concreteType = concreteConformanceSymbol.getConcreteType();
@@ -241,11 +241,6 @@ bool PropertyMap::concretizeTypeWitnessInConformance(
                  << " on " << concreteType << "\n";
   }
 
-  auto recordInvalidTypeWitness = [&] {
-    if (requirementKind == RequirementKind::SameType)
-      System.recordConflict(conformanceRuleID, concreteRuleID);
-  };
-
   CanType typeWitness;
   if (conformance.isConcrete()) {
     auto t = conformance.getConcrete()->getTypeWitness(assocType);
@@ -256,8 +251,7 @@ bool PropertyMap::concretizeTypeWitnessInConformance(
                      << " of " << concreteType << " could not be inferred\n";
       }
 
-      recordInvalidTypeWitness();
-      return false;
+      return;
     }
 
     typeWitness = t->getCanonicalType();
@@ -275,8 +269,7 @@ bool PropertyMap::concretizeTypeWitnessInConformance(
 
     typeWitness = archetype->getNestedType(assocType)->getCanonicalType();
   } else if (conformance.isInvalid()) {
-    recordInvalidTypeWitness();
-    return false;
+    return;
   }
 
   if (typeWitness->hasError()) {
@@ -285,8 +278,7 @@ bool PropertyMap::concretizeTypeWitnessInConformance(
                    << " of " << concreteType << " is invalid\n";
     }
 
-    recordInvalidTypeWitness();
-    return false;
+    return;
   }
 
   if (Debug.contains(DebugFlags::ConcretizeNestedTypes)) {
@@ -314,8 +306,6 @@ bool PropertyMap::concretizeTypeWitnessInConformance(
     llvm::dbgs() << "^^ Induced rule " << constraintType
                  << " => " << subjectType << "\n";
   }
-
-  return true;
 }
 
 /// Given the key of a property bag known to have \p concreteType,

--- a/lib/AST/RequirementMachine/ConcreteTypeWitness.cpp
+++ b/lib/AST/RequirementMachine/ConcreteTypeWitness.cpp
@@ -201,11 +201,18 @@ void PropertyMap::concretizeNestedTypesFromConcreteParent(
       continue;
     }
 
+    bool invalidTypeWitness = false;
     for (auto *assocType : proto->getAssociatedTypeMembers()) {
-      concretizeTypeWitnessInConformance(key, requirementKind,
-                                         concreteConformanceSymbol,
-                                         conformance, assocType);
+      if (!concretizeTypeWitnessInConformance(key, requirementKind,
+                                              concreteConformanceSymbol,
+                                              concreteRuleID, conformanceRuleID,
+                                              conformance, assocType)) {
+        invalidTypeWitness = true;
+        break;
+      }
     }
+    if (invalidTypeWitness)
+      continue;
 
     // We only infer conditional requirements in top-level generic signatures,
     // not in protocol requirement signatures.
@@ -215,9 +222,11 @@ void PropertyMap::concretizeNestedTypesFromConcreteParent(
   }
 }
 
-void PropertyMap::concretizeTypeWitnessInConformance(
+bool PropertyMap::concretizeTypeWitnessInConformance(
     Term key, RequirementKind requirementKind,
     Symbol concreteConformanceSymbol,
+    unsigned concreteRuleID,
+    unsigned conformanceRuleID,
     ProtocolConformanceRef conformance,
     AssociatedTypeDecl *assocType) const {
   auto concreteType = concreteConformanceSymbol.getConcreteType();
@@ -232,6 +241,11 @@ void PropertyMap::concretizeTypeWitnessInConformance(
                  << " on " << concreteType << "\n";
   }
 
+  auto recordInvalidTypeWitness = [&] {
+    if (requirementKind == RequirementKind::SameType)
+      System.recordConflict(conformanceRuleID, concreteRuleID);
+  };
+
   CanType typeWitness;
   if (conformance.isConcrete()) {
     auto t = conformance.getConcrete()->getTypeWitness(assocType);
@@ -242,7 +256,8 @@ void PropertyMap::concretizeTypeWitnessInConformance(
                      << " of " << concreteType << " could not be inferred\n";
       }
 
-      t = ErrorType::get(concreteType);
+      recordInvalidTypeWitness();
+      return false;
     }
 
     typeWitness = t->getCanonicalType();
@@ -260,7 +275,18 @@ void PropertyMap::concretizeTypeWitnessInConformance(
 
     typeWitness = archetype->getNestedType(assocType)->getCanonicalType();
   } else if (conformance.isInvalid()) {
-    typeWitness = CanType(ErrorType::get(Context.getASTContext()));
+    recordInvalidTypeWitness();
+    return false;
+  }
+
+  if (typeWitness->hasError()) {
+    if (Debug.contains(DebugFlags::ConcretizeNestedTypes)) {
+      llvm::dbgs() << "^^ " << "Type witness for " << assocType->getName()
+                   << " of " << concreteType << " is invalid\n";
+    }
+
+    recordInvalidTypeWitness();
+    return false;
   }
 
   if (Debug.contains(DebugFlags::ConcretizeNestedTypes)) {
@@ -288,6 +314,8 @@ void PropertyMap::concretizeTypeWitnessInConformance(
     llvm::dbgs() << "^^ Induced rule " << constraintType
                  << " => " << subjectType << "\n";
   }
+
+  return true;
 }
 
 /// Given the key of a property bag known to have \p concreteType,

--- a/lib/AST/RequirementMachine/InterfaceType.cpp
+++ b/lib/AST/RequirementMachine/InterfaceType.cpp
@@ -225,7 +225,8 @@ AssociatedTypeDecl *PropertyBag::getAssociatedType(Identifier name) {
     }
   }
 
-  ASSERT(assocType != nullptr && "Need to look harder");
+  if (assocType == nullptr)
+    return nullptr;
 
   auto inserted = AssocTypes.insert(std::make_pair(name, assocType)).second;
   ASSERT(inserted);
@@ -239,6 +240,8 @@ getTypeForSymbolRange(const Symbol *begin, const Symbol *end,
                       ArrayRef<GenericTypeParamType *> genericParams,
                       const PropertyMap &map) {
   auto &ctx = map.getRewriteContext();
+  auto &astCtx = ctx.getASTContext();
+  auto getErrorType = [&] { return ErrorType::get(astCtx); };
   Type result;
 
   auto handleRoot = [&](GenericTypeParamType *genericParam) {
@@ -348,6 +351,9 @@ getTypeForSymbolRange(const Symbol *begin, const Symbol *end,
 
     auto *props = map.lookUpProperties(prefix.rbegin(), prefix.rend());
     if (props == nullptr) {
+      if (astCtx.hadError())
+        return getErrorType();
+
       ABORT([&](auto &out) {
         out << "Cannot build interface type for term "
             << MutableTerm(begin, end) << "\n";
@@ -358,15 +364,29 @@ getTypeForSymbolRange(const Symbol *begin, const Symbol *end,
 
     // Assert that the associated type's protocol appears among the set
     // of protocols that the prefix conforms to.
-    if (CONDITIONAL_ASSERT_enabled()) {
-      auto conformsTo = props->getConformsTo();
-      ASSERT(std::find(conformsTo.begin(), conformsTo.end(),
-                       symbol.getProtocol())
-             != conformsTo.end());
+    auto conformsTo = props->getConformsTo();
+    if (std::find(conformsTo.begin(), conformsTo.end(),
+                  symbol.getProtocol()) == conformsTo.end()) {
+      if (astCtx.hadError())
+        return getErrorType();
+
+      ABORT([&](auto &out) {
+        out << "Cannot build interface type for term "
+            << MutableTerm(begin, end) << "\n";
+        out << "Prefix does not conform to "
+            << symbol.getProtocol()->getName() << ": " << prefix << "\n";
+        out << "Property map entry: ";
+        props->dump(out);
+        out << "\n\n";
+        map.dump(out);
+      });
     }
 
     auto *assocType = props->getAssociatedType(symbol.getName());
     if (assocType == nullptr) {
+      if (astCtx.hadError())
+        return getErrorType();
+
       ABORT([&](auto &out) {
         out << "Cannot build interface type for term "
             << MutableTerm(begin, end) << "\n";

--- a/lib/AST/RequirementMachine/PropertyMap.h
+++ b/lib/AST/RequirementMachine/PropertyMap.h
@@ -279,11 +279,9 @@ private:
                    ArrayRef<unsigned> conformsToRules,
                    ArrayRef<const ProtocolDecl *> conformsTo);
 
-  bool concretizeTypeWitnessInConformance(
+  void concretizeTypeWitnessInConformance(
                    Term key, RequirementKind requirementKind,
                    Symbol concreteConformanceSymbol,
-                   unsigned concreteRuleID,
-                   unsigned conformanceRuleID,
                    ProtocolConformanceRef conformance,
                    AssociatedTypeDecl *assocType) const;
 

--- a/lib/AST/RequirementMachine/PropertyMap.h
+++ b/lib/AST/RequirementMachine/PropertyMap.h
@@ -279,9 +279,11 @@ private:
                    ArrayRef<unsigned> conformsToRules,
                    ArrayRef<const ProtocolDecl *> conformsTo);
 
-  void concretizeTypeWitnessInConformance(
+  bool concretizeTypeWitnessInConformance(
                    Term key, RequirementKind requirementKind,
                    Symbol concreteConformanceSymbol,
+                   unsigned concreteRuleID,
+                   unsigned conformanceRuleID,
                    ProtocolConformanceRef conformance,
                    AssociatedTypeDecl *assocType) const;
 

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -3562,7 +3562,9 @@ void AttributeChecker::visitAbstractSpecializeAttr(AbstractSpecializeAttr *attr)
     return;
   }
 
-  (void)attr->getSpecializedSignature(FD);
+  auto specializedSig = attr->getSpecializedSignature(FD);
+  if (!specializedSig || attr->isInvalid())
+    return;
 
   // Force resolution of interface types written in requirements here to check
   // that generic types satisfy generic requirements, and so on.
@@ -3593,9 +3595,27 @@ SerializeAttrGenericSignatureRequest::evaluate(Evaluator &evaluator,
       /*forExtension=*/nullptr,
       ExpandDefaults};
 
-  auto specializedSig = evaluateOrDefault(Ctx.evaluator, request,
-                                          GenericSignatureWithError())
-      .getPointer();
+  auto specializedSigWithError = evaluateOrDefault(
+      Ctx.evaluator, request, GenericSignatureWithError());
+  auto specializedSig = specializedSigWithError.getPointer();
+  if (!specializedSig) {
+    attr->setInvalid();
+    return nullptr;
+  }
+
+  auto errors = specializedSigWithError.getInt();
+  if (errors.contains(GenericSignatureErrorFlags::HasInvalidRequirements) ||
+      errors.contains(GenericSignatureErrorFlags::CompletionFailed) ||
+      errors.contains(GenericSignatureErrorFlags::CircularReference)) {
+    attr->setInvalid();
+    return nullptr;
+  }
+
+  if (llvm::any_of(specializedSig.getRequirements(),
+                   [](Requirement req) { return req.hasError(); })) {
+    attr->setInvalid();
+    return nullptr;
+  }
 
   // Check the validity of provided requirements.
   checkSpecializeAttrRequirements(attr, genericSig, specializedSig, Ctx);

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -3562,15 +3562,18 @@ void AttributeChecker::visitAbstractSpecializeAttr(AbstractSpecializeAttr *attr)
     return;
   }
 
-  auto specializedSig = attr->getSpecializedSignature(FD);
-  if (!specializedSig || attr->isInvalid())
-    return;
-
   // Force resolution of interface types written in requirements here to check
   // that generic types satisfy generic requirements, and so on.
   WhereClauseOwner(FD, attr)
       .visitRequirements(TypeResolutionStage::Interface,
                          [](Requirement, RequirementRepr *) { return false; });
+
+  if (FD->getASTContext().hadError())
+    return;
+
+  auto specializedSig = attr->getSpecializedSignature(FD);
+  if (!specializedSig)
+    return;
 }
 
 GenericSignature
@@ -3583,6 +3586,9 @@ SerializeAttrGenericSignatureRequest::evaluate(Evaluator &evaluator,
   auto &Ctx = FD->getASTContext();
   auto genericSig = FD->getGenericSignature();
   if (!genericSig)
+    return nullptr;
+
+  if (Ctx.hadError())
     return nullptr;
 
   InferredGenericSignatureRequest request{
@@ -3598,24 +3604,18 @@ SerializeAttrGenericSignatureRequest::evaluate(Evaluator &evaluator,
   auto specializedSigWithError = evaluateOrDefault(
       Ctx.evaluator, request, GenericSignatureWithError());
   auto specializedSig = specializedSigWithError.getPointer();
-  if (!specializedSig) {
-    attr->setInvalid();
+  if (!specializedSig)
     return nullptr;
-  }
 
   auto errors = specializedSigWithError.getInt();
   if (errors.contains(GenericSignatureErrorFlags::HasInvalidRequirements) ||
       errors.contains(GenericSignatureErrorFlags::CompletionFailed) ||
-      errors.contains(GenericSignatureErrorFlags::CircularReference)) {
-    attr->setInvalid();
+      errors.contains(GenericSignatureErrorFlags::CircularReference))
     return nullptr;
-  }
 
   if (llvm::any_of(specializedSig.getRequirements(),
-                   [](Requirement req) { return req.hasError(); })) {
-    attr->setInvalid();
+                   [](Requirement req) { return req.hasError(); }))
     return nullptr;
-  }
 
   // Check the validity of provided requirements.
   checkSpecializeAttrRequirements(attr, genericSig, specializedSig, Ctx);

--- a/validation-test/compiler_crashers/getTypeForSymbolRange-specialize-ambiguous-associated-type.swift
+++ b/validation-test/compiler_crashers/getTypeForSymbolRange-specialize-ambiguous-associated-type.swift
@@ -1,0 +1,27 @@
+// {"kind":"typecheck","signature":"getTypeForSymbolRange(swift::rewriting::Symbol const*, swift::rewriting::Symbol const*, llvm::ArrayRef<swift::GenericTypeParamType*>, swift::rewriting::PropertyMap const&)","signatureAssert":"Assertion failed: (std::find(conformsTo.begin(), conformsTo.end(), symbol.getProtocol()) != conformsTo.end()), function getTypeForSymbolRange"}
+// RUN: not --crash %target-swift-frontend -typecheck %s
+
+public protocol P1 {
+  associatedtype DP1
+  associatedtype DP11
+}
+
+public protocol P2 {
+  associatedtype DP2: P1
+}
+
+public struct H<T> {}
+
+public struct MyStruct3: P1 {
+  public typealias DP1 = Int
+  public typealias DP11 = H<Int>
+}
+
+public struct MyStruct4: P2 {
+  public typealias DP2 = MyStruct3
+}
+
+@_specialize(where T == MyStruct4)
+public func foo<T: P2>(_ t: T) where T.DP2.DP11 == H<T.DP2.DP1> {}
+
+struct MyStruct3 {}


### PR DESCRIPTION
- **Explanation**:
Invalid `@_specialize` generic signatures are now rejected gracefully instead of crashing during interface type reconstruction.

- **Scope**:
Updates specialize attribute validation, printing, and requirement-machine recovery for invalid associated type witnesses.

- **Issues**:
Resolves https://github.com/swiftlang/swift/issues/89154

- **Risk**:
Low. The change is limited to invalid-signature recovery after diagnostics have already been emitted.

- **Testing**:
Added a reduced crash regression test on macOS.