### PR TITLE
[stdlib] BufferPointer rebasing fix

### DIFF
--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -908,6 +908,17 @@ extension Unsafe${Mutable}BufferPointer {
   /// - Parameter slice: The buffer slice to rebase.
   @inlinable @_transparent // unsafe-performance
   public init(rebasing slice: Slice<UnsafeMutableBufferPointer<Element>>) {
+    // NOTE: `Slice` does not guarantee that its start/end indices are valid
+    // in `base` -- it merely ensures that `startIndex <= endIndex`.
+    // We need manually check that we aren't given an invalid slice,
+    // or the resulting collection would allow access that was
+    // out-of-bounds with respect to the original base buffer.
+    // We only do this in debug builds to prevent a measurable performance
+    // degradation wrt passing around pointers not wrapped in a BufferPointer
+    // construct.
+    _debugPrecondition(
+      unsafe slice.startIndex >= 0 && slice.endIndex <= slice.base.count,
+      "Invalid slice")
     let base = unsafe slice.base.baseAddress?.advanced(by: slice.startIndex)
     let count = unsafe slice.endIndex &- slice.startIndex
     unsafe self.init(start: base, count: count)

--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -263,6 +263,13 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
     unsafe Range(uncheckedBounds: (0, count))
   }
 
+  @_alwaysEmitIntoClient
+  @inline(__always)
+  @safe
+  public func _checkBounds(_ bounds: Range<Index>) -> Bool {
+    0 <= bounds.lowerBound && bounds.upperBound <= count
+  }
+
   @_transparent
   @_preInverseGenerics
   public func index(after i: Int) -> Int {
@@ -511,8 +518,7 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
   @_alwaysEmitIntoClient
   @safe
   public func extracting(_ bounds: Range<Int>) -> Self {
-    _precondition(bounds.lowerBound >= 0 && bounds.upperBound <= count,
-      "Index out of range")
+    _precondition(_checkBounds(bounds), "Index out of range")
     guard let start = self.baseAddress else {
       return unsafe Self(start: nil, count: 0)
     }
@@ -791,15 +797,13 @@ extension Unsafe${Mutable}BufferPointer:
     bounds: Range<Int>
   ) -> Slice<Unsafe${Mutable}BufferPointer<Element>> {
     get {
-      _debugPrecondition(bounds.lowerBound >= startIndex)
-      _debugPrecondition(bounds.upperBound <= endIndex)
+      _debugPrecondition(_checkBounds(bounds), "Index out of range")
       return unsafe Slice(
         base: self, bounds: bounds)
     }
 %  if Mutable:
     nonmutating set {
-      _debugPrecondition(bounds.lowerBound >= startIndex)
-      _debugPrecondition(bounds.upperBound <= endIndex)
+      _debugPrecondition(_checkBounds(bounds), "Index out of range")
       unsafe _debugPrecondition(bounds.count == newValue.count)
 
       // FIXME: swift-3-indexing-model: tests.
@@ -878,8 +882,8 @@ extension Unsafe${Mutable}BufferPointer {
     // degradation wrt passing around pointers not wrapped in a BufferPointer
     // construct.
     _debugPrecondition(
-      unsafe slice.startIndex >= 0 && slice.endIndex <= slice.base.count,
-      "Invalid slice")
+      unsafe slice.base._checkBounds(slice._bounds), "Invalid slice"
+    )
     let base = unsafe slice.base.baseAddress?.advanced(by: slice.startIndex)
     let count = unsafe slice.endIndex &- slice.startIndex
     unsafe self.init(start: base, count: count)
@@ -917,8 +921,8 @@ extension Unsafe${Mutable}BufferPointer {
     // degradation wrt passing around pointers not wrapped in a BufferPointer
     // construct.
     _debugPrecondition(
-      unsafe slice.startIndex >= 0 && slice.endIndex <= slice.base.count,
-      "Invalid slice")
+      unsafe slice.base._checkBounds(slice._bounds), "Invalid slice"
+    )
     let base = unsafe slice.base.baseAddress?.advanced(by: slice.startIndex)
     let count = unsafe slice.endIndex &- slice.startIndex
     unsafe self.init(start: base, count: count)

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -259,6 +259,13 @@ extension Unsafe${Mutable}RawBufferPointer: @unsafe ${Mutable}Collection {
     return unsafe Indices(uncheckedBounds: (startIndex, endIndex))
   }
 
+  @_alwaysEmitIntoClient
+  @inline(always)
+  @safe
+  public func _checkBounds(_ bounds: Range<Index>) -> Bool {
+    0 <= bounds.lowerBound && bounds.upperBound <= count
+  }
+
   /// Accesses the byte at the given offset in the memory region as a `UInt8`
   /// value.
   ///
@@ -287,14 +294,12 @@ extension Unsafe${Mutable}RawBufferPointer: @unsafe ${Mutable}Collection {
   @inlinable
   public subscript(bounds: Range<Int>) -> SubSequence {
     get {
-      _debugPrecondition(bounds.lowerBound >= startIndex)
-      _debugPrecondition(bounds.upperBound <= endIndex)
+      _debugPrecondition(_checkBounds(bounds), "Index out of range")
       return unsafe Slice(base: self, bounds: bounds)
     }
 %  if mutable:
     nonmutating set {
-      _debugPrecondition(bounds.lowerBound >= startIndex)
-      _debugPrecondition(bounds.upperBound <= endIndex)
+      _debugPrecondition(_checkBounds(bounds), "Index out of range")
       _debugPrecondition(unsafe bounds.count == newValue.count)
 
       if unsafe !newValue.isEmpty {
@@ -707,8 +712,8 @@ extension Unsafe${Mutable}RawBufferPointer {
     // degradation wrt passing around pointers not wrapped in a BufferPointer
     // construct.
     _debugPrecondition(
-      unsafe slice.startIndex >= 0 && slice.endIndex <= slice.base.count,
-      "Invalid slice")
+      unsafe slice.base._checkBounds(slice._bounds), "Invalid slice"
+    )
     let base = unsafe slice.base.baseAddress?.advanced(by: slice.startIndex)
     let count = unsafe slice.endIndex &- slice.startIndex
     unsafe self.init(start: base, count: count)
@@ -746,8 +751,8 @@ extension Unsafe${Mutable}RawBufferPointer {
     // degradation wrt passing around pointers not wrapped in a BufferPointer
     // construct.
     _debugPrecondition(
-      unsafe slice.startIndex >= 0 && slice.endIndex <= slice.base.count,
-      "Invalid slice")
+      unsafe slice.base._checkBounds(slice._bounds), "Invalid slice"
+    )
     let base = unsafe slice.base.baseAddress?.advanced(by: slice.startIndex)
     let count = unsafe slice.endIndex &- slice.startIndex
     unsafe self.init(start: base, count: count)

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -737,6 +737,17 @@ extension Unsafe${Mutable}RawBufferPointer {
   /// - Parameter slice: The raw buffer slice to rebase.
   @inlinable @_transparent
   public init(rebasing slice: Slice<UnsafeMutableRawBufferPointer>) {
+    // NOTE: `Slice` does not guarantee that its start/end indices are valid
+    // in `base` -- it merely ensures that `startIndex <= endIndex`.
+    // We need manually check that we aren't given an invalid slice,
+    // or the resulting collection would allow access that was
+    // out-of-bounds with respect to the original base buffer.
+    // We only do this in debug builds to prevent a measurable performance
+    // degradation wrt passing around pointers not wrapped in a BufferPointer
+    // construct.
+    _debugPrecondition(
+      unsafe slice.startIndex >= 0 && slice.endIndex <= slice.base.count,
+      "Invalid slice")
     let base = unsafe slice.base.baseAddress?.advanced(by: slice.startIndex)
     let count = unsafe slice.endIndex &- slice.startIndex
     unsafe self.init(start: base, count: count)

--- a/validation-test/stdlib/UnsafeBufferPointer.swift.gyb
+++ b/validation-test/stdlib/UnsafeBufferPointer.swift.gyb
@@ -119,6 +119,56 @@ ${SelfName}TestSuite.test("rebasing") {
 %   end # Mutable
 }
 
+% if not IsMutable:
+${SelfName}TestSuite.test("rebasingInvalidNonMutableSlice")
+.require(.crashTesting)
+.code {
+  let rawBuffer = UnsafeMutableRawBufferPointer.allocate(
+    byteCount: 32, alignment: 8
+  )
+  defer { rawBuffer.deallocate() }
+
+  rawBuffer.copyBytes(from: UInt8.zero ..< 32)
+
+%   if IsRaw:
+  let baseBuffer = ${SelfType}(rawBuffer)
+%   else:
+  let rebound = rawBuffer.bindMemory(to: Float.self)
+  let baseBuffer = ${SelfType}(rebound)
+%   end
+
+  let invalidSlice = Slice(base: baseBuffer, bounds: -5 ..< 5)
+
+  expectCrashLater()
+  _ = ${SelfType}(rebasing: invalidSlice)
+}
+
+% end
+${SelfName}TestSuite.test("rebasingInvalidMutableSlice")
+.require(.minimumStdlib(.stdlib_6_4))
+.require(.crashTesting)
+.code {
+  guard #available(SwiftStdlib 6.4, *) else { return }
+
+  let rawBuffer = UnsafeMutableRawBufferPointer.allocate(
+    byteCount: 32, alignment: 8
+  )
+  defer { rawBuffer.deallocate() }
+
+  rawBuffer.copyBytes(from: UInt8.zero ..< 32)
+
+%   if IsRaw:
+  let baseBuffer = rawBuffer
+%   else:
+  let baseBuffer = rawBuffer.bindMemory(to: Float.self)
+%   end
+
+  let invalidSlice = Slice(base: baseBuffer, bounds: -5 ..< 5)
+
+  expectCrashLater()
+  _ = ${SelfType}(rebasing: invalidSlice)
+}
+
 // Allocate two buffers. Initialize one and copy it into the other. Pass those
 // to the specified generic collection test function `checkBuffers`.
 func checkWithExpectedBuffer(checkBuffers: (${SelfType}, ${SelfType}) -> Void) {
@@ -1230,7 +1280,7 @@ UnsafeMutableBufferPointerTestSuite.test("UMBP.moveInitialize.overflow")
 .code {
   let s = UnsafeMutableBufferPointer<Int>.allocate(capacity: 8)
   defer { s.deallocate() }
-  s.initialize(fromContentsOf: 0..<s.count)
+  _ = s.initialize(fromContentsOf: 0..<s.count)
 
   let b = UnsafeMutableBufferPointer<Int>.allocate(capacity: s.count-1)
   defer { b.deallocate() }
@@ -1246,7 +1296,7 @@ UnsafeMutableBufferPointerTestSuite.test("UMBP.moveUpdate.overflow")
 .code {
   let s = UnsafeMutableBufferPointer<Int>.allocate(capacity: 8)
   defer { s.deallocate() }
-  s.initialize(fromContentsOf: 0..<s.count)
+  _ = s.initialize(fromContentsOf: 0..<s.count)
 
   var b = Array(repeating: 0, count: s.count-1)
   b.withUnsafeMutableBufferPointer { b in
@@ -1283,7 +1333,7 @@ UnsafeMutableRawBufferPointerTestSuite.test("UMRBP.moveInitializeMemory.overflow
 .code {
   let s = UnsafeMutableBufferPointer<Int>.allocate(capacity: 8)
   defer { s.deallocate() }
-  s.initialize(fromContentsOf: 0..<s.count)
+  _ = s.initialize(fromContentsOf: 0..<s.count)
 
   let b = UnsafeMutableRawBufferPointer.allocate(
     byteCount: MemoryLayout<Int>.stride * (s.count-1),

--- a/validation-test/stdlib/UnsafeBufferPointer.swift.gyb
+++ b/validation-test/stdlib/UnsafeBufferPointer.swift.gyb
@@ -119,6 +119,31 @@ ${SelfName}TestSuite.test("rebasing") {
 %   end # Mutable
 }
 
+${SelfName}TestSuite.test("_checkBounds(_: Range) helper")
+.require(.minimumStdlib(.stdlib_6_4))
+.code {
+  guard #available(SwiftStdlib 6.4, *) else { return }
+
+%   if IsRaw:
+  let allocated = UnsafeMutableRawBufferPointer.allocate(byteCount: 20, alignment: 8)
+  let buffer = ${SelfType}(allocated)
+%   else:
+  let allocated = UnsafeMutableBufferPointer<Float>.allocate(capacity: 20)
+%     if IsMutable:
+  let buffer = allocated
+%     else:
+  let buffer = ${SelfType}(allocated)
+%     end
+%   end
+  defer { allocated.deallocate() }
+
+  expectFalse(buffer._checkBounds(-15 ..< -5))
+  expectFalse(buffer._checkBounds( -5 ..< 5))
+  expectTrue( buffer._checkBounds(  5 ..< 15))
+  expectFalse(buffer._checkBounds( 15 ..< 25))
+  expectFalse(buffer._checkBounds( 25 ..< 35))
+}
+
 % if not IsMutable:
 ${SelfName}TestSuite.test("rebasingInvalidNonMutableSlice")
 .require(.crashTesting)


### PR DESCRIPTION
Followup to https://github.com/swiftlang/swift/pull/34961, where `debugPrecondition`s were added to some but not all variants of the `init(rebasing:)` initializers of buffer pointers.

Addresses rdar://178009163 (https://github.com/swiftlang/swift/issues/89452).