### PR TITLE
[Concurrency] SIL: Apply `nonisolated(nonsending)` on deserialized SI…

### DIFF
--- a/lib/Serialization/SILSerializationFunctionBuilder.h
+++ b/lib/Serialization/SILSerializationFunctionBuilder.h
@@ -27,12 +27,17 @@ public:
   /// for the eventual deserialization of a function body.
   SILFunction *createDeclaration(StringRef name, SILType type,
                                  SILLocation loc) {
+    auto isolation = ActorIsolation::forUnspecified();
+    // FIXME: We should be serializing isolation associated with a `SILFunction`
+    // but for now we can get it from `SILFunctionType` which is precise enough.
+    if (type.isNonIsolatedCallerFunction())
+      isolation = ActorIsolation::forNonisolatedNonsending();
+
     return builder.createFunction(
-        SILLinkage::Private, name, type.getAs<SILFunctionType>(),
-        ActorIsolation::forUnspecified(), nullptr, loc, IsNotBare,
-        IsNotTransparent, IsNotSerialized, IsNotDynamic, IsNotDistributed,
-        IsNotRuntimeAccessible, ProfileCounter(), IsNotThunk,
-        SubclassScope::NotApplicable);
+        SILLinkage::Private, name, type.getAs<SILFunctionType>(), isolation,
+        nullptr, loc, IsNotBare, IsNotTransparent, IsNotSerialized,
+        IsNotDynamic, IsNotDistributed, IsNotRuntimeAccessible,
+        ProfileCounter(), IsNotThunk, SubclassScope::NotApplicable);
   }
 
   void setHasOwnership(SILFunction *f, bool newValue) {

--- a/test/Concurrency/nonisolated_nonsending_alwaysEmitIntoClient.swift
+++ b/test/Concurrency/nonisolated_nonsending_alwaysEmitIntoClient.swift
@@ -1,0 +1,50 @@
+// RUN: %empty-directory(%t/src)
+// RUN: split-file %s %t/src
+
+/// Build the library A
+// RUN: %target-swift-frontend -emit-module %t/src/A.swift \
+// RUN:   -module-name A -swift-version 6 -enable-library-evolution \
+// RUN:   -emit-module-path %t/A.swiftmodule \
+// RUN:   -emit-module-interface-path %t/A.swiftinterface
+
+// Build the client using module
+// RUN: %target-swift-emit-sil -verify -module-name Client -I %t %t/src/Client.swift | %FileCheck %t/src/Client.swift
+
+// RUN: rm %t/A.swiftmodule
+
+// Re-build the client using interface
+// RUN: %target-swift-emit-sil -verify -module-name Client -I %t %t/src/Client.swift | %FileCheck %t/src/Client.swift
+
+//--- A.swift
+
+@usableFromInline
+func computeAnswer() async throws -> Int {
+  42
+}
+
+@_alwaysEmitIntoClient
+public nonisolated(nonsending) func computeUltimateAnswer() async throws -> Int {
+  try await computeAnswer()
+}
+
+//--- Client.swift
+import A
+
+// CHECK: // computeUltimateAnswer()
+// CHECK-NEXT: // Isolation: nonisolated(nonsending)
+// CHECK-LABEL sil shared [export_implementation] @$s1A21computeUltimateAnswerSiyYaF : $@convention(thin) @caller_isolated @async (@sil_isolated @sil_implicit_leading_param @guaranteed Builtin.ImplicitActor) -> Int
+// CHECK: bb0([[ISOLATION:%.*]] : $Builtin.ImplicitActor):
+// CHECK:   // function_ref computeAnswer()
+// CHECK:   [[COMPUTE:%.*]] = function_ref @$s1A13computeAnswerSiyYaKF : $@convention(thin) @async () -> (Int, @error any Error)
+// CHECK:   try_apply [[COMPUTE]]() : $@convention(thin) @async () -> (Int, @error any Error), normal bb2, error bb1
+// CHECK: bb1(%3 : $any Error):
+// CHECK:   hop_to_executor [[ISOLATION]]
+// CHECK:   throw {{.*}}
+// CHECK: bb2({{.*}} : $Int):
+// CHECK:   hop_to_executor [[ISOLATION]]
+// CHECK:   return {{.*}}
+// CHECK: } // end sil function '$s1A21computeUltimateAnswerSiyYaKF'
+
+func test() async {
+  let _ = try? await computeUltimateAnswer()
+}


### PR DESCRIPTION
…L functions

If type associated with the function is `nonisolated(nonsending)` transfer that onto the new `SILFunction` itself. Without this `nonisolated(nonsending)` + `@_alwaysEmitIntoClient` declarations could be optimized incorrectly.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
