### PR TITLE
Revert "[CMake] Disable -gsplit-dwarf for RISC-V stdlib targets"

### DIFF
--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -277,13 +277,6 @@ function(_add_target_variant_c_compile_flags)
     else()
       list(APPEND result "-g0")
     endif()
-
-    # Split DWARF is incompatible with RISC-V linker relaxation (-mrelax),
-    # which clang enables by default for RISC-V targets. Override any
-    # inherited -gsplit-dwarf from the parent (LLVM) build.
-    if("${CFLAGS_ARCH}" MATCHES "^riscv")
-      list(APPEND result "-gno-split-dwarf")
-    endif()
   endif()
 
   if("${CFLAGS_SDK}" STREQUAL "WINDOWS")


### PR DESCRIPTION
This reverts commit 36ac7c935d6442a4add9ef18c0603da8661c4581.

This patch is only needed on main, not on next.

See https://github.com/swiftlang/swift/pull/89309