### PR TITLE
[cxx-interop] Stop checking default return ownership on arbitrary bases

### DIFF
--- a/lib/ClangImporter/ClangAnalysis.cpp
+++ b/lib/ClangImporter/ClangAnalysis.cpp
@@ -332,25 +332,8 @@ static void diagnoseMissingReturnsRetained(ClangImporter::Implementation &Impl,
     return; // recordDecl is not a shared reference type
 
   if (importer::matchSwiftAttr<bool>(
-          recordDecl, {{"returned_as_unretained_by_default", true}}))
+          info.getDecl(), {{"returned_as_unretained_by_default", true}}))
     return;
-
-  // FIXME: this is only here to preserve legacy behavior; we really shouldn't
-  //        consider returned_as_unretained_by_default annotations on anything
-  //        other than the "canonical" FRT base (the one whose retain/release
-  //        methods we use)
-  if (auto *cxxRecordDecl = dyn_cast<clang::CXXRecordDecl>(recordDecl);
-      cxxRecordDecl && cxxRecordDecl->hasDefinition()) {
-    auto inheritsDefaultAttr = false;
-    cxxRecordDecl->forallBases([&inheritsDefaultAttr](auto *base) {
-      inheritsDefaultAttr =
-          inheritsDefaultAttr || importer::matchSwiftAttr<bool>(
-                         base, {{"returned_as_unretained_by_default", true}});
-      return true;
-    });
-    if (inheritsDefaultAttr)
-      return;
-  }
 
   // If we reached here, then we have a call to an unannotated, Clang-imported
   // function that returns a pointer to a shared reference type that doesn't

--- a/test/Interop/Cxx/foreign-reference/Inputs/refkit.hpp
+++ b/test/Interop/Cxx/foreign-reference/Inputs/refkit.hpp
@@ -264,7 +264,7 @@ public:
       return;
     delete const_cast<T *>(static_cast<const T *>(this));
   }
-} SWIFT_RETURNED_AS_UNRETAINED_BY_DEFAULT;
+};
 
 class Object : public RefCounted<Object> {
   // noncopyable
@@ -277,7 +277,8 @@ protected:
 public:
   enum class Type : unsigned char { SomeType };
   virtual ~Object() { tracePrintf("~Object <- %p", this); }
-} SWIFT_SHARED_REFERENCE(refObject, derefObject);
+} SWIFT_SHARED_REFERENCE(refObject, derefObject)
+  SWIFT_RETURNED_AS_UNRETAINED_BY_DEFAULT;
 
 MAKE_RETAIN_RELEASE_FUNCTIONS(Object)
 
@@ -304,7 +305,8 @@ public:
 
   float get() const { return value; }
   void set(float v) { value = v; }
-} SWIFT_SHARED_REFERENCE(refNumberObj, derefNumberObj);
+} SWIFT_SHARED_REFERENCE(refNumberObj, derefNumberObj)
+  SWIFT_RETURNED_AS_UNRETAINED_BY_DEFAULT;
 
 MAKE_RETAIN_RELEASE_FUNCTIONS(NumberObj)
 
@@ -330,7 +332,8 @@ public:
 
 private:
   T m_value;
-} SWIFT_SHARED_REFERENCE(.ref, .deref);
+} SWIFT_SHARED_REFERENCE(.ref, .deref)
+  SWIFT_RETURNED_AS_UNRETAINED_BY_DEFAULT;
 
 using BoxedFloat = Boxed<float>;
 using RefBoxedFloat = Ref<Boxed<float>>;


### PR DESCRIPTION
Previously, we would honor the SWIFT_RETURNED_AS_UNRETAINED_BY_DEFAULT
when it was applied to *any* base class of a foreign shared reference.
That was never the intention, but at the time the feature was designed
it was not clear what its inheritance rules should be.

Now that we have the notion of a unique FRT base, a reasonable policy
emerges: only honor the SWIFT_RETURNED_AS_UNRETAINED_BY_DEFAULT
annotation on the FRT base, i.e., the base that provides the
retain/release operations of the derived FRT.

This patch deletes the old code that I left in to preserve the old,
unintentional and incorrect behavior. Builds on top of #89731.

rdar://172785392