### PR TITLE
[6.4] SIL: fix handling of non-constant address indices in SmallProjectionPath

### DIFF
--- a/SwiftCompilerSources/Sources/SIL/Utilities/SmallProjectionPath.swift
+++ b/SwiftCompilerSources/Sources/SIL/Utilities/SmallProjectionPath.swift
@@ -249,11 +249,15 @@ public struct SmallProjectionPath : Hashable, CustomStringConvertible, NoReflect
     return Self(bytes: b)
   }
 
-  /// Pops the first path component if it is exactly of kind `kind` - not considering wildcards.
+  /// Pops the first path component if it is exactly of kind `kind`.
   ///
   /// Returns the index of the component and the new path or - if not matching - returns nil.
   public func pop(kind: FieldKind) -> (index: Int, path: SmallProjectionPath)? {
     let (k, idx, newPath) = pop()
+    if k == .anyIndexedElement {
+      // Skip a non-constant index, because the index could be 0.
+      return newPath.pop(kind: kind)
+    }
     if k != kind { return nil }
     return (idx, newPath)
   }
@@ -725,6 +729,11 @@ let smallProjectionPathTest = Test("small_projection_path") {
     let p11 = SmallProjectionPath(.anyIndexedElement).push(.indexedElement, index: 1)
     let (k11, i11, p12) = p11.pop()
     assert(k11 == .anyIndexedElement && i11 == 0 && p12.isEmpty)
+
+    let p13 = SmallProjectionPath(.structField, index: 1).push(.anyIndexedElement)
+    let (i13, p14) = p13.pop(kind: .structField)!
+    assert(i13 == 1 && p14.isEmpty)
+    assert(p13.pop(kind: .indexedElement) == nil)
   }
 
   func parsing() {

--- a/SwiftCompilerSources/Sources/SIL/Utilities/WalkUtils.swift
+++ b/SwiftCompilerSources/Sources/SIL/Utilities/WalkUtils.swift
@@ -57,7 +57,7 @@ public protocol WalkingPath : Equatable {
   /// Returns the merged path of this path and `with`.
   func merge(with: Self) -> Self
   
-  /// Pops the first path component if it is exactly of kind `kind` - not considering wildcards.
+  /// Pops the first path component if it is exactly of kind `kind`.
   ///
   /// Returns the index of the component and the new path or - if not matching - returns nil.
   /// Called for destructure instructions during down-walking and for aggregate instructions during up-walking.

--- a/test/SILOptimizer/escape_info_unit.sil
+++ b/test/SILOptimizer/escape_info_unit.sil
@@ -1595,3 +1595,29 @@ bb0:
   dealloc_stack %0
   return %8
 }
+
+// CHECK-LABEL: Escape information for escaping_array_element:
+// CHECK:        -    :   %2 = alloc_ref [stack] [tail_elems $OneF * %1 : $Builtin.Word] $X
+// CHECK:       return[]:   %7 = alloc_ref $F
+// CHECK:       End function escaping_array_element
+sil [ossa] @escaping_array_element : $@convention(thin) (Builtin.Word) -> @owned F {
+bb0(%0 : $Builtin.Word):
+  specify_test "escape_info"
+  %1 = integer_literal $Builtin.Word, 2
+  %2 = alloc_ref [stack] [tail_elems $OneF * %1] $X
+  %3 = begin_borrow %2
+  %4 = ref_tail_addr %3, $OneF
+  %5 = integer_literal $Builtin.Word, 1
+  %6 = index_addr %4, %5
+  %7 = alloc_ref $F
+  %10 = struct $OneF (%7)
+  store %10 to [init] %6
+  %30 = index_addr [stack_protection] %4, %0
+  %31 = load [copy] %30
+  %32 = destructure_struct %31
+  end_borrow %3
+  dealloc_ref %2
+  dealloc_stack_ref %2
+  return %32
+}
+

--- a/test/SILOptimizer/stack_promotion.sil
+++ b/test/SILOptimizer/stack_promotion.sil
@@ -20,6 +20,12 @@ class YY {
 	init(newx: XX)
 }
 
+class C {}
+
+struct S {
+  let c: C
+}
+
 class DummyArrayStorage<Element> {
   @_hasStorage var count : Int
   @_hasStorage var capacity : Int
@@ -1244,5 +1250,28 @@ bb3:
   dealloc_stack %1 : $*XX
   %r = tuple ()
   return %r : $()
+}
+
+// CHECK-LABEL: sil [ossa] @escaping_array_element
+// CHECK:         alloc_ref $C
+// CHECK-LABEL: } // end sil function 'escaping_array_element'
+sil [ossa] @escaping_array_element : $@convention(thin) (Builtin.Word) -> @owned C {
+bb0(%0 : $Builtin.Word):
+  %1 = integer_literal $Builtin.Word, 2
+  %2 = alloc_ref [stack] [tail_elems $S * %1] $DummyArrayStorage<S>
+  %3 = begin_borrow %2
+  %4 = ref_tail_addr %3, $S
+  %5 = integer_literal $Builtin.Word, 1
+  %6 = index_addr %4, %5
+  %7 = alloc_ref $C
+  %10 = struct $S (%7)
+  store %10 to [init] %6
+  %30 = index_addr [stack_protection] %4, %0
+  %31 = load [copy] %30
+  %32 = destructure_struct %31
+  end_borrow %3
+  dealloc_ref %2
+  dealloc_stack_ref %2
+  return %32
 }
 

--- a/test/SILOptimizer/stack_promotion_crash.swift
+++ b/test/SILOptimizer/stack_promotion_crash.swift
@@ -31,7 +31,18 @@ func testit() {
   Delta().main()
 }
 
+protocol P {}
+
+final class C: P {}
+
+@inline(never)
+func test2() -> [P] {
+  let a: [AnyObject?] = [ C(), C(), ]
+  return a.compactMap { $0 as? P }
+}
+
 testit()
+test2()
 
 // CHECK: ok
 print("ok")


### PR DESCRIPTION
* **Explanation**: Fixes a mis-compile caused by invalid escape analysis. When trying to pop a specific element from a SmallProjectionPath, skip `index_addr` with a non-constant index, because the index could be 0. Otherwise `pop` would return nil which lets escape analysis think that there is no match and no escape.
* **Risk**: Low. It's a small change which makes escape analysis more conservative
* **Testing**: by lit tests
* **Issue**: https://github.com/swiftlang/swift/issues/89178, rdar://177183914
* **Reviewers**: @atrick
* **Main branch PR**: https://github.com/swiftlang/swift/pull/89594







