### PR TITLE
[ConstraintSystem] A few diagnostic improvements for incorrect calls

### DIFF
--- a/lib/Sema/BindingProducer.cpp
+++ b/lib/Sema/BindingProducer.cpp
@@ -487,6 +487,16 @@ TypeVariableBinding::fixForHole(ConstraintSystem &cs) const {
           cs, keyPathRoot->getImpl().getLocator());
       return std::make_pair(fix, defaultImpact);
     } else {
+      // If there are other fixes around this generic parameter (or its use
+      // site), let's increase impact of the default to prioritize solutions
+      // with fewer fixes.
+      if (llvm::any_of(cs.getFixes(), [&](const ConstraintFix *fix) {
+            return fix->getAnchor() == dstLocator->getAnchor() ||
+                   fix->getAnchor() == srcLocator->getAnchor();
+          })) {
+        defaultImpact += 3;
+      }
+
       auto path = dstLocator->getPath();
       // Drop `generic parameter` locator element so that all missing
       // generic parameters related to the same path can be coalesced later.

--- a/lib/Sema/CSDisjunction.cpp
+++ b/lib/Sema/CSDisjunction.cpp
@@ -386,15 +386,13 @@ bool ConstraintSystem::simplifyAppliedOverloadsImpl(
         });
 
     // If this is an operator application and all of the arguments are holes,
-    // let's disable all but one overload to make sure holes don't cause
-    // performance problems because hole could be bound to any type.
+    // let's disable disjunction by binding type variable that represents it
+    // to a hole.
     //
     // Non-operator calls are exempted because they have fewer overloads,
     // and it's possible to filter them based on labels.
     if (allHoles && isOperatorDisjunction(disjunction)) {
-      auto choices = disjunction->getNestedConstraints();
-      for (auto *choice : choices.slice(1))
-        choice->setDisabled();
+      recordTypeVariablesAsHoles(fnTypeVar);
     }
   }
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -11716,19 +11716,11 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyMemberConstraint(
                                                  alreadyDiagnosed, locator);
 
       auto instanceTy = baseObjTy->getMetatypeInstanceType();
-      auto impact = 4;
+      auto impact = 5;
       // Impact is higher if the base type is any function type
       // because function types can't have any members other than self
       if (instanceTy->is<AnyFunctionType>()) {
         impact += 10;
-      }
-
-      auto *anchorExpr = getAsExpr(locator->getAnchor());
-      if (anchorExpr) {
-        // Increasing the impact for missing member in any argument position
-        // which may be less likely than other potential mistakes
-        if (getArgumentLocator(anchorExpr))
-          impact += 5;
       }
 
       if (recordFix(fix, impact))

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -5643,6 +5643,11 @@ bool ConstraintSystem::repairFailures(
     if (isExpr<ErrorExpr>(anchor))
       return true;
 
+    if (getAsPattern<ExprPattern>(anchor)) {
+      if (lhs->isPlaceholder() || rhs->isPlaceholder())
+        return true;
+    }
+
     // This could be:
     // - `InOutExpr` used with r-value e.g. `foo(&x)` where `x` is a `let`.
     // - `ForceValueExpr` e.g. `foo.bar! = 42` where `bar` or `foo` are
@@ -7138,6 +7143,13 @@ bool ConstraintSystem::repairFailures(
 
     break;
   }
+
+  case ConstraintLocator::KeyPathDynamicMember: {
+    if (lhs->isPlaceholder() || rhs->isPlaceholder())
+      return true;
+    break;
+  }
+
   default:
     break;
   }
