### PR TITLE
[6.4.x] ClangImporter: Avoid mirroring protocol members that are declared elsewhere

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -8548,6 +8548,44 @@ void SwiftDeclConverter::importMirroredProtocolMembers(
       if (classImplementsProtocol(superInterface, clangProto, true))
         continue;
 
+    auto hasExistingMethodWithSelector =
+        [&](clang::Selector sel, bool isInstance,
+            bool acceptPropertyAccessor) -> bool {
+      auto matches = [&](const clang::ObjCContainerDecl *container) -> bool {
+        auto *existing = isInstance ? container->getInstanceMethod(sel)
+                                    : container->getClassMethod(sel);
+        return existing &&
+               (acceptPropertyAccessor || !existing->isPropertyAccessor());
+      };
+
+      if (matches(interfaceDecl))
+        return true;
+
+      for (auto *category : interfaceDecl->known_categories()) {
+        if (!Impl.getClangSema().isVisible(category))
+          continue;
+        if (category != decl) {
+          auto *categoryModule = Impl.getClangModuleForDecl(category);
+          if (categoryModule != declModule &&
+              categoryModule != interfaceModule) {
+            // Also accept a category in a Clang module that is imported by
+            // the module that declares the conformance, since the concrete
+            // method is reachable through that module's imports.
+            auto *clangCategoryMod =
+                categoryModule ? categoryModule->getClangModule() : nullptr;
+            auto *clangDeclMod =
+                declModule ? declModule->getClangModule() : nullptr;
+            if (!clangCategoryMod || !clangDeclMod ||
+                !clangDeclMod->isModuleVisible(clangCategoryMod))
+              continue;
+          }
+        }
+        if (matches(category))
+          return true;
+      }
+      return false;
+    };
+
     auto importProtocolRequirement = [&](Decl *member) {
       // Skip compatibility stubs; there's no reason to mirror them.
       if (member->isUnavailableInCurrentSwiftVersion())
@@ -8563,28 +8601,9 @@ void SwiftDeclConverter::importMirroredProtocolMembers(
         // name. (This also covers other properties with that same name.)
         // FIXME: We should still mirror the setter as a method if it's
         // not already there.
-        clang::Selector sel = objcProp->getGetterName();
-        if (interfaceDecl->getInstanceMethod(sel))
-          return;
-
-        bool inNearbyCategory =
-            std::any_of(interfaceDecl->known_categories_begin(),
-                        interfaceDecl->known_categories_end(),
-                        [=](const clang::ObjCCategoryDecl *category) -> bool {
-                          if (!Impl.getClangSema().isVisible(category)) {
-                            return false;
-                          }
-                          if (category != decl) {
-                            auto *categoryModule =
-                                Impl.getClangModuleForDecl(category);
-                            if (categoryModule != declModule &&
-                                categoryModule != interfaceModule) {
-                              return false;
-                            }
-                          }
-                          return category->getInstanceMethod(sel);
-                        });
-        if (inNearbyCategory)
+        if (hasExistingMethodWithSelector(objcProp->getGetterName(),
+                                          /*isInstance=*/true,
+                                          /*acceptPropertyAccessor=*/true))
           return;
 
         if (auto imported =
@@ -8607,6 +8626,17 @@ void SwiftDeclConverter::importMirroredProtocolMembers(
       auto objcMethod =
           dyn_cast_or_null<clang::ObjCMethodDecl>(member->getClangDecl());
       if (!objcMethod)
+        return;
+
+      // Don't mirror a method if there's an existing method visible that would
+      // witness the requirement.
+      //
+      // A property accessor doesn't count as an existing method for this
+      // purpose: the property only exposes the member via property syntax, so
+      // we still need the mirror in order to make method-call syntax available.
+      if (hasExistingMethodWithSelector(objcMethod->getSelector(),
+                                        objcMethod->isInstanceMethod(),
+                                        /*acceptPropertyAccessor=*/false))
         return;
 
       // For now, just remember that we saw this method.

--- a/test/ClangImporter/objc_redeclared_properties.swift
+++ b/test/ClangImporter/objc_redeclared_properties.swift
@@ -2,6 +2,12 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -typecheck -I %S/Inputs/custom-modules -D SUB_MODULE %s -verify
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -typecheck -I %S/Inputs/custom-modules -D TWO_MODULES %s -verify
 
+// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -enable-objc-interop -print-module -module-to-print RedeclaredProperties -I %S/Inputs/custom-modules -source-filename %s | %FileCheck %s
+// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -enable-objc-interop -print-module -module-to-print RedeclaredPropertiesSub -module-to-print RedeclaredPropertiesSub.Private -I %S/Inputs/custom-modules -source-filename %s | %FileCheck %s --check-prefixes=CHECK,CHECK-SUB
+// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -enable-objc-interop -print-module -module-to-print RedeclaredPropertiesSplit -module-to-print RedeclaredPropertiesSplit2 -I %S/Inputs/custom-modules -source-filename %s | %FileCheck %s --check-prefixes=CHECK,CHECK-TWO
+
+// REQUIRES: objc_interop
+
 #if ONE_MODULE
 import RedeclaredProperties
 #elseif SUB_MODULE
@@ -37,3 +43,44 @@ func test(obj: RPFoo) {
 func f_51011(obj: RPSub) {
   obj.accessorInProto = nil
 }
+
+// CHECK-SUB:      import RedeclaredPropertiesSub.Private
+// CHECK-SUB-EMPTY:
+
+// CHECK:      protocol RPProto {
+// CHECK-NEXT:   func accessorInProto() -> Any?
+// CHECK-NEXT: }
+// CHECK-NEXT: class RPFoo : RPProto {
+// CHECK-NEXT:   var nonnullToNullable: UnsafeMutablePointer<Int32> { get }
+// CHECK-NEXT:   var nullableToNonnull: UnsafeMutablePointer<Int32>? { get }
+// CHECK-NEXT:   var typeChangeMoreSpecific: Any { get }
+// CHECK-NEXT:   var typeChangeMoreGeneral: RPFoo { get }
+// CHECK-NEXT:   var accessorRedeclaredAsNullable: Any { get }
+// CHECK-NEXT:   class func accessorRedeclaredAsNullable() -> Any
+// CHECK-NEXT:   class func accessorDeclaredFirstAsNullable() -> Any
+// CHECK-NEXT:   var accessorDeclaredFirstAsNullable: Any { get }
+// CHECK-NEXT:   var accessorInProto: Any? { get }
+// CHECK-NEXT:   class func nonnullToNullable() -> UnsafeMutablePointer<Int32>
+// CHECK-NEXT:   class func nullableToNonnull() -> UnsafeMutablePointer<Int32>?
+// CHECK-NEXT:   class func typeChangeMoreSpecific() -> Any
+// CHECK-NEXT:   class func typeChangeMoreGeneral() -> RPFoo
+// CHECK-NEXT:   class func accessorInProto() -> Any?
+// CHECK-NEXT:   func accessorInProto() -> Any?
+// CHECK-NEXT: }
+// CHECK-NEXT: class RPBase : RPProto {
+// CHECK-NEXT:   var accessorInProto: Any? { get }
+// CHECK-NEXT:   class func accessorInProto() -> Any?
+// CHECK-NEXT:   func accessorInProto() -> Any?
+// CHECK-NEXT: }
+
+// CHECK-SUB-NEXT: import RedeclaredPropertiesSub
+// CHECK-SUB-EMPTY:
+
+// CHECK-TWO-NEXT: import RedeclaredPropertiesSplit
+// CHECK-TWO-EMPTY:
+
+// CHECK-NEXT: extension RPFoo {
+// CHECK-NEXT: }
+// CHECK-NEXT: class RPSub : RPBase {
+// CHECK-NEXT:   var accessorInProto: Any?
+// CHECK-NEXT: }

--- a/test/ClangImporter/objc_redeclared_properties_categories.swift
+++ b/test/ClangImporter/objc_redeclared_properties_categories.swift
@@ -1,11 +1,16 @@
-// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -typecheck -F %S/Inputs/frameworks %s 2>&1 | %FileCheck -check-prefix=CHECK -check-prefix=CHECK-PUBLIC %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -typecheck -F %S/Inputs/frameworks -verify -verify-ignore-unrelated -verify-additional-prefix public- %s
 
 // RUN: echo '#import <CategoryOverrides/Private.h>' > %t.h
-// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -F %S/Inputs/frameworks -enable-objc-interop -import-objc-header %t.h %s 2>&1 | %FileCheck -check-prefix=CHECK -check-prefix=CHECK-PRIVATE %s --allow-empty
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -F %S/Inputs/frameworks -enable-objc-interop -import-objc-header %t.h -verify -verify-ignore-unrelated -verify-additional-prefix private- %s
 
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -emit-pch -F %S/Inputs/frameworks -o %t.pch %t.h
-// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -F %S/Inputs/frameworks -enable-objc-interop -import-objc-header %t.pch %s 2>&1 | %FileCheck --allow-empty -check-prefix=CHECK -check-prefix=CHECK-PRIVATE %s
-// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -F %S/Inputs/frameworks -enable-objc-interop -import-objc-header %t.h -pch-output-dir %t/pch %s 2>&1 | %FileCheck --allow-empty -check-prefix=CHECK -check-prefix=CHECK-PRIVATE %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -F %S/Inputs/frameworks -enable-objc-interop -import-objc-header %t.pch -verify -verify-ignore-unrelated -verify-additional-prefix private- %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -F %S/Inputs/frameworks -enable-objc-interop -import-objc-header %t.h -pch-output-dir %t/pch -verify -verify-ignore-unrelated -verify-additional-prefix private- %s
+
+// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -enable-objc-interop -print-module -module-to-print CategoryOverrides -F %S/Inputs/frameworks -source-filename %s | %FileCheck %s --check-prefix=CHECK-PUBLIC
+// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -enable-objc-interop -source-filename %s -print-header -header-to-print %S/Inputs/frameworks/CategoryOverrides.framework/PrivateHeaders/Private.h --cc-args %target-cc-options -F %S/Inputs/frameworks -fsyntax-only %t.h | %FileCheck %s --check-prefix=CHECK-PRIVATE
+
+// REQUIRES: objc_interop
 
 import CategoryOverrides
 
@@ -18,23 +23,20 @@ import CategoryOverrides
 // This configuration appears as an undiagnosed redeclaration of a property and
 // function, which is illegal.
 func colors() {
-  // CHECK-PUBLIC: cannot call value of non-function type 'MyColor?'
-  // CHECK-PRIVATE-NOT: cannot call value of non-function type 'MyColor?'
   let _ : MyColor = MyColor.systemRed
   let _ : MyColor = MyColor.systemRed()!
+  // expected-public-error@-1 {{cannot call value of non-function type 'MyColor?'}}
 }
 
 // Another manifestation of the above for an instance property this time.
 func structs(_ base: MyBaseClass, _ derived: MyDerivedClass) {
-  // CHECK-PUBLIC: cannot call value of non-function type 'SomeStruct'
-  // CHECK-PRIVATE-NOT: cannot call value of non-function type 'SomeStruct'
   let _ : SomeStruct = base.myStructure
   let _ : SomeStruct = base.myStructure()
+  // expected-public-error@-1 {{cannot call value of non-function type 'SomeStruct'}}
 
-  // CHECK-PUBLIC: cannot call value of non-function type 'SomeStruct'
-  // CHECK-PRIVATE-NOT: cannot call value of non-function type 'SomeStruct'
   let _ : SomeStruct = derived.myStructure
   let _ : SomeStruct = derived.myStructure()
+  // expected-public-error@-1 {{cannot call value of non-function type 'SomeStruct'}}
 }
 
 // A category declared in a (private) header can introduce overrides of a property
@@ -43,15 +45,12 @@ func structs(_ base: MyBaseClass, _ derived: MyDerivedClass) {
 // This configuration appears as an undiagnosed override in a Swift extension,
 // which is illegal.
 func takesADerivedClass(_ x: MyDerivedClass) {
-  // CHECK-PUBLIC-NOT: has no member 'derivedMember'
-  // CHECK-PRIVATE-NOT: has no member 'derivedMember'
   x.derivedMember = Base()
 }
 
 func takesABaseClass(_ x: MyBaseClass) {
-  // CHECK-PUBLIC: has no member 'derivedMember'
-  // CHECK-PRIVATE-NOT: has no member 'derivedMember'
   x.derivedMember = Base()
+  // expected-public-error@-1 {{has no member 'derivedMember'}}
 }
 
 // A category declared in a (private) header can introduce overrides of a
@@ -74,29 +73,111 @@ extension Refinery {
 }
 
 func takesARefinery(_ x: Refinery) {
-  // CHECK: cannot assign to property: 'sugar' is a get-only property
   x.sugar = .caster
+  // expected-error@-1 {{cannot assign to property: 'sugar' is a get-only property}}
 }
 
 func takesAnExtraRefinery(_ x: ExtraRefinery) {
-  // CHECK: has no member 'sugar'
   x.sugar = .caster
+  // expected-error@-1 {{has no member 'sugar'}}
+  // expected-error@-2 {{cannot infer contextual base in reference to member 'caster'}}
   x.setSugar(0)
+  // expected-public-error@-1 {{has no member 'setSugar'}}
+  // expected-private-error@-2 {{cannot convert value of type 'Int' to expected argument type '__RefinedSugar'}}
 }
 
 func nullabilityRefinementProto(_ x: MyBaseClass) {
-  // CHECK-PUBLIC: has no member 'requirement'
-  // CHECK-PRIVATE-NOT: has no member 'requirement'
-  // CHECK-PRIVATE-NOT: value of optional type 'Base?'
   let _ : Base = x.requirement
+  // expected-public-error@-1 {{has no member 'requirement'}}
 }
 
 func readwriteRefinementProto(_ x: MyDerivedClass) {
-  // CHECK-PUBLIC: has no member 'answer'
-  // CHECK-PRIVATE-NOT: has no member 'answer'
   if x.answer == 0 {
-    // CHECK-PUBLIC: has no member 'answer'
-    // CHECK-PRIVATE-NOT: has no member 'answer'
+    // expected-public-error@-1 {{has no member 'answer'}}
     x.answer = 42
+    // expected-public-error@-1 {{has no member 'answer'}}
   }
 }
+
+// CHECK-PUBLIC:      class Base {
+// CHECK-PUBLIC-NEXT:   init()
+// CHECK-PUBLIC-NEXT: }
+// CHECK-PUBLIC-NEXT: struct SomeStruct_s {
+// CHECK-PUBLIC-NEXT:   init()
+// CHECK-PUBLIC-NEXT:   init(inner: Int32)
+// CHECK-PUBLIC-NEXT:   var inner: Int32
+// CHECK-PUBLIC-NEXT: }
+// CHECK-PUBLIC-NEXT: typealias SomeStruct = SomeStruct_s
+// CHECK-PUBLIC-NEXT: class MyColor : Base {
+// CHECK-PUBLIC-NEXT:   class var systemRed: MyColor! { get }
+// CHECK-PUBLIC-NEXT:   @available(swift, obsoleted: 3, renamed: "systemRed")
+// CHECK-PUBLIC-NEXT:   class var systemRedColor: MyColor! { get }
+// CHECK-PUBLIC-NEXT:   init()
+// CHECK-PUBLIC-NEXT: }
+// CHECK-PUBLIC-NEXT: class MyBaseClass : Base {
+// CHECK-PUBLIC-NEXT:   var myStructure: SomeStruct { get }
+// CHECK-PUBLIC-NEXT:   init()
+// CHECK-PUBLIC-NEXT: }
+// CHECK-PUBLIC-NEXT: class MyDerivedClass : MyBaseClass {
+// CHECK-PUBLIC-NEXT:   var derivedMember: Base?
+// CHECK-PUBLIC-NEXT:   init()
+// CHECK-PUBLIC-NEXT: }
+// CHECK-PUBLIC-NEXT: struct __RefinedSugar : Hashable, Equatable, RawRepresentable {
+// CHECK-PUBLIC-NEXT:   init(_ rawValue: UInt32)
+// CHECK-PUBLIC-NEXT:   init(rawValue: UInt32)
+// CHECK-PUBLIC-NEXT:   var rawValue: UInt32
+// CHECK-PUBLIC-NEXT:   typealias RawValue = UInt32
+// CHECK-PUBLIC-NEXT: }
+// CHECK-PUBLIC-NEXT: var __Caster: __RefinedSugar { get }
+// CHECK-PUBLIC-NEXT: var __Grantulated: __RefinedSugar { get }
+// CHECK-PUBLIC-NEXT: var __Confectioners: __RefinedSugar { get }
+// CHECK-PUBLIC-NEXT: var __Cane: __RefinedSugar { get }
+// CHECK-PUBLIC-NEXT: var __Demerara: __RefinedSugar { get }
+// CHECK-PUBLIC-NEXT: var __Turbinado: __RefinedSugar { get }
+// CHECK-PUBLIC-NEXT: class Refinery : Base {
+// CHECK-PUBLIC-NEXT:   var __sugar: __RefinedSugar { get }
+// CHECK-PUBLIC-NEXT:   init()
+// CHECK-PUBLIC-NEXT: }
+// CHECK-PUBLIC-NEXT: class ExtraRefinery : Base {
+// CHECK-PUBLIC-NEXT:   var __sugar: __RefinedSugar { get }
+// CHECK-PUBLIC-NEXT:   init()
+// CHECK-PUBLIC-NEXT: }
+// CHECK-PUBLIC-NEXT: protocol NullableProtocol {
+// CHECK-PUBLIC-NEXT:   var requirement: Base? { get }
+// CHECK-PUBLIC-NEXT: }
+// CHECK-PUBLIC-NEXT: protocol NonNullProtocol : NullableProtocol {
+// CHECK-PUBLIC-NEXT:   var requirement: Base { get }
+// CHECK-PUBLIC-NEXT: }
+// CHECK-PUBLIC-NEXT: protocol ReadonlyProtocol {
+// CHECK-PUBLIC-NEXT:   var answer: Int32 { get }
+// CHECK-PUBLIC-NEXT: }
+// CHECK-PUBLIC-NEXT: protocol ReadwriteProtocol : ReadonlyProtocol {
+// CHECK-PUBLIC-NEXT:   var answer: Int32 { get set }
+// CHECK-PUBLIC-NEXT: }
+
+// CHECK-PRIVATE:      import CategoryOverrides
+// CHECK-PRIVATE-NEXT: extension MyBaseClass {
+// CHECK-PRIVATE-NEXT:   var derivedMember: Base?
+// CHECK-PRIVATE-NEXT: }
+// CHECK-PRIVATE-NEXT: extension MyColor {
+// CHECK-PRIVATE-NEXT:   class func systemRed() -> MyColor!
+// CHECK-PRIVATE-NEXT:   @available(swift, obsoleted: 3, renamed: "systemRed()")
+// CHECK-PRIVATE-NEXT:   class func systemRedColor() -> MyColor!
+// CHECK-PRIVATE-NEXT: }
+// CHECK-PRIVATE-NEXT: protocol MyPrivateProtocol {
+// CHECK-PRIVATE-NEXT:   func myStructure() -> SomeStruct
+// CHECK-PRIVATE-NEXT: }
+// CHECK-PRIVATE-NEXT: extension MyBaseClass : MyPrivateProtocol {
+// CHECK-PRIVATE-NEXT:   func myStructure() -> SomeStruct
+// CHECK-PRIVATE-NEXT: }
+// CHECK-PRIVATE-NEXT: extension Refinery {
+// CHECK-PRIVATE-NEXT: }
+// CHECK-PRIVATE-NEXT: extension ExtraRefinery {
+// CHECK-PRIVATE-NEXT:   func setSugar(_ sugar: __RefinedSugar)
+// CHECK-PRIVATE-NEXT: }
+// CHECK-PRIVATE-NEXT: extension MyBaseClass : NonNullProtocol {
+// CHECK-PRIVATE-NEXT:   var requirement: Base { get }
+// CHECK-PRIVATE-NEXT: }
+// CHECK-PRIVATE-NEXT: extension MyDerivedClass : ReadwriteProtocol {
+// CHECK-PRIVATE-NEXT:   var answer: Int32
+// CHECK-PRIVATE-NEXT: }

--- a/test/ClangImporter/objc_redeclared_properties_conformances.swift
+++ b/test/ClangImporter/objc_redeclared_properties_conformances.swift
@@ -99,9 +99,11 @@ func test(x: X) {
   x.methodFromInterface()
   // expected-warning@-1 {{'methodFromInterface()' is deprecated: Interface.h}}
   x.methodFromVisibleCategory()
+  // expected-warning@-1 {{'methodFromVisibleCategory()' is deprecated: VisibleCategory.h}}
   _ = x.readonlyPropFromInterface
   // expected-warning@-1 {{'readonlyPropFromInterface' is deprecated: Interface.h}}
   _ = x.readonlyPropFromVisibleCategory
+  // expected-warning@-1 {{'readonlyPropFromVisibleCategory' is deprecated: VisibleCategory.h}}
   _ = x.readwritePropFromInterface
   // expected-warning@-1 {{'readwritePropFromInterface' is deprecated: Interface.h}}
   x.readwritePropFromInterface = 0
@@ -110,6 +112,7 @@ func test(x: X) {
   // expected-warning@-1 {{'methodAsPropertyWitnessFromInterface()' is deprecated: Interface.h}}
   _ = x.propAsMethodWitnessFromVisibleCategory()
   x.methodFromInterfaceCategory()
+  // expected-warning@-1 {{'methodFromInterfaceCategory()' is deprecated: Interface.h category}}
   _ = x.propFromInterfaceCategory
   // expected-warning@-1 {{'propFromInterfaceCategory' is deprecated: Interface.h category}}
   x.methodFromOtherCategory()
@@ -132,14 +135,7 @@ func test(x: X) {
 // CHECK-NEXT:   var propFromOtherCategory: Int32 { get }
 // CHECK-NEXT: }
 // CHECK-NEXT: extension X : Proto {
-// FIXME: should not be mirrored (rdar://166912341)
-// CHECK-NEXT:   var readonlyPropFromVisibleCategory: Int32 { get }
 // CHECK-NEXT:   var propFromOtherCategory: Int32 { get }
-// FIXME: should not be mirrored (rdar://166912341)
-// CHECK-NEXT:   func methodFromInterfaceCategory()
-// FIXME: should not be mirrored (rdar://166912341)
-// CHECK-NEXT:   func methodFromVisibleCategory()
-// FIXME: should not be mirrored (rdar://166912341)
 // CHECK-NEXT:   func propAsMethodWitnessFromVisibleCategory() -> Int32
 // CHECK-NEXT:   func methodFromOtherCategory()
 // CHECK-NEXT: }

--- a/test/ClangImporter/objc_redeclared_properties_conformances.swift
+++ b/test/ClangImporter/objc_redeclared_properties_conformances.swift
@@ -1,0 +1,145 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: %target-swift-frontend %clang-importer-sdk -typecheck %t/main.swift -I %t/include -verify -swift-version 5
+// RUN: %target-swift-frontend %clang-importer-sdk -typecheck %t/main.swift -I %t/include -verify -swift-version 5 -enable-upcoming-feature MemberImportVisibility
+
+// RUN: %target-swift-ide-test %clang-importer-sdk -print-module -module-to-print Conformances -I %t/include -source-filename %t/main.swift | %FileCheck %s
+
+// REQUIRES: objc_interop
+// REQUIRES: swift_feature_MemberImportVisibility
+
+//--- include/module.modulemap
+module Interface {
+  header "Interface.h"
+  export *
+}
+module VisibleCategory {
+  header "VisibleCategory.h"
+  export *
+}
+module Conformances {
+  header "Conformances.h"
+  export *
+}
+module OtherCategory {
+  header "OtherCategory.h"
+  export *
+}
+
+//--- include/Interface.h
+@import Foundation;
+
+@interface X : NSObject
+- (void)methodFromInterface __attribute__((deprecated("Interface.h")));
+
+@property (readonly, nonatomic) int readonlyPropFromInterface __attribute__((deprecated("Interface.h")));
+@property (readwrite, nonatomic) int readwritePropFromInterface __attribute__((deprecated("Interface.h")));
+- (int)methodAsPropertyWitnessFromInterface __attribute__((deprecated("Interface.h")));
+@end
+
+@interface X (Interface)
+- (void)methodFromInterfaceCategory __attribute__((deprecated("Interface.h category")));
+@property (readonly, nonatomic) int propFromInterfaceCategory __attribute__((deprecated("Interface.h category")));
+@end
+
+//--- include/VisibleCategory.h
+@import Interface;
+
+@interface X (VisibleCategory)
+- (void)methodFromVisibleCategory __attribute__((deprecated("VisibleCategory.h")));
+
+@property (readonly, nonatomic) int readonlyPropFromVisibleCategory __attribute__((deprecated("VisibleCategory.h")));
+@property (readonly, nonatomic) int propAsMethodWitnessFromVisibleCategory __attribute__((deprecated("VisibleCategory.h")));
+@end
+
+//--- include/Conformances.h
+@import VisibleCategory;
+
+@protocol Proto
+
+// Requirements witnessed by X's @interface.
+- (void)methodFromInterface;
+@property (readonly, nonatomic) int readonlyPropFromInterface;
+@property (readwrite, nonatomic) int readwritePropFromInterface;
+@property (readonly, nonatomic) int methodAsPropertyWitnessFromInterface;
+
+// Requirements witnessed by a category in the same module as X's @interface.
+- (void)methodFromInterfaceCategory;
+@property (readonly, nonatomic) int propFromInterfaceCategory;
+
+// Requirements witnessed by a category in the module 'VisibleCategory', which
+// is imported by the module declaring the conformance.
+- (void)methodFromVisibleCategory;
+@property (readonly, nonatomic) int readonlyPropFromVisibleCategory;
+- (int)propAsMethodWitnessFromVisibleCategory;
+
+// Requirements witnessed by a category in the module 'OtherCategory', which
+// is no visible from the module declaring the conformance.
+- (void)methodFromOtherCategory;
+@property (readonly, nonatomic) int propFromOtherCategory;
+
+@end
+
+@interface X (Proto) <Proto>
+@end
+
+//--- include/OtherCategory.h
+@import Interface;
+
+@interface X (OtherCategory)
+- (void)methodFromOtherCategory __attribute__((deprecated("OtherCategory.h")));
+@property (readonly, nonatomic) int propFromOtherCategory __attribute__((deprecated("OtherCategory.h")));
+@end
+
+//--- main.swift
+import Conformances
+import OtherCategory
+
+func test(x: X) {
+  x.methodFromInterface()
+  // expected-warning@-1 {{'methodFromInterface()' is deprecated: Interface.h}}
+  x.methodFromVisibleCategory()
+  _ = x.readonlyPropFromInterface
+  // expected-warning@-1 {{'readonlyPropFromInterface' is deprecated: Interface.h}}
+  _ = x.readonlyPropFromVisibleCategory
+  _ = x.readwritePropFromInterface
+  // expected-warning@-1 {{'readwritePropFromInterface' is deprecated: Interface.h}}
+  x.readwritePropFromInterface = 0
+  // expected-warning@-1 {{'readwritePropFromInterface' is deprecated: Interface.h}}
+  _ = x.methodAsPropertyWitnessFromInterface()
+  // expected-warning@-1 {{'methodAsPropertyWitnessFromInterface()' is deprecated: Interface.h}}
+  _ = x.propAsMethodWitnessFromVisibleCategory()
+  x.methodFromInterfaceCategory()
+  _ = x.propFromInterfaceCategory
+  // expected-warning@-1 {{'propFromInterfaceCategory' is deprecated: Interface.h category}}
+  x.methodFromOtherCategory()
+  _ = x.propFromOtherCategory
+}
+
+// CHECK:      @_exported import VisibleCategory
+// CHECK-EMPTY:
+// CHECK-NEXT: protocol Proto {
+// CHECK-NEXT:   func methodFromInterface()
+// CHECK-NEXT:   var readonlyPropFromInterface: Int32 { get }
+// CHECK-NEXT:   var readwritePropFromInterface: Int32 { get set }
+// CHECK-NEXT:   var methodAsPropertyWitnessFromInterface: Int32 { get }
+// CHECK-NEXT:   func methodFromInterfaceCategory()
+// CHECK-NEXT:   var propFromInterfaceCategory: Int32 { get }
+// CHECK-NEXT:   func methodFromVisibleCategory()
+// CHECK-NEXT:   var readonlyPropFromVisibleCategory: Int32 { get }
+// CHECK-NEXT:   func propAsMethodWitnessFromVisibleCategory() -> Int32
+// CHECK-NEXT:   func methodFromOtherCategory()
+// CHECK-NEXT:   var propFromOtherCategory: Int32 { get }
+// CHECK-NEXT: }
+// CHECK-NEXT: extension X : Proto {
+// FIXME: should not be mirrored (rdar://166912341)
+// CHECK-NEXT:   var readonlyPropFromVisibleCategory: Int32 { get }
+// CHECK-NEXT:   var propFromOtherCategory: Int32 { get }
+// FIXME: should not be mirrored (rdar://166912341)
+// CHECK-NEXT:   func methodFromInterfaceCategory()
+// FIXME: should not be mirrored (rdar://166912341)
+// CHECK-NEXT:   func methodFromVisibleCategory()
+// FIXME: should not be mirrored (rdar://166912341)
+// CHECK-NEXT:   func propAsMethodWitnessFromVisibleCategory() -> Int32
+// CHECK-NEXT:   func methodFromOtherCategory()
+// CHECK-NEXT: }

--- a/test/ClangImporter/objc_redeclared_properties_incompatible.swift
+++ b/test/ClangImporter/objc_redeclared_properties_incompatible.swift
@@ -1,11 +1,16 @@
-// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -typecheck -F %S/Inputs/frameworks %s 2>&1 | %FileCheck -check-prefix=CHECK -check-prefix=CHECK-PUBLIC %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -typecheck -F %S/Inputs/frameworks -verify -verify-additional-prefix public- %s
 
 // RUN: echo '#import <PrivatelyReadwrite/Private.h>' > %t.h
-// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -F %S/Inputs/frameworks -enable-objc-interop -import-objc-header %t.h %s 2>&1 | %FileCheck -check-prefix=CHECK -check-prefix=CHECK-PRIVATE %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -F %S/Inputs/frameworks -enable-objc-interop -import-objc-header %t.h -verify -verify-additional-prefix private- %s
 
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -emit-pch -F %S/Inputs/frameworks -o %t.pch %t.h
-// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -F %S/Inputs/frameworks -enable-objc-interop -import-objc-header %t.pch %s 2>&1 | %FileCheck -check-prefix=CHECK -check-prefix=CHECK-PRIVATE %s
-// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -F %S/Inputs/frameworks -enable-objc-interop -import-objc-header %t.h -pch-output-dir %t/pch %s 2>&1 | %FileCheck -check-prefix=CHECK -check-prefix=CHECK-PRIVATE %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -F %S/Inputs/frameworks -enable-objc-interop -import-objc-header %t.pch -verify -verify-additional-prefix private- %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -F %S/Inputs/frameworks -enable-objc-interop -import-objc-header %t.h -pch-output-dir %t/pch -verify -verify-additional-prefix private- %s
+
+// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -enable-objc-interop -print-module -module-to-print PrivatelyReadwrite -F %S/Inputs/frameworks -source-filename %s | %FileCheck %s --check-prefix=CHECK-PUBLIC
+// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -enable-objc-interop -source-filename %s -print-header -header-to-print %S/Inputs/frameworks/PrivatelyReadwrite.framework/PrivateHeaders/Private.h --cc-args %target-cc-options -F %S/Inputs/frameworks -fsyntax-only %t.h | %FileCheck %s --check-prefix=CHECK-PRIVATE
+
+// REQUIRES: objc_interop
 
 import PrivatelyReadwrite
 
@@ -15,94 +20,172 @@ func testWithInitializer() {
   let obj = PropertiesInit()
 
   let _: Int = obj.nullabilityChange
-  // CHECK: [[@LINE-1]]:20: error: cannot convert value of type 'Base' to specified type 'Int'
+  // expected-error @-1 {{cannot convert value of type 'Base' to specified type 'Int'}}
 
   let _: Int = obj.missingGenerics
-  // CHECK: [[@LINE-1]]:20: error: cannot convert value of type 'GenericClass<Base>' to specified type 'Int'
+  // expected-error @-1 {{cannot convert value of type 'GenericClass<Base>' to specified type 'Int'}}
 
   let _: Int = obj.typeChange
-  // CHECK: [[@LINE-1]]:20: error: cannot convert value of type 'Base' to specified type 'Int'
+  // expected-error @-1 {{cannot convert value of type 'Base' to specified type 'Int'}}
 
-  obj.readwriteChange = Base() // CHECK-PRIVATE-NOT: [[@LINE]]:{{.+}}: error
-  // CHECK-PUBLIC: [[@LINE-1]]:7: error: cannot assign to property: 'readwriteChange' is a get-only property
+  obj.readwriteChange = Base()
+  // expected-public-error @-1 {{cannot assign to property: 'readwriteChange' is a get-only property}}
 }
 
 func testWithoutInitializer(obj: PropertiesNoInit) {
   let _: Int = obj.nullabilityChange
-  // CHECK: [[@LINE-1]]:20: error: cannot convert value of type 'Base' to specified type 'Int'
+  // expected-error @-1 {{cannot convert value of type 'Base' to specified type 'Int'}}
 
   let _: Int = obj.missingGenerics
-  // CHECK: [[@LINE-1]]:20: error: cannot convert value of type 'GenericClass<Base>' to specified type 'Int'
+  // expected-error @-1 {{cannot convert value of type 'GenericClass<Base>' to specified type 'Int'}}
 
   let _: Int = obj.typeChange
-  // CHECK: [[@LINE-1]]:20: error: cannot convert value of type 'Base' to specified type 'Int'
+  // expected-error @-1 {{cannot convert value of type 'Base' to specified type 'Int'}}
 
-  obj.readwriteChange = Base() // CHECK-PRIVATE-NOT: [[@LINE]]:{{.+}}: error
-  // CHECK-PUBLIC: [[@LINE-1]]:7: error: cannot assign to property: 'readwriteChange' is a get-only property
+  obj.readwriteChange = Base()
+  // expected-public-error @-1 {{cannot assign to property: 'readwriteChange' is a get-only property}}
 }
 
 func testGenericWithInitializer() {
   let obj = PropertiesInitGeneric<Base>()
 
   let _: Int = obj.nullabilityChange
-  // CHECK: [[@LINE-1]]:20: error: cannot convert value of type 'Base' to specified type 'Int'
+  // expected-error @-1 {{cannot convert value of type 'Base' to specified type 'Int'}}
 
   let _: Int = obj.missingGenerics
-  // CHECK: [[@LINE-1]]:20: error: cannot convert value of type 'GenericClass<Base>' to specified type 'Int'
+  // expected-error @-1 {{cannot convert value of type 'GenericClass<Base>' to specified type 'Int'}}
 
   let _: Int = obj.typeChange
-  // CHECK: [[@LINE-1]]:20: error: cannot convert value of type 'Base' to specified type 'Int'
+  // expected-error @-1 {{cannot convert value of type 'Base' to specified type 'Int'}}
 
-  obj.readwriteChange = Base() // CHECK-PRIVATE-NOT: [[@LINE]]:{{.+}}: error
-  // CHECK-PUBLIC: [[@LINE-1]]:7: error: cannot assign to property: 'readwriteChange' is a get-only property
+  obj.readwriteChange = Base()
+  // expected-public-error @-1 {{cannot assign to property: 'readwriteChange' is a get-only property}}
 }
 
 func testGenericWithoutInitializer(obj: PropertiesNoInitGeneric<Base>) {
   let _: Int = obj.nullabilityChange
-  // CHECK: [[@LINE-1]]:20: error: cannot convert value of type 'Base' to specified type 'Int'
+  // expected-error @-1 {{cannot convert value of type 'Base' to specified type 'Int'}}
 
   let _: Int = obj.missingGenerics
-  // CHECK: [[@LINE-1]]:20: error: cannot convert value of type 'GenericClass<Base>' to specified type 'Int'
+  // expected-error @-1 {{cannot convert value of type 'GenericClass<Base>' to specified type 'Int'}}
 
   let _: Int = obj.typeChange
-  // CHECK: [[@LINE-1]]:20: error: cannot convert value of type 'Base' to specified type 'Int'
+  // expected-error @-1 {{cannot convert value of type 'Base' to specified type 'Int'}}
 
-  obj.readwriteChange = Base() // CHECK-PRIVATE-NOT: [[@LINE]]:{{.+}}: error
-  // CHECK-PUBLIC: [[@LINE-1]]:7: error: cannot assign to property: 'readwriteChange' is a get-only property
+  obj.readwriteChange = Base()
+  // expected-public-error @-1 {{cannot assign to property: 'readwriteChange' is a get-only property}}
 }
 
 func testCategoryWithInitializer() {
   let obj = PropertiesInitCategory()
 
   let _: Int = obj.nullabilityChange
-  // CHECK-PUBLIC: [[@LINE-1]]:20: error: cannot convert value of type 'Base' to specified type 'Int'
-  // CHECK-PRIVATE: [[@LINE-2]]:20: error: cannot convert value of type 'Base?' to specified type 'Int'
+  // expected-public-error @-1 {{cannot convert value of type 'Base' to specified type 'Int'}}
+  // expected-private-error @-2 {{cannot convert value of type 'Base?' to specified type 'Int'}}
 
   let _: Int = obj.missingGenerics
-  // CHECK-PUBLIC: [[@LINE-1]]:20: error: cannot convert value of type 'GenericClass<Base>' to specified type 'Int'
-  // CHECK-PRIVATE: [[@LINE-2]]:20: error: cannot convert value of type 'GenericClass<AnyObject>' to specified type 'Int'
+  // expected-public-error @-1 {{cannot convert value of type 'GenericClass<Base>' to specified type 'Int'}}
+  // expected-private-error @-2 {{cannot convert value of type 'GenericClass<AnyObject>' to specified type 'Int'}}
 
   let _: Int = obj.typeChange
-  // CHECK-PUBLIC: [[@LINE-1]]:20: error: cannot convert value of type 'Base' to specified type 'Int'
-  // CHECK-PRIVATE: [[@LINE-2]]:20: error: cannot convert value of type 'PrivateSubclass' to specified type 'Int'
+  // expected-public-error @-1 {{cannot convert value of type 'Base' to specified type 'Int'}}
+  // expected-private-error @-2 {{cannot convert value of type 'PrivateSubclass' to specified type 'Int'}}
 
-  obj.readwriteChange = Base() // CHECK-PRIVATE-NOT: [[@LINE]]:{{.+}}: error
-  // CHECK-PUBLIC: [[@LINE-1]]:7: error: cannot assign to property: 'readwriteChange' is a get-only property
+  obj.readwriteChange = Base()
+  // expected-public-error @-1 {{cannot assign to property: 'readwriteChange' is a get-only property}}
 }
 
 func testCategoryWithoutInitializer(obj: PropertiesNoInitCategory) {
   let _: Int = obj.nullabilityChange
-  // CHECK-PUBLIC: [[@LINE-1]]:20: error: cannot convert value of type 'Base' to specified type 'Int'
-  // CHECK-PRIVATE: [[@LINE-2]]:20: error: cannot convert value of type 'Base?' to specified type 'Int'
+  // expected-public-error @-1 {{cannot convert value of type 'Base' to specified type 'Int'}}
+  // expected-private-error @-2 {{cannot convert value of type 'Base?' to specified type 'Int'}}
 
   let _: Int = obj.missingGenerics
-  // CHECK-PUBLIC: [[@LINE-1]]:20: error: cannot convert value of type 'GenericClass<Base>' to specified type 'Int'
-  // CHECK-PRIVATE: [[@LINE-2]]:20: error: cannot convert value of type 'GenericClass<AnyObject>' to specified type 'Int'
+  // expected-public-error @-1 {{cannot convert value of type 'GenericClass<Base>' to specified type 'Int'}}
+  // expected-private-error @-2 {{cannot convert value of type 'GenericClass<AnyObject>' to specified type 'Int'}}
 
   let _: Int = obj.typeChange
-  // CHECK-PUBLIC: [[@LINE-1]]:20: error: cannot convert value of type 'Base' to specified type 'Int'
-  // CHECK-PRIVATE: [[@LINE-2]]:20: error: cannot convert value of type 'PrivateSubclass' to specified type 'Int'
+  // expected-public-error @-1 {{cannot convert value of type 'Base' to specified type 'Int'}}
+  // expected-private-error @-2 {{cannot convert value of type 'PrivateSubclass' to specified type 'Int'}}
 
-  obj.readwriteChange = Base() // CHECK-PRIVATE-NOT: [[@LINE]]:{{.+}}: error
-  // CHECK-PUBLIC: [[@LINE-1]]:7: error: cannot assign to property: 'readwriteChange' is a get-only property
+  obj.readwriteChange = Base()
+  // expected-public-error @-1 {{cannot assign to property: 'readwriteChange' is a get-only property}}
 }
+
+// CHECK-PUBLIC:      class Base {
+// CHECK-PUBLIC-NEXT:   init()
+// CHECK-PUBLIC-NEXT: }
+// CHECK-PUBLIC-NEXT: class GenericClass<T> : Base where T : AnyObject {
+// CHECK-PUBLIC-NEXT:   init()
+// CHECK-PUBLIC-NEXT: }
+// CHECK-PUBLIC-NEXT: class PropertiesInit : Base {
+// CHECK-PUBLIC-NEXT:   var readwriteChange: Base { get }
+// CHECK-PUBLIC-NEXT:   var nullabilityChange: Base { get }
+// CHECK-PUBLIC-NEXT:   var missingGenerics: GenericClass<Base> { get }
+// CHECK-PUBLIC-NEXT:   var typeChange: Base { get }
+// CHECK-PUBLIC-NEXT:   init()
+// CHECK-PUBLIC-NEXT: }
+// CHECK-PUBLIC-NEXT: class PropertiesNoInit : Base {
+// CHECK-PUBLIC-NEXT:   var readwriteChange: Base { get }
+// CHECK-PUBLIC-NEXT:   var nullabilityChange: Base { get }
+// CHECK-PUBLIC-NEXT:   var missingGenerics: GenericClass<Base> { get }
+// CHECK-PUBLIC-NEXT:   var typeChange: Base { get }
+// CHECK-PUBLIC-NEXT:   init()
+// CHECK-PUBLIC-NEXT: }
+// CHECK-PUBLIC-NEXT: class PropertiesInitGeneric<T> : Base where T : AnyObject {
+// CHECK-PUBLIC-NEXT:   var readwriteChange: Base { get }
+// CHECK-PUBLIC-NEXT:   var nullabilityChange: Base { get }
+// CHECK-PUBLIC-NEXT:   var missingGenerics: GenericClass<Base> { get }
+// CHECK-PUBLIC-NEXT:   var typeChange: Base { get }
+// CHECK-PUBLIC-NEXT:   init()
+// CHECK-PUBLIC-NEXT: }
+// CHECK-PUBLIC-NEXT: class PropertiesNoInitGeneric<T> : Base where T : AnyObject {
+// CHECK-PUBLIC-NEXT:   var readwriteChange: Base { get }
+// CHECK-PUBLIC-NEXT:   var nullabilityChange: Base { get }
+// CHECK-PUBLIC-NEXT:   var missingGenerics: GenericClass<Base> { get }
+// CHECK-PUBLIC-NEXT:   var typeChange: Base { get }
+// CHECK-PUBLIC-NEXT:   init()
+// CHECK-PUBLIC-NEXT: }
+// CHECK-PUBLIC-NEXT: class PropertiesInitCategory : Base {
+// CHECK-PUBLIC-NEXT:   init()
+// CHECK-PUBLIC-NEXT: }
+// CHECK-PUBLIC-NEXT: extension PropertiesInitCategory {
+// CHECK-PUBLIC-NEXT:   var readwriteChange: Base { get }
+// CHECK-PUBLIC-NEXT:   var nullabilityChange: Base { get }
+// CHECK-PUBLIC-NEXT:   var missingGenerics: GenericClass<Base> { get }
+// CHECK-PUBLIC-NEXT:   var typeChange: Base { get }
+// CHECK-PUBLIC-NEXT: }
+// CHECK-PUBLIC-NEXT: class PropertiesNoInitCategory : Base {
+// CHECK-PUBLIC-NEXT:   init()
+// CHECK-PUBLIC-NEXT: }
+// CHECK-PUBLIC-NEXT: extension PropertiesNoInitCategory {
+// CHECK-PUBLIC-NEXT:   var readwriteChange: Base { get }
+// CHECK-PUBLIC-NEXT:   var nullabilityChange: Base { get }
+// CHECK-PUBLIC-NEXT:   var missingGenerics: GenericClass<Base> { get }
+// CHECK-PUBLIC-NEXT:   var typeChange: Base { get }
+// CHECK-PUBLIC-NEXT: }
+
+// CHECK-PRIVATE:      import PrivatelyReadwrite
+// CHECK-PRIVATE-NEXT: class PrivateSubclass : Base {
+// CHECK-PRIVATE-NEXT:   init()
+// CHECK-PRIVATE-NEXT: }
+// CHECK-PRIVATE-NEXT: extension PropertiesInit {
+// CHECK-PRIVATE-NEXT: }
+// CHECK-PRIVATE-NEXT: extension PropertiesNoInit {
+// CHECK-PRIVATE-NEXT: }
+// CHECK-PRIVATE-NEXT: extension PropertiesInitGeneric {
+// CHECK-PRIVATE-NEXT: }
+// CHECK-PRIVATE-NEXT: extension PropertiesNoInitGeneric {
+// CHECK-PRIVATE-NEXT: }
+// CHECK-PRIVATE-NEXT: extension PropertiesInitCategory {
+// CHECK-PRIVATE-NEXT:   var readwriteChange: Base
+// CHECK-PRIVATE-NEXT:   var nullabilityChange: Base?
+// CHECK-PRIVATE-NEXT:   var missingGenerics: GenericClass<AnyObject>
+// CHECK-PRIVATE-NEXT:   var typeChange: PrivateSubclass
+// CHECK-PRIVATE-NEXT: }
+// CHECK-PRIVATE-NEXT: extension PropertiesNoInitCategory {
+// CHECK-PRIVATE-NEXT:   var readwriteChange: Base
+// CHECK-PRIVATE-NEXT:   var nullabilityChange: Base?
+// CHECK-PRIVATE-NEXT:   var missingGenerics: GenericClass<AnyObject>
+// CHECK-PRIVATE-NEXT:   var typeChange: PrivateSubclass
+// CHECK-PRIVATE-NEXT: }

--- a/test/NameLookup/member_import_visibility_objc.swift
+++ b/test/NameLookup/member_import_visibility_objc.swift
@@ -32,8 +32,7 @@ func test(x: X) {
   // expected-no-member-visibility-warning@-1 {{'overriddenInOverlayForC()' is deprecated: Categories_C.swift}}
   // expected-member-visibility-warning@-2 {{'overriddenInOverlayForC()' is deprecated: Categories_A.h}}
   x.witnessesObjCConformanceRequirementInC()
-  // expected-no-member-visibility-warning@-1 {{'witnessesObjCConformanceRequirementInC()' is deprecated: Categories_A.h}}
-  // expected-member-visibility-warning@-2 {{'witnessesObjCConformanceRequirementInC()' is deprecated: Categories_A.h}}
+  // expected-warning@-1 {{'witnessesObjCConformanceRequirementInC()' is deprecated: Categories_A.h}}
   x.fromSubmoduleOfD() // expected-member-visibility-error {{instance method 'fromSubmoduleOfD()' is not available due to missing import of defining module 'Categories_D'}}
   x.fromBridgingHeader()
   x.overridesCategoryMethodOnNSObject()


### PR DESCRIPTION
- **Explanation:** When an ObjC class in an imported Clang module conforms to an ObjC protocol whose requirement shares a selector with an existing, concrete method already declared on the class or a nearby category, `SwiftDeclConverter` would still synthesize a "mirrored" method. During name lookup and overload resolution, the mirror implementation could be picked instead of the concrete implementation. Prior to MemberImportVisibility, the fact that the compiler chooses the mirrored method was typically invisible to developers under most circumstances. However, with MemberImportVisibility this behavior resulted in unexpected diagnostics requiring developers to import another module. The fix is to skip mirroring when the interface, or a category in the same module as either the interface or the conformance, already declares a concrete (non-accessor) method with the same selector.
- **Scope:** Affects projects that import Clang modules containing categories that conform a type that module does not own to some protocol.
- **Issue/Radar:** rdar://166912341
- **Original PR:** https://github.com/swiftlang/swift/pull/89382
- **Risk:** Low. This change removes imported member declarations from some Clang modules, which could theoretically be source breaking. However, it only does so when another module that was imported by the affected Clang module declares those members instead, so source compatibility should be preserved in the vast majority of cases by Clang module re-export conventions.
- **Testing:** New compiler tests. 
- **Reviewers:** @j-hui @hnrklssn 