### PR TITLE
[SILGen] Establish correct isolation for async ObjC completion handler calls

### DIFF
--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -6152,38 +6152,6 @@ RValue SILGenFunction::emitApply(
     }
   }
 
-  // If there's a foreign error or async parameter, fill it in.
-  ManagedValue errorTemp;
-  if (auto foreignAsync = calleeTypeInfo.foreign.async) {
-    unsigned completionIndex = foreignAsync->completionHandlerParamIndex();
-
-    // Ram the emitted completion into the argument list, over the placeholder
-    // we left during the first pass.
-    auto &completionArgSlot = const_cast<ManagedValue &>(args[completionIndex]);
-
-    // We have already lowered foreign self/moved it into position at this
-    // point, so we know that self will be back.
-    ManagedValue self;
-    if (substFnType->hasSelfParam()) {
-      self = args.back();
-    }
-
-    auto origFormalType = *calleeTypeInfo.origFormalType;
-    completionArgSlot = resultPlan->emitForeignAsyncCompletionHandler(
-        *this, origFormalType, self, loc);
-  }
-  if (auto foreignError = calleeTypeInfo.foreign.error) {
-    unsigned errorParamIndex =
-        foreignError->getErrorParameterIndex();
-
-    // Ram the emitted error into the argument list, over the placeholder
-    // we left during the first pass.
-    auto &errorArgSlot = const_cast<ManagedValue &>(args[errorParamIndex]);
-
-    std::tie(errorTemp, errorArgSlot) =
-        resultPlan->emitForeignErrorArgument(*this, loc).value();
-  }
-
   // Emit the raw application.
   GenericSignature genericSig =
     fn.getType().castTo<SILFunctionType>()->getInvocationGenericSignature();
@@ -6261,6 +6229,38 @@ RValue SILGenFunction::emitApply(
     // own executor afterward, since the callee could have made arbitrary hops
     // out of our isolation domain.
     breadcrumb = ExecutorBreadcrumb(true);
+  }
+
+  // If there's a foreign error or async parameter, fill it in.
+  ManagedValue errorTemp;
+  if (auto foreignAsync = calleeTypeInfo.foreign.async) {
+    unsigned completionIndex = foreignAsync->completionHandlerParamIndex();
+
+    // Ram the emitted completion into the argument list, over the placeholder
+    // we left during the first pass.
+    auto &completionArgSlot = const_cast<ManagedValue &>(args[completionIndex]);
+
+    // We have already lowered foreign self/moved it into position at this
+    // point, so we know that self will be back.
+    ManagedValue self;
+    if (substFnType->hasSelfParam()) {
+      self = args.back();
+    }
+
+    auto origFormalType = *calleeTypeInfo.origFormalType;
+    completionArgSlot = resultPlan->emitForeignAsyncCompletionHandler(
+        *this, origFormalType, self, loc);
+  }
+  if (auto foreignError = calleeTypeInfo.foreign.error) {
+    unsigned errorParamIndex =
+        foreignError->getErrorParameterIndex();
+
+    // Ram the emitted error into the argument list, over the placeholder
+    // we left during the first pass.
+    auto &errorArgSlot = const_cast<ManagedValue &>(args[errorParamIndex]);
+
+    std::tie(errorTemp, errorArgSlot) =
+        resultPlan->emitForeignErrorArgument(*this, loc).value();
   }
 
   SILValue rawDirectResult;

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -6029,8 +6029,30 @@ CallEmission CallEmission::forApplyExpr(SILGenFunction &SGF, ApplyExpr *e) {
                          call->isNoAsync());
 
     // For an implicitly-async call, record the target of the actor hop.
-    if (auto target = call->isImplicitlyAsync())
+    if (auto target = call->isImplicitlyAsync()) {
       emission.setImplicitlyAsync(target);
+    } else {
+      // If we are emitting a call to an `async` variant of an ObjC completion
+      // handler API, we need to hop at the call site because there is no
+      // `async` function that is going to hop in its body. Such calls are
+      // referencing a sync variant with a special completion handler
+      // synthesized the compiler and the isolation context has to be
+      // established beforehand.
+      //
+      // This is specific to global-actor isolated functions because by default
+      // async variants are `nonisolated(nonsending)` and won't switch
+      // isolation.
+      auto callee = call->getCalledValue(/*skipFunctionConversions=*/true);
+      if (auto *F = dyn_cast_or_null<FuncDecl>(callee)) {
+        if (F->getForeignAsyncConvention()) {
+          if (auto crossing = call->getIsolationCrossing()) {
+            auto calleeIsolation = crossing->getCalleeIsolation();
+            if (calleeIsolation.isGlobalActor())
+              emission.setImplicitlyAsync(calleeIsolation);
+          }
+        }
+      }
+    }
   }
 
   return emission;