@@ -13345,7 +13357,24 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyApplicableFnConstraint(
     underlyingType =
         getFixedTypeRecursive(underlyingType, flags, /*wantRValue=*/true);
     if (underlyingType->isPlaceholder()) {
-      recordAnyTypeVarAsPotentialHole(func1);
+      if (isForCodeCompletion()) {
+        // In code completion mode it's important to attempt to infer as much
+        // type information as possible from the context, so let's delay placeholder
+        // propagation to give parameters a chance to be inferred from
+        // arguments and the result type a chance to be inferred from context.
+        recordAnyTypeVarAsPotentialHole(func1);
+      } else {
+        // In diagnostic mode, propagate function value placeholder to
+        // arguments and result. This helps to avoid recording extraneous
+        // fixes because generic parameters and leading-dot syntax arguments
+        // cannot be inferred in this case.
+        Type(func1).visit([&](Type componentTy) {
+          if (auto *typeVar = componentTy->getAs<TypeVariableType>()) {
+            if (!typeVar->getImpl().hasRepresentativeOrFixed())
+              assignFixedType(typeVar, underlyingType);
+          }
+        });
+      }
       return SolutionKind::Solved;
     }
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -13691,10 +13691,10 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyApplicableFnConstraint(
 
     auto *fix = RemoveInvalidCall::create(*this, getConstraintLocator(locator));
     // Let's make this fix as high impact so if there is a function or member
-    // overload with e.g. argument-to-parameter type mismatches it would take
-    // a higher priority.
-    return recordFix(fix, /*impact=*/3) ? SolutionKind::Error
-                                         : SolutionKind::Solved;
+    // overload with e.g. argument-to-parameter type mismatches or missing/extra
+    // arguments it would take a higher priority.
+    return recordFix(fix, /*impact=*/4) ? SolutionKind::Error
+                                        : SolutionKind::Solved;
   }
 
   return result;

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -13356,6 +13356,22 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyApplicableFnConstraint(
       recordAnyTypeVarAsPotentialHole(func1);
       return SolutionKind::Solved;
     }
+
+    if (!isForCodeCompletion()) {
+      auto argsTy = simplifyType(func1)->castTo<FunctionType>();
+      // Short-circuit calls where all arguments are invalid, otherwise the
+      // solver would end up producing a solution for every overload which
+      // it cannot disambiguate which quickly turns into "too complex" situation.
+      if (argsTy->getNumParams() > 0 &&
+          llvm::all_of(argsTy->getParams(),
+                       [](const FunctionType::Param &param) {
+                         return param.getPlainType()->isPlaceholder();
+                       })) {
+        recordTypeVariablesAsHoles(func1);
+        recordTypeVariablesAsHoles(type2);
+        return SolutionKind::Solved;
+      }
+    }
   }
 
   TypeMatchOptions subflags = getDefaultDecompositionOptions(flags);

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -16709,7 +16709,19 @@ ConstraintSystem::simplifyConstraint(const Constraint &constraint) {
         constraint.getFirstType(), constraint.getSecondType(),
         /*flags*/ std::nullopt, constraint.getLocator());
 
