### PR TITLE
[Concurrency] change task name from record to fragment, static location

### DIFF
--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -2896,13 +2896,7 @@ enum class TaskStatusRecordKind : uint8_t {
   /// enqueued on.
   TaskExecutorPreference = 5,
 
-  /// A human-readable task name.
-  ///
-  /// Deprecated:
-  /// Previously (including Swift 6.4) initial task name was stored as a record.
-  /// However, we want to facilitate more efficient name lookups and avoid the record
-  /// infrastructure which is prepared for mutable state - therefore the task name
-  /// has become a *fragment*, so there's no need for the record kind anymore.
+  /// Deprecated: A human-readable task name, replaced by `NameFragment`.
   // DEPRECATED: TaskName = 6,
 
   // Kinds >= 192 are private to the implementation.

--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -2897,7 +2897,13 @@ enum class TaskStatusRecordKind : uint8_t {
   TaskExecutorPreference = 5,
 
   /// A human-readable task name.
-  TaskName = 6,
+  ///
+  /// Deprecated:
+  /// Previously (including Swift 6.4) initial task name was stored as a record.
+  /// However, we want to facilitate more efficient name lookups and avoid the record
+  /// infrastructure which is prepared for mutable state - therefore the task name
+  /// has become a *fragment*, so there's no need for the record kind anymore.
+  // DEPRECATED: TaskName = 6,
 
   // Kinds >= 192 are private to the implementation.
   First_Reserved = 192,

--- a/include/swift/ABI/Task.h
+++ b/include/swift/ABI/Task.h
@@ -545,7 +545,7 @@ public:
 
   void cancellationShieldPop();
 
-  // ==== Name Fragment --------------------------------------------------------
+  // ==== Task Name Fragment --------------------------------------------------------
 
   /// A fragment of an async task that holds the task's name.
   ///

--- a/include/swift/ABI/Task.h
+++ b/include/swift/ABI/Task.h
@@ -557,12 +557,19 @@ public:
     /// The string is allocated no the task-local allocator as the first thing
     /// allocated on it, and must be the last thing we free on it.
     const char *Name;
+    /// The length of the string stored in Name (not counting the trailing \0).
+    /// Used by tools so they can preallocate a buffer of the right size.
+    size_t NameLength;
 
   public:
-    explicit NameFragment(const char *name) : Name(name) {}
+    NameFragment() : Name(nullptr), NameLength(0) {}
 
     const char *getName() const { return Name; }
-    void setName(const char *name) { Name = name; }
+    size_t getNameLength() const { return NameLength; }
+    void setName(const char *name, size_t length) {
+      Name = name;
+      NameLength = length;
+    }
   };
 
   /// Returns the `NameFragment` of this task.

--- a/include/swift/ABI/Task.h
+++ b/include/swift/ABI/Task.h
@@ -60,6 +60,9 @@ class TaskOptionRecord;
 class TaskGroup;
 class ContinuationAsyncContext;
 
+// Forward-declared from `stdlib/public/Concurrency/Debug.h` so we can assert against it.
+extern "C" const size_t _swift_concurrency_debug_asyncTaskNameOffset;
+
 // lldb knows about some of these internals. If you change things that lldb
 // knows about (or might know about in the future, as a future lldb might be
 // inspecting a process running an older Swift runtime), increment
@@ -566,6 +569,10 @@ public:
     assert(hasTaskName());
     auto offset = reinterpret_cast<char*>(this);
     offset += sizeof(AsyncTask);
+    assert(static_cast<size_t>(offset - reinterpret_cast<char*>(this)) ==
+           _swift_concurrency_debug_asyncTaskNameOffset &&
+       "AsyncTask::nameFragment offset must match "
+       "_swift_concurrency_debug_asyncTaskNameOffset");
     return reinterpret_cast<NameFragment*>(offset);
   }
 

--- a/include/swift/ABI/Task.h
+++ b/include/swift/ABI/Task.h
@@ -60,8 +60,11 @@ class TaskOptionRecord;
 class TaskGroup;
 class ContinuationAsyncContext;
 
-// Forward-declared from `stdlib/public/Concurrency/Debug.h` so we can assert against it.
+// Forward-declared from `stdlib/public/Concurrency/Debug.h` so we can assert
+// against it.
+#if !SWIFT_CONCURRENCY_EMBEDDED
 extern "C" const size_t _swift_concurrency_debug_asyncTaskNameOffset;
+#endif
 
 // lldb knows about some of these internals. If you change things that lldb
 // knows about (or might know about in the future, as a future lldb might be
@@ -569,10 +572,12 @@ public:
     assert(hasTaskName());
     auto offset = reinterpret_cast<char*>(this);
     offset += sizeof(AsyncTask);
+#if !SWIFT_CONCURRENCY_EMBEDDED
     assert(static_cast<size_t>(offset - reinterpret_cast<char*>(this)) ==
            _swift_concurrency_debug_asyncTaskNameOffset &&
        "AsyncTask::nameFragment offset must match "
        "_swift_concurrency_debug_asyncTaskNameOffset");
+#endif
     return reinterpret_cast<NameFragment*>(offset);
   }
 

--- a/include/swift/ABI/Task.h
+++ b/include/swift/ABI/Task.h
@@ -545,6 +545,33 @@ public:
 
   void cancellationShieldPop();
 
