### PR TITLE
[crashers] add missing getFunctionArgApplyInfo null checks

### DIFF
--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -298,7 +298,7 @@ using KeyPathCapability = std::pair<KeyPathMutability, /*isSendable=*/bool>;
 namespace constraints {
 
 template <typename T = Expr> T *castToExpr(ASTNode node) {
-  return cast<T>(cast<Expr *>(node));
+  return cast<T>(cast_or_null<Expr *>(node));
 }
 
 template <typename T = Expr> T *getAsExpr(ASTNode node) {

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -58,10 +58,15 @@
 using namespace swift;
 using namespace constraints;
 
-static bool hasFixFor(const Solution &solution, ConstraintLocator *locator) {
-  return llvm::any_of(solution.Fixes, [&locator](const ConstraintFix *fix) {
-    return fix->getLocator() == locator;
-  });
+static bool hasFixFor(const Solution &solution, ConstraintLocator *locator,
+                      std::optional<FixKind> expectedKind = std::nullopt) {
+  return llvm::any_of(
+      solution.Fixes, [&locator, &expectedKind](const ConstraintFix *fix) {
+        if (fix->getLocator() == locator) {
+          return !expectedKind || fix->getKind() == *expectedKind;
+        }
+        return false;
+      });
 }
 
 FailureDiagnostic::~FailureDiagnostic() {}
@@ -3990,8 +3995,8 @@ bool MissingCallFailure::diagnoseAsError() {
       auto fnType = type->castTo<FunctionType>();
 
       if (MissingArgumentsFailure::isMisplacedMissingArgument(getSolution(), locator)) {
-        ArgumentMismatchFailure failure(
-            getSolution(), fnType, fnType->getResult(), locator);
+        ArgumentMismatchFailure failure(getSolution(), fnType,
+                                        fnType->getResult(), locator);
         return failure.diagnoseMisplacedMissingArgument();
       }
 
@@ -5396,13 +5401,15 @@ bool MissingArgumentsFailure::diagnoseAsError() {
   // foo(bar) // `() -> Void` vs. `(Int) -> Void`
   // ```
   if (locator->isLastElement<LocatorPathElt::ApplyArgToParam>()) {
-    auto info = *(getFunctionArgApplyInfo(locator));
+    if (auto info = getFunctionArgApplyInfo(locator)) {
 
-    auto *argExpr = info.getArgExpr();
-    emitDiagnosticAt(argExpr->getLoc(), diag::cannot_convert_argument_value,
-                     info.getArgType(), info.getParamType());
-    // TODO: It would be great so somehow point out which arguments are missing.
-    return true;
+      auto *argExpr = info->getArgExpr();
+      emitDiagnosticAt(argExpr->getLoc(), diag::cannot_convert_argument_value,
+                       info->getArgType(), info->getParamType());
+      // TODO: It would be great so somehow point out which arguments are
+      // missing.
+      return true;
+    }
   }
 
   // Function type has fewer arguments than expected by context:
@@ -7643,6 +7650,25 @@ bool ArgumentMismatchFailure::diagnoseAsError() {
     return false;
   }
 
+  // FIXME: After Argument Synthesis, we're still generating Argument Mismatch
+  // fixes and errors
+  //  But the locator for the ApplyArgument is not a suitable match for a
+  //  FunctionApplyArgInfo This causes crashes when attempting to build one.
+  //  Blocking here is a stop gap while we devise a means of either not having
+  //  argument mismatches or of having usable locators.
+  if (!Info) {
+    auto locator = getLocator();
+    auto path = locator->getPath();
+    auto iter = path.rbegin();
+    if (locator->findLast<LocatorPathElt::ApplyArgument>(iter)) {
+      auto *newLoc = getSolution().getConstraintLocator(
+          locator->getAnchor(), path.drop_back(iter - path.rbegin()));
+      if (hasFixFor(getSolution(), newLoc, FixKind::AddMissingArguments))
+        return false;
+    }
+    ABORT("expected function arg apply info for argument mismatch");
+  }
+
   if (diagnoseKeyPathLiteralMutabilityMismatch())
     return true;
 
@@ -7983,7 +8009,7 @@ bool ArgumentMismatchFailure::diagnoseAttemptedRegexBuilder() const {
   auto &ctx = getASTContext();
 
   // Should be a lone trailing closure argument.
-  if (!Info.isTrailingClosure() || !Info.getArgList()->isUnary())
+  if (!Info->isTrailingClosure() || !Info->getArgList()->isUnary())
     return false;
 
   // Check if this an application of a Regex initializer, and the user has not
@@ -8021,8 +8047,7 @@ bool ArgumentMismatchFailure::diagnoseClosureMismatch() const {
   if (paramType->lookThroughAllOptionalTypes()->is<AnyFunctionType>())
     return false;
 
-  emitDiagnostic(diag::closure_bad_param, paramType,
-                 Info.isTrailingClosure())
+  emitDiagnostic(diag::closure_bad_param, paramType, Info->isTrailingClosure())
       .highlight(getSourceRange());
 
   if (auto overload = getCalleeOverloadChoiceIfAvailable(getLocator())) {
@@ -8921,15 +8946,15 @@ SourceLoc MissingOptionalUnwrapKeyPathFailure::getLoc() const {
 }
 
 bool TrailingClosureRequiresExplicitLabel::diagnoseAsError() {
-  auto argInfo = *getFunctionArgApplyInfo(getLocator());
+  auto argInfo = getFunctionArgApplyInfo(getLocator());
 
   {
     auto diagnostic = emitDiagnostic(
-        diag::unlabeled_trailing_closure_deprecated, argInfo.getParamLabel());
-    fixIt(diagnostic, argInfo);
+        diag::unlabeled_trailing_closure_deprecated, argInfo->getParamLabel());
+    fixIt(diagnostic, *argInfo);
   }
 
-  if (auto *callee = argInfo.getCallee()) {
+  if (auto *callee = argInfo->getCallee()) {
     emitDiagnosticAt(callee, diag::decl_declared_here, callee);
   }
 

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -2243,15 +2243,14 @@ public:
 /// func bar(_ v: Int) { foo(v) } // `Int` is not convertible to `String`
 /// ```
 class ArgumentMismatchFailure : public ContextualFailure {
-  FunctionArgApplyInfo Info;
+  std::optional<FunctionArgApplyInfo> Info;
 
 public:
   ArgumentMismatchFailure(const Solution &solution, Type argType,
                           Type paramType, ConstraintLocator *locator,
-                          FixBehavior fixBehavior =
-                              FixBehavior::Error)
+                          FixBehavior fixBehavior = FixBehavior::Error)
       : ContextualFailure(solution, argType, paramType, locator, fixBehavior),
-        Info(getFunctionArgApplyInfo(getLocator()).value()) {}
+        Info(getFunctionArgApplyInfo(locator)) {}
 
   bool diagnoseAsError() override;
   bool diagnoseAsNote() override;
@@ -2297,10 +2296,10 @@ public:
 
 protected:
   /// \returns The position of the argument being diagnosed, starting at 1.
-  unsigned getArgPosition() const { return Info.getArgPosition(); }
+  unsigned getArgPosition() const { return Info->getArgPosition(); }
 
   /// \returns The position of the parameter being diagnosed, starting at 1.
-  unsigned getParamPosition() const { return Info.getParamPosition(); }
+  unsigned getParamPosition() const { return Info->getParamPosition(); }
 
   /// Returns the argument expression being diagnosed.
   ///
@@ -2310,7 +2309,7 @@ protected:
   /// the conversion from T to U may fail. In this case, \c getArgExpr() will
   /// return the (T, U) expression, whereas \c getAnchor() will return the T
   /// expression.
-  Expr *getArgExpr() const { return Info.getArgExpr(); }
+  Expr *getArgExpr() const { return Info->getArgExpr(); }
 
   /// Returns the argument type for the conversion being diagnosed.
   ///
@@ -2323,25 +2322,25 @@ protected:
   /// In this case, \c getArgType() will return T?, whereas \c getFromType()
   /// will return T.
   Type getArgType(bool withSpecifier = false) const {
-    return Info.getArgType(withSpecifier);
+    return Info->getArgType(withSpecifier);
   }
 
   /// \returns A textual description of the argument suitable for diagnostics.
   /// For an argument with an unambiguous label, this will the label. Otherwise
   /// it will be its position in the argument list.
   StringRef getArgDescription(SmallVectorImpl<char> &scratch) const {
-    return Info.getArgDescription(scratch);
+    return Info->getArgDescription(scratch);
   }
 
   /// \returns The interface type for the function being applied.
-  Type getFnInterfaceType() const { return Info.getFnInterfaceType(); }
+  Type getFnInterfaceType() const { return Info->getFnInterfaceType(); }
 
   /// \returns The function type being applied, including any generic
   /// substitutions.
-  FunctionType *getFnType() const { return Info.getFnType(); }
+  FunctionType *getFnType() const { return Info->getFnType(); }
 
   /// \returns The callee for the argument conversion, if any.
-  const ValueDecl *getCallee() const { return Info.getCallee(); }
+  const ValueDecl *getCallee() const { return Info->getCallee(); }
 
   /// \returns The full name of the callee, or a null decl name if there is no
   /// callee.
@@ -2357,7 +2356,7 @@ protected:
   ///
   /// Note this may differ from \c getToType(), see the note on \c getArgType().
   Type getParamType(bool lookThroughAutoclosure = true) const {
-    return Info.getParamType(lookThroughAutoclosure);
+    return Info->getParamType(lookThroughAutoclosure);
   }
 
   /// Returns the type of the parameter involved in the mismatch.
@@ -2367,17 +2366,17 @@ protected:
   ///
   /// Note this may differ from \c getToType(), see the note on \c getArgType().
   Type getParamInterfaceType(bool lookThroughAutoclosure = true) const {
-    return Info.getParamInterfaceType(lookThroughAutoclosure);
+    return Info->getParamInterfaceType(lookThroughAutoclosure);
   }
 
   /// \returns The flags of the parameter involved in the mismatch.
   ParameterTypeFlags getParameterFlags() const {
-    return Info.getParameterFlags();
+    return Info->getParameterFlags();
   }
 
   /// \returns The flags of a parameter at a given index.
   ParameterTypeFlags getParameterFlagsAtIndex(unsigned idx) const {
-    return Info.getParameterFlagsAtIndex(idx);
+    return Info->getParameterFlagsAtIndex(idx);
   }
 };
 

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -4195,7 +4195,11 @@ Solution::getFunctionArgApplyInfo(ConstraintLocator *locator) const {
   auto argPath = path.drop_back(iter - path.rbegin());
   auto *argLocator = getConstraintLocator(anchor, argPath);
 
-  auto *argExpr = castToExpr(simplifyLocatorToAnchor(argLocator));
+  auto simplifiedAnchor = simplifyLocatorToAnchor(argLocator);
+  if (!simplifiedAnchor)
+    return std::nullopt;
+
+  auto *argExpr = getAsExpr(simplifiedAnchor);
 
   // If we were unable to simplify down to the argument expression, we don't
   // know what this is.

--- a/validation-test/compiler_crashers_fixed/MissingArgumentsFailure-diagnoseAsError-555e95.swift
+++ b/validation-test/compiler_crashers_fixed/MissingArgumentsFailure-diagnoseAsError-555e95.swift
@@ -1,4 +1,4 @@
 // {"kind":"typecheck","original":"74e5f02c","signature":"swift::constraints::MissingArgumentsFailure::diagnoseAsError()","signatureNext":"AddMissingArguments::diagnose"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 func a<each c, d, e>(repeat (each c, d) -> e, repeat each c)
 a(repeat b

--- a/validation-test/compiler_crashers_fixed/Solution-getFunctionArgApplyInfo-6a7d78.swift
+++ b/validation-test/compiler_crashers_fixed/Solution-getFunctionArgApplyInfo-6a7d78.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","original":"1aac3681","signature":"swift::constraints::Solution::getFunctionArgApplyInfo(swift::constraints::ConstraintLocator*) const","signatureAssert":"Assertion failed: (Val && \"isa<> used on a null pointer\"), function doit","signatureNext":"NonClassTypeToAnyObjectConversionFailure::diagnoseAsError"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 @propertyWrapper struct a<b {
   init(wrappedValue: b  AnyObject)
   var wrappedValue: b {

--- a/validation-test/compiler_crashers_fixed/Solution-getFunctionArgApplyInfo-7498c8.swift
+++ b/validation-test/compiler_crashers_fixed/Solution-getFunctionArgApplyInfo-7498c8.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","original":"18b55723","signature":"swift::constraints::Solution::getFunctionArgApplyInfo(swift::constraints::ConstraintLocator*) const","signatureAssert":"Assertion failed: (Val && \"isa<> used on a null pointer\"), function doit","signatureNext":"AllowArgumentMismatch::diagnose"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 // REQUIRES: OS=macosx
 import Foundation
 func a( CGFloat,  CGFloat?)

--- a/validation-test/compiler_crashers_fixed/Solution-getFunctionArgApplyInfo-9b9c6f.swift
+++ b/validation-test/compiler_crashers_fixed/Solution-getFunctionArgApplyInfo-9b9c6f.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","original":"a0565833","signature":"swift::constraints::Solution::getFunctionArgApplyInfo(swift::constraints::ConstraintLocator*) const","signatureAssert":"Assertion failed: (Val && \"isa<> used on a null pointer\"), function doit","signatureNext":"getStructuralTypeContext"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 struct a<b {
   base: b
   func callAsFunction(b  -> b) -> b

--- a/validation-test/compiler_crashers_fixed/Solution-getFunctionArgApplyInfo-a91fe2.swift
+++ b/validation-test/compiler_crashers_fixed/Solution-getFunctionArgApplyInfo-a91fe2.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","original":"8f8ce502","signature":"swift::constraints::Solution::getFunctionArgApplyInfo(swift::constraints::ConstraintLocator*) const","signatureAssert":"Assertion failed: (Val && \"isa<> used on a null pointer\"), function doit","signatureNext":"GenericArgumentsMismatchFailure::diagnoseAsError"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 enum a<b
   protocol c {
     associatedtype d

--- a/validation-test/compiler_crashers_fixed/Solution-getFunctionArgApplyInfo-ee974a.swift
+++ b/validation-test/compiler_crashers_fixed/Solution-getFunctionArgApplyInfo-ee974a.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","original":"2036470e","signature":"swift::constraints::Solution::getFunctionArgApplyInfo(swift::constraints::ConstraintLocator*) const","signatureAssert":"Assertion failed: (Val && \"isa<> used on a null pointer\"), function doit","signatureNext":"InvalidPackExpansion::diagnoseAsError"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 sequence(
   (a
 repeat a


### PR DESCRIPTION
Result of getFunctionArgApplyInfo can be null and a few callers failed to check and return false accordingly; corrected these missed patterns.

Some internal accesses could also receive null and failed to check, added checks and returned null in these circumstances. 

A few more checks are needed but don't seem to be causing crashes now.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
