### PR TITLE
[SILGen] Don't crash on self used before self.init in a call argument (#88991)

### DIFF
--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -897,8 +897,7 @@ RValue SILGenFunction::emitRValueForSelfInDelegationInit(SILLocation loc,
   // If we are already in the did shared borrow self state, just return the
   // shared borrow value.
   if (SelfInitDelegationState == SILGenFunction::DidSharedBorrowSelf) {
-    // As above, fall back to an owned copy when guaranteed plus zero is not ok
-    // so that definite initialization can diagnose the illegal use of self.
+    // As above, +1 indicates a misuse of self for definite initialization to diagnose.
     if (!C.isGuaranteedPlusZeroOk()) {
       const auto &typeLowering = getTypeLowering(addr->getType());
       ManagedValue result = emitLoad(loc, addr, typeLowering, C, IsNotTake);

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -881,9 +881,17 @@ RValue SILGenFunction::emitRValueForSelfInDelegationInit(SILLocation loc,
   // to the delegating initializer is a metatype. Thus, we perform a
   // load_borrow. And move from WillSharedBorrowSelf -> DidSharedBorrowSelf.
   if (SelfInitDelegationState == SILGenFunction::WillSharedBorrowSelf) {
-    assert(C.isGuaranteedPlusZeroOk() &&
-           "This should only be called if guaranteed plus zero is ok");
     SelfInitDelegationState = SILGenFunction::DidSharedBorrowSelf;
+    // If guaranteed plus zero is not ok, we are accessing self in a way that is
+    // illegal before the delegating initializer is called (e.g. passing a
+    // stored property as an argument to self.init). Return an owned copy so
+    // that definite initialization diagnoses the misuse instead of crashing,
+    // mirroring the DidExclusiveBorrowSelf handling below.
+    if (!C.isGuaranteedPlusZeroOk()) {
+      const auto &typeLowering = getTypeLowering(addr->getType());
+      ManagedValue result = emitLoad(loc, addr, typeLowering, C, IsNotTake);
+      return RValue(*this, loc, refType, result);
+    }
     ManagedValue result =
         B.createLoadBorrow(loc, ManagedValue::forBorrowedAddressRValue(addr));
     return RValue(*this, loc, refType, result);
@@ -892,8 +900,13 @@ RValue SILGenFunction::emitRValueForSelfInDelegationInit(SILLocation loc,
   // If we are already in the did shared borrow self state, just return the
   // shared borrow value.
   if (SelfInitDelegationState == SILGenFunction::DidSharedBorrowSelf) {
-    assert(C.isGuaranteedPlusZeroOk() &&
-           "This should only be called if guaranteed plus zero is ok");
+    // As above, fall back to an owned copy when guaranteed plus zero is not ok
+    // so that definite initialization can diagnose the illegal use of self.
+    if (!C.isGuaranteedPlusZeroOk()) {
+      const auto &typeLowering = getTypeLowering(addr->getType());
+      ManagedValue result = emitLoad(loc, addr, typeLowering, C, IsNotTake);
+      return RValue(*this, loc, refType, result);
+    }
     ManagedValue result =
         B.createLoadBorrow(loc, ManagedValue::forBorrowedAddressRValue(addr));
     return RValue(*this, loc, refType, result);

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -882,11 +882,8 @@ RValue SILGenFunction::emitRValueForSelfInDelegationInit(SILLocation loc,
   // load_borrow. And move from WillSharedBorrowSelf -> DidSharedBorrowSelf.
   if (SelfInitDelegationState == SILGenFunction::WillSharedBorrowSelf) {
     SelfInitDelegationState = SILGenFunction::DidSharedBorrowSelf;
-    // If guaranteed plus zero is not ok, we are accessing self in a way that is
-    // illegal before the delegating initializer is called (e.g. passing a
-    // stored property as an argument to self.init). Return an owned copy so
-    // that definite initialization diagnoses the misuse instead of crashing,
-    // mirroring the DidExclusiveBorrowSelf handling below.
+    // If +1 is requested, it's a misuse of self that we expect
+    // definite initialization to diagnose.
     if (!C.isGuaranteedPlusZeroOk()) {
       const auto &typeLowering = getTypeLowering(addr->getType());
       ManagedValue result = emitLoad(loc, addr, typeLowering, C, IsNotTake);

--- a/test/SILOptimizer/definite_init_diagnostics.swift
+++ b/test/SILOptimizer/definite_init_diagnostics.swift
@@ -1726,16 +1726,35 @@ class DerivedFailableOverrideInit: BaseForFailableOverrideInit {
   override init?(fail: String) {} // expected-error {{'super.init' isn't called on all paths before returning from initializer}}
 }
 
-// https://github.com/swiftlang/swift/issues/88991 - passing an uninitialized
-// stored property as an argument to self.init used to crash in SILGen instead
-// of diagnosing the use of self before the delegating initializer is called.
+// https://github.com/swiftlang/swift/issues/88991
+// passing an uninitialized stored property as an argument to self.init is illegal
+class Retained {}
+struct NC: ~Copyable {
+  let retained = Retained()
+}
+
 class SelfInitArgument {
-  let value: Int
-  init(_ value: Int) {
+  let value: Retained
+  let ncValue: NC?
+  init(_ value: Retained) {
     self.value = value
+    self.ncValue = nil
+  }
+
+  init(withNC nc: consuming NC?) {
+    self.value = Retained()
+    self.ncValue = nc
   }
 
   convenience init() {
     self.init(value) // expected-error {{'self' used before 'self.init' call or assignment to 'self'}}
+  }
+
+  convenience init(nonOverride: ()) {
+    self.init(withNC: ncValue) // expected-error {{'self' used before 'self.init' call or assignment to 'self'}}
+  }
+
+  convenience init?(failable1: ()) {
+    self.init(withNC: ncValue) // expected-error {{'self' used before 'self.init' call or assignment to 'self'}}
   }
 }

--- a/test/SILOptimizer/definite_init_diagnostics.swift
+++ b/test/SILOptimizer/definite_init_diagnostics.swift
@@ -1725,3 +1725,17 @@ class BaseForFailableOverrideInit {
 class DerivedFailableOverrideInit: BaseForFailableOverrideInit {
   override init?(fail: String) {} // expected-error {{'super.init' isn't called on all paths before returning from initializer}}
 }
+
+// https://github.com/swiftlang/swift/issues/88991 - passing an uninitialized
+// stored property as an argument to self.init used to crash in SILGen instead
+// of diagnosing the use of self before the delegating initializer is called.
+class SelfInitArgument {
+  let value: Int
+  init(_ value: Int) {
+    self.value = value
+  }
+
+  convenience init() {
+    self.init(value) // expected-error {{'self' used before 'self.init' call or assignment to 'self'}}
+  }
+}

--- a/test/SILOptimizer/definite_init_self_init_arg_objc.swift
+++ b/test/SILOptimizer/definite_init_self_init_arg_objc.swift
@@ -1,0 +1,38 @@
+// RUN: %target-swift-emit-sil -verify %s -o /dev/null
+// REQUIRES: objc_interop
+
+// https://github.com/swiftlang/swift/issues/88991
+// On the @objc/NSObject path, using an uninitialized stored property as an
+// argument to self.init produces a distinct "property access" diagnostic.
+import Foundation
+
+class Retained {}
+struct NC: ~Copyable {
+  let retained = Retained()
+}
+
+@objc class SelfInitArgument: NSObject {
+  let value: Retained
+  let ncValue: NC?
+  init(_ value: Retained) {
+    self.value = value
+    self.ncValue = nil
+  }
+
+  init(withNC nc: consuming NC?) {
+    self.value = Retained()
+    self.ncValue = nc
+  }
+
+  override convenience init() {
+    self.init(value) // expected-error {{'self' used in property access 'value' before 'self.init' call}}
+  }
+
+  convenience init(nonOverride: ()) {
+    self.init(withNC: ncValue) // expected-error {{'self' used before 'self.init' call or assignment to 'self'}}
+  }
+
+  convenience init?(failable1: ()) {
+    self.init(withNC: ncValue) // expected-error {{'self' used before 'self.init' call or assignment to 'self'}}
+  }
+}


### PR DESCRIPTION
## What this fixes

Resolves #88991. Passing an uninitialized stored property directly as an argument to a delegating `self.init(...)` call crashed the compiler in SILGen instead of diagnosing the misuse.

```swift
class Crash {
  let value: Int
  init(_ value: Int) { self.value = value }
  convenience init() {
    self.init(value) // used to crash, now diagnosed
  }
}
```

## Current behavior

SILGen aborts with an assertion failure in `emitRValueForSelfInDelegationInit` (`C.isGuaranteedPlusZeroOk()`) while lowering the constructor. The equivalent code that first binds the property to a local (`let v = value; self.init(v)`) already diagnoses correctly, so only the inline argument form crashes.

## New behavior

In the `WillSharedBorrowSelf` and `DidSharedBorrowSelf` states, when guaranteed plus zero is not ok (the property is read as a call argument before `self.init`), return an owned copy instead of asserting. This mirrors the existing `DidExclusiveBorrowSelf` branch in the same function, which already documents this case. Definite initialization then emits the expected diagnostic:

```
error: 'self' used before 'self.init' call or assignment to 'self'
```

## Testing

* Added a regression test to `test/SILOptimizer/definite_init_diagnostics.swift`.
* `test/SILGen` and `test/SILOptimizer` pass locally (2188 tests).
