### PR TITLE
Mark `CustomStringConvertible` and other String support types and functions as being `~Copyable & ~Escapable`

### DIFF
--- a/stdlib/private/StdlibUnittest/StringConvertible.swift
+++ b/stdlib/private/StdlibUnittest/StringConvertible.swift
@@ -138,6 +138,36 @@ public func expectPrinted<T>(
     stackTrace: stackTrace.pushIf(showFrame, file: file, line: line))
 }
 
+@_disfavoredOverload
+public func expectPrinted<T: CustomStringConvertible & ~Copyable & ~Escapable>(
+  expectedOneOf patterns: [String], _ object: borrowing T,
+  _ message: @autoclosure () -> String = "",
+  stackTrace: SourceLocStack = SourceLocStack(),
+  showFrame: Bool = true,
+  file: String = #file, line: UInt = #line
+) {
+  let actual = String(describing: object)
+  if !patterns.contains(actual) {
+    expectationFailure(
+      "expected: any of \(String(reflecting: patterns))\n"
+      + "actual: \(String(reflecting: actual))",
+      trace: message(),
+      stackTrace: stackTrace.pushIf(showFrame, file: file, line: line))
+  }
+}
+
+@_disfavoredOverload
+public func expectPrinted<T: CustomStringConvertible & ~Copyable & ~Escapable>(
+  _ expected: String, _ object: borrowing T,
+  _ message: @autoclosure () -> String = "",
+  stackTrace: SourceLocStack = SourceLocStack(),
+  showFrame: Bool = true,
+  file: String = #file, line: UInt = #line
+) {
+  expectPrinted(expectedOneOf: [expected], object, message(),
+    stackTrace: stackTrace.pushIf(showFrame, file: file, line: line))
+}
+
 public func expectDebugPrinted<T>(
   expectedOneOf patterns: [String], _ object: T,
   _ message: @autoclosure () -> String = "",

--- a/stdlib/public/core/Mirror.swift
+++ b/stdlib/public/core/Mirror.swift
@@ -581,6 +581,7 @@ extension String {
   ///
   ///     print(String(describing: p))
   ///     // Prints "(21, 30)"
+  @_disfavoredOverload
   public init<Subject>(describing instance: Subject) {
     self.init()
     _print_unlocked(instance, &self)
@@ -639,6 +640,17 @@ extension String {
 
   /// Creates a string representing the given value.
   ///
+  /// This overload borrows a noncopyable or nonescapable `instance` instead of
+  /// consuming it. See `init(describing:)` for the full discussion.
+  @_alwaysEmitIntoClient @_disfavoredOverload
+  public init<
+    Subject: CustomStringConvertible & ~Copyable & ~Escapable
+  >(describing instance: borrowing Subject) {
+    self = instance.description
+  }
+
+  /// Creates a string representing the given value.
+  ///
   /// Use this initializer to convert an instance of any type to its preferred
   /// representation as a `String` instance. The initializer creates the
   /// string representation of `instance` in one of the following ways,
@@ -678,6 +690,18 @@ extension String {
   ///     // Prints "(21, 30)"
   @inlinable
   public init<Subject: TextOutputStreamable>(describing instance: Subject) {
+    self.init()
+    instance.write(to: &self)
+  }
+
+  /// Creates a string representing the given value.
+  ///
+  /// This overload borrows a noncopyable or nonescapable `instance` instead of
+  /// consuming it. See `init(describing:)` for the full discussion.
+  @_alwaysEmitIntoClient @_disfavoredOverload
+  public init<
+    Subject: TextOutputStreamable & ~Copyable & ~Escapable
+  >(describing instance: borrowing Subject) {
     self.init()
     instance.write(to: &self)
   }
@@ -724,6 +748,18 @@ extension String {
   @inlinable
   public init<Subject>(describing instance: Subject)
     where Subject: CustomStringConvertible & TextOutputStreamable
+  {
+    self = instance.description
+  }
+
+  /// Creates a string representing the given value.
+  ///
+  /// This overload borrows a noncopyable or nonescapable `instance` instead of
+  /// consuming it. See `init(describing:)` for the full discussion.
+  @_alwaysEmitIntoClient @_disfavoredOverload
+  public init<
+    Subject: CustomStringConvertible & TextOutputStreamable & ~Copyable & ~Escapable
+  >(describing instance: borrowing Subject)
   {
     self = instance.description
   }
@@ -775,6 +811,7 @@ extension String {
   ///
   ///     print(String(reflecting: p))
   ///     // Prints "Point(x: 21, y: 30)"
+  @_disfavoredOverload
   public init<Subject>(reflecting subject: Subject) {
     self.init()
     _debugPrint_unlocked(subject, &self)

--- a/stdlib/public/core/OutputStream.swift
+++ b/stdlib/public/core/OutputStream.swift
@@ -99,7 +99,7 @@ extension TextOutputStream {
 /// To add `TextOutputStreamable` conformance to a custom type, implement the
 /// required `write(to:)` method. Call the given output stream's `write(_:)`
 /// method in your implementation.
-public protocol TextOutputStreamable {
+public protocol TextOutputStreamable: ~Copyable & ~Escapable {
   /// Writes a textual representation of this instance into the given output
   /// stream.
   func write<Target: TextOutputStream>(to target: inout Target)
@@ -147,7 +147,7 @@ public protocol TextOutputStreamable {
 ///
 ///     print(p)
 ///     // Prints "(21, 30)"
-public protocol CustomStringConvertible {
+public protocol CustomStringConvertible: ~Copyable & ~Escapable {
   /// A textual representation of this instance.
   ///
   /// Calling this property directly is discouraged. Instead, convert an
@@ -239,7 +239,7 @@ public protocol LosslessStringConvertible: CustomStringConvertible {
 ///
 ///     print(String(reflecting: p))
 ///     // Prints "(21, 30)"
-public protocol CustomDebugStringConvertible {
+public protocol CustomDebugStringConvertible: ~Copyable & ~Escapable {
   /// A textual representation of this instance, suitable for debugging.
   ///
   /// Calling this property directly is discouraged. Instead, convert an

--- a/stdlib/public/core/StringInterpolation.swift
+++ b/stdlib/public/core/StringInterpolation.swift
@@ -105,8 +105,10 @@ public struct DefaultStringInterpolation: StringInterpolationProtocol, Sendable 
   ///     print(message)
   ///     // Prints "If one cookie costs 2 dollars, 3 cookies cost 6 dollars."
   @inlinable
-  public mutating func appendInterpolation<T>(_ value: T)
-    where T: TextOutputStreamable, T: CustomStringConvertible
+  @_preInverseGenerics
+  public mutating func appendInterpolation<
+    T: TextOutputStreamable & CustomStringConvertible & ~Copyable & ~Escapable
+  >(_ value: borrowing T)
   {
     value.write(to: &self)
   }
@@ -127,8 +129,10 @@ public struct DefaultStringInterpolation: StringInterpolationProtocol, Sendable 
   ///     print(message)
   ///     // Prints "If one cookie costs 2 dollars, 3 cookies cost 6 dollars."
   @inlinable
-  public mutating func appendInterpolation<T>(_ value: T)
-    where T: TextOutputStreamable
+  @_preInverseGenerics
+  public mutating func appendInterpolation<
+    T: TextOutputStreamable & ~Copyable & ~Escapable
+  >(_ value: borrowing T)
   {
     value.write(to: &self)
   }
@@ -151,8 +155,10 @@ public struct DefaultStringInterpolation: StringInterpolationProtocol, Sendable 
   ///     print(message)
   ///     // Prints "If one cookie costs 2 dollars, 3 cookies cost 6 dollars."
   @inlinable
-  public mutating func appendInterpolation<T>(_ value: T)
-    where T: CustomStringConvertible
+  @_preInverseGenerics
+  public mutating func appendInterpolation<
+    T: CustomStringConvertible & ~Copyable & ~Escapable
+  >(_ value: borrowing T)
   {
     value.description.write(to: &self)
   }
@@ -175,7 +181,7 @@ public struct DefaultStringInterpolation: StringInterpolationProtocol, Sendable 
   ///     print(message)
   ///     // Prints "If one cookie costs 2 dollars, 3 cookies cost 6 dollars."
   @inlinable
-  public mutating func appendInterpolation<T>(_ value: T) {
+  public mutating func appendInterpolation<T>(_ value: borrowing T) {
     #if !$Embedded
     _print_unlocked(value, &self)
     #else
@@ -217,13 +223,16 @@ extension DefaultStringInterpolation {
   ///   - value: The value to include in a string interpolation, if non-`nil`.
   ///   - default: The string to include if `value` is `nil`.
   @_alwaysEmitIntoClient
-  public mutating func appendInterpolation<T>(
-    _ value: T?,
+  public mutating func appendInterpolation<
+    T: TextOutputStreamable & CustomStringConvertible & ~Copyable & ~Escapable
+  >(
+    _ value: borrowing T?,
     default: @autoclosure () -> some StringProtocol
-  ) where T: TextOutputStreamable, T: CustomStringConvertible {
-    if let value {
+  ) {
+    switch value {
+    case let value?:
       self.appendInterpolation(value)
-    } else {
+    case nil:
       self.appendInterpolation(`default`())
     }
   }
@@ -247,13 +256,16 @@ extension DefaultStringInterpolation {
   ///   - value: The value to include in a string interpolation, if non-`nil`.
   ///   - default: The string to include if `value` is `nil`.
   @_alwaysEmitIntoClient
-  public mutating func appendInterpolation<T>(
-    _ value: T?,
+  public mutating func appendInterpolation<
+    T: TextOutputStreamable & ~Copyable & ~Escapable
+  >(
+    _ value: borrowing T?,
     default: @autoclosure () -> some StringProtocol
-  ) where T: TextOutputStreamable {
-    if let value {
+  ) {
+    switch value {
+    case let value?:
       self.appendInterpolation(value)
-    } else {
+    case nil:
       self.appendInterpolation(`default`())
     }
   }
@@ -277,13 +289,16 @@ extension DefaultStringInterpolation {
   ///   - value: The value to include in a string interpolation, if non-`nil`.
   ///   - default: The string to include if `value` is `nil`.
   @_alwaysEmitIntoClient
-  public mutating func appendInterpolation<T>(
-    _ value: T?, 
+  public mutating func appendInterpolation<
+    T: CustomStringConvertible & ~Copyable & ~Escapable
+  >(
+    _ value: borrowing T?,
     default: @autoclosure () -> some StringProtocol
-  ) where T: CustomStringConvertible {
-    if let value {
+  ) {
+    switch value {
+    case let value?:
       self.appendInterpolation(value)
-    } else {
+    case nil:
       self.appendInterpolation(`default`())
     }
   }
@@ -311,9 +326,10 @@ extension DefaultStringInterpolation {
     _ value: T?, 
     default: @autoclosure () -> some StringProtocol
   ) {
-    if let value {
+    switch value {
+    case let value?:
       self.appendInterpolation(value)
-    } else {
+    case nil:
       self.appendInterpolation(`default`())
     }
   }

--- a/test/api-digester/Outputs/stability-stdlib-source-base.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-source-base.swift.expected
@@ -96,16 +96,12 @@ Protocol CodingKey has added inherited protocol Copyable
 Protocol CodingKey has added inherited protocol Escapable
 Protocol Collection has added inherited protocol Copyable
 Protocol Collection has added inherited protocol Escapable
-Protocol CustomDebugStringConvertible has added inherited protocol Copyable
-Protocol CustomDebugStringConvertible has added inherited protocol Escapable
 Protocol CustomLeafReflectable has added inherited protocol Copyable
 Protocol CustomLeafReflectable has added inherited protocol Escapable
 Protocol CustomPlaygroundDisplayConvertible has added inherited protocol Copyable
 Protocol CustomPlaygroundDisplayConvertible has added inherited protocol Escapable
 Protocol CustomReflectable has added inherited protocol Copyable
 Protocol CustomReflectable has added inherited protocol Escapable
-Protocol CustomStringConvertible has added inherited protocol Copyable
-Protocol CustomStringConvertible has added inherited protocol Escapable
 Protocol Decodable has added inherited protocol Copyable
 Protocol Decodable has added inherited protocol Escapable
 Protocol Decoder has added inherited protocol Copyable
@@ -197,8 +193,6 @@ Protocol StringProtocol has added inherited protocol Copyable
 Protocol StringProtocol has added inherited protocol Escapable
 Protocol TextOutputStream has added inherited protocol Copyable
 Protocol TextOutputStream has added inherited protocol Escapable
-Protocol TextOutputStreamable has added inherited protocol Copyable
-Protocol TextOutputStreamable has added inherited protocol Escapable
 Protocol UnicodeCodec has added inherited protocol Copyable
 Protocol UnicodeCodec has added inherited protocol Escapable
 Protocol UnkeyedDecodingContainer has added inherited protocol Copyable
@@ -260,6 +254,10 @@ Enum Optional has generic signature change from <Wrapped> to <Wrapped where Wrap
 Enum Result has generic signature change from <Success, Failure where Failure : Swift.Error> to <Success, Failure where Failure : Swift.Error, Success : ~Copyable, Success : ~Escapable>
 Func ??(_:_:) has generic signature change from <T> to <T where T : ~Copyable>
 Func ??(_:_:) has parameter 0 changing from Default to Owned
+Func DefaultStringInterpolation.appendInterpolation(_:) has generic signature change from <T where T : Swift.CustomStringConvertible, T : Swift.TextOutputStreamable> to <T where T : Swift.CustomStringConvertible, T : Swift.TextOutputStreamable, T : ~Copyable, T : ~Escapable>
+Func DefaultStringInterpolation.appendInterpolation(_:) has generic signature change from <T where T : Swift.CustomStringConvertible> to <T where T : Swift.CustomStringConvertible, T : ~Copyable, T : ~Escapable>
+Func DefaultStringInterpolation.appendInterpolation(_:) has generic signature change from <T where T : Swift.TextOutputStreamable> to <T where T : Swift.TextOutputStreamable, T : ~Copyable, T : ~Escapable>
+Func DefaultStringInterpolation.appendInterpolation(_:) has parameter 0 changing from Default to Shared
 Func ManagedBuffer.create(minimumCapacity:makingHeaderWith:) has generic signature change from <Header, Element> to <Header, Element where Element : ~Copyable>
 Func ManagedBufferPointer.isUniqueReference() has generic signature change from <Header, Element> to <Header, Element where Element : ~Copyable>
 Func MemoryLayout.alignment(ofValue:) has generic signature change from <T> to <T where T : ~Copyable, T : ~Escapable>
@@ -279,6 +277,7 @@ Func Optional.~=(_:_:) has parameter 1 changing from Default to Shared
 Func Result.get() has generic signature change from <Success, Failure where Failure : Swift.Error> to <Success, Failure where Failure : Swift.Error, Success : ~Copyable, Success : ~Escapable>
 Func Result.get() has self access kind changing from NonMutating to Consuming
 Func Result.mapError(_:) has self access kind changing from NonMutating to Consuming
+Func TextOutputStreamable.write(to:) has generic signature change from <Self, Target where Self : Swift.TextOutputStreamable, Target : Swift.TextOutputStream> to <Self, Target where Self : Swift.TextOutputStreamable, Target : Swift.TextOutputStream, Self : ~Copyable, Self : ~Escapable>
 Func UnsafeBufferPointer.deallocate() has generic signature change from <Element> to <Element where Element : ~Copyable>
 Func UnsafeBufferPointer.distance(from:to:) has generic signature change from <Element> to <Element where Element : ~Copyable>
 Func UnsafeBufferPointer.formIndex(after:) has generic signature change from <Element> to <Element where Element : ~Copyable>
@@ -443,6 +442,10 @@ Accessor Hashable.hashValue.Get() has generic signature change from <Self where 
 Func Hashable.hash(into:) has generic signature change from <Self where Self : Swift.Hashable> to <Self where Self : Swift.Hashable, Self : ~Copyable, Self : ~Escapable>
 Func Hasher.combine(_:) has generic signature change from <H where H : Swift.Hashable> to <H where H : Swift.Hashable, H : ~Copyable, H : ~Escapable>
 Func Hasher.combine(_:) has parameter 0 changing from Default to Shared
+
+// CustomStringConvertible & CustomDebugStringConvertible: ~Copyable & ~Escapable
+Accessor CustomStringConvertible.description.Get() has generic signature change from <Self where Self : Swift.CustomStringConvertible> to <Self where Self : Swift.CustomStringConvertible, Self : ~Copyable, Self : ~Escapable>
+Accessor CustomDebugStringConvertible.debugDescription.Get() has generic signature change from <Self where Self : Swift.CustomDebugStringConvertible> to <Self where Self : Swift.CustomDebugStringConvertible, Self : ~Copyable, Self : ~Escapable>
 
 Func Sequence.reduce(_:_:) has generic signature change from <Self, Result where Self : Swift.Sequence> to <Self, Result where Self : Swift.Sequence, Result : ~Copyable>
 Func Sequence.reduce(_:_:) has parameter 0 changing from Default to Owned

--- a/test/api-digester/stability-stdlib-abi-without-asserts.test
+++ b/test/api-digester/stability-stdlib-abi-without-asserts.test
@@ -206,16 +206,12 @@ Protocol CodingKey has added inherited protocol Copyable
 Protocol CodingKey has added inherited protocol Escapable
 Protocol Collection has added inherited protocol Copyable
 Protocol Collection has added inherited protocol Escapable
-Protocol CustomDebugStringConvertible has added inherited protocol Copyable
-Protocol CustomDebugStringConvertible has added inherited protocol Escapable
 Protocol CustomLeafReflectable has added inherited protocol Copyable
 Protocol CustomLeafReflectable has added inherited protocol Escapable
 Protocol CustomPlaygroundDisplayConvertible has added inherited protocol Copyable
 Protocol CustomPlaygroundDisplayConvertible has added inherited protocol Escapable
 Protocol CustomReflectable has added inherited protocol Copyable
 Protocol CustomReflectable has added inherited protocol Escapable
-Protocol CustomStringConvertible has added inherited protocol Copyable
-Protocol CustomStringConvertible has added inherited protocol Escapable
 Protocol Decodable has added inherited protocol Copyable
 Protocol Decodable has added inherited protocol Escapable
 Protocol Decoder has added inherited protocol Copyable
@@ -306,8 +302,6 @@ Protocol StringProtocol has added inherited protocol Copyable
 Protocol StringProtocol has added inherited protocol Escapable
 Protocol TextOutputStream has added inherited protocol Copyable
 Protocol TextOutputStream has added inherited protocol Escapable
-Protocol TextOutputStreamable has added inherited protocol Copyable
-Protocol TextOutputStreamable has added inherited protocol Escapable
 Protocol UnicodeCodec has added inherited protocol Copyable
 Protocol UnicodeCodec has added inherited protocol Escapable
 Protocol UnkeyedDecodingContainer has added inherited protocol Copyable
@@ -788,5 +782,17 @@ Func Hasher.combine(_:) is now with @_preInverseGenerics
 Func _hashValue(for:) has generic signature change from <H where H : Swift.Hashable> to <H where H : Swift.Hashable, H : ~Copyable, H : ~Escapable>
 Func _hashValue(for:) has parameter 0 changing from Default to Shared
 Func _hashValue(for:) is now with @_preInverseGenerics
+
+// CustomStringConvertible & CustomDebugStringConvertible: ~Copyable & ~Escapable
+Accessor CustomStringConvertible.description.Get() has generic signature change from <Self where Self : Swift.CustomStringConvertible> to <Self where Self : Swift.CustomStringConvertible, Self : ~Copyable, Self : ~Escapable>
+Accessor CustomDebugStringConvertible.debugDescription.Get() has generic signature change from <Self where Self : Swift.CustomDebugStringConvertible> to <Self where Self : Swift.CustomDebugStringConvertible, Self : ~Copyable, Self : ~Escapable>
+
+// TextOutputStreamable & DefaultStringInterpolation.appendInterpolation: ~Copyable & ~Escapable
+Func TextOutputStreamable.write(to:) has generic signature change from <Self, Target where Self : Swift.TextOutputStreamable, Target : Swift.TextOutputStream> to <Self, Target where Self : Swift.TextOutputStreamable, Target : Swift.TextOutputStream, Self : ~Copyable, Self : ~Escapable>
+Func DefaultStringInterpolation.appendInterpolation(_:) has generic signature change from <T where T : Swift.CustomStringConvertible, T : Swift.TextOutputStreamable> to <T where T : Swift.CustomStringConvertible, T : Swift.TextOutputStreamable, T : ~Copyable, T : ~Escapable>
+Func DefaultStringInterpolation.appendInterpolation(_:) has generic signature change from <T where T : Swift.CustomStringConvertible> to <T where T : Swift.CustomStringConvertible, T : ~Copyable, T : ~Escapable>
+Func DefaultStringInterpolation.appendInterpolation(_:) has generic signature change from <T where T : Swift.TextOutputStreamable> to <T where T : Swift.TextOutputStreamable, T : ~Copyable, T : ~Escapable>
+Func DefaultStringInterpolation.appendInterpolation(_:) has parameter 0 changing from Default to Shared
+Func DefaultStringInterpolation.appendInterpolation(_:) is now with @_preInverseGenerics
 
 // *** DO NOT DISABLE OR XFAIL THIS TEST. *** (See comment above.)

--- a/test/attr/attr_abi.swift
+++ b/test/attr/attr_abi.swift
@@ -1024,7 +1024,7 @@ func testNormalProtocols(
 ) {}
 
 @abi(
-  func testNormalProtocolsGeneric<A, B: CustomStringConvertible>( // expected-error {{generic signature '<A, B where A : Copyable, A : Escapable, B : CustomStringConvertible>' in '@abi' is not compatible with '<A, B where A : CustomStringConvertible, B : Copyable, B : Escapable>'}}
+  func testNormalProtocolsGeneric<A, B: CustomStringConvertible>( // expected-error {{generic signature '<A, B where A : Copyable, A : Escapable, B : Copyable, B : CustomStringConvertible, B : Escapable>' in '@abi' is not compatible with '<A, B where A : Copyable, A : CustomStringConvertible, A : Escapable, B : Copyable, B : Escapable>'}}
     _: A, _: B
   )
 )

--- a/test/stdlib/NoncopyableCustomStringConvertible.swift
+++ b/test/stdlib/NoncopyableCustomStringConvertible.swift
@@ -1,0 +1,144 @@
+//===--- NoncopyableCustomStringConvertible.swift ------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+// RUN: %target-run-simple-swift(-enable-experimental-feature Lifetimes)
+// REQUIRES: executable_test
+// REQUIRES: swift_feature_Lifetimes
+
+import StdlibUnittest
+
+let NoncopyableCustomStringConvertibleTests =
+  TestSuite("NoncopyableCustomStringConvertible")
+
+struct Noncopyable<Wrapped: ~Copyable & ~Escapable>: ~Copyable, ~Escapable {
+  var wrapped: Wrapped
+
+  @_lifetime(copy wrapped)
+  init(wrapping wrapped: consuming Wrapped) {
+    self.wrapped = wrapped
+  }
+}
+
+extension Noncopyable: CustomStringConvertible
+where Wrapped: CustomStringConvertible & ~Copyable & ~Escapable {
+  var description: String { "N(\(wrapped.description))" }
+}
+
+extension Noncopyable: CustomDebugStringConvertible
+where Wrapped: CustomDebugStringConvertible & ~Copyable & ~Escapable {
+  var debugDescription: String { "N[\(wrapped.debugDescription)]" }
+}
+
+extension Noncopyable: Escapable where Wrapped: Escapable & ~Copyable { }
+
+struct Nonescapable: ~Escapable {
+  let value: Int
+}
+
+extension Nonescapable: CustomStringConvertible {
+  var description: String { "NE(\(value))" }
+}
+
+extension Nonescapable: CustomDebugStringConvertible {
+  var debugDescription: String { "NE[\(value)]" }
+}
+
+struct Plain: CustomStringConvertible, CustomDebugStringConvertible {
+  let value: Int
+  var description: String { "C(\(value))" }
+  var debugDescription: String { "C[\(value)]" }
+}
+
+// Access via protocol extensions constrained to ~Copyable & ~Escapable: the
+// path that did not compile before the protocol relaxation.
+extension CustomStringConvertible where Self: ~Copyable & ~Escapable {
+  func describe() -> String { description }
+}
+
+extension CustomDebugStringConvertible where Self: ~Copyable & ~Escapable {
+  func debugDescribe() -> String { debugDescription }
+}
+
+// Access via free generics that explicitly suppress Copyable/Escapable.
+func describing<T: CustomStringConvertible & ~Copyable & ~Escapable>(
+  _ value: borrowing T
+) -> String {
+  value.description
+}
+
+func debugDescribing<T: CustomDebugStringConvertible & ~Copyable & ~Escapable>(
+  _ value: borrowing T
+) -> String {
+  value.debugDescription
+}
+
+NoncopyableCustomStringConvertibleTests.test("describing noncopyables") {
+  // Wrap a both-conforming leaf to exercise the description and debug paths.
+  let a = Noncopyable(wrapping: Plain(value: 1))
+
+  expectEqual("N(C(1))", a.description)
+  expectEqual("N[C[1]]", a.debugDescription)
+
+  expectEqual("N(C(1))", String(describing: a))
+
+  expectPrinted("N(C(1))", a)
+
+  expectEqual("N(C(1))", a.describe())
+  expectEqual("N[C[1]]", a.debugDescribe())
+
+  expectEqual("N(C(1))", describing(a))
+  expectEqual("N[C[1]]", debugDescribing(a))
+
+  let i = Noncopyable(wrapping: 5)
+  expectEqual("N(5)", i.description)
+  expectEqual("N(5)", String(describing: i))
+  expectPrinted("N(5)", i)
+
+  let nested = Noncopyable(wrapping: Noncopyable(wrapping: Plain(value: 2)))
+  expectEqual("N(N(C(2)))", nested.description)
+  expectEqual("N[N[C[2]]]", debugDescribing(nested))
+  expectPrinted("N(N(C(2)))", nested)
+}
+
+NoncopyableCustomStringConvertibleTests.test("describing nonescapables") {
+  let n = Noncopyable<Nonescapable>(wrapping: .init(value: 7))
+  expectEqual("N(NE(7))", n.description)
+  expectEqual("N[NE[7]]", n.debugDescription)
+  expectEqual("N(NE(7))", String(describing: n))
+  expectEqual("N(NE(7))", describing(n))
+  expectEqual("N[NE[7]]", debugDescribing(n))
+
+  let ne = Nonescapable(value: 7)
+  expectEqual("NE(7)", ne.description)
+  expectEqual("NE[7]", ne.debugDescription)
+  expectEqual("NE(7)", String(describing: ne))
+  expectEqual("NE(7)", ne.describe())
+  expectEqual("NE[7]", ne.debugDescribe())
+  expectPrinted("NE(7)", ne)
+}
+
+NoncopyableCustomStringConvertibleTests.test("describing copyables (baseline)") {
+  let c = Plain(value: 3)
+  expectEqual("C(3)", c.description)
+  expectEqual("C[3]", c.debugDescription)
+  expectEqual("C(3)", String(describing: c))
+  expectEqual("C(3)", c.describe())
+  expectEqual("C[3]", c.debugDescribe())
+  expectEqual("C(3)", describing(c))
+  expectEqual("C[3]", debugDescribing(c))
+  expectPrinted("C(3)", c)
+  expectDebugPrinted("C[3]", c)
+
+  let wrapped = Noncopyable(wrapping: c)
+  expectEqual("N(C(3))", wrapped.description)
+}
+
+runAllTests()

--- a/test/stdlib/NoncopyableStringInterpolation.swift
+++ b/test/stdlib/NoncopyableStringInterpolation.swift
@@ -1,0 +1,89 @@
+//===--- NoncopyableStringInterpolation.swift ----------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+// RUN: %target-run-simple-swift(-swift-version 5 -enable-experimental-feature Lifetimes)
+// REQUIRES: executable_test
+// REQUIRES: swift_feature_Lifetimes
+
+import StdlibUnittest
+
+let NoncopyableStringInterpolationTests =
+  TestSuite("NoncopyableStringInterpolation")
+
+struct NCDescribed: ~Copyable, CustomStringConvertible {
+  let value: Int
+  var description: String { "C(\(value))" }
+}
+
+struct NCStreamed: ~Copyable, TextOutputStreamable {
+  let value: Int
+  func write<Target: TextOutputStream>(to target: inout Target) {
+    "T(\(value))".write(to: &target)
+  }
+}
+
+struct NCBoth: ~Copyable, CustomStringConvertible, TextOutputStreamable {
+  let value: Int
+  var description: String { "D(\(value))" }
+  func write<Target: TextOutputStream>(to target: inout Target) {
+    "W(\(value))".write(to: &target)
+  }
+}
+
+// A ~Escapable (but Copyable) CustomStringConvertible leaf.
+struct NEDescribed: ~Escapable, CustomStringConvertible {
+  let value: Int
+  var description: String { "E(\(value))" }
+}
+
+NoncopyableStringInterpolationTests.test("interpolating noncopyables") {
+  let c = NCDescribed(value: 1)
+  expectEqual("[C(1)]", "[\(c)]")
+
+  let t = NCStreamed(value: 2)
+  expectEqual("[T(2)]", "[\(t)]")
+
+  let b = NCBoth(value: 3)
+  expectEqual("[W(3)]", "[\(b)]")
+
+  expectEqual("D(3)", String(describing: b))
+}
+
+NoncopyableStringInterpolationTests.test("interpolating nonescapables") {
+  let e = NEDescribed(value: 4)
+  expectEqual("[E(4)]", "[\(e)]")
+}
+
+NoncopyableStringInterpolationTests.test("interpolating optionals with default") {
+  let someC: NCDescribed? = NCDescribed(value: 5)
+  expectEqual("[C(5)]", "[\(someC, default: "none")]")
+  let noneC: NCDescribed? = nil
+  expectEqual("[none]", "[\(noneC, default: "none")]")
+
+  let someT: NCStreamed? = NCStreamed(value: 6)
+  expectEqual("[T(6)]", "[\(someT, default: "none")]")
+  let noneT: NCStreamed? = nil
+  expectEqual("[none]", "[\(noneT, default: "none")]")
+
+  let someB: NCBoth? = NCBoth(value: 7)
+  expectEqual("[W(7)]", "[\(someB, default: "none")]")
+}
+
+NoncopyableStringInterpolationTests.test("interpolating copyables (baseline)") {
+  expectEqual("[42]", "[\(42)]")
+  expectEqual("[hi]", "[\("hi")]")
+  let none: Int? = nil
+  expectEqual("[none]", "[\(none, default: "none")]")
+  let some: Int? = 9
+  expectEqual("[9]", "[\(some, default: "none")]")
+}
+
+runAllTests()

--- a/test/stdlib/NoncopyableTextOutputStreamable.swift
+++ b/test/stdlib/NoncopyableTextOutputStreamable.swift
@@ -1,0 +1,114 @@
+//===--- NoncopyableTextOutputStreamable.swift ---------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+// RUN: %target-run-simple-swift(-enable-experimental-feature Lifetimes)
+// REQUIRES: executable_test
+// REQUIRES: swift_feature_Lifetimes
+
+import StdlibUnittest
+
+let NoncopyableTextOutputStreamableTests =
+  TestSuite("NoncopyableTextOutputStreamable")
+
+struct Box<Wrapped: ~Copyable & ~Escapable>: ~Copyable, ~Escapable {
+  var wrapped: Wrapped
+
+  @_lifetime(copy wrapped)
+  init(_ wrapped: consuming Wrapped) {
+    self.wrapped = wrapped
+  }
+}
+
+extension Box: TextOutputStreamable
+where Wrapped: TextOutputStreamable & ~Copyable & ~Escapable {
+  func write<Target: TextOutputStream>(to target: inout Target) {
+    "B<".write(to: &target)
+    wrapped.write(to: &target)
+    ">".write(to: &target)
+  }
+}
+
+extension Box: Escapable where Wrapped: Escapable & ~Copyable {}
+
+struct NCStreamable: ~Copyable, TextOutputStreamable {
+  let value: Int
+  func write<Target: TextOutputStream>(to target: inout Target) {
+    "S(\(value))".write(to: &target)
+  }
+}
+
+struct NEStreamable: ~Escapable, TextOutputStreamable {
+  let value: Int
+  func write<Target: TextOutputStream>(to target: inout Target) {
+    "S(\(value))".write(to: &target)
+  }
+}
+
+struct NCBoth: ~Copyable, CustomStringConvertible, TextOutputStreamable {
+  let value: Int
+  var description: String { "D(\(value))" }
+  func write<Target: TextOutputStream>(to target: inout Target) {
+    "W(\(value))".write(to: &target)
+  }
+}
+
+extension TextOutputStreamable where Self: ~Copyable & ~Escapable {
+  func streamedString() -> String {
+    var s = ""
+    write(to: &s)
+    return s
+  }
+}
+
+func streaming<T: TextOutputStreamable & ~Copyable & ~Escapable>(
+  _ value: borrowing T
+) -> String {
+  var s = ""
+  value.write(to: &s)
+  return s
+}
+
+NoncopyableTextOutputStreamableTests.test("streaming noncopyables") {
+  let s = NCStreamable(value: 1)
+  var out = ""
+  s.write(to: &out)
+  expectEqual("S(1)", out)
+
+  expectEqual("S(1)", s.streamedString())
+  expectEqual("S(1)", streaming(s))
+
+  expectEqual("S(1)", String(describing: s))
+
+  let nested = Box(NEStreamable(value: 2))
+  expectEqual("B<S(2)>", streaming(nested))
+  expectEqual("B<S(2)>", String(describing: nested))
+}
+
+NoncopyableTextOutputStreamableTests.test("streaming nonescapables") {
+  let s = NEStreamable(value: 3)
+  var out = ""
+  s.write(to: &out)
+  expectEqual("S(3)", out)
+  expectEqual("S(3)", s.streamedString())
+  expectEqual("S(3)", streaming(s))
+  expectEqual("S(3)", String(describing: s))
+}
+
+NoncopyableTextOutputStreamableTests.test("String(describing:) combined overload") {
+  let b = NCBoth(value: 4)
+
+  expectEqual("D(4)", String(describing: b))
+
+  expectEqual("W(4)", streaming(b))
+  expectEqual("W(4)", b.streamedString())
+}
+
+runAllTests()


### PR DESCRIPTION
This is the implementation of https://github.com/swiftlang/swift-evolution/blob/main/proposals/0499-support-non-copyable-simple-protocols.md for `CustomStringConvertible`, `CustomDebugStringConvertible`, and `TextOutputStreamable`.

The related functions for interoperating with these types and Strings are also updated to add the new constraints. 

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