--- a/test/Concurrency/completion_handler_async_variant_isolation.swift
+++ b/test/Concurrency/completion_handler_async_variant_isolation.swift
@@ -1,0 +1,78 @@
+// RUN: %empty-directory(%t/src)
+// RUN: %empty-directory(%t/sdk)
+// RUN: split-file %s %t/src
+
+// RUN: %target-swift-emit-silgen(mock-sdk: %clang-importer-sdk) %t/src/main.swift \
+// RUN:   -enable-objc-interop \
+// RUN:   -import-objc-header %t/src/Test.h \
+// RUN:   -swift-version 5 \
+// RUN:   -module-name main -I %t -verify -verify-ignore-unrelated | %FileCheck %t/src/main.swift
+
+// REQUIRES: objc_interop
+
+//--- Test.h
+@import Foundation;
+
+#define MAIN_ACTOR __attribute__((__swift_attr__("@MainActor")))
+
+#pragma clang assume_nonnull begin
+
+@interface Doc : NSObject
+- (void)saveWithCompletionHandler:(void (^ __nullable)(BOOL success))completionHandler MAIN_ACTOR;
+- (void)undoWithCompletionHandler:(void (^ __nullable)(BOOL success))completionHandler;
+@end
+
+#pragma clang assume_nonnull end
+
+//--- main.swift
+
+// CHECK-LABEL: sil hidden [ossa] @$s4main4test3docySo3DocC_tYaF : $@convention(thin) @async (@guaranteed Doc) -> () {
+// CHECK: [[GENERIC_EXECUTOR:%.*]] = enum $Optional<any Actor>, #Optional.none!enumelt
+// CHECK: hop_to_executor [[GENERIC_EXECUTOR]]
+// CHECK: [[METHOD_REF:%.*]] = objc_method %0, #Doc.save!foreign
+// CHECK: [[MAIN_ACTOR_GETTER:%.*]] = function_ref @$sScM6sharedScMvgZ : $@convention(method) (@thick MainActor.Type) -> @owned MainActor
+// CHECK: [[MAIN_ACTOR_REF:%.*]] = apply [[MAIN_ACTOR_GETTER]]({{.*}}) : $@convention(method) (@thick MainActor.Type) -> @owned MainActor
+// CHECK: [[MAIN_ACTOR:%.*]] = begin_borrow [[MAIN_ACTOR_REF]]
+// CHECK: hop_to_executor [[MAIN_ACTOR]]
+// CHECK: apply [[METHOD_REF]]({{.*}}, %0)
+// CHECK: await_async_continuation {{.*}}, resume bb1
+// CHECK: bb1:
+// CHECK: hop_to_executor [[GENERIC_EXECUTOR]]
+// CHECK: } // end sil function '$s4main4test3docySo3DocC_tYaF'
+func test(doc: Doc) async {
+  _ = await doc.save()
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s4main17testSameIsolation3docySo3DocC_tYaF : $@convention(thin) @async (@guaranteed Doc) -> () {
+// CHECK: [[MAIN_ACTOR_GETTER:%.*]] = function_ref @$sScM6sharedScMvgZ : $@convention(method) (@thick MainActor.Type) -> @owned MainActor
+// CHECK: [[MAIN_ACTOR_REF:%.*]] = apply [[MAIN_ACTOR_GETTER]]({{.*}}) : $@convention(method) (@thick MainActor.Type) -> @owned MainActor
+// CHECK: [[MAIN_ACTOR:%.*]] = begin_borrow [[MAIN_ACTOR_REF]]
+// CHECK: hop_to_executor [[MAIN_ACTOR]]
+// CHECK: [[METHOD_REF:%.*]] = objc_method %0, #Doc.save!foreign
+// CHECK: apply [[METHOD_REF]]({{.*}}, %0)
+// CHECK-NOT: hop_to_executor {{.*}}
+// CHECK: await_async_continuation {{.*}}, resume bb1
+// CHECK: bb1:
+// CHECK: hop_to_executor [[MAIN_ACTOR]]
+// CHECK: } // end sil function '$s4main17testSameIsolation3docySo3DocC_tYaF'
+@MainActor
+func testSameIsolation(doc: Doc) async {
+  _ = await doc.save()
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s4main12testNoSwitch3docySo3DocC_tYaF : $@convention(thin) @async (@guaranteed Doc) -> () {
+// CHECK: [[MAIN_ACTOR_GETTER:%.*]] = function_ref @$sScM6sharedScMvgZ : $@convention(method) (@thick MainActor.Type) -> @owned MainActor
+// CHECK: [[MAIN_ACTOR_REF:%.*]] = apply [[MAIN_ACTOR_GETTER]]({{.*}}) : $@convention(method) (@thick MainActor.Type) -> @owned MainActor
+// CHECK: [[MAIN_ACTOR:%.*]] = begin_borrow [[MAIN_ACTOR_REF]]
+// CHECK: hop_to_executor [[MAIN_ACTOR]]
+// CHECK: [[METHOD_REF:%.*]] = objc_method %0, #Doc.undo!foreign
+// CHECK: apply [[METHOD_REF]]({{.*}}, %0)
+// CHECK-NOT: hop_to_executor {{.*}}
+// CHECK: await_async_continuation {{.*}}, resume bb1
+// CHECK: bb1:
+// CHECK: hop_to_executor [[MAIN_ACTOR]]
+// CHECK: } // end sil function '$s4main12testNoSwitch3docySo3DocC_tYaF'
+@MainActor
+func testNoSwitch(doc: Doc) async {
+  _ = await doc.undo() // `undo` is `nonisolated(nonsending)`
+}

--- a/test/SILGen/objc_async.swift
+++ b/test/SILGen/objc_async.swift
@@ -315,16 +315,19 @@ extension OptionalMemberLookups {
 
 
 // CHECK-LABEL: sil {{.*}} @$s10objc_async12checkHotdogsySSSgx_So8NSObjectCtYaKSo16HotdogCompetitorRzlF : $@convention(thin) @async <τ_0_0 where τ_0_0 : HotdogCompetitor> (@guaranteed τ_0_0, @guaranteed NSObject) -> (@owned Optional<String>, @error any Error) {
+// CHECK: [[GENERIC_EXEC:%.*]] = enum $Optional<any Actor>, #Optional.none!enumelt
+// CHECK: hop_to_executor [[GENERIC_EXEC]] : $Optional<any Actor>
+// CHECK: [[PILE_OF_HOT_DOGS_REF:%.*]] = objc_method %0 : $τ_0_0, #HotdogCompetitor.pileOfHotdogsToEat!foreign
 // CHECK: hop_to_executor {{.*}} : $MainActor
-// CHECK: [[AUTO_REL_STR:%.*]] = apply {{.*}}<τ_0_0>({{.*}}) : $@convention(objc_method)
+// CHECK: [[AUTO_REL_STR:%.*]] = apply [[PILE_OF_HOT_DOGS_REF]]<τ_0_0>({{.*}}) : $@convention(objc_method)
 // CHECK: [[UNMANAGED_OPTIONAL:%.*]] = load [trivial] {{.*}} : $*@sil_unmanaged Optional<NSError>
 // CHECK: [[MANAGED_OPTIONAL:%.*]] = unmanaged_to_ref [[UNMANAGED_OPTIONAL]] : $@sil_unmanaged Optional<NSError> to $Optional<NSError>
 // CHECK: [[RETAINED_OPTIONAL:%.*]] = copy_value [[MANAGED_OPTIONAL]] : $Optional<NSError>
 // CHECK: [[MARKED:%.*]] = mark_dependence [[RETAINED_OPTIONAL]] : $Optional<NSError> on {{.*}} : $*Optional<NSError>
 // CHECK: assign [[MARKED]] to {{.*}} : $*Optional<NSError>
-// CHECK: destroy_value {{.*}} : $MainActor
 // CHECK: dealloc_stack {{.*}} : $*AutoreleasingUnsafeMutablePointer<Optional<NSError>>
 // CHECK: dealloc_stack {{.*}} : $*@sil_unmanaged Optional<NSError>
+// CHECK: destroy_value {{.*}} : $MainActor
 // CHECK: hop_to_executor {{.*}} : $Optional<any Actor>
 // CHECK: switch_enum
 func checkHotdogs(_ v: some HotdogCompetitor, _ timeLimit: NSObject) async throws -> String? {


### PR DESCRIPTION
This is specific to global-actor isolated functions because by default
async variants are `nonisolated(nonsending)` and won't switch
isolation.

If we are emitting a call to an `async` variant of an ObjC completion
handler API, we need to hop at the call site because there is no
`async` function that is going to hop in its body. Such calls are
referencing a sync variant with a special completion handler
synthesized the compiler and the isolation context has to be
established beforehand.

Resolves: rdar://164739199

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
