### PR TITLE
[Sema] Diagnose fixes shared across all ambiguous solutions (#87218)

### DIFF
--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -998,6 +998,10 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
+    return diagnose(*commonFixes.front().first);
+  }
+
   static ForceOptional *create(ConstraintSystem &cs, Type fromType, Type toType,
                                ConstraintLocator *locator);
 
@@ -1736,6 +1740,10 @@ public:
   }
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
+
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
+    return diagnose(*commonFixes.front().first);
+  }
 
   static AllowMutatingMemberOnRValueBase *
   create(ConstraintSystem &cs, Type baseType, ValueDecl *member,

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2651,16 +2651,41 @@ static bool diagnoseAmbiguity(
     return primaryFix.second->diagnose(*primaryFix.first);
   }
 
+  // Group the fixes by (kind, locator). If *every* group is shared by all
+  // viable solutions, the solutions differ only in their overload choice and
+  // not in the fixes they require, so the ambiguity is spurious: diagnose the
+  // shared fixes instead of falling back to a generic overload ambiguity
+  // diagnostic. This handles cases where each solution carries more than one
+  // distinct fix (e.g. a mutating member on an immutable base together with an
+  // optional that must be unwrapped). When some fix is specific to a subset of
+  // the solutions the ambiguity is genuine and keeps its candidate-listing
+  // diagnostic.
   {
-    auto fixKind = aggregateFix.front().second->getKind();
-    if (llvm::all_of(
-            aggregateFix, [&](const std::pair<const Solution *,
-                                              const ConstraintFix *> &entry) {
-              auto &fix = entry.second;
-              return fix->getKind() == fixKind && fix->getLocator() == locator;
-            })) {
-      auto *primaryFix = aggregateFix.front().second;
-      if (primaryFix->diagnoseForAmbiguity(aggregateFix))
+    llvm::MapVector<std::pair<FixKind, ConstraintLocator *>,
+                    SmallVector<std::pair<const Solution *,
+                                          const ConstraintFix *>,
+                                4>>
+        fixesByKind;
+
+    for (const auto &entry : aggregateFix) {
+      auto *fix = entry.second;
+      fixesByKind[{fix->getKind(), fix->getLocator()}].push_back(entry);
+    }
+
+    bool allShared = llvm::all_of(fixesByKind, [&](const auto &entry) {
+      llvm::SmallPtrSet<const Solution *, 4> affectedSolutions;
+      for (const auto &fix : entry.second)
+        affectedSolutions.insert(fix.first);
+      return affectedSolutions.size() == solutions.size();
+    });
+
+    if (allShared) {
+      bool diagnosedCommonFix = false;
+      for (auto &entry : fixesByKind)
+        diagnosedCommonFix |=
+            entry.second.front().second->diagnoseForAmbiguity(entry.second);
+
+      if (diagnosedCommonFix)
         return true;
     }
   }

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -1587,3 +1587,18 @@ do {
     let x: String = 0 // expected-error {{cannot convert value of type 'Int' to specified type 'String'}}
   }. // expected-error {{expected member name following '.'}}
 }
+
+// https://github.com/swiftlang/swift/issues/87218 - when every viable solution
+// in an ambiguous overload set carries the same set of fixes, diagnose those
+// shared fixes instead of falling back to a generic overload ambiguity error.
+func issue87218() {
+  let dictionary = [String: [String]]()
+  var optionalValue: String?
+
+  if let array = dictionary["foo"] {
+    array.append(optionalValue) // expected-error {{cannot use mutating member on immutable value: 'array' is a 'let' constant}}
+    // expected-error@-1 {{value of optional type 'String?' must be unwrapped to a value of type 'String'}}
+    // expected-note@-2 {{coalesce using '??' to provide a default when the optional value contains 'nil'}}
+    // expected-note@-3 {{force-unwrap using '!' to abort execution if the optional value contains 'nil'}}
+  }
+}


### PR DESCRIPTION
## What this does

When an overload set is ambiguous and every viable solution carries the same fix at the same locator, this diagnoses those common fixes instead of falling back to the generic "no exact matches" diagnostic.

## Current behavior

For the case in #87218:

```swift
let dictionary = [String: [String]]()
var optionalValue: String?
if let array = dictionary["foo"] {
    array.append(optionalValue)
}
```

the compiler emits a single, unhelpful diagnostic:

```
error: no exact matches in call to instance method 'append'
```

## New behavior

Both viable solutions apply the same two fixes on the same locators (`AllowMutatingMemberOnRValueBase` and force-optional). `diagnoseAmbiguityWithFixes` now groups fixes by `(FixKind, locator)`, and when a group is present in *every* viable solution it is diagnosed via `diagnoseForAmbiguity`, producing the two precise diagnostics:

```
error: cannot use mutating member on immutable value: 'array' is a 'let' constant
error: value of optional type 'String?' must be unwrapped to a value of type 'String'
```

## Testing

- Added a regression test (`issue87218()`) in `test/Constraints/diagnostics.swift`.
- `test/Constraints/` should be run to check for regressions.

## Credit

This reconstructs the fix from the previously-closed #87278 (@elijahfriedman) and #87398 (@Flamki), which converged on this exact approach. Reopening it with credit since both PRs were closed without merging.

Resolves #87218.
