### PR TITLE
[region-isolation] Downgrade isolated-conformance/region-merge cast diagnostics to warn-until-future

### DIFF
--- a/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
@@ -2761,11 +2761,11 @@ public:
   InFlightDiagnostic diagnoseError(SourceLoc loc, Diag<T...> diag,
                                    U &&...args) {
     emittedErrorDiagnostic = true;
-    auto diag_ = getASTContext().Diags.diagnose(loc, diag,
-                                                std::forward<U>(args)...);
+    auto localDiag =
+        getASTContext().Diags.diagnose(loc, diag, std::forward<U>(args)...);
     if (downgradeToWarning)
-      return std::move(diag_.warnUntilLanguageMode(LanguageMode::future));
-    return std::move(diag_.warnUntilLanguageMode(LanguageMode::v6));
+      return std::move(localDiag.warnUntilLanguageMode(LanguageMode::future));
+    return std::move(localDiag.warnUntilLanguageMode(LanguageMode::v6));
   }
 
   template <typename... T, typename... U>
@@ -4022,6 +4022,20 @@ private:
   void emitUnknownPatternError() {
     EMIT_UNKNOWN_PATTERN_ERROR(IncompatibleRegionMergeErrorEmitter,
                                op->getUser(), getBehaviorLimit());
+  }
+
+  // Emit incompatible-region-merge diagnostics as warnings until the future
+  // language mode. This shadows the file-scope siloptimizer::diagnoseError
+  // (which wraps in warnUntilLanguageMode(v6)) so we do not double-wrap.
+  template <typename... T, typename... U>
+  InFlightDiagnostic diagnoseError(SILInstruction *inst, Diag<T...> diag,
+                                   U &&...args) {
+    auto &ctx = inst->getFunction()->getASTContext();
+    return std::move(
+        ctx.Diags
+            .diagnose(inst->getLoc().getSourceLoc(), diag,
+                      std::forward<U>(args)...)
+            .warnUntilLanguageMode(LanguageMode::future));
   }
 
   void emitUnknown();

--- a/test/Concurrency/transfernonsendable_isolated_conformances.swift
+++ b/test/Concurrency/transfernonsendable_isolated_conformances.swift
@@ -93,7 +93,7 @@ actor CastTest<T, U : NonSendableProtocol, V : AnyObject, V2 : NonSendableKlassP
   func f() async -> NonSendableProtocol {
     guard let c = await cnx else { fatalError() } // expected-swift5-warning {{non-Sendable type 'NonSendableKlass?' of property 'cnx' cannot exit main actor-isolated context}}
     // expected-swift6-error @-1 {{non-Sendable type 'NonSendableKlass?' of property 'cnx' cannot exit main actor-isolated context}}
-    guard let q = c as? NonSendableProtocol else { fatalError() } // expected-swift5-warning {{casting value to type 'any NonSendableProtocol' could allow for references between values exposed to main actor-isolated code and 'self'-isolated code risking data races; this is an error in the Swift 6 language mode}}
+    guard let q = c as? NonSendableProtocol else { fatalError() } // expected-swift5-warning {{casting value to type 'any NonSendableProtocol' could allow for references between values exposed to main actor-isolated code and 'self'-isolated code risking data races; this will be an error in a future Swift language mode}}
     // expected-swift5-note @-1 {{'c' is exposed to main actor-isolated code}}
     // expected-swift5-note @-2 {{'q' is exposed to main actor-isolated code}}
     return q // expected-swift5-warning {{assignment could allow for references between values exposed to main actor-isolated code and 'self'-isolated code risking data races}}
@@ -102,7 +102,7 @@ actor CastTest<T, U : NonSendableProtocol, V : AnyObject, V2 : NonSendableKlassP
   func f2() async -> NonSendableProtocol {
     guard let c = await cnx2 else { fatalError() } // expected-swift5-warning {{non-Sendable type 'T?' of property 'cnx2' cannot exit main actor-isolated context}}
     // expected-swift6-error @-1 {{non-Sendable type 'T?' of property 'cnx2' cannot exit main actor-isolated context}}
-    guard let q = c as? NonSendableProtocol else { fatalError() } // expected-swift5-warning {{casting value to type 'any NonSendableProtocol' could allow for references between values exposed to main actor-isolated code and 'self'-isolated code risking data races; this is an error in the Swift 6 language mode}}
+    guard let q = c as? NonSendableProtocol else { fatalError() } // expected-swift5-warning {{casting value to type 'any NonSendableProtocol' could allow for references between values exposed to main actor-isolated code and 'self'-isolated code risking data races; this will be an error in a future Swift language mode}}
     // expected-swift5-note @-1 {{'c' is exposed to main actor-isolated code}}
     // expected-swift5-note @-2 {{'q' is exposed to main actor-isolated code}}
     return q // expected-swift5-warning {{assignment could allow for references between values exposed to main actor-isolated code and 'self'-isolated code risking data races}}
@@ -113,7 +113,7 @@ actor CastTest<T, U : NonSendableProtocol, V : AnyObject, V2 : NonSendableKlassP
     // expected-swift6-error @-1 {{non-Sendable type 'U?' of property 'cnx3' cannot exit main actor-isolated context}}
     guard let q = c as? NonSendableProtocol else { fatalError() } // expected-warning {{conditional cast from 'U' to 'any NonSendableProtocol' always succeeds}}
     // expected-swift5-note @-1 {{'q' is exposed to main actor-isolated code}}
-    return q // expected-swift5-warning {{assignment could allow for references between values exposed to main actor-isolated code and 'self'-isolated code risking data races; this is an error in the Swift 6 language mode}}
+    return q // expected-swift5-warning {{assignment could allow for references between values exposed to main actor-isolated code and 'self'-isolated code risking data races; this will be an error in a future Swift language mode}}
   }
 
   func g() async -> NonSendableProtocol {
@@ -139,7 +139,7 @@ actor CastTest<T, U : NonSendableProtocol, V : AnyObject, V2 : NonSendableKlassP
     // expected-swift6-error @-1 {{non-Sendable type 'U?' of property 'cnx3' cannot exit main actor-isolated context}}
     let q = c as! NonSendableProtocol // expected-warning {{forced cast from 'U' to 'any NonSendableProtocol' always succeeds; did you mean to use 'as'}}
     // expected-swift5-note @-1 {{'q' is exposed to main actor-isolated code}}
-    return q // expected-swift5-warning {{assignment could allow for references between values exposed to main actor-isolated code and 'self'-isolated code risking data races; this is an error in the Swift 6 language mode}}
+    return q // expected-swift5-warning {{assignment could allow for references between values exposed to main actor-isolated code and 'self'-isolated code risking data races; this will be an error in a future Swift language mode}}
   }
 
 


### PR DESCRIPTION
Emit the "casting value ... risking data races" and incompatible-region-merge diagnostics as warnings until a future language mode rather than treating them as errors in the Swift 6 language mode.

Add a local diagnoseError(SILInstruction *, ...) overload that wraps the diagnostic in warnUntilLanguageMode(future). It shadows the file-scope siloptimizer::diagnoseError (which wraps in warnUntilLanguageMode(v6)) so the diagnostic is not double-wrapped. Also rename the shadowed local variable diag_ to localDiag for clarity.

Update transfernonsendable_isolated_conformances.swift to expect the "will be an error in a future Swift language mode" wording.
