### PR TITLE
[CMake] Consolidate and standardlize the embedded Swift library build

### DIFF
--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -3827,6 +3827,29 @@ function(add_embedded_swift_target_library prefix library_name)
     set_property(TARGET ${prefix}-${mod}
                  PROPERTY OSX_ARCHITECTURES "${arch}")
 
+    # When archiving on a Windows host, MSVC's lib.exe defaults to the host
+    # machine type and refuses to archive .obj files of a different machine
+    # type (LNK1112). For -windows-msvc targets, force the librarian's
+    # /MACHINE: to match the per-target arch so cross-arch builds work.
+    if(CMAKE_HOST_SYSTEM_NAME STREQUAL "Windows"
+       AND "${triple}" MATCHES "-windows-msvc$")
+      set(_emblib_msvc_machine "")
+      if("${arch}" STREQUAL "i686" OR "${arch}" STREQUAL "i386")
+        set(_emblib_msvc_machine "X86")
+      elseif("${arch}" STREQUAL "x86_64")
+        set(_emblib_msvc_machine "X64")
+      elseif("${arch}" STREQUAL "aarch64" OR "${arch}" STREQUAL "arm64"
+             OR "${arch}" STREQUAL "arm64e")
+        set(_emblib_msvc_machine "ARM64")
+      elseif("${arch}" MATCHES "^arm")
+        set(_emblib_msvc_machine "ARM")
+      endif()
+      if(_emblib_msvc_machine)
+        set_property(TARGET ${prefix}-${mod} APPEND PROPERTY
+                     STATIC_LIBRARY_OPTIONS "/MACHINE:${_emblib_msvc_machine}")
+      endif()
+    endif()
+
     # Static archives whose target triple is ELF/EABI/wasm need a different
     # archiver when cross-built from a macOS host. embedded_amend_archive_
     # commands_on_darwin_host is a no-op for other targets/hosts, so it's

--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -921,6 +921,40 @@ function(add_swift_target_library_single target name)
     endif()
   endif()
 
+  # For Embedded Swift, force a number of global stdlib feature toggles to
+  # OFF for this library build. Doing this here means callers don't have to
+  # repeat the same set of overrides in every CMakeLists.txt that builds an
+  # embedded library. The `set()`s are function-scoped and shadow the parent
+  # scope (and the CACHE), so they only affect this call and any helper
+  # functions invoked from it.
+  if("${SWIFTLIB_SINGLE_SDK}" STREQUAL "embedded")
+    set(SWIFT_SDK_embedded_LIB_SUBDIR "embedded")
+    set(SWIFT_ENABLE_REFLECTION OFF)
+    set(SWIFT_STDLIB_SUPPORT_BACK_DEPLOYMENT OFF)
+    set(SWIFT_STDLIB_STABLE_ABI OFF)
+    set(SWIFT_STDLIB_ENABLE_OBJC_INTEROP OFF)
+    set(SWIFT_STDLIB_ENABLE_VECTOR_TYPES OFF)
+
+    # Embedded swiftmodules go into a single shared subdirectory; default
+    # MODULE_DIR to it when the caller didn't supply one explicitly.
+    if(NOT SWIFTLIB_SINGLE_MODULE_DIR)
+      set(SWIFTLIB_SINGLE_MODULE_DIR "${CMAKE_BINARY_DIR}/lib/swift/embedded")
+    endif()
+
+    # Embedded Swift libraries are always fragile.
+    set(SWIFTLIB_SINGLE_IS_FRAGILE TRUE)
+    set(SWIFTLIB_SINGLE_IS_FRAGILE_keyword "IS_FRAGILE")
+
+    # When the embedded platform abstraction layer is in use, define
+    # SWIFT_USE_EMBEDDED_SWIFT_PLATFORM for every embedded library build so
+    # that the platform-conditional code paths in the embedded stdlib and
+    # related libraries pick up the platform implementations.
+    if(SWIFT_USE_SWIFT_EMBEDDED_PLATFORM)
+      list(APPEND SWIFTLIB_SINGLE_SWIFT_COMPILE_FLAGS
+        "-D" "SWIFT_USE_EMBEDDED_SWIFT_PLATFORM")
+    endif()
+  endif()
+
   if(NOT SWIFTLIB_SINGLE_SHARED AND
      NOT SWIFTLIB_SINGLE_STATIC AND
      NOT SWIFTLIB_SINGLE_OBJECT_LIBRARY AND

--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -158,6 +158,9 @@ function(_add_target_variant_c_compile_link_flags)
     list(APPEND result "-DSWIFT_LIBC_IS_MUSL")
   endif()
 
+  if("${CFLAGS_SDK}" STREQUAL "embedded")
+    list(APPEND result "-ffreestanding")
+  endif()
 
   if("${CFLAGS_SDK}" STREQUAL "ANDROID")
     # Make sure the Android NDK lld is used.
@@ -745,7 +748,6 @@ endfunction()
 #     [DONT_EMBED_BITCODE]
 #     [IS_STDLIB]
 #     [IS_STDLIB_CORE]
-#     [ONLY_SWIFTMODULE]
 #     [NO_SWIFTMODULE]
 #     [IS_SDK_OVERLAY]
 #     [IS_FRAGILE]
@@ -807,9 +809,6 @@ endfunction()
 # IS_STDLIB_CORE
 #   Compile as the standard library core.
 #
-# ONLY_SWIFTMODULE
-#   Do not build either static or shared, build just the .swiftmodule.
-#
 # NO_SWIFTMODULE
 #   Only build either static or shared, and skip the .swiftmodule.
 #
@@ -839,7 +838,6 @@ function(add_swift_target_library_single target name)
         OBJECT_LIBRARY
         SHARED
         STATIC
-        ONLY_SWIFTMODULE
         NO_SWIFTMODULE
         NO_LINK_NAME
         INSTALL_WITH_SHARED
@@ -914,13 +912,19 @@ function(add_swift_target_library_single target name)
   precondition(SWIFTLIB_SINGLE_ARCHITECTURE MESSAGE "Should specify an architecture")
   precondition(SWIFTLIB_SINGLE_INSTALL_IN_COMPONENT MESSAGE "INSTALL_IN_COMPONENT is required")
   if (NOT SWIFTLIB_SINGLE_ARCHITECTURE_SUBDIR_NAME)
-    set(SWIFTLIB_SINGLE_ARCHITECTURE_SUBDIR_NAME "${SWIFTLIB_SINGLE_ARCHITECTURE}")
+    if ("${SWIFTLIB_SINGLE_SDK}" STREQUAL "embedded")
+      # For Embedded Swift, use the whole module triple for the subdirectory.
+      set(SWIFTLIB_SINGLE_ARCHITECTURE_SUBDIR_NAME "${SWIFT_SDK_embedded_ARCH_${SWIFTLIB_SINGLE_ARCHITECTURE}_MODULE}")
+    else()
+      # The architecture itself suffices for non-Embedded Swift.
+      set(SWIFTLIB_SINGLE_ARCHITECTURE_SUBDIR_NAME "${SWIFTLIB_SINGLE_ARCHITECTURE}")
+    endif()
   endif()
 
   if(NOT SWIFTLIB_SINGLE_SHARED AND
      NOT SWIFTLIB_SINGLE_STATIC AND
      NOT SWIFTLIB_SINGLE_OBJECT_LIBRARY AND
-     NOT SWIFTLIB_SINGLE_ONLY_SWIFTMODULE)
+     NOT "${SWIFTLIB_SINGLE_SDK}" STREQUAL "embedded")
     message(FATAL_ERROR
         "Either SHARED, STATIC, or OBJECT_LIBRARY must be specified")
   endif()
@@ -980,8 +984,8 @@ function(add_swift_target_library_single target name)
     set(libkind SHARED)
   elseif(SWIFTLIB_SINGLE_STATIC)
     set(libkind STATIC)
-  elseif(SWIFTLIB_SINGLE_ONLY_SWIFTMODULE)
-    set(libkind NONE)
+  elseif("${SWIFTLIB_SINGLE_SDK}" STREQUAL "embedded")
+    set(libkind STATIC)
   else()
     message(FATAL_ERROR
         "Either SHARED, STATIC, or OBJECT_LIBRARY must be specified")
@@ -1022,6 +1026,16 @@ function(add_swift_target_library_single target name)
     endif()
     list(APPEND SWIFTLIB_SINGLE_SWIFT_COMPILE_FLAGS
       -libc;${SWIFT_STDLIB_MSVC_RUNTIME_LIBRARY})
+  endif()
+
+  if("${SWIFTLIB_SINGLE_SDK}" STREQUAL "embedded")
+      # Flags required to build embedded libraries
+      list(APPEND SWIFTLIB_SINGLE_SWIFT_COMPILE_FLAGS -Xcc;-ffreestanding;-enable-experimental-feature;Embedded)
+
+      # Embedded Swift builds with empty object files by default. Everything
+      # is emitted into the client.
+      list(APPEND SWIFTLIB_SINGLE_SWIFT_COMPILE_FLAGS -Xfrontend;-emit-empty-object-file)
+      list(APPEND SWIFTLIB_SINGLE_SWIFT_COMPILE_FLAGS -enable-experimental-feature;CodeGenerationModel=implementation)
   endif()
 
   # Define availability macros.
@@ -1142,7 +1156,6 @@ function(add_swift_target_library_single target name)
       ${SWIFTLIB_SINGLE_IS_STDLIB_CORE_keyword}
       ${SWIFTLIB_SINGLE_IS_SDK_OVERLAY_keyword}
       ${SWIFTLIB_SINGLE_IS_FRAGILE_keyword}
-      ${SWIFTLIB_SINGLE_ONLY_SWIFTMODULE_keyword}
       ${SWIFTLIB_SINGLE_NO_SWIFTMODULE_keyword}
       ${embed_bitcode_arg}
       ${SWIFTLIB_SINGLE_STATIC_keyword}
@@ -1219,15 +1232,6 @@ function(add_swift_target_library_single target name)
   if(libkind STREQUAL "SHARED")
     list(APPEND INCORPORATED_OBJECT_LIBRARIES_EXPRESSIONS
          ${SWIFTLIB_INCORPORATED_OBJECT_LIBRARIES_EXPRESSIONS_SHARED_ONLY})
-  endif()
-
-  if (SWIFTLIB_SINGLE_ONLY_SWIFTMODULE)
-    add_custom_target("${target}"
-      DEPENDS "${swift_module_dependency_target}")
-    if(TARGET "${install_in_component}")
-      add_dependencies("${install_in_component}" "${target}")
-    endif()
-    return()
   endif()
 
   add_library("${target}" ${libkind}
@@ -1721,6 +1725,10 @@ function(add_swift_target_library_single target name)
         ${SWIFTLIB_SINGLE_PRIVATE_LINK_LIBRARIES})
   endif()
 
