### PR TITLE
[6.4] MemoryLifetimeVerifier: treat enums and function types as trivial types.

### DIFF
--- a/include/swift/SIL/MemoryLocations.h
+++ b/include/swift/SIL/MemoryLocations.h
@@ -139,6 +139,13 @@ public:
     /// \endcode
     int parentIdx;
 
+    /// True if this location should be trated as "trivial" location.
+    /// This may differ from the location's type `isTrivial` property:
+    /// Conservatively treat enums and functions as trivial (even if their types
+    /// are not trivial). Memory locations of such types can be missing destroys
+    /// in case the enum is in fact a trivial case (like `Optional.none`).
+    bool isTrivial;
+
     /// Returns true if the location with index \p idx is this location or a
     /// sub location of this location.
     bool isSubLocation(unsigned idx) const {
@@ -163,9 +170,9 @@ public:
     /// -1 means: not yet initialized.
     int numNonTrivialFieldsNotCovered = -1;
 
-    Location(SILValue val, unsigned index, int parentIdx = -1);
+    Location(SILValue val, bool isTrivial, unsigned index, int parentIdx = -1);
 
-    void updateFieldCounters(SILType ty, int increment);
+    void updateFieldCounters(SILType ty, int increment, MemoryLocations *locations);
   };
 
 private:
@@ -194,6 +201,9 @@ private:
 
   /// If true, also analyze trivial memory locations.
   bool handleTrivialLocations;
+  
+  /// Cache for the `isTrivial` flags.
+  llvm::DenseMap<SILType, bool> trivialTypes;
 
 public:
   MemoryLocations(bool handleNonTrivialProjections, bool handleTrivialLocations) :
@@ -308,6 +318,12 @@ private:
 
   /// Calculates Location::numFieldsNotCoveredBySubfields
   void initFieldsCounter(Location &loc);
+
+  /// Returns true if the `type` should be treated as trivial type.
+  /// See `Location::isTrivial`.
+  bool isTrivial(SILType type, SILFunction *inFunction);
+
+  bool computeIsTrivial(SILType type, SILFunction *inFunction);
 };
 
 } // end swift namespace

