### PR TITLE
[Swiftify] print count expressions as Swift syntax

### DIFF
--- a/lib/ClangImporter/ClangClassTemplateNamePrinter.cpp
+++ b/lib/ClangImporter/ClangClassTemplateNamePrinter.cpp
@@ -47,14 +47,12 @@ struct TemplateInstantiationNamePrinter
       return "Void";
     case clang::BuiltinType::NullPtr:
       return "__cxxNullPtrT";
-
-#define MAP_BUILTIN_TYPE(CLANG_BUILTIN_KIND, SWIFT_TYPE_NAME)                  \
-    case clang::BuiltinType::CLANG_BUILTIN_KIND:                               \
-      return #SWIFT_TYPE_NAME;
-#include "swift/ClangImporter/BuiltinMappedTypes.def"
     default:
       break;
     }
+
+    if (std::optional<StringRef> swiftName = getBuiltinTypeSwiftName(type))
+      return swiftName->str();
 
     return VisitType(type);
   }

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -45,6 +45,7 @@
 #include "clang/AST/DeclObjCCommon.h"
 #include "clang/AST/DeclTemplate.h"
 #include "clang/AST/ExprCXX.h"
+#include "clang/AST/Type.h"
 #include "clang/AST/TypeVisitor.h"
 #include "clang/Basic/Builtins.h"
 #include "clang/Lex/Preprocessor.h"
@@ -52,6 +53,7 @@
 #include "clang/Sema/Sema.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/Support/Compiler.h"
+#include <optional>
 
 using namespace swift;
 using namespace importer;
