### PR TITLE
Remove Builtin.borrowAt usage from the standard library

### DIFF
--- a/stdlib/public/core/InlineArray.swift
+++ b/stdlib/public/core/InlineArray.swift
@@ -532,7 +532,7 @@ extension InlineArray where Element: ~Copyable {
     @_transparent
     @_unsafeSelfDependentResult
     borrow {
-      Builtin.borrowAt(unsafe (_protectedAddress + i)._rawValue)
+      unsafe (_protectedAddress + i).pointee
     }
 
     @_transparent

--- a/stdlib/public/core/Span/MutableSpan.swift
+++ b/stdlib/public/core/Span/MutableSpan.swift
@@ -434,7 +434,8 @@ extension MutableSpan where Element: ~Copyable {
     @_transparent
     @_unsafeSelfDependentResult
     borrow {
-      Builtin.borrowAt(unsafe _unsafeAddressOfElement(unchecked: position))
+      unsafe UnsafePointer<Element>(
+        _unsafeAddressOfElement(unchecked: position)).pointee
     }
     @_transparent
     @_unsafeSelfDependentResult

--- a/stdlib/public/core/Span/OutputSpan.swift
+++ b/stdlib/public/core/Span/OutputSpan.swift
@@ -238,7 +238,8 @@ extension OutputSpan where Element: ~Copyable {
   public subscript(unchecked index: Index) -> Element {
     @_unsafeSelfDependentResult
     borrow {
-      Builtin.borrowAt(unsafe _unsafeAddressOfElement(unchecked: index))
+      unsafe UnsafePointer<Element>(
+        _unsafeAddressOfElement(unchecked: index)).pointee
     }
     @_unsafeSelfDependentResult
     @_lifetime(self: copy self)

--- a/stdlib/public/core/Span/Span.swift
+++ b/stdlib/public/core/Span/Span.swift
@@ -474,7 +474,8 @@ extension Span where Element: ~Copyable {
   public subscript(unchecked position: Index) -> Element {
     @_unsafeSelfDependentResult
     borrow {
-      Builtin.borrowAt(unsafe _unsafeAddressOfElement(unchecked: position))
+      unsafe UnsafePointer<Element>(
+        _unsafeAddressOfElement(unchecked: position)).pointee
     }
   }
 

--- a/stdlib/public/core/_InlineArray.swift
+++ b/stdlib/public/core/_InlineArray.swift
@@ -414,7 +414,7 @@ extension _InlineArray where Element: ~Copyable {
     @_transparent
     @_unsafeSelfDependentResult
     borrow {
-      Builtin.borrowAt(unsafe (_protectedAddress + i)._rawValue)
+      unsafe (_protectedAddress + i).pointee
     }
 
     @_transparent


### PR DESCRIPTION
This builtin cannot be used inside inlinable functions without a feature
guard. It is needed for ~Escapable elements. Guarding the uses with a feature
flag will, however, be quite cumbersome. Let's hope that by the time we need ~E
elements, the oldest relevant toolchain has support for this builtin.

Fixes rdar://178659021 (condfail: error: module 'Builtin' has no member named
'borrowAt')
