### PR TITLE
[Distributed] Support any/some @Resolvable Greeter in dist funcs

### DIFF
--- a/docs/Distributed.md
+++ b/docs/Distributed.md
@@ -186,7 +186,7 @@ In pseudo-Swift, it would look something like this:
 
 **Mangling:** No special mangling, but a special name prefix: `$__resolvableProxyAdapter_$_<base>` as the method is synthesized in Sema/AST.
 
-**Synthesis:** AST, `lib/Sema/CodeSynthesisDistributedActor.cpp`. `createDistributedResolvableProxyAdapterThunkDecl()` builds the `FuncDecl`, `deriveBodyDistributed_resolvableProxyAdapterThunk()` synthesizes its body. Triggered lazily through `GetDistributedResolvableProxyAdapterThunkRequest`, which only returns a non-null thunk when the target has at least one `@Resolvable` `any P` / `some P` parameter or result. SILGen emits it via `SILGenModule::emitDistributedResolvableProxyAdapterThunkForDecl`.
+**Synthesis:** AST, `lib/Sema/CodeSynthesisDistributedActor.cpp`. `createDistributedResolvableProxyAdapterThunkDecl()` builds the `FuncDecl`, `deriveBodyDistributed_resolvableProxyAdapterThunk()` synthesizes its body. Triggered lazily through `GetDistributedRecipientResolvableProxyAdapterThunkRequest`, which only returns a non-null thunk when the target has at least one `@Resolvable` `any P` / `some P` parameter or result. SILGen emits it via `SILGenModule::emitDistributedResolvableProxyAdapterThunkForDecl`.
 
 **Body shape**, in pure Swift, for a method whose parameter and result are both `@Resolvable` existentials:
 

--- a/docs/Distributed.md
+++ b/docs/Distributed.md
@@ -98,7 +98,7 @@ The term "distributed thunk" generally refers specifically to the `...TE` thunk 
 | **distributed thunk** | `...TE` | Caller side; invoke `remoteCall()` when the actor referenced is remote | always (for every distributed target) | "if remote, encode and `system.remoteCall(...)`; else `try await self.<orig>(...)`". This is what user code, witness tables, and protocol dispatch resolve to when calling a `distributed` member. |
 | **distributed-target accessor** | `...TETF` | Recipient side; one per `distributed func`/`var`; IR-only (built by `IRGenModule::emitDistributedTargetAccessor`, no SIL) | always paired with a regular distributed thunk | Exposed to the runtime via `forDistributedTargetAccessor` / accessible-function record. Decodes wire arguments via the system's `decodeNextArgument`, then calls a SIL function (the regular thunk by default, or the resolvable-proxy-adapter thunk when one exists). |
 | **distributed-thunk witness** | `...TWTE` | Caller side; per protocol-conformance witness for a `distributed func` requirement | always (one per witness) | Forwards from the protocol-witness signature to the implementation's distributed thunk. |
-| **resolvable proxy adapter thunk** | `$__resolvableProxyAdapter_$_<base>` (plain old function) | Recipient side; synthesized in AST | only when the target has at least one `any P` / `some P` parameter or result for a `@Resolvable protocol` `P` | Bridges between the wire-level proxy stub `$P` and the user-declared `any P` / `some P`. Body forwards to the user func; for `any P` results, re-wraps via `$P.resolve(id: __result.id, using: self.actorSystem)`. |
+| **resolvable proxy adapter thunk** | `$distributedProxyAdapter$<base>` (plain old function) | Recipient side; synthesized in AST | only when the target has at least one `any P` / `some P` parameter or result for a `@Resolvable protocol` `P` | Bridges between the wire-level proxy stub `$P` and the user-declared `any P` / `some P`. Body forwards to the user func; for `any P` results, re-wraps via `$P.resolve(id: __result.id, using: self.actorSystem)`. |
 
 Wire identity vs. dispatch: the accessor's *symbol* (the one a remote peer's `remoteCall` looks up by mangled name) is always the regular distributed thunk's identity. Whether the accessor body internally calls the regular thunk or the resolvable-proxy-adapter thunk is decided in `IRGenModule::emitDistributedTargetAccessor` and passed through as `dispatchTo`; it is invisible to peers and does not affect the accessor record.
 
@@ -184,7 +184,7 @@ In pseudo-Swift, it would look something like this:
 
 #### Resolvable proxy adapter thunk
 
-**Mangling:** No special mangling, but a special name prefix: `$__resolvableProxyAdapter_$_<base>` as the method is synthesized in Sema/AST.
+**Mangling:** No special mangling, but a special name prefix: `$distributedProxyAdapter$<base>` as the method is synthesized in Sema/AST.
 
 **Synthesis:** AST, `lib/Sema/CodeSynthesisDistributedActor.cpp`. `createDistributedResolvableProxyAdapterThunkDecl()` builds the `FuncDecl`, `deriveBodyDistributed_resolvableProxyAdapterThunk()` synthesizes its body. Triggered lazily through `GetDistributedRecipientResolvableProxyAdapterThunkRequest`, which only returns a non-null thunk when the target has at least one `@Resolvable` `any P` / `some P` parameter or result. SILGen emits it via `SILGenModule::emitDistributedResolvableProxyAdapterThunkForDecl`.
 
