### PR TITLE
[6.4.x] Implement withContiguousStorageIfAvailable for EmptyCollection and CollectionOfOne

### DIFF
--- a/stdlib/public/core/CollectionOfOne.swift
+++ b/stdlib/public/core/CollectionOfOne.swift
@@ -159,6 +159,17 @@ extension CollectionOfOne: RandomAccessCollection, MutableCollection {
   }
 }
 
+extension CollectionOfOne {
+  @_alwaysEmitIntoClient
+  public func withContiguousStorageIfAvailable<R: ~Copyable, E: Error>(
+    _ body: (UnsafeBufferPointer<Element>) throws(E) -> R
+  ) throws(E) -> R? {
+    try withUnsafePointer(to: _element) { pointer throws(E) -> R in
+      try unsafe body(UnsafeBufferPointer(start: pointer, count: 1))
+    }
+  }
+}
+
 @available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension CollectionOfOne {

--- a/stdlib/public/core/EmptyCollection.swift
+++ b/stdlib/public/core/EmptyCollection.swift
@@ -164,6 +164,15 @@ extension EmptyCollection: RandomAccessCollection, MutableCollection {
   }
 }
 
+extension EmptyCollection {
+  @_alwaysEmitIntoClient
+  public func withContiguousStorageIfAvailable<R: ~Copyable, E: Error>(
+    _ body: (UnsafeBufferPointer<Element>) throws(E) -> R
+  ) throws(E) -> R? {
+    unsafe try body(UnsafeBufferPointer<Element>(start: nil, count: 0))
+  }
+}
+
 extension EmptyCollection: Equatable {
   @inlinable // trivial-implementation
   public static func == (

--- a/test/stdlib/CollectionOfOne.swift
+++ b/test/stdlib/CollectionOfOne.swift
@@ -30,4 +30,16 @@ if #available(SwiftStdlib 6.4, *) {
   }
 }
 
+OneTests.test("withContigousStorageIfAvailable")
+.require(.stdlib_6_4).code {
+
+  struct W: ~Copyable { let i: Int }
+
+  let one = CollectionOfOne(42)
+  let wrapped = one.withContiguousStorageIfAvailable({ W(i: $0.count + $0[0]) })
+  if let count = expectNotNil(wrapped) {
+    expectEqual(43, count.i)
+  }
+}
+
 runAllTests()

--- a/test/stdlib/EmptyCollection.swift
+++ b/test/stdlib/EmptyCollection.swift
@@ -26,5 +26,16 @@ if #available(SwiftStdlib 6.4, *) {
   }
 }
 
-runAllTests()
+testSuite.test("withContigousStorageIfAvailable")
+.require(.stdlib_6_4).code {
 
+  struct W: ~Copyable { let i: Int }
+
+  let zero = EmptyCollection<Int>()
+  let wrapped = zero.withContiguousStorageIfAvailable({ W(i: $0.count) })
+  if let count = expectNotNil(wrapped) {
+    expectEqual(0, count.i)
+  }
+}
+
+runAllTests()


### PR DESCRIPTION
- **Explanation**: Implements `withContiguousStorageIfAvailable` for `EmptyCollection` and `CollectionOfOne`
  <!--
  A description of the changes. This can be brief, but it should be clear.
  -->
- **Scope**: Minimal - only changes these two types and provides an implementation that overrides the default implementation for an already-existing API
  <!--
  An assessment of the impact and importance of the changes. For example, can
  the changes break existing code?
  -->
- **Issues**: N/A
  <!--
  References to issues the changes resolve, if any.
  -->
- **Original PRs**: https://github.com/swiftlang/swift/pull/89231
  <!--
  Links to mainline branch pull requests in which the changes originated.
  -->
- **Risk**: Low - the fix is small and straightforward, scope is limited
  <!--
  The (specific) risk to the release for taking the changes.
  -->
- **Testing**: Added additional unit tests that pass in CI
  <!--
  The specific testing that has been done or needs to be done to further
  validate any impact of the changes.
  -->
- **Reviewers**: @glessard @Azoy 
  <!--
  The code owners that GitHub-approved the original changes in the mainline
  branch pull requests. If an original change has not been GitHub-approved by
  a respective code owner, provide a reason. Technical review can be delegated
  by a code owner or otherwise requested as deemed appropriate or useful.
  -->
