### PR TITLE
[6.4] AST: Escape member names when printing a DependentMemberType

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -8031,9 +8031,11 @@ public:
         Printer.printName(Assoc->getProtocol()->getName());
         Printer << "]";
       }
-      Printer.printTypeRef(T, Assoc, T->getName());
+      Printer.printTypeRef(T, Assoc, T->getName(),
+                           PrintNameContext::TypeMember);
     } else {
-      Printer.printName(T->getName());
+      Printer.printName(T->getName(),
+                        PrintNameContext::TypeMember);
     }
   }
 

--- a/test/ModuleInterface/escape-Type-and-Protocol.swift
+++ b/test/ModuleInterface/escape-Type-and-Protocol.swift
@@ -73,3 +73,13 @@ public enum UncoolEnum {
   case `Type`, `Protocol`
 // CHECK: }
 }
+
+// CHECK: public protocol SillyProtocol {
+public protocol SillyProtocol {
+  // CHECK-NEXT: associatedtype `Type`
+  associatedtype `Type`
+
+  // CHECK-NEXT: var type: Self.`Type` { get }
+  var type: Self.`Type` { get }
+// CHECK: }
+}


### PR DESCRIPTION
6.4 cherry-pick of https://github.com/swiftlang/swift/pull/89688.

* **Description:** We need to ensure the right form of printName() is called, so that associated types named "Type", "Protocol", and so on, can be properly escaped. Otherwise, we can print something like "Self.Type" which is interpreted as a metatype.

* **Scope of the issue:** Compiler generates a broken swiftinterface file. It might even type check, but the meaning of the code will be incorrect.

* **Risk:** Very low. The entry points for printing escaped identifiers are well-tested in other cases, we just weren't calling the right thing when given a DependentMemberType.

* **Radar:** Fixes rdar://177052246.
