### PR TITLE
[region-isolation] Reword merge-region diagnostics so we never fail on missing names

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -1227,35 +1227,64 @@ NOTE(regionbasedisolation_inout_sending_in_same_region_note, none,
 // Merge Region Failure Error
 //
 
-GROUPED_ERROR(regionbasedisolation_merge_region_failure_error_unknown, RegionIsolationCrossIsolationDataRace, none,
-      "allowing references between %select{%0|%1 %0}4 and %3 %2 risks causing data races",
-      (Identifier, StringRef, Identifier, StringRef, bool))
-NOTE(regionbasedisolation_merge_region_failure_error_unknown_note, none,
-     "%0 could become accessible to %3 code despite remaining accessible to %select{code in the current task|%1 code}4",
-     (Identifier, StringRef, Identifier, StringRef, bool))
-GROUPED_ERROR(regionbasedisolation_merge_region_failure_error_assign, RegionIsolationCrossIsolationDataRace, none,
-      "assigning %select{%0|%1 %0}4 to %3 %2 risks causing data races",
-      (Identifier, StringRef, Identifier, StringRef, bool))
-NOTE(regionbasedisolation_merge_region_failure_error_assign_note, none,
-      "%0 could become accessible to %2 code despite remaining accessible to %select{code in the current task|%1 code}3",
-      (Identifier, StringRef, StringRef, bool))
-GROUPED_ERROR(regionbasedisolation_merge_region_failure_error_functionisolation, RegionIsolationCrossIsolationDataRace, none,
-      "passing %select{%0|%1 %0}4 to %3 %kind2 risks causing data races",
-      (Identifier, StringRef, const ValueDecl *, StringRef, bool))
-GROUPED_ERROR(regionbasedisolation_merge_region_failure_error_functionisolation_type, RegionIsolationCrossIsolationDataRace, none,
-      "passing %select{%0|%1 %0}4 to %3 %kind2 risks causing data races",
-      (Type, StringRef, const ValueDecl *, StringRef, bool))
+// Generic merge -- instruction does not match a more specific shape below.
+GROUPED_ERROR(rbi_merge_failure_unknown, RegionIsolationCrossIsolationDataRace, none,
+      "executing operation could allow for references between values exposed to "
+      "%select{%0 code|code in the current task}2 and "
+      "%select{%1 code|code in the current task}3 "
+      "risking data races",
+      (StringRef, StringRef, bool, bool))
 
-// We always put the potential task-isolated value first to simplify the note.
-GROUPED_ERROR(regionbasedisolation_merge_region_failure_error_nonisolatedfunction, RegionIsolationCrossIsolationDataRace, none,
-      "passing %select{%0|%1 %0}5 and %3 %2 as arguments to %kind4 risks causing data races",
-      (Identifier, StringRef, Identifier, StringRef, const ValueDecl *, bool))
-NOTE(regionbasedisolation_merge_region_failure_error_nonisolatedfunction_note, none,
-     "%2 could begin referencing %0 allowing concurrent access to %0 by %3 code and %select{code in the current task|%1 code}5", (Identifier, StringRef, Identifier, StringRef, const ValueDecl *, bool))
+// Store / assignment that brings two domains into the same region.
+GROUPED_ERROR(rbi_merge_failure_assign, RegionIsolationCrossIsolationDataRace, none,
+      "assignment could allow for references between values exposed to "
+      "%select{%0 code|code in the current task}2 and "
+      "%select{%1 code|code in the current task}3 "
+      "risking data races",
+      (StringRef, StringRef, bool, bool))
 
-GROUPED_ERROR(regionbasedisolation_merge_region_failure_error_cast, RegionIsolationCrossIsolationDataRace, none,
-      "casting %select{%0|%1 %0}4 to %3 %2 risks causing data races",
-      (Identifier, StringRef, Type, StringRef, bool))
+// Nonisolated callee receiving arguments from two different domains.
+GROUPED_ERROR(rbi_merge_failure_nonisolatedfn, RegionIsolationCrossIsolationDataRace, none,
+      "passing arguments to %kind2 could allow for references between values exposed to "
+      "%select{%0 code|code in the current task}3 and "
+      "%select{%1 code|code in the current task}4 "
+      "risking data races",
+      (StringRef, StringRef, const ValueDecl *, bool, bool))
+
+// Isolated callee receiving a value from a different domain.
+// Two variants: a named primary that includes the source value's name when we
+// can recover it, and an unnamed primary (no leading article) when we cannot.
+GROUPED_ERROR(rbi_merge_failure_isolatedfn, RegionIsolationCrossIsolationDataRace, none,
+      "passing value to %2 %kind1 could allow for references between values exposed to "
+      "%select{%0 code|code in the current task}3 and "
+      "%select{%2 code|code in the current task}4 "
+      "risking data races",
+      (StringRef, const ValueDecl *, StringRef, bool, bool))
+GROUPED_ERROR(rbi_merge_failure_isolatedfn_named, RegionIsolationCrossIsolationDataRace, none,
+      "passing %0 to %3 %kind2 could allow for references between values exposed to "
+      "%select{%1 code|code in the current task}4 and "
+      "%select{%3 code|code in the current task}5 "
+      "risking data races",
+      (Identifier, StringRef, const ValueDecl *, StringRef, bool, bool))
+
+// Cast across isolation domains.
+GROUPED_ERROR(rbi_merge_failure_cast, RegionIsolationCrossIsolationDataRace, none,
+      "casting value to type %1 could allow for references between values exposed to "
+      "%select{%0 code|code in the current task}3 and "
+      "%select{%2 code|code in the current task}4 "
+      "risking data races",
+      (StringRef, Type, StringRef, bool, bool))
+
+// Per-value notes -- two variants. We use the named form when we can recover a
+// name for the value, otherwise the bare form. We deliberately do not emit a
+// "value of type T" form, because SIL values often do not carry a reliable AST
+// type.
+NOTE(rbi_merge_failure_value_note_named, none,
+     "%0 is exposed to %select{%1 code|code in the current task}2",
+     (Identifier, StringRef, bool))
+NOTE(rbi_merge_failure_value_note_bare, none,
+     "value is exposed to %select{%0 code|code in the current task}1",
+     (StringRef, bool))
 
 // Concurrency related diagnostics
 ERROR(executor_factory_must_conform, none,

--- a/include/swift/SILOptimizer/Utils/VariableNameUtils.h
+++ b/include/swift/SILOptimizer/Utils/VariableNameUtils.h
@@ -136,6 +136,15 @@ private:
   /// If set, a diagnostic should do a 'root' is defined here error.
   SILValue rootValue;
 
+  /// The source location of the first (leaf-most) component pushed onto
+  /// \c variableNamePath. Since we walk use->def, the first push corresponds
+  /// to the deepest projection in the access path -- e.g., for "self.x.y"
+  /// this is the loc of the projection producing `y`. This is useful for
+  /// diagnostics that want the source location of the leaf access rather
+  /// than the root variable's location (which for a stored property accessed
+  /// in an init can be on the `init` keyword, far from the access).
+  SourceLoc firstNameProvidingLoc;
+
   /// The final string we computed.
   SmallString<64> &resultingString;
 
@@ -223,6 +232,24 @@ public:
   static std::optional<std::pair<Identifier, SILValue>>
   inferNameAndRoot(SILValue value);
 
+  /// Like \c inferName, but additionally returns the source location of the
+  /// first (leaf-most) component pushed onto the name path -- i.e., the
+  /// deepest projection in the access path. For "self.x.y" this is the loc
+  /// of the SILValue projecting `y`. Useful when a diagnostic wants the
+  /// source location of the leaf access rather than the root variable's
+  /// location.
+  ///
+  /// Returns std::nullopt if no name could be inferred. The returned
+  /// SourceLoc may be invalid when the inferred name has no associated
+  /// providing source location (e.g., a single-component name coming
+  /// directly from a debug_value with no usable loc).
+  static std::optional<std::pair<Identifier, SourceLoc>>
+  inferNameAndFirstPathComponent(SILValue value);
+
+  /// Returns the source location whose name was first pushed onto the name
+  /// path during the walk. See \c firstNameProvidingLoc for details.
+  SourceLoc getFirstNameProvidingLoc() const { return firstNameProvidingLoc; }
+
   /// Given a specific decl \p d, come up with a name for it.
   ///
   /// This is used internally for translating all decls to names. This is
@@ -232,6 +259,15 @@ public:
 
 private:
   void drainVariableNamePath();
+
+  /// Push \p name onto the variable name path, recording \p providingLoc
+  /// as the first name-providing source location if none has been recorded
+  /// yet.
+  void pushPathComponent(StringRef name, SourceLoc providingLoc) {
+    variableNamePath.push_back(name);
+    if (firstNameProvidingLoc.isInvalid())
+      firstNameProvidingLoc = providingLoc;
+  }
 
   /// Finds the SILValue that either provides the direct debug information or
   /// that has a debug_value user that provides the name of the value.

--- a/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
@@ -225,6 +225,79 @@ inferNameAndRootHelper(SILValue value) {
   return VariableNameInferrer::inferNameAndRoot(value);
 }
 
+/// Run the name inferrer over \p value purely to recover the source location
+/// of the leaf-most component pushed onto the inferred name path -- e.g. the
+/// seai for `customField` in `self.customField`. Returns an invalid SourceLoc
+/// if no name can be inferred.
+///
+/// Unlike \c inferNameHelper, this is *not* gated by \c ForceTypedErrors -- we
+/// want a usable loc even when name recovery has been suppressed for the
+/// bare-note testing path, so the note can still anchor at the leaf access.
+static SourceLoc inferFirstNameProvidingLocHelper(SILValue value) {
+  if (auto pair = VariableNameInferrer::inferNameAndFirstPathComponent(value))
+    return pair->second;
+  return SourceLoc();
+}
+
+/// Pick the most precise SourceLoc we can find for \p value: prefer the AST
+/// decl location for function arguments (so notes land on the parameter name,
+/// not the `func` keyword), otherwise the defining instruction's source loc,
+/// finally the SILValue's own coarse loc.
+///
+/// Returns SourceLoc() when we have nothing better than the function-level
+/// fallback (e.g. for a phi argument with no defining instruction). In that
+/// case the caller should consider the first-pushed name-path component as a
+/// better anchor.
+static SourceLoc preciseSourceLocForValue(SILValue value) {
+  if (auto *arg = dyn_cast<SILFunctionArgument>(value))
+    if (auto *decl = arg->getDecl())
+      if (auto loc = decl->getLoc())
+        return loc;
+  if (auto *defInst = value->getDefiningInstruction())
+    if (auto astLoc = defInst->getLoc().getSourceLoc())
+      return astLoc;
+  return SourceLoc();
+}
+
+/// Emit a per-value note describing one side of an incompatible region merge.
+/// \p ownIso is the isolation of \p value (the textual rendering used when the
+/// value is *not* task-isolated). \p ownIsTaskIsolated drives a `%select` that
+/// renders "code in the current task" instead of "X-isolated code" for the
+/// task-isolated case, matching the wording used elsewhere in the diagnostic
+/// suite.
+///
+/// Falls back to a bare note if name inference fails -- we deliberately do not
+/// try to recover an AST type, since SIL values often do not carry a reliable
+/// one. Skips emission entirely when no precise SourceLoc is available, since
+/// a note at <unknown>:0 is unhelpful and prevents test verifiers from being
+/// able to anchor on the note.
+///
+/// We prefer the value's own precise loc (the use site) when available. Only
+/// when the value has nothing better than the function-level fallback (e.g.
+/// the value is a phi argument with no defining instruction, as in
+/// `switch_enum` over a stored property accessed in an init) do we fall back
+/// to the location of the leaf-most component pushed onto the inferred name
+/// path -- e.g. the seai for `customField` in `self.customField`. That keeps
+/// notes on direct use-site values anchored at the use, while still producing
+/// usable locs for the phi-arg case (where the old code would land on the
+/// `init` keyword far from the access).
+static void emitMergeRegionValueNote(SILValue value, StringRef ownIso,
+                                     bool ownIsTaskIsolated) {
+  auto &ctx = value->getFunction()->getASTContext();
+  SourceLoc loc = preciseSourceLocForValue(value);
+  if (!loc)
+    loc = inferFirstNameProvidingLocHelper(value);
+  if (!loc)
+    return;
+  if (auto name = inferNameHelper(value)) {
+    diagnoseNote(ctx, loc, diag::rbi_merge_failure_value_note_named, *name,
+                 ownIso, ownIsTaskIsolated);
+    return;
+  }
+  diagnoseNote(ctx, loc, diag::rbi_merge_failure_value_note_bare, ownIso,
+               ownIsTaskIsolated);
+}
+
 /// Sometimes we use a store_borrow + temporary to materialize a borrowed value
 /// to be passed to another function. We want to emit the error on the function
 /// itself, not the store_borrow so we get the best location. We only do this if
@@ -3955,53 +4028,38 @@ private:
 };
 
 void IncompatibleRegionMergeDiagnosticEmitter::emitUnknown() {
-  auto srcRegionValue = valueMap.getRepresentativeValue(srcRegionValueElt);
-  auto dstRegionValue = valueMap.getRepresentativeValue(dstRegionValueElt);
-
-  // For now skip this.
-  if (dstRegionValue.hasRegionIntroducingInst())
-    return;
-
-  auto srcIsolation = srcIsolationInfo;
-  auto dstIsolation = dstIsolationInfo;
-
-  // Canonicalize so that srcRegionValue is always the task-isolated value. We
-  // do this only here since in this case, we can get away with doing this to
-  // implement a simpler diagnostic. E.x.: This doesn't work for assign.
-  if (!srcIsolation->isTaskIsolated() && dstIsolation->isTaskIsolated()) {
-    std::swap(srcIsolation, dstIsolation);
-    std::swap(srcRegionValue, dstRegionValue);
-  }
-
-  // We should always be able to find a name for an inout sending param. If we
-  // do not, emit an unknown pattern error.
-  auto srcName = inferNameHelper(srcRegionValue.getValue());
-  if (!srcName) {
-    return emitUnknownPatternError();
-  }
-  auto dstName = inferNameHelper(dstRegionValue.getValue());
-  if (!dstName) {
-    return emitUnknownPatternError();
-  }
-
   if (!srcIsolationInfo)
     return emitUnknownPatternError();
   if (!dstIsolationInfo)
     return emitUnknownPatternError();
 
+  auto srcRegionValue = valueMap.getRepresentativeValue(srcRegionValueElt);
+  auto dstRegionValue = valueMap.getRepresentativeValue(dstRegionValueElt);
+
+  auto srcIsolation = srcIsolationInfo;
+  auto dstIsolation = dstIsolationInfo;
+
+  // Canonicalize so that srcRegionValue is always the task-isolated value when
+  // possible. This only affects which isolation string is rendered first.
+  if (!srcIsolation->isTaskIsolated() && dstIsolation->isTaskIsolated()) {
+    std::swap(srcIsolation, dstIsolation);
+    std::swap(srcRegionValue, dstRegionValue);
+  }
+
   auto srcIsolationStr = srcIsolation.printForDiagnostics(getFunction());
   auto dstIsolationStr = dstIsolation.printForDiagnostics(getFunction());
 
-  diagnoseError(op->getUser(),
-                diag::regionbasedisolation_merge_region_failure_error_unknown,
-                *srcName, srcIsolationStr, *dstName, dstIsolationStr,
-                !srcIsolation->isTaskIsolated())
+  diagnoseError(op->getUser(), diag::rbi_merge_failure_unknown, srcIsolationStr,
+                dstIsolationStr, srcIsolation->isTaskIsolated(),
+                dstIsolation->isTaskIsolated())
       .limitBehaviorIf(getBehaviorLimit());
-  diagnoseNote(
-      op->getUser(),
-      diag::regionbasedisolation_merge_region_failure_error_unknown_note,
-      *srcName, srcIsolationStr, *dstName, dstIsolationStr,
-      !srcIsolation->isTaskIsolated());
+
+  if (auto srcValue = srcRegionValue.maybeGetValue())
+    emitMergeRegionValueNote(srcValue, srcIsolationStr,
+                             srcIsolation->isTaskIsolated());
+  if (auto dstValue = dstRegionValue.maybeGetValue())
+    emitMergeRegionValueNote(dstValue, dstIsolationStr,
+                             dstIsolation->isTaskIsolated());
 }
 
 void IncompatibleRegionMergeDiagnosticEmitter::emitAssign() {
@@ -4016,37 +4074,27 @@ void IncompatibleRegionMergeDiagnosticEmitter::emitAssign() {
   auto srcIsolation = srcIsolationInfo;
   auto dstIsolation = dstIsolationInfo;
 
-  // Canonicalize so that srcRegionValue is always the task-isolated value. We
-  // do this only here since in this case, we can get away with doing this to
-  // implement a simpler diagnostic. E.x.: This doesn't work for assign.
+  // Canonicalize so that srcRegionValue is always the task-isolated value when
+  // possible. This only affects which isolation string is rendered first.
   if (!srcIsolation->isTaskIsolated() && dstIsolation->isTaskIsolated()) {
     std::swap(srcIsolation, dstIsolation);
     std::swap(srcRegionValue, dstRegionValue);
   }
 
-  // We should always be able to find a name for an inout sending param. If we
-  // do not, emit an unknown pattern error.
-  auto srcName = inferNameHelper(srcRegionValue.getValue());
-  if (!srcName) {
-    return emitUnknownPatternError();
-  }
-  auto dstName = inferNameHelper(dstRegionValue.getValue());
-  if (!dstName) {
-    return emitUnknownPatternError();
-  }
+  auto srcIsolationStr = srcIsolation.printForDiagnostics(getFunction());
+  auto dstIsolationStr = dstIsolation.printForDiagnostics(getFunction());
 
-  auto srcIsolationStr = srcIsolationInfo.printForDiagnostics(getFunction());
-  auto dstIsolationStr = dstIsolationInfo.printForDiagnostics(getFunction());
-  diagnoseError(op->getUser(),
-                diag::regionbasedisolation_merge_region_failure_error_assign,
-                *srcName, srcIsolationStr, *dstName, dstIsolationStr,
-                !srcIsolation->isTaskIsolated())
+  diagnoseError(op->getUser(), diag::rbi_merge_failure_assign, srcIsolationStr,
+                dstIsolationStr, srcIsolation->isTaskIsolated(),
+                dstIsolation->isTaskIsolated())
       .limitBehaviorIf(getBehaviorLimit());
-  diagnoseNote(
-      op->getUser(),
-      diag::regionbasedisolation_merge_region_failure_error_assign_note,
-      *srcName, srcIsolationStr, dstIsolationStr,
-      !srcIsolation->isTaskIsolated());
+
+  if (auto srcValue = srcRegionValue.maybeGetValue())
+    emitMergeRegionValueNote(srcValue, srcIsolationStr,
+                             srcIsolation->isTaskIsolated());
+  if (auto dstValue = dstRegionValue.maybeGetValue())
+    emitMergeRegionValueNote(dstValue, dstIsolationStr,
+                             dstIsolation->isTaskIsolated());
 }
 
 void IncompatibleRegionMergeDiagnosticEmitter::emitNonisolatedFunction() {
@@ -4060,46 +4108,36 @@ void IncompatibleRegionMergeDiagnosticEmitter::emitNonisolatedFunction() {
   auto srcRegionValue = valueMap.getRepresentativeValue(srcRegionValueElt);
   auto dstRegionValue = valueMap.getRepresentativeValue(dstRegionValueElt);
 
-  // Canonicalize so that srcRegionValue is always the task-isolated value. We
-  // do this only here since in this case, we can get away with doing this to
-  // implement a simpler diagnostic. E.x.: This doesn't work for assign.
+  // Canonicalize so that srcRegionValue is always the task-isolated value when
+  // possible. This only affects which isolation string is rendered first.
   if (!srcIsolation->isTaskIsolated() && dstIsolation->isTaskIsolated()) {
     std::swap(srcIsolation, dstIsolation);
     std::swap(srcRegionValue, dstRegionValue);
   }
 
-  // We should always be able to find a name for an inout sending param. If we
-  // do not, emit an unknown pattern error.
-  auto srcName = inferNameHelper(srcRegionValue.getValue());
-  if (!srcName) {
-    return emitUnknownPatternError();
-  }
-  auto dstName = inferNameHelper(dstRegionValue.getValue());
-  if (!dstName) {
-    return emitUnknownPatternError();
-  }
-
   auto srcIsolationStr = srcIsolation.printForDiagnostics(getFunction());
   auto dstIsolationStr = dstIsolation.printForDiagnostics(getFunction());
+
+  // If we cannot recover a callee decl, fall through to the generic unknown
+  // shape rather than emitting an unknown-pattern error.
   auto as = ApplySite::isa(op->getUser());
   if (!as)
-    return emitUnknownPatternError();
+    return emitUnknown();
   auto declRef = as.getCalleeDeclRef();
   if (!declRef)
-    return emitUnknownPatternError();
+    return emitUnknown();
 
-  diagnoseError(
-      op->getUser(),
-      diag::regionbasedisolation_merge_region_failure_error_nonisolatedfunction,
-      *srcName, srcIsolationStr, *dstName, dstIsolationStr, declRef.getDecl(),
-      !srcIsolation->isTaskIsolated())
+  diagnoseError(op->getUser(), diag::rbi_merge_failure_nonisolatedfn,
+                srcIsolationStr, dstIsolationStr, declRef.getDecl(),
+                srcIsolation->isTaskIsolated(), dstIsolation->isTaskIsolated())
       .limitBehaviorIf(getBehaviorLimit());
-  diagnoseNote(
-      op->getUser(),
-      diag::
-          regionbasedisolation_merge_region_failure_error_nonisolatedfunction_note,
-      *srcName, srcIsolationStr, *dstName, dstIsolationStr, declRef.getDecl(),
-      !srcIsolation->isTaskIsolated());
+
+  if (auto srcValue = srcRegionValue.maybeGetValue())
+    emitMergeRegionValueNote(srcValue, srcIsolationStr,
+                             srcIsolation->isTaskIsolated());
+  if (auto dstValue = dstRegionValue.maybeGetValue())
+    emitMergeRegionValueNote(dstValue, dstIsolationStr,
+                             dstIsolation->isTaskIsolated());
 }
 
 void IncompatibleRegionMergeDiagnosticEmitter::emitIsolatedFunction() {
@@ -4126,41 +4164,31 @@ void IncompatibleRegionMergeDiagnosticEmitter::emitIsolatedFunction() {
   auto srcIsolationStr = srcIsolation.printForDiagnostics(getFunction());
   auto dstIsolationStr = dstIsolation.printForDiagnostics(getFunction());
 
-  // We should always be able to find a name for an inout sending param. If we
-  // do not, emit an unknown pattern error.
-  auto srcName = inferNameHelper(srcRegionValue.getValue());
-  if (!srcName) {
-    if (auto *svi =
-            dyn_cast<SingleValueInstruction>(srcRegionValue.getValue())) {
-      if (auto *expr = svi->getLoc().getAsASTNode<Expr>()) {
-        diagnoseError(
-            op->getUser(),
-            diag::
-                regionbasedisolation_merge_region_failure_error_functionisolation_type,
-            expr->findOriginalType(), srcIsolationStr, declRef.getDecl(),
-            dstIsolationStr, !srcIsolation->isTaskIsolated())
-            .limitBehaviorIf(getBehaviorLimit());
-        return;
-      }
-    }
-    if (auto *arg = dyn_cast<SILFunctionArgument>(srcRegionValue.getValue())) {
-      diagnoseError(
-          op->getUser(),
-          diag::
-              regionbasedisolation_merge_region_failure_error_functionisolation_type,
-          arg->getDecl()->getInterfaceType(), srcIsolationStr,
-          declRef.getDecl(), dstIsolationStr, !srcIsolation->isTaskIsolated())
-          .limitBehaviorIf(getBehaviorLimit());
-      return;
-    }
-    return emitUnknownPatternError();
+  // Prefer a named primary when we can recover a name for the source value;
+  // fall back to the unnamed form otherwise. The named primary embeds the name
+  // directly so the user does not have to read the follow-up note to see which
+  // value triggered the diagnostic.
+  std::optional<Identifier> srcName;
+  if (auto srcValue = srcRegionValue.maybeGetValue())
+    srcName = inferNameHelper(srcValue);
+
+  if (srcName) {
+    diagnoseError(op->getUser(), diag::rbi_merge_failure_isolatedfn_named,
+                  *srcName, srcIsolationStr, declRef.getDecl(), dstIsolationStr,
+                  srcIsolation->isTaskIsolated(),
+                  dstIsolation->isTaskIsolated())
+        .limitBehaviorIf(getBehaviorLimit());
+  } else {
+    diagnoseError(op->getUser(), diag::rbi_merge_failure_isolatedfn,
+                  srcIsolationStr, declRef.getDecl(), dstIsolationStr,
+                  srcIsolation->isTaskIsolated(),
+                  dstIsolation->isTaskIsolated())
+        .limitBehaviorIf(getBehaviorLimit());
   }
-  diagnoseError(
-      op->getUser(),
-      diag::regionbasedisolation_merge_region_failure_error_functionisolation,
-      *srcName, srcIsolationStr, declRef.getDecl(), dstIsolationStr,
-      !srcIsolation->isTaskIsolated())
-      .limitBehaviorIf(getBehaviorLimit());
+
+  if (auto srcValue = srcRegionValue.maybeGetValue())
+    emitMergeRegionValueNote(srcValue, srcIsolationStr,
+                             srcIsolation->isTaskIsolated());
 }
 
 void IncompatibleRegionMergeDiagnosticEmitter::emitCast() {
@@ -4199,16 +4227,14 @@ void IncompatibleRegionMergeDiagnosticEmitter::emitCast() {
   auto srcIsolationStr = srcIsolation.printForDiagnostics(getFunction());
   auto dstIsolationStr = dstIsolation.printForDiagnostics(getFunction());
 
-  // We should always be able to find a name for an inout sending param. If we
-  // do not, emit an unknown pattern error.
-  auto srcName = inferNameHelper(srcRegionValue.getValue());
-  if (!srcName)
-    return emitUnknownPatternError();
-  diagnoseError(op->getUser(),
-                diag::regionbasedisolation_merge_region_failure_error_cast,
-                *srcName, srcIsolationStr, cast.getTargetFormalType(),
-                dstIsolationStr, !srcIsolation->isTaskIsolated())
+  diagnoseError(op->getUser(), diag::rbi_merge_failure_cast, srcIsolationStr,
+                cast.getTargetFormalType(), dstIsolationStr,
+                srcIsolation->isTaskIsolated(), dstIsolation->isTaskIsolated())
       .limitBehaviorIf(getBehaviorLimit());
+
+  if (auto srcValue = srcRegionValue.maybeGetValue())
+    emitMergeRegionValueNote(srcValue, srcIsolationStr,
+                             srcIsolation->isTaskIsolated());
 }
 
 void IncompatibleRegionMergeDiagnosticEmitter::emit() {

--- a/lib/SILOptimizer/Utils/VariableNameUtils.cpp
+++ b/lib/SILOptimizer/Utils/VariableNameUtils.cpp
@@ -308,6 +308,10 @@ SILValue VariableNameInferrer::findDebugInfoProvidingValuePhiArg(
              variableNamePath.print(llvm::dbgs()));
 
   unsigned oldSnapShotIndex = variableNamePath.pushSnapShot();
+  // Also save firstNameProvidingLoc so we can restore it on failure --
+  // otherwise a failed phi branch could leave us pointing at a loc that
+  // never contributed to the final name path.
+  SourceLoc oldFirstNameProvidingLoc = firstNameProvidingLoc;
   LLVM_DEBUG(llvm::dbgs() << "After pushing a snap shot!\n";
              variableNamePath.print(llvm::dbgs()));
 
@@ -319,6 +323,7 @@ SILValue VariableNameInferrer::findDebugInfoProvidingValuePhiArg(
   }
 
   variableNamePath.popSnapShot(oldSnapShotIndex);
+  firstNameProvidingLoc = oldFirstNameProvidingLoc;
   LLVM_DEBUG(llvm::dbgs() << "After popping a snap shot!\n";
              variableNamePath.print(llvm::dbgs()));
   return SILValue();
@@ -371,7 +376,8 @@ SILValue VariableNameInferrer::findDebugInfoProvidingValueHelper(
     if (auto *use = getAnyDebugUse(searchValue)) {
       if (auto debugVar = DebugVarCarryingInst(use->getUser())) {
         assert(debugVar.getKind() == DebugVarCarryingInst::Kind::DebugValue);
-        variableNamePath.push_back(debugVar.getName());
+        pushPathComponent(debugVar.getName(),
+                          searchValue.getLoc().getSourceLoc());
 
         // We return the value, not the debug_info.
         return searchValue;
@@ -394,7 +400,8 @@ SILValue VariableNameInferrer::findDebugInfoProvidingValueHelper(
             if (auto debugVar = DebugVarCarryingInst(debugUse->getUser())) {
               assert(debugVar.getKind() ==
                      DebugVarCarryingInst::Kind::DebugValue);
-              variableNamePath.push_back(debugVar.getName());
+              pushPathComponent(debugVar.getName(),
+                                searchValue.getLoc().getSourceLoc());
 
               // We return the value, not the debug_info.
               return searchValue;
@@ -408,7 +415,8 @@ SILValue VariableNameInferrer::findDebugInfoProvidingValueHelper(
       if (auto *debugUse = getAnyDebugUse(bbi)) {
         if (auto debugVar = DebugVarCarryingInst(debugUse->getUser())) {
           assert(debugVar.getKind() == DebugVarCarryingInst::Kind::DebugValue);
-          variableNamePath.push_back(debugVar.getName());
+          pushPathComponent(debugVar.getName(),
+                            searchValue.getLoc().getSourceLoc());
 
           // We return the value, not the debug_info.
           return searchValue;
@@ -435,12 +443,14 @@ SILValue VariableNameInferrer::findDebugInfoProvidingValueHelper(
         return SILValue();
       }
 
-      variableNamePath.push_back(DebugVarCarryingInst(allocInst).getName());
+      pushPathComponent(DebugVarCarryingInst(allocInst).getName(),
+                        allocInst->getLoc().getSourceLoc());
       return allocInst;
     }
 
     if (auto *abi = dyn_cast<AllocBoxInst>(searchValue)) {
-      variableNamePath.push_back(DebugVarCarryingInst(abi).getName());
+      pushPathComponent(DebugVarCarryingInst(abi).getName(),
+                        abi->getLoc().getSourceLoc());
       return abi;
     }
 
@@ -452,7 +462,8 @@ SILValue VariableNameInferrer::findDebugInfoProvidingValueHelper(
     }
 
     if (auto *globalAddrInst = dyn_cast<GlobalAddrInst>(searchValue)) {
-      variableNamePath.push_back(VarDeclCarryingInst(globalAddrInst).getName());
+      pushPathComponent(VarDeclCarryingInst(globalAddrInst).getName(),
+                        globalAddrInst->getLoc().getSourceLoc());
       return globalAddrInst;
     }
 
@@ -462,43 +473,50 @@ SILValue VariableNameInferrer::findDebugInfoProvidingValueHelper(
     }
 
     if (auto *rei = dyn_cast<RefElementAddrInst>(searchValue)) {
-      variableNamePath.push_back(VarDeclCarryingInst(rei).getName());
+      pushPathComponent(VarDeclCarryingInst(rei).getName(),
+                        rei->getLoc().getSourceLoc());
       searchValue = rei->getOperand();
       continue;
     }
 
     if (auto *sei = dyn_cast<StructExtractInst>(searchValue)) {
-      variableNamePath.push_back(getNameFromDecl(sei->getField()));
+      pushPathComponent(getNameFromDecl(sei->getField()),
+                        sei->getLoc().getSourceLoc());
       searchValue = sei->getOperand();
       continue;
     }
 
     if (auto *uedi = dyn_cast<UncheckedEnumDataInst>(searchValue)) {
-      variableNamePath.push_back(getNameFromDecl(uedi->getElement()));
+      pushPathComponent(getNameFromDecl(uedi->getElement()),
+                        uedi->getLoc().getSourceLoc());
       searchValue = uedi->getOperand();
       continue;
     }
 
     if (auto *tei = dyn_cast<TupleExtractInst>(searchValue)) {
-      variableNamePath.push_back(getStringRefForIndex(tei->getFieldIndex()));
+      pushPathComponent(getStringRefForIndex(tei->getFieldIndex()),
+                        tei->getLoc().getSourceLoc());
       searchValue = tei->getOperand();
       continue;
     }
 
     if (auto *sei = dyn_cast<StructElementAddrInst>(searchValue)) {
-      variableNamePath.push_back(getNameFromDecl(sei->getField()));
+      pushPathComponent(getNameFromDecl(sei->getField()),
+                        sei->getLoc().getSourceLoc());
       searchValue = sei->getOperand();
       continue;
     }
 
     if (auto *tei = dyn_cast<TupleElementAddrInst>(searchValue)) {
-      variableNamePath.push_back(getStringRefForIndex(tei->getFieldIndex()));
+      pushPathComponent(getStringRefForIndex(tei->getFieldIndex()),
+                        tei->getLoc().getSourceLoc());
       searchValue = tei->getOperand();
       continue;
     }
 
     if (auto *utedai = dyn_cast<UncheckedEnumDataAddrInstBase>(searchValue)) {
-      variableNamePath.push_back(getNameFromDecl(utedai->getElement()));
+      pushPathComponent(getNameFromDecl(utedai->getElement()),
+                        utedai->getLoc().getSourceLoc());
       searchValue = utedai->getEnum();
       continue;
     }
@@ -508,7 +526,8 @@ SILValue VariableNameInferrer::findDebugInfoProvidingValueHelper(
     // them and add the case to the variableNamePath.
     if (auto *e = dyn_cast<EnumInst>(searchValue)) {
       if (e->hasOperand()) {
-        variableNamePath.push_back(getNameFromDecl(e->getElement()));
+        pushPathComponent(getNameFromDecl(e->getElement()),
+                          e->getLoc().getSourceLoc());
         searchValue = e->getOperand();
         continue;
       }
@@ -516,8 +535,9 @@ SILValue VariableNameInferrer::findDebugInfoProvidingValueHelper(
 
     if (auto *dti = dyn_cast_or_null<DestructureTupleInst>(
             searchValue->getDefiningInstruction())) {
-      variableNamePath.push_back(
-          getStringRefForIndex(*dti->getIndexOfResult(searchValue)));
+      pushPathComponent(
+          getStringRefForIndex(*dti->getIndexOfResult(searchValue)),
+          dti->getLoc().getSourceLoc());
       searchValue = dti->getOperand();
       continue;
     }
@@ -525,15 +545,16 @@ SILValue VariableNameInferrer::findDebugInfoProvidingValueHelper(
     if (auto *dsi = dyn_cast_or_null<DestructureStructInst>(
             searchValue->getDefiningInstruction())) {
       unsigned index = *dsi->getIndexOfResult(searchValue);
-      variableNamePath.push_back(
-          getNameFromDecl(dsi->getStructDecl()->getStoredProperties()[index]));
+      pushPathComponent(
+          getNameFromDecl(dsi->getStructDecl()->getStoredProperties()[index]),
+          dsi->getLoc().getSourceLoc());
       searchValue = dsi->getOperand();
       continue;
     }
 
     if (auto *fArg = dyn_cast<SILFunctionArgument>(searchValue)) {
       if (auto *decl = fArg->getDecl()) {
-        variableNamePath.push_back(decl->getBaseName().userFacingName());
+        pushPathComponent(decl->getBaseName().userFacingName(), decl->getLoc());
         return fArg;
       }
     }
@@ -564,14 +585,15 @@ SILValue VariableNameInferrer::findDebugInfoProvidingValueHelper(
       if (call.getSubstCalleeType()->hasSelfParam()) {
         if (auto *f = dyn_cast<FunctionRefBaseInst>(call.getCallee())) {
           if (auto dc = f->getInitiallyReferencedFunction()->getDeclContext()) {
-            variableNamePath.push_back(getNameFromDecl(dc->getAsDecl()));
+            pushPathComponent(getNameFromDecl(dc->getAsDecl()),
+                              call.getLoc().getSourceLoc());
             return call.getSelfArgument();
           }
         }
 
         if (auto *mi = dyn_cast<MethodInst>(call.getCallee())) {
-          variableNamePath.push_back(
-              getNameFromDecl(mi->getMember().getDecl()));
+          pushPathComponent(getNameFromDecl(mi->getMember().getDecl()),
+                            call.getLoc().getSourceLoc());
           return call.getSelfArgument();
         }
       }
@@ -726,6 +748,21 @@ VariableNameInferrer::inferNameAndRoot(SILValue value) {
   if (!rootValue)
     return {};
   return {{fn->getASTContext().getIdentifier(resultingName), rootValue}};
+}
+
+std::optional<std::pair<Identifier, SourceLoc>>
+VariableNameInferrer::inferNameAndFirstPathComponent(SILValue value) {
+  auto *fn = value->getFunction();
+  if (!fn)
+    return {};
+  VariableNameInferrer::Options options;
+  options |= VariableNameInferrer::Flag::InferSelfThroughAllAccessors;
+  SmallString<64> resultingName;
+  VariableNameInferrer inferrer(fn, options, resultingName);
+  if (!inferrer.inferByWalkingUsesToDefs(value))
+    return {};
+  return {{fn->getASTContext().getIdentifier(resultingName),
+           inferrer.getFirstNameProvidingLoc()}};
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/Concurrency/concurrent_value_checking.swift
+++ b/test/Concurrency/concurrent_value_checking.swift
@@ -43,9 +43,9 @@ actor A2 {
     await self.init(valueAsync: value)
   }
 
-  nonisolated init(nonisoAsync value: NotConcurrent, _ c: Int) async {
+  nonisolated init(nonisoAsync value: NotConcurrent, _ c: Int) async { // expected-note {{'value' is exposed to code in the current task}}
     if c == 0 {
-      await self.init(valueAsync: value) // expected-warning {{passing 'value' to 'self'-isolated initializer 'init(valueAsync:)' risks causing data races}}
+      await self.init(valueAsync: value) // expected-warning {{passing 'value' to 'self'-isolated initializer 'init(valueAsync:)' could allow for references between values exposed to code in the current task and 'self'-isolated code risking data races}}
     } else {
       self.init(value: value)
     }

--- a/test/Concurrency/sendable_checking.swift
+++ b/test/Concurrency/sendable_checking.swift
@@ -288,7 +288,7 @@ final class NonSendable {
     value = "update"
   }
 
-  func call() async {
+  func call() async { // expected-tns-note 2 {{'self' is exposed to code in the current task}}
     await update()
     // expected-tns-warning @-1 {{sending 'self' risks causing data races}}
     // expected-tns-note @-2 {{sending task-isolated 'self' to main actor-isolated instance method 'update()' risks causing data races between main actor-isolated and task-isolated uses}}
@@ -297,10 +297,10 @@ final class NonSendable {
     // expected-tns-warning @-1 {{sending 'self' risks causing data races}}
     // expected-tns-note @-2 {{sending task-isolated 'self' to main actor-isolated instance method 'update()' risks causing data races between main actor-isolated and task-isolated uses}}
 
-    _ = await x // expected-tns-warning {{passing 'self' to main actor-isolated getter for property 'x' risks causing data races}}
+    _ = await x // expected-tns-warning {{passing 'self' to main actor-isolated getter for property 'x' could allow for references between values exposed to code in the current task and main actor-isolated code risking data races}}
     // expected-warning@-1 {{non-Sendable type 'NonSendable' cannot be sent into main actor-isolated context in call to property 'x'}}
 
-    _ = await self.x // expected-tns-warning {{passing 'self' to main actor-isolated getter for property 'x' risks causing data races}}
+    _ = await self.x // expected-tns-warning {{passing 'self' to main actor-isolated getter for property 'x' could allow for references between values exposed to code in the current task and main actor-isolated code risking data races}}
       // expected-warning@-1 {{non-Sendable type 'NonSendable' cannot be sent into main actor-isolated context in call to property 'x'}}
   }
 
@@ -479,12 +479,10 @@ struct DowngradeForPreconcurrency {
   var x: NonSendable
   func createStream() -> AsyncStream<NonSendable> {
     AsyncStream<NonSendable> {
-      self.x // expected-tns-ni-warning {{assigning '$return_value' to task-isolated 'self.x.some' risks causing data races}}
-      // expected-tns-ni-note @-1 {{'$return_value' could become accessible to task-isolated code despite remaining accessible to code in the current task}}
-      // expected-tns-ni-ns-warning @-2 {{assigning '$return_value' to @concurrent task-isolated 'self.x.some' risks causing data races}}
-      // expected-tns-ni-ns-note @-3 {{'$return_value' could become accessible to @concurrent task-isolated code despite remaining accessible to code in the current task}}
-      // expected-warning @-4 {{main actor-isolated property 'x' cannot be accessed from outside of the actor; this is an error in the Swift 6 language mode}} {{7-7=await }}
-      // expected-warning @-5 {{non-Sendable type 'NonSendable' of property 'x' cannot exit main actor-isolated context; this is an error in the Swift 6 language mode}}
+      self.x // expected-tns-warning {{assignment could allow for references between values exposed to code in the current task and main actor-isolated code risking data races}}
+      // expected-tns-note @-1 {{'self.x.some' is exposed to main actor-isolated code}}
+      // expected-warning @-2 {{main actor-isolated property 'x' cannot be accessed from outside of the actor; this is an error in the Swift 6 language mode}} {{7-7=await }}
+      // expected-warning @-3 {{non-Sendable type 'NonSendable' of property 'x' cannot exit main actor-isolated context; this is an error in the Swift 6 language mode}}
     }
   }
 }

--- a/test/Concurrency/transfernonsendable.sil
+++ b/test/Concurrency/transfernonsendable.sil
@@ -458,11 +458,10 @@ bb0:
 sil [ossa] @regionMergeAssignMismerge : $@convention(thin) (@guaranteed NonisolatedClassWithMixedFields) -> () {
 bb0(%0 : @guaranteed $NonisolatedClassWithMixedFields):
   debug_value %0 : $NonisolatedClassWithMixedFields, var, name "self"
-  %1 = ref_element_addr %0 : $NonisolatedClassWithMixedFields, #NonisolatedClassWithMixedFields.mainField
+  %1 = ref_element_addr %0 : $NonisolatedClassWithMixedFields, #NonisolatedClassWithMixedFields.mainField // expected-note {{'self.mainField' is exposed to main actor-isolated code}}
   %2 = load [copy] %1
-  %3 = ref_element_addr %0 : $NonisolatedClassWithMixedFields, #NonisolatedClassWithMixedFields.customField
-  store %2 to [assign] %3 // expected-warning {{assigning main actor-isolated 'self.mainField' to global actor 'CustomActor'-isolated 'self.customField' risks causing data races}}
-  // expected-note @-1 {{'self.mainField' could become accessible to global actor 'CustomActor'-isolated code despite remaining accessible to main actor-isolated code}}
+  %3 = ref_element_addr %0 : $NonisolatedClassWithMixedFields, #NonisolatedClassWithMixedFields.customField // expected-note {{'self.customField' is exposed to global actor 'CustomActor'-isolated code}}
+  store %2 to [assign] %3 // expected-warning {{assignment could allow for references between values exposed to main actor-isolated code and global actor 'CustomActor'-isolated code risking data races}}
   %9999 = tuple ()
   return %9999 : $()
 }

--- a/test/Concurrency/transfernonsendable_global_actor.swift
+++ b/test/Concurrency/transfernonsendable_global_actor.swift
@@ -445,8 +445,9 @@ class MyObj {}
 
     init() {
       mergeValues(field!, customField!)
-      mergeValues(field2!, customField!) // expected-warning {{passing global actor 'CustomActor'-isolated 'self.customField' and main actor-isolated 'self.field2' as arguments to local function 'mergeValues' risks causing data races}}
-      // expected-note @-1 {{'self.field2' could begin referencing 'self.customField' allowing concurrent access to 'self.customField' by main actor-isolated code and global actor 'CustomActor'-isolated code}}
+      mergeValues(field2!, customField!) // expected-warning {{passing arguments to local function 'mergeValues' could allow for references between values exposed to global actor 'CustomActor'-isolated code and main actor-isolated code risking data races}}
+      // expected-note @-1 {{'self.field2' is exposed to main actor-isolated code}}
+      // expected-note @-2 {{'self.customField' is exposed to global actor 'CustomActor'-isolated code}}
     }
 
     func testMultipleAccessesAreIndependent() async {
@@ -469,8 +470,9 @@ class MyObj {}
     @CustomActor var customField: NonSendableKlass? = nil
     init() {
       mergeValues(field!, customField!)
-      mergeValues(field2!, customField!) // expected-warning {{passing global actor 'CustomActor'-isolated 'self.customField' and main actor-isolated 'self.field2' as arguments to local function 'mergeValues' risks causing data races}}
-      // expected-note @-1 {{'self.field2' could begin referencing 'self.customField' allowing concurrent access to 'self.customField' by main actor-isolated code and global actor 'CustomActor'-isolated code}}
+      mergeValues(field2!, customField!) // expected-warning {{passing arguments to local function 'mergeValues' could allow for references between values exposed to global actor 'CustomActor'-isolated code and main actor-isolated code risking data races}}
+      // expected-note @-1 {{'self.field2' is exposed to main actor-isolated code}}
+      // expected-note @-2 {{'self.customField' is exposed to global actor 'CustomActor'-isolated code}}
     }
 
     func testMultipleAccessesAreIndependent() async {
@@ -492,8 +494,9 @@ class MyObj {}
 
     init() {
       mergeValues(field!, customField!)
-      mergeValues(field2!, customField!) // expected-warning {{passing global actor 'CustomActor'-isolated 'self.customField' and main actor-isolated 'self.field2' as arguments to local function 'mergeValues' risks causing data races}}
-      // expected-note @-1 {{'self.field2' could begin referencing 'self.customField' allowing concurrent access to 'self.customField' by main actor-isolated code and global actor 'CustomActor'-isolated code}}
+      mergeValues(field2!, customField!) // expected-warning {{passing arguments to local function 'mergeValues' could allow for references between values exposed to global actor 'CustomActor'-isolated code and main actor-isolated code risking data races}}
+      // expected-note @-1 {{'self.field2' is exposed to main actor-isolated code}}
+      // expected-note @-2 {{'self.customField' is exposed to global actor 'CustomActor'-isolated code}}
     }
 
     func testMultipleAccessesAreIndependent() async {
@@ -515,8 +518,9 @@ class MyObj {}
 
     init() {
       mergeValues(field!, customField!)
-      mergeValues(field2!, customField!) // expected-warning {{passing global actor 'CustomActor'-isolated 'self.customField' and main actor-isolated 'self.field2' as arguments to local function 'mergeValues' risks causing data races}}
-      // expected-note @-1 {{'self.field2' could begin referencing 'self.customField' allowing concurrent access to 'self.customField' by main actor-isolated code and global actor 'CustomActor'-isolated code}}
+      mergeValues(field2!, customField!) // expected-warning {{passing arguments to local function 'mergeValues' could allow for references between values exposed to global actor 'CustomActor'-isolated code and main actor-isolated code risking data races}}
+      // expected-note @-1 {{'self.field2' is exposed to main actor-isolated code}}
+      // expected-note @-2 {{'self.customField' is exposed to global actor 'CustomActor'-isolated code}}
     }
 
     func testMultipleAccessesAreIndependent() async {
@@ -558,8 +562,9 @@ actor ActorWithNonisolatedUnsafeField {
 
   init() {
     mergeValues(field!, mainField!)
-    mergeValues(field2!, mainField!) // expected-warning {{passing main actor-isolated 'self.mainField' and 'self'-isolated 'self.field2' as arguments to global function 'mergeValues' risks causing data races}}
-    // expected-note @-1 {{'self.field2' could begin referencing 'self.mainField' allowing concurrent access to 'self.mainField' by 'self'-isolated code and main actor-isolated code}}
+    mergeValues(field2!, mainField!) // expected-warning {{passing arguments to global function 'mergeValues' could allow for references between values exposed to main actor-isolated code and 'self'-isolated code risking data races}}
+    // expected-note @-1 {{'self.field2' is exposed to 'self'-isolated code}}
+    // expected-note @-2 {{'self.mainField' is exposed to main actor-isolated code}}
   }
 
   func testMultipleAccessesAreIndependent() async {

--- a/test/Concurrency/transfernonsendable_isolated_conformances.swift
+++ b/test/Concurrency/transfernonsendable_isolated_conformances.swift
@@ -93,40 +93,44 @@ actor CastTest<T, U : NonSendableProtocol, V : AnyObject, V2 : NonSendableKlassP
   func f() async -> NonSendableProtocol {
     guard let c = await cnx else { fatalError() } // expected-swift5-warning {{non-Sendable type 'NonSendableKlass?' of property 'cnx' cannot exit main actor-isolated context}}
     // expected-swift6-error @-1 {{non-Sendable type 'NonSendableKlass?' of property 'cnx' cannot exit main actor-isolated context}}
-    guard let q = c as? NonSendableProtocol else { fatalError() } // expected-swift5-warning {{casting main actor-isolated 'c' to 'self'-isolated 'any NonSendableProtocol' risks causing data races; this is an error in the Swift 6 language mode}}
-    return q // expected-swift5-warning {{assigning main actor-isolated 'q' to 'self'-isolated '$return_value' risks causing data races}}
-    // expected-swift5-note @-1 {{'q' could become accessible to 'self'-isolated code despite remaining accessible to main actor-isolated code}}
+    guard let q = c as? NonSendableProtocol else { fatalError() } // expected-swift5-warning {{casting value to type 'any NonSendableProtocol' could allow for references between values exposed to main actor-isolated code and 'self'-isolated code risking data races; this is an error in the Swift 6 language mode}}
+    // expected-swift5-note @-1 {{'c' is exposed to main actor-isolated code}}
+    // expected-swift5-note @-2 {{'q' is exposed to main actor-isolated code}}
+    return q // expected-swift5-warning {{assignment could allow for references between values exposed to main actor-isolated code and 'self'-isolated code risking data races}}
   }
 
   func f2() async -> NonSendableProtocol {
     guard let c = await cnx2 else { fatalError() } // expected-swift5-warning {{non-Sendable type 'T?' of property 'cnx2' cannot exit main actor-isolated context}}
     // expected-swift6-error @-1 {{non-Sendable type 'T?' of property 'cnx2' cannot exit main actor-isolated context}}
-    guard let q = c as? NonSendableProtocol else { fatalError() } // expected-swift5-warning {{casting main actor-isolated 'c' to 'self'-isolated 'any NonSendableProtocol' risks causing data races; this is an error in the Swift 6 language mode}}
-    return q // expected-swift5-warning {{assigning main actor-isolated 'q' to 'self'-isolated '$return_value' risks causing data races}}
-    // expected-swift5-note @-1 {{'q' could become accessible to 'self'-isolated code despite remaining accessible to main actor-isolated code}}
+    guard let q = c as? NonSendableProtocol else { fatalError() } // expected-swift5-warning {{casting value to type 'any NonSendableProtocol' could allow for references between values exposed to main actor-isolated code and 'self'-isolated code risking data races; this is an error in the Swift 6 language mode}}
+    // expected-swift5-note @-1 {{'c' is exposed to main actor-isolated code}}
+    // expected-swift5-note @-2 {{'q' is exposed to main actor-isolated code}}
+    return q // expected-swift5-warning {{assignment could allow for references between values exposed to main actor-isolated code and 'self'-isolated code risking data races}}
   }
 
   func f3() async -> NonSendableProtocol {
     guard let c = await cnx3 else { fatalError() } // expected-swift5-warning {{non-Sendable type 'U?' of property 'cnx3' cannot exit main actor-isolated context}}
     // expected-swift6-error @-1 {{non-Sendable type 'U?' of property 'cnx3' cannot exit main actor-isolated context}}
     guard let q = c as? NonSendableProtocol else { fatalError() } // expected-warning {{conditional cast from 'U' to 'any NonSendableProtocol' always succeeds}}
-    return q // expected-swift5-warning {{assigning main actor-isolated 'q' to 'self'-isolated '$return_value' risks causing data races; this is an error in the Swift 6 language mode}}
-    // expected-swift5-note @-1 {{'q' could become accessible to 'self'-isolated code despite remaining accessible to main actor-isolated code}}
+    // expected-swift5-note @-1 {{'q' is exposed to main actor-isolated code}}
+    return q // expected-swift5-warning {{assignment could allow for references between values exposed to main actor-isolated code and 'self'-isolated code risking data races; this is an error in the Swift 6 language mode}}
   }
 
   func g() async -> NonSendableProtocol {
     guard let c = await cnx else { fatalError() } // expected-swift5-warning {{non-Sendable type 'NonSendableKlass?' of property 'cnx' cannot exit main actor-isolated context}}
     // expected-swift6-error @-1 {{non-Sendable type 'NonSendableKlass?' of property 'cnx' cannot exit main actor-isolated context}}
-    let q = c as! NonSendableProtocol // expected-swift5-warning {{assigning main actor-isolated 'c' to 'self'-isolated 'q' risks causing data races}}
-    // expected-swift5-note @-1 {{'c' could become accessible to 'self'-isolated code despite remaining accessible to main actor-isolated code}}
+    let q = c as! NonSendableProtocol // expected-swift5-warning {{assignment could allow for references between values exposed to main actor-isolated code and 'self'-isolated code risking data races}}
+    // expected-swift5-note @-1 {{'c' is exposed to main actor-isolated code}}
+    // expected-swift5-note @-2 {{'q' is exposed to 'self'-isolated code}}
     return q
   }
 
   func g2() async -> NonSendableProtocol {
     guard let c = await cnx2 else { fatalError() } // expected-swift5-warning {{non-Sendable type 'T?' of property 'cnx2' cannot exit main actor-isolated context}}
     // expected-swift6-error @-1 {{non-Sendable type 'T?' of property 'cnx2' cannot exit main actor-isolated context}}
-    let q = c as! NonSendableProtocol // expected-swift5-warning {{assigning main actor-isolated 'c' to 'self'-isolated 'q' risks causing data races}}
-    // expected-swift5-note @-1 {{'c' could become accessible to 'self'-isolated code despite remaining accessible to main actor-isolated code}}
+    let q = c as! NonSendableProtocol // expected-swift5-warning {{assignment could allow for references between values exposed to main actor-isolated code and 'self'-isolated code risking data races}}
+    // expected-swift5-note @-1 {{'c' is exposed to main actor-isolated code}}
+    // expected-swift5-note @-2 {{'q' is exposed to 'self'-isolated code}}
     return q
   }
 
@@ -134,22 +138,24 @@ actor CastTest<T, U : NonSendableProtocol, V : AnyObject, V2 : NonSendableKlassP
     guard let c = await cnx3 else { fatalError() } // expected-swift5-warning {{non-Sendable type 'U?' of property 'cnx3' cannot exit main actor-isolated context}}
     // expected-swift6-error @-1 {{non-Sendable type 'U?' of property 'cnx3' cannot exit main actor-isolated context}}
     let q = c as! NonSendableProtocol // expected-warning {{forced cast from 'U' to 'any NonSendableProtocol' always succeeds; did you mean to use 'as'}}
-    return q // expected-swift5-warning {{assigning main actor-isolated 'q' to 'self'-isolated '$return_value' risks causing data races; this is an error in the Swift 6 language mode}}
-    // expected-swift5-note @-1 {{'q' could become accessible to 'self'-isolated code despite remaining accessible to main actor-isolated code}}
+    // expected-swift5-note @-1 {{'q' is exposed to main actor-isolated code}}
+    return q // expected-swift5-warning {{assignment could allow for references between values exposed to main actor-isolated code and 'self'-isolated code risking data races; this is an error in the Swift 6 language mode}}
   }
 
 
   func h() async -> NonSendableKlassProtocol {
     guard let c = await cnx else { fatalError() } // expected-swift5-warning {{non-Sendable type 'NonSendableKlass?' of property 'cnx' cannot exit main actor-isolated context}}
     // expected-swift6-error @-1 {{non-Sendable type 'NonSendableKlass?' of property 'cnx' cannot exit main actor-isolated context}}
-    guard let q = c as? NonSendableKlassProtocol else { fatalError() } // expected-swift5-warning {{casting main actor-isolated 'c' to 'self'-isolated 'any NonSendableKlassProtocol' risks causing data races}}
+    // expected-swift5-note @-2 {{'c' is exposed to main actor-isolated code}}
+    guard let q = c as? NonSendableKlassProtocol else { fatalError() } // expected-swift5-warning {{casting value to type 'any NonSendableKlassProtocol' could allow for references between values exposed to main actor-isolated code and 'self'-isolated code risking data races}}
     return q
   }
 
   func h2() async -> NonSendableKlassProtocol {
     guard let c = await cnx4 else { fatalError() } // expected-swift5-warning {{non-Sendable type 'V?' of property 'cnx4' cannot exit main actor-isolated context}}
     // expected-swift6-error @-1 {{non-Sendable type 'V?' of property 'cnx4' cannot exit main actor-isolated context}}
-    guard let q = c as? NonSendableKlassProtocol else { fatalError() } // expected-swift5-warning {{casting main actor-isolated 'c' to 'self'-isolated 'any NonSendableKlassProtocol' risks causing data races}}
+    // expected-swift5-note @-2 {{'c' is exposed to main actor-isolated code}}
+    guard let q = c as? NonSendableKlassProtocol else { fatalError() } // expected-swift5-warning {{casting value to type 'any NonSendableKlassProtocol' could allow for references between values exposed to main actor-isolated code and 'self'-isolated code risking data races}}
     return q
   }
 
@@ -163,18 +169,20 @@ actor CastTest<T, U : NonSendableProtocol, V : AnyObject, V2 : NonSendableKlassP
   func k() async -> NonSendableKlassProtocol {
     guard let c = await cnx else { fatalError() } // expected-swift5-warning {{non-Sendable type 'NonSendableKlass?' of property 'cnx' cannot exit main actor-isolated context}}
     // expected-swift6-error @-1 {{non-Sendable type 'NonSendableKlass?' of property 'cnx' cannot exit main actor-isolated context}}
-    let q = c as! NonSendableKlassProtocol // expected-swift5-warning {{assigning main actor-isolated 'c' to 'self'-isolated 'q' risks causing data races}}
-    // expected-swift5-note @-1 {{'c' could become accessible to 'self'-isolated code despite remaining accessible to main actor-isolated code}}
-    // expected-swift5-warning @-2 {{casting main actor-isolated 'c' to 'self'-isolated 'any NonSendableKlassProtocol' risks causing data races}}
+    // expected-swift5-note @-2 2 {{'c' is exposed to main actor-isolated code}}
+    let q = c as! NonSendableKlassProtocol // expected-swift5-warning {{assignment could allow for references between values exposed to main actor-isolated code and 'self'-isolated code risking data races}}
+    // expected-swift5-note @-1 {{'q' is exposed to 'self'-isolated code}}
+    // expected-swift5-warning @-2 {{casting value to type 'any NonSendableKlassProtocol' could allow for references between values exposed to main actor-isolated code and 'self'-isolated code risking data races}}
     return q
   }
 
   func k2() async -> NonSendableKlassProtocol {
     guard let c = await cnx4 else { fatalError() } // expected-swift5-warning {{non-Sendable type 'V?' of property 'cnx4' cannot exit main actor-isolated context}}
     // expected-swift6-error @-1 {{non-Sendable type 'V?' of property 'cnx4' cannot exit main actor-isolated context}}
-    let q = c as! NonSendableKlassProtocol // expected-swift5-warning {{assigning main actor-isolated 'c' to 'self'-isolated 'q' risks causing data races}}
-    // expected-swift5-note @-1 {{'c' could become accessible to 'self'-isolated code despite remaining accessible to main actor-isolated code}}
-    // expected-swift5-warning @-2 {{casting main actor-isolated 'c' to 'self'-isolated 'any NonSendableKlassProtocol' risks causing data races}}
+    // expected-swift5-note @-2 2 {{'c' is exposed to main actor-isolated code}}
+    let q = c as! NonSendableKlassProtocol // expected-swift5-warning {{assignment could allow for references between values exposed to main actor-isolated code and 'self'-isolated code risking data races}}
+    // expected-swift5-note @-1 {{'q' is exposed to 'self'-isolated code}}
+    // expected-swift5-warning @-2 {{casting value to type 'any NonSendableKlassProtocol' could allow for references between values exposed to main actor-isolated code and 'self'-isolated code risking data races}}
     return q
   }
 

--- a/test/Concurrency/transfernonsendable_merge_region_checker_failures.swift
+++ b/test/Concurrency/transfernonsendable_merge_region_checker_failures.swift
@@ -1,0 +1,51 @@
+// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -target %target-swift-5.1-abi-triple -verify %s -o /dev/null -parse-as-library -enable-upcoming-feature GlobalActorIsolatedTypesUsability
+
+// REQUIRES: concurrency
+// REQUIRES: asserts
+// REQUIRES: swift_feature_GlobalActorIsolatedTypesUsability
+
+// This file is the *negative* companion to
+// transfernonsendable_merge_region_diagnostics.swift. Each scenario below is a
+// Swift-level pattern that hits the region-isolation checker's
+// "regionbasedisolation_unknown_pattern" fallback rather than one of the
+// shaped merge diagnostics. These cases represent real coverage holes in
+// either the region analysis (one side's SILIsolationInfo is lost before the
+// merge fires) or the emitter (the operation shape is not matched by any of
+// the five specialised emitters).
+//
+// Pin them here so any future fix that makes the analysis recover --- and thus
+// upgrades one of these warnings into a real shaped diagnostic --- trips the
+// verifier and forces an explicit decision about the new wording.
+
+class NonSendableKlass {}
+
+@globalActor
+actor CustomActor {
+  static let shared = CustomActor()
+}
+
+///////////////////////////////////////////////////////////////////
+// MARK: ternary phi merging cross-domain non-Sendable operands
+///////////////////////////////////////////////////////////////////
+
+// `pick ? a : b` lowers to a SIL phi where each predecessor stores a
+// cross-domain value into the bb argument. The phi merge runs through
+// translateSILPhi -> translateSILMultiAssign(reason = Unknown) ->
+// emitUnknown(). emitUnknown requires both src and dst isolations to be
+// recoverable; here the dst (the phi-result) carries no isolation override and
+// the merge falls through to emitUnknownPatternError().
+//
+// Expected fix: translateSILPhi should propagate one side's isolation onto the
+// phi result so emitUnknown can render its generic
+// "executing operation could allow ..." primary. When that lands, the
+// expectation below will flip to that wording.
+@MainActor
+struct TernaryPhi {
+  var field2: NonSendableKlass? = nil
+  @CustomActor var customField: NonSendableKlass? = nil
+
+  init(_ pick: Bool) {
+    let chosen = pick ? field2! : customField! // expected-warning {{pattern that the region-based isolation checker does not understand how to check. Please file a bug}}
+    _ = chosen
+  }
+}

--- a/test/Concurrency/transfernonsendable_merge_region_diagnostics.swift
+++ b/test/Concurrency/transfernonsendable_merge_region_diagnostics.swift
@@ -1,0 +1,249 @@
+// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -target %target-swift-5.1-abi-triple -verify -verify-additional-prefix named- %s -o /dev/null -parse-as-library -enable-upcoming-feature GlobalActorIsolatedTypesUsability
+// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -target %target-swift-5.1-abi-triple -Xllvm -sil-regionbasedisolation-force-use-of-typed-errors -verify -verify-additional-prefix bare- %s -o /dev/null -parse-as-library -enable-upcoming-feature GlobalActorIsolatedTypesUsability
+
+// REQUIRES: concurrency
+// REQUIRES: asserts
+// REQUIRES: swift_feature_GlobalActorIsolatedTypesUsability
+
+// This file exercises the *shape* of "incompatible region merge" diagnostics
+// produced by the region-isolation analysis. The points being tested:
+//
+//   1. The primary diagnostic does not depend on value-name recovery. Even
+//      under -sil-regionbasedisolation-force-use-of-typed-errors (which
+//      suppresses name inference), every merge that the analysis understands
+//      still produces a real primary -- never the "unknown pattern" fallback.
+//      The two RUN lines exercise both name-recovery paths.
+//
+//   2. Value notes are anchored at each value's *defining* location with
+//      column precision. The bare-note assertions pin the column explicitly
+//      so that any regression in note-loc recovery (the SourceLoc collapsing
+//      back to the merge site, or to the func keyword for SILFunctionArgument)
+//      trips the verifier.
+//
+//   3. The task-isolated side renders as "code in the current task" instead
+//      of "task-isolated code", matching the rest of the diagnostic suite.
+//
+//   4. The isolatedfn primary has two variants: a named form that embeds the
+//      source value's name (default) and an unnamed form ("passing value to
+//      ...") used when name inference fails (typed-errors flag).
+//
+// Coverage matrix
+// ---------------
+//
+// Each emitter in IncompatibleRegionMergeDiagnosticEmitter renders a primary
+// from one of five DiagnosticsSIL.def entries and (zero or more) per-value
+// notes from one of two note diagnostics. The matrix below records, per
+// emitter, which RegionMergeReason dispatches to it, which scenarios in this
+// file exercise it, and which isolation-string variants
+// (cross-actor vs "code in the current task") are covered. The unknown-pattern
+// fallback companion lives in transfernonsendable_merge_region_checker_failures.swift.
+//
+//   emitter / primary diag                  | reason(s)                    | covered by                  | iso variants
+//   -----------------------------------------+------------------------------+-----------------------------+---------------
+//   emitNonisolatedFunction                  | NonisolatedFunction          | TwoIsolatedFields           | actor <-> actor
+//     rbi_merge_failure_nonisolatedfn        |                              |                             |
+//   emitNonisolatedFunction -> emitUnknown   | NonisolatedFunction          | IndirectCallee              | actor <-> actor
+//     rbi_merge_failure_unknown              |   (no recoverable callee)    |                             |
+//   emitUnknown                              | NonisolatedClosure, Builtin, | --- not reachable from      | ---
+//     rbi_merge_failure_unknown              |   Unknown                    |   Swift surface (SIL only)  |
+//   emitAssign                               | Assign                       | CastingActor.f (return q),  | actor <-> actor,
+//     rbi_merge_failure_assign               |                              |   TupleMerge, TaskAssignTest|   task <-> actor
+//   emitIsolatedFunction (named)             | ActorIntroducingInst         | TaskIsolatedSelfTest (named)| task <-> actor
+//     rbi_merge_failure_isolatedfn_named     |   (ApplySite, name found)    |                             |
+//   emitIsolatedFunction (bare)              | ActorIntroducingInst         | TaskIsolatedSelfTest (bare) | task <-> actor
+//     rbi_merge_failure_isolatedfn           |   (ApplySite, no name)       |                             |
+//   emitCast                                 | Cast, ActorIntroducingInst   | CastingActor.f (c as? P)    | actor <-> actor
+//     rbi_merge_failure_cast                 |   (non-ApplySite)            |                             |
+//
+//   per-value note                           | when used                    | covered by                  |
+//   -----------------------------------------+------------------------------+-----------------------------+
+//   rbi_merge_failure_value_note_named       | name inference succeeded     | all named-prefix scenarios  |
+//   rbi_merge_failure_value_note_bare        | name inference failed        | all bare-prefix scenarios   |
+//
+// Known coverage gaps (not reachable cleanly from the Swift surface; would
+// need .sil tests to exercise):
+//
+//   - emitUnknown via NonisolatedClosure / Builtin reasons. The Sema layer
+//     either rejects the cross-domain construction up front or routes the PA
+//     through translateIsolatedPartialApply, so neither reason fires.
+//   - emitNonisolatedFunction with task-isolated source. Sema blocks the
+//     natural patterns (cross-actor property read from task context).
+//   - emitCast with task-isolated source. Same reason as above.
+
+////////////////////////
+// MARK: Declarations //
+////////////////////////
+
+class NonSendableKlass {} // expected-note 2 {{class 'NonSendableKlass' does not conform to the 'Sendable' protocol}}
+
+@globalActor
+actor CustomActor {
+  static let shared = CustomActor()
+}
+
+func mergeValues<T>(_ x: T, _ y: NonSendableKlass) {}
+
+/////////////////////////////////////////////////////////////////
+// MARK: nonisolated callee + two differently-isolated arguments
+/////////////////////////////////////////////////////////////////
+
+// Two properties of differing isolations passed to a nonisolated generic.
+// Each cross-domain property access produces a per-value note anchored at the
+// projection that contributes the leaf component of the inferred name --
+// e.g. `customField!` and `field2!` -- not at the enclosing `init` keyword.
+@MainActor
+struct TwoIsolatedFields {
+  nonisolated(unsafe) var field: NonSendableKlass? = nil
+  var field2: NonSendableKlass? = nil
+  @CustomActor var customField: NonSendableKlass? = nil
+  init() {
+    mergeValues(field!, customField!)
+    mergeValues(field2!, customField!) // expected-warning {{passing arguments to global function 'mergeValues' could allow for references between values exposed to global actor 'CustomActor'-isolated code and main actor-isolated code risking data races}}
+    // expected-named-note @-1:26 {{'self.customField' is exposed to global actor 'CustomActor'-isolated code}}
+    // expected-bare-note @-2:26 {{value is exposed to global actor 'CustomActor'-isolated code}}
+    // expected-named-note @-3:23 {{'self.field2' is exposed to main actor-isolated code}}
+    // expected-bare-note @-4:23 {{value is exposed to main actor-isolated code}}
+  }
+}
+
+/////////////////////////////////////////////////////////////////////
+// MARK: isolated callee + task-isolated source ("code in the current task")
+/////////////////////////////////////////////////////////////////////
+
+// A nonisolated method on a non-Sendable class invoking a @MainActor getter
+// on `self`. `self` is task-isolated -- the merge primary should render this
+// side as "code in the current task". The `self` value note anchors at the
+// `func call` token (col 8) because `self` is a SILFunctionArgument and we
+// resolve to the parameter decl loc.
+//
+// Returning a Sendable type (Int) from the @MainActor getter avoids any
+// follow-up assignment-merge so the diagnostics here focus on the isolatedfn
+// case.
+final class TaskIsolatedSelfTest { // expected-note {{class 'TaskIsolatedSelfTest' does not conform to the 'Sendable' protocol}}
+  func call() async { // expected-named-note@:8 {{'self' is exposed to code in the current task}}
+                      // expected-bare-note@-1:8 {{value is exposed to code in the current task}}
+    _ = await x
+    // expected-named-warning @-1 {{passing 'self' to main actor-isolated getter for property 'x' could allow for references between values exposed to code in the current task and main actor-isolated code risking data races}}
+    // expected-bare-warning @-2 {{passing value to main actor-isolated getter for property 'x' could allow for references between values exposed to code in the current task and main actor-isolated code risking data races}}
+    // expected-warning @-3 {{non-Sendable type 'TaskIsolatedSelfTest' cannot be sent into main actor-isolated context in call to property 'x'; this is an error in the Swift 6 language mode}}
+  }
+
+  @MainActor
+  var x: Int { 0 }
+}
+
+/////////////////////////////////////////////////////////////////
+// MARK: nonisolatedfn falls through to emitUnknown (indirect callee)
+/////////////////////////////////////////////////////////////////
+
+// Calling through a function-typed local loses ApplySite::getCalleeDeclRef(),
+// so emitNonisolatedFunction can not emit its named primary. Instead of
+// degrading to the "unknown pattern" fallback (which is reserved for analysis
+// failures), the emitter falls through to emitUnknown(), which renders the
+// generic "executing operation could allow ..." primary while still preserving
+// per-value notes for both sides of the merge.
+@MainActor
+struct IndirectCallee {
+  var field2: NonSendableKlass? = nil
+  @CustomActor var customField: NonSendableKlass? = nil
+
+  init() {
+    let f: (NonSendableKlass, NonSendableKlass) -> Void = { _, _ in }
+    f(field2!, customField!) // expected-warning {{executing operation could allow for references between values exposed to global actor 'CustomActor'-isolated code and main actor-isolated code risking data races}}
+    // expected-named-note @-1:16 {{'self.customField' is exposed to global actor 'CustomActor'-isolated code}}
+    // expected-named-note @-2:7 {{'self.field2' is exposed to main actor-isolated code}}
+    // expected-bare-note @-3:16 {{value is exposed to global actor 'CustomActor'-isolated code}}
+    // expected-bare-note @-4:7 {{value is exposed to main actor-isolated code}}
+  }
+}
+
+/////////////////////////////////////////////////////////////////
+// MARK: tuple constructor merging cross-domain values
+/////////////////////////////////////////////////////////////////
+
+// A tuple constructor with cross-domain operands lowers to a translateSILAssign
+// (TupleInst is CONSTANT_TRANSLATION AssignDirect), so the merge fires through
+// emitAssign — distinct from the explicit `=` assign covered below by the cast
+// scenario. This exercises the same primary but reached via a different
+// instruction shape.
+@MainActor
+struct TupleMerge {
+  var field2: NonSendableKlass? = nil
+  @CustomActor var customField: NonSendableKlass? = nil
+
+  init(_ tag: Int) {
+    let pair = (field2!, customField!) // expected-warning {{assignment could allow for references between values exposed to global actor 'CustomActor'-isolated code and main actor-isolated code risking data races}}
+    // expected-named-note @-1:26 {{'self.customField' is exposed to global actor 'CustomActor'-isolated code}}
+    // expected-named-note @-2:17 {{'self.field2' is exposed to main actor-isolated code}}
+    // expected-bare-note @-3:26 {{value is exposed to global actor 'CustomActor'-isolated code}}
+    // expected-bare-note @-4:17 {{value is exposed to main actor-isolated code}}
+    _ = pair
+  }
+}
+
+/////////////////////////////////////////////////////////////////
+// MARK: assign — task-isolated source side ("code in the current task")
+/////////////////////////////////////////////////////////////////
+
+// AsyncStream<Element>.init(_:) takes a @Sendable closure executed in a task
+// context. Reading `self.stored` (MainActor-iso) from inside the closure and
+// implicitly yielding it merges a MainActor-iso value into the task-iso
+// continuation, triggering emitAssign with the task-iso rendering on one side.
+//
+// The other warnings on this line are the Sema-side cross-actor access and
+// non-Sendable exit diagnostics — verified here so any regression that
+// suppresses or duplicates them trips the verifier.
+@MainActor
+final class TaskAssignTest {
+  var stored: NonSendableKlass = NonSendableKlass()
+  func makeStream() -> AsyncStream<NonSendableKlass> {
+    AsyncStream<NonSendableKlass> {
+      self.stored // expected-warning {{assignment could allow for references between values exposed to code in the current task and main actor-isolated code risking data races}}
+      // expected-named-note @-1 {{'self.stored.some' is exposed to main actor-isolated code}}
+      // expected-bare-note @-2 {{value is exposed to main actor-isolated code}}
+      // expected-warning @-3 {{main actor-isolated property 'stored' cannot be accessed from outside of the actor; this is an error in the Swift 6 language mode}}
+      // expected-warning @-4 {{non-Sendable type 'NonSendableKlass' of property 'stored' cannot exit main actor-isolated context; this is an error in the Swift 6 language mode}}
+    }
+  }
+}
+
+//////////////////////////////////
+// MARK: cast across domains
+//////////////////////////////////
+
+protocol NonSendableProtocol {}
+
+// An actor whose stored property is @MainActor-isolated. Reading the property
+// drags a main-actor-isolated value into a self-isolated context; the cast
+// then merges into a self-isolated type, and `return` merges into the
+// self-isolated $return_value.
+//
+// This case validates two emitter shapes:
+//   - emitCast: produces "casting value to type ..." with a single value
+//     note for the source.
+//   - emitAssign: produces "assignment could allow for references between ..."
+//     with a value note for the named source value (the $return_value side
+//     has no source loc and is suppressed by emitMergeRegionValueNote).
+actor CastingActor {
+  @MainActor var stored: NonSendableKlass?
+
+  func f() async -> NonSendableProtocol {
+    guard let c = await stored else { fatalError() }
+    // expected-warning @-1 {{non-Sendable type 'NonSendableKlass?' of property 'stored' cannot exit main actor-isolated context; this is an error in the Swift 6 language mode}}
+
+    // The note on `c` anchors at the *use* in the cast (col 21) because the
+    // SIL value being analyzed is the operand of the cast, not the original
+    // `let c` binding.
+    guard let q = c as? NonSendableProtocol else { fatalError() }
+    // expected-warning @-1 {{casting value to type 'any NonSendableProtocol' could allow for references between values exposed to main actor-isolated code and 'self'-isolated code risking data races}}
+    // expected-named-note @-2:21 {{'c' is exposed to main actor-isolated code}}
+    // expected-bare-note @-3:21 {{value is exposed to main actor-isolated code}}
+
+    // The note on `q` anchors at q's defining loc above (col 15 of the
+    // `guard let q = ...` line).
+    return q
+    // expected-warning @-1 {{assignment could allow for references between values exposed to main actor-isolated code and 'self'-isolated code risking data races}}
+    // expected-named-note @-9:15 {{'q' is exposed to main actor-isolated code}}
+    // expected-bare-note @-10:15 {{value is exposed to main actor-isolated code}}
+  }
+}


### PR DESCRIPTION
Restructure the five "incompatible region merge" diagnostics emitted by IncompatibleRegionMergeDiagnosticEmitter so that the primary error never depends on recovering a value name. Previously, when VariableNameInferrer could not infer a name for either side of the merge, every emitter fell back to emitUnknownPatternError() and the user got the unhelpful "we do not understand this pattern" diagnostic for a violation the analysis had in fact understood.

Now:

* Each primary states the *operation* that performs the merge and the two isolation domains involved -- e.g. "passing arguments to %kind2 could allow for references between values exposed to %0 and %1 code, risking data races". The primary requires only the isolation strings and (where applicable) the callee decl or cast target type.

* Per-value details move to follow-up notes anchored at each value's *defining* source location (parameter decl for SILFunctionArgument, defining-instruction loc otherwise) so the user can see where each side came from. Two note variants: named ("'self.x' is exposed to ... code") when name inference succeeds, bare ("value is exposed to ... code") otherwise. We deliberately do not emit a "value of type T" variant because SIL values often do not carry a reliable AST type.

* The shared emitMergeRegionValueNote() helper centralises note emission and the new preciseSourceLocForValue() helper picks the most precise SourceLoc available for a value.

emitNonisolatedFunction now falls through to emitUnknown rather than emitUnknownPatternError when ApplySite/getCalleeDeclRef recovery fails, so the primary still fires with isolation information in those cases. emitUnknownPatternError remains reachable only when isolation info itself is invalid -- a genuinely unknown pattern.

rdar://175592408
