### PR TITLE
[6.4] Fix LifetimeDependence scope analysis to recognize throws of Never.

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/LifetimeDependenceUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/LifetimeDependenceUtils.swift
@@ -527,6 +527,8 @@ extension LifetimeDependence.Scope {
         break
       }
     }
+    // Insert dead-end paths with no destroy_addr.
+    extendToDeadEnds(range: &range, context)
     return range
   }
 
@@ -567,28 +569,61 @@ extension LifetimeDependence.Scope {
       }
       var range = InstructionRange(begin: initializingStore, context)
       range.insert(contentsOf: deallocInsts)
-
-      // Insert unreachable paths with no dealloc_stack.
-      var forwardUnreachableWalk = BasicBlockWorklist(context)
-      defer { forwardUnreachableWalk.deinitialize() }
-
-      // TODO: ensure complete dealloc_stack on all paths in SIL verification, then assert exitBlock.isEmpty.
-      for exitBlock in range.exitBlocks {
-        forwardUnreachableWalk.pushIfNotVisited(exitBlock)
-      }
-      while let b = forwardUnreachableWalk.pop() {
-        if let unreachableInst = b.terminator as? UnreachableInst {
-          // Note: 'unreachableInst' is not necessarilly dominated by 'initializingStore'. This marks the range invalid,
-          // but leaves it in a usable state that includes all blocks covered by the temporary allocation. The extra
-          // blocks (backward up to the function entry) are irrelevant becase we already know that 'initializingStore'
-          // dominates dependent uses.
-          range.insert(unreachableInst)
-        }
-        for succBlock in b.successors {
-          forwardUnreachableWalk.pushIfNotVisited(succBlock)
-        }
-      }
+      // Insert dead-end paths with no dealloc_stack.
+      extendToDeadEnds(range: &range, context)
       return range
+    }
+  }
+
+  // Extend a range from its exit blocks forward to all blocks dominated by the range's exits. This is needed for ranges
+  // that represent a scope that must include dead-end paths. It assumes that exit blocks are on dead-end paths.
+  //
+  // TODO: This is a messy, costly computation of dominance frontiers. It can be avoided by fixing OSSA lifetime
+  // completion so that all paths from an alloc_stack to a function exit include destroy_addr and dealloc_stack. Then
+  // this utility can simply be deleted.
+  private static func extendToDeadEnds(range: inout InstructionRange, _ context: Context) {
+    // First find all blocks forward reachable from an exit block.
+    var forwardReachableExitBlocks = Stack<BasicBlock>(context)
+    var forwardReachableExitBlockSet = BasicBlockSet(context)
+    defer {
+      forwardReachableExitBlocks.deinitialize()
+      forwardReachableExitBlockSet.deinitialize()
+    }
+    let pushExitBlock = { (block: BasicBlock) in
+      if forwardReachableExitBlockSet.insert(block) {
+        forwardReachableExitBlocks.append(block)
+      }
+    }
+    var marker = forwardReachableExitBlocks.top
+    for exitBlock in range.exitBlocks {
+      pushExitBlock(exitBlock)
+    }
+    while marker != forwardReachableExitBlocks.top {
+      let prevMarker = marker
+      marker = forwardReachableExitBlocks.top
+      for forwardExitBlock in forwardReachableExitBlocks.segment(low: prevMarker, high: marker) {
+        for succBlock in forwardExitBlock.successors {
+          pushExitBlock(succBlock)
+        }
+      }
+    }
+    // Now find and forward-propagate all reachable-from-exit blocks that have a predecessor that is not
+    // reachable-from-exit. This includes blocks that are not dominated by exits or that are reachable via a destroy.
+    var forwardUnreachableWalk = BasicBlockWorklist(context)
+    defer { forwardUnreachableWalk.deinitialize() }
+    for forwardReachableExitBlock in forwardReachableExitBlocks {
+      if forwardReachableExitBlock.predecessors.contains(
+           where: { !range.blockRange.contains($0) && !forwardReachableExitBlockSet.contains($0) }) {
+        forwardUnreachableWalk.transitivelyAddBlockWithSuccessors(startingAt: forwardReachableExitBlock)
+      }
+    }
+    // Finally, add the blocks dominated by exit blocks to 'range'.
+    for forwardReachableExitBlock in forwardReachableExitBlocks {
+      if (forwardUnreachableWalk.hasBeenPushed(forwardReachableExitBlock)) {
+        // The reachable-from-exit block is not dominate by exits, so ignore it.
+        continue
+      }
+      range.insert(forwardReachableExitBlock.terminator)
     }
   }
 }
