### PR TITLE
[test] Mark watchos-armv7k unsupported for tests emitting IR/objects targeting watchOS >= 9.0

### DIFF
--- a/test/Distributed/distributed_actor_func_param_not_conforming_req_full.swift
+++ b/test/Distributed/distributed_actor_func_param_not_conforming_req_full.swift
@@ -9,6 +9,7 @@
 // rdar://76038845
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
+// UNSUPPORTED: CPU=armv7k && OS=watchos
 
 import Distributed
 

--- a/test/IRGen/prespecialized-metadata/enum-outmodule-1argument-1distinct_use-struct-inmodule.swift
+++ b/test/IRGen/prespecialized-metadata/enum-outmodule-1argument-1distinct_use-struct-inmodule.swift
@@ -6,6 +6,7 @@
 // UNSUPPORTED: CPU=i386 && OS=ios
 // UNSUPPORTED: CPU=armv7 && OS=ios
 // UNSUPPORTED: CPU=armv7s && OS=ios
+// UNSUPPORTED: CPU=armv7k && OS=watchos
 
 //      CHECK: @"$s8Argument03OneA0Oy4main03TheA0VGMN" = linkonce_odr hidden constant <{
 // CHECK-SAME:   ptr,

--- a/test/IRGen/prespecialized-metadata/struct-outmodule-1argument-1distinct_use-struct-inmodule.swift
+++ b/test/IRGen/prespecialized-metadata/struct-outmodule-1argument-1distinct_use-struct-inmodule.swift
@@ -6,6 +6,7 @@
 // UNSUPPORTED: CPU=i386 && OS=ios
 // UNSUPPORTED: CPU=armv7 && OS=ios
 // UNSUPPORTED: CPU=armv7s && OS=ios
+// UNSUPPORTED: CPU=armv7k && OS=watchos
 
 //      CHECK: @"$s8Argument03OneA0Vy4main03TheA0VGMN" = linkonce_odr hidden constant <{
 // CHECK-SAME:   ptr,

--- a/test/IRGen/prespecialized-metadata/struct-outmodule-1argument-1distinct_use-struct-outmodule-othermodule.swift
+++ b/test/IRGen/prespecialized-metadata/struct-outmodule-1argument-1distinct_use-struct-outmodule-othermodule.swift
@@ -7,6 +7,7 @@
 // UNSUPPORTED: CPU=i386 && OS=ios
 // UNSUPPORTED: CPU=armv7 && OS=ios
 // UNSUPPORTED: CPU=armv7s && OS=ios
+// UNSUPPORTED: CPU=armv7k && OS=watchos
 
 //      CHECK: @"$s7Generic11OneArgumentVy0C07IntegerVGMN" = linkonce_odr hidden constant <{
 // CHECK-SAME:   ptr,

--- a/test/IRGen/prespecialized-metadata/struct-outmodule-1argument-1distinct_use-struct-outmodule-samemodule.swift
+++ b/test/IRGen/prespecialized-metadata/struct-outmodule-1argument-1distinct_use-struct-outmodule-samemodule.swift
@@ -6,6 +6,7 @@
 // UNSUPPORTED: CPU=i386 && OS=ios
 // UNSUPPORTED: CPU=armv7 && OS=ios
 // UNSUPPORTED: CPU=armv7s && OS=ios
+// UNSUPPORTED: CPU=armv7k && OS=watchos
 
 //      CHECK: @"$s8Argument03OneA0VyAA7IntegerVGMN" = linkonce_odr hidden constant <{
 // CHECK-SAME:   ptr,

--- a/test/IRGen/prespecialized-metadata/struct-outmodule-2argument-1du-1arg_struct_outmodule_samemodule-2arg_protocol_inmodule.swift
+++ b/test/IRGen/prespecialized-metadata/struct-outmodule-2argument-1du-1arg_struct_outmodule_samemodule-2arg_protocol_inmodule.swift
@@ -6,6 +6,7 @@
 // UNSUPPORTED: CPU=i386 && OS=ios
 // UNSUPPORTED: CPU=armv7 && OS=ios
 // UNSUPPORTED: CPU=armv7s && OS=ios
