### PR TITLE
AST: Introduce the UnnecessaryUnsafe diagnostic group

### DIFF
--- a/include/swift/AST/DiagnosticGroups.def
+++ b/include/swift/AST/DiagnosticGroups.def
@@ -103,6 +103,7 @@ GROUP(TrailingClosureMatching,none,"trailing-closure-matching")
 GROUP(UnavailableSendableConformance,none,"unavailable-sendable-conformance")
 GROUP(UnknownWarningGroup,none,"unknown-warning-group")
 GROUP(UnnecessaryEffectMarker,none,"unnecessary-effect-marker")
+GROUP(UnnecessaryUnsafe,none,"unnecessary-unsafe")
 GROUP(UnsupportedScopedImport,none,"unsupported-scoped-import")
 GROUP(UnusedImportAccess,none,"unused-import-access")
 GROUP(UntypedThrows,DefaultIgnoreWarnings,"untyped-throws")
@@ -123,6 +124,8 @@ GROUP_LINK(RegionIsolation,RegionIsolationCrossIsolationDataRace)
 GROUP_LINK(RegionIsolation,RegionIsolationUnknownPattern)
 
 GROUP_LINK(StrictLanguageFeatures, UnrecognizedStrictLanguageFeatures)
+
+GROUP_LINK(UnnecessaryEffectMarker,UnnecessaryUnsafe)
 
 #define UNDEFINE_DIAGNOSTIC_GROUPS_MACROS
 #include "swift/AST/DefineDiagnosticGroupsMacros.h"

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -8867,9 +8867,9 @@ GROUPED_WARNING(unsafe_without_unsafe,StrictMemorySafety,none,
       "expression uses unsafe constructs but is not marked with 'unsafe'", ())
 GROUPED_WARNING(for_unsafe_without_unsafe,StrictMemorySafety,none,
       "for-in loop uses unsafe constructs but is not marked with 'unsafe'", ())
-GROUPED_WARNING(no_unsafe_in_unsafe,UnnecessaryEffectMarker,none,
+GROUPED_WARNING(no_unsafe_in_unsafe,UnnecessaryUnsafe,none,
         "no unsafe operations occur within 'unsafe' expression", ())
-GROUPED_WARNING(no_unsafe_in_unsafe_for,UnnecessaryEffectMarker,none,
+GROUPED_WARNING(no_unsafe_in_unsafe_for,UnnecessaryUnsafe,none,
         "no unsafe operations occur within 'unsafe' for-in loop", ())
 NOTE(make_subclass_unsafe,none,
      "make class %0 '@unsafe' to allow unsafe overrides of safe superclass "

--- a/test/Unsafe/safe.swift
+++ b/test/Unsafe/safe.swift
@@ -99,7 +99,7 @@ func testUnsafeAsSequenceForEach() {
 
   for unsafe _ in unsafe uas { } // expected-warning{{no unsafe operations occur within 'unsafe' expression}}
 
-  for unsafe _ in [1, 2, 3] { } // expected-warning{{no unsafe operations occur within 'unsafe' for-in loop}}
+  for unsafe _ in [1, 2, 3] { } // expected-warning{{no unsafe operations occur within 'unsafe' for-in loop}}{{group-name=UnnecessaryUnsafe}}
 }
 
 func testForInUnsafeAmbiguity(_ integers: [Int]) {

--- a/test/Unsafe/unsafe_nonstrict.swift
+++ b/test/Unsafe/unsafe_nonstrict.swift
@@ -14,7 +14,7 @@ func acceptP<T: P>(_: T) { }
 func testItAll(ut: UnsafeType, x: X, i: Int) {
   _ = unsafe ut
   unsafe acceptP(x)
-  _ = unsafe i // expected-warning{{no unsafe operations occur within 'unsafe' expression}}
+  _ = unsafe i // expected-warning{{no unsafe operations occur within 'unsafe' expression}}{{group-name=UnnecessaryUnsafe}}
 }
 
 func superDuperUnsafe(_ bytes: UnsafeRawBufferPointer) {

--- a/userdocs/diagnostics/diagnostic-groups.md
+++ b/userdocs/diagnostics/diagnostic-groups.md
@@ -58,6 +58,7 @@ Or upgrade all warnings except deprecated declaration to errors:
 - <doc:unavailable-sendable-conformance>
 - <doc:unknown-warning-group>
 - <doc:unnecessary-effect-marker>
+- <doc:unnecessary-unsafe>
 - <doc:unsupported-scoped-import>
 - <doc:untyped-throws>
 - <doc:unused-import-access>
@@ -123,6 +124,7 @@ Or upgrade all warnings except deprecated declaration to errors:
 - <doc:region-isolation-unknown-pattern>
 - <doc:unknown-warning-group>
 - <doc:unnecessary-effect-marker>
+- <doc:unnecessary-unsafe>
 - <doc:availability-unrecognized-name>
 - <doc:mutable-global-variable>
 - <doc:unsupported-scoped-import>

--- a/userdocs/diagnostics/unnecessary-effect-marker.md
+++ b/userdocs/diagnostics/unnecessary-effect-marker.md
@@ -34,3 +34,6 @@ func caller() async throws {
 }
 ```
 
+## See Also
+
+- <doc:unnecessary-unsafe>

--- a/userdocs/diagnostics/unnecessary-unsafe.md
+++ b/userdocs/diagnostics/unnecessary-unsafe.md
@@ -1,0 +1,40 @@
+# Unnecessary unsafe (UnnecessaryUnsafe)
+
+## Overview
+
+This warning is emitted when an `unsafe` marker appears on an expression that contains no unsafe operations. The marker may have been added preemptively or the unsafe operation it was needed for may no longer be considered unsafe.
+
+This group is a subgroup of <doc:unnecessary-effect-marker>.
+
+## Example
+
+Some APIs with 'unsafe' in their names are actually annotated with `@safe`. For example, invoking `Array.withUnsafeBytes(_:)` does not require an `unsafe` marker when `-strict-memory-safety` is specified:
+
+```swift
+func process(_ values: [UInt8]) {
+  // warning: no unsafe operations occur within 'unsafe' expression
+  unsafe values.withUnsafeBytes { _ in
+    print("Processing \(values.count) bytes")
+  }
+}
+```
+
+The call to `withUnsafeBytes(_:)` by itself is safe and the closure body performs no unsafe operations, so the outer `unsafe` is unnecessary. The unsafe operation would be using the buffer's pointer inside the closure, which can be acknowledged closer to the source of the unsafety.
+
+## How to fix
+
+Remove the `unsafe` marker from the outer expression. If a use inside the closure is the actually-unsafe operation, mark only that use:
+
+```swift
+func process(_ values: [UInt8]) {
+  values.withUnsafeBytes { buffer in
+    let first = unsafe buffer.first ?? 0
+    print("First byte: \(first)")
+  }
+}
+```
+
+## See Also
+
+- <doc:unnecessary-effect-marker>
+- <doc:strict-memory-safety>


### PR DESCRIPTION
Put diagnostics about unnecessary `unsafe` markers in a dedicated group.

Follow-up to https://github.com/swiftlang/swift/pull/89161.

Resolves rdar://177377552.
