### PR TITLE
[rbi] Replace "task-isolated" with "code in the current task" in diagnostics

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -1048,10 +1048,10 @@ NOTE(regionbasedisolation_named_value_used_after_explicit_sending, none,
       "%0 used after being passed as a 'sending' parameter; Later uses could race",
       (Identifier))
 NOTE(regionbasedisolation_named_isolated_closure_yields_race, none,
-      "%select{%1 |}0%2 is captured by a %3 closure. %3 uses in closure may race against later %4 uses",
-      (bool, StringRef, Identifier, StringRef, StringRef))
+      "%select{%1 |}0%2 is captured by a %3 closure. %3 uses in closure may race against %select{later %4 uses|code in the current isolation context}5",
+      (bool, StringRef, Identifier, StringRef, StringRef, bool))
 NOTE(regionbasedisolation_named_isolated_closure_yields_race_mutable, none,
-     "%0 closure captures reference to mutable %1 which remains modifiable by %select{%3 code|code in the current task}2", (StringRef, Identifier, bool, StringRef))
+     "%0 closure captures reference to mutable %1 which remains modifiable by %select{%3 code|code in the current isolation context}2", (StringRef, Identifier, bool, StringRef))
 
 NOTE(regionbasedisolation_typed_use_after_sending, none,
       "Passing value of non-Sendable type %0 as a 'sending' argument risks causing races in between local and caller code",
@@ -1064,19 +1064,19 @@ NOTE(regionbasedisolation_typed_use_after_sending_callee, none,
 // Sending Never Sendable Emitter
 
 NOTE(regionbasedisolation_named_send_never_sendable, none,
-      "sending %select{%2 |}0%1 to %3 callee risks causing data races between %3 and %4 uses",
-      (bool, Identifier, StringRef, StringRef, StringRef))
+      "sending %select{%2 |}0%1 to %3 callee risks causing data races between %3 %select{|code }5and %select{%4 uses|code in the current isolation context}5",
+      (bool, Identifier, StringRef, StringRef, StringRef, bool))
 NOTE(regionbasedisolation_named_send_never_sendable_callee, none,
-      "sending %select{%2 |}0%1 to %3 %kind4 risks causing data races between %3 and %5 uses",
-      (bool, Identifier, StringRef, StringRef, const ValueDecl *, StringRef))
+      "sending %select{%2 |}0%1 to %3 %kind4 risks causing data races between %3 %select{|code }6and %select{%5 uses|code in the current isolation context}6",
+      (bool, Identifier, StringRef, StringRef, const ValueDecl *, StringRef, bool))
 
 NOTE(regionbasedisolation_named_send_into_sending_param, none,
      "%select{%1 |}0%2 is passed as a 'sending' parameter; Uses in callee may race with "
-     "later %1 uses",
-     (bool, StringRef, Identifier))
+     "%select{later %1 uses|code in the current isolation context}3",
+     (bool, StringRef, Identifier, bool))
 NOTE(regionbasedisolation_named_nosend_send_into_result, none,
-     "%select{%1 |}0%2 cannot be a 'sending' result. %3 uses may race with caller uses",
-     (bool, StringRef, Identifier, StringRef))
+     "%select{%1 |}0%2 cannot be a 'sending' result. %select{%3 uses|Code in the current task}4 may race with caller uses",
+     (bool, StringRef, Identifier, StringRef, bool))
 NOTE(regionbasedisolation_typed_tns_passed_to_sending, none,
      "Passing %0 value of non-Sendable type %1 as a 'sending' parameter risks "
      "causing races inbetween %0 uses and uses reachable from the callee",
@@ -1089,16 +1089,16 @@ NOTE(regionbasedisolation_typed_tns_passed_to_sending_closure_helper_have_value,
      "closure captures %0 %1",
      (StringRef, DeclName))
 NOTE(regionbasedisolation_typed_tns_passed_to_sending_closure_helper_have_value_task_isolated, none,
-     "closure captures %0 which is accessible to code in the current task",
+     "closure captures %0 which is accessible to code in the current isolation context",
      (DeclName))
 NOTE(regionbasedisolation_typed_tns_passed_to_sending_closure_helper_have_boxed_value_task_isolated, none,
-     "closure captures reference to mutable %kind0 which remains modifiable by code in the current task",
+     "closure captures reference to mutable %kind0 which remains modifiable by code in the current isolation context",
      (const ValueDecl *))
 GROUPED_ERROR(regionbasedisolation_sent_closure_captures_mutable_var, SendingRisksDataRace, none,
-     "closure passed as an argument to a 'sending' parameter captures reference to mutable %kind0 which is accessed later by code in the current task",
+     "closure passed as an argument to a 'sending' parameter captures reference to mutable %kind0 which is accessed later by code in the current isolation context",
      (const ValueDecl *))
 GROUPED_ERROR(regionbasedisolation_sent_closure_captures_value, SendingRisksDataRace, none,
-     "closure passed as an argument to a 'sending' parameter captures %0 which is accessed later by code in the current task",
+     "closure passed as an argument to a 'sending' parameter captures %0 which is accessed later by code in the current isolation context",
      (DeclName))
 GROUPED_ERROR(regionbasedisolation_sent_autoclosure_captures_mutable_var, SendingRisksDataRace, none,
      "mutable %kind0 cannot be captured by 'sending' @autoclosure parameter because %0 is accessed later in the current task",
@@ -1122,14 +1122,14 @@ NOTE(regionbasedisolation_typed_tns_passed_to_sending_callee, none,
      (StringRef, Type, const ValueDecl *))
 
 NOTE(regionbasedisolation_named_send_nt_asynclet_capture, none,
-      "sending %1 %0 into async let risks causing data races between nonisolated and %1 uses",
-      (Identifier, StringRef))
+      "sending %select{%1 |}2%0 into async let risks causing data races between nonisolated %select{|code }2and %select{%1 uses|code in the current isolation context}2",
+      (Identifier, StringRef, bool))
 NOTE(regionbasedisolation_typed_sendneversendable_via_arg, none,
-      "sending %0 value of non-Sendable type %1 to %2 callee risks causing races in between %0 and %2 uses",
-      (StringRef, Type, StringRef))
+      "sending %select{%0 |}3value of non-Sendable type %1 to %2 callee risks causing races in between %select{%0 |code in the current isolation context }3and %2 uses",
+      (StringRef, Type, StringRef, bool))
 NOTE(regionbasedisolation_typed_sendneversendable_via_arg_callee, none,
-      "sending %0 value of non-Sendable type %1 to %2 %kind3 risks causing races in between %0 and %2 uses",
-      (StringRef, Type, StringRef, const ValueDecl *))
+      "sending %select{%0 |}4value of non-Sendable type %1 to %2 %kind3 risks causing races in between %select{%0 |code in the current isolation context }4and %2 uses",
+      (StringRef, Type, StringRef, const ValueDecl *, bool))
 
 NOTE(regionbasedisolation_isolated_conformance_introduced, none,
      "isolated conformance to %kind0 can be introduced here",
@@ -1147,11 +1147,11 @@ NOTE(regionbasedisolation_inout_sending_must_be_reinitialized, none,
      "'inout sending' parameter must be reinitialized before function exit with a non-actor-isolated value",
      ())
 GROUPED_ERROR(regionbasedisolation_inout_sending_cannot_be_actor_isolated, RegionIsolation, none,
-      "'inout sending' parameter %0 cannot be %1 at end of function",
-      (Identifier, StringRef))
+      "'inout sending' parameter %0 %select{cannot be %1 at end of function|is accessible to code in the current isolation context at end of function}2",
+      (Identifier, StringRef, bool))
 NOTE(regionbasedisolation_inout_sending_cannot_be_actor_isolated_note, none,
-      "%1 %0 risks causing races in between %1 uses and caller uses since caller assumes value is not actor isolated",
-      (Identifier, StringRef))
+      "%select{%1 |}2%0 risks causing races in between %select{%1 uses|code in the current isolation context}2 and caller uses since caller assumes value is not actor isolated",
+      (Identifier, StringRef, bool))
 GROUPED_ERROR(regionbasedisolation_inout_sending_cannot_be_returned_param, RegionIsolation, none,
       "'inout sending' parameter %0 cannot be returned",
       (Identifier))
@@ -1183,17 +1183,17 @@ NOTE(regionbasedisolation_inout_sending_cannot_be_returned_note_actor_return_val
 // Out Sending
 
 GROUPED_ERROR(regionbasedisolation_out_sending_cannot_be_actor_isolated_type, RegionIsolation, none,
-      "returning a %1 %0 value as a 'sending' result risks causing data races",
-      (Type, StringRef))
+      "returning a %select{%1 |}2%0 value as a 'sending' result risks causing data races%select{; the value is accessible to code in the current isolation context|}2",
+      (Type, StringRef, bool))
 NOTE(regionbasedisolation_out_sending_cannot_be_actor_isolated_note_type, none,
-      "returning a %1 %0 value risks causing races since the caller assumes the value can be safely sent to other isolation domains",
-      (Type, StringRef))
+      "returning a %select{%1 |}2%0 value risks causing races since the caller assumes the value can be safely sent to other isolation domains%select{, but the value is accessible to code in the current isolation context|}2",
+      (Type, StringRef, bool))
 GROUPED_ERROR(regionbasedisolation_out_sending_cannot_be_actor_isolated_named, RegionIsolation, none,
-      "returning %1 %0 as a 'sending' result risks causing data races",
-      (Identifier, StringRef))
+      "returning %select{%1 |}2%0 as a 'sending' result risks causing data races%select{; %0 is accessible to code in the current isolation context|}2",
+      (Identifier, StringRef, bool))
 NOTE(regionbasedisolation_out_sending_cannot_be_actor_isolated_note_named, none,
-      "returning %1 %0 risks causing data races since the caller assumes that %0 can be safely sent to other isolation domains",
-      (Identifier, StringRef))
+      "returning %select{%1 |}2%0 risks causing data races since the caller assumes that %0 can be safely sent to other isolation domains%select{, but %0 is accessible to code in the current isolation context|}2",
+      (Identifier, StringRef, bool))
 
 //===
 // non-Sendable Results
@@ -1230,24 +1230,24 @@ NOTE(regionbasedisolation_inout_sending_in_same_region_note, none,
 // Generic merge -- instruction does not match a more specific shape below.
 GROUPED_ERROR(rbi_merge_failure_unknown, RegionIsolationCrossIsolationDataRace, none,
       "executing operation could allow for references between values exposed to "
-      "%select{%0 code|code in the current task}2 and "
-      "%select{%1 code|code in the current task}3 "
+      "%select{%0 code|code in the current isolation context}2 and "
+      "%select{%1 code|code in the current isolation context}3 "
       "risking data races",
       (StringRef, StringRef, bool, bool))
 
 // Store / assignment that brings two domains into the same region.
 GROUPED_ERROR(rbi_merge_failure_assign, RegionIsolationCrossIsolationDataRace, none,
       "assignment could allow for references between values exposed to "
-      "%select{%0 code|code in the current task}2 and "
-      "%select{%1 code|code in the current task}3 "
+      "%select{%0 code|code in the current isolation context}2 and "
+      "%select{%1 code|code in the current isolation context}3 "
       "risking data races",
       (StringRef, StringRef, bool, bool))
 
 // Nonisolated callee receiving arguments from two different domains.
 GROUPED_ERROR(rbi_merge_failure_nonisolatedfn, RegionIsolationCrossIsolationDataRace, none,
       "passing arguments to %kind2 could allow for references between values exposed to "
-      "%select{%0 code|code in the current task}3 and "
-      "%select{%1 code|code in the current task}4 "
+      "%select{%0 code|code in the current isolation context}3 and "
+      "%select{%1 code|code in the current isolation context}4 "
       "risking data races",
       (StringRef, StringRef, const ValueDecl *, bool, bool))
 
@@ -1256,22 +1256,22 @@ GROUPED_ERROR(rbi_merge_failure_nonisolatedfn, RegionIsolationCrossIsolationData
 // can recover it, and an unnamed primary (no leading article) when we cannot.
 GROUPED_ERROR(rbi_merge_failure_isolatedfn, RegionIsolationCrossIsolationDataRace, none,
       "passing value to %2 %kind1 could allow for references between values exposed to "
-      "%select{%0 code|code in the current task}3 and "
-      "%select{%2 code|code in the current task}4 "
+      "%select{%0 code|code in the current isolation context}3 and "
+      "%select{%2 code|code in the current isolation context}4 "
       "risking data races",
       (StringRef, const ValueDecl *, StringRef, bool, bool))
 GROUPED_ERROR(rbi_merge_failure_isolatedfn_named, RegionIsolationCrossIsolationDataRace, none,
       "passing %0 to %3 %kind2 could allow for references between values exposed to "
-      "%select{%1 code|code in the current task}4 and "
-      "%select{%3 code|code in the current task}5 "
+      "%select{%1 code|code in the current isolation context}4 and "
+      "%select{%3 code|code in the current isolation context}5 "
       "risking data races",
       (Identifier, StringRef, const ValueDecl *, StringRef, bool, bool))
 
 // Cast across isolation domains.
 GROUPED_ERROR(rbi_merge_failure_cast, RegionIsolationCrossIsolationDataRace, none,
       "casting value to type %1 could allow for references between values exposed to "
-      "%select{%0 code|code in the current task}3 and "
-      "%select{%2 code|code in the current task}4 "
+      "%select{%0 code|code in the current isolation context}3 and "
+      "%select{%2 code|code in the current isolation context}4 "
       "risking data races",
       (StringRef, Type, StringRef, bool, bool))
 
@@ -1280,10 +1280,10 @@ GROUPED_ERROR(rbi_merge_failure_cast, RegionIsolationCrossIsolationDataRace, non
 // "value of type T" form, because SIL values often do not carry a reliable AST
 // type.
 NOTE(rbi_merge_failure_value_note_named, none,
-     "%0 is exposed to %select{%1 code|code in the current task}2",
+     "%0 is exposed to %select{%1 code|code in the current isolation context}2",
      (Identifier, StringRef, bool))
 NOTE(rbi_merge_failure_value_note_bare, none,
-     "value is exposed to %select{%0 code|code in the current task}1",
+     "value is exposed to %select{%0 code|code in the current isolation context}1",
      (StringRef, bool))
 
 // Concurrency related diagnostics

--- a/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
@@ -262,7 +262,7 @@ static SourceLoc preciseSourceLocForValue(SILValue value) {
 /// Emit a per-value note describing one side of an incompatible region merge.
 /// \p ownIso is the isolation of \p value (the textual rendering used when the
 /// value is *not* task-isolated). \p ownIsTaskIsolated drives a `%select` that
-/// renders "code in the current task" instead of "X-isolated code" for the
+/// renders "code in the current isolation context" instead of "X-isolated code" for the
 /// task-isolated case, matching the wording used elsewhere in the diagnostic
 /// suite.
 ///
@@ -1000,7 +1000,8 @@ public:
         SILIsolationInfo::printActorIsolationForDiagnostics(
             getFunction(), isolationCrossing.getCallerIsolation());
 
-    bool isDisconnected = namedValuesIsolationInfo.isDisconnected();
+    bool isDisconnected = namedValuesIsolationInfo.isDisconnected() ||
+                          namedValuesIsolationInfo.isTaskIsolated();
     if (auto callee = getSendingCallee()) {
       diagnoseNote(
           loc, diag::regionbasedisolation_named_info_send_yields_race_callee,
@@ -1032,7 +1033,8 @@ public:
     auto callerIsolationStr =
         SILIsolationInfo::printActorIsolationForDiagnostics(
             getFunction(), isolationCrossing.getCallerIsolation());
-    bool isDisconnected = namedValuesIsolationInfo.isDisconnected();
+    bool isDisconnected = namedValuesIsolationInfo.isDisconnected() ||
+                          namedValuesIsolationInfo.isTaskIsolated();
 
     diagnoseNote(loc,
                  diag::regionbasedisolation_named_info_send_yields_race_callee,
@@ -1212,11 +1214,13 @@ public:
     auto callerIsolationStr =
         SILIsolationInfo::printActorIsolationForDiagnostics(
             getFunction(), isolationCrossing.getCallerIsolation());
-    bool isDisconnected = namedValuesIsolationInfo.isDisconnected();
+    bool isDisconnected = namedValuesIsolationInfo.isDisconnected() ||
+                          namedValuesIsolationInfo.isTaskIsolated();
+    bool isTaskIsolated = namedValuesIsolationInfo.isTaskIsolated();
     diagnoseNote(loc,
                  diag::regionbasedisolation_named_isolated_closure_yields_race,
                  isDisconnected, descriptiveKindStr, name, calleeIsolationStr,
-                 callerIsolationStr);
+                 callerIsolationStr, isTaskIsolated);
     emitRequireInstDiagnostics();
   }
 
@@ -1834,11 +1838,13 @@ public:
       diagnoseNote(
           loc,
           diag::regionbasedisolation_typed_sendneversendable_via_arg_callee,
-          descriptiveKindStr, inferredType, calleeIsolationStr, callee.value());
+          descriptiveKindStr, inferredType, calleeIsolationStr, callee.value(),
+          getIsolationRegionInfo()->isTaskIsolated());
     } else {
       diagnoseNote(loc,
                    diag::regionbasedisolation_typed_sendneversendable_via_arg,
-                   descriptiveKindStr, inferredType, calleeIsolationStr);
+                   descriptiveKindStr, inferredType, calleeIsolationStr,
+                   getIsolationRegionInfo()->isTaskIsolated());
     }
   }
 
@@ -1854,11 +1860,13 @@ public:
     auto callerIsolationStr =
         SILIsolationInfo::printActorIsolationForDiagnostics(
             getFunction(), crossing.getCallerIsolation());
-    bool isDisconnected = getIsolationRegionInfo().isDisconnected();
+    bool isDisconnected = getIsolationRegionInfo().isDisconnected() ||
+                          getIsolationRegionInfo()->isTaskIsolated();
+    bool isTaskIsolated = getIsolationRegionInfo()->isTaskIsolated();
     diagnoseNote(loc,
                  diag::regionbasedisolation_named_isolated_closure_yields_race,
                  isDisconnected, descriptiveKindStr, name, calleeIsolationStr,
-                 callerIsolationStr);
+                 callerIsolationStr, isTaskIsolated);
   }
 
   void
@@ -2049,7 +2057,8 @@ public:
         getIsolationRegionInfo().printForDiagnostics(getFunction());
 
     diagnoseNote(loc, diag::regionbasedisolation_named_send_nt_asynclet_capture,
-                 name, descriptiveKindStr);
+                 name, descriptiveKindStr,
+                 getIsolationRegionInfo()->isTaskIsolated());
   }
 
   void emitNamedIsolation(SILLocation loc, Identifier name,
@@ -2061,17 +2070,19 @@ public:
     auto calleeIsolationStr =
         SILIsolationInfo::printActorIsolationForDiagnostics(
             getFunction(), isolationCrossing.getCalleeIsolation());
-    bool isDisconnected = getIsolationRegionInfo().isDisconnected();
+    bool isDisconnected = getIsolationRegionInfo().isDisconnected() ||
+                          getIsolationRegionInfo()->isTaskIsolated();
+    bool isTaskIsolated = getIsolationRegionInfo()->isTaskIsolated();
 
     if (auto callee = getSendingCallee()) {
       diagnoseNote(loc,
                    diag::regionbasedisolation_named_send_never_sendable_callee,
                    isDisconnected, name, descriptiveKindStr, calleeIsolationStr,
-                   callee.value(), descriptiveKindStr);
+                   callee.value(), descriptiveKindStr, isTaskIsolated);
     } else {
       diagnoseNote(loc, diag::regionbasedisolation_named_send_never_sendable,
                    isDisconnected, name, descriptiveKindStr, calleeIsolationStr,
-                   descriptiveKindStr);
+                   descriptiveKindStr, isTaskIsolated);
     }
   }
 
@@ -2081,19 +2092,24 @@ public:
 
     auto descriptiveKindStr =
         getIsolationRegionInfo().printForDiagnostics(getFunction());
-    bool isDisconnected = getIsolationRegionInfo().isDisconnected();
+    bool isTaskIsolated = getIsolationRegionInfo()->isTaskIsolated();
+    bool isDisconnected = getIsolationRegionInfo().isDisconnected() ||
+                          isTaskIsolated;
     auto diag = diag::regionbasedisolation_named_send_into_sending_param;
-    diagnoseNote(loc, diag, isDisconnected, descriptiveKindStr, varName);
+    diagnoseNote(loc, diag, isDisconnected, descriptiveKindStr, varName,
+                 isTaskIsolated);
   }
 
   void emitNamedSendingReturn(SILLocation loc, Identifier varName) {
     emitNamedOnlyError(loc, varName);
     auto descriptiveKindStr =
         getIsolationRegionInfo().printForDiagnostics(getFunction());
-    bool isDisconnected = getIsolationRegionInfo().isDisconnected();
+    bool isTaskIsolated = getIsolationRegionInfo()->isTaskIsolated();
+    bool isDisconnected = getIsolationRegionInfo().isDisconnected() ||
+                          isTaskIsolated;
     auto diag = diag::regionbasedisolation_named_nosend_send_into_result;
     diagnoseNote(loc, diag, isDisconnected, descriptiveKindStr, varName,
-                 descriptiveKindStr);
+                 descriptiveKindStr, isTaskIsolated);
   }
 
 private:
@@ -3346,13 +3362,15 @@ void InOutSendingNotDisconnectedAtExitDiagnosticEmitter::emit() {
   diagnoseError(
       functionExitingInst,
       diag::regionbasedisolation_inout_sending_cannot_be_actor_isolated,
-      *varName, descriptiveKindStr)
+      *varName, descriptiveKindStr,
+      actorIsolatedRegionInfo->isTaskIsolated())
       .limitBehaviorIf(getBehaviorLimit());
 
   diagnoseNote(
       functionExitingInst,
       diag::regionbasedisolation_inout_sending_cannot_be_actor_isolated_note,
-      *varName, descriptiveKindStr);
+      *varName, descriptiveKindStr,
+      actorIsolatedRegionInfo->isTaskIsolated());
 }
 
 //===----------------------------------------------------------------------===//
