### PR TITLE
[android] Copy over new API note for API 23 with new Runtimes/ config

### DIFF
--- a/Runtimes/Overlay/Android/clang/CMakeLists.txt
+++ b/Runtimes/Overlay/Android/clang/CMakeLists.txt
@@ -34,6 +34,7 @@ install(FILES
   SwiftBionic.h
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/swift/${SwiftOverlay_PLATFORM_SUBDIR}/${SwiftOverlay_ARCH_SUBDIR})
 install(FILES
+  _stdio.apinotes
   posix_filesystem.apinotes
   spawn.apinotes
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/swift/apinotes)

--- a/Runtimes/Resync.cmake
+++ b/Runtimes/Resync.cmake
@@ -139,6 +139,7 @@ message(STATUS "Android modulemaps[${StdlibSources}/Platform] -> ${CMAKE_CURRENT
 copy_files(public/Platform Overlay/Android/clang
   FILES
     android.modulemap
+    _stdio.apinotes
     posix_filesystem.apinotes
     spawn.apinotes
     SwiftAndroidNDK.h


### PR DESCRIPTION
The new API note was added in #88751 as part of the stdlib/ config.