### PR TITLE
[Serialization] Serialize debug reconstruction blocks

### DIFF
--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -1231,6 +1231,10 @@ llvm::Expected<SILFunction *> SILDeserializer::readSILFunctionChecked(
 
   SILBuilder Builder(*fn);
 
+  // Clear the debug BB worklist for this function.
+  DebugBBWorklist.clear();
+  DebugBBWorklistIdx = 0;
+
   // Another SIL_FUNCTION record means the end of this SILFunction.
   // SIL_VTABLE or SIL_GLOBALVAR or SIL_WITNESS_TABLE record also means the end
   // of this SILFunction.
@@ -1260,6 +1264,8 @@ llvm::Expected<SILFunction *> SILDeserializer::readSILFunctionChecked(
       if (!Loc)
         return Loc.takeError();
       Builder.applyDebugLocOverride(Loc.get());
+    } else if (kind == SIL_DEBUG_RECONSTRUCTION_BLOCK) {
+      CurrentBB = readSILDebugReconstructionBlock(fn, scratch);
     } else {
       // If CurrentBB is empty, just return fn. The code in readSILInstruction
       // assumes that such a situation means that fn is a declaration. Thus it
@@ -1341,12 +1347,19 @@ SILBasicBlock *SILDeserializer::readSILBasicBlock(SILFunction *Fn,
   //    ValueOwnershipKind. We enforce size constraints of these types above.
   // 3. A ValueID.
   SILBasicBlock *CurrentBB = getBBForDefinition(Fn, Prev, BasicBlockID++);
+  if (readBlockArgs(CurrentBB, Fn, Args))
+    return nullptr;
+  return CurrentBB;
+}
+
+bool SILDeserializer::readBlockArgs(SILBasicBlock *CurrentBB, SILFunction *Fn,
+                                    ArrayRef<uint64_t> Args) {
   bool IsEntry = CurrentBB->isEntry();
   for (unsigned I = 0, E = Args.size(); I < E; I += 3) {
     TypeID TyID = Args[I];
-    if (!TyID) return nullptr;
+    if (!TyID) return true;
     ValueID ValId = Args[I+2];
-    if (!ValId) return nullptr;
+    if (!ValId) return true;
 
     auto ArgTy = MF->getType(TyID);
     SILArgument *Arg;
@@ -1376,7 +1389,29 @@ SILBasicBlock *SILDeserializer::readSILBasicBlock(SILFunction *Fn,
     LastValueID = LastValueID + 1;
     setLocalValue(Arg, LastValueID);
   }
-  return CurrentBB;
+  return false;
+}
+
+SILBasicBlock *SILDeserializer::readSILDebugReconstructionBlock(
+    SILFunction *Fn, SmallVectorImpl<uint64_t> &scratch) {
+  // Clear local values and set up fresh IDs for this debug BB.
+  LocalValues.clear();
+  LastValueID = 1;
+
+  ArrayRef<uint64_t> Args;
+  SILDebugReconstructionBlockLayout::readRecord(scratch, Args);
+
+  auto *DebugBB = Fn->createEmptyDebugReconstructionBlock();
+  if (readBlockArgs(DebugBB, Fn, Args))
+    return nullptr;
+
+  // Pop the next DVI from the worklist and attach the debug BB.
+  if (DebugBBWorklistIdx >= DebugBBWorklist.size())
+    return nullptr;
+  auto *DVI = DebugBBWorklist[DebugBBWorklistIdx++];
+  DVI->setDebugReconstructionBlock(DebugBB);
+
+  return DebugBB;
 }
 
 static CastConsumptionKind getCastConsumptionKind(unsigned attr) {
@@ -1833,6 +1868,13 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     ResultInst =
         Builder.createDebugValue(Loc, Value, DebugVar, PoisonRefs,
                                  UsesMoveableValDebugInfo, HasTrace, !HasLoc);
+
+    // If the serialized debug_value has a reconstruction block, add it to
+    // the worklist. The matching SIL_DEBUG_RECONSTRUCTION_BLOCK records
+    // appear after all regular blocks.
+    bool hasReconstructionBlock = (Attr >> 11) & 0x1;
+    if (hasReconstructionBlock)
+      DebugBBWorklist.push_back(cast<DebugValueInst>(ResultInst));
 
     break;
   }

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -1231,9 +1231,11 @@ llvm::Expected<SILFunction *> SILDeserializer::readSILFunctionChecked(
 
   SILBuilder Builder(*fn);
 
-  // Clear the debug BB worklist for this function.
-  DebugBBWorklist.clear();
-  DebugBBWorklistIdx = 0;
+  // Worklist of debug_value instructions that have reconstruction blocks.
+  // Populated during instruction deserialization and consumed when matching
+  // trailing SIL_DEBUG_RECONSTRUCTION_BLOCK records.
+  SmallVector<DebugValueInst *, 4> DebugBBWorklist;
+  unsigned DebugBBWorklistIdx = 0;
 
   // Another SIL_FUNCTION record means the end of this SILFunction.
   // SIL_VTABLE or SIL_GLOBALVAR or SIL_WITNESS_TABLE record also means the end
@@ -1265,7 +1267,9 @@ llvm::Expected<SILFunction *> SILDeserializer::readSILFunctionChecked(
         return Loc.takeError();
       Builder.applyDebugLocOverride(Loc.get());
     } else if (kind == SIL_DEBUG_RECONSTRUCTION_BLOCK) {
-      CurrentBB = readSILDebugReconstructionBlock(fn, scratch);
+      CurrentBB = readSILDebugReconstructionBlock(fn, scratch,
+                                                    DebugBBWorklist,
+                                                    DebugBBWorklistIdx);
     } else {
       // If CurrentBB is empty, just return fn. The code in readSILInstruction
       // assumes that such a situation means that fn is a declaration. Thus it
@@ -1276,7 +1280,7 @@ llvm::Expected<SILFunction *> SILDeserializer::readSILFunctionChecked(
       Builder.setInsertionPoint(CurrentBB);
 
       // Handle a SILInstruction record.
-      if (readSILInstruction(fn, Builder, kind, scratch))
+      if (readSILInstruction(fn, Builder, kind, scratch, DebugBBWorklist))
         return MF->diagnoseFatal("readSILInstruction returns error");
     }
 
@@ -1393,7 +1397,8 @@ bool SILDeserializer::readBlockArgs(SILBasicBlock *CurrentBB, SILFunction *Fn,
 }
 
 SILBasicBlock *SILDeserializer::readSILDebugReconstructionBlock(
-    SILFunction *Fn, SmallVectorImpl<uint64_t> &scratch) {
+    SILFunction *Fn, SmallVectorImpl<uint64_t> &scratch,
+    ArrayRef<DebugValueInst *> DebugBBWorklist, unsigned &DebugBBWorklistIdx) {
   // Clear local values and set up fresh IDs for this debug BB.
   LocalValues.clear();
   LastValueID = 1;
@@ -1558,7 +1563,8 @@ SILDeserializer::readKeyPathComponent(ArrayRef<uint64_t> ListOfValues,
 bool SILDeserializer::readSILInstruction(SILFunction *Fn,
                                          SILBuilder &Builder,
                                          unsigned RecordKind,
-                                         SmallVectorImpl<uint64_t> &scratch) {
+                                         SmallVectorImpl<uint64_t> &scratch,
+                                         SmallVectorImpl<DebugValueInst *> &DebugBBWorklist) {
   unsigned RawOpCode = 0, TyCategory = 0, TyCategory2 = 0, TyCategory3 = 0,
            Attr = 0, Attr2 = 0, Attr3 = 0, Attr4 = 0, SubID = 0;
   ValueID ValID, ValID2, ValID3;
@@ -4477,11 +4483,14 @@ SILGlobalVariable *SILDeserializer::readGlobalVar(StringRef Name,
   SavedLocalValues.swap(LocalValues);
   std::swap(SavedLastValueID, LastValueID);
 
+  // Ignored, global variables don't have inner variables.
+  SmallVector<DebugValueInst *, 4> DebugBBWorklist;
+
   while (kind != SIL_FUNCTION && kind != SIL_VTABLE && kind != SIL_GLOBALVAR &&
          kind != SIL_MOVEONLY_DEINIT && kind != SIL_WITNESS_TABLE &&
          kind != SIL_DEFAULT_OVERRIDE_TABLE &&
          kind != SIL_DIFFERENTIABILITY_WITNESS) {
-    if (readSILInstruction(nullptr, Builder, kind, scratch))
+    if (readSILInstruction(nullptr, Builder, kind, scratch, DebugBBWorklist))
       MF->fatal("readSILInstruction returns error");
 
     // Fetch the next record.

--- a/lib/Serialization/DeserializeSIL.h
+++ b/lib/Serialization/DeserializeSIL.h
@@ -112,11 +112,6 @@ namespace swift {
     llvm::DenseMap<SILBasicBlock*, unsigned> UndefinedBlocks;
     unsigned BasicBlockID = 0;
 
-    /// DebugValueInsts with reconstruction blocks, collected during
-    /// deserialization and matched to trailing SIL_DEBUG_RECONSTRUCTION_BLOCK
-    /// records.
-    std::vector<DebugValueInst *> DebugBBWorklist;
-    unsigned DebugBBWorklistIdx = 0;
 
     /// Return the SILBasicBlock of a given ID.
     SILBasicBlock *getBBForReference(SILFunction *Fn, unsigned ID);
@@ -139,8 +134,9 @@ namespace swift {
                                      SmallVectorImpl<uint64_t> &scratch);
     /// Read a debug reconstruction block and attach it to the next DVI
     /// in the worklist.
-    SILBasicBlock *readSILDebugReconstructionBlock(SILFunction *Fn,
-                                                   SmallVectorImpl<uint64_t> &scratch);
+    SILBasicBlock *readSILDebugReconstructionBlock(
+        SILFunction *Fn, SmallVectorImpl<uint64_t> &scratch,
+        ArrayRef<DebugValueInst *> DebugBBWorklist, unsigned &DebugBBWorklistIdx);
     /// Parse phi arguments from serialized triples and add them to BB.
     bool readBlockArgs(SILBasicBlock *BB, SILFunction *Fn,
                        ArrayRef<uint64_t> Args);
@@ -148,7 +144,8 @@ namespace swift {
     bool readSILInstruction(SILFunction *Fn,
                             SILBuilder &Builder,
                             unsigned RecordKind,
-                            SmallVectorImpl<uint64_t> &scratch);
+                            SmallVectorImpl<uint64_t> &scratch,
+                            SmallVectorImpl<DebugValueInst *> &DebugBBWorklist);
 
     /// Read the SIL function table.
     std::unique_ptr<SerializedFuncTable>

--- a/lib/Serialization/DeserializeSIL.h
+++ b/lib/Serialization/DeserializeSIL.h
@@ -13,6 +13,7 @@
 #include "ModuleFile.h"
 #include "SILFormat.h"
 #include "swift/AST/Types.h"
+#include "swift/SIL/SILInstruction.h"
 #include "swift/SIL/SILModule.h"
 #include "swift/SIL/SILMoveOnlyDeinit.h"
 #include "swift/Serialization/SerializedSILLoader.h"
@@ -111,6 +112,12 @@ namespace swift {
     llvm::DenseMap<SILBasicBlock*, unsigned> UndefinedBlocks;
     unsigned BasicBlockID = 0;
 
+    /// DebugValueInsts with reconstruction blocks, collected during
+    /// deserialization and matched to trailing SIL_DEBUG_RECONSTRUCTION_BLOCK
+    /// records.
+    std::vector<DebugValueInst *> DebugBBWorklist;
+    unsigned DebugBBWorklistIdx = 0;
+
     /// Return the SILBasicBlock of a given ID.
     SILBasicBlock *getBBForReference(SILFunction *Fn, unsigned ID);
     SILBasicBlock *getBBForDefinition(SILFunction *Fn, SILBasicBlock *Prev,
@@ -130,6 +137,13 @@ namespace swift {
     SILBasicBlock *readSILBasicBlock(SILFunction *Fn,
                                      SILBasicBlock *Prev,
                                      SmallVectorImpl<uint64_t> &scratch);
+    /// Read a debug reconstruction block and attach it to the next DVI
+    /// in the worklist.
+    SILBasicBlock *readSILDebugReconstructionBlock(SILFunction *Fn,
+                                                   SmallVectorImpl<uint64_t> &scratch);
+    /// Parse phi arguments from serialized triples and add them to BB.
+    bool readBlockArgs(SILBasicBlock *BB, SILFunction *Fn,
+                       ArrayRef<uint64_t> Args);
     /// Read a SIL instruction.
     bool readSILInstruction(SILFunction *Fn,
                             SILBuilder &Builder,

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 1005; // index_addr projection flag
+const uint16_t SWIFTMODULE_VERSION_MINOR = 1006; // debug reconstruction blocks
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///

--- a/lib/Serialization/SILFormat.h
+++ b/lib/Serialization/SILFormat.h
@@ -206,6 +206,7 @@ namespace sil_block {
     SIL_DEBUG_VALUE_DELIMITER,
     SIL_DEBUG_VALUE,
     SIL_EXTRA_STRING,
+    SIL_DEBUG_RECONSTRUCTION_BLOCK,
   };
 
   using SILInstNoOperandLayout = BCRecordLayout<
@@ -369,9 +370,10 @@ namespace sil_block {
 
     SILTypeCategoryField, /// operand type category
     SILTypeCategoryField, /// debug var type category
-    BCFixed<11>,          /// poison, movableValueDebuginfo, trace,
+    BCFixed<12>,          /// poison, movableValueDebuginfo, trace,
                           /// hasDebugVar, isLet, isDenseMapSingleton(two
-                          /// bits), hasSource, hasLoc, hasExpr
+                          /// bits), hasSource, hasLoc, hasExpr,
+                          /// hasReconstructionBlock
     BCArray<ValueIDField> /// operand info: operand, type, debug var info:
                           /// name, argno, optional stuff: typeid
   >;
@@ -379,6 +381,12 @@ namespace sil_block {
   using DebugValueDelimiterLayout = BCRecordLayout<
     SIL_DEBUG_VALUE_DELIMITER
     >;
+
+  // Has an optional argument list where each argument is a typed valueref.
+  using SILDebugReconstructionBlockLayout = BCRecordLayout<
+    SIL_DEBUG_RECONSTRUCTION_BLOCK,
+    BCArray<DeclIDField> // The array contains type-value pairs.
+  >;
 
   using SourceLocLayout = BCRecordLayout<
     SIL_SOURCE_LOC,

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -300,6 +300,11 @@ namespace {
 
     llvm::SmallVector<const SILGlobalVariable *, 16> globalWorklist;
 
+    /// DebugValueInsts with reconstruction blocks found during serialization.
+    /// After all regular blocks are written, these are used to emit the
+    /// trailing SIL_DEBUG_RECONSTRUCTION_BLOCK records.
+    std::vector<DebugValueInst *> DebugBBWorklist;
+
     /// String storage for temporarily created strings which are referenced from
     /// the tables.
     llvm::BumpPtrAllocator StringTable;
@@ -332,6 +337,8 @@ namespace {
 
     void writeSILFunction(const SILFunction &F, bool DeclOnly = false);
     void writeSILBasicBlock(const SILBasicBlock &BB);
+    void writeBlockArgs(const SILBasicBlock &BB, SmallVectorImpl<DeclID> &Args);
+    void writeDebugReconstructionBlock(const SILBasicBlock &DebugBB);
     void writeSILInstruction(const SILInstruction &SI);
     void writeSILVTable(const SILVTable &vt);
     void writeSILMoveOnlyDeinit(const SILMoveOnlyDeinit &deinit);
@@ -738,10 +745,17 @@ void SILSerializer::writeSILFunction(const SILFunction &F, bool DeclOnly) {
     SerializedBBNum++;
   }
   assert(BasicID == SerializedBBNum && "Wrong number of BBs was serialized");
+
+  // Write debug reconstruction blocks after all regular blocks.
+  for (auto *DVI : DebugBBWorklist) {
+    auto *DebugBB = DVI->getDebugReconstructionBlock();
+    writeDebugReconstructionBlock(*DebugBB);
+  }
+  DebugBBWorklist.clear();
 }
 
-void SILSerializer::writeSILBasicBlock(const SILBasicBlock &BB) {
-  SmallVector<DeclID, 4> Args;
+void SILSerializer::writeBlockArgs(const SILBasicBlock &BB,
+                                   SmallVectorImpl<DeclID> &Args) {
   for (auto I = BB.args_begin(), E = BB.args_end(); I != E; ++I) {
     SILArgument *SA = *I;
     DeclID tId = S.addTypeRef(SA->getType().getRawASTType());
@@ -783,6 +797,11 @@ void SILSerializer::writeSILBasicBlock(const SILBasicBlock &BB) {
 
     Args.push_back(vId);
   }
+}
+
+void SILSerializer::writeSILBasicBlock(const SILBasicBlock &BB) {
+  SmallVector<DeclID, 4> Args;
+  writeBlockArgs(BB, Args);
 
   unsigned abbrCode = SILAbbrCodes[SILBasicBlockLayout::Code];
   SILBasicBlockLayout::emitRecord(Out, ScratchRecord, abbrCode, Args);
@@ -800,6 +819,37 @@ void SILSerializer::writeSILBasicBlock(const SILBasicBlock &BB) {
       writeSourceLoc(SI.getLoc(), SM);
     }
 
+    writeSILInstruction(SI);
+  }
+}
+
+void SILSerializer::writeDebugReconstructionBlock(const SILBasicBlock &DebugBB) {
+  // Set up fresh ValueIDs for the debug BB's local values.
+  ValueIDs.clear();
+  InstID = 0;
+  unsigned ValueID = 2; // 0 and 1 reserved for SILUndef.
+
+  // Assign IDs to block arguments.
+  for (auto *Arg : DebugBB.getArguments())
+    ValueIDs.insert({static_cast<const ValueBase *>(Arg), ValueID++});
+
+  // Assign IDs to instruction results.
+  for (const SILInstruction &SI : DebugBB)
+    for (auto result : SI.getResults())
+      ValueIDs[result] = ValueID++;
+
+  // Emit the debug reconstruction block header with block args.
+  SmallVector<DeclID, 4> Args;
+  writeBlockArgs(DebugBB, Args);
+
+  unsigned abbrCode = SILAbbrCodes[SILDebugReconstructionBlockLayout::Code];
+  SILDebugReconstructionBlockLayout::emitRecord(Out, ScratchRecord, abbrCode,
+                                                Args);
+
+  // Emit each instruction in the debug BB, with source locations.
+  auto &SM = DebugBB.getParent()->getModule().getSourceManager();
+  for (const SILInstruction &SI : DebugBB) {
+    writeSourceLoc(SI.getLoc(), SM);
     writeSILInstruction(SI);
   }
 }
@@ -1075,6 +1125,12 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
     unsigned attrs = unsigned(DVI->poisonRefs() & 0x1);
     attrs |= unsigned(DVI->usesMoveableValueDebugInfo()) << 1;
     attrs |= unsigned(DVI->hasTrace()) << 2;
+
+    bool hasReconstructionBlock = DVI->getDebugReconstructionBlock() != nullptr;
+    attrs |= unsigned(hasReconstructionBlock) << 11;
+
+    if (hasReconstructionBlock)
+      DebugBBWorklist.push_back(const_cast<DebugValueInst *>(DVI));
 
     auto Operand = DVI->getOperand();
     auto Type = Operand->getType();
@@ -3874,6 +3930,7 @@ void SILSerializer::writeSILBlock(const SILModule *SILMod) {
   registerSILAbbr<SourceLocLayout>();
   registerSILAbbr<SourceLocRefLayout>();
   registerSILAbbr<DebugValueDelimiterLayout>();
+  registerSILAbbr<SILDebugReconstructionBlockLayout>();
   registerSILAbbr<SILExtraStringLayout>();
 
   // Write out VTables first because it may require serializations of

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -849,6 +849,11 @@ void SILSerializer::writeDebugReconstructionBlock(const SILBasicBlock &DebugBB) 
   // Emit each instruction in the debug BB, with source locations.
   auto &SM = DebugBB.getParent()->getModule().getSourceManager();
   for (const SILInstruction &SI : DebugBB) {
+    // Although source locations within a debug reconstruction block are not
+    // useful, the deserializer will use the last valid SourceLoc for
+    // instructions. If not serialized, the last valid SourceLoc is usually
+    // the return statement, which has a ReturnKind location incompatible
+    // with regular instructions.
     writeSourceLoc(SI.getLoc(), SM);
     writeSILInstruction(SI);
   }

--- a/test/Serialization/debug-value.swift
+++ b/test/Serialization/debug-value.swift
@@ -32,16 +32,38 @@ public func fooCaller<T: AdditiveArithmetic>(_ x: T, _ y : T) -> T {
     return foo(x, y)
 }
 
+// Constant folding will eliminate a and b, salvaging them into debug
+// reconstruction blocks with integer_literal instructions.
+@inline(never) @_alwaysEmitIntoClient
+public func constantFolded() -> Int {
+    let a = 2
+    let b = 3
+    return a + b
+}
+
 // BEGIN Main.swift
 import MyModule
 // sil_scope should refer to the specialized version of foo
 //CHECK: sil_scope {{.*}} { loc "{{.*}}MyModule.swift":13:6 parent @$s8MyModule3fooyxx_xts18AdditiveArithmeticRzlFx_Ti5Si_TG5 {{.*}} inlined_at {{.*}} }
 let _ = fooCaller(1, 2)
 
+let _ = constantFolded()
+// CHECK-LABEL: sil {{.*}} @$s8MyModule14constantFoldedSiyF
+// CHECK: debug_value undef : $Builtin.Int{{[0-9]+}}, let, name "a"
+// CHECK-SAME: transform {
+// CHECK:   [[LIT1:%[0-9]+]] = integer_literal $Builtin.Int{{[0-9]+}}, 2
+// CHECK:   return [[LIT1]]
+// CHECK: }
+// CHECK: debug_value undef : $Builtin.Int{{[0-9]+}}, let, name "b"
+// CHECK-SAME: transform {
+// CHECK:   [[LIT2:%[0-9]+]] = integer_literal $Builtin.Int{{[0-9]+}}, 3
+// CHECK:   return [[LIT2]]
+// CHECK: }
+
 func test() {
     let _ = bar([10], sum: 0)
 }
-// CHECK: sil {{.*}} @$s8MyModule3bar_3sums5Int64VSayAEG_AEtF : $@convention(thin) (@guaranteed Array<Int64>, Int64) -> Int64 {
+// CHECK-LABEL: sil {{.*}} @$s8MyModule3bar_3sums5Int64VSayAEG_AEtF : $@convention(thin) (@guaranteed Array<Int64>, Int64) -> Int64 {
 
 // CHECK: debug_value %0 : $Array<Int64>, let, name "x", argno 1, loc "{{.*}}MyModule.swift":2:19
 // CHECK: debug_value %1 : $Int64, let, name "sum", argno 2, loc "{{.*}}MyModule.swift":2:31


### PR DESCRIPTION
Support debug reconstruction block serialization when serialization of debug info is enabled.

The debug reconstruction block records are all serialized at the end of the function, in the order the debug values were serialized.