+  if ("${SWIFTLIB_SINGLE_SDK}" STREQUAL "embedded")
+    embedded_amend_archive_commands_on_darwin_host(${target} "${SWIFT_SDK_embedded_ARCH_${SWIFTLIB_SINGLE_ARCHITECTURE}_TRIPLE}")
+  endif()
+
   # NOTE(compnerd) use the C linker language to invoke `clang` rather than
   # `clang++` as we explicitly link against the C++ runtime.  We were previously
   # actually passing `-nostdlib++` to avoid the C++ runtime linkage.
@@ -1796,7 +1804,6 @@ endfunction()
 #     [IS_STDLIB]
 #     [IS_STDLIB_CORE]
 #     [IS_OSLOG]
-#     [ONLY_SWIFTMODULE]
 #     [NO_SWIFTMODULE]
 #     [INSTALL_WITH_SHARED]
 #     INSTALL_IN_COMPONENT comp
@@ -1912,9 +1919,6 @@ endfunction()
 # IS_OSLOG
 #   Treat the library as OSLog library.
 #
-# ONLY_SWIFTMODULE
-#   Do not build either static or shared, build just the .swiftmodule.
-#
 # NO_SWIFTMODULE
 #   Only build either static or shared, and skip the .swiftmodule.
 #
@@ -2007,7 +2011,6 @@ function(add_swift_target_library name)
         IS_OSLOG
         IS_SWIFT_ONLY
         NOSWIFTRT
-        ONLY_SWIFTMODULE
         NO_SWIFTMODULE
         OBJECT_LIBRARY
         SHARED
@@ -2636,7 +2639,6 @@ function(add_swift_target_library name)
         ${SWIFTLIB_IS_STDLIB_CORE_keyword}
         ${SWIFTLIB_IS_SDK_OVERLAY_keyword}
         ${SWIFTLIB_NOSWIFTRT_keyword}
-        ${SWIFTLIB_ONLY_SWIFTMODULE_keyword}
         ${SWIFTLIB_NO_SWIFTMODULE_keyword}
         DARWIN_INSTALL_NAME_DIR "${SWIFTLIB_DARWIN_INSTALL_NAME_DIR}"
         INSTALL_IN_COMPONENT "${SWIFTLIB_INSTALL_IN_COMPONENT}"

--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -3627,6 +3627,216 @@ function(add_swift_target_executable name)
   endforeach()
 endfunction()
 
+# Build an embedded Swift library across every entry of
+# EMBEDDED_STDLIB_TARGET_TRIPLES, calling add_swift_target_library_single()
+# for each target triple.
+#
+# For each entry "<arch> <mod> <triple>" the function:
+#   1. Sets per-target SWIFT_SDK_embedded_ARCH_${key}_{MODULE,TRIPLE,PATH},
+#      where ${key} is ${arch} by default or ${mod} when ARCHITECTURE_KEY mod
+#      is passed.
+#   2. Calls add_swift_target_library_single(<prefix>-${mod} <library_name> ...)
+#      forwarding the sources, flags, and other options provided by the caller.
+#      ARCHITECTURE is set to ${key} and SDK is set to "embedded".
+#   3. Adds the per-target library as a dependency of the umbrella custom
+#      target named <prefix> (which the caller is expected to have already
+#      created via add_custom_target).
+#
+# Unless IS_STDLIB_CORE is passed, "embedded-stdlib-${mod}" is automatically
+# prepended to DEPENDS so that the embedded swiftCore for that target is
+# built first.
+#
+# Usage:
+#   add_embedded_swift_target_library(<prefix> <library_name>
+#     [IS_STDLIB] [IS_STDLIB_CORE] [IS_SDK_OVERLAY]
+#     [PARTIAL_SOURCES_INTENDED]
+#     [INSTALL_BINARY]
+#     <sources>...
+#     [GYB_SOURCES <sources>...]
+#     [SWIFT_COMPILE_FLAGS <flags>...]
+#     [C_COMPILE_FLAGS <flags>...]
+#     [FILE_DEPENDS <files>...]
+#     [DEPENDS <targets>...]
+#     [SKIP_ARCH_REGEX <regex>...]
+#     [SKIP_MOD_REGEX <regex>...]
+#     [SKIP_TRIPLE_REGEX <regex>...]
+#     [ONLY_ARCH_REGEX <regex>...]
+#     [ONLY_MOD_REGEX <regex>...]
+#     [ONLY_TRIPLE_REGEX <regex>...]
+#     [ARCHITECTURE_KEY <arch|mod>]
+#     [INSTALL_IN_COMPONENT <component>])
+#
+# Embedded libraries are always built as STATIC, always have their target's
+# OSX_ARCHITECTURES property set to ${arch}, and always run through
+# embedded_amend_archive_commands_on_darwin_host (a no-op for hosts/targets
+# where it doesn't apply).
+#
+# SKIP_*_REGEX and ONLY_*_REGEX are both multi-valued. An entry is processed
+# only when *every* ONLY_*_REGEX category that has at least one pattern has
+# at least one match, AND no SKIP_*_REGEX pattern matches.
+function(add_embedded_swift_target_library prefix library_name)
+  cmake_parse_arguments(EMBLIB
+    "IS_STDLIB;IS_STDLIB_CORE;IS_SDK_OVERLAY;PARTIAL_SOURCES_INTENDED;INSTALL_BINARY"
+    "INSTALL_IN_COMPONENT;ARCHITECTURE_KEY"
+    "GYB_SOURCES;SWIFT_COMPILE_FLAGS;C_COMPILE_FLAGS;FILE_DEPENDS;DEPENDS;SKIP_ARCH_REGEX;SKIP_MOD_REGEX;SKIP_TRIPLE_REGEX;ONLY_ARCH_REGEX;ONLY_MOD_REGEX;ONLY_TRIPLE_REGEX"
+    ${ARGN})
+
+  translate_flag(${EMBLIB_IS_STDLIB}              "IS_STDLIB"
+                 EMBLIB_IS_STDLIB_keyword)
+  translate_flag(${EMBLIB_IS_STDLIB_CORE}         "IS_STDLIB_CORE"
+                 EMBLIB_IS_STDLIB_CORE_keyword)
+  translate_flag(${EMBLIB_IS_SDK_OVERLAY}         "IS_SDK_OVERLAY"
+                 EMBLIB_IS_SDK_OVERLAY_keyword)
+  translate_flag(${EMBLIB_PARTIAL_SOURCES_INTENDED} "PARTIAL_SOURCES_INTENDED"
+                 EMBLIB_PARTIAL_SOURCES_INTENDED_keyword)
+
+  if(NOT EMBLIB_ARCHITECTURE_KEY)
+    set(EMBLIB_ARCHITECTURE_KEY "arch")
+  elseif(NOT (EMBLIB_ARCHITECTURE_KEY STREQUAL "arch"
+              OR EMBLIB_ARCHITECTURE_KEY STREQUAL "mod"))
+    message(FATAL_ERROR
+      "ARCHITECTURE_KEY must be either 'arch' or 'mod' "
+      "(got '${EMBLIB_ARCHITECTURE_KEY}')")
+  endif()
+
+  foreach(entry ${EMBEDDED_STDLIB_TARGET_TRIPLES})
+    string(REGEX REPLACE "[ \t]+" ";" list "${entry}")
+    list(GET list 0 arch)
+    list(GET list 1 mod)
+    list(GET list 2 triple)
+
+    # Apply caller-supplied filters. The entry is processed only when every
+    # non-empty ONLY_*_REGEX category has at least one match AND no
+    # SKIP_*_REGEX pattern matches.
+    set(_emblib_skip FALSE)
+    foreach(re ${EMBLIB_SKIP_ARCH_REGEX})
+      if("${arch}" MATCHES "${re}")
+        set(_emblib_skip TRUE)
+      endif()
+    endforeach()
+    foreach(re ${EMBLIB_SKIP_MOD_REGEX})
+      if("${mod}" MATCHES "${re}")
+        set(_emblib_skip TRUE)
+      endif()
+    endforeach()
+    foreach(re ${EMBLIB_SKIP_TRIPLE_REGEX})
+      if("${triple}" MATCHES "${re}")
+        set(_emblib_skip TRUE)
+      endif()
+    endforeach()
+
+    if(EMBLIB_ONLY_ARCH_REGEX)
+      set(_emblib_match FALSE)
+      foreach(re ${EMBLIB_ONLY_ARCH_REGEX})
+        if("${arch}" MATCHES "${re}")
+          set(_emblib_match TRUE)
+        endif()
+      endforeach()
+      if(NOT _emblib_match)
+        set(_emblib_skip TRUE)
+      endif()
+    endif()
+    if(EMBLIB_ONLY_MOD_REGEX)
+      set(_emblib_match FALSE)
+      foreach(re ${EMBLIB_ONLY_MOD_REGEX})
+        if("${mod}" MATCHES "${re}")
+          set(_emblib_match TRUE)
+        endif()
+      endforeach()
+      if(NOT _emblib_match)
+        set(_emblib_skip TRUE)
+      endif()
+    endif()
+    if(EMBLIB_ONLY_TRIPLE_REGEX)
+      set(_emblib_match FALSE)
+      foreach(re ${EMBLIB_ONLY_TRIPLE_REGEX})
+        if("${triple}" MATCHES "${re}")
+          set(_emblib_match TRUE)
+        endif()
+      endforeach()
+      if(NOT _emblib_match)
+        set(_emblib_skip TRUE)
+      endif()
+    endif()
+
+    if(_emblib_skip)
+      continue()
+    endif()
+
+    if(EMBLIB_ARCHITECTURE_KEY STREQUAL "mod")
+      set(arch_key "${mod}")
+    else()
+      set(arch_key "${arch}")
+    endif()
+
+    set(SWIFT_SDK_embedded_ARCH_${arch_key}_MODULE "${mod}")
+    set(SWIFT_SDK_embedded_ARCH_${arch_key}_TRIPLE "${triple}")
+    if(SWIFT_EMBEDDED_STDLIB_SDKS_FOR_TARGET_TRIPLES)
+      set(SWIFT_SDK_embedded_ARCH_${arch_key}_PATH
+          "${EMBEDDED_STDLIB_SDK_FOR_${triple}}")
+    endif()
+
+    # Non-core embedded libraries always need the embedded swiftCore for the
+    # same target to be built first.
+    set(per_target_depends ${EMBLIB_DEPENDS})
+    if(NOT EMBLIB_IS_STDLIB_CORE)
+      list(PREPEND per_target_depends "embedded-stdlib-${mod}")
+    endif()
+
+    add_swift_target_library_single(
+      ${prefix}-${mod}
+      ${library_name}
+      ${EMBLIB_IS_STDLIB_keyword}
+      ${EMBLIB_IS_STDLIB_CORE_keyword}
+      ${EMBLIB_IS_SDK_OVERLAY_keyword}
+      STATIC
+      ${EMBLIB_PARTIAL_SOURCES_INTENDED_keyword}
+      ${EMBLIB_UNPARSED_ARGUMENTS}
+      GYB_SOURCES ${EMBLIB_GYB_SOURCES}
+      SWIFT_COMPILE_FLAGS ${EMBLIB_SWIFT_COMPILE_FLAGS}
+      C_COMPILE_FLAGS ${EMBLIB_C_COMPILE_FLAGS}
+      SDK "embedded"
+      ARCHITECTURE "${arch_key}"
+      FILE_DEPENDS ${EMBLIB_FILE_DEPENDS}
+      DEPENDS ${per_target_depends}
+      INSTALL_IN_COMPONENT ${EMBLIB_INSTALL_IN_COMPONENT}
+    )
+
+    # Install the produced archive into lib/swift/embedded/${mod}/. Used by
+    # embedded libraries that produce a static archive consumed by clients
+    # at link time (e.g. swiftEmbeddedPlatformPOSIX, swiftUnicodeDataTables,
+    # swift_Concurrency).
+    if(EMBLIB_INSTALL_BINARY)
+      swift_install_in_component(
+        TARGETS ${prefix}-${mod}
+        DESTINATION "lib/swift/embedded/${mod}"
+        COMPONENT "${EMBLIB_INSTALL_IN_COMPONENT}"
+      )
+      swift_install_in_component(
+        FILES "${SWIFTLIB_DIR}/embedded/${mod}/lib${library_name}.a"
+        DESTINATION "lib/swift/embedded/${mod}/"
+        COMPONENT "${EMBLIB_INSTALL_IN_COMPONENT}"
+        PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE
+                    GROUP_READ GROUP_EXECUTE
+                    WORLD_READ WORLD_EXECUTE
+      )
+    endif()
+
+    # When building the per-target archive on macOS, point CMake at the
+    # specific architecture so it doesn't try to build a fat archive.
+    set_property(TARGET ${prefix}-${mod}
+                 PROPERTY OSX_ARCHITECTURES "${arch}")
+
+    # Static archives whose target triple is ELF/EABI/wasm need a different
+    # archiver when cross-built from a macOS host. embedded_amend_archive_
+    # commands_on_darwin_host is a no-op for other targets/hosts, so it's
+    # safe to call unconditionally — every embedded library is static.
+    embedded_amend_archive_commands_on_darwin_host(${prefix}-${mod} ${triple})
+
+    add_dependencies(${prefix} ${prefix}-${mod})
+  endforeach()
+endfunction()
+
 function(embedded_amend_archive_commands_on_darwin_host target triple)
   # This is a temporary solution while we work on porting the build
   # on the Embedded stdlib to the Runtime build system, where each platform

