### PR TITLE
[6.4] LoopInvariantCodeMotion: fix an ownership error caused by hoisting trivial sub-projection loads

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LoopInvariantCodeMotion.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LoopInvariantCodeMotion.swift
@@ -857,7 +857,7 @@ private extension MovableInstructions {
       }
     
       let builder = Builder(before: loadInst, context)
-      let projection = if loadInst.loadOwnership == .copy {
+      let projection = if loadInst.loadOwnership == .copy || loadInst.loadOwnership == .trivial {
         rootVal.createProjectionAndCopy(path: projectionPath, builder: builder)
       } else {
         rootVal.createProjection(path: projectionPath, builder: builder)

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LoopInvariantCodeMotion.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LoopInvariantCodeMotion.swift
@@ -764,13 +764,9 @@ private extension MovableInstructions {
       return false
     }
 
-    // We currently don't support split `load [take]`, i.e. `load [take]` which does _not_ load all
-    // non-trivial fields of the initial value.
+    // We currently don't support split `load [take]`.
     for case let load as LoadInst in loadsAndStores {
-      if load.loadOwnership == .take,
-         let path = accessPath.getProjection(to: load.address.accessPath),
-         !firstStore.destination.type.isProjectingEntireNonTrivialMembers(path: path, in: load.parentFunction)
-      {
+      if load.loadOwnership == .take, load.address.accessPath != accessPath {
         return false
       }
     }
@@ -927,35 +923,6 @@ private extension MovableInstructions {
       worklist.pushSuccessors(of: inst)
     }
     return true
-  }
-}
-
-private extension Type {
-  func isProjectingEntireNonTrivialMembers(path: SmallProjectionPath, in function: Function) -> Bool {
-    let (kind, index, subPath) = path.pop()
-    switch kind {
-    case .root:
-      return true
-    case .structField:
-      guard let fields = getNominalFields(in: function) else {
-        return false
-      }
-      for (fieldIdx, fieldType) in fields.enumerated() {
-        if fieldIdx != index && !fieldType.isTrivial(in: function) {
-          return false
-        }
-      }
-      return fields[index].isProjectingEntireNonTrivialMembers(path: subPath, in: function)
-    case .tupleField:
-      for (elementIdx, elementType) in tupleElements.enumerated() {
-        if elementIdx != index && !elementType.isTrivial(in: function) {
-          return false
-        }
-      }
-      return tupleElements[index].isProjectingEntireNonTrivialMembers(path: subPath, in: function)
-    default:
-      fatalError("path is not materializable")
-    }
   }
 }
 

--- a/test/SILOptimizer/licm.sil
+++ b/test/SILOptimizer/licm.sil
@@ -2037,10 +2037,9 @@ bb3:
 }
 
 // CHECK-LABEL: sil [ossa] @projected_load_take :
-// CHECK:       bb1([[V:%.*]] : @owned $(S, Int)):
-// CHECK-NEXT:    ([[E:%.*]], {{%[0-9]+}}) = destructure_tuple [[V]]
-// CHECK-NEXT:    ({{%[0-9]+}}, [[S:%.*]]) = destructure_struct [[E]]
-// CHECK-NEXT:    = struct $S (%1 : $Int, [[S]] : $String)
+// CHECK:       bb1:
+// CHECK:         load [take]
+// CHECK:         store
 // CHECK-LABEL: } // end sil function 'projected_load_take'
 sil [ossa] @projected_load_take : $@convention(thin) (@inout (S, Int), Int) -> () {
 bb0(%0 : $*(S, Int), %1 : $Int):
@@ -2050,9 +2049,11 @@ bb1:
   %2 = tuple_element_addr %0, 0
   %3 = struct_element_addr %2, #S.s
   %4 = load [take] %3
-  %5 = struct $S (%1, %4)
-  %6 = tuple (%5, %1)
-  store %6 to [init] %0
+  %5 = struct_element_addr %2, #S.i
+  %6 = load [trivial] %5
+  %7 = struct $S (%6, %4)
+  %8 = tuple (%7, %1)
+  store %8 to [init] %0
   cond_br undef, bb2, bb3
 
 bb2:
@@ -2090,14 +2091,9 @@ bb3:
 }
 
 // CHECK-LABEL: sil [ossa] @projected_load_copy_followed_by_take :
