### PR TITLE
[6.4.x] Remove warning from docs for `withUnsafeTemporaryAllocation()` about overallocation.

### DIFF
--- a/stdlib/public/core/TemporaryAllocation.swift
+++ b/stdlib/public/core/TemporaryAllocation.swift
@@ -212,10 +212,6 @@ internal func _fallBackToHeapAllocation<R: ~Copyable, E: Error>(
 /// initializing the buffer pointer before it is used _and_ for deinitializing
 /// it before returning, but deallocation is automatic.
 ///
-/// The implementation may allocate a larger buffer pointer than is strictly
-/// necessary to contain `byteCount` bytes. The behavior of a program that
-/// attempts to access any such additional storage is undefined.
-///
 /// The buffer pointer passed to `body` (as well as any pointers to elements in
 /// the buffer) must not escape. It will be deallocated when `body` returns and
 /// cannot be used afterward.
@@ -367,10 +363,6 @@ public func _withUnprotectedUnsafeTemporaryAllocation<R: ~Copyable, E: Error>(
 /// in an unspecified, uninitialized state. `body` is responsible for
 /// initializing the buffer pointer before it is used _and_ for deinitializing
 /// it before returning, but deallocation is automatic.
-///
-/// The implementation may allocate a larger buffer pointer than is strictly
-/// necessary to contain `capacity` values of type `type`. The behavior of a
-/// program that attempts to access any such additional storage is undefined.
 ///
 /// The buffer pointer passed to `body` (as well as any pointers to elements in
 /// the buffer) must not escape. It will be deallocated when `body` returns and


### PR DESCRIPTION
- **Explanation**: Reduce the scare factor of the documentation for `withUnsafeTemporaryAllocation()`.
- **Scope**: Documentation
- **Issues**: N/A
- **Original PRs**: https://github.com/swiftlang/swift/pull/89467
- **Risk**: N/A (docs only)
- **Testing**: N/A (docs only)
- **Reviewers**: @glessard