### PR TITLE
AST: Refine availability of switch case bodies using enum element availability

### DIFF
--- a/include/swift/AST/AvailabilityScope.h
+++ b/include/swift/AST/AvailabilityScope.h
@@ -31,11 +31,13 @@
 
 namespace swift {
 class BraceStmt;
+class CaseStmt;
 class Decl;
 class IfStmt;
 class GuardStmt;
 class SourceFile;
 class Stmt;
+class SwitchStmt;
 class Expr;
 class StmtConditionElement;
 
@@ -89,7 +91,15 @@ public:
     GuardStmtElseBranch,
 
     // The context was introduced for the body of a while statement.
-    WhileStmtBody
+    WhileStmtBody,
+
+    /// A placeholder context introduced for the entirety of a switch
+    /// statement. The contents are expanded lazily because the case label
+    /// items must be type-checked before per-case refinement can be computed.
+    SwitchStmt,
+
+    /// The context was introduced for the body of a switch statement case.
+    SwitchStmtCaseBody
   };
 
 private:
@@ -106,6 +116,8 @@ private:
       PoundAvailableInfo *PAI;
       GuardStmt *GS;
       WhileStmt *WS;
+      SwitchStmt *SS;
+      CaseStmt *CS;
     };
 
   public:
@@ -124,6 +136,10 @@ private:
           DC(DC), GS(GS) {}
     IntroNode(WhileStmt *WS, const DeclContext *DC)
         : IntroReason(Reason::WhileStmtBody), DC(DC), WS(WS) {}
+    IntroNode(SwitchStmt *SS, const DeclContext *DC)
+        : IntroReason(Reason::SwitchStmt), DC(DC), SS(SS) {}
+    IntroNode(CaseStmt *CS, const DeclContext *DC)
+        : IntroReason(Reason::SwitchStmtCaseBody), DC(DC), CS(CS) {}
 
     Reason getReason() const { return IntroReason; }
 
@@ -160,6 +176,16 @@ private:
     WhileStmt *getAsWhileStmt() const {
       assert(IntroReason == Reason::WhileStmtBody);
       return WS;
+    }
+
+    SwitchStmt *getAsSwitchStmt() const {
+      assert(IntroReason == Reason::SwitchStmt);
+      return SS;
+    }
+
+    CaseStmt *getAsCaseStmt() const {
+      assert(IntroReason == Reason::SwitchStmtCaseBody);
+      return CS;
     }
   };
 
@@ -241,6 +267,20 @@ public:
   createForWhileStmtBody(ASTContext &Ctx, WhileStmt *WS, const DeclContext *DC,
                          AvailabilityScope *Parent,
                          const AvailabilityContext Info);
+
+  /// Create a placeholder availability scope for a switch statement that
+  /// will be lazily expanded into per-case scopes once the case label items
+  /// have been type-checked.
+  static AvailabilityScope *createForSwitchStmt(ASTContext &Ctx, SwitchStmt *SS,
+                                                const DeclContext *DC,
+                                                AvailabilityScope *Parent,
+                                                const AvailabilityContext Info);
+
+  /// Create an availability scope for the body of a switch statement case.
+  static AvailabilityScope *
+  createForSwitchStmtCaseBody(ASTContext &Ctx, CaseStmt *CS,
+                              const DeclContext *DC, AvailabilityScope *Parent,
+                              const AvailabilityContext Info);
 
   Decl *getDeclOrNull() const {
     auto IntroReason = getReason();

--- a/lib/AST/AvailabilityScope.cpp
+++ b/lib/AST/AvailabilityScope.cpp
@@ -20,13 +20,13 @@
 #include "swift/AST/AvailabilityConstraint.h"
 #include "swift/AST/AvailabilitySpec.h"
 #include "swift/AST/Decl.h"
-#include "swift/AST/Expr.h"
 #include "swift/AST/Module.h"
 #include "swift/AST/SourceFile.h"
 #include "swift/AST/Stmt.h"
 #include "swift/AST/TypeCheckRequests.h"
 #include "swift/Basic/Assertions.h"
 #include "swift/Basic/SourceManager.h"
+#include "swift/Parse/Lexer.h"
 
 using namespace swift;
 
@@ -169,6 +169,36 @@ AvailabilityScope *AvailabilityScope::createForWhileStmtBody(
                                      S->getBody()->getSourceRange(), Info);
 }
 
