### PR TITLE
Revert [stdlib] Let Ref reference nonescapable types

### DIFF
--- a/stdlib/public/core/Ref.swift
+++ b/stdlib/public/core/Ref.swift
@@ -13,7 +13,7 @@
 /// A safe reference allowing in-place reads to a shared value.
 @available(SwiftStdlib 6.4, *)
 @frozen
-public struct Ref<Value: ~Copyable & ~Escapable>: Copyable, ~Escapable {
+public struct Ref<Value: ~Copyable>: Copyable, ~Escapable {
   @usableFromInline
   let builtin: Builtin.Borrow<Value>
 
@@ -57,14 +57,13 @@ extension Ref: @unchecked Sendable
 extension Ref: BitwiseCopyable {}
 
 @available(SwiftStdlib 6.4, *)
-extension Ref where Value: ~Copyable & ~Escapable {
+extension Ref where Value: ~Copyable {
   /// Dereferences the constant reference allowing for in-place reads to the
   /// underlying value.
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
   @_transparent
   public var value: Value {
-    @_lifetime(copy self)
     borrow {
       Builtin.dereferenceBorrow(builtin)
     }

--- a/stdlib/public/core/Ref.swift
+++ b/stdlib/public/core/Ref.swift
@@ -50,8 +50,7 @@ public struct Ref<Value: ~Copyable>: Copyable, ~Escapable {
 }
 
 @available(SwiftStdlib 6.4, *)
-extension Ref: @unchecked Sendable
-  where Value: Sendable & ~Copyable & ~Escapable {}
+extension Ref: @unchecked Sendable where Value: Sendable & ~Copyable {}
 
 @available(SwiftStdlib 6.4, *)
 extension Ref: BitwiseCopyable {}

--- a/test/abi/macOS/arm64/stdlib.swift
+++ b/test/abi/macOS/arm64/stdlib.swift
@@ -1263,7 +1263,7 @@ Added: __ZN5swift26getResilientMetadataBoundsEPKNS_21TargetClassDescriptorINS_9I
 // Ref
 Added: _$ss3RefVMa
 Added: _$ss3RefVMn
-Added: _$ss3RefVsRi_zRi0_zrlE7builtinxBWvg
+Added: _$ss3RefVsRi_zrlE7builtinxBWvg
 
 // MutableRef
 Added: _$ss10MutableRefVMa

--- a/test/abi/macOS/x86_64/stdlib.swift
+++ b/test/abi/macOS/x86_64/stdlib.swift
@@ -1258,7 +1258,7 @@ Added: __ZN5swift26getResilientMetadataBoundsEPKNS_21TargetClassDescriptorINS_9I
 // Ref
 Added: _$ss3RefVMa
 Added: _$ss3RefVMn
-Added: _$ss3RefVsRi_zRi0_zrlE7builtinxBWvg
+Added: _$ss3RefVsRi_zrlE7builtinxBWvg
 
 // MutableRef
 Added: _$ss10MutableRefVMa

--- a/test/stdlib/Noncopyables/RefMutableRef.swift
+++ b/test/stdlib/Noncopyables/RefMutableRef.swift
@@ -83,34 +83,6 @@ suite.test("Ref")
   expectEqual(int, 321)
 }
 
-suite.test("Ref inside a Ref")
-.require(.stdlib_6_4).code {
-  guard #available(SwiftStdlib 6.4, *) else { return }
-
-  var foo = Foo()
-
-  do {
-    let borrowFoo = Ref(foo)
-    let borrowBorrowFoo = Ref(borrowFoo)
-
-    expectEqual(borrowBorrowFoo.value.value.x, 128)
-  }
-
-  foo.bar()
-
-  let a = Atomic(123)
-  let ba = BorrowingAtomic(a)
-  let borrowBa = Ref(ba)
-  var int = borrowBa.value.load()
-
-  expectEqual(int, 123)
-
-  borrowBa.value.store(321)
-  int = borrowBa.value.load()
-
-  expectEqual(int, 321)
-}
-
 suite.test("MutableRef")
 .require(.stdlib_6_4).code {
   guard #available(SwiftStdlib 6.4, *) else { return }
@@ -137,40 +109,6 @@ suite.test("MutableRef")
   expectEqual(b.value, 64)
 
   expectEqual(a, 64)
-}
-
-suite.test("MutableRef inside a Ref")
-.require(.stdlib_6_4).code {
-  guard #available(SwiftStdlib 6.4, *) else { return }
-  var x: _? = 123
-
-  var y = x.mutate()!
-
-  do {
-    let borrowY = Ref(y)
-
-    // The following correctly doesn't compile. We cannot mutate a value within
-    // a `MutableRef` if it is behind a `Ref`.
-    // borrowY.value.value &+= 321
-
-    // But we should be able to read its value though.
-    expectEqual(borrowY.value.value, 123)
-  }
-
-  var a: Int? = nil
-
-  var b = a.insert(128)
-
-  do {
-    let borrowB = Ref(b)
-
-    expectEqual(borrowB.value.value, 128)
-
-    // Again, the following shouldn't compile (it doesn't).
-    // borrowB.value.value &-= 64
-  }
-
-  expectEqual(a, 128)
 }
 
 suite.test("Sendability")

--- a/test/stdlib/Noncopyables/RefMutableRef.swift
+++ b/test/stdlib/Noncopyables/RefMutableRef.swift
@@ -118,7 +118,7 @@ suite.test("Sendability")
   func isSendable<T: ~Copyable & ~Escapable>(_: T.Type) -> Bool { false }
   func isSendable<T: Sendable & ~Copyable & ~Escapable>(_: T.Type) -> Bool { true }
 
-  expectTrue(isSendable(Ref<MutableRawSpan>.self))
+  expectTrue(isSendable(Ref<Int>.self))
   expectTrue(isSendable(MutableRef<Int>.self))
 
   expectFalse(isSendable(Ref<UnsafeMutableRawPointer>.self))


### PR DESCRIPTION
This reverts commit 66a1326cdb600366946a43ceec33e639a05e3d5b, reversing changes made to 33ae6060115a5a596ecace49c70e8848d3d92ea5.
