### PR TITLE
[6.4.x] AST: Add the `UselessConditionalStatement` warning group

### DIFF
--- a/include/swift/AST/DiagnosticGroups.def
+++ b/include/swift/AST/DiagnosticGroups.def
@@ -107,6 +107,7 @@ GROUP(UntypedThrows,DefaultIgnoreWarnings,"untyped-throws")
 GROUP(NoUseUnstructuredThrowingTask,none,"no-use-throwing-unstructured-task")
 GROUP(UseAnyAppleOSAvailability,DefaultIgnoreWarnings,"use-any-apple-os-availability")
 GROUP(UselessAvailabilityCheck,none,"useless-availability-check")
+GROUP(UselessConditionalStatement,none,"useless-conditional-statement")
 GROUP(WeakMutability,none,"weak-mutability")
 GROUP(OldSuppressedAssociatedTypes,none,"old-suppressed-associatedtypes")
 

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5293,12 +5293,12 @@ ERROR(implicit_async_super_init,none,
       "'super.init' is 'async' and requires an explicit call",
       ())
 
-WARNING(if_always_true,none,
+GROUPED_WARNING(if_always_true,UselessConditionalStatement,none,
         "'if' condition is always true", ())
-WARNING(while_always_true,none,
+GROUPED_WARNING(while_always_true,UselessConditionalStatement,none,
         "'while' condition is always true", ())
 
-WARNING(guard_always_succeeds,none,
+GROUPED_WARNING(guard_always_succeeds,UselessConditionalStatement,none,
         "'guard' condition is always true, body is unreachable", ())
 
 

--- a/include/swift/Frontend/DiagnosticVerifier.h
+++ b/include/swift/Frontend/DiagnosticVerifier.h
@@ -78,17 +78,20 @@ struct CapturedDiagnosticInfo {
   unsigned Column;
   SmallVector<CapturedFixItInfo, 2> FixIts;
   std::string CategoryDocFile;
+  /// Names of the diagnostic group and its parent groups, leaf-first.
+  std::vector<std::string> GroupNames;
 
   CapturedDiagnosticInfo(llvm::SmallString<128> Message,
                          std::optional<unsigned> SourceBufferID,
                          DiagnosticKind Classification, SourceLoc Loc,
                          unsigned Line, unsigned Column,
                          SmallVector<CapturedFixItInfo, 2> FixIts,
-                         const std::string &categoryDocFile)
+                         const std::string &categoryDocFile,
+                         std::vector<std::string> groupNames)
       : Message(Message), SourceBufferID(SourceBufferID),
         Classification(Classification), Loc(Loc), Line(Line), Column(Column),
-        FixIts(FixIts), CategoryDocFile(categoryDocFile) {
-  }
+        FixIts(FixIts), CategoryDocFile(categoryDocFile),
+        GroupNames(std::move(groupNames)) {}
 };
 /// This class implements support for -verify mode in the compiler.  It
 /// buffers up diagnostics produced during compilation, then checks them

--- a/lib/Frontend/DiagnosticVerifier.cpp
+++ b/lib/Frontend/DiagnosticVerifier.cpp
@@ -187,6 +187,7 @@ namespace {
 
 static constexpr StringLiteral fixitExpectationNoneString("none");
 static constexpr StringLiteral categoryDocFileSpecifier("documentation-file=");
+static constexpr StringLiteral groupNameSpecifier("group-name=");
 
 struct ExpectedDiagnosticInfo {
   // This specifies the full range of the "expected-foo {{}}" specifier.
@@ -232,6 +233,18 @@ struct ExpectedDiagnosticInfo {
   };
   std::optional<ExpectedDocumentationFile> DocumentationFile;
 
+  /// Represents a specifier of the form '{{group-name=GroupName}}'. Multiple
+  /// of these are allowed per expected diagnostic; the diagnostic must belong
+  /// to each named group.
+  struct ExpectedGroupName {
+    const char *StartLoc, *EndLoc; // The loc of the {{ and }}'s.
+    StringRef Name; // Name of expected diagnostic group.
+
+    ExpectedGroupName(const char *StartLoc, const char *EndLoc, StringRef Name)
+        : StartLoc(StartLoc), EndLoc(EndLoc), Name(Name) {}
+  };
+  std::vector<ExpectedGroupName> GroupNames;
+
   std::vector<ExpectedDiagnosticInfo> NestedDiags = {};
 
   ExpectedDiagnosticInfo(const char *ExpectedStart,
@@ -265,6 +278,14 @@ renderDocumentationFile(const std::string &documentationFile) {
   std::string Result;
   llvm::raw_string_ostream OS(Result);
   OS << "{{" << categoryDocFileSpecifier << documentationFile << "}}";
+  return OS.str();
+}
+
+/// Render the verifier syntax for a given diagnostic group name.
+static std::string renderGroupName(StringRef groupName) {
+  std::string Result;
+  llvm::raw_string_ostream OS(Result);
+  OS << "{{" << groupNameSpecifier << groupName << "}}";
   return OS.str();
 }
 
@@ -1030,6 +1051,15 @@ unsigned DiagnosticVerifier::parseExpectedDiagInfo(
       continue;
     }
 
+    // If this check starts with 'group-name=', check for a diagnostic group
+    // name instead of a fix-it. Multiple group-name specifiers are allowed.
+    if (CheckStr.starts_with(groupNameSpecifier)) {
+      // Trim 'group-name='.
+      StringRef name = CheckStr.substr(groupNameSpecifier.size());
+      Expected.GroupNames.push_back({OpenLoc, CloseLoc, name});
+      continue;
+    }
+
     // This wasn't a documentation file specifier, so it must be a fix-it.
     // Special case for specifying no fixits should appear.
     if (CheckStr == fixitExpectationNoneString) {
@@ -1304,6 +1334,53 @@ void DiagnosticVerifier::verifyDiagnostics(std::vector<ExpectedDiagnosticInfo> &
                    "expected documentation file not seen; actual documentation "
                    "file: " + actual, fix);
         }
+      }
+    }
+
+    // Verify each expected diagnostic group name. The diagnostic must belong
+    // to every named group; multiple {{group-name=...}} specifiers all have
+    // to match.
+    for (const auto &expectedGroup : expected.GroupNames) {
+      bool matched = llvm::any_of(
+          FoundDiagnostic.GroupNames,
+          [&](const std::string &name) { return name == expectedGroup.Name; });
+      if (matched)
+        continue;
+
+      // Filter actual group names to exclude those that match some other
+      // expected group name on this expectation, since those have already
+      // been accounted for.
+      std::vector<StringRef> remainingActual;
+      for (const auto &name : FoundDiagnostic.GroupNames) {
+        bool isExpected = llvm::any_of(
+            expected.GroupNames,
+            [&](const ExpectedDiagnosticInfo::ExpectedGroupName &eg) {
+              return eg.Name == name;
+            });
+        if (!isExpected)
+          remainingActual.push_back(name);
+      }
+
+      if (remainingActual.empty()) {
+        addError(expectedGroup.StartLoc, "expected group name not seen");
+      } else {
+        std::string actual;
+        llvm::raw_string_ostream OS(actual);
+        llvm::interleave(
+            remainingActual,
+            [&](StringRef name) { OS << renderGroupName(name); },
+            [&] { OS << ' '; });
+
+        auto replStartLoc =
+            llvm::SMLoc::getFromPointer(expectedGroup.StartLoc);
+        auto replEndLoc = llvm::SMLoc::getFromPointer(expectedGroup.EndLoc);
+        llvm::SMFixIt fix(llvm::SMRange(replStartLoc, replEndLoc),
+                          renderGroupName(remainingActual.front()));
+        addError(expectedGroup.StartLoc,
+                 "expected group name not seen; actual group name" +
+                     std::string(remainingActual.size() > 1 ? "s" : "") +
+                     ": " + OS.str(),
+                 fix);
       }
     }
 
@@ -1701,11 +1778,17 @@ void DiagnosticVerifier::handleDiagnostic(SourceManager &SM,
                                            Info.FormatArgs);
   }
 
+  std::vector<std::string> groupNames;
+  groupNames.reserve(Info.CategoryChain.size());
+  for (const auto &category : Info.CategoryChain)
+    groupNames.emplace_back(category.Name.str());
+
   DiagLoc loc(SM, this->SM, Info.Loc);
   CapturedDiagnostics.emplace_back(message, loc.bufferID, Info.Kind,
                                    loc.sourceLoc, loc.line, loc.column, fixIts,
                                    llvm::sys::path::stem(
-                                      Info.getCategoryDocumentationURL()).str());
+                                      Info.getCategoryDocumentationURL()).str(),
+                                   std::move(groupNames));
 }
 
 /// Once all diagnostics have been captured, perform verification.

