### PR TITLE
[6.4.x] Sema: Add diagnostic group for useless availability check warning

### DIFF
--- a/include/swift/AST/DiagnosticGroups.def
+++ b/include/swift/AST/DiagnosticGroups.def
@@ -105,6 +105,7 @@ GROUP(UnusedImportAccess,none,"unused-import-access")
 GROUP(UntypedThrows,DefaultIgnoreWarnings,"untyped-throws")
 GROUP(NoUseUnstructuredThrowingTask,none,"no-use-throwing-unstructured-task")
 GROUP(UseAnyAppleOSAvailability,DefaultIgnoreWarnings,"use-any-apple-os-availability")
+GROUP(UselessAvailabilityCheck,none,"useless-availability-check")
 GROUP(WeakMutability,none,"weak-mutability")
 GROUP(OldSuppressedAssociatedTypes,none,"old-suppressed-associatedtypes")
 

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7347,9 +7347,10 @@ ERROR(availability_inout_accessor_only_in, none,
 ERROR(availability_query_required_for_platform, none,
       "condition required for target platform '%0'", (StringRef))
 
-WARNING(availability_query_useless_enclosing_scope, none,
-        "unnecessary check for '%0'; enclosing scope ensures guard "
-        "will always be true", (StringRef))
+GROUPED_WARNING(availability_query_useless_enclosing_scope,
+                UselessAvailabilityCheck, none,
+                "unnecessary check for '%0'; enclosing scope ensures guard "
+                "will always be true", (StringRef))
 
 NOTE(availability_query_useless_enclosing_scope_here, none,
      "enclosing scope here", ())

--- a/stdlib/public/Concurrency/ContinuousClock.swift
+++ b/stdlib/public/Concurrency/ContinuousClock.swift
@@ -110,6 +110,7 @@ extension ContinuousClock: Clock {
   /// `CancellationError`.
   ///
   /// This function doesn't block the underlying thread.
+  @diagnose(UselessAvailabilityCheck, as: ignored)
   public func sleep(
     until deadline: Instant, tolerance: Swift.Duration? = nil
   ) async throws {

--- a/stdlib/public/Concurrency/ExecutorImpl.swift
+++ b/stdlib/public/Concurrency/ExecutorImpl.swift
@@ -22,6 +22,7 @@ import Swift
 
 @available(SwiftStdlib 6.2, *)
 @_silgen_name("swift_task_asyncMainDrainQueueImpl")
+@diagnose(UselessAvailabilityCheck, as: ignored)
 internal func drainMainQueue() {
   #if !SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
   if #available(StdlibDeploymentTarget 6.3, *) {
@@ -37,6 +38,7 @@ internal func drainMainQueue() {
 
 @available(SwiftStdlib 6.2, *)
 @_silgen_name("swift_task_donateThreadToGlobalExecutorUntilImpl")
+@diagnose(UselessAvailabilityCheck, as: ignored)
 internal func donateToGlobalExecutor(
   condition: @convention(c) (_ ctx: UnsafeMutableRawPointer) -> CBool,
   context: UnsafeMutableRawPointer
@@ -54,6 +56,7 @@ internal func donateToGlobalExecutor(
 
 @available(SwiftStdlib 6.2, *)
 @_silgen_name("swift_task_getMainExecutorImpl")
+@diagnose(UselessAvailabilityCheck, as: ignored)
 internal func getMainExecutor() -> UnownedSerialExecutor {
   if #available(StdlibDeploymentTarget 6.3, *) {
     return unsafe _getMainExecutorAsSerialExecutor()
@@ -64,6 +67,7 @@ internal func getMainExecutor() -> UnownedSerialExecutor {
 
 @available(SwiftStdlib 6.2, *)
 @_silgen_name("swift_task_enqueueMainExecutorImpl")
+@diagnose(UselessAvailabilityCheck, as: ignored)
 internal func enqueueOnMainExecutor(job unownedJob: UnownedJob) {
   #if !SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
   if #available(StdlibDeploymentTarget 6.3, *) {
@@ -78,6 +82,7 @@ internal func enqueueOnMainExecutor(job unownedJob: UnownedJob) {
 
 @available(SwiftStdlib 6.2, *)
 @_silgen_name("swift_task_enqueueGlobalImpl")
+@diagnose(UselessAvailabilityCheck, as: ignored)
 internal func enqueueOnGlobalExecutor(job unownedJob: UnownedJob) {
   if #available(StdlibDeploymentTarget 6.3, *) {
     Task.defaultExecutor.enqueue(unownedJob)
@@ -89,6 +94,7 @@ internal func enqueueOnGlobalExecutor(job unownedJob: UnownedJob) {
 #if !$Embedded
 @available(SwiftStdlib 6.2, *)
 @_silgen_name("swift_task_enqueueGlobalWithDelayImpl")
+@diagnose(UselessAvailabilityCheck, as: ignored)
 internal func enqueueOnGlobalExecutor(delay: CUnsignedLongLong,
                                       job unownedJob: UnownedJob) {
   #if !SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
@@ -106,6 +112,7 @@ internal func enqueueOnGlobalExecutor(delay: CUnsignedLongLong,
 
 @available(SwiftStdlib 6.2, *)
 @_silgen_name("swift_task_enqueueGlobalWithDeadlineImpl")
+@diagnose(UselessAvailabilityCheck, as: ignored)
 internal func enqueueOnGlobalExecutor(seconds: CLongLong,
                                       nanoseconds: CLongLong,
                                       leewaySeconds: CLongLong,

--- a/stdlib/public/Concurrency/GlobalConcurrentExecutor.swift
+++ b/stdlib/public/Concurrency/GlobalConcurrentExecutor.swift
@@ -32,6 +32,7 @@ import Swift
 /// Customizing the global concurrent executor is currently not supported.
 @available(SwiftStdlib 6.0, *)
 @_unavailableInEmbedded
+@diagnose(UselessAvailabilityCheck, as: ignored)
 public var globalConcurrentExecutor: any TaskExecutor {
   get {
     if #available(StdlibDeploymentTarget 6.3, *) {

--- a/stdlib/public/Concurrency/PartialAsyncTask.swift
+++ b/stdlib/public/Concurrency/PartialAsyncTask.swift
@@ -86,6 +86,7 @@ public struct UnownedJob: Sendable {
 
   /// The priority of this job.
   @available(StdlibDeploymentTarget 5.9, *)
+  @diagnose(UselessAvailabilityCheck, as: ignored)
   public var priority: JobPriority {
     let raw: UInt8
     if #available(StdlibDeploymentTarget 6.3, *) {

--- a/stdlib/public/Concurrency/SuspendingClock.swift
+++ b/stdlib/public/Concurrency/SuspendingClock.swift
@@ -98,6 +98,7 @@ extension SuspendingClock: Clock {
   ///
   /// This function doesn't block the underlying thread.
   @available(StdlibDeploymentTarget 5.7, *)
+  @diagnose(UselessAvailabilityCheck, as: ignored)
   public func sleep(
     until deadline: Instant, tolerance: Swift.Duration? = nil
   ) async throws {

--- a/stdlib/public/core/StringWordBreaking.swift
+++ b/stdlib/public/core/StringWordBreaking.swift
@@ -706,6 +706,7 @@ extension String {
   ///     string.
   /// - Returns: The first word break strictly following `i` in the string.
   @available(StdlibDeploymentTarget 5.7, *)
+  @diagnose(UselessAvailabilityCheck, as: ignored)
   public func _wordIndex(after i: String.Index) -> String.Index {
     guard #available(StdlibDeploymentTarget 6.3, *) else {
       fatalError("Unreachable")

--- a/test/Availability/availability_unnecessary.swift
+++ b/test/Availability/availability_unnecessary.swift
@@ -1,14 +1,16 @@
 // Ensure that the `unnecessary check` availability warning is emitted when unnecessary due to
 // scope's explicit annotation
 
-// RUN: %target-typecheck-verify-swift -verify -target %target-cpu-apple-macosx11.2 -disable-objc-attr-requires-foundation-module
+// RUN: %target-typecheck-verify-swift -verify -target %target-cpu-apple-macosx11.2 -verify-additional-prefix noerror-
+// RUN: %target-typecheck-verify-swift -verify -target %target-cpu-apple-macosx11.2 -Werror UselessAvailabilityCheck -verify-additional-prefix werror-
 // REQUIRES: OS=macosx
 
 @available(macOS 11.1, *)
 class Foo {
     // expected-note@-1 {{enclosing scope here}}
     func foo() {
-        // expected-warning@+1 {{unnecessary check for 'macOS'; enclosing scope ensures guard will always be true}}
+        // expected-noerror-warning@+2 {{unnecessary check for 'macOS'; enclosing scope ensures guard will always be true}}
+        // expected-werror-error@+1 {{unnecessary check for 'macOS'; enclosing scope ensures guard will always be true}}
         if #available(macOS 11.0, *) {}
     }
 }

--- a/userdocs/diagnostics/diagnostic-groups.md
+++ b/userdocs/diagnostics/diagnostic-groups.md
@@ -62,6 +62,7 @@ Or upgrade all warnings except deprecated declaration to errors:
 - <doc:no-use-throwing-unstructured-task>
 - <doc:no-usage>
 - <doc:use-any-apple-os-availability>
+- <doc:useless-availability-check>
 
 
 ## Topics
@@ -124,4 +125,5 @@ Or upgrade all warnings except deprecated declaration to errors:
 - <doc:no-use-throwing-unstructured-task>
 - <doc:no-usage>
 - <doc:use-any-apple-os-availability>
+- <doc:useless-availability-check>
 - <doc:existential-member-access-limitations>

--- a/userdocs/diagnostics/useless-availability-check.md
+++ b/userdocs/diagnostics/useless-availability-check.md
@@ -1,0 +1,20 @@
+# Useless availability check (UselessAvailabilityCheck)
+
+Warnings that identify `if #available` queries that are guaranteed to succeed because an enclosing scope already restricts availability.
+
+## Overview
+
+When an `if #available` query checks for an availability that is already implied by the availability of an enclosing scope (such as a containing declaration's `@available` attribute or another `if #available` block), the check is unnecessary and the guard will always succeed at runtime.
+
+```
+@available(macOS 26.4, *)
+struct WeatherView: View {
+  var body: some View {
+    if #available(macOS 26.0, *) { // warning: unnecessary check for 'macOS'; enclosing scope ensures guard will always be true
+      // ...
+    }
+  }
+}
+```
+
+The `if #available` check above can be removed because `WeatherView` is already restricted to `macOS 26.4` or newer, which implies `macOS 26.0` or newer.


### PR DESCRIPTION
- **Explanation:** Allow developers to control the behavior of diagnostics about useless availability checks. Also, suppress warnings from this group in various source files in the standard library. The standard library modules are built with lower deployment targets in some configurations and therefore the availability checks that are diagnosed as useless cannot be removed, unfortunately.
- **Scope:** Affects code with `if #available` checks.
- **Issue/Radar:** rdar://177679716
- **Original PR:** https://github.com/swiftlang/swift/pull/89347
- **Risk:** Very low. Adding the diagnostic group to the existing warning should have no effect on existing code. Adding the `@diagnose` attributes to declarations in the standard library should have no effect on clients of the standard library since the attribute is not serialized in modules or printed in swiftinterfaces.
- **Testing:** Modified compiler tests.
- **Reviewer:** @ktoso 