### PR TITLE
[SILVerifier] Enable full debug_value type chain verification

### DIFF
--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -87,11 +87,6 @@ static llvm::cl::opt<bool> VerifyDIHoles("verify-di-holes", llvm::cl::init(
 #endif
                                                                 ));
 
-// Verify the type chain of debug_value instructions. Disabled by default
-// while we fix all root causes.
-static llvm::cl::opt<bool> VerifyDebugValueExpr("verify-debug-value-expr",
-                                                llvm::cl::init(false));
-
 static llvm::cl::opt<bool> SkipConvertEscapeToNoescapeAttributes(
     "verify-skip-convert-escape-to-noescape-attributes", llvm::cl::init(false));
 
@@ -1980,9 +1975,7 @@ public:
     }
 
     // Type chain: SSA operand -> DebugBB -> deref -> fragments -> vartype
-    if (VerifyDebugValueExpr)
-      require(inst->isExprTypeValid(),
-              "debug_value type chain should hold");
+    require(inst->isExprTypeValid(), "debug_value type chain should hold");
   }
 
   void checkInstructionsDebugInfo(SILInstruction *inst) {

--- a/test/Concurrency/silisolationinfo_inference.sil
+++ b/test/Concurrency/silisolationinfo_inference.sil
@@ -1356,7 +1356,7 @@ bb0(%0 : @guaranteed $MainActorIsolatedStruct):
 sil [ossa] @test_nonisolated_unsafe_field_override_struct_addr : $@convention(thin) (@in_guaranteed MainActorIsolatedStruct) -> () {
 bb0(%0 : $*MainActorIsolatedStruct):
   specify_test "sil_isolation_info_inference @trace[0]"
-  debug_value %0 : $*MainActorIsolatedStruct, let, name "self"
+  debug_value %0 : $*MainActorIsolatedStruct, let, name "self", expr op_deref
   %1 = struct_element_addr %0 : $*MainActorIsolatedStruct, #MainActorIsolatedStruct.nsNonisolatedUnsafe
   debug_value [trace] %1
   %9999 = tuple ()
@@ -1370,7 +1370,7 @@ bb0(%0 : $*MainActorIsolatedStruct):
 sil [ossa] @test_nonisolated_unsafe_field_override_generic_struct_addr : $@convention(thin) <T> (@in_guaranteed MainActorIsolatedGenericStruct<T>) -> () {
 bb0(%0 : $*MainActorIsolatedGenericStruct<T>):
   specify_test "sil_isolation_info_inference @trace[0]"
-  debug_value %0 : $*MainActorIsolatedGenericStruct<T>, let, name "self"
+  debug_value %0 : $*MainActorIsolatedGenericStruct<T>, let, name "self", expr op_deref
   %1 = struct_element_addr %0 : $*MainActorIsolatedGenericStruct<T>, #MainActorIsolatedGenericStruct.nsNonisolatedUnsafe
   debug_value [trace] %1
   %9999 = tuple ()
@@ -1384,7 +1384,7 @@ bb0(%0 : $*MainActorIsolatedGenericStruct<T>):
 sil [ossa] @test_nonisolated_unsafe_field_override_nonisolated_generic_struct_addr : $@convention(thin) <T> (@in_guaranteed NonisolatedGenericStruct<T>) -> () {
 bb0(%0 : $*NonisolatedGenericStruct<T>):
   specify_test "sil_isolation_info_inference @trace[0]"
-  debug_value %0 : $*NonisolatedGenericStruct<T>, let, name "self"
+  debug_value %0 : $*NonisolatedGenericStruct<T>, let, name "self", expr op_deref
   %1 = struct_element_addr %0 : $*NonisolatedGenericStruct<T>, #NonisolatedGenericStruct.nsNonisolatedUnsafe
   debug_value [trace] %1
   %9999 = tuple ()

--- a/test/DebugInfo/irgen_box_debug_value.sil
+++ b/test/DebugInfo/irgen_box_debug_value.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -Xllvm -verify-debug-value-expr -disable-debugger-shadow-copies -g -emit-irgen %s | %FileCheck %s
+// RUN: %target-swift-frontend -disable-debugger-shadow-copies -g -emit-irgen %s | %FileCheck %s
 sil_stage canonical
 
 import Swift

--- a/test/SIL/Parser/debug_transform_block.sil
+++ b/test/SIL/Parser/debug_transform_block.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -sil-print-types -verify-debug-value-expr %s | %FileCheck %s
+// RUN: %target-sil-opt -sil-print-types %s | %FileCheck %s
 sil_stage canonical
 
 import Builtin

--- a/test/SIL/verifier_failures_debug_transform.sil
+++ b/test/SIL/verifier_failures_debug_transform.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -sil-print-types -verify-debug-value-expr -verify-continue-on-failure -o /dev/null %s 2>&1 | %FileCheck %s
+// RUN: %target-sil-opt -sil-print-types -verify-continue-on-failure -o /dev/null %s 2>&1 | %FileCheck %s
 
 // REQUIRES: asserts
 

--- a/test/SILOptimizer/mark_weak_var_as_sendable.sil
+++ b/test/SILOptimizer/mark_weak_var_as_sendable.sil
@@ -382,7 +382,7 @@ bb0(%arg : @owned $C):
 // CHECK: } // end sil function 'chained_callee'
 sil [ossa] @chained_callee : $@convention(thin) (@guaranteed { var @sil_weak Optional<C> }) -> () {
 bb0(%0 : @closureCapture @guaranteed ${ var @sil_weak Optional<C> }):
-  debug_value %0, var, name "c", argno 1, expr op_deref
+  debug_value %0, var, name "c", argno 1
   %2 = function_ref @simple_callee : $@convention(thin) (@guaranteed { var @sil_weak Optional<C> }) -> ()
   %1 = copy_value %0
   %3 = partial_apply [callee_guaranteed] %2(%1) : $@convention(thin) (@guaranteed { var @sil_weak Optional<C> }) -> ()

--- a/test/SILOptimizer/moveonly_type_eliminator.sil
+++ b/test/SILOptimizer/moveonly_type_eliminator.sil
@@ -613,7 +613,7 @@ sil [ossa] @existential_metatype : $@convention(thin) (@guaranteed any Error) ->
 bb0(%x : @guaranteed $any Error):
   %y = copyable_to_moveonlywrapper [guaranteed] %x : $any Error
   %em = existential_metatype $@thick any Error.Type, %y : $@moveOnly (any Error)
-  debug_value %em : $@thick any Error.Type, var, name "s", argno 1, expr op_deref
+  debug_value %em : $@thick any Error.Type, var, name "s", argno 1
   return %em : $@thick any Error.Type
 }
 


### PR DESCRIPTION
Based on #89352 (Fixes the last remaining issue)

Enable the debug_value type chain verification introduced by #88927.