### PR TITLE
[DebugInfo] Prepend deref to existing DebugValueInsts

### DIFF
--- a/docs/HowToUpdateDebugInfo.md
+++ b/docs/HowToUpdateDebugInfo.md
@@ -136,8 +136,8 @@ debug_value %0 : $*T, var, name "value", expr op_deref
 SILGen should always use `SILBuilder::emitDebugDescription` to create debug
 values, which will automatically add an op_deref depending on the type of the
 SSA value. As there are no pointers in Swift, this will always do the right
-thing. In SIL passes, use `SILBuilder::createDebugValue` to create debug values,
-or `SILBuilder::createDebugValueAddr` to prepend an op_deref.
+thing. In SIL passes, use `DebugValueInst::prependDeref` to prepend a deref
+to an existing debug_value instruction.
 
 For any computation more complex than a simple dereference, [Debug Reconstruction Basic Blocks](SIL/DebugBasicBlocks.md) should be used.
 

--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -1080,10 +1080,6 @@ public:
       PoisonRefs_t poisonRefs = DontPoisonRefs,
       UsesMoveableValueDebugInfo_t wasMoved = DoesNotUseMoveableValueDebugInfo,
       bool trace = false, bool overrideLoc = true);
-  DebugValueInst *createDebugValueAddr(
-      SILLocation Loc, SILValue src, SILDebugVariable Var,
-      UsesMoveableValueDebugInfo_t wasMoved = DoesNotUseMoveableValueDebugInfo,
-      bool trace = false);
 
   DebugStepInst *createDebugStep(SILLocation Loc) {
     return insert(new (getModule()) DebugStepInst(getSILDebugLocation(Loc)));
@@ -1092,8 +1088,10 @@ public:
   /// Create a debug_value according to the type of \p src
   DebugValueInst *emitDebugDescription(SILLocation Loc, SILValue src,
                                        SILDebugVariable Var) {
-    if (src->getType().isAddress())
-      return createDebugValueAddr(Loc, src, Var);
+    if (src->getType().isAddress()) {
+      Var.DIExpr.prependElements(
+        {SILDIExprElement::createOperator(SILDIExprOperator::Dereference)});
+    }
     return createDebugValue(Loc, src, Var);
   }
 

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -5632,10 +5632,6 @@ class DebugValueInst final
                                 PoisonRefs_t poisonRefs,
                                 UsesMoveableValueDebugInfo_t operandWasMoved,
                                 bool trace);
-  static DebugValueInst *createAddr(SILDebugLocation DebugLoc, SILValue Operand,
-                                    SILModule &M, SILDebugVariable Var,
-                                    UsesMoveableValueDebugInfo_t wasMoved,
-                                    bool trace);
 
   SIL_DEBUG_VAR_SUPPLEMENT_TRAILING_OBJS_IMPL()
 

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -5705,6 +5705,16 @@ public:
     llvm::ArrayRef<SILDIExprElement> DIExprElements(
         getTrailingObjects<SILDIExprElement>(), NumDIExprOperands);
 
+    // Make a temporary copy to prepend a deref. This is safe as
+    // SILDebugVariable contains a copy of the expression.
+    llvm::SmallVector<SILDIExprElement, 4> DIExprCopy;
+    if (sharedUInt8().DebugValueInst.prependDeref) {
+      DIExprCopy.push_back(SILDIExprElement::createOperator(
+          SILDIExprOperator::Dereference));
+      DIExprCopy.append(DIExprElements.begin(), DIExprElements.end());
+      DIExprElements = DIExprCopy;
+    }
+
     return VarInfo.get(getDecl(), getTrailingObjects<char>(), AuxVarType,
                        VarDeclLoc, VarDeclScope, DIExprElements);
   }
@@ -5736,9 +5746,12 @@ public:
     return DVI && DVI->hasAddrVal()? DVI : nullptr;
   }
 
-  /// Whether the attached di-expression (if there is any) starts
-  /// with `op_deref`.
-  bool exprStartsWithDeref() const;
+  /// Prepends a deref operator to this debug_value in place.
+  /// This must be called when the operand is changed from an object type to
+  /// an address type (when moved to the stack, for example).
+  /// If a reconstruction block exists, a load is added at the beginning.
+  /// Otherwise, it will be prepended to the DIExpr.
+  void prependDeref();
 
   /// Validates the type chain of the DIExpr.
   /// Starting from VarType, narrows through fragments (outermost first)

