### PR TITLE
Sema: Split CodingKeys synthesis into its own request

### DIFF
--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -3036,7 +3036,6 @@ public:
 // Please do not add any more.
 enum class ImplicitMemberAction : uint8_t {
   ResolveImplicitInit,
-  ResolveCodingKeys,
   ResolveEncodable,
   ResolveDecodable,
 };
@@ -3056,6 +3055,59 @@ private:
   evaluator::SideEffect
   evaluate(Evaluator &evaluator, NominalTypeDecl *NTD,
            ImplicitMemberAction action) const;
+
+public:
+  // Separate caching.
+  bool isCached() const { return true; }
+};
+
+/// Synthesizes a CodingKeys enum for a Codable nominal type when one has not
+/// been provided explicitly. Synthesis is performed as a side effect of
+/// Codable conformance derivation in DerivedConformanceCodable. When the
+/// nominal type already has an explicit CodingKeys, this request is a no-op
+/// and does not trigger conformance derivation.
+///
+/// Because the request is a no-op for explicit CodingKeys, it can be
+/// invoked safely from member lookup paths that may execute while
+/// StoredPropertiesRequest is active (e.g. resolving CodingKeys.foo inside
+/// a property wrapper initializer).
+class SynthesizeCodingKeysRequest
+    : public SimpleRequest<SynthesizeCodingKeysRequest,
+                           evaluator::SideEffect(NominalTypeDecl *),
+                           RequestFlags::Uncached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  evaluator::SideEffect
+  evaluate(Evaluator &evaluator, NominalTypeDecl *NTD) const;
+
+public:
+  // Separate caching.
+  bool isCached() const { return true; }
+};
+
+/// Diagnoses immutable stored properties that have an initial value and are
+/// present in a Decodable type's CodingKeys, since they cannot be decoded.
+///
+/// This is a purely static check over stored properties and the CodingKeys
+/// enum. It is split off from init(from:) body synthesis so the diagnostic
+/// no longer depends on body type-checking (and therefore on Codable
+/// conformance derivation) running for the type.
+class CheckCodableStoredPropertiesRequest
+    : public SimpleRequest<CheckCodableStoredPropertiesRequest,
+                           evaluator::SideEffect(NominalTypeDecl *),
+                           RequestFlags::Uncached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  evaluator::SideEffect
+  evaluate(Evaluator &evaluator, NominalTypeDecl *NTD) const;
 
 public:
   // Separate caching.

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -404,6 +404,12 @@ SWIFT_REQUEST(TypeChecker, BraceHasExplicitReturnStmtRequest,
 SWIFT_REQUEST(TypeChecker, ResolveImplicitMemberRequest,
               evaluator::SideEffect(NominalTypeDecl *, ImplicitMemberAction),
               Uncached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, SynthesizeCodingKeysRequest,
+              evaluator::SideEffect(NominalTypeDecl *),
+              Uncached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, CheckCodableStoredPropertiesRequest,
+              evaluator::SideEffect(NominalTypeDecl *),
+              Uncached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, ResolveMacroRequest,
               ConcreteDeclRef(UnresolvedMacroReference),
               Cached, NoLocationInfo)

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -6790,10 +6790,11 @@ void NominalTypeDecl::synthesizeSemanticMembersIfNeeded(DeclName member) {
 
   if (member.isSimpleName() && !baseName.isSpecial()) {
     if (baseName.getIdentifier() == Context.Id_CodingKeys) {
-      // Only request CodingKeys synthesis if no explicit CodingKeys exists.
-      // lookupDirect does not trigger synthesis, so this is safe from cycles.
-      if (lookupDirect(DeclName(Context.Id_CodingKeys)).empty())
-        action.emplace(ImplicitMemberAction::ResolveCodingKeys);
+      // SynthesizeCodingKeysRequest is a no-op when an explicit CodingKeys
+      // exists, so this lookup site does not have to know about cycle
+      // conditions.
+      (void)evaluateOrDefault(Context.evaluator,
+                              SynthesizeCodingKeysRequest{this}, {});
     }
   } else {
     auto argumentNames = member.getArgumentNames();

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -1283,9 +1283,6 @@ void swift::simple_display(llvm::raw_ostream &out,
   case ImplicitMemberAction::ResolveImplicitInit:
     out << "resolve implicit initializer";
     break;
-  case ImplicitMemberAction::ResolveCodingKeys:
-    out << "resolve CodingKeys";
-    break;
   case ImplicitMemberAction::ResolveEncodable:
     out << "resolve Encodable.encode(to:)";
     break;

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -1394,6 +1394,39 @@ void TypeChecker::addImplicitConstructors(NominalTypeDecl *decl) {
   (void)decl->getDefaultInitializer();
 }
 
+/// Checks whether the target conforms to the given protocol. If the
+/// conformance is incomplete, force the conformance.
+///
+/// Returns whether the target conforms to the protocol.
+static bool evaluateTargetConformanceTo(Evaluator &evaluator,
+                                        NominalTypeDecl *target,
+                                        ProtocolDecl *protocol) {
+  if (!protocol)
+    return false;
+
+  auto targetType = target->getDeclaredInterfaceType();
+  auto ref = lookupConformance(targetType, protocol);
+  if (ref.isInvalid()) {
+    return false;
+  }
+
+  if (auto *conformance = dyn_cast<NormalProtocolConformance>(
+          ref.getConcrete()->getRootConformance())) {
+    // Complete evaluate the conformance.
+    evaluateOrDefault(evaluator,
+                      ResolveTypeWitnessesRequest{conformance},
+                      evaluator::SideEffect());
+
+    // FIXME: This should be more fine-grained to avoid having to check
+    // for a cycle here.
+    if (!evaluator.hasActiveRequest(ResolveValueWitnessesRequest{conformance})) {
+      conformance->resolveValueWitnesses();
+    }
+  }
+
+  return true;
+}
+
 evaluator::SideEffect
 ResolveImplicitMemberRequest::evaluate(Evaluator &evaluator,
                                        NominalTypeDecl *target,
@@ -1403,59 +1436,10 @@ ResolveImplicitMemberRequest::evaluate(Evaluator &evaluator,
   // FIXME: This entire request is a layering violation made of smaller,
   // finickier layering violations. See rdar://56844567
 
-  // Checks whether the target conforms to the given protocol. If the
-  // conformance is incomplete, force the conformance.
-  //
-  // Returns whether the target conforms to the protocol.
-  auto evaluateTargetConformanceTo = [&](ProtocolDecl *protocol) {
-    if (!protocol)
-      return false;
-
-    auto targetType = target->getDeclaredInterfaceType();
-    auto ref = lookupConformance(targetType, protocol);
-    if (ref.isInvalid()) {
-      return false;
-    }
-
-    if (auto *conformance = dyn_cast<NormalProtocolConformance>(
-            ref.getConcrete()->getRootConformance())) {
-      // Complete evaluate the conformance.
-      evaluateOrDefault(evaluator,
-                        ResolveTypeWitnessesRequest{conformance},
-                        evaluator::SideEffect());
-
-      // FIXME: This should be more fine-grained to avoid having to check
-      // for a cycle here.
-      if (!evaluator.hasActiveRequest(ResolveValueWitnessesRequest{conformance})) {
-        conformance->resolveValueWitnesses();
-      }
-    }
-
-    return true;
-  };
-
   auto &Context = target->getASTContext();
   switch (action) {
   case ImplicitMemberAction::ResolveImplicitInit:
     TypeChecker::addImplicitConstructors(target);
-    break;
-  case ImplicitMemberAction::ResolveCodingKeys: {
-    // CodingKeys is a special type which may be synthesized as part of
-    // Encodable/Decodable conformance. If the target conforms to either
-    // protocol and would derive conformance to either, the type may be
-    // synthesized.
-    // If the target conforms to either and the conformance has not yet been
-    // evaluated, then we should do that here.
-    //
-    // Try to synthesize Decodable first. If that fails, try to synthesize
-    // Encodable. If either succeeds and CodingKeys should have been
-    // synthesized, it will be synthesized.
-    auto *decodableProto = Context.getProtocol(KnownProtocolKind::Decodable);
-    auto *encodableProto = Context.getProtocol(KnownProtocolKind::Encodable);
-    if (!evaluateTargetConformanceTo(decodableProto)) {
-      (void)evaluateTargetConformanceTo(encodableProto);
-    }
-  }
     break;
   case ImplicitMemberAction::ResolveEncodable: {
     // encode(to:) may be synthesized as part of derived conformance to the
@@ -1463,7 +1447,7 @@ ResolveImplicitMemberRequest::evaluate(Evaluator &evaluator,
     // If the target should conform to the Encodable protocol, check the
     // conformance here to attempt synthesis.
     auto *encodableProto = Context.getProtocol(KnownProtocolKind::Encodable);
-    (void)evaluateTargetConformanceTo(encodableProto);
+    (void)evaluateTargetConformanceTo(evaluator, target, encodableProto);
   }
     break;
   case ImplicitMemberAction::ResolveDecodable: {
@@ -1473,9 +1457,34 @@ ResolveImplicitMemberRequest::evaluate(Evaluator &evaluator,
     // conformance here to attempt synthesis.
     TypeChecker::addImplicitConstructors(target);
     auto *decodableProto = Context.getProtocol(KnownProtocolKind::Decodable);
-    (void)evaluateTargetConformanceTo(decodableProto);
+    (void)evaluateTargetConformanceTo(evaluator, target, decodableProto);
     break;
   }
+  }
+  return std::make_tuple<>();
+}
+
+evaluator::SideEffect
+SynthesizeCodingKeysRequest::evaluate(Evaluator &evaluator,
+                                      NominalTypeDecl *target) const {
+  ASSERT(!isa<ProtocolDecl>(target));
+
+  auto &Context = target->getASTContext();
+
+  // If the user has already defined CodingKeys explicitly, there is nothing
+  // to synthesize. Skipping conformance evaluation here is what makes the
+  // request safe to invoke from member lookup paths that may execute while
+  // StoredPropertiesRequest is active (e.g. resolving CodingKeys.foo inside
+  // a property wrapper initializer).
+  if (!target->lookupDirect(DeclName(Context.Id_CodingKeys)).empty())
+    return std::make_tuple<>();
+
+  // CodingKeys is synthesized as a side effect of Codable conformance
+  // derivation. Try Decodable first; fall back to Encodable.
+  auto *decodableProto = Context.getProtocol(KnownProtocolKind::Decodable);
+  auto *encodableProto = Context.getProtocol(KnownProtocolKind::Encodable);
+  if (!evaluateTargetConformanceTo(evaluator, target, decodableProto)) {
+    (void)evaluateTargetConformanceTo(evaluator, target, encodableProto);
   }
   return std::make_tuple<>();
 }

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -1394,39 +1394,6 @@ void TypeChecker::addImplicitConstructors(NominalTypeDecl *decl) {
   (void)decl->getDefaultInitializer();
 }
 
-/// Checks whether the target conforms to the given protocol. If the
-/// conformance is incomplete, force the conformance.
-///
-/// Returns whether the target conforms to the protocol.
-static bool evaluateTargetConformanceTo(Evaluator &evaluator,
-                                        NominalTypeDecl *target,
-                                        ProtocolDecl *protocol) {
-  if (!protocol)
-    return false;
-
-  auto targetType = target->getDeclaredInterfaceType();
-  auto ref = lookupConformance(targetType, protocol);
-  if (ref.isInvalid()) {
-    return false;
-  }
-
-  if (auto *conformance = dyn_cast<NormalProtocolConformance>(
-          ref.getConcrete()->getRootConformance())) {
-    // Complete evaluate the conformance.
-    evaluateOrDefault(evaluator,
-                      ResolveTypeWitnessesRequest{conformance},
-                      evaluator::SideEffect());
-
-    // FIXME: This should be more fine-grained to avoid having to check
-    // for a cycle here.
-    if (!evaluator.hasActiveRequest(ResolveValueWitnessesRequest{conformance})) {
-      conformance->resolveValueWitnesses();
-    }
-  }
-
-  return true;
-}
-
 evaluator::SideEffect
 ResolveImplicitMemberRequest::evaluate(Evaluator &evaluator,
                                        NominalTypeDecl *target,
@@ -1435,6 +1402,37 @@ ResolveImplicitMemberRequest::evaluate(Evaluator &evaluator,
 
   // FIXME: This entire request is a layering violation made of smaller,
   // finickier layering violations. See rdar://56844567
+
+  // Checks whether the target conforms to the given protocol. If the
+  // conformance is incomplete, force the conformance.
+  //
+  // Returns whether the target conforms to the protocol.
+  auto evaluateTargetConformanceTo = [&](ProtocolDecl *protocol) {
+    if (!protocol)
+      return false;
+
+    auto targetType = target->getDeclaredInterfaceType();
+    auto ref = lookupConformance(targetType, protocol);
+    if (ref.isInvalid()) {
+      return false;
+    }
+
+    if (auto *conformance = dyn_cast<NormalProtocolConformance>(
+            ref.getConcrete()->getRootConformance())) {
+      // Complete evaluate the conformance.
+      evaluateOrDefault(evaluator,
+                        ResolveTypeWitnessesRequest{conformance},
+                        evaluator::SideEffect());
+
+      // FIXME: This should be more fine-grained to avoid having to check
+      // for a cycle here.
+      if (!evaluator.hasActiveRequest(ResolveValueWitnessesRequest{conformance})) {
+        conformance->resolveValueWitnesses();
+      }
+    }
+
+    return true;
+  };
 
   auto &Context = target->getASTContext();
   switch (action) {
@@ -1447,7 +1445,7 @@ ResolveImplicitMemberRequest::evaluate(Evaluator &evaluator,
     // If the target should conform to the Encodable protocol, check the
     // conformance here to attempt synthesis.
     auto *encodableProto = Context.getProtocol(KnownProtocolKind::Encodable);
-    (void)evaluateTargetConformanceTo(evaluator, target, encodableProto);
+    (void)evaluateTargetConformanceTo(encodableProto);
   }
     break;
   case ImplicitMemberAction::ResolveDecodable: {
@@ -1457,7 +1455,7 @@ ResolveImplicitMemberRequest::evaluate(Evaluator &evaluator,
     // conformance here to attempt synthesis.
     TypeChecker::addImplicitConstructors(target);
     auto *decodableProto = Context.getProtocol(KnownProtocolKind::Decodable);
-    (void)evaluateTargetConformanceTo(evaluator, target, decodableProto);
+    (void)evaluateTargetConformanceTo(decodableProto);
     break;
   }
   }
@@ -1479,12 +1477,38 @@ SynthesizeCodingKeysRequest::evaluate(Evaluator &evaluator,
   if (!target->lookupDirect(DeclName(Context.Id_CodingKeys)).empty())
     return std::make_tuple<>();
 
-  // CodingKeys is synthesized as a side effect of Codable conformance
-  // derivation. Try Decodable first; fall back to Encodable.
+  // Checks whether the target conforms to the given protocol and, if the
+  // conformance is incomplete, forces it. CodingKeys is synthesized as a
+  // side effect of Codable conformance derivation.
+  auto evaluateTargetConformanceTo = [&](ProtocolDecl *protocol) {
+    if (!protocol)
+      return false;
+
+    auto targetType = target->getDeclaredInterfaceType();
+    auto ref = lookupConformance(targetType, protocol);
+    if (ref.isInvalid()) {
+      return false;
+    }
+
+    if (auto *conformance = dyn_cast<NormalProtocolConformance>(
+            ref.getConcrete()->getRootConformance())) {
+      evaluateOrDefault(evaluator,
+                        ResolveTypeWitnessesRequest{conformance},
+                        evaluator::SideEffect());
+
+      if (!evaluator.hasActiveRequest(ResolveValueWitnessesRequest{conformance})) {
+        conformance->resolveValueWitnesses();
+      }
+    }
+
+    return true;
+  };
+
+  // Try Decodable first; fall back to Encodable.
   auto *decodableProto = Context.getProtocol(KnownProtocolKind::Decodable);
   auto *encodableProto = Context.getProtocol(KnownProtocolKind::Encodable);
-  if (!evaluateTargetConformanceTo(evaluator, target, decodableProto)) {
-    (void)evaluateTargetConformanceTo(evaluator, target, encodableProto);
+  if (!evaluateTargetConformanceTo(decodableProto)) {
+    (void)evaluateTargetConformanceTo(encodableProto);
   }
   return std::make_tuple<>();
 }

--- a/lib/Sema/DerivedConformance/DerivedConformanceCodable.cpp
+++ b/lib/Sema/DerivedConformance/DerivedConformanceCodable.cpp
@@ -25,6 +25,7 @@
 #include "swift/AST/ParameterList.h"
 #include "swift/AST/Pattern.h"
 #include "swift/AST/Stmt.h"
+#include "swift/AST/TypeCheckRequests.h"
 #include "swift/AST/Types.h"
 #include "swift/Basic/Assertions.h"
 #include "swift/Basic/StringExtras.h"
@@ -100,9 +101,14 @@ static EnumDecl *lookupEvaluatedCodingKeysEnum(ASTContext &C,
   if (codingKeyDecls.empty())
     return nullptr;
 
-  auto *codingKeysDecl = codingKeyDecls.front();
-  if (auto *typealiasDecl = dyn_cast<TypeAliasDecl>(codingKeysDecl))
+  Decl *codingKeysDecl = codingKeyDecls.front();
+  if (auto *typealiasDecl = dyn_cast<TypeAliasDecl>(codingKeysDecl)) {
+    // The typealias may point at an unresolved or non-nominal type; bail
+    // out in that case rather than crashing the dyn_cast below.
     codingKeysDecl = typealiasDecl->getDeclaredInterfaceType()->getAnyNominal();
+    if (!codingKeysDecl)
+      return nullptr;
+  }
 
   return dyn_cast<EnumDecl>(codingKeysDecl);
 }
@@ -1381,64 +1387,9 @@ deriveBodyDecodable_init(AbstractFunctionDecl *initDecl, void *) {
           lookupVarDeclForCodingKeysCase(conformanceDC, elt, targetDecl);
 
       // Don't output a decode statement for a let with an initial value.
+      // Diagnostics for this situation are emitted separately by
+      // CheckCodableStoredPropertiesRequest.
       if (varDecl->isLet() && varDecl->isParentInitialized()) {
-        // But emit a warning to let the user know that it won't be decoded.
-        auto lookupResult =
-            codingKeysEnum->lookupDirect(varDecl->getBaseName());
-        auto keyExistsInCodingKeys =
-            llvm::any_of(lookupResult, [&](ValueDecl *VD) {
-              if (isa<EnumElementDecl>(VD)) {
-                return VD->getBaseName() == varDecl->getBaseName();
-              }
-              return false;
-            });
-        auto *encodableProto = C.getProtocol(KnownProtocolKind::Encodable);
-        bool conformsToEncodable =
-            (bool) lookupConformance(
-                targetDecl->getDeclaredInterfaceType(), encodableProto);
-
-        // Strategy to use for CodingKeys enum diagnostic part - this is to
-        // make the behaviour more explicit:
-        //
-        // 1. If we have an *implicit* CodingKeys enum:
-        // (a) If the type is Decodable only, explicitly define the enum and
-        //     remove the key from it. This makes it explicit that the key
-        //     will not be decoded.
-        // (b) If the type is Codable, explicitly define the enum and keep the
-        //     key in it. This is because removing the key will break encoding
-        //     which is mostly likely not what the user expects.
-        //
-        // 2. If we have an *explicit* CodingKeys enum:
-        // (a) If the type is Decodable only and the key exists in the enum,
-        //     then explicitly remove the key from the enum. This makes it
-        //     explicit that the key will not be decoded.
-        // (b) If the type is Decodable only and the key does not exist in
-        //     the enum, do nothing. This is because the user has explicitly
-        //     made it clear that they don't want the key to be decoded.
-        // (c) If the type is Codable, do nothing. This is because removing
-        //     the key will break encoding which is most likely not what the
-        //     user expects.
-        if (!codingKeysEnum->isImplicit()) {
-          if (conformsToEncodable || !keyExistsInCodingKeys) {
-            continue;
-          }
-        }
-
-        varDecl->diagnose(diag::decodable_property_will_not_be_decoded);
-        if (codingKeysEnum->isImplicit()) {
-          varDecl->diagnose(
-              diag::decodable_property_init_or_codingkeys_implicit,
-              conformsToEncodable ? 0 : 1, varDecl->getName());
-        } else {
-          varDecl->diagnose(
-              diag::decodable_property_init_or_codingkeys_explicit,
-              varDecl->getName());
-        }
-        if (auto *PBD = varDecl->getParentPatternBinding()) {
-          varDecl->diagnose(diag::decodable_make_property_mutable)
-              .fixItReplace(PBD->getLoc(), "var");
-        }
-
         continue;
       }
 
@@ -2146,4 +2097,105 @@ ValueDecl *DerivedConformance::deriveDecodable(ValueDecl *requirement) {
   assert(delayedNotes.empty());
 
   return deriveDecodable_init(*this);
+}
+
+/// Looks up the stored property on \c target whose name matches the given
+/// CodingKeys case identifier. Returns nullptr if no such non-static
+/// property exists.
+static VarDecl *lookupStoredPropertyForCodingKey(NominalTypeDecl *target,
+                                                 Identifier name) {
+  for (auto decl : target->lookupDirect(DeclName(name))) {
+    auto *vd = dyn_cast<VarDecl>(decl);
+    if (!vd)
+      continue;
+    if (auto *backingVar = vd->getPropertyWrapperBackingProperty())
+      vd = backingVar;
+    if (vd->isStatic())
+      continue;
+    return vd;
+  }
+  return nullptr;
+}
+
+/// Walks the CodingKeys enum and warns about immutable stored properties
+/// that have an initial value: they cannot be decoded, so the user's intent
+/// is ambiguous and worth flagging.
+///
+/// This logic used to live inside the body synthesizer for the derived
+/// init(from:); pulling it out lets the diagnostic fire without depending
+/// on Codable conformance derivation, which is what avoids the request
+/// cycle when an explicit CodingKeys is referenced from a property wrapper
+/// initializer.
+static void diagnoseImmutableLetsInDecodable(NominalTypeDecl *target) {
+  auto &C = target->getASTContext();
+
+  // Only emit diagnostics for types that actually need to decode.
+  auto *decodableProto = C.getProtocol(KnownProtocolKind::Decodable);
+  if (!decodableProto)
+    return;
+  if (!lookupConformance(target->getDeclaredInterfaceType(), decodableProto))
+    return;
+
+  auto *codingKeysEnum = lookupEvaluatedCodingKeysEnum(C, target);
+  if (!codingKeysEnum)
+    return;
+
+  auto *encodableProto = C.getProtocol(KnownProtocolKind::Encodable);
+  bool conformsToEncodable =
+      encodableProto && (bool)lookupConformance(
+                            target->getDeclaredInterfaceType(), encodableProto);
+
+  for (auto *elt : codingKeysEnum->getAllElements()) {
+    auto *varDecl =
+        lookupStoredPropertyForCodingKey(target, elt->getBaseIdentifier());
+    if (!varDecl)
+      continue;
+    if (!(varDecl->isLet() && varDecl->isParentInitialized()))
+      continue;
+
+    auto lookupResult = codingKeysEnum->lookupDirect(varDecl->getBaseName());
+    auto keyExistsInCodingKeys =
+        llvm::any_of(lookupResult, [&](ValueDecl *VD) {
+          if (isa<EnumElementDecl>(VD)) {
+            return VD->getBaseName() == varDecl->getBaseName();
+          }
+          return false;
+        });
+
+    // Strategy for the diagnostic when an explicit CodingKeys is present:
+    //
+    // 1. If we have an *implicit* CodingKeys enum, always warn — suggest the
+    //    user define the enum explicitly so they can opt out of decoding
+    //    this key.
+    // 2. If we have an *explicit* CodingKeys enum:
+    //    (a) Decodable-only and key is in the enum -> warn; suggest
+    //        removing the key from the enum.
+    //    (b) Decodable-only and key is not in the enum -> silent; the user
+    //        has already opted out.
+    //    (c) Codable -> silent; removing the key would break encoding.
+    if (!codingKeysEnum->isImplicit()) {
+      if (conformsToEncodable || !keyExistsInCodingKeys)
+        continue;
+    }
+
+    varDecl->diagnose(diag::decodable_property_will_not_be_decoded);
+    if (codingKeysEnum->isImplicit()) {
+      varDecl->diagnose(diag::decodable_property_init_or_codingkeys_implicit,
+                        conformsToEncodable ? 0 : 1, varDecl->getName());
+    } else {
+      varDecl->diagnose(diag::decodable_property_init_or_codingkeys_explicit,
+                        varDecl->getName());
+    }
+    if (auto *PBD = varDecl->getParentPatternBinding()) {
+      varDecl->diagnose(diag::decodable_make_property_mutable)
+          .fixItReplace(PBD->getLoc(), "var");
+    }
+  }
+}
+
+evaluator::SideEffect
+CheckCodableStoredPropertiesRequest::evaluate(Evaluator &evaluator,
+                                              NominalTypeDecl *target) const {
+  diagnoseImmutableLetsInDecodable(target);
+  return std::make_tuple<>();
 }

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2942,8 +2942,7 @@ static ArrayRef<Decl *> evaluateMembersRequest(
     // Force it into existence.
     (void) evaluateOrDefault(
       ctx.evaluator,
-      ResolveImplicitMemberRequest{nominal,
-                 ImplicitMemberAction::ResolveCodingKeys},
+      SynthesizeCodingKeysRequest{nominal},
       {});
 
     // Synthesize distributed actor 'id' and 'actorSystem' if needed.

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -516,9 +516,13 @@ static void checkInheritanceClause(
 }
 
 static void installCodingKeysIfNecessary(NominalTypeDecl *NTD) {
-  auto req =
-    ResolveImplicitMemberRequest{NTD, ImplicitMemberAction::ResolveCodingKeys};
-  (void)evaluateOrDefault(NTD->getASTContext().evaluator, req, {});
+  auto &evaluator = NTD->getASTContext().evaluator;
+  // Ensure CodingKeys exists if it should be synthesized.
+  (void)evaluateOrDefault(evaluator, SynthesizeCodingKeysRequest{NTD}, {});
+  // Emit Codable-specific diagnostics for immutable stored properties even
+  // when conformance derivation hasn't been driven through this path.
+  (void)evaluateOrDefault(evaluator,
+                          CheckCodableStoredPropertiesRequest{NTD}, {});
 }
 
 // Check for static properties that produce empty option sets
@@ -3447,6 +3451,8 @@ public:
     (void) CD->getDestructor();
 
     TypeChecker::checkDeclAttributes(CD);
+
+    installCodingKeysIfNecessary(CD);
 
     if (CD->isActor())
       TypeChecker::checkConcurrencyAvailability(CD->getLoc(), CD);

--- a/test/decl/protocol/special/coding/struct_codable_codingkeys_typealias.swift
+++ b/test/decl/protocol/special/coding/struct_codable_codingkeys_typealias.swift
@@ -34,3 +34,23 @@ struct StructWithUndeclaredCodingKeys : Codable { // expected-error {{type 'Stru
   // expected-note@-1 {{cannot automatically synthesize 'Decodable' because 'CodingKeys' does not conform to CodingKey}}
   // expected-note@-2 {{cannot automatically synthesize 'Encodable' because 'CodingKeys' does not conform to CodingKey}}
 }
+
+// A typealias that resolves to a non-nominal type (tuple, function type) used
+// to crash lookupEvaluatedCodingKeysEnum because getAnyNominal() returns null
+// and the subsequent dyn_cast<EnumDecl> asserted on the null pointer. The
+// compiler should diagnose the conformance failure rather than crash.
+struct StructWithTupleCodingKeys : Codable { // expected-error {{type 'StructWithTupleCodingKeys' does not conform to protocol 'Decodable'}}
+  // expected-error@-1 {{type 'StructWithTupleCodingKeys' does not conform to protocol 'Encodable'}}
+  var x: Int = 1
+  private typealias CodingKeys = (Int, Int)
+  // expected-note@-1 {{cannot automatically synthesize 'Decodable' because 'CodingKeys' does not conform to CodingKey}}
+  // expected-note@-2 {{cannot automatically synthesize 'Encodable' because 'CodingKeys' does not conform to CodingKey}}
+}
+
+struct StructWithFunctionTypeCodingKeys : Codable { // expected-error {{type 'StructWithFunctionTypeCodingKeys' does not conform to protocol 'Decodable'}}
+  // expected-error@-1 {{type 'StructWithFunctionTypeCodingKeys' does not conform to protocol 'Encodable'}}
+  var x: Int = 1
+  private typealias CodingKeys = () -> Void
+  // expected-note@-1 {{cannot automatically synthesize 'Decodable' because 'CodingKeys' does not conform to CodingKey}}
+  // expected-note@-2 {{cannot automatically synthesize 'Encodable' because 'CodingKeys' does not conform to CodingKey}}
+}

--- a/test/decl/protocol/special/coding/struct_codable_codingkeys_typealias.swift
+++ b/test/decl/protocol/special/coding/struct_codable_codingkeys_typealias.swift
@@ -54,3 +54,17 @@ struct StructWithFunctionTypeCodingKeys : Codable { // expected-error {{type 'St
   // expected-note@-1 {{cannot automatically synthesize 'Decodable' because 'CodingKeys' does not conform to CodingKey}}
   // expected-note@-2 {{cannot automatically synthesize 'Encodable' because 'CodingKeys' does not conform to CodingKey}}
 }
+
+// An immutable 'let' with an initial value combined with a non-nominal
+// CodingKeys typealias. The CheckCodableStoredPropertiesRequest diagnostic
+// walks the CodingKeys enum; here lookupEvaluatedCodingKeysEnum returns null
+// (the tuple has no nominal), so the request must bail out without crashing
+// and without emitting a spurious "will not be decoded" warning for 'x'. Only
+// the conformance failure should be diagnosed.
+struct StructWithImmutableLetAndTupleCodingKeys : Codable { // expected-error {{type 'StructWithImmutableLetAndTupleCodingKeys' does not conform to protocol 'Decodable'}}
+  // expected-error@-1 {{type 'StructWithImmutableLetAndTupleCodingKeys' does not conform to protocol 'Encodable'}}
+  let x: Int = 1
+  private typealias CodingKeys = (Int, Int)
+  // expected-note@-1 {{cannot automatically synthesize 'Decodable' because 'CodingKeys' does not conform to CodingKey}}
+  // expected-note@-2 {{cannot automatically synthesize 'Encodable' because 'CodingKeys' does not conform to CodingKey}}
+}

--- a/test/decl/protocol/special/coding/struct_codable_property_wrapper_codingkeys.swift
+++ b/test/decl/protocol/special/coding/struct_codable_property_wrapper_codingkeys.swift
@@ -71,3 +71,20 @@ struct EncodableOnly: Encodable { // no error
     @Wrapper(key: CodingKeys.value)
     var value: String = "test"
 }
+
+// Referencing CodingKeys from the wrapper argument makes member lookup ask
+// for CodingKeys synthesis while stored properties are being computed. Since
+// an explicit CodingKeys already exists, SynthesizeCodingKeysRequest is a
+// no-op and does not trigger conformance derivation (which would re-enter
+// StoredPropertiesRequest and cycle). The no-op must not prevent the type
+// from still getting a usable derived Codable conformance through the normal
+// conformance-checking path.
+struct UsableAfterEarlyReturn: Codable { // no error
+    enum CodingKeys: String, CodingKey {
+        case value
+    }
+    @Wrapper(key: CodingKeys.value)
+    var value: String = "test"
+}
+let _ = UsableAfterEarlyReturn.init(from:)
+let _ = UsableAfterEarlyReturn.encode(to:)


### PR DESCRIPTION
### Explanation
Follow-up to #88477 implementing slavapestov's review feedback.
  
ResolveCodingKeys action of ResolveImplicitMemberRequest is split into two dedicated requests. Member lookup no longer needs an ad-hoc cycle guard.
  
- **SynthesizeCodingKeysRequest** - triggers Codable conformance derivation for CodingKeys synthesis. No-op when an explicit CodingKeys exists, so safe to invoke unconditionally from `synthesizeSemanticMembersIfNeeded`.
- **CheckCodableStoredPropertiesRequest** - hosts the "immutable property will not be decoded" diagnostic as a standalone static check, decoupled from `init(from:)` body synthesis.
  
### Scope
Codable synthesis, property wrappers, request architecture refactor.
  
### Issues
Refactor following review of #88477.
  
### Risk
Low. All 367 Codable + property wrapper tests pass. Latent crash in `lookupEvaluatedCodingKeysEnum` (typealias → non-nominal) also fixed.
  
### Testing
- 74/74 `test/decl/protocol/special/coding/`
- 367/367 broader (decl/protocol, decl/var, SILGen/codable, Distributed)
  
### Reviewers
@slavapestov @hamishknight