### PR TITLE
FunctionSignatureOptimization: fix wrong error type when creating a thunk

### DIFF
--- a/lib/SILOptimizer/FunctionSignatureTransforms/FunctionSignatureOpts.cpp
+++ b/lib/SILOptimizer/FunctionSignatureTransforms/FunctionSignatureOpts.cpp
@@ -618,6 +618,11 @@ void FunctionSignatureTransform::createFunctionSignatureOptimizedFunction() {
       Builder.getTypeExpansionContext());
   auto GenCalleeType = NewF->getLoweredFunctionType();
   auto SubstCalleeSILType = LoweredType;
+  auto FunctionTy = LoweredType.castTo<SILFunctionType>();
+  SILType errorType;
+  if (FunctionTy->hasErrorResult()) {
+    errorType = NewF->getConventions().getSILErrorType(Builder.getTypeExpansionContext());
+  }
   SubstitutionMap Subs;
   // Handle generic functions.
   if (GenCalleeType->isPolymorphic()) {
@@ -629,8 +634,10 @@ void FunctionSignatureTransform::createFunctionSignatureOptimizedFunction() {
     SubstCalleeSILType = SILType::getPrimitiveObjectType(SubstCalleeType);
     SILFunctionConventions Conv(SubstCalleeType, M);
     ResultType = Conv.getSILResultType(Builder.getTypeExpansionContext());
+    if (FunctionTy->hasErrorResult()) {
+      errorType = Conv.getSILErrorType(Builder.getTypeExpansionContext());
+    }
   }
-  auto FunctionTy = LoweredType.castTo<SILFunctionType>();
   if (FunctionTy->hasErrorResult()) {
     // We need a try_apply to call a function with an error result.
     SILFunction *Thunk = ThunkBody->getParent();
@@ -638,9 +645,7 @@ void FunctionSignatureTransform::createFunctionSignatureOptimizedFunction() {
     ReturnValue =
         NormalBlock->createPhiArgument(ResultType, OwnershipKind::Owned);
     SILBasicBlock *ErrorBlock = Thunk->createBasicBlock();
-    SILType Error =
-        SILType::getPrimitiveObjectType(FunctionTy->getErrorResult().getInterfaceType());
-    auto *ErrorArg = ErrorBlock->createPhiArgument(Error, OwnershipKind::Owned);
+    auto *ErrorArg = ErrorBlock->createPhiArgument(errorType, OwnershipKind::Owned);
     Builder.createTryApply(Loc, FRI, Subs, ThunkArgs, NormalBlock, ErrorBlock);
 
     Builder.setInsertionPoint(ErrorBlock);

--- a/test/SILOptimizer/function-signature-opt.swift
+++ b/test/SILOptimizer/function-signature-opt.swift
@@ -1,0 +1,17 @@
+// RUN: %target-swift-frontend -module-name test -emit-sil -O %s | %FileCheck %s
+
+public enum MyError<T>: Swift.Error { case fail }
+
+// Check that function signature opt does not crash when remove the dead argument.
+public func foo<T>(_ x: T) throws(MyError<T>) -> UInt8 {
+  throw .fail
+}
+
+// CHECK-LABEL: sil shared @$s4test3fooys5UInt8VxAA7MyErrorOyxGYKlFTf4d_n : $@convention(thin) <T> () -> (UInt8, @error MyError<T>) {
+public func run<T>(_ x: T) -> UInt8 {
+  do {
+    return try foo(x)
+  } catch {
+    return 0
+  }
+}


### PR DESCRIPTION
If the specialized function is generic, the optimization derived the wrong error type when creating a thunk for the specialized function.

Fixes a compiler crash
https://github.com/swiftlang/swift/issues/89617
rdar://178484080
