### PR TITLE
[Sema] Diagnose nested assignment under optional chaining

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -6817,6 +6817,14 @@ bool ConstraintSystem::repairFailures(
                                 locator))
       return true;
 
+    if (auto *oee = getAsExpr<OptionalEvaluationExpr>(locator.getAnchor())) {
+      if (auto *assign = dyn_cast<AssignExpr>(oee->getSubExpr())) {
+        conversionsOrFixes.push_back(IgnoreAssignmentDestinationType::create(
+            *this, lhs, rhs, getConstraintLocator(assign)));
+        return true;
+      }
+    }
+
     if (path.size() > 1) {
       path.pop_back();
       if (path.back().is<LocatorPathElt::SequenceElementType>()) {

--- a/test/Constraints/assignment.swift
+++ b/test/Constraints/assignment.swift
@@ -101,3 +101,61 @@ func testFunctionAssignsWithOptionals(fn: @escaping () -> () -> Void) {
   let _: (() -> () -> Super)? = b
   let _: (() -> () -> Super)?? = b
 }
+
+final class NestedAssignmentA {
+  var x: Int?
+}
+
+func testNestedAssignmentWithOptionalChaining(a: NestedAssignmentA?) {
+  a?.x = a?.x = 1 // expected-error {{cannot assign value of type '()' to type 'Int'}}
+}
+
+final class NestedAssignmentC {}
+
+final class NestedAssignmentB {
+  var x: NestedAssignmentC?
+}
+
+final class NestedAssignmentContainer {
+  var a: NestedAssignmentB?
+}
+
+func testNestedAssignmentThroughMemberChain(
+    b: NestedAssignmentContainer,
+    c: NestedAssignmentC
+) {
+  b.a?.x = b.a?.x = c // expected-error {{cannot assign value of type '()' to type 'NestedAssignmentC'}}
+}
+
+struct NestedAssignmentS {
+  var x: Int?
+}
+
+func testNestedAssignmentWithInOutOptional(
+    s: inout NestedAssignmentS?
+) {
+  s?.x = s?.x = 1 // expected-error {{cannot assign value of type '()' to type 'Int'}}
+}
+
+final class NestedAssignmentParenA {}
+final class NestedAssignmentParenB {
+  var x: NestedAssignmentParenA?
+}
+final class NestedAssignmentParenContainer {
+  var a: NestedAssignmentParenB?
+}
+func testNestedAssignmentWithParenthesizedInnerAssign(
+    b: NestedAssignmentParenContainer,
+    c: NestedAssignmentParenA
+) {
+  b.a?.x = (b.a?.x = c) // expected-error {{cannot assign value of type '()' to type 'NestedAssignmentParenA'}}
+}
+
+final class NestedAssignmentLegalA {
+  var x: Int?
+}
+func testOptionalChainedAssignmentWithOptionalRHSIsLegal(
+    a: NestedAssignmentLegalA?
+) {
+  a?.x = a?.x
+}


### PR DESCRIPTION
### Issue 
Expressions of the form `a?.x = a?.x = 1` (using an assignment as the right-hand side of another assignment under optional chaining) emitted "failed to produce diagnostic for expression" instead of a normal type error. The same failure occurred for member-chain variants `(b.a?.x = b.a?.x = c)`, inout optional structs `(s?.x = s?.x = 1)`, and parenthesized inner assignments `(b.a?.x = (b.a?.x = c))`.

### Changes
Adds a recovery path for assignment expressions wrapped by OptionalEvaluationExpr, allowing the compiler to emit a normal diagnostic instead of failing to diagnose the expression.  Regression tests were also added.

### Before
These examples show different forms of the original failure. The final example is a control case that compiles successfully and demonstrates expected behaviour.

```
% cat s01.swift
final class A {
  var x: Int?
}

func test(a: A?) {
  a?.x = a?.x = 1
}

% swiftc -typecheck s01.swift
s01.swift:6:8: error: failed to produce diagnostic for expression; please submit a bug report (https://swift.org/contributing/#reporting-bugs)
4 |
5 | func test(a: A?) {
6 |   a?.x = a?.x = 1
  |        `- error: failed to produce diagnostic for expression; please submit a bug report (https://swift.org/contributing/#reporting-bugs)
7 | }
8 |

% cat s02.swift
final class C {}

final class A {
  var x: C?
}

final class B {
  var a: A?
}

func test(b: B, c: C) {
  b.a?.x = b.a?.x = c
}

% swiftc -typecheck s02.swift
s02.swift:12:10: error: failed to produce diagnostic for expression; please submit a bug report (https://swift.org/contributing/#reporting-bugs)
10 |
11 | func test(b: B, c: C) {
12 |   b.a?.x = b.a?.x = c
   |          `- error: failed to produce diagnostic for expression; please submit a bug report (https://swift.org/contributing/#reporting-bugs)
13 | }
14 |

% cat s03.swift
struct S {
  var x: Int?
}

func test(s: inout S?) {
  s?.x = s?.x = 1
}

% swiftc -typecheck s03.swift
s03.swift:6:8: error: failed to produce diagnostic for expression; please submit a bug report (https://swift.org/contributing/#reporting-bugs)
4 |
5 | func test(s: inout S?) {
6 |   s?.x = s?.x = 1
  |        `- error: failed to produce diagnostic for expression; please submit a bug report (https://swift.org/contributing/#reporting-bugs)
7 | }
8 |

% cat s04.swift
final class C {}

final class A {
  var x: C?
}

final class B {
  var a: A?
}

func test(b: B, c: C) {
  b.a?.x = (b.a?.x = c)
}

% swiftc -typecheck s04.swift
s04.swift:12:10: error: failed to produce diagnostic for expression; please submit a bug report (https://swift.org/contributing/#reporting-bugs)
10 |
11 | func test(b: B, c: C) {
12 |   b.a?.x = (b.a?.x = c)
   |          `- error: failed to produce diagnostic for expression; please submit a bug report (https://swift.org/contributing/#reporting-bugs)
13 | }
14 |

% cat s05.swift
final class A {
  var x: Int?
}

func test(a: A?) {
  a?.x = a?.x
}

% swiftc -typecheck s05.swift


```

### After
The compiler now emits a normal type mismatch diagnostic instead of failing to produce a diagnostic.

```
% cat s01.swift
final class A {
  var x: Int?
}

func test(a: A?) {
  a?.x = a?.x = 1
}

% swiftc -typecheck s01.swift
s01.swift:6:17: error: cannot assign value of type '()' to type 'Int'
4 |
5 | func test(a: A?) {
6 |   a?.x = a?.x = 1
  |                 `- error: cannot assign value of type '()' to type 'Int'
7 | }
8 |

% cat s02.swift
final class C {}

final class A {
  var x: C?
}

final class B {
  var a: A?
}

func test(b: B, c: C) {
  b.a?.x = b.a?.x = c
}

% swiftc -typecheck s02.swift
s02.swift:12:21: error: cannot assign value of type '()' to type 'C'
10 |
11 | func test(b: B, c: C) {
12 |   b.a?.x = b.a?.x = c
   |                     `- error: cannot assign value of type '()' to type 'C'
13 | }
14 |

% cat s03.swift
struct S {
  var x: Int?
}

func test(s: inout S?) {
  s?.x = s?.x = 1
}
% swiftc -typecheck s03.swift
s03.swift:6:17: error: cannot assign value of type '()' to type 'Int'
4 |
5 | func test(s: inout S?) {
6 |   s?.x = s?.x = 1
  |                 `- error: cannot assign value of type '()' to type 'Int'
7 | }
8 |

% cat s04.swift
final class C {}

final class A {
  var x: C?
}

final class B {
  var a: A?
}

func test(b: B, c: C) {
  b.a?.x = (b.a?.x = c)
}

% swiftc -typecheck s04.swift
s04.swift:12:22: error: cannot assign value of type '()' to type 'C'
10 |
11 | func test(b: B, c: C) {
12 |   b.a?.x = (b.a?.x = c)
   |                      `- error: cannot assign value of type '()' to type 'C'
13 | }
14 |

% cat s05.swift
final class A {
  var x: Int?
}

func test(a: A?) {
  a?.x = a?.x
}

% swiftc -typecheck s05.swift
```