### PR TITLE
[rbi] Respect ApplyExpr preconcurrency on isolation-crossing diagnostics

### DIFF
--- a/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
@@ -973,6 +973,24 @@ public:
   SILFunction *getFunction() const { return sendingOp->getFunction(); }
 
   std::optional<DiagnosticBehavior> getBehaviorLimit() const {
+    // If the apply that performed the send is preconcurrency on either side
+    // of its isolation crossing, downgrade to a warning. This mirrors the
+    // AST-level ActorIsolatedCall policy in TypeCheckConcurrency.cpp (search
+    // for `actor_isolated_call`): both diagnostics observe the same
+    // isolation crossing on the same ApplyExpr, so they should observe the
+    // same severity policy. Read the crossing from the AST ApplyExpr —
+    // SILGen does not propagate it onto the SIL apply for synchronous
+    // direct calls, so `ApplySite::getIsolationCrossing()` is typically
+    // empty here.
+    if (auto *applyExpr =
+            sendingOp->getUser()->getLoc().getAsASTNode<ApplyExpr>()) {
+      if (auto crossing = applyExpr->getIsolationCrossing()) {
+        if (crossing->getCallerIsolation().preconcurrency() ||
+            crossing->getCalleeIsolation().preconcurrency())
+          return DiagnosticBehavior::Warning;
+      }
+    }
+
     return sendingOp->get()->getType().getConcurrencyDiagnosticBehavior(
         getFunction());
   }
@@ -1783,6 +1801,33 @@ public:
     return neverSent.dyn_cast<SILInstruction *>();
   }
 
+  /// Return Warning iff the consuming apply's `ApplyExpr` isolation
+  /// crossing is preconcurrency on either side.
+  ///
+  /// Mirrors the AST-level ActorIsolatedCall policy in
+  /// TypeCheckConcurrency.cpp (search for `actor_isolated_call`): when
+  /// the SIL pass and the AST diagnostic observe the same crossing,
+  /// their severity decisions must agree.
+  ///
+  /// Read the crossing from the AST `ApplyExpr` rather than the SIL
+  /// apply — SILGen does not propagate it onto SIL apply instructions
+  /// for synchronous direct calls, so
+  /// `ApplySite::getIsolationCrossing()` is typically empty here.
+  std::optional<DiagnosticBehavior>
+  getApplyPreconcurrencyBehaviorLimit() const {
+    auto *applyExpr =
+        sendingOperand->getUser()->getLoc().getAsASTNode<ApplyExpr>();
+    if (!applyExpr)
+      return {};
+    auto crossing = applyExpr->getIsolationCrossing();
+    if (!crossing)
+      return {};
+    if (crossing->getCallerIsolation().preconcurrency() ||
+        crossing->getCalleeIsolation().preconcurrency())
+      return DiagnosticBehavior::Warning;
+    return {};
+  }
+
   std::optional<DiagnosticBehavior> getBehaviorLimit() const {
     // If the failure is due to an isolated conformance, downgrade the error
     // to a warning prior to Swift 7.
@@ -1793,6 +1838,9 @@ public:
              ->getASTContext()
              .isLanguageModeAtLeast(LanguageMode::future))
       return DiagnosticBehavior::Warning;
+
+    if (auto limit = getApplyPreconcurrencyBehaviorLimit())
+      return limit;
 
     return sendingOperand->get()->getType().getConcurrencyDiagnosticBehavior(
         getOperand()->getFunction());

--- a/test/Concurrency/Inputs/transfernonsendable_preconcurrency_objc.h
+++ b/test/Concurrency/Inputs/transfernonsendable_preconcurrency_objc.h
@@ -1,0 +1,6 @@
+@import Foundation;
+
+@interface SceneComponent : NSObject
+- (void)doWork;
+- (id)sendObject:(id)obj;
+@end

