### PR TITLE
ClangImporter: Adjust to "Reland "[clang] Refactor option-related code from clangDriver into new clangOptions library" (#167374)"

### DIFF
--- a/lib/ClangImporter/CMakeLists.txt
+++ b/lib/ClangImporter/CMakeLists.txt
@@ -36,6 +36,7 @@ add_swift_host_library(swiftClangImporter STATIC
 target_link_libraries(swiftClangImporter PRIVATE
   swiftAST
   swiftParse
+  clangOptions
   clangTooling)
 
 target_link_libraries(swiftClangImporter INTERFACE

--- a/lib/ClangImporter/ClangIncludePaths.cpp
+++ b/lib/ClangImporter/ClangIncludePaths.cpp
@@ -21,6 +21,7 @@
 #include "clang/Driver/Driver.h"
 #include "clang/Driver/ToolChain.h"
 #include "clang/Frontend/CompilerInstance.h"
+#include "clang/Options/Options.h"
 #include "llvm/WindowsDriver/MSVCPaths.h"
 
 using namespace swift;
@@ -154,11 +155,11 @@ static std::optional<Path> findFirstIncludeDir(
     const llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> &vfs) {
   // C++ stdlib paths are added as `-internal-isystem`.
   std::vector<std::string> includeDirs =
-      args.getAllArgValues(clang::driver::options::OPT_internal_isystem);
+      args.getAllArgValues(clang::options::OPT_internal_isystem);
   // C stdlib paths are added as `-internal-externc-isystem`.
   llvm::append_range(includeDirs,
                      args.getAllArgValues(
-                         clang::driver::options::OPT_internal_externc_isystem));
+                         clang::options::OPT_internal_externc_isystem));
 
   for (const auto &includeDir : includeDirs) {
     Path dir(includeDir);
@@ -205,8 +206,8 @@ ClangImporter::createClangArgs(const ClangImporterOptions &ClangImporterOpts,
   // the SDK/sysroot set above; --sysroot= is checked first as the canonical
   // driver-level form.
   if (const auto *A = clangDriverArgs.getLastArg(
-          clang::driver::options::OPT__sysroot_EQ,
-          clang::driver::options::OPT_isysroot))
+          clang::options::OPT__sysroot_EQ,
+          clang::options::OPT_isysroot))
     clangDriver.SysRoot = A->getValue();
   return clangDriverArgs;
 }
@@ -313,9 +314,9 @@ static void getLibStdCxxFileMapping(
   auto parsedStdlibArgs = parseClangDriverArgs(clangDriver, stdlibArgStrings);
 
   // If we were explicitly asked to not bring in the C++ stdlib, bail.
-  if (parsedStdlibArgs.hasArg(clang::driver::options::OPT_nostdinc,
-                              clang::driver::options::OPT_nostdincxx,
-                              clang::driver::options::OPT_nostdlibinc))
+  if (parsedStdlibArgs.hasArg(clang::options::OPT_nostdinc,
+                              clang::options::OPT_nostdincxx,
+                              clang::options::OPT_nostdlibinc))
     return;
 
   Path cxxStdlibDir;
@@ -459,8 +460,8 @@ static void getLibStdCxxFileMapping(
   // enabled via a compile time flag. This prevents us from listing <coroutine>
   // in the modulemap unconditionally.
   // <generator> relies on <coroutine>.
-  if (parsedStdlibArgs.hasFlag(clang::driver::options::OPT_fcoroutines,
-                               clang::driver::options::OPT_fno_coroutines,
+  if (parsedStdlibArgs.hasFlag(clang::options::OPT_fcoroutines,
+                               clang::options::OPT_fno_coroutines,
                                /*default*/ false)) {
     additionalFiles.push_back("coroutine");
     additionalFiles.push_back("generator");


### PR DESCRIPTION
See:
* https://github.com/llvm/llvm-project/pull/167374
* https://github.com/swiftlang/llvm-project/commit/3d057bcf869b612769f7ce0b54697cdb6187ebcb

___

Paired with https://github.com/swiftlang/llvm-project/pull/13094.
Targeting main to minimise the difference between main and rebranch.