### PR TITLE
[6.4][Mangler] Support opaque types in old mangler.

### DIFF
--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -953,7 +953,9 @@ std::string ASTMangler::mangleObjCRuntimeName(const NominalTypeDecl *Nominal) {
   NewGlobal->addChild(TyMangling, Dem);
   auto mangling = mangleNodeOld(NewGlobal);
   if (!mangling.isSuccess()) {
-    llvm_unreachable("unexpected mangling failure");
+    // The old mangler doesn't support every kind of type (e.g. opaque types).
+    // Fall back to the new mangling in those cases.
+    return NewName;
   }
   return mangling.result();
 #endif

--- a/lib/Demangling/OldRemangler.cpp
+++ b/lib/Demangling/OldRemangler.cpp
@@ -860,8 +860,10 @@ ManglingError Remangler::mangleDifferentiableFunctionType(Node *node,
 
 ManglingError Remangler::mangleGlobalActorFunctionType(Node *node,
                                                        unsigned depth) {
-  Buffer << "Y" << (char)node->getIndex(); // differentiability kind
-  return ManglingError::Success;
+  // The old mangling has no representation for global-actor isolation. We
+  // previously attempted to generate one, but it called node->getIndex() on a
+  // node that has no index. Instead, fail gracefully.
+  return MANGLING_ERROR(ManglingError::UnsupportedNodeKind, node);
 }
 
 ManglingError Remangler::mangleIsolatedAnyFunctionType(Node *node,

--- a/test/IRGen/objc_runtime_name_local_class_opaque_type.swift
+++ b/test/IRGen/objc_runtime_name_local_class_opaque_type.swift
@@ -15,5 +15,33 @@ var returnsClass2: some MyProtocol {
   return MyClass2()
 }
 
+struct Impl: MyProtocol {}
+extension MyProtocol {
+  func decorate() -> some MyProtocol { Impl() }
+}
+
+func returnsClass3() {
+  let c = {
+    class MyClass3: MyProtocol {}
+    _ = MyClass3()
+    return Impl().decorate()
+  }
+  _ = c
+}
+
+func returnsClass4() {
+  let c: @MainActor () -> Void = {
+    class MyClass4: MyProtocol {}
+    _ = MyClass4()
+  }
+  _ = c
+}
+
 // CHECK: @_DATA__TtCF41objc_runtime_name_local_class_opaque_type13returnsClass1FT_QuL_8MyClass1 = internal constant
 // CHECK: @_DATA__TtCF41objc_runtime_name_local_class_opaque_typeg13returnsClass2QuL_8MyClass2 = internal constant
+// MyClass3 is nested in a scope that the old mangler can't represent (an
+// opaque type), so the runtime name falls back to the new mangling.
+// CHECK: @{{.*}} = {{(private|internal)}} {{(unnamed_addr )?}}constant [{{[0-9]+}} x i8] c"$s41objc_runtime_name_local_class_opaque_type13returnsClass3yyFAA10MyProtocolPAAE8decorateQryFQOyAA4ImplV_Qo_ycfU_0jI0L_C\00", section "__TEXT,__objc_classname,cstring_literals"
+// MyClass4 is nested in a global-actor-isolated function type, which the old
+// mangler can't represent either, so it also falls back to the new mangling.
+// CHECK: @{{.*}} = {{(private|internal)}} {{(unnamed_addr )?}}constant [{{[0-9]+}} x i8] c"$s41objc_runtime_name_local_class_opaque_type13returnsClass4yyFyyScMYccfU_02MyI0L_C\00", section "__TEXT,__objc_classname,cstring_literals"


### PR DESCRIPTION
- **Explanation**: This fixes ObjC class names for classes nested in scopes with opaque types. Without this, such classes would either hit an assertion failure, or in no-asserts compilers they would get an empty string as a class name.
- **Scope**: This fixes the names generated for ObjC classes in a context with an opaque type, and adds support for opaque types to the demangler.
- **Issues**: rdar://178851613
- **Original PRs**: https://github.com/swiftlang/swift/pull/89803
- **Risk**: Low. This is mostly additive, where classes that got an empty string ObjC name will now get a proper name. This does assert on any other constructs not supported by the old mangler, so there is some risk if any code out there has any.
- **Testing**: Added test cases for the case being fixed. CI has good coverage of other uses of the old mangler.
- **Reviewers**: @jckarter 

rdar://178851613