### PR TITLE
[DebugInfo] Salvage enums in SimplifyAllocStack

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyAllocStack.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyAllocStack.swift
@@ -49,7 +49,7 @@ private extension AllocStackInst {
       return false
     }
 
-    let builder = Builder(before: self, context)
+    let builder = Builder(replacing: self, context)
     let newAlloc = builder.createAllocStack(payloadType,
                                             hasDynamicLifetime: hasDynamicLifetime,
                                             isLexical: isLexical,
@@ -57,13 +57,19 @@ private extension AllocStackInst {
                                             usesMoveableValueDebugInfo: usesMoveableValueDebugInfo)
     let oldAllocType = type
     if let varInfo = debugVariable {
-      builder.createDebugValue(value: Undef.get(type: oldAllocType, context), debugVariable: varInfo)
+      // Move the debug variable to a debug_value, so that it gets salvaged by
+      // the logic below.
+      builder.createDebugValue(value: newAlloc, debugVariable: varInfo)
     }
     self.replace(with: newAlloc, context)
 
     context.erase(instructions: nonPayloadDestroys)
 
     newAlloc.rewriteStore(context)
+
+    // Find the unique enum case index before the loop erases these instructions.
+    // If multiple different case indices exist, we can't reconstruct the enum in debug info.
+    let caseIndex: Int? = newAlloc.getUniqueCaseIndex()
 
     for use in newAlloc.uses {
       switch use.instruction {
@@ -74,8 +80,13 @@ private extension AllocStackInst {
       case let uteda as UncheckedEnumDataAddrInstBase where uteda.enum == use.value:
         uteda.replace(with: newAlloc, context)
       case let dv as DebugValueInst:
-        // TODO: Add support for op_enum_fragment
-        dv.operand.set(to: Undef.get(type: oldAllocType, context), context)
+        if let caseIndex {
+          dv.salvageEnumPayload(caseIndex: caseIndex, enumType: oldAllocType.objectType, context)
+        } else {
+          // Kill the operand, and fix the type to be the enum type rather than the payload type.
+          dv.killOperand()
+          dv.operand.set(to: Undef.get(type: oldAllocType.objectType, context), context)
+        }
       case is DestroyAddrInst, is DeallocStackInst, is StoreInst:
         break
       default:
@@ -83,6 +94,29 @@ private extension AllocStackInst {
       }
     }
     return true
+  }
+
+  /// Returns the unique enum case index among all `init_enum_data_addr` and
+  /// `unchecked_take_enum_data_addr` users, or nil if there are multiple
+  /// different case indices.
+  private func getUniqueCaseIndex() -> Int? {
+    var caseIndex: Int? = nil
+    for use in uses {
+      let idx: Int
+      switch use.instruction {
+      case let ieda as InitEnumDataAddrInst:
+        idx = ieda.caseIndex
+      case let uteda as UncheckedEnumDataAddrInstBase where uteda.enum == use.value:
+        idx = uteda.caseIndex
+      default:
+        continue
+      }
+      if let existing = caseIndex, existing != idx {
+        return nil // Found different case indices.
+      }
+      caseIndex = idx
+    }
+    return caseIndex
   }
 
   /// Replace
@@ -519,5 +553,47 @@ private struct EnumCaseUseBlocks : AddressDefUseWalker {
   mutating func leafUse(address: Operand, path: UnusedWalkingPath) -> WalkResult {
     blocks.insert(address.instruction.parentBlock)
     return .continueWalk
+  }
+}
+
+private extension DebugValueInst {
+  /// Salvages debug info when an enum `alloc_stack` is replaced with a payload
+  /// `alloc_stack`.
+  func salvageEnumPayload(caseIndex: Int, enumType: Type, _ context: SimplifyContext) {
+    let operandType = self.operand.value.type
+
+    // Address-only types can't be represented in DWARF expressions.
+    guard operandType.objectType.isLoadable(in: self.parentFunction) else {
+      // Kill the operand, and fix the type to be the enum type rather than the payload type.
+      self.killOperand()
+      self.operand.set(to: Undef.get(type: enumType.addressType, context), context)
+      return
+    }
+
+    // Strip deref: removes the enum load it becomes an object type.
+    self.stripDeref()
+
+    let debugBB = self.getOrCreateDebugReconstructionBlock()
+    guard debugBB.arguments.count > 0 else {
+      // The debug_value was killed if it relied on the address itself.
+      // No salvaging possible.
+      return
+    }
+
+    let oldArg = debugBB.arguments[0]
+
+    // Load from the new alloc_stack (undef placeholder) and wrap it in an enum.
+    let bbBuilder = Builder(atBeginOf: debugBB, location: self.location, context)
+    let loadVal = bbBuilder.createLoad(fromAddress: Undef.get(type: operandType, context),
+                                       ownership: .unqualified)
+    let enumVal = bbBuilder.createEnum(caseIndex: caseIndex, payload: loadVal, enumType: enumType)
+
+    oldArg.uses.replaceAll(with: enumVal, context)
+
+    // Replace the phi arg with correct type, and wire the load's operand.
+    debugBB.eraseArgument(at: 0, context)
+    let newArg = debugBB.insertPhiArgument(
+      atPosition: 0, type: operandType, ownership: .none, context)
+    loadVal.operand.set(to: newArg, context)
   }
 }

--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyAllocStack.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyAllocStack.swift
@@ -84,8 +84,7 @@ private extension AllocStackInst {
           dv.salvageEnumPayload(caseIndex: caseIndex, enumType: oldAllocType.objectType, context)
         } else {
           // Kill the operand, and fix the type to be the enum type rather than the payload type.
-          dv.killOperand()
-          dv.operand.set(to: Undef.get(type: oldAllocType.objectType, context), context)
+          dv.killOperand(withType: oldAllocType)
         }
       case is DestroyAddrInst, is DeallocStackInst, is StoreInst:
         break
@@ -563,10 +562,10 @@ private extension DebugValueInst {
     let operandType = self.operand.value.type
 
     // Address-only types can't be represented in DWARF expressions.
-    guard operandType.objectType.isLoadable(in: self.parentFunction) else {
+    guard operandType.objectType.isLoadable(in: self.parentFunction),
+          enumType.isLoadable(in: self.parentFunction) else {
       // Kill the operand, and fix the type to be the enum type rather than the payload type.
-      self.killOperand()
-      self.operand.set(to: Undef.get(type: enumType.addressType, context), context)
+      self.killOperand(withType: enumType)
       return
     }
 

--- a/SwiftCompilerSources/Sources/SIL/BasicBlock.swift
+++ b/SwiftCompilerSources/Sources/SIL/BasicBlock.swift
@@ -44,6 +44,8 @@ final public class BasicBlock : CustomStringConvertible, HasShortDescription, Ha
 
   public var bridged: BridgedBasicBlock { BridgedBasicBlock(SwiftObject(self)) }
 
+  public var isDebugReconstructionBlock: Bool { bridged.isDebugReconstructionBlock() }
+
   //===----------------------------------------------------------------------===//
   //                                  Arguments
   //===----------------------------------------------------------------------===//

--- a/SwiftCompilerSources/Sources/SIL/Instruction.swift
+++ b/SwiftCompilerSources/Sources/SIL/Instruction.swift
@@ -661,7 +661,9 @@ final public class DebugValueInst : Instruction, UnaryInstruction, DebugVariable
 
   public func stripDeref() { bridged.DebugValue_stripDeref() }
   public func prependDeref() { bridged.DebugValue_prependDeref() }
-  public func killOperand() { bridged.DebugValue_killOperand() }
+  public func killOperand(withType type: Type? = nil) {
+    bridged.DebugValue_killOperand(type?.bridged ?? BridgedType())
+  }
 }
 
 final public class DebugStepInst : Instruction {}

--- a/SwiftCompilerSources/Sources/SIL/Instruction.swift
+++ b/SwiftCompilerSources/Sources/SIL/Instruction.swift
@@ -650,6 +650,18 @@ final public class DebugValueInst : Instruction, UnaryInstruction, DebugVariable
   public var debugVariable: DebugVariable? {
     return bridged.DebugValue_hasVarInfo() ? bridged.DebugValue_getVarInfo() : nil
   }
+
+  public var debugReconstructionBlock: BasicBlock? {
+    bridged.DebugValue_getDebugReconstructionBlock().block
+  }
+
+  public func getOrCreateDebugReconstructionBlock() -> BasicBlock {
+    bridged.DebugValue_getOrCreateDebugReconstructionBlock().block
+  }
+
+  public func stripDeref() { bridged.DebugValue_stripDeref() }
+  public func prependDeref() { bridged.DebugValue_prependDeref() }
+  public func killOperand() { bridged.DebugValue_killOperand() }
 }
 
 final public class DebugStepInst : Instruction {}

--- a/docs/SIL/DebugBasicBlocks.md
+++ b/docs/SIL/DebugBasicBlocks.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-A **debug basic block** is a standalone `SILBasicBlock` attached to a `debug_value` instruction via the `transform` keyword. It contains SIL instructions that describe how to reconstruct a source variable's value from the SSA values that are still alive at that program point. These instructions are not part of the normal program, and are invisible to the optimizer, they are only used to produce DWARF debug info.
+A **debug reconstruction block** (or Debug BB) is a standalone `SILBasicBlock` attached to a `debug_value` instruction via the `transform` keyword. It contains SIL instructions that describe how to reconstruct a source variable's value from the SSA values that are still alive at that program point. These instructions are not part of the normal program, and are invisible to the optimizer, they are only used to produce DWARF debug info.
 
 ## Structure
 
@@ -52,7 +52,9 @@ The terminator is always a regular `return`.
 
 ### Combining with DIExpr
 
-Debug basic blocks coexist with `SILDebugInfoExpression`. When both are present, the `transform` block is evaluated first, then the DIExpr evaluates `op_deref` and fragments.
+Debug basic blocks coexist with `SILDebugInfoExpression`. When both are present, the `transform` block is evaluated first, then the DIExpr evaluates fragments.
+
+### Combining with fragments
 
 For example, when each field of the struct is tracked separately using fragments:
 
@@ -71,6 +73,14 @@ bb0(%0 : $Int):
   return %3
 }
 ```
+
+#### Combining with `op_deref`
+
+Normally (for loadable types), `op_deref` and debug reconstruction blocks are **incompatible**. When a debug BB is created from a `debug_value` that has an `op_deref`, the deref is converted into a `load` instruction in the block
+
+For **address-only types** (types that are not loadable), `op_deref` is kept alongside the debug basic block, as `load` instructions for them cannot be generated.
+
+Because address-only types cannot be loaded or manipulated as values, debug BBs for address-only types are limited. Any salvage operation that would require manipulating the value or rewriting a load, cannot be done on an address-only type, so the operand is killed instead.
 
 ## Optimizer Interaction
 

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -1003,7 +1003,7 @@ struct BridgedInstruction {
   DebugValue_getOrCreateDebugReconstructionBlock() const;
   BRIDGED_INLINE void DebugValue_stripDeref() const;
   BRIDGED_INLINE void DebugValue_prependDeref() const;
-  BRIDGED_INLINE void DebugValue_killOperand() const;
+  BRIDGED_INLINE void DebugValue_killOperand(BridgedType operandType) const;
 
   BRIDGED_INLINE bool AllocStack_hasVarInfo() const;
   BRIDGED_INLINE BridgedSILDebugVariable AllocStack_getVarInfo() const;

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -997,6 +997,14 @@ struct BridgedInstruction {
   BRIDGED_INLINE bool DebugValue_hasVarInfo() const;
   BRIDGED_INLINE BridgedSILDebugVariable DebugValue_getVarInfo() const;
 
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE OptionalBridgedBasicBlock
+  DebugValue_getDebugReconstructionBlock() const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedBasicBlock
+  DebugValue_getOrCreateDebugReconstructionBlock() const;
+  BRIDGED_INLINE void DebugValue_stripDeref() const;
+  BRIDGED_INLINE void DebugValue_prependDeref() const;
+  BRIDGED_INLINE void DebugValue_killOperand() const;
+
   BRIDGED_INLINE bool AllocStack_hasVarInfo() const;
   BRIDGED_INLINE BridgedSILDebugVariable AllocStack_getVarInfo() const;
 
@@ -1067,6 +1075,7 @@ struct BridgedBasicBlock {
   BRIDGED_INLINE void moveAllInstructionsToBegin(BridgedBasicBlock dest) const;
   BRIDGED_INLINE void moveAllInstructionsToEnd(BridgedBasicBlock dest) const;
   BRIDGED_INLINE void moveArgumentsTo(BridgedBasicBlock dest) const;
+  BRIDGED_INLINE bool isDebugReconstructionBlock() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE OptionalBridgedSuccessor getFirstPred() const;
 };
 

--- a/include/swift/SIL/SILBridgingImpl.h
+++ b/include/swift/SIL/SILBridgingImpl.h
@@ -2031,8 +2031,8 @@ void BridgedInstruction::DebugValue_stripDeref() const {
 void BridgedInstruction::DebugValue_prependDeref() const {
   getAs<swift::DebugValueInst>()->prependDeref();
 }
-void BridgedInstruction::DebugValue_killOperand() const {
-  getAs<swift::DebugValueInst>()->killOperand();
+void BridgedInstruction::DebugValue_killOperand(BridgedType operandType) const {
+  getAs<swift::DebugValueInst>()->killOperand(operandType.unbridged());
 }
 
 bool BridgedInstruction::AllocStack_hasVarInfo() const {

--- a/include/swift/SIL/SILBridgingImpl.h
+++ b/include/swift/SIL/SILBridgingImpl.h
@@ -2018,6 +2018,23 @@ BridgedSILDebugVariable BridgedInstruction::DebugValue_getVarInfo() const {
   return BridgedSILDebugVariable(getAs<swift::DebugValueInst>()->getVarInfo().value());
 }
 
+OptionalBridgedBasicBlock BridgedInstruction::DebugValue_getDebugReconstructionBlock() const {
+  return {getAs<swift::DebugValueInst>()->getDebugReconstructionBlock()};
+}
+BridgedBasicBlock BridgedInstruction::DebugValue_getOrCreateDebugReconstructionBlock() const {
+  return {getAs<swift::DebugValueInst>()->getOrCreateDebugReconstructionBlock()};
+}
+
+void BridgedInstruction::DebugValue_stripDeref() const {
+  getAs<swift::DebugValueInst>()->stripDeref();
+}
+void BridgedInstruction::DebugValue_prependDeref() const {
+  getAs<swift::DebugValueInst>()->prependDeref();
+}
+void BridgedInstruction::DebugValue_killOperand() const {
+  getAs<swift::DebugValueInst>()->killOperand();
+}
+
 bool BridgedInstruction::AllocStack_hasVarInfo() const {
   return getAs<swift::AllocStackInst>()->getVarInfo().has_value();
 }
@@ -2129,6 +2146,10 @@ void BridgedBasicBlock::moveAllInstructionsToEnd(BridgedBasicBlock dest) const {
 
 void BridgedBasicBlock::moveArgumentsTo(BridgedBasicBlock dest) const {
   dest.unbridged()->moveArgumentList(unbridged());
+}
+
+bool BridgedBasicBlock::isDebugReconstructionBlock() const {
+  return unbridged()->isDebugReconstructionBlock();
 }
 
 OptionalBridgedSuccessor BridgedBasicBlock::getFirstPred() const {

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -5813,7 +5813,9 @@ public:
   /// value is no longer valid and cannot be salvaged.
   /// This will replace the operand with an undef, and clear any DIExpr or debug
   /// reconstruction block.
-  void killOperand();
+  /// If \p varType is specified, the undef will use that type (in the
+  /// appropriate address/object form) instead of the current operand's type.
+  void killOperand(SILType operandType = SILType());
 
   /// True if all references within this debug value will be overwritten with a
   /// poison sentinel at this point in the program. This is used in debug builds

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -5749,8 +5749,10 @@ public:
     return DVI && DVI->hasAddrVal()? DVI : nullptr;
   }
 
-  /// Whether this debug value has a DIExpr with a deref. If this instruction
-  /// has a debug reconstruction block, this returns false.
+  /// Whether this debug value has a DIExpr with a deref.
+  /// For address-only types with a debug reconstruction block, the deref
+  /// applies after the BB's result. Otherwise, this is incompatible with
+  /// debug reconstruction blocks.
   bool hasDeref() const {
     return sharedUInt8().DebugValueInst.prependDeref;
   }
@@ -5765,6 +5767,7 @@ public:
   /// Removes a deref operator to this debug_value in place.
   /// This must be called when the operand is changed from an address type to
   /// an object type (when moved from the stack to a register, for example).
+  /// Asserts that the type is loadable (cannot strip deref for address-only).
   /// If a reconstruction block exists, a load is removed at the beginning. If
   /// there is no load at the beginning, the operand is killed, marking the
   /// variable as optimized away.

--- a/lib/SIL/IR/SILInstructions.cpp
+++ b/lib/SIL/IR/SILInstructions.cpp
@@ -479,8 +479,8 @@ DebugValueInst *DebugValueInst::create(SILDebugLocation DebugLoc,
 }
 
 void DebugValueInst::prependDeref() {
-  ASSERT(!hasDeref() && "Debug value cannot have two derefs!");
   if (!ReconstructionBlock) {
+    ASSERT(!hasDeref() && "Debug value cannot have two derefs!");
     sharedUInt8().DebugValueInst.prependDeref = true;
     return;
   }
@@ -489,9 +489,14 @@ void DebugValueInst::prependDeref() {
   if (isa<SILUndef>(getOperand()))
     return;
 
+  // If the type is address-only (not loadable or opaque), we cannot insert
+  // a load into the reconstruction block. Kill the operand instead.
+  SILArgument *oldArg = ReconstructionBlock->getArgument(0);
+  if (!oldArg->getType().isLoadableOrOpaque(*getFunction()))
+    return killOperand();
+
   // If we have a reconstruction block, add a load at the beginning.
   SILBuilder builder(ReconstructionBlock->begin());
-  SILArgument *oldArg = ReconstructionBlock->getArgument(0);
   SILType addrType = oldArg->getType().getAddressType();
   SILValue undefAddress = SILUndef::get(getFunction(), addrType);
   LoadInst *load = builder.createLoad(getLoc(), undefAddress,
@@ -506,6 +511,8 @@ void DebugValueInst::stripDeref() {
   // If we have an undef, nothing to do.
   if (isa<SILUndef>(getOperand()))
     return;
+  ASSERT(getOperand()->getType().isLoadableOrOpaque(*getFunction()) &&
+         "cannot strip deref for address-only types");
   if (!ReconstructionBlock) {
     ASSERT(hasDeref() && "Cannot strip deref without one!");
     sharedUInt8().DebugValueInst.prependDeref = false;
@@ -551,22 +558,30 @@ SILBasicBlock *DebugValueInst::getOrCreateDebugReconstructionBlock() {
   SILBuilder builder(block);
 
   SILValue operand = getOperand();
+  bool addressOnly = !operand->getType().isLoadableOrOpaque(*getFunction());
   SILValue retVal;
   if (isa<SILUndef>(operand)) {
     // No arguments, return the same undef directly.
     retVal = operand;
+    // Clear the op_deref, unless we have an address-only type.
+    if (!addressOnly)
+      sharedUInt8().DebugValueInst.prependDeref = false;
   } else if (hasDeref()) {
-    // Convert the deref to a load.
     SILArgument *arg = block->createPhiArgument(
         operand->getType().getAddressType(), OwnershipKind::None);
-    retVal = builder.createLoad(getLoc(), arg,
-                                LoadOwnershipQualifier::Unqualified);
+    if (addressOnly) {
+      // Address-only: keep op_deref, cannot load.
+      retVal = arg;
+    } else {
+      // Convert the deref to a load.
+      retVal = builder.createLoad(getLoc(), arg,
+                                  LoadOwnershipQualifier::Unqualified);
+      sharedUInt8().DebugValueInst.prependDeref = false;
+    }
   } else {
     // Add a block argument matching the operand type.
     retVal = block->createPhiArgument(operand->getType(), OwnershipKind::None);
   }
-  // If the prependDeref flag was set, reset it, including in the undef case.
-  sharedUInt8().DebugValueInst.prependDeref = false;
 
   builder.createReturn(getLoc(), retVal);
   ReconstructionBlock = block;
@@ -588,14 +603,19 @@ void DebugValueInst::killOperand() {
     return;
   }
 
-  // Use the object type because we may be stripping the deref.
-  SILValue undef =
-      SILUndef::get(getFunction(), getOperand()->getType().getObjectType());
+  SILType origType = getOperand()->getType();
+  bool addressOnly = !origType.isLoadableOrOpaque(*getFunction());
+
+  // For address-only types, keep the address type and prependDeref flag.
+  // For loadable types, use the object type and strip prependDeref.
+  SILValue undef = SILUndef::get(getFunction(),
+      addressOnly ? origType : origType.getObjectType());
   setOperand(undef);
 
-  // Strip prependDeref.
+  // Strip prependDeref (unless address-only).
   // The stored DIExpr only contains fragments, which we want to keep.
-  sharedUInt8().DebugValueInst.prependDeref = false;
+  if (!addressOnly)
+    sharedUInt8().DebugValueInst.prependDeref = false;
 
   // Rather than completely removing the debug reconstruction block, remove its
   // argument, as a part of the variable might be constant and recoverable.
@@ -645,11 +665,12 @@ bool DebugValueInst::isExprTypeValid() const {
       if (debugBB->getArgument(0)->getType() != valueType)
         return false;
     }
-    // Cannot have both an op_deref and a debug reconstruction block.
-    if (hasDeref())
-      return false;
     auto *terminator = cast<ReturnInst>(debugBB->getTerminator());
     valueType = terminator->getOperand()->getType();
+    // Cannot have both an op_deref and a debug reconstruction block, unless
+    // the type is genuinely address-only (not loadable or opaque).
+    if (hasDeref() && valueType.isLoadableOrOpaque(*getFunction()))
+      return false;
   }
 
   // Fragments are in the opposite direction, process from right to left.

--- a/lib/SIL/IR/SILInstructions.cpp
+++ b/lib/SIL/IR/SILInstructions.cpp
@@ -597,19 +597,20 @@ void DebugValueInst::cloneReconstructionBlockFrom(DebugValueInst *src) {
   DebugBasicBlockCloner(*getFunction()).clone(srcBB, newBB);
 }
 
-void DebugValueInst::killOperand() {
+void DebugValueInst::killOperand(SILType operandType) {
   if (isa<SILUndef>(getOperand())) {
     // Already undef: no operand to kill.
     return;
   }
 
-  SILType origType = getOperand()->getType();
+  SILType origType = operandType ? operandType : getOperand()->getType();
   bool addressOnly = !origType.isLoadableOrOpaque(*getFunction());
 
   // For address-only types, keep the address type and prependDeref flag.
   // For loadable types, use the object type and strip prependDeref.
-  SILValue undef = SILUndef::get(getFunction(),
-      addressOnly ? origType : origType.getObjectType());
+  SILValue undef =
+      SILUndef::get(getFunction(), addressOnly ? origType.getAddressType()
+                                               : origType.getObjectType());
   setOperand(undef);
 
   // Strip prependDeref (unless address-only).

--- a/test/DebugInfo/dead-store-elimination.sil
+++ b/test/DebugInfo/dead-store-elimination.sil
@@ -57,7 +57,7 @@ bb0(%0 : $MyStruct):
 // When a debug_value has a reconstruction block with no load (e.g.
 // address_to_pointer), stripDeref cannot salvage and calls killOperand.
 // CHECK-LABEL: @dse_salvage_store_strip_deref_kill
-// CHECK: debug_value undef : $MyStruct, let, name "ptr", type $Builtin.RawPointer, transform {
+// CHECK: debug_value undef : {{.+}}, let, name "ptr", type $Builtin.RawPointer, transform {
 // CHECK:   bb0:
 // CHECK:     address_to_pointer undef : $*MyStruct to $Builtin.RawPointer
 // CHECK:     return

--- a/test/DebugInfo/sil_combine.sil
+++ b/test/DebugInfo/sil_combine.sil
@@ -18,8 +18,18 @@ enum MP {
 // CHECK-LABEL: sil @expand_alloc_stack_of_enum_without_take
 // CHECK:        [[A:%[0-9]+]] = alloc_stack $S
 // CHECK-NOT:      name "a"
-// CHECK-NEXT:   debug_value undef : $*MP, let, name "a", type $C, expr op_deref:op_fragment:#C.x
-// CHECK-NEXT:   debug_value undef : $*MP, let, name "b"
+// CHECK-NEXT:   debug_value [[A]] : $*S, let, name "a", type $C, expr op_fragment:#C.x, transform {
+// CHECK:          bb0(%[[ARG1:[0-9]+]] : $*S):
+// CHECK:            %[[LOAD1:[0-9]+]] = load %[[ARG1]] : $*S
+// CHECK:            %[[ENUM1:[0-9]+]] = enum $MP, #MP.A!enumelt, %[[LOAD1]] : $S
+// CHECK:            return %[[ENUM1]] : $MP
+// CHECK:        }
+// CHECK:        debug_value [[A]] : $*S, let, name "b", transform {
+// CHECK:          bb0(%[[ARG2:[0-9]+]] : $*S):
+// CHECK:            %[[LOAD2:[0-9]+]] = load %[[ARG2]] : $*S
+// CHECK:            %[[ENUM2:[0-9]+]] = enum $MP, #MP.A!enumelt, %[[LOAD2]] : $S
+// CHECK:            return %[[ENUM2]] : $MP
+// CHECK:        }
 // CHECK:      bb1:
 // CHECK-NEXT:   store %0 to [[A]]
 // CHECK:      bb2:

--- a/test/DebugInfo/simplify_alloc_stack.sil
+++ b/test/DebugInfo/simplify_alloc_stack.sil
@@ -1,0 +1,84 @@
+// RUN: %target-sil-opt %s -simplification -simplify-instruction=alloc_stack | %FileCheck %s
+
+import Swift
+import Builtin
+
+protocol P {
+  func foo()
+}
+
+// CHECK-LABEL: sil [ossa] @expand_enum_with_debug_value :
+// CHECK:         [[A:%[0-9]+]] = alloc_stack $Int
+// CHECK:         debug_value [[A]], var, name "x", type $Optional<Int>, transform {
+// CHECK:         bb0(%[[ARG:[0-9]+]] : $*Int):
+// CHECK:           %[[LOAD:[0-9]+]] = load %[[ARG]]
+// CHECK:           %[[ENUM:[0-9]+]] = enum $Optional<Int>, #Optional.some!enumelt, %[[LOAD]]
+// CHECK:           return %[[ENUM]]
+// CHECK:         }
+// CHECK:       } // end sil function 'expand_enum_with_debug_value'
+sil [ossa] @expand_enum_with_debug_value : $@convention(thin) (Int) -> () {
+bb0(%0 : $Int):
+  %1 = alloc_stack $Optional<Int>, var, name "x"
+  %2 = init_enum_data_addr %1, #Optional.some!enumelt
+  store %0 to [trivial] %2 : $*Int
+  inject_enum_addr %1, #Optional.some!enumelt
+  %5 = unchecked_take_enum_data_addr %1, #Optional.some!enumelt
+  destroy_addr %5
+  dealloc_stack %1
+  %r = tuple ()
+  return %r : $()
+}
+
+// When the enum payload is an opaque (existential) type, the debug_value
+// cannot be salvaged with a load (IRGen can't emit it). It must be killed.
+// CHECK-LABEL: sil [ossa] @expand_enum_with_opaque_payload :
+// CHECK:         alloc_stack $any P
+// CHECK:         debug_value undef : $*Optional<any P>, var, name "x", type $Optional<any P>, expr op_deref
+// CHECK-NOT:     transform
+// CHECK:       } // end sil function 'expand_enum_with_opaque_payload'
+sil [ossa] @expand_enum_with_opaque_payload : $@convention(thin) (@in any P) -> () {
+bb0(%0 : $*any P):
+  %1 = alloc_stack $Optional<any P>, var, name "x"
+  %2 = init_enum_data_addr %1 : $*Optional<any P>, #Optional.some!enumelt
+  copy_addr [take] %0 to [init] %2 : $*any P
+  inject_enum_addr %1 : $*Optional<any P>, #Optional.some!enumelt
+  %5 = unchecked_take_enum_data_addr %1 : $*Optional<any P>, #Optional.some!enumelt
+  destroy_addr %5 : $*any P
+  dealloc_stack %1 : $*Optional<any P>
+  %r = tuple ()
+  return %r : $()
+}
+
+enum TwoCase {
+  case a(Int)
+  case b(Int)
+}
+
+// When the enum has multiple different case indices, we can't reconstruct
+// the enum in debug info. The debug_value must be killed.
+// CHECK-LABEL: sil [ossa] @expand_enum_mismatching_cases :
+// CHECK:         alloc_stack $Int
+// CHECK:         debug_value undef : $TwoCase, var, name "x"
+// CHECK-NOT:     transform
+// CHECK:       } // end sil function 'expand_enum_mismatching_cases'
+sil [ossa] @expand_enum_mismatching_cases : $@convention(thin) (Int) -> () {
+bb0(%0 : $Int):
+  %1 = alloc_stack $TwoCase, var, name "x"
+  cond_br undef, bb1, bb2
+bb1:
+  %2 = init_enum_data_addr %1 : $*TwoCase, #TwoCase.a!enumelt
+  store %0 to [trivial] %2 : $*Int
+  inject_enum_addr %1 : $*TwoCase, #TwoCase.a!enumelt
+  br bb3
+bb2:
+  %3 = init_enum_data_addr %1 : $*TwoCase, #TwoCase.b!enumelt
+  store %0 to [trivial] %3 : $*Int
+  inject_enum_addr %1 : $*TwoCase, #TwoCase.b!enumelt
+  br bb3
+bb3:
+  %5 = unchecked_take_enum_data_addr %1 : $*TwoCase, #TwoCase.a!enumelt
+  destroy_addr %5 : $*Int
+  dealloc_stack %1 : $*TwoCase
+  %r = tuple ()
+  return %r : $()
+}

--- a/test/DebugInfo/sroa_debug_value.sil
+++ b/test/DebugInfo/sroa_debug_value.sil
@@ -71,7 +71,7 @@ sil_scope 3 { loc "sroa.swift":20:6 parent @sroa_kills_debug_reconstruction_bloc
 // CHECK-SROA-LABEL: sil {{.+}} @sroa_kills_debug_reconstruction_block
 // When a debug_value has a reconstruction block, SROA cannot append fragments.
 // Instead it kills the operand (replaces with undef) and preserves the block.
-// CHECK-SROA: debug_value undef : $MyStruct, let, name "ptr", type $Builtin.RawPointer, transform {
+// CHECK-SROA: debug_value undef : {{.+}}, let, name "ptr", type $Builtin.RawPointer, transform {
 // CHECK-SROA:   bb0:
 // CHECK-SROA:     address_to_pointer undef : $*MyStruct to $Builtin.RawPointer
 // CHECK-SROA:     return


### PR DESCRIPTION
Review commit by commit, explanations are in the long commit message
The address-only fix is needed to avoid crashes when salvaging enums of address only types.

As this replaces the logic to set the variable to undef, this doesn't decrease the amount of lost variables.
At the DWARF level, it increases the amount of variables with a value by 0.02%