### PR TITLE
Introduce _FoundationInternationalizationData library

### DIFF
--- a/lib/DriverTool/autolink_extract_main.cpp
+++ b/lib/DriverTool/autolink_extract_main.cpp
@@ -253,6 +253,7 @@ int autolink_extract_main(ArrayRef<const char *> Args, const char *Argv0,
       "-lFoundationXML",
       "-l_CFXMLInterface",
       "-l_FoundationCShims",
+      "-l_FoundationInternationalizationData",
       "-l_FoundationCollections",
       // Foundation support libs
       "-lcurl",

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -4030,7 +4030,7 @@ function Get-SelectedSDKBuilds() {
 # search path. CMake consumers receive a -vfsoverlay from the target's PUBLIC
 # interface; SDK consumers do not and therefore need the physical headers.
 function Repair-SDKHeaders([string] $SDKRoot) {
-  foreach ($Module in ("Block", "dispatch", "os", "_foundation_unicode", "_FoundationCShims")) {
+  foreach ($Module in ("Block", "dispatch", "os", "_foundation_unicode", "_FoundationCShims", "_FoundationInternationalizationData")) {
     foreach ($ResourceType in ("swift", "swift_static")) {
       $ModuleDirectory = "$SDKRoot\usr\lib\$ResourceType\$Module"
       if (Test-Path $ModuleDirectory) {


### PR DESCRIPTION
_FoundationInternationalizationData is a new library we're creating in Foundation that mirrors _FoundationCShims in setup. See https://github.com/swiftlang/swift-foundation/pull/1999 for more information.

The swift repo references `_FoundationCShims` in two places that we duplicate here for `_FoundationInternationalizationData`:
1. `build.ps1`: to copy header files from the CMake-output `/usr/lib/swift*` directories into `/usr/include` in the produced toolchain
2. `autolink_extract_main.cpp`: in a list of common toolchain-provided libraries used for deduplicating values in linker commands