@@ -79,6 +81,121 @@ bool ClangImporter::Implementation::isOverAligned(
 bool ClangImporter::Implementation::isOverAligned(clang::QualType type) const {
   auto align = getClangASTContext().getTypeAlignInChars(type);
   return align > clang::CharUnits::fromQuantity(MaximumAlignment);
+}
+
+std::optional<StringRef>
+importer::getBuiltinTypeSwiftName(const clang::BuiltinType *type) {
+  switch (type->getKind()) {
+  case clang::BuiltinType::Void:
+    return std::nullopt;
+
+    // Builtin kinds with a Swift stdlib equivalent.
+#define MAP_BUILTIN_TYPE(CLANG_KIND, SWIFT_NAME)                               \
+  case clang::BuiltinType::CLANG_KIND:                                         \
+    return StringRef(#SWIFT_NAME);
+#include "swift/ClangImporter/BuiltinMappedTypes.def"
+
+  // Types that cannot be mapped into Swift, and probably won't ever be.
+  case clang::BuiltinType::Dependent:
+  case clang::BuiltinType::ARCUnbridgedCast:
+  case clang::BuiltinType::BoundMember:
+  case clang::BuiltinType::BuiltinFn:
+  case clang::BuiltinType::IncompleteMatrixIdx:
+  case clang::BuiltinType::Overload:
+  case clang::BuiltinType::PseudoObject:
+  case clang::BuiltinType::UnknownAny:
+  case clang::BuiltinType::UnresolvedTemplate:
+    return std::nullopt;
+
+  // FIXME: Types that can be mapped, but aren't yet.
+  case clang::BuiltinType::ShortAccum:
+  case clang::BuiltinType::Accum:
+  case clang::BuiltinType::LongAccum:
+  case clang::BuiltinType::UShortAccum:
+  case clang::BuiltinType::UAccum:
+  case clang::BuiltinType::ULongAccum:
+  case clang::BuiltinType::ShortFract:
+  case clang::BuiltinType::Fract:
+  case clang::BuiltinType::LongFract:
+  case clang::BuiltinType::UShortFract:
+  case clang::BuiltinType::UFract:
+  case clang::BuiltinType::ULongFract:
+  case clang::BuiltinType::SatShortAccum:
+  case clang::BuiltinType::SatAccum:
+  case clang::BuiltinType::SatLongAccum:
+  case clang::BuiltinType::SatUShortAccum:
+  case clang::BuiltinType::SatUAccum:
+  case clang::BuiltinType::SatULongAccum:
+  case clang::BuiltinType::SatShortFract:
+  case clang::BuiltinType::SatFract:
+  case clang::BuiltinType::SatLongFract:
+  case clang::BuiltinType::SatUShortFract:
+  case clang::BuiltinType::SatUFract:
+  case clang::BuiltinType::SatULongFract:
+  case clang::BuiltinType::BFloat16:
+  case clang::BuiltinType::Float128:
+  case clang::BuiltinType::NullPtr:
+  case clang::BuiltinType::Ibm128:
+    return std::nullopt;
+
+  // Objective-C types that aren't mapped directly; rather, pointers to
+  // these types will be mapped.
+  case clang::BuiltinType::ObjCClass:
+  case clang::BuiltinType::ObjCId:
+  case clang::BuiltinType::ObjCSel:
+    return std::nullopt;
+
+  // OpenMP types that don't have Swift equivalents.
+  case clang::BuiltinType::ArraySection:
+  case clang::BuiltinType::OMPArrayShaping:
+  case clang::BuiltinType::OMPIterator:
+    return std::nullopt;
+
+  // OpenCL builtin types that don't have Swift equivalents.
+  case clang::BuiltinType::OCLClkEvent:
+  case clang::BuiltinType::OCLEvent:
+  case clang::BuiltinType::OCLSampler:
+  case clang::BuiltinType::OCLQueue:
+  case clang::BuiltinType::OCLReserveID:
+#define IMAGE_TYPE(Name, Id, ...) case clang::BuiltinType::Id:
+#include "clang/Basic/OpenCLImageTypes.def"
+#define EXT_OPAQUE_TYPE(Name, Id, ...) case clang::BuiltinType::Id:
+#include "clang/Basic/OpenCLExtensionTypes.def"
+    return std::nullopt;
+
+  // ARM SVE builtin types that don't have Swift equivalents.
+#define SVE_TYPE(Name, Id, ...) case clang::BuiltinType::Id:
+#include "clang/Basic/AArch64ACLETypes.def"
+    return std::nullopt;
+
+  // PPC SVE builtin types that don't have Swift equivalents.
+#define PPC_VECTOR_TYPE(Name, Id, Size) case clang::BuiltinType::Id:
+#include "clang/Basic/PPCTypes.def"
+    return std::nullopt;
+
+  // RISC-V V builtin types that don't have Swift equivalents.
+#define RVV_TYPE(Name, Id, Size) case clang::BuiltinType::Id:
+#include "clang/Basic/RISCVVTypes.def"
+    return std::nullopt;
+
+  // WASM builtin types that don't have Swift equivalents.
+#define WASM_TYPE(Name, Id, Size) case clang::BuiltinType::Id:
+#include "clang/Basic/WebAssemblyReferenceTypes.def"
+    return std::nullopt;
+
+  // AMDGPU builtin types that don't have Swift equivalents.
+#define AMDGPU_TYPE(Name, Id, SingletonId, Width, Align)                       \
+  case clang::BuiltinType::Id:
+#include "clang/Basic/AMDGPUTypes.def"
+    return std::nullopt;
+
+  // HLSL intangible builtin types that don't have Swift equivalents.
+#define HLSL_INTANGIBLE_TYPE(Name, Id, ...) case clang::BuiltinType::Id:
+#include "clang/Basic/HLSLIntangibleTypes.def"
+    return std::nullopt;
+  }
+
+  llvm_unreachable("Invalid BuiltinType.");
 }
 
 namespace {
@@ -268,120 +385,34 @@ namespace {
       return T;
     }
 
-    ImportResult VisitBuiltinType(const clang::BuiltinType *type) {
-      switch (type->getKind()) {
-      case clang::BuiltinType::Void:
-        return { Type(), ImportHint::Void };
-
-#define MAP_BUILTIN_TYPE(CLANG_BUILTIN_KIND, SWIFT_TYPE_NAME)             \
-      case clang::BuiltinType::CLANG_BUILTIN_KIND:                        \
-        return unwrapCType(Impl.getNamedSwiftType(Impl.getStdlibModule(), \
-                                        #SWIFT_TYPE_NAME));
-#define MAP_BUILTIN_CCHAR_TYPE(CLANG_BUILTIN_KIND, SWIFT_TYPE_NAME)       \
-      case clang::BuiltinType::CLANG_BUILTIN_KIND:                        \
-        return Impl.getNamedSwiftType(Impl.getStdlibModule(), #SWIFT_TYPE_NAME);
+    constexpr bool isCCharBuiltinType(clang::BuiltinType::Kind kind) {
+      switch (kind) {
+      default:
+        return false;
+#define MAP_BUILTIN_TYPE(CLANG_BUILTIN_KIND, SWIFT_TYPE_NAME)
+      /* Intentionally empty; fallback to default label. */
+#define MAP_BUILTIN_CCHAR_TYPE(CLANG_BUILTIN_KIND, SWIFT_TYPE_NAME)          \
+      case clang::BuiltinType::CLANG_BUILTIN_KIND:
 #include "swift/ClangImporter/BuiltinMappedTypes.def"
-
-      // Types that cannot be mapped into Swift, and probably won't ever be.
-      case clang::BuiltinType::Dependent:
-      case clang::BuiltinType::ARCUnbridgedCast:
-      case clang::BuiltinType::BoundMember:
-      case clang::BuiltinType::BuiltinFn:
-      case clang::BuiltinType::IncompleteMatrixIdx:
-      case clang::BuiltinType::Overload:
-      case clang::BuiltinType::PseudoObject:
-      case clang::BuiltinType::UnknownAny:
-      case clang::BuiltinType::UnresolvedTemplate:
-        return Type();
-
-      // FIXME: Types that can be mapped, but aren't yet.
-      case clang::BuiltinType::ShortAccum:
-      case clang::BuiltinType::Accum:
-      case clang::BuiltinType::LongAccum:
-      case clang::BuiltinType::UShortAccum:
-      case clang::BuiltinType::UAccum:
-      case clang::BuiltinType::ULongAccum:
-      case clang::BuiltinType::ShortFract:
-      case clang::BuiltinType::Fract:
-      case clang::BuiltinType::LongFract:
-      case clang::BuiltinType::UShortFract:
-      case clang::BuiltinType::UFract:
-      case clang::BuiltinType::ULongFract:
-      case clang::BuiltinType::SatShortAccum:
-      case clang::BuiltinType::SatAccum:
-      case clang::BuiltinType::SatLongAccum:
-      case clang::BuiltinType::SatUShortAccum:
-      case clang::BuiltinType::SatUAccum:
-      case clang::BuiltinType::SatULongAccum:
-      case clang::BuiltinType::SatShortFract:
-      case clang::BuiltinType::SatFract:
-      case clang::BuiltinType::SatLongFract:
-      case clang::BuiltinType::SatUShortFract:
-      case clang::BuiltinType::SatUFract:
-      case clang::BuiltinType::SatULongFract:
-      case clang::BuiltinType::BFloat16:
-      case clang::BuiltinType::Float128:
-      case clang::BuiltinType::NullPtr:
-      case clang::BuiltinType::Ibm128:
-        return Type();
-
-      // Objective-C types that aren't mapped directly; rather, pointers to
-      // these types will be mapped.
-      case clang::BuiltinType::ObjCClass:
-      case clang::BuiltinType::ObjCId:
-      case clang::BuiltinType::ObjCSel:
-        return Type();
-
-      // OpenMP types that don't have Swift equivalents.
-      case clang::BuiltinType::ArraySection:
-      case clang::BuiltinType::OMPArrayShaping:
-      case clang::BuiltinType::OMPIterator:
-        return Type();
-
-      // OpenCL builtin types that don't have Swift equivalents.
-      case clang::BuiltinType::OCLClkEvent:
-      case clang::BuiltinType::OCLEvent:
-      case clang::BuiltinType::OCLSampler:
-      case clang::BuiltinType::OCLQueue:
-      case clang::BuiltinType::OCLReserveID:
-#define IMAGE_TYPE(Name, Id, ...) case clang::BuiltinType::Id:
-#include "clang/Basic/OpenCLImageTypes.def"
-#define EXT_OPAQUE_TYPE(Name, Id, ...) case clang::BuiltinType::Id:
-#include "clang/Basic/OpenCLExtensionTypes.def"
-        return Type();
-
-      // ARM SVE builtin types that don't have Swift equivalents.
-#define SVE_TYPE(Name, Id, ...) case clang::BuiltinType::Id:
-#include "clang/Basic/AArch64ACLETypes.def"
-        return Type();
-
-      // PPC SVE builtin types that don't have Swift equivalents.
-#define PPC_VECTOR_TYPE(Name, Id, Size) case clang::BuiltinType::Id:
-#include "clang/Basic/PPCTypes.def"
-        return Type();
-
-      // RISC-V V builtin types that don't have Swift equivalents.
-#define RVV_TYPE(Name, Id, Size) case clang::BuiltinType::Id:
-#include "clang/Basic/RISCVVTypes.def"
-        return Type();
-
-#define WASM_TYPE(Name, Id, Size) case clang::BuiltinType::Id:
-#include "clang/Basic/WebAssemblyReferenceTypes.def"
-        return Type();
-
-      // AMDGPU builtin types that don't have Swift equivalents.
-#define AMDGPU_TYPE(Name, Id, SingletonId, Width, Align)                       \
-      case clang::BuiltinType::Id:
-#include "clang/Basic/AMDGPUTypes.def"
-        return Type();
-
-      // HLSL intangible builtin types that don't have Swift equivalents.
-#define HLSL_INTANGIBLE_TYPE(Name, Id, ...) case clang::BuiltinType::Id:
-#include "clang/Basic/HLSLIntangibleTypes.def"
-        return Type();
+        return true;
       }
+    }
 
-      llvm_unreachable("Invalid BuiltinType.");
+    ImportResult VisitBuiltinType(const clang::BuiltinType *type) {
+      const clang::BuiltinType::Kind kind = type->getKind();
+      if (kind == clang::BuiltinType::Void)
+        return {Type(), ImportHint::Void};
+
+      std::optional<StringRef> swiftTypeName = getBuiltinTypeSwiftName(type);
+      if (!swiftTypeName)
+        return Type();
+
+      Type swiftType =
+          Impl.getNamedSwiftType(Impl.getStdlibModule(), *swiftTypeName);
+      // FIXME: stop unwrapping typealiases
+      if (!isCCharBuiltinType(kind))
+        swiftType = unwrapCType(swiftType);
+      return swiftType;
     }
 
     ImportResult VisitBitIntType(const clang::BitIntType *type) {

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -163,33 +163,33 @@ importer::getBuiltinTypeSwiftName(const clang::BuiltinType *type) {
 #include "clang/Basic/OpenCLExtensionTypes.def"
     return std::nullopt;
 
-  // ARM SVE builtin types that don't have Swift equivalents.
+    // ARM SVE builtin types that don't have Swift equivalents.
 #define SVE_TYPE(Name, Id, ...) case clang::BuiltinType::Id:
 #include "clang/Basic/AArch64ACLETypes.def"
     return std::nullopt;
 
-  // PPC SVE builtin types that don't have Swift equivalents.
+    // PPC SVE builtin types that don't have Swift equivalents.
 #define PPC_VECTOR_TYPE(Name, Id, Size) case clang::BuiltinType::Id:
 #include "clang/Basic/PPCTypes.def"
     return std::nullopt;
 
-  // RISC-V V builtin types that don't have Swift equivalents.
+    // RISC-V V builtin types that don't have Swift equivalents.
 #define RVV_TYPE(Name, Id, Size) case clang::BuiltinType::Id:
 #include "clang/Basic/RISCVVTypes.def"
     return std::nullopt;
 
-  // WASM builtin types that don't have Swift equivalents.
+    // WASM builtin types that don't have Swift equivalents.
 #define WASM_TYPE(Name, Id, Size) case clang::BuiltinType::Id:
 #include "clang/Basic/WebAssemblyReferenceTypes.def"
     return std::nullopt;
 
-  // AMDGPU builtin types that don't have Swift equivalents.
+    // AMDGPU builtin types that don't have Swift equivalents.
 #define AMDGPU_TYPE(Name, Id, SingletonId, Width, Align)                       \
   case clang::BuiltinType::Id:
 #include "clang/Basic/AMDGPUTypes.def"
     return std::nullopt;
 
-  // HLSL intangible builtin types that don't have Swift equivalents.
+    // HLSL intangible builtin types that don't have Swift equivalents.
 #define HLSL_INTANGIBLE_TYPE(Name, Id, ...) case clang::BuiltinType::Id:
 #include "clang/Basic/HLSLIntangibleTypes.def"
     return std::nullopt;
@@ -390,9 +390,9 @@ namespace {
       default:
         return false;
 #define MAP_BUILTIN_TYPE(CLANG_BUILTIN_KIND, SWIFT_TYPE_NAME)
-      /* Intentionally empty; fallback to default label. */
+        /* Intentionally empty; fallback to default label. */
 #define MAP_BUILTIN_CCHAR_TYPE(CLANG_BUILTIN_KIND, SWIFT_TYPE_NAME)          \
-      case clang::BuiltinType::CLANG_BUILTIN_KIND:
+    case clang::BuiltinType::CLANG_BUILTIN_KIND:
 #include "swift/ClangImporter/BuiltinMappedTypes.def"
         return true;
       }

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -2079,8 +2079,7 @@ getBuiltinTypeSwiftName(const clang::BuiltinType *bt);
 
 /// Return the Swift type name if `ty` is a `clang::BuiltinType` with a Swift
 /// counterpart.
-[[nodiscard]] std::optional<StringRef> static inline
-getBuiltinTypeSwiftName(
+[[nodiscard]] std::optional<StringRef> static inline getBuiltinTypeSwiftName(
     clang::QualType ty) {
   if (const auto *bt = ty->getAs<clang::BuiltinType>())
     return getBuiltinTypeSwiftName(bt);

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -62,6 +62,7 @@
 
 namespace clang {
 class APValue;
+class BuiltinType;
 class DeclarationName;
 class MangleContext;
 class ObjCInterfaceDecl;
@@ -2070,6 +2071,21 @@ bool isSpecialAppKitFunctionKeyProperty(const clang::NamedDecl *decl);
 /// nested types other than pointers or references.
 bool hasSameUnderlyingType(const clang::Type *a,
                            const clang::TemplateTypeParmDecl *b);
+
+/// Map a `clang::BuiltinType` to its Swift stdlib counterpart as listed in
+/// `BuiltinMappedTypes.def`, if there is one.
+[[nodiscard]] std::optional<StringRef>
+getBuiltinTypeSwiftName(const clang::BuiltinType *bt);
+
+/// Return the Swift type name if `ty` is a `clang::BuiltinType` with a Swift
+/// counterpart.
+[[nodiscard]] std::optional<StringRef> static inline
+getBuiltinTypeSwiftName(
+    clang::QualType ty) {
+  if (const auto *bt = ty->getAs<clang::BuiltinType>())
+    return getBuiltinTypeSwiftName(bt);
+  return std::nullopt;
+}
 
 /// Add command-line arguments for a normal import of Clang code.
 void getNormalInvocationArguments(std::vector<std::string> &invocationArgStrs,

--- a/lib/ClangImporter/SwiftifyDecl.cpp
+++ b/lib/ClangImporter/SwiftifyDecl.cpp
@@ -104,7 +104,7 @@ struct SwiftCountExprEmitter
   explicit SwiftCountExprEmitter(const clang::ASTContext &ctx)
       : ctx(ctx), out(result) {}
 
-  llvm::StringRef str() const { return result; }
+  StringRef str() const { return result; }
 
   bool VisitDeclRefExpr(const clang::DeclRefExpr *e) {
     const clang::DeclarationName name = e->getDecl()->getDeclName();
@@ -124,11 +124,7 @@ struct SwiftCountExprEmitter
     bool isSigned = IL->getType()->isSignedIntegerType();
     llvm::SmallString<20> valueStr;
     IL->getValue().toString(valueStr, /*Radix=*/10, isSigned);
-    if (bt->getKind() == clang::BuiltinType::Int) {
-      out << valueStr;
-      return true;
-    }
-    auto swiftName = swiftBuiltinTypeName(bt);
+    std::optional<StringRef> swiftName = swiftBuiltinTypeName(bt);
     if (!swiftName) {
       DLOG("Unsupported integer literal type\n");
       return false;
@@ -173,7 +169,7 @@ struct SwiftCountExprEmitter
   }
 
   bool VisitBinaryOperator(const clang::BinaryOperator *binop) {
-    llvm::StringRef op;
+    StringRef op;
     switch (binop->getOpcode()) {
 #define BINOP(variant, string)                                                 \
   case clang::variant:                                                         \
@@ -228,7 +224,7 @@ private:
     case CK::CK_IntegralToFloating:
     case CK::CK_FloatingToIntegral:
     case CK::CK_FloatingCast: {
-      auto swiftName = swiftBuiltinTypeName(c->getType());
+      std::optional<StringRef> swiftName = swiftBuiltinTypeName(c->getType());
       if (!swiftName) {
         DLOG("Unsupported cast destination type\n");
         return false;
@@ -250,19 +246,19 @@ private:
     }
   }
 
-  std::optional<llvm::StringRef> swiftBuiltinTypeName(clang::QualType ty) {
+  std::optional<StringRef> swiftBuiltinTypeName(clang::QualType ty) {
     const auto *bt = ty->getAs<clang::BuiltinType>();
     if (!bt)
       return std::nullopt;
     return swiftBuiltinTypeName(bt);
   }
 
-  std::optional<llvm::StringRef>
+  std::optional<StringRef>
   swiftBuiltinTypeName(const clang::BuiltinType *bt) {
     switch (bt->getKind()) {
 #define MAP_BUILTIN_TYPE(CLANG_KIND, SWIFT_NAME)                               \
   case clang::BuiltinType::CLANG_KIND:                                         \
-    return llvm::StringRef(#SWIFT_NAME);
+    return StringRef(#SWIFT_NAME);
 #define MAP_BUILTIN_CCHAR_TYPE(CLANG_KIND, SWIFT_NAME)                         \
   MAP_BUILTIN_TYPE(CLANG_KIND, SWIFT_NAME)
 #define MAP_BUILTIN_INTEGER_TYPE(CLANG_KIND, SWIFT_NAME)                       \

--- a/lib/ClangImporter/SwiftifyDecl.cpp
+++ b/lib/ClangImporter/SwiftifyDecl.cpp
@@ -217,16 +217,18 @@ struct SwiftCountExprEmitter
   bool VisitBinaryOperator(const clang::BinaryOperator *binop) {
     llvm::StringRef op;
     switch (binop->getOpcode()) {
-    case clang::BO_Add: op = " + "; break;
-    case clang::BO_Sub: op = " - "; break;
-    case clang::BO_Mul: op = " * "; break;
-    case clang::BO_Div: op = " / "; break;
-    case clang::BO_Rem: op = " % "; break;
-    case clang::BO_Shl: op = " << "; break;
-    case clang::BO_Shr: op = " >> "; break;
-    case clang::BO_And: op = " & "; break;
-    case clang::BO_Or:  op = " | "; break;
-    case clang::BO_Xor: op = " ^ "; break;
+#define BINOP(variant, string) case clang::variant: op = " " string " "; break
+    BINOP(BO_Add, "+");
+    BINOP(BO_Sub, "-");
+    BINOP(BO_Mul, "*");
+    BINOP(BO_Div, "/");
+    BINOP(BO_Rem, "%");
+    BINOP(BO_Shl, "<<");
+    BINOP(BO_Shr, ">>");
+    BINOP(BO_And, "&");
+    BINOP(BO_Or,  "|");
+    BINOP(BO_Xor, "^");
+#undef CASE_BINOP
     default:
       DLOG("Unsupported binary operator\n");
       return false;

--- a/lib/ClangImporter/SwiftifyDecl.cpp
+++ b/lib/ClangImporter/SwiftifyDecl.cpp
@@ -154,15 +154,15 @@ struct SwiftCountExprEmitter
   }
 
   bool VisitUnaryOperator(const clang::UnaryOperator *unop) {
-    llvm::StringRef op;
+    char op;
     switch (unop->getOpcode()) {
-#define UNOP(variant, string)                                                  \
+#define UNOP(variant, c)                                                  \
   case clang::variant:                                                         \
-    op = string;                                                               \
+    op = c;                                                               \
     break
-      UNOP(UO_Plus, "+");
-      UNOP(UO_Minus, "-");
-      UNOP(UO_Not, "~");
+      UNOP(UO_Plus, '+');
+      UNOP(UO_Minus, '-');
+      UNOP(UO_Not, '~');
 #undef UNOP
     default:
       DLOG("Unsupported unary operator\n");

--- a/lib/ClangImporter/SwiftifyDecl.cpp
+++ b/lib/ClangImporter/SwiftifyDecl.cpp
@@ -285,10 +285,43 @@ private:
   }
 };
 
-static Type ConcretePointeeType(Type swiftType);
+static Type ConcretePointeeType(Type swiftType) {
+  Type nonnullType = swiftType->lookThroughSingleOptionalType();
+  PointerTypeKind PTK;
+  Type PointeeTy = nonnullType->getAnyPointerElementType(PTK);
+  if (PointeeTy && (PTK == PTK_UnsafePointer || PTK == PTK_UnsafeMutablePointer))
+    return PointeeTy;
+  return Type();
+}
+
+// Don't try to transform any Swift types that _SwiftifyImport doesn't know how
+// to handle.
 static bool SwiftifiableSizedByPointerType(const clang::ASTContext &ctx,
                                            Type swiftType,
-                                           const clang::CountAttributedType *CAT);
+                                           const clang::CountAttributedType *CAT) {
+  Type nonnullType = swiftType->lookThroughSingleOptionalType();
+  if (nonnullType->isOpaquePointer())
+    return true;
+  PointerTypeKind PTK;
+  if (!nonnullType->getAnyPointerElementType(PTK)) {
+    DLOG("Ignoring sized_by on non-pointer type\n");
+    return false;
+  }
+  if (PTK == PTK_UnsafeRawPointer || PTK == PTK_UnsafeMutableRawPointer)
+    return true;
+  if (PTK != PTK_UnsafePointer && PTK != PTK_UnsafeMutablePointer) {
+    DLOG("Ignoring sized_by on Autoreleasing pointer\n");
+    CONDITIONAL_ASSERT(PTK == PTK_AutoreleasingUnsafeMutablePointer);
+    return false;
+  }
+  // We have a pointer to a type with a size. Verify that it is char-sized.
+  auto PtrT = CAT->getAs<clang::PointerType>();
+  auto PointeeT = PtrT->getPointeeType();
+  bool isByteSized = ctx.getTypeSizeInChars(PointeeT).isOne();
+  if (!isByteSized)
+    DLOG("Ignoring sized_by on non-byte-sized pointer\n");
+  return isByteSized;
+}
 
 struct SwiftifyInfoPrinter {
   static const ssize_t SELF_PARAM_INDEX = -2;
@@ -455,44 +488,6 @@ private:
   }
 };
 
-
-static Type ConcretePointeeType(Type swiftType) {
-  Type nonnullType = swiftType->lookThroughSingleOptionalType();
-  PointerTypeKind PTK;
-  Type PointeeTy = nonnullType->getAnyPointerElementType(PTK);
-  if (PointeeTy && (PTK == PTK_UnsafePointer || PTK == PTK_UnsafeMutablePointer))
-    return PointeeTy;
-  return Type();
-}
-
-// Don't try to transform any Swift types that _SwiftifyImport doesn't know how
-// to handle.
-static bool SwiftifiableSizedByPointerType(const clang::ASTContext &ctx,
-                                           Type swiftType,
-                                           const clang::CountAttributedType *CAT) {
-  Type nonnullType = swiftType->lookThroughSingleOptionalType();
-  if (nonnullType->isOpaquePointer())
-    return true;
-  PointerTypeKind PTK;
-  if (!nonnullType->getAnyPointerElementType(PTK)) {
-    DLOG("Ignoring sized_by on non-pointer type\n");
-    return false;
-  }
-  if (PTK == PTK_UnsafeRawPointer || PTK == PTK_UnsafeMutableRawPointer)
-    return true;
-  if (PTK != PTK_UnsafePointer && PTK != PTK_UnsafeMutablePointer) {
-    DLOG("Ignoring sized_by on Autoreleasing pointer\n");
-    CONDITIONAL_ASSERT(PTK == PTK_AutoreleasingUnsafeMutablePointer);
-    return false;
-  }
-  // We have a pointer to a type with a size. Verify that it is char-sized.
-  auto PtrT = CAT->getAs<clang::PointerType>();
-  auto PointeeT = PtrT->getPointeeType();
-  bool isByteSized = ctx.getTypeSizeInChars(PointeeT).isOne();
-  if (!isByteSized)
-    DLOG("Ignoring sized_by on non-byte-sized pointer\n");
-  return isByteSized;
-}
 
 // Searches for template instantiations that are not behind type aliases.
 // FIXME: make sure the generated code compiles for template

--- a/lib/ClangImporter/SwiftifyDecl.cpp
+++ b/lib/ClangImporter/SwiftifyDecl.cpp
@@ -110,7 +110,8 @@ struct SwiftCountExprEmitter
 
   bool VisitIntegerLiteral(const clang::IntegerLiteral *IL) {
     const auto *bt = IL->getType()->getAs<clang::BuiltinType>();
-    if (!bt) return false;
+    if (!bt)
+      return false;
     bool isSigned = IL->getType()->isSignedIntegerType();
     llvm::SmallString<20> valueStr;
     IL->getValue().toString(valueStr, /*Radix=*/10, isSigned);
@@ -195,7 +196,8 @@ struct SwiftCountExprEmitter
 
   bool VisitParenExpr(const clang::ParenExpr *p) {
     out << '(';
-    if (!Visit(p->getSubExpr())) return false;
+    if (!Visit(p->getSubExpr()))
+      return false;
     out << ')';
     return true;
   }
@@ -203,9 +205,14 @@ struct SwiftCountExprEmitter
   bool VisitUnaryOperator(const clang::UnaryOperator *unop) {
     llvm::StringRef op;
     switch (unop->getOpcode()) {
-    case clang::UO_Plus:  op = "+"; break;
-    case clang::UO_Minus: op = "-"; break;
-    case clang::UO_Not:   op = "~"; break;
+#define UNOP(variant, string)                                                  \
+  case clang::variant:                                                         \
+    op = string;                                                               \
+    break
+      UNOP(UO_Plus, "+");
+      UNOP(UO_Minus, "-");
+      UNOP(UO_Not, "~");
+#undef CASE_UNOP
     default:
       DLOG("Unsupported unary operator\n");
       return false;
@@ -217,17 +224,20 @@ struct SwiftCountExprEmitter
   bool VisitBinaryOperator(const clang::BinaryOperator *binop) {
     llvm::StringRef op;
     switch (binop->getOpcode()) {
-#define BINOP(variant, string) case clang::variant: op = " " string " "; break
-    BINOP(BO_Add, "+");
-    BINOP(BO_Sub, "-");
-    BINOP(BO_Mul, "*");
-    BINOP(BO_Div, "/");
-    BINOP(BO_Rem, "%");
-    BINOP(BO_Shl, "<<");
-    BINOP(BO_Shr, ">>");
-    BINOP(BO_And, "&");
-    BINOP(BO_Or,  "|");
-    BINOP(BO_Xor, "^");
+#define BINOP(variant, string)                                                 \
+  case clang::variant:                                                         \
+    op = " " string " ";                                                       \
+    break
+      BINOP(BO_Add, "+");
+      BINOP(BO_Sub, "-");
+      BINOP(BO_Mul, "*");
+      BINOP(BO_Div, "/");
+      BINOP(BO_Rem, "%");
+      BINOP(BO_Shl, "<<");
+      BINOP(BO_Shr, ">>");
+      BINOP(BO_And, "&");
+      BINOP(BO_Or, "|");
+      BINOP(BO_Xor, "^");
 #undef CASE_BINOP
     default:
       DLOG("Unsupported binary operator\n");
@@ -237,9 +247,11 @@ struct SwiftCountExprEmitter
     // relative precedence of `<<`/`>>` vs `+`/`-` and `&` vs `+`/`-`, so
     // unparenthesized output could change meaning across languages.
     out << '(';
-    if (!Visit(binop->getLHS())) return false;
+    if (!Visit(binop->getLHS()))
+      return false;
     out << op;
-    if (!Visit(binop->getRHS())) return false;
+    if (!Visit(binop->getRHS()))
+      return false;
     out << ')';
     return true;
   }
@@ -251,10 +263,12 @@ struct SwiftCountExprEmitter
 
 private:
   bool isNarrowingIntCast(const clang::CastExpr *c) {
-    if (c->getCastKind() != clang::CK_IntegralCast) return false;
+    if (c->getCastKind() != clang::CK_IntegralCast)
+      return false;
     auto destTy = c->getType();
     auto srcTy = c->getSubExpr()->getType();
-    if (!destTy->isIntegerType() || !srcTy->isIntegerType()) return false;
+    if (!destTy->isIntegerType() || !srcTy->isIntegerType())
+      return false;
     uint64_t srcBits = ctx.getTypeSize(srcTy);
     uint64_t destBits = ctx.getTypeSize(destTy);
     bool srcSigned = srcTy->isSignedIntegerType();
@@ -267,19 +281,21 @@ private:
 
   std::optional<llvm::StringRef> swiftBuiltinTypeName(clang::QualType ty) {
     const auto *bt = ty->getAs<clang::BuiltinType>();
-    if (!bt) return std::nullopt;
+    if (!bt)
+      return std::nullopt;
     return swiftBuiltinTypeName(bt);
   }
 
   std::optional<llvm::StringRef>
   swiftBuiltinTypeName(const clang::BuiltinType *bt) {
     switch (bt->getKind()) {
-#define MAP_BUILTIN_TYPE(CLANG_KIND, SWIFT_NAME) \
-    case clang::BuiltinType::CLANG_KIND: return llvm::StringRef(#SWIFT_NAME);
-#define MAP_BUILTIN_CCHAR_TYPE(CLANG_KIND, SWIFT_NAME) \
-    MAP_BUILTIN_TYPE(CLANG_KIND, SWIFT_NAME)
-#define MAP_BUILTIN_INTEGER_TYPE(CLANG_KIND, SWIFT_NAME) \
-    MAP_BUILTIN_TYPE(CLANG_KIND, SWIFT_NAME)
+#define MAP_BUILTIN_TYPE(CLANG_KIND, SWIFT_NAME)                               \
+  case clang::BuiltinType::CLANG_KIND:                                         \
+    return llvm::StringRef(#SWIFT_NAME);
+#define MAP_BUILTIN_CCHAR_TYPE(CLANG_KIND, SWIFT_NAME)                         \
+  MAP_BUILTIN_TYPE(CLANG_KIND, SWIFT_NAME)
+#define MAP_BUILTIN_INTEGER_TYPE(CLANG_KIND, SWIFT_NAME)                       \
+  MAP_BUILTIN_TYPE(CLANG_KIND, SWIFT_NAME)
 #include "swift/ClangImporter/BuiltinMappedTypes.def"
     default:
       return std::nullopt;
@@ -291,16 +307,17 @@ static Type ConcretePointeeType(Type swiftType) {
   Type nonnullType = swiftType->lookThroughSingleOptionalType();
   PointerTypeKind PTK;
   Type PointeeTy = nonnullType->getAnyPointerElementType(PTK);
-  if (PointeeTy && (PTK == PTK_UnsafePointer || PTK == PTK_UnsafeMutablePointer))
+  if (PointeeTy &&
+      (PTK == PTK_UnsafePointer || PTK == PTK_UnsafeMutablePointer))
     return PointeeTy;
   return Type();
 }
 
 // Don't try to transform any Swift types that _SwiftifyImport doesn't know how
 // to handle.
-static bool SwiftifiableSizedByPointerType(const clang::ASTContext &ctx,
-                                           Type swiftType,
-                                           const clang::CountAttributedType *CAT) {
+static bool
+SwiftifiableSizedByPointerType(const clang::ASTContext &ctx, Type swiftType,
+                               const clang::CountAttributedType *CAT) {
   Type nonnullType = swiftType->lookThroughSingleOptionalType();
   if (nonnullType->isOpaquePointer())
     return true;
@@ -404,14 +421,12 @@ struct SwiftifyInfoFunctionPrinter : public SwiftifyInfoPrinter {
                       llvm::StringMap<std::string> &typeMapping)
       : SwiftifyInfoPrinter(ctx, SwiftContext, out, SwiftifyImportDecl, typeMapping) {}
 
-  bool printCountedBy(const clang::CountAttributedType *CAT,
-                      Type swiftType,
+  bool printCountedBy(const clang::CountAttributedType *CAT, Type swiftType,
                       ssize_t pointerIndex) {
     // Step 1: check if we support this attribute
     bool isSizedBy = CAT->isCountInBytes();
-    if (isSizedBy
-            ? !SwiftifiableSizedByPointerType(ctx, swiftType, CAT)
-            : ConcretePointeeType(swiftType).isNull())
+    if (isSizedBy ? !SwiftifiableSizedByPointerType(ctx, swiftType, CAT)
+                  : ConcretePointeeType(swiftType).isNull())
       return false;
     SwiftCountExprEmitter emitter(ctx);
     if (!emitter.Visit(CAT->getCountExpr()))
@@ -489,7 +504,6 @@ private:
     return false;
   }
 };
-
 
 // Searches for template instantiations that are not behind type aliases.
 // FIXME: make sure the generated code compiles for template
@@ -804,7 +818,8 @@ static bool swiftifyImpl(ClangImporter::Implementation &Self,
                "free function mapped to instance method without swift_name??");
         Self.diagnose(HeaderLoc(swiftName->getLocation()),
                  diag::note_swift_name_instance_method);
-      } else if (CAT && printer.printCountedBy(CAT, swiftParamTy, mappedIndex)) {
+      } else if (CAT &&
+                 printer.printCountedBy(CAT, swiftParamTy, mappedIndex)) {
         DLOG("Found bounds info '" << clangParamTy << "'\n");
         attachMacro = paramHasBoundsInfo = true;
       }
@@ -885,8 +900,9 @@ static bool swiftifyImpl(ClangImporter::Implementation &Self,
       return false;
     (void)printer.registerStdSpanTypeMapping(
         swiftReturnTy, clangReturnTy);
-    if (CAT && printer.printCountedBy(CAT, swiftReturnTy,
-                                       SwiftifyInfoPrinter::RETURN_VALUE_INDEX)) {
+    if (CAT &&
+        printer.printCountedBy(CAT, swiftReturnTy,
+                               SwiftifyInfoPrinter::RETURN_VALUE_INDEX)) {
       DLOG("Found bounds info '" << clang::QualType(CAT, 0) << "' on return value\n");
       attachMacro = true;
     }

--- a/lib/ClangImporter/SwiftifyDecl.cpp
+++ b/lib/ClangImporter/SwiftifyDecl.cpp
@@ -124,7 +124,7 @@ struct SwiftCountExprEmitter
     bool isSigned = IL->getType()->isSignedIntegerType();
     llvm::SmallString<20> valueStr;
     IL->getValue().toString(valueStr, /*Radix=*/10, isSigned);
-    std::optional<StringRef> swiftName = swiftBuiltinTypeName(bt);
+    std::optional<StringRef> swiftName = getBuiltinTypeSwiftName(bt);
     if (!swiftName) {
       DLOG("Unsupported integer literal type\n");
       return false;
@@ -224,7 +224,7 @@ private:
     case CK::CK_IntegralToFloating:
     case CK::CK_FloatingToIntegral:
     case CK::CK_FloatingCast: {
-      std::optional<StringRef> swiftName = swiftBuiltinTypeName(c->getType());
+      std::optional<StringRef> swiftName = getBuiltinTypeSwiftName(c->getType());
       if (!swiftName) {
         DLOG("Unsupported cast destination type\n");
         return false;
@@ -243,29 +243,6 @@ private:
     default:
       DLOG("Unsupported cast kind\n");
       return false;
-    }
-  }
-
-  std::optional<StringRef> swiftBuiltinTypeName(clang::QualType ty) {
-    const auto *bt = ty->getAs<clang::BuiltinType>();
-    if (!bt)
-      return std::nullopt;
-    return swiftBuiltinTypeName(bt);
-  }
-
-  std::optional<StringRef>
-  swiftBuiltinTypeName(const clang::BuiltinType *bt) {
-    switch (bt->getKind()) {
-#define MAP_BUILTIN_TYPE(CLANG_KIND, SWIFT_NAME)                               \
-  case clang::BuiltinType::CLANG_KIND:                                         \
-    return StringRef(#SWIFT_NAME);
-#define MAP_BUILTIN_CCHAR_TYPE(CLANG_KIND, SWIFT_NAME)                         \
-  MAP_BUILTIN_TYPE(CLANG_KIND, SWIFT_NAME)
-#define MAP_BUILTIN_INTEGER_TYPE(CLANG_KIND, SWIFT_NAME)                       \
-  MAP_BUILTIN_TYPE(CLANG_KIND, SWIFT_NAME)
-#include "swift/ClangImporter/BuiltinMappedTypes.def"
-    default:
-      return std::nullopt;
     }
   }
 };

--- a/lib/ClangImporter/SwiftifyDecl.cpp
+++ b/lib/ClangImporter/SwiftifyDecl.cpp
@@ -152,9 +152,9 @@ struct SwiftCountExprEmitter
   bool VisitUnaryOperator(const clang::UnaryOperator *unop) {
     char op;
     switch (unop->getOpcode()) {
-#define UNOP(variant, c)                                                  \
+#define UNOP(variant, c)                                                       \
   case clang::variant:                                                         \
-    op = c;                                                               \
+    op = c;                                                                    \
     break
       UNOP(UO_Plus, '+');
       UNOP(UO_Minus, '-');
@@ -224,7 +224,8 @@ private:
     case CK::CK_IntegralToFloating:
     case CK::CK_FloatingToIntegral:
     case CK::CK_FloatingCast: {
-      std::optional<StringRef> swiftName = getBuiltinTypeSwiftName(c->getType());
+      std::optional<StringRef> swiftName =
+          getBuiltinTypeSwiftName(c->getType());
       if (!swiftName) {
         DLOG("Unsupported cast destination type\n");
         return false;

--- a/lib/ClangImporter/SwiftifyDecl.cpp
+++ b/lib/ClangImporter/SwiftifyDecl.cpp
@@ -228,9 +228,15 @@ struct SwiftCountExprEmitter
       DLOG("Unsupported binary operator\n");
       return false;
     }
+    // Always parenthesize binary operations: Swift and C disagree on the
+    // relative precedence of `<<`/`>>` vs `+`/`-` and `&` vs `+`/`-`, so
+    // unparenthesized output could change meaning across languages.
+    out << '(';
     if (!Visit(binop->getLHS())) return false;
     out << op;
-    return Visit(binop->getRHS());
+    if (!Visit(binop->getRHS())) return false;
+    out << ')';
+    return true;
   }
 
   bool VisitStmt(const clang::Stmt *) {

--- a/lib/ClangImporter/SwiftifyDecl.cpp
+++ b/lib/ClangImporter/SwiftifyDecl.cpp
@@ -229,7 +229,7 @@ private:
       out << *swiftName << '(';
       // Implicit casts get plain T(x) casts: trap instead of truncate
       // Explicit casts mirror C's truncation on narrowing integer conversions
-      if (isExplicitCast && isNarrowingIntCast(c))
+      if (isExplicitCast && c->getCastKind() == CK::CK_IntegralCast)
         out << "truncatingIfNeeded: ";
       if (!Visit(c->getSubExpr()))
         return false;
@@ -240,23 +240,6 @@ private:
       DLOG("Unsupported cast kind\n");
       return false;
     }
-  }
-
-  bool isNarrowingIntCast(const clang::CastExpr *c) {
-    if (c->getCastKind() != clang::CK_IntegralCast)
-      return false;
-    auto destTy = c->getType();
-    auto srcTy = c->getSubExpr()->getType();
-    if (!destTy->isIntegerType() || !srcTy->isIntegerType())
-      return false;
-    uint64_t srcBits = ctx.getTypeSize(srcTy);
-    uint64_t destBits = ctx.getTypeSize(destTy);
-    bool srcSigned = srcTy->isSignedIntegerType();
-    bool destSigned = destTy->isSignedIntegerType();
-    // Narrowing or same-width signedness change: plain T(x) traps in Swift on
-    // values that C would silently truncate, so use truncatingIfNeeded:.
-    return destBits < srcBits ||
-           (destBits == srcBits && srcSigned != destSigned);
   }
 
   std::optional<llvm::StringRef> swiftBuiltinTypeName(clang::QualType ty) {

--- a/lib/ClangImporter/SwiftifyDecl.cpp
+++ b/lib/ClangImporter/SwiftifyDecl.cpp
@@ -90,15 +90,18 @@ static bool isStdSpanType(clang::QualType clangType) {
 
 // Walks a clang `Expr` tree that appears as a `__counted_by` /
 // `__sized_by` count expression and emits an equivalent Swift expression.
-// Returns true on success; on failure the partial output in `out` is
-// meaningless and callers must discard it.
+// `Visit(expr)` returns true on success and the result can be retrieved via
+// `str()`.
 struct SwiftCountExprEmitter
     : clang::ConstStmtVisitor<SwiftCountExprEmitter, bool> {
   const clang::ASTContext &ctx;
-  llvm::raw_ostream &out;
+  llvm::SmallString<128> result;
+  llvm::raw_svector_ostream out;
 
-  SwiftCountExprEmitter(const clang::ASTContext &ctx, llvm::raw_ostream &out)
-      : ctx(ctx), out(out) {}
+  explicit SwiftCountExprEmitter(const clang::ASTContext &ctx)
+      : ctx(ctx), out(result) {}
+
+  llvm::StringRef str() const { return result; }
 
   bool VisitDeclRefExpr(const clang::DeclRefExpr *e) {
     out << e->getDecl()->getName();
@@ -282,6 +285,11 @@ private:
   }
 };
 
+static Type ConcretePointeeType(Type swiftType);
+static bool SwiftifiableSizedByPointerType(const clang::ASTContext &ctx,
+                                           Type swiftType,
+                                           const clang::CountAttributedType *CAT);
+
 struct SwiftifyInfoPrinter {
   static const ssize_t SELF_PARAM_INDEX = -2;
   static const ssize_t RETURN_VALUE_INDEX = -1;
@@ -361,11 +369,21 @@ struct SwiftifyInfoFunctionPrinter : public SwiftifyInfoPrinter {
                       llvm::StringMap<std::string> &typeMapping)
       : SwiftifyInfoPrinter(ctx, SwiftContext, out, SwiftifyImportDecl, typeMapping) {}
 
-  void printCountedBy(const clang::CountAttributedType *CAT,
+  bool printCountedBy(const clang::CountAttributedType *CAT,
+                      Type swiftType,
                       ssize_t pointerIndex) {
-    printSeparator();
-    clang::Expr *countExpr = CAT->getCountExpr();
+    // Step 1: check if we support this attribute
     bool isSizedBy = CAT->isCountInBytes();
+    if (isSizedBy
+            ? !SwiftifiableSizedByPointerType(ctx, swiftType, CAT)
+            : ConcretePointeeType(swiftType).isNull())
+      return false;
+    SwiftCountExprEmitter emitter(ctx);
+    if (!emitter.Visit(CAT->getCountExpr()))
+      return false;
+
+    // Step 2: print - any early exit must occur before this point
+    printSeparator();
     out << ".";
     if (isSizedBy)
       out << "sizedBy";
@@ -376,16 +394,9 @@ struct SwiftifyInfoFunctionPrinter : public SwiftifyInfoPrinter {
     out << "(pointer: ";
     printParamOrReturn(pointerIndex);
     out << ", ";
-    if (isSizedBy)
-      out << "size";
-    else
-      out << "count";
-    out << ": \"";
-    // Validation in SwiftifiableCAT guarantees this succeeds.
-    bool ok = SwiftCountExprEmitter(ctx, out).Visit(countExpr);
-    (void)ok;
-    ASSERT(ok && "count expression validated but failed to emit");
-    out << "\")";
+    out << (isSizedBy ? "size" : "count");
+    out << ": \"" << emitter.str() << "\")";
+    return true;
   }
 
   void printNonEscaping(int idx) {
@@ -481,19 +492,6 @@ static bool SwiftifiableSizedByPointerType(const clang::ASTContext &ctx,
   if (!isByteSized)
     DLOG("Ignoring sized_by on non-byte-sized pointer\n");
   return isByteSized;
-}
-static bool SwiftifiableCAT(const clang::ASTContext &ctx,
-                            const clang::CountAttributedType *CAT,
-                            Type swiftType) {
-  if (!CAT) return false;
-  // Probe the emitter into a discardable buffer to determine support.
-  llvm::SmallString<128> tmp;
-  llvm::raw_svector_ostream tmpOS(tmp);
-  if (!SwiftCountExprEmitter(ctx, tmpOS).Visit(CAT->getCountExpr()))
-    return false;
-  return CAT->isCountInBytes()
-             ? SwiftifiableSizedByPointerType(ctx, swiftType, CAT)
-             : !ConcretePointeeType(swiftType).isNull();
 }
 
 // Searches for template instantiations that are not behind type aliases.
@@ -695,8 +693,6 @@ static bool swiftifyImpl(ClangImporter::Implementation &Self,
     return false;
   }
 
-  clang::ASTContext &clangASTContext = Self.getClangASTContext();
-
   const clang::Module *OwningModule = getOwningModule(ClangDecl);
   bool IsInBridgingHeader = MappedDecl->getModuleContext()->getName().str() == CLANG_HEADER_MODULE_NAME;
   ASSERT(OwningModule || IsInBridgingHeader);
@@ -811,8 +807,7 @@ static bool swiftifyImpl(ClangImporter::Implementation &Self,
                "free function mapped to instance method without swift_name??");
         Self.diagnose(HeaderLoc(swiftName->getLocation()),
                  diag::note_swift_name_instance_method);
-      } else if (SwiftifiableCAT(clangASTContext, CAT, swiftParamTy)) {
-        printer.printCountedBy(CAT, mappedIndex);
+      } else if (CAT && printer.printCountedBy(CAT, swiftParamTy, mappedIndex)) {
         DLOG("Found bounds info '" << clangParamTy << "'\n");
         attachMacro = paramHasBoundsInfo = true;
       }
@@ -893,8 +888,8 @@ static bool swiftifyImpl(ClangImporter::Implementation &Self,
       return false;
     (void)printer.registerStdSpanTypeMapping(
         swiftReturnTy, clangReturnTy);
-    if (SwiftifiableCAT(clangASTContext, CAT, swiftReturnTy)) {
-      printer.printCountedBy(CAT, SwiftifyInfoPrinter::RETURN_VALUE_INDEX);
+    if (CAT && printer.printCountedBy(CAT, swiftReturnTy,
+                                       SwiftifyInfoPrinter::RETURN_VALUE_INDEX)) {
       DLOG("Found bounds info '" << clang::QualType(CAT, 0) << "' on return value\n");
       attachMacro = true;
     }

--- a/lib/ClangImporter/SwiftifyDecl.cpp
+++ b/lib/ClangImporter/SwiftifyDecl.cpp
@@ -34,6 +34,7 @@
 #include "clang/AST/Decl.h"
 #include "clang/AST/DeclObjC.h"
 #include "clang/AST/DeclTemplate.h"
+#include "clang/AST/Expr.h"
 #include "clang/AST/RecursiveASTVisitor.h"
 #include "clang/AST/StmtVisitor.h"
 #include "clang/AST/Type.h"
@@ -129,69 +130,11 @@ struct SwiftCountExprEmitter
   }
 
   bool VisitImplicitCastExpr(const clang::ImplicitCastExpr *c) {
-    using CK = clang::CastKind;
-    switch (c->getCastKind()) {
-    case CK::CK_LValueToRValue:
-    case CK::CK_NoOp:
-    case CK::CK_ArrayToPointerDecay:
-    case CK::CK_FunctionToPointerDecay:
-      return Visit(c->getSubExpr());
-    case CK::CK_IntegralCast:
-    case CK::CK_BooleanToSignedIntegral:
-    case CK::CK_IntegralToBoolean:
-    case CK::CK_IntegralToFloating:
-    case CK::CK_FloatingToIntegral:
-    case CK::CK_FloatingCast: {
-      // Implicit casts get plain T(x) casts: trap instead of truncate
-      auto swiftName = swiftBuiltinTypeName(c->getType());
-      if (!swiftName) {
-        DLOG("Unsupported cast destination type\n");
-        return false;
-      }
-      out << *swiftName << '(';
-      if (!Visit(c->getSubExpr()))
-        return false;
-      out << ')';
-      return true;
-    }
-    default:
-      DLOG("Unsupported implicit cast kind\n");
-      return false;
-    }
+    return visitCastImpl(c);
   }
 
   bool VisitCStyleCastExpr(const clang::CStyleCastExpr *c) {
-    using CK = clang::CastKind;
-    auto kind = c->getCastKind();
-    switch (kind) {
-    case CK::CK_NoOp:
-    case CK::CK_LValueToRValue:
-      return Visit(c->getSubExpr());
-    case CK::CK_IntegralCast:
-    case CK::CK_BooleanToSignedIntegral:
-    case CK::CK_IntegralToBoolean:
-    case CK::CK_IntegralToFloating:
-    case CK::CK_FloatingToIntegral:
-    case CK::CK_FloatingCast: {
-      auto swiftName = swiftBuiltinTypeName(c->getType());
-      if (!swiftName) {
-        DLOG("Unsupported cast destination type\n");
-        return false;
-      }
-      out << *swiftName << '(';
-      // Mirror C's silent truncation on narrowing integer conversions for
-      // explicit casts.
-      if (isNarrowingIntCast(c))
-        out << "truncatingIfNeeded: ";
-      if (!Visit(c->getSubExpr()))
-        return false;
-      out << ')';
-      return true;
-    }
-    default:
-      DLOG("Unsupported C-style cast kind\n");
-      return false;
-    }
+    return visitCastImpl(c);
   }
 
   bool VisitParenExpr(const clang::ParenExpr *p) {
@@ -212,7 +155,7 @@ struct SwiftCountExprEmitter
       UNOP(UO_Plus, "+");
       UNOP(UO_Minus, "-");
       UNOP(UO_Not, "~");
-#undef CASE_UNOP
+#undef UNOP
     default:
       DLOG("Unsupported unary operator\n");
       return false;
@@ -238,7 +181,7 @@ struct SwiftCountExprEmitter
       BINOP(BO_And, "&");
       BINOP(BO_Or, "|");
       BINOP(BO_Xor, "^");
-#undef CASE_BINOP
+#undef BINOP
     default:
       DLOG("Unsupported binary operator\n");
       return false;
@@ -262,6 +205,43 @@ struct SwiftCountExprEmitter
   }
 
 private:
+  bool visitCastImpl(const clang::CastExpr *c) {
+    ASSERT(isa<clang::CStyleCastExpr>(c) || isa<clang::ImplicitCastExpr>(c));
+    using CK = clang::CastKind;
+    switch (c->getCastKind()) {
+    case CK::CK_LValueToRValue:
+    case CK::CK_NoOp:
+    case CK::CK_ArrayToPointerDecay:
+    case CK::CK_FunctionToPointerDecay:
+      return Visit(c->getSubExpr());
+    case CK::CK_IntegralCast:
+    case CK::CK_BooleanToSignedIntegral:
+    case CK::CK_IntegralToBoolean:
+    case CK::CK_IntegralToFloating:
+    case CK::CK_FloatingToIntegral:
+    case CK::CK_FloatingCast: {
+      auto swiftName = swiftBuiltinTypeName(c->getType());
+      if (!swiftName) {
+        DLOG("Unsupported cast destination type\n");
+        return false;
+      }
+      bool isExplicitCast = isa<clang::CStyleCastExpr>(c);
+      out << *swiftName << '(';
+      // Implicit casts get plain T(x) casts: trap instead of truncate
+      // Explicit casts mirror C's truncation on narrowing integer conversions
+      if (isExplicitCast && isNarrowingIntCast(c))
+        out << "truncatingIfNeeded: ";
+      if (!Visit(c->getSubExpr()))
+        return false;
+      out << ')';
+      return true;
+    }
+    default:
+      DLOG("Unsupported cast kind\n");
+      return false;
+    }
+  }
+
   bool isNarrowingIntCast(const clang::CastExpr *c) {
     if (c->getCastKind() != clang::CK_IntegralCast)
       return false;

--- a/lib/ClangImporter/SwiftifyDecl.cpp
+++ b/lib/ClangImporter/SwiftifyDecl.cpp
@@ -88,6 +88,194 @@ static bool isStdSpanType(clang::QualType clangType) {
   return decl && decl->isInStdNamespace() && decl->getName() == "span";
 }
 
+// Walks a clang `Expr` tree that appears as a `__counted_by` /
+// `__sized_by` count expression and emits an equivalent Swift expression.
+// Returns true on success; on failure the partial output in `out` is
+// meaningless and callers must discard it.
+struct SwiftCountExprEmitter
+    : clang::ConstStmtVisitor<SwiftCountExprEmitter, bool> {
+  const clang::ASTContext &ctx;
+  llvm::raw_ostream &out;
+
+  SwiftCountExprEmitter(const clang::ASTContext &ctx, llvm::raw_ostream &out)
+      : ctx(ctx), out(out) {}
+
+  bool VisitDeclRefExpr(const clang::DeclRefExpr *e) {
+    out << e->getDecl()->getName();
+    return true;
+  }
+
+  bool VisitIntegerLiteral(const clang::IntegerLiteral *IL) {
+    const auto *bt = IL->getType()->getAs<clang::BuiltinType>();
+    if (!bt) return false;
+    bool isSigned = IL->getType()->isSignedIntegerType();
+    llvm::SmallString<20> valueStr;
+    IL->getValue().toString(valueStr, /*Radix=*/10, isSigned);
+    if (bt->getKind() == clang::BuiltinType::Int) {
+      out << valueStr;
+      return true;
+    }
+    auto swiftName = swiftBuiltinTypeName(bt);
+    if (!swiftName) {
+      DLOG("Unsupported integer literal type\n");
+      return false;
+    }
+    out << *swiftName << '(' << valueStr << ')';
+    return true;
+  }
+
+  bool VisitImplicitCastExpr(const clang::ImplicitCastExpr *c) {
+    using CK = clang::CastKind;
+    switch (c->getCastKind()) {
+    case CK::CK_LValueToRValue:
+    case CK::CK_NoOp:
+    case CK::CK_ArrayToPointerDecay:
+    case CK::CK_FunctionToPointerDecay:
+      return Visit(c->getSubExpr());
+    case CK::CK_IntegralCast:
+    case CK::CK_BooleanToSignedIntegral:
+    case CK::CK_IntegralToBoolean:
+    case CK::CK_IntegralToFloating:
+    case CK::CK_FloatingToIntegral:
+    case CK::CK_FloatingCast: {
+      // Implicit casts get plain T(x) casts: trap instead of truncate
+      auto swiftName = swiftBuiltinTypeName(c->getType());
+      if (!swiftName) {
+        DLOG("Unsupported cast destination type\n");
+        return false;
+      }
+      out << *swiftName << '(';
+      if (!Visit(c->getSubExpr()))
+        return false;
+      out << ')';
+      return true;
+    }
+    default:
+      DLOG("Unsupported implicit cast kind\n");
+      return false;
+    }
+  }
+
+  bool VisitCStyleCastExpr(const clang::CStyleCastExpr *c) {
+    using CK = clang::CastKind;
+    auto kind = c->getCastKind();
+    switch (kind) {
+    case CK::CK_NoOp:
+    case CK::CK_LValueToRValue:
+      return Visit(c->getSubExpr());
+    case CK::CK_IntegralCast:
+    case CK::CK_BooleanToSignedIntegral:
+    case CK::CK_IntegralToBoolean:
+    case CK::CK_IntegralToFloating:
+    case CK::CK_FloatingToIntegral:
+    case CK::CK_FloatingCast: {
+      auto swiftName = swiftBuiltinTypeName(c->getType());
+      if (!swiftName) {
+        DLOG("Unsupported cast destination type\n");
+        return false;
+      }
+      out << *swiftName << '(';
+      // Mirror C's silent truncation on narrowing integer conversions for
+      // explicit casts.
+      if (isNarrowingIntCast(c))
+        out << "truncatingIfNeeded: ";
+      if (!Visit(c->getSubExpr()))
+        return false;
+      out << ')';
+      return true;
+    }
+    default:
+      DLOG("Unsupported C-style cast kind\n");
+      return false;
+    }
+  }
+
+  bool VisitParenExpr(const clang::ParenExpr *p) {
+    out << '(';
+    if (!Visit(p->getSubExpr())) return false;
+    out << ')';
+    return true;
+  }
+
+  bool VisitUnaryOperator(const clang::UnaryOperator *unop) {
+    llvm::StringRef op;
+    switch (unop->getOpcode()) {
+    case clang::UO_Plus:  op = "+"; break;
+    case clang::UO_Minus: op = "-"; break;
+    case clang::UO_Not:   op = "~"; break;
+    default:
+      DLOG("Unsupported unary operator\n");
+      return false;
+    }
+    out << op;
+    return Visit(unop->getSubExpr());
+  }
+
+  bool VisitBinaryOperator(const clang::BinaryOperator *binop) {
+    llvm::StringRef op;
+    switch (binop->getOpcode()) {
+    case clang::BO_Add: op = " + "; break;
+    case clang::BO_Sub: op = " - "; break;
+    case clang::BO_Mul: op = " * "; break;
+    case clang::BO_Div: op = " / "; break;
+    case clang::BO_Rem: op = " % "; break;
+    case clang::BO_Shl: op = " << "; break;
+    case clang::BO_Shr: op = " >> "; break;
+    case clang::BO_And: op = " & "; break;
+    case clang::BO_Or:  op = " | "; break;
+    case clang::BO_Xor: op = " ^ "; break;
+    default:
+      DLOG("Unsupported binary operator\n");
+      return false;
+    }
+    if (!Visit(binop->getLHS())) return false;
+    out << op;
+    return Visit(binop->getRHS());
+  }
+
+  bool VisitStmt(const clang::Stmt *) {
+    DLOG("Ignoring count parameter with unsupported expression\n");
+    return false;
+  }
+
+private:
+  bool isNarrowingIntCast(const clang::CastExpr *c) {
+    if (c->getCastKind() != clang::CK_IntegralCast) return false;
+    auto destTy = c->getType();
+    auto srcTy = c->getSubExpr()->getType();
+    if (!destTy->isIntegerType() || !srcTy->isIntegerType()) return false;
+    uint64_t srcBits = ctx.getTypeSize(srcTy);
+    uint64_t destBits = ctx.getTypeSize(destTy);
+    bool srcSigned = srcTy->isSignedIntegerType();
+    bool destSigned = destTy->isSignedIntegerType();
+    // Narrowing or same-width signedness change: plain T(x) traps in Swift on
+    // values that C would silently truncate, so use truncatingIfNeeded:.
+    return destBits < srcBits ||
+           (destBits == srcBits && srcSigned != destSigned);
+  }
+
+  std::optional<llvm::StringRef> swiftBuiltinTypeName(clang::QualType ty) {
+    const auto *bt = ty->getAs<clang::BuiltinType>();
+    if (!bt) return std::nullopt;
+    return swiftBuiltinTypeName(bt);
+  }
+
+  std::optional<llvm::StringRef>
+  swiftBuiltinTypeName(const clang::BuiltinType *bt) {
+    switch (bt->getKind()) {
+#define MAP_BUILTIN_TYPE(CLANG_KIND, SWIFT_NAME) \
+    case clang::BuiltinType::CLANG_KIND: return llvm::StringRef(#SWIFT_NAME);
+#define MAP_BUILTIN_CCHAR_TYPE(CLANG_KIND, SWIFT_NAME) \
+    MAP_BUILTIN_TYPE(CLANG_KIND, SWIFT_NAME)
+#define MAP_BUILTIN_INTEGER_TYPE(CLANG_KIND, SWIFT_NAME) \
+    MAP_BUILTIN_TYPE(CLANG_KIND, SWIFT_NAME)
+#include "swift/ClangImporter/BuiltinMappedTypes.def"
+    default:
+      return std::nullopt;
+    }
+  }
+};
+
 struct SwiftifyInfoPrinter {
   static const ssize_t SELF_PARAM_INDEX = -2;
   static const ssize_t RETURN_VALUE_INDEX = -1;
@@ -187,8 +375,10 @@ struct SwiftifyInfoFunctionPrinter : public SwiftifyInfoPrinter {
     else
       out << "count";
     out << ": \"";
-    countExpr->printPretty(
-        out, {}, {ctx.getLangOpts()}); // TODO: map clang::Expr to Swift Expr
+    // Validation in SwiftifiableCAT guarantees this succeeds.
+    bool ok = SwiftCountExprEmitter(ctx, out).Visit(countExpr);
+    (void)ok;
+    ASSERT(ok && "count expression validated but failed to emit");
     out << "\")";
   }
 
@@ -248,68 +438,6 @@ private:
   }
 };
 
-struct CountedByExpressionValidator
-    : clang::ConstStmtVisitor<CountedByExpressionValidator, bool> {
-  bool VisitDeclRefExpr(const clang::DeclRefExpr *e) { return true; }
-
-  bool VisitIntegerLiteral(const clang::IntegerLiteral *IL) {
-    switch (IL->getType()->castAs<clang::BuiltinType>()->getKind()) {
-    case clang::BuiltinType::Char_S:
-    case clang::BuiltinType::Char_U:
-    case clang::BuiltinType::UChar:
-    case clang::BuiltinType::SChar:
-    case clang::BuiltinType::Short:
-    case clang::BuiltinType::UShort:
-    case clang::BuiltinType::UInt:
-    case clang::BuiltinType::Long:
-    case clang::BuiltinType::ULong:
-    case clang::BuiltinType::LongLong:
-    case clang::BuiltinType::ULongLong:
-      DLOG("Ignoring count parameter with non-portable integer literal\n");
-      return false;
-    default:
-      return true;
-    }
-  }
-
-  bool VisitImplicitCastExpr(const clang::ImplicitCastExpr *c) {
-    return this->Visit(c->getSubExpr());
-  }
-  bool VisitParenExpr(const clang::ParenExpr *p) {
-    return this->Visit(p->getSubExpr());
-  }
-
-#define SUPPORTED_UNOP(UNOP) \
-  bool VisitUnary ## UNOP(const clang::UnaryOperator *unop) { \
-    return this->Visit(unop->getSubExpr()); \
-  }
-  SUPPORTED_UNOP(Plus)
-  SUPPORTED_UNOP(Minus)
-  SUPPORTED_UNOP(Not)
-#undef SUPPORTED_UNOP
-
-#define SUPPORTED_BINOP(BINOP) \
-  bool VisitBin ## BINOP(const clang::BinaryOperator *binop) { \
-    return this->Visit(binop->getLHS()) && this->Visit(binop->getRHS()); \
-  }
-  SUPPORTED_BINOP(Add)
-  SUPPORTED_BINOP(Sub)
-  SUPPORTED_BINOP(Div)
-  SUPPORTED_BINOP(Mul)
-  SUPPORTED_BINOP(Rem)
-  SUPPORTED_BINOP(Shl)
-  SUPPORTED_BINOP(Shr)
-  SUPPORTED_BINOP(And)
-  SUPPORTED_BINOP(Xor)
-  SUPPORTED_BINOP(Or)
-#undef SUPPORTED_BINOP
-
-  bool VisitStmt(const clang::Stmt *) {
-    DLOG("Ignoring count parameter with unsupported expression\n");
-    return false;
-  }
-};
-
 
 static Type ConcretePointeeType(Type swiftType) {
   Type nonnullType = swiftType->lookThroughSingleOptionalType();
@@ -351,10 +479,15 @@ static bool SwiftifiableSizedByPointerType(const clang::ASTContext &ctx,
 static bool SwiftifiableCAT(const clang::ASTContext &ctx,
                             const clang::CountAttributedType *CAT,
                             Type swiftType) {
-  return CAT && CountedByExpressionValidator().Visit(CAT->getCountExpr()) &&
-    (CAT->isCountInBytes() ?
-       SwiftifiableSizedByPointerType(ctx, swiftType, CAT)
-     : !ConcretePointeeType(swiftType).isNull());
+  if (!CAT) return false;
+  // Probe the emitter into a discardable buffer to determine support.
+  llvm::SmallString<128> tmp;
+  llvm::raw_svector_ostream tmpOS(tmp);
+  if (!SwiftCountExprEmitter(ctx, tmpOS).Visit(CAT->getCountExpr()))
+    return false;
+  return CAT->isCountInBytes()
+             ? SwiftifiableSizedByPointerType(ctx, swiftType, CAT)
+             : !ConcretePointeeType(swiftType).isNull();
 }
 
 // Searches for template instantiations that are not behind type aliases.

--- a/lib/ClangImporter/SwiftifyDecl.cpp
+++ b/lib/ClangImporter/SwiftifyDecl.cpp
@@ -34,11 +34,13 @@
 #include "clang/AST/Decl.h"
 #include "clang/AST/DeclObjC.h"
 #include "clang/AST/DeclTemplate.h"
+#include "clang/AST/DeclarationName.h"
 #include "clang/AST/Expr.h"
 #include "clang/AST/RecursiveASTVisitor.h"
 #include "clang/AST/StmtVisitor.h"
 #include "clang/AST/Type.h"
 #include "clang/Basic/Module.h"
+#include "clang/Sema/Overload.h"
 #include <optional>
 
 using namespace swift;
@@ -105,6 +107,12 @@ struct SwiftCountExprEmitter
   llvm::StringRef str() const { return result; }
 
   bool VisitDeclRefExpr(const clang::DeclRefExpr *e) {
+    const clang::DeclarationName name = e->getDecl()->getDeclName();
+    if (name.getNameKind() != clang::DeclarationName::Identifier ||
+        name.isEmpty()) {
+      DLOG("Unsupported decl name in count expr\n");
+      return false;
+    }
     out << e->getDecl()->getName();
     return true;
   }

--- a/test/Interop/C/swiftify-import/counted-by-lifetimebound.swift
+++ b/test/Interop/C/swiftify-import/counted-by-lifetimebound.swift
@@ -154,8 +154,8 @@ int * __counted_by(len) noncountedLifetime(int len, int * p __lifetimebound);
 // expected-experimental-expansion@+20:60{{
 //   expected-experimental-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy p) @_lifetime(p: copy p) @_disfavoredOverload public func constant(_ p: inout MutableSpan<Int32>?) -> MutableSpan<Int32> {|}}
-//   expected-experimental-remark@3{{macro content: |    if let _pCount = p?.count, _pCount != 13 {|}}
-//   expected-experimental-remark@4{{macro content: |      fatalError("bounds check failure in constant: expected \\(13) but got \\(_pCount)")|}}
+//   expected-experimental-remark@3{{macro content: |    if let _pCount = p?.count, _pCount != CInt(13) {|}}
+//   expected-experimental-remark@4{{macro content: |      fatalError("bounds check failure in constant: expected \\(CInt(13)) but got \\(_pCount)")|}}
 //   expected-experimental-remark@5{{macro content: |    }|}}
 //   expected-experimental-remark@6{{macro content: |    let _pPtr = p?.withUnsafeMutableBufferPointer {|}}
 //   expected-experimental-remark@7{{macro content: |        unsafe $0|}}
@@ -165,10 +165,10 @@ int * __counted_by(len) noncountedLifetime(int len, int * p __lifetimebound);
 //   expected-experimental-remark@11{{macro content: |    }|}}
 //   expected-experimental-remark@12{{macro content: |    let _resultValue = unsafe constant(_pPtr?.baseAddress)|}}
 //   expected-experimental-remark@13{{macro content: |    if unsafe _resultValue == nil {|}}
-//   expected-experimental-remark@14{{macro content: |      precondition(13 == 0, "counted_by may only be null if count is 0 (unlike counted_by_or_null)")|}}
+//   expected-experimental-remark@14{{macro content: |      precondition(CInt(13) == 0, "counted_by may only be null if count is 0 (unlike counted_by_or_null)")|}}
 //   expected-experimental-remark@15{{macro content: |      return MutableSpan<Int32>()|}}
 //   expected-experimental-remark@16{{macro content: |    }|}}
-//   expected-experimental-remark@17{{macro content: |    return unsafe _swiftifyOverrideLifetime(MutableSpan<Int32>(_unsafeStart: _resultValue!, count: Int(13)), copying: ())|}}
+//   expected-experimental-remark@17{{macro content: |    return unsafe _swiftifyOverrideLifetime(MutableSpan<Int32>(_unsafeStart: _resultValue!, count: Int(CInt(13))), copying: ())|}}
 //   expected-experimental-remark@18{{macro content: |}|}}
 // }}
 int * __counted_by(13) _Nullable constant(int * _Nullable p __counted_by_or_null(13) __lifetimebound);

--- a/test/Interop/C/swiftify-import/counted-by-lifetimebound.swift
+++ b/test/Interop/C/swiftify-import/counted-by-lifetimebound.swift
@@ -72,10 +72,10 @@ int * __counted_by(len) shared(int len, int * p __counted_by(len) __lifetimeboun
 //   expected-experimental-remark@9{{macro content: |    }|}}
 //   expected-experimental-remark@10{{macro content: |    let _resultValue: UnsafeMutablePointer<Int32>? = unsafe complexExpr(len, offset, len2, _pPtr.baseAddress)|}}
 //   expected-experimental-remark@11{{macro content: |    if unsafe _resultValue == nil {|}}
-//   expected-experimental-remark@12{{macro content: |      precondition(len - offset == 0, "counted_by may only be null if count is 0 (unlike counted_by_or_null)")|}}
+//   expected-experimental-remark@12{{macro content: |      precondition((len - offset) == 0, "counted_by may only be null if count is 0 (unlike counted_by_or_null)")|}}
 //   expected-experimental-remark@13{{macro content: |      return MutableSpan<Int32>()|}}
 //   expected-experimental-remark@14{{macro content: |    }|}}
-//   expected-experimental-remark@15{{macro content: |    return unsafe _swiftifyOverrideLifetime(MutableSpan<Int32>(_unsafeStart: _resultValue!, count: Int(len - offset)), copying: ())|}}
+//   expected-experimental-remark@15{{macro content: |    return unsafe _swiftifyOverrideLifetime(MutableSpan<Int32>(_unsafeStart: _resultValue!, count: Int((len - offset))), copying: ())|}}
 //   expected-experimental-remark@16{{macro content: |}|}}
 // }}
 int * __counted_by(len - offset) complexExpr(int len, int offset, int len2, int * p __counted_by(len2) __lifetimebound);

--- a/test/Interop/C/swiftify-import/counted-by-noescape.swift
+++ b/test/Interop/C/swiftify-import/counted-by-noescape.swift
@@ -72,8 +72,8 @@ void shared(int len, int * __counted_by(len) __noescape p1, int * __counted_by(l
 // expected-expansion@+15:84{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload public func complexExpr(_ len: Int32, _ offset: Int32, _ p: inout MutableSpan<Int32>) {|}}
-//   expected-remark@3{{macro content: |    if p.count != len - offset {|}}
-//   expected-remark@4{{macro content: |      fatalError("bounds check failure in complexExpr: expected \\(len - offset) but got \\(p.count)")|}}
+//   expected-remark@3{{macro content: |    if p.count != (len - offset) {|}}
+//   expected-remark@4{{macro content: |      fatalError("bounds check failure in complexExpr: expected \\((len - offset)) but got \\(p.count)")|}}
 //   expected-remark@5{{macro content: |    }|}}
 //   expected-remark@6{{macro content: |    let _pPtr = p.withUnsafeMutableBufferPointer {|}}
 //   expected-remark@7{{macro content: |        unsafe $0|}}
@@ -197,8 +197,8 @@ void pointerName(int len, int * __counted_by(len) _Nullable pointerName __noesca
 // expected-expansion@+15:83{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(_lenName_param2: copy _lenName_param2) @_disfavoredOverload public func lenName(_ _lenName_param0: Int32, _ _lenName_param1: Int32, _ _lenName_param2: inout MutableSpan<Int32>) {|}}
-//   expected-remark@3{{macro content: |    if _lenName_param2.count != _lenName_param0 * _lenName_param1 {|}}
-//   expected-remark@4{{macro content: |      fatalError("bounds check failure in lenName: expected \\(_lenName_param0 * _lenName_param1) but got \\(_lenName_param2.count)")|}}
+//   expected-remark@3{{macro content: |    if _lenName_param2.count != (_lenName_param0 * _lenName_param1) {|}}
+//   expected-remark@4{{macro content: |      fatalError("bounds check failure in lenName: expected \\((_lenName_param0 * _lenName_param1)) but got \\(_lenName_param2.count)")|}}
 //   expected-remark@5{{macro content: |    }|}}
 //   expected-remark@6{{macro content: |    let __lenName_param2Ptr = _lenName_param2.withUnsafeMutableBufferPointer {|}}
 //   expected-remark@7{{macro content: |        unsafe $0|}}

--- a/test/Interop/C/swiftify-import/counted-by-or-null-lifetimebound.swift
+++ b/test/Interop/C/swiftify-import/counted-by-or-null-lifetimebound.swift
@@ -71,10 +71,10 @@ int * __counted_by_or_null(len) shared(int len, int * p __counted_by_or_null(len
 //   expected-experimental-remark@9{{macro content: |    }|}}
 //   expected-experimental-remark@10{{macro content: |    let _resultValue: UnsafeMutablePointer<Int32>? = unsafe complexExpr(len, offset, len2, _pPtr.baseAddress)|}}
 //   expected-experimental-remark@11{{macro content: |    if unsafe _resultValue == nil {|}}
-//   expected-experimental-remark@12{{macro content: |      precondition(len - offset == 0, "counted_by may only be null if count is 0 (unlike counted_by_or_null)")|}}
+//   expected-experimental-remark@12{{macro content: |      precondition((len - offset) == 0, "counted_by may only be null if count is 0 (unlike counted_by_or_null)")|}}
 //   expected-experimental-remark@13{{macro content: |      return MutableSpan<Int32>()|}}
 //   expected-experimental-remark@14{{macro content: |    }|}}
-//   expected-experimental-remark@15{{macro content: |    return unsafe _swiftifyOverrideLifetime(MutableSpan<Int32>(_unsafeStart: _resultValue!, count: Int(len - offset)), copying: ())|}}
+//   expected-experimental-remark@15{{macro content: |    return unsafe _swiftifyOverrideLifetime(MutableSpan<Int32>(_unsafeStart: _resultValue!, count: Int((len - offset))), copying: ())|}}
 //   expected-experimental-remark@16{{macro content: |}|}}
 // }}
 int * __counted_by_or_null(len - offset) complexExpr(int len, int offset, int len2, int * p __counted_by_or_null(len2) __lifetimebound);

--- a/test/Interop/C/swiftify-import/counted-by-or-null-lifetimebound.swift
+++ b/test/Interop/C/swiftify-import/counted-by-or-null-lifetimebound.swift
@@ -153,8 +153,8 @@ int * __counted_by_or_null(len) noncountedLifetime(int len, int * p __lifetimebo
 // expected-experimental-expansion@+19:68{{
 //   expected-experimental-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-experimental-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(copy p) @_lifetime(p: copy p) @_disfavoredOverload public func constant(_ p: inout MutableSpan<Int32>?) -> MutableSpan<Int32>? {|}}
-//   expected-experimental-remark@3{{macro content: |    if let _pCount = p?.count, _pCount != 13 {|}}
-//   expected-experimental-remark@4{{macro content: |      fatalError("bounds check failure in constant: expected \\(13) but got \\(_pCount)")|}}
+//   expected-experimental-remark@3{{macro content: |    if let _pCount = p?.count, _pCount != CInt(13) {|}}
+//   expected-experimental-remark@4{{macro content: |      fatalError("bounds check failure in constant: expected \\(CInt(13)) but got \\(_pCount)")|}}
 //   expected-experimental-remark@5{{macro content: |    }|}}
 //   expected-experimental-remark@6{{macro content: |    let _pPtr = p?.withUnsafeMutableBufferPointer {|}}
 //   expected-experimental-remark@7{{macro content: |        unsafe $0|}}
@@ -166,7 +166,7 @@ int * __counted_by_or_null(len) noncountedLifetime(int len, int * p __lifetimebo
 //   expected-experimental-remark@13{{macro content: |    if unsafe _resultValue == nil {|}}
 //   expected-experimental-remark@14{{macro content: |      return nil|}}
 //   expected-experimental-remark@15{{macro content: |    }|}}
-//   expected-experimental-remark@16{{macro content: |    return unsafe _swiftifyOverrideLifetime(MutableSpan<Int32>(_unsafeStart: _resultValue!, count: Int(13)), copying: ())|}}
+//   expected-experimental-remark@16{{macro content: |    return unsafe _swiftifyOverrideLifetime(MutableSpan<Int32>(_unsafeStart: _resultValue!, count: Int(CInt(13))), copying: ())|}}
 //   expected-experimental-remark@17{{macro content: |}|}}
 // }}
 int * __counted_by_or_null(13) _Nullable constant(int * _Nullable p __counted_by_or_null(13) __lifetimebound);

--- a/test/Interop/C/swiftify-import/counted-by-or-null-noescape.swift
+++ b/test/Interop/C/swiftify-import/counted-by-or-null-noescape.swift
@@ -72,8 +72,8 @@ void shared(int len, int * __counted_by_or_null(len) __noescape p1, int * __coun
 // expected-expansion@+15:92{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(p: copy p) @_disfavoredOverload public func complexExpr(_ len: Int32, _ offset: Int32, _ p: inout MutableSpan<Int32>) {|}}
-//   expected-remark@3{{macro content: |    if p.count != len - offset {|}}
-//   expected-remark@4{{macro content: |      fatalError("bounds check failure in complexExpr: expected \\(len - offset) but got \\(p.count)")|}}
+//   expected-remark@3{{macro content: |    if p.count != (len - offset) {|}}
+//   expected-remark@4{{macro content: |      fatalError("bounds check failure in complexExpr: expected \\((len - offset)) but got \\(p.count)")|}}
 //   expected-remark@5{{macro content: |    }|}}
 //   expected-remark@6{{macro content: |    let _pPtr = p.withUnsafeMutableBufferPointer {|}}
 //   expected-remark@7{{macro content: |        unsafe $0|}}
@@ -198,8 +198,8 @@ void pointerName(int len, int * __counted_by_or_null(len) _Nullable pointerName 
 // expected-expansion@+15:91{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_lifetime(_lenName_param2: copy _lenName_param2) @_disfavoredOverload public func lenName(_ _lenName_param0: Int32, _ _lenName_param1: Int32, _ _lenName_param2: inout MutableSpan<Int32>?) {|}}
-//   expected-remark@3{{macro content: |    if let __lenName_param2Count = _lenName_param2?.count, __lenName_param2Count != _lenName_param0 * _lenName_param1 {|}}
-//   expected-remark@4{{macro content: |      fatalError("bounds check failure in lenName: expected \\(_lenName_param0 * _lenName_param1) but got \\(__lenName_param2Count)")|}}
+//   expected-remark@3{{macro content: |    if let __lenName_param2Count = _lenName_param2?.count, __lenName_param2Count != (_lenName_param0 * _lenName_param1) {|}}
+//   expected-remark@4{{macro content: |      fatalError("bounds check failure in lenName: expected \\((_lenName_param0 * _lenName_param1)) but got \\(__lenName_param2Count)")|}}
 //   expected-remark@5{{macro content: |    }|}}
 //   expected-remark@6{{macro content: |    let __lenName_param2Ptr = _lenName_param2?.withUnsafeMutableBufferPointer {|}}
 //   expected-remark@7{{macro content: |        unsafe $0|}}

--- a/test/Interop/C/swiftify-import/counted-by-or-null.swift
+++ b/test/Interop/C/swiftify-import/counted-by-or-null.swift
@@ -174,27 +174,27 @@ void constInt(int * __counted_by_or_null(42 * 10) p);
 // }}
 void constFloatCastedToInt(int * __counted_by_or_null((int) (4.2 / 12)) p);
 
-// expected-expansion@+9:60{{
+// expected-expansion@+9:148{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func sizeofType(_ p: UnsafeMutableBufferPointer<Int32>) {|}}
-//   expected-remark@3{{macro content: |    if p.count != CUnsignedLong(8) {|}}
-//   expected-remark@4{{macro content: |      fatalError("bounds check failure in sizeofType: expected \\(CUnsignedLong(8)) but got \\(p.count)")|}}
+//   expected-remark@3{{macro content: |    if p.count != CUnsignedLongLong(8) {|}}
+//   expected-remark@4{{macro content: |      fatalError("bounds check failure in sizeofType: expected \\(CUnsignedLongLong(8)) but got \\(p.count)")|}}
 //   expected-remark@5{{macro content: |    }|}}
 //   expected-remark@6{{macro content: |    return unsafe sizeofType(p.baseAddress)|}}
 //   expected-remark@7{{macro content: |}|}}
 // }}
-void sizeofType(int * __counted_by_or_null(sizeof(int *)) p);
+void sizeofType(int * __counted_by_or_null((unsigned long long /*cast to long long to avoid size_t differences between platforms*/)sizeof(int *)) p);
 
-// expected-expansion@+9:57{{
+// expected-expansion@+9:145{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func sizeofParam(_ p: UnsafeMutableBufferPointer<Int32>) {|}}
-//   expected-remark@3{{macro content: |    if p.count != CUnsignedLong(8) {|}}
-//   expected-remark@4{{macro content: |      fatalError("bounds check failure in sizeofParam: expected \\(CUnsignedLong(8)) but got \\(p.count)")|}}
+//   expected-remark@3{{macro content: |    if p.count != CUnsignedLongLong(8) {|}}
+//   expected-remark@4{{macro content: |      fatalError("bounds check failure in sizeofParam: expected \\(CUnsignedLongLong(8)) but got \\(p.count)")|}}
 //   expected-remark@5{{macro content: |    }|}}
 //   expected-remark@6{{macro content: |    return unsafe sizeofParam(p.baseAddress)|}}
 //   expected-remark@7{{macro content: |}|}}
 // }}
-void sizeofParam(int * __counted_by_or_null(sizeof(p)) p);
+void sizeofParam(int * __counted_by_or_null((unsigned long long /*cast to long long to avoid size_t differences between platforms*/)sizeof(p)) p);
 
 void derefLen(int * len, int * __counted_by_or_null(*len) p);
 

--- a/test/Interop/C/swiftify-import/counted-by-or-null.swift
+++ b/test/Interop/C/swiftify-import/counted-by-or-null.swift
@@ -174,8 +174,26 @@ void constInt(int * __counted_by_or_null(42 * 10) p);
 // }}
 void constFloatCastedToInt(int * __counted_by_or_null((int) (4.2 / 12)) p);
 
+// expected-expansion@+9:60{{
+//   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func sizeofType(_ p: UnsafeMutableBufferPointer<Int32>) {|}}
+//   expected-remark@3{{macro content: |    if p.count != CUnsignedLong(8) {|}}
+//   expected-remark@4{{macro content: |      fatalError("bounds check failure in sizeofType: expected \\(CUnsignedLong(8)) but got \\(p.count)")|}}
+//   expected-remark@5{{macro content: |    }|}}
+//   expected-remark@6{{macro content: |    return unsafe sizeofType(p.baseAddress!)|}}
+//   expected-remark@7{{macro content: |}|}}
+// }}
 void sizeofType(int * __counted_by_or_null(sizeof(int *)) p);
 
+// expected-expansion@+9:57{{
+//   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func sizeofParam(_ p: UnsafeMutableBufferPointer<Int32>) {|}}
+//   expected-remark@3{{macro content: |    if p.count != CUnsignedLong(8) {|}}
+//   expected-remark@4{{macro content: |      fatalError("bounds check failure in sizeofParam: expected \\(CUnsignedLong(8)) but got \\(p.count)")|}}
+//   expected-remark@5{{macro content: |    }|}}
+//   expected-remark@6{{macro content: |    return unsafe sizeofParam(p.baseAddress!)|}}
+//   expected-remark@7{{macro content: |}|}}
+// }}
 void sizeofParam(int * __counted_by_or_null(sizeof(p)) p);
 
 void derefLen(int * len, int * __counted_by_or_null(*len) p);
@@ -186,14 +204,52 @@ void lAnd(int len, int * __counted_by_or_null(len && len) p);
 
 void lOr(int len, int * __counted_by_or_null(len || len) p);
 
+// expected-expansion@+9:77{{
+//   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func floatCastToInt(_ meters: Float, _ p: UnsafeMutableBufferPointer<Int32>) {|}}
+//   expected-remark@3{{macro content: |    if p.count != CInt(meters) {|}}
+//   expected-remark@4{{macro content: |      fatalError("bounds check failure in floatCastToInt: expected \\(CInt(meters)) but got \\(p.count)")|}}
+//   expected-remark@5{{macro content: |    }|}}
+//   expected-remark@6{{macro content: |    return unsafe floatCastToInt(meters, p.baseAddress!)|}}
+//   expected-remark@7{{macro content: |}|}}
+// }}
 void floatCastToInt(float meters, int * __counted_by_or_null((int) meters) p);
 
 void pointerCastToInt(int *square, int * __counted_by_or_null((int) square) p);
 
+// expected-expansion@+11:58{{
+//   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func nanAsInt(_ p: UnsafeMutableBufferPointer<Int32>) {|}}
+//   expected-error@3{{division by zero}}
+//   expected-remark@3{{macro content: |    if p.count != (0 / 0) {|}}
+//   expected-error@4 2{{division by zero}}
+//   expected-remark@4{{macro content: |      fatalError("bounds check failure in nanAsInt: expected \\((0 / 0)) but got \\(p.count)")|}}
+//   expected-remark@5{{macro content: |    }|}}
+//   expected-remark@6{{macro content: |    return unsafe nanAsInt(p.baseAddress!)|}}
+//   expected-remark@7{{macro content: |}|}}
+// }}
 void nanAsInt(int * __counted_by_or_null((int) (0 / 0)) p);
 
+// expected-expansion@+9:54{{
+//   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func unsignedLiteral(_ p: UnsafeMutableBufferPointer<Int32>) {|}}
+//   expected-remark@3{{macro content: |    if p.count != CUnsignedInt(2) {|}}
+//   expected-remark@4{{macro content: |      fatalError("bounds check failure in unsignedLiteral: expected \\(CUnsignedInt(2)) but got \\(p.count)")|}}
+//   expected-remark@5{{macro content: |    }|}}
+//   expected-remark@6{{macro content: |    return unsafe unsignedLiteral(p.baseAddress!)|}}
+//   expected-remark@7{{macro content: |}|}}
+// }}
 void unsignedLiteral(int * __counted_by_or_null(2u) p);
 
+// expected-expansion@+9:50{{
+//   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func longLiteral(_ p: UnsafeMutableBufferPointer<Int32>) {|}}
+//   expected-remark@3{{macro content: |    if p.count != CLong(2) {|}}
+//   expected-remark@4{{macro content: |      fatalError("bounds check failure in longLiteral: expected \\(CLong(2)) but got \\(p.count)")|}}
+//   expected-remark@5{{macro content: |    }|}}
+//   expected-remark@6{{macro content: |    return unsafe longLiteral(p.baseAddress!)|}}
+//   expected-remark@7{{macro content: |}|}}
+// }}
 void longLiteral(int * __counted_by_or_null(2l) p);
 
 // expected-expansion@+9:51{{
@@ -286,7 +342,7 @@ module Test {
 
 //--- test.swift
 // GENERATED-BY: %target-swift-ide-test -print-module -module-to-print=Test -plugin-path %swift-plugin-dir -I %t -source-filename=x -Xcc -Wno-nullability-completeness -Xcc -Wno-div-by-zero -Xcc -Wno-pointer-to-int-cast > %t/Test-interface.swift && %swift-function-caller-generator Test %t/Test-interface.swift
-// GENERATED-HASH: 7ff35b9ab50ae75a7f0ee983328b18de19a13f5feb1e4c0fdc38e0ad6596564d
+// GENERATED-HASH: e000162a354939bc180cd01a90e021ed3b491faebc6f2f8a1b456e1df822f915
 import Test
 
 func call_simple(_ len: Int32, _ p: UnsafeMutablePointer<Int32>!) {
@@ -449,8 +505,16 @@ func call_allOrNull(_ len: Int32, _ p1: UnsafeMutablePointer<Int32>?, _ p2: Unsa
   return unsafe constInt(p)
 }
 
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_floatCastToInt(_ meters: Float, _ p: UnsafeMutableBufferPointer<Int32>) {
+  return unsafe floatCastToInt(meters, p)
+}
+
 @_alwaysEmitIntoClient @_disfavoredOverload public func call_hexLiteral(_ p: UnsafeMutableBufferPointer<Int32>) {
   return unsafe hexLiteral(p)
+}
+
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_longLiteral(_ p: UnsafeMutableBufferPointer<Int32>) {
+  return unsafe longLiteral(p)
 }
 
 @_alwaysEmitIntoClient @_disfavoredOverload public func call_mixedShared(_ p1: UnsafeMutableBufferPointer<Int32>?, _ p2: UnsafeMutableBufferPointer<Int32>) {
@@ -459,6 +523,10 @@ func call_allOrNull(_ len: Int32, _ p1: UnsafeMutablePointer<Int32>?, _ p2: Unsa
 
 @_alwaysEmitIntoClient @_disfavoredOverload public func call_mixedThree(_ p1: UnsafeMutableBufferPointer<Int32>?, _ p2: UnsafeMutableBufferPointer<Int32>, _ p3: UnsafeMutableBufferPointer<Int32>?) {
   return unsafe mixedThree(p1, p2, p3)
+}
+
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_nanAsInt(_ p: UnsafeMutableBufferPointer<Int32>) {
+  return unsafe nanAsInt(p)
 }
 
 @_alwaysEmitIntoClient @_disfavoredOverload public func call_nonnull(_ p: UnsafeMutableBufferPointer<Int32>) {
@@ -505,6 +573,18 @@ func call_allOrNull(_ len: Int32, _ p1: UnsafeMutablePointer<Int32>?, _ p2: Unsa
   return unsafe simpleFlipped(p)
 }
 
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_sizeofParam(_ p: UnsafeMutableBufferPointer<Int32>) {
+  return unsafe sizeofParam(p)
+}
+
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_sizeofType(_ p: UnsafeMutableBufferPointer<Int32>) {
+  return unsafe sizeofType(p)
+}
+
 @_alwaysEmitIntoClient @_disfavoredOverload public func call_swiftAttr(_ p: UnsafeMutableBufferPointer<Int32>) {
   return unsafe swiftAttr(p)
+}
+
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_unsignedLiteral(_ p: UnsafeMutableBufferPointer<Int32>) {
+  return unsafe unsignedLiteral(p)
 }

--- a/test/Interop/C/swiftify-import/counted-by-or-null.swift
+++ b/test/Interop/C/swiftify-import/counted-by-or-null.swift
@@ -100,8 +100,8 @@ int * __counted_by_or_null(len) returnPointer(int len);
 // expected-expansion@+9:61{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func offByOne(_ len: Int32, _ p: UnsafeMutableBufferPointer<Int32>) {|}}
-//   expected-remark@3{{macro content: |    if p.count != (len + 1) {|}}
-//   expected-remark@4{{macro content: |      fatalError("bounds check failure in offByOne: expected \\((len + 1)) but got \\(p.count)")|}}
+//   expected-remark@3{{macro content: |    if p.count != (len + CInt(1)) {|}}
+//   expected-remark@4{{macro content: |      fatalError("bounds check failure in offByOne: expected \\((len + CInt(1))) but got \\(p.count)")|}}
 //   expected-remark@5{{macro content: |    }|}}
 //   expected-remark@6{{macro content: |    return unsafe offByOne(len, p.baseAddress)|}}
 //   expected-remark@7{{macro content: |}|}}
@@ -111,8 +111,8 @@ void offByOne(int len, int * __counted_by_or_null(len + 1) p);
 // expected-expansion@+9:85{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func offBySome(_ len: Int32, _ offset: Int32, _ p: UnsafeMutableBufferPointer<Int32>) {|}}
-//   expected-remark@3{{macro content: |    if p.count != (len + ((1 + offset))) {|}}
-//   expected-remark@4{{macro content: |      fatalError("bounds check failure in offBySome: expected \\((len + ((1 + offset)))) but got \\(p.count)")|}}
+//   expected-remark@3{{macro content: |    if p.count != (len + ((CInt(1) + offset))) {|}}
+//   expected-remark@4{{macro content: |      fatalError("bounds check failure in offBySome: expected \\((len + ((CInt(1) + offset)))) but got \\(p.count)")|}}
 //   expected-remark@5{{macro content: |    }|}}
 //   expected-remark@6{{macro content: |    return unsafe offBySome(len, offset, p.baseAddress)|}}
 //   expected-remark@7{{macro content: |}|}}
@@ -155,8 +155,8 @@ void bitshift(int m, int n, int o, int * __counted_by_or_null(m << (n >> o)) p);
 // expected-expansion@+9:52{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func constInt(_ p: UnsafeMutableBufferPointer<Int32>) {|}}
-//   expected-remark@3{{macro content: |    if p.count != 420 {|}}
-//   expected-remark@4{{macro content: |      fatalError("bounds check failure in constInt: expected \\(420) but got \\(p.count)")|}}
+//   expected-remark@3{{macro content: |    if p.count != CInt(420) {|}}
+//   expected-remark@4{{macro content: |      fatalError("bounds check failure in constInt: expected \\(CInt(420)) but got \\(p.count)")|}}
 //   expected-remark@5{{macro content: |    }|}}
 //   expected-remark@6{{macro content: |    return unsafe constInt(p.baseAddress)|}}
 //   expected-remark@7{{macro content: |}|}}
@@ -166,8 +166,8 @@ void constInt(int * __counted_by_or_null(42 * 10) p);
 // expected-expansion@+9:74{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func constFloatCastedToInt(_ p: UnsafeMutableBufferPointer<Int32>) {|}}
-//   expected-remark@3{{macro content: |    if p.count != 0 {|}}
-//   expected-remark@4{{macro content: |      fatalError("bounds check failure in constFloatCastedToInt: expected \\(0) but got \\(p.count)")|}}
+//   expected-remark@3{{macro content: |    if p.count != CInt(0) {|}}
+//   expected-remark@4{{macro content: |      fatalError("bounds check failure in constFloatCastedToInt: expected \\(CInt(0)) but got \\(p.count)")|}}
 //   expected-remark@5{{macro content: |    }|}}
 //   expected-remark@6{{macro content: |    return unsafe constFloatCastedToInt(p.baseAddress)|}}
 //   expected-remark@7{{macro content: |}|}}
@@ -220,9 +220,9 @@ void pointerCastToInt(int *square, int * __counted_by_or_null((int) square) p);
 // expected-expansion@+11:58{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func nanAsInt(_ p: UnsafeMutableBufferPointer<Int32>) {|}}
-//   expected-remark@3{{macro content: |    if p.count != ((0 / 0)) {|}}
+//   expected-remark@3{{macro content: |    if p.count != ((CInt(0) / CInt(0))) {|}}
 //   expected-error@3{{division by zero}}
-//   expected-remark@4{{macro content: |      fatalError("bounds check failure in nanAsInt: expected \\(((0 / 0))) but got \\(p.count)")|}}
+//   expected-remark@4{{macro content: |      fatalError("bounds check failure in nanAsInt: expected \\(((CInt(0) / CInt(0)))) but got \\(p.count)")|}}
 //   expected-error@4 2{{division by zero}}
 //   expected-remark@5{{macro content: |    }|}}
 //   expected-remark@6{{macro content: |    return unsafe nanAsInt(p.baseAddress)|}}
@@ -255,8 +255,8 @@ void longLiteral(int * __counted_by_or_null(2l) p);
 // expected-expansion@+9:51{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func hexLiteral(_ p: UnsafeMutableBufferPointer<Int32>) {|}}
-//   expected-remark@3{{macro content: |    if p.count != 250 {|}}
-//   expected-remark@4{{macro content: |      fatalError("bounds check failure in hexLiteral: expected \\(250) but got \\(p.count)")|}}
+//   expected-remark@3{{macro content: |    if p.count != CInt(250) {|}}
+//   expected-remark@4{{macro content: |      fatalError("bounds check failure in hexLiteral: expected \\(CInt(250)) but got \\(p.count)")|}}
 //   expected-remark@5{{macro content: |    }|}}
 //   expected-remark@6{{macro content: |    return unsafe hexLiteral(p.baseAddress)|}}
 //   expected-remark@7{{macro content: |}|}}
@@ -266,8 +266,8 @@ void hexLiteral(int * __counted_by_or_null(0xfa) p);
 // expected-expansion@+9:54{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func binaryLiteral(_ p: UnsafeMutableBufferPointer<Int32>) {|}}
-//   expected-remark@3{{macro content: |    if p.count != 2 {|}}
-//   expected-remark@4{{macro content: |      fatalError("bounds check failure in binaryLiteral: expected \\(2) but got \\(p.count)")|}}
+//   expected-remark@3{{macro content: |    if p.count != CInt(2) {|}}
+//   expected-remark@4{{macro content: |      fatalError("bounds check failure in binaryLiteral: expected \\(CInt(2)) but got \\(p.count)")|}}
 //   expected-remark@5{{macro content: |    }|}}
 //   expected-remark@6{{macro content: |    return unsafe binaryLiteral(p.baseAddress)|}}
 //   expected-remark@7{{macro content: |}|}}
@@ -277,8 +277,8 @@ void binaryLiteral(int * __counted_by_or_null(0b10) p);
 // expected-expansion@+9:53{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func octalLiteral(_ p: UnsafeMutableBufferPointer<Int32>) {|}}
-//   expected-remark@3{{macro content: |    if p.count != 511 {|}}
-//   expected-remark@4{{macro content: |      fatalError("bounds check failure in octalLiteral: expected \\(511) but got \\(p.count)")|}}
+//   expected-remark@3{{macro content: |    if p.count != CInt(511) {|}}
+//   expected-remark@4{{macro content: |      fatalError("bounds check failure in octalLiteral: expected \\(CInt(511)) but got \\(p.count)")|}}
 //   expected-remark@5{{macro content: |    }|}}
 //   expected-remark@6{{macro content: |    return unsafe octalLiteral(p.baseAddress)|}}
 //   expected-remark@7{{macro content: |}|}}

--- a/test/Interop/C/swiftify-import/counted-by-or-null.swift
+++ b/test/Interop/C/swiftify-import/counted-by-or-null.swift
@@ -53,8 +53,8 @@ void shared(int len, int * __counted_by_or_null(len) p1, int * __counted_by_or_n
 // expected-expansion@+9:81{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func complexExpr(_ len: Int32, _ offset: Int32, _ p: UnsafeMutableBufferPointer<Int32>) {|}}
-//   expected-remark@3{{macro content: |    if p.count != len - offset {|}}
-//   expected-remark@4{{macro content: |      fatalError("bounds check failure in complexExpr: expected \\(len - offset) but got \\(p.count)")|}}
+//   expected-remark@3{{macro content: |    if p.count != (len - offset) {|}}
+//   expected-remark@4{{macro content: |      fatalError("bounds check failure in complexExpr: expected \\((len - offset)) but got \\(p.count)")|}}
 //   expected-remark@5{{macro content: |    }|}}
 //   expected-remark@6{{macro content: |    return unsafe complexExpr(len, offset, p.baseAddress)|}}
 //   expected-remark@7{{macro content: |}|}}
@@ -100,8 +100,8 @@ int * __counted_by_or_null(len) returnPointer(int len);
 // expected-expansion@+9:61{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func offByOne(_ len: Int32, _ p: UnsafeMutableBufferPointer<Int32>) {|}}
-//   expected-remark@3{{macro content: |    if p.count != len + 1 {|}}
-//   expected-remark@4{{macro content: |      fatalError("bounds check failure in offByOne: expected \\(len + 1) but got \\(p.count)")|}}
+//   expected-remark@3{{macro content: |    if p.count != (len + 1) {|}}
+//   expected-remark@4{{macro content: |      fatalError("bounds check failure in offByOne: expected \\((len + 1)) but got \\(p.count)")|}}
 //   expected-remark@5{{macro content: |    }|}}
 //   expected-remark@6{{macro content: |    return unsafe offByOne(len, p.baseAddress)|}}
 //   expected-remark@7{{macro content: |}|}}
@@ -111,8 +111,8 @@ void offByOne(int len, int * __counted_by_or_null(len + 1) p);
 // expected-expansion@+9:85{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func offBySome(_ len: Int32, _ offset: Int32, _ p: UnsafeMutableBufferPointer<Int32>) {|}}
-//   expected-remark@3{{macro content: |    if p.count != len + (1 + offset) {|}}
-//   expected-remark@4{{macro content: |      fatalError("bounds check failure in offBySome: expected \\(len + (1 + offset)) but got \\(p.count)")|}}
+//   expected-remark@3{{macro content: |    if p.count != (len + ((1 + offset))) {|}}
+//   expected-remark@4{{macro content: |      fatalError("bounds check failure in offBySome: expected \\((len + ((1 + offset)))) but got \\(p.count)")|}}
 //   expected-remark@5{{macro content: |    }|}}
 //   expected-remark@6{{macro content: |    return unsafe offBySome(len, offset, p.baseAddress)|}}
 //   expected-remark@7{{macro content: |}|}}
@@ -122,8 +122,8 @@ void offBySome(int len, int offset, int * __counted_by_or_null(len + (1 + offset
 // expected-expansion@+9:62{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func scalar(_ m: Int32, _ n: Int32, _ p: UnsafeMutableBufferPointer<Int32>) {|}}
-//   expected-remark@3{{macro content: |    if p.count != m * n {|}}
-//   expected-remark@4{{macro content: |      fatalError("bounds check failure in scalar: expected \\(m * n) but got \\(p.count)")|}}
+//   expected-remark@3{{macro content: |    if p.count != (m * n) {|}}
+//   expected-remark@4{{macro content: |      fatalError("bounds check failure in scalar: expected \\((m * n)) but got \\(p.count)")|}}
 //   expected-remark@5{{macro content: |    }|}}
 //   expected-remark@6{{macro content: |    return unsafe scalar(m, n, p.baseAddress)|}}
 //   expected-remark@7{{macro content: |}|}}
@@ -133,8 +133,8 @@ void scalar(int m, int n, int * __counted_by_or_null(m * n) p);
 // expected-expansion@+9:75{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func bitwise(_ m: Int32, _ n: Int32, _ o: Int32, _ p: UnsafeMutableBufferPointer<Int32>) {|}}
-//   expected-remark@3{{macro content: |    if p.count != m & n | ~o {|}}
-//   expected-remark@4{{macro content: |      fatalError("bounds check failure in bitwise: expected \\(m & n | ~o) but got \\(p.count)")|}}
+//   expected-remark@3{{macro content: |    if p.count != ((m & n) | ~o) {|}}
+//   expected-remark@4{{macro content: |      fatalError("bounds check failure in bitwise: expected \\(((m & n) | ~o)) but got \\(p.count)")|}}
 //   expected-remark@5{{macro content: |    }|}}
 //   expected-remark@6{{macro content: |    return unsafe bitwise(m, n, o, p.baseAddress)|}}
 //   expected-remark@7{{macro content: |}|}}
@@ -144,8 +144,8 @@ void bitwise(int m, int n, int o, int * __counted_by_or_null(m & n | ~o) p);
 // expected-expansion@+9:79{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func bitshift(_ m: Int32, _ n: Int32, _ o: Int32, _ p: UnsafeMutableBufferPointer<Int32>) {|}}
-//   expected-remark@3{{macro content: |    if p.count != m << (n >> o) {|}}
-//   expected-remark@4{{macro content: |      fatalError("bounds check failure in bitshift: expected \\(m << (n >> o)) but got \\(p.count)")|}}
+//   expected-remark@3{{macro content: |    if p.count != (m << ((n >> o))) {|}}
+//   expected-remark@4{{macro content: |      fatalError("bounds check failure in bitshift: expected \\((m << ((n >> o)))) but got \\(p.count)")|}}
 //   expected-remark@5{{macro content: |    }|}}
 //   expected-remark@6{{macro content: |    return unsafe bitshift(m, n, o, p.baseAddress)|}}
 //   expected-remark@7{{macro content: |}|}}
@@ -180,7 +180,7 @@ void constFloatCastedToInt(int * __counted_by_or_null((int) (4.2 / 12)) p);
 //   expected-remark@3{{macro content: |    if p.count != CUnsignedLong(8) {|}}
 //   expected-remark@4{{macro content: |      fatalError("bounds check failure in sizeofType: expected \\(CUnsignedLong(8)) but got \\(p.count)")|}}
 //   expected-remark@5{{macro content: |    }|}}
-//   expected-remark@6{{macro content: |    return unsafe sizeofType(p.baseAddress!)|}}
+//   expected-remark@6{{macro content: |    return unsafe sizeofType(p.baseAddress)|}}
 //   expected-remark@7{{macro content: |}|}}
 // }}
 void sizeofType(int * __counted_by_or_null(sizeof(int *)) p);
@@ -191,7 +191,7 @@ void sizeofType(int * __counted_by_or_null(sizeof(int *)) p);
 //   expected-remark@3{{macro content: |    if p.count != CUnsignedLong(8) {|}}
 //   expected-remark@4{{macro content: |      fatalError("bounds check failure in sizeofParam: expected \\(CUnsignedLong(8)) but got \\(p.count)")|}}
 //   expected-remark@5{{macro content: |    }|}}
-//   expected-remark@6{{macro content: |    return unsafe sizeofParam(p.baseAddress!)|}}
+//   expected-remark@6{{macro content: |    return unsafe sizeofParam(p.baseAddress)|}}
 //   expected-remark@7{{macro content: |}|}}
 // }}
 void sizeofParam(int * __counted_by_or_null(sizeof(p)) p);
@@ -210,7 +210,7 @@ void lOr(int len, int * __counted_by_or_null(len || len) p);
 //   expected-remark@3{{macro content: |    if p.count != CInt(meters) {|}}
 //   expected-remark@4{{macro content: |      fatalError("bounds check failure in floatCastToInt: expected \\(CInt(meters)) but got \\(p.count)")|}}
 //   expected-remark@5{{macro content: |    }|}}
-//   expected-remark@6{{macro content: |    return unsafe floatCastToInt(meters, p.baseAddress!)|}}
+//   expected-remark@6{{macro content: |    return unsafe floatCastToInt(meters, p.baseAddress)|}}
 //   expected-remark@7{{macro content: |}|}}
 // }}
 void floatCastToInt(float meters, int * __counted_by_or_null((int) meters) p);
@@ -220,12 +220,12 @@ void pointerCastToInt(int *square, int * __counted_by_or_null((int) square) p);
 // expected-expansion@+11:58{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func nanAsInt(_ p: UnsafeMutableBufferPointer<Int32>) {|}}
+//   expected-remark@3{{macro content: |    if p.count != ((0 / 0)) {|}}
 //   expected-error@3{{division by zero}}
-//   expected-remark@3{{macro content: |    if p.count != (0 / 0) {|}}
+//   expected-remark@4{{macro content: |      fatalError("bounds check failure in nanAsInt: expected \\(((0 / 0))) but got \\(p.count)")|}}
 //   expected-error@4 2{{division by zero}}
-//   expected-remark@4{{macro content: |      fatalError("bounds check failure in nanAsInt: expected \\((0 / 0)) but got \\(p.count)")|}}
 //   expected-remark@5{{macro content: |    }|}}
-//   expected-remark@6{{macro content: |    return unsafe nanAsInt(p.baseAddress!)|}}
+//   expected-remark@6{{macro content: |    return unsafe nanAsInt(p.baseAddress)|}}
 //   expected-remark@7{{macro content: |}|}}
 // }}
 void nanAsInt(int * __counted_by_or_null((int) (0 / 0)) p);
@@ -236,7 +236,7 @@ void nanAsInt(int * __counted_by_or_null((int) (0 / 0)) p);
 //   expected-remark@3{{macro content: |    if p.count != CUnsignedInt(2) {|}}
 //   expected-remark@4{{macro content: |      fatalError("bounds check failure in unsignedLiteral: expected \\(CUnsignedInt(2)) but got \\(p.count)")|}}
 //   expected-remark@5{{macro content: |    }|}}
-//   expected-remark@6{{macro content: |    return unsafe unsignedLiteral(p.baseAddress!)|}}
+//   expected-remark@6{{macro content: |    return unsafe unsignedLiteral(p.baseAddress)|}}
 //   expected-remark@7{{macro content: |}|}}
 // }}
 void unsignedLiteral(int * __counted_by_or_null(2u) p);
@@ -247,7 +247,7 @@ void unsignedLiteral(int * __counted_by_or_null(2u) p);
 //   expected-remark@3{{macro content: |    if p.count != CLong(2) {|}}
 //   expected-remark@4{{macro content: |      fatalError("bounds check failure in longLiteral: expected \\(CLong(2)) but got \\(p.count)")|}}
 //   expected-remark@5{{macro content: |    }|}}
-//   expected-remark@6{{macro content: |    return unsafe longLiteral(p.baseAddress!)|}}
+//   expected-remark@6{{macro content: |    return unsafe longLiteral(p.baseAddress)|}}
 //   expected-remark@7{{macro content: |}|}}
 // }}
 void longLiteral(int * __counted_by_or_null(2l) p);

--- a/test/Interop/C/swiftify-import/counted-by.swift
+++ b/test/Interop/C/swiftify-import/counted-by.swift
@@ -4,9 +4,6 @@
 // RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -I %t -strict-memory-safety -Xcc -Wno-nullability-completeness -Xcc -Wno-div-by-zero -Xcc -Wno-pointer-to-int-cast \
 // RUN:   %t/test.swift -verify -verify-additional-file %t%{fs-sep}test.h -Rmacro-expansions -suppress-notes -eager-macro-checking
 
-// Not worth adding a separate matcher for sizeof(*int) on 32 bit platforms
-// REQUIRES: PTRSIZE=64
-
 // Check that ClangImporter correctly infers and expands @_SwiftifyImport macros for functions with __counted_by parameters.
 
 //--- test.h

--- a/test/Interop/C/swiftify-import/counted-by.swift
+++ b/test/Interop/C/swiftify-import/counted-by.swift
@@ -172,8 +172,26 @@ void constInt(int * __counted_by(42 * 10) p);
 // }}
 void constFloatCastedToInt(int * __counted_by((int) (4.2 / 12)) p);
 
+// expected-expansion@+9:52{{
+//   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func sizeofType(_ p: UnsafeMutableBufferPointer<Int32>) {|}}
+//   expected-remark@3{{macro content: |    if p.count != CUnsignedLong(8) {|}}
+//   expected-remark@4{{macro content: |      fatalError("bounds check failure in sizeofType: expected \\(CUnsignedLong(8)) but got \\(p.count)")|}}
+//   expected-remark@5{{macro content: |    }|}}
+//   expected-remark@6{{macro content: |    return unsafe sizeofType(p.baseAddress!)|}}
+//   expected-remark@7{{macro content: |}|}}
+// }}
 void sizeofType(int * __counted_by(sizeof(int *)) p);
 
+// expected-expansion@+9:49{{
+//   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func sizeofParam(_ p: UnsafeMutableBufferPointer<Int32>) {|}}
+//   expected-remark@3{{macro content: |    if p.count != CUnsignedLong(8) {|}}
+//   expected-remark@4{{macro content: |      fatalError("bounds check failure in sizeofParam: expected \\(CUnsignedLong(8)) but got \\(p.count)")|}}
+//   expected-remark@5{{macro content: |    }|}}
+//   expected-remark@6{{macro content: |    return unsafe sizeofParam(p.baseAddress!)|}}
+//   expected-remark@7{{macro content: |}|}}
+// }}
 void sizeofParam(int * __counted_by(sizeof(p)) p);
 
 void derefLen(int * len, int * __counted_by(*len) p);
@@ -184,14 +202,52 @@ void lAnd(int len, int * __counted_by(len && len) p);
 
 void lOr(int len, int * __counted_by(len || len) p);
 
+// expected-expansion@+9:69{{
+//   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func floatCastToInt(_ meters: Float, _ p: UnsafeMutableBufferPointer<Int32>) {|}}
+//   expected-remark@3{{macro content: |    if p.count != CInt(meters) {|}}
+//   expected-remark@4{{macro content: |      fatalError("bounds check failure in floatCastToInt: expected \\(CInt(meters)) but got \\(p.count)")|}}
+//   expected-remark@5{{macro content: |    }|}}
+//   expected-remark@6{{macro content: |    return unsafe floatCastToInt(meters, p.baseAddress!)|}}
+//   expected-remark@7{{macro content: |}|}}
+// }}
 void floatCastToInt(float meters, int * __counted_by((int) meters) p);
 
 void pointerCastToInt(int *square, int * __counted_by((int) square) p);
 
+// expected-expansion@+11:50{{
+//   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func nanAsInt(_ p: UnsafeMutableBufferPointer<Int32>) {|}}
+//   expected-error@3{{division by zero}}
+//   expected-remark@3{{macro content: |    if p.count != (0 / 0) {|}}
+//   expected-remark@4{{macro content: |      fatalError("bounds check failure in nanAsInt: expected \\((0 / 0)) but got \\(p.count)")|}}
+//   expected-error@4 2{{division by zero}}
+//   expected-remark@5{{macro content: |    }|}}
+//   expected-remark@6{{macro content: |    return unsafe nanAsInt(p.baseAddress!)|}}
+//   expected-remark@7{{macro content: |}|}}
+// }}
 void nanAsInt(int * __counted_by((int) (0 / 0)) p);
 
+// expected-expansion@+9:46{{
+//   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func unsignedLiteral(_ p: UnsafeMutableBufferPointer<Int32>) {|}}
+//   expected-remark@3{{macro content: |    if p.count != CUnsignedInt(2) {|}}
+//   expected-remark@4{{macro content: |      fatalError("bounds check failure in unsignedLiteral: expected \\(CUnsignedInt(2)) but got \\(p.count)")|}}
+//   expected-remark@5{{macro content: |    }|}}
+//   expected-remark@6{{macro content: |    return unsafe unsignedLiteral(p.baseAddress!)|}}
+//   expected-remark@7{{macro content: |}|}}
+// }}
 void unsignedLiteral(int * __counted_by(2u) p);
 
+// expected-expansion@+9:42{{
+//   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func longLiteral(_ p: UnsafeMutableBufferPointer<Int32>) {|}}
+//   expected-remark@3{{macro content: |    if p.count != CLong(2) {|}}
+//   expected-remark@4{{macro content: |      fatalError("bounds check failure in longLiteral: expected \\(CLong(2)) but got \\(p.count)")|}}
+//   expected-remark@5{{macro content: |    }|}}
+//   expected-remark@6{{macro content: |    return unsafe longLiteral(p.baseAddress!)|}}
+//   expected-remark@7{{macro content: |}|}}
+// }}
 void longLiteral(int * __counted_by(2l) p);
 
 // expected-expansion@+9:43{{
@@ -227,6 +283,20 @@ void binaryLiteral(int * __counted_by(0b10) p);
 // }}
 void octalLiteral(int * __counted_by(0777) p);
 
+// Regression test: by printing the count expression with C syntax,
+// this example would fail to typecheck since it relies on implicit
+// casts present in C but not in Swift.
+// expected-expansion@+9:78{{
+//   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func implicitIntCast(_ offset: Int, _ len: Int32, _ p: UnsafeMutableBufferPointer<Int32>) {|}}
+//   expected-remark@3{{macro content: |    if p.count != offset + CLong(len) {|}}
+//   expected-remark@4{{macro content: |      fatalError("bounds check failure in implicitIntCast: expected \\(offset + CLong(len)) but got \\(p.count)")|}}
+//   expected-remark@5{{macro content: |    }|}}
+//   expected-remark@6{{macro content: |    return unsafe implicitIntCast(offset, len, p.baseAddress!)|}}
+//   expected-remark@7{{macro content: |}|}}
+// }}
+void implicitIntCast(long offset, int len, int * __counted_by(offset + len) p);
+
 void variadic(int len, int * __counted_by(len) p, ...);
 
 //--- module.modulemap
@@ -236,7 +306,7 @@ module Test {
 
 //--- test.swift
 // GENERATED-BY: %target-swift-ide-test -print-module -module-to-print=Test -plugin-path %swift-plugin-dir -I %t -source-filename=x -Xcc -Wno-nullability-completeness -Xcc -Wno-div-by-zero -Xcc -Wno-pointer-to-int-cast > %t/Test-interface.swift && %swift-function-caller-generator Test %t/Test-interface.swift
-// GENERATED-HASH: 32b628e12ecfcec33231930d5885791ba7495890d2d1a1f446471647c30baec1
+// GENERATED-HASH: 16b1fb4738c5e431b23930b84f738e5195935c2730f1ce04d3b5cbdf3f6d13f8
 import Test
 
 func call_simple(_ len: Int32, _ p: UnsafeMutablePointer<Int32>!) {
@@ -359,6 +429,10 @@ func call_octalLiteral(_ p: UnsafeMutablePointer<Int32>!) {
   return unsafe octalLiteral(p)
 }
 
+func call_implicitIntCast(_ offset: Int, _ len: Int32, _ p: UnsafeMutablePointer<Int32>!) {
+  return unsafe implicitIntCast(offset, len, p)
+}
+
 @_alwaysEmitIntoClient @_disfavoredOverload public func call_binaryLiteral(_ p: UnsafeMutableBufferPointer<Int32>) {
   return unsafe binaryLiteral(p)
 }
@@ -383,8 +457,24 @@ func call_octalLiteral(_ p: UnsafeMutablePointer<Int32>!) {
   return unsafe constInt(p)
 }
 
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_floatCastToInt(_ meters: Float, _ p: UnsafeMutableBufferPointer<Int32>) {
+  return unsafe floatCastToInt(meters, p)
+}
+
 @_alwaysEmitIntoClient @_disfavoredOverload public func call_hexLiteral(_ p: UnsafeMutableBufferPointer<Int32>) {
   return unsafe hexLiteral(p)
+}
+
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_implicitIntCast(_ offset: Int, _ len: Int32, _ p: UnsafeMutableBufferPointer<Int32>) {
+  return unsafe implicitIntCast(offset, len, p)
+}
+
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_longLiteral(_ p: UnsafeMutableBufferPointer<Int32>) {
+  return unsafe longLiteral(p)
+}
+
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_nanAsInt(_ p: UnsafeMutableBufferPointer<Int32>) {
+  return unsafe nanAsInt(p)
 }
 
 @_alwaysEmitIntoClient @_disfavoredOverload public func call_nonnull(_ p: UnsafeMutableBufferPointer<Int32>) {
@@ -431,6 +521,18 @@ func call_octalLiteral(_ p: UnsafeMutablePointer<Int32>!) {
   return unsafe simpleFlipped(p)
 }
 
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_sizeofParam(_ p: UnsafeMutableBufferPointer<Int32>) {
+  return unsafe sizeofParam(p)
+}
+
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_sizeofType(_ p: UnsafeMutableBufferPointer<Int32>) {
+  return unsafe sizeofType(p)
+}
+
 @_alwaysEmitIntoClient @_disfavoredOverload public func call_swiftAttr(_ p: UnsafeMutableBufferPointer<Int32>) {
   return unsafe swiftAttr(p)
+}
+
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_unsignedLiteral(_ p: UnsafeMutableBufferPointer<Int32>) {
+  return unsafe unsignedLiteral(p)
 }

--- a/test/Interop/C/swiftify-import/counted-by.swift
+++ b/test/Interop/C/swiftify-import/counted-by.swift
@@ -311,13 +311,24 @@ void castTwiceLiteral(int * __counted_by((unsigned int)(signed short)-1) p);
 // expected-expansion@+9:73{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func castParam(_ p: UnsafeMutableBufferPointer<Int32>, _ len: Int16) {|}}
-//   expected-remark@3{{macro content: |    if p.count != CUnsignedInt(len) {|}}
-//   expected-remark@4{{macro content: |      fatalError("bounds check failure in castParam: expected \\(CUnsignedInt(len)) but got \\(p.count)")|}}
+//   expected-remark@3{{macro content: |    if p.count != CUnsignedInt(truncatingIfNeeded: len) {|}}
+//   expected-remark@4{{macro content: |      fatalError("bounds check failure in castParam: expected \\(CUnsignedInt(truncatingIfNeeded: len)) but got \\(p.count)")|}}
 //   expected-remark@5{{macro content: |    }|}}
 //   expected-remark@6{{macro content: |    return unsafe castParam(p.baseAddress!, len)|}}
 //   expected-remark@7{{macro content: |}|}}
 // }}
 void castParam(int * __counted_by((unsigned int)len) p, signed short len);
+
+// expected-expansion@+9:72{{
+//   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func castParam2(_ p: UnsafeMutableBufferPointer<Int32>, _ len: UInt32) {|}}
+//   expected-remark@3{{macro content: |    if p.count != CInt(truncatingIfNeeded: len) {|}}
+//   expected-remark@4{{macro content: |      fatalError("bounds check failure in castParam2: expected \\(CInt(truncatingIfNeeded: len)) but got \\(p.count)")|}}
+//   expected-remark@5{{macro content: |    }|}}
+//   expected-remark@6{{macro content: |    return unsafe castParam2(p.baseAddress!, len)|}}
+//   expected-remark@7{{macro content: |}|}}
+// }}
+void castParam2(int * __counted_by((signed int)len) p, unsigned int len);
 
 void variadic(int len, int * __counted_by(len) p, ...);
 
@@ -328,7 +339,7 @@ module Test {
 
 //--- test.swift
 // GENERATED-BY: %target-swift-ide-test -print-module -module-to-print=Test -plugin-path %swift-plugin-dir -I %t -source-filename=x -Xcc -Wno-nullability-completeness -Xcc -Wno-div-by-zero -Xcc -Wno-pointer-to-int-cast > %t/Test-interface.swift && %swift-function-caller-generator Test %t/Test-interface.swift
-// GENERATED-HASH: 9a9868adf1d87e2316e50537687ace17870d6ae82ec1dcf06a9580facb95143d
+// GENERATED-HASH: 71efeba6e5ec0b384ab8b97441fc84136f94762bc691f5374d67cc0adc3bcdc8
 import Test
 
 func call_simple(_ len: Int32, _ p: UnsafeMutablePointer<Int32>!) {
@@ -463,6 +474,10 @@ func call_castParam(_ p: UnsafeMutablePointer<Int32>!, _ len: Int16) {
   return unsafe castParam(p, len)
 }
 
+func call_castParam2(_ p: UnsafeMutablePointer<Int32>!, _ len: UInt32) {
+  return unsafe castParam2(p, len)
+}
+
 @_alwaysEmitIntoClient @_disfavoredOverload public func call_binaryLiteral(_ p: UnsafeMutableBufferPointer<Int32>) {
   return unsafe binaryLiteral(p)
 }
@@ -477,6 +492,10 @@ func call_castParam(_ p: UnsafeMutablePointer<Int32>!, _ len: Int16) {
 
 @_alwaysEmitIntoClient @_disfavoredOverload public func call_castParam(_ p: UnsafeMutableBufferPointer<Int32>, _ len: Int16) {
   return unsafe castParam(p, len)
+}
+
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_castParam2(_ p: UnsafeMutableBufferPointer<Int32>, _ len: UInt32) {
+  return unsafe castParam2(p, len)
 }
 
 @_alwaysEmitIntoClient @_disfavoredOverload public func call_castTwiceLiteral(_ p: UnsafeMutableBufferPointer<Int32>) {

--- a/test/Interop/C/swiftify-import/counted-by.swift
+++ b/test/Interop/C/swiftify-import/counted-by.swift
@@ -172,27 +172,27 @@ void constInt(int * __counted_by(42 * 10) p);
 // }}
 void constFloatCastedToInt(int * __counted_by((int) (4.2 / 12)) p);
 
-// expected-expansion@+9:52{{
+// expected-expansion@+9:140{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func sizeofType(_ p: UnsafeMutableBufferPointer<Int32>) {|}}
-//   expected-remark@3{{macro content: |    if p.count != CUnsignedLong(8) {|}}
-//   expected-remark@4{{macro content: |      fatalError("bounds check failure in sizeofType: expected \\(CUnsignedLong(8)) but got \\(p.count)")|}}
+//   expected-remark@3{{macro content: |    if p.count != CUnsignedLongLong(8) {|}}
+//   expected-remark@4{{macro content: |      fatalError("bounds check failure in sizeofType: expected \\(CUnsignedLongLong(8)) but got \\(p.count)")|}}
 //   expected-remark@5{{macro content: |    }|}}
 //   expected-remark@6{{macro content: |    return unsafe sizeofType(p.baseAddress)|}}
 //   expected-remark@7{{macro content: |}|}}
 // }}
-void sizeofType(int * __counted_by(sizeof(int *)) p);
+void sizeofType(int * __counted_by((unsigned long long /*cast to long long to avoid size_t differences between platforms*/)sizeof(int *)) p);
 
-// expected-expansion@+9:49{{
+// expected-expansion@+9:137{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func sizeofParam(_ p: UnsafeMutableBufferPointer<Int32>) {|}}
-//   expected-remark@3{{macro content: |    if p.count != CUnsignedLong(8) {|}}
-//   expected-remark@4{{macro content: |      fatalError("bounds check failure in sizeofParam: expected \\(CUnsignedLong(8)) but got \\(p.count)")|}}
+//   expected-remark@3{{macro content: |    if p.count != CUnsignedLongLong(8) {|}}
+//   expected-remark@4{{macro content: |      fatalError("bounds check failure in sizeofParam: expected \\(CUnsignedLongLong(8)) but got \\(p.count)")|}}
 //   expected-remark@5{{macro content: |    }|}}
 //   expected-remark@6{{macro content: |    return unsafe sizeofParam(p.baseAddress)|}}
 //   expected-remark@7{{macro content: |}|}}
 // }}
-void sizeofParam(int * __counted_by(sizeof(p)) p);
+void sizeofParam(int * __counted_by((unsigned long long /*cast to long long to avoid size_t differences between platforms*/)sizeof(p)) p);
 
 void derefLen(int * len, int * __counted_by(*len) p);
 
@@ -218,10 +218,10 @@ void pointerCastToInt(int *square, int * __counted_by((int) square) p);
 // expected-expansion@+11:50{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func nanAsInt(_ p: UnsafeMutableBufferPointer<Int32>) {|}}
-//   expected-remark@3{{macro content: |    if p.count != ((0 / 0)) {|}}
 //   expected-error@3{{division by zero}}
-//   expected-remark@4{{macro content: |      fatalError("bounds check failure in nanAsInt: expected \\(((0 / 0))) but got \\(p.count)")|}}
+//   expected-remark@3{{macro content: |    if p.count != ((0 / 0)) {|}}
 //   expected-error@4 2{{division by zero}}
+//   expected-remark@4{{macro content: |      fatalError("bounds check failure in nanAsInt: expected \\(((0 / 0))) but got \\(p.count)")|}}
 //   expected-remark@5{{macro content: |    }|}}
 //   expected-remark@6{{macro content: |    return unsafe nanAsInt(p.baseAddress)|}}
 //   expected-remark@7{{macro content: |}|}}
@@ -286,16 +286,16 @@ void octalLiteral(int * __counted_by(0777) p);
 // Regression test: by printing the count expression with C syntax,
 // this example would fail to typecheck since it relies on implicit
 // casts present in C but not in Swift.
-// expected-expansion@+9:78{{
+// expected-expansion@+9:83{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
-//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func implicitIntCast(_ offset: Int, _ len: Int32, _ p: UnsafeMutableBufferPointer<Int32>) {|}}
-//   expected-remark@3{{macro content: |    if p.count != (offset + CLong(len)) {|}}
-//   expected-remark@4{{macro content: |      fatalError("bounds check failure in implicitIntCast: expected \\((offset + CLong(len))) but got \\(p.count)")|}}
+//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func implicitIntCast(_ offset: Int64, _ len: Int32, _ p: UnsafeMutableBufferPointer<Int32>) {|}}
+//   expected-remark@3{{macro content: |    if p.count != (offset + CLongLong(len)) {|}}
+//   expected-remark@4{{macro content: |      fatalError("bounds check failure in implicitIntCast: expected \\((offset + CLongLong(len))) but got \\(p.count)")|}}
 //   expected-remark@5{{macro content: |    }|}}
 //   expected-remark@6{{macro content: |    return unsafe implicitIntCast(offset, len, p.baseAddress)|}}
 //   expected-remark@7{{macro content: |}|}}
 // }}
-void implicitIntCast(long offset, int len, int * __counted_by(offset + len) p);
+void implicitIntCast(long long offset, int len, int * __counted_by(offset + len) p);
 
 void variadic(int len, int * __counted_by(len) p, ...);
 
@@ -306,7 +306,7 @@ module Test {
 
 //--- test.swift
 // GENERATED-BY: %target-swift-ide-test -print-module -module-to-print=Test -plugin-path %swift-plugin-dir -I %t -source-filename=x -Xcc -Wno-nullability-completeness -Xcc -Wno-div-by-zero -Xcc -Wno-pointer-to-int-cast > %t/Test-interface.swift && %swift-function-caller-generator Test %t/Test-interface.swift
-// GENERATED-HASH: 16b1fb4738c5e431b23930b84f738e5195935c2730f1ce04d3b5cbdf3f6d13f8
+// GENERATED-HASH: 53e42d566d4da72b941ab8adce364b9438badc1fbdc6054d986984d3ba2fc23b
 import Test
 
 func call_simple(_ len: Int32, _ p: UnsafeMutablePointer<Int32>!) {
@@ -429,7 +429,7 @@ func call_octalLiteral(_ p: UnsafeMutablePointer<Int32>!) {
   return unsafe octalLiteral(p)
 }
 
-func call_implicitIntCast(_ offset: Int, _ len: Int32, _ p: UnsafeMutablePointer<Int32>!) {
+func call_implicitIntCast(_ offset: Int64, _ len: Int32, _ p: UnsafeMutablePointer<Int32>!) {
   return unsafe implicitIntCast(offset, len, p)
 }
 
@@ -465,7 +465,7 @@ func call_implicitIntCast(_ offset: Int, _ len: Int32, _ p: UnsafeMutablePointer
   return unsafe hexLiteral(p)
 }
 
-@_alwaysEmitIntoClient @_disfavoredOverload public func call_implicitIntCast(_ offset: Int, _ len: Int32, _ p: UnsafeMutableBufferPointer<Int32>) {
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_implicitIntCast(_ offset: Int64, _ len: Int32, _ p: UnsafeMutableBufferPointer<Int32>) {
   return unsafe implicitIntCast(offset, len, p)
 }
 

--- a/test/Interop/C/swiftify-import/counted-by.swift
+++ b/test/Interop/C/swiftify-import/counted-by.swift
@@ -52,8 +52,8 @@ void shared(int len, int * __counted_by(len) p1, int * __counted_by(len) p2);
 // expected-expansion@+9:73{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func complexExpr(_ len: Int32, _ offset: Int32, _ p: UnsafeMutableBufferPointer<Int32>) {|}}
-//   expected-remark@3{{macro content: |    if p.count != len - offset {|}}
-//   expected-remark@4{{macro content: |      fatalError("bounds check failure in complexExpr: expected \\(len - offset) but got \\(p.count)")|}}
+//   expected-remark@3{{macro content: |    if p.count != (len - offset) {|}}
+//   expected-remark@4{{macro content: |      fatalError("bounds check failure in complexExpr: expected \\((len - offset)) but got \\(p.count)")|}}
 //   expected-remark@5{{macro content: |    }|}}
 //   expected-remark@6{{macro content: |    return unsafe complexExpr(len, offset, p.baseAddress)|}}
 //   expected-remark@7{{macro content: |}|}}
@@ -98,8 +98,8 @@ int * __counted_by(len) returnPointer(int len);
 // expected-expansion@+9:53{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func offByOne(_ len: Int32, _ p: UnsafeMutableBufferPointer<Int32>) {|}}
-//   expected-remark@3{{macro content: |    if p.count != len + 1 {|}}
-//   expected-remark@4{{macro content: |      fatalError("bounds check failure in offByOne: expected \\(len + 1) but got \\(p.count)")|}}
+//   expected-remark@3{{macro content: |    if p.count != (len + 1) {|}}
+//   expected-remark@4{{macro content: |      fatalError("bounds check failure in offByOne: expected \\((len + 1)) but got \\(p.count)")|}}
 //   expected-remark@5{{macro content: |    }|}}
 //   expected-remark@6{{macro content: |    return unsafe offByOne(len, p.baseAddress)|}}
 //   expected-remark@7{{macro content: |}|}}
@@ -109,8 +109,8 @@ void offByOne(int len, int * __counted_by(len + 1) p);
 // expected-expansion@+9:77{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func offBySome(_ len: Int32, _ offset: Int32, _ p: UnsafeMutableBufferPointer<Int32>) {|}}
-//   expected-remark@3{{macro content: |    if p.count != len + (1 + offset) {|}}
-//   expected-remark@4{{macro content: |      fatalError("bounds check failure in offBySome: expected \\(len + (1 + offset)) but got \\(p.count)")|}}
+//   expected-remark@3{{macro content: |    if p.count != (len + ((1 + offset))) {|}}
+//   expected-remark@4{{macro content: |      fatalError("bounds check failure in offBySome: expected \\((len + ((1 + offset)))) but got \\(p.count)")|}}
 //   expected-remark@5{{macro content: |    }|}}
 //   expected-remark@6{{macro content: |    return unsafe offBySome(len, offset, p.baseAddress)|}}
 //   expected-remark@7{{macro content: |}|}}
@@ -120,8 +120,8 @@ void offBySome(int len, int offset, int * __counted_by(len + (1 + offset)) p);
 // expected-expansion@+9:54{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func scalar(_ m: Int32, _ n: Int32, _ p: UnsafeMutableBufferPointer<Int32>) {|}}
-//   expected-remark@3{{macro content: |    if p.count != m * n {|}}
-//   expected-remark@4{{macro content: |      fatalError("bounds check failure in scalar: expected \\(m * n) but got \\(p.count)")|}}
+//   expected-remark@3{{macro content: |    if p.count != (m * n) {|}}
+//   expected-remark@4{{macro content: |      fatalError("bounds check failure in scalar: expected \\((m * n)) but got \\(p.count)")|}}
 //   expected-remark@5{{macro content: |    }|}}
 //   expected-remark@6{{macro content: |    return unsafe scalar(m, n, p.baseAddress)|}}
 //   expected-remark@7{{macro content: |}|}}
@@ -131,8 +131,8 @@ void scalar(int m, int n, int * __counted_by(m * n) p);
 // expected-expansion@+9:67{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func bitwise(_ m: Int32, _ n: Int32, _ o: Int32, _ p: UnsafeMutableBufferPointer<Int32>) {|}}
-//   expected-remark@3{{macro content: |    if p.count != m & n | ~o {|}}
-//   expected-remark@4{{macro content: |      fatalError("bounds check failure in bitwise: expected \\(m & n | ~o) but got \\(p.count)")|}}
+//   expected-remark@3{{macro content: |    if p.count != ((m & n) | ~o) {|}}
+//   expected-remark@4{{macro content: |      fatalError("bounds check failure in bitwise: expected \\(((m & n) | ~o)) but got \\(p.count)")|}}
 //   expected-remark@5{{macro content: |    }|}}
 //   expected-remark@6{{macro content: |    return unsafe bitwise(m, n, o, p.baseAddress)|}}
 //   expected-remark@7{{macro content: |}|}}
@@ -142,8 +142,8 @@ void bitwise(int m, int n, int o, int * __counted_by(m & n | ~o) p);
 // expected-expansion@+9:71{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func bitshift(_ m: Int32, _ n: Int32, _ o: Int32, _ p: UnsafeMutableBufferPointer<Int32>) {|}}
-//   expected-remark@3{{macro content: |    if p.count != m << (n >> o) {|}}
-//   expected-remark@4{{macro content: |      fatalError("bounds check failure in bitshift: expected \\(m << (n >> o)) but got \\(p.count)")|}}
+//   expected-remark@3{{macro content: |    if p.count != (m << ((n >> o))) {|}}
+//   expected-remark@4{{macro content: |      fatalError("bounds check failure in bitshift: expected \\((m << ((n >> o)))) but got \\(p.count)")|}}
 //   expected-remark@5{{macro content: |    }|}}
 //   expected-remark@6{{macro content: |    return unsafe bitshift(m, n, o, p.baseAddress)|}}
 //   expected-remark@7{{macro content: |}|}}
@@ -178,7 +178,7 @@ void constFloatCastedToInt(int * __counted_by((int) (4.2 / 12)) p);
 //   expected-remark@3{{macro content: |    if p.count != CUnsignedLong(8) {|}}
 //   expected-remark@4{{macro content: |      fatalError("bounds check failure in sizeofType: expected \\(CUnsignedLong(8)) but got \\(p.count)")|}}
 //   expected-remark@5{{macro content: |    }|}}
-//   expected-remark@6{{macro content: |    return unsafe sizeofType(p.baseAddress!)|}}
+//   expected-remark@6{{macro content: |    return unsafe sizeofType(p.baseAddress)|}}
 //   expected-remark@7{{macro content: |}|}}
 // }}
 void sizeofType(int * __counted_by(sizeof(int *)) p);
@@ -189,7 +189,7 @@ void sizeofType(int * __counted_by(sizeof(int *)) p);
 //   expected-remark@3{{macro content: |    if p.count != CUnsignedLong(8) {|}}
 //   expected-remark@4{{macro content: |      fatalError("bounds check failure in sizeofParam: expected \\(CUnsignedLong(8)) but got \\(p.count)")|}}
 //   expected-remark@5{{macro content: |    }|}}
-//   expected-remark@6{{macro content: |    return unsafe sizeofParam(p.baseAddress!)|}}
+//   expected-remark@6{{macro content: |    return unsafe sizeofParam(p.baseAddress)|}}
 //   expected-remark@7{{macro content: |}|}}
 // }}
 void sizeofParam(int * __counted_by(sizeof(p)) p);
@@ -208,7 +208,7 @@ void lOr(int len, int * __counted_by(len || len) p);
 //   expected-remark@3{{macro content: |    if p.count != CInt(meters) {|}}
 //   expected-remark@4{{macro content: |      fatalError("bounds check failure in floatCastToInt: expected \\(CInt(meters)) but got \\(p.count)")|}}
 //   expected-remark@5{{macro content: |    }|}}
-//   expected-remark@6{{macro content: |    return unsafe floatCastToInt(meters, p.baseAddress!)|}}
+//   expected-remark@6{{macro content: |    return unsafe floatCastToInt(meters, p.baseAddress)|}}
 //   expected-remark@7{{macro content: |}|}}
 // }}
 void floatCastToInt(float meters, int * __counted_by((int) meters) p);
@@ -218,12 +218,12 @@ void pointerCastToInt(int *square, int * __counted_by((int) square) p);
 // expected-expansion@+11:50{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func nanAsInt(_ p: UnsafeMutableBufferPointer<Int32>) {|}}
+//   expected-remark@3{{macro content: |    if p.count != ((0 / 0)) {|}}
 //   expected-error@3{{division by zero}}
-//   expected-remark@3{{macro content: |    if p.count != (0 / 0) {|}}
-//   expected-remark@4{{macro content: |      fatalError("bounds check failure in nanAsInt: expected \\((0 / 0)) but got \\(p.count)")|}}
+//   expected-remark@4{{macro content: |      fatalError("bounds check failure in nanAsInt: expected \\(((0 / 0))) but got \\(p.count)")|}}
 //   expected-error@4 2{{division by zero}}
 //   expected-remark@5{{macro content: |    }|}}
-//   expected-remark@6{{macro content: |    return unsafe nanAsInt(p.baseAddress!)|}}
+//   expected-remark@6{{macro content: |    return unsafe nanAsInt(p.baseAddress)|}}
 //   expected-remark@7{{macro content: |}|}}
 // }}
 void nanAsInt(int * __counted_by((int) (0 / 0)) p);
@@ -234,7 +234,7 @@ void nanAsInt(int * __counted_by((int) (0 / 0)) p);
 //   expected-remark@3{{macro content: |    if p.count != CUnsignedInt(2) {|}}
 //   expected-remark@4{{macro content: |      fatalError("bounds check failure in unsignedLiteral: expected \\(CUnsignedInt(2)) but got \\(p.count)")|}}
 //   expected-remark@5{{macro content: |    }|}}
-//   expected-remark@6{{macro content: |    return unsafe unsignedLiteral(p.baseAddress!)|}}
+//   expected-remark@6{{macro content: |    return unsafe unsignedLiteral(p.baseAddress)|}}
 //   expected-remark@7{{macro content: |}|}}
 // }}
 void unsignedLiteral(int * __counted_by(2u) p);
@@ -245,7 +245,7 @@ void unsignedLiteral(int * __counted_by(2u) p);
 //   expected-remark@3{{macro content: |    if p.count != CLong(2) {|}}
 //   expected-remark@4{{macro content: |      fatalError("bounds check failure in longLiteral: expected \\(CLong(2)) but got \\(p.count)")|}}
 //   expected-remark@5{{macro content: |    }|}}
-//   expected-remark@6{{macro content: |    return unsafe longLiteral(p.baseAddress!)|}}
+//   expected-remark@6{{macro content: |    return unsafe longLiteral(p.baseAddress)|}}
 //   expected-remark@7{{macro content: |}|}}
 // }}
 void longLiteral(int * __counted_by(2l) p);
@@ -289,10 +289,10 @@ void octalLiteral(int * __counted_by(0777) p);
 // expected-expansion@+9:78{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func implicitIntCast(_ offset: Int, _ len: Int32, _ p: UnsafeMutableBufferPointer<Int32>) {|}}
-//   expected-remark@3{{macro content: |    if p.count != offset + CLong(len) {|}}
-//   expected-remark@4{{macro content: |      fatalError("bounds check failure in implicitIntCast: expected \\(offset + CLong(len)) but got \\(p.count)")|}}
+//   expected-remark@3{{macro content: |    if p.count != (offset + CLong(len)) {|}}
+//   expected-remark@4{{macro content: |      fatalError("bounds check failure in implicitIntCast: expected \\((offset + CLong(len))) but got \\(p.count)")|}}
 //   expected-remark@5{{macro content: |    }|}}
-//   expected-remark@6{{macro content: |    return unsafe implicitIntCast(offset, len, p.baseAddress!)|}}
+//   expected-remark@6{{macro content: |    return unsafe implicitIntCast(offset, len, p.baseAddress)|}}
 //   expected-remark@7{{macro content: |}|}}
 // }}
 void implicitIntCast(long offset, int len, int * __counted_by(offset + len) p);

--- a/test/Interop/C/swiftify-import/counted-by.swift
+++ b/test/Interop/C/swiftify-import/counted-by.swift
@@ -297,6 +297,28 @@ void octalLiteral(int * __counted_by(0777) p);
 // }}
 void implicitIntCast(long long offset, int len, int * __counted_by(offset + len) p);
 
+// expected-expansion@+9:75{{
+//   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func castTwiceLiteral(_ p: UnsafeMutableBufferPointer<Int32>) {|}}
+//   expected-remark@3{{macro content: |    if p.count != CUnsignedInt(4294967295) {|}}
+//   expected-remark@4{{macro content: |      fatalError("bounds check failure in castTwiceLiteral: expected \\(CUnsignedInt(4294967295)) but got \\(p.count)")|}}
+//   expected-remark@5{{macro content: |    }|}}
+//   expected-remark@6{{macro content: |    return unsafe castTwiceLiteral(p.baseAddress!)|}}
+//   expected-remark@7{{macro content: |}|}}
+// }}
+void castTwiceLiteral(int * __counted_by((unsigned int)(signed short)-1) p);
+
+// expected-expansion@+9:73{{
+//   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
+//   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func castParam(_ p: UnsafeMutableBufferPointer<Int32>, _ len: Int16) {|}}
+//   expected-remark@3{{macro content: |    if p.count != CUnsignedInt(len) {|}}
+//   expected-remark@4{{macro content: |      fatalError("bounds check failure in castParam: expected \\(CUnsignedInt(len)) but got \\(p.count)")|}}
+//   expected-remark@5{{macro content: |    }|}}
+//   expected-remark@6{{macro content: |    return unsafe castParam(p.baseAddress!, len)|}}
+//   expected-remark@7{{macro content: |}|}}
+// }}
+void castParam(int * __counted_by((unsigned int)len) p, signed short len);
+
 void variadic(int len, int * __counted_by(len) p, ...);
 
 //--- module.modulemap
@@ -306,7 +328,7 @@ module Test {
 
 //--- test.swift
 // GENERATED-BY: %target-swift-ide-test -print-module -module-to-print=Test -plugin-path %swift-plugin-dir -I %t -source-filename=x -Xcc -Wno-nullability-completeness -Xcc -Wno-div-by-zero -Xcc -Wno-pointer-to-int-cast > %t/Test-interface.swift && %swift-function-caller-generator Test %t/Test-interface.swift
-// GENERATED-HASH: 53e42d566d4da72b941ab8adce364b9438badc1fbdc6054d986984d3ba2fc23b
+// GENERATED-HASH: 9a9868adf1d87e2316e50537687ace17870d6ae82ec1dcf06a9580facb95143d
 import Test
 
 func call_simple(_ len: Int32, _ p: UnsafeMutablePointer<Int32>!) {
@@ -433,6 +455,14 @@ func call_implicitIntCast(_ offset: Int64, _ len: Int32, _ p: UnsafeMutablePoint
   return unsafe implicitIntCast(offset, len, p)
 }
 
+func call_castTwiceLiteral(_ p: UnsafeMutablePointer<Int32>!) {
+  return unsafe castTwiceLiteral(p)
+}
+
+func call_castParam(_ p: UnsafeMutablePointer<Int32>!, _ len: Int16) {
+  return unsafe castParam(p, len)
+}
+
 @_alwaysEmitIntoClient @_disfavoredOverload public func call_binaryLiteral(_ p: UnsafeMutableBufferPointer<Int32>) {
   return unsafe binaryLiteral(p)
 }
@@ -443,6 +473,14 @@ func call_implicitIntCast(_ offset: Int64, _ len: Int32, _ p: UnsafeMutablePoint
 
 @_alwaysEmitIntoClient @_disfavoredOverload public func call_bitwise(_ m: Int32, _ n: Int32, _ o: Int32, _ p: UnsafeMutableBufferPointer<Int32>) {
   return unsafe bitwise(m, n, o, p)
+}
+
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_castParam(_ p: UnsafeMutableBufferPointer<Int32>, _ len: Int16) {
+  return unsafe castParam(p, len)
+}
+
+@_alwaysEmitIntoClient @_disfavoredOverload public func call_castTwiceLiteral(_ p: UnsafeMutableBufferPointer<Int32>) {
+  return unsafe castTwiceLiteral(p)
 }
 
 @_alwaysEmitIntoClient @_disfavoredOverload public func call_complexExpr(_ len: Int32, _ offset: Int32, _ p: UnsafeMutableBufferPointer<Int32>) {

--- a/test/Interop/C/swiftify-import/counted-by.swift
+++ b/test/Interop/C/swiftify-import/counted-by.swift
@@ -101,8 +101,8 @@ int * __counted_by(len) returnPointer(int len);
 // expected-expansion@+9:53{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func offByOne(_ len: Int32, _ p: UnsafeMutableBufferPointer<Int32>) {|}}
-//   expected-remark@3{{macro content: |    if p.count != (len + 1) {|}}
-//   expected-remark@4{{macro content: |      fatalError("bounds check failure in offByOne: expected \\((len + 1)) but got \\(p.count)")|}}
+//   expected-remark@3{{macro content: |    if p.count != (len + CInt(1)) {|}}
+//   expected-remark@4{{macro content: |      fatalError("bounds check failure in offByOne: expected \\((len + CInt(1))) but got \\(p.count)")|}}
 //   expected-remark@5{{macro content: |    }|}}
 //   expected-remark@6{{macro content: |    return unsafe offByOne(len, p.baseAddress)|}}
 //   expected-remark@7{{macro content: |}|}}
@@ -112,8 +112,8 @@ void offByOne(int len, int * __counted_by(len + 1) p);
 // expected-expansion@+9:77{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func offBySome(_ len: Int32, _ offset: Int32, _ p: UnsafeMutableBufferPointer<Int32>) {|}}
-//   expected-remark@3{{macro content: |    if p.count != (len + ((1 + offset))) {|}}
-//   expected-remark@4{{macro content: |      fatalError("bounds check failure in offBySome: expected \\((len + ((1 + offset)))) but got \\(p.count)")|}}
+//   expected-remark@3{{macro content: |    if p.count != (len + ((CInt(1) + offset))) {|}}
+//   expected-remark@4{{macro content: |      fatalError("bounds check failure in offBySome: expected \\((len + ((CInt(1) + offset)))) but got \\(p.count)")|}}
 //   expected-remark@5{{macro content: |    }|}}
 //   expected-remark@6{{macro content: |    return unsafe offBySome(len, offset, p.baseAddress)|}}
 //   expected-remark@7{{macro content: |}|}}
@@ -156,8 +156,8 @@ void bitshift(int m, int n, int o, int * __counted_by(m << (n >> o)) p);
 // expected-expansion@+9:44{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func constInt(_ p: UnsafeMutableBufferPointer<Int32>) {|}}
-//   expected-remark@3{{macro content: |    if p.count != 420 {|}}
-//   expected-remark@4{{macro content: |      fatalError("bounds check failure in constInt: expected \\(420) but got \\(p.count)")|}}
+//   expected-remark@3{{macro content: |    if p.count != CInt(420) {|}}
+//   expected-remark@4{{macro content: |      fatalError("bounds check failure in constInt: expected \\(CInt(420)) but got \\(p.count)")|}}
 //   expected-remark@5{{macro content: |    }|}}
 //   expected-remark@6{{macro content: |    return unsafe constInt(p.baseAddress)|}}
 //   expected-remark@7{{macro content: |}|}}
@@ -167,8 +167,8 @@ void constInt(int * __counted_by(42 * 10) p);
 // expected-expansion@+9:66{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func constFloatCastedToInt(_ p: UnsafeMutableBufferPointer<Int32>) {|}}
-//   expected-remark@3{{macro content: |    if p.count != 0 {|}}
-//   expected-remark@4{{macro content: |      fatalError("bounds check failure in constFloatCastedToInt: expected \\(0) but got \\(p.count)")|}}
+//   expected-remark@3{{macro content: |    if p.count != CInt(0) {|}}
+//   expected-remark@4{{macro content: |      fatalError("bounds check failure in constFloatCastedToInt: expected \\(CInt(0)) but got \\(p.count)")|}}
 //   expected-remark@5{{macro content: |    }|}}
 //   expected-remark@6{{macro content: |    return unsafe constFloatCastedToInt(p.baseAddress)|}}
 //   expected-remark@7{{macro content: |}|}}
@@ -221,10 +221,10 @@ void pointerCastToInt(int *square, int * __counted_by((int) square) p);
 // expected-expansion@+11:50{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func nanAsInt(_ p: UnsafeMutableBufferPointer<Int32>) {|}}
+//   expected-remark@3{{macro content: |    if p.count != ((CInt(0) / CInt(0))) {|}}
 //   expected-error@3{{division by zero}}
-//   expected-remark@3{{macro content: |    if p.count != ((0 / 0)) {|}}
+//   expected-remark@4{{macro content: |      fatalError("bounds check failure in nanAsInt: expected \\(((CInt(0) / CInt(0)))) but got \\(p.count)")|}}
 //   expected-error@4 2{{division by zero}}
-//   expected-remark@4{{macro content: |      fatalError("bounds check failure in nanAsInt: expected \\(((0 / 0))) but got \\(p.count)")|}}
 //   expected-remark@5{{macro content: |    }|}}
 //   expected-remark@6{{macro content: |    return unsafe nanAsInt(p.baseAddress)|}}
 //   expected-remark@7{{macro content: |}|}}
@@ -256,8 +256,8 @@ void longLiteral(int * __counted_by(2l) p);
 // expected-expansion@+9:43{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func hexLiteral(_ p: UnsafeMutableBufferPointer<Int32>) {|}}
-//   expected-remark@3{{macro content: |    if p.count != 250 {|}}
-//   expected-remark@4{{macro content: |      fatalError("bounds check failure in hexLiteral: expected \\(250) but got \\(p.count)")|}}
+//   expected-remark@3{{macro content: |    if p.count != CInt(250) {|}}
+//   expected-remark@4{{macro content: |      fatalError("bounds check failure in hexLiteral: expected \\(CInt(250)) but got \\(p.count)")|}}
 //   expected-remark@5{{macro content: |    }|}}
 //   expected-remark@6{{macro content: |    return unsafe hexLiteral(p.baseAddress)|}}
 //   expected-remark@7{{macro content: |}|}}
@@ -267,8 +267,8 @@ void hexLiteral(int * __counted_by(0xfa) p);
 // expected-expansion@+9:46{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func binaryLiteral(_ p: UnsafeMutableBufferPointer<Int32>) {|}}
-//   expected-remark@3{{macro content: |    if p.count != 2 {|}}
-//   expected-remark@4{{macro content: |      fatalError("bounds check failure in binaryLiteral: expected \\(2) but got \\(p.count)")|}}
+//   expected-remark@3{{macro content: |    if p.count != CInt(2) {|}}
+//   expected-remark@4{{macro content: |      fatalError("bounds check failure in binaryLiteral: expected \\(CInt(2)) but got \\(p.count)")|}}
 //   expected-remark@5{{macro content: |    }|}}
 //   expected-remark@6{{macro content: |    return unsafe binaryLiteral(p.baseAddress)|}}
 //   expected-remark@7{{macro content: |}|}}
@@ -278,8 +278,8 @@ void binaryLiteral(int * __counted_by(0b10) p);
 // expected-expansion@+9:45{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func octalLiteral(_ p: UnsafeMutableBufferPointer<Int32>) {|}}
-//   expected-remark@3{{macro content: |    if p.count != 511 {|}}
-//   expected-remark@4{{macro content: |      fatalError("bounds check failure in octalLiteral: expected \\(511) but got \\(p.count)")|}}
+//   expected-remark@3{{macro content: |    if p.count != CInt(511) {|}}
+//   expected-remark@4{{macro content: |      fatalError("bounds check failure in octalLiteral: expected \\(CInt(511)) but got \\(p.count)")|}}
 //   expected-remark@5{{macro content: |    }|}}
 //   expected-remark@6{{macro content: |    return unsafe octalLiteral(p.baseAddress)|}}
 //   expected-remark@7{{macro content: |}|}}

--- a/test/Interop/C/swiftify-import/counted-by.swift
+++ b/test/Interop/C/swiftify-import/counted-by.swift
@@ -306,7 +306,7 @@ void implicitIntCast(long long offset, int len, int * __counted_by(offset + len)
 //   expected-remark@3{{macro content: |    if p.count != CUnsignedInt(4294967295) {|}}
 //   expected-remark@4{{macro content: |      fatalError("bounds check failure in castTwiceLiteral: expected \\(CUnsignedInt(4294967295)) but got \\(p.count)")|}}
 //   expected-remark@5{{macro content: |    }|}}
-//   expected-remark@6{{macro content: |    return unsafe castTwiceLiteral(p.baseAddress!)|}}
+//   expected-remark@6{{macro content: |    return unsafe castTwiceLiteral(p.baseAddress)|}}
 //   expected-remark@7{{macro content: |}|}}
 // }}
 void castTwiceLiteral(int * __counted_by((unsigned int)(signed short)-1) p);
@@ -317,7 +317,7 @@ void castTwiceLiteral(int * __counted_by((unsigned int)(signed short)-1) p);
 //   expected-remark@3{{macro content: |    if p.count != CUnsignedInt(truncatingIfNeeded: len) {|}}
 //   expected-remark@4{{macro content: |      fatalError("bounds check failure in castParam: expected \\(CUnsignedInt(truncatingIfNeeded: len)) but got \\(p.count)")|}}
 //   expected-remark@5{{macro content: |    }|}}
-//   expected-remark@6{{macro content: |    return unsafe castParam(p.baseAddress!, len)|}}
+//   expected-remark@6{{macro content: |    return unsafe castParam(p.baseAddress, len)|}}
 //   expected-remark@7{{macro content: |}|}}
 // }}
 void castParam(int * __counted_by((unsigned int)len) p, signed short len);
@@ -328,7 +328,7 @@ void castParam(int * __counted_by((unsigned int)len) p, signed short len);
 //   expected-remark@3{{macro content: |    if p.count != CInt(truncatingIfNeeded: len) {|}}
 //   expected-remark@4{{macro content: |      fatalError("bounds check failure in castParam2: expected \\(CInt(truncatingIfNeeded: len)) but got \\(p.count)")|}}
 //   expected-remark@5{{macro content: |    }|}}
-//   expected-remark@6{{macro content: |    return unsafe castParam2(p.baseAddress!, len)|}}
+//   expected-remark@6{{macro content: |    return unsafe castParam2(p.baseAddress, len)|}}
 //   expected-remark@7{{macro content: |}|}}
 // }}
 void castParam2(int * __counted_by((signed int)len) p, unsigned int len);

--- a/test/Interop/C/swiftify-import/counted-by.swift
+++ b/test/Interop/C/swiftify-import/counted-by.swift
@@ -4,6 +4,9 @@
 // RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -I %t -strict-memory-safety -Xcc -Wno-nullability-completeness -Xcc -Wno-div-by-zero -Xcc -Wno-pointer-to-int-cast \
 // RUN:   %t/test.swift -verify -verify-additional-file %t%{fs-sep}test.h -Rmacro-expansions -suppress-notes -eager-macro-checking
 
+// Not worth adding a separate matcher for sizeof(*int) on 32 bit platforms
+// REQUIRES: PTRSIZE=64
+
 // Check that ClangImporter correctly infers and expands @_SwiftifyImport macros for functions with __counted_by parameters.
 
 //--- test.h

--- a/test/Interop/C/swiftify-import/memcpy.swift
+++ b/test/Interop/C/swiftify-import/memcpy.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 
-// RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -strict-memory-safety \
+// RUN: env SWIFT_BACKTRACE="" %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -strict-memory-safety \
 // RUN:   -Xcc -Werror %t/test.swift -import-bridging-header %t/test.h -dump-macro-expansions -eager-macro-checking -Xcc -fbounds-safety -disable-objc-interop 2> %t/expansion.out
 // RUN: %diff %t/expansion.out %t/expansion.expected
 

--- a/test/Interop/C/swiftify-import/memcpy.swift
+++ b/test/Interop/C/swiftify-import/memcpy.swift
@@ -40,6 +40,6 @@ void * __sized_by(n) foo(void *__sized_by(n) dst, const void *__sized_by(n) src,
     if dst.count != n {
       fatalError("bounds check failure in foo: expected \(n) but got \(dst.count)")
     }
-    return unsafe UnsafeMutableRawBufferPointer(start: unsafe foo(dst.baseAddress!, src.baseAddress!, n), count: Int(n))
+    return unsafe UnsafeMutableRawBufferPointer(start: unsafe foo(dst.baseAddress, src.baseAddress, n), count: Int(n))
 }
 ------------------------------

--- a/test/Interop/C/swiftify-import/memcpy.swift
+++ b/test/Interop/C/swiftify-import/memcpy.swift
@@ -1,0 +1,45 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -strict-memory-safety \
+// RUN:   -Xcc -Werror %t/test.swift -import-bridging-header %t/test.h -dump-macro-expansions -eager-macro-checking -Xcc -fbounds-safety -disable-objc-interop 2> %t/expansion.out
+// RUN: %diff %t/expansion.out %t/expansion.expected
+
+//--- test.swift
+public func callMemCpyOriginal(_ dst: UnsafeMutableRawPointer, _ src: UnsafeMutableRawPointer) {
+  let _ = unsafe memcpy(dst, src, 13)
+  let _ = unsafe foo(dst, src, 13)
+}
+
+public func callMemCpySwiftified(_ dst: UnsafeMutableRawBufferPointer, _ src: UnsafeRawBufferPointer) {
+  let _ = unsafe foo(dst, src)
+}
+
+//--- test.h
+#include <stddef.h>
+
+// In -fbounds-safety mode this will inherit __sized_by attributes from
+// clang's implicit declaration of memcpy. These __sized_by attributes
+// refer to the third parameter, but it has no name: swiftify must skip
+// this decl to prevent emitting a malformed size expression.
+// Unlike memcmp, memcpy is not automatically skipped for belonging to
+// SwiftShims.
+extern void* memcpy(void*, const void*, size_t);
+
+#define __sized_by(n) __attribute__((sized_by(n)))
+
+// This is here to verify that the output actually contains macro expansions.
+void * __sized_by(n) foo(void *__sized_by(n) dst, const void *__sized_by(n) src, size_t n);
+
+//--- expansion.expected
+@__swiftmacro_So3foo15_SwiftifyImportfMp_.swift
+------------------------------
+/// This is an auto-generated wrapper for safer interop
+@_alwaysEmitIntoClient @_disfavoredOverload public func foo(_ dst: UnsafeMutableRawBufferPointer, _ src: UnsafeRawBufferPointer) -> UnsafeMutableRawBufferPointer {
+    let n = src.count
+    if dst.count != n {
+      fatalError("bounds check failure in foo: expected \(n) but got \(dst.count)")
+    }
+    return unsafe UnsafeMutableRawBufferPointer(start: unsafe foo(dst.baseAddress!, src.baseAddress!, n), count: Int(n))
+}
+------------------------------

--- a/test/Interop/C/swiftify-import/sized-by-lifetimebound.swift
+++ b/test/Interop/C/swiftify-import/sized-by-lifetimebound.swift
@@ -75,10 +75,10 @@ const void * __sized_by(len) shared(int len, const void * p __sized_by(len) __li
 //   expected-experimental-remark@9{{macro content: |    }|}}
 //   expected-experimental-remark@10{{macro content: |    let _resultValue: UnsafeRawPointer? = unsafe complexExpr(len, offset, len2, _pPtr.baseAddress)|}}
 //   expected-experimental-remark@11{{macro content: |    if unsafe _resultValue == nil {|}}
-//   expected-experimental-remark@12{{macro content: |      precondition(len - offset == 0, "sized_by may only be null if size is 0 (unlike sized_by_or_null)")|}}
+//   expected-experimental-remark@12{{macro content: |      precondition((len - offset) == 0, "sized_by may only be null if size is 0 (unlike sized_by_or_null)")|}}
 //   expected-experimental-remark@13{{macro content: |      return RawSpan()|}}
 //   expected-experimental-remark@14{{macro content: |    }|}}
-//   expected-experimental-remark@15{{macro content: |    return unsafe _swiftifyOverrideLifetime(RawSpan(_unsafeStart: _resultValue!, byteCount: Int(len - offset)), copying: ())|}}
+//   expected-experimental-remark@15{{macro content: |    return unsafe _swiftifyOverrideLifetime(RawSpan(_unsafeStart: _resultValue!, byteCount: Int((len - offset))), copying: ())|}}
 //   expected-experimental-remark@16{{macro content: |}|}}
 // }}
 const void * __sized_by(len - offset) complexExpr(int len, int offset, int len2, const void * p __sized_by(len2) __lifetimebound);

--- a/test/Interop/C/swiftify-import/sized-by-noescape.swift
+++ b/test/Interop/C/swiftify-import/sized-by-noescape.swift
@@ -76,8 +76,8 @@ void shared(int len, const void * __sized_by(len) __noescape p1, const void * __
 // expected-expansion@+15:89{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_disfavoredOverload public func complexExpr(_ len: Int32, _ offset: Int32, _ p: RawSpan) {|}}
-//   expected-remark@3{{macro content: |    if p.byteCount != len - offset {|}}
-//   expected-remark@4{{macro content: |      fatalError("bounds check failure in complexExpr: expected \\(len - offset) but got \\(p.byteCount)")|}}
+//   expected-remark@3{{macro content: |    if p.byteCount != (len - offset) {|}}
+//   expected-remark@4{{macro content: |      fatalError("bounds check failure in complexExpr: expected \\((len - offset)) but got \\(p.byteCount)")|}}
 //   expected-remark@5{{macro content: |    }|}}
 //   expected-remark@6{{macro content: |    let _pPtr = p.withUnsafeBytes {|}}
 //   expected-remark@7{{macro content: |        unsafe $0|}}

--- a/test/Interop/C/swiftify-import/sized-by-or-null-lifetimebound.swift
+++ b/test/Interop/C/swiftify-import/sized-by-or-null-lifetimebound.swift
@@ -75,10 +75,10 @@ const void * __sized_by_or_null(len) shared(int len, const void * p __sized_by_o
 //   expected-experimental-remark@9{{macro content: |    }|}}
 //   expected-experimental-remark@10{{macro content: |    let _resultValue: UnsafeRawPointer? = unsafe complexExpr(len, offset, len2, _pPtr.baseAddress)|}}
 //   expected-experimental-remark@11{{macro content: |    if unsafe _resultValue == nil {|}}
-//   expected-experimental-remark@12{{macro content: |      precondition(len - offset == 0, "sized_by may only be null if size is 0 (unlike sized_by_or_null)")|}}
+//   expected-experimental-remark@12{{macro content: |      precondition((len - offset) == 0, "sized_by may only be null if size is 0 (unlike sized_by_or_null)")|}}
 //   expected-experimental-remark@13{{macro content: |      return RawSpan()|}}
 //   expected-experimental-remark@14{{macro content: |    }|}}
-//   expected-experimental-remark@15{{macro content: |    return unsafe _swiftifyOverrideLifetime(RawSpan(_unsafeStart: _resultValue!, byteCount: Int(len - offset)), copying: ())|}}
+//   expected-experimental-remark@15{{macro content: |    return unsafe _swiftifyOverrideLifetime(RawSpan(_unsafeStart: _resultValue!, byteCount: Int((len - offset))), copying: ())|}}
 //   expected-experimental-remark@16{{macro content: |}|}}
 // }}
 const void * __sized_by_or_null(len - offset) complexExpr(int len, int offset, int len2, const void * p __sized_by_or_null(len2) __lifetimebound);

--- a/test/Interop/C/swiftify-import/sized-by-or-null-noescape.swift
+++ b/test/Interop/C/swiftify-import/sized-by-or-null-noescape.swift
@@ -76,8 +76,8 @@ void shared(int len, const void * __sized_by_or_null(len) __noescape p1, const v
 // expected-expansion@+15:97{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *) @_disfavoredOverload public func complexExpr(_ len: Int32, _ offset: Int32, _ p: RawSpan) {|}}
-//   expected-remark@3{{macro content: |    if p.byteCount != len - offset {|}}
-//   expected-remark@4{{macro content: |      fatalError("bounds check failure in complexExpr: expected \\(len - offset) but got \\(p.byteCount)")|}}
+//   expected-remark@3{{macro content: |    if p.byteCount != (len - offset) {|}}
+//   expected-remark@4{{macro content: |      fatalError("bounds check failure in complexExpr: expected \\((len - offset)) but got \\(p.byteCount)")|}}
 //   expected-remark@5{{macro content: |    }|}}
 //   expected-remark@6{{macro content: |    let _pPtr = p.withUnsafeBytes {|}}
 //   expected-remark@7{{macro content: |        unsafe $0|}}

--- a/test/Interop/C/swiftify-import/sized-by-or-null.swift
+++ b/test/Interop/C/swiftify-import/sized-by-or-null.swift
@@ -49,8 +49,8 @@ void shared(int len, void * __sized_by_or_null(len) p1, void * __sized_by_or_nul
 // expected-expansion@+9:80{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func complexExpr(_ len: Int32, _ offset: Int32, _ p: UnsafeMutableRawBufferPointer) {|}}
-//   expected-remark@3{{macro content: |    if p.count != len - offset {|}}
-//   expected-remark@4{{macro content: |      fatalError("bounds check failure in complexExpr: expected \\(len - offset) but got \\(p.count)")|}}
+//   expected-remark@3{{macro content: |    if p.count != (len - offset) {|}}
+//   expected-remark@4{{macro content: |      fatalError("bounds check failure in complexExpr: expected \\((len - offset)) but got \\(p.count)")|}}
 //   expected-remark@5{{macro content: |    }|}}
 //   expected-remark@6{{macro content: |    return unsafe complexExpr(len, offset, p.baseAddress)|}}
 //   expected-remark@7{{macro content: |}|}}

--- a/test/Interop/C/swiftify-import/sized-by.swift
+++ b/test/Interop/C/swiftify-import/sized-by.swift
@@ -49,8 +49,8 @@ void shared(int len, void * __sized_by(len) p1, void * __sized_by(len) p2);
 // expected-expansion@+9:72{{
 //   expected-remark@1{{macro content: |/// This is an auto-generated wrapper for safer interop|}}
 //   expected-remark@2{{macro content: |@_alwaysEmitIntoClient @_disfavoredOverload public func complexExpr(_ len: Int32, _ offset: Int32, _ p: UnsafeMutableRawBufferPointer) {|}}
-//   expected-remark@3{{macro content: |    if p.count != len - offset {|}}
-//   expected-remark@4{{macro content: |      fatalError("bounds check failure in complexExpr: expected \\(len - offset) but got \\(p.count)")|}}
+//   expected-remark@3{{macro content: |    if p.count != (len - offset) {|}}
+//   expected-remark@4{{macro content: |      fatalError("bounds check failure in complexExpr: expected \\((len - offset)) but got \\(p.count)")|}}
 //   expected-remark@5{{macro content: |    }|}}
 //   expected-remark@6{{macro content: |    return unsafe complexExpr(len, offset, p.baseAddress)|}}
 //   expected-remark@7{{macro content: |}|}}


### PR DESCRIPTION
Previously we would just ask clang to print the count expression and then insert that string into the Swift macro expansion.
Instead manually recurse over the expression and print it as Swift syntax - we already do the traversal to validate that the expression is supported, now we just emit the expression while we're at it.

This fixes some bugs due to diverging semantics when re-parsing a C expression as Swift syntax:
 - arithmetic ops between different bitwidths need explicit casts in Swift
 - binary operators have differing precedence rules

We also get support for more kinds of constant integer literals.
This will also be necessary for converting `*len` to `len.pointee` in the future.

rdar://151791281
rdar://178108573