+// UNSUPPORTED: CPU=armv7k && OS=watchos
 
 //      CHECK: @"$s8Argument03OneA0VyAA7IntegerVGMN" = linkonce_odr hidden constant <{
 // CHECK-SAME:   ptr,

--- a/test/IRGen/prespecialized-metadata/struct-outmodule-2argument-1du-1arg_struct_outmodule_samemodule-2arg_protocol_outmodule_othermodule.swift
+++ b/test/IRGen/prespecialized-metadata/struct-outmodule-2argument-1du-1arg_struct_outmodule_samemodule-2arg_protocol_outmodule_othermodule.swift
@@ -7,6 +7,7 @@
 // UNSUPPORTED: CPU=i386 && OS=ios
 // UNSUPPORTED: CPU=armv7 && OS=ios
 // UNSUPPORTED: CPU=armv7s && OS=ios
+// UNSUPPORTED: CPU=armv7k && OS=watchos
 
 //      CHECK: @"$s6Module11OneArgumentVyAA7IntegerVAeA1P0C0yHCg_GMN" = linkonce_odr hidden constant <{
 // CHECK-SAME:  ptr,

--- a/test/IRGen/prespecialized-metadata/struct-outmodule-2argument-1du-1arg_struct_outmodule_samemodule-2arg_protocol_outmodule_samemodule.swift
+++ b/test/IRGen/prespecialized-metadata/struct-outmodule-2argument-1du-1arg_struct_outmodule_samemodule-2arg_protocol_outmodule_samemodule.swift
@@ -6,6 +6,7 @@
 // UNSUPPORTED: CPU=i386 && OS=ios
 // UNSUPPORTED: CPU=armv7 && OS=ios
 // UNSUPPORTED: CPU=armv7s && OS=ios
+// UNSUPPORTED: CPU=armv7k && OS=watchos
 
 //      CHECK: @"$s8Argument03OneA0VyAA7IntegerVGMN" = linkonce_odr hidden constant <{
 // CHECK-SAME:   ptr,

--- a/test/IRGen/prespecialized-metadata/struct-outmodule-2argument-1du-1arg_struct_outmodule_samemodule-2arg_struct_inmodule.swift
+++ b/test/IRGen/prespecialized-metadata/struct-outmodule-2argument-1du-1arg_struct_outmodule_samemodule-2arg_struct_inmodule.swift
@@ -6,6 +6,7 @@
 // UNSUPPORTED: CPU=i386 && OS=ios
 // UNSUPPORTED: CPU=armv7 && OS=ios
 // UNSUPPORTED: CPU=armv7s && OS=ios
+// UNSUPPORTED: CPU=armv7k && OS=watchos
 
 //      CHECK: @"$s6Module11OneArgumentVyAA7IntegerVAeA1P4mainyHCg_GMN" = linkonce_odr hidden constant <{
 // CHECK-SAME:   ptr,

--- a/test/IRGen/prespecialized-metadata/struct-outmodule-2argument-1du-1arg_struct_outmodule_samemodule-2arg_struct_outmodule_othermodule.swift
+++ b/test/IRGen/prespecialized-metadata/struct-outmodule-2argument-1du-1arg_struct_outmodule_samemodule-2arg_struct_outmodule_othermodule.swift
@@ -7,6 +7,7 @@
 // UNSUPPORTED: CPU=i386 && OS=ios
 // UNSUPPORTED: CPU=armv7 && OS=ios
 // UNSUPPORTED: CPU=armv7s && OS=ios
+// UNSUPPORTED: CPU=armv7k && OS=watchos
 
 //      CHECK: @"$s6Module11TwoArgumentVyAA7IntegerV0C0ADVGMN" = linkonce_odr hidden constant <{
 // CHECK-SAME:   ptr,

