### PR TITLE
[CAS] Introduce compiler options for doing dependency scanning via a CASFS

### DIFF
--- a/include/swift-c/DependencyScan/DependencyScan.h
+++ b/include/swift-c/DependencyScan/DependencyScan.h
@@ -25,7 +25,7 @@
 /// SWIFTSCAN_VERSION_MINOR should increase when there are API additions.
 /// SWIFTSCAN_VERSION_MAJOR is intended for "major" source/ABI breaking changes.
 #define SWIFTSCAN_VERSION_MAJOR 2
-#define SWIFTSCAN_VERSION_MINOR 3
+#define SWIFTSCAN_VERSION_MINOR 4
 
 SWIFTSCAN_BEGIN_DECLS
 

--- a/include/swift/Basic/CASOptions.h
+++ b/include/swift/Basic/CASOptions.h
@@ -57,6 +57,12 @@ public:
   /// Cache key for imported bridging header.
   std::string BridgingHeaderPCHCacheKey;
 
+  /// CAS FS root to be used for dep-scanning.
+  std::string DepscanCASFileSystemRootID;
+
+  /// Paths for using the underlying file system instead of CASFS.
+  std::vector<std::string> CASFSEscapePaths;
+
   /// Has immutable file system input.
   bool HasImmutableFileSystem = false;
 

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -508,6 +508,17 @@ public:
   /// if not in that mode.
   std::string getAPIDescriptorPathForWholeModule() const;
 
+  /// Create the file system by loading and validating all VFS overlay YAML
+  /// files. If the process of validating VFS files failed, or the overlay
+  /// file system could not be initialized, this function returns null. Else it
+  /// returns the VFS.
+  llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem>
+  createVirtualFileSystemOverlays(
+      llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> BaseFS,
+      std::shared_ptr<llvm::cas::ObjectStore> CAS,
+      std::shared_ptr<llvm::cas::ActionCache> Cache,
+      std::optional<std::string> &CASIDForPCH, DiagnosticEngine &Diag) const;
+
 public:
   /// Given the current configuration of this frontend invocation, a set of
   /// supplementary output paths, and a module, compute the appropriate set of

