### PR TITLE
[cxx-interop] Enforce that derived FRTs have a single shared FRT base

### DIFF
--- a/include/swift/ClangImporter/ClangImporterRequests.h
+++ b/include/swift/ClangImporter/ClangImporterRequests.h
@@ -390,8 +390,7 @@ public:
   /// A shared reference type using the retain/release functions from \a decl.
   static ForeignReferenceTypeInfo
   Shared(const clang::RecordDecl *decl,
-         const clang::CXXRecordDecl *primarySuperclass = nullptr,
-         bool isValid = true) {
+         const clang::CXXRecordDecl *primarySuperclass, bool isValid = true) {
     ASSERT(decl && "shared reference must have a non-null base decl");
     return {decl, primarySuperclass, isValid, /*isRef=*/true};
   }

--- a/lib/ClangImporter/ClangAnalysis.cpp
+++ b/lib/ClangImporter/ClangAnalysis.cpp
@@ -1,13 +1,14 @@
 #include "ImporterImpl.h"
 #include "swift/AST/DiagnosticsClangImporter.h"
 #include "swift/AST/Types.h"
+#include "swift/Basic/Defer.h"
 #include "swift/ClangImporter/ClangImporter.h"
 #include "swift/ClangImporter/ClangImporterRequests.h"
 #include "clang/AST/DeclCXX.h"
 #include "clang/AST/DeclObjC.h"
 #include "clang/AST/RecordLayout.h"
 #include "clang/AST/Type.h"
-#include "llvm/ADT/SetVector.h"
+#include "clang/Basic/Specifiers.h"
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallVector.h"
 
@@ -25,225 +26,197 @@ bool importer::hasImportAsOpaquePointerAttr(const clang::RecordDecl *decl) {
          });
 }
 
