### PR TITLE
[cxx-interop] Non-initializer methods shouldn't be imported as 'init'

### DIFF
--- a/include/swift/AST/DiagnosticsClangImporter.def
+++ b/include/swift/AST/DiagnosticsClangImporter.def
@@ -82,6 +82,14 @@ WARNING(swift_name_attr_ignored, none,
         "effect on method overrides",
         (StringRef))
 
+WARNING(swift_name_init_on_non_initializer, none,
+        "ignoring swift_name attribute '%0'; %1 cannot be imported as an "
+        "initializer",
+        (StringRef, const clang::NamedDecl *))
+
+NOTE(swift_name_use_backticks_in_init, none,
+     "use backticks (e.g. 'swift_name(\"`init`(...)\")')", ())
+
 GROUPED_WARNING(swift_name_circular_context_import, ClangDeclarationImport, none,
         "cycle detected while resolving '%0' in swift_name attribute for '%1'",
         (StringRef, StringRef))

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -63,6 +63,7 @@
 #include "swift/ClangImporter/ClangImporterRequests.h"
 #include "swift/ClangImporter/ClangModule.h"
 #include "swift/Parse/Lexer.h"
+#include "swift/Parse/ParseDeclName.h"
 #include "swift/Strings.h"
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/Attr.h"
@@ -4142,6 +4143,22 @@ namespace {
                           diag::note_while_importing, decl->getName());
             return nullptr;
           }
+        }
+      }
+
+      if (auto *attr = decl->getAttr<clang::SwiftNameAttr>();
+          attr && isActiveSwiftVersion()) {
+        ParsedDeclName parsedName = parseDeclName(attr->getName());
+        // If this function has a swift_name attribute 'init' but we can't
+        // import it as an initializer, we ignore the swift_name attribute and
+        // emit a warning.
+        if (parsedName.BaseNameKind == DeclBaseName::Kind::Constructor &&
+            !importedName.getDeclName().getBaseName().isConstructor()) {
+          Impl.diagnose(HeaderLoc(decl->getLocation()),
+                        diag::swift_name_init_on_non_initializer,
+                        attr->getName(), cast<clang::NamedDecl>(decl));
+          Impl.diagnose(HeaderLoc(decl->getLocation()),
+                        diag::swift_name_use_backticks_in_init);
         }
       }
 

--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -861,6 +861,33 @@ static bool shouldImportAsInitializer(const clang::ObjCMethodDecl *method,
   return static_cast<bool>(determineFactoryInitializerKind(method));
 }
 
+/// Determine whether this C/C++ function or method can be imported as an
+/// initializer of the type named by \p parsedName.
+static bool shouldImportAsInitializer(const clang::FunctionDecl *D,
+                                      const ParsedDeclName &parsedName) {
+  if (auto *method = dyn_cast<clang::CXXMethodDecl>(D)) {
+    if (!method->isStatic())
+      return false;
+
+    clang::QualType resultType = method->getReturnType();
+    if (resultType->isPointerType() || resultType->isReferenceType())
+      resultType = resultType->getPointeeType();
+
+    const clang::CXXRecordDecl *resultRecord = resultType->getAsCXXRecordDecl();
+    if (!resultRecord)
+      return false;
+    resultRecord = resultRecord->getCanonicalDecl();
+
+    if (parsedName.isMember())
+      return resultRecord->getName() == parsedName.ContextNames.front();
+
+    return resultRecord == method->getParent()->getCanonicalDecl();
+  }
+
+  // Free functions only support the "Type.init(...)" form.
+  return parsedName.isMember();
+}
+
 /// Attempt to omit needless words from the given function name.
 static bool omitNeedlessWordsInFunctionName(
     StringRef &baseName, SmallVectorImpl<StringRef> &argumentNames,
@@ -1713,11 +1740,16 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
         skipCustomName = true;
         result.info.hasInvalidCustomName = true;
       }