--- a/test/IRGen/prespecialized-metadata/struct-outmodule-2argument-1du-1arg_struct_outmodule_samemodule-2arg_struct_outmodule_samemodule.swift
+++ b/test/IRGen/prespecialized-metadata/struct-outmodule-2argument-1du-1arg_struct_outmodule_samemodule-2arg_struct_outmodule_samemodule.swift
@@ -6,6 +6,7 @@
 // UNSUPPORTED: CPU=i386 && OS=ios
 // UNSUPPORTED: CPU=armv7 && OS=ios
 // UNSUPPORTED: CPU=armv7s && OS=ios
+// UNSUPPORTED: CPU=armv7k && OS=watchos
 
 //      CHECK: @"$s8Argument03TwoA0VyAA7IntegerVAEGMN" = linkonce_odr hidden constant <{
 // CHECK-SAME:   ptr,

--- a/test/IRGen/prespecialized-metadata/struct-outmodule-frozen-1argument-1distinct_use-struct-inmodule.swift
+++ b/test/IRGen/prespecialized-metadata/struct-outmodule-frozen-1argument-1distinct_use-struct-inmodule.swift
@@ -6,6 +6,7 @@
 // UNSUPPORTED: CPU=i386 && OS=ios
 // UNSUPPORTED: CPU=armv7 && OS=ios
 // UNSUPPORTED: CPU=armv7s && OS=ios
+// UNSUPPORTED: CPU=armv7k && OS=watchos
 
 //      CHECK: @"$s7Generic11OneArgumentVy4main03TheC0VGMN" = linkonce_odr hidden constant <{
 // CHECK-SAME:   ptr,

--- a/test/IRGen/prespecialized-metadata/struct-outmodule-frozen-1argument-1distinct_use-struct-outmodule-frozen-othermodule.swift
+++ b/test/IRGen/prespecialized-metadata/struct-outmodule-frozen-1argument-1distinct_use-struct-outmodule-frozen-othermodule.swift
@@ -7,6 +7,7 @@
 // UNSUPPORTED: CPU=i386 && OS=ios
 // UNSUPPORTED: CPU=armv7 && OS=ios
 // UNSUPPORTED: CPU=armv7s && OS=ios
+// UNSUPPORTED: CPU=armv7k && OS=watchos
 
 //      CHECK: @"$s7Generic11OneArgumentVy0C07IntegerVGMN" = linkonce_odr hidden constant <{
 // CHECK-SAME:   ptr,

--- a/test/IRGen/prespecialized-metadata/struct-outmodule-frozen-1argument-1distinct_use-struct-outmodule-frozen-samemodule.swift
+++ b/test/IRGen/prespecialized-metadata/struct-outmodule-frozen-1argument-1distinct_use-struct-outmodule-frozen-samemodule.swift
@@ -6,6 +6,7 @@
 // UNSUPPORTED: CPU=i386 && OS=ios
 // UNSUPPORTED: CPU=armv7 && OS=ios
 // UNSUPPORTED: CPU=armv7s && OS=ios
+// UNSUPPORTED: CPU=armv7k && OS=watchos
 
 //      CHECK: @"$s7Generic11OneArgumentVyAA7IntegerVGMN" = linkonce_odr hidden constant <{
 // CHECK-SAME:   ptr,

--- a/test/IRGen/prespecialized-metadata/struct-outmodule-frozen-1argument-1distinct_use-struct-outmodule-resilient-othermodule.swift
+++ b/test/IRGen/prespecialized-metadata/struct-outmodule-frozen-1argument-1distinct_use-struct-outmodule-resilient-othermodule.swift
@@ -7,6 +7,7 @@
 // UNSUPPORTED: CPU=i386 && OS=ios
 // UNSUPPORTED: CPU=armv7 && OS=ios
 // UNSUPPORTED: CPU=armv7s && OS=ios
+// UNSUPPORTED: CPU=armv7k && OS=watchos
 
 // CHECK-NOT: @"$s7Generic11OneArgumentVy0C07IntegerVGMN" =
 

--- a/test/IRGen/prespecialized-metadata/struct-outmodule-frozen-1argument-1distinct_use-struct-outmodule-resilient-samemodule.swift
+++ b/test/IRGen/prespecialized-metadata/struct-outmodule-frozen-1argument-1distinct_use-struct-outmodule-resilient-samemodule.swift
@@ -6,6 +6,7 @@
 // UNSUPPORTED: CPU=i386 && OS=ios
 // UNSUPPORTED: CPU=armv7 && OS=ios
 // UNSUPPORTED: CPU=armv7s && OS=ios
