### PR TITLE
Wasm: fix `async` typed throws arguments mismatch trap

### DIFF
--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -491,6 +491,10 @@ LEGACY_PASS(MarkNeverWrittenMutableClosureBoxesAsImmutable, "mark-never-written-
      "Mark never written mutable closure boxes as immutable")
 LEGACY_PASS(PruneVTables, "prune-vtables",
      "Mark class methods that do not require vtable dispatch")
+LEGACY_PASS(WasmAsyncT2TLowering, "wasm-async-t2t-lowering",
+     "On wasm targets, rewrite async typed-throws thin_to_thick_function "
+     "to zero-capture partial_apply [on_stack] to work around the "
+     "wasm backend's swiftcc parameter padding bug (issue #89320)")
 
 //===----------------------------------------------------------------------===//
 //

--- a/lib/SILOptimizer/Mandatory/CMakeLists.txt
+++ b/lib/SILOptimizer/Mandatory/CMakeLists.txt
@@ -53,4 +53,5 @@ target_sources(swiftSILOptimizer PRIVATE
   MarkNeverWrittenMutableClosureBoxesAsImmutable.cpp
   RegionAnalysisInvalidationTransform.cpp
   DiagnosticDeadFunctionElimination.cpp
+  WasmAsyncT2TLowering.cpp
   OwnershipModelEliminator.cpp)

