### PR TITLE
[IRGen] Don't emit extended existential metadata for inverse-only existentials

### DIFF
--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -264,6 +264,10 @@ MetadataDependency MetadataDependencyCollector::finish(IRGenFunction &IGF) {
   return result;
 }
 
+static bool irgenNeedsExtendedExistentialMetadata(const ExistentialLayout &layout) {
+  return !layout.getParameterizedProtocols().empty();
+}
+
 llvm::Constant *IRGenModule::getAddrOfStringForMetadataRef(
     StringRef symbolName,
     unsigned alignment,
@@ -2074,7 +2078,7 @@ namespace {
 
       // Existential metatypes for extended existentials don't use
       // ExistentialMetatypeMetadata.
-      if (type->getExistentialLayout().needsExtendedShape()) {
+      if (irgenNeedsExtendedExistentialMetadata(type->getExistentialLayout())) {
         auto metadata = emitExtendedExistentialTypeMetadata(type);
         return setLocal(type, MetadataResponse::forComplete(metadata));
       }
@@ -3135,7 +3139,7 @@ static bool shouldAccessByMangledName(IRGenModule &IGM, CanType type) {
     void visitExistentialMetatypeType(CanExistentialMetatypeType meta) {
       // Extended existential metatypes just emit a different shape
       // and don't do any wrapping.
-      if (meta->getExistentialLayout().needsExtendedShape()) {
+      if (irgenNeedsExtendedExistentialMetadata(meta->getExistentialLayout())) {
         // return visit(unwrapExistentialMetatype(meta));
       }
 

--- a/test/IRGen/inverse_only_existential_metadata.swift
+++ b/test/IRGen/inverse_only_existential_metadata.swift
@@ -1,12 +1,27 @@
-// RUN: %target-swift-frontend -emit-ir %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-ir -module-name test %s | %FileCheck %s
 
-// Verify that an existential containing ONLY inverse requirements
-// (no parameterized protocols) does NOT emit a call to
-// swift_getExtendedExistentialTypeMetadata, which is unavailable on
-// older OS deployments and breaks iOS 15 / earlier.
+// Regression test for https://github.com/swiftlang/swift/issues/89402.
+//
+// An existential carrying ONLY inverse requirements (no parameterized
+// protocols) must NOT lower through swift_getExtendedExistentialTypeMetadata.
+// That runtime entry-point is unavailable in libswiftCore shipped with
+// iOS 15 / macOS 12 and earlier; using it crashes with a NULL
+// weak-external call. Inverse requirements alone are representable in
+// the classical existential shape and should keep going through
+// swift_getExistentialTypeMetadata.
 
-// CHECK-LABEL: define {{.*}} @"$s4test3fooyyF"
-// CHECK-NOT: swift_getExtendedExistentialTypeMetadata
-public func foo() {
-    let _: any (Any & ~Copyable & ~Escapable).Type = (Any).self as Any.Type
+// CHECK-NOT: call {{.*}}@swift_getExtendedExistentialTypeMetadata
+
+public class Repro {
+  public func getString<T>(str: String) -> T? {
+    return nil
+  }
+
+  public func test() {
+    // T has no contextual type. With PR #81365's behavior, IRGen would
+    // infer `any Any<~Copyable, ~Escapable>` and lower the metadata
+    // access through the extended path; the fix keeps it on the
+    // classical path.
+    if getString(str: "") != nil { return }
+  }
 }

--- a/test/IRGen/inverse_only_existential_metadata.swift
+++ b/test/IRGen/inverse_only_existential_metadata.swift
@@ -1,0 +1,12 @@
+// RUN: %target-swift-frontend -emit-ir %s | %FileCheck %s
+
+// Verify that an existential containing ONLY inverse requirements
+// (no parameterized protocols) does NOT emit a call to
+// swift_getExtendedExistentialTypeMetadata, which is unavailable on
+// older OS deployments and breaks iOS 15 / earlier.
+
+// CHECK-LABEL: define {{.*}} @"$s4test3fooyyF"
+// CHECK-NOT: swift_getExtendedExistentialTypeMetadata
+public func foo() {
+    let _: any (Any & ~Copyable & ~Escapable).Type = (Any).self as Any.Type
+}


### PR DESCRIPTION
### Summary

PR #81365 (merged into `main`, shipped as part of Swift 6.2.4 / Xcode 26.3)
made `ExistentialLayout::needsExtendedShape()` return true for existentials
carrying any inverse generic requirement (`~Copyable` / `~Escapable`).
IRGen consumes the same predicate to decide whether to lower a metadata
access through `swift_getExtendedExistentialTypeMetadata`.

That runtime entry-point is only present in the libswiftCore shipped with
iOS 16+ / macOS 14+ / tvOS 16+ / watchOS 9+. On older deployment targets
the symbol is a weak-external; dyld resolves it to NULL and any first call
to the affected accessor crashes with `bl 0x0`.

The classical existential shape can already represent inverse
requirements (the absence of `Copyable` / `Escapable` is encoded via the
existential's invertible-protocols bitmask). The extended representation
is only required for **parameterized** existentials (associated-type
constraints). This patch tightens the IRGen-side predicate to that case,
restoring the pre-#81365 behavior for inverse-only existentials while
keeping parameterized ones on the new path.

Resolves #89402

### What changed

`lib/IRGen/MetadataRequest.cpp`:

- New file-local helper `irgenNeedsExtendedExistentialMetadata(...)` that
  returns true iff the existential layout has parameterized protocols.
- The two call sites previously using `layout.needsExtendedShape()` now
  use the new helper. `ExistentialLayout::needsExtendedShape()` itself is
  left unchanged so AST-side mangling stays bit-identical.

### Test

Added `test/IRGen/inverse_only_existential_metadata.swift`:

```swift
// RUN: %target-swift-frontend -emit-ir -module-name test %s | %FileCheck %s

// CHECK-NOT: call {{.*}}@swift_getExtendedExistentialTypeMetadata

public class Repro {
  public func getString<T>(str: String) -> T? {
    return nil
  }

  public func test() {
    if getString(str: "") != nil { return }
  }
}
```

`T` has no contextual type at the call site, so under PR #81365's
behavior the compiler infers `any Any<~Copyable, ~Escapable>` and IRGen
emits `call @swift_getExtendedExistentialTypeMetadata`. With this patch
the access stays on the classical path and the call disappears from IR.

### Verification

Built a local 6.2.4 toolchain with this patch and confirmed:

```bash
$ swift-frontend -emit-ir -module-name test \
    test/IRGen/inverse_only_existential_metadata.swift \
    | FileCheck test/IRGen/inverse_only_existential_metadata.swift
$ echo $?
0
```

Without the patch, FileCheck fails because IR contains the
`call @swift_getExtendedExistentialTypeMetadata`. End-to-end runtime
verified on iOS 15 simulator: the minimal reproducer from #89402 that
previously crashed with `bl 0x0` inside the type metadata accessor for
`any Any<~Copyable, ~Escapable>` no longer crashes; the accessor now
resolves through `swift_getExistentialTypeMetadata`. `nm -mu` on the
rebuilt binary no longer references
`_swift_getExtendedExistentialTypeMetadata`.

### Backport

This is a regression in 6.2.x (Xcode 26.3 / Swift 6.2.4). I'd like to
file a follow-up backport to `release/6.2` once this lands.

@swift-ci please test