--- a/test/Availability/availability_unnecessary.swift
+++ b/test/Availability/availability_unnecessary.swift
@@ -1,16 +1,14 @@
 // Ensure that the `unnecessary check` availability warning is emitted when unnecessary due to
 // scope's explicit annotation
 
-// RUN: %target-typecheck-verify-swift -verify -target %target-cpu-apple-macosx11.2 -verify-additional-prefix noerror-
-// RUN: %target-typecheck-verify-swift -verify -target %target-cpu-apple-macosx11.2 -Werror UselessAvailabilityCheck -verify-additional-prefix werror-
+// RUN: %target-typecheck-verify-swift -verify -target %target-cpu-apple-macosx11.2
 // REQUIRES: OS=macosx
 
 @available(macOS 11.1, *)
 class Foo {
     // expected-note@-1 {{enclosing scope here}}
     func foo() {
-        // expected-noerror-warning@+2 {{unnecessary check for 'macOS'; enclosing scope ensures guard will always be true}}
-        // expected-werror-error@+1 {{unnecessary check for 'macOS'; enclosing scope ensures guard will always be true}}
+        // expected-warning@+1 {{unnecessary check for 'macOS'; enclosing scope ensures guard will always be true}}{{group-name=UselessAvailabilityCheck}}
         if #available(macOS 11.0, *) {}
     }
 }

--- a/test/Concurrency/isolated_any.swift
+++ b/test/Concurrency/isolated_any.swift
@@ -1,5 +1,4 @@
-// RUN: %target-swift-frontend -typecheck -verify -target %target-swift-5.1-abi-triple -strict-concurrency=complete -enable-upcoming-feature InferSendableFromCaptures -verify-additional-prefix noerror- %s
-// RUN: %target-swift-frontend -typecheck -verify -target %target-swift-5.1-abi-triple -strict-concurrency=complete -enable-upcoming-feature InferSendableFromCaptures -verify-additional-prefix werror- -Werror ConversionFromIsolatedAnyToSynchronous %s
+// RUN: %target-swift-frontend -typecheck -verify -target %target-swift-5.1-abi-triple -strict-concurrency=complete -enable-upcoming-feature InferSendableFromCaptures %s
 
 // REQUIRES: swift_feature_InferSendableFromCaptures
 
