### PR TITLE
[Sema] Ensure `classifyThrownErrorType` treats hole as dependent type

### DIFF
--- a/lib/Sema/TypeCheckEffects.cpp
+++ b/lib/Sema/TypeCheckEffects.cpp
@@ -5246,7 +5246,7 @@ static ThrownErrorClassification classifyThrownErrorType(Type type) {
 
   // All three cases come up. The first one from the "real" witness matcher,
   // and the other two from associated type inference.
-  if (type->hasTypeVariable() ||
+  if (type->hasTypeVariableOrPlaceholder() ||
       type->hasTypeParameter() ||
       type->hasPrimaryArchetype())
     return ThrownErrorClassification::Dependent;

--- a/validation-test/compiler_crashers_fixed/TypeChecker-typesSatisfyConstraint-3a653b.swift
+++ b/validation-test/compiler_crashers_fixed/TypeChecker-typesSatisfyConstraint-3a653b.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","original":"052e2764","signature":"swift::TypeChecker::typesSatisfyConstraint(swift::Type, swift::Type, bool, swift::constraints::ConstraintKind, swift::DeclContext*, bool*)","signatureAssert":"Assertion failed: (!type1->getRecursiveProperties().isSolverAllocated() && !type2->getRecursiveProperties().isSolverAllocated() && \"Cannot escape solver-allocated types into a nested ConstraintSystem\"), function typesSatisfyConstraint","signatureNext":"compareThrownErrorsForSubtyping"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 class a {
   var b: String {
     {

--- a/validation-test/compiler_crashers_fixed/TypeChecker-typesSatisfyConstraint-f662e6.swift
+++ b/validation-test/compiler_crashers_fixed/TypeChecker-typesSatisfyConstraint-f662e6.swift
@@ -1,0 +1,7 @@
+// {"frontendArgs":["-typecheck"],"kind":"custom","signature":"swift::TypeChecker::typesSatisfyConstraint(swift::Type, swift::Type, bool, swift::constraints::ConstraintKind, swift::DeclContext*, bool*)","signatureAssert":"Assertion failed: (!type1->getRecursiveProperties().isSolverAllocated() && !type2->getRecursiveProperties().isSolverAllocated() && \"Cannot escape solver-allocated types into a nested ConstraintSystem\"), function typesSatisfyConstraint","signatureNext":"compareThrownErrorsForSubtyping"}
+// RUN: not %target-swift-frontend -typecheck %s
+func a() -> b {
+  Result {
+    throw <#expression#>
+  }
+}


### PR DESCRIPTION
A type with a hole cannot be matched using `TypeChecker::isConvertibleTo` since we cannot allow solver-allocated types to escape the parent constraint system. Treat it as `ThrownErrorClassification::Dependent` which ensures it goes through `matchTypes` instead.

rdar://178536535