--- a/lib/SIL/Utils/MemoryLocations.cpp
+++ b/lib/SIL/Utils/MemoryLocations.cpp
@@ -62,9 +62,10 @@ static bool allUsesInSameBlock(AllocStackInst *ASI) {
 //                     MemoryLocations members
 //===----------------------------------------------------------------------===//
 
-MemoryLocations::Location::Location(SILValue val, unsigned index, int parentIdx) :
+MemoryLocations::Location::Location(SILValue val, bool isTrivial, unsigned index, int parentIdx) :
       representativeValue(val),
-      parentIdx(parentIdx) {
+      parentIdx(parentIdx),
+      isTrivial(isTrivial) {
   assert(((parentIdx >= 0) ==
           (isa<StructElementAddrInst>(val) || isa<TupleElementAddrInst>(val) ||
            isa<InitEnumDataAddrInst>(val) ||
@@ -79,13 +80,19 @@ MemoryLocations::Location::Location(SILValue val, unsigned index, int parentIdx)
   setBitAndResize(selfAndParents, index);
 }
 
-void MemoryLocations::Location::updateFieldCounters(SILType ty, int increment) {
+void MemoryLocations::Location::updateFieldCounters(SILType ty, int increment, MemoryLocations *locations) {
   SILFunction *function = representativeValue->getFunction();
-  if (!ty.isEmpty(*function)) {
-    numFieldsNotCoveredBySubfields += increment;
-    if (!ty.isTrivial(*function))
-      numNonTrivialFieldsNotCovered += increment;
+  if (ty.isEmpty(*function))
+    return;
+
+  numFieldsNotCoveredBySubfields += increment;
+  if (locations->isTrivial(ty, function)
+      // Make sure if the parent is trivial (e.g. an enum with a trivial case),
+      // all sub-locations are also trivial.
+      || isTrivial) {
+    return;
   }
+  numNonTrivialFieldsNotCovered += increment;
 }
 
 static SILValue getBaseValue(SILValue addr) {
@@ -199,7 +206,7 @@ void MemoryLocations::analyzeLocation(SILValue loc) {
     return;
 
   unsigned currentLocIdx = locations.size();
-  locations.push_back(Location(loc, currentLocIdx));
+  locations.push_back(Location(loc, isTrivial(loc->getType(), function), currentLocIdx));
   SmallVector<SILValue, 8> collectedVals;
   SubLocationMap subLocationMap;
   if (!analyzeLocationUsesRecursively(loc, currentLocIdx, collectedVals,
@@ -415,7 +422,8 @@ bool MemoryLocations::analyzeAddrProjection(
     SingleValueInstruction *projection, unsigned parentLocIdx,unsigned fieldNr,
     SmallVectorImpl<SILValue> &collectedVals, SubLocationMap &subLocationMap) {
 
-  if (projection->getType().isEmpty(*projection->getFunction()))
+  SILFunction *f = projection->getFunction();
+  if (projection->getType().isEmpty(*f))
     return false;
 
   auto key = std::make_pair(parentLocIdx, fieldNr);
@@ -424,7 +432,11 @@ bool MemoryLocations::analyzeAddrProjection(
     subLocIdx = locations.size();
     assert(subLocIdx > 0);
     subLocationMap[key] = subLocIdx;
-    locations.push_back(Location(projection, subLocIdx, parentLocIdx));
+    bool trivial = isTrivial(projection->getType(), f)
+                   // Make sure if the parent is trivial (e.g. an enum with a trivial case),
+                   // all sub-locations are also trivial.
+                   || locations[parentLocIdx].isTrivial;
+    locations.push_back(Location(projection, trivial, subLocIdx, parentLocIdx));
 
     Location &parentLoc = locations[parentLocIdx];
     locations.back().selfAndParents |= parentLoc.selfAndParents;
@@ -438,7 +450,7 @@ bool MemoryLocations::analyzeAddrProjection(
 
     initFieldsCounter(parentLoc);
     assert(parentLoc.numFieldsNotCoveredBySubfields >= 1);
-    parentLoc.updateFieldCounters(projection->getType(), -1);
+    parentLoc.updateFieldCounters(projection->getType(), -1, this);
 
     if (parentLoc.numFieldsNotCoveredBySubfields == 0) {
       int idx = (int)parentLocIdx;
@@ -496,15 +508,74 @@ void MemoryLocations::initFieldsCounter(Location &loc) {
     SILModule &module = function->getModule();
     for (VarDecl *field : decl->getStoredProperties()) {
       loc.updateFieldCounters(
-          ty.getFieldType(field, module, TypeExpansionContext(*function)), +1);
+          ty.getFieldType(field, module, TypeExpansionContext(*function)), +1, this);
     }
     return;
   }
   if (auto tupleTy = ty.getAs<TupleType>()) {
     for (unsigned idx = 0, end = tupleTy->getNumElements(); idx < end; ++idx) {
-      loc.updateFieldCounters(ty.getTupleElementType(idx), +1);
+      loc.updateFieldCounters(ty.getTupleElementType(idx), +1, this);
     }
     return;
   }
-  loc.updateFieldCounters(ty, +1);
+  loc.updateFieldCounters(ty, +1, this);
+}
+
+bool MemoryLocations::isTrivial(SILType type, SILFunction *inFunction) {
+  auto iter = trivialTypes.find(type);
+  if (iter != trivialTypes.end())
+    return iter->second;
+
+  bool trivial = computeIsTrivial(type, inFunction);
+  trivialTypes[type] = trivial;
+  return trivial;
+}
+
+bool MemoryLocations::computeIsTrivial(SILType type, SILFunction *inFunction) {
+
+  if (inFunction->getTypeProperties(type).isInfinite()) {
+    return type.isTrivial(*inFunction);
+  }
+
+  if (auto tupleTy = type.getAs<TupleType>()) {
+    // A tuple is trivial if all elements are trivial.
+    for (unsigned idx = 0, num = tupleTy->getNumElements(); idx < num; ++idx) {
+      if (!isTrivial(type.getTupleElementType(idx), inFunction))
+        return false;
+    }
+    return true;
+  }
+
+  if (StructDecl *structDecl = type.getStructOrBoundGenericStruct()) {
+    if (structDecl->isResilient(inFunction->getModule().getSwiftModule(),
+                                inFunction->getResilienceExpansion())) {
+      return false;
+    }
+
+    // A struct is trivial if all elements are trivial.
+    TypeExpansionContext typeEx = inFunction->getTypeExpansionContext();
+    for (VarDecl *field : structDecl->getStoredProperties()) {
+      if (!isTrivial(type.getFieldType(field, inFunction->getModule(), typeEx), inFunction))
+        return false;
+    }
+    return true;
+  }
+
+  if (type.isFunction()) {
+    return true;
+  }
+
+  if (EnumDecl *enumDecl = type.getEnumOrBoundGenericEnum()) {
+    // An enum is trivial if _any_ case is trivial.
+    for (EnumElementDecl *caseDecl : enumDecl->getAllElements()) {
+      if (!caseDecl->hasAssociatedValues())
+        return true;
+
+      if (isTrivial(type.getEnumElementType(caseDecl, inFunction), inFunction))
+        return true;
+    }
+    // fall-through
+  }
+
+  return type.isTrivial(*inFunction);
 }

--- a/test/SIL/memory_lifetime.sil
+++ b/test/SIL/memory_lifetime.sil
@@ -482,6 +482,43 @@ bb0(%0 : $Int):
   return %13 : $()
 }
 
+sil [ossa] @test_trivial_enum_case1 : $@convention(thin) (@owned T) -> () {
+bb0(%0 : @owned $T):
+  %1 = alloc_stack $Optional<T>
+  inject_enum_addr %1, #Optional.none!enumelt
+  %3 = init_enum_data_addr %1, #Optional.some!enumelt
+  store %0 to [init] %3
+  destroy_addr %1
+  dealloc_stack %1
+  %r = tuple ()
+  return %r
+}
+
+sil [ossa] @test_trivial_enum_case2 : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_stack $Optional<T>
+  inject_enum_addr %0, #Optional.none!enumelt
+  %2 = alloc_stack $Optional<T>
+  copy_addr %0 to [init] %2
+  dealloc_stack %2
+  dealloc_stack %0
+  %r = tuple ()
+  return %r
+}
+
+sil [ossa] @test_trivial_enum_case3 : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_stack $Optional<T>
+  inject_enum_addr %0, #Optional.none!enumelt
+  %2 = alloc_stack $(Int, Optional<T>)
+  %3 = tuple_element_addr %2, 1
+  copy_addr %0 to [init] %3
+  dealloc_stack %2
+  dealloc_stack %0
+  %r = tuple ()
+  return %r
+}
+
 sil [ossa] @test_select_enum_addr : $@convention(thin) (@in_guaranteed Optional<T>) -> Builtin.Int1 {
 bb0(%0 : $*Optional<T>):
   %1 = integer_literal $Builtin.Int1, -1

--- a/test/SIL/memory_lifetime_failures.sil
+++ b/test/SIL/memory_lifetime_failures.sil
@@ -29,6 +29,11 @@ struct Mixed {
   var i: Int
 }
 
+enum E {
+  case a(T)
+  case b(T)
+}
+
 public struct InnerWrapper<T> {
   @_hasStorage var _prop: T { get set }
   public var prop: T
@@ -188,7 +193,7 @@ bb0(%0 : $Int):
   return %3 : $Int
 }
 
-// CHECK: SIL memory lifetime failure in @test_switch_enum_addr: memory is initialized at function return but shouldn't
+// TODO-CHECK: SIL memory lifetime failure in @test_switch_enum_addr: memory is initialized at function return but shouldn't
 sil [ossa] @test_switch_enum_addr : $@convention(thin) (@in Optional<T>) -> () {
 bb0(%0 : $*Optional<T>):
   switch_enum_addr %0 : $*Optional<T>, case #Optional.some!enumelt: bb1, case #Optional.none!enumelt: bb2
@@ -205,7 +210,7 @@ bb3:
   return %r : $()
 }
 
-// CHECK: SIL memory lifetime failure in @test_switch_enum: memory is initialized at function return but shouldn't
+// TODO-CHECK: SIL memory lifetime failure in @test_switch_enum: memory is initialized at function return but shouldn't
 sil [ossa] @test_switch_enum : $@convention(thin) (@in Optional<T>) -> () {
 bb0(%0 : $*Optional<T>):
   %1 = load_borrow %0 : $*Optional<T>
@@ -244,7 +249,7 @@ bb3:
   return %r : $()
 }
 
-// CHECK: SIL memory lifetime failure in @test_store_to_enum: memory is initialized, but shouldn't be
+// TODO-CHECK: SIL memory lifetime failure in @test_store_to_enum: memory is initialized, but shouldn't be
 sil [ossa] @test_store_to_enum : $@convention(thin) (@owned T) -> () {
 bb0(%0 : @owned $T):
   %1 = alloc_stack $Optional<T>
@@ -415,12 +420,12 @@ bb0(%0 :  @guaranteed $Optional<T>):
 }
 
 // CHECK: SIL memory lifetime failure in @test_store_borrow_addr_after_dealloc: memory is initialized, but shouldn't be
-sil [ossa] @test_store_borrow_addr_after_dealloc : $@convention(thin) (@guaranteed Optional<T>) -> () {
-bb0(%0 :  @guaranteed $Optional<T>):
-  %s = alloc_stack $Optional<T>
-  %sb = store_borrow %0 to %s : $*Optional<T>
-  dealloc_stack %s : $*Optional<T>
-  end_borrow %sb : $*Optional<T>
+sil [ossa] @test_store_borrow_addr_after_dealloc : $@convention(thin) (@guaranteed T) -> () {
+bb0(%0 :  @guaranteed $T):
+  %s = alloc_stack $T
+  %sb = store_borrow %0 to %s
+  dealloc_stack %s
+  end_borrow %sb
   %res = tuple ()
   return %res : $()
 }
@@ -865,6 +870,16 @@ bb0:
   %10 = tuple ()                                  
   return %10                                      
 } 
+
+// CHECK: SIL memory lifetime failure in @non_trivial_enum: memory is initialized, but shouldn't be
+sil [ossa] @non_trivial_enum : $@convention(thin) (@owned E) -> () {
+bb0(%0 : @owned $E):
+  %1 = alloc_stack $E
+  store %0 to [init] %1
+  dealloc_stack %1
+  %r = tuple ()
+  return %r
+}
 
 
 // CHECK: SIL memory lifetime failure in @mark_dependence_addr_uninit_base: memory is not initialized, but should be


### PR DESCRIPTION
* **Explanation**: This fixes a false verifier error. The fix is to conservatively treat enums and functions as trivial (even if their types are not trivial). Memory locations of such types can be missing destroys in case the enum is in fact a trivial case (like `Optional.none`).
* **Risk**: Low. The change makes the memory lifetime verifier more tolerant.
* **Testing**: by lit tests
* **Issue**: rdar://177972760
* **Reviewers**: @meg-gupta
* **Main branch PR**: https://github.com/swiftlang/swift/pull/89458
