### PR TITLE
Opaque Values: Fix tests crashing on isInitialized assertion

### DIFF
--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -4876,7 +4876,7 @@ static void emitBorrowedLValueRecursive(SILGenFunction &SGF,
   // Load if necessary.
   if (value.getType().isAddress()) {
     if (!param.isIndirectInGuaranteed() || !SGF.silConv.useLoweredAddresses()) {
-      if (value.getType().isMoveOnly()) {
+      if (value.getType().isMoveOnly() && !param.isIndirectInGuaranteed()) {
         // We use a formal access load [copy] instead of a load_borrow here
         // since in the case where we have a second parameter that is consuming,
         // we want to avoid emitting invalid SIL and instead allow for the
@@ -4888,6 +4888,12 @@ static void emitBorrowedLValueRecursive(SILGenFunction &SGF,
         // guaranteed to be within the access scope meaning that it is easy for
         // SIL passes like the move only checker to convert this to a
         // load_borrow.
+        //
+        // For @in_guaranteed destinations the callee borrows, so emit a real
+        // load_borrow — emitting load [copy] there would be a copy of a
+        // ~Copyable value that the move-only checker can't always remove
+        // (in particular under opaque values, AddressLowering reifies it as
+        // alloc_stack + copy_addr [init] before the checker runs).
         value = SGF.B.createFormalAccessLoadCopy(loc, value);
         // Strip off the cleanup from the load [copy] since we do not want the
         // cleanup to be forwarded.

--- a/lib/SILOptimizer/Mandatory/AddressLowering.cpp
+++ b/lib/SILOptimizer/Mandatory/AddressLowering.cpp
@@ -417,6 +417,38 @@ static bool isStoreCopy(SILValue value) {
   return true;
 }
 
+/// Check if this is a copy that matches the following pattern:
+///   %source = <guaranteed ownership>
+///   %value = copy_value %source             // users: %mark
+///   %mark = mark_unresolved_noncopyable_value [no_consume_or_assign] %value
+///   where no users of %mark are copy_value instructions.
+static bool isMarkUnresolvedCopy(SILValue value) {
+  auto *copyInst = dyn_cast<CopyValueInst>(value);
+  if (!copyInst)
+    return false;
+
+  if (!copyInst->hasOneUse())
+    return false;
+
+  auto *user = value->getSingleUse()->getUser();
+  auto *inst = dyn_cast<MarkUnresolvedNonCopyableValueInst>(user);
+  if (!inst)
+    return false;
+
+  auto source = copyInst->getOperand();
+  if (source->getOwnershipKind() != OwnershipKind::Guaranteed)
+    return false;
+  if (inst->getCheckKind() !=
+      MarkUnresolvedNonCopyableValueInst::CheckKind::NoConsumeOrAssign)
+    return false;
+  // Reject if the mark has any copy_value users.
+  for (auto *use : inst->getUses()) {
+    if (isa<CopyValueInst>(use->getUser()))
+      return false;
+  }
+  return true;
+}
+
 void ValueStorageMap::insertValue(SILValue value, SILValue storageAddress) {
   assert(!stableStorage && "cannot grow stable storage map");
 
@@ -963,6 +995,8 @@ static Operand *getProjectedDefOperand(SILValue value) {
     return &cast<BeginBorrowInst>(value)->getOperandRef();
 
   case ValueKind::CopyValueInst:
+    if (isMarkUnresolvedCopy(value))
+      return &cast<CopyValueInst>(value)->getOperandRef();
     if (isStoreCopy(value))
       return &cast<CopyValueInst>(value)->getOperandRef();
 
@@ -1913,7 +1947,7 @@ SILValue AddressMaterialization::materializeDefProjection(SILValue origValue) {
     llvm_unreachable("Unexpected projection from def.");
 
   case ValueKind::CopyValueInst:
-    assert(isStoreCopy(origValue));
+    assert(isStoreCopy(origValue) || isMarkUnresolvedCopy(origValue));
     return pass.getMaterializedAddress(
         cast<CopyValueInst>(origValue)->getOperand());
 
@@ -3632,6 +3666,22 @@ protected:
 
   // Copy from an opaque source operand.
   void visitCopyValueInst(CopyValueInst *copyInst) {
+    // For the isMarkUnresolvedCopy pattern, the mark's destroy_value is the
+    // artificial cleanup of the +1 owned form. Now that the copy and mark
+    // both project onto the guaranteed source's storage, that destroy would
+    // lower to a destroy_addr of borrowed storage — illegal. Erase it.
+    if (isMarkUnresolvedCopy(copyInst)) {
+      auto *mark = cast<MarkUnresolvedNonCopyableValueInst>(
+          copyInst->getSingleUse()->getUser());
+      SmallVector<DestroyValueInst *, 4> destroys;
+      for (auto *use : mark->getConsumingUses()) {
+        if (auto *d = dyn_cast<DestroyValueInst>(use->getUser()))
+          destroys.push_back(d);
+      }
+      for (auto *d : destroys)
+        pass.deleter.forceDelete(d);
+    }
+
     SILValue srcVal = copyInst->getOperand();
     SILValue srcAddr = pass.valueStorageMap.getStorage(srcVal).storageAddress;
 

--- a/lib/SILOptimizer/Mandatory/AddressLowering.cpp
+++ b/lib/SILOptimizer/Mandatory/AddressLowering.cpp
@@ -703,8 +703,11 @@ static void convertDirectToIndirectFunctionArgs(AddressLoweringState &pass) {
       arg->replaceAllUsesWith(load);
       assert(!pass.valueStorageMap.contains(arg));
 
-      arg = arg->getParent()->replaceFunctionArgument(
+      auto *oldArg = cast<SILFunctionArgument>(arg);
+      auto *newArg = arg->getParent()->replaceFunctionArgument(
           arg->getIndex(), addrType, OwnershipKind::None, arg->getDecl());
+      newArg->copyFlags(oldArg);
+      arg = newArg;
 
       assert(isa<LoadInst>(load) || isa<LoadBorrowInst>(load));
       load->setOperand(0, arg);

--- a/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
@@ -1222,8 +1222,13 @@ addressBeginsInitialized(MarkUnresolvedNonCopyableValueInst *address) {
                  << "Adding stacked mark over init-permitting parent as "
                     "init!\n");
       return true;
-    case MarkUnresolvedNonCopyableValueInst::CheckKind::Invalid:
     case MarkUnresolvedNonCopyableValueInst::CheckKind::NoConsumeOrAssign:
+      // A read-only parent doesn't itself perform init, so the inner mark is
+      // initialized iff the parent is. This shape arises under opaque values
+      // when address lowering elides a `store_borrow` between two stacked
+      // `[no_consume_or_assign]` marks.
+      return addressBeginsInitialized(parentMark);
+    case MarkUnresolvedNonCopyableValueInst::CheckKind::Invalid:
     case MarkUnresolvedNonCopyableValueInst::CheckKind::
         AssignableButNotConsumable:
       break;

--- a/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
@@ -245,6 +245,7 @@
 #include "swift/SIL/MemAccessUtils.h"
 #include "swift/SIL/OSSACompleteLifetime.h"
 #include "swift/SIL/OwnershipUtils.h"
+#include "swift/SIL/Projection.h"
 #include "swift/SIL/PrunedLiveness.h"
 #include "swift/SIL/SILArgument.h"
 #include "swift/SIL/SILArgumentConvention.h"
@@ -496,8 +497,14 @@ static bool visitScopeEndsRequiringInit(
 static bool isCopyableValue(SILValue value) {
   if (value->getType().isMoveOnly())
     return false;
-  if (isa<MoveOnlyWrapperToCopyableAddrInst>(value))
+  if (auto *unwrap = dyn_cast<MoveOnlyWrapperToCopyableAddrInst>(value)) {
+    // If the operand is an address projection (e.g. struct_element_addr),
+    // the copy reads only a subfield rather than the entire @noImplicitCopy
+    // storage — treat as a regular copyable read.
+    if (Projection::isAddressProjection(unwrap->getOperand()))
+      return true;
     return false;
+  }
   return true;
 }
 

--- a/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
@@ -1152,11 +1152,46 @@ addressBeginsInitialized(MarkUnresolvedNonCopyableValueInst *address) {
 
   // Assume a strict check of a temporary or formal access is initialized
   // before the check.
-  if (auto *asi = dyn_cast<AllocStackInst>(stripAccessMarkers(operand));
-      asi && address->isStrict()) {
-    LLVM_DEBUG(llvm::dbgs()
-               << "Adding strict-marked alloc_stack as init!\n");
-    return true;
+  if (auto *asi = dyn_cast<AllocStackInst>(stripAccessMarkers(operand))) {
+    if (address->isStrict()) {
+      LLVM_DEBUG(llvm::dbgs() << "Adding strict-marked alloc_stack as init!\n");
+      return true;
+    }
+    // An alloc_stack initialized by a nearby `copy_addr [init]` writing
+    // into it:
+    //   %asi = alloc_stack $T
+    //   ...      (only read-only / no-effect instructions)
+    //   copy_addr _ to [init] $asi
+    //   ...      (only read-only / no-effect instructions)
+    //   %mark = mark_unresolved_noncopyable_value_inst %asi
+    // The initialization cannot be reached transitively via the use-chain
+    // since it is not applied to the mark itself. We allow benign
+    // intervening instructions but reject anything that may write to
+    // memory other than the recognized init.
+    if (asi->getParent() == address->getParent()) {
+      bool seenInit = false;
+      for (auto it = std::next(asi->getIterator()); &*it != address; ++it) {
+        SILInstruction *inst = &*it;
+        if (auto *cai = dyn_cast<CopyAddrInst>(inst);
+            cai && cai->getDest() == asi && cai->isInitializationOfDest()) {
+          seenInit = true;
+          continue;
+        }
+        // Conservative approach here given that we do not check whether this
+        // instruction applies to the address we are interested in. This would
+        // require alias analysis.
+        if (inst->mayWriteToMemory()) {
+          seenInit = false;
+          break;
+        }
+      }
+      if (seenInit) {
+        LLVM_DEBUG(llvm::dbgs() << "Adding alloc_stack initialized by "
+                                   "copy_addr [init] (no intervening "
+                                   "writes) as init!\n");
+        return true;
+      }
+    }
   }
 
   // SILGen sometimes emits two stacked `mark_unresolved_non_copyable_value`s

--- a/test/SILGen/opaque_values_silgen.swift
+++ b/test/SILGen/opaque_values_silgen.swift
@@ -947,3 +947,25 @@ func copy_expr_generic<T>(_ t: T)  {
   eat_generic(copy t)
 }
 func eat_generic<T>(_ t: consuming T) {}
+
+struct LoadBorrowNC: ~Copyable {
+  var x: Int = 0
+}
+final class LoadBorrowHolder {
+  var inner: LoadBorrowNC
+  init(inner: consuming LoadBorrowNC) { self.inner = inner }
+}
+func load_borrow_in_guaranteed_borrowMe<T: ~Copyable>(_ n: borrowing T) {}
+
+// CHECK-LABEL: sil{{.*}} [ossa] @load_borrow_in_guaranteed_caller :
+// CHECK:         ref_element_addr {{%[^,]+}}, #LoadBorrowHolder.inner
+// CHECK:         mark_unresolved_non_copyable_value [no_consume_or_assign]
+// CHECK:         [[BORROWED:%[^,]+]] = load_borrow
+// CHECK-NOT:     load [copy]
+// CHECK:         apply {{.*}}<LoadBorrowNC>([[BORROWED]])
+// CHECK:         end_borrow [[BORROWED]]
+// CHECK-LABEL: } // end sil function 'load_borrow_in_guaranteed_caller'
+@_silgen_name("load_borrow_in_guaranteed_caller")
+func load_borrow_in_guaranteed_caller(_ h: LoadBorrowHolder) {
+  load_borrow_in_guaranteed_borrowMe(h.inner)
+}

--- a/test/SILOptimizer/address_lowering.sil
+++ b/test/SILOptimizer/address_lowering.sil
@@ -2912,6 +2912,15 @@ bb0(%0 : @guaranteed $NCG<T>):
   return %4 : $()
 }
 
+// CHECK-LABEL: sil hidden [ossa] @test_no_implicit_copy_arg_flag_preserved :
+// CHECK:       bb0(%0 : @noImplicitCopy $*T):
+// CHECK-LABEL: } // end sil function 'test_no_implicit_copy_arg_flag_preserved'
+sil hidden [ossa] @test_no_implicit_copy_arg_flag_preserved : $@convention(thin) <T> (@in_guaranteed T) -> () {
+bb0(%0 : @noImplicitCopy @guaranteed $T):
+  %1 = tuple ()
+  return %1 : $()
+}
+
 // CHECK-LABEL: sil [ossa] @test_open_pack_element_dominance : $@convention(thin) <each T> (@pack_guaranteed Pack{repeat each T}, Builtin.Word) -> () {
 // CHECK:       bb0([[PACK:%[^,]+]] : 
 // CHECK-SAME:      [[RAW_INDEX:%[^,]+]] :

--- a/test/SILOptimizer/address_lowering.sil
+++ b/test/SILOptimizer/address_lowering.sil
@@ -87,6 +87,10 @@ class TestGeneric<T> {
   @_borrowed @_hasStorage var borrowedGeneric: T { get set }
 }
 
+struct NCG<T> : ~Copyable {
+  var value: T
+}
+
 precedencegroup ComparisonPrecedence {
   assignment: true
   associativity: right
@@ -2701,6 +2705,31 @@ exit:
   return %retval : $()
 }
 
+sil hidden [ossa] @borrow_use_NCG : $@convention(thin) <T> (@in_guaranteed NCG<T>) -> () {
+bb0(%0 : @guaranteed $NCG<T>):
+  %1 = tuple ()
+  return %1 : $()
+}
+
+// CHECK-LABEL: sil hidden [ossa] @test_elide_borrow_copy :
+// CHECK:       bb0(%0 : $*NCG<T>):
+// CHECK-NOT:     alloc_stack
+// CHECK-NOT:     copy_addr
+// CHECK:         mark_unresolved_non_copyable_value [no_consume_or_assign] %0 : $*NCG<T>
+// CHECK-NOT:     destroy_addr
+// CHECK-NOT:     dealloc_stack
+// CHECK-LABEL: } // end sil function 'test_elide_borrow_copy'
+sil hidden [ossa] @test_elide_borrow_copy : $@convention(thin) <T> (@in_guaranteed NCG<T>) -> () {
+bb0(%0 : @guaranteed $NCG<T>):
+  %1 = copy_value %0 : $NCG<T>
+  %2 = mark_unresolved_non_copyable_value [no_consume_or_assign] %1 : $NCG<T>
+  %f = function_ref @borrow_use_NCG : $@convention(thin) <T> (@in_guaranteed NCG<T>) -> ()
+  %3 = apply %f<T>(%2) : $@convention(thin) <T> (@in_guaranteed NCG<T>) -> ()
+  destroy_value %2 : $NCG<T>
+  %4 = tuple ()
+  return %4 : $()
+}
+
 // Verify that the init_enum_data_addr instruction is created before its first
 // use.  Although the opaque values are visited in forward order, their
 // uses are visited at the same time.  At that point, addresses are
@@ -2858,6 +2887,29 @@ entry(%tmo : @guaranteed $@moveOnly T):
   apply %borrowT<T>(%t) : $@convention(thin) <T> (@in_guaranteed T) -> ()
   %retval = tuple ()
   return %retval : $()
+}
+
+// Don't apply the isMarkUnresolvedCopy def-projection optimization when the
+// mark has a transitive copy_value user. visitCopyValueInst's deletion of
+// the mark's destroy_value would shrink the mark's pruned-liveness boundary
+// and invalidate the isStoreCopy classification of the transitive copy.
+// This input is malformed (the move-only checker will diagnose the consume
+// in a later pass), but address-lowering must not crash on it.
+//
+// CHECK-LABEL: sil hidden [ossa] @test_no_elide_borrow_copy_with_transitive_copy :
+// CHECK-LABEL: } // end sil function 'test_no_elide_borrow_copy_with_transitive_copy'
+sil hidden [ossa] @test_no_elide_borrow_copy_with_transitive_copy : $@convention(thin) <T> (@in_guaranteed NCG<T>) -> () {
+bb0(%0 : @guaranteed $NCG<T>):
+  %1 = copy_value %0 : $NCG<T>
+  %2 = mark_unresolved_non_copyable_value [no_consume_or_assign] %1 : $NCG<T>
+  %stack = alloc_stack $NCG<T>
+  %3 = copy_value %2 : $NCG<T>
+  store %3 to [init] %stack : $*NCG<T>
+  destroy_addr %stack : $*NCG<T>
+  dealloc_stack %stack : $*NCG<T>
+  destroy_value %2 : $NCG<T>
+  %4 = tuple ()
+  return %4 : $()
 }
 
 // CHECK-LABEL: sil [ossa] @test_open_pack_element_dominance : $@convention(thin) <each T> (@pack_guaranteed Pack{repeat each T}, Builtin.Word) -> () {

--- a/test/SILOptimizer/moveonly_addresschecker.sil
+++ b/test/SILOptimizer/moveonly_addresschecker.sil
@@ -968,3 +968,33 @@ bb0(%0 : $*MyBufferView<T>):
   %t = tuple ()
   return %t : $()
 }
+
+public struct ContainerC {
+  var a: CopyableKlass
+  var b: CopyableKlass
+}
+
+// CHECK-LABEL: sil hidden [ossa] @test_copy_addr_through_wrapper_projection :
+// CHECK:         [[FIELD_A:%[^,]+]] = struct_element_addr {{%[^,]+}}, #ContainerC.a
+// CHECK:         [[UNWRAP:%[^,]+]] = moveonlywrapper_to_copyable_addr [[FIELD_A]]
+// CHECK:         copy_addr [[UNWRAP]] to [init]
+// CHECK-NOT:     copy_addr [take] [[UNWRAP]]
+// CHECK:         destroy_addr {{%[^,]+}} : $*@moveOnly ContainerC
+// CHECK-LABEL: } // end sil function 'test_copy_addr_through_wrapper_projection'
+sil hidden [ossa] @test_copy_addr_through_wrapper_projection : $@convention(thin) (@in ContainerC) -> @owned CopyableKlass {
+bb0(%0 : $*ContainerC):
+  %v = load [take] %0 : $*ContainerC
+  %wv = copyable_to_moveonlywrapper [owned] %v : $ContainerC
+  %1 = alloc_stack $@moveOnly ContainerC
+  %mark = mark_unresolved_non_copyable_value [consumable_and_assignable] %1 : $*@moveOnly ContainerC
+  store %wv to [init] %mark : $*@moveOnly ContainerC
+  %field_a = struct_element_addr %mark : $*@moveOnly ContainerC, #ContainerC.a
+  %field_a_unwrap = moveonlywrapper_to_copyable_addr %field_a : $*@moveOnly CopyableKlass
+  %result_slot = alloc_stack $CopyableKlass
+  copy_addr %field_a_unwrap to [init] %result_slot : $*CopyableKlass
+  %result = load [take] %result_slot : $*CopyableKlass
+  dealloc_stack %result_slot : $*CopyableKlass
+  destroy_addr %mark : $*@moveOnly ContainerC
+  dealloc_stack %1 : $*@moveOnly ContainerC
+  return %result : $CopyableKlass
+}

--- a/test/SILOptimizer/moveonly_addresschecker.sil
+++ b/test/SILOptimizer/moveonly_addresschecker.sil
@@ -969,6 +969,20 @@ bb0(%0 : $*MyBufferView<T>):
   return %t : $()
 }
 
+// The inner mark of of two stacked `[no_consume_or_assign]` marks must be 
+// recognized as initialized when the outer mark is.
+//
+// CHECK-LABEL: sil hidden [ossa] @test_stacked_no_consume_or_assign_inherits_parent_init :
+// CHECK:       bb0({{%[^,]+}} : $*NonTrivialStruct):
+// CHECK-LABEL: } // end sil function 'test_stacked_no_consume_or_assign_inherits_parent_init'
+sil hidden [ossa] @test_stacked_no_consume_or_assign_inherits_parent_init : $@convention(thin) (@in_guaranteed NonTrivialStruct) -> () {
+bb0(%0 : $*NonTrivialStruct):
+  %outer = mark_unresolved_non_copyable_value [no_consume_or_assign] %0 : $*NonTrivialStruct
+  %inner = mark_unresolved_non_copyable_value [no_consume_or_assign] %outer : $*NonTrivialStruct
+  %t = tuple ()
+  return %t : $()
+}
+
 public struct ContainerC {
   var a: CopyableKlass
   var b: CopyableKlass

--- a/test/SILOptimizer/moveonly_addresschecker.sil
+++ b/test/SILOptimizer/moveonly_addresschecker.sil
@@ -900,3 +900,71 @@ bb4(%reborrow : @reborrow $Optional<@callee_guaranteed () -> ()>, %maybe : @owne
   %retval = tuple ()
   return %retval : $()
 }
+
+// CHECK-LABEL: sil hidden [ossa] @test_init_by_adjacent_copy_addr :
+// CHECK:       bb0(%0 : $*MyBufferView<T>):
+// CHECK:         [[STK:%[^,]+]] = alloc_stack $MyBufferView<T>
+// CHECK:         copy_addr [take] %0 to [init] [[STK]]
+// CHECK:         destroy_addr [[STK]]
+// CHECK:         dealloc_stack [[STK]]
+// CHECK-LABEL: } // end sil function 'test_init_by_adjacent_copy_addr'
+sil hidden [ossa] @test_init_by_adjacent_copy_addr : $@convention(thin) <T> (@in MyBufferView<T>) -> () {
+bb0(%0 : $*MyBufferView<T>):
+  %1 = alloc_stack $MyBufferView<T>
+  copy_addr [take] %0 to [init] %1 : $*MyBufferView<T>
+  %2 = mark_unresolved_non_copyable_value [consumable_and_assignable] %1 : $*MyBufferView<T>
+  destroy_addr %2 : $*MyBufferView<T>
+  dealloc_stack %1 : $*MyBufferView<T>
+  %3 = tuple ()
+  return %3 : $()
+}
+
+// Allow specific instructions  (read-only or no memory effect — `debug_value`
+// here) to intervene between `alloc_stack`, the `copy_addr [init]` filling it,
+// and the mark. Anything that may write to memory between them would bail the
+// walk.
+// CHECK-LABEL: sil hidden [ossa] @test_init_by_copy_addr_with_benign_interveners :
+// CHECK:       bb0(%0 : $*MyBufferView<T>):
+// CHECK:         [[STK:%[^,]+]] = alloc_stack $MyBufferView<T>
+// CHECK:         copy_addr [take] %0 to [init] [[STK]]
+// CHECK:         destroy_addr [[STK]]
+// CHECK:         dealloc_stack [[STK]]
+// CHECK-LABEL: } // end sil function 'test_init_by_copy_addr_with_benign_interveners'
+sil hidden [ossa] @test_init_by_copy_addr_with_benign_interveners : $@convention(thin) <T> (@in MyBufferView<T>) -> () {
+bb0(%0 : $*MyBufferView<T>):
+  %1 = alloc_stack $MyBufferView<T>
+  debug_value %0 : $*MyBufferView<T>, var, name "x", argno 1, expr op_deref
+  copy_addr [take] %0 to [init] %1 : $*MyBufferView<T>
+  debug_value %1 : $*MyBufferView<T>, var, name "y", argno 2, expr op_deref
+  %2 = mark_unresolved_non_copyable_value [consumable_and_assignable] %1 : $*MyBufferView<T>
+  destroy_addr %2 : $*MyBufferView<T>
+  dealloc_stack %1 : $*MyBufferView<T>
+  %3 = tuple ()
+  return %3 : $()
+}
+
+// CHECK-LABEL: sil hidden [ossa] @test_consume_let_via_take :
+// CHECK:       bb0(%0 : $*MyBufferView<T>):
+// CHECK:         [[OUTER:%[^,]+]] = alloc_stack [lexical] [var_decl] $MyBufferView<T>
+// CHECK:         copy_addr [take] %0 to [init] [[OUTER]]
+// CHECK:         [[INNER:%[^,]+]] = alloc_stack $MyBufferView<T>
+// CHECK:         copy_addr [take] [[OUTER]] to [init] [[INNER]]
+// CHECK:         destroy_addr [[INNER]]
+// CHECK:         dealloc_stack [[INNER]]
+// CHECK:         dealloc_stack [[OUTER]]
+// CHECK-LABEL: } // end sil function 'test_consume_let_via_take'
+sil hidden [ossa] @test_consume_let_via_take : $@convention(thin) <T> (@in MyBufferView<T>) -> () {
+bb0(%0 : $*MyBufferView<T>):
+  %1 = alloc_stack [lexical] [var_decl] $MyBufferView<T>, let, name "q"
+  %2 = mark_unresolved_non_copyable_value [consumable_and_assignable] %1 : $*MyBufferView<T>
+  copy_addr [take] %0 to [init] %2 : $*MyBufferView<T>
+  %3 = alloc_stack $MyBufferView<T>
+  copy_addr %2 to [init] %3 : $*MyBufferView<T>
+  %4 = mark_unresolved_non_copyable_value [consumable_and_assignable] %3 : $*MyBufferView<T>
+  destroy_addr %4 : $*MyBufferView<T>
+  dealloc_stack %3 : $*MyBufferView<T>
+  destroy_addr %2 : $*MyBufferView<T>
+  dealloc_stack %1 : $*MyBufferView<T>
+  %t = tuple ()
+  return %t : $()
+}

--- a/test/SILOptimizer/moveonly_addresschecker.swift
+++ b/test/SILOptimizer/moveonly_addresschecker.swift
@@ -5,6 +5,14 @@
 // RUN: -enable-experimental-feature BuiltinModule \
 // RUN: -Xllvm -sil-print-final-ossa-module %s | %FileCheck %s
 
+// RUN: %target-swift-emit-sil -sil-verify-all -verify \
+// RUN: -enable-experimental-feature NoImplicitCopy \
+// RUN: -enable-experimental-feature MoveOnlyClasses \
+// RUN: -enable-experimental-feature Lifetimes \
+// RUN: -enable-experimental-feature BuiltinModule \
+// RUN: -enable-sil-opaque-values \
+// RUN: -Xllvm -sil-print-final-ossa-module %s | %FileCheck %s
+
 // RUN: %target-swift-emit-sil -O -sil-verify-all -verify \
 // RUN: -enable-experimental-feature NoImplicitCopy \
 // RUN: -enable-experimental-feature MoveOnlyClasses \

--- a/test/SILOptimizer/moveonly_addresschecker_branch_order.swift
+++ b/test/SILOptimizer/moveonly_addresschecker_branch_order.swift
@@ -1,4 +1,5 @@
 //RUN: %target-swift-frontend -emit-sil -verify %s
+//RUN: %target-swift-frontend -emit-sil -verify -enable-sil-opaque-values %s
 
 @_silgen_name("cond")
 func cond() -> Bool

--- a/test/SILOptimizer/moveonly_addresschecker_convert_function_onstack.sil
+++ b/test/SILOptimizer/moveonly_addresschecker_convert_function_onstack.sil
@@ -1,4 +1,5 @@
 // RUN: %target-sil-opt -sil-print-types -module-name moveonly -sil-move-only-address-checker -enable-sil-verify-all %s | %FileCheck %s
+// RUN: %target-sil-opt -sil-print-types -module-name moveonly -address-lowering -sil-move-only-address-checker -enable-sil-verify-all -enable-sil-opaque-values %s | %FileCheck %s
 
 // Regression test for a crash in
 // `CopiedLoadBorrowEliminationVisitor::visitUse` (in

--- a/test/SILOptimizer/moveonly_addresschecker_destructure_through_deinit_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_addresschecker_destructure_through_deinit_diagnostics.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-emit-sil -sil-verify-all -verify -enable-experimental-feature MoveOnlyClasses -enable-experimental-feature MoveOnlyTuples %s
+// RUN: %target-swift-emit-sil -sil-verify-all -verify -enable-experimental-feature MoveOnlyClasses -enable-experimental-feature MoveOnlyTuples -enable-sil-opaque-values %s
 
 // REQUIRES: swift_feature_MoveOnlyClasses
 // REQUIRES: swift_feature_MoveOnlyTuples

--- a/test/SILOptimizer/moveonly_addresschecker_di_interactions.swift
+++ b/test/SILOptimizer/moveonly_addresschecker_di_interactions.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-emit-sil -sil-verify-all -verify -enable-experimental-feature NoImplicitCopy %s
+// RUN: %target-swift-emit-sil -sil-verify-all -verify -enable-experimental-feature NoImplicitCopy -enable-sil-opaque-values %s
 
 // REQUIRES: swift_feature_NoImplicitCopy
 

--- a/test/SILOptimizer/moveonly_addresschecker_diagnostics_library_evolution.swift
+++ b/test/SILOptimizer/moveonly_addresschecker_diagnostics_library_evolution.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-emit-sil -enable-experimental-feature NoImplicitCopy -sil-verify-all -verify -enable-library-evolution %s
+// RUN: %target-swift-emit-sil -enable-experimental-feature NoImplicitCopy -sil-verify-all -verify -enable-library-evolution -enable-sil-opaque-values %s
 
 // REQUIRES: swift_feature_NoImplicitCopy
 

--- a/test/SILOptimizer/moveonly_addresschecker_diagnostics_partial_consume_internal_imports.swift
+++ b/test/SILOptimizer/moveonly_addresschecker_diagnostics_partial_consume_internal_imports.swift
@@ -21,6 +21,13 @@
 // RUN:     -sil-verify-all                                         \
 // RUN:     -I %t
 
+// RUN: %target-swift-frontend                                      \
+// RUN:     %t/Downstream.swift                                     \
+// RUN:     -emit-sil -verify                                       \
+// RUN:     -sil-verify-all                                         \
+// RUN:     -enable-sil-opaque-values                               \
+// RUN:     -I %t
+
 //--- Library.swift
 
 public struct Source: ~Copyable {

--- a/test/SILOptimizer/moveonly_addresschecker_diagnostics_partial_consume_ufi.swift
+++ b/test/SILOptimizer/moveonly_addresschecker_diagnostics_partial_consume_ufi.swift
@@ -6,6 +6,12 @@
 // RUN:     -module-name Library
 // RUN: %target-swift-frontend                                      \
 // RUN:     %s                                                      \
+// RUN:     -emit-sil -verify -verify-additional-prefix fragile-    \
+// RUN:     -sil-verify-all                                         \
+// RUN:     -enable-sil-opaque-values                               \
+// RUN:     -module-name Library
+// RUN: %target-swift-frontend                                      \
+// RUN:     %s                                                      \
 // RUN:     -emit-sil -verify -verify-additional-prefix resilient-  \
 // RUN:     -sil-verify-all                                         \
 // RUN:     -enable-library-evolution                               \

--- a/test/SILOptimizer/moveonly_addresschecker_diagnostics_resilient.swift
+++ b/test/SILOptimizer/moveonly_addresschecker_diagnostics_resilient.swift
@@ -15,6 +15,14 @@
 // RUN:     -sil-verify-all                                         \
 // RUN:     -I %t
 
+// RUN: %target-swift-frontend                                      \
+// RUN:     %t/Client.swift                                         \
+// RUN:     -emit-sil -verify                                       \
+// RUN:     -debug-diagnostic-names                                 \
+// RUN:     -sil-verify-all                                         \
+// RUN:     -enable-sil-opaque-values                               \
+// RUN:     -I %t
+
 
 //--- Library.swift
 

--- a/test/SILOptimizer/moveonly_addresschecker_diagnostics_without_partial.swift
+++ b/test/SILOptimizer/moveonly_addresschecker_diagnostics_without_partial.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-emit-sil -O -sil-verify-all -verify -enable-experimental-feature NoImplicitCopy -enable-experimental-feature MoveOnlyClasses %s
+// RUN: %target-swift-emit-sil -O -sil-verify-all -verify -enable-experimental-feature NoImplicitCopy -enable-experimental-feature MoveOnlyClasses -enable-sil-opaque-values %s
 
 // REQUIRES: swift_feature_MoveOnlyClasses
 // REQUIRES: swift_feature_NoImplicitCopy

--- a/test/SILOptimizer/moveonly_addresschecker_diagnostics_without_partial_reinit.swift
+++ b/test/SILOptimizer/moveonly_addresschecker_diagnostics_without_partial_reinit.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-emit-sil -O -sil-verify-all -verify -enable-experimental-feature NoImplicitCopy -enable-experimental-feature MoveOnlyClasses %s
+// RUN: %target-swift-emit-sil -O -sil-verify-all -verify -enable-experimental-feature NoImplicitCopy -enable-experimental-feature MoveOnlyClasses -enable-sil-opaque-values %s
 
 // REQUIRES: swift_feature_MoveOnlyClasses
 // REQUIRES: swift_feature_NoImplicitCopy

--- a/test/SILOptimizer/moveonly_addresschecker_stacked_marks.sil
+++ b/test/SILOptimizer/moveonly_addresschecker_stacked_marks.sil
@@ -1,4 +1,5 @@
 // RUN: %target-sil-opt -sil-print-types -module-name moveonly -sil-move-only-address-checker -enable-sil-verify-all %s | %FileCheck %s
+// RUN: %target-sil-opt -sil-print-types -module-name moveonly -address-lowering -sil-move-only-address-checker -enable-sil-verify-all -enable-sil-opaque-values %s | %FileCheck %s
 
 // Regression test for an assertion in
 // `MoveOnlyAddressCheckerPImpl::performSingleCheck` → ... →

--- a/test/SILOptimizer/moveonly_addresschecker_trivial_read.swift
+++ b/test/SILOptimizer/moveonly_addresschecker_trivial_read.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -emit-sil -verify %s
+// RUN: %target-swift-frontend -emit-sil -verify -enable-sil-opaque-values %s
 
 func use(_: Int32) {}
 

--- a/test/SILOptimizer/moveonly_addresschecker_tsan.swift
+++ b/test/SILOptimizer/moveonly_addresschecker_tsan.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-emit-sil -sanitize=thread -sil-verify-all -verify -enable-experimental-feature NoImplicitCopy -enable-experimental-feature MoveOnlyClasses %s -Xllvm -sil-print-final-ossa-module | %FileCheck %s
+// RUN: %target-swift-emit-sil -sanitize=thread -sil-verify-all -verify -enable-experimental-feature NoImplicitCopy -enable-experimental-feature MoveOnlyClasses -enable-sil-opaque-values %s -Xllvm -sil-print-final-ossa-module | %FileCheck %s
 // RUN: %target-swift-emit-sil -sanitize=thread -O -sil-verify-all -verify -enable-experimental-feature NoImplicitCopy -enable-experimental-feature MoveOnlyClasses %s
 // REQUIRES: OS=macosx
 // REQUIRES: swift_feature_MoveOnlyClasses

--- a/test/SILOptimizer/opaque_values_Onone.swift
+++ b/test/SILOptimizer/opaque_values_Onone.swift
@@ -132,7 +132,7 @@ func duplicate_with_int2<Value>(value: Value) -> ((Value, Value), Int) {
 // CHECK:         apply {{%[^,]+}}<(Int, (Value, (Value, (Value, Int), Value)), Int)>({{%[^,]+}}, [[CONVERTED]])
 // CHECK-LABEL: } // end sil function 'duplicate_with_int3'
 // CHECK-LABEL: sil private @$s19opaque_values_Onone19duplicate_with_int35valueSi_x_x_x_SitxttSitx_tlFSi_x_x_x_SitxttSityXEfU_ {{.*}} {
-// CHECK:       {{bb[0-9]+}}([[OUT_ADDR:%[^,]+]] : $*(Int, (Value, (Value, (Value, Int), Value)), Int), [[IN_ADDR:%[^,]+]] : $*Value):
+// CHECK:       {{bb[0-9]+}}([[OUT_ADDR:%[^,]+]] : $*(Int, (Value, (Value, (Value, Int), Value)), Int), [[IN_ADDR:%[^,]+]] : @closureCapture $*Value):
 // CHECK:         [[OUT_1_ADDR:%[^,]+]] = tuple_element_addr [[OUT_ADDR]] : $*(Int, (Value, (Value, (Value, Int), Value)), Int), 1
 // CHECK:         [[OUT_1_0_ADDR:%[^,]+]] = tuple_element_addr [[OUT_1_ADDR]] : $*(Value, (Value, (Value, Int), Value)), 0
 // CHECK:         copy_addr [[IN_ADDR]] to [init] [[OUT_1_0_ADDR]]

--- a/test/SILOptimizer/opaque_values_moveonly.swift
+++ b/test/SILOptimizer/opaque_values_moveonly.swift
@@ -1,0 +1,73 @@
+// RUN: %target-swift-frontend -enable-sil-opaque-values -emit-sil %s
+
+// Regression test for the following cases:
+
+// SILGen emits the `consume q` operator on a `let` binding of a generic
+// `~Copyable` type as an SSA chain:
+//
+//     %loaded = load [copy] %q_storage
+//     %moved  = move_value [allows_diagnostics] %loaded
+//     %mark   = mark_unresolved_non_copyable_value [consumable_and_assignable]
+//                                                  %moved
+//
+// Under opaque values, AddressLowering materializes this into a fresh
+// `alloc_stack` initialized by `copy_addr [init]` and then marked. The
+// resulting mark sits on a slot whose initialization writes to the slot
+// itself rather than through the mark, so MoveOnlyAddressChecker's
+// `GatherUsesVisitor` (walking transitively from the mark) can't reach
+// the init via the use-chain.
+
+struct U<T>: ~Copyable {
+  var x: T
+}
+
+func test<T>(_ a: T) {
+  let q = U<T>(x: a)
+  _ = consume q
+}
+
+// SILGen emits a +1 owned form for `borrowing` self of `@noImplicitCopy`
+// loadable copyable types so the move-only object checker can analyze the
+// mark on owned storage:
+//
+//     %wrap = copyable_to_moveonlywrapper [guaranteed] %self
+//     %copy = copy_value %wrap
+//     %mark = mark_unresolved_non_copyable_value [no_consume_or_assign] %copy
+//     ... uses ...
+//     destroy_value %mark
+//
+// Under opaque values, AddressLowering recognizes this `copy_value → mark
+// [no_consume_or_assign]` pattern with a guaranteed source and projects both
+// onto the source's storage, erasing the artificial `destroy_value` cleanup.
+// Without that projection the destroy_value would either lower to a
+// `destroy_addr` of borrowed storage (illegal SIL) or survive as a consuming
+// boundary use of the +1 owned mark and trip the move-only address checker's
+// `[no_consume_or_assign]` diagnostic.
+
+struct Loaner<T> {
+  let value: T
+  var property: T { borrowing get { value } }
+  borrowing func method() -> T { value }
+}
+
+// Passing a stored `~Copyable` value as a `borrowing` argument produces, under
+// opaque values, a value-form copy that AddressLowering reifies into
+// `alloc_stack` + `copy_addr [init]` immediately before a
+// `mark_unresolved_non_copyable_value [no_consume_or_assign]`. The move-only
+// address checker could not establish def-initialization for that mark and
+// hit the assertion.
+
+struct NC: ~Copyable {
+  var x: Int = 0
+}
+
+final class Holder {
+  var inner: NC
+  init(i: consuming NC) { self.inner = i }
+}
+
+func borrowMe<T: ~Copyable>(_ n: borrowing T) {}
+
+func caller(_ h: Holder) {
+  borrowMe(h.inner)
+}


### PR DESCRIPTION
Resolves rdar://178449077.
> Assertion failed: (isInitialized()), function finishedInitializationOfDefs, file FieldSensitivePrunedLiveness.h, line 1324.


The assertion is triggered for some tests when run with Opaque Values mode enabled due to some of the SIL formed by the AddressLowering pass not being recognized by the MoveChecker.