### PR TITLE
Pack env vars into a struct and initialize them all at once, rather than lazily populating the _isSet flags on access. In most cases this should go from O(n) writes to 0, since none of them will be set

### DIFF
--- a/include/swift/Runtime/EnvironmentVariables.h
+++ b/include/swift/Runtime/EnvironmentVariables.h
@@ -38,11 +38,14 @@ using uint32 = uint32_t;
 using optional_uint8 = std::optional<uint8_t>;
 } // namespace types
 
-// Declare backing variables.
+struct EnvironmentVariableState {
 #define VARIABLE(name, type, defaultValue, help)                               \
-  extern swift::runtime::environment::types::type name##_variable;             \
-  extern bool name##_isSet_variable;
+  types::type name##_variable;                                                 \
+  bool name##_isSet_variable;
 #include "../../../stdlib/public/runtime/EnvironmentVariables.def"
+};
+
+extern EnvironmentVariableState environmentVariableState;
 
 // Define getter functions. This creates one function with the same name as the
 // variable which returns the value set for that variable, and second function
@@ -52,11 +55,11 @@ using optional_uint8 = std::optional<uint8_t>;
 #define VARIABLE(name, type, defaultValue, help)                               \
   inline swift::runtime::environment::types::type name() {                     \
     swift::once(initializeToken, initialize, nullptr);                         \
-    return name##_variable;                                                    \
+    return environmentVariableState.name##_variable;                           \
   }                                                                            \
   inline bool name##_isSet() {                                                 \
     swift::once(initializeToken, initialize, nullptr);                         \
-    return name##_isSet_variable;                                              \
+    return environmentVariableState.name##_isSet_variable;                     \
   }
 #include "../../../stdlib/public/runtime/EnvironmentVariables.def"
 

--- a/stdlib/public/runtime/EnvironmentVariables.cpp
+++ b/stdlib/public/runtime/EnvironmentVariables.cpp
@@ -164,12 +164,13 @@ void printHelp(const char *extra) {
 
 } // end anonymous namespace
 
-// Define backing variables.
+swift::runtime::environment::EnvironmentVariableState
+    swift::runtime::environment::environmentVariableState = {
 #define VARIABLE(name, type, defaultValue, help)                               \
-  swift::runtime::environment::types::type                                     \
-      swift::runtime::environment::name##_variable = defaultValue;             \
-  bool swift::runtime::environment::name##_isSet_variable = false;
+  /* name##_variable        = */ defaultValue,                                 \
+  /* name##_isSet_variable  = */ false,
 #include "EnvironmentVariables.def"
+};
 
 // Initialization code.
 swift::once_t swift::runtime::environment::initializeToken;
@@ -203,8 +204,8 @@ static void platformInitialize(void *context) {
 #define SYSPROP_PREFIX "debug.org.swift.runtime."
 #define VARIABLE(name, type, defaultValue, help)                \
   if (__system_property_get(SYSPROP_PREFIX #name, buffer)) {    \
-    swift::runtime::environment::name##_isSet_variable = true;  \
-    swift::runtime::environment::name##_variable =              \
+    environmentVariableState.name##_isSet_variable = true;      \
+    environmentVariableState.name##_variable =                  \
         parse_##type(#name, buffer, defaultValue);              \
   }
 #include "EnvironmentVariables.def"
@@ -229,30 +230,29 @@ void swift::runtime::environment::initialize(void *context) {
 
   bool SWIFT_DEBUG_HELP_variable = false;
 
-  // Placeholder variable, we never use the result but the macros want to write
-  // to it.
-  bool SWIFT_DEBUG_HELP_isSet_variable = false;
-  (void)SWIFT_DEBUG_HELP_isSet_variable; // Silence warnings about unused vars.
   for (char **var = ENVIRON; *var; var++) {
     // Immediately skip anything without a SWIFT_ prefix.
     if (strncmp(*var, "SWIFT_", 6) != 0)
       continue;
 
     bool foundVariable = false;
-    // Check each defined variable in turn, plus SWIFT_DEBUG_HELP. Variables are
-    // parsed by functions named parse_<type> above. An unknown type will
-    // produce an error that parse_<unknown-type> doesn't exist. Add new parsers
-    // above.
+    // Handle SWIFT_DEBUG_HELP separately since it's not in the .def file.
+    if (strncmp(*var, "SWIFT_DEBUG_HELP=",
+                strlen("SWIFT_DEBUG_HELP=")) == 0) {
+      SWIFT_DEBUG_HELP_variable = parse_boolean(
+          "SWIFT_DEBUG_HELP", *var + strlen("SWIFT_DEBUG_HELP="), false);
+      foundVariable = true;
+    }
+    // Check each defined variable in turn. Variables are parsed by functions
+    // named parse_<type> above. An unknown type will produce an error that
+    // parse_<unknown-type> doesn't exist. Add new parsers above.
 #define VARIABLE(name, type, defaultValue, help)                               \
   if (strncmp(*var, #name "=", strlen(#name "=")) == 0) {                      \
-    name##_variable =                                                          \
+    environmentVariableState.name##_variable =                                 \
         parse_##type(#name, *var + strlen(#name "="), defaultValue);           \
-    name##_isSet_variable = true;                                              \
+    environmentVariableState.name##_isSet_variable = true;                     \
     foundVariable = true;                                                      \
   }
-    // SWIFT_DEBUG_HELP is not in the variables list. Parse it like the other
-    // variables.
-    VARIABLE(SWIFT_DEBUG_HELP, boolean, false, )
 #include "EnvironmentVariables.def"
 
     // Flag unknown SWIFT_DEBUG_ variables to catch misspellings. We don't flag
@@ -284,8 +284,9 @@ void swift::runtime::environment::initialize(void *context) {
   do {                                                                         \
     const char *name##_string = getenv(#name);                                 \
     if (name##_string)                                                         \
-      name##_isSet_variable = true;                                            \
-    name##_variable = parse_##type(#name, name##_string, defaultValue);        \
+      environmentVariableState.name##_isSet_variable = true;                   \
+    environmentVariableState.name##_variable =                                 \
+        parse_##type(#name, name##_string, defaultValue);                      \
   } while (0);
 #include "EnvironmentVariables.def"
 


### PR DESCRIPTION
Fixes rdar://178564603