### PR TITLE
ArrayPropertyOpt: fix an ownership error

### DIFF
--- a/lib/SILOptimizer/LoopTransforms/ArrayPropertyOpt.cpp
+++ b/lib/SILOptimizer/LoopTransforms/ArrayPropertyOpt.cpp
@@ -463,6 +463,7 @@ namespace {
 /// fixDomTree() could be part of SILCloner itself.
 class RegionCloner : public SILCloner<RegionCloner> {
   SILBasicBlock *StartBB;
+  SmallVector<SILPhiArgument *, 4> insertedPhis;
 
   friend class SILInstructionVisitor<RegionCloner>;
   friend class SILCloner<RegionCloner>;
@@ -483,6 +484,8 @@ public:
     updateSSAForm();
     return getOpBasicBlock(StartBB);
   }
+
+  ArrayRef<SILPhiArgument *> getInsertedPhis() const { return insertedPhis; }
 
 protected:
   /// Clone the dominator tree from the original region to the cloned region.
@@ -543,7 +546,7 @@ protected:
   }
 
   void updateSSAForm() {
-    SILSSAUpdater SSAUp;
+    SILSSAUpdater SSAUp(&insertedPhis);
     SmallVector<SingleValueInstruction *, 4> newProjections;
     SinkAddressProjections sinkProj(&newProjections);
 
@@ -591,11 +594,13 @@ class ArrayPropertiesSpecializer {
   DominanceInfo *DomTree;
   SILLoopAnalysis *LoopAnalysis;
   SILBasicBlock *HoistableLoopPreheader;
+  SILPassManager *PM;
 
 public:
   ArrayPropertiesSpecializer(DominanceInfo *DT, SILLoopAnalysis *LA,
-                             SILBasicBlock *Hoistable)
-      : DomTree(DT), LoopAnalysis(LA), HoistableLoopPreheader(Hoistable) {}
+                             SILBasicBlock *Hoistable, SILPassManager *PM)
+      : DomTree(DT), LoopAnalysis(LA), HoistableLoopPreheader(Hoistable),
+        PM(PM) {}
 
   void run() {
     specializeLoopNest();
@@ -752,6 +757,14 @@ void ArrayPropertiesSpecializer::specializeLoopNest() {
   RegionCloner Cloner(NewPreheader, *DomTree);
   auto *ClonedPreheader = Cloner.cloneRegion(ExitBlocks);
 
+  // The SSA updater may have inserted trivial phis (all incoming values
+  // identical) in loop-internal blocks when threading owned values to shared
+  // exit blocks.  Such trivial phis consume the original value at each
+  // predecessor branch, causing an OSSA over-consume when the original
+  // destroy_value is still present in dominated blocks.  Simplify them away
+  // before updateAllGuaranteedPhis builds the borrowed-from instructions.
+  replacePhisWithIncomingValues(PM, Cloner.getInsertedPhis());
+
   // Collect the array.props call that we will specialize on that we have
   // cloned in the cloned loop.
   SmallVector<ArraySemanticsCall, 16> ArrayPropCalls;
@@ -834,7 +847,7 @@ class SwiftArrayPropertyOptPass : public SILFunctionTransform {
 
       // Hoist the loop nests.
       for (auto &HoistableLoopNest : HoistableLoopNests)
-        ArrayPropertiesSpecializer(DT, LA, HoistableLoopNest).run();
+        ArrayPropertiesSpecializer(DT, LA, HoistableLoopNest, getPassManager()).run();
 
       // Verify that no illegal critical edges were created.
       if (getFunction()->getModule().getOptions().VerifyAll)

--- a/test/SILOptimizer/array-property-opt-crash.swift
+++ b/test/SILOptimizer/array-property-opt-crash.swift
@@ -1,0 +1,58 @@
+// RUN: %target-swift-frontend -parse-as-library -O %s -sil-verify-all -emit-sil -o /dev/null
+
+// Check that ArrayPropertyOpt does not produce illegal SIL.
+// https://github.com/swiftlang/swift/issues/89324
+
+enum Op { case a, b }
+
+class Operation: Equatable {
+    let value1: Node
+    let value2: Node
+    let op: Op
+
+    init(value1: Node, value2: Node, op: Op) {
+        self.value1 = value1
+        self.value2 = value2
+        self.op = op
+    }
+
+    static func == (lhs: Operation, rhs: Operation) -> Bool {
+        guard lhs.op == rhs.op else { return false }
+        switch lhs.op {
+        case .a:
+            return (lhs.value1 == rhs.value1 && lhs.value2 == rhs.value2)
+                || (lhs.value1 == rhs.value2 && lhs.value2 == rhs.value1)
+        case .b:
+            return lhs.value1 == rhs.value1 && lhs.value2 == rhs.value2
+        }
+    }
+}
+
+class Node: Equatable {
+    var value: Int
+    var origin: Operation?
+
+    init(value: Int, origin: Operation? = nil) {
+        self.value = value
+        self.origin = origin
+    }
+
+    static func == (lhs: Node, rhs: Node) -> Bool {
+        if let o1 = lhs.origin, let o2 = rhs.origin {
+            return o1 == o2
+        }
+        return lhs.value == rhs.value
+    }
+}
+
+class NodeArray: Hashable {
+    var values: [Node]
+    init(values: [Node]) { self.values = values }
+    static func == (lhs: NodeArray, rhs: NodeArray) -> Bool {
+        return lhs.values == rhs.values
+    }
+    func hash(into hasher: inout Hasher) {
+        for v in values { hasher.combine(v.value) }
+    }
+}
+


### PR DESCRIPTION
The optimization can produce illegal SIL in some cases. The fix is to cleanup inserted phis by the SSAUpdater.

https://github.com/swiftlang/swift/issues/89324
rdar://177636712
