### PR TITLE
[6.4][cxx-interop] Check Clang if a sanitizer is supported for a target

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -67,11 +67,15 @@
 #include "clang/Basic/LangStandard.h"
 #include "clang/Basic/MacroBuilder.h"
 #include "clang/Basic/Module.h"
+#include "clang/Basic/Sanitizers.h"
 #include "clang/Basic/Specifiers.h"
 #include "clang/Basic/TargetInfo.h"
 #include "clang/CAS/CASOptions.h"
 #include "clang/CAS/IncludeTree.h"
 #include "clang/CodeGen/ObjectFilePCHContainerWriter.h"
+#include "clang/Driver/Compilation.h"
+#include "clang/Driver/Driver.h"
+#include "clang/Driver/ToolChain.h"
 #include "clang/Frontend/CompilerInvocation.h"
 #include "clang/Frontend/FrontendActions.h"
 #include "clang/Frontend/FrontendOptions.h"
@@ -494,6 +498,27 @@ static inline bool isPCHFilenameExtension(StringRef path) {
     .ends_with(file_types::getExtension(file_types::TY_PCH));
 }
 
+/// Returns the set of sanitizers Clang's driver considers supported for
+/// \p triple.
+static clang::SanitizerMask
+getClangSupportedSanitizers(const llvm::Triple &triple) {
+  clang::DiagnosticOptions diagOpts;
+  auto diagIDs = llvm::makeIntrusiveRefCnt<clang::DiagnosticIDs>();
+  clang::DiagnosticsEngine clangDiags(diagIDs, diagOpts,
+                                      new clang::IgnoringDiagConsumer(),
+                                      /*ShouldOwnClient=*/true);
+  clang::driver::Driver driver("clang", triple.str(), clangDiags);
+  driver.setCheckInputsExist(false);
+  std::string targetArg = "--target=" + triple.str();
+  llvm::SmallVector<const char *, 8> argv = {
+      "clang", targetArg.c_str(), "-fsyntax-only", "-x", "c", "swift.c"};
+  std::unique_ptr<clang::driver::Compilation> compilation(
+      driver.BuildCompilation(argv));
+  if (!compilation)
+    return {};
+  return compilation->getDefaultToolChain().getSupportedSanitizers();
+}
+
 void importer::getNormalInvocationArguments(
     std::vector<std::string> &invocationArgStrs, ASTContext &ctx,
     bool ignoreClangTarget) {
@@ -825,18 +850,30 @@ void importer::getNormalInvocationArguments(
   if (!LangOpts.DisableSafeInteropWrappers)
     invocationArgStrs.push_back("-fexperimental-bounds-safety-attributes");
 
-  if (ctx.SILOpts.Sanitizers & SanitizerKind::Address)
-    invocationArgStrs.push_back("-fsanitize=address");
-  if (ctx.SILOpts.Sanitizers & SanitizerKind::Thread)
-    invocationArgStrs.push_back("-fsanitize=thread");
-  if (ctx.SILOpts.Sanitizers & SanitizerKind::Undefined)
-    invocationArgStrs.push_back("-fsanitize=undefined");
-  if (ctx.SILOpts.Sanitizers & SanitizerKind::MemTagStack) {
-    invocationArgStrs.push_back("-fsanitize=memtag-stack");
-    invocationArgStrs.push_back("-Xclang");
-    invocationArgStrs.push_back("-target-feature");
-    invocationArgStrs.push_back("-Xclang");
-    invocationArgStrs.push_back("+mte");
+  // Forward sanitizer flags to the Clang importer so C++ code imported by it
+  // gets the same instrumentation as the Swift code. Only forward sanitizers
+  // that Clang's driver considers supported for this triple; otherwise Clang
+  // would error out with "unsupported option '-fsanitize=...' for target ...".
+  auto &enabledSanitizers = ctx.SILOpts.Sanitizers;
+  if (enabledSanitizers) {
+    clang::SanitizerMask clangSupported = getClangSupportedSanitizers(triple);
+    if ((enabledSanitizers & SanitizerKind::Address) &&
+        (clangSupported & clang::SanitizerKind::Address))
+      invocationArgStrs.push_back("-fsanitize=address");
+    if ((enabledSanitizers & SanitizerKind::Thread) &&
+        (clangSupported & clang::SanitizerKind::Thread))
+      invocationArgStrs.push_back("-fsanitize=thread");
+    if ((enabledSanitizers & SanitizerKind::Undefined) &&
+        (clangSupported & clang::SanitizerKind::Undefined))
+      invocationArgStrs.push_back("-fsanitize=undefined");
+    if ((enabledSanitizers & SanitizerKind::MemTagStack) &&
+        (clangSupported & clang::SanitizerKind::MemtagStack)) {
+      invocationArgStrs.push_back("-fsanitize=memtag-stack");
+      invocationArgStrs.push_back("-Xclang");
+      invocationArgStrs.push_back("-target-feature");
+      invocationArgStrs.push_back("-Xclang");
+      invocationArgStrs.push_back("+mte");
+    }
   }
 }
 

--- a/test/Interop/Cxx/driver/sanitizer-forwarding.swift
+++ b/test/Interop/Cxx/driver/sanitizer-forwarding.swift
@@ -6,6 +6,16 @@
 // RUN: %swift_frontend_plain -typecheck -parse-stdlib %s -sanitize=memtag-stack -dump-clang-diagnostics -target arm64-apple-macosx10.9 2>&1 | %FileCheck %s -check-prefix CHECK-MEMTAG
 // RUN: %swift_frontend_plain -typecheck -parse-stdlib %s -dump-clang-diagnostics 2>&1 | %FileCheck %s -check-prefix CHECK-NONE
 
+// Targets where Clang does not support TSan must not get -fsanitize=thread
+// forwarded, even though Swift's frontend accepts -sanitize=thread.
+// RUN: %swift_frontend_plain -typecheck -parse-stdlib %s -sanitize=thread -dump-clang-diagnostics -target arm64-apple-ios16.0 2>&1 | %FileCheck %s -check-prefix CHECK-TSAN-IOS-DEVICE
+
+// Sanitizers Clang does support on iOS device must still be forwarded.
+// RUN: %swift_frontend_plain -typecheck -parse-stdlib %s -sanitize=address -dump-clang-diagnostics -target arm64-apple-ios16.0 2>&1 | %FileCheck %s -check-prefix CHECK-ASAN-IOS-DEVICE
+
+// TSan is supported on the iOS simulator, so it must be forwarded there.
+// RUN: %swift_frontend_plain -typecheck -parse-stdlib %s -sanitize=thread -dump-clang-diagnostics -target arm64-apple-ios16.0-simulator 2>&1 | %FileCheck %s -check-prefix CHECK-TSAN-IOS-SIM
+
 // CHECK-ASAN: clang importer cc1 args: {{.*}} '-fsanitize=address'
 // CHECK-TSAN: clang importer driver args: {{.*}} '-fsanitize=thread'
 // CHECK-UBSAN: clang importer driver args: {{.*}} '-fsanitize=undefined'
@@ -14,3 +24,6 @@
 // CHECK-NONE-NOT: '-fsanitize=thread'
 // CHECK-NONE-NOT: '-fsanitize=undefined'
 // CHECK-NONE-NOT: '-fsanitize=memtag-stack'
+// CHECK-TSAN-IOS-DEVICE-NOT: '-fsanitize=thread'
+// CHECK-ASAN-IOS-DEVICE: clang importer {{.*}}args: {{.*}} '-fsanitize=address'
+// CHECK-TSAN-IOS-SIM: clang importer {{.*}}args: {{.*}} '-fsanitize=thread'


### PR DESCRIPTION
**Explanation:**
Sometimes, the Swift frontend and Clang disagrees in whether a target supports a sanitizer. This is mostly because most of these checks are happening in the Swift driver and not in the frontend. This PR makes sure we do not add the sanitizer when it is not supported to avoid compilation failures. This can happen when we use swift-frontend directly.

**Issues:** rdar://177233134, rdar://178358056, rdar://177890886 
**Scope:** Sanitized builds using C++ interop.
**Risk:** Low, the worst case scenario is not forwarding the sanitizer flags to the clang importer and this forwarding only started to happen recently.
**Original PR:** #89322
**Testing:** Regression tests added.
**Reviewers:** @egorzhdan

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
