### PR TITLE
[DebugInfo] Clean up salvagePackElementSetDebugInfo

### DIFF
--- a/lib/SILOptimizer/Utils/InstOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/InstOptUtils.cpp
@@ -2033,9 +2033,13 @@ static void salvagePackElementSetDebugInfo(PackElementSetInst *PESI) {
 
   for (Operand *U : getDebugUses(API)) {
     auto *DbgInst = cast<DebugValueInst>(U->getUser());
+    // TODO: Support salvaging reconstruction blocks for packs, and use a
+    // reconstruction block instead of tuple fragments to salvage their debug
+    // info.
+    ASSERT(DbgInst->getDebugReconstructionBlock() == nullptr &&
+           "We do not yet support reconstruction blocks for packs.");
     auto VarInfo = DbgInst->getCompleteVarInfo();
     VarInfo.Type = silType;
-    VarInfo.Scope = API->getDebugScope();
     if (tupleType) {
       auto FragDIExpr = SILDebugInfoExpression::createTupleFragment(
           tupleType, SPII->getComponentIndex());


### PR DESCRIPTION
- Do not set the scope, which should already be correct.
- Assert that the `debug_value` instruction has no attached reconstruction block, to avoid silently dropping it.
- Note that this will eventually have to transition from using tuple fragments to reconstruction blocks.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
