### PR TITLE
[6.4.x] AST: Adjust to renamed `llvm::Intrinsic::IITDescriptor` fields

### DIFF
--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -2684,13 +2684,13 @@ Type IntrinsicTypeDecoder::decodeImmediate() {
   case IITDescriptor::Quad:
     return Context.TheIEEE128Type;
   case IITDescriptor::Integer:
-    return BuiltinIntegerType::get(D.Integer_Width, Context);
+    return BuiltinIntegerType::get(D.IntegerWidth, Context);
 
   // A vector of an immediate type.
   case IITDescriptor::Vector: {
     Type eltType = decodeImmediate();
     if (!eltType) return Type();
-    return makeVector(eltType, D.Vector_Width.getKnownMinValue());
+    return makeVector(eltType, D.VectorWidth.getKnownMinValue());
   }
   
   // The element type of a vector type.
@@ -2706,7 +2706,7 @@ Type IntrinsicTypeDecoder::decodeImmediate() {
   case IITDescriptor::Pointer: {
     Type pointeeType = decodeImmediate();
     if (!pointeeType) return Type();
-    return makePointer(pointeeType, D.Pointer_AddressSpace);
+    return makePointer(pointeeType, D.PointerAddressSpace);
   }
 
   // A type argument.
@@ -2726,7 +2726,7 @@ Type IntrinsicTypeDecoder::decodeImmediate() {
   // A struct, which we translate as a tuple.
   case IITDescriptor::Struct: {
     SmallVector<TupleTypeElt, 5> Elts;
-    for (unsigned i = 0; i != D.Struct_NumElements; ++i) {
+    for (unsigned i = 0; i != D.StructNumElements; ++i) {
       Type T = decodeImmediate();
       if (!T) return Type();
       


### PR DESCRIPTION
Paired with https://github.com/swiftlang/llvm-project/pull/13016.

- **Explanation**: Minor adjustments for an LLVM cherry-pick to avoid a non-essential difference between main and rebranch (swift).
- **Scope**: —
- **Issues**: —
- **Original PRs**: https://github.com/swiftlang/swift/pull/89274.
- **Risk**: None
- **Testing**: —
- **Reviewers**: 
