### PR TITLE
SourceKit: Remove `CloseClangModuleFiles`

### DIFF
--- a/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
@@ -1164,8 +1164,6 @@ ASTUnitRef ASTBuildOperation::buildASTUnit(std::string &Error) {
     TracedOp.start(TraceInfo);
   }
 
-  CloseClangModuleFiles scopedCloseFiles(
-      *CompIns.getASTContext().getClangModuleLoader());
   CompIns.performSema();
 
   llvm::SmallPtrSet<ModuleDecl *, 16> Visited;

--- a/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
@@ -1305,7 +1305,6 @@ static bool reportSourceDocInfo(CompilerInvocation Invocation,
   }
 
   ASTContext &Ctx = CI.getASTContext();
-  CloseClangModuleFiles scopedCloseFiles(*Ctx.getClangModuleLoader());
   CI.performSema();
 
   SourceTextInfo SourceInfo;

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditorInterfaceGen.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditorInterfaceGen.cpp
@@ -477,7 +477,6 @@ SwiftInterfaceGenContextRef SwiftInterfaceGenContext::create(
   }
 
   ASTContext &Ctx = CI.getASTContext();
-  CloseClangModuleFiles scopedCloseFiles(*Ctx.getClangModuleLoader());
 
   // Load implicit imports so that Clang importer can use them.
   for (auto unloadedImport :
@@ -535,7 +534,6 @@ SwiftInterfaceGenContext::createForTypeInterface(CompilerInvocation Invocation,
   registerIDETypeCheckRequestFunctions(CI.getASTContext().evaluator);
   CI.performSema();
   ASTContext &Ctx = CI.getASTContext();
-  CloseClangModuleFiles scopedCloseFiles(*Ctx.getClangModuleLoader());
 
   // Load standard library so that Clang importer can use it.
   auto *Stdlib = Ctx.getModuleByIdentifier(Ctx.StdlibModuleName);

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
@@ -1184,16 +1184,6 @@ void SwiftLangSupport::getPolyglotAST(
   Receiver(RequestResult<std::string>::fromResult(buffer));
 }
 
-CloseClangModuleFiles::~CloseClangModuleFiles() {
-  clang::Preprocessor &PP = loader.getClangPreprocessor();
-  clang::ModuleMap &ModMap = PP.getHeaderSearchInfo().getModuleMap();
-  for (auto I = ModMap.module_begin(), E = ModMap.module_end(); I != E; ++I) {
-    clang::Module *M = I->second;
-    if (!M->isSubModule() && M->getASTFile())
-      M->getASTFile()->closeFile();
-  }
-}
-
 void SourceKit::disableExpensiveSILOptions(SILOptions &Opts) {
   // Disable the sanitizers.
   Opts.Sanitizers = {};

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
@@ -803,18 +803,6 @@ namespace trace {
                      ArrayRef<std::string> Args);
 }
 
-/// When we cannot build any more clang modules, close the .pcm / files to
-/// prevent fd leaks in clients that cache the AST.
-// FIXME: Remove this once rdar://problem/19720334 is complete.
-class CloseClangModuleFiles {
-  swift::ClangModuleLoader &loader;
-
-public:
-  CloseClangModuleFiles(swift::ClangModuleLoader &loader) : loader(loader) {}
-  ~CloseClangModuleFiles();
-};
-
-
 /// Disable expensive SIL options which do not affect indexing or diagnostics.
 void disableExpensiveSILOptions(swift::SILOptions &Opts);
 


### PR DESCRIPTION
Comment says to remove this thing when the radar is resolved, which was a long time ago. Try to rip it out to avoid a rebranch-specific change.