### PR TITLE
[6.4][Concurrency] Adopt `nonisolated(nonsending)` on `Clock.measure` and `Task.withValue`

### DIFF
--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -268,7 +268,7 @@ protected:
     Kind : 2
   );
 
-  SWIFT_INLINE_BITFIELD(ClosureExpr, AbstractClosureExpr, 1+1+1+1+1+1+1+1+1,
+  SWIFT_INLINE_BITFIELD(ClosureExpr, AbstractClosureExpr, 1+1+1+1+1+1+1+1+1+1,
     /// True if closure parameters were synthesized from anonymous closure
     /// variables.
     HasAnonymousClosureVars : 1,
@@ -303,7 +303,15 @@ protected:
     /// Whether this closure was type-checked as an argument to a macro. This
     /// is only populated after type-checking, and only exists for diagnostic
     /// logic. Do not add more uses of this.
-    IsMacroArgument : 1
+    IsMacroArgument : 1,
+
+    /// True if this closure, even though it has a different static isolation,
+    /// should behave like `nonisolated(nonsending)` when lowered. This is important
+    /// for cases where a closure is passed to a non-sending `nonisolated(nonsending)`
+    /// parameter of a `nonisolated(nonsending)` call and doesn't leave isolation of
+    /// the parent context. It's easier to work with statically known isolation than
+    /// make closure dynamically isolated via assuming `nonisolated(nonsending)`.
+    BehavesLikeNonisolatedNonsending: 1
   );
 
   SWIFT_INLINE_BITFIELD_FULL(BindOptionalExpr, Expr, 16,
@@ -4317,6 +4325,7 @@ public:
     Bits.ClosureExpr.NoGlobalActorAttribute = false;
     Bits.ClosureExpr.RequiresDynamicIsolationChecking = false;
     Bits.ClosureExpr.IsMacroArgument = false;
+    Bits.ClosureExpr.BehavesLikeNonisolatedNonsending = false;
   }
 
   SourceRange getSourceRange() const;
@@ -4425,6 +4434,21 @@ public:
 
   void setIsMacroArgument(bool value = true) {
     Bits.ClosureExpr.IsMacroArgument = value;
+  }
+
+  /// Determines whether this closure, even though it has a different static
+  /// isolation, should behave like `nonisolated(nonsending)` when lowered. This
+  /// is important for cases where a closure is passed to a non-sending
+  /// `nonisolated(nonsending)` parameter of a `nonisolated(nonsending)` call
+  /// and doesn't leave isolation of the parent context. It's easier to work with
+  /// statically known isolation than make closure dynamically isolated via
+  /// assuming `nonisolated(nonsending)`.
+  bool behavesLikeNonisolatedNonsending() const {
+    return Bits.ClosureExpr.BehavesLikeNonisolatedNonsending;
+  }
+
+  void setBehavesLikeNonisolatedNonsending(bool value = true) {
+    Bits.ClosureExpr.BehavesLikeNonisolatedNonsending = value;
   }
 
   /// Determine whether this closure expression has an

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -1958,6 +1958,22 @@ private:
                    true /*implicit leading parameter*/);
     }
 
+    // If the function is a closure that behaves as if it has
+    // `nonisolated(nonsending)` isolation, add the implicit isolation
+    // parameter but don't mark it as "isolated" because the closure
+    // should maintain it's statically known isolation after prolog.
+    if (Constant) {
+      if (auto *closure = dyn_cast_or_null<ClosureExpr>(
+              Constant->getAbstractClosureExpr())) {
+        if (closure->behavesLikeNonisolatedNonsending()) {
+          addParameter(-1, CanType(TC.Context.TheImplicitActorType),
+                       ParameterConvention::Direct_Guaranteed,
+                       ParameterTypeFlags(),
+                       true /*implicit leading parameter*/);
+        }
+      }
+    }
+
     // Add any foreign parameters that are positioned at the start
     // of the sequence.  visit() will add foreign parameters that are
     // positioned after any parameters it adds.

