### PR TITLE
Add pretty stacktrace printing in C++ module passes

### DIFF
--- a/lib/SILOptimizer/IPO/CrossModuleOptimization.cpp
+++ b/lib/SILOptimizer/IPO/CrossModuleOptimization.cpp
@@ -15,11 +15,12 @@
 //===----------------------------------------------------------------------===//
 
 #define DEBUG_TYPE "cross-module-serialization-setup"
-#include "swift/AST/Module.h"
 #include "swift/AST/ImportCache.h"
+#include "swift/AST/Module.h"
 #include "swift/Basic/Assertions.h"
 #include "swift/IRGen/TBDGen.h"
 #include "swift/SIL/ApplySite.h"
+#include "swift/SIL/PrettyStackTrace.h"
 #include "swift/SIL/SILCloner.h"
 #include "swift/SIL/SILFunction.h"
 #include "swift/SIL/SILModule.h"
@@ -374,6 +375,8 @@ bool CrossModuleOptimization::isReferenceSerializeCandidate(SILGlobalVariable *G
 void CrossModuleOptimization::trySerializeFunctions(
     ArrayRef<SILFunction *> functions) {
   for (SILFunction *F : functions) {
+    PrettyStackTraceSILFunction stackTrace(
+        "running cross-module optimization on", F);
     if (isSerializeCandidate(F, M.getOptions()) || everything) {
       if (canSerializeFunction(F, canSerializeFlags, /*maxDepth*/ 64)) {
         serializeFunction(F, canSerializeFlags);

--- a/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
+++ b/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
@@ -15,6 +15,7 @@
 #include "swift/Basic/Assertions.h"
 #include "swift/SIL/InstructionUtils.h"
 #include "swift/SIL/PatternMatch.h"
+#include "swift/SIL/PrettyStackTrace.h"
 #include "swift/SIL/SILBuilder.h"
 #include "swift/SIL/SILVisitor.h"
 #include "swift/SILOptimizer/PassManager/Passes.h"
@@ -346,6 +347,8 @@ class DeadFunctionAndGlobalElimination {
 
   /// Scans all references inside a function.
   void scanFunction(SILFunction *F) {
+    PrettyStackTraceSILFunction stackTrace(
+        "running dead function elimination scan on", F);
 
     LLVM_DEBUG(llvm::dbgs() << "    scan function " << F->getName() << '\n');
 

--- a/lib/SILOptimizer/IPO/GlobalPropertyOpt.cpp
+++ b/lib/SILOptimizer/IPO/GlobalPropertyOpt.cpp
@@ -12,6 +12,7 @@
 
 #define DEBUG_TYPE "globalpropertyopt"
 #include "swift/Basic/Assertions.h"
+#include "swift/SIL/PrettyStackTrace.h"
 #include "swift/SIL/SILArgument.h"
 #include "swift/SIL/SILBuilder.h"
 #include "swift/SIL/SILFunction.h"
@@ -375,6 +376,8 @@ void GlobalPropertyOpt::scanInstruction(swift::SILInstruction *Inst) {
 /// Scans all instructions of the module and builds the dependency graph.
 void GlobalPropertyOpt::scanInstructions() {
   for (auto &F : M) {
+    PrettyStackTraceSILFunction stackTrace(
+        "running global property optimization on", &F);
     LLVM_DEBUG(llvm::dbgs() << "  scan function " << F.getName() << "\n");
     for (auto &BB : F) {
       LLVM_DEBUG(llvm::dbgs() << "    scan basic block " << BB.getDebugID()

--- a/lib/SILOptimizer/Mandatory/AccessEnforcementSelection.cpp
+++ b/lib/SILOptimizer/Mandatory/AccessEnforcementSelection.cpp
@@ -36,11 +36,12 @@
 #include "swift/Basic/Assertions.h"
 #include "swift/Basic/Defer.h"
 #include "swift/SIL/ApplySite.h"
+#include "swift/SIL/BasicBlockBits.h"
+#include "swift/SIL/InstructionUtils.h"
+#include "swift/SIL/PrettyStackTrace.h"
 #include "swift/SIL/SILArgument.h"
 #include "swift/SIL/SILFunction.h"
 #include "swift/SIL/SILUndef.h"
-#include "swift/SIL/InstructionUtils.h"
-#include "swift/SIL/BasicBlockBits.h"
 #include "swift/SILOptimizer/Analysis/ClosureScope.h"
 #include "swift/SILOptimizer/Analysis/PostOrderAnalysis.h"
 #include "swift/SILOptimizer/PassManager/Transforms.h"
@@ -640,6 +641,9 @@ void AccessEnforcementSelection::
 processFunction(SILFunction *F) {
   if (F->isExternalDeclaration())
     return;
+
+  PrettyStackTraceSILFunction stackTrace(
+      "running access enforcement selection on", F);
 
   LLVM_DEBUG(llvm::dbgs() << "Access Enforcement Selection in " << F->getName()
                           << "\n");

--- a/lib/SILOptimizer/Mandatory/CapturePromotion.cpp
+++ b/lib/SILOptimizer/Mandatory/CapturePromotion.cpp
@@ -50,6 +50,7 @@
 #include "swift/Basic/Assertions.h"
 #include "swift/Basic/FrozenMultiMap.h"
 #include "swift/SIL/OwnershipUtils.h"
+#include "swift/SIL/PrettyStackTrace.h"
 #include "swift/SIL/SILCloner.h"
 #include "swift/SIL/SILInstruction.h"
 #include "swift/SIL/TypeSubstCloner.h"
@@ -1661,6 +1662,7 @@ class CapturePromotionPass : public SILModuleTransform {
 
 void CapturePromotionPass::processFunction(
     SILFunction *func, SmallVectorImpl<SILFunction *> &worklist) {
+  PrettyStackTraceSILFunction stackTrace("running capture promotion on", func);
   assert(func->hasOwnership() &&
          "Only can perform capture promotion on functions with ownership. All "
          "functions in raw SIL should have OSSA now out of SILGen");

--- a/lib/SILOptimizer/Mandatory/DiagnoseStaticExclusivity.cpp
+++ b/lib/SILOptimizer/Mandatory/DiagnoseStaticExclusivity.cpp
@@ -35,6 +35,7 @@
 #include "swift/SIL/CFG.h"
 #include "swift/SIL/InstructionUtils.h"
 #include "swift/SIL/MemAccessUtils.h"
+#include "swift/SIL/PrettyStackTrace.h"
 #include "swift/SIL/Projection.h"
 #include "swift/SIL/SILArgument.h"
 #include "swift/SIL/SILInstruction.h"
@@ -1107,6 +1108,9 @@ private:
       // Don't rerun diagnostics on deserialized functions.
       if (function.wasDeserializedCanonical())
         continue;
+
+      PrettyStackTraceSILFunction stackTrace(
+          "running static exclusivity diagnostics on", &function);
 
       // This is a staging flag. Eventually the ability to turn off static
       // enforcement will be removed.

--- a/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
+++ b/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
@@ -19,6 +19,7 @@
 #include "swift/SIL/InstructionUtils.h"
 #include "swift/SIL/LinearLifetimeChecker.h"
 #include "swift/SIL/OwnershipUtils.h"
+#include "swift/SIL/PrettyStackTrace.h"
 #include "swift/SILOptimizer/PassManager/Passes.h"
 #include "swift/SILOptimizer/PassManager/Transforms.h"
 #include "swift/SILOptimizer/Utils/BasicBlockOptUtils.h"
@@ -1106,6 +1107,8 @@ class MandatoryInlining : public SILModuleTransform {
 
     SILOptFunctionBuilder FuncBuilder(*this);
     for (auto &F : *M) {
+      PrettyStackTraceSILFunction stackTrace("running mandatory inlining on",
+                                             &F);
       switch (F.isThunk()) {
       case IsThunk_t::IsThunk:
       case IsThunk_t::IsReabstractionThunk:

--- a/lib/SILOptimizer/Mandatory/OwnershipModelEliminator.cpp
+++ b/lib/SILOptimizer/Mandatory/OwnershipModelEliminator.cpp
@@ -29,6 +29,7 @@
 #include "swift/Basic/Assertions.h"
 #include "swift/Basic/BlotSetVector.h"
 #include "swift/SIL/DebugUtils.h"
+#include "swift/SIL/PrettyStackTrace.h"
 #include "swift/SIL/Projection.h"
 #include "swift/SIL/SILBuilder.h"
 #include "swift/SIL/SILFunction.h"
@@ -916,6 +917,9 @@ struct OwnershipModelEliminator : SILModuleTransform {
     for (SILFunction &f : *getModule()) {
       if (!f.hasOwnership())
         continue;
+
+      PrettyStackTraceSILFunction stackTrace(
+          "running ownership model elimination on", &f);
 
       // Verify here to make sure ownership is correct before we strip.
       {

--- a/lib/SILOptimizer/Mandatory/PerformanceDiagnostics.cpp
+++ b/lib/SILOptimizer/Mandatory/PerformanceDiagnostics.cpp
@@ -13,9 +13,10 @@
 #define DEBUG_TYPE "performance-diagnostics"
 #include "swift/AST/DiagnosticsSIL.h"
 #include "swift/AST/SemanticAttrs.h"
+#include "swift/SIL/ApplySite.h"
 #include "swift/SIL/BasicBlockDatastructures.h"
 #include "swift/SIL/InstructionUtils.h"
-#include "swift/SIL/ApplySite.h"
+#include "swift/SIL/PrettyStackTrace.h"
 #include "swift/SILOptimizer/Analysis/ArraySemantic.h"
 #include "swift/SILOptimizer/Analysis/BasicCalleeAnalysis.h"
 #include "swift/SILOptimizer/PassManager/Transforms.h"
@@ -805,6 +806,8 @@ private:
         if (function.wasDeserializedCanonical())
           continue;
 
+        PrettyStackTraceSILFunction stackTrace(
+            "running performance diagnostics on", &function);
         diagnoser.visitFunction(&function, function.getPerfConstraints());
       }
     }

--- a/lib/SILOptimizer/Mandatory/ThunkLowering.cpp
+++ b/lib/SILOptimizer/Mandatory/ThunkLowering.cpp
@@ -12,6 +12,7 @@
 
 #include "swift/AST/ASTMangler.h"
 #include "swift/Basic/Defer.h"
+#include "swift/SIL/PrettyStackTrace.h"
 #include "swift/SIL/SILBuilder.h"
 
 #include "swift/SILOptimizer/PassManager/Passes.h"
@@ -395,6 +396,8 @@ class ThunkLoweringPass : public SILModuleTransform {
     for (auto fi = mod->begin(), fe = mod->end(); fi != fe;) {
       auto *fn = &*fi;
       ++fi;
+
+      PrettyStackTraceSILFunction stackTrace("running thunk lowering on", fn);
 
       for (auto &block : *fn) {
         for (auto ii = block.begin(), ie = block.end(); ii != ie;) {

--- a/lib/SILOptimizer/Transforms/PartialApplySimplification.cpp
+++ b/lib/SILOptimizer/Transforms/PartialApplySimplification.cpp
@@ -31,9 +31,8 @@
 
 #define DEBUG_TYPE "sil-partial-apply-simplification"
 
-#include "llvm/Support/Debug.h"
-#include "llvm/ADT/Statistic.h"
 #include "swift/Basic/Assertions.h"
+#include "swift/SIL/PrettyStackTrace.h"
 #include "swift/SIL/SILCloner.h"
 #include "swift/SIL/SILInstruction.h"
 #include "swift/SIL/TypeSubstCloner.h"
@@ -41,6 +40,8 @@
 #include "swift/SILOptimizer/PassManager/Transforms.h"
 #include "swift/SILOptimizer/Utils/SILOptFunctionBuilder.h"
 #include "swift/SILOptimizer/Utils/SpecializationMangler.h"
+#include "llvm/ADT/Statistic.h"
+#include "llvm/Support/Debug.h"
 
 STATISTIC(NumInvocationFunctionsChanged,
           "Number of invocation functions rewritten");
@@ -86,6 +87,8 @@ class PartialApplySimplificationPass : public SILModuleTransform {
     llvm::DenseMap<SILFunction *, KnownCallee> knownCallees;
     llvm::SetVector<swift::PartialApplyInst *> dynamicCallees;
     for (auto &f : *getModule()) {
+      PrettyStackTraceSILFunction stackTrace(
+          "running partial apply simplification on", &f);
       scanFunction(&f, knownCallees, dynamicCallees);
     }
 


### PR DESCRIPTION
Module passes process functions individually. Add pretty stack trace printing with function information so that the crashlogs are more descriptive. 