### PR TITLE
[Embedded] Improve annotations and standard output for the platform abstraction layer

### DIFF
--- a/stdlib/public/EmbeddedPlatform/EmbeddedPlatformPOSIX.swift
+++ b/stdlib/public/EmbeddedPlatform/EmbeddedPlatformPOSIX.swift
@@ -36,8 +36,14 @@ public func _swift_generateRandomHashSeed(_ buf: UnsafeMutableRawPointer, _ nbyt
 }
 
 @implementation @c
-public func _swift_writeCharToStandardOutput(_ c: CInt) -> CInt {
-  putchar(c)
+public func _swift_writeToStandardOutput(
+  _ pointer: UnsafePointer<UInt8>?,
+  _ count: Int
+) -> CInt {
+  for unsafe char in unsafe UnsafeBufferPointer(start: pointer, count: count) {
+    _ = putchar(CInt(char))
+  }
+  return CInt(count)
 }
 
 @implementation @c

--- a/stdlib/public/EmbeddedPlatform/swift/EmbeddedPlatform.h
+++ b/stdlib/public/EmbeddedPlatform/swift/EmbeddedPlatform.h
@@ -115,21 +115,6 @@ void _swift_typedAllocate(
     __swift_size_t size, __swift_size_t alignment, unsigned long long typeId);
 
 /**
- * Writes a single character to standard output.
- *
- * Parameters:
- *   - `c`: the character to write, which will be converted to an
- *     `unsigned char`.
- *
- * Returns the character that was written.
- *
- * This function is required when using the Embedded Swift print() facilities.
- *
- * This function can be implemented as a direct call to `putchar`.
- */
-int _swift_writeCharToStandardOutput(int c);
-
-/**
  * Writes a sequence of UTF-8 code points to standard output.
  *
  * Parameters:

--- a/stdlib/public/EmbeddedPlatform/swift/EmbeddedPlatform.h
+++ b/stdlib/public/EmbeddedPlatform/swift/EmbeddedPlatform.h
@@ -130,6 +130,25 @@ void _swift_typedAllocate(
 int _swift_writeCharToStandardOutput(int c);
 
 /**
+ * Writes a sequence of UTF-8 code points to standard output.
+ *
+ * Parameters:
+ *   - `chars`: the UTF-8 code points to standard output. It is not
+ *     NULL-terminated.
+ *   - `count`: the number of UTF-8 code points.
+ *
+ * Returns the number of characters that were written.
+ *
+ * This function is required when using the Embedded Swift print() facilities.
+ *
+ * This function can be implemented as a call to fwrite or printf with the
+ * specified number of code points.
+ */
+int _swift_writeToStandardOutput(
+    const unsigned char * EMBEDDED_SWIFT_NULLABLE EMBEDDED_SWIFT_COUNTED_BY(count) chars,
+    __swift_size_t count);
+
+/**
  * Generates random bytes into the given buffer.
  *
  * Parameters:

--- a/stdlib/public/EmbeddedPlatform/swift/EmbeddedPlatform.h
+++ b/stdlib/public/EmbeddedPlatform/swift/EmbeddedPlatform.h
@@ -41,6 +41,16 @@ typedef size_t __swift_size_t;
 #define EMBEDDED_SWIFT_NULLABLE
 #endif
 
+#if defined(__has_feature) && (__has_feature(bounds_attributes) || __has_feature(bounds_safety_attributes))
+#define EMBEDDED_SWIFT_COUNTED_BY(N) __attribute__((__counted_by__(N)))
+#define EMBEDDED_SWIFT_SIZED_BY(N) __attribute__((__sized_by__(N)))
+#define EMBEDDED_SWIFT_SINGLE __attribute__((__single__))
+#else
+#define EMBEDDED_SWIFT_COUNTED_BY(N)
+#define EMBEDDED_SWIFT_SIZED_BY(N)
+#define EMBEDDED_SWIFT_SINGLE
+#endif
+
 /**
  * Allocates memory and places the resulting pointer in `*memptr`.
  *
@@ -59,7 +69,7 @@ typedef size_t __swift_size_t;
  * 
  * This function can be implemented as a direct call to `posix_memalign`.
  */
-int _swift_alignedAllocate(void * EMBEDDED_SWIFT_NULLABLE * EMBEDDED_SWIFT_NONNULL memptr, __swift_size_t alignment, __swift_size_t size);
+int _swift_alignedAllocate(void * EMBEDDED_SWIFT_NULLABLE * EMBEDDED_SWIFT_NONNULL EMBEDDED_SWIFT_SINGLE memptr, __swift_size_t alignment, __swift_size_t size);
 
 /**
  * Frees the memory referenced by `ptr`.
@@ -101,7 +111,7 @@ void _swift_alignedFree(void * EMBEDDED_SWIFT_NONNULL ptr, __swift_size_t alignm
  * if the target platform does not support typed allocations.
  */
 void _swift_typedAllocate(
-    void *EMBEDDED_SWIFT_NULLABLE *EMBEDDED_SWIFT_NONNULL ptr,
+    void *EMBEDDED_SWIFT_NULLABLE *EMBEDDED_SWIFT_NONNULL EMBEDDED_SWIFT_SINGLE ptr,
     __swift_size_t size, __swift_size_t alignment, unsigned long long typeId);
 
 /**
@@ -137,7 +147,7 @@ int _swift_writeCharToStandardOutput(int c);
  *
  * This function can be implemented as a direct call to `arc4random_buf`.
  */
-void _swift_generateRandom(void * EMBEDDED_SWIFT_NONNULL buffer, __swift_size_t nbytes);
+void _swift_generateRandom(void * EMBEDDED_SWIFT_NONNULL EMBEDDED_SWIFT_SIZED_BY(nbytes) buffer, __swift_size_t nbytes);
 
 /**
  * Generates random bytes intended for a hashing seed into the given buffer.
@@ -156,7 +166,7 @@ void _swift_generateRandom(void * EMBEDDED_SWIFT_NONNULL buffer, __swift_size_t 
  *
  * This function can be implemented as a direct call to `arc4random_buf`.
  */
-void _swift_generateRandomHashSeed(void * EMBEDDED_SWIFT_NONNULL buffer, __swift_size_t nbytes);
+void _swift_generateRandomHashSeed(void * EMBEDDED_SWIFT_NONNULL EMBEDDED_SWIFT_SIZED_BY(nbytes) buffer, __swift_size_t nbytes);
 
 /**
  * Retrieve a pointer that will be used to retain information needed for Swift's
@@ -206,5 +216,11 @@ void _swift_setExclusivityTLS(void * EMBEDDED_SWIFT_NULLABLE ptr);
  * function.
  */
 void _swift_exit(int code);
+
+#undef EMBEDDED_SWIFT_SINGLE
+#undef EMBEDDED_SWIFT_SIZED_BY
+#undef EMBEDDED_SWIFT_COUNTED_BY
+#undef EMBEDDED_SWIFT_NULLABLE
+#undef EMBEDDED_SWIFT_NONNULL
 
 #endif

--- a/stdlib/public/core/EmbeddedPrint.swift
+++ b/stdlib/public/core/EmbeddedPrint.swift
@@ -54,12 +54,14 @@ extension String {
   }
 }
 
