### PR TITLE
[RemoteMirror] Add defensive NULL checks in getClosureContextInfo.

### DIFF
--- a/include/swift/RemoteInspection/ReflectionContext.h
+++ b/include/swift/RemoteInspection/ReflectionContext.h
@@ -2469,6 +2469,10 @@ private:
       // substitutions.
       bool Progress = false;
       for (auto Source : Info.MetadataSources) {
+        // If either component of the source is NULL, something went wrong.
+        if (!Source.first || !Source.second)
+          return nullptr;
+
         // Don't read a source more than once.
         if (Done.count(Source))
           continue;
@@ -2547,6 +2551,9 @@ private:
   std::optional<RemoteAddress>
   readMetadataSource(RemoteAddress Context, const MetadataSource *MS,
                      const RecordTypeInfoBuilder &Builder) {
+    if (!MS)
+      return std::nullopt;
+
     switch (MS->getKind()) {
     case MetadataSourceKind::ClosureBinding: {
       unsigned Index = cast<ClosureBindingMetadataSource>(MS)->getIndex();


### PR DESCRIPTION
These values should never be NULL, but this should help us be robust against bad data.

rdar://172456945