### PR TITLE
[VariableNameUtils] Look through init_existential_ref/addr when inferring variable names

### DIFF
--- a/lib/SILOptimizer/Utils/VariableNameUtils.cpp
+++ b/lib/SILOptimizer/Utils/VariableNameUtils.cpp
@@ -624,8 +624,13 @@ SILValue VariableNameInferrer::findDebugInfoProvidingValueHelper(
     // them and add the case to the variableNamePath.
     if (auto *e = dyn_cast<EnumInst>(searchValue)) {
       if (e->hasOperand()) {
-        pushPathComponent(getNameFromDecl(e->getElement()),
-                          e->getLoc().getSourceLoc());
+        // Do not push a path component for Optional.some wrapping — the
+        // programmer never writes 'x.some' in source, so adding '.some' to the
+        // inferred name produces confusing diagnostics like
+        // "'negotiator.some' cannot be returned".
+        if (!e->getType().getOptionalObjectType())
+          pushPathComponent(getNameFromDecl(e->getElement()),
+                            e->getLoc().getSourceLoc());
         searchValue = e->getOperand();
         continue;
       }
@@ -763,7 +768,16 @@ SILValue VariableNameInferrer::findDebugInfoProvidingValueHelper(
         isa<CopyableToMoveOnlyWrapperValueInst>(searchValue) ||
         isa<EndInitLetRefInst>(searchValue) ||
         isa<ConvertEscapeToNoEscapeInst>(searchValue) ||
-        isa<ConvertFunctionInst>(searchValue)) {
+        isa<ConvertFunctionInst>(searchValue) ||
+        // Look through existential type-erasure wrappers so that name inference
+        // can reach the concrete value underneath. For example, when a named
+        // variable of a concrete class type is wrapped in `any Protocol` before
+        // being stored into an indirect return slot, init_existential_ref sits
+        // between the concrete copy_value and the enum wrapping. Without
+        // looking through it the inferrer gives up and the diagnostic falls back
+        // to the generic "unknown pattern" catch-all.
+        isa<InitExistentialRefInst>(searchValue) ||
+        isa<InitExistentialAddrInst>(searchValue)) {
       searchValue = cast<SingleValueInstruction>(searchValue)->getOperand(0);
       continue;
     }

--- a/test/Concurrency/sendable_checking.swift
+++ b/test/Concurrency/sendable_checking.swift
@@ -480,7 +480,7 @@ struct DowngradeForPreconcurrency {
   func createStream() -> AsyncStream<NonSendable> {
     AsyncStream<NonSendable> {
       self.x // expected-tns-warning {{assignment could allow for references between values exposed to code in the current isolation context and main actor-isolated code risking data races}}
-      // expected-tns-note @-1 {{'self.x.some' is exposed to main actor-isolated code}}
+      // expected-tns-note @-1 {{'self.x' is exposed to main actor-isolated code}}
       // expected-warning @-2 {{main actor-isolated property 'x' cannot be accessed from outside of the actor; this is an error in the Swift 6 language mode}} {{7-7=await }}
       // expected-warning @-3 {{non-Sendable type 'NonSendable' of property 'x' cannot exit main actor-isolated context; this is an error in the Swift 6 language mode}}
     }

--- a/test/Concurrency/sendable_metatype.swift
+++ b/test/Concurrency/sendable_metatype.swift
@@ -138,8 +138,8 @@ func acceptSendingAnyObjectR(_ s: sending AnyObject & R) { }
   acceptSendingP(t) // expected-warning{{sending 't' risks causing data races}}
   // expected-note@-1{{main actor-isolated 't' is passed as a 'sending' parameter; Uses in callee may race with later main actor-isolated uses}}
   // expected-note@-2{{isolated conformance to protocol 'P' can be introduced he}}
-  acceptSendingAnyObjectP(u) // expected-warning{{sending value of non-Sendable type 'U' risks causing data races}}
-  // expected-note@-1{{Passing main actor-isolated value of non-Sendable type 'U' as a 'sending' parameter to global function 'acceptSendingAnyObjectP' risks causing races inbetween main actor-isolated uses and uses reachable from 'acceptSendingAnyObjectP'}}
+  acceptSendingAnyObjectP(u) // expected-warning{{sending 'u' risks causing data races}}
+  // expected-note@-1{{main actor-isolated 'u' is passed as a 'sending' parameter; Uses in callee may race with later main actor-isolated uses}}
   // expected-note@-2{{isolated conformance to protocol 'P' can be introduced here}}
   // All of these are okay, because there are no isolated conformances to R.
   acceptSendingR(S())

--- a/test/Concurrency/transfernonsendable_global_actor_nonsendable.swift
+++ b/test/Concurrency/transfernonsendable_global_actor_nonsendable.swift
@@ -176,16 +176,16 @@ extension NonSendableGlobalActorIsolatedEnum {
       return nil
     }
     return x
-  } // expected-error {{sending 'x.some' risks causing data races}}
-  // expected-note @-1 {{main actor-isolated 'x.some' cannot be a 'sending' result. main actor-isolated uses may race with caller uses}}
+  } // expected-error {{sending 'x' risks causing data races}}
+  // expected-note @-1 {{main actor-isolated 'x' cannot be a 'sending' result. main actor-isolated uses may race with caller uses}}
 
   mutating func test3a() -> sending NonSendableKlass? {
     if case let .second(x) = self {
       return x
     }
     return nil
-  } // expected-error {{sending 'x.some' risks causing data races}}
-  // expected-note @-1 {{main actor-isolated 'x.some' cannot be a 'sending' result. main actor-isolated uses may race with caller uses}}
+  } // expected-error {{sending 'x' risks causing data races}}
+  // expected-note @-1 {{main actor-isolated 'x' cannot be a 'sending' result. main actor-isolated uses may race with caller uses}}
 }
 
 extension NonSendableGlobalActorIsolatedKlass {

--- a/test/Concurrency/transfernonsendable_inout_sending_existential.swift
+++ b/test/Concurrency/transfernonsendable_inout_sending_existential.swift
@@ -1,0 +1,73 @@
+// RUN: %target-swift-frontend -emit-sil -swift-version 6 -disable-availability-checking -verify %s -o /dev/null
+
+// Test that the region isolation checker correctly names values that are wrapped
+// in an existential (any Protocol) before being stored into an indirect return
+// slot.
+//
+// The SIL pattern is:
+//   %concrete = <named value>
+//   %exist = init_existential_ref %concrete : $Concrete : $Concrete, $any Protocol
+//   %opt = enum $Optional<any Protocol>, #Optional.some!enumelt, %exist
+//   store %opt to [init] %return_slot
+//
+// Previously, VariableNameInferrer::findDebugInfoProvidingValueHelper did not
+// look through init_existential_ref, so the name walk would fail and the
+// region isolation checker would fall through to the generic
+// "unknown pattern" diagnostic instead of naming the value.
+
+// REQUIRES: concurrency
+// REQUIRES: synchronization
+
+import Synchronization
+
+// A simple non-Sendable class that satisfies a protocol.
+protocol BoxProtocol: AnyObject {}
+
+class Box: BoxProtocol {}
+
+// MARK: - init_existential_ref look-through via Mutex.withLock
+
+// The key regression test: returning a named concrete value through an
+// existential wrapping (any BoxProtocol) while also storing it into the
+// inout sending Mutex state.  The value flows through:
+//   alloc_ref -> move_value [lexical] [var_decl] "item"
+//             -> init_existential_ref
+//             -> enum $Optional<any BoxProtocol>.some
+//             -> store to indirect @out return slot
+//
+// Before the fix, init_existential_ref was not in the look-through list so
+// name inference failed and the checker emitted the generic catch-all error.
+// After the fix, the inferrer walks through init_existential_ref to the
+// concrete value and finds the name "item".
+
+let mutex = Mutex<Box?>(nil)
+
+func getAsExistentialFromMutex() -> (any BoxProtocol)? {
+    return mutex.withLock { state in
+        let item = Box()
+        state = item
+        return item // expected-warning {{'item' cannot be returned}}
+        // expected-note @-1 {{returning 'item' risks concurrent access to 'inout sending' parameter 'state' as caller assumes 'state' and result can be sent to different isolation domains}}
+    }
+}
+
+// MARK: - Variant: explicit closure signature
+
+func getAsExistentialExplicit() -> (any BoxProtocol)? {
+    return mutex.withLock { (state: inout sending Box?) -> (any BoxProtocol)? in
+        let item = Box()
+        state = item
+        return item // expected-warning {{'item' cannot be returned}}
+        // expected-note @-1 {{returning 'item' risks concurrent access to 'inout sending' parameter 'state' as caller assumes 'state' and result can be sent to different isolation domains}}
+    }
+}
+
+// MARK: - Safe pattern: returning a Sendable value is still OK
+
+func getSendableFromMutex() -> String {
+    return mutex.withLock { (state: inout sending Box?) -> String in
+        let item = Box()
+        state = item
+        return "ok"  // OK: String is Sendable, no region violation
+    }
+}

--- a/test/Concurrency/transfernonsendable_merge_region_diagnostics.swift
+++ b/test/Concurrency/transfernonsendable_merge_region_diagnostics.swift
@@ -200,7 +200,7 @@ final class TaskAssignTest {
   func makeStream() -> AsyncStream<NonSendableKlass> {
     AsyncStream<NonSendableKlass> {
       self.stored // expected-warning {{assignment could allow for references between values exposed to code in the current isolation context and main actor-isolated code risking data races}}
-      // expected-named-note @-1 {{'self.stored.some' is exposed to main actor-isolated code}}
+      // expected-named-note @-1 {{'self.stored' is exposed to main actor-isolated code}}
       // expected-bare-note @-2 {{value is exposed to main actor-isolated code}}
       // expected-warning @-3 {{main actor-isolated property 'stored' cannot be accessed from outside of the actor; this is an error in the Swift 6 language mode}}
       // expected-warning @-4 {{non-Sendable type 'NonSendableKlass' of property 'stored' cannot exit main actor-isolated context; this is an error in the Swift 6 language mode}}

--- a/test/Concurrency/transfernonsendable_sending_results.swift
+++ b/test/Concurrency/transfernonsendable_sending_results.swift
@@ -194,8 +194,8 @@ extension MainActorIsolatedEnum {
     case .second(let ns):
       return ns
     }
-  } // expected-warning {{sending 'ns.some' risks causing data races}}
-  // expected-note @-1 {{main actor-isolated 'ns.some' cannot be a 'sending' result. main actor-isolated uses may race with caller uses}}
+  } // expected-warning {{sending 'ns' risks causing data races; this is an error in the Swift 6 language mode}}
+  // expected-note @-1 {{main actor-isolated 'ns' cannot be a 'sending' result. main actor-isolated uses may race with caller uses}}
 
   func testSwitchReturnNoTransfer() -> NonSendableKlass? {
     switch self {
@@ -211,8 +211,8 @@ extension MainActorIsolatedEnum {
       return ns // TODO: The error below should be here.
     }
     return nil
-  } // expected-warning {{sending 'ns.some' risks causing data races}}
-  // expected-note @-1 {{main actor-isolated 'ns.some' cannot be a 'sending' result. main actor-isolated uses may race with caller uses}}
+  } // expected-warning {{sending 'ns' risks causing data races; this is an error in the Swift 6 language mode}}
+  // expected-note @-1 {{main actor-isolated 'ns' cannot be a 'sending' result. main actor-isolated uses may race with caller uses}}
 
   func testIfLetReturnNoTransfer() -> NonSendableKlass? {
     if case .second(let ns) = self {

--- a/test/SILOptimizer/variable_name_inference.sil
+++ b/test/SILOptimizer/variable_name_inference.sil
@@ -1,6 +1,7 @@
 // RUN: %target-sil-opt -module-name infer -test-runner %s 2>&1 | %FileCheck %s
 
 import Builtin
+import Swift
 
 //===----------------------------------------------------------------------===//
 //                             MARK: Declarations
@@ -783,6 +784,48 @@ bb0(%0 : $*Klass):
   return %9999 : $()
 }
 
+// Trace starts at the init_existential_addr result ($*Klass) rather than the
+// alloc_stack; the inferrer looks backward through init_existential_addr to
+// the named alloc_stack.
+//
+// CHECK-LABEL: begin running test 1 of 1 on init_existential_addr_trace_at_result: variable_name_inference with: @trace[0]
+// CHECK: Input Value:   %2 = init_existential_addr %1 : $*Any, $Klass
+// CHECK: Name: 'myStorage'
+// CHECK: Root:   %1 = alloc_stack $Any, var, name "myStorage"
+// CHECK: end running test 1 of 1 on init_existential_addr_trace_at_result: variable_name_inference with: @trace[0]
+sil [ossa] @init_existential_addr_trace_at_result : $@convention(thin) (@owned Klass) -> () {
+bb0(%0 : @owned $Klass):
+  specify_test "variable_name_inference @trace[0]"
+  %2 = alloc_stack $Any, var, name "myStorage"
+  %3 = init_existential_addr %2 : $*Any, $Klass
+  debug_value [trace] %3 : $*Klass
+  store %0 to [init] %3 : $*Klass
+  destroy_addr %2 : $*Any
+  dealloc_stack %2 : $*Any
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// Same but via copy_addr into the init_existential_addr slot.
+//
+// CHECK-LABEL: begin running test 1 of 1 on init_existential_addr_trace_at_result_copy_addr: variable_name_inference with: @trace[0]
+// CHECK: Input Value:   %2 = init_existential_addr %1 : $*Any, $Klass
+// CHECK: Name: 'myStorage'
+// CHECK: Root:   %1 = alloc_stack $Any, var, name "myStorage"
+// CHECK: end running test 1 of 1 on init_existential_addr_trace_at_result_copy_addr: variable_name_inference with: @trace[0]
+sil [ossa] @init_existential_addr_trace_at_result_copy_addr : $@convention(thin) (@in Klass) -> () {
+bb0(%0 : $*Klass):
+  specify_test "variable_name_inference @trace[0]"
+  %2 = alloc_stack $Any, var, name "myStorage"
+  %3 = init_existential_addr %2 : $*Any, $Klass
+  debug_value [trace] %3 : $*Klass
+  copy_addr [take] %0 to [init] %3 : $*Klass
+  destroy_addr %2 : $*Any
+  dealloc_stack %2 : $*Any
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
 // CHECK-LABEL: begin running test 1 of 1 on move_value_var_decl: variable_name_inference with: @trace[0]
 // CHECK: Input Value:   %2 = move_value [var_decl] %1 : $Klass
 // CHECK: Name: 'MyName'
@@ -1085,6 +1128,77 @@ bb0(%0 : @guaranteed $C):
   debug_value [trace] %r : $Klass
   destroy_value %r : $Klass
   destroy_value %pa : $@callee_guaranteed () -> @owned Klass
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+//===----------------------------------------------------------------------===//
+// MARK: init_existential_ref look-through
+//
+// When a named class value is wrapped in `any Protocol` via init_existential_ref
+// the name inferrer must look through it to reach the concrete value, otherwise
+// region-isolation diagnostics fall back to the catch-all unknown-pattern error.
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: begin running test 1 of 1 on init_existential_ref_named_variable: variable_name_inference with: @trace[0]
+// CHECK: Input Value:   %3 = init_existential_ref %2 : $Klass : $Klass, $AnyObject
+// CHECK: Name: 'myKlass'
+// CHECK: Root: %0 = argument of bb0 : $Klass
+// CHECK: end running test 1 of 1 on init_existential_ref_named_variable: variable_name_inference with: @trace[0]
+sil [ossa] @init_existential_ref_named_variable : $@convention(thin) (@owned Klass) -> () {
+bb0(%0 : @owned $Klass):
+  specify_test "variable_name_inference @trace[0]"
+  debug_value %0 : $Klass, var, name "myKlass"
+  %2 = copy_value %0 : $Klass
+  %3 = init_existential_ref %2 : $Klass : $Klass, $AnyObject
+  debug_value [trace] %3 : $AnyObject
+  destroy_value %3 : $AnyObject
+  destroy_value %0 : $Klass
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// Swift.Optional wrapping: init_existential_ref followed by Optional.some.
+// The `.some` path component is suppressed for Swift.Optional so the name
+// comes out clean as 'myKlass', not 'myKlass.some'.
+//
+// CHECK-LABEL: begin running test 1 of 1 on init_existential_ref_optional_some_suppressed: variable_name_inference with: @trace[0]
+// CHECK: Input Value:   %4 = enum $Optional<AnyObject>, #Optional.some!enumelt, %3 : $AnyObject
+// CHECK: Name: 'myKlass'
+// CHECK: Root: %0 = argument of bb0 : $Klass
+// CHECK: end running test 1 of 1 on init_existential_ref_optional_some_suppressed: variable_name_inference with: @trace[0]
+sil [ossa] @init_existential_ref_optional_some_suppressed : $@convention(thin) (@owned Klass) -> () {
+bb0(%0 : @owned $Klass):
+  specify_test "variable_name_inference @trace[0]"
+  debug_value %0 : $Klass, var, name "myKlass"
+  %2 = copy_value %0 : $Klass
+  %3 = init_existential_ref %2 : $Klass : $Klass, $AnyObject
+  %4 = enum $Optional<AnyObject>, #Optional.some!enumelt, %3 : $AnyObject
+  debug_value [trace] %4 : $Optional<AnyObject>
+  destroy_value %4 : $Optional<AnyObject>
+  destroy_value %0 : $Klass
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// FakeOptional wrapping: the `.some` path component IS included because
+// FakeOptional is not Swift.Optional (getOptionalObjectType() returns null).
+//
+// CHECK-LABEL: begin running test 1 of 1 on init_existential_ref_fakeoptional_some_kept: variable_name_inference with: @trace[0]
+// CHECK: Input Value:   %4 = enum $FakeOptional<AnyObject>, #FakeOptional.some!enumelt, %3 : $AnyObject
+// CHECK: Name: 'myKlass.some'
+// CHECK: Root: %0 = argument of bb0 : $Klass
+// CHECK: end running test 1 of 1 on init_existential_ref_fakeoptional_some_kept: variable_name_inference with: @trace[0]
+sil [ossa] @init_existential_ref_fakeoptional_some_kept : $@convention(thin) (@owned Klass) -> () {
+bb0(%0 : @owned $Klass):
+  specify_test "variable_name_inference @trace[0]"
+  debug_value %0 : $Klass, var, name "myKlass"
+  %2 = copy_value %0 : $Klass
+  %3 = init_existential_ref %2 : $Klass : $Klass, $AnyObject
+  %4 = enum $FakeOptional<AnyObject>, #FakeOptional.some!enumelt, %3 : $AnyObject
+  debug_value [trace] %4 : $FakeOptional<AnyObject>
+  destroy_value %4 : $FakeOptional<AnyObject>
+  destroy_value %0 : $Klass
   %9999 = tuple ()
   return %9999 : $()
 }


### PR DESCRIPTION
Without this, the name inferrer gave up at init_existential_ref (used when wrapping a concrete value in `any Protocol`) and region isolation diagnostics fell back to the generic "unknown pattern" catch-all instead of naming the variable.

Also suppress the `.some` path component when looking through Optional.some EnumInst wrapping, since users never write `x.some` in source and the suffix produced confusing diagnostics like "'negotiator.some' cannot be returned".

Adds a lit test covering the regression case: a value stored to an `inout sending` closure parameter and returned through an existential.

rdar://178775464

