### PR TITLE
[Embedded] Build the concurrency library as hosted again

### DIFF
--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -401,7 +401,7 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB AND SWIFT_SHOULD_BUILD_EMBEDDED_CONCURRENC
         -Xfrontend -emit-empty-object-file
         ${SWIFT_RUNTIME_CONCURRENCY_SWIFT_FLAGS}
       C_COMPILE_FLAGS
-        ${extra_c_compile_flags} ${SWIFT_RUNTIME_CONCURRENCY_C_FLAGS} -DSWIFT_CONCURRENCY_EMBEDDED=1 -DSWIFT_RUNTIME_EMBEDDED=1 -ffreestanding
+        ${extra_c_compile_flags} ${SWIFT_RUNTIME_CONCURRENCY_C_FLAGS} -DSWIFT_CONCURRENCY_EMBEDDED=1 -DSWIFT_RUNTIME_EMBEDDED=1
         -ffunction-sections -fdata-sections -fno-exceptions -fno-cxx-exceptions -fno-unwind-tables
       MODULE_DIR "${CMAKE_BINARY_DIR}/lib/swift/embedded"
       SDK "embedded"
@@ -439,7 +439,7 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB AND SWIFT_SHOULD_BUILD_EMBEDDED_CONCURRENC
 
       CooperativeGlobalExecutor.cpp
 
-      C_COMPILE_FLAGS ${extra_c_compile_flags} -ffreestanding
+      C_COMPILE_FLAGS ${extra_c_compile_flags}
       MODULE_DIR "${CMAKE_BINARY_DIR}/lib/swift/embedded"
       SDK "embedded"
       ARCHITECTURE "${mod}"


### PR DESCRIPTION
There are still more hosted dependencies in the concurrency library + cooperative global executor, which is causing breakage on some new C++ library implementations. Go back to hosted until we sort those out.
