### PR TITLE
Remove warning from docs for `withUnsafeTemporaryAllocation()` about overallocation.

### DIFF
--- a/stdlib/public/core/TemporaryAllocation.swift
+++ b/stdlib/public/core/TemporaryAllocation.swift
@@ -212,10 +212,6 @@ internal func _fallBackToHeapAllocation<R: ~Copyable, E: Error>(
 /// initializing the buffer pointer before it is used _and_ for deinitializing
 /// it before returning, but deallocation is automatic.
 ///
-/// The implementation may allocate a larger buffer pointer than is strictly
-/// necessary to contain `byteCount` bytes. The behavior of a program that
-/// attempts to access any such additional storage is undefined.
-///
 /// The buffer pointer passed to `body` (as well as any pointers to elements in
 /// the buffer) must not escape. It will be deallocated when `body` returns and
 /// cannot be used afterward.
@@ -367,10 +363,6 @@ public func _withUnprotectedUnsafeTemporaryAllocation<R: ~Copyable, E: Error>(
 /// in an unspecified, uninitialized state. `body` is responsible for
 /// initializing the buffer pointer before it is used _and_ for deinitializing
 /// it before returning, but deallocation is automatic.
-///
-/// The implementation may allocate a larger buffer pointer than is strictly
-/// necessary to contain `capacity` values of type `type`. The behavior of a
-/// program that attempts to access any such additional storage is undefined.
 ///
 /// The buffer pointer passed to `body` (as well as any pointers to elements in
 /// the buffer) must not escape. It will be deallocated when `body` returns and


### PR DESCRIPTION
The markup for the two overloads of `withUnsafeTemporaryAllocation()` states:

> The implementation may allocate a larger buffer pointer than is strictly
> necessary to contain `capacity` values of type `type`. The behavior of a
> program that attempts to access any such additional storage is undefined.

This text is meant to indicate that the compiler, runtime, OS, etc. are free to allocate a larger buffer, which may occur e.g. if you ask for 1 byte and the generated assembly pushes `SP` up by 4/8 instead, or if you ask for 1025 bytes and the OS's `malloc()` gives you a 4KB/16KB page back. It does not imply that the buffer created and passed to `body` has a bad `count` value or is otherwise unsound.

This text has proven confusing as it sounds scarier than it is meant to be. It is just meant to document that the system can and does overallocate. I'm just going to remove it; there is no way for a well-formed program to access any such excess bytes, and this API is already marked unsafe so if you decide to read off the end of the buffer, you've sealed your own fate anyway.