### PR TITLE
[6.4][AST] ParameterListInfo: Construct info for fully substituted declaration references

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -4266,6 +4266,9 @@ public:
 
   /// Retrieve the number of parameters for which we have information.
   unsigned size() const { return defaultArguments.size(); }
+
+private:
+  void setFlagsFor(const ParamDecl *param, unsigned index);
 };
 
 /// Turn a param list into a symbolic and printable representation that does not

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -4231,8 +4231,19 @@ struct ParameterListInfo {
 public:
   ParameterListInfo() { }
 
+  ParameterListInfo(ArrayRef<AnyFunctionType::Param> params);
   ParameterListInfo(ArrayRef<AnyFunctionType::Param> params,
                     const ValueDecl *paramOwner, bool skipCurriedSelf);
+
+  /// Constructs parameter information from the given set of parameters
+  /// that are associated with the given substituted declaration reference.
+  ///
+  /// Note that number of parameters doesn't necessary always match arity of the
+  /// parameter list because variadic generic parameters without arguments
+  /// are removed from the function type and multi-parameter matches are
+  /// flattened.
+  ParameterListInfo(ArrayRef<AnyFunctionType::Param> params,
+                    bool skipCurriedSelf, ConcreteDeclRef declRef);
 
   /// Whether the parameter at the given index has a default argument.
   bool hasDefaultArgument(unsigned paramIdx) const;

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -1573,39 +1573,41 @@ ParameterListInfo::ParameterListInfo(
   // Note which parameters have default arguments and/or accept unlabeled
   // trailing closure arguments with the forward-scan rule.
   for (auto i : range(0, params.size())) {
-    auto param = paramList->get(i);
-    if (param->isDefaultArgument()) {
-      defaultArguments.set(i);
-    }
+    setFlagsFor(paramList->get(i), i);
+  }
+}
 
-    if (allowsUnlabeledTrailingClosureParameter(param)) {
-      acceptsUnlabeledTrailingClosures.set(i);
-    }
+void ParameterListInfo::setFlagsFor(const ParamDecl *param, unsigned index) {
+  if (param->isDefaultArgument()) {
+    defaultArguments.set(index);
+  }
 
-    if (param->hasExternalPropertyWrapper()) {
-      propertyWrappers.set(i);
-    }
+  if (allowsUnlabeledTrailingClosureParameter(param)) {
+    acceptsUnlabeledTrailingClosures.set(index);
+  }
 
-    if (param->getAttrs().hasAttribute<ImplicitSelfCaptureAttr>()) {
-      implicitSelfCapture.set(i);
-    }
+  if (param->hasExternalPropertyWrapper()) {
+    propertyWrappers.set(index);
+  }
 
-    if (auto *attr =
-            param->getAttrs().getAttribute<InheritActorContextAttr>()) {
-      if (attr->isAlways()) {
-        alwaysInheritActorContext.set(i);
-      } else {
-        inheritActorContext.set(i);
-      }
-    }
+  if (param->getAttrs().hasAttribute<ImplicitSelfCaptureAttr>()) {
+    implicitSelfCapture.set(index);
+  }
 
-    if (param->getInterfaceType()->is<PackExpansionType>()) {
-      variadicGenerics.set(i);
+  if (auto *attr = param->getAttrs().getAttribute<InheritActorContextAttr>()) {
+    if (attr->isAlways()) {
+      alwaysInheritActorContext.set(index);
+    } else {
+      inheritActorContext.set(index);
     }
+  }
 
-    if (param->isSending()) {
-      sendingParameters.set(i);
-    }
+  if (param->getInterfaceType()->is<PackExpansionType>()) {
+    variadicGenerics.set(index);
+  }
+
+  if (param->isSending()) {
+    sendingParameters.set(index);
   }
 }
 

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -1525,10 +1525,7 @@ static bool allowsUnlabeledTrailingClosureParameter(const ParamDecl *param) {
   return paramType->is<AnyFunctionType>();
 }
 
-ParameterListInfo::ParameterListInfo(
-    ArrayRef<AnyFunctionType::Param> params,
-    const ValueDecl *paramOwner,
-    bool skipCurriedSelf) {
+ParameterListInfo::ParameterListInfo(ArrayRef<AnyFunctionType::Param> params) {
   defaultArguments.resize(params.size());
   propertyWrappers.resize(params.size());
   implicitSelfCapture.resize(params.size());
@@ -1536,7 +1533,13 @@ ParameterListInfo::ParameterListInfo(
   alwaysInheritActorContext.resize(params.size());
   variadicGenerics.resize(params.size());
   sendingParameters.resize(params.size());
+  acceptsUnlabeledTrailingClosures.resize(params.size());
+}
 
+ParameterListInfo::ParameterListInfo(ArrayRef<AnyFunctionType::Param> params,
+                                     const ValueDecl *paramOwner,
+                                     bool skipCurriedSelf)
+    : ParameterListInfo(params) {
   // No parameter owner means no parameter list means no default arguments
   // - hand back the zeroed bitvector.
   //
@@ -1566,14 +1569,33 @@ ParameterListInfo::ParameterListInfo(
   if (params.size() != paramList->size())
     return;
 
-  // Now we have enough information to determine which parameters accept
-  // unlabeled trailing closures.
-  acceptsUnlabeledTrailingClosures.resize(params.size());
-
   // Note which parameters have default arguments and/or accept unlabeled
   // trailing closure arguments with the forward-scan rule.
   for (auto i : range(0, params.size())) {
     setFlagsFor(paramList->get(i), i);
+  }
+}
+
+ParameterListInfo::ParameterListInfo(ArrayRef<AnyFunctionType::Param> params,
+                                     bool skipCurriedSelf,
+                                     ConcreteDeclRef declRef)
+  : ParameterListInfo(params) {
+  if (!declRef || params.empty())
+    return;
+
+  auto *decl = declRef.getDecl();
+  if (decl->hasCurriedSelf() && !skipCurriedSelf)
+    return;
+
+  auto *paramList = decl->getParameterList();
+  if (!paramList)
+    return;
+
+  auto subs = declRef.getSubstitutions();
+  for (auto i : indices(params)) {
+    if (auto *param = subs ? getParameterAt(declRef, i) : paramList->get(i)) {
+      setFlagsFor(param, i);
+    }
   }
 }
 

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -6180,7 +6180,7 @@ ArgumentList *ExprRewriter::coerceCallArguments(
   // Determine whether this application has curried self.
   bool skipCurriedSelf = apply ? hasCurriedSelf(cs, callee, apply) : true;
   // Determine the parameter bindings.
-  ParameterListInfo paramInfo(params, callee.getDecl(), skipCurriedSelf);
+  ParameterListInfo paramInfo(params, skipCurriedSelf, callee);
 
   // If this application is an init(wrappedValue:) call that needs an injected
   // wrapped value placeholder, the first non-defaulted argument must be

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -28,6 +28,7 @@
 #include "swift/AST/ASTVisitor.h"
 #include "swift/AST/ASTWalker.h"
 #include "swift/AST/ClangModuleLoader.h"
+#include "swift/AST/ConcreteDeclRef.h"
 #include "swift/AST/ConformanceLookup.h"
 #include "swift/AST/Effects.h"
 #include "swift/AST/ExistentialLayout.h"
@@ -43,6 +44,7 @@
 #include "swift/Basic/Assertions.h"
 #include "swift/Basic/Defer.h"
 #include "swift/Basic/StringExtras.h"
+#include "swift/Sema/ConstraintLocator.h"
 #include "swift/Sema/ConstraintSystem.h"
 #include "swift/Sema/SolutionResult.h"
 #include "clang/AST/DeclTemplate.h"
@@ -8438,8 +8440,16 @@ Expr *ExprRewriter::finishApply(ApplyExpr *apply, Type openedType,
   auto *calleeLoc = cs.getConstraintLocator(calleeLocator);
   auto overload = solution.getOverloadChoiceIfAvailable(calleeLoc);
   if (overload) {
-    auto *decl = overload->choice.getDeclOrNull();
-    callee = resolveConcreteDeclRef(decl, calleeLoc);
+    // If this is a call through an implicit `dynamicMember:` subscript,
+    // of a `@dynamicMemberLookup` type there is no callee because the
+    // call happens on a value returned by the subscript invocation and
+    // not necessary the member looked up.
+    if (overload->choice.isKeyPathDynamicMemberLookup()) {
+      callee = ConcreteDeclRef();
+    } else {
+      auto *decl = overload->choice.getDeclOrNull();
+      callee = resolveConcreteDeclRef(decl, calleeLoc);
+    }
   }
 
   // Make sure we have a function type that is callable. This helps ensure

--- a/test/Concurrency/issue-88146.swift
+++ b/test/Concurrency/issue-88146.swift
@@ -1,0 +1,40 @@
+// RUN: %target-swift-frontend -disable-availability-checking -language-mode 5 -strict-concurrency=complete %s -emit-sil -o /dev/null -verify
+// RUN: %target-swift-frontend -disable-availability-checking -language-mode 6 %s -emit-sil -o /dev/null -verify
+
+// REQUIRES: concurrency
+
+// https://github.com/swiftlang/swift/issues/88146
+
+@MainActor
+final class App {
+  var age = 1
+
+  func main() {
+    run0 {
+      self.age = 1 // Ok
+    }
+
+    runVariadic {
+      self.age = 1 // Ok
+    }
+
+    runVariadic { @MainActor in
+      self.age = 1 // Ok
+    }
+
+    runVariadic(values: 1) {
+      self.age = 1 // Ok
+    }
+  }
+
+  nonisolated func run0(
+    @_inheritActorContext action: @escaping @Sendable () async -> Swift.Void
+  )  {
+  }
+
+  nonisolated func runVariadic<each T>(
+    values: repeat each T,
+    @_inheritActorContext action: @escaping @Sendable () async -> Swift.Void
+  ) {
+  }
+}

--- a/test/Constraints/keypath_dynamic_member_lookup.swift
+++ b/test/Constraints/keypath_dynamic_member_lookup.swift
@@ -652,3 +652,22 @@ struct SingleLens<T> {
 func testRecursiveSingleSubscript(_ x: SingleLens<SingleLens<SingleLens<SingleLens<[Int]>>>>) {
   _ = x[0]
 }
+
+// Make sure that coerceCallArguments doesn't crash when arity of the subscript doesn't match
+// that of the member found by the lookup.
+func testMultipleArguments() {
+  @dynamicMemberLookup
+  struct Entity<T> {
+    subscript<R>(dynamicMember keyPath: KeyPath<T, R>) -> R {
+      fatalError()
+    }
+  }
+
+  struct FuncEntity {
+    let implementation: (String, Int) -> Void
+  }
+
+  func test(e: Entity<FuncEntity>) {
+    e.implementation("ultimate question", 42)
+  }
+}


### PR DESCRIPTION
- Explanation:

  Fixes a case were passing not an exactly one argument to variadic generic 
  leaves other arguments without flags that have to be transferred from parameters.

  This is important during CSApply because fully resolved function
  type of a variadic generic declaration reference doesn't necessary
  match arity of the parameter list and requires special handling.

  For example, parameters inferred to be empty packs are going to be
  removed from the type and multi-parameter substitutions are going
  to be flattened.

- Resolves: https://github.com/swiftlang/swift/issues/88146, rdar://173455896

- Main branch PR: https://github.com/swiftlang/swift/pull/89444

- Risk: Low. The change is narrow and only affects declarations that require substitutions and involve variadic generics otherwise `getParameterAt` behaves exactly the same as before. The change uncovered one case where a callee was set incorrectly but we don't anticipate any more issues like that.

- Reviewed By: @hamishknight   

- Testing: Added new test-cases to the suite.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
