### PR TITLE
[Swiftify] add safe wrappers for ObjC @interface methods

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -11243,13 +11243,18 @@ void ClangImporter::Implementation::insertMembersAndAlternates(
 
     // If there are auxiliary declarations (e.g., produced by macros), load
     // those.
-    member->visitAuxiliaryDecls([&](Decl *aux) {
-      if (auto auxValue = dyn_cast<ValueDecl>(aux)) {
-        if (auxValue->getDeclContext() == expectedDC &&
-            knownAlternateMembers.insert(auxValue).second)
-          members.push_back(auxValue);
-      }
-    });
+    auto addAuxiliaryDecls = [&](Decl *forDecl) {
+      forDecl->visitAuxiliaryDecls([&](Decl *aux) {
+        if (auto auxValue = dyn_cast<ValueDecl>(aux)) {
+          if (auxValue->getDeclContext() == expectedDC &&
+              knownAlternateMembers.insert(auxValue).second)
+            members.push_back(auxValue);
+        }
+      });
+    };
+    addAuxiliaryDecls(member);
+    for (auto alternate : getAlternateDecls(member))
+      addAuxiliaryDecls(alternate);
 
     // If this declaration shouldn't be visible, don't add it to
     // the list.

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -11253,13 +11253,18 @@ void ClangImporter::Implementation::insertMembersAndAlternates(
 
     // If there are auxiliary declarations (e.g., produced by macros), load
     // those.
-    member->visitAuxiliaryDecls([&](Decl *aux) {
-      if (auto auxValue = dyn_cast<ValueDecl>(aux)) {
-        if (auxValue->getDeclContext() == expectedDC &&
-            knownAlternateMembers.insert(auxValue).second)
-          members.push_back(auxValue);
-      }
-    });
+    auto addAuxiliaryDecls = [&](Decl *forDecl) {
+      forDecl->visitAuxiliaryDecls([&](Decl *aux) {
+        if (auto auxValue = dyn_cast<ValueDecl>(aux)) {
+          if (auxValue->getDeclContext() == expectedDC &&
+              knownAlternateMembers.insert(auxValue).second)
+            members.push_back(auxValue);
+        }
+      });
+    };
+    addAuxiliaryDecls(member);
+    for (auto alternate : getAlternateDecls(member))
+      addAuxiliaryDecls(alternate);
 
     // If this declaration shouldn't be visible, don't add it to
     // the list.

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -5784,6 +5784,7 @@ namespace {
         }
       }
 
+      Impl.swiftify(result);
       return result;
     }
 

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -5843,6 +5843,7 @@ namespace {
         }
       }
 
+      Impl.swiftify(result);
       return result;
     }
 

--- a/lib/ClangImporter/SwiftifyDecl.cpp
+++ b/lib/ClangImporter/SwiftifyDecl.cpp
@@ -636,6 +636,10 @@ static size_t getNumParams(const clang::FunctionDecl* D) {
     return D->getNumParams();
 }
 
