### PR TITLE
[CMake] Disable -gsplit-dwarf for RISC-V stdlib targets

### DIFF
--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -277,6 +277,13 @@ function(_add_target_variant_c_compile_flags)
     else()
       list(APPEND result "-g0")
     endif()
+
+    # Split DWARF is incompatible with RISC-V linker relaxation (-mrelax),
+    # which clang enables by default for RISC-V targets. Override any
+    # inherited -gsplit-dwarf from the parent (LLVM) build.
+    if("${CFLAGS_ARCH}" MATCHES "^riscv")
+      list(APPEND result "-gno-split-dwarf")
+    endif()
   endif()
 
   if("${CFLAGS_SDK}" STREQUAL "WINDOWS")


### PR DESCRIPTION
Clang enables -mrelax by default, which isn't compatible with -gsplit-dwarf. This fixes the -r build on Linux, which currently fails while compiling the riscv-64 stdlib.

(cherry picked from commit 36ac7c935d6442a4add9ef18c0603da8661c4581)

Explanation: Fixes a build error on linux when compiling the stdlib for riscv
Scope: standard library on riscv
Original PRs: https://github.com/swiftlang/swift/pull/89309
Risk: None. It currently doesn't build at all with debug info enabled.
Testing: N/A
Reviewers: @da-viper @JDevlieghere 