### PR TITLE
Deadlines and task cancellation reasons

### DIFF
--- a/Runtimes/Core/Concurrency/CMakeLists.txt
+++ b/Runtimes/Core/Concurrency/CMakeLists.txt
@@ -96,6 +96,7 @@ add_library(swift_Concurrency
   TaskSleep.swift
   TaskSleepDuration.swift
   UnimplementedExecutor.swift
+  Deadline.swift
   "${CMAKE_CURRENT_BINARY_DIR}/Task+init.swift"
   "${CMAKE_CURRENT_BINARY_DIR}/TaskGroup+addTask.swift"
   "${CMAKE_CURRENT_BINARY_DIR}/Task+immediate.swift")

--- a/include/swift/RemoteInspection/RuntimeInternals.h
+++ b/include/swift/RemoteInspection/RuntimeInternals.h
@@ -107,13 +107,16 @@ struct ActiveTaskStatusWithoutEscalation {
 
 struct ActiveTaskStatusFlags {
   static const uint32_t PriorityMask = 0xFF;
-  static const uint32_t IsCancelled = 0x100;
   static const uint32_t IsStatusRecordLocked = 0x200;
   static const uint32_t IsEscalated = 0x400;
   static const uint32_t IsRunning = 0x800;
   static const uint32_t IsEnqueued = 0x1000;
   static const uint32_t IsComplete = 0x2000;
   static const uint32_t HasTaskDependency = 0x4000;
+  /// Two-bit cancellation reason field. See ActiveTaskStatus::CancellationReason.
+  static const uint32_t CancellationReasonShift = 17;
+  static const uint32_t CancellationReasonMask = 0x3u << CancellationReasonShift;
+  static const uint32_t IsCancelled = CancellationReasonMask;
 };
 
 template <typename Runtime, typename ActiveTaskStatus>

--- a/include/swift/Runtime/Concurrency.h
+++ b/include/swift/Runtime/Concurrency.h
@@ -140,6 +140,29 @@ void swift_job_deallocate(Job *job, void *ptr);
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
 void swift_task_cancel(AsyncTask *task);
 
+/// The reason a task is being cancelled. Mirrors
+/// ActiveTaskStatus::CancellationReason so it can be passed across the
+/// runtime ABI without exposing the private header.
+enum swift_task_cancellation_reason : uint8_t {
+  swift_task_cancellation_reason_TaskCancelled = 1,
+  swift_task_cancellation_reason_DeadlineExpired = 2,
+};
+
+/// Cancel a task with a specific cancellation reason. The reason is
+/// recorded in the task's status and observable via
+/// swift_task_getCancellationReason. If the task is already cancelled the
+/// reason is left unchanged.
+SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
+void swift_task_cancelWithReason(AsyncTask *task,
+                                 swift_task_cancellation_reason reason);
+
+/// Returns the cancellation reason recorded for the task, or 0 if the task
+/// is not currently cancelled. Cancellation shields are NOT taken into
+/// account here; the caller is responsible for combining this with
+/// swift_task_isCancelled when the shielded view of cancellation is desired.
+SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
+uint8_t swift_task_getCancellationReason(AsyncTask *task);
+
 /// Cancel all the child tasks that belong to the `group`.
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
 void swift_task_cancel_group_child_tasks(TaskGroup *group);
@@ -296,6 +319,12 @@ bool swift_taskGroup_addPending(TaskGroup *group, bool unconditionally);
 /// \endcode
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
 void swift_taskGroup_cancelAll(TaskGroup *group);
+
+/// Cancel all tasks in the group, recording the cancellation reason on
+/// each child task. See swift_task_cancellation_reason.
+SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
+void swift_taskGroup_cancelAllWithReason(TaskGroup *group,
+                                         swift_task_cancellation_reason reason);
 
 /// Check ONLY if the group was explicitly cancelled, e.g. by `cancelAll`.
 ///

--- a/stdlib/public/CompatibilityOverride/CompatibilityOverrideConcurrency.def
+++ b/stdlib/public/CompatibilityOverride/CompatibilityOverrideConcurrency.def
@@ -335,6 +335,12 @@ OVERRIDE_TASK_GROUP(taskGroup_cancelAll, void,
                     SWIFT_EXPORT_FROM(swift_Concurrency), SWIFT_CC(swift),
                     swift::, (TaskGroup *group), (group))
 
+OVERRIDE_TASK_GROUP(taskGroup_cancelAllWithReason, void,
+                    SWIFT_EXPORT_FROM(swift_Concurrency), SWIFT_CC(swift),
+                    swift::,
+                    (TaskGroup *group, swift_task_cancellation_reason reason),
+                    (group, reason))
+
 OVERRIDE_TASK_GROUP(taskGroup_addPending, bool,
                     SWIFT_EXPORT_FROM(swift_Concurrency), SWIFT_CC(swift),
                     swift::, (TaskGroup *group, bool unconditionally),
@@ -400,6 +406,16 @@ OVERRIDE_TASK_STATUS(task_hasTaskGroupStatusRecord, bool,
                      swift::, , )
 
 OVERRIDE_TASK_STATUS(task_cancel, void, SWIFT_EXPORT_FROM(swift_Concurrency),
+                     SWIFT_CC(swift), swift::, (AsyncTask *task), (task))
+
+OVERRIDE_TASK_STATUS(task_cancelWithReason, void,
+                     SWIFT_EXPORT_FROM(swift_Concurrency),
+                     SWIFT_CC(swift), swift::,
+                     (AsyncTask *task, swift_task_cancellation_reason reason),
+                     (task, reason))
+
+OVERRIDE_TASK_STATUS(task_getCancellationReason, uint8_t,
+                     SWIFT_EXPORT_FROM(swift_Concurrency),
                      SWIFT_CC(swift), swift::, (AsyncTask *task), (task))
 
 OVERRIDE_TASK_GROUP(task_cancel_group_child_tasks, void,

--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -181,6 +181,7 @@ set(SWIFT_RUNTIME_CONCURRENCY_SWIFT_SOURCES
   PlatformExecutorOpenBSD.swift
   PlatformExecutorFreeBSD.swift
   Result+AsyncInit.swift
+  Deadline.swift
 )
 
 set(SWIFT_RUNTIME_CONCURRENCY_NONEMBEDDED_C_SOURCES

--- a/stdlib/public/Concurrency/Clock.swift
+++ b/stdlib/public/Concurrency/Clock.swift
@@ -132,6 +132,13 @@ enum _ClockID: Int32 {
   case walltime = 3
 }
 
+@available(SwiftStdlib 6.5, *)
+@nonexhaustive
+public enum SystemClockID: Hashable {
+  case continuous
+  case suspending
+}
+
 @available(StdlibDeploymentTarget 5.7, *)
 @_silgen_name("swift_get_time")
 internal func _getTime(

--- a/stdlib/public/Concurrency/ContinuousClock.swift
+++ b/stdlib/public/Concurrency/ContinuousClock.swift
@@ -41,6 +41,12 @@ extension ContinuousClock.Instant: Codable {
 }
 #endif
 
+@available(SwiftStdlib 6.5, *)
+@_unavailableInEmbedded
+extension ContinuousClock: Identifiable {
+  public var id: SystemClockID { .continuous }
+}
+
 @available(StdlibDeploymentTarget 5.7, *)
 extension Duration {
   internal init(_seconds s: Int64, nanoseconds n: Int64) {

--- a/stdlib/public/Concurrency/Deadline.swift
+++ b/stdlib/public/Concurrency/Deadline.swift
@@ -1,0 +1,247 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Swift
+
+@available(SwiftStdlib 6.5, *)
+fileprivate struct Envelope<T: ~Copyable & ~Escapable>: ~Copyable, ~Escapable, @unchecked Sendable {
+  var contents: T
+}
+
+fileprivate extension Optional where Wrapped: ~Copyable & ~Escapable {
+  @available(SwiftStdlib 6.5, *)
+  @_lifetime(copy self)
+  mutating func takeSending() -> Envelope<Self> {
+    let result = consume self
+    self = nil
+    return Envelope(contents: result)
+  }
+}
+
+@available(SwiftStdlib 6.5, *)
+fileprivate struct Disconnected<Value: ~Copyable>: ~Copyable, Sendable {
+  private nonisolated(unsafe) var value: Value?
+  
+  init(value: consuming sending Value) {
+    self.value = .some(value)
+  }
+  
+  consuming func take() -> sending Value {
+    self.value.takeSending().contents!
+  }
+}
+
+@available(SwiftStdlib 6.5, *)
+fileprivate final class RefBox<Value: ~Copyable> {
+  private nonisolated(unsafe) var value: Value?
+  
+  init(value: consuming Value) {
+    self.value = consume value
+  }
+  
+  consuming func unbox() -> Value {
+    return value.take()!
+  }
+}
+
+@available(SwiftStdlib 6.5, *)
+extension RefBox: Sendable where Value: Sendable & ~Copyable {}
+
+@available(SwiftStdlib 6.5, *)
+fileprivate enum TaskResult<Return: Sendable, Failure: Error>: Sendable {
+  case success(Return)
+  case error(Failure)
+  case timedOut
+  case cancelled
+}
+
+@available(SwiftStdlib 6.5, *)
+fileprivate protocol _DeadlineStorage: Sendable {
+  associatedtype C: Clock & Identifiable
+  
+  var expiration: C.Instant { get }
+  var tolerance: C.Instant.Duration? { get }
+  var clock: C { get }
+}
+
+@available(SwiftStdlib 6.5, *)
+fileprivate struct DeadlineStorage<C: Clock & Identifiable>: _DeadlineStorage {
+  var expiration: C.Instant
+  var tolerance: C.Instant.Duration?
+  var clock: C
+  
+  var maximumExpiration: C.Instant {
+    if let tolerance {
+      return expiration.advanced(by: tolerance)
+    } else {
+      return expiration
+    }
+  }
+}
+
+@available(SwiftStdlib 6.5, *)
+@TaskLocal fileprivate nonisolated var activeDeadlines = [any _DeadlineStorage]()
+
+@available(SwiftStdlib 6.5, *)
+fileprivate nonisolated(nonsending) func __withDeadline<Return: ~Copyable, Failure: Error, C: Clock>(
+  clock: C,
+  until expiration: C.Instant,
+  tolerance: C.Instant.Duration?,
+  body: inout (@Sendable () async throws(Failure) -> Return)?
+) async throws(Failure) -> Return {
+  let result: Result<RefBox<Disconnected<Return>>, Failure> = await withTaskGroup(
+    of: TaskResult<RefBox<Disconnected<Return>>, Failure>.self
+  ) { group in
+    let body = body.takeSending().contents!
+    group.addTask {
+      do throws(Failure) {
+        return .success(RefBox(value: Disconnected(value: try await body())))
+      } catch {
+        return .error(error)
+      }
+    }
+    group.addTask {
+      do {
+        try await clock.sleep(until: expiration, tolerance: tolerance)
+        return .timedOut
+      } catch {
+        // TODO: this should eventually check the cancellation reason to return .timedOut when the reason is .deadlineExpired
+        return .cancelled
+      }
+    }
+    
+    switch await group.next()! {
+    case .success(let success):
+      group.cancelAll(reason: .taskCancelled)
+      return .success(success)
+    case .error(let failure):
+      group.cancelAll(reason: .taskCancelled)
+      return .failure(failure)
+    case .timedOut:
+      group.cancelAll(reason: .deadlineExpired)
+    case .cancelled:
+      break
+    }
+    
+    switch await group.next() {
+    case .success(let success):
+      return .success(success)
+    case .error(let failure):
+      return .failure(failure)
+    default:
+      // task group executed timeout task twice!
+      fatalError("Internal inconsistency")
+    }
+  }
+  return try result.get().unbox().take()
+}
+
+@available(SwiftStdlib 6.5, *)
+fileprivate nonisolated(nonsending) func _withDeadline<Return: ~Copyable, Failure: Error, C: Clock>(
+  clock: C,
+  until deadline: C.Instant,
+  tolerance: C.Instant.Duration?,
+  body: @Sendable () async throws(Failure) -> Return
+) async throws(Failure) -> Return {
+  try await withoutActuallyEscaping(body) { (escapingBody) async throws(Failure) -> Return in
+    var t = Optional(escapingBody)
+    return try await __withDeadline(clock: clock, until: deadline, tolerance: tolerance, body: &t)
+  }
+}
+
+extension Task where Success == Never, Failure == Never {
+  @available(SwiftStdlib 6.5, *)
+  public static var hasActiveDeadline: Bool {
+    !activeDeadlines.isEmpty
+  }
+  
+  @available(SwiftStdlib 6.5, *)
+  public static func activeDeadline<C: Clock & Identifiable>(for clock: C) -> C.Instant? {
+    for deadline in activeDeadlines {
+      if let d = deadline as? DeadlineStorage<C>, d.clock.id == clock.id {
+        return d.expiration
+      }
+    }
+    return nil
+  }
+}
+
+@available(SwiftStdlib 6.5, *)
+@_unavailableInEmbedded
+public nonisolated(nonsending) func withDeadline<Return: ~Copyable, Failure: Error, C: Clock & Identifiable>(
+  _ expiration: C.Instant,
+  tolerance: C.Instant.Duration? = nil,
+  clock: C = ContinuousClock(),
+  body: nonisolated(nonsending) () async throws(Failure) -> Return
+) async throws(Failure) -> Return {
+  nonisolated(unsafe) let body = body
+  
+  let proposedDeadline = DeadlineStorage(expiration: expiration, tolerance: tolerance, clock: clock)
+  var deadlines = activeDeadlines
+  // find and adjust any active deadlines
+  for (index, deadline) in deadlines.enumerated() {
+    if let d = deadline as? DeadlineStorage<C>, d.clock.id == clock.id {
+      if proposedDeadline.maximumExpiration < d.maximumExpiration {
+        deadlines[index] = proposedDeadline
+        // swap in the proposed deadline in the same hiearchy as the existing one
+        let result: RefBox<Result<Return, Failure>> = await $activeDeadlines.withValue(deadlines) {
+          do throws(Failure) {
+            return RefBox(value: .success(
+              try await _withDeadline(
+                clock: clock,
+                until: expiration,
+                tolerance: tolerance,
+              ) { () async throws(Failure) -> Return in
+                try await body()
+              }
+            ))
+          } catch {
+            return RefBox(value: .failure(error))
+          }
+        }
+        return try result.unbox().get()
+      } else {
+        // optimized such that the active deadline is obviated by an existing one
+        return try await body()
+      }
+    }
+  }
+  // no matching active deadline was found, build up a new list for this application
+  // normal application
+  deadlines.append(proposedDeadline)
+  let result: RefBox<Result<Return, Failure>> = await $activeDeadlines.withValue(deadlines) {
+    do throws(Failure) {
+      return RefBox(value: .success(
+        try await _withDeadline(
+          clock: clock,
+          until: expiration,
+          tolerance: tolerance,
+        ) { () async throws(Failure) -> Return in
+          try await body()
+        }
+      ))
+    } catch {
+      return RefBox(value: .failure(error))
+    }
+  }
+  return try result.unbox().get()
+}
+
+@available(SwiftStdlib 6.5, *)
+@_unavailableInEmbedded
+public nonisolated(nonsending) func withDeadline<Return: ~Copyable, Failure: Error>(
+  in timeout: ContinuousClock.Instant.Duration,
+  tolerance: ContinuousClock.Instant.Duration? = nil,
+  body: nonisolated(nonsending) () async throws(Failure) -> Return
+) async throws(Failure) -> Return {
+  try await withDeadline(.now.advanced(by: timeout), tolerance: tolerance, clock: ContinuousClock(), body: body)
+}

--- a/stdlib/public/Concurrency/DiscardingTaskGroup.swift
+++ b/stdlib/public/Concurrency/DiscardingTaskGroup.swift
@@ -218,6 +218,14 @@ public struct DiscardingTaskGroup {
     _taskGroupCancelAll(group: _group)
   }
 
+  /// Cancel all of the remaining tasks in the group, recording the reason
+  /// on each affected child task. See `TaskGroup.cancelAll(reason:)` for the
+  /// semantics shared between all task group variants.
+  @available(SwiftStdlib 6.5, *)
+  public func cancelAll(reason: CancellationError.Reason) {
+    _taskGroupCancelAllWithReason(group: _group, reason: reason._rawValue)
+  }
+
   /// A Boolean value that indicates whether the group was canceled.
   ///
   /// To cancel a group, call the `DiscardingTaskGroup.cancelAll()` method.
@@ -514,6 +522,14 @@ public struct ThrowingDiscardingTaskGroup<Failure: Error> {
   /// - SeeAlso: `ThrowingDiscardingTaskGroup.isCancelled`
   public func cancelAll() {
     _taskGroupCancelAll(group: _group)
+  }
+
+  /// Cancel all of the remaining tasks in the group, recording the reason
+  /// on each affected child task. See `TaskGroup.cancelAll(reason:)` for the
+  /// semantics shared between all task group variants.
+  @available(SwiftStdlib 6.5, *)
+  public func cancelAll(reason: CancellationError.Reason) {
+    _taskGroupCancelAllWithReason(group: _group, reason: reason._rawValue)
   }
 
   /// A Boolean value that indicates whether the group was canceled.

--- a/stdlib/public/Concurrency/SuspendingClock.swift
+++ b/stdlib/public/Concurrency/SuspendingClock.swift
@@ -40,6 +40,12 @@ extension SuspendingClock.Instant: Codable {
 }
 #endif
 
+@available(SwiftStdlib 6.5, *)
+@_unavailableInEmbedded
+extension SuspendingClock: Identifiable {
+  public var id: SystemClockID { .suspending }
+}
+
 @available(StdlibDeploymentTarget 5.7, *)
 @_unavailableInEmbedded
 extension Clock where Self == SuspendingClock {

--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -1131,8 +1131,15 @@ swift_task_create_commonImpl(size_t rawTaskCreateFlags,
     // In a task group we would not have allowed the `add` to create a child anymore,
     // however better safe than sorry and `async let` are not expressed as task groups,
     // so they may have been spawned in any case still.
-    if ((group && group->isCancelled()) || swift_task_isCancelled(parent))
-      swift_task_cancel(task);
+    if ((group && group->isCancelled()) || swift_task_isCancelled(parent)) {
+      auto parentReason = static_cast<swift_task_cancellation_reason>(
+          swift_task_getCancellationReason(parent));
+      if (parentReason ==
+          static_cast<swift_task_cancellation_reason>(0)) {
+        parentReason = swift_task_cancellation_reason_TaskCancelled;
+      }
+      swift_task_cancelWithReason(task, parentReason);
+    }
 
     // Inside a task group, we may have to perform some defensive copying,
     // check if doing so is necessary, and initialize storage using partial

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -252,6 +252,20 @@ extension Task {
   public func cancel() {
     unsafe _taskCancel(_AsyncTask(_task))
   }
+
+  /// Indicates that the task should stop running, recording the reason for
+  /// cancellation in the task's status. The reason is observable via
+  /// the `reason` property on `CancellationError` thrown from the task and
+  /// is delivered to handlers registered via `withTaskCancellationHandler`.
+  ///
+  /// Calling `cancel(reason:)` on a task that is already cancelled has no
+  /// effect: the first reason recorded wins.
+  ///
+  /// - Parameter reason: The reason the task is being cancelled.
+  @available(SwiftStdlib 6.5, *)
+  public func cancel(reason: CancellationError.Reason) {
+    _taskCancelWithReason(_task, reason: reason._rawValue)
+  }
 }
 
 @available(SwiftStdlib 5.1, *)
@@ -918,6 +932,16 @@ public struct UnsafeCurrentTask {
   /// - SeeAlso: ``Task/hasActiveTaskCancellationShield``
   public func cancel() {
     unsafe _taskCancel(_rawTask)
+  }
+
+  /// Cancel the current task, recording the reason for cancellation in the
+  /// task's status so that observers can distinguish between, for example,
+  /// an explicit cancellation and a deadline expiration.
+  ///
+  /// - Parameter reason: The reason the task is being cancelled.
+  @available(SwiftStdlib 6.5, *)
+  public func cancel(reason: CancellationError.Reason) {
+    unsafe _taskCancelWithReason(_task, reason: reason._rawValue)
   }
 
   /// Checks if this task is executing in a scope with a task cancellation shield activated by the

--- a/stdlib/public/Concurrency/TaskCancellation.swift
+++ b/stdlib/public/Concurrency/TaskCancellation.swift
@@ -90,6 +90,47 @@ public nonisolated(nonsending) func withTaskCancellationHandler<Return, Failure>
   return try await operation()
 }
 
+/// Execute an operation with a cancellation handler that receives the
+/// reason for cancellation. Behaves identically to the existing
+/// `withTaskCancellationHandler` except that the handler is passed a
+/// `CancellationError.Reason` describing why the surrounding task was
+/// cancelled. This makes it possible to distinguish, for example, an
+/// explicit `Task.cancel()` from a deadline-driven cancellation produced
+/// by `withDeadline`.
+///
+/// - Parameters:
+///   - operation: The operation to perform.
+///   - handler: A closure to execute on cancellation. The closure receives
+///     the cancellation reason recorded on the surrounding task.
+@available(SwiftStdlib 6.5, *)
+@_alwaysEmitIntoClient
+public nonisolated(nonsending) func withTaskCancellationHandler<Return, Failure>(
+  operation: nonisolated(nonsending) () async throws(Failure) -> Return,
+  onCancel handler: sending (CancellationError.Reason) -> Void
+) async throws(Failure) -> Return {
+  // Wrap the reason-taking handler in a no-arg handler that queries the
+  // cancellation reason from the current task and forwards it. The wrapped
+  // closure is only ever called once (via the cancellation status record),
+  // matching the semantics of the underlying handler API.
+  let wrapped: () -> Void = {
+    let raw: UInt8
+    if let task = unsafe _getCurrentAsyncTask() {
+      raw = unsafe _taskGetCancellationReason(task)
+    } else {
+      raw = 1 // .taskCancelled fallback
+    }
+    handler(CancellationError.Reason(_rawValue: raw))
+  }
+#if $BuiltinConcurrencyStackNesting
+  let record = unsafe Builtin.taskAddCancellationHandler(handler: wrapped)
+  defer { unsafe Builtin.taskRemoveCancellationHandler(record: record) }
+#else
+  let record = unsafe _taskAddCancellationHandler(handler: wrapped)
+  defer { unsafe _taskRemoveCancellationHandler(record: record) }
+#endif
+  return try await operation()
+}
+
 #if !$Embedded
 /// Execute an operation with a cancellation handler that's immediately
 /// invoked if the current task is canceled.
@@ -279,8 +320,63 @@ extension Task where Success == Never, Failure == Never {
 /// if the current task has been canceled.
 @available(SwiftStdlib 5.1, *)
 public struct CancellationError: Error {
+  /// The reason that a task was cancelled. Different cancellation entry points
+  /// supply different reasons; for example, an explicit `Task.cancel()` call
+  /// records `.taskCancelled`, while a deadline expiration records
+  /// `.deadlineExpired`.
+  ///
+  /// Switching exhaustively over this type requires an `@unknown default` case
+  /// because additional reasons may be added in the future.
+  @available(SwiftStdlib 6.5, *)
+  @nonexhaustive
+  public enum Reason: Sendable {
+      /// The task was ca'ncelled through an explicit cancellation request such
+    /// as `Task.cancel()` or `TaskGroup.cancelAll()`.
+    case taskCancelled
+    /// The task was cancelled because a deadline applied via `withDeadline`
+    /// expired before the operation completed.
+    case deadlineExpired
+
+    @usableFromInline
+    internal var _rawValue: UInt8 {
+      switch self {
+      case .taskCancelled: return 1
+      case .deadlineExpired: return 2
+      }
+    }
+
+    @usableFromInline
+    internal init(_rawValue raw: UInt8) {
+      switch raw {
+      case 2: self = .deadlineExpired
+      default: self = .taskCancelled
+      }
+    }
+  }
+
+  @usableFromInline
+  internal var _reason: UInt8
+
+  /// The reason that this cancellation error was produced. The default value
+  /// is `.taskCancelled` for instances created by code written before this
+  /// API existed.
+  @available(SwiftStdlib 6.5, *)
+  public var reason: Reason {
+    Reason(_rawValue: _reason)
+  }
+
   // no extra information, cancellation is intended to be light-weight
-  public init() {}
+  public init() {
+    self._reason = 1 // .taskCancelled
+  }
+
+  /// Construct a `CancellationError` with a specific reason. Use this to
+  /// convey to callers why a task was cancelled (for example, to distinguish
+  /// a deadline expiration from an explicit cancellation request).
+  @available(SwiftStdlib 6.5, *)
+  public init(reason: Reason) {
+    self._reason = reason._rawValue
+  }
 }
 
 @usableFromInline
@@ -293,6 +389,23 @@ func _taskAddCancellationHandler(handler: () -> Void) -> UnsafeRawPointer /*Canc
 @_silgen_name("swift_task_removeCancellationHandler")
 func _taskRemoveCancellationHandler(
   record: UnsafeRawPointer /*CancellationNotificationStatusRecord*/
+)
+
+@available(SwiftStdlib 6.5, *)
+@usableFromInline
+@_silgen_name("swift_task_cancelWithReason")
+internal func _taskCancelWithReason(_ task: Builtin.NativeObject, reason: UInt8)
+
+@available(SwiftStdlib 6.5, *)
+@usableFromInline
+@_silgen_name("swift_task_getCancellationReason")
+internal func _taskGetCancellationReason(_ task: Builtin.NativeObject) -> UInt8
+
+@available(SwiftStdlib 6.5, *)
+@usableFromInline
+@_silgen_name("swift_taskGroup_cancelAllWithReason")
+internal func _taskGroupCancelAllWithReason(
+  group: Builtin.RawPointer, reason: UInt8
 )
 
 

--- a/stdlib/public/Concurrency/TaskCancellation.swift
+++ b/stdlib/public/Concurrency/TaskCancellation.swift
@@ -114,8 +114,10 @@ public nonisolated(nonsending) func withTaskCancellationHandler<Return, Failure>
   // matching the semantics of the underlying handler API.
   let wrapped: () -> Void = {
     let raw: UInt8
-    if let task = unsafe _getCurrentAsyncTask() {
-      raw = unsafe _taskGetCancellationReason(task)
+    if let rawTask = unsafe _getCurrentAsyncTask() {
+      let ref: Builtin.NativeObject =
+        unsafe Builtin.bridgeFromRawPointer(rawTask._rawValue)
+      raw = unsafe _taskGetCancellationReason(ref)
     } else {
       raw = 1 // .taskCancelled fallback
     }

--- a/stdlib/public/Concurrency/TaskGroup.cpp
+++ b/stdlib/public/Concurrency/TaskGroup.cpp
@@ -476,6 +476,11 @@ public:
   /// Cancel the group and all of its child tasks recursively.
   /// This also sets the cancelled bit in the group status.
   bool cancelAll(AsyncTask *task);
+
+  /// Cancel the group and all of its child tasks recursively, recording the
+  /// given cancellation reason on each affected child task.
+  bool cancelAllWithReason(AsyncTask *task,
+                           swift_task_cancellation_reason reason);
 };
 
 #if !SWIFT_CONCURRENCY_EMBEDDED
@@ -2119,13 +2124,27 @@ static bool swift_taskGroup_isCancelledImpl(TaskGroup *group) {
 
 SWIFT_CC(swift)
 static void swift_taskGroup_cancelAllImpl(TaskGroup *group) {
+  swift_taskGroup_cancelAllWithReason(
+      group, swift_task_cancellation_reason_TaskCancelled);
+}
+
+SWIFT_CC(swift)
+static void swift_taskGroup_cancelAllWithReasonImpl(
+    TaskGroup *group, swift_task_cancellation_reason reason) {
   // TaskGroup is not a Sendable type, so this can only be called from the
   // owning task.
-  asBaseImpl(group)->cancelAll(swift_task_getCurrent());
+  asBaseImpl(group)->cancelAllWithReason(swift_task_getCurrent(), reason);
 }
 
 bool TaskGroupBase::cancelAll(AsyncTask *owningTask) {
-  SWIFT_TASK_DEBUG_LOG("cancel all tasks in group = %p", this);
+  return cancelAllWithReason(owningTask,
+                             swift_task_cancellation_reason_TaskCancelled);
+}
+
+bool TaskGroupBase::cancelAllWithReason(
+    AsyncTask *owningTask, swift_task_cancellation_reason reason) {
+  SWIFT_TASK_DEBUG_LOG("cancel all tasks in group = %p reason = %u",
+                       this, (unsigned)reason);
 
   // Flag the task group itself as cancelled.  If this was already
   // done, any existing child tasks should already have been cancelled,
@@ -2139,7 +2158,8 @@ bool TaskGroupBase::cancelAll(AsyncTask *owningTask) {
   // Cancel all the child tasks.  TaskGroup is not a Sendable type,
   // so cancelAll() can only be called from the owning task.  This
   // satisfies the precondition on cancel_unlocked().
-  _swift_taskGroup_cancel_unlocked(asAbstract(this), owningTask);
+  _swift_taskGroup_cancelWithReason_unlocked(asAbstract(this), owningTask,
+                                             reason);
 
   return true;
 }

--- a/stdlib/public/Concurrency/TaskGroup.swift
+++ b/stdlib/public/Concurrency/TaskGroup.swift
@@ -494,6 +494,17 @@ public struct TaskGroup<ChildTaskResult: Sendable> {
     _taskGroupCancelAll(group: _group)
   }
 
+  /// Cancel all of the remaining tasks in the group, recording the reason
+  /// on each affected child task. This allows handlers to distinguish a
+  /// deadline-driven cancellation from an explicit cancellation request.
+  ///
+  /// Subsequent calls to `cancelAll(reason:)` have no effect after the
+  /// group is already cancelled.
+  @available(SwiftStdlib 6.5, *)
+  public func cancelAll(reason: CancellationError.Reason) {
+    _taskGroupCancelAllWithReason(group: _group, reason: reason._rawValue)
+  }
+
   /// A Boolean value that indicates whether the group was canceled.
   ///
   /// To cancel a group, call the `TaskGroup.cancelAll()` method.
@@ -850,6 +861,14 @@ public struct ThrowingTaskGroup<ChildTaskResult: Sendable, Failure: Error> {
   /// - SeeAlso: `ThrowingTaskGroup.isCancelled`
   public func cancelAll() {
     _taskGroupCancelAll(group: _group)
+  }
+
+  /// Cancel all of the remaining tasks in the group, recording the reason
+  /// on each affected child task. See `TaskGroup.cancelAll(reason:)` for the
+  /// semantics shared between all task group variants.
+  @available(SwiftStdlib 6.5, *)
+  public func cancelAll(reason: CancellationError.Reason) {
+    _taskGroupCancelAllWithReason(group: _group, reason: reason._rawValue)
   }
 
   /// A Boolean value that indicates whether the group was canceled.

--- a/stdlib/public/Concurrency/TaskPrivate.h
+++ b/stdlib/public/Concurrency/TaskPrivate.h
@@ -107,11 +107,27 @@ AsyncTask *_swift_task_setCurrent(AsyncTask *newTask);
 /// task's status record lock.
 void _swift_taskGroup_cancel(TaskGroup *group);
 
+/// Cancel the task group and all the child tasks that belong to `group`,
+/// recording the given cancellation reason on each child task.
+///
+/// The caller must guarantee that this is called while holding the owning
+/// task's status record lock.
+void _swift_taskGroup_cancelWithReason(TaskGroup *group,
+                                       swift_task_cancellation_reason reason);
+
 /// Cancel the task group and all the child tasks that belong to `group`.
 ///
 /// The caller must guarantee that this is called from the owning task.
 void _swift_taskGroup_cancel_unlocked(TaskGroup *group,
                                                  AsyncTask *owningTask);
+
+/// Cancel the task group and all the child tasks that belong to `group`,
+/// recording the given cancellation reason on each child task.
+///
+/// The caller must guarantee that this is called from the owning task.
+void _swift_taskGroup_cancelWithReason_unlocked(
+    TaskGroup *group, AsyncTask *owningTask,
+    swift_task_cancellation_reason reason);
 
 /// Remove the given task from the given task group.
 ///
@@ -441,12 +457,20 @@ public:
 ///     AsyncTask::PrivateStorage. The additional alignment requirements are
 ///     enforced by static asserts below.
 class alignas(2 * sizeof(void*)) ActiveTaskStatus {
+public:
+  /// The reason a task is cancelled. Stored in two adjacent bits of the
+  /// flags word, allowing three states with one encoding reserved for
+  /// future use.
+  enum class CancellationReason : uint8_t {
+    None = 0,
+    TaskCancelled = 1,
+    DeadlineExpired = 2,
+  };
+
+private:
   enum : uint32_t {
     /// The max priority of the task. This is always >= basePriority in the task
     PriorityMask = 0xFF,
-
-    /// Has the task been cancelled?
-    IsCancelled = 0x100,
 
     /// Whether the task status is "locked", meaning that further
     /// accesses need to wait on the task status record lock. This is separate
@@ -493,8 +517,16 @@ class alignas(2 * sizeof(void*)) ActiveTaskStatus {
     /// use the task executor preference when we'd otherwise be running on
     /// the generic global pool.
     HasTaskExecutorPreference = 0x8000,
-    
+
     HasActiveTaskCancellationShield = 0x10000,
+
+    /// Two adjacent bits encoding the cancellation reason. A value of 0
+    /// indicates the task is not cancelled, 1 indicates a normal task
+    /// cancellation, and 2 indicates the task was cancelled because a
+    /// deadline expired. The fourth encoding (3) is reserved for future
+    /// use. This replaces what was previously a single IsCancelled bit.
+    CancellationReasonShift = 17,
+    CancellationReasonMask = 0x3u << CancellationReasonShift, // 0x60000
   };
 
   // Note: this structure is mirrored by ActiveTaskStatusWithEscalation and
@@ -544,19 +576,37 @@ public:
       : Flags(uintptr_t(priority)), Record(nullptr) {}
 #endif
 
+  /// Returns the cancellation reason. This does not take cancellation
+  /// shields into account; while a shield is active the task is still
+  /// recorded as cancelled but observers should treat the task as not
+  /// cancelled. Use isCancelled() for the shield-aware check.
+  CancellationReason getCancellationReason() const {
+    return static_cast<CancellationReason>(
+        (Flags & CancellationReasonMask) >> CancellationReasonShift);
+  }
+
   /// Is the task currently cancelled?
   /// This does take into account cancellation shields, i.e. while a shield is active this function will always return 'false'.
-  bool isCancelled(bool ignoreShield = false) const { 
-    return (Flags & IsCancelled) && (ignoreShield || !(Flags & HasActiveTaskCancellationShield)); 
+  bool isCancelled(bool ignoreShield = false) const {
+    return (Flags & CancellationReasonMask) &&
+           (ignoreShield || !(Flags & HasActiveTaskCancellationShield));
   }
-  bool isCancelledIgnoringShield() const { return Flags & IsCancelled; }
-  ActiveTaskStatus withCancelled() const {
+  bool isCancelledIgnoringShield() const {
+    return (Flags & CancellationReasonMask) != 0;
+  }
+  ActiveTaskStatus withCancellationReason(CancellationReason reason) const {
+    uint32_t reasonBits = (static_cast<uint32_t>(reason) << CancellationReasonShift)
+                          & CancellationReasonMask;
+    uint32_t newFlags = (Flags & ~CancellationReasonMask) | reasonBits;
 #if SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION
-    return ActiveTaskStatus(Record, Flags | IsCancelled, ExecutionLock);
+    return ActiveTaskStatus(Record, newFlags, ExecutionLock);
 #else
-    return ActiveTaskStatus(Record, Flags | IsCancelled);
+    return ActiveTaskStatus(Record, newFlags);
 #endif
-  }  
+  }
+  ActiveTaskStatus withCancelled() const {
+    return withCancellationReason(CancellationReason::TaskCancelled);
+  }
   
   bool hasCancellationShield() const { return Flags & HasActiveTaskCancellationShield; }
   ActiveTaskStatus withCancellationShield() const {

--- a/stdlib/public/Concurrency/TaskStatus.cpp
+++ b/stdlib/public/Concurrency/TaskStatus.cpp
@@ -777,7 +777,11 @@ void swift::updateNewChildWithParentAndGroupState(AsyncTask *child,
   auto newChildTaskStatus = oldChildTaskStatus;
 
   if (parentStatus.isCancelled() || (group && group->isCancelled())) {
-    newChildTaskStatus = newChildTaskStatus.withCancelled();
+    auto reason = parentStatus.getCancellationReason();
+    if (reason == ActiveTaskStatus::CancellationReason::None) {
+      reason = ActiveTaskStatus::CancellationReason::TaskCancelled;
+    }
+    newChildTaskStatus = newChildTaskStatus.withCancellationReason(reason);
   }
 
   // Propagate max priority of parent to child task's active status
@@ -832,6 +836,12 @@ void swift::_swift_taskGroup_detachChild(TaskGroup *group,
 /// The caller must guarantee that this is called while holding the owning
 /// task's status record lock.
 void swift::_swift_taskGroup_cancel(TaskGroup *group) {
+  _swift_taskGroup_cancelWithReason(
+      group, swift_task_cancellation_reason_TaskCancelled);
+}
+
+void swift::_swift_taskGroup_cancelWithReason(
+    TaskGroup *group, swift_task_cancellation_reason reason) {
   (void) group->statusCancel();
 
   // Because only the owning task of the task group can modify the
@@ -839,7 +849,7 @@ void swift::_swift_taskGroup_cancel(TaskGroup *group) {
   // while holding the owning task's status record lock, we do not need
   // any additional synchronization within this function.
   for (auto childTask : group->getTaskRecord()->children())
-    swift_task_cancel(childTask);
+    swift_task_cancelWithReason(childTask, reason);
 }
 
 /// Cancel the task group and all the child tasks that belong to `group`.
@@ -847,14 +857,21 @@ void swift::_swift_taskGroup_cancel(TaskGroup *group) {
 /// The caller must guarantee that this is called from the owning task.
 void swift::_swift_taskGroup_cancel_unlocked(TaskGroup *group,
                                                         AsyncTask *owningTask) {
+  _swift_taskGroup_cancelWithReason_unlocked(
+      group, owningTask, swift_task_cancellation_reason_TaskCancelled);
+}
+
+void swift::_swift_taskGroup_cancelWithReason_unlocked(
+    TaskGroup *group, AsyncTask *owningTask,
+    swift_task_cancellation_reason reason) {
   // Early out. If there are no children, there's nothing to do. We can safely
   // check this without locking, since this can only be concurrently mutated
   // from a child task. If there are no children then no more can be added.
   if (!group->getTaskRecord()->getFirstChild())
     return;
 
-  withStatusRecordLock(owningTask, [&group](ActiveTaskStatus status) {
-    _swift_taskGroup_cancel(group);
+  withStatusRecordLock(owningTask, [&group, reason](ActiveTaskStatus status) {
+    _swift_taskGroup_cancelWithReason(group, reason);
   });
 }
 
@@ -863,13 +880,15 @@ void swift::_swift_taskGroup_cancel_unlocked(TaskGroup *group,
 /**************************************************************************/
 
 /// Perform any cancellation actions required by the given record.
-static void performCancellationAction(ActiveTaskStatus status, TaskStatusRecord *record) {
+static void performCancellationAction(ActiveTaskStatus status,
+                                      TaskStatusRecord *record,
+                                      swift_task_cancellation_reason reason) {
   switch (record->getKind()) {
   // Child tasks need to be recursively cancelled.
   case TaskStatusRecordKind::ChildTask: {
     auto childRecord = cast<ChildTaskStatusRecord>(record);
     for (AsyncTask *child: childRecord->children())
-      swift_task_cancel(child);
+      swift_task_cancelWithReason(child, reason);
     return;
   }
 
@@ -878,7 +897,7 @@ static void performCancellationAction(ActiveTaskStatus status, TaskStatusRecord 
   // under the synchronous control of the task that owns the group.
   case TaskStatusRecordKind::TaskGroup: {
     auto groupRecord = cast<TaskGroupTaskStatusRecord>(record);
-    _swift_taskGroup_cancel(groupRecord->getGroup());
+    _swift_taskGroup_cancelWithReason(groupRecord->getGroup(), reason);
     return;
   }
 
@@ -888,7 +907,7 @@ static void performCancellationAction(ActiveTaskStatus status, TaskStatusRecord 
       cast<CancellationNotificationStatusRecord>(record);
     if (status.hasCancellationShield()) {
       SWIFT_TASK_DEBUG_LOG("cancellation shielded: skip cancellation handler invocation in task = %p", swift_task_getCurrent());
-      return; 
+      return;
     }
     notification->run();
     return;
@@ -921,19 +940,32 @@ static void performCancellationAction(ActiveTaskStatus status, TaskStatusRecord 
 
 SWIFT_CC(swift)
 static void swift_task_cancelImpl(AsyncTask *task) {
-  SWIFT_TASK_DEBUG_LOG("cancel task = %p", task);
+  swift_task_cancelWithReason(
+      task, swift_task_cancellation_reason_TaskCancelled);
+}
+
+SWIFT_CC(swift)
+static void
+swift_task_cancelWithReasonImpl(AsyncTask *task,
+                                swift_task_cancellation_reason rawReason) {
+  SWIFT_TASK_DEBUG_LOG("cancel task = %p reason = %u", task, (unsigned)rawReason);
+
+  auto reason = static_cast<ActiveTaskStatus::CancellationReason>(rawReason);
+  assert(reason != ActiveTaskStatus::CancellationReason::None &&
+         "cancel reason must not be None");
 
   auto oldStatus = task->_private()._status().load(std::memory_order_relaxed);
   auto newStatus = oldStatus;
   while (true) {
-    // Are we already cancelled? 
-    // Even if we have a cancellation shield active, we do want to set the isCancelled flag.
-    if (oldStatus.isCancelled(/*ignoreShield=*/false)) {
+    // Are we already cancelled?
+    // Even if we have a cancellation shield active we want to record the
+    // reason on the first cancel; later cancels do not overwrite it.
+    if (oldStatus.isCancelled(/*ignoreShield=*/true)) {
       return;
     }
 
-    // Set cancelled bit even if oldStatus.isStatusRecordLocked()
-    newStatus = oldStatus.withCancelled();
+    // Set the cancellation reason even if oldStatus.isStatusRecordLocked()
+    newStatus = oldStatus.withCancellationReason(reason);
 
     // consume here pairs with the release in addStatusRecord.
     if (task->_private()._status().compare_exchange_weak(oldStatus, newStatus,
@@ -958,9 +990,16 @@ static void swift_task_cancelImpl(AsyncTask *task) {
       // be added since that's only possible while on task.
       //
       // Each action must independently take care of how to deal with cancellation shields.
-      performCancellationAction(newStatus, cur);
+      performCancellationAction(newStatus, cur, rawReason);
     }
   });
+}
+
+SWIFT_CC(swift)
+static uint8_t swift_task_getCancellationReasonImpl(AsyncTask *task) {
+  return static_cast<uint8_t>(
+      task->_private()._status().load(std::memory_order_relaxed)
+          .getCancellationReason());
 }
 
 /**************************************************************************/

--- a/unittests/runtime/CompatibilityOverrideConcurrency.cpp
+++ b/unittests/runtime/CompatibilityOverrideConcurrency.cpp
@@ -282,6 +282,11 @@ TEST_F(CompatibilityOverrideConcurrencyTest, test_swift_taskGroup_cancelAll) {
   swift_taskGroup_cancelAll(nullptr);
 }
 
+TEST_F(CompatibilityOverrideConcurrencyTest, test_swift_taskGroup_cancelAllWithReason) {
+  swift_taskGroup_cancelAllWithReason(
+      nullptr, swift_task_cancellation_reason_TaskCancelled);
+}
+
 TEST_F(CompatibilityOverrideConcurrencyTest, test_swift_taskGroup_waitAll) {
   swift_taskGroup_waitAll(nullptr, nullptr, nullptr, nullptr, nullptr, nullptr);
 }
@@ -324,6 +329,15 @@ TEST_F(CompatibilityOverrideConcurrencyTest, task_popTaskExecutorPreference) {
 
 TEST_F(CompatibilityOverrideConcurrencyTest, test_swift_task_cancel) {
   swift_task_cancel(nullptr);
+}
+
+TEST_F(CompatibilityOverrideConcurrencyTest, test_swift_task_cancelWithReason) {
+  swift_task_cancelWithReason(nullptr,
+                              swift_task_cancellation_reason_TaskCancelled);
+}
+
+TEST_F(CompatibilityOverrideConcurrencyTest, test_swift_task_getCancellationReason) {
+  swift_task_getCancellationReason(nullptr);
 }
 
 TEST_F(CompatibilityOverrideConcurrencyTest, test_swift_task_cancel_group_child_tasks) {


### PR DESCRIPTION
This is a start to an implementation of the deadline and task cancellation reasons proposal. 

Outstanding tasks:

- [ ] The tests still need to be ported from local swift-test based syntax to lit
- [ ] The checkCancellation should query the current task's reason
- [ ] The throws signature for Task.sleep and the specific clock sleep functions likely should be converted to typed throws.
- [ ] Verify the target release version (currently set beyond the active target release to avoid potential issues) and also verify which APIs need consideration for back-porting
- [ ] The public interface for withDeadline needs documentation