+static size_t getNumParams(const clang::ObjCMethodDecl* D) {
+    return D->param_size();
+}
+
 static bool shouldSkipModule(ModuleDecl *M) {
   if (M->isClangBridgingHeaderImportModule()) {
     DLOG("is from bridging header (or C++ namespace)\n");
@@ -911,8 +915,14 @@ static bool diagnoseMissingMacroPlugin(ASTContext &SwiftContext,
 void ClangImporter::Implementation::swiftify(AbstractFunctionDecl *MappedDecl) {
   if (SwiftContext.LangOpts.DisableSafeInteropWrappers)
     return;
-  auto ClangDecl = dyn_cast_or_null<clang::FunctionDecl>(MappedDecl->getClangDecl());
-  if (!ClangDecl)
+  auto ClangDecl = MappedDecl->getClangDecl();
+  auto ClangFuncDecl = dyn_cast_or_null<clang::FunctionDecl>(ClangDecl);
+  auto ClangObjCMethodDecl = dyn_cast_or_null<clang::ObjCMethodDecl>(ClangDecl);
+  if (!ClangFuncDecl && !ClangObjCMethodDecl)
+    return;
+  ASSERT(!ClangFuncDecl || !ClangObjCMethodDecl);
+
+  if (isa<ProtocolDecl>(MappedDecl->getParent()))
     return;
 
   MacroDecl *SwiftifyImportDecl = dyn_cast_or_null<MacroDecl>(getKnownSingleDecl(SwiftContext, "_SwiftifyImport"));
@@ -984,9 +994,16 @@ void ClangImporter::Implementation::swiftify(AbstractFunctionDecl *MappedDecl) {
     SwiftifyInfoFunctionPrinter printer(
         getClangASTContext(), SwiftContext, out, *SwiftifyImportDecl,
         typeMapping, DiagnosedMissingNullableAsEmptySpanParam);
-    if (!swiftifyImpl(*this, printer, MappedDecl, ClangDecl)) {
-      DLOG("No relevant bounds or lifetime info found\n");
-      return;
+    if (ClangFuncDecl) {
+      if (!swiftifyImpl(*this, printer, MappedDecl, ClangFuncDecl)) {
+        DLOG("No relevant bounds or lifetime info found\n");
+        return;
+      }
+    } else {
+      if (!swiftifyImpl(*this, printer, MappedDecl, ClangObjCMethodDecl)) {
+        DLOG("No relevant bounds or lifetime info found\n");
+        return;
+      }
     }
     printer.printAvailability();
     printer.printTypeMapping();

--- a/lib/ClangImporter/SwiftifyDecl.cpp
+++ b/lib/ClangImporter/SwiftifyDecl.cpp
@@ -907,7 +907,17 @@ static bool diagnoseMissingMacroPlugin(ASTContext &SwiftContext,
 void ClangImporter::Implementation::swiftify(AbstractFunctionDecl *MappedDecl) {
   if (SwiftContext.LangOpts.DisableSafeInteropWrappers)
     return;
-  auto ClangDecl = MappedDecl->getClangDecl();
+  const clang::Decl *ClangDecl = MappedDecl->getClangDecl();
+
+  if (ClangDecl && ClangDecl->isImplicit()) {
+    if (auto *F = dyn_cast<FuncDecl>(MappedDecl)) {
+      if (const FuncDecl *Orig = getOriginalForVirtualThunk(F)) {
+        DLOG("Remapping virtual thunk to original clang decl\n");
+        ClangDecl = Orig->getClangDecl();
+      }
+    }
+  }
+
   auto ClangFuncDecl = dyn_cast_or_null<clang::FunctionDecl>(ClangDecl);
   auto ClangObjCMethodDecl = dyn_cast_or_null<clang::ObjCMethodDecl>(ClangDecl);
   if (!ClangFuncDecl && !ClangObjCMethodDecl)
@@ -921,15 +931,6 @@ void ClangImporter::Implementation::swiftify(AbstractFunctionDecl *MappedDecl) {
   if (!SwiftifyImportDecl) {
     DLOG("_SwiftifyImport macro not found\n");
     return;
-  }
-
-  if (ClangDecl->isImplicit()) {
-    if (auto *F = dyn_cast<FuncDecl>(MappedDecl)) {
-      if (const FuncDecl *Orig = getOriginalForVirtualThunk(F)) {
-        DLOG("Remapping virtual thunk to original clang decl\n");
-        ClangDecl = dyn_cast<clang::FunctionDecl>(Orig->getClangDecl());
-      }
-    }
   }
 
   // A method that overrides a virtual method needs no wrapper of its own if it

--- a/lib/ClangImporter/SwiftifyDecl.cpp
+++ b/lib/ClangImporter/SwiftifyDecl.cpp
@@ -632,14 +632,6 @@ static bool getImplicitObjectParamAnnotation(const clang::ObjCMethodDecl* D) {
     return false; // Only C++ methods have implicit params
 }
 
-static size_t getNumParams(const clang::FunctionDecl* D) {
-    return D->getNumParams();
-}
-
-static size_t getNumParams(const clang::ObjCMethodDecl* D) {
-    return D->param_size();
-}
-
 static bool shouldSkipModule(ModuleDecl *M) {
   if (M->isClangBridgingHeaderImportModule()) {
     DLOG("is from bridging header (or C++ namespace)\n");
@@ -752,7 +744,7 @@ static bool swiftifyImpl(ClangImporter::Implementation &Self,
       ASSERT(MappedDecl->isImportAsInstanceMember());
       swiftNumParams += 1;
     }
-    if (getNumParams(ClangDecl) != swiftNumParams) {
+    if (ClangDecl->param_size() != swiftNumParams) {
       DLOG("mismatching parameter lists");
       assert(
           ClangDecl->isVariadic() ||
@@ -765,7 +757,7 @@ static bool swiftifyImpl(ClangImporter::Implementation &Self,
 
     size_t selfParamIndex = MappedDecl->isImportAsInstanceMember()
                                 ? MappedDecl->getSelfIndex()
-                                : getNumParams(ClangDecl);
+                                : ClangDecl->param_size();
     for (auto [index, clangParam] : llvm::enumerate(ClangDecl->parameters())) {
       clang::QualType clangParamTy = clangParam->getType();
       DLOG_SCOPE("Checking parameter '" << *clangParam << "' with type '"

--- a/lib/ClangImporter/SwiftifyDecl.cpp
+++ b/lib/ClangImporter/SwiftifyDecl.cpp
@@ -986,16 +986,12 @@ void ClangImporter::Implementation::swiftify(AbstractFunctionDecl *MappedDecl) {
     SwiftifyInfoFunctionPrinter printer(
         getClangASTContext(), SwiftContext, out, *SwiftifyImportDecl,
         typeMapping, DiagnosedMissingNullableAsEmptySpanParam);
-    if (ClangFuncDecl) {
-      if (!swiftifyImpl(*this, printer, MappedDecl, ClangFuncDecl)) {
-        DLOG("No relevant bounds or lifetime info found\n");
-        return;
-      }
-    } else {
-      if (!swiftifyImpl(*this, printer, MappedDecl, ClangObjCMethodDecl)) {
-        DLOG("No relevant bounds or lifetime info found\n");
-        return;
-      }
+    bool foundInfo = ClangFuncDecl ?
+      swiftifyImpl(*this, printer, MappedDecl, ClangFuncDecl) :
+      swiftifyImpl(*this, printer, MappedDecl, ClangObjCMethodDecl);
+    if (!foundInfo) {
+      DLOG("No relevant bounds or lifetime info found\n");
+      return;
     }
     printer.printAvailability();
     printer.printTypeMapping();

--- a/lib/ClangImporter/SwiftifyDecl.cpp
+++ b/lib/ClangImporter/SwiftifyDecl.cpp
@@ -936,16 +936,12 @@ void ClangImporter::Implementation::swiftify(AbstractFunctionDecl *MappedDecl) {
     SwiftifyInfoFunctionPrinter printer(
         getClangASTContext(), SwiftContext, out, *SwiftifyImportDecl,
         typeMapping, DiagnosedMissingNullableAsEmptySpanParam);
-    if (ClangFuncDecl) {
-      if (!swiftifyImpl(*this, printer, MappedDecl, ClangFuncDecl)) {
-        DLOG("No relevant bounds or lifetime info found\n");
-        return;
-      }
-    } else {
-      if (!swiftifyImpl(*this, printer, MappedDecl, ClangObjCMethodDecl)) {
-        DLOG("No relevant bounds or lifetime info found\n");
-        return;
-      }
+    bool foundInfo = ClangFuncDecl ?
+      swiftifyImpl(*this, printer, MappedDecl, ClangFuncDecl) :
+      swiftifyImpl(*this, printer, MappedDecl, ClangObjCMethodDecl);
+    if (!foundInfo) {
+      DLOG("No relevant bounds or lifetime info found\n");
+      return;
     }
     printer.printAvailability();
     printer.printTypeMapping();

--- a/lib/ClangImporter/SwiftifyDecl.cpp
+++ b/lib/ClangImporter/SwiftifyDecl.cpp
@@ -629,14 +629,6 @@ static bool getImplicitObjectParamAnnotation(const clang::ObjCMethodDecl* D) {
     return false; // Only C++ methods have implicit params
 }
 
-static size_t getNumParams(const clang::FunctionDecl* D) {
-    return D->getNumParams();
-}
-
-static size_t getNumParams(const clang::ObjCMethodDecl* D) {
-    return D->param_size();
-}
-
 static bool shouldSkipModule(ModuleDecl *M) {
   if (M->isClangBridgingHeaderImportModule()) {
     DLOG("is from bridging header (or C++ namespace)\n");
@@ -749,7 +741,7 @@ static bool swiftifyImpl(ClangImporter::Implementation &Self,
       ASSERT(MappedDecl->isImportAsInstanceMember());
       swiftNumParams += 1;
     }
-    if (getNumParams(ClangDecl) != swiftNumParams) {
+    if (ClangDecl->param_size() != swiftNumParams) {
       DLOG("mismatching parameter lists");
       assert(
           ClangDecl->isVariadic() ||
@@ -762,7 +754,7 @@ static bool swiftifyImpl(ClangImporter::Implementation &Self,
 
     size_t selfParamIndex = MappedDecl->isImportAsInstanceMember()
                                 ? MappedDecl->getSelfIndex()
-                                : getNumParams(ClangDecl);
+                                : ClangDecl->param_size();
     for (auto [index, clangParam] : llvm::enumerate(ClangDecl->parameters())) {
       clang::QualType clangParamTy = clangParam->getType();
       DLOG_SCOPE("Checking parameter '" << *clangParam << "' with type '"

--- a/lib/ClangImporter/SwiftifyDecl.cpp
+++ b/lib/ClangImporter/SwiftifyDecl.cpp
@@ -633,6 +633,10 @@ static size_t getNumParams(const clang::FunctionDecl* D) {
     return D->getNumParams();
 }
 
+static size_t getNumParams(const clang::ObjCMethodDecl* D) {
+    return D->param_size();
+}
+
 static bool shouldSkipModule(ModuleDecl *M) {
   if (M->isClangBridgingHeaderImportModule()) {
     DLOG("is from bridging header (or C++ namespace)\n");
@@ -908,8 +912,14 @@ static bool diagnoseMissingMacroPlugin(ASTContext &SwiftContext,
 void ClangImporter::Implementation::swiftify(AbstractFunctionDecl *MappedDecl) {
   if (SwiftContext.LangOpts.DisableSafeInteropWrappers)
     return;
-  auto ClangDecl = dyn_cast_or_null<clang::FunctionDecl>(MappedDecl->getClangDecl());
-  if (!ClangDecl)
+  auto ClangDecl = MappedDecl->getClangDecl();
+  auto ClangFuncDecl = dyn_cast_or_null<clang::FunctionDecl>(ClangDecl);
+  auto ClangObjCMethodDecl = dyn_cast_or_null<clang::ObjCMethodDecl>(ClangDecl);
+  if (!ClangFuncDecl && !ClangObjCMethodDecl)
+    return;
+  ASSERT(!ClangFuncDecl || !ClangObjCMethodDecl);
+
+  if (isa<ProtocolDecl>(MappedDecl->getParent()))
     return;
 
   MacroDecl *SwiftifyImportDecl = dyn_cast_or_null<MacroDecl>(getKnownSingleDecl(SwiftContext, "_SwiftifyImport"));
@@ -934,9 +944,16 @@ void ClangImporter::Implementation::swiftify(AbstractFunctionDecl *MappedDecl) {
     SwiftifyInfoFunctionPrinter printer(
         getClangASTContext(), SwiftContext, out, *SwiftifyImportDecl,
         typeMapping, DiagnosedMissingNullableAsEmptySpanParam);
-    if (!swiftifyImpl(*this, printer, MappedDecl, ClangDecl)) {
-      DLOG("No relevant bounds or lifetime info found\n");
-      return;
+    if (ClangFuncDecl) {
+      if (!swiftifyImpl(*this, printer, MappedDecl, ClangFuncDecl)) {
+        DLOG("No relevant bounds or lifetime info found\n");
+        return;
+      }
+    } else {
+      if (!swiftifyImpl(*this, printer, MappedDecl, ClangObjCMethodDecl)) {
+        DLOG("No relevant bounds or lifetime info found\n");
+        return;
+      }
     }
     printer.printAvailability();
     printer.printTypeMapping();

--- a/test/Interop/ObjC/swiftify-import/counted-by-in-class-noescape.swift
+++ b/test/Interop/ObjC/swiftify-import/counted-by-in-class-noescape.swift
@@ -28,6 +28,19 @@ module Method {
 #define __lifetimebound __attribute__((lifetimebound))
 
 @interface Foo
+// expected-expansion@+26:2{{
+//   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload public class final func simple(_ p: inout MutableSpan<CInt>) {|}}
+//   expected-remark@3{{macro content: |    let len = CInt(exactly: p.count)!|}}
+//   expected-remark@4{{macro content: |    let _pPtr = p.withUnsafeMutableBufferPointer {|}}
+//   expected-remark@5{{macro content: |        unsafe $0|}}
+//   expected-remark@6{{macro content: |    }|}}
+//   expected-remark@7{{macro content: |    defer {|}}
+//   expected-remark@8{{macro content: |        _fixLifetime(p)|}}
+//   expected-remark@9{{macro content: |    }|}}
+//   expected-remark@10{{macro content: |    return unsafe simple(len, _pPtr.baseAddress)|}}
+//   expected-remark@11{{macro content: |}|}}
+// }}
 // expected-expansion@+13:64{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload public final func simple(_ p: inout MutableSpan<CInt>) {|}}
@@ -43,6 +56,28 @@ module Method {
 // }}
 - (void) simple:(int)len :(int * __counted_by(len) __noescape)p;
 
+// expected-expansion@+44:2{{
+//   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p1: copy p1) @_lifetime(p2: copy p2) @_disfavoredOverload public class final func shared(_ p1: inout MutableSpan<CInt>, _ p2: inout MutableSpan<CInt>) {|}}
+//   expected-remark@3{{macro content: |    let len = CInt(exactly: p2.count)!|}}
+//   expected-remark@4{{macro content: |    if p1.count != len {|}}
+//   expected-remark@5{{macro content: |      fatalError("bounds check failure in shared: expected \\(len) but got \\(p1.count)")|}}
+//   expected-remark@6{{macro content: |    }|}}
+//   expected-remark@7{{macro content: |    let _p1Ptr = p1.withUnsafeMutableBufferPointer {|}}
+//   expected-remark@8{{macro content: |        unsafe $0|}}
+//   expected-remark@9{{macro content: |    }|}}
+//   expected-remark@10{{macro content: |    defer {|}}
+//   expected-remark@11{{macro content: |        _fixLifetime(p1)|}}
+//   expected-remark@12{{macro content: |    }|}}
+//   expected-remark@13{{macro content: |    let _p2Ptr = p2.withUnsafeMutableBufferPointer {|}}
+//   expected-remark@14{{macro content: |        unsafe $0|}}
+//   expected-remark@15{{macro content: |    }|}}
+//   expected-remark@16{{macro content: |    defer {|}}
+//   expected-remark@17{{macro content: |        _fixLifetime(p2)|}}
+//   expected-remark@18{{macro content: |    }|}}
+//   expected-remark@19{{macro content: |    return unsafe shared(len, _p1Ptr.baseAddress, _p2Ptr.baseAddress)|}}
+//   expected-remark@20{{macro content: |}|}}
+// }}
 // expected-expansion@+22:105{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p1: copy p1) @_lifetime(p2: copy p2) @_disfavoredOverload public final func shared(_ p1: inout MutableSpan<CInt>, _ p2: inout MutableSpan<CInt>) {|}}
@@ -67,6 +102,21 @@ module Method {
 // }}
 - (void) shared:(int)len :(int * __counted_by(len) __noescape)p1 :(int * __counted_by(len) __noescape)p2;
 
+// expected-expansion@+30:2{{
+//   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload public class final func complexExpr(_ len: CInt, _ offset: CInt, _ p: inout MutableSpan<CInt>) {|}}
+//   expected-remark@3{{macro content: |    if p.count != (len - offset) {|}}
+//   expected-remark@4{{macro content: |      fatalError("bounds check failure in complexExpr: expected \\((len - offset)) but got \\(p.count)")|}}
+//   expected-remark@5{{macro content: |    }|}}
+//   expected-remark@6{{macro content: |    let _pPtr = p.withUnsafeMutableBufferPointer {|}}
+//   expected-remark@7{{macro content: |        unsafe $0|}}
+//   expected-remark@8{{macro content: |    }|}}
+//   expected-remark@9{{macro content: |    defer {|}}
+//   expected-remark@10{{macro content: |        _fixLifetime(p)|}}
+//   expected-remark@11{{macro content: |    }|}}
+//   expected-remark@12{{macro content: |    return unsafe complexExpr(len, offset, _pPtr.baseAddress)|}}
+//   expected-remark@13{{macro content: |}|}}
+// }}
 // expected-expansion@+15:92{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload public final func complexExpr(_ len: CInt, _ offset: CInt, _ p: inout MutableSpan<CInt>) {|}}
@@ -84,6 +134,19 @@ module Method {
 // }}
 - (void) complexExpr:(int)len :(int) offset :(int * __counted_by(len - offset) __noescape)p;
 
+// expected-expansion@+26:2{{
+//   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload public class final func nullUnspecified(_ p: inout MutableSpan<CInt>) {|}}
+//   expected-remark@3{{macro content: |    let len = CInt(exactly: p.count)!|}}
+//   expected-remark@4{{macro content: |    let _pPtr = p.withUnsafeMutableBufferPointer {|}}
+//   expected-remark@5{{macro content: |        unsafe $0|}}
+//   expected-remark@6{{macro content: |    }|}}
+//   expected-remark@7{{macro content: |    defer {|}}
+//   expected-remark@8{{macro content: |        _fixLifetime(p)|}}
+//   expected-remark@9{{macro content: |    }|}}
+//   expected-remark@10{{macro content: |    return unsafe nullUnspecified(len, _pPtr.baseAddress)|}}
+//   expected-remark@11{{macro content: |}|}}
+// }}
 // expected-expansion@+13:91{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload public final func nullUnspecified(_ p: inout MutableSpan<CInt>) {|}}
@@ -99,6 +162,19 @@ module Method {
 // }}
 - (void) nullUnspecified:(int)len :(int * __counted_by(len) _Null_unspecified __noescape)p;
 
+// expected-expansion@+26:2{{
+//   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload public class final func nonnull(_ p: inout MutableSpan<CInt>) {|}}
+//   expected-remark@3{{macro content: |    let len = CInt(exactly: p.count)!|}}
+//   expected-remark@4{{macro content: |    let _pPtr = p.withUnsafeMutableBufferPointer {|}}
+//   expected-remark@5{{macro content: |        unsafe $0|}}
+//   expected-remark@6{{macro content: |    }|}}
+//   expected-remark@7{{macro content: |    defer {|}}
+//   expected-remark@8{{macro content: |        _fixLifetime(p)|}}
+//   expected-remark@9{{macro content: |    }|}}
+//   expected-remark@10{{macro content: |    return unsafe nonnull(len, _pPtr.baseAddress!)|}}
+//   expected-remark@11{{macro content: |}|}}
+// }}
 // expected-expansion@+13:74{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload public final func nonnull(_ p: inout MutableSpan<CInt>) {|}}
@@ -114,6 +190,23 @@ module Method {
 // }}
 - (void) nonnull:(int)len :(int * __counted_by(len) __noescape _Nonnull)p;
 
+// expected-expansion@+34:2{{
+//   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload public class final func nullable(_ p: inout MutableSpan<CInt>?) {|}}
+//   expected-stable-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload public class final func nullable(_ p: inout MutableSpan<CInt>) {|}}
+//   expected-experimental-remark@3{{macro content: |    let len = CInt(exactly: p?.count ?? 0)!|}}
+//   expected-stable-remark@3{{macro content: |    let len = CInt(exactly: p.count)!|}}
+//   expected-experimental-remark@4{{macro content: |    let _pPtr = p?.withUnsafeMutableBufferPointer {|}}
+//   expected-stable-remark@4{{macro content: |    let _pPtr = p.withUnsafeMutableBufferPointer {|}}
+//   expected-remark@5{{macro content: |        unsafe $0|}}
+//   expected-remark@6{{macro content: |    }|}}
+//   expected-remark@7{{macro content: |    defer {|}}
+//   expected-remark@8{{macro content: |        _fixLifetime(p)|}}
+//   expected-remark@9{{macro content: |    }|}}
+//   expected-experimental-remark@10{{macro content: |    return unsafe nullable(len, _pPtr?.baseAddress)|}}
+//   expected-stable-remark@10{{macro content: |    return unsafe nullable(len, _pPtr.baseAddress)|}}
+//   expected-remark@11{{macro content: |}|}}
+// }}
 // expected-expansion@+17:76{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload public final func nullable(_ p: inout MutableSpan<CInt>?) {|}}
@@ -134,6 +227,23 @@ module Method {
 - (void) nullable:(int)len :(int * __counted_by(len) _Nullable __noescape)p;
 
 
+// expected-experimental-expansion@+35:2{{
+//   expected-experimental-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy p) @_lifetime(p: copy p) @_disfavoredOverload public class final func returnPointerNullable(_ p: inout MutableSpan<CInt>?) -> MutableSpan<CInt>? {|}}
+//   expected-experimental-remark@3{{macro content: |    let len = CInt(exactly: p?.count ?? 0)!|}}
+//   expected-experimental-remark@4{{macro content: |    let _pPtr = p?.withUnsafeMutableBufferPointer {|}}
+//   expected-experimental-remark@5{{macro content: |        unsafe $0|}}
+//   expected-experimental-remark@6{{macro content: |    }|}}
+//   expected-experimental-remark@7{{macro content: |    defer {|}}
+//   expected-experimental-remark@8{{macro content: |        _fixLifetime(p)|}}
+//   expected-experimental-remark@9{{macro content: |    }|}}
+//   expected-experimental-remark@10{{macro content: |    let _resultValue = unsafe returnPointerNullable(len, _pPtr?.baseAddress)|}}
+//   expected-experimental-remark@11{{macro content: |    if unsafe _resultValue == nil {|}}
+//   expected-experimental-remark@12{{macro content: |      return nil|}}
+//   expected-experimental-remark@13{{macro content: |    }|}}
+//   expected-experimental-remark@14{{macro content: |    return unsafe _swiftifyOverrideLifetime(MutableSpan<CInt>(_unsafeStart: _resultValue!, count: Int(len)), copying: ())|}}
+//   expected-experimental-remark@15{{macro content: |}|}}
+// }}
 // expected-stable-note@+18{{'returnPointerNullable' declared here}}
 // expected-experimental-expansion@+17:125{{
 //   expected-experimental-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
@@ -155,6 +265,19 @@ module Method {
 - (int * __counted_by(len) _Nullable) returnPointerNullable:(int)len : (int * __counted_by(len) _Nullable) __lifetimebound p;
 
 
+// expected-experimental-expansion@+27:2{{
+//   expected-experimental-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy p) @_lifetime(p: copy p) @_disfavoredOverload public class final func returnPointerNonnull(_ p: inout MutableSpan<CInt>) -> MutableSpan<CInt> {|}}
+//   expected-experimental-remark@3{{macro content: |    let len = CInt(exactly: p.count)!|}}
+//   expected-experimental-remark@4{{macro content: |    let _pPtr = p.withUnsafeMutableBufferPointer {|}}
+//   expected-experimental-remark@5{{macro content: |        unsafe $0|}}
+//   expected-experimental-remark@6{{macro content: |    }|}}
+//   expected-experimental-remark@7{{macro content: |    defer {|}}
+//   expected-experimental-remark@8{{macro content: |        _fixLifetime(p)|}}
+//   expected-experimental-remark@9{{macro content: |    }|}}
+//   expected-experimental-remark@10{{macro content: |    return unsafe _swiftifyOverrideLifetime(MutableSpan<CInt>(_unsafeStart: unsafe returnPointerNonnull(len, _pPtr.baseAddress!), count: Int(len)), copying: ())|}}
+//   expected-experimental-remark@11{{macro content: |}|}}
+// }}
 // expected-stable-note@+14{{'returnPointerNonnull' declared here}}
 // expected-experimental-expansion@+13:122{{
 //   expected-experimental-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
@@ -171,6 +294,22 @@ module Method {
 // }}
 - (int * __counted_by(len) _Nonnull) returnPointerNonnull:(int)len : (int * __counted_by(len) _Nonnull) __lifetimebound p;
 
+// expected-expansion@+32:2{{
+//   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p1: copy p1) @_disfavoredOverload public class final func mixedEscapability(_ p1: inout MutableSpan<CInt>, _ p2: UnsafeMutableBufferPointer<CInt>) {|}}
+//   expected-remark@3{{macro content: |    let len = CInt(exactly: p2.count)!|}}
+//   expected-remark@4{{macro content: |    if p1.count != len {|}}
+//   expected-remark@5{{macro content: |      fatalError("bounds check failure in mixedEscapability: expected \\(len) but got \\(p1.count)")|}}
+//   expected-remark@6{{macro content: |    }|}}
+//   expected-remark@7{{macro content: |    let _p1Ptr = p1.withUnsafeMutableBufferPointer {|}}
+//   expected-remark@8{{macro content: |        unsafe $0|}}
+//   expected-remark@9{{macro content: |    }|}}
+//   expected-remark@10{{macro content: |    defer {|}}
+//   expected-remark@11{{macro content: |        _fixLifetime(p1)|}}
+//   expected-remark@12{{macro content: |    }|}}
+//   expected-remark@13{{macro content: |    return unsafe mixedEscapability(len, _p1Ptr.baseAddress, p2.baseAddress)|}}
+//   expected-remark@14{{macro content: |}|}}
+// }}
 // expected-expansion@+16:105{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p1: copy p1) @_disfavoredOverload public final func mixedEscapability(_ p1: inout MutableSpan<CInt>, _ p2: UnsafeMutableBufferPointer<CInt>) {|}}
@@ -207,7 +346,7 @@ module Method {
 
 //--- method.swift
 // GENERATED-BY: %target-swift-ide-test -print-module -module-to-print=Method -plugin-path %swift-plugin-dir -I %t/Inputs -source-filename=x -enable-experimental-feature SafeInteropWrappers -enable-experimental-feature Lifetimes > %t/Test-interface.swift && %swift-function-caller-generator Method %t/Test-interface.swift
-// GENERATED-HASH: a9547da4a99cd4b214a9c5e94e38192044d2dc660e8ef44f7bcd5b62c81aaf9d
+// GENERATED-HASH: 24225459dbf0f05079ac2dc184d6b4afa8b43324602b2e4f0625c6cd5f88b0b2
 import Method
 
 
@@ -219,6 +358,11 @@ extension Foo {
     @_lifetime(p: copy p)
     @_alwaysEmitIntoClient @_disfavoredOverload final func call_simple_Foo(_ p: inout MutableSpan<CInt>) {
     return simple(&p)
+  }
+  @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+    @_lifetime(p: copy p)
+    @_alwaysEmitIntoClient @_disfavoredOverload final func call_simple_Foo_classmethod(_ p: inout MutableSpan<CInt>) {
+    return Foo.simple(&p)
   }
   final func call_simple_Foo(_ len: CInt, _ p: UnsafeMutablePointer<CInt>!) {
     return unsafe simple(len, p)
@@ -232,6 +376,12 @@ extension Foo {
     @_alwaysEmitIntoClient @_disfavoredOverload final func call_shared_Foo(_ p1: inout MutableSpan<CInt>, _ p2: inout MutableSpan<CInt>) {
     return shared(&p1, &p2)
   }
+  @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+    @_lifetime(p1: copy p1)
+    @_lifetime(p2: copy p2)
+    @_alwaysEmitIntoClient @_disfavoredOverload final func call_shared_Foo_classmethod(_ p1: inout MutableSpan<CInt>, _ p2: inout MutableSpan<CInt>) {
+    return Foo.shared(&p1, &p2)
+  }
   final func call_shared_Foo(_ len: CInt, _ p1: UnsafeMutablePointer<CInt>!, _ p2: UnsafeMutablePointer<CInt>!) {
     return unsafe shared(len, p1, p2)
   }
@@ -242,6 +392,11 @@ extension Foo {
     @_lifetime(p: copy p)
     @_alwaysEmitIntoClient @_disfavoredOverload final func call_complexExpr_Foo(_ len: CInt, _ offset: CInt, _ p: inout MutableSpan<CInt>) {
     return complexExpr(len, offset, &p)
+  }
+  @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+    @_lifetime(p: copy p)
+    @_alwaysEmitIntoClient @_disfavoredOverload final func call_complexExpr_Foo_classmethod(_ len: CInt, _ offset: CInt, _ p: inout MutableSpan<CInt>) {
+    return Foo.complexExpr(len, offset, &p)
   }
   final func call_complexExpr_Foo(_ len: CInt, _ offset: CInt, _ p: UnsafeMutablePointer<CInt>!) {
     return unsafe complexExpr(len, offset, p)
@@ -254,6 +409,11 @@ extension Foo {
     @_alwaysEmitIntoClient @_disfavoredOverload final func call_nullUnspecified_Foo(_ p: inout MutableSpan<CInt>) {
     return nullUnspecified(&p)
   }
+  @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+    @_lifetime(p: copy p)
+    @_alwaysEmitIntoClient @_disfavoredOverload final func call_nullUnspecified_Foo_classmethod(_ p: inout MutableSpan<CInt>) {
+    return Foo.nullUnspecified(&p)
+  }
   final func call_nullUnspecified_Foo(_ len: CInt, _ p: UnsafeMutablePointer<CInt>!) {
     return unsafe nullUnspecified(len, p)
   }
@@ -264,6 +424,11 @@ extension Foo {
     @_lifetime(p: copy p)
     @_alwaysEmitIntoClient @_disfavoredOverload final func call_nonnull_Foo(_ p: inout MutableSpan<CInt>) {
     return nonnull(&p)
+  }
+  @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+    @_lifetime(p: copy p)
+    @_alwaysEmitIntoClient @_disfavoredOverload final func call_nonnull_Foo_classmethod(_ p: inout MutableSpan<CInt>) {
+    return Foo.nonnull(&p)
   }
   final func call_nonnull_Foo(_ len: CInt, _ p: UnsafeMutablePointer<CInt>) {
     return unsafe nonnull(len, p)
@@ -277,6 +442,13 @@ extension Foo {
     // expected-stable-note@+2{{force-unwrap using '!' to abort execution if the optional value contains 'nil'}}
     // expected-stable-error@+1{{value of optional type 'MutableSpan<CInt>?' (aka 'Optional<MutableSpan<Int32>>') must be unwrapped to a value of type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>')}}
     return nullable(&p)
+  }
+  @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+    @_lifetime(p: copy p)
+    @_alwaysEmitIntoClient @_disfavoredOverload final func call_nullable_Foo_classmethod(_ p: inout MutableSpan<CInt>?) {
+    // expected-stable-note@+2{{force-unwrap using '!' to abort execution if the optional value contains 'nil'}}
+    // expected-stable-error@+1{{value of optional type 'MutableSpan<CInt>?' (aka 'Optional<MutableSpan<Int32>>') must be unwrapped to a value of type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>')}}
+    return Foo.nullable(&p)
   }
   final func call_nullable_Foo(_ len: CInt, _ p: UnsafeMutablePointer<CInt>?) {
     return unsafe nullable(len, p)
@@ -296,6 +468,14 @@ extension Foo {
     // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeMutablePointer<CInt>?' (aka 'Optional<UnsafeMutablePointer<Int32>>') to return type 'MutableSpan<CInt>?' (aka 'Optional<MutableSpan<Int32>>')}}
     return returnPointerNullable(&p)
   }
+  @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+    @_lifetime(copy p)
+    @_lifetime(p: copy p)
+    @_alwaysEmitIntoClient @_disfavoredOverload final func call_returnPointerNullable_Foo_classmethod(_ p: inout MutableSpan<CInt>?) -> MutableSpan<CInt>? {
+    // expected-stable-error@+2{{cannot convert value of type 'MutableSpan<CInt>?' (aka 'Optional<MutableSpan<Int32>>') to expected argument type 'Foo'}}
+    // expected-stable-error@+1{{cannot convert return expression of type '(CInt, UnsafeMutablePointer<CInt>?) -> UnsafeMutablePointer<CInt>?' (aka '(Int32, Optional<UnsafeMutablePointer<Int32>>) -> Optional<UnsafeMutablePointer<Int32>>') to return type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>')}}
+    return Foo.returnPointerNullable(&p)
+  }
   final func call_returnPointerNullable_Foo(_ len: CInt, _ p: UnsafeMutablePointer<CInt>?) -> UnsafeMutablePointer<CInt>? {
     return unsafe returnPointerNullable(len, p)
   }
@@ -313,6 +493,14 @@ extension Foo {
     // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeMutablePointer<CInt>' (aka 'UnsafeMutablePointer<Int32>') to return type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>')}}
     return returnPointerNonnull(&p)
   }
+  @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+    @_lifetime(copy p)
+    @_lifetime(p: copy p)
+    @_alwaysEmitIntoClient @_disfavoredOverload final func call_returnPointerNonnull_Foo_classmethod(_ p: inout MutableSpan<CInt>) -> MutableSpan<CInt> {
+    // expected-stable-error@+2{{cannot convert value of type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>') to expected argument type 'Foo'}}
+    // expected-stable-error@+1{{cannot convert return expression of type '(CInt, UnsafeMutablePointer<CInt>) -> UnsafeMutablePointer<CInt>' (aka '(Int32, UnsafeMutablePointer<Int32>) -> UnsafeMutablePointer<Int32>') to return type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>')}}
+    return Foo.returnPointerNonnull(&p)
+  }
   final func call_returnPointerNonnull_Foo(_ len: CInt, _ p: UnsafeMutablePointer<CInt>) -> UnsafeMutablePointer<CInt> {
     return unsafe returnPointerNonnull(len, p)
   }
@@ -323,6 +511,11 @@ extension Foo {
     @_lifetime(p1: copy p1)
     @_alwaysEmitIntoClient @_disfavoredOverload final func call_mixedEscapability_Foo(_ p1: inout MutableSpan<CInt>, _ p2: UnsafeMutableBufferPointer<CInt>) {
     return unsafe mixedEscapability(&p1, p2)
+  }
+  @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+    @_lifetime(p1: copy p1)
+    @_alwaysEmitIntoClient @_disfavoredOverload final func call_mixedEscapability_Foo_classmethod(_ p1: inout MutableSpan<CInt>, _ p2: UnsafeMutableBufferPointer<CInt>) {
+    return unsafe Foo.mixedEscapability(&p1, p2)
   }
   final func call_mixedEscapability_Foo(_ len: CInt, _ p1: UnsafeMutablePointer<CInt>!, _ p2: UnsafeMutablePointer<CInt>!) {
     return unsafe mixedEscapability(len, p1, p2)

--- a/test/Interop/ObjC/swiftify-import/counted-by-in-class-noescape.swift
+++ b/test/Interop/ObjC/swiftify-import/counted-by-in-class-noescape.swift
@@ -13,6 +13,7 @@
 // RUN:   -verify-ignore-macro-note -verify-child-notes
 
 // REQUIRES: swift_feature_SafeInteropWrappers
+// REQUIRES: swift_feature_SafeInteropWrappersNullAsEmptySpan
 // REQUIRES: swift_feature_Lifetimes
 
 //--- Inputs/module.modulemap

--- a/test/Interop/ObjC/swiftify-import/counted-by-in-class-noescape.swift
+++ b/test/Interop/ObjC/swiftify-import/counted-by-in-class-noescape.swift
@@ -9,7 +9,7 @@
 // RUN: %target-swift-frontend -plugin-path %swift-plugin-dir -I %t/Inputs %t/method.swift -Rmacro-expansions -emit-module \
 // RUN:   -verify -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}method.h -verify-additional-prefix experimental- -eager-macro-checking \
 // RUN:   -Xcc -Wno-nullability-completeness -strict-memory-safety \
-// RUN:   -enable-experimental-feature SafeInteropWrappers -enable-experimental-feature Lifetimes \
+// RUN:   -enable-experimental-feature SafeInteropWrappers -enable-experimental-feature SafeInteropWrappersNullAsEmptySpan -enable-experimental-feature Lifetimes \
 // RUN:   -verify-ignore-macro-note -verify-child-notes
 
 // REQUIRES: swift_feature_SafeInteropWrappers
@@ -192,75 +192,77 @@ module Method {
 
 // expected-expansion@+34:2{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
-//   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload public class final func nullable(_ p: inout MutableSpan<CInt>?) {|}}
+//   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload public class final func nullable(_ p: inout MutableSpan<CInt>) {|}}
 //   expected-stable-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload public class final func nullable(_ p: inout MutableSpan<CInt>) {|}}
-//   expected-experimental-remark@3{{macro content: |    let len = CInt(exactly: p?.count ?? 0)!|}}
+//   expected-experimental-remark@3{{macro content: |    let len = CInt(exactly: p.count)!|}}
 //   expected-stable-remark@3{{macro content: |    let len = CInt(exactly: p.count)!|}}
-//   expected-experimental-remark@4{{macro content: |    let _pPtr = p?.withUnsafeMutableBufferPointer {|}}
+//   expected-experimental-remark@4{{macro content: |    let _pPtr = p.withUnsafeMutableBufferPointer {|}}
 //   expected-stable-remark@4{{macro content: |    let _pPtr = p.withUnsafeMutableBufferPointer {|}}
 //   expected-remark@5{{macro content: |        unsafe $0|}}
 //   expected-remark@6{{macro content: |    }|}}
 //   expected-remark@7{{macro content: |    defer {|}}
 //   expected-remark@8{{macro content: |        _fixLifetime(p)|}}
 //   expected-remark@9{{macro content: |    }|}}
-//   expected-experimental-remark@10{{macro content: |    return unsafe nullable(len, _pPtr?.baseAddress)|}}
+//   expected-experimental-remark@10{{macro content: |    return unsafe nullable(len, _pPtr.baseAddress)|}}
 //   expected-stable-remark@10{{macro content: |    return unsafe nullable(len, _pPtr.baseAddress)|}}
 //   expected-remark@11{{macro content: |}|}}
 // }}
 // expected-expansion@+17:76{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
-//   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload public final func nullable(_ p: inout MutableSpan<CInt>?) {|}}
+//   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload public final func nullable(_ p: inout MutableSpan<CInt>) {|}}
 //   expected-stable-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload public final func nullable(_ p: inout MutableSpan<CInt>) {|}}
-//   expected-experimental-remark@3{{macro content: |    let len = CInt(exactly: p?.count ?? 0)!|}}
+//   expected-experimental-remark@3 {{macro content: |    let len = CInt(exactly: p.count)!|}}
 //   expected-stable-remark@3{{macro content: |    let len = CInt(exactly: p.count)!|}}
-//   expected-experimental-remark@4{{macro content: |    let _pPtr = p?.withUnsafeMutableBufferPointer {|}}
+//   expected-experimental-remark@4 {{macro content: |    let _pPtr = p.withUnsafeMutableBufferPointer {|}}
 //   expected-stable-remark@4{{macro content: |    let _pPtr = p.withUnsafeMutableBufferPointer {|}}
 //   expected-remark@5{{macro content: |        unsafe $0|}}
 //   expected-remark@6{{macro content: |    }|}}
 //   expected-remark@7{{macro content: |    defer {|}}
 //   expected-remark@8{{macro content: |        _fixLifetime(p)|}}
 //   expected-remark@9{{macro content: |    }|}}
-//   expected-experimental-remark@10{{macro content: |    return unsafe nullable(len, _pPtr?.baseAddress)|}}
+//   expected-experimental-remark@10 {{macro content: |    return unsafe nullable(len, _pPtr.baseAddress)|}}
 //   expected-stable-remark@10{{macro content: |    return unsafe nullable(len, _pPtr.baseAddress)|}}
 //   expected-remark@11{{macro content: |}|}}
 // }}
 - (void) nullable:(int)len :(int * __counted_by(len) _Nullable __noescape)p;
 
 
-// expected-experimental-expansion@+35:2{{
+// expected-experimental-expansion@+37:2{{
 //   expected-experimental-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
-//   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy p) @_lifetime(p: copy p) @_disfavoredOverload public class final func returnPointerNullable(_ p: inout MutableSpan<CInt>?) -> MutableSpan<CInt>? {|}}
-//   expected-experimental-remark@3{{macro content: |    let len = CInt(exactly: p?.count ?? 0)!|}}
-//   expected-experimental-remark@4{{macro content: |    let _pPtr = p?.withUnsafeMutableBufferPointer {|}}
+//   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy p) @_lifetime(p: copy p) @_disfavoredOverload public class final func returnPointerNullable(_ p: inout MutableSpan<CInt>) -> MutableSpan<CInt> {|}}
+//   expected-experimental-remark@3{{macro content: |    let len = CInt(exactly: p.count)!|}}
+//   expected-experimental-remark@4{{macro content: |    let _pPtr = p.withUnsafeMutableBufferPointer {|}}
 //   expected-experimental-remark@5{{macro content: |        unsafe $0|}}
 //   expected-experimental-remark@6{{macro content: |    }|}}
 //   expected-experimental-remark@7{{macro content: |    defer {|}}
 //   expected-experimental-remark@8{{macro content: |        _fixLifetime(p)|}}
 //   expected-experimental-remark@9{{macro content: |    }|}}
-//   expected-experimental-remark@10{{macro content: |    let _resultValue = unsafe returnPointerNullable(len, _pPtr?.baseAddress)|}}
+//   expected-experimental-remark@10{{macro content: |    let _resultValue = unsafe returnPointerNullable(len, _pPtr.baseAddress)|}}
 //   expected-experimental-remark@11{{macro content: |    if unsafe _resultValue == nil {|}}
-//   expected-experimental-remark@12{{macro content: |      return nil|}}
-//   expected-experimental-remark@13{{macro content: |    }|}}
-//   expected-experimental-remark@14{{macro content: |    return unsafe _swiftifyOverrideLifetime(MutableSpan<CInt>(_unsafeStart: _resultValue!, count: Int(len)), copying: ())|}}
-//   expected-experimental-remark@15{{macro content: |}|}}
+//   expected-experimental-remark@12{{macro content: |      precondition(len == 0, "counted_by may only be null if count is 0 (unlike counted_by_or_null)")|}}
+//   expected-experimental-remark@13{{macro content: |      return MutableSpan<CInt>()|}}
+//   expected-experimental-remark@14{{macro content: |    }|}}
+//   expected-experimental-remark@15{{macro content: |    return unsafe _swiftifyOverrideLifetime(MutableSpan<CInt>(_unsafeStart: _resultValue!, count: Int(len)), copying: ())|}}
+//   expected-experimental-remark@16{{macro content: |}|}}
 // }}
-// expected-stable-note@+18{{'returnPointerNullable' declared here}}
-// expected-experimental-expansion@+17:125{{
+// expected-stable-note@+19{{'returnPointerNullable' declared here}}
+// expected-experimental-expansion@+18:125{{
 //   expected-experimental-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
-//   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy p) @_lifetime(p: copy p) @_disfavoredOverload public final func returnPointerNullable(_ p: inout MutableSpan<CInt>?) -> MutableSpan<CInt>? {|}}
-//   expected-experimental-remark@3{{macro content: |    let len = CInt(exactly: p?.count ?? 0)!|}}
-//   expected-experimental-remark@4{{macro content: |    let _pPtr = p?.withUnsafeMutableBufferPointer {|}}
+//   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy p) @_lifetime(p: copy p) @_disfavoredOverload public final func returnPointerNullable(_ p: inout MutableSpan<CInt>) -> MutableSpan<CInt> {|}}
+//   expected-experimental-remark@3 {{macro content: |    let len = CInt(exactly: p.count)!|}}
+//   expected-experimental-remark@4 {{macro content: |    let _pPtr = p.withUnsafeMutableBufferPointer {|}}
 //   expected-experimental-remark@5{{macro content: |        unsafe $0|}}
 //   expected-experimental-remark@6{{macro content: |    }|}}
 //   expected-experimental-remark@7{{macro content: |    defer {|}}
 //   expected-experimental-remark@8{{macro content: |        _fixLifetime(p)|}}
 //   expected-experimental-remark@9{{macro content: |    }|}}
-//   expected-experimental-remark@10{{macro content: |    let _resultValue = unsafe returnPointerNullable(len, _pPtr?.baseAddress)|}}
+//   expected-experimental-remark@10 {{macro content: |    let _resultValue = unsafe returnPointerNullable(len, _pPtr.baseAddress)|}}
 //   expected-experimental-remark@11{{macro content: |    if unsafe _resultValue == nil {|}}
-//   expected-experimental-remark@12{{macro content: |      return nil|}}
-//   expected-experimental-remark@13{{macro content: |    }|}}
-//   expected-experimental-remark@14{{macro content: |    return unsafe _swiftifyOverrideLifetime(MutableSpan<CInt>(_unsafeStart: _resultValue!, count: Int(len)), copying: ())|}}
-//   expected-experimental-remark@15{{macro content: |}|}}
+//   expected-experimental-remark@12 {{macro content: |      precondition(len == 0, "counted_by may only be null if count is 0 (unlike counted_by_or_null)")|}}
+//   expected-experimental-remark@13 {{macro content: |      return MutableSpan<CInt>()|}}
+//   expected-experimental-remark@14 {{macro content: |    }|}}
+//   expected-experimental-remark@15 {{macro content: |    return unsafe _swiftifyOverrideLifetime(MutableSpan<CInt>(_unsafeStart: _resultValue!, count: Int(len)), copying: ())|}}
+//   expected-experimental-remark@16 {{macro content: |}|}}
 // }}
 - (int * __counted_by(len) _Nullable) returnPointerNullable:(int)len : (int * __counted_by(len) _Nullable) __lifetimebound p;
 
@@ -345,8 +347,8 @@ module Method {
 @end
 
 //--- method.swift
-// GENERATED-BY: %target-swift-ide-test -print-module -module-to-print=Method -plugin-path %swift-plugin-dir -I %t/Inputs -source-filename=x -enable-experimental-feature SafeInteropWrappers -enable-experimental-feature Lifetimes > %t/Test-interface.swift && %swift-function-caller-generator Method %t/Test-interface.swift
-// GENERATED-HASH: 24225459dbf0f05079ac2dc184d6b4afa8b43324602b2e4f0625c6cd5f88b0b2
+// GENERATED-BY: %target-swift-ide-test -print-module -module-to-print=Method -plugin-path %swift-plugin-dir -I %t/Inputs -source-filename=x -enable-experimental-feature SafeInteropWrappers -enable-experimental-feature SafeInteropWrappersNullAsEmptySpan -enable-experimental-feature Lifetimes > %t/Test-interface.swift && %swift-function-caller-generator Method %t/Test-interface.swift
+// GENERATED-HASH: aa625ed717982a6dd015712bc112d86de7b553d76c42e1b97112e0d4363daccb
 import Method
 
 
@@ -438,16 +440,12 @@ extension Foo {
   }
   @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
     @_lifetime(p: copy p)
-    @_alwaysEmitIntoClient @_disfavoredOverload final func call_nullable_Foo(_ p: inout MutableSpan<CInt>?) {
-    // expected-stable-note@+2{{force-unwrap using '!' to abort execution if the optional value contains 'nil'}}
-    // expected-stable-error@+1{{value of optional type 'MutableSpan<CInt>?' (aka 'Optional<MutableSpan<Int32>>') must be unwrapped to a value of type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>')}}
+    @_alwaysEmitIntoClient @_disfavoredOverload final func call_nullable_Foo(_ p: inout MutableSpan<CInt>) {
     return nullable(&p)
   }
   @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
     @_lifetime(p: copy p)
-    @_alwaysEmitIntoClient @_disfavoredOverload final func call_nullable_Foo_classmethod(_ p: inout MutableSpan<CInt>?) {
-    // expected-stable-note@+2{{force-unwrap using '!' to abort execution if the optional value contains 'nil'}}
-    // expected-stable-error@+1{{value of optional type 'MutableSpan<CInt>?' (aka 'Optional<MutableSpan<Int32>>') must be unwrapped to a value of type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>')}}
+    @_alwaysEmitIntoClient @_disfavoredOverload final func call_nullable_Foo_classmethod(_ p: inout MutableSpan<CInt>) {
     return Foo.nullable(&p)
   }
   final func call_nullable_Foo(_ len: CInt, _ p: UnsafeMutablePointer<CInt>?) {
@@ -459,20 +457,19 @@ extension Foo {
   @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
     @_lifetime(copy p)
     @_lifetime(p: copy p)
-    @_alwaysEmitIntoClient @_disfavoredOverload final func call_returnPointerNullable_Foo(_ p: inout MutableSpan<CInt>?) -> MutableSpan<CInt>? {
-    // expected-stable-error@+6{{missing argument for parameter #2 in call}}
-    // expected-stable-note@+5{{arguments to generic parameter 'Pointee' ('MutableSpan<CInt>?' (aka 'Optional<MutableSpan<Int32>>') and 'CInt' (aka 'Int32')) are expected to be equal}}
-    // expected-stable-error@+4{{cannot convert value of type 'UnsafeMutablePointer<MutableSpan<CInt>?>' (aka 'UnsafeMutablePointer<Optional<MutableSpan<Int32>>>') to expected argument type 'UnsafeMutablePointer<CInt>' (aka 'UnsafeMutablePointer<Int32>')}}
-    // expected-stable-error@+3{{cannot convert value of type 'MutableSpan<CInt>?' (aka 'Optional<MutableSpan<Int32>>') to expected argument type 'CInt' (aka 'Int32')}}
-    // expected-stable-note@+2{{arguments to generic parameter 'Wrapped' ('UnsafeMutablePointer<CInt>' (aka 'UnsafeMutablePointer<Int32>') and 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>')) are expected to be equal}}
-    // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeMutablePointer<CInt>?' (aka 'Optional<UnsafeMutablePointer<Int32>>') to return type 'MutableSpan<CInt>?' (aka 'Optional<MutableSpan<Int32>>')}}
+    @_alwaysEmitIntoClient @_disfavoredOverload final func call_returnPointerNullable_Foo(_ p: inout MutableSpan<CInt>) -> MutableSpan<CInt> {
+    // expected-stable-error@+5{{missing argument for parameter #2 in call}}
+    // expected-stable-note@+4{{arguments to generic parameter 'Pointee' ('MutableSpan<CInt>' (aka 'MutableSpan<Int32>') and 'CInt' (aka 'Int32')) are expected to be equal}}
+    // expected-stable-error@+3{{cannot convert value of type 'UnsafeMutablePointer<MutableSpan<CInt>>' (aka 'UnsafeMutablePointer<MutableSpan<Int32>>') to expected argument type 'UnsafeMutablePointer<CInt>' (aka 'UnsafeMutablePointer<Int32>')}}
+    // expected-stable-error@+2{{cannot convert value of type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>') to expected argument type 'CInt' (aka 'Int32')}}
+    // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeMutablePointer<CInt>?' (aka 'Optional<UnsafeMutablePointer<Int32>>') to return type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>')}}
     return returnPointerNullable(&p)
   }
   @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
     @_lifetime(copy p)
     @_lifetime(p: copy p)
-    @_alwaysEmitIntoClient @_disfavoredOverload final func call_returnPointerNullable_Foo_classmethod(_ p: inout MutableSpan<CInt>?) -> MutableSpan<CInt>? {
-    // expected-stable-error@+2{{cannot convert value of type 'MutableSpan<CInt>?' (aka 'Optional<MutableSpan<Int32>>') to expected argument type 'Foo'}}
+    @_alwaysEmitIntoClient @_disfavoredOverload final func call_returnPointerNullable_Foo_classmethod(_ p: inout MutableSpan<CInt>) -> MutableSpan<CInt> {
+    // expected-stable-error@+2{{cannot convert value of type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>') to expected argument type 'Foo'}}
     // expected-stable-error@+1{{cannot convert return expression of type '(CInt, UnsafeMutablePointer<CInt>?) -> UnsafeMutablePointer<CInt>?' (aka '(Int32, Optional<UnsafeMutablePointer<Int32>>) -> Optional<UnsafeMutablePointer<Int32>>') to return type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>')}}
     return Foo.returnPointerNullable(&p)
   }

--- a/test/Interop/ObjC/swiftify-import/counted-by-in-class-noescape.swift
+++ b/test/Interop/ObjC/swiftify-import/counted-by-in-class-noescape.swift
@@ -1,0 +1,338 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t --leading-lines
+
+// RUN: %target-swift-frontend -plugin-path %swift-plugin-dir -I %t/Inputs %t/method.swift -Rmacro-expansions -emit-module \
+// RUN:   -verify -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}method.h -verify-additional-prefix stable- -eager-macro-checking \
+// RUN:   -Xcc -Wno-nullability-completeness -strict-memory-safety -enable-experimental-feature Lifetimes \
+// RUN:   -verify-ignore-macro-note -verify-child-notes
+
+// RUN: %target-swift-frontend -plugin-path %swift-plugin-dir -I %t/Inputs %t/method.swift -Rmacro-expansions -emit-module \
+// RUN:   -verify -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}method.h -verify-additional-prefix experimental- -eager-macro-checking \
+// RUN:   -Xcc -Wno-nullability-completeness -strict-memory-safety \
+// RUN:   -enable-experimental-feature SafeInteropWrappers -enable-experimental-feature Lifetimes \
+// RUN:   -verify-ignore-macro-note -verify-child-notes
+
+// REQUIRES: swift_feature_SafeInteropWrappers
+// REQUIRES: swift_feature_Lifetimes
+
+//--- Inputs/module.modulemap
+module Method {
+    header "method.h"
+}
+
+//--- Inputs/method.h
+#pragma once
+
+#define __counted_by(x) __attribute__((__counted_by__(x)))
+#define __noescape __attribute__((noescape))
+#define __lifetimebound __attribute__((lifetimebound))
+
+@interface Foo
+// expected-expansion@+13:64{{
+//   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload public final func simple(_ p: inout MutableSpan<CInt>) {|}}
+//   expected-remark@3{{macro content: |    let len = CInt(exactly: p.count)!|}}
+//   expected-remark@4{{macro content: |    let _pPtr = p.withUnsafeMutableBufferPointer {|}}
+//   expected-remark@5{{macro content: |        unsafe $0|}}
+//   expected-remark@6{{macro content: |    }|}}
+//   expected-remark@7{{macro content: |    defer {|}}
+//   expected-remark@8{{macro content: |        _fixLifetime(p)|}}
+//   expected-remark@9{{macro content: |    }|}}
+//   expected-remark@10{{macro content: |    return unsafe simple(len, _pPtr.baseAddress)|}}
+//   expected-remark@11{{macro content: |}|}}
+// }}
+- (void) simple:(int)len :(int * __counted_by(len) __noescape)p;
+
+// expected-expansion@+22:105{{
+//   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p1: copy p1) @_lifetime(p2: copy p2) @_disfavoredOverload public final func shared(_ p1: inout MutableSpan<CInt>, _ p2: inout MutableSpan<CInt>) {|}}
+//   expected-remark@3{{macro content: |    let len = CInt(exactly: p2.count)!|}}
+//   expected-remark@4{{macro content: |    if p1.count != len {|}}
+//   expected-remark@5{{macro content: |      fatalError("bounds check failure in shared: expected \\(len) but got \\(p1.count)")|}}
+//   expected-remark@6{{macro content: |    }|}}
+//   expected-remark@7{{macro content: |    let _p1Ptr = p1.withUnsafeMutableBufferPointer {|}}
+//   expected-remark@8{{macro content: |        unsafe $0|}}
+//   expected-remark@9{{macro content: |    }|}}
+//   expected-remark@10{{macro content: |    defer {|}}
+//   expected-remark@11{{macro content: |        _fixLifetime(p1)|}}
+//   expected-remark@12{{macro content: |    }|}}
+//   expected-remark@13{{macro content: |    let _p2Ptr = p2.withUnsafeMutableBufferPointer {|}}
+//   expected-remark@14{{macro content: |        unsafe $0|}}
+//   expected-remark@15{{macro content: |    }|}}
+//   expected-remark@16{{macro content: |    defer {|}}
+//   expected-remark@17{{macro content: |        _fixLifetime(p2)|}}
+//   expected-remark@18{{macro content: |    }|}}
+//   expected-remark@19{{macro content: |    return unsafe shared(len, _p1Ptr.baseAddress, _p2Ptr.baseAddress)|}}
+//   expected-remark@20{{macro content: |}|}}
+// }}
+- (void) shared:(int)len :(int * __counted_by(len) __noescape)p1 :(int * __counted_by(len) __noescape)p2;
+
+// expected-expansion@+15:92{{
+//   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload public final func complexExpr(_ len: CInt, _ offset: CInt, _ p: inout MutableSpan<CInt>) {|}}
+//   expected-remark@3{{macro content: |    if p.count != (len - offset) {|}}
+//   expected-remark@4{{macro content: |      fatalError("bounds check failure in complexExpr: expected \\((len - offset)) but got \\(p.count)")|}}
+//   expected-remark@5{{macro content: |    }|}}
+//   expected-remark@6{{macro content: |    let _pPtr = p.withUnsafeMutableBufferPointer {|}}
+//   expected-remark@7{{macro content: |        unsafe $0|}}
+//   expected-remark@8{{macro content: |    }|}}
+//   expected-remark@9{{macro content: |    defer {|}}
+//   expected-remark@10{{macro content: |        _fixLifetime(p)|}}
+//   expected-remark@11{{macro content: |    }|}}
+//   expected-remark@12{{macro content: |    return unsafe complexExpr(len, offset, _pPtr.baseAddress)|}}
+//   expected-remark@13{{macro content: |}|}}
+// }}
+- (void) complexExpr:(int)len :(int) offset :(int * __counted_by(len - offset) __noescape)p;
+
+// expected-expansion@+13:91{{
+//   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload public final func nullUnspecified(_ p: inout MutableSpan<CInt>) {|}}
+//   expected-remark@3{{macro content: |    let len = CInt(exactly: p.count)!|}}
+//   expected-remark@4{{macro content: |    let _pPtr = p.withUnsafeMutableBufferPointer {|}}
+//   expected-remark@5{{macro content: |        unsafe $0|}}
+//   expected-remark@6{{macro content: |    }|}}
+//   expected-remark@7{{macro content: |    defer {|}}
+//   expected-remark@8{{macro content: |        _fixLifetime(p)|}}
+//   expected-remark@9{{macro content: |    }|}}
+//   expected-remark@10{{macro content: |    return unsafe nullUnspecified(len, _pPtr.baseAddress)|}}
+//   expected-remark@11{{macro content: |}|}}
+// }}
+- (void) nullUnspecified:(int)len :(int * __counted_by(len) _Null_unspecified __noescape)p;
+
+// expected-expansion@+13:74{{
+//   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload public final func nonnull(_ p: inout MutableSpan<CInt>) {|}}
+//   expected-remark@3{{macro content: |    let len = CInt(exactly: p.count)!|}}
+//   expected-remark@4{{macro content: |    let _pPtr = p.withUnsafeMutableBufferPointer {|}}
+//   expected-remark@5{{macro content: |        unsafe $0|}}
+//   expected-remark@6{{macro content: |    }|}}
+//   expected-remark@7{{macro content: |    defer {|}}
+//   expected-remark@8{{macro content: |        _fixLifetime(p)|}}
+//   expected-remark@9{{macro content: |    }|}}
+//   expected-remark@10{{macro content: |    return unsafe nonnull(len, _pPtr.baseAddress!)|}}
+//   expected-remark@11{{macro content: |}|}}
+// }}
+- (void) nonnull:(int)len :(int * __counted_by(len) __noescape _Nonnull)p;
+
+// expected-expansion@+17:76{{
+//   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload public final func nullable(_ p: inout MutableSpan<CInt>?) {|}}
+//   expected-stable-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload public final func nullable(_ p: inout MutableSpan<CInt>) {|}}
+//   expected-experimental-remark@3{{macro content: |    let len = CInt(exactly: p?.count ?? 0)!|}}
+//   expected-stable-remark@3{{macro content: |    let len = CInt(exactly: p.count)!|}}
+//   expected-experimental-remark@4{{macro content: |    let _pPtr = p?.withUnsafeMutableBufferPointer {|}}
+//   expected-stable-remark@4{{macro content: |    let _pPtr = p.withUnsafeMutableBufferPointer {|}}
+//   expected-remark@5{{macro content: |        unsafe $0|}}
+//   expected-remark@6{{macro content: |    }|}}
+//   expected-remark@7{{macro content: |    defer {|}}
+//   expected-remark@8{{macro content: |        _fixLifetime(p)|}}
+//   expected-remark@9{{macro content: |    }|}}
+//   expected-experimental-remark@10{{macro content: |    return unsafe nullable(len, _pPtr?.baseAddress)|}}
+//   expected-stable-remark@10{{macro content: |    return unsafe nullable(len, _pPtr.baseAddress)|}}
+//   expected-remark@11{{macro content: |}|}}
+// }}
+- (void) nullable:(int)len :(int * __counted_by(len) _Nullable __noescape)p;
+
+
+// expected-stable-note@+18{{'returnPointerNullable' declared here}}
+// expected-experimental-expansion@+17:125{{
+//   expected-experimental-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy p) @_lifetime(p: copy p) @_disfavoredOverload public final func returnPointerNullable(_ p: inout MutableSpan<CInt>?) -> MutableSpan<CInt>? {|}}
+//   expected-experimental-remark@3{{macro content: |    let len = CInt(exactly: p?.count ?? 0)!|}}
+//   expected-experimental-remark@4{{macro content: |    let _pPtr = p?.withUnsafeMutableBufferPointer {|}}
+//   expected-experimental-remark@5{{macro content: |        unsafe $0|}}
+//   expected-experimental-remark@6{{macro content: |    }|}}
+//   expected-experimental-remark@7{{macro content: |    defer {|}}
+//   expected-experimental-remark@8{{macro content: |        _fixLifetime(p)|}}
+//   expected-experimental-remark@9{{macro content: |    }|}}
+//   expected-experimental-remark@10{{macro content: |    let _resultValue = unsafe returnPointerNullable(len, _pPtr?.baseAddress)|}}
+//   expected-experimental-remark@11{{macro content: |    if unsafe _resultValue == nil {|}}
+//   expected-experimental-remark@12{{macro content: |      return nil|}}
+//   expected-experimental-remark@13{{macro content: |    }|}}
+//   expected-experimental-remark@14{{macro content: |    return unsafe _swiftifyOverrideLifetime(MutableSpan<CInt>(_unsafeStart: _resultValue!, count: Int(len)), copying: ())|}}
+//   expected-experimental-remark@15{{macro content: |}|}}
+// }}
+- (int * __counted_by(len) _Nullable) returnPointerNullable:(int)len : (int * __counted_by(len) _Nullable) __lifetimebound p;
+
+
+// expected-stable-note@+14{{'returnPointerNonnull' declared here}}
+// expected-experimental-expansion@+13:122{{
+//   expected-experimental-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy p) @_lifetime(p: copy p) @_disfavoredOverload public final func returnPointerNonnull(_ p: inout MutableSpan<CInt>) -> MutableSpan<CInt> {|}}
+//   expected-experimental-remark@3{{macro content: |    let len = CInt(exactly: p.count)!|}}
+//   expected-experimental-remark@4{{macro content: |    let _pPtr = p.withUnsafeMutableBufferPointer {|}}
+//   expected-experimental-remark@5{{macro content: |        unsafe $0|}}
+//   expected-experimental-remark@6{{macro content: |    }|}}
+//   expected-experimental-remark@7{{macro content: |    defer {|}}
+//   expected-experimental-remark@8{{macro content: |        _fixLifetime(p)|}}
+//   expected-experimental-remark@9{{macro content: |    }|}}
+//   expected-experimental-remark@10{{macro content: |    return unsafe _swiftifyOverrideLifetime(MutableSpan<CInt>(_unsafeStart: unsafe returnPointerNonnull(len, _pPtr.baseAddress!), count: Int(len)), copying: ())|}}
+//   expected-experimental-remark@11{{macro content: |}|}}
+// }}
+- (int * __counted_by(len) _Nonnull) returnPointerNonnull:(int)len : (int * __counted_by(len) _Nonnull) __lifetimebound p;
+
+// expected-expansion@+16:105{{
+//   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p1: copy p1) @_disfavoredOverload public final func mixedEscapability(_ p1: inout MutableSpan<CInt>, _ p2: UnsafeMutableBufferPointer<CInt>) {|}}
+//   expected-remark@3{{macro content: |    let len = CInt(exactly: p2.count)!|}}
+//   expected-remark@4{{macro content: |    if p1.count != len {|}}
+//   expected-remark@5{{macro content: |      fatalError("bounds check failure in mixedEscapability: expected \\(len) but got \\(p1.count)")|}}
+//   expected-remark@6{{macro content: |    }|}}
+//   expected-remark@7{{macro content: |    let _p1Ptr = p1.withUnsafeMutableBufferPointer {|}}
+//   expected-remark@8{{macro content: |        unsafe $0|}}
+//   expected-remark@9{{macro content: |    }|}}
+//   expected-remark@10{{macro content: |    defer {|}}
+//   expected-remark@11{{macro content: |        _fixLifetime(p1)|}}
+//   expected-remark@12{{macro content: |    }|}}
+//   expected-remark@13{{macro content: |    return unsafe mixedEscapability(len, _p1Ptr.baseAddress, p2.baseAddress)|}}
+//   expected-remark@14{{macro content: |}|}}
+// }}
+- (void) mixedEscapability:(int)len :(int * __counted_by(len) __noescape)p1 :(int * __counted_by(len))p2;
+
+// expected-expansion@+13:70{{
+//   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload public class final func staticMethod(_ p: inout MutableSpan<CInt>) {|}}
+//   expected-remark@3{{macro content: |    let len = CInt(exactly: p.count)!|}}
+//   expected-remark@4{{macro content: |    let _pPtr = p.withUnsafeMutableBufferPointer {|}}
+//   expected-remark@5{{macro content: |        unsafe $0|}}
+//   expected-remark@6{{macro content: |    }|}}
+//   expected-remark@7{{macro content: |    defer {|}}
+//   expected-remark@8{{macro content: |        _fixLifetime(p)|}}
+//   expected-remark@9{{macro content: |    }|}}
+//   expected-remark@10{{macro content: |    return unsafe staticMethod(len, _pPtr.baseAddress)|}}
+//   expected-remark@11{{macro content: |}|}}
+// }}
++ (void) staticMethod:(int)len :(int * __counted_by(len) __noescape)p;
+@end
+
+//--- method.swift
+// GENERATED-BY: %target-swift-ide-test -print-module -module-to-print=Method -plugin-path %swift-plugin-dir -I %t/Inputs -source-filename=x -enable-experimental-feature SafeInteropWrappers -enable-experimental-feature Lifetimes > %t/Test-interface.swift && %swift-function-caller-generator Method %t/Test-interface.swift
+// GENERATED-HASH: a9547da4a99cd4b214a9c5e94e38192044d2dc660e8ef44f7bcd5b62c81aaf9d
+import Method
+
+
+extension Foo {
+  final func call_simple_Foo_classmethod(_ len: CInt, _ p: UnsafeMutablePointer<CInt>!) {
+    return unsafe Foo.simple(len, p)
+  }
+  @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+    @_lifetime(p: copy p)
+    @_alwaysEmitIntoClient @_disfavoredOverload final func call_simple_Foo(_ p: inout MutableSpan<CInt>) {
+    return simple(&p)
+  }
+  final func call_simple_Foo(_ len: CInt, _ p: UnsafeMutablePointer<CInt>!) {
+    return unsafe simple(len, p)
+  }
+  final func call_shared_Foo_classmethod(_ len: CInt, _ p1: UnsafeMutablePointer<CInt>!, _ p2: UnsafeMutablePointer<CInt>!) {
+    return unsafe Foo.shared(len, p1, p2)
+  }
+  @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+    @_lifetime(p1: copy p1)
+    @_lifetime(p2: copy p2)
+    @_alwaysEmitIntoClient @_disfavoredOverload final func call_shared_Foo(_ p1: inout MutableSpan<CInt>, _ p2: inout MutableSpan<CInt>) {
+    return shared(&p1, &p2)
+  }
+  final func call_shared_Foo(_ len: CInt, _ p1: UnsafeMutablePointer<CInt>!, _ p2: UnsafeMutablePointer<CInt>!) {
+    return unsafe shared(len, p1, p2)
+  }
+  final func call_complexExpr_Foo_classmethod(_ len: CInt, _ offset: CInt, _ p: UnsafeMutablePointer<CInt>!) {
+    return unsafe Foo.complexExpr(len, offset, p)
+  }
+  @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+    @_lifetime(p: copy p)
+    @_alwaysEmitIntoClient @_disfavoredOverload final func call_complexExpr_Foo(_ len: CInt, _ offset: CInt, _ p: inout MutableSpan<CInt>) {
+    return complexExpr(len, offset, &p)
+  }
+  final func call_complexExpr_Foo(_ len: CInt, _ offset: CInt, _ p: UnsafeMutablePointer<CInt>!) {
+    return unsafe complexExpr(len, offset, p)
+  }
+  final func call_nullUnspecified_Foo_classmethod(_ len: CInt, _ p: UnsafeMutablePointer<CInt>!) {
+    return unsafe Foo.nullUnspecified(len, p)
+  }
+  @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+    @_lifetime(p: copy p)
+    @_alwaysEmitIntoClient @_disfavoredOverload final func call_nullUnspecified_Foo(_ p: inout MutableSpan<CInt>) {
+    return nullUnspecified(&p)
+  }
+  final func call_nullUnspecified_Foo(_ len: CInt, _ p: UnsafeMutablePointer<CInt>!) {
+    return unsafe nullUnspecified(len, p)
+  }
+  final func call_nonnull_Foo_classmethod(_ len: CInt, _ p: UnsafeMutablePointer<CInt>) {
+    return unsafe Foo.nonnull(len, p)
+  }
+  @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+    @_lifetime(p: copy p)
+    @_alwaysEmitIntoClient @_disfavoredOverload final func call_nonnull_Foo(_ p: inout MutableSpan<CInt>) {
+    return nonnull(&p)
+  }
+  final func call_nonnull_Foo(_ len: CInt, _ p: UnsafeMutablePointer<CInt>) {
+    return unsafe nonnull(len, p)
+  }
+  final func call_nullable_Foo_classmethod(_ len: CInt, _ p: UnsafeMutablePointer<CInt>?) {
+    return unsafe Foo.nullable(len, p)
+  }
+  @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+    @_lifetime(p: copy p)
+    @_alwaysEmitIntoClient @_disfavoredOverload final func call_nullable_Foo(_ p: inout MutableSpan<CInt>?) {
+    // expected-stable-note@+2{{force-unwrap using '!' to abort execution if the optional value contains 'nil'}}
+    // expected-stable-error@+1{{value of optional type 'MutableSpan<CInt>?' (aka 'Optional<MutableSpan<Int32>>') must be unwrapped to a value of type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>')}}
+    return nullable(&p)
+  }
+  final func call_nullable_Foo(_ len: CInt, _ p: UnsafeMutablePointer<CInt>?) {
+    return unsafe nullable(len, p)
+  }
+  final func call_returnPointerNullable_Foo_classmethod(_ len: CInt, _ p: UnsafeMutablePointer<CInt>?) -> UnsafeMutablePointer<CInt>? {
+    return unsafe Foo.returnPointerNullable(len, p)
+  }
+  @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+    @_lifetime(copy p)
+    @_lifetime(p: copy p)
+    @_alwaysEmitIntoClient @_disfavoredOverload final func call_returnPointerNullable_Foo(_ p: inout MutableSpan<CInt>?) -> MutableSpan<CInt>? {
+    // expected-stable-error@+6{{missing argument for parameter #2 in call}}
+    // expected-stable-note@+5{{arguments to generic parameter 'Pointee' ('MutableSpan<CInt>?' (aka 'Optional<MutableSpan<Int32>>') and 'CInt' (aka 'Int32')) are expected to be equal}}
+    // expected-stable-error@+4{{cannot convert value of type 'UnsafeMutablePointer<MutableSpan<CInt>?>' (aka 'UnsafeMutablePointer<Optional<MutableSpan<Int32>>>') to expected argument type 'UnsafeMutablePointer<CInt>' (aka 'UnsafeMutablePointer<Int32>')}}
+    // expected-stable-error@+3{{cannot convert value of type 'MutableSpan<CInt>?' (aka 'Optional<MutableSpan<Int32>>') to expected argument type 'CInt' (aka 'Int32')}}
+    // expected-stable-note@+2{{arguments to generic parameter 'Wrapped' ('UnsafeMutablePointer<CInt>' (aka 'UnsafeMutablePointer<Int32>') and 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>')) are expected to be equal}}
+    // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeMutablePointer<CInt>?' (aka 'Optional<UnsafeMutablePointer<Int32>>') to return type 'MutableSpan<CInt>?' (aka 'Optional<MutableSpan<Int32>>')}}
+    return returnPointerNullable(&p)
+  }
+  final func call_returnPointerNullable_Foo(_ len: CInt, _ p: UnsafeMutablePointer<CInt>?) -> UnsafeMutablePointer<CInt>? {
+    return unsafe returnPointerNullable(len, p)
+  }
+  final func call_returnPointerNonnull_Foo_classmethod(_ len: CInt, _ p: UnsafeMutablePointer<CInt>) -> UnsafeMutablePointer<CInt> {
+    return unsafe Foo.returnPointerNonnull(len, p)
+  }
+  @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+    @_lifetime(copy p)
+    @_lifetime(p: copy p)
+    @_alwaysEmitIntoClient @_disfavoredOverload final func call_returnPointerNonnull_Foo(_ p: inout MutableSpan<CInt>) -> MutableSpan<CInt> {
+    // expected-stable-error@+5{{missing argument for parameter #2 in call}}
+    // expected-stable-note@+4{{arguments to generic parameter 'Pointee' ('MutableSpan<CInt>' (aka 'MutableSpan<Int32>') and 'CInt' (aka 'Int32')) are expected to be equal}}
+    // expected-stable-error@+3{{cannot convert value of type 'UnsafeMutablePointer<MutableSpan<CInt>>' (aka 'UnsafeMutablePointer<MutableSpan<Int32>>') to expected argument type 'UnsafeMutablePointer<CInt>' (aka 'UnsafeMutablePointer<Int32>')}}
+    // expected-stable-error@+2{{cannot convert value of type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>') to expected argument type 'CInt' (aka 'Int32')}}
+    // expected-stable-error@+1{{cannot convert return expression of type 'UnsafeMutablePointer<CInt>' (aka 'UnsafeMutablePointer<Int32>') to return type 'MutableSpan<CInt>' (aka 'MutableSpan<Int32>')}}
+    return returnPointerNonnull(&p)
+  }
+  final func call_returnPointerNonnull_Foo(_ len: CInt, _ p: UnsafeMutablePointer<CInt>) -> UnsafeMutablePointer<CInt> {
+    return unsafe returnPointerNonnull(len, p)
+  }
+  final func call_mixedEscapability_Foo_classmethod(_ len: CInt, _ p1: UnsafeMutablePointer<CInt>!, _ p2: UnsafeMutablePointer<CInt>!) {
+    return unsafe Foo.mixedEscapability(len, p1, p2)
+  }
+  @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+    @_lifetime(p1: copy p1)
+    @_alwaysEmitIntoClient @_disfavoredOverload final func call_mixedEscapability_Foo(_ p1: inout MutableSpan<CInt>, _ p2: UnsafeMutableBufferPointer<CInt>) {
+    return unsafe mixedEscapability(&p1, p2)
+  }
+  final func call_mixedEscapability_Foo(_ len: CInt, _ p1: UnsafeMutablePointer<CInt>!, _ p2: UnsafeMutablePointer<CInt>!) {
+    return unsafe mixedEscapability(len, p1, p2)
+  }
+  @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+    @_lifetime(p: copy p)
+    @_alwaysEmitIntoClient @_disfavoredOverload final func call_staticMethod_Foo_classmethod(_ p: inout MutableSpan<CInt>) {
+    return Foo.staticMethod(&p)
+  }
+  final func call_staticMethod_Foo_classmethod(_ len: CInt, _ p: UnsafeMutablePointer<CInt>!) {
+    return unsafe Foo.staticMethod(len, p)
+  }
+}

--- a/test/Interop/ObjC/swiftify-import/counted-by-in-class-noescape.swift
+++ b/test/Interop/ObjC/swiftify-import/counted-by-in-class-noescape.swift
@@ -190,38 +190,30 @@ module Method {
 // }}
 - (void) nonnull:(int)len :(int * __counted_by(len) __noescape _Nonnull)p;
 
-// expected-expansion@+34:2{{
+// expected-expansion@+26:2{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
-//   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload public class final func nullable(_ p: inout MutableSpan<CInt>) {|}}
-//   expected-stable-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload public class final func nullable(_ p: inout MutableSpan<CInt>) {|}}
-//   expected-experimental-remark@3{{macro content: |    let len = CInt(exactly: p.count)!|}}
-//   expected-stable-remark@3{{macro content: |    let len = CInt(exactly: p.count)!|}}
-//   expected-experimental-remark@4{{macro content: |    let _pPtr = p.withUnsafeMutableBufferPointer {|}}
-//   expected-stable-remark@4{{macro content: |    let _pPtr = p.withUnsafeMutableBufferPointer {|}}
+//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload public class final func nullable(_ p: inout MutableSpan<CInt>) {|}}
+//   expected-remark@3{{macro content: |    let len = CInt(exactly: p.count)!|}}
+//   expected-remark@4{{macro content: |    let _pPtr = p.withUnsafeMutableBufferPointer {|}}
 //   expected-remark@5{{macro content: |        unsafe $0|}}
 //   expected-remark@6{{macro content: |    }|}}
 //   expected-remark@7{{macro content: |    defer {|}}
 //   expected-remark@8{{macro content: |        _fixLifetime(p)|}}
 //   expected-remark@9{{macro content: |    }|}}
-//   expected-experimental-remark@10{{macro content: |    return unsafe nullable(len, _pPtr.baseAddress)|}}
-//   expected-stable-remark@10{{macro content: |    return unsafe nullable(len, _pPtr.baseAddress)|}}
+//   expected-remark@10{{macro content: |    return unsafe nullable(len, _pPtr.baseAddress)|}}
 //   expected-remark@11{{macro content: |}|}}
 // }}
-// expected-expansion@+17:76{{
+// expected-expansion@+13:76{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
-//   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload public final func nullable(_ p: inout MutableSpan<CInt>) {|}}
-//   expected-stable-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload public final func nullable(_ p: inout MutableSpan<CInt>) {|}}
-//   expected-experimental-remark@3 {{macro content: |    let len = CInt(exactly: p.count)!|}}
-//   expected-stable-remark@3{{macro content: |    let len = CInt(exactly: p.count)!|}}
-//   expected-experimental-remark@4 {{macro content: |    let _pPtr = p.withUnsafeMutableBufferPointer {|}}
-//   expected-stable-remark@4{{macro content: |    let _pPtr = p.withUnsafeMutableBufferPointer {|}}
+//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload public final func nullable(_ p: inout MutableSpan<CInt>) {|}}
+//   expected-remark@3 {{macro content: |    let len = CInt(exactly: p.count)!|}}
+//   expected-remark@4 {{macro content: |    let _pPtr = p.withUnsafeMutableBufferPointer {|}}
 //   expected-remark@5{{macro content: |        unsafe $0|}}
 //   expected-remark@6{{macro content: |    }|}}
 //   expected-remark@7{{macro content: |    defer {|}}
 //   expected-remark@8{{macro content: |        _fixLifetime(p)|}}
 //   expected-remark@9{{macro content: |    }|}}
-//   expected-experimental-remark@10 {{macro content: |    return unsafe nullable(len, _pPtr.baseAddress)|}}
-//   expected-stable-remark@10{{macro content: |    return unsafe nullable(len, _pPtr.baseAddress)|}}
+//   expected-remark@10 {{macro content: |    return unsafe nullable(len, _pPtr.baseAddress)|}}
 //   expected-remark@11{{macro content: |}|}}
 // }}
 - (void) nullable:(int)len :(int * __counted_by(len) _Nullable __noescape)p;

--- a/test/Interop/ObjC/swiftify-import/counted-by-in-class.swift
+++ b/test/Interop/ObjC/swiftify-import/counted-by-in-class.swift
@@ -1,11 +1,9 @@
-
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 // RUN: split-file %s %t
-// RUN: %target-swift-ide-test -plugin-path %swift-plugin-dir -I %t/Inputs -print-module -module-to-print=Method -source-filename=x | %FileCheck %s
-// RUN: %target-swift-frontend -plugin-path %swift-plugin-dir -I %t/Inputs %t/method.swift -dump-macro-expansions -typecheck -verify
 
-// CHECK: class Foo {
-// CHECK:  func bar(_ p: UnsafeMutableBufferPointer<CFloat>)
+// RUN: %target-swift-frontend -plugin-path %swift-plugin-dir -I %t/Inputs %t/method.swift -Rmacro-expansions -emit-module \
+// RUN:   -verify -verify-additional-file %t%{fs-sep}Inputs%{fs-sep}method.h -eager-macro-checking \
+// RUN:   -Xcc -Wno-nullability-completeness -strict-memory-safety -verify-ignore-macro-note
 
 //--- Inputs/module.modulemap
 module Method {
@@ -13,14 +11,180 @@ module Method {
 }
 
 //--- Inputs/method.h
+#pragma once
+
+#define __counted_by(x) __attribute__((__counted_by__(x)))
 
 @interface Foo
+// expected-expansion@+7:37{{
+//   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public final func bar(_ p: UnsafeMutableBufferPointer<CFloat>) {|}}
+//   expected-remark@3{{macro content: |    let len = CInt(exactly: p.count)!|}}
+//   expected-remark@4{{macro content: |    return unsafe bar(p.baseAddress, count: len)|}}
+//   expected-remark@5{{macro content: |}|}}
+// }}
 -(void)bar:(float *)p count:(int)len __attribute__((swift_attr("@_SwiftifyImport(.countedBy(pointer: .param(1), count: \"len\"))")));
+
+// expected-expansion@+7:53{{
+//   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public final func simple(_ p: UnsafeMutableBufferPointer<CInt>) {|}}
+//   expected-remark@3{{macro content: |    let len = CInt(exactly: p.count)!|}}
+//   expected-remark@4{{macro content: |    return unsafe simple(len, p.baseAddress)|}}
+//   expected-remark@5{{macro content: |}|}}
+// }}
+- (void) simple:(int)len :(int * __counted_by(len))p;
+
+// expected-expansion@+10:83{{
+//   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public final func shared(_ p1: UnsafeMutableBufferPointer<CInt>, _ p2: UnsafeMutableBufferPointer<CInt>) {|}}
+//   expected-remark@3{{macro content: |    let len = CInt(exactly: p2.count)!|}}
+//   expected-remark@4{{macro content: |    if p1.count != len {|}}
+//   expected-remark@5{{macro content: |      fatalError("bounds check failure in shared: expected \\(len) but got \\(p1.count)")|}}
+//   expected-remark@6{{macro content: |    }|}}
+//   expected-remark@7{{macro content: |    return unsafe shared(len, p1.baseAddress, p2.baseAddress)|}}
+//   expected-remark@8{{macro content: |}|}}
+// }}
+- (void) shared:(int)len :(int * __counted_by(len))p1 :(int * __counted_by(len))p2;
+
+// expected-expansion@+9:81{{
+//   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public final func complexExpr(_ len: CInt, _ offset: CInt, _ p: UnsafeMutableBufferPointer<CInt>) {|}}
+//   expected-remark@3{{macro content: |    if p.count != (len - offset) {|}}
+//   expected-remark@4{{macro content: |      fatalError("bounds check failure in complexExpr: expected \\((len - offset)) but got \\(p.count)")|}}
+//   expected-remark@5{{macro content: |    }|}}
+//   expected-remark@6{{macro content: |    return unsafe complexExpr(len, offset, p.baseAddress)|}}
+//   expected-remark@7{{macro content: |}|}}
+// }}
+- (void) complexExpr:(int)len :(int) offset :(int * __counted_by(len - offset))p;
+
+// expected-expansion@+7:80{{
+//   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public final func nullUnspecified(_ p: UnsafeMutableBufferPointer<CInt>) {|}}
+//   expected-remark@3{{macro content: |    let len = CInt(exactly: p.count)!|}}
+//   expected-remark@4{{macro content: |    return unsafe nullUnspecified(len, p.baseAddress)|}}
+//   expected-remark@5{{macro content: |}|}}
+// }}
+- (void) nullUnspecified:(int)len :(int * __counted_by(len) _Null_unspecified)p;
+
+// expected-expansion@+7:63{{
+//   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public final func nonnull(_ p: UnsafeMutableBufferPointer<CInt>) {|}}
+//   expected-remark@3{{macro content: |    let len = CInt(exactly: p.count)!|}}
+//   expected-remark@4{{macro content: |    return unsafe nonnull(len, p.baseAddress!)|}}
+//   expected-remark@5{{macro content: |}|}}
+// }}
+- (void) nonnull:(int)len :(int * __counted_by(len) _Nonnull)p;
+
+// expected-expansion@+7:65{{
+//   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public final func nullable(_ p: UnsafeMutableBufferPointer<CInt>) {|}}
+//   expected-remark@3{{macro content: |    let len = CInt(exactly: p.count)!|}}
+//   expected-remark@4{{macro content: |    return unsafe nullable(len, p.baseAddress)|}}
+//   expected-remark@5{{macro content: |}|}}
+// }}
+- (void) nullable:(int)len :(int * __counted_by(len) _Nullable)p;
+
+// expected-expansion@+6:51{{
+//   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public final func returnPointer(_ len: CInt) -> UnsafeMutableBufferPointer<CInt> {|}}
+//   expected-remark@3{{macro content: |    return unsafe UnsafeMutableBufferPointer<CInt>(start: unsafe returnPointer(len), count: Int(len))|}}
+//   expected-remark@4{{macro content: |}|}}
+// }}
+- (int * __counted_by(len)) returnPointer:(int)len;
+
+// expected-expansion@+7:59{{
+//   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public class final func staticMethod(_ p: UnsafeMutableBufferPointer<CInt>) {|}}
+//   expected-remark@3{{macro content: |    let len = CInt(exactly: p.count)!|}}
+//   expected-remark@4{{macro content: |    return unsafe staticMethod(len, p.baseAddress)|}}
+//   expected-remark@5{{macro content: |}|}}
+// }}
++ (void) staticMethod:(int)len :(int * __counted_by(len))p;
 @end
 
 //--- method.swift
+// GENERATED-BY: %target-swift-ide-test -print-module -module-to-print=Method -plugin-path %swift-plugin-dir -I %t/Inputs -source-filename=x > %t/Test-interface.swift && %swift-function-caller-generator Method %t/Test-interface.swift
+// GENERATED-HASH: eff549210e9574b9f39c0cd3e210dab7e5b89a100541ecc328defe33fa21542e
 import Method
-  
-func test(foo: Foo, s: UnsafeMutableBufferPointer<Float>) {
-  foo.bar(s)
-}    
+
+
+extension Foo {
+  final func call_bar_Foo_classmethod(_ p: UnsafeMutablePointer<CFloat>!, count len: CInt) {
+    return unsafe Foo.bar(p, count: len)
+  }
+  @_alwaysEmitIntoClient @_disfavoredOverload final func call_bar_Foo(_ p: UnsafeMutableBufferPointer<CFloat>) {
+    return unsafe bar(p)
+  }
+  final func call_bar_Foo(_ p: UnsafeMutablePointer<CFloat>!, count len: CInt) {
+    return unsafe bar(p, count: len)
+  }
+  final func call_simple_Foo_classmethod(_ len: CInt, _ p: UnsafeMutablePointer<CInt>!) {
+    return unsafe Foo.simple(len, p)
+  }
+  @_alwaysEmitIntoClient @_disfavoredOverload final func call_simple_Foo(_ p: UnsafeMutableBufferPointer<CInt>) {
+    return unsafe simple(p)
+  }
+  final func call_simple_Foo(_ len: CInt, _ p: UnsafeMutablePointer<CInt>!) {
+    return unsafe simple(len, p)
+  }
+  final func call_shared_Foo_classmethod(_ len: CInt, _ p1: UnsafeMutablePointer<CInt>!, _ p2: UnsafeMutablePointer<CInt>!) {
+    return unsafe Foo.shared(len, p1, p2)
+  }
+  @_alwaysEmitIntoClient @_disfavoredOverload final func call_shared_Foo(_ p1: UnsafeMutableBufferPointer<CInt>, _ p2: UnsafeMutableBufferPointer<CInt>) {
+    return unsafe shared(p1, p2)
+  }
+  final func call_shared_Foo(_ len: CInt, _ p1: UnsafeMutablePointer<CInt>!, _ p2: UnsafeMutablePointer<CInt>!) {
+    return unsafe shared(len, p1, p2)
+  }
+  final func call_complexExpr_Foo_classmethod(_ len: CInt, _ offset: CInt, _ p: UnsafeMutablePointer<CInt>!) {
+    return unsafe Foo.complexExpr(len, offset, p)
+  }
+  @_alwaysEmitIntoClient @_disfavoredOverload final func call_complexExpr_Foo(_ len: CInt, _ offset: CInt, _ p: UnsafeMutableBufferPointer<CInt>) {
+    return unsafe complexExpr(len, offset, p)
+  }
+  final func call_complexExpr_Foo(_ len: CInt, _ offset: CInt, _ p: UnsafeMutablePointer<CInt>!) {
+    return unsafe complexExpr(len, offset, p)
+  }
+  final func call_nullUnspecified_Foo_classmethod(_ len: CInt, _ p: UnsafeMutablePointer<CInt>!) {
+    return unsafe Foo.nullUnspecified(len, p)
+  }
+  @_alwaysEmitIntoClient @_disfavoredOverload final func call_nullUnspecified_Foo(_ p: UnsafeMutableBufferPointer<CInt>) {
+    return unsafe nullUnspecified(p)
+  }
+  final func call_nullUnspecified_Foo(_ len: CInt, _ p: UnsafeMutablePointer<CInt>!) {
+    return unsafe nullUnspecified(len, p)
+  }
+  final func call_nonnull_Foo_classmethod(_ len: CInt, _ p: UnsafeMutablePointer<CInt>) {
+    return unsafe Foo.nonnull(len, p)
+  }
+  @_alwaysEmitIntoClient @_disfavoredOverload final func call_nonnull_Foo(_ p: UnsafeMutableBufferPointer<CInt>) {
+    return unsafe nonnull(p)
+  }
+  final func call_nonnull_Foo(_ len: CInt, _ p: UnsafeMutablePointer<CInt>) {
+    return unsafe nonnull(len, p)
+  }
+  final func call_nullable_Foo_classmethod(_ len: CInt, _ p: UnsafeMutablePointer<CInt>?) {
+    return unsafe Foo.nullable(len, p)
+  }
+  @_alwaysEmitIntoClient @_disfavoredOverload final func call_nullable_Foo(_ p: UnsafeMutableBufferPointer<CInt>) {
+    return unsafe nullable(p)
+  }
+  final func call_nullable_Foo(_ len: CInt, _ p: UnsafeMutablePointer<CInt>?) {
+    return unsafe nullable(len, p)
+  }
+  final func call_returnPointer_Foo_classmethod(_ len: CInt) -> UnsafeMutablePointer<CInt>! {
+    return unsafe Foo.returnPointer(len)
+  }
+  @_alwaysEmitIntoClient @_disfavoredOverload final func call_returnPointer_Foo(_ len: CInt) -> UnsafeMutableBufferPointer<CInt> {
+    return unsafe returnPointer(len)
+  }
+  final func call_returnPointer_Foo(_ len: CInt) -> UnsafeMutablePointer<CInt>! {
+    return unsafe returnPointer(len)
+  }
+  @_alwaysEmitIntoClient @_disfavoredOverload final func call_staticMethod_Foo_classmethod(_ p: UnsafeMutableBufferPointer<CInt>) {
+    return unsafe Foo.staticMethod(p)
+  }
+  final func call_staticMethod_Foo_classmethod(_ len: CInt, _ p: UnsafeMutablePointer<CInt>!) {
+    return unsafe Foo.staticMethod(len, p)
+  }
+}

--- a/test/Interop/ObjC/swiftify-import/counted-by-in-class.swift
+++ b/test/Interop/ObjC/swiftify-import/counted-by-in-class.swift
@@ -16,6 +16,13 @@ module Method {
 #define __counted_by(x) __attribute__((__counted_by__(x)))
 
 @interface Foo
+// expected-expansion@+14:2{{
+//   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public class final func bar(_ p: UnsafeMutableBufferPointer<CFloat>) {|}}
+//   expected-remark@3{{macro content: |    let len = CInt(exactly: p.count)!|}}
+//   expected-remark@4{{macro content: |    return unsafe bar(p.baseAddress, count: len)|}}
+//   expected-remark@5{{macro content: |}|}}
+// }}
 // expected-expansion@+7:37{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public final func bar(_ p: UnsafeMutableBufferPointer<CFloat>) {|}}
@@ -25,6 +32,13 @@ module Method {
 // }}
 -(void)bar:(float *)p count:(int)len __attribute__((swift_attr("@_SwiftifyImport(.countedBy(pointer: .param(1), count: \"len\"))")));
 
+// expected-expansion@+14:2{{
+//   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public class final func simple(_ p: UnsafeMutableBufferPointer<CInt>) {|}}
+//   expected-remark@3{{macro content: |    let len = CInt(exactly: p.count)!|}}
+//   expected-remark@4{{macro content: |    return unsafe simple(len, p.baseAddress)|}}
+//   expected-remark@5{{macro content: |}|}}
+// }}
 // expected-expansion@+7:53{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public final func simple(_ p: UnsafeMutableBufferPointer<CInt>) {|}}
@@ -34,6 +48,16 @@ module Method {
 // }}
 - (void) simple:(int)len :(int * __counted_by(len))p;
 
+// expected-expansion@+20:2{{
+//   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public class final func shared(_ p1: UnsafeMutableBufferPointer<CInt>, _ p2: UnsafeMutableBufferPointer<CInt>) {|}}
+//   expected-remark@3{{macro content: |    let len = CInt(exactly: p2.count)!|}}
+//   expected-remark@4{{macro content: |    if p1.count != len {|}}
+//   expected-remark@5{{macro content: |      fatalError("bounds check failure in shared: expected \\(len) but got \\(p1.count)")|}}
+//   expected-remark@6{{macro content: |    }|}}
+//   expected-remark@7{{macro content: |    return unsafe shared(len, p1.baseAddress, p2.baseAddress)|}}
+//   expected-remark@8{{macro content: |}|}}
+// }}
 // expected-expansion@+10:83{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public final func shared(_ p1: UnsafeMutableBufferPointer<CInt>, _ p2: UnsafeMutableBufferPointer<CInt>) {|}}
@@ -46,6 +70,15 @@ module Method {
 // }}
 - (void) shared:(int)len :(int * __counted_by(len))p1 :(int * __counted_by(len))p2;
 
+// expected-expansion@+18:2{{
+//   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public class final func complexExpr(_ len: CInt, _ offset: CInt, _ p: UnsafeMutableBufferPointer<CInt>) {|}}
+//   expected-remark@3{{macro content: |    if p.count != (len - offset) {|}}
+//   expected-remark@4{{macro content: |      fatalError("bounds check failure in complexExpr: expected \\((len - offset)) but got \\(p.count)")|}}
+//   expected-remark@5{{macro content: |    }|}}
+//   expected-remark@6{{macro content: |    return unsafe complexExpr(len, offset, p.baseAddress)|}}
+//   expected-remark@7{{macro content: |}|}}
+// }}
 // expected-expansion@+9:81{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public final func complexExpr(_ len: CInt, _ offset: CInt, _ p: UnsafeMutableBufferPointer<CInt>) {|}}
@@ -57,6 +90,13 @@ module Method {
 // }}
 - (void) complexExpr:(int)len :(int) offset :(int * __counted_by(len - offset))p;
 
+// expected-expansion@+14:2{{
+//   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public class final func nullUnspecified(_ p: UnsafeMutableBufferPointer<CInt>) {|}}
+//   expected-remark@3{{macro content: |    let len = CInt(exactly: p.count)!|}}
+//   expected-remark@4{{macro content: |    return unsafe nullUnspecified(len, p.baseAddress)|}}
+//   expected-remark@5{{macro content: |}|}}
+// }}
 // expected-expansion@+7:80{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public final func nullUnspecified(_ p: UnsafeMutableBufferPointer<CInt>) {|}}
@@ -66,6 +106,13 @@ module Method {
 // }}
 - (void) nullUnspecified:(int)len :(int * __counted_by(len) _Null_unspecified)p;
 
+// expected-expansion@+14:2{{
+//   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public class final func nonnull(_ p: UnsafeMutableBufferPointer<CInt>) {|}}
+//   expected-remark@3{{macro content: |    let len = CInt(exactly: p.count)!|}}
+//   expected-remark@4{{macro content: |    return unsafe nonnull(len, p.baseAddress!)|}}
+//   expected-remark@5{{macro content: |}|}}
+// }}
 // expected-expansion@+7:63{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public final func nonnull(_ p: UnsafeMutableBufferPointer<CInt>) {|}}
@@ -75,6 +122,13 @@ module Method {
 // }}
 - (void) nonnull:(int)len :(int * __counted_by(len) _Nonnull)p;
 
+// expected-expansion@+14:2{{
+//   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public class final func nullable(_ p: UnsafeMutableBufferPointer<CInt>) {|}}
+//   expected-remark@3{{macro content: |    let len = CInt(exactly: p.count)!|}}
+//   expected-remark@4{{macro content: |    return unsafe nullable(len, p.baseAddress)|}}
+//   expected-remark@5{{macro content: |}|}}
+// }}
 // expected-expansion@+7:65{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public final func nullable(_ p: UnsafeMutableBufferPointer<CInt>) {|}}
@@ -84,6 +138,12 @@ module Method {
 // }}
 - (void) nullable:(int)len :(int * __counted_by(len) _Nullable)p;
 
+// expected-expansion@+12:2{{
+//   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public class final func returnPointer(_ len: CInt) -> UnsafeMutableBufferPointer<CInt> {|}}
+//   expected-remark@3{{macro content: |    return unsafe UnsafeMutableBufferPointer<CInt>(start: unsafe returnPointer(len), count: Int(len))|}}
+//   expected-remark@4{{macro content: |}|}}
+// }}
 // expected-expansion@+6:51{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public final func returnPointer(_ len: CInt) -> UnsafeMutableBufferPointer<CInt> {|}}
@@ -104,7 +164,7 @@ module Method {
 
 //--- method.swift
 // GENERATED-BY: %target-swift-ide-test -print-module -module-to-print=Method -plugin-path %swift-plugin-dir -I %t/Inputs -source-filename=x > %t/Test-interface.swift && %swift-function-caller-generator Method %t/Test-interface.swift
-// GENERATED-HASH: eff549210e9574b9f39c0cd3e210dab7e5b89a100541ecc328defe33fa21542e
+// GENERATED-HASH: e29b56d448db9d939991c4242d88cdfb3939f556b6b3bab2bdab4915ee8e8997
 import Method
 
 
@@ -115,6 +175,9 @@ extension Foo {
   @_alwaysEmitIntoClient @_disfavoredOverload final func call_bar_Foo(_ p: UnsafeMutableBufferPointer<CFloat>) {
     return unsafe bar(p)
   }
+  @_alwaysEmitIntoClient @_disfavoredOverload final func call_bar_Foo_classmethod(_ p: UnsafeMutableBufferPointer<CFloat>) {
+    return unsafe Foo.bar(p)
+  }
   final func call_bar_Foo(_ p: UnsafeMutablePointer<CFloat>!, count len: CInt) {
     return unsafe bar(p, count: len)
   }
@@ -123,6 +186,9 @@ extension Foo {
   }
   @_alwaysEmitIntoClient @_disfavoredOverload final func call_simple_Foo(_ p: UnsafeMutableBufferPointer<CInt>) {
     return unsafe simple(p)
+  }
+  @_alwaysEmitIntoClient @_disfavoredOverload final func call_simple_Foo_classmethod(_ p: UnsafeMutableBufferPointer<CInt>) {
+    return unsafe Foo.simple(p)
   }
   final func call_simple_Foo(_ len: CInt, _ p: UnsafeMutablePointer<CInt>!) {
     return unsafe simple(len, p)
@@ -133,6 +199,9 @@ extension Foo {
   @_alwaysEmitIntoClient @_disfavoredOverload final func call_shared_Foo(_ p1: UnsafeMutableBufferPointer<CInt>, _ p2: UnsafeMutableBufferPointer<CInt>) {
     return unsafe shared(p1, p2)
   }
+  @_alwaysEmitIntoClient @_disfavoredOverload final func call_shared_Foo_classmethod(_ p1: UnsafeMutableBufferPointer<CInt>, _ p2: UnsafeMutableBufferPointer<CInt>) {
+    return unsafe Foo.shared(p1, p2)
+  }
   final func call_shared_Foo(_ len: CInt, _ p1: UnsafeMutablePointer<CInt>!, _ p2: UnsafeMutablePointer<CInt>!) {
     return unsafe shared(len, p1, p2)
   }
@@ -141,6 +210,9 @@ extension Foo {
   }
   @_alwaysEmitIntoClient @_disfavoredOverload final func call_complexExpr_Foo(_ len: CInt, _ offset: CInt, _ p: UnsafeMutableBufferPointer<CInt>) {
     return unsafe complexExpr(len, offset, p)
+  }
+  @_alwaysEmitIntoClient @_disfavoredOverload final func call_complexExpr_Foo_classmethod(_ len: CInt, _ offset: CInt, _ p: UnsafeMutableBufferPointer<CInt>) {
+    return unsafe Foo.complexExpr(len, offset, p)
   }
   final func call_complexExpr_Foo(_ len: CInt, _ offset: CInt, _ p: UnsafeMutablePointer<CInt>!) {
     return unsafe complexExpr(len, offset, p)
@@ -151,6 +223,9 @@ extension Foo {
   @_alwaysEmitIntoClient @_disfavoredOverload final func call_nullUnspecified_Foo(_ p: UnsafeMutableBufferPointer<CInt>) {
     return unsafe nullUnspecified(p)
   }
+  @_alwaysEmitIntoClient @_disfavoredOverload final func call_nullUnspecified_Foo_classmethod(_ p: UnsafeMutableBufferPointer<CInt>) {
+    return unsafe Foo.nullUnspecified(p)
+  }
   final func call_nullUnspecified_Foo(_ len: CInt, _ p: UnsafeMutablePointer<CInt>!) {
     return unsafe nullUnspecified(len, p)
   }
@@ -159,6 +234,9 @@ extension Foo {
   }
   @_alwaysEmitIntoClient @_disfavoredOverload final func call_nonnull_Foo(_ p: UnsafeMutableBufferPointer<CInt>) {
     return unsafe nonnull(p)
+  }
+  @_alwaysEmitIntoClient @_disfavoredOverload final func call_nonnull_Foo_classmethod(_ p: UnsafeMutableBufferPointer<CInt>) {
+    return unsafe Foo.nonnull(p)
   }
   final func call_nonnull_Foo(_ len: CInt, _ p: UnsafeMutablePointer<CInt>) {
     return unsafe nonnull(len, p)
@@ -169,6 +247,9 @@ extension Foo {
   @_alwaysEmitIntoClient @_disfavoredOverload final func call_nullable_Foo(_ p: UnsafeMutableBufferPointer<CInt>) {
     return unsafe nullable(p)
   }
+  @_alwaysEmitIntoClient @_disfavoredOverload final func call_nullable_Foo_classmethod(_ p: UnsafeMutableBufferPointer<CInt>) {
+    return unsafe Foo.nullable(p)
+  }
   final func call_nullable_Foo(_ len: CInt, _ p: UnsafeMutablePointer<CInt>?) {
     return unsafe nullable(len, p)
   }
@@ -177,6 +258,9 @@ extension Foo {
   }
   @_alwaysEmitIntoClient @_disfavoredOverload final func call_returnPointer_Foo(_ len: CInt) -> UnsafeMutableBufferPointer<CInt> {
     return unsafe returnPointer(len)
+  }
+  @_alwaysEmitIntoClient @_disfavoredOverload final func call_returnPointer_Foo_classmethod(_ len: CInt) -> UnsafeMutableBufferPointer<CInt> {
+    return unsafe Foo.returnPointer(len)
   }
   final func call_returnPointer_Foo(_ len: CInt) -> UnsafeMutablePointer<CInt>! {
     return unsafe returnPointer(len)


### PR DESCRIPTION
This adds support for attaching `@_SwiftifyImport` to ObjC methods
imported into Swift classes. This was previously blocked by a crash in
SILGen, where callers to the safe wrapper could not find the function in
the class' vtable. Now that safe wrappers are `final`, this is no longer
an issue, because SILGen knows to call the function using static
dispatch.

Safe wrappers for protocols are still not supported, because `final` is
not (yet) allowed for protocol methods.

rdar://177544024