### PR TITLE
[check-incremental] Disable safe interop wrappers for now

### DIFF
--- a/utils/check-incremental
+++ b/utils/check-incremental
@@ -104,7 +104,8 @@ def main():
 
     new_args += [
       '-Xllvm', '-print-no-uuids',
-      '-Xllvm', '-sil-print-pass-md5']
+      '-Xllvm', '-sil-print-pass-md5',
+      '-Xfrontend', '-disable-safe-interop-wrappers']
 
     if EMIT_IR:
       new_args += [


### PR DESCRIPTION
Some of the host platforms don't have new-enough Swift versions to build with safe interop wrappers enabled, so disable them when performing this check. We aren't using them in the affected Swift files anyway.

Fixes rdar://178439806.
