### PR TITLE
DeadStoreElimination: ignore memory effects of `end_borrow`.

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/DeadStoreElimination.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/DeadStoreElimination.swift
@@ -232,7 +232,10 @@ private struct InstructionScanner {
         if ds.isStackDeallocation(of: storePath.base) {
           return .dead
         }
-      case is FixLifetimeInst, is EndAccessInst, is DebugValueInst:
+      case is FixLifetimeInst, is EndAccessInst, is EndBorrowInst, is DebugValueInst:
+        // The memory effects of `end_access` and `end_borrow` are primarily there to prevent moving
+        // memory operations _out_ of the scope. Therefore those instructions are not relevant for
+        // dead-store-elimination.
         break
       case let term as TermInst:
         if term.isFunctionExiting {

--- a/test/SILOptimizer/dead_store_elim.sil
+++ b/test/SILOptimizer/dead_store_elim.sil
@@ -162,6 +162,25 @@ bb0(%0 : $AB, %1 : $Int):
   return %18 : $()
 }
 
+// CHECK-LABEL: sil [ossa] @dead_store_across_borrow_scopes :
+// CHECK-NOT:     store
+// CHECK:         end_borrow
+// CHECK:         begin_borrow
+// CHECK:         store %1
+// CHECK:       end sil function 'dead_store_across_borrow_scopes'
+sil [ossa] @dead_store_across_borrow_scopes : $@convention(thin) (@owned AB, Int) -> @owned AB {
+bb0(%0 : @owned $AB, %1 : $Int):
+  %2 = begin_borrow %0
+  %3 = ref_element_addr %2, #AB.value
+  store %1 to [trivial] %3
+  end_borrow %2
+  %6 = begin_borrow %0
+  %7 = ref_element_addr %6, #AB.value
+  store %1 to [trivial] %7
+  end_borrow %6
+  return %0
+}
+
 // We should be able to remove the local store that is not read.
 //
 // CHECK-LABEL: trivial_local_dead_store


### PR DESCRIPTION
The memory effects of `end_borrow` are primarily there to prevent moving memory operations _out_ of the scope. Therefore `end_borrow` not relevant for dead-store-elimination.
