### PR TITLE
[cxx-interop] Enable Cxx overlay on Embedded

### DIFF
--- a/stdlib/public/CMakeLists.txt
+++ b/stdlib/public/CMakeLists.txt
@@ -75,16 +75,6 @@ endif()
 
 add_subdirectory(SwiftShims/swift/shims)
 add_subdirectory(CommandLineSupport)
-if(SWIFT_ENABLE_EXPERIMENTAL_CXX_INTEROP)
-  add_subdirectory(Cxx)
-else()
-  # SwiftCompilerSources rely on C++ interop, specifically on being able to
-  # import the C++ standard library into Swift. On Linux, this is only possible
-  # when using the modulemap that Swift provides for libstdc++. Make sure we
-  # include the libstdc++ modulemap into the build even when not building
-  # C++ interop modules.
-  add_subdirectory(Cxx/libstdcxx)
-endif()
 add_subdirectory(Threading)
 
 # This static library is shared across swiftCore and swiftRemoteInspection
@@ -347,6 +337,17 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
 
   message(STATUS "Building Embedded Swift standard libraries for targets: ${triples}")
   message(STATUS "")
+endif()
+
+if(SWIFT_ENABLE_EXPERIMENTAL_CXX_INTEROP)
+  add_subdirectory(Cxx)
+else()
+  # SwiftCompilerSources rely on C++ interop, specifically on being able to
+  # import the C++ standard library into Swift. On Linux, this is only possible
+  # when using the modulemap that Swift provides for libstdc++. Make sure we
+  # include the libstdc++ modulemap into the build even when not building
+  # C++ interop modules.
+  add_subdirectory(Cxx/libstdcxx)
 endif()
 
 if(SWIFT_BUILD_STDLIB)

--- a/stdlib/public/Cxx/CMakeLists.txt
+++ b/stdlib/public/Cxx/CMakeLists.txt
@@ -6,7 +6,7 @@ if(SWIFT_STDLIB_SUPPORT_BACK_DEPLOYMENT)
   list(APPEND SWIFT_CXX_DEPS copy-legacy-layouts)
 endif()
 
-add_swift_target_library(swiftCxx STATIC NO_LINK_NAME IS_STDLIB IS_SWIFT_ONLY
+set(SWIFT_CXX_SOURCES
     CxxConvertibleToBool.swift
     CxxConvertibleToCollection.swift
     CxxDictionary.swift
@@ -19,8 +19,9 @@ add_swift_target_library(swiftCxx STATIC NO_LINK_NAME IS_STDLIB IS_SWIFT_ONLY
     CxxVector.swift
     CxxSpan.swift
     UnsafeCxxIterators.swift
+)
 
-    SWIFT_COMPILE_FLAGS ${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS} ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
+set(SWIFT_CXX_FLAGS
     -cxx-interoperability-mode=default
     -enable-experimental-feature BuiltinModule
     -enable-experimental-feature AllowUnsafeAttribute
@@ -31,6 +32,13 @@ add_swift_target_library(swiftCxx STATIC NO_LINK_NAME IS_STDLIB IS_SWIFT_ONLY
     # This module should not pull in the C++ standard library, so we disable it explicitly.
     # For functionality that depends on the C++ stdlib, use C++ stdlib overlay (`swiftstd` module).
     -Xcc -nostdinc++
+)
+
+add_swift_target_library(swiftCxx STATIC NO_LINK_NAME IS_STDLIB IS_SWIFT_ONLY
+    ${SWIFT_CXX_SOURCES}
+
+    SWIFT_COMPILE_FLAGS ${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS} ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
+    ${SWIFT_CXX_FLAGS}
 
     DEPLOYMENT_VERSION_OSX ${COMPATIBILITY_MINIMUM_DEPLOYMENT_VERSION_OSX}
     DEPLOYMENT_VERSION_IOS ${COMPATIBILITY_MINIMUM_DEPLOYMENT_VERSION_IOS}
@@ -44,6 +52,25 @@ add_swift_target_library(swiftCxx STATIC NO_LINK_NAME IS_STDLIB IS_SWIFT_ONLY
     INSTALL_IN_COMPONENT compiler
     INSTALL_BINARY_SWIFTMODULE NON_DARWIN_ONLY
     INSTALL_WITH_SHARED)
+
+if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
+  add_custom_target(embedded-cxx)
+  add_dependencies(embedded-libraries embedded-cxx)
+
+  # On Embedded targets, the overlay is installed along with the stdlib. This
+  # is different from regular Swift, where the C++ interop overlays are
+  # installed along with the toolchain due to being version-locked to the
+  # compiler.
+  add_embedded_swift_target_library(embedded-cxx swiftCxx
+      STATIC NO_LINK_NAME IS_STDLIB IS_FRAGILE
+      ${SWIFT_CXX_SOURCES}
+
+      SWIFT_COMPILE_FLAGS ${SWIFT_CXX_FLAGS}
+
+      DEPENDS embedded-stdlib
+      INSTALL_IN_COMPONENT stdlib
+  )
+endif()
 
 add_subdirectory(libstdcxx)
 add_subdirectory(std)

--- a/stdlib/public/Cxx/cxxshim/CMakeLists.txt
+++ b/stdlib/public/Cxx/cxxshim/CMakeLists.txt
@@ -86,6 +86,8 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
   swift_install_in_component(FILES libcxxshim.modulemap libcxxshim.h libcxxstdlibshim.h
                              DESTINATION "lib/swift/embedded"
                              COMPONENT compiler)
+
+  add_dependencies(embedded-libraries cxxshim-embedded)
 endif()
 
 add_custom_target(libcxxshim_modulemap DEPENDS ${libcxxshim_modulemap_target_list})

--- a/test/embedded/Inputs/cxx-std-vector.h
+++ b/test/embedded/Inputs/cxx-std-vector.h
@@ -1,0 +1,5 @@
+#include <vector>
+
+using VectorOfInt = std::vector<int>;
+
+inline VectorOfInt makeVector() { return {1, 2, 3, 4}; }

--- a/test/embedded/Inputs/module.modulemap
+++ b/test/embedded/Inputs/module.modulemap
@@ -1,3 +1,8 @@
 module StructAsOptionSet {
   header "struct-as-option-set.h"
 }
+
+module CxxStdVector {
+  header "cxx-std-vector.h"
+  requires cplusplus
+}

--- a/test/embedded/cxx-std-vector.swift
+++ b/test/embedded/cxx-std-vector.swift
@@ -1,0 +1,23 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -I %S/Inputs %s -enable-experimental-feature Embedded -cxx-interoperability-mode=default -wmo -c -o %t/main.o
+// RUN: %target-clang %target-clang-resource-dir-opt %t/main.o -lc++ %target-embedded-posix-shim -o %t/a.out -dead_strip
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: executable_test
+// REQUIRES: optimized_stdlib
+// REQUIRES: OS=macosx
+// REQUIRES: swift_feature_Embedded
+
+import Cxx
+import CxxStdlib
+import CxxStdVector
+
+let v = makeVector()
+for elem in v {
+  print(elem)
+}
+// CHECK: 1
+// CHECK-NEXT: 2
+// CHECK-NEXT: 3
+// CHECK-NEXT: 4


### PR DESCRIPTION
This adds CMake build logic that builds the Cxx overlay module for Embedded Swift.

This enables, for instance, iteration over C++ containers with a for-in loop in Embedded Swift.

rdar://142904657