### PR TITLE
[Sema] Use diagnoseAndRemoveAttr on invalid attributes for TLGs

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -357,6 +357,8 @@ swift::checkGlobalActorAttributes(SourceLoc loc, ArrayRef<CustomAttr *> attrs) {
       ctx.Diags.diagnose(attr->getLocation(), diag::multiple_global_actors_note,
                          nominal);
 
+      const_cast<CustomAttr *>(attr)->setInvalid();
+
       continue;
     }
 
@@ -436,8 +438,9 @@ GlobalActorAttributeRequest::evaluate(
     if (auto classDecl = dyn_cast<ClassDecl>(nominal)){
       if (classDecl->isActor()) {
         // ... except for actors.
-        nominal->diagnose(diag::global_actor_on_actor_class, nominal->getName())
-            .highlight(globalActorAttr->getRangeWithAt());
+        diagnoseAndRemoveAttr(nominal, globalActorAttr,
+                              diag::global_actor_on_actor_class,
+                              nominal->getName());
         return std::nullopt;
       }
     }
@@ -450,15 +453,16 @@ GlobalActorAttributeRequest::evaluate(
           (var->getDeclContext()->isAsyncContext() ||
            var->getASTContext().LangOpts.StrictConcurrencyLevel >=
              StrictConcurrency::Complete)) {
-        var->diagnose(diag::global_actor_top_level_var)
-            .highlight(globalActorAttr->getRangeWithAt());
+        diagnoseAndRemoveAttr(var, globalActorAttr,
+                              diag::global_actor_top_level_var);
         return std::nullopt;
       }
 
       // ... and not if it's local property
       if (var->getDeclContext()->isLocalContext()) {
-        var->diagnose(diag::global_actor_on_local_variable, var->getName())
-            .highlight(globalActorAttr->getRangeWithAt());
+        diagnoseAndRemoveAttr(var, globalActorAttr,
+                              diag::global_actor_on_local_variable,
+                              var->getName());
         return std::nullopt;
       }
     }
@@ -504,14 +508,17 @@ GlobalActorAttributeRequest::evaluate(
         }
 
         // In Swift 6, once the diag above is an error, it is disallowed.
-        if (ctx.isLanguageModeAtLeast(LanguageMode::v6))
+        if (ctx.isLanguageModeAtLeast(LanguageMode::v6)) {
+          globalActorAttr->setInvalid();
           return std::nullopt;
+        }
       }
     }
     // Functions are okay.
   } else {
     // Everything else is disallowed.
-    decl->diagnose(diag::global_actor_disallowed, decl);
+    diagnoseAndRemoveAttr(decl, globalActorAttr, diag::global_actor_disallowed,
+                          decl);
     return std::nullopt;
   }
 

--- a/test/Concurrency/global_actor_inference.swift
+++ b/test/Concurrency/global_actor_inference.swift
@@ -662,7 +662,7 @@ func acceptAsyncSendableClosureInheriting<T>(@_inheritActorContext _: @Sendable 
 // defer bodies inherit global actor-ness
 @MainActor
 var statefulThingy: Bool = false // expected-minimal-targeted-note {{var declared here}}
-// expected-complete-error @-1 {{top-level code variables cannot have a global actor}}
+// expected-complete-error @-2:1 {{top-level code variables cannot have a global actor}} {{1-+1:1=}}
 
 @MainActor
 func useFooInADefer() -> String { // expected-minimal-targeted-note {{calls to global function 'useFooInADefer()' from outside of its actor context are implicitly asynchronous}}

--- a/test/Concurrency/toplevel/main.swift
+++ b/test/Concurrency/toplevel/main.swift
@@ -15,7 +15,7 @@ func foo() -> Int {
 var a = 10 // expected-swift6-note 2{{var declared here}}
 
 @MainActor
-var b = 14 // expected-error {{top-level code variables cannot have a global actor}}
+var b = 14 // expected-error@-1:1 {{top-level code variables cannot have a global actor}} {{1-+1:1=}}
 
 func nonIsolatedSynchronous() {
   // expected-swift6-note@-1 {{add '@MainActor' to make global function 'nonIsolatedSynchronous()' part of global actor 'MainActor'}}

--- a/test/Concurrency/toplevel/synchronous_mainactor.swift
+++ b/test/Concurrency/toplevel/synchronous_mainactor.swift
@@ -3,7 +3,7 @@
 var a = 10 // expected-note{{var declared here}}
 
 @MainActor
-var b = 15 // expected-error{{top-level code variables cannot have a global actor}}
+var b = 15 // expected-error@-1:1 {{top-level code variables cannot have a global actor}} {{1-+1:1=}}
 
 func unsafeAccess() { // expected-note{{add '@MainActor' to make global function 'unsafeAccess()' part of global actor 'MainActor'}}
     print(a) // expected-error@:11{{main actor-isolated var 'a' can not be referenced from a nonisolated context}}

--- a/test/attr/global_actor.swift
+++ b/test/attr/global_actor.swift
@@ -62,7 +62,7 @@ struct OtherGlobalActor {
 }
 
 @GA1 func f() {
-  @GA1 let x = 17 // expected-error{{local variable 'x' cannot have a global actor}}
+  @GA1 let x = 17 // expected-error@:3{{local variable 'x' cannot have a global actor}} {{3-8=}}
   _ = x
 }
 
@@ -83,9 +83,9 @@ class SomeClass {
   @GA1 deinit { }
 }
 
-@GA1 typealias Integer = Int // expected-error{{type alias cannot have a global actor}}
+@GA1 typealias Integer = Int // expected-error@:1{{type alias cannot have a global actor}} {{1-6=}}
 
-@GA1 actor ActorInTooManyPlaces { } // expected-error{{actor 'ActorInTooManyPlaces' cannot have a global actor}}
+@GA1 actor ActorInTooManyPlaces { } // expected-error@:1{{actor 'ActorInTooManyPlaces' cannot have a global actor}} {{1-6=}}
 
 @GA1 @OtherGlobalActor func twoGlobalActors() { } // expected-error{{declaration can not have multiple global actor attributes ('OtherGlobalActor' and 'GA1')}}
 // expected-note@-1{{'GA1' attribute previously declared here}}


### PR DESCRIPTION
Use `diagnoseAndRemoveAttr` for invalid attributes on top level globals, so we can mark them invalid and generate a fix-it for removing them. Marking them invalid seems positive to me (so arbitrary code doesn't need to special case ignore attributes on these decls), although it doesn't reduce any diagnostics in our test suite. I hit this for one of my file-level default prototypes.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
