### PR TITLE
[Sema] String representation of type information for derived conformances via macros

### DIFF
--- a/lib/Sema/DerivedConformance/DerivedConformance.cpp
+++ b/lib/Sema/DerivedConformance/DerivedConformance.cpp
@@ -26,6 +26,7 @@
 #include "swift/Basic/Assertions.h"
 #include "swift/Basic/QuotedString.h"
 #include "swift/ClangImporter/ClangModule.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/raw_ostream.h"
 
 using namespace swift;
@@ -134,10 +135,10 @@ bool DerivedConformance::derivesProtocolConformance(
         // conformance.
       case KnownDerivableProtocolKind::Equatable:
         return canDeriveEquatable(DC, Nominal);
-      
+
       case KnownDerivableProtocolKind::Comparable:
         return !enumDecl->hasPotentiallyUnavailableCaseValue()
-            && canDeriveComparable(DC, enumDecl); 
+            && canDeriveComparable(DC, enumDecl);
 
         // "Simple" enums without availability attributes can explicitly derive
         // a CaseIterable conformance.
@@ -206,7 +207,7 @@ void DerivedConformance::tryDiagnoseFailedDerivation(DeclContext *DC,
   auto knownProtocol = protocol->getKnownProtocolKind();
   if (!knownProtocol)
     return;
-  
+
   if (*knownProtocol == KnownProtocolKind::Equatable) {
     tryDiagnoseFailedEquatableDerivation(DC, nominal);
   }
@@ -360,7 +361,7 @@ ValueDecl *DerivedConformance::getDerivableRequirement(NominalTypeDecl *nominal,
   if (auto func = dyn_cast<FuncDecl>(requirement)) {
     if (func->isOperator() && name.getBaseName() == "<")
       return getRequirement(KnownProtocolKind::Comparable);
-    
+
     if (func->isOperator() && name.getBaseName() == "==")
       return getRequirement(KnownProtocolKind::Equatable);
 
@@ -646,10 +647,10 @@ bool DerivedConformance::checkAndDiagnoseDisallowedContext(
 /// \p C The AST context.
 /// \p lhsExpr The first expression to compare for equality.
 /// \p rhsExpr The second expression to compare for equality.
-/// \p guardReturnValue The expression to return if the two sides are not equal 
+/// \p guardReturnValue The expression to return if the two sides are not equal
 GuardStmt *DerivedConformance::returnIfNotEqualGuard(ASTContext &C,
                                         Expr *lhsExpr,
-                                        Expr *rhsExpr, 
+                                        Expr *rhsExpr,
                                         Expr *guardReturnValue) {
   SmallVector<StmtConditionElement, 1> conditions;
   SmallVector<ASTNode, 1> statements;
@@ -676,7 +677,7 @@ GuardStmt *DerivedConformance::returnIfNotEqualGuard(ASTContext &C,
 /// returns `false`.
 /// \p C The AST context.
 /// \p lhsExpr The first expression to compare for equality.
-/// \p rhsExpr The second expression to compare for equality. 
+/// \p rhsExpr The second expression to compare for equality.
 GuardStmt *DerivedConformance::returnFalseIfNotEqualGuard(ASTContext &C,
                                         Expr *lhsExpr,
                                         Expr *rhsExpr) {
@@ -714,7 +715,7 @@ GuardStmt *DerivedConformance::returnNilIfFalseGuardTypeChecked(ASTContext &C,
 /// returns lhs < rhs.
 /// \p C The AST context.
 /// \p lhsExpr The first expression to compare for equality.
-/// \p rhsExpr The second expression to compare for equality. 
+/// \p rhsExpr The second expression to compare for equality.
 GuardStmt *DerivedConformance::returnComparisonIfNotEqualGuard(ASTContext &C,
                                         Expr *lhsExpr,
                                         Expr *rhsExpr) {
@@ -999,79 +1000,71 @@ bool swift::memberwiseAccessorsRequireActorIsolation(NominalTypeDecl *nominal) {
   return false;
 }
 
-/// Returns a string containing swift syntax describing the case \p  decl with
-/// relevant information.
-static std::string getCaseInfoString(const EnumElementDecl *decl) {
-  std::string res;
-  llvm::raw_string_ostream out(res);
+/// Prints a string containing swift syntax describing the case \p  decl with
+/// relevant information to \p out.
+static void printCaseInfo(llvm::raw_ostream &out, const EnumElementDecl *decl) {
   out << "CaseInfo(name: " << QuotedString(decl->getNameStr())
       << ", associatedValues: [";
-  if (decl->hasAssociatedValues()) {
-    auto payloadType = decl->getPayloadInterfaceType();
-    auto *tupleType = payloadType->getAs<TupleType>();
-    bool first = true;
-    for (const auto elem : tupleType->getElements()) {
-      if (!first) out << ", ";
-      first = false;
-      if (elem.hasName()) out << QuotedString(elem.getName().str());
-      else out << "nil";
-    }
-  }
+  llvm::interleaveComma(decl->getName().getArgumentNames(), out,
+                        [&](Identifier name) {
+                          if (name.empty()) {
+                            out << "nil";
+                          } else {
+                            printAsQuotedString(out, name.str());
+                          }
+                        });
   out << "])";
-  out.flush();
-  return res;
 }
 
-/// Returns a string containing swift syntax describing the enum \p
-/// decl with relevant information.
-static std::string getEnumTypeKindString(EnumDecl *decl) {
-  std::string res = "enumLike(EnumTypeInfo(isObjC: ";
-  res += decl->isObjC() ? "true" : "false";
-  res += ", cases: [";
-  auto elements = decl->getAllElements();
-  for (const auto *elem : elements) {
-    if (elem != elements.front()) res += ", ";
-    res += getCaseInfoString(elem);
-  }
-  res += "]))";
-  return res;
+/// Prints a string containing swift syntax describing the enum \p
+/// decl with relevant information to \p out.
+static void printEnumTypeKind(llvm::raw_ostream &out, EnumDecl *decl) {
+  out << "enumLike(EnumTypeInfo(isObjC: "
+      << (decl->isObjC() ? "true" : "false")
+      << ", cases: [";
+  llvm::interleaveComma(decl->getAllElements(), out,
+                        [&](const EnumElementDecl *elem) {
+                          printCaseInfo(out, elem);
+                        });
+  out << "]))";
 }
 
-/// Returns a string containing swift syntax describing the stored property \p
-/// decl with relevant information.
-static std::string getStoredPropertyString(const VarDecl *decl) {
+/// Prints a string containing swift syntax describing the stored property \p
+/// decl with relevant information to \p out.
+static void printStoredProperty(llvm::raw_ostream &out,
+                                const VarDecl *decl) {
   bool isVar = decl->getIntroducer() == VarDecl::Introducer::Var;
-  std::string res;
-  llvm::raw_string_ostream out(res);
   out << "StoredProperty(name: " << QuotedString(decl->getNameStr())
       << ", typeName: " << QuotedString(decl->getTypeInContext().getString())
-      << ", isVar: " << (isVar ? "true" : "false")
+      << ", isVar: "    << (isVar ? "true" : "false")
       << ", isStatic: " << (decl->isStatic() ? "true" : "false") << ")";
-  out.flush();
-  return res;
 }
 
-/// Returns a string containing swift syntax describing struct \p decl with
-/// relevant information.
-static std::string getStructTypeKindString(StructDecl *decl) {
-  std::string res = "structLike(StructTypeInfo(properties: [";
-  auto properties = decl->getStoredProperties();
-  for (const auto *prop: properties) {
-    if (prop != properties.front()) res += ", ";
-    res += getStoredPropertyString(prop);
+
+/// Prints a string containing swift syntax describing struct \p decl with
+/// relevant information to \p out.
+static void printStructTypeKind(llvm::raw_ostream &out, StructDecl *decl) {
+  out << "structLike(StructTypeInfo(properties: [";
+  llvm::interleaveComma(decl->getStoredProperties(), out,
+                        [&](const VarDecl *prop) {
+                          printStoredProperty(out, prop);
+                        });
+  out << "]))";
+}
+
+/// Prints a string containing swift syntax describing \p decl with relevant
+/// information to \p out. For the moment, only struct and enum types are supported.
+static void printNominalTypeKind(llvm::raw_ostream &out,
+                                 NominalTypeDecl *decl) {
+  if (auto *enumDecl = dyn_cast<EnumDecl>(decl)) {
+    printEnumTypeKind(out, enumDecl);
+    return;
   }
-  res += "]))";
-  return res;
-}
 
-/// Returns a string containing swift syntax describing \p decl with relevant
-/// information. For the moment, only struct and enum types are supported.
-static std::string getNominalTypeKindString(NominalTypeDecl *decl) {
-  if (auto *enumDecl = dyn_cast<EnumDecl>(decl))
-    return getEnumTypeKindString(enumDecl);
-
-  if (auto *structDecl = dyn_cast<StructDecl>(decl))
-    return getStructTypeKindString(structDecl);
+  if (auto *structDecl = dyn_cast<StructDecl>(decl)) {
+    printStructTypeKind(out, structDecl);
+    return;
+  }
 
   llvm_unreachable("todo");
 }
@@ -1083,8 +1076,8 @@ std::string swift::getNominalTypeInfoString(DerivedConformance &derived) {
   std::string res;
   llvm::raw_string_ostream out(res);
   out << "NominalTypeInfo(name: " << QuotedString(derived.Nominal->getNameStr())
-      << ", kind: " << getNominalTypeKindString(derived.Nominal)
-      << ", isUnsafe: " << (isUnsafe ? "true" : "false") << ")";
-  out.flush();
+      << ", kind: ";
+  printNominalTypeKind(out, derived.Nominal);
+  out << ", isUnsafe: " << (isUnsafe ? "true" : "false") << ")";
   return res;
 }

--- a/lib/Sema/DerivedConformance/DerivedConformance.cpp
+++ b/lib/Sema/DerivedConformance/DerivedConformance.cpp
@@ -24,7 +24,9 @@
 #include "swift/AST/Stmt.h"
 #include "swift/AST/Types.h"
 #include "swift/Basic/Assertions.h"
+#include "swift/Basic/QuotedString.h"
 #include "swift/ClangImporter/ClangModule.h"
+#include "llvm/Support/raw_ostream.h"
 
 using namespace swift;
 
@@ -995,4 +997,94 @@ bool swift::memberwiseAccessorsRequireActorIsolation(NominalTypeDecl *nominal) {
   }
 
   return false;
+}
+
+/// Returns a string containing swift syntax describing the case \p  decl with
+/// relevant information.
+static std::string getCaseInfoString(const EnumElementDecl *decl) {
+  std::string res;
+  llvm::raw_string_ostream out(res);
+  out << "CaseInfo(name: " << QuotedString(decl->getNameStr())
+      << ", associatedValues: [";
+  if (decl->hasAssociatedValues()) {
+    auto payloadType = decl->getPayloadInterfaceType();
+    auto *tupleType = payloadType->getAs<TupleType>();
+    bool first = true;
+    for (const auto elem : tupleType->getElements()) {
+      if (!first) out << ", ";
+      first = false;
+      if (elem.hasName()) out << QuotedString(elem.getName().str());
+      else out << "nil";
+    }
+  }
+  out << "])";
+  out.flush();
+  return res;
+}
+
+/// Returns a string containing swift syntax describing the enum \p
+/// decl with relevant information.
+static std::string getEnumTypeKindString(EnumDecl *decl) {
+  std::string res = "enumLike(EnumTypeInfo(isObjC: ";
+  res += decl->isObjC() ? "true" : "false";
+  res += ", cases: [";
+  auto elements = decl->getAllElements();
+  for (const auto *elem : elements) {
+    if (elem != elements.front()) res += ", ";
+    res += getCaseInfoString(elem);
+  }
+  res += "]))";
+  return res;
+}
+
+/// Returns a string containing swift syntax describing the stored property \p
+/// decl with relevant information.
+static std::string getStoredPropertyString(const VarDecl *decl) {
+  bool isVar = decl->getIntroducer() == VarDecl::Introducer::Var;
+  std::string res;
+  llvm::raw_string_ostream out(res);
+  out << "StoredProperty(name: " << QuotedString(decl->getNameStr())
+      << ", typeName: " << QuotedString(decl->getTypeInContext().getString())
+      << ", isVar: " << (isVar ? "true" : "false")
+      << ", isStatic: " << (decl->isStatic() ? "true" : "false") << ")";
+  out.flush();
+  return res;
+}
+
+/// Returns a string containing swift syntax describing struct \p decl with
+/// relevant information.
+static std::string getStructTypeKindString(StructDecl *decl) {
+  std::string res = "structLike(StructTypeInfo(properties: [";
+  auto properties = decl->getStoredProperties();
+  for (const auto *prop: properties) {
+    if (prop != properties.front()) res += ", ";
+    res += getStoredPropertyString(prop);
+  }
+  res += "]))";
+  return res;
+}
+
+/// Returns a string containing swift syntax describing \p decl with relevant
+/// information. For the moment, only struct and enum types are supported.
+static std::string getNominalTypeKindString(NominalTypeDecl *decl) {
+  if (auto *enumDecl = dyn_cast<EnumDecl>(decl))
+    return getEnumTypeKindString(enumDecl);
+
+  if (auto *structDecl = dyn_cast<StructDecl>(decl))
+    return getStructTypeKindString(structDecl);
+
+  llvm_unreachable("todo");
+}
+
+std::string swift::getNominalTypeInfoString(DerivedConformance &derived) {
+  bool isUnsafe =
+      derived.Conformance->getExplicitSafety() == ExplicitSafety::Unsafe;
+
+  std::string res;
+  llvm::raw_string_ostream out(res);
+  out << "NominalTypeInfo(name: " << QuotedString(derived.Nominal->getNameStr())
+      << ", kind: " << getNominalTypeKindString(derived.Nominal)
+      << ", isUnsafe: " << (isUnsafe ? "true" : "false") << ")";
+  out.flush();
+  return res;
 }

--- a/lib/Sema/DerivedConformance/DerivedConformance.cpp
+++ b/lib/Sema/DerivedConformance/DerivedConformance.cpp
@@ -135,10 +135,10 @@ bool DerivedConformance::derivesProtocolConformance(
         // conformance.
       case KnownDerivableProtocolKind::Equatable:
         return canDeriveEquatable(DC, Nominal);
-
+      
       case KnownDerivableProtocolKind::Comparable:
         return !enumDecl->hasPotentiallyUnavailableCaseValue()
-            && canDeriveComparable(DC, enumDecl);
+            && canDeriveComparable(DC, enumDecl); 
 
         // "Simple" enums without availability attributes can explicitly derive
         // a CaseIterable conformance.
@@ -207,7 +207,7 @@ void DerivedConformance::tryDiagnoseFailedDerivation(DeclContext *DC,
   auto knownProtocol = protocol->getKnownProtocolKind();
   if (!knownProtocol)
     return;
-
+  
   if (*knownProtocol == KnownProtocolKind::Equatable) {
     tryDiagnoseFailedEquatableDerivation(DC, nominal);
   }
@@ -361,7 +361,7 @@ ValueDecl *DerivedConformance::getDerivableRequirement(NominalTypeDecl *nominal,
   if (auto func = dyn_cast<FuncDecl>(requirement)) {
     if (func->isOperator() && name.getBaseName() == "<")
       return getRequirement(KnownProtocolKind::Comparable);
-
+    
     if (func->isOperator() && name.getBaseName() == "==")
       return getRequirement(KnownProtocolKind::Equatable);
 
@@ -647,10 +647,10 @@ bool DerivedConformance::checkAndDiagnoseDisallowedContext(
 /// \p C The AST context.
 /// \p lhsExpr The first expression to compare for equality.
 /// \p rhsExpr The second expression to compare for equality.
-/// \p guardReturnValue The expression to return if the two sides are not equal
+/// \p guardReturnValue The expression to return if the two sides are not equal 
 GuardStmt *DerivedConformance::returnIfNotEqualGuard(ASTContext &C,
                                         Expr *lhsExpr,
-                                        Expr *rhsExpr,
+                                        Expr *rhsExpr, 
                                         Expr *guardReturnValue) {
   SmallVector<StmtConditionElement, 1> conditions;
   SmallVector<ASTNode, 1> statements;
@@ -677,7 +677,7 @@ GuardStmt *DerivedConformance::returnIfNotEqualGuard(ASTContext &C,
 /// returns `false`.
 /// \p C The AST context.
 /// \p lhsExpr The first expression to compare for equality.
-/// \p rhsExpr The second expression to compare for equality.
+/// \p rhsExpr The second expression to compare for equality. 
 GuardStmt *DerivedConformance::returnFalseIfNotEqualGuard(ASTContext &C,
                                         Expr *lhsExpr,
                                         Expr *rhsExpr) {
@@ -715,7 +715,7 @@ GuardStmt *DerivedConformance::returnNilIfFalseGuardTypeChecked(ASTContext &C,
 /// returns lhs < rhs.
 /// \p C The AST context.
 /// \p lhsExpr The first expression to compare for equality.
-/// \p rhsExpr The second expression to compare for equality.
+/// \p rhsExpr The second expression to compare for equality. 
 GuardStmt *DerivedConformance::returnComparisonIfNotEqualGuard(ASTContext &C,
                                         Expr *lhsExpr,
                                         Expr *rhsExpr) {

--- a/lib/Sema/DerivedConformance/DerivedConformance.h
+++ b/lib/Sema/DerivedConformance/DerivedConformance.h
@@ -465,6 +465,10 @@ public:
 /// because they involve mutable state.
 bool memberwiseAccessorsRequireActorIsolation(NominalTypeDecl *nominal);
 
+/// Get a string describing the nominal type we are deriving a conformance
+/// for by producing valid swift syntax.
+std::string getNominalTypeInfoString(DerivedConformance &derived);
+
 } // namespace swift
 
 #endif


### PR DESCRIPTION
**Overview**:
This PR introduces a way to build a string representation of the type information needed for the derivation of conformances via macros (see https://github.com/swiftlang/swift/pull/89419).

**Motivation**:
A case for deriving conformances via macros is made in the PR linked above.
As of today, macros are purely syntactical and carry no type information, nor can they query the compiler for it. 
Conformance derivation requires some information on the type being conformed for (e.g. the names of the stored properties of a struct for which we are deriving `Equatable`). 
This type information must be explicitly passed  as an argument to the deriving macro,  and therefore needs a string representation.

**Changes**:
Introduces a function that builds the string representation of type information needed by a deriving macro in Swift-like syntax. The representation is returned unquoted, quoting and escaping is the caller's responsibility. Quoting and escaping avoids requiring ABI-stable additions to the stdlib, keeping the representation opaque to the type-checker.
The format is Swift-like syntax of the form: 
```swift
NominalTypeInfo(name: "Foo", kind:
	structLike(StructTypeInfo(properties: [
		StoredProperty(name: "bar", 
					   typeName: "Bar", 
					   isVar: true, 
					   isStatic: false),
		...
	])))
```

The exact contents are not yet stable and are expected to evolve as more conformance derivations are migrated to macro-based derivation. A follow-up PR will introduce a parser for this format on the macro side.