@@ -72,15 +71,13 @@ func testConvertIsolatedAnyToNonIsolated(fn: @Sendable @isolated(any) () -> ()) 
 
 func requireSendableNonIsolated_sync(_ fn: @Sendable () -> ()) {}
 func testConvertIsolatedAnyToNonIsolated_sync(fn: @Sendable @isolated(any) () -> ()) {
-  // expected-noerror-warning @+2 {{converting @isolated(any) function of type '@isolated(any) @Sendable () -> ()' to synchronous function type '@Sendable () -> ()' is not allowed; this will be an error in a future Swift language mode}}
-  // expected-werror-error @+1 {{converting @isolated(any) function of type '@isolated(any) @Sendable () -> ()' to synchronous function type '@Sendable () -> ()' is not allowed; this will be an error in a future Swift language mode}}
+  // expected-warning @+1 {{converting @isolated(any) function of type '@isolated(any) @Sendable () -> ()' to synchronous function type '@Sendable () -> ()' is not allowed; this will be an error in a future Swift language mode}}{{group-name=ConversionFromIsolatedAnyToSynchronous}}
   requireSendableNonIsolated_sync(fn)
 }
 
 func requireNonSendableNonIsolated_sync(_ fn: () -> ()) {}
 func testConvertIsolatedAnyToNonSendableNonIsolated_sync(fn: @isolated(any) () -> ()) {
-  // expected-noerror-warning @+2 {{converting @isolated(any) function of type '@isolated(any) () -> ()' to synchronous function type '() -> ()' is not allowed; this will be an error in a future Swift language mode}}
-  // expected-werror-error @+1 {{converting @isolated(any) function of type '@isolated(any) () -> ()' to synchronous function type '() -> ()' is not allowed; this will be an error in a future Swift language mode}}
+  // expected-warning @+1 {{converting @isolated(any) function of type '@isolated(any) () -> ()' to synchronous function type '() -> ()' is not allowed; this will be an error in a future Swift language mode}}
   requireNonSendableNonIsolated_sync(fn)
 }
 
