### PR TITLE
[cxx-interop] Fix crash when specializing a templated SubscriptDecl

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -7363,19 +7363,17 @@ ClangImporter::instantiateCXXClassTemplate(
 // "long long" and then back into Swift as "Int64" not "Int."
 static ValueDecl *rewriteIntegerTypes(SubstitutionMap subst, ValueDecl *oldDecl,
                                       AbstractFunctionDecl *newDecl) {
-  auto originalFnSubst = cast<AbstractFunctionDecl>(oldDecl)
-                             ->getInterfaceType()
+  auto originalFnSubst = oldDecl->getInterfaceType()
                              ->getAs<GenericFunctionType>()
                              ->substGenericArgs(subst);
-  // The constructor type is a function type as follows:
-  //   (CType.Type) -> (Generic) -> CType
-  // And a method's function type is as follows:
-  //   (inout CType) -> (Generic) -> Void
-  // In either case, we only want the result of that function type because that
-  // is the function type with the generic params that need to be substituted:
-  //   (Generic) -> CType
-  if (isa<ConstructorDecl>(oldDecl) || oldDecl->isInstanceMember() ||
-      oldDecl->isStatic())
+  // AbstractFunctionDecl interface types with an implicit self are curried as:
+  //   (Self[.Type]) -> (Generic) -> Result
+  // Strip the outer self arrow to get the (Generic) -> Result layer, which is
+  // what the rest of this function compares against newDecl's parameters.
+  // SubscriptDecl interface types are not curried this way (they are already
+  // (Generic) -> Element; see InterfaceTypeRequest::evaluate).
+  if (auto *afd = dyn_cast<AbstractFunctionDecl>(oldDecl);
+      afd && afd->hasImplicitSelfDecl())
     originalFnSubst = cast<FunctionType>(originalFnSubst->getResult().getPointer());
 
   SmallVector<ParamDecl *, 4> fixedParameters;

--- a/test/Interop/Cxx/operators/Inputs/subscript-overloads.h
+++ b/test/Interop/Cxx/operators/Inputs/subscript-overloads.h
@@ -90,3 +90,14 @@ public:
   __attribute__((deprecated("use GetVal instead")))
   unsigned operator[](DeprecatedIndex d) const { return storage[d.index].val; }
 };
+
+struct TemplatedReturningInt {
+    int data[4] = {};
+    template<typename I> int &operator[](I index) { return data[index]; }
+};
+
+struct TemplatedTakingInt {
+    int data[4] = {};
+    // This template doesn't instantiate unless I is int. Bogus but valid.
+    template<typename I> I &operator[](int x) { return data[x]; }
+};

--- a/test/Interop/Cxx/operators/subscript-overloads-typechecker.swift
+++ b/test/Interop/Cxx/operators/subscript-overloads-typechecker.swift
@@ -122,3 +122,11 @@ u[getValPtr] = uGetValPtr // expected-error {{subscript is get-only}}
 
 let deprecatedIdx = Overloaded.DeprecatedIndex(index: 0)
 let _: CUnsignedInt = v[deprecatedIdx] // expected-warning {{deprecated: use GetVal instead}}
+
+var tri = TemplatedReturningInt()
+tri[CInt(0)] = CInt(4)
+let _ = tri[CInt(0)]
+
+var tti = TemplatedTakingInt()
+tti[CInt(0)] = CInt(4)
+let _: CInt = tti[CInt(0)]


### PR DESCRIPTION
rewriteIntegerTypes unwrapped the outer (Self) -> ... curry layer for any instance member, constructor, or static decl. SubscriptDecl interface types are not curried this way (they are already (Args) -> Element), so the strip overshot into the bare element type and the subsequent getParams() dereferenced garbage.

Gate the unwrap on hasImplicitSelfDecl(), which is the precise condition for having an outer Self curry layer.

rdar://177482177
