### PR TITLE
[AST] Make RawComment handling robust against source files changing from underneath us

### DIFF
--- a/lib/AST/RawComment.cpp
+++ b/lib/AST/RawComment.cpp
@@ -38,8 +38,8 @@
 using namespace swift;
 
 static SingleRawComment::CommentKind getCommentKind(StringRef Comment) {
-  assert(Comment.size() >= 2);
-  assert(Comment[0] == '/');
+  if (Comment.size() < 2 || Comment[0] != '/')
+    return SingleRawComment::CommentKind::OrdinaryLine;
 
   if (Comment[1] == '/') {
     if (Comment.size() < 3)
@@ -49,14 +49,15 @@ static SingleRawComment::CommentKind getCommentKind(StringRef Comment) {
       return SingleRawComment::CommentKind::LineDoc;
     }
     return SingleRawComment::CommentKind::OrdinaryLine;
-  } else {
-    assert(Comment[1] == '*');
-    assert(Comment.size() >= 4);
-    if (Comment[2] == '*') {
-      return SingleRawComment::CommentKind::BlockDoc;
-    }
-    return SingleRawComment::CommentKind::OrdinaryBlock;
   }
+
+  if (Comment[1] != '*' || Comment.size() < 4)
+    return SingleRawComment::CommentKind::OrdinaryLine;
+
+  if (Comment[2] == '*') {
+    return SingleRawComment::CommentKind::BlockDoc;
+  }
+  return SingleRawComment::CommentKind::OrdinaryBlock;
 }
 
 SingleRawComment::SingleRawComment(CharSourceRange Range,
@@ -149,6 +150,15 @@ RawComment RawCommentRequest::evaluate(Evaluator &eval, const Decl *D) const {
       SmallVector<SingleRawComment, 4> SRCs;
       for (const auto &Range : CachedLocs->DocRanges) {
         if (Range.isValid()) {
+          // Validate the extracted text looks like a comment before using it.
+          // If the source file has been modified since the .swiftsourceinfo was
+          // generated, the stored byte offset may point to non-comment content.
+          auto Text = ctx.SourceMgr.extractText(Range);
+          if (Text.size() < 2 || Text[0] != '/') {
+            // Stale .swiftsourceinfo; fall through to .swiftdoc below.
+            SRCs.clear();
+            break;
+          }
           SRCs.push_back({Range, ctx.SourceMgr});
         } else {
           // if we've run into an invalid range, don't bother trying to load

--- a/test/SymbolGraph/stale-sourceinfo-doc-comment.swift
+++ b/test/SymbolGraph/stale-sourceinfo-doc-comment.swift
@@ -1,0 +1,50 @@
+// Test that swift-symbolgraph-extract does not crash when a module's
+// .swiftsourceinfo has doc comment byte offsets that are stale relative
+// to the current source file on disk.
+//
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: %target-swift-frontend %t/P_v1.swift -module-name P -emit-module -emit-module-path %t/P.swiftmodule -emit-module-doc-path %t/P.swiftdoc -emit-module-source-info-path %t/P.swiftsourceinfo
+// RUN: cp %t/P_v2.swift %t/P_v1.swift
+// RUN: %target-swift-frontend %t/Consumer.swift -module-name Consumer -emit-module -emit-module-path %t/Consumer.swiftmodule -emit-module-source-info-path %t/Consumer.swiftsourceinfo -I %t
+// RUN: %target-swift-symbolgraph-extract -module-name Consumer -I %t -pretty-print -output-dir %t
+// RUN: %FileCheck %s --input-file %t/Consumer.symbols.json
+
+// P_v1.swift is compiled first to produce P.swiftsourceinfo, which records the
+// byte offset of the '///' doc comment on the extension.  P_v1.swift is then
+// replaced with P_v2.swift, which has different content at that same offset
+// (@available rather than ///), making the stored offset stale.
+// swift-symbolgraph-extract evaluates RawCommentRequest for P's extensions
+// during synthesized-member processing.  Before the fix, it passed the
+// non-comment text extracted from the stale offset to getCommentKind(), which
+// asserted Comment[0] == '/'.  After the fix it falls through to .swiftdoc.
+
+// CHECK: "identifier"
+// CHECK: "swift.struct"
+
+//--- P_v1.swift
+public protocol P {
+  func foo()
+}
+
+/// Documentation for the default extension.
+extension P {
+  public func bar() {}
+}
+
+//--- P_v2.swift
+public protocol P {
+  func foo()
+}
+
+@available(macOS 12.0, *)
+extension P {
+  public func bar() {}
+}
+
+//--- Consumer.swift
+import P
+
+public struct S: P {
+  public func foo() {}
+}


### PR DESCRIPTION
- **Explanation**: A `.swiftsourceinfo` file that is out-of-sync with the source file it references could trigger an assertion during documentation comment extraction. Make doc comment extraction robust against this failure mode, fixing a crash.
- **Scope**: Limited to documentation comment extraction.
- **Issues**: rdar://177358181
- **Original PRs**: https://github.com/swiftlang/swift/pull/89386
- **Risk**: Very low. It turns an assert into a safe early exit.
- **Testing**: new test + CI
- **Reviewers**:
