### PR TITLE
[ModuleInterface] Desugar implicit typealiases to generic params with module selectors

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -6821,7 +6821,16 @@ public:
   }
 
   bool shouldDesugarTypeAliasType(TypeAliasType *T) {
-    return Options.PrintForSIL || Options.PrintTypeAliasUnderlyingType;
+    if (Options.PrintForSIL || Options.PrintTypeAliasUnderlyingType)
+      return true;
+
+    if (Options.UseModuleSelectors) {
+      if (T->getDecl()->isImplicit() &&
+          T->getSinglyDesugaredType()->is<GenericTypeParamType>())
+        return true;
+    }
+
+    return false;
   }
 
   void visitTypeAliasType(TypeAliasType *T,

--- a/test/ModuleInterface/module_selector.swift
+++ b/test/ModuleInterface/module_selector.swift
@@ -282,6 +282,27 @@ public protocol AssociatedType3Protocol {
   associatedtype AssociatedType4
 }
 
+// CHECK-LABEL: struct PriorityQueue
+public struct PriorityQueue<Element: Comparable> {
+  // CHECK-LABEL: struct Iterator
+  public struct Iterator: IteratorProtocol {
+    // CHECK: var _queue:
+    // CHECK-ENABLED-SAME: TestCase::PriorityQueue<Element>
+    // CHECK-DISABLED-SAME: TestCase.PriorityQueue<Element>
+    // CHECK-PRESERVE-SAME: PriorityQueue<Element>
+    // CHECK-ALIAS-SAME: Module___TestCase.PriorityQueue<Element>
+    public var _queue: PriorityQueue<Element>
+
+    public mutating func next() -> Element? {
+      return nil
+    }
+  }
+
+  public func makeIterator() -> Iterator {
+    return Iterator(_queue: self)
+  }
+}
+
 // DIAG-PRESERVE-OVERRIDDEN: warning: ignoring '-module-interface-preserve-types-as-written'; this option has been obsoleted by module selectors (add '-disable-module-selectors-in-module-interface' to restore original behavior)
 // DIAG-PRESERVE-NOT-OVERRIDDEN-NOT: warning: ignoring '-module-interface-preserve-types-as-written'; this option has been obsoleted by module selectors (add '-disable-module-selectors-in-module-interface' to restore original behavior)
 


### PR DESCRIPTION
When printing a .swiftinterface with module selectors enabled, an implicit typealias whose underlying type is a GenericTypeParamType was being printed with a fully-qualified parent path and module selectors on each component, producing uncompilable interfaces.

Desugar these typealiases so the printer visits the underlying generic parameter directly. This is also the behavior when module selector is disabled and a dot qualifier is used.

rdar://173639093

