### PR TITLE
[stdlib] change `InlineArray` element subscripts to borrow and mutate accessors

### DIFF
--- a/stdlib/public/core/InlineArray.swift
+++ b/stdlib/public/core/InlineArray.swift
@@ -503,15 +503,15 @@ extension InlineArray where Element: ~Copyable {
   @_alwaysEmitIntoClient
   public subscript(_ i: Index) -> Element {
     @_transparent
-    unsafeAddress {
+    borrow {
       _checkIndex(i)
-      return unsafe _address + i
+      return unsafe self[unchecked: i]
     }
 
     @_transparent
-    unsafeMutableAddress {
+    mutate {
       _checkIndex(i)
-      return unsafe _mutableAddress + i
+      return unsafe &self[unchecked: i]
     }
   }
 
@@ -530,13 +530,15 @@ extension InlineArray where Element: ~Copyable {
   @unsafe
   public subscript(unchecked i: Index) -> Element {
     @_transparent
-    unsafeAddress {
-      unsafe _protectedAddress + i
+    @_unsafeSelfDependentResult
+    borrow {
+      Builtin.borrowAt(unsafe (_protectedAddress + i)._rawValue)
     }
 
     @_transparent
-    unsafeMutableAddress {
-      unsafe _protectedMutableAddress + i
+    @_unsafeSelfDependentResult
+    mutate {
+      unsafe &(_protectedMutableAddress + i).pointee
     }
   }
 }

--- a/stdlib/public/core/_InlineArray.swift
+++ b/stdlib/public/core/_InlineArray.swift
@@ -386,15 +386,15 @@ extension _InlineArray where Element: ~Copyable {
   @_alwaysEmitIntoClient
   internal subscript(_ i: Index) -> Element {
     @_transparent
-    unsafeAddress {
+    borrow {
       _checkIndex(i)
-      return unsafe _address + i
+      return unsafe self[unchecked: i]
     }
 
     @_transparent
-    unsafeMutableAddress {
+    mutate {
       _checkIndex(i)
-      return unsafe _mutableAddress + i
+      return unsafe &self[unchecked: i]
     }
   }
 
@@ -412,13 +412,15 @@ extension _InlineArray where Element: ~Copyable {
   @unsafe
   internal subscript(unchecked i: Index) -> Element {
     @_transparent
-    unsafeAddress {
-      unsafe _protectedAddress + i
+    @_unsafeSelfDependentResult
+    borrow {
+      Builtin.borrowAt(unsafe (_protectedAddress + i)._rawValue)
     }
 
     @_transparent
-    unsafeMutableAddress {
-      unsafe _protectedMutableAddress + i
+    @_unsafeSelfDependentResult
+    mutate {
+      unsafe &(_protectedMutableAddress + i).pointee
     }
   }
 }

--- a/test/SILGen/inline_array_stored_properties.swift
+++ b/test/SILGen/inline_array_stored_properties.swift
@@ -10,12 +10,7 @@ struct S {
         // CHECK:   [[ACCESS:%.*]] = begin_access [read] [unknown] [[SELF]]
         // CHECK:   [[ADDRESSOR:%.*]] = function_ref @$s{{.*}}11InlineArrayV
         // CHECK:   [[PTR:%.*]] = apply [[ADDRESSOR]]
-        // CHECK:   [[RAWPTR:%.*]] = struct_extract [[PTR]]
-        // CHECK:   [[ADDR:%.*]] = pointer_to_address [[RAWPTR]]
-        // CHECK:   [[DEP:%.*]] = mark_dependence [unresolved] [[ADDR]]
-        // CHECK:   [[ADDR_ACCESS:%.*]] = begin_access [read] [unsafe] [[DEP]]
-        // CHECK:   load [trivial] [[ADDR_ACCESS]]
-        // CHECK:   end_access [[ADDR_ACCESS]]
+        // CHECK:   load [trivial] [[PTR]]
         // CHECK:   end_access [[ACCESS]]
         x += a[y]
     }
@@ -32,12 +27,7 @@ final class C {
         // CHECK:   [[ACCESS:%.*]] = begin_access [read] [dynamic] [[FIELD]]
         // CHECK:   [[ADDRESSOR:%.*]] = function_ref @$s{{.*}}11InlineArrayV
         // CHECK:   [[PTR:%.*]] = apply [[ADDRESSOR]]
-        // CHECK:   [[RAWPTR:%.*]] = struct_extract [[PTR]]
-        // CHECK:   [[ADDR:%.*]] = pointer_to_address [[RAWPTR]]
-        // CHECK:   [[DEP:%.*]] = mark_dependence [unresolved] [[ADDR]]
-        // CHECK:   [[ADDR_ACCESS:%.*]] = begin_access [read] [unsafe] [[DEP]]
-        // CHECK:   load [trivial] [[ADDR_ACCESS]]
-        // CHECK:   end_access [[ADDR_ACCESS]]
+        // CHECK:   load [trivial] [[PTR]]
         // CHECK:   end_access [[ACCESS]]
         x += a[y]
     }
@@ -50,12 +40,7 @@ func tupleF(tuple: inout (Int, InlineArray<40, Int>), x: inout Int, y: Int) {
     // CHECK:   [[ACCESS:%.*]] = begin_access [read] [unknown] [[TUPLE]]
     // CHECK:   [[ADDRESSOR:%.*]] = function_ref @$s{{.*}}11InlineArrayV
     // CHECK:   [[PTR:%.*]] = apply [[ADDRESSOR]]
-    // CHECK:   [[RAWPTR:%.*]] = struct_extract [[PTR]]
-    // CHECK:   [[ADDR:%.*]] = pointer_to_address [[RAWPTR]]
-    // CHECK:   [[DEP:%.*]] = mark_dependence [unresolved] [[ADDR]]
-    // CHECK:   [[ADDR_ACCESS:%.*]] = begin_access [read] [unsafe] [[DEP]]
-    // CHECK:   load [trivial] [[ADDR_ACCESS]]
-    // CHECK:   end_access [[ADDR_ACCESS]]
+    // CHECK:   load [trivial] [[PTR]]
     // CHECK:   end_access [[ACCESS]]
     x += tuple.1[y]
 }
@@ -71,12 +56,7 @@ func existentialF(e: inout P, x: inout Int, y: Int) {
     // CHECK:   [[TEMP:%.*]] = alloc_stack $InlineArray
     // CHECK:   [[ADDRESSOR:%.*]] = function_ref @$s{{.*}}11InlineArrayV
     // CHECK:   [[PTR:%.*]] = apply [[ADDRESSOR]]
-    // CHECK:   [[RAWPTR:%.*]] = struct_extract [[PTR]]
-    // CHECK:   [[ADDR:%.*]] = pointer_to_address [[RAWPTR]]
-    // CHECK:   [[DEP:%.*]] = mark_dependence [unresolved] [[ADDR]]
-    // CHECK:   [[ADDR_ACCESS:%.*]] = begin_access [read] [unsafe] [[DEP]]
-    // CHECK:   load [trivial] [[ADDR_ACCESS]]
-    // CHECK:   end_access [[ADDR_ACCESS]]
+    // CHECK:   load [trivial] [[PTR]]
     // CHECK:   dealloc_stack [[TEMP]]
     x += e.a[y]
 }

--- a/test/SILOptimizer/inlinearray_bounds_check_tests.swift
+++ b/test/SILOptimizer/inlinearray_bounds_check_tests.swift
@@ -258,7 +258,7 @@ public func inlinearray_binary_search_spl<let N: Int>(_ v: InlineArray<N, Int>, 
 
 // InlineArray is copied into a temporary within the loop in the "specialized" version
 // This prevents LoopRotate which prevent bounds checks opts since it depends on induction variable analysis which doesn't work on unrotated loops.
-// CHECK-SIL-LABEL: sil @$s30inlinearray_bounds_check_tests0A35_sum_iterate_to_count_with_trap_splySis11InlineArrayVy$63_SiGF :
+// CHECK-SIL-LABEL: sil {{.*}}@$s30inlinearray_bounds_check_tests0A35_sum_iterate_to_count_with_trap_splySis11InlineArrayVy$63_SiGF :
 // CHECK-SIL: bb2
 // CHECK-NOT-SIL: cond_fail {{.*}}, "Index out of bounds"
 // CHECK-SIL: cond_br
@@ -273,7 +273,7 @@ public func inlinearray_sum_iterate_to_count_with_trap_spl(_ v: InlineArray<64, 
 
 // InlineArray is copied into a temporary within the loop in the "specialized" version
 // This prevents LoopRotate which prevent bounds checks opts since it depends on induction variable analysis which doesn't work on unrotated loops.
-// CHECK-SIL-LABEL: sil @$s30inlinearray_bounds_check_tests0A37_sum_iterate_to_unknown_with_trap_splySis11InlineArrayVy$63_SiG_SitF :
+// CHECK-SIL-LABEL: sil {{.*}}@$s30inlinearray_bounds_check_tests0A37_sum_iterate_to_unknown_with_trap_splySis11InlineArrayVy$63_SiG_SitF :
 // CHECK-SIL: bb2
 // CHECK-SIL: cond_fail {{.*}}, "Index out of bounds"
 // CHECK-SIL: cond_br
@@ -322,7 +322,7 @@ public func inlinearray_inc_by_one<let N: Int>(_ v: inout InlineArray<N, Int>, _
   }
 }
 
-// CHECK-SIL-LABEL: sil @$s30inlinearray_bounds_check_tests0A15_inc_by_one_splyys11InlineArrayVy$63_SiGz_SitF :
+// CHECK-SIL-LABEL: sil {{.*}}@$s30inlinearray_bounds_check_tests0A15_inc_by_one_splyys11InlineArrayVy$63_SiGz_SitF :
 // CHECK-SIL: bb2
 // CHECK-NOT-SIL: cond_fail {{.*}}, "Index out of bounds"
 // CHECK-SIL: cond_br


### PR DESCRIPTION
Change `InlineArray`'s element subscript implementation to use `borrow` and `mutate` accessors instead of `unsafeAddress` and `unsafeMutableAddress`.

Addresses rdar://177645276