### PR TITLE
Clarify what 'new Swift parser' means

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -2129,9 +2129,9 @@ ERROR(extra_tokens_after_expression,PointsToFirstBadToken,
       "extra tokens after expression in macro expansion", ())
 
 ERROR(parser_round_trip_error,none,
-      "source file did not round-trip through the new Swift parser", ())
+      "source file did not round-trip through SwiftSyntax", ())
 ERROR(parser_new_parser_errors,none,
-      "new Swift parser generated errors for code that C++ parser accepted",
+      "SwiftSyntax generated errors for code that C++ parser accepted",
        ())
 
 // MARK: Reference Binding Diagnostics


### PR DESCRIPTION
I was trying to get a handle on making a syntactic change. I modified the relevant C++ code, but discovered a failure when running my test:

```
new Swift parser generated errors for code that C++ parser accepted
```

It took a fair bit of hunting around for me to understand that "new Swift parser" is referring to SwiftSyntax. I thought this could be worth clarifying, especially for people that aren't very familiar with this area of the system.