### PR TITLE
[stdlib, 6.4] Use borrow accessors for `Span`, `MutableSpan` & `OutputSpan` subscripts

### DIFF
--- a/stdlib/public/core/Span/MutableSpan.swift
+++ b/stdlib/public/core/Span/MutableSpan.swift
@@ -408,15 +408,15 @@ extension MutableSpan where Element: ~Copyable {
   @_alwaysEmitIntoClient
   public subscript(_ position: Index) -> Element {
     @_transparent
-    unsafeAddress {
+    borrow {
       _checkIndex(position)
-      return unsafe UnsafePointer(_unsafeAddressOfElement(unchecked: position))
+      return unsafe self[unchecked: position]
     }
     @_transparent
     @lifetime(self: copy self)
-    unsafeMutableAddress {
+    mutate {
       _checkIndex(position)
-      return unsafe _unsafeAddressOfElement(unchecked: position)
+      return unsafe &self[unchecked: position]
     }
   }
 
@@ -432,13 +432,16 @@ extension MutableSpan where Element: ~Copyable {
   @_alwaysEmitIntoClient
   public subscript(unchecked position: Index) -> Element {
     @_transparent
-    unsafeAddress {
-      unsafe UnsafePointer(_unsafeAddressOfElement(unchecked: position))
+    @_unsafeSelfDependentResult
+    borrow {
+      Builtin.borrowAt(unsafe _unsafeAddressOfElement(unchecked: position))
     }
     @_transparent
+    @_unsafeSelfDependentResult
     @lifetime(self: copy self)
-    unsafeMutableAddress {
-      unsafe _unsafeAddressOfElement(unchecked: position)
+    mutate {
+      let address = unsafe _unsafeAddressOfElement(unchecked: position)
+      return unsafe &(UnsafeMutablePointer(address).pointee)
     }
   }
 
@@ -447,10 +450,9 @@ extension MutableSpan where Element: ~Copyable {
   @_transparent
   internal func _unsafeAddressOfElement(
     unchecked position: Index
-  ) -> UnsafeMutablePointer<Element> {
+  ) -> Builtin.RawPointer {
     let elementOffset = position &* MemoryLayout<Element>.stride
-    let address = unsafe _start().advanced(by: elementOffset)
-    return unsafe address.assumingMemoryBound(to: Element.self)
+    return unsafe _start().advanced(by: elementOffset)._rawValue
   }
 }
 
@@ -480,8 +482,10 @@ extension MutableSpan where Element: ~Copyable {
   @_alwaysEmitIntoClient
   @lifetime(self: copy self)
   public mutating func swapAt(unchecked i: Index, unchecked j: Index) {
-    let pi = unsafe _unsafeAddressOfElement(unchecked: i)
-    let pj = unsafe _unsafeAddressOfElement(unchecked: j)
+    let ri = unsafe _unsafeAddressOfElement(unchecked: i)
+    let pi = unsafe UnsafeMutablePointer<Element>(ri)
+    let rj = unsafe _unsafeAddressOfElement(unchecked: j)
+    let pj = unsafe UnsafeMutablePointer<Element>(rj)
     let temporary = unsafe pi.move()
     unsafe pi.initialize(to: pj.move())
     unsafe pj.initialize(to: consume temporary)

--- a/stdlib/public/core/Span/OutputSpan.swift
+++ b/stdlib/public/core/Span/OutputSpan.swift
@@ -213,14 +213,16 @@ extension OutputSpan where Element: ~Copyable {
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
   public subscript(_ index: Index) -> Element {
-    unsafeAddress {
+    @_transparent
+    borrow {
       _checkIndex(index)
-      return unsafe UnsafePointer(_unsafeAddressOfElement(unchecked: index))
+      return unsafe self[unchecked: index]
     }
+    @_transparent
     @lifetime(self: copy self)
-    unsafeMutableAddress {
+    mutate {
       _checkIndex(index)
-      return unsafe _unsafeAddressOfElement(unchecked: index)
+      return unsafe &(self[unchecked: index])
     }
   }
 
@@ -234,12 +236,15 @@ extension OutputSpan where Element: ~Copyable {
   @unsafe
   @_alwaysEmitIntoClient
   public subscript(unchecked index: Index) -> Element {
-    unsafeAddress {
-      unsafe UnsafePointer(_unsafeAddressOfElement(unchecked: index))
+    @_unsafeSelfDependentResult
+    borrow {
+      Builtin.borrowAt(unsafe _unsafeAddressOfElement(unchecked: index))
     }
+    @_unsafeSelfDependentResult
     @lifetime(self: copy self)
-    unsafeMutableAddress {
-      unsafe _unsafeAddressOfElement(unchecked: index)
+    mutate {
+      let address = unsafe _unsafeAddressOfElement(unchecked: index)
+      return unsafe &(UnsafeMutablePointer(address).pointee)
     }
   }
 
@@ -247,10 +252,9 @@ extension OutputSpan where Element: ~Copyable {
   @_alwaysEmitIntoClient
   internal func _unsafeAddressOfElement(
     unchecked index: Index
-  ) -> UnsafeMutablePointer<Element> {
+  ) -> Builtin.RawPointer {
     let elementOffset = index &* MemoryLayout<Element>.stride
-    let address = unsafe _start().advanced(by: elementOffset)
-    return unsafe address.assumingMemoryBound(to: Element.self)
+    return unsafe _start().advanced(by: elementOffset)._rawValue
   }
 
   /// Exchange the elements at the two given indices.
@@ -275,8 +279,10 @@ extension OutputSpan where Element: ~Copyable {
   @_alwaysEmitIntoClient
   @lifetime(self: copy self)
   public mutating func swapAt(unchecked i: Index, unchecked j: Index) {
-    let pi = unsafe _unsafeAddressOfElement(unchecked: i)
-    let pj = unsafe _unsafeAddressOfElement(unchecked: j)
+    let ri = unsafe _unsafeAddressOfElement(unchecked: i)
+    let pi = unsafe UnsafeMutablePointer<Element>(ri)
+    let rj = unsafe _unsafeAddressOfElement(unchecked: j)
+    let pj = unsafe UnsafeMutablePointer<Element>(rj)
     let temporary = unsafe pi.move()
     unsafe pi.initialize(to: pj.move())
     unsafe pj.initialize(to: consume temporary)

--- a/stdlib/public/core/Span/Span.swift
+++ b/stdlib/public/core/Span/Span.swift
@@ -453,10 +453,10 @@ extension Span where Element: ~Copyable {
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
   public subscript(_ position: Index) -> Element {
-    //FIXME: change to unsafeRawAddress when ready
-    unsafeAddress {
+    @_transparent
+    borrow {
       _checkIndex(position)
-      return unsafe _unsafeAddressOfElement(unchecked: position)
+      return unsafe self[unchecked: position]
     }
   }
 
@@ -472,9 +472,9 @@ extension Span where Element: ~Copyable {
   @unsafe
   @_alwaysEmitIntoClient
   public subscript(unchecked position: Index) -> Element {
-    //FIXME: change to unsafeRawAddress when ready
-    unsafeAddress {
-      unsafe _unsafeAddressOfElement(unchecked: position)
+    @_unsafeSelfDependentResult
+    borrow {
+      Builtin.borrowAt(unsafe _unsafeAddressOfElement(unchecked: position))
     }
   }
 
@@ -482,10 +482,9 @@ extension Span where Element: ~Copyable {
   @_alwaysEmitIntoClient
   internal func _unsafeAddressOfElement(
     unchecked position: Index
-  ) -> UnsafePointer<Element> {
+  ) -> Builtin.RawPointer {
     let elementOffset = position &* MemoryLayout<Element>.stride
-    let address = unsafe _start().advanced(by: elementOffset)
-    return unsafe address.assumingMemoryBound(to: Element.self)
+    return unsafe _start().advanced(by: elementOffset)._rawValue
   }
 }
 
@@ -500,6 +499,7 @@ extension Span where Element: BitwiseCopyable {
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
   public subscript(_ position: Index) -> Element {
+    @_transparent
     get {
       _checkIndex(position)
       return unsafe self[unchecked: position]
@@ -519,9 +519,8 @@ extension Span where Element: BitwiseCopyable {
   @_alwaysEmitIntoClient
   public subscript(unchecked position: Index) -> Element {
     get {
-      let elementOffset = position &* MemoryLayout<Element>.stride
-      let address = unsafe _start().advanced(by: elementOffset)
-      return unsafe address.loadUnaligned(as: Element.self)
+      let address = unsafe _unsafeAddressOfElement(unchecked: position)
+      return unsafe UnsafeRawPointer(address).loadUnaligned(as: Element.self)
     }
   }
 }


### PR DESCRIPTION
- **Explanation**:
Adopt borrow and mutate accessors from SE-0509 in the element subscripts of `Span`, `MutableSpan`, and `OutputSpan`. These are necessary to support non-escapable elements.

- **Scope**:
Source-compatible changes for non-ABI symbols.

- **Issues**:
Addresses rdar://176500628

- **Original PRs**:
https://github.com/swiftlang/swift/pull/89184

- **Risk**:
Low. Source-compatible with no ABI impact.

- **Testing**:
Unchanged tests pass.

- **Reviewers**:
@Azoy