### PR TITLE
[Swiftify] make safe wrappers `final` when in a Swift class

### DIFF
--- a/lib/Macros/Sources/SwiftMacros/SwiftifyImportMacro.swift
+++ b/lib/Macros/Sources/SwiftMacros/SwiftifyImportMacro.swift
@@ -1783,16 +1783,24 @@ func constructOverloadFunction(forDecl declaration: some DeclSyntaxProtocol, lea
     + disfavoredOverload)
   let trivia =
     leadingTrivia + .docLineComment("/// This is an auto-generated wrapper for safer interop\n")
+  var modifiers = funcComponents.modifiers
+  if parentNode?.as(ClassDeclSyntax.self) != nil {
+    if let openIdx = modifiers.firstIndex(where: { mod in mod.name.tokenKind == .keyword(.open)}) {
+      // "open final" is not allowed in Swift
+      modifiers[openIdx] = DeclModifierSyntax(name: .keyword(.public))
+    }
+    modifiers.append(DeclModifierSyntax(name: .keyword(.final)))
+  }
   if let origFuncDecl = declaration.as(FunctionDeclSyntax.self) {
     return DeclSyntax(
       origFuncDecl
         .with(\.signature, newSignature)
         .with(\.body, body)
         .with(\.attributes, attributes)
+        .with(\.modifiers, modifiers)
         .with(\.leadingTrivia, trivia))
   }
   if let origInitDecl = declaration.as(InitializerDeclSyntax.self) {
-    var modifiers = funcComponents.modifiers
     if parentNode?.as(ClassDeclSyntax.self) != nil { // convenience inits are forbidden in structs
       let alreadyConvenienceInit = modifiers.contains(where: { mod in
         mod.name.text == "convenience"

--- a/test/Interop/C/swiftify-import/import-as-instance-method.swift
+++ b/test/Interop/C/swiftify-import/import-as-instance-method.swift
@@ -245,7 +245,7 @@ public func lifetimeBoundSelf(_ a: A, _ len: Int32) -> MutableSpan<Int32> {
 ------------------------------
 /// This is an auto-generated wrapper for safer interop
 @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
-public func refSelf(_ p: inout MutableSpan<Int32>) {
+public final func refSelf(_ p: inout MutableSpan<Int32>) {
     let len = Int32(exactly: p.count)!
     let _pPtr = p.withUnsafeMutableBufferPointer {
         unsafe $0
@@ -275,7 +275,7 @@ public func refSelf(_ c: C!, _ p: inout MutableSpan<Int32>) {
 ------------------------------
 /// This is an auto-generated wrapper for safer interop
 @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
-public func refSelf(_ p: inout MutableSpan<Int32>) {
+public final func refSelf(_ p: inout MutableSpan<Int32>) {
     let len = Int32(exactly: p.count)!
     let _pPtr = p.withUnsafeMutableBufferPointer {
         unsafe $0
@@ -376,7 +376,7 @@ public func createA2(_ p: inout MutableSpan<Int32>) -> UnsafeMutablePointer<A>! 
 ------------------------------
 /// This is an auto-generated wrapper for safer interop
 @_alwaysEmitIntoClient @_disfavoredOverload
-public /*not inherited*/ convenience init!(pointerC p: UnsafeMutableBufferPointer<Int32>) {
+public /*not inherited*/ final convenience init!(pointerC p: UnsafeMutableBufferPointer<Int32>) {
     let len = Int32(exactly: p.count)!
     unsafe self.init(countC: len, pointerC: p.baseAddress!)
 }


### PR DESCRIPTION
With this change we prevent subclasses from overriding the implementation of a safe wrapper function, regardless of the overridability of the underlying function. Overriding the safe wrapper is an anti-pattern and almost guaranteed to be a footgun. If the *wrapped* function is overridden, the safe wrapper will still call the subclass' implementation using dynamic dispatch.

For C++ FRTs, this has the advantage that we don't add the method to the vtable and can call it using static dispatch [citation needed]. It's also quite unclear how @_alwaysEmitIntoClient interacts with dynamic dispatch. I didn't really check if these are called with dynamic dispatch, but regardless, being not-final here is wrong.

This is also necessary to unblock safe interop for ObjC `@interface`s (in a separate PR), which would previously crash in SILGen when I prototyped it, with the assertion message complaining that the function could not be found in the vtable. By eliminating it from dynamic dispatch, this will no longer be an issue.

rdar://177544334