### PR TITLE
stdlib/public: Add `EmscriptenLibc` stdlib overlay

### DIFF
--- a/stdlib/public/CommandLineSupport/CommandLine.cpp
+++ b/stdlib/public/CommandLineSupport/CommandLine.cpp
@@ -503,6 +503,56 @@ static char **swift::getUnsafeArgvArgc(int *outArgLen) {
 
 template <typename F>
 static void swift::enumerateUnsafeArgv(const F& body) { }
+#elif defined(__EMSCRIPTEN__)
+#include <emscripten.h>
+#include <stdlib.h>
+
+// EM_JS functions become wasm imports resolved by emcc's JS output.
+// Module['arguments'] and thisProgram are set in Emscripten's preamble
+// before any wasm code executes, so these work during static initialization.
+
+// EM_JS macro expansion produces an extra semicolon after extern "C" block.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wc++98-compat-extra-semi"
+
+EM_JS(int, _swift_emscripten_getArgCount, (), {
+  return (Module['arguments'] || []).length + 1;
+});
+
+EM_JS(int, _swift_emscripten_getArgLen, (int index), {
+  var args = [thisProgram].concat(Module['arguments'] || []);
+  if (index >= args.length) return -1;
+  return lengthBytesUTF8(args[index]);
+});
+
+EM_JS(void, _swift_emscripten_getArg, (int index, char *buf, int bufLen), {
+  var args = [thisProgram].concat(Module['arguments'] || []);
+  if (index < args.length) {
+    stringToUTF8(args[index], buf, bufLen);
+  }
+});
+
+#pragma clang diagnostic pop
+
+static char **swift::getUnsafeArgvArgc(int *outArgLen) {
+  return nullptr;
+}
+
+template <typename F>
+static void swift::enumerateUnsafeArgv(const F& body) {
+  int argc = _swift_emscripten_getArgCount();
+  for (int i = 0; i < argc; i++) {
+    int len = _swift_emscripten_getArgLen(i);
+    if (len >= 0) {
+      char *buf = static_cast<char *>(malloc(len + 1));
+      if (buf) {
+        _swift_emscripten_getArg(i, buf, len + 1);
+        body(argc, buf);
+        free(buf);
+      }
+    }
+  }
+}
 #elif defined(__OpenBSD__)
 #include <sys/types.h>
 #include <sys/sysctl.h>

--- a/stdlib/public/Platform/CMakeLists.txt
+++ b/stdlib/public/Platform/CMakeLists.txt
@@ -64,6 +64,23 @@ add_swift_target_library(swiftWASILibc ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_SD
     INSTALL_IN_COMPONENT sdk-overlay
     DEPENDS wasilibc_modulemap)
 
+add_swift_target_library(swiftEmscriptenLibc ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
+    ${swift_platform_sources}
+    POSIXError.swift
+
+    GYB_SOURCES
+      ${swift_platform_gyb_sources}
+      EmscriptenLibc.swift.gyb
+
+    SWIFT_COMPILE_FLAGS
+      ${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS}
+      ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
+      ${swift_platform_compile_flags}
+    LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
+    TARGET_SDKS EMSCRIPTEN
+    INSTALL_IN_COMPONENT sdk-overlay
+    DEPENDS emscriptenlibc_modulemap)
+
 add_swift_target_library(swiftCRT ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
     ucrt.swift
     ${swift_platform_sources}
@@ -466,6 +483,90 @@ add_custom_target(wasilibc_modulemap DEPENDS ${wasilibc_modulemap_target_list})
 set_property(TARGET wasilibc_modulemap PROPERTY FOLDER "Miscellaneous")
 add_dependencies(sdk-overlay wasilibc_modulemap)
 
+set(emscriptenlibc_modulemap_target_list)
+if("EMSCRIPTEN" IN_LIST SWIFT_SDKS)
+  set(emscriptenlibc_modulemap_source "emscripten-libc.modulemap")
+  foreach(arch ${SWIFT_SDK_EMSCRIPTEN_ARCHITECTURES})
+    set(arch_subdir "${SWIFT_SDK_EMSCRIPTEN_LIB_SUBDIR}/${arch}")
+    set(module_dir "${SWIFTLIB_DIR}/${arch_subdir}")
+    set(module_dir_static "${SWIFTSTATICLIB_DIR}/${arch_subdir}")
+    set(module_dir_embedded "${SWIFTLIB_DIR}/embedded/${arch}")
+
+    add_custom_command_target(
+      copy_emscriptenlibc_modulemap_resource
+      COMMAND
+        "${CMAKE_COMMAND}" "-E" "make_directory" ${module_dir} ${module_dir_static}
+      COMMAND
+        "${CMAKE_COMMAND}" "-E" "copy_if_different"
+          "${CMAKE_CURRENT_SOURCE_DIR}/${emscriptenlibc_modulemap_source}" ${module_dir}
+      COMMAND
+        "${CMAKE_COMMAND}" "-E" "copy_if_different"
+          "${CMAKE_CURRENT_SOURCE_DIR}/${emscriptenlibc_modulemap_source}" ${module_dir_static}
+      OUTPUT ${module_dir}/${emscriptenlibc_modulemap_source} ${module_dir_static}/${emscriptenlibc_modulemap_source}
+      COMMENT "Copying EmscriptenLibc modulemap to resource directories")
+    add_dependencies(sdk-overlay ${copy_emscriptenlibc_modulemap_resource})
+    list(APPEND emscriptenlibc_modulemap_target_list ${copy_emscriptenlibc_modulemap_resource})
+
+    swift_install_in_component(FILES "${emscriptenlibc_modulemap_source}"
+                               DESTINATION "lib/swift/${arch_subdir}"
+                               COMPONENT sdk-overlay)
+    if(SWIFT_BUILD_STATIC_STDLIB)
+      swift_install_in_component(FILES "${emscriptenlibc_modulemap_source}"
+                                 DESTINATION "lib/swift_static/${arch_subdir}"
+                                 COMPONENT sdk-overlay)
+    endif()
+
+    if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
+      add_custom_command_target(
+        copy_emscriptenlibc_modulemap_embedded_resource
+        COMMAND
+          "${CMAKE_COMMAND}" "-E" "make_directory" ${module_dir} ${module_dir_embedded}
+        COMMAND
+          "${CMAKE_COMMAND}" "-E" "copy_if_different"
+            "${CMAKE_CURRENT_SOURCE_DIR}/${emscriptenlibc_modulemap_source}" ${module_dir_embedded}
+        OUTPUT "${module_dir_embedded}/${emscriptenlibc_modulemap_source}"
+        COMMENT "Copying EmscriptenLibc modulemap to resource directories")
+      add_dependencies(sdk-overlay ${copy_emscriptenlibc_modulemap_embedded_resource})
+      list(APPEND emscriptenlibc_modulemap_target_list ${copy_emscriptenlibc_modulemap_embedded_resource})
+
+      swift_install_in_component(FILES "${emscriptenlibc_modulemap_source}"
+                                 DESTINATION "lib/swift/embedded/${arch}"
+                                 COMPONENT sdk-overlay)
+    endif()
+
+    set(emscriptenlibc_apinotes_source "SwiftEmscriptenLibc.apinotes")
+    add_custom_command_target(
+      copy_emscriptenlibc_apinotes_resource
+      COMMAND
+        "${CMAKE_COMMAND}" "-E" "make_directory" ${SWIFTLIB_DIR}/apinotes ${SWIFTSTATICLIB_DIR}/apinotes
+      COMMAND
+        "${CMAKE_COMMAND}" "-E" "copy_if_different"
+          "${CMAKE_CURRENT_SOURCE_DIR}/${emscriptenlibc_apinotes_source}" ${SWIFTLIB_DIR}/apinotes
+      COMMAND
+        "${CMAKE_COMMAND}" "-E" "copy_if_different"
+          "${CMAKE_CURRENT_SOURCE_DIR}/${emscriptenlibc_apinotes_source}" ${SWIFTSTATICLIB_DIR}/apinotes
+      OUTPUT
+        ${SWIFTLIB_DIR}/apinotes/${emscriptenlibc_apinotes_source}
+        ${SWIFTSTATICLIB_DIR}/apinotes/${emscriptenlibc_apinotes_source}
+      COMMENT "Copying EmscriptenLibc API notes to resource directories")
+
+    list(APPEND emscriptenlibc_modulemap_target_list ${copy_emscriptenlibc_apinotes_resource})
+    add_dependencies(sdk-overlay ${copy_emscriptenlibc_apinotes_resource})
+    swift_install_in_component(FILES "${emscriptenlibc_apinotes_source}"
+                               DESTINATION "lib/swift/apinotes"
+                               COMPONENT sdk-overlay)
+    if(SWIFT_BUILD_STATIC_STDLIB)
+      swift_install_in_component(FILES "${emscriptenlibc_apinotes_source}"
+                                 DESTINATION "lib/swift_static/apinotes"
+                                 COMPONENT sdk-overlay)
+    endif()
+
+  endforeach()
+endif()
+add_custom_target(emscriptenlibc_modulemap DEPENDS ${emscriptenlibc_modulemap_target_list})
+set_property(TARGET emscriptenlibc_modulemap PROPERTY FOLDER "Miscellaneous")
+add_dependencies(sdk-overlay emscriptenlibc_modulemap)
+
 if(WINDOWS IN_LIST SWIFT_SDKS)
   swift_install_in_component(FILES
       ucrt.modulemap
@@ -509,6 +610,39 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
       ARCHITECTURE "${arch}"
       ARCHITECTURE_SUBDIR_NAME "${triple}"
       DEPENDS embedded-stdlib-${triple} wasilibc_modulemap
+      INSTALL_IN_COMPONENT sdk-overlay
+    )
+    add_dependencies(embedded-stdlib-platform embedded-stdlib-platform-${triple})
+  endif()
+
+  if(SWIFT_EMSCRIPTEN_SYSROOT_PATH)
+    set(arch "wasm32")
+    set(triple "wasm32-unknown-emscripten")
+
+    set(SWIFT_SDK_embedded_ARCH_${arch}_MODULE "${triple}")
+    set(SWIFT_SDK_embedded_LIB_SUBDIR "embedded")
+    set(SWIFT_SDK_embedded_ARCH_${arch}_TRIPLE "${triple}")
+    add_swift_target_library_single(
+      embedded-stdlib-platform-${triple}
+      swiftEmscriptenLibc
+      ONLY_SWIFTMODULE
+      IS_STDLIB IS_FRAGILE
+        ${swift_platform_sources}
+        POSIXError.swift
+
+      GYB_SOURCES
+        ${swift_platform_gyb_sources}
+        EmscriptenLibc.swift.gyb
+
+      SWIFT_COMPILE_FLAGS
+        -enable-experimental-feature Embedded
+        -Xfrontend -emit-empty-object-file
+
+      MODULE_DIR "${CMAKE_BINARY_DIR}/lib/swift/embedded"
+      SDK "embedded"
+      ARCHITECTURE "${arch}"
+      ARCHITECTURE_SUBDIR_NAME "${triple}"
+      DEPENDS embedded-stdlib-${triple} emscriptenlibc_modulemap
       INSTALL_IN_COMPONENT sdk-overlay
     )
     add_dependencies(embedded-stdlib-platform embedded-stdlib-platform-${triple})

--- a/stdlib/public/Platform/EmscriptenLibc.swift.gyb
+++ b/stdlib/public/Platform/EmscriptenLibc.swift.gyb
@@ -1,0 +1,166 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_exported import SwiftEmscriptenLibc // Clang module
+
+//  Constants defined by <math.h>
+@available(swift, deprecated: 3.0, message: "Please use 'Double.pi' or '.pi' to get the value of correct type and avoid casting.")
+public let M_PI = Double.pi
+
+@available(swift, deprecated: 3.0, message: "Please use 'Double.pi / 2' or '.pi / 2' to get the value of correct type and avoid casting.")
+public let M_PI_2 = Double.pi / 2
+
+@available(swift, deprecated: 3.0, message: "Please use 'Double.pi / 4' or '.pi / 4' to get the value of correct type and avoid casting.")
+public let M_PI_4 = Double.pi / 4
+
+@available(swift, deprecated: 3.0, message: "Please use '2.squareRoot()'.")
+public let M_SQRT2 = 2.squareRoot()
+
+@available(swift, deprecated: 3.0, message: "Please use '0.5.squareRoot()'.")
+public let M_SQRT1_2 = 0.5.squareRoot()
+
+//  Constants defined by <float.h>
+@available(swift, deprecated: 3.0, message: "Please use 'T.radix' to get the radix of a FloatingPoint type 'T'.")
+public let FLT_RADIX = Double.radix
+
+%for type, prefix in [('Float', 'FLT'), ('Double', 'DBL')]:
+//  Where does the 1 come from? C counts the usually-implicit leading
+//  significand bit, but Swift does not. Neither is really right or wrong.
+@available(swift, deprecated: 3.0, message: "Please use '${type}.significandBitCount + 1'.")
+public let ${prefix}_MANT_DIG = ${type}.significandBitCount + 1
+
+//  Where does the 1 come from? C models floating-point numbers as having a
+//  significand in [0.5, 1), but Swift (following IEEE 754) considers the
+//  significand to be in [1, 2). This rationale applies to ${prefix}_MIN_EXP
+//  as well.
+@available(swift, deprecated: 3.0, message: "Please use '${type}.greatestFiniteMagnitude.exponent + 1'.")
+public let ${prefix}_MAX_EXP = ${type}.greatestFiniteMagnitude.exponent + 1
+
+@available(swift, deprecated: 3.0, message: "Please use '${type}.leastNormalMagnitude.exponent + 1'.")
+public let ${prefix}_MIN_EXP = ${type}.leastNormalMagnitude.exponent + 1
+
+@available(swift, deprecated: 3.0, message: "Please use '${type}.greatestFiniteMagnitude' or '.greatestFiniteMagnitude'.")
+public let ${prefix}_MAX = ${type}.greatestFiniteMagnitude
+
+@available(swift, deprecated: 3.0, message: "Please use '${type}.ulpOfOne' or '.ulpOfOne'.")
+public let ${prefix}_EPSILON = ${type}.ulpOfOne
+
+@available(swift, deprecated: 3.0, message: "Please use '${type}.leastNormalMagnitude' or '.leastNormalMagnitude'.")
+public let ${prefix}_MIN = ${type}.leastNormalMagnitude
+
+@available(swift, deprecated: 3.0, message: "Please use '${type}.leastNonzeroMagnitude' or '.leastNonzeroMagnitude'.")
+public let ${prefix}_TRUE_MIN = ${type}.leastNonzeroMagnitude
+
+%end
+
+public let MAP_FAILED: UnsafeMutableRawPointer! = UnsafeMutableRawPointer(bitPattern: -1)
+
+// NOTE: Emscripten's musl-based libc defines errno codes via __WASI_ERRNO_*
+// macros (from <wasi/api.h>), which are function-like macros that
+// ClangImporter can't import. Emscripten adopted WASI's errno ABI for its
+// low-level syscall interface, so most codes use WASI numbering (1–76).
+// EOPNOTSUPP and ENOTSUP diverge: Emscripten uses Linux/musl value 138 rather
+// than WASI's value 58. ENOTCAPABLE is omitted as it is a WASI-only capability
+// error not exposed by Emscripten's <bits/errno.h>.
+%{
+posix_error_codes = [
+  "E2BIG",
+  "EACCES",
+  "EADDRINUSE",
+  "EADDRNOTAVAIL",
+  "EAFNOSUPPORT",
+  "EAGAIN",
+  "EWOULDBLOCK",
+  "EALREADY",
+  "EBADF",
+  "EBADMSG",
+  "EBUSY",
+  "ECANCELED",
+  "ECHILD",
+  "ECONNABORTED",
+  "ECONNREFUSED",
+  "ECONNRESET",
+  "EDEADLK",
+  "EDESTADDRREQ",
+  "EDOM",
+  "EDQUOT",
+  "EEXIST",
+  "EFAULT",
+  "EFBIG",
+  "EHOSTUNREACH",
+  "EIDRM",
+  "EILSEQ",
+  "EINPROGRESS",
+  "EINTR",
+  "EINVAL",
+  "EIO",
+  "EISCONN",
+  "EISDIR",
+  "ELOOP",
+  "EMFILE",
+  "EMLINK",
+  "EMSGSIZE",
+  "EMULTIHOP",
+  "ENAMETOOLONG",
+  "ENETDOWN",
+  "ENETRESET",
+  "ENETUNREACH",
+  "ENFILE",
+  "ENOBUFS",
+  "ENODEV",
+  "ENOENT",
+  "ENOEXEC",
+  "ENOLCK",
+  "ENOLINK",
+  "ENOMEM",
+  "ENOMSG",
+  "ENOPROTOOPT",
+  "ENOSPC",
+  "ENOSYS",
+  "ENOTCONN",
+  "ENOTDIR",
+  "ENOTEMPTY",
+  "ENOTRECOVERABLE",
+  "ENOTSOCK",
+  "ENOTSUP",
+  "EOPNOTSUPP",
+  "ENOTTY",
+  "ENXIO",
+  "EOVERFLOW",
+  "EOWNERDEAD",
+  "EPERM",
+  "EPIPE",
+  "EPROTO",
+  "EPROTONOSUPPORT",
+  "EPROTOTYPE",
+  "ERANGE",
+  "EROFS",
+  "ESPIPE",
+  "ESRCH",
+  "ESTALE",
+  "ETIMEDOUT",
+  "ETXTBSY",
+  "EXDEV",
+]
+}%
+
+%for ecode in posix_error_codes:
+
+public let ${ecode} = POSIXErrorCode.${ecode}.rawValue
+
+%end
+
+// NOTE: The Emscripten sysroot's _seek.h defines these macros as function-like macros, which ClangImporter can't import for now.
+
+public let SEEK_SET: Int32 = 0
+public let SEEK_CUR: Int32 = 1
+public let SEEK_END: Int32 = 2

--- a/stdlib/public/Platform/POSIXError.swift
+++ b/stdlib/public/Platform/POSIXError.swift
@@ -432,7 +432,7 @@ public enum POSIXErrorCode: Int32, Sendable {
 
   /// Operation not supported on transport endpoint
   public static var EOPNOTSUPP: POSIXErrorCode { return .ENOTSUP }
-  
+
   /// Inappropriate I/O control operation.
   case ENOTTY          = 59
   /// No such device or address.
@@ -469,6 +469,199 @@ public enum POSIXErrorCode: Int32, Sendable {
   case EXDEV           = 75
   /// Extension: Capabilities insufficient.
   case ENOTCAPABLE     = 76
+}
+
+#elseif os(Emscripten)
+
+// Emscripten's musl-based libc uses WASI's errno ABI: most errno codes are
+// defined via __WASI_ERRNO_* macros from <wasi/api.h>, giving values 1–75 that
+// match the WASI POSIXErrorCode enum above. However, Emscripten diverges from
+// pure WASI in two ways:
+//
+// 1. EOPNOTSUPP is NOT aliased to ENOTSUP (value 58 from __WASI_ERRNO_NOTSUP).
+//    Instead, Emscripten's <bits/errno.h> defines EOPNOTSUPP = 138 as a
+//    standalone code following Linux/musl conventions, and aliases ENOTSUP to
+//    EOPNOTSUPP. If C code sets errno to EOPNOTSUPP, the value is 138, not 58.
+//
+// 2. ENOTCAPABLE (__WASI_ERRNO_NOTCAPABLE = 76) is a WASI-specific capability
+//    error. Emscripten's <bits/errno.h> does not define it because Emscripten
+//    does not use the WASI capability model.
+//
+// Because of the EOPNOTSUPP value difference (58 vs 138), Emscripten needs its
+// own POSIXErrorCode enum to ensure POSIXErrorCode(rawValue: errno) matches
+// the actual C-level errno values.
+
+/// Enumeration describing POSIX error codes.
+public enum POSIXErrorCode: Int32, Sendable {
+  /// Argument list too long.
+  case E2BIG           = 1
+  /// Permission denied.
+  case EACCES          = 2
+  /// Address in use.
+  case EADDRINUSE      = 3
+  /// Address not available.
+  case EADDRNOTAVAIL   = 4
+  /// Address family not supported.
+  case EAFNOSUPPORT    = 5
+  /// Resource unavailable, or operation would block.
+  case EAGAIN          = 6
+
+  /// Operation would block.
+  public static var EWOULDBLOCK: POSIXErrorCode { return .EAGAIN }
+
+  /// Connection already in progress.
+  case EALREADY        = 7
+  /// Bad file descriptor.
+  case EBADF           = 8
+  /// Bad message.
+  case EBADMSG         = 9
+  /// Device or resource busy.
+  case EBUSY           = 10
+  /// Operation canceled.
+  case ECANCELED       = 11
+  /// No child processes.
+  case ECHILD          = 12
+  /// Connection aborted.
+  case ECONNABORTED    = 13
+  /// Connection refused.
+  case ECONNREFUSED    = 14
+  /// Connection reset.
+  case ECONNRESET      = 15
+  /// Resource deadlock would occur.
+  case EDEADLK         = 16
+  /// Destination address required.
+  case EDESTADDRREQ    = 17
+  /// Mathematics argument out of domain of function.
+  case EDOM            = 18
+  /// Reserved.
+  case EDQUOT          = 19
+  /// File exists.
+  case EEXIST          = 20
+  /// Bad address.
+  case EFAULT          = 21
+  /// File too large.
+  case EFBIG           = 22
+  /// Host is unreachable.
+  case EHOSTUNREACH    = 23
+  /// Identifier removed.
+  case EIDRM           = 24
+  /// Illegal byte sequence.
+  case EILSEQ          = 25
+  /// Operation in progress.
+  case EINPROGRESS     = 26
+  /// Interrupted function.
+  case EINTR           = 27
+  /// Invalid argument.
+  case EINVAL          = 28
+  /// I/O error.
+  case EIO             = 29
+  /// Socket is connected.
+  case EISCONN         = 30
+  /// Is a directory.
+  case EISDIR          = 31
+  /// Too many levels of symbolic links.
+  case ELOOP           = 32
+  /// File descriptor value too large.
+  case EMFILE          = 33
+  /// Too many links.
+  case EMLINK          = 34
+  /// Message too large.
+  case EMSGSIZE        = 35
+  /// Reserved.
+  case EMULTIHOP       = 36
+  /// Filename too long.
+  case ENAMETOOLONG    = 37
+  /// Network is down.
+  case ENETDOWN        = 38
+  /// Connection aborted by network.
+  case ENETRESET       = 39
+  /// Network unreachable.
+  case ENETUNREACH     = 40
+  /// Too many files open in system.
+  case ENFILE          = 41
+  /// No buffer space available.
+  case ENOBUFS         = 42
+  /// No such device.
+  case ENODEV          = 43
+  /// No such file or directory.
+  case ENOENT          = 44
+  /// Executable file format error.
+  case ENOEXEC         = 45
+  /// No locks available.
+  case ENOLCK          = 46
+  /// Reserved.
+  case ENOLINK         = 47
+  /// Not enough space.
+  case ENOMEM          = 48
+  /// No message of the desired type.
+  case ENOMSG          = 49
+  /// Protocol not available.
+  case ENOPROTOOPT     = 50
+  /// No space left on device.
+  case ENOSPC          = 51
+  /// Function not supported.
+  case ENOSYS          = 52
+  /// The socket is not connected.
+  case ENOTCONN        = 53
+  /// Not a directory or a symbolic link to a directory.
+  case ENOTDIR         = 54
+  /// Directory not empty.
+  case ENOTEMPTY       = 55
+  /// State not recoverable.
+  case ENOTRECOVERABLE = 56
+  /// Not a socket.
+  case ENOTSOCK        = 57
+  // Note: WASI defines __WASI_ERRNO_NOTSUP = 58, but Emscripten's
+  // <bits/errno.h> does not map it. Value 58 is unused on Emscripten.
+  /// Inappropriate I/O control operation.
+  case ENOTTY          = 59
+  /// No such device or address.
+  case ENXIO           = 60
+  /// Value too large to be stored in data type.
+  case EOVERFLOW       = 61
+  /// Previous owner died.
+  case EOWNERDEAD      = 62
+  /// Operation not permitted.
+  case EPERM           = 63
+  /// Broken pipe.
+  case EPIPE           = 64
+  /// Protocol error.
+  case EPROTO          = 65
+  /// Protocol not supported.
+  case EPROTONOSUPPORT = 66
+  /// Protocol wrong type for socket.
+  case EPROTOTYPE      = 67
+  /// Result too large.
+  case ERANGE          = 68
+  /// Read-only file system.
+  case EROFS           = 69
+  /// Invalid seek.
+  case ESPIPE          = 70
+  /// No such process.
+  case ESRCH           = 71
+  /// Reserved.
+  case ESTALE          = 72
+  /// Connection timed out.
+  case ETIMEDOUT       = 73
+  /// Text file busy.
+  case ETXTBSY         = 74
+  /// Cross-device link.
+  case EXDEV           = 75
+  // Note: WASI defines __WASI_ERRNO_NOTCAPABLE = 76, but Emscripten's
+  // <bits/errno.h> does not expose it. ENOTCAPABLE is omitted here.
+
+  // --- Emscripten-specific codes (not from WASI) ---
+  // Emscripten's <bits/errno.h> defines additional errno codes starting at 100,
+  // following Linux/musl conventions. Only EOPNOTSUPP and ENOTSUP are included
+  // here because they are standard POSIX codes commonly checked in portable
+  // code. The remaining Linux-origin codes (ENODATA, ETIME, etc.) can be added
+  // if needed.
+
+  /// Operation not supported on socket.
+  case EOPNOTSUPP      = 138
+
+  /// Not supported.
+  public static var ENOTSUP: POSIXErrorCode { return .EOPNOTSUPP }
 }
 
 #elseif os(Windows)

--- a/stdlib/public/Platform/Platform.swift
+++ b/stdlib/public/Platform/Platform.swift
@@ -295,6 +295,8 @@ public var SIG_ERR: _crt_signal_t {
 }
 #elseif os(WASI)
 // No signals support on WASI yet, see https://github.com/WebAssembly/WASI/issues/166.
+#elseif os(Emscripten)
+// Emscripten has signal.h but limited support in single-threaded mode.
 #else
 internal var _ignore = _UnsupportedPlatformError()
 #endif
@@ -303,7 +305,7 @@ internal var _ignore = _UnsupportedPlatformError()
 // semaphore.h
 //===----------------------------------------------------------------------===//
 
-#if !os(Windows) && !os(WASI)
+#if !os(Windows) && !os(WASI) && !os(Emscripten)
 
 #if os(OpenBSD)
 public typealias Semaphore = UnsafeMutablePointer<sem_t?>

--- a/stdlib/public/Platform/SwiftEmscriptenLibc.apinotes
+++ b/stdlib/public/Platform/SwiftEmscriptenLibc.apinotes
@@ -1,0 +1,5 @@
+Name: SwiftEmscriptenLibc
+Globals:
+  # errno macro is importable but we provide explicit Swift wrapper
+  - Name: errno
+    SwiftPrivate: true

--- a/stdlib/public/Resources/emscripten/static-executable-args.lnk
+++ b/stdlib/public/Resources/emscripten/static-executable-args.lnk
@@ -1,0 +1,2 @@
+-static
+-lswiftSwiftOnoneSupport

--- a/stdlib/public/stubs/Random.cpp
+++ b/stdlib/public/stubs/Random.cpp
@@ -102,7 +102,7 @@ void swift_stdlib_random(void *buf, __swift_size_t nbytes) {
     if (getrandom_available) {
       actual_nbytes = WHILE_EINTR(syscall(__NR_getrandom, buf, nbytes, 0));
     }
-#elif __has_include(<sys/random.h>) && (defined(__CYGWIN__) || defined(__Fuchsia__) || defined(__wasi__))
+#elif __has_include(<sys/random.h>) && (defined(__CYGWIN__) || defined(__Fuchsia__) || defined(__wasi__) || defined(__EMSCRIPTEN__))
     __swift_size_t getentropy_nbytes = std::min(nbytes, __swift_size_t{256});
     
     if (0 == getentropy(buf, getentropy_nbytes)) {


### PR DESCRIPTION
Add the `EmscriptenLibc` standard library overlay for `wasm32-unknown-emscripten`, layered on the `emscripten-libc.modulemap` from the build-system branch. This change provides the module surface (`EmscriptenLibc.swift.gyb`, `SwiftEmscriptenLibc.apinotes`), the `os(Emscripten)` `errno` table, Emscripten `argc`/`argv` and `swift_stdlib_random` handling, and the static link arguments. Everything is guarded for the Emscripten target, so host builds are unchanged.