### PR TITLE
CSApply: Honor a pattern binding's explicit type annotation in its interface

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -9365,6 +9365,20 @@ applySolutionToInitialization(SyntacticElementTarget target, Expr *initializer,
   if (wrappedVar) {
     if (!finalPatternType->hasError() && !finalPatternType->is<TypeVariableType>())
       finalPatternType = computeWrappedValueType(wrappedVar, finalPatternType);
+  } else if (auto *typedPattern =
+                 dyn_cast<TypedPattern>(target.getInitializationPattern())) {
+    // When the pattern carries an explicit type annotation, prefer the type
+    // the solver assigned to the pattern over the type of the coerced
+    // initializer expression. The two share a canonical type, but if their
+    // sugar differs the initializer's sugar wins through coercion, which can
+    // have surprising results like printing an internal typealias into a
+    // .swiftinterface for a public stored property.
+
+    // FIXME: https://github.com/swiftlang/swift/issues/89690
+    // The final type could be set to the init type unconditionally without any
+    // regressions if constructor types were resugared consistently.
+    if (typedPattern->getTypeRepr())
+      finalPatternType = initType;
   }
 
   finalPatternType = finalPatternType->reconstituteSugar(/*recursive =*/false);

--- a/test/Constraints/construction.swift
+++ b/test/Constraints/construction.swift
@@ -298,3 +298,33 @@ public func rdar85263844_2(_ x: [Int]) -> S4<(outer: Int, y: Int)> {
   S4(x.map { (inner: $0, y: $0) })
   // expected-warning@-1 {{tuple conversion from '(inner: Int, y: Int)' to '(outer: Int, y: Int)' mismatches labels}}
 }
+
+struct AliasedStruct {
+  init() {}
+  init?(failable: Void) {}
+}
+class AliasedClass {}
+struct AliasedGeneric<T> {
+  init() {}
+  init?(failable: Void) {}
+}
+
+typealias StructAlias = AliasedStruct
+typealias ClassAlias = AliasedClass
+typealias BoundGenericAlias = AliasedGeneric<Int>
+typealias ParameterizedGenericAlias<T> = AliasedGeneric<T>
+
+func testAliasedTypeConstruction() {
+  let _: Int = StructAlias()
+  // expected-error@-1 {{cannot convert value of type 'StructAlias' (aka 'AliasedStruct') to specified type 'Int'}}
+  let _: Int = StructAlias(failable: ())
+  // expected-error@-1 {{cannot convert value of type 'StructAlias?' (aka 'Optional<AliasedStruct>') to specified type 'Int'}}
+  let _: Int = ClassAlias()
+  // expected-error@-1 {{cannot convert value of type 'ClassAlias' (aka 'AliasedClass') to specified type 'Int'}}
+  let _: Int = BoundGenericAlias()
+  // expected-error@-1 {{cannot convert value of type 'BoundGenericAlias' (aka 'AliasedGeneric<Int>') to specified type 'Int'}}
+  let _: Int = BoundGenericAlias(failable: ())
+  // expected-error@-1 {{cannot convert value of type 'BoundGenericAlias?' (aka 'Optional<AliasedGeneric<Int>>') to specified type 'Int'}}
+  let _: Int = ParameterizedGenericAlias<String>()
+  // expected-error@-1 {{cannot convert value of type 'ParameterizedGenericAlias<String>' (aka 'AliasedGeneric<String>') to specified type 'Int'}}
+}

--- a/test/IDE/print_ast_tc_decls.swift
+++ b/test/IDE/print_ast_tc_decls.swift
@@ -1367,8 +1367,7 @@ public typealias ParamAttrs6 = (@autoclosure () -> ()) -> ()
 // The following type only has the internal parameter name inferred from the
 // closure on the right-hand side of `=`. Thus, it is only part of the `Type`
 // and not part of the `TypeRepr`.
-// PASS_PRINT_AST_TYPE: public var ParamAttrs7: (_ f: @escaping () -> ()) -> ()
-// PASS_PRINT_AST_TYPEREPR: public var ParamAttrs7: (@escaping () -> ()) -> ()
+// PASS_PRINT_AST: public var ParamAttrs7: (@escaping () -> ()) -> ()
 public var ParamAttrs7: (@escaping () -> ()) -> () = { f in f() }
 
 // PASS_PRINT_AST: public var ParamAttrs8: (_ f: @escaping () -> ()) -> ()

--- a/test/ModuleInterface/access-filter.swift
+++ b/test/ModuleInterface/access-filter.swift
@@ -264,6 +264,14 @@ extension GenericStruct where T == ReallyInternalAlias_BAD {
   @usableFromInline internal func constrainedToPrivateAlias() {}
 }
 
+internal let internalAliasConstant_BAD: InternalAlias_BAD = PublicAliasBase()
+// CHECK: public let publicValueFromInternalAlias: AccessFilter::PublicAlias
+public let publicValueFromInternalAlias: PublicAlias = internalAliasConstant_BAD
+
+internal let internalGenericAliasConstant_BAD: GenericStruct<InternalAlias_BAD> = GenericStruct<InternalAlias_BAD>()
+// CHECK: public let publicGenericValueFromInternalAlias: AccessFilter::GenericStruct<AccessFilter::PublicAlias>
+public let publicGenericValueFromInternalAlias: GenericStruct<PublicAlias> = internalGenericAliasConstant_BAD
+
 extension GenericStruct {
   // For the next extension's test.
   public func requirement() {}

--- a/test/decl/protocol/conforms/typed_throws.swift
+++ b/test/decl/protocol/conforms/typed_throws.swift
@@ -62,6 +62,8 @@ struct S3: FailureAssociatedType {
 func testAssociatedTypes() {
   let _ = S1.Failure() // expected-error{{'S1.Failure' (aka 'MyError') cannot be constructed because it has no accessible initializers}}
   let _ = S2.Failure() // expected-error{{'S2.Failure' (aka 'any Error') cannot be constructed because it has no accessible initializers}}
+  // FIXME: https://github.com/swiftlang/swift/issues/89690
+  // Should print "type 'S3.Failure'"
   let _: Int = S3.Failure() // expected-error{{cannot convert value of type 'Never' to specified type 'Int'}}
   // expected-error@-1{{missing argument for parameter 'from' in call}}
 }

--- a/test/decl/typealias/generic.swift
+++ b/test/decl/typealias/generic.swift
@@ -178,6 +178,8 @@ class GenericClass<T> {
   }
 
   func testCaptureInvalid1<S>(s: S, t: T) -> TA<Int> {
+    // FIXME: https://github.com/swiftlang/swift/issues/89690
+    // Should print "type 'TA<S>'"
     return TA<S>(a: t, b: s) // expected-error {{cannot convert return expression of type 'MyType<T, S>' to return type 'GenericClass<T>.TA<Int>' (aka 'MyType<T, Int>')}}
   }
 


### PR DESCRIPTION
When applying a constraint system solution to a pattern binding initialization, the type stamped onto the pattern was derived from the initializer expression rather than from the type the solver assigned to the pattern itself. When an explicit annotation and the initializer share a canonical type but differ in sugar, coercing the initializer to the annotation type is a no-op that leaves the initializer's own sugar in place, so the pattern and the `VarDecl` printed into the `.swiftinterface` ended up with the initializer's sugar instead of the written annotation.

This is mostly cosmetic, but it turns into a correctness problem when the initializer's sugar names a typealias that isn't visible at the interface's access level. For example, a public stored property annotated with a public alias but initialized from an expression of an internal alias would print the internal alias in the interface, producing a declaration that references a type the interface can't see and breaking interface verification.

For typed patterns, use the pattern's solved type instead of the type derived from the init. Assuming type checking is successful, the two types must share a canonical type so this change only affects the printed sugar.

Resolves rdar://178091149.
