### PR TITLE
SimplifyCFG: fix `switch_enum` optimization with a default case

### DIFF
--- a/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
+++ b/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
@@ -509,7 +509,12 @@ bool SimplifyCFG::simplifyThreadedTerminators() {
         auto *LiveBlock = SEI->getCaseDestination(EI->getElement());
         if (!LiveBlock->args_empty()) {
           auto *LiveBlockArg = LiveBlock->getArgument(0);
-          auto NewValue = EI->hasOperand() ? EI->getOperand() : EI;
+          // The default block receives the whole enum value, not the extracted
+          // payload. Only use the payload for explicitly matched case blocks.
+          bool isDefaultBlock = SEI->hasDefault() && LiveBlock == SEI->getDefaultBB();
+          SILValue NewValue = (!isDefaultBlock && EI->hasOperand())
+                                  ? EI->getOperand()
+                                  : SILValue(EI);
           LiveBlockArg->replaceAllUsesWith(NewValue);
           LiveBlock->eraseArgument(0);
           SILBuilderWithScope(SEI).createBranch(SEI->getLoc(), LiveBlock);

--- a/test/SILOptimizer/simplify_cfg_dom_jumpthread.sil
+++ b/test/SILOptimizer/simplify_cfg_dom_jumpthread.sil
@@ -597,3 +597,25 @@ bb6(%12 : @guaranteed $C):
   return %15
 }
 
+// CHECK-LABEL: sil [ossa] @test_switch_enum_default_with_payload :
+// CHECK-NOT:     switch_enum
+// CHECK:         copy_value {{%.*}} : $E2
+// CHECK:       } // end sil function 'test_switch_enum_default_with_payload'
+sil [ossa] @test_switch_enum_default_with_payload : $@convention(thin) (@guaranteed E2) -> @owned E2 {
+bb0(%0 : @guaranteed $E2):
+  %1 = unchecked_enum_data %0, #E2.b!enumelt
+  %2 = enum $E2, #E2.b!enumelt, %1
+  switch_enum %2, case #E2.a!enumelt: bb1, default bb2
+
+bb1:
+  %4 = copy_value %0
+  br bb3(%4)
+
+bb2(%6 : @guaranteed $E2):
+  %7 = copy_value %6
+  br bb3(%7)
+
+bb3(%9 : @owned $E2):
+  return %9
+}
+


### PR DESCRIPTION
If a `switch_enum` has an `enum` instruction as operand, it can be replaced with a branch to the corresponding block. If this is the default-case block, the block argument is the whole enum and not only the enum payload.

Fixes a SIL verifier crash.
rdar://178144127
