### PR TITLE
[cxx-interop] Gate defaulted-comparisons test on std_compare

### DIFF
--- a/test/Interop/Cxx/operators/defaulted-comparisons.swift
+++ b/test/Interop/Cxx/operators/defaulted-comparisons.swift
@@ -1,6 +1,7 @@
 // RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -cxx-interoperability-mode=default -Xcc -std=c++20)
 
 // REQUIRES: executable_test
+// REQUIRES: std_compare
 
 import DefaultedComparisons
 import StdlibUnittest

--- a/test/Interop/lit.local.cfg
+++ b/test/Interop/lit.local.cfg
@@ -76,6 +76,8 @@ if has_cxx_stdlib_header('span'):
     config.available_features.add('std_span')
 if has_cxx_stdlib_header('expected'):
     config.available_features.add('std_expected')
+if has_cxx_stdlib_header('compare'):
+    config.available_features.add('std_compare')
 if has_cxx_stdlib_header('coroutine'):
     config.available_features.add('std_coroutine')
 


### PR DESCRIPTION
The defaulted-comparisons interop test includes <compare>, which is required by spaceship operator. The header is absent on old toolchains like Amazon Linux 2 that has GCC 7.3.

Add a std_compare feature to lit and gate the test behind this feature.

rdar://178216758