### PR TITLE
[cxx-interop] Fix-it for using `nil` instead of `std::nullopt`

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1889,6 +1889,8 @@ NOTE(note_make_optional,none,
       "add '?' to form the optional type %0", (Type))
 NOTE(note_make_implicitly_unwrapped_optional,none,
       "add '!' to form an implicitly unwrapped optional", ())
+NOTE(note_use_nil_for_cxx_optional,none,
+     "use the 'nil' literal instead", ())
 
 ERROR(invalid_ibdesignable_extension,none,
       "'@IBDesignable' can only be applied to classes and extensions "

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -48,6 +48,7 @@
 #include "swift/Sema/ConstraintSystem.h"
 #include "swift/Sema/IDETypeChecking.h"
 #include "swift/Sema/TypeVariableType.h"
+#include "clang/AST/DeclCXX.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/PointerUnion.h"
 #include "llvm/ADT/SmallString.h"
@@ -2636,6 +2637,9 @@ bool ContextualFailure::diagnoseAsError() {
   if (diagnoseConversionToNil())
     return true;
 
+  if (diagnoseConversionFromStdNullopt())
+    return true;
+
   if (path.empty()) {
     if (auto *KPE = getAsExpr<KeyPathExpr>(anchor)) {
       Diag<Type, Type> diag;
@@ -3153,6 +3157,56 @@ bool ContextualFailure::diagnoseConversionToNil() const {
       diag.fixItInsertAfter(patternTR->getEndLoc(), ")?");
     }
   }
+
+  return true;
+}
+
+static bool isStdNulloptType(Type type) {
+  auto nominal = type->getAnyNominal();
+  if (!nominal)
+    return false;
+
+  auto clangDecl =
+      dyn_cast_or_null<clang::CXXRecordDecl>(nominal->getClangDecl());
+  if (!clangDecl)
+    return false;
+
+  return clangDecl->isInStdNamespace() && clangDecl->getIdentifier() &&
+         clangDecl->getName() == "nullopt_t";
+}
+
+bool ContextualFailure::diagnoseConversionFromStdNullopt() const {
+  if (!isStdNulloptType(getFromType()))
+    return false;
+  if (!conformsToKnownProtocol(getToType(), KnownProtocolKind::CxxOptional))
+    return false;
+
+  // Pick the appropriate "cannot convert" diagnostic.
+  auto diagnostic = getDiagnosticFor(CTP, getToType());
+  if (!diagnostic)
+    return false;
+
+  emitDiagnostic(*diagnostic, getFromType(), getToType())
+      .highlight(getSourceRange());
+
+  // Locate the source expression that has `nullopt_t` type so we can produce a
+  // fix-it that replaces it with `nil`. Only emit the fix-it when we can
+  // pinpoint the offending expression — otherwise the range could include
+  // unrelated code.
+  SourceRange replaceRange;
+  if (auto anchor = getAsExpr(getAnchor())) {
+    if (auto assignExpr = dyn_cast<AssignExpr>(anchor)) {
+      if (auto src = assignExpr->getSrc())
+        replaceRange = src->getSourceRange();
+    } else if (auto type = getType(anchor);
+               type && type->isEqual(getFromType())) {
+      replaceRange = anchor->getSourceRange();
+    }
+  }
+
+  auto note = emitDiagnostic(diag::note_use_nil_for_cxx_optional);
+  if (replaceRange.isValid())
+    note.fixItReplace(replaceRange, "nil");
 
   return true;
 }

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -699,6 +699,10 @@ public:
   /// If we're trying to convert something to `nil`.
   bool diagnoseConversionToNil() const;
 
+  /// If we're trying to convert `std::nullopt_t` to a `std::optional`, suggest
+  /// using Swift's `nil` literal instead.
+  bool diagnoseConversionFromStdNullopt() const;
+
   /// Diagnose failed conversion in a `CoerceExpr`.
   bool diagnoseCoercionToUnrelatedType() const;
 

--- a/test/Interop/Cxx/stdlib/use-std-optional-typechecker.swift
+++ b/test/Interop/Cxx/stdlib/use-std-optional-typechecker.swift
@@ -20,3 +20,31 @@ takeCopyable(nonNilOptNonCopyable) // expected-error {{conform to 'Copyable'}}
 var _ = nonNilOptNonCopyable.pointee
 
 let _ = returnsConvertsToTemplated() // shouldn't crash the compiler
+
+func testNulloptAssign(_ opt: inout StdOptionalInt) {
+  opt = std.nullopt
+  // expected-error@-1 {{cannot assign value of type}}
+  // expected-note@-2 {{use the 'nil' literal instead}} {{9-20=nil}}
+}
+
+func testNulloptInit() {
+  let _: StdOptionalInt = std.nullopt
+  // expected-error@-1 {{cannot convert value of type}}
+  // expected-note@-2 {{use the 'nil' literal instead}} {{27-38=nil}}
+}
+
+func testNulloptReturn() -> StdOptionalInt {
+  return std.nullopt
+  // expected-error@-1 {{cannot convert return expression of type}}
+  // expected-note@-2 {{use the 'nil' literal instead}} {{10-21=nil}}
+}
+
+func testNulloptDefaultArg(_ x: StdOptionalInt = std.nullopt) {}
+// expected-error@-1 {{default argument value of type}}
+// expected-note@-2 {{use the 'nil' literal instead}} {{50-61=nil}}
+
+func testNulloptTernary() -> StdOptionalInt {
+  return true ? StdOptionalInt(1) : std.nullopt
+  // expected-error@-1 {{cannot convert return expression of type}}
+  // expected-note@-2 {{use the 'nil' literal instead}}
+}


### PR DESCRIPTION
In C++, `std::nullopt` is implicitly convertible to `std::optional<T>`. Swift doesn't support implicit type conversions between arbitrary types. Instead, the developer is expected to use `nil` literal, which is implicitly converted to `std::optional<T>`. This works via `CxxOptional`'s conformance to `ExpressibleByNilLiteral`.

This improves the diagnostic produced by Swift for the attempted usage of `std::nullopt` in places where the type conversion expected by the developer doesn't happen. A note will now be emitted:
```
use the 'nil' literal instead
```

rdar://162203520

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
