### PR TITLE
[RemoteInspection] Preserve inverse requirements on ConstrainedExistentialTypeRef

### DIFF
--- a/include/swift/RemoteInspection/TypeRef.h
+++ b/include/swift/RemoteInspection/TypeRef.h
@@ -689,9 +689,12 @@ public:
 class ConstrainedExistentialTypeRef final : public TypeRef {
   const ProtocolCompositionTypeRef *Base;
   std::vector<TypeRefRequirement> Requirements;
+  std::vector<TypeRefInverseRequirement> InverseRequirements;
 
-  static TypeRefID Profile(const ProtocolCompositionTypeRef *Protocol,
-                           std::vector<TypeRefRequirement> Requirements) {
+  static TypeRefID
+  Profile(const ProtocolCompositionTypeRef *Protocol,
+          std::vector<TypeRefRequirement> Requirements,
+          std::vector<TypeRefInverseRequirement> InverseRequirements) {
     TypeRefID ID;
     ID.addPointer(Protocol);
     for (auto reqt : Requirements) {
@@ -703,27 +706,38 @@ class ConstrainedExistentialTypeRef final : public TypeRef {
             unsigned(0)); // FIXME: Layout constraints aren't implemented yet
       ID.addInteger(unsigned(reqt.getKind()));
     }
+    for (auto inverse : InverseRequirements) {
+      ID.addPointer(inverse.getFirstType());
+      ID.addInteger(unsigned(inverse.getKind()));
+    }
     return ID;
   }
 
 public:
-  ConstrainedExistentialTypeRef(const ProtocolCompositionTypeRef *Protocol,
-                                std::vector<TypeRefRequirement> Requirements)
+  ConstrainedExistentialTypeRef(
+      const ProtocolCompositionTypeRef *Protocol,
+      std::vector<TypeRefRequirement> Requirements,
+      std::vector<TypeRefInverseRequirement> InverseRequirements)
       : TypeRef(TypeRefKind::ConstrainedExistential), Base(Protocol),
-        Requirements(Requirements) {}
+        Requirements(Requirements), InverseRequirements(InverseRequirements) {}
 
   template <typename Allocator>
   static const ConstrainedExistentialTypeRef *
   create(Allocator &A, const ProtocolCompositionTypeRef *Protocol,
-         std::vector<TypeRefRequirement> Requirements) {
+         std::vector<TypeRefRequirement> Requirements,
+         std::vector<TypeRefInverseRequirement> InverseRequirements) {
     FIND_OR_CREATE_TYPEREF(A, ConstrainedExistentialTypeRef, Protocol,
-                           Requirements);
+                           Requirements, InverseRequirements);
   }
 
   const ProtocolCompositionTypeRef *getBase() const { return Base; }
 
   const std::vector<TypeRefRequirement> &getRequirements() const {
     return Requirements;
+  }
+
+  const std::vector<TypeRefInverseRequirement> &getInverseRequirements() const {
+    return InverseRequirements;
   }
 
   static bool classof(const TypeRef *TR) {

--- a/include/swift/RemoteInspection/TypeRefBuilder.h
+++ b/include/swift/RemoteInspection/TypeRefBuilder.h
@@ -1303,12 +1303,12 @@ public:
 
   const ConstrainedExistentialTypeRef *createConstrainedExistentialType(
       const TypeRef *base, llvm::ArrayRef<BuiltRequirement> constraints,
-      llvm::ArrayRef<BuiltInverseRequirement> InverseRequirements) {
-    // FIXME: Handle inverse requirements.
+      llvm::ArrayRef<BuiltInverseRequirement> inverseRequirements) {
     auto *baseProto = llvm::dyn_cast<ProtocolCompositionTypeRef>(base);
     if (!baseProto)
       return nullptr;
-    return ConstrainedExistentialTypeRef::create(*this, baseProto, constraints);
+    return ConstrainedExistentialTypeRef::create(*this, baseProto, constraints,
+                                                 inverseRequirements);
   }
 
   const TypeRef *

--- a/stdlib/public/RemoteInspection/TypeRef.cpp
+++ b/stdlib/public/RemoteInspection/TypeRef.cpp
@@ -286,6 +286,8 @@ public:
     printRec(CET->getBase());
     for (auto req : CET->getRequirements())
       visitTypeRefRequirement(req);
+    for (auto inverse : CET->getInverseRequirements())
+      visitTypeRefInverseRequirement(inverse);
     stream << ")";
   }
 
@@ -387,6 +389,14 @@ public:
       stream << "layout requirement";
       break;
     }
+    stream << ")";
+  }
+
+  void
+  visitTypeRefInverseRequirement(const TypeRefInverseRequirement &inverse) {
+    printHeader("inverse_requirement ");
+    printRec(inverse.getFirstType());
+    stream << " : ~" << getInvertibleProtocolKindName(inverse.getKind());
     stream << ")";
   }
 
@@ -1045,6 +1055,8 @@ public:
         Dem.createNode(Node::Kind::ConstrainedExistentialRequirementList);
     for (auto req : CET->getRequirements())
       constraintList->addChild(visitTypeRefRequirement(req), Dem);
+    for (auto inverse : CET->getInverseRequirements())
+      constraintList->addChild(visitTypeRefInverseRequirement(inverse), Dem);
     node->addChild(constraintList, Dem);
     return node;
   }
@@ -1178,6 +1190,22 @@ public:
       // Not implemented.
       return nullptr;
     }
