### PR TITLE
Eliminate un-necessary retain/release on unsafe current task

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -218,6 +218,7 @@ set(SWIFT_BENCH_MODULES
     single-source/UTF8Decode
     single-source/UTF16Decode
     single-source/Walsh
+    single-source/WithUnsafeCurrentTask
     single-source/WordCount
     single-source/XorLoop
     cxx-source/CreateObjects

--- a/benchmark/single-source/WithUnsafeCurrentTask.swift
+++ b/benchmark/single-source/WithUnsafeCurrentTask.swift
@@ -1,0 +1,115 @@
+//===--- WithUnsafeCurrentTask.swift --------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+// Measures the cost of `withUnsafeCurrentTask`.
+
+import TestsUtils
+
+public var benchmarks: [BenchmarkInfo] {
+  guard #available(macOS 14, iOS 17, tvOS 17, watchOS 10, *) else {
+    return []
+  }
+  return [
+    BenchmarkInfo(
+      name: "WithUnsafeCurrentTask.Empty",
+      runFunction: run_WithUnsafeCurrentTask_Empty,
+      tags: [.concurrency]
+    ),
+    BenchmarkInfo(
+      name: "WithUnsafeCurrentTask.Empty.NoTask",
+      runFunction: run_WithUnsafeCurrentTask_NoTask,
+      tags: [.concurrency]
+    ),
+    BenchmarkInfo(
+      name: "WithUnsafeCurrentTask.Priority",
+      runFunction: run_WithUnsafeCurrentTask_Priority,
+      tags: [.concurrency]
+    ),
+    BenchmarkInfo(
+      name: "WithUnsafeCurrentTask.IsCancelled",
+      runFunction: run_WithUnsafeCurrentTask_IsCancelled,
+      tags: [.concurrency]
+    ),
+    BenchmarkInfo(
+      name: "WithUnsafeCurrentTask.Hash",
+      runFunction: run_WithUnsafeCurrentTask_Hash,
+      tags: [.concurrency]
+    ),
+  ]
+}
+
+// Empty closure body — isolates the cost of obtaining an `UnsafeCurrentTask`.
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
+private func run_WithUnsafeCurrentTask_Empty(_ n: Int) async {
+  for _ in 0..<n {
+    for _ in 0..<10_000 {
+      withUnsafeCurrentTask { task in
+        blackHole(task != nil)
+      }
+    }
+  }
+}
+
+// Empty closure body invoked outside any Task — measures the nil-return fast
+// path (`swift_task_getCurrent` returning null + a body call with `nil`).
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
+private func run_WithUnsafeCurrentTask_NoTask(_ n: Int) {
+  for _ in 0..<n {
+    for _ in 0..<10_000 {
+      withUnsafeCurrentTask { task in
+        blackHole(task == nil)
+      }
+    }
+  }
+}
+
+// Read `priority` inside the closure — exercises a runtime call on the
+// task pointer in addition to the acquisition cost.
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
+private func run_WithUnsafeCurrentTask_Priority(_ n: Int) async {
+  for _ in 0..<n {
+    for _ in 0..<10_000 {
+      withUnsafeCurrentTask { task in
+        if let p = task?.priority {
+          blackHole(p.rawValue)
+        }
+      }
+    }
+  }
+}
+
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
+private func run_WithUnsafeCurrentTask_IsCancelled(_ n: Int) async {
+  for _ in 0..<n {
+    for _ in 0..<10_000 {
+      withUnsafeCurrentTask { task in
+        blackHole(task?.isCancelled == true)
+      }
+    }
+  }
+}
+
+// Hash the `UnsafeCurrentTask` value — exercises the value-witness path
+// that previously had to bridge through `Builtin.bridgeToRawPointer`.
+@available(macOS 14, iOS 17, tvOS 17, watchOS 10, *)
+private func run_WithUnsafeCurrentTask_Hash(_ n: Int) async {
+  for _ in 0..<n {
+    for _ in 0..<10_000 {
+      withUnsafeCurrentTask { task in
+        guard let task = task else { return }
+        var h = Hasher()
+        task.hash(into: &h)
+        blackHole(h.finalize())
+      }
+    }
+  }
+}

