### PR TITLE
LoopUnroll: Clone debug scopes to distinguish pack element types

### DIFF
--- a/lib/SILOptimizer/LoopTransforms/LoopUnroll.cpp
+++ b/lib/SILOptimizer/LoopTransforms/LoopUnroll.cpp
@@ -15,21 +15,21 @@
 #include "llvm/ADT/DepthFirstIterator.h"
 
 #include "swift/Basic/Assertions.h"
+#include "swift/SIL/DebugUtils.h"
 #include "swift/SIL/PatternMatch.h"
 #include "swift/SIL/SILCloner.h"
-#include "swift/SILOptimizer/Analysis/LoopAnalysis.h"
-#include "swift/SILOptimizer/Analysis/IsSelfRecursiveAnalysis.h"
 #include "swift/SILOptimizer/Analysis/DeadEndBlocksAnalysis.h"
+#include "swift/SILOptimizer/Analysis/IsSelfRecursiveAnalysis.h"
+#include "swift/SILOptimizer/Analysis/LoopAnalysis.h"
 #include "swift/SILOptimizer/PassManager/Passes.h"
 #include "swift/SILOptimizer/PassManager/Transforms.h"
 #include "swift/SILOptimizer/Utils/BasicBlockOptUtils.h"
+#include "swift/SILOptimizer/Utils/CFGOptUtils.h"
 #include "swift/SILOptimizer/Utils/LoopUtils.h"
+#include "swift/SILOptimizer/Utils/OwnershipOptUtils.h"
 #include "swift/SILOptimizer/Utils/PerformanceInlinerUtils.h"
 #include "swift/SILOptimizer/Utils/SILInliner.h"
 #include "swift/SILOptimizer/Utils/SILSSAUpdater.h"
-#include "swift/SILOptimizer/Utils/BasicBlockOptUtils.h"
-#include "swift/SILOptimizer/Utils/CFGOptUtils.h"
-#include "swift/SILOptimizer/Utils/OwnershipOptUtils.h"
 
 using namespace swift;
 using namespace swift::PatternMatch;
@@ -50,7 +50,29 @@ class LoopCloner : public SILCloner<LoopCloner> {
 
 public:
   LoopCloner(SILLoop *Loop)
-      : SILCloner<LoopCloner>(*Loop->getHeader()->getParent()), Loop(Loop) {}
+      : SILCloner<LoopCloner>(*Loop->getHeader()->getParent()), Loop(Loop),
+        mustCloneScopes(false), scopeCloner(*Loop->getHeader()->getParent()) {
+
+    // If any debug info-carrying instructions use a @pack_element type that was
+    // opened inside the loop, we must clone the debug scopes. Otherwise, two
+    // instances of the same variable (with the same scope, location and name)
+    // from different iterations of the loop could have different types, after
+    // the @pack_element type is replaced with the appropriate concrete type for
+    // each iteration. This could cause a verification error.
+    for (SILBasicBlock *BB : Loop->getBlocks()) {
+      for (auto &inst : *BB) {
+        if (auto opei = dyn_cast<OpenPackElementInst>(&inst)) {
+          for (SILInstruction *user : opei->getUsers()) {
+            DebugVarCarryingInst debugVarCarryingInst(user);
+            if (debugVarCarryingInst.getKind() !=
+                DebugVarCarryingInst::Kind::Invalid) {
+              mustCloneScopes = true;
+            }
+          }
+        }
+      }
+    }
+  }
 
   /// Clone the basic blocks in the loop.
   void cloneLoop();
@@ -73,6 +95,15 @@ protected:
   // SILCloner CRTP override.
   void postProcess(SILInstruction *Orig, SILInstruction *Cloned) {
     SILCloner<LoopCloner>::postProcess(Orig, Cloned);
+  }
+
+private:
+  bool mustCloneScopes;
+  ScopeCloner scopeCloner;
+  const SILDebugScope *remapScope(const SILDebugScope *DS) {
+    if (mustCloneScopes)
+      return scopeCloner.getOrCreateClonedScope(DS);
+    return SILCloner<LoopCloner>::remapScope(DS);
   }
 };
 

