### PR TITLE
[utils/update-verify-tests] Round trip whitespace

### DIFF
--- a/test/Utils/update-verify-tests/digit-in-prefix.swift
+++ b/test/Utils/update-verify-tests/digit-in-prefix.swift
@@ -1,0 +1,13 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: not %target-swift-frontend-verify -verify-additional-prefix swift-5- -typecheck %t/test.swift 2>&1 | %update-verify-tests --prefix swift-5-
+// RUN: %target-swift-frontend-verify -verify-additional-prefix swift-5- -typecheck %t/test.swift
+// RUN: %diff %t/test.swift %t/test.swift.expected
+
+//--- test.swift
+unboundDigit = 1 // expected-swift-5-error{{wrong text}}
+
+//--- test.swift.expected
+unboundDigit = 1 // expected-swift-5-error{{cannot find 'unboundDigit' in scope}}
+

--- a/test/Utils/update-verify-tests/preserve-whitespace.swift
+++ b/test/Utils/update-verify-tests/preserve-whitespace.swift
@@ -1,0 +1,142 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: not %target-swift-frontend-verify -typecheck %t/test.swift 2>&1 | %update-verify-tests
+// RUN: %target-swift-frontend-verify -typecheck %t/test.swift
+// RUN: %diff %t/test.swift %t/test.swift.expected
+
+//--- test.swift
+func wsAtBumpToTwo() {
+  //  expected-error  @+1  {{cannot find 'unboundAlpha' in scope}}
+  unboundAlpha = 1; unboundAlpha = 1
+}
+
+func wsCountBumpToThree() {
+  // expected-error@+1   {{cannot find 'unboundBeta' in scope}}
+  unboundBeta = 1; unboundBeta = 1; unboundBeta = 1
+}
+
+func allFourSlotsDropToOne() {
+  //   expected-error  @+1   2  {{cannot find 'unboundGamma' in scope}}
+  unboundGamma = 1
+}
+
+func synthesizedSmushPrevention() {
+  unboundDelta = 1; unboundDelta = 1
+}
+
+func explicitOneBumpToTwo() {
+  // expected-error@+1 1{{cannot find 'unboundEpsilon' in scope}}
+  unboundEpsilon = 1; unboundEpsilon = 1
+}
+
+func explicitOnePreservedOnMessageChange() {
+  // expected-error@+1 1{{wrong message text}}
+  unboundZeta = 1
+}
+
+func explicitOneRoundTripWhenOtherUpdates() {
+  func dupOmicron() {} // expected-note 1{{'dupOmicron()' previously declared here}}
+  func dupOmicron() {} // expected-error{{wrong text}}
+}
+
+func bracesWsPreservedOnBump() {
+  // expected-error@+1 1 {{cannot find 'unboundEta' in scope}}
+  unboundEta = 1; unboundEta = 1
+}
+
+func multiBlockTailPreserved() {
+  unboundTheta = 1 // expected-error{{cannot find 'unboundTheta' in scope}}{{none}}
+  unboundIota = 1 // expected-error{{wrong text}}
+}
+
+func multiBlockTailSpaced() {
+  unboundMu = 1 // expected-error{{cannot find 'unboundMu' in scope}}  {{none}}
+  unboundNu = 1 // expected-error{{wrong text}}
+}
+
+@available(*, deprecated, message: "see \\junk")
+func deprecatedKappa() {}
+
+func escapesInMessagePreserved() {
+  deprecatedKappa() // expected-warning{{'deprecatedKappa()' is deprecated: see \\junk}}
+  unboundLambda = 1 // expected-error{{wrong text}}
+}
+
+func messageChangeWithBackwardTarget() {
+  unboundOmega = 1
+  // expected-error @-1 {{wrong text}}
+}
+
+func colOnlyTarget() {
+  unboundPi = 1 // expected-error@:3{{wrong text}}
+}
+
+//--- test.swift.expected
+func wsAtBumpToTwo() {
+  //  expected-error  @+1  2{{cannot find 'unboundAlpha' in scope}}
+  unboundAlpha = 1; unboundAlpha = 1
+}
+
+func wsCountBumpToThree() {
+  // expected-error@+1   3{{cannot find 'unboundBeta' in scope}}
+  unboundBeta = 1; unboundBeta = 1; unboundBeta = 1
+}
+
+func allFourSlotsDropToOne() {
+  //   expected-error  @+1     {{cannot find 'unboundGamma' in scope}}
+  unboundGamma = 1
+}
+
+func synthesizedSmushPrevention() {
+  // expected-error@+1 2{{cannot find 'unboundDelta' in scope}}
+  unboundDelta = 1; unboundDelta = 1
+}
+
+func explicitOneBumpToTwo() {
+  // expected-error@+1 2{{cannot find 'unboundEpsilon' in scope}}
+  unboundEpsilon = 1; unboundEpsilon = 1
+}
+
+func explicitOnePreservedOnMessageChange() {
+  // expected-error@+1 1{{cannot find 'unboundZeta' in scope}}
+  unboundZeta = 1
+}
+
+func explicitOneRoundTripWhenOtherUpdates() {
+  func dupOmicron() {} // expected-note 1{{'dupOmicron()' previously declared here}}
+  func dupOmicron() {} // expected-error{{invalid redeclaration of 'dupOmicron()'}}
+}
+
+func bracesWsPreservedOnBump() {
+  // expected-error@+1 2 {{cannot find 'unboundEta' in scope}}
+  unboundEta = 1; unboundEta = 1
+}
+
+func multiBlockTailPreserved() {
+  unboundTheta = 1 // expected-error{{cannot find 'unboundTheta' in scope}}{{none}}
+  unboundIota = 1 // expected-error{{cannot find 'unboundIota' in scope}}
+}
+
+func multiBlockTailSpaced() {
+  unboundMu = 1 // expected-error{{cannot find 'unboundMu' in scope}}  {{none}}
+  unboundNu = 1 // expected-error{{cannot find 'unboundNu' in scope}}
+}
+
+@available(*, deprecated, message: "see \\junk")
+func deprecatedKappa() {}
+
+func escapesInMessagePreserved() {
+  deprecatedKappa() // expected-warning{{'deprecatedKappa()' is deprecated: see \\junk}}
+  unboundLambda = 1 // expected-error{{cannot find 'unboundLambda' in scope}}
+}
+
+func messageChangeWithBackwardTarget() {
+  unboundOmega = 1
+  // expected-error @-1 {{cannot find 'unboundOmega' in scope}}
+}
+
+func colOnlyTarget() {
+  unboundPi = 1 // expected-error@:3{{cannot find 'unboundPi' in scope}}
+}
+