--- a/include/swift/SIL/SILNode.h
+++ b/include/swift/SIL/SILNode.h
@@ -222,7 +222,8 @@ protected:
     SHARED_FIELD(DebugValueInst, uint8_t
                  poisonRefs : 1,
                  usesMoveableValueDebugInfo : 1,
-                 trace : 1);
+                 trace : 1,
+                 prependDeref : 1);
 
     SHARED_FIELD(AllocStackInst, uint8_t
                  dynamicLifetime : 1,

--- a/lib/IRGen/LoadableByAddress.cpp
+++ b/lib/IRGen/LoadableByAddress.cpp
@@ -1899,11 +1899,9 @@ static void rewriteUsesOfScalar(StructLoweringState &pass, SILValue address,
       createOutlinedCopyCall(copyBuilder, address, dest, pass);
       storeUser->eraseFromParent();
     } else if (auto *dbgInst = dyn_cast<DebugValueInst>(user)) {
-      SILBuilder dbgBuilder(dbgInst, dbgInst->getDebugScope());
-      // Rewrite the debug_value to point to the variable in the alloca.
-      dbgBuilder.createDebugValueAddr(dbgInst->getLoc(), address,
-                                      *dbgInst->getVarInfo());
-      dbgInst->eraseFromParent();
+      // Update the debug_value to point to the variable in the alloca.
+      dbgInst->setOperand(address);
+      dbgInst->prependDeref();
     }
   }
 }
@@ -2425,11 +2423,7 @@ static void rewriteFunction(StructLoweringState &pass,
       } else {
         assert(currOperand->getType().isAddress() &&
                "Expected an address type");
-        // SILBuilderWithScope skips over metainstructions.
-        SILBuilder debugBuilder(instr, instr->getDebugScope());
-        debugBuilder.createDebugValueAddr(instr->getLoc(), currOperand,
-                                          *instr->getVarInfo());
-        instr->getParent()->erase(instr);
+        instr->prependDeref();
       }
     }
   }
@@ -4784,10 +4778,9 @@ protected:
       assignment.markForDeletion(dbg);
       return;
     }
-    auto builder = assignment.getBuilder(dbg->getIterator());
     SILValue addr = assignment.getAddressForValue(dbg->getOperand());
-    builder.createDebugValueAddr(dbg->getLoc(), addr, *dbg->getVarInfo());
-    assignment.markForDeletion(dbg);
+    dbg->setOperand(addr);
+    dbg->prependDeref();
   }
 
   void visitRetainValueInst(RetainValueInst *r) {

--- a/lib/SIL/IR/SILBuilder.cpp
+++ b/lib/SIL/IR/SILBuilder.cpp
@@ -662,21 +662,6 @@ DebugValueInst *SILBuilder::createDebugValue(SILLocation Loc, SILValue src,
                                        poisonRefs, moved, trace));
 }
 
-DebugValueInst *SILBuilder::createDebugValueAddr(
-    SILLocation Loc, SILValue src, SILDebugVariable Var,
-    UsesMoveableValueDebugInfo_t moved, bool trace) {
-  if (shouldDropVariable(Var, Loc))
-    return nullptr;
-
-  llvm::SmallString<4> Name;
-
-  // Debug location overrides cannot apply to debug addr instructions.
-  DebugLocOverrideRAII LocOverride{*this, std::nullopt};
-  return insert(DebugValueInst::createAddr(
-      getSILDebugLocation(Loc, true), src, getModule(),
-      *substituteAnonymousArgs(Name, Var, Loc), moved, trace));
-}
-
 void SILBuilder::emitScopedBorrowOperation(SILLocation loc, SILValue original,
                                            function_ref<void(SILValue)> &&fun) {
   SILValue value = original;

--- a/lib/SIL/IR/SILInstructions.cpp
+++ b/lib/SIL/IR/SILInstructions.cpp
@@ -481,14 +481,29 @@ DebugValueInst::createAddr(SILDebugLocation DebugLoc, SILValue Operand,
                                 wasMoved, trace);
 }
 
