### PR TITLE
[swift-inspect] Fix --summary used with --scan-search.

### DIFF
--- a/include/swift/Remote/MetadataReader.h
+++ b/include/swift/Remote/MetadataReader.h
@@ -1557,15 +1557,16 @@ public:
   ///   - address: The address of the value.
   ///   - ptr: The bytes that have been read so far. On return, the full object.
   ///   - existingByteCount: The number of bytes in ptr.
+  /// Returns the full size, or 0 if an error occurred.
   template <typename BaseTy>
-  bool readFullTrailingObjects(RemoteAddress address,
-                               MemoryReader::ReadBytesResult &ptr,
-                               size_t existingByteCount) {
+  size_t readFullTrailingObjects(RemoteAddress address,
+                                 MemoryReader::ReadBytesResult &ptr,
+                                 size_t existingByteCount) {
     // Read the full base descriptor if it's bigger than what we have so far.
     if (sizeof(BaseTy) > existingByteCount) {
       ptr = Reader->template readObj<BaseTy>(address);
       if (!ptr)
-        return false;
+        return -1;
     }
 
     // We don't know how much memory we need to read to get all the trailing
@@ -1588,15 +1589,15 @@ public:
       if (thisSize > sizeSoFar) {
         // Make sure we haven't ended up with a ridiculous size.
         if (thisSize > MaxMetadataSize)
-          return false;
+          return -1;
 
         ptr = Reader->readBytes(address, thisSize);
         if (!ptr)
-          return false;
+          return -1;
         sizeSoFar = thisSize;
       }
     }
-    return true;
+    return sizeSoFar;
   }
 
   /// Demangle the entity represented by a symbolic reference to a given symbol name.
@@ -2162,9 +2163,13 @@ protected:
                          reinterpret_cast<const TargetMetadata<Runtime> *>(
                              cached->second.get()));
 
+    return readMetadataAndSize(address).first;
+  }
+
+  std::pair<MetadataRef, size_t> readMetadataAndSize(RemoteAddress address) {
     StoredPointer KindValue = 0;
     if (!Reader->readInteger(address, &KindValue))
-      return nullptr;
+      return {nullptr, 0};
 
     switch (getEnumeratedMetadataKind(KindValue)) {
       case MetadataKind::Class:
@@ -2188,12 +2193,12 @@ protected:
         RemoteAddress signedShapePtr;
         if (!Reader->template readRemoteAddress<StoredPointer>(shapeAddress,
                                                                signedShapePtr))
-          return nullptr;
+          return {nullptr, 0};
         auto shapePtr = stripSignedPointer(signedShapePtr);
 
         auto shape = readShape(shapePtr);
         if (!shape)
-          return nullptr;
+          return {nullptr, 0};
 
         auto totalSize =
             sizeof(TargetExtendedExistentialTypeMetadata<Runtime>)
@@ -2225,13 +2230,13 @@ protected:
           TargetTupleTypeMetadata<Runtime>::getOffsetToNumElements();
         StoredSize numElements;
         if (!Reader->readInteger(numElementsAddress, &numElements))
-          return nullptr;
+          return {nullptr, 0};
         auto totalSize = sizeof(TargetTupleTypeMetadata<Runtime>) +
                          numElements * sizeof(TupleTypeMetadata::Element);
 
         // Make sure the number of elements is reasonable
         if (numElements >= 256)
-          return nullptr;
+          return {nullptr, 0};
 
         return _readMetadata(address, totalSize);
       }
@@ -2242,7 +2247,7 @@ protected:
 
     // We can fall out here if the value wasn't actually a valid
     // MetadataKind.
-    return nullptr;
+    return {nullptr, 0};
   }
 
   RemoteAddress
@@ -2315,7 +2320,7 @@ protected:
 
 private:
   template <template <class R> class M>
