### PR TITLE
🍒 pull request #88943 from hnrklssn/swiftify-synthesized-interface

### DIFF
--- a/include/swift/Driver/PluginPaths.h
+++ b/include/swift/Driver/PluginPaths.h
@@ -1,0 +1,46 @@
+//===--- PluginPaths.h - Toolchain-relative plugin path helpers -*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// Helpers for computing toolchain-relative Swift plugin search paths.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_DRIVER_PLUGINPATHS_H
+#define SWIFT_DRIVER_PLUGINPATHS_H
+
+#include "swift/Basic/LLVM.h"
+#include "llvm/ADT/SmallVector.h"
+
+namespace swift {
+namespace driver {
+
+/// Given a toolchain root (the directory containing bin/, lib/, etc.),
+/// append the platform-appropriate in-process plugin server library path.
+void appendInProcPluginServerPath(StringRef ToolchainRoot,
+                                  llvm::SmallVectorImpl<char> &InProcPluginServerPath);
+
+/// Given a toolchain root, append the platform-appropriate plugin search
+/// directory path.
+void appendPluginsPath(StringRef ToolchainRoot,
+                       llvm::SmallVectorImpl<char> &PluginsPath);
+
+/// Given a toolchain root, append the local plugin search directory path.
+/// Only meaningful on Apple/Unix platforms.
+#if defined(__APPLE__) || defined(__unix__)
+void appendLocalPluginsPath(StringRef ToolchainRoot,
+                            llvm::SmallVectorImpl<char> &LocalPluginsPath);
+#endif
+
+} // end namespace driver
+} // end namespace swift
+
+#endif

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -23,6 +23,7 @@
 #include "swift/Driver/Compilation.h"
 #include "swift/Driver/Driver.h"
 #include "swift/Driver/Job.h"
+#include "swift/Driver/PluginPaths.h"
 #include "swift/Frontend/Frontend.h"
 #include "swift/Option/Options.h"
 #include "clang/Basic/Version.h"
@@ -1562,8 +1563,9 @@ void ToolChain::addLinkRuntimeLib(const ArgList &Args, ArgStringList &Arguments,
   Arguments.push_back(Args.MakeArgString(P));
 }
 
