### PR TITLE
Packs: Replace `@pack_element` when all elements are the same concrete type

### DIFF
--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -3197,6 +3197,28 @@ void SILCloner<ImplClass>::visitOpenPackElementInst(
   auto newIndexValue = getOpValue(Inst->getIndexOperand());
   auto origEnv = Inst->getOpenedGenericEnvironment();
 
+  auto registerConcreteReplacements =
+      [&](const llvm::SmallDenseMap<CanType, CanType, 4> &elementReplacements) {
+        // Build a SubstitutionMap for the full opened element signature that
+        // maps outer params via origContextSubs and element params to concrete
+        // types.
+        auto genericSig = origEnv->getGenericSignature();
+        auto newContextSubs =
+            getOpSubstitutionMap(origEnv->getOuterSubstitutions());
+        auto subsMap = SubstitutionMap::get(
+            genericSig,
+            [&](SubstitutableType *type) -> Type {
+              auto *gp = cast<GenericTypeParamType>(type);
+              auto canGP = gp->getCanonicalType();
+              auto it = elementReplacements.find(canGP);
+              if (it != elementReplacements.end())
+                return it->second;
+              return Type(type).subst(newContextSubs);
+            },
+            LookUpConformanceInModule());
+        registerConcreteLocalArchetypeMapping(origEnv, subsMap);
+      };
+
   // If the structural pack index is statically known, and the pack element at
   // that index is scalar, we can resolve element archetypes to concrete types
   // and eliminate this instruction entirely.
@@ -3232,26 +3254,67 @@ void SILCloner<ImplClass>::visitOpenPackElementInst(
           elementReplacements[interfaceTy] = element->getCanonicalType();
         });
 
-    // Build a SubstitutionMap for the full opened element signature that
-    // maps outer params via origContextSubs and element params to concrete
-    // types.
-    auto genericSig = origEnv->getGenericSignature();
-    auto newContextSubs =
-        getOpSubstitutionMap(origEnv->getOuterSubstitutions());
-    auto subsMap = SubstitutionMap::get(
-        genericSig,
-        [&](SubstitutableType *type) -> Type {
-          auto *gp = cast<GenericTypeParamType>(type);
-          auto canGP = gp->getCanonicalType();
-          auto it = elementReplacements.find(canGP);
-          if (it != elementReplacements.end())
-            return it->second;
-          return Type(type).subst(newContextSubs);
-        },
-        LookUpConformanceInModule());
-    registerConcreteLocalArchetypeMapping(origEnv, subsMap);
+    registerConcreteReplacements(elementReplacements);
     return;
   }
+
+  // If, for each opened pack, every element is the same concrete type, we can
+  // resolve each element archetype to that single type, even when the pack
+  // index is dynamic.
+  bool replacedWithSingleElement = [&] {
+    bool allPacksHaveOneConcreteType = true;
+    llvm::SmallDenseMap<CanType, CanType, 4> elementReplacements;
+
+    origEnv->forEachPackElementBinding(
+        [&](ElementArchetypeType *elementArchetype, PackType *origPack) {
+          if (!allPacksHaveOneConcreteType)
+            return;
+
+          CanPackType pack =
+              cast<PackType>(getOpASTType(origPack->getCanonicalType()));
+
+          // No pack elements: There is no single type to register for
+          // substitution.
+          if (pack.getElementTypes().size() == 0) {
+            allPacksHaveOneConcreteType = false;
+            return;
+          }
+
+          auto firstElement = pack.getElementType(0);
+          if (firstElement->is<PackExpansionType>()) {
+            allPacksHaveOneConcreteType = false;
+            return;
+          }
+
+          // We only need to check whether the other elements of the pack are
+          // equal to the first. We know the first element is not a pack
+          // expansion, so this will catch any of them, as well as other
+          // concrete types.
+          if (llvm::any_of(pack.getElementTypes().slice(1),
+                           [&](const auto &elementType) {
+                             return elementType != firstElement;
+                           })) {
+            allPacksHaveOneConcreteType = false;
+            return;
+          }
+
+          // All pack elements have the same concrete type as the first:
+          // register that type as the replacement for this pack's element
+          // archetype.
+          auto interfaceTy =
+              elementArchetype->getInterfaceType()->getCanonicalType();
+          elementReplacements[interfaceTy] = firstElement;
+        });
+
+    if (!allPacksHaveOneConcreteType)
+      return false;
+
+    registerConcreteReplacements(elementReplacements);
+    return true;
+  }();
+
+  if (replacedWithSingleElement)
+    return;
 
   // We need to make a new opened-element environment.  This is *not*
   // a refinement of the contextual environment of the new insertion