@@ -3505,6 +3523,7 @@ void AssignNeverSendableIntoSendingResultDiagnosticEmitter::emit() {
   // Then emit the note with greater context.
   auto descriptiveKindStr =
       isolatedValueIsolationRegionInfo.printForDiagnostics(getFunction());
+  bool isTaskIsolated = isolatedValueIsolationRegionInfo->isTaskIsolated();
 
   // Grab the var name if we can find it.
   if (auto varName = VariableNameInferrer::inferName(srcOperand->get())) {
@@ -3550,14 +3569,14 @@ void AssignNeverSendableIntoSendingResultDiagnosticEmitter::emit() {
     diagnoseError(
         srcOperand,
         diag::regionbasedisolation_out_sending_cannot_be_actor_isolated_named,
-        *varName, descriptiveKindStr)
+        *varName, descriptiveKindStr, isTaskIsolated)
         .limitBehaviorIf(getConcurrencyDiagnosticBehavior());
 
     diagnoseNote(
         srcOperand,
         diag::
             regionbasedisolation_out_sending_cannot_be_actor_isolated_note_named,
-        *varName, descriptiveKindStr);
+        *varName, descriptiveKindStr, isTaskIsolated);
     return;
   }
 
@@ -3566,13 +3585,13 @@ void AssignNeverSendableIntoSendingResultDiagnosticEmitter::emit() {
   diagnoseError(
       srcOperand,
       diag::regionbasedisolation_out_sending_cannot_be_actor_isolated_type,
-      type, descriptiveKindStr)
+      type, descriptiveKindStr, isTaskIsolated)
       .limitBehaviorIf(getConcurrencyDiagnosticBehavior());
 
   diagnoseNote(
       srcOperand,
       diag::regionbasedisolation_out_sending_cannot_be_actor_isolated_note_type,
-      type, descriptiveKindStr);
+      type, descriptiveKindStr, isTaskIsolated);
   diagnoseNote(srcOperand, diag::regionbasedisolation_type_is_non_sendable,
                type);
 }

--- a/lib/SILOptimizer/Utils/SILIsolationInfo.cpp
+++ b/lib/SILOptimizer/Utils/SILIsolationInfo.cpp
@@ -1607,7 +1607,7 @@ void SILIsolationInfo::printForCodeDiagnostic(SILFunction *fn,
     os << " code";
     return;
   case Task:
-    os << "code in the current task";
+    os << "code in the current isolation context";
     return;
   }
 }

