### PR TITLE
IRGenDebugInfo: work around `LifetimeDependenceInfo` handling

### DIFF
--- a/lib/AST/ASTDemangler.cpp
+++ b/lib/AST/ASTDemangler.cpp
@@ -598,7 +598,11 @@ Type ASTBuilder::createFunctionType(
     clangFunctionType = Ctx.getClangFunctionType(funcParams, output,
                                                  representation);
 
-  // TODO: Handle LifetimeDependenceInfo here.
+  // TODO: Handle LifetimeDependenceInfo here. Until this is implemented,
+  // IRGen's debug-info round-trip check excludes types containing
+  // function types with lifetime dependencies; remove the
+  // containsFunctionTypeWithLifetimeDependencies workaround in
+  // lib/IRGen/IRGenDebugInfo.cpp when this lands.
   auto einfo = FunctionType::ExtInfoBuilder(
                    representation, noescape, flags.isThrowing(), thrownError,
                    resultDiffKind, clangFunctionType, isolation,
@@ -842,6 +846,9 @@ Type ASTBuilder::createImplFunctionType(
     clangFnType = getASTContext().getCanonicalClangFunctionType(
         funcParams, result, representation);
   }
+  // TODO: Handle LifetimeDependenceInfo here. Sibling of the AST-level TODO
+  // at the top of `createFunctionType` above; both must be implemented before
+  // the IRGen workaround in lib/IRGen/IRGenDebugInfo.cpp can be removed.
   auto einfo =
       SILFunctionType::ExtInfoBuilder(
           representation, flags.isPseudogeneric(), !flags.isEscaping(),

--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -1086,9 +1086,16 @@ private:
 
     bool IsTypeOriginallyDefinedIn = containsOriginallyDefinedIn(DbgTy.getType());
     bool IsCxxType = containsCxxType(DbgTy.getType());
+    // TODO: ASTDemangler drops LifetimeDependenceInfo (see ASTDemangler.cpp's
+    // "Handle LifetimeDependenceInfo here" TODO); until that TODO is closed,
+    // types containing function types with lifetime dependencies cannot
+    // round-trip. This exclusion is intentionally transitive.
+    bool ContainsLifetimeDependencies =
+        containsFunctionTypeWithLifetimeDependencies(DbgTy.getType());
     // There's no way to round trip when respecting @_originallyDefinedIn for a type.
     // TODO(https://github.com/apple/swift/issues/57699): We currently cannot round trip some C++ types.
-    if (!Opts.DisableRoundTripDebugTypes && !IsTypeOriginallyDefinedIn && !IsCxxType) {
+    if (!Opts.DisableRoundTripDebugTypes && !IsTypeOriginallyDefinedIn &&
+        !IsCxxType && !ContainsLifetimeDependencies) {
       // Make sure we can reconstruct mangled types for the debugger.
       auto &Ctx = Ty->getASTContext();
       Type Reconstructed = Demangle::getTypeForMangling(Ctx, SugaredName, Sig);
@@ -2678,6 +2685,23 @@ private:
         }
       }
 
+      return false;
+    });
+  }
+
+  /// Returns true if the type contains a function type with lifetime
+  /// dependencies. ASTDemangler drops LifetimeDependenceInfo (see the
+  /// "Handle LifetimeDependenceInfo here" TODO in ASTDemangler.cpp), so
+  /// such types cannot round-trip through the demangler. Covers both
+  /// inferred and explicit dependencies via hasLifetimeDependencies(),
+  /// and both AST-level (AnyFunctionType) and SIL-level (SILFunctionType)
+  /// function type hierarchies.
+  bool containsFunctionTypeWithLifetimeDependencies(Type T) {
+    return T.findIf([](Type t) -> bool {
+      if (auto *fn = t->getAs<AnyFunctionType>())
+        return fn->hasLifetimeDependencies();
+      if (auto *silFn = t->getAs<SILFunctionType>())
+        return silFn->hasLifetimeDependencies();
       return false;
     });
   }

--- a/test/embedded/debuginfo-noescape-closure-crash.swift
+++ b/test/embedded/debuginfo-noescape-closure-crash.swift
@@ -1,0 +1,20 @@
+// RUN: %target-swift-frontend -g -emit-ir %s -enable-experimental-feature Embedded -enable-experimental-feature Lifetimes -wmo
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: swift_feature_Embedded
+// REQUIRES: swift_feature_Lifetimes
+
+// Verify IRGenDebugInfo emits debug info for a stored closure of type
+// (inout T) -> U where T is ~Escapable, without crashing the round-trip
+// type-reconstruction self-check in getMangledName.
+
+public struct B: ~Copyable, ~Escapable { @_lifetime(immortal) init() {} }
+public final class C {}
+
+public final class K {
+    var fn: ((inout B) -> C)?
+    init() { self.fn = self.method }
+    func method(b: inout B) -> C { C() }
+}
+
+_ = K()


### PR DESCRIPTION
`ASTDemangler` drops LifetimeDependenceInfo (see `ASTDemangler.cpp`'s "Handle LifetimeDependenceInfo here" TODO); until that TODO is closed, types containing function types with lifetime dependencies cannot round-trip.

Resolves https://github.com/swiftlang/swift/issues/89257

rdar://177437498
