### PR TITLE
AST: Escape member names when printing a DependentMemberType

### DIFF
--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -826,8 +826,6 @@ public:
   void initForSynthesizedExtensionInScope(TypeOrExtensionDecl D,
                                           OverrideScope &scope) const;
 
-  void clearSynthesizedExtension();
-
   bool shouldPrint(const Decl* D) const {
     return CurrentPrintabilityChecker->shouldPrint(D, *this);
   }

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -8034,9 +8034,11 @@ public:
         Printer.printName(Assoc->getProtocol()->getName());
         Printer << "]";
       }
-      Printer.printTypeRef(T, Assoc, T->getName());
+      Printer.printTypeRef(T, Assoc, T->getName(),
+                           PrintNameContext::TypeMember);
     } else {
-      Printer.printName(T->getName());
+      Printer.printName(T->getName(),
+                        PrintNameContext::TypeMember);
     }
   }
 

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -118,10 +118,6 @@ void PrintOptions::initForSynthesizedExtensionInScope(TypeOrExtensionDecl D,
                                       TypeTransformContext(D));
 }
 
-void PrintOptions::clearSynthesizedExtension() {
-  TransformContext.reset();
-}
-
 static bool isPublicOrUsableFromInline(const ValueDecl *VD) {
   AccessScope scope =
       VD->getFormalAccessScope(/*useDC*/nullptr,

--- a/test/ModuleInterface/escape-Type-and-Protocol.swift
+++ b/test/ModuleInterface/escape-Type-and-Protocol.swift
@@ -73,3 +73,13 @@ public enum UncoolEnum {
   case `Type`, `Protocol`
 // CHECK: }
 }
+
+// CHECK: public protocol SillyProtocol {
+public protocol SillyProtocol {
+  // CHECK-NEXT: associatedtype `Type`
+  associatedtype `Type`
+
+  // CHECK-NEXT: var type: Self.`Type` { get }
+  var type: Self.`Type` { get }
+// CHECK: }
+}


### PR DESCRIPTION
We need to ensure the right form of printName() is called, so that associated types named "Type", "Protocol", and so on, can be properly escaped. Otherwise, we can print something like "Self.Type" which is interpreted as a metatype.

Fixes rdar://177052246.