+// UNSUPPORTED: CPU=armv7k && OS=watchos
 
 // CHECK-NOT: @"$s7Generic11OneArgumentVyAA7IntegerVGMN" =
 

--- a/test/IRGen/prespecialized-metadata/struct-outmodule-resilient-1argument-1distinct_use-struct-inmodule.swift
+++ b/test/IRGen/prespecialized-metadata/struct-outmodule-resilient-1argument-1distinct_use-struct-inmodule.swift
@@ -6,6 +6,7 @@
 // UNSUPPORTED: CPU=i386 && OS=ios
 // UNSUPPORTED: CPU=armv7 && OS=ios
 // UNSUPPORTED: CPU=armv7s && OS=ios
+// UNSUPPORTED: CPU=armv7k && OS=watchos
 
 // CHECK-NOT: @"$s7Generic11OneArgumentVy4main03TheC0VGMN" =
 

--- a/test/IRGen/prespecialized-metadata/struct-outmodule-resilient-1argument-1distinct_use-struct-outmodule-frozen-othermodule.swift
+++ b/test/IRGen/prespecialized-metadata/struct-outmodule-resilient-1argument-1distinct_use-struct-outmodule-frozen-othermodule.swift
@@ -7,6 +7,7 @@
 // UNSUPPORTED: CPU=i386 && OS=ios
 // UNSUPPORTED: CPU=armv7 && OS=ios
 // UNSUPPORTED: CPU=armv7s && OS=ios
+// UNSUPPORTED: CPU=armv7k && OS=watchos
 
 // CHECK-NOT: @"$s7Generic11OneArgumentVy0C07IntegerVGMN" =
 

--- a/test/IRGen/prespecialized-metadata/struct-outmodule-resilient-1argument-1distinct_use-struct-outmodule-frozen-samemodule.swift
+++ b/test/IRGen/prespecialized-metadata/struct-outmodule-resilient-1argument-1distinct_use-struct-outmodule-frozen-samemodule.swift
@@ -6,6 +6,7 @@
 // UNSUPPORTED: CPU=i386 && OS=ios
 // UNSUPPORTED: CPU=armv7 && OS=ios
 // UNSUPPORTED: CPU=armv7s && OS=ios
+// UNSUPPORTED: CPU=armv7k && OS=watchos
 
 // CHECK-NOT: @"$s7Generic11OneArgumentVyAA7IntegerVGMN" =
 

--- a/test/IRGen/prespecialized-metadata/struct-outmodule-resilient-1argument-1distinct_use-struct-outmodule-othermodule.swift
+++ b/test/IRGen/prespecialized-metadata/struct-outmodule-resilient-1argument-1distinct_use-struct-outmodule-othermodule.swift
@@ -7,6 +7,7 @@
 // UNSUPPORTED: CPU=i386 && OS=ios
 // UNSUPPORTED: CPU=armv7 && OS=ios
 // UNSUPPORTED: CPU=armv7s && OS=ios
+// UNSUPPORTED: CPU=armv7k && OS=watchos
 
 // CHECK-NOT: @"$s7Generic11OneArgumentVy0C07IntegerVGMN" =
 

--- a/test/IRGen/prespecialized-metadata/struct-outmodule-resilient-1argument-1distinct_use-struct-outmodule-resilient-othermodule.swift
+++ b/test/IRGen/prespecialized-metadata/struct-outmodule-resilient-1argument-1distinct_use-struct-outmodule-resilient-othermodule.swift
@@ -7,6 +7,7 @@
 // UNSUPPORTED: CPU=i386 && OS=ios
 // UNSUPPORTED: CPU=armv7 && OS=ios
 // UNSUPPORTED: CPU=armv7s && OS=ios
+// UNSUPPORTED: CPU=armv7k && OS=watchos
 
 // CHECK-NOT: @"$s7Generic11OneArgumentVy0C07IntegerVGMN" =
 