+AvailabilityScope *AvailabilityScope::createForSwitchStmt(
+    ASTContext &Ctx, SwitchStmt *S, const DeclContext *DC,
+    AvailabilityScope *Parent, const AvailabilityContext Info) {
+  ASSERT(S);
+  ASSERT(Parent);
+  // Use the brace range so that the subject expression (which sits between
+  // the `switch` keyword and the opening brace) isn't covered by this
+  // scope's source range. The subject is type-checked before the case label
+  // items, so excluding it avoids triggering this scope's lazy expansion
+  // before the patterns are ready.
+  SourceRange range(S->getLBraceLoc(), S->getRBraceLoc());
+  return new (Ctx)
+      AvailabilityScope(Ctx, IntroNode(S, DC), Parent, range, Info);
+}
+
+AvailabilityScope *AvailabilityScope::createForSwitchStmtCaseBody(
+    ASTContext &Ctx, CaseStmt *S, const DeclContext *DC,
+    AvailabilityScope *Parent, const AvailabilityContext Info) {
+  ASSERT(S);
+  ASSERT(Parent);
+  // Widen the body source range to the end of its last token so it contains
+  // child availability scopes that extend their ranges similarly (such as
+  // implicit decl scopes).
+  SourceRange range = S->getBody()->getSourceRange();
+  if (range.End.isValid())
+    range.End = Lexer::getLocForEndOfToken(Ctx.SourceMgr, range.End);
+  return new (Ctx)
+      AvailabilityScope(Ctx, IntroNode(S, DC), Parent, range, Info);
+}
+
 void AvailabilityScope::addChild(AvailabilityScope *Child, ASTContext &Ctx) {
   bool validSourceRange = Child->getSourceRange().isValid();
   ASSERT(validSourceRange);
@@ -259,6 +289,12 @@ SourceLoc AvailabilityScope::getIntroductionLoc() const {
   case Reason::WhileStmtBody:
     return Node.getAsWhileStmt()->getStartLoc();
 
+  case Reason::SwitchStmt:
+    return Node.getAsSwitchStmt()->getStartLoc();
+
+  case Reason::SwitchStmtCaseBody:
+    return Node.getAsCaseStmt()->getStartLoc();
+
   case Reason::Root:
     return SourceLoc();
   }
@@ -347,6 +383,8 @@ SourceRange AvailabilityScope::getAvailabilityConditionVersionSourceRange(
         Node.getAsWhileStmt()->getCond(), Node.getDeclContext(), Domain,
         Version);
 
+  case Reason::SwitchStmt:
+  case Reason::SwitchStmtCaseBody:
   case Reason::Root:
   case Reason::DeclImplicit:
     return SourceRange();
@@ -380,6 +418,8 @@ AvailabilityScope::getExplicitAvailabilityRange(AvailabilityDomain domain,
   case Reason::GuardStmtFallthrough:
   case Reason::GuardStmtElseBranch:
   case Reason::WhileStmtBody:
+  case Reason::SwitchStmt:
+  case Reason::SwitchStmtCaseBody:
     // Availability is inherently explicit for all of these nodes.
     return getAvailabilityContext().getAvailabilityRange(domain, ctx);
   }
@@ -478,6 +518,12 @@ StringRef AvailabilityScope::getReasonName(Reason R) {
 
   case Reason::WhileStmtBody:
     return "while_body";
+
+  case Reason::SwitchStmt:
+    return "switch_stmt";
+
+  case Reason::SwitchStmtCaseBody:
+    return "switch_case_body";
   }
 
   llvm_unreachable("Unhandled Reason in switch.");

--- a/lib/AST/AvailabilityScopeBuilder.cpp
+++ b/lib/AST/AvailabilityScopeBuilder.cpp
@@ -25,6 +25,8 @@
 #include "swift/AST/DeclExportabilityVisitor.h"
 #include "swift/AST/DiagnosticsParse.h"
 #include "swift/AST/DiagnosticsSema.h"
+#include "swift/AST/Expr.h"
+#include "swift/AST/Pattern.h"
 #include "swift/AST/PrettyStackTrace.h"
 #include "swift/AST/TypeCheckRequests.h"
 #include "swift/Parse/Lexer.h"
@@ -225,6 +227,8 @@ private:
         case AvailabilityScope::Reason::GuardStmtFallthrough:
         case AvailabilityScope::Reason::GuardStmtElseBranch:
         case AvailabilityScope::Reason::WhileStmtBody:
+        case AvailabilityScope::Reason::SwitchStmt:
+        case AvailabilityScope::Reason::SwitchStmtCaseBody:
           // Nothing to check here.
           break;
         }
