### PR TITLE
[6.4][android] Copy over new API note for API 23 with new Runtimes/ config (#89599)

### DIFF
--- a/Runtimes/Overlay/Android/clang/CMakeLists.txt
+++ b/Runtimes/Overlay/Android/clang/CMakeLists.txt
@@ -34,6 +34,7 @@ install(FILES
   SwiftBionic.h
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/swift/${SwiftOverlay_PLATFORM_SUBDIR}/${SwiftOverlay_ARCH_SUBDIR})
 install(FILES
+  _stdio.apinotes
   posix_filesystem.apinotes
   spawn.apinotes
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/swift/apinotes)

--- a/Runtimes/Resync.cmake
+++ b/Runtimes/Resync.cmake
@@ -139,6 +139,7 @@ message(STATUS "Android modulemaps[${StdlibSources}/Platform] -> ${CMAKE_CURRENT
 copy_files(public/Platform Overlay/Android/clang
   FILES
     android.modulemap
+    _stdio.apinotes
     posix_filesystem.apinotes
     spawn.apinotes
     SwiftAndroidNDK.h


### PR DESCRIPTION
- **Explanation**: The new API note was added in #88751 as part of the stdlib/ config.
- **Scope**: Only affects the 6.4 Android SDK in the Windows toolchain
- **Issues**: none
- **Original pull**: #89599
- **Risk**: very low
- **Testing**: A [trunk PR toolchain CI run passed with Android enabled](https://ci-external.swift.org/job/swift-PR-build-toolchain-windows/6563/console).
- **Reviewers**: @compnerd