### PR TITLE
[stdlib] Complete the implementation of SE-0488

### DIFF
--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift
@@ -2156,8 +2156,13 @@ public final class TestSuite {
       return self
     }
 
-    public func crashOutputMatches(_ string: String) -> _TestBuilder {
-      _data._crashOutputMatches.append(string)
+    public func crashOutputMatches(
+      _ string: String,
+      when predicate: Bool = true
+    ) -> _TestBuilder {
+      if predicate {
+        _data._crashOutputMatches.append(string)
+      }
       return self
     }
 

--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/RigidArray/RigidArray+Append.swift
+++ b/stdlib/public/core/RigidArray/RigidArray+Append.swift
@@ -127,7 +127,7 @@ extension _RigidArray where Element: ~Copyable {
     moving items: inout OutputSpan<Element>
   ) {
     unsafe items.withUnsafeMutableBufferPointer { buffer, count in
-      let source = unsafe buffer.extracting(first: count)
+      let source = buffer.extracting(first: count)
       unsafe self.append(moving: source)
       count = 0
     }

--- a/stdlib/public/core/RigidArray/RigidArray+Append.swift
+++ b/stdlib/public/core/RigidArray/RigidArray+Append.swift
@@ -76,7 +76,7 @@ extension _RigidArray where Element: ~Copyable {
   ) throws(E) {
     _precondition(newItemCount >= 0, "Cannot add a negative number of items")
     _precondition(freeCapacity >= newItemCount, "RigidArray capacity overflow")
-    let buffer = unsafe _freeSpace._extracting(first: newItemCount)
+    let buffer = unsafe _freeSpace.extracting(first: newItemCount)
     var span = unsafe OutputSpan(buffer: buffer, initializedCount: 0)
     defer {
       _count &+= unsafe span.finalize(for: buffer)
@@ -127,7 +127,7 @@ extension _RigidArray where Element: ~Copyable {
     moving items: inout OutputSpan<Element>
   ) {
     unsafe items.withUnsafeMutableBufferPointer { buffer, count in
-      let source = unsafe buffer._extracting(first: count)
+      let source = unsafe buffer.extracting(first: count)
       unsafe self.append(moving: source)
       count = 0
     }

--- a/stdlib/public/core/RigidArray/RigidArray+Insertions.swift
+++ b/stdlib/public/core/RigidArray/RigidArray+Insertions.swift
@@ -165,7 +165,7 @@ extension _RigidArray where Element: ~Copyable {
     at index: Int
   ) {
     unsafe items.withUnsafeMutableBufferPointer { buffer, count in
-      let source = unsafe buffer.extracting(first: count)
+      let source = buffer.extracting(first: count)
       unsafe self.insert(moving: source, at: index)
       count = 0
     }

--- a/stdlib/public/core/RigidArray/RigidArray+Insertions.swift
+++ b/stdlib/public/core/RigidArray/RigidArray+Insertions.swift
@@ -165,7 +165,7 @@ extension _RigidArray where Element: ~Copyable {
     at index: Int
   ) {
     unsafe items.withUnsafeMutableBufferPointer { buffer, count in
-      let source = unsafe buffer._extracting(first: count)
+      let source = unsafe buffer.extracting(first: count)
       unsafe self.insert(moving: source, at: index)
       count = 0
     }

--- a/stdlib/public/core/RigidArray/RigidArray+Replacements.swift
+++ b/stdlib/public/core/RigidArray/RigidArray+Replacements.swift
@@ -170,7 +170,7 @@ extension _RigidArray where Element: ~Copyable {
     moving items: inout OutputSpan<Element>
   ) {
     unsafe items.withUnsafeMutableBufferPointer { buffer, count in
-      let source = unsafe buffer._extracting(first: count)
+      let source = unsafe buffer.extracting(first: count)
       unsafe replaceSubrange(subrange, moving: source)
       count = 0
     }

--- a/stdlib/public/core/RigidArray/RigidArray+Replacements.swift
+++ b/stdlib/public/core/RigidArray/RigidArray+Replacements.swift
@@ -170,7 +170,7 @@ extension _RigidArray where Element: ~Copyable {
     moving items: inout OutputSpan<Element>
   ) {
     unsafe items.withUnsafeMutableBufferPointer { buffer, count in
-      let source = unsafe buffer.extracting(first: count)
+      let source = buffer.extracting(first: count)
       unsafe replaceSubrange(subrange, moving: source)
       count = 0
     }

--- a/stdlib/public/core/Span/MutableRawSpan.swift
+++ b/stdlib/public/core/Span/MutableRawSpan.swift
@@ -726,7 +726,7 @@ extension MutableRawSpan {
     _precondition(
       UInt(bitPattern: bounds.lowerBound) <= UInt(bitPattern: _count) &&
       UInt(bitPattern: bounds.upperBound) <= UInt(bitPattern: _count),
-      "Index range out of bounds"
+      "Byte offset range out of bounds"
     )
     return unsafe _mutatingExtracting(unchecked: bounds)
   }
@@ -772,7 +772,7 @@ extension MutableRawSpan {
     _precondition(
       UInt(bitPattern: bounds.lowerBound) <= UInt(bitPattern: _count) &&
       UInt(bitPattern: bounds.upperBound) <= UInt(bitPattern: _count),
-      "Index range out of bounds"
+      "Byte offset range out of bounds"
     )
     return unsafe _consumingExtracting(unchecked: bounds)
   }

--- a/stdlib/public/core/Span/OutputSpan.swift
+++ b/stdlib/public/core/Span/OutputSpan.swift
@@ -534,7 +534,7 @@ extension OutputSpan where Element: ~Copyable {
       let dstEnd = dstCount + source.count
       precondition(dstEnd <= dst.count, "OutputSpan capacity overflow")
       unsafe dst
-        ._extracting(uncheckedFrom: dstCount, to: dstEnd)
+        .extracting(unchecked: Range(uncheckedBounds: (dstCount, dstEnd)))
         ._moveInitializeAll(fromContentsOf: source)
       dstCount &+= source.count
     }
@@ -545,7 +545,8 @@ extension OutputSpan where Element: ~Copyable {
   @_lifetime(source: copy source)
   internal mutating func _append(moving source: inout OutputSpan<Element>) {
     unsafe source.withUnsafeMutableBufferPointer { src, srcCount in
-      let items = unsafe src._extracting(uncheckedFrom: 0, to: srcCount)
+      let range = unsafe Range(uncheckedBounds: (0, srcCount))
+      let items = unsafe src.extracting(unchecked: range)
       unsafe self._append(moving: items)
       srcCount = 0
     }
@@ -562,7 +563,7 @@ extension OutputSpan where Element: Copyable {
       let dstEnd = dstCount + source.count
       precondition(dstEnd <= dst.count, "OutputSpan capacity overflow")
       unsafe dst
-        ._extracting(uncheckedFrom: dstCount, to: dstEnd)
+        .extracting(unchecked: Range(uncheckedBounds: (dstCount, dstEnd)))
         ._initializeAll(fromContentsOf: source)
       dstCount &+= source.count
     }

--- a/stdlib/public/core/Span/OutputSpan.swift
+++ b/stdlib/public/core/Span/OutputSpan.swift
@@ -521,6 +521,7 @@ extension OutputSpan {
   }
 }
 
+#if !SPAN_COMPATIBILITY_STUB
 @available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension OutputSpan where Element: ~Copyable {
@@ -577,3 +578,4 @@ extension OutputSpan where Element: Copyable {
     }
   }
 }
+#endif // !SPAN_COMPATIBILITY_STUB

--- a/stdlib/public/core/Span/RawSpan.swift
+++ b/stdlib/public/core/Span/RawSpan.swift
@@ -990,6 +990,58 @@ extension RawSpan {
   }
 }
 
+// MARK: usage hints
+//
+// `RawSpan` is not a `Collection`. We add the following unavailable members
+// to redirect users who reach for the `Collection` slicing API towards the
+// corresponding `extracting(...)` function.
+@available(SwiftCompatibilitySpan 5.0, *)
+@_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
+extension RawSpan {
+
+  @_alwaysEmitIntoClient
+  @available(*, unavailable, renamed: "extracting(_:)")
+  public subscript(bounds: Range<Int>) -> Self {
+    Builtin.unreachable()
+  }
+
+  @_alwaysEmitIntoClient
+  @available(*, unavailable, renamed: "extracting(_:)")
+  public subscript(bounds: some RangeExpression<Int>) -> Self {
+    Builtin.unreachable()
+  }
+
+  @_alwaysEmitIntoClient
+  @available(*, unavailable, renamed: "extracting(_:)")
+  public subscript(bounds: UnboundedRange) -> Self {
+    Builtin.unreachable()
+  }
+
+  @_alwaysEmitIntoClient
+  @available(*, unavailable, renamed: "extracting(first:)")
+  public func prefix(_ maxLength: Int) -> Self {
+    Builtin.unreachable()
+  }
+
+  @_alwaysEmitIntoClient
+  @available(*, unavailable, renamed: "extracting(last:)")
+  public func suffix(_ maxLength: Int) -> Self {
+    Builtin.unreachable()
+  }
+
+  @_alwaysEmitIntoClient
+  @available(*, unavailable, renamed: "extracting(droppingFirst:)")
+  public func dropFirst(_ k: Int = 1) -> Self {
+    Builtin.unreachable()
+  }
+
+  @_alwaysEmitIntoClient
+  @available(*, unavailable, renamed: "extracting(droppingLast:)")
+  public func dropLast(_ k: Int = 1) -> Self {
+    Builtin.unreachable()
+  }
+}
+
 extension RawSpan {
   @available(*, deprecated)
   @usableFromInline

--- a/stdlib/public/core/Span/Span.swift
+++ b/stdlib/public/core/Span/Span.swift
@@ -984,6 +984,58 @@ extension Span where Element: ~Copyable {
   }
 }
 
+// MARK: usage hints
+//
+// `Span` is not a `Collection`. We add the following unavailable members exist
+// to redirect users who reach for the `Collection` slicing API towards the
+// corresponding `extracting(...)` function.
+@available(SwiftCompatibilitySpan 5.0, *)
+@_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
+extension Span where Element: ~Copyable {
+
+  @_alwaysEmitIntoClient
+  @available(*, unavailable, renamed: "extracting(_:)")
+  public subscript(bounds: Range<Index>) -> Self {
+    Builtin.unreachable()
+  }
+
+  @_alwaysEmitIntoClient
+  @available(*, unavailable, renamed: "extracting(_:)")
+  public subscript(bounds: some RangeExpression<Index>) -> Self {
+    Builtin.unreachable()
+  }
+
+  @_alwaysEmitIntoClient
+  @available(*, unavailable, renamed: "extracting(_:)")
+  public subscript(bounds: UnboundedRange) -> Self {
+    Builtin.unreachable()
+  }
+
+  @_alwaysEmitIntoClient
+  @available(*, unavailable, renamed: "extracting(first:)")
+  public func prefix(_ maxLength: Int) -> Self {
+    Builtin.unreachable()
+  }
+
+  @_alwaysEmitIntoClient
+  @available(*, unavailable, renamed: "extracting(last:)")
+  public func suffix(_ maxLength: Int) -> Self {
+    Builtin.unreachable()
+  }
+
+  @_alwaysEmitIntoClient
+  @available(*, unavailable, renamed: "extracting(droppingFirst:)")
+  public func dropFirst(_ k: Int = 1) -> Self {
+    Builtin.unreachable()
+  }
+
+  @_alwaysEmitIntoClient
+  @available(*, unavailable, renamed: "extracting(droppingLast:)")
+  public func dropLast(_ k: Int = 1) -> Self {
+    Builtin.unreachable()
+  }
+}
+
 @available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension Span where Element == UInt8 {

--- a/stdlib/public/core/Span/Span.swift
+++ b/stdlib/public/core/Span/Span.swift
@@ -986,7 +986,7 @@ extension Span where Element: ~Copyable {
 
 // MARK: usage hints
 //
-// `Span` is not a `Collection`. We add the following unavailable members exist
+// `Span` is not a `Collection`. We add the following unavailable members
 // to redirect users who reach for the `Collection` slicing API towards the
 // corresponding `extracting(...)` function.
 @available(SwiftCompatibilitySpan 5.0, *)

--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2025 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -571,7 +571,7 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
   ///
   /// Note that unlike slicing, the `extracting` operation remains available
   /// even if `Element` happens to be noncopyable.
-  //
+  ///
   /// - Returns: The same buffer as `self`.
   @_alwaysEmitIntoClient
   @safe
@@ -579,21 +579,112 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
     unsafe self
   }
 
+  /// Constructs a standalone buffer pointer over the items within the supplied
+  /// range of positions in the memory region addressed by this buffer pointer.
+  ///
+  /// The returned buffer's first item is always at index 0; unlike buffer
+  /// slices, extracted buffers do not generally share their indices with the
+  /// original buffer pointer.
+  ///
+  /// This function does not validate `bounds`; this is an unsafe operation.
+  ///
+  /// - Parameter bounds: A valid range of indices within this buffer.
+  /// - Returns: A new buffer pointer over the items at `bounds`.
   @_alwaysEmitIntoClient
-  internal func _extracting(first maxLength: Int) -> Self {
-    _precondition(maxLength >= 0, "Cannot have a prefix of negative length")
-    let newCount = Swift.min(maxLength, count)
-    return unsafe Self(start: baseAddress, count: newCount)
+  public func extracting(unchecked bounds: Range<Int>) -> Self {
+    let newStart = unsafe _position?.advanced(by: bounds.lowerBound)
+    return unsafe Self(start: newStart, count: bounds.count)
   }
 
-  // Note: This is public because 'libCompatibilitySpan' builds the span sources
-  // as a separate module, so it doesn't have access to 'internal' stdlib API.
+  /// Constructs a standalone buffer pointer over the items within the supplied
+  /// range of positions in the memory region addressed by this buffer pointer.
+  ///
+  /// The returned buffer's first item is always at index 0; unlike buffer
+  /// slices, extracted buffers do not generally share their indices with the
+  /// original buffer pointer.
+  ///
+  /// This function does not validate `bounds`; this is an unsafe operation.
+  ///
+  /// - Parameter bounds: A valid range of indices within this buffer.
+  /// - Returns: A new buffer pointer over the items at `bounds`.
   @_alwaysEmitIntoClient
-  public func _extracting(uncheckedFrom start: Int, to end: Int) -> Self {
-    guard let base = self.baseAddress else {
-      return Self(_empty: ())
-    }
-    return unsafe Self(start: base + start, count: end &- start)
+  public func extracting(unchecked bounds: ClosedRange<Int>) -> Self {
+    let range = unsafe Range(
+      _uncheckedBounds: (bounds.lowerBound, bounds.upperBound + 1)
+    )
+    return unsafe extracting(unchecked: range)
+  }
+
+  /// Constructs a standalone buffer pointer over the initial elements of
+  /// this buffer, up to the specified maximum length.
+  ///
+  /// If the maximum length exceeds the length of this buffer,
+  /// the result contains all the elements.
+  ///
+  /// - Parameter maxLength: The maximum number of elements to return.
+  ///   `maxLength` must be greater than or equal to zero.
+  /// - Returns: A buffer pointer with at most `maxLength` elements.
+  @_alwaysEmitIntoClient
+  @safe
+  public func extracting(first maxLength: Int) -> Self {
+    _precondition(maxLength >= 0, "Can't have a prefix of negative length")
+    let newCount = Swift.min(maxLength, count)
+    return unsafe Self(_uncheckedStart: _position, count: newCount)
+  }
+
+  /// Returns a buffer pointer over all but the given number of trailing
+  /// elements.
+  ///
+  /// If the number of elements to drop exceeds the number of elements in
+  /// the buffer, the result is an empty buffer.
+  ///
+  /// - Parameter k: The number of elements to drop off the end of the buffer.
+  ///   `k` must be greater than or equal to zero.
+  /// - Returns: A buffer pointer leaving off the specified number of trailing
+  ///   elements.
+  @_alwaysEmitIntoClient
+  @safe
+  public func extracting(droppingLast k: Int) -> Self {
+    _precondition(k >= 0, "Can't drop a negative number of elements")
+    let droppedCount = Swift.min(k, count)
+    return unsafe Self(_uncheckedStart: _position, count: count &- droppedCount)
+  }
+
+  /// Returns a buffer pointer containing the trailing elements of this buffer,
+  /// up to the given maximum length.
+  ///
+  /// If the maximum length exceeds the length of this buffer,
+  /// the result contains all the elements.
+  ///
+  /// - Parameter maxLength: The maximum number of elements to return.
+  ///   `maxLength` must be greater than or equal to zero.
+  /// - Returns: A buffer pointer with at most `maxLength` elements.
+  @_alwaysEmitIntoClient
+  @safe
+  public func extracting(last maxLength: Int) -> Self {
+    _precondition(maxLength >= 0, "Can't have a suffix of negative length")
+    let newCount = Swift.min(maxLength, count)
+    let newStart = unsafe _position?.advanced(by: count &- newCount)
+    return unsafe Self(_uncheckedStart: newStart, count: newCount)
+  }
+
+  /// Returns a buffer pointer over all but the given number of initial
+  /// elements.
+  ///
+  /// If the number of elements to drop exceeds the number of elements in
+  /// the buffer, the result is an empty buffer.
+  ///
+  /// - Parameter k: The number of elements to drop from the beginning of the
+  ///   buffer. `k` must be greater than or equal to zero.
+  /// - Returns: A buffer pointer starting after the specified number of
+  ///   elements.
+  @_alwaysEmitIntoClient
+  @safe
+  public func extracting(droppingFirst k: Int) -> Self {
+    _precondition(k >= 0, "Can't drop a negative number of elements")
+    let droppedCount = Swift.min(k, count)
+    let newStart = unsafe _position?.advanced(by: droppedCount)
+    return unsafe Self(_uncheckedStart: newStart, count: count &- droppedCount)
   }
 }
 

--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -717,10 +717,8 @@ extension UnsafeMutableBufferPointer where Element: Copyable {
     _internalInvariant(i == self.endIndex)
   }
 
-  // Note: This is public because 'libCompatibilitySpan' builds the span sources
-  // as a separate module, so it doesn't have access to 'internal' stdlib API.
   @_alwaysEmitIntoClient
-  public func _initializeAll(
+  internal func _initializeAll(
     fromContentsOf source: UnsafeBufferPointer<Element>
   ) {
     let i = unsafe self.initialize(fromContentsOf: source)
@@ -742,10 +740,8 @@ extension UnsafeMutableBufferPointer where Element: ~Copyable {
     return source.count
   }
 
-  // Note: This is public because 'libCompatibilitySpan' builds the span sources
-  // as a separate module, so it doesn't have access to 'internal' stdlib API.
   @_alwaysEmitIntoClient
-  public func _moveInitializeAll(fromContentsOf source: Self) {
+  internal func _moveInitializeAll(fromContentsOf source: Self) {
     let i = unsafe self.moveInitialize(fromContentsOf: source)
     _internalInvariant(i == self.endIndex)
   }

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2025 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -1208,7 +1208,159 @@ extension Unsafe${Mutable}RawBufferPointer {
     }
   }
 }
-  
+
+extension Unsafe${Mutable}RawBufferPointer {
+  /// Constructs a standalone buffer pointer over the bytes within the supplied
+  /// range of positions in the memory region addressed by this buffer pointer.
+  ///
+  /// The returned buffer's first byte is always at offset 0; unlike buffer
+  /// slices, extracted buffers do not generally share their indices with the
+  /// original buffer pointer.
+  ///
+  /// - Parameter bounds: A valid range of byte offsets within this buffer.
+  /// - Returns: A new buffer pointer over the bytes at `bounds`.
+  @_alwaysEmitIntoClient
+  @safe
+  public func extracting(_ bounds: Range<Int>) -> Self {
+    _precondition(_checkBounds(bounds), "Byte offset out of range")
+    guard let start = baseAddress else {
+      return unsafe Self(_uncheckedStart: nil, count: 0)
+    }
+    return unsafe Self(_uncheckedStart: start + bounds.lowerBound,
+                       count: bounds.count)
+  }
+
+  /// Constructs a standalone buffer pointer over the bytes within the supplied
+  /// range of positions in the memory region addressed by this buffer pointer.
+  ///
+  /// The returned buffer's first byte is always at offset 0; unlike buffer
+  /// slices, extracted buffers do not generally share their indices with the
+  /// original buffer pointer.
+  ///
+  /// - Parameter bounds: A valid range of byte offsets within this buffer.
+  /// - Returns: A new buffer pointer over the bytes at `bounds`.
+  @_alwaysEmitIntoClient
+  @safe
+  public func extracting(_ bounds: some RangeExpression<Int>) -> Self {
+    extracting(bounds.relative(to: unsafe Range(uncheckedBounds: (0, count))))
+  }
+
+  /// Extracts and returns a copy of the entire buffer.
+  ///
+  /// - Returns: The same buffer as `self`.
+  @_alwaysEmitIntoClient
+  @safe
+  public func extracting(_ bounds: UnboundedRange) -> Self {
+    unsafe self
+  }
+
+  /// Constructs a standalone buffer pointer over the bytes within the supplied
+  /// range of positions in the memory region addressed by this buffer pointer.
+  ///
+  /// The returned buffer's first byte is always at offset 0; unlike buffer
+  /// slices, extracted buffers do not generally share their indices with the
+  /// original buffer pointer.
+  ///
+  /// This function does not validate `bounds`; this is an unsafe operation.
+  ///
+  /// - Parameter bounds: A valid range of byte offsets within this buffer.
+  /// - Returns: A new buffer pointer over the bytes at `bounds`.
+  @_alwaysEmitIntoClient
+  public func extracting(unchecked bounds: Range<Int>) -> Self {
+    let newStart = unsafe baseAddress?.advanced(by: bounds.lowerBound)
+    return unsafe Self(_uncheckedStart: newStart, count: bounds.count)
+  }
+
+  /// Constructs a standalone buffer pointer over the bytes within the supplied
+  /// range of positions in the memory region addressed by this buffer pointer.
+  ///
+  /// The returned buffer's first byte is always at offset 0; unlike buffer
+  /// slices, extracted buffers do not generally share their indices with the
+  /// original buffer pointer.
+  ///
+  /// This function does not validate `bounds`; this is an unsafe operation.
+  ///
+  /// - Parameter bounds: A valid range of byte offsets within this buffer.
+  /// - Returns: A new buffer pointer over the bytes at `bounds`.
+  @_alwaysEmitIntoClient
+  public func extracting(unchecked bounds: ClosedRange<Int>) -> Self {
+    let range = unsafe Range(
+      _uncheckedBounds: (bounds.lowerBound, bounds.upperBound + 1)
+    )
+    return unsafe extracting(unchecked: range)
+  }
+
+  /// Constructs a standalone buffer pointer over the initial bytes of
+  /// this buffer, up to the specified maximum length.
+  ///
+  /// If the maximum length exceeds the length of this buffer,
+  /// the result contains all the bytes.
+  ///
+  /// - Parameter maxLength: The maximum number of bytes to return.
+  ///   `maxLength` must be greater than or equal to zero.
+  /// - Returns: A buffer pointer with at most `maxLength` bytes.
+  @_alwaysEmitIntoClient
+  @safe
+  public func extracting(first maxLength: Int) -> Self {
+    _precondition(maxLength >= 0, "Can't have a prefix of negative length")
+    let newCount = Swift.min(maxLength, count)
+    return unsafe Self(_uncheckedStart: baseAddress, count: newCount)
+  }
+
+  /// Returns a buffer pointer over all but the given number of trailing bytes.
+  ///
+  /// If the number of bytes to drop exceeds the number of bytes in the buffer,
+  /// the result is an empty buffer.
+  ///
+  /// - Parameter k: The number of bytes to drop off the end of the buffer.
+  ///   `k` must be greater than or equal to zero.
+  /// - Returns: A buffer pointer leaving off the specified number of trailing
+  ///   bytes.
+  @_alwaysEmitIntoClient
+  @safe
+  public func extracting(droppingLast k: Int) -> Self {
+    _precondition(k >= 0, "Can't drop a negative number of bytes")
+    let droppedCount = Swift.min(k, count)
+    return unsafe Self(_uncheckedStart: baseAddress,
+                       count: count &- droppedCount)
+  }
+
+  /// Returns a buffer pointer containing the trailing bytes of this buffer,
+  /// up to the given maximum length.
+  ///
+  /// If the maximum length exceeds the length of this buffer,
+  /// the result contains all the bytes.
+  ///
+  /// - Parameter maxLength: The maximum number of bytes to return.
+  ///   `maxLength` must be greater than or equal to zero.
+  /// - Returns: A buffer pointer with at most `maxLength` bytes.
+  @_alwaysEmitIntoClient
+  @safe
+  public func extracting(last maxLength: Int) -> Self {
+    _precondition(maxLength >= 0, "Can't have a suffix of negative length")
+    let newCount = Swift.min(maxLength, count)
+    let newStart = unsafe baseAddress?.advanced(by: count &- newCount)
+    return unsafe Self(_uncheckedStart: newStart, count: newCount)
+  }
+
+  /// Returns a buffer pointer over all but the given number of initial bytes.
+  ///
+  /// If the number of bytes to drop exceeds the number of bytes in the buffer,
+  /// the result is an empty buffer.
+  ///
+  /// - Parameter k: The number of bytes to drop from the beginning of the
+  ///   buffer. `k` must be greater than or equal to zero.
+  /// - Returns: A buffer pointer starting after the specified number of bytes.
+  @_alwaysEmitIntoClient
+  @safe
+  public func extracting(droppingFirst k: Int) -> Self {
+    _precondition(k >= 0, "Can't drop a negative number of bytes")
+    let droppedCount = Swift.min(k, count)
+    let newStart = unsafe baseAddress?.advanced(by: droppedCount)
+    return unsafe Self(_uncheckedStart: newStart, count: count &- droppedCount)
+  }
+}
+
 @available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension Unsafe${Mutable}RawBufferPointer {

--- a/test/stdlib/Span/MutableRawSpanTests.swift
+++ b/test/stdlib/Span/MutableRawSpanTests.swift
@@ -367,13 +367,8 @@ suite.test("storeBytes(repeating:count:as:) unsafe")
 }
 
 suite.test("_mutatingExtracting()")
-.skip(.custom(
-  { if #available(SwiftStdlib 6.2, *) { false } else { true } },
-  reason: "Requires Swift 6.2's standard library"
-))
+.require(.minimumStdlib(.stdlib_6_2))
 .code {
-  guard #available(SwiftStdlib 6.2, *) else { return }
-
   let capacity = 4
   var b = (0..<capacity).map(Int8.init)
   b.withUnsafeMutableBytes {
@@ -394,12 +389,27 @@ suite.test("_mutatingExtracting()")
     sub = span._mutatingExtracting(2...)
     expectEqual(sub.byteCount, 2)
     expectEqual(sub.unsafeLoad(as: UInt8.self), 2)
+
+    sub = span._mutatingExtracting(1...2)
+    expectEqual(sub.byteCount, 2)
+    expectEqual(sub.unsafeLoad(as: UInt8.self), 1)
   }
 }
 
-suite.test("_consumingExtracting()")
-.require(.stdlib_6_2).code {
+suite.test("_mutatingExtracting() bounds checking")
+.require(.minimumStdlib(.stdlib_6_2))
+.require(.crashTesting)
+.crashOutputMatches("Byte offset range out of bounds")
+.code {
+  var b: ContiguousArray<Int> = [1, 2, 3, 4]
+  var span = MutableRawSpan(elements: b.mutableSpan)
+  expectCrashLater()
+  _ = span._mutatingExtracting(2 ..< .max)
+}
 
+suite.test("_consumingExtracting()")
+.require(.minimumStdlib(.stdlib_6_2))
+.code {
   let c = 16
   let b = UnsafeMutableRawBufferPointer.allocate(byteCount: c, alignment: c)
   defer { b.deallocate() }
@@ -424,16 +434,26 @@ suite.test("_consumingExtracting()")
   span = span._consumingExtracting(2...)
   expectEqual(span.byteCount, c-2)
   expectEqual(span.unsafeLoad(as: UInt8.self), 2)
+
+  span = b.mutableBytes._consumingExtracting(1...2)
+  expectEqual(span.byteCount, 2)
+  expectEqual(span.unsafeLoad(as: UInt8.self), 1)
+}
+
+suite.test("_consumingExtracting() bounds checking")
+.require(.minimumStdlib(.stdlib_6_2))
+.require(.crashTesting)
+.crashOutputMatches("Byte offset range out of bounds")
+.code {
+  var b: ContiguousArray<Int> = [1, 2, 3, 4]
+  var span = MutableRawSpan(elements: b.mutableSpan)
+  expectCrashLater()
+  _ = span._consumingExtracting(2 ..< .max)
 }
 
 suite.test("_mutatingExtracting(unchecked:)")
-.skip(.custom(
-  { if #available(SwiftStdlib 6.2, *) { false } else { true } },
-  reason: "Requires Swift 6.2's standard library"
-))
+.require(.minimumStdlib(.stdlib_6_2))
 .code {
-  guard #available(SwiftStdlib 6.2, *) else { return }
-
   let capacity = 32
   var b = (0..<capacity).map(UInt8.init)
   b.withUnsafeMutableBytes {
@@ -446,8 +466,8 @@ suite.test("_mutatingExtracting(unchecked:)")
 }
 
 suite.test("_consumingExtracting(unchecked:)")
-.require(.stdlib_6_2).code {
-
+.require(.minimumStdlib(.stdlib_6_2))
+.code {
   let capacity = 32
   var b = (0..<capacity).map(UInt8.init)
   b.withUnsafeMutableBytes {
@@ -460,13 +480,8 @@ suite.test("_consumingExtracting(unchecked:)")
 }
 
 suite.test("_mutatingExtracting prefixes")
-.skip(.custom(
-  { if #available(SwiftStdlib 6.2, *) { false } else { true } },
-  reason: "Requires Swift 6.2's standard library"
-))
+.require(.minimumStdlib(.stdlib_6_2))
 .code {
-  guard #available(SwiftStdlib 6.2, *) else { return }
-
   let capacity = 4
   var a = Array(0..<UInt8(capacity))
   a.withUnsafeMutableBytes {
@@ -483,6 +498,9 @@ suite.test("_mutatingExtracting prefixes")
       UInt8(capacity-1)
     )
 
+    prefix = span._mutatingExtracting(first: capacity + 5)
+    expectEqual(prefix.byteCount, capacity)
+
     prefix = span._mutatingExtracting(droppingLast: capacity)
     expectEqual(prefix.isEmpty, true)
 
@@ -491,6 +509,9 @@ suite.test("_mutatingExtracting prefixes")
       prefix.unsafeLoad(fromByteOffset: capacity-2, as: UInt8.self),
       UInt8(capacity-2)
     )
+
+    prefix = span._mutatingExtracting(droppingLast: capacity + 5)
+    expectEqual(prefix.byteCount, 0)
   }
 
   do {
@@ -502,9 +523,31 @@ suite.test("_mutatingExtracting prefixes")
   }
 }
 
-suite.test("_consumingExtracting prefixes")
-.require(.stdlib_6_2).code {
+suite.test("_mutatingExtracting(first:) bound checking")
+.require(.minimumStdlib(.stdlib_6_2))
+.require(.crashTesting)
+.crashOutputMatches("Can't have a prefix of negative length")
+.code {
+  var b: ContiguousArray<Int> = [1, 2, 3, 4]
+  var span = MutableRawSpan(elements: b.mutableSpan)
+  expectCrashLater()
+  _ = span._mutatingExtracting(first: -1)
+}
 
+suite.test("_mutatingExtracting(droppingLast:) bound checking")
+.require(.minimumStdlib(.stdlib_6_2))
+.require(.crashTesting)
+.crashOutputMatches("Can't drop a negative number of bytes")
+.code {
+  var b: ContiguousArray<Int> = [1, 2, 3, 4]
+  var span = MutableRawSpan(elements: b.mutableSpan)
+  expectCrashLater()
+  _ = span._mutatingExtracting(droppingLast: -1)
+}
+
+suite.test("_consumingExtracting prefixes")
+.require(.minimumStdlib(.stdlib_6_2))
+.code {
   let capacity = 4
   var a = Array(0..<UInt8(capacity))
   a.withUnsafeMutableBytes {
@@ -520,6 +563,9 @@ suite.test("_consumingExtracting prefixes")
       UInt8(capacity-1)
     )
 
+    span = $0.mutableBytes._consumingExtracting(first: capacity + 5)
+    expectEqual(span.byteCount, capacity)
+
     span = $0.mutableBytes._consumingExtracting(droppingLast: capacity)
     expectEqual(span.isEmpty, true)
 
@@ -528,6 +574,9 @@ suite.test("_consumingExtracting prefixes")
       span.unsafeLoad(fromByteOffset: capacity-2, as: UInt8.self),
       UInt8(capacity-2)
     )
+
+    span = $0.mutableBytes._consumingExtracting(droppingLast: capacity + 5)
+    expectEqual(span.byteCount, 0)
   }
 
   do {
@@ -541,14 +590,31 @@ suite.test("_consumingExtracting prefixes")
   }
 }
 
-suite.test("_mutatingExtracting suffixes")
-.skip(.custom(
-  { if #available(SwiftStdlib 6.2, *) { false } else { true } },
-  reason: "Requires Swift 6.2's standard library"
-))
+suite.test("_consumingExtracting(first:) bound checking")
+.require(.minimumStdlib(.stdlib_6_2))
+.require(.crashTesting)
+.crashOutputMatches("Can't have a prefix of negative length")
 .code {
-  guard #available(SwiftStdlib 6.2, *) else { return }
+  var b: ContiguousArray<Int> = [1, 2, 3, 4]
+  var span = MutableRawSpan(elements: b.mutableSpan)
+  expectCrashLater()
+  _ = span._consumingExtracting(first: -1)
+}
 
+suite.test("_consumingExtracting(droppingLast:) bound checking")
+.require(.minimumStdlib(.stdlib_6_2))
+.require(.crashTesting)
+.crashOutputMatches("Can't drop a negative number of bytes")
+.code {
+  var b: ContiguousArray<Int> = [1, 2, 3, 4]
+  var span = MutableRawSpan(elements: b.mutableSpan)
+  expectCrashLater()
+  _ = span._consumingExtracting(droppingLast: -1)
+}
+
+suite.test("_mutatingExtracting suffixes")
+.require(.minimumStdlib(.stdlib_6_2))
+.code {
   let capacity = 4
   var a = Array(0..<UInt8(capacity))
   a.withUnsafeMutableBytes {
@@ -565,11 +631,17 @@ suite.test("_mutatingExtracting suffixes")
     prefix = span._mutatingExtracting(last: 1)
     expectEqual(prefix.unsafeLoad(as: UInt8.self), UInt8(capacity-1))
 
+    prefix = span._mutatingExtracting(last: capacity + 5)
+    expectEqual(prefix.byteCount, capacity)
+
     prefix = span._mutatingExtracting(droppingFirst: capacity)
     expectTrue(prefix.isEmpty)
 
     prefix = span._mutatingExtracting(droppingFirst: 1)
     expectEqual(prefix.unsafeLoad(as: UInt8.self), 1)
+
+    prefix = span._mutatingExtracting(droppingFirst: capacity + 5)
+    expectEqual(prefix.byteCount, 0)
   }
 
   do {
@@ -581,9 +653,31 @@ suite.test("_mutatingExtracting suffixes")
   }
 }
 
-suite.test("_consumingExtracting suffixes")
-.require(.stdlib_6_2).code {
+suite.test("_mutatingExtracting(last:) bound checking")
+.require(.minimumStdlib(.stdlib_6_2))
+.require(.crashTesting)
+.crashOutputMatches("Can't have a suffix of negative length")
+.code {
+  var b: ContiguousArray<Int> = [1, 2, 3, 4]
+  var span = MutableRawSpan(elements: b.mutableSpan)
+  expectCrashLater()
+  _ = span._mutatingExtracting(last: -1)
+}
 
+suite.test("_mutatingExtracting(droppingFirst:) bound checking")
+.require(.minimumStdlib(.stdlib_6_2))
+.require(.crashTesting)
+.crashOutputMatches("Can't drop a negative number of bytes")
+.code {
+  var b: ContiguousArray<Int> = [1, 2, 3, 4]
+  var span = MutableRawSpan(elements: b.mutableSpan)
+  expectCrashLater()
+  _ = span._mutatingExtracting(droppingFirst: -1)
+}
+
+suite.test("_consumingExtracting suffixes")
+.require(.minimumStdlib(.stdlib_6_2))
+.code {
   let capacity = 4
   var a = Array(0..<UInt8(capacity))
   a.withUnsafeMutableBytes {
@@ -599,11 +693,17 @@ suite.test("_consumingExtracting suffixes")
     span = $0.mutableBytes._consumingExtracting(last: 1)
     expectEqual(span.unsafeLoad(as: UInt8.self), UInt8(capacity-1))
 
+    span = $0.mutableBytes._consumingExtracting(last: capacity + 5)
+    expectEqual(span.byteCount, capacity)
+
     span = $0.mutableBytes._consumingExtracting(droppingFirst: capacity)
     expectEqual(span.isEmpty, true)
 
     span = $0.mutableBytes._consumingExtracting(droppingFirst: 1)
     expectEqual(span.unsafeLoad(as: UInt8.self), 1)
+
+    span = $0.mutableBytes._consumingExtracting(droppingFirst: capacity + 5)
+    expectEqual(span.byteCount, 0)
   }
 
   do {
@@ -615,6 +715,28 @@ suite.test("_consumingExtracting suffixes")
     span = b.mutableBytes._consumingExtracting(droppingFirst: 1)
     expectEqual(span.byteCount, b.count)
   }
+}
+
+suite.test("_consumingExtracting(last:) bound checking")
+.require(.minimumStdlib(.stdlib_6_2))
+.require(.crashTesting)
+.crashOutputMatches("Can't have a suffix of negative length")
+.code {
+  var b: ContiguousArray<Int> = [1, 2, 3, 4]
+  var span = MutableRawSpan(elements: b.mutableSpan)
+  expectCrashLater()
+  _ = span._consumingExtracting(last: -1)
+}
+
+suite.test("_consumingExtracting(droppingFirst:) bound checking")
+.require(.minimumStdlib(.stdlib_6_2))
+.require(.crashTesting)
+.crashOutputMatches("Can't drop a negative number of bytes")
+.code {
+  var b: ContiguousArray<Int> = [1, 2, 3, 4]
+  var span = MutableRawSpan(elements: b.mutableSpan)
+  expectCrashLater()
+  _ = span._consumingExtracting(droppingFirst: -1)
 }
 
 suite.test("MutableRawSpan from UnsafeMutableRawBufferPointer")

--- a/test/stdlib/Span/MutableRawSpanTests.swift
+++ b/test/stdlib/Span/MutableRawSpanTests.swift
@@ -399,7 +399,7 @@ suite.test("_mutatingExtracting()")
 suite.test("_mutatingExtracting() bounds checking")
 .require(.minimumStdlib(.stdlib_6_2))
 .require(.crashTesting)
-.crashOutputMatches("Byte offset range out of bounds")
+.crashOutputMatches("Byte offset range out of bounds", when: _isDebugAssertConfiguration())
 .code {
   var b: ContiguousArray<Int> = [1, 2, 3, 4]
   var span = MutableRawSpan(elements: b.mutableSpan)
@@ -443,7 +443,7 @@ suite.test("_consumingExtracting()")
 suite.test("_consumingExtracting() bounds checking")
 .require(.minimumStdlib(.stdlib_6_2))
 .require(.crashTesting)
-.crashOutputMatches("Byte offset range out of bounds")
+.crashOutputMatches("Byte offset range out of bounds", when: _isDebugAssertConfiguration())
 .code {
   var b: ContiguousArray<Int> = [1, 2, 3, 4]
   var span = MutableRawSpan(elements: b.mutableSpan)
@@ -526,7 +526,7 @@ suite.test("_mutatingExtracting prefixes")
 suite.test("_mutatingExtracting(first:) bound checking")
 .require(.minimumStdlib(.stdlib_6_2))
 .require(.crashTesting)
-.crashOutputMatches("Can't have a prefix of negative length")
+.crashOutputMatches("Can't have a prefix of negative length", when: _isDebugAssertConfiguration())
 .code {
   var b: ContiguousArray<Int> = [1, 2, 3, 4]
   var span = MutableRawSpan(elements: b.mutableSpan)
@@ -537,7 +537,7 @@ suite.test("_mutatingExtracting(first:) bound checking")
 suite.test("_mutatingExtracting(droppingLast:) bound checking")
 .require(.minimumStdlib(.stdlib_6_2))
 .require(.crashTesting)
-.crashOutputMatches("Can't drop a negative number of bytes")
+.crashOutputMatches("Can't drop a negative number of bytes", when: _isDebugAssertConfiguration())
 .code {
   var b: ContiguousArray<Int> = [1, 2, 3, 4]
   var span = MutableRawSpan(elements: b.mutableSpan)
@@ -593,7 +593,7 @@ suite.test("_consumingExtracting prefixes")
 suite.test("_consumingExtracting(first:) bound checking")
 .require(.minimumStdlib(.stdlib_6_2))
 .require(.crashTesting)
-.crashOutputMatches("Can't have a prefix of negative length")
+.crashOutputMatches("Can't have a prefix of negative length", when: _isDebugAssertConfiguration())
 .code {
   var b: ContiguousArray<Int> = [1, 2, 3, 4]
   var span = MutableRawSpan(elements: b.mutableSpan)
@@ -604,7 +604,7 @@ suite.test("_consumingExtracting(first:) bound checking")
 suite.test("_consumingExtracting(droppingLast:) bound checking")
 .require(.minimumStdlib(.stdlib_6_2))
 .require(.crashTesting)
-.crashOutputMatches("Can't drop a negative number of bytes")
+.crashOutputMatches("Can't drop a negative number of bytes", when: _isDebugAssertConfiguration())
 .code {
   var b: ContiguousArray<Int> = [1, 2, 3, 4]
   var span = MutableRawSpan(elements: b.mutableSpan)
@@ -656,7 +656,7 @@ suite.test("_mutatingExtracting suffixes")
 suite.test("_mutatingExtracting(last:) bound checking")
 .require(.minimumStdlib(.stdlib_6_2))
 .require(.crashTesting)
-.crashOutputMatches("Can't have a suffix of negative length")
+.crashOutputMatches("Can't have a suffix of negative length", when: _isDebugAssertConfiguration())
 .code {
   var b: ContiguousArray<Int> = [1, 2, 3, 4]
   var span = MutableRawSpan(elements: b.mutableSpan)
@@ -667,7 +667,7 @@ suite.test("_mutatingExtracting(last:) bound checking")
 suite.test("_mutatingExtracting(droppingFirst:) bound checking")
 .require(.minimumStdlib(.stdlib_6_2))
 .require(.crashTesting)
-.crashOutputMatches("Can't drop a negative number of bytes")
+.crashOutputMatches("Can't drop a negative number of bytes", when: _isDebugAssertConfiguration())
 .code {
   var b: ContiguousArray<Int> = [1, 2, 3, 4]
   var span = MutableRawSpan(elements: b.mutableSpan)
@@ -720,7 +720,7 @@ suite.test("_consumingExtracting suffixes")
 suite.test("_consumingExtracting(last:) bound checking")
 .require(.minimumStdlib(.stdlib_6_2))
 .require(.crashTesting)
-.crashOutputMatches("Can't have a suffix of negative length")
+.crashOutputMatches("Can't have a suffix of negative length", when: _isDebugAssertConfiguration())
 .code {
   var b: ContiguousArray<Int> = [1, 2, 3, 4]
   var span = MutableRawSpan(elements: b.mutableSpan)
@@ -731,7 +731,7 @@ suite.test("_consumingExtracting(last:) bound checking")
 suite.test("_consumingExtracting(droppingFirst:) bound checking")
 .require(.minimumStdlib(.stdlib_6_2))
 .require(.crashTesting)
-.crashOutputMatches("Can't drop a negative number of bytes")
+.crashOutputMatches("Can't drop a negative number of bytes", when: _isDebugAssertConfiguration())
 .code {
   var b: ContiguousArray<Int> = [1, 2, 3, 4]
   var span = MutableRawSpan(elements: b.mutableSpan)

--- a/test/stdlib/Span/MutableSpanTests.swift
+++ b/test/stdlib/Span/MutableSpanTests.swift
@@ -369,13 +369,8 @@ suite.test("swapAt")
 }
 
 suite.test("_mutatingExtracting()")
-.skip(.custom(
-  { if #available(SwiftStdlib 6.2, *) { false } else { true } },
-  reason: "Requires Swift 6.2's standard library"
-))
+.require(.minimumStdlib(.stdlib_6_2))
 .code {
-  guard #available(SwiftStdlib 6.2, *) else { return }
-
   let capacity = 4
   var b = (0..<capacity).map(Int8.init)
   b.withUnsafeMutableBufferPointer {
@@ -396,46 +391,67 @@ suite.test("_mutatingExtracting()")
     sub = span._mutatingExtracting(2...)
     expectEqual(sub.count, 2)
     expectEqual(sub[0], 2)
+
+    sub = span._mutatingExtracting(1...2)
+    expectEqual(sub.count, 2)
+    expectEqual(sub[0], 1)
   }
 }
 
-suite.test("_consumingExtracting()")
-.require(.stdlib_6_2).code {
+suite.test("_mutatingExtracting() bounds checking")
+.require(.minimumStdlib(.stdlib_6_2))
+.require(.crashTesting)
+.crashOutputMatches("Index range out of bounds")
+.code {
+  var b: ContiguousArray<Int> = [1, 2, 3, 4]
+  var span = b.mutableSpan
+  expectCrashLater()
+  _ = span._mutatingExtracting(2 ..< .max)
+}
 
+suite.test("_consumingExtracting()")
+.require(.minimumStdlib(.stdlib_6_2))
+.code {
   let c = 16
   let b = UnsafeMutableBufferPointer<Int8>.allocate(capacity: c)
   defer { b.deallocate() }
   _ = b.initialize(fromContentsOf: 0..<Int8(c))
 
-  var span = b.mutableSpan
-  span = span._consumingExtracting(0..<2)
+  var span = b.mutableSpan._consumingExtracting(0..<2)
   expectEqual(span.count, 2)
   expectEqual(span[0], 0)
 
-  span = b.mutableSpan
-  span = span._consumingExtracting(..<2)
+  span = b.mutableSpan._consumingExtracting(..<2)
   expectEqual(span.count, 2)
   expectEqual(span[0], 0)
 
-  span = b.mutableSpan
-  span = span._consumingExtracting(...)
+  span = b.mutableSpan._consumingExtracting(...)
   expectEqual(span.count, c)
   expectEqual(span[0], 0)
 
-  span = b.mutableSpan
-  span = span._consumingExtracting(2...)
+  span = b.mutableSpan._consumingExtracting(2...)
   expectEqual(span.count, c-2)
   expectEqual(span[0], 2)
+
+  span = b.mutableSpan._consumingExtracting(1...2)
+  expectEqual(span.count, 2)
+  expectEqual(span[0], 1)
+}
+
+suite.test("_consumingExtracting() bounds checking")
+.require(.minimumStdlib(.stdlib_6_2))
+.require(.crashTesting)
+.crashOutputMatches("Index range out of bounds")
+.code {
+  var b: ContiguousArray<Int> = [1, 2, 3, 4]
+  let span = b.mutableSpan
+  expectCrashLater()
+  _ = span._consumingExtracting(2 ..< .max)
 }
 
 suite.test("_mutatingExtracting(unchecked:)")
-.skip(.custom(
-  { if #available(SwiftStdlib 6.2, *) { false } else { true } },
-  reason: "Requires Swift 6.2's standard library"
-))
+.require(.minimumStdlib(.stdlib_6_2))
 .code {
-  guard #available(SwiftStdlib 6.2, *) else { return }
-
   let capacity = 32
   var b = (0..<capacity).map(UInt8.init)
   b.withUnsafeMutableBufferPointer {
@@ -448,8 +464,8 @@ suite.test("_mutatingExtracting(unchecked:)")
 }
 
 suite.test("_consumingExtracting(unchecked:)")
-.require(.stdlib_6_2).code {
-
+.require(.minimumStdlib(.stdlib_6_2))
+.code {
   let capacity = 32
   var b = (0..<capacity).map(UInt8.init)
   b.withUnsafeMutableBufferPointer {
@@ -461,13 +477,8 @@ suite.test("_consumingExtracting(unchecked:)")
 }
 
 suite.test("_mutatingExtracting prefixes")
-.skip(.custom(
-  { if #available(SwiftStdlib 6.2, *) { false } else { true } },
-  reason: "Requires Swift 6.2's standard library"
-))
+.require(.minimumStdlib(.stdlib_6_2))
 .code {
-  guard #available(SwiftStdlib 6.2, *) else { return }
-
   let capacity = 4
   var a = Array(0..<UInt8(capacity))
   a.withUnsafeMutableBufferPointer {
@@ -481,11 +492,17 @@ suite.test("_mutatingExtracting prefixes")
     prefix = span._mutatingExtracting(first: capacity)
     expectEqual(prefix[capacity-1], UInt8(capacity-1))
 
+    prefix = span._mutatingExtracting(first: capacity + 5)
+    expectEqual(prefix.count, capacity)
+
     prefix = span._mutatingExtracting(droppingLast: capacity)
     expectEqual(prefix.isEmpty, true)
 
     prefix = span._mutatingExtracting(droppingLast: 1)
     expectEqual(prefix[capacity-2], UInt8(capacity-2))
+
+    prefix = span._mutatingExtracting(droppingLast: capacity + 5)
+    expectEqual(prefix.count, 0)
   }
 
   do {
@@ -497,9 +514,31 @@ suite.test("_mutatingExtracting prefixes")
   }
 }
 
-suite.test("_consumingExtracting prefixes")
-.require(.stdlib_6_2).code {
+suite.test("_mutatingExtracting(first:) bound checking")
+.require(.minimumStdlib(.stdlib_6_2))
+.require(.crashTesting)
+.crashOutputMatches("Can't have a prefix of negative length")
+.code {
+  var b: ContiguousArray<UInt8> = [0, 1, 2, 3]
+  var span = b.mutableSpan
+  expectCrashLater()
+  _ = span._mutatingExtracting(first: -1)
+}
 
+suite.test("_mutatingExtracting(droppingLast:) bound checking")
+.require(.minimumStdlib(.stdlib_6_2))
+.require(.crashTesting)
+.crashOutputMatches("Can't drop a negative number of elements")
+.code {
+  var b: ContiguousArray<UInt8> = [0, 1, 2, 3]
+  var span = b.mutableSpan
+  expectCrashLater()
+  _ = span._mutatingExtracting(droppingLast: -1)
+}
+
+suite.test("_consumingExtracting prefixes")
+.require(.minimumStdlib(.stdlib_6_2))
+.code {
   let capacity = 4
   var a = Array(0..<capacity)
   a.withUnsafeMutableBufferPointer {
@@ -513,11 +552,17 @@ suite.test("_consumingExtracting prefixes")
     span = $0.mutableSpan._consumingExtracting(first: capacity)
     expectEqual(span[capacity-1], capacity-1)
 
+    span = $0.mutableSpan._consumingExtracting(first: capacity + 5)
+    expectEqual(span.count, capacity)
+
     span = $0.mutableSpan._consumingExtracting(droppingLast: capacity)
     expectEqual(span.isEmpty, true)
 
     span = $0.mutableSpan._consumingExtracting(droppingLast: 1)
     expectEqual(span[capacity-2], capacity-2)
+
+    span = $0.mutableSpan._consumingExtracting(droppingLast: capacity + 5)
+    expectEqual(span.count, 0)
   }
 
   do {
@@ -531,14 +576,31 @@ suite.test("_consumingExtracting prefixes")
   }
 }
 
-suite.test("_mutatingExtracting suffixes")
-.skip(.custom(
-  { if #available(SwiftStdlib 6.2, *) { false } else { true } },
-  reason: "Requires Swift 6.2's standard library"
-))
+suite.test("_consumingExtracting(first:) bound checking")
+.require(.minimumStdlib(.stdlib_6_2))
+.require(.crashTesting)
+.crashOutputMatches("Can't have a prefix of negative length")
 .code {
-  guard #available(SwiftStdlib 6.2, *) else { return }
+  var b: ContiguousArray<UInt8> = [0, 1, 2, 3]
+  let span = b.mutableSpan
+  expectCrashLater()
+  _ = span._consumingExtracting(first: -1)
+}
 
+suite.test("_consumingExtracting(droppingLast:) bound checking")
+.require(.minimumStdlib(.stdlib_6_2))
+.require(.crashTesting)
+.crashOutputMatches("Can't drop a negative number of elements")
+.code {
+  var b: ContiguousArray<UInt8> = [0, 1, 2, 3]
+  let span = b.mutableSpan
+  expectCrashLater()
+  _ = span._consumingExtracting(droppingLast: -1)
+}
+
+suite.test("_mutatingExtracting suffixes")
+.require(.minimumStdlib(.stdlib_6_2))
+.code {
   let capacity = 4
   var a = Array(0..<UInt8(capacity))
   a.withUnsafeMutableBufferPointer {
@@ -555,11 +617,17 @@ suite.test("_mutatingExtracting suffixes")
     suffix = span._mutatingExtracting(last: 1)
     expectEqual(suffix[0], UInt8(capacity-1))
 
+    suffix = span._mutatingExtracting(last: capacity + 5)
+    expectEqual(suffix.count, capacity)
+
     suffix = span._mutatingExtracting(droppingFirst: capacity)
     expectTrue(suffix.isEmpty)
 
     suffix = span._mutatingExtracting(droppingFirst: 1)
     expectEqual(suffix[0], 1)
+
+    suffix = span._mutatingExtracting(droppingFirst: capacity + 5)
+    expectEqual(suffix.count, 0)
   }
 
   do {
@@ -571,9 +639,31 @@ suite.test("_mutatingExtracting suffixes")
   }
 }
 
-suite.test("_consumingExtracting suffixes")
-.require(.stdlib_6_2).code {
+suite.test("_mutatingExtracting(last:) bound checking")
+.require(.minimumStdlib(.stdlib_6_2))
+.require(.crashTesting)
+.crashOutputMatches("Can't have a suffix of negative length")
+.code {
+  var b: ContiguousArray<UInt8> = [0, 1, 2, 3]
+  var span = b.mutableSpan
+  expectCrashLater()
+  _ = span._mutatingExtracting(last: -1)
+}
 
+suite.test("_mutatingExtracting(droppingFirst:) bound checking")
+.require(.minimumStdlib(.stdlib_6_2))
+.require(.crashTesting)
+.crashOutputMatches("Can't drop a negative number of elements")
+.code {
+  var b: ContiguousArray<UInt8> = [0, 1, 2, 3]
+  var span = b.mutableSpan
+  expectCrashLater()
+  _ = span._mutatingExtracting(droppingFirst: -1)
+}
+
+suite.test("_consumingExtracting suffixes")
+.require(.minimumStdlib(.stdlib_6_2))
+.code {
   let capacity = 4
   var a = Array(0..<capacity)
   a.withUnsafeMutableBufferPointer {
@@ -589,11 +679,17 @@ suite.test("_consumingExtracting suffixes")
     span = $0.mutableSpan._consumingExtracting(last: 1)
     expectEqual(span[0], capacity-1)
 
+    span = $0.mutableSpan._consumingExtracting(last: capacity + 5)
+    expectEqual(span.count, capacity)
+
     span = $0.mutableSpan._consumingExtracting(droppingFirst: capacity)
     expectEqual(span.isEmpty, true)
 
     span = $0.mutableSpan._consumingExtracting(droppingFirst: 1)
     expectEqual(span[0], 1)
+
+    span = $0.mutableSpan._consumingExtracting(droppingFirst: capacity + 5)
+    expectEqual(span.count, 0)
   }
 
   do {
@@ -605,6 +701,28 @@ suite.test("_consumingExtracting suffixes")
     span = b.mutableSpan._consumingExtracting(droppingFirst: 1)
     expectEqual(span.count, b.count)
   }
+}
+
+suite.test("_consumingExtracting(last:) bound checking")
+.require(.minimumStdlib(.stdlib_6_2))
+.require(.crashTesting)
+.crashOutputMatches("Can't have a suffix of negative length")
+.code {
+  var b: ContiguousArray<UInt8> = [0, 1, 2, 3]
+  let span = b.mutableSpan
+  expectCrashLater()
+  _ = span._consumingExtracting(last: -1)
+}
+
+suite.test("_consumingExtracting(droppingFirst:) bound checking")
+.require(.minimumStdlib(.stdlib_6_2))
+.require(.crashTesting)
+.crashOutputMatches("Can't drop a negative number of elements")
+.code {
+  var b: ContiguousArray<UInt8> = [0, 1, 2, 3]
+  let span = b.mutableSpan
+  expectCrashLater()
+  _ = span._consumingExtracting(droppingFirst: -1)
 }
 
 suite.test("MutableSpan from UnsafeMutableBufferPointer")

--- a/test/stdlib/Span/MutableSpanTests.swift
+++ b/test/stdlib/Span/MutableSpanTests.swift
@@ -401,7 +401,7 @@ suite.test("_mutatingExtracting()")
 suite.test("_mutatingExtracting() bounds checking")
 .require(.minimumStdlib(.stdlib_6_2))
 .require(.crashTesting)
-.crashOutputMatches("Index range out of bounds")
+.crashOutputMatches("Index range out of bounds", when: _isDebugAssertConfiguration())
 .code {
   var b: ContiguousArray<Int> = [1, 2, 3, 4]
   var span = b.mutableSpan
@@ -441,7 +441,7 @@ suite.test("_consumingExtracting()")
 suite.test("_consumingExtracting() bounds checking")
 .require(.minimumStdlib(.stdlib_6_2))
 .require(.crashTesting)
-.crashOutputMatches("Index range out of bounds")
+.crashOutputMatches("Index range out of bounds", when: _isDebugAssertConfiguration())
 .code {
   var b: ContiguousArray<Int> = [1, 2, 3, 4]
   let span = b.mutableSpan
@@ -517,7 +517,7 @@ suite.test("_mutatingExtracting prefixes")
 suite.test("_mutatingExtracting(first:) bound checking")
 .require(.minimumStdlib(.stdlib_6_2))
 .require(.crashTesting)
-.crashOutputMatches("Can't have a prefix of negative length")
+.crashOutputMatches("Can't have a prefix of negative length", when: _isDebugAssertConfiguration())
 .code {
   var b: ContiguousArray<UInt8> = [0, 1, 2, 3]
   var span = b.mutableSpan
@@ -528,7 +528,7 @@ suite.test("_mutatingExtracting(first:) bound checking")
 suite.test("_mutatingExtracting(droppingLast:) bound checking")
 .require(.minimumStdlib(.stdlib_6_2))
 .require(.crashTesting)
-.crashOutputMatches("Can't drop a negative number of elements")
+.crashOutputMatches("Can't drop a negative number of elements", when: _isDebugAssertConfiguration())
 .code {
   var b: ContiguousArray<UInt8> = [0, 1, 2, 3]
   var span = b.mutableSpan
@@ -579,7 +579,7 @@ suite.test("_consumingExtracting prefixes")
 suite.test("_consumingExtracting(first:) bound checking")
 .require(.minimumStdlib(.stdlib_6_2))
 .require(.crashTesting)
-.crashOutputMatches("Can't have a prefix of negative length")
+.crashOutputMatches("Can't have a prefix of negative length", when: _isDebugAssertConfiguration())
 .code {
   var b: ContiguousArray<UInt8> = [0, 1, 2, 3]
   let span = b.mutableSpan
@@ -590,7 +590,7 @@ suite.test("_consumingExtracting(first:) bound checking")
 suite.test("_consumingExtracting(droppingLast:) bound checking")
 .require(.minimumStdlib(.stdlib_6_2))
 .require(.crashTesting)
-.crashOutputMatches("Can't drop a negative number of elements")
+.crashOutputMatches("Can't drop a negative number of elements", when: _isDebugAssertConfiguration())
 .code {
   var b: ContiguousArray<UInt8> = [0, 1, 2, 3]
   let span = b.mutableSpan
@@ -642,7 +642,7 @@ suite.test("_mutatingExtracting suffixes")
 suite.test("_mutatingExtracting(last:) bound checking")
 .require(.minimumStdlib(.stdlib_6_2))
 .require(.crashTesting)
-.crashOutputMatches("Can't have a suffix of negative length")
+.crashOutputMatches("Can't have a suffix of negative length", when: _isDebugAssertConfiguration())
 .code {
   var b: ContiguousArray<UInt8> = [0, 1, 2, 3]
   var span = b.mutableSpan
@@ -653,7 +653,7 @@ suite.test("_mutatingExtracting(last:) bound checking")
 suite.test("_mutatingExtracting(droppingFirst:) bound checking")
 .require(.minimumStdlib(.stdlib_6_2))
 .require(.crashTesting)
-.crashOutputMatches("Can't drop a negative number of elements")
+.crashOutputMatches("Can't drop a negative number of elements", when: _isDebugAssertConfiguration())
 .code {
   var b: ContiguousArray<UInt8> = [0, 1, 2, 3]
   var span = b.mutableSpan
@@ -706,7 +706,7 @@ suite.test("_consumingExtracting suffixes")
 suite.test("_consumingExtracting(last:) bound checking")
 .require(.minimumStdlib(.stdlib_6_2))
 .require(.crashTesting)
-.crashOutputMatches("Can't have a suffix of negative length")
+.crashOutputMatches("Can't have a suffix of negative length", when: _isDebugAssertConfiguration())
 .code {
   var b: ContiguousArray<UInt8> = [0, 1, 2, 3]
   let span = b.mutableSpan
@@ -717,7 +717,7 @@ suite.test("_consumingExtracting(last:) bound checking")
 suite.test("_consumingExtracting(droppingFirst:) bound checking")
 .require(.minimumStdlib(.stdlib_6_2))
 .require(.crashTesting)
-.crashOutputMatches("Can't drop a negative number of elements")
+.crashOutputMatches("Can't drop a negative number of elements", when: _isDebugAssertConfiguration())
 .code {
   var b: ContiguousArray<UInt8> = [0, 1, 2, 3]
   let span = b.mutableSpan

--- a/test/stdlib/Span/RawSpanTests.swift
+++ b/test/stdlib/Span/RawSpanTests.swift
@@ -143,13 +143,8 @@ suite.test("unsafeLoadUnaligned(as:)")
 }
 
 suite.test("extracting() functions")
-.skip(.custom(
-  { if #available(SwiftStdlib 6.2, *) { false } else { true } },
-  reason: "Requires Swift 6.2's standard library"
-))
+.require(.minimumStdlib(.stdlib_6_2))
 .code {
-  guard #available(SwiftStdlib 6.2, *) else { return }
-
   let capacity = 4
   let b = (0..<capacity).map(Int8.init)
   b.withUnsafeBytes {
@@ -158,6 +153,7 @@ suite.test("extracting() functions")
     let sub2 = span.extracting(..<2)
     let sub3 = span.extracting(...)
     let sub4 = span.extracting(2...)
+    let sub5 = span.extracting(1...2)
 
     sub1.withUnsafeBytes { p1 in
       sub2.withUnsafeBytes { p2 in
@@ -174,17 +170,29 @@ suite.test("extracting() functions")
         expectFalse(p4.elementsEqual(p3))
       }
     }
+    expectEqual(sub5.byteCount, 2)
+    sub5.withUnsafeBytes { p5 in
+      span.extracting(1..<3).withUnsafeBytes { p15 in
+        expectTrue(p5.elementsEqual(p15))
+      }
+    }
   }
 }
 
-suite.test("extracting(unchecked:) functions")
-.skip(.custom(
-  { if #available(SwiftStdlib 6.2, *) { false } else { true } },
-  reason: "Requires Swift 6.2's standard library"
-))
+suite.test("extracting() bounds checking")
+.require(.minimumStdlib(.stdlib_6_2))
+.require(.crashTesting)
+.crashOutputMatches("Byte offset range out of bounds")
 .code {
-  guard #available(SwiftStdlib 6.2, *) else { return }
+  let b: ContiguousArray<UInt8> = [0, 1, 2, 3]
+  let bytes = b.span.bytes
+  expectCrashLater()
+  _ = bytes.extracting(2 ..< .max)
+}
 
+suite.test("extracting(unchecked:) functions")
+.require(.minimumStdlib(.stdlib_6_2))
+.code {
   let capacity = 32
   let b = (0..<capacity).map(UInt8.init)
   b.withUnsafeBytes {
@@ -197,13 +205,8 @@ suite.test("extracting(unchecked:) functions")
 }
 
 suite.test("prefix extracting() functions")
-.skip(.custom(
-  { if #available(SwiftStdlib 6.2, *) { false } else { true } },
-  reason: "Requires Swift 6.2's standard library"
-))
+.require(.minimumStdlib(.stdlib_6_2))
 .code {
-  guard #available(SwiftStdlib 6.2, *) else { return }
-
   let capacity = 4
   let a = Array(0..<UInt8(capacity))
   a.withUnsafeBytes {
@@ -216,6 +219,7 @@ suite.test("prefix extracting() functions")
       ),
       UInt8(capacity-1)
     )
+    expectEqual(span.extracting(first: capacity + 5).byteCount, capacity)
     expectTrue(span.extracting(droppingLast: capacity).isEmpty)
     expectEqual(
       span.extracting(droppingLast: 1).unsafeLoad(
@@ -223,6 +227,7 @@ suite.test("prefix extracting() functions")
       ),
       UInt8(capacity-2)
     )
+    expectTrue(span.extracting(droppingLast: capacity + 5).isEmpty)
     let emptySpan = span.extracting(first: 0)
     let emptierSpan = emptySpan.extracting(0..<0)
     expectTrue(emptySpan.isIdentical(to: emptierSpan))
@@ -237,14 +242,31 @@ suite.test("prefix extracting() functions")
   }
 }
 
-suite.test("suffix extracting() functions")
-.skip(.custom(
-  { if #available(SwiftStdlib 6.2, *) { false } else { true } },
-  reason: "Requires Swift 6.2's standard library"
-))
+suite.test("extracting(first:) bound checking")
+.require(.minimumStdlib(.stdlib_6_2))
+.require(.crashTesting)
+.crashOutputMatches("Can't have a prefix of negative length")
 .code {
-  guard #available(SwiftStdlib 6.2, *) else { return }
+  let b: ContiguousArray<UInt8> = [0, 1, 2, 3]
+  let bytes = b.span.bytes
+  expectCrashLater()
+  _ = bytes.extracting(first: -1)
+}
 
+suite.test("extracting(droppingLast:) bound checking")
+.require(.minimumStdlib(.stdlib_6_2))
+.require(.crashTesting)
+.crashOutputMatches("Can't drop a negative number of bytes")
+.code {
+  let b: ContiguousArray<UInt8> = [0, 1, 2, 3]
+  let bytes = b.span.bytes
+  expectCrashLater()
+  _ = bytes.extracting(droppingLast: -1)
+}
+
+suite.test("suffix extracting() functions")
+.require(.minimumStdlib(.stdlib_6_2))
+.code {
   let capacity = 4
   let a = Array(0..<UInt8(capacity))
   a.withUnsafeBytes {
@@ -253,8 +275,10 @@ suite.test("suffix extracting() functions")
     expectEqual(span.extracting(last: capacity).unsafeLoad(as: UInt8.self), 0)
     expectEqual(span.extracting(last: capacity-1).unsafeLoad(as: UInt8.self), 1)
     expectEqual(span.extracting(last: 1).unsafeLoad(as: UInt8.self), UInt8(capacity-1))
+    expectEqual(span.extracting(last: capacity + 5).byteCount, capacity)
     expectTrue(span.extracting(droppingFirst: capacity).isEmpty)
     expectEqual(span.extracting(droppingFirst: 1).unsafeLoad(as: UInt8.self), 1)
+    expectTrue(span.extracting(droppingFirst: capacity + 5).isEmpty)
   }
 
   do {
@@ -264,6 +288,28 @@ suite.test("suffix extracting() functions")
     expectEqual(span.extracting(last: 1).byteCount, b.count)
     expectEqual(span.extracting(droppingFirst: 1).byteCount, b.count)
   }
+}
+
+suite.test("extracting(last:) bound checking")
+.require(.minimumStdlib(.stdlib_6_2))
+.require(.crashTesting)
+.crashOutputMatches("Can't have a suffix of negative length")
+.code {
+  let b: ContiguousArray<UInt8> = [0, 1, 2, 3]
+  let bytes = b.span.bytes
+  expectCrashLater()
+  _ = bytes.extracting(last: -1)
+}
+
+suite.test("extracting(droppingFirst:) bound checking")
+.require(.stdlib_6_2)
+.require(.crashTesting)
+.crashOutputMatches("Can't drop a negative number of bytes")
+.code {
+  let b: ContiguousArray<UInt8> = [0, 1, 2, 3]
+  let bytes = b.span.bytes
+  expectCrashLater()
+  _ = bytes.extracting(droppingFirst: -1)
 }
 
 suite.test("withUnsafeBytes()")

--- a/test/stdlib/Span/RawSpanTests.swift
+++ b/test/stdlib/Span/RawSpanTests.swift
@@ -182,7 +182,7 @@ suite.test("extracting() functions")
 suite.test("extracting() bounds checking")
 .require(.minimumStdlib(.stdlib_6_2))
 .require(.crashTesting)
-.crashOutputMatches("Byte offset range out of bounds")
+.crashOutputMatches("Byte offset range out of bounds", when: _isDebugAssertConfiguration())
 .code {
   let b: ContiguousArray<UInt8> = [0, 1, 2, 3]
   let bytes = b.span.bytes
@@ -245,7 +245,7 @@ suite.test("prefix extracting() functions")
 suite.test("extracting(first:) bound checking")
 .require(.minimumStdlib(.stdlib_6_2))
 .require(.crashTesting)
-.crashOutputMatches("Can't have a prefix of negative length")
+.crashOutputMatches("Can't have a prefix of negative length", when: _isDebugAssertConfiguration())
 .code {
   let b: ContiguousArray<UInt8> = [0, 1, 2, 3]
   let bytes = b.span.bytes
@@ -256,7 +256,7 @@ suite.test("extracting(first:) bound checking")
 suite.test("extracting(droppingLast:) bound checking")
 .require(.minimumStdlib(.stdlib_6_2))
 .require(.crashTesting)
-.crashOutputMatches("Can't drop a negative number of bytes")
+.crashOutputMatches("Can't drop a negative number of bytes", when: _isDebugAssertConfiguration())
 .code {
   let b: ContiguousArray<UInt8> = [0, 1, 2, 3]
   let bytes = b.span.bytes
@@ -293,7 +293,7 @@ suite.test("suffix extracting() functions")
 suite.test("extracting(last:) bound checking")
 .require(.minimumStdlib(.stdlib_6_2))
 .require(.crashTesting)
-.crashOutputMatches("Can't have a suffix of negative length")
+.crashOutputMatches("Can't have a suffix of negative length", when: _isDebugAssertConfiguration())
 .code {
   let b: ContiguousArray<UInt8> = [0, 1, 2, 3]
   let bytes = b.span.bytes
@@ -304,7 +304,7 @@ suite.test("extracting(last:) bound checking")
 suite.test("extracting(droppingFirst:) bound checking")
 .require(.stdlib_6_2)
 .require(.crashTesting)
-.crashOutputMatches("Can't drop a negative number of bytes")
+.crashOutputMatches("Can't drop a negative number of bytes", when: _isDebugAssertConfiguration())
 .code {
   let b: ContiguousArray<UInt8> = [0, 1, 2, 3]
   let bytes = b.span.bytes

--- a/test/stdlib/Span/SpanTests.swift
+++ b/test/stdlib/Span/SpanTests.swift
@@ -363,7 +363,7 @@ suite.test("extracting() functions")
 suite.test("extracting() bounds checking")
 .require(.minimumStdlib(.stdlib_6_2))
 .require(.crashTesting)
-.crashOutputMatches("Index range out of bounds")
+.crashOutputMatches("Index range out of bounds", when: _isDebugAssertConfiguration())
 .code {
   let b: ContiguousArray<Int> = [1, 2, 3, 4]
   let span = b.span
@@ -413,7 +413,7 @@ suite.test("prefix extracting() functions")
 suite.test("extracting(first:) bound checking")
 .require(.minimumStdlib(.stdlib_6_2))
 .require(.crashTesting)
-.crashOutputMatches("Can't have a prefix of negative length")
+.crashOutputMatches("Can't have a prefix of negative length", when: _isDebugAssertConfiguration())
 .code {
   let b: ContiguousArray<Int> = [1, 2, 3, 4]
   let span = b.span
@@ -424,7 +424,7 @@ suite.test("extracting(first:) bound checking")
 suite.test("extracting(droppingLast:) bound checking")
 .require(.minimumStdlib(.stdlib_6_2))
 .require(.crashTesting)
-.crashOutputMatches("Can't drop a negative number of elements")
+.crashOutputMatches("Can't drop a negative number of elements", when: _isDebugAssertConfiguration())
 .code {
   let b: ContiguousArray<Int> = [1, 2, 3, 4]
   let span = b.span
@@ -461,7 +461,7 @@ suite.test("suffix extracting() functions")
 suite.test("extracting(last:) bound checking")
 .require(.minimumStdlib(.stdlib_6_2))
 .require(.crashTesting)
-.crashOutputMatches("Can't have a suffix of negative length")
+.crashOutputMatches("Can't have a suffix of negative length", when: _isDebugAssertConfiguration())
 .code {
   let b: ContiguousArray<Int> = [1, 2, 3, 4]
   let span = b.span
@@ -472,7 +472,7 @@ suite.test("extracting(last:) bound checking")
 suite.test("extracting(droppingFirst:) bound checking")
 .require(.minimumStdlib(.stdlib_6_2))
 .require(.crashTesting)
-.crashOutputMatches("Can't drop a negative number of elements")
+.crashOutputMatches("Can't drop a negative number of elements", when: _isDebugAssertConfiguration())
 .code {
   let b: ContiguousArray<Int> = [1, 2, 3, 4]
   let span = b.span

--- a/test/stdlib/Span/SpanTests.swift
+++ b/test/stdlib/Span/SpanTests.swift
@@ -19,7 +19,6 @@ import StdlibUnittest
 var suite = TestSuite("Span Tests")
 defer { runAllTests() }
 
-@available(SwiftStdlib 6.2, *)
 extension Span where Element: Equatable {
 
   /// Returns a Boolean value indicating whether this and another span
@@ -342,13 +341,8 @@ suite.test("subscript with BitwiseCopyable element")
 }
 
 suite.test("extracting() functions")
-.skip(.custom(
-  { if #available(SwiftStdlib 6.2, *) { false } else { true } },
-  reason: "Requires Swift 6.2's standard library"
-))
+.require(.minimumStdlib(.stdlib_6_2))
 .code {
-  guard #available(SwiftStdlib 6.2, *) else { return }
-
   let capacity = 4
   let b = (0..<capacity).map(String.init)
   b.withUnsafeBufferPointer {
@@ -357,20 +351,29 @@ suite.test("extracting() functions")
     let sub2 = span.extracting(..<2)
     let sub3 = span.extracting(...)
     let sub4 = span.extracting(2...)
+    let sub5 = span.extracting(1...2)
     expectTrue(sub1._elementsEqual(sub2))
     expectTrue(sub3._elementsEqual(span))
     expectFalse(sub4._elementsEqual(sub3))
+    expectEqual(sub5.count, 2)
+    expectTrue(sub5._elementsEqual(span.extracting(1..<3)))
   }
 }
 
-suite.test("extracting(unchecked:) functions")
-.skip(.custom(
-  { if #available(SwiftStdlib 6.2, *) { false } else { true } },
-  reason: "Requires Swift 6.2's standard library"
-))
+suite.test("extracting() bounds checking")
+.require(.minimumStdlib(.stdlib_6_2))
+.require(.crashTesting)
+.crashOutputMatches("Index range out of bounds")
 .code {
-  guard #available(SwiftStdlib 6.2, *) else { return }
+  let b: ContiguousArray<Int> = [1, 2, 3, 4]
+  let span = b.span
+  expectCrashLater()
+  _ = span.extracting(2 ..< .max)
+}
 
+suite.test("extracting(unchecked:) functions")
+.require(.minimumStdlib(.stdlib_6_2))
+.code {
   let capacity = 32
   let b = (0..<capacity).map(String.init)
   b.withUnsafeBufferPointer {
@@ -383,13 +386,8 @@ suite.test("extracting(unchecked:) functions")
 }
 
 suite.test("prefix extracting() functions")
-.skip(.custom(
-  { if #available(SwiftStdlib 6.2, *) { false } else { true } },
-  reason: "Requires Swift 6.2's standard library"
-))
+.require(.minimumStdlib(.stdlib_6_2))
 .code {
-  guard #available(SwiftStdlib 6.2, *) else { return }
-
   let capacity = 4
   let a = Array(0..<capacity)
   a.withUnsafeBufferPointer {
@@ -397,8 +395,10 @@ suite.test("prefix extracting() functions")
     expectEqual(span.count, capacity)
     expectEqual(span.extracting(first: 1)[0], 0)
     expectEqual(span.extracting(first: capacity)[capacity-1], capacity-1)
+    expectEqual(span.extracting(first: capacity + 5).count, capacity)
     expectEqual(span.extracting(droppingLast: capacity).count, 0)
     expectEqual(span.extracting(droppingLast: 1)[capacity-2], capacity-2)
+    expectEqual(span.extracting(droppingLast: capacity + 5).count, 0)
   }
 
   do {
@@ -410,14 +410,31 @@ suite.test("prefix extracting() functions")
   }
 }
 
-suite.test("suffix extracting() functions")
-.skip(.custom(
-  { if #available(SwiftStdlib 6.2, *) { false } else { true } },
-  reason: "Requires Swift 6.2's standard library"
-))
+suite.test("extracting(first:) bound checking")
+.require(.minimumStdlib(.stdlib_6_2))
+.require(.crashTesting)
+.crashOutputMatches("Can't have a prefix of negative length")
 .code {
-  guard #available(SwiftStdlib 6.2, *) else { return }
+  let b: ContiguousArray<Int> = [1, 2, 3, 4]
+  let span = b.span
+  expectCrashLater()
+  _ = span.extracting(first: -1)
+}
 
+suite.test("extracting(droppingLast:) bound checking")
+.require(.minimumStdlib(.stdlib_6_2))
+.require(.crashTesting)
+.crashOutputMatches("Can't drop a negative number of elements")
+.code {
+  let b: ContiguousArray<Int> = [1, 2, 3, 4]
+  let span = b.span
+  expectCrashLater()
+  _ = span.extracting(droppingLast: -1)
+}
+
+suite.test("suffix extracting() functions")
+.require(.minimumStdlib(.stdlib_6_2))
+.code {
   let capacity = 4
   let a = Array(0..<capacity)
   a.withUnsafeBufferPointer {
@@ -426,8 +443,10 @@ suite.test("suffix extracting() functions")
     expectEqual(span.extracting(last: capacity)[0], 0)
     expectEqual(span.extracting(last: capacity-1)[0], 1)
     expectEqual(span.extracting(last: 1)[0], capacity-1)
+    expectEqual(span.extracting(last: capacity + 5).count, capacity)
     expectEqual(span.extracting(droppingFirst: capacity).count, 0)
     expectEqual(span.extracting(droppingFirst: 1)[0], 1)
+    expectEqual(span.extracting(droppingFirst: capacity + 5).count, 0)
   }
 
   do {
@@ -437,6 +456,28 @@ suite.test("suffix extracting() functions")
     expectEqual(span.extracting(last: 1).count, b.count)
     expectEqual(span.extracting(droppingFirst: 1).count, b.count)
   }
+}
+
+suite.test("extracting(last:) bound checking")
+.require(.minimumStdlib(.stdlib_6_2))
+.require(.crashTesting)
+.crashOutputMatches("Can't have a suffix of negative length")
+.code {
+  let b: ContiguousArray<Int> = [1, 2, 3, 4]
+  let span = b.span
+  expectCrashLater()
+  _ = span.extracting(last: -1)
+}
+
+suite.test("extracting(droppingFirst:) bound checking")
+.require(.minimumStdlib(.stdlib_6_2))
+.require(.crashTesting)
+.crashOutputMatches("Can't drop a negative number of elements")
+.code {
+  let b: ContiguousArray<Int> = [1, 2, 3, 4]
+  let span = b.span
+  expectCrashLater()
+  _ = span.extracting(droppingFirst: -1)
 }
 
 suite.test("withUnsafeBufferPointer")

--- a/test/stdlib/Span/SpanUsageHints.swift
+++ b/test/stdlib/Span/SpanUsageHints.swift
@@ -1,0 +1,36 @@
+//===--- SpanUsageHints.swift ---------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+// RUN: %target-typecheck-verify-swift -verify-ignore-unrelated
+
+func testSpan<T>(_ span: Span<T>) {
+  _ = span[0..<3]        // expected-error {{has been renamed to 'extracting(_:)'}}
+  _ = span[0...3]        // expected-error {{has been renamed to 'extracting(_:)'}}
+  _ = span[...]          // expected-error {{has been renamed to 'extracting(_:)'}}
+  _ = span[..<3]         // expected-error {{has been renamed to 'extracting(_:)'}}
+  _ = span[3...]         // expected-error {{has been renamed to 'extracting(_:)'}}
+  _ = span.prefix(5)     // expected-error {{has been renamed to 'extracting(first:)'}}
+  _ = span.suffix(5)     // expected-error {{has been renamed to 'extracting(last:)'}}
+  _ = span.dropFirst(5)  // expected-error {{has been renamed to 'extracting(droppingFirst:)'}}
+  _ = span.dropLast(5)   // expected-error {{has been renamed to 'extracting(droppingLast:)'}}
+}
+
+func testRawSpan(_ span: RawSpan) {
+  _ = span[0..<3]        // expected-error {{has been renamed to 'extracting(_:)'}}
+  _ = span[0...3]        // expected-error {{has been renamed to 'extracting(_:)'}}
+  _ = span[...]          // expected-error {{has been renamed to 'extracting(_:)'}}
+  _ = span[..<3]         // expected-error {{has been renamed to 'extracting(_:)'}}
+  _ = span[3...]         // expected-error {{has been renamed to 'extracting(_:)'}}
+  _ = span.prefix(5)     // expected-error {{has been renamed to 'extracting(first:)'}}
+  _ = span.suffix(5)     // expected-error {{has been renamed to 'extracting(last:)'}}
+  _ = span.dropFirst(5)  // expected-error {{has been renamed to 'extracting(droppingFirst:)'}}
+  _ = span.dropLast(5)   // expected-error {{has been renamed to 'extracting(droppingLast:)'}}
+}

--- a/validation-test/stdlib/UnsafeBufferPointer.swift.gyb
+++ b/validation-test/stdlib/UnsafeBufferPointer.swift.gyb
@@ -380,6 +380,216 @@ ${SelfName}TestSuite.test("badNilCount")
   let buffer = ${SelfType}(start: nil, count: 1)
   _ = buffer
 }
+
+${SelfName}TestSuite.test("extracting() functions")
+.require(.stdlib_6_5)
+.code {
+  let capacity = 4
+%   if IsRaw:
+  let memory = UnsafeMutableRawPointer.allocate(byteCount: capacity, alignment: 1)
+  defer { memory.deallocate() }
+  initUnsafeRawBufferPointer(
+    UnsafeMutableRawBufferPointer(start: memory, count: capacity)
+  )
+%   else:
+  let memory = UnsafeMutablePointer<Float>.allocate(capacity: capacity)
+  defer { memory.deallocate() }
+  initUnsafeBufferPointer(
+    UnsafeMutableBufferPointer(start: memory, count: capacity)
+  )
+%   end
+  let buffer = ${SelfType}(start: ${PointerType}(memory), count: capacity)
+
+  let sub1 = buffer.extracting(0..<2)
+  let sub2 = buffer.extracting(..<2)
+  let sub3 = buffer.extracting(...)
+  let sub4 = buffer.extracting(2...)
+  let sub5 = buffer.extracting(1...3)
+
+  expectEqual(sub1.count, 2)
+  expectEqual(sub1.baseAddress, buffer.baseAddress)
+  expectEqual(sub2.count, 2)
+  expectEqual(sub2.baseAddress, buffer.baseAddress)
+  expectEqual(sub3.count, buffer.count)
+  expectEqual(sub3.baseAddress, buffer.baseAddress)
+  expectEqual(sub4.count, capacity - 2)
+  expectEqual(sub5.count, capacity - 1)
+
+  expectEqual(sub1[0], ${Element}(0))
+  expectEqual(sub1[1], ${Element}(1))
+  expectEqual(sub2[0], ${Element}(0))
+  expectEqual(sub3[capacity - 1], ${Element}(capacity - 1))
+  expectEqual(sub4[0], ${Element}(2))
+  expectEqual(sub5[0], ${Element}(1))
+}
+
+${SelfName}TestSuite.test("extracting() bounds checking")
+.require(.stdlib_6_5)
+.require(.crashTesting)
+.crashOutputMatches("${'Byte offset' if IsRaw else 'Index'} out of range")
+.code {
+  let fakeStart = ${PointerType}(bitPattern: 0xba0bab5)
+  let buffer = ${SelfType}(start: fakeStart, count: 4)
+
+  expectCrashLater()
+  _ = buffer.extracting(2 ..< .max)
+}
+
+${SelfName}TestSuite.test("extracting(unchecked:) functions")
+.require(.stdlib_6_5)
+.code {
+  let capacity = 32
+%   if IsRaw:
+  let memory = UnsafeMutableRawPointer.allocate(byteCount: capacity, alignment: 1)
+  defer { memory.deallocate() }
+  initUnsafeRawBufferPointer(
+    UnsafeMutableRawBufferPointer(start: memory, count: capacity)
+  )
+%   else:
+  let memory = UnsafeMutablePointer<Float>.allocate(capacity: capacity)
+  defer { memory.deallocate() }
+  initUnsafeBufferPointer(
+    UnsafeMutableBufferPointer(start: memory, count: capacity)
+  )
+%   end
+  let buffer = ${SelfType}(start: ${PointerType}(memory), count: capacity)
+
+  // The unchecked variant accepts bounds outside the original buffer's range,
+  // so long as the resulting region is within the underlying allocation.
+  let prefix = buffer.extracting(0..<8)
+  let beyondHalfOpen = prefix.extracting(unchecked: 16..<24)
+  expectEqual(beyondHalfOpen.count, 8)
+  expectEqual(beyondHalfOpen[0], ${Element}(16))
+  let beyondClosed = prefix.extracting(unchecked: 16...23)
+  expectEqual(beyondClosed.count, 8)
+  expectEqual(beyondClosed[0], ${Element}(16))
+
+  let empty1 = buffer.extracting(unchecked: 0..<0)
+  expectEqual(empty1.count, 0)
+  let empty2 = buffer.extracting(unchecked: capacity..<capacity)
+  expectEqual(empty2.count, 0)
+}
+
+${SelfName}TestSuite.test("prefix extracting() functions")
+.require(.stdlib_6_5)
+.code {
+  let capacity = 4
+%   if IsRaw:
+  let memory = UnsafeMutableRawPointer.allocate(byteCount: capacity, alignment: 1)
+  defer { memory.deallocate() }
+  initUnsafeRawBufferPointer(
+    UnsafeMutableRawBufferPointer(start: memory, count: capacity))
+%   else:
+  let memory = UnsafeMutablePointer<Float>.allocate(capacity: capacity)
+  defer { memory.deallocate() }
+  initUnsafeBufferPointer(
+    UnsafeMutableBufferPointer(start: memory, count: capacity))
+%   end
+  let buffer = ${SelfType}(start: ${PointerType}(memory), count: capacity)
+
+  expectEqual(buffer.count, capacity)
+  expectEqual(buffer.extracting(first: 0).count, 0)
+  expectEqual(buffer.extracting(first: 1)[0], ${Element}(0))
+  expectEqual(
+    buffer.extracting(first: capacity)[capacity - 1], ${Element}(capacity - 1))
+  // Over-large maxLength clamps to count.
+  expectEqual(buffer.extracting(first: capacity + 5).count, capacity)
+
+  expectEqual(buffer.extracting(droppingLast: capacity).count, 0)
+  expectEqual(
+    buffer.extracting(droppingLast: 1)[capacity - 2],
+    ${Element}(capacity - 2))
+  // Over-large k clamps to count.
+  expectEqual(buffer.extracting(droppingLast: capacity + 5).count, 0)
+
+  // Empty source.
+  let empty = ${SelfType}(start: nil, count: 0)
+  expectEqual(empty.extracting(first: 1).count, 0)
+  expectEqual(empty.extracting(droppingLast: 1).count, 0)
+}
+
+${SelfName}TestSuite.test("extracting(first:) bound checking")
+.require(.stdlib_6_5)
+.require(.crashTesting)
+.crashOutputMatches("Can't have a prefix of negative length")
+.code {
+  let fakeStart = ${PointerType}(bitPattern: 0xba0bab5)
+  let buffer = ${SelfType}(start: fakeStart, count: 4)
+
+  expectCrashLater()
+  _ = buffer.extracting(first: -1)
+}
+
+${SelfName}TestSuite.test("extracting(droppingLast:) bound checking")
+.require(.stdlib_6_5)
+.require(.crashTesting)
+.crashOutputMatches("Can't drop a negative number of ${'bytes' if IsRaw else 'elements'}")
+.code {
+  let fakeStart = ${PointerType}(bitPattern: 0xba0bab5)
+  let buffer = ${SelfType}(start: fakeStart, count: 4)
+
+  expectCrashLater()
+  _ = buffer.extracting(droppingLast: -1)
+}
+
+${SelfName}TestSuite.test("suffix extracting() functions")
+.require(.stdlib_6_5)
+.code {
+  let capacity = 4
+%   if IsRaw:
+  let memory = UnsafeMutableRawPointer.allocate(byteCount: capacity, alignment: 1)
+  defer { memory.deallocate() }
+  initUnsafeRawBufferPointer(
+    UnsafeMutableRawBufferPointer(start: memory, count: capacity))
+%   else:
+  let memory = UnsafeMutablePointer<Float>.allocate(capacity: capacity)
+  defer { memory.deallocate() }
+  initUnsafeBufferPointer(
+    UnsafeMutableBufferPointer(start: memory, count: capacity))
+%   end
+  let buffer = ${SelfType}(start: ${PointerType}(memory), count: capacity)
+
+  expectEqual(buffer.count, capacity)
+  expectEqual(buffer.extracting(last: capacity)[0], ${Element}(0))
+  expectEqual(buffer.extracting(last: capacity - 1)[0], ${Element}(1))
+  expectEqual(buffer.extracting(last: 1)[0], ${Element}(capacity - 1))
+  // Over-large maxLength clamps to count.
+  expectEqual(buffer.extracting(last: capacity + 5).count, capacity)
+
+  expectEqual(buffer.extracting(droppingFirst: capacity).count, 0)
+  expectEqual(buffer.extracting(droppingFirst: 1)[0], ${Element}(1))
+  // Over-large k clamps to count.
+  expectEqual(buffer.extracting(droppingFirst: capacity + 5).count, 0)
+
+  // Empty source.
+  let empty = ${SelfType}(start: nil, count: 0)
+  expectEqual(empty.extracting(last: 1).count, 0)
+  expectEqual(empty.extracting(droppingFirst: 1).count, 0)
+}
+
+${SelfName}TestSuite.test("extracting(last:) bound checking")
+.require(.stdlib_6_5)
+.require(.crashTesting)
+.crashOutputMatches("Can't have a suffix of negative length")
+.code {
+  let fakeStart = ${PointerType}(bitPattern: 0xba0bab5)
+  let buffer = ${SelfType}(start: fakeStart, count: 4)
+
+  expectCrashLater()
+  _ = buffer.extracting(last: -1)
+}
+
+${SelfName}TestSuite.test("extracting(droppingFirst:) bound checking")
+.require(.stdlib_6_5)
+.require(.crashTesting)
+.crashOutputMatches("Can't drop a negative number of ${'bytes' if IsRaw else 'elements'}")
+.code {
+  let fakeStart = ${PointerType}(bitPattern: 0xba0bab5)
+  let buffer = ${SelfType}(start: fakeStart, count: 4)
+
+  expectCrashLater()
+  _ = buffer.extracting(droppingFirst: -1)
+}
 % end # for SelfName, IsRaw, SelfType
 
 UnsafeMutableRawBufferPointerTestSuite.test("changeElementViaBuffer") {


### PR DESCRIPTION
Followup to https://github.com/swiftlang/swift/pull/82959, to complete the implementation of SE-0488.

Implements some missing `extracting()` functions for `UnsafeBufferPointer` & `UnsafeMutableBufferPointer`, implements all of the `extracting()` functions for `UnsafeRawBufferPointer` & `UnsafeMutableRawBufferPointer`, and rounds out the tests for the `extracting()` functions implementations of the Span family.

Addresses rdar://178912001