### PR TITLE
[cxx-interop] Guard FRT inheritance behind an experimental feature flag

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -514,6 +514,10 @@ EXPERIMENTAL_FEATURE(ImportNonPublicCxxMembers, true)
 /// Do not import non-field C++ record members until requested from Swift.
 EXPERIMENTAL_FEATURE(ImportCxxMembersLazily, true)
 
+/// Import a C++ foreign reference type's primary FRT base as a Swift
+/// superclass.
+EXPERIMENTAL_FEATURE(ForeignReferenceTypeInheritance, true)
+
 /// `yielding borrow`/`yielding mutate` single-yield coroutine accessors
 // TODO: When this is turned on by default, take care of:
 // * "TODO" around line 8100 of lib/Parse/ParseDecl.cpp

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -477,6 +477,7 @@ UNINTERESTING_FEATURE(SafeInteropWrappers)
 UNINTERESTING_FEATURE(AssumeResilientCxxTypes)
 UNINTERESTING_FEATURE(ImportNonPublicCxxMembers)
 UNINTERESTING_FEATURE(ImportCxxMembersLazily)
+UNINTERESTING_FEATURE(ForeignReferenceTypeInheritance)
 UNINTERESTING_FEATURE(CoroutineAccessorsUnwindOnCallerError)
 UNINTERESTING_FEATURE(AllowRuntimeSymbolDeclarations)
 

