### PR TITLE
[Macros] Don't send Syntax.Kind.accessor to plugins with protocol < 8

### DIFF
--- a/lib/ASTGen/Sources/MacroEvaluation/Macros.swift
+++ b/lib/ASTGen/Sources/MacroEvaluation/Macros.swift
@@ -507,12 +507,17 @@ func expandFreestandingMacroImpl(
 
   // Send the message.
   do {
+    let pluginProtocolVersion = macro.plugin.capability?.protocolVersion ?? 0
     let message = HostToPluginMessage.expandFreestandingMacro(
       macro: .init(moduleName: macro.moduleName, typeName: macro.typeName, name: macroName),
       macroRole: pluginMacroRole,
       discriminator: discriminator,
-      syntax: PluginMessage.Syntax(syntax: Syntax(expansionSyntax), in: sourceFilePtr)!,
-      lexicalContext: pluginLexicalContext(of: expansionSyntax),
+      syntax: PluginMessage.Syntax(
+        syntax: Syntax(expansionSyntax),
+        in: sourceFilePtr,
+        pluginProtocolVersion: pluginProtocolVersion
+      )!,
+      lexicalContext: pluginLexicalContext(of: expansionSyntax, pluginProtocolVersion: pluginProtocolVersion),
       staticBuildConfiguration: try cContext.staticBuildConfiguration.asJSON
     )
     let result = try macro.plugin.sendMessageAndWait(message)
@@ -642,8 +647,10 @@ private func lexicalContext(of node: some SyntaxProtocol) -> [Syntax] {
 
 /// Produce the full lexical context of the given node to pass along to
 /// macro expansion.
-private func pluginLexicalContext(of node: some SyntaxProtocol) -> [PluginMessage.Syntax] {
-  lexicalContext(of: node).compactMap { .init(syntax: $0) }
+private func pluginLexicalContext(of node: some SyntaxProtocol, pluginProtocolVersion: Int) -> [PluginMessage.Syntax] {
+  lexicalContext(of: node).compactMap {
+    .init(syntax: $0, pluginProtocolVersion: pluginProtocolVersion)
+  }
 }
 
 func expandAttachedMacroImpl(
@@ -682,6 +689,8 @@ func expandAttachedMacroImpl(
   }
 
   // Prepare syntax nodes to transfer.
+  let pluginProtocolVersion = macro.plugin.capability?.protocolVersion ?? 0
+
   let customAttributeSyntax = PluginMessage.Syntax(
     syntax: Syntax(customAttrNode),
     in: customAttrSourceFilePtr
@@ -689,12 +698,17 @@ func expandAttachedMacroImpl(
 
   let declSyntax = PluginMessage.Syntax(
     syntax: declarationNode,
-    in: declarationSourceFilePtr
+    in: declarationSourceFilePtr,
+    pluginProtocolVersion: pluginProtocolVersion
   )!
 
   let parentDeclSyntax: PluginMessage.Syntax?
   if parentDeclNode != nil {
-    parentDeclSyntax = .init(syntax: Syntax(parentDeclNode!), in: parentDeclSourceFilePtr!)!
+    parentDeclSyntax = .init(
+      syntax: Syntax(parentDeclNode!),
+      in: parentDeclSourceFilePtr!,
+      pluginProtocolVersion: pluginProtocolVersion
+    )!
   } else {
     parentDeclSyntax = nil
   }
@@ -730,7 +744,10 @@ func expandAttachedMacroImpl(
       parentDeclSyntax: parentDeclSyntax,
       extendedTypeSyntax: extendedTypeSyntax,
       conformanceListSyntax: conformanceListSyntax,
-      lexicalContext: pluginLexicalContext(of: declarationNode),
+      lexicalContext: pluginLexicalContext(
+        of: declarationNode,
+        pluginProtocolVersion: pluginProtocolVersion
+      ),
       staticBuildConfiguration: try cContext.staticBuildConfiguration.asJSON
     )
     let expandedSource: String?

--- a/lib/ASTGen/Sources/MacroEvaluation/PluginHost.swift
+++ b/lib/ASTGen/Sources/MacroEvaluation/PluginHost.swift
@@ -393,10 +393,10 @@ extension String {
 }
 
 extension PluginMessage.Syntax {
-  init?(syntax: Syntax, in sourceFilePtr: UnsafePointer<ExportedSourceFile>) {
+  init?(syntax: Syntax, in sourceFilePtr: UnsafePointer<ExportedSourceFile>, pluginProtocolVersion: Int = PluginMessage.PROTOCOL_VERSION_NUMBER) {
     let kind: PluginMessage.Syntax.Kind
     switch true {
-    case syntax.is(AccessorDeclSyntax.self): kind = .accessor
+    case syntax.is(AccessorDeclSyntax.self): kind = pluginProtocolVersion >= 8 ? .accessor : .declaration
     case syntax.is(DeclSyntax.self): kind = .declaration
     case syntax.is(ExprSyntax.self): kind = .expression
     case syntax.is(StmtSyntax.self): kind = .statement
@@ -424,10 +424,10 @@ extension PluginMessage.Syntax {
     )
   }
 
-  init?(syntax: Syntax) {
+  init?(syntax: Syntax, pluginProtocolVersion: Int = PluginMessage.PROTOCOL_VERSION_NUMBER) {
     let kind: PluginMessage.Syntax.Kind
     switch true {
-    case syntax.is(AccessorDeclSyntax.self): kind = .accessor
+    case syntax.is(AccessorDeclSyntax.self): kind = pluginProtocolVersion >= 8 ? .accessor : .declaration
     case syntax.is(DeclSyntax.self): kind = .declaration
     case syntax.is(ExprSyntax.self): kind = .expression
     case syntax.is(StmtSyntax.self): kind = .statement

--- a/test/Macros/macro_plugin_accessor_syntax_kind.swift
+++ b/test/Macros/macro_plugin_accessor_syntax_kind.swift
@@ -1,0 +1,74 @@
+// REQUIRES: swift_swift_parser
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %swift-build-c-plugin -o %t/mock-plugin-v7 %t/plugin-v7.c
+// RUN: %swift-build-c-plugin -o %t/mock-plugin-v8 %t/plugin-v8.c
+
+// With protocol version 7 (< 8), AccessorDeclSyntax in the lexical context must
+// be sent as "kind":"declaration" (the "accessor" kind is unknown to the plugin).
+// RUN: env SWIFT_DUMP_PLUGIN_MESSAGING=1 %target-swift-frontend \
+// RUN:   -typecheck \
+// RUN:   -swift-version 5 \
+// RUN:   -load-plugin-executable %t/mock-plugin-v7#TestPlugin \
+// RUN:   -module-name MyApp \
+// RUN:   %t/test.swift \
+// RUN:   > %t/output-v7.txt 2>&1
+// RUN: %FileCheck -check-prefix=CHECK-V7 %s < %t/output-v7.txt
+
+// With protocol version 8, AccessorDeclSyntax in the lexical context must be
+// sent as "kind":"accessor".
+// RUN: env SWIFT_DUMP_PLUGIN_MESSAGING=1 %target-swift-frontend \
+// RUN:   -typecheck \
+// RUN:   -swift-version 5 \
+// RUN:   -load-plugin-executable %t/mock-plugin-v8#TestPlugin \
+// RUN:   -module-name MyApp \
+// RUN:   %t/test.swift \
+// RUN:   > %t/output-v8.txt 2>&1
+// RUN: %FileCheck -check-prefix=CHECK-V8 %s < %t/output-v8.txt
+
+// The accessor is the innermost lexical context, so it's the first element.
+// CHECK-V7:     "lexicalContext":[{"kind":"declaration",
+// CHECK-V7-NOT: "kind":"accessor"
+
+// CHECK-V8: "lexicalContext":[{"kind":"accessor",
+
+//--- test.swift
+@freestanding(expression) macro testMacro() -> Int = #externalMacro(module: "TestPlugin", type: "TestMacro")
+
+struct S {
+  var x: Int {
+    get { #testMacro() }
+  }
+}
+
+//--- plugin-v7.c
+#include "swift-c/MockPlugin/MockPlugin.h"
+
+MOCK_PLUGIN([
+  {
+    "expect": {"getCapability": {}},
+    "response": {"getCapabilityResult": {"capability": {"protocolVersion": 7}}}
+  },
+  {
+    "expect": {"expandFreestandingMacro": {
+                "macro": {"moduleName": "TestPlugin", "typeName": "TestMacro"}}},
+    "response": {"expandFreestandingMacroResult": {"expandedSource": "0", "diagnostics": []}}
+  }
+])
+
+//--- plugin-v8.c
+#include "swift-c/MockPlugin/MockPlugin.h"
+
+MOCK_PLUGIN([
+  {
+    "expect": {"getCapability": {}},
+    "response": {"getCapabilityResult": {"capability": {"protocolVersion": 8}}}
+  },
+  {
+    "expect": {"expandFreestandingMacro": {
+                "macro": {"moduleName": "TestPlugin", "typeName": "TestMacro"}}},
+    "response": {"expandFreestandingMacroResult": {"expandedSource": "0", "diagnostics": []}}
+  }
+])


### PR DESCRIPTION
`PluginMessage.Syntax.Kind.accessor` was introduced in swift-syntax protocol version 8. Plugins on an older version don't have this case in their decoder, so sending it would cause a JSON decode failure on the plugin side.

Thread `pluginProtocolVersion` (read from the plugin's capability response) through the two `PluginMessage.Syntax` initialisers in `PluginHost.swift` and through `pluginLexicalContext(of:)` in `Macros.swift`. When the plugin's version is less than 8, downgrade `AccessorDeclSyntax` nodes to `"kind":"declaration"` — safe because `AccessorDeclSyntax` conforms to `DeclSyntaxProtocol` and the old plugin will parse it via `DeclSyntax.parse(from:)`.

(corresponding to https://github.com/swiftlang/swift-syntax/pull/3339)

rdar://177377637