### PR TITLE
[6.4] Remove a few usages of ExistentialLayout::getSuperclass()

### DIFF
--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -1780,7 +1780,7 @@ public:
           }
         }
         
-        auto superclass = erasedLayout.getSuperclass();
+        auto superclass = erasedLayout.explicitSuperclass;
         if (superclass
             && !superclass->isExactSuperclassOf(concreteTy)) {
           Out << "ErasureExpr from class to existential with a superclass "

--- a/lib/IRGen/GenExistential.cpp
+++ b/lib/IRGen/GenExistential.cpp
@@ -1608,10 +1608,7 @@ static const TypeInfo *createExistentialTypeInfo(IRGenModule &IGM, CanType T) {
     ReferenceCounting refcounting = T->getReferenceCounting();
 
     llvm::PointerType *reprTy = nullptr;
-    if (auto superclass = layout.getSuperclass()) {
-      auto &superTI = IGM.getTypeInfoForUnlowered(superclass);
-      reprTy = cast<llvm::PointerType>(superTI.getStorageType());
-    } else if (refcounting == ReferenceCounting::Native) {
+    if (refcounting == ReferenceCounting::Native) {
       reprTy = IGM.RefCountedPtrTy;
     } else {
       reprTy = IGM.UnknownRefCountedPtrTy;

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -5132,7 +5132,7 @@ public:
               "init_existential of class existential with non-class type");
     }
 
-    if (auto superclass = layout.getSuperclass()) {
+    if (auto superclass = layout.explicitSuperclass) {
       require(superclass->isExactSuperclassOf(concreteType),
               "init_existential of subclass existential with wrong type");
     }

--- a/test/IRGen/protocol_with_superclass.swift
+++ b/test/IRGen/protocol_with_superclass.swift
@@ -1,0 +1,21 @@
+// RUN: %target-swift-frontend -emit-ir %s
+
+public class Base<T> {}
+
+public protocol Proto<T>: Base<Self.T> {
+  associatedtype T
+}
+
+extension Proto {
+  public func f() {}
+}
+
+public class Derived<T>: Base<T>, Proto {}
+
+public func erase() {
+  let p1: any Proto = Derived<Int>()
+  p1.f()
+
+  let p2: any Proto<Int> = Derived<Int>()
+  p2.f()
+}


### PR DESCRIPTION
6.4 cherry-pick of the relevant parts of https://github.com/swiftlang/swift/pull/89484.

- **Description:** An impossible-to-use-correctly API was unused incorrectly in a few places. (Details are in the `main` PR description.) Two were in verifiers are were false positives, but the third would then crash in IRGen once the verifier checks were fixed.
- **Scope if the issue:** AST verifier, SIL verifier, or IRGen crash, depending on exact details of how the compiler was built.
- **Origination:** Probably broken ever since superclass-constrained protocols were added in ancient Swift.
- **Risk:** Low. The IRGen change should be a no-op. The getReferenceCounting() that now happens first already looks at the superclass decl of the protocol composition type, but in any case the pointer element type is irrelevant these days because it's all the same in LLVM.
- **Reviewed by:** @kavon 