--- a/lib/SILGen/SILGenConcurrency.cpp
+++ b/lib/SILGen/SILGenConcurrency.cpp
@@ -254,11 +254,17 @@ void SILGenFunction::emitExpectedExecutorProlog() {
   if (ExpectedExecutor.isNecessary()) {
     auto executor = ExpectedExecutor.getEager(); // never lazy
     if (F.isAsync()) {
-      // For an async function, hop to the executor.
-      B.createHopToExecutor(
-          RegularLocation::getDebugOnlyLocation(F.getLocation(), getModule()),
-          executor,
-          /*mandatory*/ false);
+      auto *closureExpr = dyn_cast<ClosureExpr>(FunctionDC);
+      if (closureExpr && closureExpr->behavesLikeNonisolatedNonsending()) {
+        // Do nothing if the closure behaves as if it has
+        // `nonisolated(nonsending)` isolation.
+      } else {
+        // For all other async functions, hop to the executor.
+        B.createHopToExecutor(
+            RegularLocation::getDebugOnlyLocation(F.getLocation(), getModule()),
+            executor,
+            /*mandatory*/ false);
+      }
     } else if (wantDataRaceChecks) {
       // For a synchronous function, check that we're on the same executor.
       // Note: if we "know" that the code is completely Sendable-safe, this

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -35,6 +35,7 @@
 #include "swift/AST/DistributedDecl.h"
 #include "swift/AST/ExistentialLayout.h"
 #include "swift/AST/Expr.h"
+#include "swift/AST/ExtInfo.h"
 #include "swift/AST/ForeignErrorConvention.h"
 #include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/InFlightSubstitution.h"
@@ -3299,6 +3300,21 @@ static bool canEmitSpecializedClosureFunction(const AbstractClosureExpr *closure
                                         const FunctionTypeInfo &contextInfo) {
   auto destType = contextInfo.FormalType;
 
+  // This is a closure that is being converted to `nonisolated(nonsending)`
+  // type and is already behaves as such even though its statically known
+  // isolation is different. Such closures are emitted in a special way where
+  // they gain an implicit isolation parameter that gets ignored to avoid
+  // unnecessary hops.
+  if (contextInfo.ExpectedLoweredType->hasNonisolatedNonsendingIsolation()) {
+    if (auto *explicitClosure = dyn_cast<ClosureExpr>(closure)) {
+      if (explicitClosure->behavesLikeNonisolatedNonsending())
+        closureType = cast<AnyFunctionType>(
+            closureType
+                ->withIsolation(FunctionTypeIsolation::forNonisolatedNonsending())
+                ->getCanonicalType());
+    }
+  }
+
   // Require the closure's formal type to be closely related to the formal
   // type we're trying to convert it to.
   if (!canEmitClosureFunctionUnderConversion(closureType, destType))
@@ -3339,31 +3355,41 @@ ManagedValue RValueEmitter::tryEmitConvertedClosure(AbstractClosureExpr *e,
     return emitClosureReference(e, *info);
   }
 
+  // Construct a conversion that just adds requested isolation and doesn't
+  // make any other changes to the closure type.
+  auto adjustClosureIsolation = [&](FunctionTypeIsolation isolation) {
+    // This assertion is why this isn't an infinite recursion.
+    assert(closureType->getIsolation() != isolation &&
+           "closure cannot directly have erased isolation");
+
+    auto newExtInfo = closureType->getExtInfo().withIsolation(isolation);
+    auto newClosureType = closureType.withExtInfo(newExtInfo);
+    auto newInfo = SGF.getFunctionTypeInfo(newClosureType);
+
+    // Emit the closure under that conversion.  This should always succeed.
+    assert(canEmitSpecializedClosureFunction(e, closureType, newInfo));
+    auto result = emitClosureReference(e, newInfo);
+
+    // Narrow the original conversion to start from the updated closure type.
+    auto convAfterIsolationChange = conv.withSourceType(SGF, newClosureType);
+
+    // Apply the narrowed conversion.
+    return convAfterIsolationChange.emit(SGF, e, result, SGFContext());
+  };
+
+  if (info->ExpectedLoweredType->hasNonisolatedNonsendingIsolation()) {
+    if (auto *closure = dyn_cast<ClosureExpr>(e)) {
+      if (closure->behavesLikeNonisolatedNonsending())
+        return adjustClosureIsolation(
+            FunctionTypeIsolation::forNonisolatedNonsending());
+    }
+  }
+
   // If we're converting to an `@isolated(any)` type, at least force the
   // closure to be emitted using the erased-isolation pattern so that
   // we don't lose that information.
-  if (info->ExpectedLoweredType->hasErasedIsolation()) {
-    // This assertion is why this isn't an infinite recursion.
-    assert(!closureType->getIsolation().isErased() &&
-           "closure cannot directly have erased isolation");
-
-    // Construct a conversion that just erases isolation and doesn't make
-    // any other changes to the closure type.
-    auto erasedExtInfo = closureType->getExtInfo()
-      .withIsolation(FunctionTypeIsolation::forErased());
-    auto erasedClosureType = closureType.withExtInfo(erasedExtInfo);
-    auto erasureInfo = SGF.getFunctionTypeInfo(erasedClosureType);
-
-    // Emit the closure under that conversion.  This should always succeed.
-    assert(canEmitSpecializedClosureFunction(e, closureType, erasureInfo));
-    auto erasedResult = emitClosureReference(e, erasureInfo);
-
-    // Narrow the original conversion to start from the erased closure type.
-    auto convAfterErasure = conv.withSourceType(SGF, erasedClosureType);
-
-    // Apply the narrowed conversion.
-    return convAfterErasure.emit(SGF, e, erasedResult, SGFContext());
-  }
+  if (info->ExpectedLoweredType->hasErasedIsolation())
+    return adjustClosureIsolation(FunctionTypeIsolation::forErased());
 
   // Otherwise, give up.
   return ManagedValue();

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2934,13 +2934,16 @@ ConstraintSystem::matchFunctionIsolations(FunctionType *func1,
   // function-conversion score to make sure this solution is worse than
   // an exact match.
   // FIXME: there may be a better way. see https://github.com/apple/swift/pull/62514
-  auto matchIfConversion = [&](bool isErasure = false) -> bool {
+  auto matchIfConversion = [&](bool isErasure = false,
+                               bool shouldIncreaseScore = true) -> bool {
     // We generally require a conversion here, but allow some lassitude
     // if we're doing witness-matching.
     if (kind < ConstraintKind::Subtype &&
         !(isErasure && isWitnessMatching(locator)))
       return false;
-    increaseScore(SK_FunctionConversion, locator);
+
+    if (shouldIncreaseScore)
+      increaseScore(SK_FunctionConversion, locator);
     return true;
   };
 
@@ -3002,7 +3005,40 @@ ConstraintSystem::matchFunctionIsolations(FunctionType *func1,
     // For synchronous: Thunk would call the function without
     // a hop.
     case FunctionTypeIsolation::Kind::NonIsolated:
-      return matchIfConversion();
+      // When a nonisolated/@concurrent closure is passed to a
+      // nonisolated(nonsending) parameter the solver has to be conservative
+      // and produce a conversion that could be dissolved by actor
+      // isolation checker when it determines that nonisolated(nonsending)
+      // could be assumed onto the closure direct (i.e. when there are no
+      // isolated captures involved), so let's not increase a score unless
+      // closure states it's isolation explicitly to avoid picking a subpar
+      // solution.
+      bool shouldIncreaseScore = true;
+      if (func1->isAsync()) {
+        auto *expr = locator.trySimplifyToExpr();
+
+        if (expr)
+          expr = expr->getSemanticsProvidingExpr();
+
+        if (auto *cast = getAsExpr<ExplicitCastExpr>(expr))
+          expr = cast->getSubExpr();
+
+        // Look through captures, we only care about the closure itself.
+        if (auto *captureList = getAsExpr<CaptureListExpr>(expr))
+          expr = captureList->getClosureBody();
+
+        if (auto *closure = getAsExpr<ClosureExpr>(expr)) {
+          shouldIncreaseScore =
+              closure->getAttrs().hasAttribute<ConcurrentAttr>();
+        }
+      } else {
+        // Converting a sync function to nonisolated(nonsending) async one
+        // doesn't require a thunk.
+        shouldIncreaseScore = false;
+      }
+
+      return matchIfConversion(
+          /*isErasure=*/false, shouldIncreaseScore);
     }
     llvm_unreachable("bad kind");
 

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -3460,9 +3460,19 @@ namespace {
 
       // The constraint solver may not have chosen legal casts.
       if (auto funcConv = dyn_cast<FunctionConversionExpr>(expr)) {
-        checkFunctionConversion(funcConv,
-                                funcConv->getSubExpr()->getType(),
+        auto *subExpr = funcConv->getSubExpr();
+
+        checkFunctionConversion(funcConv, subExpr->getType(),
                                 funcConv->getType());
+
+        // Closures are allowed to assume isolation from function conversion in
+        // some circumstances (currently only when it's
+        // `nonisolated(nonsending)`). If this happens, we can drop the
+        // conversion.
+        if (auto *closure = dyn_cast<AbstractClosureExpr>(subExpr)) {
+          if (funcConv->getType()->isEqual(closure->getType()))
+            return Action::Continue(closure);
+        }
       }
 
       if (auto *isolationErasure = dyn_cast<ActorIsolationErasureExpr>(expr)) {
@@ -4810,28 +4820,36 @@ namespace {
 } // end anonymous namespace
 
 /// Compute the isolation of a closure or local function from its parent
-/// isolation.
+/// isolation. The result indicates whether the isolation was inherited
+/// or not.
 ///
 /// Doesn't apply preconcurrency because it's generally easier for the
 /// caller to do so.
-static ActorIsolation
+static std::pair<ActorIsolation, /*inherited=*/bool>
 computeClosureIsolationFromParent(DeclContext *closure,
                                   ActorIsolation parentIsolation,
                                   bool checkIsolatedCapture) {
+  auto getNonisolatedIsolation =
+      [&](bool inherited) -> std::pair<ActorIsolation, bool> {
+    auto closureFn = AnyFunctionRef::fromFunctionDeclContext(closure);
+    if (closureFn.isAsync())
+      return {ActorIsolation::forNonisolatedConcurrent(), inherited};
+
+    return {ActorIsolation::forNonisolated(parentIsolation ==
+                                           ActorIsolation::NonisolatedUnsafe),
+            inherited};
+  };
+
   // We must have parent isolation determined to get here.
   switch (parentIsolation) {
   case ActorIsolation::NonisolatedNonsending:
+    return getNonisolatedIsolation(/*inferred=*/false);
+
   case ActorIsolation::Nonisolated:
   case ActorIsolation::NonisolatedConcurrent:
   case ActorIsolation::NonisolatedUnsafe:
-  case ActorIsolation::Unspecified: {
-    auto closureFn = AnyFunctionRef::fromFunctionDeclContext(closure);
-    if (closureFn.isAsync())
-      return ActorIsolation::forNonisolatedConcurrent();
-
-    return ActorIsolation::forNonisolated(parentIsolation ==
-                                          ActorIsolation::NonisolatedUnsafe);
-  }
+  case ActorIsolation::Unspecified:
+    return getNonisolatedIsolation(/*inferred=*/true);
 
   case ActorIsolation::Erased:
     llvm_unreachable("context cannot have erased isolation");
@@ -4839,7 +4857,8 @@ computeClosureIsolationFromParent(DeclContext *closure,
   case ActorIsolation::GlobalActor:
     // This should already be an interface type, so we don't need to remap
     // it between the contexts.
-    return ActorIsolation::forGlobalActor(parentIsolation.getGlobalActor());
+    return {ActorIsolation::forGlobalActor(parentIsolation.getGlobalActor()),
+            /*inherited=*/true};
 
   case ActorIsolation::ActorInstance: {
     // In non-@Sendable local functions, we always inherit the enclosing
@@ -4850,34 +4869,34 @@ computeClosureIsolationFromParent(DeclContext *closure,
       // locally within isolation checking.
       auto actor = parentIsolation.getActorInstance();
       assert(actor);
-      return ActorIsolation::forActorInstanceCapture(actor);
+      return {ActorIsolation::forActorInstanceCapture(actor),
+              /*inherited=*/true};
     }
 
     if (checkIsolatedCapture) {
       auto closureAsFn = AnyFunctionRef::fromFunctionDeclContext(closure);
       if (auto param = closureAsFn.getCaptureInfo().getIsolatedParamCapture())
-        return ActorIsolation::forActorInstanceCapture(param);
+        return {ActorIsolation::forActorInstanceCapture(param),
+                /*inherited=*/true};
 
       auto *explicitClosure = dyn_cast<ClosureExpr>(closure);
       // @_inheritActorContext(always) forces the isolation capture.
       if (explicitClosure && explicitClosure->alwaysInheritsActorContext()) {
         if (parentIsolation.isActorInstanceIsolated()) {
           if (auto *param = parentIsolation.getActorInstance())
-            return ActorIsolation::forActorInstanceCapture(param);
+            return {ActorIsolation::forActorInstanceCapture(param),
+                    /*inherited=*/true};
         }
-        return parentIsolation;
+        return {parentIsolation, /*inherited=*/true};
       }
     } else {
       // If we don't have capture information during code completion, assume
       // that the closure captures the `isolated` parameter from the parent
       // context.
-      return parentIsolation;
+      return {parentIsolation, /*inherited=*/true};
     }
 
-    if (AnyFunctionRef::fromFunctionDeclContext(closure).isAsync())
-      return ActorIsolation::forNonisolatedConcurrent();
-
-    return ActorIsolation::forNonisolated(/*unsafe=*/false);
+    return getNonisolatedIsolation(/*inherited=*/false);
   }
   }
 }
@@ -4931,12 +4950,60 @@ ActorIsolationChecker::determineClosureIsolation(AbstractClosureExpr *closure,
         closure->getParent(), getClosureActorIsolation);
     preconcurrency |= parentIsolation.preconcurrency();
 
-    auto normalIsolation = computeClosureIsolationFromParent(
-        closure, parentIsolation, checkIsolatedCapture);
+    ActorIsolation normalIsolation;
+    bool inheritsParentIsolation;
+    std::tie(normalIsolation, inheritsParentIsolation) =
+        computeClosureIsolationFromParent(closure, parentIsolation,
+                                          checkIsolatedCapture);
 
     bool isIsolationBoundary =
         isIsolationInferenceBoundaryClosure(closure,
                                             /*canInheritActorContext=*/true);
+
+    bool isArgumentOfNonisolatedNonsendingApply = false;
+    if (auto *apply = dyn_cast_or_null<CallExpr>(getImmediateApply())) {
+      auto type = apply->getFn()->getType();
+      if (auto *fnType = type->getAs<AnyFunctionType>()) {
+        isArgumentOfNonisolatedNonsendingApply =
+            fnType->getIsolation().isNonisolatedNonsending();
+      }
+    }
+
+    auto canAssumeNonisolatedNonsending = [&]() {
+      // Boundary closures cannot infer isolation from the parent context and
+      // so are always allowed to assume `nonisolated(nonsending)` isolation.
+      if (isIsolationBoundary)
+        return true;
+
+      // If a closure is used as an argument in `nonisolated(nonsending)` call
+      // and it assumes isolation of the parent it doesn't have to assume
+      // `nonisolated(nonsending)` isolation of the parameter because the
+      // `nonisolated(nonsending)` in this case matches isolation of the
+      // context.
+      if (isArgumentOfNonisolatedNonsendingApply)
+        return !inheritsParentIsolation;
+
+      // Since this is not a call to `nonisolated(nonsending)` declaration, the
+      // closure can assume `nonisolated(nonsending)` when it's `@concurrent`,
+      // otherwise it would hop to the generic executor which is unexpected
+      // when isolation is not explicitly specified or inferred to be a
+      // specific actor.
+      if (normalIsolation.isNonisolatedConcurrent())
+        return true;
+
+      // Otherwise closure has to assume isolation inherited from the parent
+      // context.
+      return !inheritsParentIsolation;
+    };
+
+    auto isConvertedToNonisolatedNonsending = [&context]() {
+      if (auto *fce = dyn_cast_or_null<FunctionConversionExpr>(context)) {
+        auto expectedIsolation =
+            fce->getType()->castTo<FunctionType>()->getIsolation();
+        return expectedIsolation.isNonisolatedNonsending();
+      }
+      return false;
+    };
 
     // The solver has to be conservative and produce a conversion to
     // `nonisolated(nonsending)` because at solution application time
@@ -4945,14 +5012,18 @@ ActorIsolationChecker::determineClosureIsolation(AbstractClosureExpr *closure,
     //
     // At this point we know that closure is not explicitly annotated with
     // global actor, nonisolated/@concurrent attributes and doesn't have
-    // isolated parameters. If our closure is nonisolated and we have a
-    // conversion to nonisolated(nonsending), then we should respect that.
-    if (isIsolationBoundary || normalIsolation.isNonisolatedOrConcurrent()) {
-      if (auto *fce = dyn_cast_or_null<FunctionConversionExpr>(context)) {
-        auto expectedIsolation =
-            fce->getType()->castTo<FunctionType>()->getIsolation();
-        if (expectedIsolation.isNonisolatedNonsending())
-          return ActorIsolation::forNonisolatedNonsending();
+    // isolated parameters.
+    if (isConvertedToNonisolatedNonsending()) {
+      if (canAssumeNonisolatedNonsending())
+        return ActorIsolation::forNonisolatedNonsending();
+
+      // If `nonisolated(nonsending)` cannot be assumed, let's see if it's
+      // because closure doesn't leave parent isolation and we prefer statically
+      // known isolation over dynamic one.
+      if (auto *explicitClosure = dyn_cast<ClosureExpr>(closure)) {
+        if (isArgumentOfNonisolatedNonsendingApply &&
+            inheritsParentIsolation)
+          explicitClosure->setBehavesLikeNonisolatedNonsending();
       }
     }
 
@@ -6595,14 +6666,13 @@ static InferredActorIsolation computeActorIsolation(Evaluator &evaluator,
       }
 
       auto enclosingIsolation = getActorIsolationOfContext(dc);
-      auto isolation =
-        computeClosureIsolationFromParent(func, enclosingIsolation,
-                                          /*checkIsolatedCapture*/true)
-          .withPreconcurrency(enclosingIsolation.preconcurrency());
+      auto [isolation, _] =
+          computeClosureIsolationFromParent(func, enclosingIsolation,
+                                            /*checkIsolatedCapture*/ true);
       return {
-        inferredIsolation(isolation),
-        IsolationSource(inferenceSource, IsolationSource::LexicalContext)
-      };
+          inferredIsolation(isolation).withPreconcurrency(
+              enclosingIsolation.preconcurrency()),
+          IsolationSource(inferenceSource, IsolationSource::LexicalContext)};
     }
   }
 

--- a/stdlib/public/Concurrency/Clock.swift
+++ b/stdlib/public/Concurrency/Clock.swift
@@ -78,7 +78,6 @@ extension Clock {
 
   @available(StdlibDeploymentTarget 5.7, *)
   @_alwaysEmitIntoClient
-  @_disfavoredOverload
   @available(*, deprecated, message: "Replaced by nonisolated(nonsending) overload")
   public func measure(
     isolation: isolated (any Actor)? = #isolation,

--- a/stdlib/public/Concurrency/Clock.swift
+++ b/stdlib/public/Concurrency/Clock.swift
@@ -67,7 +67,7 @@ extension Clock {
   ///       }
   @available(StdlibDeploymentTarget 5.7, *)
   @_alwaysEmitIntoClient
-  public func measure(
+  public nonisolated(nonsending) func measure(
     _ work: nonisolated(nonsending) () async throws -> Void
   ) async rethrows -> Instant.Duration {
     let start = now

--- a/stdlib/public/Concurrency/Clock.swift
+++ b/stdlib/public/Concurrency/Clock.swift
@@ -68,6 +68,19 @@ extension Clock {
   @available(StdlibDeploymentTarget 5.7, *)
   @_alwaysEmitIntoClient
   public func measure(
+    _ work: nonisolated(nonsending) () async throws -> Void
+  ) async rethrows -> Instant.Duration {
+    let start = now
+    try await work()
+    let end = now
+    return start.duration(to: end)
+  }
+
+  @available(StdlibDeploymentTarget 5.7, *)
+  @_alwaysEmitIntoClient
+  @_disfavoredOverload
+  @available(*, deprecated, message: "Replaced by nonisolated(nonsending) overload")
+  public func measure(
     isolation: isolated (any Actor)? = #isolation,
     _ work: () async throws -> Void
   ) async rethrows -> Instant.Duration {

--- a/stdlib/public/Concurrency/TaskGroup.swift
+++ b/stdlib/public/Concurrency/TaskGroup.swift
@@ -451,6 +451,14 @@ public struct TaskGroup<ChildTaskResult: Sendable> {
 
   /// Wait for all of the group's remaining tasks to complete.
   @_alwaysEmitIntoClient
+  public nonisolated(nonsending) mutating func waitForAll() async {
+    await awaitAllRemainingTasks(isolation: #isolation)
+  }
+
+  /// Wait for all of the group's remaining tasks to complete.
+  @_alwaysEmitIntoClient
+  @_disfavoredOverload
+  @available(*, deprecated, message: "Replaced by nonisolated(nonsending) overload")
   public mutating func waitForAll(isolation: isolated (any Actor)? = #isolation) async {
     await awaitAllRemainingTasks(isolation: isolation)
   }
@@ -641,6 +649,29 @@ public struct ThrowingTaskGroup<ChildTaskResult: Sendable, Failure: Error> {
   /// - Throws: The *first* error that was thrown by a child task during draining all the tasks.
   ///           This first error is stored until all other tasks have completed, and is re-thrown afterwards.
   @_alwaysEmitIntoClient
+  public nonisolated(nonsending) mutating func waitForAll() async throws {
+    var firstError: Error? = nil
+
+    // Make sure we loop until all child tasks have completed
+    while !isEmpty {
+      do {
+        while let _ = try await next() {}
+      } catch {
+        // Upon error throws, capture the first one
+        if firstError == nil {
+          firstError = error
+        }
+      }
+    }
+
+    if let firstError {
+      throw firstError
+    }
+  }
+
+  @_alwaysEmitIntoClient
+  @_disfavoredOverload
+  @available(*, deprecated, message: "Replaced by nonisolated(nonsending) overload")
   public mutating func waitForAll(isolation: isolated (any Actor)? = #isolation) async throws {
     var firstError: Error? = nil
 
@@ -780,6 +811,13 @@ public struct ThrowingTaskGroup<ChildTaskResult: Sendable, Failure: Error> {
   ///
   /// - SeeAlso: `next()`
   @_alwaysEmitIntoClient
+  public nonisolated(nonsending) mutating func nextResult() async -> Result<ChildTaskResult, Failure>? {
+    return try! await nextResultForABI()
+  }
+
+  @_alwaysEmitIntoClient
+  @_disfavoredOverload
+  @available(*, deprecated, message: "Replaced by nonisolated(nonsending) overload")
   public mutating func nextResult(isolation: isolated (any Actor)? = #isolation) async -> Result<ChildTaskResult, Failure>? {
     return try! await nextResultForABI()
   }

--- a/stdlib/public/Concurrency/TaskGroup.swift
+++ b/stdlib/public/Concurrency/TaskGroup.swift
@@ -457,7 +457,6 @@ public struct TaskGroup<ChildTaskResult: Sendable> {
 
   /// Wait for all of the group's remaining tasks to complete.
   @_alwaysEmitIntoClient
-  @_disfavoredOverload
   @available(*, deprecated, message: "Replaced by nonisolated(nonsending) overload")
   public mutating func waitForAll(isolation: isolated (any Actor)? = #isolation) async {
     await awaitAllRemainingTasks(isolation: isolation)
@@ -670,7 +669,6 @@ public struct ThrowingTaskGroup<ChildTaskResult: Sendable, Failure: Error> {
   }
 
   @_alwaysEmitIntoClient
-  @_disfavoredOverload
   @available(*, deprecated, message: "Replaced by nonisolated(nonsending) overload")
   public mutating func waitForAll(isolation: isolated (any Actor)? = #isolation) async throws {
     var firstError: Error? = nil
@@ -816,7 +814,6 @@ public struct ThrowingTaskGroup<ChildTaskResult: Sendable, Failure: Error> {
   }
 
   @_alwaysEmitIntoClient
-  @_disfavoredOverload
   @available(*, deprecated, message: "Replaced by nonisolated(nonsending) overload")
   public mutating func nextResult(isolation: isolated (any Actor)? = #isolation) async -> Result<ChildTaskResult, Failure>? {
     return try! await nextResultForABI()

--- a/stdlib/public/Concurrency/TaskLocal.swift
+++ b/stdlib/public/Concurrency/TaskLocal.swift
@@ -262,7 +262,6 @@ public final class TaskLocal<Value: Sendable>: Sendable, CustomStringConvertible
   @available(SwiftStdlib 5.1, *)
   @backDeployed(before: SwiftStdlib 6.0)
   @available(*, deprecated, message: "Prefer the 'nonisolated(nonsending)' overload with stricter execution on caller context semantics: withValue(_:operation:file:line:)")
-  @_disfavoredOverload
   public func withValue<R>( // for source compatibility
     _ valueDuringOperation: Value,
     operation: () async throws -> R,

--- a/stdlib/public/Concurrency/TaskLocal.swift
+++ b/stdlib/public/Concurrency/TaskLocal.swift
@@ -226,20 +226,49 @@ public final class TaskLocal<Value: Sendable>: Sendable, CustomStringConvertible
   /// in specific child tasks, the more specific (i.e. "deeper") binding is
   /// returned when the value is read.
   ///
+  /// The operation is guaranteed to execute in the calling context.
+  ///
   /// If the value is a reference type, it will be retained for the duration of
   /// the operation closure.
   ///
   /// If this method is called form a context where no current Swift concurrency task
   /// is available, a fallback thread-local is used to manage the task locals and
   /// all existing semantics of task-locals are upheld as-if a task was actually available.
+  @_alwaysEmitIntoClient
+  @discardableResult
+  @available(SwiftStdlib 5.1, *)
+  // ABI Note: @abi needed because the mangling otherwise conflicts with the
+  // legacy @_unsafeInheritExecutor declaration.
+  @abi(
+    nonisolated(nonsending) func withValueNonisolatedNonsending<R>(
+      _ valueDuringOperation: Value,
+      operation: nonisolated(nonsending) () async throws -> R,
+      file: String, line: UInt
+    ) async throws -> R
+  )
+  public nonisolated(nonsending) func withValue<R>(
+    _ valueDuringOperation: Value,
+    operation: nonisolated(nonsending) () async throws -> R,
+    file: String = #fileID, line: UInt = #line
+  ) async rethrows -> R {
+    return try await withValueImpl(
+      valueDuringOperation,
+      operation: operation,
+      file: file, line: line)
+  }
+
   @inlinable
   @discardableResult
   @available(SwiftStdlib 5.1, *)
   @backDeployed(before: SwiftStdlib 6.0)
-  public func withValue<R>(_ valueDuringOperation: Value,
-                           operation: () async throws -> R,
-                           isolation: isolated (any Actor)? = #isolation,
-                           file: String = #fileID, line: UInt = #line) async rethrows -> R {
+  @available(*, deprecated, message: "Prefer the 'nonisolated(nonsending)' overload with stricter execution on caller context semantics: withValue(_:operation:file:line:)")
+  @_disfavoredOverload
+  public func withValue<R>( // for source compatibility
+    _ valueDuringOperation: Value,
+    operation: () async throws -> R,
+    isolation: isolated (any Actor)? = #isolation,
+    file: String = #fileID, line: UInt = #line
+  ) async rethrows -> R {
     return try await withValueImpl(
       valueDuringOperation,
       operation: operation,
@@ -283,6 +312,24 @@ public final class TaskLocal<Value: Sendable>: Sendable, CustomStringConvertible
   /// calls to swift_task_de/alloc for the copy as follows:
   /// - withValue contains the compiler-emitted calls swift_task_de/alloc.
   /// - withValueImpl contains the calls to Builtin.{add,remove}TaskLocalValue
+  @_alwaysEmitIntoClient
+  @discardableResult
+  @available(SwiftStdlib 5.1, *)
+  internal nonisolated(nonsending) func withValueImpl<R>(
+    _ valueDuringOperation: __owned Value,
+    operation: nonisolated(nonsending) () async throws -> R,
+    file: String = #fileID, line: UInt = #line
+  ) async rethrows -> R {
+#if $BuiltinAddTaskLocalValue
+    let binding = Builtin.addTaskLocalValue(key, consume valueDuringOperation)
+    defer { Builtin.removeTaskLocalValue(binding) }
+#else
+    _taskLocalValuePush(key: key, value: consume valueDuringOperation)
+    defer { _taskLocalValuePop() }
+#endif
+    return try await operation()
+  }
+
   @inlinable
   @discardableResult
   @available(SwiftStdlib 5.1, *)
@@ -298,7 +345,6 @@ public final class TaskLocal<Value: Sendable>: Sendable, CustomStringConvertible
     _taskLocalValuePush(key: key, value: consume valueDuringOperation)
     defer { _taskLocalValuePop() }
 #endif
-
     return try await operation()
   }
 

--- a/test/Concurrency/nonisolated_nonsending_specialization.swift
+++ b/test/Concurrency/nonisolated_nonsending_specialization.swift
@@ -1,0 +1,229 @@
+// RUN: %target-swift-frontend -emit-sil -swift-version 6 -target %target-swift-5.1-abi-triple -verify %s | %FileCheck %s
+
+nonisolated(nonsending) func withValue(_ fn: nonisolated(nonsending) () async -> Void) async {
+}
+
+nonisolated(nonsending) func withValueWithArgument<T>(_ fn: nonisolated(nonsending) (T) async throws -> Void) async {
+}
+
+nonisolated(nonsending) func withValueGeneric<R>(_ fn: nonisolated(nonsending) () async throws -> R?) async throws {
+}
+
+func asyncTest(_ body: () async -> Void) async {
+}
+
+func throwingTest(_ body: () async -> Void) async throws {
+}
+
+func syncTest(_ body: () async -> Void) {
+}
+
+@MainActor func isolatedTest() {
+}
+
+@MainActor func isolatedTest(_ body: () async -> Void) async {
+}
+
+func dynamicIsolation(isolation: isolated (any Actor)? = nil, _ body: () async throws -> Void) async throws {
+}
+
+// CHECK: // testConcurrentIsolation<A>(_:body:)
+// CHECK: // Isolation: unspecified
+// CHECK-LABEL: sil hidden @$s37nonisolated_nonsending_specialization23testConcurrentIsolation_4bodyyx_yyYaXEtYalF : $@convention(thin) @async <U> (@in_guaranteed U, @guaranteed @noescape @async @callee_guaranteed () -> ()) -> () {
+// ---- closure #1-2
+// CHECK:  [[CLOSURE_1:%.*]] = function_ref @$s37nonisolated_nonsending_specialization23testConcurrentIsolation_4bodyyx_yyYaXEtYalFyyYaXEfU_ : $@convention(thin) @async (@sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, @guaranteed @noescape @async @callee_guaranteed () -> ()) -> ()
+// CHECK:  [[CLOSURE_1_WITH_BODY:%.*]] = partial_apply [callee_guaranteed] [on_stack] [[CLOSURE_1]](%1) : $@convention(thin) @async (@sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, @guaranteed @noescape @async @callee_guaranteed () -> ()) -> ()
+// CHECK:  [[CLOSURE_1:%.*]] = mark_dependence [[CLOSURE_1_WITH_BODY]] on %1
+// CHECK:  [[CONVERTED_CLOSURE_1:%.*]] = convert_function [[CLOSURE_1]] to $@caller_isolated @noescape @async @callee_guaranteed (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor) -> ()
+// CHECK:  [[WITH_VALUE:%.*]] = function_ref @$s37nonisolated_nonsending_specialization9withValueyyyyYaYCXEYaF : $@convention(thin) @caller_isolated @async (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, @guaranteed @caller_isolated @noescape @async @callee_guaranteed (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor) -> ()) -> ()
+// CHECK:  apply [[WITH_VALUE]]({{.*}}, [[CONVERTED_CLOSURE_1]])
+// ---- closure #3-5
+// CHECK:  [[CLOSURE_3:%.*]] = function_ref @$s37nonisolated_nonsending_specialization23testConcurrentIsolation_4bodyyx_yyYaXEtYalFySiYaXEfU1_ : $@convention(thin) @async @substituted <τ_0_0> (@sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, @in_guaranteed τ_0_0, @guaranteed @noescape @async @callee_guaranteed () -> ()) -> @error any Error for <Int>
+// CHECK:  [[CLOSURE_3_WITH_BODY:%.*]] = partial_apply [callee_guaranteed] [on_stack] [[CLOSURE_3]](%1) : $@convention(thin) @async @substituted <τ_0_0> (@sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, @in_guaranteed τ_0_0, @guaranteed @noescape @async @callee_guaranteed () -> ()) -> @error any Error for <Int>
+// CHECK:  [[CLOSURE_3:%.*]] = mark_dependence [[CLOSURE_3_WITH_BODY]] on %1
+// CHECK:  [[CONVERTED_CLOSURE_3:%.*]] = convert_function [[CLOSURE_3]] to $@caller_isolated @noescape @async @callee_guaranteed @substituted <τ_0_0> (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, @in_guaranteed τ_0_0) -> @error any Error for <Int>
+// CHECK:  [[WITH_VALUE_WITH_ARGUMENT:%.*]] = function_ref @$s37nonisolated_nonsending_specialization21withValueWithArgumentyyyxYaKYCXEYalF : $@convention(thin) @caller_isolated @async <τ_0_0> (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, @guaranteed @caller_isolated @noescape @async @callee_guaranteed @substituted <τ_0_0> (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, @in_guaranteed τ_0_0) -> @error any Error for <τ_0_0>) -> ()
+// CHECK:  apply [[WITH_VALUE_WITH_ARGUMENT]]<Int>({{.*}}, [[CONVERTED_CLOSURE_3]])
+// CHECK: } // end sil function '$s37nonisolated_nonsending_specialization23testConcurrentIsolation_4bodyyx_yyYaXEtYalF'                                                                                                                                        
+func testConcurrentIsolation<U>(_: U, body: () async -> Void) async {
+  // CHECK: // closure #1 in testConcurrentIsolation<A>(_:body:)
+  // CHECK: // Isolation: @concurrent
+  // CHECK-LABEL: sil private @$s37nonisolated_nonsending_specialization23testConcurrentIsolation_4bodyyx_yyYaXEtYalFyyYaXEfU_ : $@convention(thin) @async (@sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, @guaranteed @noescape @async @callee_guaranteed () -> ()) -> () {
+  // CHECK: bb0([[IGNORED_ISOLATION:%.*]] : $Builtin.ImplicitActor, [[BODY:%.*]] : @closureCapture $@noescape @async @callee_guaranteed () -> ()):
+  // CHECK:   [[ASYNC_TEST:%.*]] = function_ref @$s37nonisolated_nonsending_specialization9asyncTestyyyyYaXEYaF : $@convention(thin) @async (@guaranteed @noescape @async @callee_guaranteed () -> ()) -> ()
+  // CHECK:   apply [[ASYNC_TEST]]([[BODY]]) : $@convention(thin) @async (@guaranteed @noescape @async @callee_guaranteed () -> ()) -> ()
+  // CHECK: } // end sil function '$s37nonisolated_nonsending_specialization23testConcurrentIsolation_4bodyyx_yyYaXEtYalFyyYaXEfU_'
+  await withValue {
+    await asyncTest(body) // Ok
+  }
+
+  // CHECK: // closure #2 in testConcurrentIsolation<A>(_:body:)
+  // CHECK: // Isolation: @concurrent
+  // CHECK-LABEL: sil private @$s37nonisolated_nonsending_specialization23testConcurrentIsolation_4bodyyx_yyYaXEtYalFyyYaXEfU0_ : $@convention(thin) @async (@sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, @guaranteed @noescape @async @callee_guaranteed () -> ()) -> () {
+  // CHECK: bb0([[IGNORED_ISOLATION:%.*]] : $Builtin.ImplicitActor, [[BODY:%.*]] : @closureCapture $@noescape @async @callee_guaranteed () -> ()):
+  // CHECK-NOT: hop_to_executor {{.*}}
+  // CHECK:   [[SYNC_TEST:%.*]] = function_ref @$s37nonisolated_nonsending_specialization8syncTestyyyyYaXEF : $@convention(thin) (@guaranteed @noescape @async @callee_guaranteed () -> ()) -> ()
+  // CHECK:   apply [[SYNC_TEST]]([[BODY]]) : $@convention(thin) (@guaranteed @noescape @async @callee_guaranteed () -> ()) -> ()
+  // CHECK: } // end sil function '$s37nonisolated_nonsending_specialization23testConcurrentIsolation_4bodyyx_yyYaXEtYalFyyYaXEfU0_'
+  await withValue {
+    syncTest(body) // Ok
+  }
+
+  // CHECK: // closure #3 in testConcurrentIsolation<A>(_:body:)
+  // CHECK: // Isolation: @concurrent
+  // CHECK-LABEL: sil private @$s37nonisolated_nonsending_specialization23testConcurrentIsolation_4bodyyx_yyYaXEtYalFySiYaXEfU1_ : $@convention(thin) @async @substituted <τ_0_0> (@sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, @in_guaranteed τ_0_0, @guaranteed @noescape @async @callee_guaranteed () -> ()) -> @error any Error for <Int> {
+  // CHECK: bb0([[IGNORED_ISOLATION:%.*]] : $Builtin.ImplicitActor, [[V:%.*]] : $*Int, [[BODY:%.*]] : @closureCapture $@noescape @async @callee_guaranteed () -> ()):
+  // CHECK-NOT: hop_to_executor {{.*}}
+  // CHECK:   [[ASYNC_TEST:%.*]] = function_ref @$s37nonisolated_nonsending_specialization9asyncTestyyyyYaXEYaF : $@convention(thin) @async (@guaranteed @noescape @async @callee_guaranteed () -> ()) -> ()
+  // CHECK:   apply [[ASYNC_TEST]]([[BODY]]) : $@convention(thin) @async (@guaranteed @noescape @async @callee_guaranteed () -> ()) -> ()
+  // CHECK: } // end sil function '$s37nonisolated_nonsending_specialization23testConcurrentIsolation_4bodyyx_yyYaXEtYalFySiYaXEfU1_'
+  await withValueWithArgument { (v: Int) in
+    await asyncTest(body) // Ok
+  }
+
+  // CHECK: // closure #4 in testConcurrentIsolation<A>(_:body:)
+  // CHECK: // Isolation: @concurrent
+  // CHECK-LABEL: sil private @$s37nonisolated_nonsending_specialization23testConcurrentIsolation_4bodyyx_yyYaXEtYalFyyt_tYaKXEfU2_ : $@convention(thin) @async @substituted <τ_0_0> (@sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, @in_guaranteed τ_0_0, @guaranteed @noescape @async @callee_guaranteed () -> ()) -> @error any Error for <()> {
+  // CHECK: bb0([[IGNORED_ISOLATION:%.*]] : $Builtin.ImplicitActor, [[V:%.*]] : $*(), [[BODY:%.*]] : @closureCapture $@noescape @async @callee_guaranteed () -> ()):
+  // CHECK-NOT: hop_to_executor {{.*}}
+  // CHECK:   [[THROWING_TEST:%.*]] = function_ref @$s37nonisolated_nonsending_specialization12throwingTestyyyyYaXEYaKF : $@convention(thin) @async (@guaranteed @noescape @async @callee_guaranteed () -> ()) -> @error any Error
+  // CHECK:   try_apply [[THROWING_TEST]]([[BODY]]) : $@convention(thin) @async (@guaranteed @noescape @async @callee_guaranteed () -> ()) -> @error any Error, normal bb1, error bb2
+  // CHECK: } // end sil function '$s37nonisolated_nonsending_specialization23testConcurrentIsolation_4bodyyx_yyYaXEtYalFyyt_tYaKXEfU2_'
+  await withValueWithArgument { (v: Void) in
+    try await throwingTest(body) // Ok
+  }
+
+  // CHECK: // closure #5 in testConcurrentIsolation<A>(_:body:)
+  // CHECK: // Isolation: @concurrent
+  // CHECK-LABEL: sil private @$s37nonisolated_nonsending_specialization23testConcurrentIsolation_4bodyyx_yyYaXEtYalFySi_SSxt_tYaXEfU3_ : $@convention(thin) @async <U> (@sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, @in_guaranteed (Int, String, U), @guaranteed @noescape @async @callee_guaranteed () -> ()) -> @error any Error {
+  // CHECK: bb0([[IGNORED_ISOLATION:%.*]] : $Builtin.ImplicitActor, [[V:%.*]] : $*(Int, String, U), [[BODY:%.*]] : @closureCapture $@noescape @async @callee_guaranteed () -> ()):
+  // CHECK-NOT: hop_to_executor {{.*}}
+  // CHECK:   [[SYNC_TEST:%.*]] = function_ref @$s37nonisolated_nonsending_specialization8syncTestyyyyYaXEF : $@convention(thin) (@guaranteed @noescape @async @callee_guaranteed () -> ()) -> ()
+  // CHECK:   apply [[SYNC_TEST]]([[BODY]]) : $@convention(thin) (@guaranteed @noescape @async @callee_guaranteed () -> ()) -> ()
+  // CHECK: } // end sil function '$s37nonisolated_nonsending_specialization23testConcurrentIsolation_4bodyyx_yyYaXEtYalFySi_SSxt_tYaXEfU3_'
+  await withValueWithArgument { (v: (Int, String, U)) in
+    syncTest(body) // Ok
+  }
+
+  // CHECK: // closure #6 in testConcurrentIsolation<A>(_:body:)
+  // CHECK: // Isolation: @concurrent
+  // CHECK-LABEL: sil private @$s37nonisolated_nonsending_specialization23testConcurrentIsolation_4bodyyx_yyYaXEtYalFyyYaXEfU4_ : $@convention(thin) @async (@sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, @guaranteed @noescape @async @callee_guaranteed () -> ()) -> () {
+  // CHECK: bb0([[IGNORED_ISOLATION:%.*]] : $Builtin.ImplicitActor, [[BODY:%.*]] : @closureCapture $@noescape @async @callee_guaranteed () -> ()):
+  // CHECK:   [[ISOLATION:%.*]] = enum $Optional<any Actor>, #Optional.none!enumelt
+  // CHECK-NOT: hop_to_executor {{.*}}
+  // CHECK:   [[ASYNC_TEST:%.*]] = function_ref @$s37nonisolated_nonsending_specialization9asyncTestyyyyYaXEYaF : $@convention(thin) @async (@guaranteed @noescape @async @callee_guaranteed () -> ()) -> ()
+  // CHECK:   apply [[ASYNC_TEST]]([[BODY]]) : $@convention(thin) @async (@guaranteed @noescape @async @callee_guaranteed () -> ()) -> ()
+  // CHECK:   hop_to_executor [[ISOLATION]]
+  // CHECK:   [[ISOLATED_TEST:%.*]] = function_ref @$s37nonisolated_nonsending_specialization12isolatedTestyyF : $@convention(thin) () -> ()
+  // CHECK:   [[MAIN_ACTOR_TYPE:%.*]] = metatype $@thick MainActor.Type
+  // CHECK:   [[MAIN_ACTOR_EXEC_REF:%.*]] = function_ref @$sScM6sharedScMvgZ : $@convention(method) (@thick MainActor.Type) -> @owned MainActor
+  // CHECK:   [[MAIN_ACTOR:%.*]] = apply [[MAIN_ACTOR_EXEC_REF]]([[MAIN_ACTOR_TYPE]]) : $@convention(method) (@thick MainActor.Type) -> @owned MainActor
+  // CHECK:   hop_to_executor [[MAIN_ACTOR]]
+  // CHECK:   apply [[ISOLATED_TEST]]() : $@convention(thin) () -> ()
+  // CHECK: } // end sil function '$s37nonisolated_nonsending_specialization23testConcurrentIsolation_4bodyyx_yyYaXEtYalFyyYaXEfU4_'
+  await withValue {
+    await asyncTest(body) // Ok
+    await isolatedTest()  // Ok
+  }
+
+  // CHECK: // closure #7 in testConcurrentIsolation<A>(_:body:)
+  // CHECK: // Isolation: @concurrent
+  // CHECK: sil private @$s37nonisolated_nonsending_specialization23testConcurrentIsolation_4bodyyx_yyYaXEtYalFyyYaXEfU5_ : $@convention(thin) @async (@sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, @guaranteed @noescape @async @callee_guaranteed () -> ()) -> () {
+  // CHECK: bb0([[IGNORED_ISOLATION:%.*]] : $Builtin.ImplicitActor, [[BODY:%.*]] : @closureCapture $@noescape @async @callee_guaranteed () -> ()):
+  // CHECK:   [[ISOLATION:%.*]] = enum $Optional<any Actor>, #Optional.none!enumelt
+  // CHECK-NOT: hop_to_executor {{.*}}
+  // CHECK:   [[ASYNC_TEST:%.*]] = function_ref @$s37nonisolated_nonsending_specialization9asyncTestyyyyYaXEYaF : $@convention(thin) @async (@guaranteed @noescape @async @callee_guaranteed () -> ()) -> ()
+  // CHECK:   apply [[ASYNC_TEST]]([[BODY]]) : $@convention(thin) @async (@guaranteed @noescape @async @callee_guaranteed () -> ()) -> ()
+  // CHECK:   hop_to_executor [[ISOLATION]]
+  // CHECK:   [[SYNC_TEST:%.*]] = function_ref @$s37nonisolated_nonsending_specialization8syncTestyyyyYaXEF : $@convention(thin) (@guaranteed @noescape @async @callee_guaranteed () -> ()) -> ()
+  // CHECK:   apply [[SYNC_TEST]]([[BODY]]) : $@convention(thin) (@guaranteed @noescape @async @callee_guaranteed () -> ()) -> ()
+  // CHECK: } // end sil function '$s37nonisolated_nonsending_specialization23testConcurrentIsolation_4bodyyx_yyYaXEtYalFyyYaXEfU5_'
+  await withValue {
+    await asyncTest(body) // Ok
+    syncTest(body) // Ok
+  }
+}
+
+// CHECK: // testMainActorIsolation(body:)
+// CHECK: // Isolation: global_actor. type: MainActor
+// CHECK-LABEL: sil hidden @$s37nonisolated_nonsending_specialization22testMainActorIsolation4bodyyyyYaXE_tYaF : $@convention(thin) @async (@guaranteed @noescape @async @callee_guaranteed () -> ()) -> () {
+// CHECK:  [[CLOSURE:%.*]] = function_ref @$s37nonisolated_nonsending_specialization22testMainActorIsolation4bodyyyyYaXE_tYaFyyYaXEfU_ : $@convention(thin) @async (@sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, @guaranteed @noescape @async @callee_guaranteed () -> ()) -> ()
+// CHECK:  [[CLOSURE_WITH_BODY:%.*]] = partial_apply [callee_guaranteed] [on_stack] [[CLOSURE]](%0) : $@convention(thin) @async (@sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, @guaranteed @noescape @async @callee_guaranteed () -> ()) -> ()
+// CHECK:  [[CLOSURE:%.*]] = mark_dependence [[CLOSURE_WITH_BODY]] on %0
+// CHECK:  convert_function [[CLOSURE]] to $@caller_isolated @noescape @async @callee_guaranteed (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor) -> ()
+// CHECK: } // end sil function '$s37nonisolated_nonsending_specialization22testMainActorIsolation4bodyyyyYaXE_tYaF'
+@MainActor func testMainActorIsolation(body: () async -> Void) async {
+  // CHECK: // closure #1 in testMainActorIsolation(body:)
+  // CHECK: // Isolation: global_actor. type: MainActor
+  // CHECK: sil private @$s37nonisolated_nonsending_specialization22testMainActorIsolation4bodyyyyYaXE_tYaFyyYaXEfU_ : $@convention(thin) @async (@sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, @guaranteed @noescape @async @callee_guaranteed () -> ()) -> () {
+  // CHECK: bb0([[IGNORED_ISOLATION:%.*]] : $Builtin.ImplicitActor, [[BODY:%.*]] : @closureCapture $@noescape @async @callee_guaranteed () -> ()):
+  // CHECK-NOT: hop_to_executor {{.*}}
+  // CHECK:   [[MAIN_ACTOR:%.*]] = apply [[MAIN_ACTOR_REF:%.*]]({{.*}}) : $@convention(method) (@thick MainActor.Type) -> @owned MainActor
+  // CHECK:   [[ISOLATED_TEST:%.*]] = function_ref @$s37nonisolated_nonsending_specialization12isolatedTestyyyyYaXEYaF : $@convention(thin) @async (@guaranteed @noescape @async @callee_guaranteed () -> ()) -> ()
+  // CHECK:   apply [[ISOLATED_TEST]]([[BODY]]) : $@convention(thin) @async (@guaranteed @noescape @async @callee_guaranteed () -> ()) -> ()
+  // CHECK:   hop_to_executor [[MAIN_ACTOR]]
+  // CHECK:   [[SYNC_TEST:%.*]] = function_ref @$s37nonisolated_nonsending_specialization8syncTestyyyyYaXEF : $@convention(thin) (@guaranteed @noescape @async @callee_guaranteed () -> ()) -> ()
+  // CHECK:   %11 = apply [[SYNC_TEST]]([[BODY]]) : $@convention(thin) (@guaranteed @noescape @async @callee_guaranteed () -> ()) -> ()
+  // CHECK: } // end sil function '$s37nonisolated_nonsending_specialization22testMainActorIsolation4bodyyyyYaXE_tYaFyyYaXEfU_'
+  await withValue {
+    await isolatedTest(body) // Ok
+    syncTest(body) // Ok
+  }
+}
+
+// CHECK: // testDynamicIsolation(isolation:body:)
+// CHECK: // Isolation: actor_instance. name: 'isolation'
+// CHECK-LABEL: sil hidden @$s37nonisolated_nonsending_specialization20testDynamicIsolation9isolation4bodyyScA_pSgYi_yyYaXEtYaF : $@convention(thin) @async (@sil_isolated @guaranteed Optional<any Actor>, @guaranteed @noescape @async @callee_guaranteed () -> ()) -> () {
+// CHECK: bb0([[ISOLATION:%.*]] : $Optional<any Actor>, [[BODY:%.*]] : $@noescape @async @callee_guaranteed () -> ()):
+// CHECK:  [[CLOSURE:%.*]] = function_ref @$s37nonisolated_nonsending_specialization20testDynamicIsolation9isolation4bodyyScA_pSgYi_yyYaXEtYaFyyt_tYaKXEfU_ : $@convention(thin) @async @substituted <τ_0_0> (@sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, @in_guaranteed τ_0_0, @sil_isolated @guaranteed Optional<any Actor>, @guaranteed @noescape @async @callee_guaranteed () -> ()) -> @error any Error for <()>
+// CHECK:  [[PARTIALLY_APPLIED:%.*]] = partial_apply [callee_guaranteed] [on_stack] [[CLOSURE]]([[ISOLATION]], [[BODY]]) : $@convention(thin) @async @substituted <τ_0_0> (@sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, @in_guaranteed τ_0_0, @sil_isolated @guaranteed Optional<any Actor>, @guaranteed @noescape @async @callee_guaranteed () -> ()) -> @error any Error for <()>
+// CHECK:  [[CLOSURE_REF:%.*]] = mark_dependence [[PARTIALLY_APPLIED]] on [[ISOLATION]]
+// CHECK:  [[COMPLETE_CLOSURE:%.*]] = mark_dependence [[CLOSURE_REF]] on [[BODY]]
+// CHECK:  [[CONVERTED_CLOSURE:%.*]] = convert_function [[COMPLETE_CLOSURE]] to $@caller_isolated @noescape @async @callee_guaranteed @substituted <τ_0_0> (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, @in_guaranteed τ_0_0) -> @error any Error for <()>
+// CHECK:  apply {{.*}}<()>({{.*}}, [[CONVERTED_CLOSURE:%.*]]) : $@convention(thin) @caller_isolated @async <τ_0_0> (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, @guaranteed @caller_isolated @noescape @async @callee_guaranteed @substituted <τ_0_0> (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, @in_guaranteed τ_0_0) -> @error any Error for <τ_0_0>) -> ()
+// CHECK: } // end sil function '$s37nonisolated_nonsending_specialization20testDynamicIsolation9isolation4bodyyScA_pSgYi_yyYaXEtYaF'
+func testDynamicIsolation(isolation: isolated (any Actor)?, body: () async -> Void) async {
+  // CHECK: // closure #1 in testDynamicIsolation(isolation:body:)
+  // CHECK: // Isolation: actor_instance. name: 'isolation'
+  // CHECK: sil private @$s37nonisolated_nonsending_specialization20testDynamicIsolation9isolation4bodyyScA_pSgYi_yyYaXEtYaFyyt_tYaKXEfU_ : $@convention(thin) @async @substituted <τ_0_0> (@sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, @in_guaranteed τ_0_0, @sil_isolated @guaranteed Optional<any Actor>, @guaranteed @noescape @async @callee_guaranteed () -> ()) -> @error any Error for <()> {
+  // CHECK: bb0([[IGNORED_ISOLATION:%.*]] : $Builtin.ImplicitActor, [[V:%.*]] : $*(), [[DYNAMIC_ISOLATION:%.*]] : @closureCapture $Optional<any Actor>, [[BODY:%.*]] : @closureCapture $@noescape @async @callee_guaranteed () -> ()):
+  // CHECK-NOT: hop_to_executor {{.*}}
+  // CHECK:   [[THUNK:%.*]] = function_ref @$sIgH_s5Error_pIegHzo_TR : $@convention(thin) @async (@guaranteed @noescape @async @callee_guaranteed () -> ()) -> @error any Error
+  // CHECK:   [[THUNKED_BODY:%.*]] = partial_apply [callee_guaranteed] [on_stack] [[THUNK]]([[BODY]]) : $@convention(thin) @async (@guaranteed @noescape @async @callee_guaranteed () -> ()) -> @error any Error
+  // CHECK:   [[BODY_WITH_DEPENDENCE:%.*]] = mark_dependence [[THUNKED_BODY]] on [[BODY]]
+  // CHECK:   [[DYNAMIC_ISOLATION_TEST:%.*]] = function_ref @$s37nonisolated_nonsending_specialization16dynamicIsolation9isolation_yScA_pSgYi_yyYaKXEtYaKF : $@convention(thin) @async (@sil_isolated @guaranteed Optional<any Actor>, @guaranteed @noescape @async @callee_guaranteed () -> @error any Error) -> @error any Error
+  // CHECK:   try_apply [[DYNAMIC_ISOLATION_TEST]]([[DYNAMIC_ISOLATION]], [[BODY_WITH_DEPENDENCE]]) : $@convention(thin) @async (@sil_isolated @guaranteed Optional<any Actor>, @guaranteed @noescape @async @callee_guaranteed () -> @error any Error) -> @error any Error, normal bb1, error bb2
+  //
+  // CHECK: bb1({{.*}} : $()):
+  // CHECK:   hop_to_executor [[DYNAMIC_ISOLATION]]
+  //
+  // CHECK: bb2({{.*}} : $any Error):
+  // CHECK:   hop_to_executor [[DYNAMIC_ISOLATION]]
+  // CHECK: } // end sil function '$s37nonisolated_nonsending_specialization20testDynamicIsolation9isolation4bodyyScA_pSgYi_yyYaXEtYaFyyt_tYaKXEfU_'
+  await withValueWithArgument { (v: Void) in
+    try await dynamicIsolation(isolation: isolation, body)
+  }
+}
+
+func testReabstraction(body: () async -> Void) async throws {
+  // CHECK: // closure #1 in testReabstraction(body:)
+  // CHECK: // Isolation: @concurrent
+  // CHECK: sil private @$s37nonisolated_nonsending_specialization17testReabstraction4bodyyyyYaXE_tYaKFyyYaKXEfU_ : $@convention(thin) @async (@sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, @guaranteed @noescape @async @callee_guaranteed () -> ()) -> @error any Error {
+  // CHECK-NOT: hop_to_executor {{.*}}
+  // CHECK: } // end sil function '$s37nonisolated_nonsending_specialization17testReabstraction4bodyyyyYaXE_tYaKFyyYaKXEfU_'
+  try await withValueGeneric {
+    _ = 42
+    try await throwingTest(body)
+  }
+}
+
+// Reabstraction thunk for `testReabstraction` closure
+//
+// CHECK: // thunk for @caller_isolated @callee_guaranteed @async (@guaranteed Builtin.ImplicitActor) -> (@error @owned Error)
+// CHECK: // Isolation: nonisolated(nonsending)
+// CHECK: sil shared [transparent] [reabstraction_thunk] @$sBAs5Error_pINgHgILzo_BAytSgsAA_pIeNgHgILrzo_TR : $@convention(thin) @caller_isolated @async (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor, @guaranteed @caller_isolated @noescape @async @callee_guaranteed (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor) -> @error any Error) -> (@out Optional<()>, @error any Error) {
+// CHECK: bb0(%0 : $*Optional<()>, [[ISOLATION:%.*]] : $Builtin.ImplicitActor, [[CLOSURE:%.*]] : $@caller_isolated @noescape @async @callee_guaranteed (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor) -> @error any Error):
+// The hop gets eliminated because the parameter is also `nonisolated(nonsending)`
+// CHECK-NOT:   hop_to_executor [[ISOLATION]]
+// CHECK:   try_apply [[CLOSURE]]([[ISOLATION]]) : $@caller_isolated @noescape @async @callee_guaranteed (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor) -> @error any Error, normal bb1, error bb2
+// CHECK: } // end sil function '$sBAs5Error_pINgHgILzo_BAytSgsAA_pIeNgHgILrzo_TR'

--- a/test/Concurrency/transfernonsendable_nonisolated.swift
+++ b/test/Concurrency/transfernonsendable_nonisolated.swift
@@ -134,16 +134,24 @@ func callMainActorIsolatedFunction() async {
 }
 
 public final class LoggingScope {
-  fileprivate static let _subsystem: TaskLocal<String?>! = nil
-  fileprivate static let _scope: TaskLocal<String?>! = nil
+  static let _subsystem: TaskLocal<String?>! = nil
 }
 
-public func withLoggingSubsystemAndScope<Result>(
-  subsystem: String,
-  scope: String?,
-  @_inheritActorContext _ operation: @Sendable @concurrent () async throws -> Result
-) async rethrows -> Result {
-  return try await LoggingScope._subsystem.withValue(subsystem) {
-    return try await LoggingScope._scope.withValue(scope, operation: operation)
+func withCancellationHandling<R>(_ body: () async throws -> R) async rethrows -> R {
+  try await body()
+}
+
+func withLoggingSubsystemAndScope<R>(
+    perform body: () async throws -> R
+) async rethrows -> R {
+  return try await LoggingScope._subsystem.withValue(nil) {
+    try await withCancellationHandling(body)
+  }
+}
+func withLoggingSubsystemAndScopeNonsending<R>(
+  perform body: nonisolated(nonsending) () async throws -> R
+) async rethrows -> R {
+  return try await LoggingScope._subsystem.withValue(nil) {
+    try await withCancellationHandling(body)
   }
 }

--- a/test/api-digester/stability-concurrency-abi.test
+++ b/test/api-digester/stability-concurrency-abi.test
@@ -109,13 +109,15 @@ Func SerialExecutor.enqueue(_:) has been added as a protocol requirement
 Func Executor.enqueue(_:) is a new API without '@available'
 
 // Adopt #isolation in TaskLocal.withValue APIs
-Func TaskLocal.withValue(_:operation:file:line:) has been renamed to Func withValue(_:operation:isolation:file:line:)
+Func TaskLocal.withValue(_:operation:file:line:) has been renamed to Func withValueImpl(_:operation:isolation:file:line:)
 Func TaskLocal.withValue(_:operation:file:line:) has mangled name changing from '_Concurrency.TaskLocal.withValue<A>(_: A, operation: () async throws -> A1, file: Swift.String, line: Swift.UInt) async throws -> A1' to '_Concurrency.TaskLocal.withValue<A>(_: A, operation: () throws -> A1, file: Swift.String, line: Swift.UInt) throws -> A1'
-Func TaskLocal.withValue(_:operation:file:line:) has mangled name changing from '_Concurrency.TaskLocal.withValue<A>(_: A, operation: () throws -> A1, file: Swift.String, line: Swift.UInt) throws -> A1' to '_Concurrency.TaskLocal.withValue<A>(_: A, operation: () async throws -> A1, isolation: isolated Swift.Optional<Swift.Actor>, file: Swift.String, line: Swift.UInt) async throws -> A1'
+Func TaskLocal.withValue(_:operation:file:line:) has mangled name changing from '_Concurrency.TaskLocal.withValue<A>(_: A, operation: () throws -> A1, file: Swift.String, line: Swift.UInt) throws -> A1' to '_Concurrency.TaskLocal.withValueImpl<A>(_: __owned A, operation: () async throws -> A1, isolation: isolated Swift.Optional<Swift.Actor>, file: Swift.String, line: Swift.UInt) async throws -> A1'
+Func TaskLocal.withValue(_:operation:file:line:) has parameter 0 changing from Default to Owned
 Func TaskLocal.withValue(_:operation:file:line:) has parameter 1 type change from () async throws -> τ_1_0 to () throws -> τ_1_0
 Func TaskLocal.withValue(_:operation:file:line:) has parameter 1 type change from () throws -> τ_1_0 to () async throws -> τ_1_0
 Func TaskLocal.withValue(_:operation:file:line:) has parameter 2 type change from Swift.String to (any _Concurrency.Actor)?
 Func TaskLocal.withValue(_:operation:file:line:) has parameter 3 type change from Swift.UInt to Swift.String
+Func TaskLocal.withValue(_:operation:file:line:) has removed default argument from parameter 2
 Func withTaskGroup(of:returning:body:) has parameter 2 type change from (inout _Concurrency.TaskGroup<τ_0_0>) async -> τ_0_1 to (any _Concurrency.Actor)?
 Func withThrowingTaskGroup(of:returning:body:) has been renamed to Func withThrowingTaskGroup(of:returning:isolation:body:)
 Func withThrowingTaskGroup(of:returning:body:) has mangled name changing from '_Concurrency.withThrowingTaskGroup<A, B where A: Swift.Sendable>(of: A.Type, returning: B.Type, body: (inout Swift.ThrowingTaskGroup<A, Swift.Error>) async throws -> B) async throws -> B' to '_Concurrency.withThrowingTaskGroup<A, B where A: Swift.Sendable>(of: A.Type, returning: B.Type, isolation: isolated Swift.Optional<Swift.Actor>, body: (inout Swift.ThrowingTaskGroup<A, Swift.Error>) async throws -> B) async throws -> B'


### PR DESCRIPTION
- Explanation:

   Makes the methods themselves and their async function value parameters nonisolated(nonsending) to avoid unintended extra hops that hurt performance.

   Maintains source compatibility by preserving old versions of the API.

   This change ports specialization of `nonisolated(nonsending)` closures which is necessary to make region-based isolation work for these methods.

- Resolves: rdar://177390104, rdar://177390199

- Main branch PRs: https://github.com/swiftlang/swift/pull/89061, https://github.com/swiftlang/swift/pull/88811

- Risk: Low. This change affects only two standard library APIs and their old variants are preserved without disfavoring. Changes to `nonisolated(nonsending)` are scoped to closures only and won't impact anybody who didn't adopt `nonisolated(nonsending)` in their APIs.

- Reviewed By: @ktoso  

- Testing: Added new test-cases to the suite.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