-static ForeignReferenceTypeInfo
-checkForeignReferenceType(const clang::CXXRecordDecl *decl,
-                          ClangImporter::Implementation *Impl);
+namespace {
+class ForeignReferenceTypeChecker {
+  /// We are checking this to determine whether it is a foreign reference type.
+  const clang::CXXRecordDecl *checkedDecl;
 
-static std::pair<std::optional<StringRef>, std::optional<StringRef>>
-getRetainReleaseOperations(const clang::RecordDecl *decl) {
-  if (!decl->hasAttrs())
-    return {std::nullopt, std::nullopt};
+  /// Used for emitting diagnostics.
+  ClangImporter::Implementation *Impl = nullptr;
 
-  std::optional<StringRef> retain, release;
-  for (auto attr : decl->getAttrs()) {
-    auto swiftAttr = dyn_cast<clang::SwiftAttrAttr>(attr);
-    if (!swiftAttr)
-      continue;
-    auto attrStr = swiftAttr->getAttribute();
+  /// Whether we encountered a non-record base during the base traversal.
+  bool hasNonRecordBase = false;
 
-    if (attrStr.consume_front("retain:"))
-      retain = attrStr;
-    else if (attrStr.consume_front("release:"))
-      release = attrStr;
-  }
-  return {retain, release};
-}
+  /// Base classes that are marked as FRTs. Populated by \c visitBases().
+  llvm::SmallVector<const clang::CXXRecordDecl *, 1> FRTBases;
 
-/// If \p decl has exactly one direct FRT base and it is at offset 0 in the
-/// C++ layout, return it. Being at offset 0 means a pointer bitcast suffices
-/// for upcasting in IRGen. This is the case when the FRT base is the first
-/// base, or when all bases before it are empty (empty base optimization).
-static const clang::CXXRecordDecl *
-findPrimarySuperclassBase(const clang::CXXRecordDecl *decl,
-                          const clang::CXXRecordDecl *baseWithLifetimeOps) {
-  if (!decl->hasDefinition())
-    return nullptr;
-
-  const clang::CXXRecordDecl *singleFRTBase = nullptr;
-  ForeignReferenceTypeInfo singleFRTBaseInfo;
-
-  for (auto base : decl->bases()) {
-    if (auto baseRecordDecl = base.getType()->getAsCXXRecordDecl()) {
-      auto baseFRTInfo =
-          checkForeignReferenceType(baseRecordDecl, /*Impl=*/nullptr);
-      if (!baseFRTInfo.isReference() || base.isVirtual() ||
-          base.getAccessSpecifier() != clang::AccessSpecifier::AS_public)
-        continue;
-
-      if (singleFRTBase)
-        // Bail if we found multiple FRT bases.
-        return nullptr;
-
-      singleFRTBase = baseRecordDecl;
-      singleFRTBaseInfo = baseFRTInfo;
-    }
-  }
-
-  if (!singleFRTBase)
-    return nullptr;
-
-  auto &clangCtx = decl->getASTContext();
-  auto &layout = clangCtx.getASTRecordLayout(decl);
-  if (!layout.getBaseClassOffset(singleFRTBase).isZero())
-    return nullptr;
-
-  // If decl has attributes with lifetime operations, check that they match.
-  auto [overriddenRetain, overriddenRelease] =
-      getRetainReleaseOperations(baseWithLifetimeOps);
-  auto [baseRetain, baseRelease] =
-      getRetainReleaseOperations(singleFRTBaseInfo.getDecl());
-  if ((overriddenRelease && overriddenRelease != baseRelease) ||
-      (overriddenRetain && overriddenRetain != baseRetain))
-    return nullptr;
-
-  return singleFRTBase;
-}
-
-/// This routine determines whether \a decl is a foreign reference type, and
-/// whether its foreign reference type attributes are valid. This determinition
-/// considers attributes annotated on both \a decl itself as well as its
-/// transitive bases.
-///
-/// When \a Impl is non-null, this function will use it to emit diagnostics for
-/// invalid attributes; when \a Impl is null, those diagnostics are not emitted
-/// (but the returned ForeignReferenceTypeInfo will still indicate \a decl has
-/// invalid attributes). This function is designed this way to keep the site
-/// where diagnostics are emitted close to the logic that leads to them.
-static ForeignReferenceTypeInfo
-checkForeignReferenceType(const clang::CXXRecordDecl *decl,
-                          ClangImporter::Implementation *Impl) {
-  // This was explicitly annotated. Just trust the annotation.
-  if (importer::hasImportReferenceAttr(decl))
-    return ForeignReferenceTypeInfo::Shared(decl,
-                                            findPrimarySuperclassBase(decl, decl));
-
-  if (!decl->hasDefinition())
-    // If this doesn't have a definition, there's no inheritance info to check.
-    return ForeignReferenceTypeInfo::Value();
-
-  // Keep track of base classes that are marked as FRTs, with set semantics
-  // because we cannot have multiple copies of the same base FRT.
-  llvm::SmallSetVector<const clang::CXXRecordDecl *, 1> FRTBases;
-
-  // Keep track of virtual bases, which we only need to visit once.
+  /// Virtual bases, which we only need to visit once.
   llvm::SmallPtrSet<const clang::CXXRecordDecl *, 1> virtualBases;
 
-  // Bases we have yet to visit. Each base class instance should appear
-  // in this container exactly once.
-  llvm::SmallVector<const clang::CXXRecordDecl *, 4> unvisitedBases;
+  /// Recursively visits the bases of \p decl to accumulate FRT information.
+  ///
+  /// If exactly one base of \p decl leads to an annotated FRT base class, then
+  /// this function returns a pointer to that direct base. Returns \c nullptr
+  /// otherwise.
+  const clang::CXXRecordDecl *visitBases(const clang::CXXRecordDecl *decl) {
+    if (!decl->hasDefinition())
+      // Without a definition, there's no inheritance info to check.
+      return nullptr;
 
-  // N.B. our definition of "base" also includes the origin class itself,
-  //      i.e., decl
-  unvisitedBases.push_back(decl);
-
-  bool multipleFRTs = false;
-
-  while (!unvisitedBases.empty()) {
-    auto *rec = unvisitedBases.pop_back_val();
-
-    if (importer::hasImportReferenceAttr(rec)) {
-      if (!FRTBases.insert(rec)) {
-        // The same base FRT appears multiple times in the class hierarchy
-        // (i.e., due to diamond inheritance), which is not valid. Bail.
-        multipleFRTs = true;
-        break;
+    const clang::CXXRecordDecl *singleFRTSuperclass = nullptr;
+    bool multipleFRTSuperclasses = false;
+    for (auto declBase : decl->bases()) {
+      auto *base = declBase.getType()->getAsCXXRecordDecl();
+      if (!base) {
+        // It is possible to encounter `clang::TemplateSpecializationType`s.
+        // In such cases, report this as invalid and continue past it.
+        hasNonRecordBase = true;
+        continue;
       }
-    }
-
-    for (auto recBase : rec->bases()) {
-      auto *base = recBase.getType()->getAsCXXRecordDecl();
-      if (!base)
-        // It is possible to encounter clang::TemplateSpecializationType.
-        // In such cases, just bail and report this as an invalid value type
-        return ForeignReferenceTypeInfo::Value(/*isValid=*/false);
 
       ASSERT(base->hasDefinition() && "base record should be complete");
       base = base->getDefinition();
-
       ASSERT(!base->isDependentContext() && "base should not be dependent");
 
-      if (recBase.isVirtual()) {
-        if (virtualBases.insert(base).second)
-          // First time seeing this virtual base. Visit it later.
-          unvisitedBases.push_back(base);
-      } else {
-        // Visit this non-virtual base class later.
-        unvisitedBases.push_back(base);
+      if (!declBase.isVirtual() || virtualBases.insert(base).second) {
+        bool baseIsFRT = false;
+        if (importer::hasImportReferenceAttr(base)) {
+          FRTBases.push_back(base);
+          baseIsFRT = true;
+        }
+        baseIsFRT |= static_cast<bool>(visitBases(base));
+
+        if (baseIsFRT && !declBase.isVirtual() &&
+            declBase.getAccessSpecifier() ==
+                clang::AccessSpecifier::AS_public) {
+          if (singleFRTSuperclass)
+            multipleFRTSuperclasses = true;
+          else
+            singleFRTSuperclass = base;
+        }
       }
     }
+
+    return multipleFRTSuperclasses ? nullptr : singleFRTSuperclass;
   }
 
-  if (FRTBases.empty())
-    // Did not encounter any FRTs in the class hierarchy
-    return ForeignReferenceTypeInfo::Value();
-
-  // This is the first FRT we encountered during our base traversal,
-  // so we shall use it as our "canonical" FRT base.
-  auto *baseFRT = FRTBases.front();
-
-  if (multipleFRTs) {
-    // The same FRT base appears multiple times in the class hierarchy
-    if (Impl)
-      Impl->diagnose(HeaderLoc{decl->getLocation()},
-                     diag::cant_infer_frt_in_cxx_inheritance, decl);
-
-    // decl inherits from FRT base, so we should treat it as a reference
-    // type, albeit an invalid one (due to ambiguity).
-    //
-    // return ForeignReferenceTypeInfo::Shared(baseFRT, /*isValid=*/false);
-    //
-    // However, in honor the existing behavior, (for now) we will report that
-    // this is an (invalid) value type.
-    return ForeignReferenceTypeInfo::Value(/*isValid=*/false);
+  /// Whether \p base is non-null and has an offset of zero from \c checkedDecl.
+  bool atOffsetZero(const clang::CXXRecordDecl *base) const {
+    ASSERT(checkedDecl);
+    if (base == nullptr)
+      return false;
+    auto &clangCtx = checkedDecl->getASTContext();
+    auto &layout = clangCtx.getASTRecordLayout(checkedDecl);
+    return layout.getBaseClassOffset(base).isZero();
   }
 
-  constexpr StringRef retainPrefix = "retain:", releasePrefix = "release:";
-  std::optional<StringRef> retain = std::nullopt, release = std::nullopt;
-  bool multipleOps = false;
+  /// Extract the retain and release operation annotations from \p decl.
+  static std::pair<std::optional<StringRef>, std::optional<StringRef>>
+  getRetainReleaseOps(const clang::RecordDecl *decl) {
+    if (!decl->hasAttrs())
+      return {std::nullopt, std::nullopt};
 
-  for (auto *base : FRTBases) {
-    for (auto *attr : base->getAttrs()) {
-      auto *swiftAttr = llvm::dyn_cast<clang::SwiftAttrAttr>(attr);
+    std::optional<StringRef> retain = std::nullopt, release = std::nullopt;
+    for (auto attr : decl->getAttrs()) {
+      auto swiftAttr = dyn_cast<clang::SwiftAttrAttr>(attr);
       if (!swiftAttr)
         continue;
+
       auto attrStr = swiftAttr->getAttribute();
-      if (attrStr.consume_front(retainPrefix)) {
-        if (retain.has_value() && retain.value() != attrStr) {
-          multipleOps = true;
-          break;
-        }
+
+      if (attrStr.consume_front("retain:"))
         retain = attrStr;
-      } else if (attrStr.consume_front(releasePrefix)) {
-        if (release.has_value() && release.value() != attrStr) {
-          multipleOps = true;
-          break;
-        }
+      else if (attrStr.consume_front("release:"))
         release = attrStr;
+    }
+    return {retain, release};
+  }
+
+  /// Whether \p x is non-nullopt and matches \p y.
+  static bool opsMatch(std::optional<StringRef> x, std::optional<StringRef> y) {
+    return x && x == y;
+  }
+
+public:
+  ForeignReferenceTypeChecker(const clang::CXXRecordDecl *checkedDecl)
+      : checkedDecl{checkedDecl} {}
+
+  ForeignReferenceTypeChecker &&
+  withDiagnostics(ClangImporter::Implementation &ImplRef) && {
+    Impl = &ImplRef;
+    return std::move(*this);
+  }
+
+  ForeignReferenceTypeInfo check() && {
+    ASSERT(checkedDecl && "ForeignReferenceTypeInfo should only be used once");
+    SWIFT_DEFER { checkedDecl = nullptr; };
+
+    bool explicitlyAnnotated = importer::hasImportReferenceAttr(checkedDecl);
+    const clang::CXXRecordDecl *uniqueDirectFRTBase = visitBases(checkedDecl);
+
+    if (!explicitlyAnnotated && FRTBases.empty()) {
+      // Neither checkedDecl nor any of its base classes are annotated as
+      // a reference type, so checkedDecl is a value type.
+      ASSERT(uniqueDirectFRTBase == nullptr &&
+             "there should be no superclass if there are no FRT bases");
+      return ForeignReferenceTypeInfo::Value();
+    }
+
+    // The primary FRT superclass is the unique direct FRT base of checkedDecl,
+    // but only if it is at offset 0 (so a pointer bitcast suffices for upcast).
+    auto *primarySuperclass =
+        atOffsetZero(uniqueDirectFRTBase) ? uniqueDirectFRTBase : nullptr;
+
+    if (explicitlyAnnotated && primarySuperclass) {
+      auto [retain, release] = getRetainReleaseOps(checkedDecl);
+      auto [superRetain, superRelease] = getRetainReleaseOps(primarySuperclass);
+      if (!opsMatch(retain, superRetain) || !opsMatch(release, superRelease))
+        primarySuperclass = nullptr;
+    }
+
+    const clang::CXXRecordDecl *FRTBase;
+    if (explicitlyAnnotated) {
+      FRTBase = checkedDecl;
+    } else {
+      ASSERT(!FRTBases.empty() && "if checkedDecl wasn't explicitly annotated,"
+                                  "at least one of its bases should be an FRT");
+      FRTBase = nullptr;
+      std::optional<StringRef> FRTBaseRetain = std::nullopt,
+                               FRTBaseRelease = std::nullopt;
+      llvm::SmallPtrSet<const clang::CXXRecordDecl *, 1> seenBases;
+      bool recurringBase = false, ambiguousOps = false;
+      for (auto *base : FRTBases) {
+        if (!seenBases.insert(base).second) {
+          recurringBase = true;
+          continue;
+        }
+
+        if (FRTBase == nullptr) {
+          FRTBase = base;
+          std::tie(FRTBaseRetain, FRTBaseRelease) = getRetainReleaseOps(base);
+          continue;
+        }
+
+        auto [baseRetain, baseRelease] = getRetainReleaseOps(base);
+        if (!opsMatch(FRTBaseRetain, baseRetain) ||
+            !opsMatch(FRTBaseRelease, baseRelease))
+          ambiguousOps = true;
+      }
+
+      if (recurringBase || ambiguousOps) {
+        // checkedDecl is an invalid FRT, either because the same FRT base
+        // appears multiple times, or because different FRT bases provide
+        // conflicting retain/release operations.
+        if (Impl)
+          Impl->diagnose(HeaderLoc{checkedDecl->getLocation()},
+                         diag::cant_infer_frt_in_cxx_inheritance, checkedDecl);
+
+        // decl inherits from FRT base, so we should treat it as a reference
+        // type, albeit an invalid one (due to ambiguity).
+        //
+        // return ForeignReferenceTypeInfo::Shared(FRTBase, nullptr,
+        //                                         /*isValid=*/false);
+        //
+        // However, to honor the existing behavior, (for now) we will report
+        // that this is an (invalid) value type.
+        return ForeignReferenceTypeInfo::Value(/*isValid=*/false);
       }
     }
 
-    if (multipleOps)
-      break;
+    return ForeignReferenceTypeInfo::Shared(FRTBase, primarySuperclass);
   }
-
-  if (multipleOps) {
-    if (Impl)
-      Impl->diagnose(HeaderLoc{decl->getLocation()},
-                     diag::cant_infer_frt_in_cxx_inheritance, decl);
-
-    // decl inherits from FRT base, so we should treat it as a reference
-    // type, albeit an invalid one (due to ambiguity).
-    //
-    // return ForeignReferenceTypeInfo::Shared(baseFRT, /*isValid=*/false);
-    //
-    // However, in honor the existing behavior, (for now) we will report that
-    // this is an (invalid) value type.
-    return ForeignReferenceTypeInfo::Value(/*isValid=*/false);
-  }
-
-  return ForeignReferenceTypeInfo::Shared(
-      baseFRT, findPrimarySuperclassBase(decl, baseFRT));
-}
+};
+} // namespace
 
 void swift::simple_display(llvm::raw_ostream &out,
                            const ForeignReferenceTypeInfoDescriptor &desc) {
@@ -267,13 +240,14 @@ ForeignReferenceTypeInfo ForeignReferenceTypeInfoRequest::evaluate(
   auto *decl = desc.decl;
 
   if (auto *cxxDecl = dyn_cast<clang::CXXRecordDecl>(decl))
-    return checkForeignReferenceType(cxxDecl, nullptr);
+    return ForeignReferenceTypeChecker(cxxDecl).check();
 
   // If this isn't a C++ record, then there's no inheritance (nor any of the
   // associated complications) to worry about. Just look for ref attributes.
 
   if (importer::hasImportReferenceAttr(decl))
-    return ForeignReferenceTypeInfo::Shared(decl);
+    return ForeignReferenceTypeInfo::Shared(decl,
+                                            /*primarySuperclass=*/nullptr);
 
   return ForeignReferenceTypeInfo::Value();
 }
@@ -292,9 +266,10 @@ bool importer::diagnoseForeignReferenceType(
   // If the result was invalid, we need to run the underlying check again, but
   // this time with ClangImporter::Implemention in order to emit diagnostics.
   // This slow path does redundant work but only for invalid decls.
-  auto infoAgain = checkForeignReferenceType(decl, &Impl);
+  auto infoAgain =
+      ForeignReferenceTypeChecker(decl).withDiagnostics(Impl).check();
   // FIXME: this appears to be non-deterministic in some configurations
-  // ASSERT(!infoAgain.isValid() && "FRT check validity should be deterministic");
+  // ASSERT(!infoAgain.isValid() && "FRT check should be deterministic");
   (void)infoAgain;
   return false;
 }

--- a/lib/ClangImporter/ClangAnalysis.cpp
+++ b/lib/ClangImporter/ClangAnalysis.cpp
@@ -172,32 +172,25 @@ public:
       ASSERT(!FRTBases.empty() && "if checkedDecl wasn't explicitly annotated,"
                                   "at least one of its bases should be an FRT");
       FRTBase = nullptr;
-      std::optional<StringRef> FRTBaseRetain = std::nullopt,
-                               FRTBaseRelease = std::nullopt;
-      llvm::SmallPtrSet<const clang::CXXRecordDecl *, 1> seenBases;
-      bool recurringBase = false, ambiguousOps = false;
+      bool seenShared = false, seenMultipleShared = false, seenImmortal = false;
       for (auto *base : FRTBases) {
-        if (!seenBases.insert(base).second) {
-          recurringBase = true;
-          continue;
-        }
-
-        if (FRTBase == nullptr) {
+        if (importer::hasAnyImmortalAttr(base)) {
+          seenImmortal = true;
+        } else if (!FRTBase) {
           FRTBase = base;
-          std::tie(FRTBaseRetain, FRTBaseRelease) = getRetainReleaseOps(base);
-          continue;
+          seenShared = true;
+        } else {
+          seenMultipleShared = true;
         }
-
-        auto [baseRetain, baseRelease] = getRetainReleaseOps(base);
-        if (!opsMatch(FRTBaseRetain, baseRetain) ||
-            !opsMatch(FRTBaseRelease, baseRelease))
-          ambiguousOps = true;
       }
 
-      if (recurringBase || ambiguousOps) {
-        // checkedDecl is an invalid FRT, either because the same FRT base
-        // appears multiple times, or because different FRT bases provide
-        // conflicting retain/release operations.
+      // If there are no shared references, FRTBase is the first immortal base
+      FRTBase = FRTBase ? FRTBase : FRTBases.front();
+
+      if (seenMultipleShared || (seenShared && seenImmortal)) {
+        // checkedDecl is an invalid FRT, either because it has multiple shared
+        // FRT bases (ambiguous retain/release ops), or because it has mixed
+        // ancestry between shared and immortal bases.
         if (Impl)
           Impl->diagnose(HeaderLoc{checkedDecl->getLocation()},
                          diag::cant_infer_frt_in_cxx_inheritance, checkedDecl);
@@ -214,6 +207,7 @@ public:
       }
     }
 
+    ASSERT(FRTBase && "should have encountered FRTBase");
     return ForeignReferenceTypeInfo::Shared(FRTBase, primarySuperclass);
   }
 };

--- a/lib/ClangImporter/ClangAnalysis.cpp
+++ b/lib/ClangImporter/ClangAnalysis.cpp
@@ -69,12 +69,13 @@ class ForeignReferenceTypeChecker {
       ASSERT(!base->isDependentContext() && "base should not be dependent");
 
       if (!declBase.isVirtual() || virtualBases.insert(base).second) {
-        bool baseIsFRT = false;
+        bool baseIsFRT;
         if (importer::hasImportReferenceAttr(base)) {
           FRTBases.push_back(base);
           baseIsFRT = true;
+        } else {
+          baseIsFRT = static_cast<bool>(visitBases(base));
         }
-        baseIsFRT |= static_cast<bool>(visitBases(base));
 
         if (baseIsFRT && !declBase.isVirtual() &&
             declBase.getAccessSpecifier() ==

--- a/lib/ClangImporter/ClangAnalysis.cpp
+++ b/lib/ClangImporter/ClangAnalysis.cpp
@@ -102,12 +102,12 @@ class ForeignReferenceTypeChecker {
   }
 
   /// Extract the retain and release operation annotations from \p decl.
-  static std::pair<std::optional<StringRef>, std::optional<StringRef>>
+  static std::pair<StringRef, StringRef>
   getRetainReleaseOps(const clang::RecordDecl *decl) {
     if (!decl->hasAttrs())
-      return {std::nullopt, std::nullopt};
+      return {StringRef(), StringRef()};
 
-    std::optional<StringRef> retain = std::nullopt, release = std::nullopt;
+    StringRef retain{}, release{};
     for (auto attr : decl->getAttrs()) {
       auto swiftAttr = dyn_cast<clang::SwiftAttrAttr>(attr);
       if (!swiftAttr)
@@ -124,8 +124,8 @@ class ForeignReferenceTypeChecker {
   }
 
   /// Whether \p x is non-nullopt and matches \p y.
-  static bool opsMatch(std::optional<StringRef> x, std::optional<StringRef> y) {
-    return x && x == y;
+  static bool opsMatch(StringRef x, StringRef y) {
+    return !x.empty() && x == y;
   }
 
 public:

--- a/test/Interop/Cxx/foreign-reference/Inputs/inherit-frt.hpp
+++ b/test/Interop/Cxx/foreign-reference/Inputs/inherit-frt.hpp
@@ -39,14 +39,15 @@ _Pragma("clang diagnostic ignored \"-Wnullability-extension\"");
   }                                                                            \
   struct Name
 
-#define _SHARED(Name, RetainRelease)                                           \
+#define _SHARED(Name, Retain, Release, MoreStructMembers)                      \
   {                                                                            \
     int refcount = 1;                                                          \
     _STRUCT_PAYLOAD;                                                           \
+    MoreStructMembers                                                          \
   }                                                                            \
   __attribute__((swift_attr("import_reference")))                              \
-  __attribute__((swift_attr("retain:retain" #RetainRelease)))                  \
-  __attribute__((swift_attr("release:release" #RetainRelease)));               \
+  __attribute__((swift_attr("retain:" #Retain)))                               \
+  __attribute__((swift_attr("release:" #Release)));                            \
   __attribute__((swift_attr("returns_retained"))) inline Name *make##Name() {  \
     return new Name{};                                                         \
   }                                                                            \
@@ -59,7 +60,7 @@ _Pragma("clang diagnostic ignored \"-Wnullability-extension\"");
 /// class release function, typically done using CRTP or by embedding memory
 /// layout info into the base class.
 #define SHARED(Name)                                                           \
-  _SHARED(Name, Name);                                                         \
+  _SHARED(Name, retain##Name, release##Name, );                                \
   inline void retain##Name(Name *t) { ++t->refcount; }                         \
   inline void release##Name(Name *t) {                                         \
     if (--t->refcount <= 0)                                                    \
@@ -69,7 +70,8 @@ _Pragma("clang diagnostic ignored \"-Wnullability-extension\"");
 
 /// Struct with shared reference annotations, reusing a base's retain/release
 /// functions
-#define SHARED_USING_BASE(Name, Base) _SHARED(Name, Base)
+#define SHARED_USING_BASE(Name, Base)                                          \
+  _SHARED(Name, retain##Base, release##Base, )
 
 // MARK: Simple: simple record types without inheritance
 

--- a/test/Interop/Cxx/foreign-reference/Inputs/inherit-frt.hpp
+++ b/test/Interop/Cxx/foreign-reference/Inputs/inherit-frt.hpp
@@ -73,11 +73,31 @@ _Pragma("clang diagnostic ignored \"-Wnullability-extension\"");
 #define SHARED_USING_BASE(Name, Base)                                          \
   _SHARED(Name, retain##Base, release##Base, )
 
+/// Struct with shared reference annotations that defines its own retain/release
+/// operations as methods
+#define SHARED_DEF_METHOD(Name, Suffix)                                        \
+  _SHARED(                                                                     \
+      Name, .doRetain##Suffix, .doRelease##Suffix,                             \
+      void doRetain##Suffix() { ++refcount; };                                 \
+      void doRelease##Suffix() {                                               \
+        if (--refcount <= 0)                                                   \
+          (void)"DELETION PLACEHOLDER";                                        \
+      })
+
+/// Struct with shared reference annotations that uses retain/release methods,
+/// presumably inherited from elsewhere
+#define SHARED_USE_METHOD(Name, Suffix)                                        \
+  _SHARED(Name, .doRetain##Suffix, .doRelease##Suffix, )
+
 // MARK: Simple: simple record types without inheritance
 
 struct SimpleValue NO_ATTR(SimpleValue);
 struct SimpleShared SHARED(SimpleShared);
 struct SimpleImmortal IMMORTAL(SimpleImmortal);
+struct SimpleSharedMethod SHARED_DEF_METHOD(SimpleSharedMethod, );
+struct SimpleSharedMissingMethod SHARED_USE_METHOD(SimpleSharedMissingMethod, );
+// expected-error@-1 {{cannot find retain function}}
+// expected-error@-2 {{cannot find release function}}
 
 // MARK: SingleShared: single inheritance with a shared refence base
 
@@ -102,6 +122,13 @@ struct SingleShared_NoAttr_Shared
     : SingleShared_NoAttr SHARED(SingleShared_NoAttr_Shared);
 struct SingleShared_NoAttr_NoAttr
     : SingleShared_NoAttr NO_ATTR_SHARED(SingleShared_NoAttr_NoAttr);
+
+struct SingleSharedM_BaseM SHARED_DEF_METHOD(SingleSharedM_BaseM, );
+
+struct SingleSharedM_SharedM
+    : SingleSharedM_BaseM SHARED_DEF_METHOD(SingleSharedM_SharedM, );
+struct SingleSharedM_SharedU
+    : SingleSharedM_BaseM SHARED_USE_METHOD(SingleSharedM_SharedU, );
 
 // MARK: SingleImmortal: single inheritance with an immortal refence base
 
@@ -163,6 +190,31 @@ struct OneShared_DRU_NoAttr : OneShared_DR,
                               OneShared_U NO_ATTR_SHARED(OneShared_DRU_NoAttr);
 struct OneShared_UDR_NoAttr : OneShared_U,
                               OneShared_DR NO_ATTR_SHARED(OneShared_UDR_NoAttr);
+
+struct OneSharedM_R
+    SHARED_DEF_METHOD(OneSharedM_R, );     // the shared reference base
+struct OneSharedM_U NO_ATTR(OneSharedM_U); // an unannotated value base
+struct OneSharedM_DR : OneSharedM_R        // derives the shared ref base
+                           NO_ATTR_SHARED(OneSharedM_DR);
+
+struct OneSharedM_RU_Shared : OneSharedM_R,
+                              OneSharedM_U SHARED(OneSharedM_RU_Shared);
+struct OneSharedM_UR_Shared : OneSharedM_U,
+                              OneSharedM_R SHARED(OneSharedM_UR_Shared);
+struct OneSharedM_RU_NoAttr : OneSharedM_R,
+                              OneSharedM_U NO_ATTR_SHARED(OneSharedM_RU_NoAttr);
+struct OneSharedM_UR_NoAttr : OneSharedM_U,
+                              OneSharedM_R NO_ATTR_SHARED(OneSharedM_UR_NoAttr);
+struct OneSharedM_DRU_Shared : OneSharedM_DR,
+                               OneSharedM_U SHARED(OneSharedM_DRU_Shared);
+struct OneSharedM_UDR_Shared : OneSharedM_U,
+                               OneSharedM_DR SHARED(OneSharedM_UDR_Shared);
+struct OneSharedM_DRU_NoAttr
+    : OneSharedM_DR,
+      OneSharedM_U NO_ATTR_SHARED(OneSharedM_DRU_NoAttr);
+struct OneSharedM_UDR_NoAttr
+    : OneSharedM_U,
+      OneSharedM_DR NO_ATTR_SHARED(OneSharedM_UDR_NoAttr);
 
 // MARK: TwoShared: inheriting two shared reference bases
 

--- a/test/Interop/Cxx/foreign-reference/Inputs/inherit-frt.hpp
+++ b/test/Interop/Cxx/foreign-reference/Inputs/inherit-frt.hpp
@@ -229,6 +229,34 @@ struct TwoShared_Shared_UsingB
     : TwoShared_A,
       TwoShared_B SHARED_USING_BASE(TwoShared_Shared_UsingB, TwoShared_B);
 
+// MARK: TwoSharedM: inheriting two shared reference bases with refcounting
+// methods
+//
+// Note that the key difference from TwoShared is that the bases may contribute
+// distinct refcounting methods of the same name.
+
+struct TwoSharedM_A SHARED_DEF_METHOD(TwoSharedM_A, );  // .doRetain
+struct TwoSharedM_B SHARED_DEF_METHOD(TwoSharedM_B, );  // .doRetain
+struct TwoSharedM_C SHARED_DEF_METHOD(TwoSharedM_C, C); // .doRetainC
+
+// expected-warning@+1 {{unable to infer SWIFT_SHARED_REFERENCE}}
+struct TwoSharedM_NoAttr : TwoSharedM_A,
+                           TwoSharedM_B NO_ATTR(TwoSharedM_NoAttr);
+// expected-error@+2 {{multiple functions '.doRetain' found}}
+// expected-error@+1 {{multiple functions '.doRelease' found}}
+struct TwoSharedM_SharedAmbiguous
+    : TwoSharedM_A,
+      TwoSharedM_B SHARED_USE_METHOD(TwoSharedM_SharedAmbiguous, );
+struct TwoSharedM_SharedDisambiguated1
+    : TwoSharedM_A,
+      TwoSharedM_C SHARED_USE_METHOD(TwoSharedM_SharedDisambiguated1, );
+struct TwoSharedM_SharedDisambiguated2
+    : TwoSharedM_A,
+      TwoSharedM_C SHARED_USE_METHOD(TwoSharedM_SharedDisambiguated2, C);
+struct TwoSharedM_SharedOverridden
+    : TwoSharedM_A,
+      TwoSharedM_B SHARED_DEF_METHOD(TwoSharedM_SharedOverridden, );
+
 // MARK: DiamondRef: inheriting same ref base twice due to diamond inheritance
 
 struct DiamondRef_Base SHARED(DiamondRef_Base);
@@ -272,6 +300,55 @@ struct DiamondNoRef_RAB : DiamondNoRef_RA,
 // expected-warning@+1 {{unable to infer SWIFT_SHARED_REFERENCE}}
 struct DiamondNoRef_RARB : DiamondNoRef_RA,
                            DiamondNoRef_RB NO_ATTR(DiamondNoRef_RARB);
+
+// MARK: Immortal: singly and multiply inheriting from immortal references
+
+struct Immortal_Base IMMORTAL(Immortal_Base);
+struct Immortal_Also IMMORTAL(Immortal_Also);
+
+struct Immortal_NoAttr : Immortal_Base NO_ATTR(Immortal_NoAttr);
+struct Immortal_Immortal : Immortal_Base IMMORTAL(Immortal_Immortal);
+struct Immortal_NoAttr_Final final
+    : Immortal_Base NO_ATTR(Immortal_NoAttr_Final);
+struct Immortal_Immortal_Final final
+    : Immortal_Base IMMORTAL(Immortal_Immortal_Final);
+
+struct Immortal_Immortal_Immortal
+    : Immortal_Immortal IMMORTAL(Immortal_Immortal_Immortal);
+struct Immortal_Immortal_NoAttr
+    : Immortal_Immortal NO_ATTR(Immortal_Immortal_NoAttr);
+struct Immortal_NoAttr_Immortal
+    : Immortal_NoAttr IMMORTAL(Immortal_NoAttr_Immortal);
+struct Immortal_NoAttr_NoAttr : Immortal_NoAttr NO_ATTR(Immortal_NoAttr_NoAttr);
+
+struct Immortal_NoAttrTwo : Immortal_Base,
+                            Immortal_Also NO_ATTR(Immortal_NoAttrTwo);
+struct Immortal_ImmortalSame : Immortal_Base,
+                               Immortal_Also IMMORTAL(Immortal_ImmortalSame);
+
+struct Immortal_D1 : Immortal_Base NO_ATTR(Immortal_D1);
+struct Immortal_D2 : Immortal_Base NO_ATTR(Immortal_D2);
+struct Immortal_Diamond : Immortal_D1, Immortal_D2 NO_ATTR(Immortal_Diamond);
+
+struct Immortal_V1 : virtual Immortal_Base NO_ATTR(Immortal_V1);
+struct Immortal_V2 : virtual Immortal_Base NO_ATTR(Immortal_V2);
+struct Immortal_VDiamond : Immortal_V1, Immortal_V2 NO_ATTR(Immortal_VDiamond);
+
+// MARK: Mixed: inheriting from a mix of immortal and shared references
+
+struct Mixed_SharedBase SHARED(Mixed_SharedBase);
+struct Mixed_ImmortalBase IMMORTAL(Mixed_ImmortalBase);
+
+// expected-warning@+1 {{unable to infer SWIFT_SHARED_REFERENCE}}
+struct Mixed_NoAttr
+    : Mixed_SharedBase,
+      Mixed_ImmortalBase NO_ATTR(Mixed_NoAttr);
+struct Mixed_Shared : Mixed_SharedBase, Mixed_ImmortalBase SHARED(Mixed_Shared);
+struct Mixed_UsingShared
+    : Mixed_SharedBase,
+      Mixed_ImmortalBase SHARED_USING_BASE(Mixed_UsingShared, Mixed_SharedBase);
+struct Mixed_Immortal : Mixed_SharedBase,
+                        Mixed_ImmortalBase IMMORTAL(Mixed_Immortal);
 
 #if __has_feature(nullability)
 _Pragma("clang diagnostic pop");

--- a/test/Interop/Cxx/foreign-reference/Inputs/inherit-frt.hpp
+++ b/test/Interop/Cxx/foreign-reference/Inputs/inherit-frt.hpp
@@ -114,10 +114,8 @@ struct SingleShared_NoAttr_Final final
 
 struct SingleShared_Shared_Shared
     : SingleShared_Shared SHARED(SingleShared_Shared_Shared);
-// BUG: should be allowed, we're just singly inheriting from a shared ref
-// expected-warning@+1 {{unable to infer SWIFT_SHARED_REFERENCE}}
 struct SingleShared_Shared_NoAttr
-    : SingleShared_Shared NO_ATTR(SingleShared_Shared_NoAttr);
+    : SingleShared_Shared NO_ATTR_SHARED(SingleShared_Shared_NoAttr);
 struct SingleShared_NoAttr_Shared
     : SingleShared_NoAttr SHARED(SingleShared_NoAttr_Shared);
 struct SingleShared_NoAttr_NoAttr

--- a/test/Interop/Cxx/foreign-reference/Inputs/refcounting-methods.h
+++ b/test/Interop/Cxx/foreign-reference/Inputs/refcounting-methods.h
@@ -128,4 +128,17 @@ struct DerivedStaticRetainRelease : StaticRetainRelease {
   DerivedStaticRetainRelease(int value, int secondValue)
       : StaticRetainRelease(value), secondValue(secondValue) {}
 };
+
+struct SharedA {
+  void doRetain();
+  void doRelease();
+} SWIFT_SHARED_REFERENCE(.doRetain, .doRelease);
+
+struct SharedB {
+  void doRetain();
+  void doRelease();
+} SWIFT_SHARED_REFERENCE(.doRetain, .doRelease);
+
+// expected-warning@+1 {{unable to infer SWIFT_SHARED_REFERENCE}}
+struct SharedAB : SharedA, SharedB { SharedAB(int) {} };
 #endif

--- a/test/Interop/Cxx/foreign-reference/inherit-frt-diagnostics.swift
+++ b/test/Interop/Cxx/foreign-reference/inherit-frt-diagnostics.swift
@@ -1,5 +1,6 @@
 // RUN: %target-swift-frontend -typecheck -verify -cxx-interoperability-mode=default \
 // RUN:   -I %S%{fs-sep}Inputs %s \
+// RUN:   -disable-availability-checking \
 // RUN:   -verify-additional-file %S%{fs-sep}Inputs%{fs-sep}inherit-frt.hpp
 
 import InheritFRT
@@ -60,6 +61,12 @@ let _ = makeTwoShared_Shared()
 let _ = makeTwoShared_Shared_UsingA()
 let _ = makeTwoShared_Shared_UsingB()
 
+let _ = makeTwoSharedM_NoAttr() // NOTE: this is not a valid FRT
+let _ = makeTwoSharedM_SharedAmbiguous() // NOTE: this is not a valid FRT
+let _ = makeTwoSharedM_SharedDisambiguated1()
+let _ = makeTwoSharedM_SharedDisambiguated2()
+let _ = makeTwoSharedM_SharedOverridden()
+
 let _ = makeDiamondRef_NoAttr() // NOTE: this is not a valid FRT
 let _ = makeDiamondRef_Shared()
 let _ = makeDiamondRef_VV_NoAttr()
@@ -72,3 +79,21 @@ let _ = makeDiamondRef_VX_Shared()
 let _ = makeDiamondNoRef_ARB()
 let _ = makeDiamondNoRef_RAB()
 let _ = makeDiamondNoRef_RARB() // NOTE: this is not a valid FRT
+
+let _ = makeImmortal_NoAttr()
+let _ = makeImmortal_Immortal()
+let _ = makeImmortal_NoAttr_Final()
+let _ = makeImmortal_Immortal_Final()
+let _ = makeImmortal_Immortal_Immortal()
+let _ = makeImmortal_Immortal_NoAttr()
+let _ = makeImmortal_NoAttr_Immortal()
+let _ = makeImmortal_NoAttr_NoAttr()
+let _ = makeImmortal_NoAttrTwo()
+let _ = makeImmortal_ImmortalSame()
+let _ = makeImmortal_Diamond()
+let _ = makeImmortal_VDiamond()
+
+let _ = makeMixed_NoAttr() // NOTE: this is not a valid FRT
+let _ = makeMixed_Shared()
+let _ = makeMixed_UsingShared()
+let _ = makeMixed_Immortal()

--- a/test/Interop/Cxx/foreign-reference/inherit-frt-diagnostics.swift
+++ b/test/Interop/Cxx/foreign-reference/inherit-frt-diagnostics.swift
@@ -7,6 +7,8 @@ import InheritFRT
 let _ = makeSimpleValue()
 let _ = makeSimpleShared()
 let _ = makeSimpleImmortal()
+let _ = makeSimpleSharedMethod()
+let _ = makeSimpleSharedMissingMethod()
 
 let _ = makeSingleShared_Shared()
 let _ = makeSingleShared_NoAttr()
@@ -17,6 +19,9 @@ let _ = makeSingleShared_Shared_Shared()
 let _ = makeSingleShared_Shared_NoAttr()
 let _ = makeSingleShared_NoAttr_Shared()
 let _ = makeSingleShared_NoAttr_NoAttr()
+
+let _ = makeSingleSharedM_SharedM()
+let _ = makeSingleSharedM_SharedU()
 
 let _ = makeSingleImmortal_Immort()
 let _ = makeSingleImmortal_NoAttr()
@@ -40,6 +45,15 @@ let _ = makeOneShared_DRU_Shared()
 let _ = makeOneShared_UDR_Shared()
 let _ = makeOneShared_DRU_NoAttr()
 let _ = makeOneShared_UDR_NoAttr()
+
+let _ = makeOneSharedM_RU_Shared()
+let _ = makeOneSharedM_UR_Shared()
+let _ = makeOneSharedM_RU_NoAttr()
+let _ = makeOneSharedM_UR_NoAttr()
+let _ = makeOneSharedM_DRU_Shared()
+let _ = makeOneSharedM_UDR_Shared()
+let _ = makeOneSharedM_DRU_NoAttr()
+let _ = makeOneSharedM_UDR_NoAttr()
 
 let _ = makeTwoShared_NoAttr() // NOTE: this is not a valid FRT
 let _ = makeTwoShared_Shared()

--- a/test/Interop/Cxx/foreign-reference/member-inheritance-module-interface.swift
+++ b/test/Interop/Cxx/foreign-reference/member-inheritance-module-interface.swift
@@ -81,14 +81,14 @@
 // CHECK:  final func swiftParamsRename(a2 i: Int32) -> Int32
 // CHECK: }
 
-// CHECK: struct D3 {
+// CHECK: class D3 {
 // CHECK:  final func virtualMethod() -> Int32
 // CHECK:  final func swiftFooRename() -> Int32
 // CHECK:  final func swiftBarRename() -> Int32
 // CHECK:  final func swiftParamsRename(a1 i: Int32) -> Int32
 // CHECK: }
 
-// CHECK: struct D4 {
+// CHECK: class D4 {
 // CHECK:  final func swiftFooRename() -> Int32
 // CHECK:  final func swiftBarRename() -> Int32
 // CHECK:  final func swiftParamsRename(a1 i: Int32) -> Int32

--- a/test/Interop/Cxx/foreign-reference/refcounting-methods-typechecker.swift
+++ b/test/Interop/Cxx/foreign-reference/refcounting-methods-typechecker.swift
@@ -4,3 +4,4 @@ import RefCountingMethods
 
 let _ = StaticRetainRelease(123)
 let _ = DerivedStaticRetainRelease(123, 456)
+let _ = SharedAB(123)


### PR DESCRIPTION
This patch set refactors the FRT info checking to incorporate the primary superclass analysis, and then buckles down the inherited FRT inference algorithm around the notion of a unique/canonical "FRT base" that provides the retain/release operations of a derived shared FRT.

The tl;dr is that this is wasn't an error and now is:

```c++
struct SharedA { ... } SWIFT_SHARED_REFERENCE(.ref, .rel);
struct SharedB { ... } SWIFT_SHARED_REFERENCE(.ref, .ref);
struct SharedAB : SharedA, SharedB {};
```

And this was an error and now isn't:

```c++
struct Base1 {} SWIFT_SHARED_REFERENCE(.ref1, .rel1);
struct Base2 : Base1 {} SWIFT_SHARED_REFERENCE(.ref2, .rel2);
struct Derived : Base2 {};
```

FRT inheritance with immortal reference types are also now supported, using similar rules as shared reference types: a derived type is allowed to inherit from multiple immortal reference types (since there isn't any ambiguity about retain/release ops), or exactly one shared reference type.

rdar://178791071