### PR TITLE
Establish NoncopyableReflectionSafety as present in 6.4

### DIFF
--- a/include/swift/AST/FeatureAvailability.def
+++ b/include/swift/AST/FeatureAvailability.def
@@ -84,12 +84,13 @@ FEATURE(TaskExecutor,                                   (6, 2))
 FEATURE(TaskPriorityEscalationHandlers,                 (6, 2))
 FEATURE(TypedCoroAlloc,                                 (6, 2))
 
+FEATURE(NoncopyableReflectionSafety,                    (6, 4))
+
 FEATURE(CustomGlobalExecutors,                          FUTURE)
 FEATURE(Differentiation,                                FUTURE)
 FEATURE(ClearSensitive,                                 FUTURE)
 FEATURE(UpdatePureObjCClassMetadata,                    FUTURE)
 // TODO: CoroutineAccessors: Change to correct version number.
 FEATURE(CoroutineAccessors,                             FUTURE)
-FEATURE(NoncopyableReflectionSafety,                    FUTURE)
 #undef FEATURE
 #undef FUTURE

--- a/test/IRGen/noncopyable_field_descriptors.swift
+++ b/test/IRGen/noncopyable_field_descriptors.swift
@@ -20,6 +20,8 @@
 // RUN:   -target %target-future-triple \
 // RUN:   > %t/test_safe_runtime.irgen
 
+// FIXME: this should be `-target %target-swift-6.4-abi-triple` once the platform versions are known.
+
 // RUN: %FileCheck --check-prefix=NEW %s < %t/test_new.irgen
 // RUN: %FileCheck --check-prefix=OLD %s < %t/test_old.irgen
 // RUN: %FileCheck --check-prefix=SAFE-RUNTIME %s < %t/test_safe_runtime.irgen

--- a/test/Reflection/noncopyable_field_typeref.swift
+++ b/test/Reflection/noncopyable_field_typeref.swift
@@ -15,6 +15,8 @@
 // RUN: %target-build-swift -target %module-target-future %s -parse-as-library -emit-module -emit-library -module-name NoncopyableFields -o %t/%target-library-name(NoncopyableFields)
 // RUN: %target-swift-reflection-dump %t/%target-library-name(NoncopyableFields) | %FileCheck %s
 
+// FIXME: this should be `-target %target-swift-6.4-abi-triple` once the platform versions are known.
+
 struct NC: ~Copyable {}
 
 struct AlwaysNoncopyableBox<T>: ~Copyable {


### PR DESCRIPTION
This is contingent on merging this cherry-pick to `release/6.4.x`: https://github.com/swiftlang/swift/pull/89489