### PR TITLE
RedundantLoadElimination: insert a `drop_deinit` when splitting stores of types with a deinit

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/OptUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/OptUtils.swift
@@ -669,11 +669,28 @@ extension StoreInst {
     let builder = Builder(after: self, context)
     let type = source.type
     if type.isStruct {
-      if (type.nominal as! StructDecl).hasUnreferenceableStorage {
+      let structDecl = type.nominal as! StructDecl
+      if structDecl.hasUnreferenceableStorage {
         return
       }
       if parentFunction.hasOwnership && source.ownership != .none {
-        let destructure = builder.createDestructureStruct(struct: source)
+        let v: Value
+        if structDecl.valueTypeDestructor != nil {
+          if storeOwnership == .assign {
+            // We must not drop the original (implicit) destroy of the `store [assign]`.
+            // Therefore replace the `store [assign]` with a `destroy_addr` - `store [init]` pair
+            // and then split the `store [init]`.
+            builder.createDestroyAddr(address: destination)
+            let initStore = builder.createStore(source: source, destination: destination, ownership: .initialize)
+            context.erase(instruction: self)
+            initStore.trySplit(context)
+            return
+          }
+          v = builder.createDropDeinit(of: source)
+        } else {
+          v = source
+        }
+        let destructure = builder.createDestructureStruct(struct: v)
         for (fieldIdx, fieldValue) in destructure.results.enumerated() {
           let destFieldAddr = builder.createStructElementAddr(structAddress: destination, fieldIndex: fieldIdx)
           builder.createStore(source: fieldValue, destination: destFieldAddr, ownership: splitOwnership(for: fieldValue))

--- a/SwiftCompilerSources/Sources/SIL/Builder.swift
+++ b/SwiftCompilerSources/Sources/SIL/Builder.swift
@@ -880,6 +880,11 @@ public struct Builder {
     let fixLifetime = bridged.createFixLifetime(operand.bridged)
     return notifyNew(fixLifetime.getAs(FixLifetimeInst.self))
   }
+
+  public func createDropDeinit(of value: Value) -> DropDeinitInst {
+    let dropDeinit = bridged.createDropDeinit(value.bridged)
+    return notifyNew(dropDeinit.getAs(DropDeinitInst.self))
+  }
 }
 
 //===----------------------------------------------------------------------===//

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -1478,6 +1478,7 @@ struct BridgedBuilder{
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedInstruction createMakeBorrow(BridgedValue referent) const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedInstruction createMakeAddrBorrow(BridgedValue referent) const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedInstruction createFixLifetime(BridgedValue operand) const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedInstruction createDropDeinit(BridgedValue operand) const;
 
   SWIFT_IMPORT_UNSAFE void destroyCapturedArgs(BridgedInstruction partialApply) const;
 };

--- a/include/swift/SIL/SILBridgingImpl.h
+++ b/include/swift/SIL/SILBridgingImpl.h
@@ -3082,6 +3082,10 @@ BridgedInstruction BridgedBuilder::createFixLifetime(BridgedValue operand) const
   return {unbridged().createFixLifetime(regularLoc(), operand.getSILValue())};
 }
 
+BridgedInstruction BridgedBuilder::createDropDeinit(BridgedValue operand) const {
+  return {unbridged().createDropDeinit(regularLoc(), operand.getSILValue())};
+}
+
 //===----------------------------------------------------------------------===//
 //                            BridgedBasicBlockSet
 //===----------------------------------------------------------------------===//

--- a/test/SILOptimizer/redundant_load_elim_ossa.sil
+++ b/test/SILOptimizer/redundant_load_elim_ossa.sil
@@ -141,6 +141,12 @@ public struct S {
   var e: Optional<String>
 }
 
+struct NC : ~Copyable {
+  let a: AnyObject
+  let b: Int
+
+  deinit
+}
 
 sil_global @total : $Int32
 
@@ -1752,5 +1758,41 @@ bb5:
   destroy_value %12
   %r = tuple ()
   return %r
+}
+
+// CHECK-LABEL: sil [ossa] @split_non_copyable_with_deinit :
+// CHECK:         [[DD:%.*]] = drop_deinit %0
+// CHECK-NEXT:     = destructure_struct [[DD]]
+// CHECK-LABEL: } // end sil function 'split_non_copyable_with_deinit'
+sil [ossa] @split_non_copyable_with_deinit : $@convention(thin) (@owned NC, @owned AnyObject) -> @owned AnyObject {
+bb0(%0 : @owned $NC, %1 : @owned $AnyObject):
+  %2 = alloc_stack $NC
+  store %0 to [init] %2
+  %4 = struct_element_addr %2, #NC.a
+  %5 = load [take] %4
+  store %1 to [init] %4
+  destroy_addr %2
+  dealloc_stack %2
+  return %5
+}
+
+// CHECK-LABEL: sil [ossa] @split_non_copyable_assign_with_deinit :
+// CHECK:         destroy_addr %1
+// CHECK:         [[DD:%.*]] = drop_deinit %0
+// CHECK-NEXT:    ([[A:%.*]], [[B:%.*]]) = destructure_struct [[DD]]
+// CHECK:         [[BADDR:%.*]] = struct_element_addr %1 : $*NC, #NC.b
+// CHECK:         store [[B]] to [trivial] [[BADDR]]
+// CHECK:           = struct_element_addr %1 : $*NC, #NC.a
+// CHECK:         [[AADDR:%.*]] = struct_element_addr %1 : $*NC, #NC.a
+// CHECK:         store %2 to [init] [[AADDR]]
+// CHECK:         return [[A]]
+// CHECK-LABEL: } // end sil function 'split_non_copyable_assign_with_deinit'
+sil [ossa] @split_non_copyable_assign_with_deinit : $@convention(thin) (@owned NC, @inout NC, @owned AnyObject) -> @owned AnyObject {
+bb0(%0 : @owned $NC, %1 : $*NC, %2 : @owned $AnyObject):
+  store %0 to [assign] %1
+  %4 = struct_element_addr %1, #NC.a
+  %5 = load [take] %4
+  store %2 to [init] %4
+  return %5
 }
 


### PR DESCRIPTION
A `drop_deinit` is required to make the SIL verifier happy.

Fixes a SIL verifier crash
rdar://176373062