### PR TITLE
AST: Adjust to "[ADT] Allow member pointers in map_range and map_to_vector (#181154)"

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -6311,9 +6311,8 @@ public:
                                 fieldIndexMutabilityUpdatePairs) const;
 
   using SILFieldIndexToSILTypeTransform = std::function<SILType(unsigned)>;
-  using SILFieldToSILTypeRange =
-      iterator_range<llvm::mapped_iterator<IntRange<unsigned>::iterator,
-                                           SILFieldIndexToSILTypeTransform>>;
+  using SILFieldToSILTypeRange = iterator_range<llvm::mapped_iterator<
+      IntRange<unsigned>::iterator, SILFieldIndexToSILTypeTransform, SILType>>;
 
   /// Returns a range of SILTypes that have been specialized correctly for use
   /// in the passed in SILFunction.


### PR DESCRIPTION
See https://github.com/llvm/llvm-project/pull/181154.

`std::invoke_result` requires its template arguments to be complete types, but `SILType` is not and cannot be complete here. Specify the template argument explicitly to avoid evaluating the `std::invoke_result`-based default.