@@ -1180,7 +1215,7 @@ extension LifetimeDependenceDefUseWalker {
 
 let lifetimeDependenceScopeTest = FunctionTest("lifetime_dependence_scope") {
     function, arguments, context in
-  let markDep = arguments.takeValue() as! MarkDependenceInst
+  let markDep = arguments.takeInstruction() as! MarkDependenceInstruction
   guard let dependence = LifetimeDependence(markDep, context) else {
     print("Invalid Dependence")
     return
@@ -1192,6 +1227,7 @@ let lifetimeDependenceScopeTest = FunctionTest("lifetime_dependence_scope") {
   }
   defer { range.deinitialize() }
   print(range)
+  print(range.blockRange)
 }
 
 private struct LifetimeDependenceUsePrinter : LifetimeDependenceDefUseWalker {

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/LocalVariableUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/LocalVariableUtils.swift
@@ -52,7 +52,7 @@ private func log(prefix: Bool = true, _ message: @autoclosure () -> String) {
 // The effect of .dependenceSource on reachability is like a load of this local. The dependent value depends on any
 // value in this local that reaches this point.
 //
-// A .dependenceDest access is the point where another value becomes dependent on this local:
+// A .dependenceDest access is the point where this local becomes dependent on another value:
 //
 //     %local = alloc_stack // this local
 //     %md = mark_dependence %local on %val

--- a/SwiftCompilerSources/Sources/SIL/DataStructures/Stack.swift
+++ b/SwiftCompilerSources/Sources/SIL/DataStructures/Stack.swift
@@ -140,13 +140,23 @@ public struct Stack<Element> : CollectionLikeSequence {
   public mutating func deinitialize() { removeAll() }
 }
 
+extension BridgedContext.Slab {
+  public static func ==(lhs: BridgedContext.Slab, rhs: BridgedContext.Slab) -> Bool { 
+    lhs.data == rhs.data
+  }
+}
+
 public extension Stack {
   /// Mark a stack location for future iteration.
   ///
   /// TODO: Marker should be ~Escapable.
-  struct Marker {
+  struct Marker: Equatable {
     let slab: BridgedContext.Slab
     let index: Int
+
+    public static func ==(lhs: Marker, rhs: Marker) -> Bool { 
+      lhs.slab == rhs.slab && lhs.index == rhs.index
+    }
   }
 
   var top: Marker { Marker(slab: lastSlab, index: endIndex) }
@@ -177,6 +187,10 @@ public extension Stack {
       return Iterator(slab: low.slab, index: low.index,
                       lastSlab: high.slab, endIndex: high.index)
     }
+  }
+
+  func segment(low: Marker, high: Marker) -> Segment {
+    Segment(in: self, low: low, high: high)
   }
 
   /// Assert that `marker` is valid based on the current `top`.

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_util.sil
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_util.sil
@@ -377,3 +377,67 @@ bb(%0 : $*InlineInt, %1 : $*NE):
   %99 = tuple()
   return %99 : $()
 }
+
+// =============================================================================
+// Dead-end blocks
+// =============================================================================
+
+// A destroy_addr is the path to the return and on one of the paths to the dead-end block but not all paths.
+
+// CHECK-LABEL: testDeadEndScope: lifetime_dependence_scope with: @instruction
+// CHECK: Initialized: [[STK:%[0-9]+]] = alloc_stack [lexical] [var_decl] $PairC
+// CHECK: Dependent:   %{{.*}} = alloc_stack [lexical] [var_decl] $NE
+// CHECK: begin:       store %0 to [init] [[STK]] : $*PairC
+// CHECK: ends:        destroy_addr [[STK]] : $*PairC
+// CHECK-NEXT:         destroy_addr [[STK]] : $*PairC
+// CHECK-NEXT:         br bb7
+// CHECK-NEXT: exits:
+// CHECK-NEXT: interiors: br bb6
+// CHECK-NEXT:            br bb6
+// CHECK-NEXT: begin:     bb0
+// CHECK: range:     [bb4, bb2, bb0, bb5, bb3]
+// CHECK: inclrange: [bb8, bb4, bb2, bb0, bb1, bb5, bb3, bb6]
+// CHECK: ends:      [bb8, bb1, bb6]
+// CHECK: exits:     []
+// CHECK: interiors: [bb5, bb3]
+// CHECK-LABEL: testDeadEndScope: lifetime_dependence_scope with: @instruction
+sil hidden [ossa] @testDeadEndScope : $@convention(thin) (@owned PairC) -> () {
+bb0(%0: @owned $PairC):
+  %stack = alloc_stack [lexical] [var_decl] $PairC, let
+  store %0 to [init] %stack
+  %ne = alloc_stack [lexical] [var_decl] $NE, let
+  specify_test "lifetime_dependence_scope @instruction"
+  mark_dependence_addr [unresolved] %ne on %stack
+  cond_br undef, bb1, bb2
+
+bb1:
+  destroy_addr %ne
+  destroy_addr %stack
+  br bb7
+
+bb2:
+  cond_br undef, bb3, bb4
+
+bb3:
+  br bb6
+
+bb4:
+  cond_br undef, bb5, bb8
+
+bb5:
+  br bb6
+
+bb6:
+  br bb7
+
+bb7:
+  unreachable
+
+bb8:
+  destroy_addr %ne
+  dealloc_stack %ne
+  destroy_addr %stack
+  dealloc_stack %stack
+  %99 = tuple ()
+  return %99
+}

--- a/test/SILOptimizer/lifetime_dependence/rdar178685863-deadend-escape.sil
+++ b/test/SILOptimizer/lifetime_dependence/rdar178685863-deadend-escape.sil
@@ -1,0 +1,91 @@
+// RUN: %target-sil-opt %s \
+// RUN:   --lifetime-dependence-diagnostics \
+// RUN:   -verify \
+// RUN:   -sil-verify-all \
+// RUN:   -enable-experimental-feature Lifetimes \
+// RUN:   -enable-experimental-feature AddressableTypes \
+// RUN:   -o /dev/null
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: swift_feature_Lifetimes
+// REQUIRES: swift_feature_AddressableTypes
+
+// Verify that diagnostics does not report an escape. Requires LifetimeDependence.Scope.computeInitializedRange extends
+// the range to dead-end blocks.
+
+sil_stage raw
+
+import Builtin
+import Swift
+import SwiftShims
+
+public protocol IterableIteratorProtocol<Element, Failure> : ~Copyable, ~Escapable {
+  associatedtype Element : ~Copyable
+  associatedtype Failure : Error = Never
+}
+
+struct Iterator<T> : ~Copyable, ~Escapable, IterableIteratorProtocol {
+  typealias Element = T
+  @_hasStorage let t: T { get }
+
+  @_lifetime(borrow t)
+  init(t: borrowing T)
+
+  typealias Failure = Never
+}
+
+struct List<T> : ~Escapable {
+  @_hasStorage let t: T { get }
+
+  @_lifetime(borrow t)
+  init(t: borrowing T)
+}
+
+sil @iteratorNextSpan : $@convention(method) <τ_0_0 where τ_0_0 : IterableIteratorProtocol, τ_0_0 : ~Copyable, τ_0_0 : ~Escapable, τ_0_0.Element : ~Copyable> (@lifetime(copy 0) @inout τ_0_0) -> (@lifetime(borrow address_for_deps 0) @owned Span<τ_0_0.Element>, @error_indirect τ_0_0.Failure)
+sil @makeList : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> @lifetime(borrow address_for_deps 0) @out List<τ_0_0>
+sil @makeListIterator : $@convention(method) <τ_0_0> (@in_guaranteed List<τ_0_0>) -> @lifetime(borrow address_for_deps 0) @out Iterator<τ_0_0>
+sil @spanCount : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (@guaranteed Span<τ_0_0>) -> Int
+  
+sil hidden [ossa] @test : $@convention(thin) <T> (@in_guaranteed T) -> () {
+bb0(%0 : $*T):
+  %2 = alloc_stack [lexical] [var_decl] $List<T>, let, name "list"
+
+  %3 = function_ref @makeList : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> @lifetime(borrow address_for_deps 0) @out List<τ_0_0>
+  %4 = apply %3<T>(%2, %0) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> @lifetime(borrow address_for_deps 0) @out List<τ_0_0>
+  // NOTE: the dependency is valid as long as the lifetime of %2 extends through the dead-end block.
+  mark_dependence_addr [unresolved] %2 on %0
+  %6 = alloc_stack [lexical] [var_decl] $Iterator<T>, var, name "iterator", type $Iterator<T>
+
+  %7 = function_ref @makeListIterator : $@convention(method) <τ_0_0> (@in_guaranteed List<τ_0_0>) -> @lifetime(borrow address_for_deps 0) @out Iterator<τ_0_0>
+  %8 = apply %7<T>(%6, %2) : $@convention(method) <τ_0_0> (@in_guaranteed List<τ_0_0>) -> @lifetime(borrow address_for_deps 0) @out Iterator<τ_0_0>
+  mark_dependence_addr [unresolved] %6 on %2
+  %10 = begin_access [modify] [static] %6
+
+  %11 = function_ref @iteratorNextSpan : $@convention(method) <τ_0_0 where τ_0_0 : IterableIteratorProtocol, τ_0_0 : ~Copyable, τ_0_0 : ~Escapable, τ_0_0.Element : ~Copyable> (@lifetime(copy 0) @inout τ_0_0) -> (@lifetime(borrow address_for_deps 0) @owned Span<τ_0_0.Element>, @error_indirect τ_0_0.Failure)
+  %12 = alloc_stack $Never
+  try_apply %11<Iterator<T>>(%12, %10) : $@convention(method) <τ_0_0 where τ_0_0 : IterableIteratorProtocol, τ_0_0 : ~Copyable, τ_0_0 : ~Escapable, τ_0_0.Element : ~Copyable> (@lifetime(copy 0) @inout τ_0_0) -> (@lifetime(borrow address_for_deps 0) @owned Span<τ_0_0.Element>, @error_indirect τ_0_0.Failure), normal bb1, error bb2
+
+bb1(%14 : @owned $Span<T>):
+  mark_dependence_addr [unresolved] %12 on %10
+  %16 = mark_dependence [unresolved] %14 on %10
+  dealloc_stack %12
+  %18 = move_value [var_decl] %16
+
+  %20 = function_ref @spanCount : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (@guaranteed Span<τ_0_0>) -> Int
+  %21 = apply %20<T>(%18) : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable> (@guaranteed Span<τ_0_0>) -> Int
+  destroy_value %18
+  end_access %10
+  destroy_addr %6
+  dealloc_stack %6
+  destroy_addr %2
+  dealloc_stack %2
+  %29 = tuple ()
+  return %29
+
+bb2:
+  mark_dependence_addr [unresolved] %12 on %10
+  destroy_addr %6
+  end_access %10
+  // NOTE: destroy_addr %2 is missing, so we don't naturally see the full range of %2 = alloc_stack.
+  unreachable
+}


### PR DESCRIPTION

- **Explanation**: Handle a protocol that has a default implementation
that returns a ~Escapable value and also has a typed throw that
defaults to Never. This is blocking a pending PR that is needed on
6.4:
[[WIP] Iterable protocol with throwing iteration #89630](https://github.com/swiftlang/swift/pull/89630).

- **Scope**: Only affects API that rely on the experimental Lifetimes
  feature a and use typed throws.

- **Issues**: rdar://178685863 (CxxIterableIterator escapes its scope)

- **Original PRs**: https:/github.com/swiftlang/swift/pull/89778

- **Risk**: Limited. This introduces a new code path in the lifetime
  diagnostics that only applies to a narrow set of conditions under an
  experimental mode.

- **Testing**: New SIL-level unit tests.

- **Reviewers**: @eeckstein 

(cherry picked from commit 0f7df9bf0f6cf27a3b81167762acaede79294f0d)