-bool DebugValueInst::exprStartsWithDeref() const {
-  if (!NumDIExprOperands)
-    return false;
+void DebugValueInst::prependDeref() {
+  ASSERT(!sharedUInt8().DebugValueInst.prependDeref &&
+         "Debug value cannot have two derefs!");
+  if (!ReconstructionBlock) {
+    sharedUInt8().DebugValueInst.prependDeref = true;
+    return;
+  }
+  // If we have an undef, the reconstruction block shouldn't have an argument.
+  // Nothing to do.
+  if (isa<SILUndef>(getOperand()))
+    return;
 
-  llvm::ArrayRef<SILDIExprElement> DIExprElements(
-      getTrailingObjects<SILDIExprElement>(), NumDIExprOperands);
-  return DIExprElements.front().getAsOperator()
-          == SILDIExprOperator::Dereference;
+  // If we have a reconstruction block, add a load at the beginning.
+  SILBuilder builder(ReconstructionBlock->begin());
+  SILArgument *oldArg = ReconstructionBlock->getArgument(0);
+  SILType addrType = oldArg->getType().getAddressType();
+  SILValue undefAddress = SILUndef::get(getFunction(), addrType);
+  LoadInst *load = builder.createLoad(getLoc(), undefAddress,
+                                      LoadOwnershipQualifier::Unqualified);
+  oldArg->replaceAllUsesWith(load);
+  SILArgument *newArg =
+      ReconstructionBlock->replacePhiArgument(0, addrType, OwnershipKind::None);
+  load->setOperand(newArg);
 }
 
 SILBasicBlock *DebugValueInst::getOrCreateDebugReconstructionBlock() {
@@ -504,10 +519,18 @@ SILBasicBlock *DebugValueInst::getOrCreateDebugReconstructionBlock() {
   if (isa<SILUndef>(operand)) {
     // No arguments, return the same undef directly.
     retVal = operand;
+  } else if (sharedUInt8().DebugValueInst.prependDeref) {
+    // Convert the deref to a load.
+    SILArgument *arg = block->createPhiArgument(
+        operand->getType().getAddressType(), OwnershipKind::None);
+    retVal = builder.createLoad(getLoc(), arg,
+                                LoadOwnershipQualifier::Unqualified);
   } else {
     // Add a block argument matching the operand type.
     retVal = block->createPhiArgument(operand->getType(), OwnershipKind::None);
   }
+  // If the prependDeref flag was set, reset it, including in the undef case.
+  sharedUInt8().DebugValueInst.prependDeref = false;
 
   builder.createReturn(getLoc(), retVal);
   ReconstructionBlock = block;

--- a/lib/SIL/IR/SILInstructions.cpp
+++ b/lib/SIL/IR/SILInstructions.cpp
@@ -471,16 +471,6 @@ DebugValueInst *DebugValueInst::create(SILDebugLocation DebugLoc,
     DebugValueInst(DebugLoc, Operand, Var, poisonRefs, wasMoved, trace);
 }
 
-DebugValueInst *
-DebugValueInst::createAddr(SILDebugLocation DebugLoc, SILValue Operand,
-                           SILModule &M, SILDebugVariable Var,
-                           UsesMoveableValueDebugInfo_t wasMoved, bool trace) {
-  Var.DIExpr.prependElements(
-    {SILDIExprElement::createOperator(SILDIExprOperator::Dereference)});
-  return DebugValueInst::create(DebugLoc, Operand, M, Var, DontPoisonRefs,
-                                wasMoved, trace);
-}
-
 void DebugValueInst::prependDeref() {
   ASSERT(!sharedUInt8().DebugValueInst.prependDeref &&
          "Debug value cannot have two derefs!");

--- a/lib/SILOptimizer/Mandatory/AddressLowering.cpp
+++ b/lib/SILOptimizer/Mandatory/AddressLowering.cpp
@@ -3584,9 +3584,8 @@ protected:
   void visitDebugValueInst(DebugValueInst *debugInst) {
     SILValue srcVal = debugInst->getOperand();
     SILValue srcAddr = pass.valueStorageMap.getStorage(srcVal).storageAddress;
-    builder.createDebugValueAddr(debugInst->getLoc(), srcAddr,
-                                 *debugInst->getVarInfo());
-    pass.deleter.forceDelete(debugInst);
+    debugInst->setOperand(srcAddr);
+    debugInst->prependDeref();
   }
 
   void visitDeinitExistentialValueInst(

--- a/lib/SILOptimizer/Utils/InstOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/InstOptUtils.cpp
@@ -2039,19 +2039,16 @@ void swift::salvageDebugInfo(SILInstruction *I) {
 }
 
 void swift::salvageLoadDebugInfo(LoadOperation load) {
-  for (Operand *debugUse : getDebugUses(load.getLoadInst())) {
-    // Create a new debug_value rather than reusing the old one so the
-    // SILBuilder adds 'expr(deref)' to account for the indirection.
+  // The use list is mutated during iteration.
+  SmallVector<Operand *, 4> debugUses(getDebugUses(load.getLoadInst()));
+  for (Operand *debugUse : debugUses) {
+    // Update the debug_value to use the loaded address.
     auto *debugInst = cast<DebugValueInst>(debugUse->getUser());
-    auto varInfo = debugInst->getVarInfo();
-    if (!varInfo)
-      continue;
-
-    // The new debug_value must be "hoisted" to the load to ensure that the
+    // The debug_value must be "hoisted" to the load to ensure that the
     // address is still valid.
-    SILBuilder(load.getLoadInst(), debugInst->getDebugScope())
-      .createDebugValueAddr(debugInst->getLoc(), load.getOperand(),
-                            varInfo.value());
+    debugInst->moveBefore(load.getLoadInst());
+    debugInst->setOperand(load.getOperand());
+    debugInst->prependDeref();
   }
 }
 


### PR DESCRIPTION
Based on #89224

Instead of having to recreate new debug value instructions when a deref operator needs to be prepended (in passes where an object is moved to the stack), it is now possible to prepend a deref in place.

When a reconstruction block exists, the only correct way to prepend a deref is by adding a load at the start of the reconstruction block, as the reconstruction block is interpreted before the DIExpr.
Otherwise, a bit is set on the DebugValueInst to signal that a deref operator must be prepended to the DIExpr returned by getVarInfo.

All passes have been updated to use this new prependDeref rather than SILBuilder::createDebugValueAddr, so this function has also been removed.