### PR TITLE
[RemoteInspection] Mark test as unsupported in remote runs

### DIFF
--- a/validation-test/Reflection/reflect_extension_parent_class.swift
+++ b/validation-test/Reflection/reflect_extension_parent_class.swift
@@ -13,6 +13,7 @@
 // REQUIRES: reflection_test_support
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: asan
+// UNSUPPORTED: remote_run
 
 // Verifies that reflection can resolve types declared inside a cross-module
 // extension — i.e., types whose parent (the extended type) lives in a


### PR DESCRIPTION
reflect_extension_parent_class builds a separate Base.dylib and links the main executable against it. On device targets, remote-run only ships files referenced on the test command line, so libBase.dylib never reaches the device and dyld fails to load it.

rdar://177397336
