### PR TITLE
[6.4] The os_log section name comes from the module "os" rather than "OSLog"

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -9282,7 +9282,7 @@ ERROR(unsafe_self_dependent_result_attr_on_invalid_decl,none,
 REMARK(macro_expansion_line, none, "macro content: |%0|", (StringRef))
 
 GROUPED_WARNING(oslog_missing_string_section,OSLog,none,
-                "global variable 'osLogStringSectionName' is missing from the OSLog module; defaulting to '__TEXT,__oslogstring,cstring_literals'", ())
+                "global variable 'osLogStringSectionName' is missing from the 'os' module; defaulting to '__TEXT,__oslogstring,cstring_literals'", ())
 GROUPED_ERROR(oslog_string_section_not_literal,OSLog,none,
               "global variable 'osLogStringSectionName' requires a string literal initializer", ())
 

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -451,8 +451,8 @@ void swift::loadDerivativeConfigurations(SourceFile &SF) {
 }
 
 void swift::handleOSLogStringSectionName(ModuleDecl &module) {
-  /// We only care about the OSLog module.
-  if (!module.getName().is("OSLog"))
+  /// We only care about the os module.
+  if (!module.getName().is("os"))
     return;
 
   /// The name of the variable that defines the section name.

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1198,7 +1198,7 @@ void Serializer::writeHeader() {
         PublicModuleName.emit(ScratchRecord, publicModuleName.str());
       }
 
-      if (M->getName().is("OSLog")) {
+      if (M->getName().is("os")) {
         options_block::OSLogStringSectionNameLayout OSLogStringSectionName(Out);
         OSLogStringSectionName.emit(ScratchRecord,
                                     M->getASTContext().LangOpts.OSLogStringSectionName);

--- a/test/IRGen/oslog_literals.sil
+++ b/test/IRGen/oslog_literals.sil
@@ -2,7 +2,7 @@
 
 // RUN: %target-swift-frontend -emit-ir %s | %FileCheck %s
 
-// RUN: %target-swift-frontend -emit-module -emit-module-path %t/OSLog.swiftmodule -module-name OSLog %S/Inputs/OSLogAltName.swift
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/os.swiftmodule -module-name os %S/Inputs/OSLogAltName.swift
 // RUN: %target-swift-frontend -emit-ir %s -I %t -DIMPORT_OSLOG | %FileCheck -check-prefix ALT-NAME %s
 
 // REQUIRES: OS=macosx || OS=ios || OS=watchos
@@ -16,7 +16,7 @@ sil_stage canonical
 import Builtin
 
 #if IMPORT_OSLOG
-import OSLog
+import os
 #endif
 
 sil @oslog_utf8_literal : $@convention(thin) () -> Builtin.RawPointer {

--- a/test/Sema/OSLogSectionName.swift
+++ b/test/Sema/OSLogSectionName.swift
@@ -1,14 +1,14 @@
 // RUN: %empty-directory(%t/src)
 // RUN: split-file %s %t/src
 
-// RUN: %target-swift-frontend -typecheck -module-name OSLog %t/src/missing.swift 2>&1 | %FileCheck %s
-// RUN: %target-swift-frontend -typecheck -verify -module-name OSLog %t/src/noinit.swift
-// RUN: %target-swift-frontend -typecheck -verify -module-name OSLog %t/src/badinit.swift
-// RUN: %target-swift-frontend -typecheck -verify -module-name OSLog %t/src/goodinit.swift
+// RUN: %target-swift-frontend -typecheck -module-name os %t/src/missing.swift 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -typecheck -verify -module-name os %t/src/noinit.swift
+// RUN: %target-swift-frontend -typecheck -verify -module-name os %t/src/badinit.swift
+// RUN: %target-swift-frontend -typecheck -verify -module-name os %t/src/goodinit.swift
 
 //--- missing.swift
 
-// CHECK: global variable 'osLogStringSectionName' is missing from the OSLog module; defaulting to '__TEXT,__oslogstring,cstring_literals'
+// CHECK: global variable 'osLogStringSectionName' is missing from the 'os' module; defaulting to '__TEXT,__oslogstring,cstring_literals'
 
 //--- noinit.swift
 


### PR DESCRIPTION
- **Explanation**: Support for customizing the section name for `os_log` string literals incorrectly used the module name `OSLog` to permit overrides. The module is actually called `os`.
- **Scope**: Very narrow: applies to a single module.
- **Issues**: rdar://177629126
- **Original PRs**: https://github.com/swiftlang/swift/pull/89340
- **Risk**: Tiny. Only affects one module.
- **Testing**: Updated existing tests.
- **Reviewers**: @ian-twilightcoder 