### PR TITLE
[RemoteInspection] Fix metadata allocation iteration.

### DIFF
--- a/include/swift/RemoteInspection/ReflectionContext.h
+++ b/include/swift/RemoteInspection/ReflectionContext.h
@@ -1842,11 +1842,11 @@ public:
       return "failed to read value of " + AllocationPoolPointerName;
 
     struct PoolRange {
-      RemoteAddress Begin;
+      StoredPointer Begin;
       StoredSize Remaining;
     };
     struct PoolTrailer {
-      RemoteAddress PrevTrailer;
+      StoredPointer PrevTrailer;
       StoredSize PoolSize;
     };
     struct alignas(RemoteAddress) AllocationHeader {
@@ -1867,7 +1867,9 @@ public:
     unsigned LoopCount = 0;
     unsigned LoopLimit = 1000000;
 
-    auto TrailerPtr = Pool->Begin + Pool->Remaining;
+    auto PoolAddressSpace = AllocationPoolAddr->getResolvedAddress().getAddressSpace();
+
+    auto TrailerPtr = RemoteAddress(Pool->Begin + Pool->Remaining, PoolAddressSpace);
     while (TrailerPtr && LoopCount++ < LoopLimit) {
       auto TrailerBytes =
           getReader().readBytes(TrailerPtr, sizeof(PoolTrailer));
@@ -1899,7 +1901,7 @@ public:
         Offset += sizeof(AllocationHeader) + Header->Size;
       }
 
-      TrailerPtr = Trailer->PrevTrailer;
+      TrailerPtr = RemoteAddress(Trailer->PrevTrailer, PoolAddressSpace);
     }
     return std::nullopt;
   }


### PR DESCRIPTION
PoolRange and PoolTrailer need to use StoredPointer instead of RemoteAddress, since they're remote data being read in. RemoteAddress worked coincidentally, but is no longer correct now that it has added an address space field. This causes us to read too much memory and to read the remaining/size fields at the wrong location.

rdar://177644656