-  case ConstraintKind::Disjunction:
+  case ConstraintKind::Disjunction: {
+    if (shouldAttemptFixes()) {
+      auto *choice = constraint.getNestedConstraints()[0];
+      if (choice->getKind() == ConstraintKind::BindOverload) {
+        if (auto *choiceTy = choice->getFirstType()->getAs<TypeVariableType>()) {
+          auto resolvedTy = getFixedType(choiceTy);
+          if (resolvedTy && resolvedTy->isPlaceholder())
+            return SolutionKind::Solved;
+        }
+      }
+    }
+    LLVM_FALLTHROUGH;
+  }
   case ConstraintKind::Conjunction:
     // See {Dis, Con}junctionStep class in CSStep.cpp for solving
     return SolutionKind::Unsolved;

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -13368,6 +13368,14 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyApplicableFnConstraint(
         // arguments and result. This helps to avoid recording extraneous
         // fixes because generic parameters and leading-dot syntax arguments
         // cannot be inferred in this case.
+        //
+        // Note that `recordTypeVariablesAsHoles` is not used here because
+        // an existing hole from a function value is propagated to
+        // arguments/result instead of creating a direct one per type variable
+        // like that method would do, this is an important distinction later on,
+        // when solver decides whether to add a fix or not when a hole is
+        // subsequently propagated to other locations like leading-dot syntax
+        // base or literals.
         Type(func1).visit([&](Type componentTy) {
           if (auto *typeVar = componentTy->getAs<TypeVariableType>()) {
             if (!typeVar->getImpl().hasRepresentativeOrFixed())

--- a/test/ClangImporter/MixedSource/can_import_objc_idempotent.swift
+++ b/test/ClangImporter/MixedSource/can_import_objc_idempotent.swift
@@ -30,7 +30,6 @@
   // expected-error@-1 {{cannot find 'CGRect' in scope}}
 
   let (r, s) = square.divided(atDistance: 50, from: .minXEdge)
-  // expected-error@-1 {{cannot infer contextual base in reference to member 'minXEdge'}}
 #endif
 
 #if canImport(MixedWithHeader)

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -170,7 +170,8 @@ func rdar20142523() {
 // <rdar://problem/21080030> Bad diagnostic for invalid method call in boolean expression: (_, ExpressibleByIntegerLiteral)' is not convertible to 'ExpressibleByIntegerLiteral
 func rdar21080030() {
   var s = "Hello"
-  if s.count() == 0 {} // expected-error {{cannot call value of non-function type 'Int'}}
+  if s.count() == 0 {} // expected-error {{missing argument for parameter 'where' in call}}
+  // expected-error@-1 {{generic parameter 'E' could not be inferred}}
 }
 
 // <rdar://problem/21248136> QoI: problem with return type inference mis-diagnosed as invalid arguments
@@ -1536,7 +1537,8 @@ func issue63746() {
 }
 
 func rdar86611718(list: [Int]) {
-  String(list.count()) // expected-error {{cannot call value of non-function type 'Int'}}
+  String(list.count()) // expected-error {{missing argument for parameter 'where' in call}}
+  // expected-error@-1 {{generic parameter 'E' could not be inferred}}
 }
 
 // rdar://108977234 - failed to produce diagnostic when argument to AnyHashable parameter doesn't conform to Hashable protocol

--- a/test/Constraints/generics.swift
+++ b/test/Constraints/generics.swift
@@ -921,10 +921,7 @@ func rdar79757320() {
     var value: String
   }
 
-  // FIXME: There has to be a way to propagate holes that makes it easy to suppress failures caused by missing members.
   _ = Container(value: Value(42).formatted(.S(a: .a, b: .b(0)))) // expected-error {{type 'R_79757320' has no member 'S'}}
-  // expected-error@-1 {{cannot infer contextual base in reference to member 'a'}}
-  // expected-error@-2 {{cannot infer contextual base in reference to member 'b'}}
 }
 
 protocol P_eaf0300ff7a {}

--- a/test/Constraints/members.swift
+++ b/test/Constraints/members.swift
@@ -325,9 +325,6 @@ enum r23942743 {
   case Tomato(cloud: String)
 }
 let _ = .Tomato(cloud: .none)  // expected-error {{reference to member 'Tomato' cannot be resolved without a contextual type}}
-// expected-error@-1 {{cannot infer contextual base in reference to member 'none'}}
-
-
 
 // https://github.com/apple/swift/issues/43267
 // REGRESSION: Assertion failed: (baseTy && "Couldn't find appropriate context"), function getMemberSubstitutions

--- a/test/Constraints/type_of.swift
+++ b/test/Constraints/type_of.swift
@@ -88,7 +88,7 @@ do {
   }
 }
 
-_ = { x in // expected-error {{cannot infer type of closure parameter 'x' without a type annotation}}
+_ = { x in // expected-error {{unable to infer closure type without a type annotation}}
   let _: Undefined = Swift.type(of: x)
   // expected-error@-1 {{cannot find type 'Undefined' in scope}}
 }

--- a/test/Macros/macro_and_typealias.swift
+++ b/test/Macros/macro_and_typealias.swift
@@ -40,7 +40,6 @@ struct Test {
     }
 
     let _ = ConcretePrint<Object> { // expected-error {{cannot specialize non-generic type 'ConcretePrint' (aka 'Printer<Any>')}}
-      // expected-error@-1 {{cannot infer type of closure parameter '$0' without a type annotation}}
       compute(root: $0, \.prop)
     }
 

--- a/test/NameLookup/module_selector.swift
+++ b/test/NameLookup/module_selector.swift
@@ -125,7 +125,6 @@ extension B: @retroactive main::Equatable {
       self = main::B(value: .main::min)
       // expected-error@-1 {{'B' is not imported through module 'main'}}
       // expected-note@-2 {{did you mean module 'ModuleSelectorTestingKit'?}} {{14-18=ModuleSelectorTestingKit}}
-      // expected-error@-3 {{cannot infer contextual base in reference to member 'main::min'}}
 
       self = B.main::init(value: .min)
       // expected-error@-1 {{'init(value:)' is not imported through module 'main'}}
@@ -284,7 +283,6 @@ extension D: @retroactive Swift::Equatable {
       self = Swift::D(value: .Swift::min)
       // expected-error@-1 {{'D' is not imported through module 'Swift'}}
       // expected-note@-2 {{did you mean module 'ModuleSelectorTestingKit'?}} {{14-19=ModuleSelectorTestingKit}}
-      // expected-error@-3 {{cannot infer contextual base in reference to member 'Swift::min'}}
 
       self = D.Swift::init(value: .min)
       // expected-error@-1 {{'init(value:)' is not imported through module 'Swift'}}

--- a/test/Parse/integer_types.swift
+++ b/test/Parse/integer_types.swift
@@ -12,9 +12,7 @@ let c: -Int // expected-error {{expected type}}
             // expected-error@-1 {{consecutive statements on a line must be separated by ';'}}
             // expected-error@-2 {{unary operator '-' cannot be applied to an operand of type 'Int.Type'}}
 
-struct Generic<T> {} // expected-note {{'T' declared as parameter to type 'Generic'}}
-                     // expected-note@-1 {{'T' declared as parameter to type 'Generic'}}
-
+struct Generic<T> {}
 extension Generic where T == 123 {} // expected-error {{cannot constrain type parameter 'T' to be integer '123'}}
 
 extension Generic where T == -123 {} // expected-error {{cannot constrain type parameter 'T' to be integer '-123'}}
@@ -25,15 +23,11 @@ extension Generic where T == -Int {} // expected-error {{expected type}}
 let d = Generic<123>.self // expected-error {{cannot use value type '123' for generic argument 'T'}}
 
 // FIXME: This should at least be parsable...?
-let e = Generic<-123>.self // expected-error {{generic parameter 'T' could not be inferred}}
-                           // expected-error@-1 {{missing whitespace between '<' and '-' operators}}
-                           // expected-error@-2 {{'>' is not a postfix unary operator}}
-                           // expected-note@-3 {{explicitly specify the generic arguments to fix this issue}}
+let e = Generic<-123>.self // expected-error {{missing whitespace between '<' and '-' operators}}
+                           // expected-error@-1 {{'>' is not a postfix unary operator}}
 
-let f = Generic<-Int>.self // expected-error {{generic parameter 'T' could not be inferred}}
-                           // expected-error@-1 {{missing whitespace between '<' and '-' operators}}
-                           // expected-error@-2 {{'>' is not a postfix unary operator}}
-                           // expected-note@-3 {{explicitly specify the generic arguments to fix this issue}}
+let f = Generic<-Int>.self // expected-error {{missing whitespace between '<' and '-' operators}}
+                           // expected-error@-1 {{'>' is not a postfix unary operator}}
 
 let g: 123.Type // expected-error {{consecutive statements on a line must be separated by ';'}}
                 // expected-error@-1 {{expected type}}

--- a/test/Parse/recovery.swift
+++ b/test/Parse/recovery.swift
@@ -775,7 +775,7 @@ class r22240342 {
   lazy var xx: Int = {
     foo {  // expected-error {{cannot find 'foo' in scope}}
       let issueView = 42
-      issueView.delegate = 12 // expected-error {{value of type 'Int' has no member 'delegate'}}
+      issueView.delegate = 12
       
     }
     return 42

--- a/test/Sema/property_access_lookup.swift
+++ b/test/Sema/property_access_lookup.swift
@@ -3,6 +3,6 @@
 func example(x: Int, regions: [Int]) {
   let matchingRegion =
     regions.first { region in x + region.bogusProperty }
-    // expected-error@-1 {{cannot call value of non-function type 'Int?'}}
+    // expected-error@-1 {{value of type 'Int' has no member 'bogusProperty'}}
 }
 

--- a/test/Serialization/Recovery/typedefs.swift
+++ b/test/Serialization/Recovery/typedefs.swift
@@ -58,7 +58,6 @@ let _ = wrapped // expected-error {{cannot find 'wrapped' in scope}}
 let _ = unwrapped // okay
 
 _ = usesWrapped(nil) // expected-error {{cannot find 'usesWrapped' in scope}}
-                     // expected-error@-1 {{'nil' requires a contextual type}}
 _ = usesUnwrapped(nil) // expected-error {{'nil' is not compatible with expected argument type 'Int32'}}
 
 let _: WrappedAlias = nil // expected-error {{cannot find type 'WrappedAlias' in scope}}

--- a/test/StringProcessing/Parse/forward-slash-regex.swift
+++ b/test/StringProcessing/Parse/forward-slash-regex.swift
@@ -97,7 +97,6 @@ do {
   // expected-error@+1 {{'/' is not a prefix unary operator}}
   _ = /x /?
     .blah
-  // expected-error@-1 {{cannot infer contextual base in reference to member 'blah'}}
 }
 _ = /x/? // expected-error {{cannot use optional chaining on non-optional value of type 'Regex<Substring>'}}
   .blah // expected-error {{value of type 'Regex<Substring>' has no member 'blah'}}

--- a/test/decl/func/operator.swift
+++ b/test/decl/func/operator.swift
@@ -453,5 +453,5 @@ func testNonexistentPowerOperatorWithPowFunctionOutOfScope() {
   let x: Double = 3.0
   let y: Double = 3.0
   let z: Double = x**y // expected-error {{cannot find operator '**' in scope}}
-  let w: Double = a(x**2.0) // expected-error {{cannot find operator '**' in scope}} expected-error {{cannot convert value of type '()' to specified type 'Double'}}
+  let w: Double = a(x**2.0) // expected-error {{cannot find operator '**' in scope}}
 }

--- a/test/decl/init/nonnominal_init.swift
+++ b/test/decl/init/nonnominal_init.swift
@@ -11,9 +11,7 @@ func deMorgan<A, B>(_ ne: Not<Or<A, B>>) -> And<Not<A>, Not<B>> {
   // FIXME(diagnostics): The error message about initialization here is confusing
   return And<Not<A>, Not<B>>(
     Not<A> { a in ne(.left(a)) }, // expected-error {{type 'Not<A>' (aka '(A) -> Never') has no member 'init'}}
-    // expected-error@-1 {{type 'Or<A, B>' has no member 'left'}}
     Not<B> { a in ne(.right(a)) } // expected-error {{type 'Not<B>' (aka '(B) -> Never') has no member 'init'}}
-    // expected-error@-1 {{type 'Or<A, B>' has no member 'right'}}
   )
 }
 

--- a/test/decl/operator/power_operator_imported.swift
+++ b/test/decl/operator/power_operator_imported.swift
@@ -7,5 +7,5 @@ func testNonexistentPowerOperatorWithPowFunctionInScope() {
   let x: Double = 3.0
   let y: Double = 3.0
   let z: Double = x**y // expected-error {{no operator '**' is defined; did you mean 'pow(_:_:)'?}}
-  let w: Double = a(x**2.0) // expected-error {{no operator '**' is defined; did you mean 'pow(_:_:)'?}} expected-error {{cannot convert value of type '()' to specified type 'Double'}}
+  let w: Double = a(x**2.0) // expected-error {{no operator '**' is defined; did you mean 'pow(_:_:)'?}}
 }

--- a/test/expr/closure/multi_statement.swift
+++ b/test/expr/closure/multi_statement.swift
@@ -339,7 +339,6 @@ func test_unknown_refs_in_tilde_operator() {
   let _: (E) -> Void = {
     if case .test(unknown) = $0 {
       // expected-error@-1 2 {{cannot find 'unknown' in scope}}
-      // expected-error@-2 {{type 'E' has no member 'test'}}
     }
   }
 }

--- a/validation-test/IDE/crashers_fixed/ConstraintSystem-getType-f429dd.swift
+++ b/validation-test/IDE/crashers_fixed/ConstraintSystem-getType-f429dd.swift
@@ -1,5 +1,5 @@
 // {"kind":"complete","original":"9402aae6","signature":"swift::constraints::ConstraintSystem::getType(swift::ASTNode) const","signatureAssert":"Assertion failed: (found != NodeTypes.end() && \"Expected type to have been set!\"), function getType","signatureNext":"UnableToInferClosureParameterType::diagnoseAsError"}
-// RUN: not --crash %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -source-filename %s
+// RUN: %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -source-filename %s
 @propertyWrapper
 struct a<b> {
   var wrappedValue: b

--- a/validation-test/Sema/SwiftUI/foreach_with_typo_property.swift
+++ b/validation-test/Sema/SwiftUI/foreach_with_typo_property.swift
@@ -1,24 +1,41 @@
 // RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -target %target-cpu-apple-macosx10.15 -swift-version 5
+
 // REQUIRES: objc_interop
 // REQUIRES: OS=macosx
-//
 
-//FIXME: this illustrates issue with high impact for member lookup
-// Reverting change from PR85591 to missing member impact due to
-// interference with extra arguments causes this to be lost again
 
 import SwiftUI
- struct ContentView: View {
+
+struct ContentView: View {
    var foos: [F]
 
    var body: some View {
-     ForEach(foos) { foo in //expected-error{{cannot convert value of type '[F]' to expected argument type 'Binding<C>'}} expected-error {{generic parameter 'C' could not be inferred}}
-       let name = foo.bat //FIXME: {{value of type 'F' has no member 'bat'}}
+     ForEach(foos) { foo in
+       let name = foo.bat // expected-error {{value of type 'F' has no member 'bat'; did you mean 'bar'?}}
      }
    }
  }
 
+struct ExtraContentView: View {
+  var foos: [F]
+  var body: some View {
+    ForEach(foos) { foo in
+      switch foo.id {
+      case "1":
+        ChildView(id: foo.id, extra: 42) // expected-error {{extra argument 'extra' in call}}
+      default:
+        EmptyView()
+      }
+    }
+  }
+}
+
  struct F: Identifiable, Hashable {
    var id: String { bar }
-   var bar: String
+   var bar: String // expected-note {{'bar' declared here}}
+ }
+
+ struct ChildView: View {
+   let id: String
+   var body: some View { EmptyView() }
  }

--- a/validation-test/compiler_crashers_fixed/0180-rdar45557325.swift
+++ b/validation-test/compiler_crashers_fixed/0180-rdar45557325.swift
@@ -8,6 +8,5 @@ class MyClass: NSObject {
   func f() {
     let url = URL(url) // expected-error{{use of local variable 'url' before its declaration}}
     // expected-note@-1 {{'url' declared here}}
-    // expected-error@-2 {{missing argument label 'string:' in call}}
   }
 }

--- a/validation-test/compiler_crashers_fixed/ConnectedComponents-unionSets-7527be.swift
+++ b/validation-test/compiler_crashers_fixed/ConnectedComponents-unionSets-7527be.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","signature":"(anonymous namespace)::ConnectedComponents::unionSets(swift::TypeVariableType*, swift::TypeVariableType*)","signatureAssert":"Assertion failed: (validComponentCount > 0), function unionSets","signatureNext":"ConstraintGraph::computeConnectedComponents"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 let b = (c(), d()
 a {
   e

--- a/validation-test/compiler_crashers_fixed/ConstraintGraph-computeConnectedComponents-37d275.swift
+++ b/validation-test/compiler_crashers_fixed/ConstraintGraph-computeConnectedComponents-37d275.swift
@@ -1,3 +1,3 @@
 // {"kind":"typecheck","original":"1d97bdbd","signature":"swift::constraints::ConstraintGraph::computeConnectedComponents(llvm::ArrayRef<swift::TypeVariableType*>)","signatureAssert":"Assertion failed: (component != components.end()), function operator()","signatureNext":"SplitterStep::computeFollowupSteps"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 let i =... a { " ? \(i Array* )" [

--- a/validation-test/compiler_crashers_fixed/ConstraintSystem-applySolutionFixes-d55c93.swift
+++ b/validation-test/compiler_crashers_fixed/ConstraintSystem-applySolutionFixes-d55c93.swift
@@ -1,4 +1,4 @@
 // {"kind":"typecheck","signature":"swift::constraints::ConstraintSystem::applySolutionFixes(swift::constraints::Solution const&)","signatureNext":"ConstraintSystem::applySolution"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 func a<each b>(c: repeat (each b), d: repeat each b)
 a(d)

--- a/validation-test/compiler_crashers_fixed/ConstraintSystem-finalize-587784.swift
+++ b/validation-test/compiler_crashers_fixed/ConstraintSystem-finalize-587784.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","original":"8d3173cf","signature":"swift::constraints::ConstraintSystem::finalize()","signatureNext":"SplitterStep::mergePartialSolutions"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 protocol a
   func b(c: Bool) -> some a {
     &

--- a/validation-test/compiler_crashers_fixed/ConstraintSystem-setTargetFor-14b594.swift
+++ b/validation-test/compiler_crashers_fixed/ConstraintSystem-setTargetFor-14b594.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","original":"19492e52","signature":"swift::constraints::ConstraintSystem::setTargetFor(swift::constraints::SyntacticElementTargetKey, swift::constraints::SyntacticElementTarget)","signatureAssert":"Assertion failed: (inserted), function setTargetFor","signatureNext":"ConstraintSystem::generateConstraints"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 enum a {
   func c(d: a) {
     switch d {

--- a/validation-test/compiler_crashers_fixed/MissingConformanceFailure-MissingConformanceFailure-da6465.swift
+++ b/validation-test/compiler_crashers_fixed/MissingConformanceFailure-MissingConformanceFailure-da6465.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","original":"d896f132","signature":"swift::constraints::MissingConformanceFailure::MissingConformanceFailure(swift::constraints::Solution const&, swift::constraints::ConstraintLocator*, std::__1::pair<swift::Type, swift::Type>)","signatureAssert":"Assertion failed: (getGenericContext() && \"Affected decl not within a generic context?\"), function RequirementFailure","signatureNext":"MissingConformance::diagnose"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 let a =
   {
     0 ? [a] : [1&&: <#expression#>]

--- a/validation-test/compiler_crashers_fixed/OverloadChoice-getDecl-219a7b.swift
+++ b/validation-test/compiler_crashers_fixed/OverloadChoice-getDecl-219a7b.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","original":"58dc5134","signature":"swift::constraints::OverloadChoice::getDecl(swift::Type, swift::ValueDecl*, swift::FunctionRefInfo)","signatureAssert":"Assertion failed: (!base->hasTypeParameter()), function getDecl","signatureNext":"ConstraintSystem::performMemberLookup"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 @propertyWrapper struct a<b> {
   c {
   struct d {

--- a/validation-test/compiler_crashers_fixed/PackType-get-b5bf03.swift
+++ b/validation-test/compiler_crashers_fixed/PackType-get-b5bf03.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","original":"90279022","signature":"swift::PackType::get(swift::ASTContext const&, llvm::ArrayRef<swift::Type>)","signatureAssert":"Assertion failed: (!eltTy->is<PackType>() && \"Cannot have pack directly inside another pack\"), function get","signatureNext":"TypeBase::getContextSubstitutions"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 func a<b> -> b {
   c(f
 }

--- a/validation-test/compiler_crashers_fixed/Solution-getFunctionArgApplyInfo-07e13f.swift
+++ b/validation-test/compiler_crashers_fixed/Solution-getFunctionArgApplyInfo-07e13f.swift
@@ -1,3 +1,3 @@
 // {"kind":"typecheck","original":"0052e8e2","signature":"swift::constraints::Solution::getFunctionArgApplyInfo(swift::constraints::ConstraintLocator*) const","signatureAssert":"Assertion failed: (isa<To>(Val) && \"cast<Ty>() argument of incompatible type!\"), function cast","signatureNext":"RValueTreatedAsLValueFailure::diagnoseAsError"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 & &<##>

--- a/validation-test/compiler_crashers_fixed/SubscriptMisuseFailure-diagnoseAsError-4bacdc.swift
+++ b/validation-test/compiler_crashers_fixed/SubscriptMisuseFailure-diagnoseAsError-4bacdc.swift
@@ -1,3 +1,3 @@
 // {"kind":"typecheck","original":"cb606608","signature":"swift::constraints::SubscriptMisuseFailure::diagnoseAsError()","signatureAssert":"Assertion failed: (isa<To>(Val) && \"cast<Ty>() argument of incompatible type!\"), function cast","signatureNext":"UseSubscriptOperator::diagnose"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 a(.subscript < b)

--- a/validation-test/compiler_crashers_fixed/TypeBase-getContextSubstitutions-53e72d.swift
+++ b/validation-test/compiler_crashers_fixed/TypeBase-getContextSubstitutions-53e72d.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","original":"1b1342ff","signature":"swift::TypeBase::getContextSubstitutions(swift::DeclContext const*, swift::GenericEnvironment*)","signatureAssert":"Assertion failed: (Index < Length && \"Invalid index!\"), function operator[]","signatureNext":"TypeBase::getContextSubstitutionMap"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 @propertyWrapper struct a<b {
   wrappedValue: b
   projectedValue: a

--- a/validation-test/compiler_crashers_fixed/TypeJoin-join-1c69fa.swift
+++ b/validation-test/compiler_crashers_fixed/TypeJoin-join-1c69fa.swift
@@ -1,3 +1,3 @@
 // {"kind":"typecheck","original":"3736af0c","signature":"(anonymous namespace)::TypeJoin::join(swift::CanType, swift::CanType)","signatureAssert":"Assertion failed: (cast<ProtocolCompositionType>(First)->getInverses().empty() && \"FIXME: move-only generics\"), function visitProtocolCompositionType","signatureNext":"TypeJoin::visitMetatypeType"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 < a & ~Escapable & ~Copyable

--- a/validation-test/compiler_crashers_fixed/formatDiagnosticArgument-9967f3.swift
+++ b/validation-test/compiler_crashers_fixed/formatDiagnosticArgument-9967f3.swift
@@ -1,3 +1,3 @@
 // {"kind":"typecheck","signature":"formatDiagnosticArgument(llvm::StringRef, llvm::StringRef, llvm::ArrayRef<swift::DiagnosticArgument>, unsigned int, swift::DiagnosticFormatOptions, llvm::raw_ostream&)","signatureAssert":"Assertion failed: (Ptr && \"Cannot dereference a null Type!\"), function operator->","signatureNext":"DiagnosticEngine::formatDiagnosticText"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 @propertyWrapper struct a func b(@a Int) b($c:d

--- a/validation-test/compiler_crashers_fixed/matchCallArguments-254cc6.swift
+++ b/validation-test/compiler_crashers_fixed/matchCallArguments-254cc6.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","original":"ce7c1d7b","signature":"matchCallArguments(swift::constraints::ConstraintSystem&, swift::FunctionType*, swift::ArgumentList*, llvm::ArrayRef<swift::AnyFunctionType::Param>, llvm::ArrayRef<swift::AnyFunctionType::Param>, swift::constraints::ConstraintKind, swift::constraints::ConstraintLocatorBuilder, std::__1::optional<swift::constraints::TrailingClosureMatching>, llvm::SmallVectorImpl<std::__1::pair<swift::TypeVariableType*, swift::ExistentialArchetypeType*>>&)","signatureAssert":"Assertion failed: (param), function matchCallArguments","signatureNext":"ConstraintSystem::simplifyApplicableFnConstraint"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 func a<each b>(c: (repeat each b) -> Void) {
   c($c: d)
 }


### PR DESCRIPTION
- Adjusts scoring of "missing member" fix to make it more competitive with other fixes.
- Increases impact of `call to non-function value` fix to prevent it from shadowing other overloads with argument issues.
- Makes defaulting a generic parameter more impactful in some situations i.e. when there are other problems with their use sites.
- Skips disjunctions that have been bound to holes. This avoids having to attempt disjunctions that have no contextual information, for example, when all of their arguments are invalid.
- Propagate a hole from function value to arguments/result. Doing so prevents the solver from recording extraneous fixes caused by the problem with the overload choice.

Resolves: rdar://169736579
Resolves: rdar://156960713
<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
