### PR TITLE
[Cooperative global executor] Drop explicit <chrono> usage

### DIFF
--- a/include/swift/Basic/PriorityQueue.h
+++ b/include/swift/Basic/PriorityQueue.h
@@ -19,6 +19,7 @@
 #define SWIFT_BASIC_PRIORITYQUEUE_H
 
 #include <cassert>
+#include <limits>
 
 namespace swift {
 

--- a/include/swift/Runtime/Concurrency.h
+++ b/include/swift/Runtime/Concurrency.h
@@ -1134,6 +1134,10 @@ void swift_get_clock_res(long long *seconds,
                          long long *nanoseconds,
                          swift_clock_id clock_id);
 
+/// Sleep the current thread for the given duration.
+SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
+void swift_sleep(long long seconds, long long nanoseconds);
+
 #ifdef __APPLE__
 /// A magic symbol whose address is the mask to apply to a frame pointer to
 /// signal that it is an async frame. Do not try to read the actual value of

--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -401,7 +401,7 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB AND SWIFT_SHOULD_BUILD_EMBEDDED_CONCURRENC
         -Xfrontend -emit-empty-object-file
         ${SWIFT_RUNTIME_CONCURRENCY_SWIFT_FLAGS}
       C_COMPILE_FLAGS
-        ${extra_c_compile_flags} ${SWIFT_RUNTIME_CONCURRENCY_C_FLAGS} -DSWIFT_CONCURRENCY_EMBEDDED=1 -DSWIFT_RUNTIME_EMBEDDED=1
+        ${extra_c_compile_flags} ${SWIFT_RUNTIME_CONCURRENCY_C_FLAGS} -DSWIFT_CONCURRENCY_EMBEDDED=1 -DSWIFT_RUNTIME_EMBEDDED=1 -ffreestanding
         -ffunction-sections -fdata-sections -fno-exceptions -fno-cxx-exceptions -fno-unwind-tables
       MODULE_DIR "${CMAKE_BINARY_DIR}/lib/swift/embedded"
       SDK "embedded"
@@ -439,7 +439,7 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB AND SWIFT_SHOULD_BUILD_EMBEDDED_CONCURRENC
 
       CooperativeGlobalExecutor.cpp
 
-      C_COMPILE_FLAGS ${extra_c_compile_flags}
+      C_COMPILE_FLAGS ${extra_c_compile_flags} -ffreestanding
       MODULE_DIR "${CMAKE_BINARY_DIR}/lib/swift/embedded"
       SDK "embedded"
       ARCHITECTURE "${mod}"

--- a/stdlib/public/Concurrency/Clock.cpp
+++ b/stdlib/public/Concurrency/Clock.cpp
@@ -21,11 +21,11 @@
 #include <realtimeapiset.h>
 #endif
 
-#if __has_include(<chrono>)
+#if __has_include(<chrono>) && __STDC_HOSTED__
 #define WE_HAVE_STD_CHRONO 1
 #include <chrono>
 
-#if __has_include(<thread>)
+#if __has_include(<thread>) && __STDC_HOSTED__
 #define WE_HAVE_STD_THIS_THREAD 1
 #include <thread>
 #endif

--- a/stdlib/public/Concurrency/CooperativeGlobalExecutor.cpp
+++ b/stdlib/public/Concurrency/CooperativeGlobalExecutor.cpp
@@ -30,19 +30,12 @@
 
 #include "swift/shims/Visibility.h"
 
-#include <chrono>
-#ifndef SWIFT_THREADING_NONE
-# include <thread>
-#endif
 #include <new>
 
-#include <errno.h>
 #include "swift/Basic/PriorityQueue.h"
+#include "swift/Runtime/Concurrency.h"
 #include "swift/Runtime/Heap.h"
 
-#if __has_include(<time.h>)
-# include <time.h>
-#endif
 #ifndef NSEC_PER_SEC
 # define NSEC_PER_SEC 1000000000ull
 #endif
@@ -71,7 +64,18 @@ struct JobQueueTraits {
 };
 using JobPriorityQueue = PriorityQueue<SwiftJob*, JobQueueTraits>;
 
-using JobDeadline = std::chrono::time_point<std::chrono::steady_clock>;
+/// A deadline expressed as nanoseconds on the suspending clock — the same
+/// monotonic timebase `swift_get_time(swift_clock_id_suspending, ...)`
+/// reports.
+using JobDeadline = long long;
+
+/// Read the current time on the suspending clock and return it as a
+/// nanosecond count.
+static JobDeadline currentSuspendingNanos() {
+  long long seconds, nanoseconds;
+  swift_get_time(&seconds, &nanoseconds, swift_clock_id_suspending);
+  return seconds * static_cast<JobDeadline>(NSEC_PER_SEC) + nanoseconds;
+}
 
 template <bool = (sizeof(JobDeadline) <= sizeof(void*) &&
                   alignof(JobDeadline) <= alignof(void*))>
@@ -165,9 +169,7 @@ void swift_task_enqueueGlobalWithDelayImpl(SwiftJobDelay delay,
                                            SwiftJob *newJob) {
   assert(newJob && "no job provided");
 
-  auto deadline = std::chrono::steady_clock::now()
-                + std::chrono::duration_cast<JobDeadline::duration>(
-                    std::chrono::nanoseconds(delay));
+  auto deadline = currentSuspendingNanos() + static_cast<JobDeadline>(delay);
   JobDeadlineStorage<>::set(newJob, deadline);
 
   insertDelayedJob(newJob, deadline);
@@ -181,13 +183,16 @@ void swift_task_enqueueGlobalWithDeadlineImpl(long long sec,
                                               int clock, SwiftJob *newJob) {
   assert(newJob && "no job provided");
 
-  SwiftTime now = swift_time_now(clock);
+  // Compute how far away the caller-supplied deadline is in the caller's
+  // clock, then re-anchor it to our internal suspending-clock timebase.
+  long long nowSec, nowNsec;
+  swift_get_time(&nowSec, &nowNsec, static_cast<swift_clock_id>(clock));
 
-  uint64_t delta = (sec - now.seconds) * NSEC_PER_SEC + nsec - now.nanoseconds;
+  long long delta =
+      (sec - nowSec) * static_cast<JobDeadline>(NSEC_PER_SEC) +
+      (nsec - nowNsec);
 
-  auto deadline = std::chrono::steady_clock::now()
-                + std::chrono::duration_cast<JobDeadline::duration>(
-                    std::chrono::nanoseconds(delta));
+  auto deadline = currentSuspendingNanos() + delta;
   JobDeadlineStorage<>::set(newJob, deadline);
 
   insertDelayedJob(newJob, deadline);
@@ -200,7 +205,7 @@ static void recognizeReadyDelayedJobs() {
   auto nextDelayedJob = DelayedJobQueue;
   if (!nextDelayedJob) return;
 
-  auto now = std::chrono::steady_clock::now();
+  auto now = currentSuspendingNanos();
 
   // Pull jobs off of the delayed-jobs queue whose deadline has been
   // reached, and add them to the ready queue.
@@ -217,22 +222,13 @@ static void recognizeReadyDelayedJobs() {
 }
 
 static void sleepThisThreadUntil(JobDeadline deadline) {
-#ifdef SWIFT_THREADING_NONE
-  auto duration = deadline - std::chrono::steady_clock::now();
-  // If the deadline is in the past, don't sleep with invalid negative value
-  if (duration <= std::chrono::nanoseconds::zero()) {
+  auto now = currentSuspendingNanos();
+  auto remaining = deadline - now;
+  // If the deadline is already in the past there's nothing to wait for.
+  if (remaining <= 0)
     return;
-  }
-  auto sec = std::chrono::duration_cast<std::chrono::seconds>(duration);
-  auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(duration - sec);
-
-  struct timespec ts;
-  ts.tv_sec = sec.count();
-  ts.tv_nsec = ns.count();
-  while (nanosleep(&ts, &ts) == -1 && errno == EINTR);
-#else
-  std::this_thread::sleep_until(deadline);
-#endif
+  swift_sleep(remaining / static_cast<JobDeadline>(NSEC_PER_SEC),
+              remaining % static_cast<JobDeadline>(NSEC_PER_SEC));
 }
 
 /// Claim the next job from the cooperative global queue.

--- a/test/embedded/dependencies-concurrency-custom-executor.swift
+++ b/test/embedded/dependencies-concurrency-custom-executor.swift
@@ -19,6 +19,7 @@ _clock_gettime
 _exit
 _free
 _malloc
+_memcpy
 _memmove
 _memset
 _memset_s

--- a/test/embedded/dependencies-concurrency.swift
+++ b/test/embedded/dependencies-concurrency.swift
@@ -10,12 +10,12 @@
 // RUN: test ! -s %t/extra.txt
 
 //--- allowed-dependencies.txt
-__ZNSt3__16chrono12steady_clock3nowEv
 ___assert_rtn
 ___error
 ___stack_chk_fail
 ___stack_chk_guard
 _abort
+_clock_gettime
 _exit
 _free
 _malloc


### PR DESCRIPTION
The cooperative global executor uses `<chrono>` for its handling of times. This creates a dependency on a C++11 standard library, and doesn't actually work with freestanding implementations like we want for Embedded Swift.

Replace this `<chrono>` usage with `swift_sleep` / `swift_get_time` from the concurrency library, which already considers various platform-specific implementations before falling back to `<chrono>`.

Enable `-ffreestanding` for the embedded Concurrency library and its support libraries. This is what we want to get to so that the Concurrency library can be used anywhere with Embedded Swift.
