### PR TITLE
generate diagnostic for conflicting generic types from a ternary expression

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -6775,6 +6775,26 @@ bool ConstraintSystem::repairFailures(
     if (repairByTreatingRValueAsLValue(lhs, rhs))
       break;
 
+    // When both sides are bound generics of the same kind, a mismatch is
+    // structural, so record it as a generic-argument mismatch to enable
+    // backtracking solution to surface a fix that the conflicting-arguments
+    // diagnosis recognises.
+    // Without this, the alternate disjunct produces an `IgnoreContextualType`
+    // fix that hides the underlying conflict in a tenary expressions such as
+    // `f(c ? .a : .b)` when the branches resolve to conflicting specializations.
+    if (auto bound1 = lhs->getAs<BoundGenericType>()) {
+      if (auto bound2 = rhs->getAs<BoundGenericType>()) {
+        if (bound1->getDecl() == bound2->getDecl()) {
+          SmallVector<unsigned, 2> mismatches;
+          for (unsigned i = 0, n = bound1->getGenericArgs().size(); i != n; ++i)
+            mismatches.push_back(i);
+          conversionsOrFixes.push_back(GenericArgumentsMismatch::create(
+              *this, lhs, rhs, mismatches, getConstraintLocator(locator)));
+          break;
+        }
+      }
+    }
+
     // If there is a type mismatch here it's contextual e.g.,
     // `let x: E = .foo(42)`, where `.foo` is a member of `E`
     // but produces an incorrect type.

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2296,6 +2296,16 @@ static bool diagnoseConflictingGenericArguments(ConstraintSystem &cs,
       llvm::all_of(solutions, [](const Solution &solution) -> bool {
         return llvm::all_of(
             solution.Fixes, [](const ConstraintFix *fix) -> bool {
+              if (fix->getKind() == FixKind::IgnoreContextualType) {
+                // Only consider an `IgnoreContextualType` fix at the
+                // unresolved-member chain result when looking for conflicting
+                // generic arguments. This is produced in a ternary expression
+                // with branches that resolve to conflicting specializations of
+                // the same generic type.
+                return fix->getLocator()
+                    ->isLastElement<
+                        LocatorPathElt::UnresolvedMemberChainResult>();
+              }
               return fix->getKind() == FixKind::AllowArgumentTypeMismatch ||
                      fix->getKind() == FixKind::AllowFunctionTypeMismatch ||
                      fix->getKind() == FixKind::AllowTupleTypeMismatch ||

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2296,16 +2296,6 @@ static bool diagnoseConflictingGenericArguments(ConstraintSystem &cs,
       llvm::all_of(solutions, [](const Solution &solution) -> bool {
         return llvm::all_of(
             solution.Fixes, [](const ConstraintFix *fix) -> bool {
-              if (fix->getKind() == FixKind::IgnoreContextualType) {
-                // Only consider an `IgnoreContextualType` fix at the
-                // unresolved-member chain result when looking for conflicting
-                // generic arguments. This is produced in a ternary expression
-                // with branches that resolve to conflicting specializations of
-                // the same generic type.
-                return fix->getLocator()
-                    ->isLastElement<
-                        LocatorPathElt::UnresolvedMemberChainResult>();
-              }
               return fix->getKind() == FixKind::AllowArgumentTypeMismatch ||
                      fix->getKind() == FixKind::AllowFunctionTypeMismatch ||
                      fix->getKind() == FixKind::AllowTupleTypeMismatch ||

--- a/test/Constraints/ternary_expr.swift
+++ b/test/Constraints/ternary_expr.swift
@@ -108,3 +108,21 @@ do {
     _ = Data(value: n) // Ok
   }
 }
+
+// Test scenario from https://github.com/swiftlang/swift/issues/89507 - 
+// a ternary expression with branches that resolve to conflicting 
+// specializations of the same generic type should produce a diagnostic
+// about the conflict.
+// Both `f`'s `E` and `G`'s `E` end up in conflict, so two reports are emitted.
+do {
+  struct G<E> {
+    static var a: G<Int> { fatalError() }
+    static var b: G<String> { fatalError() }
+  }
+
+  func f<E>(_: G<E>) {}
+
+  func test(c: Bool) {
+    f(c ? .a : .b) // expected-error 2 {{conflicting arguments to generic parameter 'E' ('Int' vs. 'String')}}
+  }
+}


### PR DESCRIPTION
Resolves #89507

I'm taking my first stab at understanding the diagnostic system (and the details of the constraint solver), so I'm kind of in over my head, and very willing to change anything about this. I wasn't sure if that one exceptional flow in the `all_of` was acceptable, or if I should be looking at this another way.

My understanding is pretty anemic, but I'd love any feedback on what would be better ways of solving this so I could work it out myself, the solution I'd assembled isn't well thought out.