### PR TITLE
[Caching] Improve swift caching remarks

### DIFF
--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -503,7 +503,8 @@ GROUPED_ERROR(error_caching_no_cas_fs, CompilationCaching, none,
 GROUPED_ERROR(error_option_incompatible, CompilationCaching, none,
     "'%0' is incompatible with '%1'", (StringRef, StringRef))
 
-REMARK(replay_output, none, "replay output file '%0': key '%1'", (StringRef, StringRef))
+REMARK(replay_output, none, "replay output file '%0': id '%1'", (StringRef, StringRef))
+REMARK(output_cache_hit, none, "cache hit for input file '%0': key '%1'", (StringRef, StringRef))
 REMARK(output_cache_miss, none, "cache miss for input file '%0': key '%1'", (StringRef, StringRef))
 
 // CAS related diagnostics

--- a/lib/Frontend/CachingUtils.cpp
+++ b/lib/Frontend/CachingUtils.cpp
@@ -299,11 +299,11 @@ static bool replayCachedCompilerOutputsImpl(
                     toString(std::move(E)));
       return failedReplay();
     }
-  }
 
-  if (CacheRemarks)
-    Diag.diagnose(SourceLoc(), diag::replay_output, "<cached-diagnostics>",
-                  DiagnosticsOutput->Key.toString());
+    if (CacheRemarks)
+      Diag.diagnose(SourceLoc(), diag::replay_output, "<cached-diagnostics>",
+                    DiagnosticsOutput->Proxy.getID().toString());
+  }
 
   // Replay the result only when everything is resolved.
   for (auto &Output : OutputProxies) {
@@ -350,7 +350,7 @@ static bool replayCachedCompilerOutputsImpl(
     }
     if (CacheRemarks)
       Diag.diagnose(SourceLoc(), diag::replay_output, Output.Path,
-                    Output.Key.toString());
+                    Output.Proxy.getID().toString());
   }
 
   if (DiagHelper)
@@ -392,6 +392,10 @@ bool replayCachedCompilerOutputs(
                       OutID.toString());
       return std::nullopt;
     }