+  // ==== Task Fragment Offsets -----------------------------------------------------
+
+  size_t nameFragmentOffset() const {
+    return sizeof(AsyncTask);
+  }
+
+  size_t childFragmentOffset() const {
+    size_t offset = nameFragmentOffset();
+    if (hasTaskName())
+      offset += sizeof(NameFragment);
+    return offset;
+  }
+
+  size_t groupChildFragmentOffset() const {
+    size_t offset = childFragmentOffset();
+    if (hasChildFragment())
+      offset += sizeof(ChildFragment);
+    return offset;
+  }
+
+  size_t futureFragmentOffset() const {
+    size_t offset = groupChildFragmentOffset();
+    if (hasGroupChildFragment())
+      offset += sizeof(GroupChildFragment);
+    return offset;
+  }
+
   // ==== Task Name Fragment --------------------------------------------------------
 
   /// A fragment of an async task that holds the task's name.
@@ -572,20 +599,16 @@ public:
     }
   };
 
-  /// Returns the `NameFragment` of this task.
-  ///
-  /// WARNING: Only valid when `hasTaskName()` is true.
   NameFragment *nameFragment() {
     assert(hasTaskName());
-    auto offset = reinterpret_cast<char*>(this);
-    offset += sizeof(AsyncTask);
+    auto *offset = reinterpret_cast<char *>(this) + nameFragmentOffset();
 #if !SWIFT_CONCURRENCY_EMBEDDED
-    assert(static_cast<size_t>(offset - reinterpret_cast<char*>(this)) ==
-           _swift_concurrency_debug_asyncTaskNameOffset &&
-       "AsyncTask::nameFragment offset must match "
-       "_swift_concurrency_debug_asyncTaskNameOffset");
+    assert(static_cast<size_t>(offset - reinterpret_cast<char *>(this)) ==
+               _swift_concurrency_debug_asyncTaskNameOffset &&
+           "AsyncTask::nameFragment offset must match "
+           "_swift_concurrency_debug_asyncTaskNameOffset");
 #endif
-    return reinterpret_cast<NameFragment*>(offset);
+    return reinterpret_cast<NameFragment *>(offset);
   }
 
   // ==== Child Fragment -------------------------------------------------------
@@ -645,13 +668,8 @@ public:
 
   ChildFragment *childFragment() {
     assert(hasChildFragment());
-
-    auto offset = reinterpret_cast<char*>(this);
-    offset += sizeof(AsyncTask);
-    if (hasTaskName())
-      offset += sizeof(NameFragment);
-
-    return reinterpret_cast<ChildFragment*>(offset);
+    return reinterpret_cast<ChildFragment *>(
+        reinterpret_cast<char *>(this) + childFragmentOffset());
   }
 
   // ==== TaskGroup Child ------------------------------------------------------
@@ -686,15 +704,8 @@ public:
 
   GroupChildFragment *groupChildFragment() {
     assert(hasGroupChildFragment());
-
-    auto offset = reinterpret_cast<char*>(this);
-    offset += sizeof(AsyncTask);
-    if (hasTaskName())
-      offset += sizeof(NameFragment);
-    if (hasChildFragment())
-      offset += sizeof(ChildFragment);
-
-    return reinterpret_cast<GroupChildFragment *>(offset);
+    return reinterpret_cast<GroupChildFragment *>(
+        reinterpret_cast<char *>(this) + groupChildFragmentOffset());
   }
 
   // ==== Task Executor Preference --------------------------------------------
@@ -832,16 +843,8 @@ public:
 
   FutureFragment *futureFragment() {
     assert(isFuture());
-    auto offset = reinterpret_cast<char*>(this);
-    offset += sizeof(AsyncTask);
-    if (hasTaskName())
-      offset += sizeof(NameFragment);
-    if (hasChildFragment())
-      offset += sizeof(ChildFragment);
-    if (hasGroupChildFragment())
-      offset += sizeof(GroupChildFragment);
-
-    return reinterpret_cast<FutureFragment *>(offset);
+    return reinterpret_cast<FutureFragment *>(
+        reinterpret_cast<char *>(this) + futureFragmentOffset());
   }
 
   /// Wait for this future to complete.

--- a/include/swift/ABI/Task.h
+++ b/include/swift/ABI/Task.h
@@ -65,6 +65,8 @@ class ContinuationAsyncContext;
 // inspecting a process running an older Swift runtime), increment
 // _swift_concurrency_debug_internal_layout_version and add a comment describing
 // the new version.
+//
+// See `Concurrency/Debug.h` for details about each version.
 
 extern const HeapMetadata *jobHeapMetadataPtr;
 extern const HeapMetadata *taskHeapMetadataPtr;