@@ -199,7 +199,7 @@ distributed func echoActor(
 The synthesized thunk would be:
 
 ```swift
-func $__resolvableProxyAdapter_$_echoActor(
+func $distributedProxyAdapter$echoActor(
     _ g: $Greeter
 ) async throws -> $Greeter {
   // === Parameter case
@@ -414,7 +414,7 @@ And the recipient side, after the process boundary, decodes the call:
                        ▼
            ┌─────────────────────────────────────────────────┐
            │ resolvable proxy adapter thunk                  │
-           │ ($__resolvableProxyAdapter_$_sendAnyGreeter)   │
+           │ ($distributedProxyAdapter$sendAnyGreeter)       │
            │ // signature: ($Greeter) async throws -> S      │ ! Signature has any/some Greeter 
            │                                                 │   swapped for wire layer '$Greeter'
            │                                                 │ 

--- a/docs/Distributed.md
+++ b/docs/Distributed.md
@@ -1,0 +1,81 @@
+# Distributed module implementation notes
+
+This document is aimed at developers working in the `Distributed` module,
+and serves as a design document of the runtime internals. 
+
+> These are implementation details and are allowed to change without further notice.
+> Please refer to Swift evolution proposals for the public and documented language 
+> aspects of the Distributed module.
+
+## Distributed calls with `any/some P` where `P` is `@Resolvable protocol`
+
+Resolvable protocols are special in the sense that they allow a remote peer to refer to
+an actor on another host without knowing its _actual_ type.
+
+For example, a **server** may be hosting:
+
+```swift
+distributed actor PolishImpl: Greeter {
+   distributed func greet() -> String { "Cześć!" }
+}
+```
+
+and the only shared information between server and client is the protocol:
+
+```swift
+@Resolvable
+protocol Greeter: DistributedActor where ActorSystem == SomeSystem {
+   distributed func greet() -> String 
+}
+```
+
+This allows the client side to resolve a "proxy" (or sometimes called "stub") remote reference, 
+by using the synthesized `$Greeter` type:
+
+```swift
+let remoteRef: any Greeter = try $Greeter.resolve(<id>, using: system)
+```
+
+Next, we want to be able to share these references across remote calls, like this:
+
+```swift
+distributed actor CallCenter {
+  distributed func callMeLater(_ who: any Greeter)
+}
+```
+
+This allows us to implement distributed "callbacks", because we can send a remote peer a reference to an actor that they 
+should invoke at a later point in time. This is a fundamental building block for all kinds of bi-directional communication.
+
+> Note: Of course, there must be some validation if we allow given type to be serialized and cross network boundaries,
+> however these checks are up to the system implementation (in `resolve` and in the transport layer), and not up to the 
+> language layer which only enforces static concepts.
+
+Here, we want to allow callers to pass _any_ distributed actor that conforms to the `Greeter` protocol.
+
+Without special treatment, this is not supported, because the `any Greeter` protocol itself does cannot conform
+to e.g. the `Codable` serialization requirement of a system.
+
+We could also try to send a generic actor, which is technically supported, as long as the system transports the generic type,
+and vets it against an allow list etc:
+
+```swift
+distributed actor CallCenter {
+  distributed func callMeLater(_ who: some Greeter)
+}
+```
+
+Technically this is possible, and the system would just encode the `PolishImpl` type and send it to the remote side.
+
+This hits a problem though: The remote side does not know--nor do we want it to know--about the `PolishImpl` type!
+Therefore trying to receive `PolishImpl` type, on a system which does not have it, would fail because we cannot create actor.
+
+Distributed actors are never _actually_ serialized to begin with. We always serialize their ID, and as 
+long as we can transfer that, we can transfer a "remote reference".
+
+We also know that both server and client share the same `protocol Greeter`, and that they use the same actor system.
+Therefore the availability of the `ActorID` type is guaranteed, as is the availability of the `$Greeter` proxy.
+
+**The solution** is to encode any attempts to "send" an `any/some P` where the `P` as-if we were encoding the `$P`.
+The recipient side shall then also decode it as-if we were receiving an `$P` and this way we never attempt to decode
+unknown distributed actor types on the recipient.

--- a/docs/Distributed.md
+++ b/docs/Distributed.md
@@ -1,16 +1,307 @@
 # Distributed module implementation notes
 
-This document is aimed at developers working in the `Distributed` module,
-and serves as a design document of the runtime internals. 
+This document is aimed at developers working in the `Distributed` module, and serves as a design document of the runtime internals. This is not a user guide; please refer to the [TSPL](https://github.com/swiftlang/swift-book/blob/main/TSPL.docc/LanguageGuide) and [DocC documentation](stdlib/stdlib.docc/Distributed-collection.md) for the user-facing Distributed module documentation.
 
 > These are implementation details and are allowed to change without further notice.
-> Please refer to Swift evolution proposals for the public and documented language 
-> aspects of the Distributed module.
+
+## Remote/Local Distributed Actors
+
+A `distributed actor` _instance_ is either "local", meaning actual actor state resides in the same memory space, or a reference to a "remote instance". Casually, we refer to them to as local or remote actors. The actual instance of an object is always local, but a "remote reference" simply does not have state and serves only as a reference to the actual local instance located on some other process.
+
+Instances created by an actor `init` are always local. Instances returned from `MyActor.resolve(id:using:)` _may_ be remote, if the actor system returned `nil` while resolving the actor id.
+
+The runtime sometimes calls local ones "known to be local" actors; because generally a distributed actor in the type system pretends to not know if it is remote or local -- to enforce the concept of location transparency. The same code can execute regardless if the passed instance was remote or not. This is a core idea of distributed actors -- assuming that an actor _might be remote_ makes you write code as if it always was. Then, passing a local instance in local tests is just the unusual happy path, but all programming is done against the remote "worst" case.
+
+### Memory layout: local vs remote
+
+A remote distributed actor reference is just a normal heap object, but the runtime allocates enough memory for runtime necessary fields, such as`id`, `actorSystem`, `unownedExecutor` for it. This means a remote actor reference always has the same size in memory, regardless how large of a storage an actual local instance might need. User-declared stored properties are never backed by memory on a remote ref. Safety of this model is enforced by the type-system. It is not possible to refer to any local fields unless the actor is _guaranteed_ to be a local instance.
+
+The allocation is done by `swift_distributedActor_remote_initialize`, and can be thought of like this:
+
+```swift
+distributed actor Worker {
+  // synthesized:        let id: ActorID
+  // synthesized:        let actorSystem: System
+  // synthesized:        var unownedExecutor: UnownedSerialExecutor
+
+  var counter: Int = 0  // user-declared stored property
+  var name: String = "" // user-declared stored property
+}
+```
+
+```
+   LOCAL instance                       REMOTE instance ("reference to remote actor")
+
+   ┌──────────────────────────┐         ┌──────────────────────────┐
+   │ HeapObject header        │         │ HeapObject header        │
+   ├──────────────────────────┤         ├──────────────────────────┤
+   │ id:           ActorID    │         │ id:           ActorID    │
+   │ actorSystem:  System     │         │ actorSystem:  System     │
+   ├──────────────────────────┤         ├──────────────────────────┤
+   │ unownedExecutor: ...     │         │ unownedExecutor: ...     │
+   ├──────────────────────────┤         └──────────────────────────┘
+   │ counter:      Int        │          ^^ allocation ends here ^^
+   │ name:         String     │          
+   └──────────────────────────┘          
+```
+
+The runtime may check if an actor is remote, as there is an "is remote" flag set on every distributed actor. This can be checked ar runtime using `__isRemoteActor` / `__isLocalActor`. The user facing API for getting a reference to a local actor–if it indeed was local–is  `actor.whenLocal { isolated actor in ...}`.
+
+## Distributed func calls on remote actors
+
+Any call on a `distributed func` or `distributed var` effectively is redirected to the "distributed thunk" which performs an "if remote, make a remote call" check, like this:
+
+```swift
+distributed actor Worker {
+  // user-declared method
+  distributed func callMe() -> String {
+    return "Hello!"
+  }
+}
+```
+
+The synthesized thunk would be as follows:
+
+```swift
+extension Worker {
+  // synthesized "distributed thunk" -- 'TE' mangling suffix.
+  func callMe() async throws -> String {
+    if _isDistributedRemoteActor(self) {
+      // REMOTE: encode the invocation and pass to remoteCall()
+      var invocation = self.actorSystem.makeInvocationEncoder()
+      try invocation.recordReturnType(String.self)
+      // optional try inv.recordErrorType((any Error).self)
+      try invocation.doneRecording()
+      let target = RemoteCallTarget("$s...callMe...TE") // mangled name
+      return try await self.actorSystem.remoteCall(
+          on: self,
+          target: target,
+          invocation: &invocation,
+          throwing: Never.self,
+          returning: String.self)
+    } else {
+      // LOCAL: just call the user-declared body
+      return try await self.callMe()
+    }
+  }
+}
+```
+
+### Thunks used by Distributed
+
+There is a number of thunks involved in making distributed (remote) calls on distributed actors. Some are on the caller (sender) side, and some on the receiver (recipient) side.
+
+The term "distributed thunk" generally refers specifically to the `...TE` thunk that handles the "if remote, make remote call, otherwise call local method" routing of calls on `distributed func/var`, however the term may be used loosely so it's good to remember all the thunks involved in distributed dispatch:
+
+| Kind | Mangling | Side or purpose | When emitted | Role |
+|---|---|---|---|---|
+| **distributed thunk** | `...TE` | Caller side; invoke `remoteCall()` when the actor referenced is remote | always (for every distributed target) | "if remote, encode and `system.remoteCall(...)`; else `try await self.<orig>(...)`". This is what user code, witness tables, and protocol dispatch resolve to when calling a `distributed` member. |
+| **distributed-target accessor** | `...TETF` | Recipient side; one per `distributed func`/`var`; IR-only (built by `IRGenModule::emitDistributedTargetAccessor`, no SIL) | always paired with a regular distributed thunk | Exposed to the runtime via `forDistributedTargetAccessor` / accessible-function record. Decodes wire arguments via the system's `decodeNextArgument`, then calls a SIL function (the regular thunk by default, or the resolvable-proxy-adapter thunk when one exists). |
+| **distributed-thunk witness** | `...TWTE` | Caller side; per protocol-conformance witness for a `distributed func` requirement | always (one per witness) | Forwards from the protocol-witness signature to the implementation's distributed thunk. |
+| **resolvable proxy adapter thunk** | `$__resolvableProxyAdapter_$_<base>` (plain old function) | Recipient side; synthesized in AST | only when the target has at least one `any P` / `some P` parameter or result for a `@Resolvable protocol` `P` | Bridges between the wire-level proxy stub `$P` and the user-declared `any P` / `some P`. Body forwards to the user func; for `any P` results, re-wraps via `$P.resolve(id: __result.id, using: self.actorSystem)`. |
+
+Wire identity vs. dispatch: the accessor's *symbol* (the one a remote peer's `remoteCall` looks up by mangled name) is always the regular distributed thunk's identity. Whether the accessor body internally calls the regular thunk or the resolvable-proxy-adapter thunk is decided in `IRGenModule::emitDistributedTargetAccessor` and passed through as `dispatchTo`; it is invisible to peers and does not affect the accessor record.
+
+#### "Regular" distributed thunk
+
+**Mangling:** `...TE` on the user-declared `distributed func` / computed-property accessor's mangled name.
+
+**Synthesis:** AST, this is a plain old Swift function which just needs to perform an if/else on the remoteness of the actor.
+
+```swift
+nonisolated @concurrent
+func compute(_ x: Int) async throws -> String {
+  if _isDistributedRemoteActor(self) {
+    // REMOTE branch
+    var inv = self.actorSystem.makeInvocationEncoder()
+    try inv.recordArgument(RemoteCallArgument<Int>(label: nil,
+                                                   name: "x",
+                                                   value: x))
+    try inv.recordReturnType(String.self)
+    try inv.recordErrorType((any Error).self)
+    try inv.doneRecording()
+    let target = RemoteCallTarget("$s4main6WorkerC7computeySSSiYaKFTE")
+    return try await self.actorSystem.remoteCall(
+        on: self,
+        target: target,
+        invocation: &inv,
+        throwing: (any Error).self,
+        returning: String.self)
+  } else {
+    // LOCAL branch
+    return try await self.compute(x) // call the "real" function
+  }
+}
+```
+
+#### Distributed-target accessor
+
+**Mangling:** `...TETF` (the regular thunk's name + `TF`).
+
+**Synthesis:** IR, this accessor is synthesized and emitted in raw IR and is referenced from an `AccessibleFunctionRecord` identified by its mangling. This is what the `executeDistributedTarget` user-facing function locates and invokes when incoming calls are handled. It must obtain and decode values to make the invocation and prepare right generic values to form a correct invocation of the target function.
+
+In pseudo-Swift, it would look something like this:
+
+```swift
+// __accessor__<D: DistributedTargetInvocationDecoder>(
+//   inout D,                       // decoder
+//   UnsafeRawPointer,              // argumentTypes
+//   UnsafeRawPointer,              // resultBuffer
+//   UnsafeRawPointer?,             // generic substitutions
+//   UnsafeRawPointer?,             // witness tables
+//   UInt,                          // num witness tables
+//   <actor>                        // self
+// ) async throws
+{
+  // Validate decoder argument counts etc.
+  // ... 
+  
+  // For each parameter slot i in the SIL signature of the dispatch target:
+  for i in 0 ..< paramCount {
+    var argTy = argumentTypes[i]                             // runtime metadata
+    // For an `any (@Resolvable P)` / `some (@Resolvable P)` parameter, 
+    // override with `$P`'s metadata so `decodeNextArgument` deserializes a `$P` 
+    // instead of an `any P`, because:
+    // - `any P` cannot conform to e.g. Codable
+    // - even if we ferried the underlying type of `PImpl` the recipient may not have 
+    //   this type in-process, so the proxy type is decoded instead -- which allows remote calls, but nothing else.
+    if originalParam[i] is `any/some @Resolvable P` { 
+      argTy = $P.self 
+    }
+    let value = try decoder.decodeNextArgument<argTy>() // pseudo: argTy is runtime metadata
+    arguments.append(value)
+  }
+  let dispatchTo: TargetFn = 
+    if <any @Resolvable subsitutions necessary> {
+      resolvable-proxy-adapter // special"adapter" path
+    } else {
+      target-distributed-thunk // "normal" path
+    }
+  let result = try await dispatchTo(actorSelf, arguments...)
+  resultBuffer.initialize(to: result)
+}
+```
+
+#### Resolvable proxy adapter thunk
+
+**Mangling:** No special mangling, but a special name prefix: `$__resolvableProxyAdapter_$_<base>` as the method is synthesized in Sema/AST.
+
+**Synthesis:** AST, `lib/Sema/CodeSynthesisDistributedActor.cpp`. `createDistributedResolvableProxyAdapterThunkDecl()` builds the `FuncDecl`, `deriveBodyDistributed_resolvableProxyAdapterThunk()` synthesizes its body. Triggered lazily through `GetDistributedResolvableProxyAdapterThunkRequest`, which only returns a non-null thunk when the target has at least one `@Resolvable` `any P` / `some P` parameter or result. SILGen emits it via `SILGenModule::emitDistributedResolvableProxyAdapterThunkForDecl`.
+
+**Body shape**, in pure Swift, for a method whose parameter and result are both `@Resolvable` existentials:
+
+```swift
+distributed func echoActor(
+  _ g: any Greeter           // parameter needs $Greeter substitution
+) async throws -> any Greeter // result needs $Greeter substitution
+```
+
+The synthesized thunk would be:
+
+```swift
+func $__resolvableProxyAdapter_$_echoActor(
+    _ g: $Greeter
+) async throws -> $Greeter {
+  // === Parameter case
+  // $Greeter naturally can be passed to any/some Greeter parameters ($Greeter conforms to Greeter):
+  let __result = try await self.echoActor(g)  // typed as the user's return type (any Greeter)
+  
+  // === Result case
+  // The recipient may not have the specific greeter type in-process,
+  // so we re-resolve it as the process-boundary friendly proxy type:
+  return try $Greeter.resolve(id: __result.id, using: self.actorSystem)
+}
+```
+
+For computed properties the logic is effectively the same.
+
+#### Distributed-thunk witness (`TWTE`)
+
+**Mangling:** `...TWTE`. Standard protocol-witness thunk mangling (`TW`) plus the distributed-thunk suffix (`TE`).
+
+**Synthesis:** SILGen, via the standard witness-thunk path. When SILGen emits the protocol-conformance witness table for a `@Resolvable` protocol's `distributed func` requirement, it generates a thunk whose body just `function_ref`s the implementation's regular distributed thunk. The `TWTE` form exists because the witness's caller can't know whether the underlying type is local or remote, so the call must always go through the distributed thunk's "if remote" check rather than the original implementation directly.
+
+**Body shape**, in pseudo-SIL (real SIL has `try_apply` + error continuation blocks, elided here):
+
+```sil
+sil private [transparent] [distributed_thunk]
+    @$s4main8$GreeterCAA0B0A2aDP07sendAnyB0ySSAaD_pYaKFTWTE :
+    $@convention(witness_method: Greeter) @async
+    (@guaranteed any Greeter, @guaranteed $Greeter)
+    -> (@owned String, @error any Error) {
+bb0(%g : $any Greeter, %self : $$Greeter):
+  %thunk = function_ref @$s4main8$GreeterC07sendAnyB0ySSAA0B0_pYaKFTE  // ...TE on $Greeter
+  // try_apply %thunk(%g, %self) : ...
+  //   normal bb_ok(%result), error bb_err(%err)
+  return %result
+}
+```
+
+### Implementation: the regular distributed thunk
+
+This diagram explains the flow of a remoteCall made on a concrete distributed actor, like this one:
+
+```swift
+distributed actor Worker where ActorSystem == SomeSystem {
+  distributed func compute(_ x: Int) async throws -> String { ... }
+}
+```
+
+```
+    try await actor.compute(42) 
+                       │
+                       ▼
+           ┌────────────────────────────────────────────┐
+           │ regular distributed thunk                  │
+           │ mangling: Worker.compute(_:)...TE          │
+           │                                            │
+           │  if _isDistributedRemoteActor(self):       │
+           │     // REMOTE branch (this runs on caller) │
+           │     var inv = system.makeInvocationEncoder │
+           │     try inv.recordArgument(                │
+           │       RemoteCallArgument<Int>(             │
+           │         label, name, x))                   │
+           │     try inv.recordReturnType(String.self)  │
+           │     try inv.recordErrorType(...)           │
+           │     try inv.doneRecording()                │
+           │     return try await system.remoteCall(... │
+           │                       returning: String.s) │
+           │  else:                                     │
+           │     // LOCAL branch                        │
+           │     return try await self.compute(x)       │  ← original distributed func
+           └────────────────────────────────────────────┘
+                       │
+                       │  Specific ActorSystem's remoteCall does the serialization/networking
+                       ▼
+        ~~~~~~ process boundary ~~~~~~~~~~~~~~~~~~~~~~~~~~
+        
+         try await executeDistributedTarget(on: actor, target: target, ...)
+                       │
+                       ▼
+           ┌─────────────────────────────────────────────┐
+           │ distributed target accessor (...TETF)       │
+           │                                             │
+           │   for each param:                           │
+           │     decoder.decodeNextArgument<Int>()       │
+           │   call the dispatch SIL function (...)      │ ! `dispatchTo` is null here;
+           │                                             │    calls the regular thunk
+           └─────────────────────────────────────────────┘
+                       │
+                       │ calls regular distributed thunk
+                       │ (will usually hit LOCAL branch, since target is likely local)
+                       ▼
+           ┌────────────────────────────────────────────┐
+           │ user-declared distributed func             │
+           │ Worker.compute(_:) async throws -> String  │
+           │   { ... }                                  │
+           └────────────────────────────────────────────┘
+```
+
+Two thunks total: the regular distributed thunk and its accessor. The accessor's `dispatchTo` is null in this case, so it calls the regular distributed thunk directly, which falls into its LOCAL branch (because the recipient holds the actual local actor).
 
 ## Distributed calls with `any/some P` where `P` is `@Resolvable protocol`
 
-Resolvable protocols are special in the sense that they allow a remote peer to refer to
-an actor on another host without knowing its _actual_ type.
+Resolvable protocols are special in the sense that they allow a remote peer to refer to an actor on another host without knowing its _actual_ type.
 
 For example, a **server** may be hosting:
 
@@ -29,8 +320,7 @@ protocol Greeter: DistributedActor where ActorSystem == SomeSystem {
 }
 ```
 
-This allows the client side to resolve a "proxy" (or sometimes called "stub") remote reference, 
-by using the synthesized `$Greeter` type:
+This allows the client side to resolve a "proxy" (or sometimes called "stub") remote reference, by using the synthesized `$Greeter` type:
 
 ```swift
 let remoteRef: any Greeter = try $Greeter.resolve(<id>, using: system)
@@ -44,20 +334,15 @@ distributed actor CallCenter {
 }
 ```
 
-This allows us to implement distributed "callbacks", because we can send a remote peer a reference to an actor that they 
-should invoke at a later point in time. This is a fundamental building block for all kinds of bi-directional communication.
+This allows us to implement distributed "callbacks", because we can send a remote peer a reference to an actor that they should invoke at a later point in time. This is a fundamental building block for all kinds of bi-directional communication.
 
-> Note: Of course, there must be some validation if we allow given type to be serialized and cross network boundaries,
-> however these checks are up to the system implementation (in `resolve` and in the transport layer), and not up to the 
-> language layer which only enforces static concepts.
+> Note: Of course, there must be some validation if we allow given type to be serialized and cross network boundaries, however these checks are up to the system implementation (in `resolve` and in the transport layer), and not up to the language layer which only enforces static concepts.
 
 Here, we want to allow callers to pass _any_ distributed actor that conforms to the `Greeter` protocol.
 
-Without special treatment, this is not supported, because the `any Greeter` protocol itself does cannot conform
-to e.g. the `Codable` serialization requirement of a system.
+Without special treatment, this is not supported, because the `any Greeter` existential cannot itself conform to e.g. the `Codable` serialization requirement of a system.
 
-We could also try to send a generic actor, which is technically supported, as long as the system transports the generic type,
-and vets it against an allow list etc:
+We could also try to send a generic actor, which is technically supported, as long as the system transports the generic type, and vets it against an allow list etc:
 
 ```swift
 distributed actor CallCenter {
@@ -67,15 +352,96 @@ distributed actor CallCenter {
 
 Technically this is possible, and the system would just encode the `PolishImpl` type and send it to the remote side.
 
-This hits a problem though: The remote side does not know--nor do we want it to know--about the `PolishImpl` type!
-Therefore trying to receive `PolishImpl` type, on a system which does not have it, would fail because we cannot create actor.
+This hits a problem though: the remote side does not know, nor do we want it to know, about the `PolishImpl` type! Therefore trying to receive `PolishImpl` type, on a system which does not have it, would fail because we cannot create the actor.
 
-Distributed actors are never _actually_ serialized to begin with. We always serialize their ID, and as 
-long as we can transfer that, we can transfer a "remote reference".
+Distributed actors are never _actually_ serialized to begin with. We always serialize their ID, and as long as we can transfer that, we can transfer a "remote reference".
 
-We also know that both server and client share the same `protocol Greeter`, and that they use the same actor system.
-Therefore the availability of the `ActorID` type is guaranteed, as is the availability of the `$Greeter` proxy.
+We also know that both server and client share the same `protocol Greeter`, and that they use the same actor system. Therefore the availability of the `ActorID` type is guaranteed, as is the availability of the `$Greeter` proxy.
 
-**The solution** is to encode any attempts to "send" an `any/some P` where the `P` as-if we were encoding the `$P`.
-The recipient side shall then also decode it as-if we were receiving an `$P` and this way we never attempt to decode
-unknown distributed actor types on the recipient.
+**The solution** is to encode any attempts to "send" an `any/some P` (where the `P` is a `@Resolvable protocol`) as-if we were encoding the `$P`. The recipient side shall then also decode it as-if we were receiving a `$P`, and this way we never attempt to decode unknown distributed actor types on the recipient.
+
+### Implementation: Proxy $P type substitution
+
+For a `distributed func` (or computed `distributed var`) that uses `@Resolvable` `any P` / `some P` in its parameters or result, the process of forming and receiving a call is slightly more involved:
+
+- the distributed thunk (`...TE`) performs a substitution in the generated remote branch code:
+
+```
+   try await proxy.sendAnyGreeter(local)        // proxy: GreeterImpl
+                       │
+                       ▼
+           ┌─────────────────────────────────────────────┐
+           │ regular distributed thunk                   │
+           │                                             │
+           │  if _isDistributedRemoteActor(self):        │
+           │     // REMOTE branch                        │
+           │     var inv = system.makeInvocationEncoder  │
+           │     try inv.recordArgument(                 │
+           │       RemoteCallArgument<$Greeter>(         │ ! param is encoded as $Greeter
+           │         label, name,                        │   using substitution done in AST
+           │         try $Greeter.resolve(               │   in deriveBodyDistributed_thunk
+           │           id: g.id, using: system)))        │
+           │     ...                                     │
+           │     return try await system.remoteCall(...) │
+           │  else:                                      │
+           │     // LOCAL branch                         │
+           │     return try await self.sendAnyGreeter(g) │
+           └─────────────────────────────────────────────┘
+                       │ // remoteCall(...)
+                       ▼
+    ~~~~~~ process boundary ~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
+
+And the recipient side, after the process boundary, decodes the call:
+
+```
+        ~~~~~~ process boundary ~~~~~~~~~~~~~~~~~~~~~~~~~~
+         try await executeDistributedTarget(on: actor, target: target, ...)
+                       │
+                       ▼
+           ┌─────────────────────────────────────────────┐
+           │ distributed target accessor                 │
+           │                                             │
+           │   for each param:                           │
+           │     decoder.decodeNextArgument<$Greeter>()  │ ! decoded as $Greeter
+           │                                             │ (no knowledge of GreeterImpl on this node)
+           │   << call the [ target | or adapter] >>     │ 
+           └─────────────────────────────────────────────┘
+                       │ 
+           ! ADDITIONAL INDIRECTION !
+                       │ 
+                       │ calls resolvable-proxy-adapter thunk (if present)
+                       ▼
+           ┌─────────────────────────────────────────────────┐
+           │ resolvable proxy adapter thunk                  │
+           │ ($__resolvableProxyAdapter_$_sendAnyGreeter)   │
+           │ // signature: ($Greeter) async throws -> S      │ ! Signature has any/some Greeter 
+           │                                                 │   swapped for wire layer '$Greeter'
+           │                                                 │ 
+           │   try await self.sendAnyGreeter(g)              │ ! $Greeter conforms to Greeter,
+           └─────────────────────────────────────────────────┘   
+                       │
+                       │ calls user-defined 'distributed func'
+                       ▼
+           ┌──────────────────────────────────────────────────────────┐
+           │ GreeterImpl.sendAnyGreeter(_ g: any Greeter) -> String   │
+           │   { return try await g.sayHi() }                         │
+           └──────────────────────────────────────────────────────────┘
+```
+
+Key flow points:
+
+- The regular distributed thunk is what user code calls and is the only thunk emitted when no `@Resolvable` `any/some P` appears in the signature. Its caller-side body already substitutes `$Greeter` for the encoded argument and the `recordReturnType` (in `deriveBodyDistributed_thunk`).
+- The accessor's wire identity (the symbol `remoteCall` looks up via `LinkEntity::forDistributedTargetAccessor`) keeps using the regular thunk's identity. Only the SIL function it dispatches to changes, to the resolvable-proxy-adapter thunk when one exists.
+- The resolvable-proxy-adapter thunk's signature is `$Greeter` end-to-end, so the accessor decodes `$Greeter` directly from the wire and never has to box it back into `any Greeter` in IR. The existential erasure happens via a normal Swift implicit conversion in the thunk body.
+- For a `some P` parameter, the same thunk works: the user func's generic parameter is bound to `$Greeter` for the call, which still satisfies the `Greeter` constraint.
+- For an `any P` *result*, the thunk binds the call's result to `let __result` and emits `return try $Greeter.resolve(id: __result.id, using: self.actorSystem)` so a `$Greeter` ends up on the wire.
+- For a computed `distributed var foo: any P { get }`, the original distributed func is the synthesized `_distributed_get_foo` accessor; the resolvable-proxy-adapter thunk is created off that accessor and reads via `MemberRefExpr(self, storage)`.
+
+#### Target invocation redirect (IRGen)
+
+The distributed-target accessor's *linking identity* is always the regular distributed thunk's name (`LinkEntity::forDistributedTargetAccessor`).
+
+The SIL function the accessor actually dispatches to is selected by `IRGenModule::emitDistributedTargetAccessor` and passed to `DistributedAccessor` / `AccessorTarget` as `dispatchTo`. When the target has a `@Resolvable` parameter or result, the accessor needs to dispatch through the proxy-adapter thunk; we locate it and pass it as `dispatchTo`. When no adapter is needed, `dispatchTo` is `nil` and the accessor calls the regular distributed thunk directly.
+
+There is one residual IRGen-side fixup: `argumentTypesBuffer` on the recipient is filled by `__getParameterTypeInfo` from demangling the regular distributed thunk's mangled name, which still says `any P` / `some P`. Since `any P` does not conform to `Codable`, `decodeNextArgument` would trap if invoked with that metadata. The accessor therefore overrides the runtime-loaded `argumentTy` with a compile-time reference to `$P`'s metadata before calling `decodeNextArgument` (see the `@Resolvable protocol param: override runtime-loaded metadata` block in `decodeArguments`).

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -6506,6 +6506,14 @@ public:
   /// 'distributed' and and nullptr otherwise.
   FuncDecl *getDistributedThunk() const;
 
+  /// Return the 'resolvable proxy adapter' thunk for this computed
+  /// property, if a distributed thunk includes an `any P` / `some P`
+  /// where the P is a distributed `@Resolvable protocol`, and must
+  /// therefore be mapped to the proxy type `$P` that we use as wire
+  /// format to erase the actual implementation type (underlying the
+  /// `any P`), which may not be available on the remote peer.
+  FuncDecl *getDistributedResolvableProxyAdapterThunk() const;
+
   // Implement isa/cast/dyncast/etc.
   static bool classof(const Decl *D) {
     return D->getKind() >= DeclKind::First_AbstractStorageDecl &&
@@ -8142,6 +8150,11 @@ public:
   /// \return the synthesized thunk, or null if the base of the call has
   ///         diagnosed errors during type checking.
   FuncDecl *getDistributedThunk() const;
+
+  /// Get the 'resolvable proxy adapter' thunk used on the recipient side
+  /// of a remote call to bridge between the wire-level `@Resolvable`
+  /// proxy types (`$P`) and the user-facing `any P` / `some P` types.
+  FuncDecl *getDistributedResolvableProxyAdapterThunk() const;
 
   /// Detect whether this function declaration is an unstructured task
   /// factory: a `Task` initializer or one of the `detached`,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6064,9 +6064,24 @@ ERROR(distributed_actor_func_param_resolvable_protocol_no_concrete_actor_system,
 NOTE(distributed_actor_func_param_resolvable_protocol_no_concrete_actor_system_fixit,none,
      "add 'where Self.ActorSystem == ...' to %0", (DeclName))
 ERROR(distributed_actor_func_param_resolvable_protocol_composition_ambiguous,none,
-      "parameter %0 of type %1 in %kindonly2 contains more than one '@Resolvable protocol'; "
-      "Declare new @Resolvable protocol that refines those protocols and use it instead",
+      "parameter %0 of type %1 in %kindonly2 contains more than one '@Resolvable protocol'",
       (Identifier, Type, const AbstractFunctionDecl *))
+ERROR(distributed_actor_func_result_resolvable_protocol_composition_ambiguous,none,
+      "result type %0 of %kindonly1 contains more than one '@Resolvable protocol'",
+      (Type, const ValueDecl *))
+NOTE(distributed_actor_func_resolvable_protocol_composition_ambiguous_note,none,
+     "declare a new '@Resolvable protocol' that refines those protocols and use it instead",
+     ())
+ERROR(distributed_actor_func_result_resolvable_actor_system_mismatch,none,
+      "result type %0 of %kindonly1 must match the enclosing actor's actor system %3",
+      (Type, const ValueDecl *, DeclName, Type))
+NOTE(distributed_actor_func_result_resolvable_actor_system_mismatch_note,none,
+     "'@Resolvable protocol' %0 uses actor system %1",
+     (DeclName, Type))
+ERROR(distributed_actor_func_result_resolvable_protocol_no_concrete_actor_system,none,
+      "result type %0 of %kindonly1 uses '@Resolvable protocol' %2 "
+      "without a concrete 'ActorSystem' constraint",
+      (Type, const ValueDecl *, DeclName))
 ERROR(distributed_actor_target_result_not_codable,none,
       "result type %0 of %kindbase1 does not conform to serialization requirement '%2'",
       (Type, const ValueDecl *, StringRef))

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6050,6 +6050,23 @@ ERROR(distributed_actor_func_param_not_codable,none,
       "parameter %0 of type %1 in %kindonly2 does not conform to "
       "serialization requirement '%3'",
       (Identifier, Type, const AbstractFunctionDecl *, StringRef))
+ERROR(distributed_actor_func_param_resolvable_actor_system_mismatch,none,
+      "parameter %0 of type %1 in %kindonly2 must match the enclosing actor's "
+      "ActorSystem (%5)",
+      (Identifier, Type, const AbstractFunctionDecl *, DeclName, Type, Type))
+NOTE(distributed_actor_func_param_resolvable_actor_system_mismatch_note,none,
+     "'@Resolvable protocol' %0 uses actor system %1",
+     (DeclName, Type))
+ERROR(distributed_actor_func_param_resolvable_protocol_no_concrete_actor_system,none,
+      "parameter %0 of type %1 in %kindonly2 uses '@Resolvable protocol' %3 "
+      "without a concrete 'ActorSystem' constraint",
+      (Identifier, Type, const AbstractFunctionDecl *, DeclName))
+NOTE(distributed_actor_func_param_resolvable_protocol_no_concrete_actor_system_fixit,none,
+     "add 'where Self.ActorSystem == ...' to %0", (DeclName))
+ERROR(distributed_actor_func_param_resolvable_protocol_composition_ambiguous,none,
+      "parameter %0 of type %1 in %kindonly2 contains more than one '@Resolvable protocol'; "
+      "Declare new @Resolvable protocol that refines those protocols and use it instead",
+      (Identifier, Type, const AbstractFunctionDecl *))
 ERROR(distributed_actor_target_result_not_codable,none,
       "result type %0 of %kindbase1 does not conform to serialization requirement '%2'",
       (Type, const ValueDecl *, StringRef))

--- a/include/swift/AST/DistributedDecl.h
+++ b/include/swift/AST/DistributedDecl.h
@@ -30,6 +30,7 @@ class Decl;
 class DeclContext;
 class FuncDecl;
 class NominalTypeDecl;
+class ProtocolDecl;
 
 Type getAssociatedTypeOfDistributedSystemOfActor(DeclContext *actorOrExtension,
                                                  Identifier member);
@@ -67,6 +68,33 @@ Type getDistributedActorSystemType(NominalTypeDecl *actor);
 
 /// Determine the `ID` type for the given actor.
 Type getDistributedActorIDType(NominalTypeDecl *actor);
+
+/// If `P` is a `@Resolvable protocol`, return the generated stub type `$P`.
+NominalTypeDecl *getDistributedActorStub(ProtocolDecl *proto);
+
+/// Synthesize the identifier `$<name>` of the `@Resolvable`-generated stub
+/// peer of the given distributed-actor protocol.
+Identifier getDistributedActorStubName(ProtocolDecl *proto);
+
+/// Reverse lookup result when given a type and looking for the
+/// @Resolvable protocol it was generated from.
+struct ResolvableProtocolMatch {
+  /// The matched protocol P, whose `@Resolvable` macro generated stub type `$P`.
+  ProtocolDecl *proto = nullptr;
+  /// True if the type contains more than one `@Resolvable` protocol --
+  /// callers should diagnose ambiguity.
+  bool isAmbiguous = false;
+
+  explicit operator bool() const { return proto != nullptr; }
+};
+
+/// Walk the given type \p T looking for an existential or opaque
+/// conformance to a @Resolvable protocol.
+ResolvableProtocolMatch findDistributedResolvableExistentialOrOpaqueProtocol(Type T);
+
+/// Get the concrete `ActorSystem` to which protocol \p proto's
+/// `Self.ActorSystem` is constrained.
+Type getResolvableProtocolConcreteActorSystemType(ProtocolDecl *proto);
 
 /// Get specific 'SerializationRequirement' as defined in 'nominal'
 /// type, which must conform to the passed 'protocol' which is expected

--- a/include/swift/AST/DistributedDecl.h
+++ b/include/swift/AST/DistributedDecl.h
@@ -69,15 +69,13 @@ Type getDistributedActorSystemType(NominalTypeDecl *actor);
 /// Determine the `ID` type for the given actor.
 Type getDistributedActorIDType(NominalTypeDecl *actor);
 
-/// If `P` is a `@Resolvable protocol`, return the generated stub type `$P`.
-NominalTypeDecl *getDistributedActorStub(ProtocolDecl *proto);
+/// If `P` is a `@Resolvable protocol`, return the stub type `$P`.
+NominalTypeDecl *getDistributedResolvableProtocolStubDecl(ProtocolDecl *proto);
 
 /// Synthesize the identifier `$<name>` of the `@Resolvable`-generated stub
 /// peer of the given distributed-actor protocol.
-Identifier getDistributedActorStubName(ProtocolDecl *proto);
+Identifier getDistributedResolvableProtocolStubName(ProtocolDecl *proto);
 
-/// Reverse lookup result when given a type and looking for the
-/// @Resolvable protocol it was generated from.
 struct ResolvableProtocolMatch {
   /// The matched protocol P, whose `@Resolvable` macro generated stub type `$P`.
   ProtocolDecl *proto = nullptr;

--- a/include/swift/AST/KnownSDKTypes.def
+++ b/include/swift/AST/KnownSDKTypes.def
@@ -36,8 +36,6 @@ KNOWN_SDK_TYPE_DECL(ObjectiveC, NSObject, ClassDecl, 0)
 KNOWN_SDK_TYPE_DECL(ObjectiveC, Selector, StructDecl, 0)
 KNOWN_SDK_TYPE_DECL(ObjectiveC, ObjCBool, StructDecl, 0)
 
-// TODO(async): These might move to the stdlib module when concurrency is
-// standardized
 KNOWN_SDK_TYPE_DECL(Concurrency, CheckedContinuation, NominalTypeDecl, 2)
 KNOWN_SDK_TYPE_DECL(Concurrency, UnsafeContinuation, NominalTypeDecl, 2)
 KNOWN_SDK_TYPE_DECL(Concurrency, MainActor, NominalTypeDecl, 0)
@@ -53,6 +51,7 @@ KNOWN_SDK_TYPE_DECL(Concurrency, TaskLocal, ClassDecl, 1)
 
 // Distributed actors
 KNOWN_SDK_TYPE_DECL(Distributed, DistributedActor, ProtocolDecl, 0)
+KNOWN_SDK_TYPE_DECL(Distributed, _DistributedActorStub, ProtocolDecl, 0)
 KNOWN_SDK_TYPE_DECL(Distributed, DistributedActorSystem, ProtocolDecl, 0)
 KNOWN_SDK_TYPE_DECL(Distributed, DistributedTargetInvocationEncoder, ProtocolDecl, 0)
 KNOWN_SDK_TYPE_DECL(Distributed, DistributedTargetInvocationDecoder, ProtocolDecl, 0)

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -1566,6 +1566,36 @@ public:
   bool isCached() const { return true; }
 };
 
+/// Obtain the 'resolvable proxy adapter' thunk for the passed-in function.
+///
+/// This thunk is invoked on the recipient side of a remote call: it
+/// receives the wire-level proxy types ('$P') decoded from the
+/// invocation, forwards them into the user-facing 'any P' / 'some P'
+/// types the distributed function expects (an implicit existential
+/// erasure), invokes the function, and re-resolves the result back into
+/// the proxy type so it can be returned over the wire.
+class GetDistributedResolvableProxyAdapterThunkRequest
+    : public SimpleRequest<GetDistributedResolvableProxyAdapterThunkRequest,
+                           FuncDecl *(
+                               llvm::PointerUnion<AbstractStorageDecl *,
+                                                  AbstractFunctionDecl *>),
+                           RequestFlags::Cached> {
+  using Originator =
+      llvm::PointerUnion<AbstractStorageDecl *, AbstractFunctionDecl *>;
+
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  FuncDecl *evaluate(Evaluator &evaluator, Originator originator) const;
+
+public:
+  // Caching
+  bool isCached() const { return true; }
+};
+
 /// Obtain the 'id' property of a 'distributed actor'.
 class GetDistributedActorIDPropertyRequest :
     public SimpleRequest<GetDistributedActorIDPropertyRequest,

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -1574,8 +1574,8 @@ public:
 /// types the distributed function expects (an implicit existential
 /// erasure), invokes the function, and re-resolves the result back into
 /// the proxy type so it can be returned over the wire.
-class GetDistributedResolvableProxyAdapterThunkRequest
-    : public SimpleRequest<GetDistributedResolvableProxyAdapterThunkRequest,
+class GetDistributedRecipientResolvableProxyAdapterThunkRequest
+    : public SimpleRequest<GetDistributedRecipientResolvableProxyAdapterThunkRequest,
                            FuncDecl *(
                                llvm::PointerUnion<AbstractStorageDecl *,
                                                   AbstractFunctionDecl *>),

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -151,7 +151,7 @@ SWIFT_REQUEST(TypeChecker, GetDistributedTargetInvocationResultHandlerOnReturnFu
 SWIFT_REQUEST(TypeChecker, GetDistributedThunkRequest,
               FuncDecl *(llvm::PointerUnion<AbstractStorageDecl *, AbstractFunctionDecl *>),
               Cached, NoLocationInfo)
-SWIFT_REQUEST(TypeChecker, GetDistributedResolvableProxyAdapterThunkRequest,
+SWIFT_REQUEST(TypeChecker, GetDistributedRecipientResolvableProxyAdapterThunkRequest,
               FuncDecl *(llvm::PointerUnion<AbstractStorageDecl *, AbstractFunctionDecl *>),
               Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, GetDistributedActorIDPropertyRequest,

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -151,6 +151,9 @@ SWIFT_REQUEST(TypeChecker, GetDistributedTargetInvocationResultHandlerOnReturnFu
 SWIFT_REQUEST(TypeChecker, GetDistributedThunkRequest,
               FuncDecl *(llvm::PointerUnion<AbstractStorageDecl *, AbstractFunctionDecl *>),
               Cached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, GetDistributedResolvableProxyAdapterThunkRequest,
+              FuncDecl *(llvm::PointerUnion<AbstractStorageDecl *, AbstractFunctionDecl *>),
+              Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, GetDistributedActorIDPropertyRequest,
               VarDecl *(NominalTypeDecl *),
               Cached, NoLocationInfo)

--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -63,6 +63,7 @@ enum IsThunk_t {
   IsSignatureOptimizedThunk,
   IsBackDeployedThunk,
   IsDistributedThunk,
+  IsDistributedProxyAdapterThunk,
 };
 enum IsDynamicallyReplaceable_t {
   IsNotDynamic,
@@ -508,6 +509,7 @@ private:
     case IsReabstractionThunk:
     case IsBackDeployedThunk:
     case IsDistributedThunk:
+    case IsDistributedProxyAdapterThunk:
       thunkCanHaveSubclassScope = false;
       break;
     }

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -1531,6 +1531,7 @@ ProtocolDecl *ASTContext::getProtocol(KnownProtocolKind kind) const {
     M = getLoadedModule(Id_Concurrency);
     break;
   case KnownProtocolKind::DistributedActor:
+  case KnownProtocolKind::DistributedActorStub:
   case KnownProtocolKind::DistributedActorSystem:
   case KnownProtocolKind::DistributedTargetInvocationEncoder:
   case KnownProtocolKind::DistributedTargetInvocationDecoder:

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -4863,7 +4863,7 @@ void ASTMangler::appendDistributedThunk(
     auto M = thunk->getModuleContext();
 
     SmallVector<ValueDecl *, 1> stubClassLookupResults;
-    Context.lookupInModule(M, getDistributedActorStubName(P).str(),
+    Context.lookupInModule(M, getDistributedResolvableProtocolStubName(P).str(),
                            stubClassLookupResults);
 
     assert(stubClassLookupResults.size() <= 1 && "Found multiple distributed stub types!");

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -19,6 +19,7 @@
 #include "swift/AST/ASTVisitor.h"
 #include "swift/AST/AutoDiff.h"
 #include "swift/AST/Decl.h"
+#include "swift/AST/DistributedDecl.h"
 #include "swift/AST/ExistentialLayout.h"
 #include "swift/AST/Expr.h"
 #include "swift/AST/ExtInfo.h"
@@ -4862,7 +4863,8 @@ void ASTMangler::appendDistributedThunk(
     auto M = thunk->getModuleContext();
 
     SmallVector<ValueDecl *, 1> stubClassLookupResults;
-    Context.lookupInModule(M, llvm::Twine("$", P->getNameStr()).str(), stubClassLookupResults);
+    Context.lookupInModule(M, getDistributedActorStubName(P).str(),
+                           stubClassLookupResults);
 
     assert(stubClassLookupResults.size() <= 1 && "Found multiple distributed stub types!");
     if (stubClassLookupResults.size() > 0) {

--- a/lib/AST/DistributedDecl.cpp
+++ b/lib/AST/DistributedDecl.cpp
@@ -211,6 +211,103 @@ Type swift::getDistributedActorIDType(NominalTypeDecl *actor) {
   return getAssociatedTypeOfDistributedSystemOfActor(actor, C.Id_ActorID);
 }
 
+Identifier swift::getDistributedActorStubName(ProtocolDecl *proto) {
+  if (!proto)
+    return Identifier();
+
+  auto &ctx = proto->getASTContext();
+
+  // @Resolvable can only be attached to protocols which inherit from DistributedActor,
+  // so there cannot be a "stub type" for a not-DistributedActor protocol.
+  auto *distributedActorProto = ctx.getDistributedActorDecl();
+  if (!distributedActorProto || !proto->inheritsFrom(distributedActorProto))
+    return Identifier();
+
+  llvm::SmallString<32> buf;
+  return ctx.getIdentifier(
+      llvm::Twine("$", proto->getNameStr()).toStringRef(buf));
+}
+
+NominalTypeDecl *swift::getDistributedActorStub(ProtocolDecl *proto) {
+  if (!proto)
+    return nullptr;
+
+  auto &ctx = proto->getASTContext();
+
+  // Only relevant for protocols that refine `DistributedActor`.
+  auto *distributedActorProto = ctx.getDistributedActorDecl();
+  if (!distributedActorProto)
+    return nullptr;
+  if (!proto->inheritsFrom(distributedActorProto))
+    return nullptr;
+
+  auto *stubProto = ctx.get_DistributedActorStubDecl();
+  if (!stubProto)
+    return nullptr;
+
+  // The `@Resolvable` macro generates a peer `distributed actor $P`
+  // in the same context as the protocol. Look it up by synthesizing the prefixed name.
+  // Users cannot declare $-prefixed names, so we are confident this is the synthesized type.
+  SmallVector<ValueDecl *, 4> results;
+  proto->getModuleContext()->lookupValue(
+    getDistributedActorStubName(proto), NLKind::QualifiedLookup, results);
+
+  for (auto *result : results) {
+    auto *classDecl = dyn_cast<ClassDecl>(result);
+    if (!classDecl || !classDecl->isDistributedActor())
+      continue;
+
+    auto stubConformance =
+        lookupConformance(classDecl->getDeclaredInterfaceType(), stubProto);
+    if (stubConformance.isInvalid())
+      continue;
+
+    return classDecl;
+  }
+
+  return nullptr;
+}
+
+ResolvableProtocolMatch
+swift::findDistributedResolvableExistentialOrOpaqueProtocol(Type T) {
+  ResolvableProtocolMatch match;
+  if (!T)
+    return match;
+
+  auto recordMatch = [&](ProtocolDecl *p) {
+    if (getDistributedActorStub(p)) {
+      if (match.proto && match.proto != p) {
+        match.isAmbiguous = true;
+      } else {
+        match.proto = p;
+      }
+    }
+  };
+
+  if (T->isAnyExistentialType() || T->isConstraintType()) {
+    // Covers `any P` and protocol composition like `any P & Q`.
+    auto layout = T->getExistentialLayout();
+    for (auto *proto : layout.getProtocols())
+      recordMatch(proto);
+  } else if (auto archetype = T->getAs<ArchetypeType>()) {
+    // Covers `some P`, generic params constrained to P.
+    for (auto *proto : archetype->getConformsTo())
+      recordMatch(proto);
+  }
+
+  if (match.isAmbiguous)
+    match.proto = nullptr;
+  return match;
+}
+
+Type swift::getResolvableProtocolConcreteActorSystemType(ProtocolDecl *proto) {
+  auto sysTy = getConcreteReplacementForProtocolActorSystemType(proto);
+  if (!sysTy || sysTy->is<GenericTypeParamType>() ||
+      sysTy->is<ArchetypeType>() || sysTy->hasError())
+    return Type();
+  return sysTy;
+}
+
 static Type getTypeWitnessByName(NominalTypeDecl *type, ProtocolDecl *protocol,
                                  Identifier member) {
   if (!protocol)

--- a/lib/AST/DistributedDecl.cpp
+++ b/lib/AST/DistributedDecl.cpp
@@ -211,7 +211,7 @@ Type swift::getDistributedActorIDType(NominalTypeDecl *actor) {
   return getAssociatedTypeOfDistributedSystemOfActor(actor, C.Id_ActorID);
 }
 
-Identifier swift::getDistributedActorStubName(ProtocolDecl *proto) {
+Identifier swift::getDistributedResolvableProtocolStubName(ProtocolDecl *proto) {
   if (!proto)
     return Identifier();
 
@@ -228,7 +228,7 @@ Identifier swift::getDistributedActorStubName(ProtocolDecl *proto) {
       llvm::Twine("$", proto->getNameStr()).toStringRef(buf));
 }
 
-NominalTypeDecl *swift::getDistributedActorStub(ProtocolDecl *proto) {
+NominalTypeDecl *swift::getDistributedResolvableProtocolStubDecl(ProtocolDecl *proto) {
   if (!proto)
     return nullptr;
 
@@ -250,7 +250,7 @@ NominalTypeDecl *swift::getDistributedActorStub(ProtocolDecl *proto) {
   // Users cannot declare $-prefixed names, so we are confident this is the synthesized type.
   SmallVector<ValueDecl *, 4> results;
   proto->getModuleContext()->lookupValue(
-    getDistributedActorStubName(proto), NLKind::QualifiedLookup, results);
+    getDistributedResolvableProtocolStubName(proto), NLKind::QualifiedLookup, results);
 
   for (auto *result : results) {
     auto *classDecl = dyn_cast<ClassDecl>(result);
@@ -275,7 +275,7 @@ swift::findDistributedResolvableExistentialOrOpaqueProtocol(Type T) {
     return match;
 
   auto recordMatch = [&](ProtocolDecl *p) {
-    if (getDistributedActorStub(p)) {
+    if (getDistributedResolvableProtocolStubDecl(p)) {
       if (match.proto && match.proto != p) {
         match.isAmbiguous = true;
       } else {
@@ -1570,6 +1570,35 @@ AbstractFunctionDecl::getDistributedThunk() const {
   return evaluateOrDefault(
       getASTContext().evaluator,
       GetDistributedThunkRequest{mutableThis},
+      nullptr);
+}
+
+FuncDecl *AbstractStorageDecl::getDistributedResolvableProxyAdapterThunk() const {
+  if (!isDistributed())
+    return nullptr;
+
+  auto mutableThis = const_cast<AbstractStorageDecl *>(this);
+  return evaluateOrDefault(
+      getASTContext().evaluator,
+      GetDistributedResolvableProxyAdapterThunkRequest{mutableThis}, nullptr);
+}
+
+FuncDecl *
+AbstractFunctionDecl::getDistributedResolvableProxyAdapterThunk() const {
+  auto mutableThis = const_cast<AbstractFunctionDecl *>(this);
+
+  // For an accessor, get the Storage (VarDecl) and get the thunk off it.
+  if (auto accessor = dyn_cast<AccessorDecl>(mutableThis)) {
+    auto Storage = accessor->getStorage();
+    return Storage->getDistributedResolvableProxyAdapterThunk();
+  }
+
+  if (!isDistributed())
+    return nullptr;
+
+  return evaluateOrDefault(
+      getASTContext().evaluator,
+      GetDistributedResolvableProxyAdapterThunkRequest{mutableThis},
       nullptr);
 }
 

--- a/lib/AST/DistributedDecl.cpp
+++ b/lib/AST/DistributedDecl.cpp
@@ -1573,14 +1573,15 @@ AbstractFunctionDecl::getDistributedThunk() const {
       nullptr);
 }
 
-FuncDecl *AbstractStorageDecl::getDistributedResolvableProxyAdapterThunk() const {
+FuncDecl *
+AbstractStorageDecl::getDistributedResolvableProxyAdapterThunk() const {
   if (!isDistributed())
     return nullptr;
 
   auto mutableThis = const_cast<AbstractStorageDecl *>(this);
   return evaluateOrDefault(
       getASTContext().evaluator,
-      GetDistributedResolvableProxyAdapterThunkRequest{mutableThis}, nullptr);
+      GetDistributedRecipientResolvableProxyAdapterThunkRequest{mutableThis}, nullptr);
 }
 
 FuncDecl *
@@ -1598,7 +1599,7 @@ AbstractFunctionDecl::getDistributedResolvableProxyAdapterThunk() const {
 
   return evaluateOrDefault(
       getASTContext().evaluator,
-      GetDistributedResolvableProxyAdapterThunkRequest{mutableThis},
+      GetDistributedRecipientResolvableProxyAdapterThunkRequest{mutableThis},
       nullptr);
 }
 

--- a/lib/IRGen/GenDistributed.cpp
+++ b/lib/IRGen/GenDistributed.cpp
@@ -24,6 +24,7 @@
 #include "GenCall.h"
 #include "GenClass.h"
 #include "GenDecl.h"
+#include "GenExistential.h"
 #include "GenMeta.h"
 #include "GenOpaque.h"
 #include "GenPointerAuth.h"
@@ -36,10 +37,13 @@
 #include "LoadableTypeInfo.h"
 #include "ScalarPairTypeInfo.h"
 #include "swift/ABI/MetadataValues.h"
+#include "swift/AST/ConformanceLookup.h"
 #include "swift/AST/DistributedDecl.h"
+#include "swift/AST/ExistentialLayout.h"
 #include "swift/AST/ExtInfo.h"
 #include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/GenericSignature.h"
+#include "swift/AST/ParameterList.h"
 #include "swift/AST/ProtocolConformanceRef.h"
 #include "swift/Basic/Assertions.h"
 #include "swift/IRGen/Linking.h"
@@ -165,6 +169,13 @@ public:
     return cast<AbstractFunctionDecl *>(Target);
   }
 
+  /// The user-declared `distributed func` this accessor was generated for.
+  AbstractFunctionDecl *getAbstractFunctionDecl() const {
+    if (auto *thunk = Target.dyn_cast<SILFunction *>())
+      return thunk->getDeclRef().getAbstractFunctionDecl();
+    return cast<AbstractFunctionDecl *>(Target);
+  }
+
   CanSILFunctionType getType() const { return Type; }
 
   bool isGeneric() const {
@@ -218,8 +229,13 @@ private:
   /// Load an argument value from the given decoder \c decoder
   /// to the given explosion \c arguments. Information describing
   /// the type of argument comes from runtime metadata.
+  ///
+  /// If \p resolvableStub is non-null, the parameter is a `some P` / `any P`
+  /// for a `@Resolvable protocol`, and we must substitute the parameter with
+  /// its correct proxy type `$P`.
   void decodeArgument(unsigned argumentIdx, const ArgumentDecoderInfo &decoder,
                       llvm::Value *argumentType, const SILParameterInfo &param,
+                      NominalTypeDecl *resolvableStub,
                       Explosion &arguments);
 
   void lookupWitnessTables(llvm::Value *value,
@@ -436,10 +452,35 @@ void DistributedAccessor::decodeArguments(const ArgumentDecoderInfo &decoder,
         argumentTypes, Offset(offset), IGM.TypeMetadataPtrTy,
         Alignment(alignment.value()), "arg_type_loc");
 
-    auto *argumentTy = IGF.Builder.CreateLoad(typeLoc, "arg_type");
+    llvm::Value *argumentTy = IGF.Builder.CreateLoad(typeLoc, "arg_type");
+
+    // === @Resolvable protocol param override
+    // If the user-declared parameter type is `some P` / `any P` for a
+    // `@Resolvable protocol`, the wire-level type is the remote proxy stub `$P`.
+    //
+    // Override the runtime-loaded metadata so `decodeNextArgument<$P>()`
+    // deserializes a `$P` which will correctly `$P.resolve(id:using:)`
+    // the serialized actor identity.
+    NominalTypeDecl *replacedParamTy = nullptr;
+    if (auto *funcDecl = Target.getAbstractFunctionDecl()) {
+      auto *params = funcDecl->getParameters();
+      if (i < params->size()) {
+        Type paramTy = params->get(i)->getInterfaceType();
+        if (auto *env = funcDecl->getGenericEnvironment())
+          paramTy = env->mapTypeIntoEnvironment(paramTy);
+
+        if (auto match = findDistributedResolvableExistentialOrOpaqueProtocol(paramTy)) {
+          if (auto *stub = getDistributedActorStub(match.proto)) {
+            replacedParamTy = stub;
+            auto stubTy = stub->getDeclaredInterfaceType()->getCanonicalType();
+            argumentTy = IGF.emitTypeMetadataRef(stubTy);
+          }
+        }
+      }
+    }
 
     // Decode and load argument value using loaded type metadata.
-    decodeArgument(i, decoder, argumentTy, param, arguments);
+    decodeArgument(i, decoder, argumentTy, param, replacedParamTy, arguments);
   }
 }
 
@@ -447,6 +488,7 @@ void DistributedAccessor::decodeArgument(unsigned argumentIdx,
                                          const ArgumentDecoderInfo &decoder,
                                          llvm::Value *argumentType,
                                          const SILParameterInfo &param,
+                                         NominalTypeDecl *resolvableStub,
                                          Explosion &arguments) {
   auto &paramInfo = IGM.getTypeInfo(param.getSILStorageInterfaceType());
   // TODO: `emitLoad*` would actually load value witness table every
@@ -524,6 +566,70 @@ void DistributedAccessor::decodeArgument(unsigned argumentIdx,
     IGF.Builder.emitBlock(contBB);
     // Reset value of the slot back to `null`
     IGF.Builder.CreateStore(nullError, calleeErrorSlot);
+  }
+
+  // === Resolvable existential boxing
+  // If the parameter is a `@Resolvable` resolvable existential (`any P`), the
+  // wire payload was decoded as a `$P` actor but the user function
+  // expects the parameter as an existential `any P`. Wrap the decoded actor
+  // reference into the existential and pass it according to the parameter's
+  // convention.
+  auto userParamSILTy = param.getSILStorageInterfaceType();
+  if (resolvableStub && userParamSILTy.isAnyExistentialType()) {
+    auto stubCanTy =
+        resolvableStub->getDeclaredInterfaceType()->getCanonicalType();
+    auto stubSILTy = SILType::getPrimitiveObjectType(stubCanTy);
+
+    // Load the $P reference from the decode buffer.
+    auto refPtrTy =
+        llvm::PointerType::get(IGM.getLLVMContext(), /*AddrSpace=*/0);
+    auto refSlotPtr = IGF.Builder.CreateBitCast(resultAddr, refPtrTy);
+    Address refSlot(refSlotPtr, IGM.getStorageType(stubSILTy),
+                    IGM.getPointerAlignment());
+    llvm::Value *stubRef = IGF.Builder.CreateLoad(refSlot, "stub_ref");
+
+    // Look up conformances of $P to each protocol carried by the existential.
+    SmallVector<ProtocolConformanceRef, 2> conformances;
+    auto layout = userParamSILTy.getASTType()->getExistentialLayout();
+    for (auto *proto : layout.getProtocols()) {
+      conformances.push_back(lookupConformance(stubCanTy, proto));
+    }
+
+    // Build the existential explosion (instance + witness table pointers).
+    Explosion existExplosion;
+    emitClassExistentialContainer(IGF, existExplosion,
+                                  userParamSILTy.getObjectType(), stubRef,
+                                  stubCanTy, stubSILTy, conformances);
+
+    switch (param.getConvention()) {
+    case ParameterConvention::Direct_Guaranteed:
+    case ParameterConvention::Direct_Unowned:
+    case ParameterConvention::Direct_Owned: {
+      // Pass the exploded existential components (class ref + witness tables) directly.
+      existExplosion.transferInto(arguments, existExplosion.size());
+      return;
+    }
+    case ParameterConvention::Indirect_In_CXX:
+    case ParameterConvention::Indirect_In:
+    case ParameterConvention::Indirect_In_Guaranteed: {
+      // Materialize the existential in a stack buffer and pass its address.
+      auto &existTI = IGM.getTypeInfo(userParamSILTy.getObjectType());
+      auto existAlloca = existTI.allocateStack(
+          IGF, userParamSILTy.getObjectType(), "any_resolvable_param");
+      cast<LoadableTypeInfo>(existTI).initialize(IGF, existExplosion,
+                                                 existAlloca.getAddress(),
+                                                 /*isOutlined=*/false);
+      AllocatedArguments.push_back(existAlloca);
+      arguments.add(existAlloca.getAddress().getAddress());
+      return;
+    }
+    case ParameterConvention::Indirect_Inout:
+    case ParameterConvention::Indirect_InoutAliasable:
+    case ParameterConvention::Pack_Guaranteed:
+    case ParameterConvention::Pack_Owned:
+    case ParameterConvention::Pack_Inout:
+      llvm_unreachable("unsupported convention for resolvable existential");
+    }
   }
 
   switch (param.getConvention()) {

--- a/lib/IRGen/GenDistributed.cpp
+++ b/lib/IRGen/GenDistributed.cpp
@@ -20,7 +20,6 @@
 #include "CallEmission.h"
 #include "Callee.h"
 #include "ClassTypeInfo.h"
-#include "ExtraInhabitants.h"
 #include "GenCall.h"
 #include "GenClass.h"
 #include "GenDecl.h"
@@ -41,8 +40,6 @@
 #include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/GenericSignature.h"
 #include "swift/AST/ParameterList.h"
-#include "swift/AST/ProtocolConformanceRef.h"
-#include "swift/Basic/Assertions.h"
 #include "swift/IRGen/Linking.h"
 #include "swift/SIL/SILFunction.h"
 #include "llvm/IR/DataLayout.h"
@@ -140,20 +137,14 @@ struct ArgumentDecoderInfo {
 
 /// Get the user-declared `distributed func` (or computed-property accessor)
 /// given an arbitrary `AbstractFunctionDecl`. The caller may already hold
-/// the original decl, the synthesized regular distributed thunk, or an
-/// `AccessorDecl` of a distributed property; this helper normalizes all
-/// three to the original distributed declaration.
+/// the original decl, a synthesized 'distributed thunk', or an
+/// `AccessorDecl` of a distributed property; this helper handles returns the
+/// original distributed declaration any of these are attached to.
 ///
 /// Cases:
-///   1. Accessor of a distributed property -- return the accessor itself
-///      (the original "distributed func" view of the property's getter);
-///      `nullptr` if the storage is not distributed.
-///   2. Already the original `distributed func` (not a thunk) -- return it
-///      as-is; `nullptr` if the decl isn't actually distributed.
-///   3. The synthesized regular distributed thunk -- walk back to the
-///      original via name+identity match in the enclosing nominal:
-///      `original->getDistributedThunk() == thunkOrFunc`. `nullptr` if
-///      no matching original is found (shouldn't happen for valid input).
+///   1. Accessor of a `distributed var` computed property - return it,
+///   2. Already the original `distributed func` (not a thunk) - return it,
+///   3. The synthesized 'distributed thunk' - find the original `distributed func`.
 static AbstractFunctionDecl *
 findOriginalDistributedFuncDecl(AbstractFunctionDecl *thunkOrFunc) {
   // Case 1: distributed-property accessor.
@@ -536,14 +527,15 @@ void DistributedAccessor::decodeArguments(const ArgumentDecoderInfo &decoder,
     // === @Resolvable protocol param: override runtime-loaded metadata
     // The wire decoder is invoked with `argumentTy` taken from the runtime's
     // argument-types buffer, which `__getParameterTypeInfo` populates by
-    // demangling the regular distributed thunk's mangled name. That mangling
-    // still names `any P` / `some P`, neither of which conforms to Codable.
+    // demangling the regular distributed thunk's mangled name.
     //
-    // The caller-side thunk records the argument as the proxy stub `$P`
-    // (see `deriveBodyDistributed_thunk` in CodeSynthesisDistributedActor.cpp),
-    // so the value on the wire really is a `$P`. Substitute the wire-supplied
-    // metadata with a compile-time reference to `$P` so `decodeNextArgument<$P>`
-    // sees a Codable-conforming type.
+    // That mangling still names `any P` / `some P`, neither of which can conform
+    // to the SerializationRequirement protocol (e.g. Codable).
+    //
+    // We know the caller erased the encoded value to an `$P` for wire transmission.
+    // Therefore, we need to substitute the type with the proxy type `$P`,
+    // so that the user implemented `decodeNextArgument<$P>` receives
+    // a SerializationRequirement-conforming type (and e.g. can `Decodable::init(from:)` decode it).
     if (auto *thunk = Target.getThunk()) {
       if (auto *funcDecl = findOriginalDistributedFuncDecl(
               thunk->getDeclRef().getAbstractFunctionDecl())) {

--- a/lib/IRGen/GenDistributed.cpp
+++ b/lib/IRGen/GenDistributed.cpp
@@ -169,7 +169,7 @@ findOriginalDistributedFuncDecl(AbstractFunctionDecl *thunkOrFunc) {
 }
 
 /// Recover the user-declared distributed target's 'resolvable proxy
-/// adapter' thunk (`$__resolvableProxyAdapter_$_*`) given the regular
+/// adapter' thunk (`$distributedProxyAdapter$*`) given the regular
 /// distributed thunk decl the accessor was generated for. Returns null
 /// when the target needs no such thunk (i.e. it has no `@Resolvable`
 /// parameter or result).
@@ -436,7 +436,7 @@ void IRGenModule::emitDistributedTargetAccessor(ThunkOrRequirement target) {
 
   // Pick the SIL function to dispatch through. Default = the linked thunk;
   // if the target has a `@Resolvable` 'resolvable proxy adapter' thunk
-  // (`$__resolvableProxyAdapter_$_<base>`), dispatch there instead so the
+  // (`$distributedProxyAdapter$<base>`), dispatch there instead so the
   // accessor speaks `$P` end-to-end and no IR-level existential boxing /
   // result-buffer juggling is needed. The linking identity (the symbol
   // emitted into the accessor record) stays the regular thunk's name.

--- a/lib/IRGen/GenDistributed.cpp
+++ b/lib/IRGen/GenDistributed.cpp
@@ -825,6 +825,40 @@ void DistributedAccessor::emit() {
   auto directResultTy = targetConv.getSILResultType(expansionContext);
   const auto &directResultTI = IGM.getTypeInfo(directResultTy);
 
+  // === `@Resolvable protocol` result
+  // The caller's result buffer is sized for `$P` (one class ref word), but the
+  // target returns `any P` (existential: class ref + witness tables). Allocate
+  // a temp existential-sized buffer, emit the result there, then copy just the
+  // class ref into the real result buffer.
+  bool isResolvableExistResult = false;
+  NominalTypeDecl *resolvableResultStub = nullptr;
+  llvm::Value *resolvableExistTempBuf = nullptr;
+
+  if (auto *funcDecl = Target.getAbstractFunctionDecl()) {
+    if (auto *func = dyn_cast<FuncDecl>(funcDecl)) {
+    Type declaredResult = func->getResultInterfaceType();
+    if (auto *env = func->getGenericEnvironment())
+      declaredResult = env->mapTypeIntoEnvironment(declaredResult);
+    if (!declaredResult->isVoid()) {
+      if (auto match =
+              findDistributedResolvableExistentialOrOpaqueProtocol(declaredResult)) {
+        if (auto *stub = getDistributedActorStub(match.proto)) {
+          isResolvableExistResult = true;
+          resolvableResultStub = stub;
+          auto existAlign = directResultTI.getBestKnownAlignment();
+          auto &existTIFixed = cast<FixedTypeInfo>(directResultTI);
+          auto existSizeVal = IGM.getSize(existTIFixed.getFixedSize());
+          auto tempAlloca =
+              IGF.emitDynamicAlloca(IGM.Int8Ty, existSizeVal, existAlign);
+          resolvableExistTempBuf = IGF.Builder.CreateBitCast(
+              tempAlloca.getAddress().getAddress(), IGM.PtrTy);
+          AllocatedArguments.push_back(tempAlloca);
+        }
+      }
+    }
+    }
+  }
+
   Explosion arguments;
 
   unsigned numAsyncContextParams =
@@ -871,7 +905,8 @@ void DistributedAccessor::emit() {
     // conform to protocols), there could be only a single indirect result type
     // associated with distributed method.
     assert(targetConv.getNumIndirectSILResults() == 1);
-    arguments.add(typedResultBuffer);
+    arguments.add(isResolvableExistResult ? resolvableExistTempBuf
+                                          : typedResultBuffer);
   }
 
   // There is always at least one parameter associated with accessor - `self`
@@ -940,10 +975,35 @@ void DistributedAccessor::emit() {
     // indirect result (e.g. large struct) it result buffer would be passed
     // as an argument.
     {
-      Address resultAddr(typedResultBuffer, directResultTI.getStorageType(),
+      llvm::Value *destBuf =
+          isResolvableExistResult ? resolvableExistTempBuf : typedResultBuffer;
+      Address resultAddr(destBuf, directResultTI.getStorageType(),
                          directResultTI.getBestKnownAlignment());
       emission->emitToMemory(resultAddr, cast<LoadableTypeInfo>(directResultTI),
                              /*isOutlined=*/false);
+    }
+
+    // == `@Resolvable protocol` result: copy class ref from existential temp buf to result buf
+    if (isResolvableExistResult && resolvableExistTempBuf) {
+      auto stubCanTy =
+          resolvableResultStub->getDeclaredInterfaceType()->getCanonicalType();
+      auto stubSILTy = SILType::getPrimitiveObjectType(stubCanTy);
+
+      auto refPtrTy = llvm::PointerType::get(IGM.getLLVMContext(), /*AddrSpace=*/0);
+
+      auto existPtrBitcast =
+          IGF.Builder.CreateBitCast(resolvableExistTempBuf, refPtrTy);
+      llvm::Value *classRef = IGF.Builder.CreateLoad(
+          Address(existPtrBitcast, IGM.getStorageType(stubSILTy),
+                  IGM.getPointerAlignment()),
+          "result_actor_ref");
+
+      auto resultPtrBitcast =
+          IGF.Builder.CreateBitCast(typedResultBuffer, refPtrTy);
+      IGF.Builder.CreateStore(
+          classRef,
+          Address(resultPtrBitcast, IGM.getStorageType(stubSILTy),
+                  IGM.getPointerAlignment()));
     }
 
     // Both accessor and distributed method are always `async throws`

--- a/lib/IRGen/GenDistributed.cpp
+++ b/lib/IRGen/GenDistributed.cpp
@@ -24,7 +24,6 @@
 #include "GenCall.h"
 #include "GenClass.h"
 #include "GenDecl.h"
-#include "GenExistential.h"
 #include "GenMeta.h"
 #include "GenOpaque.h"
 #include "GenPointerAuth.h"
@@ -37,9 +36,7 @@
 #include "LoadableTypeInfo.h"
 #include "ScalarPairTypeInfo.h"
 #include "swift/ABI/MetadataValues.h"
-#include "swift/AST/ConformanceLookup.h"
 #include "swift/AST/DistributedDecl.h"
-#include "swift/AST/ExistentialLayout.h"
 #include "swift/AST/ExtInfo.h"
 #include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/GenericSignature.h"
@@ -141,6 +138,65 @@ struct ArgumentDecoderInfo {
   Callee getCallee() const;
 };
 
+/// Get the user-declared `distributed func` (or computed-property accessor)
+/// given an arbitrary `AbstractFunctionDecl`. The caller may already hold
+/// the original decl, the synthesized regular distributed thunk, or an
+/// `AccessorDecl` of a distributed property; this helper normalizes all
+/// three to the original distributed declaration.
+///
+/// Cases:
+///   1. Accessor of a distributed property -- return the accessor itself
+///      (the original "distributed func" view of the property's getter);
+///      `nullptr` if the storage is not distributed.
+///   2. Already the original `distributed func` (not a thunk) -- return it
+///      as-is; `nullptr` if the decl isn't actually distributed.
+///   3. The synthesized regular distributed thunk -- walk back to the
+///      original via name+identity match in the enclosing nominal:
+///      `original->getDistributedThunk() == thunkOrFunc`. `nullptr` if
+///      no matching original is found (shouldn't happen for valid input).
+static AbstractFunctionDecl *
+findOriginalDistributedFuncDecl(AbstractFunctionDecl *thunkOrFunc) {
+  // Case 1: distributed-property accessor.
+  if (auto *accessor = dyn_cast<AccessorDecl>(thunkOrFunc))
+    return accessor->getStorage()->isDistributed() ? accessor : nullptr;
+
+  // Case 2: already the original distributed func.
+  if (!thunkOrFunc->isDistributedThunk())
+    return thunkOrFunc->isDistributed() ? thunkOrFunc : nullptr;
+
+  // Case 3: synthesized regular distributed thunk; recover its original.
+  if (auto *nominal = thunkOrFunc->getDeclContext()->getSelfNominalTypeDecl()) {
+    for (auto *member : nominal->lookupDirect(thunkOrFunc->getName())) {
+      auto *afd = dyn_cast<AbstractFunctionDecl>(member);
+      if (afd && afd->isDistributed() &&
+          !afd->isDistributedThunk() &&
+          afd->getDistributedThunk() == thunkOrFunc)
+        return afd;
+    }
+  }
+  return nullptr;
+}
+
+/// Recover the user-declared distributed target's 'resolvable proxy
+/// adapter' thunk (`$__resolvableProxyAdapter_$_*`) given the regular
+/// distributed thunk decl the accessor was generated for. Returns null
+/// when the target needs no such thunk (i.e. it has no `@Resolvable`
+/// parameter or result).
+static FuncDecl *
+findResolvableProxyAdapterThunkDecl(AbstractFunctionDecl *thunkOrFunc) {
+  // Computed distributed property: route through the storage (var).
+  if (auto *accessor = dyn_cast<AccessorDecl>(thunkOrFunc)) {
+    auto *storage = accessor->getStorage();
+    if (!storage->isDistributed())
+      return nullptr;
+    return storage->getDistributedResolvableProxyAdapterThunk();
+  }
+
+  auto *original = findOriginalDistributedFuncDecl(thunkOrFunc);
+  return original ? original->getDistributedResolvableProxyAdapterThunk()
+                  : nullptr;
+}
+
 struct AccessorTarget {
 private:
   IRGenFunction &IGF;
@@ -148,14 +204,25 @@ private:
 
   CanSILFunctionType Type;
 
+  /// When non-null, the accessor body dispatches through this SIL function
+  /// instead of \c Target's SIL function. The accessor's record/linking
+  /// name still comes from \c Target. Whoever constructs us decides why
+  /// the dispatch differs (today: `@Resolvable` resolvable-proxy-adapter
+  /// thunk).
+  SILFunction *DispatchTo = nullptr;
+
   mutable std::optional<WitnessMetadata> Witness;
 
 public:
-  AccessorTarget(IRGenFunction &IGF, ThunkOrRequirement target)
-      : IGF(IGF), Target(target) {
+  AccessorTarget(IRGenFunction &IGF, ThunkOrRequirement target,
+                 SILFunction *dispatchTo)
+      : IGF(IGF), Target(target), DispatchTo(dispatchTo) {
     if (auto *thunk = target.dyn_cast<SILFunction *>()) {
-      Type = thunk->getLoweredFunctionType();
+      // Use the dispatch target's lowered type so argument decoding,
+      // result handling, etc. all speak its signature.
+      Type = (DispatchTo ? DispatchTo : thunk)->getLoweredFunctionType();
     } else {
+      assert(!DispatchTo && "no dispatch redirect on protocol requirements");
       auto *requirement = cast<AbstractFunctionDecl *>(target);
       Type = IGF.IGM.getSILTypes().getConstantFunctionType(
           IGF.IGM.getMaximalTypeExpansionContext(),
@@ -169,11 +236,10 @@ public:
     return cast<AbstractFunctionDecl *>(Target);
   }
 
-  /// The user-declared `distributed func` this accessor was generated for.
-  AbstractFunctionDecl *getAbstractFunctionDecl() const {
-    if (auto *thunk = Target.dyn_cast<SILFunction *>())
-      return thunk->getDeclRef().getAbstractFunctionDecl();
-    return cast<AbstractFunctionDecl *>(Target);
+  /// The SIL function the accessor was generated for, when one exists.
+  /// Null when the accessor is being emitted for a protocol requirement.
+  SILFunction *getThunk() const {
+    return Target.dyn_cast<SILFunction *>();
   }
 
   CanSILFunctionType getType() const { return Type; }
@@ -216,6 +282,7 @@ class DistributedAccessor {
 
 public:
   DistributedAccessor(IRGenFunction &IGF, ThunkOrRequirement target,
+                      SILFunction *dispatchTo,
                       CanSILFunctionType accessorTy);
 
   CanSILFunctionType getTargetType() const { return Target.getType(); }
@@ -229,13 +296,8 @@ private:
   /// Load an argument value from the given decoder \c decoder
   /// to the given explosion \c arguments. Information describing
   /// the type of argument comes from runtime metadata.
-  ///
-  /// If \p resolvableStub is non-null, the parameter is a `some P` / `any P`
-  /// for a `@Resolvable protocol`, and we must substitute the parameter with
-  /// its correct proxy type `$P`.
   void decodeArgument(unsigned argumentIdx, const ArgumentDecoderInfo &decoder,
                       llvm::Value *argumentType, const SILParameterInfo &param,
-                      NominalTypeDecl *resolvableStub,
                       Explosion &arguments);
 
   void lookupWitnessTables(llvm::Value *value,
@@ -381,8 +443,23 @@ void IRGenModule::emitDistributedTargetAccessor(ThunkOrRequirement target) {
   if (!f->isDeclaration())
     return;
 
+  // Pick the SIL function to dispatch through. Default = the linked thunk;
+  // if the target has a `@Resolvable` 'resolvable proxy adapter' thunk
+  // (`$__resolvableProxyAdapter_$_<base>`), dispatch there instead so the
+  // accessor speaks `$P` end-to-end and no IR-level existential boxing /
+  // result-buffer juggling is needed. The linking identity (the symbol
+  // emitted into the accessor record) stays the regular thunk's name.
+  SILFunction *dispatchTo = nullptr;
+  if (auto *thunk = target.dyn_cast<SILFunction *>()) {
+    if (auto *afd = thunk->getDeclRef().getAbstractFunctionDecl()) {
+      if (auto *adapter = findResolvableProxyAdapterThunkDecl(afd))
+        dispatchTo = getSILModule().lookUpFunction(SILDeclRef(adapter));
+    }
+  }
+
   IRGenFunction IGF(*this, f);
-  auto accessor = DistributedAccessor(IGF, target, getAccessorType(*this));
+  auto accessor =
+      DistributedAccessor(IGF, target, dispatchTo, getAccessorType(*this));
   accessor.emit();
 
   // Mark the accessor function and its async function pointer as used
@@ -404,8 +481,10 @@ void IRGenModule::emitDistributedTargetAccessor(ThunkOrRequirement target) {
 
 DistributedAccessor::DistributedAccessor(IRGenFunction &IGF,
                                          ThunkOrRequirement target,
+                                         SILFunction *dispatchTo,
                                          CanSILFunctionType accessorTy)
-    : IGM(IGF.IGM), IGF(IGF), Target(IGF, target), AccessorType(accessorTy),
+    : IGM(IGF.IGM), IGF(IGF), Target(IGF, target, dispatchTo),
+      AccessorType(accessorTy),
       AsyncLayout(getAsyncContextLayout(IGM, AccessorType, AccessorType,
                                         SubstitutionMap())) {
   if (IGM.DebugInfo)
@@ -454,33 +533,40 @@ void DistributedAccessor::decodeArguments(const ArgumentDecoderInfo &decoder,
 
     llvm::Value *argumentTy = IGF.Builder.CreateLoad(typeLoc, "arg_type");
 
-    // === @Resolvable protocol param override
-    // If the user-declared parameter type is `some P` / `any P` for a
-    // `@Resolvable protocol`, the wire-level type is the remote proxy stub `$P`.
+    // === @Resolvable protocol param: override runtime-loaded metadata
+    // The wire decoder is invoked with `argumentTy` taken from the runtime's
+    // argument-types buffer, which `__getParameterTypeInfo` populates by
+    // demangling the regular distributed thunk's mangled name. That mangling
+    // still names `any P` / `some P`, neither of which conforms to Codable.
     //
-    // Override the runtime-loaded metadata so `decodeNextArgument<$P>()`
-    // deserializes a `$P` which will correctly `$P.resolve(id:using:)`
-    // the serialized actor identity.
-    NominalTypeDecl *replacedParamTy = nullptr;
-    if (auto *funcDecl = Target.getAbstractFunctionDecl()) {
-      auto *params = funcDecl->getParameters();
-      if (i < params->size()) {
-        Type paramTy = params->get(i)->getInterfaceType();
-        if (auto *env = funcDecl->getGenericEnvironment())
-          paramTy = env->mapTypeIntoEnvironment(paramTy);
+    // The caller-side thunk records the argument as the proxy stub `$P`
+    // (see `deriveBodyDistributed_thunk` in CodeSynthesisDistributedActor.cpp),
+    // so the value on the wire really is a `$P`. Substitute the wire-supplied
+    // metadata with a compile-time reference to `$P` so `decodeNextArgument<$P>`
+    // sees a Codable-conforming type.
+    if (auto *thunk = Target.getThunk()) {
+      if (auto *funcDecl = findOriginalDistributedFuncDecl(
+              thunk->getDeclRef().getAbstractFunctionDecl())) {
+        auto *params = funcDecl->getParameters();
+        if (i < params->size()) {
+          Type origParamTy = params->get(i)->getInterfaceType();
+          if (auto *env = funcDecl->getGenericEnvironment())
+            origParamTy = env->mapTypeIntoEnvironment(origParamTy);
 
-        if (auto match = findDistributedResolvableExistentialOrOpaqueProtocol(paramTy)) {
-          if (auto *stub = getDistributedActorStub(match.proto)) {
-            replacedParamTy = stub;
-            auto stubTy = stub->getDeclaredInterfaceType()->getCanonicalType();
-            argumentTy = IGF.emitTypeMetadataRef(stubTy);
+          if (auto match = findDistributedResolvableExistentialOrOpaqueProtocol(
+                  origParamTy)) {
+            if (auto *stub = getDistributedResolvableProtocolStubDecl(match.proto)) {
+              auto stubTy =
+                  stub->getDeclaredInterfaceType()->getCanonicalType();
+              argumentTy = IGF.emitTypeMetadataRef(stubTy);
+            }
           }
         }
       }
     }
 
     // Decode and load argument value using loaded type metadata.
-    decodeArgument(i, decoder, argumentTy, param, replacedParamTy, arguments);
+    decodeArgument(i, decoder, argumentTy, param, arguments);
   }
 }
 
@@ -488,7 +574,6 @@ void DistributedAccessor::decodeArgument(unsigned argumentIdx,
                                          const ArgumentDecoderInfo &decoder,
                                          llvm::Value *argumentType,
                                          const SILParameterInfo &param,
-                                         NominalTypeDecl *resolvableStub,
                                          Explosion &arguments) {
   auto &paramInfo = IGM.getTypeInfo(param.getSILStorageInterfaceType());
   // TODO: `emitLoad*` would actually load value witness table every
@@ -566,70 +651,6 @@ void DistributedAccessor::decodeArgument(unsigned argumentIdx,
     IGF.Builder.emitBlock(contBB);
     // Reset value of the slot back to `null`
     IGF.Builder.CreateStore(nullError, calleeErrorSlot);
-  }
-
-  // === Resolvable existential boxing
-  // If the parameter is a `@Resolvable` resolvable existential (`any P`), the
-  // wire payload was decoded as a `$P` actor but the user function
-  // expects the parameter as an existential `any P`. Wrap the decoded actor
-  // reference into the existential and pass it according to the parameter's
-  // convention.
-  auto userParamSILTy = param.getSILStorageInterfaceType();
-  if (resolvableStub && userParamSILTy.isAnyExistentialType()) {
-    auto stubCanTy =
-        resolvableStub->getDeclaredInterfaceType()->getCanonicalType();
-    auto stubSILTy = SILType::getPrimitiveObjectType(stubCanTy);
-
-    // Load the $P reference from the decode buffer.
-    auto refPtrTy =
-        llvm::PointerType::get(IGM.getLLVMContext(), /*AddrSpace=*/0);
-    auto refSlotPtr = IGF.Builder.CreateBitCast(resultAddr, refPtrTy);
-    Address refSlot(refSlotPtr, IGM.getStorageType(stubSILTy),
-                    IGM.getPointerAlignment());
-    llvm::Value *stubRef = IGF.Builder.CreateLoad(refSlot, "stub_ref");
-
-    // Look up conformances of $P to each protocol carried by the existential.
-    SmallVector<ProtocolConformanceRef, 2> conformances;
-    auto layout = userParamSILTy.getASTType()->getExistentialLayout();
-    for (auto *proto : layout.getProtocols()) {
-      conformances.push_back(lookupConformance(stubCanTy, proto));
-    }
-
-    // Build the existential explosion (instance + witness table pointers).
-    Explosion existExplosion;
-    emitClassExistentialContainer(IGF, existExplosion,
-                                  userParamSILTy.getObjectType(), stubRef,
-                                  stubCanTy, stubSILTy, conformances);
-
-    switch (param.getConvention()) {
-    case ParameterConvention::Direct_Guaranteed:
-    case ParameterConvention::Direct_Unowned:
-    case ParameterConvention::Direct_Owned: {
-      // Pass the exploded existential components (class ref + witness tables) directly.
-      existExplosion.transferInto(arguments, existExplosion.size());
-      return;
-    }
-    case ParameterConvention::Indirect_In_CXX:
-    case ParameterConvention::Indirect_In:
-    case ParameterConvention::Indirect_In_Guaranteed: {
-      // Materialize the existential in a stack buffer and pass its address.
-      auto &existTI = IGM.getTypeInfo(userParamSILTy.getObjectType());
-      auto existAlloca = existTI.allocateStack(
-          IGF, userParamSILTy.getObjectType(), "any_resolvable_param");
-      cast<LoadableTypeInfo>(existTI).initialize(IGF, existExplosion,
-                                                 existAlloca.getAddress(),
-                                                 /*isOutlined=*/false);
-      AllocatedArguments.push_back(existAlloca);
-      arguments.add(existAlloca.getAddress().getAddress());
-      return;
-    }
-    case ParameterConvention::Indirect_Inout:
-    case ParameterConvention::Indirect_InoutAliasable:
-    case ParameterConvention::Pack_Guaranteed:
-    case ParameterConvention::Pack_Owned:
-    case ParameterConvention::Pack_Inout:
-      llvm_unreachable("unsupported convention for resolvable existential");
-    }
   }
 
   switch (param.getConvention()) {
@@ -825,40 +846,6 @@ void DistributedAccessor::emit() {
   auto directResultTy = targetConv.getSILResultType(expansionContext);
   const auto &directResultTI = IGM.getTypeInfo(directResultTy);
 
-  // === `@Resolvable protocol` result
-  // The caller's result buffer is sized for `$P` (one class ref word), but the
-  // target returns `any P` (existential: class ref + witness tables). Allocate
-  // a temp existential-sized buffer, emit the result there, then copy just the
-  // class ref into the real result buffer.
-  bool isResolvableExistResult = false;
-  NominalTypeDecl *resolvableResultStub = nullptr;
-  llvm::Value *resolvableExistTempBuf = nullptr;
-
-  if (auto *funcDecl = Target.getAbstractFunctionDecl()) {
-    if (auto *func = dyn_cast<FuncDecl>(funcDecl)) {
-    Type declaredResult = func->getResultInterfaceType();
-    if (auto *env = func->getGenericEnvironment())
-      declaredResult = env->mapTypeIntoEnvironment(declaredResult);
-    if (!declaredResult->isVoid()) {
-      if (auto match =
-              findDistributedResolvableExistentialOrOpaqueProtocol(declaredResult)) {
-        if (auto *stub = getDistributedActorStub(match.proto)) {
-          isResolvableExistResult = true;
-          resolvableResultStub = stub;
-          auto existAlign = directResultTI.getBestKnownAlignment();
-          auto &existTIFixed = cast<FixedTypeInfo>(directResultTI);
-          auto existSizeVal = IGM.getSize(existTIFixed.getFixedSize());
-          auto tempAlloca =
-              IGF.emitDynamicAlloca(IGM.Int8Ty, existSizeVal, existAlign);
-          resolvableExistTempBuf = IGF.Builder.CreateBitCast(
-              tempAlloca.getAddress().getAddress(), IGM.PtrTy);
-          AllocatedArguments.push_back(tempAlloca);
-        }
-      }
-    }
-    }
-  }
-
   Explosion arguments;
 
   unsigned numAsyncContextParams =
@@ -905,8 +892,7 @@ void DistributedAccessor::emit() {
     // conform to protocols), there could be only a single indirect result type
     // associated with distributed method.
     assert(targetConv.getNumIndirectSILResults() == 1);
-    arguments.add(isResolvableExistResult ? resolvableExistTempBuf
-                                          : typedResultBuffer);
+    arguments.add(typedResultBuffer);
   }
 
   // There is always at least one parameter associated with accessor - `self`
@@ -975,35 +961,10 @@ void DistributedAccessor::emit() {
     // indirect result (e.g. large struct) it result buffer would be passed
     // as an argument.
     {
-      llvm::Value *destBuf =
-          isResolvableExistResult ? resolvableExistTempBuf : typedResultBuffer;
-      Address resultAddr(destBuf, directResultTI.getStorageType(),
+      Address resultAddr(typedResultBuffer, directResultTI.getStorageType(),
                          directResultTI.getBestKnownAlignment());
       emission->emitToMemory(resultAddr, cast<LoadableTypeInfo>(directResultTI),
                              /*isOutlined=*/false);
-    }
-
-    // == `@Resolvable protocol` result: copy class ref from existential temp buf to result buf
-    if (isResolvableExistResult && resolvableExistTempBuf) {
-      auto stubCanTy =
-          resolvableResultStub->getDeclaredInterfaceType()->getCanonicalType();
-      auto stubSILTy = SILType::getPrimitiveObjectType(stubCanTy);
-
-      auto refPtrTy = llvm::PointerType::get(IGM.getLLVMContext(), /*AddrSpace=*/0);
-
-      auto existPtrBitcast =
-          IGF.Builder.CreateBitCast(resolvableExistTempBuf, refPtrTy);
-      llvm::Value *classRef = IGF.Builder.CreateLoad(
-          Address(existPtrBitcast, IGM.getStorageType(stubSILTy),
-                  IGM.getPointerAlignment()),
-          "result_actor_ref");
-
-      auto resultPtrBitcast =
-          IGF.Builder.CreateBitCast(typedResultBuffer, refPtrTy);
-      IGF.Builder.CreateStore(
-          classRef,
-          Address(resultPtrBitcast, IGM.getStorageType(stubSILTy),
-                  IGM.getPointerAlignment()));
     }
 
     // Both accessor and distributed method are always `async throws`
@@ -1028,15 +989,19 @@ FunctionPointer AccessorTarget::getPointerToTarget(llvm::Value *actorSelf) {
   auto &IGM = IGF.IGM;
 
   if (auto *thunk = Target.dyn_cast<SILFunction *>()) {
-    auto fpKind = classifyFunctionPointerKind(thunk);
+    // Dispatch through the explicit redirect when present (decided by the
+    // caller in `IRGenModule::emitDistributedTargetAccessor`), otherwise
+    // through `Target`'s SIL function directly.
+    SILFunction *callee = DispatchTo ? DispatchTo : thunk;
+    auto fpKind = classifyFunctionPointerKind(callee);
     auto signature = IGM.getSignature(Type, fpKind);
 
     auto *fnPtr = llvm::ConstantExpr::getBitCast(
-        IGM.getAddrOfAsyncFunctionPointer(thunk), IGM.PtrTy);
+        IGM.getAddrOfAsyncFunctionPointer(callee), IGM.PtrTy);
 
     return FunctionPointer::forDirect(
         FunctionPointer::Kind(Type), fnPtr,
-        IGM.getAddrOfSILFunction(thunk, NotForDefinition), signature);
+        IGM.getAddrOfSILFunction(callee, NotForDefinition), signature);
   }
 
   auto *requirementDecl = cast<AbstractFunctionDecl *>(Target);

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -3823,6 +3823,7 @@ void SILFunction::print(SILPrintContext &PrintCtx) const {
     break;
   case IsReabstractionThunk: OS << "[reabstraction_thunk] "; break;
   case IsDistributedThunk: OS << "[distributed_thunk] "; break;
+  case IsDistributedProxyAdapterThunk: OS << "[distributed_proxy_adapter_thunk] "; break;
   }
   if (isDynamicallyReplaceable()) {
     OS << "[dynamically_replacable] ";

--- a/lib/SIL/IR/SILSymbolVisitor.cpp
+++ b/lib/SIL/IR/SILSymbolVisitor.cpp
@@ -507,10 +507,22 @@ public:
       }
     }
 
-    if (auto distributedThunk = AFD->getDistributedThunk()) {
-      auto thunk = SILDeclRef(distributedThunk).asDistributed();
-      addFunction(thunk);
-      addAsyncFunctionPointer(thunk);
+    {
+      // Distributed functions emit a number of thunks that we need to replicate here.
+
+      // Record the 'distributed_thunk'
+      if (auto distributedThunk = AFD->getDistributedThunk()) {
+        auto thunk = SILDeclRef(distributedThunk).asDistributed();
+        addFunction(thunk);
+        addAsyncFunctionPointer(thunk);
+      }
+
+      // Record the recipient-side 'distributed_proxy_adapter_thunk'
+      if (auto adapter = AFD->getDistributedResolvableProxyAdapterThunk()) {
+        auto adapterRef = SILDeclRef(adapter);
+        addFunction(adapterRef);
+        addAsyncFunctionPointer(adapterRef);
+      }
     }
 
     // Add derivative function symbols.

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -756,6 +756,8 @@ static bool parseDeclSILOptional(
       *isThunk = IsBackDeployedThunk;
     else if (isThunk && SP.P.Tok.getText() == "distributed_thunk")
       *isThunk = IsDistributedThunk;
+    else if (isThunk && SP.P.Tok.getText() == "distributed_proxy_adapter_thunk")
+      *isThunk = IsDistributedProxyAdapterThunk;
     else if (isWithoutActuallyEscapingThunk
              && SP.P.Tok.getText() == "without_actually_escaping")
       *isWithoutActuallyEscapingThunk = true;

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1549,6 +1549,11 @@ void SILGenModule::emitAbstractFuncDecl(AbstractFunctionDecl *AFD) {
   }
 
   emitDistributedThunkForDecl(AFD);
+  // If \p AFD has an `any P` / `some P` `@Resolvable protocol` parameter
+  // or result, also emit the recipient-side thunk that adapts between the
+  // wire-level proxy stub `$P` and the user-facing `any P` / `some P`
+  // for the call into \p AFD itself.
+  emitDistributedResolvableProxyAdapterThunkForDecl(AFD);
 
   if (AFD->isBackDeployed()) {
     // Emit the fallback function that will be used when the original function

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1549,6 +1549,7 @@ void SILGenModule::emitAbstractFuncDecl(AbstractFunctionDecl *AFD) {
   }
 
   emitDistributedThunkForDecl(AFD);
+
   // If \p AFD has an `any P` / `some P` `@Resolvable protocol` parameter
   // or result, also emit the recipient-side thunk that adapts between the
   // wire-level proxy stub `$P` and the user-facing `any P` / `some P`

--- a/lib/SILGen/SILGen.h
+++ b/lib/SILGen/SILGen.h
@@ -360,6 +360,11 @@ public:
   /// with it.
   void emitDistributedThunkForDecl(AbstractFunctionDecl * afd);
 
+  /// Emits the distributed 'resolvable proxy adapter' thunk for the decl
+  /// if there is one associated with it.
+  void emitDistributedResolvableProxyAdapterThunkForDecl(
+      AbstractFunctionDecl *afd);
+
   /// Returns true if the given declaration must be referenced through a
   /// back deployment thunk in a context with the given resilience expansion.
   bool requiresBackDeploymentThunk(ValueDecl *decl,

--- a/lib/SILGen/SILGenThunk.cpp
+++ b/lib/SILGen/SILGenThunk.cpp
@@ -136,7 +136,10 @@ void SILGenModule::emitDistributedResolvableProxyAdapterThunkForDecl(
   // is a plain `nonisolated(nonsending)` function, so it is referenced by
   // an ordinary SILDeclRef (not `.asDistributed()`).
   auto ref = SILDeclRef(thunkDecl);
-  emitFunctionDefinition(ref, getFunction(ref, ForDefinition));
+  SILFunction *fn = getFunction(ref, ForDefinition);
+  // Mark the SIL function so DFE keeps it alive.
+  fn->setThunk(IsDistributedProxyAdapterThunk);
+  emitFunctionDefinition(ref, fn);
 }
 
 void SILGenModule::emitBackDeploymentThunk(SILDeclRef thunk) {

--- a/lib/SILGen/SILGenThunk.cpp
+++ b/lib/SILGen/SILGenThunk.cpp
@@ -125,6 +125,20 @@ void SILGenModule::emitDistributedThunkForDecl(
                          getFunction(thunk, ForDefinition));
 }
 
+void SILGenModule::emitDistributedResolvableProxyAdapterThunkForDecl(
+    AbstractFunctionDecl *afd) {
+  FuncDecl *thunkDecl = afd->getDistributedResolvableProxyAdapterThunk();
+
+  if (!thunkDecl || !thunkDecl->hasBody() || thunkDecl->isBodySkipped())
+    return;
+
+  // Unlike the regular distributed thunk, the resolvable proxy adapter thunk
+  // is a plain `nonisolated(nonsending)` function, so it is referenced by
+  // an ordinary SILDeclRef (not `.asDistributed()`).
+  auto ref = SILDeclRef(thunkDecl);
+  emitFunctionDefinition(ref, getFunction(ref, ForDefinition));
+}
+
 void SILGenModule::emitBackDeploymentThunk(SILDeclRef thunk) {
   // Thunks are always emitted by need, so don't need delayed emission.
   assert(thunk.isBackDeploymentThunk() && "back deployment thunks only");

--- a/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
+++ b/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
@@ -113,6 +113,12 @@ class DeadFunctionAndGlobalElimination {
     if (F->isDistributed() || F->isThunk() == IsDistributedThunk)
       return true;
 
+    // The recipient-side `$distributedProxyAdapter$<base>` thunk is
+    // referenced by name from the IRGen-only distributed-target accessor;
+    // it has no SIL caller. DFE must not remove it.
+    if (F->isThunk() == IsDistributedProxyAdapterThunk)
+      return true;
+
     if (F->getDynamicallyReplacedFunction())
       return true;
 

--- a/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
+++ b/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
@@ -1116,6 +1116,7 @@ class MandatoryInlining : public SILModuleTransform {
 
       case IsThunk_t::IsNotThunk:
       case IsThunk_t::IsBackDeployedThunk:
+      case IsThunk_t::IsDistributedProxyAdapterThunk:
         // For correctness, inlining _stdlib_isOSVersionAtLeast() when it is
         // declared transparent is mandatory in the thunks of @backDeployed
         // functions. These thunks will not contain calls to other transparent

--- a/lib/Sema/CodeSynthesisDistributedActor.cpp
+++ b/lib/Sema/CodeSynthesisDistributedActor.cpp
@@ -50,6 +50,39 @@ static void forwardParameters(AbstractFunctionDecl *afd,
   }
 }
 
+static Type getDistributedResolvableProtocolStubType(Type ty) {
+  if (!ty)
+    return Type();
+  auto match = findDistributedResolvableExistentialOrOpaqueProtocol(ty);
+  if (!match)
+    return Type();
+  auto *stub = getDistributedResolvableProtocolStubDecl(match.proto);
+  if (!stub)
+    return Type();
+  auto stubTy = stub->getDeclaredInterfaceType();
+  if (!stubTy || stubTy->hasError())
+    return Type();
+  return stubTy;
+}
+
+/// Build `try $P.resolve(id: <idExpr>, using: <systemExpr>)`.
+static Expr *createDistributedResolveCall(ASTContext &C,
+                                          Type stubInterfaceTy,
+                                          Expr *idExpr,
+                                          Expr *systemExpr) {
+  auto *stubTypeExpr = TypeExpr::createImplicit(stubInterfaceTy, C);
+  DeclName resolveName(C, C.getIdentifier("resolve"),
+                       {C.Id_id, C.getIdentifier("using")});
+  auto *resolveExpr =
+      UnresolvedDotExpr::createImplicit(C, stubTypeExpr, resolveName);
+  auto *resolveArgList = ArgumentList::forImplicitCallTo(
+      DeclNameRef(resolveName), {idExpr, systemExpr}, C);
+  auto *resolveCall =
+      CallExpr::createImplicit(C, resolveExpr, resolveArgList);
+  return TryExpr::createImplicit(C, SourceLoc(), resolveCall);
+}
+
+
 /// Mangle the target thunk in a way that we can look up the appropriate record.
 static llvm::StringRef
 mangleDistributedThunkForAccessorRecordName(
@@ -278,7 +311,7 @@ deriveBodyDistributed_thunk(AbstractFunctionDecl *thunk, void *context) {
         // the recipient without ever knowing the concrete type of the sender.
         if (auto resolvableMatch =
                 findDistributedResolvableExistentialOrOpaqueProtocol(paramTy)) {
-          if (auto *stub = getDistributedActorStub(resolvableMatch.proto)) {
+          if (auto *stub = getDistributedResolvableProtocolStubDecl(resolvableMatch.proto)) {
             auto stubInterfaceTy = stub->getDeclaredInterfaceType();
             if (stubInterfaceTy && !stubInterfaceTy->hasError()) {
               // Important! We replace the type of the parameter with `$P`
@@ -293,29 +326,14 @@ deriveBodyDistributed_thunk(AbstractFunctionDecl *thunk, void *context) {
                 auto *paramIdExpr = UnresolvedDotExpr::createImplicit(
                     C, argumentDeclRefExpr, C.Id_id);
 
-                // $P (as a metatype expression).
-                auto *stubTypeExpr = TypeExpr::createImplicit(stubInterfaceTy, C);
-
-                // $P.resolve(...)
-                DeclName resolveName(C, C.getIdentifier("resolve"),
-                                     {C.Id_id, C.getIdentifier("using")});
-                auto *resolveExpr = UnresolvedDotExpr::createImplicit(
-                    C, stubTypeExpr, resolveName);
-
                 // Get the `system` from the actor that the call is being made on.
                 auto *systemRef = new (C) DeclRefExpr(
                     ConcreteDeclRef(systemVar), dloc, implicit);
 
-                // $P.resolve(id: paramRef.id, using: system)
+                // try $P.resolve(id: paramRef.id, using: system)
                 // We have enforced in sema that the system must be compatible.
-                auto *resolveArgList = ArgumentList::forImplicitCallTo(
-                    DeclNameRef(resolveName), {paramIdExpr, systemRef}, C);
-                auto *resolveCall =
-                    CallExpr::createImplicit(C, resolveExpr, resolveArgList);
-
-                // try <resolve>
-                argumentDeclRefExpr =
-                    TryExpr::createImplicit(C, sloc, resolveCall);
+                argumentDeclRefExpr = createDistributedResolveCall(
+                    C, stubInterfaceTy, paramIdExpr, systemRef);
               }
             }
           }
@@ -406,14 +424,8 @@ deriveBodyDistributed_thunk(AbstractFunctionDecl *thunk, void *context) {
     auto resultType = thunk->mapTypeIntoEnvironment(func->getResultInterfaceType());
 
     // --- `@Resolvable protocol` result: substitute `$P` for `any/some P`
-    if (auto resolvableMatch =
-            findDistributedResolvableExistentialOrOpaqueProtocol(resultType)) {
-      if (auto *stub = getDistributedActorStub(resolvableMatch.proto)) {
-        auto stubInterfaceTy = stub->getDeclaredInterfaceType();
-        if (stubInterfaceTy && !stubInterfaceTy->hasError())
-          resultType = thunk->mapTypeIntoEnvironment(stubInterfaceTy);
-      }
-    }
+    if (Type stubTy = getDistributedResolvableProtocolStubType(resultType))
+      resultType = thunk->mapTypeIntoEnvironment(stubTy);
 
     auto *metaTypeRef = TypeExpr::createImplicit(resultType, C);
     auto *resultTypeExpr =
@@ -554,14 +566,8 @@ deriveBodyDistributed_thunk(AbstractFunctionDecl *thunk, void *context) {
           func->mapTypeIntoEnvironment(func->getResultInterfaceType());
 
       // --- `@Resolvable protocol` result: substitute `$P` for `any/some P`
-      if (auto resolvableMatch =
-              findDistributedResolvableExistentialOrOpaqueProtocol(resultType)) {
-        if (auto *stub = getDistributedActorStub(resolvableMatch.proto)) {
-          auto stubInterfaceTy = stub->getDeclaredInterfaceType();
-          if (stubInterfaceTy && !stubInterfaceTy->hasError())
-            resultType = func->mapTypeIntoEnvironment(stubInterfaceTy);
-        }
-      }
+      if (Type stubTy = getDistributedResolvableProtocolStubType(resultType))
+        resultType = func->mapTypeIntoEnvironment(stubTy);
 
       auto *metaTypeRef = TypeExpr::createImplicit(resultType, C);
       auto *resultTypeExpr =
@@ -696,6 +702,277 @@ static FuncDecl *createDistributedThunkFunction(FuncDecl *func) {
     thunk->setBodySynthesizer(deriveBodyDistributed_thunk, func);
 
   return thunk;
+}
+
+// ==== ----------------------------------------------------------------------
+// MARK: 'resolvable proxy adapter' thunk synthesis
+
+/// Synthesize the body of the 'resolvable proxy adapter' thunk.
+///
+/// This thunk runs on the *recipient* side of a remote call. Its parameters
+/// and result are the wire-level proxy stub types (`$P`), whereas the
+/// user-declared distributed function deals in `any P` / `some P`. This thunk:
+///
+///   1. forwards the proxy parameters to the user function -- a `$P` is
+///      implicitly erased to `any P` (it conforms to `P`), or bound to a
+///      `some P` generic parameter directly;
+///   2. invokes the user-declared distributed function on the local actor;
+///   3. if the result is a `@Resolvable` `any P` / `some P`, re-creates a
+///      proxy `$P` from the returned actor's identity, so a `$P` can be
+///      returned over the wire.
+///
+/// For example, given `distributed func echo(_ g: any P) -> any P`, the
+/// synthesized body is roughly:
+///
+///   nonisolated func echo(_ g: $P) async throws -> $P {
+///     let __result = try await self.echo(g)
+///     return try $P.resolve(id: __result.id, using: self.actorSystem)
+///   }
+static std::pair<BraceStmt *, bool>
+deriveBodyDistributed_resolvableProxyAdapterThunk(AbstractFunctionDecl *thunk,
+                                                  void *context) {
+  auto implicit = true;
+  ASTContext &C = thunk->getASTContext();
+
+  const SourceLoc sloc = SourceLoc();
+  const DeclNameLoc dloc = DeclNameLoc();
+
+  auto func = static_cast<FuncDecl *>(context);
+  auto funcDC = func->getDeclContext();
+  assert(funcDC->getSelfNominalTypeDecl() &&
+         funcDC->getSelfNominalTypeDecl()->isDistributedActor() &&
+         "Distributed function must be part of distributed actor");
+
+  auto selfDecl = thunk->getImplicitSelfDecl();
+  selfDecl->addAttribute(new (C) KnownToBeLocalAttr(implicit));
+
+  Type returnTy = func->getResultInterfaceType();
+  auto isVoidReturn = returnTy->isVoid();
+
+  // --- Build the call to the user-declared distributed function:
+  //       try await self.<func>(<forwarded args>)
+  //
+  // The adapter thunk's `@Resolvable` parameters are typed as the proxy
+  // `$P`. Passing a `$P` where the function expects `any P` is an implicit
+  // existential erasure (`$P` conforms to `P`); passing it where the
+  // function expects `some P` binds that generic parameter to the concrete
+  // `$P`. Either way the forward is well-typed.
+  Expr *call;
+  {
+    auto selfRefExpr = new (C) DeclRefExpr(selfDecl, dloc, implicit);
+
+    if (auto accessor = dyn_cast<AccessorDecl>(func)) {
+      auto var = accessor->getStorage();
+      Expr *localPropertyAccess = new (C) MemberRefExpr(
+          selfRefExpr, sloc, ConcreteDeclRef(var), dloc, implicit);
+      localPropertyAccess =
+          AwaitExpr::createImplicit(C, sloc, localPropertyAccess);
+      if (accessor->hasThrows())
+        localPropertyAccess =
+            TryExpr::createImplicit(C, sloc, localPropertyAccess);
+      call = localPropertyAccess;
+    } else {
+      SmallVector<Expr *, 4> forwardingParams;
+      forwardParameters(thunk, forwardingParams);
+      auto funcRef = UnresolvedDeclRefExpr::createImplicit(C, func->getName());
+      auto forwardingArgList = ArgumentList::forImplicitCallTo(
+          funcRef->getName(), forwardingParams, C);
+      auto funcDeclRef =
+          UnresolvedDotExpr::createImplicit(C, selfRefExpr, func->getBaseName());
+
+      Expr *localFuncCall =
+          CallExpr::createImplicit(C, funcDeclRef, forwardingArgList);
+      localFuncCall = AwaitExpr::createImplicit(C, sloc, localFuncCall);
+      if (func->hasThrows())
+        localFuncCall = TryExpr::createImplicit(C, sloc, localFuncCall);
+      call = localFuncCall;
+    }
+  }
+
+  // --- Does the result need to be adapted back to a proxy `$P`?
+  Type resultType =
+      thunk->mapTypeIntoEnvironment(func->getResultInterfaceType());
+  Type proxyResultTy =
+      isVoidReturn ? Type() : getDistributedResolvableProtocolStubType(resultType);
+
+  SmallVector<ASTNode, 4> stmts;
+  if (!proxyResultTy) {
+    // No proxying of the result needed - return the call result directly.
+    auto returnCall = ReturnStmt::createImplicit(C, sloc, call);
+    stmts.push_back(returnCall);
+  } else {
+    // let __result = try await self.<func>(...)
+    // The thunk body is entirely synthesized; there are no user-written locals
+    // in scope, so the `__result` name cannot collide.
+    auto *resultVar =
+        new (C) VarDecl(/*isStatic=*/false, VarDecl::Introducer::Let, sloc,
+                        C.getIdentifier("__result"), thunk);
+    resultVar->setImplicit();
+    resultVar->setSynthesized();
+
+    Pattern *resultPattern = NamedPattern::createImplicit(C, resultVar);
+    auto resultPB = PatternBindingDecl::createImplicit(
+        C, StaticSpellingKind::None, resultPattern, call, thunk);
+
+    stmts.push_back(resultPB);
+    stmts.push_back(resultVar);
+
+    // return try $P.resolve(id: __result.id, using: self.actorSystem)
+    auto *resultRef =
+        new (C) DeclRefExpr(ConcreteDeclRef(resultVar), dloc, implicit);
+    auto *resultIdExpr =
+        UnresolvedDotExpr::createImplicit(C, resultRef, C.Id_id);
+
+    auto *systemRef = UnresolvedDotExpr::createImplicit(
+        C, new (C) DeclRefExpr(selfDecl, dloc, implicit), C.Id_actorSystem);
+
+    Expr *resolveCall = createDistributedResolveCall(
+        C, proxyResultTy, resultIdExpr, systemRef);
+
+    auto returnResolve = ReturnStmt::createImplicit(C, sloc, resolveCall);
+    stmts.push_back(returnResolve);
+  }
+
+  auto body = BraceStmt::create(C, sloc, stmts, sloc, implicit);
+  return {body, /*isTypeChecked=*/false};
+}
+
+/// Create the 'resolvable proxy adapter' thunk. Its signature matches the
+/// user-declared function, except that `@Resolvable` parameters (`any P`
+/// or `some P`) and a `@Resolvable` result are replaced by the proxy stub
+/// type `$P`.
+static FuncDecl *
+createDistributedResolvableProxyAdapterThunkDecl(DeclContext *DC,
+                                                 FuncDecl *func) {
+  auto &C = func->getASTContext();
+
+  // --- Prepare generic parameters.
+  //
+  // A `some P` parameter rewritten to a concrete `$P` below leaves its
+  // generic parameter unused in the thunk's signature; that is intentional
+  // and harmless.
+  // TODO(distributed): drop the unused generic parameter from the thunk's
+  //   signature when its only use was substituted away by the `$P` rewrite.
+  GenericParamList *genericParamList = nullptr;
+  if (auto genericParams = func->getGenericParams())
+    genericParamList = genericParams->clone(DC);
+
+  GenericSignature baseSignature = func->getGenericSignature();
+
+  // --- Prepare parameters
+  auto funcParams = func->getParameters();
+  SmallVector<ParamDecl *, 2> paramDecls;
+  for (unsigned i : indices(*func->getParameters())) {
+    auto funcParam = funcParams->get(i);
+
+    auto paramName = funcParam->getParameterName();
+    if (paramName.empty())
+      paramName = C.getIdentifier("p" + llvm::utostr(i));
+
+    auto paramDecl = new (C)
+        ParamDecl(SourceLoc(),
+                  /*argumentNameLoc=*/SourceLoc(), funcParam->getArgumentName(),
+                  /*parameterNameLoc=*/SourceLoc(), paramName, DC);
+    paramDecl->setImplicit();
+    paramDecl->setSending();
+    paramDecl->setSpecifier(funcParam->getSpecifier());
+
+    // If the parameter is a `@Resolvable` `any P` (existential) or `some P`
+    // (opaque / generic) parameter, the wire-level type is the proxy stub
+    // `$P`; rewrite the parameter to `$P` in either case.
+    Type paramTy = funcParam->getInterfaceType();
+    Type mappedParamTy = func->mapTypeIntoEnvironment(paramTy);
+    if (Type proxyTy = getDistributedResolvableProtocolStubType(mappedParamTy))
+      paramTy = proxyTy;
+    paramDecl->setInterfaceType(paramTy);
+
+    paramDecls.push_back(paramDecl);
+  }
+  ParameterList *params = ParameterList::create(C, paramDecls);
+
+  // --- Prepare the result type, adapting a `@Resolvable` result to `$P`.
+  Type resultTy = func->getResultInterfaceType();
+  if (Type proxyTy = getDistributedResolvableProtocolStubType(
+          func->mapTypeIntoEnvironment(resultTy)))
+    resultTy = proxyTy;
+
+  // Synthesize a distinct, stable name so this helper neither collides with
+  // the regular distributed thunk nor goes through the distributed-thunk
+  // mangling path. Follow the compiler-synthesized-name convention used by
+  // e.g. `$__lazy_storage_$_<name>`: `$__resolvableProxyAdapter_$_<base>`.
+  // For a computed property the base is the storage (var) name.
+  Identifier baseIdent;
+  if (auto *accessor = dyn_cast<AccessorDecl>(func))
+    baseIdent = accessor->getStorage()->getBaseIdentifier();
+  else
+    baseIdent = func->getBaseIdentifier();
+
+  SmallString<64> nameBuf;
+  nameBuf += "$__resolvableProxyAdapter_$_";
+  nameBuf += baseIdent.str();
+  DeclName thunkName(C, C.getIdentifier(nameBuf),
+                     func->getName().getArgumentNames());
+
+  auto *thunk = FuncDecl::createImplicit(
+      C, swift::StaticSpellingKind::None, thunkName, SourceLoc(),
+      /*async=*/true, /*throws=*/true,
+      /*thrownType=*/Type(), genericParamList, params, resultTy, DC);
+  thunk->setSynthesized(true);
+
+  if (isa<ClassDecl>(DC))
+    thunk->addAttribute(new (C) FinalAttr(/*isImplicit=*/true));
+
+  thunk->setGenericSignature(baseSignature);
+  thunk->copyFormalAccessFrom(func, /*sourceIsParentContext=*/false);
+  // TODO(distributed): This thunk should be `nonisolated(nonsending)` so it
+  //   runs on the caller's (accessor's) executor, so we avoid an extra hop.
+  //   That makes it `@caller_isolated` (an implicit leading
+  //   `Builtin.ImplicitActor` parameter), which the hand-built distributed
+  //   target accessor in GenDistributed.cpp does not yet pass. Until the
+  //   accessor learns that ABI, match the regular distributed thunk's
+  //   isolation (`nonisolated` + `@concurrent`).
+  thunk->addAttribute(NonisolatedAttr::createImplicit(C));
+  thunk->addAttribute(new (C) ConcurrentAttr(/*IsImplicit=*/true));
+
+  return thunk;
+}
+
+static FuncDecl *
+createDistributedResolvableProxyAdapterThunkFunction(FuncDecl *func) {
+  auto DC = func->getDeclContext();
+
+  FuncDecl *thunk = createDistributedResolvableProxyAdapterThunkDecl(DC, func);
+  assert(thunk &&
+         "couldn't create a distributed resolvable proxy adapter thunk");
+
+  if (func->hasBody())
+    thunk->setBodySynthesizer(
+        deriveBodyDistributed_resolvableProxyAdapterThunk, func);
+
+  return thunk;
+}
+
+/// Determine whether \p func requires a 'resolvable proxy adapter' thunk:
+/// it does when it has a `@Resolvable` parameter (`any P` or `some P`) or
+/// a `@Resolvable` result, all of which are rewritten to the proxy stub
+/// type `$P`.
+static bool
+distributedTargetNeedsResolvableProxyAdapterThunk(AbstractFunctionDecl *func) {
+  // Does the result need a type substitution?
+  if (auto *fn = dyn_cast<FuncDecl>(func)) {
+    auto resultTy = fn->mapTypeIntoEnvironment(fn->getResultInterfaceType());
+    if (getDistributedResolvableProtocolStubType(resultTy))
+      return true;
+  }
+
+  // Do any of the parameters need type substitution?
+  for (auto *param : *func->getParameters()) {
+    auto paramTy = func->mapTypeIntoEnvironment(param->getInterfaceType());
+    if (getDistributedResolvableProtocolStubType(paramTy))
+      return true;
+  }
+
+  return false;
 }
 
 /******************************************************************************/
@@ -882,6 +1159,67 @@ FuncDecl *GetDistributedThunkRequest::evaluate(Evaluator &evaluator,
   }
 
   llvm_unreachable("Unable to synthesize distributed thunk");
+}
+
+FuncDecl *
+GetDistributedResolvableProxyAdapterThunkRequest::evaluate(
+    Evaluator &evaluator, Originator originator) const {
+  AbstractFunctionDecl *distributedTarget = nullptr;
+  if (auto *storage = originator.dyn_cast<AbstractStorageDecl *>()) {
+    if (!storage->isDistributed())
+      return nullptr;
+
+    if (auto *var = dyn_cast<VarDecl>(storage)) {
+      if (checkDistributedActorProperty(var, /*diagnose=*/false))
+        return nullptr;
+
+      distributedTarget = var->getAccessor(AccessorKind::Get);
+    } else {
+      llvm_unreachable("unsupported storage kind");
+    }
+  } else {
+    distributedTarget = cast<AbstractFunctionDecl *>(originator);
+    if (!distributedTarget->isDistributed())
+      return nullptr;
+  }
+  assert(distributedTarget);
+
+  // Avoid synthesizing for a target which had errors; mirrors the logic in
+  // GetDistributedThunkRequest so we never emit a thunk for an invalid decl.
+  if (swift::checkDistributedFunction(distributedTarget)) {
+    return nullptr;
+  }
+
+  auto &C = distributedTarget->getASTContext();
+
+  if (!canSynthesizeDistributedThunk(distributedTarget)) {
+    return nullptr;
+  }
+
+  if (distributedTarget->getInterfaceType()->hasError() ||
+      (!isa<AccessorDecl>(distributedTarget) &&
+       checkDistributedFunction(distributedTarget))) {
+    return nullptr;
+  }
+
+  if (auto func = dyn_cast<FuncDecl>(distributedTarget)) {
+    // not via `ensureDistributedModuleLoaded` to avoid generating a warning,
+    // we won't be emitting the offending decl after all.
+    if (!C.getLoadedModule(C.Id_Distributed))
+      return nullptr;
+
+    // The resolvable proxy adapter thunk is only needed when a parameter or
+    // the result is `@Resolvable` `any P` / `some P` and so must be adapted
+    // to / from the proxy stub `$P`. Otherwise the regular distributed
+    // thunk and accessor handle the call directly.
+    if (!distributedTargetNeedsResolvableProxyAdapterThunk(func))
+      return nullptr;
+
+    return createDistributedResolvableProxyAdapterThunkFunction(func);
+  }
+
+  llvm_unreachable(
+      "Unable to synthesize distributed resolvable proxy adapter thunk");
 }
 
 static VarDecl *lookupDistributedActorProperty(NominalTypeDecl *decl,

--- a/lib/Sema/CodeSynthesisDistributedActor.cpp
+++ b/lib/Sema/CodeSynthesisDistributedActor.cpp
@@ -404,6 +404,17 @@ deriveBodyDistributed_thunk(AbstractFunctionDecl *thunk, void *context) {
     // Result.self
     // Watch out and always map into thunk context
     auto resultType = thunk->mapTypeIntoEnvironment(func->getResultInterfaceType());
+
+    // --- `@Resolvable protocol` result: substitute `$P` for `any/some P`
+    if (auto resolvableMatch =
+            findDistributedResolvableExistentialOrOpaqueProtocol(resultType)) {
+      if (auto *stub = getDistributedActorStub(resolvableMatch.proto)) {
+        auto stubInterfaceTy = stub->getDeclaredInterfaceType();
+        if (stubInterfaceTy && !stubInterfaceTy->hasError())
+          resultType = thunk->mapTypeIntoEnvironment(stubInterfaceTy);
+      }
+    }
+
     auto *metaTypeRef = TypeExpr::createImplicit(resultType, C);
     auto *resultTypeExpr =
         new (C) DotSelfExpr(metaTypeRef, sloc, sloc, resultType);
@@ -541,6 +552,17 @@ deriveBodyDistributed_thunk(AbstractFunctionDecl *thunk, void *context) {
       // Result.self
       auto resultType =
           func->mapTypeIntoEnvironment(func->getResultInterfaceType());
+
+      // --- `@Resolvable protocol` result: substitute `$P` for `any/some P`
+      if (auto resolvableMatch =
+              findDistributedResolvableExistentialOrOpaqueProtocol(resultType)) {
+        if (auto *stub = getDistributedActorStub(resolvableMatch.proto)) {
+          auto stubInterfaceTy = stub->getDeclaredInterfaceType();
+          if (stubInterfaceTy && !stubInterfaceTy->hasError())
+            resultType = func->mapTypeIntoEnvironment(stubInterfaceTy);
+        }
+      }
+
       auto *metaTypeRef = TypeExpr::createImplicit(resultType, C);
       auto *resultTypeExpr =
           new (C) DotSelfExpr(metaTypeRef, sloc, sloc, resultType);

--- a/lib/Sema/CodeSynthesisDistributedActor.cpp
+++ b/lib/Sema/CodeSynthesisDistributedActor.cpp
@@ -67,10 +67,10 @@ static Type getDistributedResolvableProtocolStubType(Type ty) {
 
 /// Build `try $P.resolve(id: <idExpr>, using: <systemExpr>)`.
 static Expr *createDistributedResolveCall(ASTContext &C,
-                                          Type stubInterfaceTy,
+                                          Type actorTy,
                                           Expr *idExpr,
                                           Expr *systemExpr) {
-  auto *stubTypeExpr = TypeExpr::createImplicit(stubInterfaceTy, C);
+  auto *stubTypeExpr = TypeExpr::createImplicit(actorTy, C);
   DeclName resolveName(C, C.getIdentifier("resolve"),
                        {C.Id_id, C.getIdentifier("using")});
   auto *resolveExpr =
@@ -1162,7 +1162,7 @@ FuncDecl *GetDistributedThunkRequest::evaluate(Evaluator &evaluator,
 }
 
 FuncDecl *
-GetDistributedResolvableProxyAdapterThunkRequest::evaluate(
+GetDistributedRecipientResolvableProxyAdapterThunkRequest::evaluate(
     Evaluator &evaluator, Originator originator) const {
   AbstractFunctionDecl *distributedTarget = nullptr;
   if (auto *storage = originator.dyn_cast<AbstractStorageDecl *>()) {
@@ -1210,8 +1210,7 @@ GetDistributedResolvableProxyAdapterThunkRequest::evaluate(
 
     // The resolvable proxy adapter thunk is only needed when a parameter or
     // the result is `@Resolvable` `any P` / `some P` and so must be adapted
-    // to / from the proxy stub `$P`. Otherwise the regular distributed
-    // thunk and accessor handle the call directly.
+    // to / from the proxy stub `$P`. Otherwise, the call is made directly.
     if (!distributedTargetNeedsResolvableProxyAdapterThunk(func))
       return nullptr;
 

--- a/lib/Sema/CodeSynthesisDistributedActor.cpp
+++ b/lib/Sema/CodeSynthesisDistributedActor.cpp
@@ -257,8 +257,72 @@ deriveBodyDistributed_thunk(AbstractFunctionDecl *thunk, void *context) {
 
         auto remoteCallArgumentInitDecl =
             RCA->getDistributedRemoteCallArgumentInitFunction();
-        auto boundRCAType = BoundGenericType::get(
-            RCA, Type(), {thunk->mapTypeIntoEnvironment(param->getInterfaceType())});
+
+        // If the parameter is `some P` / `any P` (or `Optional`) where
+        // P is a `@Resolvable protocol`, encode the parameter
+        // as the macro-generated `$P` stub type.
+        Type paramTy =
+            thunk->mapTypeIntoEnvironment(param->getInterfaceType());
+        Expr *argumentDeclRefExpr = new (C) DeclRefExpr(
+            ConcreteDeclRef(param), dloc, implicit,
+            AccessSemantics::Ordinary, paramTy);
+
+        // --- Automatic @Resolvable protocol proxying
+        //
+        // If @Resolvable protocol parameter, substitute with $P.resolve()'d reference
+        // Because sending a `some P` or `any P` means transferring a `$P` on the wire,
+        // as the remote peer may not know our concrete P implementation, we need to send the "proxy".
+        //
+        // This way the remote side will decode it as `$P` proxy, which conforms to `P`,
+        // so the `some/any P` parameter is correctly filled in by a `$P` instance on
+        // the recipient without ever knowing the concrete type of the sender.
+        if (auto resolvableMatch =
+                findDistributedResolvableExistentialOrOpaqueProtocol(paramTy)) {
+          if (auto *stub = getDistributedActorStub(resolvableMatch.proto)) {
+            auto stubInterfaceTy = stub->getDeclaredInterfaceType();
+            if (stubInterfaceTy && !stubInterfaceTy->hasError()) {
+              // Important! We replace the type of the parameter with `$P`
+              paramTy = thunk->mapTypeIntoEnvironment(stubInterfaceTy);
+
+              // --- We then have to make the parameter be actually a `$P`
+              // TODO: It would be simpler if we did just create a new `$P`,
+              //  but we'd need to allow `self.id = id` inside distributed actors;
+              //  Once we allow that, we can just create an instance without this fake resolve.
+              {
+                // paramRef.id
+                auto *paramIdExpr = UnresolvedDotExpr::createImplicit(
+                    C, argumentDeclRefExpr, C.Id_id);
+
+                // $P (as a metatype expression).
+                auto *stubTypeExpr = TypeExpr::createImplicit(stubInterfaceTy, C);
+
+                // $P.resolve(...)
+                DeclName resolveName(C, C.getIdentifier("resolve"),
+                                     {C.Id_id, C.getIdentifier("using")});
+                auto *resolveExpr = UnresolvedDotExpr::createImplicit(
+                    C, stubTypeExpr, resolveName);
+
+                // Get the `system` from the actor that the call is being made on.
+                auto *systemRef = new (C) DeclRefExpr(
+                    ConcreteDeclRef(systemVar), dloc, implicit);
+
+                // $P.resolve(id: paramRef.id, using: system)
+                // We have enforced in sema that the system must be compatible.
+                auto *resolveArgList = ArgumentList::forImplicitCallTo(
+                    DeclNameRef(resolveName), {paramIdExpr, systemRef}, C);
+                auto *resolveCall =
+                    CallExpr::createImplicit(C, resolveExpr, resolveArgList);
+
+                // try <resolve>
+                argumentDeclRefExpr =
+                    TryExpr::createImplicit(C, sloc, resolveCall);
+              }
+            }
+          }
+        }
+
+        auto boundRCAType =
+            BoundGenericType::get(RCA, Type(), {paramTy});
         auto remoteCallArgumentInitDeclRef =
             TypeExpr::createImplicit(boundRCAType, C);
 
@@ -270,10 +334,7 @@ deriveBodyDistributed_thunk(AbstractFunctionDecl *thunk, void *context) {
              // name:
              new (C) StringLiteralExpr(parameterName, SourceRange(), implicit),
              // _ argument:
-             new (C) DeclRefExpr(
-                 ConcreteDeclRef(param), dloc, implicit,
-                 AccessSemantics::Ordinary,
-                 thunk->mapTypeIntoEnvironment(param->getInterfaceType()))
+             argumentDeclRefExpr
             },
             C);
 

--- a/lib/Sema/CodeSynthesisDistributedActor.cpp
+++ b/lib/Sema/CodeSynthesisDistributedActor.cpp
@@ -898,9 +898,9 @@ createDistributedResolvableProxyAdapterThunkDecl(DeclContext *DC,
 
   // Synthesize a distinct, stable name so this helper neither collides with
   // the regular distributed thunk nor goes through the distributed-thunk
-  // mangling path. Follow the compiler-synthesized-name convention used by
-  // e.g. `$__lazy_storage_$_<name>`: `$__resolvableProxyAdapter_$_<base>`.
-  // For a computed property the base is the storage (var) name.
+  // mangling path. The `$` prefix and infix make it unspellable from
+  // user code: `$distributedProxyAdapter$<base>`. For a computed property
+  // the base is the storage (var) name.
   Identifier baseIdent;
   if (auto *accessor = dyn_cast<AccessorDecl>(func))
     baseIdent = accessor->getStorage()->getBaseIdentifier();
@@ -908,7 +908,7 @@ createDistributedResolvableProxyAdapterThunkDecl(DeclContext *DC,
     baseIdent = func->getBaseIdentifier();
 
   SmallString<64> nameBuf;
-  nameBuf += "$__resolvableProxyAdapter_$_";
+  nameBuf += "$distributedProxyAdapter$";
   nameBuf += baseIdent.str();
   DeclName thunkName(C, C.getIdentifier(nameBuf),
                      func->getName().getArgumentNames());

--- a/lib/Sema/TypeCheckDistributed.cpp
+++ b/lib/Sema/TypeCheckDistributed.cpp
@@ -437,29 +437,79 @@ static bool checkDistributedTargetResultType(
       checkDistributedSerializationRequirementIsExactlyCodable(
           C, serializationRequirement);
 
-  for (auto serializationReq: serializationRequirements) {
-    auto conformance = checkConformance(resultType, serializationReq);
-    if (conformance.isInvalid()) {
+  // --- Special case: `-> some/any P` where P is a `@Resolvable protocol`
+  // Wire format encodes the actor's `id` as a Codable ActorID,
+  // so the existential/opaque does not need to conform to the serialization requirement.
+  bool skipCodableCheck = false;
+  auto resolvableMatch = findDistributedResolvableExistentialOrOpaqueProtocol(resultType);
+  if (resolvableMatch.isAmbiguous) {
+    if (diagnose) {
+      valueDecl->diagnose(
+          diag::distributed_actor_func_result_resolvable_protocol_composition_ambiguous,
+          resultType, valueDecl);
+      valueDecl->diagnose(
+          diag::distributed_actor_func_resolvable_protocol_composition_ambiguous_note);
+    }
+    return true;
+  }
+
+  if (auto *resolvableProto = resolvableMatch.proto) {
+    auto protocolSystemTy =
+        getResolvableProtocolConcreteActorSystemType(resolvableProto);
+    if (!protocolSystemTy) {
       if (diagnose) {
-        llvm::StringRef conformanceToSuggest = isCodableRequirement ?
-                                               "Codable" : // Codable is a typealias, easier to diagnose like that
-                                               serializationReq->getNameStr();
+        valueDecl->diagnose(
+            diag::distributed_actor_func_result_resolvable_protocol_no_concrete_actor_system,
+            resultType, valueDecl, resolvableProto->getName());
+      }
+      return true;
+    }
 
-        auto diag = valueDecl->diagnose(
-            diag::distributed_actor_target_result_not_codable,
-            resultType,
-            valueDecl,
-            conformanceToSuggest
-        );
+    auto enclosingSystemTy =
+        getConcreteReplacementForProtocolActorSystemType(valueDecl);
 
-        if (isCodableRequirement) {
-          if (auto resultNominalType = resultType->getAnyNominal()) {
-            addCodableFixIt(resultNominalType, diag);
+    if (enclosingSystemTy && !enclosingSystemTy->isEqual(protocolSystemTy)) {
+      if (diagnose) {
+        valueDecl->diagnose(
+            diag::distributed_actor_func_result_resolvable_actor_system_mismatch,
+            resultType, valueDecl,
+            resolvableProto->getName(), protocolSystemTy);
+        resolvableProto->diagnose(
+            diag::distributed_actor_func_result_resolvable_actor_system_mismatch_note,
+            resolvableProto->getName(), protocolSystemTy);
+      }
+      return true;
+    }
+
+    // `@Resolvable protocol` result — skip Codable check, wire uses actor ID
+    skipCodableCheck = true;
+  }
+
+  if (!skipCodableCheck) {
+    for (auto serializationReq: serializationRequirements) {
+      auto conformance = checkConformance(resultType, serializationReq);
+      if (conformance.isInvalid()) {
+        if (diagnose) {
+          llvm::StringRef conformanceToSuggest = isCodableRequirement ?
+                                                 "Codable" : // Codable is a typealias, easier to diagnose like that
+                                                 serializationReq->getNameStr();
+
+          auto diag = valueDecl->diagnose(
+              diag::distributed_actor_target_result_not_codable,
+              resultType,
+              valueDecl,
+              conformanceToSuggest
+          );
+
+          if (isCodableRequirement) {
+            if (auto resultNominalType = resultType->getAnyNominal()) {
+              addCodableFixIt(resultNominalType, diag);
+            }
           }
         }
-      } // end if: diagnose
 
-      return true;
+        return true;
+      }
     }
   }
 
@@ -562,6 +612,8 @@ bool CheckDistributedFunctionRequest::evaluate(
         func->diagnose(
             diag::distributed_actor_func_param_resolvable_protocol_composition_ambiguous,
             param->getArgumentName(), param->getInterfaceType(), func);
+        func->diagnose(
+            diag::distributed_actor_func_resolvable_protocol_composition_ambiguous_note);
         return true;
       }
 

--- a/lib/Sema/TypeCheckDistributed.cpp
+++ b/lib/Sema/TypeCheckDistributed.cpp
@@ -553,20 +553,91 @@ bool CheckDistributedFunctionRequest::evaluate(
       // --- Check parameters for 'SerializationRequirement' conformance
       auto paramTy = func->mapTypeIntoEnvironment(param->getInterfaceType());
 
-      auto srl = serializationReqType->getExistentialLayout();
-      for (auto req: srl.getProtocols()) {
-        if (checkConformance(paramTy, req).isInvalid()) {
-          auto diag = func->diagnose(
-              diag::distributed_actor_func_param_not_codable,
+      // --- Special case: `param: some/any P` where P is a `@Resolvable protocol`
+      // Wire format encodes the actor's `id` (a Codable ActorID`),
+      // so the existential/opaque does not really need to conform to the serialization requirement.
+      bool skipCodableCheck = false;
+      auto resolvableMatch = findDistributedResolvableExistentialOrOpaqueProtocol(paramTy);
+      if (resolvableMatch.isAmbiguous) {
+        func->diagnose(
+            diag::distributed_actor_func_param_resolvable_protocol_composition_ambiguous,
+            param->getArgumentName(), param->getInterfaceType(), func);
+        return true;
+      }
+
+      if (auto *resolvableProto = resolvableMatch.proto) {
+        auto enclosingSystemTy =
+            getConcreteReplacementForProtocolActorSystemType(func);
+        auto protocolSystemTy =
+            getResolvableProtocolConcreteActorSystemType(resolvableProto);
+        if (!protocolSystemTy) {
+          func->diagnose(
+              diag::distributed_actor_func_param_resolvable_protocol_no_concrete_actor_system,
               param->getArgumentName(), param->getInterfaceType(), func,
-              serializationRequirementIsCodable ? "Codable"
-                                                : req->getNameStr());
+              resolvableProto->getName());
 
-          if (auto paramNominalTy = paramTy->getAnyNominal()) {
-            addCodableFixIt(paramNominalTy, diag);
-          } // else, no nominal type to suggest the fixit for, e.g. a closure
-
+          // Fix-it: insert ` where Self.ActorSystem == <EnclosingSystem>`.
+          // We use the enclosing actor's `ActorSystem` if it is known and concrete,
+          // otherwise we emit just the placeholder.
+          auto fixItLoc = resolvableProto->getBraces().Start;
+          if (fixItLoc.isValid()) {
+            llvm::SmallString<64> fixIt;
+            fixIt += " where Self.ActorSystem == ";
+            if (enclosingSystemTy && !enclosingSystemTy->hasError() &&
+                !enclosingSystemTy->is<GenericTypeParamType>() &&
+                !enclosingSystemTy->is<ArchetypeType>()) {
+              fixIt += enclosingSystemTy->getString();
+            } else {
+              fixIt += "<#ActorSystem#>";
+            }
+            fixIt += " ";
+            resolvableProto
+                ->diagnose(
+                    diag::distributed_actor_func_param_resolvable_protocol_no_concrete_actor_system_fixit,
+                    resolvableProto->getName())
+                .fixItInsert(fixItLoc, fixIt);
+          }
           return true;
+        }
+
+        if (enclosingSystemTy && !enclosingSystemTy->isEqual(protocolSystemTy)) {
+          // The actor system of the `any P` and actor we're making the call on
+          // must match, because we need to form a `$P.resolve(param.id, using: self.system)`
+          // call.
+          func->diagnose(
+              diag::distributed_actor_func_param_resolvable_actor_system_mismatch,
+              param->getArgumentName(), param->getInterfaceType(), func,
+              resolvableProto->getName(), protocolSystemTy,
+              enclosingSystemTy);
+          resolvableProto->diagnose(
+              diag::distributed_actor_func_param_resolvable_actor_system_mismatch_note,
+              resolvableProto->getName(), protocolSystemTy);
+          return true;
+        }
+
+        // Skip the codable-conformance checks for this parameter;
+        // We know it is a distributed actor protocol on the same actor system.
+        // We also know that it is a `@Resolvable protocol` and `any/some P`,
+        // which does itself not conform to e.g. `Codable`
+        skipCodableCheck = true;
+      }
+
+      if (!skipCodableCheck) {
+        auto srl = serializationReqType->getExistentialLayout();
+        for (auto req: srl.getProtocols()) {
+          if (checkConformance(paramTy, req).isInvalid()) {
+            auto diag = func->diagnose(
+                diag::distributed_actor_func_param_not_codable,
+                param->getArgumentName(), param->getInterfaceType(), func,
+                serializationRequirementIsCodable ? "Codable"
+                                                  : req->getNameStr());
+
+            if (auto paramNominalTy = paramTy->getAnyNominal()) {
+              addCodableFixIt(paramNominalTy, diag);
+            } // else, no nominal type to suggest the fixit for, e.g. a closure
+
+            return true;
+          }
         }
       }
     }

--- a/lib/Sema/TypeCheckDistributed.cpp
+++ b/lib/Sema/TypeCheckDistributed.cpp
@@ -571,6 +571,32 @@ bool swift::checkDistributedFunction(AbstractFunctionDecl *func) {
                            false); // no error if cycle
 }
 
+/// Emit a fix-it suggesting to constrain the `@Resolvable` \p resolvableProto's
+/// `Self.ActorSystem` to the enclosing actor's system type (or a placeholder
+/// when no concrete enclosing system is known).
+static void emitResolvableProtocolMissingActorSystemFixit(
+    ProtocolDecl *resolvableProto, Type enclosingSystemTy) {
+  auto fixItLoc = resolvableProto->getBraces().Start;
+  if (!fixItLoc.isValid())
+    return;
+
+  llvm::SmallString<64> fixIt;
+  fixIt += " where Self.ActorSystem == ";
+  if (enclosingSystemTy && !enclosingSystemTy->hasError() &&
+      !enclosingSystemTy->is<GenericTypeParamType>() &&
+      !enclosingSystemTy->is<ArchetypeType>()) {
+    fixIt += enclosingSystemTy->getString();
+  } else {
+    fixIt += "<#ActorSystem#>";
+  }
+  fixIt += " ";
+  resolvableProto
+      ->diagnose(
+          diag::distributed_actor_func_param_resolvable_protocol_no_concrete_actor_system_fixit,
+          resolvableProto->getName())
+      .fixItInsert(fixItLoc, fixIt);
+}
+
 bool CheckDistributedFunctionRequest::evaluate(
     Evaluator &evaluator, AbstractFunctionDecl *func) const {
   if (auto *accessor = dyn_cast<AccessorDecl>(func)) {
@@ -603,10 +629,8 @@ bool CheckDistributedFunctionRequest::evaluate(
       // --- Check parameters for 'SerializationRequirement' conformance
       auto paramTy = func->mapTypeIntoEnvironment(param->getInterfaceType());
 
-      // --- Special case: `param: some/any P` where P is a `@Resolvable protocol`
-      // Wire format encodes the actor's `id` (a Codable ActorID`),
-      // so the existential/opaque does not really need to conform to the serialization requirement.
-      bool skipCodableCheck = false;
+      // --- Special case: `param: some/any P` where P is a `@Resolvable protocol`.
+      bool skipSerializationRequirementCheck = false;
       auto resolvableMatch = findDistributedResolvableExistentialOrOpaqueProtocol(paramTy);
       if (resolvableMatch.isAmbiguous) {
         func->diagnose(
@@ -627,28 +651,8 @@ bool CheckDistributedFunctionRequest::evaluate(
               diag::distributed_actor_func_param_resolvable_protocol_no_concrete_actor_system,
               param->getArgumentName(), param->getInterfaceType(), func,
               resolvableProto->getName());
-
-          // Fix-it: insert ` where Self.ActorSystem == <EnclosingSystem>`.
-          // We use the enclosing actor's `ActorSystem` if it is known and concrete,
-          // otherwise we emit just the placeholder.
-          auto fixItLoc = resolvableProto->getBraces().Start;
-          if (fixItLoc.isValid()) {
-            llvm::SmallString<64> fixIt;
-            fixIt += " where Self.ActorSystem == ";
-            if (enclosingSystemTy && !enclosingSystemTy->hasError() &&
-                !enclosingSystemTy->is<GenericTypeParamType>() &&
-                !enclosingSystemTy->is<ArchetypeType>()) {
-              fixIt += enclosingSystemTy->getString();
-            } else {
-              fixIt += "<#ActorSystem#>";
-            }
-            fixIt += " ";
-            resolvableProto
-                ->diagnose(
-                    diag::distributed_actor_func_param_resolvable_protocol_no_concrete_actor_system_fixit,
-                    resolvableProto->getName())
-                .fixItInsert(fixItLoc, fixIt);
-          }
+          emitResolvableProtocolMissingActorSystemFixit(resolvableProto,
+                                                       enclosingSystemTy);
           return true;
         }
 
@@ -667,17 +671,17 @@ bool CheckDistributedFunctionRequest::evaluate(
           return true;
         }
 
-        // Skip the codable-conformance checks for this parameter;
+        // Skip the serialization-requirement check for this parameter;
         // We know it is a distributed actor protocol on the same actor system.
         // We also know that it is a `@Resolvable protocol` and `any/some P`,
         // which does itself not conform to e.g. `Codable`
-        skipCodableCheck = true;
+        skipSerializationRequirementCheck = true;
       }
 
-      if (!skipCodableCheck) {
+      if (!skipSerializationRequirementCheck) {
         auto srl = serializationReqType->getExistentialLayout();
         for (auto req: srl.getProtocols()) {
-          if (checkConformance(paramTy, req).isInvalid()) {
+          if (!checkConformance(paramTy, req)) {
             auto diag = func->diagnose(
                 diag::distributed_actor_func_param_not_codable,
                 param->getArgumentName(), param->getInterfaceType(), func,

--- a/test/Distributed/Runtime/distributed_actor_resolvable_any_some_param.swift
+++ b/test/Distributed/Runtime/distributed_actor_resolvable_any_some_param.swift
@@ -1,0 +1,83 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems %S/../Inputs/FakeDistributedActorSystems.swift
+// RUN: %target-build-swift -module-name main -target %target-swift-6.0-abi-triple -plugin-path %swift-plugin-dir -j2 -parse-as-library -I %t %s %S/../Inputs/FakeDistributedActorSystems.swift -o %t/a.out
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s --dump-input=always
+//
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: distributed
+// REQUIRES: swift_swift_parser, asserts
+//
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
+// This test exercises the **remote-branch** wire round-trip for a
+// `distributed func` that takes a `some/any P` parameter where `P` is a
+// `@Resolvable protocol`.
+
+import Distributed
+import FakeDistributedActorSystems
+
+typealias DefaultDistributedActorSystem = FakeRoundtripActorSystem
+
+@Resolvable
+protocol Greeter: DistributedActor, Codable
+where ActorSystem == FakeRoundtripActorSystem {
+  distributed func sayHi() -> String
+  distributed func sendAnyGreeter(_ g: any Greeter) async throws -> String
+  distributed func sendSomeGreeter(_ g: some Greeter) async throws -> String
+}
+
+distributed actor GreeterImpl: Greeter {
+  distributed func sayHi() -> String { "Hi from \(self.id)" }
+
+  distributed func sendAnyGreeter(_ g: any Greeter) async throws -> String {
+    print("sendAnyGreeter type: \(type(of: g))")
+    return try await g.sayHi()
+  }
+
+  distributed func sendSomeGreeter(_ g: some Greeter) async throws -> String {
+    print("sendSomeGreeter type: \(type(of: g))")
+    return try await g.sayHi()
+  }
+}
+
+// ==== -----------------------------------------------------------------------
+// MARK: Tests
+
+func test_anyGreeter() async throws {
+  let system = FakeRoundtripActorSystem()
+  let local = GreeterImpl(actorSystem: system)
+  let proxy = try GreeterImpl.resolve(id: local.id, using: system)
+
+  print("--- any ---")
+  // CHECK: --- any ---
+  let result = try await proxy.sendAnyGreeter(local)
+  // CHECK: sendAnyGreeter type: $Greeter
+  print("result: \(result)")
+  // CHECK: result: Hi from
+}
+
+func test_someGreeter() async throws {
+  let system = FakeRoundtripActorSystem()
+  let local = GreeterImpl(actorSystem: system)
+  let proxy = try GreeterImpl.resolve(id: local.id, using: system)
+
+  print("--- some ---")
+  // CHECK: --- some ---
+  let result = try await proxy.sendSomeGreeter(local)
+  // CHECK: sendSomeGreeter type: $Greeter
+  print("result: \(result)")
+  // CHECK: result: Hi from
+}
+
+// ==== -----------------------------------------------------------------------
+// MARK: Main
+
+@main struct Main {
+  static func main() async throws {
+    try await test_anyGreeter()
+    try await test_someGreeter()
+  }
+}

--- a/test/Distributed/Runtime/distributed_actor_resolvable_any_some_param.swift
+++ b/test/Distributed/Runtime/distributed_actor_resolvable_any_some_param.swift
@@ -2,7 +2,7 @@
 // RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems %S/../Inputs/FakeDistributedActorSystems.swift
 // RUN: %target-build-swift -module-name main -target %target-swift-6.0-abi-triple -plugin-path %swift-plugin-dir -j2 -parse-as-library -I %t %s %S/../Inputs/FakeDistributedActorSystems.swift -o %t/a.out
 // RUN: %target-codesign %t/a.out
-// RUN: %target-run %t/a.out | %FileCheck %s --dump-input=always
+// RUN: %target-run %t/a.out | %FileCheck %s
 //
 // REQUIRES: executable_test
 // REQUIRES: concurrency

--- a/test/Distributed/Runtime/distributed_actor_resolvable_any_some_param.swift
+++ b/test/Distributed/Runtime/distributed_actor_resolvable_any_some_param.swift
@@ -14,7 +14,7 @@
 
 // This test exercises the **remote-branch** wire round-trip for a
 // `distributed func` that takes a `some/any P` parameter where `P` is a
-// `@Resolvable protocol`.
+// `@Resolvable protocol`, and for a `distributed func` that *returns* `any P`.
 
 import Distributed
 import FakeDistributedActorSystems
@@ -27,6 +27,8 @@ where ActorSystem == FakeRoundtripActorSystem {
   distributed func sayHi() -> String
   distributed func sendAnyGreeter(_ g: any Greeter) async throws -> String
   distributed func sendSomeGreeter(_ g: some Greeter) async throws -> String
+  distributed func echoActor(_ g: any Greeter) async throws -> any Greeter
+  distributed var currentSelf: any Greeter { get }
 }
 
 distributed actor GreeterImpl: Greeter {
@@ -41,6 +43,17 @@ distributed actor GreeterImpl: Greeter {
     print("sendSomeGreeter type: \(type(of: g))")
     return try await g.sayHi()
   }
+
+  distributed func echoActor(_ g: any Greeter) async throws -> any Greeter {
+    print("echoActor type: \(type(of: g))")
+    return g
+  }
+
+  distributed var currentSelf: any Greeter {
+    // FakeRoundtripActorSystem passes values by reference; resolve as $Greeter
+    // so the caller receives a remote proxy, not the local GreeterImpl instance.
+    return try! $Greeter.resolve(id: id, using: actorSystem)
+  }
 }
 
 // ==== -----------------------------------------------------------------------
@@ -51,8 +64,8 @@ func test_anyGreeter() async throws {
   let local = GreeterImpl(actorSystem: system)
   let proxy = try GreeterImpl.resolve(id: local.id, using: system)
 
-  print("--- any ---")
-  // CHECK: --- any ---
+  print("any Greeter")
+  // CHECK-LABEL: any Greeter
   let result = try await proxy.sendAnyGreeter(local)
   // CHECK: sendAnyGreeter type: $Greeter
   print("result: \(result)")
@@ -64,10 +77,41 @@ func test_someGreeter() async throws {
   let local = GreeterImpl(actorSystem: system)
   let proxy = try GreeterImpl.resolve(id: local.id, using: system)
 
-  print("--- some ---")
-  // CHECK: --- some ---
+  print("some Greeter")
+  // CHECK-LABEL: some Greeter
   let result = try await proxy.sendSomeGreeter(local)
   // CHECK: sendSomeGreeter type: $Greeter
+  print("result: \(result)")
+  // CHECK: result: Hi from
+}
+
+func test_echoActor() async throws {
+  let system = FakeRoundtripActorSystem()
+  let local = GreeterImpl(actorSystem: system)
+  let proxy = try GreeterImpl.resolve(id: local.id, using: system)
+
+  print("echo any Greeter -> any Greeter")
+  // CHECK-LABEL: echo any Greeter -> any Greeter
+  let echoed = try await proxy.echoActor(local)
+  // CHECK: echoActor type: $Greeter
+  print("echoed type: \(type(of: echoed))")
+  // CHECK: echoed type: $Greeter
+  let result = try await echoed.sayHi()
+  print("result: \(result)")
+  // CHECK: result: Hi from
+}
+
+func test_currentSelf() async throws {
+  let system = FakeRoundtripActorSystem()
+  let local = GreeterImpl(actorSystem: system)
+  let proxy = try GreeterImpl.resolve(id: local.id, using: system)
+
+  print("var currentSelf -> any Greeter")
+  // CHECK-LABEL: var currentSelf -> any Greeter
+  let got = try await proxy.currentSelf
+  print("currentSelf type: \(type(of: got))")
+  // CHECK: currentSelf type: $Greeter
+  let result = try await got.sayHi()
   print("result: \(result)")
   // CHECK: result: Hi from
 }
@@ -79,5 +123,7 @@ func test_someGreeter() async throws {
   static func main() async throws {
     try await test_anyGreeter()
     try await test_someGreeter()
+    try await test_echoActor()
+    try await test_currentSelf()
   }
 }

--- a/test/Distributed/Runtime/distributed_actor_resolvable_any_some_param.swift
+++ b/test/Distributed/Runtime/distributed_actor_resolvable_any_some_param.swift
@@ -11,6 +11,7 @@
 //
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
+// UNSUPPORTED: OS=windows-msvc
 
 // This test exercises the **remote-branch** wire round-trip for a
 // `distributed func` that takes a `some/any P` parameter where `P` is a

--- a/test/Distributed/Runtime/distributed_actor_resolvable_any_some_param_crossModule_optimized.swift
+++ b/test/Distributed/Runtime/distributed_actor_resolvable_any_some_param_crossModule_optimized.swift
@@ -1,0 +1,192 @@
+// RUN: %empty-directory(%t/src)
+// RUN: split-file %s %t/src
+
+/// Build the fake actor systems lib
+// RUN: %target-build-swift                                                    \
+// RUN:     -target %target-swift-6.0-abi-triple                               \
+// RUN:     -parse-as-library -emit-library                                    \
+// RUN:     -emit-module-path %t/FakeDistributedActorSystems.swiftmodule       \
+// RUN:     -module-name FakeDistributedActorSystems                           \
+// RUN:     -plugin-path %swift-plugin-dir                                     \
+// RUN:      %S/../Inputs/FakeDistributedActorSystems.swift                    \
+// RUN:     -enable-library-evolution                                          \
+// RUN:     -O                                                                 \
+// RUN:     -Xfrontend -validate-tbd-against-ir=all                            \
+// RUN:     -o %t/%target-library-name(FakeDistributedActorSystems)
+
+/// Build the GreeterAPILib (defines the @Resolvable protocol).
+// RUN: %target-build-swift                                                    \
+// RUN:     -target %target-swift-6.0-abi-triple                               \
+// RUN:     -parse-as-library -emit-library                                    \
+// RUN:     -emit-module-path %t/GreeterAPILib.swiftmodule                     \
+// RUN:     -module-name GreeterAPILib                                         \
+// RUN:     -I %t                                                              \
+// RUN:     -L %t                                                              \
+// RUN:     -plugin-path %swift-plugin-dir                                     \
+// RUN:     %t/src/GreeterAPILib.swift                                         \
+// RUN:     -lFakeDistributedActorSystems                                      \
+// RUN:     -enable-library-evolution                                          \
+// RUN:     -O                                                                 \
+// RUN:     -Xfrontend -validate-tbd-against-ir=all                            \
+// RUN:     -o %t/%target-library-name(GreeterAPILib)
+
+/// Build the GreeterImplLib (the implementing distributed actor).
+// RUN: %target-build-swift                                                    \
+// RUN:     -target %target-swift-6.0-abi-triple                               \
+// RUN:     -parse-as-library -emit-library                                    \
+// RUN:     -emit-module-path %t/GreeterImplLib.swiftmodule                    \
+// RUN:     -module-name GreeterImplLib                                        \
+// RUN:     -I %t                                                              \
+// RUN:     -L %t                                                              \
+// RUN:     -plugin-path %swift-plugin-dir                                     \
+// RUN:     %t/src/GreeterImplLib.swift                                        \
+// RUN:     -lFakeDistributedActorSystems                                      \
+// RUN:     -lGreeterAPILib                                                    \
+// RUN:     -enable-library-evolution                                          \
+// RUN:     -O                                                                 \
+// RUN:     -Xfrontend -validate-tbd-against-ir=all                            \
+// RUN:     -o %t/%target-library-name(GreeterImplLib)
+
+/// Build the client at -O too.
+// RUN: %target-build-swift                                                    \
+// RUN:     -target %target-swift-6.0-abi-triple                               \
+// RUN:     -parse-as-library                                                  \
+// RUN:     -lFakeDistributedActorSystems                                      \
+// RUN:     -lGreeterAPILib                                                    \
+// RUN:     -lGreeterImplLib                                                   \
+// RUN:     -module-name main                                                  \
+// RUN:     -I %t                                                              \
+// RUN:     -L %t                                                              \
+// RUN:     -plugin-path %swift-plugin-dir                                     \
+// RUN:     %t/src/Main.swift                                                  \
+// RUN:     -enable-library-evolution                                          \
+// RUN:     -O                                                                 \
+// RUN:     -Xfrontend -validate-tbd-against-ir=all                            \
+// RUN:     -o %t/a.out
+
+// RUN: %target-codesign %t/a.out
+// RUN: %target-codesign %t/%target-library-name(FakeDistributedActorSystems)
+// RUN: %target-codesign %t/%target-library-name(GreeterAPILib)
+// RUN: %target-codesign %t/%target-library-name(GreeterImplLib)
+
+// RUN: %target-run %t/a.out                                                   \
+// RUN:     %t/%target-library-name(FakeDistributedActorSystems)               \
+// RUN:     %t/%target-library-name(GreeterAPILib)                             \
+// RUN:     %t/%target-library-name(GreeterImplLib)                            \
+// RUN:     2>&1                                                               \
+// RUN:     | %FileCheck %s --color --dump-input=always
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: distributed
+// REQUIRES: swift_swift_parser, asserts
+
+// Library construction in this layout has been flaky on Linux historically;
+// macOS is what we primarily care about for this regression test.
+// UNSUPPORTED: OS=linux-gnu || OS=freebsd
+// UNSUPPORTED: OS=windows-msvc
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+// UNSUPPORTED: remote_run || device_run
+
+// Cross-module, fully-optimized (`-O`, library-evolution) round-trip for a
+// `@Resolvable` protocol that uses `any P` / `some P` parameters and an
+// `any P` result. Exercises the recipient path through the synthesized
+// `$distributedProxyAdapter$<base>` thunk, which would crash with
+// "Unexpected invocation of distributed method '...' stub!" if either the
+// adapter thunk or the `$Greeter` distributed-thunk witness gets DFE'd by
+// the per-module optimizer.
+
+//--- GreeterAPILib.swift
+
+import Distributed
+import FakeDistributedActorSystems
+
+@Resolvable
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+public protocol Greeter: DistributedActor, Codable
+where ActorSystem == FakeRoundtripActorSystem {
+  distributed func sayHi() -> String
+  distributed func sendAnyGreeter(_ g: any Greeter) async throws -> String
+  distributed func sendSomeGreeter(_ g: some Greeter) async throws -> String
+  distributed func echoActor(_ g: any Greeter) async throws -> any Greeter
+}
+
+//--- GreeterImplLib.swift
+
+import GreeterAPILib
+
+import Distributed
+import FakeDistributedActorSystems
+
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+public distributed actor GreeterImpl: Greeter {
+  public typealias ActorSystem = FakeRoundtripActorSystem
+
+  public init(actorSystem: ActorSystem) {
+    self.actorSystem = actorSystem
+  }
+
+  public distributed func sayHi() -> String { "Hi from \(self.id)" }
+
+  public distributed func sendAnyGreeter(_ g: any Greeter) async throws -> String {
+    print("sendAnyGreeter type: \(type(of: g))")
+    return try await g.sayHi()
+  }
+
+  public distributed func sendSomeGreeter(_ g: some Greeter) async throws -> String {
+    print("sendSomeGreeter type: \(type(of: g))")
+    return try await g.sayHi()
+  }
+
+  public distributed func echoActor(_ g: any Greeter) async throws -> any Greeter {
+    print("echoActor type: \(type(of: g))")
+    return g
+  }
+}
+
+//--- Main.swift
+
+import GreeterAPILib
+import GreeterImplLib
+
+import Distributed
+import FakeDistributedActorSystems
+
+@main
+struct Main {
+  static func main() async throws {
+    if #available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *) {
+      let system = FakeRoundtripActorSystem()
+      let local = GreeterImpl(actorSystem: system)
+      let proxy = try GreeterImpl.resolve(id: local.id, using: system)
+
+      print("any Greeter")
+      // CHECK-LABEL: any Greeter
+      let r1 = try await proxy.sendAnyGreeter(local)
+      // CHECK: sendAnyGreeter type: $Greeter
+      print("r1: \(r1)")
+      // CHECK: r1: Hi from
+
+      print("some Greeter")
+      // CHECK-LABEL: some Greeter
+      let r2 = try await proxy.sendSomeGreeter(local)
+      // CHECK: sendSomeGreeter type: $Greeter
+      print("r2: \(r2)")
+      // CHECK: r2: Hi from
+
+      print("echo any Greeter -> any Greeter")
+      // CHECK-LABEL: echo any Greeter -> any Greeter
+      let echoed = try await proxy.echoActor(local)
+      // CHECK: echoActor type: $Greeter
+      print("echoed type: \(type(of: echoed))")
+      // CHECK: echoed type: $Greeter
+      let r3 = try await echoed.sayHi()
+      print("r3: \(r3)")
+      // CHECK: r3: Hi from
+
+      print("DONE")
+      // CHECK: DONE
+    }
+  }
+}

--- a/test/Distributed/distributed_func_resolvable_any_some_param_sema.swift
+++ b/test/Distributed/distributed_func_resolvable_any_some_param_sema.swift
@@ -41,7 +41,8 @@ distributed actor Worker {
 distributed actor BadComposition {
   typealias ActorSystem = FakeActorSystem
 
-  // expected-error@+1{{parameter '_' of type 'any Greeter & PowerSwitch' in distributed instance method contains more than one '@Resolvable protocol'; Declare new @Resolvable protocol that refines those protocols and use it instead}}
+  // expected-error@+2{{parameter '_' of type 'any Greeter & PowerSwitch' in distributed instance method contains more than one '@Resolvable protocol'}}
+  // expected-note@+1{{declare a new '@Resolvable protocol' that refines those protocols and use it instead}}
   distributed func ambiguous(_ g: any Greeter & PowerSwitch) {}
 }
 

--- a/test/Distributed/distributed_func_resolvable_any_some_param_sema.swift
+++ b/test/Distributed/distributed_func_resolvable_any_some_param_sema.swift
@@ -1,0 +1,75 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -target %target-swift-5.7-abi-triple %S/Inputs/FakeDistributedActorSystems.swift
+// RUN: %target-swift-frontend -typecheck -verify -verify-ignore-unrelated -verify-ignore-unknown -target %target-swift-6.0-abi-triple -plugin-path %swift-plugin-dir -I %t 2>&1 %s
+// REQUIRES: swift_swift_parser, asserts
+// REQUIRES: concurrency
+// REQUIRES: distributed
+
+import Distributed
+import FakeDistributedActorSystems
+
+typealias DefaultDistributedActorSystem = FakeActorSystem
+
+// ==== Sema accepts `some/any P` parameters when P is @Resolvable 
+
+@Resolvable
+protocol Greeter: DistributedActor, Codable where ActorSystem == FakeActorSystem {
+  distributed func greet() -> String
+}
+
+@Resolvable
+protocol PowerSwitch: DistributedActor, Codable where ActorSystem == FakeActorSystem {
+  distributed func toggle()
+}
+
+distributed actor Worker {
+  typealias ActorSystem = FakeActorSystem
+
+  // OK: `some Greeter` and `any Greeter` parameters round-trip via $Greeter.
+  distributed func sendSomeGreeter(_ g: some Greeter) {}
+  distributed func sendAnyGreeter(_ g: any Greeter) {}
+
+  // OK: a non-resolvable Codable param alongside a resolvable one.
+  distributed func mixed(_ g: any Greeter, count: Int) {}
+
+  // OK: multiple resolvable parameters are allowed
+  distributed func mixed(_ g: any Greeter, _ t: any PowerSwitch) {}
+}
+
+// ==== Bad: composition of two @Resolvable protocols is ambiguous -------
+
+distributed actor BadComposition {
+  typealias ActorSystem = FakeActorSystem
+
+  // expected-error@+1{{parameter '_' of type 'any Greeter & PowerSwitch' in distributed instance method contains more than one '@Resolvable protocol'; Declare new @Resolvable protocol that refines those protocols and use it instead}}
+  distributed func ambiguous(_ g: any Greeter & PowerSwitch) {}
+}
+
+// ==== Bad: @Resolvable protocol without concrete ActorSystem 
+
+@Resolvable
+protocol GenericProto: DistributedActor, Codable { // expected-note{{add 'where Self.ActorSystem == ...' to 'GenericProto'}}
+  distributed func ping()
+}
+
+distributed actor GenericSystemUser {
+  typealias ActorSystem = FakeActorSystem
+
+  // expected-error@+1{{parameter '_' of type 'any GenericProto' in distributed instance method uses '@Resolvable protocol' 'GenericProto' without a concrete 'ActorSystem' constraint}}
+  distributed func sendGeneric(_ g: any GenericProto) {}
+}
+
+// ==== Bad: @Resolvable protocol using different concrete ActorSystem 
+
+@Resolvable
+// expected-note@+1{{'@Resolvable protocol' 'DifferentSystemActor' uses actor system 'LocalTestingDistributedActorSystem'}}
+protocol DifferentSystemActor: DistributedActor, Codable where ActorSystem == LocalTestingDistributedActorSystem {
+  distributed func toggle()
+}
+
+distributed actor MismatchedSystemUser {
+  typealias ActorSystem = FakeActorSystem
+
+  // expected-error@+1{{parameter '_' of type 'any DifferentSystemActor' in distributed instance method must match the enclosing actor's ActorSystem ('MismatchedSystemUser.ActorSystem' (aka 'FakeActorSystem'))}}
+  distributed func sendGeneric(_ g: any DifferentSystemActor) {}
+}

--- a/test/SILOptimizer/dead_function_elimination_distributed_resolvable_proxy_adapter.swift
+++ b/test/SILOptimizer/dead_function_elimination_distributed_resolvable_proxy_adapter.swift
@@ -1,0 +1,77 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -target %target-swift-6.0-abi-triple %S/../Distributed/Inputs/FakeDistributedActorSystems.swift -plugin-path %swift-plugin-dir
+// RUN: %target-swift-frontend %s -O -emit-sil -target %target-swift-6.0-abi-triple -plugin-path %swift-plugin-dir -I %t | %FileCheck %s
+
+// REQUIRES: concurrency
+// REQUIRES: distributed
+// REQUIRES: swift_swift_parser, asserts
+
+// Verify that dead function elimination does NOT remove the synthesized
+// `$distributedProxyAdapter$<base>` thunk that the IR-only distributed
+// accessor dispatches through when a `distributed func` / `distributed var`
+// has a `@Resolvable any P` / `some P` parameter or result. The accessor
+// references the adapter thunk by name at IRGen time (no SIL-level caller),
+// so DFE must treat it as alive — same reasoning that already protects
+// regular distributed thunks (see dead_function_elimination_distributed.swift).
+
+import Distributed
+import FakeDistributedActorSystems
+
+@Resolvable
+protocol Greeter: DistributedActor, Codable
+where ActorSystem == FakeRoundtripActorSystem {
+  distributed func sendAnyGreeter(_ g: any Greeter) async throws -> String
+  distributed func sendSomeGreeter(_ g: some Greeter) async throws -> String
+  distributed func echoActor(_ g: any Greeter) async throws -> any Greeter
+  distributed var currentSelf: any Greeter { get }
+}
+
+distributed actor GreeterImpl: Greeter {
+  distributed func sendAnyGreeter(_ g: any Greeter) async throws -> String { "" }
+  distributed func sendSomeGreeter(_ g: some Greeter) async throws -> String { "" }
+  distributed func echoActor(_ g: any Greeter) async throws -> any Greeter { g }
+  distributed var currentSelf: any Greeter {
+    try! $Greeter.resolve(id: id, using: actorSystem)
+  }
+}
+
+// ==== -----------------------------------------------------------------------
+// On Impl actor: adapter thunks must survive DFE.
+
+// CHECK-LABEL: GreeterImpl.$distributedProxyAdapter$sendAnyGreeter
+// CHECK: sil hidden [distributed_proxy_adapter_thunk]
+// CHECK-SAME: $@convention(method) @async (@sil_sending @guaranteed $Greeter, @guaranteed GreeterImpl) -> (@owned String, @error any Error)
+
+// CHECK-LABEL: GreeterImpl.$distributedProxyAdapter$sendSomeGreeter
+// CHECK: sil hidden [distributed_proxy_adapter_thunk]
+// CHECK-SAME: <τ_0_0 where τ_0_0 : Greeter> (@sil_sending @guaranteed $Greeter, @guaranteed GreeterImpl) -> (@owned String, @error any Error)
+
+// CHECK-LABEL: GreeterImpl.$distributedProxyAdapter$echoActor
+// CHECK: sil hidden [distributed_proxy_adapter_thunk]
+// CHECK-SAME: $@convention(method) @async (@sil_sending @guaranteed $Greeter, @guaranteed GreeterImpl) -> (@owned $Greeter, @error any Error)
+
+// CHECK-LABEL: GreeterImpl.$distributedProxyAdapter$currentSelf
+// CHECK: sil hidden [distributed_proxy_adapter_thunk]
+// CHECK-SAME: $@convention(method) @async (@guaranteed GreeterImpl) -> (@owned $Greeter, @error any Error)
+
+// ==== -----------------------------------------------------------------------
+
+// On the protocol's `_DistributedActorStub` extension:
+// adapter thunks must also survive, because
+// the `$Greeter` proxy stub's witnesses dispatch through them.
+
+// CHECK-LABEL: Greeter<>.$distributedProxyAdapter$sendAnyGreeter
+// CHECK: sil hidden [distributed_proxy_adapter_thunk]
+// CHECK-SAME: <Self where Self : _DistributedActorStub, Self : Greeter> (@sil_sending @guaranteed $Greeter, @guaranteed Self) -> (@owned String, @error any Error)
+
+// CHECK-LABEL: Greeter<>.$distributedProxyAdapter$sendSomeGreeter
+// CHECK: sil hidden [distributed_proxy_adapter_thunk]
+// CHECK-SAME: <Self where Self : _DistributedActorStub, Self : Greeter><τ_1_0 where τ_1_0 : Greeter> (@sil_sending @guaranteed $Greeter, @guaranteed Self) -> (@owned String, @error any Error)
+
+// CHECK-LABEL: Greeter<>.$distributedProxyAdapter$echoActor
+// CHECK: sil hidden [distributed_proxy_adapter_thunk]
+// CHECK-SAME: <Self where Self : _DistributedActorStub, Self : Greeter> (@sil_sending @guaranteed $Greeter, @guaranteed Self) -> (@owned $Greeter, @error any Error)
+
+// CHECK-LABEL: Greeter<>.$distributedProxyAdapter$currentSelf
+// CHECK: sil hidden [distributed_proxy_adapter_thunk]
+// CHECK-SAME: <Self where Self : _DistributedActorStub, Self : Greeter> (@guaranteed Self) -> (@owned $Greeter, @error any Error)


### PR DESCRIPTION
By encoding and decoding such protocol typed parameters in distributed calls, as the well-known proxy type $Greeter for any such protocol, we can automatically support sending any Greeter or some Greeter to remote systems which do not know the actual implementation types we're "sending" -- because we never send the actual type, just a remote reference.

Resolves rdar://147378430
Resolves rdar://143094724
