### PR TITLE
utils/update-checkout: Don't trust GitHub to keep pull request merge refs up-to-date

### DIFF
--- a/utils/python_format.py
+++ b/utils/python_format.py
@@ -174,9 +174,9 @@ def main():
         if path == known_path or path in known_path.parents
     }
 
-    # Add requested paths that exists, but aren't included in the format set.
+    # Add requested paths that aren't included in the format set.
     for path in requested_paths:
-        if path not in format_paths and path.exists():
+        if path not in format_paths:
             format_paths.add(path)
 
     command += sorted([str(path) for path in format_paths])

--- a/utils/update_checkout/run_tests.py
+++ b/utils/update_checkout/run_tests.py
@@ -39,7 +39,7 @@ if __name__ == "__main__":
     suite = unittest.TestSuite()
     suite.addTests(module_tests)
 
-    runner = unittest.TextTestRunner()
+    runner = unittest.TextTestRunner(verbosity=2)
     try:
         result = runner.run(suite)
     finally:

--- a/utils/update_checkout/run_tests.py
+++ b/utils/update_checkout/run_tests.py
@@ -30,7 +30,7 @@ if __name__ == "__main__":
 
     # Create temp directory and export it for the test suite.
     temp_dir = tempfile.mkdtemp()
-    os.environ["UPDATECHECKOUT_TEST_WORKSPACE_DIR"] = temp_dir
+    os.environ["UPDATE_CHECKOUT_TEST_SUITE_ARENA"] = temp_dir
 
     # Discover all tests for the module.
     module_tests = unittest.defaultTestLoader.discover(MODULE_DIR)

--- a/utils/update_checkout/tests/scheme_mock.py
+++ b/utils/update_checkout/tests/scheme_mock.py
@@ -24,23 +24,6 @@ import urllib.parse
 
 from typing import Any, Dict
 
-# For now we only use a config with a single scheme. We should add support for
-# handling multiple schemes.
-MOCK_REMOTE = {
-    "repo1": [
-        # This is a series of changes to repo1. (File, NewContents)
-        ("A.txt", "A"),
-        ("B.txt", "B"),
-        ("A.txt", "a"),
-    ],
-    "repo2": [
-        # This is a series of changes to repo2. (File, NewContents)
-        ("X.txt", "X"),
-        ("Y.txt", "Y"),
-        ("X.txt", "z"),
-    ],
-}
-
 MOCK_CONFIG = {
     # This is here just b/c we expect it. We should consider consolidating
     # clone-patterns into a dictionary where we map protocols (i.e. ['ssh,
@@ -166,9 +149,7 @@ def get_path_from_url(url: str) -> str:
 
 # TODO: Move this to SchemeMockTestCase.
 def setup_mock_remote(test_case, base_dir, base_config, remotes_path, local_path):
-    assert base_config["repos"].keys() == MOCK_REMOTE.keys()
-
-    for local_repo_name, changes in MOCK_REMOTE.items():
+    for local_repo_name in base_config["repos"].keys():
         local_repo_path = os.path.join(local_path, local_repo_name)
         remote_repo_path = test_case._compute_remote_path(repo_name=local_repo_name)
 
@@ -192,24 +173,21 @@ def setup_mock_remote(test_case, base_dir, base_config, remotes_path, local_path
         call_quietly(
             ["git", "symbolic-ref", "HEAD", "refs/heads/main"], cwd=local_repo_path
         )
-        for filename, contents in changes:
-            filename_path = os.path.join(local_repo_path, filename)
-            with open(filename_path, "w") as f:
-                f.write(contents)
-            call_quietly(["git", "add", filename], cwd=local_repo_path)
-            call_quietly(
-                [
-                  "git",
-                  "commit",
-                  "-m",
-                  # Equal commits created in different repositories at these
-                  # short time intervals tend to get the same SHA, which can
-                  # compromise tests. Supplying a random commit message makes
-                  # these SHA collisions far less likely.
-                  str(random.random()),
-                ],
-                cwd=local_repo_path
-            )
+
+        call_quietly(
+            [
+                "git",
+                "commit",
+                "--allow-empty",
+                "-m",
+                # Equal commits created in different repositories at these
+                # short time intervals tend to get the same SHA, which can
+                # compromise tests. Supplying a random commit message makes
+                # these SHA collisions far less likely.
+                str(random.random()),
+            ],
+            cwd=local_repo_path,
+        )
         call_quietly(["git", "push", "origin", "main"], cwd=local_repo_path)
 
     https_clone_pattern = os.path.join(f"file://{remotes_path}", "%s")

--- a/utils/update_checkout/tests/scheme_mock.py
+++ b/utils/update_checkout/tests/scheme_mock.py
@@ -18,6 +18,9 @@ import json
 import os
 import subprocess
 import unittest
+import urllib.parse
+
+from typing import Any, Dict
 
 # For now we only use a config with a single scheme. We should add support for
 # handling multiple schemes.
@@ -48,7 +51,7 @@ MOCK_CONFIG = {
             "remote": {"id": "repo1"},
         },
         "repo2": {
-            "remote": {"id": "repo2"},
+            "remote": {"id": os.path.join("org", "remote2")},
         },
     },
     "default-branch-scheme": "main",
@@ -121,21 +124,22 @@ def get_additional_config_path(base_dir):
     return os.path.join(base_dir, "test-additional-config.json")
 
 
-def setup_mock_remote(base_dir, base_config):
-    create_dir(base_dir)
+def get_path_from_url(url: str) -> str:
+    """
+    Returns the path component of the given URL.
+    """
 
-    # We use local as a workspace for creating commits.
-    LOCAL_PATH = os.path.join(base_dir, "local")
-    # We use remote as a directory that simulates our remote unchecked out
-    # repo.
-    REMOTE_PATH = os.path.join(base_dir, "remote")
+    return urllib.parse.urlsplit(url).path
 
-    create_dir(REMOTE_PATH)
-    create_dir(LOCAL_PATH)
 
-    for k, v in MOCK_REMOTE.items():
-        local_repo_path = os.path.join(LOCAL_PATH, k)
-        remote_repo_path = os.path.join(REMOTE_PATH, k)
+# TODO: Move this to SchemeMockTestCase.
+def setup_mock_remote(test_case, base_dir, base_config, remotes_path, local_path):
+    assert base_config["repos"].keys() == MOCK_REMOTE.keys()
+
+    for local_repo_name, changes in MOCK_REMOTE.items():
+        local_repo_path = os.path.join(local_path, local_repo_name)
+        remote_repo_path = test_case._compute_remote_path(repo_name=local_repo_name)
+
         create_dir(remote_repo_path)
         create_dir(local_repo_path)
         call_quietly(["git", "init", "--bare", remote_repo_path])
@@ -156,7 +160,7 @@ def setup_mock_remote(base_dir, base_config):
         call_quietly(
             ["git", "symbolic-ref", "HEAD", "refs/heads/main"], cwd=local_repo_path
         )
-        for i, (filename, contents) in enumerate(v):
+        for i, (filename, contents) in enumerate(changes):
             filename_path = os.path.join(local_repo_path, filename)
             with open(filename_path, "w") as f:
                 f.write(contents)
@@ -164,7 +168,7 @@ def setup_mock_remote(base_dir, base_config):
             call_quietly(["git", "commit", "-m", "Commit %d" % i], cwd=local_repo_path)
             call_quietly(["git", "push", "origin", "main"], cwd=local_repo_path)
 
-    https_clone_pattern = os.path.join("file://%s" % REMOTE_PATH, "%s")
+    https_clone_pattern = os.path.join(f"file://{remotes_path}", "%s")
     base_config["https-clone-pattern"] = https_clone_pattern
 
     with open(get_config_path(base_dir), "w") as f:
@@ -172,8 +176,6 @@ def setup_mock_remote(base_dir, base_config):
 
     with open(get_additional_config_path(base_dir), "w") as f:
         json.dump(MOCK_ADDITIONAL_SCHEME, f)
-
-    return (LOCAL_PATH, REMOTE_PATH)
 
 
 BASEDIR_ENV_VAR = "UPDATECHECKOUT_TEST_WORKSPACE_DIR"
@@ -215,11 +217,18 @@ class SchemeMockTestCase(unittest.TestCase):
                 "update-checkout at path: %s" % self.update_checkout_path
             )
         self.source_root = os.path.join(self.workspace, "source_root")
