### PR TITLE
[AST] Quote or print kind of DeclAttribute automatically, update tests

### DIFF
--- a/docs/Diagnostics.md
+++ b/docs/Diagnostics.md
@@ -175,6 +175,11 @@ diagnostic arguments of a given type.
 - `%kind0` - Replaced with `attribute 'foo'`, whereas `%0` is replaced with
   `'@foo'`.
 
+#### `DeclAttribute`
+
+- `%kind0` - Replaced with `attribute 'foo'` or `modifier 'foo'`, whereas `%0`
+  is replaced with `'@foo'` or `'foo'` based on if it's an attribute or modifier.
+
 Note: If your diagnostic could apply to accessors, be careful how you format the declaration's name; accessors have an empty name, so you need to display their accessor kind and the name of their storage decl instead. Inserting the name with a `Decl *` parameter will handle these complications automatically; if you want to use `DeclName` or `Identifier` instead, you'll probably need a separate version of the diagnostic for accessors. 
 
 ### Diagnostic Verifier ###

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -482,7 +482,7 @@ ERROR(operator_decl_no_fixity,none,
 ERROR(operator_decl_expected_precedencegroup, none,
       "expected precedence group name after ':' in operator declaration", ())
 ERROR(operator_decl_should_not_contain_other_attributes, none, 
-      "unexpected attribute %0 in operator declaration", (DeclAttribute))
+      "unexpected %kind0 in operator declaration", (DeclAttribute))
 
 // PrecedenceGroup
 ERROR(precedencegroup_not_infix,none,
@@ -1589,7 +1589,7 @@ WARNING(attr_renamed_to_modifier_warning, none,
 ERROR(attr_name_close_match, none,
       "no attribute named '@%0'; did you mean '@%1'?", (StringRef, StringRef))
 ERROR(attr_unsupported_on_target, none,
-      "attribute %0 is unsupported on target '%1'", (DeclAttribute, StringRef))
+      "%kind0 is unsupported on target '%1'", (DeclAttribute, StringRef))
 ERROR(attr_name_unsupported_on_target, none,
       "attribute '%0' is unsupported on target '%1'", (StringRef, StringRef))
 

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -307,8 +307,8 @@ ERROR(class_cannot_be_addressable_for_dependencies,none,
       "a class cannot be '@_addressableForDependencies'", ())
 
 ERROR(unsupported_closure_attr,none,
-      "%select{attribute |}0%1 is not supported on a closure",
-      (bool, DeclAttribute))
+      "%0 is not supported on a closure",
+      (DeclAttribute))
 
 NOTE(suggest_partial_overloads,none,
       "overloads for '%1' exist with these %select{"
@@ -1824,7 +1824,7 @@ ERROR(attribute_requires_single_argument,none,
       "%0 requires a function with one argument", (DeclAttribute))
 
 ERROR(attribute_requires_experimental_feature,none,
-      "'%0' is an experimental feature; use '-enable-experimental-feature %1'",
+      "%0 is an experimental feature; use '-enable-experimental-feature %1'",
       (DeclAttribute, StringRef))
 
 ERROR(nominal_type_not_attribute,none,
@@ -2280,13 +2280,13 @@ ERROR(attr_decl_async,none,
       "%0 %kindonly1 cannot be asynchronous", (DeclAttribute, const FuncDecl *))
 
 ERROR(attr_only_at_non_local_scope, none,
-      "attribute %0 can only be used in a non-local scope", (DeclAttribute))
+      "%kind0 can only be used in a non-local scope", (DeclAttribute))
 ERROR(attr_name_only_at_non_local_scope, none,
       "attribute '%0' can only be used in a non-local scope", (StringRef))
 ERROR(attr_only_at_non_generic_scope, none,
-      "attribute %0 cannot be used in a generic context", (DeclAttribute))
+      "%kind0 cannot be used in a generic context", (DeclAttribute))
 ERROR(attr_only_on_static_properties, none,
-      "properties with attribute %0 must be static", (DeclAttribute))
+      "properties with %kind0 must be static", (DeclAttribute))
 
 ERROR(access_control_in_protocol,none,
       "%0 modifier cannot be used in protocols", (DeclAttribute))
@@ -2346,12 +2346,12 @@ ERROR(access_control_requires_package_name, none,
       "requires a package name; set it with the compiler flag -package-name",
       (bool, const Decl*))
 ERROR(invalid_decl_attribute,none,
-      "'%0' attribute cannot be applied to this declaration", (DeclAttribute))
+      "%0 attribute cannot be applied to this declaration", (DeclAttribute))
 ERROR(attr_invalid_on_decl_kind,none,
-      "'%0' attribute cannot be applied to %kindonly1 declarations",
+      "%0 attribute cannot be applied to %kindonly1 declarations",
       (DeclAttribute, const Decl *))
 ERROR(attr_invalid_in_context,none,
-      "'%0' attribute cannot be applied to declaration in %kindonly1",
+      "%0 attribute cannot be applied to declaration in %kindonly1",
       (DeclAttribute, const Decl *))
 ERROR(invalid_decl_modifier,none,
       "%0 modifier cannot be applied to this declaration", (DeclAttribute))
