### PR TITLE
[Runtime] Look up protocol witness tables in prespecializations library.

### DIFF
--- a/include/swift/Runtime/LibPrespecialized.h
+++ b/include/swift/Runtime/LibPrespecialized.h
@@ -39,17 +39,22 @@ struct LibPrespecializedData {
 
   TargetPointer<Runtime, const void> descriptorMap;
 
+  /// Witness table map. Keys are (ProtocolConformanceDescriptor *,
+  /// conforming-type Metadata *). Values are the corresponding witness table.
+  TargetPointer<Runtime, const void> pointerKeyedWitnessTableMap;
+
   // Existing fields are above, add new fields below this point.
 
   // The major/minor version numbers for this version of the struct.
   static constexpr uint32_t currentMajorVersion = 1;
-  static constexpr uint32_t currentMinorVersion = 4;
+  static constexpr uint32_t currentMinorVersion = 5;
 
   // Version numbers where various fields were introduced.
   static constexpr uint32_t minorVersionWithDisabledProcessesTable = 2;
   static constexpr uint32_t minorVersionWithPointerKeyedMetadataMap = 3;
   static constexpr uint32_t minorVersionWithOptionFlags = 3;
   static constexpr uint32_t minorVersionWithDescriptorMap = 4;
+  static constexpr uint32_t minorVersionWithPointerKeyedWitnessTableMap = 5;
 
   // Option flags values.
   enum : typename Runtime::StoredSize {
@@ -104,6 +109,12 @@ struct LibPrespecializedData {
       return nullptr;
     return reinterpret_cast<const DescriptorMap *>(descriptorMap);
   }
+
+  const void *getPointerKeyedWitnessTableMap() const {
+    if (minorVersion < minorVersionWithPointerKeyedWitnessTableMap)
+      return nullptr;
+    return pointerKeyedWitnessTableMap;
+  }
 };
 
 enum class LibPrespecializedLookupResult {
@@ -123,6 +134,11 @@ const LibPrespecializedData<InProcess> *getLibPrespecializedData();
 Metadata *getLibPrespecializedMetadata(const TypeContextDescriptor *description,
                                        const void *const *arguments);
 void libPrespecializedImageLoaded();
+
+/// Look up a prebuilt witness table for the given conformance and type. Returns
+/// nullptr on failure. Failure is never definitive.
+const WitnessTable *getLibPrespecializedWitnessTable(
+    const ProtocolConformanceDescriptor *conformance, const Metadata *type);
 
 std::pair<LibPrespecializedLookupResult, const TypeContextDescriptor *>
 getLibPrespecializedTypeDescriptor(Demangle::NodePointer node);

--- a/stdlib/public/runtime/LibPrespecialized.cpp
+++ b/stdlib/public/runtime/LibPrespecialized.cpp
@@ -346,6 +346,8 @@ struct LibPrespecializedState {
     LOG("  disabledProcessTable=%p", data->getDisabledProcessesTable());
     LOG("  pointerKeyedMetadataMap=%p", data->getPointerKeyedMetadataMap());
     LOG("  descriptorMap=%p", data->getDescriptorMap());
+    LOG("  pointerKeyedWitnessTableMap=%p",
+        data->getPointerKeyedWitnessTableMap());
 
     return data;
   }
@@ -583,6 +585,39 @@ swift::getLibPrespecializedMetadata(const TypeContextDescriptor *description,
     return getMetadataFromPointerKeyedMapDebugMode(state, description,
                                                    arguments);
   }
+}
+
+const WitnessTable *
+swift::getLibPrespecializedWitnessTable(
+    const ProtocolConformanceDescriptor *conformance, const Metadata *type) {
+#if DYLD_FIND_POINTER_HASH_TABLE_ENTRY_DEFINED
+  auto &state = LibPrespecialized.get();
+
+  auto *data = state.data;
+  if (!data)
+    return nullptr;
+
+  if (state.mapConfiguration ==
+      LibPrespecializedState::MapConfiguration::Disabled)
+    return nullptr;
+
+  auto *map = data->getPointerKeyedWitnessTableMap();
+  if (!map)
+    return nullptr;
+
+  if (SWIFT_RUNTIME_WEAK_CHECK(_dyld_find_pointer_hash_table_entry)) {
+    // The dyld call takes the key as the first pointer in the key, then
+    // separately an array of the rest. Our keys are conformance, type.
+    const void *arguments[1] = {type};
+    auto result = SWIFT_RUNTIME_WEAK_USE(_dyld_find_pointer_hash_table_entry(
+        map, conformance, /*argumentCount=*/1, arguments));
+    LOG("WT lookup (conformance=%p, type=%p) -> %p (dyld hash table).",
+        (const void *)conformance, (const void *)type, result);
+    return reinterpret_cast<const WitnessTable *>(
+        const_cast<void *>(result));
+  }
+#endif
+  return nullptr;
 }
 
 std::pair<LibPrespecializedLookupResult, const TypeContextDescriptor *>

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -6762,6 +6762,10 @@ const WitnessTable *
 swift::swift_getWitnessTable(const ProtocolConformanceDescriptor *conformance,
                              const Metadata *type,
                              const void * const *instantiationArgs) {
+  if (auto *prebuilt =
+          getLibPrespecializedWitnessTable(conformance, type))
+    return prebuilt;
+
   /// Local function to unique a foreign witness table, if needed.
   auto uniqueForeignWitnessTableRef =
       [conformance](const WitnessTable *candidate) {


### PR DESCRIPTION
Before building our own, check a new map in the prespecializations library to see if a prebuilt witness table exists.

rdar://178748710