### PR TITLE
[test] Disable SILOptimizer/pack_specialization.swift for 32-bit platforms

### DIFF
--- a/test/SILOptimizer/pack_specialization.swift
+++ b/test/SILOptimizer/pack_specialization.swift
@@ -3,7 +3,8 @@
 
 // REQUIRES: swift_in_compiler
 
-
+// Some tests started failing for 32-bit since #88914.
+// REQUIRES: PTRSIZE=64
 
 // When no witness methods are called on pack elements, all pack code can be fully eliminated.
 // CHECK: define {{.*}} { i32, ptr, double } @"$s19pack_specialization8copyPack2xsxxQp_txxQp_tRvzlFs5Int32V_SPys5Int16VGSdQP_Tg5Tf8xx_n"(i32 %0, ptr %1, double %2)


### PR DESCRIPTION
This started failing for 32-bit armv7 alone since new test cases were added in #88914 and will likely start failing on the 32-bit watchOS CI also, so I can extend this to `// REQUIRES: PTRSIZE=64` if wanted.