### PR TITLE
[Embedded] Make sure we don't put generic witnesses into witness tables

### DIFF
--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -68,6 +68,7 @@
 #include "GenCall.h"
 #include "GenCast.h"
 #include "GenClass.h"
+#include "GenDecl.h"
 #include "GenEnum.h"
 #include "GenHeap.h"
 #include "GenMeta.h"
@@ -1672,6 +1673,17 @@ static bool isSpecializedConformance(ProtocolConformance *c) {
 #endif
 
       SILFunction *Func = entry.getMethodWitness().Witness;
+
+      // In Embedded Swift, a witness thunk's signature must be valid for
+      // embedded (only fully-specialized or class-bound generic parameters).
+      // Requirements that take unspecialized non-class-bound generics can't
+      // be dispatched through the witness table at runtime in embedded, so
+      // treat the slot as if dead-method elimination had removed it.
+      if (Func && IGM.Context.LangOpts.hasFeature(Feature::Embedded) &&
+          !hasValidSignatureForEmbedded(Func)) {
+        Func = nullptr;
+      }
+
       llvm::Constant *witness = nullptr;
       if (Func) {
         assert(Func->isAsync() == isAsyncRequirement);

--- a/test/embedded/linkage/witness_generic_method.swift
+++ b/test/embedded/linkage/witness_generic_method.swift
@@ -1,0 +1,30 @@
+// RUN: %target-swift-frontend %s -parse-as-library -enable-experimental-feature Embedded -wmo -emit-ir -o - | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: swift_feature_Embedded
+
+// In Embedded Swift, a protocol requirement that takes an unspecialized
+// non-class-bound generic parameter cannot be dispatched through a witness
+// table (the witness would have to be an unspecialized generic function,
+// which Embedded does not support). When such a conformance gets a strongly
+// emitted witness table (via @export(interface) or CodeGenerationModel=interface),
+// IRGen used to assert. Now the unsupported slot is filled with the
+// `swift_deletedMethodError` stub so the rest of the witness table emits.
+
+public protocol P {
+  associatedtype A
+  static func convert<Q: P>(_ q: Q.A, from: Q.Type) -> A?
+}
+
+@export(interface)
+public struct S: P {
+  public typealias A = Int
+  public static func convert<Q: P>(_ q: Q.A, from: Q.Type) -> Int? {
+    return nil
+  }
+}
+
+// The conformance witness table is emitted, and the `convert` slot points at
+// the deleted-method error stub.
+//
+// CHECK: @"$e{{[0-9]+}}{{[A-Za-z0-9_]*}}1SVAA1PAAWP" = {{.*}}global {{.*}}@swift_deletedMethodError


### PR DESCRIPTION
Generic witnesses cannot be called in Embedded Swift. Don't try to put them into witness tables.

Fixes rdar://178147484
