### PR TITLE
[Concurrency] add '@concurrent' to hasExplicitIsolationAttribute (noop?)

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1222,6 +1222,11 @@ bool Decl::hasExplicitIsolationAttribute() const {
     }
   }
 
+  if (auto concurrentAttr = getAttrs().getAttribute<ConcurrentAttr>()) {
+    if (!concurrentAttr->isImplicit())
+      return true;
+  }
+
   if (auto globalActorAttr = getGlobalActorAttr()) {
     if (!globalActorAttr->first->isImplicit())
       return true;

--- a/test/Concurrency/predates_concurrency.swift
+++ b/test/Concurrency/predates_concurrency.swift
@@ -220,6 +220,11 @@ nonisolated func blah() {
   // expected-warning@-1 {{call to main actor-isolated static method 'predatesConcurrency()' in a synchronous nonisolated context}}
 }
 
+@concurrent func bleh() async {
+  InferMainActorPreconcurrency.predatesConcurrency()
+  // expected-warning@-1 {{main actor-isolated static method 'predatesConcurrency()' cannot be called from outside of the actor; this is an error in the Swift 6 language mode}}
+}
+
 protocol NotIsolated {
   func requirement()
 }


### PR DESCRIPTION
This commit adds a check for the `@concurrent` attribute as part of `hasExplicitIsolationAttribute`. Concurrent is an isolation attribute, so we should consider it for this check. This change should not change behavior in any existing consumer, since a concurrent function is already an async function; it's only used in `contextRequiresStrictConcurrencyChecking`, which will also return true for async functions. However, I was surprised this check didn't include `@concurrent` when I tried to use it for file-level default isolation, and I think leaving it like this could lead to a bug in the future if it is used other places?

The test added by this commit would pass without this change, since the function is also async.

It is quite possible we don't want to make this change, but in that case I think we should change the doccomment for `hasExplicitIsolationAttribute` 😅 

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
