### PR TITLE
[cxx-interop] Fix invalid peephole optimization for immortal FRTs

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyLoad.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyLoad.swift
@@ -44,7 +44,12 @@ extension LoadInst : OnoneSimplifiable, SILCombineSimplifiable {
   private func optimizeLoadOfAddrUpcast(_ context: SimplifyContext) -> Bool {
     if let uac = address as? UncheckedAddrCastInst,
        uac.type.isExactSuperclass(of: uac.fromAddress.type),
-       uac.type != uac.fromAddress.type {
+       uac.type != uac.fromAddress.type,
+       // Skip if triviality differs (e.g. archetype bound by a trivial C++
+       // foreign reference type): the load's ownership wouldn't match the
+       // source type.
+       uac.fromAddress.type.isTrivial(in: parentFunction) ==
+         uac.type.isTrivial(in: parentFunction) {
 
       operand.set(to: uac.fromAddress, context)
       let builder = Builder(before: self, context)
@@ -131,6 +136,13 @@ extension LoadInst : OnoneSimplifiable, SILCombineSimplifiable {
   /// ```
   private func tryRemoveAddressCast(_ context: SimplifyContext) -> Bool {
     guard let addrCast = address.isAddressCastOfHeapObjects else {
+      return false
+    }
+    // Skip if triviality differs (e.g. archetype bound by a trivial C++
+    // foreign reference type): the load's ownership wouldn't match the
+    // source type.
+    if addrCast.fromAddress.type.isTrivial(in: parentFunction) !=
+       addrCast.type.isTrivial(in: parentFunction) {
       return false
     }
     let builder = Builder(before: self, context)

--- a/test/Interop/Cxx/foreign-reference/Inputs/immortal-frt-hashable.h
+++ b/test/Interop/Cxx/foreign-reference/Inputs/immortal-frt-hashable.h
@@ -1,0 +1,20 @@
+#ifndef TEST_INTEROP_CXX_FOREIGN_REFERENCE_INPUTS_IMMORTAL_FRT_HASHABLE_H
+#define TEST_INTEROP_CXX_FOREIGN_REFERENCE_INPUTS_IMMORTAL_FRT_HASHABLE_H
+
+#include <stdint.h>
+
+struct ImmortalFRT {
+} __attribute__((swift_attr("import_reference")))
+__attribute__((swift_attr("retain:immortal")))
+__attribute__((swift_attr("release:immortal")));
+
+struct UnsafeFRT {
+} __attribute__((swift_attr("import_reference")))
+__attribute__((swift_attr("retain:immortal")))
+__attribute__((swift_attr("release:immortal")))
+__attribute__((swift_attr("unsafe")));
+
+inline int64_t getHashValue(const struct ImmortalFRT &) { return 0; }
+inline int64_t getHashValue(const struct UnsafeFRT &) { return 0; }
+
+#endif

--- a/test/Interop/Cxx/foreign-reference/Inputs/module.modulemap
+++ b/test/Interop/Cxx/foreign-reference/Inputs/module.modulemap
@@ -117,3 +117,8 @@ module Upcast {
   header "upcast.h"
   requires cplusplus
 }
+
+module ImmortalFRTHashable {
+  header "immortal-frt-hashable.h"
+  requires cplusplus
+}

--- a/test/Interop/Cxx/foreign-reference/immortal-frt-hashable-release.swift
+++ b/test/Interop/Cxx/foreign-reference/immortal-frt-hashable-release.swift
@@ -1,0 +1,31 @@
+// RUN: %target-swift-frontend -I %S/Inputs %s -emit-sil -O -cxx-interoperability-mode=default -disable-availability-checking | %FileCheck %s
+
+import ImmortalFRTHashable
+
+extension ImmortalFRT: Equatable {
+    public static func ==(lhs: ImmortalFRT, rhs: ImmortalFRT) -> Bool { true }
+}
+
+extension ImmortalFRT: Hashable {
+    public func hash(into hasher: inout Hasher) {
+        _ = getHashValue(self)
+    }
+}
+
+extension UnsafeFRT: Equatable {
+    public static func ==(lhs: UnsafeFRT, rhs: UnsafeFRT) -> Bool { true }
+}
+
+extension UnsafeFRT: Hashable {
+    public func hash(into hasher: inout Hasher) {
+        _ = getHashValue(self)
+    }
+}
+
+// CHECK-LABEL: sil {{.*}} @{{.*}}_rawHashValue{{.*}}ImmortalFRT
+// CHECK-NOT: load [trivial] {{.*}} : $*τ_0_0
+// CHECK: end sil function
+
+// CHECK-LABEL: sil {{.*}} @{{.*}}_rawHashValue{{.*}}UnsafeFRT
+// CHECK-NOT: load [trivial] {{.*}} : $*τ_0_0
+// CHECK: end sil function


### PR DESCRIPTION
Immortal foreign reference types never need release or retain operations in Swift, they are represented as trival types, i.e, they can be copied/loaded without any refcount operations. Some peepholes introducing upcast or unchecked_ref_cast on the archetype which is not trivial. As a result, we ended up with SIL that failed to pass verification, we tried to do trivial operations on a non-trivial type.

This PR disables the peephole optimizations when the triviality of the address type differs from the triviality of the type after the transformation.

rdar://177549159
