### PR TITLE
[6.4] Inliner: fix a ownership violation when inlining a begin_apply into a dead-end block

### DIFF
--- a/lib/SILOptimizer/Utils/SILInliner.cpp
+++ b/lib/SILOptimizer/Utils/SILInliner.cpp
@@ -109,6 +109,12 @@ class BeginApplySite {
 
   SmallVector<EndBorrowInst *, 2> EndBorrows;
 
+  // begin_borrow instructions introduced for owned values yielded @guaranteed.
+  // These need their borrow scopes completed when the coroutine is ended via
+  // end_borrow (rather than end_apply/abort_apply), because processTerminator
+  // does not emit end_borrow for them in that case.
+  SmallVector<BeginBorrowInst *, 2> guaranteedYields;
+
 public:
   BeginApplySite(BeginApplyInst *BeginApply, SILLocation Loc,
                  SILBuilder *Builder)
@@ -208,7 +214,6 @@ public:
       auto calleeYields = yield->getYieldedValues();
       auto callerYields = BeginApply->getYieldedValues();
       assert(calleeYields.size() == callerYields.size());
-      SmallVector<BeginBorrowInst *, 2> guaranteedYields;
       for (auto i : indices(calleeYields)) {
         auto remappedYield = getMappedValue(calleeYields[i]);
         // When owned values are yielded @guaranteed, the mapped value must be
@@ -320,7 +325,19 @@ public:
     // Complete lifetimes of all inlined values at the point where the `begin_apply`
     // is ended with an `end_borrow`.
     // See `SILInlineCloner::valuesToComplete`.
-    completeLifetimes(pm, ArrayRef(valuesToComplete), ArrayRef(endBorrowInsts));
+    //
+    // guaranteedYields (begin_borrow instructions for owned values yielded
+    // @guaranteed) are appended after all cloned values. completeLifetimes
+    // processes the list in reverse, so guaranteedYields are completed first
+    // (inserting end_borrow just before the dead-end point), and the owned
+    // bases are completed second (inserting destroy_value [dead_end] after the
+    // end_borrows).  This preserves the required borrow-before-destroy order.
+    llvm::SmallVector<SILValue, 32> allValuesToComplete(valuesToComplete.begin(),
+                                                        valuesToComplete.end());
+    for (auto *bbi : guaranteedYields)
+      allValuesToComplete.push_back(bbi);
+
+    completeLifetimes(pm, ArrayRef(allValuesToComplete), ArrayRef(endBorrowInsts));
 
     for (EndBorrowInst *endBorrow : EndBorrows) {
       endBorrow->eraseFromParent();

--- a/test/SILOptimizer/inline_begin_apply.sil
+++ b/test/SILOptimizer/inline_begin_apply.sil
@@ -846,6 +846,28 @@ bb2(%12 : $Int):
   return %0
 }
 
+// Regression test: when a coroutine scope is ended via end_borrow on the token
+// (rather than end_apply/abort_apply) on a dead-end path, the inliner must
+// insert end_borrow for any owned value yielded @guaranteed before destroying
+// it. The bug was that destroy_value [dead_end] was inserted before end_borrow,
+// producing an ownership violation.
+//
+// CHECK-LABEL: sil [ossa] @test_yield_owned_end_borrow_unreachable :
+// CHECK:       bb0:
+// CHECK:         [[INSTANCE:%[^,]+]] = apply
+// CHECK:         [[BORROWED:%[^,]+]] = begin_borrow [[INSTANCE]]
+// CHECK:         end_borrow [[BORROWED]]
+// CHECK:         destroy_value [dead_end] [[INSTANCE]]
+// CHECK:         unreachable
+// CHECK-LABEL: } // end sil function 'test_yield_owned_end_borrow_unreachable'
+sil [ossa] @test_yield_owned_end_borrow_unreachable : $@convention(thin) () -> () {
+bb0:
+  %callee = function_ref @yield_owned_as_guaranteed : $@yield_once @convention(thin) () -> @yields @guaranteed SomeClass
+  (%value, %token) = begin_apply %callee() : $@yield_once @convention(thin) () -> @yields @guaranteed SomeClass
+  end_borrow %token : $Builtin.SILToken
+  unreachable
+}
+
 sil @co_routine : $@yield_once @convention(thin) (@guaranteed String) -> @yields @inout Optional<Int>
 
 sil [ossa] [transparent] @call_co_routine : $@yield_once @convention(thin) (@guaranteed String, @guaranteed String) -> @yields @inout Optional<Int> {


### PR DESCRIPTION
* **Explanation**: Fixes a SIL verification crash. When inlining a co-routine, lifetime completion was done in the wrong order, which led to an `end_borrow` inserted _after_ `destroy_value [dead_end]` of the same value.
* **Risk**: Low. It's a small change which only affects inlining of co-routines
* **Testing**: by lit tests
* **Issue**: rdar://178166465
* **Reviewers**: @meg-gupta
* **Main branch PR**: https://github.com/swiftlang/swift/pull/89542