--- a/utils/update_verify_tests/core.py
+++ b/utils/update_verify_tests/core.py
@@ -1,8 +1,17 @@
 import sys
 import re
 from codecs import encode, decode
+from collections import namedtuple
 
 DEBUG = False
+
+
+# Whitespace slots inside a single `// expected-X{{...}}` directive. Stored
+# verbatim from parse so render reproduces the source byte-for-byte:
+#
+#   //{slash}expected-{category}{re}{at}{@+N}{:M}{count}{N}{braces}{{...}}
+Whitespace = namedtuple("Whitespace", ["slash", "at", "count", "braces"])
+DEFAULT_WHITESPACE = Whitespace(slash=" ", at="", count="", braces="")
 
 
 def dprint(*args):
@@ -70,9 +79,18 @@ class Diag:
         whitespace_strings,
         is_from_source_file,
         nested_lines,
+        diag_content_raw=None,
+        original_count_str=None,
     ):
         self.prefix = prefix
         self.diag_content = diag_content
+        # Raw text from {{...}} preserved for round-trip rendering. None for
+        # synthesized diags (which fall through to escape-on-render).
+        self.diag_content_raw = diag_content_raw
+        # The count digit as written in source ("", "1", "2", ...) or None if
+        # absent. Frozen at parse time and never mutated. render() preserves it
+        # iff the current count value still equals what was written.
+        self.original_count_str = original_count_str
         self.category = category
         self.parsed_target_line_n = parsed_target_line_n
         self.line_is_absolute = line_is_absolute
@@ -133,9 +151,11 @@ class Diag:
         assert not other_diag.is_re and not self.is_re
         self.line_is_absolute = False
         self.diag_content = other_diag.diag_content
+        self.diag_content_raw = other_diag.diag_content_raw
+        # original_count_str is deliberately not copied: render keys off it
+        # vs the new count to decide whether to keep self's original digit.
         self.count = other_diag.count
         self.category = other_diag.category
