### PR TITLE
Serialization: skip SIL bodies that reference foreign -static modules

### DIFF
--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -395,6 +395,14 @@ namespace {
     /// deserialization if the function body for F should be deserialized.
     bool shouldEmitFunctionBody(const SILFunction *F, bool isReference = true);
 
+    /// True if F's body references any function or global owned by a foreign
+    /// `-static` module. Such a body must not be serialized for cross-module
+    /// inlining: when a non-static client inlines it, the resulting code emits
+    /// a direct reference to the static module's symbol, which may not be
+    /// exported by whichever shared library the client links against.
+    /// See issue #88199.
+    bool bodyReferencesForeignStaticModule(const SILFunction &F);
+
     IdentifierID addSILFunctionRef(SILFunction *F);
 
   public:
@@ -441,7 +449,7 @@ void SILSerializer::addReferencedSILFunction(const SILFunction *F,
 
   // We haven't seen this function before. Let's see if we should
   // serialize the body or just the declaration.
-  if (shouldEmitFunctionBody(F)) {
+  if (shouldEmitFunctionBody(F) && !bodyReferencesForeignStaticModule(*F)) {
     FuncsToEmit[F] = false;
     functionWorklist.push_back(F);
     return;
@@ -525,7 +533,8 @@ void SILSerializer::writeSILFunction(const SILFunction &F, bool DeclOnly) {
 
   // Check if we need to emit a body for this function.
   bool NoBody = DeclOnly || isAvailableExternally(Linkage) ||
-                F.isExternalDeclaration();
+                F.isExternalDeclaration() ||
+                bodyReferencesForeignStaticModule(F);
 
   // If we don't emit a function body then make sure to mark the declaration
   // as available externally.
@@ -3809,6 +3818,31 @@ bool SILSerializer::shouldEmitFunctionBody(const SILFunction *F,
   if (F->isAnySerialized() && !hasSharedVisibility(F->getLinkage()))
     return true;
 
+  return false;
+}
+
+bool SILSerializer::bodyReferencesForeignStaticModule(const SILFunction &F) {
+  ModuleDecl *currentModule = F.getModule().getSwiftModule();
+  auto isForeignStatic = [&](ModuleDecl *M) {
+    return M && M != currentModule && M->isStaticLibrary();
+  };
+  for (auto &BB : F) {
+    for (auto &I : BB) {
+      if (auto *FRI = dyn_cast<FunctionRefBaseInst>(&I)) {
+        if (auto *Fn = FRI->getReferencedFunctionOrNull())
+          if (isForeignStatic(Fn->getParentModule()))
+            return true;
+      } else if (auto *GAI = dyn_cast<GlobalAddrInst>(&I)) {
+        if (auto *G = GAI->getReferencedGlobal())
+          if (isForeignStatic(G->getParentModule()))
+            return true;
+      } else if (auto *GVI = dyn_cast<GlobalValueInst>(&I)) {
+        if (auto *G = GVI->getReferencedGlobal())
+          if (isForeignStatic(G->getParentModule()))
+            return true;
+      }
+    }
+  }
   return false;
 }
 

--- a/test/Serialization/static-no-cross-inline.swift
+++ b/test/Serialization/static-no-cross-inline.swift
@@ -1,0 +1,67 @@
+// Regression test for #88199: a function whose body references symbols owned
+// by a foreign `-static` module must not have its body serialized for
+// cross-module inlining. Otherwise, when a non-static client inlines such a
+// body, the resulting code emits a direct reference to the static module's
+// symbol — which may not be exported by whichever shared library the client
+// links against, and the link will fail.
+//
+// The test exercises the 3-module chain from the issue:
+//
+//   StaticC (`-static`)  →  defines `f3`
+//   DynamicB             →  defines `f2` whose body calls `f3`
+//   Main                 →  imports DynamicB and calls `f2`
+//
+// We expect DynamicB's serialized SIL for `f2` to be a declaration only
+// (no body) when StaticC is built with `-static`. As a control, when
+// StaticC is built without `-static`, `f2`'s body should be serialized
+// normally.
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// --- Static case: StaticC built with -static. f2's body must be dropped.
+// RUN: %target-swift-frontend -emit-module -static -parse-as-library \
+// RUN:   -module-name StaticC %t/StaticC.swift \
+// RUN:   -emit-module-path %t/StaticC.swiftmodule
+// RUN: %target-swift-frontend -emit-module -parse-as-library \
+// RUN:   -module-name DynamicB -I %t %t/DynamicB.swift \
+// RUN:   -emit-module-path %t/DynamicB.swiftmodule
+// RUN: %target-sil-opt -enable-sil-verify-all -I %t %t/DynamicB.swiftmodule \
+// RUN:   -emit-sorted-sil -o - | %FileCheck %s --check-prefix=CHECK-STATIC
+
+// --- Control case: StaticC built without -static. f2's body must be kept.
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: %target-swift-frontend -emit-module -parse-as-library \
+// RUN:   -module-name StaticC %t/StaticC.swift \
+// RUN:   -emit-module-path %t/StaticC.swiftmodule
+// RUN: %target-swift-frontend -emit-module -parse-as-library \
+// RUN:   -module-name DynamicB -I %t %t/DynamicB.swift \
+// RUN:   -emit-module-path %t/DynamicB.swiftmodule
+// RUN: %target-sil-opt -enable-sil-verify-all -I %t %t/DynamicB.swiftmodule \
+// RUN:   -emit-sorted-sil -o - | %FileCheck %s --check-prefix=CHECK-DYNAMIC
+
+// In the static case, f2's body is not serialized — the `sil` line for
+// f2 ends without a `{` opening a body.
+// CHECK-STATIC: sil {{.*}}@$s8DynamicB2f2SiyF{{.*}} -> Int{{[[:space:]]*$}}
+
+// In the control case, f2's body is serialized: the `sil` line for f2
+// ends with `{` and a `function_ref` to f3 appears inside.
+// CHECK-DYNAMIC: sil {{.*}}@$s8DynamicB2f2SiyF{{.*}} -> Int {
+// CHECK-DYNAMIC: function_ref @$s7StaticC2f3SiyF
+
+//--- StaticC.swift
+
+@inlinable
+public func f3() -> Int {
+  return 42
+}
+
+//--- DynamicB.swift
+
+import StaticC
+
+@inlinable
+public func f2() -> Int {
+  return f3() &+ 1
+}


### PR DESCRIPTION
Cross-module inlining of a body that calls into a `-static` Swift module emits a direct reference to that module's symbol in the inlining client. On Windows (and other platforms that internalize symbols of statically linked libraries), the static module's symbols are not exported by the shared library that absorbed it, so a downstream link fails to resolve the reference. This failure can be transitive: a non-static intermediate module B can also leak C's symbols into a non-static client A by inlining a B function whose body calls into static C.

Detect the leak at serialization time. When emitting a SIL function's body, walk the instructions and check whether any FunctionRefBaseInst, GlobalAddrInst, or GlobalValueInst points to a function or global owned by a foreign module that was compiled with -static. If so, do not serialize the body. The function is published as an external declaration and clients see a normal call/link, so static-module symbols can no longer escape via cross-module inlining.

Fixes(?):
- rdar://178757853

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
