### PR TITLE
[CMake] Disable -gsplit-dwarf for RISC-V stdlib targets

### DIFF
--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -277,6 +277,13 @@ function(_add_target_variant_c_compile_flags)
     else()
       list(APPEND result "-g0")
     endif()
+
+    # Split DWARF is incompatible with RISC-V linker relaxation (-mrelax),
+    # which clang enables by default for RISC-V targets. Override any
+    # inherited -gsplit-dwarf from the parent (LLVM) build.
+    if("${CFLAGS_ARCH}" MATCHES "^riscv")
+      list(APPEND result "-gno-split-dwarf")
+    endif()
   endif()
 
   if("${CFLAGS_SDK}" STREQUAL "WINDOWS")


### PR DESCRIPTION
Clang enables -mrelax by default, which isn't compatible with -gsplit-dwarf. This fixes the -r build on Linux, which currently fails while compiling the riscv-64 stdlib.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
