### PR TITLE
CMake: Enable `AllowRuntimeSymbolDeclarations` for _CompilerRegexParser

### DIFF
--- a/lib/ASTGen/CMakeLists.txt
+++ b/lib/ASTGen/CMakeLists.txt
@@ -15,7 +15,9 @@ if(SWIFT_BUILD_REGEX_PARSER_IN_COMPILER)
     "${COMPILER_REGEX_PARSER_SOURCES}"
   )
   target_compile_options(_CompilerRegexParser PRIVATE
-    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -disable-implicit-string-processing-module-import>")
+    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -disable-implicit-string-processing-module-import>"
+    # For swift_getTupleTypeMetadata().
+    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature AllowRuntimeSymbolDeclarations>")
 else()
   # Dummy target for dependencies
   add_custom_target(_CompilerRegexParser)


### PR DESCRIPTION
The host-side `_RegexParser` build was missing this flag, producing a warning about the `@_silgen_name` reference to `swift_getTupleTypeMetadata`. The stdlib build of `_RegexParser` already passes this flag.