### PR TITLE
[6.3][Concurrency] A few more `nonisolated(nonsending)` fixes 

### DIFF
--- a/lib/SILGen/SILGenThunk.cpp
+++ b/lib/SILGen/SILGenThunk.cpp
@@ -646,10 +646,17 @@ getOrCreateReabstractionThunk(CanSILFunctionType thunkType,
   }
 
   SILGenFunctionBuilder builder(*this);
-  return builder.getOrCreateSharedFunction(
+  auto *thunk = builder.getOrCreateSharedFunction(
       loc, name, thunkDeclType, IsBare, IsTransparent, serializable,
       ProfileCounter(), IsReabstractionThunk, IsNotDynamic, IsNotDistributed,
       IsNotRuntimeAccessible);
+
+  if (auto isolatedParam = thunkType->maybeGetIsolatedParameter()) {
+    if (isolatedParam->hasOption(SILParameterInfo::ImplicitLeading))
+      thunk->setActorIsolation(ActorIsolation::forCallerIsolationInheriting());
+  }
+
+  return thunk;
 }
 
 SILFunction *SILGenModule::getOrCreateDerivativeVTableThunk(

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -39,6 +39,7 @@
 #include "swift/Basic/Assertions.h"
 #include "swift/Sema/IDETypeChecking.h"
 #include "swift/Strings.h"
+#include "llvm/Support/Casting.h"
 
 using namespace swift;
 using namespace swift::version;
@@ -3357,22 +3358,32 @@ namespace {
         return Action::Continue(expr);
       }
 
-      if (auto *closure = dyn_cast<AbstractClosureExpr>(expr)) {
-        auto isolation = determineClosureIsolation(closure);
-        closure->setActorIsolation(isolation);
+      auto determineClosureIsolationInContext =
+          [&](AbstractClosureExpr *closure, Expr *context) {
+            // If closure has explicit captures its isolation was determined as
+            // part of the capture list expression processing.
+            if (llvm::isa_and_nonnull<CaptureListExpr>(context))
+              return;
 
-        // There is a case in which the constraint solver cannot decide
-        // that a closure is `nonisolated(nonsending)` because it cannot
-        // analyze the captures, but the closure isolation logic can.
-        // Rewrite the closure type at this point.
-        if (isolation.isCallerIsolationInheriting()) {
-          auto fnType = closure->getType()->castTo<AnyFunctionType>();
-          if (!fnType->getIsolation().isNonIsolatedCaller()) {
-            fnType = fnType->withIsolation(
-              FunctionTypeIsolation::forNonIsolatedCaller());
-            closure->setType(fnType);
-          }
-        }
+            auto isolation = determineClosureIsolation(closure, context);
+            closure->setActorIsolation(isolation);
+
+            // There is a case in which the constraint solver cannot decide
+            // that a closure is `nonisolated(nonsending)` because it cannot
+            // analyze the captures, but the closure isolation logic can.
+            // Rewrite the closure type at this point.
+            if (isolation.isCallerIsolationInheriting()) {
+              auto fnType = closure->getType()->castTo<AnyFunctionType>();
+              if (!fnType->getIsolation().isNonIsolatedCaller()) {
+                fnType = fnType->withIsolation(
+                    FunctionTypeIsolation::forNonIsolatedCaller());
+                closure->setType(fnType);
+              }
+            }
+          };
+
+      if (auto *closure = dyn_cast<AbstractClosureExpr>(expr)) {
+        determineClosureIsolationInContext(closure, Parent.getAsExpr());
 
         checkLocalCaptures(closure);
         contextStack.push_back(closure);
@@ -3486,6 +3497,12 @@ namespace {
         for (const auto &entry : captureList->getCaptureList()) {
           captureContexts[entry.getVar()].push_back(closure);
         }
+
+        // The parent of `CaptureListExpr` here is used instead because
+        // \c determineClosureIsolationInContext is looking for conversion
+        // expressions that wrap the closure and cannot wait for the walker
+        // to find it in this case.
+        determineClosureIsolationInContext(closure, Parent.getAsExpr());
       }
 
       if (auto *defaultArg = dyn_cast<DefaultArgumentExpr>(expr)) {
@@ -4908,8 +4925,16 @@ namespace {
     ///
     /// This function assumes that enclosing closures have already had their
     /// isolation checked.
-    ActorIsolation
-    determineClosureIsolation(AbstractClosureExpr *closure) const;
+    ///
+    /// \param closure The closure to analyze.
+    /// \param context The context that wraps this closure looking through
+    /// a parent `CaptureListExpr` if any. This is parameter is currently used
+    /// to determine whether the closure appears inside of
+    /// `FunctionConversionExpr` and adjust the isolation accordingly.
+    ///
+    /// \returns The isolation of the given closure.
+    ActorIsolation determineClosureIsolation(AbstractClosureExpr *closure,
+                                             Expr *context) const;
   };
 } // end anonymous namespace
 
@@ -4977,8 +5002,11 @@ computeClosureIsolationFromParent(DeclContext *closure,
   }
 }
 
-ActorIsolation ActorIsolationChecker::determineClosureIsolation(
-    AbstractClosureExpr *closure) const {
+ActorIsolation
+ActorIsolationChecker::determineClosureIsolation(AbstractClosureExpr *closure,
+                                                 Expr *context) const {
+  ASSERT(!context || !isa<CaptureListExpr>(context));
+
   bool preconcurrency = false;
 
   ActorIsolation isolation = [&] {
@@ -5041,8 +5069,7 @@ ActorIsolation ActorIsolationChecker::determineClosureIsolation(
     // conversion to nonisolated(nonsending), then we should respect that.
     if (auto *explicitClosure = dyn_cast<ClosureExpr>(closure);
         isIsolationBoundary || !normalIsolation.isGlobalActor()) {
-      if (auto *fce =
-              dyn_cast_or_null<FunctionConversionExpr>(Parent.getAsExpr())) {
+      if (auto *fce = dyn_cast_or_null<FunctionConversionExpr>(context)) {
         auto expectedIsolation =
             fce->getType()->castTo<FunctionType>()->getIsolation();
         if (expectedIsolation.isNonIsolatedCaller()) {
@@ -5184,7 +5211,7 @@ ActorIsolation swift::determineClosureActorIsolation(
   ActorIsolationChecker checker(closure->getParent(), getType,
                                 getClosureActorIsolation,
                                 /*checkIsolatedCapture=*/false);
-  return checker.determineClosureIsolation(closure);
+  return checker.determineClosureIsolation(closure, /*context=*/nullptr);
 }
 
 /// Determine actor isolation solely from attributes.

--- a/test/Concurrency/issue-87097.swift
+++ b/test/Concurrency/issue-87097.swift
@@ -1,0 +1,48 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift  -target %target-swift-5.1-abi-triple %s -parse-as-library -module-name main -o %t/main
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main | %FileCheck %s
+
+// REQUIRES: concurrency
+// REQUIRES: concurrency_runtime
+// REQUIRES: executable_test
+// REQUIRES: OS=macosx
+
+// UNSUPPORTED: back_deployment_runtime
+// UNSUPPORTED: OS=windows-msvc
+
+actor MyActor {
+  func test(_ closure: nonisolated(nonsending) () async -> Void) async {
+    self.assertIsolated()
+    await closure()
+  }
+}
+
+nonisolated func test() async {
+  let a = MyActor()
+  let x = 1
+
+  await a.test { [x] in
+    let iso = #isolation
+    // CHECK: Optional(main.MyActor)
+    print(iso)
+    assert(iso === a)
+    iso!.assertIsolated()
+    a.assertIsolated()
+  }
+
+  await a.test {
+    let iso = #isolation
+    // CHECK: Optional(main.MyActor)
+    print(iso)
+    assert(iso === a)
+    iso!.assertIsolated()
+    a.assertIsolated()
+  }
+}
+
+@main struct Main {
+  static func main() async {
+    await test()
+  }
+}

--- a/test/Concurrency/nonisolated_nonsending.swift
+++ b/test/Concurrency/nonisolated_nonsending.swift
@@ -26,7 +26,8 @@ func testPartialApplication(p: [any P]) async {
 //   Reabstraction thunk from caller-isolated () -> () to caller-isolated () -> T
 // CHECK-LABEL: sil shared [transparent] [reabstraction_thunk] @$sBAIeghHgIL_BAytIeghHgILr_TR : $@convention(thin) @Sendable @async (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, @guaranteed @Sendable @async @callee_guaranteed (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor) -> ()) -> @out () {
 // CHECK:       bb0(%0 : $*(), %1 : $Builtin.ImplicitActor, %2 : $@Sendable @async @callee_guaranteed (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor) -> ()):
-// CHECK-NEXT:    hop_to_executor %1
+// The hop is eliminated because the argument is `nonisolated(nonsending)`
+// CHECK-NOT:    hop_to_executor %1
 // CHECK-NEXT:    apply %2(%1) :
 
 func takesGenericAsyncFunction<T>(_ fn: nonisolated(nonsending) (T) async -> Void) {}
@@ -45,11 +46,50 @@ func testReabstractionPreservingCallerIsolation(fn: nonisolated(nonsending) (Int
 // CHECK-LABEL: sil shared [transparent] [reabstraction_thunk] @$sBASiIgHgILy_BASiIegHgILn_TR : $@convention(thin) @async (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, @in_guaranteed Int, @guaranteed @noescape @async @callee_guaranteed (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, Int) -> ()) -> () {
 // CHECK:       bb0(%0 : $Builtin.ImplicitActor, %1 : $*Int, %2 : $@noescape @async @callee_guaranteed (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, Int) -> ()):
 // CHECK-NEXT:    %3 = load %1
-// CHECK-NEXT:    hop_to_executor %0
+// The hop is eliminated because the argument is `nonisolated(nonsending)`
+// CHECK-NOT:    hop_to_executor %0
 // CHECK-NEXT:    apply %2(%0, %3)
 
 func takesAsyncIsolatedAnyFunction(_ fn: @isolated(any) () async -> Void) {}
 func takesGenericAsyncIsolatedAnyFunction<T>(_ fn: @isolated(any) (T) async -> Void) {}
+
+func testReabstractionHopsBack() async throws {
+  func compute<T, R>(_ fn: nonisolated(nonsending) (T) async -> R?) async {
+  }
+
+  func computeThowing(_ fn: nonisolated(nonsending) () async throws -> Void) async throws {
+  }
+
+  // CHECK: // thunk for @callee_guaranteed @async (@unowned Int) -> (@unowned ()?)
+  // CHECK: // Isolation: caller_isolation_inheriting
+  // CHECK: sil shared [transparent] [reabstraction_thunk] @$sSiytSgIgHyd_BASiAAIegHgILnr_TR : $@convention(thin) @async (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, @in_guaranteed Int, @guaranteed @noescape @async @callee_guaranteed (Int) -> Optional<()>) -> @out Optional<()> {
+  // CHECK: bb0([[RESULT:%.*]] : $*Optional<()>, [[ISOLATION:%.*]] : $Builtin.ImplicitActor, [[X_REF:%.*]] : $*Int, [[CLOSURE:%.*]] : $@noescape @async @callee_guaranteed (Int) -> Optional<()>):
+  // CHECK:   [[X:%.*]] = load [[X_REF]]
+  // CHECK:   [[CLOSURE_RESULT:%.*]] = apply [[CLOSURE]]([[X]]) : $@noescape @async @callee_guaranteed (Int) -> Optional<()>
+  // CHECK:   store [[CLOSURE_RESULT]] to [[RESULT]]
+  // CHECK:   hop_to_executor [[ISOLATION]]
+  // CHECK: } // end sil function '$sSiytSgIgHyd_BASiAAIegHgILnr_TR'
+  await compute { @concurrent (x: Int) in
+      _ = x
+  }
+
+  struct MyError: Error {
+  }
+
+  // CHECK: // thunk for @callee_guaranteed @Sendable @async () -> (@error @owned Error)
+  // CHECK: // Isolation: caller_isolation_inheriting
+  // CHECK: sil shared [transparent] [reabstraction_thunk] @$ss5Error_pIghHzo_BAsAA_pIegHgILzo_TR : $@convention(thin) @async (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, @guaranteed @noescape @Sendable @async @callee_guaranteed () -> @error any Error) -> @error any Error {
+  // CHECK: bb0([[ISOLATION:%.*]] : $Builtin.ImplicitActor, [[CLOSURE:%.*]] : $@noescape @Sendable @async @callee_guaranteed () -> @error any Error):
+  // CHECK:   try_apply [[CLOSURE]]() : $@noescape @Sendable @async @callee_guaranteed () -> @error any Error, normal bb1, error bb2
+  // CHECK: bb1({{.*}} : $()):
+  // CHECK:   hop_to_executor [[ISOLATION]]
+  // CHECK: bb2({{.*}} : $any Error):
+  // CHECK:   hop_to_executor [[ISOLATION]]
+  // CHECK: } // end sil function '$ss5Error_pIghHzo_BAsAA_pIegHgILzo_TR'
+  try await computeThowing { @MainActor in
+      throw MyError()
+  }
+}
 
 // These would be good to test, but we apparently reject this conversion.
 #if false

--- a/test/Interpreter/issue88731.swift
+++ b/test/Interpreter/issue88731.swift
@@ -1,0 +1,36 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -language-mode 6 -target %target-swift-5.1-abi-triple %s -parse-as-library -module-name main -o %t/main
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main | %FileCheck %s
+
+// REQUIRES: concurrency
+// REQUIRES: concurrency_runtime
+// REQUIRES: executable_test
+
+// UNSUPPORTED: back_deployment_runtime
+
+// https://github.com/swiftlang/swift/issues/88731
+
+@MainActor
+func compute(_ fn: nonisolated(nonsending) @Sendable () async throws -> Void) async throws {
+  try await fn()
+  assertIsMainActor()
+}
+
+func assertIsMainActor() {
+    MainActor.assumeIsolated {}
+}
+
+func performComputation() async throws {
+  let x: Int = 42
+  try await compute { [x] in
+    print(x)
+  }
+}
+
+@main struct Main {
+  static func main() async throws {
+    try await performComputation()
+    // CHECK: 42
+  }
+}

--- a/test/Interpreter/issue88993.swift
+++ b/test/Interpreter/issue88993.swift
@@ -1,0 +1,43 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -language-mode 5 -strict-concurrency=complete -target %target-swift-5.1-abi-triple %s -parse-as-library -module-name main -o %t/main
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main
+
+// REQUIRES: concurrency
+// REQUIRES: concurrency_runtime
+// REQUIRES: executable_test
+
+// UNSUPPORTED: back_deployment_runtime
+
+// https://github.com/swiftlang/swift/issues/88993
+
+actor MyActor {
+  nonisolated func perform<E: Error>(_ work: @escaping @Sendable (isolated MyActor) async throws(E) -> ()) async throws(E) {
+    try await work(self)
+  }
+}
+
+// The bug only happens if this closure is `nonisolated(nonsending)`
+typealias MigrationWorkBlock = nonisolated(nonsending) () async -> Void
+
+nonisolated struct MyOperation {
+  let actor = MyActor()
+  let migrationWork: MigrationWorkBlock
+
+  nonisolated func run() async {
+    await self.actor.perform { actor in
+      actor.assertIsolated()
+
+      await migrationWork() // nonisolated(nonsending) should hop back to the context were it was executed
+
+      actor.assertIsolated() // Ok
+    }
+  }
+}
+
+@main struct Main {
+  static func main() async throws {
+    let operation = MyOperation(migrationWork: { }) // closure here is @MainActor isolated
+    await operation.run()
+  }
+}


### PR DESCRIPTION
- Explanation:

  This is backport of a few fixes that address recently discovered regressions.

  First issue is related to incorrect isolation inference when closure specifies explicit captures, the second one fixes reabstraction thunk isolation and prevents `OptimizeHopToExecutor` from removing valid hop backs.

- Resolves: rdar://170007831, rdar://176709091
- Resolves GitHub Issues: https://github.com/swiftlang/swift/issues/88993, https://github.com/swiftlang/swift/issues/87097

- Main Branch PRs: https://github.com/swiftlang/swift/pull/89015, https://github.com/swiftlang/swift/pull/87163

- Risk: Very Low. Both changes are very narrow and apply only to `nonisolated(nonsending)` declarations/values (inference via `NonisolatedNonsendingByDefault` upcoming feature flag is disabled by default).

- Reviewed By: @ktoso  

- Testing: Added new test-cases to the suite.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
