### PR TITLE
[Sema] Fix `nonisolated(nonsending)` combined with `sending` modifier

### DIFF
--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -688,7 +688,8 @@ private:
   NeverNullType resolveIsolatedTypeRepr(IsolatedTypeRepr *repr,
                                         TypeResolutionOptions options);
   NeverNullType resolveSendingTypeRepr(SendingTypeRepr *repr,
-                                       TypeResolutionOptions options);
+                                       TypeResolutionOptions options,
+                                       TypeAttrSet *attrs);
   NeverNullType resolveNonisolatedNonsendingTypeRepr(NonisolatedNonsendingTypeRepr *repr,
                                               TypeResolutionOptions options);
   NeverNullType
@@ -2923,7 +2924,7 @@ NeverNullType TypeResolver::resolveType(TypeRepr *repr,
   case TypeReprKind::Isolated:
     return resolveIsolatedTypeRepr(cast<IsolatedTypeRepr>(repr), options);
   case TypeReprKind::Sending:
-    return resolveSendingTypeRepr(cast<SendingTypeRepr>(repr), options);
+    return resolveSendingTypeRepr(cast<SendingTypeRepr>(repr), options, /*attrs=*/nullptr);
   case TypeReprKind::NonisolatedNonsending:
     return resolveNonisolatedNonsendingTypeRepr(cast<NonisolatedNonsendingTypeRepr>(repr),
                                          options);
@@ -3753,6 +3754,10 @@ TypeResolver::resolveAttributedType(TypeRepr *repr, TypeResolutionOptions option
   // Packs
   } else if (auto packRepr = dyn_cast<PackTypeRepr>(repr)) {
     ty = resolvePackType(packRepr, options, &attrs);
+
+  // `sending`
+  } else if (auto *sendingRepr = dyn_cast<SendingTypeRepr>(repr)) {
+    ty = resolveSendingTypeRepr(sendingRepr, options, &attrs);
 
   // Otherwise, just resolve normally.
   } else {
@@ -5705,7 +5710,8 @@ TypeResolver::resolveIsolatedTypeRepr(IsolatedTypeRepr *repr,
 
 NeverNullType
 TypeResolver::resolveSendingTypeRepr(SendingTypeRepr *repr,
-                                     TypeResolutionOptions options) {
+                                     TypeResolutionOptions options,
+                                     TypeAttrSet  *attrs) {
   if (options.is(TypeResolverContext::TupleElement)) {
     diagnoseInvalid(repr, repr->getSpecifierLoc(),
                     diag::sending_cannot_be_applied_to_tuple_elt);
@@ -5719,6 +5725,15 @@ TypeResolver::resolveSendingTypeRepr(SendingTypeRepr *repr,
     diagnoseInvalid(repr, repr->getSpecifierLoc(),
                     diag::sending_only_on_parameters_and_results);
     return ErrorType::get(getASTContext());
+  }
+
+  // Handles situations like `nonisolated(nonsending) sending @escaping ...`
+  if (attrs) {
+    auto *baseRepr = repr->getBase();
+    if (auto *attrRepr = dyn_cast<AttributedTypeRepr>(baseRepr)) {
+      baseRepr = attrs->accumulate(attrRepr);
+    }
+    return resolveAttributedType(baseRepr, options, *attrs);
   }
 
   // Return the type.

--- a/test/Concurrency/attr_execution/nonisolated_cross_module_with_flag_enabled.swift
+++ b/test/Concurrency/attr_execution/nonisolated_cross_module_with_flag_enabled.swift
@@ -94,6 +94,9 @@ public struct TestGenericTypeAlias {
   public subscript<U>(_: G<U>) -> Bool { false }
 }
 
+// CHECK: nonisolated(nonsending) public func test(_: nonisolated(nonsending) sending @escaping () async -> Swift::Void) async
+public func test(_: nonisolated(nonsending) sending @escaping () async -> Void) async {}
+
 //--- Client.swift
 import A
 


### PR DESCRIPTION
`nonisolated(nonsending)` is currently represented as a bit on `TypeAttrSet` so in order to avoid inferring it when it's already explicitly specified the attributes have to be propagated down the type chain through `sending`.

Resolves: rdar://177435927

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
