### PR TITLE
[Sema] Fix diagnostic generation for missing protocol conformance.

### DIFF
--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -3656,8 +3656,12 @@ bool ContextualFailure::tryProtocolConformanceFixIt() const {
     }
   }
 
-  assert(!missingProtoTypeStrings.empty() &&
-         "type already conforms to all the protocols?");
+  if (missingProtoTypeStrings.empty()) {
+    // This can happen if a type is declared as implementing all the
+    // protocols, but where the conformance to one or more protocols is
+    // invalid.
+    return false;
+  }
 
   // Combine all protocol names together, separated by commas.
   std::string protoString = llvm::join(missingProtoTypeStrings, ", ");

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -4485,6 +4485,9 @@ ConstraintSystem::matchExistentialTypes(Type type1, Type type2,
         parameterizedType->getRequirements(type1, reqs);
         for (const auto &req : reqs) {
           assert(req.getKind() == RequirementKind::SameType);
+          if (req.hasError())
+            continue;
+
           auto result = matchTypes(req.getFirstType(), req.getSecondType(),
                                    ConstraintKind::Bind,
                                    subflags, locator);

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -4485,8 +4485,15 @@ ConstraintSystem::matchExistentialTypes(Type type1, Type type2,
         parameterizedType->getRequirements(type1, reqs);
         for (const auto &req : reqs) {
           assert(req.getKind() == RequirementKind::SameType);
-          if (req.hasError())
-            continue;
+          if (req.hasError()) {
+            if (shouldAttemptFixes()) {
+              // Increase SK_Hole just to ensure the solution is marked invalid.
+              increaseScore(SK_Hole, locator);
+              continue;
+            }
+
+            return TypeMatchResult::failure();
+          }
 
           auto result = matchTypes(req.getFirstType(), req.getSecondType(),
                                    ConstraintKind::Bind,

--- a/test/Constraints/parameterized_existentials.swift
+++ b/test/Constraints/parameterized_existentials.swift
@@ -53,3 +53,13 @@ func h3(x: (any P<Int>)?) -> (any P<String>)? {
 func generic1<T>(x: any P<T>) -> T {
   return x.f()
 }
+
+protocol P2<T> {
+  associatedtype T
+}
+
+final class P2Class<T> {}
+
+func makeP2<T>() -> any P2<T> {
+  P2Class<T>() // expected-error {{return expression of type 'P2Class<T>' does not conform to 'P2'}}
+}

--- a/validation-test/compiler_crashers_fixed/ContextualFailure-tryProtocolConformanceFixIt-1047d0.swift
+++ b/validation-test/compiler_crashers_fixed/ContextualFailure-tryProtocolConformanceFixIt-1047d0.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","original":"b9eafd0d","signature":"swift::constraints::ContextualFailure::tryProtocolConformanceFixIt() const","signatureAssert":"Assertion failed: (!missingProtoTypeStrings.empty() && \"type already conforms to all the protocols?\"), function tryProtocolConformanceFixIt","signatureNext":"ContextualFailure::tryFixIts"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 protocol a<b> {
   associatedtype b
 }

--- a/validation-test/compiler_crashers_fixed/ContextualFailure-tryProtocolConformanceFixIt-2d4649.swift
+++ b/validation-test/compiler_crashers_fixed/ContextualFailure-tryProtocolConformanceFixIt-2d4649.swift
@@ -1,5 +1,5 @@
 // {"extraArgs":["-language-mode","6"],"kind":"typecheck","original":"e6383766","signature":"swift::constraints::ContextualFailure::tryProtocolConformanceFixIt() const","signatureAssert":"Assertion failed: (!missingProtoTypeStrings.empty() && \"type already conforms to all the protocols?\"), function tryProtocolConformanceFixIt","signatureNext":"ContextualFailure::tryFixIts"}
-// RUN: not --crash %target-swift-frontend -typecheck -language-mode 6 %s
+// RUN: not %target-swift-frontend -typecheck -language-mode 6 %s
 class a {
   b{ self= \c ?? self
   }


### PR DESCRIPTION
If we try to return a parameterized existential and the type returned does not conform to the protocol for that existential, the constraint system can get itself into an invalid state, leading to a "failure to produce a diagnostic" message.

As a fix, skip requirements that have error types after substitution.

Assisted-by: claude

rdar://178854703
