### PR TITLE
[Evaluator] Count request evaluator cache hits

### DIFF
--- a/include/swift/AST/AccessRequests.h
+++ b/include/swift/AST/AccessRequests.h
@@ -101,12 +101,17 @@ public:
 #undef SWIFT_TYPEID_ZONE
 #undef SWIFT_TYPEID_HEADER
 
-// Set up reporting of evaluated requests.
+// Set up reporting of evaluated and cache-hit requests.
 #define SWIFT_REQUEST(Zone, RequestType, Sig, Caching, LocOptions)             \
   template <>                                                                  \
   inline void reportEvaluatedRequest(UnifiedStatsReporter &stats,              \
                                      const RequestType &request) {             \
     ++stats.getFrontendCounters().RequestType;                                 \
+  }                                                                            \
+  template <>                                                                  \
+  inline void reportCachedRequest(UnifiedStatsReporter &stats,                 \
+                                  const RequestType &request) {                \
+    ++stats.getFrontendCounters().RequestType##CacheHit;                       \
   }
 #include "swift/AST/AccessTypeIDZone.def"
 #undef SWIFT_REQUEST

--- a/include/swift/AST/Evaluator.h
+++ b/include/swift/AST/Evaluator.h
@@ -75,6 +75,12 @@ template<typename Request>
 void reportEvaluatedRequest(UnifiedStatsReporter &stats,
                             const Request &request) { }
 
+/// Report that a request of the given kind returned a cached result, so it
+/// can be recorded by the stats reporter.
+template<typename Request>
+void reportCachedRequest(UnifiedStatsReporter &stats,
+                         const Request &request) { }
+
 /// Evaluation engine that evaluates and caches "requests", checking for cyclic
 /// dependencies along the way.
 ///
