### PR TITLE
Convert PreInverseGenericsExcept to a SUPPRESSIBLE_EXPERIMENTAL_FEATURE

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -558,7 +558,7 @@ EXPERIMENTAL_FEATURE(DefaultIsolationPerFile, false)
 SUPPRESSIBLE_EXPERIMENTAL_FEATURE(Lifetimes, true)
 
 /// Enable @_preInverseGenerics(except:) attribute
-EXPERIMENTAL_FEATURE(PreInverseGenericsExcept, true)
+SUPPRESSIBLE_EXPERIMENTAL_FEATURE(PreInverseGenericsExcept, true)
 
 /// Deprecates the compatibility memberwise initializer introduced by SE-0502,
 /// and removes it in the next major language mode.

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3685,6 +3685,14 @@ suppressingFeatureABIAttributeSE0479(PrintOptions &options,
 }
 
 static void
+suppressingFeaturePreInverseGenericsExcept(PrintOptions &options,
+                                           llvm::function_ref<void()> action) {
+  ExcludeAttrRAII scope(options.ExcludeAttrList,
+                        DeclAttrKind::PreInverseGenerics);
+  action();
+}
+
+static void
 suppressingFeatureAddressableTypes(PrintOptions &options,
                                    llvm::function_ref<void()> action) {
   ExcludeAttrRAII scope(options.ExcludeAttrList,

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -8713,12 +8713,11 @@ void AttributeChecker::visitMacroRoleAttr(MacroRoleAttr *attr) {
 void AttributeChecker::visitPreInverseGenericsAttr(
     PreInverseGenericsAttr *attr) {
   if (attr->hasExcept(D) &&
-      !Ctx.LangOpts.hasFeature(Feature::PreInverseGenericsExcept)) {
-    Ctx.Diags
-        .diagnose(attr->getLocation(),
-                  diag::attribute_requires_experimental_feature, attr,
-                  "PreInverseGenericsExcept")
-        .warnInSwiftInterface(D->getDeclContext());
+      !Ctx.LangOpts.hasFeature(Feature::PreInverseGenericsExcept) &&
+      !D->getDeclContext()->isInSwiftinterface()) {
+    Ctx.Diags.diagnose(attr->getLocation(),
+                       diag::attribute_requires_experimental_feature, attr,
+                       "PreInverseGenericsExcept");
   }
 
   // Trigger the request to resolve and validate the optional 'except:' argument.

--- a/test/ModuleInterface/pre_inverse_generics_except.swift
+++ b/test/ModuleInterface/pre_inverse_generics_except.swift
@@ -15,28 +15,38 @@
 public func bare<T: ~Copyable>(_ t: borrowing T) {}
 
 // The except: form requires a #if $PreInverseGenericsExcept guard.
-// Older compilers that don't support the feature will not see the declaration.
+// Older compilers that don't support the feature will see the decl with the
+// attribute simply omitted.
 
 // CHECK:      #if compiler(>=5.3) && $PreInverseGenericsExcept
 // CHECK-NEXT: @_preInverseGenericsExceptCopyable public func exceptCopyable<T>(_ t: borrowing T) where T : ~Copyable, T : ~Escapable
+// CHECK-NEXT: #else
+// CHECK-NEXT: public func exceptCopyable<T>(_ t: borrowing T) where T : ~Copyable, T : ~Escapable
 // CHECK-NEXT: #endif
 @_preInverseGenerics(except: ~Copyable)
 public func exceptCopyable<T: ~Copyable & ~Escapable>(_ t: borrowing T) {}
 
 // CHECK:      #if compiler(>=5.3) && $PreInverseGenericsExcept
 // CHECK-NEXT: @_preInverseGenericsExceptCopyable public func exceptCopyable2<T>(_ t: borrowing T) where T : ~Copyable, T : ~Escapable
+// CHECK-NEXT: #else
+// CHECK-NEXT: public func exceptCopyable2<T>(_ t: borrowing T) where T : ~Copyable, T : ~Escapable
 // CHECK-NEXT: #endif
 @_preInverseGenericsExceptCopyable
 public func exceptCopyable2<T: ~Copyable & ~Escapable>(_ t: borrowing T) {}
 
 // CHECK:      #if compiler(>=5.3) && $PreInverseGenericsExcept
 // CHECK-NEXT: @_preInverseGenerics(except: ~Escapable) public func exceptEscapable<T>(_ t: borrowing T) where T : ~Copyable, T : ~Escapable
+// CHECK-NEXT: #else
+// CHECK-NEXT: public func exceptEscapable<T>(_ t: borrowing T) where T : ~Copyable, T : ~Escapable
 // CHECK-NEXT: #endif
 @_preInverseGenerics(except: ~Escapable)
 public func exceptEscapable<T: ~Copyable & ~Escapable>(_ t: borrowing T) {}
 
 // CHECK:      #if compiler(>=5.3) && $PreInverseGenericsExcept
 // CHECK-NEXT: @_preInverseGenerics(except: ~Copyable & ~Escapable) public func exceptBoth<T>(_ t: borrowing T) where T : ~Copyable, T : ~Escapable
+// CHECK-NEXT: #else
+// CHECK-NEXT: public func exceptBoth<T>(_ t: borrowing T) where T : ~Copyable, T : ~Escapable
+// CHECK-NEXT: #endif
 @_preInverseGenerics(except: ~Copyable & ~Escapable)
 public func exceptBoth<T: ~Copyable & ~Escapable>(_ t: borrowing T) {}
 
@@ -45,6 +55,8 @@ public func exceptBoth<T: ~Copyable & ~Escapable>(_ t: borrowing T) {}
 public struct MySpan<T: ~Copyable & ~Escapable>: ~Copyable {
 // CHECK:      #if compiler(>=5.3) && $PreInverseGenericsExcept
 // CHECK-NEXT: @_preInverseGenericsExceptCopyable public var _count: Swift::Int
+// CHECK-NEXT: #else
+// CHECK-NEXT: public var _count: Swift::Int
 // CHECK-NEXT: #endif
   @_preInverseGenerics(except: ~Copyable)
   public var _count: Int

--- a/test/attr/attr_preInverseGenerics.swift
+++ b/test/attr/attr_preInverseGenerics.swift
@@ -16,5 +16,3 @@ func exceptInt<T: ~Copyable & ~Escapable>(_ t: borrowing T) {}
 // The shorthand alias also requires the experimental feature.
 @_preInverseGenericsExceptCopyable // expected-error {{'@_preInverseGenerics' is an experimental feature; use '-enable-experimental-feature PreInverseGenericsExcept'}}
 func exceptCopyableShorthand<T: ~Copyable & ~Escapable>(_ t: borrowing T) {}
-
-


### PR DESCRIPTION
The suppression can help us avoid a typechecking condfail, though the mangled names of any symbols will be wrong as we simply omit the attribute in this simplistic suppression strategy.

There's also no reason to have introduced this as experimental, as we plan to use it right away.

related to rdar://176395527