@@ -283,6 +285,7 @@ struct ResultTypeInfo {
 /// An AsyncTask may have the following fragments:
 ///
 ///    +--------------------------+
+///    | nameFragment?            |
 ///    | childFragment?           |
 ///    | groupChildFragment?      |
 ///    | futureFragment?          |*
@@ -473,25 +476,18 @@ public:
   ///        Cancellation shields prevent the observation of the isCancelled flag while active.
   bool isCancelled(bool ignoreShield) const;
 
-  // ==== INITIAL TASK RECORDS =================================================
-  // A task may have a number of "initial" records set, they MUST be set in the
-  // following order to make the task-local allocation/deallocation's stack
-  // discipline easy to work out at the tasks destruction:
-  //
-  // - Initial TaskName
-  // - Initial ExecutorPreference
-
   // ==== Task Naming ----------------------------------------------------------
 
-  /// At task creation a task may be assigned a name.
-  void pushInitialTaskName(const char* taskName);
-  void dropInitialTaskNameRecord();
-
   /// Get the initial task name that was given to this task during creation,
-  /// or nullptr if the task has no name
+  /// or nullptr if the task has no name.
   const char* getTaskName();
 
-  bool hasInitialTaskNameRecord() const {
+  /// Copy `taskName` into the the task local allocated memory, and store a pointer
+  /// to it in `NameFragment`.
+  void initializeTaskName(const char *taskName);
+
+  /// True only if this task has a `NameFragment`.
+  bool hasTaskName() const {
     return Flags.task_hasInitialTaskName();
   }
 
@@ -542,6 +538,36 @@ public:
   bool cancellationShieldPush();
 
   void cancellationShieldPop();
+
+  // ==== Name Fragment --------------------------------------------------------
+
+  /// A fragment of an async task that holds the task's name.
+  ///
+  /// This fragment MUST be allocated immediately after the AsyncTask itself,
+  /// as external tools rely on the location of this record to read the task name,
+  /// see `Concurrency/Debug.h`.
+  class NameFragment {
+    /// Pointer to a null-terminated UTF-8 string.
+    /// The string is allocated no the task-local allocator as the first thing
+    /// allocated on it, and must be the last thing we free on it.
+    const char *Name;
+
+  public:
+    explicit NameFragment(const char *name) : Name(name) {}
+
+    const char *getName() const { return Name; }
+    void setName(const char *name) { Name = name; }
+  };
+
+  /// Returns the `NameFragment` of this task.
+  ///
+  /// WARNING: Only valid when `hasTaskName()` is true.
+  NameFragment *nameFragment() {
+    assert(hasTaskName());
+    auto offset = reinterpret_cast<char*>(this);
+    offset += sizeof(AsyncTask);
+    return reinterpret_cast<NameFragment*>(offset);
+  }
 
   // ==== Child Fragment -------------------------------------------------------
 
@@ -603,6 +629,8 @@ public:
 
     auto offset = reinterpret_cast<char*>(this);
     offset += sizeof(AsyncTask);
+    if (hasTaskName())
+      offset += sizeof(NameFragment);
 
     return reinterpret_cast<ChildFragment*>(offset);
   }
@@ -642,6 +670,8 @@ public:
 
     auto offset = reinterpret_cast<char*>(this);
     offset += sizeof(AsyncTask);
+    if (hasTaskName())
+      offset += sizeof(NameFragment);
     if (hasChildFragment())
       offset += sizeof(ChildFragment);
 
@@ -785,6 +815,8 @@ public:
     assert(isFuture());
     auto offset = reinterpret_cast<char*>(this);
     offset += sizeof(AsyncTask);
+    if (hasTaskName())
+      offset += sizeof(NameFragment);
     if (hasChildFragment())
       offset += sizeof(ChildFragment);
     if (hasGroupChildFragment())

--- a/include/swift/ABI/TaskStatus.h
+++ b/include/swift/ABI/TaskStatus.h
@@ -328,21 +328,14 @@ public:
   }
 };
 
-class TaskNameStatusRecord : public TaskStatusRecord {
-private:
-  const char *Name;
-
-public:
-  TaskNameStatusRecord(const char *name)
-      : TaskStatusRecord(TaskStatusRecordKind::TaskName),
-        Name(name) {}
-
-  const char *getName() { return Name; }
-
-  static bool classof(const TaskStatusRecord *record) {
-    return record->getKind() == TaskStatusRecordKind::TaskName;
-  }
-};
+// Deprecated: TaskNameStatusRecord was used Swift 6.4 (including)
+// to store the initial task name of a task; However we later optimized
+// this to avoid the ready-for-mutable-operations record infrastructure
+// in order to facilitate quicker task name lookups by tools like lldb, spindump etc.
+//
+//    class TaskNameStatusRecord : public TaskStatusRecord {
+//      const char *Name;
+//    };
 
 // This record is allocated for a task to record what it is dependent on before
 // the task can make progress again.

--- a/include/swift/RemoteInspection/ReflectionContext.h
+++ b/include/swift/RemoteInspection/ReflectionContext.h
@@ -2101,57 +2101,61 @@ private:
     return {false, 0};
   }
 
