### PR TITLE
[swift-synthesize-interface] Improve C++ interop support

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -8633,13 +8633,12 @@ public:
                           ParameterList *BodyParams, TypeRepr *ResultTyR,
                           DeclContext *Parent);
 
-  static FuncDecl *createImplicit(ASTContext &Context,
-                                  StaticSpellingKind StaticSpelling,
-                                  DeclName Name, SourceLoc NameLoc, bool Async,
-                                  bool Throws, Type ThrownType,
-                                  GenericParamList *GenericParams,
-                                  ParameterList *BodyParams, Type FnRetType,
-                                  DeclContext *Parent);
+  static FuncDecl *
+  createImplicit(ASTContext &Context, StaticSpellingKind StaticSpelling,
+                 DeclName Name, SourceLoc NameLoc, bool Async, bool Throws,
+                 Type ThrownType, GenericParamList *GenericParams,
+                 ParameterList *BodyParams, Type FnRetType, DeclContext *Parent,
+                 bool isSynthesized = false);
 
   static FuncDecl *createImported(ASTContext &Context, SourceLoc FuncLoc,
                                   DeclName Name, SourceLoc NameLoc, bool Async,

--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -341,6 +341,10 @@ public:
   /// Whether to print implicit parts of the AST.
   bool SkipImplicit = false;
 
+  /// Whether to print implicit but synthesized (user-facing) declarations, even
+  /// if SkipImplicit.
+  bool AlwaysPrintSynthesized = false;
+
   /// Whether to print unavailable parts of the AST.
   bool SkipUnavailable = false;
 

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -1954,6 +1954,14 @@ def print_fully_qualified_types : Flag<["-"], "print-fully-qualified-types">,
   Flags<[NoDriverOption, SwiftSynthesizeInterfaceOption]>,
   HelpText<"Always print fully qualified type names">;
 
+def synthesize_interface_show :
+  Joined<["-"], "synthesize-interface-show=">,
+  Flags<[NoDriverOption, SwiftSynthesizeInterfaceOption]>,
+  MetaVarName<"<options>">,
+  HelpText<"Comma-separated options controlling what gets printed.\n"
+           "Options: 'unavailable', 'implicit-attrs', 'qualified-types'.\n"
+           "Shorthands: 'all' (every option enabled), 'minimal' (default).">;
+
 // swift-symbolgraph-extract-only options
 def output_dir : Separate<["-"], "output-dir">,
   Flags<[NoDriverOption, SwiftSymbolGraphExtractOption, SwiftAPIDigesterOption,
@@ -1970,7 +1978,8 @@ def skip_synthesized_members: Flag<[ "-" ], "skip-synthesized-members">,
   HelpText<"Skip members inherited through classes or default implementations">;
 
 def minimum_access_level : Separate<["-"], "minimum-access-level">,
-  Flags<[NoDriverOption, SwiftSymbolGraphExtractOption]>,
+  Flags<[NoDriverOption, SwiftSymbolGraphExtractOption,
+         SwiftSynthesizeInterfaceOption]>,
   HelpText<"Include symbols with this access level or more">,
   MetaVarName<"<level>">;
 

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -2517,8 +2517,16 @@ bool ShouldPrintChecker::shouldPrint(const Decl *D,
   // Optionally skip these checks for extensions synthesized for '@_nonSendable'
   if (!Options.AlwaysPrintNonSendableExtensions || !isNonSendableExtension(D)) {
     if (Options.SkipImplicit && D->isImplicit()) {
-      const auto &IgnoreList = Options.TreatAsExplicitDeclList;
-      if (!llvm::is_contained(IgnoreList, D))
+      auto keepSynthesized = false;
+      if (Options.AlwaysPrintSynthesized) {
+        if (auto *VD = dyn_cast<ValueDecl>(D))
+          keepSynthesized = VD->isSynthesized();
+      }
+
+      auto keepAsExplicit =
+          llvm::is_contained(Options.TreatAsExplicitDeclList, D);
+
+      if (!keepSynthesized && !keepAsExplicit)
         return false;
     }
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -11536,13 +11536,14 @@ FuncDecl *FuncDecl::createImplicit(ASTContext &Context,
                                    bool Throws, Type ThrownType,
                                    GenericParamList *GenericParams,
                                    ParameterList *BodyParams, Type FnRetType,
-                                   DeclContext *Parent) {
+                                   DeclContext *Parent, bool isSynthesized) {
   assert(FnRetType);
   auto *const FD = FuncDecl::createImpl(
       Context, SourceLoc(), StaticSpelling, SourceLoc(), Name, NameLoc, Async,
       SourceLoc(), Throws, SourceLoc(), TypeLoc::withoutLoc(ThrownType),
       GenericParams, Parent, ClangNode());
   FD->setImplicit();
+  FD->setSynthesized(isSynthesized);
   FD->setParameters(BodyParams);
   FD->setResultInterfaceType(FnRetType);
   return FD;

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -6448,11 +6448,10 @@ static ValueDecl *cloneBaseMemberDecl(ValueDecl *decl, DeclContext *newContext,
     }
 
     auto out = FuncDecl::createImplicit(
-        context, fn->getStaticSpelling(), fn->getName(),
-        fn->getNameLoc(), fn->hasAsync(), fn->hasThrows(),
-        fn->getThrownInterfaceType(),
+        context, fn->getStaticSpelling(), fn->getName(), fn->getNameLoc(),
+        fn->hasAsync(), fn->hasThrows(), fn->getThrownInterfaceType(),
         fn->getGenericParams(), fn->getParameters(),
-        fn->getResultInterfaceType(), newContext);
+        fn->getResultInterfaceType(), newContext, /*isSynthesized=*/true);
     cloneImportedAttributes(decl, out);
     out->setAccess(access);
     inheritance.setUnavailableIfNecessary(decl, out);

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -482,6 +482,7 @@ void ClangImporter::Implementation::addSynthesizedTypealias(
   typealias->setUnderlyingType(underlyingType);
   typealias->setAccess(nominal->getFormalAccess());
   typealias->setImplicit();
+  typealias->setSynthesized();
 
   nominal->addMember(typealias);
 }
@@ -1894,6 +1895,7 @@ namespace {
                                         SourceLoc(), varName,
                                         enumDecl);
         rawValue->setImplicit();
+        rawValue->setSynthesized();
         rawValue->copyFormalAccessFrom(enumDecl);
         rawValue->setSetterAccess(AccessLevel::Private);
         rawValue->setInterfaceType(underlyingType);
@@ -5616,8 +5618,10 @@ namespace {
       // Mark class methods as static.
       if (decl->isClassMethod() || forceClassMethod)
         result->setStatic();
-      if (forceClassMethod)
+      if (forceClassMethod) {
         result->setImplicit();
+        result->setSynthesized();
+      }
 
       ClangImporter::Implementation::recordImplicitUnwrapForDecl(result, isIUO);
 
@@ -6073,6 +6077,7 @@ namespace {
             addObjCAttribute(result,
                             Impl.importIdentifier(decl->getIdentifier()));
             result->setImplicit();
+            result->setSynthesized();
             auto attr = AvailableAttr::createUniversallyUnavailable(
                 Impl.SwiftContext,
                 "This Objective-C protocol has only been forward-declared; "
@@ -6228,6 +6233,7 @@ namespace {
             auto result = createFakeClass(name, /* cacheResult */ true,
                                               /* inheritFromNSObject */ true);
             result->setImplicit();
+            result->setSynthesized();
             auto attr = AvailableAttr::createUniversallyUnavailable(
                 Impl.SwiftContext,
                 "This Objective-C class has only been forward-declared; "
@@ -7840,8 +7846,10 @@ ConstructorDecl *SwiftDeclConverter::importConstructor(
   ClangImporter::Implementation::recordImplicitUnwrapForDecl(
       result, importedType.isImplicitlyUnwrapped());
 
-  if (implicit)
+  if (implicit) {
     result->setImplicit();
+    result->setSynthesized();
+  }
 
   // Set the kind of initializer.
   result->getASTContext().evaluator.cacheOutput(InitKindRequest{result},

--- a/lib/ClangImporter/SwiftDeclSynthesizer.cpp
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.cpp
@@ -1422,6 +1422,7 @@ SwiftDeclSynthesizer::makeEnumRawValueConstructor(EnumDecl *enumDecl) {
                               /*ThrownType=*/TypeLoc(), paramPL,
                               /*GenericParams=*/nullptr, enumDecl);
   ctorDecl->setImplicit();
+  ctorDecl->setSynthesized();
   ctorDecl->copyFormalAccessFrom(enumDecl);
   ctorDecl->setBodySynthesizer(synthesizeEnumRawValueConstructorBody, enumDecl);
   return ctorDecl;
@@ -2078,7 +2079,7 @@ FuncDecl *SwiftDeclSynthesizer::makeSuccessorFunc(FuncDecl *incrementFunc) {
   auto result = FuncDecl::createImplicit(
       ctx, StaticSpellingKind::None, name, SourceLoc(),
       /*Async*/ false, /*Throws*/ false, /*ThrownType=*/Type(),
-      /*GenericParams*/ nullptr, params, returnTy, dc);
+      /*GenericParams*/ nullptr, params, returnTy, dc, /*isSynthesized=*/true);
 
   result->copyFormalAccessFrom(incrementFunc);
   result->setIsDynamic(false);
@@ -2420,9 +2421,10 @@ SwiftDeclSynthesizer::makeOperator(FuncDecl *operatorMethod,
 
   auto topLevelStaticFuncDecl = FuncDecl::createImplicit(
       ctx, StaticSpellingKind::None, opDeclName, SourceLoc(),
-      /*Async*/ false, /*Throws*/ false, /*ThrownType=*/Type(), 
+      /*Async*/ false, /*Throws*/ false, /*ThrownType=*/Type(),
       genericParamList, ParameterList::create(ctx, newParams),
-      operatorMethod->getResultInterfaceType(), parentCtx);
+      operatorMethod->getResultInterfaceType(), parentCtx,
+      /*isSynthesized=*/true);
 
   topLevelStaticFuncDecl->copyFormalAccessFrom(operatorMethod);
   topLevelStaticFuncDecl->setIsDynamic(false);

--- a/lib/DriverTool/swift_synthesize_interface_main.cpp
+++ b/lib/DriverTool/swift_synthesize_interface_main.cpp
@@ -280,6 +280,10 @@ int swift_synthesize_interface_main(ArrayRef<const char *> Args,
     printOpts.FullyQualifiedTypes = true;
   }
 
+  // Show user-facing synthesized members but do not show other implicit decls
+  printOpts.SkipImplicit = true;
+  printOpts.AlwaysPrintSynthesized = true;
+
   swift::OptionSet<swift::ide::ModuleTraversal> traversalOpts = std::nullopt;
   if (ParsedArgs.hasArg(OPT_include_submodules)) {
     traversalOpts = swift::ide::ModuleTraversal::VisitSubmodules;

--- a/lib/DriverTool/swift_synthesize_interface_main.cpp
+++ b/lib/DriverTool/swift_synthesize_interface_main.cpp
@@ -15,6 +15,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "swift/AST/ASTPrinter.h"
+#include "swift/AST/AttrKind.h"
 #include "swift/AST/DiagnosticsFrontend.h"
 #include "swift/AST/SearchPathOptions.h"
 #include "swift/Basic/LLVM.h"
@@ -29,6 +30,8 @@
 #include "swift/Parse/ParseVersion.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringSwitch.h"
+#include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/raw_ostream.h"
 
@@ -160,8 +163,8 @@ int swift_synthesize_interface_main(ArrayRef<const char *> Args,
 
   Invocation.getLangOptions().EnableObjCInterop = Target.isOSDarwin();
   Invocation.getLangOptions().AttachCommentsToDecls = true;
-  Invocation.getLangOptions().setCxxInteropFromArgs(ParsedArgs, Diags,
-                                                    Invocation.getFrontendOptions());
+  Invocation.getLangOptions().setCxxInteropFromArgs(
+      ParsedArgs, Diags, Invocation.getFrontendOptions());
   Invocation.computeCXXStdlibOptions();
 
   if (ParsedArgs.hasArg(OPT_disable_safe_interop_wrappers))
@@ -203,7 +206,8 @@ int swift_synthesize_interface_main(ArrayRef<const char *> Args,
     return EXIT_FAILURE;
   }
 
-  (void)CI.getMainModule(); // clang modules inherit default imports from main module
+  (void)CI.getMainModule(); // clang modules inherit default imports from main
+                            // module
   auto M = CI.getASTContext().getModuleByName(ModuleName);
   if (!M) {
     llvm::errs() << "Couldn't load module '" << ModuleName << '\''
@@ -283,6 +287,116 @@ int swift_synthesize_interface_main(ArrayRef<const char *> Args,
   // Show user-facing synthesized members but do not show other implicit decls
   printOpts.SkipImplicit = true;
   printOpts.AlwaysPrintSynthesized = true;
+
+  // -synthesized-interface-show=<list> and -minimum-access-level
+  //
+  // Items within a single comma-separated list are additive. Repeated
+  // -synthesized-interface-show= invocations follow last-wins semantics:
+  // each invocation resets the show state before applying its items.
+  std::optional<AccessLevel> MinAccessLevel;
+  struct Opts {
+    bool ShowUnavailable = false;
+    bool ShowImplicitAttrs = false;
+    bool ShowQualifiedTypes = false;
+    bool ShowCompilerInternals = false;
+
+    bool apply(StringRef name) {
+      if (name == "unavailable") {
+        ShowUnavailable = true;
+        return true;
+      }
+      if (name == "implicit-attrs") {
+        ShowImplicitAttrs = true;
+        return true;
+      }
+      if (name == "qualified-types") {
+        ShowQualifiedTypes = true;
+        return true;
+      }
+      if (name == "minimal") {
+        return true;
+      }
+      if (name == "all") {
+        ShowUnavailable = true;
+        ShowImplicitAttrs = true;
+        ShowQualifiedTypes = true;
+        return true;
+      }
+      if (name == "compiler-internal-details") {
+        ShowUnavailable = true;
+        ShowImplicitAttrs = true;
+        ShowQualifiedTypes = true;
+        ShowCompilerInternals = true;
+        return true;
+      }
+      return false;
+    }
+
+    static bool isShorthand(StringRef item) {
+      return item == "all" || item == "minimal" ||
+             item == "compiler-internal-details";
+    };
+  };
+
+  Opts opts{};
+
+  for (const auto *A : ParsedArgs.filtered(OPT_synthesize_interface_show,
+                                           OPT_minimum_access_level)) {
+    auto &Opt = A->getOption();
+    StringRef Value = A->getValue();
+    if (Opt.matches(OPT_minimum_access_level)) {
+      auto Parsed = llvm::StringSwitch<std::optional<AccessLevel>>(Value)
+                        .Case("private", AccessLevel::Private)
+                        .Case("fileprivate", AccessLevel::FilePrivate)
+                        .Case("internal", AccessLevel::Internal)
+                        .Case("package", AccessLevel::Package)
+                        .Case("public", AccessLevel::Public)
+                        .Case("open", AccessLevel::Open)
+                        .Default(std::nullopt);
+      if (!Parsed) {
+        Diags.diagnose(SourceLoc(), diag::error_invalid_arg_value,
+                       "-minimum-access-level", Value);
+        return EXIT_FAILURE;
+      }
+      MinAccessLevel = *Parsed;
+      continue;
+    }
+
+    if (Opt.matches(OPT_synthesize_interface_show)) {
+      opts = {}; // Reset state for last-win semantics across multiple args
+
+      if (Opts::isShorthand(Value)) {
+        // Shorthands cannot be combined with other item in the same list
+        opts.apply(Value);
+      } else {
+        SmallVector<StringRef, 2> Items;
+        Value.split(Items, ',', /*MaxSplit=*/-1, /*KeepEmpty=*/false);
+        for (auto Item : Items) {
+          if (Opts::isShorthand(Item) || !opts.apply(Item)) {
+            Diags.diagnose(SourceLoc(), diag::error_invalid_arg_value,
+                           "-synthesized-interface-show", Item);
+            return EXIT_FAILURE;
+          }
+        }
+      }
+      continue;
+    }
+    llvm_unreachable("unhandled arg");
+  }
+
+  printOpts.SkipUnavailable = !opts.ShowUnavailable;
+  printOpts.PrintImplicitAttrs = opts.ShowImplicitAttrs;
+  printOpts.QualifyImportedTypes = opts.ShowQualifiedTypes;
+  if (opts.ShowCompilerInternals) {
+    printOpts.SkipUnsafeCXXMethods = false;
+    printOpts.SkipImplicit = false;
+  }
+
+  if (MinAccessLevel) {
+    printOpts.AccessFilter = *MinAccessLevel;
+    if (printOpts.AccessFilter < AccessLevel::Public)
+      printOpts.PrintAccess = true;
+  }
 
   swift::OptionSet<swift::ide::ModuleTraversal> traversalOpts = std::nullopt;
   if (ParsedArgs.hasArg(OPT_include_submodules)) {

--- a/test/SynthesizeInterfaceTool/cxx-decls.swift
+++ b/test/SynthesizeInterfaceTool/cxx-decls.swift
@@ -1,0 +1,135 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: %target-swift-synthesize-interface -module-name CxxDecls -I %t/Inputs -cxx-interoperability-mode=default | %FileCheck %s
+// RUN: %target-swift-synthesize-interface -module-name CxxDeclsExtra -I %t/Inputs -cxx-interoperability-mode=default | %FileCheck %s --check-prefix=EXTRA
+
+//--- Inputs/module.modulemap
+module CxxDecls {
+  requires cplusplus
+  header "cxx-decls.h"
+}
+
+module CxxDeclsExtra {
+  requires cplusplus
+  header "cxx-decls-extra.h"
+}
+
+//--- Inputs/cxx-decls.h
+#pragma once
+
+struct Counter {
+  int value;
+  Counter operator+(Counter rhs) const { return Counter{value + rhs.value}; }
+  Counter &operator++() {
+    ++value;
+    return *this;
+  }
+};
+// `operator+` on a C++ struct is imported as a synthesized `static func +`
+// CHECK: public struct Counter {
+// CHECK:     public static func + (lhs: Counter, rhs: Counter) -> Counter
+// CHECK:     public func successor() -> Counter
+// CHECK: }
+
+struct Iter {
+  int *ptr;
+  int &operator*() const { return *ptr; }
+};
+
+// `operator*()` is imported as a synthesized `pointee` property
+// CHECK: public struct Iter {
+// CHECK:     public var pointee: Int32
+// CHECK: }
+
+struct Base {
+  int baseField;
+  void baseMethod() const {}
+};
+
+struct Derived : Base {
+  int derivedField;
+};
+
+// C++ public inheritance: `Derived` exposes `Base`'s field and method
+// alongside its own.
+// CHECK: public struct Derived {
+// CHECK:     public var baseField: Int32
+// CHECK:     public func baseMethod()
+// CHECK:     public var derivedField: Int32
+// CHECK: }
+
+enum class Status : int {
+  Active,
+  Inactive,
+};
+
+// A C++ scoped enum imports as a Swift enum with a synthesized
+// `init?(rawValue:)`, `rawValue` property, and `RawValue` typealias.
+// CHECK: public enum Status : Int32 {
+// CHECK:     public init?(rawValue: Int32)
+// CHECK:     public var rawValue: Int32 { get }
+// CHECK:     public typealias RawValue = Int32
+// CHECK:     case Active
+// CHECK:     case Inactive
+// CHECK: }
+
+namespace OuterNS {
+// A C++ namespace imports as a Swift enum at the module top level.
+// CHECK: public enum OuterNS {
+
+int globalFn(int x);
+// CHECK: public static func globalFn(_ x: Int32) -> Int32
+
+struct Nested {
+  int method() const { return field; }
+  int field;
+};
+// CHECK: public struct Nested {
+// CHECK:     public func method() -> Int32
+// CHECK:     public var field: Int32
+// CHECK: }
+
+namespace InnerNS {
+  int innerFn();
+}
+// CHECK: public enum InnerNS {
+// CHECK:     public static func innerFn() -> Int32
+// CHECK: }
+
+} // namespace OuterNS
+// CHECK: }
+
+namespace EmptyNS {}
+// Empty namespaces do not appear in output
+// CHECK-NOT: EmptyNS
+
+namespace SharedNS {
+  void fn1();
+  void fnShared();
+}
+
+// CxxDecls should only see its own contributions to `SharedNS`, not `fn2`
+// which is defined in another module
+// CHECK: enum SharedNS {
+// CHECK-NOT: fn2
+// CHECK:     func fn1()
+// CHECK:     func fnShared()
+// CHECK: }
+
+//--- Inputs/cxx-decls-extra.h
+#pragma once
+
+namespace SharedNS {
+  void fn2();
+  void fnShared();
+}
+
+#include <cxx-decls.h>
+
+// CxxDeclsExtra should only see its own contributions to `SharedNS`,
+// even if CxxDeclsExtra imports CxxDecls (which declares `SharedNS::fn1`)
+// EXTRA: enum SharedNS {
+// EXTRA-NOT: fn1
+// EXTRA:     func fn2()
+// EXTRA:     func fnShared()
+// EXTRA: }

--- a/test/SynthesizeInterfaceTool/objc-decls.swift
+++ b/test/SynthesizeInterfaceTool/objc-decls.swift
@@ -1,0 +1,37 @@
+// REQUIRES: objc_interop
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: %target-swift-synthesize-interface -module-name ObjCDecls -F %t/Inputs/Frameworks | %FileCheck %s
+
+//--- Inputs/Frameworks/ObjCDecls.framework/Modules/module.modulemap
+framework module ObjCDecls {
+  header "ObjCDecls.h"
+  export *
+}
+
+//--- Inputs/Frameworks/ObjCDecls.framework/Headers/ObjCDecls.h
+@import Foundation;
+
+__attribute__((objc_root_class))
+@interface RootThing
+- (void)greet;
+@end
+// Instance methods on root classes get mirrored as class methods
+// CHECK: open class RootThing {
+// CHECK:     open class func greet()
+// CHECK:     open func greet()
+// CHECK: }
+
+@protocol Greetable <NSObject>
+- (instancetype)initWithName:(NSString *)name;
+@end
+
+@interface Greetee : NSObject <Greetable>
+@end
+// When a class adopts a protocol with a required init, the init is mirrored
+// onto the class.
+// CHECK: open class Greetee : NSObject, Greetable {
+// CHECK:     public init()
+// CHECK:     public init!(name: String!)
+// CHECK: }


### PR DESCRIPTION
This patch set builds on #89312 to improve support for C++ interop users, for printing more of the API imported from Clang.

rdar://177579631

