### PR TITLE
[CMake] Reland consolidation & cleanup of the Embedded Swift library builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1442,6 +1442,26 @@ if(SWIFT_PARALLEL_LINK_JOBS)
   endif()
 endif()
 
+# Cap concurrency for embedded-stdlib Swift compilations.
+#
+# `SWIFT_PARALLEL_EMBEDDED_COMPILE_JOBS` defaults to a small fraction of
+# the host's logical cores so the C++ build phase still gets to run at
+# full parallelism; only the embedded Swift compilations queue up through
+# this pool.
+if(CMAKE_MAKE_PROGRAM MATCHES "ninja")
+  if(NOT DEFINED SWIFT_PARALLEL_EMBEDDED_COMPILE_JOBS)
+    cmake_host_system_information(
+      RESULT _swift_embedded_pool_cores QUERY NUMBER_OF_LOGICAL_CORES)
+    math(EXPR SWIFT_PARALLEL_EMBEDDED_COMPILE_JOBS
+         "(${_swift_embedded_pool_cores} + 3) / 4")
+    if(SWIFT_PARALLEL_EMBEDDED_COMPILE_JOBS LESS 1)
+      set(SWIFT_PARALLEL_EMBEDDED_COMPILE_JOBS 1)
+    endif()
+  endif()
+  set_property(GLOBAL APPEND PROPERTY
+    JOB_POOLS swift_embedded_compile_job_pool=${SWIFT_PARALLEL_EMBEDDED_COMPILE_JOBS})
+endif()
+
 # Set the CMAKE_OSX_* variables in a way that minimizes conflicts.
 if("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin" AND NOT CMAKE_CROSSCOMPILING)
   set(CMAKE_OSX_SYSROOT "${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_PATH}")

--- a/cmake/modules/SwiftAddCustomCommandTarget.cmake
+++ b/cmake/modules/SwiftAddCustomCommandTarget.cmake
@@ -112,7 +112,7 @@ function(add_custom_command_target dependency_out_var_name)
   # forwarded verbatim.
   set(options ALL VERBATIM APPEND IDEMPOTENT EXCLUDE_FROM_ALL)
   set(single_value_args
-      MAIN_DEPENDENCY WORKING_DIRECTORY COMMENT CUSTOM_TARGET_NAME)
+      MAIN_DEPENDENCY WORKING_DIRECTORY COMMENT CUSTOM_TARGET_NAME JOB_POOL)
   set(multi_value_args OUTPUT DEPENDS IMPLICIT_DEPENDS SOURCES)
   cmake_parse_arguments(
       ACCT # prefix
@@ -140,7 +140,7 @@ function(add_custom_command_target dependency_out_var_name)
 
     _make_acct_argument_list(
       OUTPUT MAIN_DEPENDENCY DEPENDS
-      IMPLICIT_DEPENDS WORKING_DIRECTORY COMMENT VERBATIM APPEND)
+      IMPLICIT_DEPENDS WORKING_DIRECTORY COMMENT VERBATIM APPEND JOB_POOL)
     add_custom_command(${ACCT_COMMANDS} ${args})
 
     _make_acct_argument_list(ALL WORKING_DIRECTORY SOURCES)

--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -854,6 +854,7 @@ function(add_swift_target_library_single target name)
         NO_SWIFTMODULE
         NO_LINK_NAME
         NO_FREESTANDING_CXX
+        NON_EMPTY_OBJECT_FILE
         INSTALL_WITH_SHARED
         IS_FRAGILE)
   set(SWIFTLIB_SINGLE_single_parameter_options
@@ -1080,9 +1081,15 @@ function(add_swift_target_library_single target name)
       # Flags required to build embedded libraries
       list(APPEND SWIFTLIB_SINGLE_SWIFT_COMPILE_FLAGS -Xcc;-ffreestanding;-enable-experimental-feature;Embedded)
 
-      # Embedded Swift builds with empty object files by default. Everything
-      # is emitted into the client.
-      list(APPEND SWIFTLIB_SINGLE_SWIFT_COMPILE_FLAGS -Xfrontend;-emit-empty-object-file)
+      # Embedded Swift libraries default to producing an empty object file:
+      # they only serve as a swiftmodule for client compilation, and the
+      # client emits the actual code. Libraries that are meant to be linked
+      # in without their swiftmodule ever being imported (e.g. the
+      # EmbeddedPlatform shim archives) must opt out with
+      # NON_EMPTY_OBJECT_FILE so their .a files actually contain code.
+      if(NOT SWIFTLIB_SINGLE_NON_EMPTY_OBJECT_FILE)
+        list(APPEND SWIFTLIB_SINGLE_SWIFT_COMPILE_FLAGS -Xfrontend;-emit-empty-object-file)
+      endif()
       list(APPEND SWIFTLIB_SINGLE_SWIFT_COMPILE_FLAGS -enable-experimental-feature;CodeGenerationModel=implementation)
   endif()
 
@@ -3667,6 +3674,7 @@ endfunction()
 #     [PARTIAL_SOURCES_INTENDED]
 #     [INSTALL_BINARY]
 #     [NO_FREESTANDING_CXX]
+#     [NON_EMPTY_OBJECT_FILE]
 #     <sources>...
 #     [GYB_SOURCES <sources>...]
 #     [SWIFT_COMPILE_FLAGS <flags>...]
@@ -3691,12 +3699,17 @@ endfunction()
 # C/C++ compile flag is suppressed for this library. The Swift driver's
 # -Xcc;-ffreestanding (which affects the clang importer) is left untouched.
 #
+# When NON_EMPTY_OBJECT_FILE is set, the embedded default
+# -Xfrontend;-emit-empty-object-file is suppressed. Use this for libraries
+# whose swiftmodule is never imported by clients but whose object code must
+# be linked in (e.g. the EmbeddedPlatform shim archives).
+#
 # SKIP_*_REGEX and ONLY_*_REGEX are both multi-valued. An entry is processed
 # only when *every* ONLY_*_REGEX category that has at least one pattern has
 # at least one match, AND no SKIP_*_REGEX pattern matches.
 function(add_embedded_swift_target_library prefix library_name)
   cmake_parse_arguments(EMBLIB
-    "IS_STDLIB;IS_STDLIB_CORE;IS_SDK_OVERLAY;PARTIAL_SOURCES_INTENDED;INSTALL_BINARY;NO_FREESTANDING_CXX"
+    "IS_STDLIB;IS_STDLIB_CORE;IS_SDK_OVERLAY;PARTIAL_SOURCES_INTENDED;INSTALL_BINARY;NO_FREESTANDING_CXX;NON_EMPTY_OBJECT_FILE"
     "INSTALL_IN_COMPONENT;ARCHITECTURE_KEY"
     "GYB_SOURCES;SWIFT_COMPILE_FLAGS;C_COMPILE_FLAGS;FILE_DEPENDS;DEPENDS;SKIP_ARCH_REGEX;SKIP_MOD_REGEX;SKIP_TRIPLE_REGEX;ONLY_ARCH_REGEX;ONLY_MOD_REGEX;ONLY_TRIPLE_REGEX"
     ${ARGN})
@@ -3711,6 +3724,8 @@ function(add_embedded_swift_target_library prefix library_name)
                  EMBLIB_PARTIAL_SOURCES_INTENDED_keyword)
   translate_flag(${EMBLIB_NO_FREESTANDING_CXX}    "NO_FREESTANDING_CXX"
                  EMBLIB_NO_FREESTANDING_CXX_keyword)
+  translate_flag(${EMBLIB_NON_EMPTY_OBJECT_FILE}  "NON_EMPTY_OBJECT_FILE"
+                 EMBLIB_NON_EMPTY_OBJECT_FILE_keyword)
 
   if(NOT EMBLIB_ARCHITECTURE_KEY)
     set(EMBLIB_ARCHITECTURE_KEY "arch")
@@ -3814,6 +3829,7 @@ function(add_embedded_swift_target_library prefix library_name)
       STATIC
       ${EMBLIB_PARTIAL_SOURCES_INTENDED_keyword}
       ${EMBLIB_NO_FREESTANDING_CXX_keyword}
+      ${EMBLIB_NON_EMPTY_OBJECT_FILE_keyword}
       ${EMBLIB_UNPARSED_ARGUMENTS}
       GYB_SOURCES ${EMBLIB_GYB_SOURCES}
       SWIFT_COMPILE_FLAGS ${EMBLIB_SWIFT_COMPILE_FLAGS}

--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -158,6 +158,9 @@ function(_add_target_variant_c_compile_link_flags)
     list(APPEND result "-DSWIFT_LIBC_IS_MUSL")
   endif()
 
+  if("${CFLAGS_SDK}" STREQUAL "embedded")
+    list(APPEND result "-ffreestanding")
+  endif()
 
   if("${CFLAGS_SDK}" STREQUAL "ANDROID")
     # Make sure the Android NDK lld is used.
@@ -752,7 +755,6 @@ endfunction()
 #     [DONT_EMBED_BITCODE]
 #     [IS_STDLIB]
 #     [IS_STDLIB_CORE]
-#     [ONLY_SWIFTMODULE]
 #     [NO_SWIFTMODULE]
 #     [IS_SDK_OVERLAY]
 #     [IS_FRAGILE]
@@ -814,9 +816,6 @@ endfunction()
 # IS_STDLIB_CORE
 #   Compile as the standard library core.
 #
-# ONLY_SWIFTMODULE
-#   Do not build either static or shared, build just the .swiftmodule.
-#
 # NO_SWIFTMODULE
 #   Only build either static or shared, and skip the .swiftmodule.
 #
@@ -846,7 +845,6 @@ function(add_swift_target_library_single target name)
         OBJECT_LIBRARY
         SHARED
         STATIC
-        ONLY_SWIFTMODULE
         NO_SWIFTMODULE
         NO_LINK_NAME
         INSTALL_WITH_SHARED
@@ -921,13 +919,53 @@ function(add_swift_target_library_single target name)
   precondition(SWIFTLIB_SINGLE_ARCHITECTURE MESSAGE "Should specify an architecture")
   precondition(SWIFTLIB_SINGLE_INSTALL_IN_COMPONENT MESSAGE "INSTALL_IN_COMPONENT is required")
   if (NOT SWIFTLIB_SINGLE_ARCHITECTURE_SUBDIR_NAME)
-    set(SWIFTLIB_SINGLE_ARCHITECTURE_SUBDIR_NAME "${SWIFTLIB_SINGLE_ARCHITECTURE}")
+    if ("${SWIFTLIB_SINGLE_SDK}" STREQUAL "embedded")
+      # For Embedded Swift, use the whole module triple for the subdirectory.
+      set(SWIFTLIB_SINGLE_ARCHITECTURE_SUBDIR_NAME "${SWIFT_SDK_embedded_ARCH_${SWIFTLIB_SINGLE_ARCHITECTURE}_MODULE}")
+    else()
+      # The architecture itself suffices for non-Embedded Swift.
+      set(SWIFTLIB_SINGLE_ARCHITECTURE_SUBDIR_NAME "${SWIFTLIB_SINGLE_ARCHITECTURE}")
+    endif()
+  endif()
+
+  # For Embedded Swift, force a number of global stdlib feature toggles to
+  # OFF for this library build. Doing this here means callers don't have to
+  # repeat the same set of overrides in every CMakeLists.txt that builds an
+  # embedded library. The `set()`s are function-scoped and shadow the parent
+  # scope (and the CACHE), so they only affect this call and any helper
+  # functions invoked from it.
+  if("${SWIFTLIB_SINGLE_SDK}" STREQUAL "embedded")
+    set(SWIFT_SDK_embedded_LIB_SUBDIR "embedded")
+    set(SWIFT_ENABLE_REFLECTION OFF)
+    set(SWIFT_STDLIB_SUPPORT_BACK_DEPLOYMENT OFF)
+    set(SWIFT_STDLIB_STABLE_ABI OFF)
+    set(SWIFT_STDLIB_ENABLE_OBJC_INTEROP OFF)
+    set(SWIFT_STDLIB_ENABLE_VECTOR_TYPES OFF)
+
+    # Embedded swiftmodules go into a single shared subdirectory; default
+    # MODULE_DIR to it when the caller didn't supply one explicitly.
+    if(NOT SWIFTLIB_SINGLE_MODULE_DIR)
+      set(SWIFTLIB_SINGLE_MODULE_DIR "${CMAKE_BINARY_DIR}/lib/swift/embedded")
+    endif()
+
+    # Embedded Swift libraries are always fragile.
+    set(SWIFTLIB_SINGLE_IS_FRAGILE TRUE)
+    set(SWIFTLIB_SINGLE_IS_FRAGILE_keyword "IS_FRAGILE")
+
+    # When the embedded platform abstraction layer is in use, define
+    # SWIFT_USE_EMBEDDED_SWIFT_PLATFORM for every embedded library build so
+    # that the platform-conditional code paths in the embedded stdlib and
+    # related libraries pick up the platform implementations.
+    if(SWIFT_USE_SWIFT_EMBEDDED_PLATFORM)
+      list(APPEND SWIFTLIB_SINGLE_SWIFT_COMPILE_FLAGS
+        "-D" "SWIFT_USE_EMBEDDED_SWIFT_PLATFORM")
+    endif()
   endif()
 
   if(NOT SWIFTLIB_SINGLE_SHARED AND
      NOT SWIFTLIB_SINGLE_STATIC AND
      NOT SWIFTLIB_SINGLE_OBJECT_LIBRARY AND
-     NOT SWIFTLIB_SINGLE_ONLY_SWIFTMODULE)
+     NOT "${SWIFTLIB_SINGLE_SDK}" STREQUAL "embedded")
     message(FATAL_ERROR
         "Either SHARED, STATIC, or OBJECT_LIBRARY must be specified")
   endif()
@@ -987,8 +1025,8 @@ function(add_swift_target_library_single target name)
     set(libkind SHARED)
   elseif(SWIFTLIB_SINGLE_STATIC)
     set(libkind STATIC)
-  elseif(SWIFTLIB_SINGLE_ONLY_SWIFTMODULE)
-    set(libkind NONE)
+  elseif("${SWIFTLIB_SINGLE_SDK}" STREQUAL "embedded")
+    set(libkind STATIC)
   else()
     message(FATAL_ERROR
         "Either SHARED, STATIC, or OBJECT_LIBRARY must be specified")
