### PR TITLE
SILGen: Don't emit weird debug_value instruction for 'Never' thrown type

### DIFF
--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -1744,7 +1744,7 @@ uint16_t SILGenFunction::emitBasicProlog(
       .emitParams(origClosureType, paramList, selfParam);
 
   // Record the ArgNo of the artificial $error inout argument. 
-  if (errorType && IndirectErrorResult == nullptr) {
+  if (errorType && !(*errorType)->isNever() && IndirectErrorResult == nullptr) {
     CanType errorTypeInContext =
       DC->mapTypeIntoEnvironment(*errorType)->getCanonicalType();
     auto loweredErrorTy = getLoweredType(*origErrorType, errorTypeInContext);

--- a/test/DebugInfo/typed_throws.swift
+++ b/test/DebugInfo/typed_throws.swift
@@ -1,0 +1,48 @@
+// RUN: %target-swift-frontend -emit-ir -g %s
+
+protocol P {
+  associatedtype Failure: Error
+  func f() -> G<Failure>
+}
+
+struct G<T> {}
+
+struct MyError: Error {}
+
+struct Opaque1: P {
+  func f() -> G<some Error> {
+    return G<Never>()
+  }
+}
+
+struct Opaque2: P {
+  func f() -> G<some Error> {
+    return G<MyError>()
+  }
+}
+
+extension P where Failure == Never {
+  func f1() throws(Failure) {}
+}
+
+extension P where Failure == Opaque1.Failure {
+  func f2() throws(Failure) {}
+}
+
+extension P where Failure == Opaque2.Failure {
+  func f3() throws(Failure) {}
+}
+
+func g<T: P>(_ t: T) throws where T.Failure == Never {
+  try t.f1()
+}
+
+func g<T: P>(_ t: T) throws where T.Failure == Opaque1.Failure {
+  // FIXME: We still crash while generating the call to f2().
+  // try t.f2()
+}
+
+func g3<T: P>(_ t: T) throws where T.Failure == Opaque2.Failure {
+  // FIXME: We still crash while generating the call to f3().
+  // try t.f3()
+}

--- a/validation-test/compiler_crashers_fixed/IRGenSILFunction-visitDebugValueInst-a038f9.swift
+++ b/validation-test/compiler_crashers_fixed/IRGenSILFunction-visitDebugValueInst-a038f9.swift
@@ -1,5 +1,5 @@
 // {"kind":"emit-ir","original":"eeed16fc","signature":"(anonymous namespace)::IRGenSILFunction::visitDebugValueInst(swift::DebugValueInst*)","signatureAssert":"Assertion failed: (hasErrorResult()), function getMutableErrorResult","signatureNext":"IRGenSILFunction::emitSILFunction"}
-// RUN: not --crash %target-swift-frontend -emit-ir %s
+// RUN: %target-swift-frontend -emit-ir %s
 protocol a {
   associatedtype b: c where b.d == Self
   associatedtype e: Collection where e.Element == Self


### PR DESCRIPTION
In the bug report, adding a same-type requirement would crash the compiler, because a function was declared to throws(Failure) with Failure == Never. While this may not have been intended, the compiler shouldn't crash.

Usually if a function doesn't throw, errorType is std::nullopt here and not 'Never'. But it can happen that the thrown error type either reduces to 'Never', or is an opaque result type wrapping 'Never', in which case we will only realize this fact after lowering the type.

The test case lives in test/DebugInfo, because that's where the crash was. But it seemed cleaner to fix it by not emitting the useless instruction in the first place.

The opaque result type case exposes another issue and only partially works still. See the FIXME comment.

- Fixes https://github.com/swiftlang/swift/issues/89482.
- Fixes rdar://178084957.

