### PR TITLE
[Sema] Remove dead code in getIsolationFromAttributes

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -5168,8 +5168,7 @@ ActorIsolation swift::determineClosureActorIsolation(
 /// inference rules). Returns \c None if there were no attributes on this
 /// declaration.
 static std::optional<ActorIsolation>
-getIsolationFromAttributes(const Decl *decl, bool shouldDiagnose = true,
-                           bool onlyExplicit = false) {
+getIsolationFromAttributes(const Decl *decl, bool shouldDiagnose = true) {
   // Look up attributes on the declaration that can affect its actor isolation.
   // If any of them are present, use that attribute.
 
@@ -5183,22 +5182,7 @@ getIsolationFromAttributes(const Decl *decl, bool shouldDiagnose = true,
   auto globalActorAttr = decl->getGlobalActorAttr();
   auto concurrentAttr = decl->getAttrs().getAttribute<ConcurrentAttr>();
 
-  // Remove implicit attributes if we only care about explicit ones.
-  if (onlyExplicit) {
-    if (nonisolatedAttr && nonisolatedAttr->isImplicit())
-      nonisolatedAttr = nullptr;
-    if (isolatedAttr && isolatedAttr->isImplicit())
-      isolatedAttr = nullptr;
-    if (globalActorAttr && globalActorAttr->first->isImplicit())
-      globalActorAttr = std::nullopt;
-    if (concurrentAttr && concurrentAttr->isImplicit())
-      concurrentAttr = nullptr;
-  }
-
-  unsigned numIsolationAttrs =
-      (isolatedAttr ? 1 : 0) + (nonisolatedAttr ? 1 : 0) +
-      (globalActorAttr ? 1 : 0) + (concurrentAttr ? 1 : 0);
-  if (numIsolationAttrs == 0) {
+  if (!(isolatedAttr || nonisolatedAttr || globalActorAttr || concurrentAttr)) {
     if (isa<DestructorDecl>(decl) && !decl->isImplicit()) {
       return cast<DestructorDecl>(decl)->isAsync()
                  ? ActorIsolation::forNonisolatedConcurrent()


### PR DESCRIPTION
This PR removes a dead parameter + branch, 'onlyExplicit'. Added in e0bd26942e6 to be used where the question 'are there explicit isolation attributes' was useful for determining if a context was a concurrency context. 7d55dea4aec replaced those consumers with hasExplicitIsolationAttribute, making this branch confusing dead code.

This commit also removes a ternary, that used to check for more than one concurrency attribute, but now is only used for checking for the nonexistence of a concurrency attribute for destructors. Added in 77584928da3, diagnosing if `> 1`. Removed in 527616d1054 when this logic moved to attribute checker.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