@@ -1031,6 +1069,16 @@ function(add_swift_target_library_single target name)
       -libc;${SWIFT_STDLIB_MSVC_RUNTIME_LIBRARY})
   endif()
 
+  if("${SWIFTLIB_SINGLE_SDK}" STREQUAL "embedded")
+      # Flags required to build embedded libraries
+      list(APPEND SWIFTLIB_SINGLE_SWIFT_COMPILE_FLAGS -Xcc;-ffreestanding;-enable-experimental-feature;Embedded)
+
+      # Embedded Swift builds with empty object files by default. Everything
+      # is emitted into the client.
+      list(APPEND SWIFTLIB_SINGLE_SWIFT_COMPILE_FLAGS -Xfrontend;-emit-empty-object-file)
+      list(APPEND SWIFTLIB_SINGLE_SWIFT_COMPILE_FLAGS -enable-experimental-feature;CodeGenerationModel=implementation)
+  endif()
+
   # Define availability macros.
   deployment_version(DEPLOYMENT_VERSION
     SDK "${SWIFTLIB_SINGLE_SDK}"
@@ -1040,8 +1088,22 @@ function(add_swift_target_library_single target name)
     DEPLOYMENT_VERSION_WATCHOS "${SWIFTLIB_SINGLE_DEPLOYMENT_VERSION_WATCHOS}"
     DEPLOYMENT_VERSION_XROS "${SWIFTLIB_SINGLE_DEPLOYMENT_VERSION_XROS}")
 
+  # Compute the availability definitions to use for this library. Under
+  # Embedded Swift, all stdlib APIs should be available always, so replace
+  # all availability macros with an empty expansion (`*`). Otherwise, use
+  # the global SWIFT_STDLIB_AVAILABILITY_DEFINITIONS as-is.
+  if("${SWIFTLIB_SINGLE_SDK}" STREQUAL "embedded")
+    set(SWIFTLIB_SINGLE_AVAILABILITY_DEFINITIONS)
+    foreach(def ${SWIFT_STDLIB_AVAILABILITY_DEFINITIONS})
+      string(REGEX REPLACE ":.*" ":*" replaced "${def}")
+      list(APPEND SWIFTLIB_SINGLE_AVAILABILITY_DEFINITIONS "${replaced}")
+    endforeach()
+  else()
+    set(SWIFTLIB_SINGLE_AVAILABILITY_DEFINITIONS "${SWIFT_STDLIB_AVAILABILITY_DEFINITIONS}")
+  endif()
+
   set(availability_macros)
-  foreach(def ${SWIFT_STDLIB_AVAILABILITY_DEFINITIONS})
+  foreach(def ${SWIFTLIB_SINGLE_AVAILABILITY_DEFINITIONS})
     list(APPEND availability_macros "-Xfrontend -define-availability -Xfrontend \"${def}\"")
 
     if("${def}" MATCHES "SwiftStdlib .*")
@@ -1149,7 +1211,6 @@ function(add_swift_target_library_single target name)
       ${SWIFTLIB_SINGLE_IS_STDLIB_CORE_keyword}
       ${SWIFTLIB_SINGLE_IS_SDK_OVERLAY_keyword}
       ${SWIFTLIB_SINGLE_IS_FRAGILE_keyword}
-      ${SWIFTLIB_SINGLE_ONLY_SWIFTMODULE_keyword}
       ${SWIFTLIB_SINGLE_NO_SWIFTMODULE_keyword}
       ${embed_bitcode_arg}
       ${SWIFTLIB_SINGLE_STATIC_keyword}
@@ -1226,15 +1287,6 @@ function(add_swift_target_library_single target name)
   if(libkind STREQUAL "SHARED")
     list(APPEND INCORPORATED_OBJECT_LIBRARIES_EXPRESSIONS
          ${SWIFTLIB_INCORPORATED_OBJECT_LIBRARIES_EXPRESSIONS_SHARED_ONLY})
-  endif()
-
-  if (SWIFTLIB_SINGLE_ONLY_SWIFTMODULE)
-    add_custom_target("${target}"
-      DEPENDS "${swift_module_dependency_target}")
-    if(TARGET "${install_in_component}")
-      add_dependencies("${install_in_component}" "${target}")
-    endif()
-    return()
   endif()
 
   add_library("${target}" ${libkind}
@@ -1728,6 +1780,10 @@ function(add_swift_target_library_single target name)
         ${SWIFTLIB_SINGLE_PRIVATE_LINK_LIBRARIES})
   endif()
 
+  if ("${SWIFTLIB_SINGLE_SDK}" STREQUAL "embedded")
+    embedded_amend_archive_commands_on_darwin_host(${target} "${SWIFT_SDK_embedded_ARCH_${SWIFTLIB_SINGLE_ARCHITECTURE}_TRIPLE}")
+  endif()
+
   # NOTE(compnerd) use the C linker language to invoke `clang` rather than
   # `clang++` as we explicitly link against the C++ runtime.  We were previously
   # actually passing `-nostdlib++` to avoid the C++ runtime linkage.
@@ -1803,7 +1859,6 @@ endfunction()
 #     [IS_STDLIB]
 #     [IS_STDLIB_CORE]
 #     [IS_OSLOG]
-#     [ONLY_SWIFTMODULE]
 #     [NO_SWIFTMODULE]
 #     [INSTALL_WITH_SHARED]
 #     INSTALL_IN_COMPONENT comp
@@ -1919,9 +1974,6 @@ endfunction()
 # IS_OSLOG
 #   Treat the library as OSLog library.
 #
-# ONLY_SWIFTMODULE
-#   Do not build either static or shared, build just the .swiftmodule.
-#
 # NO_SWIFTMODULE
 #   Only build either static or shared, and skip the .swiftmodule.
 #
@@ -2014,7 +2066,6 @@ function(add_swift_target_library name)
         IS_OSLOG
         IS_SWIFT_ONLY
         NOSWIFTRT
-        ONLY_SWIFTMODULE
         NO_SWIFTMODULE
         OBJECT_LIBRARY
         SHARED
@@ -2643,7 +2694,6 @@ function(add_swift_target_library name)
         ${SWIFTLIB_IS_STDLIB_CORE_keyword}
         ${SWIFTLIB_IS_SDK_OVERLAY_keyword}
         ${SWIFTLIB_NOSWIFTRT_keyword}
-        ${SWIFTLIB_ONLY_SWIFTMODULE_keyword}
         ${SWIFTLIB_NO_SWIFTMODULE_keyword}
         DARWIN_INSTALL_NAME_DIR "${SWIFTLIB_DARWIN_INSTALL_NAME_DIR}"
         INSTALL_IN_COMPONENT "${SWIFTLIB_INSTALL_IN_COMPONENT}"
@@ -3581,6 +3631,239 @@ function(add_swift_target_executable name)
       endforeach()
     endif()
 
+  endforeach()
+endfunction()
+
+# Build an embedded Swift library across every entry of
+# EMBEDDED_STDLIB_TARGET_TRIPLES, calling add_swift_target_library_single()
+# for each target triple.
+#
+# For each entry "<arch> <mod> <triple>" the function:
+#   1. Sets per-target SWIFT_SDK_embedded_ARCH_${key}_{MODULE,TRIPLE,PATH},
+#      where ${key} is ${arch} by default or ${mod} when ARCHITECTURE_KEY mod
+#      is passed.
+#   2. Calls add_swift_target_library_single(<prefix>-${mod} <library_name> ...)
+#      forwarding the sources, flags, and other options provided by the caller.
+#      ARCHITECTURE is set to ${key} and SDK is set to "embedded".
+#   3. Adds the per-target library as a dependency of the umbrella custom
+#      target named <prefix> (which the caller is expected to have already
+#      created via add_custom_target).
+#
+# Unless IS_STDLIB_CORE is passed, "embedded-stdlib-${mod}" is automatically
+# prepended to DEPENDS so that the embedded swiftCore for that target is
+# built first.
+#
+# Usage:
+#   add_embedded_swift_target_library(<prefix> <library_name>
+#     [IS_STDLIB] [IS_STDLIB_CORE] [IS_SDK_OVERLAY]
+#     [PARTIAL_SOURCES_INTENDED]
+#     [INSTALL_BINARY]
+#     <sources>...
+#     [GYB_SOURCES <sources>...]
+#     [SWIFT_COMPILE_FLAGS <flags>...]
+#     [C_COMPILE_FLAGS <flags>...]
+#     [FILE_DEPENDS <files>...]
+#     [DEPENDS <targets>...]
+#     [SKIP_ARCH_REGEX <regex>...]
+#     [SKIP_MOD_REGEX <regex>...]
+#     [SKIP_TRIPLE_REGEX <regex>...]
+#     [ONLY_ARCH_REGEX <regex>...]
+#     [ONLY_MOD_REGEX <regex>...]
+#     [ONLY_TRIPLE_REGEX <regex>...]
+#     [ARCHITECTURE_KEY <arch|mod>]
+#     [INSTALL_IN_COMPONENT <component>])
+#
+# Embedded libraries are always built as STATIC, always have their target's
+# OSX_ARCHITECTURES property set to ${arch}, and always run through
+# embedded_amend_archive_commands_on_darwin_host (a no-op for hosts/targets
+# where it doesn't apply).
+#
+# SKIP_*_REGEX and ONLY_*_REGEX are both multi-valued. An entry is processed
+# only when *every* ONLY_*_REGEX category that has at least one pattern has
+# at least one match, AND no SKIP_*_REGEX pattern matches.
+function(add_embedded_swift_target_library prefix library_name)
+  cmake_parse_arguments(EMBLIB
+    "IS_STDLIB;IS_STDLIB_CORE;IS_SDK_OVERLAY;PARTIAL_SOURCES_INTENDED;INSTALL_BINARY"
+    "INSTALL_IN_COMPONENT;ARCHITECTURE_KEY"
+    "GYB_SOURCES;SWIFT_COMPILE_FLAGS;C_COMPILE_FLAGS;FILE_DEPENDS;DEPENDS;SKIP_ARCH_REGEX;SKIP_MOD_REGEX;SKIP_TRIPLE_REGEX;ONLY_ARCH_REGEX;ONLY_MOD_REGEX;ONLY_TRIPLE_REGEX"
+    ${ARGN})
+
+  translate_flag(${EMBLIB_IS_STDLIB}              "IS_STDLIB"
+                 EMBLIB_IS_STDLIB_keyword)
+  translate_flag(${EMBLIB_IS_STDLIB_CORE}         "IS_STDLIB_CORE"
+                 EMBLIB_IS_STDLIB_CORE_keyword)
+  translate_flag(${EMBLIB_IS_SDK_OVERLAY}         "IS_SDK_OVERLAY"
+                 EMBLIB_IS_SDK_OVERLAY_keyword)
+  translate_flag(${EMBLIB_PARTIAL_SOURCES_INTENDED} "PARTIAL_SOURCES_INTENDED"
+                 EMBLIB_PARTIAL_SOURCES_INTENDED_keyword)
+
+  if(NOT EMBLIB_ARCHITECTURE_KEY)
+    set(EMBLIB_ARCHITECTURE_KEY "arch")
+  elseif(NOT (EMBLIB_ARCHITECTURE_KEY STREQUAL "arch"
+              OR EMBLIB_ARCHITECTURE_KEY STREQUAL "mod"))
+    message(FATAL_ERROR
+      "ARCHITECTURE_KEY must be either 'arch' or 'mod' "
+      "(got '${EMBLIB_ARCHITECTURE_KEY}')")
+  endif()
+
+  foreach(entry ${EMBEDDED_STDLIB_TARGET_TRIPLES})
+    string(REGEX REPLACE "[ \t]+" ";" list "${entry}")
+    list(GET list 0 arch)
+    list(GET list 1 mod)
+    list(GET list 2 triple)
+
+    # Apply caller-supplied filters. The entry is processed only when every
+    # non-empty ONLY_*_REGEX category has at least one match AND no
+    # SKIP_*_REGEX pattern matches.
+    set(_emblib_skip FALSE)
+    foreach(re ${EMBLIB_SKIP_ARCH_REGEX})
+      if("${arch}" MATCHES "${re}")
+        set(_emblib_skip TRUE)
+      endif()
+    endforeach()
+    foreach(re ${EMBLIB_SKIP_MOD_REGEX})
+      if("${mod}" MATCHES "${re}")
+        set(_emblib_skip TRUE)
+      endif()
+    endforeach()
+    foreach(re ${EMBLIB_SKIP_TRIPLE_REGEX})
+      if("${triple}" MATCHES "${re}")
+        set(_emblib_skip TRUE)
+      endif()
+    endforeach()
+
+    if(EMBLIB_ONLY_ARCH_REGEX)
+      set(_emblib_match FALSE)
+      foreach(re ${EMBLIB_ONLY_ARCH_REGEX})
+        if("${arch}" MATCHES "${re}")
+          set(_emblib_match TRUE)
+        endif()
+      endforeach()
+      if(NOT _emblib_match)
+        set(_emblib_skip TRUE)
+      endif()
+    endif()
+    if(EMBLIB_ONLY_MOD_REGEX)
+      set(_emblib_match FALSE)
+      foreach(re ${EMBLIB_ONLY_MOD_REGEX})
+        if("${mod}" MATCHES "${re}")
+          set(_emblib_match TRUE)
+        endif()
+      endforeach()
+      if(NOT _emblib_match)
+        set(_emblib_skip TRUE)
+      endif()
+    endif()
+    if(EMBLIB_ONLY_TRIPLE_REGEX)
+      set(_emblib_match FALSE)
+      foreach(re ${EMBLIB_ONLY_TRIPLE_REGEX})
+        if("${triple}" MATCHES "${re}")
+          set(_emblib_match TRUE)
+        endif()
+      endforeach()
+      if(NOT _emblib_match)
+        set(_emblib_skip TRUE)
+      endif()
+    endif()
+
+    if(_emblib_skip)
+      continue()
+    endif()
+
+    if(EMBLIB_ARCHITECTURE_KEY STREQUAL "mod")
+      set(arch_key "${mod}")
+    else()
+      set(arch_key "${arch}")
+    endif()
+
+    set(SWIFT_SDK_embedded_ARCH_${arch_key}_MODULE "${mod}")
+    set(SWIFT_SDK_embedded_ARCH_${arch_key}_TRIPLE "${triple}")
+    if(SWIFT_EMBEDDED_STDLIB_SDKS_FOR_TARGET_TRIPLES)
+      set(SWIFT_SDK_embedded_ARCH_${arch_key}_PATH
+          "${EMBEDDED_STDLIB_SDK_FOR_${triple}}")
+    endif()
+
+    # Non-core embedded libraries always need the embedded swiftCore for the
+    # same target to be built first.
+    set(per_target_depends ${EMBLIB_DEPENDS})
+    if(NOT EMBLIB_IS_STDLIB_CORE)
+      list(PREPEND per_target_depends "embedded-stdlib-${mod}")
+    endif()
+
+    add_swift_target_library_single(
+      ${prefix}-${mod}
+      ${library_name}
+      ${EMBLIB_IS_STDLIB_keyword}
+      ${EMBLIB_IS_STDLIB_CORE_keyword}
+      ${EMBLIB_IS_SDK_OVERLAY_keyword}
+      STATIC
+      ${EMBLIB_PARTIAL_SOURCES_INTENDED_keyword}
+      ${EMBLIB_UNPARSED_ARGUMENTS}
+      GYB_SOURCES ${EMBLIB_GYB_SOURCES}
+      SWIFT_COMPILE_FLAGS ${EMBLIB_SWIFT_COMPILE_FLAGS}
+      C_COMPILE_FLAGS ${EMBLIB_C_COMPILE_FLAGS}
+      SDK "embedded"
+      ARCHITECTURE "${arch_key}"
+      FILE_DEPENDS ${EMBLIB_FILE_DEPENDS}
+      DEPENDS ${per_target_depends}
+      INSTALL_IN_COMPONENT ${EMBLIB_INSTALL_IN_COMPONENT}
+    )
+
+    # Install the produced archive into lib/swift/embedded/${mod}/. Used by
+    # embedded libraries that produce a static archive consumed by clients
+    # at link time (e.g. swiftEmbeddedPlatformPOSIX, swiftUnicodeDataTables,
+    # swift_Concurrency).
+    if(EMBLIB_INSTALL_BINARY)
+      swift_install_in_component(
+        TARGETS ${prefix}-${mod}
+        DESTINATION "lib/swift/embedded/${mod}"
+        COMPONENT "${EMBLIB_INSTALL_IN_COMPONENT}"
+      )
+      swift_install_in_component(
+        FILES "${SWIFTLIB_DIR}/embedded/${mod}/lib${library_name}.a"
+        DESTINATION "lib/swift/embedded/${mod}/"
+        COMPONENT "${EMBLIB_INSTALL_IN_COMPONENT}"
+        PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE
+                    GROUP_READ GROUP_EXECUTE
+                    WORLD_READ WORLD_EXECUTE
+      )
+    endif()
+
+    # When building the per-target archive on macOS, point CMake at the
+    # specific architecture so it doesn't try to build a fat archive.
+    set_property(TARGET ${prefix}-${mod}
+                 PROPERTY OSX_ARCHITECTURES "${arch}")
+
+    # When archiving on a Windows host, MSVC's lib.exe defaults to the host
+    # machine type and refuses to archive .obj files of a different machine
+    # type (LNK1112). For -windows-msvc targets, force the librarian's
+    # /MACHINE: to match the per-target arch so cross-arch builds work.
+    if(CMAKE_HOST_SYSTEM_NAME STREQUAL "Windows"
+       AND "${triple}" MATCHES "-windows-msvc$")
+      set(_emblib_msvc_machine "")
+      if("${arch}" STREQUAL "i686" OR "${arch}" STREQUAL "i386")
+        set(_emblib_msvc_machine "X86")
+      elseif("${arch}" STREQUAL "x86_64")
+        set(_emblib_msvc_machine "X64")
+      elseif("${arch}" STREQUAL "aarch64" OR "${arch}" STREQUAL "arm64"
+             OR "${arch}" STREQUAL "arm64e")
+        set(_emblib_msvc_machine "ARM64")
+      elseif("${arch}" MATCHES "^arm")
+        set(_emblib_msvc_machine "ARM")
+      endif()
+      if(_emblib_msvc_machine)
+        set_property(TARGET ${prefix}-${mod} APPEND PROPERTY
+                     STATIC_LIBRARY_OPTIONS "/MACHINE:${_emblib_msvc_machine}")
+      endif()
+    endif()
+
+    # Static archives whose target triple is ELF/EABI/wasm need a different
+    # archiver when cross-built from a macOS host. embedded_amend_archive_
+    # commands_on_darwin_host is a no-op for other targets/hosts, so it's
+    # safe to call unconditionally — every embedded library is static.
+    embedded_amend_archive_commands_on_darwin_host(${prefix}-${mod} ${triple})
+
+    add_dependencies(${prefix} ${prefix}-${mod})
   endforeach()
 endfunction()
 

