### PR TITLE
[6.4] Remove Builtin.borrowAt usage from the standard library

### DIFF
--- a/stdlib/public/core/Span/MutableSpan.swift
+++ b/stdlib/public/core/Span/MutableSpan.swift
@@ -434,7 +434,8 @@ extension MutableSpan where Element: ~Copyable {
     @_transparent
     @_unsafeSelfDependentResult
     borrow {
-      Builtin.borrowAt(unsafe _unsafeAddressOfElement(unchecked: position))
+      unsafe UnsafePointer<Element>(
+        _unsafeAddressOfElement(unchecked: position)).pointee
     }
     @_transparent
     @_unsafeSelfDependentResult

--- a/stdlib/public/core/Span/OutputSpan.swift
+++ b/stdlib/public/core/Span/OutputSpan.swift
@@ -238,7 +238,8 @@ extension OutputSpan where Element: ~Copyable {
   public subscript(unchecked index: Index) -> Element {
     @_unsafeSelfDependentResult
     borrow {
-      Builtin.borrowAt(unsafe _unsafeAddressOfElement(unchecked: index))
+      unsafe UnsafePointer<Element>(
+        _unsafeAddressOfElement(unchecked: index)).pointee
     }
     @_unsafeSelfDependentResult
     @lifetime(self: copy self)

--- a/stdlib/public/core/Span/Span.swift
+++ b/stdlib/public/core/Span/Span.swift
@@ -474,7 +474,8 @@ extension Span where Element: ~Copyable {
   public subscript(unchecked position: Index) -> Element {
     @_unsafeSelfDependentResult
     borrow {
-      Builtin.borrowAt(unsafe _unsafeAddressOfElement(unchecked: position))
+      unsafe UnsafePointer<Element>(
+        _unsafeAddressOfElement(unchecked: position)).pointee
     }
   }
 


### PR DESCRIPTION

- **Explanation**: Back out recent standard library usage of
  Builtin.borrowAt. It will need to be guarded by a feature flag, but
  it's only for ~E elements, which we don't need to support on 6.4

- **Scope**: Reverts Span, MutableSpan, OutputSpan, and InlineArray
  subscripts to the prior implementation.

- **Issues**: rdar://178659021 (swiftlang-6.4.0.24.3 condfail: error:
  module 'Builtin' has no member named 'borrowAt')

- **Original PRs**: https://github.com/swiftlang/swift/pull/89669

- **Risk**: Minimal

- **Testing**: None required - this only reverts some stdlib changes

- **Reviewers**: @glessard 

This builtin cannot be used inside inlinable functions without a feature
guard. It is needed for ~Escapable elements. Guarding the uses with a feature
flag will, however, be quite cumbersome. Let's hope that by the time we need ~E
elements, the oldest relevant toolchain has support for this builtin.
