### PR TITLE
[Utils] handle unrelated diagnostics in macro expansions

### DIFF
--- a/test/Utils/update-verify-tests/expansion-in-unrelated.swift
+++ b/test/Utils/update-verify-tests/expansion-in-unrelated.swift
@@ -3,10 +3,10 @@
 
 // RUN: not %target-swift-frontend -typecheck -plugin-path %swift-plugin-dir -I %t %t/test.swift \
 // RUN:   -verify -verify-ignore-unrelated -Rmacro-expansions 2> %t/output.txt
-// RUN: not %update-verify-tests < %t/output.txt 2>&1 | %FileCheck %s
-
-// CHECK: Error in update-verify-tests while parsing tool output: unhandled note found
-// CHECK-SAME: in expansion from here
+// RUN: %update-verify-tests < %t/output.txt
+// RUN: %target-swift-frontend -typecheck -plugin-path %swift-plugin-dir -I %t %t/test.swift \
+// RUN:   -verify -verify-ignore-unrelated -Rmacro-expansions
+// RUN: %diff %t/test.swift %t/test.swift.expected
 
 //--- module.modulemap
 module Unrelated {
@@ -23,5 +23,12 @@ void foo(const int * __counted_by(len) p, int len);
 import Unrelated
 
 func bar(_ s: Span<CInt>) {
+  foo(s)
+}
+//--- test.swift.expected
+import Unrelated
+
+func bar(_ s: Span<CInt>) {
+  // expected-error@+1{{cannot convert value of type 'Span<CInt>' (aka 'Span<Int32>') to expected argument type 'UnsafeBufferPointer<Int32>'}}
   foo(s)
 }

--- a/test/Utils/update-verify-tests/expansion-in-unrelated.swift
+++ b/test/Utils/update-verify-tests/expansion-in-unrelated.swift
@@ -1,0 +1,27 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: not %target-swift-frontend -typecheck -plugin-path %swift-plugin-dir -I %t %t/test.swift \
+// RUN:   -verify -verify-ignore-unrelated -Rmacro-expansions 2> %t/output.txt
+// RUN: not %update-verify-tests < %t/output.txt 2>&1 | %FileCheck %s
+
+// CHECK: Error in update-verify-tests while parsing tool output: unhandled note found
+// CHECK-SAME: in expansion from here
+
+//--- module.modulemap
+module Unrelated {
+  header "unrelated.h"
+  export *
+}
+
+//--- unrelated.h
+#define __counted_by(x) __attribute__((__counted_by__(x)))
+
+void foo(const int * __counted_by(len) p, int len);
+
+//--- test.swift
+import Unrelated
+
+func bar(_ s: Span<CInt>) {
+  foo(s)
+}

--- a/utils/update_verify_tests/core.py
+++ b/utils/update_verify_tests/core.py
@@ -759,7 +759,15 @@ def check_expectations(tool_output, prefix):
                 dprint(
                     f"diagnostic produced elsewhere (ignored): {line.strip()}"
                 )
-                extra_lines = tool_output[i + 1 : i + 3]
+                n_extra_lines = 3
+                if i + n_extra_lines < len(tool_output):
+                    next_line = tool_output[i + n_extra_lines]
+                    if diag_expansion_note_re.match(next_line.strip()):
+                        dprint(
+                            f"expansion note (ignored): {next_line.strip()}"
+                        )
+                        n_extra_lines += 1
+                extra_lines = tool_output[i + 1 : i + n_extra_lines]
             elif not "error:" in line:
                 if "note:" in line:
                     if m := diag_not_parsed_note_re.match(line.strip()):


### PR DESCRIPTION
This swallows the expansion note for "diagnostic produced elsewhere"
messages, when the diagnostic was emitted from a macro expansion.