--- a/test/DebugInfo/loop-unroll.sil
+++ b/test/DebugInfo/loop-unroll.sil
@@ -1,0 +1,118 @@
+// RUN: %target-sil-opt -sil-print-debuginfo -loop-unroll -verify %s | %FileCheck %s
+
+sil_stage canonical
+
+import Builtin
+
+// Check that the compiler clones the scope for each loop iteration when an
+// instruction with debug information uses a @pack_element opened within the
+// loop body.
+struct A {
+}
+
+// CHECK: sil_scope [[FIRST_SCOPE:[0-9]+]] { loc "file.swift":1:1 parent @pack_element_debug_info_clone_scopes
+// CHECK: sil_scope [[SECOND_SCOPE:[0-9]+]] { loc "file.swift":1:1 parent @pack_element_debug_info_clone_scopes
+sil_scope 1 { loc "file.swift":1:1 parent @pack_element_debug_info_clone_scopes : $@convention(thin) () -> () }
+
+// CHECK-LABEL: sil @pack_element_debug_info_clone_scopes : $@convention(thin) () -> () {
+// CHECK: alloc_stack {{.*}} scope [[FIRST_SCOPE]]
+// CHECK: alloc_stack {{.*}} scope [[SECOND_SCOPE]]
+// CHECK-LABEL: } // end sil function 'pack_element_debug_info_clone_scopes'
+sil @pack_element_debug_info_clone_scopes : $@convention(thin) () -> () {
+bb0:
+ %0 = integer_literal $Builtin.Word, 0
+ %1 = integer_literal $Builtin.Word, 1
+ %2 = integer_literal $Builtin.Word, 2
+ %3 = integer_literal $Builtin.Int1, 1
+ %pack = alloc_pack $Pack{A, A}
+ br bb1(%0 : $Builtin.Word)
+
+bb1(%4 : $Builtin.Word):
+  %index = dynamic_pack_index %4 of $Pack{A, A}
+  %opened = open_pack_element %index of <each Z> at <Pack{A, A}>, shape $each Z, uuid "A8C5CF80-5AAD-11F1-A304-929C59BC796A"
+  %alloca = alloc_stack $@pack_element("A8C5CF80-5AAD-11F1-A304-929C59BC796A") each Z, var, name "x", scope 1
+  dealloc_stack %alloca
+  %5 = builtin "sadd_with_overflow_Word"(%4 : $Builtin.Word, %1 : $Builtin.Word, %3 : $Builtin.Int1) : $(Builtin.Word, Builtin.Int1)
+  %6 = tuple_extract %5 : $(Builtin.Word, Builtin.Int1), 0
+  %7 = builtin "cmp_slt_Word"(%6 : $Builtin.Word, %2 : $Builtin.Word) : $Builtin.Int1
+  cond_br %7, bb2, bb3
+
+bb2:
+  br bb1(%6 : $Builtin.Word)
+
+bb3:
+ dealloc_pack %pack
+ %8 = tuple()
+ return %8 : $()
+}
+
+// CHECK: sil_scope [[ONLY_SCOPE:[0-9]+]] { loc "file.swift":1:1 parent @pack_element_debug_info_clone_scopes_unused
+sil_scope 2 { loc "file.swift":1:1 parent @pack_element_debug_info_clone_scopes_unused : $@convention(thin) () -> () }
+
+// CHECK-LABEL: sil @pack_element_debug_info_clone_scopes_unused : $@convention(thin) () -> () {
+// CHECK: alloc_stack {{.*}} scope [[ONLY_SCOPE]]
+// CHECK: alloc_stack {{.*}} scope [[ONLY_SCOPE]]
+// CHECK-LABEL: } // end sil function 'pack_element_debug_info_clone_scopes_unused'
+sil @pack_element_debug_info_clone_scopes_unused : $@convention(thin) () -> () {
+bb0:
+ %0 = integer_literal $Builtin.Word, 0
+ %1 = integer_literal $Builtin.Word, 1
+ %2 = integer_literal $Builtin.Word, 2
+ %3 = integer_literal $Builtin.Int1, 1
+ %pack = alloc_pack $Pack{A, A}
+ br bb1(%0 : $Builtin.Word)
+
+bb1(%4 : $Builtin.Word):
+  %index = dynamic_pack_index %4 of $Pack{A, A}
+  %opened = open_pack_element %index of <each Z> at <Pack{A, A}>, shape $each Z, uuid "A8C5CF80-5AAD-11F1-A304-929C59BC796B"
+  %alloca = alloc_stack $A, var, name "x", scope 2
+  dealloc_stack %alloca
+  %5 = builtin "sadd_with_overflow_Word"(%4 : $Builtin.Word, %1 : $Builtin.Word, %3 : $Builtin.Int1) : $(Builtin.Word, Builtin.Int1)
+  %6 = tuple_extract %5 : $(Builtin.Word, Builtin.Int1), 0
+  %7 = builtin "cmp_slt_Word"(%6 : $Builtin.Word, %2 : $Builtin.Word) : $Builtin.Int1
+  cond_br %7, bb2, bb3
+
+bb2:
+  br bb1(%6 : $Builtin.Word)
+
+bb3:
+ dealloc_pack %pack
+ %8 = tuple()
+ return %8 : $()
+}
+
+
+// CHECK: sil_scope [[ONLY_SCOPE:[0-9]+]] { loc "file.swift":1:1 parent @pack_element_debug_info_clone_scopes_hoisted
+sil_scope 3 { loc "file.swift":1:1 parent @pack_element_debug_info_clone_scopes_hoisted : $@convention(thin) (Builtin.Word) -> () }
+
+// CHECK-LABEL: sil @pack_element_debug_info_clone_scopes_hoisted : $@convention(thin) (Builtin.Word) -> () {
+// CHECK: alloc_stack {{.*}} scope [[ONLY_SCOPE]]
+// CHECK: alloc_stack {{.*}} scope [[ONLY_SCOPE]]
+// CHECK-LABEL: } // end sil function 'pack_element_debug_info_clone_scopes_hoisted'
+sil @pack_element_debug_info_clone_scopes_hoisted : $@convention(thin) (Builtin.Word) -> () {
+bb0(%idx : $Builtin.Word):
+ %0 = integer_literal $Builtin.Word, 0
+ %1 = integer_literal $Builtin.Word, 1
+ %2 = integer_literal $Builtin.Word, 2
+ %3 = integer_literal $Builtin.Int1, 1
+ %pack = alloc_pack $Pack{A, A}
+ %index = dynamic_pack_index %idx of $Pack{A, A}
+ %opened = open_pack_element %index of <each Z> at <Pack{A, A}>, shape $each Z, uuid "A8C5CF80-5AAD-11F1-A304-929C59BC796C"
+ br bb1(%0 : $Builtin.Word)
+
+bb1(%4 : $Builtin.Word):
+  %alloca = alloc_stack $@pack_element("A8C5CF80-5AAD-11F1-A304-929C59BC796C") each Z, var, name "x", scope 3
+  dealloc_stack %alloca
+  %5 = builtin "sadd_with_overflow_Word"(%4 : $Builtin.Word, %1 : $Builtin.Word, %3 : $Builtin.Int1) : $(Builtin.Word, Builtin.Int1)
+  %6 = tuple_extract %5 : $(Builtin.Word, Builtin.Int1), 0
+  %7 = builtin "cmp_slt_Word"(%6 : $Builtin.Word, %2 : $Builtin.Word) : $Builtin.Int1
+  cond_br %7, bb2, bb3
+
+bb2:
+  br bb1(%6 : $Builtin.Word)
+
+bb3:
+ dealloc_pack %pack
+ %8 = tuple()
+ return %8 : $()
+}

