### PR TITLE
[Embedded] Mark _getSuperclass and readLine unavailable in Embedded Swift

### DIFF
--- a/stdlib/public/core/Builtin.swift
+++ b/stdlib/public/core/Builtin.swift
@@ -725,6 +725,7 @@ internal func _swift_class_getSuperclass(_ t: AnyClass) -> AnyClass?
 
 /// Returns the superclass of `t`, if any.  The result is `nil` if `t` is
 /// a root class or class protocol.
+@_unavailableInEmbedded
 public func _getSuperclass(_ t: AnyClass) -> AnyClass? {
   return _swift_class_getSuperclass(t)
 }
@@ -733,6 +734,7 @@ public func _getSuperclass(_ t: AnyClass) -> AnyClass? {
 /// not a class, is a root class, or is a class protocol.
 @inlinable
 @inline(__always)
+@_unavailableInEmbedded
 public // @testable
 func _getSuperclass(_ t: Any.Type) -> AnyClass? {
   return (t as? AnyClass).flatMap { _getSuperclass($0) }

--- a/stdlib/public/core/InputStream.swift
+++ b/stdlib/public/core/InputStream.swift
@@ -28,6 +28,7 @@ import SwiftShims
 ///   or character combinations are preserved. The default is `true`.
 /// - Returns: The string of characters read from standard input. If EOF has
 ///   already been reached when `readLine()` is called, the result is `nil`.
+@_unavailableInEmbedded
 public func readLine(strippingNewline: Bool = true) -> String? {
   var utf8Start: UnsafeMutablePointer<UInt8>?
   let utf8Count = unsafe swift_stdlib_readLine_stdin(&utf8Start)

--- a/test/embedded/unicode-dead-strip4.swift
+++ b/test/embedded/unicode-dead-strip4.swift
@@ -8,20 +8,6 @@
 // REQUIRES: swift_feature_Embedded
 // REQUIRES: swift_feature_Extern
 
-@_extern(c, "getline")
-func getline(
-  _ linePointer: UnsafeMutablePointer<UnsafeMutablePointer<UInt8>?>?,
-  _ linecapp: UnsafeMutablePointer<UInt>?,
-  _ stream: UnsafeRawPointer?
-) -> Int
-
-@c
-func swift_stdlib_readLine_stdin(_ linePointer: UnsafeMutablePointer<UnsafeMutablePointer<UInt8>?>?) -> Int {
-  return getline(linePointer, nil, nil)
-}
-
-
-
 @main
 struct Main {
   static func main() {
@@ -35,10 +21,6 @@ struct Main {
     print(b1 ?? false)
     print(b2 ?? false)
     print(b3 ?? false)
-
-    if let value = readLine(), let b4 = Bool(value) {
-      print(b4)
-    }
 
     let bi: StaticBigInt = 17
     print(bi.debugDescription)


### PR DESCRIPTION
The former isn't really needed in Embedded, and the latter needs standard input to make any sense. We can re-enable these once we have clear platform requirements for them.