### PR TITLE
[6.4] [Embedded] Prohibit @export(interface) on generic functions

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1128,6 +1128,16 @@ public:
   /// @_neverEmitIntoClient.
   bool isNeverEmittedIntoClient() const;
 
+  /// Compute the code generation model that is required for this declaration.
+  ///
+  /// This function applies the limitations of the compilation model to
+  /// determine if there's a code generation model that *must* be used for the
+  /// given declaration. For example, generic declarations must be
+  /// `@export(implementation)` in Embedded Swift, because it does not support
+  /// unspecialized generics.
+  std::optional<CodeGenerationModel>
+  getRequiredCodeGenerationModel() const;
+
   /// Compute the code generation model that was explicitly requested for
   /// this declaration.
   ///

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2369,6 +2369,37 @@ Decl::getExplicitCodeGenerationModel() const {
   return std::nullopt;
 }
 
+/// Determine the code generation model that is required by the given
+/// declaration.
+///
+/// This accounts for limitations of the code generation model. For example,
+/// a generic declaration can only be treated as @export(implementation) in
+/// Embedded Swift, because there are no unspecialized generics.
+std::optional<CodeGenerationModel>
+Decl::getRequiredCodeGenerationModel() const {
+  bool isEmbedded = getASTContext().LangOpts.hasFeature(Feature::Embedded);
+
+  // A generic declaration must be @export(implementation) in Embedded Swift.
+  auto dc = getInnermostDeclContext();
+  if (auto sig = dc->getGenericSignatureOfContext()) {
+    if (!sig->areAllParamsConcrete() && isEmbedded)
+      return CodeGenerationModel::Implementation;
+  }
+
+  // Foreign types are always @export(implementation).
+  if (auto nominal = dyn_cast<NominalTypeDecl>(this)) {
+    if (isa<ClangModuleUnit>(nominal->getModuleScopeContext()))
+      return CodeGenerationModel::Implementation;
+  }
+
+  // Types must be @export(interface) in non-Embedded Swift, because the type
+  // metadata symbols need to be unique.
+  if (isa<TypeDecl>(this) && !isEmbedded)
+    return CodeGenerationModel::Interface;
+
+  return std::nullopt;
+}
+
 CodeGenerationModel
 Decl::getEffectiveCodeGenerationModel() const {
   // If there is an explicit attribute that specifies the model for this

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -49,6 +49,7 @@
 #include "swift/AST/TypeCheckRequests.h"
 #include "swift/AST/Types.h"
 #include "swift/Basic/Assertions.h"
+#include "swift/Basic/CodeGenerationModel.h"
 #include "swift/Parse/Lexer.h"
 #include "swift/Parse/ParseDeclName.h"
 #include "swift/Sema/IDETypeChecking.h"

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -3930,21 +3930,19 @@ void AttributeChecker::visitExportAttr(ExportAttr *attr) {
   if (auto other = D->getAttrs().getAttribute<ExternAttr>())
     diagnoseAndRemoveAttr(attr, diag::attr_incompatible_with_attr, attr, other);
 
-  // In Embedded Swift, @export(interface) is not supported on generic types
-  // or on extensions of generic types: IRGen emits a unique strong definition
-  // of the type metadata / conformance witness tables, and per-specialization
-  // emission of those globals is not compatible with that.
+  // In Embedded Swift, @export(interface) is not supported on generic types,
+  // extensions of generic types, or generic functions: IRGen emits a unique
+  // strong definition of the type metadata / conformance witness tables /
+  // function, and per-specialization emission of those globals is not
+  // compatible with that.
   if (attr->exportKind == ExportKind::Interface &&
       Ctx.LangOpts.hasFeature(Feature::Embedded)) {
-    bool isGeneric = false;
-    if (auto *nominal = dyn_cast<NominalTypeDecl>(D))
-      isGeneric = nominal->isGenericContext();
-    else if (auto *ext = dyn_cast<ExtensionDecl>(D))
-      isGeneric = ext->isGenericContext();
-    if (isGeneric) {
-      diagnoseAndRemoveAttr(attr,
-                            diag::export_interface_on_generic_in_embedded_swift,
-                            D);
+    if (auto required = D->getRequiredCodeGenerationModel()) {
+      if (*required != CodeGenerationModel::Interface) {
+        diagnoseAndRemoveAttr(attr,
+                              diag::export_interface_on_generic_in_embedded_swift,
+                              D);
+      }
     }
   }
 }

--- a/test/embedded/export_interface_generic.swift
+++ b/test/embedded/export_interface_generic.swift
@@ -49,3 +49,14 @@ extension GenericHolder: P {}
 // @export(implementation) does not have this restriction.
 @export(implementation)
 public struct GenericImplStruct<T> {}
+
+extension P {
+  @export(interface) // expected-error{{'@export(interface)' cannot be applied to a instance method 'f()' in Embedded Swift}}
+  public func f() { }
+}
+
+@export(interface) // expected-error{{'@export(interface)' cannot be applied to a global function 'globalGeneric' in Embedded Swift}}
+public func globalGeneric<T>(_: T) { }
+
+@export(interface) // expected-error{{'@export(interface)' attribute cannot be applied to this declaration}}
+protocol Q { }

--- a/test/embedded/linkage/export_interface_types_exec.swift
+++ b/test/embedded/linkage/export_interface_types_exec.swift
@@ -8,7 +8,7 @@
 
 // RUN: %target-swift-frontend -c -emit-module -o %t/Library.o %t/Library.swift -enable-experimental-feature Embedded -enable-experimental-feature Extern -parse-as-library
 // RUN: %target-swift-frontend -c -I %t -emit-module -o %t/Application.o %t/Application.swift -enable-experimental-feature Embedded -enable-experimental-feature Extern -parse-as-library
-// RUN: %target-clang %target-clang-resource-dir-opt %t/Library.o %t/Application.o %target-embedded-posix-shim -o %t/Application
+// RUN: %target-embedded-link %target-clang-resource-dir-opt %t/Library.o %t/Application.o %target-embedded-posix-shim -o %t/Application
 // RUN: %target-run %t/Application | %FileCheck %s
 
 // REQUIRES: swift_in_compiler

--- a/test/embedded/lit.local.cfg
+++ b/test/embedded/lit.local.cfg
@@ -34,8 +34,11 @@ target_cpu = [y for (x, y) in config.substitutions if x == "%target-cpu"][0]
 target_triple = [y for (x, y) in config.substitutions if x == "%target-triple"][0]
 
 # (5) Provide some useful substitutions to simplify writing tests that work across platforms (macOS, Linux, etc.)
+# Use an absolute path to the embedded Inputs directory so that tests in
+# subdirectories (e.g. embedded/linkage/) can also use %target-embedded-link.
+embedded_inputs_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "Inputs")
 if "OS=linux-gnu" in config.available_features:
-  config.substitutions.append(("%target-embedded-link", config.target_clang + " -x c %S/Inputs/linux-rng-support.c -x none"))
+  config.substitutions.append(("%target-embedded-link", config.target_clang + f" -x c {embedded_inputs_dir}/linux-rng-support.c -x none"))
   config.substitutions.append(("%embedded-unicode-tables", f"-Xlinker {config.swift_obj_root}/lib/swift/embedded/{target_cpu}-unknown-linux-gnu/libswiftUnicodeDataTables.a"))
 elif "OS=macosx" in config.available_features:
   config.substitutions.append(("%target-embedded-link", config.target_clang))


### PR DESCRIPTION
- **Explanation**: Embedded Swift cannot emit IR for unspecialized generic functions. Diagnose attempts to use `@export(interface)` on generic functions in Embedded Swift, because it cannot work and causes assertions in IRGen.
- **Scope**: Limited to use of a fairly new feature (`@export(interface)`) in Embedded Swift.
- **Issues**: rdar://177755296.
- **Original PRs**: https://github.com/swiftlang/swift/pull/89445
- **Risk**: Low due to limited scope.
- **Testing**: New tests.