@@ -144,8 +141,7 @@ func nonSendableIsolatedAnySyncToSendableSync(
   _ fn: @escaping @isolated(any) () -> Void // expected-note {{parameter 'fn' is implicitly non-Sendable}}
 ) {
   let _: @Sendable () -> Void = fn  // expected-warning {{using non-Sendable parameter 'fn' in a context expecting a '@Sendable' closure}}
-  // expected-noerror-warning @-1 {{converting @isolated(any) function of type '@isolated(any) () -> Void' to synchronous function type '@Sendable () -> Void' is not allowed; this will be an error in a future Swift language mode}}
-  // expected-werror-error @-2 {{converting @isolated(any) function of type '@isolated(any) () -> Void' to synchronous function type '@Sendable () -> Void' is not allowed; this will be an error in a future Swift language mode}}
+  // expected-warning @-1 {{converting @isolated(any) function of type '@isolated(any) () -> Void' to synchronous function type '@Sendable () -> Void' is not allowed; this will be an error in a future Swift language mode}}
 }
 
 func nonSendableIsolatedAnyAsyncToSendableSync(

--- a/test/Concurrency/sendable_without_preconcurrency_2.swift
+++ b/test/Concurrency/sendable_without_preconcurrency_2.swift
@@ -3,18 +3,15 @@
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/StrictModule.swiftmodule -module-name StrictModule -swift-version 6 %S/Inputs/StrictModule.swift
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/NonStrictModule.swiftmodule -module-name NonStrictModule %S/Inputs/NonStrictModule.swift
 
-// RUN: %target-swift-frontend -strict-concurrency=minimal -disable-availability-checking -I %t %s -verify -verify-ignore-unrelated -emit-sil -o /dev/null -verify-additional-prefix noerror-
-// RUN: %target-swift-frontend -strict-concurrency=targeted -verify-additional-prefix targeted-complete- -disable-availability-checking -I %t %s -verify -verify-ignore-unrelated -emit-sil -o /dev/null -verify-additional-prefix noerror-
+// RUN: %target-swift-frontend -strict-concurrency=minimal -disable-availability-checking -I %t %s -verify -verify-ignore-unrelated -emit-sil -o /dev/null
+// RUN: %target-swift-frontend -strict-concurrency=targeted -verify-additional-prefix targeted-complete- -disable-availability-checking -I %t %s -verify -verify-ignore-unrelated -emit-sil -o /dev/null
 
-// RUN: %target-swift-frontend -strict-concurrency=complete -verify-additional-prefix targeted-complete- -verify-additional-prefix complete- -disable-availability-checking -I %t %s -verify -verify-ignore-unrelated -emit-sil -o /dev/null -verify-additional-prefix tns- -verify-additional-prefix noerror-
-
-// RUN: %target-swift-frontend -strict-concurrency=minimal -disable-availability-checking -I %t %s -verify -verify-ignore-unrelated -emit-sil -o /dev/null -verify-additional-prefix werror- -Werror AddPreconcurrencyImport
+// RUN: %target-swift-frontend -strict-concurrency=complete -verify-additional-prefix targeted-complete- -verify-additional-prefix complete- -disable-availability-checking -I %t %s -verify -verify-ignore-unrelated -emit-sil -o /dev/null -verify-additional-prefix tns-
 
 // REQUIRES: concurrency
 
 import StrictModule // no remark: we never recommend @preconcurrency due to an explicitly non-Sendable (via -strict-concurrency=complete) type
-import NonStrictModule // expected-noerror-warning{{add '@preconcurrency' to suppress 'Sendable'-related warnings from module 'NonStrictModule'}}
-// expected-werror-error@-1{{add '@preconcurrency' to suppress 'Sendable'-related warnings from module 'NonStrictModule'}}
+import NonStrictModule // expected-warning{{add '@preconcurrency' to suppress 'Sendable'-related warnings from module 'NonStrictModule'}}{{group-name=AddPreconcurrencyImport}}
 
 actor A {
   func f() -> [StrictStruct: NonStrictClass] { [:] }

--- a/test/Frontend/DiagnosticVerifier/verify-group-name.swift
+++ b/test/Frontend/DiagnosticVerifier/verify-group-name.swift
@@ -1,0 +1,18 @@
+// RUN: not %target-swift-frontend -typecheck -verify %s 2>&1 | %FileCheck %s --implicit-check-not error: --implicit-check-not note: --implicit-check-not warning:
+
+typealias FnType = () -> ()
+
+// Positive case: the diagnostic belongs to the expected group.
+extension FnType {} // expected-error {{non-nominal type 'FnType' (aka '() -> ()') cannot be extended}} {{group-name=NominalTypes}}
+
+// Wrong group name: the diagnostic belongs to a different group.
+extension FnType {} // expected-error {{non-nominal type 'FnType' (aka '() -> ()') cannot be extended}} {{group-name=FooBarBaz}}
+// CHECK: error: expected group name not seen; actual group name: {{[{][{]}}group-name=NominalTypes{{[}][}]}}
+
+// One of multiple expected group names doesn't match.
+extension FnType {} // expected-error {{non-nominal type 'FnType' (aka '() -> ()') cannot be extended}} {{group-name=NominalTypes}} {{group-name=FooBarBaz}}
+// CHECK: error: expected group name not seen{{$}}
+
+// Diagnostic has no group at all.
+let x: Int = "hello, world!" // expected-error {{cannot convert value of type 'String' to specified type 'Int'}} {{group-name=NominalTypes}}
+// CHECK: error: expected group name not seen

--- a/test/ModuleInterface/imports.swift
+++ b/test/ModuleInterface/imports.swift
@@ -1,16 +1,14 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -disable-implicit-concurrency-module-import -disable-implicit-string-processing-module-import -emit-module -o %t/empty.swiftmodule %S/../Inputs/empty.swift
 // RUN: %target-swift-frontend -disable-implicit-concurrency-module-import -disable-implicit-string-processing-module-import -emit-module -o %t/emptyButWithLibraryEvolution.swiftmodule %S/../Inputs/empty.swift -enable-library-evolution
-// RUN: %target-swift-emit-module-interface(%t.swiftinterface) %s %S/Inputs/imports-other.swift -disable-implicit-concurrency-module-import -disable-implicit-string-processing-module-import -I %S/Inputs/imports-clang-modules/ -I %t -verify -swift-version 5 -enable-library-evolution -verify-additional-prefix noerror-
+// RUN: %target-swift-emit-module-interface(%t.swiftinterface) %s %S/Inputs/imports-other.swift -disable-implicit-concurrency-module-import -disable-implicit-string-processing-module-import -I %S/Inputs/imports-clang-modules/ -I %t -verify -swift-version 5 -enable-library-evolution
 // RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -I %S/Inputs/imports-clang-modules/ -I %t
 // RUN: %FileCheck -implicit-check-not BAD %s < %t.swiftinterface
-// RUN: %target-swift-emit-module-interface(%t-werror.swiftinterface) %s %S/Inputs/imports-other.swift -disable-implicit-concurrency-module-import -disable-implicit-string-processing-module-import -I %S/Inputs/imports-clang-modules/ -I %t -verify -swift-version 5 -enable-library-evolution -verify-additional-prefix werror- -Werror UnsupportedScopedImport
 
 @_exported import empty // expected-warning {{module 'empty' was not compiled with library evolution support; using it means binary compatibility for 'imports' can't be guaranteed}}
 @_exported import emptyButWithLibraryEvolution
 import B.B2
-import func C.c // expected-noerror-warning {{scoped imports are not yet supported in module interfaces}}
-// expected-werror-error @-1 {{scoped imports are not yet supported in module interfaces}}
+import func C.c // expected-warning {{scoped imports are not yet supported in module interfaces}}{{group-name=UnsupportedScopedImport}}
 import D
 @_implementationOnly import Secret_BAD
 

--- a/test/SPI/warn_on_ineffective_spi_import.swift
+++ b/test/SPI/warn_on_ineffective_spi_import.swift
@@ -14,8 +14,6 @@
 
 /// Reading from the public .swiftinterface should produce the warning.
 // RUN: rm %t/SPIHelper.private.swiftinterface
-// RUN: %target-typecheck-verify-swift -I %t -verify-additional-prefix noerror-
-// RUN: %target-typecheck-verify-swift -I %t -verify-additional-prefix werror- -Werror SPIImportIgnored
+// RUN: %target-typecheck-verify-swift -I %t
 
-@_spi(SPIHelper) import SPIHelper // expected-noerror-warning {{'@_spi' import of 'SPIHelper' will not include any SPI symbols; 'SPIHelper' was built from the public interface at}}
-// expected-werror-error @-1 {{'@_spi' import of 'SPIHelper' will not include any SPI symbols; 'SPIHelper' was built from the public interface at}}
+@_spi(SPIHelper) import SPIHelper // expected-warning {{'@_spi' import of 'SPIHelper' will not include any SPI symbols; 'SPIHelper' was built from the public interface at}}{{group-name=SPIImportIgnored}}

--- a/test/Sema/access-level-import-inconsistencies.swift
+++ b/test/Sema/access-level-import-inconsistencies.swift
@@ -19,25 +19,18 @@
 public struct LibType {}
 
 // RUN: %target-swift-frontend -typecheck %t/OneFile_AllExplicit.swift -I %t \
-// RUN:   -package-name package -verify -verify-additional-prefix noerror-
-// RUN: %target-swift-frontend -typecheck %t/OneFile_AllExplicit.swift -I %t \
-// RUN:   -package-name package -verify -verify-additional-prefix werror- \
-// RUN:   -Werror InconsistentImportAccess
+// RUN:   -package-name package -verify
 //--- OneFile_AllExplicit.swift
 public import Lib // expected-warning {{public import of 'Lib' was not used in public declarations or inlinable code}}
 // expected-note @-1 4 {{imported 'public' here}}
 package import Lib // expected-warning {{package import of 'Lib' was not used in package declarations}}
-// expected-noerror-warning @-1 {{module 'Lib' is imported as 'public' from the same file; this 'package' access level will be ignored}}
-// expected-werror-error @-2 {{module 'Lib' is imported as 'public' from the same file; this 'package' access level will be ignored}}
+// expected-warning @-1 {{module 'Lib' is imported as 'public' from the same file; this 'package' access level will be ignored}}{{group-name=InconsistentImportAccess}}
 internal import Lib
-// expected-noerror-warning @-1 {{module 'Lib' is imported as 'public' from the same file; this 'internal' access level will be ignored}}
-// expected-werror-error @-2 {{module 'Lib' is imported as 'public' from the same file; this 'internal' access level will be ignored}}
+// expected-warning @-1 {{module 'Lib' is imported as 'public' from the same file; this 'internal' access level will be ignored}}{{group-name=InconsistentImportAccess}}
 fileprivate import Lib
-// expected-noerror-warning @-1 {{module 'Lib' is imported as 'public' from the same file; this 'fileprivate' access level will be ignored}}
-// expected-werror-error @-2 {{module 'Lib' is imported as 'public' from the same file; this 'fileprivate' access level will be ignored}}
+// expected-warning @-1 {{module 'Lib' is imported as 'public' from the same file; this 'fileprivate' access level will be ignored}}
 private import Lib
-// expected-noerror-warning @-1 {{module 'Lib' is imported as 'public' from the same file; this 'private' access level will be ignored}}
-// expected-werror-error @-2 {{module 'Lib' is imported as 'public' from the same file; this 'private' access level will be ignored}}
+// expected-warning @-1 {{module 'Lib' is imported as 'public' from the same file; this 'private' access level will be ignored}}
 
 // RUN: %target-swift-frontend -typecheck %t/ManyFiles_AllExplicit_File?.swift -I %t \
 // RUN:   -package-name package -verify

--- a/test/Sema/diag_no_usage.swift
+++ b/test/Sema/diag_no_usage.swift
@@ -1,15 +1,12 @@
-// RUN: %target-typecheck-verify-swift -verify-additional-prefix noerror-
-// RUN: %target-typecheck-verify-swift -verify-additional-prefix werror- -Werror NoUsage
+// RUN: %target-typecheck-verify-swift
 
 // MARK: - Unused literals
 
 func testUnusedLiterals() {
   42
-  // expected-noerror-warning@-1 {{integer literal is unused}}
-  // expected-werror-error@-2 {{integer literal is unused}}
+  // expected-warning@-1 {{integer literal is unused}}{{group-name=NoUsage}}
   "hello"
-  // expected-noerror-warning@-1 {{string literal is unused}}
-  // expected-werror-error@-2 {{string literal is unused}}
+  // expected-warning@-1 {{string literal is unused}}
 }
 
 // MARK: - Unused function call result
@@ -18,8 +15,7 @@ func returnsInt() -> Int { return 42 }
 
 func testUnusedResult() {
   returnsInt()
-  // expected-noerror-warning@-1 {{result of call to 'returnsInt()' is unused}}
-  // expected-werror-error@-2 {{result of call to 'returnsInt()' is unused}}
+  // expected-warning@-1 {{result of call to 'returnsInt()' is unused}}{{group-name=NoUsage}}
 }
 
 // MARK: - Unused initializer result
@@ -28,24 +24,21 @@ class MyClass {}
 
 func testUnusedInitResult() {
   MyClass()
-  // expected-noerror-warning@-1 {{result of 'MyClass' initializer is unused}}
-  // expected-werror-error@-2 {{result of 'MyClass' initializer is unused}}
+  // expected-warning@-1 {{result of 'MyClass' initializer is unused}}
 }
 
 // MARK: - Unused variable binding
 
 func testUnusedVariable() {
   let x = 5
-  // expected-noerror-warning@-1 {{initialization of immutable value 'x' was never used; consider replacing with assignment to '_' or removing it}}
-  // expected-werror-error@-2 {{initialization of immutable value 'x' was never used; consider replacing with assignment to '_' or removing it}}
+  // expected-warning@-1 {{initialization of immutable value 'x' was never used; consider replacing with assignment to '_' or removing it}}
 }
 
 // MARK: - Unused pattern binding
 
 func testUnusedPatternBinding(_ pair: (Int, String)) {
   switch pair {
-  case (let n, _): break // expected-noerror-warning {{immutable value 'n' was never used; consider replacing with '_' or removing it}}
-                         // expected-werror-error@-1 {{immutable value 'n' was never used; consider replacing with '_' or removing it}}
+  case (let n, _): break // expected-warning {{immutable value 'n' was never used; consider replacing with '_' or removing it}}
   }
 }
 
@@ -54,8 +47,7 @@ func testUnusedPatternBinding(_ pair: (Int, String)) {
 func testUnusedCapture() {
   let value = 42
   let _ = { [value] in 0 }
-  // expected-noerror-warning@-1 {{capture 'value' was never used}}
-  // expected-werror-error@-2 {{capture 'value' was never used}}
+  // expected-warning@-1 {{capture 'value' was never used}}
 }
 
 // MARK: - Unused optional try result
@@ -65,14 +57,12 @@ func throwingFunc() throws -> Int { throw SomeError.problem }
 
 func testUnusedOptionalTry() {
   try? throwingFunc()
-  // expected-noerror-warning@-1 {{result of 'try?' is unused}}
-  // expected-werror-error@-2 {{result of 'try?' is unused}}
+  // expected-warning@-1 {{result of 'try?' is unused}}
 }
 
 // MARK: - Unused value in condition binding
 
 func testUnusedStmtCond(_ opt: Int?) {
   if let x = opt {}
-  // expected-noerror-warning@-1 {{value 'x' was defined but never used; consider replacing with boolean test}}
-  // expected-werror-error@-2 {{value 'x' was defined but never used; consider replacing with boolean test}}
+  // expected-warning@-1 {{value 'x' was defined but never used; consider replacing with boolean test}}
 }

--- a/test/Sema/import_package_module_from_sdk.swift
+++ b/test/Sema/import_package_module_from_sdk.swift
@@ -14,9 +14,7 @@
 
 // RUN: test -f %t/SDK/Frameworks/LibInSDK.framework/Modules/LibInSDK.swiftmodule/%module-target-triple.swiftmodule
 
-// RUN: %target-swift-frontend -typecheck -verify -verify-ignore-unknown %t/Client1.swift -package-name libPkg -sdk %t/SDK -I %t -I %t/SDK/Frameworks/LibInSDK.framework/Modules -verify-additional-prefix noerror-
-
-// RUN: %target-swift-frontend -typecheck -verify -verify-ignore-unknown %t/Client1.swift -package-name libPkg -sdk %t/SDK -I %t -I %t/SDK/Frameworks/LibInSDK.framework/Modules -verify-additional-prefix werror- -Werror PackageModuleLoadedFromSDK
+// RUN: %target-swift-frontend -typecheck -verify -verify-ignore-unknown %t/Client1.swift -package-name libPkg -sdk %t/SDK -I %t -I %t/SDK/Frameworks/LibInSDK.framework/Modules
 
 // RUN: %target-swift-frontend -module-name LibLocal -emit-module -emit-module-path %t/LibLocal.swiftmodule -parse-as-library %t/Lib.swift -package-name libPkg
 // RUN: test -f %t/LibLocal.swiftmodule
@@ -32,8 +30,7 @@ package func log(level: Int) {}
 
 //--- Client1.swift
 import LibInSDK
-// expected-noerror-warning@-1 {{module 'LibInSDK' is in package 'libPkg' but was loaded from SDK; modules of the same package should be built locally from source only}}
-// expected-werror-error@-2 {{module 'LibInSDK' is in package 'libPkg' but was loaded from SDK; modules of the same package should be built locally from source only}}
+// expected-warning@-1 {{module 'LibInSDK' is in package 'libPkg' but was loaded from SDK; modules of the same package should be built locally from source only}}{{group-name=PackageModuleLoadedFromSDK}}
 
 func someFunc() {
   log(level: 1)

--- a/test/Sema/superfluously-public-imports.swift
+++ b/test/Sema/superfluously-public-imports.swift
@@ -28,27 +28,15 @@
 // RUN: %target-swift-frontend -typecheck %t/Client.swift -I %t \
 // RUN:   -package-name pkg -Rmodule-api-import \
 // RUN:   -enable-upcoming-feature InternalImportsByDefault -verify \
-// RUN:   -experimental-spi-only-imports -verify-additional-prefix noerror-
-// RUN: %target-swift-frontend -typecheck %t/Client.swift -I %t \
-// RUN:   -package-name pkg -Rmodule-api-import \
-// RUN:   -enable-upcoming-feature InternalImportsByDefault -verify \
-// RUN:   -experimental-spi-only-imports -verify-additional-prefix werror- \
-// RUN:   -Werror UnusedImportAccess
+// RUN:   -experimental-spi-only-imports
 // RUN: %target-swift-frontend -typecheck %t/ClientOfClangModules.swift -I %t \
 // RUN:   -package-name pkg -Rmodule-api-import \
-// RUN:   -enable-upcoming-feature InternalImportsByDefault -verify \
-// RUN:   -verify-additional-prefix noerror-
-// RUN: %target-swift-frontend -typecheck %t/ClientOfClangModules.swift -I %t \
-// RUN:   -package-name pkg -Rmodule-api-import \
-// RUN:   -enable-upcoming-feature InternalImportsByDefault -verify \
-// RUN:   -verify-additional-prefix werror- -Werror UnusedImportAccess
+// RUN:   -enable-upcoming-feature InternalImportsByDefault -verify
 // RUN: %target-swift-frontend -typecheck %t/ClientOfClangReexportedSubmodules.swift -I %t \
 // RUN:   -package-name pkg -Rmodule-api-import \
 // RUN:   -enable-upcoming-feature InternalImportsByDefault -verify
 // RUN: %target-swift-frontend -typecheck %t/Client_Swift5.swift -I %t \
-// RUN:   -swift-version 5 -verify -verify-additional-prefix noerror-
-// RUN: %target-swift-frontend -typecheck %t/Client_Swift5.swift -I %t \
-// RUN:   -swift-version 5 -verify -verify-additional-prefix werror- -Werror UnusedImportAccess
+// RUN:   -swift-version 5 -verify
 
 // REQUIRES: swift_feature_InternalImportsByDefault
 
@@ -141,8 +129,7 @@ public struct Extended {
 //--- Client_Swift5.swift
 /// No diagnostics should be raised on the implicit access level.
 import UnusedImport
-public import UnusedImport // expected-noerror-warning {{public import of 'UnusedImport' was not used in public declarations or inlinable code}} {{1-7=internal}}
-// expected-werror-error @-1 {{public import of 'UnusedImport' was not used in public declarations or inlinable code}} {{1-7=internal}}
+public import UnusedImport // expected-warning {{public import of 'UnusedImport' was not used in public declarations or inlinable code}} {{group-name=UnusedImportAccess}} {{1-7=internal}}
 
 //--- Client.swift
 public import DepUsedFromInlinableCode
@@ -156,26 +143,19 @@ public import ExtensionA
 public import ExtensionB
 public import PropertyWrapper
 public import ExtendedDefinitionPublic
-public import ExtendedDefinitionNonPublic // expected-noerror-warning {{public import of 'ExtendedDefinitionNonPublic' was not used in public declarations or inlinable code}} {{1-8=}}
-// expected-werror-error @-1 {{public import of 'ExtendedDefinitionNonPublic' was not used in public declarations or inlinable code}} {{1-8=}}
+public import ExtendedDefinitionNonPublic // expected-warning {{public import of 'ExtendedDefinitionNonPublic' was not used in public declarations or inlinable code}} {{group-name=UnusedImportAccess}} {{1-8=}}
 
 /// Repeat some imports to make sure we report all of them.
-public import UnusedImport // expected-noerror-warning {{public import of 'UnusedImport' was not used in public declarations or inlinable code}} {{1-8=}}
-// expected-werror-error @-1 {{public import of 'UnusedImport' was not used in public declarations or inlinable code}} {{1-8=}}
-// expected-note @-2 {{imported 'public' here}}
-public import UnusedImport // expected-noerror-warning {{public import of 'UnusedImport' was not used in public declarations or inlinable code}} {{1-8=}}
-// expected-werror-error @-1 {{public import of 'UnusedImport' was not used in public declarations or inlinable code}} {{1-8=}}
-package import UnusedImport // expected-noerror-warning {{package import of 'UnusedImport' was not used in package declarations}} {{1-9=}}
-// expected-werror-error @-1 {{package import of 'UnusedImport' was not used in package declarations}} {{1-9=}}
-// expected-warning @-2 {{module 'UnusedImport' is imported as 'public' from the same file; this 'package' access level will be ignored}}
+public import UnusedImport // expected-warning {{public import of 'UnusedImport' was not used in public declarations or inlinable code}} {{1-8=}}
+// expected-note @-1 {{imported 'public' here}}
+public import UnusedImport // expected-warning {{public import of 'UnusedImport' was not used in public declarations or inlinable code}} {{1-8=}}
+package import UnusedImport // expected-warning {{package import of 'UnusedImport' was not used in package declarations}} {{1-9=}}
+// expected-warning @-1 {{module 'UnusedImport' is imported as 'public' from the same file; this 'package' access level will be ignored}}
 
-package import UnusedPackageImport // expected-noerror-warning {{package import of 'UnusedPackageImport' was not used in package declarations}} {{1-9=}}
-// expected-werror-error @-1 {{package import of 'UnusedPackageImport' was not used in package declarations}} {{1-9=}}
+package import UnusedPackageImport // expected-warning {{package import of 'UnusedPackageImport' was not used in package declarations}} {{1-9=}}
 package import ExtendedPackageTypeImport
-public import ImportNotUseFromAPI // expected-noerror-warning {{public import of 'ImportNotUseFromAPI' was not used in public declarations or inlinable code}} {{1-8=}}
-// expected-werror-error @-1 {{public import of 'ImportNotUseFromAPI' was not used in public declarations or inlinable code}} {{1-8=}}
-public import ImportUsedInPackage // expected-noerror-warning {{public import of 'ImportUsedInPackage' was not used in public declarations or inlinable code}} {{1-7=package}}
-// expected-werror-error @-1 {{public import of 'ImportUsedInPackage' was not used in public declarations or inlinable code}} {{1-7=package}}
+public import ImportNotUseFromAPI // expected-warning {{public import of 'ImportNotUseFromAPI' was not used in public declarations or inlinable code}} {{1-8=}}
+public import ImportUsedInPackage // expected-warning {{public import of 'ImportUsedInPackage' was not used in public declarations or inlinable code}} {{1-7=package}}
 
 @_exported public import ExportedUnused
 @_spiOnly public import SPIOnlyUsedInSPI
@@ -349,11 +329,9 @@ typedef struct _TypedefTypeUnderlying {
 
 //--- ClientOfClangModules.swift
 public import ClangSimple
-public import ClangSimpleUnused // expected-noerror-warning {{public import of 'ClangSimpleUnused' was not used in public declarations or inlinable code}}
-// expected-werror-error @-1 {{public import of 'ClangSimpleUnused' was not used in public declarations or inlinable code}}
+public import ClangSimpleUnused // expected-warning {{public import of 'ClangSimpleUnused' was not used in public declarations or inlinable code}} {{group-name=UnusedImportAccess}}
 public import ClangSubmodule.ClangSubmoduleSubmodule
-public import ClangSubmoduleUnused.ClangSubmoduleUnsuedSubmodule // expected-noerror-warning {{public import of 'ClangSubmoduleUnused' was not used in public declarations or inlinable code}}
-// expected-werror-error @-1 {{public import of 'ClangSubmoduleUnused' was not used in public declarations or inlinable code}}
+public import ClangSubmoduleUnused.ClangSubmoduleUnsuedSubmodule // expected-warning {{public import of 'ClangSubmoduleUnused' was not used in public declarations or inlinable code}}
 
 // Only the top-level module is used, but we can't detect whether the submodule was used or not.
 public import ClangTopModule.ClangTopModuleSubmodule

--- a/test/decl/import/import.swift
+++ b/test/decl/import/import.swift
@@ -2,8 +2,7 @@
 // RUN: echo "import Swift; public struct X {}; public var x = X()" | %target-swift-frontend -module-name import_builtin -parse-stdlib -emit-module -o %t -
 // RUN: echo "public func foo() -> Int { return false }" > %t/import_text.swift
 // RUN: echo "public func phoûx() -> Int { return false }" > %t/français.swift
-// RUN: %target-swift-frontend -typecheck %s -I %t -I %S/../../Inputs/ -sdk "" -enable-source-import -module-name main -verify -show-diagnostics-after-fatal -verify-ignore-unknown -verify-additional-prefix noerror-
-// RUN: %target-swift-frontend -typecheck %s -I %t -I %S/../../Inputs/ -sdk "" -enable-source-import -module-name main -verify -show-diagnostics-after-fatal -verify-ignore-unknown -verify-additional-prefix werror- -Werror ModuleSelfImport
+// RUN: %target-swift-frontend -typecheck %s -I %t -I %S/../../Inputs/ -sdk "" -enable-source-import -module-name main -verify -show-diagnostics-after-fatal -verify-ignore-unknown
 
 // -verify-ignore-unknown is for:
 // <unknown>:0: error: unexpected note produced: did you forget to set an SDK using -sdk or SDKROOT?
@@ -72,8 +71,7 @@ var _ : Int = foo()
 import français
 import func français.phoûx
 
-import main // expected-noerror-warning {{file 'import.swift' is part of module 'main'; ignoring import}}
-// expected-werror-error @-1 {{file 'import.swift' is part of module 'main'; ignoring import}}
+import main // expected-warning {{file 'import.swift' is part of module 'main'; ignoring import}}{{group-name=ModuleSelfImport}}
 
 @_exported @_implementationOnly import empty // expected-error {{module 'empty' cannot be both exported and implementation-only}} {{12-33=}}
 // expected-warning @-1 {{safely use '@_implementationOnly' without library evolution by setting '-enable-experimental-feature CheckImplementationOnly' for 'main'}}

--- a/test/stmt/useless_conditional_statement.swift
+++ b/test/stmt/useless_conditional_statement.swift
@@ -1,9 +1,7 @@
-// RUN: %target-typecheck-verify-swift -verify-additional-prefix noerror-
-// RUN: %target-typecheck-verify-swift -verify-additional-prefix werror- -Werror UselessConditionalStatement
+// RUN: %target-typecheck-verify-swift
 
 func testUselessIfCondition(_ x: Int) {
-  // expected-noerror-warning@+2 {{'if' condition is always true}}{{none}}
-  // expected-werror-error@+1 {{'if' condition is always true}}{{none}}
+  // expected-warning@+1 {{'if' condition is always true}}{{group-name=UselessConditionalStatement}}{{none}}
   if case _ = x {
     _ = 0
   } else {
@@ -12,8 +10,7 @@ func testUselessIfCondition(_ x: Int) {
 }
 
 func testUselessWhile(_ x: Int) {
-  // expected-noerror-warning@+2 {{'while' condition is always true}}{{none}}
-  // expected-werror-error@+1 {{'while' condition is always true}}{{none}}
+  // expected-warning@+1 {{'while' condition is always true}}{{group-name=UselessConditionalStatement}}{{none}}
   while case _ = x {
     _ = 0
     break
@@ -22,8 +19,7 @@ func testUselessWhile(_ x: Int) {
 }
 
 func testUselessGuard(_ x: Int) {
-  // expected-noerror-warning@+2 {{'guard' condition is always true, body is unreachable}}{{none}}
-  // expected-werror-error@+1 {{'guard' condition is always true, body is unreachable}}{{none}}
+  // expected-warning@+1 {{'guard' condition is always true, body is unreachable}}{{none}}
   guard case _ = x else {
     _ = 0
     return

--- a/test/stmt/useless_conditional_statement.swift
+++ b/test/stmt/useless_conditional_statement.swift
@@ -1,0 +1,32 @@
+// RUN: %target-typecheck-verify-swift -verify-additional-prefix noerror-
+// RUN: %target-typecheck-verify-swift -verify-additional-prefix werror- -Werror UselessConditionalStatement
+
+func testUselessIfCondition(_ x: Int) {
+  // expected-noerror-warning@+2 {{'if' condition is always true}}{{none}}
+  // expected-werror-error@+1 {{'if' condition is always true}}{{none}}
+  if case _ = x {
+    _ = 0
+  } else {
+    _ = 1
+  }
+}
+
+func testUselessWhile(_ x: Int) {
+  // expected-noerror-warning@+2 {{'while' condition is always true}}{{none}}
+  // expected-werror-error@+1 {{'while' condition is always true}}{{none}}
+  while case _ = x {
+    _ = 0
+    break
+  }
+  _ = 1
+}
+
+func testUselessGuard(_ x: Int) {
+  // expected-noerror-warning@+2 {{'guard' condition is always true, body is unreachable}}{{none}}
+  // expected-werror-error@+1 {{'guard' condition is always true, body is unreachable}}{{none}}
+  guard case _ = x else {
+    _ = 0
+    return
+  }
+  _ = 1
+}

--- a/userdocs/diagnostics/diagnostic-groups.md
+++ b/userdocs/diagnostics/diagnostic-groups.md
@@ -63,6 +63,7 @@ Or upgrade all warnings except deprecated declaration to errors:
 - <doc:no-usage>
 - <doc:use-any-apple-os-availability>
 - <doc:useless-availability-check>
+- <doc:useless-conditional-statement>
 
 
 ## Topics
@@ -127,4 +128,5 @@ Or upgrade all warnings except deprecated declaration to errors:
 - <doc:no-usage>
 - <doc:use-any-apple-os-availability>
 - <doc:useless-availability-check>
+- <doc:useless-conditional-statement>
 - <doc:existential-member-access-limitations>

--- a/userdocs/diagnostics/useless-conditional-statement.md
+++ b/userdocs/diagnostics/useless-conditional-statement.md
@@ -1,0 +1,36 @@
+# Useless conditional statement (UselessConditionalStatement)
+
+Warnings that identify conditional statements (`if`, `while`, and `guard`) whose conditions can never be false.
+
+## Overview
+
+When the condition of an `if`, `while`, or `guard` statement is statically known to always be true, the conditional structure is unnecessary. For `if` and `while`, the body always executes (and a `while` loop with no `break` would never terminate); for `guard`, the `else` branch is unreachable.
+
+## Examples
+
+```
+let x = 0
+if case _ = x { // warning: 'if' condition is always true
+  // ...
+}
+
+while case _ = x { // warning: 'while' condition is always true
+  break
+}
+
+guard case _ = x else { // warning: 'guard' condition is always true, body is unreachable
+  fatalError()
+}
+```
+
+In the examples above, the pattern matching conditions (`case _ = ...`) can never fail.
+
+## See Also
+
+- [If Statement][if-statement]
+- [Guard Statement][guard-statement]
+- [While Statement][while-statement]
+
+[if-statement]: https://docs.swift.org/swift-book/documentation/the-swift-programming-language/statements/#If-Statement
+[guard-statement]: https://docs.swift.org/swift-book/documentation/the-swift-programming-language/statements/#Guard-Statement
+[while-statement]: https://docs.swift.org/swift-book/documentation/the-swift-programming-language/statements/#While-Statement


### PR DESCRIPTION
- **Explanation**: Adds a `UselessConditionalStatement` diagnostic group so the existing warnings emitted for trivially constant `if`/`guard`/`while` conditions can be controlled (suppressed or escalated to errors) via `-Wwarning`/`-Werror` flags. Also adds testing support for diagnostic groups.
- **Scope**: Limited to attaching a diagnostic group to a small set of existing warnings and changes to the diagnostic verifier which is only used in the compiler test suite.
- **Issues**: rdar://178154296
- **Risk**: Low. The change only categorizes existing warnings; no diagnostic behavior changes for users who do not opt into controlling the behavior of the new group. The diagnostic verifier changes should not be observable by any developer code.
- **Testing**: New test `test/stmt/useless_conditional_statement.swift` verifies the group can be used to both suppress and escalate the warnings.
- **Original PR**: https://github.com/swiftlang/swift/pull/89513
- **Reviewer**: @ktoso @artemcm 