### PR TITLE
SIL/LICM: Fix over-consume of owned `rootVal`

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LoopInvariantCodeMotion.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LoopInvariantCodeMotion.swift
@@ -817,33 +817,33 @@ private extension MovableInstructions {
     var changed = false
     var currentBlock: BasicBlock?
     var currentVal: Value?
-    
+
     // Remove all stores and replace the loads with the current value.
     //
     // This loop depends on loadsAndStores being in order the instructions appear in blocks.
     for inst in loadsAndStores {
       let block = inst.parentBlock
-      
+
       if block != currentBlock {
         currentBlock = block
         currentVal = nil
       }
-      
+
       if let storeInst = inst as? StoreInst, storeInst.storesTo(accessPath) {
         currentVal = storeInst.source
         context.erase(instruction: storeInst)
         changed = true
         continue
       }
-      
+
       guard let loadInst = inst as? LoadInst,
             loadInst.loadsFrom(accessPath) else {
         continue
       }
-      
+
       // If we didn't see a store in this block yet, get the current value from the ssaUpdater.
       let rootVal = currentVal ?? ssaUpdater.getValue(inMiddleOf: block)
-      
+
       if loadInst.operand.value.accessPath == accessPath {
         if loadInst.loadOwnership == .copy {
           let builder = Builder(before: loadInst, context)
@@ -855,30 +855,30 @@ private extension MovableInstructions {
         changed = true
         continue
       }
-      
+
       guard let projectionPath = accessPath.getProjection(to: loadInst.operand.value.accessPath) else {
         continue
       }
-    
+
       let builder = Builder(before: loadInst, context)
-      let projection = if loadInst.loadOwnership == .copy {
+      let projection = if loadInst.loadOwnership != .take {
         rootVal.createProjectionAndCopy(path: projectionPath, builder: builder)
       } else {
         rootVal.createProjection(path: projectionPath, builder: builder)
       }
       loadInst.replace(with: projection, context)
-      
+
       changed = true
     }
-    
+
     loadsAndStores.removeAll(where: { $0.isDeleted })
-    
+
     // Store back the value at all loop exits.
     for exitBlock in loop.exitBlocks {
       assert(exitBlock.hasSinglePredecessor, "Exiting edge should not be critical.")
-      
+
       let builder = Builder(before: exitBlock.instructions.first!, context)
-      
+
       builder.createStore(
         source: ssaUpdater.getValue(inMiddleOf: exitBlock),
         destination: initialAddr,
@@ -886,7 +886,7 @@ private extension MovableInstructions {
       )
       changed = true
     }
-    
+
     // In case the value is only stored but never loaded in the loop.
     if initialLoad.uses.isEmpty {
       context.erase(instruction: initialLoad)

--- a/test/SILOptimizer/licm.sil
+++ b/test/SILOptimizer/licm.sil
@@ -29,6 +29,12 @@ struct S2 {
   var s2: String
 }
 
+struct S3 {
+  var i: Int
+  var j: Int
+  var s: String
+}
+
 struct Pair  {
   var t: (a: Int, b: Int)
 }
@@ -2260,5 +2266,76 @@ bb4:
 
 bb5:
   return %0
+}
+
+// Sub-projection `load [trivial]` co-occurring with a whole-value `load [take]`
+// on an owned access path. LICM emits a borrow + extract + end_borrow for the
+// sub-projection and consumes rootVal via the whole-value path's destroy_value.
+// CHECK-LABEL: sil [ossa] @licm_subproj_trivial_plus_whole_take_owned :
+// CHECK:       bb1([[V:%.*]] : @owned $S2):
+// CHECK-NEXT:    [[B:%.*]] = begin_borrow [[V]]
+// CHECK-NEXT:    [[SE:%.*]] = struct_extract [[B]] : $S2, #S2.i
+// CHECK-NEXT:    end_borrow [[B]]
+// CHECK-NEXT:    destroy_value [[V]]
+// CHECK-NOT:   destructure_struct
+// CHECK-LABEL: } // end sil function 'licm_subproj_trivial_plus_whole_take_owned'
+sil [ossa] @licm_subproj_trivial_plus_whole_take_owned : $@convention(thin) (@inout S2, @owned S2) -> () {
+bb0(%0 : $*S2, %1 : @owned $S2):
+  br bb1
+
+bb1:
+  %2 = struct_element_addr %0, #S2.i
+  %3 = load [trivial] %2
+  %4 = load [take] %0
+  destroy_value %4
+  %5 = copy_value %1
+  store %5 to [init] %0
+  cond_br undef, bb2, bb3
+
+bb2:
+  br bb1
+
+bb3:
+  destroy_value %1
+  %r = tuple ()
+  return %r
+}
+
+// Two distinct trivial sub-projection loads of an owned access path in one
+// block. LICM emits a borrow + extract + end_borrow per load and one
+// destroy_value of the source rootVal.
+// CHECK-LABEL: sil [ossa] @licm_multi_trivial_subproj_owned :
+// CHECK:       bb1([[V:%.*]] : @owned $S3):
+// CHECK-NEXT:    [[B1:%.*]] = begin_borrow [[V]]
+// CHECK-NEXT:    [[SE1:%.*]] = struct_extract [[B1]] : $S3, #S3.i
+// CHECK-NEXT:    end_borrow [[B1]]
+// CHECK-NEXT:    [[B2:%.*]] = begin_borrow [[V]]
+// CHECK-NEXT:    [[SE2:%.*]] = struct_extract [[B2]] : $S3, #S3.j
+// CHECK-NEXT:    end_borrow [[B2]]
+// CHECK-NEXT:    destroy_value [[V]]
+// CHECK-NOT:   destructure_struct
+// CHECK-LABEL: } // end sil function 'licm_multi_trivial_subproj_owned'
+sil [ossa] @licm_multi_trivial_subproj_owned : $@convention(thin) (@inout S3, @owned S3) -> () {
+bb0(%0 : $*S3, %1 : @owned $S3):
+  br bb1
+
+bb1:
+  %2 = struct_element_addr %0, #S3.i
+  %3 = load [trivial] %2
+  %4 = struct_element_addr %0, #S3.j
+  %5 = load [trivial] %4
+  %6 = load [take] %0
+  destroy_value %6
+  %7 = copy_value %1
+  store %7 to [init] %0
+  cond_br undef, bb2, bb3
+
+bb2:
+  br bb1
+
+bb3:
+  destroy_value %1
+  %r = tuple ()
+  return %r
 }
 

--- a/test/SILOptimizer/ossa_overconsume_substring_inout_loop_crash.swift
+++ b/test/SILOptimizer/ossa_overconsume_substring_inout_loop_crash.swift
@@ -1,0 +1,19 @@
+// RUN: %target-swift-frontend -O -c -parse-as-library -module-name repro %s -o %t.o
+
+// REQUIRES: swift_in_compiler
+
+// https://github.com/swiftlang/swift/issues/89255
+// SIL ownership verifier rejects the optimized SIL for a simple inout-Substring
+// loop with "Found over consume?!" / "Found ownership error?!" during the
+// OwnershipModelEliminator pass. Regression after swift-6.3.1-RELEASE.
+
+public func f(_ s: inout Substring, _ b: Bool) -> Substring? {
+    while !s.isEmpty {
+        let c = s; var i = c.startIndex; var x: Substring.Index?
+        while i < c.endIndex { if b { x = i }; c.formIndex(after: &i) }
+        s = ""
+        guard let x else { continue }
+        return c[..<x]
+    }
+    return nil
+}


### PR DESCRIPTION
The sub-projection branch now routes any non-`take` load through `createProjectionAndCopy`, so trivial sub-projection loads on an owned `rootVal` borrow + extract instead of destructuring and over-consuming. The borrow scope is self-closing inside `createProjectionAndCopy`, so no external liveness tracking is needed.

Resolves https://github.com/swiftlang/swift/issues/89255
rdar://177430359