### PR TITLE
[6.4][cxx-interop] Allow function template instantiations with optional foreign reference types

### DIFF
--- a/lib/AST/ClangTypeConverter.cpp
+++ b/lib/AST/ClangTypeConverter.cpp
@@ -1013,6 +1013,30 @@ clang::QualType ClangTypeConverter::convertTemplateArgument(Type type) {
                                                                kind.value());
         });
 
+      // Optional<FRT> maps to a nullable pointer so the instantiated
+      // function re-imports with an optional return type. Otherwise, it would
+      // be re-imported as non-optional FRT.
+      if (argType->isForeignReferenceType()) {
+        return withCache([&]() {
+          if (auto nominal = argType->getAs<NominalType>()) {
+            if (auto clangTypeDecl = dyn_cast_or_null<clang::TypeDecl>(
+                    nominal->getDecl()->getClangDecl())) {
+              auto ptrTy = ClangASTContext.getPointerType(
+                  ClangASTContext.getTypeDeclType(clangTypeDecl));
+              auto nullableAttr = new (ClangASTContext) clang::TypeNullableAttr(
+                  ClangASTContext,
+                  clang::AttributeCommonInfo(
+                      clang::SourceRange(),
+                      clang::AttributeCommonInfo::AT_TypeNullable,
+                      clang::AttributeCommonInfo::Form::Implicit()));
+              return ClangASTContext.getAttributedType(nullableAttr, ptrTy,
+                                                       ptrTy);
+            }
+          }
+          return clang::QualType();
+        });
+      }
+
       // Arbitrary optional types are not (yet) supported
       return clang::QualType();
     }

--- a/test/Interop/Cxx/templates/Inputs/function-template-with-optional-frt.h
+++ b/test/Interop/Cxx/templates/Inputs/function-template-with-optional-frt.h
@@ -1,0 +1,61 @@
+#pragma once
+
+template <class T>
+struct RemovePointerImpl {
+  using type = T;
+};
+template <class T>
+struct RemovePointerImpl<T *> {
+  using type = T;
+};
+template <class T>
+using RemovePointer = typename RemovePointerImpl<T>::type;
+
+struct OSMetaClass;
+
+struct OSMetaClassBase {
+  static OSMetaClassBase *safeMetaCast(const OSMetaClassBase *inst,
+                                       const OSMetaClass *meta) {
+    (void)meta;
+    return const_cast<OSMetaClassBase *>(inst);
+  }
+  virtual ~OSMetaClassBase() = default;
+};
+
+#define OSTypeID(type) ((const OSMetaClass *)nullptr)
+
+#define OSDynamicCast(type, inst)                                              \
+  ((type *)OSMetaClassBase::safeMetaCast((inst), OSTypeID(type)))
+
+struct __attribute__((swift_attr("import_reference")))
+__attribute__((swift_attr("retain:immortal")))
+__attribute__((swift_attr("release:immortal"))) FRTBase : OSMetaClassBase {
+  int x;
+};
+
+struct __attribute__((swift_attr("import_reference")))
+__attribute__((swift_attr("retain:immortal")))
+__attribute__((swift_attr("release:immortal"))) FRTDerived : FRTBase {
+  int y;
+};
+
+template <class T>
+T passThrough(T value) {
+  return value;
+}
+
+template <class R, class I>
+R cast(I i) {
+  return (R)i;
+}
+
+template <class BasePtr, class DerivedPtr>
+DerivedPtr dynamicCast(BasePtr x) {
+  return dynamic_cast<DerivedPtr>(x);
+}
+
+template <class BasePtr, class DerivedPtr>
+DerivedPtr downcast(BasePtr x) {
+  DerivedPtr d = OSDynamicCast(RemovePointer<DerivedPtr>, x);
+  return d;
+}

--- a/test/Interop/Cxx/templates/Inputs/module.modulemap
+++ b/test/Interop/Cxx/templates/Inputs/module.modulemap
@@ -192,3 +192,8 @@ module ClassTemplateWithFrt {
   header "class-template-with-frt.h"
   requires cplusplus
 }
+
+module FunctionTemplateWithOptionalFrt {
+  header "function-template-with-optional-frt.h"
+  requires cplusplus
+}

--- a/test/Interop/Cxx/templates/function-template-with-optional-frt.swift
+++ b/test/Interop/Cxx/templates/function-template-with-optional-frt.swift
@@ -1,0 +1,52 @@
+// RUN: %target-swift-emit-ir %s -I %S/Inputs -cxx-interoperability-mode=default -disable-availability-checking | %FileCheck %s
+
+import FunctionTemplateWithOptionalFrt
+
+// CHECK-LABEL: define {{.*}}@{{.*}}testPassThrough
+func testPassThrough(x: FRTBase) -> FRTBase {
+  return passThrough(x)
+}
+
+// CHECK-LABEL: define {{.*}}@{{.*}}testPassThroughOptional
+func testPassThroughOptional(x: FRTBase?) -> FRTBase? {
+  return passThrough(x)
+}
+
+// CHECK-LABEL: define {{.*}}@{{.*}}testCast
+func testCast(x: FRTBase) -> FRTDerived? {
+  return cast(x)
+}
+
+// CHECK-LABEL: define {{.*}}@{{.*}}testDynamicCast
+func testDynamicCast(x: FRTBase) -> FRTDerived? {
+  return dynamicCast(x)
+}
+
+// CHECK-LABEL: define {{.*}}@{{.*}}testDowncast
+func testDowncast(x: FRTBase) -> FRTDerived? {
+  return downcast(x)
+}
+
+// CHECK-LABEL: define {{.*}}@{{.*}}testPassThroughLet
+func testPassThroughLet(base: FRTBase) {
+  let _: FRTBase = passThrough(base)
+  let _: FRTBase? = passThrough(base)
+}
+
+// CHECK-LABEL: define {{.*}}@{{.*}}testCastLet
+func testCastLet(base: FRTBase) {
+  let _: FRTDerived = cast(base)
+  let _: FRTDerived? = cast(base)
+}
+
+// CHECK-LABEL: define {{.*}}@{{.*}}testDynamicCastLet
+func testDynamicCastLet(base: FRTBase) {
+  let _: FRTDerived = dynamicCast(base)
+  let _: FRTDerived? = dynamicCast(base)
+}
+
+// CHECK-LABEL: define {{.*}}@{{.*}}testDowncastLet
+func testDowncastLet(base: FRTBase) {
+  let _: FRTDerived = downcast(base)
+  let _: FRTDerived? = downcast(base)
+}


### PR DESCRIPTION
- **Explanation**: This change allows instantiating function templates with optional foreign reference types.
- **Scope**: Swift/C++ Interop only, affects template instantiation when an `Optional<FRT>` is used as a template argument for C++ function templates.
- **Issue**: rdar://177206923
- **Original PRs**: https://github.com/swiftlang/swift/pull/89265
- **Risk**: Low. Before this change, instantiating function templates with optional foreign reference types would fail, so it's unlikely this will break anything. Other paths/cases should not be affected.
- **Testing**: Added a new test that exercises the new path and verified that all other tests are fine.
- **Reviewers**: @Xazax-hun @j-hui

rdar://177206923

(cherry picked from commit e50e624693b36e43e29ea075d07fca00cd9a5924)
