### PR TITLE
🍒[Swiftify] make safe wrappers `final` when in a Swift class

### DIFF
--- a/lib/Macros/Sources/SwiftMacros/SwiftifyImportMacro.swift
+++ b/lib/Macros/Sources/SwiftMacros/SwiftifyImportMacro.swift
@@ -1777,16 +1777,24 @@ func constructOverloadFunction(forDecl declaration: some DeclSyntaxProtocol, lea
     + disfavoredOverload)
   let trivia =
     leadingTrivia + .docLineComment("/// This is an auto-generated wrapper for safer interop\n")
+  var modifiers = funcComponents.modifiers
+  if parentNode?.as(ClassDeclSyntax.self) != nil {
+    if let openIdx = modifiers.firstIndex(where: { mod in mod.name.tokenKind == .keyword(.open)}) {
+      // "open final" is not allowed in Swift
+      modifiers[openIdx] = DeclModifierSyntax(name: .keyword(.public))
+    }
+    modifiers.append(DeclModifierSyntax(name: .keyword(.final)))
+  }
   if let origFuncDecl = declaration.as(FunctionDeclSyntax.self) {
     return DeclSyntax(
       origFuncDecl
         .with(\.signature, newSignature)
         .with(\.body, body)
         .with(\.attributes, attributes)
+        .with(\.modifiers, modifiers)
         .with(\.leadingTrivia, trivia))
   }
   if let origInitDecl = declaration.as(InitializerDeclSyntax.self) {
-    var modifiers = funcComponents.modifiers
     if parentNode?.as(ClassDeclSyntax.self) != nil { // convenience inits are forbidden in structs
       let alreadyConvenienceInit = modifiers.contains(where: { mod in
         mod.name.text == "convenience"

--- a/test/Interop/C/swiftify-import/import-as-instance-method.swift
+++ b/test/Interop/C/swiftify-import/import-as-instance-method.swift
@@ -244,7 +244,7 @@ public func lifetimeBoundSelf(_ a: A, _ len: Int32) -> MutableSpan<Int32> {
 ------------------------------
 /// This is an auto-generated wrapper for safer interop
 @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
-public func refSelf(_ p: inout MutableSpan<Int32>) {
+public final func refSelf(_ p: inout MutableSpan<Int32>) {
     let len = Int32(exactly: p.count)!
     let _pPtr = p.withUnsafeMutableBufferPointer {
         unsafe $0
@@ -274,7 +274,7 @@ public func refSelf(_ c: C!, _ p: inout MutableSpan<Int32>) {
 ------------------------------
 /// This is an auto-generated wrapper for safer interop
 @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload
-public func refSelf(_ p: inout MutableSpan<Int32>) {
+public final func refSelf(_ p: inout MutableSpan<Int32>) {
     let len = Int32(exactly: p.count)!
     let _pPtr = p.withUnsafeMutableBufferPointer {
         unsafe $0
@@ -375,7 +375,7 @@ public func createA2(_ p: inout MutableSpan<Int32>) -> UnsafeMutablePointer<A>! 
 ------------------------------
 /// This is an auto-generated wrapper for safer interop
 @_alwaysEmitIntoClient @_disfavoredOverload
-public /*not inherited*/ convenience init!(pointerC p: UnsafeMutableBufferPointer<Int32>) {
+public /*not inherited*/ final convenience init!(pointerC p: UnsafeMutableBufferPointer<Int32>) {
     let len = Int32(exactly: p.count)!
     unsafe self.init(countC: len, pointerC: p.baseAddress!)
 }


### PR DESCRIPTION
- **Explanation**:
This updates the `_SwiftifyImport` macro to emit functions that are `final` when the function is an instance method in a reference type. `@_alwaysEmitIntoClient` does not make sense to combine with dynamic dispatch, so this makes sure we always have static dispatch.
- **Scope**:
Any code broken by this is already broken: if you override an `@_alwaysEmitIntoClient` function you may call different function implementations depending on whether the optimizer inlines the `@_alwaysEmitIntoClient` body, or does dynamic dispatch at runtime.
- **Issues**:
rdar://177544334
- **Original PRs**:
https://github.com/swiftlang/swift/pull/89298
- **Risk**:
Low, this should only surface (rare) runtime issues as compile time issues
- **Testing**:
Lit testing
- **Reviewers**:
@Xazax-hun 