### PR TITLE
🍒 [6.4] [cxx-interop] Fix crash when specializing a templated SubscriptDecl

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -7363,19 +7363,17 @@ ClangImporter::instantiateCXXClassTemplate(
 // "long long" and then back into Swift as "Int64" not "Int."
 static ValueDecl *rewriteIntegerTypes(SubstitutionMap subst, ValueDecl *oldDecl,
                                       AbstractFunctionDecl *newDecl) {
-  auto originalFnSubst = cast<AbstractFunctionDecl>(oldDecl)
-                             ->getInterfaceType()
+  auto originalFnSubst = oldDecl->getInterfaceType()
                              ->getAs<GenericFunctionType>()
                              ->substGenericArgs(subst);
-  // The constructor type is a function type as follows:
-  //   (CType.Type) -> (Generic) -> CType
-  // And a method's function type is as follows:
-  //   (inout CType) -> (Generic) -> Void
-  // In either case, we only want the result of that function type because that
-  // is the function type with the generic params that need to be substituted:
-  //   (Generic) -> CType
-  if (isa<ConstructorDecl>(oldDecl) || oldDecl->isInstanceMember() ||
-      oldDecl->isStatic())
+  // AbstractFunctionDecl interface types with an implicit self are curried as:
+  //   (Self[.Type]) -> (Generic) -> Result
+  // Strip the outer self arrow to get the (Generic) -> Result layer, which is
+  // what the rest of this function compares against newDecl's parameters.
+  // SubscriptDecl interface types are not curried this way (they are already
+  // (Generic) -> Element; see InterfaceTypeRequest::evaluate).
+  if (auto *afd = dyn_cast<AbstractFunctionDecl>(oldDecl);
+      afd && afd->hasImplicitSelfDecl())
     originalFnSubst = cast<FunctionType>(originalFnSubst->getResult().getPointer());
 
   SmallVector<ParamDecl *, 4> fixedParameters;

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -7363,18 +7363,18 @@ ClangImporter::instantiateCXXClassTemplate(
 // "long long" and then back into Swift as "Int64" not "Int."
 static ValueDecl *rewriteIntegerTypes(SubstitutionMap subst, ValueDecl *oldDecl,
                                       AbstractFunctionDecl *newDecl) {
-  auto originalFnSubst = oldDecl->getInterfaceType()
-                             ->getAs<GenericFunctionType>()
-                             ->substGenericArgs(subst);
+  auto *originalFnSubst = oldDecl->getInterfaceType()
+                              ->castTo<GenericFunctionType>()
+                              ->substGenericArgs(subst);
   // AbstractFunctionDecl interface types with an implicit self are curried as:
   //   (Self[.Type]) -> (Generic) -> Result
   // Strip the outer self arrow to get the (Generic) -> Result layer, which is
   // what the rest of this function compares against newDecl's parameters.
-  // SubscriptDecl interface types are not curried this way (they are already
-  // (Generic) -> Element; see InterfaceTypeRequest::evaluate).
+  // This mirrors what AbstractFunctionDecl::getMethodInterfaceType() does, but
+  // on the result of substituting into the generic interface type.
   if (auto *afd = dyn_cast<AbstractFunctionDecl>(oldDecl);
-      afd && afd->hasImplicitSelfDecl())
-    originalFnSubst = cast<FunctionType>(originalFnSubst->getResult().getPointer());
+      afd && afd->getDeclContext()->isTypeContext())
+    originalFnSubst = originalFnSubst->getResult()->castTo<FunctionType>();
 
   SmallVector<ParamDecl *, 4> fixedParameters;
   unsigned parameterIndex = 0;

--- a/test/Interop/Cxx/operators/Inputs/module.modulemap
+++ b/test/Interop/Cxx/operators/Inputs/module.modulemap
@@ -27,3 +27,8 @@ module PointeeOverloads {
   header "pointee-overloads.h"
   requires cplusplus
 }
+
+module SubscriptOverloads {
+  header "subscript-overloads.h"
+  requires cplusplus
+}

--- a/test/Interop/Cxx/operators/Inputs/subscript-overloads.h
+++ b/test/Interop/Cxx/operators/Inputs/subscript-overloads.h
@@ -1,0 +1,12 @@
+#pragma once
+
+struct TemplatedReturningInt {
+    int data[4] = {};
+    template<typename I> int &operator[](I index) { return data[index]; }
+};
+
+struct TemplatedTakingInt {
+    int data[4] = {};
+    // This template doesn't instantiate unless I is int. Bogus but valid.
+    template<typename I> I &operator[](int x) { return data[x]; }
+};

--- a/test/Interop/Cxx/operators/subscript-overloads-typechecker.swift
+++ b/test/Interop/Cxx/operators/subscript-overloads-typechecker.swift
@@ -1,0 +1,15 @@
+// RUN: %target-typecheck-verify-swift -suppress-notes -I %S/Inputs -cxx-interoperability-mode=default
+
+// In this release, the templated `operator[]` is not usable because it is given
+// the wrong availability message, but should not cause a compiler crash like it
+// did before. This test checks against that.
+
+import SubscriptOverloads
+
+var tri = TemplatedReturningInt()
+tri[CInt(0)] = CInt(4) // expected-error {{'__operatorSubscript' is unavailable: use subscript}}
+let _ = tri[CInt(0)] // expected-error {{'__operatorSubscript' is unavailable: use subscript}}
+
+var tti = TemplatedTakingInt()
+tti[CInt(0)] = CInt(4) // expected-error {{'__operatorSubscript' is unavailable: use subscript}}
+let _: CInt = tti[CInt(0)] // expected-error {{'__operatorSubscript' is unavailable: use subscript}}


### PR DESCRIPTION
- **Explanation**: SubscriptDecl interface types are not curried the same way as templated methods, and our improper handling of such types caused a compiler crash. This patch tightens what we check to detect that kind of method type currying, to avoid the crash.
- **Scope**: This only affects our importing of templated `operator[]`, which is not even fully supported in this release. Nonetheless, this fixes a crash and makes sure the compiler terminates gracefully.
- **Issues**: rdar://177482177
- **Original PRs**: https://github.com/swiftlang/swift/pull/89276
- **Risk**: Very low. The change itself tightens the condition for detecting curried interface types to what it should have been all along.
- **Testing**: Added a new test to cover this case.
- **Reviewers**: @Xazax-hun @egorzhdan 