### PR TITLE
[Frontend] Rename -debug-*-after-parse flags to -after-type-checking (#50784)

### DIFF
--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -477,8 +477,8 @@ public:
   /// An enum with different modes for automatically crashing at defined times.
   enum class DebugCrashMode {
     None, ///< Don't automatically crash.
-    AssertAfterParse, ///< Automatically assert after parsing.
-    CrashAfterParse, ///< Automatically crash after parsing.
+    AssertAfterTypeChecking, ///< Automatically assert after type checking.
+    CrashAfterTypeChecking, ///< Automatically crash after type checking.
   };
 
   /// Indicates a debug crash mode for the frontend.

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -587,12 +587,18 @@ def debug_time_expression_type_checking : Flag<["-"], "debug-time-expression-typ
 
 def debug_assert_immediately : Flag<["-"], "debug-assert-immediately">,
   DebugCrashOpt, HelpText<"Force an assertion failure immediately">;
+def debug_assert_after_type_checking : Flag<["-"], "debug-assert-after-type-checking">,
+  DebugCrashOpt, HelpText<"Force an assertion failure after type checking">;
 def debug_assert_after_parse : Flag<["-"], "debug-assert-after-parse">,
-  DebugCrashOpt, HelpText<"Force an assertion failure after parsing">;
+  DebugCrashOpt,
+  HelpText<"Deprecated alias for -debug-assert-after-type-checking">;
 def debug_crash_immediately : Flag<["-"], "debug-crash-immediately">,
   DebugCrashOpt, HelpText<"Force a crash immediately">;
+def debug_crash_after_type_checking : Flag<["-"], "debug-crash-after-type-checking">,
+  DebugCrashOpt, HelpText<"Force a crash after type checking">;
 def debug_crash_after_parse : Flag<["-"], "debug-crash-after-parse">,
-  DebugCrashOpt, HelpText<"Force a crash after parsing">;
+  DebugCrashOpt,
+  HelpText<"Deprecated alias for -debug-crash-after-type-checking">;
 
 def debug_test_dependency_scan_cache_serialization: Flag<["-"], "test-dependency-scan-cache-serialization">,
    HelpText<"After performing a dependency scan, serialize and then deserialize the scanner's internal state.">;

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -590,14 +590,14 @@ def debug_assert_immediately : Flag<["-"], "debug-assert-immediately">,
 def debug_assert_after_type_checking : Flag<["-"], "debug-assert-after-type-checking">,
   DebugCrashOpt, HelpText<"Force an assertion failure after type checking">;
 def debug_assert_after_parse : Flag<["-"], "debug-assert-after-parse">,
-  DebugCrashOpt,
+  DebugCrashOpt, Flags<[HelpHidden]>,
   HelpText<"Deprecated alias for -debug-assert-after-type-checking">;
 def debug_crash_immediately : Flag<["-"], "debug-crash-immediately">,
   DebugCrashOpt, HelpText<"Force a crash immediately">;
 def debug_crash_after_type_checking : Flag<["-"], "debug-crash-after-type-checking">,
   DebugCrashOpt, HelpText<"Force a crash after type checking">;
 def debug_crash_after_parse : Flag<["-"], "debug-crash-after-parse">,
-  DebugCrashOpt,
+  DebugCrashOpt, Flags<[HelpHidden]>,
   HelpText<"Deprecated alias for -debug-crash-after-type-checking">;
 
 def debug_test_dependency_scan_cache_serialization: Flag<["-"], "test-dependency-scan-cache-serialization">,

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -481,12 +481,14 @@ void ArgsToFrontendOptionsConverter::handleDebugCrashGroupArguments() {
       debugFailWithAssertion();
     } else if (Opt.matches(OPT_debug_crash_immediately)) {
       debugFailWithCrash();
-    } else if (Opt.matches(OPT_debug_assert_after_parse)) {
+    } else if (Opt.matches(OPT_debug_assert_after_type_checking) ||
+               Opt.matches(OPT_debug_assert_after_parse)) {
       // Set in FrontendOptions
-      Opts.CrashMode = FrontendOptions::DebugCrashMode::AssertAfterParse;
-    } else if (Opt.matches(OPT_debug_crash_after_parse)) {
+      Opts.CrashMode = FrontendOptions::DebugCrashMode::AssertAfterTypeChecking;
+    } else if (Opt.matches(OPT_debug_crash_after_type_checking) ||
+               Opt.matches(OPT_debug_crash_after_parse)) {
       // Set in FrontendOptions
-      Opts.CrashMode = FrontendOptions::DebugCrashMode::CrashAfterParse;
+      Opts.CrashMode = FrontendOptions::DebugCrashMode::CrashAfterTypeChecking;
     } else {
       llvm_unreachable("Unknown debug_crash_Group option!");
     }

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1308,10 +1308,10 @@ withSemanticAnalysis(CompilerInstance &Instance, FrontendObserver *observer,
     observer->performedSemanticAnalysis(Instance);
 
   switch (opts.CrashMode) {
-  case FrontendOptions::DebugCrashMode::AssertAfterParse:
+  case FrontendOptions::DebugCrashMode::AssertAfterTypeChecking:
     debugFailWithAssertion();
     return true;
-  case FrontendOptions::DebugCrashMode::CrashAfterParse:
+  case FrontendOptions::DebugCrashMode::CrashAfterTypeChecking:
     debugFailWithCrash();
     return true;
   case FrontendOptions::DebugCrashMode::None:

--- a/test/Driver/crash.swift
+++ b/test/Driver/crash.swift
@@ -1,5 +1,8 @@
 // RUN: not %swiftc_driver -emit-executable -o %t.exe %s -Xfrontend -debug-crash-immediately 2>&1 | %FileCheck %s
 
+// RUN: not %swiftc_driver -emit-executable -o %t.exe %s -Xfrontend -debug-crash-after-type-checking 2>&1 | %FileCheck %s
+
+// Deprecated alias, kept for backwards compatibility.
 // RUN: not %swiftc_driver -emit-executable -o %t.exe %s -Xfrontend -debug-crash-after-parse 2>&1 | %FileCheck %s
 
 // CHECK: error: compile command failed due to signal {{-?[0-9]+}}


### PR DESCRIPTION
## What this does

Addresses #50784. The `-debug-assert-after-parse` and `-debug-crash-after-parse` frontend flags fire in `withSemanticAnalysis`, right after `performSema()`, so they actually trigger after type checking, not after parsing. The name reflects the old meaning of "parse" (parse and type check), which is misleading now that parsing and type checking are distinct actions.

## Change

* Add accurately named `-debug-assert-after-type-checking` and `-debug-crash-after-type-checking`.
* Keep `-debug-assert-after-parse` and `-debug-crash-after-parse` working as deprecated aliases, since existing tests and `utils/swift_build_sdk_interfaces.py` use them.
* Rename the internal `DebugCrashMode` enum cases (`AssertAfterParse` to `AssertAfterTypeChecking`, and likewise for crash) to match.

## Testing

* `test/Driver/crash.swift` now exercises the new spelling and keeps a case for the deprecated alias.
* `test/Driver` and `test/Frontend` crash/assert tests pass locally.

## Open question

This addresses the misnaming. The issue also mentions consolidating the immediate-vs-after-phase distinction (for example a single `-debug-crash-after=<phase>` form). I kept this change minimal and backward compatible; happy to follow up with a fuller consolidation if that is the preferred direction.

Resolves rdar://176645526.
