### PR TITLE
[6.4.x] Concurrency/SILGen: Fixes for `Continuation`

### DIFF
--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -5472,9 +5472,9 @@ SILFunctionType::SILFunctionType(
 
   if (!ext.getLifetimeDependencies().empty()) {
     NumLifetimeDependencies = ext.getLifetimeDependencies().size();
-    memcpy(getMutableLifetimeDependenceInfo().data(),
-           ext.getLifetimeDependencies().data(),
-           NumLifetimeDependencies * sizeof(LifetimeDependenceInfo));
+    auto src = ext.getLifetimeDependencies();
+    std::uninitialized_copy(src.begin(), src.end(),
+                            getMutableLifetimeDependenceInfo().begin());
   }
 #ifndef NDEBUG
   if (ext.getRepresentation() == Representation::WitnessMethod)

--- a/lib/SILGen/SILGenDestructor.cpp
+++ b/lib/SILGen/SILGenDestructor.cpp
@@ -326,13 +326,13 @@ void SILGenFunction::emitDeallocatingMoveOnlyDestructor(DestructorDecl *dd) {
     if (auto *mu =
             dyn_cast<MarkUnresolvedNonCopyableValueInst>(ddi->getOperand())) {
       if (auto *asi = dyn_cast<AllocStackInst>(mu->getOperand())) {
-        B.createDeallocStack(loc, asi);
+        B.createDeallocStack(cleanupLoc, asi);
       }
     }
   }
 
   // Return.
-  B.createReturn(loc, emitEmptyTuple(loc));
+  B.createReturn(returnLoc, emitEmptyTuple(cleanupLoc));
 }
 
 /// Determine whether the availability for the body the given destructor predates the introduction of

--- a/stdlib/public/Concurrency/Continuation.swift
+++ b/stdlib/public/Concurrency/Continuation.swift
@@ -47,7 +47,7 @@ public struct Continuation<Success: ~Copyable, Failure: Error>: ~Copyable, @unch
 
   @inlinable
   init(_ context: Builtin.RawUnsafeContinuation) {
-    unsafe self.context = context
+    self.context = context
   }
 
   deinit {
@@ -58,9 +58,9 @@ public struct Continuation<Success: ~Copyable, Failure: Error>: ~Copyable, @unch
   /// without firing the deinit trap
   @_alwaysEmitIntoClient
   consuming func _takeContext() -> Builtin.RawUnsafeContinuation {
-    let ctx = unsafe self.context
+    let ctx = self.context
     discard self
-    return unsafe ctx
+    return ctx
   }
 
   /// Resume the task awaiting the continuation by having it return
@@ -69,7 +69,7 @@ public struct Continuation<Success: ~Copyable, Failure: Error>: ~Copyable, @unch
   /// - Parameter value: The value to return from the continuation
   @_alwaysEmitIntoClient
   public consuming func resume(returning value: consuming sending Success) where Failure == Never {
-    unsafe Builtin.resumeNonThrowingContinuationReturning(context, value)
+    Builtin.resumeNonThrowingContinuationReturning(context, value)
     discard self // prevent deinit from firing
   }
 
@@ -79,7 +79,7 @@ public struct Continuation<Success: ~Copyable, Failure: Error>: ~Copyable, @unch
   /// - Parameter value: The value to return from the continuation
   @_alwaysEmitIntoClient
   public consuming func resume(returning value: consuming sending Success) {
-    unsafe Builtin.resumeThrowingContinuationReturning(context, value)
+    Builtin.resumeThrowingContinuationReturning(context, value)
     discard self // prevent deinit from firing
   }
 
@@ -89,7 +89,7 @@ public struct Continuation<Success: ~Copyable, Failure: Error>: ~Copyable, @unch
   /// - Parameter error: The error to throw from the continuation
   @_alwaysEmitIntoClient
   public consuming func resume(throwing error: __owned Failure) {
-    unsafe Builtin.resumeThrowingContinuationThrowing(context, error)
+    Builtin.resumeThrowingContinuationThrowing(context, error)
     discard self // prevent deinit from firing
   }
 
@@ -105,9 +105,9 @@ public struct Continuation<Success: ~Copyable, Failure: Error>: ~Copyable, @unch
   ) {
     switch consume result {
     case .success(let val):
-      unsafe Builtin.resumeThrowingContinuationReturning(context, val)
+      Builtin.resumeThrowingContinuationReturning(context, val)
     case .failure(let err):
-      unsafe Builtin.resumeThrowingContinuationThrowing(context, err)
+      Builtin.resumeThrowingContinuationThrowing(context, err)
     }
     discard self // prevent deinit from firing
   }
@@ -151,7 +151,7 @@ public nonisolated(nonsending) func withContinuation<Success: ~Copyable, Failure
 ) async throws(Failure) -> sending Success {
   do {
     return try await Builtin.withUnsafeThrowingContinuation {
-      body(unsafe Continuation($0))
+      body(Continuation($0))
     }
   } catch {
     throw error as! Failure
@@ -182,7 +182,7 @@ public nonisolated(nonsending) func withContinuation<Success: ~Copyable>(
   _ body: (consuming Continuation<Success, Never>) -> Void
 ) async -> sending Success {
   return await Builtin.withUnsafeContinuation {
-    body(unsafe Continuation($0))
+    body(Continuation($0))
   }
 }
 

--- a/test/SILOptimizer/diagnose_unreachable.swift
+++ b/test/SILOptimizer/diagnose_unreachable.swift
@@ -590,3 +590,28 @@ func noWarningForWait(for task: Task<Never, any Error>) async throws -> Never {
     try await task.value
 }
 
+class NoWarningClassDeinit {
+  deinit {
+    fatalError() // no-warning
+  }
+}
+
+struct NoWarningNoncopyableDeinit: ~Copyable {
+  deinit {
+    fatalError() // no-warning
+  }
+}
+
+struct NoWarningNoncopyableDeinitWithFields: ~Copyable {
+  var x: Int
+  deinit {
+    fatalError() // no-warning
+  }
+}
+
+struct NoWarningGenericNoncopyableDeinit<T: ~Copyable>: ~Copyable {
+  var value: T
+  deinit {
+    fatalError() // no-warning
+  }
+}


### PR DESCRIPTION
- **Explanation:** Follow-up to fix a couple minor issues with the new `Continuation` type in the `_Concurrency` module.
- **Scope:** The removal of superfluous `unsafe` markers only affects the source of stdlib. The SILGen fix affects code generation for non-copyable destructors is in a very minor way.
- **Issue/Radar:** N/A
- **Original PR:** https://github.com/swiftlang/swift/pull/89345, https://github.com/swiftlang/swift/pull/89290, https://github.com/swiftlang/swift/pull/88977
- **Risk:** Very low. Removal of unnecessary `unsafe` markers should not affect anything but whether or not diagnostics are emitted during the build of the `_Concurrency` module. The SILGen fix only adjusts source locations for compiler generated code in a very specific kind of declarations.
- **Testing:** New compiler tests.
- **Reviewer:** @ktoso @jckarter 