@@ -2425,7 +2425,7 @@ NOTE(option_set_empty_set_init,none,
      "use [] to silence this warning", ())
 
 ERROR(originally_definedin_topleve_decl,none,
-      "'%0' is only applicable to top-level decl", (DeclAttribute))
+      "%0 is only applicable to top-level decl", (DeclAttribute))
 
 ERROR(originally_definedin_must_not_before_available_version,none,
       "symbols are moved to the current module before they were available in "
@@ -2775,7 +2775,7 @@ ERROR(access_level_on_import_unsupported, none,
       "are accepted",
       (DeclAttribute))
 ERROR(access_level_conflict_with_exported,none,
-      "'%0' is incompatible with %1; it can only be applied to public imports",
+      "%0 is incompatible with %1; it can only be applied to public imports",
       (DeclAttribute, DeclAttribute))
 NOTE(module_imported_here,none,
      "module %0 imported as '%select{private|fileprivate|internal|package|%ERROR|%ERROR}1' here",
@@ -3925,9 +3925,9 @@ ERROR(enum_with_raw_type_case_with_argument,none,
 NOTE(enum_raw_type_here,none,
      "declared raw type %0 here", (Type))
 ERROR(objc_enum_no_raw_type,none,
-      "'%0' enum must declare an integer raw type", (DeclAttribute))
+      "%0 enum must declare an integer raw type", (DeclAttribute))
 ERROR(objc_enum_raw_type_not_integer,none,
-      "'%0' enum raw type %1 is not an integer type", (DeclAttribute, Type))
+      "%0 enum raw type %1 is not an integer type", (DeclAttribute, Type))
 ERROR(enum_non_integer_raw_value_auto_increment,none,
       "enum case must declare a raw value when the preceding raw value is not an integer", ())
 ERROR(enum_non_integer_convertible_raw_type_no_value,none,
@@ -4242,33 +4242,33 @@ ERROR(attr_only_valid_on_func_or_init_params,none,
 ERROR(attr_not_on_variadic_parameters,none,
       "'%0' must not be used on variadic parameters", (StringRef))
 ERROR(attr_not_on_stored_properties,none,
-      "'%0' must not be used on stored properties", (DeclAttribute))
+      "%0 must not be used on stored properties", (DeclAttribute))
 ERROR(attr_not_on_computed_properties,none,
-      "'%0' must not be used on computed properties", (DeclAttribute))
+      "%0 must not be used on computed properties", (DeclAttribute))
 
 WARNING(attr_has_no_effect_on_decl_with_access_level,none,
-       "'%0' does not have any effect on "
+       "%0 does not have any effect on "
        "%select{private|fileprivate|internal|package|%error|%error}1 declarations",
        (DeclAttribute, AccessLevel))
 ERROR(attr_not_on_decl_with_invalid_access_level,none,
-      "'%0' may not be used on "
+      "%0 may not be used on "
       "%select{private|fileprivate|internal|package|public|%error}1 declarations",
       (DeclAttribute, AccessLevel))
 
 ERROR(attr_has_no_effect_decl_not_available_before,none,
-      "'%0' has no effect because %1 is not "
+      "%0 has no effect because %1 is not "
       "available before %2 %3",
       (DeclAttribute, const ValueDecl *, AvailabilityDomain, AvailabilityRange))
 
 ERROR(attr_has_no_effect_on_unavailable_decl,none,
-      "'%0' has no effect because %1 is unavailable on %2",
+      "%0 has no effect because %1 is unavailable on %2",
       (DeclAttribute, const ValueDecl *, AvailabilityDomain))
 
 ERROR(attr_ambiguous_reference_to_decl,none,
       "ambiguous reference to %0 in %1 attribute", (DeclNameRef, DeclAttribute))
 
 ERROR(attr_contains_multiple_versions_for_platform,none,
-      "'%0' contains multiple versions for %1", (DeclAttribute, StringRef))
+      "%0 contains multiple versions for %1", (DeclAttribute, StringRef))
 
 ERROR(override_final,none,
       "%kindonly0 overrides a 'final' %kindonly1",
@@ -4286,23 +4286,23 @@ ERROR(final_not_allowed_here,none,
       "subscripts", ())
 
 ERROR(attr_incompatible_with_attr,none,
-      "'%0' cannot be used with '%1'",
+      "%0 cannot be used with %1",
       (DeclAttribute, DeclAttribute))
 
 ERROR(attr_incompatible_with_non_final,none,
-      "'%0' cannot be applied to a non-final %kindonly1",
+      "%0 cannot be applied to a non-final %kindonly1",
       (DeclAttribute, const ValueDecl *))
 
 ERROR(attr_incompatible_with_override,none,
-      "'%0' cannot be combined with 'override'",
+      "%0 cannot be combined with 'override'",
       (DeclAttribute))
 
 ERROR(attr_incompatible_with_objc,none,
-      "'%0' must not be used on an '@objc' %kindonly1",
+      "%0 must not be used on an '@objc' %kindonly1",
       (DeclAttribute, const ValueDecl *))
 
 ERROR(attr_unusable_in_protocol,none,
-      "'%0' cannot be used inside a protocol declaration",
+      "%0 cannot be used inside a protocol declaration",
       (DeclAttribute))
 
 ERROR(final_not_on_accessors,none,
@@ -7244,29 +7244,29 @@ ERROR(availability_domain_requires_feature, none,
       (AvailabilityDomain, StringRef))
 
 WARNING(attr_availability_expected_deprecated_version, none,
-       "expected version number with 'deprecated' in '%0' attribute for %1",
+       "expected version number with 'deprecated' in %0 attribute for %1",
        (const DeclAttribute, AvailabilityDomain))
 WARNING(attr_availability_cannot_be_used_for_domain, none,
-       "'%0' cannot be used in '%1' attribute for %2",
+       "'%0' cannot be used in %1 attribute for %2",
        (StringRef, const DeclAttribute, AvailabilityDomain))
 WARNING(attr_availability_expected_version_spec, none,
-       "expected 'introduced', 'deprecated', or 'obsoleted' in '%0' attribute "
+       "expected 'introduced', 'deprecated', or 'obsoleted' in %0 attribute "
        "for %1", (const DeclAttribute, AvailabilityDomain))
 ERROR(attr_availability_domain_access, none,
       "availability domain '%0' is "
       "%select{private|fileprivate|internal|package|%error|%error}1 "
-      "and cannot be used in '%2' on "
+      "and cannot be used in %2 on "
       "%select{private|fileprivate|internal|package|public|%error}3 %kind4",
       (AvailabilityDomain, AccessLevel, DeclAttribute, AccessLevel,
        const Decl *))
 ERROR(attr_availability_domain_not_usable_from_inline, none,
-      "availability domain '%0' used in '%1' on %kind2 must be "
+      "availability domain '%0' used in %1 on %kind2 must be "
       "'@usableFromInline' or public",
       (AvailabilityDomain, DeclAttribute, const Decl *))
 
 GROUPED_WARNING(attr_availability_has_no_effect_domain_always_available,
                 AlwaysAvailableDomain, none,
-                "'%0' has no effect because '%1' is always available",
+                "%0 has no effect because '%1' is always available",
                 (DeclAttribute, AvailabilityDomain))
 GROUPED_WARNING(attr_availability_domain_always_available,
                 AlwaysAvailableDomain, none,
@@ -7451,7 +7451,7 @@ ERROR(public_decl_needs_availability, none,
       "with an introduction version", ())
 
 ERROR(attr_requires_decl_availability_for_platform,none,
-      "'%0' requires that %1 have explicit availability for %2",
+      "%0 requires that %1 have explicit availability for %2",
       (DeclAttribute, const Decl *, StringRef))
 
 // This doesn't display as an availability diagnostic, but it's
@@ -7627,7 +7627,7 @@ ERROR(class_designated_init_inlinable_resilient,none,
       "delegate to another initializer", (Type, unsigned))
 
 ERROR(attribute_invalid_on_stored_property,
-      none, "'%0' attribute cannot be applied to stored properties", (DeclAttribute))
+      none, "%0 attribute cannot be applied to stored properties", (DeclAttribute))
 
 ERROR(inlinable_dynamic_not_supported,
       none, "'@inlinable' attribute cannot be applied to 'dynamic' declarations", ())
@@ -8209,15 +8209,15 @@ ERROR(cannot_convert_default_value_type_to_argument_type, none,
 //------------------------------------------------------------------------------
 
 ERROR(attr_incompatible_with_back_deployed,none,
-      "'%0' cannot be applied to a back deployed %kind1",
+      "%0 cannot be applied to a back deployed %kind1",
       (DeclAttribute, const Decl *))
 
 WARNING(back_deployed_opaque_result_not_supported,none,
-      "'%0' cannot be applied to %kind1 because it has a 'some' return type",
+      "%0 cannot be applied to %kind1 because it has a 'some' return type",
       (DeclAttribute, const ValueDecl *))
 
 ERROR(back_deployed_requires_body,none,
-      "'%0' requires that %kind1 have a body",
+      "%0 requires that %kind1 have a body",
       (DeclAttribute, const ValueDecl *))
 
 //------------------------------------------------------------------------------

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -819,6 +819,29 @@ void swift::printClangTypeName(const clang::Type *Ty, llvm::raw_ostream &os) {
                          clang::PrintingPolicy{clang::LangOptions()}, "");
 }
 
+/// Print a reference to an attribute or modifier, writing its name via
+/// \p printName.
+///
+/// With the "kind" modifier this produces "attribute 'foo'"/"modifier
+/// 'foo'"; otherwise it produces the bare "'@foo'"/"'foo'".
+static void formatAttributeArgument(StringRef formatModifier,
+                                    bool isDeclModifier,
+                                    llvm::function_ref<void()> printName,
+                                    DiagnosticFormatOptions FormatOpts,
+                                    llvm::raw_ostream &Out) {
+  const bool includeKind = formatModifier == "kind";
+  ASSERT((includeKind || formatModifier.empty()) &&
+         "Improper modifier for attribute argument");
+
+  if (includeKind)
+    Out << (isDeclModifier ? "modifier " : "attribute ");
+  Out << FormatOpts.OpeningQuotationMark;
+  if (!includeKind && !isDeclModifier)
+    Out << '@';
+  printName();
+  Out << FormatOpts.ClosingQuotationMark;
+}
+
 /// Format a single diagnostic argument and write it to the given
 /// stream.
 static void formatDiagnosticArgument(StringRef Modifier,
@@ -1126,46 +1149,23 @@ static void formatDiagnosticArgument(StringRef Modifier,
 
   case DiagnosticArgumentKind::DeclAttribute: {
     auto *const attr = Arg.getAsDeclAttribute();
-    const auto printAttrName = [&] {
-      if (auto *custom = dyn_cast<CustomAttr>(attr)) {
-        custom->getTypeRepr()->print(Out);
-      } else {
-        Out << attr->getAttrName();
-      }
-    };
-
-    assert(Modifier.empty() &&
-           "Improper modifier for DeclAttribute argument");
-    if (Arg.getAsDeclAttribute()->isDeclModifier()) {
-      Out << FormatOpts.OpeningQuotationMark;
-      printAttrName();
-      Out << FormatOpts.ClosingQuotationMark;
-    } else {
-      Out << '@';
-      printAttrName();
-    }
+    formatAttributeArgument(
+        Modifier, attr->isDeclModifier(),
+        [&] {
+          if (auto *custom = dyn_cast<CustomAttr>(attr))
+            custom->getTypeRepr()->print(Out);
+          else
+            Out << attr->getAttrName();
+        },
+        FormatOpts, Out);
     break;
   }
-  case DiagnosticArgumentKind::TypeAttribute: {
-    bool useAtStyle = true;
-    if (Modifier == "kind") {
-      useAtStyle = false;
-    } else {
-      ASSERT(Modifier.empty() &&
-             "Improper modifier for TypeAttribute argument");
-    }
-
-    if (!useAtStyle) {
-      Out << "attribute ";
-    }
-    Out << FormatOpts.OpeningQuotationMark;
-    if (useAtStyle) {
-      Out << '@';
-    }
-    Out << Arg.getAsTypeAttribute()->getAttrName();
-    Out << FormatOpts.ClosingQuotationMark;
+  case DiagnosticArgumentKind::TypeAttribute:
+    formatAttributeArgument(
+        Modifier, /*isDeclModifier=*/false,
+        [&] { Out << Arg.getAsTypeAttribute()->getAttrName(); }, FormatOpts,
+        Out);
     break;
-  }
   case DiagnosticArgumentKind::AvailabilityDomain:
     assert(Modifier.empty() &&
            "Improper modifier for AvailabilityDomain argument");

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -8939,8 +8939,7 @@ public:
 
   void visitDeclAttribute(DeclAttribute *attr) {
     ctx.Diags
-        .diagnose(attr->getLocation(), diag::unsupported_closure_attr,
-                  attr->isDeclModifier(), attr)
+        .diagnose(attr->getLocation(), diag::unsupported_closure_attr, attr)
         .fixItRemove(attr->getRangeWithAt());
     attr->setInvalid();
   }
@@ -9022,8 +9021,7 @@ public:
 
     // Otherwise, it's an error.
     ctx.Diags
-        .diagnose(attr->getLocation(), diag::unsupported_closure_attr,
-                  attr->isDeclModifier(), attr)
+        .diagnose(attr->getLocation(), diag::unsupported_closure_attr, attr)
         .fixItRemove(attr->getRangeWithAt());
     attr->setInvalid();
   }

--- a/test/ASTGen/attrs.swift
+++ b/test/ASTGen/attrs.swift
@@ -153,7 +153,7 @@ struct ImplementsStruct: ImplementsProto {
 
 @_optimize(speed) func OspeedFunc() {}
 
-@_private(sourceFile: "none") func foo() {} // expected-error {{@_private may only be used on 'import' declarations}} {{1-31=}}
+@_private(sourceFile: "none") func foo() {} // expected-error {{'@_private' may only be used on 'import' declarations}} {{1-31=}}
 
 struct ProjectedValueStruct {
   @_projectedValueProperty($dummy)

--- a/test/AutoDiff/Sema/differentiable_features_disabled.swift
+++ b/test/AutoDiff/Sema/differentiable_features_disabled.swift
@@ -16,7 +16,7 @@ let _: @noDerivative Float
 func id(_ x: Float) -> Float {
   return x
 }
-// expected-error @+1 {{@derivative attribute used without importing module '_Differentiation'}}
+// expected-error @+1 {{'@derivative' attribute used without importing module '_Differentiation'}}
 @derivative(of: id)
 func jvpId(x: Float) -> (value: Float, differential: (Float) -> (Float)) {
   return (x, { $0 })

--- a/test/AutoDiff/Sema/differentiable_swift_without_import.swift
+++ b/test/AutoDiff/Sema/differentiable_swift_without_import.swift
@@ -1,7 +1,7 @@
 // RUN: %target-typecheck-verify-swift
 
 protocol P {
-  @differentiable(reverse) // expected-error {{@differentiable attribute used without importing module '_Differentiation'}}
+  @differentiable(reverse) // expected-error {{'@differentiable' attribute used without importing module '_Differentiation'}}
   func req()
 }
 

--- a/test/AutoDiff/compiler_crashers_fixed/tf1167-differentiable-attr-override-match.swift
+++ b/test/AutoDiff/compiler_crashers_fixed/tf1167-differentiable-attr-override-match.swift
@@ -12,12 +12,12 @@ public protocol Base {
   // expected-error @+1 {{cannot find type 'Differentiable' in scope}}
   associatedtype Output: Differentiable
 
-  // expected-error @+1 {{@differentiable attribute used without importing module '_Differentiation'}}
+  // expected-error @+1 {{'@differentiable' attribute used without importing module '_Differentiation'}}
   @differentiable(reverse, wrt: self)
   func callAsFunction(_ input: Input) -> Output
 }
 public protocol Derived: Base {
-  // expected-error @+1 {{@differentiable attribute used without importing module '_Differentiation'}}
+  // expected-error @+1 {{'@differentiable' attribute used without importing module '_Differentiation'}}
   @differentiable(reverse)
   func callAsFunction(_ input: Input) -> Output
 }

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -1801,7 +1801,7 @@ actor UserDefinedActorSelfDotMethod {
 }
 
 func requireSendableInheritContext(@_inheritActorContext _: @Sendable () -> ()) {}
-// expected-warning@-1 {{@_inheritActorContext only applies to '@isolated(any)' parameters or parameters with asynchronous function types; this will be an error in a future Swift language mode}}
+// expected-warning@-1 {{'@_inheritActorContext' only applies to '@isolated(any)' parameters or parameters with asynchronous function types; this will be an error in a future Swift language mode}}
 
 actor InvalidInheritedActorIsolation {
   func actorFunction() {} // expected-note {{calls to instance method 'actorFunction()' from outside of its actor context are implicitly asynchronous}}

--- a/test/Concurrency/attr_execution/conversions.swift
+++ b/test/Concurrency/attr_execution/conversions.swift
@@ -93,7 +93,7 @@ do {
 
 do {
   let _: () -> Void = { @concurrent in
-    // expected-error@-1 {{cannot use @concurrent on non-async closure}}{{none}}
+    // expected-error@-1 {{cannot use '@concurrent' on non-async closure}}{{none}}
   }
 }
 

--- a/test/Concurrency/isolated_parameters_typechecker_errors.swift
+++ b/test/Concurrency/isolated_parameters_typechecker_errors.swift
@@ -296,7 +296,7 @@ func isolatedClosures() {
   }
 }
 
-// expected-error@+3 {{global function 'allOfEm' has multiple actor-isolation attributes (@MainActor and 'nonisolated')}}
+// expected-error@+3 {{global function 'allOfEm' has multiple actor-isolation attributes ('@MainActor' and 'nonisolated')}}
 // expected-warning@+2 {{global function with 'isolated' parameter cannot be 'nonisolated'; this is an error in the Swift 6 language mode}}{{12-24=}}
 // expected-warning@+1 {{global function with 'isolated' parameter cannot have a global actor; this is an error in the Swift 6 language mode}}{{1-12=}}
 @MainActor nonisolated func allOfEm(_ a: isolated A) {

--- a/test/Concurrency/nonisolated_rules.swift
+++ b/test/Concurrency/nonisolated_rules.swift
@@ -297,7 +297,7 @@ class KlassA {
 
 @MainActor
 nonisolated struct Conflict {}
-// expected-error@-1 {{struct 'Conflict' has multiple actor-isolation attributes (@MainActor and 'nonisolated')}}
+// expected-error@-1 {{struct 'Conflict' has multiple actor-isolation attributes ('@MainActor' and 'nonisolated')}}
 
 struct B: Sendable {
   // expected-error@+1 {{'nonisolated' can not be applied to variable with non-'Sendable' type 'NonSendable}}

--- a/test/Concurrency/predates_concurrency.swift
+++ b/test/Concurrency/predates_concurrency.swift
@@ -370,7 +370,7 @@ func testSendableMetatypeDowngrades() {
 
 do {
   func test(@_inheritActorContext _: @Sendable () -> Void) async {
-    // expected-warning@-1 {{@_inheritActorContext only applies to '@isolated(any)' parameters or parameters with asynchronous function types; this will be an error in a future Swift language mode}}
+    // expected-warning@-1 {{'@_inheritActorContext' only applies to '@isolated(any)' parameters or parameters with asynchronous function types; this will be an error in a future Swift language mode}}
   }
 
   @MainActor

--- a/test/Concurrency/reasync_protocol.swift
+++ b/test/Concurrency/reasync_protocol.swift
@@ -4,4 +4,4 @@
 @reasync protocol ReasyncProtocol {}
 
 @reasync struct ReasyncStruct {}
-// expected-error@-1 {{@reasync may only be used on 'protocol' declarations}}
+// expected-error@-1 {{'@reasync' may only be used on 'protocol' declarations}}

--- a/test/Concurrency/unsafe_inherit_executor.swift
+++ b/test/Concurrency/unsafe_inherit_executor.swift
@@ -14,7 +14,7 @@ func testAsync() async {}
 // expected-warning@-1{{'@_unsafeInheritExecutor' is deprecated; consider an 'isolated' parameter defaulted to '#isolation' instead}}
 
 struct A {
-  // expected-error @+1 {{@_unsafeInheritExecutor may only be used on 'func' declarations}}
+  // expected-error @+1 {{'@_unsafeInheritExecutor' may only be used on 'func' declarations}}
   @_unsafeInheritExecutor
   init() async {}
 

--- a/test/IRGen/section_errors.swift
+++ b/test/IRGen/section_errors.swift
@@ -10,7 +10,7 @@ struct MyStruct {
 }
 
 struct MyStruct2 {
-  @section("__TEXT,__mysection") var member0: Int = 1 // expected-error {{properties with attribute @section must be static}}
+  @section("__TEXT,__mysection") var member0: Int = 1 // expected-error {{properties with attribute 'section' must be static}}
 
   @section("__TEXT,__mysection") static var static1: Int { return 1 } // expected-error {{'@section' must not be used on computed properties}}
 }
@@ -18,7 +18,7 @@ struct MyStruct2 {
 struct MyStruct3<T> {
   static var member1: Int = 1 // expected-error {{static stored properties not supported in generic types}}
 
-  @section("__TEXT,__mysection") func foo() {} // expected-error {{attribute @section cannot be used in a generic context}}
+  @section("__TEXT,__mysection") func foo() {} // expected-error {{attribute 'section' cannot be used in a generic context}}
 }
 
 struct MyStruct4<T> {
@@ -26,9 +26,9 @@ struct MyStruct4<T> {
     static var member2: Int = 1 // expected-error {{static stored properties not supported in generic types}}
 
     @section("__TEXT,__mysection") static var member3: Int = 1 // expected-error {{static stored properties not supported in generic types}}
-    // expected-error@-1 {{attribute @section cannot be used in a generic context}}
+    // expected-error@-1 {{attribute 'section' cannot be used in a generic context}}
 
-    @section("__TEXT,__mysection") func foo() {} // expected-error {{attribute @section cannot be used in a generic context}}
+    @section("__TEXT,__mysection") func foo() {} // expected-error {{attribute 'section' cannot be used in a generic context}}
   }
 }
 
@@ -49,7 +49,7 @@ func function() {
   l0 += 1
   _ = l0
 
-  @used var l1: Int = 1 // expected-error {{attribute @used can only be used in a non-local scope}}
+  @used var l1: Int = 1 // expected-error {{attribute 'used' can only be used in a non-local scope}}
   l1 += 1
   _ = l1
 }
@@ -69,6 +69,6 @@ func function_with_type() {
 func function_with_type_generic<T>() -> T {
   class MyClass { // expected-error {{type 'MyClass' cannot be nested in generic function}}
     @section("__TEXT,__mysection") static var member: Int = 1 // expected-error {{static stored properties not supported in generic types}}
-    // expected-error@-1 {{attribute @section cannot be used in a generic context}}
+    // expected-error@-1 {{attribute 'section' cannot be used in a generic context}}
   }
 }

--- a/test/NameLookup/property_wrapper_and_macro.swift
+++ b/test/NameLookup/property_wrapper_and_macro.swift
@@ -80,7 +80,7 @@ func bar() {
 @SomeAttr var x = 0 // expected-error {{could not be found for macro}}
 
 _ = { @SomeAttr<Int> in }
-// expected-error@-1 {{attribute @SomeAttr<Int> is not supported on a closure}}
+// expected-error@-1 {{'@SomeAttr<Int>' is not supported on a closure}}
 // expected-warning@-2 {{cannot specialize a non-generic external macro 'SomeAttr()'}}
 
 //--- other.swift

--- a/test/Parse/const.swift
+++ b/test/Parse/const.swift
@@ -1,7 +1,7 @@
 // RUN: %target-typecheck-verify-swift -enable-experimental-feature CompileTimeValues
 // REQUIRES: swift_feature_CompileTimeValues
 @const let x: Int = 42
-@const var y: Int = 42 // expected-error{{@const may only be used on 'let' declarations}}
+@const var y: Int = 42 // expected-error{{'@const' may only be used on 'let' declarations}}
 
 // FIXME: Only allow 'let' for `@const` properties, even in protocol requirements
 protocol ConstUserProto {
@@ -10,7 +10,7 @@ protocol ConstUserProto {
 
 class ConstFanClassWrong: ConstUserProto {
   @const static let v: String = ""
-  @const static var B: String = "" // expected-error{{@const may only be used on 'let' declarations}}
+  @const static var B: String = "" // expected-error{{'@const' may only be used on 'let' declarations}}
   @const static let C: String = ""
 }
 

--- a/test/Parse/constinitialized.swift
+++ b/test/Parse/constinitialized.swift
@@ -9,16 +9,16 @@ protocol ConstUserProto {
 }
 
 class ConstFanClassWrong: ConstUserProto {
-	@constInitialized var v: String = "" // expected-error{{properties with attribute @constInitialized must be static}}
+	@constInitialized var v: String = "" // expected-error{{properties with attribute 'constInitialized' must be static}}
   @constInitialized static var B: String = ""
   @constInitialized static var Computed: String { get { return "" } } // expected-error{{'@constInitialized' must not be used on computed properties}}
 }
 
-func takeIntConst(@constInitialized _ a: Int) {} // expected-error{{@constInitialized may only be used on 'var' declarations}}
+func takeIntConst(@constInitialized _ a: Int) {} // expected-error{{'@constInitialized' may only be used on 'var' declarations}}
 
-@constInitialized func constFunc(_ a: Int) {} // expected-error{{@constInitialized may only be used on 'var' declarations}}
+@constInitialized func constFunc(_ a: Int) {} // expected-error{{'@constInitialized' may only be used on 'var' declarations}}
 
 func LocalConstVarUser() -> Int {
-		@constInitialized let localConst = 3 // expected-error{{attribute @constInitialized can only be used in a non-local scope}}
+		@constInitialized let localConst = 3 // expected-error{{attribute 'constInitialized' can only be used in a non-local scope}}
 		return localConst + 1
 }

--- a/test/Parse/invalid.swift
+++ b/test/Parse/invalid.swift
@@ -130,13 +130,13 @@ let x: () = ()
 
 // https://github.com/apple/swift/issues/50734
 
-func f1_50734(@NSApplicationMain x: Int) {} // expected-error {{@NSApplicationMain may only be used on 'class' declarations}}
+func f1_50734(@NSApplicationMain x: Int) {} // expected-error {{'@NSApplicationMain' may only be used on 'class' declarations}}
 func f2_50734(@available(iOS, deprecated: 1) x: Int) {} // expected-error {{'@available' attribute cannot be applied to this declaration}}
 func f3_50734(@discardableResult x: Int) {} // expected-error {{'@discardableResult' attribute cannot be applied to this declaration}}
-func f4_50734(@objcMembers x: String) {} // expected-error {{@objcMembers may only be used on 'class' declarations}}
+func f4_50734(@objcMembers x: String) {} // expected-error {{'@objcMembers' may only be used on 'class' declarations}}
 func f5_50734(@weak x: String) {} // expected-error {{'weak' is a declaration modifier, not an attribute}} expected-error {{'weak' may only be used on 'var' declarations}}
 
-class C_50734<@NSApplicationMain T: AnyObject> {} // expected-error {{@NSApplicationMain may only be used on 'class' declarations}}
+class C_50734<@NSApplicationMain T: AnyObject> {} // expected-error {{'@NSApplicationMain' may only be used on 'class' declarations}}
 func f6_50734<@discardableResult T>(x: T) {} // expected-error {{'@discardableResult' attribute cannot be applied to this declaration}}
 enum E_50734<@indirect T> {} // expected-error {{'indirect' is a declaration modifier, not an attribute}} expected-error {{'indirect' modifier cannot be applied to this declaration}}
 protocol P {

--- a/test/Parse/weakLinked.swift
+++ b/test/Parse/weakLinked.swift
@@ -1,5 +1,5 @@
 // RUN: %swift -target x86_64-unknown-windows-msvc -parse-stdlib -typecheck -verify %s
 
-// expected-error@+1{{attribute @_weakLinked is unsupported on target 'x86_64-unknown-windows-msvc'}}
+// expected-error@+1{{attribute '_weakLinked' is unsupported on target 'x86_64-unknown-windows-msvc'}}
 @_weakLinked func f() { }
 

--- a/test/Sema/alwaysEmitConformanceMetadata_attr.swift
+++ b/test/Sema/alwaysEmitConformanceMetadata_attr.swift
@@ -7,19 +7,19 @@ protocol TestP {
     static var foo: Int { get }
 }
 
-@_alwaysEmitConformanceMetadata // expected-error {{@_alwaysEmitConformanceMetadata may only be used on 'protocol' declarations}}
+@_alwaysEmitConformanceMetadata // expected-error {{'@_alwaysEmitConformanceMetadata' may only be used on 'protocol' declarations}}
 class TestC {}
 
-@_alwaysEmitConformanceMetadata // expected-error {{@_alwaysEmitConformanceMetadata may only be used on 'protocol' declarations}}
+@_alwaysEmitConformanceMetadata // expected-error {{'@_alwaysEmitConformanceMetadata' may only be used on 'protocol' declarations}}
 struct TestS {}
 
-@_alwaysEmitConformanceMetadata // expected-error {{@_alwaysEmitConformanceMetadata may only be used on 'protocol' declarations}}
+@_alwaysEmitConformanceMetadata // expected-error {{'@_alwaysEmitConformanceMetadata' may only be used on 'protocol' declarations}}
 enum TestE {}
 
-@_alwaysEmitConformanceMetadata // expected-error {{@_alwaysEmitConformanceMetadata may only be used on 'protocol' declarations}}
+@_alwaysEmitConformanceMetadata // expected-error {{'@_alwaysEmitConformanceMetadata' may only be used on 'protocol' declarations}}
 extension TestS {}
 
 class TestC2 {
-    @_alwaysEmitConformanceMetadata  // expected-error {{@_alwaysEmitConformanceMetadata may only be used on 'protocol' declarations}}
+    @_alwaysEmitConformanceMetadata  // expected-error {{'@_alwaysEmitConformanceMetadata' may only be used on 'protocol' declarations}}
     var foo: Int = 11
 }

--- a/test/Sema/dynamic_attr_requires_module.swift
+++ b/test/Sema/dynamic_attr_requires_module.swift
@@ -3,5 +3,5 @@
 
 class Oof {
   @objc dynamic func impliesObjC() { }
-  // expected-error@-1 {{@objc attribute used without importing module 'Foundation'}}
+  // expected-error@-1 {{'@objc' attribute used without importing module 'Foundation'}}
 }

--- a/test/Sema/objc_attr_requires_module_1.swift
+++ b/test/Sema/objc_attr_requires_module_1.swift
@@ -5,7 +5,7 @@
 // appeared before any top-level expressions. The _1 and _2 variants of
 // this test cover both cases.
 
-@objc class Foo {} // expected-error {{@objc attribute used without importing module 'Foundation'}} expected-error {{only classes that inherit from NSObject can be declared '@objc'}} {{1-7=}}
+@objc class Foo {} // expected-error {{'@objc' attribute used without importing module 'Foundation'}} expected-error {{only classes that inherit from NSObject can be declared '@objc'}} {{1-7=}}
 // expected-note@-1 {{inherit from 'NSObject' to silence this error}} {{16-16=: NSObject}}
 
 #if false

--- a/test/Sema/objc_attr_requires_module_2.swift
+++ b/test/Sema/objc_attr_requires_module_2.swift
@@ -3,5 +3,5 @@
 class Foo {}
 _ = Foo()
 
-@objc class NSFoo {} // expected-error {{@objc attribute used without importing module 'Foundation'}} expected-error {{only classes that inherit from NSObject can be declared '@objc'}} {{1-7=}}
+@objc class NSFoo {} // expected-error {{'@objc' attribute used without importing module 'Foundation'}} expected-error {{only classes that inherit from NSObject can be declared '@objc'}} {{1-7=}}
 // expected-note@-1 {{inherit from 'NSObject' to silence this error}} {{18-18=: NSObject}}

--- a/test/Sema/objc_attr_requires_module_3.swift
+++ b/test/Sema/objc_attr_requires_module_3.swift
@@ -38,6 +38,6 @@ class TestClass5 {
 
 #if true
 class TestClass6 {
-  @objc func testMethod() {} // expected-error {{@objc attribute used without importing module 'Foundation'}}
+  @objc func testMethod() {} // expected-error {{'@objc' attribute used without importing module 'Foundation'}}
 }
 #endif

--- a/test/Sema/objcmembers_attr_requires_module.swift
+++ b/test/Sema/objcmembers_attr_requires_module.swift
@@ -2,5 +2,5 @@
 // RUN: %target-swift-frontend -typecheck -verify -enable-objc-interop %s -parse-as-library
 
 @objcMembers class Oof {
-  // expected-error@-1 {{@objcMembers attribute used without importing module 'Foundation'}}
+  // expected-error@-1 {{'@objcMembers' attribute used without importing module 'Foundation'}}
 }

--- a/test/Sema/raw_layout.swift
+++ b/test/Sema/raw_layout.swift
@@ -28,20 +28,20 @@ struct HasWrappedStoredProperty: ~Copyable { @Wrapper var x: Int }
 @_rawLayout(like: T) // expected-error{{cannot find type 'T' in scope}}
 struct TypeDoesntExist<A>: ~Copyable {}
 
-@_rawLayout(size: 4, alignment: 4) // expected-error{{@_rawLayout may only be used on 'struct'}}
+@_rawLayout(size: 4, alignment: 4) // expected-error{{'@_rawLayout' may only be used on 'struct'}}
 enum EnumWithRawLayout: ~Copyable {}
 
-@_rawLayout(size: 4, alignment: 4) // expected-error{{@_rawLayout may only be used on 'struct'}}
+@_rawLayout(size: 4, alignment: 4) // expected-error{{'@_rawLayout' may only be used on 'struct'}}
 class ClassWithRawLayout {}
 
 @_rawLayout(size: 4, alignment: 4)
 struct Lock: ~Copyable {}
 
-@_rawLayout(size: 4, alignment: 4) // expected-error{{@_rawLayout may only be used on 'struct'}}
+@_rawLayout(size: 4, alignment: 4) // expected-error{{'@_rawLayout' may only be used on 'struct'}}
 typealias TypealiasWithRawLayout = Lock
 
 struct Butt {
-    @_rawLayout(size: 4, alignment: 4) // expected-error{{@_rawLayout may only be used on 'struct'}}
+    @_rawLayout(size: 4, alignment: 4) // expected-error{{'@_rawLayout' may only be used on 'struct'}}
     var propertyWithStoredLayout: ()
 }
 

--- a/test/SourceKit/Sema/objc_attr_without_import.swift
+++ b/test/SourceKit/Sema/objc_attr_without_import.swift
@@ -2,7 +2,7 @@
 // RUN: %FileCheck -input-file=%t.response %s
 // This tests that we are not crashing in SILGen.
 
-// CHECK: {{Objective-C interoperability is disabled|@objc attribute used without importing module}}
+// CHECK: {{Objective-C interoperability is disabled|'@objc' attribute used without importing module}}
 @objc protocol Communicate {
   var name: String { get }
 }

--- a/test/attr/accessibility.swift
+++ b/test/attr/accessibility.swift
@@ -108,7 +108,7 @@ duplicateAttr(1) // expected-error{{argument passed to call that takes no argume
 
 // CHECK ALLOWED DECLS
 private import Swift
-private(set) infix operator ~~~ // expected-error {{unexpected attribute 'private' in operator declaration}} {{1-14=}}
+private(set) infix operator ~~~ // expected-error {{unexpected modifier 'private' in operator declaration}} {{1-14=}}
 
 private typealias MyInt = Int
 

--- a/test/attr/attr_cdecl.swift
+++ b/test/attr/attr_cdecl.swift
@@ -24,7 +24,7 @@ enum SwiftEnum { case A, B }
 @objc enum CEnum: Int { case A, B }
 #endif
 
-@_cdecl("enum") // expected-error {{@_cdecl may only be used on 'func' declarations}}
+@_cdecl("enum") // expected-error {{'@_cdecl' may only be used on 'func' declarations}}
 enum UnderscoreCDeclEnum: CInt { case A, B }
 
 @_cdecl("swiftStruct")
@@ -56,7 +56,7 @@ func hasNested() {
 }
 
 // TODO: Handle error conventions in SILGen for toplevel functions.
-@_cdecl("throwing") // expected-error{{raising errors from @_cdecl functions is not supported}}
+@_cdecl("throwing") // expected-error{{raising errors from '@_cdecl' functions is not supported}}
 func throwing() throws { }
 
 // TODO: cdecl name collisions

--- a/test/attr/attr_cdecl_async.swift
+++ b/test/attr/attr_cdecl_async.swift
@@ -2,6 +2,6 @@
 
 // REQUIRES: concurrency
 
-@_cdecl("async") // expected-error{{@_cdecl global function cannot be asynchronous}}
+@_cdecl("async") // expected-error{{'@_cdecl' global function cannot be asynchronous}}
 func asynchronous() async { }
 

--- a/test/attr/attr_cdecl_official.swift
+++ b/test/attr/attr_cdecl_official.swift
@@ -87,10 +87,10 @@ enum CDeclAndObjC: CInt { case A, B }
 func TwoCDecls() {}
 
 class Foo {
-  @c(Foo_foo) // expected-error{{@c can only be applied to global functions}}
+  @c(Foo_foo) // expected-error{{'@c' can only be applied to global functions}}
   func foo(x: Int) -> Int { return x }
 
-  @c(Foo_foo_2) // expected-error{{@c can only be applied to global functions}}
+  @c(Foo_foo_2) // expected-error{{'@c' can only be applied to global functions}}
   static func foo(x: Int) -> Int { return x }
 
   @c(Foo_init) // expected-error{{'@c' attribute cannot be applied to this declaration}}
@@ -100,7 +100,7 @@ class Foo {
   deinit {}
 }
 
-@c(throwing) // expected-error{{raising errors from @c functions is not supported}}
+@c(throwing) // expected-error{{raising errors from '@c' functions is not supported}}
 func throwing() throws { }
 
 @c(acceptedPointers)

--- a/test/attr/attr_cdecl_official_async.swift
+++ b/test/attr/attr_cdecl_official_async.swift
@@ -3,10 +3,10 @@
 
 // REQUIRES: concurrency
 
-@_cdecl("async") // expected-error{{@_cdecl global function cannot be asynchronous}}
+@_cdecl("async") // expected-error{{'@_cdecl' global function cannot be asynchronous}}
 func asynchronous() async { }
 
-@c(async2) // expected-error{{@c global function cannot be asynchronous}}
+@c(async2) // expected-error{{'@c' global function cannot be asynchronous}}
 func asynchronous2() async { }
 
 @c(asyncParam)

--- a/test/attr/attr_dynamic.swift
+++ b/test/attr/attr_dynamic.swift
@@ -7,7 +7,7 @@ struct NotObjCAble {
 
 @objc class ObjCClass {}
 
-dynamic prefix operator +!+  // expected-error{{unexpected attribute 'dynamic' in operator declaration}} {{1-9=}}
+dynamic prefix operator +!+  // expected-error{{unexpected modifier 'dynamic' in operator declaration}} {{1-9=}}
 
 class Foo {
   @objc dynamic init() {}

--- a/test/attr/attr_extern.swift
+++ b/test/attr/attr_extern.swift
@@ -140,23 +140,23 @@ func throwsFuncC() throws // expected-error {{raising errors from C functions is
 @_extern(c)
 func genericFuncC<T>(_: T) // expected-error {{'T' cannot be represented in C}}
 
-@_extern(c) // expected-error {{'@_extern' cannot be applied to an @_cdecl declaration}}
+@_extern(c) // expected-error {{'@_extern' cannot be applied to an '@_cdecl' declaration}}
 @_cdecl("another_c_name")
 func withAtCDecl_C()
 
-@_extern(wasm, module: "", name: "") // expected-error {{'@_extern' cannot be applied to an @_cdecl declaration}}
+@_extern(wasm, module: "", name: "") // expected-error {{'@_extern' cannot be applied to an '@_cdecl' declaration}}
 @_cdecl("another_c_name")
 func withAtCDecl_Wasm()
 
-@_extern(c) // expected-error {{'@_extern' cannot be applied to an @_silgen_name declaration}}
+@_extern(c) // expected-error {{'@_extern' cannot be applied to an '@_silgen_name' declaration}}
 @_silgen_name("another_sil_name")
 func withAtSILGenName_C()
 
-@_extern(wasm, module: "", name: "") // expected-error {{'@_extern' cannot be applied to an @_silgen_name declaration}}
+@_extern(wasm, module: "", name: "") // expected-error {{'@_extern' cannot be applied to an '@_silgen_name' declaration}}
 @_silgen_name("another_sil_name")
 func withAtSILGenName_Wasm()
 
-@_extern(c) // expected-error {{'@_extern' cannot be applied to an @_silgen_name declaration}} expected-error {{'@_extern' cannot be applied to an @_cdecl declaration}}
+@_extern(c) // expected-error {{'@_extern' cannot be applied to an '@_silgen_name' declaration}} expected-error {{'@_extern' cannot be applied to an '@_cdecl' declaration}}
 @_cdecl("another_c_name")
 @_silgen_name("another_sil_name")
 func withAtSILGenName_CDecl_C()

--- a/test/attr/attr_ibaction.swift
+++ b/test/attr/attr_ibaction.swift
@@ -2,20 +2,20 @@
 
 // REQUIRES: objc_interop
 
-@IBAction // expected-error {{@IBAction may only be used on 'func' declarations}} {{1-11=}}
+@IBAction // expected-error {{'@IBAction' may only be used on 'func' declarations}} {{1-11=}}
 var iboutlet_global: Int
 
 var iboutlet_accessor: Int {
-  @IBAction // expected-error {{@IBAction may only be used on 'func' declarations}} {{3-13=}}
+  @IBAction // expected-error {{'@IBAction' may only be used on 'func' declarations}} {{3-13=}}
   get { return 42 }
 }
 
-@IBAction // expected-error {{@IBAction may only be used on 'func' declarations}} {{1-11=}}
+@IBAction // expected-error {{'@IBAction' may only be used on 'func' declarations}} {{1-11=}}
 class IBOutletClassTy {}
-@IBAction // expected-error {{@IBAction may only be used on 'func' declarations}} {{1-11=}}
+@IBAction // expected-error {{'@IBAction' may only be used on 'func' declarations}} {{1-11=}}
 struct IBStructTy {}
 
-@IBAction // expected-error {{only instance methods can be declared @IBAction}} {{1-11=}}
+@IBAction // expected-error {{only instance methods can be declared '@IBAction'}} {{1-11=}}
 func IBFunction() -> () {}
 
 class IBActionWrapperTy {
@@ -23,14 +23,14 @@ class IBActionWrapperTy {
   func click(_: AnyObject) -> () {} // no-warning
 
   func outer(_: AnyObject) -> () {
-    @IBAction  // expected-error {{only instance methods can be declared @IBAction}} {{5-15=}}
+    @IBAction  // expected-error {{only instance methods can be declared '@IBAction'}} {{5-15=}}
     func inner(_: AnyObject) -> () {}
   }
-  @IBAction // expected-error {{@IBAction may only be used on 'func' declarations}} {{3-13=}}
+  @IBAction // expected-error {{'@IBAction' may only be used on 'func' declarations}} {{3-13=}}
   var value : Void = ()
 
   @IBAction
-  func process(x: AnyObject) -> Int {}  // expected-error {{methods declared @IBAction must not return a value}}
+  func process(x: AnyObject) -> Int {}  // expected-error {{methods declared '@IBAction' must not return a value}}
 
   // @IBAction does /not/ semantically imply @objc.
   @IBAction // expected-note {{attribute already specified here}}
@@ -45,7 +45,7 @@ class IBActionWrapperTy {
   @available(SwiftStdlib 5.5, *)
   @IBAction
   func asyncIBActionNoSpace(_: AnyObject) async -> () {}
-  // expected-error@-1 {{@IBAction instance method cannot be async}}
+  // expected-error@-1 {{'@IBAction' instance method cannot be asynchronous}}
   // expected-note@-2 {{remove 'async' and wrap in 'Task' to use concurrency in 'asyncIBActionNoSpace'}}{{45:3-47:57=@available(SwiftStdlib 5.5, *)\n  @IBAction\n  func asyncIBActionNoSpace(_: AnyObject) -> () {\nTask { @MainActor in \}\n\}}}
 
   @available(SwiftStdlib 5.5, *)
@@ -53,12 +53,12 @@ class IBActionWrapperTy {
   func asyncIBActionWithFullBody(_: AnyObject) async {
       print("Hello World")
   }
-  // expected-error@-3 {{@IBAction instance method cannot be async}}
+  // expected-error@-3 {{'@IBAction' instance method cannot be asynchronous}}
   // expected-note@-4 {{remove 'async' and wrap in 'Task' to use concurrency in 'asyncIBActionWithFullBody'}}{{51:3-55:4=@available(SwiftStdlib 5.5, *)\n  @IBAction\n  func asyncIBActionWithFullBody(_: AnyObject) {\nTask { @MainActor in\n      print("Hello World")\n  \}\n\}}}
 
   @available(SwiftStdlib 5.5, *) @IBAction func asyncIBActionNoBody(_: AnyObject) async
   // expected-error@-1 {{expected '{' in body of function declaration}}
-  // expected-error@-2 {{@IBAction instance method cannot be asynchronous}}
+  // expected-error@-2 {{'@IBAction' instance method cannot be asynchronous}}
   // expected-note@-3 {{remove 'async' and wrap in 'Task' to use concurrency in 'asyncIBActionNoBody}}{{3-88=@available(SwiftStdlib 5.5, *) @IBAction func asyncIBActionNoBody(_: AnyObject)}}
 
 }

--- a/test/attr/attr_ibaction_ios.swift
+++ b/test/attr/attr_ibaction_ios.swift
@@ -5,7 +5,7 @@
 class IBActionWrapperTy {
   @IBAction func nullary() {}
   // CHECK-ios-NOT: attr_ibaction_ios.swift:[[@LINE-1]]
-  // CHECK-macosx: attr_ibaction_ios.swift:[[@LINE-2]]:18: error: @IBAction methods must have 1 argument
+  // CHECK-macosx: attr_ibaction_ios.swift:[[@LINE-2]]:18: error: '@IBAction' methods must have 1 argument
   // CHECK-tvos-NOT: attr_ibaction_ios.swift:[[@LINE-3]]
   // CHECK-watchos-NOT: attr_ibaction_ios.swift:[[@LINE-4]]
   // CHECK-xros-NOT: attr_ibaction_ios.swift:[[@LINE-5]]
@@ -19,14 +19,14 @@ class IBActionWrapperTy {
 
   @IBAction func binary(_: AnyObject, _: AnyObject) {}
   // CHECK-ios-NOT: attr_ibaction_ios.swift:[[@LINE-1]]
-  // CHECK-macosx: attr_ibaction_ios.swift:[[@LINE-2]]:18: error: @IBAction methods must have 1 argument
+  // CHECK-macosx: attr_ibaction_ios.swift:[[@LINE-2]]:18: error: '@IBAction' methods must have 1 argument
   // CHECK-tvos-NOT: attr_ibaction_ios.swift:[[@LINE-3]]
   // CHECK-watchos-NOT: attr_ibaction_ios.swift:[[@LINE-4]]
   // CHECK-xros-NOT: attr_ibaction_ios.swift:[[@LINE-5]]
 
   @IBAction func ternary(_: AnyObject, _: AnyObject, _: AnyObject) {}
-  // CHECK-ios: attr_ibaction_ios.swift:[[@LINE-1]]:18: error: @IBAction methods must have at most 2 arguments
-  // CHECK-macosx: attr_ibaction_ios.swift:[[@LINE-2]]:18: error: @IBAction methods must have 1 argument
-  // CHECK-tvos: attr_ibaction_ios.swift:[[@LINE-3]]:18: error: @IBAction methods must have at most 2 arguments
-  // CHECK-watchos: attr_ibaction_ios.swift:[[@LINE-4]]:18: error: @IBAction methods must have at most 2 arguments
-  // CHECK-xros: attr_ibaction_ios.swift:[[@LINE-5]]:18: error: @IBAction methods must have at most 2 arguments
+  // CHECK-ios: attr_ibaction_ios.swift:[[@LINE-1]]:18: error: '@IBAction' methods must have at most 2 arguments
+  // CHECK-macosx: attr_ibaction_ios.swift:[[@LINE-2]]:18: error: '@IBAction' methods must have 1 argument
+  // CHECK-tvos: attr_ibaction_ios.swift:[[@LINE-3]]:18: error: '@IBAction' methods must have at most 2 arguments
+  // CHECK-watchos: attr_ibaction_ios.swift:[[@LINE-4]]:18: error: '@IBAction' methods must have at most 2 arguments
+  // CHECK-xros: attr_ibaction_ios.swift:[[@LINE-5]]:18: error: '@IBAction' methods must have at most 2 arguments

--- a/test/attr/attr_iboutlet.swift
+++ b/test/attr/attr_iboutlet.swift
@@ -4,15 +4,15 @@
 import Foundation
 
 // expected-error@+1 {{'@IBOutlet' property cannot have non-object type 'Int'}}
-@IBOutlet // expected-error {{only class instance properties can be declared @IBOutlet}} {{1-11=}}
+@IBOutlet // expected-error {{only class instance properties can be declared '@IBOutlet'}} {{1-11=}}
 var iboutlet_global: Int?
 
-@IBOutlet // expected-error {{@IBOutlet may only be used on 'var' declarations}} {{1-11=}}
+@IBOutlet // expected-error {{'@IBOutlet' may only be used on 'var' declarations}} {{1-11=}}
 class IBOutletClassTy {}
-@IBOutlet // expected-error {{@IBOutlet may only be used on 'var' declarations}} {{1-11=}}
+@IBOutlet // expected-error {{'@IBOutlet' may only be used on 'var' declarations}} {{1-11=}}
 struct IBStructTy {}
 
-@IBOutlet // expected-error {{@IBOutlet may only be used on 'var' declarations}} {{1-11=}}
+@IBOutlet // expected-error {{'@IBOutlet' may only be used on 'var' declarations}} {{1-11=}}
 func IBFunction() -> () {}
 
 @objc
@@ -22,10 +22,10 @@ class IBOutletWrapperTy {
 
   @IBOutlet
   class var staticValue: IBOutletWrapperTy? = 52  // expected-error {{cannot convert value of type 'Int' to specified type 'IBOutletWrapperTy'}}
-  // expected-error@-2 {{only class instance properties can be declared @IBOutlet}} {{1-+1:1=}}
+  // expected-error@-2 {{only class instance properties can be declared '@IBOutlet'}} {{1-+1:1=}}
   // expected-error@-2 {{class stored properties not supported}}
 
-  @IBOutlet // expected-error {{@IBOutlet may only be used on 'var' declarations}} {{3-13=}}
+  @IBOutlet // expected-error {{'@IBOutlet' may only be used on 'var' declarations}} {{3-13=}}
   func click() -> () {}
 
   @IBOutlet // expected-error {{'@IBOutlet' requires property to be mutable}} {{3-13=}}

--- a/test/attr/attr_ibsegueaction.swift
+++ b/test/attr/attr_ibsegueaction.swift
@@ -2,20 +2,20 @@
 
 // REQUIRES: objc_interop
 
-@IBSegueAction // expected-error {{@IBSegueAction may only be used on 'func' declarations}} {{1-16=}}
+@IBSegueAction // expected-error {{'@IBSegueAction' may only be used on 'func' declarations}} {{1-16=}}
 var iboutlet_global: Int
 
 var iboutlet_accessor: Int {
-  @IBSegueAction // expected-error {{@IBSegueAction may only be used on 'func' declarations}} {{3-18=}}
+  @IBSegueAction // expected-error {{'@IBSegueAction' may only be used on 'func' declarations}} {{3-18=}}
   get { return 42 }
 }
 
-@IBSegueAction // expected-error {{@IBSegueAction may only be used on 'func' declarations}} {{1-16=}}
+@IBSegueAction // expected-error {{'@IBSegueAction' may only be used on 'func' declarations}} {{1-16=}}
 class IBOutletClassTy {}
-@IBSegueAction // expected-error {{@IBSegueAction may only be used on 'func' declarations}} {{1-16=}}
+@IBSegueAction // expected-error {{'@IBSegueAction' may only be used on 'func' declarations}} {{1-16=}}
 struct IBStructTy {}
 
-@IBSegueAction // expected-error {{only instance methods can be declared @IBSegueAction}} {{1-16=}}
+@IBSegueAction // expected-error {{only instance methods can be declared '@IBSegueAction'}} {{1-16=}}
 func IBFunction(_: AnyObject, _: AnyObject, _: AnyObject) -> AnyObject {}
 
 class IBActionWrapperTy {
@@ -23,15 +23,15 @@ class IBActionWrapperTy {
   func click(_: AnyObject, _: AnyObject, _: AnyObject) -> AnyObject {fatalError()} // no-warning
 
   func outer(_: AnyObject, _: AnyObject, _: AnyObject) -> AnyObject {
-    @IBSegueAction  // expected-error {{only instance methods can be declared @IBSegueAction}} {{5-20=}}
+    @IBSegueAction  // expected-error {{only instance methods can be declared '@IBSegueAction'}} {{5-20=}}
     func inner(_: AnyObject, _: AnyObject, _: AnyObject) -> AnyObject {fatalError()}
     fatalError()
   }
-  @IBSegueAction // expected-error {{@IBSegueAction may only be used on 'func' declarations}} {{3-18=}}
+  @IBSegueAction // expected-error {{'@IBSegueAction' may only be used on 'func' declarations}} {{3-18=}}
   var value : AnyObject? = nil
 
   @IBSegueAction
-  func process(x: AnyObject, _: AnyObject, _: AnyObject) {}  // expected-error {{methods declared @IBSegueAction must return a value}}
+  func process(x: AnyObject, _: AnyObject, _: AnyObject) {}  // expected-error {{methods declared '@IBSegueAction' must return a value}}
 
   @IBSegueAction
   func process(_: AnyObject, _: AnyObject, _: AnyObject) -> Int? {fatalError()}  // expected-error {{method cannot be marked '@IBSegueAction' because its result type cannot be represented in Objective-C}}
@@ -48,7 +48,7 @@ class IBActionWrapperTy {
 
   @available(SwiftStdlib 5.5, *) @IBSegueAction
   func process(_: AnyObject, _: AnyObject, _: AnyObject) async -> AnyObject { }
-  // expected-error@-1 {{@IBSegueAction instance method cannot be asynchronous}}
+  // expected-error@-1 {{'@IBSegueAction' instance method cannot be asynchronous}}
   // expected-note@-2 {{remove 'async' and wrap in 'Task' to use concurrency in 'process'}}{{49:3-50:80=@available(SwiftStdlib 5.5, *) @IBSegueAction\n  func process(_: AnyObject, _: AnyObject, _: AnyObject) -> AnyObject {\nTask { @MainActor in \}\n\}}}
 }
 
@@ -68,27 +68,27 @@ protocol CP2 : class { }
 // semantics.
 @objc class Leaky {
   @IBSegueAction func newScreen(_: AnyObject) -> AnyObject {fatalError()}
-  // expected-error@-1{{@IBSegueAction method cannot have selector 'newScreen:' because it has special memory management behavior}}
+  // expected-error@-1{{'@IBSegueAction' method cannot have selector 'newScreen:' because it has special memory management behavior}}
   // expected-note@-2{{change Swift name to 'makeScreen'}} {{23-32=makeScreen}}
   // expected-note@-3{{change Objective-C selector to 'makeScreen:'}} {{3-3=@objc(makeScreen:) }}
   @IBSegueAction func allocScreen(_: AnyObject) -> AnyObject {fatalError()}
-  // expected-error@-1{{@IBSegueAction method cannot have selector 'allocScreen:' because it has special memory management behavior}}
+  // expected-error@-1{{'@IBSegueAction' method cannot have selector 'allocScreen:' because it has special memory management behavior}}
   // expected-note@-2{{change Swift name to 'makeScreen'}} {{23-34=makeScreen}}
   // expected-note@-3{{change Objective-C selector to 'makeScreen:'}} {{3-3=@objc(makeScreen:) }}
   @IBSegueAction func initScreen(_: AnyObject) -> AnyObject {fatalError()}
-  // expected-error@-1{{@IBSegueAction method cannot have selector 'initScreen:' because it has special memory management behavior}}
+  // expected-error@-1{{'@IBSegueAction' method cannot have selector 'initScreen:' because it has special memory management behavior}}
   // expected-note@-2{{change Swift name to 'makeScreen'}} {{23-33=makeScreen}}
   // expected-note@-3{{change Objective-C selector to 'makeScreen:'}} {{3-3=@objc(makeScreen:) }}
   @IBSegueAction func copyScreen(_: AnyObject) -> AnyObject {fatalError()}
-  // expected-error@-1{{@IBSegueAction method cannot have selector 'copyScreen:' because it has special memory management behavior}}
+  // expected-error@-1{{'@IBSegueAction' method cannot have selector 'copyScreen:' because it has special memory management behavior}}
   // expected-note@-2{{change Swift name to 'makeCopyScreen'}} {{23-33=makeCopyScreen}}
   // expected-note@-3{{change Objective-C selector to 'makeCopyScreen:'}} {{3-3=@objc(makeCopyScreen:) }}
   @IBSegueAction func mutableCopyScreen(_: AnyObject) -> AnyObject {fatalError()}
-  // expected-error@-1{{@IBSegueAction method cannot have selector 'mutableCopyScreen:' because it has special memory management behavior}}
+  // expected-error@-1{{'@IBSegueAction' method cannot have selector 'mutableCopyScreen:' because it has special memory management behavior}}
   // expected-note@-2{{change Swift name to 'makeMutableCopyScreen'}} {{23-40=makeMutableCopyScreen}}
   // expected-note@-3{{change Objective-C selector to 'makeMutableCopyScreen:'}} {{3-3=@objc(makeMutableCopyScreen:) }}
   @IBSegueAction func newScreen(_: AnyObject, secondArg: AnyObject) -> AnyObject {fatalError()}
-  // expected-error@-1{{@IBSegueAction method cannot have selector 'newScreen:secondArg:' because it has special memory management behavior}}
+  // expected-error@-1{{'@IBSegueAction' method cannot have selector 'newScreen:secondArg:' because it has special memory management behavior}}
   // expected-note@-2{{change Swift name to 'makeScreen(_:secondArg:)'}} {{23-32=makeScreen}}
   // expected-note@-3{{change Objective-C selector to 'makeScreen:secondArg:'}} {{3-3=@objc(makeScreen:secondArg:) }}
 
@@ -102,12 +102,12 @@ protocol CP2 : class { }
 
   @objc(newProblematicScreen:)
   @IBSegueAction func problematicScreen(_: AnyObject) -> AnyObject {fatalError()}
-  // expected-error@-1{{@IBSegueAction method cannot have selector 'newProblematicScreen:' because it has special memory management behavior}}
+  // expected-error@-1{{'@IBSegueAction' method cannot have selector 'newProblematicScreen:' because it has special memory management behavior}}
   // expected-note@-2{{change Objective-C selector to 'makeProblematicScreen:'}} {{-1:9-30=makeProblematicScreen:}}
 
   @objc(newProblematicScreen:secondArg:)
   @IBSegueAction func problematicScreen(_: AnyObject, secondArg: AnyObject) -> AnyObject {fatalError()}
-  // expected-error@-1{{@IBSegueAction method cannot have selector 'newProblematicScreen:secondArg:' because it has special memory management behavior}}
+  // expected-error@-1{{'@IBSegueAction' method cannot have selector 'newProblematicScreen:secondArg:' because it has special memory management behavior}}
   // expected-note@-2{{change Objective-C selector to 'makeProblematicScreen:secondArg:'}} {{-1:9-40=makeProblematicScreen:secondArg:}}
 }
 
@@ -230,11 +230,11 @@ protocol CP2 : class { }
   @IBSegueAction func action31d(_: AnyObject, _: AnyObject, _: E) -> AnyObject {fatalError()} // expected-error{{method cannot be marked '@IBSegueAction' because the type of the parameter 3 cannot be represented in Objective-C}} expected-note{{Swift enums not marked '@c' or '@objc' cannot be represented in Objective-C}}
 
   // Supported arities
-  @IBSegueAction func actionWith0() -> X {fatalError()} // expected-error{{@IBSegueAction methods must have 1 to 3 arguments}}
+  @IBSegueAction func actionWith0() -> X {fatalError()} // expected-error{{'@IBSegueAction' methods must have 1 to 3 arguments}}
   @IBSegueAction func actionWith1(_: X) -> X {fatalError()}
   @IBSegueAction func actionWith2(_: X, _: X) -> X {fatalError()}
   @IBSegueAction func actionWith3(_: X, _: X, _: X) -> X {fatalError()}
-  @IBSegueAction func actionWith4(_: X, _: X, _: X, _: X) -> X {fatalError()} // expected-error{{@IBSegueAction methods must have 1 to 3 arguments}}
+  @IBSegueAction func actionWith4(_: X, _: X, _: X, _: X) -> X {fatalError()} // expected-error{{'@IBSegueAction' methods must have 1 to 3 arguments}}
 
   init() { }
 }

--- a/test/attr/attr_inheritActorContext.swift
+++ b/test/attr/attr_inheritActorContext.swift
@@ -4,19 +4,19 @@ func test1(@_inheritActorContext _: @Sendable () async -> Void) {} // Ok
 func test2(@_inheritActorContext(always) _: sending () async -> Void) {} // Ok
 
 func test3(@_inheritActorContext _: () async -> Void) {}
-// expected-warning@-1 {{@_inheritActorContext only applies to 'sending' parameters or parameters with '@Sendable' function types}}
+// expected-warning@-1 {{'@_inheritActorContext' only applies to 'sending' parameters or parameters with '@Sendable' function types; this will be an error in a future Swift language mode}}
 func test3(@_inheritActorContext _: @Sendable () -> Void) {}
-// expected-warning@-1 {{@_inheritActorContext only applies to '@isolated(any)' parameters or parameters with asynchronous function types}}
+// expected-warning@-1 {{'@_inheritActorContext' only applies to '@isolated(any)' parameters or parameters with asynchronous function types; this will be an error in a future Swift language mode}}
 
 func test4(@_inheritActorContext _: Int) {}
-// expected-error@-1 {{@_inheritActorContext only applies to parameters with function types (got: 'Int')}}
+// expected-error@-1 {{'@_inheritActorContext' only applies to parameters with function types (got: 'Int')}}
 
 func test5(@_inheritActorContext _: sending Optional<() async -> Int>) {} // Ok
 func test6(@_inheritActorContext _: (Optional<@Sendable () async -> Int>)?) {} // Ok
 func test6(@_inheritActorContext _: (Optional<@Sendable @isolated(any) () -> Int>)?) {} // Ok
 
 func test7(@_inheritActorContext _: Int?) {} // Ok
-// expected-error@-1 {{@_inheritActorContext only applies to parameters with function types (got: 'Int?')}}
+// expected-error@-1 {{'@_inheritActorContext' only applies to parameters with function types (got: 'Int?')}}
 
 struct S {
   init(@_inheritActorContext(always) _: @escaping @Sendable () async -> Void) {} // Ok
@@ -32,7 +32,7 @@ struct S {
   subscript(x: Int, @_inheritActorContext(always) _: @Sendable (Int, Int) async -> Void) -> Bool { false }
 
   func testClosure() {
-    _ = { @_inheritActorContext in // expected-error {{attribute @_inheritActorContext is not supported on a closure}}
+    _ = { @_inheritActorContext in // expected-error {{'@_inheritActorContext' is not supported on a closure}}
     }
   }
 }

--- a/test/attr/attr_nonexhaustive.swift
+++ b/test/attr/attr_nonexhaustive.swift
@@ -16,21 +16,21 @@ public enum E3 {
 @usableFromInline
 enum E4 {}
 
-@nonexhaustive // expected-error {{@nonexhaustive may only be used on 'enum' declarations}}
+@nonexhaustive // expected-error {{'@nonexhaustive' may only be used on 'enum' declarations}}
 struct Test {
-  @nonexhaustive // expected-error {{@nonexhaustive may only be used on 'enum' declarations}}
+  @nonexhaustive // expected-error {{'@nonexhaustive' may only be used on 'enum' declarations}}
   var v: Int {
-    @nonexhaustive // expected-error {{@nonexhaustive may only be used on 'enum' declarations}}
+    @nonexhaustive // expected-error {{'@nonexhaustive' may only be used on 'enum' declarations}}
     get { 0 }
   }
 
-  @nonexhaustive // expected-error {{@nonexhaustive may only be used on 'enum' declarations}}
+  @nonexhaustive // expected-error {{'@nonexhaustive' may only be used on 'enum' declarations}}
   var v2: String = ""
   
-  @nonexhaustive // expected-error {{@nonexhaustive may only be used on 'enum' declarations}}
+  @nonexhaustive // expected-error {{'@nonexhaustive' may only be used on 'enum' declarations}}
   func test() {}
 
-  @nonexhaustive // expected-error {{@nonexhaustive may only be used on 'enum' declarations}}
+  @nonexhaustive // expected-error {{'@nonexhaustive' may only be used on 'enum' declarations}}
   subscript(a: Int) -> Bool {
     get { false }
     set { }

--- a/test/attr/attr_requires_stored_property_inits.swift
+++ b/test/attr/attr_requires_stored_property_inits.swift
@@ -44,11 +44,11 @@ class RequiresInheritedBad : RequiresOkay { // expected-error{{class 'RequiresIn
 }
 
 // Diagnose attempts to use this attribute on a non-class.
-@requires_stored_property_inits struct S { } // expected-error{{@requires_stored_property_inits may only be used on 'class' declarations}} {{1-33=}}
+@requires_stored_property_inits struct S { } // expected-error{{'@requires_stored_property_inits' may only be used on 'class' declarations}} {{1-33=}}
 
-@requires_stored_property_inits enum E { } // expected-error{{@requires_stored_property_inits may only be used on 'class' declarations}} {{1-33=}}
+@requires_stored_property_inits enum E { } // expected-error{{'@requires_stored_property_inits' may only be used on 'class' declarations}} {{1-33=}}
 
-@requires_stored_property_inits func f() { } // expected-error{{@requires_stored_property_inits may only be used on 'class' declarations}} {{1-33=}}
+@requires_stored_property_inits func f() { } // expected-error{{'@requires_stored_property_inits' may only be used on 'class' declarations}} {{1-33=}}
 
 
 @requires_stored_property_inits

--- a/test/attr/attr_static_exclusive_only.swift
+++ b/test/attr/attr_static_exclusive_only.swift
@@ -50,19 +50,19 @@ func i() {
   }
 }
 
-@_staticExclusiveOnly // expected-error {{@_staticExclusiveOnly may only be used on 'struct' declarations}}
+@_staticExclusiveOnly // expected-error {{'@_staticExclusiveOnly' may only be used on 'struct' declarations}}
 enum J {}
 
-@_staticExclusiveOnly // expected-error {{@_staticExclusiveOnly may only be used on 'struct' declarations}}
+@_staticExclusiveOnly // expected-error {{'@_staticExclusiveOnly' may only be used on 'struct' declarations}}
 class K {}
 
-@_staticExclusiveOnly // expected-error {{@_staticExclusiveOnly may only be used on 'struct' declarations}}
+@_staticExclusiveOnly // expected-error {{'@_staticExclusiveOnly' may only be used on 'struct' declarations}}
 func l() {}
 
-@_staticExclusiveOnly // expected-error {{@_staticExclusiveOnly may only be used on 'struct' declarations}}
+@_staticExclusiveOnly // expected-error {{'@_staticExclusiveOnly' may only be used on 'struct' declarations}}
 let m = 123
 
-@_staticExclusiveOnly // expected-error {{@_staticExclusiveOnly may only be used on 'struct' declarations}}
+@_staticExclusiveOnly // expected-error {{'@_staticExclusiveOnly' may only be used on 'struct' declarations}}
 protocol N {}
 
 func o(_: consuming B) {} // OK

--- a/test/attr/attributes.swift
+++ b/test/attr/attributes.swift
@@ -37,18 +37,18 @@ class Inspect {
   @IBInspectable var value : Int = 0 // okay
   @GKInspectable var value2: Int = 0 // okay
 
-  @IBInspectable func foo() {} // expected-error {{@IBInspectable may only be used on 'var' declarations}} {{3-18=}}
-  @GKInspectable func foo2() {} // expected-error {{@GKInspectable may only be used on 'var' declarations}} {{3-18=}}
+  @IBInspectable func foo() {} // expected-error {{'@IBInspectable' may only be used on 'var' declarations}} {{3-18=}}
+  @GKInspectable func foo2() {} // expected-error {{'@GKInspectable' may only be used on 'var' declarations}} {{3-18=}}
 
-  @IBInspectable class var cval: Int { return 0 } // expected-error {{only class instance properties can be declared @IBInspectable}} {{3-18=}}
-  @GKInspectable class var cval2: Int { return 0 } // expected-error {{only class instance properties can be declared @GKInspectable}} {{3-18=}}
+  @IBInspectable class var cval: Int { return 0 } // expected-error {{only class instance properties can be declared '@IBInspectable'}} {{3-18=}}
+  @GKInspectable class var cval2: Int { return 0 } // expected-error {{only class instance properties can be declared '@GKInspectable'}} {{3-18=}}
 }
-@IBInspectable var ibinspectable_global : Int // expected-error {{only class instance properties can be declared @IBInspectable}} {{1-16=}}
-@GKInspectable var gkinspectable_global : Int // expected-error {{only class instance properties can be declared @GKInspectable}} {{1-16=}}
+@IBInspectable var ibinspectable_global : Int // expected-error {{only class instance properties can be declared '@IBInspectable'}} {{1-16=}}
+@GKInspectable var gkinspectable_global : Int // expected-error {{only class instance properties can be declared '@GKInspectable'}} {{1-16=}}
 
 struct inspectableWithStruct {
-  @IBInspectable var IBInspectableInStruct: Int // expected-error {{only class instance properties can be declared @IBInspectable}} {{3-18=}}
-  @GKInspectable var GKInspectableInStruct: Int // expected-error {{only class instance properties can be declared @GKInspectable}} {{3-18=}}
+  @IBInspectable var IBInspectableInStruct: Int // expected-error {{only class instance properties can be declared '@IBInspectable'}} {{3-18=}}
+  @GKInspectable var GKInspectableInStruct: Int // expected-error {{only class instance properties can be declared '@GKInspectable'}} {{3-18=}}
 }
 
 func foo(x: @convention(block) Int) {} // expected-error {{'@convention' only applies to function types}}
@@ -198,9 +198,9 @@ _ = {
   weak var x: SomeClass & SomeProtocol // expected-error {{'weak' variable should have optional type '(any SomeClass & SomeProtocol)?'}} {{15-15=(}} {{39-39=)?}}
 }
 
-@_exported var exportVar: Int // expected-error {{@_exported may only be used on 'import' declarations}}{{1-12=}}
-@_exported func exportFunc() {} // expected-error {{@_exported may only be used on 'import' declarations}}{{1-12=}}
-@_exported struct ExportStruct {} // expected-error {{@_exported may only be used on 'import' declarations}}{{1-12=}}
+@_exported var exportVar: Int // expected-error {{'@_exported' may only be used on 'import' declarations}}{{1-12=}}
+@_exported func exportFunc() {} // expected-error {{'@_exported' may only be used on 'import' declarations}}{{1-12=}}
+@_exported struct ExportStruct {} // expected-error {{'@_exported' may only be used on 'import' declarations}}{{1-12=}}
 
 
 // Function result type attributes.
@@ -340,7 +340,7 @@ struct S1<T> {
   func quux(@_nonEphemeral _ x: UnsafeMutablePointer<Int>?) {}
 }
 
-@_nonEphemeral struct S2 {} // expected-error {{@_nonEphemeral may only be used on 'parameter' declarations}}
+@_nonEphemeral struct S2 {} // expected-error {{'@_nonEphemeral' may only be used on 'parameter' declarations}}
 
 protocol P {}
 extension P {
@@ -369,7 +369,7 @@ struct I65705 {
   func f2(_: @discardableResult Int) {} // expected-error {{attribute can only be applied to declarations, not types}} {{14-33=}} {{3-3=@discardableResult }} {{none}}
 
   func stmt(_ a: Int?) {
-    if let _: @discardableResult Int = a { // expected-error {{attribute can only be applied to declarations, not types}} {{15-34=}} 
+    if let _: @discardableResult Int = a { // expected-error {{attribute can only be applied to declarations, not types}} {{15-34=}}
     }
     if var _: @discardableResult Int = a { // expected-error {{attribute can only be applied to declarations, not types}} {{15-34=}}
     }

--- a/test/attr/closures.swift
+++ b/test/attr/closures.swift
@@ -1,11 +1,11 @@
 // RUN: %target-typecheck-verify-swift -swift-version 5
 
 func testNonacceptedClosures() {
-  let fn = { @usableFromInline in // expected-error{{attribute @usableFromInline is not supported on a closure}}
+  let fn = { @usableFromInline in // expected-error{{'@usableFromInline' is not supported on a closure}}
     "hello"
   }
 
-  let fn2: (Int) -> Int = { @usableFromInline x in  // expected-error{{attribute @usableFromInline is not supported on a closure}}
+  let fn2: (Int) -> Int = { @usableFromInline x in  // expected-error{{'@usableFromInline' is not supported on a closure}}
     print("hello")
     return x
   }

--- a/test/attr/execution_behavior_attrs.swift
+++ b/test/attr/execution_behavior_attrs.swift
@@ -8,7 +8,7 @@ nonisolated(something) func invalidAttr() async {} // expected-error {{cannot fi
 // expected-error@-2 {{consecutive statements on a line must be separated by ';'}}
 
 @concurrent nonisolated(nonsending) func mutipleAttrs() async {}
-// expected-error@-1 {{global function 'mutipleAttrs()' has multiple actor-isolation attributes (@concurrent and 'nonisolated(nonsending)')}}
+// expected-error@-1 {{global function 'mutipleAttrs()' has multiple actor-isolation attributes ('@concurrent' and 'nonisolated(nonsending)')}}
 
 do {
   nonisolated(nonsending) struct S {}
@@ -21,7 +21,7 @@ do {
 }
 
 @concurrent func nonAsync1() {}
-// expected-error@-1 {{cannot use @concurrent on non-async global function 'nonAsync1()'}}
+// expected-error@-1 {{cannot use '@concurrent' on non-async global function 'nonAsync1()'}}
 
 nonisolated(nonsending) func nonAsync2() {}
 // expected-error@-1 {{cannot use 'nonisolated(nonsending)' on non-async global function 'nonAsync2()'}}
@@ -30,17 +30,17 @@ nonisolated(nonsending) func nonAsync2() {}
 
 struct Test {
   @concurrent init() {}
-  // expected-error@-1 {{cannot use @concurrent on non-async initializer 'init()'}}
+  // expected-error@-1 {{cannot use '@concurrent' on non-async initializer 'init()'}}
 
   @concurrent init(async: Void) async {}
 
   @concurrent func member() {}
-  // expected-error@-1 {{cannot use @concurrent on non-async instance method 'member()'}}
+  // expected-error@-1 {{cannot use '@concurrent' on non-async instance method 'member()'}}
 
   @concurrent func member() async {} // Ok
 
   @concurrent var syncP: Int {
-  // expected-error@-1 {{cannot use @concurrent on non-async property 'syncP'}}
+  // expected-error@-1 {{cannot use '@concurrent' on non-async property 'syncP'}}
     get {}
   }
   @concurrent var asyncP: Int {
@@ -60,9 +60,9 @@ struct Test {
 
   // FIXME: Incorrect quotes due to inconsistent DeclAttribute printing between modifiers and attributes
   nonisolated(nonsending) var storedVar: Int
-  // expected-error@-1 {{''nonisolated(nonsending)'' must not be used on stored properties}}
+  // expected-error@-1 {{'nonisolated(nonsending)' must not be used on stored properties}}
   nonisolated(nonsending) let storedLet: Int
-  // expected-error@-1 {{''nonisolated(nonsending)'' must not be used on stored properties}}
+  // expected-error@-1 {{'nonisolated(nonsending)' must not be used on stored properties}}
 }
 
 do {
@@ -87,9 +87,9 @@ struct TestAttributeCollisions {
   @concurrent nonisolated func testNonIsolated() async {}
 
   @concurrent func test(arg: isolated MainActor) async {}
-  // expected-error@-1 {{cannot use @concurrent on instance method 'test(arg:)' because it has an isolated parameter: 'arg'}}
+  // expected-error@-1 {{cannot use '@concurrent' on instance method 'test(arg:)' because it has an isolated parameter: 'arg'}}
   @concurrent subscript(test arg: isolated MainActor) -> Int {
-  // expected-error@-1 {{cannot use @concurrent on subscript 'subscript(test:)' because it has an isolated parameter: 'arg'}}
+  // expected-error@-1 {{cannot use '@concurrent' on subscript 'subscript(test:)' because it has an isolated parameter: 'arg'}}
     get async {}
   }
 
@@ -99,11 +99,11 @@ struct TestAttributeCollisions {
   }
 
   @MainActor @concurrent func testGlobalActor() async {}
-  // expected-error@-1 {{instance method 'testGlobalActor()' has multiple actor-isolation attributes (@MainActor and @concurrent)}}
+  // expected-error@-1 {{instance method 'testGlobalActor()' has multiple actor-isolation attributes ('@MainActor' and '@concurrent')}}
 
   nonisolated(nonsending) nonisolated func testNonIsolatedCaller() async {} // expected-error {{duplicate modifier}} expected-note {{modifier already specified here}}
   @MainActor nonisolated(nonsending) func testGlobalActorCaller() async {}
-  // expected-error@-1 {{instance method 'testGlobalActorCaller()' has multiple actor-isolation attributes (@MainActor and 'nonisolated(nonsending)')}}
+  // expected-error@-1 {{instance method 'testGlobalActorCaller()' has multiple actor-isolation attributes ('@MainActor' and 'nonisolated(nonsending)')}}
   nonisolated(nonsending) func testCaller(arg: isolated MainActor) async {}
   // expected-error@-1 {{cannot use 'nonisolated(nonsending)' on instance method 'testCaller(arg:)' because it has an isolated parameter: 'arg'}}
   
@@ -128,12 +128,12 @@ struct IsolatedType {
 // `@concurrent` on closures does not contribute to `async` inference.
 do {
   _ = { @concurrent in }
-  // expected-error@-1:9 {{cannot use @concurrent on non-async closure}}{{none}}
+  // expected-error@-1:9 {{cannot use '@concurrent' on non-async closure}}{{none}}
   _ = { @concurrent () -> Int in }
-  // expected-error@-1:9 {{cannot use @concurrent on non-async closure}}{{none}}
+  // expected-error@-1:9 {{cannot use '@concurrent' on non-async closure}}{{none}}
   // Explicit effect precludes effects inference from the body.
   _ = { @concurrent () throws in await awaitMe() }
-  // expected-error@-1:9 {{cannot use @concurrent on non-async closure}}{{none}}
+  // expected-error@-1:9 {{cannot use '@concurrent' on non-async closure}}{{none}}
   // expected-error@-2:40 {{'async' call in a function that does not support concurrency}}{{none}}
   _ = { @concurrent () async in }
   _ = { @concurrent in await awaitMe() }
@@ -146,7 +146,7 @@ do {
 
     func sync() {
       foo { @concurrent in }
-      // expected-error@-1:13 {{cannot use @concurrent on non-async closure}}{{none}}
+      // expected-error@-1:13 {{cannot use '@concurrent' on non-async closure}}{{none}}
     }
     // expected-note@+1:10 {{add 'async' to function 'sync2()' to make it asynchronous}}{{17-17= async}}
     func sync2() {
@@ -157,7 +157,7 @@ do {
       // Even though the context is async, the sync overload is favored because
       // the closure is sync, so the error is expected.
       foo { @concurrent in }
-      // expected-error@-1:13 {{cannot use @concurrent on non-async closure}}{{none}}
+      // expected-error@-1:13 {{cannot use '@concurrent' on non-async closure}}{{none}}
 
       foo { @concurrent in await awaitMe() }
       // expected-error@-1:7 {{expression is 'async' but is not marked with 'await'}}{{7-7=await }}
@@ -175,7 +175,7 @@ do {
     }
     func async() async {
       foo { @concurrent _ in }
-      // expected-error@-1:13 {{cannot use @concurrent on non-async closure}}{{none}}
+      // expected-error@-1:13 {{cannot use '@concurrent' on non-async closure}}{{none}}
       // expected-error@-2:7 {{expression is 'async' but is not marked with 'await'}}{{7-7=await }}
       // expected-note@-3:7 {{call is 'async'}}{{none}}
     }
@@ -185,12 +185,12 @@ do {
     func foo<T>(_: T) {}
 
     foo({@concurrent in })
-    // expected-error@-1:10 {{cannot use @concurrent on non-async closure}}{{none}}
+    // expected-error@-1:10 {{cannot use '@concurrent' on non-async closure}}{{none}}
   }
 }
 
 _ = { @MainActor @concurrent in
-  // expected-error@-1 {{cannot use @concurrent because function type is isolated to a global actor 'MainActor'}}
+  // expected-error@-1 {{cannot use '@concurrent' because function type is isolated to a global actor 'MainActor'}}
 }
 
 // Make sure that explicit use of `@concurrent` doesn't interfere with inference of `throws` from the body.

--- a/test/attr/global_actor.swift
+++ b/test/attr/global_actor.swift
@@ -100,7 +100,7 @@ struct Container {
 // Redundant attributes
 // -----------------------------------------------------------------------
 extension SomeActor {
-  @GA1 nonisolated func conflict1() { } // expected-error {{instance method 'conflict1()' has multiple actor-isolation attributes (@GA1 and 'nonisolated')}}
+  @GA1 nonisolated func conflict1() { } // expected-error {{instance method 'conflict1()' has multiple actor-isolation attributes ('@GA1' and 'nonisolated')}}
 }
 
 

--- a/test/attr/lexical.swift
+++ b/test/attr/lexical.swift
@@ -15,10 +15,10 @@ func bar(@_noEagerMove _ s: S) {} // okay
 
 func baz(@_eagerMove _ c: C) {} // okay
 
-@_eagerMove // expected-error {{@_eagerMove is only valid on methods}}
+@_eagerMove // expected-error {{'@_eagerMove' is only valid on methods}}
 func bazzoo(_ c: C) {}
 
-@_noEagerMove // expected-error {{@_noEagerMove is only valid on methods}}
+@_noEagerMove // expected-error {{'@_noEagerMove' is only valid on methods}}
 func bazzoozoo(_ c: C) {}
 
 extension C {

--- a/test/attr/private_import.swift
+++ b/test/attr/private_import.swift
@@ -6,4 +6,4 @@
 @_private(sourceFile: "empty.swift") import empty // no-error
 @_private(sourceFile: "nonexistent_file.swift") import empty // no-error
 
-@_private(sourceFile: "none") func foo() {} // expected-error {{@_private may only be used on 'import' declarations}} {{1-31=}}
+@_private(sourceFile: "none") func foo() {} // expected-error {{'@_private' may only be used on 'import' declarations}} {{1-31=}}

--- a/test/attr/testable_invalid_decl.swift
+++ b/test/attr/testable_invalid_decl.swift
@@ -1,3 +1,3 @@
 // RUN: %target-swift-frontend -typecheck -verify %s
 
-@testable func foo() {} // expected-error {{@testable may only be used on 'import' declarations}} {{1-11=}}
+@testable func foo() {} // expected-error {{'@testable' may only be used on 'import' declarations}} {{1-11=}}

--- a/test/attr/typeEraser.swift
+++ b/test/attr/typeEraser.swift
@@ -35,7 +35,7 @@ protocol A2 {}
 @_typeEraser(AnyP // expected-note {{to match this opening '('}}
 protocol A3 {} // expected-error {{expected ')' after type name for '@_typeEraser'}}
 
-@_typeEraser(AnyP) // expected-error {{@_typeEraser may only be used on 'protocol' declarations}}
+@_typeEraser(AnyP) // expected-error {{'@_typeEraser' may only be used on 'protocol' declarations}}
 func notAProtocol() {}
 
 // MARK: - Type eraser must be a concrete nominal type

--- a/test/attr/warn_unqualified_access.swift
+++ b/test/attr/warn_unqualified_access.swift
@@ -6,13 +6,13 @@
 import Other1
 import Other2
 
-@warn_unqualified_access // expected-error {{@warn_unqualified_access may only be used on 'func' declarations}} {{1-26=}}
+@warn_unqualified_access // expected-error {{'@warn_unqualified_access' may only be used on 'func' declarations}} {{1-26=}}
 var x: Int { return 0 }
 
-@warn_unqualified_access // expected-error {{@warn_unqualified_access may only be used on 'func' declarations}} {{1-26=}}
+@warn_unqualified_access // expected-error {{'@warn_unqualified_access' may only be used on 'func' declarations}} {{1-26=}}
 struct X {}
 
-@warn_unqualified_access // expected-error {{only methods can be declared @warn_unqualified_access}} {{1-26=}}
+@warn_unqualified_access // expected-error {{only methods can be declared '@warn_unqualified_access'}} {{1-26=}}
 func topLevel() {
 }
 
@@ -58,7 +58,7 @@ func test(_ sub: Sub) {
   sub.b()
   sub.c()
 
-  @warn_unqualified_access // expected-error {{only methods can be declared @warn_unqualified_access}} {{3-28=}}
+  @warn_unqualified_access // expected-error {{only methods can be declared '@warn_unqualified_access'}} {{3-28=}}
   func inner() {
   }
   inner()

--- a/test/decl/enum/frozen-nonresilient.swift
+++ b/test/decl/enum/frozen-nonresilient.swift
@@ -2,4 +2,4 @@
 
 @frozen public enum Exhaustive {} // expected-no-warning
 
-@frozen enum NotPublic {} // expected-warning{{@frozen has no effect on non-public enums}}
+@frozen enum NotPublic {} // expected-warning{{'@frozen' has no effect on non-public enums}}

--- a/test/decl/enum/frozen.swift
+++ b/test/decl/enum/frozen.swift
@@ -2,7 +2,7 @@
 
 @frozen public enum Exhaustive {} // no-warning
 
-@frozen enum NotPublic {} // expected-warning {{@frozen has no effect on non-public enums}} {{1-9=}}
+@frozen enum NotPublic {} // expected-warning {{'@frozen' has no effect on non-public enums}} {{1-9=}}
 
 internal enum Outer {
   @frozen public enum ButThisIsOK {} // no-warning
@@ -10,6 +10,6 @@ internal enum Outer {
 
 @frozen @usableFromInline enum NotPublicButVersioned {} // no-warning
 
-@frozen enum DeprecationWarning {} // expected-warning {{@frozen has no effect on non-public enums}} {{1-9=}}
+@frozen enum DeprecationWarning {} // expected-warning {{'@frozen' has no effect on non-public enums}} {{1-9=}}
 
 @_frozen public enum UnderscoredFrozen {}

--- a/test/decl/ext/cdecl_official_implementation.swift
+++ b/test/decl/ext/cdecl_official_implementation.swift
@@ -76,7 +76,7 @@ extension CImplStruct {
   @implementation @c(CImplStructStaticFunc1)
   static func staticFunc1(_: Int32) {
     // FIXME: Add underlying support for this
-    // expected-error@-3 {{@c can only be applied to global functions}}
+    // expected-error@-3 {{'@c' can only be applied to global functions}}
     // FIXME: Lookup in an enclosing type is not working yet
     // expected-error@-5 {{could not find imported function 'CImplStructStaticFunc1' matching static method 'staticFunc1'; make sure you import the module or header that declares it}}
   }

--- a/test/decl/ext/objc_implementation.swift
+++ b/test/decl/ext/objc_implementation.swift
@@ -659,7 +659,7 @@ extension CImplStruct {
   @implementation @_cdecl("CImplStructStaticFunc1")
   static func staticFunc1(_: Int32) {
     // FIXME: Add underlying support for this
-    // expected-error@-3 {{@_cdecl can only be applied to global functions}}
+    // expected-error@-3 {{'@_cdecl' can only be applied to global functions}}
     // FIXME: Lookup in an enclosing type is not working yet
     // expected-error@-5 {{could not find imported function 'CImplStructStaticFunc1' matching static method 'staticFunc1'; make sure you import the module or header that declares it}}
   }

--- a/test/decl/ext/objc_implementation_early_adopter.swift
+++ b/test/decl/ext/objc_implementation_early_adopter.swift
@@ -640,7 +640,7 @@ extension CImplStruct {
   @implementation @_cdecl("CImplStructStaticFunc1")
   static func staticFunc1(_: Int32) {
     // FIXME: Add underlying support for this
-    // expected-error@-3 {{@_cdecl can only be applied to global functions}}
+    // expected-error@-3 {{'@_cdecl' can only be applied to global functions}}
     // FIXME: Lookup in an enclosing type is not working yet
     // expected-error@-5 {{could not find imported function 'CImplStructStaticFunc1' matching static method 'staticFunc1'; make sure you import the module or header that declares it}}
   }

--- a/test/decl/func/debugger_function.swift
+++ b/test/decl/func/debugger_function.swift
@@ -1,7 +1,7 @@
 // RUN: %target-typecheck-verify-swift -enable-throw-without-try -debugger-support
 
 var invalidAccessor : Int {
-  // expected-error@+1 {{@LLDBDebuggerFunction may only be used on 'func' declarations}} {{1-+1:1=}}
+  // expected-error@+1 {{'@LLDBDebuggerFunction' may only be used on 'func' declarations}} {{1-+1:1=}}
   @LLDBDebuggerFunction
   get { return 42 }
 }

--- a/test/decl/import/inconsistent-weaklinked-import.swift
+++ b/test/decl/import/inconsistent-weaklinked-import.swift
@@ -12,31 +12,31 @@
 
 //--- 1.swift
 
-@_weakLinked import NotSoSecret // expected-note {{imported with @_weakLinked here}}
-import NotSoSecret2 // expected-error {{'NotSoSecret2' inconsistently imported with @_weakLinked}} {{1-1=@_weakLinked }}
-import NotSoSecret3 // expected-error {{'NotSoSecret3' inconsistently imported with @_weakLinked}} {{1-1=@_weakLinked }}
+@_weakLinked import NotSoSecret // expected-note {{imported with '@_weakLinked' here}}
+import NotSoSecret2 // expected-error {{'NotSoSecret2' inconsistently imported with '@_weakLinked'}} {{1-1=@_weakLinked }}
+import NotSoSecret3 // expected-error {{'NotSoSecret3' inconsistently imported with '@_weakLinked'}} {{1-1=@_weakLinked }}
 
 @_weakLinked import ActuallySecret // no-error
 import ActuallyOkay // no-error
 
-@_exported import Contradictory // expected-error {{'Contradictory' inconsistently imported with @_weakLinked}} {{12-12=@_weakLinked }}
+@_exported import Contradictory // expected-error {{'Contradictory' inconsistently imported with '@_weakLinked'}} {{12-12=@_weakLinked }}
 
 //--- 2.swift
 
-import NotSoSecret // expected-error {{'NotSoSecret' inconsistently imported with @_weakLinked}}
-@_weakLinked import NotSoSecret2 // expected-note 2 {{imported with @_weakLinked here}}
-import NotSoSecret3 // expected-error {{'NotSoSecret3' inconsistently imported with @_weakLinked}}
+import NotSoSecret // expected-error {{'NotSoSecret' inconsistently imported with '@_weakLinked'}}
+@_weakLinked import NotSoSecret2 // expected-note 2 {{imported with '@_weakLinked' here}}
+import NotSoSecret3 // expected-error {{'NotSoSecret3' inconsistently imported with '@_weakLinked'}}
 
 @_weakLinked import ActuallySecret // no-error
 import ActuallyOkay // no-error
 
-@_weakLinked import Contradictory // expected-note {{imported with @_weakLinked here}}
+@_weakLinked import Contradictory // expected-note {{imported with '@_weakLinked' here}}
 
 //--- 3.swift
 
 @_weakLinked import NotSoSecret
-import NotSoSecret2 // expected-error {{'NotSoSecret2' inconsistently imported with @_weakLinked}}
-@_weakLinked import NotSoSecret3 // expected-note 2 {{imported with @_weakLinked here}}
+import NotSoSecret2 // expected-error {{'NotSoSecret2' inconsistently imported with '@_weakLinked'}}
+@_weakLinked import NotSoSecret3 // expected-note 2 {{imported with '@_weakLinked' here}}
 
 @_weakLinked import ActuallySecret // no-error
 import ActuallyOkay // no-error

--- a/test/decl/var/NSCopying.swift
+++ b/test/decl/var/NSCopying.swift
@@ -11,10 +11,10 @@ class CopyableClass : NSCopying {
   }
 }
 
-@NSCopying  // expected-error {{@NSCopying may only be used on 'var' declarations}}
+@NSCopying  // expected-error {{'@NSCopying' may only be used on 'var' declarations}}
 func copyFunction() {}
 
-@NSCopying   // expected-error {{@NSCopying may only be used on 'var' declarations}}
+@NSCopying   // expected-error {{'@NSCopying' may only be used on 'var' declarations}}
 struct CopyingStruct  {
   @NSCopying var x : CopyableClass   // expected-error {{'@NSCopying' may only be used on properties in classes}}
 }


### PR DESCRIPTION
Changes how `DiagnosticEngine` prints `DeclAttribute`, to match `TypeAttribute`. `%kind0` will show attribute or modifier as appropriate, and `%0` will quote and include an at sign if appropriate. This prevents diagnostics like `attribute @foo`. Also updates the diagnostic message for unsupported_closure_attr to use this new behavior instead of a select.

This updates a ton of tests, to use the new consistent `'@foo' `or `attribute 'foo'` style. Many of these diagnostics had `%0`, and now get quoting automatically, but diagnostics that quoted their attribute needed to be edited.

This change means it's easier for new diagnostics to follow @AnthonyLatsis's newish guidelines for attributes in `docs/Diagnostics.md`.

This might be annoying to land while we are still picking changes to 6.4 since a diagnostic handled by this PR would quote its attribute, but wouldn't on 6.4 (unless we cherrypick this...). 

#89023 has a diagnostic that manually quotes an attribute right now, so whichever one lands second needs to be edited.

I only tested on macOS so I'd be totally unsurprised if I missed diagnostics that only show up on Windows or Linux, but those _should_ get caught in PR testing... Note that some of these diagnostics do appear to have no test coverage, those were found based on having `DeclAttribute` in the diagnostic.

Edit: going to revisit this after the betas...