### PR TITLE
[PrintAsClang] Ensure "unavailable" comments are printed in a stable order

### DIFF
--- a/lib/PrintAsClang/DeclAndTypePrinter.h
+++ b/lib/PrintAsClang/DeclAndTypePrinter.h
@@ -22,6 +22,7 @@
 // for OptionalTypeKind
 #include "swift/AST/TypeRepr.h"
 #include "swift/ClangImporter/ClangImporter.h"
+#include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/StringSet.h"
 
 namespace clang {
@@ -50,7 +51,7 @@ struct CxxDeclEmissionScope {
   /// The string holds a reason why the declaration is unrepresentable;
   /// empty string means the reason should be acqured from
   /// 'getDeclRepresentation'.
-  llvm::DenseMap<const ValueDecl *, std::string>
+  llvm::MapVector<const ValueDecl *, std::string>
       additionalUnrepresentableDeclarations;
   /// Records the C++ declaration names already emitted in this lexical scope.
   llvm::StringSet<> emittedDeclarationNames;

--- a/lib/PrintAsClang/ModuleContentsWriter.cpp
+++ b/lib/PrintAsClang/ModuleContentsWriter.cpp
@@ -40,6 +40,7 @@
 #include "clang/AST/DeclObjC.h"
 #include "clang/Basic/Module.h"
 
+#include "llvm/ADT/SetVector.h"
 #include "llvm/Support/raw_ostream.h"
 #include <utility>
 
@@ -932,7 +933,7 @@ public:
   void write() {
     SmallVector<Decl *, 64> decls;
     M.getTopLevelDeclsWithAuxiliaryDecls(decls);
-    llvm::DenseSet<const ValueDecl *> removedValueDecls;
+    llvm::SmallSetVector<const ValueDecl *, 4> removedValueDecls;
 
     auto newEnd =
         std::remove_if(decls.begin(), decls.end(),
@@ -1083,7 +1084,8 @@ public:
             }),
         removedVDList.end());
     // Sort the unavaiable decls by their name and kind.
-    llvm::sort(removedVDList, [](const ValueDecl *lhs, const ValueDecl *rhs) {
+    llvm::stable_sort(removedVDList, [](const ValueDecl *lhs,
+                                        const ValueDecl *rhs) {
       auto getSortKey = [](const ValueDecl *vd) {
         std::string sortKey;
         llvm::raw_string_ostream os(sortKey);

--- a/test/Interop/SwiftToCxx/unsupported/unsupported-decls-deterministic-order.swift
+++ b/test/Interop/SwiftToCxx/unsupported/unsupported-decls-deterministic-order.swift
@@ -1,0 +1,46 @@
+// Compile the same source three times and verify the resulting C++ headers are
+// byte-identical.
+
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -module-name DeterministicOrder -clang-header-expose-decls=all-public -disable-availability-checking -typecheck -emit-clang-header-path %t/header1.h
+// RUN: %target-swift-frontend %s -module-name DeterministicOrder -clang-header-expose-decls=all-public -disable-availability-checking -typecheck -emit-clang-header-path %t/header2.h
+// RUN: %target-swift-frontend %s -module-name DeterministicOrder -clang-header-expose-decls=all-public -disable-availability-checking -typecheck -emit-clang-header-path %t/header3.h
+// RUN: cmp %t/header1.h %t/header2.h
+// RUN: cmp %t/header2.h %t/header3.h
+
+// Sanity check: confirm the expected stub comments are actually being
+// emitted, so the cmp checks above can't pass vacuously by all
+// producing empty (or stub-less) headers.
+// RUN: %FileCheck %s < %t/header1.h
+
+public struct T00 {}
+public struct T01 {}
+public struct T02 {}
+public struct T03 {}
+public struct T04 {}
+public struct T05 {}
+public struct T06 {}
+public struct T07 {}
+public struct T08 {}
+public struct T09 {}
+
+infix operator <==> : ComparisonPrecedence
+
+// Five overloads that hit the "requires code to be emitted into client" path.
+@_alwaysEmitIntoClient public func <==> (lhs: T00, rhs: T00) -> Bool { false }
+@_alwaysEmitIntoClient public func <==> (lhs: T01, rhs: T01) -> Bool { false }
+@_alwaysEmitIntoClient public func <==> (lhs: T02, rhs: T02) -> Bool { false }
+@_alwaysEmitIntoClient public func <==> (lhs: T03, rhs: T03) -> Bool { false }
+@_alwaysEmitIntoClient public func <==> (lhs: T04, rhs: T04) -> Bool { false }
+
+// Five overloads that hit the "may throw an error" path.
+public func <==> (lhs: T05, rhs: T05) throws -> Bool { false }
+public func <==> (lhs: T06, rhs: T06) throws -> Bool { false }
+public func <==> (lhs: T07, rhs: T07) throws -> Bool { false }
+public func <==> (lhs: T08, rhs: T08) throws -> Bool { false }
+public func <==> (lhs: T09, rhs: T09) throws -> Bool { false }
+
+// The ten resulting stub comments must be emitted in the same order on every run.
+
+// CHECK-COUNT-5: // Unavailable in C++: Swift operator function '<==>(_:_:)'. operator function '<==>' can not be exposed to C++ as it requires code to be emitted into client.
+// CHECK-COUNT-5: // Unavailable in C++: Swift operator function '<==>(_:_:)'. operator function '<==>' can not yet be represented in C++ as it may throw an error.


### PR DESCRIPTION
The two containers feeding the unavailable-stub sort were keyed by `ValueDecl *` in a `DenseSet` / `DenseMap`, so their iteration order varied across processes. This led to decls sharing a name + kind (e.g. operator overloads) emerged in a different relative order on each invocation. Switch the storage to `SmallSetVector` / `MapVector` so the sort sees a deterministic input.

rdar://178167240
