### PR TITLE
[DebugInfo] Remove boxes being interpreted as boxes for async code

### DIFF
--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -6207,17 +6207,6 @@ void IRGenSILFunction::visitDebugValueInst(DebugValueInst *i) {
   }
 
   auto RealTy = SILTy.getASTType();
-  if (IsAddrVal && IsInCoro)
-    if (auto *PBI = dyn_cast<ProjectBoxInst>(i->getOperand())) {
-      // Usually debug info only ever describes the *result* of a projectBox
-      // call. To allow the debugger to display a boxed parameter of an async
-      // continuation object, however, the debug info can only describe the box
-      // itself and thus also needs to emit a box type for it so the debugger
-      // knows to call into Remote Mirrors to unbox the value.
-      RealTy = PBI->getOperand()->getType().getASTType();
-      assert(isa<SILBoxType>(RealTy));
-    }
-
   VarDecl *VD = i->getDecl();
   if (!VD) {
     // The source location of a DebugValueInst inserted by the SIL optimizer is

--- a/test/DebugInfo/async-boxed-arg.swift
+++ b/test/DebugInfo/async-boxed-arg.swift
@@ -1,6 +1,8 @@
 // RUN: %target-swift-frontend %s -emit-ir -g -o - -parse-as-library \
-// RUN:    -module-name M  -target %target-swift-5.1-abi-triple | %FileCheck %s
+// RUN:    -module-name M  -target %target-swift-5.1-abi-triple
 // REQUIRES: concurrency
+
+// This used to crash the compiler. Just verify it builds.
 
 @available(SwiftStdlib 5.1, *)
 extension Collection where Element: Sendable {
@@ -16,6 +18,3 @@ extension Collection where Element: Sendable {
     }
   }
 }
-
-// CHECK: ![[BOXTY:[0-9]+]] = !DICompositeType(tag: DW_TAG_structure_type, name: "$s5IndexSlQzz_x_SlRzs8Sendable7ElementSTRpzlXXD"
-// CHECK: !DILocalVariable(name: "i", arg: 3, {{.*}}type: ![[BOXTY]]


### PR DESCRIPTION
This condition was added to avoid a compiler crash, however, the compiler no longer crashes with the same code.

LLDB doesn't support unwrapping boxes, so with this condition, boxed captures were unusable. Removing this condition makes the variable work again, although it doesn't appear in the entry function, it does appear after the hop_to_executor, which is better than nothing.