### PR TITLE
SIL: add more assert checks for deleting instructions

### DIFF
--- a/lib/SIL/IR/SILBasicBlock.cpp
+++ b/lib/SIL/IR/SILBasicBlock.cpp
@@ -103,7 +103,7 @@ void SILBasicBlock::erase(SILInstruction *I) {
 }
 
 void SILBasicBlock::erase(SILInstruction *I, SILModule &module) {
-  assert(!I->isDeleted() && "double delete of instruction");
+  ASSERT(!I->isDeleted() && "double delete of instruction");
   module.willDeleteInstruction(I);
   InstList.remove(I);
   I->asSILNode()->markAsDeleted();

--- a/lib/SIL/IR/SILModule.cpp
+++ b/lib/SIL/IR/SILModule.cpp
@@ -231,6 +231,12 @@ void SILModule::scheduleForDeletion(SILInstruction *I) {
 
 void SILModule::flushDeletedInsts() {
   for (SILInstruction *instToDelete : scheduledForDeletion) {
+    for (SILValue result: instToDelete->getResults()) {
+      ASSERT(result->use_empty() && "deleted instruction is still used");
+    }
+    for (Operand &op : instToDelete->getAllOperands()) {
+      ASSERT(!op.get() && "deleted instruction is using a value");
+    }
     SILInstruction::destroy(instToDelete);
     AlignedFree(instToDelete);
   }


### PR DESCRIPTION
* `assert` -> `ASSERT` for checking if an instruction is deleted twice. This will let us catch an error also with non-assert compiler builds.
* add checks that a deleted instructions is not used and is not using other values

This will hopefully give us more information for some rare non-deterministic compiler crashes. rdar://176816390