--- a/test/ClangImporter/regionbasedisolation.swift
+++ b/test/ClangImporter/regionbasedisolation.swift
@@ -142,12 +142,12 @@ func testTaskLocal(_ y: NSObject) async {
   let x = ObjCObject()
   await x.useValue(y)
   await useValueConcurrently(x) // expected-ni-ns-error {{sending 'x' risks causing data races}}
-  // expected-ni-ns-note @-1 {{sending task-isolated 'x' to @concurrent global function 'useValueConcurrently' risks causing data races between @concurrent and task-isolated uses}}
+  // expected-ni-ns-note @-1 {{sending 'x' to @concurrent global function 'useValueConcurrently' risks causing data races between @concurrent code and code in the current isolation context}}
 
   // This is not safe since we merge x into y's region making x task
   // isolated. We then try to send it to a main actor function.
   await useValueMainActor(x) // expected-error {{sending 'x' risks causing data races}}
-  // expected-note @-1 {{sending task-isolated 'x' to main actor-isolated global function 'useValueMainActor' risks causing data races between main actor-isolated and task-isolated uses}}
+  // expected-note @-1 {{sending 'x' to main actor-isolated global function 'useValueMainActor' risks causing data races between main actor-isolated code and code in the current isolation context}}
 }
 
 actor MyActor {

--- a/test/Concurrency/concurrent_value_checking.swift
+++ b/test/Concurrency/concurrent_value_checking.swift
@@ -43,9 +43,9 @@ actor A2 {
     await self.init(valueAsync: value)
   }
 
-  nonisolated init(nonisoAsync value: NotConcurrent, _ c: Int) async { // expected-note {{'value' is exposed to code in the current task}}
+  nonisolated init(nonisoAsync value: NotConcurrent, _ c: Int) async { // expected-note {{'value' is exposed to code in the current isolation context}}
     if c == 0 {
-      await self.init(valueAsync: value) // expected-warning {{passing 'value' to 'self'-isolated initializer 'init(valueAsync:)' could allow for references between values exposed to code in the current task and 'self'-isolated code risking data races}}
+      await self.init(valueAsync: value) // expected-warning {{passing 'value' to 'self'-isolated initializer 'init(valueAsync:)' could allow for references between values exposed to code in the current isolation context and 'self'-isolated code risking data races}}
     } else {
       self.init(value: value)
     }
@@ -67,23 +67,23 @@ actor A2 {
 func testActorCreation(value: NotConcurrent) async {
   _ = A2(value: value)
   // expected-warning @-1 {{sending 'value' risks causing data races}}
-  // expected-note @-2 {{sending task-isolated 'value' to actor-isolated initializer 'init(value:)' risks causing data races between actor-isolated and task-isolated uses}}
+  // expected-note @-2 {{sending 'value' to actor-isolated initializer 'init(value:)' risks causing data races between actor-isolated code and code in the current isolation context}}
 
   _ = await A2(valueAsync: value)
   // expected-warning @-1 {{sending 'value' risks causing data races}}
-  // expected-note @-2 {{sending task-isolated 'value' to actor-isolated initializer 'init(valueAsync:)' risks causing data races between actor-isolated and task-isolated uses}}
+  // expected-note @-2 {{sending 'value' to actor-isolated initializer 'init(valueAsync:)' risks causing data races between actor-isolated code and code in the current isolation context}}
 
   _ = A2(delegatingSync: value)
   // expected-warning @-1 {{sending 'value' risks causing data races}}
-  // expected-note @-2 {{sending task-isolated 'value' to actor-isolated initializer 'init(delegatingSync:)' risks causing data races between actor-isolated and task-isolated uses}}
+  // expected-note @-2 {{sending 'value' to actor-isolated initializer 'init(delegatingSync:)' risks causing data races between actor-isolated code and code in the current isolation context}}
 
   _ = await A2(delegatingAsync: value, 9)
   // expected-warning @-1 {{sending 'value' risks causing data races}}
-  // expected-note @-2 {{sending task-isolated 'value' to actor-isolated initializer 'init(delegatingAsync:_:)' risks causing data races between actor-isolated and task-isolated uses}}
+  // expected-note @-2 {{sending 'value' to actor-isolated initializer 'init(delegatingAsync:_:)' risks causing data races between actor-isolated code and code in the current isolation context}}
 
   _ = await A2(nonisoAsync: value, 3)
   // expected-warning @-1 {{sending 'value' risks causing data races}}
-  // expected-note @-2 {{sending task-isolated 'value' to actor-isolated initializer 'init(nonisoAsync:_:)' risks causing data races between actor-isolated and task-isolated uses}}
+  // expected-note @-2 {{sending 'value' to actor-isolated initializer 'init(nonisoAsync:_:)' risks causing data races between actor-isolated code and code in the current isolation context}}
 }
 
 extension A1 {
@@ -397,20 +397,20 @@ extension NotConcurrent {
   func f() { }
 
   func test() {
-    Task { // expected-warning {{passing closure as a 'sending' parameter risks causing data races between code in the current task and concurrent execution of the closure}}
-      f() // expected-note {{closure captures 'self' which is accessible to code in the current task}}
+    Task { // expected-warning {{passing closure as a 'sending' parameter risks causing data races between code in the current isolation context and concurrent execution of the closure}}
+      f() // expected-note {{closure captures 'self' which is accessible to code in the current isolation context}}
     }
 
-    Task { // expected-warning {{passing closure as a 'sending' parameter risks causing data races between code in the current task and concurrent execution of the closure}}
-      self.f() // expected-note {{closure captures 'self' which is accessible to code in the current task}}
+    Task { // expected-warning {{passing closure as a 'sending' parameter risks causing data races between code in the current isolation context and concurrent execution of the closure}}
+      self.f() // expected-note {{closure captures 'self' which is accessible to code in the current isolation context}}
     }
 
-    Task { [self] in // expected-warning {{passing closure as a 'sending' parameter risks causing data races between code in the current task and concurrent execution of the closure}}
-      f() // expected-note {{closure captures 'self' which is accessible to code in the current task}}
+    Task { [self] in // expected-warning {{passing closure as a 'sending' parameter risks causing data races between code in the current isolation context and concurrent execution of the closure}}
+      f() // expected-note {{closure captures 'self' which is accessible to code in the current isolation context}}
     }
 
-    Task { [self] in // expected-warning {{passing closure as a 'sending' parameter risks causing data races between code in the current task and concurrent execution of the closure}}
-      self.f() // expected-note {{closure captures 'self' which is accessible to code in the current task}}
+    Task { [self] in // expected-warning {{passing closure as a 'sending' parameter risks causing data races between code in the current isolation context and concurrent execution of the closure}}
+      self.f() // expected-note {{closure captures 'self' which is accessible to code in the current isolation context}}
     }
   }
 }

--- a/test/Concurrency/isolated_parameters.swift
+++ b/test/Concurrency/isolated_parameters.swift
@@ -88,7 +88,7 @@ func checkConformer(_ s: S, _ p: any P, _ ma: MyActor) async {
   s.m(thing: ma)
   await p.m(thing: ma)
   // expected-warning @-1 {{sending 'p' risks causing data races}}
-  // expected-note @-2 {{sending task-isolated 'p' to actor-isolated instance method 'm(thing:)' risks causing data races between actor-isolated and task-isolated uses}}
+  // expected-note @-2 {{sending 'p' to actor-isolated instance method 'm(thing:)' risks causing data races between actor-isolated code and code in the current isolation context}}
 }
 
 // Redeclaration checking
@@ -212,7 +212,7 @@ nonisolated func callFromNonisolated(ns: NotSendable) async {
 
   await optionalIsolated(ns, to: myActor)
   // expected-warning @-1 {{sending 'ns' risks causing data races}}
-  // expected-note @-2 {{sending task-isolated 'ns' to actor-isolated global function 'optionalIsolated(_:to:)' risks causing data races between actor-isolated and task-isolated uses}}
+  // expected-note @-2 {{sending 'ns' to actor-isolated global function 'optionalIsolated(_:to:)' risks causing data races between actor-isolated code and code in the current isolation context}}
 }
 
 @MainActor func callFromMainActor(ns: NotSendable) async {

--- a/test/Concurrency/issue-57376.swift
+++ b/test/Concurrency/issue-57376.swift
@@ -26,35 +26,35 @@ func testAsyncSequence1Sendable<Seq: AsyncSequence>(_ seq: Seq) async throws whe
 
 func testAsyncSequenceTypedPattern<Seq: AsyncSequence>(_ seq: Seq) async throws where Seq.Element == Int {
   async let result: Int = seq.reduce(0) { $0 + $1 } // expected-transferring-tns-warning {{sending 'seq' risks causing data races}}
-  // expected-transferring-tns-note @-1 {{sending task-isolated 'seq' into async let risks causing data races between nonisolated and task-isolated uses}}
+  // expected-transferring-tns-note @-1 {{sending 'seq' into async let risks causing data races between nonisolated code and code in the current isolation context}}
   let _ = try! await result
 }
 
 func testAsyncSequenceTypedPattern1<Seq: AsyncSequence>(_ seq: Seq) async throws where Seq.Element == Int {
   async let _: Int = seq.reduce(0) { $0 + $1 } // expected-transferring-tns-warning {{sending 'seq' risks causing data races}}
-  // expected-transferring-tns-note @-1 {{sending task-isolated 'seq' into async let risks causing data races between nonisolated and task-isolated uses}}
+  // expected-transferring-tns-note @-1 {{sending 'seq' into async let risks causing data races between nonisolated code and code in the current isolation context}}
 }
 
 func testAsyncSequence<Seq: AsyncSequence>(_ seq: Seq) async throws where Seq.Element == Int {
   async let result = seq.reduce(0) { $0 + $1 } // expected-transferring-tns-warning {{sending 'seq' risks causing data races}}
-  // expected-transferring-tns-note @-1 {{sending task-isolated 'seq' into async let risks causing data races between nonisolated and task-isolated uses}}
+  // expected-transferring-tns-note @-1 {{sending 'seq' into async let risks causing data races between nonisolated code and code in the current isolation context}}
   let _ = try! await result
 }
 
 func testAsyncSequence1<Seq: AsyncSequence>(_ seq: Seq) async throws where Seq.Element == Int {
   async let _ = seq.reduce(0) { $0 + $1 } // expected-transferring-tns-warning {{sending 'seq' risks causing data races}}
-  // expected-transferring-tns-note @-1 {{sending task-isolated 'seq' into async let risks causing data races between nonisolated and task-isolated uses}}
+  // expected-transferring-tns-note @-1 {{sending 'seq' into async let risks causing data races between nonisolated code and code in the current isolation context}}
 }
 
 func testAsyncSequence3<Seq>(_ seq: Seq) async throws where Seq: AsyncSequence, Seq.Element == Int {
   async let result = seq // expected-transferring-tns-warning {{sending 'seq' risks causing data races}}
-  // expected-transferring-tns-note @-1 {{sending task-isolated 'seq' into async let risks causing data races between nonisolated and task-isolated uses}}
+  // expected-transferring-tns-note @-1 {{sending 'seq' into async let risks causing data races between nonisolated code and code in the current isolation context}}
   let _ = await result
 }
 
 func testAsyncSequence4<Seq>(_ seq: Seq) async throws where Seq: AsyncSequence, Seq.Element == Int {
   async let _ = seq // expected-transferring-tns-warning {{sending 'seq' risks causing data races}}
-  // expected-transferring-tns-note @-1 {{sending task-isolated 'seq' into async let risks causing data races between nonisolated and task-isolated uses}}
+  // expected-transferring-tns-note @-1 {{sending 'seq' into async let risks causing data races between nonisolated code and code in the current isolation context}}
 }
 
 func search(query: String, entities: [String]) async throws -> [String] {

--- a/test/Concurrency/nonisolated_inherits_isolation.swift
+++ b/test/Concurrency/nonisolated_inherits_isolation.swift
@@ -289,13 +289,13 @@ func unspecifiedCallingVariousNonisolated(_ x: NonSendableKlass) async {
   await x.nonisolatedCaller()
   await x.nonisolatedNonSendingCaller()
   await x.concurrentCaller() // expected-enabled-error {{sending 'x' risks causing data races}}
-  // expected-enabled-note @-1 {{sending task-isolated 'x' to @concurrent instance method 'concurrentCaller()' risks causing data races between @concurrent and task-isolated uses}}
+  // expected-enabled-note @-1 {{sending 'x' to @concurrent instance method 'concurrentCaller()' risks causing data races between @concurrent code and code in the current isolation context}}
 
   await unspecifiedAsyncUse(x)
   await nonisolatedAsyncUse(x)
   await nonisolatedNonSendingAsyncUse(x)
   await concurrentAsyncUse(x) // expected-enabled-error {{sending 'x' risks causing data races}}
-  // expected-enabled-note @-1 {{sending task-isolated 'x' to @concurrent global function 'concurrentAsyncUse' risks causing data races between @concurrent and task-isolated uses}}
+  // expected-enabled-note @-1 {{sending 'x' to @concurrent global function 'concurrentAsyncUse' risks causing data races between @concurrent code and code in the current isolation context}}
 }
 
 nonisolated func nonisolatedCallingVariousNonisolated(_ x: NonSendableKlass) async {
@@ -303,33 +303,33 @@ nonisolated func nonisolatedCallingVariousNonisolated(_ x: NonSendableKlass) asy
   await x.nonisolatedCaller()
   await x.nonisolatedNonSendingCaller()
   await x.concurrentCaller() // expected-enabled-error {{sending 'x' risks causing data races}}
-  // expected-enabled-note @-1 {{sending task-isolated 'x' to @concurrent instance method 'concurrentCaller()' risks causing data races between @concurrent and task-isolated uses}}
+  // expected-enabled-note @-1 {{sending 'x' to @concurrent instance method 'concurrentCaller()' risks causing data races between @concurrent code and code in the current isolation context}}
 
   await unspecifiedAsyncUse(x)
   await nonisolatedAsyncUse(x)
   await nonisolatedNonSendingAsyncUse(x)
   await concurrentAsyncUse(x) // expected-enabled-error {{sending 'x' risks causing data races}}
-  // expected-enabled-note @-1 {{sending task-isolated 'x' to @concurrent global function 'concurrentAsyncUse' risks causing data races between @concurrent and task-isolated uses}}
+  // expected-enabled-note @-1 {{sending 'x' to @concurrent global function 'concurrentAsyncUse' risks causing data races between @concurrent code and code in the current isolation context}}
 }
 
 nonisolated(nonsending) func nonisolatedNonSendingCallingVariousNonisolated(_ x: NonSendableKlass) async {
   await x.unspecifiedCaller() // expected-disabled-error {{sending 'x' risks causing data races}}
-  // expected-disabled-note @-1 {{sending nonisolated(nonsending) task-isolated 'x' to @concurrent instance method 'unspecifiedCaller()' risks causing data races between @concurrent and nonisolated(nonsending) task-isolated uses}}
+  // expected-disabled-note @-1 {{sending 'x' to @concurrent instance method 'unspecifiedCaller()' risks causing data races between @concurrent code and code in the current isolation context}}
   await x.nonisolatedCaller() // expected-disabled-error {{sending 'x' risks causing data races}}
-  // expected-disabled-note @-1 {{sending nonisolated(nonsending) task-isolated 'x' to @concurrent instance method 'nonisolatedCaller()' risks causing data races between @concurrent and nonisolated(nonsending) task-isolated uses}}
+  // expected-disabled-note @-1 {{sending 'x' to @concurrent instance method 'nonisolatedCaller()' risks causing data races between @concurrent code and code in the current isolation context}}
   await x.nonisolatedNonSendingCaller()
   await x.concurrentCaller() // expected-error {{sending 'x' risks causing data races}}
-  // expected-disabled-note @-1 {{sending nonisolated(nonsending) task-isolated 'x' to @concurrent instance method 'concurrentCaller()' risks causing data races between @concurrent and nonisolated(nonsending) task-isolated uses}}
-  // expected-enabled-note @-2 {{sending task-isolated 'x' to @concurrent instance method 'concurrentCaller()' risks causing data races between @concurrent and task-isolated uses}}
+  // expected-disabled-note @-1 {{sending 'x' to @concurrent instance method 'concurrentCaller()' risks causing data races between @concurrent code and code in the current isolation context}}
+  // expected-enabled-note @-2 {{sending 'x' to @concurrent instance method 'concurrentCaller()' risks causing data races between @concurrent code and code in the current isolation context}}
 
   await unspecifiedAsyncUse(x) // expected-disabled-error {{sending 'x' risks causing data races}}
-  // expected-disabled-note @-1 {{sending nonisolated(nonsending) task-isolated 'x' to @concurrent global function 'unspecifiedAsyncUse' risks causing data races between @concurrent and nonisolated(nonsending) task-isolated uses}}
+  // expected-disabled-note @-1 {{sending 'x' to @concurrent global function 'unspecifiedAsyncUse' risks causing data races between @concurrent code and code in the current isolation context}}
   await nonisolatedAsyncUse(x) // expected-disabled-error {{sending 'x' risks causing data races}}
-  // expected-disabled-note @-1 {{sending nonisolated(nonsending) task-isolated 'x' to @concurrent global function 'nonisolatedAsyncUse' risks causing data races between @concurrent and nonisolated(nonsending) task-isolated uses}}
+  // expected-disabled-note @-1 {{sending 'x' to @concurrent global function 'nonisolatedAsyncUse' risks causing data races between @concurrent code and code in the current isolation context}}
   await nonisolatedNonSendingAsyncUse(x)
   await concurrentAsyncUse(x) // expected-error {{sending 'x' risks causing data races}}
-  // expected-disabled-note @-1 {{sending nonisolated(nonsending) task-isolated 'x' to @concurrent global function 'concurrentAsyncUse' risks causing data races between @concurrent and nonisolated(nonsending) task-isolated uses}}
-  // expected-enabled-note @-2 {{sending task-isolated 'x' to @concurrent global function 'concurrentAsyncUse' risks causing data races between @concurrent and task-isolated uses}}
+  // expected-disabled-note @-1 {{sending 'x' to @concurrent global function 'concurrentAsyncUse' risks causing data races between @concurrent code and code in the current isolation context}}
+  // expected-enabled-note @-2 {{sending 'x' to @concurrent global function 'concurrentAsyncUse' risks causing data races between @concurrent code and code in the current isolation context}}
 }
 
 @concurrent func concurrentCallingVariousNonisolated(_ x: NonSendableKlass) async {

--- a/test/Concurrency/sendable_checking.swift
+++ b/test/Concurrency/sendable_checking.swift
@@ -288,19 +288,19 @@ final class NonSendable {
     value = "update"
   }
 
-  func call() async { // expected-tns-note 2 {{'self' is exposed to code in the current task}}
+  func call() async { // expected-tns-note 2 {{'self' is exposed to code in the current isolation context}}
     await update()
     // expected-tns-warning @-1 {{sending 'self' risks causing data races}}
-    // expected-tns-note @-2 {{sending task-isolated 'self' to main actor-isolated instance method 'update()' risks causing data races between main actor-isolated and task-isolated uses}}
+    // expected-tns-note @-2 {{sending 'self' to main actor-isolated instance method 'update()' risks causing data races between main actor-isolated code and code in the current isolation context}}
 
     await self.update()
     // expected-tns-warning @-1 {{sending 'self' risks causing data races}}
-    // expected-tns-note @-2 {{sending task-isolated 'self' to main actor-isolated instance method 'update()' risks causing data races between main actor-isolated and task-isolated uses}}
+    // expected-tns-note @-2 {{sending 'self' to main actor-isolated instance method 'update()' risks causing data races between main actor-isolated code and code in the current isolation context}}
 
-    _ = await x // expected-tns-warning {{passing 'self' to main actor-isolated getter for property 'x' could allow for references between values exposed to code in the current task and main actor-isolated code risking data races}}
+    _ = await x // expected-tns-warning {{passing 'self' to main actor-isolated getter for property 'x' could allow for references between values exposed to code in the current isolation context and main actor-isolated code risking data races}}
     // expected-warning@-1 {{non-Sendable type 'NonSendable' cannot be sent into main actor-isolated context in call to property 'x'}}
 
-    _ = await self.x // expected-tns-warning {{passing 'self' to main actor-isolated getter for property 'x' could allow for references between values exposed to code in the current task and main actor-isolated code risking data races}}
+    _ = await self.x // expected-tns-warning {{passing 'self' to main actor-isolated getter for property 'x' could allow for references between values exposed to code in the current isolation context and main actor-isolated code risking data races}}
       // expected-warning@-1 {{non-Sendable type 'NonSendable' cannot be sent into main actor-isolated context in call to property 'x'}}
   }
 
@@ -463,15 +463,15 @@ func preconcurrencyContext(_: @escaping @Sendable () -> Void) {}
 struct DowngradeForPreconcurrency {
   func capture(completion: @escaping @MainActor () -> Void) {
     preconcurrencyContext {
-        Task { // expected-tns-warning {{passing closure as a 'sending' parameter risks causing data races between code in the current task and concurrent execution of the closure}}
-            completion() // expected-tns-note {{closure captures 'completion' which is accessible to code in the current task}}
+        Task { // expected-tns-warning {{passing closure as a 'sending' parameter risks causing data races between code in the current isolation context and concurrent execution of the closure}}
+            completion() // expected-tns-note {{closure captures 'completion' which is accessible to code in the current isolation context}}
         // expected-warning@-1 {{capture of 'completion' with non-Sendable type '@MainActor () -> Void' in a '@Sendable' closure}}
         // expected-warning@-2 {{capture of 'completion' with non-Sendable type '@MainActor () -> Void' in an isolated closure}}
         // expected-note@-3 2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
         // expected-warning@-4 {{expression is 'async' but is not marked with 'await'; this is an error in the Swift 6 language mode}}
         // expected-note@-5 {{calls to parameter 'completion' from outside of its actor context are implicitly asynchronous}}
-        // expected-complete-and-tns-warning @-7 {{passing closure as a 'sending' parameter risks causing data races between code in the current task and concurrent execution of the closure}}
-        // expected-complete-and-tns-note @-7 {{closure captures 'completion' which is accessible to code in the current task}}
+        // expected-complete-and-tns-warning @-7 {{passing closure as a 'sending' parameter risks causing data races between code in the current isolation context and concurrent execution of the closure}}
+        // expected-complete-and-tns-note @-7 {{closure captures 'completion' which is accessible to code in the current isolation context}}
       }
     }
   }
@@ -479,7 +479,7 @@ struct DowngradeForPreconcurrency {
   var x: NonSendable
   func createStream() -> AsyncStream<NonSendable> {
     AsyncStream<NonSendable> {
-      self.x // expected-tns-warning {{assignment could allow for references between values exposed to code in the current task and main actor-isolated code risking data races}}
+      self.x // expected-tns-warning {{assignment could allow for references between values exposed to code in the current isolation context and main actor-isolated code risking data races}}
       // expected-tns-note @-1 {{'self.x.some' is exposed to main actor-isolated code}}
       // expected-warning @-2 {{main actor-isolated property 'x' cannot be accessed from outside of the actor; this is an error in the Swift 6 language mode}} {{7-7=await }}
       // expected-warning @-3 {{non-Sendable type 'NonSendable' of property 'x' cannot exit main actor-isolated context; this is an error in the Swift 6 language mode}}

--- a/test/Concurrency/sendable_metatype.swift
+++ b/test/Concurrency/sendable_metatype.swift
@@ -20,14 +20,14 @@ func acceptMetaOnMainActor<T>(_: T.Type) { }
 nonisolated func staticCallThroughMetaSmuggled<T: Q>(_: T.Type) {
   let x: Q.Type = T.self
   Task.detached { // expected-warning{{risks causing data races}}
-    x.g() // expected-note{{closure captures 'x' which is accessible to code in the current task}}
+    x.g() // expected-note{{closure captures 'x' which is accessible to code in the current isolation context}}
   }
 }
 
 nonisolated func passMetaSmuggled<T: Q>(_: T.Type) {
   let x: Q.Type = T.self
   Task.detached { // expected-warning{{risks causing data races}}
-    acceptMeta(x) // expected-note{{closure captures 'x' which is accessible to code in the current task}}
+    acceptMeta(x) // expected-note{{closure captures 'x' which is accessible to code in the current isolation context}}
   }
 }
 
@@ -79,8 +79,8 @@ nonisolated func passSendableToMainActorSmuggledAny<T: Sendable>(_: T.Type) asyn
 // -------------------------------------------------------------------------
 nonisolated func passMetaSmuggledAnyFromExistential(_ pqT: (P & Q).Type) {
   let x: P.Type = pqT
-  Task.detached { // expected-warning{{passing closure as a 'sending' parameter risks causing data races between code in the current task and concurrent execution of the closure}}
-    acceptMeta(x) // expected-note{{closure captures 'x' which is accessible to code in the current task}}
+  Task.detached { // expected-warning{{passing closure as a 'sending' parameter risks causing data races between code in the current isolation context and concurrent execution of the closure}}
+    acceptMeta(x) // expected-note{{closure captures 'x' which is accessible to code in the current isolation context}}
   }
 }
 
@@ -155,14 +155,14 @@ func dynamicCastingExistential(
 ) {
   if let s1p = s1 as? any P { // expected-note{{isolated conformance to protocol 'P' can be introduced here}}
     acceptSendingP(s1p) // expected-warning{{sending 's1p' risks causing data races}}
-    // expected-note@-1{{task-isolated 's1p' is passed as a 'sending' parameter; Uses in callee may race with later task-isolated uses}}
+    // expected-note@-1{{'s1p' is passed as a 'sending' parameter; Uses in callee may race with code in the current isolation context}}
   } else {
     print(s1)
   }
 
   if let s2p = s2 as? any AnyObject & P { // expected-note{{isolated conformance to protocol 'P' can be introduced here}}
     acceptSendingAnyObjectP(s2p) // expected-warning{{sending 's2p' risks causing data races}}
-    // expected-note@-1{{task-isolated 's2p' is passed as a 'sending' parameter; Uses in callee may race with later task-isolated uses}}
+    // expected-note@-1{{'s2p' is passed as a 'sending' parameter; Uses in callee may race with code in the current isolation context}}
   } else {
     print(s2)
   }
@@ -193,14 +193,14 @@ func dynamicCastingGeneric(
 ) {
   if let s1p = s1 as? any P { // expected-note{{isolated conformance to protocol 'P' can be introduced here}}
     acceptSendingP(s1p) // expected-warning{{sending 's1p' risks causing data races}}
-    // expected-note@-1{{task-isolated 's1p' is passed as a 'sending' parameter; Uses in callee may race with later task-isolated uses}}
+    // expected-note@-1{{'s1p' is passed as a 'sending' parameter; Uses in callee may race with code in the current isolation context}}
   } else {
     print(s1)
   }
 
   if let s2p = s2 as? any AnyObject & P { // expected-note{{isolated conformance to protocol 'P' can be introduced here}}
     acceptSendingAnyObjectP(s2p) // expected-warning{{sending 's2p' risks causing data races}}
-    // expected-note@-1{{task-isolated 's2p' is passed as a 'sending' parameter; Uses in callee may race with later task-isolated uses}}
+    // expected-note@-1{{'s2p' is passed as a 'sending' parameter; Uses in callee may race with code in the current isolation context}}
   } else {
     print(s2)
   }
@@ -246,11 +246,11 @@ func forceCastingExistential(
 ) {
   let s1p = s1 as! any P // expected-note{{isolated conformance to protocol 'P' can be introduced here}}
   acceptSendingP(s1p) // expected-warning{{sending 's1p' risks causing data races}}
-  // expected-note@-1{{task-isolated 's1p' is passed as a 'sending' parameter; Uses in callee may race with later task-isolated uses}}
+  // expected-note@-1{{'s1p' is passed as a 'sending' parameter; Uses in callee may race with code in the current isolation context}}
 
   let s2p = s2 as! any AnyObject & P // expected-note{{isolated conformance to protocol 'P' can be introduced here}}
   acceptSendingAnyObjectP(s2p) // expected-warning{{sending 's2p' risks causing data races}}
-  // expected-note@-1{{task-isolated 's2p' is passed as a 'sending' parameter; Uses in callee may race with later task-isolated uses}}
+  // expected-note@-1{{'s2p' is passed as a 'sending' parameter; Uses in callee may race with code in the current isolation context}}
 }
 
 @MainActor func forceCastingExistentialGood(
@@ -270,11 +270,11 @@ func forceCastingGeneric(
 ) {
   let s1p = s1 as! any P // expected-note{{isolated conformance to protocol 'P' can be introduced here}}
   acceptSendingP(s1p) // expected-warning{{sending 's1p' risks causing data races}}
-  // expected-note@-1{{task-isolated 's1p' is passed as a 'sending' parameter; Uses in callee may race with later task-isolated uses}}
+  // expected-note@-1{{'s1p' is passed as a 'sending' parameter; Uses in callee may race with code in the current isolation context}}
 
   let s2p = s2 as! any AnyObject & P // expected-note{{isolated conformance to protocol 'P' can be introduced here}}
   acceptSendingAnyObjectP(s2p) // expected-warning{{sending 's2p' risks causing data races}}
-  // expected-note@-1{{task-isolated 's2p' is passed as a 'sending' parameter; Uses in callee may race with later task-isolated uses}}
+  // expected-note@-1{{'s2p' is passed as a 'sending' parameter; Uses in callee may race with code in the current isolation context}}
 }
 
 @MainActor func forceCastingGenericMainActor(

--- a/test/Concurrency/sendable_preconcurrency.swift
+++ b/test/Concurrency/sendable_preconcurrency.swift
@@ -31,8 +31,8 @@ struct MyType3 {
 }
 
 func testA(ns: NS, mt: MyType, mt2: MyType2, mt3: MyType3, sc: StrictClass, nsc: NonStrictClass) async {
-  Task { // expected-tns-warning {{passing closure as a 'sending' parameter risks causing data races between code in the current task and concurrent execution of the closure}}
-    print(ns) // expected-tns-note {{closure captures 'ns' which is accessible to code in the current task}}
+  Task { // expected-tns-warning {{passing closure as a 'sending' parameter risks causing data races between code in the current isolation context and concurrent execution of the closure}}
+    print(ns) // expected-tns-note {{closure captures 'ns' which is accessible to code in the current isolation context}}
     print(mt)
     print(mt2)
     print(mt3)

--- a/test/Concurrency/sendable_without_preconcurrency.swift
+++ b/test/Concurrency/sendable_without_preconcurrency.swift
@@ -26,8 +26,8 @@ struct MyType2 {
 }
 
 func testA(ns: NS, mt: MyType, mt2: MyType2, sc: StrictClass, nsc: NonStrictClass) async {
-  Task { // expected-tns-warning {{passing closure as a 'sending' parameter risks causing data races between code in the current task and concurrent execution of the closure}}
-    print(ns) // expected-tns-note {{closure captures 'ns' which is accessible to code in the current task}}
+  Task { // expected-tns-warning {{passing closure as a 'sending' parameter risks causing data races between code in the current isolation context and concurrent execution of the closure}}
+    print(ns) // expected-tns-note {{closure captures 'ns' which is accessible to code in the current isolation context}}
     print(mt)
     print(mt2)
     print(sc)

--- a/test/Concurrency/sendable_without_preconcurrency_2.swift
+++ b/test/Concurrency/sendable_without_preconcurrency_2.swift
@@ -29,8 +29,8 @@ struct MyType2: Sendable {
 }
 
 func testA(ns: NS, mt: MyType, mt2: MyType2, sc: StrictClass, nsc: NonStrictClass) async {
-  Task { // expected-tns-warning {{passing closure as a 'sending' parameter risks causing data races between code in the current task and concurrent execution of the closure}}
-    print(ns) // expected-tns-note {{closure captures 'ns' which is accessible to code in the current task}}
+  Task { // expected-tns-warning {{passing closure as a 'sending' parameter risks causing data races between code in the current isolation context and concurrent execution of the closure}}
+    print(ns) // expected-tns-note {{closure captures 'ns' which is accessible to code in the current isolation context}}
     print(mt)
     print(mt2)
     print(sc)
@@ -40,20 +40,20 @@ func testA(ns: NS, mt: MyType, mt2: MyType2, sc: StrictClass, nsc: NonStrictClas
 
 // No warning with targeted: MyType is Sendable because we suppressed NonStrictClass's warning.
 func testB(mt: MyType) async {
-  Task { // expected-tns-warning {{passing closure as a 'sending' parameter risks causing data races between code in the current task and concurrent execution of the closure}}
-    print(mt) // expected-tns-note {{closure captures 'mt' which is accessible to code in the current task}}
+  Task { // expected-tns-warning {{passing closure as a 'sending' parameter risks causing data races between code in the current isolation context and concurrent execution of the closure}}
+    print(mt) // expected-tns-note {{closure captures 'mt' which is accessible to code in the current isolation context}}
   }
 }
 
 func testNonStrictClass(_ mt: NonStrictClass) async {
-  Task { // expected-tns-warning {{passing closure as a 'sending' parameter risks causing data races between code in the current task and concurrent execution of the closure}}
-    print(mt) // expected-tns-note {{closure captures 'mt' which is accessible to code in the current task}}
+  Task { // expected-tns-warning {{passing closure as a 'sending' parameter risks causing data races between code in the current isolation context and concurrent execution of the closure}}
+    print(mt) // expected-tns-note {{closure captures 'mt' which is accessible to code in the current isolation context}}
   }
 }
 
 func testStrictClass(_ mt: StrictClass) async {
-  Task { // expected-tns-warning {{passing closure as a 'sending' parameter risks causing data races between code in the current task and concurrent execution of the closure}}
-    print(mt) // expected-tns-note {{closure captures 'mt' which is accessible to code in the current task}}
+  Task { // expected-tns-warning {{passing closure as a 'sending' parameter risks causing data races between code in the current isolation context and concurrent execution of the closure}}
+    print(mt) // expected-tns-note {{closure captures 'mt' which is accessible to code in the current isolation context}}
   }
 }
 

--- a/test/Concurrency/sending_continuation.swift
+++ b/test/Concurrency/sending_continuation.swift
@@ -100,7 +100,7 @@ func withCheckedContinuation_4a() async {
   let x = await withCheckedContinuation { continuation in
     continuation.resume(returning: y)
     // expected-error @-1 {{sending 'y' risks causing data races}}
-    // expected-note @-2 {{task-isolated 'y' is passed as a 'sending' parameter}}
+    // expected-note @-2 {{'y' is passed as a 'sending' parameter; Uses in callee may race with code in the current isolation context}}
     useValue(y)
   }
   await useValueAsync(x)
@@ -229,7 +229,7 @@ func withUnsafeContinuation_4a() async {
   let x = await withUnsafeContinuation { continuation in
     continuation.resume(returning: y)
     // expected-error @-1 {{sending 'y' risks causing data races}}
-    // expected-note @-2 {{task-isolated 'y' is passed as a 'sending' parameter}}
+    // expected-note @-2 {{'y' is passed as a 'sending' parameter; Uses in callee may race with code in the current isolation context}}
     useValue(y)
   }
   await useValueAsync(x)

--- a/test/Concurrency/transfernonsendable.sil
+++ b/test/Concurrency/transfernonsendable.sil
@@ -219,7 +219,7 @@ bb0(%0 : @guaranteed $NonSendableStruct):
   %2 = struct_extract %0 : $NonSendableStruct, #NonSendableStruct.ns
   %3 = copy_value %2 : $NonSendableKlass
   return %3 : $NonSendableKlass // expected-warning {{sending 'myname.ns' risks causing data races}}
-  // expected-note @-1 {{task-isolated 'myname.ns' cannot be a 'sending' result. task-isolated uses may race with caller uses}}
+  // expected-note @-1 {{'myname.ns' cannot be a 'sending' result. Code in the current task may race with caller uses}}
 }
 
 sil [ossa] @synchronous_returns_transferring_globalactor_struct_structextract : $@convention(method) (@guaranteed MainActorIsolatedStruct) -> @sil_sending @owned NonSendableKlass {

--- a/test/Concurrency/transfernonsendable.swift
+++ b/test/Concurrency/transfernonsendable.swift
@@ -512,7 +512,7 @@ func testNoncopyableNonsendableStructWithNonescapingMainActorAsync() {
   let _ = {
     nonescapingAsyncClosure { @MainActor in
       useValueNoncopyable(x) // expected-warning {{sending 'x' risks causing data races}}
-      // expected-note @-1 {{task-isolated 'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+      // expected-note @-1 {{'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against code in the current isolation context}}
     }
   }
 }
@@ -534,7 +534,7 @@ func testConversionsAndSendable(a: MyActor, f: @Sendable () -> Void, f2: () -> V
   await a.useNonSendableFunction(f2)
 
   // expected-warning @-2 {{sending 'f2' risks causing data races}}
-  // expected-note @-3 {{sending task-isolated 'f2' to actor-isolated instance method 'useNonSendableFunction' risks causing data races between actor-isolated and task-isolated uses}}
+  // expected-note @-3 {{sending 'f2' to actor-isolated instance method 'useNonSendableFunction' risks causing data races between actor-isolated code and code in the current isolation context}}
 }
 
 func testSendableClosureCapturesNonSendable(a: MyActor) {
@@ -1468,7 +1468,7 @@ final actor FinalActorWithSetter {
 func functionArgumentIntoClosure(_ x: @escaping () -> ()) async {
   let _ = { @MainActor in
     let _ = x // expected-warning {{sending 'x' risks causing data races}}
-    // expected-note @-1 {{task-isolated 'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+    // expected-note @-1 {{'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against code in the current isolation context}}
 
 
   }
@@ -1792,8 +1792,8 @@ extension MyActor {
 
 func nonSendableAllocBoxConsumingParameter(x: consuming SendableKlass) async throws {
   try await withThrowingTaskGroup(of: Void.self) { group in
-    group.addTask { // expected-warning {{passing closure as a 'sending' parameter risks causing data races between code in the current task and concurrent execution of the closure}}
-      useValue(x) // expected-note {{closure captures reference to mutable parameter 'x' which remains modifiable by code in the current task}}
+    group.addTask { // expected-warning {{passing closure as a 'sending' parameter risks causing data races between code in the current isolation context and concurrent execution of the closure}}
+      useValue(x) // expected-note {{closure captures reference to mutable parameter 'x' which remains modifiable by code in the current isolation context}}
     }
 
     try await group.waitForAll()
@@ -1805,8 +1805,8 @@ func nonSendableAllocBoxConsumingVar() async throws {
   x = SendableKlass()
 
   try await withThrowingTaskGroup(of: Void.self) { group in
-    group.addTask { // expected-warning {{passing closure as a 'sending' parameter risks causing data races between code in the current task and concurrent execution of the closure}}
-      useValue(x) // expected-note {{closure captures reference to mutable var 'x' which remains modifiable by code in the current task}}
+    group.addTask { // expected-warning {{passing closure as a 'sending' parameter risks causing data races between code in the current isolation context and concurrent execution of the closure}}
+      useValue(x) // expected-note {{closure captures reference to mutable var 'x' which remains modifiable by code in the current isolation context}}
     }
 
     try await group.waitForAll()
@@ -1825,7 +1825,7 @@ func offByOneWithImplicitPartialApply() {
           let asdf = ""
           Task { @MainActor in
             a.description = asdf // expected-warning {{sending 'self' risks causing data races}}
-            // expected-note @-1 {{task-isolated 'self' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+            // expected-note @-1 {{'self' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against code in the current isolation context}}
           }
       }
   }
@@ -1863,8 +1863,8 @@ func testIndirectAndDirectSendingResultsWithGlobalActor() async {
 func testFunctionIsNotEmpty(input: SendableKlass) async throws {
   var result: [SendableKlass] = []
   try await withThrowingTaskGroup(of: Void.self) { taskGroup in // expected-warning {{no calls to throwing functions occur within 'try' expression}}
-    taskGroup.addTask { // expected-warning {{passing closure as a 'sending' parameter risks causing data races between code in the current task and concurrent execution of the closure}}
-      result.append(input) // expected-note {{closure captures reference to mutable var 'result' which remains modifiable by code in the current task}}
+    taskGroup.addTask { // expected-warning {{passing closure as a 'sending' parameter risks causing data races between code in the current isolation context and concurrent execution of the closure}}
+      result.append(input) // expected-note {{closure captures reference to mutable var 'result' which remains modifiable by code in the current isolation context}}
     }
   }
 }
@@ -1885,7 +1885,7 @@ extension NonIsolatedFinalKlass {
   // here. Make sure we do not crash.
   func testGetIsolationInfoOfField() async {
     await transferToMain(ns) // expected-warning {{sending 'self.ns' risks causing data races}}
-    // expected-note @-1 {{sending task-isolated 'self.ns' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and task-isolated uses}}
+    // expected-note @-1 {{sending 'self.ns' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
   }
 }
 
@@ -1895,7 +1895,7 @@ func mutableLocalCaptureDataRace() async {
   _ = x
 
   Task.detached { x = 1 }
-  // expected-warning @-1 {{closure passed as an argument to a 'sending' parameter captures reference to mutable var 'x' which is accessed later by code in the current task}}
+  // expected-warning @-1 {{closure passed as an argument to a 'sending' parameter captures reference to mutable var 'x' which is accessed later by code in the current isolation context}}
 
   x = 2 // expected-note {{access can happen concurrently}}
 }
@@ -1904,7 +1904,7 @@ func mutableLocalCaptureDataRace2() async {
   var x = 0
   x = 0
 
-  Task.detached { x = 1 } // expected-warning {{closure passed as an argument to a 'sending' parameter captures reference to mutable var 'x' which is accessed later by code in the current task}}
+  Task.detached { x = 1 } // expected-warning {{closure passed as an argument to a 'sending' parameter captures reference to mutable var 'x' which is accessed later by code in the current isolation context}}
 
   print(x) // expected-note {{access can happen concurrently}}
 }
@@ -1998,7 +1998,7 @@ func inferLocationOfCapturedTaskIsolatedSelfCorrectly() {
     func d() {
       a.block = c
       // expected-warning @-1 {{sending 'self' risks causing data races}}
-      // expected-note @-2 {{task-isolated 'self' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+      // expected-note @-2 {{'self' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against code in the current isolation context}}
     }
 
     @MainActor
@@ -2008,10 +2008,10 @@ func inferLocationOfCapturedTaskIsolatedSelfCorrectly() {
 
 nonisolated(nonsending) func testCallNonisolatedNonsending(_ x: NonSendableKlass) async {
   await useValueAsync(x) // expected-ni-warning {{sending 'x' risks causing data races}}
-  // expected-ni-note @-1 {{sending nonisolated(nonsending) task-isolated 'x' to @concurrent global function 'useValueAsync' risks causing data races between @concurrent and nonisolated(nonsending) task-isolated uses}}
+  // expected-ni-note @-1 {{sending 'x' to @concurrent global function 'useValueAsync' risks causing data races between @concurrent code and code in the current isolation context}}
   await useValueAsyncConcurrent(x) // expected-warning {{sending 'x' risks causing data races}}
-  // expected-ni-note @-1 {{sending nonisolated(nonsending) task-isolated 'x' to @concurrent global function 'useValueAsyncConcurrent' risks causing data races between @concurrent and nonisolated(nonsending) task-isolated uses}}
-  // expected-ni-ns-note @-2 {{sending task-isolated 'x' to @concurrent global function 'useValueAsyncConcurrent' risks causing data races between @concurrent and task-isolated uses}}
+  // expected-ni-note @-1 {{sending 'x' to @concurrent global function 'useValueAsyncConcurrent' risks causing data races between @concurrent code and code in the current isolation context}}
+  // expected-ni-ns-note @-2 {{sending 'x' to @concurrent global function 'useValueAsyncConcurrent' risks causing data races between @concurrent code and code in the current isolation context}}
 }
 
 func avoidThinkingClosureParameterIsSending() {
@@ -2037,7 +2037,7 @@ enum RequireSrcWhenStoringEvenWhenSendable {
   func test<T: Sendable>(t: T) {
     var result: T = t
     Task {
-      result = t // expected-warning {{closure passed as an argument to a 'sending' parameter captures reference to mutable var 'result' which is accessed later by code in the current task}}
+      result = t // expected-warning {{closure passed as an argument to a 'sending' parameter captures reference to mutable var 'result' which is accessed later by code in the current isolation context}}
     }
     useValue(result) // expected-note {{access can happen concurrently}}
   }
@@ -2045,7 +2045,7 @@ enum RequireSrcWhenStoringEvenWhenSendable {
   func test2() {
     var result: Any = 0
     Task {
-      result = 0 // expected-warning {{closure passed as an argument to a 'sending' parameter captures 'result' which is accessed later by code in the current task}}
+      result = 0 // expected-warning {{closure passed as an argument to a 'sending' parameter captures 'result' which is accessed later by code in the current isolation context}}
     }
     useValue(result) // expected-note {{access can happen concurrently}}
   }
@@ -2057,7 +2057,7 @@ enum RequireSrcWhenStoringEvenWhenSendable {
   func test3<T: Initializable & SendableMetatype>(type: T.Type) {
     var result = type.init()
     Task {
-      result = type.init() // expected-warning {{closure passed as an argument to a 'sending' parameter captures 'result' which is accessed later by code in the current task}}
+      result = type.init() // expected-warning {{closure passed as an argument to a 'sending' parameter captures 'result' which is accessed later by code in the current isolation context}}
     }
     useValue(result) // expected-note {{access can happen concurrently}}
   }
@@ -2071,8 +2071,8 @@ extension Optional where Wrapped: ~Copyable {
   mutating func takeSending() -> sending Self {
     let result = self
     self = nil
-    return result // expected-warning {{returning task-isolated 'result' as a 'sending' result risks causing data races}}
-    // expected-note @-1 {{returning task-isolated 'result' risks causing data races since the caller assumes that 'result' can be safely sent to other isolation domains}}
+    return result // expected-warning {{returning 'result' as a 'sending' result risks causing data races; this is an error in the Swift 6 language mode}}
+    // expected-note @-1 {{returning 'result' risks causing data races since the caller assumes that 'result' can be safely sent to other isolation domains}}
   }
 }
 
@@ -2086,7 +2086,7 @@ struct IndirectAssignTests {
       if let v = value {
         self.value = nil
         return v // expected-warning {{sending 'v' risks causing data races}}
-        // expected-note @-1 {{task-isolated 'v' cannot be a 'sending' result. task-isolated uses may race with caller uses}}
+        // expected-note @-1 {{'v' cannot be a 'sending' result. Code in the current task may race with caller uses}}
       } else {
         preconditionFailure("Consumed twice")
       }
@@ -2106,7 +2106,7 @@ struct IndirectAssignTests {
       if let value {
         self.value = nil
         return value // expected-warning {{sending 'value' risks causing data races}}
-        // expected-note @-1 {{task-isolated 'value' cannot be a 'sending' result. task-isolated uses may race with caller uses}}
+        // expected-note @-1 {{'value' cannot be a 'sending' result. Code in the current task may race with caller uses}}
       } else {
         preconditionFailure("Consumed twice")
       }
@@ -2119,8 +2119,8 @@ struct IndirectAssignTests {
     mutating func take() -> sending T {
       if let value {
         self.value = nil
-        return value // expected-warning {{returning task-isolated 'value' as a 'sending' result risks causing data races}}
-        // expected-note @-1 {{returning task-isolated 'value' risks causing data races since the caller assumes that 'value' can be safely sent to other isolation domains}}
+        return value // expected-warning {{returning 'value' as a 'sending' result risks causing data races; this is an error in the Swift 6 language mode}}
+        // expected-note @-1 {{returning 'value' risks causing data races since the caller assumes that 'value' can be safely sent to other isolation domains}}
       } else {
         preconditionFailure("Consumed twice")
       }
@@ -2136,7 +2136,7 @@ struct IndirectAssignTests {
       }
       self.value = nil
       return value // expected-warning {{sending 'value' risks causing data races}}
-      // expected-note @-1 {{task-isolated 'value' cannot be a 'sending' result. task-isolated uses may race with caller uses}}
+      // expected-note @-1 {{'value' cannot be a 'sending' result. Code in the current task may race with caller uses}}
     }
   }
 
@@ -2157,7 +2157,7 @@ struct IndirectAssignTests {
       if let value {
         self.value = nil
         return value.0 // expected-warning {{sending 'value.0' risks causing data races}}
-        // expected-note @-1 {{task-isolated 'value.0' cannot be a 'sending' result. task-isolated uses may race with caller uses}}
+        // expected-note @-1 {{'value.0' cannot be a 'sending' result. Code in the current task may race with caller uses}}
       } else {
         preconditionFailure("Consumed twice")
       }
@@ -2171,7 +2171,7 @@ struct IndirectAssignTests {
       if let value {
         self.value = nil
         return value // expected-warning {{sending 'value' risks causing data races}}
-        // expected-note @-1 {{task-isolated 'value' cannot be a 'sending' result. task-isolated uses may race with caller uses}}
+        // expected-note @-1 {{'value' cannot be a 'sending' result. Code in the current task may race with caller uses}}
       } else {
         preconditionFailure("Consumed twice")
       }
@@ -2200,7 +2200,7 @@ struct IndirectAssignTests {
       if let value {
         self.value = nil
         return value // expected-warning {{sending 'value' risks causing data races}}
-        // expected-note @-1 {{task-isolated 'value' cannot be a 'sending' result. task-isolated uses may race with caller uses}}
+        // expected-note @-1 {{'value' cannot be a 'sending' result. Code in the current task may race with caller uses}}
       } else {
         preconditionFailure("Consumed twice")
       }
@@ -2229,7 +2229,7 @@ struct IndirectAssignTests {
       if let value {
         self.value = nil
         return value // expected-warning {{sending 'value' risks causing data races}}
-        // expected-note @-1 {{task-isolated 'value' cannot be a 'sending' result. task-isolated uses may race with caller uses}}
+        // expected-note @-1 {{'value' cannot be a 'sending' result. Code in the current task may race with caller uses}}
       } else {
         preconditionFailure("Consumed twice")
       }
@@ -2243,7 +2243,7 @@ struct IndirectAssignTests {
       if let value, let innerValue = value {
         self.value = nil
         return innerValue // expected-warning {{sending 'innerValue' risks causing data races}}
-        // expected-note @-1 {{task-isolated 'innerValue' cannot be a 'sending' result. task-isolated uses may race with caller uses}}
+        // expected-note @-1 {{'innerValue' cannot be a 'sending' result. Code in the current task may race with caller uses}}
       } else {
         preconditionFailure("Consumed twice")
       }
@@ -2261,7 +2261,7 @@ struct IndirectAssignTests {
       case .full(let value):
         self = .empty
         return value // expected-warning {{sending 'value' risks causing data races}}
-        // expected-note @-1 {{task-isolated 'value' cannot be a 'sending' result. task-isolated uses may race with caller uses}}
+        // expected-note @-1 {{'value' cannot be a 'sending' result. Code in the current task may race with caller uses}}
       }
     }
   }
@@ -2272,7 +2272,7 @@ struct IndirectAssignTests {
     consuming func take() -> sending NonSendableKlass {
       if let value {
         return value // expected-warning {{sending 'value' risks causing data races}}
-        // expected-note @-1 {{task-isolated 'value' cannot be a 'sending' result. task-isolated uses may race with caller uses}}
+        // expected-note @-1 {{'value' cannot be a 'sending' result. Code in the current task may race with caller uses}}
       } else {
         preconditionFailure("Consumed twice")
       }
@@ -2303,7 +2303,7 @@ struct IndirectAssignTests {
       let value = values.removeFirst()
       values = []
       return value // expected-warning {{sending 'value' risks causing data races}}
-      // expected-note @-1 {{task-isolated 'value' cannot be a 'sending' result. task-isolated uses may race with caller uses}}
+      // expected-note @-1 {{'value' cannot be a 'sending' result. Code in the current task may race with caller uses}}
     }
   }
 
@@ -2316,7 +2316,7 @@ struct IndirectAssignTests {
       }
       values = [:]
       return value // expected-warning {{sending 'value' risks causing data races}}
-      // expected-note @-1 {{task-isolated 'value' cannot be a 'sending' result. task-isolated uses may race with caller uses}}
+      // expected-note @-1 {{'value' cannot be a 'sending' result. Code in the current task may race with caller uses}}
     }
   }
 
@@ -2336,7 +2336,7 @@ struct IndirectAssignTests {
       }
       // TODO: The warning should be on the user itself.
     } // expected-warning {{sending 'value2' risks causing data races}}
-    // expected-note @-1 {{task-isolated 'value2' cannot be a 'sending' result. task-isolated uses may race with caller uses}}
+    // expected-note @-1 {{'value2' cannot be a 'sending' result. Code in the current task may race with caller uses}}
   }
 
   struct LazyBox {
@@ -2352,7 +2352,7 @@ struct IndirectAssignTests {
       _value = nil
       initialized = false
       return result // expected-warning {{sending 'result' risks causing data races}}
-      // expected-note @-1 {{task-isolated 'result' cannot be a 'sending' result. task-isolated uses may race with caller uses}}
+      // expected-note @-1 {{'result' cannot be a 'sending' result. Code in the current task may race with caller uses}}
     }
   }
 
@@ -2364,7 +2364,7 @@ struct IndirectAssignTests {
     if let value = box.value {
       box.value = nil
       return value // expected-warning {{sending 'value' risks causing data races}}
-      // expected-note @-1 {{task-isolated 'value' cannot be a 'sending' result. task-isolated uses may race with caller uses}}
+      // expected-note @-1 {{'value' cannot be a 'sending' result. Code in the current task may race with caller uses}}
     } else {
       preconditionFailure("Consumed twice")
     }
@@ -2391,7 +2391,7 @@ struct IndirectAssignTests {
       if let value {
         self.value = nil
         return value // expected-warning {{sending 'value' risks causing data races}}
-        // expected-note @-1 {{task-isolated 'value' cannot be a 'sending' result. task-isolated uses may race with caller uses}}
+        // expected-note @-1 {{'value' cannot be a 'sending' result. Code in the current task may race with caller uses}}
       } else {
         preconditionFailure("Consumed twice")
       }

--- a/test/Concurrency/transfernonsendable_closure_captures.swift
+++ b/test/Concurrency/transfernonsendable_closure_captures.swift
@@ -49,7 +49,7 @@ func testMutableCopyableSendableStructWithEscapingMainActorAsync() {
   let _ = {
     escapingAsyncUse { @MainActor in
       useValue(x) // expected-error {{sending 'x' risks causing data races}}
-      // expected-note @-1 {{main actor-isolated closure captures reference to mutable 'x' which remains modifiable by code in the current task}}
+      // expected-note @-1 {{main actor-isolated closure captures reference to mutable 'x' which remains modifiable by code in the current isolation context}}
     }
   }
 }
@@ -59,7 +59,7 @@ func testCopyableNonsendableStructWithEscapingMainActorAsync() {
   let _ = {
     escapingAsyncUse { @MainActor in
       useValue(x) // expected-error {{sending 'x' risks causing data races}}
-      // expected-note @-1 {{task-isolated 'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+      // expected-note @-1 {{'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against code in the current isolation context}}
     }
   }
 }
@@ -70,7 +70,7 @@ func testMutableCopyableNonsendableStructWithEscapingMainActorAsync() {
   let _ = {
     escapingAsyncUse { @MainActor in
       useValue(x) // expected-error {{sending 'x' risks causing data races}}
-      // expected-note @-1 {{task-isolated 'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+      // expected-note @-1 {{'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against code in the current isolation context}}
     }
   }
 }
@@ -103,7 +103,7 @@ func testCopyableNonsendableStructWithNonescapingMainActorAsync() {
   let _ = {
     nonescapingAsyncUse { @MainActor in
       useValue(x) // expected-error {{sending 'x' risks causing data races}}
-      // expected-note @-1 {{task-isolated 'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+      // expected-note @-1 {{'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against code in the current isolation context}}
     }
   }
 }
@@ -114,7 +114,7 @@ func testMutableCopyableNonsendableStructWithNonescapingMainActorAsync() {
   let _ = {
     nonescapingAsyncUse { @MainActor in
       useValue(x) // expected-error {{sending 'x' risks causing data races}}
-      // expected-note @-1 {{task-isolated 'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+      // expected-note @-1 {{'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against code in the current isolation context}}
     }
   }
 }
@@ -138,7 +138,7 @@ func testMutableNoncopyableSendableStructWithEscapingMainActorAsync() {
   let _ = {
     escapingAsyncUse { @MainActor in
       useValue(x) // expected-error {{sending 'x' risks causing data races}}
-      // expected-note @-1 {{main actor-isolated closure captures reference to mutable 'x' which remains modifiable by code in the current task}}
+      // expected-note @-1 {{main actor-isolated closure captures reference to mutable 'x' which remains modifiable by code in the current isolation context}}
     }
   }
 }
@@ -148,7 +148,7 @@ func testNoncopyableNonsendableStructWithEscapingMainActorAsync() {
   let _ = {
     escapingAsyncUse { @MainActor in
       useValue(x) // expected-error {{sending 'x' risks causing data races}}
-      // expected-note @-1 {{task-isolated 'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+      // expected-note @-1 {{'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against code in the current isolation context}}
     }
   }
 }
@@ -159,7 +159,7 @@ func testMutableNoncopyableNonsendableStructWithEscapingMainActorAsync() {
   let _ = {
     escapingAsyncUse { @MainActor in
       useValue(x) // expected-error {{sending 'x' risks causing data races}}
-      // expected-note @-1 {{task-isolated 'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+      // expected-note @-1 {{'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against code in the current isolation context}}
     }
   }
 }
@@ -188,7 +188,7 @@ func testNoncopyableNonsendableStructWithNonescapingMainActorAsync() {
   let _ = {
     nonescapingAsyncUse { @MainActor in
       useValue(x) // expected-error {{sending 'x' risks causing data races}}
-      // expected-note @-1 {{task-isolated 'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+      // expected-note @-1 {{'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against code in the current isolation context}}
     }
   }
 }
@@ -199,7 +199,7 @@ func testMutableNoncopyableNonsendableStructWithNonescapingMainActorAsync() {
   let _ = {
     nonescapingAsyncUse { @MainActor in
       useValue(x) // expected-error {{sending 'x' risks causing data races}}
-      // expected-note @-1 {{task-isolated 'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+      // expected-note @-1 {{'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against code in the current isolation context}}
     }
   }
 }
@@ -232,7 +232,7 @@ func testCopyableNonsendableStructWithEscapingMainActorAsyncNormalCapture() {
   let _ = { [x] in
     escapingAsyncUse { @MainActor in
       useValue(x) // expected-error {{sending 'x' risks causing data races}}
-      // expected-note @-1 {{task-isolated 'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+      // expected-note @-1 {{'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against code in the current isolation context}}
     }
   }
 }
@@ -243,7 +243,7 @@ func testMutableCopyableNonsendableStructWithEscapingMainActorAsyncNormalCapture
   let _ = { [x] in
     escapingAsyncUse { @MainActor in
       useValue(x) // expected-error {{sending 'x' risks causing data races}}
-      // expected-note @-1 {{task-isolated 'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+      // expected-note @-1 {{'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against code in the current isolation context}}
     }
   }
 }
@@ -272,7 +272,7 @@ func testNoncopyableNonsendableStructWithEscapingMainActorAsyncNormalCapture() {
   let _ = { [x] in
     escapingAsyncUse { @MainActor in
       useValue(x) // expected-error {{sending 'x' risks causing data races}}
-      // expected-note @-1 {{task-isolated 'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+      // expected-note @-1 {{'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against code in the current isolation context}}
     }
   }
 }
@@ -283,7 +283,7 @@ func testMutableNoncopyableNonsendableStructWithEscapingMainActorAsyncNormalCapt
   let _ = { [x] in
     escapingAsyncUse { @MainActor in
       useValue(x) // expected-error {{sending 'x' risks causing data races}}
-      // expected-note @-1 {{task-isolated 'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+      // expected-note @-1 {{'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against code in the current isolation context}}
     }
   }
 }
@@ -312,7 +312,7 @@ func testCopyableNonsendableStructWithNonescapingMainActorAsyncNormalCapture() {
   let _ = { [x] in
     nonescapingAsyncUse { @MainActor in
       useValue(x) // expected-error {{sending 'x' risks causing data races}}
-      // expected-note @-1 {{task-isolated 'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+      // expected-note @-1 {{'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against code in the current isolation context}}
     }
   }
 }
@@ -323,7 +323,7 @@ func testMutableCopyableNonsendableStructWithNonescapingMainActorAsyncNormalCapt
   let _ = { [x] in
     nonescapingAsyncUse { @MainActor in
       useValue(x) // expected-error {{sending 'x' risks causing data races}}
-      // expected-note @-1 {{task-isolated 'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+      // expected-note @-1 {{'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against code in the current isolation context}}
     }
   }
 }
@@ -351,7 +351,7 @@ func testNoncopyableNonsendableStructWithNonescapingMainActorAsyncNormalCapture(
   let _ = { [x] in
     nonescapingAsyncUse { @MainActor in
       useValue(x) // expected-error {{sending 'x' risks causing data races}}
-      // expected-note @-1 {{task-isolated 'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+      // expected-note @-1 {{'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against code in the current isolation context}}
     }
   }
 }
@@ -362,7 +362,7 @@ func testMutableNoncopyableNonsendableStructWithNonescapingMainActorAsyncNormalC
   let _ = { [x] in
     nonescapingAsyncUse { @MainActor in
       useValue(x) // expected-error {{sending 'x' risks causing data races}}
-      // expected-note @-1 {{task-isolated 'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+      // expected-note @-1 {{'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against code in the current isolation context}}
     }
   }
 }
@@ -395,7 +395,7 @@ func testCopyableNonsendableClassWithEscapingMainActorAsyncWeakCapture() {
   let _ = { [weak x] in
     escapingAsyncUse { @MainActor in
       useValue(x) // expected-error {{sending 'x' risks causing data races}}
-      // expected-note @-1 {{task-isolated 'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+      // expected-note @-1 {{'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against code in the current isolation context}}
     }
   }
 }
@@ -406,7 +406,7 @@ func testMutableCopyableNonsendableClassWithEscapingMainActorAsyncWeakCapture() 
   let _ = { [weak x] in
     escapingAsyncUse { @MainActor in
       useValue(x) // expected-error {{sending 'x' risks causing data races}}
-      // expected-note @-1 {{task-isolated 'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+      // expected-note @-1 {{'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against code in the current isolation context}}
     }
   }
 }
@@ -435,7 +435,7 @@ func testCopyableNonsendableClassWithNonescapingMainActorAsyncWeakCapture() {
   let _ = { [weak x] in
     nonescapingAsyncUse { @MainActor in
       useValue(x) // expected-error {{sending 'x' risks causing data races}}
-      // expected-note @-1 {{task-isolated 'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+      // expected-note @-1 {{'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against code in the current isolation context}}
     }
   }
 }
@@ -446,7 +446,7 @@ func testMutableCopyableNonsendableClassWithNonescapingMainActorAsyncWeakCapture
   let _ = { [weak x] in
     nonescapingAsyncUse { @MainActor in
       useValue(x) // expected-error {{sending 'x' risks causing data races}}
-      // expected-note @-1 {{task-isolated 'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+      // expected-note @-1 {{'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against code in the current isolation context}}
     }
   }
 }
@@ -483,7 +483,7 @@ func testChainedClosuresReadOnlyWeakCaptureNonsendable() {
     let inner = {
       escapingAsyncUse { @MainActor in
         if let obj = obj { // expected-error {{sending 'obj' risks causing data races}}
-                  // expected-note @-1 {{task-isolated 'obj' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+                  // expected-note @-1 {{'obj' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against code in the current isolation context}}
           useValue(obj)
         }
       }
@@ -518,14 +518,14 @@ func testMultipleWeakCapturesNonsendable() {
   let _ = { [weak obj1, weak obj2, weak obj3] in
     escapingAsyncUse { @MainActor in
       if let o1 = obj1 { // expected-error {{sending 'obj1' risks causing data races}}
-        useValue(o1) // expected-note @-1 {{task-isolated 'obj1' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+        useValue(o1) // expected-note @-1 {{'obj1' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against code in the current isolation context}}
       }
       if let o2 = obj2 { // expected-error {{sending 'obj2' risks causing data races}}
-        // expected-note @-1 {{task-isolated 'obj2' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+        // expected-note @-1 {{'obj2' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against code in the current isolation context}}
         useValue(o2)
       }
       if let o3 = obj3 { // expected-error {{sending 'obj3' risks causing data races}}
-        // expected-note @-1 {{task-isolated 'obj3' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+        // expected-note @-1 {{'obj3' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against code in the current isolation context}}
         useValue(o3)
       }
     }
@@ -575,7 +575,7 @@ class DelegateNonsendable {
     let _ = { [weak self] in
       escapingAsyncUse { @MainActor in
         guard let self = self else { return } // expected-error {{sending 'self' risks causing data races}}
-        // expected-note @-1 {{task-isolated 'self' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+        // expected-note @-1 {{'self' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against code in the current isolation context}}
         useValue(self)
       }
     }
@@ -605,7 +605,7 @@ func testWeakCaptureInLoopNonsendable() {
     escapingAsyncUse { @MainActor in
       for _ in 0..<10 {
         if let obj = obj { // expected-error {{sending 'obj' risks causing data races}}
-          // expected-note @-1 {{task-isolated 'obj' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+          // expected-note @-1 {{'obj' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against code in the current isolation context}}
           useValue(obj)
         }
       }
@@ -657,11 +657,11 @@ func testNestedWeakCapturesNonsendable() {
     let _ = { [weak outer, weak inner] in
       escapingAsyncUse { @MainActor in
         if let o = outer { // expected-error {{sending 'outer' risks causing data races}}
-          // expected-note @-1 {{task-isolated 'outer' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+          // expected-note @-1 {{'outer' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against code in the current isolation context}}
           useValue(o)
         }
         if let i = inner { // expected-error {{sending 'inner' risks causing data races}}
-          // expected-note @-1 {{task-isolated 'inner' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+          // expected-note @-1 {{'inner' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against code in the current isolation context}}
           useValue(i)
         }
       }
@@ -724,7 +724,7 @@ func testChainedClosuresPartialWriteSendable() {
       escapingAsyncUse { @MainActor in
         if let obj = readOnly1 { useValue(obj) }  // Read-only throughout
         if let obj = writable { // expected-error {{sending 'writable' risks causing data races}}
-          // expected-note @-1 {{closure captures reference to mutable 'writable' which remains modifiable by code in the current task}}
+          // expected-note @-1 {{closure captures reference to mutable 'writable' which remains modifiable by code in the current isolation context}}
           useValue(obj)
         }
         if let obj = readOnly2 { useValue(obj) }  // Read-only throughout
@@ -775,7 +775,7 @@ func testMultipleClosuresSameWeakCaptureNonsendable() {
   let closure1 = { [weak obj] in
     escapingAsyncUse { @MainActor in
       if let o = obj { // expected-error {{sending 'obj' risks causing data races}}
-        // expected-note @-1 {{task-isolated 'obj' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+        // expected-note @-1 {{'obj' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against code in the current isolation context}}
         useValue(o)
       }
     }
@@ -784,7 +784,7 @@ func testMultipleClosuresSameWeakCaptureNonsendable() {
   let closure2 = { [weak obj] in
     escapingAsyncUse { @MainActor in
       if let o = obj { // expected-error {{sending 'obj' risks causing data races}}
-        // expected-note @-1 {{task-isolated 'obj' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+        // expected-note @-1 {{'obj' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against code in the current isolation context}}
         useValue(o)
       }
     }
@@ -836,7 +836,7 @@ func testWeakCaptureProtocolNonsendable<T: ProtocolNonsendable>(_ obj: T) {
   let _ = { [weak obj] in
     escapingAsyncUse { @MainActor in
       if let obj = obj { // expected-error {{sending 'obj' risks causing data races}}
-        // expected-note @-1 {{task-isolated 'obj' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+        // expected-note @-1 {{'obj' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against code in the current isolation context}}
         useValue(obj)
       }
     }
@@ -863,7 +863,7 @@ func testChainedClosuresProtocolNonsendable<T: ProtocolNonsendable>(_ obj: T) {
     let inner = {
       escapingAsyncUse { @MainActor in
         if let obj = obj { // expected-error {{sending 'obj' risks causing data races}}
-          // expected-note @-1 {{task-isolated 'obj' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+          // expected-note @-1 {{'obj' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against code in the current isolation context}}
           useValue(obj)
         }
       }
@@ -888,15 +888,15 @@ func testMultipleProtocolWeakCapturesNonsendable<T: ProtocolNonsendable, U: Prot
   let _ = { [weak obj1, weak obj2, weak obj3] in
     escapingAsyncUse { @MainActor in
       if let o1 = obj1 { // expected-error {{sending 'obj1' risks causing data races}}
-        // expected-note @-1 {{task-isolated 'obj1' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+        // expected-note @-1 {{'obj1' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against code in the current isolation context}}
         useValue(o1)
       }
       if let o2 = obj2 { // expected-error {{sending 'obj2' risks causing data races}}
-        // expected-note @-1 {{task-isolated 'obj2' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+        // expected-note @-1 {{'obj2' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against code in the current isolation context}}
         useValue(o2)
       }
       if let o3 = obj3 { // expected-error {{sending 'obj3' risks causing data races}}
-        // expected-note @-1 {{task-isolated 'obj3' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+        // expected-note @-1 {{'obj3' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against code in the current isolation context}}
         useValue(o3)
       }
     }
@@ -928,7 +928,7 @@ class ConcreteDelegateNonsendable: DelegateProtocolNonsendable {
     let _ = { [weak self] in
       escapingAsyncUse { @MainActor in
         guard let self = self else { return } // expected-error {{sending 'self' risks causing data races}}
-        // expected-note @-1 {{task-isolated 'self' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+        // expected-note @-1 {{'self' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against code in the current isolation context}}
         useValue(self)
       }
     }
@@ -952,11 +952,11 @@ func testNestedProtocolWeakCapturesNonsendable<T: ProtocolNonsendable, U: Protoc
     let _ = { [weak outer, weak inner = inner] in
       escapingAsyncUse { @MainActor in
         if let o = outer { // expected-error {{sending 'outer' risks causing data races}}
-          // expected-note @-1 {{task-isolated 'outer' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+          // expected-note @-1 {{'outer' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against code in the current isolation context}}
           useValue(o)
         }
         if let i = inner { // expected-error {{sending 'inner' risks causing data races}}
-          // expected-note @-1 {{task-isolated 'inner' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+          // expected-note @-1 {{'inner' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against code in the current isolation context}}
           useValue(i)
         }
       }
@@ -1003,7 +1003,7 @@ extension ProtocolNonsendable {
     return { [weak self] in
       escapingAsyncUse { @MainActor in
         guard let self = self else { return } // expected-error {{sending 'self' risks causing data races}}
-        // expected-note @-1 {{task-isolated 'self' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+        // expected-note @-1 {{'self' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against code in the current isolation context}}
         useValue(self)
       }
     }
@@ -1025,7 +1025,7 @@ func testExistentialWeakCaptureNonsendable(_ obj: any ProtocolNonsendable) {
   let _ = { [weak obj] in
     escapingAsyncUse { @MainActor in
       if let obj = obj { // expected-error {{sending 'obj' risks causing data races}}
-        // expected-note @-1 {{task-isolated 'obj' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+        // expected-note @-1 {{'obj' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against code in the current isolation context}}
         useValue(obj)
       }
     }
@@ -1081,7 +1081,7 @@ func testCopyableNonsendableClassWithEscapingMainActorAsyncUnownedCapture() {
   let _ = { [unowned x] in
     escapingAsyncUse { @MainActor in
       useValue(x) // expected-error {{sending 'x' risks causing data races}}
-      // expected-note @-1 {{task-isolated 'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+      // expected-note @-1 {{'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against code in the current isolation context}}
     }
   }
 }
@@ -1092,7 +1092,7 @@ func testMutableCopyableNonsendableClassWithEscapingMainActorAsyncUnownedCapture
   let _ = { [unowned x] in
     escapingAsyncUse { @MainActor in
       useValue(x) // expected-error {{sending 'x' risks causing data races}}
-      // expected-note @-1 {{task-isolated 'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+      // expected-note @-1 {{'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against code in the current isolation context}}
     }
   }
 }
@@ -1121,7 +1121,7 @@ func testCopyableNonsendableClassWithNonescapingMainActorAsyncUnownedCapture() {
   let _ = { [unowned x] in
     nonescapingAsyncUse { @MainActor in
       useValue(x) // expected-error {{sending 'x' risks causing data races}}
-      // expected-note @-1 {{task-isolated 'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+      // expected-note @-1 {{'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against code in the current isolation context}}
     }
   }
 }
@@ -1132,7 +1132,7 @@ func testMutableCopyableNonsendableClassWithNonescapingMainActorAsyncUnownedCapt
   let _ = { [unowned x] in
     nonescapingAsyncUse { @MainActor in
       useValue(x) // expected-error {{sending 'x' risks causing data races}}
-      // expected-note @-1 {{task-isolated 'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+      // expected-note @-1 {{'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against code in the current isolation context}}
     }
   }
 }
@@ -1148,7 +1148,7 @@ func testGenericSendableWithEscapingMainActorAsync<T : ~Copyable>(_ value: consu
   let _ = {
     escapingAsyncUse { @MainActor in
       useValue(x) // expected-error {{sending 'x' risks causing data races}}
-      // expected-note @-1 {{main actor-isolated closure captures reference to mutable 'x' which remains modifiable by code in the current task}}
+      // expected-note @-1 {{main actor-isolated closure captures reference to mutable 'x' which remains modifiable by code in the current isolation context}}
     }
   }
 }
@@ -1161,7 +1161,7 @@ func testMutableGenericSendableWithEscapingMainActorAsync<T : ~Copyable>(
   let _ = {
     escapingAsyncUse { @MainActor in
       useValue(x) // expected-error {{sending 'x' risks causing data races}}
-      // expected-note @-1 {{main actor-isolated closure captures reference to mutable 'x' which remains modifiable by code in the current task}}
+      // expected-note @-1 {{main actor-isolated closure captures reference to mutable 'x' which remains modifiable by code in the current isolation context}}
     }
   }
 }
@@ -1174,7 +1174,7 @@ func testGenericNonsendableWithEscapingMainActorAsync<T : ~Copyable>(
   let _ = {
     escapingAsyncUse { @MainActor in
       useValue(x) // expected-error {{sending 'x' risks causing data races}}
-      // expected-note @-1 {{task-isolated 'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+      // expected-note @-1 {{'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against code in the current isolation context}}
     }
   }
 }
@@ -1187,7 +1187,7 @@ func testMutableGenericNonsendableWithEscapingMainActorAsync<T : ~Copyable>(
   let _ = {
     escapingAsyncUse { @MainActor in
       useValue(x) // expected-error {{sending 'x' risks causing data races}}
-      // expected-note @-1 {{task-isolated 'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+      // expected-note @-1 {{'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against code in the current isolation context}}
     }
   }
 }
@@ -1224,7 +1224,7 @@ func testGenericNonsendableWithNonescapingMainActorAsync<T : ~Copyable>(
   let _ = {
     nonescapingAsyncUse { @MainActor in
       useValue(x) // expected-error {{sending 'x' risks causing data races}}
-      // expected-note @-1 {{task-isolated 'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+      // expected-note @-1 {{'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against code in the current isolation context}}
     }
   }
 }
@@ -1237,7 +1237,7 @@ func testMutableGenericNonsendableWithNonescapingMainActorAsync<T : ~Copyable>(
   let _ = {
     nonescapingAsyncUse { @MainActor in
       useValue(x) // expected-error {{sending 'x' risks causing data races}}
-      // expected-note @-1 {{task-isolated 'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+      // expected-note @-1 {{'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against code in the current isolation context}}
     }
   }
 }
@@ -1288,7 +1288,7 @@ func testGenericNoncopyableNonsendableLetWithEscapingMainActorAsync<T: ~Copyable
   let _ = {
     escapingAsyncUse { @MainActor in
       useValue(x) // expected-error {{sending 'x' risks causing data races}}
-      // expected-note @-1 {{task-isolated 'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+      // expected-note @-1 {{'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against code in the current isolation context}}
     }
   }
 }
@@ -1342,7 +1342,7 @@ func testNestedClosuresNoncopyableNonsendable() {
     let _ = {
       escapingAsyncUse { @MainActor in
         useValue(x) // expected-error {{sending 'x' risks causing data races}}
-        // expected-note @-1 {{task-isolated 'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+        // expected-note @-1 {{'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against code in the current isolation context}}
       }
     }
   }
@@ -1357,7 +1357,7 @@ func testNestedClosuresMixedSendability() {
       escapingAsyncUse { @MainActor in
         useValue(sendable) // OK
         useValue(nonsendable) // expected-error {{sending 'nonsendable' risks causing data races}}
-        // expected-note @-1 {{task-isolated 'nonsendable' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+        // expected-note @-1 {{'nonsendable' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against code in the current isolation context}}
       }
     }
   }
@@ -1404,7 +1404,7 @@ func useAfterFreeClosureTests() {
     var x = KlassNonsendable()
     x = KlassNonsendable()
     acceptsSendingClosure {
-      _ = x // expected-error {{closure passed as an argument to a 'sending' parameter captures 'x' which is accessed later by code in the current task}}
+      _ = x // expected-error {{closure passed as an argument to a 'sending' parameter captures 'x' which is accessed later by code in the current isolation context}}
     }
     useValue(x) // expected-note {{access can happen concurrently}}
   }
@@ -1429,7 +1429,7 @@ func useAfterFreeClosureTests() {
     var x = NoncopyableStructNonsendable()
     x = NoncopyableStructNonsendable()
     acceptsSendingClosure {
-      _ = x // expected-error {{closure passed as an argument to a 'sending' parameter captures 'x' which is accessed later by code in the current task}}
+      _ = x // expected-error {{closure passed as an argument to a 'sending' parameter captures 'x' which is accessed later by code in the current isolation context}}
       x = NoncopyableStructNonsendable()
     }
     useValue(x) // expected-note {{access can happen concurrently}}
@@ -1453,7 +1453,7 @@ func useAfterFreeClosureTests() {
     var x = KlassNonsendable()
     x = KlassNonsendable()
     acceptsEscapingSendingClosure {
-      _ = x // expected-error {{closure passed as an argument to a 'sending' parameter captures 'x' which is accessed later by code in the current task}}
+      _ = x // expected-error {{closure passed as an argument to a 'sending' parameter captures 'x' which is accessed later by code in the current isolation context}}
     }
     useValue(x) // expected-note {{access can happen concurrently}}
   }
@@ -1462,7 +1462,7 @@ func useAfterFreeClosureTests() {
     var x = KlassSendable()
     x = KlassSendable()
     acceptsEscapingSendingClosure {
-      x = KlassSendable() // expected-error {{closure passed as an argument to a 'sending' parameter captures reference to mutable var 'x' which is accessed later by code in the current task}}
+      x = KlassSendable() // expected-error {{closure passed as an argument to a 'sending' parameter captures reference to mutable var 'x' which is accessed later by code in the current isolation context}}
     }
     x = KlassSendable() // expected-note {{access can happen concurrently}}
     _ = x
@@ -1472,7 +1472,7 @@ func useAfterFreeClosureTests() {
     var x = NoncopyableStructNonsendable()
     x = NoncopyableStructNonsendable()
     acceptsEscapingSendingClosure {
-      x = NoncopyableStructNonsendable() // expected-error {{closure passed as an argument to a 'sending' parameter captures 'x' which is accessed later by code in the current task}}
+      x = NoncopyableStructNonsendable() // expected-error {{closure passed as an argument to a 'sending' parameter captures 'x' which is accessed later by code in the current isolation context}}
     }
     useValue(x) // expected-note {{access can happen concurrently}}
   }
@@ -1481,7 +1481,7 @@ func useAfterFreeClosureTests() {
     var x = NoncopyableStructSendable() // expected-warning {{variable 'x' was written to, but never read}}
     x = NoncopyableStructSendable()
     acceptsEscapingSendingClosure {
-      x = NoncopyableStructSendable() // expected-error {{closure passed as an argument to a 'sending' parameter captures reference to mutable var 'x' which is accessed later by code in the current task}}
+      x = NoncopyableStructSendable() // expected-error {{closure passed as an argument to a 'sending' parameter captures reference to mutable var 'x' which is accessed later by code in the current isolation context}}
     }
     x = NoncopyableStructSendable() // expected-note {{access can happen concurrently}}
   }

--- a/test/Concurrency/transfernonsendable_initializers.swift
+++ b/test/Concurrency/transfernonsendable_initializers.swift
@@ -74,10 +74,10 @@ func initActorWithSyncNonIsolatedInit() {
 func initActorWithSyncNonIsolatedInit2(_ k: NonSendableKlass) {
   // TODO: This should say actor isolated.
   _ = ActorWithSynchronousNonIsolatedInit(k) // expected-error {{sending 'k' risks causing data races}}
-  // expected-note @-1 {{sending task-isolated 'k' to actor-isolated initializer 'init(_:)' risks causing data races between actor-isolated and task-isolated uses}}
+  // expected-note @-1 {{sending 'k' to actor-isolated initializer 'init(_:)' risks causing data races between actor-isolated code and code in the current isolation context}}
   let _ = { @MainActor in
     print(k) // expected-error {{sending 'k' risks causing data races}}
-    // expected-note @-1 {{task-isolated 'k' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+    // expected-note @-1 {{'k' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against code in the current isolation context}}
   }
 }
 
@@ -103,10 +103,10 @@ func initActorWithAsyncIsolatedInit() async {
 func initActorWithAsyncIsolatedInit2(_ k: NonSendableKlass) async {
   // TODO: This should say actor isolated.
   _ = await ActorWithAsyncIsolatedInit(k) // expected-error {{sending 'k' risks causing data races}}
-  // expected-note @-1 {{sending task-isolated 'k' to actor-isolated initializer 'init(_:)' risks causing data races between actor-isolated and task-isolated uses}}
+  // expected-note @-1 {{sending 'k' to actor-isolated initializer 'init(_:)' risks causing data races between actor-isolated code and code in the current isolation context}}
   let _ = { @MainActor in
     print(k) // expected-error {{sending 'k' risks causing data races}}
-    // expected-note @-1 {{task-isolated 'k' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+    // expected-note @-1 {{'k' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against code in the current isolation context}}
   }
 }
 
@@ -123,7 +123,7 @@ class ClassWithSynchronousNonIsolatedInit {
 
     let _ = { @MainActor in
       print(newK) // expected-error {{sending 'newK' risks causing data races}}
-      // expected-note @-1 {{task-isolated 'newK' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+      // expected-note @-1 {{'newK' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against code in the current isolation context}}
     }
   }
 
@@ -142,7 +142,7 @@ func initClassWithSyncNonIsolatedInit2(_ k: NonSendableKlass) {
   _ = ClassWithSynchronousNonIsolatedInit(k)
   let _ = { @MainActor in
     print(k) // expected-error {{sending 'k' risks causing data races}}
-    // expected-note @-1 {{task-isolated 'k' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+    // expected-note @-1 {{'k' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against code in the current isolation context}}
   }
 }
 
@@ -170,10 +170,10 @@ func initClassWithAsyncIsolatedInit() async {
 
 func initClassWithAsyncIsolatedInit2(_ k: NonSendableKlass) async {
   _ = await ClassWithAsyncIsolatedInit(k) // expected-error {{sending 'k' risks causing data races}}
-  // expected-note @-1 {{sending task-isolated 'k' to global actor 'CustomActor'-isolated initializer 'init(_:)' risks causing data races between global actor 'CustomActor'-isolated and task-isolated uses}}
+  // expected-note @-1 {{sending 'k' to global actor 'CustomActor'-isolated initializer 'init(_:)' risks causing data races between global actor 'CustomActor'-isolated code and code in the current isolation context}}
   let _ = { @MainActor in
     print(k) // expected-error {{sending 'k' risks causing data races}}
-    // expected-note @-1 {{task-isolated 'k' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+    // expected-note @-1 {{'k' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against code in the current isolation context}}
   }
 }
 

--- a/test/Concurrency/transfernonsendable_inout_sending_indirect_out.swift
+++ b/test/Concurrency/transfernonsendable_inout_sending_indirect_out.swift
@@ -166,10 +166,10 @@ func testSendingClosureAssignsToCapture() {
   let m2 = NonSendableKlass()
   let _ = takeSendingClosure { (state: inout sending NonSendableKlass) -> NonSendableKlass in
     state = m2
-    return state // expected-error {{returning task-isolated 'state' as a 'sending' result risks causing data races}}
-    // expected-note @-1 {{returning task-isolated 'state' risks causing data races since the caller assumes that 'state' can be safely sent to other isolation domains}}
-    // expected-error @-2 {{'inout sending' parameter 'state' cannot be task-isolated at end of function}}
-    // expected-note @-3 {{task-isolated 'state' risks causing races in between task-isolated uses and caller uses since caller assumes value is not actor isolated}}
+    return state // expected-error {{returning 'state' as a 'sending' result risks causing data races}}
+    // expected-note @-1 {{returning 'state' risks causing data races since the caller assumes that 'state' can be safely sent to other isolation domains}}
+    // expected-error @-2 {{'inout sending' parameter 'state' is accessible to code in the current isolation context at end of function}}
+    // expected-note @-3 {{'state' risks causing races in between code in the current isolation context and caller uses since caller assumes value is not actor isolated}}
   }
 }
 

--- a/test/Concurrency/transfernonsendable_inout_sending_mutex.swift
+++ b/test/Concurrency/transfernonsendable_inout_sending_mutex.swift
@@ -65,9 +65,9 @@ func testMutexWithLockAssignsToCapture() {
   let m2 = NonSendableKlass()
   let _ = m.withLock { (state: inout sending NonSendableKlass) -> NonSendableKlass in
     state = m2
-    return state // expected-error {{'inout sending' parameter 'state' cannot be task-isolated at end of function}}
-    // expected-note @-1 {{task-isolated 'state' risks causing races in between task-isolated uses and caller uses since caller assumes value is not actor isolated}}
-    // expected-error @-2 {{returning task-isolated 'state' as a 'sending' result risks causing data races}}
-    // expected-note @-3 {{returning task-isolated 'state' risks causing data races since the caller assumes that 'state' can be safely sent to other isolation domains}}
+    return state // expected-error {{'inout sending' parameter 'state' is accessible to code in the current isolation context at end of function}}
+    // expected-note @-1 {{'state' risks causing races in between code in the current isolation context and caller uses since caller assumes value is not actor isolated}}
+    // expected-error @-2 {{returning 'state' as a 'sending' result risks causing data races}}
+    // expected-note @-3 {{returning 'state' risks causing data races since the caller assumes that 'state' can be safely sent to other isolation domains}}
   }
 }

--- a/test/Concurrency/transfernonsendable_inout_sending_params.swift
+++ b/test/Concurrency/transfernonsendable_inout_sending_params.swift
@@ -171,9 +171,9 @@ func passInOutSendingToInOutSending(_ x: inout sending NonSendableKlass) {
 
 func passInOutSendingMultipleTimes(_ x: inout NonSendableStruct) {
   useInOutSending(&x.first, &x.second) // expected-warning {{sending 'x.first' risks causing data races}}
-  // expected-note @-1 {{task-isolated 'x.first' is passed as a 'sending' parameter}}
+  // expected-note @-1 {{'x.first' is passed as a 'sending' parameter}}
   // expected-warning @-2 {{sending 'x.second' risks causing data races}}
-  // expected-note @-3 {{task-isolated 'x.second' is passed as a 'sending' parameter}}
+  // expected-note @-3 {{'x.second' is passed as a 'sending' parameter}}
 }
 
 func twoInoutSendingParamsInSameRegion(_ x: inout sending NonSendableKlass, _ y: inout sending NonSendableKlass) {

--- a/test/Concurrency/transfernonsendable_isolationcrossing_partialapply.swift
+++ b/test/Concurrency/transfernonsendable_isolationcrossing_partialapply.swift
@@ -43,16 +43,16 @@ actor ProtectsNonSendable {
   nonisolated func testParameter(_ nsArg: NonSendableKlass) async {
     self.assumeIsolated { isolatedSelf in
       isolatedSelf.ns = nsArg // expected-warning {{sending 'nsArg' risks causing data races}}
-      // expected-concurrent-note @-1 {{task-isolated 'nsArg' is captured by a actor-isolated closure. actor-isolated uses in closure may race against later nonisolated uses}}
-      // expected-ni-note @-2 {{task-isolated 'nsArg' is captured by a actor-isolated closure. actor-isolated uses in closure may race against later nonisolated uses}}
+      // expected-concurrent-note @-1 {{'nsArg' is captured by a actor-isolated closure. actor-isolated uses in closure may race against code in the current isolation context}}
+      // expected-ni-note @-2 {{'nsArg' is captured by a actor-isolated closure. actor-isolated uses in closure may race against code in the current isolation context}}
     }
   }
 
   nonisolated func testParameterOutOfLine2(_ nsArg: NonSendableKlass) async {
     let closure: (isolated ProtectsNonSendable) -> () = { isolatedSelf in
       isolatedSelf.ns = nsArg // expected-warning {{sending 'nsArg' risks causing data races}}
-      // expected-concurrent-note @-1 {{task-isolated 'nsArg' is captured by a actor-isolated closure. actor-isolated uses in closure may race against later nonisolated uses}}
-      // expected-ni-note @-2 {{task-isolated 'nsArg' is captured by a actor-isolated closure. actor-isolated uses in closure may race against later nonisolated uses}}
+      // expected-concurrent-note @-1 {{'nsArg' is captured by a actor-isolated closure. actor-isolated uses in closure may race against code in the current isolation context}}
+      // expected-ni-note @-2 {{'nsArg' is captured by a actor-isolated closure. actor-isolated uses in closure may race against code in the current isolation context}}
     }
     self.assumeIsolated(closure)
     self.assumeIsolated(closure)
@@ -63,8 +63,8 @@ actor ProtectsNonSendable {
     doSomething(l, nsArg)
     self.assumeIsolated { isolatedSelf in
       isolatedSelf.ns = l // expected-warning {{sending 'l' risks causing data races}}
-      // expected-concurrent-note @-1 {{task-isolated 'l' is captured by a actor-isolated closure. actor-isolated uses in closure may race against later nonisolated uses}}
-      // expected-ni-note @-2 {{task-isolated 'l' is captured by a actor-isolated closure. actor-isolated uses in closure may race against later nonisolated uses}}
+      // expected-concurrent-note @-1 {{'l' is captured by a actor-isolated closure. actor-isolated uses in closure may race against code in the current isolation context}}
+      // expected-ni-note @-2 {{'l' is captured by a actor-isolated closure. actor-isolated uses in closure may race against code in the current isolation context}}
     }
   }
 

--- a/test/Concurrency/transfernonsendable_merge_region_diagnostics.swift
+++ b/test/Concurrency/transfernonsendable_merge_region_diagnostics.swift
@@ -21,7 +21,7 @@
 //      back to the merge site, or to the func keyword for SILFunctionArgument)
 //      trips the verifier.
 //
-//   3. The task-isolated side renders as "code in the current task" instead
+//   3. The task-isolated side renders as "code in the current isolation context" instead
 //      of "task-isolated code", matching the rest of the diagnostic suite.
 //
 //   4. The isolatedfn primary has two variants: a named form that embeds the
@@ -36,7 +36,7 @@
 // notes from one of two note diagnostics. The matrix below records, per
 // emitter, which RegionMergeReason dispatches to it, which scenarios in this
 // file exercise it, and which isolation-string variants
-// (cross-actor vs "code in the current task") are covered. The unknown-pattern
+// (cross-actor vs "code in the current isolation context") are covered. The unknown-pattern
 // fallback companion lives in transfernonsendable_merge_region_checker_failures.swift.
 //
 //   emitter / primary diag                  | reason(s)                    | covered by                  | iso variants
@@ -108,12 +108,12 @@ struct TwoIsolatedFields {
 }
 
 /////////////////////////////////////////////////////////////////////
-// MARK: isolated callee + task-isolated source ("code in the current task")
+// MARK: isolated callee + task-isolated source ("code in the current isolation context")
 /////////////////////////////////////////////////////////////////////
 
 // A nonisolated method on a non-Sendable class invoking a @MainActor getter
 // on `self`. `self` is task-isolated -- the merge primary should render this
-// side as "code in the current task". The `self` value note anchors at the
+// side as "code in the current isolation context". The `self` value note anchors at the
 // `func call` token (col 8) because `self` is a SILFunctionArgument and we
 // resolve to the parameter decl loc.
 //
@@ -121,11 +121,11 @@ struct TwoIsolatedFields {
 // follow-up assignment-merge so the diagnostics here focus on the isolatedfn
 // case.
 final class TaskIsolatedSelfTest { // expected-note {{class 'TaskIsolatedSelfTest' does not conform to the 'Sendable' protocol}}
-  func call() async { // expected-named-note@:8 {{'self' is exposed to code in the current task}}
-                      // expected-bare-note@-1:8 {{value is exposed to code in the current task}}
+  func call() async { // expected-named-note@:8 {{'self' is exposed to code in the current isolation context}}
+                      // expected-bare-note@-1:8 {{value is exposed to code in the current isolation context}}
     _ = await x
-    // expected-named-warning @-1 {{passing 'self' to main actor-isolated getter for property 'x' could allow for references between values exposed to code in the current task and main actor-isolated code risking data races}}
-    // expected-bare-warning @-2 {{passing value to main actor-isolated getter for property 'x' could allow for references between values exposed to code in the current task and main actor-isolated code risking data races}}
+    // expected-named-warning @-1 {{passing 'self' to main actor-isolated getter for property 'x' could allow for references between values exposed to code in the current isolation context and main actor-isolated code risking data races}}
+    // expected-bare-warning @-2 {{passing value to main actor-isolated getter for property 'x' could allow for references between values exposed to code in the current isolation context and main actor-isolated code risking data races}}
     // expected-warning @-3 {{non-Sendable type 'TaskIsolatedSelfTest' cannot be sent into main actor-isolated context in call to property 'x'; this is an error in the Swift 6 language mode}}
   }
 
@@ -183,7 +183,7 @@ struct TupleMerge {
 }
 
 /////////////////////////////////////////////////////////////////
-// MARK: assign — task-isolated source side ("code in the current task")
+// MARK: assign — task-isolated source side ("code in the current isolation context")
 /////////////////////////////////////////////////////////////////
 
 // AsyncStream<Element>.init(_:) takes a @Sendable closure executed in a task
@@ -199,7 +199,7 @@ final class TaskAssignTest {
   var stored: NonSendableKlass = NonSendableKlass()
   func makeStream() -> AsyncStream<NonSendableKlass> {
     AsyncStream<NonSendableKlass> {
-      self.stored // expected-warning {{assignment could allow for references between values exposed to code in the current task and main actor-isolated code risking data races}}
+      self.stored // expected-warning {{assignment could allow for references between values exposed to code in the current isolation context and main actor-isolated code risking data races}}
       // expected-named-note @-1 {{'self.stored.some' is exposed to main actor-isolated code}}
       // expected-bare-note @-2 {{value is exposed to main actor-isolated code}}
       // expected-warning @-3 {{main actor-isolated property 'stored' cannot be accessed from outside of the actor; this is an error in the Swift 6 language mode}}

--- a/test/Concurrency/transfernonsendable_nonisolatedunsafe.swift
+++ b/test/Concurrency/transfernonsendable_nonisolatedunsafe.swift
@@ -55,36 +55,36 @@ func transferLetNonTransferrableSquelched(_ ns: NonSendableKlass) async {
 
   await transferToMainDirect(ns)
   // expected-warning @-1 {{sending 'ns' risks causing data races}}
-  // expected-note @-2 {{sending task-isolated 'ns' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and task-isolated uses}}
+  // expected-note @-2 {{sending 'ns' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated code and code in the current isolation context}}
   // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
   await transferToMainDirect(ns2)
 
   await transferToMainDirect(ns3)
   // expected-warning @-1 {{sending 'ns3' risks causing data races}}
-  // expected-note @-2 {{sending task-isolated 'ns3' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and task-isolated uses}}
+  // expected-note @-2 {{sending 'ns3' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated code and code in the current isolation context}}
   // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
   await transferToMainDirect(ns4)
   // expected-warning @-1 {{sending 'ns4' risks causing data races}}
-  // expected-note @-2 {{sending task-isolated 'ns4' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and task-isolated uses}}
+  // expected-note @-2 {{sending 'ns4' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated code and code in the current isolation context}}
   // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
   await transferToMainIndirect(ns)
   // expected-warning @-1 {{sending 'ns' risks causing data races}}
-  // expected-note @-2 {{sending task-isolated 'ns' to main actor-isolated global function 'transferToMainIndirect' risks causing data races between main actor-isolated and task-isolated uses}}
+  // expected-note @-2 {{sending 'ns' to main actor-isolated global function 'transferToMainIndirect' risks causing data races between main actor-isolated code and code in the current isolation context}}
   // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
   await transferToMainIndirect(ns2)
 
   await transferToMainIndirect(ns3)
   // expected-warning @-1 {{sending 'ns3' risks causing data races}}
-  // expected-note @-2 {{sending task-isolated 'ns3' to main actor-isolated global function 'transferToMainIndirect' risks causing data races between main actor-isolated and task-isolated uses}}
+  // expected-note @-2 {{sending 'ns3' to main actor-isolated global function 'transferToMainIndirect' risks causing data races between main actor-isolated code and code in the current isolation context}}
   // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
   await transferToMainIndirect(ns4)
   // expected-warning @-1 {{sending 'ns4' risks causing data races}}
-  // expected-note @-2 {{sending task-isolated 'ns4' to main actor-isolated global function 'transferToMainIndirect' risks causing data races between main actor-isolated and task-isolated uses}}
+  // expected-note @-2 {{sending 'ns4' to main actor-isolated global function 'transferToMainIndirect' risks causing data races between main actor-isolated code and code in the current isolation context}}
   // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 }
 
@@ -150,11 +150,11 @@ func transferNonTransferrableClassField(_ ns: NonSendableKlass) async {
 
   await transferToMainDirect(ns2.field!)
   // expected-warning @-1 {{sending 'ns2.field' risks causing data races}}
-  // expected-note @-2 {{sending task-isolated 'ns2.field' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and task-isolated uses}}
+  // expected-note @-2 {{sending 'ns2.field' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated code and code in the current isolation context}}
   // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   await transferToMainIndirect(ns2.field!)
   // expected-warning @-1 {{sending 'ns2.field' risks causing data races}}
-  // expected-note @-2 {{sending task-isolated 'ns2.field' to main actor-isolated global function 'transferToMainIndirect' risks causing data races between main actor-isolated and task-isolated uses}}
+  // expected-note @-2 {{sending 'ns2.field' to main actor-isolated global function 'transferToMainIndirect' risks causing data races between main actor-isolated code and code in the current isolation context}}
   // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 }
 
@@ -167,17 +167,17 @@ func transferNonTransferrableStructField(_ ns: NonSendableStruct) async {
 
   await transferToMainDirect(ns2.field!)
   // expected-warning @-1 {{sending 'ns2.field' risks causing data races}}
-  // expected-note @-2 {{sending task-isolated 'ns2.field' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and task-isolated uses}}
+  // expected-note @-2 {{sending 'ns2.field' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated code and code in the current isolation context}}
   // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
   await transferToMainIndirect(ns2.field!)
   // expected-warning @-1 {{sending 'ns2.field' risks causing data races}}
-  // expected-note @-2 {{sending task-isolated 'ns2.field' to main actor-isolated global function 'transferToMainIndirect' risks causing data races between main actor-isolated and task-isolated uses}}
+  // expected-note @-2 {{sending 'ns2.field' to main actor-isolated global function 'transferToMainIndirect' risks causing data races between main actor-isolated code and code in the current isolation context}}
   // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
   await transferToMainIndirect(ns2.field)
   // expected-warning @-1 {{sending 'ns2.field' risks causing data races}}
-  // expected-note @-2 {{sending task-isolated 'ns2.field' to main actor-isolated global function 'transferToMainIndirect' risks causing data races between main actor-isolated and task-isolated uses}}
+  // expected-note @-2 {{sending 'ns2.field' to main actor-isolated global function 'transferToMainIndirect' risks causing data races between main actor-isolated code and code in the current isolation context}}
   // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass?' into main actor-isolated context may introduce data races}}
 }
 
@@ -187,12 +187,12 @@ func testConsumingTransfer(_ ns: NonSendableKlass) async {
 
   await transferToMainDirectConsuming(ns)
   // expected-warning @-1 {{sending 'ns' risks causing data races}}
-  // expected-note @-2 {{sending task-isolated 'ns' to main actor-isolated global function 'transferToMainDirectConsuming' risks causing data races between main actor-isolated and task-isolated uses}}
+  // expected-note @-2 {{sending 'ns' to main actor-isolated global function 'transferToMainDirectConsuming' risks causing data races between main actor-isolated code and code in the current isolation context}}
   // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
   await transferToMainIndirectConsuming(ns)
   // expected-warning @-1 {{sending 'ns' risks causing data races}}
-  // expected-note @-2 {{sending task-isolated 'ns' to main actor-isolated global function 'transferToMainIndirectConsuming' risks causing data races between main actor-isolated and task-isolated uses}}
+  // expected-note @-2 {{sending 'ns' to main actor-isolated global function 'transferToMainIndirectConsuming' risks causing data races between main actor-isolated code and code in the current isolation context}}
   // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
   await transferToMainDirectConsuming(ns2)
@@ -210,36 +210,36 @@ func transferVarNonTransferrableSquelched(_ ns: NonSendableKlass) async {
 
   await transferToMainDirect(ns)
   // expected-warning @-1 {{sending 'ns' risks causing data races}}
-  // expected-note @-2 {{sending task-isolated 'ns' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and task-isolated uses}}
+  // expected-note @-2 {{sending 'ns' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated code and code in the current isolation context}}
   // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
   await transferToMainDirect(ns2)
 
   await transferToMainDirect(ns3)
   // expected-warning @-1 {{sending 'ns3' risks causing data races}}
-  // expected-note @-2 {{sending task-isolated 'ns3' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and task-isolated uses}}
+  // expected-note @-2 {{sending 'ns3' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated code and code in the current isolation context}}
   // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
   await transferToMainDirect(ns4)
   // expected-warning @-1 {{sending 'ns4' risks causing data races}}
-  // expected-note @-2 {{sending task-isolated 'ns4' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and task-isolated uses}}
+  // expected-note @-2 {{sending 'ns4' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated code and code in the current isolation context}}
   // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
   await transferToMainIndirect(ns)
   // expected-warning @-1 {{sending 'ns' risks causing data races}}
-  // expected-note @-2 {{sending task-isolated 'ns' to main actor-isolated global function 'transferToMainIndirect' risks causing data races between main actor-isolated and task-isolated uses}}
+  // expected-note @-2 {{sending 'ns' to main actor-isolated global function 'transferToMainIndirect' risks causing data races between main actor-isolated code and code in the current isolation context}}
   // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
   await transferToMainIndirect(ns2)
 
   await transferToMainIndirect(ns3)
   // expected-warning @-1 {{sending 'ns3' risks causing data races}}
-  // expected-note @-2 {{sending task-isolated 'ns3' to main actor-isolated global function 'transferToMainIndirect' risks causing data races between main actor-isolated and task-isolated uses}}
+  // expected-note @-2 {{sending 'ns3' to main actor-isolated global function 'transferToMainIndirect' risks causing data races between main actor-isolated code and code in the current isolation context}}
   // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
   await transferToMainIndirect(ns4)
   // expected-warning @-1 {{sending 'ns4' risks causing data races}}
-  // expected-note @-2 {{sending task-isolated 'ns4' to main actor-isolated global function 'transferToMainIndirect' risks causing data races between main actor-isolated and task-isolated uses}}
+  // expected-note @-2 {{sending 'ns4' to main actor-isolated global function 'transferToMainIndirect' risks causing data races between main actor-isolated code and code in the current isolation context}}
   // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 }
 
@@ -285,19 +285,19 @@ func transferLetNonTransferrableSquelchedAddressOnly<T>(_ ns: T) async { // expe
 
   await transferToMainIndirect(ns)
   // expected-warning @-1 {{sending 'ns' risks causing data races}}
-  // expected-note @-2 {{sending task-isolated 'ns' to main actor-isolated global function 'transferToMainIndirect' risks causing data races between main actor-isolated and task-isolated uses}}
+  // expected-note @-2 {{sending 'ns' to main actor-isolated global function 'transferToMainIndirect' risks causing data races between main actor-isolated code and code in the current isolation context}}
   // expected-complete-warning @-3 {{passing argument of non-Sendable type 'T' into main actor-isolated context may introduce data races}}
 
   await transferToMainIndirect(ns2)
 
   await transferToMainIndirect(ns3)
   // expected-warning @-1 {{sending 'ns3' risks causing data races}}
-  // expected-note @-2 {{sending task-isolated 'ns3' to main actor-isolated global function 'transferToMainIndirect' risks causing data races between main actor-isolated and task-isolated uses}}
+  // expected-note @-2 {{sending 'ns3' to main actor-isolated global function 'transferToMainIndirect' risks causing data races between main actor-isolated code and code in the current isolation context}}
   // expected-complete-warning @-3 {{passing argument of non-Sendable type 'T' into main actor-isolated context may introduce data races}}
 
   await transferToMainIndirect(ns4)
   // expected-warning @-1 {{sending 'ns4' risks causing data races}}
-  // expected-note @-2 {{sending task-isolated 'ns4' to main actor-isolated global function 'transferToMainIndirect' risks causing data races between main actor-isolated and task-isolated uses}}
+  // expected-note @-2 {{sending 'ns4' to main actor-isolated global function 'transferToMainIndirect' risks causing data races between main actor-isolated code and code in the current isolation context}}
   // expected-complete-warning @-3 {{passing argument of non-Sendable type 'T' into main actor-isolated context may introduce data races}}
 }
 
@@ -309,7 +309,7 @@ func useAfterTransferLetSquelchedIndirectAddressOnly<T : ProvidesStaticValue>(_ 
 
   await transferToMainIndirect(ns)
   // expected-warning @-1 {{sending 'ns' risks causing data races}}
-  // expected-note @-2 {{sending task-isolated 'ns' to main actor-isolated global function 'transferToMainIndirect' risks causing data races between main actor-isolated and task-isolated uses}}
+  // expected-note @-2 {{sending 'ns' to main actor-isolated global function 'transferToMainIndirect' risks causing data races between main actor-isolated code and code in the current isolation context}}
   // expected-complete-warning @-3 {{passing argument of non-Sendable type 'T' into main actor-isolated context may introduce data races}}
   print(ns)
 
@@ -318,13 +318,13 @@ func useAfterTransferLetSquelchedIndirectAddressOnly<T : ProvidesStaticValue>(_ 
 
   await transferToMainIndirect(ns3)
   // expected-warning @-1 {{sending 'ns3' risks causing data races}}
-  // expected-note @-2 {{sending task-isolated 'ns3' to main actor-isolated global function 'transferToMainIndirect' risks causing data races between main actor-isolated and task-isolated uses}}
+  // expected-note @-2 {{sending 'ns3' to main actor-isolated global function 'transferToMainIndirect' risks causing data races between main actor-isolated code and code in the current isolation context}}
   // expected-complete-warning @-3 {{passing argument of non-Sendable type 'T' into main actor-isolated context may introduce data races}}
   print(ns3)
 
   await transferToMainIndirect(ns4)
   // expected-warning @-1 {{sending 'ns4' risks causing data races}}
-  // expected-note @-2 {{sending task-isolated 'ns4' to main actor-isolated global function 'transferToMainIndirect' risks causing data races between main actor-isolated and task-isolated uses}}
+  // expected-note @-2 {{sending 'ns4' to main actor-isolated global function 'transferToMainIndirect' risks causing data races between main actor-isolated code and code in the current isolation context}}
   // expected-complete-warning @-3 {{passing argument of non-Sendable type 'T' into main actor-isolated context may introduce data races}}
   print(ns4)
 }
@@ -749,11 +749,11 @@ struct NonIsolatedUnsafeFieldNonSendableStruct {
     // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
     await transferToMainDirect(letObject)
     // expected-warning @-1 {{sending 'self.letObject' risks causing data races}}
-    // expected-note @-2 {{sending task-isolated 'self.letObject' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and task-isolated uses}}
+    // expected-note @-2 {{sending 'self.letObject' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated code and code in the current isolation context}}
     // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
     await transferToMainDirect(varObject)
     // expected-warning @-1 {{sending 'self.varObject' risks causing data races}}
-    // expected-note @-2 {{sending task-isolated 'self.varObject' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and task-isolated uses}}
+    // expected-note @-2 {{sending 'self.varObject' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated code and code in the current isolation context}}
     // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   }
 
@@ -782,11 +782,11 @@ final class FinalNonIsolatedUnsafeFieldKlass {
     // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
     await transferToMainDirect(letObject)
     // expected-warning @-1 {{sending 'self.letObject' risks causing data races}}
-    // expected-note @-2 {{sending task-isolated 'self.letObject' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and task-isolated uses}}
+    // expected-note @-2 {{sending 'self.letObject' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated code and code in the current isolation context}}
     // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
     await transferToMainDirect(varObject)
     // expected-warning @-1 {{sending 'self.varObject' risks causing data races}}
-    // expected-note @-2 {{sending task-isolated 'self.varObject' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and task-isolated uses}}
+    // expected-note @-2 {{sending 'self.varObject' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated code and code in the current isolation context}}
     // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   }
 
@@ -815,11 +815,11 @@ class NonIsolatedUnsafeFieldKlass {
     // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
     await transferToMainDirect(letObject)
     // expected-warning @-1 {{sending 'self.letObject' risks causing data races}}
-    // expected-note @-2 {{sending task-isolated 'self.letObject' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and task-isolated uses}}
+    // expected-note @-2 {{sending 'self.letObject' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated code and code in the current isolation context}}
     // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
     await transferToMainDirect(varObject)
     // expected-warning @-1 {{sending 'self.varObject' risks causing data races}}
-    // expected-note @-2 {{sending task-isolated 'self.varObject' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and task-isolated uses}}
+    // expected-note @-2 {{sending 'self.varObject' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated code and code in the current isolation context}}
     // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   }
 
@@ -850,14 +850,14 @@ class NonIsolatedUnsafeFieldGenericKlass<T> { // expected-complete-note 4{{}}
 
     await transferToMainIndirect(letAddressOnly)
     // expected-warning @-1 {{sending 'self.letAddressOnly' risks causing data races}}
-    // expected-note @-2 {{sending task-isolated 'self.letAddressOnly' to main actor-isolated global function 'transferToMainIndirect' risks causing data races between main actor-isolated and task-isolated uses}}
+    // expected-note @-2 {{sending 'self.letAddressOnly' to main actor-isolated global function 'transferToMainIndirect' risks causing data races between main actor-isolated code and code in the current isolation context}}
     // expected-complete-warning @-3 {{passing argument of non-Sendable type 'T?' into main actor-isolated context may introduce data races}}
 
     // TODO: This diagnostic is unfortunate since we are erroring on the
     // temporary created by the class_method call.
     await transferToMainIndirect(varAddressOnly)
     // expected-warning @-1 {{sending value of non-Sendable type 'T?' risks causing data races}}
-    // expected-note @-2 {{sending task-isolated value of non-Sendable type 'T?' to main actor-isolated global function 'transferToMainIndirect' risks causing races in between task-isolated and main actor-isolated uses}}
+    // expected-note @-2 {{sending value of non-Sendable type 'T?' to main actor-isolated global function 'transferToMainIndirect' risks causing races in between code in the current isolation context and main actor-isolated uses}}
   }
 
   // This is safe since self will become MainActor isolated as a result of
@@ -895,7 +895,7 @@ func closureTests() async {
 
   func testLetOneNSVariableError() async {
     let x = NonSendableKlass()
-    sendingClosure { _ = x } // expected-warning {{closure passed as an argument to a 'sending' parameter captures 'x' which is accessed later by code in the current task}}
+    sendingClosure { _ = x } // expected-warning {{closure passed as an argument to a 'sending' parameter captures 'x' which is accessed later by code in the current isolation context}}
     sendingClosure { _ = x } // expected-note {{access can happen concurrently}}
   }
 
@@ -909,7 +909,7 @@ func closureTests() async {
     let x = NonSendableKlass()
     let y = CustomActorInstance()
     sendingClosure {
-      _ = x // expected-warning {{closure passed as an argument to a 'sending' parameter captures 'x' which is accessed later by code in the current task}}
+      _ = x // expected-warning {{closure passed as an argument to a 'sending' parameter captures 'x' which is accessed later by code in the current isolation context}}
       _ = y
     }
     sendingClosure { // expected-note {{access can happen concurrently}}
@@ -935,8 +935,8 @@ func closureTests() async {
     let x = NonSendableKlass()
     let y = NonSendableKlass()
     sendingClosure {
-      _ = x // expected-warning {{closure passed as an argument to a 'sending' parameter captures 'x' which is accessed later by code in the current task}}
-      _ = y // expected-warning {{closure passed as an argument to a 'sending' parameter captures 'y' which is accessed later by code in the current task}}
+      _ = x // expected-warning {{closure passed as an argument to a 'sending' parameter captures 'x' which is accessed later by code in the current isolation context}}
+      _ = y // expected-warning {{closure passed as an argument to a 'sending' parameter captures 'y' which is accessed later by code in the current isolation context}}
     }
     sendingClosure { // expected-note {{access can happen concurrently}}
       _ = x
@@ -949,7 +949,7 @@ func closureTests() async {
     let y = NonSendableKlass()
     sendingClosure {
       _ = x
-      _ = y // expected-warning {{closure passed as an argument to a 'sending' parameter captures 'y' which is accessed later by code in the current task}}
+      _ = y // expected-warning {{closure passed as an argument to a 'sending' parameter captures 'y' which is accessed later by code in the current isolation context}}
     }
     sendingClosure { // expected-note {{access can happen concurrently}}
       _ = x
@@ -974,7 +974,7 @@ func closureTests() async {
     var x = NonSendableKlass()
     x = NonSendableKlass()
 
-    sendingClosure { _ = x } // expected-warning {{closure passed as an argument to a 'sending' parameter captures 'x' which is accessed later by code in the current task}}
+    sendingClosure { _ = x } // expected-warning {{closure passed as an argument to a 'sending' parameter captures 'x' which is accessed later by code in the current isolation context}}
     sendingClosure { _ = x } // expected-note {{access can happen concurrently}}
   }
 
@@ -992,7 +992,7 @@ func closureTests() async {
     var y = CustomActorInstance()
     y = CustomActorInstance()
     sendingClosure {
-      _ = x // expected-warning {{closure passed as an argument to a 'sending' parameter captures 'x' which is accessed later by code in the current task}}
+      _ = x // expected-warning {{closure passed as an argument to a 'sending' parameter captures 'x' which is accessed later by code in the current isolation context}}
       _ = y
     }
     sendingClosure { // expected-note {{access can happen concurrently}}
@@ -1022,8 +1022,8 @@ func closureTests() async {
     var y = NonSendableKlass()
     y = NonSendableKlass()
     sendingClosure {
-      _ = x // expected-warning {{closure passed as an argument to a 'sending' parameter captures 'x' which is accessed later by code in the current task}}
-      _ = y // expected-warning {{closure passed as an argument to a 'sending' parameter captures 'y' which is accessed later by code in the current task}}
+      _ = x // expected-warning {{closure passed as an argument to a 'sending' parameter captures 'x' which is accessed later by code in the current isolation context}}
+      _ = y // expected-warning {{closure passed as an argument to a 'sending' parameter captures 'y' which is accessed later by code in the current isolation context}}
     }
     sendingClosure { // expected-note {{access can happen concurrently}}
       _ = x
@@ -1038,7 +1038,7 @@ func closureTests() async {
     y = NonSendableKlass()
     sendingClosure {
       _ = x
-      _ = y // expected-warning {{closure passed as an argument to a 'sending' parameter captures 'y' which is accessed later by code in the current task}}
+      _ = y // expected-warning {{closure passed as an argument to a 'sending' parameter captures 'y' which is accessed later by code in the current isolation context}}
     }
     sendingClosure { // expected-note {{access can happen concurrently}}
       _ = x
@@ -1063,7 +1063,7 @@ func closureTests() async {
 
   func testWithTaskDetached() async {
     let x1 = NonSendableKlass()
-    Task.detached { _ = x1 } // expected-warning {{closure passed as an argument to a 'sending' parameter captures 'x1' which is accessed later by code in the current task}}
+    Task.detached { _ = x1 } // expected-warning {{closure passed as an argument to a 'sending' parameter captures 'x1' which is accessed later by code in the current isolation context}}
     Task.detached { _ = x1 } // expected-note {{access can happen concurrently}}
 
     nonisolated(unsafe) let x2 = NonSendableKlass()
@@ -1079,7 +1079,7 @@ func closureTests() async {
     let x4b = NonSendableKlass()
     Task.detached {
       _ = x4a;
-      _ = x4b // expected-warning {{closure passed as an argument to a 'sending' parameter captures 'x4b' which is accessed later by code in the current task}}
+      _ = x4b // expected-warning {{closure passed as an argument to a 'sending' parameter captures 'x4b' which is accessed later by code in the current isolation context}}
     }
 
     Task.detached { // expected-note {{access can happen concurrently}}
@@ -1127,18 +1127,18 @@ func closureTests() async {
     sendingClosure(y)
   }
 
-  // Task-isolated parameter + nonisolated(unsafe) capture. Each send of the
-  // closure triggers a SentNeverSendable error for ns (task-isolated), while
+  // Parameter accessible to code in the current isolation context + nonisolated(unsafe) capture. Each send of the
+  // closure triggers a SentNeverSendable error for ns (accessible to code in the current isolation context), while
   // x (nonisolated(unsafe)) is not diagnosed.
   func testSendingClosureTaskIsolatedAndNonisolatedUnsafe(_ ns: NonSendableKlass) async {
     nonisolated(unsafe) let x = NonSendableKlass()
-    sendingClosure { // expected-warning {{passing closure as a 'sending' parameter risks causing data races between code in the current task and concurrent execution of the closure}}
+    sendingClosure { // expected-warning {{passing closure as a 'sending' parameter risks causing data races between code in the current isolation context and concurrent execution of the closure}}
       _ = x
-      _ = ns // expected-note {{closure captures 'ns' which is accessible to code in the current task}}
+      _ = ns // expected-note {{closure captures 'ns' which is accessible to code in the current isolation context}}
     }
-    sendingClosure { // expected-warning {{passing closure as a 'sending' parameter risks causing data races between code in the current task and concurrent execution of the closure}}
+    sendingClosure { // expected-warning {{passing closure as a 'sending' parameter risks causing data races between code in the current isolation context and concurrent execution of the closure}}
       _ = x
-      _ = ns // expected-note {{closure captures 'ns' which is accessible to code in the current task}}
+      _ = ns // expected-note {{closure captures 'ns' which is accessible to code in the current isolation context}}
     }
   }
 

--- a/test/Concurrency/transfernonsendable_ownership.swift
+++ b/test/Concurrency/transfernonsendable_ownership.swift
@@ -37,12 +37,12 @@ struct CustomActor {
 
 func testConsuming(_ x: consuming Klass) async {
   await transferToMain(x) // expected-warning {{sending 'x' risks causing data races}}
-  // expected-note @-1 {{sending task-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and task-isolated uses}}
+  // expected-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
 }
 
 func testConsumingError(_ x: consuming Klass) async {
   await transferToMain(x) // expected-warning {{sending 'x' risks causing data races}}
-  // expected-note @-1 {{sending task-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and task-isolated uses}}
+  // expected-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
   print(x)
 }
 
@@ -54,7 +54,7 @@ func testConsumingError(_ x: consuming Klass) async {
 
 func testConsumingUseAfterConsumeError(_ x: consuming Klass) async { // expected-error {{'x' used after consume}}
   await consumeTransferToMain(x) // expected-warning {{sending 'x' risks causing data races}}
-  // expected-note @-1 {{sending task-isolated 'x' to main actor-isolated global function 'consumeTransferToMain' risks causing data races between main actor-isolated and task-isolated uses}}
+  // expected-note @-1 {{sending 'x' to main actor-isolated global function 'consumeTransferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
   // expected-note @-2 {{consumed here}}
   print(x)
   // expected-note @-1 {{used here}}
@@ -70,12 +70,12 @@ func testConsumingUseAfterConsumeError(_ x: consuming Klass) async { // expected
 
 func testBorrowing(_ x: borrowing Klass) async {
   await transferToMain(x) // expected-warning {{sending 'x' risks causing data races}}
-  // expected-note @-1 {{sending task-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and task-isolated uses}}
+  // expected-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
 }
 
 func testBorrowingError(_ x: borrowing Klass) async { // expected-error {{'x' is borrowed and cannot be consumed}}
   await transferToMain(x) // expected-warning {{sending 'x' risks causing data races}}
-  // expected-note @-1 {{sending task-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and task-isolated uses}}
+  // expected-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
   print(x) // expected-note {{consumed here}}
 }
 
@@ -87,12 +87,12 @@ func testBorrowingError(_ x: borrowing Klass) async { // expected-error {{'x' is
 
 func testInOut(_ x: inout Klass) async {
   await transferToMain(x) // expected-warning {{sending 'x' risks causing data races}}
-  // expected-note @-1 {{sending task-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and task-isolated uses}}
+  // expected-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
 }
 
 func testInOutError(_ x: inout Klass) async {
   await transferToMain(x) // expected-warning {{sending 'x' risks causing data races}}
-  // expected-note @-1 {{sending task-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and task-isolated uses}}
+  // expected-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
   print(x)
 }
 

--- a/test/Concurrency/transfernonsendable_preconcurrency.swift
+++ b/test/Concurrency/transfernonsendable_preconcurrency.swift
@@ -109,17 +109,17 @@ func testNeverTransfer(_ x: PreCUncheckedNonSendableKlass) async {
 func testNeverTransferExplicit(_ x: PreCUncheckedExplicitlyNonSendableKlass) async {
   await transferToMain(x)
   // expected-swift-5-warning @-1 {{sending 'x' risks causing data races}}
-  // expected-swift-5-note @-2 {{sending task-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and task-isolated uses}}
+  // expected-swift-5-note @-2 {{sending 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
   // expected-swift-6-warning @-3 {{sending 'x' risks causing data races}}
-  // expected-swift-6-note @-4 {{sending task-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and task-isolated uses}}
+  // expected-swift-6-note @-4 {{sending 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
 }
 
 func testNeverTransferNormal(_ x: PostCUncheckedNonSendableKlass) async {
   await transferToMain(x)
   // expected-swift-5-warning @-1 {{sending 'x' risks causing data races}}
-  // expected-swift-5-note @-2 {{sending task-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and task-isolated uses}}
+  // expected-swift-5-note @-2 {{sending 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
   // expected-swift-6-error @-3 {{sending 'x' risks causing data races}}
-  // expected-swift-6-note @-4 {{sending task-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and task-isolated uses}}
+  // expected-swift-6-note @-4 {{sending 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
 }
 
 func testNeverTransferInexactMatch(_ x: (PreCUncheckedNonSendableKlass, PreCUncheckedNonSendableKlass)) async {
@@ -129,9 +129,9 @@ func testNeverTransferInexactMatch(_ x: (PreCUncheckedNonSendableKlass, PreCUnch
 func testNeverTransferInexactMatchExplicit(_ x: (PreCUncheckedExplicitlyNonSendableKlass, PreCUncheckedExplicitlyNonSendableKlass)) async {
   await transferToMain(x)
   // expected-swift-5-warning @-1 {{sending 'x' risks causing data races}}
-  // expected-swift-5-note @-2 {{sending task-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and task-isolated uses}}
+  // expected-swift-5-note @-2 {{sending 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
   // expected-swift-6-warning @-3 {{sending 'x' risks causing data races}}
-  // expected-swift-6-note @-4 {{sending task-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and task-isolated uses}}
+  // expected-swift-6-note @-4 {{sending 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
 }
 
 

--- a/test/Concurrency/transfernonsendable_preconcurrency_sending.swift
+++ b/test/Concurrency/transfernonsendable_preconcurrency_sending.swift
@@ -137,17 +137,17 @@ func testNeverTransfer(_ x: PreCUncheckedNonSendableKlass) async {
 func testNeverTransferExplicit(_ x: PreCUncheckedExplicitlyNonSendableKlass) async {
   transferArg(x)
   // expected-swift-5-warning @-1 {{sending 'x' risks causing data races}}
-  // expected-swift-5-note @-2 {{task-isolated 'x' is passed as a 'sending' parameter; Uses in callee may race with later task-isolated uses}}
+  // expected-swift-5-note @-2 {{'x' is passed as a 'sending' parameter; Uses in callee may race with code in the current isolation context}}
   // expected-swift-6-warning @-3 {{sending 'x' risks causing data races}}
-  // expected-swift-6-note @-4 {{task-isolated 'x' is passed as a 'sending' parameter; Uses in callee may race with later task-isolated uses}}
+  // expected-swift-6-note @-4 {{'x' is passed as a 'sending' parameter; Uses in callee may race with code in the current isolation context}}
 }
 
 func testNeverTransferNormal(_ x: PostCUncheckedNonSendableKlass) async {
   transferArg(x)
   // expected-swift-5-warning @-1 {{sending 'x' risks causing data races}}
-  // expected-swift-5-note @-2 {{task-isolated 'x' is passed as a 'sending' parameter; Uses in callee may race with later task-isolated uses}}
+  // expected-swift-5-note @-2 {{'x' is passed as a 'sending' parameter; Uses in callee may race with code in the current isolation context}}
   // expected-swift-6-error @-3 {{sending 'x' risks causing data races}}
-  // expected-swift-6-note @-4 {{task-isolated 'x' is passed as a 'sending' parameter; Uses in callee may race with later task-isolated uses}}
+  // expected-swift-6-note @-4 {{'x' is passed as a 'sending' parameter; Uses in callee may race with code in the current isolation context}}
 }
 
 // Inexact match => normal behavior.
@@ -165,9 +165,9 @@ func testNeverTransferInexactMatch(_ x: (PreCUncheckedNonSendableKlass, PreCUnch
 func testNeverTransferInexactMatchExplicit(_ x: (PreCUncheckedExplicitlyNonSendableKlass, PreCUncheckedExplicitlyNonSendableKlass)) async {
   transferArg(x)
   // expected-swift-5-warning @-1 {{sending 'x' risks causing data races}}
-  // expected-swift-5-note @-2 {{task-isolated 'x' is passed as a 'sending' parameter; Uses in callee may race with later task-isolated uses}}
+  // expected-swift-5-note @-2 {{'x' is passed as a 'sending' parameter; Uses in callee may race with code in the current isolation context}}
   // expected-swift-6-warning @-3 {{sending 'x' risks causing data races}}
-  // expected-swift-6-note @-4 {{task-isolated 'x' is passed as a 'sending' parameter; Uses in callee may race with later task-isolated uses}}
+  // expected-swift-6-note @-4 {{'x' is passed as a 'sending' parameter; Uses in callee may race with code in the current isolation context}}
 }
 
 ////////////////////////////////////////
@@ -248,37 +248,37 @@ extension MyActor {
 // what the importing user wanted and change swift 6 to warn and swift 5 to
 // warn.
 func taskIsolatedCaptureInSendingClosureLiteral(_ x: PreCUncheckedExplicitlyNonSendableKlass) {
-  Task { // expected-warning {{passing closure as a 'sending' parameter risks causing data races between code in the current task and concurrent execution of the closure}}
-    print(x) // expected-note {{closure captures 'x' which is accessible to code in the current task}}
+  Task { // expected-warning {{passing closure as a 'sending' parameter risks causing data races between code in the current isolation context and concurrent execution of the closure}}
+    print(x) // expected-note {{closure captures 'x' which is accessible to code in the current isolation context}}
   }
 
-  takeClosure { // expected-warning {{passing closure as a 'sending' parameter risks causing data races between code in the current task and concurrent execution of the closure}}
-    print(x) // expected-note {{closure captures 'x' which is accessible to code in the current task}}
+  takeClosure { // expected-warning {{passing closure as a 'sending' parameter risks causing data races between code in the current isolation context and concurrent execution of the closure}}
+    print(x) // expected-note {{closure captures 'x' which is accessible to code in the current isolation context}}
   }
 
-  takeClosureAndParam(PreCUncheckedExplicitlyNonSendableKlass()) { // expected-warning {{passing closure as a 'sending' parameter risks causing data races between code in the current task and concurrent execution of the closure}}
-    print(x) // expected-note {{closure captures 'x' which is accessible to code in the current task}}
+  takeClosureAndParam(PreCUncheckedExplicitlyNonSendableKlass()) { // expected-warning {{passing closure as a 'sending' parameter risks causing data races between code in the current isolation context and concurrent execution of the closure}}
+    print(x) // expected-note {{closure captures 'x' which is accessible to code in the current isolation context}}
   }
 
   let y = (x, x)
-  Task { // expected-warning {{passing closure as a 'sending' parameter risks causing data races between code in the current task and concurrent execution of the closure}}
-    print(y) // expected-note {{closure captures 'y' which is accessible to code in the current task}}
+  Task { // expected-warning {{passing closure as a 'sending' parameter risks causing data races between code in the current isolation context and concurrent execution of the closure}}
+    print(y) // expected-note {{closure captures 'y' which is accessible to code in the current isolation context}}
   }
 
   let z = (x, y)
-  Task { // expected-warning {{passing closure as a 'sending' parameter risks causing data races between code in the current task and concurrent execution of the closure}}
+  Task { // expected-warning {{passing closure as a 'sending' parameter risks causing data races between code in the current isolation context and concurrent execution of the closure}}
     print(y, z) // expected-note @:11 {{closure captures non-Sendable 'y'}}
     // expected-note @-1:14 {{closure captures non-Sendable 'z'}}
   }
 
   let w = PreCUncheckedExplicitlyNonSendableKlassPair(lhs: x, rhs: x)
-  Task { // expected-warning {{passing closure as a 'sending' parameter risks causing data races between code in the current task and concurrent execution of the closure}}
-    print(w) // expected-note {{closure captures 'w' which is accessible to code in the current task}}
+  Task { // expected-warning {{passing closure as a 'sending' parameter risks causing data races between code in the current isolation context and concurrent execution of the closure}}
+    print(w) // expected-note {{closure captures 'w' which is accessible to code in the current isolation context}}
   }
 
   let u = Pair(lhs: x, rhs: x)
-  Task { // expected-warning {{passing closure as a 'sending' parameter risks causing data races between code in the current task and concurrent execution of the closure}}
-    print(u) // expected-note {{closure captures 'u' which is accessible to code in the current task}}
+  Task { // expected-warning {{passing closure as a 'sending' parameter risks causing data races between code in the current isolation context and concurrent execution of the closure}}
+    print(u) // expected-note {{closure captures 'u' which is accessible to code in the current isolation context}}
   }
 }
 
@@ -321,44 +321,44 @@ extension MyActor {
 
 // Since this is a swift 6 class, we emit the full error.
 func taskIsolatedCaptureInSendingClosureLiteral(_ x: PostCUncheckedNonSendableKlass) {
-  Task { // expected-swift-6-error {{passing closure as a 'sending' parameter risks causing data races between code in the current task and concurrent execution of the closure}}
-    // expected-swift-5-warning @-1 {{passing closure as a 'sending' parameter risks causing data races between code in the current task and concurrent execution of the closure}}
-    print(x) // expected-note {{closure captures 'x' which is accessible to code in the current task}}
+  Task { // expected-swift-6-error {{passing closure as a 'sending' parameter risks causing data races between code in the current isolation context and concurrent execution of the closure}}
+    // expected-swift-5-warning @-1 {{passing closure as a 'sending' parameter risks causing data races between code in the current isolation context and concurrent execution of the closure}}
+    print(x) // expected-note {{closure captures 'x' which is accessible to code in the current isolation context}}
   }
 
-  takeClosure { // expected-swift-6-error {{passing closure as a 'sending' parameter risks causing data races between code in the current task and concurrent execution of the closure}}
-    // expected-swift-5-warning @-1 {{passing closure as a 'sending' parameter risks causing data races between code in the current task and concurrent execution of the closure}}
-    print(x) // expected-note {{closure captures 'x' which is accessible to code in the current task}}
+  takeClosure { // expected-swift-6-error {{passing closure as a 'sending' parameter risks causing data races between code in the current isolation context and concurrent execution of the closure}}
+    // expected-swift-5-warning @-1 {{passing closure as a 'sending' parameter risks causing data races between code in the current isolation context and concurrent execution of the closure}}
+    print(x) // expected-note {{closure captures 'x' which is accessible to code in the current isolation context}}
   }
 
-  takeClosureAndParam(PostCUncheckedNonSendableKlass()) { // expected-swift-6-error {{passing closure as a 'sending' parameter risks causing data races between code in the current task and concurrent execution of the closure}}
-    // expected-swift-5-warning @-1 {{passing closure as a 'sending' parameter risks causing data races between code in the current task and concurrent execution of the closure}}
-    print(x) // expected-note {{closure captures 'x' which is accessible to code in the current task}}
+  takeClosureAndParam(PostCUncheckedNonSendableKlass()) { // expected-swift-6-error {{passing closure as a 'sending' parameter risks causing data races between code in the current isolation context and concurrent execution of the closure}}
+    // expected-swift-5-warning @-1 {{passing closure as a 'sending' parameter risks causing data races between code in the current isolation context and concurrent execution of the closure}}
+    print(x) // expected-note {{closure captures 'x' which is accessible to code in the current isolation context}}
   }
 
   let y = (x, x)
-  Task { // expected-swift-6-error {{passing closure as a 'sending' parameter risks causing data races between code in the current task and concurrent execution of the closure}}
-    // expected-swift-5-warning @-1 {{passing closure as a 'sending' parameter risks causing data races between code in the current task and concurrent execution of the closure}}
-    print(y) // expected-note {{closure captures 'y' which is accessible to code in the current task}}
+  Task { // expected-swift-6-error {{passing closure as a 'sending' parameter risks causing data races between code in the current isolation context and concurrent execution of the closure}}
+    // expected-swift-5-warning @-1 {{passing closure as a 'sending' parameter risks causing data races between code in the current isolation context and concurrent execution of the closure}}
+    print(y) // expected-note {{closure captures 'y' which is accessible to code in the current isolation context}}
   }
 
   let z = (x, y)
-  Task { // expected-swift-6-error {{passing closure as a 'sending' parameter risks causing data races between code in the current task and concurrent execution of the closure}}
-    // expected-swift-5-warning @-1 {{passing closure as a 'sending' parameter risks causing data races between code in the current task and concurrent execution of the closure}}
+  Task { // expected-swift-6-error {{passing closure as a 'sending' parameter risks causing data races between code in the current isolation context and concurrent execution of the closure}}
+    // expected-swift-5-warning @-1 {{passing closure as a 'sending' parameter risks causing data races between code in the current isolation context and concurrent execution of the closure}}
     print(y, z) // expected-note @:11 {{closure captures non-Sendable 'y'}}
     // expected-note @-1:14 {{closure captures non-Sendable 'z'}}
   }
 
   let w = PostCUncheckedNonSendableKlassPair(lhs: x, rhs: x)
-  Task { // expected-swift-6-error {{passing closure as a 'sending' parameter risks causing data races between code in the current task and concurrent execution of the closure}}
-    // expected-swift-5-warning @-1 {{passing closure as a 'sending' parameter risks causing data races between code in the current task and concurrent execution of the closure}}
-    print(w) // expected-note {{closure captures 'w' which is accessible to code in the current task}}
+  Task { // expected-swift-6-error {{passing closure as a 'sending' parameter risks causing data races between code in the current isolation context and concurrent execution of the closure}}
+    // expected-swift-5-warning @-1 {{passing closure as a 'sending' parameter risks causing data races between code in the current isolation context and concurrent execution of the closure}}
+    print(w) // expected-note {{closure captures 'w' which is accessible to code in the current isolation context}}
   }
 
   let u = Pair(lhs: x, rhs: x)
-  Task { // expected-swift-6-error {{passing closure as a 'sending' parameter risks causing data races between code in the current task and concurrent execution of the closure}}
-    // expected-swift-5-warning @-1 {{passing closure as a 'sending' parameter risks causing data races between code in the current task and concurrent execution of the closure}}
-    print(u) // expected-note {{closure captures 'u' which is accessible to code in the current task}}
+  Task { // expected-swift-6-error {{passing closure as a 'sending' parameter risks causing data races between code in the current isolation context and concurrent execution of the closure}}
+    // expected-swift-5-warning @-1 {{passing closure as a 'sending' parameter risks causing data races between code in the current isolation context and concurrent execution of the closure}}
+    print(u) // expected-note {{closure captures 'u' which is accessible to code in the current isolation context}}
   }
 }
 

--- a/test/Concurrency/transfernonsendable_rbi_result.swift
+++ b/test/Concurrency/transfernonsendable_rbi_result.swift
@@ -144,7 +144,7 @@ actor A {
 func callActorFuncsFromNonisolated(a : A, ns : NonSendable) async {
   await a.actorTakesNS(ns)
   // expected-error @-1 {{sending 'ns' risks causing data races}}
-  // expected-note @-2 {{sending task-isolated 'ns' to actor-isolated instance method 'actorTakesNS' risks causing data races between actor-isolated and task-isolated uses}}
+  // expected-note @-2 {{sending 'ns' to actor-isolated instance method 'actorTakesNS' risks causing data races between actor-isolated code and code in the current isolation context}}
 
   _ = await a.actorRetsNS()
   // expected-error @-1 {{non-Sendable 'NonSendable'-typed result can not be returned from actor-isolated instance method 'actorRetsNS()' to nonisolated context}}

--- a/test/Concurrency/transfernonsendable_region_based_sendability.swift
+++ b/test/Concurrency/transfernonsendable_region_based_sendability.swift
@@ -78,7 +78,7 @@ func test_arg_nonconsumable(a : A, ns_arg : NonSendable) async {
 
   // Not safe to consume an arg.
   await a.foo(ns_arg); // expected-warning {{sending 'ns_arg' risks causing data races}}
-  // expected-note @-1 {{sending task-isolated 'ns_arg' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and task-isolated uses}}
+  // expected-note @-1 {{sending 'ns_arg' to actor-isolated instance method 'foo' risks causing data races between actor-isolated code and code in the current isolation context}}
   // expected-complete-warning @-2 {{passing argument of non-Sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
   // Check for no duplicate warnings once self is "consumed"
@@ -413,7 +413,7 @@ class C_NonSendable {
 
     // this is a cross-isolation call that captures non-Sendable self, so it should not be permitted
     await a.foo(captures_self) // expected-warning {{sending 'captures_self' risks causing data races}}
-    // expected-note @-1 {{sending task-isolated 'captures_self' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and task-isolated uses}}
+    // expected-note @-1 {{sending 'captures_self' to actor-isolated instance method 'foo' risks causing data races between actor-isolated code and code in the current isolation context}}
     // expected-complete-warning @-2 {{passing argument of non-Sendable type '() -> ()' into actor-isolated context may introduce data races}}
     // expected-complete-note @-3 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
   }

--- a/test/Concurrency/transfernonsendable_sending_params.swift
+++ b/test/Concurrency/transfernonsendable_sending_params.swift
@@ -155,7 +155,7 @@ func testNonStrongTransferDoesntMerge() async {
 func testTransferringParameter_canTransfer(_ x: sending NonSendableKlass, _ y: NonSendableKlass) async {
   await transferToMain(x)
   await transferToMain(y) // expected-warning {{sending 'y' risks causing data races}}
-  // expected-note @-1 {{sending task-isolated 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and task-isolated uses}}
+  // expected-note @-1 {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
 }
 
 func testTransferringParameter_cannotTransferTwice(_ x: sending NonSendableKlass, _ y: NonSendableKlass) async {
@@ -433,12 +433,12 @@ func taskIsolatedInsideError(_ x: @escaping @MainActor () async -> ()) {
 }
 
 // Make sure we error here on only the second since x by being assigned a part
-// of y becomes task-isolated
+// of y becomes accessible to code in the current isolation context
 func testMergeWithTaskIsolated(_ x: sending NonSendableKlass, y: NonSendableKlass) async {
   await transferToMain(x)
   x = y
   await transferToMain(x) // expected-warning {{sending 'x' risks causing data races}}
-  // expected-note @-1 {{sending task-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and task-isolated uses}}
+  // expected-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
 }
 
 @MainActor func testMergeWithActorIsolated(_ x: sending NonSendableKlass, y: NonSendableKlass) async {
@@ -476,37 +476,37 @@ func testNoCrashWhenSendingNoEscapeClosure() async {
 //////////////////////
 
 func taskIsolatedCaptureInSendingClosureLiteral(_ x: NonSendableKlass) {
-  Task { // expected-warning {{passing closure as a 'sending' parameter risks causing data races between code in the current task and concurrent execution of the closure}}
-    print(x) // expected-note {{closure captures 'x' which is accessible to code in the current task}}
+  Task { // expected-warning {{passing closure as a 'sending' parameter risks causing data races between code in the current isolation context and concurrent execution of the closure}}
+    print(x) // expected-note {{closure captures 'x' which is accessible to code in the current isolation context}}
   }
 
-  Task { // expected-warning {{passing closure as a 'sending' parameter risks causing data races between code in the current task and concurrent execution of the closure}}
+  Task { // expected-warning {{passing closure as a 'sending' parameter risks causing data races between code in the current isolation context and concurrent execution of the closure}}
     {
-      print(x) // expected-note {{closure captures 'x' which is accessible to code in the current task}}
+      print(x) // expected-note {{closure captures 'x' which is accessible to code in the current isolation context}}
     }()
   }
 
-  Task { // expected-warning {{passing closure as a 'sending' parameter risks causing data races between code in the current task and concurrent execution of the closure}}
-    { // expected-note {{closure captures 'x' which is accessible to code in the current task}}
+  Task { // expected-warning {{passing closure as a 'sending' parameter risks causing data races between code in the current isolation context and concurrent execution of the closure}}
+    { // expected-note {{closure captures 'x' which is accessible to code in the current isolation context}}
       print($0)
     }(x)
   }
 
-  takeClosure { // expected-warning {{passing closure as a 'sending' parameter risks causing data races between code in the current task and concurrent execution of the closure}}
-    print(x) // expected-note {{closure captures 'x' which is accessible to code in the current task}}
+  takeClosure { // expected-warning {{passing closure as a 'sending' parameter risks causing data races between code in the current isolation context and concurrent execution of the closure}}
+    print(x) // expected-note {{closure captures 'x' which is accessible to code in the current isolation context}}
   }
 
-  takeClosureAndParam(NonSendableKlass()) { // expected-warning {{passing closure as a 'sending' parameter risks causing data races between code in the current task and concurrent execution of the closure}}
-    print(x) // expected-note {{closure captures 'x' which is accessible to code in the current task}}
+  takeClosureAndParam(NonSendableKlass()) { // expected-warning {{passing closure as a 'sending' parameter risks causing data races between code in the current isolation context and concurrent execution of the closure}}
+    print(x) // expected-note {{closure captures 'x' which is accessible to code in the current isolation context}}
   }
 
   let y = (x, x)
-  Task { // expected-warning {{passing closure as a 'sending' parameter risks causing data races between code in the current task and concurrent execution of the closure}}
-    print(y) // expected-note {{closure captures 'y' which is accessible to code in the current task}}
+  Task { // expected-warning {{passing closure as a 'sending' parameter risks causing data races between code in the current isolation context and concurrent execution of the closure}}
+    print(y) // expected-note {{closure captures 'y' which is accessible to code in the current isolation context}}
   }
 
   let z = (x, y)
-  Task { // expected-warning {{passing closure as a 'sending' parameter risks causing data races between code in the current task and concurrent execution of the closure}}
+  Task { // expected-warning {{passing closure as a 'sending' parameter risks causing data races between code in the current isolation context and concurrent execution of the closure}}
     print(y, z) // expected-note @:11 {{closure captures non-Sendable 'y'}}
     // expected-note @-1:14 {{closure captures non-Sendable 'z'}}
   }

--- a/test/Concurrency/transfernonsendable_sending_results.swift
+++ b/test/Concurrency/transfernonsendable_sending_results.swift
@@ -151,8 +151,8 @@ func transferInAndOut(_ x: sending NonSendableKlass) -> sending NonSendableKlass
 
 func transferReturnArg(_ x: NonSendableKlass) -> sending NonSendableKlass {
   return x // expected-warning {{sending 'x' risks causing data races}}
-  // expected-ni-note @-1 {{task-isolated 'x' cannot be a 'sending' result. task-isolated uses may race with caller uses}}
-  // expected-ni-ns-note @-2 {{task-isolated 'x' cannot be a 'sending' result. task-isolated uses may race with caller uses}}
+  // expected-ni-note @-1 {{'x' cannot be a 'sending' result. Code in the current task may race with caller uses}}
+  // expected-ni-ns-note @-2 {{'x' cannot be a 'sending' result. Code in the current task may race with caller uses}}
 }
 
 // TODO: This will be fixed once I represent @MainActor on func types.
@@ -288,28 +288,28 @@ func asyncLetReabstractionThunkTest2() async {
 ///////////////////////////////////
 
 func indirectSending<T>(_ t: T) -> sending T {
-  return t // expected-warning {{returning task-isolated 't' as a 'sending' result risks causing data races}}
-  // expected-note @-1 {{returning task-isolated 't' risks causing data races since the caller assumes that 't' can be safely sent to other isolation domains}}
+  return t // expected-warning {{returning 't' as a 'sending' result risks causing data races; this is an error in the Swift 6 language mode}}
+  // expected-note @-1 {{returning 't' risks causing data races since the caller assumes that 't' can be safely sent to other isolation domains}}
 }
 
 func indirectSendingStructField<T>(_ t: GenericNonSendableStruct<T>) -> sending T {
-  return t.t // expected-warning {{returning task-isolated 't.t' as a 'sending' result risks causing data races}}
-  // expected-note @-1 {{returning task-isolated 't.t' risks causing data races since the caller assumes that 't.t' can be safely sent to other isolation domains}}
+  return t.t // expected-warning {{returning 't.t' as a 'sending' result risks causing data races; this is an error in the Swift 6 language mode}}
+  // expected-note @-1 {{returning 't.t' risks causing data races since the caller assumes that 't.t' can be safely sent to other isolation domains}}
 }
 
 func indirectSendingStructOptionalField<T>(_ t: GenericNonSendableStruct<T>) -> sending T {
-  return t.t2! // expected-warning {{returning task-isolated 't.t2.some' as a 'sending' result risks causing data races}}
-  // expected-note @-1 {{returning task-isolated 't.t2.some' risks causing data races since the caller assumes that 't.t2.some' can be safely sent to other isolation domains}}
+  return t.t2! // expected-warning {{returning 't.t2.some' as a 'sending' result risks causing data races; this is an error in the Swift 6 language mode}}
+  // expected-note @-1 {{returning 't.t2.some' risks causing data races since the caller assumes that 't.t2.some' can be safely sent to other isolation domains}}
 }
 
 func indirectSendingClassField<T>(_ t: GenericNonSendableKlass<T>) -> sending T {
-  return t.t // expected-warning {{returning task-isolated 't.t' as a 'sending' result risks causing data races}}
-  // expected-note @-1 {{returning task-isolated 't.t' risks causing data races since the caller assumes that 't.t' can be safely sent to other isolation domains}}
+  return t.t // expected-warning {{returning 't.t' as a 'sending' result risks causing data races; this is an error in the Swift 6 language mode}}
+  // expected-note @-1 {{returning 't.t' risks causing data races since the caller assumes that 't.t' can be safely sent to other isolation domains}}
 }
 
 func indirectSendingOptionalClassField<T>(_ t: GenericNonSendableKlass<T>) -> sending T {
-  return t.t2! // expected-warning {{returning a task-isolated 'Optional<T>' value as a 'sending' result risks causing data races}}
-  // expected-note @-1 {{returning a task-isolated 'Optional<T>' value risks causing races since the caller assumes the value can be safely sent to other isolation domains}}
+  return t.t2! // expected-warning {{returning a 'Optional<T>' value as a 'sending' result risks causing data races; this is an error in the Swift 6 language mode}}
+  // expected-note @-1 {{returning a 'Optional<T>' value risks causing races since the caller assumes the value can be safely sent to other isolation domains}}
   // expected-note @-2 {{'Optional<T>' is a non-Sendable type}}
 }
 

--- a/test/Concurrency/transfernonsendable_typed_errors.swift
+++ b/test/Concurrency/transfernonsendable_typed_errors.swift
@@ -81,5 +81,5 @@ func sendingTransferNonSendableError(_ x: NonSendableKlass) {
 
 func sendingTransferNonSendableError(_ x: NonSendableKlass) async {
   await transferToMain(x) // expected-error {{sending value of non-Sendable type 'NonSendableKlass' risks causing data races}}
-  // expected-note @-1 {{sending task-isolated value of non-Sendable type 'NonSendableKlass' to main actor-isolated global function 'transferToMain' risks causing races in between task-isolated and main actor-isolated uses}}
+  // expected-note @-1 {{sending value of non-Sendable type 'NonSendableKlass' to main actor-isolated global function 'transferToMain' risks causing races in between code in the current isolation context and main actor-isolated uses}}
 }

--- a/test/Concurrency/transfernonsendable_warning_until_swift6.swift
+++ b/test/Concurrency/transfernonsendable_warning_until_swift6.swift
@@ -29,12 +29,12 @@ func testIsolationError() async {
 
 func testTransferArgumentError(_ x: NonSendableType) async {
   await transferToMain(x) // expected-error {{sending 'x' risks causing data races}}
-  // expected-note @-1 {{sending task-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and task-isolated uses}}
+  // expected-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
 }
 
 func testPassArgumentAsTransferringParameter(_ x: NonSendableType) async {
   transferValue(x) // expected-error {{sending 'x' risks causing data races}}
-  // expected-note @-1 {{task-isolated 'x' is passed as a 'sending' parameter; Uses in callee may race with later task-isolated uses}}
+  // expected-note @-1 {{'x' is passed as a 'sending' parameter; Uses in callee may race with code in the current isolation context}}
 }
 
 func testAssignmentIntoTransferringParameter(_ x: sending NonSendableType) async {
@@ -60,7 +60,7 @@ func testIsolationCrossingDueToCapture() async {
 func testIsolationCrossingDueToCaptureParameter(_ x: NonSendableType) async {
   let _ = { @MainActor in
     print(x) // expected-error {{sending 'x' risks causing data races}}
-    // expected-note @-1 {{task-isolated 'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+    // expected-note @-1 {{'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against code in the current isolation context}}
   }
   useValue(x)
 }

--- a/userdocs/diagnostics/sending-closure-risks-data-race.md
+++ b/userdocs/diagnostics/sending-closure-risks-data-race.md
@@ -28,9 +28,9 @@ The compiler diagnoses the capture of `self` in the task closure:
 | class MyModel {
 |   func perform() {
 |     Task {
-|     `- error: passing closure as a 'sending' parameter risks causing data races between code in the current task and concurrent execution of the closure
+|     `- error: passing closure as a 'sending' parameter risks causing data races between code in the current isolation context and concurrent execution of the closure
 |       self.update()
-|            `- note: closure captures 'self' which is accessible to code in the current task
+|            `- note: closure captures 'self' which is accessible to code in the current isolation context
 |     }
 |   }
 ```


### PR DESCRIPTION
"Task-isolated" is an internal implementation term that is not meaningful to users. Replace it with the user-facing "code in the current task" formulation throughout region-based isolation diagnostics.

Diagnostic definitions in DiagnosticsSIL.def are updated to accept an additional bool parameter for task-isolation and use %select to choose between the actor-isolation string and "code in the current task". Emission sites in SendNonSendable.cpp are updated to pass isTaskIsolated() at each call site. All affected test expectations are updated to match the new output.
