### PR TITLE
[cxx-interop] Skip empty C++ fields in explosion schema

### DIFF
--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -56,6 +56,7 @@
 #include "GenPointerAuth.h"
 #include "GenPoly.h"
 #include "GenProto.h"
+#include "GenStruct.h"
 #include "GenType.h"
 #include "IRGenDebugInfo.h"
 #include "IRGenFunction.h"
@@ -2783,6 +2784,11 @@ irgen::getCoroFunctionValues(IRGenFunction &IGF,
   return {fn, size, typeID};
 }
 
+static void
+emitClangRecordCallResult(IRGenFunction &IGF, const LoadableTypeInfo &recordTI,
+                          llvm::Value *result, Address indirectReturn,
+                          bool convertDirectToIndirectReturn, Explosion &out);
+
 namespace {
 
 class SyncCallEmission final : public CallEmission {
@@ -3098,6 +3104,11 @@ public:
     if (expectedNativeResultType->isVoidTy())
       return;
     if (result->getType() != expectedNativeResultType) {
+      if (auto *recordTI = getAsLoadableCXXRecord(IGF.IGM, resultType)) {
+        emitClangRecordCallResult(IGF, *recordTI, result, indirectReturnAddress,
+                                  convertDirectToIndirectReturn, out);
+        return;
+      }
       result =
           IGF.coerceValue(result, expectedNativeResultType, IGF.IGM.DataLayout);
     }
@@ -4800,6 +4811,34 @@ void CallEmission::emitToUnmappedExplosionWithDirectTypedError(
                          [](auto i) { return i; });
     out = nativeSchema.mapFromNative(IGF.IGM, IGF, resultExplosion, resultType);
   }
+}
+
+static void
+emitClangRecordCallResult(IRGenFunction &IGF, const LoadableTypeInfo &recordTI,
+                          llvm::Value *result, Address indirectReturn,
+                          bool convertDirectToIndirectReturn, Explosion &out) {
+  auto *returnTy = result->getType();
+
+  if (convertDirectToIndirectReturn) {
+    Address indirectAddr =
+        IGF.Builder.CreateElementBitCast(indirectReturn, returnTy);
+    IGF.Builder.CreateStore(result, indirectAddr);
+    return;
+  }
+
+  auto *storageTy = recordTI.getStorageType();
+  StackAddress temporary =
+      allocateForCoercion(IGF, returnTy, storageTy, "clang.record.return");
+
+  Address coercionAddr =
+      IGF.Builder.CreateElementBitCast(temporary.getAddress(), returnTy);
+  IGF.Builder.CreateStore(result, coercionAddr);
+
+  Address storageAddr =
+      IGF.Builder.CreateElementBitCast(temporary.getAddress(), storageTy);
+  recordTI.loadAsTake(IGF, storageAddr, out);
+
+  IGF.emitDeallocateStaticAlloca(temporary);
 }
 
 void CallEmission::setKeyPathAccessorArguments(Explosion &in, bool isOutlined,

--- a/lib/IRGen/GenHeap.cpp
+++ b/lib/IRGen/GenHeap.cpp
@@ -349,6 +349,7 @@ HeapNonFixedOffsets::HeapNonFixedOffsets(IRGenFunction &IGF,
       case ElementLayout::Kind::Empty:
       case ElementLayout::Kind::EmptyTailAllocatedCType:
       case ElementLayout::Kind::Fixed:
+      case ElementLayout::Kind::Hollow:
         // Don't need to dynamically calculate this offset.
         Offsets.push_back(nullptr);
         break;

--- a/lib/IRGen/GenRecord.h
+++ b/lib/IRGen/GenRecord.h
@@ -69,6 +69,8 @@ public:
     return Layout.isEmpty();
   }
 
+  bool isEmptyOrHollow() const { return Layout.isEmptyOrHollow(); }
+
   IsTriviallyDestroyable_t isTriviallyDestroyable() const {
     return Layout.isTriviallyDestroyable();
   }
@@ -175,6 +177,8 @@ public:
   /// The standard schema is just all the fields jumbled together.
   void getSchema(ExplosionSchema &schema) const override {
     for (auto &field : getFields()) {
+      if (field.isEmptyOrHollow())
+        continue;
       field.getTypeInfo().getSchema(schema);
     }
   }
@@ -189,7 +193,7 @@ public:
     if (isOutlined || T.hasParameterizedExistential()) {
       auto offsets = asImpl().getNonFixedOffsets(IGF, T);
       for (auto &field : getFields()) {
-        if (field.isEmpty())
+        if (field.isEmptyOrHollow())
           continue;
 
         Address destField = field.projectAddress(IGF, dest, offsets);
@@ -219,7 +223,7 @@ public:
     if (isOutlined || T.hasParameterizedExistential()) {
       auto offsets = asImpl().getNonFixedOffsets(IGF, T);
       for (auto &field : getFields()) {
-        if (field.isEmpty())
+        if (field.isEmptyOrHollow())
           continue;
 
         Address destField = field.projectAddress(IGF, dest, offsets);
@@ -250,7 +254,7 @@ public:
     if (isOutlined || T.hasParameterizedExistential()) {
       auto offsets = asImpl().getNonFixedOffsets(IGF, T);
       for (auto &field : getFields()) {
-        if (field.isEmpty())
+        if (field.isEmptyOrHollow())
           continue;
 
         Address destField = field.projectAddress(IGF, dest, offsets);
@@ -283,7 +287,7 @@ public:
     } else if (isOutlined || T.hasParameterizedExistential()) {
       auto offsets = asImpl().getNonFixedOffsets(IGF, T);
       for (auto &field : getFields()) {
-        if (field.isEmpty())
+        if (field.isEmptyOrHollow())
           continue;
 
         Address destField = field.projectAddress(IGF, dest, offsets);
@@ -635,7 +639,7 @@ private:
     unsigned result = 0;
     for (auto &field : fields) {
       // Ignore empty fields.
-      if (field.isEmpty()) continue;
+      if (field.isEmptyOrHollow()) continue;
 
       // If the field is not ABI-accessible, suppress this.
       if (!field.isABIAccessible()) return 0;
@@ -794,7 +798,7 @@ private:
   void forAllFields(IRGenFunction &IGF, Address addr, Explosion &out) const {
     auto offsets = asImpl().getNonFixedOffsets(IGF);
     for (auto &field : getFields()) {
-      if (field.isEmpty()) continue;
+      if (field.isEmptyOrHollow()) continue;
 
       Address fieldAddr = field.projectAddress(IGF, addr, offsets);
       (cast<LoadableTypeInfo>(field.getTypeInfo()).*Op)(IGF, fieldAddr, out);
@@ -807,7 +811,7 @@ private:
                     Atomicity atomicity) const {
     auto offsets = asImpl().getNonFixedOffsets(IGF);
     for (auto &field : getFields()) {
-      if (field.isEmpty()) continue;
+      if (field.isEmptyOrHollow()) continue;
 
       Address fieldAddr = field.projectAddress(IGF, addr, offsets);
       (cast<LoadableTypeInfo>(field.getTypeInfo()).*Op)(IGF, fieldAddr, out,
@@ -821,7 +825,7 @@ private:
                     bool isOutlined) const {
     auto offsets = asImpl().getNonFixedOffsets(IGF);
     for (auto &field : getFields()) {
-      if (field.isEmpty()) continue;
+      if (field.isEmptyOrHollow()) continue;
 
       Address fieldAddr = field.projectAddress(IGF, addr, offsets);
       (cast<LoadableTypeInfo>(field.getTypeInfo()).*Op)(IGF, in, fieldAddr,
@@ -836,7 +840,7 @@ private:
                     bool isOutlined, SILType T) const {
     auto offsets = asImpl().getNonFixedOffsets(IGF);
     for (auto &field : getFields()) {
-      if (field.isEmpty()) continue;
+      if (field.isEmptyOrHollow()) continue;
 
       Address fieldAddr = field.projectAddress(IGF, addr, offsets);
       (cast<LoadableTypeInfo>(field.getTypeInfo()).*Op)(IGF, in, fieldAddr,
@@ -874,28 +878,39 @@ public:
 
   void reexplode(Explosion &src,
                  Explosion &dest) const override {
-    for (auto &field : getFields())
+    for (auto &field : getFields()) {
+      if (field.isEmptyOrHollow())
+        continue;
       cast<LoadableTypeInfo>(field.getTypeInfo()).reexplode(src, dest);
+    }
   }
 
   void copy(IRGenFunction &IGF, Explosion &src,
             Explosion &dest, Atomicity atomicity) const override {
-    for (auto &field : getFields())
+    for (auto &field : getFields()) {
+      if (field.isEmptyOrHollow())
+        continue;
       cast<LoadableTypeInfo>(field.getTypeInfo())
           .copy(IGF, src, dest, atomicity);
+    }
   }
 
   void consume(IRGenFunction &IGF, Explosion &src,
                Atomicity atomicity, SILType T) const override {
     for (auto &field : getFields()) {
+      if (field.isEmptyOrHollow())
+        continue;
       cast<LoadableTypeInfo>(field.getTypeInfo())
           .consume(IGF, src, atomicity, field.getType(IGF.IGM, T));
     }
   }
 
   void fixLifetime(IRGenFunction &IGF, Explosion &src) const override {
-    for (auto &field : getFields())
+    for (auto &field : getFields()) {
+      if (field.isEmptyOrHollow())
+        continue;
       cast<LoadableTypeInfo>(field.getTypeInfo()).fixLifetime(IGF, src);
+    }
   }
   
   void packIntoEnumPayload(IRGenModule &IGM,
@@ -904,7 +919,7 @@ public:
                            Explosion &src,
                            unsigned startOffset) const override {
     for (auto &field : getFields()) {
-      if (!field.isEmpty()) {
+      if (!field.isEmptyOrHollow()) {
         unsigned offset = field.getFixedByteOffset().getValueInBits()
           + startOffset;
         cast<LoadableTypeInfo>(field.getTypeInfo())
@@ -917,7 +932,7 @@ public:
                              Explosion &dest, unsigned startOffset)
                             const override {
     for (auto &field : getFields()) {
-      if (!field.isEmpty()) {
+      if (!field.isEmptyOrHollow()) {
         unsigned offset = field.getFixedByteOffset().getValueInBits()
           + startOffset;
         cast<LoadableTypeInfo>(field.getTypeInfo())

--- a/lib/IRGen/GenStruct.cpp
+++ b/lib/IRGen/GenStruct.cpp
@@ -237,6 +237,7 @@ namespace {
       auto &fieldInfo = getFieldInfo(field);
       switch (fieldInfo.getKind()) {
       case ElementLayout::Kind::Fixed:
+      case ElementLayout::Kind::Hollow:
       case ElementLayout::Kind::Empty:
       case ElementLayout::Kind::EmptyTailAllocatedCType:
         return MemberAccessStrategy::getDirectFixed(
@@ -320,7 +321,8 @@ namespace {
       // Check that constant field offsets we know match
       for (auto &field : asImpl().getFields()) {
         switch (field.getKind()) {
-        case ElementLayout::Kind::Fixed: {
+        case ElementLayout::Kind::Fixed:
+        case ElementLayout::Kind::Hollow: {
           // We know the offset at compile time. See whether there's also an
           // entry for this field in the field offset vector.
           class FindOffsetOfFieldOffsetVector
@@ -1457,9 +1459,7 @@ public:
 
 private:
   /// Collect all the fields of a union.
-  void collectUnionFields() {
-    addOpaqueField(Size(0), TotalStride);
-  }
+  void collectUnionFields() { addOpaqueField(Size(0), TotalStride, false); }
 
   static bool isImportOfClangField(VarDecl *swiftField,
                                    const clang::FieldDecl *clangField) {
@@ -1571,12 +1571,21 @@ private:
       }
     }
 
+    // An empty C++ field (that is, a field whose type is a class or struct
+    // that has no non-static data members) takes a byte of storage in order to
+    // be able to guarantee that the addresses of distinct objects of the same
+    // type are always distinct.
+    // However, it can be skipped in value operations or schema explosions, so
+    // we consider it "hollow".
+    auto *cxxRecord = clangField->getType()->getAsCXXRecordDecl();
+    bool isHollowField = isTransitivelyEmpty(cxxRecord);
+
     // If we have a Swift import of this type, use our lowered information.
     if (swiftField) {
       auto &fieldTI = cast<FixedTypeInfo>(IGM.getTypeInfo(
           SwiftType.getFieldType(swiftField, IGM.getSILModule(),
                                  IGM.getMaximalTypeExpansionContext())));
-      addField(swiftField, offset, fieldTI, isZeroSized);
+      addField(swiftField, offset, fieldTI, isZeroSized, isHollowField);
       auto fieldTy =
           swiftField->getInterfaceType()->lookThroughSingleOptionalType();
       if (fieldTy->isAnyClassReferenceType() &&
@@ -1595,7 +1604,8 @@ private:
     auto fieldTypeSize = ClangContext.getTypeSizeInChars(clangField->getType());
     auto fieldSize = isZeroSized ? clang::CharUnits::Zero()
                                  : dataSize.value_or(fieldTypeSize);
-    return addOpaqueField(offset, Size(fieldSize.getQuantity()));
+
+    return addOpaqueField(offset, Size(fieldSize.getQuantity()), isHollowField);
   }
 
   /// Add opaque storage for bitfields spanning the given range of bits.
@@ -1610,36 +1620,41 @@ private:
     Size offset = Size(bitBegin / 8);
     Size byteLength = Size((bitEnd - bitBegin + 7) / 8);
 
-    addOpaqueField(offset, byteLength);
+    addOpaqueField(offset, byteLength, false);
   }
 
   /// Add opaque storage at the given offset.
-  void addOpaqueField(Size offset, Size fieldSize) {
+  void addOpaqueField(Size offset, Size fieldSize, bool isHollowField) {
     // No need to add storage for zero-size fields (e.g. incomplete array
     // decls).
     if (fieldSize.isZero()) return;
 
     auto &opaqueTI = IGM.getOpaqueStorageTypeInfo(fieldSize, Alignment(1));
-    addField(nullptr, offset, opaqueTI, false);
+    addField(nullptr, offset, opaqueTI, false, isHollowField);
   }
 
   /// Add storage for an (optional) Swift field at the given offset.
   void addField(VarDecl *swiftField, Size offset,
-                const FixedTypeInfo &fieldType, bool isZeroSized) {
+                const FixedTypeInfo &fieldType, bool isZeroSized,
+                bool isHollowField) {
     assert(isZeroSized || offset >= NextOffset && "adding fields out of order");
 
     // Add a padding field if required.
     if (!isZeroSized && offset != NextOffset)
       addPaddingField(offset);
 
-    addFieldInfo(swiftField, fieldType, isZeroSized);
+    addFieldInfo(swiftField, fieldType, isZeroSized, isHollowField);
   }
 
   /// Add information to track a value field at the current offset.
-  void addFieldInfo(VarDecl *swiftField, const FixedTypeInfo &fieldType, bool isZeroSized) {
+  void addFieldInfo(VarDecl *swiftField, const FixedTypeInfo &fieldType,
+                    bool isZeroSized, bool isHollowField) {
     bool isLoadableField = isa<LoadableTypeInfo>(fieldType);
     unsigned explosionSize = 0;
-    if (isLoadableField)
+    // Hollow fields are skipped by `getSchema` and the value-op loops, so
+    // they must not consume explosion slots either; otherwise subsequent
+    // fields' projection ranges run past the end of the loaded explosion.
+    if (isLoadableField && !isHollowField)
       explosionSize = cast<LoadableTypeInfo>(fieldType).getExplosionSize();
     unsigned explosionBegin = NextExplosionIndex;
     NextExplosionIndex += explosionSize;
@@ -1654,6 +1669,10 @@ private:
       else
         layout.completeEmptyTailAllocatedCType(
             fieldType.isTriviallyDestroyable(ResilienceExpansion::Maximal), NextOffset);
+    } else if (isHollowField) {
+      layout.completeHollow(
+          fieldType.isTriviallyDestroyable(ResilienceExpansion::Maximal),
+          NextOffset, LLVMFields.size());
     } else
       layout.completeFixed(fieldType.isTriviallyDestroyable(ResilienceExpansion::Maximal),
                            NextOffset, LLVMFields.size());
@@ -1678,6 +1697,42 @@ private:
     LLVMFields.push_back(llvm::ArrayType::get(IGM.Int8Ty, count.getValue()));
     NextOffset = offset;
     SpareBits.appendSetBits(count.getValueInBits());
+  }
+
+  static bool isTransitivelyEmpty(const clang::CXXRecordDecl *cxxRecordDecl) {
+    if (!cxxRecordDecl || !cxxRecordDecl->hasDefinition())
+      return false;
+    cxxRecordDecl = cxxRecordDecl->getDefinition();
+    if (cxxRecordDecl->isEmpty())
+      return true;
+
+    // A union always carries one of its members, even when every member is
+    // itself empty: the union's storage byte is real and must show up in
+    // both the explosion schema and the native ABI schema. Marking it hollow
+    // would collapse the substituted schema to a single element when the
+    // parent has additional non-zero-offset fields, which makes
+    // `mapFromNative`'s simple-coerce path truncate at offset 0 and grab
+    // the wrong bytes.
+    if (cxxRecordDecl->isUnion())
+      return false;
+
+    // A class with a vptr or a virtual base contributes an entry to
+    // `SwiftAggLowering`, so its explosion schema must include it too.
+    if (cxxRecordDecl->isPolymorphic() || cxxRecordDecl->getNumVBases() > 0)
+      return false;
+
+    bool fieldsAllEmpty =
+        llvm::all_of(cxxRecordDecl->fields(), [](const auto *field) {
+          return isTransitivelyEmpty(field->getType()->getAsCXXRecordDecl());
+        });
+    if (!fieldsAllEmpty)
+      return false;
+
+    bool basesAllEmpty =
+        llvm::all_of(cxxRecordDecl->bases(), [](const auto &base) {
+          return isTransitivelyEmpty(base.getType()->getAsCXXRecordDecl());
+        });
+    return basesAllEmpty;
   }
 };
 

--- a/lib/IRGen/GenStruct.cpp
+++ b/lib/IRGen/GenStruct.cpp
@@ -50,6 +50,7 @@
 #include "llvm/Support/Error.h"
 #include <iterator>
 
+#include "GenCall.h"
 #include "GenDecl.h"
 #include "GenMeta.h"
 #include "GenRecord.h"
@@ -1880,4 +1881,18 @@ const TypeInfo *TypeConverter::convertStructType(TypeBase *key, CanType type,
   // Build the type.
   StructTypeBuilder builder(IGM, ty, type);
   return builder.layout(fields);
+}
+
+const LoadableTypeInfo *irgen::getAsLoadableCXXRecord(IRGenModule &IGM,
+                                                      SILType silType) {
+  auto *structDecl = silType.getStructOrBoundGenericStruct();
+  if (!structDecl ||
+      !isa_and_nonnull<clang::CXXRecordDecl>(structDecl->getClangDecl()))
+    return nullptr;
+
+  auto &type = IGM.getTypeInfo(silType);
+  if (getStructTypeInfoKind(type) !=
+      StructTypeInfoKind::LoadableClangRecordTypeInfo)
+    return nullptr;
+  return &cast<LoadableTypeInfo>(type);
 }

--- a/lib/IRGen/GenStruct.h
+++ b/lib/IRGen/GenStruct.h
@@ -33,6 +33,7 @@ namespace irgen {
   class Explosion;
   class IRGenFunction;
   class IRGenModule;
+  class LoadableTypeInfo;
   class MemberAccessStrategy;
   class TypeInfo;
 
@@ -71,6 +72,11 @@ namespace irgen {
   std::optional<unsigned> getPhysicalStructFieldIndex(IRGenModule &IGM,
                                                       SILType baseType,
                                                       VarDecl *field);
+
+  /// If \p silType is a loadable C++ record,
+  /// return its LoadableTypeInfo.
+  const LoadableTypeInfo *getAsLoadableCXXRecord(IRGenModule &IGM,
+                                                 SILType silType);
 } // end namespace irgen
 } // end namespace swift
 

--- a/lib/IRGen/GenTuple.cpp
+++ b/lib/IRGen/GenTuple.cpp
@@ -198,6 +198,7 @@ namespace {
       case ElementLayout::Kind::Empty:
       case ElementLayout::Kind::EmptyTailAllocatedCType:
       case ElementLayout::Kind::Fixed:
+      case ElementLayout::Kind::Hollow:
         return field.getFixedByteOffset();
       case ElementLayout::Kind::InitialNonFixedSize:
         return Size(0);
@@ -228,7 +229,8 @@ namespace {
       for (unsigned i : indices(fields)) {
         const TupleFieldInfo &field = fields[i];
         switch (field.getKind()) {
-        case ElementLayout::Kind::Fixed: {
+        case ElementLayout::Kind::Fixed:
+        case ElementLayout::Kind::Hollow: {
           // Check that the fixed layout matches the layout in the tuple
           // metadata.
           auto fixedOffset = field.getFixedByteOffset();

--- a/lib/IRGen/StructLayout.cpp
+++ b/lib/IRGen/StructLayout.cpp
@@ -317,6 +317,7 @@ Address ElementLayout::project(IRGenFunction &IGF, Address baseAddr,
     return getType().getUndefAddress();
 
   case Kind::Fixed:
+  case Kind::Hollow:
     return IGF.Builder.CreateStructGEP(baseAddr,
                                        getStructIndex(),
                                        getByteOffset(),

--- a/lib/IRGen/StructLayout.h
+++ b/lib/IRGen/StructLayout.h
@@ -100,13 +100,17 @@ public:
     /// The element is an object lacking a fixed size but located at
     /// offset zero.  This is necessary because LLVM forbids even a
     /// 'gep 0' on an unsized type.
-    InitialNonFixedSize
+    InitialNonFixedSize,
+
+    /// The element has fixed offset and size, but doesn't store anything,
+    /// e.g. empty C++ struct
+    Hollow
 
     // IncompleteKind comes here
   };
 
 private:
-  enum : unsigned { IncompleteKind  = unsigned(Kind::InitialNonFixedSize) + 1 };
+  enum : unsigned { IncompleteKind = unsigned(Kind::Hollow) + 1 };
 
   /// The swift type information for this element's layout.
   const TypeInfo *Type;
@@ -199,6 +203,17 @@ public:
     Index = nonFixedElementIndex;
   }
 
+  void completeHollow(IsTriviallyDestroyable_t isTriviallyDestroyable,
+                      Size byteOffset, unsigned structIndex) {
+    TheKind = unsigned(Kind::Hollow);
+    IsTriviallyDestroyable = unsigned(isTriviallyDestroyable);
+    ByteOffset = byteOffset.getValue();
+    ByteOffsetForLayout = ByteOffset;
+    Index = structIndex;
+
+    ASSERT(getByteOffset() == byteOffset);
+  }
+
   const TypeInfo &getType() const { return *Type; }
 
   Kind getKind() const {
@@ -210,6 +225,14 @@ public:
   bool isEmpty() const {
     return getKind() == Kind::Empty ||
            getKind() == Kind::EmptyTailAllocatedCType;
+  }
+
+  /// Is this element known to be empty, or to contribute nothing to the
+  /// explosion/schema of the Element
+  bool isEmptyOrHollow() const {
+    return getKind() == Kind::Empty ||
+           getKind() == Kind::EmptyTailAllocatedCType ||
+           getKind() == Kind::Hollow;
   }
 
   /// Is this element known to be POD?
@@ -224,6 +247,7 @@ public:
     case Kind::Empty:
     case Kind::EmptyTailAllocatedCType:
     case Kind::Fixed:
+    case Kind::Hollow:
       return true;
 
     // FIXME: InitialNonFixedSize should go in the above, but I'm being
@@ -255,7 +279,8 @@ public:
   /// Given that this element has a fixed offset, return the index in
   /// the LLVM struct.
   unsigned getStructIndex() const {
-    assert(isCompleted() && getKind() == Kind::Fixed);
+    assert(isCompleted() &&
+           (getKind() == Kind::Fixed || getKind() == Kind::Hollow));
     return Index;
   }
 

--- a/test/Interop/Cxx/class/Inputs/empty-field-layout.h
+++ b/test/Interop/Cxx/class/Inputs/empty-field-layout.h
@@ -1,0 +1,100 @@
+#ifndef EMPTY_FIELD_LAYOUT_H
+#define EMPTY_FIELD_LAYOUT_H
+
+struct Empty {};
+
+struct BaseEmpty {
+  Empty e;
+};
+
+struct EmptyThenInt {
+  Empty e;
+  int i;
+};
+
+inline EmptyThenInt makeEmptyThenInt(int n) { return EmptyThenInt{{}, n}; }
+
+struct IntThenEmpty {
+  int i;
+  Empty e;
+};
+
+inline IntThenEmpty makeIntThenEmpty(int n) { return IntThenEmpty{n, {}}; }
+
+struct EmptyEmptyInt {
+  Empty e1;
+  Empty e2;
+  int i;
+};
+
+inline EmptyEmptyInt makeEmptyEmptyInt(int n) {
+  return EmptyEmptyInt{{}, {}, n};
+}
+
+struct IntEmptyInt {
+  int a;
+  Empty e;
+  int b;
+};
+
+inline IntEmptyInt makeIntEmptyInt(int a, int b) { return IntEmptyInt{a, {}, b}; }
+
+// Empty-base optimization: empty base contributes 0 bytes, i is at offset 0.
+struct DerivedFromEmpty : Empty {
+  int i;
+};
+
+inline DerivedFromEmpty makeDerivedFromEmpty(int n) {
+  DerivedFromEmpty v;
+  v.i = n;
+  return v;
+}
+
+// `[[no_unique_address]]` lets the empty member share another field's address.
+// sizeof(NoUniqueAddressEmpty) is typically 4 bytes, i at offset 0.
+struct NoUniqueAddressEmpty {
+  [[no_unique_address]] Empty e;
+  int i;
+};
+
+inline NoUniqueAddressEmpty makeNoUniqueAddressEmpty(int n) {
+  return NoUniqueAddressEmpty{{}, n};
+}
+
+struct IntTrailingNoUniqueAddressEmpty {
+  int i;
+  [[no_unique_address]] Empty e;
+};
+
+inline IntTrailingNoUniqueAddressEmpty
+makeIntTrailingNoUniqueAddressEmpty(int n) {
+  return IntTrailingNoUniqueAddressEmpty{n, {}};
+}
+
+// Multi-register C ABI return
+struct IntEmptyIntInt {
+  int a;
+  Empty e;
+  int b;
+  int c;
+};
+
+inline IntEmptyIntInt makeIntEmptyIntInt(int a, int b, int c) {
+  return IntEmptyIntInt{a, {}, b, c};
+}
+
+// Address-only: non-trivial destructor forces sret.
+// This shouldn't exercise the `getAsLoadableCXXRecord` path
+struct EmptyAndIntNonTrivial {
+  Empty e;
+  int i;
+  ~EmptyAndIntNonTrivial() {}
+};
+
+inline EmptyAndIntNonTrivial makeEmptyAndIntNonTrivial(int n) {
+  EmptyAndIntNonTrivial v;
+  v.i = n;
+  return v;
+}
+
+#endif

--- a/test/Interop/Cxx/class/Inputs/module.modulemap
+++ b/test/Interop/Cxx/class/Inputs/module.modulemap
@@ -28,6 +28,11 @@ module DestructorsWithTemporaryValues {
   requires cplusplus
 }
 
+module EmptyFieldLayout {
+  header "empty-field-layout.h"
+  requires cplusplus
+}
+
 module Extensions {
   header "extensions.h"
   requires cplusplus

--- a/test/Interop/Cxx/class/empty-field-layout-irgen.swift
+++ b/test/Interop/Cxx/class/empty-field-layout-irgen.swift
@@ -1,0 +1,29 @@
+// RUN: %target-swiftxx-frontend -emit-ir -I %S/Inputs -module-name main %s | %FileCheck %s
+
+import EmptyFieldLayout
+
+public func readEmptyThenInt() -> Int32 {
+  let v = makeEmptyThenInt(2026)
+  return v.i
+}
+
+// CHECK-LABEL: define {{.*}} @"$s4main16readEmptyThenInts5Int32VyF"
+// CHECK: %[[BUF:clang\.record\.return\.coerced]] = alloca
+// CHECK: %[[CALL:[0-9]+]] = {{(invoke|call)}} i64 @{{.*}}makeEmptyThenInt
+// CHECK: store i64 %[[CALL]], ptr %[[BUF]]
+// CHECK: getelementptr inbounds {{.*}} %[[BUF]],
+// CHECK: load i32
+// CHECK-NOT: load i32, ptr %{{[^,]*}}.coercion.coerced
+
+public func readNonTrivial() -> Int32 {
+  let v = makeEmptyAndIntNonTrivial(2026)
+  return v.i
+}
+
+// A struct with a non-trivial destructor is address-only, 
+// so the C ABI returns it via `sret` — no `clang.record.return.coerced` alloca.
+
+// CHECK-LABEL: define {{.*}} @"$s4main14readNonTrivials5Int32VyF"
+// CHECK: alloca %TSo21EmptyAndIntNonTrivialV
+// CHECK: {{(invoke|call)}} void @{{.*}}makeEmptyAndIntNonTrivial{{.*}}(ptr {{.*}}sret(%TSo21EmptyAndIntNonTrivialV)
+// CHECK-NOT: clang.record.return.coerced = alloca

--- a/test/Interop/Cxx/class/empty-field-layout.swift
+++ b/test/Interop/Cxx/class/empty-field-layout.swift
@@ -1,0 +1,56 @@
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-experimental-cxx-interop)
+// REQUIRES: executable_test
+
+import EmptyFieldLayout
+import StdlibUnittest
+
+var Tests = TestSuite("EmptyFieldLayout")
+
+Tests.test("empty before int") {
+  let v = makeEmptyThenInt(42)
+  expectEqual(42, v.i)
+}
+
+Tests.test("int before empty") {
+  let v = makeIntThenEmpty(7)
+  expectEqual(7, v.i)
+}
+
+Tests.test("two empties then int") {
+  let v = makeEmptyEmptyInt(99)
+  expectEqual(99, v.i)
+}
+
+Tests.test("int empty int") {
+  let v = makeIntEmptyInt(11, 22)
+  expectEqual(11, v.a)
+  expectEqual(22, v.b)
+}
+
+Tests.test("derived from empty base") {
+  let v = makeDerivedFromEmpty(123)
+  expectEqual(123, v.i)
+}
+
+Tests.test("no_unique_address empty") {
+  let v1 = makeNoUniqueAddressEmpty(77)
+  expectEqual(77, v1.i)
+
+  let v2 = makeIntTrailingNoUniqueAddressEmpty(88)
+  expectEqual(88, v2.i)
+}
+
+Tests.test("int empty int int (16 bytes, mid empty)") {
+  let v = makeIntEmptyIntInt(11, 22, 33)
+  expectEqual(11, v.a)
+  expectEqual(22, v.b)
+  expectEqual(33, v.c)
+}
+
+Tests.test("non-trivial dtor (address-only, sret path)") {
+  let v = makeEmptyAndIntNonTrivial(2026)
+  expectEqual(2026, v.i)
+}
+
+runAllTests()
+

--- a/test/Interop/Cxx/class/inheritance/Inputs/fields.h
+++ b/test/Interop/Cxx/class/inheritance/Inputs/fields.h
@@ -175,6 +175,12 @@ struct EmptyOnlyDerived : BaseEmpty {};
 
 inline EmptyOnlyDerived makeEmptyOnlyDerived() { return {}; }
 
+struct BaseEmptyAndInt : BaseEmpty {
+  int x;
+};
+
+inline BaseEmptyAndInt makeBaseEmptyAndInt(int n) { return {{}, n}; }
+
 struct IntAndEmpty {
   int x;
   Empty e;
@@ -222,8 +228,8 @@ inline ContainsEmptyClass makeContainsEmptyClass() { return {}; }
 
 struct OuterWithEmpty {
   struct Inner {};
-  int x;
   Inner i;
+  int x;
 };
 
 inline OuterWithEmpty makeOuterWithEmpty() {
@@ -240,8 +246,8 @@ inline EmptyArrayHolder makeEmptyArrayHolder() { return {}; }
 
 template <class T>
 struct EmptyHolder {
-  bool x;
   T t;
+  bool x;
 };
 
 inline EmptyHolder<Empty> makeEmptyHolderOfEmpty() {
@@ -343,8 +349,8 @@ inline HasEmptyUnion makeHasEmptyUnion() {
 }
 
 union UnionEmptyAndInt {
-  int x;
   Empty e;
+  int x;
 };
 
 struct HasUnionEmptyAndInt {

--- a/test/Interop/Cxx/class/inheritance/Inputs/fields.h
+++ b/test/Interop/Cxx/class/inheritance/Inputs/fields.h
@@ -1,3 +1,9 @@
+#if defined(_MSC_VER)
+#define NO_UNIQUE_ADDRESS [[msvc::no_unique_address]]
+#else
+#define NO_UNIQUE_ADDRESS [[no_unique_address]]
+#endif
+
 struct HasThreeFields {
   int a = 1;
   int b = 2;
@@ -156,3 +162,205 @@ struct DerivedOutOfOrder : public HasOneField,
 
   ~DerivedOutOfOrder() override {}
 };
+
+struct Empty {};
+
+struct BaseEmpty {
+  Empty e;
+};
+
+inline BaseEmpty makeBaseEmpty() { return {}; }
+
+struct EmptyOnlyDerived : BaseEmpty {};
+
+inline EmptyOnlyDerived makeEmptyOnlyDerived() { return {}; }
+
+struct IntAndEmpty {
+  int x;
+  Empty e;
+};
+
+inline IntAndEmpty makeIntAndEmpty() {
+  IntAndEmpty v;
+  v.x = 42;
+  return v;
+}
+
+struct NoUniqueAddressEmpty {
+  NO_UNIQUE_ADDRESS Empty e;
+  int x;
+};
+
+inline NoUniqueAddressEmpty makeNoUniqueAddressEmpty() {
+  NoUniqueAddressEmpty v;
+  v.x = 17;
+  return v;
+}
+
+struct EmptyBaseA {};
+struct EmptyBaseB {};
+struct MultiEmptyBases : EmptyBaseA, EmptyBaseB {};
+
+inline MultiEmptyBases makeMultiEmptyBases() { return {}; }
+
+struct BaseWithEmpty1 {
+  Empty e1;
+};
+struct BaseWithEmpty2 {
+  Empty e2;
+};
+struct MultiBaseWithEmpty : BaseWithEmpty1, BaseWithEmpty2 {};
+
+inline MultiBaseWithEmpty makeMultiBaseWithEmpty() { return {}; }
+
+class ContainsEmptyClass {
+public:
+  Empty e;
+};
+
+inline ContainsEmptyClass makeContainsEmptyClass() { return {}; }
+
+struct OuterWithEmpty {
+  struct Inner {};
+  int x;
+  Inner i;
+};
+
+inline OuterWithEmpty makeOuterWithEmpty() {
+  OuterWithEmpty v;
+  v.x = 7;
+  return v;
+}
+
+struct EmptyArrayHolder {
+  Empty arr[3];
+};
+
+inline EmptyArrayHolder makeEmptyArrayHolder() { return {}; }
+
+template <class T>
+struct EmptyHolder {
+  bool x;
+  T t;
+};
+
+inline EmptyHolder<Empty> makeEmptyHolderOfEmpty() {
+  EmptyHolder<Empty> v;
+  v.x = false;
+  return v;
+}
+
+inline EmptyHolder<int> makeEmptyHolderOfInt() {
+  EmptyHolder<int> v;
+  v.t = 2;
+  v.x = false;
+  return v;
+}
+
+// Has a vfptr so it's not empty even though it has no data members.
+struct VirtualDtor {
+  virtual ~VirtualDtor() {}
+};
+struct HasFieldWithOnlyVDtor {
+  VirtualDtor v;
+};
+
+inline HasFieldWithOnlyVDtor makeHasFieldWithOnlyVDtor() { return {}; }
+
+struct EmptyForVBase {};
+struct DerivedWithVBase : virtual EmptyForVBase {};
+
+struct WrapsVirtualBase {
+  DerivedWithVBase d;
+};
+
+inline WrapsVirtualBase makeWrapsVirtualBase() { return {}; }
+
+struct BaseEmptyAndTwoChars {
+  Empty e;
+  char a;
+  char b;
+};
+
+struct ChildEmptyAndTwoChars : BaseEmptyAndTwoChars {};
+
+inline ChildEmptyAndTwoChars makeChildEmptyAndTwoChars() {
+  ChildEmptyAndTwoChars v;
+  v.a = 'A';
+  v.b = 'B';
+  return v;
+}
+
+struct BaseEmptyIntChar {
+  Empty e;
+  int x;
+  char y;
+};
+
+struct ChildEmptyIntChar : BaseEmptyIntChar {};
+
+inline ChildEmptyIntChar makeChildEmptyIntChar() {
+  ChildEmptyIntChar v;
+  v.x = 42;
+  v.y = 'Y';
+  return v;
+}
+
+struct S1 {};
+
+struct S2 {
+  S1 member;
+};
+
+struct S3 {
+  S2 field;
+};
+
+inline S3 makeS3() { return S3(); }
+
+inline int takeBaseEmpty(BaseEmpty x, int n) { return n; }
+
+inline BaseEmpty roundTripBaseEmpty(BaseEmpty x) { return x; }
+
+inline EmptyOnlyDerived roundTripEmptyOnlyDerived(EmptyOnlyDerived x) {
+  return x;
+}
+
+union UnionAllEmpty {
+  Empty e1;
+  Empty e2;
+};
+
+struct HasEmptyUnion {
+  UnionAllEmpty u;
+  int i;
+};
+
+inline HasEmptyUnion makeHasEmptyUnion() {
+  HasEmptyUnion v;
+  v.i = 3;
+  return v;
+}
+
+union UnionEmptyAndInt {
+  int x;
+  Empty e;
+};
+
+struct HasUnionEmptyAndInt {
+  UnionEmptyAndInt u;
+  int i;
+};
+
+inline HasUnionEmptyAndInt makeHasUnionEmptyAndInt() {
+  HasUnionEmptyAndInt v;
+  v.i = 5;
+  return v;
+}
+
+inline HasUnionEmptyAndInt makeHasUnionEmptyAndIntWithValue() {
+  HasUnionEmptyAndInt v;
+  v.i = 5;
+  v.u.x = 15;
+  return v;
+}

--- a/test/Interop/Cxx/class/inheritance/fields.swift
+++ b/test/Interop/Cxx/class/inheritance/fields.swift
@@ -131,4 +131,95 @@ FieldsTestSuite.test("Out-of-order inheritance") {
   expectEqual(d.baseField, 123)
 }
 
+FieldsTestSuite.test("Empty subobjects") {
+  _ = makeBaseEmpty()
+  _ = makeEmptyOnlyDerived()
+}
+
+FieldsTestSuite.test("Contain empty fields") {
+  let o1 = makeIntAndEmpty()
+  expectEqual(o1.x, 42)
+
+  let o2 = makeNoUniqueAddressEmpty()
+  expectEqual(o2.x, 17)
+}
+
+FieldsTestSuite.test("Multiple empty bases") {
+  _ = makeMultiEmptyBases()
+  _ = makeMultiBaseWithEmpty()
+}
+
+FieldsTestSuite.test("Empty as nested or array field") {
+  _ = makeContainsEmptyClass()
+
+  let o = makeOuterWithEmpty()
+  expectEqual(o.x, 7)
+
+  _ = makeEmptyArrayHolder()
+}
+
+FieldsTestSuite.test("Empty as template type parameter") {
+  let o1 = makeEmptyHolderOfEmpty()
+  expectEqual(o1.x, false)
+
+  let o2 = makeEmptyHolderOfInt()
+  expectEqual(o2.x, false)
+  expectEqual(o2.t, 2)
+}
+
+FieldsTestSuite.test("Empty virtual classes") {
+  _ = makeHasFieldWithOnlyVDtor()
+  _ = makeWrapsVirtualBase()
+}
+
+FieldsTestSuite.test("Empty field + 2 chars") {
+  let c1 = makeChildEmptyAndTwoChars()
+  expectEqual(c1.a, CChar(65))  // 'A'
+  expectEqual(c1.b, CChar(66))  // 'B'
+}
+
+FieldsTestSuite.test("Empty field + int + char") {
+  _ = makeChildEmptyIntChar()
+}
+
+FieldsTestSuite.test("Recursively empty field") {
+  let _ = S3()
+}
+
+FieldsTestSuite.test("Empty struct as parameter") {
+  expectEqual(takeBaseEmpty(BaseEmpty(), 17), 17)
+  expectEqual(takeBaseEmpty(makeBaseEmpty(), 71), 71)
+
+  let b1 = roundTripBaseEmpty(makeBaseEmpty())
+  _ = b1
+
+  let d = roundTripEmptyOnlyDerived(makeEmptyOnlyDerived())
+  _ = d
+}
+
+FieldsTestSuite.test("Hollow type stored in Swift containers") {
+  let arr = [makeBaseEmpty(), makeBaseEmpty(), makeBaseEmpty()]
+  expectEqual(arr.count, 3)
+
+  let tup = (makeBaseEmpty(), 42, makeEmptyOnlyDerived())
+  expectEqual(tup.1, 42)
+
+  struct SwiftWrapper {
+    var inner: BaseEmpty
+    var n: Int
+  }
+  let w = SwiftWrapper(inner: makeBaseEmpty(), n: 5)
+  expectEqual(w.n, 5)
+}
+
+FieldsTestSuite.test("Unions") {
+  let s1 = makeHasEmptyUnion()
+  expectEqual(s1.i, 3)
+  let s2 = makeHasUnionEmptyAndInt()
+  expectEqual(s2.i, 5)
+  let s3 = makeHasUnionEmptyAndIntWithValue()
+  expectEqual(s3.i, 5)
+  expectEqual(s3.u.x, 15)
+}
+
 runAllTests()

--- a/test/Interop/Cxx/class/inheritance/fields.swift
+++ b/test/Interop/Cxx/class/inheritance/fields.swift
@@ -142,6 +142,9 @@ FieldsTestSuite.test("Contain empty fields") {
 
   let o2 = makeNoUniqueAddressEmpty()
   expectEqual(o2.x, 17)
+
+  let o3 = makeBaseEmptyAndInt(72)
+  expectEqual(o3.x, 72)
 }
 
 FieldsTestSuite.test("Multiple empty bases") {


### PR DESCRIPTION
In C++, an empty field (i.e. a field whose type is a record that has no non-static data members) takes 1 byte of storage to guarantee that distinct objects of the same type have different addresses. `SwiftAggLowering` skips these empty fields, and so does `getSchema()` in general. However, base-class fields are imported as opaque, so `getSchema()` ends up including them which creates an inconsistency between the schema and the explosion. 

To fix this, we can introduce a new `ElementLayout::Kind::Hollow` that is applied to these empty fields. `Hollow` fields are skipped by `getSchema()` (even when they are imported as opaque) and by other field-iteration helpers in `RecordTypeInfoImpl`, so that the schema and value operations stay consistent.

rdar://164555140