### PR TITLE
[Reflection] Mark reflect_extension_parent_class as unsupported on device

### DIFF
--- a/validation-test/Reflection/reflect_extension_parent_class.swift
+++ b/validation-test/Reflection/reflect_extension_parent_class.swift
@@ -13,7 +13,7 @@
 // REQUIRES: reflection_test_support
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: asan
-// UNSUPPORTED: remote_run
+// UNSUPPORTED: device_run
 
 // Verifies that reflection can resolve types declared inside a cross-module
 // extension — i.e., types whose parent (the extended type) lives in a


### PR DESCRIPTION
reflect_extension_parent_class.swift cannot be tested on real devices because it depends on a dylib which isn't copied over. I had previously marked it as "UNSUPPORTED: remote_run" but that was the wrong configuration, the right configuration is marking it as unsupported in device_run.

rdar://177903223