-static void appendInProcPluginServerPath(StringRef PluginPathRoot,
-                                         llvm::SmallVectorImpl<char> &InProcPluginServerPath) {
+void swift::driver::appendInProcPluginServerPath(
+    StringRef PluginPathRoot,
+    llvm::SmallVectorImpl<char> &InProcPluginServerPath) {
   InProcPluginServerPath.append(PluginPathRoot.begin(), PluginPathRoot.end());
 #if defined(_WIN32)
   llvm::sys::path::append(InProcPluginServerPath, "bin", "SwiftInProcPluginServer.dll");
@@ -1576,8 +1578,8 @@ static void appendInProcPluginServerPath(StringRef PluginPathRoot,
 #endif
 }
 
-static void appendPluginsPath(StringRef PluginPathRoot,
-                              llvm::SmallVectorImpl<char> &PluginsPath) {
+void swift::driver::appendPluginsPath(
+    StringRef PluginPathRoot, llvm::SmallVectorImpl<char> &PluginsPath) {
   PluginsPath.append(PluginPathRoot.begin(), PluginPathRoot.end());
 #if defined(_WIN32)
   llvm::sys::path::append(PluginsPath, "bin");
@@ -1589,11 +1591,11 @@ static void appendPluginsPath(StringRef PluginPathRoot,
 }
 
 #if defined(__APPLE__) || defined(__unix__)
-static void appendLocalPluginsPath(StringRef PluginPathRoot,
-                                   llvm::SmallVectorImpl<char> &LocalPluginsPath) {
+void swift::driver::appendLocalPluginsPath(
+    StringRef PluginPathRoot, llvm::SmallVectorImpl<char> &LocalPluginsPath) {
   SmallString<261> localPluginPathRoot = PluginPathRoot;
   llvm::sys::path::append(localPluginPathRoot, "local");
-  appendPluginsPath(localPluginPathRoot, LocalPluginsPath);
+  swift::driver::appendPluginsPath(localPluginPathRoot, LocalPluginsPath);
 }
 #endif
 

--- a/lib/DriverTool/swift_synthesize_interface_main.cpp
+++ b/lib/DriverTool/swift_synthesize_interface_main.cpp
@@ -16,10 +16,12 @@
 
 #include "swift/AST/ASTPrinter.h"
 #include "swift/AST/DiagnosticsFrontend.h"
+#include "swift/AST/SearchPathOptions.h"
 #include "swift/Basic/LLVM.h"
 #include "swift/Basic/LLVMInitialize.h"
 #include "swift/Basic/LangOptions.h"
 #include "swift/Basic/Version.h"
+#include "swift/Driver/PluginPaths.h"
 #include "swift/Frontend/Frontend.h"
 #include "swift/Frontend/PrintingDiagnosticConsumer.h"
 #include "swift/IDE/ModuleInterfacePrinting.h"
@@ -27,6 +29,7 @@
 #include "swift/Parse/ParseVersion.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/Path.h"
 #include "llvm/Support/raw_ostream.h"
 
 using namespace swift;
@@ -132,7 +135,32 @@ int swift_synthesize_interface_main(ArrayRef<const char *> Args,
   }
   Invocation.setImportSearchPaths(ImportSearchPaths);
 
+  // Add default toolchain-relative plugin paths.
+  SmallString<261> toolchainRoot{MainExecutablePath};
+  llvm::sys::path::remove_filename(toolchainRoot); // remove executable name
+  llvm::sys::path::remove_filename(toolchainRoot); // remove 'bin'
+
+  SearchPathOptions &SearchPathOpts = Invocation.getSearchPathOptions();
+
+  SmallString<261> inProcPluginServerPath;
+  driver::appendInProcPluginServerPath(toolchainRoot, inProcPluginServerPath);
+  SearchPathOpts.InProcessPluginServerPath =
+      std::string(inProcPluginServerPath);
+
+  SmallString<261> defaultPluginPath;
+  driver::appendPluginsPath(toolchainRoot, defaultPluginPath);
+  SearchPathOpts.PluginSearchOpts.emplace_back(
+      PluginSearchOption::PluginPath{std::string(defaultPluginPath)});
+
+#if defined(__APPLE__) || defined(__unix__)
+  SmallString<261> localPluginPath;
+  driver::appendLocalPluginsPath(toolchainRoot, localPluginPath);
+  SearchPathOpts.PluginSearchOpts.emplace_back(
+      PluginSearchOption::PluginPath{std::string(localPluginPath)});
+#endif
+
   Invocation.getLangOptions().EnableObjCInterop = Target.isOSDarwin();
+  Invocation.getLangOptions().AttachCommentsToDecls = true;
   Invocation.getLangOptions().setCxxInteropFromArgs(ParsedArgs, Diags,
                                                     Invocation.getFrontendOptions());
   Invocation.computeCXXStdlibOptions();
@@ -173,6 +201,7 @@ int swift_synthesize_interface_main(ArrayRef<const char *> Args,
     return EXIT_FAILURE;
   }
 
+  (void)CI.getMainModule(); // clang modules inherit default imports from main module
   auto M = CI.getASTContext().getModuleByName(ModuleName);
   if (!M) {
     llvm::errs() << "Couldn't load module '" << ModuleName << '\''

--- a/test/Interop/C/swiftify-import/comments.swift
+++ b/test/Interop/C/swiftify-import/comments.swift
@@ -1,51 +1,69 @@
-
-// RUN: %target-swift-ide-test -print-module -module-to-print=CommentsClang -plugin-path %swift-plugin-dir -I %S/Inputs -source-filename=x | %FileCheck %s --strict-whitespace --match-full-lines
+// RUN: %target-swift-ide-test -print-module -module-to-print=CommentsClang -plugin-path %swift-plugin-dir -I %S/Inputs -source-filename=x | %FileCheck %s --strict-whitespace --match-full-lines --check-prefixes=BOTH,IDE
+// RUN: %target-swift-synthesize-interface -module-name CommentsClang -I %S/Inputs -o - | %FileCheck %s --strict-whitespace --match-full-lines --check-prefixes=BOTH,SYNTH
 
 // Check that doc comments are carried over from clang to the safe macro expansion.
 
-// CHECK:func begin()
-// CHECK-NEXT:func lineComment(_ len: Int32, _ p: UnsafeMutablePointer<Int32>!)
+// IDE:func begin()
+// SYNTH:public func begin()
 
-// CHECK-NEXT:/// line doc comment
-// CHECK-NEXT:/// 
-// CHECK-NEXT:/// Here's a more complete description.
-// CHECK-NEXT:///
-// CHECK-NEXT:/// @param len the buffer length
-// CHECK-NEXT:/// @param p the buffer
-// CHECK-NEXT:func lineDocComment(_ len: Int32, _ p: UnsafeMutablePointer<Int32>!)
+// SYNTH-EMPTY:
+// IDE-NEXT:func lineComment(_ len: Int32, _ p: UnsafeMutablePointer<Int32>!)
+// SYNTH-NEXT:public func lineComment(_ len: Int32, _ p: UnsafeMutablePointer<Int32>!)
 
-// CHECK-NEXT:func blockComment(_ len: Int32, _ p: UnsafeMutablePointer<Int32>!)
+// SYNTH-EMPTY:
+// BOTH-NEXT:/// line doc comment
+// BOTH-NEXT:/// 
+// BOTH-NEXT:/// Here's a more complete description.
+// BOTH-NEXT:///
+// BOTH-NEXT:/// @param len the buffer length
+// BOTH-NEXT:/// @param p the buffer
+// IDE-NEXT:func lineDocComment(_ len: Int32, _ p: UnsafeMutablePointer<Int32>!)
+// SYNTH-NEXT:public func lineDocComment(_ len: Int32, _ p: UnsafeMutablePointer<Int32>!)
 
-// CHECK-NEXT:/**
-// CHECK-NEXT: * block doc comment
-// CHECK-NEXT: * 
-// CHECK-NEXT: * NB: it's very important to pass the correct length to this function
-// CHECK-NEXT: * @param len don't mess this one up
-// CHECK-NEXT: * @param p   some integers to play with
-// CHECK-NEXT: */
-// CHECK-NEXT:func blockDocComment(_ len: Int32, _ p: UnsafeMutablePointer<Int32>!)
+// SYNTH-EMPTY:
+// IDE-NEXT:func blockComment(_ len: Int32, _ p: UnsafeMutablePointer<Int32>!)
+// SYNTH-NEXT:public func blockComment(_ len: Int32, _ p: UnsafeMutablePointer<Int32>!)
 
-// CHECK-NEXT:/// This is an auto-generated wrapper for safer interop
-// CHECK-NEXT:@_alwaysEmitIntoClient @_disfavoredOverload public func blockComment(_ p: UnsafeMutableBufferPointer<Int32>)
+// SYNTH-EMPTY:
+// BOTH-NEXT:/**
+// BOTH-NEXT: * block doc comment
+// BOTH-NEXT: * 
+// BOTH-NEXT: * NB: it's very important to pass the correct length to this function
+// BOTH-NEXT: * @param len don't mess this one up
+// BOTH-NEXT: * @param p   some integers to play with
+// BOTH-NEXT: */
+// IDE-NEXT:func blockDocComment(_ len: Int32, _ p: UnsafeMutablePointer<Int32>!)
+// SYNTH-NEXT:public func blockDocComment(_ len: Int32, _ p: UnsafeMutablePointer<Int32>!)
 
-// CHECK-NEXT:/**
-// CHECK-NEXT: * block doc comment
-// CHECK-NEXT: * 
-// CHECK-NEXT: * NB: it's very important to pass the correct length to this function
-// CHECK-NEXT: * @param len don't mess this one up
-// CHECK-NEXT: * @param p   some integers to play with
-// CHECK-NEXT: */
-// CHECK-NEXT:/// This is an auto-generated wrapper for safer interop
-// CHECK-NEXT:@_alwaysEmitIntoClient @_disfavoredOverload public func blockDocComment(_ p: UnsafeMutableBufferPointer<Int32>)
+// SYNTH-EMPTY:
+// BOTH-NEXT:/// This is an auto-generated wrapper for safer interop
+// IDE-NEXT:@_alwaysEmitIntoClient @_disfavoredOverload public func blockComment(_ p: UnsafeMutableBufferPointer<Int32>)
+// SYNTH-NEXT:public func blockComment(_ p: UnsafeMutableBufferPointer<Int32>)
 
-// CHECK-NEXT:/// This is an auto-generated wrapper for safer interop
-// CHECK-NEXT:@_alwaysEmitIntoClient @_disfavoredOverload public func lineComment(_ p: UnsafeMutableBufferPointer<Int32>)
+// SYNTH-EMPTY:
+// BOTH-NEXT:/**
+// BOTH-NEXT: * block doc comment
+// BOTH-NEXT: * 
+// BOTH-NEXT: * NB: it's very important to pass the correct length to this function
+// BOTH-NEXT: * @param len don't mess this one up
+// BOTH-NEXT: * @param p   some integers to play with
+// BOTH-NEXT: */
+// BOTH-NEXT:/// This is an auto-generated wrapper for safer interop
+// IDE-NEXT:@_alwaysEmitIntoClient @_disfavoredOverload public func blockDocComment(_ p: UnsafeMutableBufferPointer<Int32>)
+// SYNTH-NEXT:public func blockDocComment(_ p: UnsafeMutableBufferPointer<Int32>)
 
-// CHECK-NEXT:/// line doc comment
-// CHECK-NEXT:/// 
-// CHECK-NEXT:/// Here's a more complete description.
-// CHECK-NEXT:///
-// CHECK-NEXT:/// @param len the buffer length
-// CHECK-NEXT:/// @param p the buffer
-// CHECK-NEXT:/// This is an auto-generated wrapper for safer interop
-// CHECK-NEXT:@_alwaysEmitIntoClient @_disfavoredOverload public func lineDocComment(_ p: UnsafeMutableBufferPointer<Int32>)
+// SYNTH-EMPTY:
+// BOTH-NEXT:/// This is an auto-generated wrapper for safer interop
+// IDE-NEXT:@_alwaysEmitIntoClient @_disfavoredOverload public func lineComment(_ p: UnsafeMutableBufferPointer<Int32>)
+// SYNTH-NEXT:public func lineComment(_ p: UnsafeMutableBufferPointer<Int32>)
+
+// SYNTH-EMPTY:
+// BOTH-NEXT:/// line doc comment
+// BOTH-NEXT:/// 
+// BOTH-NEXT:/// Here's a more complete description.
+// BOTH-NEXT:///
+// BOTH-NEXT:/// @param len the buffer length
+// BOTH-NEXT:/// @param p the buffer
+// BOTH-NEXT:/// This is an auto-generated wrapper for safer interop
+// IDE-NEXT:@_alwaysEmitIntoClient @_disfavoredOverload public func lineDocComment(_ p: UnsafeMutableBufferPointer<Int32>)
+// SYNTH-NEXT:public func lineDocComment(_ p: UnsafeMutableBufferPointer<Int32>)


### PR DESCRIPTION
- **Explanation**:
This adds support for safe interop wrappers to `swift-synthesize-interface`. This required the following changes:
 - adding discovery of the plugin path to load the `_SwiftifyImport` macro
 - enabling parsing of Swift comments, to keep doc comments for the macro generated wrappers
 - creating a Swift main module for the imported module to inherit implicit imports from
- **Scope**:
This does not affect the compiler itself. It should only make `swift-synthesize-interface` display additional interfaces that were previously missing.
- **Issues**:
https://github.com/swiftlang/swift/issues/88880'
rdar://176377924
- **Original PRs**:
https://github.com/swiftlang/swift/pull/88943
- **Risk**:
Low, does not affect the compiler
- **Testing**:
Lit testing
- **Reviewers**:
@artemcm 