### PR TITLE
Sema: Suggest `anyAppleOS` availability when appropriate in fix-its

### DIFF
--- a/include/swift/AST/AvailabilityConstraint.h
+++ b/include/swift/AST/AvailabilityConstraint.h
@@ -175,6 +175,12 @@ public:
   /// on the reason for the constraint.
   AvailabilityDomainAndRange getDomainAndRange(const ASTContext &ctx) const;
 
+  /// Returns the domain and range to use in availability fix-its. This may be
+  /// different than the value returned by `getDomainAndRange()` depending on
+  /// which domain the underlying availability attribute was written with.
+  AvailabilityDomainAndRange
+  getFixItDomainAndRange(const ASTContext &ctx) const;
+
   /// Some availability constraints are active for type-checking but cannot
   /// be translated directly into an `if #available(...)` runtime query.
   bool isActiveForRuntimeQueries(const ASTContext &ctx) const;

--- a/lib/AST/AvailabilityConstraint.cpp
+++ b/lib/AST/AvailabilityConstraint.cpp
@@ -29,6 +29,25 @@ AvailabilityConstraint::getDomainAndRange(const ASTContext &ctx) const {
   }
 }
 
+AvailabilityDomainAndRange
+AvailabilityConstraint::getFixItDomainAndRange(const ASTContext &ctx) const {
+  auto attrDomain = getAttr().getDomain();
+  if (attrDomain.contains(
+          AvailabilityDomain::forPlatform(PlatformKind::anyAppleOS))) {
+    switch (getReason()) {
+    case Reason::UnavailableUnconditionally:
+    case Reason::UnavailableObsolete:
+      return AvailabilityDomainAndRange(
+          attrDomain, AvailabilityRange(getAttr().getObsoleted().value()));
+    case Reason::UnavailableUnintroduced:
+    case Reason::Unintroduced:
+      return AvailabilityDomainAndRange(
+          attrDomain, AvailabilityRange(getAttr().getIntroduced().value()));
+    }
+  }
+  return getDomainAndRange(ctx);
+}
+
 bool AvailabilityConstraint::isActiveForRuntimeQueries(
     const ASTContext &ctx) const {
   if (getAttr().getPlatform() == PlatformKind::none)

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -727,9 +727,11 @@ static void findAvailabilityFixItNodes(
 
 /// Emit a diagnostic note and Fix-It to add an @available attribute
 /// on the given declaration for the given version range.
-static void fixAvailabilityForDecl(
-    SourceRange ReferenceRange, const Decl *D, AvailabilityDomain Domain,
-    const AvailabilityRange &RequiredAvailability, ASTContext &Context) {
+static void fixAvailabilityForDecl(SourceRange ReferenceRange, const Decl *D,
+                                   const AvailabilityDomainAndRange &DomainAndRange,
+                                   ASTContext &Context) {
+  AvailabilityDomain Domain = DomainAndRange.getDomain();
+  const AvailabilityRange &RequiredAvailability = DomainAndRange.getRange();
   assert(D);
 
   // Don't suggest adding an @available to a declaration where we would
@@ -836,9 +838,8 @@ static bool fixAvailabilityByNarrowingNearbyVersionCheck(
 /// Emit a diagnostic note and Fix-It to add an if #available(...) { } guard
 /// that checks for the given version range around the given node.
 static void fixAvailabilityByAddingVersionCheck(
-    ASTNode NodeToWrap, AvailabilityDomain Domain,
-    const AvailabilityRange &RequiredAvailability, SourceRange ReferenceRange,
-    ASTContext &Context) {
+    ASTNode NodeToWrap, const AvailabilityDomainAndRange &DomainAndRange,
+    SourceRange ReferenceRange, ASTContext &Context) {
   // If this is an implicit variable that wraps an expression,
   // let's point to it's initializer. For example, result builder
   // transform captures expressions into implicit variables.
@@ -883,7 +884,8 @@ static void fixAvailabilityByAddingVersionCheck(
       StartAt += NewLine.length();
     }
 
-    AvailabilityDomain QueryDomain = Domain;
+    AvailabilityDomain QueryDomain = DomainAndRange.getDomain();
+    const AvailabilityRange &RequiredAvailability = DomainAndRange.getRange();
 
     // Runtime availability checks that specify app extension platforms don't
     // work, so only suggest checks against the base platform.
@@ -918,8 +920,7 @@ static void fixAvailabilityByAddingVersionCheck(
 
 void swift::fixAvailability(SourceRange ReferenceRange,
                             const DeclContext *ReferenceDC,
-                            AvailabilityDomain Domain,
-                            const AvailabilityRange &RequiredAvailability,
+                            const AvailabilityDomainAndRange &DomainAndRange,
                             ASTContext &Context) {
   if (ReferenceRange.isInvalid())
     return;
@@ -935,19 +936,19 @@ void swift::fixAvailability(SourceRange ReferenceRange,
   // Suggest wrapping in if #available(...) { ... } if possible.
   if (NodeToWrapInVersionCheck.has_value()) {
     fixAvailabilityByAddingVersionCheck(NodeToWrapInVersionCheck.value(),
-                                        Domain, RequiredAvailability,
-                                        ReferenceRange, Context);
+                                        DomainAndRange, ReferenceRange,
+                                        Context);
   }
 
   // Suggest adding availability attributes.
   if (FoundMemberDecl) {
-    fixAvailabilityForDecl(ReferenceRange, FoundMemberDecl, Domain,
-                           RequiredAvailability, Context);
+    fixAvailabilityForDecl(ReferenceRange, FoundMemberDecl, DomainAndRange,
+                           Context);
   }
 
   if (FoundTypeLevelDecl) {
-    fixAvailabilityForDecl(ReferenceRange, FoundTypeLevelDecl, Domain,
-                           RequiredAvailability, Context);
+    fixAvailabilityForDecl(ReferenceRange, FoundTypeLevelDecl, DomainAndRange,
+                           Context);
   }
 }
 
@@ -956,9 +957,10 @@ static void diagnosePotentialUnavailability(
     llvm::function_ref<InFlightDiagnostic(AvailabilityDomain,
                                           AvailabilityRange)>
         Diagnose,
-    const DeclContext *ReferenceDC, AvailabilityDomain Domain,
-    const AvailabilityRange &Availability) {
+    const DeclContext *ReferenceDC, const AvailabilityDomainAndRange &DomainAndRange) {
   ASTContext &Context = ReferenceDC->getASTContext();
+  AvailabilityDomain Domain = DomainAndRange.getDomain();
+  const AvailabilityRange &Availability = DomainAndRange.getRange();
 
   {
     auto Err = Diagnose(Domain, Availability);
@@ -968,7 +970,7 @@ static void diagnosePotentialUnavailability(
             ReferenceRange, ReferenceDC, Domain, Availability, Context, Err))
       return;
   }
-  fixAvailability(ReferenceRange, ReferenceDC, Domain, Availability, Context);
+  fixAvailability(ReferenceRange, ReferenceDC, DomainAndRange, Context);
 }
 
 // FIXME: [availability] Should this take an AvailabilityContext instead of
@@ -993,7 +995,8 @@ bool TypeChecker::checkAvailability(SourceRange ReferenceRange,
 
   if (!availabilityAtLocation.isContainedIn(PlatformRange)) {
     diagnosePotentialUnavailability(ReferenceRange, Diagnose, ReferenceDC,
-                                    domain, PlatformRange);
+                                    AvailabilityDomainAndRange(domain,
+                                                               PlatformRange));
     return true;
   }
 
@@ -1062,10 +1065,11 @@ static Diagnostic getPotentialUnavailabilityDiagnostic(
 static bool
 diagnosePotentialUnavailability(const ValueDecl *D, SourceRange ReferenceRange,
                                 const DeclContext *ReferenceDC,
-                                AvailabilityDomain Domain,
-                                const AvailabilityRange &Availability,
+                                const AvailabilityDomainAndRange &DomainAndRange,
                                 bool WarnBeforeDeploymentTarget = false) {
   ASTContext &Context = ReferenceDC->getASTContext();
+  AvailabilityDomain Domain = DomainAndRange.getDomain();
+  const AvailabilityRange &Availability = DomainAndRange.getRange();
   if (Context.LangOpts.DisableAvailabilityChecking)
     return false;
 
@@ -1082,7 +1086,7 @@ diagnosePotentialUnavailability(const ValueDecl *D, SourceRange ReferenceRange,
       return IsError;
   }
 
-  fixAvailability(ReferenceRange, ReferenceDC, Domain, Availability, Context);
+  fixAvailability(ReferenceRange, ReferenceDC, DomainAndRange, Context);
   return IsError;
 }
 
@@ -1090,9 +1094,11 @@ diagnosePotentialUnavailability(const ValueDecl *D, SourceRange ReferenceRange,
 /// potentially unavailable.
 static void diagnosePotentialAccessorUnavailability(
     const AccessorDecl *Accessor, SourceRange ReferenceRange,
-    const DeclContext *ReferenceDC, AvailabilityDomain Domain,
-    const AvailabilityRange &Availability, bool ForInout) {
+    const DeclContext *ReferenceDC, const AvailabilityDomainAndRange &DomainAndRange,
+    bool ForInout) {
   ASTContext &Context = ReferenceDC->getASTContext();
+  AvailabilityDomain Domain = DomainAndRange.getDomain();
+  const AvailabilityRange &Availability = DomainAndRange.getRange();
 
   assert(Accessor->isGetterOrSetter());
 
@@ -1111,7 +1117,7 @@ static void diagnosePotentialAccessorUnavailability(
       return;
   }
 
-  fixAvailability(ReferenceRange, ReferenceDC, Domain, Availability, Context);
+  fixAvailability(ReferenceRange, ReferenceDC, DomainAndRange, Context);
 }
 
 static DiagnosticBehavior
@@ -1137,12 +1143,14 @@ behaviorLimitForExplicitUnavailability(
 /// unavailable at the given source location.
 static bool diagnosePotentialUnavailability(
     const RootProtocolConformance *rootConf, const ExtensionDecl *ext,
-    SourceLoc loc, const DeclContext *dc, AvailabilityDomain domain,
-    const AvailabilityRange &availability) {
+    SourceLoc loc, const DeclContext *dc,
+    const AvailabilityDomainAndRange &domainAndRange) {
   ASTContext &ctx = dc->getASTContext();
   if (ctx.LangOpts.DisableAvailabilityChecking)
     return false;
 
+  AvailabilityDomain domain = domainAndRange.getDomain();
+  const AvailabilityRange &availability = domainAndRange.getRange();
   {
     auto type = rootConf->getType();
     auto proto = rootConf->getProtocol()->getDeclaredInterfaceType();
@@ -1169,7 +1177,7 @@ static bool diagnosePotentialUnavailability(
       return true;
   }
 
-  fixAvailability(loc, dc, domain, availability, ctx);
+  fixAvailability(loc, dc, domainAndRange, ctx);
   return true;
 }
 
@@ -3164,10 +3172,10 @@ bool swift::diagnoseDeclAvailability(const ValueDecl *D, SourceRange R,
 
   if (accessor) {
     bool forInout = Flags.contains(DeclAvailabilityFlag::ForInout);
-    diagnosePotentialAccessorUnavailability(accessor, R, DC, domain,
-                                            requiredRange, forInout);
+    diagnosePotentialAccessorUnavailability(accessor, R, DC, domainAndRange,
+                                            forInout);
   } else {
-    if (!diagnosePotentialUnavailability(D, R, DC, domain, requiredRange))
+    if (!diagnosePotentialUnavailability(D, R, DC, domainAndRange))
       return false;
   }
 
@@ -3682,8 +3690,7 @@ swift::diagnoseConformanceAvailability(SourceLoc loc,
       // Diagnose (and possibly signal) for potential unavailability
       auto domainAndRange = constraint->getDomainAndRange(ctx);
       if (diagnosePotentialUnavailability(rootConf, ext, loc, DC,
-                                          domainAndRange.getDomain(),
-                                          domainAndRange.getRange())) {
+                                          domainAndRange)) {
         maybeEmitAssociatedTypeNote();
         return true;
       }

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -1062,11 +1062,12 @@ static Diagnostic getPotentialUnavailabilityDiagnostic(
 // Emits a diagnostic for a reference to a declaration that is potentially
 // unavailable at the given source location. Returns true if an error diagnostic
 // was emitted.
-static bool
-diagnosePotentialUnavailability(const ValueDecl *D, SourceRange ReferenceRange,
-                                const DeclContext *ReferenceDC,
-                                const AvailabilityDomainAndRange &DomainAndRange,
-                                bool WarnBeforeDeploymentTarget = false) {
+static bool diagnosePotentialUnavailability(
+    const ValueDecl *D, SourceRange ReferenceRange,
+    const DeclContext *ReferenceDC,
+    const AvailabilityDomainAndRange &DomainAndRange,
+    const AvailabilityDomainAndRange &FixItDomainAndRange,
+    bool WarnBeforeDeploymentTarget = false) {
   ASTContext &Context = ReferenceDC->getASTContext();
   AvailabilityDomain Domain = DomainAndRange.getDomain();
   const AvailabilityRange &Availability = DomainAndRange.getRange();
@@ -1086,7 +1087,7 @@ diagnosePotentialUnavailability(const ValueDecl *D, SourceRange ReferenceRange,
       return IsError;
   }
 
-  fixAvailability(ReferenceRange, ReferenceDC, DomainAndRange, Context);
+  fixAvailability(ReferenceRange, ReferenceDC, FixItDomainAndRange, Context);
   return IsError;
 }
 
@@ -1094,8 +1095,9 @@ diagnosePotentialUnavailability(const ValueDecl *D, SourceRange ReferenceRange,
 /// potentially unavailable.
 static void diagnosePotentialAccessorUnavailability(
     const AccessorDecl *Accessor, SourceRange ReferenceRange,
-    const DeclContext *ReferenceDC, const AvailabilityDomainAndRange &DomainAndRange,
-    bool ForInout) {
+    const DeclContext *ReferenceDC,
+    const AvailabilityDomainAndRange &DomainAndRange,
+    const AvailabilityDomainAndRange &FixItDomainAndRange, bool ForInout) {
   ASTContext &Context = ReferenceDC->getASTContext();
   AvailabilityDomain Domain = DomainAndRange.getDomain();
   const AvailabilityRange &Availability = DomainAndRange.getRange();
@@ -1117,7 +1119,7 @@ static void diagnosePotentialAccessorUnavailability(
       return;
   }
 
-  fixAvailability(ReferenceRange, ReferenceDC, DomainAndRange, Context);
+  fixAvailability(ReferenceRange, ReferenceDC, FixItDomainAndRange, Context);
 }
 
 static DiagnosticBehavior
@@ -1144,7 +1146,8 @@ behaviorLimitForExplicitUnavailability(
 static bool diagnosePotentialUnavailability(
     const RootProtocolConformance *rootConf, const ExtensionDecl *ext,
     SourceLoc loc, const DeclContext *dc,
-    const AvailabilityDomainAndRange &domainAndRange) {
+    const AvailabilityDomainAndRange &domainAndRange,
+    const AvailabilityDomainAndRange &fixItDomainAndRange) {
   ASTContext &ctx = dc->getASTContext();
   if (ctx.LangOpts.DisableAvailabilityChecking)
     return false;
@@ -1177,7 +1180,7 @@ static bool diagnosePotentialUnavailability(
       return true;
   }
 
-  fixAvailability(loc, dc, domainAndRange, ctx);
+  fixAvailability(loc, dc, fixItDomainAndRange, ctx);
   return true;
 }
 
@@ -3161,6 +3164,7 @@ bool swift::diagnoseDeclAvailability(const ValueDecl *D, SourceRange R,
     return false;
 
   auto domainAndRange = constraint->getDomainAndRange(ctx);
+  auto fixItDomainAndRange = constraint->getFixItDomainAndRange(ctx);
   auto domain = domainAndRange.getDomain();
   auto requiredRange = domainAndRange.getRange();
 
@@ -3173,9 +3177,10 @@ bool swift::diagnoseDeclAvailability(const ValueDecl *D, SourceRange R,
   if (accessor) {
     bool forInout = Flags.contains(DeclAvailabilityFlag::ForInout);
     diagnosePotentialAccessorUnavailability(accessor, R, DC, domainAndRange,
-                                            forInout);
+                                            fixItDomainAndRange, forInout);
   } else {
-    if (!diagnosePotentialUnavailability(D, R, DC, domainAndRange))
+    if (!diagnosePotentialUnavailability(D, R, DC, domainAndRange,
+                                         fixItDomainAndRange))
       return false;
   }
 
@@ -3689,8 +3694,9 @@ swift::diagnoseConformanceAvailability(SourceLoc loc,
 
       // Diagnose (and possibly signal) for potential unavailability
       auto domainAndRange = constraint->getDomainAndRange(ctx);
-      if (diagnosePotentialUnavailability(rootConf, ext, loc, DC,
-                                          domainAndRange)) {
+      auto fixItDomainAndRange = constraint->getFixItDomainAndRange(ctx);
+      if (diagnosePotentialUnavailability(
+              rootConf, ext, loc, DC, domainAndRange, fixItDomainAndRange)) {
         maybeEmitAssociatedTypeNote();
         return true;
       }

--- a/lib/Sema/TypeCheckAvailability.h
+++ b/lib/Sema/TypeCheckAvailability.h
@@ -278,8 +278,7 @@ void checkExplicitAvailability(Decl *decl);
 /// Emit suggested Fix-Its for a reference to an unavailable symbol requiring
 /// the given availability range in the given domain.
 void fixAvailability(SourceRange ReferenceRange, const DeclContext *ReferenceDC,
-                     AvailabilityDomain Domain,
-                     const AvailabilityRange &RequiredAvailability,
+                     const AvailabilityDomainAndRange &DomainAndRange,
                      ASTContext &Context);
 
 } // namespace swift

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -3564,8 +3564,7 @@ private:
                        seqType, protoDecl,
                        domainAndRange.getDomain().getNameForAttributePrinting(),
                        domainAndRange.getRange().getVersionString());
-    fixAvailability(loc, dc, domainAndRange.getDomain(),
-                    domainAndRange.getRange(), ctx);
+    fixAvailability(loc, dc, domainAndRange, ctx);
   }
 
   void buildMakeIteratorVar() {

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -3564,7 +3564,7 @@ private:
                        seqType, protoDecl,
                        domainAndRange.getDomain().getNameForAttributePrinting(),
                        domainAndRange.getRange().getVersionString());
-    fixAvailability(loc, dc, domainAndRange, ctx);
+    fixAvailability(loc, dc, constraint.getFixItDomainAndRange(ctx), ctx);
   }
 
   void buildMakeIteratorVar() {

--- a/test/Availability/availability_any_apple_os.swift
+++ b/test/Availability/availability_any_apple_os.swift
@@ -49,19 +49,17 @@ func unavailableInAnyAppleOS() { // expected-apple-note {{'unavailableInAnyApple
   unavailableInEveryAppleOS()
 }
 
-// FIXME: [availability] Ensure the fix-it suggests @available(anyAppleOS ...) rdar://163819878
 func availableAtDeploymentTarget() {
-  // expected-apple-note@-1 {{add '@available' attribute to enclosing global function}}
-  // expected-macos-note@-2 2 {{add '@available' attribute to enclosing global function}}
+  // expected-apple-note@-1 {{add '@available' attribute to enclosing global function}}{{1-1=@available(anyAppleOS 26.1, *)\n}}
+  // expected-macos-note@-2 2 {{add '@available' attribute to enclosing global function}}{{1-1=@available(macOS 26.1, *)\n}}
 
-  // FIXME: [availability] Ensure the fix-it suggests if #available(anyAppleOS ...) rdar://163819878
   availableInAnyAppleOS26_1()
   // expected-macos-error@-1 {{'availableInAnyAppleOS26_1()' is only available in macOS 26.1 or newer}}
   // expected-ios-error@-2 {{'availableInAnyAppleOS26_1()' is only available in iOS 26.1 or newer}}
   // expected-watchos-error@-3 {{'availableInAnyAppleOS26_1()' is only available in watchOS 26.1 or newer}}
   // expected-tvos-error@-4 {{'availableInAnyAppleOS26_1()' is only available in tvOS 26.1 or newer}}
   // expected-visionos-error@-5 {{'availableInAnyAppleOS26_1()' is only available in visionOS 26.1 or newer}}
-  // expected-apple-note@-6 {{add 'if #available' version check}}
+  // expected-apple-note@-6 {{add 'if #available' version check}}{{3-30=if #available(anyAppleOS 26.1, *) {\n      availableInAnyAppleOS26_1()\n  \} else {\n      // Fallback on earlier versions\n  \}}}
 
   // FIXME: [availability] Remap domain/version in deprecation diagnostics
   deprecatedInAnyAppleOS26()

--- a/test/ClangImporter/availability_any_apple_os.swift
+++ b/test/ClangImporter/availability_any_apple_os.swift
@@ -23,13 +23,14 @@ void unavailable() __attribute__((availability(anyappleos, unavailable)));
 import AnyAppleOS
 
 func test() {
-  // expected-macosx-note@-1 {{add '@available' attribute to enclosing global function}}{{1-1=@available(macOS 26.2, *)\n}}
-  // expected-ios-note@-2 {{add '@available' attribute to enclosing global function}}{{1-1=@available(iOS 26.2, *)\n}}
+  // expected-macosx-note@-1 {{add '@available' attribute to enclosing global function}}{{1-1=@available(anyAppleOS 26.2, *)\n}}
+  // expected-ios-note@-2 {{add '@available' attribute to enclosing global function}}{{1-1=@available(anyAppleOS 26.2, *)\n}}
   introduced_in_26_2()
   // expected-macosx-error@-1 {{'introduced_in_26_2()' is only available in macOS 26.2 or newer}}
-  // expected-macosx-note@-2 {{add 'if #available' version check}}{{3-23=if #available(macOS 26.2, *) {\n      introduced_in_26_2()\n  \} else {\n      // Fallback on earlier versions\n  \}}}
+  // expected-macosx-note@-2 {{add 'if #available' version check}}{{3-23=if #available(anyAppleOS 26.2, *) {\n      introduced_in_26_2()\n  \} else {\n      // Fallback on earlier versions\n  \}}}
   // expected-ios-error@-3 {{'introduced_in_26_2()' is only available in iOS 26.2 or newer}}
-  // expected-ios-note@-4 {{add 'if #available' version check}}{{3-23=if #available(iOS 26.2, *) {\n      introduced_in_26_2()\n  \} else {\n      // Fallback on earlier versions\n  \}}}
+  // expected-ios-note@-4 {{add 'if #available' version check}}{{3-23=if #available(anyAppleOS 26.2, *) {\n      introduced_in_26_2()\n  \} else {\n      // Fallback on earlier versions\n  \}}}
+
 
   deprecated_in_26_0()
   // expected-macosx-warning@-1 {{'deprecated_in_26_0()' was deprecated in any Apple OS 26.0}}


### PR DESCRIPTION
When emitting fix-its that would make an unavailable declaration available, use `anyAppleOS` in the fix-it instead of the target platform if the unmet availability constraint is in the `anyAppleOS` domain.

Resolves rdar://174558882.