--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -1047,8 +1047,22 @@ function(add_swift_target_library_single target name)
     DEPLOYMENT_VERSION_WATCHOS "${SWIFTLIB_SINGLE_DEPLOYMENT_VERSION_WATCHOS}"
     DEPLOYMENT_VERSION_XROS "${SWIFTLIB_SINGLE_DEPLOYMENT_VERSION_XROS}")
 
+  # Compute the availability definitions to use for this library. Under
+  # Embedded Swift, all stdlib APIs should be available always, so replace
+  # all availability macros with an empty expansion (`*`). Otherwise, use
+  # the global SWIFT_STDLIB_AVAILABILITY_DEFINITIONS as-is.
+  if("${SWIFTLIB_SINGLE_SDK}" STREQUAL "embedded")
+    set(SWIFTLIB_SINGLE_AVAILABILITY_DEFINITIONS)
+    foreach(def ${SWIFT_STDLIB_AVAILABILITY_DEFINITIONS})
+      string(REGEX REPLACE ":.*" ":*" replaced "${def}")
+      list(APPEND SWIFTLIB_SINGLE_AVAILABILITY_DEFINITIONS "${replaced}")
+    endforeach()
+  else()
+    set(SWIFTLIB_SINGLE_AVAILABILITY_DEFINITIONS "${SWIFT_STDLIB_AVAILABILITY_DEFINITIONS}")
+  endif()
+
   set(availability_macros)
-  foreach(def ${SWIFT_STDLIB_AVAILABILITY_DEFINITIONS})
+  foreach(def ${SWIFTLIB_SINGLE_AVAILABILITY_DEFINITIONS})
     list(APPEND availability_macros "-Xfrontend -define-availability -Xfrontend \"${def}\"")
 
     if("${def}" MATCHES "SwiftStdlib .*")

--- a/stdlib/cmake/modules/SwiftSource.cmake
+++ b/stdlib/cmake/modules/SwiftSource.cmake
@@ -49,7 +49,7 @@ function(handle_swift_sources
     dependency_sibgen_target_out_var_name
     sourcesvar externalvar name)
   cmake_parse_arguments(SWIFTSOURCES
-      "IS_MAIN;IS_STDLIB;IS_STDLIB_CORE;IS_SDK_OVERLAY;EMBED_BITCODE;STATIC;NO_LINK_NAME;IS_FRAGILE;ONLY_SWIFTMODULE;NO_SWIFTMODULE"
+      "IS_MAIN;IS_STDLIB;IS_STDLIB_CORE;IS_SDK_OVERLAY;EMBED_BITCODE;STATIC;NO_LINK_NAME;IS_FRAGILE;NO_SWIFTMODULE"
       "SDK;ARCHITECTURE;ARCHITECTURE_SUBDIR_NAME;INSTALL_IN_COMPONENT;DEPLOYMENT_VERSION_OSX;DEPLOYMENT_VERSION_IOS;DEPLOYMENT_VERSION_TVOS;DEPLOYMENT_VERSION_WATCHOS;MACCATALYST_BUILD_FLAVOR;BOOTSTRAPPING;INSTALL_BINARY_SWIFTMODULE"
       "DEPENDS;COMPILE_FLAGS;MODULE_NAME;MODULE_DIR;ENABLE_LTO"
       ${ARGN})
@@ -65,7 +65,6 @@ function(handle_swift_sources
                  STATIC_arg)
   translate_flag(${SWIFTSOURCES_NO_LINK_NAME} "NO_LINK_NAME" NO_LINK_NAME_arg)
   translate_flag(${SWIFTSOURCES_IS_FRAGILE} "IS_FRAGILE" IS_FRAGILE_arg)
-  translate_flag(${SWIFTSOURCES_ONLY_SWIFTMODULE} "ONLY_SWIFTMODULE" ONLY_SWIFTMODULE_arg)
   translate_flag(${SWIFTSOURCES_NO_SWIFTMODULE} "NO_SWIFTMODULE" NO_SWIFTMODULE_arg)
   if(DEFINED SWIFTSOURCES_BOOTSTRAPPING)
     set(BOOTSTRAPPING_arg "BOOTSTRAPPING" ${SWIFTSOURCES_BOOTSTRAPPING})