-        self.count = other_diag.count
         other_diag.count = 0
 
     def render(self):
@@ -152,30 +172,45 @@ class Diag:
                 line_location_s = (
                     f"@{self.relative_target()}"  # the minus sign is implicit
                 )
-        count_s = "" if self.count == 1 else f"{self.count}"
-        re_s = "-re" if self.is_re else ""
-        if self.whitespace_strings:
-            whitespace1_s = self.whitespace_strings[0]
-            whitespace2_s = self.whitespace_strings[1]
+        # If the source had an explicit digit and the count value still equals
+        # what was written, preserve the original (e.g. "1" stays "1").
+        original_count = (
+            int(self.original_count_str) if self.original_count_str else 1
+        )
+        if self.count == original_count and self.original_count_str is not None:
+            count_s = self.original_count_str
+        elif self.count != 1:
+            count_s = str(self.count)
         else:
-            whitespace1_s = " "
-            whitespace2_s = ""
-        if count_s and not whitespace2_s:
-            whitespace2_s = " "  # required to parse correctly
-        elif not count_s and whitespace2_s == " ":
-            """Don't emit a weird extra space.
-            However if the whitespace is something other than the
-            standard single space, let it be to avoid disrupting manual formatting.
-            """
-            whitespace2_s = ""
+            count_s = ""
+        re_s = "-re" if self.is_re else ""
+        ws = self.whitespace_strings or DEFAULT_WHITESPACE
         col_s = f":{self.col()}" if self.col() else ""
-        base_s = f"//{whitespace1_s}expected-{self.prefix}{self.category}{re_s}{line_location_s}{col_s}{whitespace2_s}{count_s}"
+        # Col-only forms (`@:N`) need the leading "@" even with no line offset,
+        # otherwise the verifier would see `:N` as part of the message slot.
+        if col_s and not line_location_s:
+            line_location_s = "@"
+        # Smush prevention: if a count is being newly added (no original digit)
+        # and there's no ws between location and count, force a separator so
+        # the C++ verifier doesn't read "@+1" + "2" as "@+12".
+        ws_count = ws.count
+        if count_s and not ws_count and self.original_count_str is None:
+            ws_count = " "
+        base_s = (
+            f"//{ws.slash}expected-{self.prefix}{self.category}{re_s}"
+            f"{ws.at}{line_location_s}{col_s}{ws_count}{count_s}{ws.braces}"
+        )
         if self.category == "expansion":
             return base_s + "{{"
         else:
-            # python trivia: raw strings can't end with a backslash
-            escaped_diag_s = self.diag_content.replace("\\", "\\\\")
-            return base_s + "{{" + escaped_diag_s + "}}"
+            if self.diag_content_raw is not None:
+                content_s = self.diag_content_raw
+            else:
+                # Synthesized from a verifier message; escape backslashes so
+                # the C++ lexer reads them back literally.
+                # python trivia: raw strings can't end with a backslash
+                content_s = self.diag_content.replace("\\", "\\\\")
+            return base_s + "{{" + content_s + "}}"
 
 
 class ExpansionDiagClose:
@@ -190,10 +225,10 @@ class ExpansionDiagClose:
 
 
 expected_diag_re = re.compile(
-    r"//(\s*)expected-([a-zA-Z-]*)(note|warning|error|remark)(-re)?(@[+-]?\d+)?(:\d+)?(\s*)(\d+)?\{\{(.*)\}\}"
+    r"//(\s*)expected-([a-zA-Z0-9-]*)(note|warning|error|remark)(-re)?(\s*?)(@[+-]?\d+|@(?=:))?(:\d+)?(\s*)(\d+)?(\s*)\{\{(.*?)\}\}"
 )
 expected_expansion_diag_re = re.compile(
-    r"//(\s*)expected-([a-zA-Z-]*)(expansion)(-re)?(@[+-]?\d+)(:\d+)(\s*)(\d+)?\{\{(.*)"
+    r"//(\s*)expected-([a-zA-Z0-9-]*)(expansion)(-re)?(\s*?)(@[+-]?\d+|@(?=:))(:\d+)(\s*)(\d+)?(\s*)\{\{(.*?)"
 )
 expected_expansion_close_re = re.compile(r"//(\s*)\}\}")
 