+
+    if (CacheRemarks)
+      Diag.diagnose(SourceLoc(), diag::output_cache_hit, InputPath,
+                    OutID.toString());
 
     return *OutputRef;
   };

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -822,7 +822,8 @@ static bool ParseCASArgs(CASOptions &Opts, ArgList &Args,
   using namespace options;
   Opts.EnableCaching |= Args.hasFlag(
       OPT_cache_compile_job, OPT_no_cache_compile_job, /*Default=*/false);
-  Opts.EnableCachingRemarks |= Args.hasArg(OPT_cache_remarks);
+  Opts.EnableCachingRemarks |= Args.hasArg(OPT_cache_remarks) ||
+                               ::getenv("SWIFT_ENABLE_COMPILE_CACHE_REMARK");
   Opts.CacheSkipReplay |= Args.hasArg(OPT_cache_disable_replay);
   Opts.WriteOutputHashXAttr |= Args.hasArg(OPT_write_output_hash_xattr);
   if (const Arg *A = Args.getLastArg(OPT_cas_path))

--- a/test/CAS/cache-remarks.swift
+++ b/test/CAS/cache-remarks.swift
@@ -1,0 +1,39 @@
+// REQUIRES: !legacy_swift_driver
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: env SWIFT_ENABLE_COMPILE_CACHE_REMARK=1 %swiftc_driver -module-name Test -O -c -explicit-module-build -module-cache-path %t/clang-module-cache \
+// RUN:   -Xfrontend -disable-implicit-string-processing-module-import -Xfrontend -disable-implicit-concurrency-module-import -Xfrontend -parse-stdlib \
+// RUN:   %t/main.swift -o %t/main.o -swift-version 5 -cache-compile-job -cas-path %t/cas -I %t/include 2>&1 | %FileCheck %s --check-prefix=CACHE-MISS
+
+// RUN: %empty-directory(%t/clang-module-cache)
+// RUN: env SWIFT_ENABLE_COMPILE_CACHE_REMARK=1 %swiftc_driver -module-name Test -O -c -explicit-module-build -module-cache-path %t/clang-module-cache \
+// RUN:   -Xfrontend -disable-implicit-string-processing-module-import -Xfrontend -disable-implicit-concurrency-module-import -Xfrontend -parse-stdlib \
+// RUN:   %t/main.swift -o %t/main.o -swift-version 5 -cache-compile-job -cas-path %t/cas -I %t/include 2>&1 | %FileCheck %s --check-prefix=CACHE-HIT
+
+// CACHE-MISS-COUNT-3: remark: cache miss
+// CACHE-MISS-NOT: remark: cache hit
+
+// CACHE-HIT-COUNT-3: remark: cache hit
+// CACHE-HIT-NOT: remark: cache miss
+
+//--- main.swift
+import A
+import C
+
+//--- single.swift
+
+//--- include/module.modulemap
+module A {
+  header "A.h"
+  export *
+}
+
+//--- include/A.h
+void a(void);
+
+//--- include/C.swiftinterface
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name C -O -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib -user-module-version 1.0
+public func c() { }

--- a/test/CAS/cache_replay.swift
+++ b/test/CAS/cache_replay.swift
@@ -42,11 +42,11 @@
 // RUN:  -module-name Test -o %t/test.o -cas-path %t/cas @%t/MyApp.cmd 2>&1 | %FileCheck --allow-empty --check-prefix=SKIP-CACHE %s
 
 // CACHE-MISS: remark: cache miss for input
-// CACHE-HIT: remark: replay output file '<cached-diagnostics>': key 'llvmcas://{{.*}}'
-// CACHE-HIT: remark: replay output file '{{.*}}{{/|\\}}test.o': key 'llvmcas://{{.*}}'
-// CACHE-HIT: remark: replay output file '{{.*}}{{/|\\}}Test.swiftmodule': key 'llvmcas://{{.*}}'
-// CACHE-HIT-CLANG: remark: replay output file '<cached-diagnostics>': key 'llvmcas://{{.*}}'
-// CACHE-HIT-CLANG: remark: replay output file '{{.*}}{{/|\\}}Dummy-{{.*}}.pcm': key 'llvmcas://{{.*}}'
+// CACHE-HIT: remark: replay output file '<cached-diagnostics>': id 'llvmcas://{{.*}}'
+// CACHE-HIT: remark: replay output file '{{.*}}{{/|\\}}test.o': id 'llvmcas://{{.*}}'
+// CACHE-HIT: remark: replay output file '{{.*}}{{/|\\}}Test.swiftmodule': id 'llvmcas://{{.*}}'
+// CACHE-HIT-CLANG: remark: replay output file '<cached-diagnostics>': id 'llvmcas://{{.*}}'
+// CACHE-HIT-CLANG: remark: replay output file '{{.*}}{{/|\\}}Dummy-{{.*}}.pcm': id 'llvmcas://{{.*}}'
 // SKIP-CACHE-NOT: remark:
 
 //--- test.swift

--- a/test/CAS/cache_replay_mccas.swift
+++ b/test/CAS/cache_replay_mccas.swift
@@ -49,11 +49,11 @@
 // RUN:  -module-name Test -o %t/test.o -cas-path %t/cas @%t/MyApp.cmd 2>&1 | %FileCheck --allow-empty --check-prefix=SKIP-CACHE %s
 
 // CACHE-MISS: remark: cache miss for input
-// CACHE-HIT: remark: replay output file '<cached-diagnostics>': key 'llvmcas://{{.*}}'
-// CACHE-HIT: remark: replay output file '{{.*}}{{/|\\}}test.o': key 'llvmcas://{{.*}}'
-// CACHE-HIT: remark: replay output file '{{.*}}{{/|\\}}Test.swiftmodule': key 'llvmcas://{{.*}}'
-// CACHE-HIT-CLANG: remark: replay output file '<cached-diagnostics>': key 'llvmcas://{{.*}}'
-// CACHE-HIT-CLANG: remark: replay output file '{{.*}}{{/|\\}}Dummy-{{.*}}.pcm': key 'llvmcas://{{.*}}'
+// CACHE-HIT: remark: replay output file '<cached-diagnostics>': id 'llvmcas://{{.*}}'
+// CACHE-HIT: remark: replay output file '{{.*}}{{/|\\}}test.o': id 'llvmcas://{{.*}}'
+// CACHE-HIT: remark: replay output file '{{.*}}{{/|\\}}Test.swiftmodule': id 'llvmcas://{{.*}}'
+// CACHE-HIT-CLANG: remark: replay output file '<cached-diagnostics>': id 'llvmcas://{{.*}}'
+// CACHE-HIT-CLANG: remark: replay output file '{{.*}}{{/|\\}}Dummy-{{.*}}.pcm': id 'llvmcas://{{.*}}'
 // SKIP-CACHE-NOT: remark:
 
 //--- test.swift

--- a/test/CAS/dependency_file.swift
+++ b/test/CAS/dependency_file.swift
@@ -30,7 +30,7 @@
 // RUN:   -module-name Test -explicit-swift-module-map-file @%t/map.casid \
 // RUN:   %t/main.swift @%t/MyApp.cmd -emit-dependencies -emit-dependencies-path %t/main-2.d 2>&1 | %FileCheck %s --check-prefix=CACHE-HIT
 
-// CACHE-HIT: remark: replay output file '{{.*}}{{/|\\}}main-2.d': key 'llvmcas://{{.*}}'
+// CACHE-HIT: remark: replay output file '{{.*}}{{/|\\}}main-2.d': id 'llvmcas://{{.*}}'
 
 // RUN: %FileCheck %s --check-prefix=DEPS2 --input-file=%t/main-2.d -DTMP=%t
 // DEPS2: [[TMP]]{{/|\\}}main-2.o :
@@ -74,7 +74,7 @@
 // RUN:   -module-name Test -explicit-swift-module-map-file @%t/map.casid \
 // RUN:   -cache-replay-prefix-map /^src %swift_src_root -cache-replay-prefix-map /^tmp %t -cache-replay-prefix-map /^sdk %t/sdk \
 // RUN:   /^tmp/main.swift @%t/MyApp-1.cmd -emit-dependencies -emit-dependencies-path %t/main-4.d 2>&1 | %FileCheck %s --check-prefix=CACHE-HIT4
-// CACHE-HIT4: remark: replay output file '{{.*}}{{/|\\}}main-4.d': key 'llvmcas://{{.*}}'
+// CACHE-HIT4: remark: replay output file '{{.*}}{{/|\\}}main-4.d': id 'llvmcas://{{.*}}'
 // RUN: %FileCheck %s --check-prefix=DEPS4 --input-file=%t/main-4.d -DTMP=%t
 // DEPS4: [[TMP]]{{/|\\}}main-4.o : [[TMP]]{{/|\\}}main.swift
 

--- a/test/CAS/opt-record.swift
+++ b/test/CAS/opt-record.swift
@@ -24,8 +24,8 @@
 // RUN: not %FileCheck %s --check-prefix=YAML --input-file=%t/record-1.yaml
 
 // CACHE-MISS: remark: cache miss for input
-// CACHE-HIT: remark: replay output file '<cached-diagnostics>': key 'llvmcas://{{.*}}'
-// CACHE-HIT: remark: replay output file '{{.*}}{{/|\\}}test.o': key 'llvmcas://{{.*}}'
+// CACHE-HIT: remark: replay output file '<cached-diagnostics>': id 'llvmcas://{{.*}}'
+// CACHE-HIT: remark: replay output file '{{.*}}{{/|\\}}test.o': id 'llvmcas://{{.*}}'
 // YAML: ---
 
 var a: Int = 1

--- a/test/CAS/output_hash_xattr.swift
+++ b/test/CAS/output_hash_xattr.swift
@@ -33,7 +33,7 @@
 // CHECK: 00000030  {{(([A-F0-9]{2} ){16})}}|
 
 // CACHE-MISS: remark: cache miss for input
-// CACHE-HIT: remark: replay output file '{{.*}}{{/|\\}}test.o': key 'llvmcas://{{.*}}'
+// CACHE-HIT: remark: replay output file '{{.*}}{{/|\\}}test.o': id 'llvmcas://{{.*}}'
 
 /// Check that -write-output-hash-xattr with -cas-backend is an error.
 // RUN: not %target-swift-frontend-plain -c -cache-compile-job \

--- a/test/CAS/symbol-graph.swift
+++ b/test/CAS/symbol-graph.swift
@@ -32,8 +32,8 @@
 // RUN:   -emit-symbol-graph -emit-symbol-graph-dir %t/symbol-graph2 \
 // RUN:   -emit-module @%t/Test.cmd -Rcache-compile-job 2>&1 | %FileCheck %s --check-prefix=CACHE-HIT
 
-// CACHE-HIT: remark: replay output file '{{.*}}{{/|\\}}symbol-graph2{{/|\\}}Test.symbols.json': key 'llvmcas://{{.*}}'
-// CACHE-HIT: remark: replay output file '{{.*}}{{/|\\}}symbol-graph2{{/|\\}}Test@A.symbols.json': key 'llvmcas://{{.*}}'
+// CACHE-HIT: remark: replay output file '{{.*}}{{/|\\}}symbol-graph2{{/|\\}}Test.symbols.json': id 'llvmcas://{{.*}}'
+// CACHE-HIT: remark: replay output file '{{.*}}{{/|\\}}symbol-graph2{{/|\\}}Test@A.symbols.json': id 'llvmcas://{{.*}}'
 
 // RUN: diff -r -u %t/symbol-graph1 %t/symbol-graph2
 


### PR DESCRIPTION
Make swift caching remarks more friendly to use by:
* Allow environmental variable `SWIFT_ENABLE_COMPILE_CACHE_REMARK` to control if the remarks are emitted or not. This avoids updating and reconfiguring build flags just to see the caching remarks.
* Add a new cache hit remark on top of the existing cache replay output remarks. Cache output replay remark is one per output, while cache hit remark is one per invocation. This allows better cache hit/miss rate calculation just based on the number of remarks emitted.

rdar://178563432

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
