### PR TITLE
[cxx-interop] Add a test for `super` with inherited foreign reference type

### DIFF
--- a/test/Interop/Cxx/foreign-reference/Inputs/module.modulemap
+++ b/test/Interop/Cxx/foreign-reference/Inputs/module.modulemap
@@ -118,6 +118,12 @@ module Upcast {
   requires cplusplus
 }
 
+module SuperStaticDispatch {
+  header "super-static-dispatch.h"
+  requires cplusplus
+  export *
+}
+
 module ImmortalFRTHashable {
   header "immortal-frt-hashable.h"
   requires cplusplus

--- a/test/Interop/Cxx/foreign-reference/Inputs/super-static-dispatch.h
+++ b/test/Interop/Cxx/foreign-reference/Inputs/super-static-dispatch.h
@@ -1,0 +1,22 @@
+#define FRT_IMMORTAL                                                           \
+  __attribute__((swift_attr("import_reference")))                              \
+  __attribute__((swift_attr("retain:immortal")))                               \
+  __attribute__((swift_attr("release:immortal")))
+
+struct FRT_IMMORTAL Base {
+  int nonVirtualMethod() const { return 42; }
+
+  static Base &create() {
+    static Base instance;
+    return instance;
+  }
+};
+
+struct FRT_IMMORTAL Derived : Base {
+  int nonVirtualMethod() const { return 99; }
+
+  static Derived &create() {
+    static Derived instance;
+    return instance;
+  }
+};

--- a/test/Interop/Cxx/foreign-reference/super-static-dispatch-silgen.swift
+++ b/test/Interop/Cxx/foreign-reference/super-static-dispatch-silgen.swift
@@ -1,0 +1,18 @@
+// RUN: %target-swift-emit-silgen %s -I %S/Inputs -cxx-interoperability-mode=default -disable-availability-checking | %FileCheck %s
+
+import SuperStaticDispatch
+
+extension Derived {
+  public func callSuper() -> Int32 {
+    return super.nonVirtualMethod()
+  }
+}
+
+// CHECK-LABEL: sil {{.*}}callSuper{{.*}}
+// CHECK-NOT: objc_super_method
+// CHECK: Base.nonVirtualMethod()
+// CHECK-NOT: Derived.nonVirtualMethod()
+// CHECK: end sil function
+
+// CHECK: [clang Base.nonVirtualMethod]
+// CHECK-NOT: [clang Derived.nonVirtualMethod]


### PR DESCRIPTION
Swift allows calling a method from a superclass by doing `super.foo()` within an extension for a derived class. This adds a test to ensure it works correctly for FRTs too.

rdar://177619427

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
