### PR TITLE
AST: Account for the types enclosing an extended nominal in access scopes

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -5494,6 +5494,32 @@ getAccessScopeForFormalAccess(const ValueDecl *VD,
                                                treatUsableFromInlineAsPublic);
   const DeclContext *resultDC = VD->getDeclContext();
 
+  // For a DeclContext that introduces a type or extends one,
+  // restrict `access` by that type's adjusted formal access and return
+  // the type's own enclosing DeclContext to continue walking. Returns
+  // nullptr for any other kind of context.
+  auto adjustForEnclosingType =
+      [&](const DeclContext *dc) -> const DeclContext * {
+    if (auto enclosing = dyn_cast<GenericTypeDecl>(dc)) {
+      access = std::min(access,
+                        getAdjustedFormalAccess(enclosing, useDC,
+                                                treatUsableFromInlineAsPublic));
+      return enclosing->getDeclContext();
+    }
+    if (auto ext = dyn_cast<ExtensionDecl>(dc)) {
+      // Just check the base type. If it's a constrained extension, Sema
+      // should have already enforced access more strictly.
+      auto *nominal = ext->getExtendedNominal();
+      if (!nominal || nominal->getParentModule() != ext->getParentModule())
+        return nullptr;
+      access =
+          std::min(access, getAdjustedFormalAccess(
+                               nominal, useDC, treatUsableFromInlineAsPublic));
+      return nominal->getDeclContext();
+    }
+    return nullptr;
+  };
+
   while (!resultDC->isModuleScopeContext()) {
     if (isa<TopLevelCodeDecl>(resultDC)) {
       return AccessScope(resultDC->getModuleScopeContext(),
@@ -5503,24 +5529,20 @@ getAccessScopeForFormalAccess(const ValueDecl *VD,
     if (resultDC->isLocalContext() || access == AccessLevel::Private)
       return AccessScope(resultDC, /*private*/ true);
 
-    if (auto enclosingNominal = dyn_cast<GenericTypeDecl>(resultDC)) {
-      auto enclosingAccess =
-          getAdjustedFormalAccess(enclosingNominal, useDC,
-                                  treatUsableFromInlineAsPublic);
-      access = std::min(access, enclosingAccess);
-
-    } else if (auto enclosingExt = dyn_cast<ExtensionDecl>(resultDC)) {
-      // Just check the base type. If it's a constrained extension, Sema should
-      // have already enforced access more strictly.
-      if (auto nominal = enclosingExt->getExtendedNominal()) {
-        if (nominal->getParentModule() == enclosingExt->getParentModule()) {
-          auto nominalAccess =
-              getAdjustedFormalAccess(nominal, useDC,
-                                      treatUsableFromInlineAsPublic);
-          access = std::min(access, nominalAccess);
-        }
+    if (isa<GenericTypeDecl>(resultDC)) {
+      // Restrict by this nominal's access. The outer parent walk below
+      // will pick up any types that enclose it.
+      adjustForEnclosingType(resultDC);
+    } else if (isa<ExtensionDecl>(resultDC)) {
+      // Restrict by the extended nominal and any types that enclose it.
+      // Extensions are always at file scope, so the parent walk below would
+      // otherwise skip those types entirely. We don't redirect `resultDC` here,
+      // because `fileprivate` and `private` scopes must continue to resolve to
+      // the file containing the declaration, which may differ from the file
+      // containing the extended type.
+      for (const DeclContext *dc = adjustForEnclosingType(resultDC);
+           dc != nullptr; dc = adjustForEnclosingType(dc)) {
       }
-
     } else {
       llvm_unreachable("unknown DeclContext kind");
     }

--- a/test/Sema/accessibility.swift
+++ b/test/Sema/accessibility.swift
@@ -1725,3 +1725,31 @@ public typealias TestGenericAliasWhereClausePkg<T> = T where T: PackageProto // 
 
 package typealias PackageTestGenericAlias<T: PrivateProto> = T // expected-warning {{type alias should not be declared package because its generic parameter uses a private type}}
 package typealias PackageTestGenericAliasWhereClause<T> = T where T: PrivateProto // expected-warning {{type alias should not be declared package because its generic requirement uses a private type}}
+
+// The effective access of a member of an extension should be bounded by the
+// effective access of every type enclosing the extended type, not just the
+// formal access of the extended type itself.
+
+internal struct InternalOuterStruct {
+  public struct PublicInnerStruct {}
+}
+
+extension InternalOuterStruct.PublicInnerStruct {
+  public func publicMethodWithPublicParam(_ x: PublicStruct) {}
+  public func publicMethodWithPackageParam(_ x: PackageStruct) {}
+  public func publicMethodWithInternalParam(_ x: InternalStruct) {}
+  public func publicMethodWithPrivateParam(_ x: PrivateStruct) {} // expected-error {{method cannot be declared public because its parameter uses a private type}}
+  public func publicMethodWithFilePrivateParam(_ x: FilePrivateStruct) {} // expected-error {{method cannot be declared public because its parameter uses a fileprivate type}}
+}
+
+extension InternalOuterStruct {
+  public struct PublicInnerStructInExtension {}
+}
+
+extension InternalOuterStruct.PublicInnerStructInExtension {
+  public func publicMethodWithPublicParam(_ x: PublicStruct) {}
+  public func publicMethodWithPackageParam(_ x: PackageStruct) {}
+  public func publicMethodWithInternalParam(_ x: InternalStruct) {}
+  public func publicMethodWithPrivateParam(_ x: PrivateStruct) {} // expected-error {{method cannot be declared public because its parameter uses a private type}}
+  public func publicMethodWithFilePrivateParam(_ x: FilePrivateStruct) {} // expected-error {{method cannot be declared public because its parameter uses a fileprivate type}}
+}


### PR DESCRIPTION
`getAccessScopeForFormalAccess` walks a declaration's own DeclContext chain to find enclosing types whose formal access should restrict its own. For a member declared in an extension, that chain steps directly from the extension to file scope, so any types enclosing the extended nominal were silently skipped. As a result, members of an extension of a nested type were treated as having the formal access of the immediately extended type, ignoring the types that contain it.

For example, the public method below was treated as truly public, even though `Outer` is internal and so the effective access of any member of an extension of `Inner` is internal:

```
struct Outer {
  public struct Inner { }
}

internal struct InternalType { }

extension Outer.Inner {
  public func f(x: InternalType) { }
}
```

This incorrect access scope could cause a range of misbehavior, from spurious access-control diagnostics to incorrect SIL linkage decisions.

Refactor the walk to use a helper that handles nominals and extensions uniformly, and have the extension branch chain through into the extended nominal's enclosing types. Don't redirect `resultDC` itself, since `fileprivate` and `private` scopes must continue to resolve to the file containing the declaration, which may differ from the file containing the extended type.

Resolves rdar://150448686.