--- a/test/Concurrency/transfernonsendable_preconcurrency_objc.swift
+++ b/test/Concurrency/transfernonsendable_preconcurrency_objc.swift
@@ -1,0 +1,62 @@
+// RUN: %target-swift-frontend -emit-sil -swift-version 6 -verify %s -o /dev/null -import-objc-header %S/Inputs/transfernonsendable_preconcurrency_objc.h
+
+// REQUIRES: objc_interop
+// REQUIRES: concurrency
+
+// Pattern: a @MainActor Swift class overrides a non-isolated ObjC method
+// and then calls another @MainActor method on `self`. Both sides of the
+// resulting `ApplyExpr` isolation crossing carry the `preconcurrency`
+// flag (the override inherits the ObjC method's lack of isolation under
+// preconcurrency rules), so the AST-level ActorIsolatedCall diagnostic
+// correctly downgrades to a warning. The RBI SendNonSendable pass must
+// mirror that policy: when the underlying
+// ApplyExpr::getIsolationCrossing() is preconcurrency on either side,
+// the SendingRisksDataRace diagnostic must be a warning, not an error.
+
+@MainActor
+class HostComponent: SceneComponent {
+  // expected-warning @+3 {{call to main actor-isolated instance method 'helper()' in a synchronous nonisolated context}}
+  // expected-warning @+2 {{this will be an error in a future Swift language mode}}
+  // expected-warning @+1 {{sending 'self' risks causing data races}}
+  override func doWork() { helper() }
+  // expected-note @-1 {{'self' is exposed to code in the current isolation context}}
+  // expected-note @-2 {{value is exposed to main actor-isolated code}}
+  // expected-note @-3 {{sending 'self' to main actor-isolated instance method 'helper()' risks causing data races between main actor-isolated code and code in the current isolation context}}
+
+  // expected-note @+1 {{calls to instance method 'helper()' from outside of its actor context are implicitly asynchronous}}
+  private func helper() {}
+}
+
+// Second pattern: a non-Sendable value is sent into the same kind of
+// preconcurrency apply (the @MainActor helper called from the
+// ObjC-override-treated-as-nonisolated context) and then used afterward
+// in the original (nonisolated) context. The use-after-send shape is
+// emitted by UseAfterSendDiagnosticEmitter::getBehaviorLimit() — the
+// second of the two emitter classes that observe an ApplyExpr isolation
+// crossing and must mirror the AST-level preconcurrency-downgrade
+// policy.
+
+class NonSendable {}
+
+func nonisolatedUse(_: NonSendable) {}
+
+@MainActor
+class UseAfterSendComponent: SceneComponent {
+  // expected-note @+1 {{'self' is exposed to code in the current isolation context}}
+  override func doWork() {
+    let x = NonSendable()
+    // expected-warning @+5 {{call to main actor-isolated instance method 'consume' in a synchronous nonisolated context}}
+    // expected-warning @+4 {{this will be an error in a future Swift language mode}}
+    // expected-warning @+3 {{sending 'x' risks causing data races}}
+    // expected-warning @+2 {{sending 'self' risks causing data races}}
+    // expected-note    @+1 {{value is exposed to main actor-isolated code}}
+    consume(x)
+    // expected-note @-1 {{sending 'x' to main actor-isolated instance method 'consume' risks causing data races between main actor-isolated and local nonisolated uses}}
+    // expected-note @-2 {{sending 'self' to main actor-isolated instance method 'consume' risks causing data races between main actor-isolated code and code in the current isolation context}}
+    nonisolatedUse(x)
+    // expected-note @-1 {{access can happen concurrently}}
+  }
+
+  // expected-note @+1 {{calls to instance method 'consume' from outside of its actor context are implicitly asynchronous}}
+  private func consume(_: NonSendable) {}
+}


### PR DESCRIPTION
When the SendNonSendable SIL pass and the AST-level actor_isolated_call diagnostic observe the same ApplyExpr isolation crossing, their severity decisions must agree. The AST already downgrades to a warning when either side of the crossing carries the preconcurrency flag; the SIL pass did not.

Now we do respect it.

rdar://178874894
