### PR TITLE
Tests: Mark `SILGenFunction-emitThrow-24ea1f.swift` as fixed

### DIFF
--- a/validation-test/compiler_crashers_fixed/SILGenFunction-emitThrow-24ea1f.swift
+++ b/validation-test/compiler_crashers_fixed/SILGenFunction-emitThrow-24ea1f.swift
@@ -1,5 +1,5 @@
 // {"kind":"emit-silgen","original":"6deeffa3","signature":"swift::Lowering::SILGenFunction::emitThrow(swift::SILLocation, swift::Lowering::ManagedValue, bool)","signatureAssert":"Assertion failed: (destErrorType == SILType::getExceptionType(getASTContext())), function emitThrow","signatureNext":"PatternMatchEmission::emitIsDispatch"}
-// RUN: not --crash %target-swift-frontend -emit-silgen %s
+// RUN: not %target-swift-frontend -emit-silgen %s
 protocol a: Error {
 }
 protocol b {


### PR DESCRIPTION
Resolves fall out from https://github.com/swiftlang/swift/pull/88948.