--- a/test/SILOptimizer/pack_specialization.swift
+++ b/test/SILOptimizer/pack_specialization.swift
@@ -146,3 +146,25 @@ public func applyDirect<each T>(input: repeat each T, op: (repeat each T) -> Int
 public func testDirect() -> Int32 {
     applyDirect(input: 27, 27) { ($0 + $1) }
 }
+
+// rdar://178048566: Two variables with different type but same scope
+
+public protocol P { var n: Int { get } }
+public struct A: P {
+  public var n: Int
+  public init(_ n: Int) { self.n = n }
+}
+public struct B: P {
+  public var n: Int
+  public init(_ n: Int) { self.n = n }
+}
+
+@inline(never)
+public func sum<each T: P>(_ xs: repeat each T) -> Int {
+  var total = 0
+  for x in repeat each xs { total += x.n }
+  return total
+}
+
+@inline(never)
+public func driver(_ a: A, _ b: B) -> Int { sum(a, b) }


### PR DESCRIPTION
If any debug info-carrying instructions use a `@pack_element` type that was opened inside a loop, we must clone the debug scopes when unrolling the loop. Otherwise, two instances of the same variable (with the same scope, location and name) from different iterations of the loop could have different types, after the `@pack_element` type is replaced with the appropriate concrete type for each iteration. This could cause a verification error.

Fixes:
- rdar://178048566
<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
