### PR TITLE
[6.4] [CS] Remove `shouldHaveDirectCalleeOverload`

### DIFF
--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -4141,37 +4141,6 @@ Solution::getConversionRestriction(CanType type1, CanType type2) const {
   return std::nullopt;
 }
 
-#ifndef NDEBUG
-/// Given an apply expr, returns true if it is expected to have a direct callee
-/// overload, resolvable using `getChoiceFor`. Otherwise, returns false.
-static bool shouldHaveDirectCalleeOverload(const CallExpr *callExpr) {
-  auto *fnExpr = callExpr->getDirectCallee();
-
-  // An apply of an apply/subscript doesn't have a direct callee.
-  if (isa<ApplyExpr>(fnExpr) || isa<SubscriptExpr>(fnExpr))
-    return false;
-
-  // Applies of closures don't have callee overloads.
-  if (isa<ClosureExpr>(fnExpr))
-    return false;
-
-  // No direct callee for a try!/try?.
-  if (isa<ForceTryExpr>(fnExpr) || isa<OptionalTryExpr>(fnExpr))
-    return false;
-
-  // If we have an intermediate cast, there's no direct callee.
-  if (isa<ExplicitCastExpr>(fnExpr))
-    return false;
-
-  // No direct callee for a ternary expr.
-  if (isa<TernaryExpr>(fnExpr))
-    return false;
-
-  // Assume that anything else would have a direct callee.
-  return true;
-}
-#endif
-
 ASTNode ConstraintSystem::includingParentApply(ASTNode node) {
   if (auto *expr = getAsExpr(node)) {
     if (auto apply = getAsExpr<ApplyExpr>(getParentExpr(expr))) {
@@ -4263,9 +4232,6 @@ Solution::getFunctionArgApplyInfo(ConstraintLocator *locator) const {
       if (metaTy->getInstanceType()->is<TupleType>())
         return std::nullopt;
     }
-
-    assert(!shouldHaveDirectCalleeOverload(call) &&
-             "Should we have resolved a callee for this?");
   }
 
   // Try to resolve the function type by loading lvalues and looking through

--- a/validation-test/IDE/crashers_fixed/Solution-getFunctionArgApplyInfo-f44add.swift
+++ b/validation-test/IDE/crashers_fixed/Solution-getFunctionArgApplyInfo-f44add.swift
@@ -1,5 +1,5 @@
 // {"kind":"complete","original":"22c5dffd","signature":"swift::constraints::Solution::getFunctionArgApplyInfo(swift::constraints::ConstraintLocator*) const","signatureAssert":"Assertion failed: (!shouldHaveDirectCalleeOverload(call) && \"Should we have resolved a callee for this?\"), function getFunctionArgApplyInfo","signatureNext":"ArgumentTypeCheckCompletionCallback::sawSolutionImpl"}
-// RUN: not --crash %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -source-filename %s
+// RUN: %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -source-filename %s
 struct a {
   ap { a<b>(c( #^^#
   }

--- a/validation-test/compiler_crashers_fixed/Solution-getFunctionArgApplyInfo-00bf5e.swift
+++ b/validation-test/compiler_crashers_fixed/Solution-getFunctionArgApplyInfo-00bf5e.swift
@@ -1,0 +1,6 @@
+// {"kind":"typecheck","original":"940008f2","signature":"swift::constraints::Solution::getFunctionArgApplyInfo(swift::constraints::ConstraintLocator*) const","signatureAssert":"Assertion failed: (!shouldHaveDirectCalleeOverload(call) && \"Should we have resolved a callee for this?\"), function getFunctionArgApplyInfo","signatureNext":"GenericArgumentsMismatchFailure::diagnoseAsError"}
+// RUN: not %target-swift-frontend -typecheck %s
+func a<b, each c>(d: repeat (b inout [each c]) -> Void) {
+  var f: [Any]  repeat
+    (d(e
+    f

--- a/validation-test/compiler_crashers_fixed/Solution-getFunctionArgApplyInfo-13ac67.swift
+++ b/validation-test/compiler_crashers_fixed/Solution-getFunctionArgApplyInfo-13ac67.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","original":"0bee11b5","signature":"swift::constraints::Solution::getFunctionArgApplyInfo(swift::constraints::ConstraintLocator*) const","signatureAssert":"Assertion failed: (!shouldHaveDirectCalleeOverload(call) && \"Should we have resolved a callee for this?\"), function getFunctionArgApplyInfo","signatureNext":"RValueTreatedAsLValueFailure::diagnoseAsError"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 @propertyWrapper struct a<b> {
   var c: d
   var wrappedValue: b {

--- a/validation-test/compiler_crashers_fixed/Solution-getFunctionArgApplyInfo-166f11.swift
+++ b/validation-test/compiler_crashers_fixed/Solution-getFunctionArgApplyInfo-166f11.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","original":"e34f553a","signature":"swift::constraints::Solution::getFunctionArgApplyInfo(swift::constraints::ConstraintLocator*) const","signatureAssert":"Assertion failed: (!shouldHaveDirectCalleeOverload(call) && \"Should we have resolved a callee for this?\"), function getFunctionArgApplyInfo","signatureNext":"MissingOptionalUnwrapFailure::offerDefaultValueUnwrapFixIt"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 func a<each b>(c: repeat each b?, d: repeat (each b) -> Bool) {
   repeat (d(c))
 }

--- a/validation-test/compiler_crashers_fixed/Solution-getFunctionArgApplyInfo-31f59b.swift
+++ b/validation-test/compiler_crashers_fixed/Solution-getFunctionArgApplyInfo-31f59b.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","original":"40a86b54","signature":"swift::constraints::Solution::getFunctionArgApplyInfo(swift::constraints::ConstraintLocator*) const","signatureAssert":"Assertion failed: (!shouldHaveDirectCalleeOverload(call) && \"Should we have resolved a callee for this?\"), function getFunctionArgApplyInfo","signatureNext":"MissingArgumentsFailure::diagnoseAsError"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 func a<b, each c>(d: repeat ((b) -> each c) -> Void, e: repeat () -> each c) {
   repeat (d(e))
 }

--- a/validation-test/compiler_crashers_fixed/Solution-getFunctionArgApplyInfo-3f6370.swift
+++ b/validation-test/compiler_crashers_fixed/Solution-getFunctionArgApplyInfo-3f6370.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","original":"98525e94","signature":"swift::constraints::Solution::getFunctionArgApplyInfo(swift::constraints::ConstraintLocator*) const","signatureAssert":"Assertion failed: (!shouldHaveDirectCalleeOverload(call) && \"Should we have resolved a callee for this?\"), function getFunctionArgApplyInfo","signatureNext":"InvalidUseOfAddressOf::diagnoseAsError"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 func a<b, each c>(d: b, e: repeat (b, each c) -> Void) {
   repeat (e(&d))
 }

--- a/validation-test/compiler_crashers_fixed/Solution-getFunctionArgApplyInfo-5d93b5.swift
+++ b/validation-test/compiler_crashers_fixed/Solution-getFunctionArgApplyInfo-5d93b5.swift
@@ -1,3 +1,3 @@
 // {"kind":"typecheck","original":"1b96e3e3","signature":"swift::constraints::Solution::getFunctionArgApplyInfo(swift::constraints::ConstraintLocator*) const","signatureAssert":"Assertion failed: (!shouldHaveDirectCalleeOverload(call) && \"Should we have resolved a callee for this?\"), function getFunctionArgApplyInfo","signatureNext":"RValueTreatedAsLValueFailure::diagnoseAsError"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 0(&0)

--- a/validation-test/compiler_crashers_fixed/Solution-getFunctionArgApplyInfo-60b044.swift
+++ b/validation-test/compiler_crashers_fixed/Solution-getFunctionArgApplyInfo-60b044.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","original":"123f98be","signature":"swift::constraints::Solution::getFunctionArgApplyInfo(swift::constraints::ConstraintLocator*) const","signatureAssert":"Assertion failed: (!shouldHaveDirectCalleeOverload(call) && \"Should we have resolved a callee for this?\"), function getFunctionArgApplyInfo","signatureNext":"MissingArgumentsFailure::diagnoseClosure"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 struct a<each b> {
   var c: (repeat ((each b) -> String) -> Int) = repeat (each c) {
   }

--- a/validation-test/compiler_crashers_fixed/Solution-getFunctionArgApplyInfo-86af0c.swift
+++ b/validation-test/compiler_crashers_fixed/Solution-getFunctionArgApplyInfo-86af0c.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","original":"bff75c6c","signature":"swift::constraints::Solution::getFunctionArgApplyInfo(swift::constraints::ConstraintLocator*) const","signatureAssert":"Assertion failed: (!shouldHaveDirectCalleeOverload(call) && \"Should we have resolved a callee for this?\"), function getFunctionArgApplyInfo","signatureNext":"InvalidPackExpansion::diagnoseAsError"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 func a<each b, each c>(d: repeat (repeat each b) -> each c) {
   repeat (d(.e))
 }

--- a/validation-test/compiler_crashers_fixed/Solution-getFunctionArgApplyInfo-c9616a.swift
+++ b/validation-test/compiler_crashers_fixed/Solution-getFunctionArgApplyInfo-c9616a.swift
@@ -1,3 +1,3 @@
 // {"kind":"typecheck","signature":"swift::constraints::Solution::getFunctionArgApplyInfo(swift::constraints::ConstraintLocator*) const","signatureAssert":"Assertion failed: (!shouldHaveDirectCalleeOverload(call) && \"Should we have resolved a callee for this?\"), function getFunctionArgApplyInfo","signatureNext":"AllowArgumentMismatch::diagnose"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 func a<b, each c>(d : repeat(b)->each c) { repeat d(e = f


### PR DESCRIPTION
*6.4 cherry-pick of #89318*

- Explanation: Removes an assertion that would incorrectly fire in a bunch of different cases
- Scope: Affects constraint system argument matching diagnostics
- Issue: N/A
- Risk: None, removes an !NDEBUG-only assert
- Testing: Added tests to test suite
- Reviewer: Slava Pestov, Pavel Yaskevich