### PR TITLE
[SILGen] Fix `swift repl` to not crash on async code.

### DIFF
--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -520,7 +520,9 @@ Type SILGenModule::getConfiguredExecutorFactory() {
   auto &ctx = getASTContext();
 
   // First look in the @main struct, if any
-  NominalTypeDecl *mainType = ctx.MainModule->getMainTypeDecl();
+  ModuleDecl *mainModule = ctx.MainModule;
+  NominalTypeDecl *mainType
+    = mainModule ? mainModule->getMainTypeDecl() : nullptr;
   if (mainType) {
     SmallVector<ValueDecl *, 1> decls;
     auto identifier = ctx.getIdentifier("DefaultExecutorFactory");


### PR DESCRIPTION
`swift repl` crashes when someone attempts to use async code because it fails to find the main module (there isn't one), then it tries to call `getMainTypeDecl()` on the non-existent main module.

rdar://177393479
