### PR TITLE
SILGen: Use cleanup locations in non-copyable destructor epilogue

### DIFF
--- a/lib/SILGen/SILGenDestructor.cpp
+++ b/lib/SILGen/SILGenDestructor.cpp
@@ -326,13 +326,13 @@ void SILGenFunction::emitDeallocatingMoveOnlyDestructor(DestructorDecl *dd) {
     if (auto *mu =
             dyn_cast<MarkUnresolvedNonCopyableValueInst>(ddi->getOperand())) {
       if (auto *asi = dyn_cast<AllocStackInst>(mu->getOperand())) {
-        B.createDeallocStack(loc, asi);
+        B.createDeallocStack(cleanupLoc, asi);
       }
     }
   }
 
   // Return.
-  B.createReturn(loc, emitEmptyTuple(loc));
+  B.createReturn(returnLoc, emitEmptyTuple(cleanupLoc));
 }
 
 /// Determine whether the availability for the body the given destructor predates the introduction of

--- a/test/SILOptimizer/diagnose_unreachable.swift
+++ b/test/SILOptimizer/diagnose_unreachable.swift
@@ -590,3 +590,28 @@ func noWarningForWait(for task: Task<Never, any Error>) async throws -> Never {
     try await task.value
 }
 
+class NoWarningClassDeinit {
+  deinit {
+    fatalError() // no-warning
+  }
+}
+
+struct NoWarningNoncopyableDeinit: ~Copyable {
+  deinit {
+    fatalError() // no-warning
+  }
+}
+
+struct NoWarningNoncopyableDeinitWithFields: ~Copyable {
+  var x: Int
+  deinit {
+    fatalError() // no-warning
+  }
+}
+
+struct NoWarningGenericNoncopyableDeinit<T: ~Copyable>: ~Copyable {
+  var value: T
+  deinit {
+    fatalError() // no-warning
+  }
+}


### PR DESCRIPTION
The `dealloc_stack`, empty tuple, and return at the end of a non-copyable type's deinit were emitted with the deinit declaration's source location. When the body ends in a noreturn call (e.g. `fatalError()`), `DiagnoseUnreachable` saw these epilogue instructions as user code following the noreturn call and emitted a spurious 'will never be executed' warning on the deinit.