### PR TITLE
[6.3][cherrypick] OpenBSD needs this tar invocation as well.

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -3208,7 +3208,7 @@ function build_and_test_installable_package() {
               call tar -c -z -f "${package_for_host}" "${TOOLCHAIN_PREFIX/#\/}"
         else
             # BSD tar doesn't support --owner/--group.
-            if [[ "$(uname -s)" == "Darwin" || "$(uname -s)" == "FreeBSD" ]] ; then
+            if [[ "$(uname -s)" == "Darwin" || "$(uname -s)" == "FreeBSD" || "$(uname -s)" == "OpenBSD" ]] ; then
                 with_pushd "${host_install_destdir}" \
                     tar -c -z -f "${package_for_host}" "${host_install_prefix/#\/}"
             else


### PR DESCRIPTION
- **Explanation**:

Special-case in build-script-impl for tar flags needs to apply to OpenBSD too.

- **Scope**:

Minor. Affects OpenBSD only.

- **Issues**:

Of relevance to the OpenBSD port in #78437

- **Original PRs**:

#85714

- **Risk**:

Minor, adjusts a conditional for the platform.

- **Testing**:

Local testing, passed CI.

- **Reviewers**:

@etcwilde