### PR TITLE
[Embedded] Drop dependencies on _swift_stdlib_* standard output entrypoints

### DIFF
--- a/stdlib/public/core/EmbeddedPrint.swift
+++ b/stdlib/public/core/EmbeddedPrint.swift
@@ -28,7 +28,7 @@ func putchar(_: CInt) -> CInt
 #endif
 
 
-private func writeChars(_ chars: UnsafeBufferPointer<UInt8>) {
+internal func writeChars(_ chars: UnsafeBufferPointer<UInt8>) {
 #if SWIFT_USE_EMBEDDED_SWIFT_PLATFORM
   _ = unsafe _swift_writeToStandardOutput(chars.baseAddress, chars.count)
 #else

--- a/stdlib/public/core/Exclusivity.swift
+++ b/stdlib/public/core/Exclusivity.swift
@@ -238,6 +238,7 @@ internal func _swift_exclusivityAccessSetNext(
 @c(swift_dumpTrackedAccesses)
 @usableFromInline
 @unsafe
+@_unavailableInEmbedded
 internal func swift_dumpTrackedAccesses() {
   if let head = unsafe accessHead {
     unsafe Access.forEach(head) {

--- a/stdlib/public/core/OutputStream.swift
+++ b/stdlib/public/core/OutputStream.swift
@@ -560,19 +560,29 @@ internal struct _Stdout: TextOutputStream {
   internal init() {}
 
   internal mutating func _lock() {
+    #if !$Embedded
     _swift_stdlib_flockfile_stdout()
+    #endif
   }
 
   internal mutating func _unlock() {
+    #if !$Embedded
     _swift_stdlib_funlockfile_stdout()
+    #endif
   }
 
   internal mutating func write(_ string: String) {
     if string.isEmpty { return }
 
     var string = string
-    _ = string.withUTF8 { utf8 in
-      unsafe _swift_stdlib_fwrite_stdout(utf8.baseAddress!, 1, utf8.count)
+    string.withUTF8 { utf8 in
+      #if $Embedded
+      // Route through the embedded platform's stdout entry point
+      // (in EmbeddedPrint.swift).
+      unsafe writeChars(utf8)
+      #else
+      _ = unsafe _swift_stdlib_fwrite_stdout(utf8.baseAddress!, 1, utf8.count)
+      #endif
     }
   }
 }


### PR DESCRIPTION
The functionality that depends on these functions isn't needed in Embedded Swift. Drop it from embedded swift so we don't have these hanging dependencies in the embedded standard library.