### PR TITLE
[stdlib] Concurrency: Make `{Continuous, Suspending}Clock::sleep` `nonisolated(nonsending)`

### DIFF
--- a/stdlib/public/Concurrency/Clock.swift
+++ b/stdlib/public/Concurrency/Clock.swift
@@ -117,7 +117,7 @@ extension Clock {
   /// access to an absolute instant.
   @available(StdlibDeploymentTarget 5.7, *)
   @_alwaysEmitIntoClient
-  public func sleep(
+  public nonisolated(nonsending) func sleep(
     for duration: Instant.Duration,
     tolerance: Instant.Duration? = nil
   ) async throws {

--- a/stdlib/public/Concurrency/ContinuousClock.swift
+++ b/stdlib/public/Concurrency/ContinuousClock.swift
@@ -111,17 +111,34 @@ extension ContinuousClock: Clock {
   ///
   /// This function doesn't block the underlying thread.
   @diagnose(UselessAvailabilityCheck, as: ignored)
-  public func sleep(
+  @_alwaysEmitIntoClient
+  @abi(
+    nonisolated(nonsending) func sleepNonisolatedNonsending(
+      until deadline: Instant, tolerance: Swift.Duration?
+    ) async throws
+  )
+  public nonisolated(nonsending) func sleep(
     until deadline: Instant, tolerance: Swift.Duration? = nil
   ) async throws {
-    if #available(StdlibDeploymentTarget 6.3, *) {
-      try await Task._sleep(until: deadline,
-                            tolerance: tolerance,
-                            clock: self)
-    } else {
-      fatalError("we should never get here; if we have, availability is broken")
-    }
+    try await Task._sleep(until: deadline,
+                          tolerance: tolerance,
+                          clock: self)
   }
+
+  @abi(
+    func sleep(
+      until deadline: Instant, tolerance: Swift.Duration?
+    ) async throws
+  )
+  @usableFromInline
+  internal func __abi_sleep(
+    until deadline: Instant, tolerance: Swift.Duration? = nil
+  ) async throws {
+    try await Task._sleep(until: deadline,
+                          tolerance: tolerance,
+                          clock: self)
+  }
+
 #else
   @available(StdlibDeploymentTarget 5.7, *)
   @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")

--- a/stdlib/public/Concurrency/ContinuousClock.swift
+++ b/stdlib/public/Concurrency/ContinuousClock.swift
@@ -110,19 +110,24 @@ extension ContinuousClock: Clock {
   /// `CancellationError`.
   ///
   /// This function doesn't block the underlying thread.
-  @diagnose(UselessAvailabilityCheck, as: ignored)
-  @_alwaysEmitIntoClient
   @abi(
     nonisolated(nonsending) func sleepNonisolatedNonsending(
       until deadline: Instant, tolerance: Swift.Duration?
     ) async throws
   )
+  @_alwaysEmitIntoClient
   public nonisolated(nonsending) func sleep(
     until deadline: Instant, tolerance: Swift.Duration? = nil
   ) async throws {
-    try await Task._sleep(until: deadline,
-                          tolerance: tolerance,
-                          clock: self)
+    // If the ABI symbol for `nonisolated(nonsending)` Task::_sleep is
+    // available, let's use that, otherwise fallback to the version that hops.
+    if #available(anyAppleOS 27, *) {
+      try await Task._sleep(until: deadline,
+                            tolerance: tolerance,
+                            clock: self)
+    } else {
+      try await __abi_sleep(until: deadline, tolerance: tolerance)
+    }
   }
 
   @abi(
@@ -130,13 +135,18 @@ extension ContinuousClock: Clock {
       until deadline: Instant, tolerance: Swift.Duration?
     ) async throws
   )
+  @diagnose(UselessAvailabilityCheck, as: ignored)
   @usableFromInline
   internal func __abi_sleep(
     until deadline: Instant, tolerance: Swift.Duration? = nil
   ) async throws {
-    try await Task._sleep(until: deadline,
-                          tolerance: tolerance,
-                          clock: self)
+    if #available(StdlibDeploymentTarget 6.3, *) {
+      try await Task._sleep(until: deadline,
+                            tolerance: tolerance,
+                            clock: self)
+    } else {
+      fatalError("we should never get here; if we have, availability is broken")
+    }
   }
 
 #else

--- a/stdlib/public/Concurrency/SuspendingClock.swift
+++ b/stdlib/public/Concurrency/SuspendingClock.swift
@@ -99,16 +99,32 @@ extension SuspendingClock: Clock {
   /// This function doesn't block the underlying thread.
   @available(StdlibDeploymentTarget 5.7, *)
   @diagnose(UselessAvailabilityCheck, as: ignored)
-  public func sleep(
+  @_alwaysEmitIntoClient
+  @abi(
+    nonisolated(nonsending) func sleepNonisolatedNonsending(
+      until deadline: Instant, tolerance: Swift.Duration?
+    ) async throws
+  )
+  public nonisolated(nonsending) func sleep(
     until deadline: Instant, tolerance: Swift.Duration? = nil
   ) async throws {
-    if #available(StdlibDeploymentTarget 6.3, *) {
-      try await Task._sleep(until: deadline,
-                            tolerance: tolerance,
-                            clock: self)
-    } else {
-      fatalError("we shouldn't get here; if we have, availability is broken")
-    }
+    try await Task._sleep(until: deadline,
+                          tolerance: tolerance,
+                          clock: self)
+  }
+
+  @abi(
+    func sleep(
+      until deadline: Instant, tolerance: Swift.Duration?
+    ) async throws
+  )
+  @usableFromInline
+  internal func __abi_sleep(
+    until deadline: Instant, tolerance: Swift.Duration? = nil
+  ) async throws {
+    try await Task._sleep(until: deadline,
+                          tolerance: tolerance,
+                          clock: self)
   }
 #else
   @available(StdlibDeploymentTarget 5.7, *)

--- a/stdlib/public/Concurrency/SuspendingClock.swift
+++ b/stdlib/public/Concurrency/SuspendingClock.swift
@@ -98,19 +98,25 @@ extension SuspendingClock: Clock {
   ///
   /// This function doesn't block the underlying thread.
   @available(StdlibDeploymentTarget 5.7, *)
-  @diagnose(UselessAvailabilityCheck, as: ignored)
-  @_alwaysEmitIntoClient
   @abi(
     nonisolated(nonsending) func sleepNonisolatedNonsending(
       until deadline: Instant, tolerance: Swift.Duration?
     ) async throws
   )
+  @_alwaysEmitIntoClient
   public nonisolated(nonsending) func sleep(
     until deadline: Instant, tolerance: Swift.Duration? = nil
   ) async throws {
-    try await Task._sleep(until: deadline,
-                          tolerance: tolerance,
-                          clock: self)
+    // If the ABI symbol for `nonisolated(nonsending)` Task::_sleep is
+    // available, let's use that, otherwise fallback to the version that hops.
+    if #available(anyAppleOS 27, *) {
+      try await Task._sleep(until: deadline,
+                            tolerance: tolerance,
+                            clock: self)
+    } else {
+      try await __abi_sleep(until: deadline,
+                            tolerance: tolerance)
+    }
   }
 
   @abi(
@@ -118,13 +124,18 @@ extension SuspendingClock: Clock {
       until deadline: Instant, tolerance: Swift.Duration?
     ) async throws
   )
+  @diagnose(UselessAvailabilityCheck, as: ignored)
   @usableFromInline
   internal func __abi_sleep(
     until deadline: Instant, tolerance: Swift.Duration? = nil
   ) async throws {
-    try await Task._sleep(until: deadline,
-                          tolerance: tolerance,
-                          clock: self)
+    if #available(StdlibDeploymentTarget 6.3, *) {
+      try await Task._sleep(until: deadline,
+                            tolerance: tolerance,
+                            clock: self)
+    } else {
+      fatalError("we should never get here; if we have, availability is broken")
+    }
   }
 #else
   @available(StdlibDeploymentTarget 5.7, *)

--- a/stdlib/public/Concurrency/TaskSleepDuration.swift
+++ b/stdlib/public/Concurrency/TaskSleepDuration.swift
@@ -77,7 +77,8 @@ fileprivate func durationComponents<C: Clock>(for duration: C.Duration, clock: C
 @_unavailableInEmbedded
 extension Task where Success == Never, Failure == Never {
   @available(StdlibDeploymentTarget 5.7, *)
-  internal static func _sleep<C: Clock>(
+  @usableFromInline
+  internal static nonisolated(nonsending) func _sleep<C: Clock>(
     until instant: C.Instant,
     tolerance: C.Duration?,
     clock: C

--- a/stdlib/public/Concurrency/TaskSleepDuration.swift
+++ b/stdlib/public/Concurrency/TaskSleepDuration.swift
@@ -236,7 +236,7 @@ extension Task where Success == Never, Failure == Never {
   ///
   @available(SwiftStdlib 5.7, *)
   @_alwaysEmitIntoClient
-  public static func sleep<C: Clock>(
+  public static nonisolated(nonsending) func sleep<C: Clock>(
     for duration: C.Instant.Duration,
     tolerance: C.Instant.Duration? = nil,
     clock: C = .continuous

--- a/stdlib/public/Concurrency/TaskSleepDuration.swift
+++ b/stdlib/public/Concurrency/TaskSleepDuration.swift
@@ -76,7 +76,7 @@ fileprivate func durationComponents<C: Clock>(for duration: C.Duration, clock: C
 @available(StdlibDeploymentTarget 5.7, *)
 @_unavailableInEmbedded
 extension Task where Success == Never, Failure == Never {
-  @available(StdlibDeploymentTarget 5.7, *)
+  @available(StdlibDeploymentTarget 6.4, *)
   @usableFromInline
   internal static nonisolated(nonsending) func _sleep<C: Clock>(
     until instant: C.Instant,

--- a/test/abi/macOS/arm64/concurrency.swift
+++ b/test/abi/macOS/arm64/concurrency.swift
@@ -462,3 +462,7 @@ Added: _$sSct8_rawTasks06_AsyncB0VvpMV
 
 /// Expose async task name offset in debug header.
 Added: __swift_concurrency_debug_asyncTaskNameOffset
+
+/// Task::_sleep is now @usableFromInline
+Added: _$sScTss5NeverORszABRs_rlE6_sleep5until9tolerance5clocky7InstantQyd___8DurationQyd__Sgqd__tYaKs5ClockRd__lFZ
+Added: _$sScTss5NeverORszABRs_rlE6_sleep5until9tolerance5clocky7InstantQyd___8DurationQyd__Sgqd__tYaKs5ClockRd__lFZTu

--- a/test/abi/macOS/x86_64/concurrency.swift
+++ b/test/abi/macOS/x86_64/concurrency.swift
@@ -462,3 +462,7 @@ Added: _$sSct8_rawTasks06_AsyncB0VvpMV
 
 /// Expose async task name offset in debug header.
 Added: __swift_concurrency_debug_asyncTaskNameOffset
+
+/// Task::_sleep is now @usableFromInline
+Added: _$sScTss5NeverORszABRs_rlE6_sleep5until9tolerance5clocky7InstantQyd___8DurationQyd__Sgqd__tYaKs5ClockRd__lFZ
+Added: _$sScTss5NeverORszABRs_rlE6_sleep5until9tolerance5clocky7InstantQyd___8DurationQyd__Sgqd__tYaKs5ClockRd__lFZTu


### PR DESCRIPTION
These methods should stay on the caller's thread to avoid any extra performance impact from hopping
because it's unnecessary.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