@@ -384,6 +390,8 @@ private:
   getResultCached(const Request &request, Fn defaultValueFn) {
     // If there is a cached result, return it.
     if (auto cached = request.getCachedResult()) {
+      if (stats)
+        reportCachedRequest(*stats, request);
       recorder.replayCachedRequest(request);
       handleDependencySinkRequest<Request>(request, *cached);
       return *cached;
@@ -410,6 +418,8 @@ private:
     auto known = cache.find_as<Request>(request);
     if (known != cache.end<Request>()) {
       auto result = known->second;
+      if (stats)
+        reportCachedRequest(*stats, request);
       recorder.replayCachedRequest(request);
       handleDependencySinkRequest<Request>(request, result);
       return result;

--- a/include/swift/AST/IRGenRequests.h
+++ b/include/swift/AST/IRGenRequests.h
@@ -260,6 +260,12 @@ template<typename Request>
 void reportEvaluatedRequest(UnifiedStatsReporter &stats,
                             const Request &request);
 
+/// Report that a request of the given kind returned a cached result, so it
+/// can be recorded by the stats reporter.
+template<typename Request>
+void reportCachedRequest(UnifiedStatsReporter &stats,
+                         const Request &request);
+
 class IRGenRequest
     : public SimpleRequest<IRGenRequest, GeneratedModule(IRGenDescriptor),
                            RequestFlags::Uncached |
@@ -326,12 +332,17 @@ public:
 #undef SWIFT_TYPEID_ZONE
 #undef SWIFT_TYPEID_HEADER
 
- // Set up reporting of evaluated requests.
+// Set up reporting of evaluated and cache-hit requests.
 #define SWIFT_REQUEST(Zone, RequestType, Sig, Caching, LocOptions)             \
 template<>                                                                     \
 inline void reportEvaluatedRequest(UnifiedStatsReporter &stats,                \
                             const RequestType &request) {                      \
   ++stats.getFrontendCounters().RequestType;                                   \
+}                                                                              \
+template<>                                                                     \
+inline void reportCachedRequest(UnifiedStatsReporter &stats,                   \
+                                const RequestType &request) {                  \
+  ++stats.getFrontendCounters().RequestType##CacheHit;                         \
 }
 #include "swift/AST/IRGenTypeIDZone.def"
 #undef SWIFT_REQUEST

--- a/include/swift/AST/NameLookupRequests.h
+++ b/include/swift/AST/NameLookupRequests.h
@@ -1078,16 +1078,24 @@ public:
 #undef SWIFT_TYPEID_ZONE
 #undef SWIFT_TYPEID_HEADER
 
-// Set up reporting of evaluated requests.
+// Set up reporting of evaluated and cache-hit requests.
 template<typename Request>
 void reportEvaluatedRequest(UnifiedStatsReporter &stats,
                             const Request &request);
+template<typename Request>
+void reportCachedRequest(UnifiedStatsReporter &stats,
+                         const Request &request);
 
 #define SWIFT_REQUEST(Zone, RequestType, Sig, Caching, LocOptions)             \
   template <>                                                                  \
   inline void reportEvaluatedRequest(UnifiedStatsReporter &stats,              \
                                      const RequestType &request) {             \
     ++stats.getFrontendCounters().RequestType;                                 \
+  }                                                                            \
+  template <>                                                                  \
+  inline void reportCachedRequest(UnifiedStatsReporter &stats,                 \
+                                  const RequestType &request) {                \
+    ++stats.getFrontendCounters().RequestType##CacheHit;                       \
   }
 #include "swift/AST/NameLookupTypeIDZone.def"
 #undef SWIFT_REQUEST

--- a/include/swift/AST/ParseRequests.h
+++ b/include/swift/AST/ParseRequests.h
@@ -33,6 +33,12 @@ template<typename Request>
 void reportEvaluatedRequest(UnifiedStatsReporter &stats,
                             const Request &request);
 
+/// Report that a request of the given kind returned a cached result, so it
+/// can be recorded by the stats reporter.
+template<typename Request>
+void reportCachedRequest(UnifiedStatsReporter &stats,
+                         const Request &request);
+
 struct FingerprintAndMembers {
   std::optional<Fingerprint> fingerprint = std::nullopt;
   ArrayRef<Decl *> members = {};
@@ -225,12 +231,17 @@ void simple_display(llvm::raw_ostream &out, const ASTContext *state);
 #undef SWIFT_TYPEID_ZONE
 #undef SWIFT_TYPEID_HEADER
 
-// Set up reporting of evaluated requests.
+// Set up reporting of evaluated and cache-hit requests.
 #define SWIFT_REQUEST(Zone, RequestType, Sig, Caching, LocOptions)             \
   template <>                                                                  \
   inline void reportEvaluatedRequest(UnifiedStatsReporter &stats,              \
                                      const RequestType &request) {             \
     ++stats.getFrontendCounters().RequestType;                                 \
+  }                                                                            \
+  template <>                                                                  \
+  inline void reportCachedRequest(UnifiedStatsReporter &stats,                 \
+                                  const RequestType &request) {                \
+    ++stats.getFrontendCounters().RequestType##CacheHit;                       \
   }
 #include "swift/AST/ParseTypeIDZone.def"
 #undef SWIFT_REQUEST

--- a/include/swift/AST/SILGenRequests.h
+++ b/include/swift/AST/SILGenRequests.h
@@ -42,6 +42,12 @@ template<typename Request>
 void reportEvaluatedRequest(UnifiedStatsReporter &stats,
                             const Request &request);
 
+/// Report that a request of the given kind returned a cached result, so it
+/// can be recorded by the stats reporter.
+template<typename Request>
+void reportCachedRequest(UnifiedStatsReporter &stats,
+                         const Request &request);
+
 using SILRefsToEmit = llvm::SmallVector<SILDeclRef, 1>;
 
 using SymbolSources = llvm::SmallVector<SymbolSource, 1>;
@@ -151,12 +157,17 @@ private:
 #undef SWIFT_TYPEID_ZONE
 #undef SWIFT_TYPEID_HEADER
 
- // Set up reporting of evaluated requests.
+ // Set up reporting of evaluated and cache-hit requests.
 #define SWIFT_REQUEST(Zone, RequestType, Sig, Caching, LocOptions)             \
 template<>                                                                     \
 inline void reportEvaluatedRequest(UnifiedStatsReporter &stats,                \
                             const RequestType &request) {                      \
   ++stats.getFrontendCounters().RequestType;                                   \
+}                                                                              \
+template<>                                                                     \
+inline void reportCachedRequest(UnifiedStatsReporter &stats,                   \
+                                const RequestType &request) {                  \
+  ++stats.getFrontendCounters().RequestType##CacheHit;                         \
 }
 #include "swift/AST/SILGenTypeIDZone.def"
 #undef SWIFT_REQUEST

--- a/include/swift/AST/SILOptimizerRequests.h
+++ b/include/swift/AST/SILOptimizerRequests.h
@@ -93,6 +93,12 @@ template <typename Request>
 void reportEvaluatedRequest(UnifiedStatsReporter &stats,
                             const Request &request);
 
+/// Report that a request of the given kind returned a cached result, so it
+/// can be recorded by the stats reporter.
+template <typename Request>
+void reportCachedRequest(UnifiedStatsReporter &stats,
+                         const Request &request);
+
 /// The zone number for SILOptimizer.
 #define SWIFT_TYPEID_ZONE SILOptimizer
 #define SWIFT_TYPEID_HEADER "swift/AST/SILOptimizerTypeIDZone.def"
@@ -100,12 +106,17 @@ void reportEvaluatedRequest(UnifiedStatsReporter &stats,
 #undef SWIFT_TYPEID_ZONE
 #undef SWIFT_TYPEID_HEADER
 
-// Set up reporting of evaluated requests.
+// Set up reporting of evaluated and cache-hit requests.
 #define SWIFT_REQUEST(Zone, RequestType, Sig, Caching, LocOptions)             \
 template<>                                                                     \
 inline void reportEvaluatedRequest(UnifiedStatsReporter &stats,                \
                                    const RequestType &request) {               \
   ++stats.getFrontendCounters().RequestType;                                   \
+}                                                                              \
+template<>                                                                     \
+inline void reportCachedRequest(UnifiedStatsReporter &stats,                   \
+                                const RequestType &request) {                  \
+  ++stats.getFrontendCounters().RequestType##CacheHit;                         \
 }
 #include "swift/AST/SILOptimizerTypeIDZone.def"
 #undef SWIFT_REQUEST

--- a/include/swift/AST/TBDGenRequests.h
+++ b/include/swift/AST/TBDGenRequests.h
@@ -320,6 +320,12 @@ template <typename Request>
 void reportEvaluatedRequest(UnifiedStatsReporter &stats,
                             const Request &request);
 
+/// Report that a request of the given kind returned a cached result, so it
+/// can be recorded by the stats reporter.
+template <typename Request>
+void reportCachedRequest(UnifiedStatsReporter &stats,
+                         const Request &request);
+
 /// The zone number for TBDGen.
 #define SWIFT_TYPEID_ZONE TBDGen
 #define SWIFT_TYPEID_HEADER "swift/AST/TBDGenTypeIDZone.def"
@@ -327,12 +333,17 @@ void reportEvaluatedRequest(UnifiedStatsReporter &stats,
 #undef SWIFT_TYPEID_ZONE
 #undef SWIFT_TYPEID_HEADER
 
-// Set up reporting of evaluated requests.
+// Set up reporting of evaluated and cache-hit requests.
 #define SWIFT_REQUEST(Zone, RequestType, Sig, Caching, LocOptions)             \
 template<>                                                                     \
 inline void reportEvaluatedRequest(UnifiedStatsReporter &stats,                \
                                    const RequestType &request) {               \
   ++stats.getFrontendCounters().RequestType;                                   \
+}                                                                              \
+template<>                                                                     \
+inline void reportCachedRequest(UnifiedStatsReporter &stats,                   \
+                                const RequestType &request) {                  \
+  ++stats.getFrontendCounters().RequestType##CacheHit;                         \
 }
 #include "swift/AST/TBDGenTypeIDZone.def"
 #undef SWIFT_REQUEST

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -5637,12 +5637,17 @@ public:
 #undef SWIFT_TYPEID_ZONE
 #undef SWIFT_TYPEID_HEADER
 
-// Set up reporting of evaluated requests.
+// Set up reporting of evaluated and cache-hit requests.
 #define SWIFT_REQUEST(Zone, RequestType, Sig, Caching, LocOptions)             \
   template<>                                                                   \
   inline void reportEvaluatedRequest(UnifiedStatsReporter &stats,              \
                               const RequestType &request) {                    \
     ++stats.getFrontendCounters().RequestType;                                 \
+  }                                                                            \
+  template<>                                                                   \
+  inline void reportCachedRequest(UnifiedStatsReporter &stats,                 \
+                                  const RequestType &request) {                \
+    ++stats.getFrontendCounters().RequestType##CacheHit;                       \
   }
 #include "swift/AST/TypeCheckerTypeIDZone.def"
 #undef SWIFT_REQUEST

--- a/include/swift/Basic/Statistics.def
+++ b/include/swift/Basic/Statistics.def
@@ -184,6 +184,11 @@ FRONTEND_STATISTIC(Parse, NumIterableDeclContextParsed)
 #include "swift/AST/ParseTypeIDZone.def"
 #undef SWIFT_REQUEST
 
+/// Cache hit counters for Parse requests.
+#define SWIFT_REQUEST(ZONE, NAME, SIG, CACHE, LocOptions) FRONTEND_STATISTIC(Parse, NAME##CacheHit)
+#include "swift/AST/ParseTypeIDZone.def"
+#undef SWIFT_REQUEST
+
 /// Number of conformances that were deserialized by this frontend job.
 FRONTEND_STATISTIC(Sema, NumConformancesDeserialized)
 
@@ -291,7 +296,23 @@ FRONTEND_STATISTIC(Sema, NumSwift6Errors)
 #include "swift/ConstExtract/ConstExtractTypeIDZone.def"
 #undef SWIFT_REQUEST
 
+/// Cache hit counters for type check requests.
+#define SWIFT_REQUEST(ZONE, NAME, Sig, Caching, LocOptions) FRONTEND_STATISTIC(Sema, NAME##CacheHit)
+#include "swift/AST/AccessTypeIDZone.def"
+#include "swift/AST/NameLookupTypeIDZone.def"
+#include "swift/AST/TypeCheckerTypeIDZone.def"
+#include "swift/Sema/IDETypeCheckingRequestIDZone.def"
+#include "swift/IDE/IDERequestIDZone.def"
+#include "swift/ClangImporter/ClangImporterTypeIDZone.def"
+#include "swift/ConstExtract/ConstExtractTypeIDZone.def"
+#undef SWIFT_REQUEST
+
 #define SWIFT_REQUEST(ZONE, NAME, Sig, Caching, LocOptions) FRONTEND_STATISTIC(SILGen, NAME)
+#include "swift/AST/SILGenTypeIDZone.def"
+#undef SWIFT_REQUEST
+
+/// Cache hit counters for SILGen requests.
+#define SWIFT_REQUEST(ZONE, NAME, Sig, Caching, LocOptions) FRONTEND_STATISTIC(SILGen, NAME##CacheHit)
 #include "swift/AST/SILGenTypeIDZone.def"
 #undef SWIFT_REQUEST
 
@@ -309,6 +330,11 @@ FRONTEND_STATISTIC(SILModule, NumSILGenGlobalVariables)
 #include "swift/AST/SILOptimizerTypeIDZone.def"
 #undef SWIFT_REQUEST
 
+/// Cache hit counters for SILOptimizer requests.
+#define SWIFT_REQUEST(ZONE, NAME, Sig, Caching, LocOptions) FRONTEND_STATISTIC(SILOptimizer, NAME##CacheHit)
+#include "swift/AST/SILOptimizerTypeIDZone.def"
+#undef SWIFT_REQUEST
+
 FRONTEND_STATISTIC(SILModule, NumSILOptFunctions)
 FRONTEND_STATISTIC(SILModule, NumSILOptVtables)
 FRONTEND_STATISTIC(SILModule, NumSILOptWitnessTables)
@@ -316,6 +342,11 @@ FRONTEND_STATISTIC(SILModule, NumSILOptDefaultWitnessTables)
 FRONTEND_STATISTIC(SILModule, NumSILOptGlobalVariables)
 
 #define SWIFT_REQUEST(ZONE, NAME, Sig, Caching, LocOptions) FRONTEND_STATISTIC(IRGen, NAME)
+#include "swift/AST/IRGenTypeIDZone.def"
+#undef SWIFT_REQUEST
+
+/// Cache hit counters for IRGen requests.
+#define SWIFT_REQUEST(ZONE, NAME, Sig, Caching, LocOptions) FRONTEND_STATISTIC(IRGen, NAME##CacheHit)
 #include "swift/AST/IRGenTypeIDZone.def"
 #undef SWIFT_REQUEST
 
@@ -340,6 +371,11 @@ FRONTEND_STATISTIC(IRModule, NumGOTEntries)
 FRONTEND_STATISTIC(LLVM, NumLLVMBytesOutput)
 
 #define SWIFT_REQUEST(ZONE, NAME, Sig, Caching, LocOptions) FRONTEND_STATISTIC(TBDGen, NAME)
+#include "swift/AST/TBDGenTypeIDZone.def"
+#undef SWIFT_REQUEST
+
+/// Cache hit counters for TBDGen requests.
+#define SWIFT_REQUEST(ZONE, NAME, Sig, Caching, LocOptions) FRONTEND_STATISTIC(TBDGen, NAME##CacheHit)
 #include "swift/AST/TBDGenTypeIDZone.def"
 #undef SWIFT_REQUEST
 

--- a/include/swift/ClangImporter/ClangImporterRequests.h
+++ b/include/swift/ClangImporter/ClangImporterRequests.h
@@ -881,16 +881,23 @@ private:
 #undef SWIFT_TYPEID_ZONE
 #undef SWIFT_TYPEID_HEADER
 
-// Set up reporting of evaluated requests.
-template<typename Request>
+// Set up reporting of evaluated and cache-hit requests.
+template <typename Request>
 void reportEvaluatedRequest(UnifiedStatsReporter &stats,
                             const Request &request);
+template <typename Request>
+void reportCachedRequest(UnifiedStatsReporter &stats, const Request &request);
 
 #define SWIFT_REQUEST(Zone, RequestType, Sig, Caching, LocOptions)             \
   template <>                                                                  \
   inline void reportEvaluatedRequest(UnifiedStatsReporter &stats,              \
                                      const RequestType &request) {             \
     ++stats.getFrontendCounters().RequestType;                                 \
+  }                                                                            \
+  template <>                                                                  \
+  inline void reportCachedRequest(UnifiedStatsReporter &stats,                 \
+                                  const RequestType &request) {                \
+    ++stats.getFrontendCounters().RequestType##CacheHit;                       \
   }
 #include "swift/ClangImporter/ClangImporterTypeIDZone.def"
 #undef SWIFT_REQUEST

--- a/include/swift/ConstExtract/ConstExtractRequests.h
+++ b/include/swift/ConstExtract/ConstExtractRequests.h
@@ -65,16 +65,23 @@ public:
 #undef SWIFT_TYPEID_ZONE
 #undef SWIFT_TYPEID_HEADER
 
-// Set up reporting of evaluated requests.
-template<typename Request>
+// Set up reporting of evaluated and cache-hit requests.
+template <typename Request>
 void reportEvaluatedRequest(UnifiedStatsReporter &stats,
                             const Request &request);
+template <typename Request>
+void reportCachedRequest(UnifiedStatsReporter &stats, const Request &request);
 
 #define SWIFT_REQUEST(Zone, RequestType, Sig, Caching, LocOptions)             \
   template <>                                                                  \
   inline void reportEvaluatedRequest(UnifiedStatsReporter &stats,              \
                                      const RequestType &request) {             \
     ++stats.getFrontendCounters().RequestType;                                 \
+  }                                                                            \
+  template <>                                                                  \
+  inline void reportCachedRequest(UnifiedStatsReporter &stats,                 \
+                                  const RequestType &request) {                \
+    ++stats.getFrontendCounters().RequestType##CacheHit;                       \
   }
 #include "swift/ConstExtract/ConstExtractTypeIDZone.def"
 #undef SWIFT_REQUEST

--- a/include/swift/IDE/IDERequests.h
+++ b/include/swift/IDE/IDERequests.h
@@ -287,12 +287,17 @@ public:
 #undef SWIFT_TYPEID_ZONE
 #undef SWIFT_TYPEID_HEADER
 
-// Set up reporting of evaluated requests.
+// Set up reporting of evaluated and cache-hit requests.
 #define SWIFT_REQUEST(Zone, RequestType, Sig, Caching, LocOptions)             \
 template<>                                                                     \
 inline void reportEvaluatedRequest(UnifiedStatsReporter &stats,                \
                             const RequestType &request) {                      \
   ++stats.getFrontendCounters().RequestType;                                   \
+}                                                                              \
+template<>                                                                     \
+inline void reportCachedRequest(UnifiedStatsReporter &stats,                   \
+                                const RequestType &request) {                  \
+  ++stats.getFrontendCounters().RequestType##CacheHit;                         \
 }
 #include "swift/IDE/IDERequestIDZone.def"
 #undef SWIFT_REQUEST

--- a/include/swift/Sema/IDETypeCheckingRequests.h
+++ b/include/swift/Sema/IDETypeCheckingRequests.h
@@ -234,12 +234,17 @@ public:
 #undef SWIFT_TYPEID_ZONE
 #undef SWIFT_TYPEID_HEADER
 
-// Set up reporting of evaluated requests.
+// Set up reporting of evaluated and cache-hit requests.
 #define SWIFT_REQUEST(Zone, RequestType, Sig, Caching, LocOptions)             \
 template<>                                                                     \
 inline void reportEvaluatedRequest(UnifiedStatsReporter &stats,                \
                             const RequestType &request) {                      \
   ++stats.getFrontendCounters().RequestType;                                   \
+}                                                                              \
+template<>                                                                     \
+inline void reportCachedRequest(UnifiedStatsReporter &stats,                   \
+                                const RequestType &request) {                  \
+  ++stats.getFrontendCounters().RequestType##CacheHit;                         \
 }
 #include "swift/Sema/IDETypeCheckingRequestIDZone.def"
 #undef SWIFT_REQUEST


### PR DESCRIPTION
When -fine-grained-timers are enabled, we currently log the requests we evaluate. However, for cached requests, this only tells us how many times many cache misses we have, and not cache hits, i.e., how well we actually utilize the cached results.

This patch adds cache hit counters to record that information as well. By adding up the number of cache misses and hits, we can also ascertain the total number of requests made.

rdar://177768273