### PR TITLE
SimplifyPointerToAddress: always remove `address_to_pointer`-`pointer_to_address` pairs with matching types

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyPointerToAddress.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyPointerToAddress.swift
@@ -37,7 +37,6 @@ private func removeAddressToPointerToAddressPair(
   _ context: SimplifyContext
 ) -> Bool {
   guard let addr2Ptr = ptr2Addr.pointer as? AddressToPointerInst,
-        ptr2Addr.isStrict,
         !ptr2Addr.hasIllegalUsesAfterLifetime(of: addr2Ptr, context)
   else {
     return false
@@ -45,11 +44,14 @@ private func removeAddressToPointerToAddressPair(
 
   if ptr2Addr.type == addr2Ptr.address.type {
     ptr2Addr.replace(with: addr2Ptr.address, context)
-  } else {
+    return true
+  }
+  if ptr2Addr.isStrict {
     let cast = Builder(before: ptr2Addr, context).createUncheckedAddrCast(from: addr2Ptr.address, to: ptr2Addr.type)
     ptr2Addr.replace(with: cast, context)
+    return true
   }
-  return true
+  return false
 }
 
 /// Replace an `index_raw_pointer` with a manually computed stride with `index_addr`:

--- a/test/SILOptimizer/simplify_pointer_to_address.sil
+++ b/test/SILOptimizer/simplify_pointer_to_address.sil
@@ -37,18 +37,32 @@ bb0(%0 : $*Int):
   return %3 : $Bool
 }
 
-// CHECK-LABEL: sil @no_strict :
+// CHECK-LABEL: sil @matching_type_no_strict :
+// CHECK-NOT:     address_to_pointer
+// CHECK-NOT:     pointer_to_address
+// CHECK:         [[L:%.*]] = load %0
+// CHECK:         return [[L]]
+// CHECK:       } // end sil function 'matching_type_no_strict'
+sil @matching_type_no_strict : $@convention(thin) (@in Int) -> Int {
+bb0(%0 : $*Int):
+  %1 = address_to_pointer %0 to $Builtin.RawPointer
+  %2 = pointer_to_address %1 to $*Int
+  %3 = load %2
+  return %3
+}
+
+// CHECK-LABEL: sil @mismatching_type_no_strict :
 // CHECK:         address_to_pointer
 // CHECK:         [[A:%.*]] = pointer_to_address
 // CHECK:         [[L:%.*]] = load [[A]]
 // CHECK:         return [[L]]
-// CHECK:       } // end sil function 'no_strict'
-sil @no_strict : $@convention(thin) (@in Int) -> Int {
+// CHECK:       } // end sil function 'mismatching_type_no_strict'
+sil @mismatching_type_no_strict : $@convention(thin) (@in Int) -> Bool {
 bb0(%0 : $*Int):
-  %1 = address_to_pointer %0 : $*Int to $Builtin.RawPointer
-  %2 = pointer_to_address %1 : $Builtin.RawPointer to $*Int
-  %3 = load %2 : $*Int
-  return %3 : $Int
+  %1 = address_to_pointer %0 to $Builtin.RawPointer
+  %2 = pointer_to_address %1 to $*Bool
+  %3 = load %2
+  return %3
 }
 
 // CHECK-LABEL: sil [ossa] @borrow_escape :


### PR DESCRIPTION
Don't require the `strict` flag when removing `address_to_pointer`-`pointer_to_address` pairs with matching types

rdar://177220346
