### PR TITLE
[cxx-interop] Patch up compound names of imported methods

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4708,8 +4708,22 @@ namespace {
           if (auto updatedName =
                   Impl.importFullName(decl, Impl.CurrentVersion)) {
             auto *valueDecl = cast<ValueDecl>(method);
-            if (valueDecl->getName() != updatedName.getDeclName())
-              valueDecl->setName(updatedName.getDeclName());
+            auto newName = updatedName.getDeclName();
+
+            // Mirror the name reconciliation in importFunctionDecl:
+            // rebuild compound name from the function's actual parameter list
+            // so it stays a valid function-decl name.
+            if (auto *fn = dyn_cast<AbstractFunctionDecl>(valueDecl);
+                fn && newName) {
+              if (newName.isSimpleName() || newName.getArgumentNames().size() !=
+                                                fn->getParameters()->size()) {
+                newName = DeclName(Impl.SwiftContext,
+                                   newName.getBaseName(), fn->getParameters());
+              }
+            }
+
+            if (valueDecl->getName() != newName)
+              valueDecl->setName(newName);
           }
         }
       }

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4279,13 +4279,6 @@ namespace {
         return known2->second;
       }
 
-      if (name && name.isSimpleName()) {
-        assert(importedName.hasCustomName() &&
-               "imported function with simple name?");
-        // Just fill in empty argument labels.
-        name = DeclName(Impl.SwiftContext, name.getBaseName(), bodyParams);
-      }
-
       if (name && name.getArgumentNames().size() != bodyParams->size()) {
         // We synthesized additional parameters so rebuild the DeclName.
         name = DeclName(Impl.SwiftContext, name.getBaseName(), bodyParams);
@@ -4708,22 +4701,8 @@ namespace {
           if (auto updatedName =
                   Impl.importFullName(decl, Impl.CurrentVersion)) {
             auto *valueDecl = cast<ValueDecl>(method);
-            auto newName = updatedName.getDeclName();
-
-            // Mirror the name reconciliation in importFunctionDecl:
-            // rebuild compound name from the function's actual parameter list
-            // so it stays a valid function-decl name.
-            if (auto *fn = dyn_cast<AbstractFunctionDecl>(valueDecl);
-                fn && newName) {
-              if (newName.isSimpleName() || newName.getArgumentNames().size() !=
-                                                fn->getParameters()->size()) {
-                newName = DeclName(Impl.SwiftContext,
-                                   newName.getBaseName(), fn->getParameters());
-              }
-            }
-
-            if (valueDecl->getName() != newName)
-              valueDecl->setName(newName);
+            if (valueDecl->getName() != updatedName.getDeclName())
+              valueDecl->setName(updatedName.getDeclName());
           }
         }
       }

--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -1711,6 +1711,21 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
           swiftCtx, /*isSubscript=*/false,
           isa<clang::ClassTemplateSpecializationDecl>(D));
 
