### PR TITLE
[SILGen] Handle @export(interface) on @_silgen_name'd variables

### DIFF
--- a/lib/SILGen/SILGenGlobalVariable.cpp
+++ b/lib/SILGen/SILGenGlobalVariable.cpp
@@ -52,8 +52,10 @@ SILGlobalVariable *SILGenModule::getSILGlobalVariable(VarDecl *gDecl,
 
   auto cExternAttr = ExternAttr::find(gDecl->getAttrs(), ExternKind::C);
   if (gDecl->getAttrs().hasAttribute<SILGenNameAttr>() || cExternAttr) {
-    silLinkage = SILLinkage::DefaultForDeclaration;
-    if (! gDecl->hasInitialValue()) {
+    // `@_extern(c)` and body-less `@_silgen_name` declarations name a symbol
+    // defined elsewhere; the SIL global is just a forward declaration.
+    if (!gDecl->hasInitialValue()) {
+      silLinkage = SILLinkage::DefaultForDeclaration;
       forDef = NotForDefinition;
     }
   }

--- a/test/Misc/verify-swift-feature-testing.test-sh
+++ b/test/Misc/verify-swift-feature-testing.test-sh
@@ -36,6 +36,7 @@ EXCEPTIONAL_FILES = [
     pathlib.Path("test/embedded/linkage/diamond.swift"),
     pathlib.Path("test/embedded/linkage/diamond_embedded_exist.swift"),
     pathlib.Path("test/embedded/linkage/export_interface_vars.swift"),
+    pathlib.Path("test/embedded/linkage/silgen_name_var_interface_emission.swift"),
     pathlib.Path("test/embedded/linkage/interface.swift"),
     pathlib.Path("test/embedded/linkage/leaf_application.swift"),
     pathlib.Path("test/embedded/serialization.swift"),

--- a/test/embedded/linkage/silgen_name_var_interface_emission.swift
+++ b/test/embedded/linkage/silgen_name_var_interface_emission.swift
@@ -1,0 +1,22 @@
+// REQUIRES: swift_in_compiler
+// REQUIRES: swift_feature_Embedded
+
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-ir -emit-module -o %t/Library.ll %s -enable-experimental-feature Embedded -enable-experimental-feature CodeGenerationModel=interface -parse-as-library -module-name Library
+// RUN: %FileCheck %s < %t/Library.ll
+
+// Under `CodeGenerationModel=interface` the library emits the storage as
+// a strong definition so clients can reference it externally.
+// CHECK-DAG: @my_renamed_storage = {{(dso_local |protected |linkonce_odr |weak )*}}global
+// CHECK-NOT: @my_renamed_storage = available_externally
+// CHECK-DAG: define {{(hidden |protected |dllexport )?}}swiftcc ptr @"$e7Library14renamedStorageSVSg_ACtvau"
+@_silgen_name("my_renamed_storage")
+@export(interface)
+var renamedStorage: (UnsafeRawPointer?, UnsafeRawPointer?) = (nil, nil)
+
+// Force the accessor (and therefore a reference to the storage) to be
+// kept after dead-code elimination.
+public func touch() -> UnsafeRawPointer? {
+  return renamedStorage.0
+}
+


### PR DESCRIPTION
The data for such variables was not getting emitted as a strong definition, causing linker errors.