### PR TITLE
[6.4🍒][Source Warning Control] Plumb `ConfiguredRegions` through `@diagnose` region queries

### DIFF
--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -287,6 +287,18 @@ bool BridgedASTContext_canImport(BridgedASTContext cContext,
                                  const SwiftInt *_Nullable versionComponents,
                                  SwiftInt numVersionComponents);
 
+/// Like `canImport`, but does not emit any diagnostics or update the
+/// `CanImportModuleVersions` cache. Use this from analysis paths that
+/// re-evaluate `#if canImport(...)` after the compiler's primary
+/// `EvaluateIfConditionRequest` has already done so, to avoid duplicate
+/// diagnostics.
+SWIFT_NAME("BridgedASTContext.testCanImport(self:importPath:versionKind:versionComponents:numVersionComponents:)")
+bool BridgedASTContext_testCanImport(BridgedASTContext cContext,
+                                     BridgedStringRef importPath,
+                                     BridgedCanImportVersion versionKind,
+                                     const SwiftInt *_Nullable versionComponents,
+                                     SwiftInt numVersionComponents);
+
 SWIFT_NAME("getter:BridgedASTContext.staticBuildConfigurationPtr(self:)")
 void * _Nonnull BridgedASTContext_staticBuildConfiguration(BridgedASTContext cContext);
 

