### PR TITLE
:cherries: [6.4] [cxx-interop] Patch up compound names of imported methods

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4677,8 +4677,22 @@ namespace {
           if (auto updatedName =
                   Impl.importFullName(decl, Impl.CurrentVersion)) {
             auto *valueDecl = cast<ValueDecl>(method);
-            if (valueDecl->getName() != updatedName.getDeclName())
-              valueDecl->setName(updatedName.getDeclName());
+            auto newName = updatedName.getDeclName();
+
+            // Mirror the name reconciliation in importFunctionDecl:
+            // rebuild compound name from the function's actual parameter list
+            // so it stays a valid function-decl name.
+            if (auto *fn = dyn_cast<AbstractFunctionDecl>(valueDecl);
+                fn && newName) {
+              if (newName.isSimpleName() || newName.getArgumentNames().size() !=
+                                                fn->getParameters()->size()) {
+                newName = DeclName(Impl.SwiftContext,
+                                   newName.getBaseName(), fn->getParameters());
+              }
+            }
+
+            if (valueDecl->getName() != newName)
+              valueDecl->setName(newName);
           }
         }
       }

--- a/test/Interop/Cxx/templates/template-type-parameter-not-in-signature-silgen.swift
+++ b/test/Interop/Cxx/templates/template-type-parameter-not-in-signature-silgen.swift
@@ -1,4 +1,11 @@
-// RUN: %target-swift-emit-silgen %s -cxx-interoperability-mode=default -I %S/Inputs | %FileCheck %s
+// RUN: %target-swift-emit-silgen %s -cxx-interoperability-mode=default -I %S/Inputs \
+// RUN: | %FileCheck %s
+//
+// RUN: %target-swift-emit-silgen %s -cxx-interoperability-mode=default -I %S/Inputs \
+// RUN:   -enable-experimental-feature ImportCxxMembersLazily \
+// RUN: | %FileCheck %s
+//
+// REQUIRES: swift_feature_ImportCxxMembersLazily
 
 import TemplateTypeParameterNotInSignature
 

--- a/test/Interop/Cxx/templates/template-type-parameter-not-in-signature-typechecker.swift
+++ b/test/Interop/Cxx/templates/template-type-parameter-not-in-signature-typechecker.swift
@@ -1,0 +1,51 @@
+// RUN: %target-typecheck-verify-swift -I %S/Inputs -cxx-interoperability-mode=default
+// RUN: %target-typecheck-verify-swift -I %S/Inputs -cxx-interoperability-mode=default \
+// RUN:   -enable-experimental-feature ImportCxxMembersLazily
+//
+// REQUIRES: swift_feature_ImportCxxMembersLazily
+
+import TemplateTypeParameterNotInSignature
+
+public func callMemberFunctionTemplates(_ s: Struct) {
+  s.templateTypeParamNotUsedInSignature(T: Int.self)
+  let _: Int = s.templateTypeParamUsedInReturnType(0)
+}
+
+public func callMutableMemberFunctionTemplate(_ s: inout Struct) {
+  s.templateTypeParamNotUsedInSignatureMutable(T: Int.self)
+}
+
+public func callStaticMemberFunctionTemplate() {
+  Struct.templateTypeParamNotUsedInSignatureStatic(T: Int.self)
+}
+
+public func callFreeFunctionTemplates() {
+  let _: Bool = templateTypeParamNotUsedInSignature(T: Int.self)
+  multiTemplateTypeParamNotUsedInSignature(T: Float.self, U: Int.self)
+  let _: Int = multiTemplateTypeParamOneUsedInSignature(1, T: Int.self)
+  multiTemplateTypeParamNotUsedInSignatureWithUnrelatedParams(
+      1, 1, T: Int32.self, U: Int.self)
+  let _: Int = templateTypeParamUsedInReturnType(10)
+}
+
+public func callReferenceParamTemplates() {
+  var x: Int = 1
+  let _ = templateTypeParamUsedInReferenceParam(&x)
+  let _ = templateTypeParamNotUsedInSignatureWithRef(&x, U: Int.self)
+}
+
+// FIXME: Function templates with varargs are imported but marked unavailable
+// (see the corresponding -module-interface test), but the availability
+// diagnostic does not seem to fire on this call site.
+public func callVarargsTemplates() {
+  templateTypeParamNotUsedInSignatureWithVarargs(T: Int.self, U: Int.self)
+  templateTypeParamNotUsedInSignatureWithVarargsAndUnrelatedParam(
+    0, T: Int.self, U: Int.self, V: Int.self)
+}
+
+// Function templates with non-type template parameters are not imported;
+// try to call one anyway to make sure we don't crash trying to resolve it.
+public func callNonTypeParamTemplate() {
+  templateTypeParamNotUsedInSignatureWithNonTypeParam(T: Int.self)
+  // expected-error@-1 {{cannot find 'templateTypeParamNotUsedInSignatureWithNonTypeParam' in scope}}
+}


### PR DESCRIPTION
**Explanation**: When we import a method with `ImportCxxMembersLazily` enabled, we re-import its name to account for potential `__Unsafe` mangling. However, we did not perform the `DeclName` fix-up that `importFunctionDecl()` does, which is necessary to account for `SWIFT_NAME("simple_identifier_no_parens")`. This patch adds that `DeclName` fix-up and avoids some assertion failures.
**Issues**: rdar://177990003
**Risk**: Low. This only affects Swift compilations where `ImportCxxMembersLazily` is enabled (currently off by default). Only the first, more surgical commit from #89487 (5060a79bd77548430e6efaf6fabfbc1aac4b3d77) is cherry-picked.
**Testing**: Added testing + existing regression tests pass.
**Original PR**: https://github.com/swiftlang/swift/pull/89487
**Reviewers**: @egorzhdan 
