### PR TITLE
SILGen: Mark lazily-allocated addressable representation buffers for move-checking.

### DIFF
--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -37,6 +37,7 @@
 #include "swift/SIL/SILSymbolVisitor.h"
 #include "swift/SIL/SILType.h"
 #include "swift/SIL/TypeLowering.h"
+#include "clang/AST/DeclarationName.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/Support/ErrorHandling.h"
 #include <iterator>
@@ -2567,8 +2568,12 @@ SILGenFunction::getVariableAddressableBuffer(VarDecl *decl,
                           cleanupPoint.state);
     cleanupPoint.inst->eraseFromParent();
   }
-  
-  return storeBorrow;
+
+  SILValue result = storeBorrow;
+  if (result->getType().isMoveOnly()) {
+    result = B.createMarkUnresolvedNonCopyableValueInst(result.getLoc(), result, MarkUnresolvedNonCopyableValueInst::CheckKind::NoConsumeOrAssign);
+  }
+  return result;
 }
 
 void BlackHoleInitialization::performPackExpansionInitialization(

--- a/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
@@ -1052,6 +1052,11 @@ addressBeginsInitialized(MarkUnresolvedNonCopyableValueInst *address) {
     }
   }
 
+  // A stored borrow is always initialized.
+  if (isa<StoreBorrowInst>(operand)) {
+    return true;
+  }
+
   // A read or write access always begins on an initialized value.
   if (auto access = dyn_cast<BeginAccessInst>(operand)) {
     switch (access->getAccessKind()) {

--- a/test/SILOptimizer/moveonly_addressable_implicit_read.swift
+++ b/test/SILOptimizer/moveonly_addressable_implicit_read.swift
@@ -1,0 +1,21 @@
+// RUN: %target-swift-frontend -enable-experimental-feature Lifetimes -enable-experimental-feature AddressableTypes -emit-sil %s | %FileCheck %s
+
+// REQUIRES: swift_feature_Lifetimes
+// REQUIRES: swift_feature_AddressableTypes
+
+public struct Butt: ~Copyable, ~Escapable {
+  // The compiler will synthesize an implicit `_read` coroutine for external
+  // users of this property. This test ensures that the generated code is
+  // properly move-checked.
+  // CHECK-LABEL: sil{{.*}} @${{.*}}4ButtV3foo{{.*}}vr
+  // CHECK:       bb0([[SELF:%.*]] : $Butt):
+  // CHECK:         [[FOO:%.*]] = struct_extract [[SELF]]
+  // CHECK:         yield [[FOO]]
+  public let foo: Tubb
+}
+
+@_addressableForDependencies
+public struct Tubb: ~Copyable, ~Escapable {
+  var x: AnyObject
+  @_lifetime(immortal) init() { fatalError() }
+}


### PR DESCRIPTION
Move-only code generation based on the location may lead to SILGen emitting loads and copies out of the addressable memory location that need to be checked and eliminated by the move checker.

Fixes rdar://179022026.