### PR TITLE
Sema: Offer fix-its for useless conditional statements

### DIFF
--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -818,6 +818,156 @@ ConcreteDeclRef TypeChecker::getReferencedDeclForHasSymbolCondition(Expr *E) {
   return ConcreteDeclRef();
 }
 
+/// Builds the dedented replacement text for the body of an `if` statement
+/// whose condition is always true, so that the body can replace the entire
+/// if statement.
+///
+/// The body content (between the open and close braces of the then branch) is
+/// extracted and each interior line is dedented by the difference between the
+/// body's leading indentation and the if statement's leading indentation. The
+/// first interior line has its leading indentation stripped entirely because
+/// the replacement text is inserted at the column where the `if` keyword
+/// originally appeared.
+static std::string buildDedentedIfBody(const SourceManager &SM,
+                                       SourceLoc ifStartLoc,
+                                       SourceLoc afterLBrace,
+                                       SourceLoc rBraceLoc) {
+  unsigned bufferID = SM.findBufferContainingLoc(ifStartLoc);
+  unsigned ifColumn = SM.getColumnInBuffer(ifStartLoc, bufferID);
+  unsigned ifIndent = ifColumn > 0 ? ifColumn - 1 : 0;
+
+  StringRef body =
+      SM.extractText(CharSourceRange(SM, afterLBrace, rBraceLoc), bufferID);
+
+  // For single-line bodies just trim the outer whitespace.
+  if (!body.contains('\n'))
+    return body.trim().str();
+
+  SmallVector<StringRef, 8> lines;
+  body.split(lines, '\n');
+
+  // `lines.front()` is the text between '{' and the first newline;
+  // `lines.back()` is the text between the final newline and '}'. Typically
+  // these are pure whitespace (code starts on a new line after '{' and '}' sits
+  // on its own line), in which case they are dropped. If either contains
+  // non-whitespace, the user placed code on the same line as a brace and we
+  // must preserve it.
+  bool firstHasContent = !lines.front().trim().empty();
+  bool lastHasContent = lines.size() > 1 && !lines.back().trim().empty();
+
+  ArrayRef<StringRef> contentLines(lines);
+  if (!firstHasContent)
+    contentLines = contentLines.drop_front();
+  if (!lastHasContent && !contentLines.empty())
+    contentLines = contentLines.drop_back();
+
+  if (contentLines.empty())
+    return "";
+  if (contentLines.size() == 1)
+    return contentLines.front().trim().str();
+
+  // Determine the body indentation from a line that wasn't adjacent to a brace,
+  // since brace-adjacent code has no meaningful leading indentation. Lines
+  // containing only whitespace are also skipped because their indentation is
+  // unreliable. Indentation is measured in characters, so mixing tabs and
+  // spaces between the if statement and its body will produce a visually
+  // misaligned result.
+  ArrayRef<StringRef> indentSource = contentLines;
+  if (firstHasContent)
+    indentSource = indentSource.drop_front();
+  if (lastHasContent && !indentSource.empty())
+    indentSource = indentSource.drop_back();
+
+  unsigned bodyIndent = 0;
+  for (StringRef line : indentSource) {
+    StringRef ltrimmed = line.ltrim();
+    if (!ltrimmed.empty()) {
+      bodyIndent = line.size() - ltrimmed.size();
+      break;
+    }
+  }
+
+  std::string result;
+  llvm::raw_string_ostream os(result);
+  for (auto it : llvm::enumerate(contentLines)) {
+    unsigned i = it.index();
+    StringRef line = it.value();
+
+    // Brace-adjacent content has no meaningful leading/trailing whitespace;
+    // for interior lines, strip up to bodyIndent characters of leading space.
+    StringRef dedented;
+    if (i == 0 && firstHasContent) {
+      dedented = line.ltrim();
+    } else {
+      unsigned leading = line.size() - line.ltrim().size();
+      dedented = line.substr(std::min(leading, bodyIndent));
+    }
+    if (i + 1 == contentLines.size() && lastHasContent)
+      dedented = dedented.rtrim();
+
+    if (i > 0)
+      os << '\n';
+    if (i > 0 && !dedented.empty())
+      os.indent(ifIndent);
+    os << dedented;
+  }
+  return result;
+}
+
+/// Adds a fix-it to the always-true diagnostic for an `if` or `guard`
+/// statement, removing the now-redundant statement. For `if`, the body of
+/// the then branch replaces the whole statement; for `guard`, the entire
+/// statement is removed (its body is unreachable). For an `else if` branch,
+/// the inner `if` is replaced with just its body braces, turning
+/// `else if X { body } [else ...]` into `else { body }` and discarding any
+/// now-unreachable trailing branches. No fix-it is offered for `while`,
+/// since removing an always-true condition would produce an unconditional
+/// infinite loop, and none is offered for a labeled `if`, since the label
+/// may be referenced by `break`/`continue` inside the body.
+static void addFixItForUnnecessaryConditionalStmt(InFlightDiagnostic &inflight,
+                                                  LabeledConditionalStmt *stmt,
+                                                  bool isElseIfBranch,
+                                                  ASTContext &ctx) {
+  auto &SM = ctx.SourceMgr;
+
+  if (auto *ifStmt = dyn_cast<IfStmt>(stmt)) {
+    if (ifStmt->getLabelInfo())
+      return;
+
+    auto *thenBrace = ifStmt->getThenStmt();
+    SourceLoc lBraceLoc = thenBrace->getLBraceLoc();
+    SourceLoc rBraceLoc = thenBrace->getRBraceLoc();
+    if (lBraceLoc.isInvalid() || rBraceLoc.isInvalid())
+      return;
+
+    if (isElseIfBranch) {
+      // Replace the inner if-stmt with just the text of its then-body
+      // (braces included). This converts `else if X { body } [else ...]`
+      // into `else { body }` and drops any unreachable trailing branches.
+      auto bodyCharRange = CharSourceRange(
+          SM, lBraceLoc, Lexer::getLocForEndOfToken(SM, rBraceLoc));
+      StringRef bodyText = SM.extractText(bodyCharRange);
+      inflight.fixItReplace(
+          SourceRange(ifStmt->getStartLoc(), ifStmt->getEndLoc()),
+          bodyText.str());
+      return;
+    }
+
+    SourceLoc afterLBrace = Lexer::getLocForEndOfToken(SM, lBraceLoc);
+    std::string replacement =
+        buildDedentedIfBody(SM, ifStmt->getStartLoc(), afterLBrace, rBraceLoc);
+    inflight.fixItReplace(
+        SourceRange(ifStmt->getStartLoc(), ifStmt->getEndLoc()), replacement);
+    return;
+  }
+
+  if (auto *guardStmt = dyn_cast<GuardStmt>(stmt)) {
+    inflight.fixItRemove(
+        SourceRange(guardStmt->getStartLoc(), guardStmt->getEndLoc()));
+    return;
+  }
+}
+
 static bool typeCheckAvailableStmtConditionElement(StmtConditionElement &elt,
                                                    bool &isFalseable,
                                                    DeclContext *dc) {
@@ -945,10 +1095,13 @@ bool TypeChecker::typeCheckStmtConditionElement(StmtConditionElement &elt,
 ///
 /// \param stmt The conditional statement to type-check, which will be modified
 /// in place.
+/// \param isElseIfBranch When \p stmt is the inner `if` of an `else if`
+/// branch. Affects the shape of the always-true fix-it.
 ///
 /// \returns true if an error occurred, false otherwise.
 static bool typeCheckConditionForStatement(LabeledConditionalStmt *stmt,
-                                           DeclContext *dc) {
+                                           DeclContext *dc,
+                                           bool isElseIfBranch = false) {
   bool hadError = false;
   bool hadAnyFalsable = false;
   auto cond = stmt->getCond();
@@ -959,9 +1112,9 @@ static bool typeCheckConditionForStatement(LabeledConditionalStmt *stmt,
 
   // If none of the statement's conditions can be false, diagnose.
   // FIXME: Also diagnose if none of the statements conditions can be true.
-  // FIXME: Offer a fix-it to remove the unreachable code.
   if (!stmt->isImplicit() && !hadAnyFalsable && !hadError) {
-    auto &diags = dc->getASTContext().Diags;
+    auto &ctx = dc->getASTContext();
+    auto &diags = ctx.Diags;
     Diag<> msg = diag::invalid_diagnostic;
     switch (stmt->getKind()) {
     case StmtKind::If:
@@ -976,7 +1129,8 @@ static bool typeCheckConditionForStatement(LabeledConditionalStmt *stmt,
     default:
       llvm_unreachable("unknown LabeledConditionalStmt kind");
     }
-    diags.diagnose(cond[0].getStartLoc(), msg);
+    auto inflight = diags.diagnose(cond[0].getStartLoc(), msg);
+    addFixItForUnnecessaryConditionalStmt(inflight, stmt, isElseIfBranch, ctx);
   }
 
   stmt->setCond(cond);
@@ -1051,6 +1205,11 @@ public:
   /// The BraceStmts that should be type-checked. This should always be `All`,
   /// unless we're lazy type-checking for e.g completion.
   BraceStmtChecking BraceChecking = BraceStmtChecking::All;
+
+  /// Whether the next \c IfStmt to be visited is the inner `if` of an
+  /// `else if` branch. Set by \c visitIfStmt before recursing into the
+  /// statement's else clause.
+  bool VisitingElseIfBranch = false;
 
   ASTContext &getASTContext() const { return Ctx; };
 
@@ -1442,16 +1601,23 @@ public:
   }
   
   Stmt *visitIfStmt(IfStmt *IS) {
-    typeCheckConditionForStatement(IS, DC);
+    bool isElseIfBranch = VisitingElseIfBranch;
+    typeCheckConditionForStatement(IS, DC, isElseIfBranch);
 
     auto sourceFile = DC->getParentSourceFile();
     checkLabeledStmtShadowing(getASTContext(), sourceFile, IS);
 
     auto *TS = IS->getThenStmt();
-    typeCheckStmt(TS);
+    {
+      llvm::SaveAndRestore<bool> save(VisitingElseIfBranch, false);
+      typeCheckStmt(TS);
+    }
     IS->setThenStmt(TS);
 
     if (auto *ES = IS->getElseStmt()) {
+      // The immediate `else` clause forms an `else if` chain when it is itself
+      // an `IfStmt`; mark that for the inner visit.
+      llvm::SaveAndRestore<bool> save(VisitingElseIfBranch, isa<IfStmt>(ES));
       typeCheckStmt(ES);
       IS->setElseStmt(ES);
     }

--- a/test/ClangImporter/availability_custom_domains_access_availability.swift
+++ b/test/ClangImporter/availability_custom_domains_access_availability.swift
@@ -382,10 +382,11 @@ extension PublicGenericStruct {
 }
 
 func testUnnecessaryIfAvailableStmt() {
+  // expected-warning@+3 {{availability domain 'Aral' is deprecated}}
+  // expected-warning@+2 {{unnecessary check for 'Aral'; this condition will always be true}}{{none}}
+  // expected-warning@+1 {{'if' condition is always true}}{{3-+2:4=_ = 0}}
   if #available(Aral) {
-    // expected-warning@-1 {{availability domain 'Aral' is deprecated}}
-    // expected-warning@-2 {{unnecessary check for 'Aral'; this condition will always be true}}{{none}}
-    // expected-warning@-3 {{'if' condition is always true}}{{none}}
+    _ = 0
   }
 }
 
@@ -418,10 +419,10 @@ func testUnnecessaryIfUnavailableCompoundStmt() {
 }
 
 func testUnnecessaryGuardAvailableStmt() {
+  // expected-warning@+3 {{availability domain 'Aral' is deprecated}}
+  // expected-warning@+2 {{unnecessary check for 'Aral'; this condition will always be true}}{{none}}
+  // expected-warning@+1 {{'guard' condition is always true}}{{1-+3:1=}}
   guard #available(Aral) else {
-    // expected-warning@-1 {{availability domain 'Aral' is deprecated}}
-    // expected-warning@-2 {{unnecessary check for 'Aral'; this condition will always be true}}{{none}}
-    // expected-warning@-3 {{'guard' condition is always true}}{{none}}
     return
   }
 }
@@ -440,5 +441,16 @@ func testUnnecessaryWhileAvailableStmt() {
     // expected-warning@-2 {{unnecessary check for 'Aral'; this condition will always be true}}{{none}}
     // expected-warning@-3 {{'while' condition is always true}}{{none}}
     break
+  }
+}
+
+func testUnnecessaryIfAvailableStmtWithElse() {
+  // expected-warning@+3 {{availability domain 'Aral' is deprecated}}
+  // expected-warning@+2 {{unnecessary check for 'Aral'; this condition will always be true}}{{none}}
+  // expected-warning@+1 {{'if' condition is always true}}{{3-+4:4=_ = 0}}
+  if #available(Aral) {
+    _ = 0
+  } else {
+    _ = 1
   }
 }

--- a/test/stmt/useless_conditional_statement.swift
+++ b/test/stmt/useless_conditional_statement.swift
@@ -1,15 +1,153 @@
 // RUN: %target-typecheck-verify-swift
 
 func testUselessIfCondition(_ x: Int) {
-  // expected-warning@+1 {{'if' condition is always true}}{{group-name=UselessConditionalStatement}}{{none}}
+  // With else clause: replace the entire `if` with the body of the then branch.
+
+  // expected-warning@+1 {{'if' condition is always true}}{{group-name=UselessConditionalStatement}}{{3-+4:4=_ = 0}}
   if case _ = x {
     _ = 0
   } else {
     _ = 1
   }
+
+  // Multi-line body: each interior line is dedented to match the `if`'s indent.
+
+  // expected-warning@+1 {{'if' condition is always true}}{{3-+3:4=_ = 0\n  _ = 1}}
+  if case _ = x {
+    _ = 0
+    _ = 1
+  }
+
+  // Empty body: `fixItReplace` with empty replacement triggers smart whitespace
+  // handling that removes the entire pair of lines.
+
+  // expected-warning@+1 {{'if' condition is always true}}{{1-+2:1=}}
+  if case _ = x {
+  }
+
+  // Same-line body: trim outer whitespace; no newlines in the replacement.
+
+  // expected-warning@+1 {{'if' condition is always true}}{{3-26=_ = 0}}
+  if case _ = x { _ = 0 }
+
+  // Blank lines within the body are preserved.
+
+  // expected-warning@+1 {{'if' condition is always true}}{{3-+4:4=_ = 0\n\n  _ = 1}}
+  if case _ = x {
+    _ = 0
+
+    _ = 1
+  }
+
+  // Code on the same line as `{`: the leading statement is preserved and
+  // emitted on the same line as the dedented body.
+
+  // expected-warning@+1 {{'if' condition is always true}}{{3-+2:4=_ = 0\n  _ = 1}}
+  if case _ = x { _ = 0
+    _ = 1
+  }
+
+  // Code on the same line as `}`: the trailing statement is preserved.
+
+  // expected-warning@+1 {{'if' condition is always true}}{{3-+2:12=_ = 0\n  _ = 1}}
+  if case _ = x {
+    _ = 0
+    _ = 1 }
+
+  // Nested statement inside the body: dedent strips one indentation level
+  // while preserving the relative nesting.
+
+  // expected-warning@+1 {{'if' condition is always true}}{{3-+4:4=if true {\n    _ = 0\n  \}}}
+  if case _ = x {
+    if true {
+      _ = 0
+    }
+  }
+
+  // `else if` branch: the inner `if` is replaced by the text of its body
+  // braces, turning the chain into a plain `else` branch and discarding any
+  // now-unreachable trailing branches.
+
+  // expected-warning@+2 {{'if' condition is always true}}{{10-+2:4={\n    _ = 0\n  \}}}
+  if false {
+  } else if case _ = x {
+    _ = 0
+  }
+
+  // `else if` with subsequent unreachable branches: those branches are
+  // dropped along with the inner `if` header.
+
+  // expected-warning@+2 {{'if' condition is always true}}{{10-+6:4={\n    _ = 0\n  \}}}
+  if false {
+  } else if case _ = x {
+    _ = 0
+  } else if x > 0 {
+    _ = 1
+  } else {
+    _ = 2
+  }
+
+  // Single-line `else if`: the body braces are extracted intact and replace
+  // the inner `if` header.
+
+  // expected-warning@+1 {{'if' condition is always true}}{{21-44={ _ = 0 \}}}
+  if false { } else if case _ = x { _ = 0 }
+
+  // Empty `else if` body: extracted text is just `{\n  }`, producing a plain
+  // `else { }`.
+
+  // expected-warning@+2 {{'if' condition is always true}}{{10-+1:4={\n  \}}}
+  if false {
+  } else if case _ = x {
+  }
+
+  // `else if` at the end of a longer chain: only the innermost `if` is
+  // rewritten; preceding branches are preserved.
+
+  // expected-warning@+4 {{'if' condition is always true}}{{10-+2:4={\n    _ = 0\n  \}}}
+  if false {
+  } else if x > 0 {
+    _ = 99
+  } else if case _ = x {
+    _ = 0
+  }
+
+  // A nested `if` that lives inside an `else { ... }` block (not an
+  // `else if` chain) is treated as a regular always-true `if`: the fix-it
+  // dedents the body rather than producing brace text. This verifies that
+  // the else-if flag is correctly reset when descending into a non-if else.
+
+  if false {
+  } else {
+    // expected-warning@+1 {{'if' condition is always true}}{{5-+2:6=_ = 0}}
+    if case _ = x {
+      _ = 0
+    }
+  }
+
+  // An always-true outer `if` whose else clause contains an `else if` chain:
+  // the outer fix-it discards the entire chain along with the if header.
+
+  // expected-warning@+1 {{'if' condition is always true}}{{3-+4:4=_ = 0}}
+  if case _ = x {
+    _ = 0
+  } else if x > 0 {
+    _ = 1
+  }
+
+  // A labeled `if` is left untouched: no fix-it, since the label may be
+  // referenced by `break`/`continue` inside the body.
+
+  // expected-warning@+1 {{'if' condition is always true}}{{none}}
+  outer: if case _ = x {
+    break outer
+  }
 }
 
 func testUselessWhile(_ x: Int) {
+  // No fix-it for `while`: removing an always-true condition would create an
+  // unconditional infinite loop.
+
   // expected-warning@+1 {{'while' condition is always true}}{{group-name=UselessConditionalStatement}}{{none}}
   while case _ = x {
     _ = 0
@@ -19,10 +157,21 @@ func testUselessWhile(_ x: Int) {
 }
 
 func testUselessGuard(_ x: Int) {
-  // expected-warning@+1 {{'guard' condition is always true, body is unreachable}}{{none}}
+  // Multi-line: fix-it removes the entire guard statement (its body is unreachable).
+
+  // expected-warning@+1 {{'guard' condition is always true, body is unreachable}}{{group-name=UselessConditionalStatement}}{{1-+4:1=}}
   guard case _ = x else {
     _ = 0
     return
   }
   _ = 1
+
+  // Same line: fix-it removes the entire line.
+
+  // expected-warning@+1 {{'guard' condition is always true, body is unreachable}}{{1-+1:1=}}
+  guard case _ = x else { return }
+  _ = 1
+}
+
+func testUselessGuardEmptyBody(_ x: Int) {
 }


### PR DESCRIPTION
When an `if` or `guard` statement is diagnosed as always succeeding, emit a fix-it that removes the redundant statement. For `if`, the then-branch body replaces the entire statement, dedented to match the surrounding indentation level, like this:

```
// Before
if case let _ = x {
  doSomething()
} else {
  // ...
}

// After
doSomething()
```

For `guard`, the entire statement is removed (its body is unreachable). For an `else if` branch, the inner `if` is replaced with just its body braces, turning `else if X { body } [else ...]` into `else { body }` and discarding any now-unreachable trailing branches.

No fix-it is offered for `while`, since removing the always-true condition would produce an unconditional infinite loop.

Resolves rdar://178194980.
