### PR TITLE
IRGen: Adjust to some low-risk upstream LLVM changes

### DIFF
--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -1730,6 +1730,7 @@ void SignatureExpansion::expandExternalSignatureTypes() {
       break;
     }
     case clang::CodeGen::ABIArgInfo::IndirectAliased:
+    case clang::CodeGen::ABIArgInfo::TargetSpecific:
       llvm_unreachable("not implemented");
     case clang::CodeGen::ABIArgInfo::Indirect: {
       // When `i` is 0, if the clang offset is 1, that means we mapped the last
@@ -4663,6 +4664,7 @@ void CallEmission::externalizeArguments(IRGenFunction &IGF, const Callee &callee
       break;
     }
     case clang::CodeGen::ABIArgInfo::IndirectAliased:
+    case clang::CodeGen::ABIArgInfo::TargetSpecific:
       llvm_unreachable("not implemented");
     case clang::CodeGen::ABIArgInfo::Indirect: {
       auto &ti = cast<LoadableTypeInfo>(IGF.getTypeInfo(paramType));
@@ -4988,7 +4990,8 @@ void irgen::emitForeignParameter(IRGenFunction &IGF, Explosion &params,
                                paramTI);
     return;
   case clang::CodeGen::ABIArgInfo::IndirectAliased:
-      llvm_unreachable("not implemented");
+  case clang::CodeGen::ABIArgInfo::TargetSpecific:
+    llvm_unreachable("not implemented");
   case clang::CodeGen::ABIArgInfo::Indirect: {
     Address address = paramTI.getAddressForPointer(params.claimNext());
     paramTI.loadAsTake(IGF, address, paramExplosion);

--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -499,7 +499,7 @@ void swift::performLLVMOptimizations(
                                            llvm::ThinOrFullLTOPhase) {
       std::vector<std::string> allowlistFiles;
       std::vector<std::string> ignorelistFiles;
-      MPM.addPass(SanitizerCoveragePass(Opts.SanitizeCoverage,
+      MPM.addPass(SanitizerCoveragePass(Opts.SanitizeCoverage, /*VFS=*/FS,
                                         allowlistFiles, ignorelistFiles));
     });
   }


### PR DESCRIPTION
See https://github.com/llvm/llvm-project/pull/165267.
___
Paired with https://github.com/swiftlang/llvm-project/pull/13140.
Targeting main to minimise the difference between main and rebranch.