### PR TITLE
[rbi] Downgrade 'inout sending' returned via sending indirect out to warning until a future language version.

### DIFF
--- a/include/swift/SILOptimizer/Utils/PartitionUtils.h
+++ b/include/swift/SILOptimizer/Utils/PartitionUtils.h
@@ -1402,6 +1402,9 @@ public:
     /// parameter of a actor isolated method... this is that actor isolation.
     SILDynamicMergedIsolationInfo isolationInfo;
 
+    /// If set, the emitter should downgrade this error to a warning.
+    bool downgradeToWarning = false;
+
     InOutSendingReturnedError(const PartitionOp &op,
                               Element inoutSendingElement,
                               Element returnedValue,
@@ -2255,9 +2258,10 @@ public:
       // them to be send separately.
       if (auto outParam =
           findSendingOutParameterInRegion(inoutSendingRegion)) {
-        handleError(InOutSendingReturnedError(op, op.getOpArg1(),
-                                              outParam.value(),
-                                              dynamicRegionIsolation));
+        InOutSendingReturnedError error(op, op.getOpArg1(), outParam.value(),
+                                       dynamicRegionIsolation);
+        error.downgradeToWarning = true;
+        handleError(std::move(error));
         return;
       }
 

--- a/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
@@ -2534,6 +2534,7 @@ private:
   /// isolation.
   SILDynamicMergedIsolationInfo isolationInfo;
 
+  bool downgradeToWarning = false;
   bool emittedErrorDiagnostic = false;
 
 public:
@@ -2548,7 +2549,8 @@ public:
         inoutSendingParamElement(error.inoutSendingElement),
         returnedValue(
             raFuncInfo->getValueMap().getRepresentative(error.returnedValue)),
-        isolationInfo(error.isolationInfo) {}
+        isolationInfo(error.isolationInfo),
+        downgradeToWarning(error.downgradeToWarning) {}
 
   ~InOutSendingReturnedDiagnosticEmitter() {
     // If we were supposed to emit a diagnostic and didn't emit an unknown
@@ -2686,9 +2688,11 @@ public:
   InFlightDiagnostic diagnoseError(SourceLoc loc, Diag<T...> diag,
                                    U &&...args) {
     emittedErrorDiagnostic = true;
-    return std::move(getASTContext()
-                         .Diags.diagnose(loc, diag, std::forward<U>(args)...)
-                         .warnUntilLanguageMode(LanguageMode::v6));
+    auto diag_ = getASTContext().Diags.diagnose(loc, diag,
+                                                std::forward<U>(args)...);
+    if (downgradeToWarning)
+      return std::move(diag_.warnUntilLanguageMode(LanguageMode::future));
+    return std::move(diag_.warnUntilLanguageMode(LanguageMode::v6));
   }
 
   template <typename... T, typename... U>

--- a/test/Concurrency/transfernonsendable_inout_sending_indirect_out.swift
+++ b/test/Concurrency/transfernonsendable_inout_sending_indirect_out.swift
@@ -125,14 +125,14 @@ func takeSendingClosureThrowing<T>(_ fn: (inout sending NonSendableKlass) throws
 
 // The closure { $0 } directly returns the inout sending parameter via sending @out.
 func testSendingClosureReturnsInOutSendingParam() {
-  let _ = takeSendingClosure { $0 } // expected-error {{'inout sending' parameter '$0' cannot be returned}}
+  let _ = takeSendingClosure { $0 } // expected-warning {{'inout sending' parameter '$0' cannot be returned}}
   // expected-note @-1 {{returning 'inout sending' parameter '$0' risks concurrent access as caller assumes '$0' and result can be sent to different isolation domains}}
 }
 
 // Same pattern but with an explicit closure body.
 func testSendingClosureExplicitReturn() {
   let _ = takeSendingClosure { (x: inout sending NonSendableKlass) -> NonSendableKlass in
-    return x // expected-error {{'inout sending' parameter 'x' cannot be returned}}
+    return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
     // expected-note @-1 {{returning 'inout sending' parameter 'x' risks concurrent access as caller assumes 'x' and result can be sent to different isolation domains}}
   }
 }
@@ -141,7 +141,7 @@ func testSendingClosureExplicitReturn() {
 func testSendingClosureReturnsDerivedValue() {
   let _ = takeSendingClosure { (x: inout sending NonSendableKlass) -> NonSendableKlass in
     let y = x
-    return y // expected-error {{'y' cannot be returned}}
+    return y // expected-warning {{'y' cannot be returned}}
     // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' and result can be sent to different isolation domains}}
   }
 }
@@ -157,7 +157,7 @@ func testSendingClosureReturnsFreshValue() {
 func testSendingClosureAssignsOverButStillReturnsIt() {
   let _ = takeSendingClosure { (state: inout sending NonSendableKlass) -> NonSendableKlass in
     state = NonSendableKlass()
-    return state // expected-error {{'inout sending' parameter 'state' cannot be returned}}
+    return state // expected-warning {{'inout sending' parameter 'state' cannot be returned}}
     // expected-note @-1 {{returning 'inout sending' parameter 'state' risks concurrent access as caller assumes 'state' and result can be sent to different isolation domains}}
   }
 }
@@ -179,7 +179,7 @@ func testSendingClosureAssignsToCapture() {
 
 // A function returning 'sending some Any' has an indirect @out sending result in SIL.
 func returnInOutSendingViaSendingOpaqueResult(_ x: inout sending NonSendableKlass) -> sending some Any {
-  return x // expected-error {{'inout sending' parameter 'x' cannot be returned}}
+  return x // expected-warning {{'inout sending' parameter 'x' cannot be returned}}
   // expected-note @-1 {{returning 'inout sending' parameter 'x' risks concurrent access as caller assumes 'x' and result can be sent to different isolation domains}}
 }
 
@@ -192,7 +192,7 @@ func returnInOutSendingGenericSending<T: AnyObject>(_ x: inout sending T) -> sen
 // Returning a derived value through sending indirect out.
 func returnDerivedViaSendingOpaqueResult(_ x: inout sending NonSendableKlass) -> sending some Any {
   let y = x
-  return y // expected-error {{'y' cannot be returned}}
+  return y // expected-warning {{'y' cannot be returned}}
   // expected-note @-1 {{returning 'y' risks concurrent access to 'inout sending' parameter 'x' as caller assumes 'x' and result can be sent to different isolation domains}}
 }
 

--- a/test/Concurrency/transfernonsendable_inout_sending_mutex.swift
+++ b/test/Concurrency/transfernonsendable_inout_sending_mutex.swift
@@ -19,7 +19,7 @@ class NonSendableKlass {
 // a reference that aliases the Mutex's protected state.
 func testMutexWithLockReturnsParam() {
   let m = Mutex(NonSendableKlass())
-  let _ = m.withLock { $0 } // expected-error {{'inout sending' parameter '$0' cannot be returned}}
+  let _ = m.withLock { $0 } // expected-warning {{'inout sending' parameter '$0' cannot be returned}}
   // expected-note @-1 {{returning 'inout sending' parameter '$0' risks concurrent access as caller assumes '$0' and result can be sent to different isolation domains}}
 }
 
@@ -27,7 +27,7 @@ func testMutexWithLockReturnsParam() {
 func testMutexWithLockExplicitClosure() {
   let m = Mutex(NonSendableKlass())
   let _ = m.withLock { (state: inout sending NonSendableKlass) -> NonSendableKlass in
-    return state // expected-error {{'inout sending' parameter 'state' cannot be returned}}
+    return state // expected-warning {{'inout sending' parameter 'state' cannot be returned}}
     // expected-note @-1 {{returning 'inout sending' parameter 'state' risks concurrent access as caller assumes 'state' and result can be sent to different isolation domains}}
   }
 }
@@ -37,7 +37,7 @@ func testMutexWithLockReturnsDerived() {
   let m = Mutex(NonSendableKlass())
   let _ = m.withLock { (state: inout sending NonSendableKlass) -> NonSendableKlass in
     let copy = state
-    return copy // expected-error {{'copy' cannot be returned}}
+    return copy // expected-warning {{'copy' cannot be returned}}
     // expected-note @-1 {{returning 'copy' risks concurrent access to 'inout sending' parameter 'state' as caller assumes 'state' and result can be sent to different isolation domains}}
   }
 }
@@ -55,7 +55,7 @@ func testMutexWithLockAssignsOverButStillReturnsIt() {
   let m = Mutex(NonSendableKlass())
   let _ = m.withLock { (state: inout sending NonSendableKlass) -> NonSendableKlass in
     state = NonSendableKlass()
-    return state // expected-error {{'inout sending' parameter 'state' cannot be returned}}
+    return state // expected-warning {{'inout sending' parameter 'state' cannot be returned}}
     // expected-note @-1 {{returning 'inout sending' parameter 'state' risks concurrent access as caller assumes 'state' and result can be sent to different isolation domains}}
   }
 }


### PR DESCRIPTION
The diagnostic introduced in 472e938a for the case where an 'inout sending' parameter is returned through a sending indirect out result is hitting too many people in the field. Add a downgradeToWarning field to InOutSendingReturnedError and set it for this specific case so the emitter issues a warning instead of an error. We found it was having too many source stability impacts.

rdar://177491579
