### PR TITLE
utils: repair cross-compilation for X64->ARM64

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1379,11 +1379,11 @@ function Invoke-Program() {
 }
 
 function Get-DotNetRuntime() {
-  if (-not $DotNetRuntime.Runtimes.ContainsKey($HostArchName)) {
-    throw "Unsupported .NET runtime host architecture '$HostArchName'"
+  if (-not $DotNetRuntime.Runtimes.ContainsKey($BuildArchName)) {
+    throw "Unsupported .NET runtime host architecture '$BuildArchName'"
   }
 
-  return $DotNetRuntime.Runtimes[$HostArchName]
+  return $DotNetRuntime.Runtimes[$BuildArchName]
 }
 
 function Get-DotNetRuntimeRoot() {


### PR DESCRIPTION
Ensure that we download the build architecture's .NET runtime as it is not a distributed component but rather a build dependency required for packaging.