### PR TITLE
[6.4] SILGen: laziness fixes for properties defined in secondary files

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -2677,6 +2677,13 @@ public:
   /// Returns the typechecked binding entry at the given index.
   const PatternBindingEntry *getCheckedPatternBindingEntry(unsigned i) const;
 
+  /// Returns the typechecked pattern at the given index, if any.
+  Pattern *getCheckedPattern(unsigned i) const {
+    if (auto *entry = getCheckedPatternBindingEntry(i))
+      return entry->getPattern();
+    return nullptr;
+  }
+
   /// Clean up walking the initializers for the pattern
   class InitIterator {
 

--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -1571,10 +1571,7 @@ void SILGenFunction::emitMemberInitializationViaInitAccessor(
   if (!init)
     return;
 
-  // Force the pattern's type to be resolved.
-  (void)member->getCheckedPatternBindingEntry(0);
-
-  auto *varPattern = member->getPattern(0);
+  auto *varPattern = member->getCheckedPattern(0);
 
   // Cleanup after this initialization.
   FullExpr scope(Cleanups, varPattern);
@@ -1657,10 +1654,7 @@ void SILGenFunction::emitMemberInitializer(DeclContext *dc, VarDecl *selfDecl,
     }
     }
 
-    // Force the pattern's type to be resolved.
-    (void)field->getCheckedPatternBindingEntry(i);
-
-    auto *varPattern = field->getPattern(i);
+    auto *varPattern = field->getCheckedPattern(i);
 
     // Cleanup after this initialization.
     FullExpr scope(Cleanups, varPattern);

--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -1613,6 +1613,9 @@ void SILGenFunction::emitMemberInitializer(DeclContext *dc, VarDecl *selfDecl,
   assert(!field->isStatic());
 
   for (auto i : range(field->getNumPatternEntries())) {
+    if (auto *var = field->getAnchoringVarDecl(i))
+      (void)var->getImplInfo(); // trigger expansion of attached accessor macros
+
     auto init = field->getExecutableInit(i);
     if (!init)
       continue;

--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -1571,6 +1571,9 @@ void SILGenFunction::emitMemberInitializationViaInitAccessor(
   if (!init)
     return;
 
+  // Force the pattern's type to be resolved.
+  (void)member->getCheckedPatternBindingEntry(0);
+
   auto *varPattern = member->getPattern(0);
 
   // Cleanup after this initialization.
@@ -1650,6 +1653,9 @@ void SILGenFunction::emitMemberInitializer(DeclContext *dc, VarDecl *selfDecl,
       }
     }
     }
+
+    // Force the pattern's type to be resolved.
+    (void)field->getCheckedPatternBindingEntry(i);
 
     auto *varPattern = field->getPattern(i);
 

--- a/test/SILGen/Inputs/accessor_macro_multifile_other.swift
+++ b/test/SILGen/Inputs/accessor_macro_multifile_other.swift
@@ -1,0 +1,7 @@
+@attached(accessor, names: named(get))
+public macro AddGetter() = #externalMacro(module: "MacroDefinition", type: "AddGetterMacro")
+
+public struct Holder {
+  @AddGetter
+  var foo: Int = 0
+}

--- a/test/SILGen/Inputs/init_accessor_multifile_other.swift
+++ b/test/SILGen/Inputs/init_accessor_multifile_other.swift
@@ -1,0 +1,15 @@
+public struct Holder {
+  var foo: Int {
+    @storageRestrictions(initializes: backing)
+    init(initialValue) {}
+    get { fatalError() }
+  }
+
+  var backing: Int
+
+  var bar: Int = 0 {
+    @storageRestrictions(initializes: backing)
+    init(initialValue) {}
+    get { fatalError() }
+  }
+}

--- a/test/SILGen/accessor_macro_multifile.swift
+++ b/test/SILGen/accessor_macro_multifile.swift
@@ -1,0 +1,14 @@
+// REQUIRES: swift_swift_parser
+
+// RUN: %empty-directory(%t)
+// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/../Macros/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath
+
+// RUN: %target-swift-emit-silgen -load-plugin-library %t/%target-library-name(MacroDefinition) -primary-file %s %S/Inputs/accessor_macro_multifile_other.swift -module-name AccMacroMulti | %FileCheck %s
+
+extension Holder {
+  public init(action f: () -> Void) {}
+}
+
+// CHECK-LABEL: sil [ossa] @$s13AccMacroMulti6HolderV6actionACyyXE_tcfC :
+// CHECK-NOT:     struct_element_addr {{.*}} #Holder.foo
+// CHECK:       } // end sil function '$s13AccMacroMulti6HolderV6actionACyyXE_tcfC'

--- a/test/SILGen/init_accessor_multifile.swift
+++ b/test/SILGen/init_accessor_multifile.swift
@@ -1,0 +1,11 @@
+// RUN: %target-swift-emit-silgen -primary-file %s %S/Inputs/init_accessor_multifile_other.swift -module-name InitAccMulti | %FileCheck %s
+
+// Constructor in this file implicitly refers to Holder's stored properties declared in
+// the other file. Triggers a case where the type of a property may not be resolved
+// during SILGen in emitMemberInitializationViaInitAccessor.
+
+extension Holder {
+  public init(action f: () -> Void) {}
+}
+
+// CHECK-LABEL: sil [ossa] @$s12InitAccMulti6HolderV6actionACyyXE_tcfC :


### PR DESCRIPTION
- Explanation: Defining init accessors or applying a macro to a member property of a type defined in another file can cause SILGen to crash due to incorrect responses from APIs in the AST, whose answers change based on whether a request was triggered or not by Sema when it performs typechecking. Those paths aren't being hit when the type appears in a non-primary file and this problem seems to be endemic. So as a workaround, we need to explicitly force these requests in a few more places.
- Scope: SILGen
- Issues: rdar://176892954 / https://github.com/swiftlang/swift/issues/89808
- Risk: Low. There are already several instances throughout Sema call `getCheckedPatternBindingEntry` and `getImplInfo` just to trigger a request. We will now trigger macro expansions when we hadn't before, but they're needed to know whether a property is stored or computed.
- Testing: Manual testing and regression tests included
- Original PRs: 
    - https://github.com/swiftlang/swift/pull/89653 
    - https://github.com/swiftlang/swift/pull/89813
- Reviewers: Pavel