### PR TITLE
[6.4] Frontend: drop implicitly inferred blocklist

### DIFF
--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -261,9 +261,6 @@ public:
   ///       options have been parsed.
   void setDefaultPrebuiltCacheIfNecessary();
 
-  /// If we haven't explicitly passed -blocklist-paths, set it to the default value.
-  void setDefaultBlocklistsIfNecessary();
-
   /// If we haven't explicitly passed '-in-process-plugin-server-path', infer
   /// it as a default value.
   ///

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -143,31 +143,6 @@ void CompilerInvocation::setDefaultPrebuiltCacheIfNecessary() {
     (llvm::Twine(pair.first) + "preferred-interfaces" + pair.second).str();
 }
 
-void CompilerInvocation::setDefaultBlocklistsIfNecessary() {
-  if (!LangOpts.BlocklistConfigFilePaths.empty())
-    return;
-  if (SearchPathOpts.RuntimeResourcePath.empty())
-    return;
-  // XcodeDefault.xctoolchain/usr/lib/swift
-  SmallString<64> blocklistDir{SearchPathOpts.RuntimeResourcePath};
-  // XcodeDefault.xctoolchain/usr/lib
-  llvm::sys::path::remove_filename(blocklistDir);
-  // XcodeDefault.xctoolchain/usr
-  llvm::sys::path::remove_filename(blocklistDir);
-  // XcodeDefault.xctoolchain/usr/local/lib/swift/blocklists
-  llvm::sys::path::append(blocklistDir, "local", "lib", "swift", "blocklists");
-  std::error_code EC;
-  if (llvm::sys::fs::is_directory(blocklistDir)) {
-    for (llvm::sys::fs::directory_iterator F(blocklistDir, EC), FE;
-         F != FE; F.increment(EC)) {
-      StringRef ext = llvm::sys::path::extension(F->path());
-      if (ext.ends_with(".yml") || ext.ends_with(".yaml")) {
-        LangOpts.BlocklistConfigFilePaths.push_back(F->path());
-      }
-    }
-  }
-}
-
 void CompilerInvocation::setDefaultInProcessPluginServerPathIfNecessary() {
   if (!SearchPathOpts.InProcessPluginServerPath.empty())
     return;
@@ -4440,7 +4415,6 @@ bool CompilerInvocation::parseArgs(
   updateRuntimeLibraryPaths(SearchPathOpts, FrontendOpts, LangOpts, SDKInfo);
   updateImplicitFrameworkSearchPaths(SearchPathOpts, LangOpts, SDKInfo);
   setDefaultPrebuiltCacheIfNecessary();
-  setDefaultBlocklistsIfNecessary();
   setDefaultInProcessPluginServerPathIfNecessary();
 
   // Now that we've parsed everything, setup some inter-option-dependent state.


### PR DESCRIPTION
- Explanation:  All blocklists are currently provided by build system as compiler flags explicitly. We shouldn't
    need to infer those blocklist paths from the resource dir. Additionally, one recent change from Pavel (https://github.com/swiftlang/swift/pull/88631)
    shows that the inference logics never worked in the first place. Let's take this opportunity to drop it.
- Scope: how blocklist paths are collected from Swift compiler and other tools like ABI checker
- Issue: rdar://179014423
- Risk: Very Low; the inferred blocklist paths have never been used
- Original PR: https://github.com/swiftlang/swift/pull/89288
- Testing: Tested by running projects that hit issues where blocklists were falsely picked.
- Reviewers: @xedin 