### PR TITLE
[Concurrency] Avoid availability troubles in different CIs

### DIFF
--- a/test/Concurrency/Runtime/noncopyable_continuation.swift
+++ b/test/Concurrency/Runtime/noncopyable_continuation.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift( -target %target-swift-5.1-abi-triple -parse-as-library) 2>&1 | %FileCheck %s
+// RUN: %target-run-simple-swift( -target %target-swift-5.1-abi-triple -parse-as-library -disable-availability-checking) 2>&1 | %FileCheck %s
 
 // REQUIRES: executable_test
 // REQUIRES: concurrency
@@ -25,229 +25,227 @@ struct UniqueResource: ~Copyable {
   static func main() async {
     let tests = TestSuite("Continuation: ~Copyable")
 
-    if #available(SwiftStdlib 6.4, *) {
-      #if !os(WASI)
-      tests.test("trap on dropped continuation") {
-        expectCrashLater()
+    #if !os(WASI)
+    tests.test("trap on dropped continuation") {
+      expectCrashLater()
 
-        let task = Task.detached {
-          let _: Void = await withContinuation { c in
-            _ = consume c // don't do this
-          }
+      let task = Task.detached {
+        let _: Void = await withContinuation { c in
+          _ = consume c // don't do this
         }
-        await task.value
       }
+      await task.value
+    }
 
-      tests.test("trap on dropped throwing continuation") {
-        expectCrashLater()
+    tests.test("trap on dropped throwing continuation") {
+      expectCrashLater()
 
-        do {
-          let _: Void = try await withContinuation(of: Void.self, throwing: (any Error).self) { c in
-            _ = consume c // bad! should have resumed
-          }
-        } catch {}
+      do {
+        let _: Void = try await withContinuation(of: Void.self, throwing: (any Error).self) { c in
+          _ = consume c // bad! should have resumed
+        }
+      } catch {}
+    }
+    #endif
+
+    tests.test("resume returning value") {
+      let value: Int = await withContinuation { c in
+        c.resume(returning: 42)
       }
-      #endif
+      expectEqual(42, value)
+    }
 
-      tests.test("resume returning value") {
-        let value: Int = await withContinuation { c in
+    tests.test("resume void") {
+      await withContinuation { c in
+        c.resume()
+      }
+    }
+
+    tests.test("throwing continuation resume returning") {
+      do {
+        let value: Int = try await withContinuation(of: Int.self, throwing: (any Error).self) { c in
           c.resume(returning: 42)
         }
         expectEqual(42, value)
+      } catch {
+        expectUnreachable()
       }
+    }
 
-      tests.test("resume void") {
-        await withContinuation { c in
-          c.resume()
+    tests.test("throwing continuation resume throwing") {
+      do {
+        let _: Int = try await withContinuation(of: Int.self, throwing: (any Error).self) { c in
+          c.resume(throwing: TestError())
         }
+        expectUnreachable()
+      } catch {
+        // Expected
       }
+    }
 
-      tests.test("throwing continuation resume returning") {
-        do {
-          let value: Int = try await withContinuation(of: Int.self, throwing: (any Error).self) { c in
-            c.resume(returning: 42)
-          }
-          expectEqual(42, value)
-        } catch {
-          expectUnreachable()
+    tests.test("resume with result success") {
+      let value: Int = try! await withContinuation(of: Int.self, throwing: (any Error).self) { c in
+        c.resume(with: .success(17))
+      }
+      expectEqual(17, value)
+    }
+
+    tests.test("resume with result failure") {
+      do {
+        let _: Int = try await withContinuation(of: Int.self, throwing: (any Error).self) { c in
+          c.resume(with: .failure(TestError()))
         }
+        expectUnreachable()
+      } catch {
+        // Expected
       }
+    }
 
-      tests.test("throwing continuation resume throwing") {
-        do {
-          let _: Int = try await withContinuation(of: Int.self, throwing: (any Error).self) { c in
-            c.resume(throwing: TestError())
-          }
-          expectUnreachable()
-        } catch {
-          // Expected
-        }
+    // MARK: Conversion to CheckedContinuation
+
+    tests.test("convert to CheckedContinuation and resume returning") {
+      let value: Int = await withContinuation { c in
+        let checked = CheckedContinuation(c)
+        checked.resume(returning: 42)
       }
+      expectEqual(42, value)
+    }
 
-      tests.test("resume with result success") {
-        let value: Int = try! await withContinuation(of: Int.self, throwing: (any Error).self) { c in
-          c.resume(with: .success(17))
-        }
-        expectEqual(17, value)
-      }
-
-      tests.test("resume with result failure") {
-        do {
-          let _: Int = try await withContinuation(of: Int.self, throwing: (any Error).self) { c in
-            c.resume(with: .failure(TestError()))
-          }
-          expectUnreachable()
-        } catch {
-          // Expected
-        }
-      }
-
-      // MARK: Conversion to CheckedContinuation
-
-      tests.test("convert to CheckedContinuation and resume returning") {
-        let value: Int = await withContinuation { c in
+    tests.test("convert throwing to CheckedContinuation and resume returning") {
+      do {
+        let value: Int = try await withContinuation(of: Int.self, throwing: (any Error).self) { c in
           let checked = CheckedContinuation(c)
-          checked.resume(returning: 42)
+          checked.resume(returning: 99)
         }
-        expectEqual(42, value)
+        expectEqual(99, value)
+      } catch {
+        expectUnreachable()
       }
+    }
 
-      tests.test("convert throwing to CheckedContinuation and resume returning") {
-        do {
-          let value: Int = try await withContinuation(of: Int.self, throwing: (any Error).self) { c in
-            let checked = CheckedContinuation(c)
-            checked.resume(returning: 99)
-          }
-          expectEqual(99, value)
-        } catch {
-          expectUnreachable()
+    tests.test("convert throwing to CheckedContinuation and resume throwing") {
+      do {
+        let _: Int = try await withContinuation(of: Int.self, throwing: (any Error).self) { c in
+          let checked = CheckedContinuation(c)
+          checked.resume(throwing: TestError())
         }
+        expectUnreachable()
+      } catch {
+        // Expected
       }
+    }
 
-      tests.test("convert throwing to CheckedContinuation and resume throwing") {
-        do {
-          let _: Int = try await withContinuation(of: Int.self, throwing: (any Error).self) { c in
-            let checked = CheckedContinuation(c)
-            checked.resume(throwing: TestError())
-          }
-          expectUnreachable()
-        } catch {
-          // Expected
+    tests.test("convert typed-throws to CheckedContinuation and resume throwing") {
+      struct MyCoolError: Error, Equatable {}
+      do {
+        try await withContinuation(of: Void.self, throwing: MyCoolError.self) { c in
+          let checked = CheckedContinuation(c)
+          checked.resume(throwing: MyCoolError())
         }
+        expectUnreachable()
+      } catch let error as MyCoolError {
+        expectEqual(MyCoolError(), error)
+      } catch {
+        expectUnreachable()
       }
+    }
 
-      tests.test("convert typed-throws to CheckedContinuation and resume throwing") {
-        struct MyCoolError: Error, Equatable {}
-        do {
-          try await withContinuation(of: Void.self, throwing: MyCoolError.self) { c in
-            let checked = CheckedContinuation(c)
-            checked.resume(throwing: MyCoolError())
-          }
-          expectUnreachable()
-        } catch let error as MyCoolError {
-          expectEqual(MyCoolError(), error)
-        } catch {
-          expectUnreachable()
-        }
+    // MARK: Conversion to UnsafeContinuation
+
+    tests.test("convert to UnsafeContinuation and resume returning") {
+      let value: Int = await withContinuation { c in
+        let uc = UnsafeContinuation(c)
+        uc.resume(returning: 7)
       }
+      expectEqual(7, value)
+    }
 
-      // MARK: Conversion to UnsafeContinuation
-
-      tests.test("convert to UnsafeContinuation and resume returning") {
-        let value: Int = await withContinuation { c in
+    tests.test("convert throwing to UnsafeContinuation and resume returning") {
+      do {
+        let value: Int = try await withContinuation(of: Int.self, throwing: (any Error).self) { c in
           let uc = UnsafeContinuation(c)
-          uc.resume(returning: 7)
+          uc.resume(returning: 55)
         }
-        expectEqual(7, value)
+        expectEqual(55, value)
+      } catch {
+        expectUnreachable()
       }
+    }
 
-      tests.test("convert throwing to UnsafeContinuation and resume returning") {
-        do {
-          let value: Int = try await withContinuation(of: Int.self, throwing: (any Error).self) { c in
-            let uc = UnsafeContinuation(c)
-            uc.resume(returning: 55)
-          }
-          expectEqual(55, value)
-        } catch {
-          expectUnreachable()
+    tests.test("convert throwing to UnsafeContinuation and resume throwing") {
+      do {
+        let _: Int = try await withContinuation(of: Int.self, throwing: (any Error).self) { c in
+          let uc = UnsafeContinuation(c)
+          uc.resume(throwing: TestError())
         }
+        expectUnreachable()
+      } catch {
+        // Expected
       }
+    }
 
-      tests.test("convert throwing to UnsafeContinuation and resume throwing") {
-        do {
-          let _: Int = try await withContinuation(of: Int.self, throwing: (any Error).self) { c in
-            let uc = UnsafeContinuation(c)
-            uc.resume(throwing: TestError())
-          }
-          expectUnreachable()
-        } catch {
-          // Expected
-        }
+    tests.test("noncopyable resume returning value") {
+      let resource: UniqueResource = await withContinuation { c in
+        c.resume(returning: UniqueResource(99))
+        print("non-throwing resume done")
+        // CHECK: non-throwing resume done
       }
+      print("non-throwing resumed with: \(resource.value)")
+      // CHECK: non-throwing resumed with: 99
+      expectEqual(99, resource.value)
+      _ = consume resource
+      // CHECK: UniqueResource(99).deinit
+    }
 
-      tests.test("noncopyable resume returning value") {
-        let resource: UniqueResource = await withContinuation { c in
-          c.resume(returning: UniqueResource(99))
-          print("non-throwing resume done")
-          // CHECK: non-throwing resume done
+    tests.test("noncopyable throwing continuation resume returning") {
+      do {
+        let resource: UniqueResource = try await withContinuation(of: UniqueResource.self, throwing: (any Error).self) { c in
+          c.resume(returning: UniqueResource(77))
+          print("throwing resume done")
+          // CHECK: throwing resume done
         }
-        print("non-throwing resumed with: \(resource.value)")
-        // CHECK: non-throwing resumed with: 99
-        expectEqual(99, resource.value)
+        print("throwing resumed with: \(resource.value)")
+        // CHECK: throwing resumed with: 77
+        expectEqual(77, resource.value)
         _ = consume resource
-        // CHECK: UniqueResource(99).deinit
+        // CHECK: UniqueResource(77).deinit
+      } catch {
+        expectUnreachable()
       }
+    }
 
-      tests.test("noncopyable throwing continuation resume returning") {
-        do {
-          let resource: UniqueResource = try await withContinuation(of: UniqueResource.self, throwing: (any Error).self) { c in
-            c.resume(returning: UniqueResource(77))
-            print("throwing resume done")
-            // CHECK: throwing resume done
-          }
-          print("throwing resumed with: \(resource.value)")
-          // CHECK: throwing resumed with: 77
-          expectEqual(77, resource.value)
-          _ = consume resource
-          // CHECK: UniqueResource(77).deinit
-        } catch {
-          expectUnreachable()
+    tests.test("noncopyable throwing continuation resume throwing") {
+      do {
+        let _: UniqueResource = try await withContinuation(of: UniqueResource.self, throwing: (any Error).self) { c in
+          c.resume(throwing: TestError())
         }
+        expectUnreachable()
+      } catch {
+        // Expected
       }
+    }
 
-      tests.test("noncopyable throwing continuation resume throwing") {
-        do {
-          let _: UniqueResource = try await withContinuation(of: UniqueResource.self, throwing: (any Error).self) { c in
-            c.resume(throwing: TestError())
-          }
-          expectUnreachable()
-        } catch {
-          // Expected
-        }
+    tests.test("noncopyable resume with result success") {
+      let resource: UniqueResource = try! await withContinuation(of: UniqueResource.self, throwing: (any Error).self) { c in
+        c.resume(with: .success(UniqueResource(55)))
+        print("result resume done")
+        // CHECK: result resume done
       }
+      print("result resumed with: \(resource.value)")
+      // CHECK: result resumed with: 55
+      expectEqual(55, resource.value)
+      _ = consume resource
+      // CHECK: UniqueResource(55).deinit
+    }
 
-      tests.test("noncopyable resume with result success") {
-        let resource: UniqueResource = try! await withContinuation(of: UniqueResource.self, throwing: (any Error).self) { c in
-          c.resume(with: .success(UniqueResource(55)))
-          print("result resume done")
-          // CHECK: result resume done
+    tests.test("noncopyable resume with result failure") {
+      do {
+        let _: UniqueResource = try await withContinuation(of: UniqueResource.self, throwing: (any Error).self) { c in
+          c.resume(with: .failure(TestError()))
         }
-        print("result resumed with: \(resource.value)")
-        // CHECK: result resumed with: 55
-        expectEqual(55, resource.value)
-        _ = consume resource
-        // CHECK: UniqueResource(55).deinit
-      }
-
-      tests.test("noncopyable resume with result failure") {
-        do {
-          let _: UniqueResource = try await withContinuation(of: UniqueResource.self, throwing: (any Error).self) { c in
-            c.resume(with: .failure(TestError()))
-          }
-          expectUnreachable()
-        } catch {
-          // Expected
-        }
+        expectUnreachable()
+      } catch {
+        // Expected
       }
     }
 


### PR DESCRIPTION
In the noncopyable_continuation test the availability being different on differnet runtimes has sometimes caused the CHECK to fail since the availability didn't trigger correctly.

resolves rdar://177255768

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
