### PR TITLE
[DebugInfo] Implement element address salvage 

### DIFF
--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -6267,6 +6267,12 @@ void IRGenSILFunction::visitDebugValueInst(DebugValueInst *i) {
     llvm::Instruction *LastBefore =
         (InsertPt == BB->begin()) ? nullptr : &*std::prev(InsertPt);
 
+    // Visiting debug BB instructions may cache type metadata. Those LLVM
+    // instructions will be erased right after, which could leave dangling
+    // pointers in the cache. Use a ConditionalDominanceScope so that any cache
+    // entries added during the emission are cleaned up.
+    ConditionalDominanceScope condScope(*this);
+
     if (!DebugBB->args_empty()) {
       // Bind the block argument to the operand.
       SILValue operand = i->getOperand();

--- a/lib/SIL/IR/SILInstructions.cpp
+++ b/lib/SIL/IR/SILInstructions.cpp
@@ -466,7 +466,8 @@ DebugValueInst *DebugValueInst::create(SILDebugLocation DebugLoc,
     Var.Loc = {};
   if (Var.Scope == DebugLoc.getScope())
     Var.Scope = nullptr;
-  if (Var.Type == Operand->getType().getObjectType())
+  if (Var.Type == Operand->getType().getObjectType() &&
+      !Var.DIExpr.getFragmentPart())
     Var.Type = {};
   // Use the prependDeref bit rather than storing it in the DIExpr.
   bool prependDeref = Var.DIExpr.startsWithDeref();

--- a/lib/SILOptimizer/Utils/InstOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/InstOptUtils.cpp
@@ -2196,6 +2196,10 @@ void swift::salvageDebugInfo(SILInstruction *I) {
 
   if (isa<AddressToPointerInst>(I) || isa<PointerToAddressInst>(I))
     salvageUnaryInst(cast<SingleValueInstruction>(I));
+
+  if (isa<StructElementAddrInst>(I) || isa<TupleElementAddrInst>(I) ||
+      isa<RefElementAddrInst>(I) || isa<VectorBaseAddrInst>(I))
+    salvageUnaryInst(cast<SingleValueInstruction>(I));
 }
 
 void swift::salvageLoadDebugInfo(LoadOperation load) {

--- a/test/DebugInfo/inlined-generics-basic.swift
+++ b/test/DebugInfo/inlined-generics-basic.swift
@@ -58,14 +58,8 @@ public class C<R> {
     // IR: call {{.*}}3use
 #sourceLocation(file: "f.swift", line: 2)
     g(s)
-    // Jump-threading removes the basic block containing debug_value
-    // "t" before the second call to `g(r)`. When this happens, the
-    // ref_element_addr in that removed block is left with a single
-    // debug_value use, so they are both deleted. This means we have
-    // no debug value for "t" in the call to `g(r)`.
-    //   dbg_value({{.*}}, ![[GR_T:[0-9]+]]
-
-    // IR: #dbg_value({{.*}}, ![[GR_U:[0-9]+]], !DIExp
+    // IR: #dbg_value({{.*}}, ![[GR_T:[0-9]+]], !DIExpression
+    // IR: #dbg_value({{.*}}, ![[GR_U:[0-9]+]], !DIExpression
     // IR: call {{.*}}3use
 #sourceLocation(file: "f.swift", line: 3)
     g(r)
@@ -112,10 +106,8 @@ public class C<R> {
 // IR-DAG: ![[GS_U]] = !DILocalVariable(name: "u", {{.*}} scope: ![[SP_GS_U:[0-9]+]], {{.*}} type: ![[LET_TAU_1_0]])
 // IR-DAG: ![[SP_GS_U]] = {{.*}}linkageName: "$s1A1hyyxlFx_Ti5qd___Ti5"
 
-// Debug info for this variable is removed. See the note above the call to g(r).
-//   ![[GR_T]] = !DILocalVariable(name: "t", {{.*}} scope: ![[SP_GR_T:[0-9]+]], {{.*}}type: ![[LET_TAU_0_0]])
-// S has the same generic parameter numbering s T and U.
-//   ![[SP_GR_T]] = {{.*}}linkageName: "$s1A1gyyxlF"
+// IR-DAG: ![[GR_T]] = !DILocalVariable(name: "t", {{.*}} scope: ![[SP_GR_T:[0-9]+]], {{.*}}type: ![[LET_TAU_0_0]])
+// IR-DAG: ![[SP_GR_T]] = {{.*}}linkageName: "$s1A1gyyxlFx_Ti5"
 
 // IR-DAG: ![[GR_U]] = !DILocalVariable(name: "u", {{.*}} scope: ![[SP_GR_U:[0-9]+]], {{.*}}type: ![[LET_TAU_0_0]])
 // IR-DAG: ![[SP_GR_U]] = {{.*}}linkageName: "$s1A1hyyxlFx_Ti5x_Ti5"

--- a/test/DebugInfo/salvage_addr_projections.sil
+++ b/test/DebugInfo/salvage_addr_projections.sil
@@ -1,0 +1,100 @@
+// RUN: %target-sil-opt -sil-print-types %s -sil-combine -sil-print-debuginfo | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+
+// Test that struct_element_addr, tuple_element_addr, ref_element_addr, and
+// vector_base_addr are salvaged into debug reconstruction blocks when they
+// become dead (only debug uses remain).
+
+sil_stage canonical
+
+import Builtin
+import Swift
+
+struct MyStruct {
+  @_hasStorage var x: Int64 { get set }
+  @_hasStorage var y: Int64 { get set }
+}
+
+class MyClass {
+  @_hasStorage var field: Int64 { get set }
+  deinit
+  init()
+}
+
+sil_scope 1 { loc "test.swift":1:1 parent @test_salvage_struct_element_addr : $@convention(thin) (@in_guaranteed MyStruct) -> () }
+sil_scope 2 { loc "test.swift":10:1 parent @test_salvage_tuple_element_addr : $@convention(thin) (@in_guaranteed (Int64, Int64)) -> () }
+sil_scope 3 { loc "test.swift":20:1 parent @test_salvage_ref_element_addr : $@convention(thin) (@guaranteed MyClass) -> () }
+sil_scope 4 { loc "test.swift":30:1 parent @test_salvage_vector_base_addr : $@convention(thin) (@in_guaranteed Builtin.FixedArray<4, Int64>) -> () }
+
+// CHECK-LABEL: sil @test_salvage_struct_element_addr
+// CHECK:       bb0([[ADDR:%[0-9]+]] : $*MyStruct):
+// CHECK:         debug_value [[ADDR]] : $*MyStruct, let, name "field_x", transform {
+// CHECK:           bb0([[SEA_ARG:%[0-9]+]] : $*MyStruct):
+// CHECK:             [[SEA:%[0-9]+]] = struct_element_addr [[SEA_ARG]] : $*MyStruct, #MyStruct.x
+// CHECK:             [[SEA_LD:%[0-9]+]] = load [[SEA]] : $*Int64
+// CHECK:             return [[SEA_LD]] : $Int64
+// CHECK:         }
+// CHECK:         return
+// CHECK-LABEL: } // end sil function 'test_salvage_struct_element_addr'
+sil @test_salvage_struct_element_addr : $@convention(thin) (@in_guaranteed MyStruct) -> () {
+bb0(%0 : $*MyStruct):
+  %1 = struct_element_addr %0 : $*MyStruct, #MyStruct.x
+  debug_value %1 : $*Int64, let, name "field_x", expr op_deref, loc "test.swift":1:1, scope 1
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK-LABEL: sil @test_salvage_tuple_element_addr
+// CHECK:       bb0([[ADDR:%[0-9]+]] : $*(Int64, Int64)):
+// CHECK:         debug_value [[ADDR]] : $*(Int64, Int64), let, name "elt0", transform {
+// CHECK:           bb0([[TEA_ARG:%[0-9]+]] : $*(Int64, Int64)):
+// CHECK:             [[TEA:%[0-9]+]] = tuple_element_addr [[TEA_ARG]] : $*(Int64, Int64), 0
+// CHECK:             [[TEA_LD:%[0-9]+]] = load [[TEA]] : $*Int64
+// CHECK:             return [[TEA_LD]] : $Int64
+// CHECK:         }
+// CHECK:         return
+// CHECK-LABEL: } // end sil function 'test_salvage_tuple_element_addr'
+sil @test_salvage_tuple_element_addr : $@convention(thin) (@in_guaranteed (Int64, Int64)) -> () {
+bb0(%0 : $*(Int64, Int64)):
+  %1 = tuple_element_addr %0 : $*(Int64, Int64), 0
+  debug_value %1 : $*Int64, let, name "elt0", expr op_deref, loc "test.swift":10:1, scope 2
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK-LABEL: sil @test_salvage_ref_element_addr
+// CHECK:       bb0([[REF:%[0-9]+]] : $MyClass):
+// CHECK:         debug_value [[REF]] : $MyClass, let, name "obj_field", transform {
+// CHECK:           bb0([[REA_ARG:%[0-9]+]] : $MyClass):
+// CHECK:             [[REA:%[0-9]+]] = ref_element_addr [[REA_ARG]] : $MyClass, #MyClass.field
+// CHECK:             [[REA_LD:%[0-9]+]] = load [[REA]] : $*Int64
+// CHECK:             return [[REA_LD]] : $Int64
+// CHECK:         }
+// CHECK:         return
+// CHECK-LABEL: } // end sil function 'test_salvage_ref_element_addr'
+sil @test_salvage_ref_element_addr : $@convention(thin) (@guaranteed MyClass) -> () {
+bb0(%0 : $MyClass):
+  %1 = ref_element_addr %0 : $MyClass, #MyClass.field
+  debug_value %1 : $*Int64, let, name "obj_field", expr op_deref, loc "test.swift":20:1, scope 3
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK-LABEL: sil @test_salvage_vector_base_addr
+// CHECK:       bb0([[ADDR:%[0-9]+]] : $*Builtin.FixedArray<4, Int64>):
+// CHECK:         debug_value [[ADDR]] : $*Builtin.FixedArray<4, Int64>, let, name "base", transform {
+// CHECK:           bb0([[VBA_ARG:%[0-9]+]] : $*Builtin.FixedArray<4, Int64>):
+// CHECK:             [[VBA:%[0-9]+]] = vector_base_addr [[VBA_ARG]] : $*Builtin.FixedArray<4, Int64>
+// CHECK:             [[VBA_LD:%[0-9]+]] = load [[VBA]] : $*Int64
+// CHECK:             return [[VBA_LD]] : $Int64
+// CHECK:         }
+// CHECK:         return
+// CHECK-LABEL: } // end sil function 'test_salvage_vector_base_addr'
+sil @test_salvage_vector_base_addr : $@convention(thin) (@in_guaranteed Builtin.FixedArray<4, Int64>) -> () {
+bb0(%0 : $*Builtin.FixedArray<4, Int64>):
+  %1 = vector_base_addr %0 : $*Builtin.FixedArray<4, Int64>
+  debug_value %1 : $*Int64, let, name "base", expr op_deref, loc "test.swift":30:1, scope 4
+  %r = tuple ()
+  return %r : $()
+}


### PR DESCRIPTION
Decreases the amount of lost variables in the stdlib at the SIL level by 0.27%, and increases the variables with a value at the DWARF level by 0.01%.

Note that the `DebugInfo/inlined-generics-basic.swift` test had to be updated, as the `t` variable is now being salvaged! This is what it looks like in SIL:
```swift
debug_value %1 : $C<R>, let, name "t", argno 1, expr op_deref, transform {
  bb0(%0 : $C<R>):
    %1 = ref_element_addr [immutable] %0 : $C<R>, #C.r
    return %1 : $*R
  }
```
and in LLVM IR:
```llvm
#dbg_value(!DIArgList(ptr %1, ptr %1), !140, !DIExpression(DW_OP_LLVM_arg, 0, DW_OP_LLVM_arg, 1, DW_OP_deref, DW_OP_plus_uconst, 88, DW_OP_deref, DW_OP_plus, DW_OP_deref, DW_OP_stack_value), !143)
```