### PR TITLE
[DebugInfo] Fix support for debug_value on alloc_box

### DIFF
--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -7060,9 +7060,6 @@ void IRGenSILFunction::visitDeallocBoxInst(swift::DeallocBoxInst *i) {
 void IRGenSILFunction::visitAllocBoxInst(swift::AllocBoxInst *i) {
   assert(i->getBoxType()->getLayout()->getFields().size() == 1
          && "multi field boxes not implemented yet");
-  const TypeInfo &type = getTypeInfo(
-      getSILBoxFieldType(IGM.getMaximalTypeExpansionContext(), i->getBoxType(),
-                         IGM.getSILModule().Types, 0));
 
   // Derive name from SIL location.
   bool IsAnonymous = false;
@@ -7085,9 +7082,6 @@ void IRGenSILFunction::visitAllocBoxInst(swift::AllocBoxInst *i) {
   if (i->getDebugScope()->getInlinedFunction()->isTransparent())
     return;
 
-  if (!Decl)
-    return;
-
   // FIXME: This is a workaround to not produce local variables for
   // capture list arguments like "[weak self]". The better solution
   // would be to require all variables to be described with a
@@ -7102,8 +7096,16 @@ void IRGenSILFunction::visitAllocBoxInst(swift::AllocBoxInst *i) {
       IGM.getMaximalTypeExpansionContext(),
       i->getBoxType(), IGM.getSILModule().Types, 0);
   auto RealType = SILTy.getASTType();
-  auto DbgTy =
-      DebugTypeInfo::getLocalVariable(Decl, RealType, type, IGM);
+  DebugTypeInfo DbgTy;
+  if (Decl) {
+    DbgTy = DebugTypeInfo::getLocalVariable(Decl, RealType, getTypeInfo(SILTy),
+                                            IGM);
+  } else if (!SILTy.hasArchetype() && !Name.empty()) {
+    // Handle the cases that read from a SIL file.
+    DbgTy = DebugTypeInfo::getFromTypeInfo(RealType, getTypeInfo(SILTy), IGM);
+  } else {
+    return;
+  }
 
   auto VarInfo = i->getVarInfo();
   if (!VarInfo)

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -6316,10 +6316,27 @@ void IRGenSILFunction::visitDebugValueInst(DebugValueInst *i) {
 
     // Collect LLVM instructions emitted by the debug BB so we can salvage and
     // erase them after the debug record is emitted.
-    assert(BB == Builder.GetInsertBlock() && InsertPt == Builder.GetInsertPoint() && "DebugBB content must not affect control flow!");
-    auto Start = LastBefore ? std::next(LastBefore->getIterator()) : BB->begin();
+    assert(BB == Builder.GetInsertBlock() &&
+           InsertPt == Builder.GetInsertPoint() &&
+           "DebugBB content must not affect control flow!");
+    auto Start =
+        LastBefore ? std::next(LastBefore->getIterator()) : BB->begin();
     for (auto It = Start; It != InsertPt; ++It)
       DebugBBInsts.push_back(&*It);
+  } else if (getLoweredValue(SILVal).isBoxWithAddress()) {
+    // Special case for debug_values cloned from an alloc_box: Use the
+    // project_box address rather than the actual box.
+    auto &TI = getTypeInfo(SILVal->getType());
+    auto Addr = getLoweredValue(SILVal).getAddressOfBox();
+    auto *Storage = Addr.getAddress();
+
+    VarInfo->DIExpr.prependElements(
+        {SILDIExprElement::createOperator(SILDIExprOperator::Dereference)});
+
+    Copy.emplace_back(emitShadowCopyIfNeeded(
+        Storage, TI.getStorageType(),
+        i->getDebugScope(), *VarInfo, IsAnonymous,
+        i->usesMoveableValueDebugInfo(), &VarInfo->DIExpr));
   } else if (IsAddrVal) {
     auto &TI = getTypeInfo(SILVal->getType());
     auto Addr = getLoweredAddress(SILVal);

--- a/lib/SIL/IR/SILInstructions.cpp
+++ b/lib/SIL/IR/SILInstructions.cpp
@@ -527,6 +527,14 @@ bool DebugValueInst::isExprTypeValid() const {
 
   SILType valueType = getOperand()->getType();
 
+  // Special case: a DebugValueInst with an alloc_box operand is equivalent to
+  // the alloc_box.
+  if (auto *box = dyn_cast<AllocBoxInst>(getOperand()))
+    if (varInfo.DIExpr.elements().empty() &&
+        getDebugReconstructionBlock() == nullptr &&
+        varInfo.Type == box->getAddressType().getObjectType())
+      return true;
+
   // Transform: debug BB transforms the SSA value to its return type.
   if (auto *debugBB = getDebugReconstructionBlock()) {
     if (debugBB->getNumArguments() > 0) {

--- a/test/DebugInfo/irgen_box_debug_value.sil
+++ b/test/DebugInfo/irgen_box_debug_value.sil
@@ -1,0 +1,34 @@
+// RUN: %target-swift-frontend -Xllvm -verify-debug-value-expr -disable-debugger-shadow-copies -g -emit-irgen %s | %FileCheck %s
+sil_stage canonical
+
+import Swift
+import Builtin
+
+sil_scope 1 { parent @test_box_debug : $@convention(thin) @async (Builtin.Int64) -> () }
+
+// Verify that an alloc_box gets duplicated after a hop_to_executor, and that it generates
+// correctly, as a debug_value on the projection.
+
+// CHECK-LABEL: define {{.*}} @test_box_debug
+sil @test_box_debug : $@convention(thin) @async (Builtin.Int64) -> () {
+bb0(%0 : $Builtin.Int64):
+  // The alloc_box emits a #dbg_declare_value in the entry block (hoisted).
+  // CHECK: #dbg_declare_value(ptr [[PROJ:%.+]], ![[KVAR:[0-9]+]], !DIExpression()
+
+  // CHECK: [[BOX:%[0-9]+]] = call {{.*}} @swift_allocObject
+  // CHECK: [[PROJ]] = getelementptr inbounds {{.*}} [[BOX]], i32 0, i32 1
+  %1 = alloc_box [moveable_value_debuginfo] ${ var Builtin.Int64 }, var, name "k", scope 1
+  %2 = project_box %1 : ${ var Builtin.Int64 }, 0, scope 1
+  store %0 to %2 : $*Builtin.Int64, scope 1
+
+  %3 = enum $Optional<Builtin.Executor>, #Optional.none!enumelt, scope 1
+  hop_to_executor %3 : $Optional<Builtin.Executor>, scope 1
+
+  // CHECK: #dbg_value(ptr [[PROJ]], ![[KVAR]], !DIExpression(DW_OP_deref)
+
+  strong_release %1 : ${ var Builtin.Int64 }, scope 1
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK: ![[KVAR]] = !DILocalVariable(name: "k"


### PR DESCRIPTION
Debug value instructions using an alloc_box as operand are generated by MovedAsyncVarDebugInfoPropagator and other passes, from cloning the varinfo from an alloc_box into debug_values. These debug_values cannot be optimized, as alloc_boxes don't get salvaged at this point, and this pass only exists at Onone.

Allow debug_value to point to an alloc_box, if and only if there is no DIExpr, reconstruction block, and the varinfo type matches. In IRGen, handle those debug_values the same as how debug variables on the alloc_box are handled, by using the box projection.
