### PR TITLE
Fix specialization of checked_cast_br instruction

### DIFF
--- a/include/swift/SIL/TypeSubstCloner.h
+++ b/include/swift/SIL/TypeSubstCloner.h
@@ -264,6 +264,76 @@ protected:
     return;
   }
 
+  void visitCheckedCastBranchInst(CheckedCastBranchInst *inst) {
+    CanType sourceType = getOpASTType(inst->getSourceFormalType());
+    CanType targetType = getOpASTType(inst->getTargetFormalType());
+
+    auto &M = getBuilder().getFunction().getModule();
+    if (canSILUseScalarCheckedCastInstructions(M, sourceType, targetType)) {
+      super::visitCheckedCastBranchInst(inst);
+      return;
+    }
+
+    // The substituted types require an address-based cast. Convert
+    // checked_cast_br to checked_cast_addr_br.
+    SILLocation loc = getOpLocation(inst->getLoc());
+    SILValue op = getOpValue(inst->getOperand());
+    SILType targetLoweredType = getOpType(inst->getTargetLoweredType());
+    SILBasicBlock *succBB = getOpBasicBlock(inst->getSuccessBB());
+    SILBasicBlock *failBB = getOpBasicBlock(inst->getFailureBB());
+    SILBuilderWithPostProcess<TypeSubstCloner, 16> B(this, inst);
+    B.setCurrentDebugScope(super::getOpScope(inst->getDebugScope()));
+
+    bool isTrivial = op->getType().isTrivial(B.getFunction());
+
+    // Allocate temporaries for source and destination.
+    auto *srcTemp = B.createAllocStack(loc, op->getType().getObjectType());
+    auto *destTemp = B.createAllocStack(loc, targetLoweredType.getObjectType());
+
+    // Store the source value into the source temporary.
+    B.emitStoreValueOperation(loc, op, srcTemp,
+                              isTrivial ? StoreOwnershipQualifier::Trivial
+                                        : StoreOwnershipQualifier::Init);
+
+    // Create new success and failure blocks that load from the temporaries
+    // and branch to the original targets.
+    auto *newSuccBB = B.getFunction().createBasicBlockBefore(succBB);
+    auto *newFailBB = B.getFunction().createBasicBlockBefore(failBB);
+
+    B.createCheckedCastAddrBranch(
+        loc, inst->getCheckedCastOptions(), CastConsumptionKind::TakeOnSuccess,
+        srcTemp, sourceType, destTemp, targetType, newSuccBB, newFailBB);
+
+    // Emit the success block.
+    B.setInsertionPoint(newSuccBB);
+    SILValue result = B.emitLoadValueOperation(
+        loc, destTemp,
+        isTrivial ? LoadOwnershipQualifier::Trivial
+                  : LoadOwnershipQualifier::Take);
+    B.createDeallocStack(loc, destTemp);
+    B.createDeallocStack(loc, srcTemp);
+    B.createBranch(loc, succBB, {result});
+
+    // Emit the failure block.
+    B.setInsertionPoint(newFailBB);
+    // For non-trivial types, load the unconsumed source value back from
+    // the source temporary to pass it to the failure block.
+    SILValue failValue;
+    if (isTrivial) {
+      failValue = op;
+    } else {
+      failValue = B.emitLoadValueOperation(loc, srcTemp,
+                                           LoadOwnershipQualifier::Take);
+    }
+    B.createDeallocStack(loc, destTemp);
+    B.createDeallocStack(loc, srcTemp);
+    if (B.hasOwnership()) {
+      B.createBranch(loc, failBB, {failValue});
+    } else {
+      B.createBranch(loc, failBB);
+    }
+  }
+
   void visitUpcastInst(UpcastInst *Upcast) {
     // If the type substituted type of the operand type and result types match
     // there is no need for an upcast and we can just use the operand.

--- a/test/SILOptimizer/specialize_casts.sil
+++ b/test/SILOptimizer/specialize_casts.sil
@@ -60,3 +60,63 @@ bb0(%0 : @owned $AnyObject):
   return %8
 }
 
