### PR TITLE
[DebugInfo] Add salvage for float literals

### DIFF
--- a/lib/SILOptimizer/Utils/InstOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/InstOptUtils.cpp
@@ -2018,20 +2018,21 @@ void swift::salvageDebugInfo(SILInstruction *I) {
     }
   }
 
-  if (auto *IL = dyn_cast<IntegerLiteralInst>(I)) {
+  if (isa<IntegerLiteralInst>(I) || isa<FloatLiteralInst>(I)) {
+    auto *literal = cast<SingleValueInstruction>(I);
     // Rather than recreating new debug values, we update the existing ones.
     // The use list is mutated during iteration.
-    SmallVector<Operand *, 4> debugUses(getDebugUses(IL));
+    SmallVector<Operand *, 4> debugUses(getDebugUses(literal));
     for (Operand *U : debugUses) {
       auto *DbgInst = cast<DebugValueInst>(U->getUser());
       auto VarInfo = DbgInst->getVarInfo();
       if (!VarInfo)
         continue;
-      // Copy the integer literal into the reconstruction block, and set
-      // the operand to undef.
-      auto *debugBB = DbgInst->getOrCreateDebugReconstructionBlock();
-      auto *NewIL = IL->clone(&*debugBB->begin());
-      debugBB->getArgument(0)->replaceAllUsesWith(NewIL);
+      // Copy the literal into the reconstruction block, and set the operand
+      // of the reconstruction block to undef.
+      SILBasicBlock *debugBB = DbgInst->getOrCreateDebugReconstructionBlock();
+      SILValue newLiteral = literal->clone(&*debugBB->begin());
+      debugBB->getArgument(0)->replaceAllUsesWith(newLiteral);
       debugBB->eraseArgument(0);
       DbgInst->setOperand(SILUndef::get(DbgInst->getOperand()));
     }

--- a/test/DebugInfo/irgen_undef.sil
+++ b/test/DebugInfo/irgen_undef.sil
@@ -58,6 +58,18 @@ bb0:
 return %0 : $Builtin.Int64
 }
 
+// CHECK-LABEL: define {{.*}} @float_constant
+sil @float_constant : $@convention(thin) (Builtin.FPIEEE64) -> (Builtin.FPIEEE64) {
+bb0(%0 : $Builtin.FPIEEE64):
+  // CHECK: #dbg_value(double 2.000000e+00, ![[FCONST_VAR:[0-9]+]], !DIExpression()
+  debug_value undef : $Builtin.FPIEEE64, var, name "fconst", transform {
+  bb0:
+    %1 = float_literal $Builtin.FPIEEE64, 0x4000000000000000 // 2.0
+    return %1 : $Builtin.FPIEEE64
+  }
+  return %0 : $Builtin.FPIEEE64
+}
+
 
 // CHECK: ![[JUST_UNDEF_VAR]] = !DILocalVariable(name: "optimizedout"
 // CHECK: ![[CURRENT_VAR]] = !DILocalVariable(name: "current"
@@ -66,3 +78,4 @@ return %0 : $Builtin.Int64
 // CHECK: ![[CONST_VAR]] = !DILocalVariable(name: "const"
 // CHECK: ![[CONSTINT_VAR]] = !DILocalVariable(name: "constint"
 // CHECK: ![[CONSTUPLE_VAR]] = !DILocalVariable(name: "constuple"
+// CHECK: ![[FCONST_VAR]] = !DILocalVariable(name: "fconst"

--- a/test/DebugInfo/salvage-literal.swift
+++ b/test/DebugInfo/salvage-literal.swift
@@ -3,7 +3,7 @@
 // In optimized code, a + b will be folded to 5, but we should still keep their
 // debug values.
 
-// CHECK-LABEL: sil
+// CHECK-LABEL: sil @$s4main1fSiyF
 public func f() -> Int {
   let a = 2
   let b = 3
@@ -13,6 +13,21 @@ public func f() -> Int {
   // CHECK: }
   // CHECK: debug_value undef : $Builtin.Int{{32|64}}, let, name "b", type $Int, expr op_fragment:#Int._value, transform {
   // CHECK:   %0 = integer_literal $Builtin.Int{{32|64}}, 3
+  // CHECK:   return %0
+  // CHECK: }
+  return a + b
+}
+
+// CHECK-LABEL: sil @$s4main1gSdyF
+public func g() -> Double {
+  let a = 2.0
+  let b = 3.0
+  // CHECK: debug_value undef : $Builtin.FPIEEE64, let, name "a", type $Double, expr op_fragment:#Double._value, transform {
+  // CHECK:   %0 = float_literal $Builtin.FPIEEE64, 0x4000000000000000
+  // CHECK:   return %0
+  // CHECK: }
+  // CHECK: debug_value undef : $Builtin.FPIEEE64, let, name "b", type $Double, expr op_fragment:#Double._value, transform {
+  // CHECK:   %0 = float_literal $Builtin.FPIEEE64, 0x4008000000000000
   // CHECK:   return %0
   // CHECK: }
   return a + b


### PR DESCRIPTION
With debug reconstruction blocks, it is now much easier to add support for float literal salvages. The salvage for float literals works the same way as the one for integer literals: clone the instruction into debug reconstruction block.