--- a/test/SILOptimizer/pack_specialization.swift
+++ b/test/SILOptimizer/pack_specialization.swift
@@ -146,3 +146,30 @@ public func applyDirect<each T>(input: repeat each T, op: (repeat each T) -> Int
 public func testDirect() -> Int32 {
     applyDirect(input: 27, 27) { ($0 + $1) }
 }
+
+// Eliminating @pack_element types when a pack loop cannot be unrolled.
+// This only works if every element of the pack is the same type.
+//
+// This test produces a loop with 33 iterations, exceeding the upper bound in
+// the LoopUnroll pass.
+
+
+func addTogetherInlinable<each A: Numeric>(xs: repeat each A) -> (repeat each A) {
+  return (repeat (each xs + each xs))
+}
+
+// CHECK:         define {{.*}} void @"$s19pack_specialization13addTogether33s5Int32V_A32DtyF"(ptr {{.*}} sret(<{ %Ts5Int32V, %Ts5Int32V, %Ts5Int32V, %Ts5Int32V, %Ts5Int32V, %Ts5Int32V, %Ts5Int32V, %Ts5Int32V, %Ts5Int32V, %Ts5Int32V, %Ts5Int32V, %Ts5Int32V, %Ts5Int32V, %Ts5Int32V, %Ts5Int32V, %Ts5Int32V, %Ts5Int32V, %Ts5Int32V, %Ts5Int32V, %Ts5Int32V, %Ts5Int32V, %Ts5Int32V, %Ts5Int32V, %Ts5Int32V, %Ts5Int32V, %Ts5Int32V, %Ts5Int32V, %Ts5Int32V, %Ts5Int32V, %Ts5Int32V, %Ts5Int32V, %Ts5Int32V, %Ts5Int32V }>) {{.*}} %0) {{.*}} {
+// CHECK:           [[INPUT_PACK:%[0-9]+]] =  alloca [33 x ptr]
+// CHECK-COUNT-33:  alloca %Ts5Int32V
+// CHECK:           store ptr {{.*}}, ptr [[INPUT_PACK]]
+// CHECK:           [[DYN_IDX:%[0-9]+]] = phi
+// CHECK-NEXT:      [[DYN_ADDR:%[0-9]+]] = getelementptr {{.*}} [[INPUT_PACK]]
+// CHECK-NEXT:      [[ELEM_ADDR:%[0-9]+]] = load ptr, ptr [[DYN_ADDR]]
+// CHECK-NEXT:      [[ELEM:%[0-9]+]] = load i32, ptr [[ELEM_ADDR]]
+// CHECK-NEXT:      [[DOUBLED:%[0-9]+]] = call { i32, i1 } @llvm.sadd.with.overflow.i32(i32 [[ELEM]], i32 [[ELEM]])
+// CHECK-NOT:       @llvm.sadd.with.overflow.i32
+// CHECK:         }
+
+public func addTogether33() -> (Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32) {
+  return addTogetherInlinable(xs: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33)
+}

--- a/test/SILOptimizer/variadic_generics.sil
+++ b/test/SILOptimizer/variadic_generics.sil
@@ -192,3 +192,145 @@ bb0:
   return %ret : $()
 }
 
