### PR TITLE
🍒 [6.4][cxx-interop] Check for experimental flag in derived conformances

### DIFF
--- a/lib/ClangImporter/ClangDerivedConformances.cpp
+++ b/lib/ClangImporter/ClangDerivedConformances.cpp
@@ -1033,6 +1033,9 @@ static void conformToCxxBorrowingSequenceIfNeeded(
   PrettyStackTraceDecl trace("trying to conform to CxxBorrowingSequence", decl);
   ASTContext &ctx = decl->getASTContext();
 
+  if (!ctx.LangOpts.hasFeature(Feature::BorrowingSequence))
+    return;
+
   ProtocolDecl *cxxIteratorProto =
       ctx.getProtocol(KnownProtocolKind::UnsafeCxxInputIterator);
   ProtocolDecl *cxxBorrowingSequenceProto =

--- a/test/Interop/Cxx/stdlib/libcxx-module-interface.swift
+++ b/test/Interop/Cxx/stdlib/libcxx-module-interface.swift
@@ -23,10 +23,10 @@
 
 // CHECK-IOSFWD: enum std {
 // CHECK-IOSFWD:   enum __1 {
-// CHECK-IOSFWD:     struct basic_string<CChar, std.__1.char_traits<CChar>, std.__1.allocator<CChar>> : CxxMutableRandomAccessCollection, CxxBorrowingSequence {
+// CHECK-IOSFWD:     struct basic_string<CChar, std.__1.char_traits<CChar>, std.__1.allocator<CChar>> : CxxMutableRandomAccessCollection {
 // CHECK-IOSFWD:       typealias value_type = CChar
 // CHECK-IOSFWD:     }
-// CHECK-IOSFWD:     struct basic_string<CWideChar, std.__1.char_traits<CWideChar>, std.__1.allocator<CWideChar>> : CxxMutableRandomAccessCollection, CxxBorrowingSequence {
+// CHECK-IOSFWD:     struct basic_string<CWideChar, std.__1.char_traits<CWideChar>, std.__1.allocator<CWideChar>> : CxxMutableRandomAccessCollection {
 // CHECK-IOSFWD:       typealias value_type = CWideChar
 // CHECK-IOSFWD:     }
 // CHECK-IOSFWD:     typealias string = std.__1.basic_string<CChar, std.__1.char_traits<CChar>, std.__1.allocator<CChar>>

--- a/test/Interop/Cxx/stdlib/libstdcxx-module-interface.swift
+++ b/test/Interop/Cxx/stdlib/libstdcxx-module-interface.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-ide-test -print-module -module-to-print=CxxStdlib -source-filename=x -enable-experimental-cxx-interop -module-cache-path %t -enable-experimental-feature ImportCxxMembersLazily > %t/interface.swift
+// RUN: %target-swift-ide-test -print-module -module-to-print=CxxStdlib -source-filename=x -enable-experimental-cxx-interop -module-cache-path %t -enable-experimental-feature ImportCxxMembersLazily -enable-experimental-feature BorrowingSequence > %t/interface.swift
 // RUN: %FileCheck %s -check-prefix=CHECK-STD < %t/interface.swift
 // RUN: %FileCheck %s -check-prefix=CHECK-SIZE-T < %t/interface.swift
 // RUN: %FileCheck %s -check-prefix=CHECK-TO-STRING < %t/interface.swift
@@ -13,6 +13,7 @@
 // The RHS of basic_string's typealias value_type depends on how eagerly/lazily
 // we import type members
 // REQUIRES: swift_feature_ImportCxxMembersLazily
+// REQUIRES: swift_feature_BorrowingSequence
 
 // CHECK-STD: enum std {
 // CHECK-STRING:   struct basic_string<CChar, std{{(.__cxx11)?}}.char_traits<CChar>, std{{(.__cxx11)?}}.allocator<CChar>> : CxxMutableRandomAccessCollection, CxxBorrowingSequence {

--- a/test/Interop/Cxx/stdlib/msvcprt-module-interface.swift
+++ b/test/Interop/Cxx/stdlib/msvcprt-module-interface.swift
@@ -12,10 +12,10 @@
 // CHECK-STRING:   typealias size_t = size_t
 // CHECK-STRING:   static func to_string(_ _Val: Int32) -> std.string
 // CHECK-STRING:   static func to_wstring(_ _Val: Int32) -> std.wstring
-// CHECK-STRING:   struct basic_string<CChar, std.char_traits<CChar>, std.allocator<CChar>> : CxxMutableRandomAccessCollection, CxxBorrowingSequence {
+// CHECK-STRING:   struct basic_string<CChar, std.char_traits<CChar>, std.allocator<CChar>> : CxxMutableRandomAccessCollection {
 // CHECK-STRING:     typealias value_type = CChar
 // CHECK-STRING:   }
-// CHECK-STRING:   struct basic_string<CChar16, std.char_traits<CChar16>, std.allocator<CChar16>> : CxxMutableRandomAccessCollection, CxxBorrowingSequence {
+// CHECK-STRING:   struct basic_string<CChar16, std.char_traits<CChar16>, std.allocator<CChar16>> : CxxMutableRandomAccessCollection {
 // CHECK-STRING:     typealias value_type = UInt16
 // FIXME: why the value type is different from CChar16?
 // CHECK-STRING:   }

--- a/test/Interop/Cxx/stdlib/overlay/custom-borrowing-sequence-module-interface.swift
+++ b/test/Interop/Cxx/stdlib/overlay/custom-borrowing-sequence-module-interface.swift
@@ -1,6 +1,6 @@
-// RUN: %target-swift-ide-test -print-module -module-to-print=CustomBorrowingSequence -source-filename=x -I %S/Inputs -enable-experimental-cxx-interop -module-cache-path %t -I %swift_src_root/lib/ClangImporter/SwiftBridging | %FileCheck %s
-// RUN: %target-swift-ide-test -print-module -module-to-print=CustomBorrowingSequence -source-filename=x -I %S/Inputs -cxx-interoperability-mode=swift-6 -module-cache-path %t -I %swift_src_root/lib/ClangImporter/SwiftBridging | %FileCheck %s
-// RUN: %target-swift-ide-test -print-module -module-to-print=CustomBorrowingSequence -source-filename=x -I %S/Inputs -cxx-interoperability-mode=upcoming-swift -module-cache-path %t -I %swift_src_root/lib/ClangImporter/SwiftBridging | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=CustomBorrowingSequence -source-filename=x -I %S/Inputs -cxx-interoperability-mode=default -module-cache-path %t -I %swift_src_root/lib/ClangImporter/SwiftBridging -enable-experimental-feature BorrowingSequence | %FileCheck %s
+
+// REQUIRES: swift_feature_BorrowingSequence
 
 // CHECK:     struct SimpleNonCopyableSequence : ~Copyable, CxxBorrowingSequence {
 // CHECK:       typealias Element = ConstIterator.Pointee

--- a/test/Interop/Cxx/stdlib/overlay/custom-borrowing-sequence.swift
+++ b/test/Interop/Cxx/stdlib/overlay/custom-borrowing-sequence.swift
@@ -1,5 +1,6 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -cxx-interoperability-mode=default -I %swift_src_root/lib/ClangImporter/SwiftBridging -Xcc -std=c++20)
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -cxx-interoperability-mode=default -I %swift_src_root/lib/ClangImporter/SwiftBridging -Xcc -std=c++20 -enable-experimental-feature BorrowingSequence)
 //