--- a/lib/SILOptimizer/Mandatory/WasmAsyncT2TLowering.cpp
+++ b/lib/SILOptimizer/Mandatory/WasmAsyncT2TLowering.cpp
@@ -1,0 +1,140 @@
+//===--- WasmAsyncT2TLowering.cpp - Rewrite async t2t to partial_apply ----===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+//
+// Workaround for swiftlang/swift#89320: on wasm32/wasm64 the WebAssembly
+// backend's swiftcc parameter padding pass inserts swiftself/swifterror
+// at the trailing position to make caller/callee wasm signatures match
+// for `call_indirect`. Async typed-throws closures emit a trailing
+// `ind_error_ptr` regular parameter AFTER the swiftself slot, so when a
+// Thick caller (with swiftself in the middle) calls a Thin callee
+// (without swiftself), the wasm padding produces positional misalignment:
+// the callee reads `ind_error_ptr` from the slot the caller passes
+// swiftself in, and reads swiftself from the slot the caller passes
+// `ind_error_ptr` in. The typed error value ends up written to a null
+// context pointer; the caller reads zeros from the real error slot.
+//
+// This pass rewrites the affected `thin_to_thick_function` instructions
+// into zero-capture `partial_apply [callee_guaranteed] [on_stack]`. The
+// partial_apply path uses an explicit context allocation that produces
+// LLVM IR with matching positional layout on both caller and callee,
+// avoiding the wasm backend padding mismatch.
+//
+//===----------------------------------------------------------------------===//
+
+#define DEBUG_TYPE "wasm-async-t2t-lowering"
+#include "swift/SIL/SILBuilder.h"
+#include "swift/SIL/SILFunction.h"
+#include "swift/SIL/SILInstruction.h"
+#include "swift/SILOptimizer/PassManager/Transforms.h"
+#include "llvm/Support/Debug.h"
+
+using namespace swift;
+
+namespace {
+
+/// Returns true if `t2t` matches the issue#89320 bug shape and can be
+/// safely rewritten to a zero-capture `partial_apply [on_stack]`.
+static bool shouldRewriteT2T(ThinToThickFunctionInst *t2t) {
+  auto operandType = t2t->getOperand()->getType().castTo<SILFunctionType>();
+  auto resultType = t2t->getType().castTo<SILFunctionType>();
+
+  if (!operandType->isAsync())
+    return false;
+  if (!operandType->hasIndirectErrorResult())
+    return false;
+
+  // Restrict to non-polymorphic shapes for the same reason the IRGen
+  // wrapper did: arg-walking gets complex with polymorphic metadata.
+  if (operandType->isPolymorphic() || resultType->isPolymorphic())
+    return false;
+
+  // Don't rewrite if the operand is not a function_ref or one of its
+  // subclasses; the operand-kind expansion is orthogonal to this pass.
+  if (!isa<FunctionRefBaseInst>(t2t->getOperand()))
+    return false;
+
+  return true;
+}
+
+/// Rewrite a single `thin_to_thick_function` to a zero-capture
+/// `partial_apply [callee_guaranteed] [on_stack]`, then insert
+/// `dealloc_stack` after each terminating use.
+///
+/// Returns true if the rewrite succeeded.
+static bool rewriteToPartialApply(ThinToThickFunctionInst *t2t) {
+  // We only handle t2t whose result is consumed in a way we can
+  // unambiguously bracket with a single dealloc_stack. Specifically,
+  // every use must be in the same basic block (or strictly dominated
+  // by the t2t). For the issue#89320 repro shapes, SILGen always
+  // produces a t2t immediately followed by its consuming apply in
+  // the same BB, so this constraint covers the bug.
+  SILBasicBlock *parentBB = t2t->getParent();
+  SILInstruction *lastUse = t2t;
+  for (auto *use : t2t->getUses()) {
+    if (use->getUser()->getParent() != parentBB)
+      return false;
+    if (lastUse == t2t ||
+        std::distance(lastUse->getIterator(), use->getUser()->getIterator()) > 0)
+      lastUse = use->getUser();
+  }
+
+  SILBuilderWithScope builder(t2t);
+
+  auto *pa = builder.createPartialApply(
+      t2t->getLoc(),
+      t2t->getOperand(),
+      /*Subs=*/SubstitutionMap(),
+      /*Args=*/{},
+      ParameterConvention::Direct_Guaranteed,
+      SILFunctionTypeIsolation::forUnknown(),
+      PartialApplyInst::OnStackKind::OnStack);
+
+  t2t->replaceAllUsesWith(pa);
+  t2t->eraseFromParent();
+
+  SILBuilderWithScope deallocBuilder(std::next(lastUse->getIterator()));
+  deallocBuilder.createDeallocStack(lastUse->getLoc(), pa);
+
+  return true;
+}
+
+class WasmAsyncT2TLoweringPass : public SILFunctionTransform {
+  void run() override {
+    SILFunction *F = getFunction();
+    if (!F->getModule().getASTContext().LangOpts.Target.isWasm())
+      return;
+
+    llvm::SmallVector<ThinToThickFunctionInst *, 4> toRewrite;
+    for (auto &BB : *F) {
+      for (auto &I : BB) {
+        if (auto *t2t = dyn_cast<ThinToThickFunctionInst>(&I)) {
+          if (shouldRewriteT2T(t2t))
+            toRewrite.push_back(t2t);
+        }
+      }
+    }
+
+    bool changed = false;
+    for (auto *t2t : toRewrite) {
+      if (rewriteToPartialApply(t2t))
+        changed = true;
+    }
+
+    if (changed)
+      invalidateAnalysis(SILAnalysis::InvalidationKind::Instructions);
+  }
+};
+
+} // end anonymous namespace
+
+SILTransform *swift::createWasmAsyncT2TLowering() {
+  return new WasmAsyncT2TLoweringPass();
+}

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -925,6 +925,12 @@ SILPassPipelinePlan::getLoweringPassPipeline(const SILOptions &Options) {
   P.addThunkLowering();
   P.addLowerHopToActor(); // FIXME: earlier for more opportunities?
   P.addOwnershipModelEliminator();
+  // Workaround for the wasm backend's swiftcc parameter padding bug
+  // (issue #89320): rewrite async typed-throws thin_to_thick_function
+  // instructions on wasm into zero-capture partial_apply [on_stack].
+  // Runs after ownership elimination so dealloc_stack of the on-stack
+  // partial_apply is valid in lowered (non-OSSA) SIL. No-op off wasm.
+  P.addWasmAsyncT2TLowering();
   P.addAlwaysEmitConformanceMetadataPreservation();
   P.addIRGenPrepare();
 

--- a/test/IRGen/async_typed_throws_nonwasm.swift
+++ b/test/IRGen/async_typed_throws_nonwasm.swift
@@ -1,0 +1,37 @@
+// RUN: %target-swift-frontend -primary-file %s \
+// RUN:   -emit-ir -parse-as-library -disable-availability-checking \
+// RUN:   | %FileCheck %s
+
+// REQUIRES: concurrency
+// UNSUPPORTED: CPU=wasm32
+// UNSUPPORTED: CPU=wasm64
+
+enum E: Error { case boom }
+
+func run<T, Failure: Error>(
+  _ body: () async throws(Failure) -> T
+) async -> Result<T, Failure> {
+  do { return .success(try await body()) }
+  catch { return .failure(error) }
+}
+
+@main
+struct Main {
+  static func main() async {
+    let r = await run { () async throws -> String in throw E.boom }
+    _ = r
+  }
+}
+
+// Off-wasm regression guard for the `TwasmA` thin-to-thick wrapper introduced
+// for swiftlang/swift#89320. The wrapper exists to work around an LLVM wasm
+// backend lowering bug; on every non-wasm target, `IGM.Triple.isWasm()`
+// short-circuits the predicate in IRGenSIL.cpp and the wrapper is NOT
+// emitted. main() must call run() passing the closure's own Tu directly.
+
+// CHECK-LABEL: define {{(hidden|internal)}} {{(swiftcc|swifttailcc)}} void @"$s{{[^"]+}}4MainV4mainyyYaFZ"
+// CHECK: call {{(swiftcc|swifttailcc)}} void @"$s{{[^"]+}}3runy{{[^"]+}}"({{.*}} ptr @"$s{{[^"]+}}fU_Tu",
+
+// Wrapper symbols MUST NOT appear in the module on any non-wasm target.
+// `TwasmA` matches both the wrapper definition and its Tu global.
+// CHECK-NOT: TwasmA

--- a/test/IRGen/async_typed_throws_nonwasm.swift
+++ b/test/IRGen/async_typed_throws_nonwasm.swift
@@ -24,10 +24,7 @@ struct Main {
 }
 
 // Off-wasm regression guard for the `TwasmA` thin-to-thick wrapper introduced
-// for swiftlang/swift#89320. The wrapper exists to work around an LLVM wasm
-// backend lowering bug; on every non-wasm target, `IGM.Triple.isWasm()`
-// short-circuits the predicate in IRGenSIL.cpp and the wrapper is NOT
-// emitted. main() must call run() passing the closure's own Tu directly.
+// for swiftlang/swift#89320.
 
 // CHECK-LABEL: define {{(hidden|internal)}} {{(swiftcc|swifttailcc)}} void @"$s{{[^"]+}}4MainV4mainyyYaFZ"
 // CHECK: call {{(swiftcc|swifttailcc)}} void @"$s{{[^"]+}}3runy{{[^"]+}}"({{.*}} ptr @"$s{{[^"]+}}fU_Tu",

--- a/test/Interpreter/async_typed_throws_wasm.swift
+++ b/test/Interpreter/async_typed_throws_wasm.swift
@@ -1,0 +1,194 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -parse-as-library -Onone %s -o %t/main
+// RUN: %target-run %t/main | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: concurrency_runtime
+// REQUIRES: OS=wasip1
+
+enum SmallErr: Error { case boom }
+
+struct LargeErr: Error {
+  var tag: Int
+  var pad: (Int, Int, Int, Int)
+}
+
+struct LargeResult {
+  var tag: Int
+  var pad: (Int, Int, Int, Int, Int, Int, Int, Int)
+}
+
+func run<T, Failure: Error>(
+  _ body: () async throws(Failure) -> T
+) async -> Result<T, Failure> {
+  do { return .success(try await body()) }
+  catch { return .failure(error) }
+}
+
+func runIdent(_ body: () async -> String) async -> String {
+  await body()
+}
+
+// For shape h: stored function pointer (forces non-FunctionRef SIL operand).
+enum StoredClosure {
+  static let boomClosure: () async throws(SmallErr) -> String = {
+    throw SmallErr.boom
+  }
+}
+
+// For shape j: witness-method async typed-throws.
+protocol AsyncBoom {
+  associatedtype Failure: Error
+  func boom() async throws(Failure) -> String
+}
+
+struct BoomThrower: AsyncBoom {
+  typealias Failure = SmallErr
+  func boom() async throws(SmallErr) -> String { throw .boom }
+}
+
+func invokeWitness<T: AsyncBoom>(_ x: T) async -> Result<String, T.Failure> {
+  do { return .success(try await x.boom()) }
+  catch { return .failure(error) }
+}
+
+// For shape k: Thick self-context (actor method invoking a typed-throws closure).
+actor BoomActor {
+  func run() async -> Result<String, SmallErr> {
+    do {
+      return .success(try await { () async throws(SmallErr) -> String in
+        throw SmallErr.boom
+      }())
+    } catch {
+      return .failure(error)
+    }
+  }
+}
+
+@main
+struct Main {
+  static func main() async {
+    // a: untyped throws (the issue #89320 repro shape).
+    let a = await run { () async throws -> String in throw SmallErr.boom }
+    switch a {
+    case .success(let s): print("a-ok: \(s)")
+    case .failure(let e): print("a-err: \(e)")
+    }
+    // CHECK: a-err: boom
+
+    // b: typed throws, small error enum.
+    let b = await run { () async throws(SmallErr) -> String in
+      throw SmallErr.boom
+    }
+    switch b {
+    case .success(let s): print("b-ok: \(s)")
+    case .failure(let e): print("b-err: \(e)")
+    }
+    // CHECK-NEXT: b-err: boom
+
+    // c: typed throws, large error struct (forces ind_error indirection).
+    let c = await run { () async throws(LargeErr) -> String in
+      throw LargeErr(tag: 42, pad: (0, 0, 0, 0))
+    }
+    switch c {
+    case .success(let s): print("c-ok: \(s)")
+    case .failure(let e): print("c-err: tag=\(e.tag)")
+    }
+    // CHECK-NEXT: c-err: tag=42
+
+    // d: success path, no throws taken.
+    let d = await run { () async throws -> String in "yay" }
+    switch d {
+    case .success(let s): print("d-ok: \(s)")
+    case .failure(let e): print("d-err: \(e)")
+    }
+    // CHECK-NEXT: d-ok: yay
+
+    // e: non-throws closure passed through a t2t, exercises the
+    // predicate's negative branch (no indirect error result, so predicate
+    // returns false and no wrapper is emitted; default lowering).
+    let e = await runIdent { () async -> String in "noerror" }
+    print("e-ok: \(e)")
+    // CHECK-NEXT: e-ok: noerror
+
+    // f: generic async typed-throws via explicit type argument
+    // (R3 — polymorphic SIL function type rejected by SIL workaround).
+    let f: Result<String, SmallErr> = await run {
+      () async throws(SmallErr) -> String in throw SmallErr.boom
+    }
+    switch f {
+    case .success(let s): print("f-ok: \(s)")
+    case .failure(let e): print("f-err: \(e)")
+    }
+    // CHECK-NEXT: f-err: boom
+
+    // g: t2t fed by phi/block-arg operand (R4 — non-FunctionRef rejected).
+    let cond = Bool.random()
+    let g: Result<String, SmallErr> = await run {
+      () async throws(SmallErr) -> String in
+        if cond { throw SmallErr.boom } else { throw SmallErr.boom }
+    }
+    switch g {
+    case .success(let s): print("g-ok: \(s)")
+    case .failure(let e): print("g-err: \(e)")
+    }
+    // CHECK-NEXT: g-err: boom
+
+    // h: closure loaded from a stored global (R4 — non-FunctionRef operand).
+    let h: Result<String, SmallErr> = await run(StoredClosure.boomClosure)
+    switch h {
+    case .success(let s): print("h-ok: \(s)")
+    case .failure(let e): print("h-err: \(e)")
+    }
+    // CHECK-NEXT: h-err: boom
+
+    // i: t2t result used across BBs (R5 — cross-BB use rejected).
+    var iResult: Result<String, SmallErr>?
+    let iClosure: () async throws(SmallErr) -> String = {
+      throw SmallErr.boom
+    }
+    if Bool.random() || true {
+      iResult = await run(iClosure)
+    }
+    switch iResult! {
+    case .success(let s): print("i-ok: \(s)")
+    case .failure(let e): print("i-err: \(e)")
+    }
+    // CHECK-NEXT: i-err: boom
+
+    // j: witness-method async typed-throws (R3 via Self-as-polymorphic).
+    let j = await invokeWitness(BoomThrower())
+    switch j {
+    case .success(let s): print("j-ok: \(s)")
+    case .failure(let e): print("j-err: \(e)")
+    }
+    // CHECK-NEXT: j-err: boom
+
+    // k: Thick-self-context async typed-throws (actor isolation).
+    let k = await BoomActor().run()
+    switch k {
+    case .success(let s): print("k-ok: \(s)")
+    case .failure(let e): print("k-err: \(e)")
+    }
+    // CHECK-NEXT: k-err: boom
+
+    // l: large indirect result + indirect error (exercises both
+    // hasIndirectSILResults and the typed-error indirect-return path).
+    let l: Result<LargeResult, LargeErr> = await run {
+      () async throws(LargeErr) -> LargeResult in
+        throw LargeErr(tag: 99, pad: (0, 0, 0, 0))
+    }
+    switch l {
+    case .success(let r): print("l-ok: tag=\(r.tag)")
+    case .failure(let e): print("l-err: tag=\(e.tag)")
+    }
+    // CHECK-NEXT: l-err: tag=99
+
+    // m: NEGATIVE — async non-throws (no indirect-error slot, no marker
+    // attached, must work). Regression guard against spurious padding.
+    let m = await runIdent { () async -> String in "no-error" }
+    print("m-ok: \(m)")
+    // CHECK-NEXT: m-ok: no-error
+  }
+}

--- a/test/Interpreter/async_typed_throws_wasm_formal_params.swift
+++ b/test/Interpreter/async_typed_throws_wasm_formal_params.swift
@@ -1,0 +1,49 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -parse-as-library -Onone %s -o %t/main
+// RUN: %target-run %t/main | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: concurrency_runtime
+// REQUIRES: OS=wasip1
+
+// Regression test for the wasm async typed-throws t2t wrapper's formal-param
+// arity bug (swiftlang/swift#89320 follow-up): the wrapper's argument-walking
+// loop iterates over `outType->getParameters().size()` and consumes one LLVM
+// arg per iteration, but a SIL formal parameter can expand to multiple LLVM
+// args (e.g., String = 3 wasm32 words, multi-word structs, tuples).
+//
+// On wasm32, `(Int, String, Bool) async throws(LargeErr) -> String` lowers to:
+//   Int    = 1 LLVM arg
+//   String = 3 LLVM args (guts + payload + discrim)
+//   Bool   = 1 LLVM arg
+// = 5 LLVM arg slots for 3 SIL formal params. The wrapper's loop runs 3 times
+// and consumes only 3 LLVM slots, mis-attributing the remaining slots to
+// swiftself / ind_error.
+
+enum LargeErr: Error {
+  case boom(Int, Int, Int, Int)
+}
+
+func runMulti<T, Failure: Error>(
+  _ a: Int, _ b: String, _ c: Bool,
+  _ body: (Int, String, Bool) async throws(Failure) -> T
+) async -> Result<T, Failure> {
+  do { return .success(try await body(a, b, c)) }
+  catch { return .failure(error) }
+}
+
+@main
+struct Main {
+  static func main() async {
+    let r = await runMulti(42, "hello", true) {
+      (x, y, z) async throws(LargeErr) -> String in
+      "x=\(x) y=\(y) z=\(z)"
+    }
+    switch r {
+    case .success(let s): print("ok: \(s)")
+    case .failure(let e): print("err: \(e)")
+    }
+    // CHECK: ok: x=42 y=hello z=true
+  }
+}


### PR DESCRIPTION
Workaround for issue #89320: a Wasm runtime trap when `async` typed-throws closures are coerced via `thin_to_thick_function`. The WebAssembly backend pads swiftcc signatures with trailing `swiftself`/`swifterror` placeholders to align `call_indirect`. On thin `async` typed-throws callees the padding collides positionally with the trailing `ind_error_ptr`, miscompiling calls from thick callers.

This PR adds a mandatory SIL pass `WasmAsyncT2TLowering` (gated on `Triple::isWasm()`, runs after `OwnershipModelEliminator`) that rewrites the narrow bug shape (`isAsync`, `hasIndirectErrorResult`, non-polymorphic operand/result, `FunctionRefBaseInst` operand, single-BB uses) into a zero-capture `partial_apply [callee_guaranteed] [on_stack]` bracketed by `dealloc_stack`. The `partial_apply` lowering emits matching caller and callee arg layouts at the LLVM level, sidestepping the backend padding mismatch.

Resolves https://github.com/swiftlang/swift/issues/89320
rdar://177615931
