### PR TITLE
[6.4.x] Revert #89451

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -8562,44 +8562,6 @@ void SwiftDeclConverter::importMirroredProtocolMembers(
       if (classImplementsProtocol(superInterface, clangProto, true))
         continue;
 
-    auto hasExistingMethodWithSelector =
-        [&](clang::Selector sel, bool isInstance,
-            bool acceptPropertyAccessor) -> bool {
-      auto matches = [&](const clang::ObjCContainerDecl *container) -> bool {
-        auto *existing = isInstance ? container->getInstanceMethod(sel)
-                                    : container->getClassMethod(sel);
-        return existing &&
-               (acceptPropertyAccessor || !existing->isPropertyAccessor());
-      };
-
-      if (matches(interfaceDecl))
-        return true;
-
-      for (auto *category : interfaceDecl->known_categories()) {
-        if (!Impl.getClangSema().isVisible(category))
-          continue;
-        if (category != decl) {
-          auto *categoryModule = Impl.getClangModuleForDecl(category);
-          if (categoryModule != declModule &&
-              categoryModule != interfaceModule) {
-            // Also accept a category in a Clang module that is imported by
-            // the module that declares the conformance, since the concrete
-            // method is reachable through that module's imports.
-            auto *clangCategoryMod =
-                categoryModule ? categoryModule->getClangModule() : nullptr;
-            auto *clangDeclMod =
-                declModule ? declModule->getClangModule() : nullptr;
-            if (!clangCategoryMod || !clangDeclMod ||
-                !clangDeclMod->isModuleVisible(clangCategoryMod))
-              continue;
-          }
-        }
-        if (matches(category))
-          return true;
-      }
-      return false;
-    };
-
     auto importProtocolRequirement = [&](Decl *member) {
       // Skip compatibility stubs; there's no reason to mirror them.
       if (member->isUnavailableInCurrentSwiftVersion())
@@ -8615,9 +8577,28 @@ void SwiftDeclConverter::importMirroredProtocolMembers(
         // name. (This also covers other properties with that same name.)
         // FIXME: We should still mirror the setter as a method if it's
         // not already there.
-        if (hasExistingMethodWithSelector(objcProp->getGetterName(),
-                                          /*isInstance=*/true,
-                                          /*acceptPropertyAccessor=*/true))
+        clang::Selector sel = objcProp->getGetterName();
+        if (interfaceDecl->getInstanceMethod(sel))
+          return;
+
+        bool inNearbyCategory =
+            std::any_of(interfaceDecl->known_categories_begin(),
+                        interfaceDecl->known_categories_end(),
+                        [=](const clang::ObjCCategoryDecl *category) -> bool {
+                          if (!Impl.getClangSema().isVisible(category)) {
+                            return false;
+                          }
+                          if (category != decl) {
+                            auto *categoryModule =
+                                Impl.getClangModuleForDecl(category);
+                            if (categoryModule != declModule &&
+                                categoryModule != interfaceModule) {
+                              return false;
+                            }
+                          }
+                          return category->getInstanceMethod(sel);
+                        });
+        if (inNearbyCategory)
           return;
 
         if (auto imported =
@@ -8640,17 +8621,6 @@ void SwiftDeclConverter::importMirroredProtocolMembers(
       auto objcMethod =
           dyn_cast_or_null<clang::ObjCMethodDecl>(member->getClangDecl());
       if (!objcMethod)
-        return;
-
-      // Don't mirror a method if there's an existing method visible that would
-      // witness the requirement.
-      //
-      // A property accessor doesn't count as an existing method for this
-      // purpose: the property only exposes the member via property syntax, so
-      // we still need the mirror in order to make method-call syntax available.
-      if (hasExistingMethodWithSelector(objcMethod->getSelector(),
-                                        objcMethod->isInstanceMethod(),
-                                        /*acceptPropertyAccessor=*/false))
         return;
 
       // For now, just remember that we saw this method.

--- a/test/ClangImporter/objc_redeclared_properties_conformances.swift
+++ b/test/ClangImporter/objc_redeclared_properties_conformances.swift
@@ -99,11 +99,9 @@ func test(x: X) {
   x.methodFromInterface()
   // expected-warning@-1 {{'methodFromInterface()' is deprecated: Interface.h}}
   x.methodFromVisibleCategory()
-  // expected-warning@-1 {{'methodFromVisibleCategory()' is deprecated: VisibleCategory.h}}
   _ = x.readonlyPropFromInterface
   // expected-warning@-1 {{'readonlyPropFromInterface' is deprecated: Interface.h}}
   _ = x.readonlyPropFromVisibleCategory
-  // expected-warning@-1 {{'readonlyPropFromVisibleCategory' is deprecated: VisibleCategory.h}}
   _ = x.readwritePropFromInterface
   // expected-warning@-1 {{'readwritePropFromInterface' is deprecated: Interface.h}}
   x.readwritePropFromInterface = 0
@@ -112,7 +110,6 @@ func test(x: X) {
   // expected-warning@-1 {{'methodAsPropertyWitnessFromInterface()' is deprecated: Interface.h}}
   _ = x.propAsMethodWitnessFromVisibleCategory()
   x.methodFromInterfaceCategory()
-  // expected-warning@-1 {{'methodFromInterfaceCategory()' is deprecated: Interface.h category}}
   _ = x.propFromInterfaceCategory
   // expected-warning@-1 {{'propFromInterfaceCategory' is deprecated: Interface.h category}}
   x.methodFromOtherCategory()
@@ -135,7 +132,14 @@ func test(x: X) {
 // CHECK-NEXT:   var propFromOtherCategory: Int32 { get }
 // CHECK-NEXT: }
 // CHECK-NEXT: extension X : Proto {
+// FIXME: should not be mirrored (rdar://166912341)
+// CHECK-NEXT:   var readonlyPropFromVisibleCategory: Int32 { get }
 // CHECK-NEXT:   var propFromOtherCategory: Int32 { get }
+// FIXME: should not be mirrored (rdar://166912341)
+// CHECK-NEXT:   func methodFromInterfaceCategory()
+// FIXME: should not be mirrored (rdar://166912341)
+// CHECK-NEXT:   func methodFromVisibleCategory()
+// FIXME: should not be mirrored (rdar://166912341)
 // CHECK-NEXT:   func propAsMethodWitnessFromVisibleCategory() -> Int32
 // CHECK-NEXT:   func methodFromOtherCategory()
 // CHECK-NEXT: }

--- a/test/NameLookup/member_import_visibility_objc.swift
+++ b/test/NameLookup/member_import_visibility_objc.swift
@@ -32,7 +32,8 @@ func test(x: X) {
   // expected-no-member-visibility-warning@-1 {{'overriddenInOverlayForC()' is deprecated: Categories_C.swift}}
   // expected-member-visibility-warning@-2 {{'overriddenInOverlayForC()' is deprecated: Categories_A.h}}
   x.witnessesObjCConformanceRequirementInC()
-  // expected-warning@-1 {{'witnessesObjCConformanceRequirementInC()' is deprecated: Categories_A.h}}
+  // expected-no-member-visibility-warning@-1 {{'witnessesObjCConformanceRequirementInC()' is deprecated: Categories_A.h}}
+  // expected-member-visibility-warning@-2 {{'witnessesObjCConformanceRequirementInC()' is deprecated: Categories_A.h}}
   x.fromSubmoduleOfD() // expected-member-visibility-error {{instance method 'fromSubmoduleOfD()' is not available due to missing import of defining module 'Categories_D'}}
   x.fromBridgingHeader()
   x.overridesCategoryMethodOnNSObject()


### PR DESCRIPTION
- **Explanation:**  This reverts https://github.com/swiftlang/swift/pull/89451 due to source compatibility regressions.
- **Issue/Radar:** rdar://178453543
- **Original PR:** https://github.com/swiftlang/swift/pull/89613
- **Risk:** Low, returning to baseline tested behavior.
- **Testing:** N/A
- **Reviewer:** @nkcsgexi 