### PR TITLE
wasistdlib.py: Add `SILOptimizer` to lit test paths

### DIFF
--- a/test/SILOptimizer/Inputs/cross-module/c-module.c
+++ b/test/SILOptimizer/Inputs/cross-module/c-module.c
@@ -1,7 +1,7 @@
 
 #include "c-module.h"
 
-long privateCFunc() {
+long privateCFunc(void) {
   return 123;
 }
 

--- a/test/SILOptimizer/Inputs/cross-module/c-module.h
+++ b/test/SILOptimizer/Inputs/cross-module/c-module.h
@@ -1,4 +1,4 @@
 
-long privateCFunc();
+long privateCFunc(void);
 
 long privateCVar;

--- a/test/SILOptimizer/assemblyvision_remark/basic_yaml.swift
+++ b/test/SILOptimizer/assemblyvision_remark/basic_yaml.swift
@@ -17,7 +17,7 @@ public class Klass {}
 // CHECK-NEXT: Name:            sil.memory
 // CHECK-NEXT: DebugLoc:        { File: '{{.*}}basic_yaml.swift',
 // CHECK-NEXT:                    Line: [[# @LINE + 7 ]], Column: 21 }
-// CHECK-NEXT: Function:        main
+// CHECK-NEXT: Function:        {{main|__main_argc_argv}}
 // CHECK-NEXT: Args:
 // CHECK-NEXT:   - String:          'heap allocated ref of type '''
 // CHECK-NEXT:   - ValueType:       Klass

--- a/test/SILOptimizer/c_string_optimization.swift
+++ b/test/SILOptimizer/c_string_optimization.swift
@@ -12,6 +12,8 @@
   import Glibc
 #elseif canImport(Android)
   import Android
+#elseif canImport(WASILibc)
+  import WASILibc
 #elseif os(Windows)
   import CRT
 #else

--- a/test/SILOptimizer/concat_string_literals.32.swift
+++ b/test/SILOptimizer/concat_string_literals.32.swift
@@ -4,6 +4,8 @@
 
 // We have a separate test for 64-bit architectures.
 // REQUIRES: PTRSIZE=32
+// wasm32: multi-byte inline-string fold not applied
+// UNSUPPORTED: OS=wasip1
 // XFAIL: OS=linux-androideabi
 
 // NOTE: 25185.byteSwapped = 0x62 'a', 0x61 'b'

--- a/test/SILOptimizer/definite_init_cross_module.swift
+++ b/test/SILOptimizer/definite_init_cross_module.swift
@@ -6,6 +6,8 @@
 // RUN: %target-swift-frontend -emit-module -emit-module-path=%t/OtherModule.swiftmodule %S/Inputs/definite_init_cross_module/OtherModule.swift
 // RUN: %target-swift-frontend -emit-sil -verify -I %t -swift-version 5 %s > /dev/null -enable-objc-interop -disable-objc-attr-requires-foundation-module -import-objc-header %S/Inputs/definite_init_cross_module/BridgingHeader.h
 
+// REQUIRES: objc_codegen
+
 import OtherModule
 
 extension Point {

--- a/test/SILOptimizer/definite_init_cross_module_swift4.swift
+++ b/test/SILOptimizer/definite_init_cross_module_swift4.swift
@@ -6,6 +6,8 @@
 // RUN: %target-swift-frontend -emit-module -emit-module-path=%t/OtherModule.swiftmodule %S/Inputs/definite_init_cross_module/OtherModule.swift
 // RUN: %target-swift-frontend -emit-sil -verify -verify-ignore-unknown -I %t -swift-version 4 %s > /dev/null -enable-objc-interop -disable-objc-attr-requires-foundation-module -import-objc-header %S/Inputs/definite_init_cross_module/BridgingHeader.h
 
+// REQUIRES: objc_codegen
+
 import OtherModule
 
 extension Point {

--- a/test/SILOptimizer/devirt_jump_thread.sil
+++ b/test/SILOptimizer/devirt_jump_thread.sil
@@ -1,5 +1,7 @@
 // RUN: %target-sil-opt -enable-objc-interop -enable-sil-verify-all %s -jumpthread-simplify-cfg -common-subexpression-elimination | %FileCheck %s
 
+// REQUIRES: objc_codegen
+
 // Check that jump-threading works for sequences of checked_cast_br instructions produced by the devirtualizer.
 // This allows for simplifications of code like e.g. f.foo() + f.foo()
 

--- a/test/SILOptimizer/devirt_nested_class.swift
+++ b/test/SILOptimizer/devirt_nested_class.swift
@@ -26,6 +26,6 @@ fileprivate func foo<T, U, V>(d: Outer<T>.Inner<U>, v: V) {
 
 foo(d: Outer<Int>.Inner<Int>(), v: 0)
 
-// CHECK-LABEL: sil {{.*}}@main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32
+// CHECK-LABEL: sil {{.*}}@{{main|__main_argc_argv}} : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32
 // CHECK: function_ref @$s19devirt_nested_class5Outer{{.*}}LC5InnerC6method1vyqd0___tlF : $@convention(method) <τ_0_0><τ_1_0><τ_2_0> (@in_guaranteed τ_2_0, @guaranteed Outer<τ_0_0>.Inner<τ_1_0>) -> ()
 // CHECK: return

--- a/test/SILOptimizer/devirt_specialized_conformance.swift
+++ b/test/SILOptimizer/devirt_specialized_conformance.swift
@@ -3,7 +3,7 @@
 // Make sure that we completely inline/devirtualize/substitute all the way down
 // to unknown1.
 
-// CHECK-LABEL: sil {{.*}}@main
+// CHECK-LABEL: sil {{.*}}@{{main|__main_argc_argv}}
 // CHECK: bb0({{.*}}):
 // CHECK: function_ref @unknown1
 // CHECK: apply

--- a/test/SILOptimizer/exclusivity_violation.swift
+++ b/test/SILOptimizer/exclusivity_violation.swift
@@ -6,6 +6,10 @@
 // For some reason we don't get exclusivity violations on older OSes
 // UNSUPPORTED: back_deployment_runtime
 
+// expectCrashLater() relies on StdlibUnittest's spawnChild, which is
+// `fatalError` on WASI (no fork()/posix_spawn()).
+// UNSUPPORTED: OS=wasip1
+
 import StdlibUnittest
 
 

--- a/test/SILOptimizer/existential_type_propagation.sil
+++ b/test/SILOptimizer/existential_type_propagation.sil
@@ -1,5 +1,7 @@
 // RUN: %target-sil-opt -sil-print-types -enable-objc-interop -enable-sil-verify-all %s -sil-combine -devirtualizer -inline -sil-combine | %FileCheck %s
 
+// REQUIRES: objc_codegen
+
 // Check that type propagation is performed correctly for existentials.
 // The concrete type set in init_existential instructions should be propagated
 // all the way down to witness_method instructions.

--- a/test/SILOptimizer/inline_self.swift
+++ b/test/SILOptimizer/inline_self.swift
@@ -74,7 +74,7 @@ class Z : BaseZ {
 
 _ = Z().capturesSelf()
 
-// CHECK-LABEL: sil {{.*}}@main : $@convention(c)
+// CHECK-LABEL: sil {{.*}}@{{main|__main_argc_argv}} : $@convention(c)
 // CHECK: function_ref static inline_self.C.factory(Swift.Int) -> Self
 // CHECK: [[F:%[0-9]+]] = function_ref @$s11inline_self1CC7factory{{[_0-9a-zA-Z]*}}FZ : $@convention(method) (Int, @thick C.Type) -> @owned C
 // CHECK: apply [[F]](%{{.+}}, %{{.+}}) : $@convention(method) (Int, @thick C.Type) -> @owned C

--- a/test/SILOptimizer/inlinearray_bounds_check_tests.swift
+++ b/test/SILOptimizer/inlinearray_bounds_check_tests.swift
@@ -7,6 +7,9 @@
 // REQUIRES: swift_in_compiler
 // REQUIRES: swift_stdlib_no_asserts, optimized_stdlib
 
+// CHECK-IR shape differs on wasm32: optimized vector-reduce form not produced, trap retained
+// XFAIL: OS=wasip1
+
 // Bounds check should be eliminated
 // Induction variable optimization eliminates the bounds check in SIL
 // CHECK-SIL-LABEL: sil @$s30inlinearray_bounds_check_tests0A29_sum_iterate_to_count_wo_trapySis11InlineArrayVyxSiGSiRVzlF :

--- a/test/SILOptimizer/looprotate.sil
+++ b/test/SILOptimizer/looprotate.sil
@@ -1,5 +1,7 @@
 // RUN: %target-sil-opt -sil-print-types -enable-objc-interop -enforce-exclusivity=none -enable-sil-verify-all -loop-rotate %s | %FileCheck %s
 
+// REQUIRES: objc_codegen
+
 // Declare this SIL to be canonical because some tests break raw SIL
 // conventions. e.g. address-type block args. -enforce-exclusivity=none is also
 // required to allow address-type block args in canonical SIL.

--- a/test/SILOptimizer/looprotate_ossa.sil
+++ b/test/SILOptimizer/looprotate_ossa.sil
@@ -1,5 +1,7 @@
 // RUN: %target-sil-opt -sil-print-types -enable-objc-interop -enforce-exclusivity=none -enable-sil-verify-all -loop-rotate %s | %FileCheck %s
 
+// REQUIRES: objc_codegen
+
 // Declare this SIL to be canonical because some tests break raw SIL
 // conventions. e.g. address-type block args. -enforce-exclusivity=none is also
 // required to allow address-type block args in canonical SIL.

--- a/test/SILOptimizer/mandatory_inlining.sil
+++ b/test/SILOptimizer/mandatory_inlining.sil
@@ -2,6 +2,7 @@
 
 // guardmalloc is incompatible with ASAN
 // REQUIRES: no_asan
+// REQUIRES: objc_codegen
 
 import Builtin
 import Swift

--- a/test/SILOptimizer/mandatory_inlining_inline_always.sil
+++ b/test/SILOptimizer/mandatory_inlining_inline_always.sil
@@ -2,6 +2,7 @@
 
 // guardmalloc is incompatible with ASAN
 // REQUIRES: no_asan
+// REQUIRES: objc_codegen
 
 import Builtin
 import Swift

--- a/test/SILOptimizer/mandatory_inlining_ownership2.sil
+++ b/test/SILOptimizer/mandatory_inlining_ownership2.sil
@@ -1,5 +1,7 @@
 // RUN: %target-sil-opt -sil-print-types -enable-objc-interop -module-name mandatory_inlining -enable-sil-verify-all %s -mandatory-inlining | %FileCheck %s
 
+// REQUIRES: objc_codegen
+
 import Builtin
 import Swift
 

--- a/test/SILOptimizer/mutable_span_bounds_check_tests.swift
+++ b/test/SILOptimizer/mutable_span_bounds_check_tests.swift
@@ -7,6 +7,9 @@
 
 // REQUIRES: swift_stdlib_no_asserts, optimized_stdlib
 
+// CHECK-IR shape differs on wasm32: optimized vector-reduce form not produced, trap retained
+// XFAIL: OS=wasip1
+
 // CHECK-SIL-LABEL: sil @$s31mutable_span_bounds_check_tests0a1_B11_sum_w_trapySis11MutableSpanVySiGF :
 // CHECK-SIL: bb3({{.*}}):
 // CHECK-SIL-NOT: cond_fail {{.*}}, "index out of bounds"

--- a/test/SILOptimizer/predictable_memopt_unreferenceable_storage.swift
+++ b/test/SILOptimizer/predictable_memopt_unreferenceable_storage.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -Xllvm -sil-print-types -emit-sil %s | %FileCheck %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk -Xcc -isystem -Xcc %clang-importer-sdk-path/usr/include) -Xllvm -sil-print-types -emit-sil %s | %FileCheck %s
 
 import ctypes
 struct S {

--- a/test/SILOptimizer/sil_combine.sil
+++ b/test/SILOptimizer/sil_combine.sil
@@ -1,6 +1,7 @@
 // RUN: %target-sil-opt -sil-print-types -enable-objc-interop -enable-sil-verify-all %s -sil-combine | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
+// REQUIRES: objc_codegen
 
 // Declare this SIL to be canonical because some tests break raw SIL
 // conventions. e.g. address-type block args. -enforce-exclusivity=none is also

--- a/test/SILOptimizer/sil_combine_cast_foldings.sil
+++ b/test/SILOptimizer/sil_combine_cast_foldings.sil
@@ -1,5 +1,7 @@
 // RUN: %target-sil-opt -sil-print-types -enable-objc-interop -enable-sil-verify-all -sil-combine %s | %FileCheck %s
 
+// REQUIRES: objc_codegen
+
 import Swift
 
 class AClass {

--- a/test/SILOptimizer/sil_combine_cast_foldings_ossa.sil
+++ b/test/SILOptimizer/sil_combine_cast_foldings_ossa.sil
@@ -1,5 +1,7 @@
 // RUN: %target-sil-opt -sil-print-types -enable-objc-interop -enable-sil-verify-all -sil-combine %s | %FileCheck %s
 
+// REQUIRES: objc_codegen
+
 import Swift
 
 class AClass {

--- a/test/SILOptimizer/sil_combine_casts.sil
+++ b/test/SILOptimizer/sil_combine_casts.sil
@@ -1,5 +1,7 @@
 // RUN: %target-sil-opt -sil-print-types -enable-objc-interop -enforce-exclusivity=none -enable-sil-verify-all %s -sil-combine -sil-combine-disable-alloc-stack-opts | %FileCheck %s
 
+// REQUIRES: objc_codegen
+
 sil_stage canonical
 
 import Builtin

--- a/test/SILOptimizer/sil_combine_concrete_existential.sil
+++ b/test/SILOptimizer/sil_combine_concrete_existential.sil
@@ -2,6 +2,7 @@
 // RUN: %target-swift-frontend -O %s -emit-ir
 
 // REQUIRES: swift_in_compiler
+// REQUIRES: objc_codegen
 
 // These tests exercise the same SILCombine optimization as
 // existential_type_propagation.sil, but cover additional corner

--- a/test/SILOptimizer/sil_combine_enum_addr.sil
+++ b/test/SILOptimizer/sil_combine_enum_addr.sil
@@ -3,7 +3,7 @@
 // RUN:   -emit-module-path=%t/resilient_struct.swiftmodule \
 // RUN:   -module-name=resilient_struct %S/../Inputs/resilient_struct.swift
 
-// RUN: %target-sil-opt -sil-print-types -sdk %clang-importer-sdk-path -enable-sil-verify-all %s -sil-combine -jumpthread-simplify-cfg -I %t | %FileCheck %s
+// RUN: %target-sil-opt -sil-print-types -sdk %clang-importer-sdk-path -Xcc -isystem -Xcc %clang-importer-sdk-path/usr/include -enable-sil-verify-all %s -sil-combine -jumpthread-simplify-cfg -I %t | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/sil_combine_ossa.sil
+++ b/test/SILOptimizer/sil_combine_ossa.sil
@@ -5,6 +5,7 @@
 // RUN: %target-sil-opt -sil-print-types -enable-objc-interop -enforce-exclusivity=none -enable-sil-verify-all %s -sil-combine -enable-copy-propagation -enable-lexical-lifetimes=false | %FileCheck %s --check-prefix=CHECK_COPYPROP
 
 // REQUIRES: swift_in_compiler
+// REQUIRES: objc_codegen
 
 // Declare this SIL to be canonical because some tests break raw SIL
 // conventions. e.g. address-type block args. -enforce-exclusivity=none is also

--- a/test/SILOptimizer/sil_verify_all_triggers_verifier_without_asserts.sil
+++ b/test/SILOptimizer/sil_verify_all_triggers_verifier_without_asserts.sil
@@ -5,6 +5,11 @@
 
 // UNSUPPORTED: asserts
 
+// The wasi lit.site.cfg has LLVM_ENABLE_ASSERTIONS=FALSE, so `asserts` is
+// not in available_features. But the macOS-arm64 asserts compiler is what
+// actually runs the wasi tests, so the SIL verifier triggers anyway.
+// UNSUPPORTED: OS=wasip1
+
 class Klass {}
 
 sil [ossa] @leaky_code : $@convention(thin) () -> () {

--- a/test/SILOptimizer/simplify_cfg.sil
+++ b/test/SILOptimizer/simplify_cfg.sil
@@ -1,5 +1,7 @@
 // RUN: %target-sil-opt -sil-print-types -enable-objc-interop -enforce-exclusivity=none -enable-sil-verify-all %s -jumpthread-simplify-cfg | %FileCheck %s
 
+// REQUIRES: objc_codegen
+
 // Declare this SIL to be canonical because some tests break raw SIL
 // conventions. e.g. address-type block args. -enforce-exclusivity=none is also
 // required to allow address-type block args in canonical SIL.

--- a/test/SILOptimizer/simplify_cfg_ossa.sil
+++ b/test/SILOptimizer/simplify_cfg_ossa.sil
@@ -1,6 +1,7 @@
 // RUN: %target-sil-opt -sil-print-types -enable-objc-interop -enable-experimental-feature MoveOnlyEnumDeinits -enable-sil-verify-all %s -simplify-cfg | %FileCheck %s
 
 // REQUIRES: swift_feature_MoveOnlyEnumDeinits
+// REQUIRES: objc_codegen
 
 // OSSA form of tests from simplify_cfg.sil and simplify_cfg_simple.sil.
 //

--- a/test/SILOptimizer/simplify_cfg_ossa_disabled.sil
+++ b/test/SILOptimizer/simplify_cfg_ossa_disabled.sil
@@ -1,4 +1,7 @@
 // RUN: %target-sil-opt -sil-print-types -enable-objc-interop -enforce-exclusivity=none -enable-sil-verify-all %s -jumpthread-simplify-cfg | %FileCheck %s
+
+// REQUIRES: objc_codegen
+
 //
 // These tests case are converted to OSSA form, but aren't yet
 // optimized in OSSA mode. Move them to one of these files when

--- a/test/SILOptimizer/simplify_cfg_ossa_dom_jumpthread.sil
+++ b/test/SILOptimizer/simplify_cfg_ossa_dom_jumpthread.sil
@@ -1,5 +1,7 @@
 // RUN: %target-sil-opt -sil-print-types -enable-objc-interop -enforce-exclusivity=none -enable-sil-verify-all %s -jumpthread-simplify-cfg | %FileCheck %s
 
+// REQUIRES: objc_codegen
+
 sil_stage canonical
 
 import Builtin

--- a/test/SILOptimizer/span_bounds_check_tests.swift
+++ b/test/SILOptimizer/span_bounds_check_tests.swift
@@ -12,6 +12,9 @@
 // REQUIRES: swift_feature_Lifetimes
 // REQUIRES: swift_stdlib_no_asserts, optimized_stdlib
 
+// CHECK-IR shape differs on wasm32: optimized vector-reduce form not produced, trap retained
+// XFAIL: OS=wasip1
+
 // Bounds check should be eliminated
 // SIL optimizer eliminates bounds checks from the loop
 // CHECK-SIL-LABEL: sil @$s23span_bounds_check_tests0A29_sum_iterate_to_count_wo_trapySis4SpanVySiGF :

--- a/test/SILOptimizer/split_critical_edges.sil
+++ b/test/SILOptimizer/split_critical_edges.sil
@@ -1,5 +1,7 @@
 // RUN: %target-sil-opt -sil-print-types -enable-objc-interop -enable-sil-verify-all %s -split-critical-edges | %FileCheck %s
 
+// REQUIRES: objc_codegen
+
 import Builtin
 import Swift
 

--- a/test/SILOptimizer/static_atomics.swift
+++ b/test/SILOptimizer/static_atomics.swift
@@ -7,6 +7,8 @@
 // REQUIRES: executable_test,swift_stdlib_no_asserts,optimized_stdlib
 // REQUIRES: synchronization
 // UNSUPPORTED: back_deployment_runtime
+// Mutex storage empty on single-threaded wasi; expected to flip to PASS on wasi-threads once WasmKit supports WASI threads
+// XFAIL: OS=wasip1 && threading_none
 
 import Synchronization
 

--- a/test/SILOptimizer/static_enums.swift
+++ b/test/SILOptimizer/static_enums.swift
@@ -6,6 +6,8 @@
 
 // REQUIRES: executable_test,swift_stdlib_no_asserts,optimized_stdlib
 // REQUIRES: swift_in_compiler
+// wasm32: non-inline String static-init body not materialized
+// UNSUPPORTED: OS=wasip1
 
 
 // CHECK-LABEL: sil_global @$s4test6optIntSiSgvp : $Optional<Int> = {

--- a/test/SILOptimizer/swift_sil_combine.sil
+++ b/test/SILOptimizer/swift_sil_combine.sil
@@ -1,5 +1,6 @@
 // RUN: %target-sil-opt -enable-objc-interop -enforce-exclusivity=none -enable-sil-verify-all %s -sil-combine -sil-combine-disable-alloc-stack-opts | %FileCheck %s
 // REQUIRES: swift_in_compiler
+// REQUIRES: objc_codegen
 
 sil_stage canonical
 

--- a/test/SILOptimizer/switch_enum_objc.swift
+++ b/test/SILOptimizer/switch_enum_objc.swift
@@ -1,6 +1,8 @@
 // RUN: %target-swift-frontend -Xllvm -sil-print-types -emit-sil -O -primary-file %s -enable-objc-interop -disable-objc-attr-requires-foundation-module -import-objc-header %S/Inputs/switch_enum_objc.h | %FileCheck %s
 // RUN: %target-swift-frontend -Xllvm -sil-print-types -emit-sil -Osize -primary-file %s -enable-objc-interop -disable-objc-attr-requires-foundation-module -import-objc-header %S/Inputs/switch_enum_objc.h | %FileCheck %s
 
+// REQUIRES: objc_codegen
+
 @inline(never)
 func action0() {}
 

--- a/test/SILOptimizer/throws_prediction.swift
+++ b/test/SILOptimizer/throws_prediction.swift
@@ -18,6 +18,9 @@
 
 // UNSUPPORTED: CPU=armv7k, CPU=arm64_32, CPU=armv7
 
+// CHECK-IR labels for throws-prediction differ on wasm32 (inlining/layout)
+// XFAIL: OS=wasip1
+
 // CHECK-DISABLED-NOT: normal_count
 
 enum MyError: Error { case err }

--- a/test/SILOptimizer/unavailable_enum_element_mandatory_objc.swift
+++ b/test/SILOptimizer/unavailable_enum_element_mandatory_objc.swift
@@ -1,6 +1,8 @@
 // RUN: %target-swift-emit-sil -Xllvm -sil-print-types -module-name Test -parse-as-library %s -verify -unavailable-decl-optimization=none -Onone -enable-objc-interop -disable-objc-attr-requires-foundation-module -import-objc-header %S/Inputs/switch_enum_objc.h | %FileCheck %s
 // RUN: %target-swift-emit-sil -Xllvm -sil-print-types -module-name Test -parse-as-library %s -verify -unavailable-decl-optimization=complete -Onone -enable-objc-interop -disable-objc-attr-requires-foundation-module -import-objc-header %S/Inputs/switch_enum_objc.h | %FileCheck %s
 
+// REQUIRES: objc_codegen
+
 // CHECK-LABEL: sil @$s4Test30testFullyCoveredSwitchOpenEnumyySo9DimensionVF : $@convention(thin) (Dimension) -> () {
 // CHECK:         switch_enum %0 : $Dimension, case #Dimension.x!enumelt: [[XBB:bb[0-9]+]], case #Dimension.z!enumelt: [[ZBB:bb[0-9]+]], case #Dimension.y!enumelt: [[YBB:bb[0-9]+]], default [[DEFAULTBB:bb[0-9]+]]
 // CHECK:       [[ZBB]]:

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -891,12 +891,16 @@ config.substitutions.append(('%clang-importer-sdk-path',
                              '%r' % (make_path(config.test_source_root, 'Inputs', 'clang-importer-sdk'))))
 
 config.substitutions.append(('%clang-importer-sdk-nosource',
-                             '-sdk %r' % (make_path(config.test_source_root, 'Inputs', 'clang-importer-sdk'))))
+                             '-sdk %r -Xcc -isystem -Xcc %r' % (
+                                 make_path(config.test_source_root, 'Inputs', 'clang-importer-sdk'),
+                                 make_path(config.test_source_root, 'Inputs', 'clang-importer-sdk', 'usr', 'include'))))
 # FIXME: END -enable-source-import hackaround
 
 config.substitutions.append(('%clang-importer-sdk',
-                             '-enable-source-import -sdk %r -I %r ' % (make_path(config.test_source_root, 'Inputs', 'clang-importer-sdk'),
-                                                                       make_path(config.test_source_root, 'Inputs', 'clang-importer-sdk', 'swift-modules'))))
+                             '-enable-source-import -sdk %r -I %r -Xcc -isystem -Xcc %r ' % (
+                                 make_path(config.test_source_root, 'Inputs', 'clang-importer-sdk'),
+                                 make_path(config.test_source_root, 'Inputs', 'clang-importer-sdk', 'swift-modules'),
+                                 make_path(config.test_source_root, 'Inputs', 'clang-importer-sdk', 'usr', 'include'))))
 
 config.substitutions.append( ('%clang_apinotes',
                               "%r -cc1apinotes" %

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -891,16 +891,12 @@ config.substitutions.append(('%clang-importer-sdk-path',
                              '%r' % (make_path(config.test_source_root, 'Inputs', 'clang-importer-sdk'))))
 
 config.substitutions.append(('%clang-importer-sdk-nosource',
-                             '-sdk %r -Xcc -isystem -Xcc %r' % (
-                                 make_path(config.test_source_root, 'Inputs', 'clang-importer-sdk'),
-                                 make_path(config.test_source_root, 'Inputs', 'clang-importer-sdk', 'usr', 'include'))))
+                             '-sdk %r' % (make_path(config.test_source_root, 'Inputs', 'clang-importer-sdk'))))
 # FIXME: END -enable-source-import hackaround
 
 config.substitutions.append(('%clang-importer-sdk',
-                             '-enable-source-import -sdk %r -I %r -Xcc -isystem -Xcc %r ' % (
-                                 make_path(config.test_source_root, 'Inputs', 'clang-importer-sdk'),
-                                 make_path(config.test_source_root, 'Inputs', 'clang-importer-sdk', 'swift-modules'),
-                                 make_path(config.test_source_root, 'Inputs', 'clang-importer-sdk', 'usr', 'include'))))
+                             '-enable-source-import -sdk %r -I %r ' % (make_path(config.test_source_root, 'Inputs', 'clang-importer-sdk'),
+                                                                       make_path(config.test_source_root, 'Inputs', 'clang-importer-sdk', 'swift-modules'))))
 
 config.substitutions.append( ('%clang_apinotes',
                               "%r -cc1apinotes" %

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -2208,8 +2208,9 @@ elif kIsWASI:
     subst_target_swift_ide_test_mock_sdk = config.target_swift_ide_test
     subst_target_swift_ide_test_mock_sdk_after = ""
     config.target_swiftc_driver = (
-        "%s -target %s -toolchain-stdlib-rpath %s %s" %
-        (config.swiftc, config.variant_triple, config.resource_dir_opt, mcp_opt))
+        "%s -target %s -sdk %s -toolchain-stdlib-rpath %s %s %s" %
+        (config.swiftc, config.variant_triple, config.variant_sdk,
+         config.resource_dir_opt, mcp_opt, config.swift_driver_test_options))
     config.target_stdlib_swiftc_driver = config.target_swiftc_driver
     config.target_swift_modulewrap = (
         '%s -modulewrap -target %s' %

--- a/utils/swift_build_support/swift_build_support/products/wasistdlib.py
+++ b/utils/swift_build_support/swift_build_support/products/wasistdlib.py
@@ -196,6 +196,7 @@ class WASIStdlib(cmake_product.CMakeProduct):
         self.cmake_options.define('SWIFT_ENABLE_SOURCEKIT_TESTS:BOOL', 'FALSE')
         lit_test_paths = [
             'IRGen', 'stdlib', 'Concurrency/Runtime', 'embedded', 'AutoDiff', 'DebugInfo',
+            'SILOptimizer',
             # TODO(katei): Enable all interpreter tests
             'Interpreter/enum.swift',
         ]


### PR DESCRIPTION
This test suite was previously not in the list of tests we run for Wasm, which meant some 32-bit-specific and Wasm-specific bugs in this area could be left unnoticed.