+// REQUIRES: swift_feature_BorrowingSequence
 // REQUIRES: executable_test
 // Ubuntu 20.04 ships with an old version of libstdc++, which does not provide
 // std::contiguous_iterator_tag from C++20.

--- a/test/Interop/Cxx/stdlib/overlay/custom-collection-module-interface.swift
+++ b/test/Interop/Cxx/stdlib/overlay/custom-collection-module-interface.swift
@@ -1,6 +1,6 @@
-// RUN: %target-swift-ide-test -print-module -module-to-print=CustomSequence -source-filename=x -I %S/Inputs -enable-experimental-cxx-interop -module-cache-path %t | %FileCheck %s
-// RUN: %target-swift-ide-test -print-module -module-to-print=CustomSequence -source-filename=x -I %S/Inputs -cxx-interoperability-mode=swift-6 -module-cache-path %t | %FileCheck %s
-// RUN: %target-swift-ide-test -print-module -module-to-print=CustomSequence -source-filename=x -I %S/Inputs -cxx-interoperability-mode=upcoming-swift -module-cache-path %t | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=CustomSequence -source-filename=x -I %S/Inputs -cxx-interoperability-mode=default -module-cache-path %t -enable-experimental-feature BorrowingSequence | %FileCheck %s
+
+// REQUIRES: swift_feature_BorrowingSequence
 
 // CHECK: struct SimpleArrayWrapper : CxxRandomAccessCollection, CxxBorrowingSequence {
 // CHECK:   typealias Element = UnsafePointer<Int32>.Pointee