--- a/benchmark/utils/main.swift
+++ b/benchmark/utils/main.swift
@@ -223,6 +223,7 @@ import TypeFlood
 import UTF8Decode
 import UTF16Decode
 import Walsh
+import WithUnsafeCurrentTask
 import WordCount
 import XorLoop
 
@@ -440,6 +441,7 @@ register(TypeFlood.benchmarks)
 register(UTF8Decode.benchmarks)
 register(UTF16Decode.benchmarks)
 register(Walsh.benchmarks)
+register(WithUnsafeCurrentTask.benchmarks)
 register(WordCount.benchmarks)
 register(XorLoop.benchmarks)
 

--- a/stdlib/public/Concurrency/Task+PriorityEscalation.swift
+++ b/stdlib/public/Concurrency/Task+PriorityEscalation.swift
@@ -44,7 +44,7 @@ extension Task {
   ///   - newPriority: the new priority the task should continue executing on
   @available(SwiftStdlib 6.2, *)
   public func escalatePriority(to newPriority: TaskPriority) {
-    _taskEscalate(self._task, newPriority: newPriority.rawValue)
+    unsafe _taskEscalate(_AsyncTask(self._task), newPriority: newPriority.rawValue)
   }
 }
 
@@ -77,7 +77,7 @@ extension UnsafeCurrentTask {
   ///   - newPriority: the new priority the task should continue executing on
   @available(SwiftStdlib 6.2, *)
   public func escalatePriority(to newPriority: TaskPriority) {
-    unsafe _taskEscalate(self._task, newPriority: newPriority.rawValue)
+    unsafe _taskEscalate(self._rawTask, newPriority: newPriority.rawValue)
   }
 }
 

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -250,7 +250,7 @@ extension Task {
   /// - SeeAlso: `Task.checkCancellation()`
   /// - SeeAlso: `withTaskCancellationHandler(operation:onCancel:isolation:)`
   public func cancel() {
-    _taskCancel(_task)
+    unsafe _taskCancel(_AsyncTask(_task))
   }
 }
 
