### PR TITLE
ClangImporter: Avoid mirroring protocol members that are declared elsewhere

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -8579,6 +8579,44 @@ void SwiftDeclConverter::importMirroredProtocolMembers(
       if (classImplementsProtocol(superInterface, clangProto, true))
         continue;
 
+    auto hasExistingMethodWithSelector =
+        [&](clang::Selector sel, bool isInstance,
+            bool acceptPropertyAccessor) -> bool {
+      auto matches = [&](const clang::ObjCContainerDecl *container) -> bool {
+        auto *existing = isInstance ? container->getInstanceMethod(sel)
+                                    : container->getClassMethod(sel);
+        return existing &&
+               (acceptPropertyAccessor || !existing->isPropertyAccessor());
+      };
+
+      if (matches(interfaceDecl))
+        return true;
+
+      for (auto *category : interfaceDecl->known_categories()) {
+        if (!Impl.getClangSema().isVisible(category))
+          continue;
+        if (category != decl) {
+          auto *categoryModule = Impl.getClangModuleForDecl(category);
+          if (categoryModule != declModule &&
+              categoryModule != interfaceModule) {
+            // Also accept a category in a Clang module that is imported by
+            // the module that declares the conformance, since the concrete
+            // method is reachable through that module's imports.
+            auto *clangCategoryMod =
+                categoryModule ? categoryModule->getClangModule() : nullptr;
+            auto *clangDeclMod =
+                declModule ? declModule->getClangModule() : nullptr;
+            if (!clangCategoryMod || !clangDeclMod ||
+                !clangDeclMod->isModuleVisible(clangCategoryMod))
+              continue;
+          }
+        }
+        if (matches(category))
+          return true;
+      }
+      return false;
+    };
+
     auto importProtocolRequirement = [&](Decl *member) {
       // Skip compatibility stubs; there's no reason to mirror them.
       if (member->isUnavailableInCurrentSwiftVersion())
@@ -8594,28 +8632,9 @@ void SwiftDeclConverter::importMirroredProtocolMembers(
         // name. (This also covers other properties with that same name.)
         // FIXME: We should still mirror the setter as a method if it's
         // not already there.
-        clang::Selector sel = objcProp->getGetterName();
-        if (interfaceDecl->getInstanceMethod(sel))
-          return;
-
-        bool inNearbyCategory =
-            std::any_of(interfaceDecl->known_categories_begin(),
-                        interfaceDecl->known_categories_end(),
-                        [=](const clang::ObjCCategoryDecl *category) -> bool {
-                          if (!Impl.getClangSema().isVisible(category)) {
-                            return false;
-                          }
-                          if (category != decl) {
-                            auto *categoryModule =
-                                Impl.getClangModuleForDecl(category);
-                            if (categoryModule != declModule &&
-                                categoryModule != interfaceModule) {
-                              return false;
-                            }
-                          }
-                          return category->getInstanceMethod(sel);
-                        });
-        if (inNearbyCategory)
+        if (hasExistingMethodWithSelector(objcProp->getGetterName(),
+                                          /*isInstance=*/true,
+                                          /*acceptPropertyAccessor=*/true))
           return;
 
         if (auto imported =
@@ -8638,6 +8657,17 @@ void SwiftDeclConverter::importMirroredProtocolMembers(
       auto objcMethod =
           dyn_cast_or_null<clang::ObjCMethodDecl>(member->getClangDecl());
       if (!objcMethod)
+        return;
+
+      // Don't mirror a method if there's an existing method visible that would
+      // witness the requirement.
+      //
+      // A property accessor doesn't count as an existing method for this
+      // purpose: the property only exposes the member via property syntax, so
+      // we still need the mirror in order to make method-call syntax available.
+      if (hasExistingMethodWithSelector(objcMethod->getSelector(),
+                                        objcMethod->isInstanceMethod(),
+                                        /*acceptPropertyAccessor=*/false))
         return;
 
       // For now, just remember that we saw this method.

--- a/test/ClangImporter/objc_redeclared_properties_conformances.swift
+++ b/test/ClangImporter/objc_redeclared_properties_conformances.swift
@@ -99,9 +99,11 @@ func test(x: X) {
   x.methodFromInterface()
   // expected-warning@-1 {{'methodFromInterface()' is deprecated: Interface.h}}
   x.methodFromVisibleCategory()
+  // expected-warning@-1 {{'methodFromVisibleCategory()' is deprecated: VisibleCategory.h}}
   _ = x.readonlyPropFromInterface
   // expected-warning@-1 {{'readonlyPropFromInterface' is deprecated: Interface.h}}
   _ = x.readonlyPropFromVisibleCategory
+  // expected-warning@-1 {{'readonlyPropFromVisibleCategory' is deprecated: VisibleCategory.h}}
   _ = x.readwritePropFromInterface
   // expected-warning@-1 {{'readwritePropFromInterface' is deprecated: Interface.h}}
   x.readwritePropFromInterface = 0
@@ -110,6 +112,7 @@ func test(x: X) {
   // expected-warning@-1 {{'methodAsPropertyWitnessFromInterface()' is deprecated: Interface.h}}
   _ = x.propAsMethodWitnessFromVisibleCategory()
   x.methodFromInterfaceCategory()
+  // expected-warning@-1 {{'methodFromInterfaceCategory()' is deprecated: Interface.h category}}
   _ = x.propFromInterfaceCategory
   // expected-warning@-1 {{'propFromInterfaceCategory' is deprecated: Interface.h category}}
   x.methodFromOtherCategory()
@@ -132,14 +135,7 @@ func test(x: X) {
 // CHECK-NEXT:   var propFromOtherCategory: Int32 { get }
 // CHECK-NEXT: }
 // CHECK-NEXT: extension X : Proto {
-// FIXME: should not be mirrored (rdar://166912341)
-// CHECK-NEXT:   var readonlyPropFromVisibleCategory: Int32 { get }
 // CHECK-NEXT:   var propFromOtherCategory: Int32 { get }
-// FIXME: should not be mirrored (rdar://166912341)
-// CHECK-NEXT:   func methodFromInterfaceCategory()
-// FIXME: should not be mirrored (rdar://166912341)
-// CHECK-NEXT:   func methodFromVisibleCategory()
-// FIXME: should not be mirrored (rdar://166912341)
 // CHECK-NEXT:   func propAsMethodWitnessFromVisibleCategory() -> Int32
 // CHECK-NEXT:   func methodFromOtherCategory()
 // CHECK-NEXT: }

--- a/test/NameLookup/member_import_visibility_objc.swift
+++ b/test/NameLookup/member_import_visibility_objc.swift
@@ -32,8 +32,7 @@ func test(x: X) {
   // expected-no-member-visibility-warning@-1 {{'overriddenInOverlayForC()' is deprecated: Categories_C.swift}}
   // expected-member-visibility-warning@-2 {{'overriddenInOverlayForC()' is deprecated: Categories_A.h}}
   x.witnessesObjCConformanceRequirementInC()
-  // expected-no-member-visibility-warning@-1 {{'witnessesObjCConformanceRequirementInC()' is deprecated: Categories_A.h}}
-  // expected-member-visibility-warning@-2 {{'witnessesObjCConformanceRequirementInC()' is deprecated: Categories_A.h}}
+  // expected-warning@-1 {{'witnessesObjCConformanceRequirementInC()' is deprecated: Categories_A.h}}
   x.fromSubmoduleOfD() // expected-member-visibility-error {{instance method 'fromSubmoduleOfD()' is not available due to missing import of defining module 'Categories_D'}}
   x.fromBridgingHeader()
   x.overridesCategoryMethodOnNSObject()


### PR DESCRIPTION
When an ObjC class in an imported Clang module conforms to an ObjC protocol whose requirement shares a selector with an existing, concrete method already declared on the class or a nearby category, SwiftDeclConverter would still synthesize a "mirrored" method.  During name lookup and overload resolution, the mirror implementation could be picked instead of the concrete implementation. Prior to MemberImportVisibility, the fact that the compiler chooses the mirrored method was typically invisible to developers under most circumstances. However, with MemberImportVisibility this behavior resulted in unexpected diagnostics requiring developers to import another module.

Skip mirroring when the interface, or a category in the same module as either the interface or the conformance, already declares a concrete (non-accessor) method with the same selector. Property accessors don't count: a property only exposes the member via property syntax, so the mirror is still needed for method-call syntax. The existing property-mirroring path already had an analogous check; the two now share a helper.

Resolves rdar://166912341.