### PR TITLE
ForEach: diagnose unavailable conformance

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -8588,6 +8588,11 @@ ERROR(for_loop_sequence_conformance_unavailable,none,
       "only available in %2 %3 or newer",
       (Type, ProtocolDecl *, StringRef, StringRef))
 
+ERROR(for_loop_sequence_conformance_unavailable_unconditionally,none,
+      "for-in loop requires %0 to conform to %1, "
+      "but the conformance is unavailable",
+      (Type, ProtocolDecl *))
+
 //------------------------------------------------------------------------------
 // MARK: Init accessors
 //------------------------------------------------------------------------------

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -3560,11 +3560,19 @@ private:
     auto protoDecl = seqConformanceRef.getProtocol();
 
     auto domainAndRange = constraint.getDomainAndRange(ctx);
-    ctx.Diags.diagnose(loc, diag::for_loop_sequence_conformance_unavailable,
-                       seqType, protoDecl,
-                       domainAndRange.getDomain().getNameForAttributePrinting(),
-                       domainAndRange.getRange().getVersionString());
-    fixAvailability(loc, dc, constraint.getFixItDomainAndRange(ctx), ctx);
+    auto domain = domainAndRange.getDomain();
+    auto range = domainAndRange.getRange();
+    if (domain.isVersioned() && range.hasMinimumVersion()) {
+      ctx.Diags.diagnose(loc, diag::for_loop_sequence_conformance_unavailable,
+                         seqType, protoDecl,
+                         domain.getNameForAttributePrinting(),
+                         range.getVersionString());
+      fixAvailability(loc, dc, constraint.getFixItDomainAndRange(ctx), ctx);
+    } else {
+      ctx.Diags.diagnose(
+          loc, diag::for_loop_sequence_conformance_unavailable_unconditionally,
+          seqType, protoDecl);
+    }
   }
 
   void buildMakeIteratorVar() {

--- a/test/stmt/foreach.swift
+++ b/test/stmt/foreach.swift
@@ -406,3 +406,19 @@ func testInvalidContainerNotInScope(){
   // expected-error@-1 {{cannot find 'a' in scope}} 
   // expected-error@-2 {{cannot find 'b' in scope}}
 }
+
+// A Sequence conformance that is unconditionally unavailable. Previously this
+// crashed in DesugarForEachStmtRequest because the diagnostic path called
+// AvailabilityRange::getVersionString() on an unversioned constraint.
+struct UnavailableSeq {
+  func makeIterator() -> AnyIterator<Int> { AnyIterator { nil } }
+}
+
+@available(*, unavailable)
+extension UnavailableSeq: Sequence {}
+
+func testUnavailableSequenceConformance(seq: UnavailableSeq) {
+  for x in seq { // expected-error {{for-in loop requires 'UnavailableSeq' to conform to 'Sequence', but the conformance is unavailable}}
+    _ = x
+  }
+}


### PR DESCRIPTION
Resolves rdar://177969592.

The current diagnosis for unavailable conformance to Sequence/BorrowingSequence did not account for `@available(*, unavailable)`, causing a crash when querying `AvailabilityRange:: getVersionString`.