### PR TITLE
[Embedded] Fix duplicate symbol issues with @export(interface) on global variables and class-bound witness tables

### DIFF
--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -2791,6 +2791,19 @@ void IRGenModule::emitSILWitnessTable(SILWitnessTable *wt) {
   if (isAvailableExternally(wt->getLinkage()))
     return;
 
+  // In Embedded Swift, an `@export(interface)` conformance has a unique
+  // strong definition in the module that owns it. Importing modules must
+  // reference that definition externally rather than emit their own copy.
+  if (Context.LangOpts.hasFeature(Feature::Embedded)) {
+    if (auto *normal =
+            dyn_cast<NormalProtocolConformance>(wt->getConformance())) {
+      if (normal->getEffectiveCodeGenerationModel() ==
+              CodeGenerationModel::Interface &&
+          wt->getDeclContext()->getParentModule() != getSwiftModule())
+        return;
+    }
+  }
+
   // Ensure that relatively-referenced symbols for witness thunks are collocated
   // in the same LLVM module.
   IRGen.ensureRelativeSymbolCollocation(*wt);

--- a/lib/SIL/IR/Linker.cpp
+++ b/lib/SIL/IR/Linker.cpp
@@ -61,6 +61,7 @@
 #include "swift/AST/ProtocolConformance.h"
 #include "swift/AST/SubstitutionMap.h"
 #include "swift/Basic/Assertions.h"
+#include "swift/Basic/CodeGenerationModel.h"
 #include "swift/ClangImporter/ClangModule.h"
 #include "swift/SIL/FormalLinkage.h"
 #include "swift/Serialization/SerializedSILLoader.h"
@@ -519,9 +520,15 @@ void SILLinkerVisitor::visitGlobalAddrInst(GlobalAddrInst *GAI) {
   if (!Mod.getOptions().EmbeddedSwift)
     return;
 
-  // In Embedded Swift, we want to actually link globals from other modules too,
-  // so strip "external" from the linkage.
+  // In Embedded Swift, globals from other modules are normally materialized
+  // as definitions in the importing module (linkonce_odr at IRGen time), so
+  // strip "external" from their linkage. The exception is the Interface code
+  // generation model: those globals have a unique strong definition in their
+  // defining module, and the importer must reference them externally.
   SILGlobalVariable *G = GAI->getReferencedGlobal();
+  if (auto cgModel = G->codeGenerationModel())
+    if (*cgModel == CodeGenerationModel::Interface)
+      return;
   if (G->isDefinition())
     G->setLinkage(stripExternalFromLinkage(G->getLinkage()));
 }

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -4319,6 +4319,19 @@ SILGlobalVariable *SILDeserializer::readGlobalVar(StringRef Name,
     return nullptr;
   }
 
+  // A SIL global variable that uses the Interface code generation model has a
+  // unique strong definition in its defining module. When deserialized into a
+  // different module, mark its linkage as externally available so that the
+  // importer references the defining module's symbol rather than emitting
+  // its own definition.
+  if (codeGenerationModel &&
+      static_cast<CodeGenerationModel>(codeGenerationModel - 1) ==
+          CodeGenerationModel::Interface &&
+      MF->getAssociatedModule() != SILMod.getSwiftModule()) {
+    linkage = addExternalToLinkage(*linkage);
+    IsDeclaration = true;
+  }
+
   VarDecl *globalDecl = nullptr;
   if (dID) {
     llvm::Expected<Decl *> d = MF->getDeclChecked(dID);

--- a/test/embedded/linkage/export_interface_class_protocol_witness.swift
+++ b/test/embedded/linkage/export_interface_class_protocol_witness.swift
@@ -1,0 +1,52 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: swift_feature_Embedded
+// UNSUPPORTED: CPU=wasm32
+
+// RUN: %target-swift-frontend -emit-ir -emit-module -o %t/Library.ll -emit-module-path %t/Library.swiftmodule %t/Library.swift -enable-experimental-feature Embedded -parse-as-library -module-name Library
+// RUN: %FileCheck %s -check-prefix LIBRARY-IR < %t/Library.ll
+
+// RUN: %target-swift-frontend -emit-ir -o %t/Client.ll %t/Client.swift -I %t -enable-experimental-feature Embedded -parse-as-library -module-name Client
+// RUN: %FileCheck %s -check-prefix CLIENT-IR < %t/Client.ll
+
+//--- Library.swift
+
+// A class-bound protocol declared in the same module as the conforming class.
+public protocol Resource: AnyObject {
+  func read() -> Int
+}
+
+// `@export(interface)` makes Library the unique strong definer of `Stream`
+// and its protocol conformances. The protocol witness table for
+// `Stream: Resource` should therefore be a strong definition here.
+// LIBRARY-IR-DAG: @"$e7Library6StreamCAA8ResourceAAWP" = {{(protected )?}}constant
+@export(interface)
+public class Stream: Resource {
+  public var byte: Int = 42
+  public init() {}
+  public func read() -> Int { return byte }
+}
+
+public func makeStream() -> Stream {
+  return Stream()
+}
+
+//--- Client.swift
+import Library
+
+// The importer must reference the protocol witness table for
+// `Stream: Resource` as an external declaration rather than re-emitting it.
+// Before the fix the importer emitted its own (constant) definition here,
+// which collided with Library's strong definition at link time.
+// CLIENT-IR-DAG: @"$e7Library6StreamCAA8ResourceAAWP" = external global
+// CLIENT-IR-NOT: @"$e7Library6StreamCAA8ResourceAAWP" ={{.*}} constant
+
+public func use() -> Int {
+  let stream = makeStream()
+  // Forming a class-bound existential of `Resource` from the exported
+  // class is what causes the importer to need the witness table.
+  let any: any Resource = stream
+  return any.read()
+}

--- a/test/embedded/linkage/inlined_global_addr_external.swift
+++ b/test/embedded/linkage/inlined_global_addr_external.swift
@@ -1,0 +1,55 @@
+// Regression test: an inlinable function in a library that references a
+// global variable via `global_addr` (e.g. through `Builtin.addressof`) used
+// to cause IRGen in the importing client to *redefine* the global. When the
+// global is `@export(interface)` — where the library has the unique strong
+// definition — the client must instead reference it externally.
+//
+// `@_silgen_name` on the storage forces direct symbol access, so
+// `Builtin.addressof` lowers to `global_addr` rather than calling an
+// addressor function. That's the SIL shape that exposed the bug; addressor
+// calls hide the global from the importer.
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: swift_feature_Embedded
+// REQUIRES: swift_feature_BuiltinModule
+// UNSUPPORTED: CPU=wasm32
+
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/Library.swiftmodule %t/Library.swift -parse-stdlib -enable-experimental-feature BuiltinModule -enable-experimental-feature Embedded -parse-as-library -module-name Library
+
+// RUN: %target-swift-frontend -emit-ir -o %t/Client.ll %t/Client.swift -parse-stdlib -I %t -enable-experimental-feature BuiltinModule -enable-experimental-feature Embedded -parse-as-library -module-name Client
+// RUN: %FileCheck %s -check-prefix CLIENT-IR < %t/Client.ll
+
+//--- Library.swift
+
+import Builtin
+
+@export(interface)
+@_silgen_name("library_storage")
+public var _myStorage: (Builtin.Int64, Builtin.Int64) =
+    (Builtin.zeroInitializer(), Builtin.zeroInitializer())
+
+// Inlinable function whose body produces a `global_addr` against the
+// library's storage. When this is inlined into a client, the client sees
+// the raw address, not an addressor call.
+@inlinable
+public func getStoragePtr() -> Builtin.RawPointer {
+  return Builtin.addressof(&_myStorage)
+}
+
+//--- Client.swift
+import Builtin
+import Library
+
+// The client must reference Library's `library_storage` as an external
+// declaration, not redefine it. Before the fix, the client emitted a
+// (zero-initialized) definition here, which collided with the library's
+// strong definition under the Interface code-generation model.
+// CLIENT-IR-DAG: @library_storage = external global
+// CLIENT-IR-NOT: @library_storage ={{.*}} global {{.*}}zeroinitializer
+
+public func use() -> Builtin.RawPointer {
+  return getStoragePtr()
+}


### PR DESCRIPTION
Fixes two issues of duplicated symbols when using `@export(interface)` in Embedded Swift:
* Global variables that can be directly referenced (e.g., because they are imported from C or are `@_silgen_name`)
* Witness tables for class-bound protocols

Fixes rdar://178238940