### PR TITLE
Sema: remove warning about `@_preInverseGenerics` on extensions

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4468,9 +4468,6 @@ ERROR(attr_pre_inverse_generics_invalid_except,none,
 WARNING(attr_pre_inverse_generics_except_all,none,
       "'@_preInverseGenerics' that excepts all inverse constraints is "
       "equivalent to not using the attribute", ())
-WARNING(attr_pre_inverse_generics_on_extension,none,
-      "'@_preInverseGenerics' has no effect on an extension; place it on "
-      "individual members instead", ())
 
 // lazy
 ERROR(lazy_not_on_let,none,

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -8712,12 +8712,6 @@ void AttributeChecker::visitMacroRoleAttr(MacroRoleAttr *attr) {
 
 void AttributeChecker::visitPreInverseGenericsAttr(
     PreInverseGenericsAttr *attr) {
-  if (isa<ExtensionDecl>(D)) {
-    diagnose(attr->getLocation(),
-             diag::attr_pre_inverse_generics_on_extension);
-    return;
-  }
-
   if (attr->hasExcept(D) &&
       !Ctx.LangOpts.hasFeature(Feature::PreInverseGenericsExcept)) {
     Ctx.Diags

--- a/test/Sema/preInverseGenerics.swift
+++ b/test/Sema/preInverseGenerics.swift
@@ -30,11 +30,3 @@ func bad2() {}
 // positive protocol (not inverted)
 @_preInverseGenerics(except: Copyable) // expected-error {{'except' argument to '@_preInverseGenerics' must consist only of inverse constraints such as '~Copyable' or '~Escapable'}}
 func bad3() {}
-
-// Warning: attribute on extension has no effect
-struct S<T: ~Copyable>: ~Copyable {}
-
-@_preInverseGenerics // expected-warning {{'@_preInverseGenerics' has no effect on an extension; place it on individual members instead}}
-extension S where T: ~Copyable {
-  func extMethod() {}
-}


### PR DESCRIPTION
I added the warning based on an observation that it has no effect on members of the extension, but didn't validate whether it has some subtle effect on other symbols, such as those for conformances declared with that extension. To reduce confusion, it's better to not warn until it's safe enough to remove uses of it on extensions in the stdlib.

Related to https://github.com/swiftlang/swift/pull/88976