### PR TITLE
[stdlib] switch away from old @lifetime annotations

### DIFF
--- a/stdlib/public/core/Array.swift
+++ b/stdlib/public/core/Array.swift
@@ -1756,7 +1756,7 @@ extension Array {
   /// - Complexity: O(1) for native arrays, amortized O(1) for bridged arrays.
   @available(SwiftStdlib 6.2, *)
   public var span: Span<Element> {
-    @lifetime(borrow self)
+    @_lifetime(borrow self)
     @_alwaysEmitIntoClient
     borrowing get {
 #if _runtime(_ObjC)
@@ -1883,7 +1883,7 @@ extension Array {
   @available(SwiftStdlib 6.2, *)
   @_alwaysEmitIntoClient
   public var mutableSpan: MutableSpan<Element> {
-    @lifetime(&self)
+    @_lifetime(&self)
     mutating get {
       // _makeMutableAndUnique*() inserts begin_cow_mutation.
       // LifetimeDependence analysis inserts call to end_cow_mutation_addr since we cannot schedule it in the stdlib for mutableSpan property.

--- a/stdlib/public/core/ArraySlice.swift
+++ b/stdlib/public/core/ArraySlice.swift
@@ -1236,7 +1236,7 @@ extension ArraySlice {
   @available(SwiftCompatibilitySpan 5.0, *)
   @_alwaysEmitIntoClient
   public var span: Span<Element> {
-    @lifetime(borrow self)
+    @_lifetime(borrow self)
     borrowing get {
       let (pointer, count) = unsafe (_buffer.firstElementAddress, _buffer.count)
       let span = unsafe Span(_unsafeStart: pointer, count: count)
@@ -1338,7 +1338,7 @@ extension ArraySlice {
   ///   O(*n*) otherwise.
   @_alwaysEmitIntoClient
   public var mutableSpan: MutableSpan<Element> {
-    @lifetime(&self)
+    @_lifetime(&self)
     mutating get {
       // _makeMutableAndUnique*() inserts begin_cow_mutation.
       // LifetimeDependence analysis inserts call to end_cow_mutation_addr since we cannot schedule it in the stdlib for mutableSpan property.

--- a/stdlib/public/core/BorrowingSequence.swift
+++ b/stdlib/public/core/BorrowingSequence.swift
@@ -151,7 +151,7 @@ public protocol BorrowingSequence<Element>: ~Copyable, ~Escapable {
   associatedtype BorrowingIterator: BorrowingIteratorProtocol<Element> & ~Copyable & ~Escapable
 
   /// Returns a borrowing iterator over the elements of this sequence.
-  @lifetime(borrow self)
+  @_lifetime(borrow self)
   func makeBorrowingIterator() -> BorrowingIterator
   
   /// A value less than or equal to the number of elements in the sequence,
@@ -210,7 +210,7 @@ public struct BorrowingIteratorAdapter<Iterator: IteratorProtocol>: BorrowingIte
   }
 
   @_transparent
-  @lifetime(&self)
+  @_lifetime(&self)
   public mutating func nextSpan(maximumCount: Int) -> Span<Iterator.Element> {
     curValue = iterator.next()
     return curValue._span()

--- a/stdlib/public/core/CollectionOfOne.swift
+++ b/stdlib/public/core/CollectionOfOne.swift
@@ -181,7 +181,7 @@ extension CollectionOfOne {
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
   public var span: Span<Element> {
-    @lifetime(borrow self)
+    @_lifetime(borrow self)
     get {
       let pointer = unsafe UnsafePointer<Element>(Builtin.addressOfBorrow(self))
       let span = unsafe Span(_unsafeStart: pointer, count: 1)
@@ -196,7 +196,7 @@ extension CollectionOfOne {
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
   public var mutableSpan: MutableSpan<Element> {
-    @lifetime(&self)
+    @_lifetime(&self)
     mutating get {
       let pointer = unsafe UnsafeMutablePointer<Element>(
         Builtin.addressOfBorrow(self)

--- a/stdlib/public/core/CompilerProtocols.swift
+++ b/stdlib/public/core/CompilerProtocols.swift
@@ -269,7 +269,7 @@ public protocol CaseIterable {
 /// purposes is discouraged.
 public protocol ExpressibleByNilLiteral: ~Copyable, ~Escapable {
   /// Creates an instance initialized with `nil`.
-  @lifetime(immortal)
+  @_lifetime(immortal)
   init(nilLiteral: ())
 }
 

--- a/stdlib/public/core/ContiguousArray.swift
+++ b/stdlib/public/core/ContiguousArray.swift
@@ -1300,7 +1300,7 @@ extension ContiguousArray {
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
   public var span: Span<Element> {
-    @lifetime(borrow self)
+    @_lifetime(borrow self)
     borrowing get {
       let pointer = unsafe _buffer.firstElementAddress
       let count = _buffer.immutableCount
@@ -1402,7 +1402,7 @@ extension ContiguousArray {
   ///   O(*n*) otherwise.
   @_alwaysEmitIntoClient
   public var mutableSpan: MutableSpan<Element> {
-    @lifetime(&self)
+    @_lifetime(&self)
     mutating get {
       // _makeMutableAndUnique*() inserts begin_cow_mutation.
       // LifetimeDependence analysis inserts call to end_cow_mutation_addr since we cannot schedule it in the stdlib for mutableSpan property.

--- a/stdlib/public/core/InlineArray.swift
+++ b/stdlib/public/core/InlineArray.swift
@@ -591,7 +591,7 @@ extension InlineArray where Element: ~Copyable {
   @available(SwiftStdlib 6.2, *)
   @_alwaysEmitIntoClient
   public var span: Span<Element> {
-    @lifetime(borrow self)
+    @_lifetime(borrow self)
     @_transparent
     borrowing get {
       guard count > 0 else {
@@ -611,7 +611,7 @@ extension InlineArray where Element: ~Copyable {
   @available(SwiftStdlib 6.2, *)
   @_alwaysEmitIntoClient
   public var mutableSpan: MutableSpan<Element> {
-    @lifetime(&self)
+    @_lifetime(&self)
     @_transparent
     mutating get {
       guard count > 0 else {
@@ -634,7 +634,7 @@ extension InlineArray: BorrowingSequence where Element: ~Copyable {
   
   @available(SwiftStdlib 6.4, *)
   @inlinable
-  @lifetime(borrow self)
+  @_lifetime(borrow self)
   public func makeBorrowingIterator() -> SpanIterator<Element> {
     SpanIterator(self.span)
   }

--- a/stdlib/public/core/KeyValuePairs.swift
+++ b/stdlib/public/core/KeyValuePairs.swift
@@ -136,7 +136,7 @@ extension KeyValuePairs {
   @available(SwiftCompatibilitySpan 5.0, *)
   @_alwaysEmitIntoClient
   public var span: Span<Element> {
-    @lifetime(borrow self)
+    @_lifetime(borrow self)
     get {
       let rp = unsafe UnsafeRawPointer(_elements._buffer.firstElementAddress)
       let span = unsafe Span(

--- a/stdlib/public/core/LifetimeManager.swift
+++ b/stdlib/public/core/LifetimeManager.swift
@@ -305,7 +305,7 @@ public func _copy<T>(_ value: T) -> T {
 @_unsafeNonescapableResult
 @_alwaysEmitIntoClient
 @_transparent
-@lifetime(borrow source)
+@_lifetime(borrow source)
 public func _overrideLifetime<
   T: ~Copyable & ~Escapable, U: ~Copyable & ~Escapable
 >(
@@ -321,7 +321,7 @@ public func _overrideLifetime<
 @_unsafeNonescapableResult
 @_alwaysEmitIntoClient
 @_transparent
-@lifetime(copy source)
+@_lifetime(copy source)
 public func _overrideLifetime<
   T: ~Copyable & ~Escapable, U: ~Copyable & ~Escapable
 >(
@@ -337,7 +337,7 @@ public func _overrideLifetime<
 @_unsafeNonescapableResult
 @_alwaysEmitIntoClient
 @_transparent
-@lifetime(&source)
+@_lifetime(&source)
 public func _overrideLifetime<
   T: ~Copyable & ~Escapable, U: ~Copyable & ~Escapable
 >(
@@ -354,7 +354,7 @@ public func _overrideLifetime<
 @_unsafeNonescapableResult
 @_alwaysEmitIntoClient
 @_transparent
-@lifetime(dependent: borrow source)
+@_lifetime(dependent: borrow source)
 public func _overrideLifetime<
   T: ~Copyable & ~Escapable, U: ~Copyable & ~Escapable
 >(

--- a/stdlib/public/core/Optional.swift
+++ b/stdlib/public/core/Optional.swift
@@ -156,7 +156,7 @@ where Wrapped: ~Copyable & ~Escapable {
   /// initializer behind the scenes.
   @_transparent
   @_preInverseGenerics
-  @lifetime(immortal)
+  @_lifetime(immortal)
   public init(nilLiteral: ()) {
     self = .none
   }
@@ -166,7 +166,7 @@ extension Optional where Wrapped: ~Copyable & ~Escapable {
   /// Creates an instance that stores the given value.
   @_transparent
   @_preInverseGenerics
-  @lifetime(copy value)
+  @_lifetime(copy value)
   public init(_ value: consuming Wrapped) {
     self = .some(value)
   }
@@ -354,7 +354,7 @@ extension Optional where Wrapped: ~Escapable {
     // implementation is copying the value, so that generalization will need to
     // be emitted into clients -- `@_preInverseGenerics` will not cut it.
     @inline(__always)
-    @lifetime(copy self)
+    @_lifetime(copy self)
     get {
       if let x = self {
         return x
@@ -367,7 +367,7 @@ extension Optional where Wrapped: ~Escapable {
 extension Optional where Wrapped: ~Copyable & ~Escapable {
   // FIXME(NCG): Do we want this? It seems like we do. Make this public.
   @_alwaysEmitIntoClient
-  @lifetime(copy self)
+  @_lifetime(copy self)
   public consuming func _consumingUnsafelyUnwrap() -> Wrapped {
     switch consume self {
     case .some(let x):
@@ -387,7 +387,7 @@ extension Optional where Wrapped: ~Escapable {
   @_preInverseGenerics
   internal var _unsafelyUnwrappedUnchecked: Wrapped {
     @inline(__always)
-    @lifetime(copy self)
+    @_lifetime(copy self)
     get {
       if let x = self {
         return x
@@ -403,7 +403,7 @@ extension Optional where Wrapped: ~Copyable & ~Escapable {
   /// This version is for internal stdlib use; it avoids any checking
   /// overhead for users, even in Debug builds.
   @_alwaysEmitIntoClient
-  @lifetime(copy self)
+  @_lifetime(copy self)
   internal consuming func _consumingUncheckedUnwrapped() -> Wrapped {
     if let x = self {
       return x
@@ -417,7 +417,7 @@ extension Optional where Wrapped: ~Copyable & ~Escapable {
 extension Optional where Wrapped: ~Copyable & Escapable {
   @_alwaysEmitIntoClient
   @_addressableSelf
-  @lifetime(borrow self)
+  @_lifetime(borrow self)
   public func _span() -> Span<Wrapped> {
     if self == nil {
       return Span()
@@ -446,7 +446,7 @@ extension Optional where Wrapped: ~Copyable & ~Escapable {
   /// - Returns: The wrapped value being stored in this instance. If this
   ///   instance is `nil`, returns `nil`.
   @_alwaysEmitIntoClient
-  @lifetime(copy self)
+  @_lifetime(copy self)
   public mutating func take() -> Self {
     let result = consume self
     self = nil
@@ -840,7 +840,7 @@ public func ?? <T: ~Copyable>(
   // To implement that, we need to be able to express that the result's lifetime
   // is limited to the intersection of `optional` and the result of
   // `defaultValue`:
-  //    @lifetime(optional, defaultValue.result)
+  //    @_lifetime(optional, defaultValue.result)
   switch consume optional {
   case .some(let value):
     return value
@@ -916,7 +916,7 @@ public func ?? <T: ~Copyable>(
   // To implement that, we need to be able to express that the result's lifetime
   // is limited to the intersection of `optional` and the result of
   // `defaultValue`:
-  //    @lifetime(optional, defaultValue.result)
+  //    @_lifetime(optional, defaultValue.result)
   switch consume optional {
   case .some(let value):
     return value

--- a/stdlib/public/core/Result.swift
+++ b/stdlib/public/core/Result.swift
@@ -138,7 +138,7 @@ extension Result where Success: ~Copyable & ~Escapable {
   /// - Returns: A `Result` instance with the result of evaluating `transform`
   ///   as the new failure value if this instance represents a failure.
   @_alwaysEmitIntoClient
-  @lifetime(copy self)
+  @_lifetime(copy self)
   public consuming func mapError<NewFailure>(
     _ transform: (Failure) -> NewFailure
   ) -> Result<Success, NewFailure> {
@@ -311,7 +311,7 @@ extension Result where Success: ~Copyable & ~Escapable {
   /// - Returns: The success value, if the instance represents a success.
   /// - Throws: The failure value, if the instance represents a failure.
   @_alwaysEmitIntoClient
-  @lifetime(copy self)
+  @_lifetime(copy self)
   public consuming func get() throws(Failure) -> Success {
     switch consume self {
     case let .success(success):

--- a/stdlib/public/core/Span/MutableRawSpan.swift
+++ b/stdlib/public/core/Span/MutableRawSpan.swift
@@ -36,7 +36,7 @@ public struct MutableRawSpan: ~Copyable & ~Escapable {
   /// Create an empty span.
   @_alwaysEmitIntoClient
   @inline(__always)
-  @lifetime(immortal)
+  @_lifetime(immortal)
   public init() {
     unsafe _pointer = nil
     _count = 0
@@ -44,7 +44,7 @@ public struct MutableRawSpan: ~Copyable & ~Escapable {
 
   @unsafe
   @_alwaysEmitIntoClient
-  @lifetime(borrow pointer)
+  @_lifetime(borrow pointer)
   internal init(
     _unchecked pointer: UnsafeMutableRawPointer?,
     byteCount: Int
@@ -64,7 +64,7 @@ extension MutableRawSpan {
 
   @unsafe
   @_alwaysEmitIntoClient
-  @lifetime(borrow bytes)
+  @_lifetime(borrow bytes)
   public init(
     _unsafeBytes bytes: UnsafeMutableRawBufferPointer
   ) {
@@ -75,7 +75,7 @@ extension MutableRawSpan {
 
   @unsafe
   @_alwaysEmitIntoClient
-  @lifetime(borrow bytes)
+  @_lifetime(borrow bytes)
   public init(
     _unsafeBytes bytes: borrowing Slice<UnsafeMutableRawBufferPointer>
   ) {
@@ -86,7 +86,7 @@ extension MutableRawSpan {
 
   @unsafe
   @_alwaysEmitIntoClient
-  @lifetime(borrow pointer)
+  @_lifetime(borrow pointer)
   public init(
     _unsafeStart pointer: UnsafeMutableRawPointer,
     byteCount: Int
@@ -97,7 +97,7 @@ extension MutableRawSpan {
 
   @unsafe
   @_alwaysEmitIntoClient
-  @lifetime(borrow elements)
+  @_lifetime(borrow elements)
   public init<Element: BitwiseCopyable>(
     _unsafeElements elements: UnsafeMutableBufferPointer<Element>
   ) {
@@ -108,7 +108,7 @@ extension MutableRawSpan {
 
   @unsafe
   @_alwaysEmitIntoClient
-  @lifetime(borrow elements)
+  @_lifetime(borrow elements)
   public init<Element: BitwiseCopyable>(
     _unsafeElements elements: borrowing Slice<UnsafeMutableBufferPointer<Element>>
   ) {
@@ -118,7 +118,7 @@ extension MutableRawSpan {
   }
 
   @_alwaysEmitIntoClient
-  @lifetime(&elements)
+  @_lifetime(&elements)
   @unsafe
   public init<Element: BitwiseCopyable>(
     _elements elements: inout MutableSpan<Element>
@@ -297,7 +297,7 @@ extension MutableRawSpan {
   /// - Returns: The return value of the `body` closure parameter.
   @_alwaysEmitIntoClient
   @_transparent
-  @lifetime(self: copy self)
+  @_lifetime(self: copy self)
   @safe
   public mutating func withUnsafeMutableBytes<E: Error, Result: ~Copyable>(
     _ body: (UnsafeMutableRawBufferPointer) throws(E) -> Result
@@ -311,7 +311,7 @@ extension MutableRawSpan {
 extension RawSpan {
 
   @_alwaysEmitIntoClient
-  @lifetime(borrow mutableRawSpan)
+  @_lifetime(borrow mutableRawSpan)
   public init(_mutableRawSpan mutableRawSpan: borrowing MutableRawSpan) {
     let (start, count) = unsafe (mutableRawSpan._pointer, mutableRawSpan._count)
     let span = unsafe RawSpan(_unchecked: start, byteCount: count)
@@ -327,7 +327,7 @@ extension MutableRawSpan {
   public var bytes: RawSpan {
     @_alwaysEmitIntoClient
     @_transparent
-    @lifetime(borrow self)
+    @_lifetime(borrow self)
     borrowing get {
       return RawSpan(_mutableRawSpan: self)
     }
@@ -335,7 +335,7 @@ extension MutableRawSpan {
 
   @unsafe
   @_alwaysEmitIntoClient
-  @lifetime(borrow self)
+  @_lifetime(borrow self)
   public borrowing func _unsafeView<T: BitwiseCopyable>(
     as type: T.Type
   ) -> Span<T> {
@@ -346,7 +346,7 @@ extension MutableRawSpan {
 
   @unsafe
   @_alwaysEmitIntoClient
-  @lifetime(&self)
+  @_lifetime(&self)
   public mutating func _unsafeMutableView<T: BitwiseCopyable>(
     as type: T.Type
   ) -> MutableSpan<T> {
@@ -527,7 +527,7 @@ extension MutableRawSpan {
   ///   - type: The type of `value`.
   @unsafe
   @_alwaysEmitIntoClient
-  @lifetime(self: copy self)
+  @_lifetime(self: copy self)
   public mutating func storeBytes<T: BitwiseCopyable>(
     of value: T, toByteOffset offset: Int = 0, as type: T.Type
   ) {
@@ -560,7 +560,7 @@ extension MutableRawSpan {
   ///   - type: The type of `value`.
   @unsafe
   @_alwaysEmitIntoClient
-  @lifetime(self: copy self)
+  @_lifetime(self: copy self)
   public mutating func storeBytes<T: BitwiseCopyable>(
     of value: T, toUncheckedByteOffset offset: Int, as type: T.Type
   ) {
@@ -721,7 +721,7 @@ extension MutableRawSpan {
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
-  @lifetime(&self)
+  @_lifetime(&self)
   mutating public func _mutatingExtracting(_ bounds: Range<Int>) -> Self {
     _precondition(
       UInt(bitPattern: bounds.lowerBound) <= UInt(bitPattern: _count) &&
@@ -748,7 +748,7 @@ extension MutableRawSpan {
   /// - Complexity: O(1)
   @available(*, deprecated, renamed: "_mutatingExtracting(_:)")
   @_alwaysEmitIntoClient
-  @lifetime(&self)
+  @_lifetime(&self)
   mutating public func extracting(_ bounds: Range<Int>) -> Self {
     _mutatingExtracting(bounds)
   }
@@ -767,7 +767,7 @@ extension MutableRawSpan {
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
-  @lifetime(copy self)
+  @_lifetime(copy self)
   consuming public func _consumingExtracting(_ bounds: Range<Int>) -> Self {
     _precondition(
       UInt(bitPattern: bounds.lowerBound) <= UInt(bitPattern: _count) &&
@@ -796,7 +796,7 @@ extension MutableRawSpan {
   /// - Complexity: O(1)
   @unsafe
   @_alwaysEmitIntoClient
-  @lifetime(&self)
+  @_lifetime(&self)
   mutating public func _mutatingExtracting(unchecked bounds: Range<Int>) -> Self {
     let newStart = unsafe _pointer?.advanced(by: bounds.lowerBound)
     let newSpan = unsafe Self(_unchecked: newStart, byteCount: bounds.count)
@@ -823,7 +823,7 @@ extension MutableRawSpan {
   @unsafe
   @available(*, deprecated, renamed: "_mutatingExtracting(unchecked:)")
   @_alwaysEmitIntoClient
-  @lifetime(&self)
+  @_lifetime(&self)
   mutating public func extracting(unchecked bounds: Range<Int>) -> Self {
     unsafe _mutatingExtracting(unchecked: bounds)
   }
@@ -845,7 +845,7 @@ extension MutableRawSpan {
   /// - Complexity: O(1)
   @unsafe
   @_alwaysEmitIntoClient
-  @lifetime(copy self)
+  @_lifetime(copy self)
   consuming public func _consumingExtracting(unchecked bounds: Range<Int>) -> Self {
     let newStart = unsafe _pointer?.advanced(by: bounds.lowerBound)
     let newSpan = unsafe Self(_unchecked: newStart, byteCount: bounds.count)
@@ -868,7 +868,7 @@ extension MutableRawSpan {
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
-  @lifetime(&self)
+  @_lifetime(&self)
   mutating public func _mutatingExtracting(
     _ bounds: some RangeExpression<Int>
   ) -> Self {
@@ -892,7 +892,7 @@ extension MutableRawSpan {
   /// - Complexity: O(1)
   @available(*, deprecated, renamed: "_mutatingExtracting(_:)")
   @_alwaysEmitIntoClient
-  @lifetime(&self)
+  @_lifetime(&self)
   mutating public func extracting(
     _ bounds: some RangeExpression<Int>
   ) -> Self {
@@ -913,7 +913,7 @@ extension MutableRawSpan {
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
-  @lifetime(copy self)
+  @_lifetime(copy self)
   consuming public func _consumingExtracting(
     _ bounds: some RangeExpression<Int>
   ) -> Self {
@@ -939,7 +939,7 @@ extension MutableRawSpan {
   /// - Complexity: O(1)
   @unsafe
   @_alwaysEmitIntoClient
-  @lifetime(&self)
+  @_lifetime(&self)
   mutating public func _mutatingExtracting(
     unchecked bounds: ClosedRange<Int>
   ) -> Self {
@@ -969,7 +969,7 @@ extension MutableRawSpan {
   @unsafe
   @available(*, deprecated, renamed: "_mutatingExtracting(unchecked:)")
   @_alwaysEmitIntoClient
-  @lifetime(&self)
+  @_lifetime(&self)
   mutating public func extracting(
     unchecked bounds: ClosedRange<Int>
   ) -> Self {
@@ -993,7 +993,7 @@ extension MutableRawSpan {
   /// - Complexity: O(1)
   @unsafe
   @_alwaysEmitIntoClient
-  @lifetime(copy self)
+  @_lifetime(copy self)
   consuming public func _consumingExtracting(
     unchecked bounds: ClosedRange<Int>
   ) -> Self {
@@ -1015,7 +1015,7 @@ extension MutableRawSpan {
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
-  @lifetime(&self)
+  @_lifetime(&self)
   mutating public func _mutatingExtracting(_: UnboundedRange) -> Self {
     unsafe _overrideLifetime(
       Self(_unchecked: _pointer, byteCount: _count), mutating: &self
@@ -1041,7 +1041,7 @@ extension MutableRawSpan {
   /// - Complexity: O(1)
   @available(*, deprecated, renamed: "_mutatingExtracting(_:)")
   @_alwaysEmitIntoClient
-  @lifetime(&self)
+  @_lifetime(&self)
   mutating public func extracting(_: UnboundedRange) -> Self {
     _mutatingExtracting(...)
   }
@@ -1056,7 +1056,7 @@ extension MutableRawSpan {
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
-  @lifetime(copy self)
+  @_lifetime(copy self)
   consuming public func _consumingExtracting(_: UnboundedRange) -> Self {
     self
   }
@@ -1085,7 +1085,7 @@ extension MutableRawSpan {
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
-  @lifetime(&self)
+  @_lifetime(&self)
   mutating public func _mutatingExtracting(first maxLength: Int) -> Self {
 #if compiler(>=5.3) && hasFeature(SendableCompletionHandlers)
     _precondition(maxLength >= 0, "Can't have a prefix of negative length")
@@ -1116,7 +1116,7 @@ extension MutableRawSpan {
   /// - Complexity: O(1)
   @available(*, deprecated, renamed: "_mutatingExtracting(first:)")
   @_alwaysEmitIntoClient
-  @lifetime(&self)
+  @_lifetime(&self)
   mutating public func extracting(first maxLength: Int) -> Self {
     _mutatingExtracting(first: maxLength)
   }
@@ -1137,7 +1137,7 @@ extension MutableRawSpan {
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
-  @lifetime(copy self)
+  @_lifetime(copy self)
   consuming public func _consumingExtracting(first maxLength: Int) -> Self {
 #if compiler(>=5.3) && hasFeature(SendableCompletionHandlers)
     _precondition(maxLength >= 0, "Can't have a prefix of negative length")
@@ -1166,7 +1166,7 @@ extension MutableRawSpan {
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
-  @lifetime(&self)
+  @_lifetime(&self)
   mutating public func _mutatingExtracting(droppingLast k: Int) -> Self {
 #if compiler(>=5.3) && hasFeature(SendableCompletionHandlers)
     _precondition(k >= 0, "Can't drop a negative number of bytes")
@@ -1197,7 +1197,7 @@ extension MutableRawSpan {
   /// - Complexity: O(1)
   @available(*, deprecated, renamed: "_mutatingExtracting(droppingLast:)")
   @_alwaysEmitIntoClient
-  @lifetime(&self)
+  @_lifetime(&self)
   mutating public func extracting(droppingLast k: Int) -> Self {
     _mutatingExtracting(droppingLast: k)
   }
@@ -1217,7 +1217,7 @@ extension MutableRawSpan {
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
-  @lifetime(copy self)
+  @_lifetime(copy self)
   consuming public func _consumingExtracting(droppingLast k: Int) -> Self {
 #if compiler(>=5.3) && hasFeature(SendableCompletionHandlers)
     _precondition(k >= 0, "Can't drop a negative number of bytes")
@@ -1248,7 +1248,7 @@ extension MutableRawSpan {
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
-  @lifetime(&self)
+  @_lifetime(&self)
   mutating public func _mutatingExtracting(last maxLength: Int) -> Self {
 #if compiler(>=5.3) && hasFeature(SendableCompletionHandlers)
     _precondition(maxLength >= 0, "Can't have a suffix of negative length")
@@ -1280,7 +1280,7 @@ extension MutableRawSpan {
   /// - Complexity: O(1)
   @available(*, deprecated, renamed: "_mutatingExtracting(last:)")
   @_alwaysEmitIntoClient
-  @lifetime(&self)
+  @_lifetime(&self)
   mutating public func extracting(last maxLength: Int) -> Self {
     _mutatingExtracting(last: maxLength)
   }
@@ -1301,7 +1301,7 @@ extension MutableRawSpan {
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
-  @lifetime(copy self)
+  @_lifetime(copy self)
   consuming public func _consumingExtracting(last maxLength: Int) -> Self {
 #if compiler(>=5.3) && hasFeature(SendableCompletionHandlers)
     _precondition(maxLength >= 0, "Can't have a suffix of negative length")
@@ -1331,7 +1331,7 @@ extension MutableRawSpan {
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
-  @lifetime(&self)
+  @_lifetime(&self)
   mutating public func _mutatingExtracting(droppingFirst k: Int) -> Self {
 #if compiler(>=5.3) && hasFeature(SendableCompletionHandlers)
     _precondition(k >= 0, "Can't drop a negative number of bytes")
@@ -1363,7 +1363,7 @@ extension MutableRawSpan {
   /// - Complexity: O(1)
   @available(*, deprecated, renamed: "_mutatingExtracting(droppingFirst:)")
   @_alwaysEmitIntoClient
-  @lifetime(&self)
+  @_lifetime(&self)
   mutating public func extracting(droppingFirst k: Int) -> Self {
     _mutatingExtracting(droppingFirst: k)
   }
@@ -1383,7 +1383,7 @@ extension MutableRawSpan {
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
-  @lifetime(copy self)
+  @_lifetime(copy self)
   consuming public func _consumingExtracting(droppingFirst k: Int) -> Self {
 #if compiler(>=5.3) && hasFeature(SendableCompletionHandlers)
     _precondition(k >= 0, "Can't drop a negative number of bytes")
@@ -1403,7 +1403,7 @@ extension MutableRawSpan {
 extension MutableRawSpan: BorrowingSequence {
   @available(SwiftStdlib 6.4, *)
   @inlinable
-  @lifetime(borrow self)
+  @_lifetime(borrow self)
   public func makeBorrowingIterator() -> SpanIterator<UInt8> {
     SpanIterator(Span(viewing: self.bytes))
   }

--- a/stdlib/public/core/Span/MutableSpan.swift
+++ b/stdlib/public/core/Span/MutableSpan.swift
@@ -38,7 +38,7 @@ public struct MutableSpan<Element: ~Copyable>
   /// Create an empty span.
   @_alwaysEmitIntoClient
   @inline(__always)
-  @lifetime(immortal)
+  @_lifetime(immortal)
   public init() {
     unsafe _pointer = nil
     _count = 0
@@ -46,7 +46,7 @@ public struct MutableSpan<Element: ~Copyable>
 
   @unsafe
   @_alwaysEmitIntoClient
-  @lifetime(borrow start)
+  @_lifetime(borrow start)
   internal init(
     _unchecked start: UnsafeMutableRawPointer?,
     count: Int
@@ -66,7 +66,7 @@ extension MutableSpan where Element: ~Copyable {
 
   @unsafe
   @_alwaysEmitIntoClient
-  @lifetime(borrow elements)
+  @_lifetime(borrow elements)
   internal init(
     _unchecked elements: UnsafeMutableBufferPointer<Element>
   ) {
@@ -76,7 +76,7 @@ extension MutableSpan where Element: ~Copyable {
 
   @unsafe
   @_alwaysEmitIntoClient
-  @lifetime(borrow buffer)
+  @_lifetime(borrow buffer)
   public init(
     _unsafeElements buffer: UnsafeMutableBufferPointer<Element>
   ) {
@@ -92,7 +92,7 @@ extension MutableSpan where Element: ~Copyable {
   @unsafe
   @_alwaysEmitIntoClient
   @_transparent
-  @lifetime(borrow start)
+  @_lifetime(borrow start)
   public init(
     _unsafeStart start: UnsafeMutablePointer<Element>,
     count: Int
@@ -110,7 +110,7 @@ extension MutableSpan {
 
   @unsafe
   @_alwaysEmitIntoClient
-  @lifetime(borrow elements)
+  @_lifetime(borrow elements)
   public init(
     _unsafeElements elements: borrowing Slice<UnsafeMutableBufferPointer<Element>>
   ) {
@@ -126,7 +126,7 @@ extension MutableSpan where Element: BitwiseCopyable {
 
   @unsafe
   @_alwaysEmitIntoClient
-  @lifetime(borrow buffer)
+  @_lifetime(borrow buffer)
   public init(
     _unsafeBytes buffer: UnsafeMutableRawBufferPointer
   ) {
@@ -148,7 +148,7 @@ extension MutableSpan where Element: BitwiseCopyable {
 
   @unsafe
   @_alwaysEmitIntoClient
-  @lifetime(borrow pointer)
+  @_lifetime(borrow pointer)
   public init(
     _unsafeStart pointer: UnsafeMutableRawPointer,
     byteCount: Int
@@ -163,7 +163,7 @@ extension MutableSpan where Element: BitwiseCopyable {
 
   @unsafe
   @_alwaysEmitIntoClient
-  @lifetime(borrow buffer)
+  @_lifetime(borrow buffer)
   public init(
     _unsafeBytes buffer: borrowing Slice<UnsafeMutableRawBufferPointer>
   ) {
@@ -234,7 +234,7 @@ extension MutableSpan where Element: ConvertibleFromBytes & ConvertibleToBytes {
 extension Span where Element: ~Copyable {
 
   @_alwaysEmitIntoClient
-  @lifetime(borrow mutableSpan)
+  @_lifetime(borrow mutableSpan)
   public init(_mutableSpan mutableSpan: borrowing MutableSpan<Element>) {
     let pointer =
       unsafe mutableSpan._pointer?.assumingMemoryBound(to: Element.self)
@@ -254,7 +254,7 @@ extension MutableSpan where Element: ~Copyable {
   @_alwaysEmitIntoClient
   @_transparent
   public var span: Span<Element> {
-    @lifetime(borrow self)
+    @_lifetime(borrow self)
     borrowing get {
       Span(_mutableSpan: self)
     }
@@ -267,7 +267,7 @@ extension RawSpan {
 
   @_alwaysEmitIntoClient
   @unsafe
-  @lifetime(borrow mutableSpan)
+  @_lifetime(borrow mutableSpan)
   public init<Element>(
     _mutableSpan mutableSpan: borrowing MutableSpan<Element>
   ) {
@@ -328,7 +328,7 @@ extension MutableSpan where Element: Copyable {
   @_transparent
   @unsafe
   public var bytes: RawSpan {
-    @lifetime(borrow self)
+    @_lifetime(borrow self)
     borrowing get {
       unsafe RawSpan(_mutableSpan: self)
     }
@@ -350,7 +350,7 @@ extension MutableSpan where Element: BitwiseCopyable {
   @_transparent
   @unsafe
   public var mutableBytes: MutableRawSpan {
-    @lifetime(&self)
+    @_lifetime(&self)
     mutating get {
       unsafe MutableRawSpan(_elements: &self)
     }
@@ -413,7 +413,7 @@ extension MutableSpan where Element: ~Copyable {
       return unsafe self[unchecked: position]
     }
     @_transparent
-    @lifetime(self: copy self)
+    @_lifetime(self: copy self)
     mutate {
       _checkIndex(position)
       return unsafe &self[unchecked: position]
@@ -438,7 +438,7 @@ extension MutableSpan where Element: ~Copyable {
     }
     @_transparent
     @_unsafeSelfDependentResult
-    @lifetime(self: copy self)
+    @_lifetime(self: copy self)
     mutate {
       let address = unsafe _unsafeAddressOfElement(unchecked: position)
       return unsafe &(UnsafeMutablePointer(address).pointee)
@@ -465,7 +465,7 @@ extension MutableSpan where Element: ~Copyable {
   /// - Parameter i: A valid index into this span.
   /// - Parameter j: A valid index into this span.
   @_alwaysEmitIntoClient
-  @lifetime(self: copy self)
+  @_lifetime(self: copy self)
   public mutating func swapAt(_ i: Index, _ j: Index) {
     _precondition(indices.contains(Index(i)))
     _precondition(indices.contains(Index(j)))
@@ -480,7 +480,7 @@ extension MutableSpan where Element: ~Copyable {
   /// - Parameter j: A valid index into this span.
   @unsafe
   @_alwaysEmitIntoClient
-  @lifetime(self: copy self)
+  @_lifetime(self: copy self)
   public mutating func swapAt(unchecked i: Index, unchecked j: Index) {
     let ri = unsafe _unsafeAddressOfElement(unchecked: i)
     let pi = unsafe UnsafeMutablePointer<Element>(ri)
@@ -534,7 +534,7 @@ extension MutableSpan where Element: ~Copyable {
   //FIXME: mark closure parameter as non-escaping
   @_alwaysEmitIntoClient
   @_transparent
-  @lifetime(self: copy self)
+  @_lifetime(self: copy self)
   @safe
   public mutating func withUnsafeMutableBufferPointer<
     E: Error, Result: ~Copyable
@@ -596,7 +596,7 @@ extension MutableSpan where Element: BitwiseCopyable {
   //FIXME: mark closure parameter as non-escaping
   @_alwaysEmitIntoClient
   @_transparent
-  @lifetime(self: copy self)
+  @_lifetime(self: copy self)
   @safe
   public mutating func withUnsafeMutableBytes<E: Error, Result: ~Copyable>(
     _ body: (_ buffer: UnsafeMutableRawBufferPointer) throws(E) -> Result
@@ -617,7 +617,7 @@ extension MutableSpan {
   ///
   /// - Parameter repeatedValue: The value to set for every element.
   @_alwaysEmitIntoClient
-  @lifetime(self: copy self)
+  @_lifetime(self: copy self)
   public mutating func update(repeating repeatedValue: consuming Element) {
     guard !isEmpty else { return }
     unsafe _start().withMemoryRebound(to: Element.self, capacity: count) {
@@ -647,7 +647,7 @@ extension MutableSpan where Element: ~Copyable {
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
-  @lifetime(&self)
+  @_lifetime(&self)
   mutating public func _mutatingExtracting(_ bounds: Range<Index>) -> Self {
     _precondition(
       UInt(bitPattern: bounds.lowerBound) <= UInt(bitPattern: _count) &&
@@ -674,7 +674,7 @@ extension MutableSpan where Element: ~Copyable {
   /// - Complexity: O(1)
   @available(*, deprecated, renamed: "_mutatingExtracting(_:)")
   @_alwaysEmitIntoClient
-  @lifetime(&self)
+  @_lifetime(&self)
   mutating public func extracting(_ bounds: Range<Index>) -> Self {
     _mutatingExtracting(bounds)
   }
@@ -693,7 +693,7 @@ extension MutableSpan where Element: ~Copyable {
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
-  @lifetime(copy self)
+  @_lifetime(copy self)
   consuming public func _consumingExtracting(_ bounds: Range<Index>) -> Self {
     _precondition(
       UInt(bitPattern: bounds.lowerBound) <= UInt(bitPattern: _count) &&
@@ -722,7 +722,7 @@ extension MutableSpan where Element: ~Copyable {
   /// - Complexity: O(1)
   @unsafe
   @_alwaysEmitIntoClient
-  @lifetime(&self)
+  @_lifetime(&self)
   mutating public func _mutatingExtracting(unchecked bounds: Range<Index>) -> Self {
     let delta = bounds.lowerBound &* MemoryLayout<Element>.stride
     let newStart = unsafe _pointer?.advanced(by: delta)
@@ -750,7 +750,7 @@ extension MutableSpan where Element: ~Copyable {
   @unsafe
   @available(*, deprecated, renamed: "_mutatingExtracting(unchecked:)")
   @_alwaysEmitIntoClient
-  @lifetime(&self)
+  @_lifetime(&self)
   mutating public func extracting(unchecked bounds: Range<Index>) -> Self {
     unsafe _mutatingExtracting(unchecked: bounds)
   }
@@ -772,7 +772,7 @@ extension MutableSpan where Element: ~Copyable {
   /// - Complexity: O(1)
   @unsafe
   @_alwaysEmitIntoClient
-  @lifetime(copy self)
+  @_lifetime(copy self)
   consuming public func _consumingExtracting(unchecked bounds: Range<Index>) -> Self {
     let delta = bounds.lowerBound &* MemoryLayout<Element>.stride
     let newStart = unsafe _pointer?.advanced(by: delta)
@@ -796,7 +796,7 @@ extension MutableSpan where Element: ~Copyable {
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
-  @lifetime(&self)
+  @_lifetime(&self)
   mutating public func _mutatingExtracting(
     _ bounds: some RangeExpression<Index>
   ) -> Self {
@@ -820,7 +820,7 @@ extension MutableSpan where Element: ~Copyable {
   /// - Complexity: O(1)
   @available(*, deprecated, renamed: "_mutatingExtracting(_:)")
   @_alwaysEmitIntoClient
-  @lifetime(&self)
+  @_lifetime(&self)
   mutating public func extracting(
     _ bounds: some RangeExpression<Index>
   ) -> Self {
@@ -841,7 +841,7 @@ extension MutableSpan where Element: ~Copyable {
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
-  @lifetime(copy self)
+  @_lifetime(copy self)
   consuming public func _consumingExtracting(
     _ bounds: some RangeExpression<Index>
   ) -> Self {
@@ -867,7 +867,7 @@ extension MutableSpan where Element: ~Copyable {
   /// - Complexity: O(1)
   @unsafe
   @_alwaysEmitIntoClient
-  @lifetime(&self)
+  @_lifetime(&self)
   mutating public func _mutatingExtracting(
     unchecked bounds: ClosedRange<Index>
   ) -> Self {
@@ -897,7 +897,7 @@ extension MutableSpan where Element: ~Copyable {
   @unsafe
   @available(*, deprecated, renamed: "_mutatingExtracting(unchecked:)")
   @_alwaysEmitIntoClient
-  @lifetime(&self)
+  @_lifetime(&self)
   mutating public func extracting(
     unchecked bounds: ClosedRange<Index>
   ) -> Self {
@@ -921,7 +921,7 @@ extension MutableSpan where Element: ~Copyable {
   /// - Complexity: O(1)
   @unsafe
   @_alwaysEmitIntoClient
-  @lifetime(copy self)
+  @_lifetime(copy self)
   consuming public func _consumingExtracting(
     unchecked bounds: ClosedRange<Index>
   ) -> Self {
@@ -943,7 +943,7 @@ extension MutableSpan where Element: ~Copyable {
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
-  @lifetime(&self)
+  @_lifetime(&self)
   mutating public func _mutatingExtracting(_: UnboundedRange) -> Self {
     unsafe _overrideLifetime(
       Self(_unchecked: _pointer, count: _count), mutating: &self
@@ -969,7 +969,7 @@ extension MutableSpan where Element: ~Copyable {
   /// - Complexity: O(1)
   @available(*, deprecated, renamed: "_mutatingExtracting(_:)")
   @_alwaysEmitIntoClient
-  @lifetime(&self)
+  @_lifetime(&self)
   mutating public func extracting(_: UnboundedRange) -> Self {
     _mutatingExtracting(...)
   }
@@ -984,7 +984,7 @@ extension MutableSpan where Element: ~Copyable {
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
-  @lifetime(copy self)
+  @_lifetime(copy self)
   consuming public func _consumingExtracting(_: UnboundedRange) -> Self {
     self
   }
@@ -1013,7 +1013,7 @@ extension MutableSpan where Element: ~Copyable {
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
-  @lifetime(&self)
+  @_lifetime(&self)
   mutating public func _mutatingExtracting(first maxLength: Int) -> Self {
 #if compiler(>=5.3) && hasFeature(SendableCompletionHandlers)
     _precondition(maxLength >= 0, "Can't have a prefix of negative length")
@@ -1044,7 +1044,7 @@ extension MutableSpan where Element: ~Copyable {
   /// - Complexity: O(1)
   @available(*, deprecated, renamed: "_mutatingExtracting(first:)")
   @_alwaysEmitIntoClient
-  @lifetime(&self)
+  @_lifetime(&self)
   mutating public func extracting(first maxLength: Int) -> Self {
     _mutatingExtracting(first: maxLength)
   }
@@ -1065,7 +1065,7 @@ extension MutableSpan where Element: ~Copyable {
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
-  @lifetime(copy self)
+  @_lifetime(copy self)
   consuming public func _consumingExtracting(first maxLength: Int) -> Self {
 #if compiler(>=5.3) && hasFeature(SendableCompletionHandlers)
     _precondition(maxLength >= 0, "Can't have a prefix of negative length")
@@ -1094,7 +1094,7 @@ extension MutableSpan where Element: ~Copyable {
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
-  @lifetime(&self)
+  @_lifetime(&self)
   mutating public func _mutatingExtracting(droppingLast k: Int) -> Self {
 #if compiler(>=5.3) && hasFeature(SendableCompletionHandlers)
     _precondition(k >= 0, "Can't drop a negative number of elements")
@@ -1125,7 +1125,7 @@ extension MutableSpan where Element: ~Copyable {
   /// - Complexity: O(1)
   @available(*, deprecated, renamed: "_mutatingExtracting(droppingLast:)")
   @_alwaysEmitIntoClient
-  @lifetime(&self)
+  @_lifetime(&self)
   mutating public func extracting(droppingLast k: Int) -> Self {
     _mutatingExtracting(droppingLast: k)
   }
@@ -1145,7 +1145,7 @@ extension MutableSpan where Element: ~Copyable {
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
-  @lifetime(copy self)
+  @_lifetime(copy self)
   consuming public func _consumingExtracting(droppingLast k: Int) -> Self {
 #if compiler(>=5.3) && hasFeature(SendableCompletionHandlers)
     _precondition(k >= 0, "Can't drop a negative number of elements")
@@ -1176,7 +1176,7 @@ extension MutableSpan where Element: ~Copyable {
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
-  @lifetime(&self)
+  @_lifetime(&self)
   mutating public func _mutatingExtracting(last maxLength: Int) -> Self {
 #if compiler(>=5.3) && hasFeature(SendableCompletionHandlers)
     _precondition(maxLength >= 0, "Can't have a suffix of negative length")
@@ -1209,7 +1209,7 @@ extension MutableSpan where Element: ~Copyable {
   /// - Complexity: O(1)
   @available(*, deprecated, renamed: "_mutatingExtracting(last:)")
   @_alwaysEmitIntoClient
-  @lifetime(&self)
+  @_lifetime(&self)
   mutating public func extracting(last maxLength: Int) -> Self {
     _mutatingExtracting(last: maxLength)
   }
@@ -1230,7 +1230,7 @@ extension MutableSpan where Element: ~Copyable {
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
-  @lifetime(copy self)
+  @_lifetime(copy self)
   consuming public func _consumingExtracting(last maxLength: Int) -> Self {
 #if compiler(>=5.3) && hasFeature(SendableCompletionHandlers)
     _precondition(maxLength >= 0, "Can't have a suffix of negative length")
@@ -1261,7 +1261,7 @@ extension MutableSpan where Element: ~Copyable {
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
-  @lifetime(&self)
+  @_lifetime(&self)
   mutating public func _mutatingExtracting(droppingFirst k: Int) -> Self {
 #if compiler(>=5.3) && hasFeature(SendableCompletionHandlers)
     _precondition(k >= 0, "Can't drop a negative number of elements")
@@ -1294,7 +1294,7 @@ extension MutableSpan where Element: ~Copyable {
   /// - Complexity: O(1)
   @available(*, deprecated, renamed: "_mutatingExtracting(droppingFirst:)")
   @_alwaysEmitIntoClient
-  @lifetime(&self)
+  @_lifetime(&self)
   mutating public func extracting(droppingFirst k: Int) -> Self {
     _mutatingExtracting(droppingFirst: k)
   }
@@ -1314,7 +1314,7 @@ extension MutableSpan where Element: ~Copyable {
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
-  @lifetime(copy self)
+  @_lifetime(copy self)
   consuming public func _consumingExtracting(droppingFirst k: Int) -> Self {
 #if compiler(>=5.3) && hasFeature(SendableCompletionHandlers)
     _precondition(k >= 0, "Can't drop a negative number of elements")
@@ -1335,7 +1335,7 @@ extension MutableSpan where Element: ~Copyable {
 extension MutableSpan: BorrowingSequence where Element: ~Copyable {
   @available(SwiftStdlib 6.4, *)
   @inlinable
-  @lifetime(borrow self)
+  @_lifetime(borrow self)
   public func makeBorrowingIterator() -> SpanIterator<Element> {
     SpanIterator(self.span)
   }

--- a/stdlib/public/core/Span/OutputRawSpan.swift
+++ b/stdlib/public/core/Span/OutputRawSpan.swift
@@ -34,7 +34,7 @@ public struct OutputRawSpan: ~Copyable, ~Escapable {
 
   /// Create an OutputRawSpan with zero capacity.
   @_alwaysEmitIntoClient
-  @lifetime(immortal)
+  @_lifetime(immortal)
   public init() {
     unsafe _pointer = nil
     capacity = 0
@@ -104,7 +104,7 @@ extension OutputRawSpan {
 
   @unsafe
   @_alwaysEmitIntoClient
-  @lifetime(borrow buffer)
+  @_lifetime(borrow buffer)
   internal init(
     _uncheckedBuffer buffer: UnsafeMutableRawBufferPointer,
     initializedCount: Int
@@ -127,7 +127,7 @@ extension OutputRawSpan {
   ///                       at the beginning of `buffer`.
   @unsafe
   @_alwaysEmitIntoClient
-  @lifetime(borrow buffer)
+  @_lifetime(borrow buffer)
   public init(
     buffer: UnsafeMutableRawBufferPointer,
     initializedCount: Int
@@ -160,7 +160,7 @@ extension OutputRawSpan {
   ///                       at the beginning of `buffer`.
   @unsafe
   @_alwaysEmitIntoClient
-  @lifetime(borrow buffer)
+  @_lifetime(borrow buffer)
   public init(
     buffer: borrowing Slice<UnsafeMutableRawBufferPointer>,
     initializedCount: Int
@@ -181,7 +181,7 @@ extension OutputRawSpan {
   ///
   /// - Parameter value: The byte to append.
   @_alwaysEmitIntoClient
-  @lifetime(self: copy self)
+  @_lifetime(self: copy self)
   public mutating func append(_ value: UInt8) {
     unsafe _append(value, as: UInt8.self)
   }
@@ -193,7 +193,7 @@ extension OutputRawSpan {
   /// - Returns: The removed byte.
   @_alwaysEmitIntoClient
   @discardableResult
-  @lifetime(self: copy self)
+  @_lifetime(self: copy self)
   public mutating func removeLast() -> UInt8 {
     _precondition(!isEmpty, "OutputRawSpan underflow")
     _count &-= 1
@@ -208,7 +208,7 @@ extension OutputRawSpan {
   /// - Parameter n: The number of bytes to remove.
   ///     `n` must not be negative or greater than `byteCount`.
   @_alwaysEmitIntoClient
-  @lifetime(self: copy self)
+  @_lifetime(self: copy self)
   public mutating func removeLast(_ n: Int) {
     _precondition(n >= 0, "Can't remove a negative number of bytes")
     _precondition(n <= _count, "OutputRawSpan underflow")
@@ -218,7 +218,7 @@ extension OutputRawSpan {
   /// Remove all this span's bytes and return its memory
   /// to the uninitialized state.
   @_alwaysEmitIntoClient
-  @lifetime(self: copy self)
+  @_lifetime(self: copy self)
   public mutating func removeAll() {
     // TODO: Consider an option to zero the `_count` bytes being removed.
     _count = 0
@@ -282,7 +282,7 @@ extension OutputRawSpan {
   ///   - type: The type of the value.
   @_alwaysEmitIntoClient
   @unsafe
-  @lifetime(self: copy self)
+  @_lifetime(self: copy self)
   public mutating func append<T: BitwiseCopyable>(_ value: T, as type: T.Type) {
     unsafe _append(value, as: T.self)
   }
@@ -354,7 +354,7 @@ extension OutputRawSpan {
   ///   - type: The type of the instance to store repeatedly.
   @_alwaysEmitIntoClient
   @unsafe
-  @lifetime(self: copy self)
+  @_lifetime(self: copy self)
   public mutating func append<T: BitwiseCopyable>(
     repeating repeatedValue: T,
     count: Int,
@@ -432,7 +432,7 @@ extension OutputRawSpan {
   @_alwaysEmitIntoClient
   @_transparent
   public var bytes: RawSpan {
-    @lifetime(borrow self)
+    @_lifetime(borrow self)
     borrowing get {
       let buffer = unsafe UnsafeRawBufferPointer(start: _pointer, count: _count)
       let span = unsafe RawSpan(_unsafeBytes: buffer)
@@ -444,7 +444,7 @@ extension OutputRawSpan {
   @_alwaysEmitIntoClient
   @_transparent
   public var mutableBytes: MutableRawSpan {
-    @lifetime(&self)
+    @_lifetime(&self)
     mutating get {
       let buffer = unsafe UnsafeMutableRawBufferPointer(
         start: _pointer, count: _count
@@ -486,7 +486,7 @@ extension OutputRawSpan {
   /// - Returns: The return value of the `body` closure.
   @_alwaysEmitIntoClient
   @_transparent
-  @lifetime(self: copy self)
+  @_lifetime(self: copy self)
   @unsafe
   public mutating func withUnsafeMutableBytes<E: Error, R: ~Copyable>(
     _ body: (

--- a/stdlib/public/core/Span/OutputSpan.swift
+++ b/stdlib/public/core/Span/OutputSpan.swift
@@ -47,7 +47,7 @@ public struct OutputSpan<Element: ~Copyable>: ~Copyable, ~Escapable {
 
   /// Create an OutputSpan with zero capacity.
   @_alwaysEmitIntoClient
-  @lifetime(immortal)
+  @_lifetime(immortal)
   public init() {
     unsafe _pointer = nil
     capacity = 0
@@ -108,7 +108,7 @@ extension OutputSpan where Element: ~Copyable  {
 
   @unsafe
   @_alwaysEmitIntoClient
-  @lifetime(borrow buffer)
+  @_lifetime(borrow buffer)
   @usableFromInline
   internal init(
     _uncheckedBuffer buffer: UnsafeMutableBufferPointer<Element>,
@@ -133,7 +133,7 @@ extension OutputSpan where Element: ~Copyable  {
   ///                       at the beginning of `buffer`.
   @unsafe
   @_alwaysEmitIntoClient
-  @lifetime(borrow buffer)
+  @_lifetime(borrow buffer)
   public init(
     buffer: UnsafeMutableBufferPointer<Element>,
     initializedCount: Int
@@ -173,7 +173,7 @@ extension OutputSpan {
   ///                       at the beginning of `buffer`.
   @unsafe
   @_alwaysEmitIntoClient
-  @lifetime(borrow buffer)
+  @_lifetime(borrow buffer)
   public init(
     buffer: borrowing Slice<UnsafeMutableBufferPointer<Element>>,
     initializedCount: Int
@@ -219,7 +219,7 @@ extension OutputSpan where Element: ~Copyable {
       return unsafe self[unchecked: index]
     }
     @_transparent
-    @lifetime(self: copy self)
+    @_lifetime(self: copy self)
     mutate {
       _checkIndex(index)
       return unsafe &(self[unchecked: index])
@@ -241,7 +241,7 @@ extension OutputSpan where Element: ~Copyable {
       Builtin.borrowAt(unsafe _unsafeAddressOfElement(unchecked: index))
     }
     @_unsafeSelfDependentResult
-    @lifetime(self: copy self)
+    @_lifetime(self: copy self)
     mutate {
       let address = unsafe _unsafeAddressOfElement(unchecked: index)
       return unsafe &(UnsafeMutablePointer(address).pointee)
@@ -262,7 +262,7 @@ extension OutputSpan where Element: ~Copyable {
   /// - Parameter i: A valid index into this span.
   /// - Parameter j: A valid index into this span.
   @_alwaysEmitIntoClient
-  @lifetime(self: copy self)
+  @_lifetime(self: copy self)
   public mutating func swapAt(_ i: Index, _ j: Index) {
     _precondition(indices.contains(i))
     _precondition(indices.contains(j))
@@ -277,7 +277,7 @@ extension OutputSpan where Element: ~Copyable {
   /// - Parameter j: A valid index into this span.
   @unsafe
   @_alwaysEmitIntoClient
-  @lifetime(self: copy self)
+  @_lifetime(self: copy self)
   public mutating func swapAt(unchecked i: Index, unchecked j: Index) {
     let ri = unsafe _unsafeAddressOfElement(unchecked: i)
     let pi = unsafe UnsafeMutablePointer<Element>(ri)
@@ -296,7 +296,7 @@ extension OutputSpan where Element: ~Copyable {
   ///
   /// - Parameter value: The element to append.
   @_alwaysEmitIntoClient
-  @lifetime(self: copy self)
+  @_lifetime(self: copy self)
   public mutating func append(_ value: consuming Element) {
     _precondition(_count < capacity, "OutputSpan capacity overflow")
     unsafe _tail().initializeMemory(as: Element.self, to: value)
@@ -309,7 +309,7 @@ extension OutputSpan where Element: ~Copyable {
   ///
   /// - Returns: The removed element.
   @_alwaysEmitIntoClient
-  @lifetime(self: copy self)
+  @_lifetime(self: copy self)
   public mutating func removeLast() -> Element {
     _precondition(!isEmpty, "OutputSpan underflow")
     _count &-= 1
@@ -326,7 +326,7 @@ extension OutputSpan where Element: ~Copyable {
   /// - Parameter n: The number of elements to remove.
   ///     `n` must not be negative or greater than `count`.
   @_alwaysEmitIntoClient
-  @lifetime(self: copy self)
+  @_lifetime(self: copy self)
   public mutating func removeLast(_ n: Int) {
     _precondition(n >= 0, "Can't remove a negative number of elements")
     _precondition(n <= _count, "OutputSpan underflow")
@@ -339,7 +339,7 @@ extension OutputSpan where Element: ~Copyable {
   /// Remove all this span's elements and return its memory
   /// to the uninitialized state.
   @_alwaysEmitIntoClient
-  @lifetime(self: copy self)
+  @_lifetime(self: copy self)
   public mutating func removeAll() {
     guard count > 0 else { return }
     _ = unsafe _start().withMemoryRebound(to: Element.self, capacity: _count) {
@@ -361,7 +361,7 @@ extension OutputSpan {
   ///   - count: The number of times to append `repeatedValue`.
   ///       `count` must not exceed `freeCapacity`.
   @_alwaysEmitIntoClient
-  @lifetime(self: copy self)
+  @_lifetime(self: copy self)
   public mutating func append(repeating repeatedValue: Element, count: Int) {
     _precondition(count <= freeCapacity, "OutputSpan capacity overflow")
     unsafe _tail().initializeMemory(
@@ -378,7 +378,7 @@ extension OutputSpan where Element: ~Copyable {
   @_alwaysEmitIntoClient
   @_transparent
   public var span: Span<Element> {
-    @lifetime(borrow self)
+    @_lifetime(borrow self)
     borrowing get {
       let pointer = unsafe _pointer?.assumingMemoryBound(to: Element.self)
       let buffer = unsafe UnsafeBufferPointer(start: pointer, count: _count)
@@ -391,7 +391,7 @@ extension OutputSpan where Element: ~Copyable {
   @_alwaysEmitIntoClient
   @_transparent
   public var mutableSpan: MutableSpan<Element> {
-    @lifetime(&self)
+    @_lifetime(&self)
     mutating get {
       let pointer = unsafe _pointer?.assumingMemoryBound(to: Element.self)
       let buffer = unsafe UnsafeMutableBufferPointer(
@@ -433,7 +433,7 @@ extension OutputSpan where Element: ~Copyable {
   /// - Returns: The return value of the `body` closure.
   @_alwaysEmitIntoClient
   @_transparent
-  @lifetime(self: copy self)
+  @_lifetime(self: copy self)
   @unsafe
   public mutating func withUnsafeMutableBufferPointer<E: Error, R: ~Copyable>(
     _ body: (

--- a/stdlib/public/core/Span/RawSpan.swift
+++ b/stdlib/public/core/Span/RawSpan.swift
@@ -54,7 +54,7 @@ public struct RawSpan: ~Escapable, Copyable, BitwiseCopyable {
   /// Create an empty span.
   @_alwaysEmitIntoClient
   @inline(__always)
-  @lifetime(immortal)
+  @_lifetime(immortal)
   public init() {
     unsafe _pointer = nil
     _count = 0
@@ -76,7 +76,7 @@ public struct RawSpan: ~Escapable, Copyable, BitwiseCopyable {
   @unsafe
   @_alwaysEmitIntoClient
   @inline(__always)
-  @lifetime(borrow pointer)
+  @_lifetime(borrow pointer)
   internal init(
     _unchecked pointer: UnsafeRawPointer?,
     byteCount: Int
@@ -104,7 +104,7 @@ extension RawSpan {
   ///   - buffer: an `UnsafeRawBufferPointer` to initialized memory.
   @unsafe
   @_alwaysEmitIntoClient
-  @lifetime(borrow buffer)
+  @_lifetime(borrow buffer)
   public init(
     _unsafeBytes buffer: UnsafeRawBufferPointer
   ) {
@@ -125,7 +125,7 @@ extension RawSpan {
   ///   - buffer: a `Slice<UnsafeRawBufferPointer>` to initialized memory.
   @unsafe
   @_alwaysEmitIntoClient
-  @lifetime(borrow buffer)
+  @_lifetime(borrow buffer)
   public init(
     _unsafeBytes buffer: borrowing Slice<UnsafeRawBufferPointer>
   ) {
@@ -146,7 +146,7 @@ extension RawSpan {
   ///   - buffer: an `UnsafeMutableRawBufferPointer` to initialized memory.
   @unsafe
   @_alwaysEmitIntoClient
-  @lifetime(borrow buffer)
+  @_lifetime(borrow buffer)
   public init(
     _unsafeBytes buffer: UnsafeMutableRawBufferPointer
   ) {
@@ -167,7 +167,7 @@ extension RawSpan {
   ///   - buffer: a `Slice<UnsafeMutableRawBufferPointer>` to initialized memory.
   @unsafe
   @_alwaysEmitIntoClient
-  @lifetime(borrow buffer)
+  @_lifetime(borrow buffer)
   public init(
     _unsafeBytes buffer: borrowing Slice<UnsafeMutableRawBufferPointer>
   ) {
@@ -192,7 +192,7 @@ extension RawSpan {
   ///   - byteCount: the number of initialized bytes in the span.
   @unsafe
   @_alwaysEmitIntoClient
-  @lifetime(borrow pointer)
+  @_lifetime(borrow pointer)
   public init(
     _unsafeStart pointer: UnsafeRawPointer,
     byteCount: Int
@@ -211,7 +211,7 @@ extension RawSpan {
   ///   - buffer: an `UnsafeBufferPointer<T>` to initialized memory.
   @unsafe
   @_alwaysEmitIntoClient
-  @lifetime(borrow buffer)
+  @_lifetime(borrow buffer)
   public init<T: BitwiseCopyable>(
     _unsafeElements buffer: UnsafeBufferPointer<T>
   ) {
@@ -232,7 +232,7 @@ extension RawSpan {
   ///   - buffer: a `Slice<UnsafeBufferPointer<T>>` to initialized memory.
   @unsafe
   @_alwaysEmitIntoClient
-  @lifetime(borrow buffer)
+  @_lifetime(borrow buffer)
   public init<T: BitwiseCopyable>(
     _unsafeElements buffer: borrowing Slice<UnsafeBufferPointer<T>>
   ) {
@@ -253,7 +253,7 @@ extension RawSpan {
   ///   - buffer: an `UnsafeMutableBufferPointer<T>` to initialized memory.
   @unsafe
   @_alwaysEmitIntoClient
-  @lifetime(borrow buffer)
+  @_lifetime(borrow buffer)
   public init<T: BitwiseCopyable>(
     _unsafeElements buffer: UnsafeMutableBufferPointer<T>
   ) {
@@ -274,7 +274,7 @@ extension RawSpan {
   ///   - buffer: a `Slice<UnsafeMutableBufferPointer<T>>` to initialized memory.
   @unsafe
   @_alwaysEmitIntoClient
-  @lifetime(borrow buffer)
+  @_lifetime(borrow buffer)
   public init<T: BitwiseCopyable>(
     _unsafeElements buffer: borrowing Slice<UnsafeMutableBufferPointer<T>>
   ) {
@@ -299,7 +299,7 @@ extension RawSpan {
   ///   - count: the number of initialized elements in the span.
   @unsafe
   @_alwaysEmitIntoClient
-  @lifetime(borrow pointer)
+  @_lifetime(borrow pointer)
   public init<T: BitwiseCopyable>(
     _unsafeStart pointer: UnsafePointer<T>,
     count: Int
@@ -320,7 +320,7 @@ extension RawSpan {
   @available(*, deprecated, renamed: "init(unsafeElements:)")
   @_alwaysEmitIntoClient
   @unsafe
-  @lifetime(copy span)
+  @_lifetime(copy span)
   public init<Element>(_elements span: Span<Element>) {
     unsafe self = Self.init(unsafeElements: span)
   }
@@ -443,7 +443,7 @@ extension RawSpan {
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
-  @lifetime(copy self)
+  @_lifetime(copy self)
   public func extracting(_ bounds: Range<Int>) -> Self {
     _precondition(
       UInt(bitPattern: bounds.lowerBound) <= UInt(bitPattern: _count) &&
@@ -455,7 +455,7 @@ extension RawSpan {
 
   @available(*, deprecated, renamed: "extracting(_:)")
   @_alwaysEmitIntoClient
-  @lifetime(copy self)
+  @_lifetime(copy self)
   public func _extracting(_ bounds: Range<Int>) -> Self {
     extracting(bounds)
   }
@@ -477,7 +477,7 @@ extension RawSpan {
   /// - Complexity: O(1)
   @unsafe
   @_alwaysEmitIntoClient
-  @lifetime(copy self)
+  @_lifetime(copy self)
   public func extracting(unchecked bounds: Range<Int>) -> Self {
     let newStart = unsafe _pointer?.advanced(by: bounds.lowerBound)
     let newSpan = unsafe RawSpan(_unchecked: newStart, byteCount: bounds.count)
@@ -487,7 +487,7 @@ extension RawSpan {
   @unsafe
   @available(*, deprecated, renamed: "extracting(unchecked:)")
   @_alwaysEmitIntoClient
-  @lifetime(copy self)
+  @_lifetime(copy self)
   public func _extracting(unchecked bounds: Range<Int>) -> Self {
     unsafe extracting(unchecked: bounds)
   }
@@ -506,14 +506,14 @@ extension RawSpan {
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
-  @lifetime(copy self)
+  @_lifetime(copy self)
   public func extracting(_ bounds: some RangeExpression<Int>) -> Self {
     extracting(bounds.relative(to: byteOffsets))
   }
 
   @available(*, deprecated, renamed: "extracting(_:)")
   @_alwaysEmitIntoClient
-  @lifetime(copy self)
+  @_lifetime(copy self)
   public func _extracting(_ bounds: some RangeExpression<Int>) -> Self {
     extracting(bounds)
   }
@@ -535,7 +535,7 @@ extension RawSpan {
   /// - Complexity: O(1)
   @unsafe
   @_alwaysEmitIntoClient
-  @lifetime(copy self)
+  @_lifetime(copy self)
   public func extracting(
     unchecked bounds: ClosedRange<Int>
   ) -> Self {
@@ -548,7 +548,7 @@ extension RawSpan {
   @unsafe
   @available(*, deprecated, renamed: "extracting(unchecked:)")
   @_alwaysEmitIntoClient
-  @lifetime(copy self)
+  @_lifetime(copy self)
   public func _extracting(unchecked bounds: ClosedRange<Int>) -> Self {
     unsafe extracting(unchecked: bounds)
   }
@@ -563,14 +563,14 @@ extension RawSpan {
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
-  @lifetime(copy self)
+  @_lifetime(copy self)
   public func extracting(_: UnboundedRange) -> Self {
     self
   }
 
   @available(*, deprecated, renamed: "extracting(_:)")
   @_alwaysEmitIntoClient
-  @lifetime(copy self)
+  @_lifetime(copy self)
   public func _extracting(_: UnboundedRange) -> Self {
     self
   }
@@ -624,7 +624,7 @@ extension RawSpan {
   /// - Returns: A typed span viewing these bytes as instances of `T`.
   @unsafe
   @_alwaysEmitIntoClient
-  @lifetime(copy self)
+  @_lifetime(copy self)
   consuming public func _unsafeView<T: BitwiseCopyable>(
     as type: T.Type
   ) -> Span<T> {
@@ -875,7 +875,7 @@ extension RawSpan {
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
-  @lifetime(copy self)
+  @_lifetime(copy self)
   public func extracting(first maxLength: Int) -> Self {
     _precondition(maxLength >= 0, "Can't have a prefix of negative length")
     let newCount = min(maxLength, byteCount)
@@ -885,7 +885,7 @@ extension RawSpan {
 
   @available(*, deprecated, renamed: "extracting(first:)")
   @_alwaysEmitIntoClient
-  @lifetime(copy self)
+  @_lifetime(copy self)
   public func _extracting(first maxLength: Int) -> Self {
     extracting(first: maxLength)
   }
@@ -905,7 +905,7 @@ extension RawSpan {
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
-  @lifetime(copy self)
+  @_lifetime(copy self)
   public func extracting(droppingLast k: Int) -> Self {
     _precondition(k >= 0, "Can't drop a negative number of bytes")
     let droppedCount = min(k, byteCount)
@@ -916,7 +916,7 @@ extension RawSpan {
 
   @available(*, deprecated, renamed: "extracting(droppingLast:)")
   @_alwaysEmitIntoClient
-  @lifetime(copy self)
+  @_lifetime(copy self)
   public func _extracting(droppingLast k: Int) -> Self {
     extracting(droppingLast: k)
   }
@@ -937,7 +937,7 @@ extension RawSpan {
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
-  @lifetime(copy self)
+  @_lifetime(copy self)
   public func extracting(last maxLength: Int) -> Self {
     _precondition(maxLength >= 0, "Can't have a suffix of negative length")
     let newCount = min(maxLength, byteCount)
@@ -950,7 +950,7 @@ extension RawSpan {
 
   @available(*, deprecated, renamed: "extracting(last:)")
   @_alwaysEmitIntoClient
-  @lifetime(copy self)
+  @_lifetime(copy self)
   public func _extracting(last maxLength: Int) -> Self {
     extracting(last: maxLength)
   }
@@ -970,7 +970,7 @@ extension RawSpan {
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
-  @lifetime(copy self)
+  @_lifetime(copy self)
   public func extracting(droppingFirst k: Int) -> Self {
     _precondition(k >= 0, "Can't drop a negative number of bytes")
     let droppedCount = min(k, byteCount)
@@ -984,7 +984,7 @@ extension RawSpan {
 
   @available(*, deprecated, renamed: "extracting(droppingFirst:)")
   @_alwaysEmitIntoClient
-  @lifetime(copy self)
+  @_lifetime(copy self)
   public func _extracting(droppingFirst k: Int) -> Self {
     extracting(droppingFirst: k)
   }
@@ -994,7 +994,7 @@ extension RawSpan {
   @available(*, deprecated)
   @usableFromInline
   var _span: Span<UInt8> {
-    @lifetime(copy self)
+    @_lifetime(copy self)
     get {
       Span(viewing: self)
     }
@@ -1006,7 +1006,7 @@ extension RawSpan {
 extension RawSpan: BorrowingSequence {
   @available(SwiftStdlib 6.4, *)
   @inlinable
-  @lifetime(borrow self)
+  @_lifetime(borrow self)
   public func makeBorrowingIterator() -> SpanIterator<UInt8> {
     SpanIterator(Span(viewing: self))
   }

--- a/stdlib/public/core/StringUTF8View.swift
+++ b/stdlib/public/core/StringUTF8View.swift
@@ -320,7 +320,7 @@ extension String.UTF8View {
 @available(SwiftStdlib 6.2, *)
 extension String.UTF8View {
 
-  @lifetime(borrow self)
+  @_lifetime(borrow self)
   internal borrowing func _underlyingSpan() -> Span<UTF8.CodeUnit> {
 #if _runtime(_ObjC)
     // handle non-UTF8 Objective-C bridging cases here
@@ -358,7 +358,7 @@ extension String.UTF8View {
   ///   UTF-16 strings.
   @available(SwiftStdlib 6.2, *)
   public var span: Span<UTF8.CodeUnit> {
-    @lifetime(borrow self)
+    @_lifetime(borrow self)
     borrowing get {
       _underlyingSpan()
     }
@@ -377,7 +377,7 @@ extension String.UTF8View {
   @available(SwiftStdlib 6.2, *)
   public var _span: Span<UTF8.CodeUnit>? {
     @_alwaysEmitIntoClient @inline(__always)
-    @lifetime(borrow self)
+    @_lifetime(borrow self)
     borrowing get {
       span
     }
@@ -385,7 +385,7 @@ extension String.UTF8View {
 #else // !(os(watchOS) && _pointerBitWidth(_32))
   @available(watchOS, unavailable)
   public var span: Span<UTF8.CodeUnit> {
-    @lifetime(borrow self)
+    @_lifetime(borrow self)
     borrowing get {
       fatalError("\(#function) unavailable on 32-bit watchOS")
     }
@@ -404,7 +404,7 @@ extension String.UTF8View {
   ///   UTF-16 strings.
   @available(SwiftStdlib 6.2, *)
   public var _span: Span<UTF8.CodeUnit>? {
-    @lifetime(borrow self)
+    @_lifetime(borrow self)
     borrowing get {
       if _guts.isSmall, _guts.count > _SmallString.contiguousCapacity() {
         return nil

--- a/stdlib/public/core/Substring.swift
+++ b/stdlib/public/core/Substring.swift
@@ -786,7 +786,7 @@ extension Substring.UTF8View: BidirectionalCollection {
 @available(SwiftStdlib 6.2, *)
 extension Substring.UTF8View {
 
-  @lifetime(borrow self)
+  @_lifetime(borrow self)
   private borrowing func _underlyingSpan() -> Span<UTF8.CodeUnit> {
 #if _runtime(_ObjC)
     // handle non-UTF8 Objective-C bridging cases here
@@ -847,7 +847,7 @@ extension Substring.UTF8View {
   ///   strings.
   @available(SwiftStdlib 6.2, *)
   public var span: Span<UTF8.CodeUnit> {
-    @lifetime(borrow self)
+    @_lifetime(borrow self)
     borrowing get {
       _underlyingSpan()
     }
@@ -886,7 +886,7 @@ extension Substring.UTF8View {
   @available(SwiftStdlib 6.2, *)
   public var _span: Span<UTF8.CodeUnit>? {
     @_alwaysEmitIntoClient @inline(__always)
-    @lifetime(borrow self)
+    @_lifetime(borrow self)
     borrowing get {
       span
     }
@@ -930,7 +930,7 @@ extension Substring.UTF8View {
   ///   strings.
   @available(SwiftStdlib 6.2, *)
   public var _span: Span<UTF8.CodeUnit>? {
-    @lifetime(borrow self)
+    @_lifetime(borrow self)
     borrowing get {
       if _wholeGuts.isSmall,
          _wholeGuts.count > _SmallString.contiguousCapacity() {

--- a/stdlib/public/core/SwiftifyImport.swift
+++ b/stdlib/public/core/SwiftifyImport.swift
@@ -99,7 +99,7 @@ public enum _SwiftifyProtocolMethodInfo {
 @_unsafeNonescapableResult
 @_alwaysEmitIntoClient
 @_transparent
-@lifetime(borrow source)
+@_lifetime(borrow source)
 public func _swiftifyOverrideLifetime<
   T: ~Copyable & ~Escapable, U: ~Copyable & ~Escapable
 >(
@@ -119,7 +119,7 @@ public func _swiftifyOverrideLifetime<
 @_unsafeNonescapableResult
 @_alwaysEmitIntoClient
 @_transparent
-@lifetime(copy source)
+@_lifetime(copy source)
 public func _swiftifyOverrideLifetime<
   T: ~Copyable & ~Escapable, U: ~Copyable & ~Escapable
 >(

--- a/stdlib/public/core/UTF8Span.swift
+++ b/stdlib/public/core/UTF8Span.swift
@@ -36,7 +36,7 @@ public struct UTF8Span: Copyable, ~Escapable, BitwiseCopyable {
 
   // @_alwaysEmitIntoClient
   @inline(__always)
-  @lifetime(borrow start)
+  @_lifetime(borrow start)
   internal init(
     _unsafeAssumingValidUTF8 start: borrowing UnsafeRawPointer,
     _countAndFlags: UInt64
@@ -53,7 +53,7 @@ public struct UTF8Span: Copyable, ~Escapable, BitwiseCopyable {
   /// passed`, the contents must be ASCII, or else undefined behavior may
   /// result upon use.
   @unsafe
-  @lifetime(copy codeUnits)
+  @_lifetime(copy codeUnits)
   public init(
     unchecked codeUnits: Span<UInt8>,
     isKnownASCII: Bool = false
@@ -83,7 +83,7 @@ extension UTF8Span {
   /// The resulting UTF8Span has the same lifetime constraints as `codeUnits`.
   ///
   /// - Complexity: O(n)
-  @lifetime(copy codeUnits)
+  @_lifetime(copy codeUnits)
   public init(
     validating codeUnits: consuming Span<UInt8>
   ) throws(UTF8.ValidationError) {
@@ -91,7 +91,7 @@ extension UTF8Span {
   }
 
   // TODO: this doesn't need to be underscored, I don't think
-  @lifetime(copy codeUnits)
+  @_lifetime(copy codeUnits)
   internal init(
     _validating codeUnits: consuming Span<UInt8>
   ) throws(UTF8.ValidationError) {
@@ -113,7 +113,7 @@ extension UTF8Span {
   }
 
   // TODO: SPI?
-  @lifetime(copy codeUnits)
+  @_lifetime(copy codeUnits)
   internal init(
     _uncheckedAssumingValidUTF8 codeUnits: consuming Span<UInt8>,
     isKnownASCII: Bool,
@@ -199,7 +199,7 @@ extension UTF8Span {
   ///
   /// - Complexity: O(1)
   public var span: Span<UInt8> {
-    @lifetime(copy self)
+    @_lifetime(copy self)
     get {
       let newSpan = unsafe Span<UInt8>(_unchecked: _unsafeBaseAddress, count: self.count)
       return unsafe _overrideLifetime(newSpan, copying: self)
@@ -228,7 +228,7 @@ extension String {
 @available(SwiftStdlib 6.2, *)
 extension String {
 
-  @lifetime(borrow self)
+  @_lifetime(borrow self)
   private borrowing func _underlyingSpan() -> Span<UTF8.CodeUnit> {
 #if _runtime(_ObjC)
     // handle non-UTF8 Objective-C bridging cases here
@@ -266,7 +266,7 @@ extension String {
   ///   UTF-16 strings.
   @available(SwiftStdlib 6.2, *)
   public var utf8Span: UTF8Span {
-    @lifetime(borrow self)
+    @_lifetime(borrow self)
     borrowing get {
       unsafe UTF8Span(
         unchecked: _underlyingSpan(), isKnownASCII: _guts.isASCII
@@ -287,7 +287,7 @@ extension String {
   @available(SwiftStdlib 6.2, *)
   public var _utf8Span: UTF8Span? {
     @_alwaysEmitIntoClient @inline(__always)
-    @lifetime(borrow self)
+    @_lifetime(borrow self)
     borrowing get {
       utf8Span
     }
@@ -311,7 +311,7 @@ extension String {
   ///   UTF-16 strings.
   @available(SwiftStdlib 6.2, *)
   public var _utf8Span: UTF8Span? {
-    @lifetime(borrow self)
+    @_lifetime(borrow self)
     borrowing get {
       if _guts.isSmall, _guts.count > _SmallString.contiguousCapacity() {
         return nil
@@ -327,7 +327,7 @@ extension String {
 @available(SwiftStdlib 6.2, *)
 extension Substring {
 
-  @lifetime(borrow self)
+  @_lifetime(borrow self)
   private borrowing func _underlyingSpan() -> Span<UTF8.CodeUnit> {
 #if _runtime(_ObjC)
     // handle non-UTF8 Objective-C bridging cases here
@@ -388,7 +388,7 @@ extension Substring {
   ///   strings.
   @available(SwiftStdlib 6.2, *)
   public var utf8Span: UTF8Span {
-    @lifetime(borrow self)
+    @_lifetime(borrow self)
     borrowing get {
       unsafe UTF8Span(
         unchecked: _underlyingSpan(), isKnownASCII: base._guts.isASCII
@@ -429,7 +429,7 @@ extension Substring {
   @available(SwiftStdlib 6.2, *)
   public var _utf8Span: UTF8Span? {
     @_alwaysEmitIntoClient @inline(__always)
-    @lifetime(borrow self)
+    @_lifetime(borrow self)
     borrowing get {
       utf8Span
     }
@@ -473,7 +473,7 @@ extension Substring {
   ///   strings.
   @available(SwiftStdlib 6.2, *)
   public var _utf8Span: UTF8Span? {
-    @lifetime(borrow self)
+    @_lifetime(borrow self)
     borrowing get {
       if _wholeGuts.isSmall,
          _wholeGuts.count > _SmallString.contiguousCapacity() {

--- a/stdlib/public/core/UTF8SpanBits.swift
+++ b/stdlib/public/core/UTF8SpanBits.swift
@@ -36,7 +36,7 @@ extension UTF8Span {
   /// Updates the `isKnownASCII` bit if contents are all-ASCII.
   ///
   /// - Complexity: O(n)
-  @lifetime(self: copy self)
+  @_lifetime(self: copy self)
   public mutating func checkForASCII() -> Bool {
     if isKnownASCII { return true }
 
@@ -60,14 +60,14 @@ extension UTF8Span {
 
   // Set the isKnownASCII bit to true (also isNFC)
   @_alwaysEmitIntoClient
-  @lifetime(self: copy self)
+  @_lifetime(self: copy self)
   internal mutating func _setIsASCII() {
     self._countAndFlags |= Self._asciiBit | Self._nfcBit
   }
 
   // Set the isKnownNFC bit to true (also isNFC)
   @_alwaysEmitIntoClient
-  @lifetime(self: copy self)
+  @_lifetime(self: copy self)
   internal mutating func _setIsNFC() {
     self._countAndFlags |= Self._nfcBit
   }
@@ -84,7 +84,7 @@ extension UTF8Span {
   ///
   /// - Complexity: O(n)
   @_unavailableInEmbedded
-  @lifetime(self: copy self)
+  @_lifetime(self: copy self)
   public mutating func checkForNFC(
     quickCheck: Bool
   ) -> Bool {

--- a/stdlib/public/core/UTF8SpanIterators.swift
+++ b/stdlib/public/core/UTF8SpanIterators.swift
@@ -16,7 +16,7 @@ extension UTF8Span {
   /// `Unicode.Scalar`s.
   ///
   /// The resulting iterator has the same lifetime constraints as `self`.
-  @lifetime(copy self)
+  @_lifetime(copy self)
   public func makeUnicodeScalarIterator() -> UnicodeScalarIterator {
     .init(self)
   }
@@ -43,7 +43,7 @@ extension UTF8Span {
     fileprivate(set)
     public var currentCodeUnitOffset: Int
 
-    @lifetime(copy codeUnits)
+    @_lifetime(copy codeUnits)
     public init(_ codeUnits: UTF8Span) {
       self.codeUnits = codeUnits
       self.currentCodeUnitOffset = 0
@@ -61,7 +61,7 @@ extension UTF8Span {
     /// Returns `nil` if at the end of the `UTF8Span`.
     ///
     /// - Complexity: O(1)
-    @lifetime(self: copy self)
+    @_lifetime(self: copy self)
     public mutating func next() -> Unicode.Scalar? {
       guard currentCodeUnitOffset < codeUnits.count else {
         return nil
@@ -81,7 +81,7 @@ extension UTF8Span {
     /// Returns `nil` if at the start of the `UTF8Span`.
     ///
     /// - Complexity: O(1)
-    @lifetime(self: copy self)
+    @_lifetime(self: copy self)
     public mutating func previous() -> Unicode.Scalar? {
       guard currentCodeUnitOffset > 0 else {
         return nil
@@ -101,7 +101,7 @@ extension UTF8Span {
     /// if at the end of the UTF8Span.
     ///
     /// - Complexity: O(1)
-    @lifetime(self: copy self)
+    @_lifetime(self: copy self)
     public mutating func skipForward() -> Int {
       guard currentCodeUnitOffset < codeUnits.count else {
         return 0
@@ -120,7 +120,7 @@ extension UTF8Span {
     /// fewer than `n` if at the end of the UTF8Span.
     ///
     /// - Complexity: O(n)
-    @lifetime(self: copy self)
+    @_lifetime(self: copy self)
     public mutating func skipForward(by n: Int) -> Int {
       var numSkipped = 0
       while numSkipped < n && skipForward() != 0 {
@@ -137,7 +137,7 @@ extension UTF8Span {
     /// if at the start of the UTF8Span.
     ///
     /// - Complexity: O(1)
-    @lifetime(self: copy self)
+    @_lifetime(self: copy self)
     public mutating func skipBack() -> Int {
       guard currentCodeUnitOffset > 0 else {
         return 0
@@ -156,7 +156,7 @@ extension UTF8Span {
     /// fewer than `n` if at the start of the UTF8Span.
     ///
     /// - Complexity: O(n)
-    @lifetime(self: copy self)
+    @_lifetime(self: copy self)
     public mutating func skipBack(by n: Int) -> Int {
       var numSkipped = 0
       while numSkipped < n && skipBack() != 0 {
@@ -179,7 +179,7 @@ extension UTF8Span {
     ///     printScalarAfterReset(string)
     ///
     /// - Complexity: O(1)
-    @lifetime(self: copy self)
+    @_lifetime(self: copy self)
     public mutating func reset(roundingBackwardsFrom i: Int)  {
       self.currentCodeUnitOffset = codeUnits._scalarAlignBackwards(i)
     }
@@ -187,7 +187,7 @@ extension UTF8Span {
     /// Reset to the nearest scalar-aligned code unit offset `>= i`.
     ///
     /// - Complexity: O(1)
-    @lifetime(self: copy self)
+    @_lifetime(self: copy self)
     public mutating func reset(roundingForwardsFrom i: Int)  {
       self.currentCodeUnitOffset = codeUnits._scalarAlignForwards(i)
     }
@@ -208,7 +208,7 @@ extension UTF8Span {
     ///
     /// - Complexity: O(1)
     @unsafe
-    @lifetime(self: copy self)
+    @_lifetime(self: copy self)
     public mutating func reset(toUnchecked codeUnitOffset: Int) {
       _internalInvariant(codeUnits._isScalarAligned(unchecked: codeUnitOffset))
       self.currentCodeUnitOffset = codeUnitOffset
@@ -220,7 +220,7 @@ extension UTF8Span {
     /// The resultant `UTF8Span` has the same lifetime constraints as `self`.
     ///
     /// - Complexity: O(1)
-    @lifetime(copy self)
+    @_lifetime(copy self)
     public func prefix() -> UTF8Span {
       let slice = codeUnits.span.extracting(0..<currentCodeUnitOffset)
       return UTF8Span(
@@ -235,7 +235,7 @@ extension UTF8Span {
     /// The resultant `UTF8Span` has the same lifetime constraints as `self`.
     ///
     /// - Complexity: O(1)
-    @lifetime(copy self)
+    @_lifetime(copy self)
     public func suffix() -> UTF8Span {
       let slice = codeUnits.span.extracting(currentCodeUnitOffset..<codeUnits.count)
       return UTF8Span(
@@ -253,7 +253,7 @@ extension UTF8Span {
   /// UTF-8 content.
   ///
   /// The resulting iterator has the same lifetime constraints as `self`.
-  @lifetime(copy self)
+  @_lifetime(copy self)
   public func makeCharacterIterator() -> CharacterIterator {
     .init(self)
   }
@@ -287,7 +287,7 @@ extension UTF8Span {
     fileprivate(set)
     public var currentCodeUnitOffset: Int
 
-    @lifetime(copy codeUnits)
+    @_lifetime(copy codeUnits)
     public init(_ codeUnits: UTF8Span) {
       self.codeUnits = codeUnits
       self.currentCodeUnitOffset = 0
@@ -303,7 +303,7 @@ extension UTF8Span {
     /// `Character`.
     ///
     /// Returns `nil` if at the end of the `UTF8Span`.
-    @lifetime(self: copy self)
+    @_lifetime(self: copy self)
     public mutating func next() -> Character? {
       guard currentCodeUnitOffset < codeUnits.count else { return nil }
 
@@ -322,7 +322,7 @@ extension UTF8Span {
     /// previous `Character`.
     ///
     /// Returns `nil` if at the start of the `UTF8Span`.
-    @lifetime(self: copy self)
+    @_lifetime(self: copy self)
     public mutating func previous() -> Character? {
       guard currentCodeUnitOffset > 0 else { return nil }
 
@@ -339,7 +339,7 @@ extension UTF8Span {
     ///
     /// Returns the number of `Character`s skipped over, which can be 0
     /// if at the end of the UTF8Span.
-    @lifetime(self: copy self)
+    @_lifetime(self: copy self)
     public mutating func skipForward() -> Int {
       guard currentCodeUnitOffset < codeUnits.count else {
         return 0
@@ -356,7 +356,7 @@ extension UTF8Span {
     ///
     /// Returns the number of `Character`s skipped over, which can be
     /// fewer than `n` if at the end of the UTF8Span.
-    @lifetime(self: copy self)
+    @_lifetime(self: copy self)
     public mutating func skipForward(by n: Int) -> Int {
       var numSkipped = 0
       while numSkipped < n && skipForward() != 0 {
@@ -371,7 +371,7 @@ extension UTF8Span {
     ///
     /// Returns the number of `Character`s skipped over, which can be 0
     /// if at the start of the UTF8Span.
-    @lifetime(self: copy self)
+    @_lifetime(self: copy self)
     public mutating func skipBack() -> Int {
       guard currentCodeUnitOffset > 0 else {
         return 0
@@ -389,7 +389,7 @@ extension UTF8Span {
     ///
     /// Returns the number of `Character`s skipped over, which can be
     /// fewer than `n` if at the start of the UTF8Span.
-    @lifetime(self: copy self)
+    @_lifetime(self: copy self)
     public mutating func skipBack(by n: Int) -> Int {
       var numSkipped = 0
       while numSkipped < n && skipBack() != 0 {
@@ -400,13 +400,13 @@ extension UTF8Span {
     }
 
     /// Reset to the nearest character-aligned position `<= i`.
-    @lifetime(self: copy self)
+    @_lifetime(self: copy self)
     public mutating func reset(roundingBackwardsFrom i: Int) {
       self.currentCodeUnitOffset = codeUnits._scalarAlignBackwards(i)
     }
 
     /// Reset to the nearest character-aligned position `>= i`.
-    @lifetime(self: copy self)
+    @_lifetime(self: copy self)
     public mutating func reset(roundingForwardsFrom i: Int) {
       self.currentCodeUnitOffset = codeUnits._scalarAlignForwards(i)
     }
@@ -425,7 +425,7 @@ extension UTF8Span {
     /// known-valid previous position.
     ///
     @unsafe
-    @lifetime(self: copy self)
+    @_lifetime(self: copy self)
     public mutating func reset(toUnchecked codeUnitOffset: Int) {
       _internalInvariant(codeUnits._isScalarAligned(unchecked: codeUnitOffset))
       self.currentCodeUnitOffset = codeUnitOffset
@@ -433,7 +433,7 @@ extension UTF8Span {
 
     /// Returns the UTF8Span containing all the content up to the iterator's
     /// current position.
-    @lifetime(copy self)
+    @_lifetime(copy self)
     public func prefix() -> UTF8Span {
       let slice = codeUnits.span.extracting(0..<currentCodeUnitOffset)
       return UTF8Span(
@@ -444,7 +444,7 @@ extension UTF8Span {
 
     /// Returns the UTF8Span containing all the content after the iterator's
     /// current position.
-    @lifetime(copy self)
+    @_lifetime(copy self)
     public func suffix() -> UTF8Span {
       let slice = codeUnits.span.extracting(currentCodeUnitOffset..<codeUnits.count)
       return UTF8Span(

--- a/stdlib/public/core/UniqueBox.swift
+++ b/stdlib/public/core/UniqueBox.swift
@@ -84,7 +84,7 @@ extension UniqueBox where Value: ~Copyable {
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
   public var span: Span<Value> {
-    @lifetime(borrow self)
+    @_lifetime(borrow self)
     @_transparent
     get {
       unsafe Span(_unsafeStart: pointer, count: 1)
@@ -99,7 +99,7 @@ extension UniqueBox where Value: ~Copyable {
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
   public var mutableSpan: MutableSpan<Value> {
-    @lifetime(&self)
+    @_lifetime(&self)
     @_transparent
     mutating get {
       unsafe MutableSpan(_unsafeStart: pointer, count: 1)

--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -595,7 +595,7 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
   @unsafe
   @_alwaysEmitIntoClient
   public var span: Span<Element> {
-    @lifetime(borrow self)
+    @_lifetime(borrow self)
     @_transparent
     get {
       unsafe Span(_unsafeElements: self)
@@ -621,7 +621,7 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
   @unsafe
   @_alwaysEmitIntoClient
   public var mutableSpan: MutableSpan<Element> {
-    @lifetime(borrow self)
+    @_lifetime(borrow self)
     @_transparent
     get {
       unsafe MutableSpan(_unsafeElements: self)

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -464,7 +464,7 @@ extension Unsafe${Mutable}RawBufferPointer {
   /// - Returns: A new instance of type `T`, copied from the buffer pointer's
   ///   memory.
   @_alwaysEmitIntoClient
-  @lifetime(borrow self)
+  @_lifetime(borrow self)
   public func loadUnaligned<T: BitwiseCopyable & ~Escapable>(
     fromByteOffset offset: Int = 0,
     as type: T.Type
@@ -1214,7 +1214,7 @@ extension Unsafe${Mutable}RawBufferPointer {
   @unsafe
   @_alwaysEmitIntoClient
   public var bytes: RawSpan {
-    @lifetime(borrow self)
+    @_lifetime(borrow self)
     @_transparent
     get {
       unsafe RawSpan(_unsafeBytes: self)
@@ -1240,7 +1240,7 @@ extension Unsafe${Mutable}RawBufferPointer {
   @unsafe
   @_alwaysEmitIntoClient
   public var mutableBytes: MutableRawSpan {
-    @lifetime(borrow self)
+    @_lifetime(borrow self)
     @_transparent
     get {
       unsafe MutableRawSpan(_unsafeBytes: self)

--- a/stdlib/public/core/UnsafeRawPointer.swift
+++ b/stdlib/public/core/UnsafeRawPointer.swift
@@ -443,7 +443,7 @@ extension UnsafeRawPointer {
   ///   with the value in the memory referenced by this pointer.
   @inlinable
   @_preInverseGenerics
-  @lifetime(borrow self)
+  @_lifetime(borrow self)
   public func load<T: ~Escapable>(
     fromByteOffset offset: Int = 0,
     as type: T.Type
@@ -490,7 +490,7 @@ extension UnsafeRawPointer {
   ///   with the value in the range of memory referenced by this pointer.
   @inlinable
   @_alwaysEmitIntoClient
-  @lifetime(borrow self)
+  @_lifetime(borrow self)
   public func loadUnaligned<T: BitwiseCopyable & ~Escapable>(
     fromByteOffset offset: Int = 0,
     as type: T.Type
@@ -1285,7 +1285,7 @@ extension UnsafeMutableRawPointer {
   ///   with the value in the memory referenced by this pointer.
   @inlinable
   @_preInverseGenerics
-  @lifetime(borrow self)
+  @_lifetime(borrow self)
   public func load<T: ~Escapable>(
     fromByteOffset offset: Int = 0,
     as type: T.Type
@@ -1333,7 +1333,7 @@ extension UnsafeMutableRawPointer {
   ///   with the value in the range of memory referenced by this pointer.
   @inlinable
   @_alwaysEmitIntoClient
-  @lifetime(borrow self)
+  @_lifetime(borrow self)
   public func loadUnaligned<T: BitwiseCopyable & ~Escapable>(
     fromByteOffset offset: Int = 0,
     as type: T.Type

--- a/stdlib/public/core/_InlineArray.swift
+++ b/stdlib/public/core/_InlineArray.swift
@@ -464,7 +464,7 @@ extension _InlineArray where Element: ~Copyable {
 extension _InlineArray where Element: ~Copyable {
   @_alwaysEmitIntoClient
   internal var span: Span<Element> {
-    @lifetime(borrow self)
+    @_lifetime(borrow self)
     @_transparent
     borrowing get {
       let span = unsafe Span(_unsafeStart: _protectedAddress, count: count)
@@ -474,7 +474,7 @@ extension _InlineArray where Element: ~Copyable {
 
   @_alwaysEmitIntoClient
   internal var mutableSpan: MutableSpan<Element> {
-    @lifetime(&self)
+    @_lifetime(&self)
     @_transparent
     mutating get {
       let span = unsafe MutableSpan(

--- a/test/Interop/CxxToSwiftToCxx/bridge-cxx-enum-back-to-cxx-execution.cpp
+++ b/test/Interop/CxxToSwiftToCxx/bridge-cxx-enum-back-to-cxx-execution.cpp
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 
-// RUN: %target-swift-frontend -parse-as-library %stdlib_dir/Swift.swiftmodule/%module-target-triple.swiftinterface -enable-library-evolution -disable-objc-attr-requires-foundation-module -typecheck -module-name Swift -parse-stdlib -enable-experimental-cxx-interop -clang-header-expose-decls=has-expose-attr -emit-clang-header-path %t/Swift.h  -experimental-skip-all-function-bodies -enable-experimental-feature LifetimeDependence -enable-experimental-feature BorrowingSequence -enable-experimental-feature Reparenting -enable-experimental-feature AddressableParameters
+// RUN: %target-swift-frontend -parse-as-library %stdlib_dir/Swift.swiftmodule/%module-target-triple.swiftinterface -enable-library-evolution -disable-objc-attr-requires-foundation-module -typecheck -module-name Swift -parse-stdlib -enable-experimental-cxx-interop -clang-header-expose-decls=has-expose-attr -emit-clang-header-path %t/Swift.h  -experimental-skip-all-function-bodies -enable-experimental-feature LifetimeDependence -enable-experimental-feature Lifetimes -enable-experimental-feature BorrowingSequence -enable-experimental-feature Reparenting -enable-experimental-feature AddressableParameters
 // RUN: %target-swift-frontend -typecheck %t/use-cxx-types.swift -typecheck -module-name UseCxx -emit-clang-header-path %t/UseCxx.h -I %t -enable-experimental-cxx-interop -clang-header-expose-decls=all-public
 
 // RUN: %target-interop-build-clangxx -std=c++20 -c %t/use-swift-cxx-types.cpp -I %t -o %t/swift-cxx-execution.o -g
@@ -12,6 +12,7 @@
 
 // REQUIRES: executable_test
 // REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_Lifetimes
 // REQUIRES: swift_feature_BorrowingSequence
 // REQUIRES: swift_feature_Reparenting
 // REQUIRES: swift_feature_AddressableParameters

--- a/test/Interop/CxxToSwiftToCxx/bridge-cxx-struct-back-to-cxx-execution.cpp
+++ b/test/Interop/CxxToSwiftToCxx/bridge-cxx-struct-back-to-cxx-execution.cpp
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 
-// RUN: %target-swift-frontend -parse-as-library %platform-module-dir/Swift.swiftmodule/%module-target-triple.swiftinterface -enable-library-evolution -disable-objc-attr-requires-foundation-module -typecheck -module-name Swift -parse-stdlib -enable-experimental-cxx-interop -clang-header-expose-decls=has-expose-attr -emit-clang-header-path %t/Swift.h  -experimental-skip-all-function-bodies -enable-experimental-feature LifetimeDependence -enable-experimental-feature BorrowingSequence -enable-experimental-feature Reparenting -enable-experimental-feature AddressableParameters
+// RUN: %target-swift-frontend -parse-as-library %platform-module-dir/Swift.swiftmodule/%module-target-triple.swiftinterface -enable-library-evolution -disable-objc-attr-requires-foundation-module -typecheck -module-name Swift -parse-stdlib -enable-experimental-cxx-interop -clang-header-expose-decls=has-expose-attr -emit-clang-header-path %t/Swift.h  -experimental-skip-all-function-bodies -enable-experimental-feature LifetimeDependence -enable-experimental-feature Lifetimes -enable-experimental-feature BorrowingSequence -enable-experimental-feature Reparenting -enable-experimental-feature AddressableParameters
 
 // RUN: %target-swift-frontend -typecheck %t/use-cxx-types.swift -typecheck -module-name UseCxx -emit-clang-header-path %t/UseCxx.h -I %t -enable-experimental-cxx-interop -clang-header-expose-decls=all-public
 
@@ -13,6 +13,7 @@
 
 // REQUIRES: executable_test
 // REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_Lifetimes
 // REQUIRES: swift_feature_BorrowingSequence
 // REQUIRES: swift_feature_Reparenting
 // REQUIRES: swift_feature_AddressableParameters

--- a/test/Interop/SwiftToCxx/stdlib/swift-stdlib-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/stdlib/swift-stdlib-in-cxx.swift
@@ -1,11 +1,12 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -parse-as-library %platform-module-dir/Swift.swiftmodule/%module-target-triple.swiftinterface -enable-library-evolution -disable-objc-attr-requires-foundation-module -typecheck -module-name Swift -parse-stdlib -enable-experimental-cxx-interop -clang-header-expose-decls=has-expose-attr-or-stdlib -emit-clang-header-path %t/Swift.h  -experimental-skip-all-function-bodies -enable-experimental-feature LifetimeDependence  -enable-experimental-feature BorrowingSequence -enable-experimental-feature Reparenting -enable-experimental-feature AddressableParameters
+// RUN: %target-swift-frontend -parse-as-library %platform-module-dir/Swift.swiftmodule/%module-target-triple.swiftinterface -enable-library-evolution -disable-objc-attr-requires-foundation-module -typecheck -module-name Swift -parse-stdlib -enable-experimental-cxx-interop -clang-header-expose-decls=has-expose-attr-or-stdlib -emit-clang-header-path %t/Swift.h  -experimental-skip-all-function-bodies -enable-experimental-feature LifetimeDependence  -enable-experimental-feature Lifetimes -enable-experimental-feature BorrowingSequence -enable-experimental-feature Reparenting -enable-experimental-feature AddressableParameters
 // RUN: %FileCheck %s < %t/Swift.h
 
 // RUN: %check-interop-cxx-header-in-clang(%t/Swift.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY -Wno-unused-private-field -Wno-unused-function -Wc++98-compat-extra-semi)
 // RUN: %check-interop-cxx-header-in-clang(%t/Swift.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY -Wno-unused-private-field -Wno-unused-function -Wc++98-compat-extra-semi -DDEBUG=1)
 
 // REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_Lifetimes
 // REQUIRES: swift_feature_BorrowingSequence
 // REQUIRES: swift_feature_Reparenting
 // REQUIRES: swift_feature_AddressableParameters


### PR DESCRIPTION
Use the `@_lifetime` annotations from the `Lifetimes` experimental feature rather than the `@lifetime` annotations from the older, semi-deprecated `LifetimesDependence` experimental feature.

This leaves "Span.swift" alone, since it is involved in [another PR](https://github.com/swiftlang/swift/pull/89213). The experimental feature flag(s) will be removed later.