### PR TITLE
SILGen: Fix 'multiple definitions' error for funcs nested in `@backDeployed` funcs

### DIFF
--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1315,6 +1315,20 @@ void SILGenModule::emitOrDelayFunction(SILDeclRef constant) {
                   !isPossiblyUsedExternally(linkage, M.isWholeModule());
 
   if (!mayDelay) {
+    // We may visit the same function multiple times in some cases. For
+    // instance, the body of a back deployed function is emitted twice (once for
+    // the original function and once for the fallback copy emitted into the
+    // client), so any nested local functions it contains are visited twice as
+    // well. Don't re-emit a definition that we already emitted for this
+    // declaration. Note that this checks for a previously emitted function
+    // belonging to this specific SILDeclRef rather than just any existing
+    // definition of the symbol so that genuine symbol collisions (e.g. via
+    // @_silgen_name) are still diagnosed below.
+    if (auto *f = getEmittedFunction(constant, ForDefinition)) {
+      if (!f->isExternalDeclaration())
+        return;
+    }
+
     emitFunctionDefinition(constant, getFunction(constant, ForDefinition));
     return;
   }

--- a/test/SILGen/back_deployed_attr_nested_func.swift
+++ b/test/SILGen/back_deployed_attr_nested_func.swift
@@ -1,0 +1,104 @@
+// RUN: %target-swift-emit-sil -Xllvm -sil-print-types -parse-as-library -module-name back_deploy %s -target %target-cpu-apple-macosx10.50 -verify
+// RUN: %target-swift-emit-silgen -Xllvm -sil-print-types -parse-as-library -module-name back_deploy %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -Xllvm -sil-print-types -parse-as-library -module-name back_deploy %s -target %target-cpu-apple-macosx10.50 | %FileCheck %s
+
+// REQUIRES: OS=macosx
+
+// -- Fallback definition of hasNestedFunc() references the nested function.
+// CHECK-LABEL: sil non_abi [serialized] [ossa] @$s11back_deploy13hasNestedFuncSiyFTwB : $@convention(thin) () -> Int
+// CHECK: bb0:
+// CHECK:   [[NESTEDFN:%.*]] = function_ref @$s11back_deploy13hasNestedFuncSiyF6nestedL_SiyF : $@convention(thin) () -> Int
+// CHECK:   [[RESULT:%.*]] = apply [[NESTEDFN]]() : $@convention(thin) () -> Int
+// CHECK:   return [[RESULT]] : $Int
+
+// -- The nested function
+// CHECK-LABEL: sil shared [serialized] [ossa] @$s11back_deploy13hasNestedFuncSiyF6nestedL_SiyF : $@convention(thin) () -> Int
+
+// -- Back deployment thunk for hasNestedFunc()
+// CHECK-LABEL: sil non_abi [serialized] [back_deployed_thunk] [ossa] @$s11back_deploy13hasNestedFuncSiyFTwb : $@convention(thin) () -> Int
+// CHECK: bb0:
+// CHECK:   [[MAJOR:%.*]] = integer_literal $Builtin.Word, 52
+// CHECK:   [[MINOR:%.*]] = integer_literal $Builtin.Word, 1
+// CHECK:   [[PATCH:%.*]] = integer_literal $Builtin.Word, 0
+// CHECK:   [[OSVFN:%.*]] = function_ref @$ss26_stdlib_isOSVersionAtLeastyBi1_Bw_BwBwtF : $@convention(thin) (Builtin.Word, Builtin.Word, Builtin.Word) -> Builtin.Int1
+// CHECK:   [[AVAIL:%.*]] = apply [[OSVFN]]([[MAJOR]], [[MINOR]], [[PATCH]]) : $@convention(thin) (Builtin.Word, Builtin.Word, Builtin.Word) -> Builtin.Int1
+// CHECK:   cond_br [[AVAIL]], [[AVAIL_BB:bb[0-9]+]], [[UNAVAIL_BB:bb[0-9]+]]
+//
+// CHECK: [[UNAVAIL_BB]]:
+// CHECK:   [[FALLBACKFN:%.*]] = function_ref @$s11back_deploy13hasNestedFuncSiyFTwB : $@convention(thin) () -> Int
+// CHECK:   [[RESULT:%.*]] = apply [[FALLBACKFN]]() : $@convention(thin) () -> Int
+// CHECK:   br [[RETURN_BB:bb[0-9]+]]([[RESULT]] : $Int)
+//
+// CHECK: [[AVAIL_BB]]:
+// CHECK:   [[ORIGFN:%.*]] = function_ref @$s11back_deploy13hasNestedFuncSiyF : $@convention(thin) () -> Int
+// CHECK:   [[RESULT:%.*]] = apply [[ORIGFN]]() : $@convention(thin) () -> Int
+// CHECK:   br [[RETURN_BB]]([[RESULT]] : $Int)
+//
+// CHECK: [[RETURN_BB]]([[RETURN_BB_ARG:%.*]] : $Int)
+// CHECK:   return [[RETURN_BB_ARG]] : $Int
+
+// -- Original definition of hasNestedFunc() references the same nested function.
+// CHECK-LABEL: sil [available 52.1] [ossa] @$s11back_deploy13hasNestedFuncSiyF : $@convention(thin) () -> Int
+// CHECK: bb0:
+// CHECK:   [[NESTEDFN:%.*]] = function_ref @$s11back_deploy13hasNestedFuncSiyF6nestedL_SiyF : $@convention(thin) () -> Int
+// CHECK:   [[RESULT:%.*]] = apply [[NESTEDFN]]() : $@convention(thin) () -> Int
+// CHECK:   return [[RESULT]] : $Int
+@backDeployed(before: macOS 52.1)
+public func hasNestedFunc() -> Int {
+  func nested() -> Int { 42 }
+  return nested()
+}
+
+// -- Fallback definition of hasNestedClosure() references the closure.
+// CHECK-LABEL: sil non_abi [serialized] [ossa] @$s11back_deploy16hasNestedClosureSiyFTwB : $@convention(thin) () -> Int
+// CHECK: bb0:
+// CHECK:   [[CLOSUREFN:%.*]] = function_ref @$s11back_deploy16hasNestedClosureSiyFSiycfU_ : $@convention(thin) () -> Int
+// CHECK:   [[THICK:%.*]] = thin_to_thick_function [[CLOSUREFN]]
+// CHECK:   return {{%.*}} : $Int
+
+// -- The nested closure
+// CHECK-LABEL: sil shared [serialized] [ossa] @$s11back_deploy16hasNestedClosureSiyFSiycfU_ : $@convention(thin) () -> Int
+
+// -- Back deployment thunk for hasNestedClosure()
+// CHECK-LABEL: sil non_abi [serialized] [back_deployed_thunk] [ossa] @$s11back_deploy16hasNestedClosureSiyFTwb : $@convention(thin) () -> Int
+// CHECK: bb0:
+// CHECK:   [[MAJOR:%.*]] = integer_literal $Builtin.Word, 52
+// CHECK:   [[MINOR:%.*]] = integer_literal $Builtin.Word, 1
+// CHECK:   [[PATCH:%.*]] = integer_literal $Builtin.Word, 0
+// CHECK:   [[OSVFN:%.*]] = function_ref @$ss26_stdlib_isOSVersionAtLeastyBi1_Bw_BwBwtF : $@convention(thin) (Builtin.Word, Builtin.Word, Builtin.Word) -> Builtin.Int1
+// CHECK:   [[AVAIL:%.*]] = apply [[OSVFN]]([[MAJOR]], [[MINOR]], [[PATCH]]) : $@convention(thin) (Builtin.Word, Builtin.Word, Builtin.Word) -> Builtin.Int1
+// CHECK:   cond_br [[AVAIL]], [[AVAIL_BB:bb[0-9]+]], [[UNAVAIL_BB:bb[0-9]+]]
+//
+// CHECK: [[UNAVAIL_BB]]:
+// CHECK:   [[FALLBACKFN:%.*]] = function_ref @$s11back_deploy16hasNestedClosureSiyFTwB : $@convention(thin) () -> Int
+// CHECK:   [[RESULT:%.*]] = apply [[FALLBACKFN]]() : $@convention(thin) () -> Int
+// CHECK:   br [[RETURN_BB:bb[0-9]+]]([[RESULT]] : $Int)
+//
+// CHECK: [[AVAIL_BB]]:
+// CHECK:   [[ORIGFN:%.*]] = function_ref @$s11back_deploy16hasNestedClosureSiyF : $@convention(thin) () -> Int
+// CHECK:   [[RESULT:%.*]] = apply [[ORIGFN]]() : $@convention(thin) () -> Int
+// CHECK:   br [[RETURN_BB]]([[RESULT]] : $Int)
+//
+// CHECK: [[RETURN_BB]]([[RETURN_BB_ARG:%.*]] : $Int)
+// CHECK:   return [[RETURN_BB_ARG]] : $Int
+
+// -- Original definition of hasNestedClosure() references the same closure.
+// CHECK-LABEL: sil [available 52.1] [ossa] @$s11back_deploy16hasNestedClosureSiyF : $@convention(thin) () -> Int
+// CHECK: bb0:
+// CHECK:   [[CLOSUREFN:%.*]] = function_ref @$s11back_deploy16hasNestedClosureSiyFSiycfU_ : $@convention(thin) () -> Int
+// CHECK:   [[THICK:%.*]] = thin_to_thick_function [[CLOSUREFN]]
+// CHECK:   return {{%.*}} : $Int
+@backDeployed(before: macOS 52.1)
+public func hasNestedClosure() -> Int {
+  let c = { () -> Int in 42 }
+  return c()
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s11back_deploy6calleryyF : $@convention(thin) () -> ()
+func caller() {
+  // -- Verify the thunk is called
+  // CHECK: {{%.*}} = function_ref @$s11back_deploy13hasNestedFuncSiyFTwb : $@convention(thin) () -> Int
+  _ = hasNestedFunc()
+  // CHECK: {{%.*}} = function_ref @$s11back_deploy16hasNestedClosureSiyFTwb : $@convention(thin) () -> Int
+  _ = hasNestedClosure()
+}

--- a/test/attr/Inputs/BackDeployHelper.swift
+++ b/test/attr/Inputs/BackDeployHelper.swift
@@ -101,6 +101,15 @@ public func trivial() {
 
 @available(BackDeploy 1.0, *)
 @backDeployed(before: BackDeploy 2.0)
+public func trivialWithNestedFunc() {
+  func nested() {
+    testPrint(handle: #dsohandle, "trivialWithNestedFunc")
+  }
+  nested()
+}
+
+@available(BackDeploy 1.0, *)
+@backDeployed(before: BackDeploy 2.0)
 public func pleaseThrow(_ shouldThrow: Bool) throws -> Bool {
   if shouldThrow { throw BadError.bad }
   return !shouldThrow

--- a/test/attr/attr_backDeployed_evolution.swift
+++ b/test/attr/attr_backDeployed_evolution.swift
@@ -131,6 +131,12 @@ if isV2OrLater() {
 // CHECK-BD: client: trivial
 trivial()
 
+// A back deployed function with a nested function emits a copy of the nested
+// function into the client; verify the right copy runs (rdar://105137047).
+// CHECK-ABI: library: trivialWithNestedFunc
+// CHECK-BD: client: trivialWithNestedFunc
+trivialWithNestedFunc()
+
 precondition(try! pleaseThrow(false))
 do {
   _ = try pleaseThrow(true)


### PR DESCRIPTION
The body of a `@backDeployed` function is emitted twice during SILGen: once for the original copy and once for the fallback copy that is emitted into the client and run on OSes where the original is unavailable. As a result, any nested local function declared in the body is visited twice.

Nested closures were already handled correctly because `emitClosure()` skips re-emission of a closure that has already been defined. A nested named function, however, took a different path: since it has user-written code it is not delayable, so `emitOrDelayFunction()` emitted its definition unconditionally on each visit. The second emission then tripped the 'multiple definitions of symbol' diagnostic.

Fix this by teaching the non-delayable path in `emitOrDelayFunction()` to skip a function that has already been defined, mirroring `emitClosure()`. The nested function is emitted a single time with shared linkage and referenced from both copies of the enclosing function, just as a nested closure is.

Resolves rdar://105137047