### PR TITLE
🍒[SILGen] emit correct line number for macro source location

### DIFF
--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -20,6 +20,7 @@
 #include "LValue.h"
 #include "RValue.h"
 #include "ResultPlan.h"
+#include "SILGenFunction.h"
 #include "Scope.h"
 #include "SpecializedEmitter.h"
 #include "StorageRefResult.h"
@@ -2250,8 +2251,9 @@ buildBuiltinLiteralArgs(SILGenFunction &SGF, SGFContext C,
 /// If the given source loc is in a macro expansion buffer, this
 /// method walks up the macro expansion buffer tree to the outermost
 /// source file. Otherwise, the method returns the given loc.
-static SourceLoc
-getLocInOutermostSourceFile(SourceManager &sourceManager, SourceLoc loc) {
+SourceLoc
+SILGenFunction::getLocInOutermostSourceFile(SourceLoc loc) {
+  auto &sourceManager = getSourceManager();
   auto outermostLoc = loc;
   auto bufferID = sourceManager.findBufferContainingLoc(outermostLoc);
 
@@ -2297,7 +2299,7 @@ buildBuiltinLiteralArgs(SILGenFunction &SGF, SGFContext C,
   case MagicIdentifierLiteralExpr::Column: {
     unsigned Value = 0;
     if (auto Loc = magicLiteral->getStartLoc()) {
-      Loc = getLocInOutermostSourceFile(SGF.getSourceManager(), Loc);
+      Loc = SGF.getLocInOutermostSourceFile(Loc);
       if (Loc.isValid()) {
         Value = magicLiteral->getKind() == MagicIdentifierLiteralExpr::Line
                     ? ctx.SourceMgr.getPresumedLineAndColumnForLoc(Loc).first
@@ -7000,8 +7002,7 @@ StringRef SILGenFunction::getMagicFunctionString() {
 
 StringRef SILGenFunction::getMagicFilePathString(SourceLoc loc) {
   assert(loc.isValid());
-  auto &sourceManager = getSourceManager();
-  auto outermostLoc = getLocInOutermostSourceFile(sourceManager, loc);
+  auto outermostLoc = getLocInOutermostSourceFile(loc);
 
   return getSourceManager().getDisplayNameForLoc(outermostLoc);
 }

--- a/lib/SILGen/SILGenConvert.cpp
+++ b/lib/SILGen/SILGenConvert.cpp
@@ -147,6 +147,7 @@ auto SILGenFunction::emitSourceLocationArgs(SourceLoc sourceLoc,
   unsigned line = 0;
   unsigned column = 0;
   if (sourceLoc.isValid()) {
+    sourceLoc = getLocInOutermostSourceFile(sourceLoc);
     filename = getMagicFileIDString(sourceLoc);
     std::tie(line, column) =
         ctx.SourceMgr.getPresumedLineAndColumnForLoc(sourceLoc);

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -945,6 +945,7 @@ public:
   std::string getMagicFileIDString(SourceLoc loc);
   StringRef getMagicFilePathString(SourceLoc loc);
   StringRef getMagicFunctionString();
+  SourceLoc getLocInOutermostSourceFile(SourceLoc loc);
 
   SILDebugLocation
   getSILDebugLocation(SILBuilder &B, SILLocation Loc,

--- a/test/Interop/C/swiftify-import/trap-source-location.swift
+++ b/test/Interop/C/swiftify-import/trap-source-location.swift
@@ -1,0 +1,34 @@
+// REQUIRES: executable_test
+// REQUIRES: swift_test_mode_optimize_none
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-build-swift %t/test.swift -plugin-path %swift-plugin-dir \
+// RUN:   -import-bridging-header %t/bridging.h \
+// RUN:   -Xfrontend -validate-tbd-against-ir=none -o %t/test -target %target-swift-6.2-abi-triple
+// RUN: %target-codesign %t/test
+
+// RUN: not --crash env SWIFT_BACKTRACE=enable=no %target-run %t/test interop 2>&1 | %FileCheck %s --check-prefix CLANG
+// RUN: not --crash env SWIFT_BACKTRACE=enable=no %target-run %t/test         2>&1 | %FileCheck %s --check-prefix SWIFT
+
+// Trigger Optional unwrapping inside a macro by passing a default Span to a safe wrapper
+// where the underlying function does not accept null pointers - the base pointer of the
+// empty Span is null, and triggers a runtime exception. This is a regression test to make
+// sure the source location of the trap is correct.
+
+//--- test.swift
+@_SwiftifyImport(.countedBy(pointer: .param(1), count: "len"), .nonescaping(pointer: .param(1)))
+public func invokeMacroInSwiftModule(_ p: UnsafePointer<Int32>, _ len: Int32) {}
+
+if CommandLine.arguments.dropFirst().first == "interop" {
+  invokeMacroInClangModule(Span()) // CLANG: bridging.h:3: Fatal error: Unexpectedly found nil while unwrapping an Optional value
+} else {
+  invokeMacroInSwiftModule(Span()) // SWIFT: test.swift:2: Fatal error: Unexpectedly found nil while unwrapping an Optional value
+}
+//--- bridging.h
+#include <ptrcheck.h>
+
+static inline void invokeMacroInClangModule(
+    const int* __counted_by(count) __attribute__((__noescape__)) arr,
+    int count) {}

--- a/test/Interop/C/swiftify-import/trap-source-location.swift
+++ b/test/Interop/C/swiftify-import/trap-source-location.swift
@@ -9,8 +9,12 @@
 // RUN:   -Xfrontend -validate-tbd-against-ir=none -o %t/test -target %target-swift-6.2-abi-triple
 // RUN: %target-codesign %t/test
 
-// RUN: not --crash env SWIFT_BACKTRACE=enable=no %target-run %t/test interop 2>&1 | %FileCheck %s --check-prefix CLANG
-// RUN: not --crash env SWIFT_BACKTRACE=enable=no %target-run %t/test         2>&1 | %FileCheck %s --check-prefix SWIFT
+// RUN: env SWIFT_BACKTRACE=enable=no %{python} %S/../../../Inputs/not.py "%target-run %t/test interop" 2>&1 | %FileCheck %s --check-prefix CLANG
+// RUN: env SWIFT_BACKTRACE=enable=no %{python} %S/../../../Inputs/not.py "%target-run %t/test"         2>&1 | %FileCheck %s --check-prefix SWIFT
+
+// NOTE: not.py is used above instead of "not --crash" because simctl's exit
+// status doesn't reflect whether its child process crashed or not. So "not
+// --crash %target-run ..." always fails when testing for the iOS Simulator.
 
 // Trigger Optional unwrapping inside a macro by passing a default Span to a safe wrapper
 // where the underlying function does not accept null pointers - the base pointer of the


### PR DESCRIPTION
- **Explanation**:
When creating the SIL source location for a SourceLoc inside a macro
expansion, getMagicFileIDString traverses the GeneratedSourceInfo to
get the name of the parent source file. The call to
getPresumedFileAndColumnForLoc does not do this however, and instead
ends up using the line and column in the macro expansion buffer rather
than in the parent source file. This means that you could get crash messages
looking like `test.swift:10: Fatal error: Unexpectedly found nil while unwrapping an Optional value`
in a Swift file with 5 lines of code.
- **Scope**:
This affects runtime crashes in macro generated code.
- **Issues**:
rdar://177664640
- **Original PRs**:
https://github.com/swiftlang/swift/pull/89436
- **Risk**:
Low, the source location is already incorrect in the affected cases
- **Testing**:
Lit testing
- **Reviewers**:
@j-hui @Xazax-hun 