### PR TITLE
[Demangling] Fix `_buildDemanglingForExtendedExistential`.

### DIFF
--- a/stdlib/public/runtime/Demangle.cpp
+++ b/stdlib/public/runtime/Demangle.cpp
@@ -498,7 +498,10 @@ _buildDemanglingForExtendedExistential(const Metadata *type,
                                               ee->getGeneralizationArguments());
 
   // Dig out the requirement list.
-  auto constrainedExistential = demangledExistential->getChild(0);
+  auto constrainedExistential = demangledExistential;
+  while (constrainedExistential->getKind() == Node::Kind::Type
+         || constrainedExistential->getKind() == Node::Kind::ExistentialMetatype)
+    constrainedExistential = constrainedExistential->getFirstChild();
   assert(constrainedExistential->getKind() == Node::Kind::ConstrainedExistential);
   auto reqList = constrainedExistential->getChild(1);
   assert(reqList->getKind() == Node::Kind::ConstrainedExistentialRequirementList);


### PR DESCRIPTION
The shapes this function sees can include both things like

```
kind=Type
  kind=ConstrainedExistential
    ...
```

as well as

```
kind=Type
  kind=ExistentialMetatype
    kind=Type
      kind=ConstrainedExistential
        ...
```

As such, we need to eat any `Type` or `ExistentialMetatype` nodes when searching for the `ConstrainedExistential` node.

rdar://177213844
