### PR TITLE
[Windows][Build] Fix expansion of swift-ci comments.

### DIFF
--- a/utils/build-windows-toolchain.bat
+++ b/utils/build-windows-toolchain.bat
@@ -125,7 +125,7 @@ set "args=%args% --skip-repository ninja"
 set "args=%args% --skip-repository swift-integration-tests"
 set "args=%args% --skip-repository swift-stress-tester"
 
-call "%SourceRoot%\swift\utils\update-checkout.cmd" %args% --clone --skip-history --reset-to-remote --github-comment "%ghprbCommentBody%"
+call "%SourceRoot%\swift\utils\update-checkout.cmd" %args% --clone --skip-history --reset-to-remote --github-comment "!ghprbCommentBody!"
 
 goto :eof
 endlocal


### PR DESCRIPTION
If a comment with an instruction for `swift-ci` in it contained `cmd.exe` metacharacters, it could lead to unexpected behaviour in the `build-windows-toolchain.bat` batch file.

This isn't a security issue since only members of the swiftlang organisation can issue those instructions; they're ignored for anyone not in swiftlang, and people in swiftlang can already cause any code they like to run on the CI machines (e.g. by writing a test case, then triggering PR testing with `@swift-ci please test`).

Nevertheless, it might cause unexpected behaviour and we should fix it.

rdar://177455431