### PR TITLE
Parsing: introduce `@_preInverseGenericsExceptCopyable` as an alias attribute

### DIFF
--- a/include/swift/AST/DeclAttr.def
+++ b/include/swift/AST/DeclAttr.def
@@ -836,6 +836,7 @@ DECL_ATTR(_preInverseGenerics, PreInverseGenerics,
   OnAbstractFunction | OnSubscript | OnVar | OnExtension,
   UserInaccessible | ABIBreakingToAdd | ABIBreakingToRemove | APIStableToAdd | APIStableToRemove | UnconstrainedInABIAttr,
   158)
+DECL_ATTR_ALIAS(_preInverseGenericsExceptCopyable, PreInverseGenerics)
 
 // Declares that a struct contains "sensitive" data. It enforces that the contents of such a struct value
 // is zeroed out at the end of its lifetime. In other words: the content of such a value is not observable

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -1712,8 +1712,19 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
 
   case DeclAttrKind::PreInverseGenerics: {
     auto *attr = cast<PreInverseGenericsAttr>(this);
-    Printer.printAttrName("@_preInverseGenerics");
     Type exceptTy = attr->getResolvedExceptType(D);
+    auto *pct = exceptTy->castTo<ProtocolCompositionType>();
+
+    // To avoid condfails during Span<~Escapable> adoption, emit
+    // `@_preInverseGenericsExceptCopyable` instead of
+    // `@_preInverseGenerics(except: ~Copyable)`.
+    if (pct->getInverses() ==
+        InvertibleProtocolSet({InvertibleProtocolKind::Copyable})) {
+      Printer.printAttrName("@_preInverseGenericsExceptCopyable");
+      break;
+    }
+
+    Printer.printAttrName("@_preInverseGenerics");
     // Avoid printing `@_preInverseGenerics(except: Any)` despite that being the
     // meaning of the no-arg version. It's rejected as it can confuse people.
     if (exceptTy->getCanonicalType() != D->getASTContext().TheAnyType) {

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -2745,9 +2745,18 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
 
   case DeclAttrKind::PreInverseGenerics: {
     TypeRepr *exceptType = nullptr;
+    Type resolvedExceptType;
     SourceLoc rParenLoc = Loc;
 
-    if (consumeIfAttributeLParen()) {
+    // The @_preInverseGenericsExceptCopyable spelling is a shorthand for
+    // @_preInverseGenerics(except: ~Copyable) to avoid condfails during the
+    // Span<~E> adoption.
+    //
+    // We inject the resolved 'except:' type directly into the attribute.
+    if (AttrName == "_preInverseGenericsExceptCopyable") {
+      resolvedExceptType = ProtocolCompositionType::getInverseOf(
+          Context, InvertibleProtocolKind::Copyable);
+    } else if (consumeIfAttributeLParen()) {
       if (Tok.getText() != "except" || peekToken().isNot(tok::colon)) {
         diagnose(Tok, diag::attr_pre_inverse_generics_expected_except);
         skipUntil(tok::r_paren);
@@ -2772,7 +2781,7 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
     if (!DiscardAttribute)
       Attributes.add(new (Context) PreInverseGenericsAttr(
           AtLoc, SourceRange(AtLoc.isValid() ? AtLoc : Loc, rParenLoc),
-          exceptType));
+          exceptType, resolvedExceptType));
     break;
   }
 

--- a/test/ModuleInterface/pre_inverse_generics_except.swift
+++ b/test/ModuleInterface/pre_inverse_generics_except.swift
@@ -5,6 +5,8 @@
 
 // RUN: %FileCheck --implicit-check-not '#if' %s < %t/Test.swiftinterface
 
+// RUN: %target-swift-typecheck-module-from-interface(%t/Test.swiftinterface)
+
 // REQUIRES: swift_feature_PreInverseGenericsExcept
 
 // The bare @_preInverseGenerics needs no feature guard.
@@ -16,10 +18,16 @@ public func bare<T: ~Copyable>(_ t: borrowing T) {}
 // Older compilers that don't support the feature will not see the declaration.
 
 // CHECK:      #if compiler(>=5.3) && $PreInverseGenericsExcept
-// CHECK-NEXT: @_preInverseGenerics(except: ~Copyable) public func exceptCopyable<T>(_ t: borrowing T) where T : ~Copyable, T : ~Escapable
+// CHECK-NEXT: @_preInverseGenericsExceptCopyable public func exceptCopyable<T>(_ t: borrowing T) where T : ~Copyable, T : ~Escapable
 // CHECK-NEXT: #endif
 @_preInverseGenerics(except: ~Copyable)
 public func exceptCopyable<T: ~Copyable & ~Escapable>(_ t: borrowing T) {}
+
+// CHECK:      #if compiler(>=5.3) && $PreInverseGenericsExcept
+// CHECK-NEXT: @_preInverseGenericsExceptCopyable public func exceptCopyable2<T>(_ t: borrowing T) where T : ~Copyable, T : ~Escapable
+// CHECK-NEXT: #endif
+@_preInverseGenericsExceptCopyable
+public func exceptCopyable2<T: ~Copyable & ~Escapable>(_ t: borrowing T) {}
 
 // CHECK:      #if compiler(>=5.3) && $PreInverseGenericsExcept
 // CHECK-NEXT: @_preInverseGenerics(except: ~Escapable) public func exceptEscapable<T>(_ t: borrowing T) where T : ~Copyable, T : ~Escapable
@@ -36,7 +44,7 @@ public func exceptBoth<T: ~Copyable & ~Escapable>(_ t: borrowing T) {}
 @frozen
 public struct MySpan<T: ~Copyable & ~Escapable>: ~Copyable {
 // CHECK:      #if compiler(>=5.3) && $PreInverseGenericsExcept
-// CHECK-NEXT: @_preInverseGenerics(except: ~Copyable) public var _count: Swift::Int
+// CHECK-NEXT: @_preInverseGenericsExceptCopyable public var _count: Swift::Int
 // CHECK-NEXT: #endif
   @_preInverseGenerics(except: ~Copyable)
   public var _count: Int

--- a/test/SILGen/mangling_inverse_generics.swift
+++ b/test/SILGen/mangling_inverse_generics.swift
@@ -378,6 +378,12 @@ public func keepEscapable<T: ~Copyable & ~Escapable>(_ t: borrowing T) {}
 @_preInverseGenerics
 public func stripBoth<T: ~Copyable & ~Escapable>(_ t: borrowing T) {}
 
+// The shorthand alias mangles identically to `(except: ~Copyable)`.
+// DEMANGLED: test.keepCopyableShorthand<A where A: ~Swift.Copyable>(A) -> ()
+// CHECK: sil [ossa] @$s4test21keepCopyableShorthandyyxRi_zlF : $@convention(thin) <T where T : ~Copyable, T : ~Escapable> (@in_guaranteed T) -> () {
+@_preInverseGenericsExceptCopyable
+public func keepCopyableShorthand<T: ~Copyable & ~Escapable>(_ t: borrowing T) {}
+
 
 public struct F<T: ~Copyable>: ~Copyable {
   // DEMANGLED: (extension in test):test.F< where A: ~Swift.Copyable>.memberKeepCopyable() -> ()
@@ -405,6 +411,11 @@ public struct MySpan<T: ~Copyable & ~Escapable>: ~Copyable, ~Escapable {
   // CHECK: sil [transparent] [serialized] [ossa] @$s4test6MySpanVAARi_zrlE6_countSivg : $@convention(method) <T where T : ~Copyable, T : ~Escapable> (@guaranteed MySpan<T>) -> Int {
   @_preInverseGenerics(except: ~Copyable)
   public var _count: Int
+
+  // DEMANGLED: (extension in test):test.MySpan< where A: ~Swift.Copyable>._count2.getter : Swift.Int
+  // CHECK: sil [transparent] [serialized] [ossa] @$s4test6MySpanVAARi_zrlE7_count2Sivg : $@convention(method) <T where T : ~Copyable, T : ~Escapable> (@guaranteed MySpan<T>) -> Int {
+  @_preInverseGenericsExceptCopyable
+  public var _count2: Int
 
   // DEMANGLED: (extension in test):test.MySpan< where A: ~Swift.Copyable>._pointer.getter : Swift.UnsafeRawPointer?
   // CHECK: sil [transparent] [serialized] [ossa] @$s4test6MySpanVAARi_zrlE8_pointerSVSgvg : $@convention(method) <T where T : ~Copyable, T : ~Escapable> (@guaranteed MySpan<T>) -> Optional<UnsafeRawPointer> {
@@ -436,4 +447,3 @@ extension MySpan where T: ~Copyable & ~Escapable {
   // CHECK: sil [ossa] @$s4test6MySpanVAARi_zRi0_zrlE9extMethodyyF : $@convention(method) <T where T : ~Copyable, T : ~Escapable> (@guaranteed MySpan<T>) -> () {
   public func extMethod() {}
 }
-

--- a/test/Sema/preInverseGenerics.swift
+++ b/test/Sema/preInverseGenerics.swift
@@ -8,6 +8,10 @@ func bare<T: ~Copyable>(_ t: borrowing T) {}
 @_preInverseGenerics(except: ~Copyable)
 func exceptCopyable<T: ~Copyable & ~Escapable>(_ t: borrowing T) {}
 
+// Shorthand alias for `@_preInverseGenerics(except: ~Copyable)`.
+@_preInverseGenericsExceptCopyable
+func exceptCopyableShorthand<T: ~Copyable & ~Escapable>(_ t: borrowing T) {}
+
 @_preInverseGenerics(except: ~Escapable)
 func exceptEscapable<T: ~Copyable & ~Escapable>(_ t: borrowing T) {}
 

--- a/test/attr/attr_preInverseGenerics.swift
+++ b/test/attr/attr_preInverseGenerics.swift
@@ -13,4 +13,8 @@ func exceptCopyable<T: ~Copyable & ~Escapable>(_ t: borrowing T) {}
                                   // expected-error@-1 {{'except' argument to '@_preInverseGenerics' must consist only of inverse constraints such as '~Copyable' or '~Escapable'}}
 func exceptInt<T: ~Copyable & ~Escapable>(_ t: borrowing T) {}
 
+// The shorthand alias also requires the experimental feature.
+@_preInverseGenericsExceptCopyable // expected-error {{'@_preInverseGenerics' is an experimental feature; use '-enable-experimental-feature PreInverseGenericsExcept'}}
+func exceptCopyableShorthand<T: ~Copyable & ~Escapable>(_ t: borrowing T) {}
+
 


### PR DESCRIPTION
We need an alias since `@_preInverseGenerics(except: ...)` has custom parsing that older compilers aren't designed to handle. Only simple decl attributes are parsed correctly by older compilers.

This helps with the introduction of Span<~Escapable>.

related to rdar://176395527