--- a/test/Interop/Cxx/stdlib/overlay/custom-iterator-module-interface.swift
+++ b/test/Interop/Cxx/stdlib/overlay/custom-iterator-module-interface.swift
@@ -1,4 +1,6 @@
-// RUN: %target-swift-ide-test -print-module -module-to-print=CustomIterator -source-filename=x -I %S/Inputs -cxx-interoperability-mode=default | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=CustomIterator -source-filename=x -I %S/Inputs -cxx-interoperability-mode=default -enable-experimental-feature BorrowingSequence | %FileCheck %s
+
+// REQUIRES: swift_feature_BorrowingSequence
 
 // CHECK: struct ConstIterator : UnsafeCxxInputIterator {
 // CHECK:   func __operatorStar() -> UnsafePointer<Int32>

--- a/test/Interop/Cxx/stdlib/overlay/custom-sequence-module-interface.swift
+++ b/test/Interop/Cxx/stdlib/overlay/custom-sequence-module-interface.swift
@@ -1,6 +1,6 @@
-// RUN: %target-swift-ide-test -print-module -module-to-print=CustomSequence -source-filename=x -I %S/Inputs -enable-experimental-cxx-interop -module-cache-path %t | %FileCheck %s
-// RUN: %target-swift-ide-test -print-module -module-to-print=CustomSequence -source-filename=x -I %S/Inputs -cxx-interoperability-mode=swift-6 -module-cache-path %t | %FileCheck %s
-// RUN: %target-swift-ide-test -print-module -module-to-print=CustomSequence -source-filename=x -I %S/Inputs -cxx-interoperability-mode=upcoming-swift -module-cache-path %t | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=CustomSequence -source-filename=x -I %S/Inputs -cxx-interoperability-mode=default -module-cache-path %t -enable-experimental-feature BorrowingSequence | %FileCheck %s
+
+// REQUIRES: swift_feature_BorrowingSequence
 
 // CHECK: struct SimpleSequence : CxxConvertibleToCollection, CxxBorrowingSequence {
 // CHECK:   typealias Element = ConstIterator.Pointee

--- a/test/Interop/Cxx/stdlib/use-std-list.swift
+++ b/test/Interop/Cxx/stdlib/use-std-list.swift
@@ -1,6 +1,7 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop)
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -enable-experimental-feature BorrowingSequence)
 // Test iterating through a list using the borrowing iterators (currently behind a feature flag).
 
+// REQUIRES: swift_feature_BorrowingSequence
 // REQUIRES: executable_test
 
 import StdlibUnittest

--- a/test/Interop/Cxx/stdlib/use-std-span-typechecker.swift
+++ b/test/Interop/Cxx/stdlib/use-std-span-typechecker.swift
@@ -1,5 +1,6 @@
-// RUN: %target-typecheck-verify-swift -I %S/Inputs -enable-experimental-cxx-interop -Xcc -std=c++20 2>&1 -disable-availability-checking
+// RUN: %target-typecheck-verify-swift -I %S/Inputs -enable-experimental-cxx-interop -Xcc -std=c++20 2>&1 -disable-availability-checking -enable-experimental-feature BorrowingSequence
 // REQUIRES: std_span
+// REQUIRES: swift_feature_BorrowingSequence
 
 import StdSpan
 

--- a/test/Interop/Cxx/stdlib/use-std-span.swift
+++ b/test/Interop/Cxx/stdlib/use-std-span.swift
@@ -1,7 +1,7 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -Xcc -std=c++20)
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -Xcc -std=c++20 -Xcc -D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_DEBUG)
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -Xcc -std=c++20 -enable-experimental-feature BorrowingForLoop)
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -Xcc -std=c++20 -Xcc -D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_DEBUG -enable-experimental-feature BorrowingForLoop)
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -Xcc -std=c++20 -enable-experimental-feature BorrowingSequence)
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -Xcc -std=c++20 -Xcc -D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_DEBUG -enable-experimental-feature BorrowingSequence)
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -Xcc -std=c++20 -enable-experimental-feature BorrowingForLoop -enable-experimental-feature BorrowingSequence)
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -Xcc -std=c++20 -Xcc -D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_DEBUG -enable-experimental-feature BorrowingForLoop -enable-experimental-feature BorrowingSequence)
 
 
 // TODO: test failed in macOS PR testing but passes locally: rdar://163049442
