### PR TITLE
[6.4.x] Runtimes: add vendor extension point for shims

### DIFF
--- a/Runtimes/Core/SwiftShims/swift/shims/CMakeLists.txt
+++ b/Runtimes/Core/SwiftShims/swift/shims/CMakeLists.txt
@@ -43,3 +43,5 @@ target_compile_options(swiftShims INTERFACE
 install(TARGETS swiftShims
   EXPORT SwiftCoreTargets
   COMPONENT SwiftCore_development)
+
+include("${SwiftCore_VENDOR_MODULE_DIR}/swiftShims.cmake" OPTIONAL)


### PR DESCRIPTION
**Explanation:**
This adds a vendor extension point for shims, which is needed to support changes to Apple's internal configurations.

**Scope:**
Part of the runtimes build system that deals with installing the shims

**Issues:**
rdar://177631069

**Original PRs:**
main -- https://github.com/swiftlang/swift/pull/89468

**Risk:**
Low:
* this uses the same mechanism used for other extension points
* the inclusion in itself will not cause issue because we don't require the file to exist
* no configuration at the moment is using this extension point

**Testing:**
* CI testing
* verified at desk that the extension point is triggered when adding `swiftShims.cmake` to `Runtimes/Core/cmake/modules/vendor`

**Reviewers:**
@justice-adams-apple 