-  MetadataRef _readMetadataFixedSize(RemoteAddress address) {
+  std::pair<MetadataRef, size_t> _readMetadataFixedSize(RemoteAddress address) {
     static_assert(!ABI::typeHasTrailingObjects<M<Runtime>>(),
                   "Type must not have trailing objects. Use "
                   "_readMetadataVariableSize for types that have them.");
@@ -2324,23 +2329,23 @@ private:
   }
 
   template <template <class R> class M>
-  MetadataRef _readMetadataVariableSize(RemoteAddress address) {
+  std::pair<MetadataRef, size_t> _readMetadataVariableSize(RemoteAddress address) {
     static_assert(ABI::typeHasTrailingObjects<M<Runtime>>(),
                   "Type must have trailing objects. Use _readMetadataFixedSize "
                   "for types that don't.");
 
     MemoryReader::ReadBytesResult bytes;
     auto readResult = readFullTrailingObjects<M<Runtime>>(address, bytes, 0);
-    if (!readResult)
-      return nullptr;
-    return _cacheMetadata(address, bytes);
+    if (readResult == 0)
+      return {nullptr, 0};
+    return {_cacheMetadata(address, bytes), readResult};
   }
 
-  MetadataRef _readMetadata(RemoteAddress address, size_t sizeAfter) {
+  std::pair<MetadataRef, size_t> _readMetadata(RemoteAddress address, size_t sizeAfter) {
     if (sizeAfter > MaxMetadataSize)
-      return nullptr;
+      return {nullptr, 0};
     auto readResult = Reader->readBytes(address, sizeAfter);
-    return _cacheMetadata(address, readResult);
+    return {_cacheMetadata(address, readResult), sizeAfter};
   }
 
   MetadataRef _cacheMetadata(RemoteAddress address,

--- a/include/swift/RemoteInspection/ReflectionContext.h
+++ b/include/swift/RemoteInspection/ReflectionContext.h
@@ -1683,6 +1683,10 @@ public:
     return Descriptor->getTypeContextDescriptorFlags().class_isActor();
   }
 
+  size_t metadataSize(RemoteAddress MetadataAddress) {
+    return this->readMetadataAndSize(MetadataAddress).second;
+  }
+
   /// Iterate the protocol conformance cache tree rooted at NodePtr, calling
   /// Call with the type and protocol in each node.
   void iterateConformanceTree(

--- a/include/swift/SwiftRemoteMirror/SwiftRemoteMirror.h
+++ b/include/swift/SwiftRemoteMirror/SwiftRemoteMirror.h
@@ -165,6 +165,11 @@ int
 swift_reflection_metadataIsActor(SwiftReflectionContextRef ContextRef,
                                  swift_reflection_ptr_t Metadata);
 
+SWIFT_REMOTE_MIRROR_LINKAGE
+size_t
+swift_reflection_metadataSize(SwiftReflectionContextRef ContextRef,
+                              swift_reflection_ptr_t Metadata);
+
 /// Returns an opaque type reference for a class or closure context
 /// instance pointer, or NULL if one can't be constructed.
 ///

--- a/stdlib/public/SwiftRemoteMirror/SwiftRemoteMirror.cpp
+++ b/stdlib/public/SwiftRemoteMirror/SwiftRemoteMirror.cpp
@@ -398,6 +398,15 @@ int swift_reflection_metadataIsActor(SwiftReflectionContextRef ContextRef,
   });
 }
 
+size_t
+swift_reflection_metadataSize(SwiftReflectionContextRef ContextRef,
+                              swift_reflection_ptr_t Metadata) {
+  return ContextRef->withContext([&](auto *Context) -> size_t {
+    return Context->metadataSize(
+        RemoteAddress(Metadata, RemoteAddress::DefaultAddressSpace));
+  });
+}
+
 swift_typeref_t
 swift_reflection_typeRefForInstance(SwiftReflectionContextRef ContextRef,
                                     uintptr_t Object) {

--- a/tools/swift-inspect/Sources/swift-inspect/Operations/DumpGenericMetadata.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/Operations/DumpGenericMetadata.swift
@@ -130,15 +130,14 @@ internal struct DumpGenericMetadata: ParsableCommand {
 
       // Update summary
       generics.forEach { metadata in
-        if let allocation = metadata.allocation {
-          let name = metadata.name
-          if metadataSummary.keys.contains(name) {
-            metadataSummary[name]!.totalSize += allocation.size
-            metadataSummary[name]!.processes.insert(process.processName)
-          } else {
-            metadataSummary[name] = MetadataSummary(totalSize: allocation.size,
-                                                    processes: Set([process.processName]))
-            }
+        let size = metadata.allocation?.size ?? swift_reflection_metadataSize(process.context, metadata.ptr)
+        let name = metadata.name
+        if metadataSummary.keys.contains(name) {
+          metadataSummary[name]!.totalSize += size
+          metadataSummary[name]!.processes.insert(process.processName)
+        } else {
+          metadataSummary[name] = MetadataSummary(totalSize: size,
+                                                  processes: Set([process.processName]))
         }
       }
 


### PR DESCRIPTION
--summary needs allocation sizes. Add a Remote Mirror call to fetch the size of a metadata, and plumb it through to the --summary code.

rdar://177648979