@@ -670,6 +674,11 @@ private:
       return Action::SkipNode(stmt);
     }
 
+    if (auto *switchStmt = dyn_cast<SwitchStmt>(stmt)) {
+      if (buildSwitchStmtRefinementContext(switchStmt))
+        return Action::SkipNode(stmt);
+    }
+
     return Action::Continue(stmt);
   }
 
@@ -770,6 +779,136 @@ private:
     } else {
       build(whileStmt->getBody());
     }
+  }
+
+  /// Returns the enum element matched by \p pattern, or null if the pattern
+  /// does not bind to a single enum element. The pattern is expected to have
+  /// already been resolved to an `EnumElementPattern` with a resolved decl
+  /// (which is the state after switch type-checking has run).
+  static const EnumElementDecl *getMatchedEnumElement(const Pattern *pattern) {
+    auto *p = pattern->getSemanticsProvidingPattern();
+    if (auto *eep = dyn_cast<EnumElementPattern>(p))
+      return eep->getElementDecl();
+    return nullptr;
+  }
+
+  /// Builds the children of a switch statement's placeholder availability
+  /// scope. Called during lazy expansion via
+  /// `ExpandChildAvailabilityScopesRequest`. By this point the case label
+  /// items have been type-checked, so we can extract the matched enum
+  /// elements and decide which case bodies need refinement scopes.
+  void expandSwitchStmtRefinementContext(SwitchStmt *switchStmt) {
+    // Note: the subject expression has already been walked in the outer
+    // scope when the placeholder was created, so it isn't walked again here.
+
+    // In a single pass over the cases, compute the set of cases that can be
+    // entered via fallthrough from another case.
+    llvm::DenseSet<CaseStmt *> casesWithFallthroughPredecessor;
+    for (auto *caseStmt : switchStmt->getCases()) {
+      if (!caseStmt->hasFallthroughDest())
+        continue;
+      if (auto *dest = caseStmt->getFallthroughDest().getPtrOrNull())
+        casesWithFallthroughPredecessor.insert(dest);
+    }
+
+    auto enclosingAvailability = getCurrentScope()->getAvailabilityContext();
+    for (auto *caseStmt : switchStmt->getCases()) {
+      // If a fallthrough statement could enter this case body from another
+      // case, matching this case's patterns isn't a precondition for
+      // executing the body. Avoid introducing a refined availability scope
+      // and walk the body directly in the placeholder scope.
+      if (casesWithFallthroughPredecessor.count(caseStmt)) {
+        walkCaseStmtChildren(caseStmt);
+        continue;
+      }
+
+      // Otherwise, compute the case body's effective availability as what's
+      // *common* to the matched enum elements: matching any one of the case
+      // label items is sufficient to enter the body, so we only refine when
+      // every item produces the same availability context.
+      std::optional<AvailabilityContext> bodyAvailability;
+      for (auto &item : caseStmt->getCaseLabelItems()) {
+        auto *element = getMatchedEnumElement(item.getPattern());
+        if (!element) {
+          bodyAvailability = std::nullopt;
+          break;
+        }
+        auto itemAvailability = enclosingAvailability;
+        itemAvailability.constrainWithDecl(element);
+
+        if (!bodyAvailability) {
+          bodyAvailability = itemAvailability;
+        } else if (*bodyAvailability != itemAvailability) {
+          bodyAvailability = std::nullopt;
+          break;
+        }
+      }
+
+      // Only introduce a new scope when the matched-element availability
+      // actually refines what's already in scope.
+      if (bodyAvailability && *bodyAvailability != enclosingAvailability) {
+        auto *caseBodyScope = AvailabilityScope::createForSwitchStmtCaseBody(
+            Context, caseStmt, getCurrentDeclContext(), getCurrentScope(),
+            *bodyAvailability);
+        // Walk the case label items in the outer scope: the patterns and
+        // `where` guards execute before entering the case body.
+        for (auto &item : caseStmt->getMutableCaseLabelItems()) {
+          if (auto *p = item.getPattern())
+            p->walk(*this);
+          if (auto *g = item.getGuardExpr())
+            g->walk(*this);
+        }
+        AvailabilityScopeBuilder(caseBodyScope, Context)
+            .build(caseStmt->getBody());
+        continue;
+      }
+
+      walkCaseStmtChildren(caseStmt);
+    }
+  }
+
+  /// Walks the patterns, where guards, and body of \p caseStmt in the current
+  /// scope.
+  void walkCaseStmtChildren(CaseStmt *caseStmt) {
+    for (auto &item : caseStmt->getMutableCaseLabelItems()) {
+      if (auto *p = item.getPattern())
+        p->walk(*this);
+      if (auto *g = item.getGuardExpr())
+        g->walk(*this);
+    }
+    if (auto *body = caseStmt->getBody())
+      body->walk(*this);
+  }
+
+  /// During the initial scope build, defers all switch-statement scope
+  /// construction by creating a placeholder availability scope that is
+  /// expanded lazily. This is necessary because the case label items haven't
+  /// been type-checked yet when the function body's availability scope is
+  /// built, so we can't yet tell which case bodies need refinement.
+  ///
+  /// Returns true if a placeholder has been created and the caller should
+  /// skip walking the switch's children.
+  bool buildSwitchStmtRefinementContext(SwitchStmt *switchStmt) {
+    // If parse recovery left us without a valid brace range, skip this
+    // statement and let the walker handle its (incomplete) children.
+    if (switchStmt->getLBraceLoc().isInvalid() ||
+        switchStmt->getRBraceLoc().isInvalid())
+      return false;
+
+    // Walk the subject expression in the *outer* scope. The placeholder's
+    // source range only covers the case bodies (between the braces), so the
+    // subject is excluded — that excludes any nested availability scopes
+    // induced by the subject from being added as out-of-range children of
+    // the placeholder.
+    if (auto *subject = switchStmt->getSubjectExpr())
+      subject->walk(*this);
+
+    auto *currentScope = getCurrentScope();
+    auto *placeholderScope = AvailabilityScope::createForSwitchStmt(
+        Context, switchStmt, getCurrentDeclContext(), currentScope,
+        currentScope->getAvailabilityContext());
+    placeholderScope->setNeedsExpansion(true);
+    return true;
   }
 
   /// Builds the availability scopes for the GuardStmt and pushes