-  // ==== Task fragment offsets ===============================================
-  //
-  // An `AsyncTask` has a fixed-size header followed by optional tail-allocated
-  // fragments, in the following order:
-  //
-  //   1. `NameFragment`        — present iff `JobFlags::task_hasInitialTaskName`
-  //   2. `ChildFragment`       — present iff `JobFlags::task_isChildTask`
-  //   3. `GroupChildFragment`  — present iff `JobFlags::task_isGroupChildTask`
-  //   4. `FutureFragment`      — present iff `JobFlags::task_isFuture`
+  /// Warning: Does not validate if the fragment is actually present.
+  size_t nameFragmentOffset() const {
+    return asyncTaskSize;
+  }
+
+  /// Warning: Does not validate if the fragment is actually present.
+  size_t childFragmentOffset(swift::JobFlags flags) const {
+    size_t offset = nameFragmentOffset();
+    if (flags.task_hasInitialTaskName())
+      offset += sizeof(NameFragment<Runtime>);
+    return offset;
+  }
+
+  /// Warning: Does not validate if the fragment is actually present.
+  size_t groupChildFragmentOffset(swift::JobFlags flags) const {
+    size_t offset = childFragmentOffset(flags);
+    if (flags.task_isChildTask())
+      offset += sizeof(ChildFragment<Runtime>);
+    return offset;
+  }
+
+  /// Warning: Does not validate if the fragment is actually present.
+  size_t futureFragmentOffset(swift::JobFlags flags) const {
+    size_t offset = groupChildFragmentOffset(flags);
+    if (flags.task_isGroupChildTask())
+      offset += sizeof(GroupChildFragment<Runtime>);
+    return offset;
+  }
 
   /// Address of `NameFragment` for `task`.
   RemoteAddress nameFragmentAddr(RemoteAddress task,
                                  swift::JobFlags flags) const {
     assert(asyncTaskSize != 0 && flags.task_hasInitialTaskName());
-    return task + asyncTaskSize;
+    return task + nameFragmentOffset();
   }
 
   /// Address of `ChildFragment` for `task`.
   RemoteAddress childFragmentAddr(RemoteAddress task,
                                   swift::JobFlags flags) const {
     assert(asyncTaskSize != 0 && flags.task_isChildTask());
-    RemoteAddress addr = task + asyncTaskSize;
-    if (flags.task_hasInitialTaskName())
-      addr = addr + sizeof(NameFragment<Runtime>);
-    return addr;
+    return task + childFragmentOffset(flags);
   }
 
   /// Address of `GroupChildFragment` for `task`.
   RemoteAddress groupChildFragmentAddr(RemoteAddress task,
                                        swift::JobFlags flags) const {
     assert(asyncTaskSize != 0 && flags.task_isGroupChildTask());
-    RemoteAddress addr = task + asyncTaskSize;
-    if (flags.task_hasInitialTaskName())
-      addr = addr + sizeof(NameFragment<Runtime>);
-    if (flags.task_isChildTask())
-      addr = addr + sizeof(ChildFragment<Runtime>);
-    return addr;
+    return task + groupChildFragmentOffset(flags);
   }
 
   /// Address of `FutureFragment` for `task`.
   RemoteAddress futureFragmentAddr(RemoteAddress task,
                                    swift::JobFlags flags) const {
     assert(asyncTaskSize != 0 && flags.task_isFuture());
-    RemoteAddress addr = task + asyncTaskSize;
-    if (flags.task_hasInitialTaskName())
-      addr = addr + sizeof(NameFragment<Runtime>);
-    if (flags.task_isChildTask())
-      addr = addr + sizeof(ChildFragment<Runtime>);
-    if (flags.task_isGroupChildTask())
-      addr = addr + sizeof(GroupChildFragment<Runtime>);
-    return addr;
+    return task + futureFragmentOffset(flags);
   }
 
   template <typename AsyncTaskType>

--- a/include/swift/RemoteInspection/ReflectionContext.h
+++ b/include/swift/RemoteInspection/ReflectionContext.h
@@ -2101,6 +2101,59 @@ private:
     return {false, 0};
   }
 
+  // ==== Task fragment offsets ===============================================
+  //
+  // An `AsyncTask` has a fixed-size header followed by optional tail-allocated
+  // fragments, in the following order:
+  //
+  //   1. `NameFragment`        — present iff `JobFlags::task_hasInitialTaskName`
+  //   2. `ChildFragment`       — present iff `JobFlags::task_isChildTask`
+  //   3. `GroupChildFragment`  — present iff `JobFlags::task_isGroupChildTask`
+  //   4. `FutureFragment`      — present iff `JobFlags::task_isFuture`
+
+  /// Address of `NameFragment` for `task`.
+  RemoteAddress nameFragmentAddr(RemoteAddress task,
+                                 swift::JobFlags flags) const {
+    assert(asyncTaskSize != 0 && flags.task_hasInitialTaskName());
+    return task + asyncTaskSize;
+  }
+
+  /// Address of `ChildFragment` for `task`.
+  RemoteAddress childFragmentAddr(RemoteAddress task,
+                                  swift::JobFlags flags) const {
+    assert(asyncTaskSize != 0 && flags.task_isChildTask());
+    RemoteAddress addr = task + asyncTaskSize;
+    if (flags.task_hasInitialTaskName())
+      addr = addr + sizeof(NameFragment<Runtime>);
+    return addr;
+  }
+
+  /// Address of `GroupChildFragment` for `task`.
+  RemoteAddress groupChildFragmentAddr(RemoteAddress task,
+                                       swift::JobFlags flags) const {
+    assert(asyncTaskSize != 0 && flags.task_isGroupChildTask());
+    RemoteAddress addr = task + asyncTaskSize;
+    if (flags.task_hasInitialTaskName())
+      addr = addr + sizeof(NameFragment<Runtime>);
+    if (flags.task_isChildTask())
+      addr = addr + sizeof(ChildFragment<Runtime>);
+    return addr;
+  }
+
+  /// Address of `FutureFragment` for `task`.
+  RemoteAddress futureFragmentAddr(RemoteAddress task,
+                                   swift::JobFlags flags) const {
+    assert(asyncTaskSize != 0 && flags.task_isFuture());
+    RemoteAddress addr = task + asyncTaskSize;
+    if (flags.task_hasInitialTaskName())
+      addr = addr + sizeof(NameFragment<Runtime>);
+    if (flags.task_isChildTask())
+      addr = addr + sizeof(ChildFragment<Runtime>);
+    if (flags.task_isGroupChildTask())
+      addr = addr + sizeof(GroupChildFragment<Runtime>);
+    return addr;
+  }
+
   template <typename AsyncTaskType>
   std::pair<std::optional<std::string>, AsyncTaskInfo>
   asyncTaskInfo(RemoteAddress AsyncTaskPtr, unsigned ChildTaskLimit,
@@ -2140,8 +2193,7 @@ private:
 
     Info.ParentTask = 0;
     if (Info.IsChildTask && asyncTaskSize != 0) {
-      // Parent information ("child fragment") is right after the task itself.
-      RemoteAddress ChildFragmentAddr = AsyncTaskPtr + asyncTaskSize;
+      RemoteAddress ChildFragmentAddr = childFragmentAddr(AsyncTaskPtr, JobFlags);
       auto ChildFragmentObj =
           readObj<ChildFragment<Runtime>>(ChildFragmentAddr);
       if (ChildFragmentObj)
@@ -2191,7 +2243,7 @@ private:
                                 "iterate child tasks"),
                     Info};
 
