### PR TITLE
SILGen: adjust special case in expandInnerTupleOuterIndirect

### DIFF
--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -3292,6 +3292,7 @@ class ResultPlanner : public ExpanderBase<ResultPlanner, IndirectSlot> {
   SmallVector<Operation, 8> Operations;
   ArrayRef<SILResultInfo> AllOuterResults;
   ArrayRef<SILResultInfo> AllInnerResults;
+  CanSILFunctionType UnsubstInnerFnType;
   SmallVectorImpl<SILValue> &InnerArgs;
   InnerPackResultGenerator InnerPacks;
 
@@ -3316,7 +3317,8 @@ public:
             .getNumIndirectSILResults());
 
     AllOuterResults = outerFnType->getUnsubstitutedType(SGF.SGM.M)->getResults();
-    AllInnerResults = innerFnType->getUnsubstitutedType(SGF.SGM.M)->getResults();
+    UnsubstInnerFnType = innerFnType->getUnsubstitutedType(SGF.SGM.M);
+    AllInnerResults = UnsubstInnerFnType->getResults();
 
     // Recursively walk the result types.
     expand(innerOrigType, innerSubstType, outerOrigType, outerSubstType);
@@ -4576,7 +4578,10 @@ ResultPlanner::expandInnerTupleOuterIndirect(AbstractionPattern innerOrigType,
   // treats the slot as a single fixed-layout value and would crash on the
   // dynamic-layout pack-expansion tuple.
   if (outerSubstTupleType && !outerOrigType.isTuple()
-      && AllInnerResults.size() == 1
+      && AllInnerResults.size() == 1 &&
+      AllInnerResults.front().getReturnValueType(
+          SGF.SGM.M, UnsubstInnerFnType, TypeExpansionContext::minimal()) ==
+          innerSubstType
       && !outerSubstTupleType.containsPackExpansionType()) {
     SILResultInfo innerResult = claimNextInnerResult();
     planSingleIntoIndirect(innerOrigType, innerSubstType,

--- a/test/SILGen/typed_throws_tuple_into_opaque_thunk.swift
+++ b/test/SILGen/typed_throws_tuple_into_opaque_thunk.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-emit-sil %s -sil-verify-all > /dev/null
 
 // https://github.com/swiftlang/swift/issues/77880
 // (and related: https://github.com/swiftlang/swift/issues/88027)
@@ -110,3 +111,34 @@ func compilesThrowsAnyAll() throws -> (Int, Int)? {
     return (3, 4)
   }
 }
+
+// Sibling: outer pattern is a tuple `(opaque T, String?)` whose first
+// element substitutes to `()`. The fix's interface-type gate prevents
+// the whole-tuple-into-opaque branch from mis-claiming the sibling
+// `String?` slot when recursively processing the empty-tuple element.
+
+protocol DonutFryer {}
+
+extension DonutFryer {
+  @discardableResult
+  func fry<T>(perform: () throws -> (donut: T, glaze: String?)) rethrows -> T {
+    let (d, _) = try perform()
+    return d
+  }
+}
+
+func drainOil() {}
+
+struct DonutShop {
+  let fryer: DonutFryer
+  func openForBusiness() {
+    self.fryer.fry {
+      (drainOil(), nil)
+    }
+  }
+}
+
+// CHECK-LABEL: sil shared {{.*}}[reabstraction_thunk] {{.*}}@$sSSSgIgo_ytAAs5Error_pIegrozo_TR
+// CHECK: bb0([[OUT:%.*]] : $*(), [[INNER:%.*]] : @guaranteed $@noescape @callee_guaranteed () -> @owned Optional<String>):
+// CHECK-NEXT: [[RES:%.*]] = apply [[INNER]]()
+// CHECK-NEXT: return [[RES]]


### PR DESCRIPTION
The hack added here in https://github.com/swiftlang/swift/pull/88926 doesn't quite work right, so let's throw another on top.

ResultPlanner::expandInnerTupleOuterIndirect's narrow whole-tuple-into-opaque guard to redirect to planSingleIntoIndirect checked only AllInnerResults.size() == 1, so when the dispatcher reached the function recursively from expandParallelTuples for an empty-tuple element, it mis-claimed the lone residual inner slot, which actually belonged to a sibling tuple element, and the real later element then tripped claimNext on an empty list.

If we just ensure the types are the same, we can avoid that.

resolves rdar://178736957
