### PR TITLE
[RemoteInspection] Fix wrong depth of generic parameters in opaque types

### DIFF
--- a/include/swift/RemoteInspection/TypeRefBuilder.h
+++ b/include/swift/RemoteInspection/TypeRefBuilder.h
@@ -1116,11 +1116,15 @@ public:
       return nullptr;
 
     GenericArgumentMap subs;
+    unsigned subDepth = 0;
     for (unsigned d = 0, de = genericArgs.size(); d < de; ++d) {
       auto argsForDepth = genericArgs[d];
+      if (argsForDepth.empty())
+        continue;
       for (unsigned i = 0, ie = argsForDepth.size(); i < ie; ++i) {
-        subs.insert({{d, i}, argsForDepth[i]});
+        subs.insert({{subDepth, i}, argsForDepth[i]});
       }
+      ++subDepth;
     }
 
     return underlyingTy->subst(*this, subs);

--- a/include/swift/StaticMirror/ObjectFileContext.h
+++ b/include/swift/StaticMirror/ObjectFileContext.h
@@ -118,11 +118,9 @@ public:
 
   reflection::RemoteAddress getImageStartAddress(unsigned i) const;
 
-  // TODO: We could consult the dynamic symbol tables of the images to
-  // implement this.
-  reflection::RemoteAddress getSymbolAddress(const std::string &name) override {
-    return reflection::RemoteAddress();
-  }
+  // Look up the address of a symbol by name in the symbol tables of the
+  // loaded images.
+  reflection::RemoteAddress getSymbolAddress(const std::string &name) override;
 
   ReadBytesResult readBytes(reflection::RemoteAddress Addr,
                             uint64_t Size) override;

--- a/lib/StaticMirror/ObjectFileContext.cpp
+++ b/lib/StaticMirror/ObjectFileContext.cpp
@@ -526,6 +526,62 @@ ObjectMemoryReader::getImageStartAddress(unsigned i) const {
                             reflection::RemoteAddress::DefaultAddressSpace)));
 }
 
+reflection::RemoteAddress
+ObjectMemoryReader::getSymbolAddress(const std::string &name) {
+  if (name.empty())
+    return reflection::RemoteAddress();
+
+  // Object file symbol tables store some names with a leading underscore (e.g.
+  // Mach-O), while the demangler hands us names without one. Accept either.
+  auto matches = [&name](StringRef symbolName) {
+    return symbolName == name ||
+           (symbolName.starts_with("_") && symbolName.drop_front() == name);
+  };
+
+  for (auto &Entry : Images) {
+    const llvm::object::ObjectFile *O = Entry.TheImage.getObjectFile();
+    for (const auto &Symbol : O->symbols()) {
+      llvm::Expected<uint32_t> Flags = Symbol.getFlags();
+      if (!Flags) {
+        llvm::consumeError(Flags.takeError());
+        continue;
+      }
+      if (*Flags & llvm::object::SymbolRef::SF_Undefined)
+        continue;
+
+      llvm::Expected<llvm::object::section_iterator> Section =
+          Symbol.getSection();
+      if (!Section) {
+        llvm::consumeError(Section.takeError());
+        continue;
+      }
+      if (*Section == O->section_end())
+        continue;
+
+      auto SymbolName = Symbol.getName();
+      if (!SymbolName) {
+        llvm::consumeError(SymbolName.takeError());
+        continue;
+      }
+      if (!matches(*SymbolName))
+        continue;
+
+      auto Address = Symbol.getAddress();
+      if (!Address) {
+        llvm::consumeError(Address.takeError());
+        continue;
+      }
+
+      return encodeImageIndexAndAddress(
+          &Entry.TheImage,
+          remote::RemoteAddress(
+              *Address, reflection::RemoteAddress::DefaultAddressSpace));
+    }
+  }
+
+  return reflection::RemoteAddress();
+}
+
 ReadBytesResult ObjectMemoryReader::readBytes(reflection::RemoteAddress Addr,
                                               uint64_t Size) {
   auto addrValue = Addr.getRawAddress();

--- a/test/Reflection/Inputs/TypeLowering.swift
+++ b/test/Reflection/Inputs/TypeLowering.swift
@@ -267,6 +267,20 @@ public struct OpaqueWitness: AssocType {
   }
 }
 
+public struct Pair<First, Second> {
+  public var first: First
+  public var second: Second
+}
+
+
+public struct Outer<T> {
+  public struct Inner {
+    public func makeSequence<U>(_ t: T, _ u: U) -> some Sequence {
+      return [Pair(first: t, second: u)]
+    }
+  }
+}
+
 public struct GenericOnAssocType<T: AssocType> {
   var x: T.A
   var y: T.A

--- a/test/Reflection/typeref_lowering.swift
+++ b/test/Reflection/typeref_lowering.swift
@@ -1453,3 +1453,20 @@ SpySiGXu
 // CHECK-32-NEXT: (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=1))
 // CHECK-32-NEXT: (field name=wtable offset=4
 // CHECK-32-NEXT: (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1 bitwise_takable=1)))
+
+// Opaque return type capturing generic parameters across a non-generic context level (the mangled bound generics have an empty middle level).
+12TypeLowering5OuterV5InnerV12makeSequenceyQrx_qd__tlFQOySi__SSQo_
+// CHECK:      (bound_generic_struct Swift.Array
+// CHECK-NEXT:   (bound_generic_struct TypeLowering.Pair
+// CHECK-NEXT:     (struct Swift.Int)
+// CHECK-NEXT:     (struct Swift.String)))
+// CHECK-64-NEXT: (struct size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=1
+// CHECK-64-NEXT:   (field name=_buffer offset=0
+// CHECK-64-NEXT:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=1
+// CHECK-64-NEXT:       (field name=_storage offset=0
+// CHECK-32-NEXT: (struct size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=1
+// CHECK-32-NEXT:   (field name=_buffer offset=0
+// CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=1
+// CHECK-32-NEXT:       (field name=_storage offset=0
+
+


### PR DESCRIPTION
The stored generic parameter list skips non-generic context levels. When building a TypeRef out of a demangle tree, TypeRefBuilder was applying them on the wrong level.

Assisted-by: claude

rdar://177198545
