### PR TITLE
vim: correct syntax highlighting for attributes

### DIFF
--- a/utils/vim/syntax/swift.vim
+++ b/utils/vim/syntax/swift.vim
@@ -219,7 +219,7 @@ syn region swiftPreprocFalse
       \ start="^\s*#\<if\>\s\+\<false\>" end="^\s*#\(\<else\>\|\<elseif\>\|\<endif\>\)"
 
 syn match swiftAttribute
-      \ /@\<\w\+\>/ skipwhite skipempty nextgroup=swiftType,swiftTypeDefinition
+      \ /@\<\w\+\>/ skipwhite skipempty nextgroup=swiftAttribute,swiftDefinitionModifier,swiftImport,swiftType,swiftTypeAliasDefinition,swiftTypeDefinition
 
 syn keyword swiftTodo MARK TODO FIXME contained
 


### PR DESCRIPTION
Attributes may be stacked, applied prior to modifiers, and to non-types (i.e. `import`). Correctly handle syntax highlighting in those cases.