@@ -165,7 +164,6 @@ function(handle_swift_sources
         ${STATIC_arg}
         ${BOOTSTRAPPING_arg}
         ${IS_FRAGILE_arg}
-        ${ONLY_SWIFTMODULE_arg}
         ${NO_SWIFTMODULE_arg}
         INSTALL_BINARY_SWIFTMODULE ${SWIFTSOURCES_INSTALL_BINARY_SWIFTMODULE}
         INSTALL_IN_COMPONENT "${SWIFTSOURCES_INSTALL_IN_COMPONENT}"
@@ -411,7 +409,6 @@ endfunction()
 #     [IS_MAIN]                         # This is an executable, not a library
 #     [IS_STDLIB]
 #     [IS_STDLIB_CORE]                  # This is the core standard library
-#     [ONLY_SWIFTMODULE]                # Emit swiftmodule only, no binary
 #     [NO_SWIFTMODULE]                  # Emit binary only, no swiftmodule
 #     [OPT_FLAGS]                       # Optimization flags (overrides SWIFT_OPTIMIZE)
 #     [MODULE_DIR]                      # Put .swiftmodule, .swiftdoc., and .o
@@ -427,7 +424,7 @@ function(_compile_swift_files
     dependency_sib_target_out_var_name dependency_sibopt_target_out_var_name
     dependency_sibgen_target_out_var_name)
   cmake_parse_arguments(SWIFTFILE
-    "IS_MAIN;IS_STDLIB;IS_STDLIB_CORE;IS_SDK_OVERLAY;EMBED_BITCODE;STATIC;IS_FRAGILE;ONLY_SWIFTMODULE;NO_SWIFTMODULE"
+    "IS_MAIN;IS_STDLIB;IS_STDLIB_CORE;IS_SDK_OVERLAY;EMBED_BITCODE;STATIC;IS_FRAGILE;NO_SWIFTMODULE"
     "OUTPUT;MODULE_NAME;INSTALL_IN_COMPONENT;DEPLOYMENT_VERSION_OSX;DEPLOYMENT_VERSION_IOS;DEPLOYMENT_VERSION_TVOS;DEPLOYMENT_VERSION_WATCHOS;MACCATALYST_BUILD_FLAVOR;BOOTSTRAPPING;INSTALL_BINARY_SWIFTMODULE"
     "SOURCES;FLAGS;DEPENDS;SDK;ARCHITECTURE;OPT_FLAGS;MODULE_DIR"
     ${ARGN})
@@ -1080,7 +1077,6 @@ function(_compile_swift_files
     set(copy_legacy_layouts_dep)
   endif()
 
-  if(NOT SWIFTFILE_ONLY_SWIFTMODULE)
   add_custom_command_target(
       dependency_target
       COMMAND "${CMAKE_COMMAND}" -E make_directory ${dirs_to_create}
@@ -1100,7 +1096,6 @@ function(_compile_swift_files
         ${copy_legacy_layouts_dep}
       COMMENT "Compiling ${first_output}")
   set("${dependency_target_out_var_name}" "${dependency_target}" PARENT_SCOPE)
-  endif()
 
   # This is the target to generate:
   #

--- a/stdlib/public/ClangOverlays/CMakeLists.txt
+++ b/stdlib/public/ClangOverlays/CMakeLists.txt
@@ -61,16 +61,13 @@ if(NOT DEFINED SWIFT_BUILD_CLANG_OVERLAYS_SKIP_BUILTIN_FLOAT OR NOT SWIFT_BUILD_
       add_swift_target_library_single(
         embedded-builtin_float-${mod}
         swift_Builtin_float
-        ONLY_SWIFTMODULE
         IS_FRAGILE
         
-        ${BUILTIN_FLOAT_SOURCES}
         GYB_SOURCES
           ${BUILTIN_FLOAT_GYB_SOURCES}
   
         SWIFT_COMPILE_FLAGS
           ${BUILTIN_FLOAT_SWIFT_FLAGS}
-          -Xcc -ffreestanding -enable-experimental-feature Embedded
   
         MODULE_DIR "${CMAKE_BINARY_DIR}/lib/swift/embedded"
         SDK "embedded"

--- a/stdlib/public/ClangOverlays/CMakeLists.txt
+++ b/stdlib/public/ClangOverlays/CMakeLists.txt
@@ -40,33 +40,17 @@ if(NOT DEFINED SWIFT_BUILD_CLANG_OVERLAYS_SKIP_BUILTIN_FLOAT OR NOT SWIFT_BUILD_
     add_custom_target(embedded-builtin_float)
     add_dependencies(embedded-libraries embedded-builtin_float)
 
-    foreach(entry ${EMBEDDED_STDLIB_TARGET_TRIPLES})
-      string(REGEX REPLACE "[ \t]+" ";" list "${entry}")
-      list(GET list 0 arch)
-      list(GET list 1 mod)
-      list(GET list 2 triple)
-  
-      set(SWIFT_SDK_embedded_ARCH_${arch}_MODULE "${mod}")
-      set(SWIFT_SDK_embedded_ARCH_${arch}_TRIPLE "${triple}")
-      if(SWIFT_EMBEDDED_STDLIB_SDKS_FOR_TARGET_TRIPLES)
-        set(SWIFT_SDK_embedded_ARCH_${arch}_PATH "${EMBEDDED_STDLIB_SDK_FOR_${triple}}")
-      endif()
-      add_swift_target_library_single(
-        embedded-builtin_float-${mod}
-        swift_Builtin_float
-        
-        GYB_SOURCES
-          ${BUILTIN_FLOAT_GYB_SOURCES}
-  
-        SWIFT_COMPILE_FLAGS
-          ${BUILTIN_FLOAT_SWIFT_FLAGS}
-  
-        SDK "embedded"
-        ARCHITECTURE "${arch}"
-        DEPENDS embedded-stdlib-${mod}
-        INSTALL_IN_COMPONENT stdlib
-        )
-      add_dependencies(embedded-builtin_float embedded-builtin_float-${mod})
-    endforeach()
+    add_embedded_swift_target_library(
+      embedded-builtin_float
+      swift_Builtin_float
+
+      GYB_SOURCES
+        ${BUILTIN_FLOAT_GYB_SOURCES}
+
+      SWIFT_COMPILE_FLAGS
+        ${BUILTIN_FLOAT_SWIFT_FLAGS}
+
+      INSTALL_IN_COMPONENT stdlib
+    )
   endif()
 endif()

--- a/stdlib/public/ClangOverlays/CMakeLists.txt
+++ b/stdlib/public/ClangOverlays/CMakeLists.txt
@@ -39,12 +39,6 @@ if(NOT DEFINED SWIFT_BUILD_CLANG_OVERLAYS_SKIP_BUILTIN_FLOAT OR NOT SWIFT_BUILD_
   if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
     add_custom_target(embedded-builtin_float)
     add_dependencies(embedded-libraries embedded-builtin_float)
-  
-    set(SWIFT_ENABLE_REFLECTION OFF)
-    set(SWIFT_STDLIB_SUPPORT_BACK_DEPLOYMENT OFF)
-    set(SWIFT_STDLIB_STABLE_ABI OFF)
-    set(SWIFT_STDLIB_ENABLE_OBJC_INTEROP OFF)
-    set(SWIFT_STDLIB_ENABLE_VECTOR_TYPES OFF)
 
     foreach(entry ${EMBEDDED_STDLIB_TARGET_TRIPLES})
       string(REGEX REPLACE "[ \t]+" ";" list "${entry}")
@@ -53,7 +47,6 @@ if(NOT DEFINED SWIFT_BUILD_CLANG_OVERLAYS_SKIP_BUILTIN_FLOAT OR NOT SWIFT_BUILD_
       list(GET list 2 triple)
   
       set(SWIFT_SDK_embedded_ARCH_${arch}_MODULE "${mod}")
-      set(SWIFT_SDK_embedded_LIB_SUBDIR "embedded")
       set(SWIFT_SDK_embedded_ARCH_${arch}_TRIPLE "${triple}")
       if(SWIFT_EMBEDDED_STDLIB_SDKS_FOR_TARGET_TRIPLES)
         set(SWIFT_SDK_embedded_ARCH_${arch}_PATH "${EMBEDDED_STDLIB_SDK_FOR_${triple}}")
@@ -61,7 +54,6 @@ if(NOT DEFINED SWIFT_BUILD_CLANG_OVERLAYS_SKIP_BUILTIN_FLOAT OR NOT SWIFT_BUILD_
       add_swift_target_library_single(
         embedded-builtin_float-${mod}
         swift_Builtin_float
-        IS_FRAGILE
         
         GYB_SOURCES
           ${BUILTIN_FLOAT_GYB_SOURCES}
@@ -69,7 +61,6 @@ if(NOT DEFINED SWIFT_BUILD_CLANG_OVERLAYS_SKIP_BUILTIN_FLOAT OR NOT SWIFT_BUILD_
         SWIFT_COMPILE_FLAGS
           ${BUILTIN_FLOAT_SWIFT_FLAGS}
   
-        MODULE_DIR "${CMAKE_BINARY_DIR}/lib/swift/embedded"
         SDK "embedded"
         ARCHITECTURE "${arch}"
         DEPENDS embedded-stdlib-${mod}

--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -293,10 +293,6 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB AND SWIFT_SHOULD_BUILD_EMBEDDED_CONCURRENC
   add_custom_target(embedded-concurrency)
   add_dependencies(embedded-libraries embedded-concurrency)
 
-  set(SWIFT_ENABLE_REFLECTION OFF)
-  set(SWIFT_STDLIB_SUPPORT_BACK_DEPLOYMENT OFF)
-  set(SWIFT_STDLIB_STABLE_ABI OFF)
-  set(SWIFT_STDLIB_ENABLE_OBJC_INTEROP OFF)
   set(SWIFT_CONCURRENCY_USES_DISPATCH FALSE)
   set(SWIFT_STDLIB_SINGLE_THREADED_CONCURRENCY TRUE)
   set(SWIFT_STDLIB_TRACING FALSE)
@@ -362,7 +358,6 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB AND SWIFT_SHOULD_BUILD_EMBEDDED_CONCURRENC
     set(SWIFT_SDK_embedded_THREADING_PACKAGE none)
     set(SWIFT_SDK_embedded_ARCH_${arch}_MODULE "${mod}")
     set(SWIFT_SDK_embedded_ARCH_${mod}_MODULE "${mod}")
-    set(SWIFT_SDK_embedded_LIB_SUBDIR "embedded")
     set(SWIFT_SDK_embedded_ARCH_${arch}_TRIPLE "${triple}")
     set(SWIFT_SDK_embedded_ARCH_${mod}_TRIPLE "${triple}")
     if(SWIFT_EMBEDDED_STDLIB_SDKS_FOR_TARGET_TRIPLES)
@@ -376,7 +371,7 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB AND SWIFT_SHOULD_BUILD_EMBEDDED_CONCURRENC
       embedded-concurrency-${mod}
       swift_Concurrency
       STATIC
-      IS_STDLIB IS_FRAGILE
+      IS_STDLIB
 
       ${SWIFT_RUNTIME_CONCURRENCY_C_SOURCES}
       ${SWIFT_RUNTIME_CONCURRENCY_SWIFT_SOURCES}
@@ -392,7 +387,6 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB AND SWIFT_SHOULD_BUILD_EMBEDDED_CONCURRENC
       C_COMPILE_FLAGS
         ${extra_c_compile_flags} ${SWIFT_RUNTIME_CONCURRENCY_C_FLAGS} -DSWIFT_CONCURRENCY_EMBEDDED=1 -DSWIFT_RUNTIME_EMBEDDED=1
         -ffunction-sections -fdata-sections -fno-exceptions -fno-cxx-exceptions -fno-unwind-tables
-      MODULE_DIR "${CMAKE_BINARY_DIR}/lib/swift/embedded"
       SDK "embedded"
       ARCHITECTURE "${arch}"
       DEPENDS embedded-stdlib-${mod}
@@ -421,12 +415,10 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB AND SWIFT_SHOULD_BUILD_EMBEDDED_CONCURRENC
       embedded-concurrency-default-executor-${mod}
       swift_ConcurrencyDefaultExecutor
       STATIC
-      IS_FRAGILE
 
       CooperativeGlobalExecutor.cpp
 
       C_COMPILE_FLAGS ${extra_c_compile_flags}
-      MODULE_DIR "${CMAKE_BINARY_DIR}/lib/swift/embedded"
       SDK "embedded"
       ARCHITECTURE "${mod}"
       DEPENDS embedded-stdlib-${mod}

--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -304,15 +304,6 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB AND SWIFT_SHOULD_BUILD_EMBEDDED_CONCURRENC
   set(SWIFT_STDLIB_HAS_ASL FALSE)
   list(APPEND LLVM_OPTIONAL_SOURCES ExecutorImpl.cpp)
 
-  # Under Embedded Swift, all stdlib APIs should be available always. Replace
-  # all availability macros with an empty expansion (`*`).
-  set(SWIFT_STDLIB_AVAILABILITY_DEFINITIONS_EMBEDDED)
-  foreach(def ${SWIFT_STDLIB_AVAILABILITY_DEFINITIONS})
-    string(REGEX REPLACE ":.*" ":*" replaced "${def}")
-    list(APPEND SWIFT_STDLIB_AVAILABILITY_DEFINITIONS_EMBEDDED "${replaced}")
-  endforeach()
-  set(SWIFT_STDLIB_AVAILABILITY_DEFINITIONS "${SWIFT_STDLIB_AVAILABILITY_DEFINITIONS_EMBEDDED}")
-
   foreach(entry ${EMBEDDED_STDLIB_TARGET_TRIPLES})
     string(REGEX REPLACE "[ \t]+" ";" list "${entry}")
     list(GET list 0 arch)

--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -395,9 +395,8 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB AND SWIFT_SHOULD_BUILD_EMBEDDED_CONCURRENC
         ${SWIFT_CONCURRENCY_GYB_SOURCES}
 
       SWIFT_COMPILE_FLAGS
-        ${extra_swift_compile_flags} -enable-experimental-feature Embedded
+        ${extra_swift_compile_flags}
         -parse-stdlib -DSWIFT_CONCURRENCY_EMBEDDED
-        -Xfrontend -emit-empty-object-file
         ${SWIFT_RUNTIME_CONCURRENCY_SWIFT_FLAGS}
       C_COMPILE_FLAGS
         ${extra_c_compile_flags} ${SWIFT_RUNTIME_CONCURRENCY_C_FLAGS} -DSWIFT_CONCURRENCY_EMBEDDED=1 -DSWIFT_RUNTIME_EMBEDDED=1
@@ -405,7 +404,6 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB AND SWIFT_SHOULD_BUILD_EMBEDDED_CONCURRENC
       MODULE_DIR "${CMAKE_BINARY_DIR}/lib/swift/embedded"
       SDK "embedded"
       ARCHITECTURE "${arch}"
-      ARCHITECTURE_SUBDIR_NAME "${mod}"
       DEPENDS embedded-stdlib-${mod}
       INSTALL_IN_COMPONENT stdlib
       )
@@ -424,8 +422,6 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB AND SWIFT_SHOULD_BUILD_EMBEDDED_CONCURRENC
     if(NOT "${arch}" MATCHES "wasm32")
       set_property(TARGET embedded-concurrency-${mod} PROPERTY OSX_ARCHITECTURES "${arch}")
     endif()
-
-    embedded_amend_archive_commands_on_darwin_host(embedded-concurrency-${mod} ${triple})
 
     add_dependencies(embedded-concurrency embedded-concurrency-${mod})
 
@@ -457,8 +453,6 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB AND SWIFT_SHOULD_BUILD_EMBEDDED_CONCURRENC
       PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
       )
     set_property(TARGET embedded-concurrency-default-executor-${mod} PROPERTY OSX_ARCHITECTURES "${arch}")
-
-    embedded_amend_archive_commands_on_darwin_host(embedded-concurrency-default-executor-${mod} ${triple})
 
     add_dependencies(embedded-concurrency embedded-concurrency-default-executor-${mod})
   endforeach()

--- a/stdlib/public/EmbeddedPlatform/CMakeLists.txt
+++ b/stdlib/public/EmbeddedPlatform/CMakeLists.txt
@@ -21,52 +21,22 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
   add_custom_target(embedded-posix-shim)
   add_dependencies(embedded-libraries embedded-posix-shim)
 
-  foreach(entry ${EMBEDDED_STDLIB_TARGET_TRIPLES})
-    string(REGEX REPLACE "[ \t]+" ";" list "${entry}")
-    list(GET list 0 arch)
-    list(GET list 1 mod)
-    list(GET list 2 triple)
+  add_embedded_swift_target_library(
+    embedded-posix-shim
+    swiftEmbeddedPlatformPOSIX
+    INSTALL_BINARY
 
-    if("${mod}" MATCHES "-windows-msvc$")
-      continue()
-    endif()
+    EmbeddedPlatformPOSIX.swift
 
-    if("${arch}" MATCHES "avr")
-      continue()
-    endif()
-
-    set(SWIFT_SDK_embedded_ARCH_${mod}_MODULE "${mod}")
-    set(SWIFT_SDK_embedded_ARCH_${mod}_TRIPLE "${triple}")
-    if(SWIFT_EMBEDDED_STDLIB_SDKS_FOR_TARGET_TRIPLES)
-      set(SWIFT_SDK_embedded_ARCH_${mod}_PATH "${EMBEDDED_STDLIB_SDK_FOR_${triple}}")
-    endif()
-
-    add_swift_target_library_single(
-      embedded-posix-shim-${mod}
-      swiftEmbeddedPlatformPOSIX
-      STATIC
-
-      EmbeddedPlatformPOSIX.swift
-
-      SWIFT_COMPILE_FLAGS ${swift_stdlib_compile_flags} "-import-bridging-header" ${CMAKE_CURRENT_SOURCE_DIR}/swift/EmbeddedPlatform.h -enable-experimental-feature Extern -enable-experimental-feature AllowRuntimeSymbolDeclarations "-disable-bridging-pch"
-      SDK "embedded"
-      ARCHITECTURE "${mod}"
-      DEPENDS embedded-stdlib-${mod}
-      INSTALL_IN_COMPONENT stdlib
-      )
-    swift_install_in_component(
-      TARGETS embedded-posix-shim-${mod}
-      DESTINATION "lib/swift/embedded/${mod}"
-      COMPONENT "stdlib"
-      )
-    swift_install_in_component(
-      FILES "${SWIFTLIB_DIR}/embedded/${mod}/libswiftEmbeddedPlatformPOSIX.a"
-      DESTINATION "lib/swift/embedded/${mod}/"
-      COMPONENT "stdlib"
-      PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
-      )
-    set_property(TARGET embedded-posix-shim-${mod} PROPERTY OSX_ARCHITECTURES "${arch}")
-
-    add_dependencies(embedded-posix-shim embedded-posix-shim-${mod})
-  endforeach()
+    SWIFT_COMPILE_FLAGS
+      ${swift_stdlib_compile_flags}
+      "-import-bridging-header" ${CMAKE_CURRENT_SOURCE_DIR}/swift/EmbeddedPlatform.h
+      -enable-experimental-feature Extern
+      -enable-experimental-feature AllowRuntimeSymbolDeclarations
+      "-disable-bridging-pch"
+    SKIP_MOD_REGEX "-windows-msvc$"
+    SKIP_ARCH_REGEX "avr"
+    ARCHITECTURE_KEY mod
+    INSTALL_IN_COMPONENT stdlib
+  )
 endif()

--- a/stdlib/public/EmbeddedPlatform/CMakeLists.txt
+++ b/stdlib/public/EmbeddedPlatform/CMakeLists.txt
@@ -36,7 +36,6 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
     endif()
 
     set(SWIFT_SDK_embedded_ARCH_${mod}_MODULE "${mod}")
-    set(SWIFT_SDK_embedded_LIB_SUBDIR "embedded")
     set(SWIFT_SDK_embedded_ARCH_${mod}_TRIPLE "${triple}")
     if(SWIFT_EMBEDDED_STDLIB_SDKS_FOR_TARGET_TRIPLES)
       set(SWIFT_SDK_embedded_ARCH_${mod}_PATH "${EMBEDDED_STDLIB_SDK_FOR_${triple}}")
@@ -46,12 +45,10 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
       embedded-posix-shim-${mod}
       swiftEmbeddedPlatformPOSIX
       STATIC
-      IS_FRAGILE
 
       EmbeddedPlatformPOSIX.swift
 
       SWIFT_COMPILE_FLAGS ${swift_stdlib_compile_flags} "-import-bridging-header" ${CMAKE_CURRENT_SOURCE_DIR}/swift/EmbeddedPlatform.h -enable-experimental-feature Extern -enable-experimental-feature AllowRuntimeSymbolDeclarations "-disable-bridging-pch"
-      MODULE_DIR "${CMAKE_BINARY_DIR}/lib/swift/embedded"
       SDK "embedded"
       ARCHITECTURE "${mod}"
       DEPENDS embedded-stdlib-${mod}

--- a/stdlib/public/EmbeddedPlatform/CMakeLists.txt
+++ b/stdlib/public/EmbeddedPlatform/CMakeLists.txt
@@ -35,13 +35,6 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
       continue()
     endif()
 
-    if (SWIFT_HOST_VARIANT STREQUAL "linux")
-      set(extra_c_compile_flags -ffreestanding)
-    elseif (SWIFT_HOST_VARIANT STREQUAL "macosx")
-      set(extra_c_compile_flags -ffreestanding)
-    endif()
-    list(APPEND extra_c_compile_flags -nostdinc++)
-
     set(SWIFT_SDK_embedded_ARCH_${mod}_MODULE "${mod}")
     set(SWIFT_SDK_embedded_LIB_SUBDIR "embedded")
     set(SWIFT_SDK_embedded_ARCH_${mod}_TRIPLE "${triple}")
@@ -57,8 +50,7 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
 
       EmbeddedPlatformPOSIX.swift
 
-      C_COMPILE_FLAGS ${extra_c_compile_flags}
-      SWIFT_COMPILE_FLAGS ${swift_stdlib_compile_flags} -Xcc -ffreestanding -enable-experimental-feature Embedded "-import-bridging-header" ${CMAKE_CURRENT_SOURCE_DIR}/swift/EmbeddedPlatform.h -enable-experimental-feature Extern -enable-experimental-feature AllowRuntimeSymbolDeclarations "-disable-bridging-pch"
+      SWIFT_COMPILE_FLAGS ${swift_stdlib_compile_flags} "-import-bridging-header" ${CMAKE_CURRENT_SOURCE_DIR}/swift/EmbeddedPlatform.h -enable-experimental-feature Extern -enable-experimental-feature AllowRuntimeSymbolDeclarations "-disable-bridging-pch"
       MODULE_DIR "${CMAKE_BINARY_DIR}/lib/swift/embedded"
       SDK "embedded"
       ARCHITECTURE "${mod}"

--- a/stdlib/public/Platform/CMakeLists.txt
+++ b/stdlib/public/Platform/CMakeLists.txt
@@ -491,7 +491,6 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
     add_swift_target_library_single(
       embedded-stdlib-platform-${triple}
       swiftWASILibc
-      ONLY_SWIFTMODULE
       IS_STDLIB IS_FRAGILE
         ${swift_platform_sources}
         POSIXError.swift
@@ -507,7 +506,6 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
       MODULE_DIR "${CMAKE_BINARY_DIR}/lib/swift/embedded"
       SDK "embedded"
       ARCHITECTURE "${arch}"
-      ARCHITECTURE_SUBDIR_NAME "${triple}"
       DEPENDS embedded-stdlib-${triple} wasilibc_modulemap
       INSTALL_IN_COMPONENT sdk-overlay
     )

--- a/stdlib/public/Platform/CMakeLists.txt
+++ b/stdlib/public/Platform/CMakeLists.txt
@@ -486,12 +486,11 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
     set(triple "wasm32-unknown-wasip1")
 
     set(SWIFT_SDK_embedded_ARCH_${arch}_MODULE "${triple}")
-    set(SWIFT_SDK_embedded_LIB_SUBDIR "embedded")
     set(SWIFT_SDK_embedded_ARCH_${arch}_TRIPLE "${triple}")
     add_swift_target_library_single(
       embedded-stdlib-platform-${triple}
       swiftWASILibc
-      IS_STDLIB IS_FRAGILE
+      IS_STDLIB
         ${swift_platform_sources}
         POSIXError.swift
 
@@ -503,7 +502,6 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
         -enable-experimental-feature Embedded
         -Xfrontend -emit-empty-object-file
 
-      MODULE_DIR "${CMAKE_BINARY_DIR}/lib/swift/embedded"
       SDK "embedded"
       ARCHITECTURE "${arch}"
       DEPENDS embedded-stdlib-${triple} wasilibc_modulemap

--- a/stdlib/public/Synchronization/CMakeLists.txt
+++ b/stdlib/public/Synchronization/CMakeLists.txt
@@ -169,49 +169,32 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
   add_custom_target(embedded-synchronization)
   add_dependencies(embedded-libraries embedded-synchronization)
 
-  foreach(entry ${EMBEDDED_STDLIB_TARGET_TRIPLES})
-    string(REGEX REPLACE "[ \t]+" ";" list "${entry}")
-    list(GET list 0 arch)
-    list(GET list 1 mod)
-    list(GET list 2 triple)
+  # wasm32 builds the full Synchronization library plus its wasm-specific
+  # mutex implementation.
+  add_embedded_swift_target_library(
+    embedded-synchronization
+    swiftSynchronization
 
-    # Disable the Synchronization library on AVR for now.
-    if("${arch}" MATCHES "avr")
-      continue()
-    endif()
+    ${SWIFT_SYNCHRONIZATION_SOURCES}
+    ${SWIFT_SYNCHRONIZATION_WASM_SOURCES}
 
-    set(SWIFT_SDK_embedded_ARCH_${arch}_MODULE "${mod}")
-    set(SWIFT_SDK_embedded_ARCH_${arch}_TRIPLE "${triple}")
-    if(SWIFT_EMBEDDED_STDLIB_SDKS_FOR_TARGET_TRIPLES)
-      set(SWIFT_SDK_embedded_ARCH_${arch}_PATH "${EMBEDDED_STDLIB_SDK_FOR_${triple}}")
-    endif()
+    GYB_SOURCES ${SWIFT_SYNCHRONIZATION_GYB_SOURCES}
+    SWIFT_COMPILE_FLAGS ${SWIFT_SYNCHRNOIZATION_SWIFT_FLAGS}
+    ONLY_ARCH_REGEX "^wasm32$"
+    INSTALL_IN_COMPONENT stdlib
+  )
 
-    set(SWIFT_SYNCHRONIZATION_EMBEDDED_SOURCES)
+  # All other architectures get just the atomic sources. wasm32 is handled
+  # by the previous call; avr is unsupported.
+  add_embedded_swift_target_library(
+    embedded-synchronization
+    swiftSynchronization
 
-    if("${arch}" MATCHES "wasm32")
-      list(APPEND SWIFT_SYNCHRONIZATION_EMBEDDED_SOURCES ${SWIFT_SYNCHRONIZATION_SOURCES})
-      list(APPEND SWIFT_SYNCHRONIZATION_EMBEDDED_SOURCES ${SWIFT_SYNCHRONIZATION_WASM_SOURCES})
-    else()
-      list(APPEND SWIFT_SYNCHRONIZATION_EMBEDDED_SOURCES ${SWIFT_SYNCHRONIZATION_ATOMIC_SOURCES})
-    endif()
-      
-    add_swift_target_library_single(
-      embedded-synchronization-${mod}
-      swiftSynchronization
-      
-      ${SWIFT_SYNCHRONIZATION_EMBEDDED_SOURCES}
-      
-      GYB_SOURCES
-        ${SWIFT_SYNCHRONIZATION_GYB_SOURCES}
+    ${SWIFT_SYNCHRONIZATION_ATOMIC_SOURCES}
 
-      SWIFT_COMPILE_FLAGS
-        ${SWIFT_SYNCHRNOIZATION_SWIFT_FLAGS}
-
-      SDK "embedded"
-      ARCHITECTURE "${arch}"
-      DEPENDS embedded-stdlib-${mod}
-      INSTALL_IN_COMPONENT stdlib
-      )
-    add_dependencies(embedded-synchronization embedded-synchronization-${mod})
-  endforeach()
+    GYB_SOURCES ${SWIFT_SYNCHRONIZATION_GYB_SOURCES}
+    SWIFT_COMPILE_FLAGS ${SWIFT_SYNCHRNOIZATION_SWIFT_FLAGS}
+    SKIP_ARCH_REGEX "^wasm32$" "^avr$"
+    INSTALL_IN_COMPONENT stdlib
+  )
 endif()

--- a/stdlib/public/Synchronization/CMakeLists.txt
+++ b/stdlib/public/Synchronization/CMakeLists.txt
@@ -205,7 +205,6 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
     add_swift_target_library_single(
       embedded-synchronization-${mod}
       swiftSynchronization
-      ONLY_SWIFTMODULE
       IS_FRAGILE
       
       ${SWIFT_SYNCHRONIZATION_EMBEDDED_SOURCES}
@@ -215,7 +214,6 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
 
       SWIFT_COMPILE_FLAGS
         ${SWIFT_SYNCHRNOIZATION_SWIFT_FLAGS}
-        -Xcc -ffreestanding -enable-experimental-feature Embedded
 
       MODULE_DIR "${CMAKE_BINARY_DIR}/lib/swift/embedded"
       SDK "embedded"

--- a/stdlib/public/Synchronization/CMakeLists.txt
+++ b/stdlib/public/Synchronization/CMakeLists.txt
@@ -169,12 +169,6 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
   add_custom_target(embedded-synchronization)
   add_dependencies(embedded-libraries embedded-synchronization)
 
-  set(SWIFT_ENABLE_REFLECTION OFF)
-  set(SWIFT_STDLIB_SUPPORT_BACK_DEPLOYMENT OFF)
-  set(SWIFT_STDLIB_STABLE_ABI OFF)
-  set(SWIFT_STDLIB_ENABLE_OBJC_INTEROP OFF)
-  set(SWIFT_STDLIB_ENABLE_VECTOR_TYPES OFF)
-
   foreach(entry ${EMBEDDED_STDLIB_TARGET_TRIPLES})
     string(REGEX REPLACE "[ \t]+" ";" list "${entry}")
     list(GET list 0 arch)
@@ -187,7 +181,6 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
     endif()
 
     set(SWIFT_SDK_embedded_ARCH_${arch}_MODULE "${mod}")
-    set(SWIFT_SDK_embedded_LIB_SUBDIR "embedded")
     set(SWIFT_SDK_embedded_ARCH_${arch}_TRIPLE "${triple}")
     if(SWIFT_EMBEDDED_STDLIB_SDKS_FOR_TARGET_TRIPLES)
       set(SWIFT_SDK_embedded_ARCH_${arch}_PATH "${EMBEDDED_STDLIB_SDK_FOR_${triple}}")
@@ -205,7 +198,6 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
     add_swift_target_library_single(
       embedded-synchronization-${mod}
       swiftSynchronization
-      IS_FRAGILE
       
       ${SWIFT_SYNCHRONIZATION_EMBEDDED_SOURCES}
       
@@ -215,7 +207,6 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
       SWIFT_COMPILE_FLAGS
         ${SWIFT_SYNCHRNOIZATION_SWIFT_FLAGS}
 
-      MODULE_DIR "${CMAKE_BINARY_DIR}/lib/swift/embedded"
       SDK "embedded"
       ARCHITECTURE "${arch}"
       DEPENDS embedded-stdlib-${mod}

--- a/stdlib/public/Volatile/CMakeLists.txt
+++ b/stdlib/public/Volatile/CMakeLists.txt
@@ -24,31 +24,16 @@ add_swift_target_library(swift_Volatile ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_S
 if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
   add_custom_target(embedded-volatile)
   add_dependencies(embedded-libraries embedded-volatile)
-  foreach(entry ${EMBEDDED_STDLIB_TARGET_TRIPLES})
-    string(REGEX REPLACE "[ \t]+" ";" list "${entry}")
-    list(GET list 0 arch)
-    list(GET list 1 mod)
-    list(GET list 2 triple)
 
-    set(SWIFT_SDK_embedded_ARCH_${arch}_MODULE "${mod}")
-    set(SWIFT_SDK_embedded_ARCH_${arch}_TRIPLE "${triple}")
-    if(SWIFT_EMBEDDED_STDLIB_SDKS_FOR_TARGET_TRIPLES)
-      set(SWIFT_SDK_embedded_ARCH_${arch}_PATH "${EMBEDDED_STDLIB_SDK_FOR_${triple}}")
-    endif()
-    add_swift_target_library_single(
-      embedded-volatile-${mod}
-      swift_Volatile
-      IS_SDK_OVERLAY
+  add_embedded_swift_target_library(
+    embedded-volatile
+    swift_Volatile
+    IS_SDK_OVERLAY
 
-      Volatile.swift
+    Volatile.swift
 
-      SWIFT_COMPILE_FLAGS
-        -parse-stdlib
-      SDK "embedded"
-      ARCHITECTURE "${arch}"
-      DEPENDS embedded-stdlib-${mod}
-      INSTALL_IN_COMPONENT stdlib
-      )
-    add_dependencies(embedded-volatile embedded-volatile-${mod})
-  endforeach()
+    SWIFT_COMPILE_FLAGS
+      -parse-stdlib
+    INSTALL_IN_COMPONENT stdlib
+  )
 endif()

--- a/stdlib/public/Volatile/CMakeLists.txt
+++ b/stdlib/public/Volatile/CMakeLists.txt
@@ -31,7 +31,6 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
     list(GET list 2 triple)
 
     set(SWIFT_SDK_embedded_ARCH_${arch}_MODULE "${mod}")
-    set(SWIFT_SDK_embedded_LIB_SUBDIR "embedded")
     set(SWIFT_SDK_embedded_ARCH_${arch}_TRIPLE "${triple}")
     if(SWIFT_EMBEDDED_STDLIB_SDKS_FOR_TARGET_TRIPLES)
       set(SWIFT_SDK_embedded_ARCH_${arch}_PATH "${EMBEDDED_STDLIB_SDK_FOR_${triple}}")
@@ -39,13 +38,12 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
     add_swift_target_library_single(
       embedded-volatile-${mod}
       swift_Volatile
-      IS_SDK_OVERLAY IS_FRAGILE
+      IS_SDK_OVERLAY
 
       Volatile.swift
 
       SWIFT_COMPILE_FLAGS
         -parse-stdlib
-      MODULE_DIR "${CMAKE_BINARY_DIR}/lib/swift/embedded"
       SDK "embedded"
       ARCHITECTURE "${arch}"
       DEPENDS embedded-stdlib-${mod}

--- a/stdlib/public/Volatile/CMakeLists.txt
+++ b/stdlib/public/Volatile/CMakeLists.txt
@@ -39,16 +39,12 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
     add_swift_target_library_single(
       embedded-volatile-${mod}
       swift_Volatile
-      ONLY_SWIFTMODULE
       IS_SDK_OVERLAY IS_FRAGILE
 
       Volatile.swift
 
       SWIFT_COMPILE_FLAGS
-        -Xcc -ffreestanding -enable-experimental-feature Embedded
         -parse-stdlib
-      C_COMPILE_FLAGS
-        -ffreestanding
       MODULE_DIR "${CMAKE_BINARY_DIR}/lib/swift/embedded"
       SDK "embedded"
       ARCHITECTURE "${arch}"

--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -516,12 +516,6 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
   add_custom_target(embedded-stdlib)
   add_dependencies(embedded-libraries embedded-stdlib)
 
-  set(SWIFT_ENABLE_REFLECTION OFF)
-  set(SWIFT_STDLIB_SUPPORT_BACK_DEPLOYMENT OFF)
-  set(SWIFT_STDLIB_STABLE_ABI OFF)
-  set(SWIFT_STDLIB_ENABLE_OBJC_INTEROP OFF)
-  set(SWIFT_STDLIB_ENABLE_VECTOR_TYPES OFF)
-
   foreach(entry ${EMBEDDED_STDLIB_TARGET_TRIPLES})
     string(REGEX REPLACE "[ \t]+" ";" list "${entry}")
     list(GET list 0 arch)
@@ -529,24 +523,18 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
     list(GET list 2 triple)
     
     set(SWIFT_SDK_embedded_ARCH_${arch}_MODULE "${mod}")
-    set(SWIFT_SDK_embedded_LIB_SUBDIR "embedded")
     set(SWIFT_SDK_embedded_ARCH_${arch}_TRIPLE "${triple}")
     if(SWIFT_EMBEDDED_STDLIB_SDKS_FOR_TARGET_TRIPLES)
       set(SWIFT_SDK_embedded_ARCH_${arch}_PATH "${EMBEDDED_STDLIB_SDK_FOR_${triple}}")
     endif()
-    set(swift_embedded_stdlib_extra_compile_flags)
-    if(SWIFT_USE_SWIFT_EMBEDDED_PLATFORM)
-      list(APPEND swift_embedded_stdlib_extra_compile_flags "-D" "SWIFT_USE_EMBEDDED_SWIFT_PLATFORM")
-    endif()
     add_swift_target_library_single(
       embedded-stdlib-${mod}
       swiftCore
-      IS_STDLIB IS_STDLIB_CORE IS_FRAGILE
+      IS_STDLIB IS_STDLIB_CORE
       ${SWIFTLIB_EMBEDDED_SOURCES}
       GYB_SOURCES ${SWIFTLIB_EMBEDDED_GYB_SOURCES}
       SWIFT_COMPILE_FLAGS
-        ${swift_stdlib_compile_flags} ${swift_embedded_stdlib_extra_compile_flags}
-      MODULE_DIR "${CMAKE_BINARY_DIR}/lib/swift/embedded"
+        ${swift_stdlib_compile_flags}
       SDK "embedded"
       ARCHITECTURE "${arch}"
       FILE_DEPENDS ${swiftCore_common_dependencies}

--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -550,12 +550,11 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
     add_swift_target_library_single(
       embedded-stdlib-${mod}
       swiftCore
-      ONLY_SWIFTMODULE
       IS_STDLIB IS_STDLIB_CORE IS_FRAGILE
       ${SWIFTLIB_EMBEDDED_SOURCES}
       GYB_SOURCES ${SWIFTLIB_EMBEDDED_GYB_SOURCES}
       SWIFT_COMPILE_FLAGS
-        ${swift_stdlib_compile_flags} -Xcc -ffreestanding -enable-experimental-feature Embedded ${swift_embedded_stdlib_extra_compile_flags}
+        ${swift_stdlib_compile_flags} ${swift_embedded_stdlib_extra_compile_flags}
       MODULE_DIR "${CMAKE_BINARY_DIR}/lib/swift/embedded"
       SDK "embedded"
       ARCHITECTURE "${arch}"

--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -522,15 +522,6 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
   set(SWIFT_STDLIB_ENABLE_OBJC_INTEROP OFF)
   set(SWIFT_STDLIB_ENABLE_VECTOR_TYPES OFF)
 
-  # Under Embedded Swift, all stdlib APIs should be available always. Replace
-  # all availability macros with an empty expansion (`*`).
-  set(SWIFT_STDLIB_AVAILABILITY_DEFINITIONS_EMBEDDED)
-  foreach(def ${SWIFT_STDLIB_AVAILABILITY_DEFINITIONS})
-    string(REGEX REPLACE ":.*" ":*" replaced "${def}")
-    list(APPEND SWIFT_STDLIB_AVAILABILITY_DEFINITIONS_EMBEDDED "${replaced}")
-  endforeach()
-  set(SWIFT_STDLIB_AVAILABILITY_DEFINITIONS "${SWIFT_STDLIB_AVAILABILITY_DEFINITIONS_EMBEDDED}")
-
   foreach(entry ${EMBEDDED_STDLIB_TARGET_TRIPLES})
     string(REGEX REPLACE "[ \t]+" ";" list "${entry}")
     list(GET list 0 arch)

--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -509,38 +509,21 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
   endforeach()
 endif()
 
-# Embedded standard library - embedded libraries are built as .swiftmodule only,
-# i.e. there is no .o or .a file produced (no binary code is actually produced)
-# and only users of a library are going to actually compile any needed code.
+# Embedded standard library.
 if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
   add_custom_target(embedded-stdlib)
   add_dependencies(embedded-libraries embedded-stdlib)
 
-  foreach(entry ${EMBEDDED_STDLIB_TARGET_TRIPLES})
-    string(REGEX REPLACE "[ \t]+" ";" list "${entry}")
-    list(GET list 0 arch)
-    list(GET list 1 mod)
-    list(GET list 2 triple)
-    
-    set(SWIFT_SDK_embedded_ARCH_${arch}_MODULE "${mod}")
-    set(SWIFT_SDK_embedded_ARCH_${arch}_TRIPLE "${triple}")
-    if(SWIFT_EMBEDDED_STDLIB_SDKS_FOR_TARGET_TRIPLES)
-      set(SWIFT_SDK_embedded_ARCH_${arch}_PATH "${EMBEDDED_STDLIB_SDK_FOR_${triple}}")
-    endif()
-    add_swift_target_library_single(
-      embedded-stdlib-${mod}
-      swiftCore
-      IS_STDLIB IS_STDLIB_CORE
-      ${SWIFTLIB_EMBEDDED_SOURCES}
-      GYB_SOURCES ${SWIFTLIB_EMBEDDED_GYB_SOURCES}
-      SWIFT_COMPILE_FLAGS
-        ${swift_stdlib_compile_flags}
-      SDK "embedded"
-      ARCHITECTURE "${arch}"
-      FILE_DEPENDS ${swiftCore_common_dependencies}
-      DEPENDS ${tooling_stdlib_deps}
-      INSTALL_IN_COMPONENT stdlib
-      )
-    add_dependencies(embedded-stdlib embedded-stdlib-${mod})
-  endforeach()
+  add_embedded_swift_target_library(
+    embedded-stdlib
+    swiftCore
+    IS_STDLIB IS_STDLIB_CORE
+    ${SWIFTLIB_EMBEDDED_SOURCES}
+    GYB_SOURCES ${SWIFTLIB_EMBEDDED_GYB_SOURCES}
+    SWIFT_COMPILE_FLAGS
+      ${swift_stdlib_compile_flags}
+    FILE_DEPENDS ${swiftCore_common_dependencies}
+    DEPENDS ${tooling_stdlib_deps}
+    INSTALL_IN_COMPONENT stdlib
+  )
 endif()

--- a/stdlib/public/stubs/Exclusivity/CMakeLists.txt
+++ b/stdlib/public/stubs/Exclusivity/CMakeLists.txt
@@ -18,12 +18,7 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
       continue()
     endif()
 
-    if (SWIFT_HOST_VARIANT STREQUAL "linux")
-      set(extra_c_compile_flags -ffreestanding)
-    elseif (SWIFT_HOST_VARIANT STREQUAL "macosx")
-      set(extra_c_compile_flags -ffreestanding)
-    endif()
-    list(APPEND extra_c_compile_flags -nostdinc++)
+    set(extra_c_compile_flags -nostdinc++)
 
     set(SWIFT_SDK_embedded_ARCH_${mod}_MODULE "${mod}")
     set(SWIFT_SDK_embedded_LIB_SUBDIR "embedded")
@@ -68,8 +63,6 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
         PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
         )
       set_property(TARGET embedded-exclusivity-${impl}-${mod} PROPERTY OSX_ARCHITECTURES "${arch}")
-
-      embedded_amend_archive_commands_on_darwin_host(embedded-exclusivity-${impl}-${mod} ${triple})
 
       add_dependencies(embedded-exclusivity embedded-exclusivity-${impl}-${mod})
     endforeach()

--- a/stdlib/public/stubs/Exclusivity/CMakeLists.txt
+++ b/stdlib/public/stubs/Exclusivity/CMakeLists.txt
@@ -21,7 +21,6 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
     set(extra_c_compile_flags -nostdinc++)
 
     set(SWIFT_SDK_embedded_ARCH_${mod}_MODULE "${mod}")
-    set(SWIFT_SDK_embedded_LIB_SUBDIR "embedded")
     set(SWIFT_SDK_embedded_ARCH_${mod}_TRIPLE "${triple}")
     if(SWIFT_EMBEDDED_STDLIB_SDKS_FOR_TARGET_TRIPLES)
       set(SWIFT_SDK_embedded_ARCH_${mod}_PATH "${EMBEDDED_STDLIB_SDK_FOR_${triple}}")
@@ -39,13 +38,11 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
         embedded-exclusivity-${impl}-${mod}
         swiftExclusivity${impl}
         STATIC
-        IS_FRAGILE
         PARTIAL_SOURCES_INTENDED
 
         ${impl}.cpp
 
         C_COMPILE_FLAGS ${extra_c_compile_flags}
-        MODULE_DIR "${CMAKE_BINARY_DIR}/lib/swift/embedded"
         SDK "embedded"
         ARCHITECTURE "${mod}"
         DEPENDS embedded-stdlib-${mod}

--- a/stdlib/public/stubs/Exclusivity/CMakeLists.txt
+++ b/stdlib/public/stubs/Exclusivity/CMakeLists.txt
@@ -4,64 +4,30 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
   add_custom_target(embedded-exclusivity)
   add_dependencies(embedded-libraries embedded-exclusivity)
 
-  foreach(entry ${EMBEDDED_STDLIB_TARGET_TRIPLES})
-    string(REGEX REPLACE "[ \t]+" ";" list "${entry}")
-    list(GET list 0 arch)
-    list(GET list 1 mod)
-    list(GET list 2 triple)
+  foreach(impl ${EMBEDDED_SWIFT_EXCLUSIVITY_IMPLEMENTATIONS})
+    add_custom_target(embedded-exclusivity-${impl})
+    add_dependencies(embedded-exclusivity embedded-exclusivity-${impl})
 
-    if("${mod}" MATCHES "-windows-msvc$")
-      continue()
+    # C11 thread-local does not work with -none- triples.
+    set(per_impl_skip_triple)
+    if("${impl}" STREQUAL "C11ThreadLocal")
+      list(APPEND per_impl_skip_triple "-none-")
     endif()
 
-    if("${arch}" MATCHES "avr")
-      continue()
-    endif()
+    add_embedded_swift_target_library(
+      embedded-exclusivity-${impl}
+      swiftExclusivity${impl}
+      PARTIAL_SOURCES_INTENDED
+      INSTALL_BINARY
 
-    set(extra_c_compile_flags -nostdinc++)
+      ${impl}.cpp
 
-    set(SWIFT_SDK_embedded_ARCH_${mod}_MODULE "${mod}")
-    set(SWIFT_SDK_embedded_ARCH_${mod}_TRIPLE "${triple}")
-    if(SWIFT_EMBEDDED_STDLIB_SDKS_FOR_TARGET_TRIPLES)
-      set(SWIFT_SDK_embedded_ARCH_${mod}_PATH "${EMBEDDED_STDLIB_SDK_FOR_${triple}}")
-    endif()
-
-    foreach(impl ${EMBEDDED_SWIFT_EXCLUSIVITY_IMPLEMENTATIONS})
-      # C11 thread-local does not work with -none- triples.
-      if ("${impl}" MATCHES "C11ThreadLocal")
-        if("${triple}" MATCHES "-none-")
-            continue()
-        endif()
-      endif()
-
-      add_swift_target_library_single(
-        embedded-exclusivity-${impl}-${mod}
-        swiftExclusivity${impl}
-        STATIC
-        PARTIAL_SOURCES_INTENDED
-
-        ${impl}.cpp
-
-        C_COMPILE_FLAGS ${extra_c_compile_flags}
-        SDK "embedded"
-        ARCHITECTURE "${mod}"
-        DEPENDS embedded-stdlib-${mod}
-        INSTALL_IN_COMPONENT stdlib
-        )
-      swift_install_in_component(
-        TARGETS embedded-exclusivity-${impl}-${mod}
-        DESTINATION "lib/swift/embedded/${mod}"
-        COMPONENT "stdlib"
-        )
-      swift_install_in_component(
-        FILES "${SWIFTLIB_DIR}/embedded/${mod}/libswiftExclusivity${impl}.a"
-        DESTINATION "lib/swift/embedded/${mod}/"
-        COMPONENT "stdlib"
-        PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
-        )
-      set_property(TARGET embedded-exclusivity-${impl}-${mod} PROPERTY OSX_ARCHITECTURES "${arch}")
-
-      add_dependencies(embedded-exclusivity embedded-exclusivity-${impl}-${mod})
-    endforeach()
+      C_COMPILE_FLAGS -nostdinc++
+      SKIP_MOD_REGEX "-windows-msvc$"
+      SKIP_ARCH_REGEX "avr"
+      SKIP_TRIPLE_REGEX ${per_impl_skip_triple}
+      ARCHITECTURE_KEY mod
+      INSTALL_IN_COMPONENT stdlib
+    )
   endforeach()
 endif()

--- a/stdlib/public/stubs/Unicode/CMakeLists.txt
+++ b/stdlib/public/stubs/Unicode/CMakeLists.txt
@@ -18,12 +18,7 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
       continue()
     endif()
 
-    if (SWIFT_HOST_VARIANT STREQUAL "linux")
-      set(extra_c_compile_flags -ffreestanding)
-    elseif (SWIFT_HOST_VARIANT STREQUAL "macosx")
-      set(extra_c_compile_flags -ffreestanding)
-    endif()
-    list(APPEND extra_c_compile_flags -nostdinc++)
+    set(extra_c_compile_flags -nostdinc++)
 
     set(SWIFT_SDK_embedded_ARCH_${mod}_MODULE "${mod}")
     set(SWIFT_SDK_embedded_LIB_SUBDIR "embedded")
@@ -64,8 +59,6 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
       PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
       )
     set_property(TARGET embedded-unicode-${mod} PROPERTY OSX_ARCHITECTURES "${arch}")
-
-    embedded_amend_archive_commands_on_darwin_host(embedded-unicode-${mod} ${triple})
 
     add_dependencies(embedded-unicode embedded-unicode-${mod})
   endforeach()

--- a/stdlib/public/stubs/Unicode/CMakeLists.txt
+++ b/stdlib/public/stubs/Unicode/CMakeLists.txt
@@ -21,7 +21,6 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
     set(extra_c_compile_flags -nostdinc++)
 
     set(SWIFT_SDK_embedded_ARCH_${mod}_MODULE "${mod}")
-    set(SWIFT_SDK_embedded_LIB_SUBDIR "embedded")
     set(SWIFT_SDK_embedded_ARCH_${mod}_TRIPLE "${triple}")
     if(SWIFT_EMBEDDED_STDLIB_SDKS_FOR_TARGET_TRIPLES)
       set(SWIFT_SDK_embedded_ARCH_${mod}_PATH "${EMBEDDED_STDLIB_SDK_FOR_${triple}}")
@@ -31,7 +30,6 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
       embedded-unicode-${mod}
       swiftUnicodeDataTables
       STATIC
-      IS_FRAGILE
 
       UnicodeData.cpp
       UnicodeEmoji.cpp
@@ -41,7 +39,6 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
       UnicodeWord.cpp
 
       C_COMPILE_FLAGS ${extra_c_compile_flags}
-      MODULE_DIR "${CMAKE_BINARY_DIR}/lib/swift/embedded"
       SDK "embedded"
       ARCHITECTURE "${mod}"
       DEPENDS embedded-stdlib-${mod}

--- a/stdlib/public/stubs/Unicode/CMakeLists.txt
+++ b/stdlib/public/stubs/Unicode/CMakeLists.txt
@@ -4,59 +4,22 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
   add_custom_target(embedded-unicode)
   add_dependencies(embedded-libraries embedded-unicode)
 
-  foreach(entry ${EMBEDDED_STDLIB_TARGET_TRIPLES})
-    string(REGEX REPLACE "[ \t]+" ";" list "${entry}")
-    list(GET list 0 arch)
-    list(GET list 1 mod)
-    list(GET list 2 triple)
+  add_embedded_swift_target_library(
+    embedded-unicode
+    swiftUnicodeDataTables
+    INSTALL_BINARY
 
-    if("${mod}" MATCHES "-windows-msvc$")
-      continue()
-    endif()
+    UnicodeData.cpp
+    UnicodeEmoji.cpp
+    UnicodeGrapheme.cpp
+    UnicodeNormalization.cpp
+    UnicodeScalarProps.cpp
+    UnicodeWord.cpp
 
-    if("${arch}" MATCHES "avr")
-      continue()
-    endif()
-
-    set(extra_c_compile_flags -nostdinc++)
-
-    set(SWIFT_SDK_embedded_ARCH_${mod}_MODULE "${mod}")
-    set(SWIFT_SDK_embedded_ARCH_${mod}_TRIPLE "${triple}")
-    if(SWIFT_EMBEDDED_STDLIB_SDKS_FOR_TARGET_TRIPLES)
-      set(SWIFT_SDK_embedded_ARCH_${mod}_PATH "${EMBEDDED_STDLIB_SDK_FOR_${triple}}")
-    endif()
-
-    add_swift_target_library_single(
-      embedded-unicode-${mod}
-      swiftUnicodeDataTables
-      STATIC
-
-      UnicodeData.cpp
-      UnicodeEmoji.cpp
-      UnicodeGrapheme.cpp
-      UnicodeNormalization.cpp
-      UnicodeScalarProps.cpp
-      UnicodeWord.cpp
-
-      C_COMPILE_FLAGS ${extra_c_compile_flags}
-      SDK "embedded"
-      ARCHITECTURE "${mod}"
-      DEPENDS embedded-stdlib-${mod}
-      INSTALL_IN_COMPONENT stdlib
-      )
-    swift_install_in_component(
-      TARGETS embedded-unicode-${mod}
-      DESTINATION "lib/swift/embedded/${mod}"
-      COMPONENT "stdlib"
-      )
-    swift_install_in_component(
-      FILES "${SWIFTLIB_DIR}/embedded/${mod}/libswiftUnicodeDataTables.a"
-      DESTINATION "lib/swift/embedded/${mod}/"
-      COMPONENT "stdlib"
-      PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
-      )
-    set_property(TARGET embedded-unicode-${mod} PROPERTY OSX_ARCHITECTURES "${arch}")
-
-    add_dependencies(embedded-unicode embedded-unicode-${mod})
-  endforeach()
+    C_COMPILE_FLAGS -nostdinc++
+    SKIP_MOD_REGEX "-windows-msvc$"
+    SKIP_ARCH_REGEX "avr"
+    ARCHITECTURE_KEY mod
+    INSTALL_IN_COMPONENT stdlib
+  )
 endif()

--- a/test/embedded/dependencies-concurrency-custom-executor.swift
+++ b/test/embedded/dependencies-concurrency-custom-executor.swift
@@ -19,6 +19,7 @@ _clock_gettime
 _exit
 _free
 _malloc
+_memcpy
 _memmove
 _memset
 _memset_s


### PR DESCRIPTION
The Embedded Swift library builds for the standard library, concurrency, etc. had a lot of copy-paste in them, as well as a bunch of specialized behavior forced through `add_swift_target_library_single`. Consolidate most of that logic into `add_swift_target_library_single` itself, predicated on the SDK being `embedded`. Then, introduce `add_embedded_swift_target_library` to handle the looping over the embedded architectures.

There's also a deliberate semantic change that started this all: this removes the `ONLY_SWIFTMODULE` option, which was used to create a `.swiftmodule` but not a corresponding `.a` for some of the embedded swift libraries. This approach doesn't really match with what any other build system does (including CMake's proper support for Swift), and has been made unnecessary by `-emit-empty-object-file` and `CodeGenerationModel=implementation`. The latter is what ensures that everything is emitted into client when used, while the former makes sure that *nothing* gets into the object file at all. This change also sets us up for allowing alternative compilation modules for embedded swift.

Addresses https://github.com/swiftlang/swift/pull/89494