### PR TITLE
[test][android] Temporarily disable new Reflection/noncopyable_field_typeref.swift test

### DIFF
--- a/test/Reflection/noncopyable_field_typeref.swift
+++ b/test/Reflection/noncopyable_field_typeref.swift
@@ -8,6 +8,7 @@
 
 // rdar://100805115
 // UNSUPPORTED: CPU=arm64e
+// UNSUPPORTED: OS=linux-android
 
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift -target %module-target-future %s -parse-as-library -emit-module -emit-library -module-name NoncopyableFields -o %t/%target-library-name(NoncopyableFields)


### PR DESCRIPTION
I'll try enabling again once we switch to the upcoming LTS NDK 30.