### PR TITLE
[🍒6.4][Swiftify][Embedded] always return primary IGM for swiftify macros

### DIFF
--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -2285,8 +2285,17 @@ IRGenModule *IRGenerator::getGenModule(SourceFile *SF) {
   if (GenModules.size() == 1)
     return getPrimaryIGM();
 
- IRGenModule *IGM = GenModules[SF];
- assert(IGM);
+ IRGenModule *IGM = GenModules.lookup(SF);
+
+ if (!IGM) {
+   // SF is a macro expansion buffer from a _SwiftifyImport macro attached
+   // to a function imported from clang module, so it doesn't have a mapping
+   // in GenModule. The contents are @_alwaysEmitIntoClient, so for all intents
+   // and purposes they belong to the primary module.
+   ASSERT(SF->getParentModule()->findUnderlyingClangModule());
+   return getPrimaryIGM();
+ }
+
  return IGM;
 }
 
@@ -2299,9 +2308,7 @@ IRGenModule *IRGenerator::getGenModule(DeclContext *ctxt) {
     return getPrimaryIGM();
   }
 
-  IRGenModule *IGM = GenModules[SF];
-  assert(IGM);
-  return IGM;
+  return getGenModule(SF);
 }
 
 IRGenModule *IRGenerator::getGenModule(SILFunction *f) {

--- a/test/embedded/safe-interop-multiple-outputs.swift
+++ b/test/embedded/safe-interop-multiple-outputs.swift
@@ -1,0 +1,38 @@
+// Regression test: this used to trigger a compiler crash in IRGenerator::getGenModule
+// since the SourceFile for the _SwiftifyImport macro expansion had no corresponding
+// IRGenModule. This would only trigger with multiple outputs and multiple threads
+// since there's only a single IRGenModule to return otherwise.
+
+// REQUIRES: swift_feature_Embedded
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -c -plugin-path %swift-plugin-dir -I %t \
+// RUN:   -enable-experimental-feature Embedded \
+// RUN:   -parse-as-library -num-threads 2 \
+// RUN:   %t/A.swift %t/B.swift \
+// RUN:   -o %t/A.swift.o -o %t/B.swift.o
+
+//--- test.h
+#pragma once
+
+#define __counted_by(x) __attribute__((__counted_by__(x)))
+#define __noescape __attribute__((noescape))
+
+void foo(const int *__counted_by(len) p __noescape, int len);
+
+//--- module.modulemap
+module Test {
+  header "test.h"
+}
+
+//--- A.swift
+import Test
+
+public func bar(_ s: Span<Int32>) {
+    foo(s)
+}
+
+//--- B.swift
+public struct Baz {}


### PR DESCRIPTION
- **Explanation**:
The SourceFile for a `_SwiftifyImport` macro expansion has no IRGenModule mapping since it's in a clang module rather than a Swift module. When compiling with multiple outputs and threads this triggers a because there was no default. This checks for SourceFiles from a clang module and returns the default IRGenModule.

- **Scope**:
Only affects when compiling multiple outputs with multiple threads. Would previously crash, now doesn't.
- **Issues**:
https://github.com/swiftlang/swift/issues/88864
rdar://176347021
- **Original PRs**:
https://github.com/swiftlang/swift/pull/88908
- **Risk**:
Low
- **Testing**:
Lit testing
- **Reviewers**:
@eeckstein 