### PR TITLE
Opaque Values support for Keypath components

### DIFF
--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -658,7 +658,17 @@ void verifyKeyPathComponent(SILModule &M,
         auto opIndex = index.Operand;
         auto contextType =
           index.LoweredType.subst(M, patternSubs);
-        require(contextType == operands[opIndex].get()->getType(),
+        auto operandType = operands[opIndex].get()->getType();
+        // The operand normally matches the pattern's lowered type exactly.
+        // In opaque-values mode, SILGen records address-only indices'
+        // LoweredType in the pattern as the address form (since the keypath
+        // runtime ABI passes them by address), but the operand is still at
+        // object type until AddressLowering rewrites it. Accept that
+        // intermediate shape.
+        require(contextType == operandType ||
+                    (!M.useLoweredAddresses() &&
+                     (contextType.isAddress() && operandType.isObject() &&
+                      contextType.getObjectType() == operandType)),
                 "operand must match type required by pattern");
         SILType loweredType = index.LoweredType;
         require(

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -2171,10 +2171,6 @@ static bool canStorageUseTrivialDescriptor(SILGenModule &SGM,
 }
 
 void SILGenModule::tryEmitPropertyDescriptor(AbstractStorageDecl *decl) {
-  // TODO: Key path code emission doesn't handle opaque values properly yet.
-  if (!SILModuleConventions(M).useLoweredAddresses())
-    return;
-  
   auto descriptorContext = decl->getPropertyDescriptorGenericSignature();
   if (!descriptorContext)
     return;

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -3658,14 +3658,23 @@ static PreparedArguments loadIndexValuesForKeyPathComponent(
   }
 
   for (unsigned i : indices(indexes)) {
-    SILValue eltAddr = pointer;
-    if (indexes.size() > 1) {
-      eltAddr = SGF.B.createTupleElementAddr(loc, eltAddr, i);
-    }
+    SILValue elt = pointer;
     auto ty = SGF.F.mapTypeIntoEnvironment(indexes[i].second);
-    auto value = SGF.emitLoad(loc, eltAddr,
-                              SGF.getTypeLowering(ty),
-                              SGFContext(), IsNotTake);
+    ManagedValue value;
+    if (pointer->getType().isAddress()) {
+      if (indexes.size() > 1)
+        elt = SGF.B.createTupleElementAddr(loc, elt, i);
+      value = SGF.emitLoad(loc, elt, SGF.getTypeLowering(ty), SGFContext(),
+                           IsNotTake);
+    } else {
+      // The index argument arrives as an `Indirect_In_Guaranteed` parameter,
+      // so a non-address shape is only possible when SIL operates on opaque
+      // values rather than addresses.
+      assert(!SGF.SGM.M.useLoweredAddresses());
+      if (indexes.size() > 1)
+        elt = SGF.B.createTupleExtract(loc, elt, i);
+      value = ManagedValue::forBorrowedRValue(elt).copy(SGF, loc);
+    }
     auto substType =
       SGF.F.mapTypeIntoEnvironment(indexes[i].first)->getCanonicalType();
     indexValues.add(loc, RValue(SGF, loc, substType, value));
@@ -4397,27 +4406,43 @@ getOrCreateKeyPathEqualsAndHash(SILGenModule &SGM,
 
       Scope branchScope(subSGF, loc);
 
-      SILValue lhsEltAddr = lhsAddr;
-      SILValue rhsEltAddr = rhsAddr;
-      if (indexes.size() > 1) {
-        lhsEltAddr = subSGF.B.createTupleElementAddr(loc, lhsAddr, i);
-        rhsEltAddr = subSGF.B.createTupleElementAddr(loc, rhsAddr, i);
-      }
-      auto lhsArg = subSGF.emitLoad(loc, lhsEltAddr,
-             subSGF.getTypeLowering(AbstractionPattern::getOpaque(), formalTy),
-             SGFContext(), IsNotTake);
-      auto rhsArg = subSGF.emitLoad(loc, rhsEltAddr,
-             subSGF.getTypeLowering(AbstractionPattern::getOpaque(), formalTy),
-             SGFContext(), IsNotTake);
-      
-      if (!lhsArg.getType().isAddress()) {
-        auto lhsBuf = subSGF.emitTemporaryAllocation(loc, lhsArg.getType());
-        lhsArg.forwardInto(subSGF, loc, lhsBuf);
-        lhsArg = subSGF.emitManagedBufferWithCleanup(lhsBuf);
+      ManagedValue lhsArg, rhsArg;
+      if (lhsAddr->getType().isAddress()) {
+        SILValue lhsEltAddr = lhsAddr;
+        SILValue rhsEltAddr = rhsAddr;
+        if (indexes.size() > 1) {
+          lhsEltAddr = subSGF.B.createTupleElementAddr(loc, lhsAddr, i);
+          rhsEltAddr = subSGF.B.createTupleElementAddr(loc, rhsAddr, i);
+        }
+        lhsArg = subSGF.emitLoad(loc, lhsEltAddr,
+               subSGF.getTypeLowering(AbstractionPattern::getOpaque(), formalTy),
+               SGFContext(), IsNotTake);
+        rhsArg = subSGF.emitLoad(loc, rhsEltAddr,
+               subSGF.getTypeLowering(AbstractionPattern::getOpaque(), formalTy),
+               SGFContext(), IsNotTake);
 
-        auto rhsBuf = subSGF.emitTemporaryAllocation(loc, rhsArg.getType());
-        rhsArg.forwardInto(subSGF, loc, rhsBuf);
-        rhsArg = subSGF.emitManagedBufferWithCleanup(rhsBuf);
+        if (!lhsArg.getType().isAddress()) {
+          auto lhsBuf = subSGF.emitTemporaryAllocation(loc, lhsArg.getType());
+          lhsArg.forwardInto(subSGF, loc, lhsBuf);
+          lhsArg = subSGF.emitManagedBufferWithCleanup(lhsBuf);
+
+          auto rhsBuf = subSGF.emitTemporaryAllocation(loc, rhsArg.getType());
+          rhsArg.forwardInto(subSGF, loc, rhsBuf);
+          rhsArg = subSGF.emitManagedBufferWithCleanup(rhsBuf);
+        }
+      } else {
+        // Opaque-values mode: the function arguments are guaranteed object
+        // values rather than addresses. Extract the i-th element (if needed)
+        // and copy it; the apply will borrow the owned value for the
+        // @in_guaranteed Self parameter.
+        SILValue lhsElt = lhsAddr;
+        SILValue rhsElt = rhsAddr;
+        if (indexes.size() > 1) {
+          lhsElt = subSGF.B.createTupleExtract(loc, lhsAddr, i);
+          rhsElt = subSGF.B.createTupleExtract(loc, rhsAddr, i);
+        }
+        lhsArg = ManagedValue::forBorrowedRValue(lhsElt).copy(subSGF, loc);
+        rhsArg = ManagedValue::forBorrowedRValue(rhsElt).copy(subSGF, loc);
       }
 
       auto metaty = CanMetatypeType::get(formalCanTy,
@@ -4531,7 +4556,11 @@ getOrCreateKeyPathEqualsAndHash(SILGenModule &SGM,
       // Extract the index value.
       SILValue indexAddr = indexPtr;
       if (indexes.size() > 1) {
-        indexAddr = subSGF.B.createTupleElementAddr(loc, indexPtr, 0);
+        if (indexPtr->getType().isAddress()) {
+          indexAddr = subSGF.B.createTupleElementAddr(loc, indexPtr, 0);
+        } else {
+          indexAddr = subSGF.B.createTupleExtract(loc, indexPtr, 0);
+        }
       }
 
       VarDecl *hashValueVar =
@@ -4553,7 +4582,9 @@ getOrCreateKeyPathEqualsAndHash(SILGenModule &SGM,
           hashGenericSig, formalTy, hashable);
 
       // Read the storage.
-      ManagedValue base = ManagedValue::forBorrowedAddressRValue(indexAddr);
+      ManagedValue base = indexAddr->getType().isAddress()
+                              ? ManagedValue::forBorrowedAddressRValue(indexAddr)
+                              : ManagedValue::forBorrowedObjectRValue(indexAddr);
       hashCode =
         subSGF.emitRValueForStorageLoad(loc, base, formalTy, /*super*/ false,
                                         hashValueVar, PreparedArguments(),
@@ -4649,7 +4680,32 @@ static void lowerKeyPathMemberIndexTypes(
           AbstractionPattern::getOpaque(), paramTy,
           TypeExpansionContext::noOpaqueTypeArchetypesSubstitution(
               ResilienceExpansion::Minimal));
+
+      // In opaque-values mode, TypeLowering::handleAddressOnly lowers
+      // address-only AST types objects until AddressLowering runs, so the
+      // `getLoweredType` above returns the object form. The keypath runtime
+      // ABI requires the address form, and KeyPathPatternComponent caches
+      // its lowered index type — AddressLowering does not reconstruct the
+      // pattern with refreshed lowerings, so we have to embed the
+      // post-AddressLowering shape here. Bypass TypeLowering with
+      // SILType::isAddressOnly and switch address-only indices to address form.
+      // The keypath instruction's operand may still be at object type in
+      // opaque-values mode; the SIL verifier accepts that intermediate shape 
+      // and AddressLowering rewrites the operand later.
+      //
+      // TODO: Drop the cached lowering from KeyPathPatternComponent::Index,
+      // or have AddressLowering rebuild the keypath pattern with refreshed
+      // type lowerings.
+      bool addressOnly =
+          paramLoweredTy.isObject() &&
+          SILType::isAddressOnly(
+              paramTy->getCanonicalType(), SGM.Types,
+              sig ? sig->getCanonicalSignature() : CanGenericSignature(),
+              TypeExpansionContext::noOpaqueTypeArchetypesSubstitution(
+                  ResilienceExpansion::Minimal));
       paramLoweredTy = paramLoweredTy.mapTypeOutOfEnvironment();
+      if (addressOnly)
+        paramLoweredTy = paramLoweredTy.getAddressType();
 
       indexPatterns.push_back(
           {paramTy->mapTypeOutOfEnvironment()->getCanonicalType(), paramLoweredTy});

--- a/lib/SILOptimizer/Mandatory/AddressLowering.cpp
+++ b/lib/SILOptimizer/Mandatory/AddressLowering.cpp
@@ -3561,6 +3561,15 @@ protected:
     yield->setOperand(use->getOperandNumber(), addr);
   }
 
+  // Captured index value of a keypath. The keypath runtime ABI passes each
+  // index via address. Rewrite the operand to its storage address now; the
+  // pattern's recorded LoweredType is patched up after the main rewrite loop
+  // by rebuildKeyPathInstsForAddressOnlyIndices.
+  void visitKeyPathInst(KeyPathInst *kpi) {
+    SILValue addr = addrMat.materializeAddress(use->get());
+    kpi->setOperand(use->getOperandNumber(), addr);
+  }
+
   void visitIgnoredUseInst(IgnoredUseInst *ignored) {
     SILValue addr = addrMat.materializeAddress(use->get());
     ignored->setOperand(addr);

--- a/test/SILGen/opaque_values_keypath.swift
+++ b/test/SILGen/opaque_values_keypath.swift
@@ -1,0 +1,79 @@
+// Tests for keypath emission under -enable-sil-opaque-values.
+
+// RUN: %target-swift-emit-silgen -enable-sil-opaque-values %s | %FileCheck --check-prefix=SILGEN %s
+// RUN: %target-swift-emit-sil    -enable-sil-opaque-values %s | %FileCheck --check-prefix=SIL    %s
+
+// RUN: %target-swift-frontend -c -enable-sil-opaque-values -sil-verify-all %s -o %t.o
+
+struct Loadable {
+  subscript(_ i: Int) -> Int { return i }
+}
+
+struct Multi {
+  subscript(i: Int, j: String) -> Int { return i }
+}
+
+struct Generic<T: Hashable> {
+  subscript(_ x: T) -> Int { return 0 }
+}
+
+public class PublicClass {
+  public var publicProp: Int = 0
+}
+
+// The synthesized equals helper takes the indices as opaque object values.
+
+// SILGEN-LABEL: sil shared [thunk] [ossa] @$sSiTH : $@convention(keypath_accessor_equals) (@in_guaranteed Int, @in_guaranteed Int) -> Bool {
+// SILGEN:       bb0(%0 : $Int, %1 : $Int):
+// SILGEN-NOT:     load
+// SILGEN-NOT:     tuple_element_addr
+// SILGEN:         apply {{.*}}(%0, %1, {{.*}}) : $@convention(witness_method: Equatable)
+
+// SILGEN-LABEL: sil shared [thunk] [ossa] @$sSiTh : $@convention(keypath_accessor_hash) (@in_guaranteed Int) -> Int {
+// SILGEN:       bb0(%0 : $Int):
+
+func mkLoadable() -> KeyPath<Loadable, Int> { return \Loadable.[42] }
+
+// SILGen records the address form of the index LoweredType in the pattern
+// even when getLoweredType returns the object form, so the keypath runtime ABI
+// sees an address-form index slot.
+
+// SILGEN-LABEL: sil shared [thunk] [ossa] @$sSiSSTH : $@convention(keypath_accessor_equals) (@in_guaranteed (Int, String), @in_guaranteed (Int, String)) -> Bool {
+// SILGEN:       bb0(%0 : @guaranteed $(Int, String), %1 : @guaranteed $(Int, String)):
+// SILGEN-NOT:     tuple_element_addr
+// SILGEN:         tuple_extract %0, 0
+// SILGEN:         tuple_extract %1, 0
+// SILGEN:         tuple_extract %0, 1
+// SILGEN:         tuple_extract %1, 1
+
+// SILGEN-LABEL: sil shared [thunk] [ossa] @$sSiSSTh : $@convention(keypath_accessor_hash) (@in_guaranteed (Int, String)) -> Int {
+// SILGEN:       bb0(%0 : @guaranteed $(Int, String)):
+// SILGEN-NOT:     tuple_element_addr
+// SILGEN:         tuple_extract %0, 0
+
+// Getter helper for multi-index also extracts opaque indices via tuple_extract.
+
+// SILGEN-LABEL: sil shared [thunk] [ossa] @$s{{[^ ]+}}5MultiVyS2i_SStcipACTK :
+// SILGEN:       bb0(%0 : $Multi, %1 : @guaranteed $(Int, String)):
+// SILGEN-NOT:     tuple_element_addr
+// SILGEN:         tuple_extract %1, 0
+// SILGEN:         tuple_extract %1, 1
+
+func mkMulti() -> KeyPath<Multi, Int> { return \Multi.[0, "x"] }
+
+// SILVerifier accepts the intermediate state where an index operand is at
+// object type while its pattern slot is at address type.
+
+// SILGEN-LABEL: sil hidden [ossa] @$s{{[^ ]+}}9mkGeneric{{[^ ]*}} : $@convention(thin) <T where T : Hashable> (@in_guaranteed T) -> @owned KeyPath<Generic<T>, Int> {
+// SILGEN:         keypath $KeyPath<Generic<T>, Int>{{.*}}indices [%$0 : $τ_0_0 : $*τ_0_0]
+// SIL-LABEL: sil hidden @$s{{[^ ]+}}9mkGeneric{{[^ ]*}} : $@convention(thin) <T where T : Hashable> (@in_guaranteed T) -> @owned KeyPath<Generic<T>, Int> {
+// SIL:         [[STK:%[0-9]+]] = alloc_stack $T
+// SIL:         keypath $KeyPath<Generic<T>, Int>{{.*}}indices [%$0 : $τ_0_0 : $*τ_0_0]{{.*}}([[STK]])
+
+func mkGeneric<T: Hashable>(_ x: T) -> KeyPath<Generic<T>, Int> {
+  return \Generic<T>.[x]
+}
+
+// Public stored properties get a sil_property descriptor under OV mode.
+
+// SILGEN: sil_property #PublicClass.publicProp

--- a/test/SILOptimizer/capture_propagate_keypath.swift
+++ b/test/SILOptimizer/capture_propagate_keypath.swift
@@ -1,6 +1,9 @@
 // RUN: %target-swift-frontend  -primary-file %s -O -sil-verify-all -module-name=test -emit-sil | %FileCheck %s
 // RUN: %target-swift-frontend  -primary-file %s -swift-version 6 -O -sil-verify-all -module-name=test -emit-sil | %FileCheck %s
 
+// RUN: %target-swift-frontend  -primary-file %s -O -sil-verify-all -module-name=test -emit-sil -enable-sil-opaque-values | %FileCheck %s
+// RUN: %target-swift-frontend  -primary-file %s -swift-version 6 -O -sil-verify-all -module-name=test -emit-sil -enable-sil-opaque-values | %FileCheck %s
+
 // Also do an end-to-end test to check if the generated code is correct.
 // RUN: %empty-directory(%t) 
 // RUN: %target-build-swift -O -module-name=test %s -o %t/a.out

--- a/test/SILOptimizer/dead_func_objc_extension_keypath.swift
+++ b/test/SILOptimizer/dead_func_objc_extension_keypath.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend %s -O -emit-sil -import-objc-header %S/Inputs/keypaths_objc.h
+// RUN: %target-swift-frontend %s -O -emit-sil -enable-sil-opaque-values -import-objc-header %S/Inputs/keypaths_objc.h
 // REQUIRES: objc_interop
 
 import Foundation

--- a/test/SILOptimizer/inline_keypath.swift
+++ b/test/SILOptimizer/inline_keypath.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -O -emit-sil %s | %FileCheck %s
+// RUN: %target-swift-frontend -O -emit-sil -enable-sil-opaque-values %s | %FileCheck %s
 
 public protocol P {}
 

--- a/test/SILOptimizer/keypath_offset.swift
+++ b/test/SILOptimizer/keypath_offset.swift
@@ -2,6 +2,7 @@
 // RUN: %target-build-swift %S/Inputs/struct_with_fields.swift -parse-as-library -wmo -enable-library-evolution -module-name=Test -emit-module -emit-module-path=%t/Test.swiftmodule -c -o %t/test.o
 
 // RUN: %target-build-swift -O %s -module-name=test -Xfrontend -sil-verify-all -I%t -emit-sil | %FileCheck %s
+// RUN: %target-build-swift -O %s -module-name=test -Xfrontend -sil-verify-all -I%t -emit-sil -Xfrontend -enable-sil-opaque-values | %FileCheck %s
 
 // RUN: %target-build-swift -Onone %s -I%t %t/test.o -o %t/Onone.out
 // RUN: %target-build-swift -O %s -I%t %t/test.o -o %t/O.out

--- a/test/SILOptimizer/keypath_opt_crash.swift
+++ b/test/SILOptimizer/keypath_opt_crash.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -O -emit-sil %s | %FileCheck %s
+// RUN: %target-swift-frontend -O -emit-sil -enable-sil-opaque-values %s | %FileCheck %s
 
 // REQUIRES: objc_interop
 

--- a/test/SILOptimizer/optimize_keypath.swift
+++ b/test/SILOptimizer/optimize_keypath.swift
@@ -3,7 +3,16 @@
 // RUN: %FileCheck --check-prefix=CHECK --check-prefix=CHECK1 %s < %t/output.sil
 // RUN: %FileCheck -check-prefix=CHECK-ALL %s < %t/output.sil
 
+// RUN: %empty-directory(%t) 
+// RUN: %target-swift-frontend -primary-file %s -O -sil-verify-all -Xllvm -sil-print-types -emit-sil -enable-sil-opaque-values >%t/output.sil
+// RUN: %FileCheck --check-prefix=CHECK --check-prefix=CHECK1 %s < %t/output.sil
+// RUN: %FileCheck -check-prefix=CHECK-ALL %s < %t/output.sil
+
 // RUN: %target-swift-frontend -primary-file %s -O -sil-verify-all -swift-version 6 -Xllvm -sil-print-types -emit-sil >%t/output6.sil
+// RUN: %FileCheck --check-prefix=CHECK --check-prefix=CHECK2 %s < %t/output6.sil
+// RUN: %FileCheck -check-prefix=CHECK-ALL %s < %t/output6.sil
+
+// RUN: %target-swift-frontend -primary-file %s -O -sil-verify-all -swift-version 6 -Xllvm -sil-print-types -emit-sil -enable-sil-opaque-values >%t/output6.sil
 // RUN: %FileCheck --check-prefix=CHECK --check-prefix=CHECK2 %s < %t/output6.sil
 // RUN: %FileCheck -check-prefix=CHECK-ALL %s < %t/output6.sil
 

--- a/test/SILOptimizer/optimize_keypath_bug.swift
+++ b/test/SILOptimizer/optimize_keypath_bug.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -emit-sil -O -sil-verify-all %s
+// RUN: %target-swift-frontend -emit-sil -O -sil-verify-all -enable-sil-opaque-values %s
 // REQUIRES: OS=macosx
 
 import Foundation

--- a/test/SILOptimizer/optimize_keypath_objc.swift
+++ b/test/SILOptimizer/optimize_keypath_objc.swift
@@ -2,6 +2,10 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -primary-file %s -O -sil-verify-all -emit-sil >%t/output.sil
 // RUN: %FileCheck %s < %t/output.sil
 
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -primary-file %s -O -sil-verify-all -emit-sil -enable-sil-opaque-values >%t/output.sil
+// RUN: %FileCheck %s < %t/output.sil
+
 // REQUIRES: objc_interop
 // REQUIRES: swift_in_compiler
 

--- a/test/SILOptimizer/simplify_keypath_resilient.swift
+++ b/test/SILOptimizer/simplify_keypath_resilient.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -primary-file %s -enable-library-evolution -emit-sil | %FileCheck %s
+// RUN: %target-swift-frontend -primary-file %s -enable-library-evolution -emit-sil -enable-sil-opaque-values | %FileCheck %s
 
 public enum E: Hashable {
   case e


### PR DESCRIPTION
Resolves rdar://178751810.

Keypath components are not equipped to handle opaque values mode. This PR aims to fix that.