### PR TITLE
Sema: Infer availability for property wrapper projection variables

### DIFF
--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -3441,6 +3441,13 @@ static VarDecl *synthesizePropertyWrapperProjectionVar(
                             wrapperVar->getSetterFormalAccess())
                  : var->getSetterFormalAccess());
 
+  // The property must be as available as both the wrapped property and
+  // the wrapper type's `projectedValue` property.
+  SmallVector<const Decl *, 2> asAvailableAs = {var};
+  if (wrapperVar)
+    asAvailableAs.push_back(wrapperVar);
+  AvailabilityInference::applyInferredAvailableAttrs(property, asAvailableAs);
+
   // Add the accessors we need.
   if (var->hasImplicitPropertyWrapper()) {
     // FIXME: This can have a setter, but we need a resolved type first

--- a/test/Availability/property_wrapper_accessors_availability.swift
+++ b/test/Availability/property_wrapper_accessors_availability.swift
@@ -71,6 +71,47 @@ struct ModifyMoreAvailable<T> {
     }
 }
 
+@propertyWrapper
+struct UnrestrictedProjection<T> {
+    var wrappedValue: T {
+        get { fatalError() }
+        set { fatalError() }
+    }
+
+    var projectedValue: T {
+        get { fatalError() }
+        set { fatalError() }
+    }
+}
+
+@propertyWrapper
+struct ProjectedValueConditionallyAvailable<T> {
+    var wrappedValue: T {
+        get { fatalError() }
+        set { fatalError() }
+    }
+
+    @available(macOS 51, *)
+    var projectedValue: T {
+        get { fatalError() }
+        set { fatalError() }
+    }
+}
+
+@propertyWrapper
+struct ProjectedValueUnavailable<T> {
+    var wrappedValue: T {
+        get { fatalError() }
+        set { fatalError() }
+    }
+
+    @available(macOS, unavailable)
+    var projectedValue: T {
+        get { fatalError() }
+        set { fatalError() }
+    }
+}
+
 struct Butt {
     var modify_conditionally_available: Int {
         get { fatalError() }
@@ -90,6 +131,12 @@ struct Butt {
 
     @ModifyMoreAvailable
     var wrapped_modify_more_available: Int
+
+    @ProjectedValueConditionallyAvailable
+    var wrapped_projected_value_conditionally_available: Int
+
+    @ProjectedValueUnavailable
+    var wrapped_projected_value_unavailable: Int // expected-note 2 {{'$wrapped_projected_value_unavailable' has been explicitly marked unavailable here}}
 }
 
 func butt(x: inout Butt) { // expected-note * {{}}
@@ -103,12 +150,22 @@ func butt(x: inout Butt) { // expected-note * {{}}
     x.$wrapped_setter_more_available = 0
     x.$wrapped_modify_more_available = 0
 
+    _ = x.wrapped_projected_value_conditionally_available
+    _ = x.$wrapped_projected_value_conditionally_available // expected-error {{'$wrapped_projected_value_conditionally_available' is only available in macOS 51 or newer}} expected-note{{}}
+    x.$wrapped_projected_value_conditionally_available = 0 // expected-error {{'$wrapped_projected_value_conditionally_available' is only available in macOS 51 or newer}} expected-note{{}}
+
+    _ = x.wrapped_projected_value_unavailable
+    _ = x.$wrapped_projected_value_unavailable // expected-error {{'$wrapped_projected_value_unavailable' is unavailable in macOS}}
+    x.$wrapped_projected_value_unavailable = 0 // expected-error {{'$wrapped_projected_value_unavailable' is unavailable in macOS}}
+
     if #available(macOS 51, *) {
         x.modify_conditionally_available = 0
         x.wrapped_setter_conditionally_available = 0
         x.wrapped_modify_conditionally_available = 0
         x.$wrapped_setter_conditionally_available = 0
         x.$wrapped_modify_conditionally_available = 0
+        _ = x.$wrapped_projected_value_conditionally_available
+        x.$wrapped_projected_value_conditionally_available = 0
     }
 }
 
@@ -156,6 +213,9 @@ struct LessAvailable {
   @ModifyConditionallyAvailable
   var wrapped_modify_more_available: Int
 
+  @UnrestrictedProjection
+  var unrestricted_projection: Int
+
   var nested: Nested
 
   struct Nested {
@@ -164,30 +224,48 @@ struct LessAvailable {
 
     @ModifyConditionallyAvailable
     var wrapped_modify_more_available: Int
+
+    @UnrestrictedProjection
+    var unrestricted_projection: Int
   }
 }
 
 func testInferredAvailability(x: inout LessAvailable) { // expected-error {{'LessAvailable' is only available in macOS 51.0 or newer}} expected-note*{{}}
   x.wrapped_setter_more_available = 0 // expected-error {{setter for 'wrapped_setter_more_available' is only available in macOS 51 or newer}} expected-note{{}}
   x.wrapped_modify_more_available = 0 // expected-error {{setter for 'wrapped_modify_more_available' is only available in macOS 51 or newer}} expected-note{{}}
-  x.$wrapped_setter_more_available = 0 // expected-error {{setter for '$wrapped_setter_more_available' is only available in macOS 51 or newer}} expected-note{{}}
-  x.$wrapped_modify_more_available = 0 // expected-error {{setter for '$wrapped_modify_more_available' is only available in macOS 51 or newer}} expected-note{{}}
+  x.$wrapped_setter_more_available = 0 // expected-error {{'$wrapped_setter_more_available' is only available in macOS 51.0 or newer}} expected-note{{}}
+  x.$wrapped_modify_more_available = 0 // expected-error {{'$wrapped_modify_more_available' is only available in macOS 51.0 or newer}} expected-note{{}}
+
+  // The synthesized projection variable inherits availability from the
+  // wrapped property, so reads of the projection should also error.
+  _ = x.$wrapped_setter_more_available // expected-error {{'$wrapped_setter_more_available' is only available in macOS 51.0 or newer}} expected-note{{}}
+  _ = x.$wrapped_modify_more_available // expected-error {{'$wrapped_modify_more_available' is only available in macOS 51.0 or newer}} expected-note{{}}
+  _ = x.$unrestricted_projection // expected-error {{'$unrestricted_projection' is only available in macOS 51.0 or newer}} expected-note{{}}
+  x.$unrestricted_projection = 0 // expected-error {{'$unrestricted_projection' is only available in macOS 51.0 or newer}} expected-note{{}}
 
   x.nested.wrapped_setter_more_available = 0 // expected-error {{setter for 'wrapped_setter_more_available' is only available in macOS 51 or newer}} expected-note{{}}
   x.nested.wrapped_modify_more_available = 0 // expected-error {{setter for 'wrapped_modify_more_available' is only available in macOS 51 or newer}} expected-note{{}}
-  x.nested.$wrapped_setter_more_available = 0 // expected-error {{setter for '$wrapped_setter_more_available' is only available in macOS 51 or newer}} expected-note{{}}
-  x.nested.$wrapped_modify_more_available = 0 // expected-error {{setter for '$wrapped_modify_more_available' is only available in macOS 51 or newer}} expected-note{{}}
+  x.nested.$wrapped_setter_more_available = 0 // expected-error {{'$wrapped_setter_more_available' is only available in macOS 51.0 or newer}} expected-note{{}}
+  x.nested.$wrapped_modify_more_available = 0 // expected-error {{'$wrapped_modify_more_available' is only available in macOS 51.0 or newer}} expected-note{{}}
+  _ = x.nested.$unrestricted_projection // expected-error {{'$unrestricted_projection' is only available in macOS 51.0 or newer}} expected-note{{}}
+  x.nested.$unrestricted_projection = 0 // expected-error {{'$unrestricted_projection' is only available in macOS 51.0 or newer}} expected-note{{}}
 
   if #available(macOS 51.0, *) {
     x.wrapped_setter_more_available = 0
     x.wrapped_modify_more_available = 0
     x.$wrapped_setter_more_available = 0
     x.$wrapped_modify_more_available = 0
+    _ = x.$wrapped_setter_more_available
+    _ = x.$wrapped_modify_more_available
+    _ = x.$unrestricted_projection
+    x.$unrestricted_projection = 0
 
     x.nested.wrapped_setter_more_available = 0
     x.nested.wrapped_modify_more_available = 0
     x.nested.$wrapped_setter_more_available = 0
     x.nested.$wrapped_modify_more_available = 0
+    _ = x.nested.$unrestricted_projection
+    x.nested.$unrestricted_projection = 0
   }
 }
 

--- a/test/ModuleInterface/property_wrapper_availability.swift
+++ b/test/ModuleInterface/property_wrapper_availability.swift
@@ -11,6 +11,36 @@ public struct ConditionallyAvailableWrapper<T> {
   public init(wrappedValue: T) {
     self.wrappedValue = wrappedValue
   }
+
+  public var projectedValue: T { wrappedValue }
+}
+
+@available(SwiftStdlib 5.2, *)
+@propertyWrapper
+public struct ConditionallyAvailableMutableProjectionWrapper<T> {
+  public var wrappedValue: T
+
+  public init(wrappedValue: T) {
+    self.wrappedValue = wrappedValue
+  }
+
+  public var projectedValue: T {
+    get { wrappedValue }
+    set { wrappedValue = newValue }
+  }
+}
+
+@available(SwiftStdlib 5.3, *)
+@propertyWrapper
+public struct StricterProjectionWrapper<T> {
+  public var wrappedValue: T
+
+  public init(wrappedValue: T) {
+    self.wrappedValue = wrappedValue
+  }
+
+  @available(SwiftStdlib 5.5, *)
+  public var projectedValue: T { wrappedValue }
 }
 
 @available(macOS, unavailable)
@@ -24,20 +54,58 @@ public struct UnavailableWrapper<T> {
   public init(wrappedValue: T) {
     self.wrappedValue = wrappedValue
   }
+
+  public var projectedValue: T { wrappedValue }
 }
 
 // CHECK: public struct HasWrappers {
 public struct HasWrappers {
-  // CHECK: @available(macOS 10.15.4, iOS 13.4, watchOS 6.2, tvOS 13.4, *)
-  // CHECK-NEXT: @Library::ConditionallyAvailableWrapper<Swift::Int> public var x: Swift::Int {
+  // CHECK:      @available(macOS 10.15.4, iOS 13.4, watchOS 6.2, tvOS 13.4, *)
+  // CHECK-NEXT: @Library::ConditionallyAvailableWrapper<Swift::Int> @_projectedValueProperty($conditionallyAvailable) public var conditionallyAvailable: Swift::Int {
   // CHECK-NEXT:   get
   // CHECK-NEXT:   @available(macOS 10.15.4, iOS 13.4, tvOS 13.4, watchOS 6.2, *)
   // CHECK-NEXT:   set
   // CHECK-NEXT:   @available(macOS 10.15.4, iOS 13.4, tvOS 13.4, watchOS 6.2, *)
   // CHECK-NEXT:   _modify
   // CHECK-NEXT: }
+  // CHECK-NEXT: @available(macOS 10.15.4, iOS 13.4, tvOS 13.4, watchOS 6.2, *)
+  // CHECK-NEXT: public var $conditionallyAvailable: Swift::Int {
+  // CHECK-NEXT:   get
+  // CHECK-NEXT: }
   @available(SwiftStdlib 5.2, *)
-  @ConditionallyAvailableWrapper public var x: Int
+  @ConditionallyAvailableWrapper public var conditionallyAvailable: Int
+
+  // CHECK:      @available(macOS 10.15.4, iOS 13.4, watchOS 6.2, tvOS 13.4, *)
+  // CHECK-NEXT: @Library::ConditionallyAvailableMutableProjectionWrapper<Swift::Int> @_projectedValueProperty($mutableProjection) public var mutableProjection: Swift::Int {
+  // CHECK-NEXT:   get
+  // CHECK-NEXT:   @available(macOS 10.15.4, iOS 13.4, tvOS 13.4, watchOS 6.2, *)
+  // CHECK-NEXT:   set
+  // CHECK-NEXT:   @available(macOS 10.15.4, iOS 13.4, tvOS 13.4, watchOS 6.2, *)
+  // CHECK-NEXT:   _modify
+  // CHECK-NEXT: }
+  // CHECK-NEXT: @available(macOS 10.15.4, iOS 13.4, tvOS 13.4, watchOS 6.2, *)
+  // CHECK-NEXT: public var $mutableProjection: Swift::Int {
+  // CHECK-NEXT:   get
+  // CHECK-NEXT:   @available(macOS 10.15.4, iOS 13.4, tvOS 13.4, watchOS 6.2, *)
+  // CHECK-NEXT:   set
+  // CHECK-NEXT: }
+  @available(SwiftStdlib 5.2, *)
+  @ConditionallyAvailableMutableProjectionWrapper public var mutableProjection: Int
+
+  // CHECK:      @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
+  // CHECK-NEXT: @Library::StricterProjectionWrapper<Swift::Int> @_projectedValueProperty($stricterProjection) public var stricterProjection: Swift::Int {
+  // CHECK-NEXT:   get
+  // CHECK-NEXT:   @available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *)
+  // CHECK-NEXT:   set
+  // CHECK-NEXT:   @available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *)
+  // CHECK-NEXT:   _modify
+  // CHECK-NEXT: }
+  // CHECK-NEXT: @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+  // CHECK-NEXT: public var $stricterProjection: Swift::Int {
+  // CHECK-NEXT:   get
+  // CHECK-NEXT: }
+  @available(SwiftStdlib 5.3, *)
+  @StricterProjectionWrapper public var stricterProjection: Int
 }
 
 // CHECK:       @available(macOS, unavailable)
@@ -50,7 +118,7 @@ public struct HasWrappers {
 @available(watchOS, unavailable)
 @available(tvOS, unavailable)
 public struct UnavailableHasWrappers {
-  // CHECK-LABEL:   @Library::UnavailableWrapper<Swift::Int> public var x: Swift::Int {
+  // CHECK-LABEL:   @Library::UnavailableWrapper<Swift::Int> @_projectedValueProperty($unavailable) public var unavailable: Swift::Int {
   // CHECK-NEXT:      get
   // CHECK-NEXT:      @available(macOS, unavailable)
   // CHECK-NEXT:      @available(iOS, unavailable)
@@ -63,5 +131,12 @@ public struct UnavailableHasWrappers {
   // CHECK-NEXT:      @available(watchOS, unavailable)
   // CHECK-NEXT:      _modify
   // CHECK-NEXT:    }
-  @UnavailableWrapper public var x: Int
+  // CHECK-NEXT:    @available(macOS, unavailable)
+  // CHECK-NEXT:    @available(iOS, unavailable)
+  // CHECK-NEXT:    @available(tvOS, unavailable)
+  // CHECK-NEXT:    @available(watchOS, unavailable)
+  // CHECK-NEXT:    public var $unavailable: Swift::Int {
+  // CHECK-NEXT:      get
+  // CHECK-NEXT:    }
+  @UnavailableWrapper public var unavailable: Int
 }


### PR DESCRIPTION
The synthesized `$foo` projection variable for a property with an attached property wrapper was not picking up any inferred availability from the wrapped property or from the wrapper's `projectedValue`, causing some projections to be more available than they should be. For back deployed applications that reference the projections this could result in crashes due to missing symbols.

Resolves rdar://177839191.