+      if (result.declName && result.declName.isSimpleName()) {
+        const clang::FunctionDecl *fnDecl = dyn_cast<clang::FunctionDecl>(D);
+        if (!fnDecl) {
+          if (auto *fnTemplate = dyn_cast<clang::FunctionTemplateDecl>(D))
+            fnDecl = fnTemplate->getAsFunction();
+        }
+        if (fnDecl) {
+          // Function-typed clang decls require a compound (non-simple) name.
+          SmallVector<Identifier, 4> emptyArgs(fnDecl->getNumParams(),
+                                               Identifier());
+          result.declName = DeclName(
+              swiftCtx, result.declName.getBaseName(), emptyArgs);
+        }
+      }
+
       // Handle globals treated as members.
       if (parsedName.isMember()) {
         // FIXME: Make sure this thing is global.

--- a/test/Interop/Cxx/templates/template-type-parameter-not-in-signature-silgen.swift
+++ b/test/Interop/Cxx/templates/template-type-parameter-not-in-signature-silgen.swift
@@ -1,4 +1,11 @@
-// RUN: %target-swift-emit-silgen %s -cxx-interoperability-mode=default -I %S/Inputs | %FileCheck %s
+// RUN: %target-swift-emit-silgen %s -cxx-interoperability-mode=default -I %S/Inputs \
+// RUN: | %FileCheck %s
+//
+// RUN: %target-swift-emit-silgen %s -cxx-interoperability-mode=default -I %S/Inputs \
+// RUN:   -enable-experimental-feature ImportCxxMembersLazily \
+// RUN: | %FileCheck %s
+//
+// REQUIRES: swift_feature_ImportCxxMembersLazily
 
 import TemplateTypeParameterNotInSignature
 

--- a/test/Interop/Cxx/templates/template-type-parameter-not-in-signature-typechecker.swift
+++ b/test/Interop/Cxx/templates/template-type-parameter-not-in-signature-typechecker.swift
@@ -1,0 +1,51 @@
+// RUN: %target-typecheck-verify-swift -I %S/Inputs -cxx-interoperability-mode=default
+// RUN: %target-typecheck-verify-swift -I %S/Inputs -cxx-interoperability-mode=default \
+// RUN:   -enable-experimental-feature ImportCxxMembersLazily
+//
+// REQUIRES: swift_feature_ImportCxxMembersLazily
+
+import TemplateTypeParameterNotInSignature
+
+public func callMemberFunctionTemplates(_ s: Struct) {
+  s.templateTypeParamNotUsedInSignature(T: Int.self)
+  let _: Int = s.templateTypeParamUsedInReturnType(0)
+}
+
+public func callMutableMemberFunctionTemplate(_ s: inout Struct) {
+  s.templateTypeParamNotUsedInSignatureMutable(T: Int.self)
+}
+
+public func callStaticMemberFunctionTemplate() {
+  Struct.templateTypeParamNotUsedInSignatureStatic(T: Int.self)
+}
+
+public func callFreeFunctionTemplates() {
+  let _: Bool = templateTypeParamNotUsedInSignature(T: Int.self)
+  multiTemplateTypeParamNotUsedInSignature(T: Float.self, U: Int.self)
+  let _: Int = multiTemplateTypeParamOneUsedInSignature(1, T: Int.self)
+  multiTemplateTypeParamNotUsedInSignatureWithUnrelatedParams(
+      1, 1, T: Int32.self, U: Int.self)
+  let _: Int = templateTypeParamUsedInReturnType(10)
+}
+
+public func callReferenceParamTemplates() {
+  var x: Int = 1
+  let _ = templateTypeParamUsedInReferenceParam(&x)
+  let _ = templateTypeParamNotUsedInSignatureWithRef(&x, U: Int.self)
+}
+
+// FIXME: Function templates with varargs are imported but marked unavailable
+// (see the corresponding -module-interface test), but the availability
+// diagnostic does not seem to fire on this call site.
+public func callVarargsTemplates() {
+  templateTypeParamNotUsedInSignatureWithVarargs(T: Int.self, U: Int.self)
+  templateTypeParamNotUsedInSignatureWithVarargsAndUnrelatedParam(
+    0, T: Int.self, U: Int.self, V: Int.self)
+}
+
+// Function templates with non-type template parameters are not imported;
+// try to call one anyway to make sure we don't crash trying to resolve it.
+public func callNonTypeParamTemplate() {
+  templateTypeParamNotUsedInSignatureWithNonTypeParam(T: Int.self)
+  // expected-error@-1 {{cannot find 'templateTypeParamNotUsedInSignatureWithNonTypeParam' in scope}}
+}


### PR DESCRIPTION
When we import methods, we need to re-import their name to account for potential __Unsafe mangling. However, this re-import did not perform the DeclName fix-up importFunctionDecl does, which is necessary to account for SWIFT_NAME("simple_identifier_no_parens") or other parameter count changes. One concrete scenario comes from templates that don't use their template parameter, for which we generate a wrapper thunk that includes an additional metatype parameter used to drive the unused template type argument. The lack of patching triggers an assertion failure when we import do some post-specialization fix-up for specialized template functions, because it sees that a function with a simple name like "foo" instead of a compound name like "foo(_:)" or "foo(T:)".

This patch replicates the importFunctionDecl patching when we do the post-method-import name-patching, to avoid that assertion failure. We never hit this before because the post-method-import name-patching is only performed when we enable ImportCxxMembersLazily, which is not yet enabled by default.

rdar://177990003