### PR TITLE
Implement missing instruction use/def handling for Opaque Values

### DIFF
--- a/lib/SILOptimizer/Mandatory/AddressLowering.cpp
+++ b/lib/SILOptimizer/Mandatory/AddressLowering.cpp
@@ -1040,8 +1040,15 @@ static Operand *getReusedStorageOperand(SILValue value) {
   case ValueKind::OpenExistentialValueInst:
   case ValueKind::OpenExistentialBoxValueInst:
   case ValueKind::UncheckedEnumDataInst:
-  case ValueKind::UncheckedBitwiseCastInst:
     return &cast<SingleValueInstruction>(value)->getOperandRef(0);
+
+  case ValueKind::UncheckedBitwiseCastInst: {
+    auto *castInst = cast<SingleValueInstruction>(value);
+    if (!castInst->getOperand(0)->getType().isAddressOnly(
+            *castInst->getFunction()))
+      return nullptr;
+    return &castInst->getOperandRef(0);
+  }
 
   case ValueKind::SILPhiArgument: {
     if (auto *term = cast<SILPhiArgument>(value)->getTerminatorForResult()) {
@@ -4234,6 +4241,31 @@ protected:
     // results, and generating a new apply instruction.
     CallArgRewriter(applyInst, pass).rewriteArguments();
     ApplyRewriter(applyInst, pass).convertApplyWithIndirectResults();
+  }
+
+  void rewriteOpaqueUncheckedCastDef(SingleValueInstruction *uncheckedCast) {
+    SILValue srcVal = uncheckedCast->getOperand(0);
+    assert(!srcVal->getType().isAddressOnly(*pass.function) &&
+           "opaque operand should share storage via getReusedStorageOperand");
+
+    addrMat.materializeAddress(uncheckedCast);
+    SILValue destAddr = storage.storageAddress;
+    auto loc = uncheckedCast->getLoc();
+    SILValue srcView = builder.createUncheckedAddrCast(
+        loc, destAddr, srcVal->getType().getAddressType());
+    auto qual = srcVal->getType().isTrivial(*pass.function)
+                    ? StoreOwnershipQualifier::Trivial
+                    : StoreOwnershipQualifier::Init;
+    builder.createStore(loc, srcVal, srcView, qual);
+    storage.markRewritten();
+  }
+
+  void visitUncheckedBitwiseCastInst(UncheckedBitwiseCastInst *uncheckedCast) {
+    rewriteOpaqueUncheckedCastDef(uncheckedCast);
+  }
+
+  void visitUncheckedValueCastInst(UncheckedValueCastInst *uncheckedCast) {
+    rewriteOpaqueUncheckedCastDef(uncheckedCast);
   }
 
   void visitBeginApplyInst(BeginApplyInst *bai) {

--- a/lib/SILOptimizer/Mandatory/AddressLowering.cpp
+++ b/lib/SILOptimizer/Mandatory/AddressLowering.cpp
@@ -4293,6 +4293,16 @@ protected:
 
   void visitBuiltinInst(BuiltinInst *bi) {
     switch (bi->getBuiltinKind().value_or(BuiltinValueKind::None)) {
+    case BuiltinValueKind::ZeroInitializer: {
+      // Value-form `builtin "zeroInitializer"() : $T` with an opaque T.
+      assert(bi->getNumOperands() == 0 &&
+             "address-form zeroInitializer should not appear as an opaque def");
+      addrMat.materializeAddress(bi);
+      SILValue destAddr = storage.storageAddress;
+      builder.createZeroInitAddr(bi->getLoc(), destAddr);
+      storage.markRewritten();
+      break;
+    }
     default:
       bi->dump();
       llvm::report_fatal_error("^^^ Unimplemented builtin opaque value def.");

--- a/lib/SILOptimizer/Mandatory/AddressLowering.cpp
+++ b/lib/SILOptimizer/Mandatory/AddressLowering.cpp
@@ -1022,7 +1022,12 @@ static Operand *getProjectedDefOperand(SILValue value) {
 /// is address-only, then the operand must be address-only and therefore must
 /// mapped to ValueStorage.
 ///
-/// If \p value is an unchecked_bitwise_cast, then return the cast operand.
+/// If \p value is an unchecked_bitwise_cast or unchecked_value_cast with an
+/// address-only source operand, then return the cast operand. When the source
+/// operand is loadable, return nullptr instead: the cast result needs its own
+/// storage so the loadable source value can be stored into an
+/// unchecked_addr_cast view of that storage. The DefRewriter handles this
+/// case.
 ///
 /// open_existential_value must reuse storage because the boxed value is shared
 /// with other instances of the existential. An explicit copy is needed to
@@ -1042,7 +1047,12 @@ static Operand *getReusedStorageOperand(SILValue value) {
   case ValueKind::UncheckedEnumDataInst:
     return &cast<SingleValueInstruction>(value)->getOperandRef(0);
 
+  case ValueKind::UncheckedValueCastInst:
   case ValueKind::UncheckedBitwiseCastInst: {
+    // Only share storage when the source is address-only. A loadable source
+    // has no ValueStorage to share; the DefRewriter materializes fresh storage
+    // for the cast result and stores the loadable source through an
+    // unchecked_addr_cast view.
     auto *castInst = cast<SingleValueInstruction>(value);
     if (!castInst->getOperand(0)->getType().isAddressOnly(
             *castInst->getFunction()))
@@ -3771,9 +3781,8 @@ protected:
   // Extract from an opaque pack tuple.
   void visitTuplePackExtractInst(TuplePackExtractInst *extractInst);
 
-  void
-  visitUncheckedBitwiseCastInst(UncheckedBitwiseCastInst *uncheckedCastInst) {
-    SILValue srcVal = uncheckedCastInst->getOperand();
+  void rewriteOpaqueUncheckedCastUse(SingleValueInstruction *uncheckedCastInst) {
+    SILValue srcVal = uncheckedCastInst->getOperand(0);
     SILValue srcAddr = pass.valueStorageMap.getStorage(srcVal).storageAddress;
 
     auto destAddr = builder.createUncheckedAddrCast(
@@ -3800,6 +3809,15 @@ protected:
     uncheckedCastInst->replaceAllUsesWith(load);
     pass.deleter.forceDelete(uncheckedCastInst);
     emitEndBorrows(load, pass);
+  }
+
+  void
+  visitUncheckedBitwiseCastInst(UncheckedBitwiseCastInst *uncheckedCastInst) {
+    rewriteOpaqueUncheckedCastUse(uncheckedCastInst);
+  }
+
+  void visitUncheckedValueCastInst(UncheckedValueCastInst *uncheckedCastInst) {
+    rewriteOpaqueUncheckedCastUse(uncheckedCastInst);
   }
 
   void visitUnconditionalCheckedCastInst(

--- a/lib/SILOptimizer/Mandatory/AddressLowering.cpp
+++ b/lib/SILOptimizer/Mandatory/AddressLowering.cpp
@@ -972,6 +972,10 @@ static Operand *getProjectedDefOperand(SILValue value) {
   case ValueKind::MarkUnresolvedNonCopyableValueInst:
     return &cast<MarkUnresolvedNonCopyableValueInst>(value)->getOperandRef();
 
+  case ValueKind::MarkDependenceInst:
+    return &cast<MarkDependenceInst>(value)
+                ->getAllOperands()[MarkDependenceInst::Dependent];
+
   case ValueKind::MoveValueInst:
     return &cast<MoveValueInst>(value)->getOperandRef();
 
@@ -3559,6 +3563,29 @@ protected:
     SILValue address = pass.valueStorageMap.getStorage(value).storageAddress;
     builder.createFixLifetime(fli->getLoc(), address);
     pass.deleter.forceDelete(fli);
+  }
+
+  void visitMarkDependenceInst(MarkDependenceInst *mdi) {
+    if (use->getOperandNumber() == MarkDependenceInst::Base) {
+      SILValue baseAddr = addrMat.materializeAddress(use->get());
+      mdi->setBase(baseAddr);
+      return;
+    }
+    assert(use->getOperandNumber() == MarkDependenceInst::Dependent);
+    SILValue valueAddr =
+        pass.valueStorageMap.getStorage(use->get()).storageAddress;
+    builder.createMarkDependenceAddr(mdi->getLoc(), valueAddr, mdi->getBase(),
+                                     mdi->dependenceKind());
+    markRewritten(mdi, valueAddr);
+  }
+
+  void visitMarkDependenceAddrInst(MarkDependenceAddrInst *mdai) {
+    if (use->getOperandNumber() != MarkDependenceAddrInst::Base) {
+      visitSILInstruction(mdai);
+      return;
+    }
+    SILValue baseAddr = addrMat.materializeAddress(use->get());
+    mdai->setBase(baseAddr);
   }
 
   void visitBranchInst(BranchInst *) {

--- a/test/SILOptimizer/address_lowering.sil
+++ b/test/SILOptimizer/address_lowering.sil
@@ -2724,6 +2724,36 @@ bb0:
   return %5
 }
 
+// CHECK-LABEL: sil hidden [ossa] @test_mark_dependence_addr_dep_opaque_base :
+// CHECK:       bb0(%0 : $*U):
+// CHECK:         [[STK:%[^,]+]] = alloc_stack $T
+// CHECK:         mark_dependence [unresolved] [[STK]] : $*T on %0 : $*U
+// CHECK:         dealloc_stack [[STK]]
+// CHECK-LABEL: } // end sil function 'test_mark_dependence_addr_dep_opaque_base'
+sil hidden [ossa] @test_mark_dependence_addr_dep_opaque_base : $@convention(thin) <T, U> (@in_guaranteed U) -> () {
+bb0(%0 : @guaranteed $U):
+  %1 = alloc_stack $T
+  %2 = mark_dependence [unresolved] %1 : $*T on %0 : $U
+  dealloc_stack %1 : $*T
+  %3 = tuple ()
+  return %3 : $()
+}
+
+// CHECK-LABEL: sil hidden [ossa] @test_mark_dependence_opaque_dep_opaque_base :
+// CHECK:       bb0(%0 : $*T, %1 : $*T, %2 : $*U):
+// CHECK:         [[STK:%[^,]+]] = alloc_stack $T
+// CHECK:         copy_addr %1 to [init] [[STK]] : $*T
+// CHECK:         mark_dependence_addr [unresolved] [[STK]] : $*T on %2 : $*U
+// CHECK:         copy_addr [take] [[STK]] to [init] %0 : $*T
+// CHECK:         dealloc_stack [[STK]]
+// CHECK-LABEL: } // end sil function 'test_mark_dependence_opaque_dep_opaque_base'
+sil hidden [ossa] @test_mark_dependence_opaque_dep_opaque_base : $@convention(thin) <T, U> (@in_guaranteed T, @in_guaranteed U) -> @out T {
+bb0(%0 : @guaranteed $T, %1 : @guaranteed $U):
+  %2 = copy_value %0 : $T
+  %3 = mark_dependence [unresolved] %2 : $T on %1 : $U
+  return %3 : $T
+}
+
 // CHECK-LABEL: sil [ossa] @test_mark_unresolved_non_copyable_value_1_consumable_and_assignable : {{.*}} {
 // CHECK:       bb0([[T:%[^,]+]] :
 // CHECK:         [[TP:%[^,]+]] = mark_unresolved_non_copyable_value [consumable_and_assignable] [[T]]

--- a/test/SILOptimizer/address_lowering.sil
+++ b/test/SILOptimizer/address_lowering.sil
@@ -3586,3 +3586,14 @@ bb2:
   unwind
 }
 
+// CHECK-LABEL: sil hidden [ossa] @test_zero_initializer_opaque :
+// CHECK:       bb0(%0 : $*T):
+// CHECK:         builtin "zeroInitializer"(%0 : $*T) : $()
+// CHECK:         return
+// CHECK-LABEL: } // end sil function 'test_zero_initializer_opaque'
+sil hidden [ossa] @test_zero_initializer_opaque : $@convention(thin) <T> () -> @out T {
+bb0:
+  %0 = builtin "zeroInitializer"() : $T
+  return %0 : $T
+}
+

--- a/test/SILOptimizer/address_lowering.sil
+++ b/test/SILOptimizer/address_lowering.sil
@@ -3146,6 +3146,21 @@ bb0(%0 : @owned $Klass):
   return %1 : $T
 }
 
+// CHECK-LABEL: sil hidden [ossa] @test_unchecked_value_cast_opaque :
+// CHECK:       bb0(%0 : $*U, %1 : $*T):
+// CHECK:         [[STK:%[^,]+]] = alloc_stack $T
+// CHECK:         copy_addr %1 to [init] [[STK]] : $*T
+// CHECK:         [[CAST:%[^,]+]] = unchecked_addr_cast [[STK]] : $*T to $*U
+// CHECK:         copy_addr [take] [[CAST]] to [init] %0 : $*U
+// CHECK:         dealloc_stack [[STK]]
+// CHECK-LABEL: } // end sil function 'test_unchecked_value_cast_opaque'
+sil hidden [ossa] @test_unchecked_value_cast_opaque : $@convention(thin) <T, U> (@in_guaranteed T) -> @out U {
+bb0(%0 : @guaranteed $T):
+  %1 = copy_value %0 : $T
+  %2 = unchecked_value_cast %1 : $T to $U
+  return %2 : $U
+}
+
 // CHECK-LABEL: sil hidden [ossa] @test_unconditional_checked_cast1 : $@convention(thin) <T> (Builtin.Int64) -> @out T {
 // CHECK: bb0(%0 : $*T, %1 : $Builtin.Int64):
 // CHECK:   [[INT:%.*]] = alloc_stack $Builtin.Int64

--- a/test/SILOptimizer/address_lowering.sil
+++ b/test/SILOptimizer/address_lowering.sil
@@ -3073,6 +3073,21 @@ bb0(%0 : @guaranteed $T, %1 : $@thick U.Type):
   return %6 : $U
 }
 
+// CHECK-LABEL: sil hidden [ossa] @test_unchecked_bitwise_cast_from_loadable_trivial :
+// CHECK:       bb0(%0 : $*T, %1 : $Builtin.Int64):
+// CHECK:         [[STK:%[^,]+]] = alloc_stack $T
+// CHECK:         [[CAST:%[^,]+]] = unchecked_addr_cast [[STK]] : $*T to $*Builtin.Int64
+// CHECK:         store %1 to [trivial] [[CAST]] : $*Builtin.Int64
+// CHECK:         copy_addr [[STK]] to [init] %0 : $*T
+// CHECK:         dealloc_stack [[STK]]
+// CHECK-LABEL: } // end sil function 'test_unchecked_bitwise_cast_from_loadable_trivial'
+sil hidden [ossa] @test_unchecked_bitwise_cast_from_loadable_trivial : $@convention(thin) <T> (Builtin.Int64) -> @out T {
+bb0(%0 : $Builtin.Int64):
+  %1 = unchecked_bitwise_cast %0 : $Builtin.Int64 to $T
+  %2 = copy_value %1 : $T
+  return %2 : $T
+}
+
 // There's only one use and it's a copy, just rewrite it as a load [copy].
 // CHECK-LABEL: sil hidden [ossa] @test_unchecked_bitwise_cast_to_loadable :
 // CHECK:       {{bb[0-9]+}}([[ADDR_IN:%[^,]+]] : $*T):
@@ -3118,6 +3133,17 @@ bb0(%instance : @guaranteed $T):
   destroy_value %klass2 : $Klass
   destroy_value %copy : $T
   return %klass : $Klass
+}
+
+// CHECK-LABEL: sil hidden [ossa] @test_unchecked_value_cast_from_loadable :
+// CHECK:       bb0(%0 : $*T, %1 : @owned $Klass):
+// CHECK:         [[CAST:%[^,]+]] = unchecked_addr_cast %0 : $*T to $*Klass
+// CHECK:         store %1 to [init] [[CAST]] : $*Klass
+// CHECK-LABEL: } // end sil function 'test_unchecked_value_cast_from_loadable'
+sil hidden [ossa] @test_unchecked_value_cast_from_loadable : $@convention(thin) <T> (@owned Klass) -> @out T {
+bb0(%0 : @owned $Klass):
+  %1 = unchecked_value_cast %0 : $Klass to $T
+  return %1 : $T
 }
 
 // CHECK-LABEL: sil hidden [ossa] @test_unconditional_checked_cast1 : $@convention(thin) <T> (Builtin.Int64) -> @out T {


### PR DESCRIPTION
Resolves rdar://177702093

Some instructions are missing Opaque Values use/def handling during AddressLowering.

1. Run tests with -enable-sil-opaque-values or the ninja target check-swift-optimize_none_with_opaque_values.
2. Look for tests failing with “^^^ Unimplemented opaque value use/def”