### PR TITLE
embedded: allow finite specialization loops up to a larger limit

### DIFF
--- a/include/swift/SILOptimizer/Utils/Generics.h
+++ b/include/swift/SILOptimizer/Utils/Generics.h
@@ -184,6 +184,7 @@ private:
 
   bool prepareAndCheck(ApplySite Apply, SILFunction *Callee,
                        SubstitutionMap ParamSubs,
+                       bool isMandatory,
                        OptRemark::Emitter *ORE = nullptr);
   void performFullSpecializationPreparation(SILFunction *Callee,
                                             SubstitutionMap ParamSubs);
@@ -206,6 +207,7 @@ public:
                     ApplySite Apply, SILFunction *Callee,
                     SubstitutionMap ParamSubs, SerializedKind_t Serialized,
                     bool ConvertIndirectToDirect, bool dropUnusedArguments,
+                    bool isMandatory = false,
                     OptRemark::Emitter *ORE = nullptr);
 
   /// Constructs the ReabstractionInfo for generic function \p Callee with

--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -345,13 +345,16 @@ static bool growingSubstitutions(SubstitutionMap Subs1,
 /// The specialization graph is represented by means of SpecializationInformation.
 /// We use this meta-information about specializations to detect cycles in this
 /// graph.
-static bool createsInfiniteSpecializationLoop(ApplySite Apply) {
+static bool createsInfiniteSpecializationLoop(ApplySite Apply, bool isMandatory) {
   if (!Apply)
     return false;
   auto *Callee = Apply.getCalleeFunction();
   SILFunction *Caller = nullptr;
   Caller = Apply.getFunction();
-  int numAcceptedCycles = 1;
+
+  // If there is a specialization loop and it is not infinite, we should allow this in embedded swift.
+  // Still, there is a hard coded limit, but 10 should be good enough for real world scenarios.
+  int numAcceptedCycles = isMandatory ? 10 : 1;
 
   // Name of the function to be specialized.
   auto GenericFunc = Callee;
@@ -555,6 +558,7 @@ static bool canDropMetatypeArg(ApplySite apply, SILFunction *callee,
 /// Returns true otherwise.
 bool ReabstractionInfo::prepareAndCheck(ApplySite Apply, SILFunction *Callee,
                                         SubstitutionMap ParamSubs,
+                                        bool isMandatory,
                                         OptRemark::Emitter *ORE) {
   assert(ParamSubs.hasAnySubstitutableParams());
 
@@ -673,7 +677,7 @@ bool ReabstractionInfo::prepareAndCheck(ApplySite Apply, SILFunction *Callee,
 
   // Check if specializing this call site would create in an infinite generic
   // specialization loop.
-  if (createsInfiniteSpecializationLoop(Apply)) {
+  if (createsInfiniteSpecializationLoop(Apply, isMandatory)) {
     REMARK_OR_DEBUG(ORE, [&]() {
       return RemarkMissed("SpecializationLoop", *Apply.getInstruction())
              << IndentDebug(4)
@@ -696,19 +700,20 @@ bool ReabstractionInfo::prepareAndCheck(ApplySite Apply, SILFunction *Callee,
 bool ReabstractionInfo::canBeSpecialized(ApplySite Apply, SILFunction *Callee,
                                          SubstitutionMap ParamSubs) {
   ReabstractionInfo ReInfo(Callee->getModule());
-  return ReInfo.prepareAndCheck(Apply, Callee, ParamSubs);
+  return ReInfo.prepareAndCheck(Apply, Callee, ParamSubs, /*isMandatory=*/ false);
 }
 
 ReabstractionInfo::ReabstractionInfo(
     ModuleDecl *targetModule, bool isWholeModule, ApplySite Apply,
     SILFunction *Callee, SubstitutionMap ParamSubs, SerializedKind_t Serialized,
     bool ConvertIndirectToDirect, bool dropUnusedArguments,
+    bool isMandatory,
     OptRemark::Emitter *ORE)
     : ConvertIndirectToDirect(ConvertIndirectToDirect),
       dropUnusedArguments(dropUnusedArguments), M(&Callee->getModule()),
       TargetModule(targetModule), isWholeModule(isWholeModule),
       Serialized(Serialized) {
-  if (!prepareAndCheck(Apply, Callee, ParamSubs, ORE))
+  if (!prepareAndCheck(Apply, Callee, ParamSubs, isMandatory, ORE))
     return;
 
   SILFunction *Caller = nullptr;
@@ -3241,7 +3246,7 @@ static bool usePrespecialized(
           funcBuilder.getModule().isWholeModule(), apply, refF, newSubstMap,
           apply.getFunction()->getSerializedKind(),
           /*ConvertIndirectToDirect=*/ true,
-          /*dropUnusedArguments=*/ false, nullptr);
+          /*dropUnusedArguments=*/ false);
 
       if (layoutReInfo.getSpecializedType() == reInfo.getSpecializedType()) {
         layoutMatches.push_back(
@@ -3354,6 +3359,7 @@ void swift::trySpecializeApplyOfGeneric(
                            Apply.getSubstitutionMap(), serializedKind,
                            /*ConvertIndirectToDirect=*/ true,
                            /*dropUnusedArguments=*/ true,
+                           isMandatory,
                            &ORE);
   if (!ReInfo.canBeSpecialized())
     return;

--- a/lib/SILOptimizer/Utils/OptimizerBridging.cpp
+++ b/lib/SILOptimizer/Utils/OptimizerBridging.cpp
@@ -191,7 +191,8 @@ OptionalBridgedFunction BridgedPassContext::specializeFunction(BridgedFunction f
   ReabstractionInfo ReInfo(mod->getSwiftModule(), mod->isWholeModule(),
                            ApplySite(), origFunc, subs, origFunc->getSerializedKind(),
                            convertIndirectToDirect,
-                           /*dropUnusedArguments=*/false);
+                           /*dropUnusedArguments=*/false,
+                           isMandatory);
 
   if (!ReInfo.canBeSpecialized()) {
     return {nullptr};

--- a/test/embedded/generic-error.swift
+++ b/test/embedded/generic-error.swift
@@ -23,3 +23,45 @@ public class C: P {
     self.init(y: z)  // expected-error {{cannot call an initializer or static method, which is defined as default protocol method, from a class method or initializer}}
   }
 }
+
+struct S<T> {
+  let t: T
+}
+
+func infiniteSpecialization<T>(t: T, i : Int) {
+  if i > 0 {
+    infiniteSpecialization(t: S(t: t), i: i - 1) // expected-error {{cannot specialize generic function or default protocol method in this context}}
+  }
+}
+
+public func callInfiniteSpecialization() {
+  infiniteSpecialization(t: S(t: 1), i: 10) // expected-note {{generic specialization called here}}
+}
+
+protocol P2 {
+  associatedtype A : P2
+
+  var a: A { get }
+}
+
+struct S3 : P2 {
+  let a: S2
+}
+
+struct S2 : P2 {
+  let a: S1
+}
+
+struct S1 : P2 {
+  var a: S1 { return self }
+}
+
+func finiteSpecialization<T: P2>(t: T, i : Int) {
+  if i > 0 {
+    finiteSpecialization(t: t.a, i: i - 1)
+  }
+}
+
+public func callFiniteSpecialization() {
+  finiteSpecialization(t: S3(a: S2(a: S1())), i: 10)
+}


### PR DESCRIPTION
Generic function specialization can up in infinite loops, e.g.
```
   func f<T>(t: T) { f(t: S<T>()) }
```

However, if there is a specialization loop and it is not infinite, we should allow this in embedded swift. Still, there is a hard coded limit, but increasing the limit from 1 to 10 should be good enough for real world scenarios.

Fixes a false "cannot specialize generic function" error in embedded swift. https://github.com/swiftlang/swift/issues/89291
rdar://177541698