--- a/lib/ClangImporter/ClangLookup.cpp
+++ b/lib/ClangImporter/ClangLookup.cpp
@@ -452,7 +452,8 @@ TinyPtrVector<ValueDecl *> ClangRecordMemberLookup::evaluate(
     // from that base: they are reachable via the Swift superclass chain
     // instead.
     const clang::RecordDecl *superclassClangDecl = nullptr;
-    if (!inheritance) {
+    if (!inheritance &&
+        ctx.LangOpts.hasFeature(Feature::ForeignReferenceTypeInheritance)) {
       auto derivedInfo = evaluateOrDefault(
           ctx.evaluator, ForeignReferenceTypeInfoRequest({cxxRecord}), {});
       if (auto primaryBase = derivedInfo.getPrimarySuperclass())
@@ -882,9 +883,14 @@ ClangImporter::Implementation::lookupAndImportSubscripts(
   // If this FRT class has a single FRT superclass, inherited overloads whose
   // declaring class is that superclass (or a Clang base of it) are reachable
   // via the Swift superclass chain and should not be synthesized here again.
-  auto frtInfo = evaluateOrDefault(
-      SwiftContext.evaluator, ForeignReferenceTypeInfoRequest({CXXRecord}), {});
-  auto superclassClangDecl = frtInfo.getPrimarySuperclass();
+  const clang::CXXRecordDecl *superclassClangDecl = nullptr;
+  if (SwiftContext.LangOpts.hasFeature(
+          Feature::ForeignReferenceTypeInheritance)) {
+    auto frtInfo =
+        evaluateOrDefault(SwiftContext.evaluator,
+                          ForeignReferenceTypeInfoRequest({CXXRecord}), {});
+    superclassClangDecl = frtInfo.getPrimarySuperclass();
+  }
 
   llvm::SmallMapVector<CXXOverloadArgTypes,
                        std::pair<CXXOverload, CXXOverload>, 1>

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2559,18 +2559,21 @@ namespace {
 
           // If this is an inherited foreign reference type, check if it has a
           // suitable superclass.
-          auto frtInfo = evaluateOrDefault(
-              Impl.SwiftContext.evaluator,
-              ForeignReferenceTypeInfoRequest({cxxRecordDecl}), {});
-          if (auto primaryBase = frtInfo.getPrimarySuperclass()) {
-            if (auto baseDecl = cast_or_null<ClassDecl>(
-                    Impl.importDecl(primaryBase, getVersion()))) {
-              auto classResult = cast<ClassDecl>(result);
-              Type superclassType = baseDecl->getDeclaredInterfaceType();
-              classResult->setSuperclass(superclassType);
-              classResult->setInherited(
-                  Impl.SwiftContext.AllocateCopy(ArrayRef<InheritedEntry>{
-                      TypeLoc::withoutLoc(superclassType)}));
+          if (Impl.SwiftContext.LangOpts.hasFeature(
+                  Feature::ForeignReferenceTypeInheritance)) {
+            auto frtInfo = evaluateOrDefault(
+                Impl.SwiftContext.evaluator,
+                ForeignReferenceTypeInfoRequest({cxxRecordDecl}), {});
+            if (auto primaryBase = frtInfo.getPrimarySuperclass()) {
+              if (auto baseDecl = cast_or_null<ClassDecl>(
+                      Impl.importDecl(primaryBase, getVersion()))) {
+                auto classResult = cast<ClassDecl>(result);
+                Type superclassType = baseDecl->getDeclaredInterfaceType();
+                classResult->setSuperclass(superclassType);
+                classResult->setInherited(
+                    Impl.SwiftContext.AllocateCopy(ArrayRef<InheritedEntry>{
+                        TypeLoc::withoutLoc(superclassType)}));
+              }
             }
           }
         }
@@ -10927,10 +10930,14 @@ void ClangRecordMemberLoader::load(const clang::RecordDecl *clangRecord,
   const clang::CXXRecordDecl *cxxRecord;
   if ((cxxRecord = dyn_cast<clang::CXXRecordDecl>(clangRecord)) &&
       cxxRecord->isCompleteDefinition()) {
-    auto derivedInfo =
-        evaluateOrDefault(Impl.SwiftContext.evaluator,
-                          ForeignReferenceTypeInfoRequest({cxxRecord}), {});
-    auto superclassClangDecl = derivedInfo.getPrimarySuperclass();
+    const clang::RecordDecl *superclassClangDecl = nullptr;
+    if (Impl.SwiftContext.LangOpts.hasFeature(
+            Feature::ForeignReferenceTypeInheritance)) {
+      auto derivedInfo =
+          evaluateOrDefault(Impl.SwiftContext.evaluator,
+                            ForeignReferenceTypeInfoRequest({cxxRecord}), {});
+      superclassClangDecl = derivedInfo.getPrimarySuperclass();
+    }
 
     for (auto base : cxxRecord->bases()) {
       if (skipIfNonPublic && base.getAccessSpecifier() != clang::AS_public)

--- a/test/Interop/Cxx/foreign-reference/member-inheritance-module-interface.swift
+++ b/test/Interop/Cxx/foreign-reference/member-inheritance-module-interface.swift
@@ -1,14 +1,21 @@
-// RUN: %target-swift-ide-test -print-module -cxx-interoperability-mode=swift-5.9 -print-implicit-attrs -module-to-print=MemberInheritance -I %S/Inputs -source-filename=x | %FileCheck %s
-// RUN: %target-swift-ide-test -print-module -cxx-interoperability-mode=swift-6 -print-implicit-attrs -module-to-print=MemberInheritance -I %S/Inputs -source-filename=x | %FileCheck %s
-// RUN: %target-swift-ide-test -print-module -cxx-interoperability-mode=upcoming-swift -print-implicit-attrs -module-to-print=MemberInheritance -I %S/Inputs -source-filename=x | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -cxx-interoperability-mode=swift-5.9 -print-implicit-attrs -module-to-print=MemberInheritance -I %S/Inputs -source-filename=x | %FileCheck --check-prefixes=CHECK,CHECK-OFF %s
+// RUN: %target-swift-ide-test -print-module -cxx-interoperability-mode=swift-6 -print-implicit-attrs -module-to-print=MemberInheritance -I %S/Inputs -source-filename=x | %FileCheck --check-prefixes=CHECK,CHECK-OFF %s
+// RUN: %target-swift-ide-test -print-module -cxx-interoperability-mode=upcoming-swift -print-implicit-attrs -module-to-print=MemberInheritance -I %S/Inputs -source-filename=x | %FileCheck --check-prefixes=CHECK,CHECK-OFF %s
+// RUN: %target-swift-ide-test -print-module -cxx-interoperability-mode=upcoming-swift -enable-experimental-feature ForeignReferenceTypeInheritance -print-implicit-attrs -module-to-print=MemberInheritance -I %S/Inputs -source-filename=x | %FileCheck --check-prefixes=CHECK,CHECK-ON %s
+
+// REQUIRES: swift_feature_ForeignReferenceTypeInheritance
 
 // CHECK: class ImmortalBase {
 // CHECK:  func get42() -> Int32
 // CHECK:  func getOverridden42() -> Int32
 // CHECK: }
-// CHECK: class Immortal : ImmortalBase {
-// CHECK:  override func getOverridden42() -> Int32
-// CHECK: }
+// CHECK-OFF: class Immortal {
+// CHECK-OFF:  func getOverridden42() -> Int32
+// CHECK-OFF:  func get42() -> Int32
+// CHECK-OFF: }
+// CHECK-ON: class Immortal : ImmortalBase {
+// CHECK-ON:  override func getOverridden42() -> Int32
+// CHECK-ON: }
 
 // CHECK: class Immortal2 {
 // CHECK-NEXT: final func virtualMethod(_: HasDestructor)
@@ -22,31 +29,55 @@
 // CHECK:  final func swiftParamsRename(a1 i: Int32) -> Int32
 // CHECK: }
 
-// CHECK: class B1 : A1 {
-// CHECK:  final override func virtualMethod() -> Int32
-// CHECK:  final override func swiftFooRename() -> Int32
-// CHECK:  final override func swiftBarRename() -> Int32
-// CHECK:  final override func swiftParamsRename(a1 i: Int32) -> Int32
-// CHECK: }
+// CHECK-OFF: class B1 {
+// CHECK-OFF:  final func virtualMethod() -> Int32
+// CHECK-OFF:  final func swiftFooRename() -> Int32
+// CHECK-OFF:  final func swiftBarRename() -> Int32
+// CHECK-OFF:  final func swiftParamsRename(a1 i: Int32) -> Int32
+// CHECK-OFF: }
+// CHECK-ON: class B1 : A1 {
+// CHECK-ON:  final override func virtualMethod() -> Int32
+// CHECK-ON:  final override func swiftFooRename() -> Int32
+// CHECK-ON:  final override func swiftBarRename() -> Int32
+// CHECK-ON:  final override func swiftParamsRename(a1 i: Int32) -> Int32
+// CHECK-ON: }
 
-// CHECK: class B2 : A1 {
-// CHECK:   final override func virtualMethod() -> Int32
-// CHECK:   final override func swiftFooRename() -> Int32
-// CHECK:   final override func swiftBarRename() -> Int32
-// CHECK: }
+// CHECK-OFF: class B2 {
+// CHECK-OFF:   final func virtualMethod() -> Int32
+// CHECK-OFF:   final func swiftFooRename() -> Int32
+// CHECK-OFF:   final func swiftBarRename() -> Int32
+// CHECK-OFF:   final func swiftParamsRename(a1 i: Int32) -> Int32
+// CHECK-OFF: }
+// CHECK-ON: class B2 : A1 {
+// CHECK-ON:   final override func virtualMethod() -> Int32
+// CHECK-ON:   final override func swiftFooRename() -> Int32
+// CHECK-ON:   final override func swiftBarRename() -> Int32
+// CHECK-ON: }
 
-// CHECK: class C1 : B1 {
-// CHECK:  final override func swiftFooRename() -> Int32
-// CHECK:  final override func swiftBarRename() -> Int32
-// CHECK:  final override func swiftParamsRename(a1 i: Int32) -> Int32
-// CHECK: }
+// CHECK-OFF: class C1 {
+// CHECK-OFF:  final func swiftFooRename() -> Int32
+// CHECK-OFF:  final func swiftBarRename() -> Int32
+// CHECK-OFF:  final func swiftParamsRename(a1 i: Int32) -> Int32
+// CHECK-OFF:  final func virtualMethod() -> Int32
+// CHECK-OFF: }
+// CHECK-ON: class C1 : B1 {
+// CHECK-ON:  final override func swiftFooRename() -> Int32
+// CHECK-ON:  final override func swiftBarRename() -> Int32
+// CHECK-ON:  final override func swiftParamsRename(a1 i: Int32) -> Int32
+// CHECK-ON: }
 
-// CHECK: class C2 : B1 {
-// CHECK:  final override func virtualMethod() -> Int32
-// CHECK:  final override func swiftFooRename() -> Int32
-// CHECK:  final override func swiftBarRename() -> Int32
-// CHECK:  final override func swiftParamsRename(a1 i: Int32) -> Int32
-// CHECK: }
+// CHECK-OFF: class C2 {
+// CHECK-OFF:  final func virtualMethod() -> Int32
+// CHECK-OFF:  final func swiftFooRename() -> Int32
+// CHECK-OFF:  final func swiftBarRename() -> Int32
+// CHECK-OFF:  final func swiftParamsRename(a1 i: Int32) -> Int32
+// CHECK-OFF: }
+// CHECK-ON: class C2 : B1 {
+// CHECK-ON:  final override func virtualMethod() -> Int32
+// CHECK-ON:  final override func swiftFooRename() -> Int32
+// CHECK-ON:  final override func swiftBarRename() -> Int32
+// CHECK-ON:  final override func swiftParamsRename(a1 i: Int32) -> Int32
+// CHECK-ON: }
 
 // CHECK: class A2 {
 // CHECK:  final func swiftVirtualMethod() -> Int32
@@ -143,11 +174,22 @@
 // CHECK:   final func pureRenameDerived() -> Int32
 // CHECK: }
 
-// CHECK: class DerivedAbstractFRT : AbstractFRT {
-// CHECK:   final override func pureVirtualMethod() -> Int32
-// CHECK:   final override func swiftPureRenameBase() -> Int32
-// CHECK:   final override func pureRenameDerived() -> Int32
-// CHECK: }
+// CHECK-OFF: class DerivedAbstractFRT {
+// CHECK-OFF:   init()
+// CHECK-OFF:   final func pureVirtualMethod() -> Int32
+// CHECK-OFF:   final func swiftPureRenameBase() -> Int32
+// CHECK-OFF:   final func pureRenameDerived() -> Int32
+// CHECK-OFF: }
+// CHECK-ON: class DerivedAbstractFRT : AbstractFRT {
+// CHECK-ON:   final override func pureVirtualMethod() -> Int32
+// CHECK-ON:   final override func swiftPureRenameBase() -> Int32
+// CHECK-ON:   final override func pureRenameDerived() -> Int32
+// CHECK-ON: }
 
-// CHECK: class EmptyDerivedAbstractFRT : AbstractFRT {
-// CHECK: }
+// CHECK-OFF: class EmptyDerivedAbstractFRT {
+// CHECK-OFF:   final func pureVirtualMethod() -> Int32
+// CHECK-OFF:   final func swiftPureRenameBase() -> Int32
+// CHECK-OFF:   final func pureRenameDerived() -> Int32
+// CHECK-OFF: }
+// CHECK-ON: class EmptyDerivedAbstractFRT : AbstractFRT {
+// CHECK-ON: }

--- a/test/Interop/Cxx/foreign-reference/refcounting-methods-module-interface.swift
+++ b/test/Interop/Cxx/foreign-reference/refcounting-methods-module-interface.swift
@@ -1,11 +1,18 @@
-// RUN: %target-swift-ide-test -print-module -cxx-interoperability-mode=upcoming-swift -I %swift_src_root/lib/ClangImporter/SwiftBridging -module-to-print=RefCountingMethods -I %S/Inputs -source-filename=x | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -cxx-interoperability-mode=upcoming-swift -I %swift_src_root/lib/ClangImporter/SwiftBridging -module-to-print=RefCountingMethods -I %S/Inputs -source-filename=x | %FileCheck --check-prefixes=CHECK,CHECK-OFF %s
+// RUN: %target-swift-ide-test -print-module -cxx-interoperability-mode=upcoming-swift -enable-experimental-feature ForeignReferenceTypeInheritance -I %swift_src_root/lib/ClangImporter/SwiftBridging -module-to-print=RefCountingMethods -I %S/Inputs -source-filename=x | %FileCheck --check-prefixes=CHECK,CHECK-ON %s
+
+// REQUIRES: swift_feature_ForeignReferenceTypeInheritance
 
 // CHECK: class RefCountedBox {
 // CHECK:   func doRetain()
 // CHECK:   func doRelease()
 // CHECK: }
-// CHECK: class DerivedRefCountedBox : RefCountedBox {
-// CHECK: }
+// CHECK-OFF: class DerivedRefCountedBox {
+// CHECK-OFF:   func doRetain()
+// CHECK-OFF:   func doRelease()
+// CHECK-OFF: }
+// CHECK-ON: class DerivedRefCountedBox : RefCountedBox {
+// CHECK-ON: }
 
 // CHECK: class DerivedHasRelease {
 // CHECK:   func doRetainInBase()
@@ -23,7 +30,8 @@
 // CHECK:   func doRetainInBase()
 // CHECK: }
 
-// CHECK: class CRTPDerived : CRTPBase<CRTPDerived> {
+// CHECK-OFF: class CRTPDerived {
+// CHECK-ON: class CRTPDerived : CRTPBase<CRTPDerived> {
 // CHECK:   var value: Int32
 // CHECK: }
 
@@ -31,7 +39,8 @@
 // CHECK:   func doRetainVirtual()
 // CHECK:   func doReleaseVirtual()
 // CHECK: }
-// CHECK: class DerivedVirtualRetainRelease : VirtualRetainRelease {
+// CHECK-OFF: class DerivedVirtualRetainRelease {
+// CHECK-ON: class DerivedVirtualRetainRelease : VirtualRetainRelease {
 // CHECK:   func doRetainVirtual()
 // CHECK:   func doReleaseVirtual()
 // CHECK: }
@@ -40,7 +49,8 @@
 // CHECK:   func doRetainPure()
 // CHECK:   func doReleasePure()
 // CHECK: }
-// CHECK: class DerivedPureVirtualRetainRelease : PureVirtualRetainRelease {
+// CHECK-OFF: class DerivedPureVirtualRetainRelease {
+// CHECK-ON: class DerivedPureVirtualRetainRelease : PureVirtualRetainRelease {
 // CHECK:   func doRetainPure()
 // CHECK:   func doReleasePure()
 // CHECK:   var refCount: Int32

--- a/test/Interop/Cxx/foreign-reference/super-static-dispatch-silgen.swift
+++ b/test/Interop/Cxx/foreign-reference/super-static-dispatch-silgen.swift
@@ -1,4 +1,6 @@
-// RUN: %target-swift-emit-silgen %s -I %S/Inputs -cxx-interoperability-mode=default -disable-availability-checking | %FileCheck %s
+// RUN: %target-swift-emit-silgen %s -I %S/Inputs -cxx-interoperability-mode=default -enable-experimental-feature ForeignReferenceTypeInheritance -disable-availability-checking | %FileCheck %s
+
+// REQUIRES: swift_feature_ForeignReferenceTypeInheritance
 
 import SuperStaticDispatch
 

--- a/test/Interop/Cxx/foreign-reference/upcast-irgen.swift
+++ b/test/Interop/Cxx/foreign-reference/upcast-irgen.swift
@@ -1,4 +1,6 @@
-// RUN: %target-swift-emit-irgen %s -I %S/Inputs -cxx-interoperability-mode=default -validate-tbd-against-ir=none -disable-llvm-verify -Xcc -fignore-exceptions -disable-availability-checking | %FileCheck %s
+// RUN: %target-swift-emit-irgen %s -I %S/Inputs -cxx-interoperability-mode=default -enable-experimental-feature ForeignReferenceTypeInheritance -validate-tbd-against-ir=none -disable-llvm-verify -Xcc -fignore-exceptions -disable-availability-checking | %FileCheck %s
+
+// REQUIRES: swift_feature_ForeignReferenceTypeInheritance
 
 import Upcast
 

--- a/test/Interop/Cxx/foreign-reference/upcast-module-interface.swift
+++ b/test/Interop/Cxx/foreign-reference/upcast-module-interface.swift
@@ -1,4 +1,6 @@
-// RUN: %target-swift-ide-test -print-module -module-to-print=Upcast -I %S/Inputs -I %swift_src_root/lib/ClangImporter/SwiftBridging -source-filename=x -cxx-interoperability-mode=upcoming-swift -print-implicit-attrs | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=Upcast -I %S/Inputs -I %swift_src_root/lib/ClangImporter/SwiftBridging -source-filename=x -cxx-interoperability-mode=upcoming-swift -enable-experimental-feature ForeignReferenceTypeInheritance -print-implicit-attrs | %FileCheck %s
+
+// REQUIRES: swift_feature_ForeignReferenceTypeInheritance
 
 // CHECK: class Base {
 // CHECK:   var baseValue: Int32

--- a/test/Interop/Cxx/foreign-reference/upcast-typechecker.swift
+++ b/test/Interop/Cxx/foreign-reference/upcast-typechecker.swift
@@ -1,4 +1,6 @@
-// RUN: %target-typecheck-verify-swift -cxx-interoperability-mode=default -disable-availability-checking -I %S/Inputs
+// RUN: %target-typecheck-verify-swift -cxx-interoperability-mode=default -enable-experimental-feature ForeignReferenceTypeInheritance -disable-availability-checking -I %S/Inputs
+
+// REQUIRES: swift_feature_ForeignReferenceTypeInheritance
 
 import Upcast
 

--- a/test/Interop/Cxx/foreign-reference/upcast.swift
+++ b/test/Interop/Cxx/foreign-reference/upcast.swift
@@ -1,6 +1,7 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=default -Xfrontend -disable-availability-checking -Onone)
+// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=default -enable-experimental-feature ForeignReferenceTypeInheritance -Xfrontend -disable-availability-checking -Onone)
 
 // REQUIRES: executable_test
+// REQUIRES: swift_feature_ForeignReferenceTypeInheritance
 
 import StdlibUnittest
 import Upcast


### PR DESCRIPTION
This is a follow-up to 6c464579.

Importing superclasses of C++ foreign reference types can introduce source breaks in Swift under some circumstances.

This change puts the feature behind an experimental flag.

rdar://178736469

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
