### PR TITLE
[Sema] Map conformance types into generic env before sendable checking

### DIFF
--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -3740,8 +3740,15 @@ ConformanceChecker::checkActorIsolation(ValueDecl *requirement,
         // and associated types within the conformance can both resolve.
         auto reqGenEnv = requirement->getInnermostDeclContext()
                              ->getGenericEnvironmentOfContext();
-        auto reqSubs = Conformance->getType()->getMemberSubstitutionMap(
-            requirement, reqGenEnv);
+        // Map the conformance's type into its generic environment so that any
+        // conformer-introduced type parameters appearing in the substituted
+        // parameter type are archetypes carrying their conformer-side
+        // constraints (rather than bare interface-type generic parameters,
+        // which `lookupConformance` treats as trivially conforming).
+        Type mappedConformanceType =
+            DC->mapTypeIntoEnvironment(Conformance->getType());
+        auto reqSubs =
+            mappedConformanceType->getMemberSubstitutionMap(requirement, reqGenEnv);
         diagnoseNonSendableTypesInReference(
             /*base=*/nullptr, ConcreteDeclRef(requirement, reqSubs),
             requirement->getInnermostDeclContext(), requirement->getLoc(),

--- a/test/Concurrency/sendable_associated_type_in_witness.swift
+++ b/test/Concurrency/sendable_associated_type_in_witness.swift
@@ -122,3 +122,30 @@ actor ActorNonSendableAssocReturn: AssocReturn {
   func produce() async -> NS { NS() }
   // expected-error@-1 {{non-Sendable type 'NS' cannot be returned from actor-isolated implementation to caller of protocol requirement 'produce()'}}
 }
+
+// https://github.com/swiftlang/swift/issues/89226
+// Nested Sendable struct binding the associated type.
+actor ActorNestedSendableStructAssoc: AssocParam {
+  struct Value: Sendable {}
+  func process(_ value: Value) async {}
+}
+
+// Nested non-Sendable class binding the associated type (gotta reject this).
+actor ActorNestedNonSendableClassAssoc: AssocParam {
+  class Value {} // expected-note {{class 'Value' does not conform to the 'Sendable' protocol}}
+  func process(_ value: Value) async {}
+  // expected-error@-1 {{non-Sendable parameter type 'ActorNestedNonSendableClassAssoc.Value' cannot be sent from caller of protocol requirement 'process' into actor-isolated implementation}}
+}
+
+// https://github.com/swiftlang/swift/issues/89372
+// When the conformer is generic and binds the requirement's associated type to one of its
+// own unconstrained parameters, the witness must be rejected as T carries no Sendable conformance.
+actor ActorGenericConformerUnconstrainedAssoc<T>: AssocParam {
+  // expected-note@-1 {{consider making generic parameter 'T' conform to the 'Sendable' protocol}} {{48-48=: Sendable}}
+  func process(_ value: T) async {}
+  // expected-error@-1 {{non-Sendable parameter type 'T' cannot be sent from caller of protocol requirement 'process' into actor-isolated implementation}}
+}
+
+actor ActorGenericConformerSendableAssoc<T: Sendable>: AssocParam {
+  func process(_ value: T) async {}
+}


### PR DESCRIPTION
This PR maps the conformances types into its generic environment, so we don't represent type params as 'bare' without constraints. `lookupConformance` was treating these as trivially conforming, so we accepted unsound code where the type param was bound to the associated type. I'd like to add an assertion against this in `lookupConformance` but some code paths appear to rely on the trivial conformance behavior.

We can now reject this unsound code:

```swift
protocol AssocParam {
  associatedtype Value
  func process(_ value: Value) async
}

actor ActorGenericConformerUnconstrainedAssoc<T>: AssocParam {
  // expected-note@-1 {{consider making generic parameter 'T' conform to the 'Sendable' protocol}} {{48-48=: Sendable}}
  func process(_ value: T) async {}
  // expected-error@-1 {{non-Sendable parameter type 'T' cannot be sent from caller of protocol requirement 'process' into actor-isolated implementation}}
}

```

Resolves #89372
Resolves rdar://177734802