### PR TITLE
[Concurrency] Generalize sleep and checkCancellation methods for typed throws (CancellationError)

### DIFF
--- a/stdlib/public/Concurrency/Clock.swift
+++ b/stdlib/public/Concurrency/Clock.swift
@@ -120,8 +120,12 @@ extension Clock {
   public func sleep(
     for duration: Instant.Duration,
     tolerance: Instant.Duration? = nil
-  ) async throws {
-    try await sleep(until: now.advanced(by: duration), tolerance: tolerance)
+  ) async throws(_Concurrency.CancellationError) {
+    do {
+      try await sleep(until: now.advanced(by: duration), tolerance: tolerance)
+    } catch {
+      throw error as! _Concurrency.CancellationError
+    }
   }
 }
 #endif

--- a/stdlib/public/Concurrency/ContinuousClock.swift
+++ b/stdlib/public/Concurrency/ContinuousClock.swift
@@ -110,8 +110,33 @@ extension ContinuousClock: Clock {
   /// `CancellationError`.
   ///
   /// This function doesn't block the underlying thread.
-  @diagnose(UselessAvailabilityCheck, as: ignored)
+  @_alwaysEmitIntoClient
+  @abi(
+    func __typed_throws_sleep(
+      until deadline: Instant, tolerance: Swift.Duration?
+    ) async throws(_Concurrency.CancellationError)
+  )
   public func sleep(
+    until deadline: Instant, tolerance: Swift.Duration? = nil
+  ) async throws(_Concurrency.CancellationError) {
+    do {
+      // Calling self.__untyped_throws_sleep(until:tolerance:) in this method
+      // instead of vice versa in order to avoid exposing the contained
+      // internal symbols as ABI.
+      try await self.__untyped_throws_sleep(until: deadline, tolerance: tolerance)
+    } catch {
+      throw error as! _Concurrency.CancellationError
+    }
+  }
+
+  @diagnose(UselessAvailabilityCheck, as: ignored)
+  @abi(
+    func sleep(
+      until deadline: Instant, tolerance: Swift.Duration?
+    ) async throws
+  )
+  @usableFromInline
+  internal func __untyped_throws_sleep(
     until deadline: Instant, tolerance: Swift.Duration? = nil
   ) async throws {
     if #available(StdlibDeploymentTarget 6.3, *) {

--- a/stdlib/public/Concurrency/SuspendingClock.swift
+++ b/stdlib/public/Concurrency/SuspendingClock.swift
@@ -98,8 +98,34 @@ extension SuspendingClock: Clock {
   ///
   /// This function doesn't block the underlying thread.
   @available(StdlibDeploymentTarget 5.7, *)
-  @diagnose(UselessAvailabilityCheck, as: ignored)
+  @_alwaysEmitIntoClient
+  @abi(
+    func __typed_throws_sleep(
+      until deadline: Instant, tolerance: Swift.Duration?
+    ) async throws(_Concurrency.CancellationError)
+  )
   public func sleep(
+    until deadline: Instant, tolerance: Swift.Duration? = nil
+  ) async throws(_Concurrency.CancellationError) {
+    do {
+      // Calling self.__untyped_throws_sleep(until:tolerance:) in this method
+      // instead of vice versa in order to avoid exposing the contained
+      // internal symbols as ABI.
+      try await self.__untyped_throws_sleep(until: deadline, tolerance: tolerance)
+    } catch {
+      throw error as! _Concurrency.CancellationError
+    }
+  }
+
+  @available(StdlibDeploymentTarget 5.7, *)
+  @diagnose(UselessAvailabilityCheck, as: ignored)
+  @abi(
+    func sleep(
+      until deadline: Instant, tolerance: Swift.Duration?
+    ) async throws
+  )
+  @usableFromInline
+  internal func __untyped_throws_sleep(
     until deadline: Instant, tolerance: Swift.Duration? = nil
   ) async throws {
     if #available(StdlibDeploymentTarget 6.3, *) {

--- a/stdlib/public/Concurrency/TaskCancellation.swift
+++ b/stdlib/public/Concurrency/TaskCancellation.swift
@@ -266,11 +266,27 @@ extension Task where Success == Never, Failure == Never {
   ///
   /// - SeeAlso: `isCancelled()`
   @_unavailableInEmbedded
-  public static func checkCancellation() throws {
+  @_alwaysEmitIntoClient
+  @abi(
+    static func __typed_throws_checkCancellation() throws(_Concurrency.CancellationError)
+  )
+  public static func checkCancellation() throws(_Concurrency.CancellationError) {
     if Task<Never, Never>.isCancelled {
       throw _Concurrency.CancellationError()
     }
   }
+
+#if !hasFeature(Embedded)
+  @_unavailableInEmbedded
+  @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
+  @abi(
+    static func checkCancellation() throws
+  )
+  @usableFromInline
+  internal static func __untyped_throws_checkCancellation() throws {
+    try Self.checkCancellation()
+  }
+#endif // !hasFeature(Embedded)
 }
 
 /// An error that indicates a task was canceled.

--- a/stdlib/public/Concurrency/TaskSleep.swift
+++ b/stdlib/public/Concurrency/TaskSleep.swift
@@ -47,7 +47,7 @@ extension Task where Success == Never, Failure == Never {
 
   /// The type of continuation used in the implementation of
   /// sleep(nanoseconds:).
-  typealias SleepContinuation = UnsafeContinuation<(), Error>
+  typealias SleepContinuation = UnsafeContinuation<(), _Concurrency.CancellationError>
 
   /// Describes the state of a sleep() operation.
   @unsafe enum SleepState {
@@ -237,7 +237,26 @@ extension Task where Success == Never, Failure == Never {
   /// this function throws `CancellationError`.
   ///
   /// This function doesn't block the underlying thread.
-  public static func sleep(nanoseconds duration: UInt64) async throws {
+  @available(SwiftStdlib 5.1, *)
+  @_alwaysEmitIntoClient
+  @abi(static func __typed_throws_sleep(nanoseconds duration: UInt64) async throws(_Concurrency.CancellationError))
+  public static func sleep(nanoseconds duration: UInt64) async throws(_Concurrency.CancellationError) {
+    do {
+      // Calling self.__untyped_throws_sleep(nanoseconds:) in this method
+      // instead of vice versa in order to avoid exposing the contained
+      // internal symbols as ABI.
+      try await Self.__untyped_throws_sleep(nanoseconds: duration)
+    } catch {
+      throw error as! _Concurrency.CancellationError
+    }
+  }
+
+  @available(SwiftStdlib 5.1, *)
+  @abi(
+    static func sleep(nanoseconds duration: UInt64) async throws
+  )
+  @usableFromInline
+  internal static func __untyped_throws_sleep(nanoseconds duration: UInt64) async throws {
     // Create a token which will initially have the value "not started", which
     // means the continuation has neither been created nor completed.
     let token = unsafe UnsafeSleepStateToken()
@@ -347,7 +366,7 @@ extension Task where Success == Never, Failure == Never {
   }
   @available(SwiftStdlib 5.1, *)
   @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
-  public static func sleep(nanoseconds duration: UInt64) async throws {
+  public static func sleep(nanoseconds duration: UInt64) async throws(_Concurrency.CancellationError) {
     fatalError("Unavailable in task-to-thread concurrency model")
   }
 }

--- a/stdlib/public/Concurrency/TaskSleepDuration.swift
+++ b/stdlib/public/Concurrency/TaskSleepDuration.swift
@@ -81,15 +81,15 @@ extension Task where Success == Never, Failure == Never {
     until instant: C.Instant,
     tolerance: C.Duration?,
     clock: C
-  ) async throws {
+  ) async throws(_Concurrency.CancellationError) {
     // Create a token which will initially have the value "not started", which
     // means the continuation has neither been created nor completed.
     let token = unsafe UnsafeSleepStateToken()
 
-    do {
+    do throws(_Concurrency.CancellationError) {
       // Install a cancellation handler to resume the continuation by
       // throwing CancellationError.
-      try await withTaskCancellationHandler {
+      try await withTaskCancellationHandler { () throws(_Concurrency.CancellationError) in
         let _: () = try unsafe await withUnsafeThrowingContinuation { continuation in
           while true {
             let state = unsafe token.load()
@@ -217,12 +217,42 @@ extension Task where Success == Never, Failure == Never {
   ///       try await Task.sleep(until: .now + .seconds(3))
   ///
   @available(SwiftStdlib 5.7, *)
+  @_alwaysEmitIntoClient
+  @abi(
+    static func __typed_throws_sleep<C: Clock>(
+      until deadline: C.Instant,
+      tolerance: C.Instant.Duration?,
+      clock: C
+    ) async throws(_Concurrency.CancellationError)
+  )
   public static func sleep<C: Clock>(
     until deadline: C.Instant,
     tolerance: C.Instant.Duration? = nil,
     clock: C = .continuous
+  ) async throws(_Concurrency.CancellationError) {
+    do {
+      try await clock.sleep(until: deadline, tolerance: tolerance)
+    } catch {
+      throw error as! _Concurrency.CancellationError
+    }
+  }
+  
+  @available(SwiftStdlib 5.7, *)
+  @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
+  @abi(
+    static func sleep<C: Clock>(
+      until deadline: C.Instant,
+      tolerance: C.Instant.Duration?,
+      clock: C
+    ) async throws
+  )
+  @usableFromInline
+  internal static func __untyped_throws_sleep<C: Clock>(
+    until deadline: C.Instant,
+    tolerance: C.Instant.Duration? = nil,
+    clock: C = .continuous
   ) async throws {
-    try await clock.sleep(until: deadline, tolerance: tolerance)
+    try await Self.sleep(until: deadline, tolerance: tolerance, clock: clock)
   }
 
   /// Suspends the current task for the given duration.
@@ -240,7 +270,7 @@ extension Task where Success == Never, Failure == Never {
     for duration: C.Instant.Duration,
     tolerance: C.Instant.Duration? = nil,
     clock: C = .continuous
-  ) async throws {
+  ) async throws(_Concurrency.CancellationError) {
     try await clock.sleep(for: duration, tolerance: tolerance)
   }
   #endif

--- a/test/api-digester/stability-concurrency-abi.test
+++ b/test/api-digester/stability-concurrency-abi.test
@@ -91,6 +91,11 @@ Func withTaskCancellationHandler(operation:onCancel:) has mangled name changing 
 // Task.value adopted typed throws and old one needed `@_silgen_name` which this test doesn't understand how to handle.
 Accessor Task.value.Get() has been removed
 
+// Typed throws adoption for methods that throw _Concurrency.CancellationError()
+Func Task.checkCancellation() has been removed
+Func Task.sleep(nanoseconds:) has been renamed to Func __untyped_throws_sleep(nanoseconds:)
+Func Task.sleep(nanoseconds:) has mangled name changing from 'static (extension in _Concurrency):Swift.Task< where A == Swift.Never, B == Swift.Never>.sleep(nanoseconds: Swift.UInt64) async throws -> ()' to 'static (extension in _Concurrency):Swift.Task< where A == Swift.Never, B == Swift.Never>.__untyped_throws_sleep(nanoseconds: Swift.UInt64) async throws -> ()'
+
 // AsyncStream.init(unfolding:onCancel:) uses @_silgen_name to preserve mangling after adding @preconcurrency.
 Constructor AsyncStream.init(unfolding:onCancel:) has mangled name changing from 'Swift.AsyncStream.init(unfolding: () async -> Swift.Optional<A>, onCancel: Swift.Optional<@Sendable () -> ()>) -> Swift.AsyncStream<A>' to 'Swift.AsyncStream.init(unfolding: () async -> Swift.Optional<A>, onCancel: Swift.Optional<() -> ()>) -> Swift.AsyncStream<A>'
 


### PR DESCRIPTION
Generalizes some methods throwing `CancellationError` for typed throws: `Task.checkCancellation()`, `Task.sleep(nanoseconds:)`, `Task.sleep<C: Clock>(until:tolerance:clock:)`, `Task.sleep<C: Clock>(for:tolerance:clock:)`, and `Clock.sleep(until:tolerance:)` in `ContinuousClock` and `SuspendingClock`.