+// CHECK-LABEL: // specialized generic_checked_cast_to_nserror
+// CHECK-LABEL: sil shared [ossa] @$s31generic_checked_cast_to_nserrorSo7NSErrorC_Tg5 :
+// CHECK: store %0 to [init]
+// CHECK: checked_cast_addr_br take_on_success NSObject in {{.*}} to NSError
+// CHECK: load [take]
+// CHECK-LABEL: } // end sil function '$s31generic_checked_cast_to_nserrorSo7NSErrorC_Tg5'
+sil [ossa] @generic_checked_cast_to_nserror : $@convention(thin) <T where T : NSObject> (@owned NSObject) -> @owned Optional<T> {
+bb0(%0 : @owned $NSObject):
+  checked_cast_br NSObject in %0 : $NSObject to T, bb1, bb2
+
+bb1(%succ : @owned $T):
+  %some = enum $Optional<T>, #Optional.some!enumelt, %succ : $T
+  br bb3(%some : $Optional<T>)
+
+bb2(%fail : @owned $NSObject):
+  destroy_value %fail : $NSObject
+  %none = enum $Optional<T>, #Optional.none!enumelt
+  br bb3(%none : $Optional<T>)
+
+bb3(%result : @owned $Optional<T>):
+  return %result : $Optional<T>
+}
+
+sil [ossa] @caller_specialize_nserror : $@convention(thin) (@owned NSObject) -> @owned Optional<NSError> {
+bb0(%0 : @owned $NSObject):
+  %f = function_ref @generic_checked_cast_to_nserror : $@convention(thin) <T where T : NSObject> (@owned NSObject) -> @owned Optional<T>
+  %r = apply %f<NSError>(%0) : $@convention(thin) <T where T : NSObject> (@owned NSObject) -> @owned Optional<T>
+  return %r : $Optional<NSError>
+}
+
+protocol ParameterizedProto<T> {
+  associatedtype T
+}
+
+// CHECK-LABEL: sil shared [ossa] @$s29generic_checked_cast_metatype
+// CHECK-NOT: checked_cast_br (any AnyObject).Type in {{.*}} to (any ParameterizedProto<Int>).Type
+// CHECK: } // end sil function
+sil [ossa] @generic_checked_cast_metatype : $@convention(thin) <Element> () -> Builtin.Int1 {
+bb0:
+  %0 = metatype $@thick (any AnyObject).Type
+  checked_cast_br (any AnyObject).Type in %0 : $@thick (any AnyObject).Type to Element.Type, bb1, bb2
+
+bb1(%succ : $@thick Element.Type):
+  %t = integer_literal $Builtin.Int1, -1
+  br bb3(%t : $Builtin.Int1)
+
+bb2(%fail : $@thick (any AnyObject).Type):
+  %f = integer_literal $Builtin.Int1, 0
+  br bb3(%f : $Builtin.Int1)
+
+bb3(%result : $Builtin.Int1):
+  return %result : $Builtin.Int1
+}
+
+sil [ossa] @parameterized_existential_caller : $@convention(thin) () -> Builtin.Int1 {
+bb0:
+  %f = function_ref @generic_checked_cast_metatype : $@convention(thin) <Element> () -> Builtin.Int1
+  %r = apply %f<any ParameterizedProto<Int>>() : $@convention(thin) <Element> () -> Builtin.Int1
+  return %r : $Builtin.Int1
+}

--- a/test/SILOptimizer/specialize_ossa.sil
+++ b/test/SILOptimizer/specialize_ossa.sil
@@ -1808,3 +1808,4 @@ bb0(%0 : @guaranteed $Wrapper):
   return %4 : $String
 }
 
+


### PR DESCRIPTION
When a generic function containing `checked_cast_br` on a metatype is specialized with a parameterized existential type (e.g. `any P<Int>`), the substituted types may no longer satisfy the requirements of `canSILUseScalarCheckedCastInstructions`.

The fix adds a `visitCheckedCastBranchInst` override to TypeSubstCloner that checks whether the substituted types are still valid for scalar checked cast. If not, it converts the `checked_cast_br` into a `checked_cast_addr_br` using stack temporaries.