--- a/lib/DependencyScan/ModuleDependencyScanner.cpp
+++ b/lib/DependencyScan/ModuleDependencyScanner.cpp
@@ -196,12 +196,20 @@ static std::vector<std::string> inputSpecificClangScannerCommand(
 static llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem>
 getClangScanningFS(SwiftDependencyScanningService &service,
                    std::shared_ptr<llvm::cas::ObjectStore> cas,
-                   ASTContext &ctx) {
+                   std::shared_ptr<llvm::cas::ActionCache> cache,
+                   const CompilerInvocation &invocation, ASTContext &ctx) {
   auto *importer = static_cast<ClangImporter *>(ctx.getClangModuleLoader());
+  // Create the file system that the swift frontend uses. Creating a new one
+  // for each clang worker since the workers run concurrently.
+  std::optional<std::string> CASIDForPCH;
+  // We don't need to emit diagnostics, errors would have been emitted earlier
+  // when the frontend first created the file system.
+  DiagnosticEngine Diags(ctx.SourceMgr);
+  auto FS = invocation.createVirtualFileSystemOverlays(
+      llvm::vfs::createPhysicalFileSystem(), cas, cache, CASIDForPCH, Diags);
   // Dependency scanner needs to create its own file system per worker.
   auto fs = ClangImporter::computeClangImporterFileSystem(
-      ctx, importer->getClangFileMapping(),
-      llvm::vfs::createPhysicalFileSystem(), true,
+      ctx, importer->getClangFileMapping(), std::move(FS), true,
       [&](StringRef str) { return service.save(str); });
 
   if (cas)
@@ -221,9 +229,10 @@ ModuleDependencyScanningWorker::ModuleDependencyScanningWorker(
     : workerCompilerInvocation(
           std::make_unique<CompilerInvocation>(ScanCompilerInvocation)),
       workerSourceMgr(ScanASTContext.SourceMgr.getFileSystem()),
-      clangScanningTool(
-          *globalScanningService.ClangScanningService,
-          getClangScanningFS(globalScanningService, CAS, ScanASTContext)),
+      clangScanningTool(*globalScanningService.ClangScanningService,
+                        getClangScanningFS(globalScanningService, CAS,
+                                           ActionCache, ScanCompilerInvocation,
+                                           ScanASTContext)),
       CAS(CAS), ActionCache(ActionCache),
       diagnosticReporter(DiagnosticReporter),
       ShareClangCompilerInstance(ShareClangCompilerInstance) {

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -23,6 +23,7 @@
 #include "swift/Basic/LanguageMode.h"
 #include "swift/Basic/Platform.h"
 #include "swift/Basic/Version.h"
+#include "swift/Frontend/CachingUtils.h"
 #include "swift/Option/Options.h"
 #include "swift/Option/SanitizerOptions.h"
 #include "swift/Parse/Lexer.h"
@@ -31,6 +32,7 @@
 #include "swift/Strings.h"
 #include "swift/SymbolGraphGen/SymbolGraphOptions.h"
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/CAS/CASFileSystem.h"
 #include "llvm/Option/Arg.h"
 #include "llvm/Option/ArgList.h"
 #include "llvm/Option/Option.h"
@@ -39,6 +41,7 @@
 #include "llvm/Support/Path.h"
 #include "llvm/Support/PrefixMapper.h"
 #include "llvm/Support/Process.h"
+#include "llvm/Support/SandboxingFileSystem.h"
 #include "llvm/Support/VersionTuple.h"
 #include "llvm/Support/WithColor.h"
 #include "llvm/TargetParser/Triple.h"
@@ -840,6 +843,10 @@ static bool ParseCASArgs(CASOptions &Opts, ArgList &Args,
   }
 
   Opts.ImportModuleFromCAS |= Args.hasArg(OPT_module_import_from_cas);
+
+  if (auto *A = Args.getLastArg(OPT_scanner_cas_fs))
+    Opts.DepscanCASFileSystemRootID = A->getValue();
+  Opts.CASFSEscapePaths = Args.getAllArgValues(OPT_cas_fs_escape);
 
   if (auto *A = Args.getLastArg(OPT_clang_include_tree_root))
     Opts.ClangIncludeTree = A->getValue();
@@ -4606,4 +4613,147 @@ CompilerInvocation::setUpInputForSILTool(
     getFrontendOptions().InputMode = FrontendOptions::ParseInputMode::SIL;
   }
   return fileBufOrErr;
+}
+
+llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem>
+CompilerInvocation::createVirtualFileSystemOverlays(
+    llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> BaseFS,
+    std::shared_ptr<llvm::cas::ObjectStore> CAS,
+    std::shared_ptr<llvm::cas::ActionCache> Cache,
+    std::optional<std::string> &CASIDForPCH,
+    DiagnosticEngine &Diagnostics) const {
+  auto CurFS = std::move(BaseFS);
+
+  const auto &CASOpts = getCASOptions();
+  if (CASOpts.EnableCaching && !CASOpts.HasImmutableFileSystem &&
+      FrontendOptions::supportCompilationCaching(
+          getFrontendOptions().RequestedAction)) {
+    Diagnostics.diagnose(SourceLoc(), diag::error_caching_no_cas_fs);
+    return nullptr;
+  }
+
+  if (!CASOpts.DepscanCASFileSystemRootID.empty() &&
+      getFrontendOptions().RequestedAction ==
+          FrontendOptions::ActionType::ScanDependencies) {
+    if (CASOpts.requireCASFS()) {
+      Diagnostics.diagnose(
+          SourceLoc(), diag::error_option_incompatible, "-scanner-cas-fs",
+          "-clang-include-tree-root | -clang-include-tree-filelist | "
+          "-input-file-key | -bridging-header-pch-key");
+      return nullptr;
+    }
+
+    auto reportError =
+        [&](llvm::Error E) -> llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> {
+      Diagnostics.diagnose(SourceLoc(), diag::error_cas_fs_creation,
+                           toString(std::move(E)));
+      return nullptr;
+    };
+
+    auto ID = CAS->parseID(CASOpts.DepscanCASFileSystemRootID);
+    if (!ID)
+      return reportError(ID.takeError());
+    auto CASFS = llvm::cas::createCASFileSystem(CAS, *ID);
+    if (!CASFS)
+      return reportError(CASFS.takeError());
+
+    if (!CASOpts.CASFSEscapePaths.empty()) {
+      SmallVector<StringRef, 4> EscapePaths;
+      for (const auto &Path : CASOpts.CASFSEscapePaths) {
+        EscapePaths.push_back(Path);
+      }
+      auto SandboxFS =
+          llvm::vfs::createSandboxingFileSystem(CurFS, EscapePaths);
+      if (!SandboxFS) {
+        Diagnostics.diagnose(SourceLoc(), diag::error_cas_fs_creation,
+                             toString(SandboxFS.takeError()));
+        return nullptr;
+      }
+      auto OverlayFS = llvm::makeIntrusiveRefCnt<llvm::vfs::OverlayFileSystem>(
+          std::move(*CASFS));
+      OverlayFS->pushOverlay(std::move(*SandboxFS));
+      CurFS = std::move(OverlayFS);
+    } else {
+      CurFS = std::move(*CASFS);
+    }
+  }
+
+  if (CASOpts.requireCASFS()) {
+    if (CASOpts.HasImmutableFileSystem) {
+      // Set up CASFS as BaseFS.
+      auto FS = createCASFileSystem(*CAS, CASOpts.ClangIncludeTree,
+                                    CASOpts.ClangIncludeTreeFileList);
+      if (!FS) {
+        Diagnostics.diagnose(SourceLoc(), diag::error_cas_fs_creation,
+                             toString(FS.takeError()));
+        return nullptr;
+      }
+      CurFS = std::move(*FS);
+    }
+
+    // If we need to load any files from CAS, try load it now and overlay it.
+    llvm::IntrusiveRefCntPtr<llvm::vfs::InMemoryFileSystem> MemFS =
+        new llvm::vfs::InMemoryFileSystem();
+    const auto &ClangOpts = getClangImporterOptions();
+
+    if (!CASOpts.BridgingHeaderPCHCacheKey.empty()) {
+      auto Proxy = loadCachedCompileResultProxy(
+          *CAS, *Cache, CASOpts.BridgingHeaderPCHCacheKey,
+          file_types::ID::TY_PCH);
+
+      if (!Proxy) {
+        Diagnostics.diagnose(SourceLoc(), diag::error_cas, "loading pch file",
+                             llvm::toString(Proxy.takeError()));
+        return nullptr;
+      }
+      if (!*Proxy) {
+        Diagnostics.diagnose(SourceLoc(), diag::error_load_input_from_cas,
+                             ClangOpts.getPCHInputPath());
+        return nullptr;
+      }
+      MemFS->addFile(ClangOpts.getPCHInputPath(), 0,
+                     (*Proxy)->getMemoryBuffer());
+      CASIDForPCH = (*Proxy)->getID().toString();
+    }
+    if (!CASOpts.InputFileKey.empty()) {
+      if (getFrontendOptions().InputsAndOutputs.getAllInputs().size() != 1)
+        Diagnostics.diagnose(SourceLoc(),
+                             diag::error_wrong_input_num_for_input_file_key);
+      else {
+        auto InputPath =
+            getFrontendOptions().InputsAndOutputs.getFilenameOfFirstInput();
+        auto Type = file_types::lookupTypeFromFilename(
+            llvm::sys::path::filename(InputPath));
+        if (auto loadedBuffer = loadCachedCompileResultFromCacheKey(
+                *CAS, *Cache, Diagnostics, CASOpts.InputFileKey, Type,
+                InputPath))
+          MemFS->addFile(InputPath, 0, std::move(loadedBuffer));
+        else
+          Diagnostics.diagnose(SourceLoc(), diag::error_load_input_from_cas,
+                               InputPath);
+      }
+    }
+    llvm::IntrusiveRefCntPtr<llvm::vfs::OverlayFileSystem> OverlayVFS =
+        new llvm::vfs::OverlayFileSystem(MemFS);
+    OverlayVFS->pushOverlay(CurFS);
+    CurFS = std::move(OverlayVFS);
+  }
+
+  auto ExpectedOverlay = getSearchPathOptions().makeOverlayFileSystem(CurFS);
+  if (!ExpectedOverlay) {
+    llvm::handleAllErrors(
+        ExpectedOverlay.takeError(), [&](const llvm::FileError &FE) {
+          if (FE.convertToErrorCode() == std::errc::no_such_file_or_directory) {
+            Diagnostics.diagnose(SourceLoc(), diag::cannot_open_file,
+                                 FE.getFileName(), FE.messageWithoutFileInfo());
+          } else {
+            Diagnostics.diagnose(SourceLoc(), diag::invalid_vfs_overlay_file,
+                                 FE.getFileName());
+          }
+        });
+    return nullptr;
+  }
+
+  CurFS = std::move(*ExpectedOverlay);
+  return CurFS;
 }

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -54,7 +54,6 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/CAS/ActionCache.h"
 #include "llvm/CAS/BuiltinUnifiedCASDatabases.h"
-#include "llvm/CAS/CASFileSystem.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/MemoryBuffer.h"
@@ -676,95 +675,14 @@ bool CompilerInstance::setupForReplay(const CompilerInvocation &Invoke,
 }
 
 bool CompilerInstance::setUpVirtualFileSystemOverlays() {
-  const auto &CASOpts = getInvocation().getCASOptions();
-  if (CASOpts.EnableCaching && !CASOpts.HasImmutableFileSystem &&
-      FrontendOptions::supportCompilationCaching(
-          Invocation.getFrontendOptions().RequestedAction)) {
-    Diagnostics.diagnose(SourceLoc(), diag::error_caching_no_cas_fs);
+  std::optional<std::string> CASIDForPCH;
+  auto FS = Invocation.createVirtualFileSystemOverlays(
+      SourceMgr.getFileSystem(), CAS, ResultCache, CASIDForPCH, Diagnostics);
+  if (!FS)
     return true;
-  }
-
-  if (Invocation.getCASOptions().requireCASFS()) {
-    if (Invocation.getCASOptions().HasImmutableFileSystem) {
-      // Set up CASFS as BaseFS.
-      auto FS = createCASFileSystem(*CAS, CASOpts.ClangIncludeTree,
-                                    CASOpts.ClangIncludeTreeFileList);
-      if (!FS) {
-        Diagnostics.diagnose(SourceLoc(), diag::error_cas_fs_creation,
-                             toString(FS.takeError()));
-        return true;
-      }
-      SourceMgr.setFileSystem(std::move(*FS));
-    }
-
-    // If we need to load any files from CAS, try load it now and overlay it.
-    llvm::IntrusiveRefCntPtr<llvm::vfs::InMemoryFileSystem> MemFS =
-        new llvm::vfs::InMemoryFileSystem();
-    const auto &ClangOpts = getInvocation().getClangImporterOptions();
-
-    if (!CASOpts.BridgingHeaderPCHCacheKey.empty()) {
-      auto Proxy = loadCachedCompileResultProxy(
-          getObjectStore(), getActionCache(), CASOpts.BridgingHeaderPCHCacheKey,
-          file_types::ID::TY_PCH);
-
-      if (!Proxy) {
-        Diagnostics.diagnose(SourceLoc(), diag::error_cas, "loading pch file",
-                             llvm::toString(Proxy.takeError()));
-        return true;
-      }
-      if (!*Proxy) {
-        Diagnostics.diagnose(SourceLoc(), diag::error_load_input_from_cas,
-                             ClangOpts.getPCHInputPath());
-        return true;
-      }
-      MemFS->addFile(ClangOpts.getPCHInputPath(), 0,
-                     (*Proxy)->getMemoryBuffer());
-      CASIDForPCH = (*Proxy)->getID().toString();
-    }
-    if (!CASOpts.InputFileKey.empty()) {
-      if (Invocation.getFrontendOptions()
-              .InputsAndOutputs.getAllInputs()
-              .size() != 1)
-        Diagnostics.diagnose(SourceLoc(),
-                             diag::error_wrong_input_num_for_input_file_key);
-      else {
-        auto InputPath = Invocation.getFrontendOptions()
-                             .InputsAndOutputs.getFilenameOfFirstInput();
-        auto Type = file_types::lookupTypeFromFilename(
-            llvm::sys::path::filename(InputPath));
-        if (auto loadedBuffer = loadCachedCompileResultFromCacheKey(
-                getObjectStore(), getActionCache(), Diagnostics,
-                CASOpts.InputFileKey, Type, InputPath))
-          MemFS->addFile(InputPath, 0, std::move(loadedBuffer));
-        else
-          Diagnostics.diagnose(SourceLoc(), diag::error_load_input_from_cas,
-                               InputPath);
-      }
-    }
-    llvm::IntrusiveRefCntPtr<llvm::vfs::OverlayFileSystem> OverlayVFS =
-        new llvm::vfs::OverlayFileSystem(MemFS);
-    OverlayVFS->pushOverlay(SourceMgr.getFileSystem());
-    SourceMgr.setFileSystem(std::move(OverlayVFS));
-  }
-
-  auto ExpectedOverlay =
-      Invocation.getSearchPathOptions().makeOverlayFileSystem(
-          SourceMgr.getFileSystem());
-  if (!ExpectedOverlay) {
-    llvm::handleAllErrors(
-        ExpectedOverlay.takeError(), [&](const llvm::FileError &FE) {
-          if (FE.convertToErrorCode() == std::errc::no_such_file_or_directory) {
-            Diagnostics.diagnose(SourceLoc(), diag::cannot_open_file,
-                                 FE.getFileName(), FE.messageWithoutFileInfo());
-          } else {
-            Diagnostics.diagnose(SourceLoc(), diag::invalid_vfs_overlay_file,
-                                 FE.getFileName());
-          }
-        });
-    return true;
-  }
-
-  SourceMgr.setFileSystem(*ExpectedOverlay);
+  if (CASIDForPCH)
+    this->CASIDForPCH = *CASIDForPCH;
+  SourceMgr.setFileSystem(std::move(FS));
   return false;
 }
 

--- a/lib/Option/features.json
+++ b/lib/Option/features.json
@@ -43,6 +43,9 @@
       "name": "compilation-caching"
     },
     {
+      "name": "dependency-scan-cas-sandbox"
+    },
+    {
        "name": "emit-package-module-interface-path"
     },
     {

--- a/test/CAS/depscan-with-casfs.swift
+++ b/test/CAS/depscan-with-casfs.swift
@@ -1,0 +1,58 @@
+// REQUIRES: objc_interop
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: mkdir %t/smod-dir
+
+// RUN: %target-swift-frontend -emit-module -module-name SMod \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
+// RUN:   -module-cache-path %t/clang-module-cache %t/smod.swift -o %t/smod-dir/SMod.swiftmodule
+
+// Normal scanning, make sure everything is setup correctly.
+// RUN: %target-swift-frontend -scan-dependencies -module-name Test -O \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -I %t/smod-dir -I %t/omod-dir \
+// RUN:   %t/main.swift -o %t/deps.json -cache-compile-job -cas-path %t/cas 2>&1 | %FileCheck %s --check-prefix=SCAN_NOERR -allow-empty
+// SCAN_NOERR-NOT: error:
+
+// RUN: %swift-scan-test -action=create_casfs -cas-path %t/cas %t/main.swift > %t/main-only.id
+
+// Scanning with CASFS without including the modules, make sure modules are not found.
+// RUN: %target-swift-frontend -scan-dependencies -module-name Test -O \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -I %t/smod-dir -I %t/omod-dir \
+// RUN:   -scanner-cas-fs @%t/main-only.id -cas-fs-escape %test-resource-dir \
+// RUN:   %t/main.swift -o %t/deps.json -cache-compile-job -cas-path %t/cas 2>&1 | %FileCheck %s --check-prefix=SCAN_BOTHFAIL
+// SCAN_BOTHFAIL: error: unable to resolve module dependency: 'SMod'
+// SCAN_BOTHFAIL: error: unable to resolve module dependency: 'OMod'
+
+// Scanning with CASFS without including the modules but escaping their paths, make sure modules are found.
+// RUN: %target-swift-frontend -scan-dependencies -module-name Test -O \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -I %t/smod-dir -I %t/omod-dir \
+// RUN:   -scanner-cas-fs @%t/main-only.id -cas-fs-escape %test-resource-dir -cas-fs-escape %t/smod-dir -cas-fs-escape %t/omod-dir \
+// RUN:   %t/main.swift -o %t/deps.json -cache-compile-job -cas-path %t/cas 2>&1 | %FileCheck %s --check-prefix=SCAN_NOERR -allow-empty
+
+// RUN: %swift-scan-test -action=create_casfs -cas-path %t/cas @%t/main-only.id %t/smod-dir %t/omod-dir > %t/allmods.id
+
+// Scanning with CASFS including the modules, make sure modules are found.
+// RUN: %target-swift-frontend -scan-dependencies -module-name Test -O \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -I %t/smod-dir -I %t/omod-dir \
+// RUN:   -scanner-cas-fs @%t/allmods.id -cas-fs-escape %test-resource-dir \
+// RUN:   %t/main.swift -o %t/deps.json -cache-compile-job -cas-path %t/cas 2>&1 | %FileCheck %s --check-prefix=SCAN_NOERR -allow-empty
+
+//--- main.swift
+import SMod
+import OMod
+
+smod_func()
+omod_func()
+
+//--- smod.swift
+public func smod_func() {}
+
+//--- omod-dir/module.modulemap
+module OMod {
+  header "omod.h"
+}
+
+//--- omod-dir/omod.h
+void omod_func(void);
+


### PR DESCRIPTION
The new capability is providing a CASFS tree root that dependency scanning will be performed on, along with ability to provide specific directory paths for "escaping" the CASFS and going to the underlying file system.