+        # We use remote as a directory that simulates our remote unchecked out
+        # repo.
+        self._remotes_path = os.path.join(self.workspace, "remote")
+        # We use local as a workspace for creating commits.
+        self.local_path = os.path.join(self.workspace, "local")
 
     def setUp(self):
         create_dir(self.source_root)
-        (self.local_path, self.remote_path) = setup_mock_remote(
-            self.workspace, self.config
+        create_dir(self._remotes_path)
+        create_dir(self.local_path)
+        setup_mock_remote(
+            self, self.workspace, self.config, self._remotes_path, self.local_path
         )
 
     def tearDown(self):
@@ -233,6 +242,27 @@ class SchemeMockTestCase(unittest.TestCase):
     @property
     def repo_names(self):
         return list(self.config["repos"].keys())
+
+    def _compute_remote_path(self, *, repo_name: str):
+        remote_info = self.config["repos"][repo_name]["remote"]
+        id = remote_info.get("id")
+        url = remote_info.get("url")
+        if id is not None:
+            return os.path.join(self._remotes_path, remote_info["id"])
+        elif url is not None:
+            url_path = get_path_from_url(url)
+            workspace_path = os.path.dirname(self._remotes_path)
+            self.assertEqual(
+                os.path.commonpath((workspace_path, url_path)), workspace_path
+            )
+            return os.path.join(self._remotes_path, os.path.basename(url_path))
+        else:
+            raise RuntimeError(
+                f"'remote' for '{local_repo_name}' must have an 'id' or 'url' item"
+            )
+
+    def remote_path(self, *, repo_name: str):
+        return self._compute_remote_path(repo_name=repo_name)
 
     def add_branch_scheme(self, name, scheme):
         self.config["branch-schemes"][name] = scheme

--- a/utils/update_checkout/tests/scheme_mock.py
+++ b/utils/update_checkout/tests/scheme_mock.py
@@ -129,8 +129,7 @@ def call_quietly(*args, **kwargs):
 
 
 def create_dir(d):
-    if not os.path.isdir(d):
-        os.makedirs(d)
+    os.makedirs(d)
 
 
 def teardown_mock_remote(base_dir):

--- a/utils/update_checkout/tests/scheme_mock.py
+++ b/utils/update_checkout/tests/scheme_mock.py
@@ -17,6 +17,7 @@ import copy
 import json
 import os
 import subprocess
+import tempfile
 import unittest
 import urllib.parse
 
@@ -198,7 +199,8 @@ def setup_mock_remote(test_case, base_dir, base_config, remotes_path, local_path
         json.dump(MOCK_ADDITIONAL_SCHEME, f)
 
 
-BASEDIR_ENV_VAR = "UPDATECHECKOUT_TEST_WORKSPACE_DIR"
+TEST_SUITE_ARENA_ENV_VAR = "UPDATE_CHECKOUT_TEST_SUITE_ARENA"
+TEST_SUITE_ARENA_DIR = os.getenv(TEST_SUITE_ARENA_ENV_VAR)
 CURRENT_FILE_DIR = os.path.dirname(os.path.abspath(__file__))
 UPDATE_CHECKOUT_EXECUTABLE = (
     "update-checkout.cmd" if os.name == "nt" else "update-checkout"
@@ -222,12 +224,17 @@ class SchemeMockTestCase(unittest.TestCase):
         # not affect subsequent tests.
         self.config = copy.deepcopy(MOCK_CONFIG)
 
-        self.workspace = os.getenv(BASEDIR_ENV_VAR)
-        if self.workspace is None:
+        if TEST_SUITE_ARENA_DIR is None:
             raise RuntimeError(
                 "Misconfigured test suite! Environment "
-                "variable %s must be set!" % BASEDIR_ENV_VAR
+                "variable %s must be set!" % TEST_SUITE_ARENA_ENV_VAR
             )
+
+        # Each individual test gets a temporary directory in the arena. This is
+        # important even though the tests are run serially, because an exception
+        # will interrupt execution of a test and prevent teardown, but will not
+        # prevent subsequent tests from running.
+        self.workspace = tempfile.mkdtemp(dir=TEST_SUITE_ARENA_DIR)
         self.config_path = get_config_path(self.workspace)
         self.additional_config_path = get_additional_config_path(self.workspace)
         self.update_checkout_path = UPDATE_CHECKOUT_PATH

--- a/utils/update_checkout/tests/scheme_mock.py
+++ b/utils/update_checkout/tests/scheme_mock.py
@@ -120,10 +120,9 @@ Output:
 
 
 def call_quietly(*args, **kwargs):
-    kwargs["stderr"] = subprocess.STDOUT
     kwargs["encoding"] = "utf-8"
     try:
-        return subprocess.check_output(*args, **kwargs)
+        return subprocess.check_output(*args, stderr=subprocess.STDOUT, **kwargs)
     except subprocess.SubprocessError as e:
         raise PrintableSubprocessError(underlying_error=e) from e
 

--- a/utils/update_checkout/tests/scheme_mock.py
+++ b/utils/update_checkout/tests/scheme_mock.py
@@ -230,7 +230,8 @@ class SchemeMockTestCase(unittest.TestCase):
             kwargs["cwd"] = self.source_root
         return call_quietly(*args, **kwargs)
 
-    def get_all_repos(self):
+    @property
+    def repo_names(self):
         return list(self.config["repos"].keys())
 
     def add_branch_scheme(self, name, scheme):

--- a/utils/update_checkout/tests/scheme_mock.py
+++ b/utils/update_checkout/tests/scheme_mock.py
@@ -82,18 +82,40 @@ MOCK_ADDITIONAL_SCHEME = {
 }
 
 
-class CallQuietlyException(Exception):
-    def __init__(self, command, returncode, output):
-        self.command = command
-        self.returncode = returncode
-        self.output = output
+class PrintableSubprocessError(Exception):
+    def __init__(self, *, underlying_error: subprocess.SubprocessError):
+        self.underlying_error = underlying_error
+
+    @property
+    def stdout(self):
+        return self.underlying_error.stdout
+
+    @property
+    def stderr(self):
+        return self.underlying_error.stderr
+
+    @property
+    def output(self):
+        return self.underlying_error.output
+
+    @property
+    def cmd(self):
+        return self.underlying_error.cmd
+
+    @property
+    def returncode(self):
+        return self.underlying_error.returncode
 
     def __str__(self):
-        return (
-            f"Command returned a non-zero exit status {self.returncode}:\n"
-            f"Command: {' '.join(self.command)}\n"
-            f"Output: {self.output.decode('utf-8')}"
-        )
+        decoded_output = self.underlying_error.output
+        if isinstance(decoded_output, bytes):
+            decoded_output = decoded_output.decode()
+
+        return f"""Command returned a non-zero exit status {self.underlying_error.returncode}:
+Command: {' '.join(self.underlying_error.cmd)}
+Output:
+
+{decoded_output}"""
 
 
 def call_quietly(*args, **kwargs):
@@ -101,10 +123,8 @@ def call_quietly(*args, **kwargs):
     kwargs["encoding"] = "utf-8"
     try:
         return subprocess.check_output(*args, **kwargs)
-    except subprocess.CalledProcessError as e:
-        raise CallQuietlyException(
-            command=e.cmd, returncode=e.returncode, output=e.stdout
-        ) from e
+    except subprocess.SubprocessError as e:
+        raise PrintableSubprocessError(underlying_error=e) from e
 
 
 def create_dir(d):

--- a/utils/update_checkout/tests/scheme_mock.py
+++ b/utils/update_checkout/tests/scheme_mock.py
@@ -121,9 +121,21 @@ Output:
 
 
 def call_quietly(*args, **kwargs):
+    """
+    Runs the command described by `args` and returns its combined stdout and
+    stderr output.
+    """
+
     kwargs["encoding"] = "utf-8"
     try:
-        return subprocess.check_output(*args, stderr=subprocess.STDOUT, **kwargs)
+        return subprocess.run(
+            *args,
+            check=True,
+            capture_output=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            **kwargs,
+        ).stdout
     except subprocess.SubprocessError as e:
         raise PrintableSubprocessError(underlying_error=e) from e
 

--- a/utils/update_checkout/tests/scheme_mock.py
+++ b/utils/update_checkout/tests/scheme_mock.py
@@ -210,7 +210,7 @@ def setup_mock_remote(test_case, base_dir, base_config, remotes_path, local_path
                 ],
                 cwd=local_repo_path
             )
-            call_quietly(["git", "push", "origin", "main"], cwd=local_repo_path)
+        call_quietly(["git", "push", "origin", "main"], cwd=local_repo_path)
 
     https_clone_pattern = os.path.join(f"file://{remotes_path}", "%s")
     base_config["https-clone-pattern"] = https_clone_pattern

--- a/utils/update_checkout/tests/scheme_mock.py
+++ b/utils/update_checkout/tests/scheme_mock.py
@@ -13,6 +13,7 @@
 a json .config file and a series of .git repos with "fake commits".
 """
 
+import copy
 import json
 import os
 import subprocess
@@ -192,7 +193,13 @@ class SchemeMockTestCase(unittest.TestCase):
     def __init__(self, *args, **kwargs):
         super(SchemeMockTestCase, self).__init__(*args, **kwargs)
 
-        self.config = MOCK_CONFIG.copy()
+        # The test runner will first create TestCase instances for all test
+        # methods in the suite and only then run each test. Although we should
+        # not be mutating a configuration at run time, have each instance get a
+        # copy of the given configuration so that potential mutations to it do
+        # not affect subsequent tests.
+        self.config = copy.deepcopy(MOCK_CONFIG)
+
         self.workspace = os.getenv(BASEDIR_ENV_VAR)
         if self.workspace is None:
             raise RuntimeError(

--- a/utils/update_checkout/tests/scheme_mock.py
+++ b/utils/update_checkout/tests/scheme_mock.py
@@ -16,6 +16,7 @@ a json .config file and a series of .git repos with "fake commits".
 import copy
 import json
 import os
+import random
 import subprocess
 import tempfile
 import unittest
@@ -179,12 +180,24 @@ def setup_mock_remote(test_case, base_dir, base_config, remotes_path, local_path
         call_quietly(
             ["git", "symbolic-ref", "HEAD", "refs/heads/main"], cwd=local_repo_path
         )
-        for i, (filename, contents) in enumerate(changes):
+        for filename, contents in changes:
             filename_path = os.path.join(local_repo_path, filename)
             with open(filename_path, "w") as f:
                 f.write(contents)
             call_quietly(["git", "add", filename], cwd=local_repo_path)
-            call_quietly(["git", "commit", "-m", "Commit %d" % i], cwd=local_repo_path)
+            call_quietly(
+                [
+                  "git",
+                  "commit",
+                  "-m",
+                  # Equal commits created in different repositories at these
+                  # short time intervals tend to get the same SHA, which can
+                  # compromise tests. Supplying a random commit message makes
+                  # these SHA collisions far less likely.
+                  str(random.random()),
+                ],
+                cwd=local_repo_path
+            )
             call_quietly(["git", "push", "origin", "main"], cwd=local_repo_path)
 
     https_clone_pattern = os.path.join(f"file://{remotes_path}", "%s")

--- a/utils/update_checkout/tests/test_ci_optimizations.py
+++ b/utils/update_checkout/tests/test_ci_optimizations.py
@@ -71,7 +71,7 @@ class ShallowCloneTestCase(scheme_mock.SchemeMockTestCase):
             ]
         )
 
-        for repo in self.get_all_repos():
+        for repo in self.repo_names:
             repo_path = os.path.join(self.source_root, repo)
             is_shallow = self.call(
                 ["git", "rev-parse", "--is-shallow-repository"], cwd=repo_path
@@ -98,7 +98,7 @@ class ShallowCloneTestCase(scheme_mock.SchemeMockTestCase):
             ]
         )
 
-        for repo in self.get_all_repos():
+        for repo in self.repo_names:
             repo_path = os.path.join(self.source_root, repo)
             remote_branches = self.call(["git", "branch", "-r"], cwd=repo_path).strip()
             self.assertIn("origin/main", remote_branches)
@@ -123,7 +123,7 @@ class ShallowCloneTestCase(scheme_mock.SchemeMockTestCase):
             ]
         )
 
-        for repo in self.get_all_repos():
+        for repo in self.repo_names:
             repo_path = os.path.join(self.source_root, repo)
             remote_branches = self.call(["git", "branch", "-r"], cwd=repo_path).strip()
             self.assertIn("origin/main", remote_branches)
@@ -148,7 +148,7 @@ class ShallowCloneTestCase(scheme_mock.SchemeMockTestCase):
             ]
         )
 
-        for repo in self.get_all_repos():
+        for repo in self.repo_names:
             repo_path = os.path.join(self.source_root, repo)
             is_shallow = self.call(
                 ["git", "rev-parse", "--is-shallow-repository"], cwd=repo_path
@@ -188,7 +188,7 @@ class PartialCloneTestCase(scheme_mock.SchemeMockTestCase):
             ]
         )
 
-        for repo in self.get_all_repos():
+        for repo in self.repo_names:
             repo_path = os.path.join(self.source_root, repo)
             filter_value = self._get_partial_clone_filter(repo_path)
             self.assertEqual(
@@ -212,7 +212,7 @@ class PartialCloneTestCase(scheme_mock.SchemeMockTestCase):
             ]
         )
 
-        for repo in self.get_all_repos():
+        for repo in self.repo_names:
             repo_path = os.path.join(self.source_root, repo)
             filter_value = self._get_partial_clone_filter(repo_path)
             self.assertIsNone(
@@ -237,7 +237,7 @@ class PartialCloneTestCase(scheme_mock.SchemeMockTestCase):
             ]
         )
 
-        for repo in self.get_all_repos():
+        for repo in self.repo_names:
             repo_path = os.path.join(self.source_root, repo)
 
             is_shallow = self.call(
@@ -265,7 +265,7 @@ class ShallowUpdateTestCase(scheme_mock.SchemeMockTestCase):
     def _push_new_commits(self):
         _add_commit_to_repos(
             self.local_path,
-            self.get_all_repos(),
+            self.repo_names,
             self._NEW_FILE,
             "added by CI update test",
         )
@@ -288,7 +288,7 @@ class ShallowUpdateTestCase(scheme_mock.SchemeMockTestCase):
         self._push_new_commits()
         self.call(base_cmd)
 
-        for repo in self.get_all_repos():
+        for repo in self.repo_names:
             repo_path = os.path.join(self.source_root, repo)
             is_shallow = self.call(
                 ["git", "rev-parse", "--is-shallow-repository"], cwd=repo_path
@@ -317,7 +317,7 @@ class ShallowUpdateTestCase(scheme_mock.SchemeMockTestCase):
         self._push_new_commits()
         self.call(base_cmd)
 
-        for repo in self.get_all_repos():
+        for repo in self.repo_names:
             repo_path = os.path.join(self.source_root, repo)
             local_head = self.call(["git", "rev-parse", "HEAD"], cwd=repo_path).strip()
             remote_tip = self.call(

--- a/utils/update_checkout/tests/test_ci_optimizations.py
+++ b/utils/update_checkout/tests/test_ci_optimizations.py
@@ -22,15 +22,6 @@ import os
 
 from . import scheme_mock
 
-def _add_branch_to_remotes(remote_path, repo_names, branch_name):
-    """Create *branch_name* on every bare remote repo."""
-    for repo_name in repo_names:
-        remote_repo = os.path.join(remote_path, repo_name)
-        scheme_mock.call_quietly(
-            ["git", "branch", branch_name, "main"],
-            cwd=remote_repo,
-        )
-
 
 def _add_commit_to_repos(local_path, repo_names, filename, content):
     """Commit a new file to each local clone and push it to origin."""
@@ -49,11 +40,19 @@ def _add_commit_to_repos(local_path, repo_names, filename, content):
 class ShallowCloneTestCase(scheme_mock.SchemeMockTestCase):
     """--skip-history should produce depth-1, single-branch clones."""
 
+    def _add_branch_to_remotes(self, branch_name):
+        """Create *branch_name* on every bare remote repo."""
+        for repo_name in self.repo_names:
+            scheme_mock.call_quietly(
+                ["git", "branch", branch_name, "main"],
+                cwd=self.remote_path(repo_name=repo_name),
+            )
+
     def setUp(self):
         super().setUp()
         # Add a second branch to every bare remote so single-branch tests are
         # meaningful.
-        _add_branch_to_remotes(self.remote_path, self.get_all_repos(), "other-branch")
+        self._add_branch_to_remotes("other-branch")
 
     def test_skip_history_produces_shallow_clone(self):
         """Repos cloned with --skip-history must be depth-1 shallow clones."""

--- a/utils/update_checkout/tests/test_ci_optimizations.py
+++ b/utils/update_checkout/tests/test_ci_optimizations.py
@@ -168,7 +168,7 @@ class PartialCloneTestCase(scheme_mock.SchemeMockTestCase):
                 ["git", "config", "remote.origin.partialclonefilter"],
                 cwd=repo_path,
             ).strip()
-        except scheme_mock.CallQuietlyException:
+        except scheme_mock.PrintableSubprocessError:
             return None
 
     def test_partial_clone_sets_filter(self):

--- a/utils/update_checkout/tests/test_clone.py
+++ b/utils/update_checkout/tests/test_clone.py
@@ -39,7 +39,7 @@ class CloneTestCase(scheme_mock.SchemeMockTestCase):
             ]
         )
 
-        for repo in self.get_all_repos():
+        for repo in self.repo_names:
             repo_path = os.path.join(self.source_root, repo)
             self.assertTrue(os.path.isdir(repo_path))
 
@@ -79,7 +79,7 @@ class CloneTestCase(scheme_mock.SchemeMockTestCase):
             output,
         )
 
-        repo = self.get_all_repos()[0]
+        repo = self.repo_names[0]
         repo_path = os.path.join(self.source_root, repo)
         shutil.rmtree(repo_path)
         output = self.call(
@@ -113,7 +113,7 @@ class CloneTestCase(scheme_mock.SchemeMockTestCase):
             ]
         )
 
-        for repo in self.get_all_repos():
+        for repo in self.repo_names:
             repo_path = os.path.join(self.source_root, repo)
             output = subprocess.check_output(
                 ["git", "-C", repo_path, "config", "--get", "core.symlinks"], text=True
@@ -127,7 +127,7 @@ class CloneTestCase(scheme_mock.SchemeMockTestCase):
     @patch("update_checkout.update_checkout.obtain_all_additional_swift_sources")
     @patch("sys.exit", return_value=None)
     def test_clone_with_incorrect_git_config(self, mock_exit, mock_obtain):
-        repo = self.get_all_repos()[0]
+        repo = self.repo_names[0]
 
         def side_effect(*args, **kwargs):
             result = obtain_all_additional_swift_sources(*args, **kwargs)
@@ -161,7 +161,7 @@ class CloneTestCase(scheme_mock.SchemeMockTestCase):
     @patch("update_checkout.update_checkout.obtain_all_additional_swift_sources")
     @patch("sys.exit", return_value=None)
     def test_clone_with_missing_git_config_entry(self, mock_exit, mock_obtain):
-        repo = self.get_all_repos()[0]
+        repo = self.repo_names[0]
 
         def side_effect(*args, **kwargs):
             result = obtain_all_additional_swift_sources(*args, **kwargs)
@@ -305,7 +305,7 @@ class SchemeWithHashTestCase(scheme_mock.SchemeMockTestCase):
             ] + additional_flags
         )
 
-        for repo in self.get_all_repos():
+        for repo in self.repo_names:
             repo_path = os.path.join(self.source_root, repo)
             self.assertTrue(os.path.isdir(repo_path))
 
@@ -327,7 +327,7 @@ class SchemeWithMissingRepoTestCase(scheme_mock.SchemeMockTestCase):
             self.source_root,
         ]
 
-        repos = self.get_all_repos()
+        repos = self.repo_names
         repos.pop()
 
         self.scheme_name = "missing-repo"
@@ -342,7 +342,7 @@ class SchemeWithMissingRepoTestCase(scheme_mock.SchemeMockTestCase):
     def test_clone(self):
         self.call(self.base_args + ["--scheme", self.scheme_name, "--clone"])
 
-        missing_repo_path = os.path.join(self.source_root, self.get_all_repos().pop())
+        missing_repo_path = os.path.join(self.source_root, self.repo_names.pop())
         self.assertFalse(os.path.isdir(missing_repo_path))
 
     # Test that we do not update a repository that is not listed in the given

--- a/utils/update_checkout/tests/test_cross_repo_pr.py
+++ b/utils/update_checkout/tests/test_cross_repo_pr.py
@@ -1,0 +1,254 @@
+# ===--- test_cross_repo_pr.py -----------------------------------------------===#
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2026 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+# ===----------------------------------------------------------------------===#
+
+import os
+import random
+
+from . import scheme_mock
+from typing import Dict, List
+
+
+class CrossRepoPRTestCase(scheme_mock.SchemeMockTestCase):
+
+    def setUp(self):
+        self.update_checkout_base_args = [
+            self.update_checkout_path,
+            "--config",
+            self.config_path,
+            "--source-root",
+            self.source_root,
+            "--scheme",
+            "main",
+            "--max-retries",
+            "0",
+        ]
+
+        self.config = {
+            "repos": {
+                "repo1": {
+                    "remote": {"id": os.path.join("apple", "repo1")},
+                },
+                "repo2": {
+                    "remote": {"id": os.path.join("swiftlang", "repo2")},
+                },
+                "swift": {
+                    "remote": {"id": os.path.join("swiftlang", "swift")},
+                },
+            },
+            "default-branch-scheme": "main",
+            "branch-schemes": {
+                "main": {
+                    "aliases": ["main"],
+                    "repos": {
+                        "repo1": "main",
+                        "repo2": "main",
+                        "swift": "main",
+                    },
+                },
+            },
+        }
+
+        super().setUp()
+
+        self.call(self.update_checkout_base_args + ["--clone"])
+
+    def set_up_pr_merge_ref(
+        self,
+        *,
+        repo_name: str,
+        pr_id: int,
+        stale: bool,
+        conflicts_with_base: bool = False,
+    ):
+        # Conflict is only relevant for the stale case.
+        self.assertTrue(stale is True or conflicts_with_base is False)
+
+        repo_path = os.path.join(self.local_path, repo_name)
+        conflict_filename = "conflict.txt"
+        conflict_file_path = os.path.join(repo_path, conflict_filename)
+
+        # Goal:
+        #   C---D (my_branch)
+        #  /   /
+        # A---B---E (main)
+        #
+        # We will use commit D for the PR merge ref. Commit E is created if
+        # the `stale` argument is true.
+
+        # Create commit B. Commit A should already exist from initial setup.
+        self.call(
+            ["git", "commit", "--allow-empty", "-m", "B"],
+            cwd=repo_path,
+        )
+
+        # Create my_branch.
+        self.call(["git", "checkout", "-b", "my_branch", "HEAD~1"], cwd=repo_path)
+
+        # Arrange for an eventual conflict between commits E and D if asked to.
+        if conflicts_with_base:
+            with open(conflict_file_path, "w") as f:
+                f.write("pr-version\n")
+            self.call(["git", "add", conflict_filename], cwd=repo_path)
+
+        # Create commit C and the merge commit D.
+        self.call(
+            ["git", "commit", "--allow-empty", "-m", "C"],
+            cwd=repo_path,
+        )
+        self.call(["git", "merge", "--no-ff", "-m", "D", "main"], cwd=repo_path)
+
+        # Advance main (create commit E) to make the merge commit D stale if
+        # asked to.
+        if stale:
+            self.call(["git", "checkout", "main"], cwd=repo_path)
+
+            # Arrange for an eventual conflict between commits E and D if
+            # asked to.
+            if conflicts_with_base:
+                with open(conflict_file_path, "w") as f:
+                    f.write("main-version\n")
+                self.call(["git", "add", conflict_filename], cwd=repo_path)
+
+            # Create commit E.
+            self.call(
+                ["git", "commit", "--allow-empty", "-m", "E"],
+                cwd=repo_path,
+            )
+
+        # Push main and the PR merge ref to the remote.
+        self.call(
+            ["git", "push", "origin", "main", f"my_branch:refs/pull/{pr_id}/merge"],
+            cwd=repo_path,
+        )
+
+    # When the merge ref is stale, update-checkout is expected to check it out
+    # and merge the tip of the base branch into it.
+    def verify_head_for_stale_pr_merge_ref(self, *, repo_name: str, pr_id: int):
+        repo_path = os.path.join(self.source_root, repo_name)
+        remote_path = self.remote_path(repo_name=repo_name)
+
+        expected_parent_commits = self.call(
+            ["git", "rev-parse", f"refs/pull/{pr_id}/merge", "refs/heads/main"],
+            cwd=remote_path,
+        ).split()
+
+        actual_parent_commits = self.call(
+            ["git", "log", "--pretty=%P", "-1", "HEAD"],
+            cwd=repo_path,
+        ).split()
+
+        self.assertEqual(expected_parent_commits, actual_parent_commits)
+
+    # When the merge ref is up to date, update-checkout is expected to simply
+    # check it out.
+    def verify_head_for_up_to_date_pr_merge_ref(self, *, repo_name: str, pr_id: int):
+        repo_path = os.path.join(self.source_root, repo_name)
+        remote_path = self.remote_path(repo_name=repo_name)
+
+        expected_head = self.call(
+            ["git", "rev-parse", f"refs/pull/{pr_id}/merge"], cwd=remote_path
+        )
+
+        actual_head = self.call(["git", "rev-parse", "HEAD"], cwd=repo_path)
+
+        self.assertEqual(expected_head, actual_head)
+
+    def test_checkout_stale_pr_merge_ref(self):
+        pr_id = 1
+        self.set_up_pr_merge_ref(repo_name="repo1", pr_id=pr_id, stale=True)
+        self.call(
+            self.update_checkout_base_args
+            + [
+                "--github-comment",
+                f"""
+                https://github.com/apple/repo1/pull/{pr_id}
+                @swift-ci please test
+                """,
+            ]
+        )
+        self.verify_head_for_stale_pr_merge_ref(repo_name="repo1", pr_id=pr_id)
+
+    def test_checkout_stale_pr_merge_ref_swift(self):
+        pr_id = 1
+        self.set_up_pr_merge_ref(repo_name="swift", pr_id=pr_id, stale=True)
+        self.call(
+            self.update_checkout_base_args
+            + [
+                "--github-comment",
+                f"""
+                https://github.com/swiftlang/swift/pull/{pr_id}
+                @swift-ci please test
+                """,
+            ]
+        )
+        self.verify_head_for_stale_pr_merge_ref(repo_name="swift", pr_id=pr_id)
+
+    def test_checkout_stale_pr_merge_ref_conflict_with_base_branch(self):
+        pr_id = 1
+        self.set_up_pr_merge_ref(
+            repo_name="repo1", pr_id=pr_id, stale=True, conflicts_with_base=True
+        )
+
+        # update-checkout should fail because re-merging main into the PR
+        # merge ref produces a conflict.
+        with self.assertRaises(scheme_mock.PrintableSubprocessError) as cxt_mgr:
+            self.call(
+                self.update_checkout_base_args
+                + [
+                    "--github-comment",
+                    f"""
+                    https://github.com/apple/repo1/pull/{pr_id}
+                    @swift-ci please test
+                    """,
+                ]
+            )
+
+        self.assertIn("CONFLICT (add/add)", cxt_mgr.exception.output)
+
+        # The merge should have been aborted, leaving no MERGE_HEAD and no
+        # uncommitted changes in the working tree.
+        repo_path = os.path.join(self.source_root, "repo1")
+        self.assertFalse(os.path.exists(os.path.join(repo_path, ".git", "MERGE_HEAD")))
+        status_output = self.call(["git", "status", "--porcelain"], cwd=repo_path)
+        self.assertEqual(status_output.strip(), "")
+
+    def test_checkout_multiple_stale_pr_merge_ref(self):
+        self.set_up_pr_merge_ref(repo_name="repo1", pr_id=1, stale=True)
+        self.set_up_pr_merge_ref(repo_name="repo2", pr_id=2, stale=True)
+        self.call(
+            self.update_checkout_base_args
+            + [
+                "--github-comment",
+                f"""
+                https://github.com/apple/repo1/pull/1
+                @swift-ci please test
+                https://github.com/swiftlang/repo2/pull/2
+                """,
+            ]
+        )
+        self.verify_head_for_stale_pr_merge_ref(repo_name="repo1", pr_id=1)
+        self.verify_head_for_stale_pr_merge_ref(repo_name="repo2", pr_id=2)
+
+    def test_checkout_up_to_date_pr_merge_ref(self):
+        pr_id = 1
+        self.set_up_pr_merge_ref(repo_name="repo1", pr_id=pr_id, stale=False)
+        self.call(
+            self.update_checkout_base_args
+            + [
+                "--github-comment",
+                f"""
+                https://github.com/apple/repo1/pull/{pr_id}
+                @swift-ci please test
+                """,
+            ]
+        )
+        self.verify_head_for_up_to_date_pr_merge_ref(repo_name="repo1", pr_id=pr_id)

--- a/utils/update_checkout/update_checkout/update_checkout.py
+++ b/utils/update_checkout/update_checkout/update_checkout.py
@@ -92,6 +92,10 @@ def find_rev_by_timestamp(
         raise RuntimeError("No rev in %s before timestamp %s" % (repo_name, timestamp))
 
 
+def output_prefix(repo_name: str):
+    return f"[{repo_name}] ".ljust(40)
+
+
 def get_branch_for_repo(
     repo_path: Path,
     config: Dict[str, Any],
@@ -120,30 +124,55 @@ def get_branch_for_repo(
     repo_branch = scheme_name
     if scheme_map:
         scheme_branch = scheme_map[repo_name]
-        repo_branch = scheme_branch
         remote_repo_id = config["repos"][repo_name]["remote"]["id"]
         if remote_repo_id in cross_repos_pr:
+            prefix = output_prefix(repo_name)
             cross_repo = True
             pr_id = cross_repos_pr[remote_repo_id]
             repo_branch = "ci_pr_{0}".format(pr_id)
-            Git.run(repo_path, ["checkout", scheme_branch], echo=True)
-            Git.run(
-                repo_path,
-                ["branch", "-D", repo_branch],
-                echo=True,
-                allow_non_zero_exit=True,
-                fatal=True,
-            )
+
+            # Fetch the PR merge branch into repo_branch, and also fetch the
+            # scheme branch, which ought to match the PR base branch.
             Git.run(
                 repo_path,
                 [
                     "fetch",
                     "origin",
-                    "pull/{0}/merge:{1}".format(pr_id, repo_branch),
+                    # If repo_branch exists, overwrite it.
+                    "--force",
+                    # If repo_branch exists and is checked out, this will
+                    # prevent Git from refusing the fetch.
+                    "--update-head-ok",
                     "--tags",
+                    f"pull/{pr_id}/merge:{repo_branch}",
+                    scheme_branch,
                 ],
                 echo=True,
+                prefix=prefix,
             )
+            # Check out repo_branch and merge the base branch into it.
+            # GitHub cannot be trusted to keep PR merge branches up-to-date.
+            Git.run(repo_path, ["checkout", repo_branch], echo=True, prefix=prefix)
+            try:
+                Git.run(
+                    repo_path,
+                    ["merge", f"origin/{scheme_branch}", "--no-edit"],
+                    echo=True,
+                    prefix=prefix,
+                )
+            except Exception as e:
+                # If the merge fails, odds are there's a conflict. Either way
+                # we do not want to proceed. Abort the merge to leave a clean
+                # working directory behind, ignoring errors, and fail with the
+                # merge error.
+                try:
+                    Git.run(repo_path, ["merge", "--abort"], echo=True, prefix=prefix)
+                except:
+                    pass
+                raise e
+        else:
+            repo_branch = scheme_branch
+
     return repo_branch, cross_repo
 
 
@@ -156,7 +185,7 @@ def update_single_repository(pool_args: UpdateArguments):
         return
 
     try:
-        prefix = f"[{repo_path.name}] ".ljust(40)
+        prefix = output_prefix(repo_name)
         if verbose:
             print(f"{prefix}Updating '{repo_path}'")
 
@@ -1025,7 +1054,7 @@ def main() -> int:
                     swift_repo_path,
                     ["checkout", branch_name],
                     echo=True,
-                    prefix="[swift] ",
+                    prefix=output_prefix("swift"),
                 )
 
                 # Re-read the config after checkout.


### PR DESCRIPTION
GitHub seems to have stopped updating PR merge refs in response to updates to their respective base branches. This is very disprutive: people are getting spurious failures in pull request testing (with the only timely remedy being a rebase) or merging unviable pull requests and breaking CI.

Re-merge the base branch into a checked out PR merge ref to make sure it is up to date.