### PR TITLE
Parse: Allow up to five components in `#if compiler()` and `canImport()` versions

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1973,8 +1973,9 @@ ERROR(unsupported_conditional_compilation_integer,none,
       (StringRef, StringRef))
 ERROR(version_component_not_number,none,
       "version component contains non-numeric characters", ())
-ERROR(compiler_version_too_many_components,none,
-      "compiler version must not have more than five components", ())
+WARNING(compiler_version_too_many_components,none,
+      "trailing components of version '%0' are ignored",
+      (StringRef))
 GROUPED_WARNING(unused_compiler_version_component,NoUsage,NoUsage,
       "the second version component is not used for comparison in legacy "
       "compiler versions%select{|; are you trying to encode a new Swift "

--- a/lib/AST/Bridging/ASTContextBridging.cpp
+++ b/lib/AST/Bridging/ASTContextBridging.cpp
@@ -71,9 +71,14 @@ bool BridgedASTContext_canImport(BridgedASTContext cContext,
     version = llvm::VersionTuple(versionComponents[0], versionComponents[1],
                                  versionComponents[2]);
     break;
-  default:
+  case 4:
     version = llvm::VersionTuple(versionComponents[0], versionComponents[1],
                                  versionComponents[2], versionComponents[3]);
+    break;
+  default:
+    version = llvm::VersionTuple(versionComponents[0], versionComponents[1],
+                                 versionComponents[2], versionComponents[3],
+                                 versionComponents[4]);
     break;
   }
 

--- a/lib/Parse/ParseIfConfig.cpp
+++ b/lib/Parse/ParseIfConfig.cpp
@@ -116,15 +116,24 @@ static llvm::VersionTuple getCanImportVersion(ArgumentList *args,
     return result;
   }
 
-  // VersionTuple supports a maximum of 4 components.
-  ssize_t excessComponents = verText.count('.') - 3;
+  // VersionTuple supports a maximum of 5 components.
+  ssize_t excessComponents = verText.count('.') - 4;
   if (excessComponents > 0) {
+    auto originalSize = verText.size();
     do {
       verText = verText.rsplit('.').first;
     } while (--excessComponents > 0);
     if (D) {
+      // Highlight the trailing dotted components that are about to be dropped,
+      // starting at the period that precedes the first ignored component.
+      SourceLoc verStart = isa<StringLiteralExpr>(subE)
+                               ? subE->getStartLoc().getAdvancedLoc(1)
+                               : subE->getStartLoc();
+      SourceLoc trailingStart = verStart.getAdvancedLoc(verText.size());
+      SourceLoc trailingEnd = verStart.getAdvancedLoc(originalSize);
       D->diagnose(subE->getLoc(), diag::canimport_version_too_many_components,
-                  verText);
+                  verText)
+          .highlightChars(trailingStart, trailingEnd);
     }
   }
 

--- a/lib/Parse/ParseVersion.cpp
+++ b/lib/Parse/ParseVersion.cpp
@@ -13,7 +13,9 @@
 #include "swift/Parse/ParseVersion.h"
 #include "swift/AST/DiagnosticsParse.h"
 #include "swift/Basic/Assertions.h"
+#include "llvm/ADT/SmallString.h"
 #include "llvm/Support/FormatVariadic.h"
+#include "llvm/Support/raw_ostream.h"
 
 using namespace swift;
 using namespace swift::version;
@@ -137,9 +139,19 @@ std::optional<Version> VersionParser::parseCompilerVersionString(
   }
 
   if (CV.Components.size() > 5) {
-    if (Diags)
-      Diags->diagnose(Loc, diag::compiler_version_too_many_components);
-    isValidVersion = false;
+    // Highlight the trailing dotted components that are about to be dropped,
+    // starting at the period that precedes the first ignored component.
+    auto trailingStart =
+        SplitComponents[5].second.Start.getAdvancedLoc(-1);
+    auto trailingEnd = SplitComponents.back().second.End;
+    CV.Components.truncate(5);
+    if (Diags) {
+      SmallString<32> truncated;
+      llvm::raw_svector_ostream(truncated) << CV;
+      Diags->diagnose(Loc, diag::compiler_version_too_many_components,
+                      truncated.str())
+          .highlightChars(trailingStart, trailingEnd);
+    }
   }
 
   // In the beginning, '_compiler_version(string-literal)' was designed for a

