### PR TITLE
SILGen: laziness fixes for properties defined in secondary files

### DIFF
--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -1613,6 +1613,9 @@ void SILGenFunction::emitMemberInitializer(DeclContext *dc, VarDecl *selfDecl,
   assert(!field->isStatic());
 
   for (auto i : range(field->getNumPatternEntries())) {
+    if (auto *var = field->getAnchoringVarDecl(i))
+      (void)var->getImplInfo(); // trigger expansion of attached accessor macros
+
     auto init = field->getExecutableInit(i);
     if (!init)
       continue;

--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -1571,6 +1571,9 @@ void SILGenFunction::emitMemberInitializationViaInitAccessor(
   if (!init)
     return;
 
+  // Force the pattern's type to be resolved.
+  (void)member->getCheckedPatternBindingEntry(0);
+
   auto *varPattern = member->getPattern(0);
 
   // Cleanup after this initialization.
@@ -1650,6 +1653,9 @@ void SILGenFunction::emitMemberInitializer(DeclContext *dc, VarDecl *selfDecl,
       }
     }
     }
+
+    // Force the pattern's type to be resolved.
+    (void)field->getCheckedPatternBindingEntry(i);
 
     auto *varPattern = field->getPattern(i);
 

--- a/test/SILGen/Inputs/accessor_macro_multifile_other.swift
+++ b/test/SILGen/Inputs/accessor_macro_multifile_other.swift
@@ -1,0 +1,7 @@
+@attached(accessor, names: named(get))
+public macro AddGetter() = #externalMacro(module: "MacroDefinition", type: "AddGetterMacro")
+
+public struct Holder {
+  @AddGetter
+  var foo: Int = 0
+}

--- a/test/SILGen/Inputs/init_accessor_multifile_other.swift
+++ b/test/SILGen/Inputs/init_accessor_multifile_other.swift
@@ -1,0 +1,15 @@
+public struct Holder {
+  var foo: Int {
+    @storageRestrictions(initializes: backing)
+    init(initialValue) {}
+    get { fatalError() }
+  }
+
+  var backing: Int
+
+  var bar: Int = 0 {
+    @storageRestrictions(initializes: backing)
+    init(initialValue) {}
+    get { fatalError() }
+  }
+}

--- a/test/SILGen/accessor_macro_multifile.swift
+++ b/test/SILGen/accessor_macro_multifile.swift
@@ -1,0 +1,14 @@
+// REQUIRES: swift_swift_parser
+
+// RUN: %empty-directory(%t)
+// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/../Macros/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath
+
+// RUN: %target-swift-emit-silgen -load-plugin-library %t/%target-library-name(MacroDefinition) -primary-file %s %S/Inputs/accessor_macro_multifile_other.swift -module-name AccMacroMulti | %FileCheck %s
+
+extension Holder {
+  public init(action f: () -> Void) {}
+}
+
+// CHECK-LABEL: sil [ossa] @$s13AccMacroMulti6HolderV6actionACyyXE_tcfC :
+// CHECK-NOT:     struct_element_addr {{.*}} #Holder.foo
+// CHECK:       } // end sil function '$s13AccMacroMulti6HolderV6actionACyyXE_tcfC'

--- a/test/SILGen/init_accessor_multifile.swift
+++ b/test/SILGen/init_accessor_multifile.swift
@@ -1,0 +1,11 @@
+// RUN: %target-swift-emit-silgen -primary-file %s %S/Inputs/init_accessor_multifile_other.swift -module-name InitAccMulti | %FileCheck %s
+
+// Constructor in this file implicitly refers to Holder's stored properties declared in
+// the other file. Triggers a case where the type of a property may not be resolved
+// during SILGen in emitMemberInitializationViaInitAccessor.
+
+extension Holder {
+  public init(action f: () -> Void) {}
+}
+
+// CHECK-LABEL: sil [ossa] @$s12InitAccMulti6HolderV6actionACyyXE_tcfC :


### PR DESCRIPTION
Member properties of a type defined in a non-primary file can end up having several kinds of Sema requests that are not triggered. This was causing crashing in SILGen with regards to emitting an initializer for that type within an extension of the primary file, as the type of the pattern and macros attached to that property were not computed. Thus, the answers SILGen was getting were stale. In the case of uncomputed type, it was getting a `Type()` back, and for the macro that changes it to a computed property, we were treating it like a stored property.

resolves rdar://176892954
Resolves #89653