### PR TITLE
IRGen: lower hidden C-type layout to TrivialHiddenTypeInfo

### DIFF
--- a/include/swift/AST/DeclAttr.def
+++ b/include/swift/AST/DeclAttr.def
@@ -922,7 +922,12 @@ DECL_ATTR(diagnose, Diagnose,
   OnFunc | OnConstructor | OnDestructor | OnSubscript | OnVar | OnNominalType | OnExtension | OnEnumElement | OnAccessor | OnImport | OnTypeAlias | OnAssociatedType | OnMacro,
   AllowMultipleAttributes | NotSerialized | ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIStableToRemove | ForbiddenInABIAttr,
   174)
-LAST_DECL_ATTR(Diagnose)
+
+SIMPLE_DECL_ATTR(_hasHiddenStoredProperties, HasHiddenStoredProperties,
+  OnStruct,
+  UserInaccessible | ABIBreakingToAdd | ABIBreakingToRemove | APIStableToAdd | APIStableToRemove | ForbiddenInABIAttr,
+  175)
+LAST_DECL_ATTR(HasHiddenStoredProperties)
 
 #undef DECL_ATTR_ALIAS
 #undef CONTEXTUAL_DECL_ATTR_ALIAS

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -8384,25 +8384,36 @@ DEFINE_EMPTY_CAN_TYPE_WRAPPER(IntegerType, Type)
 ///
 /// HiddenType is never produced by type-checking user code. It is synthesized
 /// only on the serialization path and consumed by deserialization and IRGen.