@@ -433,7 +433,7 @@ extension Task where Success == Never, Failure == Never {
     unsafe withUnsafeCurrentTask { task in
       // If we are running on behalf of a task, use that task's priority.
       if let unsafeTask = unsafe task {
-         return unsafe TaskPriority(rawValue: _taskBasePriority(unsafeTask._task))
+         return unsafe TaskPriority(rawValue: _taskBasePriority(unsafeTask._rawTask))
       }
       return nil
     }
@@ -637,7 +637,7 @@ extension Task {
   @inlinable
   @available(SwiftStdlib 6.4, *)
   public var name: String? {
-    if let name = unsafe _getTaskName(self._task) {
+    if let name = unsafe _getTaskName(_AsyncTask(self._task)) {
       unsafe String(cString: name)
     } else {
       nil
@@ -713,14 +713,9 @@ extension Task where Success == Never, Failure == Never {
 /// - Returns: The return value, if any, of the `body` closure.
 @available(SwiftStdlib 5.1, *)
 public func withUnsafeCurrentTask<T>(body: (UnsafeCurrentTask?) throws -> T) rethrows -> T {
-  guard let _task = _getCurrentAsyncTask() else {
+  guard let _task = unsafe _getCurrentAsyncTask() else {
     return try body(nil)
   }
-
-  // FIXME: This retain seems pretty wrong, however if we don't we WILL crash
-  //        with "destroying a task that never completed" in the task's destroy.
-  //        How do we solve this properly?
-  Builtin.retain(_task)
 
   return try unsafe body(UnsafeCurrentTask(_task))
 }
@@ -762,12 +757,9 @@ public func withUnsafeCurrentTask<T>(body: (UnsafeCurrentTask?) throws -> T) ret
 public nonisolated(nonsending) func withUnsafeCurrentTask<T>(
   body: nonisolated(nonsending) (UnsafeCurrentTask?) async throws -> T
 ) async rethrows -> T {
-  guard let _task = _getCurrentAsyncTask() else {
+  guard let _task = unsafe _getCurrentAsyncTask() else {
     return try await body(nil)
   }
-
-  // FIXME: This will be unnecessary once we avoid the release of the task builtin
-  Builtin.retain(_task)
 
   return try unsafe await body(UnsafeCurrentTask(_task))
 }
@@ -811,13 +803,30 @@ internal func __abi_withUnsafeCurrentTask<T>(
 public struct UnsafeCurrentTask {
   @usableFromInline
   @available(SwiftStdlib 5.1, *)
-  internal let _task: Builtin.NativeObject
+  internal let _rawTask: _AsyncTask
+
+  /// ABI-compat shim for the old `_task: Builtin.NativeObject` accessor.
+  /// Inlined client code compiled against earlier stdlibs references the
+  /// mangled `_$sSct5_taskBovg` / `_$sSct5_taskBovpMV` symbols; preserving
+  /// them keeps that code linking. The old caller's calling convention
+  /// expects a `+1` owned reference, so we retain on each call.
+  @usableFromInline
+  @available(SwiftStdlib 5.1, *)
+  internal var _task: Builtin.NativeObject {
+    @_transparent
+    get {
+      let ref: Builtin.NativeObject =
+        unsafe Builtin.bridgeFromRawPointer(_rawTask._rawValue)
+      Builtin.retain(ref)
+      return ref
+    }
+  }
 
   // May only be created by the standard library.
   @usableFromInline // Since 6.4
   @available(SwiftStdlib 5.1, *)
-  internal init(_ task: Builtin.NativeObject) {
-    unsafe self._task = task
+  internal init(_ asyncTask: _AsyncTask) {
+    unsafe self._rawTask = asyncTask
   }
 
   /// A Boolean value that indicates whether the current task was canceled.
@@ -868,7 +877,7 @@ public struct UnsafeCurrentTask {
     if #available(SwiftStdlib 6.4, *) {
       unsafe _isCancelled(ignoreTaskCancellationShield: true)
     } else {
-      unsafe _taskIsCancelled(_task)
+      unsafe _taskIsCancelled(_rawTask)
     }
   }
 
@@ -877,7 +886,7 @@ public struct UnsafeCurrentTask {
   @_alwaysEmitIntoClient
   internal func _isCancelled(ignoreTaskCancellationShield: Bool) -> Bool {
     let flags: UInt64 = ignoreTaskCancellationShield ? 0x1 : 0x0
-    return unsafe _taskIsCancelledWithFlags(_task, flags: flags)
+    return unsafe _taskIsCancelledWithFlags(_rawTask, flags: flags)
   }
 
   /// The current task's priority.
@@ -885,7 +894,7 @@ public struct UnsafeCurrentTask {
   /// - SeeAlso: `TaskPriority`
   /// - SeeAlso: `Task.currentPriority`
   public var priority: TaskPriority {
-    unsafe TaskPriority(rawValue: _taskCurrentPriority(_task))
+    unsafe TaskPriority(rawValue: _taskCurrentPriority(_rawTask))
   }
 
   /// The current task's base priority.
@@ -894,7 +903,7 @@ public struct UnsafeCurrentTask {
   /// - SeeAlso: `Task.basePriority`
   @available(SwiftStdlib 5.9, *)
   public var basePriority: TaskPriority {
-    unsafe TaskPriority(rawValue: _taskBasePriority(_task))
+    unsafe TaskPriority(rawValue: _taskBasePriority(_rawTask))
   }
 
   /// Cancel the current task.
@@ -908,7 +917,7 @@ public struct UnsafeCurrentTask {
   /// - SeeAlso: ``withTaskCancellationShield(operation:)``
   /// - SeeAlso: ``Task/hasActiveTaskCancellationShield``
   public func cancel() {
-    unsafe _taskCancel(_task)
+    unsafe _taskCancel(_rawTask)
   }
 
   /// Checks if this task is executing in a scope with a task cancellation shield activated by the
@@ -933,7 +942,7 @@ public struct UnsafeCurrentTask {
   public var hasActiveCancellationShield: Bool {
     @_alwaysEmitIntoClient
     get {
-      unsafe _taskHasActiveCancellationShield(_task)
+      unsafe _taskHasActiveCancellationShield(_rawTask)
     }
   }
 
@@ -941,7 +950,7 @@ public struct UnsafeCurrentTask {
   @inlinable
   @available(SwiftStdlib 6.4, *)
   public var name: String? {
-    if let name = unsafe _getTaskName(self._task) {
+    if let name = unsafe _getTaskName(_rawTask) {
       unsafe String(cString: name)
     } else {
       nil
@@ -956,22 +965,46 @@ extension UnsafeCurrentTask: Sendable { }
 @available(SwiftStdlib 5.1, *)
 extension UnsafeCurrentTask: @unsafe Hashable {
   public func hash(into hasher: inout Hasher) {
-    unsafe UnsafeRawPointer(Builtin.bridgeToRawPointer(_task)).hash(into: &hasher)
+    unsafe UnsafeRawPointer(_rawTask._rawValue).hash(into: &hasher)
   }
 }
 
 @available(SwiftStdlib 5.1, *)
 extension UnsafeCurrentTask: Equatable {
   public static func ==(lhs: Self, rhs: Self) -> Bool {
-    unsafe UnsafeRawPointer(Builtin.bridgeToRawPointer(lhs._task)) ==
-      UnsafeRawPointer(Builtin.bridgeToRawPointer(rhs._task))
+    unsafe Bool(Builtin.cmp_eq_RawPointer(lhs._rawTask._rawValue, rhs._rawTask._rawValue))
   }
 }
 
 // ==== Internal ---------------------------------------------------------------
+
+/// Opaque non-owning handle to an `AsyncTask` object.
+@available(SwiftStdlib 5.1, *)
+@frozen
+@unsafe
+@usableFromInline
+internal struct _AsyncTask {
+  @usableFromInline
+  internal let _rawValue: Builtin.RawPointer
+
+  @usableFromInline @_transparent
+  internal init(_ rawValue: Builtin.RawPointer) {
+    unsafe self._rawValue = rawValue
+  }
+
+  /// Bridge a `Task._task` (a `Builtin.NativeObject` strong reference) into
+  /// a non-owning `_AsyncTask`. The caller's `Builtin.NativeObject` keeps
+  /// the task alive for the duration the wrapper is used.
+  @usableFromInline @_transparent
+  internal init(_ task: Builtin.NativeObject) {
+    unsafe self._rawValue = Builtin.bridgeToRawPointer(task)
+  }
+}
+
 @available(SwiftStdlib 5.1, *)
 @_silgen_name("swift_task_getCurrent")
-public func _getCurrentAsyncTask() -> Builtin.NativeObject?
+@usableFromInline
+internal func _getCurrentAsyncTask() -> _AsyncTask?
 
 @available(SwiftStdlib 5.1, *)
 @_silgen_name("swift_task_getJobFlags")
@@ -1082,34 +1115,39 @@ public func _taskFutureGetThrowing<T>(_ task: Builtin.NativeObject) async throws
 
 @available(SwiftStdlib 5.1, *)
 @_silgen_name("swift_task_cancel")
-public func _taskCancel(_ task: Builtin.NativeObject)
+@usableFromInline
+internal func _taskCancel(_ task: _AsyncTask)
 
 @available(SwiftStdlib 5.1, *)
 @_silgen_name("swift_task_isCancelled")
 @usableFromInline
-func _taskIsCancelled(_ task: Builtin.NativeObject) -> Bool
+internal func _taskIsCancelled(_ task: _AsyncTask) -> Bool
 
 @available(SwiftStdlib 6.4, *)
 @_silgen_name("swift_task_isCancelledWithFlags")
 @usableFromInline
-func _taskIsCancelledWithFlags(_ task: Builtin.NativeObject, flags: UInt64) -> Bool
+internal func _taskIsCancelledWithFlags(_ task: _AsyncTask, flags: UInt64) -> Bool
 
 @available(SwiftStdlib 6.4, *)
 @_silgen_name("swift_task_hasActiveCancellationShield")
 @usableFromInline
-internal func _taskHasActiveCancellationShield(_ task: Builtin.NativeObject) -> Bool
+internal func _taskHasActiveCancellationShield(_ task: _AsyncTask) -> Bool
 
+@available(SwiftStdlib 5.1, *)
 @_silgen_name("swift_task_currentPriority")
-internal func _taskCurrentPriority(_ task: Builtin.NativeObject) -> UInt8
+@usableFromInline
+internal func _taskCurrentPriority(_ task: _AsyncTask) -> UInt8
 
 @available(SwiftStdlib 6.2, *)
 @_silgen_name("swift_task_escalate")
 @discardableResult
-internal func _taskEscalate(_ task: Builtin.NativeObject, newPriority: UInt8) -> UInt8
+@usableFromInline
+internal func _taskEscalate(_ task: _AsyncTask, newPriority: UInt8) -> UInt8
 
 @available(SwiftStdlib 5.1, *)
 @_silgen_name("swift_task_basePriority")
-internal func _taskBasePriority(_ task: Builtin.NativeObject) -> UInt8
+@usableFromInline
+internal func _taskBasePriority(_ task: _AsyncTask) -> UInt8
 
 @available(SwiftStdlib 5.1, *)
 @_silgen_name("swift_task_createNullaryContinuationJob")
@@ -1156,7 +1194,7 @@ internal func _getCurrentTaskName() -> UnsafePointer<UInt8>?
 @available(StdlibDeploymentTarget 6.4, *)
 @usableFromInline
 @_silgen_name("swift_task_getTaskName")
-internal func _getTaskName(_ job: Builtin.NativeObject) -> UnsafePointer<UInt8>?
+internal func _getTaskName(_ job: _AsyncTask) -> UnsafePointer<UInt8>?
 
 @available(SwiftStdlib 6.2, *)
 internal func _getCurrentTaskNameString() -> String? {

--- a/stdlib/public/Concurrency/TaskCancellation.swift
+++ b/stdlib/public/Concurrency/TaskCancellation.swift
@@ -225,9 +225,9 @@ extension Task {
     // This is @available(SwiftStdlib 6.4, *) but can't use SwiftStdlib in transparent function
     if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, visionOS 9999, *) {
       let ignoreTaskCancellationShield: UInt64 = 0x1
-      return _taskIsCancelledWithFlags(_task, flags: ignoreTaskCancellationShield)
+      return unsafe _taskIsCancelledWithFlags(_AsyncTask(_task), flags: ignoreTaskCancellationShield)
     } else {
-      return _taskIsCancelled(_task)
+      return unsafe _taskIsCancelled(_AsyncTask(_task))
     }
   }
 }

--- a/test/abi/macOS/arm64/concurrency.swift
+++ b/test/abi/macOS/arm64/concurrency.swift
@@ -417,8 +417,8 @@ Added: _swift_task_isCancelledWithFlags
 Added: _$sSct5_taskBovg
 Added: _$sSct5_taskBovpMV
 
-// Swift.UnsafeCurrentTask.init(Builtin.NativeObject) -> Swift.UnsafeCurrentTask
-Added: _$sSctySctBocfC
+// Swift.UnsafeCurrentTask.init(_AsyncTask) -> Swift.UnsafeCurrentTask
+Added: _$sSctyScts10_AsyncTaskVcfC
 // Swift.withUnsafeCurrentTaskNonsending<A>(body: nonisolated(nonsending) (Swift.UnsafeCurrentTask?) async throws -> A) async throws -> A
 Added: _$ss31withUnsafeCurrentTaskNonsending4bodyxxSctSgYaKYCXE_tYaKlF
 Added: _$ss31withUnsafeCurrentTaskNonsending4bodyxxSctSgYaKYCXE_tYaKlFTu
@@ -443,3 +443,19 @@ Added: _$ss12ContinuationVMn
 Added: _$ss12ContinuationVsRi_zrlE7contextBcvg
 Added: _$ss12ContinuationVsRi_zrlEfD
 Added: _$ss12ContinuationVsRi_zrlEyAByxq_GBccfC
+
+// _AsyncTask: opaque pointer wrapper for AsyncTask*. Single decl for each
+// runtime fn parameter (replaces the previous Builtin.NativeObject /
+// UnsafeRawPointer? Raw-overload pairs which collided at the SIL level).
+Added: _$ss10_AsyncTaskV9_rawValueBpvg
+Added: _$ss10_AsyncTaskV9_rawValueBpvpMV
+Added: _$ss10_AsyncTaskVMa
+Added: _$ss10_AsyncTaskVMn
+Added: _$ss10_AsyncTaskVN
+Added: _$ss10_AsyncTaskVyABBocfC
+Added: _$ss10_AsyncTaskVyABBpcfC
+
+// UnsafeCurrentTask now stores the task as a non-owning `_AsyncTask`
+// (raw pointer wrapper) under the new `_rawTask` field.
+Added: _$sSct8_rawTasks06_AsyncB0Vvg
+Added: _$sSct8_rawTasks06_AsyncB0VvpMV

--- a/test/abi/macOS/x86_64/concurrency.swift
+++ b/test/abi/macOS/x86_64/concurrency.swift
@@ -417,8 +417,8 @@ Added: _swift_task_isCancelledWithFlags
 Added: _$sSct5_taskBovg
 Added: _$sSct5_taskBovpMV
 
-// Swift.UnsafeCurrentTask.init(Builtin.NativeObject) -> Swift.UnsafeCurrentTask
-Added: _$sSctySctBocfC
+// Swift.UnsafeCurrentTask.init(_AsyncTask) -> Swift.UnsafeCurrentTask
+Added: _$sSctyScts10_AsyncTaskVcfC
 // Swift.withUnsafeCurrentTaskNonsending<A>(body: nonisolated(nonsending) (Swift.UnsafeCurrentTask?) async throws -> A) async throws -> A
 Added: _$ss31withUnsafeCurrentTaskNonsending4bodyxxSctSgYaKYCXE_tYaKlF
 Added: _$ss31withUnsafeCurrentTaskNonsending4bodyxxSctSgYaKYCXE_tYaKlFTu
@@ -443,3 +443,19 @@ Added: _$ss12ContinuationVMn
 Added: _$ss12ContinuationVsRi_zrlE7contextBcvg
 Added: _$ss12ContinuationVsRi_zrlEfD
 Added: _$ss12ContinuationVsRi_zrlEyAByxq_GBccfC
+
+// _AsyncTask: opaque pointer wrapper for AsyncTask*. Single decl for each
+// runtime fn parameter (replaces the previous Builtin.NativeObject /
+// UnsafeRawPointer? Raw-overload pairs which collided at the SIL level).
+Added: _$ss10_AsyncTaskV9_rawValueBpvg
+Added: _$ss10_AsyncTaskV9_rawValueBpvpMV
+Added: _$ss10_AsyncTaskVMa
+Added: _$ss10_AsyncTaskVMn
+Added: _$ss10_AsyncTaskVN
+Added: _$ss10_AsyncTaskVyABBocfC
+Added: _$ss10_AsyncTaskVyABBpcfC
+
+// UnsafeCurrentTask now stores the task as a non-owning `_AsyncTask`
+// (raw pointer wrapper) under the new `_rawTask` field.
+Added: _$sSct8_rawTasks06_AsyncB0Vvg
+Added: _$sSct8_rawTasks06_AsyncB0VvpMV

--- a/test/api-digester/stability-concurrency-abi.test
+++ b/test/api-digester/stability-concurrency-abi.test
@@ -135,6 +135,9 @@ Func pthread_main_np() is a new API without '@available'
 Func TaskLocal.get() has been renamed to Func __abi_get()
 Func TaskLocal.get() has mangled name changing from '_Concurrency.TaskLocal.get() -> A' to '_Concurrency.TaskLocal.__abi_get() -> A'
 
+Func _taskIsCancelled(_:) has mangled name changing from '_Concurrency._taskIsCancelled(Builtin.NativeObject) -> Swift.Bool' to '_Concurrency._taskIsCancelled(_Concurrency._AsyncTask) -> Swift.Bool'
+Func _taskIsCancelled(_:) has parameter 0 type change from Builtin.NativeObject to _Concurrency._AsyncTask
+
 // *** DO NOT DISABLE OR XFAIL THIS TEST. *** (See comment above.)
 
 


### PR DESCRIPTION
I'm still working out some edge cases here and there's ABI trouble as well... but this would shave off un-necessary retain/release dance that `withUnsafeCurrentTask` has incurred since forever.

The problem is that returning a Builtin.NativeObject causes it to be released at end of scope, so to balance that out we used to have a stray retain in library code. This is pretty hacky.

This idea solves this by returning the pointer as _raw pointer_ when we don't want to retain the task, i.e. during withUnsafeCurrentTask.

This change gives a meaningful 10ish ns performance improvement AFAICS on an M2 macbook (I'll measure on others later), but I need to measure more.