### PR TITLE
[ClangImporter] Add regression test for SwiftAttr payload collisions

### DIFF
--- a/test/ClangImporter/swift_attr_objc_type_collision.swift
+++ b/test/ClangImporter/swift_attr_objc_type_collision.swift
@@ -44,7 +44,7 @@ import Foundation
 // expected-no-diagnostics
 
 final class SwiftAttrCollisionUIActorSecondWitness: NSObject, SwiftAttrCollisionUIActorSecond {
-  func second(completionHandler: @escaping @MainActor @Sendable (Int32) -> Void) {}
+  func second(completionHandler: @MainActor @Sendable (Int32) -> Void) {}
 }
 
 //--- UIActorFirst.h
@@ -72,5 +72,5 @@ import Foundation
 // expected-no-diagnostics
 
 final class SwiftAttrCollisionSendableSecondWitness: NSObject, SwiftAttrCollisionSendableSecond {
-  func second(completionHandler: @escaping @Sendable (Int32) -> Void) {}
+  func second(completionHandler: @Sendable (Int32) -> Void) {}
 }

--- a/test/ClangImporter/swift_attr_objc_type_collision.swift
+++ b/test/ClangImporter/swift_attr_objc_type_collision.swift
@@ -1,0 +1,76 @@
+// RUN: %empty-directory(%t/src)
+// RUN: split-file %s %t/src
+
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck %t/src/sendable_first.swift \
+// RUN:   -import-objc-header %t/src/SendableFirst.h \
+// RUN:   -swift-version 6 \
+// RUN:   -strict-concurrency=complete \
+// RUN:   -enable-experimental-feature SendableCompletionHandlers \
+// RUN:   -module-name main -verify
+
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck %t/src/ui_actor_first.swift \
+// RUN:   -import-objc-header %t/src/UIActorFirst.h \
+// RUN:   -swift-version 6 \
+// RUN:   -strict-concurrency=complete \
+// RUN:   -enable-experimental-feature SendableCompletionHandlers \
+// RUN:   -module-name main -verify
+
+// REQUIRES: objc_interop
+// REQUIRES: concurrency
+// REQUIRES: swift_feature_SendableCompletionHandlers
+
+//--- SendableFirst.h
+#define SWIFT_SENDABLE __attribute__((__swift_attr__("@Sendable")))
+#define SWIFT_UI_ACTOR __attribute__((swift_attr("@UIActor")))
+
+#pragma clang assume_nonnull begin
+
+@import Foundation;
+
+@protocol SwiftAttrCollisionSendableFirst
+- (void)firstWithCompletionHandler:(SWIFT_SENDABLE void (^)(int result))completionHandler;
+@end
+
+@protocol SwiftAttrCollisionUIActorSecond
+@optional
+- (void)secondWithCompletionHandler:(SWIFT_UI_ACTOR void (^)(int result))completionHandler;
+@end
+
+#pragma clang assume_nonnull end
+
+//--- sendable_first.swift
+import Foundation
+
+// expected-no-diagnostics
+
+final class SwiftAttrCollisionUIActorSecondWitness: NSObject, SwiftAttrCollisionUIActorSecond {
+  func second(completionHandler: @escaping @MainActor @Sendable (Int32) -> Void) {}
+}
+
+//--- UIActorFirst.h
+#define SWIFT_SENDABLE __attribute__((__swift_attr__("@Sendable")))
+#define SWIFT_UI_ACTOR __attribute__((swift_attr("@UIActor")))
+
+#pragma clang assume_nonnull begin
+
+@import Foundation;
+
+@protocol SwiftAttrCollisionUIActorFirst
+- (void)firstWithCompletionHandler:(SWIFT_UI_ACTOR void (^)(int result))completionHandler;
+@end
+
+@protocol SwiftAttrCollisionSendableSecond
+@optional
+- (void)secondWithCompletionHandler:(SWIFT_SENDABLE void (^)(int result))completionHandler;
+@end
+
+#pragma clang assume_nonnull end
+
+//--- ui_actor_first.swift
+import Foundation
+
+// expected-no-diagnostics
+
+final class SwiftAttrCollisionSendableSecondWitness: NSObject, SwiftAttrCollisionSendableSecond {
+  func second(completionHandler: @escaping @Sendable (Int32) -> Void) {}
+}


