### PR TITLE
[cxx-interop] Make __convertToBool() available but deprecated

### DIFF
--- a/lib/ClangImporter/ClangLookup.cpp
+++ b/lib/ClangImporter/ClangLookup.cpp
@@ -566,13 +566,12 @@ static auto filterMethodOverloads(clang::LookupResult &R,
 
 /// Imports a C++ \a method to a Swift \a struct as a non-inherited member when
 /// \a access is AS_none, or an inherited member with effective \a access
-/// otherwise. Marks the method as unavailable with \a unavailabilityMsg.
+/// otherwise.
 ///
 /// Helper for the lookupAndImport* functions.
-static FuncDecl *importUnavailableMethod(ClangImporter::Implementation &Impl,
-                                         CXXOverload overload,
-                                         NominalTypeDecl *Struct,
-                                         StringRef unavailabilityMsg) {
+static FuncDecl *importUnderlyingFunction(ClangImporter::Implementation &Impl,
+                                          CXXOverload overload,
+                                          NominalTypeDecl *Struct) {
   Decl *imported;
   if (auto *ftd = overload.method->getDescribedFunctionTemplate())
     imported = Impl.importDecl(ftd, Impl.CurrentVersion);
@@ -586,7 +585,6 @@ static FuncDecl *importUnavailableMethod(ClangImporter::Implementation &Impl,
         Impl.importBaseMemberDecl(func, Struct, inheritance));
   if (!func)
     return nullptr;
-  Impl.markUnavailable(func, unavailabilityMsg);
   return func;
 }
 
@@ -647,19 +645,19 @@ ClangImporter::Implementation::lookupAndImportPointeeAndOperatorStar(
   FuncDecl *getter = nullptr, *setter = nullptr;
 
   if (CXXSetter) {
-    setter = importUnavailableMethod(*this, CXXSetter, Struct,
-                                     "use .pointee property");
+    setter = importUnderlyingFunction(*this, CXXSetter, Struct);
     if (!setter)
       return {};
+    markUnavailable(setter, "use .pointee property");
   }
 
   if (CXXGetter == CXXSetter) {
     getter = setter;
   } else if (CXXGetter) {
-    getter = importUnavailableMethod(*this, CXXGetter, Struct,
-                                     "use .pointee property");
+    getter = importUnderlyingFunction(*this, CXXGetter, Struct);
     if (!getter)
       return {};
+    markUnavailable(getter, "use .pointee property");
   }
 
   SwiftDeclSynthesizer synth{*this};
@@ -733,10 +731,10 @@ FuncDecl *ClangImporter::Implementation::lookupAndImportSuccessor(
   if (!CXXMethod)
     return nullptr;
 
-  auto *incr = importUnavailableMethod(*this, CXXMethod, Struct,
-                                       "use .pointee property");
+  auto *incr = importUnderlyingFunction(*this, CXXMethod, Struct);
   if (!incr)
     return nullptr;
+  markUnavailable(incr, "use .successor()");
 
   SwiftDeclSynthesizer synth{*this};
   auto *succ = synth.makeSuccessorFunc(incr);
@@ -843,10 +841,10 @@ ClangImporter::Implementation::lookupAndImportSubscripts(
       if (!overload)
         return nullptr;
 
-      auto *swiftFunc =
-          importUnavailableMethod(*this, overload, Struct, "use subscript");
+      auto *swiftFunc = importUnderlyingFunction(*this, overload, Struct);
       if (!swiftFunc)
         return nullptr;
+      markUnavailable(swiftFunc, "use subscript");
 
       auto name = swiftFunc->getBaseName();
       ASSERT(!name.isSpecial() &&
@@ -1003,8 +1001,13 @@ FuncDecl *ClangImporter::Implementation::lookupAndImportOperatorBool(
   }
   CXXRecord->addDecl(Method);
 
-  auto *func = importUnavailableMethod(*this, {Method, clang::AS_none}, Struct,
-                                       "use Bool(fromCxx:)");
+  auto *func =
+      importUnderlyingFunction(*this, {Method, clang::AS_none}, Struct);
+  if (!func)
+    return nullptr;
+  auto *depr = AvailableAttr::createUniversallyDeprecated(SwiftContext,
+                                                          "use Bool(fromCxx:)");
+  func->addAttribute(depr);
   markMemberSynthesizedPerType(func);
   importAttributes(OpBool, func);
 

--- a/test/Interop/Cxx/class/inheritance/using-base-members-module-interface.swift
+++ b/test/Interop/Cxx/class/inheritance/using-base-members-module-interface.swift
@@ -70,7 +70,7 @@
 
 // CHECK:      public struct OperatorBasePrivateInheritance : CxxConvertibleToBool {
 // CHECK-NEXT:   public init()
-// CHECK-NEXT:   @available(*, unavailable, message: "use Bool(fromCxx:)")
+// CHECK-NEXT:   @available(*, deprecated, message: "use Bool(fromCxx:)")
 // CHECK-NEXT:   public func __convertToBool() -> Bool
 // CHECK-NEXT:   @available(*, unavailable, message: "use .pointee property")
 // CHECK-NEXT:   public func __operatorStar() -> Int32
@@ -100,6 +100,6 @@
 
 // CHECK:      public struct ProtectedOperatorBoolMadePublic : CxxConvertibleToBool {
 // CHECK-NEXT:   public init()
-// CHECK-NEXT:   @available(*, unavailable, message: "use Bool(fromCxx:)")
+// CHECK-NEXT:   @available(*, deprecated, message: "use Bool(fromCxx:)")
 // CHECK-NEXT:   public func __convertToBool() -> Bool
 // CHECK-NEXT: }

--- a/test/Interop/Cxx/stdlib/overlay/convertible-to-bool-typechecker.swift
+++ b/test/Interop/Cxx/stdlib/overlay/convertible-to-bool-typechecker.swift
@@ -22,3 +22,4 @@ let _ = Bool(fromCxx: ProtectedInheritedBoolBox()) // expected-error {{initializ
 let _ = Bool(fromCxx: PublicUsingBoolBox())
 let _ = Bool(fromCxx: ProtectedUsingBoolBox()) // expected-error {{initializer 'init(fromCxx:)' requires that 'ProtectedUsingBoolBox' conform to 'CxxConvertibleToBool'}}
 
+let _: Bool = BoolBox().__convertToBool() // expected-warning {{use Bool(fromCxx:)}}

--- a/test/Interop/Cxx/stdlib/overlay/convertible-to-bool-typechecker.swift
+++ b/test/Interop/Cxx/stdlib/overlay/convertible-to-bool-typechecker.swift
@@ -1,6 +1,4 @@
-// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -I %S/Inputs -enable-experimental-cxx-interop
-// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -I %S/Inputs -cxx-interoperability-mode=swift-6
-// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -I %S/Inputs -cxx-interoperability-mode=upcoming-swift
+// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -I %S/Inputs -cxx-interoperability-mode=default
 
 import ConvertibleToBool
 


### PR DESCRIPTION
In 9c352307397208f9eb122c87af59272b4e41167b I made __convertToBool()
an unavailable function following the pattern of other synthesized
underlying functions. This was actually not good because others were
relying on this as a workaround for when CxxBool conformance doesn't
kick in.

In this patch, I bring back __convertToBool() and mark it as deprecated
rather than as unavailable. This allows the user to call it but warns
them against doing so while we iron out the kinks with CxxBool.

rdar://177377260