### PR TITLE
[build-script] Drop LLVM_CACHE_REMOTE_SERVICE_SOCKET_PATH

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -836,9 +836,6 @@ def main_normal():
         if args.caching_prefix_map:
             os.environ['LLVM_CACHE_PREFIX_MAPS'] = \
                 SWIFT_SOURCE_ROOT + '=/^src'
-        if args.caching_remote_service_path:
-            os.environ['LLVM_CACHE_REMOTE_SERVICE_SOCKET_PATH'] = \
-                args.caching_remote_service_path
 
         # Enable MCCAS backend unless using remote service or explicitly
         # disabled via environment.


### PR DESCRIPTION
The remote service socket path is already passed via the remote-service-path plugin option in LLVM_CACHE_PLUGIN_OPTIONS, matching how the Swift compiler receives it on the command line. Drop the redundant env var.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
