### PR TITLE
[flow-isolation] Gate global-actor flow-isolation delegation behind FlowIsolationGlobalActor feature

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -616,6 +616,11 @@ EXPERIMENTAL_FEATURE(StrictAccessControl, true)
 /// non-resilient modules. Layout will be encoded in the .swiftmodule.
 EXPERIMENTAL_FEATURE(AbstractStoredPropertyLayout, false)
 
+/// Defer checking of global-actor-isolated initializers (and the
+/// global-actor-isolated stored properties they access) from Sema to the
+/// SIL-level flow-isolation pass, allowing more programs to be accepted.
+EXPERIMENTAL_FEATURE(FlowIsolationGlobalActor, false)
+
 #undef EXPERIMENTAL_FEATURE_EXCLUDED_FROM_MODULE_INTERFACE
 #undef EXPERIMENTAL_FEATURE
 #undef UPCOMING_FEATURE

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -698,6 +698,7 @@ static bool usesFeatureReparenting(Decl *decl) {
 UNINTERESTING_FEATURE(StrictAccessControl)
 UNINTERESTING_FEATURE(BorrowingSequence)
 UNINTERESTING_FEATURE(AbstractStoredPropertyLayout)
+UNINTERESTING_FEATURE(FlowIsolationGlobalActor)
 
 static bool usesFeatureBorrowInout(Decl *decl) {
   auto &ctx = decl->getASTContext();

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -141,7 +141,9 @@ static bool isolatedConstructorRequiresFlowIsolation(ActorIsolation typeIso,
     llvm_unreachable("constructor cannot have erased isolation");
 
   case ActorIsolation::GlobalActor:
-    return ctor->getASTContext().LangOpts.StrictConcurrencyLevel >=
+    return ctor->getASTContext().LangOpts.hasFeature(
+               Feature::FlowIsolationGlobalActor) &&
+           ctor->getASTContext().LangOpts.StrictConcurrencyLevel >=
                StrictConcurrency::Complete &&
            !ctor->hasAsync();
   case ActorIsolation::ActorInstance:
@@ -8759,10 +8761,13 @@ ActorReferenceResult ActorReferenceResult::Builder::build() {
   // type is Sendable. Note that if the init is a nonisolated actor init,
   // Sendable checking is already performed on arguments at the call-site.
   if (auto *init = dyn_cast<ConstructorDecl>(fromDC)) {
-    // If strict concurrency is complete, we allow for users to initialize
-    // global actor non-Sendable types in initializers more aggressively through
-    // the usage of flow isolation.
-    if (fromDC->getASTContext().LangOpts.StrictConcurrencyLevel >=
+    // When the FlowIsolationGlobalActor feature is enabled under complete
+    // strict concurrency, we allow users to initialize global actor
+    // non-Sendable types in initializers more aggressively by deferring the
+    // check to the SIL-level flow-isolation pass.
+    if (fromDC->getASTContext().LangOpts.hasFeature(
+            Feature::FlowIsolationGlobalActor) &&
+        fromDC->getASTContext().LangOpts.StrictConcurrencyLevel >=
             StrictConcurrency::Complete &&
         referencedActor && referencedActor->isSelf() &&
         checkedByFlowIsolation(fromDC, *referencedActor, decl, declRefLoc,

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -3,7 +3,9 @@
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/OtherActors.swiftmodule -module-name OtherActors %S/Inputs/OtherActors.swift -target %target-swift-5.1-abi-triple
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/GlobalVariables.swiftmodule -module-name GlobalVariables %S/Inputs/GlobalVariables.swift -target %target-swift-5.1-abi-triple -parse-as-library
 
-// RUN: %target-swift-frontend -I %t  -target %target-swift-5.1-abi-triple -strict-concurrency=complete -parse-as-library -emit-sil -o /dev/null -verify -verify-ignore-unrelated -enable-upcoming-feature GlobalActorIsolatedTypesUsability %s
+// RUN: %target-swift-frontend -I %t  -target %target-swift-5.1-abi-triple -strict-concurrency=complete -enable-experimental-feature FlowIsolationGlobalActor -parse-as-library -emit-sil -o /dev/null -verify -verify-ignore-unrelated -enable-upcoming-feature GlobalActorIsolatedTypesUsability %s
+
+// REQUIRES: swift_feature_FlowIsolationGlobalActor
 
 // REQUIRES: concurrency
 // REQUIRES: swift_feature_GlobalActorIsolatedTypesUsability

--- a/test/Concurrency/flow_isolation_actor.swift
+++ b/test/Concurrency/flow_isolation_actor.swift
@@ -1,4 +1,6 @@
-// RUN: %target-swift-frontend -strict-concurrency=complete -swift-version 5 -parse-as-library -emit-sil -verify %s -o /dev/null
+// RUN: %target-swift-frontend -strict-concurrency=complete -enable-experimental-feature FlowIsolationGlobalActor -swift-version 5 -parse-as-library -emit-sil -verify %s -o /dev/null
+
+// REQUIRES: swift_feature_FlowIsolationGlobalActor
 
 ////////////////////////
 // MARK: Declarations //

--- a/test/Concurrency/flow_isolation_basic.swift
+++ b/test/Concurrency/flow_isolation_basic.swift
@@ -1,4 +1,6 @@
-// RUN: %target-swift-frontend -strict-concurrency=complete -swift-version 5 -parse-as-library -emit-sil -verify %s -o /dev/null
+// RUN: %target-swift-frontend -strict-concurrency=complete -enable-experimental-feature FlowIsolationGlobalActor -swift-version 5 -parse-as-library -emit-sil -verify %s -o /dev/null
+
+// REQUIRES: swift_feature_FlowIsolationGlobalActor
 
 // NOTE: This test is for general testing of how flow isolation handles control
 // flow and basic errors. For specific testing related to

--- a/test/Concurrency/flow_isolation_class.swift
+++ b/test/Concurrency/flow_isolation_class.swift
@@ -1,4 +1,6 @@
-// RUN: %target-swift-frontend -strict-concurrency=complete -swift-version 5 -parse-as-library -emit-sil -verify %s -o /dev/null
+// RUN: %target-swift-frontend -strict-concurrency=complete -enable-experimental-feature FlowIsolationGlobalActor -swift-version 5 -parse-as-library -emit-sil -verify %s -o /dev/null
+
+// REQUIRES: swift_feature_FlowIsolationGlobalActor
 
 ////////////////////////
 // MARK: Declarations //

--- a/test/Concurrency/flow_isolation_enum.swift
+++ b/test/Concurrency/flow_isolation_enum.swift
@@ -1,4 +1,6 @@
-// RUN: %target-swift-frontend -strict-concurrency=complete -swift-version 5 -parse-as-library -emit-sil -verify %s -o /dev/null
+// RUN: %target-swift-frontend -strict-concurrency=complete -enable-experimental-feature FlowIsolationGlobalActor -swift-version 5 -parse-as-library -emit-sil -verify %s -o /dev/null
+
+// REQUIRES: swift_feature_FlowIsolationGlobalActor
 
 ////////////////////////
 // MARK: Declarations //

--- a/test/Concurrency/flow_isolation_no_feature.swift
+++ b/test/Concurrency/flow_isolation_no_feature.swift
@@ -1,0 +1,41 @@
+// This test validates that WITHOUT the FlowIsolationGlobalActor experimental
+// feature, we retain the old (pre-feature) Sema behavior: the global-actor
+// flow-isolation extension is gated off, so Sema directly diagnoses
+// cross-isolation initialization of global-actor-isolated stored properties
+// instead of deferring the check to the SIL flow-isolation pass.
+//
+// NOTE: This is intentionally a small, standalone test so that it is trivial to
+// delete once FlowIsolationGlobalActor becomes the default behavior. It should
+// NOT pass -enable-experimental-feature FlowIsolationGlobalActor.
+
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -swift-version 6 -parse-as-library %s -emit-sil -o /dev/null -verify -strict-concurrency=complete
+
+// REQUIRES: concurrency
+
+@MainActor
+protocol GloballyIsolated {}
+
+class NonSendable {}
+
+// A nonisolated struct removes global-actor isolation from its stored
+// properties, so initializing them from a nonisolated init is always fine. This
+// does not depend on FlowIsolationGlobalActor.
+nonisolated struct StructRemovesGlobalActor: GloballyIsolated {
+  var x: NonSendable
+  init(x: NonSendable) {
+    self.x = x // okay
+  }
+}
+
+// A global-actor-isolated struct keeps its stored properties isolated to the
+// global actor. Without FlowIsolationGlobalActor, Sema rejects writing the
+// isolated property from a nonisolated init rather than deferring to flow
+// isolation.
+struct GlobalActorIsolated: GloballyIsolated {
+  // expected-note@+1 {{mutation of this property is only permitted within the actor}}
+  var z: NonSendable
+  nonisolated init(z: NonSendable) {
+    // expected-error@+1 {{main actor-isolated property 'z' can not be mutated from a nonisolated context}}
+    self.z = z
+  }
+}

--- a/test/Concurrency/flow_isolation_struct.swift
+++ b/test/Concurrency/flow_isolation_struct.swift
@@ -1,4 +1,6 @@
-// RUN: %target-swift-frontend -strict-concurrency=complete -swift-version 5 -parse-as-library -emit-sil -verify %s -o /dev/null
+// RUN: %target-swift-frontend -strict-concurrency=complete -enable-experimental-feature FlowIsolationGlobalActor -swift-version 5 -parse-as-library -emit-sil -verify %s -o /dev/null
+
+// REQUIRES: swift_feature_FlowIsolationGlobalActor
 
 ////////////////////////
 // MARK: Declarations //

--- a/test/Concurrency/global_actor_inference.swift
+++ b/test/Concurrency/global_actor_inference.swift
@@ -3,7 +3,9 @@
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/other_global_actor_inference.swiftmodule -module-name other_global_actor_inference -strict-concurrency=complete %S/Inputs/other_global_actor_inference.swift -enable-upcoming-feature GlobalActorIsolatedTypesUsability
 // RUN: %target-swift-frontend -I %t -disable-availability-checking %s -emit-sil -o /dev/null -verify -verify-additional-prefix minimal-targeted- -enable-upcoming-feature GlobalActorIsolatedTypesUsability
 // RUN: %target-swift-frontend -I %t -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=targeted -verify-additional-prefix minimal-targeted- -enable-upcoming-feature GlobalActorIsolatedTypesUsability
-// RUN: %target-swift-frontend -I %t -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -verify-additional-prefix complete- -enable-upcoming-feature GlobalActorIsolatedTypesUsability
+// RUN: %target-swift-frontend -I %t -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -verify-additional-prefix complete- -enable-upcoming-feature GlobalActorIsolatedTypesUsability -enable-experimental-feature FlowIsolationGlobalActor
+
+// REQUIRES: swift_feature_FlowIsolationGlobalActor
 
 // REQUIRES: concurrency
 // REQUIRES: swift_feature_GlobalActorIsolatedTypesUsability

--- a/test/Concurrency/global_actor_inference_swift6.swift
+++ b/test/Concurrency/global_actor_inference_swift6.swift
@@ -2,7 +2,9 @@
 
 // RUN: %target-swift-frontend -swift-version 6 -emit-module -emit-module-path %t/other_global_actor_inference.swiftmodule -module-name other_global_actor_inference -strict-concurrency=complete %S/Inputs/other_global_actor_inference.swift
 
-// RUN: %target-swift-frontend -swift-version 6 -I %t -disable-availability-checking %s -emit-sil -o /dev/null -verify
+// RUN: %target-swift-frontend -swift-version 6 -I %t -disable-availability-checking %s -emit-sil -o /dev/null -verify -enable-experimental-feature FlowIsolationGlobalActor
+
+// REQUIRES: swift_feature_FlowIsolationGlobalActor
 
 // REQUIRES: concurrency
 

--- a/test/Concurrency/nonisolated_rules.swift
+++ b/test/Concurrency/nonisolated_rules.swift
@@ -1,4 +1,6 @@
-// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -swift-version 6 -parse-as-library %s -emit-sil -o /dev/null -verify -strict-concurrency=complete
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -swift-version 6 -parse-as-library %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature FlowIsolationGlobalActor
+
+// REQUIRES: swift_feature_FlowIsolationGlobalActor
 
 // REQUIRES: concurrency
 

--- a/test/Concurrency/transfernonsendable_global_actor.swift
+++ b/test/Concurrency/transfernonsendable_global_actor.swift
@@ -1,9 +1,10 @@
-// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -target %target-swift-5.1-abi-triple -verify -verify-additional-prefix ni- %s -o /dev/null -parse-as-library -enable-upcoming-feature GlobalActorIsolatedTypesUsability
-// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -target %target-swift-5.1-abi-triple -verify -verify-additional-prefix ni-ns- %s -o /dev/null -parse-as-library -enable-upcoming-feature GlobalActorIsolatedTypesUsability -enable-upcoming-feature NonisolatedNonsendingByDefault
+// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -target %target-swift-5.1-abi-triple -verify -verify-additional-prefix ni- %s -o /dev/null -parse-as-library -enable-upcoming-feature GlobalActorIsolatedTypesUsability -enable-experimental-feature FlowIsolationGlobalActor
+// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -target %target-swift-5.1-abi-triple -verify -verify-additional-prefix ni-ns- %s -o /dev/null -parse-as-library -enable-upcoming-feature GlobalActorIsolatedTypesUsability -enable-upcoming-feature NonisolatedNonsendingByDefault -enable-experimental-feature FlowIsolationGlobalActor
 
 // REQUIRES: concurrency
 // REQUIRES: swift_feature_GlobalActorIsolatedTypesUsability
 // REQUIRES: swift_feature_NonisolatedNonsendingByDefault
+// REQUIRES: swift_feature_FlowIsolationGlobalActor
 
 ////////////////////////
 // MARK: Declarations //

--- a/test/Concurrency/transfernonsendable_merge_region_checker_failures.swift
+++ b/test/Concurrency/transfernonsendable_merge_region_checker_failures.swift
@@ -1,8 +1,9 @@
-// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -target %target-swift-5.1-abi-triple -verify %s -o /dev/null -parse-as-library -enable-upcoming-feature GlobalActorIsolatedTypesUsability
+// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -target %target-swift-5.1-abi-triple -verify %s -o /dev/null -parse-as-library -enable-upcoming-feature GlobalActorIsolatedTypesUsability -enable-experimental-feature FlowIsolationGlobalActor
 
 // REQUIRES: concurrency
 // REQUIRES: asserts
 // REQUIRES: swift_feature_GlobalActorIsolatedTypesUsability
+// REQUIRES: swift_feature_FlowIsolationGlobalActor
 
 // This file is the *negative* companion to
 // transfernonsendable_merge_region_diagnostics.swift. Each scenario below is a

--- a/test/Concurrency/transfernonsendable_merge_region_diagnostics.swift
+++ b/test/Concurrency/transfernonsendable_merge_region_diagnostics.swift
@@ -1,9 +1,10 @@
-// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -target %target-swift-5.1-abi-triple -verify -verify-additional-prefix named- %s -o /dev/null -parse-as-library -enable-upcoming-feature GlobalActorIsolatedTypesUsability
-// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -target %target-swift-5.1-abi-triple -Xllvm -sil-regionbasedisolation-force-use-of-typed-errors -verify -verify-additional-prefix bare- %s -o /dev/null -parse-as-library -enable-upcoming-feature GlobalActorIsolatedTypesUsability
+// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -target %target-swift-5.1-abi-triple -verify -verify-additional-prefix named- %s -o /dev/null -parse-as-library -enable-upcoming-feature GlobalActorIsolatedTypesUsability -enable-experimental-feature FlowIsolationGlobalActor
+// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -target %target-swift-5.1-abi-triple -Xllvm -sil-regionbasedisolation-force-use-of-typed-errors -verify -verify-additional-prefix bare- %s -o /dev/null -parse-as-library -enable-upcoming-feature GlobalActorIsolatedTypesUsability -enable-experimental-feature FlowIsolationGlobalActor
 
 // REQUIRES: concurrency
 // REQUIRES: asserts
 // REQUIRES: swift_feature_GlobalActorIsolatedTypesUsability
+// REQUIRES: swift_feature_FlowIsolationGlobalActor
 
 // This file exercises the *shape* of "incompatible region merge" diagnostics
 // produced by the region-isolation analysis. The points being tested:


### PR DESCRIPTION
Previously, the Sema changes that defer checking of global-actor-isolated initializers (and the global-actor-isolated stored properties they access) to the SIL-level flow-isolation pass were enabled unconditionally whenever strict concurrency was complete.

This introduces a new experimental feature, FlowIsolationGlobalActor, and gates those two Sema delegation code paths behind it:

  - isolatedConstructorRequiresFlowIsolation's GlobalActor case, which makes synchronous global-actor-isolated nominal-type initializers use flow-sensitive isolation.
  - ActorReferenceResult::Builder::build's checkedByFlowIsolation delegation, which suppresses the cross-isolation Sema diagnostic in favor of the flow-isolation pass.

With the feature off, we restore the prior Sema behavior. Since the SIL passes key off usesFlowSensitiveIsolation, gating Sema is sufficient end-to-end.

The dedicated flow_isolation_* tests and the shared tests whose expectations were updated for this behavior now enable the feature explicitly. A small, standalone flow_isolation_no_feature.swift test validates that the old behavior is restored without the flag and is easy to delete once the feature becomes the default.
