### PR TITLE
Opaque Values: inconsistent stack states

### DIFF
--- a/lib/SILOptimizer/Mandatory/AddressLowering.cpp
+++ b/lib/SILOptimizer/Mandatory/AddressLowering.cpp
@@ -152,7 +152,7 @@
 #include "swift/SIL/SILValue.h"
 #include "swift/SIL/SILVisitor.h"
 #include "swift/SIL/StackList.h"
-#include "swift/SILOptimizer/Analysis/DeadEndBlocksAnalysis.h"
+#include "swift/SILOptimizer/Analysis/LoopAnalysis.h"
 #include "swift/SILOptimizer/Analysis/PostOrderAnalysis.h"
 #include "swift/SILOptimizer/PassManager/Transforms.h"
 #include "swift/SILOptimizer/Utils/BasicBlockOptUtils.h"
@@ -512,9 +512,6 @@ struct AddressLoweringState {
   // Dominators remain valid throughout this pass.
   DominanceInfo *domInfo;
 
-  // Dead-end blocks remain valid through this pass.
-  DeadEndBlocks *deBlocks;
-
   InstructionDeleter deleter;
 
   // All opaque values mapped to their associated storage.
@@ -549,10 +546,12 @@ struct AddressLoweringState {
   // legal to reuse use projections for non-canonical users or for phis.
   SmallVector<SILValue, 16> useProjections;
 
+  SILLoopAnalysis *SLA;
+
   AddressLoweringState(SILFunction *function, DominanceInfo *domInfo,
-                       DeadEndBlocks *deBlocks)
+                       SILLoopAnalysis *SLA)
       : function(function), loweredFnConv(getLoweredFnConv(function)),
-        domInfo(domInfo), deBlocks(deBlocks) {
+        domInfo(domInfo), SLA(SLA) {
     for (auto &block : *function) {
       if (block.getTerminator()->isFunctionExiting())
         exitingInsts.push_back(block.getTerminator());
@@ -1198,6 +1197,12 @@ bool ValueStorageMap::isComposingUseProjection(Operand *oper) const {
 }
 
 namespace {
+enum class SinkResult {
+  NoUsers,
+  Unmoved,
+  Moved,
+};
+
 /// Allocate storage on the stack for every opaque value defined in this
 /// function in postorder. If the definition is an argument of this function,
 /// simply replace the function argument with an address representing the
@@ -1255,6 +1260,8 @@ protected:
     pass.valueStorageMap.getStorage(value).storageAddress =
         createStackAllocation(value);
   }
+
+  SinkResult sinkToUses(SingleValueInstruction *svi, DominanceInfo *domInfo);
 };
 } // end anonymous namespace
 
@@ -1592,13 +1599,8 @@ AllocStackInst *OpaqueStorageAllocation::createStackAllocation(SILValue value) {
   return alloc;
 }
 
-namespace {
-enum class SinkResult {
-  NoUsers,
-  Unmoved,
-  Moved,
-};
-SinkResult sinkToUses(SingleValueInstruction *svi, DominanceInfo *domInfo) {
+SinkResult OpaqueStorageAllocation::sinkToUses(SingleValueInstruction *svi,
+                                               DominanceInfo *domInfo) {
   // Fast paths for 0 and 1 users.
 
   if (svi->use_begin() == svi->use_end()) {
@@ -1618,8 +1620,22 @@ SinkResult sinkToUses(SingleValueInstruction *svi, DominanceInfo *domInfo) {
 
   SILBasicBlock *lca = domInfo->getLeastCommonAncestorOfUses(svi);
 
-  // The lca may contain a user.  Look for the user to insert before it.
+  // If the materialized address is itself an alloc_stack, avoid sinking it
+  // into a loop.
+  // The deallocs were placed based on the alloc's current location.
+  // Relocating the alloc into a loop would re-execute it every iteration
+  // without matching deallocs on the back-edge, breaking stack discipline.
+  if (auto *asi = dyn_cast<AllocStackInst>(svi)) {
+    auto *LI = pass.SLA->get(asi->getFunction());
+    auto *startNode = domInfo->getNode(asi->getParent());
+    for (auto node = domInfo->getNode(lca); node && node != startNode;
+         node = node->getIDom()) {
+      if (LI->isLoopHeader(node->getBlock()))
+        return SinkResult::Unmoved;
+    }
+  }
 
+  // The lca may contain a user.  Look for the user to insert before it.
   InstructionSet userSet(svi->getFunction());
   for (auto user : svi->getUsers()) {
     userSet.insert(user);
@@ -1638,7 +1654,6 @@ SinkResult sinkToUses(SingleValueInstruction *svi, DominanceInfo *domInfo) {
   svi->moveBefore(&lca->back());
   return SinkResult::Moved;
 }
-} // end anonymous namespace
 
 void OpaqueStorageAllocation::finalizeOpaqueStorage() {
   SmallVector<SILBasicBlock *, 4> boundary;
@@ -1661,7 +1676,11 @@ void OpaqueStorageAllocation::finalizeOpaqueStorage() {
     // a use projection.
     computeDominatedBoundaryBlocks(alloc->getParent(), pass.domInfo, boundary);
     for (SILBasicBlock *deallocBlock : boundary) {
-      if (pass.deBlocks->isDeadEnd(deallocBlock))
+      // Owned values need not be destroyed on paths terminating in
+      // `unreachable`, so the corresponding storage need not be deallocated
+      // there either; emitting a dealloc_stack in such a block could free
+      // storage that was never deinitialized.
+      if (DeadEndBlocks::triviallyEndsInUnreachable(deallocBlock))
         continue;
       auto deallocBuilder = pass.getBuilder(deallocBlock->back().getIterator());
       deallocBuilder.createDeallocStack(pass.genLoc(), alloc);
@@ -4700,10 +4719,9 @@ void AddressLowering::runOnFunction(SILFunction *function) {
   removeUnreachableBlocks(*function);
 
   auto *dominance = PM->getAnalysis<DominanceAnalysis>();
-  auto *deadEnds = PM->getAnalysis<DeadEndBlocksAnalysis>();
+  auto *SLA = PM->getAnalysis<SILLoopAnalysis>();
 
-  AddressLoweringState pass(function, dominance->get(function),
-                            deadEnds->get(function));
+  AddressLoweringState pass(function, dominance->get(function), SLA);
 
   // ## Step #1: Map opaque values
   //

--- a/test/Interpreter/for_each_any_collection_opaque_values.swift
+++ b/test/Interpreter/for_each_any_collection_opaque_values.swift
@@ -1,0 +1,33 @@
+// RUN: %target-run-simple-swift(-Xfrontend -enable-sil-opaque-values) | %FileCheck %s
+// REQUIRES: executable_test
+
+// Execution test for `for v in c` over `any Collection` under opaque values.
+// The phi storage for the loop's per-iteration `Optional<Element>` is
+// allocated outside the loop; per-iteration `@out` slots are alloc'd/dealloc'd
+// each iteration. This test verifies the loop iterates exactly the right
+// number of times and produces the right values at runtime.
+
+func testForEachAnyCollection(_ c: any Collection) {
+  for v in c {
+    print(v)
+  }
+}
+
+print("--- Int ---")
+testForEachAnyCollection([1, 2, 3])
+print("--- Mixed ---")
+testForEachAnyCollection([1, 2.0, "Hello"] as [Any])
+print("--- Empty ---")
+testForEachAnyCollection([] as [Int])
+print("--- Done ---")
+
+// CHECK:      --- Int ---
+// CHECK-NEXT: 1
+// CHECK-NEXT: 2
+// CHECK-NEXT: 3
+// CHECK-NEXT: --- Mixed ---
+// CHECK-NEXT: 1
+// CHECK-NEXT: 2.0
+// CHECK-NEXT: Hello
+// CHECK-NEXT: --- Empty ---
+// CHECK-NEXT: --- Done ---

--- a/test/SILOptimizer/address_lowering.sil
+++ b/test/SILOptimizer/address_lowering.sil
@@ -2517,6 +2517,58 @@ entry(%t : @guaranteed $T):
   return %retval : $()
 }
 
+// In a function whose only exit is `unreachable`, every block is dead-end.
+// The dealloc for an opaque value defined in an outer-loop body must still
+// be placed on the outer-loop back-edge, because that block flows into the
+// outer-loop header — a join point with the pre-loop predecessor where the
+// alloc is not live.
+// Skipping the dealloc on the back-edge breaks stack-state consistency at the header.
+//
+// CHECK-LABEL: sil hidden [ossa] @test_dead_end_outer_back_edge :
+// CHECK:       bb0:
+// CHECK-NEXT:    br [[OUTER_HEADER:bb[0-9]+]]
+// CHECK:       [[OUTER_HEADER]]:
+// CHECK-NEXT:    cond_br {{.*}}, [[OUTER_BODY:bb[0-9]+]], {{bb[0-9]+}}
+// CHECK:       [[OUTER_BODY]]:
+// CHECK:         [[STK:%[^,]+]] = alloc_stack $T
+// CHECK:         apply undef<T>([[STK]])
+// CHECK-NEXT:    br [[INNER_HEADER:bb[0-9]+]]
+// CHECK:       [[INNER_HEADER]]:
+// CHECK-NEXT:    cond_br {{.*}}, [[INNER_BODY:bb[0-9]+]], [[OUTER_BACK:bb[0-9]+]]
+// CHECK:       [[OUTER_BACK]]:
+// CHECK-NEXT:    destroy_addr [[STK]]
+// CHECK-NEXT:    dealloc_stack [[STK]]
+// CHECK-NEXT:    br [[OUTER_HEADER]]
+// CHECK:       [[INNER_BODY]]:
+// CHECK-NEXT:    apply undef<T>([[STK]])
+// CHECK-NEXT:    br [[INNER_HEADER]]
+// CHECK-LABEL: } // end sil function 'test_dead_end_outer_back_edge'
+sil hidden [ossa] @test_dead_end_outer_back_edge : $@convention(thin) <T> () -> () {
+bb0:
+  br bb1
+
+bb1:
+  cond_br undef, bb_outer_body, bb_unreachable
+
+bb_outer_body:
+  %v = apply undef<T>() : $@convention(thin) <τ_0_0> () -> @out τ_0_0
+  br bb_inner_header
+
+bb_inner_header:
+  cond_br undef, bb_inner_body, bb_outer_back
+
+bb_inner_body:
+  %use = apply undef<T>(%v) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  br bb_inner_header
+
+bb_outer_back:
+  destroy_value %v : $T
+  br bb1
+
+bb_unreachable:
+  unreachable
+}
+
 enum PairEnum<T> {
   case it(T, T)
 }
@@ -2939,6 +2991,44 @@ bb0(%c : @owned $Klass):
   destroy_value %closure : $@callee_guaranteed (@inout Int) -> (@out Int)
   %retval = tuple ()
   return %retval : $()
+}
+
+// Phi-arg storage for an opaque enum constructed inside a loop must stay
+// outside the loop. `sinkToUses` skips sinking the phi's alloc_stack
+// when the sink target is inside a loop containing the alloc, since
+// the matching dealloc is placed based on the alloc's pre-sink location.
+// CHECK-LABEL: sil hidden [ossa] @test_phi_inside_loop :
+// CHECK:       bb0(%0 : $*T):
+// CHECK-NEXT:    [[STK:%[^,]+]] = alloc_stack $Optional<T>
+// CHECK-NEXT:    br [[HEADER:bb[0-9]+]]
+// CHECK:       [[HEADER]]:
+// CHECK-NEXT:    cond_br
+// CHECK:       [[EXIT:bb[0-9]+]]:
+// CHECK:         dealloc_stack [[STK]]
+// CHECK-NEXT:    return
+// CHECK:       [[LATCH:bb[0-9]+]]:
+// CHECK:         destroy_addr [[STK]]
+// CHECK-NEXT:    br [[HEADER]]
+// CHECK-LABEL: } // end sil function 'test_phi_inside_loop'
+sil hidden [ossa] @test_phi_inside_loop : $@convention(thin) <T> (@in_guaranteed T) -> () {
+bb0(%0 : @guaranteed $T):
+  br bb1
+
+bb1:
+  cond_br undef, bb2, bb_exit
+
+bb2:
+  %v = copy_value %0 : $T
+  %some = enum $Optional<T>, #Optional.some!enumelt, %v : $T
+  br bb3(%some : $Optional<T>)
+
+bb3(%phi : @owned $Optional<T>):
+  destroy_value %phi : $Optional<T>
+  br bb1
+
+bb_exit:
+  %r = tuple ()
+  return %r : $()
 }
 
 // CHECK-LABEL: sil hidden [ossa] @test_store_1 : {{.*}} {

--- a/test/SILOptimizer/address_lowering_for_each_existential.swift
+++ b/test/SILOptimizer/address_lowering_for_each_existential.swift
@@ -1,0 +1,36 @@
+// RUN: %target-swift-frontend -sil-verify-all -enable-sil-opaque-values -parse-as-library -emit-sil -Onone %s | %FileCheck %s
+
+// Regression test: `for v in c` over an existential collection (`any
+// Collection`).
+// Ensure that stack allocations are not sunk into a loop header.
+//
+// CHECK-LABEL: sil @${{.*}}testForEachAnyCollection{{.*}} :
+// Phi storage for the per-iteration Optional<Any> is allocated up-front in
+// the entry block, BEFORE the loop body — not in the loop header.
+// CHECK:       bb0(%0 : $*any Collection):
+// CHECK:         [[PHI_STK:%[^,]+]] = alloc_stack [lexical] $Optional<Any>
+// CHECK:         alloc_stack $any IteratorProtocol
+// CHECK:         br [[HEADER:bb[0-9]+]]
+//
+// Loop header allocates the per-iteration apply @out slot for iterator.next().
+// CHECK:       [[HEADER]]:
+// CHECK:         [[NEXT_STK:%[^,]+]] = alloc_stack $Optional<{{.*}}>
+// CHECK:         switch_enum_addr [[NEXT_STK]], case #Optional.some!enumelt:
+//
+// Back-edge block: dealloc the per-iteration slot then loop back to header.
+// The phi storage [[PHI_STK]] is NOT deallocated on this path.
+// CHECK:       [[BACK_EDGE:bb[0-9]+]]:
+// CHECK:         dealloc_stack [[NEXT_STK]]
+// CHECK-NEXT:    br [[HEADER]]
+//
+// Loop exit block: dealloc both per-iteration slot and phi storage, return.
+// CHECK:       [[EXIT:bb[0-9]+]]:
+// CHECK:         dealloc_stack [[NEXT_STK]]
+// CHECK:         dealloc_stack [[PHI_STK]]
+// CHECK-NEXT:    return
+// CHECK-LABEL: } // end sil function '${{.*}}testForEachAnyCollection{{.*}}'
+public func testForEachAnyCollection(_ c: any Collection) {
+  for v in c {
+    _ = v
+  }
+}

--- a/test/SILOptimizer/address_lowering_nested_for_await.swift
+++ b/test/SILOptimizer/address_lowering_nested_for_await.swift
@@ -1,0 +1,56 @@
+// RUN: %target-swift-frontend -sil-verify-all -enable-sil-opaque-values -parse-as-library -emit-sil -Onone %s | %FileCheck %s
+
+// REQUIRES: concurrency
+
+// Regression test: Make sure that `dealloc_stack` are placed when required
+// when a block ultimately exits via `unreachable`.
+
+public func makeStream() -> AsyncStream<String> {
+  AsyncStream { c in
+    c.yield("a")
+    c.finish()
+  }
+}
+
+// CHECK-LABEL: sil @${{.*}}testNestedForAwait{{.*}} :
+// Outer-loop iterator storage is allocated up-front in the entry block.
+// CHECK:       bb0:
+// CHECK:         [[OUTER_ITER:%[^,]+]] = alloc_stack [var_decl] $IndexingIterator<Range<Int>>
+// CHECK:         br [[OUTER_HEADER:bb[0-9]+]]
+//
+// CHECK:       [[OUTER_HEADER]]:
+// CHECK:         switch_enum {{.*}}, case #Optional.some!enumelt: [[OUTER_BODY:bb[0-9]+]], case #Optional.none!enumelt: [[OUTER_EXIT:bb[0-9]+]]
+//
+// Outer-loop body allocates the per-outer-iteration AsyncStream iterator
+// storage. The `[lexical] [var_decl]` alloc is the `$x$generator`.
+// CHECK:       [[OUTER_BODY]]({{.*}}):
+// CHECK:         [[STREAM:%[^,]+]] = alloc_stack $AsyncStream<String>
+// CHECK:         [[ITER:%[^,]+]] = alloc_stack $AsyncStream<String>.Iterator
+// CHECK:         [[GEN:%[^,]+]] = alloc_stack [lexical] [var_decl] $AsyncStream<String>.Iterator
+// CHECK:         br [[INNER_HEADER:bb[0-9]+]]
+//
+// CHECK:       [[INNER_HEADER]]:
+// CHECK:         switch_enum {{.*}}, case #Optional.some!enumelt: {{bb[0-9]+}}, case #Optional.none!enumelt: [[OUTER_BACK:bb[0-9]+]]
+//
+// Outer-loop back-edge: deallocates ALL the outer-body allocs, then loops
+// back to the outer header.
+// CHECK:       [[OUTER_BACK]]:
+// CHECK:         destroy_addr [[GEN]]
+// CHECK:         dealloc_stack [[GEN]]
+// CHECK:         dealloc_stack [[ITER]]
+// CHECK:         dealloc_stack [[STREAM]]
+// CHECK-NEXT:    br [[OUTER_HEADER]]
+//
+// Outer-loop exit: only the outer iterator is deallocated.
+// CHECK:       [[OUTER_EXIT]]:
+// CHECK:         dealloc_stack [[OUTER_ITER]]
+// CHECK-NEXT:    tuple
+// CHECK-NEXT:    return
+// CHECK-LABEL: } // end sil function '${{.*}}testNestedForAwait{{.*}}'
+public func testNestedForAwait() async {
+  for _ in 0..<2 {
+    for await x in makeStream() {
+      _ = x
+    }
+  }
+}


### PR DESCRIPTION
Resolves rdar://178450321.

We encounter `SIL verification failed: inconsistent stack states entering basic block` when trying to emit SIL for code similar to the examples below, with Opaque Values mode enabled (-enable-sil-opaque-values):


```
func testAnyCollection(_ c: any Collection) {
  for v in c {
    _ = v
  }
}
```


```
func makeStream() -> AsyncStream<String> {
  AsyncStream { c in
    c.yield("a")
    c.finish()
  }
}

for _ in 0..<2 {
  for await x in makeStream() {
    _ = x
  }
}
```