### PR TITLE
[6.4] 🍒 Restore NaN printing behavior that matches documented guarantees

### DIFF
--- a/stdlib/public/core/FloatingPointTypes.swift.gyb
+++ b/stdlib/public/core/FloatingPointTypes.swift.gyb
@@ -133,6 +133,11 @@ extension ${Self}: CustomDebugStringConvertible {
 ${Availability(bits)}
 extension ${Self}: TextOutputStreamable {
   public func write<Target>(to target: inout Target) where Target: TextOutputStream {
+    if isNaN {
+      // Match `description`.
+      target.write("nan")
+      return
+    }
     var buffer = _InlineArray<64, UTF8.CodeUnit>(repeating: 0x30)
     var span = buffer.mutableSpan
     let textRange = _Float${bits}ToASCII(value: self, buffer: &span)

--- a/test/stdlib/PrintFloat.swift.gyb
+++ b/test/stdlib/PrintFloat.swift.gyb
@@ -645,6 +645,17 @@ PrintTests.test("Printable_Float") {
   expectNaN("snan(0xffff)", Float(nan: 65535, signaling: true))
   expectNaN("-snan(0xffff)", -Float(nan: 65535, signaling: true))
   expectNaN("snan(0x1fffff)", Float(bitPattern: 0x7fbf_ffff))
+  // Streamed, interpolated, and printed forms should always match "nan".
+  do {
+    let value = -Float(nan: 65535, signaling: true)
+    var streamed = ""
+    value.write(to: &streamed)
+    expectEqual("nan", streamed)
+    expectEqual("nan", "\(value)")
+    var printed = ""
+    print(value, terminator: "", to: &printed)
+    expectEqual("nan", printed)
+  }
 
   // Every power of 10 should print with only a single digit '1'
 #if arch(arm)


### PR DESCRIPTION
**Explanation**: Aligns NaN printing behavior with that of (some) older versions, and to be consistent with documentation.
**Scope**: Limited to an early exit after writing "nan" in `TextOutputStreamable.write` implementation of concrete stdlib floating-point types.
**Issue**: #89496 
**Risk**: Low. NaN printing behavior was not stable from point release to point release, and never tested.
**Testing**: New regression tests were added.
**Original PR**: #89579 
**Reviewer**: @tbkka 
