### PR TITLE
[6.3][SILOptimizer] Transfer `nonisolated(nonsending)` from the original t…

### DIFF
--- a/lib/SILOptimizer/FunctionSignatureTransforms/FunctionSignatureOpts.cpp
+++ b/lib/SILOptimizer/FunctionSignatureTransforms/FunctionSignatureOpts.cpp
@@ -563,6 +563,12 @@ void FunctionSignatureTransform::createFunctionSignatureOptimizedFunction() {
     NewF->setSpecializationInfo(F->getSpecializationInfo());
   }
 
+  // Optimizing `nonisolated(nonsending)` functions should preserve isolation
+  // otherwise it could lead to `OptimizeHopToExecutor` pass removing valid
+  // backward hops.
+  if (F->isNonisolatedNonsending())
+    NewF->setActorIsolation(*F->getActorIsolation());
+
   // Then we transfer the body of F to NewF.
   NewF->moveAllBlocksFromOtherFunction(F);
 

--- a/lib/SILOptimizer/Utils/OptimizerBridging.cpp
+++ b/lib/SILOptimizer/Utils/OptimizerBridging.cpp
@@ -469,6 +469,14 @@ createSpecializedFunctionDeclaration(BridgedStringRef specializedName,
   for (auto &Attr : original->getSemanticsAttrs())
     specializedApplySiteCallee->addSemanticsAttr(Attr);
 
+  // A narrow fix for issues with reabstraction thunk specialization.
+  // If the isolation is not set when re-abstracting into
+  // `nonisolated(nonsending)` it could lead to `OptimizeHopToExecutor`
+  // pass removing valid backward hops.
+  if (original->isNonisolatedNonsending())
+    specializedApplySiteCallee->setActorIsolation(
+        *original->getActorIsolation());
+
   return {specializedApplySiteCallee};
 }
 

--- a/test/Interpreter/issue88993.swift
+++ b/test/Interpreter/issue88993.swift
@@ -3,8 +3,11 @@
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main
 
-// Temporarily disabled until issues in the optimized builds are addressed.
-// REQUIRES: rdar178397835
+// RUN: rm %t/main
+
+// RUN: %target-build-swift -language-mode 5 -strict-concurrency=complete -target %target-swift-5.1-abi-triple %s -parse-as-library -module-name main -O -o %t/main
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main
 
 // REQUIRES: concurrency
 // REQUIRES: concurrency_runtime


### PR DESCRIPTION
…o specialized/optimized SILFunction variant

- Explanation:

  This is a narrow fix for `nonisolated(nonsending)` function and reabstraction thunks in particular. If the speciflized/optimized variant doesn't get the right isolation, `OptimizeHopToExecutor` pass can incorrectly remove a valid backward hop which results in a potential runtime crash if the call to `nonisolated(nonsending)` is followed by synchronous code that expects the original isolation.

- Resolves: rdar://178397835

- Main Branch PRs: This is a 6.3 specific fix that is not required for 6.4/main because there isolation is assigned on `SILFunction{Type}` construction.

- Risk: Very Low. The change is very narrow and apply only to specializations of `nonisolated(nonsending)` declarations.

- Reviewed By: N/A

- Testing: Added new test-cases to the suite.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
