### PR TITLE
[6.4] Fix LICM producing illegal load [trivial] on non-trivial address types

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LoopInvariantCodeMotion.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LoopInvariantCodeMotion.swift
@@ -771,10 +771,12 @@ private extension MovableInstructions {
       }
     }
 
+    let phiOwnership: Ownership = firstStore.parentFunction.hasOwnership ? (firstStore.source.type.isTrivial(in: firstStore.parentFunction) ? .none : .owned) : .none
+
     var ssaUpdater = SSAUpdater(
       function: firstStore.parentFunction,
       type: firstStore.destination.type.objectType,
-      ownership: firstStore.source.ownership,
+      ownership: phiOwnership,
       context
     )
     
@@ -804,9 +806,9 @@ private extension MovableInstructions {
     }) else {
       return false
     }
-    
-    let ownership: LoadInst.LoadOwnership = firstStore.parentFunction.hasOwnership ? (firstStore.storeOwnership == .initialize ? .take : .trivial) : .unqualified
-    
+
+    let ownership: LoadInst.LoadOwnership = firstStore.parentFunction.hasOwnership ? (initialAddr.type.isTrivial(in: firstStore.parentFunction) ? .trivial : .take) : .unqualified
+
     let initialLoad = builder.createLoad(fromAddress: initialAddr, ownership: ownership)
     ssaUpdater.addAvailableValue(initialLoad, in: loop.preheader!)
     

--- a/test/SILOptimizer/licm.sil
+++ b/test/SILOptimizer/licm.sil
@@ -2361,3 +2361,30 @@ bb3:
   return %r
 }
 
+// CHECK-LABEL: sil [ossa] @licm_trivial_store_to_nontrivial_addr :
+// CHECK:         load [take] %0 : $*Optional<String>
+// CHECK:       bb1({{%[0-9]+}} : @owned $Optional<String>):
+// CHECK:       bb3:
+// CHECK:         store {{%[0-9]+}} to [trivial] %0
+// CHECK-LABEL: } // end sil function 'licm_trivial_store_to_nontrivial_addr'
+sil [ossa] @licm_trivial_store_to_nontrivial_addr : $@convention(thin) () -> @out Optional<String> {
+bb0(%0 : $*Optional<String>):
+  %none = enum $Optional<String>, #Optional.none!enumelt
+  store %none to [trivial] %0 : $*Optional<String>
+  br bb1
+
+bb1:
+  %loaded = load [take] %0 : $*Optional<String>
+  destroy_value %loaded : $Optional<String>
+  %none2 = enum $Optional<String>, #Optional.none!enumelt
+  store %none2 to [trivial] %0 : $*Optional<String>
+  cond_br undef, bb2, bb3
+
+bb2:
+  br bb1
+
+bb3:
+  %r = tuple ()
+  return %r : $()
+}
+


### PR DESCRIPTION
- Explanation: The LICM pass's hoistAndSinkLoadAndStore incorrectly determined load/store ownership based on firstStore.storeOwnership rather than the address type. This PR fixes the verification error due to this by determining ownership based on the address type's triviality. 
- Risk: Low.
- Testing: Added unit test
- Issue: rdar://177663456
- Reviewers: @eeckstein 
- Main branch PR: https://github.com/swiftlang/swift/pull/89383 



