### PR TITLE
Remove a few usages of ExistentialLayout::getSuperclass()

### DIFF
--- a/include/swift/AST/ExistentialLayout.h
+++ b/include/swift/AST/ExistentialLayout.h
@@ -89,7 +89,15 @@ struct ExistentialLayout {
   /// Returns the existential's superclass, if any; this is either an explicit
   /// superclass term in a composition type, or the superclass of one of the
   /// protocols.
-  Type getSuperclass() const;
+  ///
+  /// FIXME: This is bogus if the protocol has a superclass that involves an
+  /// associated type, because the superclass type is unsubstituted in
+  /// the protocol case (it can't be substituted with anything, except
+  /// perhaps an existential archetype), but the caller has no way to tell.
+  ///
+  /// Do not introduce new uses of this function! It's awkwardly named on
+  /// purpose.
+  Type getExplicitSuperclassOrProtocolSuperclass() const;
 
   /// Does this existential contain the Error protocol?
   bool isExistentialWithError(ASTContext &ctx) const;

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -6336,7 +6336,9 @@ GenericEnvironment::forOpenedExistential(
   auto layout = existential->getExistentialLayout();
   auto properties = ArchetypeType::archetypeProperties(
       RecursiveTypeProperties::HasOpenedExistential,
-      layout.getProtocols(), layout.getSuperclass(), subs);
+      layout.getProtocols(),
+      layout.getExplicitSuperclassOrProtocolSuperclass(),
+      subs);
 
   auto arena = getArena(properties);
 

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -1780,7 +1780,7 @@ public:
           }
         }
         
