### PR TITLE
[RemoteInspection] Fix existential metatypes in DemanglingForTypeRef

### DIFF
--- a/stdlib/public/RemoteInspection/TypeRef.cpp
+++ b/stdlib/public/RemoteInspection/TypeRef.cpp
@@ -1074,7 +1074,7 @@ public:
 
   Demangle::NodePointer
   visitExistentialMetatypeTypeRef(const ExistentialMetatypeTypeRef *EM) {
-    auto node = Dem.createNode(Node::Kind::Metatype);
+    auto node = Dem.createNode(Node::Kind::ExistentialMetatype);
     node->addChild(visit(EM->getInstanceType()), Dem);
     return node;
   }

--- a/validation-test/Reflection/reflect_existential_metatype.swift
+++ b/validation-test/Reflection/reflect_existential_metatype.swift
@@ -1,0 +1,28 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_existential_metatype
+// RUN: %target-codesign %t/reflect_existential_metatype
+// RUN: %target-run %target-swift-reflection-test %t/reflect_existential_metatype | %FileCheck %s
+
+// REQUIRES: reflection_test_support
+// REQUIRES: executable_test
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: asan
+
+// An existential metatype `P.Type` must reflect as `.Type`, not `.Protocol`
+// (`P.Protocol` is the distinct protocol metatype).
+
+import SwiftReflectionTest
+
+protocol MyProto {}
+
+class Box<T> {}
+
+reflect(any: Box<any MyProto.Type>())
+
+// CHECK: Reflecting an existential.
+// CHECK: Type reference:
+// CHECK: (bound_generic_class {{.*}}Box
+// CHECK: (existential_metatype
+// CHECK: Demangled name: {{.*}}Box<{{.*}}MyProto.Type>
+
+doneReflecting()


### PR DESCRIPTION
RemoteMirror's `swift_reflection_copyDemangledNameForTypeRef` renders an existential metatype `P.Type` as `P.Protocol`. Reflecting `Box<any MyProto.Type>`, for instance, prints `module.Box<module.MyProto.Protocol>`

This only affects the TypeRef -> demangle-node rebuild that RemoteMirror and swift-inspect use. The string-path demanglers (`swift-demangle`, `swift_reflection_demangle`) already render `.Type` correctly

`DemanglingForTypeRef::visitExistentialMetatypeTypeRef` built a `Metatype` node instead of `ExistentialMetatype`, so it’s a 1-line fix

Adds a reflection regression test under `validation-test/Reflection/`