### PR TITLE
🍒[Dependency Scanning] Adding an Option to Turn Off Clang Scanner Comp…

### DIFF
--- a/include/swift/DependencyScan/ModuleDependencyScanner.h
+++ b/include/swift/DependencyScan/ModuleDependencyScanner.h
@@ -119,7 +119,7 @@ public:
       std::shared_ptr<llvm::cas::ObjectStore> CAS,
       std::shared_ptr<llvm::cas::ActionCache> ActionCache,
       DependencyScannerDiagnosticReporter &DiagnosticReporter,
-      llvm::PrefixMapper *mapper);
+      llvm::PrefixMapper *mapper, bool ShareClangCompilerInstance);
 
 private:
   /// Initialize/finalize the clang compiler scanning tool.
@@ -224,6 +224,11 @@ private:
   std::vector<std::string> swiftModuleClangCC1CommandLineArgs;
   // Working directory for clang module lookup queries
   std::string clangScanningWorkingDirectoryPath;
+
+  // Flag to use a single clang compiler instance to do all
+  // dependency queries during the life time of this worker.
+  bool ShareClangCompilerInstance = true;
+
   // Restrict access to the parent scanner class.
   friend class ModuleDependencyScanner;
 };
@@ -316,6 +321,7 @@ private:
                           ASTContext &ScanASTContext,
                           DependencyTracker &DependencyTracker,
                           DiagnosticEngine &Diagnostics, bool ParallelScan,
+                          bool ShareClangCompilerInstance,
                           bool EmitScanRemarks);
   llvm::Error initializeWorkerClangScanningTool();
   llvm::Error finalizeWorkerClangScanningTool();
@@ -470,6 +476,10 @@ private:
   std::mutex WorkersLock;
   /// Count of filesystem queries performed
   std::atomic<unsigned> NumLookups = 0;
+  /// Flag to use a single clang compiler instance to do all
+  /// dependency queries during the life time of each worker this
+  /// scanner owns.
+  bool ShareClangCompilerInstance = true;
 };
 
 /// Check if a module path is under one of the known SDK private framework

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -417,6 +417,10 @@ public:
   /// to filesystem modules in parallel.
   bool ParallelDependencyScan = true;
 
+  /// Whether the dependency scanning worker should share a single Clang
+  /// compiler instance across named module dependency queries.
+  bool ShareClangCompilerInstance = true;
+
   /// When performing an incremental build, ensure that cross-module incremental
   /// build metadata is available in any swift modules emitted by this frontend
   /// job.

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -315,6 +315,11 @@ def parallel_scan : Flag<["-"], "parallel-scan">,
 def no_parallel_scan : Flag<["-"], "no-parallel-scan">,
    HelpText<"Perform dependency scanning in a single-threaded fashion.">;
 
+def no_clang_compiler_instance_sharing
+    : Flag<["-"], "no-clang-scanner-instance-sharing">,
+      HelpText<"Disable sharing of the Clang compiler instance across "
+               "dependency scans.">;
+
 def enable_copy_propagation : Flag<["-"], "enable-copy-propagation">,
   HelpText<"Always run SIL copy propagation with lexical lifetimes to shorten object "
            "lifetimes while preserving variable lifetimes.">;

--- a/lib/DependencyScan/ModuleDependencyScanner.cpp
+++ b/lib/DependencyScan/ModuleDependencyScanner.cpp
@@ -210,14 +210,15 @@ ModuleDependencyScanningWorker::ModuleDependencyScanningWorker(
     std::shared_ptr<llvm::cas::ObjectStore> CAS,
     std::shared_ptr<llvm::cas::ActionCache> ActionCache,
     DependencyScannerDiagnosticReporter &DiagnosticReporter,
-    llvm::PrefixMapper *Mapper)
+    llvm::PrefixMapper *Mapper, bool ShareClangCompilerInstance)
     : workerCompilerInvocation(
           std::make_unique<CompilerInvocation>(ScanCompilerInvocation)),
       clangScanningTool(
           *globalScanningService.ClangScanningService,
           getClangScanningFS(globalScanningService, CAS, ScanASTContext)),
       CAS(CAS), ActionCache(ActionCache),
