### PR TITLE
Extend @section to cover functions of all kinds

### DIFF
--- a/lib/SIL/IR/SILFunctionBuilder.cpp
+++ b/lib/SIL/IR/SILFunctionBuilder.cpp
@@ -252,8 +252,8 @@ void SILFunctionBuilder::addFunctionAttributes(
     return;
   auto *decl = constant.getDecl();
 
-  // Don't add section for addressor functions (where decl is a global)
-  if (isa<FuncDecl>(decl)) {
+  // Add section for anything that was originally a function.
+  if (isa<AbstractFunctionDecl>(decl)) {
     if (auto *SA = Attrs.getAttribute<SectionAttr>())
       F->setSection(SA->Name);
   }

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -2536,6 +2536,39 @@ synthesizeAccessorBody(AbstractFunctionDecl *fn, void *) {
   llvm_unreachable("bad synthesized function kind");
 }
 
+/// If the accessor is one of the given kinds, and there is a @section on a
+/// parsed accessor of one of the given kinds, transfer it to the accessor.
+///
+/// Returns true if anything was transferred.
+static bool tryTransferAccessorSection(
+    AccessorDecl *accessor, ArrayRef<AccessorKind> kinds) {
+  // Is our accessor one of the expected kinds?
+  if (std::find(kinds.begin(), kinds.end(), accessor->getAccessorKind()) ==
+        kinds.end())
+    return false;
+
+  // If the accessor has a @section attribute already, we're done.
+  if (accessor->getAttrs().hasAttribute<SectionAttr>())
+    return true;
+
+  // Look for a parsed accessor from which we can pull the section name.
+  auto storage = accessor->getStorage();
+  for (auto kind : kinds) {
+    auto parsed = storage->getParsedAccessor(kind);
+    if (!parsed)
+      continue;
+
+    if (auto section = parsed->getAttrs().getAttribute<SectionAttr>()) {
+      // Clone the attribute.
+      ASTContext &ctx = storage->getASTContext();
+      accessor->getAttrs().add(section->clone(ctx));
+      return true;
+    }
+  }
+
+  return false;
+}
+
 static void finishImplicitAccessor(AccessorDecl *accessor,
                                    ASTContext &ctx) {
   accessor->setImplicit();
@@ -2545,6 +2578,28 @@ static void finishImplicitAccessor(AccessorDecl *accessor,
 
   if (accessor->doesAccessorHaveBody())
     accessor->setBodySynthesizer(&synthesizeAccessorBody);
+
+  // Look for a @section attribute to transfer.
+  AccessorKind readAccessors[] = {
+    AccessorKind::Get,
+    AccessorKind::DistributedGet,
+    AccessorKind::Read,
+    AccessorKind::YieldingBorrow,
+    AccessorKind::Borrow,
+    AccessorKind::Address
+  };
+  AccessorKind writeAccessors[] = {
+    AccessorKind::Set,
+    AccessorKind::Modify,
+    AccessorKind::YieldingMutate,
+    AccessorKind::Mutate,
+    AccessorKind::MutableAddress,
+    AccessorKind::Init,
+    AccessorKind::WillSet,
+    AccessorKind::DidSet
+  };
+  if (!tryTransferAccessorSection(accessor, writeAccessors))
+    tryTransferAccessorSection(accessor, readAccessors);
 }
 
 static AccessorDecl *createGetterPrototype(AbstractStorageDecl *storage,

--- a/test/IRGen/section.swift
+++ b/test/IRGen/section.swift
@@ -12,9 +12,25 @@
 @section("__DATA,__mysection") var g5: UnsafeMutablePointer<Int>? = UnsafeMutablePointer(bitPattern: 0x42424242)
 @section("__TEXT,__mysection") @used func foo() {}
 
+var g6: Int {
+  @section("__TEXT,__mysection") @used get { 0 }
+  @section("__TEXT,__mymutsection") @used set { }
+}
+
 struct MyStruct {
-	@section("__DATA,__mysection") static var static0: Int = 1
-	@section("__TEXT,__mysection") @used func foo() {}
+  @section("__DATA,__mysection") static var static0: Int = 1
+  @section("__TEXT,__mysection") @used func foo() {}
+  @section("__TEXT,__mysection") @used init(initialValue: Int) {}
+
+  subscript(i: Int) -> Int {
+    @section("__TEXT,__mysection") get { i }
+    @section("__TEXT,__mymutsection") set { }
+  }
+}
+
+class MyClass {
+  @used @section("__TEXT,__mysection") init() { }
+  @used @section("__TEXT,__mysection") deinit { }
 }
 
 @section("__TEXT,__mysection")
@@ -28,9 +44,18 @@ func testit(_ e: consuming Any) -> Any { e }
 // SIL: @section("__DATA,__mysection") @_hasStorage @_hasInitialValue var g4: UnsafeMutablePointer<Int>? { get set }
 // SIL: @section("__DATA,__mysection") @_hasStorage @_hasInitialValue var g5: UnsafeMutablePointer<Int>? { get set }
 // SIL: @section("__TEXT,__mysection") @used func foo()
+// SIL: var g6: Int {
+// SIL:   @section("__TEXT,__mysection") @used get
+// SIL:   @section("__TEXT,__mymutsection") @used set
+// SIL: }
 // SIL: struct MyStruct {
 // SIL:   @section("__DATA,__mysection") @_hasStorage @_hasInitialValue static var static0: Int { get set }
 // SIL:   @section("__TEXT,__mysection") @used func foo()
+// SIL: @section("__TEXT,__mysection") @used init(initialValue:
+// SIL:  subscript(i: Int) -> Int {
+// SIL:    @section("__TEXT,__mysection") get
+// SIL:    @section("__TEXT,__mymutsection") set
+// SIL:  }
 
 // SIL: sil private [global_init_once_fn] @$s7section2g0_WZ : $@convention(c)
 // SIL: sil hidden [global_init] @$s7section2g0Sivau : $@convention(thin)
@@ -45,9 +70,19 @@ func testit(_ e: consuming Any) -> Any { e }
 // SIL: sil private [global_init_once_fn] @$s7section2g5_WZ : $@convention(c)
 // SIL: sil hidden [global_init] @$s7section2g5SpySiGSgvau : $@convention(thin)
 // SIL: sil hidden [used] [section "__TEXT,__mysection"] @$s7section3fooyyF : $@convention(thin)
+// SIL: sil hidden [used] [section "__TEXT,__mysection"] @$s7section2g6Sivg : $@convention(thin)
+// SIL: sil hidden [used] [section "__TEXT,__mymutsection"] @$s7section2g6Sivs : $@convention(thin)
 // SIL: sil private [global_init_once_fn] @$s7section8MyStructV7static0_WZ : $@convention(c)
 // SIL: sil hidden [global_init] @$s7section8MyStructV7static0Sivau : $@convention(thin)
 // SIL: sil hidden [used] [section "__TEXT,__mysection"] @$s7section8MyStructV3fooyyF : $@convention(method)
+// SIL: sil hidden [used] [section "__TEXT,__mysection"] @$s7section8MyStructV12initialValueACSi_tcfC : $@convention(method)
+// SIL: sil hidden [section "__TEXT,__mysection"] @$s7section8MyStructVyS2icig : $@convention(method)
+// SIL: sil hidden [section "__TEXT,__mymutsection"] @$s7section8MyStructVyS2icis : $@convention(method)
+// SIL: sil hidden [transparent] [section "__TEXT,__mymutsection"] @$s7section8MyStructVyS2iciM : $@yield_once @convention(method)
+// SIL: sil hidden [exact_self_class] [used] [section "__TEXT,__mysection"] @$s7section7MyClassCACycfC : $@convention(method)
+// SIL: sil hidden [used] [section "__TEXT,__mysection"] @$s7section7MyClassCACycfc : $@convention(method)
+// SIL: sil hidden [used] [section "__TEXT,__mysection"] @$s7section7MyClassCfd : $@convention(method)
+// SIL: sil hidden [used] [section "__TEXT,__mysection"] @$s7section7MyClassCfD : $@convention(method)
 // SIL: sil hidden @$s7section6testityypypnF : $@convention(thin) (@in Any) -> @out Any {
 
 // IR:  @"$s7section2g0Sivp" = hidden global %TSi <{ {{(i64|i32)}} 1 }>, section "__DATA,__mysection"
@@ -59,3 +94,4 @@ func testit(_ e: consuming Any) -> Any { e }
 // IR:  @"$s7section8MyStructV7static0SivpZ" = hidden global %TSi <{ {{(i64|i32)}} 1 }>, section "__DATA,__mysection"
 // IR:  define {{.*}}@"$s7section3fooyyF"(){{.*}} section "__TEXT,__mysection"
 // IR:  define {{.*}}@"$s7section8MyStructV3fooyyF"() #0 section "__TEXT,__mysection"
+// IR:  define {{.*}}@"$s7section8MyStructV12initialValueACSi_tcfC"({{.*}}) #0 section "__TEXT,__mysection"

--- a/test/IRGen/section_asm.swift
+++ b/test/IRGen/section_asm.swift
@@ -34,6 +34,14 @@
 
 // CHECKELF: .section{{.*}}"__TEXT,__mysection","axR"
 // CHECKELF-NOT: .section
+// CHECKELF: $s7section2g6Sivg:
+
+// CHECKELF: .section{{.*}}"__TEXT,__mymutsection","axR"
+// CHECKELF-NOT: .section
+// CHECKELF: $s7section2g6Sivs:
+
+// CHECKELF: .section{{.*}}"__TEXT,__mysection","axR"
+// CHECKELF-NOT: .section
 // CHECKELF: $s7section8MyStructV3fooyyF:
 
 // CHECKELF: .section{{.*}}"__DATA,__mysection","awR"


### PR DESCRIPTION
This is a Future Direction of SE-0492 that was partially implemented (only for functions described by "func"). Extend the implementation also to initializers, deinitializers, and accessors. Add some transfer rules so that synthesized accessors get their @section from accessors that were written, e.g., "mutate" gets it from "set".

Implements rdar://178898017
