### PR TITLE
[Utils] add suport for static (class) and final methods to function caller generator

### DIFF
--- a/test/Utils/swift-function-caller-generator/compile.swift
+++ b/test/Utils/swift-function-caller-generator/compile.swift
@@ -49,7 +49,7 @@ public class C {
   open func ope(_ x: Int) -> Int {
     return x
   }
-  public class func clas(x: Int) -> Int {
+  public final class func clas(x: Int) -> Int {
     return x
   }
   open class func clas2(x: Int) -> Int {
@@ -117,8 +117,7 @@ public func call_qux(_ func: inout Swift::MutableSpan<Swift::CInt>) {
 func call_ope(_ self: C, _ x: Swift::Int) -> Swift::Int {
   return self.ope(x)
 }
-
-  public func call_clas(x: Swift::Int) -> Swift::Int {
+public func call_clas(x: Swift::Int) -> Swift::Int {
   return C.clas(x: x)
 }
 func call_clas2(x: Swift::Int) -> Swift::Int {

--- a/test/Utils/swift-function-caller-generator/compile.swift
+++ b/test/Utils/swift-function-caller-generator/compile.swift
@@ -49,6 +49,12 @@ public class C {
   open func ope(_ x: Int) -> Int {
     return x
   }
+  public class func clas(x: Int) -> Int {
+    return x
+  }
+  open class func clas2(x: Int) -> Int {
+    return x
+  }
 }
 
 @available(*, unavailable)
@@ -110,4 +116,11 @@ public func call_qux(_ func: inout Swift::MutableSpan<Swift::CInt>) {
 }
 func call_ope(_ self: C, _ x: Swift::Int) -> Swift::Int {
   return self.ope(x)
+}
+
+  public func call_clas(x: Swift::Int) -> Swift::Int {
+  return C.clas(x: x)
+}
+func call_clas2(x: Swift::Int) -> Swift::Int {
+  return C.clas2(x: x)
 }

--- a/test/Utils/swift-function-caller-generator/method.swift
+++ b/test/Utils/swift-function-caller-generator/method.swift
@@ -12,6 +12,10 @@ struct Foo {
   func unsafeMethod(p: UnsafeMutablePointer<Int>)
 }
 
+class Bar {
+  class func classFunction(x: Int) -> Int
+}
+
 //--- out.swift.expected
 import Test
 
@@ -25,4 +29,7 @@ func call_mutatingMethod(_ self: inout Foo, x: Int) {
 
 func call_unsafeMethod(_ self: Foo, p: UnsafeMutablePointer<Int>) {
   return unsafe self.unsafeMethod(p: p)
+}
+func call_classFunction(x: Int) -> Int {
+  return Bar.classFunction(x: x)
 }

--- a/tools/swift-function-caller-generator/Sources/swift-function-caller-generator/swift-function-caller-generator.swift
+++ b/tools/swift-function-caller-generator/Sources/swift-function-caller-generator/swift-function-caller-generator.swift
@@ -74,7 +74,7 @@ class SwiftMacroTestGen: SyntaxVisitor {
     let isMutating = res.modifiers.contains(where: {
       $0.name.tokenKind == .keyword(.mutating)
     })
-    let selfParam = surroundingType.map { _ in TokenSyntax("self") }
+    let selfParam = surroundingType.map { type in res.isClassMethod ? type.with(\.trailingTrivia, "") : TokenSyntax("self") }
     res = createFunctionSignature(res)
     res =
       res
@@ -82,23 +82,27 @@ class SwiftMacroTestGen: SyntaxVisitor {
       .with(\.name, "call_\(res.name.withoutBackticks)")
       .with(\.leadingTrivia, res.leadingTrivia.withoutComments)
     if let surroundingType {
+      if !res.isClassMethod {
+        res =
+          res
+          .with(
+            \.signature.parameterClause.parameters,
+            addSelfParam(
+              res.signature.parameterClause.parameters, surroundingType, selfParam!,
+              isMutating: isMutating)
+          )
+      }
       res =
         res
-        .with(
-          \.signature.parameterClause.parameters,
-          addSelfParam(
-            res.signature.parameterClause.parameters, surroundingType, selfParam!,
-            isMutating: isMutating)
-        )
         .with(\.leadingTrivia, "\n")
         .with(
           \.modifiers,
           res.modifiers.filter { modifier in
             switch modifier.name.tokenKind {
-              case .keyword(.mutating), .keyword(.open):
-                false
-              default:
-                true
+            case .keyword(.mutating), .keyword(.open), .keyword(.class):
+              false
+            default:
+              true
             }
           }
         )
@@ -248,6 +252,12 @@ extension TypeSyntax {
       }
       return simpleSpec.specifier.text == "inout"
     })
+  }
+}
+
+extension FunctionDeclSyntax {
+  var isClassMethod: Bool {
+    return self.modifiers.contains(where: { mod in mod.name.tokenKind == .keyword(.class) })
   }
 }
 

--- a/tools/swift-function-caller-generator/Sources/swift-function-caller-generator/swift-function-caller-generator.swift
+++ b/tools/swift-function-caller-generator/Sources/swift-function-caller-generator/swift-function-caller-generator.swift
@@ -99,7 +99,7 @@ class SwiftMacroTestGen: SyntaxVisitor {
           \.modifiers,
           res.modifiers.filter { modifier in
             switch modifier.name.tokenKind {
-            case .keyword(.mutating), .keyword(.open), .keyword(.class):
+            case .keyword(.mutating), .keyword(.open), .keyword(.class), .keyword(.final):
               false
             default:
               true


### PR DESCRIPTION
Previously the generated code would try to call class methods as instance methods, and callers to methods marked `final` would inherit this modifier despite being top-level functions.