### PR TITLE
[Option] Fix Options.swift regeneration in swift-driver

### DIFF
--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -1582,6 +1582,9 @@ def Xcc : Separate<["-"], "Xcc">,
 def Xclang_linker : Separate<["-"], "Xclang-linker">, Flags<[HelpHidden]>,
   MetaVarName<"<arg>">, HelpText<"Pass <arg> to Clang when it is used for linking.">;
 
+def Xlinker_driver : Separate<["-"], "Xlinker-driver">, Flags<[HelpHidden]>,
+  MetaVarName<"<arg>">, HelpText<"Pass <arg> to the linker driver (clang, emcc, etc.) regardless of which one is in use.">;
+
 def Xllvm : Separate<["-"], "Xllvm">,
   Flags<[FrontendOption, HelpHidden]>,
   MetaVarName<"<arg>">, HelpText<"Pass <arg> to LLVM.">;
@@ -1964,8 +1967,8 @@ def synthesize_interface_show :
   Joined<["-"], "synthesize-interface-show=">,
   Flags<[NoDriverOption, SwiftSynthesizeInterfaceOption]>,
   MetaVarName<"<options>">,
-  HelpText<"Comma-separated options controlling what gets printed.\n"
-           "Options: 'unavailable', 'implicit-attrs', 'qualified-types'.\n"
+  HelpText<"Comma-separated options controlling what gets printed. "
+           "Options: 'unavailable', 'implicit-attrs', 'qualified-types'. "
            "Shorthands: 'all' (every option enabled), 'minimal' (default).">;
 
 // swift-symbolgraph-extract-only options


### PR DESCRIPTION
Two issues in Options.td prevented swift-driver's Options.swift from being regenerated cleanly via the makeOptions tool:

-Xlinker-driver was missing entirely, even though swift-driver's Options.swift had a hand-added option Xlinker-Driver entry that couldn't be reproduced by makeOptions.

The HelpText for -synthesize-interface-show= contained embedded "\n" sequences which was leading to the regenerated file having an unterminated string literal.

Add a TableGen def for Xlinker-driver and remove "\n" from synthesize-interface-show help text.

rdar://178177595