-      diagnosticReporter(DiagnosticReporter) {
+      diagnosticReporter(DiagnosticReporter),
+      ShareClangCompilerInstance(ShareClangCompilerInstance) {
   assert(globalScanningService.ClangScanningService->getCAS() == CAS &&
          "Need to be the same CAS instance");
   assert(globalScanningService.ClangScanningService->getActionCache() ==
@@ -326,8 +327,13 @@ ModuleDependencyScanningWorker::scanFilesystemForClangModuleDependency(
         &alreadySeenModules) {
   diagnosticReporter.registerNamedClangModuleQuery();
   auto clangModuleDependencies =
-      clangScanningTool.computeDependenciesByNameWithContext(
-          moduleName.str(), alreadySeenModules, lookupModuleOutput);
+      ShareClangCompilerInstance
+          ? clangScanningTool.computeDependenciesByNameWithContext(
+                moduleName.str(), alreadySeenModules, lookupModuleOutput)
+          : clangScanningTool.getModuleDependencies(
+                moduleName.str(), clangScanningModuleCommandLineArgs,
+                clangScanningWorkingDirectoryPath, alreadySeenModules,
+                lookupModuleOutput);
   if (!clangModuleDependencies) {
     llvm::handleAllErrors(
         clangModuleDependencies.takeError(),
@@ -544,17 +550,22 @@ ModuleDependencyScanner::create(SwiftDependencyScanningService &service,
           instance->getInvocation().getFrontendOptions().ParallelDependencyScan,
           instance->getInvocation()
               .getFrontendOptions()
+              .ShareClangCompilerInstance,
+          instance->getInvocation()
+              .getFrontendOptions()
               .EmitDependencyScannerRemarks));
 
-  auto initError = scanner->initializeWorkerClangScanningTool();
+  if (scanner->ShareClangCompilerInstance) {
+    auto initError = scanner->initializeWorkerClangScanningTool();
 
-  if (initError) {
-    llvm::handleAllErrors(
-        std::move(initError), [&](const llvm::StringError &E) {
-          instance->getDiags().diagnose(
-              SourceLoc(), diag::clang_dependency_scan_error, E.getMessage());
-        });
-    return std::make_error_code(std::errc::invalid_argument);
+    if (initError) {
+      llvm::handleAllErrors(
+          std::move(initError), [&](const llvm::StringError &E) {
+            instance->getDiags().diagnose(
+                SourceLoc(), diag::clang_dependency_scan_error, E.getMessage());
+          });
+      return std::make_error_code(std::errc::invalid_argument);
+    }
   }
 
   return scanner;
@@ -566,7 +577,7 @@ ModuleDependencyScanner::ModuleDependencyScanner(
     const CompilerInvocation &ScanCompilerInvocation,
     const SILOptions &SILOptions, ASTContext &ScanASTContext,
     swift::DependencyTracker &DependencyTracker, DiagnosticEngine &Diagnostics,
-    bool ParallelScan, bool EmitScanRemarks)
+    bool ParallelScan, bool ShareClangCompilerInstance, bool EmitScanRemarks)
     : ScanCompilerInvocation(ScanCompilerInvocation),
       ScanASTContext(ScanASTContext),
       ScanDiagnosticReporter(Diagnostics, EmitScanRemarks),
@@ -580,7 +591,8 @@ ModuleDependencyScanner::ModuleDependencyScanner(
                      : 1),
       ScanningThreadPool(llvm::hardware_concurrency(NumThreads)),
       CAS(ScanningService.ClangScanningService->getCAS()),
-      ActionCache(ScanningService.ClangScanningService->getActionCache()) {
+      ActionCache(ScanningService.ClangScanningService->getActionCache()),
+      ShareClangCompilerInstance(ShareClangCompilerInstance) {
   // Setup prefix mapping.
   auto &ScannerPrefixMapper =
       ScanCompilerInvocation.getSearchPathOptions().ScannerPrefixMapper;
@@ -605,12 +617,14 @@ ModuleDependencyScanner::ModuleDependencyScanner(
     Workers.emplace_front(std::make_unique<ModuleDependencyScanningWorker>(
         ScanningService, ScanCompilerInvocation, SILOptions, ScanASTContext,
         DependencyTracker, CAS, ActionCache, ScanDiagnosticReporter,
-        PrefixMapper.get()));
+        PrefixMapper.get(), ShareClangCompilerInstance));
 }
 
 ModuleDependencyScanner::~ModuleDependencyScanner() {
-  auto finError = finalizeWorkerClangScanningTool();
-  assert(!finError && "ClangScanningTool finalization must succeed.");
+  if (ShareClangCompilerInstance) {
+    auto finError = finalizeWorkerClangScanningTool();
+    assert(!finError && "ClangScanningTool finalization must succeed.");
+  }
 }
 
 llvm::Error ModuleDependencyScanner::initializeWorkerClangScanningTool() {

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -165,6 +165,8 @@ bool ArgsToFrontendOptionsConverter::convert(
   Opts.ParallelDependencyScan = Args.hasFlag(OPT_parallel_scan,
                                              OPT_no_parallel_scan,
                                              true);
+  Opts.ShareClangCompilerInstance =
+      !Args.hasArg(OPT_no_clang_compiler_instance_sharing);
   Opts.GenReproducer |= Args.hasArg(OPT_gen_reproducer);
   Opts.GenReproducerDir = Args.getLastArgValue(OPT_gen_reproducer_dir);
 

--- a/test/ScanDependencies/no_clang_compiler_instance_sharing.swift
+++ b/test/ScanDependencies/no_clang_compiler_instance_sharing.swift
@@ -1,0 +1,58 @@
+// Test that the dependency scanning results are identical with or without
+// compiler instance sharing.
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/module-cache)
+// RUN: %empty-directory(%t/inputs)
+// RUN: split-file %s %t
+
+// Run with default (shared instance)
+// RUN: %target-swift-frontend -scan-dependencies -module-name Test -module-cache-path %t/module-cache -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib %t/test.swift -o %t/deps_shared.json -I %t/inputs
+
+// Run with sharing disabled
+// RUN: %target-swift-frontend -scan-dependencies -module-name Test -module-cache-path %t/module-cache -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib %t/test.swift -o %t/deps_no_sharing.json -I %t/inputs -no-clang-scanner-instance-sharing
+
+// Verify identical results
+// RUN: diff %t/deps_shared.json %t/deps_no_sharing.json
+
+// Also verify the output is actually valid (not empty/broken)
+// RUN: %validate-json %t/deps_no_sharing.json | %FileCheck %s
+
+// CHECK: "mainModuleName": "Test"
+// CHECK-DAG: "clang": "C"
+// CHECK-DAG: "clang": "D"
+// CHECK-DAG: "swift": "A"
+// CHECK-DAG: "swift": "B"
+
+//--- test.swift
+import A
+import B
+public func test() {}
+
+//--- inputs/A.swiftinterface
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name A -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib -user-module-version 1.0
+import C
+public func a() {}
+
+//--- inputs/B.swiftinterface
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name B -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib -user-module-version 1.0
+import D
+public func b() {}
+
+//--- inputs/C.h
+void c(void);
+
+//--- inputs/D.h
+void d(void);
+
+//--- inputs/module.modulemap
+module C {
+  header "C.h"
+  export *
+}
+module D {
+  header "D.h"
+  export *
+}
+


### PR DESCRIPTION
…iler Instance Sharing (#89307)

https://github.com/swiftlang/swift/commit/954c8a28d002670d3df6a8c52ea451f98301411b introduced an optimization to speedup scanning. This PR adds an option `no-clang-scanner-instance-sharing` to turn off the optimization, in case the user runs into issues caused by it.

(cherry picked from commit 9279daab5e7ef0042573910933b45bd0698dfe4f)

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