@@ -10,6 +10,7 @@
 // REQUIRES: executable_test
 // REQUIRES: std_span
 // REQUIRES: swift_feature_BorrowingForLoop
+// REQUIRES: swift_feature_BorrowingSequence
 
 import StdlibUnittest
 #if !BRIDGING_HEADER

--- a/test/Interop/Cxx/stdlib/use-std-vector-borrowing-iterators.swift
+++ b/test/Interop/Cxx/stdlib/use-std-vector-borrowing-iterators.swift
@@ -1,18 +1,19 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -Xcc -std=c++20)
-// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=swift-6 -Xcc -std=c++20)
-// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift -Xcc -std=c++20)
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -Xcc -std=c++20 -enable-experimental-feature BorrowingSequence)
+// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=swift-6 -Xcc -std=c++20 -enable-experimental-feature BorrowingSequence)
+// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift -Xcc -std=c++20 -enable-experimental-feature BorrowingSequence)
 
 // Also test this with a bridging header instead of the StdVector module.
 // RUN: %empty-directory(%t2)
 // RUN: cp %S/Inputs/std-vector.h %t2/std-vector-bridging-header.h
-// RUN: %target-run-simple-swift(-D BRIDGING_HEADER -import-objc-header %t2/std-vector-bridging-header.h -Xfrontend -enable-experimental-cxx-interop -Xcc -std=c++20)
-// RUN: %target-run-simple-swift(-D BRIDGING_HEADER -import-objc-header %t2/std-vector-bridging-header.h -cxx-interoperability-mode=swift-6 -Xcc -std=c++20)
-// RUN: %target-run-simple-swift(-D BRIDGING_HEADER -import-objc-header %t2/std-vector-bridging-header.h -cxx-interoperability-mode=upcoming-swift -Xcc -std=c++20)
+// RUN: %target-run-simple-swift(-D BRIDGING_HEADER -import-objc-header %t2/std-vector-bridging-header.h -Xfrontend -enable-experimental-cxx-interop -Xcc -std=c++20 -enable-experimental-feature BorrowingSequence)
+// RUN: %target-run-simple-swift(-D BRIDGING_HEADER -import-objc-header %t2/std-vector-bridging-header.h -cxx-interoperability-mode=swift-6 -Xcc -std=c++20 -enable-experimental-feature BorrowingSequence)
+// RUN: %target-run-simple-swift(-D BRIDGING_HEADER -import-objc-header %t2/std-vector-bridging-header.h -cxx-interoperability-mode=upcoming-swift -Xcc -std=c++20 -enable-experimental-feature BorrowingSequence)
 
 // Ubuntu 20.04 ships with an old version of libstdc++, which does not provide
 // std::contiguous_iterator_tag from C++20.
 // REQUIRES: OS=macosx || OS=windows-msvc
 
+// REQUIRES: swift_feature_BorrowingSequence
 // REQUIRES: executable_test
 
 import StdlibUnittest


### PR DESCRIPTION
- **Explanation**: Currently, `BorrowingSequence` is behind an experimental feature flag with the same name. We should only automatically conforming to `CxxBorrowingSequence` when such flag is passed.
- **Scope**: Checks if the `BorrowingSequence` flag is enabled and, if not, skips automatic conformance to `CxxBorrowingSequence`
- **Issues**: rdar://178513830
- **Original PRs**: https://github.com/swiftlang/swift/pull/89625
- **Risk**: Low, it's two-line change that reverts the behaviour to what we had before `BorrowingSequence`, when the flag isn't passed.
- **Testing**: Changed a few tests that now require the `BorrowingSequence` experimental feature flag.
- **Reviewers**: @Xazax-hun @egorzhdan @j-hui @patrykstefanski 

(cherry picked from commit 0d4dcd97d8a8ec34878e48593f529f04522e8de6)
