### PR TITLE
[Mangler] Support opaque types in old mangler.

### DIFF
--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -953,9 +953,7 @@ std::string ASTMangler::mangleObjCRuntimeName(const NominalTypeDecl *Nominal) {
   Node *NewGlobal = Dem.createNode(Node::Kind::Global);
   NewGlobal->addChild(TyMangling, Dem);
   auto mangling = mangleNodeOld(NewGlobal);
-  if (!mangling.isSuccess()) {
-    llvm_unreachable("unexpected mangling failure");
-  }
+  ASSERT(mangling.isSuccess());
   return mangling.result();
 #endif
 }

--- a/lib/Demangling/OldDemangler.cpp
+++ b/lib/Demangling/OldDemangler.cpp
@@ -2110,6 +2110,36 @@ private:
           Factory.createNode(Node::Kind::OpaqueReturnTypeIndex, ordinal), Factory);
         return result;
       }
+      if (Mangled.nextIf('o')) {
+        // Special mangling for opaque type.
+        Node::IndexType index;
+        if (!demangleIndex(index, depth))
+          return nullptr;
+        if (!Mangled.nextIf('Q') || !Mangled.nextIf('O'))
+          return nullptr;
+        NodePointer context = demangleContext(depth + 1);
+        if (!context)
+          return nullptr;
+        auto opaqueReturnTypeOf =
+            Factory.createNode(Node::Kind::OpaqueReturnTypeOf);
+        opaqueReturnTypeOf->addChild(context, Factory);
+        // The generic arguments are flattened into a single '_'-terminated
+        // list; wrap them in the list-of-lists shape the printer expects.
+        auto innerArgs = Factory.createNode(Node::Kind::TypeList);
+        while (!Mangled.nextIf('_')) {
+          NodePointer arg = demangleType(depth + 1);
+          if (!arg)
+            return nullptr;
+          innerArgs->addChild(arg, Factory);
+        }
+        auto args = Factory.createNode(Node::Kind::TypeList);
+        args->addChild(innerArgs, Factory);
+        auto opaque = Factory.createNode(Node::Kind::OpaqueType);
+        opaque->addChild(opaqueReturnTypeOf, Factory);
+        opaque->addChild(Factory.createNode(Node::Kind::Index, index), Factory);
+        opaque->addChild(args, Factory);
+        return opaque;
+      }
       return demangleArchetypeType(depth + 1);
     }
     if (c == 'q') {

--- a/lib/Demangling/OldRemangler.cpp
+++ b/lib/Demangling/OldRemangler.cpp
@@ -2953,10 +2953,22 @@ ManglingError Remangler::mangleOpaqueReturnTypeParent(Node *node, unsigned depth
 ManglingError Remangler::mangleOpaqueReturnTypeOf(Node *node,
                                                   EntityContext &ctx,
                                                   unsigned depth) {
-  return MANGLING_ERROR(ManglingError::UnsupportedNodeKind, node);
+  DEMANGLER_ASSERT(node->getNumChildren() >= 1, node);
+  Buffer << "QO";
+  return mangleEntityContext(node->getChild(0), ctx, depth + 1);
 }
 ManglingError Remangler::mangleOpaqueType(Node *node, unsigned depth) {
-  return MANGLING_ERROR(ManglingError::UnsupportedNodeKind, node);
+  DEMANGLER_ASSERT(node->getNumChildren() >= 2, node);
+  Buffer << "Qo";
+  mangleIndex(node->getChild(1)->getIndex());
+  RETURN_IF_ERROR(mangle(node->getChild(0), depth + 1));
+  if (node->getNumChildren() >= 3) {
+    Node *boundGenerics = node->getChild(2);
+    for (unsigned i = 0, e = boundGenerics->getNumChildren(); i < e; ++i)
+      RETURN_IF_ERROR(mangleChildNodes(boundGenerics->getChild(i), depth + 1));
+  }
+  Buffer << '_';
+  return ManglingError::Success;
 }
 ManglingError Remangler::mangleOpaqueTypeDescriptor(Node *node,
                                                     unsigned depth) {

--- a/test/Demangle/remangle.swift
+++ b/test/Demangle/remangle.swift
@@ -23,3 +23,10 @@ RUN: swift-demangle -remangle-objc-rt '$sSIxip6foobarP' | %FileCheck -check-pref
 
 // CHECK-GENERICEXT: _TtGCs23_ContiguousArrayStorageGVEsVs15FlattenSequence5IndexGV24StdlibCollectionUnittest30MinimalBidirectionalCollectionGS3_Si_____
 RUN: swift-demangle -remangle-objc-rt '$ss23_ContiguousArrayStorageCys15FlattenSequenceVsE5IndexVy24StdlibCollectionUnittest020MinimalBidirectionalH0VyAIySiGG_GGD' | %FileCheck -check-prefix CHECK-GENERICEXT %s
+
+
+// CHECK-OPAQUE: _TCFF1A5outerFT_T_U_FT_Qo_QOFES_PS_1P8decorateFT_QuVS_4Impl_L_9MenuState
+RUN: swift-demangle -remangle-objc-rt '$s1A5outeryyFAA1PPAAE8decorateQryFQOyAA4ImplV_Qo_yXEfU_9MenuStateL_C' | %FileCheck -check-prefix CHECK-OPAQUE %s
+
+// CHECK-OPAQUE-RT: MenuState #1 in closure #1 () -> <<opaque return type of (extension in A):A.P.decorate() -> some>>.0 in A.outer() -> (){{$}}
+RUN: swift-demangle '_TCFF1A5outerFT_T_U_FT_Qo_QOFES_PS_1P8decorateFT_QuVS_4Impl_L_9MenuState' | %FileCheck -check-prefix CHECK-OPAQUE-RT %s

--- a/test/IRGen/objc_runtime_name_local_class_opaque_type.swift
+++ b/test/IRGen/objc_runtime_name_local_class_opaque_type.swift
@@ -15,5 +15,20 @@ var returnsClass2: some MyProtocol {
   return MyClass2()
 }
 
+struct Impl: MyProtocol {}
+extension MyProtocol {
+  func decorate() -> some MyProtocol { Impl() }
+}
+
+func returnsClass3() {
+  let c = {
+    class MyClass3: MyProtocol {}
+    _ = MyClass3()
+    return Impl().decorate()
+  }
+  _ = c
+}
+
 // CHECK: @_DATA__TtCF41objc_runtime_name_local_class_opaque_type13returnsClass1FT_QuL_8MyClass1 = internal constant
 // CHECK: @_DATA__TtCF41objc_runtime_name_local_class_opaque_typeg13returnsClass2QuL_8MyClass2 = internal constant
+// CHECK: @{{[A-Za-z0-9_.]+}} = {{(private|internal)}} {{(unnamed_addr )?}}constant [{{[0-9]+}} x i8] c"_TtC{{[^"]*}}MyClass3\00", section "__TEXT,__objc_classname,cstring_literals"


### PR DESCRIPTION
This fixes ObjC class names for classes nested in scopes with opaque types. Without this, such classes would either hit an assertion failure, or in no-asserts compilers they would get an empty string as a class name.

rdar://178851613