+// Dynamic pack index, all pack elements are the same type: pack element types
+// can be eliminated.
+
+// CHECK-LABEL: sil @test_dynamic_open_pack_element_single_type
+// CHECK:         [[TUPLE:%[0-9]+]] = alloc_stack $(Float, Float)
+// CHECK:         [[INDEX:%.*]] = dynamic_pack_index %0 of $Pack{Float, Float}
+// CHECK-NOT:     open_pack_element
+// CHECK:         tuple_pack_element_addr [[INDEX]] of [[TUPLE]] : $*(Float, Float) as $*Float
+sil @test_dynamic_open_pack_element_single_type : $(Builtin.Word) -> () {
+bb0(%i : $Builtin.Word):
+  %tuple = alloc_stack $(Float, Float)
+  %fn = function_ref @tuple_pack_element : $@convention(thin) <each T> (Builtin.Word, @inout (repeat each T)) -> ()
+  apply %fn<Pack{Float, Float}>(%i, %tuple) : $@convention(thin) <each T> (Builtin.Word, @inout (repeat each T)) -> ()
+  dealloc_stack %tuple : $*(Float, Float)
+  %ret = tuple ()
+  return %ret : $()
+}
+
+// CHECK-LABEL: sil @test_dynamic_open_pack_element_single_type_2
+// CHECK:         [[TUPLE:%[0-9]+]] = alloc_stack $(Int, Int)
+// CHECK:         [[INDEX:%.*]] = dynamic_pack_index %0 of $Pack{Int, Int}
+// CHECK-NOT:     open_pack_element
+// CHECK:         tuple_pack_element_addr [[INDEX]] of [[TUPLE]] : $*(Int, Int) as $*Int
+sil @test_dynamic_open_pack_element_single_type_2 : $(Builtin.Word) -> () {
+bb0(%i : $Builtin.Word):
+  %tuple = alloc_stack $(Int, Int)
+  %fn = function_ref @tuple_pack_element : $@convention(thin) <each T> (Builtin.Word, @inout (repeat each T)) -> ()
+  apply %fn<Pack{Int, Int}>(%i, %tuple) : $@convention(thin) <each T> (Builtin.Word, @inout (repeat each T)) -> ()
+  dealloc_stack %tuple : $*(Int, Int)
+  %ret = tuple ()
+  return %ret : $()
+}
+
+sil [ossa] [heuristic_always_inline] @tuple_pack_element_2 : $@convention(thin) <each T, each U where (repeat (each T, each U)): Any> (Builtin.Word, @inout (repeat each T), @inout(repeat each U)) -> () {
+bb0(%i: $Builtin.Word, %tupleT : $*(repeat each T), %tupleU : $*(repeat each U)):
+  %index = dynamic_pack_index %i of $Pack{repeat each T}
+  %tok = open_pack_element %index of <each A, each B where (repeat (each A, each B)): Any> at <Pack{repeat each T}, Pack{repeat each U}>, shape $each A, uuid "01234567-89AB-CDEF-0123-000000000013"
+  %0 = tuple_pack_element_addr %index of %tupleT : $*(repeat each T) as $*@pack_element("01234567-89AB-CDEF-0123-000000000013") A
+  %1 = tuple_pack_element_addr %index of %tupleU : $*(repeat each U) as $*@pack_element("01234567-89AB-CDEF-0123-000000000013") B
+  %ret = tuple ()
+  return %ret : $()
+}
+
+// CHECK-LABEL: sil @test_dynamic_open_pack_element_multiple_packs_1 : $@convention(thin) (Builtin.Word) -> () {
+// CHECK:         [[TUPT:%[0-9]+]] = alloc_stack $(Int, Int)
+// CHECK:         [[TUPU:%[0-9]+]] = alloc_stack $(Float, Float)
+// CHECK:         [[INDEX:%[0-9]+]] = dynamic_pack_index %0 of $Pack{Int, Int}
+// CHECK-NOT:     open_pack_element
+// CHECK:         tuple_pack_element_addr [[INDEX]] of [[TUPT]] : $*(Int, Int) as $*Int
+// CHECK:         tuple_pack_element_addr [[INDEX]] of [[TUPU]] : $*(Float, Float) as $*Float
+// CHECK-LABEL: } // end sil function 'test_dynamic_open_pack_element_multiple_packs_1'
+sil @test_dynamic_open_pack_element_multiple_packs_1 : $@convention(thin) (Builtin.Word) -> () {
+bb0(%i : $Builtin.Word):
+  %tupleT = alloc_stack $(Int, Int)
+  %tupleU = alloc_stack $(Float, Float)
+  %fn = function_ref @tuple_pack_element_2 : $@convention(thin) <each T, each U where (repeat (each T, each U)): Any> (Builtin.Word, @inout (repeat each T), @inout(repeat each U)) -> ()
+  apply %fn<Pack{Int, Int}, Pack{Float, Float}>(%i, %tupleT, %tupleU) : $@convention(thin) <each T, each U where (repeat (each T, each U)): Any> (Builtin.Word, @inout (repeat each T), @inout(repeat each U)) -> ()
+  dealloc_stack %tupleU : $*(Float, Float)
+  dealloc_stack %tupleT : $*(Int, Int)
+  %ret = tuple ()
+  return %ret : $()
+}
+
+// CHECK-LABEL: sil @test_dynamic_open_pack_element_multiple_packs_2 : $@convention(thin) (Builtin.Word) -> () {
+// CHECK:         [[TUPT:%[0-9]+]] = alloc_stack $(Int, Float)
+// CHECK:         [[TUPU:%[0-9]+]] = alloc_stack $(Float, Float)
+// CHECK:         [[INDEX:%[0-9]+]] = dynamic_pack_index %0 of $Pack{Int, Float}
+// CHECK:         open_pack_element
+// CHECK:         tuple_pack_element_addr [[INDEX]] of [[TUPT]] : $*(Int, Float) as $*@pack_element
+// CHECK:         tuple_pack_element_addr [[INDEX]] of [[TUPU]] : $*(Float, Float) as $*@pack_element
+// CHECK-LABEL: } // end sil function 'test_dynamic_open_pack_element_multiple_packs_2'
+sil @test_dynamic_open_pack_element_multiple_packs_2 : $@convention(thin) (Builtin.Word) -> () {
+bb0(%i : $Builtin.Word):
+  %tupleT = alloc_stack $(Int, Float)
+  %tupleU = alloc_stack $(Float, Float)
+  %fn = function_ref @tuple_pack_element_2 : $@convention(thin) <each T, each U where (repeat (each T, each U)): Any> (Builtin.Word, @inout (repeat each T), @inout(repeat each U)) -> ()
+  apply %fn<Pack{Int, Float}, Pack{Float, Float}>(%i, %tupleT, %tupleU) : $@convention(thin) <each T, each U where (repeat (each T, each U)): Any> (Builtin.Word, @inout (repeat each T), @inout(repeat each U)) -> ()
+  dealloc_stack %tupleU : $*(Float, Float)
+  dealloc_stack %tupleT : $*(Int, Float)
+  %ret = tuple ()
+  return %ret : $()
+}
+
+// CHECK-LABEL: sil @test_dynamic_open_pack_element_multiple_packs_3 : $@convention(thin) (Builtin.Word) -> () {
+// CHECK:         [[TUPT:%[0-9]+]] = alloc_stack $(Int, Int)
+// CHECK:         [[TUPU:%[0-9]+]] = alloc_stack $(Float, Int)
+// CHECK:         [[INDEX:%[0-9]+]] = dynamic_pack_index %0 of $Pack{Int, Int}
+// CHECK:         open_pack_element
+// CHECK:         tuple_pack_element_addr [[INDEX]] of [[TUPT]] : $*(Int, Int) as $*@pack_element
+// CHECK:         tuple_pack_element_addr [[INDEX]] of [[TUPU]] : $*(Float, Int) as $*@pack_element
+// CHECK-LABEL: } // end sil function 'test_dynamic_open_pack_element_multiple_packs_3'
+sil @test_dynamic_open_pack_element_multiple_packs_3 : $@convention(thin) (Builtin.Word) -> () {
+bb0(%i : $Builtin.Word):
+  %tupleT = alloc_stack $(Int, Int)
+  %tupleU = alloc_stack $(Float, Int)
+  %fn = function_ref @tuple_pack_element_2 : $@convention(thin) <each T, each U where (repeat (each T, each U)): Any> (Builtin.Word, @inout (repeat each T), @inout(repeat each U)) -> ()
+  apply %fn<Pack{Int, Int}, Pack{Float, Int}>(%i, %tupleT, %tupleU) : $@convention(thin) <each T, each U where (repeat (each T, each U)): Any> (Builtin.Word, @inout (repeat each T), @inout(repeat each U)) -> ()
+  dealloc_stack %tupleU : $*(Float, Int)
+  dealloc_stack %tupleT : $*(Int, Int)
+  %ret = tuple ()
+  return %ret : $()
+}
+
+// CHECK-LABEL: sil @test_dynamic_open_pack_element_multiple_packs_4 : $@convention(thin) <each T, each U where (repeat (each T, each U)) : Any> (Builtin.Word) -> () {
+// CHECK:         [[TUPT:%[0-9]+]] = alloc_stack $(repeat each T)
+// CHECK:         [[TUPU:%[0-9]+]] = alloc_stack $(repeat each U)
+// CHECK:         [[INDEX:%[0-9]+]] = dynamic_pack_index %0 of $Pack{repeat each T}
+// CHECK:         open_pack_element
+// CHECK:         tuple_pack_element_addr [[INDEX]] of [[TUPT]] : $*(repeat each T) as $*@pack_element
+// CHECK:         tuple_pack_element_addr [[INDEX]] of [[TUPU]] : $*(repeat each U) as $*@pack_element
+// CHECK-LABEL: } // end sil function 'test_dynamic_open_pack_element_multiple_packs_4'
+sil @test_dynamic_open_pack_element_multiple_packs_4 : $@convention(thin) <each T, each U where (repeat (each T, each U)) : Any> (Builtin.Word) -> () {
+bb0(%i : $Builtin.Word):
+  %tupleT = alloc_stack $(repeat each T)
+  %tupleU = alloc_stack $(repeat each U)
+  %fn = function_ref @tuple_pack_element_2 : $@convention(thin) <each T, each U where (repeat (each T, each U)): Any> (Builtin.Word, @inout (repeat each T), @inout(repeat each U)) -> ()
+  apply %fn<Pack{repeat each T}, Pack{repeat each U}>(%i, %tupleT, %tupleU) : $@convention(thin) <each T, each U where (repeat (each T, each U)): Any> (Builtin.Word, @inout (repeat each T), @inout(repeat each U)) -> ()
+  dealloc_stack %tupleU : $*(repeat each U)
+  dealloc_stack %tupleT : $*(repeat each T)
+  %ret = tuple ()
+  return %ret : $()
+}
+
+// CHECK-LABEL: sil @test_dynamic_open_pack_element_multiple_packs_5 : $@convention(thin) <each T, each U where (repeat (each T, each U)) : Any> (Builtin.Word) -> () {
+// CHECK:         [[TUPT:%[0-9]+]] = alloc_stack $(Int, repeat each T)
+// CHECK:         [[TUPU:%[0-9]+]] = alloc_stack $(Float, repeat each U)
+// CHECK:         [[INDEX:%[0-9]+]] = dynamic_pack_index %0 of $Pack{Int, repeat each T}
+// CHECK:         open_pack_element
+// CHECK:         tuple_pack_element_addr [[INDEX]] of [[TUPT]] : $*(Int, repeat each T) as $*@pack_element
+// CHECK:         tuple_pack_element_addr [[INDEX]] of [[TUPU]] : $*(Float, repeat each U) as $*@pack_element
+// CHECK-LABEL: } // end sil function 'test_dynamic_open_pack_element_multiple_packs_5'
+sil @test_dynamic_open_pack_element_multiple_packs_5 : $@convention(thin) <each T, each U where (repeat (each T, each U)) : Any> (Builtin.Word) -> () {
+bb0(%i : $Builtin.Word):
+  %tupleT = alloc_stack $(Int, repeat each T)
+  %tupleU = alloc_stack $(Float, repeat each U)
+  %fn = function_ref @tuple_pack_element_2 : $@convention(thin) <each T, each U where (repeat (each T, each U)): Any> (Builtin.Word, @inout (repeat each T), @inout(repeat each U)) -> ()
+  apply %fn<Pack{Int, repeat each T}, Pack{Float, repeat each U}>(%i, %tupleT, %tupleU) : $@convention(thin) <each T, each U where (repeat (each T, each U)): Any> (Builtin.Word, @inout (repeat each T), @inout(repeat each U)) -> ()
+  dealloc_stack %tupleU : $*(Float, repeat each U)
+  dealloc_stack %tupleT : $*(Int, repeat each T)
+  %ret = tuple ()
+  return %ret : $()
+}


### PR DESCRIPTION
If every element of a pack is the same concrete type, we can replace a `@pack_element` type opened from it with that concrete type. This allows the bodies of some loops over packs to be specialized, even when they can't be unrolled.
<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
