### PR TITLE
Fix typos in comments

### DIFF
--- a/lib/ClangImporter/PolyglotAST.cpp
+++ b/lib/ClangImporter/PolyglotAST.cpp
@@ -52,7 +52,7 @@ class PolyglotAPIVisitor : public clang::ConstDeclVisitor<PolyglotAPIVisitor> {
       Json.attribute("debug", "note: findPropertyDecl path");
       return prop;
     } else if (decl->isOverriding()) {
-      // Look for inherited decls being overriden.
+      // Look for inherited decls being overridden.
       Json.attribute("debug", "note: isOverriding path");
       auto overridens = SmallVector<const clang::ObjCMethodDecl*>();
       decl->getOverriddenMethods(overridens);

--- a/lib/DependencyScan/ScanDependencies.cpp
+++ b/lib/DependencyScan/ScanDependencies.cpp
@@ -468,7 +468,7 @@ private:
       StringRef readLegacyTypeInfoPath =
           instance.getInvocation().getIRGenOptions().ReadLegacyTypeInfoPath;
       if (!readLegacyTypeInfoPath.empty()) {
-        // If legacy layout is specifed, just need to track that file.
+        // If legacy layout is specified, just need to track that file.
         if (tracker->trackFile(readLegacyTypeInfoPath))
           commandline.push_back("-read-legacy-type-info-path=" +
                                 scanner.remapPath(readLegacyTypeInfoPath));

--- a/lib/Frontend/ModuleInterfaceSupport.cpp
+++ b/lib/Frontend/ModuleInterfaceSupport.cpp
@@ -228,7 +228,7 @@ static void printImports(raw_ostream &out,
   // Track the `public` imports here to determine whether to override.
   ImportSet publicImportSet = getImports(allImportFilter);
 
-  // Used to determine whether `package import` should be overriden below.
+  // Used to determine whether `package import` should be overridden below.
   ImportSet packageOnlyImportSet;
   if (Opts.printPackageInterface()) {
     packageOnlyImportSet =

--- a/lib/IDE/CompletionOverrideLookup.cpp
+++ b/lib/IDE/CompletionOverrideLookup.cpp
@@ -39,7 +39,7 @@ bool CompletionOverrideLookup::addAccessControl(
   //   #^COMPLETE^#
   // }
   //
-  // The formal access level for the overriden decl is internal, but it needs
+  // The formal access level for the overridden decl is internal, but it needs
   // to be public to satisfy the conformance. Check to see if there are any
   // requirements that demand public.
   AccessLevel Access = std::min(VD->getFormalAccess(), AccessOfContext);

--- a/lib/SILOptimizer/Transforms/AccessEnforcementOpts.cpp
+++ b/lib/SILOptimizer/Transforms/AccessEnforcementOpts.cpp
@@ -1174,7 +1174,7 @@ struct AccessEnforcementOpts : public SILFunctionTransform {
       invalidateAnalysis(SILAnalysis::InvalidationKind::Instructions);
 
     // Perform the access merging
-    // The inital version of the optimization requires a postDomTree
+    // The initial version of the optimization requires a postDomTree
     PostDominanceAnalysis *postDomAnalysis =
         getAnalysis<PostDominanceAnalysis>();
     PostDominanceInfo *postDomTree = postDomAnalysis->get(F);

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -5961,7 +5961,7 @@ static OverrideIsolationResult validOverrideIsolation(
   auto &ctx = declContext->getASTContext();
 
   // Normally we are checking if overriding declaration can be called by calling
-  // overriden declaration. But in case of destructors, overriden declaration is
+  // overridden declaration. But in case of destructors, overridden declaration is
   // always callable by definition and we are checking that subclass deinit can
   // call super deinit.
   bool isDtor = isa<DestructorDecl>(value);


### PR DESCRIPTION
Fix minor typos in code comments:
  
  - `overriden` → `overridden` (4 occurrences)
  - `inital` → `initial` (1 occurrence)
  - `specifed` → `specified` (1 occurrence)