-    }
+    } else if (auto *func = dyn_cast<clang::FunctionDecl>(D)) {
+      if (auto *cxxMethod = dyn_cast<clang::CXXMethodDecl>(func)) {
+        // `swift_name` attribute is not supported in virtual methods overrides
+        if (cxxMethod->isVirtual() && cxxMethod->size_overridden_methods() > 0)
+          skipCustomName = true;
+      }
 
-    // `swift_name` attribute is not supported in virtual methods overrides
-    if (auto method = dyn_cast<clang::CXXMethodDecl>(D)) {
-      if (method->isVirtual() && method->size_overridden_methods() > 0)
+      if (!skipCustomName &&
+          parsedName.BaseNameKind == DeclBaseName::Kind::Constructor &&
+          !shouldImportAsInitializer(func, parsedName))
         skipCustomName = true;
     }
 

--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -865,6 +865,8 @@ static bool shouldImportAsInitializer(const clang::ObjCMethodDecl *method,
 /// initializer of the type named by \p parsedName.
 static bool shouldImportAsInitializer(const clang::FunctionDecl *D,
                                       const ParsedDeclName &parsedName) {
+  if (isa<clang::CXXConstructorDecl>(D))
+    return true;
   if (auto *method = dyn_cast<clang::CXXMethodDecl>(D)) {
     if (!method->isStatic())
       return false;

--- a/lib/ClangImporter/SwiftDeclSynthesizer.cpp
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.cpp
@@ -2455,7 +2455,14 @@ FuncDecl *SwiftDeclSynthesizer::makeVirtualMethod(
       clangDC, clangDC, clangMethodDecl, ForwardingMethodKind::Virtual,
       ReferenceReturnTypeBehaviorForBaseMethodSynthesis::KeepReference,
       /*forceConstQualifier*/ false);
-  
+
+  llvm::SmallString<64> backtickedSwiftName;
+  if (swiftName == "init" || swiftName.starts_with("init(")) {
+    backtickedSwiftName = "`init`";
+    backtickedSwiftName += swiftName.drop_front(StringRef("init").size());
+    swiftName = backtickedSwiftName;
+  }
+
   // If the override has a swift_name different from the base
   // method, we ignore the swift_name attribute and instead use the base method's name.
   // In this case, swiftName holds the correct derived method name obtained through NameImporter

--- a/test/Interop/Cxx/class/inheritance/Inputs/functions.h
+++ b/test/Interop/Cxx/class/inheritance/Inputs/functions.h
@@ -163,3 +163,9 @@ class CopyTrackedDerivedDerivedClass: public NonEmptyBase, public CopyTrackedDer
 public:
     CopyTrackedDerivedDerivedClass(int x) : CopyTrackedDerivedClass(x) {}
 };
+
+inline int freeFuncRenamedToInit() __attribute__((swift_name("init()"))) {
+  return 42;
+}
+// expected-warning@-3 {{ignoring swift_name attribute 'init()'; 'freeFuncRenamedToInit' cannot be imported as an initializer}}
+// expected-note@-4 {{use backticks (e.g. 'swift_name("`init`(...)")')}}

--- a/test/Interop/Cxx/class/inheritance/functions-typechecker.swift
+++ b/test/Interop/Cxx/class/inheritance/functions-typechecker.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -verify-ignore-unknown -I %S/Inputs -enable-experimental-cxx-interop
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown -I %S%{fs-sep}Inputs -cxx-interoperability-mode=default -verify-additional-file %S%{fs-sep}Inputs%{fs-sep}functions.h
 
 import Functions
 
@@ -16,3 +16,10 @@ Derived().sameMethodDifferentSignature()
 
 // FIXME: we should import this (https://github.com/apple/swift/issues/69745):
 Derived().rvalueThisInBase() // expected-error {{value of type 'Derived' has no member 'rvalueThisInBase'}}
+
+func callfreeFuncRenamedToInit() -> Int32 {
+  var result: Int32 = 0
+  result += freeFuncRenamedToInit()
+  result += `init`() // expected-error {{cannot find 'init' in scope}}
+  return result
+}

--- a/test/Interop/Cxx/class/inheritance/functions.swift
+++ b/test/Interop/Cxx/class/inheritance/functions.swift
@@ -104,4 +104,8 @@ FunctionsTestSuite.test("mutating base member calls do not require copying") {
   expectEqual(copyCounter, getCopyCounter().pointee)
 }
 
+FunctionsTestSuite.test("non-initializer function renamed to init()") {
+  expectEqual(freeFuncRenamedToInit(), 42)
+}
+
 runAllTests()

--- a/test/Interop/Cxx/class/method/Inputs/methods.h
+++ b/test/Interop/Cxx/class/method/Inputs/methods.h
@@ -47,4 +47,71 @@ struct ReferenceParams {
   }
 };
 
+struct HasInitMethods {
+  int field;
+  int init() const { return field; }
+  int init(int n) {
+    field = n;
+    return field;
+  }
+};
+
+struct HasInitWithBackticks {
+  int x;
+  int notInit() const __attribute__((swift_name("`init`()"))) { return x; }
+};
+
+struct HasRenamedInitMethods {
+  int field;
+  int start() const __attribute__((swift_name("init()"))) { return field; }
+  // expected-warning@-1 {{ignoring swift_name attribute 'init()'; 'start' cannot be imported as an initializer}} 
+  // expected-note@-2 {{use backticks (e.g. 'swift_name("`init`(...)")')}}
+  int startWith(int a) const __attribute__((swift_name("init(n:)"))) {
+    return field + a;
+  }
+  // expected-warning@-3 {{ignoring swift_name attribute 'init(n:)'; 'startWith' cannot be imported as an initializer}} 
+  // expected-note@-4 {{use backticks (e.g. 'swift_name("`init`(...)")')}}
+};
+
+struct HasStaticInitFactoryAndInitMethod {
+  // Should be renamed to `init`
+  int init() const { return value; }
+
+  // Should be imported as an initializer
+  static HasStaticInitFactoryAndInitMethod makeWithValue(int value)
+      __attribute__((swift_name("init(value:)"))) {
+    HasStaticInitFactoryAndInitMethod result;
+    result.value = value + 3;
+    return result;
+  }
+
+private:
+  int value = 0;
+};
+
+struct HasNonInitializerStaticInitMethod {
+  static int nonInitializer(int value) __attribute__((swift_name("init(n:)"))) {
+    return value;
+  }
+  // expected-warning@-3 {{ignoring swift_name attribute 'init(n:)'; 'nonInitializer' cannot be imported as an initializer}} 
+  // expected-note@-4 {{use backticks (e.g. 'swift_name("`init`(...)")')}}
+};
+
+struct WithFactory {
+  int x;
+};
+
+inline WithFactory makeWithFactory(int n)
+    __attribute__((swift_name("WithFactory.init(n:)"))) {
+  return {n * 2};
+}
+// expected-note@-4 {{'makeWithFactory' declared here}}
+
+inline WithFactory makeWithWrongFactory(int n)
+    __attribute__((swift_name("WrongFactory.init(n:)"))) {
+  return {n * 3};
+}
+// expected-warning@-3 {{imported declaration 'makeWithWrongFactory' could not be mapped to 'WrongFactory.init(n:)'}}
+// expected-note@-4 {{please report this issue to the owners of 'Methods}}
+
 #endif // TEST_INTEROP_CXX_CLASS_METHOD_METHODS_H

--- a/test/Interop/Cxx/class/method/Inputs/methods.h
+++ b/test/Interop/Cxx/class/method/Inputs/methods.h
@@ -97,6 +97,12 @@ struct HasNonInitializerStaticInitMethod {
   // expected-note@-4 {{use backticks (e.g. 'swift_name("`init`(...)")')}}
 };
 
+struct ConstructorWithRenamedLabel {
+  int value;
+  __attribute__((swift_name("init(renamed:)")))
+  ConstructorWithRenamedLabel(int v) : value(v) {}
+};
+
 struct WithFactory {
   int x;
 };

--- a/test/Interop/Cxx/class/method/methods-diagnostics.swift
+++ b/test/Interop/Cxx/class/method/methods-diagnostics.swift
@@ -1,0 +1,20 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-typecheck-verify-swift -cxx-interoperability-mode=default -disable-availability-checking -I %S%{fs-sep}Inputs -module-cache-path %t/mcp -verify-additional-file %S%{fs-sep}Inputs%{fs-sep}methods.h
+
+import Methods
+
+let s1 = HasRenamedInitMethods()
+s1.start()
+s1.init() // expected-error {{'init' is a member of the type; use 'type(of: ...)' to initialize a new object of the same dynamic type}}
+s1.startWith(5)
+s1.init(n: 5) 
+// expected-error@-1 {{'init' is a member of the type; use 'type(of: ...)' to initialize a new object of the same dynamic type}}
+// expected-error@-2 {{incorrect argument label in call (have 'n:', expected 'field:')}}
+
+let _ = HasNonInitializerStaticInitMethod()
+let _ = HasNonInitializerStaticInitMethod.nonInitializer(5)
+let _ = HasNonInitializerStaticInitMethod(n: 5)
+// expected-error@-1 {{argument passed to call that takes no arguments}}
+
+let _ = makeWithWrongFactory(n: 5)
+// expected-error@-1 {{cannot find 'makeWithWrongFactory' in scope}}

--- a/test/Interop/Cxx/class/method/methods-module-interface.swift
+++ b/test/Interop/Cxx/class/method/methods-module-interface.swift
@@ -17,3 +17,38 @@
 
 // CHECK: mutating func nonConstPassThroughAsWrapper(_ a: Int32) -> NonTrivialInWrapper
 // CHECK: func constPassThroughAsWrapper(_ a: Int32) -> NonTrivialInWrapper
+
+// CHECK: struct HasInitMethods {
+// CHECK:   init(field: Int32)
+// CHECK:   init()
+// CHECK:   func `init`() -> Int32
+// CHECK:   mutating func initMutating(_ n: Int32) -> Int32
+// CHECK: }
+
+// CHECK: struct HasInitWithBackticks {
+// CHECK:   init(x: Int32)
+// CHECK:   func `init`() -> Int32
+// CHECK: }
+
+// CHECK: struct HasRenamedInitMethods {
+// CHECK:   func start() -> Int32
+// CHECK:   func startWith(_ a: Int32) -> Int32
+// CHECK: }
+
+// CHECK: struct HasStaticInitFactoryAndInitMethod {
+// CHECK:   func `init`() -> Int32
+// CHECK:   init(value: Int32)
+// CHECK: }
+
+// CHECK: struct HasNonInitializerStaticInitMethod {
+// CHECK:   init()
+// CHECK:   static func nonInitializer(_ value: Int32) -> Int32
+// CHECK: }
+
+// CHECK: struct WithFactory {
+// CHECK:   init(x: Int32)
+// CHECK: }
+
+// CHECK: extension WithFactory {
+// CHECK:   init(n: Int32)
+// CHECK: }

--- a/test/Interop/Cxx/class/method/methods-module-interface.swift
+++ b/test/Interop/Cxx/class/method/methods-module-interface.swift
@@ -45,6 +45,10 @@
 // CHECK:   static func nonInitializer(_ value: Int32) -> Int32
 // CHECK: }
 
+// CHECK: struct ConstructorWithRenamedLabel {
+// CHECK:   init(renamed v: Int32)
+// CHECK: }
+
 // CHECK: struct WithFactory {
 // CHECK:   init(x: Int32)
 // CHECK: }

--- a/test/Interop/Cxx/class/method/methods.swift
+++ b/test/Interop/Cxx/class/method/methods.swift
@@ -68,4 +68,38 @@ CxxMethodTestSuite.test("Static method with ref params") {
   ReferenceParams.staticMethod(a, b)
 }
 
+CxxMethodTestSuite.test("C++ method called init") {
+  var instance = HasInitMethods(field: 42)
+  expectEqual(instance.`init`(), 42)
+  expectEqual(instance.initMutating(7), 7)
+}
+
+CxxMethodTestSuite.test("C++ method with swift_name `init`") {
+  var instance = HasInitWithBackticks(x: 3)
+  expectEqual(instance.`init`(), 3)
+}
+
+CxxMethodTestSuite.test("C++ method called init, renamed with swift_name attribute") {
+  var instance = HasRenamedInitMethods(field: 42)
+  expectEqual(instance.start(), 42)
+  expectEqual(instance.startWith(7), 49)
+}
+
+CxxMethodTestSuite.test("C++ static init method still gets imported as an initializer") {
+  let instance = HasStaticInitFactoryAndInitMethod(value: 42)
+  expectEqual(instance.`init`(), 45)
+}
+
+CxxMethodTestSuite.test("C++ static init method that is not an initializer") {
+  expectEqual(HasNonInitializerStaticInitMethod.nonInitializer(42), 42)
+}
+
+CxxMethodTestSuite.test("Inline factory function renamed to init") {
+  let instance = WithFactory(x: 5)
+  expectEqual(instance.x, 5)
+
+  let anotherInstance = WithFactory(n: 5)
+  expectEqual(anotherInstance.x, 10)
+}
+
 runAllTests()

--- a/test/Interop/Cxx/class/method/methods.swift
+++ b/test/Interop/Cxx/class/method/methods.swift
@@ -94,6 +94,11 @@ CxxMethodTestSuite.test("C++ static init method that is not an initializer") {
   expectEqual(HasNonInitializerStaticInitMethod.nonInitializer(42), 42)
 }
 
+CxxMethodTestSuite.test("C++ constructor with swift_name attribute") {
+  let instance = ConstructorWithRenamedLabel(renamed: 42)
+  expectEqual(instance.value, 42)
+}
+
 CxxMethodTestSuite.test("Inline factory function renamed to init") {
   let instance = WithFactory(x: 5)
   expectEqual(instance.x, 5)

--- a/test/Interop/Cxx/foreign-reference/Inputs/member-inheritance.h
+++ b/test/Interop/Cxx/foreign-reference/Inputs/member-inheritance.h
@@ -365,3 +365,44 @@ struct DerivedAbstractFRT : AbstractFRT {
 };
 
 struct EmptyDerivedAbstractFRT : AbstractFRT {};
+
+struct IMMORTAL_FRT BaseWithInitMethod {
+  virtual int init() const { return 1; }
+  static BaseWithInitMethod *_Nonnull create() { return new BaseWithInitMethod(); }
+};
+
+struct IMMORTAL_FRT DerivedWithInitMethod : BaseWithInitMethod {
+  virtual int init() const override { return 2; }
+  static DerivedWithInitMethod *_Nonnull create() {
+    return new DerivedWithInitMethod();
+  }
+};
+
+struct IMMORTAL_FRT RenamedBaseWithInitMethod {
+  virtual int method() const __attribute__((swift_name("init()"))) {
+    return 11;
+  }
+  static RenamedBaseWithInitMethod *_Nonnull create() {
+    return new RenamedBaseWithInitMethod();
+  }
+};
+
+struct IMMORTAL_FRT RenamedDerivedWithInitMethod : RenamedBaseWithInitMethod {
+  virtual int method() const override __attribute__((swift_name("init()"))) {
+    return 12;
+  }
+  static RenamedDerivedWithInitMethod *_Nonnull create() {
+    return new RenamedDerivedWithInitMethod();
+  }
+};
+
+struct IMMORTAL_FRT HasCreateMethodImportedAsInitializer {
+  int field;
+
+  int getField() const { return field; }
+
+  static HasCreateMethodImportedAsInitializer *_Nonnull create(int v)
+      __attribute__((swift_name("init(n:)"))) {
+    return new HasCreateMethodImportedAsInitializer{v * 5};
+  }
+};

--- a/test/Interop/Cxx/foreign-reference/member-inheritance-module-interface.swift
+++ b/test/Interop/Cxx/foreign-reference/member-inheritance-module-interface.swift
@@ -193,3 +193,25 @@
 // CHECK-OFF: }
 // CHECK-ON: class EmptyDerivedAbstractFRT : AbstractFRT {
 // CHECK-ON: }
+
+// CHECK: class BaseWithInitMethod {
+// CHECK:   func `init`() -> Int32
+// CHECK: }
+
+// CHECK-OFF: class DerivedWithInitMethod {
+// CHECK-OFF:   func `init`() -> Int32
+// CHECK-OFF: }
+// CHECK-ON: class DerivedWithInitMethod : BaseWithInitMethod {
+// CHECK-ON:   func `init`() -> Int32
+// CHECK-ON: }
+
+// CHECK: class RenamedBaseWithInitMethod {
+// CHECK:   func method() -> Int32
+// CHECK: }
+
+// CHECK-OFF: class RenamedDerivedWithInitMethod {
+// CHECK-OFF:   func method() -> Int32
+// CHECK-OFF: }
+// CHECK-ON: class RenamedDerivedWithInitMethod : RenamedBaseWithInitMethod {
+// CHECK-ON:   func method() -> Int32
+// CHECK-ON: }

--- a/test/Interop/Cxx/foreign-reference/member-inheritance.swift
+++ b/test/Interop/Cxx/foreign-reference/member-inheritance.swift
@@ -178,4 +178,27 @@ if #available(SwiftStdlib 5.8, *) {
   }
 }
 
+if #available(SwiftStdlib 5.8, *) {
+  FunctionsTestSuite.test("calls C++ methods called init()") {
+    let base = BaseWithInitMethod.create()
+    expectEqual(base.`init`(), 1)
+
+    let derived = DerivedWithInitMethod.create()
+    expectEqual(derived.`init`(), 2)
+
+    let renamedBase = RenamedBaseWithInitMethod.create()
+    expectEqual(renamedBase.method(), 11)
+
+    let renamedDerived = RenamedDerivedWithInitMethod.create()
+    expectEqual(renamedDerived.method(), 12)
+  }
+}
+
+if #available(SwiftStdlib 5.8, *) {
+  FunctionsTestSuite.test("static create() imported as initializer") {
+    let instance = HasCreateMethodImportedAsInitializer(n: 5)
+    expectEqual(instance.getField(), 25)
+  } 
+}
+
 runAllTests()


### PR DESCRIPTION
C++ methods with a `swift_name("init()")` — added manually, or automatically in `ClangImporter` when handling virtual methods — used to trigger an assertion failure, because the compiler tried to import a non-initializer method as a Swift `init`.

Now we check whether a method with such a `swift_name` should actually be imported as an initializer; if not, we ignore the `swift_name` attribute and emit a warning. Virtual method overrides called `init`, for which we automatically would add `swift_name(“init()”)`, now get imported as `` `init` ``.

rdar://178257590