--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -79,7 +79,7 @@ endfunction()
 #   DEPLOYMENT_VERSION_TVOS version
 #   DEPLOYMENT_VERSION_WATCHOS version
 #   DEPLOYMENT_VERSION_XROS version
-#   NO_FREESTANDING_CXX # If TRUE, do not pass -ffreestanding for the embedded SDK.
+#   NO_FREESTANDING_CXX # Option: when passed, do not add -ffreestanding for the embedded SDK.
 #
 # )
 function(_add_target_variant_c_compile_link_flags)
@@ -87,10 +87,9 @@ function(_add_target_variant_c_compile_link_flags)
     DEPLOYMENT_VERSION_OSX DEPLOYMENT_VERSION_MACCATALYST DEPLOYMENT_VERSION_IOS DEPLOYMENT_VERSION_TVOS DEPLOYMENT_VERSION_WATCHOS
     DEPLOYMENT_VERSION_XROS
     MACCATALYST_BUILD_FLAVOR
-    NO_FREESTANDING_CXX
   )
   cmake_parse_arguments(CFLAGS
-    ""
+    "NO_FREESTANDING_CXX"
     "${oneValueArgs}"
     ""
     ${ARGN})
@@ -202,10 +201,9 @@ function(_add_target_variant_c_compile_flags)
     DEPLOYMENT_VERSION_OSX DEPLOYMENT_VERSION_MACCATALYST DEPLOYMENT_VERSION_IOS DEPLOYMENT_VERSION_TVOS DEPLOYMENT_VERSION_WATCHOS
     DEPLOYMENT_VERSION_XROS
     RESULT_VAR_NAME ENABLE_LTO
-    MACCATALYST_BUILD_FLAVOR
-    NO_FREESTANDING_CXX)
+    MACCATALYST_BUILD_FLAVOR)
   cmake_parse_arguments(CFLAGS
-    ""
+    "NO_FREESTANDING_CXX"
     "${oneValueArgs}"
     ""
     ${ARGN})
@@ -225,6 +223,9 @@ function(_add_target_variant_c_compile_flags)
     endif()
   endif()
 
+  translate_flag(${CFLAGS_NO_FREESTANDING_CXX} "NO_FREESTANDING_CXX"
+                 CFLAGS_NO_FREESTANDING_CXX_keyword)
+
   _add_target_variant_c_compile_link_flags(
     SDK "${CFLAGS_SDK}"
     ARCH "${CFLAGS_ARCH}"
@@ -240,7 +241,7 @@ function(_add_target_variant_c_compile_flags)
     DEPLOYMENT_VERSION_XROS "${CFLAGS_DEPLOYMENT_VERSION_XROS}"
     RESULT_VAR_NAME result
     MACCATALYST_BUILD_FLAVOR "${CFLAGS_MACCATALYST_BUILD_FLAVOR}"
-    NO_FREESTANDING_CXX "${CFLAGS_NO_FREESTANDING_CXX}")
+    ${CFLAGS_NO_FREESTANDING_CXX_keyword})
 
   is_build_type_optimized("${CFLAGS_BUILD_TYPE}" optimized)
   if(optimized)
@@ -1602,6 +1603,9 @@ function(add_swift_target_library_single target name)
   set(enable_assertions "${SWIFT_STDLIB_ASSERTIONS}")
   set(lto_type "${SWIFT_STDLIB_ENABLE_LTO}")
 
+  translate_flag(${SWIFTLIB_SINGLE_NO_FREESTANDING_CXX} "NO_FREESTANDING_CXX"
+                 SWIFTLIB_SINGLE_NO_FREESTANDING_CXX_keyword)
+
   _add_target_variant_c_compile_flags(
     SDK "${SWIFTLIB_SINGLE_SDK}"
     ARCH "${SWIFTLIB_SINGLE_ARCHITECTURE}"
@@ -1617,7 +1621,7 @@ function(add_swift_target_library_single target name)
     DEPLOYMENT_VERSION_XROS "${SWIFTLIB_SINGLE_DEPLOYMENT_VERSION_XROS}"
     RESULT_VAR_NAME c_compile_flags
     MACCATALYST_BUILD_FLAVOR "${SWIFTLIB_SINGLE_MACCATALYST_BUILD_FLAVOR}"
-    NO_FREESTANDING_CXX "${SWIFTLIB_SINGLE_NO_FREESTANDING_CXX}"
+    ${SWIFTLIB_SINGLE_NO_FREESTANDING_CXX_keyword}
     )
 
   if(SWIFTLIB_SINGLE_SDK STREQUAL "WINDOWS")

--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -79,6 +79,7 @@ endfunction()
 #   DEPLOYMENT_VERSION_TVOS version
 #   DEPLOYMENT_VERSION_WATCHOS version
 #   DEPLOYMENT_VERSION_XROS version
+#   NO_FREESTANDING_CXX # If TRUE, do not pass -ffreestanding for the embedded SDK.
 #
 # )
 function(_add_target_variant_c_compile_link_flags)
@@ -86,6 +87,7 @@ function(_add_target_variant_c_compile_link_flags)
     DEPLOYMENT_VERSION_OSX DEPLOYMENT_VERSION_MACCATALYST DEPLOYMENT_VERSION_IOS DEPLOYMENT_VERSION_TVOS DEPLOYMENT_VERSION_WATCHOS
     DEPLOYMENT_VERSION_XROS
     MACCATALYST_BUILD_FLAVOR
+    NO_FREESTANDING_CXX
   )
   cmake_parse_arguments(CFLAGS
     ""
@@ -159,7 +161,9 @@ function(_add_target_variant_c_compile_link_flags)
   endif()
 
   if("${CFLAGS_SDK}" STREQUAL "embedded")
-    list(APPEND result "-ffreestanding")
+    if(NOT CFLAGS_NO_FREESTANDING_CXX)
+      list(APPEND result "-ffreestanding")
+    endif()
   endif()
 
   if("${CFLAGS_SDK}" STREQUAL "ANDROID")
@@ -198,7 +202,8 @@ function(_add_target_variant_c_compile_flags)
     DEPLOYMENT_VERSION_OSX DEPLOYMENT_VERSION_MACCATALYST DEPLOYMENT_VERSION_IOS DEPLOYMENT_VERSION_TVOS DEPLOYMENT_VERSION_WATCHOS
     DEPLOYMENT_VERSION_XROS
     RESULT_VAR_NAME ENABLE_LTO
-    MACCATALYST_BUILD_FLAVOR)
+    MACCATALYST_BUILD_FLAVOR
+    NO_FREESTANDING_CXX)
   cmake_parse_arguments(CFLAGS
     ""
     "${oneValueArgs}"
@@ -234,7 +239,8 @@ function(_add_target_variant_c_compile_flags)
     DEPLOYMENT_VERSION_WATCHOS "${CFLAGS_DEPLOYMENT_VERSION_WATCHOS}"
     DEPLOYMENT_VERSION_XROS "${CFLAGS_DEPLOYMENT_VERSION_XROS}"
     RESULT_VAR_NAME result
-    MACCATALYST_BUILD_FLAVOR "${CFLAGS_MACCATALYST_BUILD_FLAVOR}")
+    MACCATALYST_BUILD_FLAVOR "${CFLAGS_MACCATALYST_BUILD_FLAVOR}"
+    NO_FREESTANDING_CXX "${CFLAGS_NO_FREESTANDING_CXX}")
 
   is_build_type_optimized("${CFLAGS_BUILD_TYPE}" optimized)
   if(optimized)
@@ -847,6 +853,7 @@ function(add_swift_target_library_single target name)
         STATIC
         NO_SWIFTMODULE
         NO_LINK_NAME
+        NO_FREESTANDING_CXX
         INSTALL_WITH_SHARED
         IS_FRAGILE)
   set(SWIFTLIB_SINGLE_single_parameter_options
@@ -1603,6 +1610,7 @@ function(add_swift_target_library_single target name)
     DEPLOYMENT_VERSION_XROS "${SWIFTLIB_SINGLE_DEPLOYMENT_VERSION_XROS}"
     RESULT_VAR_NAME c_compile_flags
     MACCATALYST_BUILD_FLAVOR "${SWIFTLIB_SINGLE_MACCATALYST_BUILD_FLAVOR}"
+    NO_FREESTANDING_CXX "${SWIFTLIB_SINGLE_NO_FREESTANDING_CXX}"
     )
 
   if(SWIFTLIB_SINGLE_SDK STREQUAL "WINDOWS")
@@ -3658,6 +3666,7 @@ endfunction()
 #     [IS_STDLIB] [IS_STDLIB_CORE] [IS_SDK_OVERLAY]
 #     [PARTIAL_SOURCES_INTENDED]
 #     [INSTALL_BINARY]
+#     [NO_FREESTANDING_CXX]
 #     <sources>...
 #     [GYB_SOURCES <sources>...]
 #     [SWIFT_COMPILE_FLAGS <flags>...]
@@ -3678,12 +3687,16 @@ endfunction()
 # embedded_amend_archive_commands_on_darwin_host (a no-op for hosts/targets
 # where it doesn't apply).
 #
