### PR TITLE
IRGen: Address upstream llvm rename

### DIFF
--- a/lib/IRGen/IRGen.h
+++ b/lib/IRGen/IRGen.h
@@ -332,7 +332,7 @@ public:
   template<unsigned Value>
   static constexpr Alignment create() {
     Alignment result;
-    result.Shift = llvm::CTLog2<Value>();
+    result.Shift = llvm::ConstantLog2<Value>();
     return result;
   }
 


### PR DESCRIPTION
See https://github.com/llvm/llvm-project/pull/158006. Cherry-picked in https://github.com/swiftlang/llvm-project/pull/13036 to enable this change, to avoid a non-essential difference between main and rebranch.