+@inline(never)
 public func print(_ string: StaticString, terminator: StaticString = "\n") {
   string.writeToStandardOutput()
   terminator.writeToStandardOutput()
 }
 
 @_disfavoredOverload
+@inline(never)
 public func print(_ string: String, terminator: StaticString = "\n") {
   var string = string
   string.writeToStandardOutput()
@@ -67,12 +69,14 @@ public func print(_ string: String, terminator: StaticString = "\n") {
 }
 
 @_disfavoredOverload
+@inline(never)
 public func print(_ object: some CustomStringConvertible, terminator: StaticString = "\n") {
   var string = object.description
   string.writeToStandardOutput()
   terminator.writeToStandardOutput()
 }
 
+@inline(never)
 func print(_ buf: UnsafeBufferPointer<UInt8>, terminator: StaticString = "\n") {
   unsafe writeChars(buf)
   terminator.writeToStandardOutput()
@@ -138,6 +142,7 @@ extension BinaryInteger {
   }
 }
 
+@inline(never)
 public func print(_ integer: some BinaryInteger, terminator: StaticString = "\n") {
   integer.writeToStdout(radix: 10)
   print("", terminator: terminator)
@@ -148,6 +153,7 @@ internal func printAsHex(_ integer: some BinaryInteger, terminator: StaticString
   print("", terminator: terminator)
 }
 
+@inline(never)
 public func print(_ boolean: Bool, terminator: StaticString = "\n") {
   if boolean {
     print("true", terminator: terminator)

--- a/stdlib/public/core/EmbeddedPrint.swift
+++ b/stdlib/public/core/EmbeddedPrint.swift
@@ -17,14 +17,11 @@ import SwiftShims
 // printing to not need to heap allocate).
 
 #if SWIFT_USE_EMBEDDED_SWIFT_PLATFORM
-private func _swift_writeToStandardOutput(_ pointer: UnsafePointer<UInt8>?, _ count: Int) -> CInt {
-  // TODO: Use _swift_writeCharToStandardOutput until clients provide their
-  // own C _swift_writeToStandardOutput.
-  for unsafe char in unsafe UnsafeBufferPointer(start: pointer, count: count) {
-    _ = unsafe _swift_writeCharToStandardOutput(CInt(char))
-  }
-  return CInt(count)
-}
+@_extern(c, "_swift_writeToStandardOutput")
+private func _swift_writeToStandardOutput(
+  _ pointer: UnsafePointer<UInt8>?,
+  _ count: Int
+) -> CInt
 #else
 @_extern(c, "putchar")
 func putchar(_: CInt) -> CInt
@@ -36,7 +33,7 @@ private func writeChars(_ chars: UnsafeBufferPointer<UInt8>) {
   _ = unsafe _swift_writeToStandardOutput(chars.baseAddress, chars.count)
 #else
   for unsafe char in unsafe chars {
-    putchar(CInt(char))
+    _ = putchar(CInt(char))
   }
 #endif
 }

--- a/stdlib/public/core/EmbeddedPrint.swift
+++ b/stdlib/public/core/EmbeddedPrint.swift
@@ -17,80 +17,68 @@ import SwiftShims
 // printing to not need to heap allocate).
 
 #if SWIFT_USE_EMBEDDED_SWIFT_PLATFORM
-private func writeSingleChar(_ c: CInt) {
-  _ = _swift_writeCharToStandardOutput(c)
+private func _swift_writeToStandardOutput(_ pointer: UnsafePointer<UInt8>?, _ count: Int) -> CInt {
+  // TODO: Use _swift_writeCharToStandardOutput until clients provide their
+  // own C _swift_writeToStandardOutput.
+  for unsafe char in unsafe UnsafeBufferPointer(start: pointer, count: count) {
+    _ = unsafe _swift_writeCharToStandardOutput(CInt(char))
+  }
+  return CInt(count)
 }
 #else
 @_extern(c, "putchar")
 func putchar(_: CInt) -> CInt
-
-private func writeSingleChar(_ c: CInt) {
-  _ = putchar(c)
-}
 #endif
 
+
+private func writeChars(_ chars: UnsafeBufferPointer<UInt8>) {
+#if SWIFT_USE_EMBEDDED_SWIFT_PLATFORM
+  _ = unsafe _swift_writeToStandardOutput(chars.baseAddress, chars.count)
+#else
+  for unsafe char in unsafe chars {
+    putchar(CInt(char))
+  }
+#endif
+}
+
+extension StaticString {
+  fileprivate func writeToStandardOutput() {
+    withUTF8Buffer {
+      unsafe writeChars($0)
+    }
+  }
+}
+
+extension String {
+  fileprivate mutating func writeToStandardOutput() {
+    withUTF8 {
+      unsafe writeChars($0)
+    }
+  }
+}
+
 public func print(_ string: StaticString, terminator: StaticString = "\n") {
-  var p = unsafe string.utf8Start
-  while unsafe p.pointee != 0 {
-    writeSingleChar(CInt(unsafe p.pointee))
-    unsafe p += 1
-  }
-  unsafe p = terminator.utf8Start
-  while unsafe p.pointee != 0 {
-    writeSingleChar(CInt(unsafe p.pointee))
-    unsafe p += 1
-  }
+  string.writeToStandardOutput()
+  terminator.writeToStandardOutput()
 }
 
 @_disfavoredOverload
 public func print(_ string: String, terminator: StaticString = "\n") {
   var string = string
-  string.withUTF8 { buf in
-    for unsafe c in unsafe buf {
-      writeSingleChar(CInt(c))
-    }
-  }
-  var p = unsafe terminator.utf8Start
-  while unsafe p.pointee != 0 {
-    writeSingleChar(CInt(unsafe p.pointee))
-    unsafe p += 1
-  }
+  string.writeToStandardOutput()
+  terminator.writeToStandardOutput()
 }
 
 @_disfavoredOverload
 public func print(_ object: some CustomStringConvertible, terminator: StaticString = "\n") {
   var string = object.description
-  string.withUTF8 { buf in
-    for unsafe c in unsafe buf {
-      writeSingleChar(CInt(c))
-    }
-  }
-  var p = unsafe terminator.utf8Start
-  while unsafe p.pointee != 0 {
-    writeSingleChar(CInt(unsafe p.pointee))
-    unsafe p += 1
-  }
+  string.writeToStandardOutput()
+  terminator.writeToStandardOutput()
 }
 
 func print(_ buf: UnsafeBufferPointer<UInt8>, terminator: StaticString = "\n") {
-  for unsafe c in unsafe buf {
-    writeSingleChar(CInt(c))
-  }
-  var p = unsafe terminator.utf8Start
-  while unsafe p.pointee != 0 {
-    unsafe writeSingleChar(CInt(p.pointee))
-    unsafe p += 1
-  }
-}
-
-func printCharacters(_ buf: UnsafeRawBufferPointer) {
-  for unsafe c in unsafe buf {
-    writeSingleChar(CInt(c))
-  }
-}
-
-func printCharacters(_ buf: UnsafeBufferPointer<UInt8>) {
-  unsafe printCharacters(UnsafeRawBufferPointer(buf))
+  unsafe writeChars(buf)
+  terminator.writeToStandardOutput()
 }
 
 extension BinaryInteger {
@@ -147,7 +135,7 @@ extension BinaryInteger {
 
     let count = unsafe _toStringImpl(buffer, 64, radix, false)
 
-    unsafe printCharacters(UnsafeBufferPointer(start: buffer, count: count))
+    unsafe writeChars(UnsafeBufferPointer(start: buffer, count: count))
 
     Builtin.stackDealloc(stackBuffer)
   }
@@ -178,11 +166,14 @@ public func _swift_fatalError(_ message: UnsafePointer<UInt8>) -> Never {
   if _isDebugAssertConfiguration() {
     print("fatal error", terminator: ": ")
 
+    var count = 0
     var pointer = unsafe message
     while unsafe pointer.pointee != 0 {
-      unsafe writeSingleChar(CInt(pointer.pointee))
+      count += 1
       unsafe pointer += 1
     }
+
+    unsafe writeChars(UnsafeBufferPointer(start: message, count: count))
   } else {
     Builtin.condfail_message(true._value, message._rawValue)
   }

--- a/stdlib/public/core/EmbeddedRuntime.swift
+++ b/stdlib/public/core/EmbeddedRuntime.swift
@@ -146,9 +146,6 @@ public func _swift_generateRandom(_ buf: UnsafeMutableRawPointer, _ nbytes: Int)
 @_extern(c, "_swift_generateRandomHashSeed")
 public func _swift_generateRandomHashSeed(_ buf: UnsafeMutableRawPointer, _ nbytes: Int)
 
-@_extern(c, "_swift_writeCharToStandardOutput")
-public func _swift_writeCharToStandardOutput(_: CInt) -> CInt
-
 @_extern(c, "_swift_typedAllocate")
 public func _swift_typedAllocate(_ buf: UnsafeMutablePointer<UnsafeMutableRawPointer?>, _ size: Int, _ alignMask: Int, _ typeId: UInt64)
 

--- a/test/embedded/classes-stack-promotion.swift
+++ b/test/embedded/classes-stack-promotion.swift
@@ -81,7 +81,7 @@ struct Main {
 // CHECK-IR-NEXT:   ret void
 // CHECK-IR-NEXT: }
 
-// CHECK-IR:      define {{.*}}i32 @main(
+// CHECK-IR:      define {{.*}}i32 @{{(main|__main_argc_argv)}}(
 // CHECK-IR-NEXT: entry:
 // CHECK-IR-NEXT:   alloca %T4main10MySubClassC
 // CHECK-IR-NEXT:   alloca %T4main12MyFinalClassC

--- a/test/embedded/classes-stack-promotion.swift
+++ b/test/embedded/classes-stack-promotion.swift
@@ -72,28 +72,36 @@ struct Main {
 
 // CHECK-IR:      define {{.*}}@"$e4main8MyStructVyAcA0B10FinalClassCcfC"
 // CHECK-IR-NEXT: entry:
-// CHECK-IR-NEXT:   call {{.*}}@"$es5print_10terminatorys12StaticStringV_ADtF"
+// CHECK-IR-NEXT:   call {{.*}}@"$es12StaticStringV21writeToStandardOutput
+// CHECK-IR-NEXT:   call {{.*}}@"$es12StaticStringV21writeToStandardOutput
 // CHECK-IR-NEXT:   call {{.*}}@swift_release
 // CHECK-IR-NEXT:   ret void
 // CHECK-IR-NEXT: }
 
-// CHECK-IR:      define {{.*}}@{{_*}}main
+// CHECK-IR:      define {{.*}}@"$e4main4MainVAAyyFZ"()
 // CHECK-IR-NEXT: entry:
 // CHECK-IR-NEXT:   alloca %T4main10MySubClassC
 // CHECK-IR-NEXT:   alloca %T4main12MyFinalClassC
 // CHECK-IR-NEXT:   call {{.*}}@swift_initStackObject
-// CHECK-IR-NEXT:   call {{.*}}@"$es5print_10terminatorys12StaticStringV_ADtF"
-// CHECK-IR-NEXT:   call {{.*}}@"$es5print_10terminatorys12StaticStringV_ADtF"
-// CHECK-IR-NEXT:   call {{.*}}@"$es5print_10terminatorys12StaticStringV_ADtF"
+// CHECK-IR-NEXT:   call {{.*}}@"$es12StaticStringV21writeToStandardOutput
+// CHECK-IR-NEXT:   call {{.*}}@"$es12StaticStringV21writeToStandardOutput
+// CHECK-IR-NEXT:   call {{.*}}@"$es12StaticStringV21writeToStandardOutput
+// CHECK-IR-NEXT:   call {{.*}}@"$es12StaticStringV21writeToStandardOutput
+// CHECK-IR-NEXT:   call {{.*}}@"$es12StaticStringV21writeToStandardOutput
+// CHECK-IR-NEXT:   call {{.*}}@"$es12StaticStringV21writeToStandardOutput
 // CHECK-IR-NEXT:   call {{.*}}@"$e4main3bar1oyAA7MyClassC_tF"
 // CHECK-IR-NEXT:   call {{.*}}@swift_setDeallocating
-// CHECK-IR-NEXT:   call {{.*}}@"$es5print_10terminatorys12StaticStringV_ADtF"
-// CHECK-IR-NEXT:   call {{.*}}@"$es5print_10terminatorys12StaticStringV_ADtF"
+// CHECK-IR-NEXT:   call {{.*}}@"$es12StaticStringV21writeToStandardOutput
+// CHECK-IR-NEXT:   call {{.*}}@"$es12StaticStringV21writeToStandardOutput
+// CHECK-IR-NEXT:   call {{.*}}@"$es12StaticStringV21writeToStandardOutput
+// CHECK-IR-NEXT:   call {{.*}}@"$es12StaticStringV21writeToStandardOutput
 // CHECK-IR-NEXT:   call {{.*}}@llvm.lifetime.end.p0
-// CHECK-IR-NEXT:   call {{.*}}@"$es5print_10terminatorys12StaticStringV_ADtF"
+// CHECK-IR-NEXT:   call {{.*}}@"$es12StaticStringV21writeToStandardOutput
+// CHECK-IR-NEXT:   call {{.*}}@"$es12StaticStringV21writeToStandardOutput
 // CHECK-IR-NEXT:   call {{.*}}@swift_initStackObject
-// CHECK-IR-NEXT:   call {{.*}}@"$es5print_10terminatorys12StaticStringV_ADtF"
+// CHECK-IR-NEXT:   call {{.*}}@"$es12StaticStringV21writeToStandardOutput
+// CHECK-IR-NEXT:   call {{.*}}@"$es12StaticStringV21writeToStandardOutput
 // CHECK-IR-NEXT:   call {{.*}}@"$e4main8MyStructVyAcA0B10FinalClassCcfC"
 // CHECK-IR-NEXT:   call {{.*}}@llvm.lifetime.end.p0
-// CHECK-IR-NEXT:   ret {{.*}}0
+// CHECK-IR-NEXT:   ret
 // CHECK-IR-NEXT: }

--- a/test/embedded/classes-stack-promotion.swift
+++ b/test/embedded/classes-stack-promotion.swift
@@ -81,7 +81,7 @@ struct Main {
 // CHECK-IR-NEXT:   ret void
 // CHECK-IR-NEXT: }
 
-// CHECK-IR:      define i32 @main(
+// CHECK-IR:      define {{.*}}i32 @main(
 // CHECK-IR-NEXT: entry:
 // CHECK-IR-NEXT:   alloca %T4main10MySubClassC
 // CHECK-IR-NEXT:   alloca %T4main12MyFinalClassC

--- a/test/embedded/classes-stack-promotion.swift
+++ b/test/embedded/classes-stack-promotion.swift
@@ -9,16 +9,21 @@
 // REQUIRES: optimized_stdlib
 // REQUIRES: swift_feature_Embedded
 
+// Use an @inline(never) wrapper so each event produces a single stable call
+// instruction in the IR regardless of how print() is lowered on a given platform.
+@inline(never)
+func output(_ s: StaticString) { print(s) }
+
 public class MyClass {
-  public init() { print("MyClass.init") }
-  deinit { print("MyClass.deinit") }
-  public func foo() { print("MyClass.foo") }
+  public init() { output("MyClass.init") }
+  deinit { output("MyClass.deinit") }
+  public func foo() { output("MyClass.foo") }
 }
 
 public class MySubClass: MyClass {
-  public override init() { print("MySubClass.init") }
-  deinit { print("MySubClass.deinit") }
-  public override func foo() { print("MySubClass.foo") }
+  public override init() { output("MySubClass.init") }
+  deinit { output("MySubClass.deinit") }
+  public override func foo() { output("MySubClass.foo") }
 }
 
 @inline(never)
@@ -27,9 +32,9 @@ public func bar(o: MyClass) {
 }
 
 final public class MyFinalClass {
-  public init() { print("MyFinalClass.init") }
-  deinit { print("MyFinalClass.deinit") }
-  public func foo() { print("MyFinalClass.foo") }
+  public init() { output("MyFinalClass.init") }
+  deinit { output("MyFinalClass.deinit") }
+  public func foo() { output("MyFinalClass.foo") }
 }
 
 public struct MyStruct {
@@ -63,7 +68,6 @@ struct Main {
 
   static func main() {
     test1()
-    print("")
     test2()
   }
 }
@@ -72,35 +76,26 @@ struct Main {
 
 // CHECK-IR:      define {{.*}}@"$e4main8MyStructVyAcA0B10FinalClassCcfC"
 // CHECK-IR-NEXT: entry:
-// CHECK-IR-NEXT:   call {{.*}}@"$es12StaticStringV21writeToStandardOutput
-// CHECK-IR-NEXT:   call {{.*}}@"$es12StaticStringV21writeToStandardOutput
+// CHECK-IR-NEXT:   call {{.*}}@"$e4main6output
 // CHECK-IR-NEXT:   call {{.*}}@swift_release
 // CHECK-IR-NEXT:   ret void
 // CHECK-IR-NEXT: }
 
-// CHECK-IR:      define {{.*}}@"$e4main4MainVAAyyFZ"()
+// CHECK-IR:      define i32 @main(
 // CHECK-IR-NEXT: entry:
 // CHECK-IR-NEXT:   alloca %T4main10MySubClassC
 // CHECK-IR-NEXT:   alloca %T4main12MyFinalClassC
 // CHECK-IR-NEXT:   call {{.*}}@swift_initStackObject
-// CHECK-IR-NEXT:   call {{.*}}@"$es12StaticStringV21writeToStandardOutput
-// CHECK-IR-NEXT:   call {{.*}}@"$es12StaticStringV21writeToStandardOutput
-// CHECK-IR-NEXT:   call {{.*}}@"$es12StaticStringV21writeToStandardOutput
-// CHECK-IR-NEXT:   call {{.*}}@"$es12StaticStringV21writeToStandardOutput
-// CHECK-IR-NEXT:   call {{.*}}@"$es12StaticStringV21writeToStandardOutput
-// CHECK-IR-NEXT:   call {{.*}}@"$es12StaticStringV21writeToStandardOutput
+// CHECK-IR-NEXT:   call {{.*}}@"$e4main6output
+// CHECK-IR-NEXT:   call {{.*}}@"$e4main6output
+// CHECK-IR-NEXT:   call {{.*}}@"$e4main6output
 // CHECK-IR-NEXT:   call {{.*}}@"$e4main3bar1oyAA7MyClassC_tF"
 // CHECK-IR-NEXT:   call {{.*}}@swift_setDeallocating
-// CHECK-IR-NEXT:   call {{.*}}@"$es12StaticStringV21writeToStandardOutput
-// CHECK-IR-NEXT:   call {{.*}}@"$es12StaticStringV21writeToStandardOutput
-// CHECK-IR-NEXT:   call {{.*}}@"$es12StaticStringV21writeToStandardOutput
-// CHECK-IR-NEXT:   call {{.*}}@"$es12StaticStringV21writeToStandardOutput
+// CHECK-IR-NEXT:   call {{.*}}@"$e4main6output
+// CHECK-IR-NEXT:   call {{.*}}@"$e4main6output
 // CHECK-IR-NEXT:   call {{.*}}@llvm.lifetime.end.p0
-// CHECK-IR-NEXT:   call {{.*}}@"$es12StaticStringV21writeToStandardOutput
-// CHECK-IR-NEXT:   call {{.*}}@"$es12StaticStringV21writeToStandardOutput
 // CHECK-IR-NEXT:   call {{.*}}@swift_initStackObject
-// CHECK-IR-NEXT:   call {{.*}}@"$es12StaticStringV21writeToStandardOutput
-// CHECK-IR-NEXT:   call {{.*}}@"$es12StaticStringV21writeToStandardOutput
+// CHECK-IR-NEXT:   call {{.*}}@"$e4main6output
 // CHECK-IR-NEXT:   call {{.*}}@"$e4main8MyStructVyAcA0B10FinalClassCcfC"
 // CHECK-IR-NEXT:   call {{.*}}@llvm.lifetime.end.p0
 // CHECK-IR-NEXT:   ret


### PR DESCRIPTION
It's far better to write characters in bulk than one at a time, putchar-style. Start moving the platform abstraction layer over to a function that does so. While here, add the various counted_by / single / sized_by annotations to better describe the APIs in the PAL.