@@ -1332,6 +1471,13 @@ evaluator::SideEffect ExpandChildAvailabilityScopesRequest::evaluate(
     AvailabilityScopeBuilder builder(parentScope, ctx);
     builder.prepareDeclForLazyExpansion(decl);
     builder.build(decl);
+  } else if (parentScope->getReason() ==
+             AvailabilityScope::Reason::SwitchStmt) {
+    auto *switchStmt = parentScope->getIntroductionNode().getAsSwitchStmt();
+    auto *dc = parentScope->getIntroductionNode().getDeclContext();
+    ASTContext &ctx = dc->getASTContext();
+    AvailabilityScopeBuilder builder(parentScope, ctx);
+    builder.expandSwitchStmtRefinementContext(switchStmt);
   }
   return evaluator::SideEffect();
 }

--- a/test/Availability/availability_custom_domains.swift
+++ b/test/Availability/availability_custom_domains.swift
@@ -610,3 +610,97 @@ func testP() { // expected-note 2{{add '@available' attribute to enclosing globa
   acceptP(MyType3.self)  // expected-error{{conformance of 'MyType3' to 'P' is only available in DisabledDomain}}
   // expected-note@-1{{add 'if #available' version check}}
 }
+
+enum E {
+  case unrestricted
+
+  @available(DynamicDomain)
+  case onlyInDynamic
+
+  @available(DynamicDomain)
+  case alsoInDynamic
+
+  @available(DisabledDomain, unavailable)
+  case unavailableInDisabled
+}
+
+func testSwitch(e: E) { // expected-note 5 {{add '@available' attribute to enclosing global function}}
+  switch e {
+  case .unrestricted:
+    availableInDynamicDomain() // expected-error {{'availableInDynamicDomain()' is only available in DynamicDomain}}
+      // expected-note@-1 {{add 'if #available' version check}}
+    unavailableInDisabledDomain() // expected-error {{'unavailableInDisabledDomain()' is unavailable}}
+  case .onlyInDynamic:
+    availableInDynamicDomain()
+  case .alsoInDynamic:
+    availableInDynamicDomain()
+  case .unavailableInDisabled:
+    unavailableInDisabledDomain()
+  }
+
+  // Matching elements that share the same availability allows refinement.
+  switch e {
+  case .onlyInDynamic, .alsoInDynamic:
+    availableInDynamicDomain()
+  default:
+    break
+  }
+
+  // Matching elements with differing availability suppresses refinement.
+  switch e {
+  case .unrestricted, .onlyInDynamic:
+    availableInDynamicDomain() // expected-error {{'availableInDynamicDomain()' is only available in DynamicDomain}}
+      // expected-note@-1 {{add 'if #available' version check}}
+  default:
+    break
+  }
+
+  let x = 1
+  switch (e, x) {
+  case (.onlyInDynamic, 1):
+    availableInDynamicDomain() // expected-error {{'availableInDynamicDomain()' is only available in DynamicDomain}}
+      // expected-note@-1 {{add 'if #available' version check}}
+  default:
+    break
+  }
+
+  // Fall-through statements suppress refinement.
+  switch e {
+  case .unrestricted:
+    fallthrough
+  case .onlyInDynamic:
+    availableInDynamicDomain() // expected-error {{'availableInDynamicDomain()' is only available in DynamicDomain}}
+      // expected-note@-1 {{add 'if #available' version check}}
+  default:
+    break
+  }
+
+  // FIXME: [availability] Refinement could be supported here.
+  switch e {
+  case .onlyInDynamic:
+    fallthrough
+  case .alsoInDynamic:
+    availableInDynamicDomain() // expected-error {{'availableInDynamicDomain()' is only available in DynamicDomain}}
+      // expected-note@-1 {{add 'if #available' version check}}
+  default:
+    break
+  }
+}
+
+// Refinement also applies inside `switch` expressions.
+@available(DynamicDomain)
+func getDynamicDomainValue() -> Int { 0 }
+
+func testSwitchExpr(e: E) -> Int { // expected-note 2 {{add '@available' attribute to enclosing global function}}
+  return switch e {
+  case .unrestricted:
+    getDynamicDomainValue() // expected-error {{'getDynamicDomainValue()' is only available in DynamicDomain}}
+    // expected-note@-1 {{add 'if #available' version check}}
+  case .onlyInDynamic, .alsoInDynamic:
+    // FIXME: https://github.com/swiftlang/swift/issues/89721
+    getDynamicDomainValue() // expected-error {{'getDynamicDomainValue()' is only available in DynamicDomain}}
+    // expected-note@-1 {{add 'if #available' version check}}
+  default:
+    0
+  }
+}