-// CHECK:       bb1([[V:%.*]] : @owned $S):
-// CHECK-NEXT:    [[B:%.*]] = begin_borrow [[V]]
-// CHECK-NEXT:    [[SE:%.*]] = struct_extract [[B]]
-// CHECK-NEXT:    [[C:%.*]] = copy_value [[SE]]
-// CHECK-NEXT:    end_borrow [[B]]
-// CHECK-NEXT:    destroy_value [[C]]
-// CHECK-NEXT:    ({{%[0-9]+}}, [[S:%.*]]) = destructure_struct [[V]]
-// CHECK-NEXT:      = struct $S (%1 : $Int, [[S]] : $String)
+// CHECK:       bb1:
+// CHECK:         load [copy]
+// CHECK:         load [take]
 // CHECK-LABEL: } // end sil function 'projected_load_copy_followed_by_take'
 sil [ossa] @projected_load_copy_followed_by_take : $@convention(thin) (@inout S, Int) -> () {
 bb0(%0 : $*S, %1 : $Int):

--- a/test/SILOptimizer/licm.sil
+++ b/test/SILOptimizer/licm.sil
@@ -29,6 +29,12 @@ struct S2 {
   var s2: String
 }
 
+struct S3 {
+  var i: Int
+  var j: Int
+  var s: String
+}
+
 struct Pair  {
   var t: (a: Int, b: Int)
 }
@@ -2256,5 +2262,102 @@ bb4:
 
 bb5:
   return %0
+}
+
+// Sub-projection `load [trivial]` co-occurring with a whole-value `load [take]`
+// on an owned access path. LICM emits a borrow + extract + end_borrow for the
+// sub-projection and consumes rootVal via the whole-value path's destroy_value.
+// CHECK-LABEL: sil [ossa] @subproj_trivial_plus_whole_take_owned :
+// CHECK:       bb1([[V:%.*]] : @owned $S2):
+// CHECK-NEXT:    [[B:%.*]] = begin_borrow [[V]]
+// CHECK-NEXT:    [[SE:%.*]] = struct_extract [[B]] : $S2, #S2.i
+// CHECK-NEXT:    end_borrow [[B]]
+// CHECK-NEXT:    destroy_value [[V]]
+// CHECK-NOT:   destructure_struct
+// CHECK-LABEL: } // end sil function 'subproj_trivial_plus_whole_take_owned'
+sil [ossa] @subproj_trivial_plus_whole_take_owned : $@convention(thin) (@inout S2, @owned S2) -> () {
+bb0(%0 : $*S2, %1 : @owned $S2):
+  br bb1
+
+bb1:
+  %2 = struct_element_addr %0, #S2.i
+  %3 = load [trivial] %2
+  %4 = load [take] %0
+  destroy_value %4
+  %5 = copy_value %1
+  store %5 to [init] %0
+  cond_br undef, bb2, bb3
+
+bb2:
+  br bb1
+
+bb3:
+  destroy_value %1
+  %r = tuple ()
+  return %r
+}
+
+// CHECK-LABEL: sil @subproj_non_trivial_non_ossa :
+// CHECK:       bb1([[V:%.*]] : $S2):
+// CHECK-NEXT:    [[SE:%.*]] = struct_extract [[V]] : $S2, #S2.s1
+// CHECK-NEXT:    release_value [[SE]]
+// CHECK-LABEL: } // end sil function 'subproj_non_trivial_non_ossa'
+sil @subproj_non_trivial_non_ossa : $@convention(thin) (@inout S2, @owned S2) -> () {
+bb0(%0 : $*S2, %1 : $S2):
+  br bb1
+
+bb1:
+  %2 = struct_element_addr %0, #S2.s1
+  %3 = load %2
+  release_value %3
+  retain_value %1
+  store %1 to %0
+  cond_br undef, bb2, bb3
+
+bb2:
+  br bb1
+
+bb3:
+  release_value %1
+  %r = tuple ()
+  return %r
+}
+
+// Two distinct trivial sub-projection loads of an owned access path in one
+// block. LICM emits a borrow + extract + end_borrow per load and one
+// destroy_value of the source rootVal.
+// CHECK-LABEL: sil [ossa] @multi_trivial_subproj_owned :
+// CHECK:       bb1([[V:%.*]] : @owned $S3):
+// CHECK-NEXT:    [[B1:%.*]] = begin_borrow [[V]]
+// CHECK-NEXT:    [[SE1:%.*]] = struct_extract [[B1]] : $S3, #S3.i
+// CHECK-NEXT:    end_borrow [[B1]]
+// CHECK-NEXT:    [[B2:%.*]] = begin_borrow [[V]]
+// CHECK-NEXT:    [[SE2:%.*]] = struct_extract [[B2]] : $S3, #S3.j
+// CHECK-NEXT:    end_borrow [[B2]]
+// CHECK-NEXT:    destroy_value [[V]]
+// CHECK-NOT:   destructure_struct
+// CHECK-LABEL: } // end sil function 'multi_trivial_subproj_owned'
+sil [ossa] @multi_trivial_subproj_owned : $@convention(thin) (@inout S3, @owned S3) -> () {
+bb0(%0 : $*S3, %1 : @owned $S3):
+  br bb1
+
+bb1:
+  %2 = struct_element_addr %0, #S3.i
+  %3 = load [trivial] %2
+  %4 = struct_element_addr %0, #S3.j
+  %5 = load [trivial] %4
+  %6 = load [take] %0
+  destroy_value %6
+  %7 = copy_value %1
+  store %7 to [init] %0
+  cond_br undef, bb2, bb3
+
+bb2:
+  br bb1
+
+bb3:
+  destroy_value %1
+  %r = tuple ()
+  return %r
 }
 

