### PR TITLE
Fix LifetimeDependenceDiagnostics - disable noescape function args

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceDiagnostics.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceDiagnostics.swift
@@ -30,6 +30,16 @@ private func log(prefix: Bool = true, _ message: @autoclosure () -> String) {
   }
 }
 
+// @noescape functions cannot yet compose other types, but they can be wrapped in an arbitrary number of Optionals.
+extension AST.`Type` {
+  var fullyUnwrappedType: AST.`Type` {
+    if !self.isOptional {
+      return self
+    }
+    return self.genericArgumentsOfBoundGenericType[0].fullyUnwrappedType
+  }
+}
+
 /// Diagnostic pass.
 ///
 /// Find the roots of all non-escapable values in this function. All
@@ -44,7 +54,7 @@ let lifetimeDependenceDiagnosticsPass = FunctionPass(
   log("\(function.convention)")
 
   for argument in function.arguments
-      where !argument.type.isEscapable(in: function)
+      where !argument.type.isEscapable(in: function) && !argument.type.rawType.fullyUnwrappedType.isLoweredFunction
   {
     // Indirect results are not checked here. Type checking ensures
     // that they have a lifetime dependence.

--- a/test/SILOptimizer/lifetime_dependence/Inputs/verify_diagnostics_objc_header.h
+++ b/test/SILOptimizer/lifetime_dependence/Inputs/verify_diagnostics_objc_header.h
@@ -1,0 +1,5 @@
+#import <Foundation/Foundation.h>
+
+@interface TakeNoEscapeBlock : NSObject
++ (instancetype)takeNoEscapeBlock:(void(NS_NOESCAPE ^)(void))block;
+@end

--- a/test/SILOptimizer/lifetime_dependence/verify_diagnostics.sil
+++ b/test/SILOptimizer/lifetime_dependence/verify_diagnostics.sil
@@ -450,3 +450,30 @@ bb0(%0 : $*BorrowWrapper<T>, %1 : $*T, %2 : $@thin BorrowWrapper<T>.Type):
   %15 = tuple ()
   return %15
 }
+
+// rdar://177381648: error: lifetime-dependent variable escapes its scope
+//
+// Test that lifetime diagnostics are disabled for @noescape function arguments.
+// The diagnostics would fail here because the mark_dependence is on the conditionally unwrapped value.
+sil @noescape_to_escape_thunk : $@convention(thin) (@guaranteed @noescape @callee_guaranteed () -> ()) -> ()
+
+sil shared [serialized] [thunk] [ossa] @testNoEscapeBlockEscape : $@convention(thin) (@owned Optional<@noescape @callee_guaranteed () -> ()>) -> () {
+bb0(%0 : @owned $Optional<@noescape @callee_guaranteed () -> ()>):
+  switch_enum %0, case #Optional.some!enumelt: bb1, case #Optional.none!enumelt: bb2
+
+bb1(%3 : @owned $@noescape @callee_guaranteed () -> ()):
+  %4 = copy_value %3
+  %5 = function_ref @noescape_to_escape_thunk : $@convention(thin) (@guaranteed @noescape @callee_guaranteed () -> ()) -> ()
+  %6 = partial_apply [callee_guaranteed] %5(%4) : $@convention(thin) (@guaranteed @noescape @callee_guaranteed () -> ()) -> ()
+  %7 = mark_dependence [unresolved] %6 on %3
+  destroy_value %7
+  destroy_value %3
+  br bb3
+
+bb2:
+  br bb3
+
+bb3:
+  %tup = tuple ()
+  return %tup
+}

--- a/test/SILOptimizer/lifetime_dependence/verify_diagnostics_objc.swift
+++ b/test/SILOptimizer/lifetime_dependence/verify_diagnostics_objc.swift
@@ -1,0 +1,13 @@
+// RUN: %target-swift-frontend -primary-file %s -parse-as-library -emit-sil \
+// RUN:   -import-objc-header "%S/Inputs/verify_diagnostics_objc_header.h" \
+// RUN:   -o /dev/null \
+// RUN:   -verify \
+// RUN:   -verify-additional-file "%S/Inputs/verify_diagnostics_objc_header.h" \
+// RUN:   -sil-verify-all \
+// RUN:   -module-name test
+
+// REQUIRES: objc_interop
+
+func test() {
+  let _ = TakeNoEscapeBlock { }
+}


### PR DESCRIPTION
In LifetimeDependenceDiagnostics, disable diagnostics of function arguments that
have a noescape function type. Diagosing noescape function-type arguments is
meant to be handled by a separate pass, DiagnoseInvalidEscapingCaptures. In some
distant future, we could consider merging these diagnostics. For now, they
should be independent.

This fixes a bug introduced with:

commit e3d55f64c281032f2cb4b83508e0b8589fc1e9c9
Date:   Wed Apr 29 10:37:32 2026 +0100

    Lifetimes: Treat noescape function types as ~Escapable

After that change, lifetime diagnostics inadvertantly kicked on for noescape
function-type arg. The diagnostic would then fail when importing ObjC API with
an optional noescape function such as:

+ (instancetype)takeNoEscapeBlock:(void(NS_NOESCAPE ^)(void))block;
// error: lifetime-dependent variable 'block' escapes its scope)

Here the compiler generates a thunk to unwrap the optional and generates a
mark_dependence on the Optional's inner value.

Fixes rdar://177381648 - error: lifetime-dependent variable escapes its scope