+# When NO_FREESTANDING_CXX is set, the embedded SDK's default -ffreestanding
+# C/C++ compile flag is suppressed for this library. The Swift driver's
+# -Xcc;-ffreestanding (which affects the clang importer) is left untouched.
+#
 # SKIP_*_REGEX and ONLY_*_REGEX are both multi-valued. An entry is processed
 # only when *every* ONLY_*_REGEX category that has at least one pattern has
 # at least one match, AND no SKIP_*_REGEX pattern matches.
 function(add_embedded_swift_target_library prefix library_name)
   cmake_parse_arguments(EMBLIB
-    "IS_STDLIB;IS_STDLIB_CORE;IS_SDK_OVERLAY;PARTIAL_SOURCES_INTENDED;INSTALL_BINARY"
+    "IS_STDLIB;IS_STDLIB_CORE;IS_SDK_OVERLAY;PARTIAL_SOURCES_INTENDED;INSTALL_BINARY;NO_FREESTANDING_CXX"
     "INSTALL_IN_COMPONENT;ARCHITECTURE_KEY"
     "GYB_SOURCES;SWIFT_COMPILE_FLAGS;C_COMPILE_FLAGS;FILE_DEPENDS;DEPENDS;SKIP_ARCH_REGEX;SKIP_MOD_REGEX;SKIP_TRIPLE_REGEX;ONLY_ARCH_REGEX;ONLY_MOD_REGEX;ONLY_TRIPLE_REGEX"
     ${ARGN})
@@ -3696,6 +3709,8 @@ function(add_embedded_swift_target_library prefix library_name)
                  EMBLIB_IS_SDK_OVERLAY_keyword)
   translate_flag(${EMBLIB_PARTIAL_SOURCES_INTENDED} "PARTIAL_SOURCES_INTENDED"
                  EMBLIB_PARTIAL_SOURCES_INTENDED_keyword)
+  translate_flag(${EMBLIB_NO_FREESTANDING_CXX}    "NO_FREESTANDING_CXX"
+                 EMBLIB_NO_FREESTANDING_CXX_keyword)
 
   if(NOT EMBLIB_ARCHITECTURE_KEY)
     set(EMBLIB_ARCHITECTURE_KEY "arch")
@@ -3798,6 +3813,7 @@ function(add_embedded_swift_target_library prefix library_name)
       ${EMBLIB_IS_SDK_OVERLAY_keyword}
       STATIC
       ${EMBLIB_PARTIAL_SOURCES_INTENDED_keyword}
+      ${EMBLIB_NO_FREESTANDING_CXX_keyword}
       ${EMBLIB_UNPARSED_ARGUMENTS}
       GYB_SOURCES ${EMBLIB_GYB_SOURCES}
       SWIFT_COMPILE_FLAGS ${EMBLIB_SWIFT_COMPILE_FLAGS}