@@ -220,19 +255,21 @@ def parse_diag(line, filename, prefix, all_prefixes=False):
             f"multiple diags on line {filename}:{line.line_n}. Aborting due to missing implementation."
         )
     [
-        whitespace1_s,
+        ws_slash,
         check_prefix,
         category_s,
         re_s,
+        ws_at,
         target_line_s,
         target_col_s,
-        whitespace2_s,
+        ws_count,
         count_s,
+        ws_braces,
         diag_s,
     ] = ms[0]
     if check_prefix != prefix and check_prefix != "" and not all_prefixes:
         return None
-    if not target_line_s:
+    if not target_line_s or target_line_s == "@":
         target_line_n = 0
         is_absolute = False
     elif target_line_s.startswith("@+"):
@@ -261,9 +298,11 @@ def parse_diag(line, filename, prefix, all_prefixes=False):
         count,
         line,
         bool(re_s),
-        [whitespace1_s, whitespace2_s],
+        Whitespace(slash=ws_slash, at=ws_at, count=ws_count, braces=ws_braces),
         True,
         [],
+        diag_content_raw=diag_s,
+        original_count_str=count_s if count_s else None,
     )
 
 
@@ -365,15 +404,13 @@ def add_diag(
 
     whitespace_strings = None
     if prev_line.diag:
-        whitespace_strings = (
-            prev_line.diag.whitespace_strings.copy()
-            if prev_line.diag.whitespace_strings
-            else None
-        )
+        whitespace_strings = prev_line.diag.whitespace_strings
         if prev_line.diag == nested_context:
             if not whitespace_strings:
-                whitespace_strings = [" ", "", ""]
-            whitespace_strings[0] += "  "
+                whitespace_strings = DEFAULT_WHITESPACE
+            whitespace_strings = whitespace_strings._replace(
+                slash=whitespace_strings.slash + "  "
+            )
 
     new_diag = Diag(
         prefix,
@@ -397,6 +434,9 @@ def add_diag(
 
 def remove_dead_diags(lines, prefix):
     for line in lines.copy():
+        if line not in lines:
+            # Already removed by an earlier take(); skip.
+            continue
         if not line.diag:
             continue
         if line.diag.category == "expansion":
@@ -408,10 +448,11 @@ def remove_dead_diags(lines, prefix):
                     line.diag.count = 0
         if line.diag.count != 0:
             continue
-        if line.render() == "":
-            remove_line(line, lines)
-        else:
-            assert line.diag.is_from_source_file
+        # Try absorbing a same-category sibling first so the dead diag's
+        # formatting (whitespace, original_count_str) survives a content
+        # rewrite. Nested expansion diags have no target, so skip.
+        took = False
+        if line.diag.target is not None:
             for other_diag in line.diag.target.targeting_diags:
                 if (
                     other_diag.is_from_source_file
@@ -421,9 +462,15 @@ def remove_dead_diags(lines, prefix):
                     continue
                 if other_diag.is_re or line.diag.is_re:
                     continue
+                assert line.diag.is_from_source_file
                 line.diag.take(other_diag)
                 remove_line(other_diag.line, lines)
+                took = True
                 break
+        if took:
+            continue
+        if line.render() == "":
+            remove_line(line, lines)
 
 
 def fold_expansions(lines):
@@ -532,7 +579,7 @@ def update_lines(
         if isinstance(diag_error, NestedDiag):
             if not diag.closer:
                 whitespace = (
-                    diag.whitespace_strings[0]
+                    diag.whitespace_strings.slash
                     if diag.whitespace_strings
                     else " "
                 )


### PR DESCRIPTION
Fixes some bugs that were preventing round tripping assertions, so --update-tests can be used to mechanically get rid of prefix matches (has other uses though, just makes the diff less noisy when updating tests that didn't use the normal formatting).

- whitespace before `{{` no longer stripped
- whitespace between category and `@` now parsed (was bailing)
- whitespace between count and `{{` now captured
- multi-block lines (`{{message}}{{fix-it}}`) no longer mis-captured by greedy regex
- escapes in message content (`\n`, `\}`) round-trip via raw preservation
- explicit count of 1 preserved when message changes
- smush prevention: synthesizing a count after `@+1` inserts a separator
- pre-existing typo: `take()` had `self.count = other_diag.count` twice; removed dupe
- supports digits in expectation prefix

Assisted-by: Claude Opus 4.7

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
