### PR TITLE
AST: Simplify RequirementEnvironment::RequirementEnvironment()

### DIFF
--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -3116,7 +3116,8 @@ ASTContext::getNormalConformance(Type conformingType,
                                  DeclContext *dc,
                                  ProtocolConformanceState state,
                                  ProtocolConformanceOptions options) {
-  assert(dc->isTypeContext());
+  ASSERT(dc->isTypeContext());
+  ASSERT(!conformingType->is<ProtocolType>());
 
   llvm::FoldingSetNodeID id;
   NormalProtocolConformance::Profile(id, protocol, dc);

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -4478,7 +4478,17 @@ ASTMangler::appendProtocolConformance(const ProtocolConformance *conformance) {
       conformance->getDeclContext()->getModuleScopeContext();
   Mod = topLevelSubcontext->getParentModule();
 
-  auto conformingType = conformance->getType();
+  Type conformingType;
+  if (isa<NormalProtocolConformance>(conformance) &&
+      conformance->isReparented()) {
+    // Note: The conforming type of a reparented conformance used to be the
+    // protocol, but that interacted badly with type substitution. Instead
+    // we set the conforming type to be the Self type parameter, but that
+    // requires a special case here to maintain the previous mangling.
+    conformingType = conformance->getDeclContext()->getDeclaredInterfaceType();
+  } else {
+    conformingType = conformance->getType();
+  }
   appendType(conformingType->getCanonicalType(), nullptr);
 
   appendProtocolName(conformance->getProtocol());

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -1555,7 +1555,6 @@ createProtocolToProtocolConformances(ProtocolDecl *protocol) {
 
   for (auto &[newBase, ext, index] : protocol->getReparentingProtocols()) {
     // We say that 'Self' is what conforms to the @reparented entry.
-    auto conformingType = protocol->getDeclaredInterfaceType();
     auto const &entry = ext->getInherited().getEntry(index);
     assert(entry.isReparented());
 
@@ -1564,7 +1563,7 @@ createProtocolToProtocolConformances(ProtocolDecl *protocol) {
       loc = ext->getLoc();
 
     conformances.push_back(ctx.getNormalConformance(
-        conformingType, newBase, loc, entry.getTypeRepr(), /*dc=*/ext,
+        ctx.TheSelfType, newBase, loc, entry.getTypeRepr(), /*dc=*/ext,
         ProtocolConformanceState::Incomplete,
         ProtocolConformanceFlags::Reparented));
   }

--- a/lib/AST/RequirementEnvironment.cpp
+++ b/lib/AST/RequirementEnvironment.cpp
@@ -70,12 +70,10 @@ RequirementEnvironment::RequirementEnvironment(
 
     return t;
   };
-  auto conformanceToWitnessThunkConformanceFn =
-      LookUpConformanceInModule();
 
   auto substConcreteType = concreteType.subst(
       conformanceToWitnessThunkTypeFn,
-      conformanceToWitnessThunkConformanceFn);
+      LookUpConformanceInModule());
 
   // Calculate the depth at which the requirement's generic parameters
   // appear in the witness thunk signature.
@@ -113,34 +111,26 @@ RequirementEnvironment::RequirementEnvironment(
       }
       return substGenericParam;
     },
-    [substConcreteType, conformance, conformanceDC, covariantSelf, &ctx](
+    [substConcreteType, conformance, &ctx](
         InFlightSubstitution &IFS, Type type, ProtocolDecl *proto)
           -> ProtocolConformanceRef {
-      // The protocol 'Self' conforms concretely to the conforming type.
-      if (type->isEqual(ctx.TheSelfType) && !covariantSelf && conformance) {
-        ProtocolConformance *specialized = conformance;
-
-        if (conformance->getGenericSignature()) {
-          auto concreteSubs =
-            substConcreteType->getContextSubstitutionMap(conformanceDC);
-          specialized =
-            ctx.getSpecializedConformance(substConcreteType,
-                                          cast<NormalProtocolConformance>(conformance),
-                                          concreteSubs);
-        }
-
-        // findWitnessedObjCRequirements() does a weird thing by passing in a
-        // DC that is not the conformance DC. Work around it here.
-        if (!specialized->getType()->isEqual(substConcreteType)) {
-          ASSERT(specialized->getType()->isExactSuperclassOf(substConcreteType));
-          specialized = ctx.getInheritedConformance(substConcreteType, specialized);
-        }
-
-        return ProtocolConformanceRef(specialized);
+      // There are two special cases where we must use the Self conformance
+      // given to us:
+      // 1) The hard-coded DistributedActor conformance to Actor.
+      // 2) A reparented protocol conformance representing the default witness table.
+      //
+      // In both cases, the conforming type is a type parameter, so we must
+      // use the supplied conformance.
+      //
+      // In every other situation, we do the lookup again, even for the Self
+      // conformance we already do have, to avoid having to re-create the right
+      // Inherited / SpecializedProtocolConformance sugar by hand.
+      if (type->isEqual(ctx.TheSelfType) &&
+          substConcreteType->isEqual(ctx.TheSelfType) &&
+          conformance) {
+        return ProtocolConformanceRef(conformance);
       }
 
-      // All other generic parameters come from the requirement itself
-      // and conform abstractly.
       return lookupConformance(type.subst(IFS), proto);
     });
 
@@ -188,7 +178,7 @@ RequirementEnvironment::RequirementEnvironment(
   if (conformanceSig) {
     for (auto &rawReq : conformanceSig.getRequirements()) {
       auto req = rawReq.subst(conformanceToWitnessThunkTypeFn,
-                              conformanceToWitnessThunkConformanceFn);
+                              LookUpConformanceInModule());
       requirements.push_back(req);
     }
   }

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -2576,8 +2576,8 @@ checkIndividualConformance(NormalProtocolConformance *conformance) {
   }
 
   // Dig out some of the fields from the conformance.
-  Type T = conformance->getType();
   DeclContext *DC = conformance->getDeclContext();
+  Type T = DC->getDeclaredInterfaceType();
   auto Proto = conformance->getProtocol();
   auto ProtoType = Proto->getDeclaredInterfaceType();
   SourceLoc ComplainLoc = conformance->getLoc();
@@ -5701,8 +5701,8 @@ static void ensureRequirementsAreSatisfied(ASTContext &ctx,
     // Make sure any associated type witnesses don't make reference to a
     // type we can't emit metadata for, or we're going to have trouble at
     // runtime.
-    checkTypeMetadataAvailability(type, typeDecl->getLoc(),
-                                  where.getDeclContext());
+    SourceLoc diagLoc = getLocForDiagnosingWitness(conformance, typeDecl);
+    checkTypeMetadataAvailability(type, diagLoc, where.getDeclContext());
 
     return false;
   });

--- a/test/decl/protocol/conforms/Inputs/objc_bad_superclass_corner_case.h
+++ b/test/decl/protocol/conforms/Inputs/objc_bad_superclass_corner_case.h
@@ -1,0 +1,10 @@
+@import Foundation;
+
+@protocol P
+@optional
+- (void) f;
+@end
+
+@interface C: NSObject <P>
+- (void) f;
+@end

--- a/test/decl/protocol/conforms/objc_bad_superclass_corner_case.swift
+++ b/test/decl/protocol/conforms/objc_bad_superclass_corner_case.swift
@@ -1,0 +1,13 @@
+// RUN: %target-typecheck-verify-swift -import-objc-header %S/Inputs/objc_bad_superclass_corner_case.h
+// REQUIRES: objc_interop
+
+import Foundation
+
+class D<T: Hashable>: C {}
+
+struct S {}
+
+// expected-error@+1 {{type 'S' does not conform to protocol 'Hashable'}}
+class E: D<S> {
+  override func f() {}
+}

--- a/validation-test/compiler_crashers_fixed/ProtocolConformanceRef-getTypeWitness-c0b5f9.swift
+++ b/validation-test/compiler_crashers_fixed/ProtocolConformanceRef-getTypeWitness-c0b5f9.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","original":"0ff257dd","signature":"swift::ProtocolConformanceRef::getTypeWitness(swift::AssociatedTypeDecl*, swift::SubstOptions) const","signatureAssert":"Assertion failed: (concrete->getProtocol() == assocType->getProtocol()), function getTypeWitness","signatureNext":"TypeSubstituter::transformDependentMemberType"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 protocol a {
   associatedtype b
 }

--- a/validation-test/compiler_crashers_fixed/SubstitutionMap-lookupConformance-ebecdd.swift
+++ b/validation-test/compiler_crashers_fixed/SubstitutionMap-lookupConformance-ebecdd.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","original":"fba90dae","signature":"swift::SubstitutionMap::lookupConformance(swift::CanType, swift::ProtocolDecl*) const","signatureAssert":"Assertion failed: (result && \"Subject type must be exactly equal to left-hand side of a\" \"conformance requirement in protocol requirement signature\"), function getAssociatedConformance","signatureNext":"LookUpConformanceInSubstitutionMap"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 protocol a {
   associatedtype b
   func c < d where Self : e, b == <#type#>>()


### PR DESCRIPTION
Past me thought this code was clever because it avoided a redundant lookup of the conformance we're checking. But present me thinks this is over-engineered, and deleting it is the easiest way to fix a crash.

This actually doesn't fix the root cause of the crash, which is that getSuperclass() and getSuperclassDecl() might return different results, with the former failing to resolve even when the latter returns a valid Decl, because the latter goes via a simpler lookup mechanism, and it's possible we will crash elsewhere if this invariant is violated. However, in this particular case, RequirementEnvironment doesn't really care at all, so there's point doing any of this or asserting.

Fixes rdar://177691260.