--- a/stdlib/cmake/modules/SwiftSource.cmake
+++ b/stdlib/cmake/modules/SwiftSource.cmake
@@ -453,6 +453,13 @@ function(_compile_swift_files
   precondition(SWIFTFILE_ARCHITECTURE MESSAGE "Should specify an architecture")
   precondition(SWIFTFILE_INSTALL_IN_COMPONENT MESSAGE "INSTALL_IN_COMPONENT is required")
 
+  # Route embedded-stdlib Swift compilations through a bounded ninja job
+  # pool defined in the top-level CMakeLists.txt.
+  set(_swiftfile_job_pool_args)
+  if("${SWIFTFILE_SDK}" STREQUAL "embedded")
+    set(_swiftfile_job_pool_args JOB_POOL swift_embedded_compile_job_pool)
+  endif()
+
   # Determine if/what macCatalyst build variant we are
   get_maccatalyst_build_flavor(maccatalyst_build_flavor
     "${SWIFTFILE_SDK}" "${SWIFTFILE_MACCATALYST_BUILD_FLAVOR}")
@@ -1113,6 +1120,7 @@ function(_compile_swift_files
         ${source_files} ${SWIFTFILE_DEPENDS}
         ${swift_ide_test_dependency}
         ${copy_legacy_layouts_dep}
+      ${_swiftfile_job_pool_args}
       COMMENT "Compiling ${first_output}")
   set("${dependency_target_out_var_name}" "${dependency_target}" PARENT_SCOPE)
 
@@ -1160,6 +1168,7 @@ function(_compile_swift_files
           ${source_files} ${SWIFTFILE_DEPENDS}
           ${swift_ide_test_dependency}
           ${copy_legacy_layouts_dep}
+        ${_swiftfile_job_pool_args}
         COMMENT "Generating ${module_file}")
 
     if(SWIFTFILE_STATIC)
@@ -1240,6 +1249,7 @@ function(_compile_swift_files
           ${swift_ide_test_dependency}
           ${obj_dirs_dependency_target}
           ${copy_legacy_layouts_dep}
+        ${_swiftfile_job_pool_args}
         COMMENT
           "Generating ${maccatalyst_module_file}")
 

--- a/stdlib/cmake/modules/SwiftSource.cmake
+++ b/stdlib/cmake/modules/SwiftSource.cmake
@@ -49,7 +49,7 @@ function(handle_swift_sources
     dependency_sibgen_target_out_var_name
     sourcesvar externalvar name)
   cmake_parse_arguments(SWIFTSOURCES
-      "IS_MAIN;IS_STDLIB;IS_STDLIB_CORE;IS_SDK_OVERLAY;EMBED_BITCODE;STATIC;NO_LINK_NAME;IS_FRAGILE;ONLY_SWIFTMODULE;NO_SWIFTMODULE"
+      "IS_MAIN;IS_STDLIB;IS_STDLIB_CORE;IS_SDK_OVERLAY;EMBED_BITCODE;STATIC;NO_LINK_NAME;IS_FRAGILE;NO_SWIFTMODULE"
       "SDK;ARCHITECTURE;ARCHITECTURE_SUBDIR_NAME;INSTALL_IN_COMPONENT;DEPLOYMENT_VERSION_OSX;DEPLOYMENT_VERSION_IOS;DEPLOYMENT_VERSION_TVOS;DEPLOYMENT_VERSION_WATCHOS;MACCATALYST_BUILD_FLAVOR;BOOTSTRAPPING;INSTALL_BINARY_SWIFTMODULE"
       "DEPENDS;COMPILE_FLAGS;MODULE_NAME;MODULE_DIR;ENABLE_LTO"
       ${ARGN})
@@ -65,7 +65,6 @@ function(handle_swift_sources
                  STATIC_arg)
   translate_flag(${SWIFTSOURCES_NO_LINK_NAME} "NO_LINK_NAME" NO_LINK_NAME_arg)
   translate_flag(${SWIFTSOURCES_IS_FRAGILE} "IS_FRAGILE" IS_FRAGILE_arg)
-  translate_flag(${SWIFTSOURCES_ONLY_SWIFTMODULE} "ONLY_SWIFTMODULE" ONLY_SWIFTMODULE_arg)
   translate_flag(${SWIFTSOURCES_NO_SWIFTMODULE} "NO_SWIFTMODULE" NO_SWIFTMODULE_arg)
   if(DEFINED SWIFTSOURCES_BOOTSTRAPPING)
     set(BOOTSTRAPPING_arg "BOOTSTRAPPING" ${SWIFTSOURCES_BOOTSTRAPPING})
@@ -165,7 +164,6 @@ function(handle_swift_sources
         ${STATIC_arg}
         ${BOOTSTRAPPING_arg}
         ${IS_FRAGILE_arg}
-        ${ONLY_SWIFTMODULE_arg}
         ${NO_SWIFTMODULE_arg}
         INSTALL_BINARY_SWIFTMODULE ${SWIFTSOURCES_INSTALL_BINARY_SWIFTMODULE}
         INSTALL_IN_COMPONENT "${SWIFTSOURCES_INSTALL_IN_COMPONENT}"
@@ -411,7 +409,6 @@ endfunction()
 #     [IS_MAIN]                         # This is an executable, not a library
 #     [IS_STDLIB]
 #     [IS_STDLIB_CORE]                  # This is the core standard library
-#     [ONLY_SWIFTMODULE]                # Emit swiftmodule only, no binary
 #     [NO_SWIFTMODULE]                  # Emit binary only, no swiftmodule
 #     [OPT_FLAGS]                       # Optimization flags (overrides SWIFT_OPTIMIZE)
 #     [MODULE_DIR]                      # Put .swiftmodule, .swiftdoc., and .o
@@ -427,7 +424,7 @@ function(_compile_swift_files
     dependency_sib_target_out_var_name dependency_sibopt_target_out_var_name
     dependency_sibgen_target_out_var_name)
   cmake_parse_arguments(SWIFTFILE
-    "IS_MAIN;IS_STDLIB;IS_STDLIB_CORE;IS_SDK_OVERLAY;EMBED_BITCODE;STATIC;IS_FRAGILE;ONLY_SWIFTMODULE;NO_SWIFTMODULE"
+    "IS_MAIN;IS_STDLIB;IS_STDLIB_CORE;IS_SDK_OVERLAY;EMBED_BITCODE;STATIC;IS_FRAGILE;NO_SWIFTMODULE"
     "OUTPUT;MODULE_NAME;INSTALL_IN_COMPONENT;DEPLOYMENT_VERSION_OSX;DEPLOYMENT_VERSION_IOS;DEPLOYMENT_VERSION_TVOS;DEPLOYMENT_VERSION_WATCHOS;MACCATALYST_BUILD_FLAVOR;BOOTSTRAPPING;INSTALL_BINARY_SWIFTMODULE"
     "SOURCES;FLAGS;DEPENDS;SDK;ARCHITECTURE;OPT_FLAGS;MODULE_DIR"
     ${ARGN})
@@ -1099,7 +1096,6 @@ function(_compile_swift_files
     set(copy_legacy_layouts_dep)
   endif()
 
-  if(NOT SWIFTFILE_ONLY_SWIFTMODULE)
   add_custom_command_target(
       dependency_target
       COMMAND "${CMAKE_COMMAND}" -E make_directory ${dirs_to_create}
@@ -1119,7 +1115,6 @@ function(_compile_swift_files
         ${copy_legacy_layouts_dep}
       COMMENT "Compiling ${first_output}")
   set("${dependency_target_out_var_name}" "${dependency_target}" PARENT_SCOPE)
-  endif()
 
   # This is the target to generate:
   #

--- a/stdlib/public/CMakeLists.txt
+++ b/stdlib/public/CMakeLists.txt
@@ -75,16 +75,6 @@ endif()
 
 add_subdirectory(SwiftShims/swift/shims)
 add_subdirectory(CommandLineSupport)
-if(SWIFT_ENABLE_EXPERIMENTAL_CXX_INTEROP)
-  add_subdirectory(Cxx)
-else()
-  # SwiftCompilerSources rely on C++ interop, specifically on being able to
-  # import the C++ standard library into Swift. On Linux, this is only possible
-  # when using the modulemap that Swift provides for libstdc++. Make sure we
-  # include the libstdc++ modulemap into the build even when not building
-  # C++ interop modules.
-  add_subdirectory(Cxx/libstdcxx)
-endif()
 add_subdirectory(Threading)
 
 # This static library is shared across swiftCore and swiftRemoteInspection
@@ -365,6 +355,17 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
 
   message(STATUS "Building Embedded Swift standard libraries for targets: ${triples}")
   message(STATUS "")
+endif()
+
+if(SWIFT_ENABLE_EXPERIMENTAL_CXX_INTEROP)
+  add_subdirectory(Cxx)
+else()
+  # SwiftCompilerSources rely on C++ interop, specifically on being able to
+  # import the C++ standard library into Swift. On Linux, this is only possible
+  # when using the modulemap that Swift provides for libstdc++. Make sure we
+  # include the libstdc++ modulemap into the build even when not building
+  # C++ interop modules.
+  add_subdirectory(Cxx/libstdcxx)
 endif()
 
 if(SWIFT_BUILD_STDLIB)

--- a/stdlib/public/ClangOverlays/CMakeLists.txt
+++ b/stdlib/public/ClangOverlays/CMakeLists.txt
@@ -39,46 +39,18 @@ if(NOT DEFINED SWIFT_BUILD_CLANG_OVERLAYS_SKIP_BUILTIN_FLOAT OR NOT SWIFT_BUILD_
   if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
     add_custom_target(embedded-builtin_float)
     add_dependencies(embedded-libraries embedded-builtin_float)
-  
-    set(SWIFT_ENABLE_REFLECTION OFF)
-    set(SWIFT_STDLIB_SUPPORT_BACK_DEPLOYMENT OFF)
-    set(SWIFT_STDLIB_STABLE_ABI OFF)
-    set(SWIFT_STDLIB_ENABLE_OBJC_INTEROP OFF)
-    set(SWIFT_STDLIB_ENABLE_VECTOR_TYPES OFF)
 
-    foreach(entry ${EMBEDDED_STDLIB_TARGET_TRIPLES})
-      string(REGEX REPLACE "[ \t]+" ";" list "${entry}")
-      list(GET list 0 arch)
-      list(GET list 1 mod)
-      list(GET list 2 triple)
-  
-      set(SWIFT_SDK_embedded_ARCH_${arch}_MODULE "${mod}")
-      set(SWIFT_SDK_embedded_LIB_SUBDIR "embedded")
-      set(SWIFT_SDK_embedded_ARCH_${arch}_TRIPLE "${triple}")
-      if(SWIFT_EMBEDDED_STDLIB_SDKS_FOR_TARGET_TRIPLES)
-        set(SWIFT_SDK_embedded_ARCH_${arch}_PATH "${EMBEDDED_STDLIB_SDK_FOR_${triple}}")
-      endif()
-      add_swift_target_library_single(
-        embedded-builtin_float-${mod}
-        swift_Builtin_float
-        ONLY_SWIFTMODULE
-        IS_FRAGILE
-        
-        ${BUILTIN_FLOAT_SOURCES}
-        GYB_SOURCES
-          ${BUILTIN_FLOAT_GYB_SOURCES}
-  
-        SWIFT_COMPILE_FLAGS
-          ${BUILTIN_FLOAT_SWIFT_FLAGS}
-          -Xcc -ffreestanding -enable-experimental-feature Embedded
-  
-        MODULE_DIR "${CMAKE_BINARY_DIR}/lib/swift/embedded"
-        SDK "embedded"
-        ARCHITECTURE "${arch}"
-        DEPENDS embedded-stdlib-${mod}
-        INSTALL_IN_COMPONENT stdlib
-        )
-      add_dependencies(embedded-builtin_float embedded-builtin_float-${mod})
-    endforeach()
+    add_embedded_swift_target_library(
+      embedded-builtin_float
+      swift_Builtin_float
+
+      GYB_SOURCES
+        ${BUILTIN_FLOAT_GYB_SOURCES}
+
+      SWIFT_COMPILE_FLAGS
+        ${BUILTIN_FLOAT_SWIFT_FLAGS}
+
+      INSTALL_IN_COMPONENT stdlib
+    )
   endif()
 endif()

--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -293,23 +293,27 @@ elseif(SWIFT_HOST_VARIANT STREQUAL "windows") # For now, don't build embedded Co
 endif()
 if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB AND SWIFT_SHOULD_BUILD_EMBEDDED_CONCURRENCY)
   add_custom_target(embedded-concurrency)
+  add_custom_target(embedded-concurrency-default-executor)
   add_dependencies(embedded-libraries embedded-concurrency)
+  add_dependencies(embedded-concurrency embedded-concurrency-default-executor)
 
   set(SWIFT_CONCURRENCY_USES_DISPATCH FALSE)
   set(SWIFT_STDLIB_SINGLE_THREADED_CONCURRENCY TRUE)
   set(SWIFT_STDLIB_TRACING FALSE)
   set(SWIFT_STDLIB_HAS_ENVIRON FALSE)
   set(SWIFT_STDLIB_HAS_ASL FALSE)
+  set(SWIFT_SDK_embedded_THREADING_PACKAGE none)
   list(APPEND LLVM_OPTIONAL_SOURCES ExecutorImpl.cpp)
 
-  foreach(entry ${EMBEDDED_STDLIB_TARGET_TRIPLES})
+  set(_concurrency_all_triples "${EMBEDDED_STDLIB_TARGET_TRIPLES}")
+
+  foreach(entry ${_concurrency_all_triples})
     string(REGEX REPLACE "[ \t]+" ";" list "${entry}")
     list(GET list 0 arch)
     list(GET list 1 mod)
     list(GET list 2 triple)
 
     set(extra_c_compile_flags)
-    set(extra_swift_compile_flags)
 
     # Skip Concurrency for freestanding Wasm (no libc/libc++ available).
     if("${triple}" MATCHES "-none-wasm$")
@@ -352,34 +356,33 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB AND SWIFT_SHOULD_BUILD_EMBEDDED_CONCURRENC
         ExecutorImpl.swift
         PlatformExecutorCooperative.swift
       )
-      list(APPEND SWIFT_RUNTIME_CONCURRENCY_C_SOURCES
+      set(SWIFT_RUNTIME_CONCURRENCY_EMBEDDED_C_SOURCES
+        ${SWIFT_RUNTIME_CONCURRENCY_C_SOURCES}
         ExecutorImpl.cpp
       )
     else()
       set(SWIFT_RUNTIME_CONCURRENCY_EMBEDDED_SWIFT_SOURCES
         PlatformExecutorNone.swift
       )
+      set(SWIFT_RUNTIME_CONCURRENCY_EMBEDDED_C_SOURCES
+        ${SWIFT_RUNTIME_CONCURRENCY_C_SOURCES}
+      )
     endif()
 
-    set(SWIFT_SDK_embedded_THREADING_PACKAGE none)
-    set(SWIFT_SDK_embedded_ARCH_${arch}_MODULE "${mod}")
-    set(SWIFT_SDK_embedded_ARCH_${mod}_MODULE "${mod}")
-    set(SWIFT_SDK_embedded_ARCH_${arch}_TRIPLE "${triple}")
-    set(SWIFT_SDK_embedded_ARCH_${mod}_TRIPLE "${triple}")
-    if(SWIFT_EMBEDDED_STDLIB_SDKS_FOR_TARGET_TRIPLES)
-      set(SWIFT_SDK_embedded_ARCH_${arch}_PATH "${EMBEDDED_STDLIB_SDK_FOR_${triple}}")
-      set(SWIFT_SDK_embedded_ARCH_${mod}_PATH "${EMBEDDED_STDLIB_SDK_FOR_${triple}}")
-    endif()
+    # Restrict each call below to the current triple by temporarily narrowing
+    # the triple list visible to add_embedded_swift_target_library.
+    set(EMBEDDED_STDLIB_TARGET_TRIPLES "${entry}")
 
     # lib/swift/embedded/_Concurrency.swiftmodule
     # lib/swift/embedded/<triple>/libswift_Concurrency.a
-    add_swift_target_library_single(
-      embedded-concurrency-${mod}
+    add_embedded_swift_target_library(
+      embedded-concurrency
       swift_Concurrency
-      STATIC
       IS_STDLIB
+      INSTALL_BINARY
+      NO_FREESTANDING_CXX
 
-      ${SWIFT_RUNTIME_CONCURRENCY_C_SOURCES}
+      ${SWIFT_RUNTIME_CONCURRENCY_EMBEDDED_C_SOURCES}
       ${SWIFT_RUNTIME_CONCURRENCY_SWIFT_SOURCES}
       ${SWIFT_RUNTIME_CONCURRENCY_EMBEDDED_SWIFT_SOURCES}
 
@@ -387,64 +390,31 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB AND SWIFT_SHOULD_BUILD_EMBEDDED_CONCURRENC
         ${SWIFT_CONCURRENCY_GYB_SOURCES}
 
       SWIFT_COMPILE_FLAGS
-        ${extra_swift_compile_flags}
         -parse-stdlib -DSWIFT_CONCURRENCY_EMBEDDED
         ${SWIFT_RUNTIME_CONCURRENCY_SWIFT_FLAGS}
       C_COMPILE_FLAGS
-        ${extra_c_compile_flags} ${SWIFT_RUNTIME_CONCURRENCY_C_FLAGS} -DSWIFT_CONCURRENCY_EMBEDDED=1 -DSWIFT_RUNTIME_EMBEDDED=1
+        ${extra_c_compile_flags} ${SWIFT_RUNTIME_CONCURRENCY_C_FLAGS}
+        -DSWIFT_CONCURRENCY_EMBEDDED=1 -DSWIFT_RUNTIME_EMBEDDED=1
         -ffunction-sections -fdata-sections -fno-exceptions -fno-cxx-exceptions -fno-unwind-tables
-      SDK "embedded"
-      ARCHITECTURE "${arch}"
-      DEPENDS embedded-stdlib-${mod}
       INSTALL_IN_COMPONENT stdlib
       )
-    swift_install_in_component(
-      TARGETS embedded-concurrency-${mod}
-      DESTINATION "lib/swift/embedded/${mod}"
-      COMPONENT "stdlib"
-      )
-    swift_install_in_component(
-      FILES "${SWIFTLIB_DIR}/embedded/${mod}/libswift_Concurrency.a"
-      DESTINATION "lib/swift/embedded/${mod}/"
-      COMPONENT "stdlib"
-      PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
-      )
-
-    if(NOT "${arch}" MATCHES "wasm32")
-      set_property(TARGET embedded-concurrency-${mod} PROPERTY OSX_ARCHITECTURES "${arch}")
-    endif()
-
-    add_dependencies(embedded-concurrency embedded-concurrency-${mod})
 
     # lib/swift/embedded/<triple>/libswift_ConcurrencyDefaultExecutor.a
-    add_swift_target_library_single(
-      embedded-concurrency-default-executor-${mod}
+    add_embedded_swift_target_library(
+      embedded-concurrency-default-executor
       swift_ConcurrencyDefaultExecutor
-      STATIC
+      INSTALL_BINARY
+      NO_FREESTANDING_CXX
 
       CooperativeGlobalExecutor.cpp
 
       C_COMPILE_FLAGS ${extra_c_compile_flags}
-      SDK "embedded"
-      ARCHITECTURE "${mod}"
-      DEPENDS embedded-stdlib-${mod}
       INSTALL_IN_COMPONENT stdlib
       )
-    swift_install_in_component(
-      TARGETS embedded-concurrency-default-executor-${mod}
-      DESTINATION "lib/swift/embedded/${mod}"
-      COMPONENT "stdlib"
-      )
-    swift_install_in_component(
-      FILES "${SWIFTLIB_DIR}/embedded/${mod}/libswift_ConcurrencyDefaultExecutor.a"
-      DESTINATION "lib/swift/embedded/${mod}/"
-      COMPONENT "stdlib"
-      PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
-      )
-    set_property(TARGET embedded-concurrency-default-executor-${mod} PROPERTY OSX_ARCHITECTURES "${arch}")
-
-    add_dependencies(embedded-concurrency embedded-concurrency-default-executor-${mod})
   endforeach()
+
+  # Restore the full triple list for any later consumers.
+  set(EMBEDDED_STDLIB_TARGET_TRIPLES "${_concurrency_all_triples}")
 
   # Copy the ExecutorImpl.h header into the local include directory
   # and install it in the compiler toolchain

--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -295,25 +295,12 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB AND SWIFT_SHOULD_BUILD_EMBEDDED_CONCURRENC
   add_custom_target(embedded-concurrency)
   add_dependencies(embedded-libraries embedded-concurrency)
 
-  set(SWIFT_ENABLE_REFLECTION OFF)
-  set(SWIFT_STDLIB_SUPPORT_BACK_DEPLOYMENT OFF)
-  set(SWIFT_STDLIB_STABLE_ABI OFF)
-  set(SWIFT_STDLIB_ENABLE_OBJC_INTEROP OFF)
   set(SWIFT_CONCURRENCY_USES_DISPATCH FALSE)
   set(SWIFT_STDLIB_SINGLE_THREADED_CONCURRENCY TRUE)
   set(SWIFT_STDLIB_TRACING FALSE)
   set(SWIFT_STDLIB_HAS_ENVIRON FALSE)
   set(SWIFT_STDLIB_HAS_ASL FALSE)
   list(APPEND LLVM_OPTIONAL_SOURCES ExecutorImpl.cpp)
-
-  # Under Embedded Swift, all stdlib APIs should be available always. Replace
-  # all availability macros with an empty expansion (`*`).
-  set(SWIFT_STDLIB_AVAILABILITY_DEFINITIONS_EMBEDDED)
-  foreach(def ${SWIFT_STDLIB_AVAILABILITY_DEFINITIONS})
-    string(REGEX REPLACE ":.*" ":*" replaced "${def}")
-    list(APPEND SWIFT_STDLIB_AVAILABILITY_DEFINITIONS_EMBEDDED "${replaced}")
-  endforeach()
-  set(SWIFT_STDLIB_AVAILABILITY_DEFINITIONS "${SWIFT_STDLIB_AVAILABILITY_DEFINITIONS_EMBEDDED}")
 
   foreach(entry ${EMBEDDED_STDLIB_TARGET_TRIPLES})
     string(REGEX REPLACE "[ \t]+" ";" list "${entry}")
@@ -377,7 +364,6 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB AND SWIFT_SHOULD_BUILD_EMBEDDED_CONCURRENC
     set(SWIFT_SDK_embedded_THREADING_PACKAGE none)
     set(SWIFT_SDK_embedded_ARCH_${arch}_MODULE "${mod}")
     set(SWIFT_SDK_embedded_ARCH_${mod}_MODULE "${mod}")
-    set(SWIFT_SDK_embedded_LIB_SUBDIR "embedded")
     set(SWIFT_SDK_embedded_ARCH_${arch}_TRIPLE "${triple}")
     set(SWIFT_SDK_embedded_ARCH_${mod}_TRIPLE "${triple}")
     if(SWIFT_EMBEDDED_STDLIB_SDKS_FOR_TARGET_TRIPLES)
@@ -391,7 +377,7 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB AND SWIFT_SHOULD_BUILD_EMBEDDED_CONCURRENC
       embedded-concurrency-${mod}
       swift_Concurrency
       STATIC
-      IS_STDLIB IS_FRAGILE
+      IS_STDLIB
 
       ${SWIFT_RUNTIME_CONCURRENCY_C_SOURCES}
       ${SWIFT_RUNTIME_CONCURRENCY_SWIFT_SOURCES}
@@ -401,17 +387,14 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB AND SWIFT_SHOULD_BUILD_EMBEDDED_CONCURRENC
         ${SWIFT_CONCURRENCY_GYB_SOURCES}
 
       SWIFT_COMPILE_FLAGS
-        ${extra_swift_compile_flags} -enable-experimental-feature Embedded
+        ${extra_swift_compile_flags}
         -parse-stdlib -DSWIFT_CONCURRENCY_EMBEDDED
-        -Xfrontend -emit-empty-object-file
         ${SWIFT_RUNTIME_CONCURRENCY_SWIFT_FLAGS}
       C_COMPILE_FLAGS
         ${extra_c_compile_flags} ${SWIFT_RUNTIME_CONCURRENCY_C_FLAGS} -DSWIFT_CONCURRENCY_EMBEDDED=1 -DSWIFT_RUNTIME_EMBEDDED=1
         -ffunction-sections -fdata-sections -fno-exceptions -fno-cxx-exceptions -fno-unwind-tables
-      MODULE_DIR "${CMAKE_BINARY_DIR}/lib/swift/embedded"
       SDK "embedded"
       ARCHITECTURE "${arch}"
-      ARCHITECTURE_SUBDIR_NAME "${mod}"
       DEPENDS embedded-stdlib-${mod}
       INSTALL_IN_COMPONENT stdlib
       )
@@ -431,8 +414,6 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB AND SWIFT_SHOULD_BUILD_EMBEDDED_CONCURRENC
       set_property(TARGET embedded-concurrency-${mod} PROPERTY OSX_ARCHITECTURES "${arch}")
     endif()
 
-    embedded_amend_archive_commands_on_darwin_host(embedded-concurrency-${mod} ${triple})
-
     add_dependencies(embedded-concurrency embedded-concurrency-${mod})
 
     # lib/swift/embedded/<triple>/libswift_ConcurrencyDefaultExecutor.a
@@ -440,12 +421,10 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB AND SWIFT_SHOULD_BUILD_EMBEDDED_CONCURRENC
       embedded-concurrency-default-executor-${mod}
       swift_ConcurrencyDefaultExecutor
       STATIC
-      IS_FRAGILE
 
       CooperativeGlobalExecutor.cpp
 
       C_COMPILE_FLAGS ${extra_c_compile_flags}
-      MODULE_DIR "${CMAKE_BINARY_DIR}/lib/swift/embedded"
       SDK "embedded"
       ARCHITECTURE "${mod}"
       DEPENDS embedded-stdlib-${mod}
@@ -463,8 +442,6 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB AND SWIFT_SHOULD_BUILD_EMBEDDED_CONCURRENC
       PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
       )
     set_property(TARGET embedded-concurrency-default-executor-${mod} PROPERTY OSX_ARCHITECTURES "${arch}")
-
-    embedded_amend_archive_commands_on_darwin_host(embedded-concurrency-default-executor-${mod} ${triple})
 
     add_dependencies(embedded-concurrency embedded-concurrency-default-executor-${mod})
   endforeach()

--- a/stdlib/public/Cxx/CMakeLists.txt
+++ b/stdlib/public/Cxx/CMakeLists.txt
@@ -6,7 +6,7 @@ if(SWIFT_STDLIB_SUPPORT_BACK_DEPLOYMENT)
   list(APPEND SWIFT_CXX_DEPS copy-legacy-layouts)
 endif()
 
-add_swift_target_library(swiftCxx STATIC NO_LINK_NAME IS_STDLIB IS_SWIFT_ONLY
+set(SWIFT_CXX_SOURCES
     CxxConvertibleToBool.swift
     CxxConvertibleToCollection.swift
     CxxDictionary.swift
@@ -19,8 +19,9 @@ add_swift_target_library(swiftCxx STATIC NO_LINK_NAME IS_STDLIB IS_SWIFT_ONLY
     CxxVector.swift
     CxxSpan.swift
     UnsafeCxxIterators.swift
+)
 
-    SWIFT_COMPILE_FLAGS ${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS} ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
+set(SWIFT_CXX_FLAGS
     -cxx-interoperability-mode=default
     -enable-experimental-feature BuiltinModule
     -enable-experimental-feature AllowUnsafeAttribute
@@ -31,6 +32,13 @@ add_swift_target_library(swiftCxx STATIC NO_LINK_NAME IS_STDLIB IS_SWIFT_ONLY
     # This module should not pull in the C++ standard library, so we disable it explicitly.
     # For functionality that depends on the C++ stdlib, use C++ stdlib overlay (`swiftstd` module).
     -Xcc -nostdinc++
+)
+
+add_swift_target_library(swiftCxx STATIC NO_LINK_NAME IS_STDLIB IS_SWIFT_ONLY
+    ${SWIFT_CXX_SOURCES}
+
+    SWIFT_COMPILE_FLAGS ${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS} ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
+    ${SWIFT_CXX_FLAGS}
 
     DEPLOYMENT_VERSION_OSX ${COMPATIBILITY_MINIMUM_DEPLOYMENT_VERSION_OSX}
     DEPLOYMENT_VERSION_IOS ${COMPATIBILITY_MINIMUM_DEPLOYMENT_VERSION_IOS}
@@ -44,6 +52,25 @@ add_swift_target_library(swiftCxx STATIC NO_LINK_NAME IS_STDLIB IS_SWIFT_ONLY
     INSTALL_IN_COMPONENT compiler
     INSTALL_BINARY_SWIFTMODULE NON_DARWIN_ONLY
     INSTALL_WITH_SHARED)
+
+if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
+  add_custom_target(embedded-cxx)
+  add_dependencies(embedded-libraries embedded-cxx)
+
+  # On Embedded targets, the overlay is installed along with the stdlib. This
+  # is different from regular Swift, where the C++ interop overlays are
+  # installed along with the toolchain due to being version-locked to the
+  # compiler.
+  add_embedded_swift_target_library(embedded-cxx swiftCxx
+      STATIC NO_LINK_NAME IS_STDLIB IS_FRAGILE
+      ${SWIFT_CXX_SOURCES}
+
+      SWIFT_COMPILE_FLAGS ${SWIFT_CXX_FLAGS}
+
+      DEPENDS embedded-stdlib
+      INSTALL_IN_COMPONENT stdlib
+  )
+endif()
 
 add_subdirectory(libstdcxx)
 add_subdirectory(std)

--- a/stdlib/public/Cxx/cxxshim/CMakeLists.txt
+++ b/stdlib/public/Cxx/cxxshim/CMakeLists.txt
@@ -86,6 +86,8 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
   swift_install_in_component(FILES libcxxshim.modulemap libcxxshim.h libcxxstdlibshim.h
                              DESTINATION "lib/swift/embedded"
                              COMPONENT compiler)
+
+  add_dependencies(embedded-libraries cxxshim-embedded)
 endif()
 
 add_custom_target(libcxxshim_modulemap DEPENDS ${libcxxshim_modulemap_target_list})

--- a/stdlib/public/EmbeddedPlatform/CMakeLists.txt
+++ b/stdlib/public/EmbeddedPlatform/CMakeLists.txt
@@ -39,6 +39,7 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
     swiftEmbeddedPlatformPOSIX
     PARTIAL_SOURCES_INTENDED
     INSTALL_BINARY
+    NON_EMPTY_OBJECT_FILE
 
     EmbeddedPlatformPOSIX.swift
 
@@ -54,6 +55,7 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
     swiftEmbeddedPlatformSingleThreaded
     PARTIAL_SOURCES_INTENDED
     INSTALL_BINARY
+    NON_EMPTY_OBJECT_FILE
 
     EmbeddedPlatformSingleThreaded.swift
 
@@ -79,6 +81,7 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
     swiftEmbeddedPlatformMultiThreadedPOSIX
     PARTIAL_SOURCES_INTENDED
     INSTALL_BINARY
+    NON_EMPTY_OBJECT_FILE
 
     EmbeddedPlatformMultiThreadedPOSIX.c
 
@@ -100,6 +103,7 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
       swiftEmbeddedPlatformMultiThreadedDarwin
       PARTIAL_SOURCES_INTENDED
       INSTALL_BINARY
+      NON_EMPTY_OBJECT_FILE
 
       EmbeddedPlatformMultiThreadedDarwin.c
 

--- a/stdlib/public/EmbeddedPlatform/CMakeLists.txt
+++ b/stdlib/public/EmbeddedPlatform/CMakeLists.txt
@@ -27,174 +27,88 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
   add_custom_target(embedded-multi-threaded-darwin-shim)
   add_dependencies(embedded-libraries embedded-multi-threaded-darwin-shim)
 
-  foreach(entry ${EMBEDDED_STDLIB_TARGET_TRIPLES})
-    string(REGEX REPLACE "[ \t]+" ";" list "${entry}")
-    list(GET list 0 arch)
-    list(GET list 1 mod)
-    list(GET list 2 triple)
+  set(_embedded_platform_swift_flags
+    ${swift_stdlib_compile_flags}
+    "-import-bridging-header" ${CMAKE_CURRENT_SOURCE_DIR}/swift/EmbeddedPlatform.h
+    -enable-experimental-feature Extern
+    -enable-experimental-feature AllowRuntimeSymbolDeclarations
+    "-disable-bridging-pch")
 
-    if("${mod}" MATCHES "-windows-msvc$")
-      continue()
-    endif()
+  add_embedded_swift_target_library(
+    embedded-posix-shim
+    swiftEmbeddedPlatformPOSIX
+    PARTIAL_SOURCES_INTENDED
+    INSTALL_BINARY
 
-    if("${arch}" MATCHES "avr")
-      continue()
-    endif()
+    EmbeddedPlatformPOSIX.swift
 
-    if (SWIFT_HOST_VARIANT STREQUAL "linux")
-      set(extra_c_compile_flags -ffreestanding)
-    elseif (SWIFT_HOST_VARIANT STREQUAL "macosx")
-      set(extra_c_compile_flags -ffreestanding)
-    endif()
-    list(APPEND extra_c_compile_flags -nostdinc++)
+    SWIFT_COMPILE_FLAGS ${_embedded_platform_swift_flags}
+    SKIP_MOD_REGEX "-windows-msvc$"
+    SKIP_ARCH_REGEX "avr"
+    ARCHITECTURE_KEY mod
+    INSTALL_IN_COMPONENT stdlib
+  )
 
-    set(SWIFT_SDK_embedded_ARCH_${mod}_MODULE "${mod}")
-    set(SWIFT_SDK_embedded_LIB_SUBDIR "embedded")
-    set(SWIFT_SDK_embedded_ARCH_${mod}_TRIPLE "${triple}")
-    if(SWIFT_EMBEDDED_STDLIB_SDKS_FOR_TARGET_TRIPLES)
-      set(SWIFT_SDK_embedded_ARCH_${mod}_PATH "${EMBEDDED_STDLIB_SDK_FOR_${triple}}")
-    endif()
+  add_embedded_swift_target_library(
+    embedded-single-threaded-shim
+    swiftEmbeddedPlatformSingleThreaded
+    PARTIAL_SOURCES_INTENDED
+    INSTALL_BINARY
 
-    add_swift_target_library_single(
-      embedded-posix-shim-${mod}
-      swiftEmbeddedPlatformPOSIX
-      STATIC
-      IS_FRAGILE
+    EmbeddedPlatformSingleThreaded.swift
+
+    SWIFT_COMPILE_FLAGS ${_embedded_platform_swift_flags}
+    SKIP_MOD_REGEX "-windows-msvc$"
+    SKIP_ARCH_REGEX "avr"
+    ARCHITECTURE_KEY mod
+    INSTALL_IN_COMPONENT stdlib
+  )
+
+  # The POSIX pthread-based shim only makes sense on hosted POSIX targets;
+  # skip bare-metal and Windows triples that lack a pthread implementation.
+  # Also skip Apple targets when the host is not macOS: cross-compiling to
+  # Apple from Linux/Windows without an Apple SDK picks up the host libc's
+  # `<pthread.h>`, which fails.
+  set(_mt_posix_skip_triple "-none-" "-windows-")
+  if(NOT SWIFT_HOST_VARIANT STREQUAL "macosx")
+    list(APPEND _mt_posix_skip_triple "-apple-")
+  endif()
+
+  add_embedded_swift_target_library(
+    embedded-multi-threaded-posix-shim
+    swiftEmbeddedPlatformMultiThreadedPOSIX
+    PARTIAL_SOURCES_INTENDED
+    INSTALL_BINARY
+
+    EmbeddedPlatformMultiThreadedPOSIX.c
+
+    C_COMPILE_FLAGS -nostdinc++ -I${CMAKE_CURRENT_SOURCE_DIR}/swift
+    SKIP_MOD_REGEX "-windows-msvc$"
+    SKIP_ARCH_REGEX "avr"
+    SKIP_TRIPLE_REGEX ${_mt_posix_skip_triple}
+    ARCHITECTURE_KEY mod
+    INSTALL_IN_COMPONENT stdlib
+  )
+
+  # The Darwin-specific `os_unfair_lock` shim is only meaningful on hosted
+  # Apple target triples, and can only be compiled when the host has an
+  # Apple SDK (i.e. macOS). Skip bare-metal `-apple-none-*` triples and
+  # non-macOS hosts.
+  if(SWIFT_HOST_VARIANT STREQUAL "macosx")
+    add_embedded_swift_target_library(
+      embedded-multi-threaded-darwin-shim
+      swiftEmbeddedPlatformMultiThreadedDarwin
       PARTIAL_SOURCES_INTENDED
+      INSTALL_BINARY
 
-      EmbeddedPlatformPOSIX.swift
+      EmbeddedPlatformMultiThreadedDarwin.c
 
-      C_COMPILE_FLAGS ${extra_c_compile_flags}
-      SWIFT_COMPILE_FLAGS ${swift_stdlib_compile_flags} -Xcc -ffreestanding -enable-experimental-feature Embedded "-import-bridging-header" ${CMAKE_CURRENT_SOURCE_DIR}/swift/EmbeddedPlatform.h -enable-experimental-feature Extern -enable-experimental-feature AllowRuntimeSymbolDeclarations "-disable-bridging-pch"
-      MODULE_DIR "${CMAKE_BINARY_DIR}/lib/swift/embedded"
-      SDK "embedded"
-      ARCHITECTURE "${mod}"
-      DEPENDS embedded-stdlib-${mod}
+      C_COMPILE_FLAGS -nostdinc++ -I${CMAKE_CURRENT_SOURCE_DIR}/swift
+      ONLY_TRIPLE_REGEX "-apple-"
+      SKIP_TRIPLE_REGEX "-apple-none-"
+      SKIP_ARCH_REGEX "avr"
+      ARCHITECTURE_KEY mod
       INSTALL_IN_COMPONENT stdlib
-      )
-    swift_install_in_component(
-      TARGETS embedded-posix-shim-${mod}
-      DESTINATION "lib/swift/embedded/${mod}"
-      COMPONENT "stdlib"
-      )
-    swift_install_in_component(
-      FILES "${SWIFTLIB_DIR}/embedded/${mod}/libswiftEmbeddedPlatformPOSIX.a"
-      DESTINATION "lib/swift/embedded/${mod}/"
-      COMPONENT "stdlib"
-      PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
-      )
-    set_property(TARGET embedded-posix-shim-${mod} PROPERTY OSX_ARCHITECTURES "${arch}")
-
-    add_dependencies(embedded-posix-shim embedded-posix-shim-${mod})
-
-    add_swift_target_library_single(
-      embedded-single-threaded-shim-${mod}
-      swiftEmbeddedPlatformSingleThreaded
-      STATIC
-      IS_FRAGILE
-      PARTIAL_SOURCES_INTENDED
-
-      EmbeddedPlatformSingleThreaded.swift
-
-      C_COMPILE_FLAGS ${extra_c_compile_flags}
-      SWIFT_COMPILE_FLAGS ${swift_stdlib_compile_flags} -Xcc -ffreestanding -enable-experimental-feature Embedded "-import-bridging-header" ${CMAKE_CURRENT_SOURCE_DIR}/swift/EmbeddedPlatform.h -enable-experimental-feature Extern -enable-experimental-feature AllowRuntimeSymbolDeclarations "-disable-bridging-pch"
-      MODULE_DIR "${CMAKE_BINARY_DIR}/lib/swift/embedded"
-      SDK "embedded"
-      ARCHITECTURE "${mod}"
-      DEPENDS embedded-stdlib-${mod}
-      INSTALL_IN_COMPONENT stdlib
-      )
-    swift_install_in_component(
-      TARGETS embedded-single-threaded-shim-${mod}
-      DESTINATION "lib/swift/embedded/${mod}"
-      COMPONENT "stdlib"
-      )
-    swift_install_in_component(
-      FILES "${SWIFTLIB_DIR}/embedded/${mod}/libswiftEmbeddedPlatformSingleThreaded.a"
-      DESTINATION "lib/swift/embedded/${mod}/"
-      COMPONENT "stdlib"
-      PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
-      )
-    set_property(TARGET embedded-single-threaded-shim-${mod} PROPERTY OSX_ARCHITECTURES "${arch}")
-
-    add_dependencies(embedded-single-threaded-shim embedded-single-threaded-shim-${mod})
-
-    # The POSIX pthread-based shim only makes sense on hosted POSIX targets;
-    # skip bare-metal and Windows triples that lack a pthread implementation.
-    # Also skip Apple targets when the host is not macOS: cross-compiling to
-    # Apple from Linux/Windows without an Apple SDK picks up the host libc's
-    # `<pthread.h>`, which fails.
-    if(NOT "${triple}" MATCHES "-none-|-windows-" AND
-       (NOT "${triple}" MATCHES "-apple-" OR SWIFT_HOST_VARIANT STREQUAL "macosx"))
-      add_swift_target_library_single(
-        embedded-multi-threaded-posix-shim-${mod}
-        swiftEmbeddedPlatformMultiThreadedPOSIX
-        STATIC
-        IS_FRAGILE
-        PARTIAL_SOURCES_INTENDED
-
-        EmbeddedPlatformMultiThreadedPOSIX.c
-
-        C_COMPILE_FLAGS ${extra_c_compile_flags} -I${CMAKE_CURRENT_SOURCE_DIR}/swift
-        MODULE_DIR "${CMAKE_BINARY_DIR}/lib/swift/embedded"
-        SDK "embedded"
-        ARCHITECTURE "${mod}"
-        DEPENDS embedded-stdlib-${mod}
-        INSTALL_IN_COMPONENT stdlib
-        )
-      swift_install_in_component(
-        TARGETS embedded-multi-threaded-posix-shim-${mod}
-        DESTINATION "lib/swift/embedded/${mod}"
-        COMPONENT "stdlib"
-        )
-      swift_install_in_component(
-        FILES "${SWIFTLIB_DIR}/embedded/${mod}/libswiftEmbeddedPlatformMultiThreadedPOSIX.a"
-        DESTINATION "lib/swift/embedded/${mod}/"
-        COMPONENT "stdlib"
-        PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
-        )
-      set_property(TARGET embedded-multi-threaded-posix-shim-${mod} PROPERTY OSX_ARCHITECTURES "${arch}")
-
-      add_dependencies(embedded-multi-threaded-posix-shim embedded-multi-threaded-posix-shim-${mod})
-    endif()
-
-    # The Darwin-specific `os_unfair_lock` shim is only meaningful on hosted
-    # Apple target triples, and can only be compiled when the host has an
-    # Apple SDK (i.e. macOS). Skip bare-metal `-apple-none-*` triples and
-    # non-macOS hosts.
-    if("${triple}" MATCHES "-apple-" AND
-       NOT "${triple}" MATCHES "-apple-none-" AND
-       SWIFT_HOST_VARIANT STREQUAL "macosx")
-      add_swift_target_library_single(
-        embedded-multi-threaded-darwin-shim-${mod}
-        swiftEmbeddedPlatformMultiThreadedDarwin
-        STATIC
-        IS_FRAGILE
-        PARTIAL_SOURCES_INTENDED
-
-        EmbeddedPlatformMultiThreadedDarwin.c
-
-        C_COMPILE_FLAGS ${extra_c_compile_flags} -I${CMAKE_CURRENT_SOURCE_DIR}/swift
-        MODULE_DIR "${CMAKE_BINARY_DIR}/lib/swift/embedded"
-        SDK "embedded"
-        ARCHITECTURE "${mod}"
-        DEPENDS embedded-stdlib-${mod}
-        INSTALL_IN_COMPONENT stdlib
-        )
-      swift_install_in_component(
-        TARGETS embedded-multi-threaded-darwin-shim-${mod}
-        DESTINATION "lib/swift/embedded/${mod}"
-        COMPONENT "stdlib"
-        )
-      swift_install_in_component(
-        FILES "${SWIFTLIB_DIR}/embedded/${mod}/libswiftEmbeddedPlatformMultiThreadedDarwin.a"
-        DESTINATION "lib/swift/embedded/${mod}/"
-        COMPONENT "stdlib"
-        PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
-        )
-      set_property(TARGET embedded-multi-threaded-darwin-shim-${mod} PROPERTY OSX_ARCHITECTURES "${arch}")
-
-      add_dependencies(embedded-multi-threaded-darwin-shim embedded-multi-threaded-darwin-shim-${mod})
-    endif()
-  endforeach()
+    )
+  endif()
 endif()

--- a/stdlib/public/Platform/CMakeLists.txt
+++ b/stdlib/public/Platform/CMakeLists.txt
@@ -587,13 +587,11 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
     set(triple "wasm32-unknown-wasip1")
 
     set(SWIFT_SDK_embedded_ARCH_${arch}_MODULE "${triple}")
-    set(SWIFT_SDK_embedded_LIB_SUBDIR "embedded")
     set(SWIFT_SDK_embedded_ARCH_${arch}_TRIPLE "${triple}")
     add_swift_target_library_single(
       embedded-stdlib-platform-${triple}
       swiftWASILibc
-      ONLY_SWIFTMODULE
-      IS_STDLIB IS_FRAGILE
+      IS_STDLIB
         ${swift_platform_sources}
         POSIXError.swift
 
@@ -605,10 +603,8 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
         -enable-experimental-feature Embedded
         -Xfrontend -emit-empty-object-file
 
-      MODULE_DIR "${CMAKE_BINARY_DIR}/lib/swift/embedded"
       SDK "embedded"
       ARCHITECTURE "${arch}"
-      ARCHITECTURE_SUBDIR_NAME "${triple}"
       DEPENDS embedded-stdlib-${triple} wasilibc_modulemap
       INSTALL_IN_COMPONENT sdk-overlay
     )

--- a/stdlib/public/Synchronization/CMakeLists.txt
+++ b/stdlib/public/Synchronization/CMakeLists.txt
@@ -171,62 +171,35 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
   add_custom_target(embedded-synchronization)
   add_dependencies(embedded-libraries embedded-synchronization)
 
-  set(SWIFT_ENABLE_REFLECTION OFF)
-  set(SWIFT_STDLIB_SUPPORT_BACK_DEPLOYMENT OFF)
-  set(SWIFT_STDLIB_STABLE_ABI OFF)
-  set(SWIFT_STDLIB_ENABLE_OBJC_INTEROP OFF)
-  set(SWIFT_STDLIB_ENABLE_VECTOR_TYPES OFF)
+  # wasm32 builds the full Synchronization library plus its wasm-specific
+  # mutex implementation.
+  add_embedded_swift_target_library(
+    embedded-synchronization
+    swiftSynchronization
 
-  foreach(entry ${EMBEDDED_STDLIB_TARGET_TRIPLES})
-    string(REGEX REPLACE "[ \t]+" ";" list "${entry}")
-    list(GET list 0 arch)
-    list(GET list 1 mod)
-    list(GET list 2 triple)
+    ${SWIFT_SYNCHRONIZATION_SOURCES}
+    ${SWIFT_SYNCHRONIZATION_WASM_SOURCES}
 
-    # Disable the Synchronization library on AVR for now.
-    if("${arch}" MATCHES "avr")
-      continue()
-    endif()
+    GYB_SOURCES ${SWIFT_SYNCHRONIZATION_GYB_SOURCES}
+    SWIFT_COMPILE_FLAGS ${SWIFT_SYNCHRNOIZATION_SWIFT_FLAGS}
+    ONLY_ARCH_REGEX "^wasm32$"
+    INSTALL_IN_COMPONENT stdlib
+  )
 
-    set(SWIFT_SDK_embedded_ARCH_${arch}_MODULE "${mod}")
-    set(SWIFT_SDK_embedded_LIB_SUBDIR "embedded")
-    set(SWIFT_SDK_embedded_ARCH_${arch}_TRIPLE "${triple}")
-    if(SWIFT_EMBEDDED_STDLIB_SDKS_FOR_TARGET_TRIPLES)
-      set(SWIFT_SDK_embedded_ARCH_${arch}_PATH "${EMBEDDED_STDLIB_SDK_FOR_${triple}}")
-    endif()
+  # All other architectures get the full Synchronization sources plus the
+  # embedded Mutex implementation. wasm32 is handled by the previous call;
+  # avr is unsupported.
+  add_embedded_swift_target_library(
+    embedded-synchronization
+    swiftSynchronization
 
-    set(SWIFT_SYNCHRONIZATION_EMBEDDED_SOURCES)
+    ${SWIFT_SYNCHRONIZATION_SOURCES}
+    Mutex/EmbeddedImpl.swift
+    Mutex/Mutex.swift
 
-    if("${arch}" MATCHES "wasm32")
-      list(APPEND SWIFT_SYNCHRONIZATION_EMBEDDED_SOURCES ${SWIFT_SYNCHRONIZATION_SOURCES})
-      list(APPEND SWIFT_SYNCHRONIZATION_EMBEDDED_SOURCES ${SWIFT_SYNCHRONIZATION_WASM_SOURCES})
-    else()
-      list(APPEND SWIFT_SYNCHRONIZATION_EMBEDDED_SOURCES ${SWIFT_SYNCHRONIZATION_SOURCES})
-      list(APPEND SWIFT_SYNCHRONIZATION_EMBEDDED_SOURCES Mutex/EmbeddedImpl.swift)
-      list(APPEND SWIFT_SYNCHRONIZATION_EMBEDDED_SOURCES Mutex/Mutex.swift)
-    endif()
-      
-    add_swift_target_library_single(
-      embedded-synchronization-${mod}
-      swiftSynchronization
-      ONLY_SWIFTMODULE
-      IS_FRAGILE
-      
-      ${SWIFT_SYNCHRONIZATION_EMBEDDED_SOURCES}
-      
-      GYB_SOURCES
-        ${SWIFT_SYNCHRONIZATION_GYB_SOURCES}
-
-      SWIFT_COMPILE_FLAGS
-        ${SWIFT_SYNCHRNOIZATION_SWIFT_FLAGS}
-        -Xcc -ffreestanding -enable-experimental-feature Embedded
-
-      MODULE_DIR "${CMAKE_BINARY_DIR}/lib/swift/embedded"
-      SDK "embedded"
-      ARCHITECTURE "${arch}"
-      DEPENDS embedded-stdlib-${mod}
-      INSTALL_IN_COMPONENT stdlib
-      )
-    add_dependencies(embedded-synchronization embedded-synchronization-${mod})
-  endforeach()
+    GYB_SOURCES ${SWIFT_SYNCHRONIZATION_GYB_SOURCES}
+    SWIFT_COMPILE_FLAGS ${SWIFT_SYNCHRNOIZATION_SWIFT_FLAGS}
+    SKIP_ARCH_REGEX "^wasm32$" "^avr$"
+    INSTALL_IN_COMPONENT stdlib
+  )
 endif()

--- a/stdlib/public/Volatile/CMakeLists.txt
+++ b/stdlib/public/Volatile/CMakeLists.txt
@@ -24,37 +24,16 @@ add_swift_target_library(swift_Volatile ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_S
 if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
   add_custom_target(embedded-volatile)
   add_dependencies(embedded-libraries embedded-volatile)
-  foreach(entry ${EMBEDDED_STDLIB_TARGET_TRIPLES})
-    string(REGEX REPLACE "[ \t]+" ";" list "${entry}")
-    list(GET list 0 arch)
-    list(GET list 1 mod)
-    list(GET list 2 triple)
 
-    set(SWIFT_SDK_embedded_ARCH_${arch}_MODULE "${mod}")
-    set(SWIFT_SDK_embedded_LIB_SUBDIR "embedded")
-    set(SWIFT_SDK_embedded_ARCH_${arch}_TRIPLE "${triple}")
-    if(SWIFT_EMBEDDED_STDLIB_SDKS_FOR_TARGET_TRIPLES)
-      set(SWIFT_SDK_embedded_ARCH_${arch}_PATH "${EMBEDDED_STDLIB_SDK_FOR_${triple}}")
-    endif()
-    add_swift_target_library_single(
-      embedded-volatile-${mod}
-      swift_Volatile
-      ONLY_SWIFTMODULE
-      IS_SDK_OVERLAY IS_FRAGILE
+  add_embedded_swift_target_library(
+    embedded-volatile
+    swift_Volatile
+    IS_SDK_OVERLAY
 
-      Volatile.swift
+    Volatile.swift
 
-      SWIFT_COMPILE_FLAGS
-        -Xcc -ffreestanding -enable-experimental-feature Embedded
-        -parse-stdlib
-      C_COMPILE_FLAGS
-        -ffreestanding
-      MODULE_DIR "${CMAKE_BINARY_DIR}/lib/swift/embedded"
-      SDK "embedded"
-      ARCHITECTURE "${arch}"
-      DEPENDS embedded-stdlib-${mod}
-      INSTALL_IN_COMPONENT stdlib
-      )
-    add_dependencies(embedded-volatile embedded-volatile-${mod})
-  endforeach()
+    SWIFT_COMPILE_FLAGS
+      -parse-stdlib
+    INSTALL_IN_COMPONENT stdlib
+  )
 endif()

--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -534,60 +534,21 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
   endforeach()
 endif()
 
-# Embedded standard library - embedded libraries are built as .swiftmodule only,
-# i.e. there is no .o or .a file produced (no binary code is actually produced)
-# and only users of a library are going to actually compile any needed code.
+# Embedded standard library.
 if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
   add_custom_target(embedded-stdlib)
   add_dependencies(embedded-libraries embedded-stdlib)
 
-  set(SWIFT_ENABLE_REFLECTION OFF)
-  set(SWIFT_STDLIB_SUPPORT_BACK_DEPLOYMENT OFF)
-  set(SWIFT_STDLIB_STABLE_ABI OFF)
-  set(SWIFT_STDLIB_ENABLE_OBJC_INTEROP OFF)
-  set(SWIFT_STDLIB_ENABLE_VECTOR_TYPES OFF)
-
-  # Under Embedded Swift, all stdlib APIs should be available always. Replace
-  # all availability macros with an empty expansion (`*`).
-  set(SWIFT_STDLIB_AVAILABILITY_DEFINITIONS_EMBEDDED)
-  foreach(def ${SWIFT_STDLIB_AVAILABILITY_DEFINITIONS})
-    string(REGEX REPLACE ":.*" ":*" replaced "${def}")
-    list(APPEND SWIFT_STDLIB_AVAILABILITY_DEFINITIONS_EMBEDDED "${replaced}")
-  endforeach()
-  set(SWIFT_STDLIB_AVAILABILITY_DEFINITIONS "${SWIFT_STDLIB_AVAILABILITY_DEFINITIONS_EMBEDDED}")
-
-  foreach(entry ${EMBEDDED_STDLIB_TARGET_TRIPLES})
-    string(REGEX REPLACE "[ \t]+" ";" list "${entry}")
-    list(GET list 0 arch)
-    list(GET list 1 mod)
-    list(GET list 2 triple)
-    
-    set(SWIFT_SDK_embedded_ARCH_${arch}_MODULE "${mod}")
-    set(SWIFT_SDK_embedded_LIB_SUBDIR "embedded")
-    set(SWIFT_SDK_embedded_ARCH_${arch}_TRIPLE "${triple}")
-    if(SWIFT_EMBEDDED_STDLIB_SDKS_FOR_TARGET_TRIPLES)
-      set(SWIFT_SDK_embedded_ARCH_${arch}_PATH "${EMBEDDED_STDLIB_SDK_FOR_${triple}}")
-    endif()
-    set(swift_embedded_stdlib_extra_compile_flags)
-    if(SWIFT_USE_SWIFT_EMBEDDED_PLATFORM)
-      list(APPEND swift_embedded_stdlib_extra_compile_flags "-D" "SWIFT_USE_EMBEDDED_SWIFT_PLATFORM")
-    endif()
-    add_swift_target_library_single(
-      embedded-stdlib-${mod}
-      swiftCore
-      ONLY_SWIFTMODULE
-      IS_STDLIB IS_STDLIB_CORE IS_FRAGILE
-      ${SWIFTLIB_EMBEDDED_SOURCES}
-      GYB_SOURCES ${SWIFTLIB_EMBEDDED_GYB_SOURCES}
-      SWIFT_COMPILE_FLAGS
-        ${swift_stdlib_compile_flags} -Xcc -ffreestanding -enable-experimental-feature Embedded ${swift_embedded_stdlib_extra_compile_flags}
-      MODULE_DIR "${CMAKE_BINARY_DIR}/lib/swift/embedded"
-      SDK "embedded"
-      ARCHITECTURE "${arch}"
-      FILE_DEPENDS ${swiftCore_common_dependencies}
-      DEPENDS ${tooling_stdlib_deps}
-      INSTALL_IN_COMPONENT stdlib
-      )
-    add_dependencies(embedded-stdlib embedded-stdlib-${mod})
-  endforeach()
+  add_embedded_swift_target_library(
+    embedded-stdlib
+    swiftCore
+    IS_STDLIB IS_STDLIB_CORE
+    ${SWIFTLIB_EMBEDDED_SOURCES}
+    GYB_SOURCES ${SWIFTLIB_EMBEDDED_GYB_SOURCES}
+    SWIFT_COMPILE_FLAGS
+      ${swift_stdlib_compile_flags}
+    FILE_DEPENDS ${swiftCore_common_dependencies}
+    DEPENDS ${tooling_stdlib_deps}
+    INSTALL_IN_COMPONENT stdlib
+  )
 endif()

--- a/stdlib/public/stubs/Exclusivity/CMakeLists.txt
+++ b/stdlib/public/stubs/Exclusivity/CMakeLists.txt
@@ -4,74 +4,30 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
   add_custom_target(embedded-exclusivity)
   add_dependencies(embedded-libraries embedded-exclusivity)
 
-  foreach(entry ${EMBEDDED_STDLIB_TARGET_TRIPLES})
-    string(REGEX REPLACE "[ \t]+" ";" list "${entry}")
-    list(GET list 0 arch)
-    list(GET list 1 mod)
-    list(GET list 2 triple)
+  foreach(impl ${EMBEDDED_SWIFT_EXCLUSIVITY_IMPLEMENTATIONS})
+    add_custom_target(embedded-exclusivity-${impl})
+    add_dependencies(embedded-exclusivity embedded-exclusivity-${impl})
 
-    if("${mod}" MATCHES "-windows-msvc$")
-      continue()
+    # C11 thread-local does not work with -none- triples.
+    set(per_impl_skip_triple)
+    if("${impl}" STREQUAL "C11ThreadLocal")
+      list(APPEND per_impl_skip_triple "-none-")
     endif()
 
-    if("${arch}" MATCHES "avr")
-      continue()
-    endif()
+    add_embedded_swift_target_library(
+      embedded-exclusivity-${impl}
+      swiftExclusivity${impl}
+      PARTIAL_SOURCES_INTENDED
+      INSTALL_BINARY
 
-    if (SWIFT_HOST_VARIANT STREQUAL "linux")
-      set(extra_c_compile_flags -ffreestanding)
-    elseif (SWIFT_HOST_VARIANT STREQUAL "macosx")
-      set(extra_c_compile_flags -ffreestanding)
-    endif()
-    list(APPEND extra_c_compile_flags -nostdinc++)
+      ${impl}.cpp
 
-    set(SWIFT_SDK_embedded_ARCH_${mod}_MODULE "${mod}")
-    set(SWIFT_SDK_embedded_LIB_SUBDIR "embedded")
-    set(SWIFT_SDK_embedded_ARCH_${mod}_TRIPLE "${triple}")
-    if(SWIFT_EMBEDDED_STDLIB_SDKS_FOR_TARGET_TRIPLES)
-      set(SWIFT_SDK_embedded_ARCH_${mod}_PATH "${EMBEDDED_STDLIB_SDK_FOR_${triple}}")
-    endif()
-
-    foreach(impl ${EMBEDDED_SWIFT_EXCLUSIVITY_IMPLEMENTATIONS})
-      # C11 thread-local does not work with -none- triples.
-      if ("${impl}" MATCHES "C11ThreadLocal")
-        if("${triple}" MATCHES "-none-")
-            continue()
-        endif()
-      endif()
-
-      add_swift_target_library_single(
-        embedded-exclusivity-${impl}-${mod}
-        swiftExclusivity${impl}
-        STATIC
-        IS_FRAGILE
-        PARTIAL_SOURCES_INTENDED
-
-        ${impl}.cpp
-
-        C_COMPILE_FLAGS ${extra_c_compile_flags}
-        MODULE_DIR "${CMAKE_BINARY_DIR}/lib/swift/embedded"
-        SDK "embedded"
-        ARCHITECTURE "${mod}"
-        DEPENDS embedded-stdlib-${mod}
-        INSTALL_IN_COMPONENT stdlib
-        )
-      swift_install_in_component(
-        TARGETS embedded-exclusivity-${impl}-${mod}
-        DESTINATION "lib/swift/embedded/${mod}"
-        COMPONENT "stdlib"
-        )
-      swift_install_in_component(
-        FILES "${SWIFTLIB_DIR}/embedded/${mod}/libswiftExclusivity${impl}.a"
-        DESTINATION "lib/swift/embedded/${mod}/"
-        COMPONENT "stdlib"
-        PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
-        )
-      set_property(TARGET embedded-exclusivity-${impl}-${mod} PROPERTY OSX_ARCHITECTURES "${arch}")
-
-      embedded_amend_archive_commands_on_darwin_host(embedded-exclusivity-${impl}-${mod} ${triple})
-
-      add_dependencies(embedded-exclusivity embedded-exclusivity-${impl}-${mod})
-    endforeach()
+      C_COMPILE_FLAGS -nostdinc++
+      SKIP_MOD_REGEX "-windows-msvc$"
+      SKIP_ARCH_REGEX "avr"
+      SKIP_TRIPLE_REGEX ${per_impl_skip_triple}
+      ARCHITECTURE_KEY mod
+      INSTALL_IN_COMPONENT stdlib
+    )
   endforeach()
 endif()

--- a/stdlib/public/stubs/Unicode/CMakeLists.txt
+++ b/stdlib/public/stubs/Unicode/CMakeLists.txt
@@ -4,69 +4,22 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
   add_custom_target(embedded-unicode)
   add_dependencies(embedded-libraries embedded-unicode)
 
-  foreach(entry ${EMBEDDED_STDLIB_TARGET_TRIPLES})
-    string(REGEX REPLACE "[ \t]+" ";" list "${entry}")
-    list(GET list 0 arch)
-    list(GET list 1 mod)
-    list(GET list 2 triple)
+  add_embedded_swift_target_library(
+    embedded-unicode
+    swiftUnicodeDataTables
+    INSTALL_BINARY
 
-    if("${mod}" MATCHES "-windows-msvc$")
-      continue()
-    endif()
+    UnicodeData.cpp
+    UnicodeEmoji.cpp
+    UnicodeGrapheme.cpp
+    UnicodeNormalization.cpp
+    UnicodeScalarProps.cpp
+    UnicodeWord.cpp
 
-    if("${arch}" MATCHES "avr")
-      continue()
-    endif()
-
-    if (SWIFT_HOST_VARIANT STREQUAL "linux")
-      set(extra_c_compile_flags -ffreestanding)
-    elseif (SWIFT_HOST_VARIANT STREQUAL "macosx")
-      set(extra_c_compile_flags -ffreestanding)
-    endif()
-    list(APPEND extra_c_compile_flags -nostdinc++)
-
-    set(SWIFT_SDK_embedded_ARCH_${mod}_MODULE "${mod}")
-    set(SWIFT_SDK_embedded_LIB_SUBDIR "embedded")
-    set(SWIFT_SDK_embedded_ARCH_${mod}_TRIPLE "${triple}")
-    if(SWIFT_EMBEDDED_STDLIB_SDKS_FOR_TARGET_TRIPLES)
-      set(SWIFT_SDK_embedded_ARCH_${mod}_PATH "${EMBEDDED_STDLIB_SDK_FOR_${triple}}")
-    endif()
-
-    add_swift_target_library_single(
-      embedded-unicode-${mod}
-      swiftUnicodeDataTables
-      STATIC
-      IS_FRAGILE
-
-      UnicodeData.cpp
-      UnicodeEmoji.cpp
-      UnicodeGrapheme.cpp
-      UnicodeNormalization.cpp
-      UnicodeScalarProps.cpp
-      UnicodeWord.cpp
-
-      C_COMPILE_FLAGS ${extra_c_compile_flags}
-      MODULE_DIR "${CMAKE_BINARY_DIR}/lib/swift/embedded"
-      SDK "embedded"
-      ARCHITECTURE "${mod}"
-      DEPENDS embedded-stdlib-${mod}
-      INSTALL_IN_COMPONENT stdlib
-      )
-    swift_install_in_component(
-      TARGETS embedded-unicode-${mod}
-      DESTINATION "lib/swift/embedded/${mod}"
-      COMPONENT "stdlib"
-      )
-    swift_install_in_component(
-      FILES "${SWIFTLIB_DIR}/embedded/${mod}/libswiftUnicodeDataTables.a"
-      DESTINATION "lib/swift/embedded/${mod}/"
-      COMPONENT "stdlib"
-      PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
-      )
-    set_property(TARGET embedded-unicode-${mod} PROPERTY OSX_ARCHITECTURES "${arch}")
-
-    embedded_amend_archive_commands_on_darwin_host(embedded-unicode-${mod} ${triple})
-
-    add_dependencies(embedded-unicode embedded-unicode-${mod})
-  endforeach()
+    C_COMPILE_FLAGS -nostdinc++
+    SKIP_MOD_REGEX "-windows-msvc$"
+    SKIP_ARCH_REGEX "avr"
+    ARCHITECTURE_KEY mod
+    INSTALL_IN_COMPONENT stdlib
+  )
 endif()

--- a/test/embedded/Inputs/cxx-std-vector.h
+++ b/test/embedded/Inputs/cxx-std-vector.h
@@ -1,0 +1,5 @@
+#include <vector>
+
+using VectorOfInt = std::vector<int>;
+
+inline VectorOfInt makeVector() { return {1, 2, 3, 4}; }

--- a/test/embedded/Inputs/module.modulemap
+++ b/test/embedded/Inputs/module.modulemap
@@ -1,3 +1,8 @@
 module StructAsOptionSet {
   header "struct-as-option-set.h"
 }
+
+module CxxStdVector {
+  header "cxx-std-vector.h"
+  requires cplusplus
+}

--- a/test/embedded/cxx-std-vector.swift
+++ b/test/embedded/cxx-std-vector.swift
@@ -1,0 +1,23 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -I %S/Inputs %s -enable-experimental-feature Embedded -cxx-interoperability-mode=default -wmo -c -o %t/main.o
+// RUN: %target-clang %target-clang-resource-dir-opt %t/main.o -lc++ %target-embedded-posix-shim -o %t/a.out -dead_strip
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: executable_test
+// REQUIRES: optimized_stdlib
+// REQUIRES: OS=macosx
+// REQUIRES: swift_feature_Embedded
+
+import Cxx
+import CxxStdlib
+import CxxStdVector
+
+let v = makeVector()
+for elem in v {
+  print(elem)
+}
+// CHECK: 1
+// CHECK-NEXT: 2
+// CHECK-NEXT: 3
+// CHECK-NEXT: 4


### PR DESCRIPTION
This re-lands the work to improve the CMake build of the Embedded Swift libraries. It includes:
* https://github.com/swiftlang/swift/pull/89494: reverted in https://github.com/swiftlang/swift/pull/89631 due to the freestanding issue above.
* https://github.com/swiftlang/swift/pull/89546: reverted in https://github.com/swiftlang/swift/pull/89681 because it depended on the above. Fixes rdar://142904657.