### PR TITLE
Remove deprecated PrintCSEInternals flag

### DIFF
--- a/utils/check-incremental
+++ b/utils/check-incremental
@@ -106,9 +106,6 @@ def main():
       '-Xllvm', '-print-no-uuids',
       '-Xllvm', '-sil-print-pass-md5']
 
-    new_args += [
-      '-Xllvm', '-print-cse-internals']
-
     if EMIT_IR:
       new_args += [
         '-Xllvm', '-save-sil', '-Xllvm', output_file + '.sil',


### PR DESCRIPTION
Resolves rdar://177222636

The -print-cse-internals flag was deprecated as a part of the Swift rewrite of the CSE pass.
It was still being used in [utils/check-incremental](https://github.com/swiftlang/swift/blob/2ed7079b9bdf4f2583577c4fb37b5881af65236b/utils/check-incremental#L109-L110).