--- a/test/IRGen/prespecialized-metadata/struct-outmodule-resilient-1argument-1distinct_use-struct-outmodule-resilient-samemodule.swift
+++ b/test/IRGen/prespecialized-metadata/struct-outmodule-resilient-1argument-1distinct_use-struct-outmodule-resilient-samemodule.swift
@@ -6,6 +6,7 @@
 // UNSUPPORTED: CPU=i386 && OS=ios
 // UNSUPPORTED: CPU=armv7 && OS=ios
 // UNSUPPORTED: CPU=armv7s && OS=ios
+// UNSUPPORTED: CPU=armv7k && OS=watchos
 
 // CHECK-NOT: @"$s7Generic11OneArgumentVyAA7IntegerVGMN" =
 

--- a/test/Reflection/noncopyable_field_typeref.swift
+++ b/test/Reflection/noncopyable_field_typeref.swift
@@ -9,6 +9,7 @@
 // rdar://100805115
 // UNSUPPORTED: CPU=arm64e
 // UNSUPPORTED: OS=linux-android
+// UNSUPPORTED: CPU=armv7k && OS=watchos
 
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift -target %module-target-future %s -parse-as-library -emit-module -emit-library -module-name NoncopyableFields -o %t/%target-library-name(NoncopyableFields)

--- a/test/Reflection/typeref_decoding_objc.swift
+++ b/test/Reflection/typeref_decoding_objc.swift
@@ -15,6 +15,7 @@
 
 // rdar://100558042
 // UNSUPPORTED: CPU=arm64e
+// UNSUPPORTED: CPU=armv7k && OS=watchos
 
 // CHECK: FIELDS:
 // CHECK: =======

--- a/test/Reflection/typeref_decoding_packs.swift
+++ b/test/Reflection/typeref_decoding_packs.swift
@@ -10,6 +10,7 @@
 
 // FIXME: rdar://127796117
 // UNSUPPORTED: OS=linux-gnu && CPU=aarch64
+// UNSUPPORTED: CPU=armv7k && OS=watchos
 
 // RUN: %target-build-swift -target %target-swift-5.9-abi-triple %S/Inputs/Packs.swift -parse-as-library -emit-module -emit-library %no-fixup-chains -module-name TypesToReflect -o %t/%target-library-name(TypesToReflect)
 // RUN: %target-build-swift -target %target-swift-5.9-abi-triple %S/Inputs/Packs.swift -emit-module -emit-executable %no-fixup-chains -module-name TypesToReflect -o %t/TypesToReflect

--- a/test/TypeDecoder/variadic_nominal_types.swift
+++ b/test/TypeDecoder/variadic_nominal_types.swift
@@ -1,3 +1,4 @@
+// UNSUPPORTED: CPU=armv7k && OS=watchos
 // RUN: %empty-directory(%t)
 
 // RUN: %target-build-swift -emit-executable %s -g -o %t/variadic_nominal_types -emit-module -target %target-swift-5.9-abi-triple

--- a/validation-test/IRGen/rdar127535274.swift
+++ b/validation-test/IRGen/rdar127535274.swift
@@ -2,6 +2,7 @@
 
 // REQUIRES: swift_feature_LayoutStringValueWitnesses
 // REQUIRES: swift_feature_LayoutStringValueWitnessesInstantiation
+// UNSUPPORTED: CPU=armv7k && OS=watchos
 
 // CHECK: define internal ptr @"$s13rdar1275352744TestVMi"
 // CHECK:  [[METADATA:%.*]] = call ptr @swift_cvw_allocateGenericValueMetadataWithLayoutString

--- a/validation-test/IRGen/rdar147207926.swift
+++ b/validation-test/IRGen/rdar147207926.swift
@@ -1,3 +1,4 @@
+// UNSUPPORTED: CPU=armv7k && OS=watchos
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 


### PR DESCRIPTION
These tests use abi-triple substitutions that resolve to watchOS >= 9.0 on armv7k, which the driver rejects. This was exposed when the test runner switched to the new swift-driver in #85930; the legacy driver did not enforce this check.

