### PR TITLE
[6.4] SILCombine: don't fold `unchecked_enum_data_addr` - `destroy_addr` for non-copyable enums

### DIFF
--- a/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
@@ -1073,7 +1073,7 @@ SILInstruction *SILCombiner::visitUncheckedEnumDataAddrInstBase(
 
   if (onlyDestroys) {
     // Destroying whole non-copyable enums with a deinit would wrongly trigger calling its deinit.
-    if (tedai->getEnum()->getType().isValueTypeWithDeinit())
+    if (tedai->getEnum()->getType().isMoveOnly())
       return nullptr;
 
     // The unchecked_take_enum_data_addr is dead: remove it and replace all

--- a/test/SILOptimizer/devirt_deinits.swift
+++ b/test/SILOptimizer/devirt_deinits.swift
@@ -85,6 +85,18 @@ struct StrWithoutDeinit: ~Copyable {
   let c = 27
 }
 
+public struct NC: ~Copyable {
+  var t: Int
+
+  deinit {}
+}
+
+public enum E<T>: ~Copyable {
+  case a(NC)
+  case b(NC)
+  case c(T)
+}
+
 // CHECK-LABEL: sil hidden [noinline] @$s4test2S3VfD :
 // CHECK:         [[D:%.*]] = function_ref @$s4test2S1VfD :
 // CHECK:         apply [[D]]
@@ -167,6 +179,12 @@ func testInlineArray(_ a: consuming InlineArray<3, S1>) {
   log("### testInlineArray")
 }
 
+// Check that the optimizer doesn't run into an DeinitDevirtualizer - Inliner loop.
+// CHECK-LABEL: sil @$s4test21enumWithDeinitPayload1eyAA1EOyxGn_tlF :
+// CHECK-NOT:   bb10
+// CHECK:       } // end sil function '$s4test21enumWithDeinitPayload1eyAA1EOyxGn_tlF'
+public func enumWithDeinitPayload<T>(e: consuming E<T>) {
+}
 
 
 @main

--- a/test/SILOptimizer/sil_combine_moveonly.sil
+++ b/test/SILOptimizer/sil_combine_moveonly.sil
@@ -48,6 +48,12 @@ enum NonCopyableForwardingEnum : ~Copyable {
   deinit
 }
 
+enum NonCopyableWithoutDeinit: ~Copyable {
+  case a(S)
+  case b(S)
+  case c(Int)
+}
+
 sil @getWrappedValue : $@convention(thin) <T> (@in_guaranteed Wrapper<T>) -> @out T
 
 // Test that a release_value is not removed for a struct-with-deinit.
@@ -207,6 +213,19 @@ bb0(%0 : $*MaybeFileDescriptor):
 sil @dont_fold_destroy_of_take_enum_with_deinit : $@convention(thin) (@in MaybeFileDescriptor) -> () {
 bb0(%0 : $*MaybeFileDescriptor):
   %1 = unchecked_take_enum_data_addr %0, #MaybeFileDescriptor.some!enumelt
+  destroy_addr %1
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK-LABEL: sil @dont_fold_destroy_of_take_non_copyable_enum :
+// CHECK:       bb0(%0 : $*NonCopyableWithoutDeinit):
+// CHECK-NEXT:    %1 = unchecked_take_enum_data_addr %0
+// CHECK-NEXT:    destroy_addr %1
+// CHECK:       } // end sil function 'dont_fold_destroy_of_take_non_copyable_enum'
+sil @dont_fold_destroy_of_take_non_copyable_enum : $@convention(thin) (@in NonCopyableWithoutDeinit) -> () {
+bb0(%0 : $*NonCopyableWithoutDeinit):
+  %1 = unchecked_take_enum_data_addr %0, #NonCopyableWithoutDeinit.a!enumelt
   destroy_addr %1
   %r = tuple ()
   return %r : $()


### PR DESCRIPTION
* **Explanation**: Fixes a compiler hang. This peephole optimization can trigger a DeinitDevirtualizer - Inliner loop in the pass pipeline, which can explode the generated SIL.
The DeinitDevirtualizer replaces a `destroy_addr of` an enum by a `switch_enum_addr`. The case-blocks then contain `destroy_addr` for the payloads. However, if SILCombine replaces such a payload `destroy_addr` with a destroy of the whole enum, DeinitDevirtualizer again generates a switch for it. This happens multiple times because the inliner restarts the pass pipeline after inlining a deinit call.
* **Risk**: Low. It's a small change which makes the peephole optimization more conservative
* **Testing**: by lit tests
* **Issue**: https://github.com/swiftlang/swift/issues/89483, rdar://178088780
* **Reviewers**: @meg-gupta
* **Main branch PR**: https://github.com/swiftlang/swift/pull/89506
