### PR TITLE
[Dependency Scanning] Include compiler version in incremental scan cache serialized context hash

### DIFF
--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -33,6 +33,7 @@
 #include "swift/Basic/Platform.h"
 #include "swift/Basic/SourceManager.h"
 #include "swift/Basic/Statistic.h"
+#include "swift/Basic/Version.h"
 #include "swift/DependencyScan/ModuleDependencyScanner.h"
 #include "swift/Frontend/CachingUtils.h"
 #include "swift/Frontend/CompileJobCacheKey.h"
@@ -87,7 +88,20 @@ std::string CompilerInvocation::getPCHHash() const {
 std::string CompilerInvocation::getModuleScanningHash() const {
   using llvm::hash_combine;
 
-  auto Code = hash_combine(LangOpts.getModuleScanningHashComponents(),
+  // The compiler version is folded into the hash so that swapping the
+  // swift-frontend binary forces the serialized scanner cache to be
+  // discarded. Without this, a Clang module's contextHash can shift
+  // (for example because ClangImporter injects -D__SWIFT_COMPILER_VERSION
+  // into every Clang invocation), causing the live scan to produce a new
+  // variant of a module already in the loaded cache.
+  static const char *forcedDependencyScanVersion =
+      ::getenv("SWIFT_DEBUG_FORCE_DEPENDENCY_SCAN_VERSION");
+  std::string compilerVersion = forcedDependencyScanVersion
+                                    ? std::string(forcedDependencyScanVersion)
+                                    : version::getSwiftFullVersion();
+
+  auto Code = hash_combine(compilerVersion,
+                           LangOpts.getModuleScanningHashComponents(),
                            FrontendOpts.getModuleScanningHashComponents(),
                            ClangImporterOpts.getModuleScanningHashComponents(),
                            SearchPathOpts.getModuleScanningHashComponents(),

--- a/test/ScanDependencies/Incremental/compiler_version_invalidate.swift
+++ b/test/ScanDependencies/Incremental/compiler_version_invalidate.swift
@@ -1,0 +1,30 @@
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/module-cache)
+
+// Initial scan with a stable, simulated compiler version.
+// RUN: env SWIFT_DEBUG_FORCE_DEPENDENCY_SCAN_VERSION=v1 %target-swift-frontend -scan-dependencies -scanner-module-validation -module-load-mode prefer-interface -Rdependency-scan-cache -load-dependency-scan-cache -serialize-dependency-scan-cache -dependency-scan-cache-path %t/cache.moddepcache -module-cache-path %t/module-cache %s -o %t/deps.json -I %S/../Inputs/CHeaders -module-name Test &> %t/v1_initial.txt
+// RUN: cat %t/v1_initial.txt | %FileCheck %s -check-prefix=V1-INITIAL
+
+// Re-scan with the same compiler version reuses the cache.
+// RUN: env SWIFT_DEBUG_FORCE_DEPENDENCY_SCAN_VERSION=v1 %target-swift-frontend -scan-dependencies -scanner-module-validation -module-load-mode prefer-interface -Rdependency-scan-cache -load-dependency-scan-cache -serialize-dependency-scan-cache -dependency-scan-cache-path %t/cache.moddepcache -module-cache-path %t/module-cache %s -o %t/deps.json -I %S/../Inputs/CHeaders -module-name Test &> %t/v1_rescan.txt
+// RUN: cat %t/v1_rescan.txt | %FileCheck %s -check-prefix=V1-RESCAN
+
+// Re-scan with a different compiler version rejects the cache.
+// RUN: env SWIFT_DEBUG_FORCE_DEPENDENCY_SCAN_VERSION=v2 %target-swift-frontend -scan-dependencies -scanner-module-validation -module-load-mode prefer-interface -Rdependency-scan-cache -load-dependency-scan-cache -serialize-dependency-scan-cache -dependency-scan-cache-path %t/cache.moddepcache -module-cache-path %t/module-cache %s -o %t/deps.json -I %S/../Inputs/CHeaders -module-name Test &> %t/v2_after_v1.txt
+// RUN: cat %t/v2_after_v1.txt | %FileCheck %s -check-prefix=V2-AFTER-V1
+
+// Re-scan again at v2 reuses the freshly-written cache.
+// RUN: env SWIFT_DEBUG_FORCE_DEPENDENCY_SCAN_VERSION=v2 %target-swift-frontend -scan-dependencies -scanner-module-validation -module-load-mode prefer-interface -Rdependency-scan-cache -load-dependency-scan-cache -serialize-dependency-scan-cache -dependency-scan-cache-path %t/cache.moddepcache -module-cache-path %t/module-cache %s -o %t/deps.json -I %S/../Inputs/CHeaders -module-name Test &> %t/v2_rescan.txt
+// RUN: cat %t/v2_rescan.txt | %FileCheck %s -check-prefix=V2-RESCAN
+
+// V1-INITIAL: remark: Incremental module scan: Failed to load module scanning dependency cache from: {{.*}}cache.moddepcache
+// V1-INITIAL: remark: Incremental module scan: Serializing module scanning dependency cache to: {{.*}}cache.moddepcache
+
+// V1-RESCAN: remark: Incremental module scan: Re-using serialized module scanning dependency cache from: {{.*}}cache.moddepcache
+// V1-RESCAN-NOT: remark: Incremental module scan: Failed to load module scanning dependency cache from:
+
+// V2-AFTER-V1: remark: Incremental module scan: Failed to load module scanning dependency cache from: {{.*}}cache.moddepcache
+// V2-AFTER-V1: remark: Incremental module scan: Serializing module scanning dependency cache to: {{.*}}cache.moddepcache
+
+// V2-RESCAN: remark: Incremental module scan: Re-using serialized module scanning dependency cache from: {{.*}}cache.moddepcache
+// V2-RESCAN-NOT: remark: Incremental module scan: Failed to load module scanning dependency cache from:


### PR DESCRIPTION
This ensures that we are not able to re-use a serialized scan cache produced by a different compiler.

Resolves rdar://174848510