+  }
+
+  Demangle::NodePointer
+  visitTypeRefInverseRequirement(const TypeRefInverseRequirement &inverse) {
+    auto subjectType = Dem.createNode(Node::Kind::Type);
+    // The only possible child of an inverse conformance requirement
+    // is ConstrainedExistentialSelf.
+    subjectType->addChild(
+        Dem.createNode(Node::Kind::ConstrainedExistentialSelf), Dem);
+    auto r = Dem.createNode(
+        Node::Kind::DependentGenericInverseConformanceRequirement);
+    r->addChild(subjectType, Dem);
+    r->addChild(Dem.createNode(Node::Kind::Number,
+                               static_cast<Node::IndexType>(inverse.getKind())),
+                Dem);
+    return r;
   }
 
   Demangle::NodePointer
@@ -1468,7 +1496,8 @@ public:
   const TypeRef *
   visitConstrainedExistentialTypeRef(const ConstrainedExistentialTypeRef *CET) {
     return ConstrainedExistentialTypeRef::create(Builder, CET->getBase(),
-                                                 CET->getRequirements());
+                                                 CET->getRequirements(),
+                                                 CET->getInverseRequirements());
   }
 
   const TypeRef *visitSymbolicExtendedExistentialTypeRef(
@@ -1763,8 +1792,8 @@ public:
         continue;
       constraints.emplace_back(*substReq);
     }
-    return ConstrainedExistentialTypeRef::create(Builder, CET->getBase(),
-                                                 constraints);
+    return ConstrainedExistentialTypeRef::create(
+        Builder, CET->getBase(), constraints, CET->getInverseRequirements());
   }
 
   const TypeRef *visitSymbolicExtendedExistentialTypeRef(

--- a/test/Reflection/Inputs/TypeLowering.swift
+++ b/test/Reflection/Inputs/TypeLowering.swift
@@ -324,3 +324,5 @@ public struct AlmostBig {
 public struct Big {
   var a, b, c, d, e: Int
 }
+
+public protocol TheProtocol: ~Copyable {}

--- a/test/Reflection/typeref_lowering.swift
+++ b/test/Reflection/typeref_lowering.swift
@@ -1453,3 +1453,13 @@ SpySiGXu
 // CHECK-32-NEXT: (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=1))
 // CHECK-32-NEXT: (field name=wtable offset=4
 // CHECK-32-NEXT: (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1 bitwise_takable=1)))
+
+// Constrained existential whose only requirement is an inverse Copyable
+// conformance.
+12TypeLowering11TheProtocol_pRi_s_XP
+// CHECK: (constrained_existential_type
+// CHECK-NEXT: (protocol_composition
+// CHECK-NEXT: (protocol TypeLowering.TheProtocol))
+// CHECK: (inverse_requirement
+// CHECK-NEXT: (generic_type_parameter depth=0 index=0) : ~Copyable
+

--- a/unittests/Reflection/CMakeLists.txt
+++ b/unittests/Reflection/CMakeLists.txt
@@ -5,7 +5,12 @@ if(("${SWIFT_HOST_VARIANT_SDK}" STREQUAL "${SWIFT_PRIMARY_VARIANT_SDK}") AND
       TypeRef.cpp)
     target_include_directories(SwiftReflectionTests BEFORE PRIVATE
       ${SWIFT_SOURCE_DIR}/stdlib/include)
+    # `stdlib/include/llvm/Support` is a stripped-down subset of
+    # `llvm-project/llvm/include/llvm/Support`. Since we favor the stdlib
+    # version (BEFORE PRIVATE above), make sure the LLVM Support headers
+    # don't get pulled in transitively through gtest's custom port.
     target_compile_definitions(SwiftReflectionTests PRIVATE
+      GTEST_NO_LLVM_SUPPORT
       SWIFT_INLINE_NAMESPACE=__runtime)
     target_link_libraries(SwiftReflectionTests
       PRIVATE

--- a/unittests/Reflection/TypeRef.cpp
+++ b/unittests/Reflection/TypeRef.cpp
@@ -10,8 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "swift/RemoteInspection/TypeRefBuilder.h"
+#include "swift/ABI/InvertibleProtocols.h"
 #include "swift/Remote/MetadataReader.h"
+#include "swift/RemoteInspection/TypeRefBuilder.h"
 #include "gtest/gtest.h"
 
 using namespace swift;
@@ -570,4 +571,27 @@ TEST(TypeRefTest, DeriveSubstitutions) {
   auto ResultTwo = DerivedSubs[{0,1}];
   EXPECT_EQ(SubstOne, ResultOne);
   EXPECT_EQ(SubstTwo, ResultTwo);
+}
+
+// Round-trips a constrained existential carrying an inverse `~Copyable`
+// requirement through TypeRef::mangle.
+TEST(TypeRefTest, ConstrainedExistentialInverseRequirementMangle) {
+  TypeRefBuilder Builder(TypeRefBuilder::ForTesting);
+  Demangle::Demangler Dem;
+
+  static const std::string MangledProtocol = "5Tests1PP";
+  TypeRefBuilder::BuiltProtocolDecl P =
+      std::make_pair(MangledProtocol, /*isObjC=*/false);
+  auto *base = Builder.createProtocolCompositionType(
+      {P}, /*superclass=*/nullptr, /*isClassBound=*/false);
+  auto *self = Builder.createGenericTypeParameterType(0, 0);
+  TypeRefInverseRequirement inv(self, InvertibleProtocolKind::Copyable);
+
+  auto *cet = Builder.createConstrainedExistentialType(
+      base, /*requirements=*/{}, {inv});
+  ASSERT_NE(cet, nullptr);
+
+  auto mangled = cet->mangle(Dem);
+  ASSERT_TRUE(mangled.has_value());
+  EXPECT_FALSE(mangled->empty());
 }


### PR DESCRIPTION
Implement support for types such as SomeProtocol<Self : ~Copyable> in RemoteInspection.

Assisted-by: claude

rdar://177433383
