### PR TITLE
[Runtime] Avoid optimizing away user deinit on ~C struct when fields are POD

### DIFF
--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -3218,10 +3218,14 @@ void swift::swift_initStructMetadata(StructMetadata *structType,
       });
 
   // If the struct is always noncopyable, we must honor that.
-  if (layout.flags.isCopyable() &&
-      structType->getDescription()->isUnconditionallySuppressing(
-          InvertibleProtocolKind::Copyable))
+  if (structType->getDescription()->isUnconditionallySuppressing(
+          InvertibleProtocolKind::Copyable)) {
     layout.flags = layout.flags.withCopyable(false);
+    // Unconditionally ~Copyable types may have a user-defined deinit.
+    // Mark as non-POD to avoid optimizations which may skip calling that
+    // deinit.
+    layout.flags = layout.flags.withPOD(false);
+  }
 
   // We have extra inhabitants if any element does. Use the field with the most.
   unsigned extraInhabitantCount = 0;

--- a/test/Interpreter/Inputs/noncopyable_pod_generic_deinit_lib.swift
+++ b/test/Interpreter/Inputs/noncopyable_pod_generic_deinit_lib.swift
@@ -1,0 +1,13 @@
+public struct SomePOD {
+  public var x: Int = 0
+  public init() {}
+}
+
+// ~Copyable type which is POD according to its fields as long as T is also POD
+public struct NCWrapper<T: ~Copyable>: ~Copyable {
+  var inner: T
+  public init(_ t: consuming T) { inner = t }
+  deinit {
+    print("Container.deinit fired")
+  }
+}

--- a/test/Interpreter/noncopyable_pod_generic_deinit_separate_file.swift
+++ b/test/Interpreter/noncopyable_pod_generic_deinit_separate_file.swift
@@ -1,0 +1,32 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift-dylib(%t/%target-library-name(deinit_lib)) \
+// RUN:     -emit-module -emit-module-path %t/deinit_lib.swiftmodule \
+// RUN:     -module-name deinit_lib \
+// RUN:     %S/Inputs/noncopyable_pod_generic_deinit_lib.swift
+// RUN: %target-codesign %t/%target-library-name(deinit_lib)
+// RUN: %target-build-swift -parse-as-library -I %t -L %t -ldeinit_lib %s -o %t/a.out %target-rpath(%t)
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out %t/%target-library-name(deinit_lib) | %FileCheck %s
+
+// REQUIRES: executable_test
+
+// Verifies that runtime metadata initialization does not optimize away
+// the user-defined deinit for a ~Copyable struct which is determined to be POD
+// based on its fields alone (rdar://166549159).
+
+import deinit_lib
+
+@main
+struct App {
+  static func main() {
+    print("-- start")
+    do {
+      let _ = NCWrapper<SomePOD>(SomePOD())
+    }
+    print("-- done")
+  }
+}
+
+// CHECK:      -- start
+// CHECK-NEXT: Container.deinit fired
+// CHECK-NEXT: -- done


### PR DESCRIPTION
Currently if a `~Copyable` type with a user-defined `deinit` goes through runtime metadata instantiation, if the runtime code sees that the struct is POD based on resolving each field to be POD, it will assume the type is trivially destructible and corrupt the VWT by placing a no-op for destroy. This results in the `deinit` not being invoked whenever a destroy goes through the VWT.

This is happening in `swift::installCommonValueWitnesses` where it looks at whether or not the type is `POD` based on its evaluation of each field (not considering any existing deinit) and replaces the VWT entries. To avoid this sort of optimization, this PR tackles the issue by reporting unconditionally noncopyable types (types which could have a user-defined deinit) as not being POD.

The following reproduces the issue when compiled without WMO (and is the test included in this PR):

File with NC type:
```
public struct SomePOD {
  public var x: Int = 0
  public init() {}
}

public struct NCWrapper<T: ~Copyable>: ~Copyable {
  var inner: T
  public init(_ t: consuming T) { inner = t }
  deinit {
    print("Container.deinit fired")
  }
}
```

Calling file:
```
@main
struct App {
  static func main() {
    print("-- start")
    do {
      let _ = NCWrapper<SomePOD>(SomePOD())
    }
    print("-- done")
  }
}
```

Resolves rdar://166549159