-        auto superclass = erasedLayout.getSuperclass();
+        auto superclass = erasedLayout.explicitSuperclass;
         if (superclass
             && !superclass->isExactSuperclassOf(concreteTy)) {
           Out << "ErasureExpr from class to existential with a superclass "

--- a/lib/AST/ClangTypeConverter.cpp
+++ b/lib/AST/ClangTypeConverter.cpp
@@ -749,7 +749,7 @@ ClangTypeConverter::visitProtocolCompositionType(ProtocolCompositionType *type) 
     return getClangIdType(ClangASTContext);
 
   auto superclassTy = clangCtx.ObjCBuiltinIdTy;
-  if (auto layoutSuperclassTy = layout.getSuperclass()) {
+  if (auto layoutSuperclassTy = layout.getExplicitSuperclassOrProtocolSuperclass()) {
     auto clangTy = convert(layoutSuperclassTy);
     if (clangTy.isNull())
       return clang::QualType();

--- a/lib/AST/ConformanceLookup.cpp
+++ b/lib/AST/ConformanceLookup.cpp
@@ -114,7 +114,12 @@ swift::lookupExistentialConformance(Type type, ProtocolDecl *protocol) {
       auto layout = type->getExistentialLayout();
       if (llvm::all_of(layout.getProtocols(),
                        [](const auto *P) { return P->isMarkerProtocol(); })) {
-        if (auto conformance = lookupSuperclassConformance(layout.explicitSuperclass)) {
+        // Since we know we have a marker protocol or something similar at
+        // point, this usage of getExplicitSuperclassOrProtocolSuperclass()
+        // is _probably_ OK. However, we should still clean it up. See the
+        // comment on that getter method.
+        if (auto conformance = lookupSuperclassConformance(
+            layout.getExplicitSuperclassOrProtocolSuperclass())) {
           return ProtocolConformanceRef(
               ctx.getInheritedConformance(type, conformance.getConcrete()));
         }
@@ -154,7 +159,8 @@ swift::lookupExistentialConformance(Type type, ProtocolDecl *protocol) {
 
   // If the existential is class-constrained, the class might conform
   // concretely.
-  if (auto conformance = lookupSuperclassConformance(layout.getSuperclass()))
+  if (auto conformance = lookupSuperclassConformance(
+        layout.getExplicitSuperclassOrProtocolSuperclass()))
     return conformance;
 
   // If the protocol is SendableMetatype, and there are no non-marker protocol

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -10143,7 +10143,7 @@ SubscriptDecl::getDynamicMemberParamTypeAsKeyPathType(Type paramTy) {
       return nullptr;
     }
 
-    paramTy = layout.getSuperclass();
+    paramTy = layout.explicitSuperclass;
     if (!paramTy) {
       return nullptr;
     }

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -426,7 +426,7 @@ bool ExistentialLayout::requiresClass() const {
   return false;
 }
 
-Type ExistentialLayout::getSuperclass() const {
+Type ExistentialLayout::getExplicitSuperclassOrProtocolSuperclass() const {
   if (explicitSuperclass)
     return explicitSuperclass;
 
@@ -495,7 +495,7 @@ NominalTypeDecl *TypeBase::getAnyActor() {
   // Existential types: check for Actor protocol.
   if (isExistentialType()) {
     auto layout = getExistentialLayout();
-    if (auto superclass = layout.getSuperclass()) {
+    if (auto superclass = layout.getExplicitSuperclassOrProtocolSuperclass()) {
       if (auto actor = superclass->getAnyActor())
         return actor;
     }
@@ -2456,8 +2456,10 @@ Type TypeBase::getSuperclass(bool useArchetypes) {
     if (auto dynamicSelfTy = getAs<DynamicSelfType>())
       return dynamicSelfTy->getSelfType();
 
-    if (isExistentialType())
-      return getExistentialLayout().getSuperclass();
+    if (isExistentialType()) {
+    // FIXME: This is broken, see the comment on that getter method.
+      return getExistentialLayout().getExplicitSuperclassOrProtocolSuperclass();
+    }
 
     // No other types have superclasses.
     return Type();
@@ -4695,7 +4697,7 @@ ReferenceCounting TypeBase::getReferenceCounting() {
   case TypeKind::ProtocolComposition: {
     auto layout = type->getExistentialLayout();
     assert(layout.requiresClass() && "Opaque existentials don't use refcounting");
-    if (auto superclass = layout.getSuperclass())
+    if (auto superclass = layout.getExplicitSuperclassOrProtocolSuperclass())
       return superclass->getReferenceCounting();
     return ReferenceCounting::Unknown;
   }

--- a/lib/AST/TypeSubstitution.cpp
+++ b/lib/AST/TypeSubstitution.cpp
@@ -516,7 +516,8 @@ Type Type::subst(InFlightSubstitution &IFS) const {
 
 static Type getConcreteTypeForSuperclassTraversing(Type t) {
   if (t->isExistentialType()) {
-    return t->getExistentialLayout().getSuperclass();
+    // FIXME: This is broken, see the comment on that getter method.
+    return t->getExistentialLayout().getExplicitSuperclassOrProtocolSuperclass();
   } if (auto archetype = t->getAs<ArchetypeType>()) {
     return archetype->getSuperclass();
   } else if (auto dynamicSelfTy = t->getAs<DynamicSelfType>()) {

--- a/lib/IRGen/GenExistential.cpp
+++ b/lib/IRGen/GenExistential.cpp
@@ -1608,10 +1608,7 @@ static const TypeInfo *createExistentialTypeInfo(IRGenModule &IGM, CanType T) {
     ReferenceCounting refcounting = T->getReferenceCounting();
 
     llvm::PointerType *reprTy = nullptr;
-    if (auto superclass = layout.getSuperclass()) {
-      auto &superTI = IGM.getTypeInfoForUnlowered(superclass);
-      reprTy = cast<llvm::PointerType>(superTI.getStorageType());
-    } else if (refcounting == ReferenceCounting::Native) {
+    if (refcounting == ReferenceCounting::Native) {
       reprTy = IGM.RefCountedPtrTy;
     } else {
       reprTy = IGM.UnknownRefCountedPtrTy;

--- a/lib/PrintAsClang/PrintClangFunction.cpp
+++ b/lib/PrintAsClang/PrintClangFunction.cpp
@@ -289,7 +289,8 @@ public:
                        std::optional<OptionalTypeKind> optionalKind,
                        bool isInOutParam) {
     bool hasSwiftSuperClass = false;
-    if (auto superClass = ty->getExistentialLayout().getSuperclass()) {
+    if (auto superClass = ty->getExistentialLayout()
+          .getExplicitSuperclassOrProtocolSuperclass()) {
       auto *CD = superClass->getClassOrBoundGenericClass();
       hasSwiftSuperClass = !CD->isObjC();
     }

--- a/lib/SIL/IR/SILType.cpp
+++ b/lib/SIL/IR/SILType.cpp
@@ -311,38 +311,7 @@ static bool isSingleSwiftRefcounted(SILModule &M,
   if (isa<SILBoxType>(Ty))
     return true;
   
-  // Is the type a Swift-refcounted class?
-  // For a generic type, consider its superclass constraint, if any.
-  auto ClassTy = Ty;
-  if (auto archety = dyn_cast<ArchetypeType>(Ty)) {
-    if (auto superclass = Ty->getSuperclass()) {
-      ClassTy = superclass->getCanonicalType();
-    }
-  }
-  // For an existential type, consider its superclass constraint, if it carries
-  // no witness tables.
-  if (Ty->isAnyExistentialType()) {
-    auto layout = Ty->getExistentialLayout();
-    // Must be no protocol constraints that aren't @objc or @_marker.
-    if (layout.containsSwiftProtocol) {
-      return false;
-    }
-    
-    // The Error existential has its own special layout.
-    if (layout.isErrorExistential()) {
-      return false;
-    }
-    
-    // We can look at the superclass constraint, if any, to see if it's
-    // Swift-refcounted.
-    if (!layout.getSuperclass()) {
-      return false;
-    }
-    ClassTy = layout.getSuperclass()->getCanonicalType();
-  }
-  
-  // TODO: Does the base class we found have fully native Swift ancestry,
-  // so we can use Swift native refcounting on it?
+  // FIXME: Draw the rest of the horse.
   return false;
 }
 

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -5179,7 +5179,7 @@ public:
               "init_existential of class existential with non-class type");
     }
 
-    if (auto superclass = layout.getSuperclass()) {
+    if (auto superclass = layout.explicitSuperclass) {
       require(superclass->isExactSuperclassOf(concreteType),
               "init_existential of subclass existential with wrong type");
     }

--- a/lib/SILGen/SILGenBridging.cpp
+++ b/lib/SILGen/SILGenBridging.cpp
@@ -75,7 +75,7 @@ static bool shouldBridgeThroughError(SILGenModule &SGM, CanType type,
 
     // They're also convertible to Error if they have a class bound that
     // conforms to Error.
-    if (auto superclass = layout.getSuperclass()) {
+    if (auto superclass = layout.getExplicitSuperclassOrProtocolSuperclass()) {
       type = superclass->getCanonicalType();
 
     // Otherwise, they are not convertible to Error.

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -726,34 +726,6 @@ ManagedValue Transform::transform(ManagedValue v,
                                         ctxt);
   }
 
-  // - upcasting class-constrained existentials or metatypes thereof
-  if (inputSubstType->isAnyExistentialType()) {
-    auto instanceType = inputSubstType;
-    while (auto metatypeType = dyn_cast<ExistentialMetatypeType>(instanceType))
-      instanceType = metatypeType.getInstanceType();
-
-    auto layout = instanceType.getExistentialLayout();
-    if (layout.getSuperclass()) {
-      CanType openedType = ExistentialArchetypeType::getAny(inputSubstType)
-          ->getCanonicalType();
-      SILType loweredOpenedType = SGF.getLoweredType(openedType);
-
-      FormalEvaluationScope scope(SGF);
-
-      auto payload = SGF.emitOpenExistential(Loc, v,
-                                             loweredOpenedType,
-                                             AccessKind::Read);
-      payload = payload.ensurePlusOne(SGF, Loc);
-      return transform(payload,
-                       AbstractionPattern::getOpaque(),
-                       openedType,
-                       outputOrigType,
-                       outputSubstType,
-                       loweredResultTy,
-                       ctxt);
-    }
-  }
-
   // - T : Hashable to AnyHashable
   if (outputSubstType->isAnyHashable()) {
     auto *protocol = SGF.getASTContext().getProtocol(
@@ -765,6 +737,31 @@ ManagedValue Transform::transform(ManagedValue v,
     if (result.isInContext())
       return ManagedValue::forInContext();
     return std::move(result).getAsSingleValue(SGF, Loc);
+  }
+
+  // - upcasting class-constrained existentials or metatypes thereof
+  if (inputSubstType->isAnyExistentialType()) {
+    auto instanceType = inputSubstType;
+    while (auto metatypeType = dyn_cast<ExistentialMetatypeType>(instanceType))
+      instanceType = metatypeType.getInstanceType();
+
+    CanType openedType = ExistentialArchetypeType::getAny(inputSubstType)
+        ->getCanonicalType();
+    SILType loweredOpenedType = SGF.getLoweredType(openedType);
+
+    FormalEvaluationScope scope(SGF);
+
+    auto payload = SGF.emitOpenExistential(Loc, v,
+                                           loweredOpenedType,
+                                           AccessKind::Read);
+    payload = payload.ensurePlusOne(SGF, Loc);
+    return transform(payload,
+                     AbstractionPattern::getOpaque(),
+                     openedType,
+                     outputOrigType,
+                     outputSubstType,
+                     loweredResultTy,
+                     ctxt);
   }
 
   // - T.TangentVector to Optional<T>.TangentVector

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -9797,8 +9797,14 @@ ConstraintSystem::applySolution(Solution &solution,
     auto isValidType = [&](Type ty) {
       return !ty->hasError() && !ty->hasTypeVariableOrPlaceholder();
     };
-    for (auto &[_, type] : solution.typeBindings) {
-      ASSERT(isValidType(type) && "type binding has invalid type");
+    for (auto pair : solution.typeBindings) {
+      if (!isValidType(pair.second)) {
+        ABORT([&](llvm::raw_ostream &out) {
+          out << "Type binding has invalid type:\n";
+          pair.first->dump(out);
+          pair.second->dump(out);
+        });
+      }
     }
     for (auto &[_, type] : solution.nodeTypes) {
       ASSERT(isValidType(solution.simplifyType(type)) &&

--- a/lib/Sema/Subtyping.cpp
+++ b/lib/Sema/Subtyping.cpp
@@ -709,7 +709,8 @@ bool swift::constraints::isPossibleSupertypeOfFunctionType(Type type) {
     auto layout = type->getExistentialLayout();
 
     // Revisit this if functions ever conform to arbitrary protocols!
-    if (!layout.containsNonMarkerProtocols() && !layout.requiresClass())
+    if (!layout.containsNonMarkerProtocols() &&
+        !layout.getExplicitSuperclassOrProtocolSuperclass())
       return true;
   }
 

--- a/lib/Sema/Subtyping.cpp
+++ b/lib/Sema/Subtyping.cpp
@@ -709,7 +709,7 @@ bool swift::constraints::isPossibleSupertypeOfFunctionType(Type type) {
     auto layout = type->getExistentialLayout();
 
     // Revisit this if functions ever conform to arbitrary protocols!
-    if (!layout.containsNonMarkerProtocols() && !layout.getSuperclass())
+    if (!layout.containsNonMarkerProtocols() && !layout.requiresClass())
       return true;
   }
 

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -2732,7 +2732,8 @@ private:
 
           if (auto *existential = ty->getAs<ExistentialType>()) {
             if (auto superclass =
-                    existential->getExistentialLayout().getSuperclass()) {
+                    existential->getExistentialLayout()
+                      .getExplicitSuperclassOrProtocolSuperclass()) {
               if (superclass->isKnownImmutableKeyPathType())
                 return StorageAccessKind::Get;
             }

--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -173,7 +173,8 @@ namespace {
       // pull out the superclass instead, and use that below.
       if (foundInType->isExistentialType()) {
         auto layout = foundInType->getExistentialLayout();
-        if (auto superclass = layout.getSuperclass()) {
+        // FIXME: This is broken, see the comment on that getter method.
+        if (auto superclass = layout.getExplicitSuperclassOrProtocolSuperclass()) {
           conformingType = superclass;
         } else {
           // Non-subclass existential: don't need to look for further

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -6205,7 +6205,9 @@ TypeChecker::containsProtocol(Type T, ProtocolDecl *Proto,
     // Note that `allowMissing` is not propagated here because it
     // would result in a missing conformance if type is `& Sendable`
     // protocol composition. It's handled for type as a whole below.
-    if (auto superclass = layout.getSuperclass()) {
+    //
+    // FIXME: This is broken, see the comment on that getter method.
+    if (auto superclass = layout.getExplicitSuperclassOrProtocolSuperclass()) {
       auto conformance = lookupConformance(superclass, Proto,
                                            /*allowMissing=*/false);
       if (conformance)

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -6587,7 +6587,7 @@ TypeResolver::resolveCompositionType(CompositionTypeRepr *repr,
       auto kp = getKnownProtocolKind(ip);
 
       if (layout.requiresClass()) {
-        auto superclass = layout.getSuperclass();
+        auto superclass = layout.explicitSuperclass;
         diagnose(repr->getStartLoc(),
                  diag::inverse_with_class_constraint,
                  !superclass,

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -1735,14 +1735,24 @@ Type TypeResolution::applyUnboundGenericArguments(
         return BoundGenericType::get(nominalDecl, parentTy, genericArgs);
       }
 
+      // We have a generic type alias referenced with an unbound generic
+      // base, which is only valid if all of the unbound generic type's
+      // generic parameters are fixed to concrete types by the generic
+      // signature of the type alias, eg:
+      //
+      // struct G<T> {
+      //   typealias A<U> = Int where T == String
+      // }
       if (!resultType->hasTypeParameter())
         return resultType;
 
       auto genericSig = decl->getGenericSignature();
       auto parentSig = decl->getDeclContext()->getGenericSignatureOfContext();
-      for (auto gp : parentSig.getGenericParams())
+      for (auto gp : parentSig.getGenericParams()) {
+        ASSERT(genericSig->isConcreteType(gp));
         subs[gp->getCanonicalType()->castTo<GenericTypeParamType>()] =
             genericSig->getConcreteType(gp);
+      }
     } else {
       subs = parentTy->getContextSubstitutions(decl->getDeclContext());
     }

--- a/test/IRGen/protocol_with_superclass.swift
+++ b/test/IRGen/protocol_with_superclass.swift
@@ -1,0 +1,21 @@
+// RUN: %target-swift-frontend -emit-ir %s
+
+public class Base<T> {}
+
+public protocol Proto<T>: Base<Self.T> {
+  associatedtype T
+}
+
+extension Proto {
+  public func f() {}
+}
+
+public class Derived<T>: Base<T>, Proto {}
+
+public func erase() {
+  let p1: any Proto = Derived<Int>()
+  p1.f()
+
+  let p2: any Proto<Int> = Derived<Int>()
+  p2.f()
+}


### PR DESCRIPTION
This API is fatally flawed in the case where the protocol's superclass bound involves an associated type of the protocol itself, eg:
```
protocol P where Self: C<Self.T> {
  ...
}
```

ExistentialLayout::getSuperclass() would first check if the existential type had an explicit superclass member, like `P & C<T>`, and then it would check if any of the protocols have a superclass. The problem is that it does not distinguish the two cases--in the first case you'd get `C<T>` where `T` is a type parameter in the current lexical scope, in the second you get `C<Self.T>` in the protocol's generic signature. There is no possible correct way to interpret the result that it returns, if it happens to be an interface type.

In a few spots, we actually only care about the explicit superclass member of a composition, so I changed it to look at the `explicitSuperclass` member instead. Other places don't care about generic substitutions and are safe. (Perhaps we could add an ExistentialLayout::getSuperclassDecl() for these situations instead.) The rest I added FIXME comments because they're susceptible to the same kind of crash. I also renamed the method, to prevent people from introducing new calls on accident.

There's probably no way to fix all of these problems completely without restricting this part of the language somewhat. Perhaps the superclass of a protocol should not be allowed to depend on type parameters of `Self` at all.

Fixes https://github.com/swiftlang/swift/issues/88949.