### PR TITLE
[SILOptimizer] VariableNameInferrer: name call results after their callee

### DIFF
--- a/include/swift/SILOptimizer/Utils/VariableNameUtils.h
+++ b/include/swift/SILOptimizer/Utils/VariableNameUtils.h
@@ -258,6 +258,13 @@ public:
   static StringRef getNameFromDecl(Decl *d);
 
 private:
+  /// Helper that names the result of a call (apply / try_apply / begin_apply),
+  /// looking through partial_apply / conversions to the underlying callee and
+  /// walking into self to produce 'self.member'. Defined out-of-line in
+  /// VariableNameUtils.cpp. Holds a back-reference to its owning inferrer so it
+  /// can push path components and stash state across queries.
+  struct CallResultNamer;
+
   void drainVariableNamePath();
 
   /// Push \p name onto the variable name path, recording \p providingLoc

--- a/lib/SILOptimizer/Utils/VariableNameUtils.cpp
+++ b/lib/SILOptimizer/Utils/VariableNameUtils.cpp
@@ -356,9 +356,107 @@ constexpr StringLiteral UnknownDeclString = "<unknown decl>";
 
 } // namespace
 
+/// Helper that names the result of a call. Looks through partial_apply and
+/// closure-forming / conversion instructions on the callee to recover the
+/// underlying function reference, and recovers the call's self value (directly
+/// or as captured by a partial_apply) so the result can be named 'self.member'.
+///
+/// Holds a back-reference to its owning inferrer so it can push path components
+/// and (in the future) stash state across queries.
+struct VariableNameInferrer::CallResultNamer {
+  VariableNameInferrer &owner;
+
+  explicit CallResultNamer(VariableNameInferrer &owner) : owner(owner) {}
+
+  /// The call (apply / try_apply / begin_apply) that produces \p value, if
+  /// any. 'apply' and 'begin_apply' produce their result as the defining
+  /// instruction; a 'try_apply' delivers its result as the normal successor's
+  /// block argument, so look through the terminator in that case.
+  static FullApplySite getCallProducing(SILValue value) {
+    if (auto *inst = value->getDefiningInstruction())
+      return FullApplySite::isa(inst);
+    if (auto *arg = dyn_cast<SILArgument>(value))
+      if (auto *term = arg->getTerminatorForResult())
+        return FullApplySite::isa(term);
+    return FullApplySite();
+  }
+
+  /// Strip closure-forming / conversion / ownership-forwarding instructions
+  /// from a callee value (everything except partial_apply itself).
+  static SILValue stripCalleeConversions(SILValue v) {
+    while (isa<ThinToThickFunctionInst>(v) || isa<ConvertFunctionInst>(v) ||
+           isa<ConvertEscapeToNoEscapeInst>(v) || isa<CopyValueInst>(v) ||
+           isa<BeginBorrowInst>(v) || isa<MoveValueInst>(v)) {
+      v = cast<SingleValueInstruction>(v)->getOperand(0);
+    }
+    return v;
+  }
+
+  /// The user-facing name of the function/method invoked by \p call, or an
+  /// empty StringRef if one cannot be determined. Looks through an
+  /// immediately-invoked partial_apply to the underlying function reference.
+  StringRef getCalleeName(FullApplySite call) const {
+    SILValue callee = stripCalleeConversions(call.getCallee());
+    while (auto *pai = dyn_cast<PartialApplyInst>(callee))
+      callee = stripCalleeConversions(pai->getCallee());
+
+    // A dynamically dispatched method (class_method, witness_method, ...): use
+    // the referenced member's name (which also handles accessors).
+    if (auto *mi = dyn_cast<MethodInst>(callee))
+      return getNameFromDecl(mi->getMember().getDecl());
+
+    // A direct call: prefer the referenced function's own decl name.
+    if (auto *f = dyn_cast<FunctionRefBaseInst>(callee)) {
+      auto *fn = f->getInitiallyReferencedFunction();
+      if (auto declRef = fn->getDeclRef())
+        if (auto *decl = declRef.getDecl())
+          return getNameFromDecl(decl);
+      // Fall back to the SILFunction's name (e.g. for SIL-only declarations
+      // that carry no AST decl).
+      return fn->getName();
+    }
+
+    return StringRef();
+  }
+
+  /// The self value associated with \p call, if any: either the call's own
+  /// self argument (a direct method call) or, when the callee is a
+  /// partial_apply that captured self, that captured self. Self is always the
+  /// last parameter, so a non-empty partial_apply of a method captures it as
+  /// its last applied argument.
+  SILValue getCalleeSelfValue(FullApplySite call) const {
+    if (call.hasSelfArgument())
+      return call.getSelfArgument();
+    SILValue callee = stripCalleeConversions(call.getCallee());
+    if (auto *pai = dyn_cast<PartialApplyInst>(callee)) {
+      ApplySite site(pai);
+      if (site.getSubstCalleeType()->hasSelfParam() &&
+          site.getNumArguments() >= 1)
+        return site.getArgument(site.getNumArguments() - 1);
+    }
+    return SILValue();
+  }
+
+  /// If \p call can be named, push the callee (member) name and return its
+  /// self value so the walk continues into it -- producing 'self.member'.
+  /// Returns SILValue() if there is no name or no self.
+  SILValue nameThroughSelf(FullApplySite call) {
+    auto name = getCalleeName(call);
+    if (name.empty())
+      return SILValue();
+    auto self = getCalleeSelfValue(call);
+    if (!self)
+      return SILValue();
+    owner.pushPathComponent(name, call.getLoc().getSourceLoc());
+    return self;
+  }
+};
+
 SILValue VariableNameInferrer::findDebugInfoProvidingValueHelper(
     SILValue searchValue, ValueSet &visitedValues) {
   assert(searchValue);
+
+  CallResultNamer namer(*this);
 
   while (true) {
     assert(searchValue);
@@ -580,43 +678,26 @@ SILValue VariableNameInferrer::findDebugInfoProvidingValueHelper(
       }
     }
 
-    auto getNamePathComponentFromCallee = [&](FullApplySite call) -> SILValue {
-      // Use the name of the property being accessed if we can get to it.
-      if (call.getSubstCalleeType()->hasSelfParam()) {
-        if (auto *f = dyn_cast<FunctionRefBaseInst>(call.getCallee())) {
-          if (auto dc = f->getInitiallyReferencedFunction()->getDeclContext()) {
-            pushPathComponent(getNameFromDecl(dc->getAsDecl()),
-                              call.getLoc().getSourceLoc());
-            return call.getSelfArgument();
-          }
-        }
+    // Name a call result (apply / try_apply / begin_apply). Read/modify
+    // (begin_apply) accessors are always looked through; other calls only when
+    // InferSelfThroughAllAccessors is set.
+    if (auto fas = CallResultNamer::getCallProducing(searchValue)) {
+      bool isBeginApply = isa<BeginApplyInst>(fas.getInstruction());
+      if (isBeginApply ||
+          options.contains(Flag::InferSelfThroughAllAccessors)) {
+        if (auto name = namer.getCalleeName(fas); !name.empty()) {
+          pushPathComponent(name, fas.getLoc().getSourceLoc());
 
-        if (auto *mi = dyn_cast<MethodInst>(call.getCallee())) {
-          pushPathComponent(getNameFromDecl(mi->getMember().getDecl()),
-                            call.getLoc().getSourceLoc());
-          return call.getSelfArgument();
-        }
-      }
-
-      return SILValue();
-    };
-
-    // Read or modify accessor.
-    if (auto bai = dyn_cast_or_null<BeginApplyInst>(
-            searchValue->getDefiningInstruction())) {
-      if (auto selfParam = getNamePathComponentFromCallee(bai)) {
-        searchValue = selfParam;
-        continue;
-      }
-    }
-
-    if (options.contains(Flag::InferSelfThroughAllAccessors)) {
-      if (auto *inst = searchValue->getDefiningInstruction()) {
-        if (auto fas = FullApplySite::isa(inst)) {
-          if (auto selfParam = getNamePathComponentFromCallee(fas)) {
-            searchValue = selfParam;
+          // If there is a self value (directly, or captured by a
+          // partial_apply), continue into it to produce 'self.member'.
+          if (auto self = namer.getCalleeSelfValue(fas)) {
+            searchValue = self;
             continue;
           }
+
+          // Otherwise treat the result as the root, naming it after the
+          // callee.
+          return searchValue;
         }
       }
     }
@@ -625,7 +706,7 @@ SILValue VariableNameInferrer::findDebugInfoProvidingValueHelper(
     if (searchValue->isBorrowAccessorResult()) {
       if (auto fas =
               FullApplySite::isa(searchValue->getDefiningInstruction())) {
-        if (auto selfParam = getNamePathComponentFromCallee(fas)) {
+        if (auto selfParam = namer.nameThroughSelf(fas)) {
           searchValue = selfParam;
           continue;
         }
@@ -646,8 +727,7 @@ SILValue VariableNameInferrer::findDebugInfoProvidingValueHelper(
       }
 
       if (addressorInvocation) {
-        if (auto selfParam =
-                getNamePathComponentFromCallee(addressorInvocation)) {
+        if (auto selfParam = namer.nameThroughSelf(addressorInvocation)) {
           searchValue = selfParam;
           continue;
         }

--- a/test/SILOptimizer/moveonly_addresschecker_diagnostics.sil
+++ b/test/SILOptimizer/moveonly_addresschecker_diagnostics.sil
@@ -656,7 +656,7 @@ bb0(%0 : $*NonTrivialStruct, %1 : $*NonTrivialStructPair):
   %5 = function_ref @nontrivialstruct_borrow : $@convention(method) (@in_guaranteed NonTrivialStructPair) -> @guaranteed_address NonTrivialStruct
   %6 = apply %5(%3) : $@convention(method) (@in_guaranteed NonTrivialStructPair) -> @guaranteed_address NonTrivialStruct
   %7 = mark_unresolved_non_copyable_value [no_consume_or_assign] %6 : $*NonTrivialStruct
-  // expected-error @-1 {{'unknown' is borrowed and cannot be consumed}}
+  // expected-error @-1 {{'self.nontrivialstruct_borrow' is borrowed and cannot be consumed}}
   copy_addr %7 to [init] %0 : $*NonTrivialStruct
   // expected-note @-1 {{consumed here}}
   %9 = tuple ()

--- a/test/SILOptimizer/moveonly_unsafeAddress.sil
+++ b/test/SILOptimizer/moveonly_unsafeAddress.sil
@@ -45,7 +45,7 @@ bb0(%0 : $*SNC):
   %8 = pointer_to_address %7 : $Builtin.RawPointer to [strict] $*NC
   %9 = mark_dependence [nonescaping] %8 : $*NC on %3 : $*SNC
   %10 = begin_access [read] [unsafe] %9 : $*NC
-  %11 = mark_unresolved_non_copyable_value [no_consume_or_assign] %10 : $*NC  // expected-error {{'unknown' is borrowed and cannot be consumed}}
+  %11 = mark_unresolved_non_copyable_value [no_consume_or_assign] %10 : $*NC  // expected-error {{'snc.unsafeAddressor' is borrowed and cannot be consumed}}
   %12 = load [copy] %11 : $*NC
   end_access %10 : $*NC
   end_borrow %4 : $SNC

--- a/test/SILOptimizer/variable_name_inference.sil
+++ b/test/SILOptimizer/variable_name_inference.sil
@@ -26,10 +26,18 @@ class KlassWithKlassPair {
   var ns2: (KlassPair, KlassPair) { get }
 }
 
+class MyError {}
+class C {}
+
 sil @getKlass : $@convention(thin) () -> @owned Klass
 sil @getContainsKlass : $@convention(thin) () -> @owned ContainsKlass
 sil @useIndirect : $@convention(thin) <T> (@in_guaranteed T) -> ()
 sil @sideEffect : $@convention(thin) () -> ()
+sil @getKlassThrows : $@convention(thin) () -> (@owned Klass, @error MyError)
+sil @getKlassCoro : $@yield_once @convention(thin) () -> @yields @owned Klass
+sil @C_throwingMethod : $@convention(method) (@guaranteed C) -> (@owned Klass, @error MyError)
+sil @C_method : $@convention(method) (@owned C) -> @owned Klass
+sil @freeFunc : $@convention(thin) (@owned C) -> @owned Klass
 
 enum FakeOptional<T> {
 case none
@@ -811,10 +819,12 @@ bb0:
   return %9999 : $()
 }
 
+// A plain move_value (no [var_decl]) does not carry a name, but we can still
+// recover one by naming the result after the callee that produced it.
 // CHECK-LABEL: begin running test 1 of 1 on move_value_var_decl_3: variable_name_inference with: @trace[0]
 // CHECK-LABEL: Input Value:   %1 = apply %0() : $@convention(thin) () -> @owned Klass
-// CHECK-LABEL: Name: 'unknown'
-// CHECK-LABEL: Root: 'unknown'
+// CHECK-LABEL: Name: 'getKlass'
+// CHECK-LABEL: Root:   %1 = apply %0() : $@convention(thin) () -> @owned Klass
 // CHECK-LABEL: end running test 1 of 1 on move_value_var_decl_3: variable_name_inference with: @trace[0]
 sil [ossa] @move_value_var_decl_3 : $@convention(thin) () -> () {
 bb0:
@@ -867,10 +877,12 @@ bb0:
   return %9999 : $()
 }
 
+// A plain begin_borrow (no [var_decl]) does not carry a name, but we can still
+// recover one by naming the result after the callee that produced it.
 // CHECK-LABEL: begin running test 1 of 1 on begin_borrow_var_decl_3: variable_name_inference with: @trace[0]
 // CHECK: Input Value:   %1 = apply %0() : $@convention(thin) () -> @owned Klass
-// CHECK: Name: 'unknown'
-// CHECK: Root: 'unknown'
+// CHECK: Name: 'getKlass'
+// CHECK: Root:   %1 = apply %0() : $@convention(thin) () -> @owned Klass
 // CHECK: end running test 1 of 1 on begin_borrow_var_decl_3: variable_name_inference with: @trace[0]
 sil [ossa] @begin_borrow_var_decl_3 : $@convention(thin) () -> () {
 bb0:
@@ -936,6 +948,143 @@ bb0:
   debug_value %0 : $@convention(thin) () -> (), let, name "closure"
   %1 = convert_function %0 : $@convention(thin) () -> () to $@convention(thin) () -> ()
   debug_value [trace] %0 : $@convention(thin) () -> ()
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+//===----------------------------------------------------------------------===//
+// MARK: Call results (apply / try_apply / begin_apply)
+//
+// A bare call result that carries no other debug info is named after the
+// callee. If the callee has a self argument, we instead produce
+// 'self.member' by walking into self.
+//===----------------------------------------------------------------------===//
+
+// No self argument: name the 'apply' result after the callee function.
+// CHECK-LABEL: begin running test 1 of 1 on apply_result_callee_name: variable_name_inference with: @trace[0]
+// CHECK: Input Value:   %1 = apply %0() : $@convention(thin) () -> @owned Klass
+// CHECK: Name: 'getKlass'
+// CHECK: Root:   %1 = apply %0() : $@convention(thin) () -> @owned Klass
+// CHECK: end running test 1 of 1 on apply_result_callee_name: variable_name_inference with: @trace[0]
+sil [ossa] @apply_result_callee_name : $@convention(thin) () -> () {
+bb0:
+  specify_test "variable_name_inference @trace[0]"
+  %0 = function_ref @getKlass : $@convention(thin) () -> @owned Klass
+  %r = apply %0() : $@convention(thin) () -> @owned Klass
+  debug_value [trace] %r : $Klass
+  destroy_value %r : $Klass
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// No self argument: name the 'try_apply' result (delivered as the normal
+// successor's block argument) after the callee function.
+// CHECK-LABEL: begin running test 1 of 1 on try_apply_result_callee_name: variable_name_inference with: @trace[0]
+// CHECK: Input Value: %2 = argument of bb1 : $Klass
+// CHECK: Name: 'getKlassThrows'
+// CHECK: Root: %2 = argument of bb1 : $Klass
+// CHECK: end running test 1 of 1 on try_apply_result_callee_name: variable_name_inference with: @trace[0]
+sil [ossa] @try_apply_result_callee_name : $@convention(thin) () -> () {
+bb0:
+  specify_test "variable_name_inference @trace[0]"
+  %0 = function_ref @getKlassThrows : $@convention(thin) () -> (@owned Klass, @error MyError)
+  try_apply %0() : $@convention(thin) () -> (@owned Klass, @error MyError), normal bb1, error bb2
+
+bb1(%r : @owned $Klass):
+  debug_value [trace] %r : $Klass
+  destroy_value %r : $Klass
+  %9999 = tuple ()
+  return %9999 : $()
+
+bb2(%e : @owned $MyError):
+  destroy_value %e : $MyError
+  unreachable
+}
+
+// No self argument: name the 'begin_apply' yield after the callee function.
+// CHECK-LABEL: begin running test 1 of 1 on begin_apply_result_callee_name: variable_name_inference with: @trace[0]
+// CHECK: Input Value: (**%1**, %2) = begin_apply %0() : $@yield_once @convention(thin) () -> @yields @owned Klass
+// CHECK: Name: 'getKlassCoro'
+// CHECK: Root: (**%1**, %2) = begin_apply %0() : $@yield_once @convention(thin) () -> @yields @owned Klass
+// CHECK: end running test 1 of 1 on begin_apply_result_callee_name: variable_name_inference with: @trace[0]
+sil [ossa] @begin_apply_result_callee_name : $@convention(thin) () -> () {
+bb0:
+  specify_test "variable_name_inference @trace[0]"
+  %0 = function_ref @getKlassCoro : $@yield_once @convention(thin) () -> @yields @owned Klass
+  (%v, %token) = begin_apply %0() : $@yield_once @convention(thin) () -> @yields @owned Klass
+  debug_value [trace] %v : $Klass
+  destroy_value %v : $Klass
+  end_apply %token as $()
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// With a self argument: walk into self and produce 'self.member' for a
+// try_apply result.
+// CHECK-LABEL: begin running test 1 of 1 on try_apply_result_self_member: variable_name_inference with: @trace[0]
+// CHECK: Input Value: %4 = argument of bb1 : $Klass
+// CHECK: Name: 'myC.C_throwingMethod'
+// CHECK: Root: %0 = argument of bb0 : $C
+// CHECK: end running test 1 of 1 on try_apply_result_self_member: variable_name_inference with: @trace[0]
+sil [ossa] @try_apply_result_self_member : $@convention(thin) (@guaranteed C) -> () {
+bb0(%0 : @guaranteed $C):
+  debug_value %0 : $C, let, name "myC"
+  specify_test "variable_name_inference @trace[0]"
+  %f = function_ref @C_throwingMethod : $@convention(method) (@guaranteed C) -> (@owned Klass, @error MyError)
+  try_apply %f(%0) : $@convention(method) (@guaranteed C) -> (@owned Klass, @error MyError), normal bb1, error bb2
+
+bb1(%r : @owned $Klass):
+  debug_value [trace] %r : $Klass
+  destroy_value %r : $Klass
+  %9999 = tuple ()
+  return %9999 : $()
+
+bb2(%e : @owned $MyError):
+  destroy_value %e : $MyError
+  unreachable
+}
+
+// Immediately-invoked partial_apply that captures self: look through the
+// partial_apply to the underlying function_ref, and since self was captured,
+// produce 'self.member'.
+// CHECK-LABEL: begin running test 1 of 1 on pa_self_method: variable_name_inference with: @trace[0]
+// CHECK: Input Value:   %5 = apply %4() : $@callee_guaranteed () -> @owned Klass
+// CHECK: Name: 'myC.C_method'
+// CHECK: Root: %0 = argument of bb0 : $C
+// CHECK: end running test 1 of 1 on pa_self_method: variable_name_inference with: @trace[0]
+sil [ossa] @pa_self_method : $@convention(thin) (@guaranteed C) -> () {
+bb0(%0 : @guaranteed $C):
+  debug_value %0 : $C, let, name "myC"
+  specify_test "variable_name_inference @trace[0]"
+  %f = function_ref @C_method : $@convention(method) (@owned C) -> @owned Klass
+  %c = copy_value %0 : $C
+  %pa = partial_apply [callee_guaranteed] %f(%c) : $@convention(method) (@owned C) -> @owned Klass
+  %r = apply %pa() : $@callee_guaranteed () -> @owned Klass
+  debug_value [trace] %r : $Klass
+  destroy_value %r : $Klass
+  destroy_value %pa : $@callee_guaranteed () -> @owned Klass
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// Immediately-invoked partial_apply with no self: still look through it to the
+// underlying function_ref.
+// CHECK-LABEL: begin running test 1 of 1 on pa_no_self: variable_name_inference with: @trace[0]
+// CHECK: Input Value:   %5 = apply %4() : $@callee_guaranteed () -> @owned Klass
+// CHECK: Name: 'freeFunc'
+// CHECK: Root:   %5 = apply %4() : $@callee_guaranteed () -> @owned Klass
+// CHECK: end running test 1 of 1 on pa_no_self: variable_name_inference with: @trace[0]
+sil [ossa] @pa_no_self : $@convention(thin) (@guaranteed C) -> () {
+bb0(%0 : @guaranteed $C):
+  debug_value %0 : $C, let, name "myC"
+  specify_test "variable_name_inference @trace[0]"
+  %f = function_ref @freeFunc : $@convention(thin) (@owned C) -> @owned Klass
+  %c = copy_value %0 : $C
+  %pa = partial_apply [callee_guaranteed] %f(%c) : $@convention(thin) (@owned C) -> @owned Klass
+  %r = apply %pa() : $@callee_guaranteed () -> @owned Klass
+  debug_value [trace] %r : $Klass
+  destroy_value %r : $Klass
+  destroy_value %pa : $@callee_guaranteed () -> @owned Klass
   %9999 = tuple ()
   return %9999 : $()
 }


### PR DESCRIPTION
VariableNameInferrer previously failed to infer a name for the result of a call when the result carried no other debug info. In particular:

  - 'try_apply' results were never handled at all: the result is delivered as the normal successor's block argument, so it has no defining instruction and never reached the apply-handling code.
  - The 'function_ref'-with-self path pushed the callee's *decl context* name (often '<unknown decl>') rather than the callee's own name.
  - A bare call result (no self, no debug info) was left unnamed.

As a result, region-isolation diagnostics such as the 'inout sending' returned-value error fell through to the catch-all "please file a bug" unknown-pattern diagnostic for ordinary code like:

    func f(mutex: borrowing Mutex<[NS]>) -> [NS] {
        mutex.withLock { items in items.filter { _ in true } }
    }

Now a name is recovered uniformly for apply / try_apply / begin_apply results:

  - If the callee has a self argument, walk into self and produce 'self.member'.
  - Otherwise, name the result after the callee function itself.

The 'filter' example above now produces a clear, named diagnostic ("'items.filter' cannot be returned") instead of the unknown-pattern error.

Adds naming tests for apply/try_apply/begin_apply results (with and without self), and updates two move-only diagnostics whose inferred names improved from 'unknown' to 'self.<accessor>'.

rdar://178534561

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
