### PR TITLE
utils: stage mimalloc to NoAsserts toolchain as well

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -3463,10 +3463,18 @@ function Build-mimalloc() {
 
   $HostSuffix = if ($Platform -eq $KnownPlatforms["WindowsX64"]) { "" } else { "-arm64" }
 
-  foreach ($item in "mimalloc.dll", "mimalloc-redirect$HostSuffix.dll") {
-    Copy-Item `
-      -Path "$BinaryCache\$($Platform.Triple)\mimalloc\bin\$item" `
-      -Destination "$($Platform.ToolchainInstallRoot)\usr\bin\"
+  $ToolchainRoots = @($Platform.ToolchainInstallRoot)
+  if ($IncludeNoAsserts) {
+    $ToolchainRoots += $Platform.NoAssertsToolchainInstallRoot
+  }
+
+  foreach ($ToolchainRoot in $ToolchainRoots) {
+    New-Item -ItemType Directory -Force "$ToolchainRoot\usr\bin" | Out-Null
+    foreach ($item in "mimalloc.dll", "mimalloc-redirect$HostSuffix.dll") {
+      Copy-Item -Force `
+        -Path "$BinaryCache\$($Platform.Triple)\mimalloc\bin\$item" `
+        -Destination "$ToolchainRoot\usr\bin\"
+    }
   }
 }
 


### PR DESCRIPTION
When cross-compiling the NoAsserts toolchain, we would no copy the mimalloc into the staged NoAsserts toolchain. This would break the packaging as that expects to find the dependency for distribution.