### PR TITLE
[Runtime] Fix spurious "cannot parse value" environment variable warning.

### DIFF
--- a/stdlib/public/runtime/EnvironmentVariables.cpp
+++ b/stdlib/public/runtime/EnvironmentVariables.cpp
@@ -100,7 +100,7 @@ parse_optional_uint8(const char *name, const char *value,
 static uint8_t parse_uint8(const char *name, const char *value,
                            uint8_t defaultValue) {
   auto result = parse_optional_uint8(name, value, std::nullopt);
-  if (!result)
+  if (!result && value)
     swift::warning(RuntimeErrorFlagNone,
                    "Warning: cannot parse value %s=%s, defaulting to %u.\n",
                    name, value, defaultValue);


### PR DESCRIPTION
When using the getenv path, parse_uint8 would print the "cannot parse value" when the value was NULL, but that should only be printed when a value is provided but cannot be parsed.