### PR TITLE
[ClangImporter] Import 'const T *' self on ~Copyable types as borrowing

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4169,6 +4169,7 @@ namespace {
       ImportedType resultType;
       bool selfIsInOut = false;
       bool selfIsConsuming = false;
+      bool selfIsBorrowing = false;
       ParameterList *bodyParams = nullptr;
       if (!dc->isModuleScopeContext() && !isClangNamespace(dc) &&
           !isa<clang::CXXMethodDecl>(decl)) {
@@ -4199,6 +4200,14 @@ namespace {
                       selfParamTy->getPointeeType().getCanonicalType())
                     selfIsInOut = false;
             }
+          } else if ((selfParamTy->isPointerType() ||
+                      selfParamTy->isReferenceType()) &&
+                     selfParamTy->getPointeeType().isConstQualified()) {
+            // A 'const T *' / 'const T &' self is a borrow. On a ~Copyable type
+            // 'nonmutating' would lower to a consuming 'in', so use 'borrowing'.
+            if (auto *selfNominal = dc->getSelfNominalTypeDecl())
+              selfIsBorrowing =
+                  selfNominal->getAttrs().hasAttribute<MoveOnlyAttr>();
           }
         }
 
@@ -4294,7 +4303,8 @@ namespace {
           } else if (selfIsInOut) {
             func->setSelfAccessKind(SelfAccessKind::Mutating);
           } else {
-            if (getImplicitObjectParamAnnotation<clang::LifetimeBoundAttr>(
+            if (selfIsBorrowing ||
+                getImplicitObjectParamAnnotation<clang::LifetimeBoundAttr>(
                     decl))
               func->setSelfAccessKind(SelfAccessKind::Borrowing);
             else

--- a/test/Interop/C/struct/Inputs/module.modulemap
+++ b/test/Interop/C/struct/Inputs/module.modulemap
@@ -19,6 +19,10 @@ module NoncopyableStructs {
   header "noncopyable-struct.h"
 }
 
+module NoncopyableMethod {
+  header "noncopyable-method.h"
+}
+
 module ReturnForeignReference {
   header "return-foreign-reference.h"
 }

--- a/test/Interop/C/struct/Inputs/noncopyable-method.h
+++ b/test/Interop/C/struct/Inputs/noncopyable-method.h
@@ -1,0 +1,23 @@
+#include "swift/bridging"
+
+// A ~Copyable C struct with a destroy operation.
+typedef struct SWIFT_NONCOPYABLE_WITH_DESTROY(Handle_deinit) Handle {
+  int value;
+} Handle;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void Handle_deinit(Handle handle);
+
+// 'const Handle *self' is a borrow: on a ~Copyable type it must import as a
+// borrowing method, else 'self' lowers to consuming 'in'.
+int Handle_read(const Handle *self, int id) SWIFT_NAME(Handle.read(self:id:));
+
+// Non-const 'Handle *self' must stay mutating.
+void Handle_update(Handle *self, int id) SWIFT_NAME(Handle.update(self:id:));
+
+#ifdef __cplusplus
+}
+#endif

--- a/test/Interop/C/struct/noncopyable-borrowing-self.swift
+++ b/test/Interop/C/struct/noncopyable-borrowing-self.swift
@@ -1,0 +1,32 @@
+// A C method taking 'const T *self' on a ~Copyable type imports as 'borrowing
+// self', so it can be called through a borrow such as a stored property.
+
+// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs -I %swift_src_root/lib/ClangImporter/SwiftBridging %s
+
+// RUN: %target-swift-frontend -emit-silgen -I %S/Inputs -I %swift_src_root/lib/ClangImporter/SwiftBridging %s | %FileCheck %s
+
+import NoncopyableMethod
+
+// 'const Handle *self' must lower to borrowed (@in_guaranteed), not consumed (@in).
+// CHECK: [clang Handle.read] {{.*}}@convention(c) (@in_guaranteed Handle, Int32) -> Int32
+// Non-const 'Handle *self' must stay mutating (@inout).
+// CHECK: [clang Handle.update] {{.*}}@convention(c) (@inout Handle, Int32) -> ()
+
+struct Container: ~Copyable {
+  var handle: Handle
+
+  // Before the fix 'self' was consuming, so this failed: "noncopyable
+  // 'self.handle' cannot be consumed when ... borrowed".
+  borrowing func readThroughProperty(_ id: CInt) -> CInt {
+    return handle.read(id: id)
+  }
+
+  // Non-const 'Handle *self' must remain mutating.
+  mutating func updateThroughProperty(_ id: CInt) {
+    handle.update(id: id)
+  }
+}
+
+func callThroughBorrow(_ c: borrowing Container) -> CInt {
+  return c.readThroughProperty(5)
+}


### PR DESCRIPTION
A pointer/reference to const is a borrow, not a consume. Import such 'self' as 'borrowing' so it lowers to '@in_guaranteed', matching native Swift and C++ const methods.

rdar://178057648

