### PR TITLE
IRGenDebugInfo: Adjust to "[llvm][DebugInfo][NFC] Remove DITypeRefArray in favour of DITypeArray (#177066)"

### DIFF
--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -817,13 +817,13 @@ private:
     }
   }
 
-  llvm::DITypeRefArray createParameterTypes(SILType SILTy) {
+  llvm::DITypeArray createParameterTypes(SILType SILTy) {
     if (!SILTy)
       return nullptr;
     return createParameterTypes(SILTy.castTo<SILFunctionType>());
   }
 
-  llvm::DITypeRefArray createParameterTypes(CanSILFunctionType FnTy) {
+  llvm::DITypeArray createParameterTypes(CanSILFunctionType FnTy) {
     SmallVector<llvm::Metadata *, 16> Parameters;
 
     GenericContextScope scope(IGM, FnTy->getInvocationGenericSignature());


### PR DESCRIPTION
See https://github.com/llvm/llvm-project/pull/177066.
___
Paired with https://github.com/swiftlang/llvm-project/pull/13063.
Targeting main to minimise the difference between main and rebranch.