### PR TITLE
[cxx-interop] Fix assertion failure for macros in bridging header

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -959,7 +959,7 @@ static ModuleDecl *getModuleContextForNameLookupForCxxDecl(const Decl *decl) {
     return nullptr;
   }
 
-  auto clangModule = clangImporter->getClangOwningModule(decl->getClangDecl());
+  auto clangModule = clangImporter->getClangOwningModule(decl->getClangNode());
   if (!clangModule)
     return nullptr;
 

--- a/test/Interop/C/macros/Inputs/numeric-macro-bridging-header.h
+++ b/test/Interop/C/macros/Inputs/numeric-macro-bridging-header.h
@@ -1,0 +1,1 @@
+#define SOME_NUMERIC_CONSTANT 42

--- a/test/Interop/C/macros/numeric-macro-bridging-header.swift
+++ b/test/Interop/C/macros/numeric-macro-bridging-header.swift
@@ -1,0 +1,7 @@
+// RUN: %target-typecheck-verify-swift -enable-upcoming-feature MemberImportVisibility -import-objc-header %S/Inputs/numeric-macro-bridging-header.h %s
+// RUN: %target-typecheck-verify-swift -enable-upcoming-feature MemberImportVisibility -import-objc-header %S/Inputs/numeric-macro-bridging-header.h -cxx-interoperability-mode=default %s
+
+// REQUIRES: swift_feature_MemberImportVisibility
+
+let x = SOME_NUMERIC_CONSTANT
+_ = x


### PR DESCRIPTION
When `MemberImportVisibility` upcoming feature is enabled, the typechecker tries to determine the owning module of C/C++ macros used in Swift.

That logic didn't handle bridging headers correctly, and triggered an assertion failure:
```
Assertion failed: (Node.getAsMacroInfo()), function getClangOwningModule, file ClangImporter.cpp, line 3612.
```

rdar://178264720

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