--- a/test/Parse/ConditionalCompilation/can_import_options.swift
+++ b/test/Parse/ConditionalCompilation/can_import_options.swift
@@ -69,8 +69,12 @@ func canImportVersioned() {
   let buildLarger = 1
 #endif
   
-#if canImport(Bar, _version: 113.330.1.2.0) // expected-warning {{trailing components of version '113.330.1.2' are ignored}}
+#if canImport(Bar, _version: 113.330.1.2.0)
   let extraComponent = 1 // expected-warning {{initialization of immutable value 'extraComponent' was never used; consider replacing with assignment to '_' or removing it}}
+#endif
+
+#if canImport(Bar, _version: 113.330.1.2.0.0) // expected-warning {{trailing components of version '113.330.1.2.0' are ignored}}
+  let extraExtraComponent = 1 // expected-warning {{initialization of immutable value 'extraExtraComponent' was never used; consider replacing with assignment to '_' or removing it}}
 #endif
 
 #if canImport(Bar, _underlyingVersion: 113.33) // expected-warning{{cannot find user version number for Clang module 'Bar'; version number ignored}}
@@ -137,8 +141,12 @@ func canImportUnderlyingVersion() {
   let buildLarger = 1
 #endif
   
-#if canImport(Baz, _underlyingVersion: 113.330.1.2.0) // expected-warning {{trailing components of version '113.330.1.2' are ignored}}
+#if canImport(Baz, _underlyingVersion: 113.330.1.2.0)
   let extraComponent = 1 // expected-warning {{initialization of immutable value 'extraComponent' was never used; consider replacing with assignment to '_' or removing it}}
+#endif
+
+#if canImport(Baz, _underlyingVersion: 113.330.1.2.0.0) // expected-warning {{trailing components of version '113.330.1.2.0' are ignored}}
+  let extraExtraComponent = 1 // expected-warning {{initialization of immutable value 'extraExtraComponent' was never used; consider replacing with assignment to '_' or removing it}}
 #endif
 
 #if canImport(Baz, _version: 113.33)

--- a/test/Parse/ConditionalCompilation/can_import_version.swift
+++ b/test/Parse/ConditionalCompilation/can_import_version.swift
@@ -63,8 +63,12 @@ func canImportVersioned() {
   let buildLarger = 1
 #endif
   
-#if canImport(Foo, _version: 113.330.1.2.0) // expected-warning {{trailing components of version '113.330.1.2' are ignored}}
+#if canImport(Foo, _version: 113.330.1.2.0)
   let extraComponent = 1 // expected-warning {{initialization of immutable value 'extraComponent' was never used; consider replacing with assignment to '_' or removing it}}
+#endif
+
+#if canImport(Foo, _version: 113.330.1.2.0.0) // expected-warning {{trailing components of version '113.330.1.2.0' are ignored}}
+  let extraExtraComponent = 1 // expected-warning {{initialization of immutable value 'extraExtraComponent' was never used; consider replacing with assignment to '_' or removing it}}
 #endif
 
 #if canImport(Foo, _underlyingVersion: 113.33) // expected-warning {{cannot find user version number for Clang module 'Foo'; version number ignored}}
@@ -132,8 +136,12 @@ func canImportVersionedString() {
   let buildLarger = 1
 #endif
 
-#if canImport(Foo, _version: "113.330.1.2.0") // expected-warning {{trailing components of version '113.330.1.2' are ignored}}
+#if canImport(Foo, _version: "113.330.1.2.0")
   let extraComponent = 1 // expected-warning {{initialization of immutable value 'extraComponent' was never used; consider replacing with assignment to '_' or removing it}}
+#endif
+
+#if canImport(Foo, _version: "113.330.1.2.0.0") // expected-warning {{trailing components of version '113.330.1.2.0' are ignored}}
+  let extraExtraComponent = 1 // expected-warning {{initialization of immutable value 'extraExtraComponent' was never used; consider replacing with assignment to '_' or removing it}}
 #endif
 
 #if canImport(Foo, _underlyingVersion: "113.33") // expected-warning {{cannot find user version number for Clang module 'Foo'; version number ignored}}

--- a/test/Parse/ConditionalCompilation/compiler.swift
+++ b/test/Parse/ConditionalCompilation/compiler.swift
@@ -46,3 +46,14 @@
   foo bar
  #endif
 #endif
+
+#if compiler(>=4.1.0.0.0)
+ let _: Int = 1
+#else
+ // There should be no error here.
+ foo bar
+#endif
+
+#if compiler(>=4.1.0.0.0.0) // expected-warning {{trailing components of version '4.1.0.0.0' are ignored}}
+ let _: Int = 1
+#endif

--- a/test/Parse/ConditionalCompilation/compiler_version.swift
+++ b/test/Parse/ConditionalCompilation/compiler_version.swift
@@ -52,7 +52,7 @@
 #if _compiler_version("5.7.100") // expected-warning {{the second version component is not used for comparison in legacy compiler versions}}
 #endif
 
-#if _compiler_version("700.*.1.1.1.1") // expected-error {{version must not have more than five components}}
+#if _compiler_version("700.*.1.1.1.1") // expected-warning {{trailing components of version '700.0.1.1.1' are ignored}}
 #endif
 
 #if _compiler_version("9223372.*.1.1.1") // expected-error {{compiler version component '9223372' is not in the allowed range 0...9223371}}

--- a/test/Parse/ifconfig_expr.swift
+++ b/test/Parse/ifconfig_expr.swift
@@ -142,8 +142,12 @@ func canImportVersioned() {
 #if canImport(A, _version: 2.2.2.2)
   let a = 1
 #endif
-  
-#if canImport(A, _version: 2.2.2.2.2) // expected-warning {{trailing components of version '2.2.2.2' are ignored}}
+
+#if canImport(A, _version: 2.2.2.2.2)
+  let a = 1
+#endif
+
+#if canImport(A, _version: 2.2.2.2.2.2) // expected-warning {{trailing components of version '2.2.2.2.2' are ignored}}
   let a = 1
 #endif
 


### PR DESCRIPTION
The parser truncated user-specified versions for `canImport(_:_version:)` to four components, citing an outdated claim that `llvm::VersionTuple` supports a maximum of four. It actually supports five (major, minor, subminor, build, sub-build), matching the cap already enforced by `swift::version::Version` for the `compiler(>=...)` form. Lift the cap to five everywhere.

Also demote `compiler_version_too_many_components` from an error to a warning, and align its message with the `canImport` variant: `"trailing components of version '%0' are ignored"`. The truncated version that the compiler is actually using for the comparison is substituted into the message so users can see what was kept.

Requires https://github.com/swiftlang/swift-syntax/pull/3350.

Resolves rdar://112954087.
