### PR TITLE
Runtimes: add vendor extension point for shims

### DIFF
--- a/Runtimes/Core/SwiftShims/swift/shims/CMakeLists.txt
+++ b/Runtimes/Core/SwiftShims/swift/shims/CMakeLists.txt
@@ -43,3 +43,5 @@ target_compile_options(swiftShims INTERFACE
 install(TARGETS swiftShims
   EXPORT SwiftCoreTargets
   COMPONENT SwiftCore_development)
+
+include("${SwiftCore_VENDOR_MODULE_DIR}/swiftShims.cmake" OPTIONAL)


### PR DESCRIPTION
This will make it slightly easier to install additional files compared to using the existing `swiftCore.cmake` since `CMAKE_CURRENT_SOURCE_DIR` will be set to the correct value (that is, the `shims` folder).

Supports rdar://177631069