### PR TITLE
swift-inspect: repair build for Android

### DIFF
--- a/tools/swift-inspect/Sources/swift-inspect/String+Extensions.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/String+Extensions.swift
@@ -22,12 +22,7 @@ extension DefaultStringInterpolation {
 
 enum Std {
   struct File: TextOutputStream {
-
-#if os(Android)
-    typealias File = OpaquePointer
-#else
     typealias File = UnsafeMutablePointer<FILE>
-#endif
 
     var underlying: File
 


### PR DESCRIPTION
Android now imports `FILE` as a typed pointer rather than an `OpaquePointer`. Remove the conditional typealias.