### PR TITLE
[6.4] Sema: ignore macro in qualified import

### DIFF
--- a/lib/AST/ModuleNameLookup.cpp
+++ b/lib/AST/ModuleNameLookup.cpp
@@ -206,7 +206,8 @@ void ModuleNameLookup<LookupStrategy>::lookupInModule(
   const size_t initialCount = decls.size();
   size_t currentCount = decls.size();
 
-  auto updateNewDecls = [&](const DeclContext *moduleScopeContext) {
+  auto updateNewDecls = [&](const DeclContext *moduleScopeContext,
+                            bool fromScopedImport) {
     if (decls.size() == currentCount)
       return;
 
@@ -216,6 +217,9 @@ void ModuleNameLookup<LookupStrategy>::lookupInModule(
         if (resolutionKind == ResolutionKind::TypesOnly && !isa<TypeDecl>(VD))
           return true;
         if (resolutionKind == ResolutionKind::MacrosOnly && !isa<MacroDecl>(VD))
+          return true;
+        // Macros are not scoped-importable.
+        if (fromScopedImport && isa<MacroDecl>(VD))
           return true;
         if (respectAccessControl &&
             !declIsVisibleToNameLookup(VD, moduleScopeContext, options))
@@ -241,7 +245,19 @@ void ModuleNameLookup<LookupStrategy>::lookupInModule(
   auto *module = moduleOrFile->getParentModule();
   getDerived()->doLocalLookup(
       module, accessPath, currentModuleLookupFlags, decls);
-  updateNewDecls(moduleScopeContext);
+  // Treat as scoped if the access path is scoped, or the target module is
+  // only visible via scoped imports (e.g. `@StructAndMacro.Foo` referenced
+  // through `import struct StructAndMacro.Foo`).
+  bool fromScopedImport = !accessPath.empty();
+  if (!fromScopedImport && module != moduleScopeContext->getParentModule()) {
+    auto visiblePaths =
+        ctx.getImportCache().getAllVisibleAccessPaths(module, moduleScopeContext);
+    if (!visiblePaths.empty() &&
+        llvm::all_of(visiblePaths,
+                     [](ImportPath::Access p) { return !p.empty(); }))
+      fromScopedImport = true;
+  }
+  updateNewDecls(moduleScopeContext, fromScopedImport);
 
   bool canReturnEarly = (initialCount != decls.size() &&
                          getDerived()->canReturnEarly());
@@ -275,7 +291,8 @@ void ModuleNameLookup<LookupStrategy>::lookupInModule(
 
       getDerived()->doLocalLookup(import.importedModule, import.accessPath,
                                   importedModuleLookupFlags, decls);
-      updateNewDecls(moduleScopeContext);
+      updateNewDecls(moduleScopeContext,
+                     /*fromScopedImport=*/!import.accessPath.empty());
     };
 
     // If the ClangImporter's special header import module appears in the

--- a/lib/Sema/ImportResolution.cpp
+++ b/lib/Sema/ImportResolution.cpp
@@ -1360,6 +1360,11 @@ ScopedImportLookupRequest::evaluate(Evaluator &evaluator,
                  import->getDeclContext()->getModuleScopeContext(),
                  import->getLoc(), NL_QualifiedDefault);
 
+  // `import macro` has not been implementd. Filter them out for now.
+  llvm::erase_if(decls, [](ValueDecl *VD) {
+    return isa<MacroDecl>(VD);
+  });
+
   auto importLoc = import->getLoc();
   if (decls.empty()) {
     ctx.Diags.diagnose(importLoc, diag::decl_does_not_exist_in_module,

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -601,6 +601,10 @@ void ModuleFile::getImportDecls(SmallVectorImpl<Decl *> &Results) {
           TopLevelModule->lookupQualified(
               TopLevelModule, DeclNameRef(ScopeID),
               SourceLoc(), NL_QualifiedDefault, Decls);
+          // Skip macro until `import macro` is implemented.
+          llvm::erase_if(Decls, [](ValueDecl *VD) {
+            return isa<MacroDecl>(VD);
+          });
           std::optional<ImportKind> FoundKind =
               ImportDecl::findBestImportKind(Decls);
           assert(FoundKind.has_value() &&

--- a/test/ImportResolution/qualified-import-macro-and-struct.swift
+++ b/test/ImportResolution/qualified-import-macro-and-struct.swift
@@ -1,0 +1,67 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: %target-swift-frontend -emit-module -o %t/StructAndMacro.swiftmodule %t/StructAndMacro.swift -module-name StructAndMacro
+// RUN: %target-swift-frontend -typecheck -I %t %t/ClientStruct.swift -verify -verify-ignore-unrelated
+// RUN: %target-swift-frontend -typecheck -I %t %t/ClientMacro.swift -verify -verify-ignore-unrelated
+// RUN: %target-swift-frontend -typecheck -I %t %t/ClientUnscoped.swift -verify -verify-ignore-unrelated
+// RUN: %target-swift-frontend -typecheck -I %t %t/ClientBoth.swift -verify -verify-ignore-unrelated
+// RUN: %target-swift-frontend -emit-module -o %t/ClientStruct.swiftmodule -I %t %t/ClientStruct.swift -module-name ClientStruct
+// RUN: %target-swift-ide-test -print-module -module-to-print ClientStruct -source-filename %t/ClientStruct.swift -I %t
+
+//--- StructAndMacro.swift
+
+public struct Foo {
+  public init() {}
+}
+
+@attached(accessor)
+public macro Foo() = #externalMacro(module: "NonExistent", type: "NonExistent")
+
+//--- ClientStruct.swift
+
+// Struct is accessible.
+import struct StructAndMacro.Foo // no-error
+func testStruct() {
+  _ = Foo()
+}
+
+//--- ClientMacro.swift
+
+// Scoped import does not expose the macro.
+import struct StructAndMacro.Foo
+struct Bar {
+  @Foo var x: Int // expected-error {{struct 'Foo' cannot be used as an attribute}}
+}
+
+// Module-qualified attribute also does not.
+struct BarQualified {
+  @StructAndMacro.Foo var x: Int // expected-error {{struct 'Foo' cannot be used as an attribute}}
+}
+
+//--- ClientUnscoped.swift
+
+// Unscoped import exposes both struct and macro.
+import StructAndMacro
+func testStruct() {
+  _ = Foo()
+}
+struct Baz {
+  @Foo var x: Int // expected-error {{external macro implementation type 'NonExistent.NonExistent' could not be found for macro 'Foo()'}}
+}
+
+// Module-qualified attribute resolves to the macro.
+struct BazQualified {
+  @StructAndMacro.Foo var x: Int // expected-error {{external macro implementation type 'NonExistent.NonExistent' could not be found for macro 'Foo()'}}
+}
+
+//--- ClientBoth.swift
+
+// Unscoped import still exposes the macro alongside the scoped struct.
+import StructAndMacro
+import struct StructAndMacro.Foo
+func testStruct() {
+  _ = Foo()
+}
+struct Qux {
+  @Foo var x: Int // expected-error {{external macro implementation type 'NonExistent.NonExistent' could not be found for macro 'Foo()'}}
+}


### PR DESCRIPTION
*6.4 cherry-pick of https://github.com/swiftlang/swift/pull/88447*

- Explanation: Fixes an issue where a scoped import would incorrectly diagnose an ambiguity if a same-named `macro` is present in the overload set. This requires also filtering out macro results from name lookups where a scoped import is used
- Scope: Affects scoped import validation and name lookup
- Issue: rdar://174526734
- Risk: Low/Medium - While this does exclude results from name lookup, in practice we would have previously rejected any attempt at doing a scoped import if a `macro` were in scope for that access path
- Testing: Added tests to test suite
- Reviewer: Hamish Knight