### PR TITLE
Fix `@export(interface)` for synthesized members and generic functions

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1128,6 +1128,16 @@ public:
   /// @_neverEmitIntoClient.
   bool isNeverEmittedIntoClient() const;
 
+  /// Compute the code generation model that is required for this declaration.
+  ///
+  /// This function applies the limitations of the compilation model to
+  /// determine if there's a code generation model that *must* be used for the
+  /// given declaration. For example, generic declarations must be
+  /// `@export(implementation)` in Embedded Swift, because it does not support
+  /// unspecialized generics.
+  std::optional<CodeGenerationModel>
+  getRequiredCodeGenerationModel() const;
+
   /// Compute the code generation model that was explicitly requested for
   /// this declaration.
   ///

--- a/include/swift/AST/ProtocolConformance.h
+++ b/include/swift/AST/ProtocolConformance.h
@@ -810,6 +810,16 @@ public:
   /// modules, but in a manner that ensures that all copies are equivalent.
   bool isSynthesizedNonUnique() const;
 
+  /// Compute the code generation model that is required for this conformance.
+  ///
+  /// This function applies the limitations of the compilation model to
+  /// determine if there's a code generation model that *must* be used for the
+  /// given conformances. For example, generic conformances must be
+  /// `@export(implementation)` in Embedded Swift, because it does not support
+  /// unspecialized generics.
+  std::optional<CodeGenerationModel>
+  getRequiredCodeGenerationModel() const;
+
   /// Retrieve the code generation model explicitly requested for this
   /// conformance, inherited from the @export attribute on the declaring
   /// nominal type or extension. Returns nullopt if the declaring context

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2428,27 +2428,30 @@ Decl::getEffectiveCodeGenerationModel() const {
   if (auto explicitModel = getExplicitCodeGenerationModel())
     return *explicitModel;
 
-  // A member of a nominal type or extension inherits its code generation
-  // model from the enclosing type/extension's *explicit* model, so that
-  // `@export(...)` on a type or extension controls the linkage of its
-  // members — including members synthesized by the compiler (e.g. derived
-  // `Equatable.==`). We only consider an explicit model on the parent so
-  // that this inheritance only kicks in when the user has actually written
-  // `@export(...)` (or an equivalent attribute) on the type/extension.
+  // A *synthesized* member of a nominal type or extension inherits its code
+  // generation model from the enclosing type/extension's *explicit* model,
+  // so that `@export(...)` on a type or extension controls the linkage of
+  // its compiler-synthesized members (e.g. derived `Equatable.==`, the
+  // implicit memberwise initializer). We deliberately do *not* propagate
+  // to user-written members — those can carry `@export(...)` directly if
+  // the author wants that linkage, and inheriting silently would surprise
+  // users who expect their explicit members to keep the default linkage.
   //
   // We only inherit when the member itself has effective public visibility,
   // to avoid promoting internal/private members to public symbols in
   // importing modules.
   if (auto *valueDecl = dyn_cast<ValueDecl>(this)) {
-    AccessScope access =
-        valueDecl->getFormalAccessScope(
-            nullptr, /*treatUsableFromInlineAsPublic*/false,
-            /*ignoreImportAccessLevel*/false);
-    if (access.isPublic()) {
-      if (auto *parent = getDeclContext()->getAsDecl()) {
-        if (isa<NominalTypeDecl>(parent) || isa<ExtensionDecl>(parent)) {
-          if (auto parentModel = parent->getExplicitCodeGenerationModel())
-            return *parentModel;
+    if (valueDecl->isSynthesized()) {
+      AccessScope access =
+          valueDecl->getFormalAccessScope(
+              nullptr, /*treatUsableFromInlineAsPublic*/false,
+              /*ignoreImportAccessLevel*/false);
+      if (access.isPublic()) {
+        if (auto *parent = getDeclContext()->getAsDecl()) {
+          if (isa<NominalTypeDecl>(parent) || isa<ExtensionDecl>(parent)) {
+            if (auto parentModel = parent->getExplicitCodeGenerationModel())
+              return *parentModel;
+          }
         }
       }
     }

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2427,6 +2427,32 @@ Decl::getEffectiveCodeGenerationModel() const {
   if (auto required = getRequiredCodeGenerationModel(this))
     return *required;
 
+  // A member of a nominal type or extension inherits its code generation
+  // model from the enclosing type/extension's *explicit* model, so that
+  // `@export(...)` on a type or extension controls the linkage of its
+  // members — including members synthesized by the compiler (e.g. derived
+  // `Equatable.==`). We only consider an explicit model on the parent so
+  // that this inheritance only kicks in when the user has actually written
+  // `@export(...)` (or an equivalent attribute) on the type/extension.
+  //
+  // We only inherit when the member itself has effective public visibility,
+  // to avoid promoting internal/private members to public symbols in
+  // importing modules.
+  if (auto *valueDecl = dyn_cast<ValueDecl>(this)) {
+    AccessScope access =
+        valueDecl->getFormalAccessScope(
+            nullptr, /*treatUsableFromInlineAsPublic*/false,
+            /*ignoreImportAccessLevel*/false);
+    if (access.isPublic()) {
+      if (auto *parent = getDeclContext()->getAsDecl()) {
+        if (isa<NominalTypeDecl>(parent) || isa<ExtensionDecl>(parent)) {
+          if (auto parentModel = parent->getExplicitCodeGenerationModel())
+            return *parentModel;
+        }
+      }
+    }
+  }
+
   // Otherwise, apply the module-level default.
   return getModuleContext()->codeGenerationModel();
 }

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2391,26 +2391,26 @@ Decl::getExplicitCodeGenerationModel() const {
 /// This accounts for limitations of the code generation model. For example,
 /// a generic declaration can only be treated as @export(implementation) in
 /// Embedded Swift, because there are no unspecialized generics.
-static std::optional<CodeGenerationModel>
-getRequiredCodeGenerationModel(const Decl *decl) {
-  bool isEmbedded = decl->getASTContext().LangOpts.hasFeature(Feature::Embedded);
+std::optional<CodeGenerationModel>
+Decl::getRequiredCodeGenerationModel() const {
+  bool isEmbedded = getASTContext().LangOpts.hasFeature(Feature::Embedded);
 
   // A generic declaration must be @export(implementation) in Embedded Swift.
-  auto dc = decl->getInnermostDeclContext();
+  auto dc = getInnermostDeclContext();
   if (auto sig = dc->getGenericSignatureOfContext()) {
     if (!sig->areAllParamsConcrete() && isEmbedded)
       return CodeGenerationModel::Implementation;
   }
 
   // Foreign types are always @export(implementation).
-  if (auto nominal = dyn_cast<NominalTypeDecl>(decl)) {
+  if (auto nominal = dyn_cast<NominalTypeDecl>(this)) {
     if (isa<ClangModuleUnit>(nominal->getModuleScopeContext()))
       return CodeGenerationModel::Implementation;
   }
 
   // Types must be @export(interface) in non-Embedded Swift, because the type
   // metadata symbols need to be unique.
-  if (isa<TypeDecl>(decl) && !isEmbedded)
+  if (isa<TypeDecl>(this) && !isEmbedded)
     return CodeGenerationModel::Interface;
 
   return std::nullopt;
@@ -2418,14 +2418,15 @@ getRequiredCodeGenerationModel(const Decl *decl) {
 
 CodeGenerationModel
 Decl::getEffectiveCodeGenerationModel() const {
+  // If there is a required code generation model, return that. This overrides
+  // any explicitly-written model, which is diagnosed in attribute checking.
+  if (auto required = getRequiredCodeGenerationModel())
+    return *required;
+
   // If there is an explicit attribute that specifies the model for this
   // declaration, use it.
   if (auto explicitModel = getExplicitCodeGenerationModel())
     return *explicitModel;
-
-  // If there is a required code generation model, return that.
-  if (auto required = getRequiredCodeGenerationModel(this))
-    return *required;
 
   // A member of a nominal type or extension inherits its code generation
   // model from the enclosing type/extension's *explicit* model, so that

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -433,9 +433,9 @@ NormalProtocolConformance::getExplicitCodeGenerationModel() const {
   return std::nullopt;
 }
 
-static std::optional<CodeGenerationModel>
-getRequiredCodeGenerationModel(const NormalProtocolConformance *conformance) {
-  auto dc = conformance->getDeclContext();
+std::optional<CodeGenerationModel>
+NormalProtocolConformance::getRequiredCodeGenerationModel() const {
+  auto dc = getDeclContext();
   bool isEmbedded = dc->getASTContext().LangOpts.hasFeature(Feature::Embedded);
 
   // A conformance in a generic context must be @export(implementation) in
@@ -446,7 +446,7 @@ getRequiredCodeGenerationModel(const NormalProtocolConformance *conformance) {
   }
 
   // Synthesized conformances are always @export(implementation).
-  if (conformance->isSynthesized())
+  if (isSynthesized())
     return CodeGenerationModel::Implementation;
 
   // Other conformances must be @export(interface) in non-Embedded Swift,
@@ -460,11 +460,11 @@ getRequiredCodeGenerationModel(const NormalProtocolConformance *conformance) {
 
 CodeGenerationModel
 NormalProtocolConformance::getEffectiveCodeGenerationModel() const {
+  if (auto required = getRequiredCodeGenerationModel())
+    return *required;
+
   if (auto explicitModel = getExplicitCodeGenerationModel())
     return *explicitModel;
-
-  if (auto required = getRequiredCodeGenerationModel(this))
-    return *required;
 
   // Otherwise, apply the module-level default.
   return getDeclContext()->getParentModule()->codeGenerationModel();

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -3830,21 +3830,19 @@ void AttributeChecker::visitExportAttr(ExportAttr *attr) {
   if (auto other = D->getAttrs().getAttribute<ExternAttr>())
     diagnoseAndRemoveAttr(attr, diag::attr_incompatible_with_attr, attr, other);
 
-  // In Embedded Swift, @export(interface) is not supported on generic types
-  // or on extensions of generic types: IRGen emits a unique strong definition
-  // of the type metadata / conformance witness tables, and per-specialization
-  // emission of those globals is not compatible with that.
+  // In Embedded Swift, @export(interface) is not supported on generic types,
+  // extensions of generic types, or generic functions: IRGen emits a unique
+  // strong definition of the type metadata / conformance witness tables /
+  // function, and per-specialization emission of those globals is not
+  // compatible with that.
   if (attr->exportKind == ExportKind::Interface &&
       Ctx.LangOpts.hasFeature(Feature::Embedded)) {
-    bool isGeneric = false;
-    if (auto *nominal = dyn_cast<NominalTypeDecl>(D))
-      isGeneric = nominal->isGenericContext();
-    else if (auto *ext = dyn_cast<ExtensionDecl>(D))
-      isGeneric = ext->isGenericContext();
-    if (isGeneric) {
-      diagnoseAndRemoveAttr(attr,
-                            diag::export_interface_on_generic_in_embedded_swift,
-                            D);
+    if (auto required = D->getRequiredCodeGenerationModel()) {
+      if (*required != CodeGenerationModel::Interface) {
+        diagnoseAndRemoveAttr(attr,
+                              diag::export_interface_on_generic_in_embedded_swift,
+                              D);
+      }
     }
   }
 }

--- a/test/embedded/export_interface_generic.swift
+++ b/test/embedded/export_interface_generic.swift
@@ -49,3 +49,14 @@ extension GenericHolder: P {}
 // @export(implementation) does not have this restriction.
 @export(implementation)
 public struct GenericImplStruct<T> {}
+
+extension P {
+  @export(interface) // expected-error{{'@export(interface)' cannot be applied to a instance method 'f()' in Embedded Swift}}
+  public func f() { }
+}
+
+@export(interface) // expected-error{{'@export(interface)' cannot be applied to a global function 'globalGeneric' in Embedded Swift}}
+public func globalGeneric<T>(_: T) { }
+
+@export(interface) // expected-error{{'@export(interface)' attribute cannot be applied to this declaration}}
+protocol Q { }

--- a/test/embedded/linkage/export_interface_types.swift
+++ b/test/embedded/linkage/export_interface_types.swift
@@ -129,28 +129,27 @@ extension PlainEnum: Equatable {
 // LIBRARY-SIL-DAG: sil_witness_table shared NonExportedEnum: Greeter module Library
 // LIBRARY-SIL-DAG: sil_witness_table PlainStruct: Greeter module Library
 
-// Members of an @export(interface) type or extension inherit the
-// `[export_interface]` SIL function attribute, both for user-written
-// methods and for compiler-synthesized members (e.g. derived `==`).
-// LIBRARY-SIL-DAG: sil [export_interface]{{.*}} @$e7Library11ExportedFooV5greetyyF
-// LIBRARY-SIL-DAG: sil [export_interface]{{.*}} @$e7Library13ExportedClassC5greetyyF
-// LIBRARY-SIL-DAG: sil [export_interface]{{.*}} @$e7Library12ExportedEnumO5greetyyF
+// Members of an @export(interface) type or extension inherit
+// `[export_interface]` *only when they are compiler-synthesized*.
+// User-written methods keep their default linkage so that authors retain
+// per-member control and explicit members aren't silently promoted to a
+// strong cross-module symbol.
+
+// Compiler-synthesized members of @export(interface) types/extensions
+// DO inherit `[export_interface]`: derived `==` (whether the conformance
+// is declared on the type itself or on an @export(interface) extension).
 // LIBRARY-SIL-DAG: sil [export_interface]{{.*}} @$e7Library12ExportedEnumO21__derived_enum_equalsySbAC_ACtFZ
-// LIBRARY-SIL-DAG: sil [export_interface]{{.*}} @$e7Library11PlainStructV5greetyyF
-
-// Multiple members of a single @export(interface) extension all inherit
-// the attribute (the conformance witness, an extra non-witness method,
-// and a computed property's getter).
-// LIBRARY-SIL-DAG: sil [export_interface]{{.*}} @$e7Library11PlainStructV8describeyyF
-// LIBRARY-SIL-DAG: sil [export_interface]{{.*}} @$e7Library11PlainStructV7doubledSivg
-
-// A synthesized `==` from an @export(interface) extension-declared
-// `Equatable` conformance also inherits the attribute (the synthesized
-// member's DeclContext is the extension itself).
 // LIBRARY-SIL-DAG: sil [export_interface]{{.*}} @$e7Library9PlainEnumO21__derived_enum_equalsySbAC_ACtFZ
 
-// And: a non-@export(interface) extension on the same type does NOT
-// promote its members. They keep the default shared/linkonce behavior.
+// User-written methods of @export(interface) types/extensions do NOT
+// inherit `[export_interface]`; they keep the default per-importer
+// linkage. (We assert this with -NOT directives at SIL level.)
+// LIBRARY-SIL-NOT: sil [export_interface]{{.*}} @$e7Library11ExportedFooV5greetyyF
+// LIBRARY-SIL-NOT: sil [export_interface]{{.*}} @$e7Library13ExportedClassC5greetyyF
+// LIBRARY-SIL-NOT: sil [export_interface]{{.*}} @$e7Library12ExportedEnumO5greetyyF
+// LIBRARY-SIL-NOT: sil [export_interface]{{.*}} @$e7Library11PlainStructV5greetyyF
+// LIBRARY-SIL-NOT: sil [export_interface]{{.*}} @$e7Library11PlainStructV8describeyyF
+// LIBRARY-SIL-NOT: sil [export_interface]{{.*}} @$e7Library11PlainStructV7doubledSivg
 // LIBRARY-SIL-NOT: sil [export_interface]{{.*}} @$e7Library11PlainStructV19nonExportedDescribe
 
 //--- Application.swift
@@ -234,27 +233,22 @@ public func compareExportedEnum(_ a: ExportedEnum, _ b: ExportedEnum) -> Bool {
 // APPLICATION-SIL-DAG: sil_witness_table shared NonExportedBar: Greeter module Library
 // APPLICATION-SIL-DAG: sil_witness_table shared NonExportedEnum: Greeter module Library
 
-// Members of @export(interface) types/extensions are referenced as
-// declarations only in the importer (no body emitted here, even for
-// synthesized members like derived `==`). Class methods are dispatched
-// via the vtable so they don't appear as direct symbol references here.
-// APPLICATION-IR-DAG: declare {{.*}}@"$e7Library11ExportedFooV5greetyyF"
-// APPLICATION-IR-DAG: declare {{.*}}@"$e7Library12ExportedEnumO5greetyyF"
+// Compiler-synthesized members of @export(interface) types/extensions
+// are referenced as external declarations in the importer: derived `==`
+// (whether on the type or on an extension).
 // APPLICATION-IR-DAG: declare {{.*}}@"$e7Library12ExportedEnumO21__derived_enum_equalsySbAC_ACtFZ"
-// APPLICATION-IR-DAG: declare {{.*}}@"$e7Library11PlainStructV5greetyyF"
-
-// All members of the @export(interface) extension on PlainStruct are
-// external declarations in the importer (witness, extra method, and the
-// computed property's getter).
-// APPLICATION-IR-DAG: declare {{.*}}@"$e7Library11PlainStructV8describeyyF"
-// APPLICATION-IR-DAG: declare {{.*}}@"$e7Library11PlainStructV7doubledSivg"
-
-// And the synthesized `==` from the @export(interface) extension-declared
-// Equatable conformance on PlainEnum.
 // APPLICATION-IR-DAG: declare {{.*}}@"$e7Library9PlainEnumO21__derived_enum_equalsySbAC_ACtFZ"
 
-// The non-@export(interface) extension's member is NOT externalized; the
+// User-written methods are NOT inherited as @export(interface); the
 // importer emits its own linkonce_odr copy (i.e. a `define`, not a
-// `declare`).
+// `declare`). Class methods go through the vtable, so we don't check them
+// at the IR level here.
+// APPLICATION-IR-DAG: define {{.*}}@"$e7Library11ExportedFooV5greetyyF"
+// APPLICATION-IR-DAG: define {{.*}}@"$e7Library12ExportedEnumO5greetyyF"
+// APPLICATION-IR-DAG: define {{.*}}@"$e7Library11PlainStructV5greetyyF"
+// APPLICATION-IR-DAG: define {{.*}}@"$e7Library11PlainStructV8describeyyF"
+// APPLICATION-IR-DAG: define {{.*}}@"$e7Library11PlainStructV7doubledSivg"
 // APPLICATION-IR-DAG: define {{.*}}@"$e7Library11PlainStructV19nonExportedDescribeyyF"
-// APPLICATION-IR-NOT: declare {{.*}}@"$e7Library11PlainStructV19nonExportedDescribeyyF"
+// APPLICATION-IR-NOT: declare {{.*}}@"$e7Library11ExportedFooV5greetyyF"
+// APPLICATION-IR-NOT: declare {{.*}}@"$e7Library12ExportedEnumO5greetyyF"
+// APPLICATION-IR-NOT: declare {{.*}}@"$e7Library11PlainStructV5greetyyF"

--- a/test/embedded/linkage/export_interface_types.swift
+++ b/test/embedded/linkage/export_interface_types.swift
@@ -39,6 +39,20 @@ public class ExportedClass: Greeter {
   public func greet() { print("class") }
 }
 
+@export(interface)
+public enum ExportedEnum: Greeter, Error, Equatable {
+  case red
+  case green
+  case blue
+  public func greet() { print("enum") }
+}
+
+public enum NonExportedEnum: Greeter {
+  case foo
+  case bar
+  public func greet() { print("plainEnum") }
+}
+
 // A plain type with its conformance declared on an @export(interface)
 // extension: the extension's attribute makes the conformance
 // @export(interface), but does NOT make the type's metadata @export(interface)
@@ -48,9 +62,35 @@ public struct PlainStruct {
   public init(w: Int) { self.w = w }
 }
 
+// Members of an @export(interface) extension — the conformance witness,
+// extra non-witness members, and a computed property's accessor — should
+// all inherit @export(interface) from the enclosing extension, even
+// though `PlainStruct` itself does not carry @export(interface).
 @export(interface)
 extension PlainStruct: Greeter {
   public func greet() { print("plain") }
+  public func describe() { print("plain w=\(w)") }
+  public var doubled: Int { w * 2 }
+}
+
+// A second extension on `PlainStruct` *without* @export(interface): its
+// member should keep the default per-importer linkonce_odr behavior.
+extension PlainStruct {
+  public func nonExportedDescribe() { print("plain non-exported w=\(w)") }
+}
+
+// A plain enum with `Equatable` conformance declared on an
+// @export(interface) extension: the synthesized `__derived_enum_equals`
+// is a member of the extension's DeclContext and should inherit
+// @export(interface) from it.
+public enum PlainEnum {
+  case alpha
+  case beta
+}
+
+@export(interface)
+extension PlainEnum: Equatable {
+  public func describe() { print("plain enum") }
 }
 
 // Library IR:
@@ -61,8 +101,10 @@ extension PlainStruct: Greeter {
 //    (`constant`, or `protected constant` on ELF).
 // LIBRARY-IR-DAG: @"$e7Library11ExportedFooVMf" = {{(protected )?}}constant
 // LIBRARY-IR-DAG: @"$e7Library13ExportedClassCMf" = {{(protected )?}}constant
+// LIBRARY-IR-DAG: @"$e7Library12ExportedEnumOMf" = {{(protected )?}}constant
 // LIBRARY-IR-DAG: @"$e7Library11ExportedFooVAA7GreeterAAWP" = {{(protected )?}}constant
 // LIBRARY-IR-DAG: @"$e7Library13ExportedClassCAA7GreeterAAWP" = {{(protected )?}}constant
+// LIBRARY-IR-DAG: @"$e7Library12ExportedEnumOAA7GreeterAAWP" = {{(protected )?}}constant
 // LIBRARY-IR-DAG: @"$e7Library11PlainStructVAA7GreeterAAWP" = {{(protected )?}}constant
 
 // Non-@export(interface) type metadata and conformances are NOT eagerly
@@ -70,8 +112,10 @@ extension PlainStruct: Greeter {
 // PlainStruct's type metadata is also not emitted here (the type itself is
 // not @export(interface); only its conformance is).
 // LIBRARY-IR-NOT: @"$e7Library14NonExportedBarVMf"
+// LIBRARY-IR-NOT: @"$e7Library15NonExportedEnumOMf"
 // LIBRARY-IR-NOT: @"$e7Library11PlainStructVMf"
 // LIBRARY-IR-NOT: @"$e7Library14NonExportedBarVAA7GreeterAAWP"
+// LIBRARY-IR-NOT: @"$e7Library15NonExportedEnumOAA7GreeterAAWP"
 
 // SIL-level linkage:
 //  - @export(interface) conformances have "public" SIL linkage (shown with
@@ -81,7 +125,33 @@ extension PlainStruct: Greeter {
 // LIBRARY-SIL-DAG: sil_witness_table ExportedFoo: Greeter module Library
 // LIBRARY-SIL-DAG: sil_witness_table shared NonExportedBar: Greeter module Library
 // LIBRARY-SIL-DAG: sil_witness_table ExportedClass: Greeter module Library
+// LIBRARY-SIL-DAG: sil_witness_table ExportedEnum: Greeter module Library
+// LIBRARY-SIL-DAG: sil_witness_table shared NonExportedEnum: Greeter module Library
 // LIBRARY-SIL-DAG: sil_witness_table PlainStruct: Greeter module Library
+
+// Members of an @export(interface) type or extension inherit the
+// `[export_interface]` SIL function attribute, both for user-written
+// methods and for compiler-synthesized members (e.g. derived `==`).
+// LIBRARY-SIL-DAG: sil [export_interface]{{.*}} @$e7Library11ExportedFooV5greetyyF
+// LIBRARY-SIL-DAG: sil [export_interface]{{.*}} @$e7Library13ExportedClassC5greetyyF
+// LIBRARY-SIL-DAG: sil [export_interface]{{.*}} @$e7Library12ExportedEnumO5greetyyF
+// LIBRARY-SIL-DAG: sil [export_interface]{{.*}} @$e7Library12ExportedEnumO21__derived_enum_equalsySbAC_ACtFZ
+// LIBRARY-SIL-DAG: sil [export_interface]{{.*}} @$e7Library11PlainStructV5greetyyF
+
+// Multiple members of a single @export(interface) extension all inherit
+// the attribute (the conformance witness, an extra non-witness method,
+// and a computed property's getter).
+// LIBRARY-SIL-DAG: sil [export_interface]{{.*}} @$e7Library11PlainStructV8describeyyF
+// LIBRARY-SIL-DAG: sil [export_interface]{{.*}} @$e7Library11PlainStructV7doubledSivg
+
+// A synthesized `==` from an @export(interface) extension-declared
+// `Equatable` conformance also inherits the attribute (the synthesized
+// member's DeclContext is the extension itself).
+// LIBRARY-SIL-DAG: sil [export_interface]{{.*}} @$e7Library9PlainEnumO21__derived_enum_equalsySbAC_ACtFZ
+
+// And: a non-@export(interface) extension on the same type does NOT
+// promote its members. They keep the default shared/linkonce behavior.
+// LIBRARY-SIL-NOT: sil [export_interface]{{.*}} @$e7Library11PlainStructV19nonExportedDescribe
 
 //--- Application.swift
 import Library
@@ -98,11 +168,43 @@ public func useExportedClass() -> Any {
   return ExportedClass(z: 7)
 }
 
+public func useExportedEnum() -> Any {
+  return ExportedEnum.red
+}
+
+public func useNonExportedEnum() -> Any {
+  return NonExportedEnum.foo
+}
+
 public func useAsGreeter(_ g: any Greeter) { g.greet() }
 public func formGreeterFoo() { useAsGreeter(ExportedFoo(x: 1)) }
 public func formGreeterBar() { useAsGreeter(NonExportedBar(y: 2)) }
 public func formGreeterClass() { useAsGreeter(ExportedClass(z: 3)) }
+public func formGreeterEnum() { useAsGreeter(ExportedEnum.green) }
+public func formGreeterNonExportedEnum() { useAsGreeter(NonExportedEnum.bar) }
 public func formGreeterPlain() { useAsGreeter(PlainStruct(w: 4)) }
+
+// Direct (non-existential) calls to the @export(interface) members so
+// each appears as an external declaration in the application IR.
+public func directExportedFooGreet(_ v: ExportedFoo) { v.greet() }
+public func directExportedClassGreet(_ v: ExportedClass) { v.greet() }
+public func directExportedEnumGreet(_ v: ExportedEnum) { v.greet() }
+public func directPlainStructGreet(_ v: PlainStruct) { v.greet() }
+
+// Force references to all members of the @export(interface) extension
+// on PlainStruct (witness, extra method, computed property), the
+// non-@export extension's member (negative control), and the
+// auto-derived `==` on the @export(interface) extension on PlainEnum.
+public func usePlainStructDescribe(_ v: PlainStruct) { v.describe() }
+public func usePlainStructDoubled(_ v: PlainStruct) -> Int { v.doubled }
+public func useNonExportedDescribe(_ v: PlainStruct) { v.nonExportedDescribe() }
+public func comparePlainEnum(_ a: PlainEnum, _ b: PlainEnum) -> Bool { a == b }
+
+// Force a reference to the auto-derived `==` on the @export(interface) enum
+// so its synthesized member shows up in the application IR.
+public func compareExportedEnum(_ a: ExportedEnum, _ b: ExportedEnum) -> Bool {
+  return a == b
+}
 
 // Application IR:
 //  - @export(interface) type metadata: referenced as external declarations.
@@ -112,16 +214,47 @@ public func formGreeterPlain() { useAsGreeter(PlainStruct(w: 4)) }
 //  - Non-@export(interface) conformances: linkonce_odr hidden local copy.
 // APPLICATION-IR-DAG: @"$e7Library11ExportedFooVMf" = external global
 // APPLICATION-IR-DAG: @"$e7Library13ExportedClassCMf" = external global
+// APPLICATION-IR-DAG: @"$e7Library12ExportedEnumOMf" = external global
 // APPLICATION-IR-DAG: @"$e7Library11ExportedFooVAA7GreeterAAWP" = external global
 // APPLICATION-IR-DAG: @"$e7Library13ExportedClassCAA7GreeterAAWP" = external global
+// APPLICATION-IR-DAG: @"$e7Library12ExportedEnumOAA7GreeterAAWP" = external global
 // APPLICATION-IR-DAG: @"$e7Library11PlainStructVAA7GreeterAAWP" = external global
 // APPLICATION-IR-DAG: @"$e7Library14NonExportedBarVMf" = linkonce_odr hidden constant
+// APPLICATION-IR-DAG: @"$e7Library15NonExportedEnumOMf" = linkonce_odr hidden constant
 // APPLICATION-IR-DAG: @"$e7Library14NonExportedBarVAA7GreeterAAWP" = linkonce_odr hidden constant
+// APPLICATION-IR-DAG: @"$e7Library15NonExportedEnumOAA7GreeterAAWP" = linkonce_odr hidden constant
 
 // At the SIL level, the application does not own the @export(interface)
 // conformances — they aren't added to the SIL witness_table list here. It
 // does own a shared copy of the non-@export(interface) conformance.
 // APPLICATION-SIL-NOT: sil_witness_table {{.*}} ExportedFoo: Greeter
 // APPLICATION-SIL-NOT: sil_witness_table {{.*}} ExportedClass: Greeter
+// APPLICATION-SIL-NOT: sil_witness_table {{.*}} ExportedEnum: Greeter
 // APPLICATION-SIL-NOT: sil_witness_table {{.*}} PlainStruct: Greeter
-// APPLICATION-SIL: sil_witness_table shared NonExportedBar: Greeter module Library
+// APPLICATION-SIL-DAG: sil_witness_table shared NonExportedBar: Greeter module Library
+// APPLICATION-SIL-DAG: sil_witness_table shared NonExportedEnum: Greeter module Library
+
+// Members of @export(interface) types/extensions are referenced as
+// declarations only in the importer (no body emitted here, even for
+// synthesized members like derived `==`). Class methods are dispatched
+// via the vtable so they don't appear as direct symbol references here.
+// APPLICATION-IR-DAG: declare {{.*}}@"$e7Library11ExportedFooV5greetyyF"
+// APPLICATION-IR-DAG: declare {{.*}}@"$e7Library12ExportedEnumO5greetyyF"
+// APPLICATION-IR-DAG: declare {{.*}}@"$e7Library12ExportedEnumO21__derived_enum_equalsySbAC_ACtFZ"
+// APPLICATION-IR-DAG: declare {{.*}}@"$e7Library11PlainStructV5greetyyF"
+
+// All members of the @export(interface) extension on PlainStruct are
+// external declarations in the importer (witness, extra method, and the
+// computed property's getter).
+// APPLICATION-IR-DAG: declare {{.*}}@"$e7Library11PlainStructV8describeyyF"
+// APPLICATION-IR-DAG: declare {{.*}}@"$e7Library11PlainStructV7doubledSivg"
+
+// And the synthesized `==` from the @export(interface) extension-declared
+// Equatable conformance on PlainEnum.
+// APPLICATION-IR-DAG: declare {{.*}}@"$e7Library9PlainEnumO21__derived_enum_equalsySbAC_ACtFZ"
+
+// The non-@export(interface) extension's member is NOT externalized; the
+// importer emits its own linkonce_odr copy (i.e. a `define`, not a
+// `declare`).
+// APPLICATION-IR-DAG: define {{.*}}@"$e7Library11PlainStructV19nonExportedDescribeyyF"
+// APPLICATION-IR-NOT: declare {{.*}}@"$e7Library11PlainStructV19nonExportedDescribeyyF"

--- a/test/embedded/linkage/export_interface_types_exec.swift
+++ b/test/embedded/linkage/export_interface_types_exec.swift
@@ -36,6 +36,25 @@ public class ExportedClass: Greeter {
   public func greet() { print("class greeting from \(name)") }
 }
 
+@export(interface)
+public enum ExportedEnum: Greeter, Error, Equatable {
+  case red
+  case green
+  case blue
+  public func greet() {
+    switch self {
+    case .red:   print("enum greeting from red")
+    case .green: print("enum greeting from green")
+    case .blue:  print("enum greeting from blue")
+    }
+  }
+}
+
+@export(interface)
+public func throwExportedEnum() throws {
+  throw ExportedEnum.red
+}
+
 //--- Application.swift
 import Library
 
@@ -54,13 +73,38 @@ struct Main {
     callThroughExistential(ExportedStruct(name: "S"))
     // CHECK-NEXT: class greeting from C
     callThroughExistential(ExportedClass(name: "C"))
+    // CHECK-NEXT: enum greeting from green
+    callThroughExistential(ExportedEnum.green)
 
     // Also check casting out of Any still works end-to-end.
-    let anys: [Any] = [ExportedStruct(name: "S2"), ExportedClass(name: "C2")]
+    let anys: [Any] = [
+      ExportedStruct(name: "S2"),
+      ExportedClass(name: "C2"),
+      ExportedEnum.blue,
+    ]
     // CHECK-NEXT: struct greeting from S2
     (anys[0] as! ExportedStruct).greet()
     // CHECK-NEXT: class greeting from C2
     (anys[1] as! ExportedClass).greet()
+    // CHECK-NEXT: enum greeting from blue
+    (anys[2] as! ExportedEnum).greet()
+
+    // Throw the @export(interface) enum across the module boundary and
+    // catch it as the concrete type in the application module.
+    do {
+      try throwExportedEnum()
+    } catch let e as ExportedEnum {
+      // CHECK-NEXT: caught enum greeting from red
+      print("caught", terminator: " ")
+      e.greet()
+      // Exercise the cross-module Equatable conformance on the caught value.
+      // CHECK-NEXT: true
+      print(e == .red)
+      // CHECK-NEXT: false
+      print(e == .green)
+    } catch {
+      print("WRONG ERROR")
+    }
 
     // CHECK-NEXT: DONE
     print("DONE")

--- a/test/embedded/linkage/export_interface_types_exec.swift
+++ b/test/embedded/linkage/export_interface_types_exec.swift
@@ -8,7 +8,7 @@
 
 // RUN: %target-swift-frontend -c -emit-module -o %t/Library.o %t/Library.swift -enable-experimental-feature Embedded -enable-experimental-feature Extern -parse-as-library
 // RUN: %target-swift-frontend -c -I %t -emit-module -o %t/Application.o %t/Application.swift -enable-experimental-feature Embedded -enable-experimental-feature Extern -parse-as-library
-// RUN: %target-clang %target-clang-resource-dir-opt %t/Library.o %t/Application.o %target-embedded-posix-shim -o %t/Application
+// RUN: %target-embedded-link %target-clang-resource-dir-opt %t/Library.o %t/Application.o %target-embedded-posix-shim -o %t/Application
 // RUN: %target-run %t/Application | %FileCheck %s
 
 // REQUIRES: swift_in_compiler

--- a/test/embedded/lit.local.cfg
+++ b/test/embedded/lit.local.cfg
@@ -34,8 +34,11 @@ target_cpu = [y for (x, y) in config.substitutions if x == "%target-cpu"][0]
 target_triple = [y for (x, y) in config.substitutions if x == "%target-triple"][0]
 
 # (5) Provide some useful substitutions to simplify writing tests that work across platforms (macOS, Linux, etc.)
+# Use an absolute path to the embedded Inputs directory so that tests in
+# subdirectories (e.g. embedded/linkage/) can also use %target-embedded-link.
+embedded_inputs_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "Inputs")
 if "OS=linux-gnu" in config.available_features:
-  config.substitutions.append(("%target-embedded-link", config.target_clang + " -x c %S/Inputs/linux-rng-support.c -x none"))
+  config.substitutions.append(("%target-embedded-link", config.target_clang + f" -x c {embedded_inputs_dir}/linux-rng-support.c -x none"))
   config.substitutions.append(("%embedded-unicode-tables", f"-Xlinker {config.swift_obj_root}/lib/swift/embedded/{target_cpu}-unknown-linux-gnu/libswiftUnicodeDataTables.a"))
 elif "OS=macosx" in config.available_features:
   config.substitutions.append(("%target-embedded-link", config.target_clang))


### PR DESCRIPTION
Fix two issues with `@export(interface)` in Embedded Swift:
* It wasn't applying to public, synthesized members, which otherwise cannot be annotated
* Diagnose attempts to put `@export(interface)` on a generic function, which will crash later on and can't work

Fixes rdar://177755296