### PR TITLE
[ClangImporter] Import `-_init...:` selectors as initializers

### DIFF
--- a/lib/ClangImporter/ClangAdapter.cpp
+++ b/lib/ClangImporter/ClangAdapter.cpp
@@ -673,9 +673,16 @@ bool importer::isInitMethod(const clang::ObjCMethodDecl *method) {
   if (method->getMethodFamily() != clang::OMF_init)
     return false;
 
-  // Swift restriction: init methods must start with the word "init".
-  auto selector = method->getSelector();
-  return camel_case::getFirstWord(selector.getNameForSlot(0)) == "init";
+  // The selector's first word must be "init", or "_init" for SPI-prefixed
+  // selectors like `-_initFoo:`. The prefix-stripping logic in the importer
+  // assumes the leading word is "init" (with an optional underscore); a
+  // method that has `OMF_init` via an explicit `objc_method_family(init)`
+  // attribute on a selector that doesn't start with `init`/`_init` would
+  // produce a malformed argument label, so we require the syntactic form.
+  auto firstSlot = method->getSelector().getNameForSlot(0);
+  StringRef afterUnderscore =
+      firstSlot.starts_with("_") ? firstSlot.drop_front(1) : firstSlot;
+  return camel_case::getFirstWord(afterUnderscore) == "init";
 }
 
 bool importer::isObjCId(const clang::Decl *decl) {

--- a/lib/ClangImporter/ClangAdapter.cpp
+++ b/lib/ClangImporter/ClangAdapter.cpp
@@ -680,9 +680,8 @@ bool importer::isInitMethod(const clang::ObjCMethodDecl *method) {
   // attribute on a selector that doesn't start with `init`/`_init` would
   // produce a malformed argument label, so we require the syntactic form.
   auto firstSlot = method->getSelector().getNameForSlot(0);
-  StringRef afterUnderscore =
-      firstSlot.starts_with("_") ? firstSlot.drop_front(1) : firstSlot;
-  return camel_case::getFirstWord(afterUnderscore) == "init";
+  firstSlot.consume_front("_");
+  return camel_case::getFirstWord(firstSlot) == "init";
 }
 
 bool importer::isObjCId(const clang::Decl *decl) {

--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -812,7 +812,12 @@ static bool shouldImportAsInitializer(const clang::ObjCMethodDecl *method,
                                       unsigned &prefixLength) {
   /// Is this an initializer?
   if (isInitMethod(method)) {
-    prefixLength = 4;
+    // Length of the leading "init" word (4) plus any leading underscore (1)
+    // on SPI-prefixed selectors like `-_initFoo:`. Callers strip this many
+    // characters from the first selector piece to compute the first
+    // argument label.
+    StringRef firstSlot = method->getSelector().getNameForSlot(0);
+    prefixLength = firstSlot.starts_with("_") ? 5 : 4;
     return true;
   }
 
@@ -2119,8 +2124,11 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
 
     // For initializers, compute the first argument name.
     if (isInitializer) {
+      StringRef firstSlot = selector.getNameForSlot(0);
+      bool hasUnderscorePrefix = firstSlot.starts_with("_");
+
       // Skip over the prefix.
-      auto argName = selector.getNameForSlot(0).substr(initializerPrefixLen);
+      auto argName = firstSlot.substr(initializerPrefixLen);
 
       // Drop "With" if present after the "init".
       bool droppedWith = false;
@@ -2137,7 +2145,24 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
       if (droppedWith && isSwiftReservedName(argName)) {
         selectorSplitScratch = "with";
         selectorSplitScratch +=
-            selector.getNameForSlot(0).substr(initializerPrefixLen + 4);
+            firstSlot.substr(initializerPrefixLen + 4);
+        argName = selectorSplitScratch;
+      }
+
+      // For SPI-prefixed selectors (`-_initFoo:`), preserve the underscore on
+      // the imported argument label so the SPI marker is visible at the use
+      // site, e.g. `init(_foo:)` rather than `init(foo:)`.
+      //
+      // `argName` may currently alias `selectorSplitScratch` (from the
+      // lowercase or with-restore steps above). We read it into a separate
+      // local `withUnderscore` first, then assign back to `selectorSplitScratch`
+      // — this order is safe because `withUnderscore += argName` finishes
+      // reading from the scratch before the scratch is overwritten.
+      if (hasUnderscorePrefix && !argName.empty()) {
+        SmallString<16> withUnderscore;
+        withUnderscore = "_";
+        withUnderscore += argName;
+        selectorSplitScratch = withUnderscore;
         argName = selectorSplitScratch;
       }
 

--- a/test/ClangImporter/Inputs/objc_underscore_init.h
+++ b/test/ClangImporter/Inputs/objc_underscore_init.h
@@ -1,0 +1,37 @@
+@class NSArray;
+
+@interface UnderscoreInitTest
+- (instancetype)init;
+
+// Bare SPI-prefixed init: Clang classifies this as `OMF_init` family;
+// importer should recognize the `_init`-prefixed selector and import as
+// an initializer with a `_`-prefixed first argument label.
+- (instancetype)_initWithOther:(int)x;
+
+// Explicit `swift_name(init(...))` should be honored on a `_init`-prefixed
+// selector; the user's custom argument label is preserved.
+- (instancetype)_initWithOtherSwiftName:(int)x
+    __attribute__((swift_name("init(_otherSwiftName:)")));
+
+// `objc_method_family(init)` on a `_init`-prefixed selector should be
+// honored too.
+- (instancetype)_initWithOtherFamily:(int)x
+    __attribute__((objc_method_family(init)));
+
+// Multi-piece selector: only the first label gets the underscore prefix.
+- (instancetype)_initWithFoo:(int)foo bar:(int)bar;
+
+// Zero-arg `-_init` (just the prefix, no suffix). Imports as `init()`,
+// shadowing the inherited no-arg init.
+- (instancetype)_init __attribute__((objc_method_family(init)));
+
+// `-_initWithArray:` exercises the `omitNeedlessWords` path: without the
+// underscore-preserve fix the omission could collapse the label to `init(_:)`.
+// With the fix, the leading `_` is retained: `init(_array:)`.
+- (instancetype)_initWithArray:(NSArray *)arr;
+
+// Class methods are never imported as initializers, regardless of the
+// underscore prefix or family attribute.
++ (instancetype)_initFromClassMethod:(int)x
+    __attribute__((objc_method_family(init)));
+@end

--- a/test/ClangImporter/Inputs/objc_underscore_init.h
+++ b/test/ClangImporter/Inputs/objc_underscore_init.h
@@ -9,9 +9,11 @@
 - (instancetype)_initWithOther:(int)x;
 
 // Explicit `swift_name(init(...))` should be honored on a `_init`-prefixed
-// selector; the user's custom argument label is preserved.
+// selector. The annotated label differs from what the implicit naming path
+// would produce (`init(_otherSwiftName:)`), so the test fails if the
+// annotation is silently dropped.
 - (instancetype)_initWithOtherSwiftName:(int)x
-    __attribute__((swift_name("init(_otherSwiftName:)")));
+    __attribute__((swift_name("init(customLabel:)")));
 
 // `objc_method_family(init)` on a `_init`-prefixed selector should be
 // honored too.
@@ -25,9 +27,10 @@
 // shadowing the inherited no-arg init.
 - (instancetype)_init __attribute__((objc_method_family(init)));
 
-// `-_initWithArray:` exercises the `omitNeedlessWords` path: without the
-// underscore-preserve fix the omission could collapse the label to `init(_:)`.
-// With the fix, the leading `_` is retained: `init(_array:)`.
+// Unlike `_initWithOther:` above, `NSArray *` matches the trailing `Array`
+// word in the selector, so this routes through `omitNeedlessWordsInFunctionName`
+// after the underscore is prepended. Guards against the label collapsing
+// to `init(_:)`.
 - (instancetype)_initWithArray:(NSArray *)arr;
 
 // Class methods are never imported as initializers, regardless of the

--- a/test/ClangImporter/objc_parse.swift
+++ b/test/ClangImporter/objc_parse.swift
@@ -159,7 +159,10 @@ func newConstruction(_ a: A, aproxy: AProxy) {
   b = B(forWorldDomination:())
   b = B(int: 17, andDouble : 3.14159)
   b = B.new(with: a)
-  B.alloc()._initFoo()
+  // SPI-prefixed init-family selectors like `-_initFoo` are imported as
+  // initializers; the leading underscore is preserved on the argument label
+  // to mark the SPI nature at the use site.
+  b = B(_foo: ())
   b.notAnInit()
 
   // init methods are not imported by themselves.

--- a/test/ClangImporter/objc_underscore_init.swift
+++ b/test/ClangImporter/objc_underscore_init.swift
@@ -1,0 +1,34 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -verify -verify-ignore-unrelated -import-objc-header %S/Inputs/objc_underscore_init.h %s
+
+// REQUIRES: objc_interop
+
+import Foundation
+
+func test() {
+    // Bare `-_initWithOther:` is imported as `init(_other:)`; the leading
+    // underscore is preserved on the argument label so the SPI marker
+    // stays visible at the use site.
+    _ = UnderscoreInitTest(_other: 1)
+
+    // Explicit `swift_name(init(_otherSwiftName:))` is honored.
+    _ = UnderscoreInitTest(_otherSwiftName: 2)
+
+    // `objc_method_family(init)` is honored.
+    _ = UnderscoreInitTest(_otherFamily: 3)
+
+    // Multi-piece selector: first label is `_foo`, second stays plain.
+    _ = UnderscoreInitTest(_foo: 1, bar: 2)
+
+    // Zero-arg `-_init` imports as `init()` (no spurious label).
+    _ = UnderscoreInitTest()
+
+    // `omitNeedlessWords` doesn't strip the leading underscore.
+    _ = UnderscoreInitTest(_array: [])
+
+    // Class methods are never imported as initializers, regardless of the
+    // family attribute. They are imported as class methods instead — the
+    // standard ObjC method-name splitting applies.
+    _ = UnderscoreInitTest._init(fromClassMethod: 1)
+}
+
+

--- a/test/ClangImporter/objc_underscore_init.swift
+++ b/test/ClangImporter/objc_underscore_init.swift
@@ -10,8 +10,10 @@ func test() {
     // stays visible at the use site.
     _ = UnderscoreInitTest(_other: 1)
 
-    // Explicit `swift_name(init(_otherSwiftName:))` is honored.
-    _ = UnderscoreInitTest(_otherSwiftName: 2)
+    // Explicit `swift_name(init(customLabel:))` is honored. The label
+    // differs from what the implicit naming path would produce
+    // (`init(_otherSwiftName:)`), so this fails if the annotation is dropped.
+    _ = UnderscoreInitTest(customLabel: 2)
 
     // `objc_method_family(init)` is honored.
     _ = UnderscoreInitTest(_otherFamily: 3)
@@ -22,7 +24,10 @@ func test() {
     // Zero-arg `-_init` imports as `init()` (no spurious label).
     _ = UnderscoreInitTest()
 
-    // `omitNeedlessWords` doesn't strip the leading underscore.
+    // Unlike `_other:` above, `NSArray *` matches the trailing `Array`
+    // word, routing this through `omitNeedlessWordsInFunctionName` after
+    // the underscore is prepended. Guards against the label collapsing
+    // to `init(_:)`.
     _ = UnderscoreInitTest(_array: [])
 
     // Class methods are never imported as initializers, regardless of the


### PR DESCRIPTION
Methods whose ObjC selector starts with `_init` (the SPI underscore convention) are classified by Clang as the init family but were being imported as Swift methods because `isInitMethod` required the selector's first word to be exactly `init`. Likewise, `objc_method_family(init)` and `swift_name(init(...))` annotations were silently ignored on such selectors.

Accept `_init` as a valid first word and strip the matching prefix when computing the first argument label. The leading underscore is preserved on the resulting label (e.g. `-_initWithFoo:` imports as `init(_foo:)`) so the SPI marker stays visible at the use site.

Addresses rdar://96631007