-          RemoteAddress ChildFragmentAddr = ChildTaskAddress + asyncTaskSize;
+          RemoteAddress ChildFragmentAddr = childFragmentAddr(ChildTaskAddress, ChildJobFlags);
           auto ChildFragmentObj =
               readObj<ChildFragment<Runtime>>(ChildFragmentAddr);
           if (ChildFragmentObj)
@@ -2210,17 +2262,7 @@ private:
 
     // Read the wait queue from the FutureFragment, if this is a future task.
     if (Info.IsFuture && asyncTaskSize != 0) {
-      // The FutureFragment is located after AsyncTask, ChildFragment (if
-      // child), and GroupChildFragment (if group child).
-      // See AsyncTask::futureFragment() in include/swift/ABI/Task.h.
-      auto FutureFragmentAddr = AsyncTaskPtr + asyncTaskSize;
-      if (Info.IsChildTask)
-        FutureFragmentAddr =
-            FutureFragmentAddr + sizeof(ChildFragment<Runtime>);
-      if (Info.IsGroupChildTask)
-        FutureFragmentAddr =
-            FutureFragmentAddr + sizeof(GroupChildFragment<Runtime>);
-
+      RemoteAddress FutureFragmentAddr = futureFragmentAddr(AsyncTaskPtr, JobFlags);
       auto FutureFragmentObj =
           readObj<FutureFragment<Runtime>>(FutureFragmentAddr);
       if (FutureFragmentObj) {

--- a/include/swift/RemoteInspection/RuntimeInternals.h
+++ b/include/swift/RemoteInspection/RuntimeInternals.h
@@ -205,6 +205,15 @@ struct GroupChildFragment {
   typename Runtime::StoredPointer Group;
 };
 
+/// Mirror of `AsyncTask::NameFragment` in include/swift/ABI/Task.h.
+/// Tail-allocated immediately after `AsyncTask` iff
+/// `JobFlags::task_hasInitialTaskName()` is set.
+template <typename Runtime>
+struct NameFragment {
+  typename Runtime::StoredPointer Name;
+  typename Runtime::StoredSize NameLength;
+};
+
 template <typename Runtime>
 struct FutureFragment {
   // The low 2 bits are the status, the rest is a pointer to the first

--- a/stdlib/public/Concurrency/Debug.h
+++ b/stdlib/public/Concurrency/Debug.h
@@ -38,6 +38,13 @@ const void *const _swift_concurrency_debug_asyncTaskMetadata;
 SWIFT_EXPORT_FROM(swift_Concurrency)
 const size_t _swift_concurrency_debug_asyncTaskSize;
 
+/// Offset from the start of an `AsyncTask` to its `NameFragment`
+/// (a single `const char *` pointing to the task's null-terminated name).
+///
+/// The fragment is ONLY present when `JobFlags::task_hasInitialTaskName()` is true.
+SWIFT_EXPORT_FROM(swift_Concurrency)
+const size_t _swift_concurrency_debug_asyncTaskNameOffset;
+
 /// A fake metadata pointer placed at the start of async task slab allocations.
 SWIFT_EXPORT_FROM(swift_Concurrency)
 const void *const _swift_concurrency_debug_asyncTaskSlabMetadata;
@@ -58,6 +65,8 @@ bool _swift_concurrency_debug_supportsPriorityEscalation;
 /// The current version of internal data structures that lldb may decode.
 /// The version numbers used so far are:
 /// 1 - The initial version number when this variable was added, in swift 6.1.
+/// 2 - Task names moved from a record to a dedicated fragment,
+///     tail allocated just after the AsyncTask itself.
 SWIFT_EXPORT_FROM(swift_Concurrency)
 uint32_t _swift_concurrency_debug_internal_layout_version;
 

--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -337,7 +337,7 @@ AsyncTask::~AsyncTask() {
   if (hasTaskName()) {
     if (const char *name = nameFragment()->getName()) {
       _swift_task_dealloc_specific(this, const_cast<char*>(name));
-      nameFragment()->setName(nullptr);
+      nameFragment()->setName(nullptr, 0);
     }
 
     #ifndef NDEBUG
@@ -1134,7 +1134,7 @@ swift_task_create_commonImpl(size_t rawTaskCreateFlags,
 
   // First, initialize the NameFragment, if any.
   if (jobFlags.task_hasInitialTaskName()) {
-    ::new (task->nameFragment()) AsyncTask::NameFragment(nullptr);
+    ::new (task->nameFragment()) AsyncTask::NameFragment();
     task->initializeTaskName(taskName);
   }
 

--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -89,7 +89,10 @@ const void *const swift::_swift_concurrency_debug_asyncTaskSlabMetadata =
 bool swift::_swift_concurrency_debug_supportsPriorityEscalation =
     SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION;
 
-uint32_t swift::_swift_concurrency_debug_internal_layout_version = 1;
+// ************************* PLEASE UPDATE DEBUG.H DOCS ***************************************
+// * When changing this version number you MUST document the change in `Concurrency/Debug.h`. *
+// ********************************************************************************************
+uint32_t swift::_swift_concurrency_debug_internal_layout_version = 2;
 
 void FutureFragment::destroy() {
   auto queueHead = waitQueue.load(std::memory_order_acquire);
@@ -327,11 +330,15 @@ AsyncTask::~AsyncTask() {
     futureFragment()->destroy();
   }
 
-  // The initial task name record is special in that we allow it to stay until
-  // task destruction, since it is possible to read a name off a task handle,
-  // even after it completed; so drop it here:
-  if (hasInitialTaskNameRecord()) {
-    dropInitialTaskNameRecord();
+  // The task name characters live in the task's slab as the FIRST slab
+  // allocation. Free them last (i.e. here) so that the LIFO discipline
+  // holds — `task.name` is allowed to be read off a completed task right
+  // up until destruction.
+  if (hasTaskName()) {
+    if (const char *name = nameFragment()->getName()) {
+      _swift_task_dealloc_specific(this, const_cast<char*>(name));
+      nameFragment()->setName(nullptr);
+    }
 
     #ifndef NDEBUG
     auto oldStatus = _private()._status().load(std::memory_order_relaxed);
@@ -459,6 +466,9 @@ const void *const swift::_swift_concurrency_debug_asyncTaskMetadata =
     static_cast<Metadata *>(&taskHeapMetadata);
 
 const size_t swift::_swift_concurrency_debug_asyncTaskSize = sizeof(AsyncTask);
+
+const size_t swift::_swift_concurrency_debug_asyncTaskNameOffset =
+    sizeof(AsyncTask);
 
 const HeapMetadata *swift::jobHeapMetadataPtr =
     static_cast<HeapMetadata *>(&jobHeapMetadata);
@@ -692,9 +702,16 @@ static inline bool taskIsDetached(TaskCreateFlags createFlags, JobFlags jobFlags
 
 static std::pair<size_t, size_t> amountToAllocateForHeaderAndTask(
     const AsyncTask *parent, const TaskGroup *group,
-    ResultTypeInfo futureResultType, size_t initialContextSize) {
+    ResultTypeInfo futureResultType, size_t initialContextSize,
+    bool hasTaskName) {
   // Figure out the size of the header.
   size_t headerSize = sizeof(AsyncTask);
+  if (hasTaskName) {
+    // The NameFragment must be the FIRST tail-allocated fragment so that
+    // its slot lives at the constant offset `sizeof(AsyncTask)` (exported
+    // as `_swift_concurrency_debug_asyncTaskNameOffset`).
+    headerSize += sizeof(AsyncTask::NameFragment);
+  }
   if (parent) {
     headerSize += sizeof(AsyncTask::ChildFragment);
   }
@@ -923,7 +940,8 @@ swift_task_create_commonImpl(size_t rawTaskCreateFlags,
 
   size_t headerSize, amountToAllocate;
   std::tie(headerSize, amountToAllocate) = amountToAllocateForHeaderAndTask(
-      parent, group, futureResultType, initialContextSize);
+      parent, group, futureResultType, initialContextSize,
+      /*hasTaskName=*/jobFlags.task_hasInitialTaskName());
 
   unsigned initialSlabSize = 512;
 
@@ -1114,14 +1132,10 @@ swift_task_create_commonImpl(size_t rawTaskCreateFlags,
     task->Private.initialize(basePriority);
   }
 
-  // Task name
-  // This record MUST be the FIRST allocation on the task allocator stack.
-  //
-  // The task name is the only initial record we keep alive after the task completes,
-  // until it is destroyed, because `task.name` can be read off a completed task.
-  // All other records are released early, during task completion.
+  // First, initialize the NameFragment, if any.
   if (jobFlags.task_hasInitialTaskName()) {
-    task->pushInitialTaskName(taskName);
+    ::new (task->nameFragment()) AsyncTask::NameFragment(nullptr);
+    task->initializeTaskName(taskName);
   }
 
   // Perform additional linking between parent and child task.
@@ -1259,7 +1273,8 @@ void swift::swift_task_run_inline(OpaqueValue *result, void *closureAFP,
   size_t candidateAllocationBytes = SWIFT_TASK_RUN_INLINE_INITIAL_CONTEXT_BYTES;
   size_t minimumAllocationSize =
       amountToAllocateForHeaderAndTask(/*parent=*/nullptr, /*group=*/nullptr,
-                                       futureResultType, closureContextSize)
+                                       futureResultType, closureContextSize,
+                                       /*hasTaskName=*/false)
           .second;
   void *allocation = nullptr;
   size_t allocationBytes = 0;

--- a/stdlib/public/Concurrency/TaskPrivate.h
+++ b/stdlib/public/Concurrency/TaskPrivate.h
@@ -921,8 +921,8 @@ struct AsyncTask::PrivateStorage {
       if (task->hasInitialTaskExecutorPreferenceRecord()) {
         task->dropInitialTaskExecutorPreferenceRecord();
       }
-      // We specifically DO NOT drop the task name record here, even if present,
-      // as it is possible to read it off a task handle (`task.name`).
+      // The task name lives in the tail-allocated NameFragment slot now,
+      // not on the status-record chain — there is no record to drop here.
     }
 
     // Drain unlock the task and remove any overrides on thread as a
@@ -930,16 +930,8 @@ struct AsyncTask::PrivateStorage {
     auto oldStatus = task->_private()._status().load(std::memory_order_relaxed);
     while (true) {
       #ifndef NDEBUG
-      if (task->hasInitialTaskNameRecord()) {
-        // While we generally drop all task records during complete, the task name record is allowed to
-        // stay until destruction, because we allow reading the name from a task handle: `task.name`.
-        assert((oldStatus.getInnermostRecord() &&
-               (oldStatus.getInnermostRecord()->getKind() == TaskStatusRecordKind::TaskName)) &&
-          "The only remaining task record allowed after complete() is a task name, but was different!");
-      } else {
-        assert(oldStatus.getInnermostRecord() == NULL &&
+      assert(oldStatus.getInnermostRecord() == NULL &&
              "Status records should have been removed by this time!");
-      }
       #endif
       assert(oldStatus.isRunning());
 

--- a/stdlib/public/Concurrency/TaskStatus.cpp
+++ b/stdlib/public/Concurrency/TaskStatus.cpp
@@ -668,17 +668,21 @@ static size_t swift_strlen(const char *text) {
 }
 #endif
 
-void AsyncTask::pushInitialTaskName(const char* _taskName) {
+void AsyncTask::initializeTaskName(const char *_taskName) {
   assert(_taskName && "Task name must not be null!");
-  assert(hasInitialTaskNameRecord() && "Attempted pushing name but task has no initial task name flag!");
+  assert(hasTaskName() &&
+         "Attempted to initialize the task name fragment but the task has no "
+         "initial task name flag!");
 
-  void *allocation = _swift_task_alloc_specific(
-      this, sizeof(class TaskNameStatusRecord));
-
-  // TODO: Copy the string maybe into the same allocation at an offset or retain the swift string?
+  // The name fragment is tail-allocated on the task, but the actual name string
+  // we allocate on the task local allocator;
+  //
+  // The task name string therefore must respect stack discipline and must be
+  // the first allocation made on the task-local allocator, as it will be the
+  // last thing we destroy.
   auto taskNameLen = swift_strlen(_taskName);
-  char* taskNameCopy = reinterpret_cast<char*>(
-      _swift_task_alloc_specific(this, taskNameLen + 1/*null terminator*/));
+  char *taskNameCopy = reinterpret_cast<char *>(
+      _swift_task_alloc_specific(this, taskNameLen + 1 /*null terminator*/));
 #if SWIFT_CONCURRENCY_EMBEDDED
   swift_strcpy(taskNameCopy, _taskName);
 #elif defined(_WIN32)
@@ -689,58 +693,19 @@ void AsyncTask::pushInitialTaskName(const char* _taskName) {
   taskNameCopy[taskNameLen] = '\0'; // make sure we null-terminate
 #endif
 
-  auto record =
-      ::new (allocation) TaskNameStatusRecord(taskNameCopy);
-  SWIFT_TASK_DEBUG_LOG("[TaskName] Create initial task name record %p "
-                       "for task:%p, name:%s", record, this, taskNameCopy);
-
-  addStatusRecord(this, record,
-                  [&](ActiveTaskStatus oldStatus, ActiveTaskStatus &newStatus) {
-                    return true; // always add the record
-                  });
-}
-
-void AsyncTask::dropInitialTaskNameRecord() {
-  if (!hasInitialTaskNameRecord()) {
-    return;
-  }
-
-  SWIFT_TASK_DEBUG_LOG("[TaskName] Drop initial task name record for task:%p", this);
-  TaskNameStatusRecord *record =
-      popStatusRecordOfType<TaskNameStatusRecord>(this);
-  assert(record &&
-         "hasInitialTaskNameRecord is true but we did not find a name record");
-  // Since we first allocated the record, and then the string copy, deallocate
-  // in LIFO order.
-  char *name = const_cast<char *>(record->getName());
-  _swift_task_dealloc_specific(this, name);
-  _swift_task_dealloc_specific(this, record);
+  nameFragment()->setName(taskNameCopy);
+  SWIFT_TASK_DEBUG_LOG("[TaskName] Initialize name slot for task:%p, name:%s",
+                       this, taskNameCopy);
 }
 
 const char*
 AsyncTask::getTaskName() {
-  // We first check the executor preference status flag, in order to avoid
-  // having to scan through the records of the task checking if there was
-  // such record.
-  //
-  // This is an optimization in order to make the enqueue/run
-  // path of a task avoid excessive work if a task had many records.
-  if (!hasInitialTaskNameRecord()) {
+  if (!hasTaskName())
     return nullptr;
-  }
 
-  const char *data = nullptr;
-  withStatusRecordLock(this, [&](ActiveTaskStatus status) {
-    for (auto record : status.records()) {
-      if (record->getKind() == TaskStatusRecordKind::TaskName) {
-        auto nameRecord = cast<TaskNameStatusRecord>(record);
-        data = nameRecord->getName();
-        return;
-      }
-    }
-  });
-
-  return data;
+  // Reads are trivial, no locking or record walks are involved;
+  // Just get the name fragment and pointed at name string.
+  return nameFragment()->getName();
 }
 
 /**************************************************************************/
@@ -761,18 +726,13 @@ void swift::updateNewChildWithParentAndGroupState(AsyncTask *child,
                                                   TaskGroup *group) {
   // We can take the fast path of just modifying the ActiveTaskStatus in the
   // child task since we know it cannot be accessed by anyone else yet -- it
-  // hasn't been linked in. The only record that may already be present is the
-  // initial task name (pushed first during task creation so it can outlive
-  // `complete()`); that's harmless here because we only mutate status flags,
-  // not the records list.
+  // hasn't been linked in. There should be no status records yet: the task
+  // name now lives in a tail-allocated `NameFragment`, not on the chain.
   // Avoids the extra logic in `swift_task_cancel` and `swift_task_escalate`
   auto oldChildTaskStatus =
       child->_private()._status().load(std::memory_order_relaxed);
-  assert((oldChildTaskStatus.getInnermostRecord() == NULL ||
-          (oldChildTaskStatus.getInnermostRecord()->getKind() ==
-               TaskStatusRecordKind::TaskName &&
-           oldChildTaskStatus.getInnermostRecord()->getParent() == NULL)) &&
-         "child task should have no records, or only the initial task name");
+  assert(oldChildTaskStatus.getInnermostRecord() == NULL &&
+         "child task should have no records yet");
 
   auto newChildTaskStatus = oldChildTaskStatus;
 
@@ -906,10 +866,6 @@ static void performCancellationAction(ActiveTaskStatus status, TaskStatusRecord 
   case TaskStatusRecordKind::TaskExecutorPreference:
     break;
 
-  // Cancellation has no impact on task names.
-  case TaskStatusRecordKind::TaskName:
-    break;
-
   // This should never be found, but the compiler complains if we don't check.
   case TaskStatusRecordKind::First_Reserved:
     break;
@@ -1009,9 +965,6 @@ static void performEscalationAction(TaskStatusRecord *record,
     return;
   /// Executor preference we can ignore.
   case TaskStatusRecordKind::TaskExecutorPreference:
-    return;
-  /// Task names don't matter to priority escalation.
-  case TaskStatusRecordKind::TaskName:
     return;
   // This should never be found, but the compiler complains if we don't check.
   case TaskStatusRecordKind::First_Reserved:

--- a/stdlib/public/Concurrency/TaskStatus.cpp
+++ b/stdlib/public/Concurrency/TaskStatus.cpp
@@ -693,7 +693,7 @@ void AsyncTask::initializeTaskName(const char *_taskName) {
   taskNameCopy[taskNameLen] = '\0'; // make sure we null-terminate
 #endif
 
-  nameFragment()->setName(taskNameCopy);
+  nameFragment()->setName(taskNameCopy, taskNameLen);
   SWIFT_TASK_DEBUG_LOG("[TaskName] Initialize name slot for task:%p, name:%s",
                        this, taskNameCopy);
 }

--- a/test/abi/macOS/arm64/concurrency.swift
+++ b/test/abi/macOS/arm64/concurrency.swift
@@ -459,3 +459,6 @@ Added: _$ss10_AsyncTaskVyABBpcfC
 // (raw pointer wrapper) under the new `_rawTask` field.
 Added: _$sSct8_rawTasks06_AsyncB0Vvg
 Added: _$sSct8_rawTasks06_AsyncB0VvpMV
+
+/// Expose async task name offset in debug header.
+Added: __swift_concurrency_debug_asyncTaskNameOffset

--- a/test/abi/macOS/x86_64/concurrency.swift
+++ b/test/abi/macOS/x86_64/concurrency.swift
@@ -459,3 +459,6 @@ Added: _$ss10_AsyncTaskVyABBpcfC
 // (raw pointer wrapper) under the new `_rawTask` field.
 Added: _$sSct8_rawTasks06_AsyncB0Vvg
 Added: _$sSct8_rawTasks06_AsyncB0VvpMV
+
+/// Expose async task name offset in debug header.
+Added: __swift_concurrency_debug_asyncTaskNameOffset


### PR DESCRIPTION
In order to help out tools which read memory to diagnose failures, move the task name out of records into its own fragment -- which we guarantee is at a known known offset, if the task has a name.

Task names are constant and can never change, by moving them to the fragment we avoid the record infrastructure which is more general and supports chaining records -- we don't need this for task names.

The actual string of the name is not allocated in the fragment but just uses the task local allocator like previously. This is fine, we can take this one indirection: task + offset -> follow pointer to `char*`.


Resolves rdar://178705032