--- a/test/SILOptimizer/ossa_overconsume_substring_inout_loop_crash.swift
+++ b/test/SILOptimizer/ossa_overconsume_substring_inout_loop_crash.swift
@@ -1,0 +1,19 @@
+// RUN: %target-swift-frontend -O -c -parse-as-library -module-name repro %s -o %t.o
+
+// REQUIRES: swift_in_compiler
+
+// https://github.com/swiftlang/swift/issues/89255
+// SIL ownership verifier rejects the optimized SIL for a simple inout-Substring
+// loop with "Found over consume?!" / "Found ownership error?!" during the
+// OwnershipModelEliminator pass. Regression after swift-6.3.1-RELEASE.
+
+public func f(_ s: inout Substring, _ b: Bool) -> Substring? {
+    while !s.isEmpty {
+        let c = s; var i = c.startIndex; var x: Substring.Index?
+        while i < c.endIndex { if b { x = i }; c.formIndex(after: &i) }
+        s = ""
+        guard let x else { continue }
+        return c[..<x]
+    }
+    return nil
+}


### PR DESCRIPTION
* **Explanation**: If `load [trivial]` only loads a "part" of a stored value, which itself is non-trivial, the pass crashes with an ownership error. The fix is to wrap the projection instructions (e.g. `struct_extract`) inside a borrow scope. This is correctly done in `createProjectionAndCopy`. Also, fix a crash when trying to hoist a projected `load [take]`. So far we supported hoisting a `load [take]` which "takes" just a part of a stored value (i.e. a projected value). This works as long as no other struct/tuple field is also loaded in the loop. If this is the case it causes an ownership error. The fix is to disallow hoisting projected `load [take]` instructions.
* **Risk**: Low. It's a small change which only affects code which would otherwise cause a crash
* **Testing**: by lit tests
* **Issue**: https://github.com/swiftlang/swift/issues/89255, rdar://177430359
* **Reviewers**: @MaxDesiatov 
* **Main branch PR**: https://github.com/swiftlang/swift/pull/89315
