### PR TITLE
[Embedded] _swift_getSwiftClassInstanceExtents cannot be implemented in Embedded Swift

### DIFF
--- a/stdlib/public/core/Builtin.swift
+++ b/stdlib/public/core/Builtin.swift
@@ -403,16 +403,19 @@ internal func _usesNativeSwiftReferenceCounting(_ theClass: AnyClass) -> Bool {
 
 @usableFromInline
 @_silgen_name("_swift_getSwiftClassInstanceExtents")
+@_unavailableInEmbedded
 internal func getSwiftClassInstanceExtents(_ theClass: AnyClass)
   -> (negative: UInt, positive: UInt)
 
 @usableFromInline
 @_silgen_name("_swift_getObjCClassInstanceExtents")
+@_unavailableInEmbedded
 internal func getObjCClassInstanceExtents(_ theClass: AnyClass)
   -> (negative: UInt, positive: UInt)
 
 @inlinable
 @inline(__always)
+@_unavailableInEmbedded
 internal func _class_getInstancePositiveExtentSize(_ theClass: AnyClass) -> Int {
 #if _runtime(_ObjC)
   return Int(getObjCClassInstanceExtents(theClass).positive)

--- a/stdlib/public/core/ManagedBuffer.swift
+++ b/stdlib/public/core/ManagedBuffer.swift
@@ -348,7 +348,9 @@ public struct ManagedBufferPointer<
     bufferClass: AnyClass,
     minimumCapacity: Int
   ) {
+    #if !$Embedded
     ManagedBufferPointer._checkValidBufferClass(bufferClass, creating: true)
+    #endif
     _precondition(
       minimumCapacity >= 0,
       "ManagedBufferPointer must have non-negative capacity")
@@ -365,8 +367,10 @@ public struct ManagedBufferPointer<
     _uncheckedBufferClass: AnyClass,
     minimumCapacity: Int
   ) {
+    #if !$Embedded
     ManagedBufferPointer._internalInvariantValidBufferClass(
       _uncheckedBufferClass, creating: true)
+    #endif
     _internalInvariant(
       minimumCapacity >= 0,
       "ManagedBufferPointer must have non-negative capacity")
@@ -524,6 +528,7 @@ extension ManagedBufferPointer {
 extension ManagedBufferPointer where Element: ~Copyable {
   @_preInverseGenerics
   @inlinable
+  @_unavailableInEmbedded
   internal static func _checkValidBufferClass(
     _ bufferClass: AnyClass, creating: Bool = false
   ) {
@@ -543,6 +548,7 @@ extension ManagedBufferPointer where Element: ~Copyable {
 
   @_preInverseGenerics
   @inlinable
+  @_unavailableInEmbedded
   internal static func _internalInvariantValidBufferClass(
     _ bufferClass: AnyClass, creating: Bool = false
   ) {


### PR DESCRIPTION
Implementing this function would require us to extend the metadata format to include size information, which is heap overhead for all callers. And we don't actually need the function for anything in embedded, because we know the sizes of everything at construction time.

Mark this function and those builtins that build on it as unavailable in Embedded Swift, and #if out the code on embedded that would have used them unnecessarily.