### PR TITLE
[DebugInfo] Fix forwarding ownership of salvaged unary instructions

### DIFF
--- a/lib/SILOptimizer/Utils/InstOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/InstOptUtils.cpp
@@ -1950,6 +1950,8 @@ static void salvageUnaryInst(SingleValueInstruction *SVI) {
     // original operands, which we fix up below.
     auto *cloned =
         cast<SingleValueInstruction>(SVI->clone(&*debugBB->begin()));
+    if (auto *fwdInst = ForwardingInstruction::get(cloned))
+      fwdInst->setForwardingOwnershipKind(OwnershipKind::None);
     oldArg->replaceAllUsesWith(cloned);
 
     // Replace the block arg type with the input operand type.
@@ -2103,6 +2105,7 @@ void swift::salvageDebugInfo(SILInstruction *I) {
             elements.push_back(SILUndef::get(elt));
           auto *newStructInst = builder.createStruct(
             DbgInst->getLoc(), structTy, elements);
+          newStructInst->setForwardingOwnershipKind(OwnershipKind::None);
           oldArg->replaceAllUsesWith(newStructInst);
 
           // Replace the block arg and wire the operand.

--- a/test/DebugInfo/salvage_enum.sil
+++ b/test/DebugInfo/salvage_enum.sil
@@ -50,3 +50,29 @@ bb0:
   %2 = integer_literal $Builtin.Int64, 0
   return %2
 }
+
+// Salvaging a move-only enum should not preserve `forwarding: @owned` in the
+// debug reconstruction block.
+
+struct FileDescriptor: ~Copyable {
+  var fd: Builtin.Int64
+}
+
+// CHECK-LABEL: sil [ossa] @test_salvage_enum_ossa
+// CHECK:       bb0([[VAL:%[0-9]+]] : @owned $FileDescriptor):
+// CHECK:         debug_value [[VAL]] : $FileDescriptor, let, name "self", transform {
+// CHECK:           bb0([[ARG:%[0-9]+]] : $FileDescriptor):
+// CHECK-NOT:         forwarding
+// CHECK:             [[ENUM:%[0-9]+]] = enum $Optional<FileDescriptor>, #Optional.some!enumelt, [[ARG]] : $FileDescriptor
+// CHECK-NOT:         forwarding
+// CHECK:             return [[ENUM]] : $Optional<FileDescriptor>
+// CHECK:         }
+// CHECK-LABEL: } // end sil function 'test_salvage_enum_ossa'
+sil_scope 3 { loc "test.swift":3:1 parent @test_salvage_enum_ossa : $@convention(thin) (@owned FileDescriptor) -> @owned FileDescriptor }
+sil [ossa] @test_salvage_enum_ossa : $@convention(thin) (@owned FileDescriptor) -> @owned FileDescriptor {
+bb0(%0 : @owned $FileDescriptor):
+  %1 = enum $Optional<FileDescriptor>, #Optional.some!enumelt, %0 : $FileDescriptor, forwarding: @owned
+  debug_value %1 : $Optional<FileDescriptor>, let, name "self", loc "test.swift":3:1, scope 3
+  %3 = unchecked_enum_data %1 : $Optional<FileDescriptor>, #Optional.some!enumelt
+  return %3 : $FileDescriptor
+}

--- a/test/DebugInfo/sil_combine.sil
+++ b/test/DebugInfo/sil_combine.sil
@@ -152,6 +152,62 @@ bb0:
   return %r : $()
 }
 
+// Salvaging a move-only struct should not preserve `forwarding: @owned` in the
+// debug reconstruction block.
+
+struct NCPair: ~Copyable {
+  @_hasStorage var x: Int64 { get set }
+  @_hasStorage var y: Int64 { get set }
+  init(x: Int64, y: Int64)
+}
+
+// CHECK-LABEL: sil @salvage_noncopyable_struct_with_debug_bb
+// CHECK: debug_value {{.*}} %0 : $Int64, let, name "field_x", type $Int64, transform {
+// CHECK:   bb0(%[[ARG:[0-9]+]] : $Int64):
+// CHECK-NOT:   forwarding
+// CHECK:     %[[S:[0-9]+]] = struct $NCPair (%[[ARG]] : $Int64, undef : $Int64)
+// CHECK-NOT:   forwarding
+// CHECK:     %[[E:[0-9]+]] = struct_extract %[[S]] : $NCPair, #NCPair.x
+// CHECK:     return %[[E]] : $Int64
+// CHECK:   }
+// CHECK: return %0
+sil @salvage_noncopyable_struct_with_debug_bb : $@convention(thin) (Int64, Int64) -> Int64 {
+bb0(%0 : $Int64, %1 : $Int64):
+  %s = struct $NCPair (%0 : $Int64, %1 : $Int64)
+  debug_value %s : $NCPair, let, name "field_x", type $Int64, transform {
+  bb0(%0 : $NCPair):
+    %1 = struct_extract %0 : $NCPair, #NCPair.x
+    return %1 : $Int64
+  }
+  %e = struct_extract %s : $NCPair, #NCPair.x
+  return %e : $Int64
+}
+
+// Salvaging a move-only tuple should not preserve `forwarding: @owned` in the
+// debug reconstruction block.
+
+// CHECK-LABEL: sil @salvage_noncopyable_tuple_with_debug_bb
+// CHECK: debug_value %0 : $Int64, let, name "x", type $Int64, transform {
+// CHECK:   bb0(%[[ARG:[0-9]+]] : $Int64):
+// CHECK-NOT:   forwarding
+// CHECK:     %[[T:[0-9]+]] = tuple (%[[ARG]] : $Int64, undef : $Int64)
+// CHECK-NOT:   forwarding
+// CHECK:     %[[E:[0-9]+]] = tuple_extract %[[T]] : $(Int64, Int64), 0
+// CHECK:     return %[[E]] : $Int64
+// CHECK:   }
+// CHECK: return %0
+sil @salvage_noncopyable_tuple_with_debug_bb : $@convention(thin) (Int64, Int64) -> Int64 {
+bb0(%0 : $Int64, %1 : $Int64):
+  %t = tuple (%0 : $Int64, %1 : $Int64)
+  debug_value %t : $(Int64, Int64), let, name "x", type $Int64, transform {
+  bb0(%0 : $(Int64, Int64)):
+    %1 = tuple_extract %0 : $(Int64, Int64), 0
+    return %1 : $Int64
+  }
+  %e = tuple_extract %t : $(Int64, Int64), 0
+  return %e : $Int64
+}
+
 // This test verifies that splitAggregateLoad in CanonicalizeInstruction.cpp
 // salvages debug info attached to the loaded aggregate in optimized builds.
 //


### PR DESCRIPTION
Enum, struct and tuple instructions should not have a forwarding ownership within a debug reconstruction block.

Enum instructions (via salvageUnaryInst) and struct salvaging now reset the forwarding ownership to None. Tuple instructions don't force the forwarding ownership to owned for move-only types, so no fix was needed for those, but tests have been added for all cases.
