### PR TITLE
[Concurrency][Docs] Improve TaskExecutor docs correctness and centralize

### DIFF
--- a/stdlib/public/Concurrency/Executor.swift
+++ b/stdlib/public/Concurrency/Executor.swift
@@ -447,7 +447,7 @@ extension SerialExecutor {
 /// the provided task executor, instead of the default global one.
 ///
 /// If an actor has a specific executor requirement, the task executor preference will not take effect.
-
+///
 /// The task executor preference is effective through child tasks as well, so even if
 /// a child task of a task with a preference did not re-state the preference, the preference is still active:
 ///
@@ -461,8 +461,106 @@ extension SerialExecutor {
 ///         }
 ///       }
 ///     }
-///
 /// Unstructured tasks do not inherit the task executor preference.
+///
+/// ### Task executor preference semantics
+/// Task executors influence _where_ nonisolated asynchronous functions, and default actor methods execute.
+/// The preferred executor will be used whenever possible, rather than hopping to the global concurrent pool.
+///
+/// For an in depth discussion of this topic, see ``TaskExecutor``.
+///
+/// ### Asynchronous function execution semantics in presence of task executor preferences
+/// The following diagram illustrates on which executor an `async` function will
+/// execute, in presence (or lack thereof) a task executor preference.
+///
+/// ```
+/// [ func / closure ] - /* where should it execute? */
+///                               |
+///                     +--------------+          +===========================+
+///           +-------- | is isolated? | - yes -> | actor has unownedExecutor |
+///           |         +--------------+          +===========================+
+///           |                                       |                |
+///           |                                      yes               no
+///           |                                       |                |
+///           |                                       v                v
+///           |                  +=======================+    /* task executor preference? */
+///           |                  | on specified executor |        |                   |
+///           |                  +=======================+       yes                  no
+///           |                                                   |                   |
+///           |                                                   |                   v
+///           |                                                   |    +==========================+
+///           |                                                   |    | default (actor) executor |
+///           |                                                   v    +==========================+
+///           v                                     +==============================+
+///  /* task executor preference? */ ---- yes ----> | on Task's preferred executor |
+///           |                                     +==============================+
+///           no
+///           |
+///           v
+///  +===============================+
+///  | on global concurrent executor |
+///  +===============================+
+/// ```
+///
+/// In short, without a task executor preference, `nonisolated async` functions
+/// will execute on the global concurrent executor. If a task executor preference
+/// is present, such `nonisolated async` functions will execute on the preferred
+/// task executor.
+///
+/// Isolated functions semantically execute on the actor they are isolated to,
+/// however if such actor does not declare a custom executor (it is a "default
+/// actor"), in presence of a task executor preference, tasks executing on this
+/// actor will use the preferred executor as source of threads to run the task,
+/// while isolated on the actor.
+///
+/// ### Disabling task executor preference
+/// Pass ``globalConcurrentExecutor`` to override any existing preference with the global concurrent executor,
+/// which is equivalent to having no preference set.
+///
+/// ### Example
+///
+///     Task {
+///       // case 0) "no task executor preference"
+///
+///       // default task executor
+///       // ...
+///       await SomeDefaultActor().hello() // default executor
+///       await ActorWithCustomExecutor().hello() // 'hello' executes on actor's custom executor
+///
+///       // child tasks execute on default executor:
+///       async let x = ...
+///       await withTaskGroup(of: Int.self) { group in g.addTask { 7 } }
+///
+///       await withTaskExecutorPreference(specific) {
+///         // case 1) 'specific' task executor preference
+///
+///         // 'specific' task executor
+///         // ...
+///         await SomeDefaultActor().hello() // 'hello' executes on 'specific' executor
+///         await ActorWithCustomExecutor().hello() // 'hello' executes on actor's custom executor (same as case 0)
+///
+///         // child tasks execute on 'specific' task executor:
+///         async let x = ...
+///         await withTaskGroup(of: Int.self) { group in
+///           group.addTask { 7 } // child task executes on 'specific' executor
+///           group.addTask(executorPreference: globalConcurrentExecutor) { 13 } // child task executes on global concurrent executor
+///         }
+///
+///         // disable the task executor preference:
+///         await withTaskExecutorPreference(globalConcurrentExecutor) {
+///           // equivalent to case 0) preference is globalConcurrentExecutor
+///
+///           // default task executor
+///           // ...
+///           await SomeDefaultActor().hello() // default executor (same as case 0)
+///           await ActorWithCustomExecutor().hello() // 'hello' executes on actor's custom executor (same as case 0)
+///
+///           // child tasks execute on default executor (same as case 0):
+///           async let x = ...
+///           await withTaskGroup(of: Int.self) { group in group.addTask { 7 } }
+///         }
+///       }
+///     }
 ///
 /// - SeeAlso: ``withTaskExecutorPreference(_:operation:)``
 @available(StdlibDeploymentTarget 6.0, *)

--- a/stdlib/public/Concurrency/Executor.swift
+++ b/stdlib/public/Concurrency/Executor.swift
@@ -433,7 +433,7 @@ extension SerialExecutor {
 /// An executor that may be used as preferred executor by a task.
 ///
 /// ### Impact of setting a task executor preference
-/// By default, without setting a task executor preference, nonisolated
+/// By default, without setting a task executor preference, @concurrent
 /// asynchronous functions, as well as methods declared on default actors --
 /// that is actors which do not require a specific executor -- execute on
 /// Swift's default global concurrent executor. This is an executor shared by
@@ -443,10 +443,28 @@ extension SerialExecutor {
 /// By setting a task executor preference, either with a
 /// ``withTaskExecutorPreference(_:operation:)``, creating a task with a preference
 /// (`Task(executorPreference:)`, or `group.addTask(executorPreference:)`), the task and all of its child
-/// tasks (unless a new preference is set) will be preferring to execute on
-/// the provided task executor.
+/// tasks (unless a new preference is set) will prefer to execute on
+/// the provided task executor, instead of the default global one.
 ///
-/// Unstructured tasks do not inherit the task executor.
+/// If an actor has a specific executor requirement, the task executor preference will not take effect.
+
+/// The task executor preference is effective through child tasks as well, so even if
+/// a child task of a task with a preference did not re-state the preference, the preference is still active:
+///
+///     await withTaskExecutorPreference(myExecutor) {
+///       // 'myExecutor' is the preferred task executor here.
+///       await withDiscardingTaskGroup { group in
+///         group.addTask {
+///           // No 'executorPreference:' was passed when adding this child task,
+///           // but it still inherits 'myExecutor' from the enclosing task.
+///           await runWork()
+///         }
+///       }
+///     }
+///
+/// Unstructured tasks do not inherit the task executor preference.
+///
+/// - SeeAlso: ``withTaskExecutorPreference(_:operation:)``
 @available(StdlibDeploymentTarget 6.0, *)
 public protocol TaskExecutor: Executor {
   // This requirement is repeated here as a non-override so that we

--- a/stdlib/public/Concurrency/Task+TaskExecutor.swift
+++ b/stdlib/public/Concurrency/Task+TaskExecutor.swift
@@ -18,110 +18,11 @@ import Swift
 /// Configure the current task hierarchy's task executor preference to the passed ``TaskExecutor``,
 /// and execute the passed in closure by immediately hopping to that executor.
 ///
-/// ### Task executor preference semantics
-/// Task executors influence _where_ nonisolated asynchronous functions, and default actor methods execute.
-/// The preferred executor will be used whenever possible, rather than hopping to the global concurrent pool.
-///
-/// For an in depth discussion of this topic, see ``TaskExecutor``.
-///
-/// ### Disabling task executor preference
-/// Pass `globalConcurrentExecutor` to override any existing preference with the default global executor,
-/// which is equivalent to having no preference set.
-///
-/// ### Asynchronous function execution semantics in presence of task executor preferences
-/// The following diagram illustrates on which executor an `async` function will
-/// execute, in presence (or lack thereof) a task executor preference.
-///
-/// ```
-/// [ func / closure ] - /* where should it execute? */
-///                               |
-///                     +--------------+          +===========================+
-///           +-------- | is isolated? | - yes -> | actor has unownedExecutor |
-///           |         +--------------+          +===========================+
-///           |                                       |                |
-///           |                                      yes               no
-///           |                                       |                |
-///           |                                       v                v
-///           |                  +=======================+    /* task executor preference? */
-///           |                  | on specified executor |        |                   |
-///           |                  +=======================+       yes                  no
-///           |                                                   |                   |
-///           |                                                   |                   v
-///           |                                                   |    +==========================+
-///           |                                                   |    | default (actor) executor |
-///           |                                                   v    +==========================+
-///           v                                     +==============================+
-///  /* task executor preference? */ ---- yes ----> | on Task's preferred executor |
-///           |                                     +==============================+
-///           no
-///           |
-///           v
-///  +===============================+
-///  | on global concurrent executor |
-///  +===============================+
-/// ```
-///
-/// In short, without a task executor preference, `nonisolated async` functions
-/// will execute on the global concurrent executor. If a task executor preference
-/// is present, such `nonisolated async` functions will execute on the preferred
-/// task executor.
-///
-/// Isolated functions semantically execute on the actor they are isolated to,
-/// however if such actor does not declare a custom executor (it is a "default
-/// actor") in presence of a task executor preference, tasks executing on this
-/// actor will use the preferred executor as source of threads to run the task,
-/// while isolated on the actor.
-///
-/// ### Example
-///
-///     Task {
-///       // case 0) "no task executor preference"
-///
-///       // default task executor
-///       // ...
-///       await SomeDefaultActor().hello() // default executor
-///       await ActorWithCustomExecutor().hello() // 'hello' executes on actor's custom executor
-///
-///       // child tasks execute on default executor:
-///       async let x = ...
-///       await withTaskGroup(of: Int.self) { group in g.addTask { 7 } }
-///
-///       await withTaskExecutorPreference(specific) {
-///         // case 1) 'specific' task executor preference
-///
-///         // 'specific' task executor
-///         // ...
-///         await SomeDefaultActor().hello() // 'hello' executes on 'specific' executor
-///         await ActorWithCustomExecutor().hello() // 'hello' executes on actor's custom executor (same as case 0)
-///
-///         // child tasks execute on 'specific' task executor:
-///         async let x = ...
-///         await withTaskGroup(of: Int.self) { group in
-///           group.addTask { 7 } // child task executes on 'specific' executor
-///           group.addTask(executorPreference: globalConcurrentExecutor) { 13 } // child task executes on global concurrent executor
-///         }
-///
-///         // disable the task executor preference:
-///         await withTaskExecutorPreference(globalConcurrentExecutor) {
-///           // equivalent to case 0) preference is globalConcurrentExecutor
-///
-///           // default task executor
-///           // ...
-///           await SomeDefaultActor().hello() // default executor (same as case 0)
-///           await ActorWithCustomExecutor().hello() // 'hello' executes on actor's custom executor (same as case 0)
-///
-///           // child tasks execute on default executor (same as case 0):
-///           async let x = ...
-///           await withTaskGroup(of: Int.self) { group in group.addTask { 7 } }
-///         }
-///       }
-///     }
+/// Refer to ``TaskExecutor`` documentation for an in-depth explanation about executor selection mechanisms.
 ///
 /// - Parameters:
 ///   - taskExecutor: The preferred task executor for this operation, and any
 ///     child tasks created inside the `operation` closure.
-///     If `nil` it is interpreted as "no preference" and calling this method
-///     will have no impact on execution semantics of the `operation`.
 ///     Pass ``globalConcurrentExecutor`` to explicitly prefer the global
 ///     concurrent executor (e.g. to override an outer task's preference).
 ///   - operation: the operation to execute on the passed executor

--- a/stdlib/public/Concurrency/Task+TaskExecutor.swift
+++ b/stdlib/public/Concurrency/Task+TaskExecutor.swift
@@ -25,8 +25,8 @@ import Swift
 /// For an in depth discussion of this topic, see ``TaskExecutor``.
 ///
 /// ### Disabling task executor preference
-/// Passing `nil` as executor means disabling any preference (if it was set) and the task hierarchy
-/// will execute without any executor preference until a different preference is set.
+/// Pass `globalConcurrentExecutor` to override any existing preference with the default global executor,
+/// which is equivalent to having no preference set.
 ///
 /// ### Asynchronous function execution semantics in presence of task executor preferences
 /// The following diagram illustrates on which executor an `async` function will
@@ -118,10 +118,12 @@ import Swift
 ///     }
 ///
 /// - Parameters:
-///   - taskExecutor: the executor to use as preferred task executor for this
-///     operation, and any child tasks created inside the `operation` closure.
+///   - taskExecutor: The preferred task executor for this operation, and any
+///     child tasks created inside the `operation` closure.
 ///     If `nil` it is interpreted as "no preference" and calling this method
-///     will have no impact on execution semantics of the `operation`
+///     will have no impact on execution semantics of the `operation`.
+///     Pass ``globalConcurrentExecutor`` to explicitly prefer the global
+///     concurrent executor (e.g. to override an outer task's preference).
 ///   - operation: the operation to execute on the passed executor
 /// - Returns: the value returned from the `operation` closure
 /// - Throws: if the operation closure throws

--- a/stdlib/public/Concurrency/Task+immediate.swift.gyb
+++ b/stdlib/public/Concurrency/Task+immediate.swift.gyb
@@ -64,10 +64,8 @@ extension Task where Failure == ${FAILURE_TYPE} {
   ///   - name: The high-level human-readable name given for this task
   ///   - priority: The priority of the task.
   ///     Pass `nil` to use the ``Task/basePriority`` of the current task (if there is one).
-  ///   - taskExecutor: The task executor that the child task should be started on and keep using.
-  ///      Explicitly passing `nil` as the executor preference is equivalent to no preference,
-  ///      and effectively means to inherit the outer context's executor preference.
-  ///      You can also pass the ``globalConcurrentExecutor`` global executor explicitly.
+  ///   - taskExecutor: The preferred task executor for this task and any child
+  ///      tasks it creates. Explicitly passing `nil` means no preference.
   ///   - operation: the operation to be run immediately upon entering the task.
   /// - Returns: A reference to the unstructured task which may be awaited on.
   @available(SwiftStdlib 6.2, *)
@@ -245,11 +243,9 @@ extension ${GROUP_TYPE} {
   ///   - name: Human readable name of this task.
   ///   - priority: The priority of the operation task.
   ///      Omit this parameter or pass `nil` to inherit the task group's base priority.
-  ///   - taskExecutor: The task executor that the child task should be started on and keep using.
-  ///      Explicitly passing `nil` as the executor preference is equivalent to
-  ///      calling the `${METHOD_NAME}` method without a preference, and effectively
-  ///      means to inherit the outer context's executor preference.
-  ///      You can also pass the ``globalConcurrentExecutor`` global executor explicitly.
+  ///   - taskExecutor: The preferred task executor for this task and any child
+  ///      tasks it creates. Pass ``globalConcurrentExecutor`` to explicitly prefer
+  ///      the global concurrent executor (e.g. to override an outer task's preference).
   ///   - operation: The operation to execute as part of the task group.
   % if IS_ADD_UNLESS_CANCELLED:
   /// - Returns: `true` if the child task was added to the group;

--- a/stdlib/public/Concurrency/Task+init.swift.gyb
+++ b/stdlib/public/Concurrency/Task+init.swift.gyb
@@ -275,10 +275,8 @@ extension Task where Failure == ${FAILURE_TYPE} {
   ///   - name: Human readable name of the task.
   % end
   % if HAS_TASK_EXECUTOR:
-  ///   - taskExecutor: The task executor that the child task should be started on and keep using.
-  ///      Explicitly passing `nil` as the executor preference is equivalent to no preference,
-  ///      and effectively means to inherit the outer context's executor preference.
-  ///      You can also pass the ``globalConcurrentExecutor`` global executor explicitly.
+  ///   - taskExecutor: The preferred task executor for this task and any child
+  ///      tasks it creates. Explicitly passing `nil` means no preference.
   % end
   ///   - priority: The priority of the operation task.
   % if IS_DETACHED:

--- a/stdlib/public/Concurrency/TaskGroup+addTask.swift.gyb
+++ b/stdlib/public/Concurrency/TaskGroup+addTask.swift.gyb
@@ -232,11 +232,10 @@ extension ${TYPE} {
   ///   - name: Human readable name of this task.
   % end
   % if HAS_TASK_EXECUTOR:
-  ///   - taskExecutor: The task executor that the child task should be started on and keep using.
-  ///      Explicitly passing `nil` as the executor preference is equivalent to
-  ///      calling the `${METHOD_NAME}` method without a preference, and effectively
-  ///      means to inherit the outer context's executor preference.
-  ///      You can also pass the ``globalConcurrentExecutor`` global executor explicitly.
+  ///   - taskExecutor: The preferred task executor for this task and any child
+  ///      tasks it creates.
+  ///      Pass ``globalConcurrentExecutor`` to explicitly prefer the global
+  ///      concurrent executor (e.g. to override an outer task's preference).
   % end
   % if HAS_TASK_PRIORITY:
   ///   - priority: The priority of the operation task.


### PR DESCRIPTION
There is no "inherit" the preference when we create a new unstructured task; clarify the docs a bit.

Also move the "center of gravity" a bit to TaskExecutor docs, rather than withTaskExecutorPreference -- it's the right place to have the most detailed docs.

resolves rdar://171455704