--- a/test/Availability/availability_scopes_macos.swift
+++ b/test/Availability/availability_scopes_macos.swift
@@ -330,6 +330,7 @@ struct SomeStruct {
 // CHECK-NEXT: {{^}}  (decl version=51 decl=SomeEnum
 // CHECK-NEXT: {{^}}    (decl version=52 decl=a
 // CHECK-NEXT: {{^}}    (decl version=53 decl=b
+// CHECK-NEXT: {{^}}    (decl version=51 unavailable=macOS decl=d
 
 @available(OSX 51, *)
 enum SomeEnum {
@@ -338,6 +339,56 @@ enum SomeEnum {
 
   @available(OSX 53, *)
   case b, c
+
+  @available(OSX, unavailable)
+  case d
+
+  case e
+}
+
+// CHECK-NEXT: {{^}}  (decl version=51 decl=switchStatementRefinement(e:)
+// CHECK-NEXT: {{^}}    (switch_stmt version=51
+// CHECK-NEXT: {{^}}      (switch_case_body version=52
+// CHECK-NEXT: {{^}}        (condition_following_availability version=53
+// CHECK-NEXT: {{^}}        (if_then version=53
+// CHECK-NEXT: {{^}}          (decl version=54 decl=funcInIfThen()
+// CHECK-NEXT: {{^}}      (switch_case_body version=53
+// CHECK-NEXT: {{^}}      (switch_case_body version=53
+// CHECK-NEXT: {{^}}      (switch_case_body version=51 unavailable=macOS
+
+@available(OSX 51, *)
+func switchStatementRefinement(e: SomeEnum) {
+  switch e {
+  case .a:
+    if #available(OSX 53, *) {
+      @available(OSX 54, *)
+      func funcInIfThen() { }
+    }
+    someFunction()
+  case .b:
+    someFunction()
+  case .c:
+    someFunction()
+  case .d:
+    someFunction()
+  case .e:
+    someFunction()
+  }
+}
+
+// Refinement also applies inside `switch` expressions.
+
+// CHECK-NEXT: {{^}}  (decl version=51 decl=switchExpressionRefinement(e:)
+// CHECK-NEXT: {{^}}    (switch_stmt version=51
+// CHECK-NEXT: {{^}}      (switch_case_body version=52
+@available(OSX 51, *)
+func switchExpressionRefinement(e: SomeEnum) -> Int {
+  return switch e {
+  case .a:
+    1
+  default:
+    0
+  }
 }
 
 // CHECK-NEXT: {{^}}  (decl_implicit version=50 decl=someComputedGlobalVar

--- a/test/Availability/availability_versions.swift
+++ b/test/Availability/availability_versions.swift
@@ -647,7 +647,7 @@ enum CompassPoint {
 func functionTakingEnumIntroducedOn52(_ e: EnumIntroducedOn52) { }
 
 func useEnums() {
-      // expected-note@-1 3{{add '@available' attribute to enclosing global function}}
+      // expected-note@-1 2{{add '@available' attribute to enclosing global function}}
   let _: CompassPoint = .North // expected-error {{'CompassPoint' is only available in macOS 51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
@@ -686,13 +686,89 @@ func useEnums() {
         markUsed("WithAvailableByEnumElementPayload2")
       case .WithAvailableByEnumElementPayload(let p):
         markUsed("WithAvailableByEnumElementPayload")
-
-        // For the moment, we do not incorporate enum element availability into 
-        // scope construction. Perhaps we should?
-        functionTakingEnumIntroducedOn52(p)  // expected-error {{'functionTakingEnumIntroducedOn52' is only available in macOS 52 or newer}}
-          
-          // expected-note@-2 {{add 'if #available' version check}}
+        functionTakingEnumIntroducedOn52(p)
     }
+  }
+}
+
+@available(OSX, introduced: 51)
+func switchStatements(point: CompassPoint) {
+  // Matching `case .West` (which is `@available(OSX 52, *)`) refines the body
+  // so that OSX 52 APIs can be called without an `if #available` guard.
+  switch point {
+  case .North, .South, .East:
+    _ = globalFuncAvailableOn52() // expected-error {{'globalFuncAvailableOn52()' is only available in macOS 52 or newer}}
+    // expected-note@-1 {{add 'if #available' version check}}
+  case .West:
+    _ = globalFuncAvailableOn52()
+  default:
+    break
+  }
+
+  // A `where` guard does not disable refinement.
+  switch point {
+  case .West where true:
+    _ = globalFuncAvailableOn52()
+  default:
+    break
+  }
+
+  // Multiple case label items that share the same availability still allow
+  // refinement to that common availability.
+  switch point {
+  case .WithAvailableByEnumElementPayload1(_), .WithAvailableByEnumElementPayload2(_):
+    _ = globalFuncAvailableOn52()
+  default:
+    break
+  }
+
+  // When case label items have different availability, the body can be reached
+  // through whichever item happens to match so the body cannot be refined.
+  switch point {
+  case .North, .West:
+    _ = globalFuncAvailableOn52() // expected-error {{'globalFuncAvailableOn52()' is only available in macOS 52 or newer}}
+    // expected-note@-1 {{add 'if #available' version check}}
+  default:
+    break
+
+    // Fallthrough from another case always disables refinement.
+    switch point {
+    case .North:
+      fallthrough
+    case .West:
+      _ = globalFuncAvailableOn52() // expected-error {{'globalFuncAvailableOn52()' is only available in macOS 52 or newer}}
+      // expected-note@-1 {{add 'if #available' version check}}
+    default:
+      break
+    }
+
+    // Refinement still applies for cases that aren't reachable via fallthrough.
+    switch point {
+    case .North:
+      fallthrough
+    case .West:
+      _ = globalFuncAvailableOn52() // expected-error {{'globalFuncAvailableOn52()' is only available in macOS 52 or newer}}
+      // expected-note@-1 {{add 'if #available' version check}}
+    case .WithAvailableByEnumElementPayload1(_):
+      _ = globalFuncAvailableOn52()
+    default:
+      break
+    }
+  }
+}
+
+@available(OSX, introduced: 51)
+func switchExprs(point: CompassPoint) -> Int {
+  return switch point {
+  case .North, .South, .East:
+    globalFuncAvailableOn52() // expected-error {{'globalFuncAvailableOn52()' is only available in macOS 52 or newer}}
+    // expected-note@-1 {{add 'if #available' version check}}
+  case .West:
+    // FIXME: https://github.com/swiftlang/swift/issues/89721
+    globalFuncAvailableOn52() // expected-error {{'globalFuncAvailableOn52()' is only available in macOS 52 or newer}}
+    // expected-note@-1 {{add 'if #available' version check}}
+  default:
+    0
   }
 }
 


### PR DESCRIPTION
When a case statement body inside a switch statement is only reachable if a specific enum element matches the switch subject, the compiler now generates an availability scope for the case body that matches the availability of the enum element:

```
@available(macOS 26, *)
func f() -> Int { 0 }

enum E {
  @available(macOS 26, *)
  case a
}

func multiplex(_ e: E) -> Int {
  switch e {
  case .a:
    return f() // OK, .a is only available in macOS 26
  }
}
```

Supporting the same refinement for cases in switch expressions will need to be handled as a follow-up (https://github.com/swiftlang/swift/issues/89721) as it may require changes to the order in which switch expression case bodies are type checked relative to the case label.

Resolves https://github.com/swiftlang/swift/issues/46662 and rdar://20937722.
