### PR TITLE
[6.3][cherrypick] Fix module names on OpenBSD for amd64/x86_64.

### DIFF
--- a/lib/Basic/Platform.cpp
+++ b/lib/Basic/Platform.cpp
@@ -472,15 +472,20 @@ llvm::Triple swift::getTargetSpecificModuleTriple(const llvm::Triple &triple) {
 
 llvm::Triple swift::getUnversionedTriple(const llvm::Triple &triple) {
   StringRef unversionedOSName = triple.getOSName().take_until(llvm::isDigit);
+  StringRef arch = triple.getArchName();
+  if (triple.isOSOpenBSD()) {
+    arch = swift::getMajorArchitectureName(triple);
+  }
+
   if (triple.getEnvironment()) {
     StringRef environment =
         llvm::Triple::getEnvironmentTypeName(triple.getEnvironment());
 
-    return llvm::Triple(triple.getArchName(), triple.getVendorName(),
+    return llvm::Triple(arch, triple.getVendorName(),
                         unversionedOSName, environment);
   }
 
-  return llvm::Triple(triple.getArchName(), triple.getVendorName(),
+  return llvm::Triple(arch, triple.getVendorName(),
                       unversionedOSName);
 }
 


### PR DESCRIPTION
- **Explanation**:

Module names on OpenBSD must be transposed to the x86_64 spelling.

- **Scope**:

Minor. Affects OpenBSD only.

- **Issues**:

Of relevance to the OpenBSD port in #78437

- **Original PRs**:

#88353

- **Risk**:

Minor. Light refactoring change.

- **Testing**:

Local testing, passed CI.

- **Reviewers**:

@DougGregor