--- a/include/swift/Bridging/ASTGen.h
+++ b/include/swift/Bridging/ASTGen.h
@@ -119,12 +119,14 @@ void swift_ASTGen_freeConfiguredRegions(
 
 swift::WarningGroupBehavior swift_ASTGen_warningGroupBehaviorAtPosition(
     void *_Nonnull sourceFile,
+    BridgedASTContext astContext,
     BridgedArrayRef globalRules,
     BridgedStringRef diagnosticGroupNameStrRef,
     swift::SourceLoc loc);
 
 bool swift_ASTGen_isWarningGroupEnabledInFile(
     void *_Nonnull sourceFile,
+    BridgedASTContext astContext,
     BridgedArrayRef globalRules,
     BridgedStringRef diagnosticGroupNameStrRef);
 

--- a/include/swift/Bridging/ASTGen.h
+++ b/include/swift/Bridging/ASTGen.h
@@ -117,6 +117,12 @@ intptr_t swift_ASTGen_configuredRegions(
 void swift_ASTGen_freeConfiguredRegions(
     BridgedIfConfigClauseRangeInfo *_Nullable regions, intptr_t numRegions);
 
+/// In ASTGen-only mode, drive the canonical `#if` evaluation for this source
+/// file, emitting `canImport` diagnostics and populating the version cache
+/// before any analysis path consumes the configured-regions cache.
+void swift_ASTGen_evaluateConfiguredRegionsForDiagnostics(
+    BridgedASTContext astContext, void *_Nonnull sourceFile);
+
 swift::WarningGroupBehavior swift_ASTGen_warningGroupBehaviorAtPosition(
     void *_Nonnull sourceFile,
     BridgedASTContext astContext,

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -2807,17 +2807,20 @@ bool ASTContext::canImportModuleImpl(
   if (FailedModuleImportNames.count(ModuleNameStr))
     return false;
 
-  auto missingVersion = [this, &loc, &ModuleName,
-                         &isUnderlyingVersion]() -> bool {
+  auto missingVersion = [this, &loc, &ModuleName, &isUnderlyingVersion,
+                         isSourceCanImport]() -> bool {
     // The module version could not be parsed from the preferred source for
-    // this query. Diagnose and return `true` to indicate that the unversioned
-    // module will satisfy the query.
-    auto mID = ModuleName[0];
-    auto diagLoc = mID.Loc;
-    if (mID.Loc.isInvalid())
-      diagLoc = loc;
-    Diags.diagnose(diagLoc, diag::cannot_find_module_version, mID.Item.str(),
-                   isUnderlyingVersion);
+    // this query. Diagnose (only for source-level `#if canImport` queries) and
+    // return `true` to indicate that the unversioned module will satisfy the
+    // query.
+    if (isSourceCanImport) {
+      auto mID = ModuleName[0];
+      auto diagLoc = mID.Loc;
+      if (mID.Loc.isInvalid())
+        diagLoc = loc;
+      Diags.diagnose(diagLoc, diag::cannot_find_module_version, mID.Item.str(),
+                     isUnderlyingVersion);
+    }
     return true;
   };
 

--- a/lib/AST/Bridging/ASTContextBridging.cpp
+++ b/lib/AST/Bridging/ASTContextBridging.cpp
@@ -85,6 +85,38 @@ bool BridgedASTContext_canImport(BridgedASTContext cContext,
       versionKind == CanImportUnderlyingVersion);
 }
 
+bool BridgedASTContext_testCanImport(BridgedASTContext cContext,
+                                     BridgedStringRef importPath,
+                                     BridgedCanImportVersion versionKind,
+                                     const SwiftInt *_Nullable versionComponents,
+                                     SwiftInt numVersionComponents) {
+  llvm::VersionTuple version;
+  switch (numVersionComponents) {
+  case 0:
+    break;
+  case 1:
+    version = llvm::VersionTuple(versionComponents[0]);
+    break;
+  case 2:
+    version = llvm::VersionTuple(versionComponents[0], versionComponents[1]);
+    break;
+  case 3:
+    version = llvm::VersionTuple(versionComponents[0], versionComponents[1],
+                                 versionComponents[2]);
+    break;
+  default:
+    version = llvm::VersionTuple(versionComponents[0], versionComponents[1],
+                                 versionComponents[2], versionComponents[3]);
+    break;
+  }
+
+  ImportPath::Module::Builder builder(cContext.unbridged(),
+                                      importPath.unbridged(), /*separator=*/'.',
+                                      SourceLoc());
+  return cContext.unbridged().testImportModule(
+      builder.get(), version, versionKind == CanImportUnderlyingVersion);
+}
+
 BridgedAvailabilityMacroMap BridgedASTContext::getAvailabilityMacroMap() const {
   return &unbridged().getAvailabilityMacroMap();
 }

--- a/lib/AST/Bridging/ASTContextBridging.cpp
+++ b/lib/AST/Bridging/ASTContextBridging.cpp
@@ -104,9 +104,14 @@ bool BridgedASTContext_testCanImport(BridgedASTContext cContext,
     version = llvm::VersionTuple(versionComponents[0], versionComponents[1],
                                  versionComponents[2]);
     break;
-  default:
+  case 4:
     version = llvm::VersionTuple(versionComponents[0], versionComponents[1],
                                  versionComponents[2], versionComponents[3]);
+    break;
+  default:
+    version = llvm::VersionTuple(versionComponents[0], versionComponents[1],
+                                 versionComponents[2], versionComponents[3],
+                                 versionComponents[4]);
     break;
   }
 

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -606,7 +606,7 @@ bool DiagnosticEngine::isDiagnosticGroupEnabled(SourceFile *sf, DiagGroupID grou
       sf->getExportedSourceFile()) {
     auto ruleRefArray = getWarningGroupBehaviorControlRefArray();
     return swift_ASTGen_isWarningGroupEnabledInFile(
-        sf->getExportedSourceFile(),
+        sf->getExportedSourceFile(), sf->getASTContext(),
         BridgedArrayRef(ruleRefArray.data(), ruleRefArray.size()),
         StringRef(getDiagGroupInfoByID(groupID).name));
   }
@@ -1372,7 +1372,7 @@ DiagnosticState::determineUserControlledWarningBehavior(
         auto ruleRefArray = getWarningGroupBehaviorControlRefArray();
         WarningGroupBehavior behavior =
             swift_ASTGen_warningGroupBehaviorAtPosition(
-                SF->getExportedSourceFile(),
+                SF->getExportedSourceFile(), SF->getASTContext(),
                 BridgedArrayRef(ruleRefArray.data(), ruleRefArray.size()),
                 StringRef(getDiagGroupInfoByID(diag.getGroupID()).name), loc);
         switch (behavior) {

--- a/lib/ASTGen/Sources/ASTGen/CompilerBuildConfiguration.swift
+++ b/lib/ASTGen/Sources/ASTGen/CompilerBuildConfiguration.swift
@@ -27,6 +27,22 @@ extension BridgedASTContext {
   }
 }
 
+/// Distinguishes the canonical, parser-driven evaluation of `#if canImport`
+/// from the side-effect-free re-derivations performed by later analyses.
+enum CanImportMode {
+  /// Canonical evaluation: run the live module-loader query, emit any
+  /// `cannot_find_module_version` diagnostic, and record the result in
+  /// `ASTContext::CanImportModuleVersions`. Use only at the canonical drive
+  /// site: the C++ parser's `EvaluateIfConditionRequest` path
+  /// (`evaluatePoundIfCondition`).
+  case driving
+
+  /// Side-effect-free re-derivation: answer from the module loaders without
+  /// emitting diagnostics or mutating the version cache. Use for any analysis
+  /// that re-derives `#if` activity after the canonical drive has run.
+  case analyzing
+}
+
 /// A build configuration that uses the compiler's ASTContext to answer
 /// queries.
 struct CompilerBuildConfiguration: BuildConfiguration {
@@ -34,10 +50,22 @@ struct CompilerBuildConfiguration: BuildConfiguration {
   let staticBuildConfiguration: StaticBuildConfiguration
   let sourceBuffer: UnsafeBufferPointer<UInt8>
 
-  init(ctx: BridgedASTContext, sourceBuffer: UnsafeBufferPointer<UInt8>) {
+  /// Selects whether `canImport(...)` performs the canonical, diagnostic-
+  /// emitting query or a side-effect-free re-derivation. Defaults to
+  /// `.analyzing` so that only the explicitly-marked canonical drive sites
+  /// emit `canImport` diagnostics; every other walk re-derives `#if` activity
+  /// without duplicating them.
+  let canImportMode: CanImportMode
+
+  init(
+    ctx: BridgedASTContext,
+    sourceBuffer: UnsafeBufferPointer<UInt8>,
+    canImportMode: CanImportMode = .analyzing
+  ) {
     self.ctx = ctx
     self.staticBuildConfiguration = ctx.staticBuildConfiguration
     self.sourceBuffer = sourceBuffer
+    self.canImportMode = canImportMode
   }
 
   func isCustomConditionSet(name: String) -> Bool {
@@ -76,16 +104,26 @@ struct CompilerBuildConfiguration: BuildConfiguration {
 
     return importPathStr.withBridgedString { bridgedImportPathStr in
       versionComponents.withUnsafeBufferPointer { versionComponentsBuf in
-        ctx.canImport(
-          importPath: bridgedImportPathStr,
-          location: SourceLoc(
-            at: importPath.first!.0.position,
-            in: sourceBuffer
-          ),
-          versionKind: cVersionKind,
-          versionComponents: versionComponentsBuf.baseAddress,
-          numVersionComponents: versionComponentsBuf.count
-        )
+        switch canImportMode {
+        case .analyzing:
+          return ctx.testCanImport(
+            importPath: bridgedImportPathStr,
+            versionKind: cVersionKind,
+            versionComponents: versionComponentsBuf.baseAddress,
+            numVersionComponents: versionComponentsBuf.count
+          )
+        case .driving:
+          return ctx.canImport(
+            importPath: bridgedImportPathStr,
+            location: SourceLoc(
+              at: importPath.first!.0.position,
+              in: sourceBuffer
+            ),
+            versionKind: cVersionKind,
+            versionComponents: versionComponentsBuf.baseAddress,
+            numVersionComponents: versionComponentsBuf.count
+          )
+        }
       }
     }
   }
@@ -159,9 +197,14 @@ extension ExportedSourceFile {
       return _configuredRegions
     }
 
+    // Re-derive the regions in `.analyzing` mode: the parser's primary
+    // `EvaluateIfConditionRequest` path is the canonical `canImport` drive
+    // that emits diagnostics and populates `CanImportModuleVersions`, so this
+    // secondary walk must not duplicate those side effects.
     let configuration = CompilerBuildConfiguration(
       ctx: astContext,
-      sourceBuffer: buffer
+      sourceBuffer: buffer,
+      canImportMode: .analyzing
     )
 
     let regions = syntax.configuredRegions(in: configuration)
@@ -387,10 +430,13 @@ public func inactiveCodeContainsReference(
     let searchRangeBuffer = UnsafeBufferPointer<UInt8>(start: searchRange.data, count: searchRange.count)
     syntax = Parser.parse(source: searchRangeBuffer)
 
-    // Compute the configured regions within the search range.
+    // Compute the configured regions within the search range. This runs during
+    // diagnostics, after the canonical `canImport` drive, so use `.analyzing`
+    // to re-derive `#if` activity without re-emitting `canImport` diagnostics.
     let configuration = CompilerBuildConfiguration(
       ctx: astContext,
-      sourceBuffer: searchRangeBuffer
+      sourceBuffer: searchRangeBuffer,
+      canImportMode: .analyzing
     )
     configuredRegions = syntax.configuredRegions(in: configuration)
 
@@ -416,10 +462,13 @@ public func inactiveCodeContainsTryOrThrow(
   let searchRangeBuffer = UnsafeBufferPointer<UInt8>(start: searchRange.data, count: searchRange.count)
   let syntax = Parser.parse(source: searchRangeBuffer)
 
-  // Compute the configured regions within the search range.
+  // Compute the configured regions within the search range. This runs during
+  // diagnostics, after the canonical `canImport` drive, so use `.analyzing`
+  // to re-derive `#if` activity without re-emitting `canImport` diagnostics.
   let configuration = CompilerBuildConfiguration(
     ctx: astContext,
-    sourceBuffer: searchRangeBuffer
+    sourceBuffer: searchRangeBuffer,
+    canImportMode: .analyzing
   )
   let configuredRegions = syntax.configuredRegions(in: configuration)
 
@@ -457,10 +506,13 @@ public func evaluatePoundIfCondition(
   let syntaxErrorsAllowed: Bool
   let diagnostics: [Diagnostic]
   if shouldEvaluate {
-    // Evaluate the condition against the compiler's build configuration.
+    // Evaluate the condition against the compiler's build configuration. This
+    // is the C++ parser's canonical per-`#if` evaluation, so it drives the
+    // `canImport` query: emitting diagnostics and populating the version cache.
     let configuration = CompilerBuildConfiguration(
       ctx: astContext,
-      sourceBuffer: textBuffer
+      sourceBuffer: textBuffer,
+      canImportMode: .driving
     )
 
     let state: IfConfigRegionState

--- a/lib/ASTGen/Sources/ASTGen/CompilerBuildConfiguration.swift
+++ b/lib/ASTGen/Sources/ASTGen/CompilerBuildConfiguration.swift
@@ -28,16 +28,14 @@ extension BridgedASTContext {
 }
 
 /// Distinguishes the canonical, parser-driven evaluation of `#if canImport`
-/// from the side-effect-free re-derivations performed by later analyses.
+/// from the side-effect-free queries performed by later analyses.
 enum CanImportMode {
-  /// Canonical evaluation: run the live module-loader query, emit any
-  /// `cannot_find_module_version` diagnostic, and record the result in
-  /// `ASTContext::CanImportModuleVersions`. Use only at the canonical drive
-  /// site: the C++ parser's `EvaluateIfConditionRequest` path
-  /// (`evaluatePoundIfCondition`).
+  /// Run the live module-loader query, emit any
+  /// `cannot_find_module_version` diagnostics, and record the result in
+  /// `ASTContext::CanImportModuleVersions`.
   case driving
 
-  /// Side-effect-free re-derivation: answer from the module loaders without
+  /// Side-effect-free queries: answer from the module loaders without
   /// emitting diagnostics or mutating the version cache. Use for any analysis
   /// that re-derives `#if` activity after the canonical drive has run.
   case analyzing
@@ -51,8 +49,8 @@ struct CompilerBuildConfiguration: BuildConfiguration {
   let sourceBuffer: UnsafeBufferPointer<UInt8>
 
   /// Selects whether `canImport(...)` performs the canonical, diagnostic-
-  /// emitting query or a side-effect-free re-derivation. Defaults to
-  /// `.analyzing` so that only the explicitly-marked canonical drive sites
+  /// emitting query or a side-effect-free query. Defaults to
+  /// `.analyzing` so that only the explicitly-marked effectful drive sites
   /// emit `canImport` diagnostics; every other walk re-derives `#if` activity
   /// without duplicating them.
   let canImportMode: CanImportMode
@@ -197,10 +195,10 @@ extension ExportedSourceFile {
       return _configuredRegions
     }
 
-    // Re-derive the regions in `.analyzing` mode: the parser's primary
+    // Compute the regions in `.analyzing` mode: the parser's primary
     // `EvaluateIfConditionRequest` path is the canonical `canImport` drive
     // that emits diagnostics and populates `CanImportModuleVersions`, so this
-    // secondary walk must not duplicate those side effects.
+    // secondary walk must not duplicate those effects.
     let configuration = CompilerBuildConfiguration(
       ctx: astContext,
       sourceBuffer: buffer,
@@ -211,6 +209,33 @@ extension ExportedSourceFile {
     _configuredRegions = regions
     return regions
   }
+
+  /// Perform the canonical evaluation of this file's `#if` directives for
+  /// ASTGen mode, where the C++ parser's `EvaluateIfConditionRequest`
+  /// never runs and would otherwise be the site that emits `canImport`
+  /// diagnostics and populates `CanImportModuleVersions`.
+  mutating func evaluateConfiguredRegionsForDiagnostics(astContext: BridgedASTContext) {
+    guard _configuredRegions == nil else {
+      return
+    }
+
+    _configuredRegions = syntax.configuredRegions(
+      in: CompilerBuildConfiguration(
+        ctx: astContext, sourceBuffer: buffer, canImportMode: .driving))
+  }
+}
+
+/// In ASTGen-only mode, perform the canonical `#if` evaluation for this source
+/// file, emitting `canImport` diagnostics and populating the version cache
+/// exactly once, before any analysis path consumes the configured-regions
+/// cache.
+@_cdecl("swift_ASTGen_evaluateConfiguredRegionsForDiagnostics")
+public func evaluateConfiguredRegionsForDiagnostics(
+  astContext: BridgedASTContext,
+  sourceFilePtr: UnsafeMutableRawPointer
+) {
+  let sourceFilePtr = sourceFilePtr.bindMemory(to: ExportedSourceFile.self, capacity: 1)
+  sourceFilePtr.pointee.evaluateConfiguredRegionsForDiagnostics(astContext: astContext)
 }
 
 /// Extract the #if clause range information for the given source file.

--- a/lib/ASTGen/Sources/ASTGen/WarningGroupBehaviorConfiguration.swift
+++ b/lib/ASTGen/Sources/ASTGen/WarningGroupBehaviorConfiguration.swift
@@ -10,54 +10,71 @@
 //
 //===----------------------------------------------------------------------===//
 
-import BasicBridging
 import ASTBridging
-import swiftBasicSwift
+import BasicBridging
 import SwiftDiagnostics
-@_spi(ExperimentalLanguageFeatures) import SwiftWarningControl
 @_spi(ExperimentalLanguageFeatures) import SwiftParser
 @_spi(ExperimentalLanguageFeatures) import SwiftSyntax
+import SwiftWarningControl
+import swiftBasicSwift
 
 @_cdecl("swift_ASTGen_warningGroupBehaviorAtPosition")
 public func warningGroupBehaviorAtPosition(
   sourceFilePtr: UnsafeMutableRawPointer,
+  astContext: BridgedASTContext,
   globalRules: BridgedArrayRef,
   diagnosticGroupNameStrRef: BridgedStringRef,
-  loc: SourceLoc) -> swift.WarningGroupBehavior {
-    let sourceFilePtr = sourceFilePtr.bindMemory(to: ExportedSourceFile.self, capacity: 1)
-    let regions = sourceFilePtr.pointee.warningGroupControlRegionTree(globalRules: globalRules)
+  loc: SourceLoc
+) -> swift.WarningGroupBehavior {
+  let sourceFilePtr = sourceFilePtr.bindMemory(to: ExportedSourceFile.self, capacity: 1)
+  let regions = sourceFilePtr.pointee.warningGroupControlRegionTree(
+    globalRules: globalRules,
+    ctx: astContext
+  )
 
-    let diagnosticGroupIdentifier = DiagnosticGroupIdentifier(String(bridged: diagnosticGroupNameStrRef))
-    guard let position = sourceFilePtr.pointee.position(of: loc) else {
-      return swift.WarningGroupBehavior.none
-    }
+  let diagnosticGroupIdentifier = DiagnosticGroupIdentifier(String(bridged: diagnosticGroupNameStrRef))
+  guard let position = sourceFilePtr.pointee.position(of: loc) else {
+    return swift.WarningGroupBehavior.none
+  }
 
-    guard let control = regions.warningGroupControl(at: position,
-                                                    for: diagnosticGroupIdentifier) else {
-      return swift.WarningGroupBehavior.none
-    }
+  guard
+    let control = regions.warningGroupControl(
+      at: position,
+      for: diagnosticGroupIdentifier
+    )
+  else {
+    return swift.WarningGroupBehavior.none
+  }
 
-    switch control {
-      case .error: return swift.WarningGroupBehavior.error
-      case .warning: return swift.WarningGroupBehavior.warning
-      case .ignored: return swift.WarningGroupBehavior.ignored
-    }
+  switch control {
+  case .error: return swift.WarningGroupBehavior.error
+  case .warning: return swift.WarningGroupBehavior.warning
+  case .ignored: return swift.WarningGroupBehavior.ignored
+  }
 }
 
 @_cdecl("swift_ASTGen_isWarningGroupEnabledInFile")
 public func isWarningGroupEnabledInFile(
   sourceFilePtr: UnsafeMutableRawPointer,
+  astContext: BridgedASTContext,
   globalRules: BridgedArrayRef,
-  diagnosticGroupNameStrRef: BridgedStringRef) -> Bool {
-    let sourceFilePtr = sourceFilePtr.bindMemory(to: ExportedSourceFile.self, capacity: 1)
-    let regions = sourceFilePtr.pointee.warningGroupControlRegionTree(globalRules: globalRules)
-    let diagnosticGroupIdentifier = DiagnosticGroupIdentifier(String(bridged: diagnosticGroupNameStrRef))
-    return regions.enabledGroups.contains(diagnosticGroupIdentifier)
+  diagnosticGroupNameStrRef: BridgedStringRef
+) -> Bool {
+  let sourceFilePtr = sourceFilePtr.bindMemory(to: ExportedSourceFile.self, capacity: 1)
+  let regions = sourceFilePtr.pointee.warningGroupControlRegionTree(
+    globalRules: globalRules,
+    ctx: astContext
+  )
+  let diagnosticGroupIdentifier = DiagnosticGroupIdentifier(String(bridged: diagnosticGroupNameStrRef))
+  return regions.enabledGroups.contains(diagnosticGroupIdentifier)
 }
 
 extension ExportedSourceFile {
   /// Return the warning group behavior regions for this source file.
-  mutating func warningGroupControlRegionTree(globalRules: BridgedArrayRef) -> WarningControlRegionTree {
+  mutating func warningGroupControlRegionTree(
+    globalRules: BridgedArrayRef,
+    ctx: BridgedASTContext
+  ) -> WarningControlRegionTree {
     if let _warningControlRegionTree {
       return _warningControlRegionTree
     }
@@ -68,17 +85,18 @@ extension ExportedSourceFile {
     let globalRuleArray = Array(UnsafeBufferPointer(start: pointer, count: globalRules.count))
     for rule in globalRuleArray {
       let groupIdentifier = DiagnosticGroupIdentifier(String(bridged: rule.getGroupName()))
-      let groupBehavior = switch rule.getBehavior() {
+      let groupBehavior =
+        switch rule.getBehavior() {
         case .error: WarningGroupControl.error
         case .warning: WarningGroupControl.warning
         case .ignored: WarningGroupControl.ignored
         case .none: fatalError("unexpected 'none' warning group behavior control")
-      }
+        }
       globalGroupRules.append((groupIdentifier, groupBehavior))
     }
 
     // Bridge the compiler's diagnostic group links
-    var subGroups: [DiagnosticGroupIdentifier : [DiagnosticGroupIdentifier]] = [:]
+    var subGroups: [DiagnosticGroupIdentifier: [DiagnosticGroupIdentifier]] = [:]
     for i in 0..<getDiagnosticGroupLinksCount() {
       let linkPair = getDiagnosticGroupLink(at: i)
       let superGroupID = DiagnosticGroupIdentifier(String(bridged: linkPair.first))
@@ -90,8 +108,11 @@ extension ExportedSourceFile {
       }
     }
     let groupInheritanceTree = (try? DiagnosticGroupInheritanceTree(subGroups: subGroups)) ?? nil
-    let regions = syntax.warningGroupControlRegionTree(globalControls: globalGroupRules,
-                                                       groupInheritanceTree: groupInheritanceTree)
+    let regions = syntax.warningGroupControlRegionTree(
+      configuredRegions: configuredRegions(astContext: ctx),
+      globalControls: globalGroupRules,
+      groupInheritanceTree: groupInheritanceTree
+    )
     _warningControlRegionTree = regions
     return regions
   }

--- a/lib/Parse/ParseRequests.cpp
+++ b/lib/Parse/ParseRequests.cpp
@@ -381,6 +381,13 @@ SourceFileParsingResult parseSourceFileViaASTGen(SourceFile &SF) {
   }
   swift_ASTGen_freeBridgedVirtualFiles(virtualFiles, numVirtualFiles);
 
+  // In ASTGen-only mode the C++ parser's EvaluateIfConditionRequest never runs,
+  // so this is the canonical evaluation of `#if` directives: emit `canImport`
+  // diagnostics and populate the version cache now, before any analysis path
+  // (parser diagnostics, AST building, fingerprinting) consumes the configured-
+  // regions cache.
+  swift_ASTGen_evaluateConfiguredRegionsForDiagnostics(Ctx, exportedSourceFile);
+
   // Emit parser diagnostics.
   (void)swift_ASTGen_emitParserDiagnostics(
       Ctx, &Diags, exportedSourceFile, /*emitOnlyErrors=*/false,

--- a/test/ClangImporter/can_import_underlying_version_tbd_missing_version.swift
+++ b/test/ClangImporter/can_import_underlying_version_tbd_missing_version.swift
@@ -10,14 +10,12 @@ import Simple
 
 func canImportUnderlyingVersion() {
 #if canImport(Simple, _underlyingVersion: 3.3) // expected-warning {{cannot find user version number for Clang module 'Simple'; version number ignored}}
-  // TODO(ParserValidation): expected-warning@-1 *{{cannot find user version number for Clang module 'Simple'; version number ignored}}
   let a = 1  // expected-warning {{initialization of immutable value 'a' was never used; consider replacing with assignment to '_' or removing it}}
 #endif
 }
 
 func canImportVersion() {
 #if canImport(Simple, _version: 3.3) // expected-warning {{cannot find user version number for module 'Simple'; version number ignored}}
-  // TODO(ParserValidation): expected-warning@-1 *{{cannot find user version number for module 'Simple'; version number ignored}}
   let a = 1  // expected-warning {{initialization of immutable value 'a' was never used; consider replacing with assignment to '_' or removing it}}
 #endif
 }

--- a/test/ClangImporter/can_import_version_ignores_missing_tbd_version.swift
+++ b/test/ClangImporter/can_import_version_ignores_missing_tbd_version.swift
@@ -23,17 +23,14 @@ import Simple
 
 func canImportUnderlyingVersion() {
 #if canImport(Simple, _underlyingVersion: 2) // expected-warning {{cannot find user version number for Clang module 'Simple'; version number ignored}}
-  // TODO(ParserValidation): expected-warning@-1 *{{cannot find user version number for Clang module 'Simple'; version number ignored}}
   let a = 1  // expected-warning {{initialization of immutable value 'a' was never used; consider replacing with assignment to '_' or removing it}}
 #endif
 
 #if canImport(Simple, _underlyingVersion: 3) // expected-warning {{cannot find user version number for Clang module 'Simple'; version number ignored}}
-  // TODO(ParserValidation): expected-warning@-1 *{{cannot find user version number for Clang module 'Simple'; version number ignored}}
   let b = 1 // expected-warning {{initialization of immutable value 'b' was never used; consider replacing with assignment to '_' or removing it}}
 #endif
   
 #if canImport(Simple, _underlyingVersion: 4) // expected-warning {{cannot find user version number for Clang module 'Simple'; version number ignored}}
-  // TODO(ParserValidation): expected-warning@-1 *{{cannot find user version number for Clang module 'Simple'; version number ignored}}
   let c = 1 // expected-warning {{initialization of immutable value 'c' was never used; consider replacing with assignment to '_' or removing it}}
 #endif
 

--- a/test/Parse/ConditionalCompilation/can_import_options.swift
+++ b/test/Parse/ConditionalCompilation/can_import_options.swift
@@ -10,7 +10,6 @@ func canImport() {
 #endif
 
 #if canImport(Foo, _version: 1) // expected-warning {{cannot find user version number for module 'Foo'; version number ignored}}
-  // TODO(ParserValidation): expected-warning@-1 *{{cannot find user version number for module 'Foo'; version number ignored}}
   // An unversioned 'Foo' causes versioned queries to evaluate to 'true'
   let versionCheck = 1 // expected-warning {{initialization of immutable value 'versionCheck' was never used; consider replacing with assignment to '_' or removing it}}
 #endif
@@ -74,7 +73,6 @@ func canImportVersioned() {
 #endif
 
 #if canImport(Bar, _underlyingVersion: 113.33) // expected-warning{{cannot find user version number for Clang module 'Bar'; version number ignored}}
-  // TODO(ParserValidation): expected-warning@-1 *{{cannot find user version number for Clang module 'Bar'; version number ignored}}
   // Bar is an unversioned Swift module with no underlying clang module.
   let underlyingMinorSmaller = 1 // expected-warning {{initialization of immutable value 'underlyingMinorSmaller' was never used; consider replacing with assignment to '_' or removing it}}
 #endif

--- a/test/Parse/ConditionalCompilation/can_import_version.swift
+++ b/test/Parse/ConditionalCompilation/can_import_version.swift
@@ -68,7 +68,6 @@ func canImportVersioned() {
 #endif
 
 #if canImport(Foo, _underlyingVersion: 113.33) // expected-warning {{cannot find user version number for Clang module 'Foo'; version number ignored}}
-  // TODO(ParserValidation): expected-warning@-1 *{{cannot find user version number for Clang module 'Foo'; version number ignored}}
   // Foo is a Swift module with no underlying clang module.
   let underlyingMinorSmaller = 1 // expected-warning {{initialization of immutable value 'underlyingMinorSmaller' was never used; consider replacing with assignment to '_' or removing it}}
 #endif
@@ -137,7 +136,6 @@ func canImportVersionedString() {
 #endif
 
 #if canImport(Foo, _underlyingVersion: "113.33") // expected-warning {{cannot find user version number for Clang module 'Foo'; version number ignored}}
-  // TODO(ParserValidation): expected-warning@-1 *{{cannot find user version number for Clang module 'Foo'; version number ignored}}
   // Foo is a Swift module with no underlying clang module.
   let underlyingMinorSmaller = 1 // expected-warning {{initialization of immutable value 'underlyingMinorSmaller' was never used; consider replacing with assignment to '_' or removing it}}
 #endif

--- a/test/Parse/ConditionalCompilation/can_import_version_astgen.swift
+++ b/test/Parse/ConditionalCompilation/can_import_version_astgen.swift
@@ -1,0 +1,30 @@
+// A top-level `#if canImport(M, _version: v)` for a
+// versionless module must emit `cannot_find_module_version` exactly once in
+// ASTGen-only mode (`ParserASTGen`), matching the default C++-parser mode.
+// In ASTGen-only mode the C++ parser's `EvaluateIfConditionRequest` never runs,
+// so `parseSourceFileViaASTGen` performs the canonical evaluation instead.
+
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/textual)
+// RUN: %empty-directory(%t/binary)
+// RUN: echo "public func foo() {}" > %t/Foo.swift
+
+// RUN: %target-swift-frontend -emit-module %t/Foo.swift \
+// RUN:   -module-name NoUserModuleVersion -swift-version 5 \
+// RUN:   -disable-implicit-concurrency-module-import \
+// RUN:   -emit-module-interface-path %t/textual/NoUserModuleVersion.swiftinterface \
+// RUN:   -enable-library-evolution \
+// RUN:   -emit-module-path %t/binary/NoUserModuleVersion.swiftmodule
+
+// RUN: %target-typecheck-verify-swift -disable-implicit-concurrency-module-import -I %t/textual
+// RUN: %target-typecheck-verify-swift -disable-implicit-concurrency-module-import -I %t/binary
+// RUN: %target-typecheck-verify-swift -disable-implicit-concurrency-module-import -I %t/textual -enable-experimental-feature ParserASTGen
+// RUN: %target-typecheck-verify-swift -disable-implicit-concurrency-module-import -I %t/binary -enable-experimental-feature ParserASTGen
+
+// REQUIRES: swift_feature_ParserASTGen
+
+import NoUserModuleVersion
+
+#if canImport(NoUserModuleVersion, _version: 113.331) // expected-warning {{cannot find user version number for module 'NoUserModuleVersion'; version number ignored}}
+func active() {}
+#endif

--- a/test/Parse/ConditionalCompilation/can_import_version_emitted_once.swift
+++ b/test/Parse/ConditionalCompilation/can_import_version_emitted_once.swift
@@ -1,0 +1,32 @@
+// Regression test: cannot_find_module_version is emitted exactly once per
+// `#if canImport(M, _version: v)` for a versionless module. Without a count
+// marker the verifier requires exactly one match.
+//
+// Both the textual and binary swiftmodule paths are exercised. This test runs
+// without parser validation enabled, demonstrating that the duplicate is not
+// specific to parser validation.
+
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/textual)
+// RUN: %empty-directory(%t/binary)
+// RUN: echo "public func foo() {}" > %t/Foo.swift
+
+// RUN: %target-swift-frontend -emit-module %t/Foo.swift \
+// RUN:   -module-name NoUserModuleVersion -swift-version 5 \
+// RUN:   -disable-implicit-concurrency-module-import \
+// RUN:   -emit-module-interface-path %t/textual/NoUserModuleVersion.swiftinterface \
+// RUN:   -enable-library-evolution \
+// RUN:   -emit-module-path %t/binary/NoUserModuleVersion.swiftmodule
+
+// RUN: %target-typecheck-verify-swift -disable-implicit-concurrency-module-import -I %t/textual
+// RUN: %target-typecheck-verify-swift -disable-implicit-concurrency-module-import -I %t/binary
+
+import NoUserModuleVersion
+
+func testCanImportNoUserModuleVersion() {
+
+#if canImport(NoUserModuleVersion, _version: 113.331) // expected-warning {{cannot find user version number for module 'NoUserModuleVersion'; version number ignored}}
+  let a = 1 // expected-warning {{initialization of immutable value 'a' was never used; consider replacing with assignment to '_' or removing it}}
+#endif
+
+}

--- a/test/Parse/ConditionalCompilation/can_import_version_missing_user_module_version.swift
+++ b/test/Parse/ConditionalCompilation/can_import_version_missing_user_module_version.swift
@@ -14,16 +14,10 @@ import NoUserModuleVersion
 func testCanImportNoUserModuleVersion() {
 
 #if canImport(NoUserModuleVersion, _version: 113.331) // expected-warning {{cannot find user version number for module 'NoUserModuleVersion'; version number ignored}}
-  // NOTE: Duplicate warning because the canImport request happens twice when parser
-  // validation is enabled.
-  // TODO(ParserValidation): expected-warning@-3 *{{cannot find user version number for module 'NoUserModuleVersion'; version number ignored}}
   let a = 1 // expected-warning {{initialization of immutable value 'a' was never used; consider replacing with assignment to '_' or removing it}}
 #endif
 
 #if canImport(NoUserModuleVersion, _version: 2) // expected-warning {{cannot find user version number for module 'NoUserModuleVersion'; version number ignored}}
-  // NOTE: Duplicate warning because the canImport request happens twice when parser
-  // validation is enabled.
-  // TODO(ParserValidation): expected-warning@-3 *{{cannot find user version number for module 'NoUserModuleVersion'; version number ignored}}
   let b = 1 // expected-warning {{initialization of immutable value 'b' was never used; consider replacing with assignment to '_' or removing it}}
 #endif
 

--- a/test/ScanDependencies/can_import_explicit_versioned_unversioned_module.swift
+++ b/test/ScanDependencies/can_import_explicit_versioned_unversioned_module.swift
@@ -50,7 +50,6 @@ public func Foo() {
 
 //--- MyExe.swift
 #if canImport(MyLib, _version: 42) // expected-warning {{cannot find user version number for module 'MyLib'; version number ignored}}
-  // TODO(ParserValidation): expected-warning@-1 *{{cannot find user version number for module 'MyLib'; version number ignored}}
   #warning("versioned canImport() of unversioned module is working")
   // expected-warning@-1{{versioned canImport() of unversioned module is working}}
 #else

--- a/test/attr/diagnose_if_config.swift
+++ b/test/attr/diagnose_if_config.swift
@@ -1,0 +1,78 @@
+// RUN: %target-typecheck-verify-swift -verify-additional-prefix lenient-
+// RUN: %target-typecheck-verify-swift -verify-additional-prefix strict- -DSTRICT
+
+@available(*, deprecated)
+func dep() -> Bool { return false }
+
+// `dep()` is deprecated, so it produces a warning by default. With `STRICT`
+// defined the inner `@diagnose(..., as: error)` is active and promotes the
+// warning to an error.
+#if STRICT
+@diagnose(DeprecatedDeclaration, as: error)
+#endif
+func onlyInsideIf() {
+  let _ = dep()
+  // expected-lenient-warning@-1 {{'dep()' is deprecated}}
+  // expected-strict-error@-2 {{'dep()' is deprecated}}
+}
+
+// The outer `@diagnose(..., as: warning)` always applies. When `STRICT` is set,
+// the inner `@diagnose(..., as: error)` comes after it in source order and
+// wins.
+@diagnose(DeprecatedDeclaration, as: warning)
+#if STRICT
+@diagnose(DeprecatedDeclaration, as: error)
+#endif
+func outerPlusIf() {
+  let _ = dep()
+  // expected-lenient-warning@-1 {{'dep()' is deprecated}}
+  // expected-strict-error@-2 {{'dep()' is deprecated}}
+}
+
+// Active branch picks the corresponding attribute.
+#if STRICT
+@diagnose(DeprecatedDeclaration, as: error)
+#else
+@diagnose(DeprecatedDeclaration, as: ignored)
+#endif
+func ifElse() {
+  let _ = dep()
+  // No diagnostic in lenient mode (silenced by `as: ignored`).
+  // expected-strict-error@-2 {{'dep()' is deprecated}}
+}
+
+#if STRICT
+@diagnose(DeprecatedDeclaration, as: error)
+#elseif OTHER
+@diagnose(DeprecatedDeclaration, as: ignored)
+#else
+@diagnose(DeprecatedDeclaration, as: warning)
+#endif
+func elseifChain() {
+  let _ = dep()
+  // expected-lenient-warning@-1 {{'dep()' is deprecated}}
+  // expected-strict-error@-2 {{'dep()' is deprecated}}
+}
+
+// Both layers must be active for the inner `@diagnose` to apply.
+@diagnose(DeprecatedDeclaration, as: warning)
+#if STRICT
+#if NESTED
+@diagnose(DeprecatedDeclaration, as: error)
+#endif
+#endif
+func nestedIf() {
+  let _ = dep()
+  // expected-lenient-warning@-1 {{'dep()' is deprecated}}
+  // expected-strict-warning@-2 {{'dep()' is deprecated}}
+}
+
+// Only present in the strict run; the lenient run must not see this decl at
+// all (otherwise the verifier would complain about an unmatched diagnostic).
+#if STRICT
+@diagnose(DeprecatedDeclaration, as: error)
+func wholeDeclOnlyIfStrict() {
+  let _ = dep()
+  // expected-strict-error@-1 {{'dep()' is deprecated}}
+}
+#endif


### PR DESCRIPTION
Cherry-pick of https://github.com/swiftlang/swift/pull/89077
------------------------------------

- **Explanation**: Adopt changes to `SwiftWarningControl` library API that allow specifying an input `ConfiguredRegions` parameter to construct a `warningControlTree`. This allows for correctly supporting `@diagnose` attributes which are guarded by `#if` conditionals. 
- **Scope**: Affects uses of @diagnose attribute which are contained inside a compilation conditional (#if).
- **Issue**: rdar://176454319
- **Risk**: Low, this addition uses the compiler's and this library's proven existing infrastructure to restrict cases where the @diagnose is applied.
- **Original PR**: https://github.com/swiftlang/swift/pull/89077
- **Testing**: Tests verifying new functionality added to the test suite.
- **Reviewers**: @DougGregor  