### PR TITLE
[Test] Add a test for member attribute macro providing availability

### DIFF
--- a/test/Macros/member_attribute_macro_availability.swift
+++ b/test/Macros/member_attribute_macro_availability.swift
@@ -1,0 +1,43 @@
+// REQUIRES: swift_swift_parser
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// Build the macro plugin.
+// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %t/macro.swift -g -no-toolchain-stdlib-rpath
+
+// RUN: %target-swift-frontend -typecheck -verify -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) %t/test.swift
+
+//--- macro.swift
+import SwiftSyntax
+import SwiftSyntaxMacros
+
+/// Attaches `@available(*, unavailable)` to every member of the annotated type.
+public struct UnavailableMembersMacro: MemberAttributeMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    attachedTo decl: some DeclGroupSyntax,
+    providingAttributesFor member: some DeclSyntaxProtocol,
+    in context: some MacroExpansionContext
+  ) throws -> [AttributeSyntax] {
+    ["@available(*, unavailable, message: \"unavailable via macro\")"]
+  }
+}
+
+//--- test.swift
+@attached(memberAttribute)
+macro UnavailableMembers() = #externalMacro(module: "MacroDefinition", type: "UnavailableMembersMacro")
+
+@UnavailableMembers
+class Base {
+  func member() {} // expected-note 2 {{'member()' has been explicitly marked unavailable here}}
+}
+
+class Sub: Base {
+  override func member() {} // expected-error {{cannot override 'member' which has been marked unavailable: unavailable via macro}}
+  // expected-note@-1 {{remove 'override' modifier to declare a new 'member'}}
+}
+
+func useBaseMember(_ b: Base) {
+  b.member() // expected-error {{'member()' is unavailable: unavailable via macro}}
+}


### PR DESCRIPTION
Add a test to try to ensure we don't break member attribute macros interaction with availability macros in the future. It would be nice to request macro expansion inside `getSemanticAvailableAttrs` but that leads to a cycle (Presumably the expansion causes availability to be checked? Didn't investigate further). This test is probably insufficient, but it's a start. Found this potential gap while working on SE-0478. It seems fine in practice...