### PR TITLE
[DebugInfo] Use debug blocks in PhiExpansion rather than fragments

### DIFF
--- a/include/swift/SIL/DebugUtils.h
+++ b/include/swift/SIL/DebugUtils.h
@@ -420,6 +420,23 @@ struct DebugVarCarryingInst : VarDeclCarryingInst {
     llvm_unreachable("covered switch");
   }
 
+  /// Like getVarInfo, but always includes the variable type.
+  /// For DebugValueInst, delegates to its getCompleteVarInfo().
+  /// For AllocStack/AllocBox, fills in the type from the element/address type.
+  std::optional<SILDebugVariable> getCompleteVarInfo() const {
+    switch (getKind()) {
+    case Kind::Invalid:
+      llvm_unreachable("Invalid?!");
+    case Kind::DebugValue:
+      return cast<DebugValueInst>(**this)->getCompleteVarInfo();
+    case Kind::AllocStack:
+      return cast<AllocStackInst>(**this)->getVarInfo(/*complete*/ true);
+    case Kind::AllocBox:
+      return cast<AllocBoxInst>(**this)->getVarInfo(/*complete*/ true);
+    }
+    llvm_unreachable("covered switch");
+  }
+
   void setDebugVarScope(const SILDebugScope *NewDS) {
     switch (getKind()) {
     case Kind::Invalid:

--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -281,6 +281,8 @@ public:
   /// If we have a SILFunction, return SILFunction::hasOwnership(). If we have a
   /// SILGlobalVariable, just return false.
   bool hasOwnership() const {
+    if (BB && BB->isDebugReconstructionBlock())
+      return false;
     if (F)
       return F->hasOwnership();
     return false;
@@ -800,7 +802,7 @@ public:
   LoadInst *createLoad(SILLocation Loc, SILValue LV,
                        LoadOwnershipQualifier Qualifier) {
     ASSERT((Qualifier != LoadOwnershipQualifier::Unqualified) ||
-           !hasOwnership() || (BB && BB->isDebugReconstructionBlock()) &&
+           !hasOwnership() &&
            "Unqualified inst in qualified function");
     ASSERT((Qualifier == LoadOwnershipQualifier::Unqualified) ||
            hasOwnership() && "Qualified inst in unqualified function");

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -5665,6 +5665,12 @@ public:
     return getLoc().strippedForDebugVariable();
   }
 
+  /// Returns the effective variable type for this debug value.
+  /// If there is a stored type, returns that. If there is a debug
+  /// reconstruction block, returns its return type. Otherwise returns the
+  /// SSA operand type.
+  SILType getVarType() const;
+
   /// Return the debug variable information attached to this instruction.
   ///
   /// \param includeLoc If true (by default), always return a variable with
@@ -5687,7 +5693,7 @@ public:
     if (HasAuxDebugVariableType)
       AuxVarType = *getTrailingObjects<SILType>();
     else if (includeType)
-      AuxVarType = getOperand()->getType().getObjectType();
+      AuxVarType = getVarType();
 
     if (hasAuxDebugLocation())
       VarDeclLoc = *getTrailingObjects<SILLocation>();

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -6217,9 +6217,8 @@ void IRGenSILFunction::visitDebugValueInst(DebugValueInst *i) {
   if (i->getDebugScope()->getInlinedFunction()->isTransparent())
     return;
 
-  auto VarInfo = i->getVarInfo();
-  assert(VarInfo && "debug_value without debug info");
-  if (isa<SILUndef>(SILVal) && VarInfo->Name == "$error") {
+  auto VarInfo = i->getCompleteVarInfo();
+  if (isa<SILUndef>(SILVal) && VarInfo.Name == "$error") {
     // We cannot track the location of inlined error arguments because it has no
     // representation in SIL.
     if (!IsAddrVal && !i->getDebugScope()->InlinedCallSite) {
@@ -6235,15 +6234,9 @@ void IRGenSILFunction::visitDebugValueInst(DebugValueInst *i) {
   bool IsInCoro = InCoroContext(*CurSILFn, *i);
 
   bool IsAnonymous = false;
-  VarInfo->Name = getVarName(i, IsAnonymous);
+  VarInfo.Name = getVarName(i, IsAnonymous);
   DebugTypeInfo DbgTy;
-  SILType SILTy;
-  if (auto MaybeSILTy = VarInfo->Type) {
-    // If there is auxiliary type info, use it
-    SILTy = *MaybeSILTy;
-  } else {
-    SILTy = SILVal->getType();
-  }
+  SILType SILTy = *VarInfo.Type;
 
   auto RealTy = SILTy.getASTType();
   VarDecl *VD = i->getDecl();
@@ -6251,13 +6244,13 @@ void IRGenSILFunction::visitDebugValueInst(DebugValueInst *i) {
     // The source location of a DebugValueInst inserted by the SIL optimizer is
     // not necessarily the VarDecl, as it can be the source location of the
     // update point this DebugValueInst represents.
-    VD = VarInfo->getDecl();
+    VD = VarInfo.getDecl();
   }
   // Figure out the debug variable type
   if (VD) {
     DbgTy = DebugTypeInfo::getLocalVariable(VD, RealTy, getTypeInfo(SILTy),
                                             IGM);
-  } else if (!SILTy.hasArchetype() && !VarInfo->Name.empty()) {
+  } else if (!SILTy.hasArchetype() && !VarInfo.Name.empty()) {
     // Handle the cases that read from a SIL file
     DbgTy = DebugTypeInfo::getFromTypeInfo(RealTy, getTypeInfo(SILTy), IGM);
   } else
@@ -6319,13 +6312,13 @@ void IRGenSILFunction::visitDebugValueInst(DebugValueInst *i) {
     auto Addr = getLoweredValue(SILVal).getAddressOfBox();
     auto *Storage = Addr.getAddress();
 
-    VarInfo->DIExpr.prependElements(
+    VarInfo.DIExpr.prependElements(
         {SILDIExprElement::createOperator(SILDIExprOperator::Dereference)});
 
     Copy.emplace_back(emitShadowCopyIfNeeded(
         Storage, TI.getStorageType(),
-        i->getDebugScope(), *VarInfo, IsAnonymous,
-        i->usesMoveableValueDebugInfo(), &VarInfo->DIExpr));
+        i->getDebugScope(), VarInfo, IsAnonymous,
+        i->usesMoveableValueDebugInfo(), &VarInfo.DIExpr));
   } else if (IsAddrVal) {
     auto &TI = getTypeInfo(SILVal->getType());
     auto Addr = getLoweredAddress(SILVal);
@@ -6333,12 +6326,12 @@ void IRGenSILFunction::visitDebugValueInst(DebugValueInst *i) {
 
     Copy.emplace_back(emitShadowCopyIfNeeded(
         Storage, TI.getStorageType(),
-        i->getDebugScope(), *VarInfo, IsAnonymous,
-        i->usesMoveableValueDebugInfo(), &VarInfo->DIExpr));
+        i->getDebugScope(), VarInfo, IsAnonymous,
+        i->usesMoveableValueDebugInfo(), &VarInfo.DIExpr));
   } else {
-    emitShadowCopyIfNeeded(SILVal, i->getDebugScope(), *VarInfo, IsAnonymous,
+    emitShadowCopyIfNeeded(SILVal, i->getDebugScope(), VarInfo, IsAnonymous,
                            i->usesMoveableValueDebugInfo(), Copy,
-                           &VarInfo->DIExpr);
+                           &VarInfo.DIExpr);
   }
 
   bindArchetypes(DbgTy.getType());
@@ -6346,7 +6339,7 @@ void IRGenSILFunction::visitDebugValueInst(DebugValueInst *i) {
     return;
 
   emitDebugVariableDeclaration(
-      Copy, DbgTy, SILTy, i->getDebugScope(), i->getLoc(), *VarInfo,
+      Copy, DbgTy, SILTy, i->getDebugScope(), i->getLoc(), VarInfo,
       IsInCoro, AddrDbgInstrKind(i->usesMoveableValueDebugInfo()));
 
   // Erase any LLVM instructions emitted by the debug BB. They were only needed

--- a/lib/SIL/IR/SILInstructions.cpp
+++ b/lib/SIL/IR/SILInstructions.cpp
@@ -533,6 +533,15 @@ SILBasicBlock *DebugValueInst::getOrCreateDebugReconstructionBlock() {
   return block;
 }
 
+SILType DebugValueInst::getVarType() const {
+  if (HasAuxDebugVariableType)
+    return *getTrailingObjects<SILType>();
+  if (auto *debugBB = getDebugReconstructionBlock())
+    return cast<ReturnInst>(debugBB->getTerminator())
+        ->getOperand()->getType().getObjectType();
+  return getOperand()->getType().getObjectType();
+}
+
 bool DebugValueInst::isExprTypeValid() const {
   auto varInfo = getCompleteVarInfo();
 

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -1806,28 +1806,12 @@ public:
   void checkDebugVariable(SILInstruction *inst) {
     std::optional<SILDebugVariable> varInfo;
     if (auto di = DebugVarCarryingInst(inst))
-      varInfo = di.getVarInfo();
+      varInfo = di.getCompleteVarInfo();
 
     if (!varInfo)
       return;
 
-    // Retrieve debug variable type
-    SILType SSAType;
-    switch (inst->getKind()) {
-    case SILInstructionKind::AllocStackInst:
-    case SILInstructionKind::AllocBoxInst:
-      // TODO: unwrap box for AllocBox
-      SSAType = inst->getResult(0)->getType().getObjectType();
-      break;
-    case SILInstructionKind::DebugValueInst:
-      SSAType = inst->getOperand(0)->getType();
-      break;
-    default:
-      llvm_unreachable("impossible instruction kind");
-    }
-    
-    SILType DebugVarTy = varInfo->Type ? *varInfo->Type :
-      SSAType.getObjectType();
+    SILType DebugVarTy = *varInfo->Type;
 
     auto *debugScope = inst->getDebugScope();
     if (varInfo->ArgNo)

--- a/lib/SILOptimizer/Transforms/PhiArgumentOptimizations.cpp
+++ b/lib/SILOptimizer/Transforms/PhiArgumentOptimizations.cpp
@@ -408,14 +408,33 @@ bool PhiExpansionPass::optimizeArg(SILPhiArgument *initialArg) {
     }
   
     for (DebugValueInst *dvi : debugValueUsers) {
-      // Recreate the debug_value with a fragment.
-      SILBuilder B(dvi, dvi->getDebugScope());
-      SILDebugVariable var = *dvi->getVarInfo();
-      if (!var.Type)
-        var.Type = initialArg->getType();
-      var.DIExpr.append(SILDebugInfoExpression::createFragment(field));
-      B.createDebugValue(dvi->getLoc(), dvi->getOperand(), var);
-      dvi->eraseFromParent();
+      // Build a debug reconstruction block that rebuilds the struct from
+      // the single known field, using undef for the remaining fields.
+      SILBasicBlock *debugBB = dvi->getOrCreateDebugReconstructionBlock();
+      SILType structType = initialArg->getType();
+      StructDecl *structDecl = structType.getStructOrBoundGenericStruct();
+      SILFunction *fn = dvi->getFunction();
+
+      // Create the struct with all-undef operands first.
+      unsigned fieldIdx = 0;
+      SmallVector<SILValue, 4> structFields;
+      for (VarDecl *FD : structDecl->getStoredProperties()) {
+        if (FD == field)
+          fieldIdx = structFields.size();
+        SILType fieldTy = structType.getFieldType(FD, fn);
+        structFields.push_back(SILUndef::get(fn, fieldTy));
+      }
+
+      StructInst *structVal =
+          SILBuilder(&debugBB->front())
+              .createStruct(dvi->getLoc(), structType, structFields);
+
+      // Replace the known field operand with the new phi argument.
+      SILArgument *oldArg = debugBB->getArgument(0);
+      oldArg->replaceAllUsesWith(structVal);
+      SILPhiArgument *newArg = debugBB->replacePhiArgument(
+          0, newType, OwnershipKind::None);
+      structVal->setOperand(fieldIdx, newArg);
     }
     for (StructExtractInst *sei : structExtractUsers) {
       sei->replaceAllUsesWith(sei->getOperand());

--- a/test/DebugInfo/phi-expansion.sil
+++ b/test/DebugInfo/phi-expansion.sil
@@ -12,7 +12,11 @@ struct Mystruct {
 // CHECK-LABEL: sil @test_simple
 // CHECK:   br bb3(%{{[0-9]*}} : $Int)
 // CHECK: bb3(%[[PHI:[0-9]*]] : $Int):
-// CHECK:   debug_value %[[PHI]] : $Int, let, name "pos", type $Mystruct, expr op_fragment:#Mystruct.i
+// CHECK:   debug_value %[[PHI]] : $Int, let, name "pos", transform {
+// CHECK:     bb0(%[[BBARG:[0-9]*]] : $Int):
+// CHECK:       %[[STRUCT:[0-9]*]] = struct $Mystruct (%[[BBARG]] : $Int, undef : $Int)
+// CHECK:       return %[[STRUCT]] : $Mystruct
+// CHECK:   }
 // CHECK: } // end sil function 'test_simple'
 
 sil @test_simple : $@convention(thin) (Mystruct, Mystruct) -> Int {


### PR DESCRIPTION
Includes #89470 

When a struct is unwrapped in a phi node, only one field value can be salvaged at that point. Rather than using a fragment to express that, use a debug reconstruction basic block that sets all other fields to undef, which is an equivalent representation that supports existing debug reconstruction blocks.
