### PR TITLE
Sema: Preserve typealias sugar on the result of an implicit initializer call

### DIFF
--- a/lib/Sema/TypeOfReference.cpp
+++ b/lib/Sema/TypeOfReference.cpp
@@ -1791,6 +1791,47 @@ Type ConstraintSystem::getMemberReferenceTypeFromOpenedType(
     // For a static member referenced through a metatype or an instance
     // member referenced through an instance, strip off the 'self'.
     type = type->castTo<FunctionType>()->getResult();
+
+    // For an initializer of a non-class type, the result type baked into the
+    // function type is the canonical nominal type (struct/enum). If the base
+    // metatype carries typealias sugar, resugar any occurrence of the nominal
+    // in the function's result so the constraint system records the type
+    // written in source.
+    if (isa<ConstructorDecl>(value) && !baseObjTy->isCanonical()) {
+      if (auto *fnTy = type->getAs<FunctionType>()) {
+        auto *baseDecl = baseObjTy->getAnyNominal();
+        Type newResult = fnTy->getResult().transformRec(
+            [&](TypeBase *t) -> std::optional<Type> {
+              // Concrete match against the base (e.g. `init() -> Self` for a
+              // non-generic struct, after self has been stripped).
+              if (t->isCanonical() && Type(t)->isEqual(baseObjTy))
+                return baseObjTy;
+
+              // Generic Self: the result has the constructed nominal with the
+              // opened type variables for the struct's own generic params as
+              // its arguments. Once those bind through the metatype-self
+              // matching they will exactly produce baseObjTy's underlying, so
+              // it is safe to substitute eagerly. Restricting to the case
+              // where every arg is a type variable avoids resugaring an
+              // unrelated literal occurrence like `init() -> Generic<Int>`.
+              if (auto *bgt = dyn_cast<BoundGenericType>(t)) {
+                if (baseDecl && bgt->getDecl() == baseDecl) {
+                  bool allTypeVars =
+                      llvm::all_of(bgt->getGenericArgs(), [](Type arg) {
+                        return arg->is<TypeVariableType>();
+                      });
+                  if (allTypeVars)
+                    return baseObjTy;
+                }
+              }
+              return std::nullopt;
+            });
+        if (newResult.getPointer() != fnTy->getResult().getPointer()) {
+          type = FunctionType::get(fnTy->getParams(), newResult,
+                                   fnTy->getExtInfo());
+        }
+      }
+    }
   } else {
     // For an unbound instance method reference, replace the 'Self'
     // parameter with the base type.

--- a/test/Constraints/construction.swift
+++ b/test/Constraints/construction.swift
@@ -298,3 +298,33 @@ public func rdar85263844_2(_ x: [Int]) -> S4<(outer: Int, y: Int)> {
   S4(x.map { (inner: $0, y: $0) })
   // expected-warning@-1 {{tuple conversion from '(inner: Int, y: Int)' to '(outer: Int, y: Int)' mismatches labels}}
 }
+
+struct AliasedStruct {
+  init() {}
+  init?(failable: Void) {}
+}
+class AliasedClass {}
+struct AliasedGeneric<T> {
+  init() {}
+  init?(failable: Void) {}
+}
+
+typealias StructAlias = AliasedStruct
+typealias ClassAlias = AliasedClass
+typealias BoundGenericAlias = AliasedGeneric<Int>
+typealias ParameterizedGenericAlias<T> = AliasedGeneric<T>
+
+func testAliasedTypeConstruction() {
+  let _: Int = StructAlias()
+  // expected-error@-1 {{cannot convert value of type 'StructAlias' (aka 'AliasedStruct') to specified type 'Int'}}
+  let _: Int = StructAlias(failable: ())
+  // expected-error@-1 {{cannot convert value of type 'StructAlias?' (aka 'Optional<AliasedStruct>') to specified type 'Int'}}
+  let _: Int = ClassAlias()
+  // expected-error@-1 {{cannot convert value of type 'ClassAlias' (aka 'AliasedClass') to specified type 'Int'}}
+  let _: Int = BoundGenericAlias()
+  // expected-error@-1 {{cannot convert value of type 'BoundGenericAlias' (aka 'AliasedGeneric<Int>') to specified type 'Int'}}
+  let _: Int = BoundGenericAlias(failable: ())
+  // expected-error@-1 {{cannot convert value of type 'BoundGenericAlias?' (aka 'Optional<AliasedGeneric<Int>>') to specified type 'Int'}}
+  let _: Int = ParameterizedGenericAlias<String>()
+  // expected-error@-1 {{cannot convert value of type 'ParameterizedGenericAlias<String>' (aka 'AliasedGeneric<String>') to specified type 'Int'}}
+}

--- a/test/IDE/complete_init.swift
+++ b/test/IDE/complete_init.swift
@@ -138,8 +138,8 @@ typealias CAlias = C
 
 var CAliasInstance = CAlias(#^ALIAS_CONSTRUCTOR_0^#
 // rdar://18586415
-// ALIAS_CONSTRUCTOR_0: Decl[Constructor]/CurrNominal/Flair[ArgLabels]:      ['(']{#x: A#}[')'][#C#];
-// ALIAS_CONSTRUCTOR_0: Decl[Constructor]/CurrNominal/Flair[ArgLabels]:      ['(']{#y: A#}[')'][#C#];
+// ALIAS_CONSTRUCTOR_0: Decl[Constructor]/CurrNominal/Flair[ArgLabels]:      ['(']{#x: A#}[')'][#CAlias#];
+// ALIAS_CONSTRUCTOR_0: Decl[Constructor]/CurrNominal/Flair[ArgLabels]:      ['(']{#y: A#}[')'][#CAlias#];
 
 // https://github.com/apple/swift/issues/57916
 struct Issue57916 {

--- a/test/decl/protocol/conforms/typed_throws.swift
+++ b/test/decl/protocol/conforms/typed_throws.swift
@@ -62,7 +62,7 @@ struct S3: FailureAssociatedType {
 func testAssociatedTypes() {
   let _ = S1.Failure() // expected-error{{'S1.Failure' (aka 'MyError') cannot be constructed because it has no accessible initializers}}
   let _ = S2.Failure() // expected-error{{'S2.Failure' (aka 'any Error') cannot be constructed because it has no accessible initializers}}
-  let _: Int = S3.Failure() // expected-error{{cannot convert value of type 'Never' to specified type 'Int'}}
+  let _: Int = S3.Failure() // expected-error{{cannot convert value of type 'S3.Failure' (aka 'Never') to specified type 'Int'}}
   // expected-error@-1{{missing argument for parameter 'from' in call}}
 }
 

--- a/test/decl/typealias/generic.swift
+++ b/test/decl/typealias/generic.swift
@@ -178,7 +178,7 @@ class GenericClass<T> {
   }
 
   func testCaptureInvalid1<S>(s: S, t: T) -> TA<Int> {
-    return TA<S>(a: t, b: s) // expected-error {{cannot convert return expression of type 'MyType<T, S>' to return type 'GenericClass<T>.TA<Int>' (aka 'MyType<T, Int>')}}
+    return TA<S>(a: t, b: s) // expected-error {{cannot convert return expression of type 'GenericClass<T>.TA<S>' (aka 'MyType<T, S>') to return type 'GenericClass<T>.TA<Int>' (aka 'MyType<T, Int>')}}
   }
 
   func testCaptureInvalid2<S>(s: Int, t: T) -> TA<S> {


### PR DESCRIPTION
When the constraint system resolves an implicit `.init(...)` on a metatype TypeExpr like `A.Type` (where `typealias A = X`), the function type produced by overload resolution embeds the canonical underlying nominal as the result. For class types, `withCovariantResultType` plus `replaceDynamicSelfType` already carry the sugared base through, but for non-class types Self in the result is the concrete struct or enum, so the sugar is lost. As a result, `solution.getType()` of the call records the canonical type rather than what the user wrote.

`TypeChecker::substituteInputSugarTypeForResult` patches the sugar back onto the AST node post-CSApply, but anything that consults the solver's recorded types (pattern bindings, conversion diagnostics, etc.) still sees only the canonical form. Most visibly, the type assigned to a pattern in a solved binding loses the typealias name, and "cannot convert value of type ..." errors print the underlying type.

Resugar inside `getMemberReferenceTypeFromOpenedType` for ConstructorDecl members whose base metatype carries sugar: walk the function's result and replace any occurrence of the canonical nominal with the sugared base.