### PR TITLE
[6.4] [Runtime] Fix the swift_retain hook when ObjC interop is disabled.

### DIFF
--- a/stdlib/public/SwiftShims/swift/shims/HeapObject.h
+++ b/stdlib/public/SwiftShims/swift/shims/HeapObject.h
@@ -295,6 +295,9 @@ static const unsigned ObjCReservedLowBits =
     _swift_abi_ObjCReservedLowBits;
 static const __swift_uintptr_t BridgeObjectTagBitsMask =
     _swift_BridgeObject_TaggedPointerBits;
+static const __swift_uintptr_t UntaggedNonNativeBridgeObjectBits =
+   SwiftSpareBitsMask & ~ObjCReservedBitsMask & ~BridgeObjectTagBitsMask;
+
 } // heap_object_abi
 #endif // __cplusplus
 

--- a/stdlib/public/runtime/HeapObject.cpp
+++ b/stdlib/public/runtime/HeapObject.cpp
@@ -492,7 +492,7 @@ SWIFT_ALWAYS_INLINE static HeapObject *_swift_retain_(HeapObject *object) {
 SWIFT_REFCOUNT_CC
 static HeapObject *_swift_retain_adapterImpl(HeapObject *object) {
   HeapObject *masked =
-      (HeapObject *)((uintptr_t)object & ~heap_object_abi::SwiftSpareBitsMask);
+      (HeapObject *)((uintptr_t)object & ~heap_object_abi::UntaggedNonNativeBridgeObjectBits);
   _swift_retain(masked);
   return object;
 }

--- a/stdlib/public/runtime/SwiftObject.mm
+++ b/stdlib/public/runtime/SwiftObject.mm
@@ -567,12 +567,6 @@ _swift_objcClassUsesNativeSwiftReferenceCounting(const Metadata *theClass) {
 #endif
 }
 
-// The non-pointer bits, excluding the tag bits.
-static auto const unTaggedNonNativeBridgeObjectBits
-  = heap_object_abi::SwiftSpareBitsMask
-  & ~heap_object_abi::ObjCReservedBitsMask
-  & ~heap_object_abi::BridgeObjectTagBitsMask;
-
 #if SWIFT_OBJC_INTEROP
 
 #if defined(__x86_64__)
@@ -674,7 +668,7 @@ static bool isBridgeObjectTaggedPointer(void *object) {
 ///
 /// Precondition: object does not encode a tagged pointer
 static void* toPlainObject_unTagged_bridgeObject(void *object) {
-  return (void*)(uintptr_t(object) & ~unTaggedNonNativeBridgeObjectBits);
+  return (void*)(uintptr_t(object) & ~heap_object_abi::UntaggedNonNativeBridgeObjectBits);
 }
 
 #if SWIFT_OBJC_INTEROP

--- a/test/Runtime/Inputs/refcount_hooks.h
+++ b/test/Runtime/Inputs/refcount_hooks.h
@@ -1,0 +1,7 @@
+#include <stddef.h>
+
+typedef void *(*AllocObjectFn)(const void *metadata,
+                               size_t requiredSize,
+                               size_t requiredAlignmentMask);
+
+extern AllocObjectFn _swift_allocObject;

--- a/test/Runtime/refcount_hooks.swift
+++ b/test/Runtime/refcount_hooks.swift
@@ -1,0 +1,27 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-run-simple-swift(-import-objc-header %S/Inputs/refcount_hooks.h)
+
+// REQUIRES: executable_test
+// REQUIRES: OS=macosx || OS=linux-gnu
+
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
+// Override _swift_allocObject with a no-op wrapper that forwards to the
+// original implementation. This ensures the runtime goes through the hooks
+// path and exercises the hooks machinery without crashing.
+
+var originalAllocObject: AllocObjectFn = _swift_allocObject
+
+func hookedAllocObject(
+  _ metadata: UnsafeRawPointer?,
+  _ requiredSize: Int,
+  _ requiredAlignmentMask: Int
+) -> UnsafeMutableRawPointer? {
+  return originalAllocObject(metadata, requiredSize, requiredAlignmentMask)
+}
+
+_swift_allocObject = hookedAllocObject
+
+// A single print does plenty of refcounting to exercise the hooks.
+print("Hello, world.")


### PR DESCRIPTION
- **Explanation**:
  Mask the non-native bridgeobject bits rather than all spare bits in the
  `swift_retain` hook path. This prevents the runtime from trying to retain
  pointers that aren't valid native object pointers when Objective-C interop
  is disabled (e.g. on Linux).
- **Scope**:
  Affects the runtime's reference-counting hook behavior when ObjC interop is
  disabled. The fix narrows the bits that are masked so that only non-native
  bridgeobject bits are cleared. Small, contained change to the runtime.
- **Issues**:
  None referenced in the original PR.
- **Original PRs**:
  https://github.com/swiftlang/swift/pull/88924
- **Risk**:
  Low. The change corrects masking logic in the retain hook and is covered by a
  new runtime test. It only alters behavior on the previously-incorrect path
  (ObjC interop disabled), making it safer rather than introducing new behavior.
- **Testing**:
  Adds `test/Runtime/refcount_hooks.swift` (with `Inputs/refcount_hooks.h`)
  exercising the retain/release hooks. Validated via CI.
- **Reviewers**:
  The original change was GitHub-approved by code owners @compnerd and
  @al45tair in https://github.com/swiftlang/swift/pull/88924.
