### PR TITLE
[cxx-interop] Support static dispatch for virtual methods using `super`

### DIFF
--- a/include/swift/AST/ClangModuleLoader.h
+++ b/include/swift/AST/ClangModuleLoader.h
@@ -223,6 +223,10 @@ public:
   /// Returns the original method if \param decl is a clone from a base class
   virtual ValueDecl *getOriginalForClonedMember(const ValueDecl *decl) = 0;
 
+  /// If \param decl is a synthesized thunk for a virtual method of a foreign
+  /// reference type, returns the originally-imported (un-thunked) method.
+  virtual FuncDecl *getOriginalForVirtualThunk(const FuncDecl *decl) = 0;
+
   /// Returns the forwarding method in the derived class that calls the base
   /// method.
   virtual ValueDecl *getCalledBaseCxxMethod(const ValueDecl *decl) = 0;

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6619,6 +6619,9 @@ ERROR(invalid_ownership_incompatible_foreign_reference_type,none,
 ERROR(downcast_to_foreign_reference_type,none,
       "downcast from %0 to %1 is not supported for foreign reference types",
       (Type, Type))
+ERROR(cxx_super_pure_virtual_call,none,
+      "cannot use 'super' to call C++ pure virtual method %0; it has no base "
+      "class implementation", (const ValueDecl *))
 ERROR(invalid_ownership_with_optional,none,
       "%0 variable cannot have optional type", (ReferenceOwnership))
 ERROR(invalid_ownership_not_optional,none,

--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -698,6 +698,7 @@ public:
                                   ClangInheritanceInfo inheritance) override;
 
   ValueDecl *getOriginalForClonedMember(const ValueDecl *decl) override;
+  FuncDecl *getOriginalForVirtualThunk(const FuncDecl *decl) override;
   ValueDecl *getCalledBaseCxxMethod(const ValueDecl *decl) override;
   bool isMemberSynthesizedPerType(const ValueDecl *decl) override;
 

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -8019,6 +8019,14 @@ ValueDecl *ClangImporter::Implementation::getOriginalForClonedMember(
   return nullptr;
 }
 
+FuncDecl *ClangImporter::Implementation::getOriginalForVirtualThunk(
+    const FuncDecl *decl) {
+  auto result = virtualThunkToOriginal.find(decl);
+  if (result != virtualThunkToOriginal.end())
+    return result->getSecond();
+  return nullptr;
+}
+
 bool ClangImporter::Implementation::isMemberSynthesizedPerType(
     const ValueDecl *decl) {
   return membersSynthesizedPerType.contains(decl);
@@ -8037,6 +8045,11 @@ ClangImporter::importBaseMemberDecl(ValueDecl *decl, DeclContext *newContext,
 
 ValueDecl *ClangImporter::getOriginalForClonedMember(const ValueDecl *decl) {
   return Impl.getOriginalForClonedMember(decl);
+}
+
+FuncDecl *
+ClangImporter::getOriginalForVirtualThunk(const FuncDecl *decl) {
+  return Impl.getOriginalForVirtualThunk(decl);
 }
 
 ValueDecl *ClangImporter::getCalledBaseCxxMethod(const ValueDecl *decl) {

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4776,15 +4776,26 @@ namespace {
             // side is mapped from `T*` on the C++ side, an invocation of a
             // virtual method `t->method()` should get dispatched dynamically.
             // Create a thunk that will perform dynamic dispatch.
-            // TODO: we don't have to import the actual `method` in this case,
-            // we can just synthesize a thunk and import that instead.
 
             llvm::SmallString<64> swiftName;
             funcDecl->getName().getString(swiftName);
             FuncDecl *result =
                 synthesizer.makeVirtualMethod(decl, swiftName.str());
 
+            // A `super.virtualMethod()` call should instead statically dispatch
+            // to the base class implementation. Store the original method, so
+            // SILGen can substitute it for super calls.
             if (result) {
+              SmallString<64> staticCallName("__staticCall_");
+              staticCallName += swiftName;
+
+              // Rename the original method to make sure it gets a distinct
+              // mangled name from the thunk.
+              funcDecl->setName(
+                  DeclName(Impl.SwiftContext,
+                           Impl.SwiftContext.getIdentifier(staticCallName),
+                           funcDecl->getName().getArgumentNames()));
+              Impl.virtualThunkToOriginal[result] = funcDecl;
               return result;
             }
             Impl.markUnavailable(funcDecl,

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -688,6 +688,10 @@ public:
 
   llvm::SmallPtrSet<const clang::Decl *, 1> synthesizedAndAlwaysVisibleDecls;
 
+  /// For virtual methods of foreign reference types, whenever a virtual thunk
+  /// is generated, keep track of the original C++ method.
+  llvm::DenseMap<const FuncDecl *, FuncDecl *> virtualThunkToOriginal;
+
 private:
   // Keep track of the decls that were already cloned for this specific class.
   llvm::DenseMap<std::pair<ValueDecl *, DeclContext *>, ValueDecl *>
@@ -785,6 +789,8 @@ public:
                                   ClangInheritanceInfo inheritance);
 
   ValueDecl *getOriginalForClonedMember(const ValueDecl *decl);
+  FuncDecl *getOriginalForVirtualThunk(const FuncDecl *decl);
+
   bool isMemberSynthesizedPerType(const ValueDecl *decl);
   void markMemberSynthesizedPerType(const ValueDecl *decl);
 

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -1436,8 +1436,24 @@ public:
     } else if (auto *declRef = dyn_cast<DeclRefExpr>(fn)) {
       assert(isa<FuncDecl>(declRef->getDecl()) && "non-function super call?!");
       // FIXME(backDeploy): Handle calls to back deployed methods on super?
-      constant = SILDeclRef(declRef->getDecl())
-        .asForeign(requiresForeignEntryPoint(declRef->getDecl()));
+      auto funcDecl = cast<FuncDecl>(declRef->getDecl());
+
+      // A call to a virtual method of a foreign reference type in Swift
+      // resolves to a synthesized thunk that performs dynamic dispatch.
+      // However, a `super` call should statically dispatch to the base class
+      // implementation. Substitute it so the direct call below references that
+      // symbol instead of the thunk.
+      if (auto classDecl = funcDecl->getDeclContext()->getSelfClassDecl()) {
+        if (classDecl->isForeignReferenceType()) {
+          auto clangImporter = SGF.getASTContext().getClangModuleLoader();
+          if (auto original =
+                  clangImporter->getOriginalForVirtualThunk(funcDecl))
+            funcDecl = original;
+        }
+      }
+
+      constant =
+          SILDeclRef(funcDecl).asForeign(requiresForeignEntryPoint(funcDecl));
 
       if (declRef->getDeclRef().isSpecialized())
         substitutions = declRef->getDeclRef().getSubstitutions();

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -50,6 +50,7 @@
 #include "swift/Parse/ParseDeclName.h"
 #include "swift/Sema/ConstraintSystem.h"
 #include "swift/Sema/IDETypeChecking.h"
+#include "clang/AST/DeclCXX.h"
 #include "clang/AST/DeclObjC.h"
 #include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/StringSwitch.h"
@@ -147,6 +148,10 @@ static void diagSyntacticUseRestrictions(const Expr *E, const DeclContext *DC,
 
       if (auto *KPE = dyn_cast<KeyPathExpr>(E))
         checkForInvalidKeyPath(KPE);
+
+      // Verify that a 'super' call does not target a pure virtual C++ method.
+      if (auto selfApply = dyn_cast<SelfApplyExpr>(E))
+        checkSuperCallToPureVirtualCXXMethod(selfApply);
 
       // Check function calls, looking through implicit conversions on the
       // function and inspecting the arguments directly.
@@ -341,6 +346,34 @@ static void diagSyntacticUseRestrictions(const Expr *E, const DeclContext *DC,
       }
 
       return Action::Continue(E);
+    }
+
+    /// A `super` call statically dispatches to the base class implementation.
+    /// A pure virtual C++ method of a foreign reference type has none.
+    void checkSuperCallToPureVirtualCXXMethod(SelfApplyExpr *selfApply) {
+      if (!selfApply->getBase()->isSuperExpr())
+        return;
+
+      auto func = dyn_cast_or_null<FuncDecl>(
+          selfApply->getCalledValue(/*skipFunctionConversions=*/true));
+      if (!func)
+        return;
+
+      auto classDecl = func->getDeclContext()->getSelfClassDecl();
+      if (!classDecl || !classDecl->isForeignReferenceType())
+        return;
+
+      auto clangImporter = Ctx.getClangModuleLoader();
+      auto original = clangImporter->getOriginalForVirtualThunk(func);
+      if (!original)
+        return;
+
+      if (auto methodDecl = dyn_cast_or_null<clang::CXXMethodDecl>(
+              original->getClangDecl())) {
+        if (methodDecl->isPureVirtual())
+          Ctx.Diags.diagnose(selfApply->getFn()->getLoc(),
+                             diag::cxx_super_pure_virtual_call, func);
+      }
     }
 
     /// Visit each component of the keypath and emit a diagnostic if they

--- a/test/Interop/Cxx/foreign-reference/Inputs/module.modulemap
+++ b/test/Interop/Cxx/foreign-reference/Inputs/module.modulemap
@@ -124,6 +124,12 @@ module SuperStaticDispatch {
   export *
 }
 
+module SuperVirtualDispatch {
+  header "super-virtual-dispatch.h"
+  requires cplusplus
+  export *
+}
+
 module ImmortalFRTHashable {
   header "immortal-frt-hashable.h"
   requires cplusplus

--- a/test/Interop/Cxx/foreign-reference/Inputs/super-virtual-dispatch.h
+++ b/test/Interop/Cxx/foreign-reference/Inputs/super-virtual-dispatch.h
@@ -1,0 +1,98 @@
+#define FRT_IMMORTAL                                                           \
+  __attribute__((swift_attr("import_reference")))                              \
+  __attribute__((swift_attr("retain:immortal")))                               \
+  __attribute__((swift_attr("release:immortal")))
+
+struct FRT_IMMORTAL Base {
+  virtual int virtualMethod() const { return 100; }
+  virtual ~Base() = default;
+
+  static Base &create() {
+    static Base instance;
+    return instance;
+  }
+};
+
+struct FRT_IMMORTAL Derived : Base {
+  int virtualMethod() const override { return 200; }
+
+  static Derived &create() {
+    static Derived instance;
+    return instance;
+  }
+};
+
+struct FRT_IMMORTAL LeafDerived : Derived {
+  int virtualMethod() const override { return 300; }
+
+  static LeafDerived &create() {
+    static LeafDerived instance;
+    return instance;
+  }
+};
+
+struct FRT_IMMORTAL DerivedNoOverride : Base {
+  static DerivedNoOverride &create() {
+    static DerivedNoOverride instance;
+    return instance;
+  }
+};
+
+struct FRT_IMMORTAL LeafOverNoOverride : DerivedNoOverride {
+  int virtualMethod() const override { return 400; }
+
+  static LeafOverNoOverride &create() {
+    static LeafOverNoOverride instance;
+    return instance;
+  }
+};
+
+struct UnrelatedBase {
+  int unrelatedMethod() const { return 999; }
+};
+
+struct FRT_IMMORTAL DerivedWithUnrelatedBase : Base, UnrelatedBase {
+  int virtualMethod() const override { return 500; }
+
+  static DerivedWithUnrelatedBase &create() {
+    static DerivedWithUnrelatedBase instance;
+    return instance;
+  }
+};
+
+struct SecondBaseWithSameMethod {
+  virtual int virtualMethod() const { return 700; }
+  virtual ~SecondBaseWithSameMethod() = default;
+};
+
+struct FRT_IMMORTAL DerivedWithConflictingBase : Base, SecondBaseWithSameMethod {
+  int virtualMethod() const override { return 600; }
+
+  static DerivedWithConflictingBase &create() {
+    static DerivedWithConflictingBase instance;
+    return instance;
+  }
+};
+
+struct FRT_IMMORTAL AbstractBase {
+  virtual int pureMethod() const = 0;
+  virtual ~AbstractBase() = default;
+};
+
+struct FRT_IMMORTAL ConcreteDerived : AbstractBase {
+  int pureMethod() const override { return 42; }
+
+  static ConcreteDerived &create() {
+    static ConcreteDerived instance;
+    return instance;
+  }
+};
+
+struct FRT_IMMORTAL VirtuallyDerived : virtual Base {
+  int virtualMethod() const override { return 800; }
+
+  static VirtuallyDerived &create() {
+    static VirtuallyDerived instance;
+    return instance;
+  }
+};

--- a/test/Interop/Cxx/foreign-reference/super-virtual-dispatch-silgen.swift
+++ b/test/Interop/Cxx/foreign-reference/super-virtual-dispatch-silgen.swift
@@ -1,0 +1,39 @@
+// RUN: %target-swift-emit-silgen %s -I %S/Inputs -cxx-interoperability-mode=default -enable-experimental-feature ForeignReferenceTypeInheritance -disable-availability-checking | %FileCheck %s
+
+// REQUIRES: swift_feature_ForeignReferenceTypeInheritance
+
+import SuperVirtualDispatch
+
+extension Derived {
+  public func callSuperVirtual() -> Int32 {
+    return super.virtualMethod()
+  }
+}
+
+extension LeafOverNoOverride {
+  public func callSuperVirtualFromLeafOverNoOverride() -> Int32 {
+    return super.virtualMethod()
+  }
+}
+
+extension DerivedWithUnrelatedBase {
+  public func callSuperVirtualFromMultiBase() -> Int32 {
+    return super.virtualMethod()
+  }
+}
+
+// CHECK-LABEL: Derived.callSuperVirtual()
+// CHECK-NOT: super_method
+// CHECK-NOT: objc_super_method
+// CHECK-NOT: _ZNK7Derived
+// CHECK-NOT: __synthesizedVirtualCall
+// CHECK: function_ref {{.*}}Base{{.*}}__staticCall_virtualMethod
+// CHECK: end sil function
+
+// CHECK-LABEL: LeafOverNoOverride.callSuperVirtualFromLeafOverNoOverride()
+// CHECK-NOT: super_method
+// CHECK-NOT: objc_super_method
+// CHECK-NOT: _ZNK18LeafOverNoOverride
+// CHECK-NOT: __synthesizedVirtualCall
+// CHECK: function_ref {{.*}}Base{{.*}}__staticCall_virtualMethod
+// CHECK: end sil function

--- a/test/Interop/Cxx/foreign-reference/super-virtual-dispatch-typechecker.swift
+++ b/test/Interop/Cxx/foreign-reference/super-virtual-dispatch-typechecker.swift
@@ -1,0 +1,26 @@
+// RUN: %target-typecheck-verify-swift -I %S/Inputs -cxx-interoperability-mode=default -enable-experimental-feature ForeignReferenceTypeInheritance -disable-availability-checking
+
+// REQUIRES: swift_feature_ForeignReferenceTypeInheritance
+
+import SuperVirtualDispatch
+
+extension ConcreteDerived {
+  public func callSuperPure() -> Int32 {
+    return super.pureMethod() // expected-error {{cannot use 'super' to call C++ pure virtual method 'pureMethod()'; it has no base class implementation}}
+  }
+
+  public func callPureImpl() -> Int32 {
+    return pureMethod()
+  }
+
+  public func storeSuperPure() {
+    let _ = super.pureMethod // expected-error {{cannot use 'super' to call C++ pure virtual method 'pureMethod()'; it has no base class implementation}}
+  }
+}
+
+// A virtual base is not imported as a Swift superclass, so 'super' is unavailable.
+extension VirtuallyDerived {
+  public func callSuperVirtual() -> Int32 {
+    return super.virtualMethod() // expected-error {{'super' cannot be used in extension of class 'VirtuallyDerived' because it has no superclass}}
+  }
+}

--- a/test/Interop/Cxx/foreign-reference/super-virtual-dispatch.swift
+++ b/test/Interop/Cxx/foreign-reference/super-virtual-dispatch.swift
@@ -1,0 +1,84 @@
+// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=default -enable-experimental-feature ForeignReferenceTypeInheritance -Xfrontend -disable-availability-checking)
+
+// REQUIRES: executable_test
+// REQUIRES: swift_feature_ForeignReferenceTypeInheritance
+
+import SuperVirtualDispatch
+import StdlibUnittest
+
+var SuperVirtualDispatchTests = TestSuite("super.virtualMethod() dispatch for FRTs")
+
+extension Derived {
+  public func callSuperVirtual() -> Int32 {
+    return super.virtualMethod()
+  }
+}
+
+extension LeafDerived {
+  public func callSuperVirtualFromLeaf() -> Int32 {
+    return super.virtualMethod()
+  }
+}
+
+extension LeafOverNoOverride {
+  public func callSuperVirtualFromLeafOverNoOverride() -> Int32 {
+    return super.virtualMethod()
+  }
+}
+
+extension DerivedWithUnrelatedBase {
+  public func callSuperVirtualFromMultiBase() -> Int32 {
+    return super.virtualMethod()
+  }
+}
+
+extension DerivedWithConflictingBase {
+  public func callSuperVirtualFromConflictingBase() -> Int32 {
+    return super.virtualMethod()
+  }
+}
+
+extension Derived {
+  public func callSuperVirtualViaValue(_ b: Bool) -> Int32 {
+    let toCall = b ? self.virtualMethod : super.virtualMethod
+    return toCall()
+  }
+}
+
+SuperVirtualDispatchTests.test("super.virtualMethod() dispatches statically to the base implementation") {
+  let derived = Derived.create()
+  expectEqual(200, derived.virtualMethod())
+  expectEqual(100, derived.callSuperVirtual())
+}
+
+SuperVirtualDispatchTests.test("super.virtualMethod() resolves to the immediate base across multiple inheritance levels") {
+  let leaf = LeafDerived.create()
+  expectEqual(300, leaf.virtualMethod())
+  expectEqual(200, leaf.callSuperVirtualFromLeaf())
+}
+
+SuperVirtualDispatchTests.test("super.virtualMethod() resolves to a method the immediate base inherits from its own base") {
+  let leaf = LeafOverNoOverride.create()
+  expectEqual(400, leaf.virtualMethod())
+  expectEqual(100, leaf.callSuperVirtualFromLeafOverNoOverride())
+}
+
+SuperVirtualDispatchTests.test("super.virtualMethod() dispatches to the primary FRT base when there is also an unrelated base") {
+  let derived = DerivedWithUnrelatedBase.create()
+  expectEqual(500, derived.virtualMethod())
+  expectEqual(100, derived.callSuperVirtualFromMultiBase())
+}
+
+SuperVirtualDispatchTests.test("super.virtualMethod() dispatches to the primary FRT base when a secondary base declares the same method") {
+  let derived = DerivedWithConflictingBase.create()
+  expectEqual(600, derived.virtualMethod())
+  expectEqual(100, derived.callSuperVirtualFromConflictingBase())
+}
+
+SuperVirtualDispatchTests.test("an unapplied super.virtualMethod reference statically dispatches to the base") {
+  let derived = Derived.create()
+  expectEqual(200, derived.callSuperVirtualViaValue(true))
+  expectEqual(100, derived.callSuperVirtualViaValue(false))
+}
+
+runAllTests()


### PR DESCRIPTION
This adds support for calling virtual methods of C++ foreign reference types with static dispatch.

In C++, one can do:
```cpp
this->Base::virtualMethod()
```

Swift doesn't allow calling a particular overload of an overridden method, however, it allows calling an overload from the superclass with `super`:
```swift
extension Derived {
  public func callSuper() {
    return super.foo()
  }
}
```

For inherited FRTs, the example above behaved in an unexpected way: the call would still be dispatched dynamically, despite using the syntax reserved for static dispatch. This change makes it behave similarly to pure-Swift classes.

rdar://177619427

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
