### PR TITLE
[DebugInfo] Fix salvage struct/tuple when a debug block exists

### DIFF
--- a/lib/SILOptimizer/Utils/InstOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/InstOptUtils.cpp
@@ -1917,6 +1917,18 @@ void swift::endLifetimeAtLeakingBlocks(SILValue value,
       });
 }
 
+/// Clone a self-contained instruction (with no operands) into the debug
+/// reconstruction block of \p DbgInst, replacing the block argument.
+/// This uses the TrivialCloner, so its restrictions apply.
+static void salvageTrivialInst(DebugValueInst *DbgInst,
+                               SingleValueInstruction *inst) {
+  SILBasicBlock *debugBB = DbgInst->getOrCreateDebugReconstructionBlock();
+  SILValue cloned = inst->clone(&*debugBB->begin());
+  debugBB->getArgument(0)->replaceAllUsesWith(cloned);
+  debugBB->eraseArgument(0);
+  DbgInst->setOperand(SILUndef::get(DbgInst->getOperand()));
+}
+
 /// Create a new debug value from a store and a debug variable.
 static void transferStoreDebugValue(DebugVarCarryingInst DefiningInst,
                                     SILInstruction *SI,
@@ -1980,20 +1992,51 @@ void swift::salvageDebugInfo(SILInstruction *I) {
   if (auto *STI = dyn_cast<StructInst>(I)) {
     auto STVal = STI->getResult(0);
     llvm::ArrayRef<VarDecl *> FieldDecls =
-      STI->getStructDecl()->getStoredProperties();
-    for (Operand *U : getDebugUses(STVal)) {
+        STI->getStructDecl()->getStoredProperties();
+    SmallVector<Operand *, 4> debugUses(getDebugUses(STVal));
+    for (Operand *U : debugUses) {
       auto *DbgInst = cast<DebugValueInst>(U->getUser());
       auto VarInfo = DbgInst->getCompleteVarInfo();
-      for (VarDecl *FD : FieldDecls) {
-        SILDebugVariable NewVarInfo = VarInfo;
-        auto FieldVal = STI->getFieldValue(FD);
-        // Build the corresponding fragment DIExpression
-        auto FragDIExpr = SILDebugInfoExpression::createFragment(FD);
-        NewVarInfo.DIExpr.append(FragDIExpr);
 
-        // Create a new debug_value
-        SILBuilder(STI, DbgInst->getDebugScope())
-          .createDebugValue(DbgInst->getLoc(), FieldVal, NewVarInfo);
+      if (STI->getElements().empty()) {
+        // Empty structs cannot use fragments, as they have no fields.
+        salvageTrivialInst(DbgInst, STI);
+      } else if (SILBasicBlock *debugBB = DbgInst->getDebugReconstructionBlock()) {
+        // Cannot combine debug reconstruction blocks and fragments.
+        // As debug_values and debug reconstruction blocks only support a
+        // single operand, only salvage one field (the first one).
+        SILValue fieldVal = STI->getOperand(0);
+        SILType structTy = STVal->getType();
+        SILArgument *oldArg = debugBB->getArgument(0);
+
+        // Create an all-undef struct instruction.
+        SILBuilder builder(debugBB->begin());
+        SmallVector<SILValue, 4> elements;
+        for (auto elt : STI->getElements())
+          elements.push_back(SILUndef::get(elt));
+        auto *newStructInst = builder.createStruct(
+            DbgInst->getLoc(), structTy, elements);
+        oldArg->replaceAllUsesWith(newStructInst);
+
+        // Replace the block arg and wire the operand.
+        auto *newArg = debugBB->replacePhiArgument(
+            0, fieldVal->getType(), OwnershipKind::None);
+        newStructInst->setOperand(0, newArg);
+        DbgInst->setOperand(fieldVal);
+      } else {
+        // Fragments are the only way to use multiple operands to reconstruct
+        // a variable, as debug values can only have a single operand.
+        for (VarDecl *FD : FieldDecls) {
+          SILDebugVariable NewVarInfo = VarInfo;
+          auto FieldVal = STI->getFieldValue(FD);
+          // Build the corresponding fragment DIExpression.
+          auto FragDIExpr = SILDebugInfoExpression::createFragment(FD);
+          NewVarInfo.DIExpr.append(FragDIExpr);
+          
+          // Create a new debug_value for each fragment.
+          SILBuilder(STI, DbgInst->getDebugScope())
+            .createDebugValue(DbgInst->getLoc(), FieldVal, NewVarInfo);
+        }
       }
     }
   }
@@ -2030,11 +2073,7 @@ void swift::salvageDebugInfo(SILInstruction *I) {
         continue;
       // Copy the literal into the reconstruction block, and set the operand
       // of the reconstruction block to undef.
-      SILBasicBlock *debugBB = DbgInst->getOrCreateDebugReconstructionBlock();
-      SILValue newLiteral = literal->clone(&*debugBB->begin());
-      debugBB->getArgument(0)->replaceAllUsesWith(newLiteral);
-      debugBB->eraseArgument(0);
-      DbgInst->setOperand(SILUndef::get(DbgInst->getOperand()));
+      salvageTrivialInst(DbgInst, literal);
     }
   }
 }

--- a/lib/SILOptimizer/Utils/InstOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/InstOptUtils.cpp
@@ -2045,18 +2045,52 @@ void swift::salvageDebugInfo(SILInstruction *I) {
   // are preserved.
   if (auto *TTI = dyn_cast<TupleInst>(I)) {
     auto TTVal = TTI->getResult(0);
-    for (Operand *U : getDebugUses(TTVal)) {
+    SmallVector<Operand *, 4> debugUses(getDebugUses(TTVal));
+    for (Operand *U : debugUses) {
       auto *DbgInst = cast<DebugValueInst>(U->getUser());
       auto VarInfo = DbgInst->getCompleteVarInfo();
-      TupleType *TT = TTI->getTupleType();
-      for (auto i : indices(TT->getElements())) {
-        SILDebugVariable NewVarInfo = VarInfo;
-        auto FragDIExpr = SILDebugInfoExpression::createTupleFragment(TT, i);
-        NewVarInfo.DIExpr.append(FragDIExpr);
 
-        // Create a new debug_value
-        SILBuilder(TTI, DbgInst->getDebugScope())
-          .createDebugValue(DbgInst->getLoc(), TTI->getElement(i), NewVarInfo);
+      // Empty tuple: clone into a debug BB and set operand to undef.
+      if (TTI->getElements().empty()) {
+        salvageTrivialInst(DbgInst, TTI);
+        continue;
+      }
+
+      if (SILBasicBlock *debugBB = DbgInst->getDebugReconstructionBlock()) {
+        // Cannot combine debug reconstruction blocks and fragments.
+        // Only salvage one element (the first one).
+        SILValue eltVal = TTI->getOperand(0);
+        SILType tupleTy = TTVal->getType();
+        SILArgument *oldArg = debugBB->getArgument(0);
+
+        // Create an all-undef tuple instruction.
+        SILBuilder builder(debugBB->begin());
+        SmallVector<SILValue, 4> elements;
+        for (auto elt : TTI->getElements())
+          elements.push_back(SILUndef::get(elt));
+        auto *tupleInst = builder.createTuple(
+            DbgInst->getLoc(), tupleTy, elements);
+        oldArg->replaceAllUsesWith(tupleInst);
+
+        // Replace the block arg and wire the operand.
+        auto *newArg = debugBB->replacePhiArgument(
+            0, eltVal->getType(), OwnershipKind::None);
+        tupleInst->setOperand(0, newArg);
+        // Update the debug_value operand.
+        DbgInst->setOperand(eltVal);
+      } else {
+        TupleType *TT = TTI->getTupleType();
+        for (auto i : indices(TT->getElements())) {
+          SILDebugVariable NewVarInfo = VarInfo;
+          auto FragDIExpr =
+              SILDebugInfoExpression::createTupleFragment(TT, i);
+          NewVarInfo.DIExpr.append(FragDIExpr);
+
+          // Create a new debug_value for each fragment.
+          SILBuilder(TTI, DbgInst->getDebugScope())
+              .createDebugValue(DbgInst->getLoc(), TTI->getElement(i),
+                                NewVarInfo);
+        }
       }
     }
   }

--- a/test/DebugInfo/debug_transform_block.sil
+++ b/test/DebugInfo/debug_transform_block.sil
@@ -5,9 +5,16 @@ sil_stage canonical
 import Builtin
 import Swift
 
+struct MyStruct {
+  @_hasStorage var x: Int64 { get set }
+  @_hasStorage var y: Int64 { get set }
+  init(x: Int64, y: Int64)
+}
+
 sil_scope 1 { loc "file.swift":1:6 parent @test_transform_const : $@convention(thin) () -> () }
 sil_scope 2 { loc "file.swift":5:6 parent @test_transform_add : $@convention(thin) (Builtin.Int64) -> () }
 sil_scope 3 { loc "file.swift":10:6 parent @test_transform_multi : $@convention(thin) (Builtin.Int64) -> () }
+sil_scope 4 { loc "file.swift":15:6 parent @test_transform_struct_extract : $@convention(thin) (Int64) -> () }
 
 // CHECK-LABEL: define {{.*}} @test_transform_const
 sil @test_transform_const : $@convention(thin) () -> () {
@@ -62,6 +69,31 @@ bb0(%arg : $Builtin.Int64):
   return %r : $(), loc "file.swift":12:3, scope 3
 }
 
+// CHECK-LABEL: define {{.*}} @test_transform_struct_extract
+sil @test_transform_struct_extract : $@convention(thin) (Int64) -> () {
+bb0(%arg : $Int64):
+// struct + struct_extract of the same field should cancel out.
+// CHECK: #dbg_value(i64 %0, ![[VAR4:[0-9]+]]
+  debug_value %arg : $Int64, let, name "x", transform {
+  bb0(%0 : $Int64):
+    %1 = struct $MyStruct (%0 : $Int64, undef : $Int64)
+    %2 = struct_extract %1 : $MyStruct, #MyStruct.x
+    return %2 : $Int64
+  }, loc "file.swift":16:3, scope 4
+// struct + struct_extract of a different field should yield undef.
+// CHECK: #dbg_value(i64 undef, ![[VAR5:[0-9]+]]
+  debug_value %arg : $Int64, let, name "y", transform {
+  bb0(%0 : $Int64):
+    %1 = struct $MyStruct (%0 : $Int64, undef : $Int64)
+    %2 = struct_extract %1 : $MyStruct, #MyStruct.y
+    return %2 : $Int64
+  }, loc "file.swift":18:3, scope 4
+  %r = tuple ()
+  return %r : $(), loc "file.swift":17:3, scope 4
+}
+
 // CHECK-DAG: ![[VAR1]] = !DILocalVariable(name: "x"
 // CHECK-DAG: ![[VAR2]] = !DILocalVariable(name: "y"
 // CHECK-DAG: ![[VAR3]] = !DILocalVariable(name: "z"
+// CHECK-DAG: ![[VAR4]] = !DILocalVariable(name: "x"
+// CHECK-DAG: ![[VAR5]] = !DILocalVariable(name: "y"

--- a/test/DebugInfo/debug_transform_block.sil
+++ b/test/DebugInfo/debug_transform_block.sil
@@ -15,6 +15,7 @@ sil_scope 1 { loc "file.swift":1:6 parent @test_transform_const : $@convention(t
 sil_scope 2 { loc "file.swift":5:6 parent @test_transform_add : $@convention(thin) (Builtin.Int64) -> () }
 sil_scope 3 { loc "file.swift":10:6 parent @test_transform_multi : $@convention(thin) (Builtin.Int64) -> () }
 sil_scope 4 { loc "file.swift":15:6 parent @test_transform_struct_extract : $@convention(thin) (Int64) -> () }
+sil_scope 5 { loc "file.swift":20:6 parent @test_transform_tuple_extract : $@convention(thin) (Int64) -> () }
 
 // CHECK-LABEL: define {{.*}} @test_transform_const
 sil @test_transform_const : $@convention(thin) () -> () {
@@ -92,8 +93,33 @@ bb0(%arg : $Int64):
   return %r : $(), loc "file.swift":17:3, scope 4
 }
 
+// CHECK-LABEL: define {{.*}} @test_transform_tuple_extract
+sil @test_transform_tuple_extract : $@convention(thin) (Int64) -> () {
+bb0(%arg : $Int64):
+// tuple + tuple_extract of the same element should cancel out.
+// CHECK: #dbg_value(i64 %0, ![[VAR6:[0-9]+]]
+  debug_value %arg : $Int64, let, name "x", transform {
+  bb0(%0 : $Int64):
+    %1 = tuple (%0 : $Int64, undef : $Int64)
+    %2 = tuple_extract %1 : $(Int64, Int64), 0
+    return %2 : $Int64
+  }, loc "file.swift":21:3, scope 5
+// tuple + tuple_extract of the undef element should yield undef.
+// CHECK: #dbg_value(i64 undef, ![[VAR7:[0-9]+]]
+  debug_value %arg : $Int64, let, name "y", transform {
+  bb0(%0 : $Int64):
+    %1 = tuple (%0 : $Int64, undef : $Int64)
+    %2 = tuple_extract %1 : $(Int64, Int64), 1
+    return %2 : $Int64
+  }, loc "file.swift":23:3, scope 5
+  %r = tuple ()
+  return %r : $(), loc "file.swift":24:3, scope 5
+}
+
 // CHECK-DAG: ![[VAR1]] = !DILocalVariable(name: "x"
 // CHECK-DAG: ![[VAR2]] = !DILocalVariable(name: "y"
 // CHECK-DAG: ![[VAR3]] = !DILocalVariable(name: "z"
 // CHECK-DAG: ![[VAR4]] = !DILocalVariable(name: "x"
 // CHECK-DAG: ![[VAR5]] = !DILocalVariable(name: "y"
+// CHECK-DAG: ![[VAR6]] = !DILocalVariable(name: "x"
+// CHECK-DAG: ![[VAR7]] = !DILocalVariable(name: "y"

--- a/test/DebugInfo/sil_combine.sil
+++ b/test/DebugInfo/sil_combine.sil
@@ -103,6 +103,45 @@ bb0:
   return %r : $()
 }
 
+// When a tuple is removed and a debug_value with a reconstruction block
+// references it, salvageDebugInfo should prepend a tuple reconstruction
+// into the debug BB using the first element + undefs for the rest.
+// CHECK-LABEL: sil @salvage_tuple_with_debug_bb
+// CHECK: debug_value %0 : $Int64, let, name "x", type $Int64, transform {
+// CHECK:   bb0(%[[ARG:[0-9]+]] : $Int64):
+// CHECK:     %[[T:[0-9]+]] = tuple (%[[ARG]] : $Int64, undef : $Int64)
+// CHECK:     %[[E:[0-9]+]] = tuple_extract %[[T]] : $(Int64, Int64), 0
+// CHECK:     return %[[E]] : $Int64
+// CHECK:   }
+// CHECK: return %0
+sil @salvage_tuple_with_debug_bb : $@convention(thin) (Int64, Int64) -> Int64 {
+bb0(%0 : $Int64, %1 : $Int64):
+  %t = tuple (%0 : $Int64, %1 : $Int64)
+  debug_value %t : $(Int64, Int64), let, name "x", type $Int64, transform {
+  bb0(%0 : $(Int64, Int64)):
+    %1 = tuple_extract %0 : $(Int64, Int64), 0
+    return %1 : $Int64
+  }
+  %e = tuple_extract %t : $(Int64, Int64), 0
+  return %e : $Int64
+}
+
+// When an empty tuple is removed, the debug_value should be fully salvaged
+// into a debug BB by cloning the tuple construction.
+// CHECK-LABEL: sil @salvage_empty_tuple
+// CHECK: debug_value undef : $(), let, name "e", transform {
+// CHECK:   bb0:
+// CHECK:     %[[T:[0-9]+]] = tuple ()
+// CHECK:     return %[[T]] : $()
+// CHECK:   }
+sil @salvage_empty_tuple : $@convention(thin) () -> () {
+bb0:
+  %t = tuple ()
+  debug_value %t : $(), let, name "e"
+  %r = tuple ()
+  return %r : $()
+}
+
 // This test verifies that splitAggregateLoad in CanonicalizeInstruction.cpp
 // salvages debug info attached to the loaded aggregate in optimized builds.
 //

--- a/test/DebugInfo/sil_combine.sil
+++ b/test/DebugInfo/sil_combine.sil
@@ -56,6 +56,53 @@ struct T {
   init(x: Builtin.Int32)
 }
 
+struct MyStruct {
+  @_hasStorage var x: Int64 { get set }
+  @_hasStorage var y: Int64 { get set }
+  init(x: Int64, y: Int64)
+}
+
+// When a struct is removed and a debug_value with a reconstruction block
+// references it, salvageDebugInfo should prepend a struct reconstruction
+// into the debug BB using the first field + undefs for the rest.
+// CHECK-LABEL: sil @salvage_struct_with_debug_bb
+// CHECK: debug_value %0 : $Int64, let, name "field_x", type $Int64, transform {
+// CHECK:   bb0(%[[ARG:[0-9]+]] : $Int64):
+// CHECK:     %[[S:[0-9]+]] = struct $MyStruct (%[[ARG]] : $Int64, undef : $Int64)
+// CHECK:     %[[E:[0-9]+]] = struct_extract %[[S]] : $MyStruct, #MyStruct.x
+// CHECK:     return %[[E]] : $Int64
+// CHECK:   }
+// CHECK: return %0
+sil @salvage_struct_with_debug_bb : $@convention(thin) (Int64, Int64) -> Int64 {
+bb0(%0 : $Int64, %1 : $Int64):
+  %s = struct $MyStruct (%0 : $Int64, %1 : $Int64)
+  debug_value %s : $MyStruct, let, name "field_x", type $Int64, transform {
+  bb0(%0 : $MyStruct):
+    %1 = struct_extract %0 : $MyStruct, #MyStruct.x
+    return %1 : $Int64
+  }
+  %e = struct_extract %s : $MyStruct, #MyStruct.x
+  return %e : $Int64
+}
+
+public struct Empty {}
+
+// When an empty struct is removed, the debug_value should be fully salvaged
+// into a debug BB by cloning the struct construction.
+// CHECK-LABEL: sil @salvage_empty_struct
+// CHECK: debug_value undef : $Empty, let, name "e", transform {
+// CHECK:   bb0:
+// CHECK:     %[[S:[0-9]+]] = struct $Empty ()
+// CHECK:     return %[[S]] : $Empty
+// CHECK:   }
+sil @salvage_empty_struct : $@convention(thin) () -> () {
+bb0:
+  %s = struct $Empty ()
+  debug_value %s : $Empty, let, name "e"
+  %r = tuple ()
+  return %r : $()
+}
+
 // This test verifies that splitAggregateLoad in CanonicalizeInstruction.cpp
 // salvages debug info attached to the loaded aggregate in optimized builds.
 //

--- a/test/SILOptimizer/cast_folding.swift
+++ b/test/SILOptimizer/cast_folding.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -O -Xllvm -sil-print-types -Xllvm -sil-disable-pass=function-signature-opts -emit-sil %s | %FileCheck %s
+// RUN: %target-swift-frontend -O -Xllvm -sil-print-types -Xllvm -sil-print-transform-blocks=false -Xllvm -sil-disable-pass=function-signature-opts -emit-sil %s | %FileCheck %s
 
 // We want to check two things here:
 // - Correctness
@@ -548,9 +548,10 @@ func test20_1() -> Bool {
 
 // CHECK-LABEL: sil hidden [noinline] @$s12cast_folding8test20_2SbyF : $@convention(thin) () -> Bool
 // CHECK: bb0
-// CHECK-NEXT: %0 = integer_literal $Builtin.Int1, 0
-// CHECK-NEXT: %1 = struct $Bool
-// CHECK-NEXT: return %1
+// CHECK-NEXT: debug_value
+// CHECK-NEXT: %1 = integer_literal $Builtin.Int1, 0
+// CHECK-NEXT: %2 = struct $Bool
+// CHECK-NEXT: return %2
 @inline(never)
 func test20_2() -> Bool {
     return cast20(U())
@@ -934,9 +935,10 @@ public func test40b() -> Bool {
 
 // CHECK-LABEL: sil [noinline] @$s12cast_folding7test40c{{[_0-9a-zA-Z]*}}F
 // CHECK: bb0
-// CHECK-NEXT: %0 = integer_literal $Builtin.Int1, 0
-// CHECK-NEXT: %1 = struct $Bool
-// CHECK-NEXT: return %1
+// CHECK-NEXT: debug_value
+// CHECK-NEXT: %1 = integer_literal $Builtin.Int1, 0
+// CHECK-NEXT: %2 = struct $Bool
+// CHECK-NEXT: return %2
 @inline(never)
 public func test40c() -> Bool {
   return cast40((1, S()))

--- a/test/SILOptimizer/optional_of_existential.swift
+++ b/test/SILOptimizer/optional_of_existential.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -O -module-name=test -Xllvm -sil-print-types -emit-sil -primary-file %s | %FileCheck %s
+// RUN: %target-swift-frontend -O -module-name=test -Xllvm -sil-print-types -Xllvm -sil-print-transform-blocks=false -emit-sil -primary-file %s | %FileCheck %s
 
 protocol P { associatedtype A = Int }
 protocol Q : P {}
@@ -17,6 +17,7 @@ struct X : Q {
 
 // CHECK-LABEL: sil hidden @$s4test1XV0A2MeSiSgvg : $@convention(method) (X) -> Optional<Int> {
 // CHECK:      bb0(%0 : $X):
+// CHECK-NEXT:   debug_value
 // CHECK-NEXT:   debug_value
 // CHECK-NEXT:   integer_literal ${{.*}}, 0
 // CHECK-NEXT:   struct $Int


### PR DESCRIPTION
When a debug reconstruction block exists, adding a fragment is invalid. Instead, salvage struct/tuple instructions into the existing block. As these blocks don't support multiple inputs, only one element is salvaged, but this works well for single-element structs.

Additionally, empty structs/tuples are **no longer dropped** by salvageDebugInfo (breaking some SILOptimizer tests).
