### PR TITLE
[DebugInfo] Support salvaging pointer_to_address

### DIFF
--- a/lib/SILOptimizer/Utils/InstOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/InstOptUtils.cpp
@@ -2191,7 +2191,7 @@ void swift::salvageDebugInfo(SILInstruction *I) {
   if (isa<IntegerLiteralInst>(I) || isa<FloatLiteralInst>(I))
     salvageNullaryInst(cast<SingleValueInstruction>(I));
 
-  if (isa<AddressToPointerInst>(I))
+  if (isa<AddressToPointerInst>(I) || isa<PointerToAddressInst>(I))
     salvageUnaryInst(cast<SingleValueInstruction>(I));
 }
 

--- a/test/DebugInfo/salvage_pointer_to_address.sil
+++ b/test/DebugInfo/salvage_pointer_to_address.sil
@@ -1,0 +1,26 @@
+// RUN: %target-sil-opt -sil-verify-all -sil-combine %s | %FileCheck %s
+
+sil_stage canonical
+
+import Builtin
+import Swift
+
+// When a pointer_to_address is dead (only used by debug_value), SILCombine
+// should salvage the debug info into a reconstruction block.
+//
+// CHECK-LABEL: sil @salvage_pointer_to_address
+// CHECK: bb0(%0 : $Builtin.RawPointer):
+// CHECK:   debug_value %0, let, name "addr", transform {
+// CHECK:   bb0(%[[ARG:[0-9]+]] : $Builtin.RawPointer):
+// CHECK:     %[[PTA:[0-9]+]] = pointer_to_address %[[ARG]] to [strict] $*Int
+// CHECK:     %[[LOAD:[0-9]+]] = load %[[PTA]]
+// CHECK:     return %[[LOAD]]
+// CHECK:   }
+// CHECK:   return
+sil @salvage_pointer_to_address : $@convention(thin) (Builtin.RawPointer) -> () {
+bb0(%0 : $Builtin.RawPointer):
+  %1 = pointer_to_address %0 : $Builtin.RawPointer to [strict] $*Int
+  debug_value %1 : $*Int, let, name "addr", expr op_deref
+  %r = tuple ()
+  return %r : $()
+}


### PR DESCRIPTION
Adds a salvage for pointer_to_address

Doesn't change the variable coverage of the standard library, it just moves a single variable being lost by SimplifyCFG to being lost by EarlyCodeMotion instead (the very next pass in the pipeline)