### PR TITLE
[ClangImporter] Import C++ subscript overloads in stable order

### DIFF
--- a/lib/ClangImporter/ClangLookup.cpp
+++ b/lib/ClangImporter/ClangLookup.cpp
@@ -53,6 +53,7 @@
 #include "clang/Sema/Sema.h"
 #include "clang/Serialization/ASTReader.h"
 #include "clang/Serialization/ASTWriter.h"
+#include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/iterator_range.h"
@@ -826,8 +827,8 @@ ClangImporter::Implementation::lookupAndImportSubscripts(
       SwiftContext.evaluator, ForeignReferenceTypeInfoRequest({CXXRecord}), {});
   auto superclassClangDecl = frtInfo.getPrimarySuperclass();
 
-  llvm::SmallDenseMap<CXXOverloadArgTypes, std::pair<CXXOverload, CXXOverload>,
-                      1>
+  llvm::SmallMapVector<CXXOverloadArgTypes,
+                       std::pair<CXXOverload, CXXOverload>, 1>
       CXXSubscripts;
 
   auto overloads =
@@ -856,7 +857,8 @@ ClangImporter::Implementation::lookupAndImportSubscripts(
   }
 
   llvm::SmallVector<SubscriptDecl *, 1> subscripts;
-  for (auto [CXXGetter, CXXSetter] : CXXSubscripts.values()) {
+  for (auto &[_, pair] : CXXSubscripts) {
+    auto [CXXGetter, CXXSetter] = pair;
     ASSERT((CXXGetter || CXXSetter) &&
            "subscript should have at least getter or setter");
 


### PR DESCRIPTION
`lookupAndImportSubscripts` grouped operator[] overloads in a SmallDenseMap keyed by CXXOverloadArgTypes, whose hash is built from clang::QualType opaque pointers. ASLR makes those pointer values vary across runs, so iteration order over the map varies too — and that order determined the order of subscripts added to the imported Swift struct. Downstream, that fed the constraint solver's overload set in varying order; for cases with multiple equally-ranked viable candidates, *which one wins* could change run-to-run.

Switch to SmallMapVector so iteration follows insertion order. The hash-keyed lookup that groups same-arg-type getters/setters is preserved; only iteration becomes deterministic.

Concrete repro: typechecking
test/Interop/Cxx/operators/subscript-overloads-typechecker.swift 20 times produced 3 distinct outputs before this change and 1 afterwards.