### PR DESCRIPTION
Add regression coverage for an already-fixed Clang `AttributedType` uniquing bug that can affect Swift's Objective-C importer. The underlying bug has already been fixed in LLVM and entered Swift through the LLVM/Clang rebranch; this PR only adds end-to-end Swift coverage for the user-visible failure mode.

The test checks Swift 6 strict-concurrency Objective-C optional protocol witness matching when imported block types use same-shaped `swift_attr` type attributes with different payloads.

This covers the failure mode where a Swift method only "nearly matches" an optional Objective-C protocol requirement because the imported completion-handler block type has the wrong Swift concurrency attributes.

## Background

`swift_attr` is represented in Clang as the single attribute kind `SwiftAttr`, while the Swift-side meaning is carried by the payload string, for example `@Sendable` or `@UIActor`.

For block types with the same shape but different `swift_attr` payloads:

```objc
- (void)firstWithCompletionHandler:
    (__attribute__((swift_attr("@Sendable"))) void (^)(int result))completionHandler;

- (void)secondWithCompletionHandler:
    (__attribute__((swift_attr("@UIActor"))) void (^)(int result))completionHandler;
```

an affected Clang could unique both as the same `AttributedType` when the uniquing key did not distinguish the attribute payload. The attributed type created first then won.

This can surface through ClangImporter as an Objective-C optional protocol requirement with the wrong Swift function type. For example, a requirement that should import with `@MainActor @Sendable` can import as only `@Sendable`, and the expected Swift witness then produces `nearly matches optional requirement` instead of satisfying the requirement.

A standalone public reproducer is available here:

- https://github.com/iXerol/SwiftAttrPayloadCollisionRepro

The public release boundary observed for that reproducer is:

- Affected: Xcode 26.3 / Swift 6.2.4
- Fixed: Xcode 26.4 / Swift 6.3

## Relationship to LLVM

The underlying Clang issue is fixed by:

- LLVM PR: https://github.com/llvm/llvm-project/pull/108631
- LLVM commit: https://github.com/llvm/llvm-project/commit/d3daa3c4435a54f7876d0ced81787fea92e77d08

That fix includes the `Attr *` in `AttributedType::Profile`, so two `swift_attr` type attributes with the same Clang attribute kind but different payloads no longer fold into the same `AttributedType`.

The fix entered Swift through the LLVM/Clang rebranch:

- Swift PR: https://github.com/swiftlang/swift/pull/84606
- Swift merge commit: https://github.com/swiftlang/swift/commit/03a599c5be57da27a9708bfb93f159bf0aa47a22

This PR adds end-to-end coverage at the ClangImporter / Swift protocol witness layer. The user-visible failure is not only an AST dump difference; it manifests as an Objective-C optional protocol requirement not being satisfied by the expected Swift method.

## What This Tests

The test covers both declaration orders:

- `@Sendable` first, then `@UIActor`
- `@UIActor` first, then `@Sendable`

Both cases are intentional because the historical failure was order-dependent.

The test uses Swift 6 plus complete strict concurrency because this is the mode where the imported function type mismatch is visible as a concurrency-attribute witness mismatch.

## Testing

Focused local verification:

- Swift 6.3 release toolchain: passes
- Xcode 26.3 / Swift 6.2.4: fails as expected with unexpected `nearly matches optional requirement` diagnostics

The public SwiftPM reproducer also passes with Xcode 26.4 / Swift 6.3 and fails with Xcode 26.3 / Swift 6.2.4.