+///
+/// Each HiddenType also carries the ModuleDecl it was emitted from (the
+/// "defining module"). That module's HiddenTypeLayouts table holds the
+/// AbstractTypeLayout entry that backs this placeholder; IRGen resolves the
+/// layout via that module.
 class HiddenType final : public TypeBase, public llvm::FoldingSetNode {
   friend class ASTContext;
 
   StringRef MangledName;
+  ModuleDecl *DefiningModule;
 
-  HiddenType(StringRef mangledName, const ASTContext &ctx)
+  HiddenType(StringRef mangledName, ModuleDecl *definingModule,
+             const ASTContext &ctx)
       : TypeBase(TypeKind::Hidden, &ctx, RecursiveTypeProperties()),
-        MangledName(mangledName) {}
+        MangledName(mangledName), DefiningModule(definingModule) {}
 
 public:
-  static HiddenType *get(const ASTContext &ctx, StringRef mangledName);
+  static HiddenType *get(const ASTContext &ctx, StringRef mangledName,
+                         ModuleDecl *definingModule);
 
   StringRef getMangledName() const { return MangledName; }
+  ModuleDecl *getDefiningModule() const { return DefiningModule; }
 
   void Profile(llvm::FoldingSetNodeID &ID) {
-    Profile(ID, getMangledName());
+    Profile(ID, getMangledName(), getDefiningModule());
   }
-  static void Profile(llvm::FoldingSetNodeID &ID, StringRef mangledName) {
+  static void Profile(llvm::FoldingSetNodeID &ID, StringRef mangledName,
+                      ModuleDecl *definingModule) {
     ID.AddString(mangledName);
+    ID.AddPointer(definingModule);
   }
 
   static bool classof(const TypeBase *T) {

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -3883,9 +3883,10 @@ IntegerType *IntegerType::get(StringRef value, bool isNegative,
   return intType;
 }
 
-HiddenType *HiddenType::get(const ASTContext &ctx, StringRef mangledName) {
+HiddenType *HiddenType::get(const ASTContext &ctx, StringRef mangledName,
+                            ModuleDecl *definingModule) {
   llvm::FoldingSetNodeID id;
-  HiddenType::Profile(id, mangledName);
+  HiddenType::Profile(id, mangledName, definingModule);
 
   void *insertPos;
   if (auto *hidden =
@@ -3896,7 +3897,7 @@ HiddenType *HiddenType::get(const ASTContext &ctx, StringRef mangledName) {
   auto nameCopy = ctx.AllocateCopy(mangledName);
 
   auto *hidden = new (ctx, AllocationArena::Permanent)
-      HiddenType(nameCopy, ctx);
+      HiddenType(nameCopy, definingModule, ctx);
 
   ctx.getImpl().HiddenTypes.InsertNode(hidden, insertPos);
   return hidden;

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -5092,6 +5092,8 @@ public:
   TRIVIAL_ATTR_PRINTER(Frozen, frozen)
   TRIVIAL_ATTR_PRINTER(GKInspectable, gk_inspectable)
   TRIVIAL_ATTR_PRINTER(GlobalActor, global_actor)
+  TRIVIAL_ATTR_PRINTER(HasHiddenStoredProperties,
+                       has_hidden_stored_properties)
   TRIVIAL_ATTR_PRINTER(HasInitialValue, has_initial_value)
   TRIVIAL_ATTR_PRINTER(HasMissingDesignatedInitializers,
                        has_missing_designated_initializers)

--- a/lib/ASTGen/Sources/ASTGen/DeclAttrs.swift
+++ b/lib/ASTGen/Sources/ASTGen/DeclAttrs.swift
@@ -258,6 +258,7 @@ extension ASTGenVisitor {
         .Frozen,
         .GKInspectable,
         .GlobalActor,
+        .HasHiddenStoredProperties,
         .HasInitialValue,
         .HasMissingDesignatedInitializers,
         .HasStorage,

--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -20,6 +20,7 @@
 #include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/LazyResolver.h"
 #include "swift/AST/IRGenOptions.h"
+#include "swift/AST/Module.h"
 #include "swift/AST/PrettyStackTrace.h"
 #include "swift/AST/SearchPathOptions.h"
 #include "swift/AST/Types.h"
@@ -1430,6 +1431,55 @@ namespace {
       llvm_unreachable("should not call on an immovable opaque type");
     }
   };
+
+  /// A TypeInfo for a HiddenType placeholder. The placeholder stands in for a
+  /// real C-imported type whose identity has been elided from the importing
+  /// Layout is recovered from the defining module's HiddenTypeLayouts table.
+  ///
+  /// Address-only: clients lack the clang::RecordDecl required to derive a
+  /// correct register-passing schema for the hidden field, so values are
+  /// always passed indirectly. 
+  class TrivialHiddenTypeInfo final
+      : public IndirectTypeInfo<TrivialHiddenTypeInfo, FixedTypeInfo> {
+  public:
+    TrivialHiddenTypeInfo(llvm::Type *storage, Size size, Alignment align)
+      : IndirectTypeInfo(storage, size,
+                         SpareBitVector::getConstant(size.getValueInBits(),
+                                                     false),
+                         align,
+                         IsTriviallyDestroyable, IsBitwiseTakableAndBorrowable,
+                         IsCopyable,
+                         IsFixedSize, IsABIAccessible) {}
+
+    void assignWithCopy(IRGenFunction &IGF, Address dest, Address src,
+                        SILType T, bool isOutlined) const override {
+      IGF.emitMemCpy(dest, src, getFixedSize());
+    }
+    void initializeWithCopy(IRGenFunction &IGF, Address dest, Address src,
+                            SILType T, bool isOutlined) const override {
+      IGF.emitMemCpy(dest, src, getFixedSize());
+    }
+    void destroy(IRGenFunction &IGF, Address addr, SILType T,
+                 bool isOutlined) const override {
+      // Trivial destructor under the plain-C assumption.
+    }
+
+    TypeLayoutEntry *
+    buildTypeLayoutEntry(IRGenModule &IGM, SILType T,
+                         bool useStructLayouts) const override {
+      if (!useStructLayouts)
+        return IGM.typeLayoutCache.getOrCreateTypeInfoBasedEntry(*this, T);
+      return IGM.typeLayoutCache.getOrCreateScalarEntry(
+          *this, T, ScalarKind::TriviallyDestroyable);
+    }
+
+    unsigned getFixedExtraInhabitantCount(IRGenModule &) const override {
+      return 0;
+    }
+    bool mayHaveExtraInhabitants(IRGenModule &) const override {
+      return false;
+    }
+  };
 } // end anonymous namespace
 
 /// Constructs a type info which performs simple loads and stores of
@@ -2402,8 +2452,19 @@ const TypeInfo *TypeConverter::convertType(CanType ty) {
     llvm_unreachable("should not be asking for representation of a SILToken");
   case TypeKind::Integer:
     llvm_unreachable("should not be asking for the type info an IntegerType");
-  case TypeKind::Hidden:
-    llvm_unreachable("HiddenType should be resolved before IRGen sees it");
+  case TypeKind::Hidden: {
+    auto hidden = cast<HiddenType>(ty);
+    auto *defining = hidden->getDefiningModule();
+    assert(defining &&
+           "HiddenType must carry a defining module after deserialization");
+    auto layout = defining->lookupHiddenTypeLayout(hidden->getMangledName());
+    assert(layout &&
+           "no HIDDEN_TYPE_LAYOUTS_BLOCK entry for this mangled name");
+
+    auto *storage = llvm::ArrayType::get(IGM.Int8Ty, layout->size);
+    return new TrivialHiddenTypeInfo(storage, Size(layout->size),
+                              Alignment(layout->alignment));
+  }
   }
   }
   llvm_unreachable("bad type kind");

--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -1981,11 +1981,16 @@ private:
     case TypeKind::Module:
     case TypeKind::BuiltinUnboundGeneric:
     case TypeKind::BuiltinBorrow:
-    case TypeKind::Hidden:
       ABORT([&](llvm::raw_ostream &out) {
         out << "Don't know how to emit debug info for type:\n";
         BaseTy->dump(out);
       });
+
+    case TypeKind::Hidden: {
+      unsigned FwdDeclLine = 0;
+      return createOpaqueStruct(Scope, MangledName, MainFile, FwdDeclLine,
+                                SizeInBits, AlignInBits, Flags, MangledName);
+    }
 
     case TypeKind::BuiltinFixedArray: {
       if (Opts.DebugInfoLevel > IRGenDebugInfoLevel::ASTTypes) {

--- a/lib/IRGen/StructLayout.cpp
+++ b/lib/IRGen/StructLayout.cpp
@@ -243,6 +243,19 @@ StructLayout::StructLayout(IRGenModule &IGM, std::optional<CanType> type,
     if (IGM.isResilient(decl, ResilienceExpansion::Minimal))
       IsKnownAlwaysFixedSize = IsNotFixedSize;
 
+    // Force non-loadable when the struct has stored properties of hidden types.
+    // With a stored property of hidden type, having the library and client side
+    // to agree on expansion scheme is challenging and error-prone. Therefore,
+    // we make these types always address-only.
+    if (decl->getAttrs().hasAttribute<HasHiddenStoredPropertiesAttr>()) {
+      IsLoadable = false;
+      // Set zero spare bits so both sides agree on 0 extra inhabitants
+      // (the client can't know the hidden field's
+      // spare-bit pattern, so Optional<S> must use a tag byte).
+      SpareBits =
+          SpareBitVector::getConstant(MinimumSize.getValueInBits(), false);
+    }
+
     applyLayoutAttributes(IGM, decl, IsFixedLayout, MinimumAlign);
   }
 }

--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -2603,6 +2603,15 @@ namespace {
         return handleAddressOnly(structType, properties);
       }
 
+      // Force address-only when the struct has hidden stored properties from
+      // an internal bridging header.
+      if (D->getAttrs().hasAttribute<HasHiddenStoredPropertiesAttr>()) {
+        properties.setAddressOnly();
+        properties.setNonTrivial();
+        properties.setLexical(IsLexical);
+        return handleAddressOnly(structType, properties);
+      }
+
       if (D->isCxxNonTrivial()) {
         properties.setDefinitelyAddressableForDependencies();
         properties.setAddressOnly();
@@ -3457,6 +3466,11 @@ void TypeConverter::verifyTrivialLowering(const TypeLowering &lowering,
           if (isa<SILPackType>(ty) || isa<PackExpansionType>(ty))
             return true;
 
+          // A HiddenType placeholder is a leaf with no inner structure to
+          // walk
+          if (isa<HiddenType>(ty))
+            return true;
+
           auto *nominal = ty.getAnyNominal();
           // Only pack-related non-nominal aggregates may be responsible for
           // non-conformance; walk into the rest.
@@ -3503,6 +3517,12 @@ void TypeConverter::verifyTrivialLowering(const TypeLowering &lowering,
 
           // The error type doesn't conform but is trivial (case (8)).
           if (isa<ErrorType>(ty))
+            return false;
+
+          // A HiddenType placeholder stands in for a C-imported type whose
+          // identity has been elided from the client's view. It can be
+          // trivial without explicit conformance to BitwiseCopyable.
+          if (isa<HiddenType>(ty))
             return false;
 
           // These show up in the context of non-conforming variadic generics

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -180,6 +180,7 @@ public:
 #define IGNORED_ATTR(X) void visit##X##Attr(X##Attr *) {}
   IGNORED_ATTR(AlwaysEmitIntoClient)
   IGNORED_ATTR(HasInitialValue)
+  IGNORED_ATTR(HasHiddenStoredProperties)
   IGNORED_ATTR(ClangImporterSynthesizedType)
   IGNORED_ATTR(Convenience)
   IGNORED_ATTR(Effects)

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -342,6 +342,16 @@ bool ExportContext::encapsulatedAsHiddenStoredProperty(
       DC->getASTContext().recordTypeToHideWhenEmittingModule(
           nominal->getDeclaredInterfaceType()->getCanonicalType(),
           layout->mangledName);
+      auto *enclosingStruct =
+          dyn_cast_or_null<StructDecl>(DC->getInnermostTypeContext());
+      ASSERT(enclosingStruct &&
+             "encapsulated hidden stored property must be inside a struct");
+      if (!enclosingStruct->getAttrs()
+               .hasAttribute<HasHiddenStoredPropertiesAttr>()) {
+        auto &ctx = DC->getASTContext();
+        enclosingStruct->getAttrs().add(
+            new (ctx) HasHiddenStoredPropertiesAttr(/*IsImplicit=*/true));
+      }
       return true;
     }
   }

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1613,6 +1613,7 @@ namespace  {
     UNINTERESTING_ATTR(ForbidSerializingReference)
     UNINTERESTING_ATTR(GKInspectable)
     UNINTERESTING_ATTR(HasMissingDesignatedInitializers)
+    UNINTERESTING_ATTR(HasHiddenStoredProperties)
     UNINTERESTING_ATTR(IBAction)
     UNINTERESTING_ATTR(IBDesignable)
     UNINTERESTING_ATTR(IBInspectable)

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -8403,7 +8403,7 @@ Expected<Type> DESERIALIZE_TYPE(HIDDEN_TYPE)(ModuleFile &MF,
 
   decls_block::HiddenTypeLayout::readRecord(scratch);
 
-  return HiddenType::get(ctx, blobData);
+  return HiddenType::get(ctx, blobData, MF.getAssociatedModule());
 }
 } // namespace decls_block
 } // namespace serialization

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -4870,7 +4870,8 @@ public:
     auto &ctx = var->getASTContext();
     if (auto mangledName = ctx.lookupTypeToHideWhenEmittingModule(
             ty->getCanonicalType())) {
-      ty = HiddenType::get(ctx, *mangledName);
+      ty = HiddenType::get(ctx, *mangledName,
+                           var->getDeclContext()->getParentModule());
     }
     SmallVector<TypeID, 2> arrayFields;
     for (auto accessor : accessors.Decls)

--- a/test/ClangImporter/InternalBridgingHeader/hidden-type-irgen.swift
+++ b/test/ClangImporter/InternalBridgingHeader/hidden-type-irgen.swift
@@ -1,0 +1,137 @@
+// Test that a Client importing a Library with -internal-import-bridging-header
+// can allocate, copy, and destroy values whose stored properties are hidden.
+
+// REQUIRES: swift_feature_AbstractStoredPropertyLayout
+// REQUIRES: PTRSIZE=64
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend \
+// RUN:   -internal-import-bridging-header %t/Utility.h \
+// RUN:   -enable-experimental-feature AbstractStoredPropertyLayout \
+// RUN:   -emit-module -module-name Library \
+// RUN:   -parse-as-library \
+// RUN:   -o %t/Library.swiftmodule \
+// RUN:   %t/Library.swift
+
+// RUN: %target-swift-frontend \
+// RUN:   -enable-experimental-feature AbstractStoredPropertyLayout \
+// RUN:   -emit-ir -module-name Client \
+// RUN:   -parse-as-library \
+// RUN:   -I %t \
+// RUN:   %t/Client.swift | %FileCheck --check-prefix=IR %s
+
+//--- Utility.h
+typedef struct {
+  int value;
+} Wrapper;
+
+typedef struct {
+  double d;
+} BigWrapper;
+
+// char + long long forces 8-byte alignment the client must honor.
+typedef struct {
+  char c;
+  long long v;
+} MixWrapper;
+
+//--- Library.swift
+public struct S {
+  private var w: Wrapper
+  public init(value: Int32) {
+    w = Wrapper(value: value)
+  }
+}
+
+// Two hidden fields: size=16, alignment=8.
+public struct S2 {
+  private var a: Wrapper
+  private var b: BigWrapper
+  public init() {
+    a = Wrapper(value: 0)
+    b = BigWrapper(d: 0.0)
+  }
+}
+
+// Hidden and visible fields interleaved: size=32, alignment=8.
+public struct S3 {
+  private var w: Wrapper
+  public var x: Int
+  private var w2: Wrapper
+  public var y: Double
+  public init(value: Int32) {
+    w = Wrapper(value: value)
+    x = 0
+    w2 = Wrapper(value: value)
+    y = 0.0
+  }
+}
+
+// Hidden field with non-obvious 8-byte alignment (from long long).
+public struct S4 {
+  private var m: MixWrapper
+  public init() {
+    m = MixWrapper(c: 0, v: 0)
+  }
+}
+
+//--- Client.swift
+import Library
+
+// IR: %T7Library1SV = type <{ [4 x i8] }>
+
+// IR-LABEL: define {{.*}} @"$s6Client3useyS2iF"
+// IR: alloca %T7Library1SV, align 4
+// IR: alloca %T7Library1SV, align 4
+// IR: call void @llvm.memcpy.{{.*}}(ptr {{[^,]+}}, ptr {{[^,]+}}, i64 4, i1 false)
+public func use(_ value: Int) -> Int {
+  let s = S(value: Int32(value))
+  var s2 = s
+  s2 = s
+  _ = s2
+  return MemoryLayout<S>.size
+}
+
+// IR-LABEL: define {{.*}}useS2
+// IR: alloca %T7Library2S2V, align 8
+// IR: call void @llvm.memset.{{.*}}(ptr align 8 {{[^,]+}}, i8 0, i64 16, i1 false)
+// IR: call {{.*}}@"$s7Library2S2VWOc"
+public func useS2() -> Int {
+  let s = S2()
+  var s2 = s
+  s2 = s
+  _ = s2
+  return MemoryLayout<S2>.size
+}
+
+// IR-LABEL: define {{.*}}useS3
+// IR: alloca %T7Library2S3V, align 8
+// IR: call void @llvm.memset.{{.*}}(ptr align 8 {{[^,]+}}, i8 0, i64 32, i1 false)
+// IR: call {{.*}}@"$s7Library2S3VWOc"
+public func useS3() -> Int {
+  let s = S3(value: 1)
+  var s2 = s
+  s2 = s
+  _ = s2
+  return MemoryLayout<S3>.size
+}
+
+// IR-LABEL: define {{.*}}useS4
+// IR: alloca %T7Library2S4V, align 8
+// IR: call void @llvm.memset.{{.*}}(ptr align 8 {{[^,]+}}, i8 0, i64 16, i1 false)
+// IR: call {{.*}}@"$s7Library2S4VWOc"
+public func useS4() -> Int {
+  let s = S4()
+  var s2 = s
+  s2 = s
+  _ = s2
+  return MemoryLayout<S4>.size
+}
+
+// Client IR must not reference the hidden C types.
+// IR-NOT: Utility.h
+// IR-NOT: SC7Wrapper
+// IR-NOT: SC10BigWrapper
+// IR-NOT: SC10MixWrapper

--- a/test/ClangImporter/InternalBridgingHeader/hidden-type-runtime.swift
+++ b/test/ClangImporter/InternalBridgingHeader/hidden-type-runtime.swift
@@ -1,0 +1,133 @@
+// Runtime test: values of encapsulated types round-trip correctly across the
+// dylib boundary, proving the layout-table-driven codegen is correct.
+
+// REQUIRES: swift_feature_AbstractStoredPropertyLayout
+// REQUIRES: executable_test
+// REQUIRES: PTRSIZE=64
+
+// UNSUPPORTED: remote_run || device_run
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// Build Library as a dylib. -wmo skips the merge-modules step (whose verifier
+// can't round-trip HiddenType placeholders yet).
+// RUN: %target-build-swift \
+// RUN:   -Xfrontend -internal-import-bridging-header \
+// RUN:   -Xfrontend %t/Utility.h \
+// RUN:   -enable-experimental-feature AbstractStoredPropertyLayout \
+// RUN:   -wmo -parse-as-library -emit-library \
+// RUN:   -emit-module -emit-module-path %t/Library.swiftmodule \
+// RUN:   -module-name Library \
+// RUN:   %t/Library.swift \
+// RUN:   -o %t/%target-library-name(Library)
+
+// Build Client with -Onone to prevent the optimizer from folding away copies.
+// RUN: %target-build-swift -Onone \
+// RUN:   -enable-experimental-feature AbstractStoredPropertyLayout \
+// RUN:   -I %t -L %t -lLibrary \
+// RUN:   %target-rpath(%t) \
+// RUN:   -o %t/main %t/Client.swift
+// RUN: %target-codesign %t/main
+
+// RUN: %target-run %t/main | %FileCheck %s
+
+//--- Utility.h
+typedef struct {
+  int value;
+} Wrapper;
+
+typedef struct {
+  double d;
+} BigWrapper;
+
+//--- Library.swift
+public struct S {
+  private var w: Wrapper
+  public init(value: Int32) {
+    w = Wrapper(value: value)
+  }
+  public func payload() -> Int32 {
+    return w.value
+  }
+}
+
+// Multiple hidden fields.
+public struct S2 {
+  private var a: Wrapper
+  private var b: BigWrapper
+  public init(a: Int32, b: Double) {
+    self.a = Wrapper(value: a)
+    self.b = BigWrapper(d: b)
+  }
+  public func payloadA() -> Int32 { return a.value }
+  public func payloadB() -> Double { return b.d }
+}
+
+// Hidden and visible fields interleaved.
+public struct S3 {
+  private var w: Wrapper
+  public var x: Int
+  public init(value: Int32, x: Int) {
+    self.w = Wrapper(value: value)
+    self.x = x
+  }
+  public func hiddenValue() -> Int32 { return w.value }
+}
+
+//--- Client.swift
+import Library
+
+@inline(never)
+func roundTrip() -> Int32 {
+  let s = S(value: 42)
+  var s2 = s
+  s2 = S(value: 99)
+  s2 = s
+  return s2.payload()
+}
+
+@inline(never)
+func roundTripS2() -> (Int32, Double) {
+  let s = S2(a: 42, b: 2.5)
+  var s2 = s
+  s2 = S2(a: 99, b: 99.0)
+  s2 = s
+  return (s2.payloadA(), s2.payloadB())
+}
+
+@inline(never)
+func roundTripS3() -> (Int32, Int) {
+  let s = S3(value: 42, x: 100)
+  var s2 = s
+  s2 = S3(value: 99, x: 200)
+  s2 = s
+  return (s2.hiddenValue(), s2.x)
+}
+
+@inline(never)
+func roundTripOptional() -> Int32 {
+  var opt: S? = S(value: 42)
+  opt = nil
+  opt = S(value: 77)
+  return opt!.payload()
+}
+
+// CHECK: size=4 alignment=4 stride=4
+print("size=\(MemoryLayout<S>.size) "
+    + "alignment=\(MemoryLayout<S>.alignment) "
+    + "stride=\(MemoryLayout<S>.stride)")
+
+// CHECK-NEXT: payload=42
+print("payload=\(roundTrip())")
+
+// CHECK-NEXT: s2 a=42 b=2.5
+let (a, b) = roundTripS2()
+print("s2 a=\(a) b=\(b)")
+
+// CHECK-NEXT: s3 w=42 x=100
+let (w, x) = roundTripS3()
+print("s3 w=\(w) x=\(x)")
+
+// CHECK-NEXT: optional=77
+print("optional=\(roundTripOptional())")


### PR DESCRIPTION
When a struct has stored properties from an internal bridging header, add @_hasHiddenStoredProperties to force address-only on both library and client sides, and resolve layout via the defining module's HiddenTypeLayouts table in IRGen.

Making these structs loadable is challenging because library and client must agree on the register-passing scheme (which registers carry which fields), and that scheme depends on the full type structure that the client cannot see. Address-only sidesteps this by passing everything indirectly.

Tests: hidden-type-irgen.swift verifies the Client's IR has correct alloca sizes/alignments and outlined copy witnesses without referencing hidden C symbols. hidden-type-runtime.swift builds a dylib + executable and verifies values round-trip correctly across the boundary at runtime.
