### PR TITLE
[Swiftify] don't unwrap pointers for UP! when not needed

### DIFF
--- a/lib/Macros/Sources/SwiftMacros/SwiftifyImportMacro.swift
+++ b/lib/Macros/Sources/SwiftMacros/SwiftifyImportMacro.swift
@@ -805,9 +805,11 @@ extension PointerBoundsThunkBuilder {
   // Whether the wrapper exposes the buffer parameter / return value as an
   // Optional. Only the `*OrNull` variants propagate the underlying nullability;
   // the plain variants always produce a non-Optional Span/buffer pointer.
-  var nullable: Bool { return isOrNull && oldTypeIsOptional }
+  var nullable: Bool { return isOrNull && oldTypeIsNormalOptional }
 
-  var oldTypeIsOptional: Bool { return oldType.is(OptionalTypeSyntax.self) }
+  var oldTypeIsNormalOptional: Bool { return oldType.is(OptionalTypeSyntax.self) }
+  var oldTypeIsAnyOptional: Bool { return oldType.is(OptionalTypeSyntax.self) ||
+    oldType.is(ImplicitlyUnwrappedOptionalTypeSyntax.self) }
 
   var newType: TypeSyntax {
     get throws {
@@ -896,7 +898,7 @@ struct CountedOrSizedReturnPointerThunkBuilder: PointerBoundsThunkBuilder {
           return nil
         }
         """)))
-    } else if oldTypeIsOptional && generateSpan {
+    } else if oldTypeIsAnyOptional && generateSpan {
       // Span's `_unsafeStart` requires a non-nil pointer; the underlying
       // function promises to only return null if count is 0, we can handle
       // that by returning a default constructed Span. The precondition helps
@@ -907,8 +909,15 @@ struct CountedOrSizedReturnPointerThunkBuilder: PointerBoundsThunkBuilder {
       let cast = try newType
       let attrName = isSizedBy ? "sized_by" : "counted_by"
       let valueName = isSizedBy ? "size" : "count"
+      var castToNormalOptional = ""
+      if !oldTypeIsNormalOptional {
+        let IUOType = oldType.as(ImplicitlyUnwrappedOptionalTypeSyntax.self)!
+        // Immediatiely casting to a normal optional guarantees that we don't
+        // accidentally unwrap it implicitly
+        castToNormalOptional = ": \(IUOType.wrappedType)?"
+      }
       res.append(CodeBlockItemSyntax.Item(try VariableDeclSyntax(
-        "let _resultValue = \(call)")))
+        "let _resultValue\(raw: castToNormalOptional) = \(call)")))
       res.append(CodeBlockItemSyntax.Item(StmtSyntax(
         """
         if unsafe _resultValue == nil {
@@ -929,7 +938,7 @@ struct CountedOrSizedReturnPointerThunkBuilder: PointerBoundsThunkBuilder {
       }
     var cast = try newType
     var expr: ExprSyntax
-    if nullable || (oldTypeIsOptional && generateSpan) {
+    if nullable || (oldTypeIsAnyOptional && generateSpan) {
       // The call has already been bound to `_resultValue` (and the empty
       // case handled with an early return) by `buildPreReturnStatements`.
       if let optType = cast.as(OptionalTypeSyntax.self) {
@@ -1079,7 +1088,7 @@ struct CountedOrSizedPointerThunkBuilder: ParamBoundsThunkBuilder, PointerBounds
   }
 
   func unwrapIfNonnullable(_ expr: ExprSyntax) -> ExprSyntax {
-    if !oldTypeIsOptional {
+    if !oldTypeIsAnyOptional {
       return ExprSyntax(ForceUnwrapExprSyntax(expression: expr))
     }
     return expr

--- a/test/Frontend/DiagnosticVerifier/clang-attribute.swift
+++ b/test/Frontend/DiagnosticVerifier/clang-attribute.swift
@@ -45,7 +45,7 @@ module TestClang {
 // CHECK: TEST_H:1:6: note: in expansion from here
 // CHECK: TEST_H:1:6: note: file 'TEST_H' is not parsed for 'expected' statements. Use '-verify-additional-file TEST_H' to enable, or '-verify-ignore-unrelated' to ignore diagnostics in this file 
 
-// CHECK: @__swiftmacro_So3foo15_SwiftifyImportfMp_.swift:4:1: error: unexpected remark produced: macro content: |    return unsafe foo(len, p.baseAddress!)|
+// CHECK: @__swiftmacro_So3foo15_SwiftifyImportfMp_.swift:4:1: error: unexpected remark produced: macro content: |    return unsafe foo(len, p.baseAddress)|
 // CHECK: TEST_H:1:25: note: in expansion from here
 // CHECK: TEST_H:1:25: note: file 'TEST_H' is not parsed for 'expected' statements. Use '-verify-additional-file TEST_H' to enable, or '-verify-ignore-unrelated' to ignore diagnostics in this file
 // CHECK: <empty-filename>:1:1: error: unexpected note produced: in expansion of macro '_SwiftifyImport' on global function 'foo' here

--- a/test/Interop/C/swiftify-import/availability.swift
+++ b/test/Interop/C/swiftify-import/availability.swift
@@ -29,7 +29,7 @@ void span(int *__counted_by(len) p __noescape, int len) __attribute__((availabil
 @available(macOS 10.5, *) @_alwaysEmitIntoClient @_disfavoredOverload
 public func bufferPointer(_ _bufferPointer_param0: UnsafeMutableBufferPointer<Int32>) {
     let _bufferPointer_param1 = Int32(exactly: _bufferPointer_param0.count)!
-    return unsafe bufferPointer(_bufferPointer_param0.baseAddress!, _bufferPointer_param1)
+    return unsafe bufferPointer(_bufferPointer_param0.baseAddress, _bufferPointer_param1)
 }
 ------------------------------
 @__swiftmacro_So4span15_SwiftifyImportfMp_.swift
@@ -44,7 +44,7 @@ public func span(_ p: inout MutableSpan<Int32>) {
     defer {
         _fixLifetime(p)
     }
-    return unsafe span(_pPtr.baseAddress!, len)
+    return unsafe span(_pPtr.baseAddress, len)
 }
 ------------------------------
 //--- ios-expansions.expected

--- a/test/Interop/C/swiftify-import/availability.swift
+++ b/test/Interop/C/swiftify-import/availability.swift
@@ -54,7 +54,7 @@ public func span(_ p: inout MutableSpan<Int32>) {
 @available(iOS 2.0, *) @_alwaysEmitIntoClient @_disfavoredOverload
 public func bufferPointer(_ _bufferPointer_param0: UnsafeMutableBufferPointer<Int32>) {
     let _bufferPointer_param1 = Int32(exactly: _bufferPointer_param0.count)!
-    return unsafe bufferPointer(_bufferPointer_param0.baseAddress!, _bufferPointer_param1)
+    return unsafe bufferPointer(_bufferPointer_param0.baseAddress, _bufferPointer_param1)
 }
 ------------------------------
 @__swiftmacro_So4span15_SwiftifyImportfMp_.swift
@@ -69,7 +69,7 @@ public func span(_ p: inout MutableSpan<Int32>) {
     defer {
         _fixLifetime(p)
     }
-    return unsafe span(_pPtr.baseAddress!, len)
+    return unsafe span(_pPtr.baseAddress, len)
 }
 ------------------------------
 //--- watchos-expansions.expected
@@ -79,7 +79,7 @@ public func span(_ p: inout MutableSpan<Int32>) {
 @available(watchOS 2.0, *) @_alwaysEmitIntoClient @_disfavoredOverload
 public func bufferPointer(_ _bufferPointer_param0: UnsafeMutableBufferPointer<Int32>) {
     let _bufferPointer_param1 = Int32(exactly: _bufferPointer_param0.count)!
-    return unsafe bufferPointer(_bufferPointer_param0.baseAddress!, _bufferPointer_param1)
+    return unsafe bufferPointer(_bufferPointer_param0.baseAddress, _bufferPointer_param1)
 }
 ------------------------------
 @__swiftmacro_So4span15_SwiftifyImportfMp_.swift
@@ -94,7 +94,7 @@ public func span(_ p: inout MutableSpan<Int32>) {
     defer {
         _fixLifetime(p)
     }
-    return unsafe span(_pPtr.baseAddress!, len)
+    return unsafe span(_pPtr.baseAddress, len)
 }
 ------------------------------
 //--- xros-expansions.expected
@@ -104,7 +104,7 @@ public func span(_ p: inout MutableSpan<Int32>) {
 @available(visionOS 1.0, *) @_alwaysEmitIntoClient @_disfavoredOverload
 public func bufferPointer(_ _bufferPointer_param0: UnsafeMutableBufferPointer<Int32>) {
     let _bufferPointer_param1 = Int32(exactly: _bufferPointer_param0.count)!
-    return unsafe bufferPointer(_bufferPointer_param0.baseAddress!, _bufferPointer_param1)
+    return unsafe bufferPointer(_bufferPointer_param0.baseAddress, _bufferPointer_param1)
 }
 ------------------------------
 @__swiftmacro_So4span15_SwiftifyImportfMp_.swift
@@ -119,7 +119,7 @@ public func span(_ p: inout MutableSpan<Int32>) {
     defer {
         _fixLifetime(p)
     }
-    return unsafe span(_pPtr.baseAddress!, len)
+    return unsafe span(_pPtr.baseAddress, len)
 }
 ------------------------------
 //--- tvos-expansions.expected
@@ -128,7 +128,7 @@ public func span(_ p: inout MutableSpan<Int32>) {
 /// This is an auto-generated wrapper for safer interop
 @_alwaysEmitIntoClient @_disfavoredOverload public func bufferPointer(_ _bufferPointer_param0: UnsafeMutableBufferPointer<Int32>) {
     let _bufferPointer_param1 = Int32(exactly: _bufferPointer_param0.count)!
-    return unsafe bufferPointer(_bufferPointer_param0.baseAddress!, _bufferPointer_param1)
+    return unsafe bufferPointer(_bufferPointer_param0.baseAddress, _bufferPointer_param1)
 }
 ------------------------------
 @__swiftmacro_So4span15_SwiftifyImportfMp_.swift
@@ -142,7 +142,7 @@ public func span(_ p: inout MutableSpan<Int32>) {
     defer {
         _fixLifetime(p)
     }
-    return unsafe span(_pPtr.baseAddress!, len)
+    return unsafe span(_pPtr.baseAddress, len)
 }
 ------------------------------
 //--- other-expansions.expected
@@ -151,7 +151,7 @@ public func span(_ p: inout MutableSpan<Int32>) {
 /// This is an auto-generated wrapper for safer interop
 @_alwaysEmitIntoClient @_disfavoredOverload public func bufferPointer(_ _bufferPointer_param0: UnsafeMutableBufferPointer<Int32>) {
     let _bufferPointer_param1 = Int32(exactly: _bufferPointer_param0.count)!
-    return unsafe bufferPointer(_bufferPointer_param0.baseAddress!, _bufferPointer_param1)
+    return unsafe bufferPointer(_bufferPointer_param0.baseAddress, _bufferPointer_param1)
 }
 ------------------------------
 @__swiftmacro_So4span15_SwiftifyImportfMp_.swift
@@ -165,7 +165,7 @@ public func span(_ p: inout MutableSpan<Int32>) {
     defer {
         _fixLifetime(p)
     }
-    return unsafe span(_pPtr.baseAddress!, len)
+    return unsafe span(_pPtr.baseAddress, len)
 }
 ------------------------------
 //--- test.swift

--- a/test/Interop/C/swiftify-import/bridging-header-from-module.swift
+++ b/test/Interop/C/swiftify-import/bridging-header-from-module.swift
@@ -37,7 +37,7 @@ imports for @__swiftmacro_So3foo15_SwiftifyImportfMp_.swift:
     defer {
         _fixLifetime(p)
     }
-    return unsafe foo(len, _pPtr.baseAddress!, x)
+    return unsafe foo(len, _pPtr.baseAddress, x)
 }
 ------------------------------
 

--- a/test/Interop/C/swiftify-import/bridging-header-import-once.swift
+++ b/test/Interop/C/swiftify-import/bridging-header-import-once.swift
@@ -20,7 +20,7 @@ const int FOO = 42;
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func func1(_ p: UnsafeBufferPointer<Int32>) {|}}
 //   expected-remark@3{{macro content: |    let len = Int32(exactly: p.count)!|}}
-//   expected-remark@4{{macro content: |    return unsafe func1(p.baseAddress!, len)|}}
+//   expected-remark@4{{macro content: |    return unsafe func1(p.baseAddress, len)|}}
 //   expected-remark@5{{macro content: |}|}}
 // }}
 // expected-expansion@+3:6{{

--- a/test/Interop/C/swiftify-import/bridging-header-including-module.swift
+++ b/test/Interop/C/swiftify-import/bridging-header-including-module.swift
@@ -39,7 +39,7 @@ imports for @__swiftmacro_So3foo15_SwiftifyImportfMp_.swift:
 /// This is an auto-generated wrapper for safer interop
 @_alwaysEmitIntoClient @_disfavoredOverload public func foo(_ p: UnsafeMutableBufferPointer<Int32>) {
     let len = Int32(exactly: p.count)!
-    return unsafe foo(len, p.baseAddress!)
+    return unsafe foo(len, p.baseAddress)
 }
 ------------------------------
 

--- a/test/Interop/C/swiftify-import/bridging-header-nontrivial.swift
+++ b/test/Interop/C/swiftify-import/bridging-header-nontrivial.swift
@@ -41,7 +41,7 @@ imports for @__swiftmacro_So3bar15_SwiftifyImportfMp_.swift:
     defer {
         _fixLifetime(p)
     }
-    return unsafe foo(len, _pPtr.baseAddress!)
+    return unsafe foo(len, _pPtr.baseAddress)
 }
 ------------------------------
 @__swiftmacro_So3bar15_SwiftifyImportfMp_.swift
@@ -55,7 +55,7 @@ imports for @__swiftmacro_So3bar15_SwiftifyImportfMp_.swift:
     defer {
         _fixLifetime(p)
     }
-    return unsafe bar(len, _pPtr.baseAddress!)
+    return unsafe bar(len, _pPtr.baseAddress)
 }
 ------------------------------
 

--- a/test/Interop/C/swiftify-import/bridging-header.swift
+++ b/test/Interop/C/swiftify-import/bridging-header.swift
@@ -35,7 +35,7 @@ imports for @__swiftmacro_So3foo15_SwiftifyImportfMp_.swift:
     defer {
         _fixLifetime(p)
     }
-    return unsafe foo(len, _pPtr.baseAddress!, x)
+    return unsafe foo(len, _pPtr.baseAddress, x)
 }
 ------------------------------
 

--- a/test/Interop/C/swiftify-import/conflicting-opaqueness.swift
+++ b/test/Interop/C/swiftify-import/conflicting-opaqueness.swift
@@ -39,7 +39,7 @@ struct container_t {
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func fooWrapped(_ x: UnsafeMutablePointer<container_t>!, _ p: UnsafeMutableBufferPointer<Int32>) {|}}
 //   expected-remark@3{{macro content: |    let len = Int32(exactly: p.count)!|}}
-//   expected-remark@4{{macro content: |    return unsafe fooWrapped(x, p.baseAddress!, len)|}}
+//   expected-remark@4{{macro content: |    return unsafe fooWrapped(x, p.baseAddress, len)|}}
 //   expected-remark@5{{macro content: |}|}}
 // }}
 void fooWrapped(struct container_t * x, int * __counted_by(len) p, int len);
@@ -55,7 +55,7 @@ void foobar_release(foobar_ref x);
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func foobar(_ _foobar_param0: UnsafeMutableBufferPointer<Int32>, _ _foobar_param2: foobar_ref!) {|}}
 //   expected-remark@3{{macro content: |    let _foobar_param1 = Int32(exactly: _foobar_param0.count)!|}}
-//   expected-remark@4{{macro content: |    return unsafe foobar(_foobar_param0.baseAddress!, _foobar_param1, _foobar_param2)|}}
+//   expected-remark@4{{macro content: |    return unsafe foobar(_foobar_param0.baseAddress, _foobar_param1, _foobar_param2)|}}
 //   expected-remark@5{{macro content: |}|}}
 // }}
 // expected-expansion@+3:6{{
@@ -73,7 +73,7 @@ void foobar(int * __counted_by(len), int len, foobar_ref);
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func bar(_ x: UnsafeMutablePointer<qux>!, _ p: UnsafeMutableBufferPointer<Int32>) {|}}
 //   expected-remark@3{{macro content: |    let len = Int32(exactly: p.count)!|}}
-//   expected-remark@4{{macro content: |    return unsafe bar(x, p.baseAddress!, len)|}}
+//   expected-remark@4{{macro content: |    return unsafe bar(x, p.baseAddress, len)|}}
 //   expected-remark@5{{macro content: |}|}}
 // }}
 // expected-expansion@+3:6{{
@@ -84,7 +84,7 @@ void bar(struct qux *x, int * __counted_by(len) p, int len);
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func barReturn(_ p: UnsafeMutableBufferPointer<Int32>) -> UnsafeMutablePointer<qux>! {|}}
 //   expected-remark@3{{macro content: |    let len = Int32(exactly: p.count)!|}}
-//   expected-remark@4{{macro content: |    return unsafe barReturn(p.baseAddress!, len)|}}
+//   expected-remark@4{{macro content: |    return unsafe barReturn(p.baseAddress, len)|}}
 //   expected-remark@5{{macro content: |}|}}
 // }}
 // expected-expansion@+3:14{{
@@ -103,7 +103,7 @@ struct qux;
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func baz(_ x: UnsafeMutablePointer<qux>!, _ p: UnsafeMutableBufferPointer<Int32>) {|}}
 //   expected-remark@3{{macro content: |    let len = Int32(exactly: p.count)!|}}
-//   expected-remark@4{{macro content: |    return unsafe baz(x, p.baseAddress!, len)|}}
+//   expected-remark@4{{macro content: |    return unsafe baz(x, p.baseAddress, len)|}}
 //   expected-remark@5{{macro content: |}|}}
 // }}
 // expected-expansion@+3:6{{
@@ -114,7 +114,7 @@ void baz(struct qux *x, int * __counted_by(len) p, int len);
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func bazReturn(_ p: UnsafeMutableBufferPointer<Int32>) -> UnsafeMutablePointer<qux>! {|}}
 //   expected-remark@3{{macro content: |    let len = Int32(exactly: p.count)!|}}
-//   expected-remark@4{{macro content: |    return unsafe bazReturn(p.baseAddress!, len)|}}
+//   expected-remark@4{{macro content: |    return unsafe bazReturn(p.baseAddress, len)|}}
 //   expected-remark@5{{macro content: |}|}}
 // }}
 // expected-expansion@+3:14{{

--- a/test/Interop/C/swiftify-import/counted-by-lifetimebound.swift
+++ b/test/Interop/C/swiftify-import/counted-by-lifetimebound.swift
@@ -20,7 +20,7 @@
 #define __counted_by_or_null(x) __attribute__((__counted_by_or_null__(x)))
 #define __lifetimebound __attribute__((lifetimebound))
 
-// expected-experimental-expansion@+13:58{{
+// expected-experimental-expansion@+18:58{{
 //   expected-experimental-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy p) @_lifetime(p: copy p) @_disfavoredOverload public func simple(_ len: Int32, _ p: inout MutableSpan<Int32>) -> MutableSpan<Int32> {|}}
 //   expected-experimental-remark@3{{macro content: |    let len2 = Int32(exactly: p.count)!|}}
@@ -30,12 +30,17 @@
 //   expected-experimental-remark@7{{macro content: |    defer {|}}
 //   expected-experimental-remark@8{{macro content: |        _fixLifetime(p)|}}
 //   expected-experimental-remark@9{{macro content: |    }|}}
-//   expected-experimental-remark@10{{macro content: |    return unsafe _swiftifyOverrideLifetime(MutableSpan<Int32>(_unsafeStart: unsafe simple(len, len2, _pPtr.baseAddress!), count: Int(len)), copying: ())|}}
-//   expected-experimental-remark@11{{macro content: |}|}}
+//   expected-experimental-remark@10{{macro content: |    let _resultValue: UnsafeMutablePointer<Int32>? = unsafe simple(len, len2, _pPtr.baseAddress)|}}
+//   expected-experimental-remark@11{{macro content: |    if unsafe _resultValue == nil {|}}
+//   expected-experimental-remark@12{{macro content: |      precondition(len == 0, "counted_by may only be null if count is 0 (unlike counted_by_or_null)")|}}
+//   expected-experimental-remark@13{{macro content: |      return MutableSpan<Int32>()|}}
+//   expected-experimental-remark@14{{macro content: |    }|}}
+//   expected-experimental-remark@15{{macro content: |    return unsafe _swiftifyOverrideLifetime(MutableSpan<Int32>(_unsafeStart: _resultValue!, count: Int(len)), copying: ())|}}
+//   expected-experimental-remark@16{{macro content: |}|}}
 // }}
 int * __counted_by(len) simple(int len, int len2, int * p __counted_by(len2) __lifetimebound);
 
-// expected-experimental-expansion@+13:48{{
+// expected-experimental-expansion@+18:48{{
 //   expected-experimental-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy p) @_lifetime(p: copy p) @_disfavoredOverload public func shared(_ p: inout MutableSpan<Int32>) -> MutableSpan<Int32> {|}}
 //   expected-experimental-remark@3{{macro content: |    let len = Int32(exactly: p.count)!|}}
@@ -45,12 +50,17 @@ int * __counted_by(len) simple(int len, int len2, int * p __counted_by(len2) __l
 //   expected-experimental-remark@7{{macro content: |    defer {|}}
 //   expected-experimental-remark@8{{macro content: |        _fixLifetime(p)|}}
 //   expected-experimental-remark@9{{macro content: |    }|}}
-//   expected-experimental-remark@10{{macro content: |    return unsafe _swiftifyOverrideLifetime(MutableSpan<Int32>(_unsafeStart: unsafe shared(len, _pPtr.baseAddress!), count: Int(len)), copying: ())|}}
-//   expected-experimental-remark@11{{macro content: |}|}}
+//   expected-experimental-remark@10{{macro content: |    let _resultValue: UnsafeMutablePointer<Int32>? = unsafe shared(len, _pPtr.baseAddress)|}}
+//   expected-experimental-remark@11{{macro content: |    if unsafe _resultValue == nil {|}}
+//   expected-experimental-remark@12{{macro content: |      precondition(len == 0, "counted_by may only be null if count is 0 (unlike counted_by_or_null)")|}}
+//   expected-experimental-remark@13{{macro content: |      return MutableSpan<Int32>()|}}
+//   expected-experimental-remark@14{{macro content: |    }|}}
+//   expected-experimental-remark@15{{macro content: |    return unsafe _swiftifyOverrideLifetime(MutableSpan<Int32>(_unsafeStart: _resultValue!, count: Int(len)), copying: ())|}}
+//   expected-experimental-remark@16{{macro content: |}|}}
 // }}
 int * __counted_by(len) shared(int len, int * p __counted_by(len) __lifetimebound);
 
-// expected-experimental-expansion@+13:84{{
+// expected-experimental-expansion@+18:84{{
 //   expected-experimental-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy p) @_lifetime(p: copy p) @_disfavoredOverload public func complexExpr(_ len: Int32, _ offset: Int32, _ p: inout MutableSpan<Int32>) -> MutableSpan<Int32> {|}}
 //   expected-experimental-remark@3{{macro content: |    let len2 = Int32(exactly: p.count)!|}}
@@ -60,12 +70,17 @@ int * __counted_by(len) shared(int len, int * p __counted_by(len) __lifetimeboun
 //   expected-experimental-remark@7{{macro content: |    defer {|}}
 //   expected-experimental-remark@8{{macro content: |        _fixLifetime(p)|}}
 //   expected-experimental-remark@9{{macro content: |    }|}}
-//   expected-experimental-remark@10{{macro content: |    return unsafe _swiftifyOverrideLifetime(MutableSpan<Int32>(_unsafeStart: unsafe complexExpr(len, offset, len2, _pPtr.baseAddress!), count: Int(len - offset)), copying: ())|}}
-//   expected-experimental-remark@11{{macro content: |}|}}
+//   expected-experimental-remark@10{{macro content: |    let _resultValue: UnsafeMutablePointer<Int32>? = unsafe complexExpr(len, offset, len2, _pPtr.baseAddress)|}}
+//   expected-experimental-remark@11{{macro content: |    if unsafe _resultValue == nil {|}}
+//   expected-experimental-remark@12{{macro content: |      precondition(len - offset == 0, "counted_by may only be null if count is 0 (unlike counted_by_or_null)")|}}
+//   expected-experimental-remark@13{{macro content: |      return MutableSpan<Int32>()|}}
+//   expected-experimental-remark@14{{macro content: |    }|}}
+//   expected-experimental-remark@15{{macro content: |    return unsafe _swiftifyOverrideLifetime(MutableSpan<Int32>(_unsafeStart: _resultValue!, count: Int(len - offset)), copying: ())|}}
+//   expected-experimental-remark@16{{macro content: |}|}}
 // }}
 int * __counted_by(len - offset) complexExpr(int len, int offset, int len2, int * p __counted_by(len2) __lifetimebound);
 
-// expected-experimental-expansion@+13:103{{
+// expected-experimental-expansion@+18:103{{
 //   expected-experimental-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy p) @_lifetime(p: copy p) @_disfavoredOverload public func nullUnspecified(_ len: Int32, _ p: inout MutableSpan<Int32>) -> MutableSpan<Int32> {|}}
 //   expected-experimental-remark@3{{macro content: |    let len2 = Int32(exactly: p.count)!|}}
@@ -75,8 +90,13 @@ int * __counted_by(len - offset) complexExpr(int len, int offset, int len2, int 
 //   expected-experimental-remark@7{{macro content: |    defer {|}}
 //   expected-experimental-remark@8{{macro content: |        _fixLifetime(p)|}}
 //   expected-experimental-remark@9{{macro content: |    }|}}
-//   expected-experimental-remark@10{{macro content: |    return unsafe _swiftifyOverrideLifetime(MutableSpan<Int32>(_unsafeStart: unsafe nullUnspecified(len, len2, _pPtr.baseAddress!), count: Int(len)), copying: ())|}}
-//   expected-experimental-remark@11{{macro content: |}|}}
+//   expected-experimental-remark@10{{macro content: |    let _resultValue: UnsafeMutablePointer<Int32>? = unsafe nullUnspecified(len, len2, _pPtr.baseAddress)|}}
+//   expected-experimental-remark@11{{macro content: |    if unsafe _resultValue == nil {|}}
+//   expected-experimental-remark@12{{macro content: |      precondition(len == 0, "counted_by may only be null if count is 0 (unlike counted_by_or_null)")|}}
+//   expected-experimental-remark@13{{macro content: |      return MutableSpan<Int32>()|}}
+//   expected-experimental-remark@14{{macro content: |    }|}}
+//   expected-experimental-remark@15{{macro content: |    return unsafe _swiftifyOverrideLifetime(MutableSpan<Int32>(_unsafeStart: _resultValue!, count: Int(len)), copying: ())|}}
+//   expected-experimental-remark@16{{macro content: |}|}}
 // }}
 int * __counted_by(len) _Null_unspecified nullUnspecified(int len, int len2, int * _Null_unspecified p __counted_by(len2) __lifetimebound);
 
@@ -118,11 +138,16 @@ int * __counted_by(len) _Nullable nullable(int len, int len2, int * _Nullable p 
 typedef struct foo opaque_t;
 opaque_t * __counted_by(len) opaque(int len, int len2, opaque_t * p __counted_by(len2) __lifetimebound);
 
-// expected-experimental-expansion@+6:60{{
+// expected-experimental-expansion@+11:60{{
 //   expected-experimental-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(borrow p) @_disfavoredOverload public func noncountedLifetime(_ len: Int32, _ p: UnsafeMutablePointer<Int32>!) -> MutableSpan<Int32> {|}}
-//   expected-experimental-remark@3{{macro content: |    return unsafe _swiftifyOverrideLifetime(MutableSpan<Int32>(_unsafeStart: unsafe noncountedLifetime(len, p), count: Int(len)), copying: ())|}}
-//   expected-experimental-remark@4{{macro content: |}|}}
+//   expected-experimental-remark@3{{macro content: |    let _resultValue: UnsafeMutablePointer<Int32>? = unsafe noncountedLifetime(len, p)|}}
+//   expected-experimental-remark@4{{macro content: |    if unsafe _resultValue == nil {|}}
+//   expected-experimental-remark@5{{macro content: |      precondition(len == 0, "counted_by may only be null if count is 0 (unlike counted_by_or_null)")|}}
+//   expected-experimental-remark@6{{macro content: |      return MutableSpan<Int32>()|}}
+//   expected-experimental-remark@7{{macro content: |    }|}}
+//   expected-experimental-remark@8{{macro content: |    return unsafe _swiftifyOverrideLifetime(MutableSpan<Int32>(_unsafeStart: _resultValue!, count: Int(len)), copying: ())|}}
+//   expected-experimental-remark@9{{macro content: |}|}}
 // }}
 int * __counted_by(len) noncountedLifetime(int len, int * p __lifetimebound);
 
@@ -154,7 +179,7 @@ struct EscapableStruct {};
 //   expected-experimental-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func lifetimeboundEscapableReturn(_ p: UnsafeMutableBufferPointer<Int32>) -> EscapableStruct {|}}
 //   expected-experimental-remark@3{{macro content: |    let len = Int32(exactly: p.count)!|}}
-//   expected-experimental-remark@4{{macro content: |    return unsafe lifetimeboundEscapableReturn(len, p.baseAddress!)|}}
+//   expected-experimental-remark@4{{macro content: |    return unsafe lifetimeboundEscapableReturn(len, p.baseAddress)|}}
 //   expected-experimental-remark@5{{macro content: |}|}}
 // }}
 struct EscapableStruct lifetimeboundEscapableReturn(int len, int * __counted_by(len) p __lifetimebound);
@@ -170,7 +195,7 @@ struct __attribute__((swift_attr("~Escapable"))) NonescapableStruct {};
 //   expected-experimental-remark@7{{macro content: |    defer {|}}
 //   expected-experimental-remark@8{{macro content: |        _fixLifetime(p)|}}
 //   expected-experimental-remark@9{{macro content: |    }|}}
-//   expected-experimental-remark@10{{macro content: |    return unsafe _swiftifyOverrideLifetime(unsafe lifetimeboundNonescapableReturn(len, _pPtr.baseAddress!), copying: ())|}}
+//   expected-experimental-remark@10{{macro content: |    return unsafe _swiftifyOverrideLifetime(unsafe lifetimeboundNonescapableReturn(len, _pPtr.baseAddress), copying: ())|}}
 //   expected-experimental-remark@11{{macro content: |}|}}
 // }}
 struct NonescapableStruct lifetimeboundNonescapableReturn(int len, int * __counted_by(len) p __lifetimebound);
@@ -185,12 +210,12 @@ struct NonescapableStruct lifetimeboundNonescapableReturn(int len, int * __count
 //   expected-experimental-remark@7{{macro content: |    defer {|}}
 //   expected-experimental-remark@8{{macro content: |        _fixLifetime(p)|}}
 //   expected-experimental-remark@9{{macro content: |    }|}}
-//   expected-experimental-remark@10{{macro content: |    return unsafe _swiftifyOverrideLifetime(unsafe lifetimeboundNonescapableReturnDoubleBounds(len, _pPtr.baseAddress!, s), copying: ())|}}
+//   expected-experimental-remark@10{{macro content: |    return unsafe _swiftifyOverrideLifetime(unsafe lifetimeboundNonescapableReturnDoubleBounds(len, _pPtr.baseAddress, s), copying: ())|}}
 //   expected-experimental-remark@11{{macro content: |}|}}
 // }}
 struct NonescapableStruct lifetimeboundNonescapableReturnDoubleBounds(int len, int * __counted_by(len) p __lifetimebound, struct NonescapableStruct s __lifetimebound);
 
-// expected-experimental-expansion@+14:135{{
+// expected-experimental-expansion@+19:135{{
 //   expected-experimental-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy p) @_lifetime(p: copy p) @_disfavoredOverload public func oneLifetimeboundOneEscapable(_ len: Int32, _ p: inout MutableSpan<Int32>, _ p2: UnsafeMutableBufferPointer<Int32>) -> MutableSpan<Int32> {|}}
 //   expected-experimental-remark@3{{macro content: |    let len2 = Int32(exactly: p.count)!|}}
@@ -201,8 +226,13 @@ struct NonescapableStruct lifetimeboundNonescapableReturnDoubleBounds(int len, i
 //   expected-experimental-remark@8{{macro content: |    defer {|}}
 //   expected-experimental-remark@9{{macro content: |        _fixLifetime(p)|}}
 //   expected-experimental-remark@10{{macro content: |    }|}}
-//   expected-experimental-remark@11{{macro content: |    return unsafe _swiftifyOverrideLifetime(MutableSpan<Int32>(_unsafeStart: unsafe oneLifetimeboundOneEscapable(len, len2, _pPtr.baseAddress!, len3, p2.baseAddress!), count: Int(len)), copying: ())|}}
-//   expected-experimental-remark@12{{macro content: |}|}}
+//   expected-experimental-remark@11{{macro content: |    let _resultValue: UnsafeMutablePointer<Int32>? = unsafe oneLifetimeboundOneEscapable(len, len2, _pPtr.baseAddress, len3, p2.baseAddress)|}}
+//   expected-experimental-remark@12{{macro content: |    if unsafe _resultValue == nil {|}}
+//   expected-experimental-remark@13{{macro content: |      precondition(len == 0, "counted_by may only be null if count is 0 (unlike counted_by_or_null)")|}}
+//   expected-experimental-remark@14{{macro content: |      return MutableSpan<Int32>()|}}
+//   expected-experimental-remark@15{{macro content: |    }|}}
+//   expected-experimental-remark@16{{macro content: |    return unsafe _swiftifyOverrideLifetime(MutableSpan<Int32>(_unsafeStart: _resultValue!, count: Int(len)), copying: ())|}}
+//   expected-experimental-remark@17{{macro content: |}|}}
 // }}
 int * __counted_by(len) oneLifetimeboundOneEscapable(int len, int len2, int * p __counted_by(len2) __lifetimebound, int len3, int * p2 __counted_by(len3));
 

--- a/test/Interop/C/swiftify-import/counted-by-noescape.swift
+++ b/test/Interop/C/swiftify-import/counted-by-noescape.swift
@@ -24,7 +24,7 @@
 //   expected-remark@7{{macro content: |    defer {|}}
 //   expected-remark@8{{macro content: |        _fixLifetime(p)|}}
 //   expected-remark@9{{macro content: |    }|}}
-//   expected-remark@10{{macro content: |    return unsafe simple(len, _pPtr.baseAddress!)|}}
+//   expected-remark@10{{macro content: |    return unsafe simple(len, _pPtr.baseAddress)|}}
 //   expected-remark@11{{macro content: |}|}}
 // }}
 void simple(int len, int * __counted_by(len) __noescape p);
@@ -39,7 +39,7 @@ void simple(int len, int * __counted_by(len) __noescape p);
 //   expected-remark@7{{macro content: |    defer {|}}
 //   expected-remark@8{{macro content: |        _fixLifetime(p)|}}
 //   expected-remark@9{{macro content: |    }|}}
-//   expected-remark@10{{macro content: |    return unsafe swiftAttr(len, _pPtr.baseAddress!)|}}
+//   expected-remark@10{{macro content: |    return unsafe swiftAttr(len, _pPtr.baseAddress)|}}
 //   expected-remark@11{{macro content: |}|}}
 // }}
 void swiftAttr(int len, int *p) __attribute__((
@@ -64,7 +64,7 @@ void swiftAttr(int len, int *p) __attribute__((
 //   expected-remark@16{{macro content: |    defer {|}}
 //   expected-remark@17{{macro content: |        _fixLifetime(p2)|}}
 //   expected-remark@18{{macro content: |    }|}}
-//   expected-remark@19{{macro content: |    return unsafe shared(len, _p1Ptr.baseAddress!, _p2Ptr.baseAddress!)|}}
+//   expected-remark@19{{macro content: |    return unsafe shared(len, _p1Ptr.baseAddress, _p2Ptr.baseAddress)|}}
 //   expected-remark@20{{macro content: |}|}}
 // }}
 void shared(int len, int * __counted_by(len) __noescape p1, int * __counted_by(len) __noescape p2);
@@ -81,7 +81,7 @@ void shared(int len, int * __counted_by(len) __noescape p1, int * __counted_by(l
 //   expected-remark@9{{macro content: |    defer {|}}
 //   expected-remark@10{{macro content: |        _fixLifetime(p)|}}
 //   expected-remark@11{{macro content: |    }|}}
-//   expected-remark@12{{macro content: |    return unsafe complexExpr(len, offset, _pPtr.baseAddress!)|}}
+//   expected-remark@12{{macro content: |    return unsafe complexExpr(len, offset, _pPtr.baseAddress)|}}
 //   expected-remark@13{{macro content: |}|}}
 // }}
 void complexExpr(int len, int offset, int * __counted_by(len - offset) __noescape p);
@@ -96,7 +96,7 @@ void complexExpr(int len, int offset, int * __counted_by(len - offset) __noescap
 //   expected-remark@7{{macro content: |    defer {|}}
 //   expected-remark@8{{macro content: |        _fixLifetime(p)|}}
 //   expected-remark@9{{macro content: |    }|}}
-//   expected-remark@10{{macro content: |    return unsafe nullUnspecified(len, _pPtr.baseAddress!)|}}
+//   expected-remark@10{{macro content: |    return unsafe nullUnspecified(len, _pPtr.baseAddress)|}}
 //   expected-remark@11{{macro content: |}|}}
 // }}
 void nullUnspecified(int len, int * __counted_by(len) _Null_unspecified __noescape p);
@@ -351,7 +351,7 @@ typedef struct actor_ *actor;
 //   expected-warning@8{{expression uses unsafe constructs but is not marked with 'unsafe'}}
 //   expected-remark@8{{macro content: |        _fixLifetime(p)|}}
 //   expected-remark@9{{macro content: |    }|}}
-//   expected-remark@10{{macro content: |    return unsafe keywordType(len, _pPtr.baseAddress!, p2)|}}
+//   expected-remark@10{{macro content: |    return unsafe keywordType(len, _pPtr.baseAddress, p2)|}}
 //   expected-remark@11{{macro content: |}|}}
 // }}
 actor _Nonnull keywordType(int len, actor * __counted_by(len) __noescape p, actor _Nonnull p2);

--- a/test/Interop/C/swiftify-import/counted-by-or-null-lifetimebound.swift
+++ b/test/Interop/C/swiftify-import/counted-by-or-null-lifetimebound.swift
@@ -19,7 +19,7 @@
 #define __counted_by_or_null(x) __attribute__((__counted_by_or_null__(x)))
 #define __lifetimebound __attribute__((lifetimebound))
 
-// expected-experimental-expansion@+13:66{{
+// expected-experimental-expansion@+18:66{{
 //   expected-experimental-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy p) @_lifetime(p: copy p) @_disfavoredOverload public func simple(_ len: Int32, _ p: inout MutableSpan<Int32>) -> MutableSpan<Int32> {|}}
 //   expected-experimental-remark@3{{macro content: |    let len2 = Int32(exactly: p.count)!|}}
@@ -29,12 +29,17 @@
 //   expected-experimental-remark@7{{macro content: |    defer {|}}
 //   expected-experimental-remark@8{{macro content: |        _fixLifetime(p)|}}
 //   expected-experimental-remark@9{{macro content: |    }|}}
-//   expected-experimental-remark@10{{macro content: |    return unsafe _swiftifyOverrideLifetime(MutableSpan<Int32>(_unsafeStart: unsafe simple(len, len2, _pPtr.baseAddress!), count: Int(len)), copying: ())|}}
-//   expected-experimental-remark@11{{macro content: |}|}}
+//   expected-experimental-remark@10{{macro content: |    let _resultValue: UnsafeMutablePointer<Int32>? = unsafe simple(len, len2, _pPtr.baseAddress)|}}
+//   expected-experimental-remark@11{{macro content: |    if unsafe _resultValue == nil {|}}
+//   expected-experimental-remark@12{{macro content: |      precondition(len == 0, "counted_by may only be null if count is 0 (unlike counted_by_or_null)")|}}
+//   expected-experimental-remark@13{{macro content: |      return MutableSpan<Int32>()|}}
+//   expected-experimental-remark@14{{macro content: |    }|}}
+//   expected-experimental-remark@15{{macro content: |    return unsafe _swiftifyOverrideLifetime(MutableSpan<Int32>(_unsafeStart: _resultValue!, count: Int(len)), copying: ())|}}
+//   expected-experimental-remark@16{{macro content: |}|}}
 // }}
 int * __counted_by_or_null(len) simple(int len, int len2, int * p __counted_by_or_null(len2) __lifetimebound);
 
-// expected-experimental-expansion@+13:56{{
+// expected-experimental-expansion@+18:56{{
 //   expected-experimental-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy p) @_lifetime(p: copy p) @_disfavoredOverload public func shared(_ p: inout MutableSpan<Int32>) -> MutableSpan<Int32> {|}}
 //   expected-experimental-remark@3{{macro content: |    let len = Int32(exactly: p.count)!|}}
@@ -44,12 +49,17 @@ int * __counted_by_or_null(len) simple(int len, int len2, int * p __counted_by_o
 //   expected-experimental-remark@7{{macro content: |    defer {|}}
 //   expected-experimental-remark@8{{macro content: |        _fixLifetime(p)|}}
 //   expected-experimental-remark@9{{macro content: |    }|}}
-//   expected-experimental-remark@10{{macro content: |    return unsafe _swiftifyOverrideLifetime(MutableSpan<Int32>(_unsafeStart: unsafe shared(len, _pPtr.baseAddress!), count: Int(len)), copying: ())|}}
-//   expected-experimental-remark@11{{macro content: |}|}}
+//   expected-experimental-remark@10{{macro content: |    let _resultValue: UnsafeMutablePointer<Int32>? = unsafe shared(len, _pPtr.baseAddress)|}}
+//   expected-experimental-remark@11{{macro content: |    if unsafe _resultValue == nil {|}}
+//   expected-experimental-remark@12{{macro content: |      precondition(len == 0, "counted_by may only be null if count is 0 (unlike counted_by_or_null)")|}}
+//   expected-experimental-remark@13{{macro content: |      return MutableSpan<Int32>()|}}
+//   expected-experimental-remark@14{{macro content: |    }|}}
+//   expected-experimental-remark@15{{macro content: |    return unsafe _swiftifyOverrideLifetime(MutableSpan<Int32>(_unsafeStart: _resultValue!, count: Int(len)), copying: ())|}}
+//   expected-experimental-remark@16{{macro content: |}|}}
 // }}
 int * __counted_by_or_null(len) shared(int len, int * p __counted_by_or_null(len) __lifetimebound);
 
-// expected-experimental-expansion@+13:92{{
+// expected-experimental-expansion@+18:92{{
 //   expected-experimental-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy p) @_lifetime(p: copy p) @_disfavoredOverload public func complexExpr(_ len: Int32, _ offset: Int32, _ p: inout MutableSpan<Int32>) -> MutableSpan<Int32> {|}}
 //   expected-experimental-remark@3{{macro content: |    let len2 = Int32(exactly: p.count)!|}}
@@ -59,12 +69,17 @@ int * __counted_by_or_null(len) shared(int len, int * p __counted_by_or_null(len
 //   expected-experimental-remark@7{{macro content: |    defer {|}}
 //   expected-experimental-remark@8{{macro content: |        _fixLifetime(p)|}}
 //   expected-experimental-remark@9{{macro content: |    }|}}
-//   expected-experimental-remark@10{{macro content: |    return unsafe _swiftifyOverrideLifetime(MutableSpan<Int32>(_unsafeStart: unsafe complexExpr(len, offset, len2, _pPtr.baseAddress!), count: Int(len - offset)), copying: ())|}}
-//   expected-experimental-remark@11{{macro content: |}|}}
+//   expected-experimental-remark@10{{macro content: |    let _resultValue: UnsafeMutablePointer<Int32>? = unsafe complexExpr(len, offset, len2, _pPtr.baseAddress)|}}
+//   expected-experimental-remark@11{{macro content: |    if unsafe _resultValue == nil {|}}
+//   expected-experimental-remark@12{{macro content: |      precondition(len - offset == 0, "counted_by may only be null if count is 0 (unlike counted_by_or_null)")|}}
+//   expected-experimental-remark@13{{macro content: |      return MutableSpan<Int32>()|}}
+//   expected-experimental-remark@14{{macro content: |    }|}}
+//   expected-experimental-remark@15{{macro content: |    return unsafe _swiftifyOverrideLifetime(MutableSpan<Int32>(_unsafeStart: _resultValue!, count: Int(len - offset)), copying: ())|}}
+//   expected-experimental-remark@16{{macro content: |}|}}
 // }}
 int * __counted_by_or_null(len - offset) complexExpr(int len, int offset, int len2, int * p __counted_by_or_null(len2) __lifetimebound);
 
-// expected-experimental-expansion@+13:111{{
+// expected-experimental-expansion@+18:111{{
 //   expected-experimental-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy p) @_lifetime(p: copy p) @_disfavoredOverload public func nullUnspecified(_ len: Int32, _ p: inout MutableSpan<Int32>) -> MutableSpan<Int32> {|}}
 //   expected-experimental-remark@3{{macro content: |    let len2 = Int32(exactly: p.count)!|}}
@@ -74,8 +89,13 @@ int * __counted_by_or_null(len - offset) complexExpr(int len, int offset, int le
 //   expected-experimental-remark@7{{macro content: |    defer {|}}
 //   expected-experimental-remark@8{{macro content: |        _fixLifetime(p)|}}
 //   expected-experimental-remark@9{{macro content: |    }|}}
-//   expected-experimental-remark@10{{macro content: |    return unsafe _swiftifyOverrideLifetime(MutableSpan<Int32>(_unsafeStart: unsafe nullUnspecified(len, len2, _pPtr.baseAddress!), count: Int(len)), copying: ())|}}
-//   expected-experimental-remark@11{{macro content: |}|}}
+//   expected-experimental-remark@10{{macro content: |    let _resultValue: UnsafeMutablePointer<Int32>? = unsafe nullUnspecified(len, len2, _pPtr.baseAddress)|}}
+//   expected-experimental-remark@11{{macro content: |    if unsafe _resultValue == nil {|}}
+//   expected-experimental-remark@12{{macro content: |      precondition(len == 0, "counted_by may only be null if count is 0 (unlike counted_by_or_null)")|}}
+//   expected-experimental-remark@13{{macro content: |      return MutableSpan<Int32>()|}}
+//   expected-experimental-remark@14{{macro content: |    }|}}
+//   expected-experimental-remark@15{{macro content: |    return unsafe _swiftifyOverrideLifetime(MutableSpan<Int32>(_unsafeStart: _resultValue!, count: Int(len)), copying: ())|}}
+//   expected-experimental-remark@16{{macro content: |}|}}
 // }}
 int * __counted_by_or_null(len) _Null_unspecified nullUnspecified(int len, int len2, int * _Null_unspecified p __counted_by_or_null(len2) __lifetimebound);
 
@@ -117,11 +137,16 @@ int * __counted_by_or_null(len) _Nullable nullable(int len, int len2, int * _Nul
 typedef struct foo opaque_t;
 opaque_t * __counted_by_or_null(len) opaque(int len, int len2, opaque_t * p __counted_by_or_null(len2) __lifetimebound);
 
-// expected-experimental-expansion@+6:68{{
+// expected-experimental-expansion@+11:68{{
 //   expected-experimental-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(borrow p) @_disfavoredOverload public func noncountedLifetime(_ len: Int32, _ p: UnsafeMutablePointer<Int32>!) -> MutableSpan<Int32> {|}}
-//   expected-experimental-remark@3{{macro content: |    return unsafe _swiftifyOverrideLifetime(MutableSpan<Int32>(_unsafeStart: unsafe noncountedLifetime(len, p), count: Int(len)), copying: ())|}}
-//   expected-experimental-remark@4{{macro content: |}|}}
+//   expected-experimental-remark@3{{macro content: |    let _resultValue: UnsafeMutablePointer<Int32>? = unsafe noncountedLifetime(len, p)|}}
+//   expected-experimental-remark@4{{macro content: |    if unsafe _resultValue == nil {|}}
+//   expected-experimental-remark@5{{macro content: |      precondition(len == 0, "counted_by may only be null if count is 0 (unlike counted_by_or_null)")|}}
+//   expected-experimental-remark@6{{macro content: |      return MutableSpan<Int32>()|}}
+//   expected-experimental-remark@7{{macro content: |    }|}}
+//   expected-experimental-remark@8{{macro content: |    return unsafe _swiftifyOverrideLifetime(MutableSpan<Int32>(_unsafeStart: _resultValue!, count: Int(len)), copying: ())|}}
+//   expected-experimental-remark@9{{macro content: |}|}}
 // }}
 int * __counted_by_or_null(len) noncountedLifetime(int len, int * p __lifetimebound);
 
@@ -152,7 +177,7 @@ struct EscapableStruct {};
 //   expected-experimental-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func lifetimeboundEscapableReturn(_ p: UnsafeMutableBufferPointer<Int32>) -> EscapableStruct {|}}
 //   expected-experimental-remark@3{{macro content: |    let len = Int32(exactly: p.count)!|}}
-//   expected-experimental-remark@4{{macro content: |    return unsafe lifetimeboundEscapableReturn(len, p.baseAddress!)|}}
+//   expected-experimental-remark@4{{macro content: |    return unsafe lifetimeboundEscapableReturn(len, p.baseAddress)|}}
 //   expected-experimental-remark@5{{macro content: |}|}}
 // }}
 struct EscapableStruct lifetimeboundEscapableReturn(int len, int * __counted_by_or_null(len) p __lifetimebound);
@@ -168,7 +193,7 @@ struct __attribute__((swift_attr("~Escapable"))) NonescapableStruct {};
 //   expected-experimental-remark@7{{macro content: |    defer {|}}
 //   expected-experimental-remark@8{{macro content: |        _fixLifetime(p)|}}
 //   expected-experimental-remark@9{{macro content: |    }|}}
-//   expected-experimental-remark@10{{macro content: |    return unsafe _swiftifyOverrideLifetime(unsafe lifetimeboundNonescapableReturn(len, _pPtr.baseAddress!), copying: ())|}}
+//   expected-experimental-remark@10{{macro content: |    return unsafe _swiftifyOverrideLifetime(unsafe lifetimeboundNonescapableReturn(len, _pPtr.baseAddress), copying: ())|}}
 //   expected-experimental-remark@11{{macro content: |}|}}
 // }}
 struct NonescapableStruct lifetimeboundNonescapableReturn(int len, int * __counted_by_or_null(len) p __lifetimebound);
@@ -183,12 +208,12 @@ struct NonescapableStruct lifetimeboundNonescapableReturn(int len, int * __count
 //   expected-experimental-remark@7{{macro content: |    defer {|}}
 //   expected-experimental-remark@8{{macro content: |        _fixLifetime(p)|}}
 //   expected-experimental-remark@9{{macro content: |    }|}}
-//   expected-experimental-remark@10{{macro content: |    return unsafe _swiftifyOverrideLifetime(unsafe lifetimeboundNonescapableReturnDoubleBounds(len, _pPtr.baseAddress!, s), copying: ())|}}
+//   expected-experimental-remark@10{{macro content: |    return unsafe _swiftifyOverrideLifetime(unsafe lifetimeboundNonescapableReturnDoubleBounds(len, _pPtr.baseAddress, s), copying: ())|}}
 //   expected-experimental-remark@11{{macro content: |}|}}
 // }}
 struct NonescapableStruct lifetimeboundNonescapableReturnDoubleBounds(int len, int * __counted_by_or_null(len) p __lifetimebound, struct NonescapableStruct s __lifetimebound);
 
-// expected-experimental-expansion@+14:151{{
+// expected-experimental-expansion@+19:151{{
 //   expected-experimental-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy p) @_lifetime(p: copy p) @_disfavoredOverload public func oneLifetimeboundOneEscapable(_ len: Int32, _ p: inout MutableSpan<Int32>, _ p2: UnsafeMutableBufferPointer<Int32>) -> MutableSpan<Int32> {|}}
 //   expected-experimental-remark@3{{macro content: |    let len2 = Int32(exactly: p.count)!|}}
@@ -199,8 +224,13 @@ struct NonescapableStruct lifetimeboundNonescapableReturnDoubleBounds(int len, i
 //   expected-experimental-remark@8{{macro content: |    defer {|}}
 //   expected-experimental-remark@9{{macro content: |        _fixLifetime(p)|}}
 //   expected-experimental-remark@10{{macro content: |    }|}}
-//   expected-experimental-remark@11{{macro content: |    return unsafe _swiftifyOverrideLifetime(MutableSpan<Int32>(_unsafeStart: unsafe oneLifetimeboundOneEscapable(len, len2, _pPtr.baseAddress!, len3, p2.baseAddress!), count: Int(len)), copying: ())|}}
-//   expected-experimental-remark@12{{macro content: |}|}}
+//   expected-experimental-remark@11{{macro content: |    let _resultValue: UnsafeMutablePointer<Int32>? = unsafe oneLifetimeboundOneEscapable(len, len2, _pPtr.baseAddress, len3, p2.baseAddress)|}}
+//   expected-experimental-remark@12{{macro content: |    if unsafe _resultValue == nil {|}}
+//   expected-experimental-remark@13{{macro content: |      precondition(len == 0, "counted_by may only be null if count is 0 (unlike counted_by_or_null)")|}}
+//   expected-experimental-remark@14{{macro content: |      return MutableSpan<Int32>()|}}
+//   expected-experimental-remark@15{{macro content: |    }|}}
+//   expected-experimental-remark@16{{macro content: |    return unsafe _swiftifyOverrideLifetime(MutableSpan<Int32>(_unsafeStart: _resultValue!, count: Int(len)), copying: ())|}}
+//   expected-experimental-remark@17{{macro content: |}|}}
 // }}
 int * __counted_by_or_null(len) oneLifetimeboundOneEscapable(int len, int len2, int * p __counted_by_or_null(len2) __lifetimebound, int len3, int * p2 __counted_by_or_null(len3));
 

--- a/test/Interop/C/swiftify-import/counted-by-or-null-noescape.swift
+++ b/test/Interop/C/swiftify-import/counted-by-or-null-noescape.swift
@@ -24,7 +24,7 @@
 //   expected-remark@7{{macro content: |    defer {|}}
 //   expected-remark@8{{macro content: |        _fixLifetime(p)|}}
 //   expected-remark@9{{macro content: |    }|}}
-//   expected-remark@10{{macro content: |    return unsafe simple(len, _pPtr.baseAddress!)|}}
+//   expected-remark@10{{macro content: |    return unsafe simple(len, _pPtr.baseAddress)|}}
 //   expected-remark@11{{macro content: |}|}}
 // }}
 void simple(int len, int * __counted_by_or_null(len) __noescape p);
@@ -39,7 +39,7 @@ void simple(int len, int * __counted_by_or_null(len) __noescape p);
 //   expected-remark@7{{macro content: |    defer {|}}
 //   expected-remark@8{{macro content: |        _fixLifetime(p)|}}
 //   expected-remark@9{{macro content: |    }|}}
-//   expected-remark@10{{macro content: |    return unsafe swiftAttr(len, _pPtr.baseAddress!)|}}
+//   expected-remark@10{{macro content: |    return unsafe swiftAttr(len, _pPtr.baseAddress)|}}
 //   expected-remark@11{{macro content: |}|}}
 // }}
 void swiftAttr(int len, int *p) __attribute__((
@@ -64,7 +64,7 @@ void swiftAttr(int len, int *p) __attribute__((
 //   expected-remark@16{{macro content: |    defer {|}}
 //   expected-remark@17{{macro content: |        _fixLifetime(p2)|}}
 //   expected-remark@18{{macro content: |    }|}}
-//   expected-remark@19{{macro content: |    return unsafe shared(len, _p1Ptr.baseAddress!, _p2Ptr.baseAddress!)|}}
+//   expected-remark@19{{macro content: |    return unsafe shared(len, _p1Ptr.baseAddress, _p2Ptr.baseAddress)|}}
 //   expected-remark@20{{macro content: |}|}}
 // }}
 void shared(int len, int * __counted_by_or_null(len) __noescape p1, int * __counted_by_or_null(len) __noescape p2);
@@ -81,7 +81,7 @@ void shared(int len, int * __counted_by_or_null(len) __noescape p1, int * __coun
 //   expected-remark@9{{macro content: |    defer {|}}
 //   expected-remark@10{{macro content: |        _fixLifetime(p)|}}
 //   expected-remark@11{{macro content: |    }|}}
-//   expected-remark@12{{macro content: |    return unsafe complexExpr(len, offset, _pPtr.baseAddress!)|}}
+//   expected-remark@12{{macro content: |    return unsafe complexExpr(len, offset, _pPtr.baseAddress)|}}
 //   expected-remark@13{{macro content: |}|}}
 // }}
 void complexExpr(int len, int offset, int * __counted_by_or_null(len - offset) __noescape p);
@@ -96,7 +96,7 @@ void complexExpr(int len, int offset, int * __counted_by_or_null(len - offset) _
 //   expected-remark@7{{macro content: |    defer {|}}
 //   expected-remark@8{{macro content: |        _fixLifetime(p)|}}
 //   expected-remark@9{{macro content: |    }|}}
-//   expected-remark@10{{macro content: |    return unsafe nullUnspecified(len, _pPtr.baseAddress!)|}}
+//   expected-remark@10{{macro content: |    return unsafe nullUnspecified(len, _pPtr.baseAddress)|}}
 //   expected-remark@11{{macro content: |}|}}
 // }}
 void nullUnspecified(int len, int * __counted_by_or_null(len) _Null_unspecified __noescape p);
@@ -352,7 +352,7 @@ typedef struct actor_ *actor;
 //   expected-warning@8{{expression uses unsafe constructs but is not marked with 'unsafe'}}
 //   expected-remark@8{{macro content: |        _fixLifetime(p)|}}
 //   expected-remark@9{{macro content: |    }|}}
-//   expected-remark@10{{macro content: |    return unsafe keywordType(len, _pPtr.baseAddress!, p2)|}}
+//   expected-remark@10{{macro content: |    return unsafe keywordType(len, _pPtr.baseAddress, p2)|}}
 //   expected-remark@11{{macro content: |}|}}
 // }}
 actor _Nonnull keywordType(int len, actor * __counted_by_or_null(len) __noescape p, actor _Nonnull p2);

--- a/test/Interop/C/swiftify-import/counted-by-or-null.swift
+++ b/test/Interop/C/swiftify-import/counted-by-or-null.swift
@@ -14,7 +14,7 @@
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func simple(_ p: UnsafeMutableBufferPointer<Int32>) {|}}
 //   expected-remark@3{{macro content: |    let len = Int32(exactly: p.count)!|}}
-//   expected-remark@4{{macro content: |    return unsafe simple(len, p.baseAddress!)|}}
+//   expected-remark@4{{macro content: |    return unsafe simple(len, p.baseAddress)|}}
 //   expected-remark@5{{macro content: |}|}}
 // }}
 void simple(int len, int * __counted_by_or_null(len) p);
@@ -23,7 +23,7 @@ void simple(int len, int * __counted_by_or_null(len) p);
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func simpleFlipped(_ p: UnsafeMutableBufferPointer<Int32>) {|}}
 //   expected-remark@3{{macro content: |    let len = Int32(exactly: p.count)!|}}
-//   expected-remark@4{{macro content: |    return unsafe simpleFlipped(p.baseAddress!, len)|}}
+//   expected-remark@4{{macro content: |    return unsafe simpleFlipped(p.baseAddress, len)|}}
 //   expected-remark@5{{macro content: |}|}}
 // }}
 void simpleFlipped(int * __counted_by_or_null(len) p, int len);
@@ -32,7 +32,7 @@ void simpleFlipped(int * __counted_by_or_null(len) p, int len);
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func swiftAttr(_ p: UnsafeMutableBufferPointer<Int32>) {|}}
 //   expected-remark@3{{macro content: |    let len = Int32(exactly: p.count)!|}}
-//   expected-remark@4{{macro content: |    return unsafe swiftAttr(len, p.baseAddress!)|}}
+//   expected-remark@4{{macro content: |    return unsafe swiftAttr(len, p.baseAddress)|}}
 //   expected-remark@5{{macro content: |}|}}
 // }}
 void swiftAttr(int len, int *p) __attribute__((
@@ -45,7 +45,7 @@ void swiftAttr(int len, int *p) __attribute__((
 //   expected-remark@4{{macro content: |    if p1.count != len {|}}
 //   expected-remark@5{{macro content: |      fatalError("bounds check failure in shared: expected \\(len) but got \\(p1.count)")|}}
 //   expected-remark@6{{macro content: |    }|}}
-//   expected-remark@7{{macro content: |    return unsafe shared(len, p1.baseAddress!, p2.baseAddress!)|}}
+//   expected-remark@7{{macro content: |    return unsafe shared(len, p1.baseAddress, p2.baseAddress)|}}
 //   expected-remark@8{{macro content: |}|}}
 // }}
 void shared(int len, int * __counted_by_or_null(len) p1, int * __counted_by_or_null(len) p2);
@@ -56,7 +56,7 @@ void shared(int len, int * __counted_by_or_null(len) p1, int * __counted_by_or_n
 //   expected-remark@3{{macro content: |    if p.count != len - offset {|}}
 //   expected-remark@4{{macro content: |      fatalError("bounds check failure in complexExpr: expected \\(len - offset) but got \\(p.count)")|}}
 //   expected-remark@5{{macro content: |    }|}}
-//   expected-remark@6{{macro content: |    return unsafe complexExpr(len, offset, p.baseAddress!)|}}
+//   expected-remark@6{{macro content: |    return unsafe complexExpr(len, offset, p.baseAddress)|}}
 //   expected-remark@7{{macro content: |}|}}
 // }}
 void complexExpr(int len, int offset, int * __counted_by_or_null(len - offset) p);
@@ -65,7 +65,7 @@ void complexExpr(int len, int offset, int * __counted_by_or_null(len - offset) p
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func nullUnspecified(_ p: UnsafeMutableBufferPointer<Int32>) {|}}
 //   expected-remark@3{{macro content: |    let len = Int32(exactly: p.count)!|}}
-//   expected-remark@4{{macro content: |    return unsafe nullUnspecified(len, p.baseAddress!)|}}
+//   expected-remark@4{{macro content: |    return unsafe nullUnspecified(len, p.baseAddress)|}}
 //   expected-remark@5{{macro content: |}|}}
 // }}
 void nullUnspecified(int len, int * __counted_by_or_null(len) _Null_unspecified p);
@@ -103,7 +103,7 @@ int * __counted_by_or_null(len) returnPointer(int len);
 //   expected-remark@3{{macro content: |    if p.count != len + 1 {|}}
 //   expected-remark@4{{macro content: |      fatalError("bounds check failure in offByOne: expected \\(len + 1) but got \\(p.count)")|}}
 //   expected-remark@5{{macro content: |    }|}}
-//   expected-remark@6{{macro content: |    return unsafe offByOne(len, p.baseAddress!)|}}
+//   expected-remark@6{{macro content: |    return unsafe offByOne(len, p.baseAddress)|}}
 //   expected-remark@7{{macro content: |}|}}
 // }}
 void offByOne(int len, int * __counted_by_or_null(len + 1) p);
@@ -114,7 +114,7 @@ void offByOne(int len, int * __counted_by_or_null(len + 1) p);
 //   expected-remark@3{{macro content: |    if p.count != len + (1 + offset) {|}}
 //   expected-remark@4{{macro content: |      fatalError("bounds check failure in offBySome: expected \\(len + (1 + offset)) but got \\(p.count)")|}}
 //   expected-remark@5{{macro content: |    }|}}
-//   expected-remark@6{{macro content: |    return unsafe offBySome(len, offset, p.baseAddress!)|}}
+//   expected-remark@6{{macro content: |    return unsafe offBySome(len, offset, p.baseAddress)|}}
 //   expected-remark@7{{macro content: |}|}}
 // }}
 void offBySome(int len, int offset, int * __counted_by_or_null(len + (1 + offset)) p);
@@ -125,7 +125,7 @@ void offBySome(int len, int offset, int * __counted_by_or_null(len + (1 + offset
 //   expected-remark@3{{macro content: |    if p.count != m * n {|}}
 //   expected-remark@4{{macro content: |      fatalError("bounds check failure in scalar: expected \\(m * n) but got \\(p.count)")|}}
 //   expected-remark@5{{macro content: |    }|}}
-//   expected-remark@6{{macro content: |    return unsafe scalar(m, n, p.baseAddress!)|}}
+//   expected-remark@6{{macro content: |    return unsafe scalar(m, n, p.baseAddress)|}}
 //   expected-remark@7{{macro content: |}|}}
 // }}
 void scalar(int m, int n, int * __counted_by_or_null(m * n) p);
@@ -136,7 +136,7 @@ void scalar(int m, int n, int * __counted_by_or_null(m * n) p);
 //   expected-remark@3{{macro content: |    if p.count != m & n | ~o {|}}
 //   expected-remark@4{{macro content: |      fatalError("bounds check failure in bitwise: expected \\(m & n | ~o) but got \\(p.count)")|}}
 //   expected-remark@5{{macro content: |    }|}}
-//   expected-remark@6{{macro content: |    return unsafe bitwise(m, n, o, p.baseAddress!)|}}
+//   expected-remark@6{{macro content: |    return unsafe bitwise(m, n, o, p.baseAddress)|}}
 //   expected-remark@7{{macro content: |}|}}
 // }}
 void bitwise(int m, int n, int o, int * __counted_by_or_null(m & n | ~o) p);
@@ -147,7 +147,7 @@ void bitwise(int m, int n, int o, int * __counted_by_or_null(m & n | ~o) p);
 //   expected-remark@3{{macro content: |    if p.count != m << (n >> o) {|}}
 //   expected-remark@4{{macro content: |      fatalError("bounds check failure in bitshift: expected \\(m << (n >> o)) but got \\(p.count)")|}}
 //   expected-remark@5{{macro content: |    }|}}
-//   expected-remark@6{{macro content: |    return unsafe bitshift(m, n, o, p.baseAddress!)|}}
+//   expected-remark@6{{macro content: |    return unsafe bitshift(m, n, o, p.baseAddress)|}}
 //   expected-remark@7{{macro content: |}|}}
 // }}
 void bitshift(int m, int n, int o, int * __counted_by_or_null(m << (n >> o)) p);
@@ -158,7 +158,7 @@ void bitshift(int m, int n, int o, int * __counted_by_or_null(m << (n >> o)) p);
 //   expected-remark@3{{macro content: |    if p.count != 420 {|}}
 //   expected-remark@4{{macro content: |      fatalError("bounds check failure in constInt: expected \\(420) but got \\(p.count)")|}}
 //   expected-remark@5{{macro content: |    }|}}
-//   expected-remark@6{{macro content: |    return unsafe constInt(p.baseAddress!)|}}
+//   expected-remark@6{{macro content: |    return unsafe constInt(p.baseAddress)|}}
 //   expected-remark@7{{macro content: |}|}}
 // }}
 void constInt(int * __counted_by_or_null(42 * 10) p);
@@ -169,7 +169,7 @@ void constInt(int * __counted_by_or_null(42 * 10) p);
 //   expected-remark@3{{macro content: |    if p.count != 0 {|}}
 //   expected-remark@4{{macro content: |      fatalError("bounds check failure in constFloatCastedToInt: expected \\(0) but got \\(p.count)")|}}
 //   expected-remark@5{{macro content: |    }|}}
-//   expected-remark@6{{macro content: |    return unsafe constFloatCastedToInt(p.baseAddress!)|}}
+//   expected-remark@6{{macro content: |    return unsafe constFloatCastedToInt(p.baseAddress)|}}
 //   expected-remark@7{{macro content: |}|}}
 // }}
 void constFloatCastedToInt(int * __counted_by_or_null((int) (4.2 / 12)) p);
@@ -202,7 +202,7 @@ void longLiteral(int * __counted_by_or_null(2l) p);
 //   expected-remark@3{{macro content: |    if p.count != 250 {|}}
 //   expected-remark@4{{macro content: |      fatalError("bounds check failure in hexLiteral: expected \\(250) but got \\(p.count)")|}}
 //   expected-remark@5{{macro content: |    }|}}
-//   expected-remark@6{{macro content: |    return unsafe hexLiteral(p.baseAddress!)|}}
+//   expected-remark@6{{macro content: |    return unsafe hexLiteral(p.baseAddress)|}}
 //   expected-remark@7{{macro content: |}|}}
 // }}
 void hexLiteral(int * __counted_by_or_null(0xfa) p);
@@ -213,7 +213,7 @@ void hexLiteral(int * __counted_by_or_null(0xfa) p);
 //   expected-remark@3{{macro content: |    if p.count != 2 {|}}
 //   expected-remark@4{{macro content: |      fatalError("bounds check failure in binaryLiteral: expected \\(2) but got \\(p.count)")|}}
 //   expected-remark@5{{macro content: |    }|}}
-//   expected-remark@6{{macro content: |    return unsafe binaryLiteral(p.baseAddress!)|}}
+//   expected-remark@6{{macro content: |    return unsafe binaryLiteral(p.baseAddress)|}}
 //   expected-remark@7{{macro content: |}|}}
 // }}
 void binaryLiteral(int * __counted_by_or_null(0b10) p);
@@ -224,7 +224,7 @@ void binaryLiteral(int * __counted_by_or_null(0b10) p);
 //   expected-remark@3{{macro content: |    if p.count != 511 {|}}
 //   expected-remark@4{{macro content: |      fatalError("bounds check failure in octalLiteral: expected \\(511) but got \\(p.count)")|}}
 //   expected-remark@5{{macro content: |    }|}}
-//   expected-remark@6{{macro content: |    return unsafe octalLiteral(p.baseAddress!)|}}
+//   expected-remark@6{{macro content: |    return unsafe octalLiteral(p.baseAddress)|}}
 //   expected-remark@7{{macro content: |}|}}
 // }}
 void octalLiteral(int * __counted_by_or_null(0777) p);
@@ -244,7 +244,7 @@ void variadic(int len, int * __counted_by_or_null(len) p, ...);
 //   expected-remark@4{{macro content: |    if let _p1Count = unsafe p1?.count, _p1Count != len {|}}
 //   expected-remark@5{{macro content: |      fatalError("bounds check failure in mixedShared: expected \\(len) but got \\(_p1Count)")|}}
 //   expected-remark@6{{macro content: |    }|}}
-//   expected-remark@7{{macro content: |    return unsafe mixedShared(len, p1?.baseAddress, p2.baseAddress!)|}}
+//   expected-remark@7{{macro content: |    return unsafe mixedShared(len, p1?.baseAddress, p2.baseAddress)|}}
 //   expected-remark@8{{macro content: |}|}}
 // }}
 void mixedShared(int len, int * __counted_by_or_null(len) _Nullable p1, int * __counted_by(len) p2);
@@ -261,7 +261,7 @@ void mixedShared(int len, int * __counted_by_or_null(len) _Nullable p1, int * __
 //   expected-remark@7{{macro content: |    if let _p3Count = unsafe p3?.count, _p3Count != len {|}}
 //   expected-remark@8{{macro content: |      fatalError("bounds check failure in mixedThree: expected \\(len) but got \\(_p3Count)")|}}
 //   expected-remark@9{{macro content: |    }|}}
-//   expected-remark@10{{macro content: |    return unsafe mixedThree(len, p1?.baseAddress, p2.baseAddress!, p3?.baseAddress)|}}
+//   expected-remark@10{{macro content: |    return unsafe mixedThree(len, p1?.baseAddress, p2.baseAddress, p3?.baseAddress)|}}
 //   expected-remark@11{{macro content: |}|}}
 // }}
 void mixedThree(int len, int * __counted_by_or_null(len) _Nullable p1, int * __counted_by(len) p2, int * __counted_by_or_null(len) _Nullable p3);

--- a/test/Interop/C/swiftify-import/counted-by.swift
+++ b/test/Interop/C/swiftify-import/counted-by.swift
@@ -13,7 +13,7 @@
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func simple(_ p: UnsafeMutableBufferPointer<Int32>) {|}}
 //   expected-remark@3{{macro content: |    let len = Int32(exactly: p.count)!|}}
-//   expected-remark@4{{macro content: |    return unsafe simple(len, p.baseAddress!)|}}
+//   expected-remark@4{{macro content: |    return unsafe simple(len, p.baseAddress)|}}
 //   expected-remark@5{{macro content: |}|}}
 // }}
 void simple(int len, int * __counted_by(len) p);
@@ -22,7 +22,7 @@ void simple(int len, int * __counted_by(len) p);
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func simpleFlipped(_ p: UnsafeMutableBufferPointer<Int32>) {|}}
 //   expected-remark@3{{macro content: |    let len = Int32(exactly: p.count)!|}}
-//   expected-remark@4{{macro content: |    return unsafe simpleFlipped(p.baseAddress!, len)|}}
+//   expected-remark@4{{macro content: |    return unsafe simpleFlipped(p.baseAddress, len)|}}
 //   expected-remark@5{{macro content: |}|}}
 // }}
 void simpleFlipped(int * __counted_by(len) p, int len);
@@ -31,7 +31,7 @@ void simpleFlipped(int * __counted_by(len) p, int len);
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func swiftAttr(_ p: UnsafeMutableBufferPointer<Int32>) {|}}
 //   expected-remark@3{{macro content: |    let len = Int32(exactly: p.count)!|}}
-//   expected-remark@4{{macro content: |    return unsafe swiftAttr(len, p.baseAddress!)|}}
+//   expected-remark@4{{macro content: |    return unsafe swiftAttr(len, p.baseAddress)|}}
 //   expected-remark@5{{macro content: |}|}}
 // }}
 void swiftAttr(int len, int *p) __attribute__((
@@ -44,7 +44,7 @@ void swiftAttr(int len, int *p) __attribute__((
 //   expected-remark@4{{macro content: |    if p1.count != len {|}}
 //   expected-remark@5{{macro content: |      fatalError("bounds check failure in shared: expected \\(len) but got \\(p1.count)")|}}
 //   expected-remark@6{{macro content: |    }|}}
-//   expected-remark@7{{macro content: |    return unsafe shared(len, p1.baseAddress!, p2.baseAddress!)|}}
+//   expected-remark@7{{macro content: |    return unsafe shared(len, p1.baseAddress, p2.baseAddress)|}}
 //   expected-remark@8{{macro content: |}|}}
 // }}
 void shared(int len, int * __counted_by(len) p1, int * __counted_by(len) p2);
@@ -55,7 +55,7 @@ void shared(int len, int * __counted_by(len) p1, int * __counted_by(len) p2);
 //   expected-remark@3{{macro content: |    if p.count != len - offset {|}}
 //   expected-remark@4{{macro content: |      fatalError("bounds check failure in complexExpr: expected \\(len - offset) but got \\(p.count)")|}}
 //   expected-remark@5{{macro content: |    }|}}
-//   expected-remark@6{{macro content: |    return unsafe complexExpr(len, offset, p.baseAddress!)|}}
+//   expected-remark@6{{macro content: |    return unsafe complexExpr(len, offset, p.baseAddress)|}}
 //   expected-remark@7{{macro content: |}|}}
 // }}
 void complexExpr(int len, int offset, int * __counted_by(len - offset) p);
@@ -64,7 +64,7 @@ void complexExpr(int len, int offset, int * __counted_by(len - offset) p);
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func nullUnspecified(_ p: UnsafeMutableBufferPointer<Int32>) {|}}
 //   expected-remark@3{{macro content: |    let len = Int32(exactly: p.count)!|}}
-//   expected-remark@4{{macro content: |    return unsafe nullUnspecified(len, p.baseAddress!)|}}
+//   expected-remark@4{{macro content: |    return unsafe nullUnspecified(len, p.baseAddress)|}}
 //   expected-remark@5{{macro content: |}|}}
 // }}
 void nullUnspecified(int len, int * __counted_by(len) _Null_unspecified p);
@@ -101,7 +101,7 @@ int * __counted_by(len) returnPointer(int len);
 //   expected-remark@3{{macro content: |    if p.count != len + 1 {|}}
 //   expected-remark@4{{macro content: |      fatalError("bounds check failure in offByOne: expected \\(len + 1) but got \\(p.count)")|}}
 //   expected-remark@5{{macro content: |    }|}}
-//   expected-remark@6{{macro content: |    return unsafe offByOne(len, p.baseAddress!)|}}
+//   expected-remark@6{{macro content: |    return unsafe offByOne(len, p.baseAddress)|}}
 //   expected-remark@7{{macro content: |}|}}
 // }}
 void offByOne(int len, int * __counted_by(len + 1) p);
@@ -112,7 +112,7 @@ void offByOne(int len, int * __counted_by(len + 1) p);
 //   expected-remark@3{{macro content: |    if p.count != len + (1 + offset) {|}}
 //   expected-remark@4{{macro content: |      fatalError("bounds check failure in offBySome: expected \\(len + (1 + offset)) but got \\(p.count)")|}}
 //   expected-remark@5{{macro content: |    }|}}
-//   expected-remark@6{{macro content: |    return unsafe offBySome(len, offset, p.baseAddress!)|}}
+//   expected-remark@6{{macro content: |    return unsafe offBySome(len, offset, p.baseAddress)|}}
 //   expected-remark@7{{macro content: |}|}}
 // }}
 void offBySome(int len, int offset, int * __counted_by(len + (1 + offset)) p);
@@ -123,7 +123,7 @@ void offBySome(int len, int offset, int * __counted_by(len + (1 + offset)) p);
 //   expected-remark@3{{macro content: |    if p.count != m * n {|}}
 //   expected-remark@4{{macro content: |      fatalError("bounds check failure in scalar: expected \\(m * n) but got \\(p.count)")|}}
 //   expected-remark@5{{macro content: |    }|}}
-//   expected-remark@6{{macro content: |    return unsafe scalar(m, n, p.baseAddress!)|}}
+//   expected-remark@6{{macro content: |    return unsafe scalar(m, n, p.baseAddress)|}}
 //   expected-remark@7{{macro content: |}|}}
 // }}
 void scalar(int m, int n, int * __counted_by(m * n) p);
@@ -134,7 +134,7 @@ void scalar(int m, int n, int * __counted_by(m * n) p);
 //   expected-remark@3{{macro content: |    if p.count != m & n | ~o {|}}
 //   expected-remark@4{{macro content: |      fatalError("bounds check failure in bitwise: expected \\(m & n | ~o) but got \\(p.count)")|}}
 //   expected-remark@5{{macro content: |    }|}}
-//   expected-remark@6{{macro content: |    return unsafe bitwise(m, n, o, p.baseAddress!)|}}
+//   expected-remark@6{{macro content: |    return unsafe bitwise(m, n, o, p.baseAddress)|}}
 //   expected-remark@7{{macro content: |}|}}
 // }}
 void bitwise(int m, int n, int o, int * __counted_by(m & n | ~o) p);
@@ -145,7 +145,7 @@ void bitwise(int m, int n, int o, int * __counted_by(m & n | ~o) p);
 //   expected-remark@3{{macro content: |    if p.count != m << (n >> o) {|}}
 //   expected-remark@4{{macro content: |      fatalError("bounds check failure in bitshift: expected \\(m << (n >> o)) but got \\(p.count)")|}}
 //   expected-remark@5{{macro content: |    }|}}
-//   expected-remark@6{{macro content: |    return unsafe bitshift(m, n, o, p.baseAddress!)|}}
+//   expected-remark@6{{macro content: |    return unsafe bitshift(m, n, o, p.baseAddress)|}}
 //   expected-remark@7{{macro content: |}|}}
 // }}
 void bitshift(int m, int n, int o, int * __counted_by(m << (n >> o)) p);
@@ -156,7 +156,7 @@ void bitshift(int m, int n, int o, int * __counted_by(m << (n >> o)) p);
 //   expected-remark@3{{macro content: |    if p.count != 420 {|}}
 //   expected-remark@4{{macro content: |      fatalError("bounds check failure in constInt: expected \\(420) but got \\(p.count)")|}}
 //   expected-remark@5{{macro content: |    }|}}
-//   expected-remark@6{{macro content: |    return unsafe constInt(p.baseAddress!)|}}
+//   expected-remark@6{{macro content: |    return unsafe constInt(p.baseAddress)|}}
 //   expected-remark@7{{macro content: |}|}}
 // }}
 void constInt(int * __counted_by(42 * 10) p);
@@ -167,7 +167,7 @@ void constInt(int * __counted_by(42 * 10) p);
 //   expected-remark@3{{macro content: |    if p.count != 0 {|}}
 //   expected-remark@4{{macro content: |      fatalError("bounds check failure in constFloatCastedToInt: expected \\(0) but got \\(p.count)")|}}
 //   expected-remark@5{{macro content: |    }|}}
-//   expected-remark@6{{macro content: |    return unsafe constFloatCastedToInt(p.baseAddress!)|}}
+//   expected-remark@6{{macro content: |    return unsafe constFloatCastedToInt(p.baseAddress)|}}
 //   expected-remark@7{{macro content: |}|}}
 // }}
 void constFloatCastedToInt(int * __counted_by((int) (4.2 / 12)) p);
@@ -200,7 +200,7 @@ void longLiteral(int * __counted_by(2l) p);
 //   expected-remark@3{{macro content: |    if p.count != 250 {|}}
 //   expected-remark@4{{macro content: |      fatalError("bounds check failure in hexLiteral: expected \\(250) but got \\(p.count)")|}}
 //   expected-remark@5{{macro content: |    }|}}
-//   expected-remark@6{{macro content: |    return unsafe hexLiteral(p.baseAddress!)|}}
+//   expected-remark@6{{macro content: |    return unsafe hexLiteral(p.baseAddress)|}}
 //   expected-remark@7{{macro content: |}|}}
 // }}
 void hexLiteral(int * __counted_by(0xfa) p);
@@ -211,7 +211,7 @@ void hexLiteral(int * __counted_by(0xfa) p);
 //   expected-remark@3{{macro content: |    if p.count != 2 {|}}
 //   expected-remark@4{{macro content: |      fatalError("bounds check failure in binaryLiteral: expected \\(2) but got \\(p.count)")|}}
 //   expected-remark@5{{macro content: |    }|}}
-//   expected-remark@6{{macro content: |    return unsafe binaryLiteral(p.baseAddress!)|}}
+//   expected-remark@6{{macro content: |    return unsafe binaryLiteral(p.baseAddress)|}}
 //   expected-remark@7{{macro content: |}|}}
 // }}
 void binaryLiteral(int * __counted_by(0b10) p);
@@ -222,7 +222,7 @@ void binaryLiteral(int * __counted_by(0b10) p);
 //   expected-remark@3{{macro content: |    if p.count != 511 {|}}
 //   expected-remark@4{{macro content: |      fatalError("bounds check failure in octalLiteral: expected \\(511) but got \\(p.count)")|}}
 //   expected-remark@5{{macro content: |    }|}}
-//   expected-remark@6{{macro content: |    return unsafe octalLiteral(p.baseAddress!)|}}
+//   expected-remark@6{{macro content: |    return unsafe octalLiteral(p.baseAddress)|}}
 //   expected-remark@7{{macro content: |}|}}
 // }}
 void octalLiteral(int * __counted_by(0777) p);

--- a/test/Interop/C/swiftify-import/import-as-instance-method.swift
+++ b/test/Interop/C/swiftify-import/import-as-instance-method.swift
@@ -117,7 +117,7 @@ public mutating func basic(_ p: inout MutableSpan<Int32>) {
     defer {
         _fixLifetime(p)
     }
-    return unsafe basic(_pPtr.baseAddress!, len)
+    return unsafe basic(_pPtr.baseAddress, len)
 }
 ------------------------------
 @__swiftmacro_So5basic15_SwiftifyImportfMp_.swift
@@ -132,7 +132,7 @@ public func basic(_ a: UnsafeMutablePointer<A>!, _ p: inout MutableSpan<Int32>) 
     defer {
         _fixLifetime(p)
     }
-    return unsafe basic(a, _pPtr.baseAddress!, len)
+    return unsafe basic(a, _pPtr.baseAddress, len)
 }
 ------------------------------
 @__swiftmacro_So1AV3bar15_SwiftifyImportfMp_.swift
@@ -147,7 +147,7 @@ public mutating func bar(_ p: inout MutableSpan<Int32>) {
     defer {
         _fixLifetime(p)
     }
-    return unsafe bar(_pPtr.baseAddress!, len)
+    return unsafe bar(_pPtr.baseAddress, len)
 }
 ------------------------------
 @__swiftmacro_So7renamed15_SwiftifyImportfMp_.swift
@@ -162,7 +162,7 @@ public func renamed(_ a: UnsafeMutablePointer<A>!, _ p: inout MutableSpan<Int32>
     defer {
         _fixLifetime(p)
     }
-    return unsafe renamed(a, _pPtr.baseAddress!, len)
+    return unsafe renamed(a, _pPtr.baseAddress, len)
 }
 ------------------------------
 @__swiftmacro_So1AV9constSelf15_SwiftifyImportfMp_.swift
@@ -177,7 +177,7 @@ public func constSelf(_ p: inout MutableSpan<Int32>) {
     defer {
         _fixLifetime(p)
     }
-    return unsafe constSelf(_pPtr.baseAddress!, len)
+    return unsafe constSelf(_pPtr.baseAddress, len)
 }
 ------------------------------
 @__swiftmacro_So9constSelf15_SwiftifyImportfMp_.swift
@@ -192,7 +192,7 @@ public func constSelf(_ a: UnsafePointer<A>!, _ p: inout MutableSpan<Int32>) {
     defer {
         _fixLifetime(p)
     }
-    return unsafe constSelf(a, _pPtr.baseAddress!, len)
+    return unsafe constSelf(a, _pPtr.baseAddress, len)
 }
 ------------------------------
 @__swiftmacro_So1AV7valSelf15_SwiftifyImportfMp_.swift
@@ -207,7 +207,7 @@ public func valSelf(_ p: inout MutableSpan<Int32>) {
     defer {
         _fixLifetime(p)
     }
-    return unsafe valSelf(_pPtr.baseAddress!, len)
+    return unsafe valSelf(_pPtr.baseAddress, len)
 }
 ------------------------------
 @__swiftmacro_So7valSelf15_SwiftifyImportfMp_.swift
@@ -222,7 +222,7 @@ public func valSelf(_ a: A, _ p: inout MutableSpan<Int32>) {
     defer {
         _fixLifetime(p)
     }
-    return unsafe valSelf(a, _pPtr.baseAddress!, len)
+    return unsafe valSelf(a, _pPtr.baseAddress, len)
 }
 ------------------------------
 @__swiftmacro_So1AV17lifetimeBoundSelf15_SwiftifyImportfMp_.swift
@@ -230,7 +230,12 @@ public func valSelf(_ a: A, _ p: inout MutableSpan<Int32>) {
 /// This is an auto-generated wrapper for safer interop
 @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(borrow self) @_disfavoredOverload
 public func lifetimeBoundSelf(_ len: Int32) -> MutableSpan<Int32> {
-    return unsafe _swiftifyOverrideLifetime(MutableSpan<Int32>(_unsafeStart: unsafe lifetimeBoundSelf(len), count: Int(len)), copying: ())
+    let _resultValue: UnsafeMutablePointer<Int32>? = unsafe lifetimeBoundSelf(len)
+    if unsafe _resultValue == nil {
+      precondition(len == 0, "counted_by may only be null if count is 0 (unlike counted_by_or_null)")
+      return MutableSpan<Int32>()
+    }
+    return unsafe _swiftifyOverrideLifetime(MutableSpan<Int32>(_unsafeStart: _resultValue!, count: Int(len)), copying: ())
 }
 ------------------------------
 @__swiftmacro_So17lifetimeBoundSelf15_SwiftifyImportfMp_.swift
@@ -238,7 +243,12 @@ public func lifetimeBoundSelf(_ len: Int32) -> MutableSpan<Int32> {
 /// This is an auto-generated wrapper for safer interop
 @available(swift, obsoleted: 3, renamed: "A.lifetimeBoundSelf(self:_:)") @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(borrow a) @_disfavoredOverload
 public func lifetimeBoundSelf(_ a: A, _ len: Int32) -> MutableSpan<Int32> {
-    return unsafe _swiftifyOverrideLifetime(MutableSpan<Int32>(_unsafeStart: unsafe lifetimeBoundSelf(a, len), count: Int(len)), copying: ())
+    let _resultValue: UnsafeMutablePointer<Int32>? = unsafe lifetimeBoundSelf(a, len)
+    if unsafe _resultValue == nil {
+      precondition(len == 0, "counted_by may only be null if count is 0 (unlike counted_by_or_null)")
+      return MutableSpan<Int32>()
+    }
+    return unsafe _swiftifyOverrideLifetime(MutableSpan<Int32>(_unsafeStart: _resultValue!, count: Int(len)), copying: ())
 }
 ------------------------------
 @__swiftmacro_So1CV7refSelf15_SwiftifyImportfMp_.swift
@@ -253,7 +263,7 @@ public final func refSelf(_ p: inout MutableSpan<Int32>) {
     defer {
         _fixLifetime(p)
     }
-    return unsafe refSelf(_pPtr.baseAddress!, len)
+    return unsafe refSelf(_pPtr.baseAddress, len)
 }
 ------------------------------
 @__swiftmacro_So7refSelf15_SwiftifyImportfMp_.swift
@@ -268,7 +278,7 @@ public func refSelf(_ c: C!, _ p: inout MutableSpan<Int32>) {
     defer {
         _fixLifetime(p)
     }
-    return unsafe refSelf(c, _pPtr.baseAddress!, len)
+    return unsafe refSelf(c, _pPtr.baseAddress, len)
 }
 ------------------------------
 @__swiftmacro_So4DRefa7refSelf15_SwiftifyImportfMp_.swift
@@ -283,7 +293,7 @@ public final func refSelf(_ p: inout MutableSpan<Int32>) {
     defer {
         _fixLifetime(p)
     }
-    return unsafe refSelf(_pPtr.baseAddress!, len)
+    return unsafe refSelf(_pPtr.baseAddress, len)
 }
 ------------------------------
 @__swiftmacro_So9refSelfCF15_SwiftifyImportfMp_.swift
@@ -298,7 +308,7 @@ public func refSelfCF(_ d: D!, _ p: inout MutableSpan<Int32>) {
     defer {
         _fixLifetime(p)
     }
-    return unsafe refSelfCF(d, _pPtr.baseAddress!, len)
+    return unsafe refSelfCF(d, _pPtr.baseAddress, len)
 }
 ------------------------------
 @__swiftmacro_So1BV11nonescaping15_SwiftifyImportfMp_.swift
@@ -313,7 +323,7 @@ public func nonescaping(_ p: inout MutableSpan<Int32>) {
     defer {
         _fixLifetime(p)
     }
-    return unsafe nonescaping(_pPtr.baseAddress!, len)
+    return unsafe nonescaping(_pPtr.baseAddress, len)
 }
 ------------------------------
 @__swiftmacro_So1BV24nonescapingLifetimebound15_SwiftifyImportfMp_.swift
@@ -321,7 +331,12 @@ public func nonescaping(_ p: inout MutableSpan<Int32>) {
 /// This is an auto-generated wrapper for safer interop
 @_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(&self) @_disfavoredOverload
 public mutating func nonescapingLifetimebound(_ len: Int32) -> MutableSpan<Int32> {
-    return unsafe _swiftifyOverrideLifetime(MutableSpan<Int32>(_unsafeStart: unsafe nonescapingLifetimebound(len), count: Int(len)), copying: ())
+    let _resultValue: UnsafeMutablePointer<Int32>? = unsafe nonescapingLifetimebound(len)
+    if unsafe _resultValue == nil {
+      precondition(len == 0, "counted_by may only be null if count is 0 (unlike counted_by_or_null)")
+      return MutableSpan<Int32>()
+    }
+    return unsafe _swiftifyOverrideLifetime(MutableSpan<Int32>(_unsafeStart: _resultValue!, count: Int(len)), copying: ())
 }
 ------------------------------
 @__swiftmacro_So1AV4init15_SwiftifyImportfMp_.swift
@@ -330,7 +345,7 @@ public mutating func nonescapingLifetimebound(_ len: Int32) -> MutableSpan<Int32
 @_alwaysEmitIntoClient @_disfavoredOverload
 public /*not inherited*/ init!(pointerA p: UnsafeMutableBufferPointer<Int32>) {
     let len = Int32(exactly: p.count)!
-    unsafe self.init(countA: len, pointerA: p.baseAddress!)
+    unsafe self.init(countA: len, pointerA: p.baseAddress)
 }
 ------------------------------
 @__swiftmacro_So7createA15_SwiftifyImportfMp_.swift
@@ -339,7 +354,7 @@ public /*not inherited*/ init!(pointerA p: UnsafeMutableBufferPointer<Int32>) {
 @available(swift, obsoleted: 3, renamed: "A.init(countA:pointerA:)") @_alwaysEmitIntoClient @_disfavoredOverload
 public func createA(_ p: UnsafeMutableBufferPointer<Int32>) -> UnsafeMutablePointer<A>! {
     let len = Int32(exactly: p.count)!
-    return unsafe createA(len, p.baseAddress!)
+    return unsafe createA(len, p.baseAddress)
 }
 ------------------------------
 @__swiftmacro_So1AV4init15_SwiftifyImportfMp_.swift
@@ -354,7 +369,7 @@ public /*not inherited*/ init!(pointerA2 p: inout MutableSpan<Int32>) {
     defer {
         _fixLifetime(p)
     }
-    unsafe self.init(countA2: len, pointerA2: _pPtr.baseAddress!)
+    unsafe self.init(countA2: len, pointerA2: _pPtr.baseAddress)
 }
 ------------------------------
 @__swiftmacro_So8createA215_SwiftifyImportfMp_.swift
@@ -369,7 +384,7 @@ public func createA2(_ p: inout MutableSpan<Int32>) -> UnsafeMutablePointer<A>! 
     defer {
         _fixLifetime(p)
     }
-    return unsafe createA2(len, _pPtr.baseAddress!)
+    return unsafe createA2(len, _pPtr.baseAddress)
 }
 ------------------------------
 @__swiftmacro_So1CV4init15_SwiftifyImportfMp_.swift
@@ -378,7 +393,7 @@ public func createA2(_ p: inout MutableSpan<Int32>) -> UnsafeMutablePointer<A>! 
 @_alwaysEmitIntoClient @_disfavoredOverload
 public /*not inherited*/ final convenience init!(pointerC p: UnsafeMutableBufferPointer<Int32>) {
     let len = Int32(exactly: p.count)!
-    unsafe self.init(countC: len, pointerC: p.baseAddress!)
+    unsafe self.init(countC: len, pointerC: p.baseAddress)
 }
 ------------------------------
 @__swiftmacro_So7createC15_SwiftifyImportfMp_.swift
@@ -387,7 +402,7 @@ public /*not inherited*/ final convenience init!(pointerC p: UnsafeMutableBuffer
 @available(swift, obsoleted: 3, renamed: "C.init(countC:pointerC:)") @_alwaysEmitIntoClient @_disfavoredOverload
 public func createC(_ p: UnsafeMutableBufferPointer<Int32>) -> C! {
     let len = Int32(exactly: p.count)!
-    return unsafe createC(len, p.baseAddress!)
+    return unsafe createC(len, p.baseAddress)
 }
 ------------------------------
 @__swiftmacro_So7createD15_SwiftifyImportfMp_.swift
@@ -396,6 +411,6 @@ public func createC(_ p: UnsafeMutableBufferPointer<Int32>) -> C! {
 @available(swift, obsoleted: 3, renamed: "D.init(countD:pointerD:)") @_alwaysEmitIntoClient @_disfavoredOverload
 public func createD(_ p: UnsafeMutableBufferPointer<Int32>) -> Unmanaged<D>! {
     let len = Int32(exactly: p.count)!
-    return unsafe createD(len, p.baseAddress!)
+    return unsafe createD(len, p.baseAddress)
 }
 ------------------------------

--- a/test/Interop/C/swiftify-import/runtime.swift
+++ b/test/Interop/C/swiftify-import/runtime.swift
@@ -38,6 +38,16 @@ static inline void interop_counted_nullable(const int* __counted_by(count) _Null
     out[i] = in[i];
 }
 
+static inline void interop_counted_noescape_null_unspecified(const int* __counted_by(count) _Null_unspecified in __noescape, int * __counted_by(count) _Null_unspecified out __noescape, int count) {
+  for(int i = 0; i < count; i++)
+    out[i] = in[i];
+}
+
+static inline void interop_counted_null_unspecified(const int* __counted_by(count) _Null_unspecified in, int * __counted_by(count) _Null_unspecified out, int count) {
+  for(int i = 0; i < count; i++)
+    out[i] = in[i];
+}
+
 static inline const int* __counted_by(count) _Nonnull interop_counted_return_lifetimebound(const int* __counted_by(count) _Nonnull in __lifetimebound, int count) {
   int *out = malloc(count * sizeof(int));
   for(int i = 0; i < count; i++)
@@ -60,6 +70,20 @@ static inline const int* __counted_by(count) _Nullable interop_counted_return_li
 }
 
 static inline const int* __counted_by(count) _Nullable interop_counted_return_nullable(const int* __counted_by(count) _Nullable in, int count) {
+  int *out = malloc(count * sizeof(int));
+  for(int i = 0; i < count; i++)
+    out[i] = in[i];
+  return out;
+}
+
+static inline const int* __counted_by(count) _Null_unspecified interop_counted_return_lifetimebound_null_unspecified(const int* __counted_by(count) _Null_unspecified in __lifetimebound, int count) {
+  int *out = malloc(count * sizeof(int));
+  for(int i = 0; i < count; i++)
+    out[i] = in[i];
+  return out;
+}
+
+static inline const int* __counted_by(count) _Null_unspecified interop_counted_return_null_unspecified(const int* __counted_by(count) _Null_unspecified in, int count) {
   int *out = malloc(count * sizeof(int));
   for(int i = 0; i < count; i++)
     out[i] = in[i];
@@ -313,6 +337,84 @@ Suite.test("Non-empty inline array with counted_by_nullable") {
     expectEqual(arr, arrOut)
 }
 
+Suite.test("Empty array with counted_by_null_unspecified and noescape") {
+    let emptyArr: [Int32] = []
+    var emptyArrOut: [Int32] = []
+    var spanOut = emptyArrOut.mutableSpan
+    interop_counted_noescape_null_unspecified(emptyArr.span, &spanOut)
+    expectEqual(emptyArr, emptyArrOut)
+}
+
+Suite.test("Empty array with counted_by_null_unspecified") {
+    let emptyArr: [Int32] = []
+    var emptyArrOut: [Int32] = []
+    emptyArr.withUnsafeBufferPointer { buf in
+      emptyArrOut.withUnsafeMutableBufferPointer { bufOut in
+        unsafe interop_counted_null_unspecified(buf, bufOut)
+      }
+    }
+    expectEqual(emptyArr, emptyArrOut)
+}
+
+Suite.test("Non-empty array with counted_by_null_unspecified and noescape") {
+    let arr: [Int32] = [1, 2, 3]
+    var arrOut: [Int32] = [3, 2, 1]
+    var spanOut = arrOut.mutableSpan
+    interop_counted_noescape_null_unspecified(arr.span, &spanOut)
+    expectEqual(arr, arrOut)
+}
+
+Suite.test("Non-empty array with counted_by_null_unspecified") {
+    let arr: [Int32] = [1, 2, 3]
+    var arrOut: [Int32] = [3, 2, 1]
+    arr.withUnsafeBufferPointer { buf in
+      arrOut.withUnsafeMutableBufferPointer { bufOut in
+        unsafe interop_counted_null_unspecified(buf, bufOut)
+      }
+    }
+    expectEqual(arr, arrOut)
+}
+
+Suite.test("Empty inline array with counted_by_null_unspecified and noescape") {
+    let emptyArr: [0 of Int32] = []
+    var emptyArrOut: [0 of Int32] = []
+    var spanOut = emptyArrOut.mutableSpan
+    interop_counted_noescape_null_unspecified(emptyArr.span, &spanOut)
+    expectEqual(emptyArr, emptyArrOut)
+}
+
+Suite.test("Empty inline array with counted_by_null_unspecified") {
+    let emptyArr: [0 of Int32] = []
+    var emptyArrOut: [0 of Int32] = []
+    var spanOut = emptyArrOut.mutableSpan
+    emptyArr.span.withUnsafeBufferPointer { buf in
+      spanOut.withUnsafeMutableBufferPointer { bufOut in
+        unsafe interop_counted_null_unspecified(buf, bufOut)
+      }
+    }
+    expectEqual(emptyArr, emptyArrOut)
+}
+
+Suite.test("Non-empty inline array with counted_by_null_unspecified and noescape") {
+    let arr: [3 of Int32] = [1, 2, 3]
+    var arrOut: [3 of Int32] = [3, 2, 1]
+    var spanOut = arrOut.mutableSpan
+    interop_counted_noescape_null_unspecified(arr.span, &spanOut)
+    expectEqual(arr, arrOut)
+}
+
+Suite.test("Non-empty inline array with counted_by_null_unspecified") {
+    let arr: [3 of Int32] = [1, 2, 3]
+    var arrOut: [3 of Int32] = [3, 2, 1]
+    var spanOut = arrOut.mutableSpan
+    arr.span.withUnsafeBufferPointer { buf in
+      spanOut.withUnsafeMutableBufferPointer { bufOut in
+        unsafe interop_counted_null_unspecified(buf, bufOut)
+      }
+    }
+    expectEqual(arr, arrOut)
+}
+
 Suite.test("Empty array with return_lifetimebound") {
     let emptyArr: [Int32] = []
     let result = interop_counted_return_lifetimebound(emptyArr.span)
@@ -447,6 +549,74 @@ Suite.test("Default buffer with return_nullable") {
     unsafe expectEqual(buf, result)
 }
 
+Suite.test("Empty array with return_lifetimebound_null_unspecified") {
+    let emptyArr: [Int32] = []
+    let result = interop_counted_return_lifetimebound_null_unspecified(emptyArr.span)
+    expectEqual(emptyArr.span, result)
+}
+
+Suite.test("Non-empty array with return_lifetimebound_null_unspecified") {
+    let arr: [Int32] = [1, 2, 3]
+    let result = interop_counted_return_lifetimebound_null_unspecified(arr.span)
+    expectEqual(arr.span, result)
+}
+
+Suite.test("Empty array with return_null_unspecified") {
+    let emptyArr: [Int32] = []
+    emptyArr.withUnsafeBufferPointer { buf in
+        let result = unsafe interop_counted_return_null_unspecified(buf)
+        unsafe expectEqual(buf, result)
+    }
+}
+
+Suite.test("Non-empty array with return_null_unspecified") {
+    let arr: [Int32] = [1, 2, 3]
+    arr.withUnsafeBufferPointer { buf in
+        let result = unsafe interop_counted_return_null_unspecified(buf)
+        unsafe expectEqual(buf, result)
+    }
+}
+
+Suite.test("Empty inline array with return_lifetimebound_null_unspecified") {
+    let emptyArr: [0 of Int32] = []
+    let result = interop_counted_return_lifetimebound_null_unspecified(emptyArr.span)
+    expectEqual(emptyArr.span, result)
+}
+
+Suite.test("Non-empty inline array with return_lifetimebound_null_unspecified") {
+    let arr: [3 of Int32] = [1, 2, 3]
+    let result = interop_counted_return_lifetimebound_null_unspecified(arr.span)
+    expectEqual(arr.span, result)
+}
+
+Suite.test("Default span with return_lifetimebound_null_unspecified") {
+    let span = Span<Int32>()
+    let result = interop_counted_return_lifetimebound_null_unspecified(span)
+    expectEqual(span, result)
+}
+
+Suite.test("Empty inline array with return_null_unspecified") {
+    let emptyArr: [0 of Int32] = []
+    emptyArr.span.withUnsafeBufferPointer { buf in
+      let result = unsafe interop_counted_return_null_unspecified(buf)
+      unsafe expectEqual(buf, result)
+    }
+}
+
+Suite.test("Non-empty inline array with return_null_unspecified") {
+    let arr: [3 of Int32] = [1, 2, 3]
+    arr.span.withUnsafeBufferPointer { buf in
+      let result = unsafe interop_counted_return_null_unspecified(buf)
+      unsafe expectEqual(buf, result)
+    }
+}
+
+Suite.test("Default buffer with return_null_unspecified") {
+    let buf = UnsafeBufferPointer<Int32>(_empty:())
+    let result = unsafe interop_counted_return_null_unspecified(buf)
+    unsafe expectEqual(buf, result)
+}
+
 Suite.test("Mismatching lengths span") {
     let emptyArr: [Int32] = [1]
     var emptyArrOut: [Int32] = []
@@ -459,6 +629,13 @@ Suite.test("Mismatching lengths span nullable") {
     var emptyArrOut: [Int32] = []
     var spanOut = emptyArrOut.mutableSpan
     expectCrash { interop_counted_noescape_nullable(emptyArr.span, &spanOut) }
+}
+
+Suite.test("Mismatching lengths span null_unspecified") {
+    let emptyArr: [Int32] = [1]
+    var emptyArrOut: [Int32] = []
+    var spanOut = emptyArrOut.mutableSpan
+    expectCrash { interop_counted_noescape_null_unspecified(emptyArr.span, &spanOut) }
 }
 
 // --- Mixed nullability shared-count tests ---

--- a/test/Interop/C/swiftify-import/sized-by-lifetimebound.swift
+++ b/test/Interop/C/swiftify-import/sized-by-lifetimebound.swift
@@ -23,7 +23,7 @@
 #endif
 #define __lifetimebound __attribute__((lifetimebound))
 
-// expected-experimental-expansion@+13:70{{
+// expected-experimental-expansion@+18:70{{
 //   expected-experimental-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy p) @_disfavoredOverload public func simple(_ len: Int32, _ p: RawSpan) -> RawSpan {|}}
 //   expected-experimental-remark@3{{macro content: |    let len2 = Int32(exactly: p.byteCount)!|}}
@@ -33,12 +33,17 @@
 //   expected-experimental-remark@7{{macro content: |    defer {|}}
 //   expected-experimental-remark@8{{macro content: |        _fixLifetime(p)|}}
 //   expected-experimental-remark@9{{macro content: |    }|}}
-//   expected-experimental-remark@10{{macro content: |    return unsafe _swiftifyOverrideLifetime(RawSpan(_unsafeStart: unsafe simple(len, len2, _pPtr.baseAddress!), byteCount: Int(len)), copying: ())|}}
-//   expected-experimental-remark@11{{macro content: |}|}}
+//   expected-experimental-remark@10{{macro content: |    let _resultValue: UnsafeRawPointer? = unsafe simple(len, len2, _pPtr.baseAddress)|}}
+//   expected-experimental-remark@11{{macro content: |    if unsafe _resultValue == nil {|}}
+//   expected-experimental-remark@12{{macro content: |      precondition(len == 0, "sized_by may only be null if size is 0 (unlike sized_by_or_null)")|}}
+//   expected-experimental-remark@13{{macro content: |      return RawSpan()|}}
+//   expected-experimental-remark@14{{macro content: |    }|}}
+//   expected-experimental-remark@15{{macro content: |    return unsafe _swiftifyOverrideLifetime(RawSpan(_unsafeStart: _resultValue!, byteCount: Int(len)), copying: ())|}}
+//   expected-experimental-remark@16{{macro content: |}|}}
 // }}
 const void * __sized_by(len) simple(int len, int len2, const void * p __sized_by(len2) __lifetimebound);
 
-// expected-experimental-expansion@+13:60{{
+// expected-experimental-expansion@+18:60{{
 //   expected-experimental-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy p) @_disfavoredOverload public func shared(_ p: RawSpan) -> RawSpan {|}}
 //   expected-experimental-remark@3{{macro content: |    let len = Int32(exactly: p.byteCount)!|}}
@@ -48,12 +53,17 @@ const void * __sized_by(len) simple(int len, int len2, const void * p __sized_by
 //   expected-experimental-remark@7{{macro content: |    defer {|}}
 //   expected-experimental-remark@8{{macro content: |        _fixLifetime(p)|}}
 //   expected-experimental-remark@9{{macro content: |    }|}}
-//   expected-experimental-remark@10{{macro content: |    return unsafe _swiftifyOverrideLifetime(RawSpan(_unsafeStart: unsafe shared(len, _pPtr.baseAddress!), byteCount: Int(len)), copying: ())|}}
-//   expected-experimental-remark@11{{macro content: |}|}}
+//   expected-experimental-remark@10{{macro content: |    let _resultValue: UnsafeRawPointer? = unsafe shared(len, _pPtr.baseAddress)|}}
+//   expected-experimental-remark@11{{macro content: |    if unsafe _resultValue == nil {|}}
+//   expected-experimental-remark@12{{macro content: |      precondition(len == 0, "sized_by may only be null if size is 0 (unlike sized_by_or_null)")|}}
+//   expected-experimental-remark@13{{macro content: |      return RawSpan()|}}
+//   expected-experimental-remark@14{{macro content: |    }|}}
+//   expected-experimental-remark@15{{macro content: |    return unsafe _swiftifyOverrideLifetime(RawSpan(_unsafeStart: _resultValue!, byteCount: Int(len)), copying: ())|}}
+//   expected-experimental-remark@16{{macro content: |}|}}
 // }}
 const void * __sized_by(len) shared(int len, const void * p __sized_by(len) __lifetimebound);
 
-// expected-experimental-expansion@+13:96{{
+// expected-experimental-expansion@+18:96{{
 //   expected-experimental-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy p) @_disfavoredOverload public func complexExpr(_ len: Int32, _ offset: Int32, _ p: RawSpan) -> RawSpan {|}}
 //   expected-experimental-remark@3{{macro content: |    let len2 = Int32(exactly: p.byteCount)!|}}
@@ -63,12 +73,17 @@ const void * __sized_by(len) shared(int len, const void * p __sized_by(len) __li
 //   expected-experimental-remark@7{{macro content: |    defer {|}}
 //   expected-experimental-remark@8{{macro content: |        _fixLifetime(p)|}}
 //   expected-experimental-remark@9{{macro content: |    }|}}
-//   expected-experimental-remark@10{{macro content: |    return unsafe _swiftifyOverrideLifetime(RawSpan(_unsafeStart: unsafe complexExpr(len, offset, len2, _pPtr.baseAddress!), byteCount: Int(len - offset)), copying: ())|}}
-//   expected-experimental-remark@11{{macro content: |}|}}
+//   expected-experimental-remark@10{{macro content: |    let _resultValue: UnsafeRawPointer? = unsafe complexExpr(len, offset, len2, _pPtr.baseAddress)|}}
+//   expected-experimental-remark@11{{macro content: |    if unsafe _resultValue == nil {|}}
+//   expected-experimental-remark@12{{macro content: |      precondition(len - offset == 0, "sized_by may only be null if size is 0 (unlike sized_by_or_null)")|}}
+//   expected-experimental-remark@13{{macro content: |      return RawSpan()|}}
+//   expected-experimental-remark@14{{macro content: |    }|}}
+//   expected-experimental-remark@15{{macro content: |    return unsafe _swiftifyOverrideLifetime(RawSpan(_unsafeStart: _resultValue!, byteCount: Int(len - offset)), copying: ())|}}
+//   expected-experimental-remark@16{{macro content: |}|}}
 // }}
 const void * __sized_by(len - offset) complexExpr(int len, int offset, int len2, const void * p __sized_by(len2) __lifetimebound);
 
-// expected-experimental-expansion@+13:115{{
+// expected-experimental-expansion@+18:115{{
 //   expected-experimental-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy p) @_disfavoredOverload public func nullUnspecified(_ len: Int32, _ p: RawSpan) -> RawSpan {|}}
 //   expected-experimental-remark@3{{macro content: |    let len2 = Int32(exactly: p.byteCount)!|}}
@@ -78,8 +93,13 @@ const void * __sized_by(len - offset) complexExpr(int len, int offset, int len2,
 //   expected-experimental-remark@7{{macro content: |    defer {|}}
 //   expected-experimental-remark@8{{macro content: |        _fixLifetime(p)|}}
 //   expected-experimental-remark@9{{macro content: |    }|}}
-//   expected-experimental-remark@10{{macro content: |    return unsafe _swiftifyOverrideLifetime(RawSpan(_unsafeStart: unsafe nullUnspecified(len, len2, _pPtr.baseAddress!), byteCount: Int(len)), copying: ())|}}
-//   expected-experimental-remark@11{{macro content: |}|}}
+//   expected-experimental-remark@10{{macro content: |    let _resultValue: UnsafeRawPointer? = unsafe nullUnspecified(len, len2, _pPtr.baseAddress)|}}
+//   expected-experimental-remark@11{{macro content: |    if unsafe _resultValue == nil {|}}
+//   expected-experimental-remark@12{{macro content: |      precondition(len == 0, "sized_by may only be null if size is 0 (unlike sized_by_or_null)")|}}
+//   expected-experimental-remark@13{{macro content: |      return RawSpan()|}}
+//   expected-experimental-remark@14{{macro content: |    }|}}
+//   expected-experimental-remark@15{{macro content: |    return unsafe _swiftifyOverrideLifetime(RawSpan(_unsafeStart: _resultValue!, byteCount: Int(len)), copying: ())|}}
+//   expected-experimental-remark@16{{macro content: |}|}}
 // }}
 const void * __sized_by(len) _Null_unspecified nullUnspecified(int len, int len2, const void * _Null_unspecified p __sized_by(len2) __lifetimebound);
 
@@ -119,7 +139,7 @@ const void * __sized_by(len) _Nonnull nonnull(int len, int len2, const void * _N
 const void * __sized_by(len) _Nullable nullable(int len, int len2, const void * _Nullable p __sized_by(len2) __lifetimebound);
 
 typedef struct foo opaque_t;
-// expected-experimental-expansion@+13:66{{
+// expected-experimental-expansion@+18:66{{
 //   expected-experimental-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy p) @_disfavoredOverload public func opaque(_ len: Int32, _ p: RawSpan) -> RawSpan {|}}
 //   expected-experimental-remark@3{{macro content: |    let len2 = Int32(exactly: p.byteCount)!|}}
@@ -129,20 +149,30 @@ typedef struct foo opaque_t;
 //   expected-experimental-remark@7{{macro content: |    defer {|}}
 //   expected-experimental-remark@8{{macro content: |        _fixLifetime(p)|}}
 //   expected-experimental-remark@9{{macro content: |    }|}}
-//   expected-experimental-remark@10{{macro content: |    return unsafe _swiftifyOverrideLifetime(RawSpan(_unsafeStart: unsafe UnsafeRawPointer(unsafe opaque(len, len2, OpaquePointer(_pPtr.baseAddress!))), byteCount: Int(len)), copying: ())|}}
-//   expected-experimental-remark@11{{macro content: |}|}}
+//   expected-experimental-remark@10{{macro content: |    let _resultValue: OpaquePointer? = unsafe opaque(len, len2, OpaquePointer(_pPtr.baseAddress))|}}
+//   expected-experimental-remark@11{{macro content: |    if unsafe _resultValue == nil {|}}
+//   expected-experimental-remark@12{{macro content: |      precondition(len == 0, "sized_by may only be null if size is 0 (unlike sized_by_or_null)")|}}
+//   expected-experimental-remark@13{{macro content: |      return RawSpan()|}}
+//   expected-experimental-remark@14{{macro content: |    }|}}
+//   expected-experimental-remark@15{{macro content: |    return unsafe _swiftifyOverrideLifetime(RawSpan(_unsafeStart: unsafe UnsafeRawPointer(_resultValue!), byteCount: Int(len)), copying: ())|}}
+//   expected-experimental-remark@16{{macro content: |}|}}
 // }}
 opaque_t * __sized_by(len) opaque(int len, int len2, opaque_t * p __sized_by(len2) __lifetimebound);
 
-// expected-experimental-expansion@+6:70{{
+// expected-experimental-expansion@+11:70{{
 //   expected-experimental-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(borrow p) @_disfavoredOverload public func nonsizedLifetime(_ len: Int32, _ p: UnsafeRawPointer!) -> RawSpan {|}}
-//   expected-experimental-remark@3{{macro content: |    return unsafe _swiftifyOverrideLifetime(RawSpan(_unsafeStart: unsafe nonsizedLifetime(len, p), byteCount: Int(len)), copying: ())|}}
-//   expected-experimental-remark@4{{macro content: |}|}}
+//   expected-experimental-remark@3{{macro content: |    let _resultValue: UnsafeRawPointer? = unsafe nonsizedLifetime(len, p)|}}
+//   expected-experimental-remark@4{{macro content: |    if unsafe _resultValue == nil {|}}
+//   expected-experimental-remark@5{{macro content: |      precondition(len == 0, "sized_by may only be null if size is 0 (unlike sized_by_or_null)")|}}
+//   expected-experimental-remark@6{{macro content: |      return RawSpan()|}}
+//   expected-experimental-remark@7{{macro content: |    }|}}
+//   expected-experimental-remark@8{{macro content: |    return unsafe _swiftifyOverrideLifetime(RawSpan(_unsafeStart: _resultValue!, byteCount: Int(len)), copying: ())|}}
+//   expected-experimental-remark@9{{macro content: |}|}}
 // }}
 const void * __sized_by(len) nonsizedLifetime(int len, const void * p __lifetimebound);
 
-// expected-experimental-expansion@+13:65{{
+// expected-experimental-expansion@+19:65{{
 //   expected-experimental-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy p) @_disfavoredOverload public func bytesized(_ p: RawSpan) -> MutableRawSpan {|}}
 //   expected-experimental-remark@3{{macro content: |    let size = Int32(exactly: p.byteCount)!|}}
@@ -152,12 +182,18 @@ const void * __sized_by(len) nonsizedLifetime(int len, const void * p __lifetime
 //   expected-experimental-remark@7{{macro content: |    defer {|}}
 //   expected-experimental-remark@8{{macro content: |        _fixLifetime(p)|}}
 //   expected-experimental-remark@9{{macro content: |    }|}}
-//   expected-experimental-remark@10{{macro content: |    return unsafe _swiftifyOverrideLifetime(MutableRawSpan(_unsafeStart: unsafe bytesized(size, _pPtr.baseAddress!.assumingMemoryBound(to: UInt8.self)), byteCount: Int(size)), copying: ())|}}
-//   expected-experimental-remark@11{{macro content: |}|}}
+//   expected-experimental-remark@10{{macro content: |    let _resultValue: UnsafeMutablePointer<UInt8>? = unsafe bytesized(size, _pPtr.baseAddress.assumingMemoryBound(to: UInt8.self))|}}
+//   expected-experimental-error@10{{value of optional type 'UnsafeRawPointer?' must be unwrapped to refer to member 'assumingMemoryBound' of wrapped base type 'UnsafeRawPointer'}}
+//   expected-experimental-remark@11{{macro content: |    if unsafe _resultValue == nil {|}}
+//   expected-experimental-remark@12{{macro content: |      precondition(size == 0, "sized_by may only be null if size is 0 (unlike sized_by_or_null)")|}}
+//   expected-experimental-remark@13{{macro content: |      return MutableRawSpan()|}}
+//   expected-experimental-remark@14{{macro content: |    }|}}
+//   expected-experimental-remark@15{{macro content: |    return unsafe _swiftifyOverrideLifetime(MutableRawSpan(_unsafeStart: _resultValue!, byteCount: Int(size)), copying: ())|}}
+//   expected-experimental-remark@16{{macro content: |}|}}
 // }}
 uint8_t *__sized_by(size)  bytesized(int size, const uint8_t * p __sized_by(size) __lifetimebound);
 
-// expected-experimental-expansion@+13:85{{
+// expected-experimental-expansion@+19:85{{
 //   expected-experimental-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy p) @_lifetime(p: copy p) @_disfavoredOverload public func charsized(_ p: inout MutableRawSpan) -> MutableRawSpan {|}}
 //   expected-experimental-remark@3{{macro content: |    let size = Int32(exactly: p.byteCount)!|}}
@@ -167,8 +203,14 @@ uint8_t *__sized_by(size)  bytesized(int size, const uint8_t * p __sized_by(size
 //   expected-experimental-remark@7{{macro content: |    defer {|}}
 //   expected-experimental-remark@8{{macro content: |        _fixLifetime(p)|}}
 //   expected-experimental-remark@9{{macro content: |    }|}}
-//   expected-experimental-remark@10{{macro content: |    return unsafe _swiftifyOverrideLifetime(MutableRawSpan(_unsafeStart: unsafe charsized(_pPtr.baseAddress!.assumingMemoryBound(to: CChar.self), size), byteCount: Int(size)), copying: ())|}}
-//   expected-experimental-remark@11{{macro content: |}|}}
+//   expected-experimental-remark@10{{macro content: |    let _resultValue: UnsafeMutablePointer<CChar>? = unsafe charsized(_pPtr.baseAddress.assumingMemoryBound(to: CChar.self), size)|}}
+//   expected-experimental-error@10{{value of optional type 'UnsafeMutableRawPointer?' must be unwrapped to refer to member 'assumingMemoryBound' of wrapped base type 'UnsafeMutableRawPointer'}}
+//   expected-experimental-remark@11{{macro content: |    if unsafe _resultValue == nil {|}}
+//   expected-experimental-remark@12{{macro content: |      precondition(size == 0, "sized_by may only be null if size is 0 (unlike sized_by_or_null)")|}}
+//   expected-experimental-remark@13{{macro content: |      return MutableRawSpan()|}}
+//   expected-experimental-remark@14{{macro content: |    }|}}
+//   expected-experimental-remark@15{{macro content: |    return unsafe _swiftifyOverrideLifetime(MutableRawSpan(_unsafeStart: _resultValue!, byteCount: Int(size)), copying: ())|}}
+//   expected-experimental-remark@16{{macro content: |}|}}
 // }}
 char *__sized_by(size) charsized(char * p __sized_by(size) __lifetimebound, int size);
 

--- a/test/Interop/C/swiftify-import/sized-by-noescape.swift
+++ b/test/Interop/C/swiftify-import/sized-by-noescape.swift
@@ -28,7 +28,7 @@
 //   expected-remark@7{{macro content: |    defer {|}}
 //   expected-remark@8{{macro content: |        _fixLifetime(p)|}}
 //   expected-remark@9{{macro content: |    }|}}
-//   expected-remark@10{{macro content: |    return unsafe simple(len, _pPtr.baseAddress!)|}}
+//   expected-remark@10{{macro content: |    return unsafe simple(len, _pPtr.baseAddress)|}}
 //   expected-remark@11{{macro content: |}|}}
 // }}
 void simple(int len, const void * __sized_by(len) __noescape p);
@@ -43,7 +43,7 @@ void simple(int len, const void * __sized_by(len) __noescape p);
 //   expected-remark@7{{macro content: |    defer {|}}
 //   expected-remark@8{{macro content: |        _fixLifetime(p)|}}
 //   expected-remark@9{{macro content: |    }|}}
-//   expected-remark@10{{macro content: |    return unsafe swiftAttr(len, _pPtr.baseAddress!)|}}
+//   expected-remark@10{{macro content: |    return unsafe swiftAttr(len, _pPtr.baseAddress)|}}
 //   expected-remark@11{{macro content: |}|}}
 // }}
 void swiftAttr(int len, const void *p) __attribute__((swift_attr(
@@ -68,7 +68,7 @@ void swiftAttr(int len, const void *p) __attribute__((swift_attr(
 //   expected-remark@16{{macro content: |    defer {|}}
 //   expected-remark@17{{macro content: |        _fixLifetime(p2)|}}
 //   expected-remark@18{{macro content: |    }|}}
-//   expected-remark@19{{macro content: |    return unsafe shared(len, _p1Ptr.baseAddress!, _p2Ptr.baseAddress!)|}}
+//   expected-remark@19{{macro content: |    return unsafe shared(len, _p1Ptr.baseAddress, _p2Ptr.baseAddress)|}}
 //   expected-remark@20{{macro content: |}|}}
 // }}
 void shared(int len, const void * __sized_by(len) __noescape p1, const void * __sized_by(len) __noescape p2);
@@ -85,7 +85,7 @@ void shared(int len, const void * __sized_by(len) __noescape p1, const void * __
 //   expected-remark@9{{macro content: |    defer {|}}
 //   expected-remark@10{{macro content: |        _fixLifetime(p)|}}
 //   expected-remark@11{{macro content: |    }|}}
-//   expected-remark@12{{macro content: |    return unsafe complexExpr(len, offset, _pPtr.baseAddress!)|}}
+//   expected-remark@12{{macro content: |    return unsafe complexExpr(len, offset, _pPtr.baseAddress)|}}
 //   expected-remark@13{{macro content: |}|}}
 // }}
 void complexExpr(int len, int offset, const void * __sized_by(len - offset) __noescape p);
@@ -100,7 +100,7 @@ void complexExpr(int len, int offset, const void * __sized_by(len - offset) __no
 //   expected-remark@7{{macro content: |    defer {|}}
 //   expected-remark@8{{macro content: |        _fixLifetime(p)|}}
 //   expected-remark@9{{macro content: |    }|}}
-//   expected-remark@10{{macro content: |    return unsafe nullUnspecified(len, _pPtr.baseAddress!)|}}
+//   expected-remark@10{{macro content: |    return unsafe nullUnspecified(len, _pPtr.baseAddress)|}}
 //   expected-remark@11{{macro content: |}|}}
 // }}
 void nullUnspecified(int len, const void * __sized_by(len) __noescape _Null_unspecified p);
@@ -154,12 +154,12 @@ typedef struct foo opaque_t;
 //   expected-remark@7{{macro content: |    defer {|}}
 //   expected-remark@8{{macro content: |        _fixLifetime(p)|}}
 //   expected-remark@9{{macro content: |    }|}}
-//   expected-remark@10{{macro content: |    return unsafe opaque(len, OpaquePointer(_pPtr.baseAddress!))|}}
+//   expected-remark@10{{macro content: |    return unsafe opaque(len, OpaquePointer(_pPtr.baseAddress))|}}
 //   expected-remark@11{{macro content: |}|}}
 // }}
 void opaque(int len, opaque_t * __sized_by(len) __noescape p);
 
-// expected-expansion@+13:41{{
+// expected-expansion@+14:41{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_disfavoredOverload public func bytesized(_ _bytesized_param1: RawSpan) {|}}
 //   expected-remark@3{{macro content: |    let _bytesized_param0 = Int32(exactly: _bytesized_param1.byteCount)!|}}
@@ -169,12 +169,13 @@ void opaque(int len, opaque_t * __sized_by(len) __noescape p);
 //   expected-remark@7{{macro content: |    defer {|}}
 //   expected-remark@8{{macro content: |        _fixLifetime(_bytesized_param1)|}}
 //   expected-remark@9{{macro content: |    }|}}
-//   expected-remark@10{{macro content: |    return unsafe bytesized(_bytesized_param0, __bytesized_param1Ptr.baseAddress!.assumingMemoryBound(to: UInt8.self))|}}
+//   expected-error@10{{value of optional type 'UnsafeRawPointer?' must be unwrapped to refer to member 'assumingMemoryBound' of wrapped base type 'UnsafeRawPointer'}}
+//   expected-remark@10{{macro content: |    return unsafe bytesized(_bytesized_param0, __bytesized_param1Ptr.baseAddress.assumingMemoryBound(to: UInt8.self))|}}
 //   expected-remark@11{{macro content: |}|}}
 // }}
 void bytesized(int size, const uint8_t *__sized_by(size) __noescape);
 
-// expected-expansion@+13:59{{
+// expected-expansion@+14:59{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(_charsized_param0: copy _charsized_param0) @_disfavoredOverload public func charsized(_ _charsized_param0: inout MutableRawSpan) {|}}
 //   expected-remark@3{{macro content: |    let _charsized_param1 = Int32(exactly: _charsized_param0.byteCount)!|}}
@@ -184,7 +185,8 @@ void bytesized(int size, const uint8_t *__sized_by(size) __noescape);
 //   expected-remark@7{{macro content: |    defer {|}}
 //   expected-remark@8{{macro content: |        _fixLifetime(_charsized_param0)|}}
 //   expected-remark@9{{macro content: |    }|}}
-//   expected-remark@10{{macro content: |    return unsafe charsized(__charsized_param0Ptr.baseAddress!.assumingMemoryBound(to: CChar.self), _charsized_param1)|}}
+//   expected-error@10{{value of optional type 'UnsafeMutableRawPointer?' must be unwrapped to refer to member 'assumingMemoryBound' of wrapped base type 'UnsafeMutableRawPointer'}}
+//   expected-remark@10{{macro content: |    return unsafe charsized(__charsized_param0Ptr.baseAddress.assumingMemoryBound(to: CChar.self), _charsized_param1)|}}
 //   expected-remark@11{{macro content: |}|}}
 // }}
 void charsized(char *__sized_by(size) __noescape, int size);

--- a/test/Interop/C/swiftify-import/sized-by-or-null-lifetimebound.swift
+++ b/test/Interop/C/swiftify-import/sized-by-or-null-lifetimebound.swift
@@ -23,7 +23,7 @@
 #endif
 #define __lifetimebound __attribute__((lifetimebound))
 
-// expected-experimental-expansion@+13:78{{
+// expected-experimental-expansion@+18:78{{
 //   expected-experimental-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy p) @_disfavoredOverload public func simple(_ len: Int32, _ p: RawSpan) -> RawSpan {|}}
 //   expected-experimental-remark@3{{macro content: |    let len2 = Int32(exactly: p.byteCount)!|}}
@@ -33,12 +33,17 @@
 //   expected-experimental-remark@7{{macro content: |    defer {|}}
 //   expected-experimental-remark@8{{macro content: |        _fixLifetime(p)|}}
 //   expected-experimental-remark@9{{macro content: |    }|}}
-//   expected-experimental-remark@10{{macro content: |    return unsafe _swiftifyOverrideLifetime(RawSpan(_unsafeStart: unsafe simple(len, len2, _pPtr.baseAddress!), byteCount: Int(len)), copying: ())|}}
-//   expected-experimental-remark@11{{macro content: |}|}}
+//   expected-experimental-remark@10{{macro content: |    let _resultValue: UnsafeRawPointer? = unsafe simple(len, len2, _pPtr.baseAddress)|}}
+//   expected-experimental-remark@11{{macro content: |    if unsafe _resultValue == nil {|}}
+//   expected-experimental-remark@12{{macro content: |      precondition(len == 0, "sized_by may only be null if size is 0 (unlike sized_by_or_null)")|}}
+//   expected-experimental-remark@13{{macro content: |      return RawSpan()|}}
+//   expected-experimental-remark@14{{macro content: |    }|}}
+//   expected-experimental-remark@15{{macro content: |    return unsafe _swiftifyOverrideLifetime(RawSpan(_unsafeStart: _resultValue!, byteCount: Int(len)), copying: ())|}}
+//   expected-experimental-remark@16{{macro content: |}|}}
 // }}
 const void * __sized_by_or_null(len) simple(int len, int len2, const void * p __sized_by_or_null(len2) __lifetimebound);
 
-// expected-experimental-expansion@+13:68{{
+// expected-experimental-expansion@+18:68{{
 //   expected-experimental-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy p) @_disfavoredOverload public func shared(_ p: RawSpan) -> RawSpan {|}}
 //   expected-experimental-remark@3{{macro content: |    let len = Int32(exactly: p.byteCount)!|}}
@@ -48,12 +53,17 @@ const void * __sized_by_or_null(len) simple(int len, int len2, const void * p __
 //   expected-experimental-remark@7{{macro content: |    defer {|}}
 //   expected-experimental-remark@8{{macro content: |        _fixLifetime(p)|}}
 //   expected-experimental-remark@9{{macro content: |    }|}}
-//   expected-experimental-remark@10{{macro content: |    return unsafe _swiftifyOverrideLifetime(RawSpan(_unsafeStart: unsafe shared(len, _pPtr.baseAddress!), byteCount: Int(len)), copying: ())|}}
-//   expected-experimental-remark@11{{macro content: |}|}}
+//   expected-experimental-remark@10{{macro content: |    let _resultValue: UnsafeRawPointer? = unsafe shared(len, _pPtr.baseAddress)|}}
+//   expected-experimental-remark@11{{macro content: |    if unsafe _resultValue == nil {|}}
+//   expected-experimental-remark@12{{macro content: |      precondition(len == 0, "sized_by may only be null if size is 0 (unlike sized_by_or_null)")|}}
+//   expected-experimental-remark@13{{macro content: |      return RawSpan()|}}
+//   expected-experimental-remark@14{{macro content: |    }|}}
+//   expected-experimental-remark@15{{macro content: |    return unsafe _swiftifyOverrideLifetime(RawSpan(_unsafeStart: _resultValue!, byteCount: Int(len)), copying: ())|}}
+//   expected-experimental-remark@16{{macro content: |}|}}
 // }}
 const void * __sized_by_or_null(len) shared(int len, const void * p __sized_by_or_null(len) __lifetimebound);
 
-// expected-experimental-expansion@+13:104{{
+// expected-experimental-expansion@+18:104{{
 //   expected-experimental-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy p) @_disfavoredOverload public func complexExpr(_ len: Int32, _ offset: Int32, _ p: RawSpan) -> RawSpan {|}}
 //   expected-experimental-remark@3{{macro content: |    let len2 = Int32(exactly: p.byteCount)!|}}
@@ -63,12 +73,17 @@ const void * __sized_by_or_null(len) shared(int len, const void * p __sized_by_o
 //   expected-experimental-remark@7{{macro content: |    defer {|}}
 //   expected-experimental-remark@8{{macro content: |        _fixLifetime(p)|}}
 //   expected-experimental-remark@9{{macro content: |    }|}}
-//   expected-experimental-remark@10{{macro content: |    return unsafe _swiftifyOverrideLifetime(RawSpan(_unsafeStart: unsafe complexExpr(len, offset, len2, _pPtr.baseAddress!), byteCount: Int(len - offset)), copying: ())|}}
-//   expected-experimental-remark@11{{macro content: |}|}}
+//   expected-experimental-remark@10{{macro content: |    let _resultValue: UnsafeRawPointer? = unsafe complexExpr(len, offset, len2, _pPtr.baseAddress)|}}
+//   expected-experimental-remark@11{{macro content: |    if unsafe _resultValue == nil {|}}
+//   expected-experimental-remark@12{{macro content: |      precondition(len - offset == 0, "sized_by may only be null if size is 0 (unlike sized_by_or_null)")|}}
+//   expected-experimental-remark@13{{macro content: |      return RawSpan()|}}
+//   expected-experimental-remark@14{{macro content: |    }|}}
+//   expected-experimental-remark@15{{macro content: |    return unsafe _swiftifyOverrideLifetime(RawSpan(_unsafeStart: _resultValue!, byteCount: Int(len - offset)), copying: ())|}}
+//   expected-experimental-remark@16{{macro content: |}|}}
 // }}
 const void * __sized_by_or_null(len - offset) complexExpr(int len, int offset, int len2, const void * p __sized_by_or_null(len2) __lifetimebound);
 
-// expected-experimental-expansion@+13:123{{
+// expected-experimental-expansion@+18:123{{
 //   expected-experimental-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy p) @_disfavoredOverload public func nullUnspecified(_ len: Int32, _ p: RawSpan) -> RawSpan {|}}
 //   expected-experimental-remark@3{{macro content: |    let len2 = Int32(exactly: p.byteCount)!|}}
@@ -78,8 +93,13 @@ const void * __sized_by_or_null(len - offset) complexExpr(int len, int offset, i
 //   expected-experimental-remark@7{{macro content: |    defer {|}}
 //   expected-experimental-remark@8{{macro content: |        _fixLifetime(p)|}}
 //   expected-experimental-remark@9{{macro content: |    }|}}
-//   expected-experimental-remark@10{{macro content: |    return unsafe _swiftifyOverrideLifetime(RawSpan(_unsafeStart: unsafe nullUnspecified(len, len2, _pPtr.baseAddress!), byteCount: Int(len)), copying: ())|}}
-//   expected-experimental-remark@11{{macro content: |}|}}
+//   expected-experimental-remark@10{{macro content: |    let _resultValue: UnsafeRawPointer? = unsafe nullUnspecified(len, len2, _pPtr.baseAddress)|}}
+//   expected-experimental-remark@11{{macro content: |    if unsafe _resultValue == nil {|}}
+//   expected-experimental-remark@12{{macro content: |      precondition(len == 0, "sized_by may only be null if size is 0 (unlike sized_by_or_null)")|}}
+//   expected-experimental-remark@13{{macro content: |      return RawSpan()|}}
+//   expected-experimental-remark@14{{macro content: |    }|}}
+//   expected-experimental-remark@15{{macro content: |    return unsafe _swiftifyOverrideLifetime(RawSpan(_unsafeStart: _resultValue!, byteCount: Int(len)), copying: ())|}}
+//   expected-experimental-remark@16{{macro content: |}|}}
 // }}
 const void * __sized_by_or_null(len) _Null_unspecified nullUnspecified(int len, int len2, const void * _Null_unspecified p __sized_by_or_null(len2) __lifetimebound);
 
@@ -119,7 +139,7 @@ const void * __sized_by_or_null(len) _Nonnull nonnull(int len, int len2, const v
 const void * __sized_by_or_null(len) _Nullable nullable(int len, int len2, const void * _Nullable p __sized_by_or_null(len2) __lifetimebound);
 
 typedef struct foo opaque_t;
-// expected-experimental-expansion@+13:74{{
+// expected-experimental-expansion@+18:74{{
 //   expected-experimental-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy p) @_disfavoredOverload public func opaque(_ len: Int32, _ p: RawSpan) -> RawSpan {|}}
 //   expected-experimental-remark@3{{macro content: |    let len2 = Int32(exactly: p.byteCount)!|}}
@@ -129,20 +149,30 @@ typedef struct foo opaque_t;
 //   expected-experimental-remark@7{{macro content: |    defer {|}}
 //   expected-experimental-remark@8{{macro content: |        _fixLifetime(p)|}}
 //   expected-experimental-remark@9{{macro content: |    }|}}
-//   expected-experimental-remark@10{{macro content: |    return unsafe _swiftifyOverrideLifetime(RawSpan(_unsafeStart: unsafe UnsafeRawPointer(unsafe opaque(len, len2, OpaquePointer(_pPtr.baseAddress!))), byteCount: Int(len)), copying: ())|}}
-//   expected-experimental-remark@11{{macro content: |}|}}
+//   expected-experimental-remark@10{{macro content: |    let _resultValue: OpaquePointer? = unsafe opaque(len, len2, OpaquePointer(_pPtr.baseAddress))|}}
+//   expected-experimental-remark@11{{macro content: |    if unsafe _resultValue == nil {|}}
+//   expected-experimental-remark@12{{macro content: |      precondition(len == 0, "sized_by may only be null if size is 0 (unlike sized_by_or_null)")|}}
+//   expected-experimental-remark@13{{macro content: |      return RawSpan()|}}
+//   expected-experimental-remark@14{{macro content: |    }|}}
+//   expected-experimental-remark@15{{macro content: |    return unsafe _swiftifyOverrideLifetime(RawSpan(_unsafeStart: unsafe UnsafeRawPointer(_resultValue!), byteCount: Int(len)), copying: ())|}}
+//   expected-experimental-remark@16{{macro content: |}|}}
 // }}
 opaque_t * __sized_by_or_null(len) opaque(int len, int len2, opaque_t * p __sized_by_or_null(len2) __lifetimebound);
 
-// expected-experimental-expansion@+6:78{{
+// expected-experimental-expansion@+11:78{{
 //   expected-experimental-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(borrow p) @_disfavoredOverload public func nonsizedLifetime(_ len: Int32, _ p: UnsafeRawPointer!) -> RawSpan {|}}
-//   expected-experimental-remark@3{{macro content: |    return unsafe _swiftifyOverrideLifetime(RawSpan(_unsafeStart: unsafe nonsizedLifetime(len, p), byteCount: Int(len)), copying: ())|}}
-//   expected-experimental-remark@4{{macro content: |}|}}
+//   expected-experimental-remark@3{{macro content: |    let _resultValue: UnsafeRawPointer? = unsafe nonsizedLifetime(len, p)|}}
+//   expected-experimental-remark@4{{macro content: |    if unsafe _resultValue == nil {|}}
+//   expected-experimental-remark@5{{macro content: |      precondition(len == 0, "sized_by may only be null if size is 0 (unlike sized_by_or_null)")|}}
+//   expected-experimental-remark@6{{macro content: |      return RawSpan()|}}
+//   expected-experimental-remark@7{{macro content: |    }|}}
+//   expected-experimental-remark@8{{macro content: |    return unsafe _swiftifyOverrideLifetime(RawSpan(_unsafeStart: _resultValue!, byteCount: Int(len)), copying: ())|}}
+//   expected-experimental-remark@9{{macro content: |}|}}
 // }}
 const void * __sized_by_or_null(len) nonsizedLifetime(int len, const void * p __lifetimebound);
 
-// expected-experimental-expansion@+13:73{{
+// expected-experimental-expansion@+19:73{{
 //   expected-experimental-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy p) @_disfavoredOverload public func bytesized(_ p: RawSpan) -> MutableRawSpan {|}}
 //   expected-experimental-remark@3{{macro content: |    let size = Int32(exactly: p.byteCount)!|}}
@@ -152,12 +182,18 @@ const void * __sized_by_or_null(len) nonsizedLifetime(int len, const void * p __
 //   expected-experimental-remark@7{{macro content: |    defer {|}}
 //   expected-experimental-remark@8{{macro content: |        _fixLifetime(p)|}}
 //   expected-experimental-remark@9{{macro content: |    }|}}
-//   expected-experimental-remark@10{{macro content: |    return unsafe _swiftifyOverrideLifetime(MutableRawSpan(_unsafeStart: unsafe bytesized(size, _pPtr.baseAddress!.assumingMemoryBound(to: UInt8.self)), byteCount: Int(size)), copying: ())|}}
-//   expected-experimental-remark@11{{macro content: |}|}}
+//   expected-experimental-remark@10{{macro content: |    let _resultValue: UnsafeMutablePointer<UInt8>? = unsafe bytesized(size, _pPtr.baseAddress.assumingMemoryBound(to: UInt8.self))|}}
+//   expected-experimental-error@10{{value of optional type 'UnsafeRawPointer?' must be unwrapped to refer to member 'assumingMemoryBound' of wrapped base type 'UnsafeRawPointer'}}
+//   expected-experimental-remark@11{{macro content: |    if unsafe _resultValue == nil {|}}
+//   expected-experimental-remark@12{{macro content: |      precondition(size == 0, "sized_by may only be null if size is 0 (unlike sized_by_or_null)")|}}
+//   expected-experimental-remark@13{{macro content: |      return MutableRawSpan()|}}
+//   expected-experimental-remark@14{{macro content: |    }|}}
+//   expected-experimental-remark@15{{macro content: |    return unsafe _swiftifyOverrideLifetime(MutableRawSpan(_unsafeStart: _resultValue!, byteCount: Int(size)), copying: ())|}}
+//   expected-experimental-remark@16{{macro content: |}|}}
 // }}
 uint8_t *__sized_by_or_null(size)  bytesized(int size, const uint8_t * p __sized_by_or_null(size) __lifetimebound);
 
-// expected-experimental-expansion@+13:101{{
+// expected-experimental-expansion@+19:101{{
 //   expected-experimental-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy p) @_lifetime(p: copy p) @_disfavoredOverload public func charsized(_ p: inout MutableRawSpan) -> MutableRawSpan {|}}
 //   expected-experimental-remark@3{{macro content: |    let size = Int32(exactly: p.byteCount)!|}}
@@ -167,8 +203,14 @@ uint8_t *__sized_by_or_null(size)  bytesized(int size, const uint8_t * p __sized
 //   expected-experimental-remark@7{{macro content: |    defer {|}}
 //   expected-experimental-remark@8{{macro content: |        _fixLifetime(p)|}}
 //   expected-experimental-remark@9{{macro content: |    }|}}
-//   expected-experimental-remark@10{{macro content: |    return unsafe _swiftifyOverrideLifetime(MutableRawSpan(_unsafeStart: unsafe charsized(_pPtr.baseAddress!.assumingMemoryBound(to: CChar.self), size), byteCount: Int(size)), copying: ())|}}
-//   expected-experimental-remark@11{{macro content: |}|}}
+//   expected-experimental-remark@10{{macro content: |    let _resultValue: UnsafeMutablePointer<CChar>? = unsafe charsized(_pPtr.baseAddress.assumingMemoryBound(to: CChar.self), size)|}}
+//   expected-experimental-error@10{{value of optional type 'UnsafeMutableRawPointer?' must be unwrapped to refer to member 'assumingMemoryBound' of wrapped base type 'UnsafeMutableRawPointer'}}
+//   expected-experimental-remark@11{{macro content: |    if unsafe _resultValue == nil {|}}
+//   expected-experimental-remark@12{{macro content: |      precondition(size == 0, "sized_by may only be null if size is 0 (unlike sized_by_or_null)")|}}
+//   expected-experimental-remark@13{{macro content: |      return MutableRawSpan()|}}
+//   expected-experimental-remark@14{{macro content: |    }|}}
+//   expected-experimental-remark@15{{macro content: |    return unsafe _swiftifyOverrideLifetime(MutableRawSpan(_unsafeStart: _resultValue!, byteCount: Int(size)), copying: ())|}}
+//   expected-experimental-remark@16{{macro content: |}|}}
 // }}
 char *__sized_by_or_null(size) charsized(char * p __sized_by_or_null(size) __lifetimebound, int size);
 

--- a/test/Interop/C/swiftify-import/sized-by-or-null-noescape.swift
+++ b/test/Interop/C/swiftify-import/sized-by-or-null-noescape.swift
@@ -28,7 +28,7 @@
 //   expected-remark@7{{macro content: |    defer {|}}
 //   expected-remark@8{{macro content: |        _fixLifetime(p)|}}
 //   expected-remark@9{{macro content: |    }|}}
-//   expected-remark@10{{macro content: |    return unsafe simple(len, _pPtr.baseAddress!)|}}
+//   expected-remark@10{{macro content: |    return unsafe simple(len, _pPtr.baseAddress)|}}
 //   expected-remark@11{{macro content: |}|}}
 // }}
 void simple(int len, const void * __sized_by_or_null(len) __noescape p);
@@ -43,7 +43,7 @@ void simple(int len, const void * __sized_by_or_null(len) __noescape p);
 //   expected-remark@7{{macro content: |    defer {|}}
 //   expected-remark@8{{macro content: |        _fixLifetime(p)|}}
 //   expected-remark@9{{macro content: |    }|}}
-//   expected-remark@10{{macro content: |    return unsafe swiftAttr(len, _pPtr.baseAddress!)|}}
+//   expected-remark@10{{macro content: |    return unsafe swiftAttr(len, _pPtr.baseAddress)|}}
 //   expected-remark@11{{macro content: |}|}}
 // }}
 void swiftAttr(int len, const void *p) __attribute__((swift_attr(
@@ -68,7 +68,7 @@ void swiftAttr(int len, const void *p) __attribute__((swift_attr(
 //   expected-remark@16{{macro content: |    defer {|}}
 //   expected-remark@17{{macro content: |        _fixLifetime(p2)|}}
 //   expected-remark@18{{macro content: |    }|}}
-//   expected-remark@19{{macro content: |    return unsafe shared(len, _p1Ptr.baseAddress!, _p2Ptr.baseAddress!)|}}
+//   expected-remark@19{{macro content: |    return unsafe shared(len, _p1Ptr.baseAddress, _p2Ptr.baseAddress)|}}
 //   expected-remark@20{{macro content: |}|}}
 // }}
 void shared(int len, const void * __sized_by_or_null(len) __noescape p1, const void * __sized_by_or_null(len) __noescape p2);
@@ -85,7 +85,7 @@ void shared(int len, const void * __sized_by_or_null(len) __noescape p1, const v
 //   expected-remark@9{{macro content: |    defer {|}}
 //   expected-remark@10{{macro content: |        _fixLifetime(p)|}}
 //   expected-remark@11{{macro content: |    }|}}
-//   expected-remark@12{{macro content: |    return unsafe complexExpr(len, offset, _pPtr.baseAddress!)|}}
+//   expected-remark@12{{macro content: |    return unsafe complexExpr(len, offset, _pPtr.baseAddress)|}}
 //   expected-remark@13{{macro content: |}|}}
 // }}
 void complexExpr(int len, int offset, const void * __sized_by_or_null(len - offset) __noescape p);
@@ -100,7 +100,7 @@ void complexExpr(int len, int offset, const void * __sized_by_or_null(len - offs
 //   expected-remark@7{{macro content: |    defer {|}}
 //   expected-remark@8{{macro content: |        _fixLifetime(p)|}}
 //   expected-remark@9{{macro content: |    }|}}
-//   expected-remark@10{{macro content: |    return unsafe nullUnspecified(len, _pPtr.baseAddress!)|}}
+//   expected-remark@10{{macro content: |    return unsafe nullUnspecified(len, _pPtr.baseAddress)|}}
 //   expected-remark@11{{macro content: |}|}}
 // }}
 void nullUnspecified(int len, const void * __sized_by_or_null(len) __noescape _Null_unspecified p);
@@ -155,12 +155,12 @@ typedef struct foo opaque_t;
 //   expected-remark@7{{macro content: |    defer {|}}
 //   expected-remark@8{{macro content: |        _fixLifetime(p)|}}
 //   expected-remark@9{{macro content: |    }|}}
-//   expected-remark@10{{macro content: |    return unsafe opaque(len, OpaquePointer(_pPtr.baseAddress!))|}}
+//   expected-remark@10{{macro content: |    return unsafe opaque(len, OpaquePointer(_pPtr.baseAddress))|}}
 //   expected-remark@11{{macro content: |}|}}
 // }}
 void opaque(int len, opaque_t * __sized_by_or_null(len) __noescape p);
 
-// expected-expansion@+13:41{{
+// expected-expansion@+14:41{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_disfavoredOverload public func bytesized(_ _bytesized_param1: RawSpan) {|}}
 //   expected-remark@3{{macro content: |    let _bytesized_param0 = Int32(exactly: _bytesized_param1.byteCount)!|}}
@@ -170,12 +170,13 @@ void opaque(int len, opaque_t * __sized_by_or_null(len) __noescape p);
 //   expected-remark@7{{macro content: |    defer {|}}
 //   expected-remark@8{{macro content: |        _fixLifetime(_bytesized_param1)|}}
 //   expected-remark@9{{macro content: |    }|}}
-//   expected-remark@10{{macro content: |    return unsafe bytesized(_bytesized_param0, __bytesized_param1Ptr.baseAddress!.assumingMemoryBound(to: UInt8.self))|}}
+//   expected-error@10{{value of optional type 'UnsafeRawPointer?' must be unwrapped to refer to member 'assumingMemoryBound' of wrapped base type 'UnsafeRawPointer'}}
+//   expected-remark@10{{macro content: |    return unsafe bytesized(_bytesized_param0, __bytesized_param1Ptr.baseAddress.assumingMemoryBound(to: UInt8.self))|}}
 //   expected-remark@11{{macro content: |}|}}
 // }}
 void bytesized(int size, const uint8_t *__sized_by_or_null(size) __noescape);
 
-// expected-expansion@+13:67{{
+// expected-expansion@+14:67{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(_charsized_param0: copy _charsized_param0) @_disfavoredOverload public func charsized(_ _charsized_param0: inout MutableRawSpan) {|}}
 //   expected-remark@3{{macro content: |    let _charsized_param1 = Int32(exactly: _charsized_param0.byteCount)!|}}
@@ -185,7 +186,8 @@ void bytesized(int size, const uint8_t *__sized_by_or_null(size) __noescape);
 //   expected-remark@7{{macro content: |    defer {|}}
 //   expected-remark@8{{macro content: |        _fixLifetime(_charsized_param0)|}}
 //   expected-remark@9{{macro content: |    }|}}
-//   expected-remark@10{{macro content: |    return unsafe charsized(__charsized_param0Ptr.baseAddress!.assumingMemoryBound(to: CChar.self), _charsized_param1)|}}
+//   expected-error@10{{value of optional type 'UnsafeMutableRawPointer?' must be unwrapped to refer to member 'assumingMemoryBound' of wrapped base type 'UnsafeMutableRawPointer'}}
+//   expected-remark@10{{macro content: |    return unsafe charsized(__charsized_param0Ptr.baseAddress.assumingMemoryBound(to: CChar.self), _charsized_param1)|}}
 //   expected-remark@11{{macro content: |}|}}
 // }}
 void charsized(char *__sized_by_or_null(size) __noescape, int size);

--- a/test/Interop/C/swiftify-import/sized-by-or-null.swift
+++ b/test/Interop/C/swiftify-import/sized-by-or-null.swift
@@ -19,7 +19,7 @@
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func simple(_ p: UnsafeMutableRawBufferPointer) {|}}
 //   expected-remark@3{{macro content: |    let len = Int32(exactly: p.count)!|}}
-//   expected-remark@4{{macro content: |    return unsafe simple(len, p.baseAddress!)|}}
+//   expected-remark@4{{macro content: |    return unsafe simple(len, p.baseAddress)|}}
 //   expected-remark@5{{macro content: |}|}}
 // }}
 void simple(int len, void * __sized_by_or_null(len) p);
@@ -28,7 +28,7 @@ void simple(int len, void * __sized_by_or_null(len) p);
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func swiftAttr(_ p: UnsafeMutableRawBufferPointer) {|}}
 //   expected-remark@3{{macro content: |    let len = Int32(exactly: p.count)!|}}
-//   expected-remark@4{{macro content: |    return unsafe swiftAttr(len, p.baseAddress!)|}}
+//   expected-remark@4{{macro content: |    return unsafe swiftAttr(len, p.baseAddress)|}}
 //   expected-remark@5{{macro content: |}|}}
 // }}
 void swiftAttr(int len, void *p) __attribute__((swift_attr(
@@ -41,7 +41,7 @@ void swiftAttr(int len, void *p) __attribute__((swift_attr(
 //   expected-remark@4{{macro content: |    if p1.count != len {|}}
 //   expected-remark@5{{macro content: |      fatalError("bounds check failure in shared: expected \\(len) but got \\(p1.count)")|}}
 //   expected-remark@6{{macro content: |    }|}}
-//   expected-remark@7{{macro content: |    return unsafe shared(len, p1.baseAddress!, p2.baseAddress!)|}}
+//   expected-remark@7{{macro content: |    return unsafe shared(len, p1.baseAddress, p2.baseAddress)|}}
 //   expected-remark@8{{macro content: |}|}}
 // }}
 void shared(int len, void * __sized_by_or_null(len) p1, void * __sized_by_or_null(len) p2);
@@ -52,7 +52,7 @@ void shared(int len, void * __sized_by_or_null(len) p1, void * __sized_by_or_nul
 //   expected-remark@3{{macro content: |    if p.count != len - offset {|}}
 //   expected-remark@4{{macro content: |      fatalError("bounds check failure in complexExpr: expected \\(len - offset) but got \\(p.count)")|}}
 //   expected-remark@5{{macro content: |    }|}}
-//   expected-remark@6{{macro content: |    return unsafe complexExpr(len, offset, p.baseAddress!)|}}
+//   expected-remark@6{{macro content: |    return unsafe complexExpr(len, offset, p.baseAddress)|}}
 //   expected-remark@7{{macro content: |}|}}
 // }}
 void complexExpr(int len, int offset, void * __sized_by_or_null(len - offset) p);
@@ -61,7 +61,7 @@ void complexExpr(int len, int offset, void * __sized_by_or_null(len - offset) p)
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func nullUnspecified(_ p: UnsafeMutableRawBufferPointer) {|}}
 //   expected-remark@3{{macro content: |    let len = Int32(exactly: p.count)!|}}
-//   expected-remark@4{{macro content: |    return unsafe nullUnspecified(len, p.baseAddress!)|}}
+//   expected-remark@4{{macro content: |    return unsafe nullUnspecified(len, p.baseAddress)|}}
 //   expected-remark@5{{macro content: |}|}}
 // }}
 void nullUnspecified(int len, void * __sized_by_or_null(len) _Null_unspecified p);
@@ -98,7 +98,7 @@ typedef struct foo opaque_t;
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func opaque(_ p: UnsafeRawBufferPointer) {|}}
 //   expected-remark@3{{macro content: |    let len = Int32(exactly: p.count)!|}}
-//   expected-remark@4{{macro content: |    return unsafe opaque(len, OpaquePointer(p.baseAddress!))|}}
+//   expected-remark@4{{macro content: |    return unsafe opaque(len, OpaquePointer(p.baseAddress))|}}
 //   expected-remark@5{{macro content: |}|}}
 // }}
 void opaque(int len, opaque_t * __sized_by_or_null(len) p);
@@ -108,16 +108,17 @@ typedef opaque_t *opaqueptr_t;
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func opaqueptr(_ p: UnsafeRawBufferPointer) {|}}
 //   expected-remark@3{{macro content: |    let len = Int32(exactly: p.count)!|}}
-//   expected-remark@4{{macro content: |    return unsafe opaqueptr(len, OpaquePointer(p.baseAddress!))|}}
+//   expected-remark@4{{macro content: |    return unsafe opaqueptr(len, OpaquePointer(p.baseAddress))|}}
 //   expected-remark@5{{macro content: |}|}}
 // }}
 void opaqueptr(int len, opaqueptr_t __sized_by_or_null(len) p);
 
-// expected-expansion@+7:56{{
+// expected-expansion@+8:56{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func charsized(_ _charsized_param0: UnsafeMutableRawBufferPointer) {|}}
 //   expected-remark@3{{macro content: |    let _charsized_param1 = Int32(exactly: _charsized_param0.count)!|}}
-//   expected-remark@4{{macro content: |    return unsafe charsized(_charsized_param0.baseAddress!.assumingMemoryBound(to: CChar.self), _charsized_param1)|}}
+//   expected-error@4{{value of optional type 'UnsafeMutableRawPointer?' must be unwrapped to refer to member 'assumingMemoryBound' of wrapped base type 'UnsafeMutableRawPointer'}}
+//   expected-remark@4{{macro content: |    return unsafe charsized(_charsized_param0.baseAddress.assumingMemoryBound(to: CChar.self), _charsized_param1)|}}
 //   expected-remark@5{{macro content: |}|}}
 // }}
 void charsized(char *__sized_by_or_null(size), int size);
@@ -133,11 +134,12 @@ uint8_t *__sized_by_or_null(size) bytesized(int size);
 void doublebytesized(uint16_t *__sized_by_or_null(size), int size);
 
 typedef uint8_t * bytesizedptr_t;
-// expected-expansion@+7:74{{
+// expected-expansion@+8:74{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func aliasedBytesized(_ p: UnsafeMutableRawBufferPointer) {|}}
 //   expected-remark@3{{macro content: |    let size = Int32(exactly: p.count)!|}}
-//   expected-remark@4{{macro content: |    return unsafe aliasedBytesized(p.baseAddress!.assumingMemoryBound(to: UInt8.self), size)|}}
+//   expected-error@4{{value of optional type 'UnsafeMutableRawPointer?' must be unwrapped to refer to member 'assumingMemoryBound' of wrapped base type 'UnsafeMutableRawPointer'}}
+//   expected-remark@4{{macro content: |    return unsafe aliasedBytesized(p.baseAddress.assumingMemoryBound(to: UInt8.self), size)|}}
 //   expected-remark@5{{macro content: |}|}}
 // }}
 void aliasedBytesized(bytesizedptr_t __sized_by_or_null(size) p, int size);

--- a/test/Interop/C/swiftify-import/sized-by.swift
+++ b/test/Interop/C/swiftify-import/sized-by.swift
@@ -19,7 +19,7 @@
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func simple(_ p: UnsafeMutableRawBufferPointer) {|}}
 //   expected-remark@3{{macro content: |    let len = Int32(exactly: p.count)!|}}
-//   expected-remark@4{{macro content: |    return unsafe simple(len, p.baseAddress!)|}}
+//   expected-remark@4{{macro content: |    return unsafe simple(len, p.baseAddress)|}}
 //   expected-remark@5{{macro content: |}|}}
 // }}
 void simple(int len, void * __sized_by(len) p);
@@ -28,7 +28,7 @@ void simple(int len, void * __sized_by(len) p);
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func swiftAttr(_ p: UnsafeMutableRawBufferPointer) {|}}
 //   expected-remark@3{{macro content: |    let len = Int32(exactly: p.count)!|}}
-//   expected-remark@4{{macro content: |    return unsafe swiftAttr(len, p.baseAddress!)|}}
+//   expected-remark@4{{macro content: |    return unsafe swiftAttr(len, p.baseAddress)|}}
 //   expected-remark@5{{macro content: |}|}}
 // }}
 void swiftAttr(int len, void *p) __attribute__((swift_attr(
@@ -41,7 +41,7 @@ void swiftAttr(int len, void *p) __attribute__((swift_attr(
 //   expected-remark@4{{macro content: |    if p1.count != len {|}}
 //   expected-remark@5{{macro content: |      fatalError("bounds check failure in shared: expected \\(len) but got \\(p1.count)")|}}
 //   expected-remark@6{{macro content: |    }|}}
-//   expected-remark@7{{macro content: |    return unsafe shared(len, p1.baseAddress!, p2.baseAddress!)|}}
+//   expected-remark@7{{macro content: |    return unsafe shared(len, p1.baseAddress, p2.baseAddress)|}}
 //   expected-remark@8{{macro content: |}|}}
 // }}
 void shared(int len, void * __sized_by(len) p1, void * __sized_by(len) p2);
@@ -52,7 +52,7 @@ void shared(int len, void * __sized_by(len) p1, void * __sized_by(len) p2);
 //   expected-remark@3{{macro content: |    if p.count != len - offset {|}}
 //   expected-remark@4{{macro content: |      fatalError("bounds check failure in complexExpr: expected \\(len - offset) but got \\(p.count)")|}}
 //   expected-remark@5{{macro content: |    }|}}
-//   expected-remark@6{{macro content: |    return unsafe complexExpr(len, offset, p.baseAddress!)|}}
+//   expected-remark@6{{macro content: |    return unsafe complexExpr(len, offset, p.baseAddress)|}}
 //   expected-remark@7{{macro content: |}|}}
 // }}
 void complexExpr(int len, int offset, void * __sized_by(len - offset) p);
@@ -61,7 +61,7 @@ void complexExpr(int len, int offset, void * __sized_by(len - offset) p);
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func nullUnspecified(_ p: UnsafeMutableRawBufferPointer) {|}}
 //   expected-remark@3{{macro content: |    let len = Int32(exactly: p.count)!|}}
-//   expected-remark@4{{macro content: |    return unsafe nullUnspecified(len, p.baseAddress!)|}}
+//   expected-remark@4{{macro content: |    return unsafe nullUnspecified(len, p.baseAddress)|}}
 //   expected-remark@5{{macro content: |}|}}
 // }}
 void nullUnspecified(int len, void * __sized_by(len) _Null_unspecified p);
@@ -97,7 +97,7 @@ typedef struct foo opaque_t;
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func opaque(_ p: UnsafeRawBufferPointer) {|}}
 //   expected-remark@3{{macro content: |    let len = Int32(exactly: p.count)!|}}
-//   expected-remark@4{{macro content: |    return unsafe opaque(len, OpaquePointer(p.baseAddress!))|}}
+//   expected-remark@4{{macro content: |    return unsafe opaque(len, OpaquePointer(p.baseAddress))|}}
 //   expected-remark@5{{macro content: |}|}}
 // }}
 void opaque(int len, opaque_t * __sized_by(len) p);
@@ -107,16 +107,17 @@ typedef opaque_t *opaqueptr_t;
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func opaqueptr(_ p: UnsafeRawBufferPointer) {|}}
 //   expected-remark@3{{macro content: |    let len = Int32(exactly: p.count)!|}}
-//   expected-remark@4{{macro content: |    return unsafe opaqueptr(len, OpaquePointer(p.baseAddress!))|}}
+//   expected-remark@4{{macro content: |    return unsafe opaqueptr(len, OpaquePointer(p.baseAddress))|}}
 //   expected-remark@5{{macro content: |}|}}
 // }}
 void opaqueptr(int len, opaqueptr_t __sized_by(len) p);
 
-// expected-expansion@+7:48{{
+// expected-expansion@+8:48{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func charsized(_ _charsized_param0: UnsafeMutableRawBufferPointer) {|}}
 //   expected-remark@3{{macro content: |    let _charsized_param1 = Int32(exactly: _charsized_param0.count)!|}}
-//   expected-remark@4{{macro content: |    return unsafe charsized(_charsized_param0.baseAddress!.assumingMemoryBound(to: CChar.self), _charsized_param1)|}}
+//   expected-error@4{{value of optional type 'UnsafeMutableRawPointer?' must be unwrapped to refer to member 'assumingMemoryBound' of wrapped base type 'UnsafeMutableRawPointer'}}
+//   expected-remark@4{{macro content: |    return unsafe charsized(_charsized_param0.baseAddress.assumingMemoryBound(to: CChar.self), _charsized_param1)|}}
 //   expected-remark@5{{macro content: |}|}}
 // }}
 void charsized(char *__sized_by(size), int size);
@@ -132,11 +133,12 @@ uint8_t *__sized_by(size) bytesized(int size);
 void doublebytesized(uint16_t *__sized_by(size), int size);
 
 typedef uint8_t * bytesizedptr_t;
-// expected-expansion@+7:66{{
+// expected-expansion@+8:66{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func aliasedBytesized(_ p: UnsafeMutableRawBufferPointer) {|}}
 //   expected-remark@3{{macro content: |    let size = Int32(exactly: p.count)!|}}
-//   expected-remark@4{{macro content: |    return unsafe aliasedBytesized(p.baseAddress!.assumingMemoryBound(to: UInt8.self), size)|}}
+//   expected-error@4{{value of optional type 'UnsafeMutableRawPointer?' must be unwrapped to refer to member 'assumingMemoryBound' of wrapped base type 'UnsafeMutableRawPointer'}}
+//   expected-remark@4{{macro content: |    return unsafe aliasedBytesized(p.baseAddress.assumingMemoryBound(to: UInt8.self), size)|}}
 //   expected-remark@5{{macro content: |}|}}
 // }}
 void aliasedBytesized(bytesizedptr_t __sized_by(size) p, int size);

--- a/test/Interop/C/swiftify-import/trap-source-location.swift
+++ b/test/Interop/C/swiftify-import/trap-source-location.swift
@@ -34,5 +34,5 @@ if CommandLine.arguments.dropFirst().first == "interop" {
 #include <ptrcheck.h>
 
 static inline void invokeMacroInClangModule(
-    const int* __counted_by(count) __attribute__((__noescape__)) arr,
+    const int* _Nonnull __counted_by(count) __attribute__((__noescape__)) arr,
     int count) {}

--- a/test/Interop/Cxx/swiftify-import/no-safe-wrapper-attr.swift
+++ b/test/Interop/Cxx/swiftify-import/no-safe-wrapper-attr.swift
@@ -11,7 +11,7 @@
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func control_group_function(_ p: UnsafeMutableBufferPointer<Int32>) {|}}
 //   expected-remark@3{{macro content: |    let len = Int32(exactly: p.count)!|}}
-//   expected-remark@4{{macro content: |    return unsafe control_group_function(p.baseAddress!, len)|}}
+//   expected-remark@4{{macro content: |    return unsafe control_group_function(p.baseAddress, len)|}}
 //   expected-remark@5{{macro content: |}|}}
 // }}
 void control_group_function(int * __counted_by(len) p, int len);
@@ -24,7 +24,7 @@ struct Bar {
   //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload|}}
   //   expected-remark@3{{macro content: |public mutating func control_group_method(_ p: UnsafeMutableBufferPointer<Int32>) {|}}
   //   expected-remark@4{{macro content: |    let len = Int32(exactly: p.count)!|}}
-  //   expected-remark@5{{macro content: |    return unsafe control_group_method(p.baseAddress!, len)|}}
+  //   expected-remark@5{{macro content: |    return unsafe control_group_method(p.baseAddress, len)|}}
   //   expected-remark@6{{macro content: |}|}}
   // }}
   void control_group_method(int * __counted_by(len) p, int len);

--- a/test/Interop/Cxx/swiftify-import/parameter-type-from-namespace.swift
+++ b/test/Interop/Cxx/swiftify-import/parameter-type-from-namespace.swift
@@ -70,7 +70,7 @@ namespace foo {
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func bar(_ p: UnsafeMutableBufferPointer<Float>, _ extra: foo.foo_t) {|}}
 //   expected-remark@3{{macro content: |    let len = Int32(exactly: p.count)!|}}
-//   expected-remark@4{{macro content: |    return unsafe bar(p.baseAddress!, len, extra)|}}
+//   expected-remark@4{{macro content: |    return unsafe bar(p.baseAddress, len, extra)|}}
 //   expected-remark@5{{macro content: |}|}}
 // }}
 // expected-expansion@+3:102{{
@@ -87,7 +87,7 @@ __attribute__((swift_attr("@_SwiftifyImport(.countedBy(pointer: .param(1), count
 //   expected-remark@7{{macro content: |    defer {|}}
 //   expected-remark@8{{macro content: |        _fixLifetime(p)|}}
 //   expected-remark@9{{macro content: |    }|}}
-//   expected-remark@10{{macro content: |    return unsafe bar2(_pPtr.baseAddress!, len, extra)|}}
+//   expected-remark@10{{macro content: |    return unsafe bar2(_pPtr.baseAddress, len, extra)|}}
 //   expected-remark@11{{macro content: |}|}}
 // }}
 // expected-expansion@+3:6{{
@@ -106,7 +106,7 @@ namespace baz {
   //   expected-remark@8{{macro content: |    defer {|}}
   //   expected-remark@9{{macro content: |        _fixLifetime(p)|}}
   //   expected-remark@10{{macro content: |    }|}}
-  //   expected-remark@11{{macro content: |    return unsafe baz_func(_pPtr.baseAddress!, len, extra)|}}
+  //   expected-remark@11{{macro content: |    return unsafe baz_func(_pPtr.baseAddress, len, extra)|}}
   //   expected-remark@12{{macro content: |}|}}
   // }}
   // expected-expansion@+3:8{{

--- a/test/Macros/SwiftifyImport/CountedBy/Unwrapped.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/Unwrapped.swift
@@ -19,6 +19,6 @@ public func myFunc(_ ptr: UnsafePointer<CInt>!, _ len: CInt) {
 @_alwaysEmitIntoClient @_disfavoredOverload
 public func myFunc(_ ptr: UnsafeBufferPointer<CInt>) {
     let len = CInt(exactly: ptr.count)!
-    return unsafe myFunc(ptr.baseAddress!, len)
+    return unsafe myFunc(ptr.baseAddress, len)
 }
 ------------------------------

--- a/test/Macros/SwiftifyImport/CountedByOrNull/Unwrapped.swift
+++ b/test/Macros/SwiftifyImport/CountedByOrNull/Unwrapped.swift
@@ -19,6 +19,6 @@ public func myFunc(_ ptr: UnsafePointer<CInt>!, _ len: CInt) {
 @_alwaysEmitIntoClient @_disfavoredOverload
 public func myFunc(_ ptr: UnsafeBufferPointer<CInt>) {
     let len = CInt(exactly: ptr.count)!
-    return unsafe myFunc(ptr.baseAddress!, len)
+    return unsafe myFunc(ptr.baseAddress, len)
 }
 ------------------------------

--- a/test/Macros/SwiftifyImport/SizedBy/Opaque.swift
+++ b/test/Macros/SwiftifyImport/SizedBy/Opaque.swift
@@ -57,7 +57,7 @@ public func nullableUnsafeRawBufferPointer(_ ptr: UnsafeRawBufferPointer) {
 @_alwaysEmitIntoClient @_disfavoredOverload
 public func impNullableUnsafeRawBufferPointer(_ ptr: UnsafeRawBufferPointer) {
     let size = CInt(exactly: ptr.count)!
-    return unsafe impNullableUnsafeRawBufferPointer(OpaquePointer(ptr.baseAddress!), size)
+    return unsafe impNullableUnsafeRawBufferPointer(OpaquePointer(ptr.baseAddress), size)
 }
 ------------------------------
 @__swiftmacro_4test11nonnullSpan15_SwiftifyImportfMp_.swift
@@ -102,6 +102,6 @@ public func impNullableSpan(_ ptr: RawSpan) {
     defer {
         _fixLifetime(ptr)
     }
-    return unsafe impNullableSpan(OpaquePointer(_ptrPtr.baseAddress!), size)
+    return unsafe impNullableSpan(OpaquePointer(_ptrPtr.baseAddress), size)
 }
 ------------------------------

--- a/test/Macros/SwiftifyImport/SizedBy/OpaqueReturn.swift
+++ b/test/Macros/SwiftifyImport/SizedBy/OpaqueReturn.swift
@@ -98,7 +98,12 @@ public func impNullableSpan(p: RawSpan) -> RawSpan {
     defer {
         _fixLifetime(p)
     }
-    return unsafe _swiftifyOverrideLifetime(RawSpan(_unsafeStart: unsafe UnsafeRawPointer(unsafe impNullableSpan(p: OpaquePointer(_pPtr.baseAddress!), size)), byteCount: Int(size)), copying: ())
+    let _resultValue: OpaquePointer? = unsafe impNullableSpan(p: OpaquePointer(_pPtr.baseAddress), size)
+    if unsafe _resultValue == nil {
+      precondition(size == 0, "sized_by may only be null if size is 0 (unlike sized_by_or_null)")
+      return RawSpan()
+    }
+    return unsafe _swiftifyOverrideLifetime(RawSpan(_unsafeStart: unsafe UnsafeRawPointer(_resultValue!), byteCount: Int(size)), copying: ())
 }
 ------------------------------
 

--- a/test/Macros/SwiftifyImport/SizedBy/Unwrapped.swift
+++ b/test/Macros/SwiftifyImport/SizedBy/Unwrapped.swift
@@ -19,6 +19,6 @@ public func myFunc(_ ptr: UnsafeRawPointer!, _ len: CInt) {
 @_alwaysEmitIntoClient @_disfavoredOverload
 public func myFunc(_ ptr: UnsafeRawBufferPointer) {
     let len = CInt(exactly: ptr.count)!
-    return unsafe myFunc(ptr.baseAddress!, len)
+    return unsafe myFunc(ptr.baseAddress, len)
 }
 ------------------------------

--- a/test/Macros/SwiftifyImport/SizedByOrNull/Opaque.swift
+++ b/test/Macros/SwiftifyImport/SizedByOrNull/Opaque.swift
@@ -57,7 +57,7 @@ public func nullableUnsafeRawBufferPointer(_ ptr: UnsafeRawBufferPointer?) {
 @_alwaysEmitIntoClient @_disfavoredOverload
 public func impNullableUnsafeRawBufferPointer(_ ptr: UnsafeRawBufferPointer) {
     let size = CInt(exactly: ptr.count)!
-    return unsafe impNullableUnsafeRawBufferPointer(OpaquePointer(ptr.baseAddress!), size)
+    return unsafe impNullableUnsafeRawBufferPointer(OpaquePointer(ptr.baseAddress), size)
 }
 ------------------------------
 @__swiftmacro_4test11nonnullSpan15_SwiftifyImportfMp_.swift
@@ -102,6 +102,6 @@ public func impNullableSpan(_ ptr: RawSpan) {
     defer {
         _fixLifetime(ptr)
     }
-    return unsafe impNullableSpan(OpaquePointer(_ptrPtr.baseAddress!), size)
+    return unsafe impNullableSpan(OpaquePointer(_ptrPtr.baseAddress), size)
 }
 ------------------------------

--- a/test/Macros/SwiftifyImport/SizedByOrNull/OpaqueReturn.swift
+++ b/test/Macros/SwiftifyImport/SizedByOrNull/OpaqueReturn.swift
@@ -101,7 +101,12 @@ public func impNullableSpan(p: RawSpan) -> RawSpan {
     defer {
         _fixLifetime(p)
     }
-    return unsafe _swiftifyOverrideLifetime(RawSpan(_unsafeStart: unsafe UnsafeRawPointer(unsafe impNullableSpan(p: OpaquePointer(_pPtr.baseAddress!), size)), byteCount: Int(size)), copying: ())
+    let _resultValue: OpaquePointer? = unsafe impNullableSpan(p: OpaquePointer(_pPtr.baseAddress), size)
+    if unsafe _resultValue == nil {
+      precondition(size == 0, "sized_by may only be null if size is 0 (unlike sized_by_or_null)")
+      return RawSpan()
+    }
+    return unsafe _swiftifyOverrideLifetime(RawSpan(_unsafeStart: unsafe UnsafeRawPointer(_resultValue!), byteCount: Int(size)), copying: ())
 }
 ------------------------------
 

--- a/test/Macros/SwiftifyImport/SizedByOrNull/Unwrapped.swift
+++ b/test/Macros/SwiftifyImport/SizedByOrNull/Unwrapped.swift
@@ -19,6 +19,6 @@ public func myFunc(_ ptr: UnsafeRawPointer!, _ len: CInt) {
 @_alwaysEmitIntoClient @_disfavoredOverload
 public func myFunc(_ ptr: UnsafeRawBufferPointer) {
     let len = CInt(exactly: ptr.count)!
-    return unsafe myFunc(ptr.baseAddress!, len)
+    return unsafe myFunc(ptr.baseAddress, len)
 }
 ------------------------------

--- a/test/embedded/safe-interop-wrapper.swift
+++ b/test/embedded/safe-interop-wrapper.swift
@@ -23,7 +23,7 @@
 //   expected-remark@7{{macro content: |    defer {|}}
 //   expected-remark@8{{macro content: |        _fixLifetime(p)|}}
 //   expected-remark@9{{macro content: |    }|}}
-//   expected-remark@10{{macro content: |    return unsafe simple(len, _pPtr.baseAddress!)|}}
+//   expected-remark@10{{macro content: |    return unsafe simple(len, _pPtr.baseAddress)|}}
 //   expected-remark@11{{macro content: |}|}}
 // }}
 void simple(int len, int * __counted_by(len) __noescape p);


### PR DESCRIPTION
Safe wrapper expansions included an explicit unwrap of the baseAddress
of the span parameter unless the underlying pointer parameter was
explicitly `_Nullable`. Since the baseAddress can only be null if the
count is 0, and the pointer is annotated with counted_by, it is not
allowed to dereference the zero-length buffer, even if the nullability
is not set (i.e. the underlying function parameter is imported with an
implicitly unwrapped optional type).

For consistency, this also adds the same early exit handling for the
return value as for nullable return values.

rdar://177555277