### PR TITLE
[cxx-interop] Define defaulted C++20 comparison operators before emitting them

### DIFF
--- a/lib/IRGen/GenClangDecl.cpp
+++ b/lib/IRGen/GenClangDecl.cpp
@@ -175,7 +175,8 @@ public:
 // In the case of a function, executable code is contained in the function
 // definition. In the case of a variable, executable code can be contained in
 // the initializer of the variable.
-clang::Decl *getDeclWithExecutableCode(clang::Decl *decl) {
+clang::Decl *getDeclWithExecutableCode(clang::Sema &clangSema,
+                                       clang::Decl *decl) {
   if (auto fd = dyn_cast<clang::FunctionDecl>(decl)) {
     const clang::FunctionDecl *definition;
     if (fd->hasBody(definition)) {
@@ -185,6 +186,13 @@ clang::Decl *getDeclWithExecutableCode(clang::Decl *decl) {
     // If this is a potentially not-yet-instantiated template, we might
     // still have a body.
     if (fd->getTemplateInstantiationPattern())
+      return fd;
+
+    // If this is a defaulted comparison op, we will have body once we define
+    // it.
+    if (fd->isDefaulted() && !fd->isDeleted() &&
+        clangSema.getDefaultedComparisonKind(fd) !=
+            clang::Sema::DefaultedComparisonKind::None)
       return fd;
   } else if (auto vd = dyn_cast<clang::VarDecl>(decl)) {
     clang::VarDecl *initializingDecl = vd->getInitializingDeclaration();
@@ -206,9 +214,13 @@ void IRGenModule::emitClangDecl(const clang::Decl *decl) {
   if (!GlobalClangDecls.insert(decl->getCanonicalDecl()).second)
     return;
 
+  ClangModuleLoader *clangModuleLoader = Context.getClangModuleLoader();
+  auto &clangSema = clangModuleLoader->getClangSema();
+
   // Fast path for the case where `decl` doesn't contain executable code, so it
   // can't reference any other declarations that we would need to emit.
-  if (getDeclWithExecutableCode(const_cast<clang::Decl *>(decl)) == nullptr) {
+  if (getDeclWithExecutableCode(clangSema, const_cast<clang::Decl *>(decl)) ==
+      nullptr) {
     ClangCodeGen->HandleTopLevelDecl(
                           clang::DeclGroupRef(const_cast<clang::Decl*>(decl)));
     return;
@@ -241,10 +253,7 @@ void IRGenModule::emitClangDecl(const clang::Decl *decl) {
     stack.push_back(D);
   };
 
-  ClangModuleLoader *clangModuleLoader = Context.getClangModuleLoader();
   ClangDeclFinder refFinder(callback, clangModuleLoader);
-
-  auto &clangSema = clangModuleLoader->getClangSema();
 
   while (!stack.empty()) {
     auto *next = const_cast<clang::Decl *>(stack.pop_back_val());
@@ -265,11 +274,21 @@ void IRGenModule::emitClangDecl(const clang::Decl *decl) {
       // Make sure that this method is part of a class template specialization.
       if (fn->getTemplateInstantiationPattern())
         clangSema.InstantiateFunctionDefinition(fn->getLocation(), fn);
+
+      // Defaulted comparison operators (e.g. `operator== ... = default`) don't
+      // have a body until explicitly defined. Define them here.
+      if (fn->isDefaulted() && !fn->isDeleted() &&
+          !fn->doesThisDeclarationHaveABody()) {
+        auto DCK = clangSema.getDefaultedComparisonKind(fn);
+        if (DCK != clang::Sema::DefaultedComparisonKind::None)
+          clangSema.DefineDefaultedComparison(fn->getLocation(), fn, DCK);
+      }
     }
 
-    if (clang::Decl *executableDecl = getDeclWithExecutableCode(next)) {
-        refFinder.TraverseDecl(executableDecl);
-        next = executableDecl;
+    if (clang::Decl *executableDecl =
+            getDeclWithExecutableCode(clangSema, next)) {
+      refFinder.TraverseDecl(executableDecl);
+      next = executableDecl;
     }
 
     // Unfortunately, implicitly defined CXXDestructorDecls don't have a real

--- a/test/Interop/Cxx/operators/Inputs/defaulted-comparisons.h
+++ b/test/Interop/Cxx/operators/Inputs/defaulted-comparisons.h
@@ -1,0 +1,112 @@
+#ifndef DEFAULTED_COMPARISONS_H
+#define DEFAULTED_COMPARISONS_H
+
+#include <compare>
+
+struct SingleField {
+  int value;
+
+  SingleField(int v) : value(v) {}
+  SingleField(const SingleField &) = default;
+
+  bool operator==(const SingleField &) const = default;
+};
+
+struct MultipleFields {
+  int x;
+  int y;
+
+  MultipleFields(int x, int y) : x(x), y(y) {}
+  MultipleFields(const MultipleFields &) = default;
+
+  bool operator==(const MultipleFields &) const = default;
+};
+
+struct Inner {
+  int value;
+
+  Inner(int v) : value(v) {}
+  Inner(const Inner &) = default;
+
+  bool operator==(const Inner &) const = default;
+};
+
+struct Outer {
+  Inner inner;
+
+  Outer(int v) : inner(v) {}
+  Outer(const Outer &) = default;
+
+  bool operator==(const Outer &) const = default;
+};
+
+struct OuterExplicit {
+  Inner inner;
+
+  OuterExplicit(int v) : inner(v) {}
+  OuterExplicit(const OuterExplicit &) = default;
+
+  bool operator==(const OuterExplicit &other) const {
+    return inner == other.inner;
+  }
+};
+
+struct FriendEq {
+  int value;
+
+  FriendEq(int v) : value(v) {}
+  FriendEq(const FriendEq &) = default;
+
+  friend bool operator==(const FriendEq &, const FriendEq &) = default;
+};
+
+struct WithNotEqual {
+  int value;
+
+  WithNotEqual(int v) : value(v) {}
+  WithNotEqual(const WithNotEqual &) = default;
+
+  bool operator==(const WithNotEqual &) const = default;
+  bool operator!=(const WithNotEqual &) const = default;
+};
+
+struct Spaceship {
+  int value;
+
+  Spaceship(int v) : value(v) {}
+  Spaceship(const Spaceship &) = default;
+
+  auto operator<=>(const Spaceship &) const = default;
+};
+
+struct Base {
+  int x;
+
+  Base(int x) : x(x) {}
+  Base(const Base &) = default;
+
+  bool operator==(const Base &) const = default;
+};
+
+struct Derived : Base {
+  int y;
+
+  Derived(int x, int y) : Base(x), y(y) {}
+  Derived(const Derived &) = default;
+
+  bool operator==(const Derived &) const = default;
+};
+
+template <typename T>
+struct Wrapper {
+  T value;
+
+  Wrapper(T v) : value(v) {}
+  Wrapper(const Wrapper &) = default;
+
+  bool operator==(const Wrapper &) const = default;
+};
+
+using IntWrapper = Wrapper<int>;
+
+#endif

--- a/test/Interop/Cxx/operators/Inputs/module.modulemap
+++ b/test/Interop/Cxx/operators/Inputs/module.modulemap
@@ -3,6 +3,11 @@ module MemberInline {
   requires cplusplus
 }
 
+module DefaultedComparisons {
+  header "defaulted-comparisons.h"
+  requires cplusplus
+}
+
 module MemberOutOfLine {
   header "member-out-of-line.h"
   requires cplusplus

--- a/test/Interop/Cxx/operators/defaulted-comparisons.swift
+++ b/test/Interop/Cxx/operators/defaulted-comparisons.swift
@@ -1,0 +1,95 @@
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -cxx-interoperability-mode=default -Xcc -std=c++20)
+
+// REQUIRES: executable_test
+
+import DefaultedComparisons
+import StdlibUnittest
+
+var OperatorsTestSuite = TestSuite("DefaultedComparisons")
+
+OperatorsTestSuite.test("SingleField.== (single field)") {
+    let a = SingleField(42)
+    let b = SingleField(42)
+    let c = SingleField(123)
+
+    expectTrue(a == b)
+    expectFalse(a == c)
+}
+
+OperatorsTestSuite.test("MultipleFields.== (multiple fields)") {
+    let a = MultipleFields(1, 2)
+    let b = MultipleFields(1, 2)
+    let c = MultipleFields(1, 3)
+    let d = MultipleFields(2, 2)
+
+    expectTrue(a == b)
+    expectFalse(a == c)
+    expectFalse(a == d)
+}
+
+OperatorsTestSuite.test("Outer.== (transitive defaulted inner)") {
+    let a = Outer(1)
+    let b = Outer(1)
+    let c = Outer(2)
+
+    expectTrue(a == b)
+    expectFalse(a == c)
+}
+
+OperatorsTestSuite.test("OuterExplicit.== (explicit outer, defaulted inner)") {
+    let a = OuterExplicit(1)
+    let b = OuterExplicit(1)
+    let c = OuterExplicit(2)
+
+    expectTrue(a == b)
+    expectFalse(a == c)
+}
+
+OperatorsTestSuite.test("FriendEq.== (friend operator)") {
+    let a = FriendEq(42)
+    let b = FriendEq(42)
+    let c = FriendEq(123)
+
+    expectTrue(a == b)
+    expectFalse(a == c)
+}
+
+OperatorsTestSuite.test("WithNotEqual.!= (defaulted != with defaulted ==)") {
+    let a = WithNotEqual(42)
+    let b = WithNotEqual(42)
+    let c = WithNotEqual(123)
+
+    expectFalse(a != b)
+    expectTrue(a != c)
+}
+
+OperatorsTestSuite.test("Spaceship.== (implicit == from <=>)") {
+    let a = Spaceship(42)
+    let b = Spaceship(42)
+    let c = Spaceship(123)
+
+    expectTrue(a == b)
+    expectFalse(a == c)
+}
+
+OperatorsTestSuite.test("Derived.== (defaulted with inheritance)") {
+    let a = Derived(1, 2)
+    let b = Derived(1, 2)
+    let c = Derived(1, 3)
+    let d = Derived(2, 2)
+
+    expectTrue(a == b)
+    expectFalse(a == c)
+    expectFalse(a == d)
+}
+
+OperatorsTestSuite.test("IntWrapper.== (defaulted in class template)") {
+    let a = IntWrapper(42)
+    let b = IntWrapper(42)
+    let c = IntWrapper(123)
+
+    expectTrue(a == b)
+    expectFalse(a == c)
+}
+
+runAllTests()


### PR DESCRIPTION
C++20 defaulted comparison operators don't have body until Clang's Sema synthesizes one. In Clang this happens when the operators are referenced (`Sema::MarkFunctionReferenced`). In Swift's IRGen, we skip marking functions as referenced, and manually define a set of selected functions. This patch adds defining C++20 defaulted comparison operators to this set.

Fixes #88710

rdar://175766744

