### PR TITLE
[CAS/CachedDiagnostics] Fallback to reading the input source file from the file-system if not in the CAS

### DIFF
--- a/lib/Frontend/CachedDiagnostics.cpp
+++ b/lib/Frontend/CachedDiagnostics.cpp
@@ -530,15 +530,35 @@ DiagnosticSerializer::deserializeFile(const SerializedFile &File) {
   auto FileName = remapFilePath(File.FileName);
 
   if (!File.ContentCASID.empty()) {
-    auto ID = CAS.parseID(File.ContentCASID);
-    if (!ID)
-      return ID.takeError();
+    auto getContentFromCAS = [this](StringRef FileName, StringRef ContentCASID)
+        -> llvm::Expected<std::unique_ptr<llvm::MemoryBuffer>> {
+      auto ID = CAS.parseID(ContentCASID);
+      if (!ID)
+        return ID.takeError();
+      auto IDRef = CAS.getReference(*ID);
+      if (!IDRef)
+        return nullptr;
 
-    auto Proxy = CAS.getProxy(*ID);
-    if (!Proxy)
-      return Proxy.takeError();
+      std::optional<llvm::cas::ObjectProxy> Proxy;
+      if (llvm::Error E = CAS.getProxyIfExists(*IDRef).moveInto(Proxy))
+        return E;
+      if (!Proxy)
+        return nullptr;
 
-    auto Content = Proxy->getMemoryBuffer(FileName);
+      return Proxy->getMemoryBuffer(FileName);
+    };
+
+    std::unique_ptr<llvm::MemoryBuffer> Content;
+    if (llvm::Error E =
+            getContentFromCAS(FileName, File.ContentCASID).moveInto(Content))
+      return E;
+    if (!Content) {
+      // Fallback to reading the file from the filesystem.
+      auto MBOrErr = llvm::MemoryBuffer::getFile(FileName);
+      if (!MBOrErr)
+        return llvm::createFileError(FileName, MBOrErr.getError());
+      Content = std::move(*MBOrErr);
+    }
     return SrcMgr.addNewSourceBuffer(std::move(Content));
   }
 

--- a/test/CAS/cache_replay_direct_from_upstream.swift
+++ b/test/CAS/cache_replay_direct_from_upstream.swift
@@ -26,8 +26,12 @@
 // RUN: diff %t/Test.swiftmodule %t/Test2.swiftmodule
 
 func testFunc() {}
+#warning("some warning")
 
 // CACHE-MISS: remark: cache miss for input
 // CACHE-MISS-NOT: remark: replay output file
+// CACHE-MISS: some warning
+
+// CACHE-HIT: some warning
 // CACHE-HIT: remark: replay output file
 // CACHE-HIT-NOT: remark: cache miss for input


### PR DESCRIPTION
This allows replaying the cached compiler diagnostics from an upstream CAS, if we know the key, without needing access to the caching key input CAS tree.
