### PR TITLE
[ClangImporter] Do not import things twice

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -10258,19 +10258,41 @@ Decl *ClangImporter::Implementation::importDeclAndCacheImpl(
   startedImportingEntity();
   Decl *Result = importDeclImpl(ClangDecl, version, TypedefIsSuperfluous,
                                 HadForwardDeclaration);
-  if (!Result) {
-    ImportedDecls[{Canon, version}] = nullptr;
-    return nullptr;
-  }
 
-  if (TypedefIsSuperfluous) {
+  if (Result && TypedefIsSuperfluous) {
     SuperfluousTypedefs.insert(Canon);
     if (auto tagDecl = dyn_cast_or_null<clang::TagDecl>(Result->getClangDecl()))
       DeclsWithSuperfluousTypedefs.insert(tagDecl);
   }
 
-  if (!HadForwardDeclaration)
-    ImportedDecls[{Canon, version}] = Result;
+  if (!HadForwardDeclaration) {
+    auto it = ImportedDecls.try_emplace({Canon, version}, Result);
+    if (CONDITIONAL_ASSERT_enabled() && !it.second &&
+        Result != it.first->second) {
+      ABORT([&](auto &out) {
+        out << "Imported the same clang::Decl twice: '";
+        ClangDecl->getNameForDiagnostic(out, {{}}, true);
+        out << "' ";
+        ClangDecl->getSourceRange().print(out, Instance->getSourceManager());
+        if (ClangDecl != Canon) {
+          out << "\nCanonical clang::Decl: '";
+          Canon->getNameForDiagnostic(out, {{}}, true);
+          out << "' ";
+          Canon->getSourceRange().print(out, Instance->getSourceManager());
+        }
+        out << "\nImported as Swift Decl:\n";
+        if (Result)
+          Result->dump(out, 4);
+        else
+          out << "    (null)\n";
+        out << "\nPreviously imported as Swift Decl:\n";
+        if (it.first->second)
+          it.first->second->dump(out, 4);
+        else
+          out << "    (null)\n";
+      });
+    }
+  }
 
   if (!SuperfluousTypedefsAreTransparent && TypedefIsSuperfluous)
     return nullptr;

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4103,7 +4103,15 @@ namespace {
 
       // We may have already imported this function decl while importing its
       // decl context. Check decl cache to make sure we don't import twice.
-      auto known = Impl.ImportedDecls.find({decl, getVersion()});
+      const clang::Decl *cacheKey;
+      if (funcTemplate)
+        // Function templates are cached under the FunctionTemplateDecl
+        // so use funcTemplate as cache key if set.
+        cacheKey = funcTemplate->getCanonicalDecl();
+      else
+        // Otherwise use decl's canonical decl, matching importDeclAndCacheImpl
+        cacheKey = decl->getCanonicalDecl();
+      auto known = Impl.ImportedDecls.find({cacheKey, getVersion()});
       if (known != Impl.ImportedDecls.end()) {
         return known->second;
       }
@@ -4250,7 +4258,7 @@ namespace {
 
       // We may have already imported this function decl while importing its
       // type signature. Check decl cache to make sure we don't import twice.
-      auto known2 = Impl.ImportedDecls.find({decl, getVersion()});
+      auto known2 = Impl.ImportedDecls.find({cacheKey, getVersion()});
       if (known2 != Impl.ImportedDecls.end()) {
         return known2->second;
       }

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -5725,7 +5725,22 @@ namespace {
 
       // Check whether there's some special method to import.
       if (!forceClassMethod) {
-        if (dc == Impl.importDeclContextOf(decl, decl->getDeclContext()))
+        // Don't cache when the accessor we're producing will be attached
+        // to a synthesized property (importObjCMethodAsEffectfulProp).
+        // In that case the property VarDecl is the user-facing decl and
+        // **it** (and not this accessor) is what the outer
+        // importDeclAndCacheImpl will cache under {canonical, version}.
+        //
+        // We detect this case by checking whether the storage's clang
+        // decl is the same ObjCMethodDecl we're importing; that's only
+        // true for the synthesized-from-method effectful-prop case, not
+        // for ordinary @property accessors (whose storage is the
+        // ObjCPropertyDecl).
+        bool isEffectfulPropAccessor =
+            accessorInfo &&
+            accessorInfo->Storage->getClangDecl() == decl;
+        if (!isEffectfulPropAccessor &&
+            dc == Impl.importDeclContextOf(decl, decl->getDeclContext()))
           Impl.ImportedDecls.try_emplace(
               {decl->getCanonicalDecl(), getVersion()}, result);
 

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -1612,6 +1612,14 @@ namespace {
       if (!SwiftType)
         return nullptr;
 
+      // While importing the underlying type, we may encounter this typedef
+      // again and thus may already have imported this typedef by this point.
+      // If so, reuse the cached result rather than creating a duplicate.
+      auto alreadyImported = Impl.ImportedDecls.find(
+          {Decl->getCanonicalDecl(), getVersion()});
+      if (alreadyImported != Impl.ImportedDecls.end())
+        return alreadyImported->second;
+
       auto Loc = Impl.importSourceLoc(Decl->getLocation());
       auto Result = Impl.createDeclWithClangNode<TypeAliasDecl>(
           Decl, importer::convertClangAccess(Decl->getAccess()),

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2504,6 +2504,14 @@ namespace {
             decl, importer::convertClangAccess(decl->getAccess()), loc, name,
             loc, ArrayRef<InheritedEntry>(), nullptr, dc);
       Impl.ImportedDecls[{decl->getCanonicalDecl(), getVersion()}] = result;
+      // We've written a partial entry into ImportedDecls so that nested
+      // member imports (especially those that recurse into us via
+      // VisitRecordDecl) can find this StructDecl/ClassDecl instead of
+      // looping. If we later decide to bail out and return nullptr, we need to
+      // erase the partial entry.
+      auto eraseCacheOnBailOut = [&] {
+        Impl.ImportedDecls.erase({decl->getCanonicalDecl(), getVersion()});
+      };
 
       if (getCxxValueSemanticsKind(decl->getTypeForDecl(), Impl) !=
           CxxValueSemanticsKind::Copyable) {
@@ -2546,6 +2554,7 @@ namespace {
                                Impl.SwiftContext.AllocateCopy(
                                    base.getType().getAsString())),
                     base.getBeginLoc());
+                eraseCacheOnBailOut();
                 return nullptr;
               }
             }
@@ -2686,6 +2695,7 @@ namespace {
                   Diagnostic(diag::nonescapable_member_of_escapable, false,
                              decl, nd->getName()),
                   decl->getLocation());
+              eraseCacheOnBailOut();
               return nullptr;
             }
           }
@@ -2987,8 +2997,10 @@ namespace {
       // If we need it, add an explicit "deinit" to this type.
       synthesizer.addExplicitDeinitIfRequired(result, decl);
 
-      if (!injectBridgingConversionsForRefCountedSmartPtrs(result))
+      if (!injectBridgingConversionsForRefCountedSmartPtrs(result)) {
+        eraseCacheOnBailOut();
         return nullptr;
+      }
 
       result->setMemberLoader(&Impl, 0);
       return result;

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -7583,7 +7583,7 @@ SwiftDeclConverter::getImplicitProperty(ImportedName importedName,
     return nullptr;
 
   Impl.importAttributes(getter, swiftGetter);
-  Impl.ImportedDecls[{getter, getVersion()}] = swiftGetter;
+  Impl.ImportedDecls[{getter->getCanonicalDecl(), getVersion()}] = swiftGetter;
   if (swift3GetterName)
     markAsVariant(swiftGetter, *swift3GetterName);
 
@@ -7597,7 +7597,8 @@ SwiftDeclConverter::getImplicitProperty(ImportedName importedName,
       return nullptr;
 
     Impl.importAttributes(setter, swiftSetter);
-    Impl.ImportedDecls[{setter, getVersion()}] = swiftSetter;
+    Impl.ImportedDecls[{setter->getCanonicalDecl(), getVersion()}] =
+        swiftSetter;
     if (swift3SetterName)
       markAsVariant(swiftSetter, *swift3SetterName);
   }

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2487,6 +2487,14 @@ namespace {
 
       Impl.validateSwiftAttributes(decl);
       auto loc = Impl.importSourceLoc(decl->getLocation());
+
+      // Do not import std::promise.
+      if (decl->isInStdNamespace() && decl->getName() == "promise" &&
+          getCxxValueSemanticsKind(decl->getTypeForDecl(), Impl) !=
+              CxxValueSemanticsKind::Copyable) {
+        return nullptr;
+      }
+
       if (recordHasReferenceSemantics(decl))
         result = Impl.createDeclWithClangNode<ClassDecl>(
             decl, importer::convertClangAccess(decl->getAccess()), loc, name,
@@ -2499,10 +2507,6 @@ namespace {
 
       if (getCxxValueSemanticsKind(decl->getTypeForDecl(), Impl) !=
           CxxValueSemanticsKind::Copyable) {
-        if (decl->isInStdNamespace() && decl->getName() == "promise") {
-          // Do not import std::promise.
-          return nullptr;
-        }
         result->addAttribute(new (Impl.SwiftContext)
                                  MoveOnlyAttr(/*Implicit=*/true));
         addSuppressedProtocol(result, KnownProtocolKind::Copyable);

--- a/test/Interop/Cxx/class/import-implicit-property-redecl.swift
+++ b/test/Interop/Cxx/class/import-implicit-property-redecl.swift
@@ -1,0 +1,42 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: %target-swift-frontend -typecheck -I %t %t/test.swift
+
+// Setup: a struct with two C functions imported as a Swift property via
+// `swift_name("getter:...")` / `swift_name("setter:...")`. We deliberately
+// give both the getter AND the setter multiple declarations so the redecl
+// chain has a non-canonical member that could end up as the lookup-table
+// hit during getImplicitProperty's "find the other accessor" loop.
+
+//--- module.modulemap
+module ImplicitPropertyRedecl {
+    header "implicit-property-redecl.h"
+}
+
+//--- implicit-property-redecl.h
+#pragma once
+
+struct Box { int data; };
+
+// Canonical
+extern int Box_getValue(const struct Box *self)
+    __attribute__((swift_name("getter:Box.value(self:)")));
+// Most recent
+extern int Box_getValue(const struct Box *self)
+    __attribute__((swift_name("getter:Box.value(self:)")));
+
+// Canonical
+extern void Box_setValue(struct Box *self, int v)
+    __attribute__((swift_name("setter:Box.value(self:_:)")));
+// Most recent
+extern void Box_setValue(struct Box *self, int v)
+    __attribute__((swift_name("setter:Box.value(self:_:)")));
+
+//--- test.swift
+import ImplicitPropertyRedecl
+
+func test() -> CInt {
+    var b = Box(data: 0)
+    b.value = 42
+    return b.value
+}

--- a/test/Interop/Cxx/class/import-operator-with-friend-redecl.swift
+++ b/test/Interop/Cxx/class/import-operator-with-friend-redecl.swift
@@ -1,0 +1,41 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: %target-swift-frontend -typecheck -I %t -cxx-interoperability-mode=default %t/test.swift
+
+// Regression test involving a free function with two declarations: a friend
+// declaration inside a class (canonical) and a separate inline out-of-line
+// definition (most-recent in the redecl chain). This originally caused the
+// same member to be imported twice.
+
+// This pattern is based on std::__1::operator==(__thread_id, __thread_id),
+// which we reach while buildign the Swift stdlib via the Equatable conformance
+// witness lookup for std::string (which pulls in *every* operator==).
+
+//--- module.modulemap
+module FriendOpRedecl {
+    header "friend-op-redecl.h"
+    requires cplusplus
+}
+
+//--- friend-op-redecl.h
+#pragma once
+
+struct Id {
+  int data;
+  // This friend declaration is the canonical decl for `operator==`
+  friend bool operator==(Id a, Id b);
+};
+
+// This out-of-line definition is the most-recent decl in the redecl chain
+inline bool operator==(Id a, Id b) { return a.data == b.data; }
+
+// Decoy used only to trigger Swift's unqualified lookup for '=='
+struct Decoy { int x; };
+inline bool operator==(Decoy a, Decoy b) { return a.x == b.x; }
+
+//--- test.swift
+import FriendOpRedecl
+
+// Note: Swift code does NOT mention `Id`; resolving `==` between Decoys
+// drives unqualified lookup for '=='
+let _ = Decoy() == Decoy()

--- a/test/Interop/Cxx/class/import-typedef-with-recursive-record.swift
+++ b/test/Interop/Cxx/class/import-typedef-with-recursive-record.swift
@@ -1,0 +1,41 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: %target-swift-frontend -typecheck -I %t -cxx-interoperability-mode=default %t/test.swift
+
+// A typedef's underlying type sugars back to the typedef's enclosing record,
+// std::ratio<1>::type (`typedef ratio<num,den> type;` in libc++ <ratio>).
+
+//--- module.modulemap
+module RecursiveRecordTypedef {
+    header "recursive-record-typedef.h"
+    requires cplusplus
+}
+
+//--- recursive-record-typedef.h
+#pragma once
+
+namespace M {
+  template <int N>
+  struct S {
+    // Self-referential: the underlying type *is* the enclosing class template
+    // specialization S<N>. Importing this typedef therefore recurses into
+    // importing S<N>, which in turn iterates its members, including this
+    // typedef.
+    typedef S<N> type;
+  };
+}
+
+// Top-level typedef chain so that importing `Trigger` drives
+// SwiftTypeConverter through TypedefType('M::S<1>::type') and into the
+// recursive record import.
+//
+// Mirrors how libc++'s std::chrono::duration<long long>::period is encountered
+// while importing std::chrono::seconds.
+typedef M::S<1>::type Trigger;
+
+//--- test.swift
+import RecursiveRecordTypedef
+
+// Force import of `Trigger` -- before the fix, this aborted while importing
+// `M::S<1>::type`.
+let _: Trigger? = nil


### PR DESCRIPTION
A series of patches that squash out ClangImporter ImportDecl cache inconsistencies.

Continuation of https://github.com/swiftlang/swift/pull/85424.

rdar://164616956