### PR TITLE
tests: Enable the lit test suite for `wasm32-unknown-emscripten`

### DIFF
--- a/docs/WebAssembly.md
+++ b/docs/WebAssembly.md
@@ -66,6 +66,33 @@ LIT_FILTER_OUT='(embedded|KeyPath)' PATH="$(pwd)/wasmkit-macosx-arm64/bin:$(pwd)
   ninja check-swift-wasi-wasm32-custom check-swift-embedded-wasi -C wasistdlib-macosx-arm64
 ```
 
+## Building and testing the Emscripten stdlib
+
+Prerequisites: Emscripten SDK installed via Homebrew (`brew install emscripten`).
+
+The following `build-script` invocation is macOS-specific. Build LLVM, Swift,
+and the Emscripten stdlib:
+
+```
+./utils/build-script --release-debuginfo \
+  --build-emscripten-stdlib \
+  --emscripten-path /opt/homebrew/Cellar/emscripten/<VERSION>/libexec \
+  --skip-test-emscripten-stdlib \
+  --sccache \
+  --install-swift --install-llvm \
+  --skip-build-benchmarks
+```
+
+Replace `<VERSION>` with your installed Emscripten version (e.g. `5.0.2`).
+
+To run only the Emscripten stdlib tests after building:
+
+```
+cd build/Ninja-RelWithDebInfoAssert
+PATH="$(pwd)/wasmkit-macosx-arm64/bin:$(pwd)/llvm-macosx-arm64/bin:$PATH" \
+  ninja check-swift-emscripten-wasm32-custom check-swift-embedded-emscripten \
+  -C emscriptenstdlib-macosx-arm64
+```
 
 ## Building Swift SDK for WebAssembly
 

--- a/test/AutoDiff/stdlib/tgmath_derivatives.swift.gyb
+++ b/test/AutoDiff/stdlib/tgmath_derivatives.swift.gyb
@@ -13,6 +13,8 @@
   import CRT
 #elseif canImport(WASILibc)
   import WASILibc
+#elseif canImport(EmscriptenLibc)
+  import EmscriptenLibc
 #else
 #error("Unsupported platform")
 #endif

--- a/test/AutoDiff/validation-test/always_emit_into_client/multi_module_struct_no_jvp.swift
+++ b/test/AutoDiff/validation-test/always_emit_into_client/multi_module_struct_no_jvp.swift
@@ -1,4 +1,5 @@
 // REQUIRES: executable_test
+// UNSUPPORTED: OS=emscripten
 // RUN: %empty-directory(%t)
 
 // RUN: %target-build-swift-dylib(%t/%target-library-name(MultiModuleStruct1)) %S/Inputs/MultiModuleStruct/file1.swift \

--- a/test/AutoDiff/validation-test/closure_specialization/single_bb1.swift
+++ b/test/AutoDiff/validation-test/closure_specialization/single_bb1.swift
@@ -25,6 +25,8 @@ import Glibc
 import Android
 #elseif canImport(WASILibc)
 import WASILibc
+#elseif canImport(EmscriptenLibc)
+import EmscriptenLibc
 #elseif canImport(Foundation)
 import Foundation
 #else

--- a/test/AutoDiff/validation-test/custom_derivatives.swift
+++ b/test/AutoDiff/validation-test/custom_derivatives.swift
@@ -12,6 +12,8 @@ import StdlibUnittest
   import CRT
 #elseif canImport(WASILibc)
   import WASILibc
+#elseif canImport(EmscriptenLibc)
+  import EmscriptenLibc
 #else
 #error("Unsupported platform")
 #endif

--- a/test/AutoDiff/validation-test/reflection.swift
+++ b/test/AutoDiff/validation-test/reflection.swift
@@ -1,5 +1,5 @@
 // REQUIRES: no_asan
-// UNSUPPORTED: OS=linux-android, OS=linux-androideabi, OS=wasip1
+// UNSUPPORTED: OS=linux-android, OS=linux-androideabi, OS=wasip1, OS=emscripten
 // RUN: %empty-directory(%t)
 import _Differentiation
 

--- a/test/AutoDiff/validation-test/separate_tangent_type.swift
+++ b/test/AutoDiff/validation-test/separate_tangent_type.swift
@@ -12,6 +12,8 @@ import StdlibUnittest
   import CRT
 #elseif canImport(WASILibc)
   import WASILibc
+#elseif canImport(EmscriptenLibc)
+  import EmscriptenLibc
 #else
 #error("Unsupported platform")
 #endif

--- a/test/Concurrency/Runtime/actor_recursive_deinit.swift
+++ b/test/Concurrency/Runtime/actor_recursive_deinit.swift
@@ -34,6 +34,10 @@ func equalThreadIDs(_ a: ThreadID, _ b: ThreadID) -> Bool { a == b }
 typealias ThreadID = UInt32
 func getCurrentThreadID() -> ThreadID { 0 }
 func equalThreadIDs(_ a: ThreadID, _ b: ThreadID) -> Bool { a == b }
+#elseif os(Emscripten)
+typealias ThreadID = UInt32
+func getCurrentThreadID() -> ThreadID { 0 }
+func equalThreadIDs(_ a: ThreadID, _ b: ThreadID) -> Bool { a == b }
 #endif
 
 var mainThread: ThreadID?

--- a/test/Concurrency/Runtime/async_stream.swift
+++ b/test/Concurrency/Runtime/async_stream.swift
@@ -10,6 +10,7 @@
 // rdar://78109470
 // UNSUPPORTED: back_deployment_runtime
 // UNSUPPORTED: freestanding
+// XFAIL: OS=emscripten
 
 import _Concurrency
 import StdlibUnittest

--- a/test/Concurrency/Runtime/cancellation_handler.swift
+++ b/test/Concurrency/Runtime/cancellation_handler.swift
@@ -8,6 +8,7 @@
 // REQUIRES: concurrency_runtime
 // UNSUPPORTED: back_deployment_runtime
 // UNSUPPORTED: freestanding
+// UNSUPPORTED: OS=emscripten
 
 // for sleep
 #if canImport(Darwin)

--- a/test/Concurrency/Runtime/cancellation_handler_concurrent.swift
+++ b/test/Concurrency/Runtime/cancellation_handler_concurrent.swift
@@ -6,6 +6,7 @@
 
 // REQUIRES: concurrency_runtime
 // UNSUPPORTED: freestanding
+// UNSUPPORTED: OS=emscripten
 
 func recurseABunch(_ call: () async throws -> Void, n: Int = 100) async throws {
   try await withTaskCancellationHandler {

--- a/test/Concurrency/Runtime/continuation_validation.swift
+++ b/test/Concurrency/Runtime/continuation_validation.swift
@@ -12,7 +12,7 @@
 // UNSUPPORTED: back_deploy_concurrency
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: freestanding
-// UNSUPPORTED: OS=wasip1
+// UNSUPPORTED: OS=wasip1 || OS=emscripten
 
 import StdlibUnittest
 

--- a/test/Concurrency/Runtime/exclusivity.swift
+++ b/test/Concurrency/Runtime/exclusivity.swift
@@ -8,7 +8,7 @@
 
 // REQUIRES: concurrency_runtime
 // UNSUPPORTED: back_deployment_runtime
-// UNSUPPORTED: OS=wasip1
+// UNSUPPORTED: OS=wasip1 || OS=emscripten
 // UNSUPPORTED: back_deploy_concurrency
 
 // This test makes sure that:

--- a/test/Concurrency/Runtime/exclusivity_custom_executors.swift
+++ b/test/Concurrency/Runtime/exclusivity_custom_executors.swift
@@ -14,7 +14,7 @@
 // UNSUPPORTED: back_deploy_concurrency
 
 // Crash expectations can't be implemented on WASI/WebAssembly.
-// UNSUPPORTED: OS=wasip1
+// UNSUPPORTED: OS=wasip1 || OS=emscripten
 
 // This test makes sure that we properly save/restore access when we
 // synchronously launch a task from a serial executor. The access from the task

--- a/test/Concurrency/Runtime/noncopyable_continuation.swift
+++ b/test/Concurrency/Runtime/noncopyable_continuation.swift
@@ -25,7 +25,7 @@ struct UniqueResource: ~Copyable {
   static func main() async {
     let tests = TestSuite("Continuation: ~Copyable")
 
-    #if !os(WASI)
+    #if !os(WASI) && !os(Emscripten)
     tests.test("trap on dropped continuation") {
       expectCrashLater()
 

--- a/test/DebugInfo/file_compilation_dir.swift
+++ b/test/DebugInfo/file_compilation_dir.swift
@@ -7,12 +7,14 @@
 // RUN: cd %t
 // RUN: cp %s .
 // Output paths differ in the new driver, so force SWIFT_USE_OLD_DRIVER for now.
-// RUN: env SWIFT_USE_OLD_DRIVER=1 %target-swiftc_driver -g \
+// The legacy driver does not recognize the `wasm32-unknown-emscripten` triple,
+// so skip the legacy-driver RUN lines on Emscripten.
+// RUN: %if !OS=emscripten %{ env SWIFT_USE_OLD_DRIVER=1 %target-swiftc_driver -g \
 // RUN:   -c -file-compilation-dir /path/to \
-// RUN:   file_compilation_dir.swift -o - -emit-ir | %FileCheck --check-prefix=CHECK-REL %s
-// RUN: env SWIFT_USE_OLD_DRIVER=1 %target-swiftc_driver -g \
+// RUN:   file_compilation_dir.swift -o - -emit-ir | %FileCheck --check-prefix=CHECK-REL %s %}
+// RUN: %if !OS=emscripten %{ env SWIFT_USE_OLD_DRIVER=1 %target-swiftc_driver -g \
 // RUN:   -c -file-compilation-dir . \
-// RUN:   file_compilation_dir.swift -o - -emit-ir | %FileCheck --check-prefix=CHECK-REL-CWD %s
+// RUN:   file_compilation_dir.swift -o - -emit-ir | %FileCheck --check-prefix=CHECK-REL-CWD %s %}
 
 func foo() {}
 

--- a/test/IRGen/builtin_math.swift
+++ b/test/IRGen/builtin_math.swift
@@ -6,6 +6,8 @@
   import Glibc
 #elseif os(WASI)
   import WASILibc
+#elseif os(Emscripten)
+  import EmscriptenLibc
 #elseif canImport(Android)
   import Android
 #elseif os(Windows)

--- a/test/embedded/accessors.swift
+++ b/test/embedded/accessors.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %s -Onone -parse-as-library -enable-experimental-feature Embedded -c -o %t/main.o
-// RUN: %target-clang %target-clang-resource-dir-opt %t/main.o -o %t/a.out -dead_strip %target-embedded-posix-shim
+// RUN: %target-embedded-link %target-clang-resource-dir-opt %t/main.o -o %t/a.out -dead_strip %target-embedded-posix-shim
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: swift_in_compiler

--- a/test/embedded/array-to-pointer.swift
+++ b/test/embedded/array-to-pointer.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %s -enable-experimental-feature Extern -enable-experimental-feature Embedded -c -o %t/main.o
 // RUN: %target-clang -x c -c %S/Inputs/print.c -o %t/print.o
-// RUN: %target-clang %target-clang-resource-dir-opt %t/main.o %t/print.o -o %t/a.out -dead_strip %target-embedded-posix-shim
+// RUN: %target-embedded-link %target-clang-resource-dir-opt %t/main.o %t/print.o -o %t/a.out -dead_strip %target-embedded-posix-shim
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: swift_in_compiler

--- a/test/embedded/arrays.swift
+++ b/test/embedded/arrays.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -enable-experimental-feature Extern %s -enable-experimental-feature Embedded -c -o %t/main.o
 // RUN: %target-clang -x c -c %S/Inputs/print.c -o %t/print.o
-// RUN: %target-clang %target-clang-resource-dir-opt %t/main.o %t/print.o %target-embedded-posix-shim -o %t/a.out -dead_strip
+// RUN: %target-embedded-link %target-clang-resource-dir-opt %t/main.o %t/print.o %target-embedded-posix-shim -o %t/a.out -dead_strip
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: swift_in_compiler

--- a/test/embedded/classes-multi-module.swift
+++ b/test/embedded/classes-multi-module.swift
@@ -3,7 +3,7 @@
 
 // RUN: %target-swift-frontend -enable-experimental-feature Embedded -c -I%t -parse-as-library %t/MyModule.swift -o %t/MyModule.o -emit-module -emit-module-path %t/MyModule.swiftmodule -emit-empty-object-file
 // RUN: %target-swift-frontend -enable-experimental-feature Embedded -c -I%t %t/Main.swift -o %t/Main.o
-// RUN: %target-clang %target-clang-resource-dir-opt %t/Main.o %t/MyModule.o %target-embedded-posix-shim -o %t/a.out
+// RUN: %target-embedded-link %target-clang-resource-dir-opt %t/Main.o %t/MyModule.o %target-embedded-posix-shim -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: executable_test

--- a/test/embedded/classes-optional.swift
+++ b/test/embedded/classes-optional.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %s -enable-experimental-feature Embedded -c -o %t/main.o
-// RUN: %target-clang %target-clang-resource-dir-opt %t/main.o %target-embedded-posix-shim -o %t/a.out -dead_strip
+// RUN: %target-embedded-link %target-clang-resource-dir-opt %t/main.o %target-embedded-posix-shim -o %t/a.out -dead_strip
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: swift_in_compiler

--- a/test/embedded/classes-stack-promotion.swift
+++ b/test/embedded/classes-stack-promotion.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -O -Xllvm -sil-disable-pass=function-signature-opts %s -parse-as-library -enable-experimental-feature Embedded -module-name main -emit-irgen | %FileCheck %s --check-prefix CHECK-IR
 // RUN: %target-swift-frontend -O -Xllvm -sil-disable-pass=function-signature-opts %s -parse-as-library -enable-experimental-feature Embedded -c -o %t/main.o
-// RUN: %target-clang %target-clang-resource-dir-opt %t/main.o %target-embedded-posix-shim -o %t/a.out -dead_strip
+// RUN: %target-embedded-link %target-clang-resource-dir-opt %t/main.o %target-embedded-posix-shim -o %t/a.out -dead_strip
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: swift_in_compiler

--- a/test/embedded/classes.swift
+++ b/test/embedded/classes.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %s -parse-as-library -enable-experimental-feature Embedded -c -o %t/main.o
-// RUN: %target-clang %target-clang-resource-dir-opt %t/main.o %target-embedded-posix-shim -o %t/a.out -dead_strip
+// RUN: %target-embedded-link %target-clang-resource-dir-opt %t/main.o %target-embedded-posix-shim -o %t/a.out -dead_strip
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: swift_in_compiler

--- a/test/embedded/closures-heap.swift
+++ b/test/embedded/closures-heap.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %s -parse-as-library -enable-experimental-feature Embedded -c -o %t/main.o -enforce-exclusivity=checked
-// RUN: %target-clang %target-clang-resource-dir-opt %t/main.o %target-embedded-posix-shim -o %t/a.out -dead_strip
+// RUN: %target-embedded-link %target-clang-resource-dir-opt %t/main.o %target-embedded-posix-shim -o %t/a.out -dead_strip
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: swift_in_compiler

--- a/test/embedded/collection.swift
+++ b/test/embedded/collection.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -enable-experimental-feature Extern -enable-experimental-feature Embedded -enforce-exclusivity=none %s -c -o %t/a.o
 // RUN: %target-clang -x c -c %S/Inputs/print.c -o %t/print.o
-// RUN: %target-clang %target-clang-resource-dir-opt %t/a.o %t/print.o %target-embedded-posix-shim -o %t/a.out
+// RUN: %target-embedded-link %target-clang-resource-dir-opt %t/a.o %t/print.o %target-embedded-posix-shim -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: swift_in_compiler

--- a/test/embedded/compeval-print.swift
+++ b/test/embedded/compeval-print.swift
@@ -2,7 +2,7 @@
 
 // RUN: %target-swift-frontend -O -emit-module -o %t/MyCustomMessage.swiftmodule %S/Inputs/MyCustomMessage.swift -enable-experimental-feature Embedded -parse-as-library
 // RUN: %target-swift-frontend -O -c -I %t %s -enable-experimental-feature Embedded -o %t/a.o
-// RUN: %target-clang %target-clang-resource-dir-opt %t/a.o %target-embedded-posix-shim -o %t/a.out
+// RUN: %target-embedded-link %target-clang-resource-dir-opt %t/a.o %target-embedded-posix-shim -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: swift_in_compiler

--- a/test/embedded/compeval-print2.swift
+++ b/test/embedded/compeval-print2.swift
@@ -2,7 +2,7 @@
 
 // RUN: %target-swift-frontend -O -emit-module -o %t/MyCustomMessage.swiftmodule %S/Inputs/MyCustomMessage2.swift -enable-experimental-feature Embedded -parse-as-library
 // RUN: %target-swift-frontend -O -c -I %t %s -enable-experimental-feature Embedded -o %t/a.o
-// RUN: %target-clang %target-clang-resource-dir-opt %t/a.o %target-embedded-posix-shim -o %t/a.out
+// RUN: %target-embedded-link %target-clang-resource-dir-opt %t/a.o %target-embedded-posix-shim -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: swift_in_compiler

--- a/test/embedded/concurrency-actors.swift
+++ b/test/embedded/concurrency-actors.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -enable-experimental-feature Embedded -parse-as-library %s -c -o %t/a.o
-// RUN: %target-clang %t/a.o %target-embedded-posix-shim -o %t/a.out -L%swift_obj_root/lib/swift/embedded/%module-target-triple %target-clang-resource-dir-opt -lswift_Concurrency %target-swift-default-executor-opt -dead_strip
+// RUN: %target-embedded-link %t/a.o %target-embedded-posix-shim -o %t/a.out -L%swift_obj_root/lib/swift/embedded/%module-target-triple %target-clang-resource-dir-opt -lswift_Concurrency %target-swift-default-executor-opt -dead_strip
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: executable_test

--- a/test/embedded/concurrency-async-let.swift
+++ b/test/embedded/concurrency-async-let.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -enable-experimental-feature Embedded -parse-as-library %s -c -o %t/a.o
-// RUN: %target-clang %t/a.o %target-embedded-posix-shim -o %t/a.out -L%swift_obj_root/lib/swift/embedded/%module-target-triple %target-clang-resource-dir-opt -lswift_Concurrency %target-swift-default-executor-opt -dead_strip
+// RUN: %target-embedded-link %t/a.o %target-embedded-posix-shim -o %t/a.out -L%swift_obj_root/lib/swift/embedded/%module-target-triple %target-clang-resource-dir-opt -lswift_Concurrency %target-swift-default-executor-opt -dead_strip
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: executable_test

--- a/test/embedded/concurrency-continuations.swift
+++ b/test/embedded/concurrency-continuations.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -enable-experimental-feature Embedded -parse-as-library %s -c -o %t/a.o
-// RUN: %target-clang %target-clang-resource-dir-opt %t/a.o %target-embedded-posix-shim -o %t/a.out -L%swift_obj_root/lib/swift/embedded/%module-target-triple %target-clang-resource-dir-opt -lswift_Concurrency %target-swift-default-executor-opt -dead_strip
+// RUN: %target-embedded-link %target-clang-resource-dir-opt %t/a.o %target-embedded-posix-shim -o %t/a.out -L%swift_obj_root/lib/swift/embedded/%module-target-triple %target-clang-resource-dir-opt -lswift_Concurrency %target-swift-default-executor-opt -dead_strip
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: executable_test

--- a/test/embedded/concurrency-currenttask.swift
+++ b/test/embedded/concurrency-currenttask.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -enable-experimental-feature Embedded -parse-as-library %s -c -o %t/a.o
-// RUN: %target-clang %t/a.o %target-embedded-posix-shim -o %t/a.out -L%swift_obj_root/lib/swift/embedded/%module-target-triple %target-clang-resource-dir-opt -lswift_Concurrency %target-swift-default-executor-opt -dead_strip
+// RUN: %target-embedded-link %t/a.o %target-embedded-posix-shim -o %t/a.out -L%swift_obj_root/lib/swift/embedded/%module-target-triple %target-clang-resource-dir-opt -lswift_Concurrency %target-swift-default-executor-opt -dead_strip
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: executable_test

--- a/test/embedded/concurrency-deleted-method.swift
+++ b/test/embedded/concurrency-deleted-method.swift
@@ -1,13 +1,13 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -enable-experimental-feature Embedded -parse-as-library -module-name main %s -emit-ir | %FileCheck --check-prefix=CHECK-IR %s
 // RUN: %target-swift-frontend -enable-experimental-feature Embedded -parse-as-library -module-name main %s -c -o %t/a.o
-// RUN: %target-clang %t/a.o %target-embedded-posix-shim -o %t/a.out -L%swift_obj_root/lib/swift/embedded/%module-target-triple %target-clang-resource-dir-opt -lswift_Concurrency %target-swift-default-executor-opt -dead_strip
+// RUN: %target-embedded-link %t/a.o %target-embedded-posix-shim -o %t/a.out -L%swift_obj_root/lib/swift/embedded/%module-target-triple %target-clang-resource-dir-opt -lswift_Concurrency %target-swift-default-executor-opt -dead_strip
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -enable-experimental-feature Embedded -parse-as-library -module-name main %s -emit-ir | %FileCheck --check-prefix=EXIST-IR %s
 // RUN: %target-swift-frontend -enable-experimental-feature Embedded -parse-as-library -module-name main %s -c -o %t/a.o
-// RUN: %target-clang %t/a.o %target-embedded-posix-shim -o %t/a.out -L%swift_obj_root/lib/swift/embedded/%module-target-triple %target-clang-resource-dir-opt -lswift_Concurrency %target-swift-default-executor-opt -dead_strip
+// RUN: %target-embedded-link %t/a.o %target-embedded-posix-shim -o %t/a.out -L%swift_obj_root/lib/swift/embedded/%module-target-triple %target-clang-resource-dir-opt -lswift_Concurrency %target-swift-default-executor-opt -dead_strip
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 

--- a/test/embedded/concurrency-discardingtaskgroup.swift
+++ b/test/embedded/concurrency-discardingtaskgroup.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -enable-experimental-feature Embedded -parse-as-library %s -c -o %t/a.o
-// RUN: %target-clang %t/a.o %target-embedded-posix-shim -o %t/a.out -L%swift_obj_root/lib/swift/embedded/%module-target-triple %target-clang-resource-dir-opt -lc++abi -lswift_Concurrency %target-swift-default-executor-opt -dead_strip
+// RUN: %target-embedded-link %t/a.o %target-embedded-posix-shim -o %t/a.out -L%swift_obj_root/lib/swift/embedded/%module-target-triple %target-clang-resource-dir-opt -lc++abi -lswift_Concurrency %target-swift-default-executor-opt -dead_strip
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: executable_test

--- a/test/embedded/concurrency-leaks.swift
+++ b/test/embedded/concurrency-leaks.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -enable-experimental-feature Embedded -parse-as-library %s -c -o %t/a.o -g -O
 // RUN: %target-clang -x c -std=c11 -c %S/Inputs/debug-malloc.c -o %t/debug-malloc.o -g
-// RUN: %target-clang %t/a.o %t/debug-malloc.o %target-embedded-posix-shim -o %t/a.out -L%swift_obj_root/lib/swift/embedded/%module-target-triple %target-clang-resource-dir-opt %target-swift-default-executor-opt -lswift_Concurrency %target-swift-default-executor-opt -dead_strip -g
+// RUN: %target-embedded-link %t/a.o %t/debug-malloc.o %target-embedded-posix-shim -o %t/a.out -L%swift_obj_root/lib/swift/embedded/%module-target-triple %target-clang-resource-dir-opt %target-swift-default-executor-opt -lswift_Concurrency %target-swift-default-executor-opt -dead_strip -g
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: executable_test

--- a/test/embedded/concurrency-modules.swift
+++ b/test/embedded/concurrency-modules.swift
@@ -3,7 +3,7 @@
 
 // RUN: %target-swift-frontend -emit-module -o %t/MyModule.swiftmodule %t/MyModule.swift -enable-experimental-feature Embedded -parse-as-library
 // RUN: %target-swift-frontend -c -I %t %t/Main.swift -enable-experimental-feature Embedded -o %t/a.o -parse-as-library
-// RUN: %target-clang %t/a.o %target-embedded-posix-shim -o %t/a.out -L%swift_obj_root/lib/swift/embedded/%module-target-triple %target-clang-resource-dir-opt -lswift_Concurrency %target-swift-default-executor-opt -dead_strip
+// RUN: %target-embedded-link %t/a.o %target-embedded-posix-shim -o %t/a.out -L%swift_obj_root/lib/swift/embedded/%module-target-triple %target-clang-resource-dir-opt -lswift_Concurrency %target-swift-default-executor-opt -dead_strip
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: swift_in_compiler

--- a/test/embedded/concurrency-simple.swift
+++ b/test/embedded/concurrency-simple.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -enable-experimental-feature Embedded -parse-as-library %s -c -o %t/a.o
-// RUN: %target-clang %target-clang-resource-dir-opt %t/a.o %target-embedded-posix-shim -o %t/a.out -L%swift_obj_root/lib/swift/embedded/%module-target-triple -lc++ -lswift_Concurrency %target-swift-default-executor-opt -dead_strip
+// RUN: %target-embedded-link %target-clang-resource-dir-opt %t/a.o %target-embedded-posix-shim -o %t/a.out -L%swift_obj_root/lib/swift/embedded/%module-target-triple -lc++ -lswift_Concurrency %target-swift-default-executor-opt -dead_strip
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: executable_test

--- a/test/embedded/concurrency-stream-throwing.swift
+++ b/test/embedded/concurrency-stream-throwing.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -enable-experimental-feature Embedded -parse-as-library %s -c -o %t/a.o
-// RUN: %target-clang %t/a.o %target-embedded-posix-shim -o %t/a.out -L%swift_obj_root/lib/swift/embedded/%module-target-triple %target-clang-resource-dir-opt -lswift_Concurrency %target-swift-default-executor-opt -dead_strip
+// RUN: %target-embedded-link %t/a.o %target-embedded-posix-shim -o %t/a.out -L%swift_obj_root/lib/swift/embedded/%module-target-triple %target-clang-resource-dir-opt -lswift_Concurrency %target-swift-default-executor-opt -dead_strip
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: executable_test

--- a/test/embedded/concurrency-stream.swift
+++ b/test/embedded/concurrency-stream.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -enable-experimental-feature Embedded -parse-as-library %s -c -o %t/a.o
-// RUN: %target-clang %t/a.o %target-embedded-posix-shim -o %t/a.out -L%swift_obj_root/lib/swift/embedded/%module-target-triple %target-clang-resource-dir-opt -lswift_Concurrency %target-swift-default-executor-opt -dead_strip
+// RUN: %target-embedded-link %t/a.o %target-embedded-posix-shim -o %t/a.out -L%swift_obj_root/lib/swift/embedded/%module-target-triple %target-clang-resource-dir-opt -lswift_Concurrency %target-swift-default-executor-opt -dead_strip
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: executable_test

--- a/test/embedded/concurrency-taskgroup.swift
+++ b/test/embedded/concurrency-taskgroup.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -enable-experimental-feature Embedded -parse-as-library %s -c -o %t/a.o
-// RUN: %target-clang %t/a.o %target-embedded-posix-shim -o %t/a.out -L%swift_obj_root/lib/swift/embedded/%module-target-triple %target-clang-resource-dir-opt -lc++abi -lswift_Concurrency %target-swift-default-executor-opt -dead_strip
+// RUN: %target-embedded-link %t/a.o %target-embedded-posix-shim -o %t/a.out -L%swift_obj_root/lib/swift/embedded/%module-target-triple %target-clang-resource-dir-opt -lc++abi -lswift_Concurrency %target-swift-default-executor-opt -dead_strip
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: executable_test

--- a/test/embedded/concurrency-tasklocal.swift
+++ b/test/embedded/concurrency-tasklocal.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -enable-experimental-feature Embedded -parse-as-library %s -c -o %t/a.o -plugin-path %swift-plugin-dir
-// RUN: %target-clang %t/a.o %target-embedded-posix-shim -o %t/a.out -L%swift_obj_root/lib/swift/embedded/%module-target-triple %target-clang-resource-dir-opt -lc++abi -lswift_Concurrency %target-swift-default-executor-opt -dead_strip -Xlinker %swift_obj_root/lib/swift/embedded/%module-target-triple/libswiftUnicodeDataTables.a
+// RUN: %target-embedded-link %t/a.o %target-embedded-posix-shim -o %t/a.out -L%swift_obj_root/lib/swift/embedded/%module-target-triple %target-clang-resource-dir-opt -lc++abi -lswift_Concurrency %target-swift-default-executor-opt -dead_strip -Xlinker %swift_obj_root/lib/swift/embedded/%module-target-triple/libswiftUnicodeDataTables.a
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: executable_test

--- a/test/embedded/concurrency-throwing-task.swift
+++ b/test/embedded/concurrency-throwing-task.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -enable-experimental-feature Embedded -parse-as-library %s -c -o %t/a.o
-// RUN: %target-clang %t/a.o %target-embedded-posix-shim -o %t/a.out -L%swift_obj_root/lib/swift/embedded/%module-target-triple %target-clang-resource-dir-opt -lswift_Concurrency %target-swift-default-executor-opt -dead_strip
+// RUN: %target-embedded-link %t/a.o %target-embedded-posix-shim -o %t/a.out -L%swift_obj_root/lib/swift/embedded/%module-target-triple %target-clang-resource-dir-opt -lswift_Concurrency %target-swift-default-executor-opt -dead_strip
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: executable_test

--- a/test/embedded/concurrency-typed-throws.swift
+++ b/test/embedded/concurrency-typed-throws.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -enable-experimental-feature Embedded -parse-as-library %s -c -o %t/a.o
-// RUN: %target-clang %t/a.o %target-embedded-posix-shim -o %t/a.out -L%swift_obj_root/lib/swift/embedded/%module-target-triple %target-clang-resource-dir-opt -lswift_Concurrency %target-swift-default-executor-opt -dead_strip
+// RUN: %target-embedded-link %t/a.o %target-embedded-posix-shim -o %t/a.out -L%swift_obj_root/lib/swift/embedded/%module-target-triple %target-clang-resource-dir-opt -lswift_Concurrency %target-swift-default-executor-opt -dead_strip
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: executable_test

--- a/test/embedded/custom-executor.swift
+++ b/test/embedded/custom-executor.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -enable-experimental-feature Embedded -parse-as-library %s -c -o %t/a.o
 // RUN: %target-clang -x c -std=c11 -I %swift_obj_root/include -c %S/Inputs/executor.c -o %t/executor.o
-// RUN: %target-clang %target-clang-resource-dir-opt %t/a.o %t/executor.o %target-embedded-posix-shim -o %t/a.out %swift_obj_root/lib/swift/embedded/%module-target-triple/libswift_Concurrency.a -dead_strip
+// RUN: %target-embedded-link %target-clang-resource-dir-opt %t/a.o %t/executor.o %target-embedded-posix-shim -o %t/a.out %swift_obj_root/lib/swift/embedded/%module-target-triple/libswift_Concurrency.a -dead_strip
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: executable_test

--- a/test/embedded/custom-print.swift
+++ b/test/embedded/custom-print.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -enable-experimental-feature Extern -enable-experimental-feature Embedded -enforce-exclusivity=none %s -c -o %t/a.o
-// RUN: %target-clang %target-clang-resource-dir-opt %t/a.o %target-embedded-posix-shim -o %t/a.out
+// RUN: %target-embedded-link %target-clang-resource-dir-opt %t/a.o %target-embedded-posix-shim -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: swift_in_compiler

--- a/test/embedded/darwin-bridging-header.swift
+++ b/test/embedded/darwin-bridging-header.swift
@@ -2,7 +2,7 @@
 // RUN: %{python} %utils/split_file.py -o %t %s
 
 // RUN: %target-swift-frontend %t/Main.swift -parse-as-library -import-bridging-header %t/BridgingHeader.h -enable-experimental-feature Embedded -c -o %t/main.o
-// RUN: %target-clang %t/main.o %target-embedded-posix-shim -o %t/a.out -dead_strip
+// RUN: %target-embedded-link %t/main.o %target-embedded-posix-shim -o %t/a.out -dead_strip
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: swift_in_compiler

--- a/test/embedded/darwin.swift
+++ b/test/embedded/darwin.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %s -parse-as-library -enable-experimental-feature Embedded -throws-as-traps -enable-builtin-module -c -o %t/main.o
-// RUN: %target-clang %t/main.o %target-embedded-posix-shim -o %t/a.out -dead_strip
+// RUN: %target-embedded-link %t/main.o %target-embedded-posix-shim -o %t/a.out -dead_strip
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: swift_in_compiler

--- a/test/embedded/deinit-noncopyable.swift
+++ b/test/embedded/deinit-noncopyable.swift
@@ -2,7 +2,7 @@
 // RUN: split-file %s %t
 // RUN: %target-swift-frontend %t/Library.swift -g -enable-experimental-feature Embedded -enable-experimental-feature Lifetimes -c -parse-as-library -o %t/Library.o -emit-module
 // RUN: %target-swift-frontend -I %t %t/Application.swift -g -enable-experimental-feature Embedded -enable-experimental-feature Lifetimes -c -o %t/main.o
-// RUN: %target-clang %target-clang-resource-dir-opt %t/main.o %target-embedded-posix-shim -o %t/a.out -dead_strip
+// RUN: %target-embedded-link %target-clang-resource-dir-opt %t/main.o %target-embedded-posix-shim -o %t/a.out -dead_strip
 // RUN: %target-run %t/a.out | %FileCheck %s
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test

--- a/test/embedded/deinit-release.swift
+++ b/test/embedded/deinit-release.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %s -enable-experimental-feature Embedded -O -c -o %t/main.o
-// RUN: %target-clang %target-clang-resource-dir-opt %t/main.o %target-embedded-posix-shim -o %t/a.out -dead_strip
+// RUN: %target-embedded-link %target-clang-resource-dir-opt %t/main.o %target-embedded-posix-shim -o %t/a.out -dead_strip
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: swift_in_compiler

--- a/test/embedded/deinit-release2.swift
+++ b/test/embedded/deinit-release2.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %s -enable-experimental-feature Embedded -O -c -o %t/main.o
-// RUN: %target-clang %target-clang-resource-dir-opt %t/main.o %target-embedded-posix-shim -o %t/a.out -dead_strip
+// RUN: %target-embedded-link %target-clang-resource-dir-opt %t/main.o %target-embedded-posix-shim -o %t/a.out -dead_strip
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: swift_in_compiler

--- a/test/embedded/dependencies-concurrency-custom-executor.swift
+++ b/test/embedded/dependencies-concurrency-custom-executor.swift
@@ -2,7 +2,7 @@
 // RUN: split-file %s %t
 // RUN: %target-swift-frontend -target %target-cpu-apple-macos14 -disable-availability-checking -parse-as-library -enable-experimental-feature Embedded %t/test.swift -c -o %t/a.o
 // RUN: %target-clang -x c -std=c11 -I %swift_obj_root/include -c %S/Inputs/executor.c -o %t/executor.o
-// RUN: %target-clang %t/a.o %t/executor.o %target-embedded-posix-shim -o %t/a.out %swift_obj_root/lib/swift/embedded/%target-cpu-apple-macos/libswift_Concurrency.a -dead_strip
+// RUN: %target-embedded-link %t/a.o %t/executor.o %target-embedded-posix-shim -o %t/a.out %swift_obj_root/lib/swift/embedded/%target-cpu-apple-macos/libswift_Concurrency.a -dead_strip
 
 // RUN: %llvm-nm --undefined-only --format=just-symbols %t/a.out | sort | tee %t/actual-dependencies.txt
 

--- a/test/embedded/dependencies-concurrency-custom-executor2.swift
+++ b/test/embedded/dependencies-concurrency-custom-executor2.swift
@@ -2,7 +2,7 @@
 // RUN: split-file %s %t
 // RUN: %target-swift-frontend -target %target-cpu-apple-macos14 -disable-availability-checking -parse-as-library -enable-experimental-feature Embedded %t/test.swift -c -o %t/a.o -Osize
 // RUN: %target-clang -x c -std=c11 -I %swift_obj_root/include -c %S/Inputs/executor.c -o %t/executor.o -Oz -DNDEBUG -DDEBUG_EXECUTOR=0
-// RUN: %target-clang %t/a.o %t/executor.o -o %t/a.out %swift_obj_root/lib/swift/embedded/%target-cpu-apple-macos/libswift_Concurrency.a -dead_strip
+// RUN: %target-embedded-link %t/a.o %t/executor.o -o %t/a.out %swift_obj_root/lib/swift/embedded/%target-cpu-apple-macos/libswift_Concurrency.a -dead_strip
 
 // RUN: %llvm-nm --undefined-only --format=just-symbols %t/a.out | sort | tee %t/actual-dependencies.txt
 

--- a/test/embedded/dependencies-concurrency.swift
+++ b/test/embedded/dependencies-concurrency.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 // RUN: %target-swift-frontend -target %target-cpu-apple-macos14 -disable-availability-checking -parse-as-library -enable-experimental-feature Embedded %t/test.swift -c -o %t/a.o
-// RUN: %target-clang %t/a.o %target-embedded-posix-shim -o %t/a.out -L%swift_obj_root/lib/swift/embedded/%target-cpu-apple-macos -lswift_Concurrency -lswift_ConcurrencyDefaultExecutor -dead_strip
+// RUN: %target-embedded-link %t/a.o %target-embedded-posix-shim -o %t/a.out -L%swift_obj_root/lib/swift/embedded/%target-cpu-apple-macos -lswift_Concurrency -lswift_ConcurrencyDefaultExecutor -dead_strip
 
 // RUN: %llvm-nm --undefined-only --format=just-symbols %t/a.out | sort | tee %t/actual-dependencies.txt
 

--- a/test/embedded/dependencies-concurrency2.swift
+++ b/test/embedded/dependencies-concurrency2.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 // RUN: %target-swift-frontend -target %target-cpu-apple-macos14 -disable-availability-checking -parse-as-library -enable-experimental-feature Embedded %t/test.swift -c -o %t/a.o
-// RUN: %target-clang -nostdlib -lSystem %t/a.o %target-embedded-posix-shim -o %t/a.out -L%swift_obj_root/lib/swift/embedded/%target-cpu-apple-macos -lswift_Concurrency -dead_strip -Wl,-undefined,dynamic_lookup
+// RUN: %target-embedded-link -nostdlib -lSystem %t/a.o %target-embedded-posix-shim -o %t/a.out -L%swift_obj_root/lib/swift/embedded/%target-cpu-apple-macos -lswift_Concurrency -dead_strip -Wl,-undefined,dynamic_lookup
 
 // RUN: %llvm-nm --undefined-only --format=just-symbols %t/a.out | sort | tee %t/actual-dependencies.txt
 

--- a/test/embedded/dependencies-no-allocations.swift
+++ b/test/embedded/dependencies-no-allocations.swift
@@ -26,7 +26,7 @@ memset
 putchar
 //--- test.swift
 // RUN: %target-clang -x c -c %S/Inputs/print.c -o %t/print.o
-// RUN: %target-clang %t/a.o %t/print.o -o %t/a.out
+// RUN: %target-embedded-link %t/a.o %t/print.o -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: swift_in_compiler

--- a/test/embedded/dependencies-print.swift
+++ b/test/embedded/dependencies-print.swift
@@ -29,7 +29,7 @@ memset
 putchar
 //--- test.swift
 // RUN: %target-clang -x c -c %S/Inputs/print.c -o %t/print.o
-// RUN: %target-clang %t/a.o %t/print.o -o %t/a.out
+// RUN: %target-embedded-link %t/a.o %t/print.o -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: swift_in_compiler

--- a/test/embedded/dependencies-random.swift
+++ b/test/embedded/dependencies-random.swift
@@ -45,14 +45,16 @@ posix_memalign
 putchar
 //--- test.swift
 // RUN: %target-clang -x c -c %S/Inputs/print.c -o %t/print.o
-// RUN: %target-clang -x c -c %S/Inputs/linux-rng-support.c -o %t/linux-rng-support.o
-// RUN: %target-clang %target-clang-resource-dir-opt %t/a.o %t/print.o %t/linux-rng-support.o -o %t/a.out
+// RUN: %target-embedded-link %target-clang-resource-dir-opt %t/a.o %t/print.o -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
 // UNSUPPORTED: OS=linux-gnu && CPU=aarch64
+// UNSUPPORTED: OS=emscripten
+// arc4random_buf is not provided by emscripten's musl-derived libc
+// (`wasm-ld: error: undefined symbol: arc4random_buf`).
 
 // REQUIRES: swift_feature_Embedded
 // REQUIRES: swift_feature_Extern

--- a/test/embedded/dependencies.swift
+++ b/test/embedded/dependencies.swift
@@ -30,7 +30,7 @@ posix_memalign
 putchar
 //--- test.swift
 // RUN: %target-clang -x c -c %S/Inputs/print.c -o %t/print.o
-// RUN: %target-clang %t/a.o %t/print.o -o %t/a.out
+// RUN: %target-embedded-link %t/a.o %t/print.o -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: swift_in_compiler

--- a/test/embedded/exclusivity_runtime.swift
+++ b/test/embedded/exclusivity_runtime.swift
@@ -10,7 +10,7 @@
 // RUN: %FileCheck -check-prefix YESOPT %s < %t/yesopt.ll
 
 // Run without optimization.
-// RUN: %target-clang %t/a.o %target-embedded-posix-shim -o %t/noopt.out -L%swift_obj_root/lib/swift/embedded/%module-target-triple %target-clang-resource-dir-opt -lswift_Concurrency %target-swift-default-executor-opt -dead_strip -lswiftExclusivitySingleThreaded
+// RUN: %target-embedded-link %t/a.o %target-embedded-posix-shim -o %t/noopt.out -L%swift_obj_root/lib/swift/embedded/%module-target-triple %target-clang-resource-dir-opt -lswift_Concurrency %target-swift-default-executor-opt -dead_strip -lswiftExclusivitySingleThreaded
 // RUN: %target-run not --crash %t/noopt.out
 
 // Build with optimization.
@@ -22,7 +22,7 @@
 // RUN: %FileCheck -check-prefix NOOPT %s < %t/noopt.ll
 
 // Run with optimization.
-// RUN: %target-clang %t/a.o %target-embedded-posix-shim -o %t/opt.out -L%swift_obj_root/lib/swift/embedded/%module-target-triple %target-clang-resource-dir-opt -lswift_Concurrency %target-swift-default-executor-opt -dead_strip -lswiftExclusivitySingleThreaded
+// RUN: %target-embedded-link %t/a.o %target-embedded-posix-shim -o %t/opt.out -L%swift_obj_root/lib/swift/embedded/%module-target-triple %target-clang-resource-dir-opt -lswift_Concurrency %target-swift-default-executor-opt -dead_strip -lswiftExclusivitySingleThreaded
 // RUN: %target-run not --crash %t/opt.out
 
 // REQUIRES: executable_test
@@ -32,6 +32,10 @@
 // REQUIRES: swift_feature_EmbeddedDynamicExclusivity
 
 // UNSUPPORTED: OS=wasip1
+// UNSUPPORTED: OS=emscripten
+// The RUN line asserts a trap via LLVM's `not --crash`, but emscripten-run.py
+// passes its arguments to `node`, which then cannot load `not` as a JS module
+// (`Error: Cannot find module 'not'`).
 
 struct NC: ~Copyable {
   var i: Int = 1

--- a/test/embedded/exclusivity_runtime_multi.swift
+++ b/test/embedded/exclusivity_runtime_multi.swift
@@ -2,7 +2,7 @@
 // RUN: %target-swift-frontend -enable-experimental-feature Embedded -parse-as-library %s -c -o %t/a.o -enforce-exclusivity=checked -enable-experimental-feature EmbeddedDynamicExclusivity
 
 // Multi-threaded exclusivity checking implementation (that uses C11 thread_local).
-// RUN: %target-clang %t/a.o %target-embedded-posix-shim -o %t/a.out -L%swift_obj_root/lib/swift/embedded/%module-target-triple %target-clang-resource-dir-opt -lswift_Concurrency %target-swift-default-executor-opt -dead_strip -lswiftExclusivityC11ThreadLocal
+// RUN: %target-embedded-link %t/a.o %target-embedded-posix-shim -o %t/a.out -L%swift_obj_root/lib/swift/embedded/%module-target-triple %target-clang-resource-dir-opt -lswift_Concurrency %target-swift-default-executor-opt -dead_strip -lswiftExclusivityC11ThreadLocal
 // RUN: %target-run not --crash %t/a.out
 
 // REQUIRES: executable_test
@@ -12,6 +12,10 @@
 // REQUIRES: swift_feature_EmbeddedDynamicExclusivity
 
 // UNSUPPORTED: OS=wasip1
+// UNSUPPORTED: OS=emscripten
+// libswiftExclusivityC11ThreadLocal.a links no symbols on emscripten because
+// C11 `_Thread_local` is gated out for its musl-derived libc
+// (`wasm-ld: error: undefined symbol: _swift_{get,set}ExclusivityTLS`).
 
 struct NC: ~Copyable {
   var i: Int = 1

--- a/test/embedded/import-vtables.swift
+++ b/test/embedded/import-vtables.swift
@@ -4,7 +4,7 @@
 // RUN: %target-swift-frontend -emit-module -o %t/MyModule.swiftmodule %t/MyModule.swift -enable-experimental-feature Embedded -parse-as-library
 // RUN: %target-swift-frontend -c -I %t %t/Main.swift -enable-experimental-feature Embedded -o %t/a.o
 // RUN: %target-clang -x c -c %S/Inputs/print.c -o %t/print.o
-// RUN: %target-clang %target-clang-resource-dir-opt %t/a.o %t/print.o %target-embedded-posix-shim -o %t/a.out
+// RUN: %target-embedded-link %target-clang-resource-dir-opt %t/a.o %t/print.o %target-embedded-posix-shim -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: swift_in_compiler

--- a/test/embedded/linkage-mergeable-dead-strip.swift
+++ b/test/embedded/linkage-mergeable-dead-strip.swift
@@ -2,13 +2,18 @@
 
 // RUN: %target-swift-frontend -enable-experimental-feature Embedded -module-name main -O %s -emit-ir | %FileCheck %s --check-prefix=CHECK-IR
 // RUN: %target-swift-frontend -enable-experimental-feature Embedded -module-name main -O %s -c -o %t/a.o
-// RUN: %target-clang %target-clang-resource-dir-opt %t/a.o %target-embedded-posix-shim -o %t/a.out -dead_strip
+// RUN: %target-embedded-link %target-clang-resource-dir-opt %t/a.o %target-embedded-posix-shim -o %t/a.out -dead_strip
 // RUN: %llvm-nm --defined-only --format=just-symbols --demangle %t/a.out | sort | %FileCheck %s --check-prefix=CHECK-NM
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
 // REQUIRES: swift_feature_Embedded
+
+// UNSUPPORTED: OS=emscripten
+// With `-o a.out`, emcc emits a JS launcher named `a.out` plus the wasm binary
+// at `a.out.wasm`, so the CHECK-NM step's `llvm-nm a.out` rejects the JS file as
+// "not recognized as a valid object file".
 
 public func a_this_is_unused() { }
 

--- a/test/embedded/linkage-mergeable.swift
+++ b/test/embedded/linkage-mergeable.swift
@@ -3,7 +3,7 @@
 
 // RUN: %target-swift-frontend -c -emit-module -o %t/MyModule.o %t/MyModule.swift   -enable-experimental-feature Embedded -parse-as-library
 // RUN: %target-swift-frontend -c              -o %t/a.o        %t/Main.swift -I %t -enable-experimental-feature Embedded
-// RUN: %target-clang %target-clang-resource-dir-opt %t/a.o %t/MyModule.o %target-embedded-posix-shim -o %t/a.out
+// RUN: %target-embedded-link %target-clang-resource-dir-opt %t/a.o %t/MyModule.o %target-embedded-posix-shim -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: swift_in_compiler

--- a/test/embedded/linkage-mergeable2.swift
+++ b/test/embedded/linkage-mergeable2.swift
@@ -3,7 +3,7 @@
 
 // RUN: %target-swift-frontend -O -c -emit-module -o %t/MyModule.o %t/MyModule.swift   -enable-experimental-feature Embedded -parse-as-library
 // RUN: %target-swift-frontend -O -c              -o %t/a.o        %t/Main.swift -I %t -enable-experimental-feature Embedded
-// RUN: %target-clang %target-clang-resource-dir-opt %t/a.o %t/MyModule.o %target-embedded-posix-shim -o %t/a.out
+// RUN: %target-embedded-link %target-clang-resource-dir-opt %t/a.o %t/MyModule.o %target-embedded-posix-shim -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: swift_in_compiler

--- a/test/embedded/linkage-mergeable3.swift
+++ b/test/embedded/linkage-mergeable3.swift
@@ -3,7 +3,7 @@
 
 // RUN: %target-swift-frontend -num-threads 2 -O -c -emit-module -o %t/MyModule.o             %t/MyModule.swift                   -enable-experimental-feature Embedded -parse-as-library
 // RUN: %target-swift-frontend -num-threads 2 -O -c              -o %t/MainA.o -o %t/MainB.o  %t/MainA.swift %t/MainB.swift -I %t -enable-experimental-feature Embedded -parse-as-library
-// RUN: %target-clang %target-clang-resource-dir-opt %t/MainA.o %t/MainB.o %t/MyModule.o %target-embedded-posix-shim -o %t/a.out
+// RUN: %target-embedded-link %target-clang-resource-dir-opt %t/MainA.o %t/MainB.o %t/MyModule.o %target-embedded-posix-shim -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: swift_in_compiler

--- a/test/embedded/linkage-mergeable4.swift
+++ b/test/embedded/linkage-mergeable4.swift
@@ -10,6 +10,12 @@
 // REQUIRES: executable_test
 // REQUIRES: swift_feature_Embedded
 
+// UNSUPPORTED: OS=emscripten
+// Dictionary literals trigger the embedded stdlib's hash-seed init, which calls
+// arc4random_buf, not provided by emscripten's musl-derived libc
+// (`wasm-ld: error: undefined symbol: arc4random_buf`). Same cause as
+// dependencies-random.swift.
+
 // BEGIN MyModule.swift
 
 var dict: [Int:Int] = [1: 2, 3: 4]

--- a/test/embedded/linkage/cxx-exceptions.swift
+++ b/test/embedded/linkage/cxx-exceptions.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %s -enable-experimental-feature Embedded -O -c -o %t/main.o -cxx-interoperability-mode=default
-// RUN: %target-clang %target-clang-resource-dir-opt %t/main.o %target-embedded-posix-shim -o %t/a.out -dead_strip
+// RUN: %target-embedded-link %target-clang-resource-dir-opt %t/main.o %target-embedded-posix-shim -o %t/a.out -dead_strip
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: swift_in_compiler

--- a/test/embedded/linkage/diamond.swift
+++ b/test/embedded/linkage/diamond.swift
@@ -28,7 +28,7 @@
 // RUN: %target-swift-frontend -c -I %t -emit-module -o %t/ClientA.o %t/ClientA.swift -enable-experimental-feature Embedded -parse-as-library
 // RUN: %target-swift-frontend -c -I %t -emit-module -o %t/ClientB.o %t/ClientB.swift -enable-experimental-feature Embedded -parse-as-library
 // RUN: %target-swift-frontend -c -I %t -emit-module -o %t/Application.o %t/Application.swift -enable-experimental-feature Embedded -parse-as-library
-// RUN: %target-clang %target-clang-resource-dir-opt %t/Root.o %t/ClientA.o %t/ClientB.o %t/Application.o %target-embedded-posix-shim -o %t/Application
+// RUN: %target-embedded-link %target-clang-resource-dir-opt %t/Root.o %t/ClientA.o %t/ClientB.o %t/Application.o %target-embedded-posix-shim -o %t/Application
 // RUN: %target-run %t/Application | %FileCheck %s
 
 // Test #2: Root is an "intermediate" library for everything
@@ -36,7 +36,7 @@
 // RUN: %target-swift-frontend -c -I %t -emit-module -o %t/ClientA.o %t/ClientA.swift -enable-experimental-feature Embedded -parse-as-library
 // RUN: %target-swift-frontend -c -I %t -emit-module -o %t/ClientB.o %t/ClientB.swift -enable-experimental-feature Embedded -parse-as-library
 // RUN: %target-swift-frontend -c -I %t -emit-module -o %t/Application.o %t/Application.swift -enable-experimental-feature Embedded -parse-as-library
-// RUN: %target-clang %target-clang-resource-dir-opt %t/Root.o %t/ClientA.o %t/ClientB.o %t/Application.o %target-embedded-posix-shim -o %t/Application
+// RUN: %target-embedded-link %target-clang-resource-dir-opt %t/Root.o %t/ClientA.o %t/ClientB.o %t/Application.o %target-embedded-posix-shim -o %t/Application
 // RUN: %target-run %t/Application | %FileCheck %s
 
 // Test #3: ClientA as an "intermediate" library
@@ -44,7 +44,7 @@
 // RUN: %target-swift-frontend -c -I %t -emit-module -o %t/ClientA.o %t/ClientA.swift -enable-experimental-feature Embedded -enable-experimental-feature CodeGenerationModel=implementation -parse-as-library
 // RUN: %target-swift-frontend -c -I %t -emit-module -o %t/ClientB.o %t/ClientB.swift -enable-experimental-feature Embedded -parse-as-library
 // RUN: %target-swift-frontend -c -I %t -emit-module -o %t/Application.o %t/Application.swift -enable-experimental-feature Embedded -parse-as-library
-// RUN: %target-clang %target-clang-resource-dir-opt %t/Root.o %t/ClientA.o %t/ClientB.o %t/Application.o %target-embedded-posix-shim -o %t/Application
+// RUN: %target-embedded-link %target-clang-resource-dir-opt %t/Root.o %t/ClientA.o %t/ClientB.o %t/Application.o %target-embedded-posix-shim -o %t/Application
 // RUN: %target-run %t/Application | %FileCheck %s
 
 // Test #4: Root and ClientA as "intermediate" libraries
@@ -52,7 +52,7 @@
 // RUN: %target-swift-frontend -c -I %t -emit-module -o %t/ClientA.o %t/ClientA.swift -enable-experimental-feature Embedded -enable-experimental-feature CodeGenerationModel=implementation -parse-as-library
 // RUN: %target-swift-frontend -c -I %t -emit-module -o %t/ClientB.o %t/ClientB.swift -enable-experimental-feature Embedded -parse-as-library
 // RUN: %target-swift-frontend -c -I %t -emit-module -o %t/Application.o %t/Application.swift -enable-experimental-feature Embedded -parse-as-library
-// RUN: %target-clang %target-clang-resource-dir-opt %t/Root.o %t/ClientA.o %t/ClientB.o %t/Application.o %target-embedded-posix-shim -o %t/Application
+// RUN: %target-embedded-link %target-clang-resource-dir-opt %t/Root.o %t/ClientA.o %t/ClientB.o %t/Application.o %target-embedded-posix-shim -o %t/Application
 // RUN: %target-run %t/Application | %FileCheck %s
 
 // Test #%: All "intermediate", all the time. Main drives code generation
@@ -60,7 +60,7 @@
 // RUN: %target-swift-frontend -c -I %t -emit-module -o %t/ClientA.o %t/ClientA.swift -enable-experimental-feature Embedded -enable-experimental-feature CodeGenerationModel=implementation -parse-as-library
 // RUN: %target-swift-frontend -c -I %t -emit-module -o %t/ClientB.o %t/ClientB.swift -enable-experimental-feature Embedded -enable-experimental-feature CodeGenerationModel=implementation -parse-as-library
 // RUN: %target-swift-frontend -c -I %t -emit-module -o %t/Application.o %t/Application.swift -enable-experimental-feature Embedded -enable-experimental-feature CodeGenerationModel=implementation -parse-as-library
-// RUN: %target-clang %target-clang-resource-dir-opt %t/Root.o %t/ClientA.o %t/ClientB.o %t/Application.o %target-embedded-posix-shim -o %t/Application
+// RUN: %target-embedded-link %target-clang-resource-dir-opt %t/Root.o %t/ClientA.o %t/ClientB.o %t/Application.o %target-embedded-posix-shim -o %t/Application
 // RUN: %target-run %t/Application | %FileCheck %s
 
 

--- a/test/embedded/linkage/diamond_embedded_exist.swift
+++ b/test/embedded/linkage/diamond_embedded_exist.swift
@@ -6,7 +6,7 @@
 // RUN: %target-swift-frontend -c -I %t -emit-module -o %t/ClientA.o %t/ClientA.swift -enable-experimental-feature Embedded -enable-experimental-feature CodeGenerationModel=implementation -parse-as-library
 // RUN: %target-swift-frontend -c -I %t -emit-module -o %t/ClientB.o %t/ClientB.swift -enable-experimental-feature Embedded -enable-experimental-feature CodeGenerationModel=implementation -parse-as-library
 // RUN: %target-swift-frontend -c -I %t -emit-module -o %t/Application.o %t/Application.swift -enable-experimental-feature Embedded -enable-experimental-feature CodeGenerationModel=implementation -parse-as-library
-// RUN: %target-clang %target-clang-resource-dir-opt %t/Root.o %t/ClientA.o %t/ClientB.o %t/Application.o %target-embedded-posix-shim -o %t/Application
+// RUN: %target-embedded-link %target-clang-resource-dir-opt %t/Root.o %t/ClientA.o %t/ClientB.o %t/Application.o %target-embedded-posix-shim -o %t/Application
 // RUN: %target-run %t/Application | %FileCheck %s
 
 // But use this file's Root.swift
@@ -19,7 +19,7 @@
 // RUN: %target-swift-frontend -c -I %t -emit-module -o %t/ClientA.o %t/ClientA.swift -enable-experimental-feature Embedded -enable-experimental-feature CodeGenerationModel=implementation -parse-as-library
 // RUN: %target-swift-frontend -c -I %t -emit-module -o %t/ClientB.o %t/ClientB.swift -enable-experimental-feature Embedded -enable-experimental-feature CodeGenerationModel=implementation -parse-as-library
 // RUN: %target-swift-frontend -c -I %t -emit-module -o %t/Application.o %t/Application.swift -enable-experimental-feature Embedded -enable-experimental-feature CodeGenerationModel=implementation -parse-as-library
-// RUN: %target-clang %target-clang-resource-dir-opt %t/Root.o %t/ClientA.o %t/ClientB.o %t/Application.o %target-embedded-posix-shim -o %t/Application
+// RUN: %target-embedded-link %target-clang-resource-dir-opt %t/Root.o %t/ClientA.o %t/ClientB.o %t/Application.o %target-embedded-posix-shim -o %t/Application
 // RUN: %target-run %t/Application | %FileCheck %s
 
 // REQUIRES: swift_in_compiler

--- a/test/embedded/linkage/weak_linkage_bug.swift
+++ b/test/embedded/linkage/weak_linkage_bug.swift
@@ -5,7 +5,7 @@
 // RUN: %target-swift-frontend -c -wmo -emit-module -o %t/C.o %t/C.swift -enable-experimental-feature Embedded -parse-as-library
 // RUN: %target-swift-frontend -num-threads 1 -c -I %t -emit-module -o %t/D.o -o %t/D2.o %t/D.swift %t/D2.swift -wmo -enable-experimental-feature Embedded -parse-as-library
 
-// RUN: %target-clang %target-clang-resource-dir-opt %t/C.o %t/D.o %t/D2.o  %target-embedded-posix-shim -o %t/Application
+// RUN: %target-embedded-link %target-clang-resource-dir-opt %t/C.o %t/D.o %t/D2.o  %target-embedded-posix-shim -o %t/Application
 // RUN: %target-run %t/Application | %FileCheck %s
 
 

--- a/test/embedded/lit.local.cfg
+++ b/test/embedded/lit.local.cfg
@@ -20,7 +20,7 @@ if 'embedded_stdlib' not in config.available_features:
   config.unsupported = True
 
 # (3) Restrict Embedded Swift tests only to the currently supported set of test target OS's, skip them otherwise.
-supported_test_os_list = ["OS=macosx", "OS=linux-gnu", "OS=none-eabi", "OS=none-elf", "OS=wasip1"]
+supported_test_os_list = ["OS=macosx", "OS=linux-gnu", "OS=none-eabi", "OS=none-elf", "OS=wasip1", "OS=emscripten"]
 if config.available_features.intersection(set(supported_test_os_list)) == set():
   config.unsupported = True
 
@@ -34,12 +34,37 @@ target_cpu = [y for (x, y) in config.substitutions if x == "%target-cpu"][0]
 target_triple = [y for (x, y) in config.substitutions if x == "%target-triple"][0]
 
 # (5) Provide some useful substitutions to simplify writing tests that work across platforms (macOS, Linux, etc.)
+# %target-embedded-link: the linker driver plus per-OS auxiliary inputs embedded
+# tests need. Linux injects the local arc4random_buf shim. Emscripten routes
+# through emcc with the Swift-ABI flags swift-driver uses for the same triple.
+# macOS and others use the bare driver with no aux inputs.
 # Use an absolute path to the embedded Inputs directory so that tests in
 # subdirectories (e.g. embedded/linkage/) can also use %target-embedded-link.
 embedded_inputs_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "Inputs")
 if "OS=linux-gnu" in config.available_features:
   config.substitutions.append(("%target-embedded-link", config.target_clang + f" -x c {embedded_inputs_dir}/linux-rng-support.c -x none"))
   config.substitutions.append(("%embedded-unicode-tables", f"-Xlinker {config.swift_obj_root}/lib/swift/embedded/{target_cpu}-unknown-linux-gnu/libswiftUnicodeDataTables.a"))
+elif "OS=emscripten" in config.available_features:
+  # Emscripten programs must link through `emcc`: `crt1.o` references symbols
+  # (`exit`, `__main_void`) that only emcc's runtime and JS glue provide. The
+  # `-sGLOBAL_BASE`/`-sTABLE_BASE`/`-sSTACK_SIZE` flags mirror swift-driver's
+  # EmscriptenToolchain+LinkerSupport.swift and are required for Swift ABI
+  # correctness and adequate stack space. `-Wno-unused-command-line-argument`
+  # silences emcc warnings on flags it accepts but ignores (e.g. `-dead_strip`
+  # from the macOS-shaped RUN lines).
+  emcc_link = (config.target_emcc
+               + " -Wno-unused-command-line-argument"
+               + " -sGLOBAL_BASE=4096 -sTABLE_BASE=4096 -sSTACK_SIZE=131072")
+  config.substitutions.append(("%target-embedded-link", emcc_link))
+  config.substitutions.append(("%embedded-unicode-tables", f"-Xlinker {config.swift_obj_root}/lib/swift/embedded/{target_triple}/libswiftUnicodeDataTables.a"))
+  # emcc manages its own resource directory and does not accept clang's
+  # space-separated `-resource-dir <path>`: it swallows the flag but lets the
+  # path through as a positional input, which wasm-ld rejects (`cannot open
+  # <path>: Is a directory`). Suppress %target-clang-resource-dir-opt here; no
+  # embedded compile-only RUN line uses it, and emcc's bundled resource-dir is
+  # correct at link sites anyway.
+  config.substitutions = [(k, "") if k == "%target-clang-resource-dir-opt" else (k, v)
+                          for (k, v) in config.substitutions]
 elif "OS=macosx" in config.available_features:
   config.substitutions.append(("%target-embedded-link", config.target_clang))
   config.substitutions.append(("%embedded-unicode-tables", f"-Xlinker {config.swift_obj_root}/lib/swift/embedded/{target_cpu}-apple-macos/libswiftUnicodeDataTables.a"))

--- a/test/embedded/lto-multiple-object-files.swift
+++ b/test/embedded/lto-multiple-object-files.swift
@@ -9,7 +9,7 @@
 // RUN: %{python} %utils/split_file.py -o %t %s
 
 // RUN: %target-swift-frontend -Osize -lto=llvm-full %t/MyFile1.swift %t/MyFile2.swift -enable-experimental-feature Embedded -emit-bc -num-threads 2 -o %t/MyFile1.o -o %t/MyFile2.o
-// RUN: %target-clang %target-clang-resource-dir-opt -Oz %t/MyFile1.o %t/MyFile2.o %target-embedded-posix-shim -o %t/a.out
+// RUN: %target-embedded-link %target-clang-resource-dir-opt -Oz %t/MyFile1.o %t/MyFile2.o %target-embedded-posix-shim -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: swift_in_compiler

--- a/test/embedded/lto.swift
+++ b/test/embedded/lto.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -enable-experimental-feature Extern -lto=llvm-full %s -enable-experimental-feature Embedded -emit-bc -o %t/a.o
-// RUN: %target-clang %target-clang-resource-dir-opt %t/a.o %target-embedded-posix-shim -o %t/a.out
+// RUN: %target-embedded-link %target-clang-resource-dir-opt %t/a.o %target-embedded-posix-shim -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: swift_in_compiler

--- a/test/embedded/metatypes-run.swift
+++ b/test/embedded/metatypes-run.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -enable-experimental-feature Embedded -parse-as-library %s -c -o %t/a.o
-// RUN: %target-clang %t/a.o %target-embedded-posix-shim -o %t/a.out -L%swift_obj_root/lib/swift/embedded/%module-target-triple %target-clang-resource-dir-opt -lswift_Concurrency %target-swift-default-executor-opt -dead_strip
+// RUN: %target-embedded-link %t/a.o %target-embedded-posix-shim -o %t/a.out -L%swift_obj_root/lib/swift/embedded/%module-target-triple %target-clang-resource-dir-opt -lswift_Concurrency %target-swift-default-executor-opt -dead_strip
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: executable_test

--- a/test/embedded/modules-class-bound-existential.swift
+++ b/test/embedded/modules-class-bound-existential.swift
@@ -4,7 +4,7 @@
 // RUN: %target-swift-frontend -emit-module -o %t/MyModule.swiftmodule %t/MyModule.swift -enable-experimental-feature Embedded -parse-as-library
 // RUN: %target-swift-frontend -c -I %t %t/Main.swift -enable-experimental-feature Embedded -parse-as-library -o %t/a.o
 // RUN: %target-clang -x c -c %S/Inputs/print.c -o %t/print.o
-// RUN: %target-clang %target-clang-resource-dir-opt %t/a.o %t/print.o %target-embedded-posix-shim -o %t/a.out
+// RUN: %target-embedded-link %target-clang-resource-dir-opt %t/a.o %t/print.o %target-embedded-posix-shim -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: swift_in_compiler

--- a/test/embedded/modules-classes.swift
+++ b/test/embedded/modules-classes.swift
@@ -4,7 +4,7 @@
 // RUN: %target-swift-frontend -emit-module -o %t/MyModule.swiftmodule %t/MyModule.swift -enable-experimental-feature Embedded -parse-as-library
 // RUN: %target-swift-frontend -c -I %t %t/Main.swift -enable-experimental-feature Embedded -o %t/a.o
 // RUN: %target-clang -x c -c %S/Inputs/print.c -o %t/print.o
-// RUN: %target-clang %target-clang-resource-dir-opt %t/a.o %t/print.o %target-embedded-posix-shim -o %t/a.out
+// RUN: %target-embedded-link %target-clang-resource-dir-opt %t/a.o %t/print.o %target-embedded-posix-shim -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: swift_in_compiler

--- a/test/embedded/modules-empty-object.swift
+++ b/test/embedded/modules-empty-object.swift
@@ -5,7 +5,7 @@
 // RUN: %target-swift-frontend -enable-experimental-feature Embedded -c -I%t -parse-as-library %t/MyModuleB.swift -o %t/MyModuleB.o -emit-module -emit-module-path %t/MyModuleB.swiftmodule -emit-empty-object-file
 // RUN: %target-swift-frontend -enable-experimental-feature Embedded -c -I%t -parse-as-library %t/MyModuleC.swift -o %t/MyModuleC.o -emit-module -emit-module-path %t/MyModuleC.swiftmodule -emit-empty-object-file
 // RUN: %target-swift-frontend -enable-experimental-feature Embedded -c -I%t %t/Main.swift -o %t/Main.o
-// RUN: %target-clang %target-clang-resource-dir-opt %t/Main.o %t/MyModuleA.o %t/MyModuleB.o %t/MyModuleC.o %target-embedded-posix-shim -o %t/a.out
+// RUN: %target-embedded-link %target-clang-resource-dir-opt %t/Main.o %t/MyModuleA.o %t/MyModuleB.o %t/MyModuleC.o %target-embedded-posix-shim -o %t/a.out
 // RUN: %target-run %t/a.out
 
 // REQUIRES: swift_in_compiler

--- a/test/embedded/modules-globals-exec.swift
+++ b/test/embedded/modules-globals-exec.swift
@@ -4,7 +4,7 @@
 // RUN: %target-swift-frontend -enable-experimental-feature Extern -emit-module -o %t/MyModule.swiftmodule %t/MyModule.swift -enable-experimental-feature Embedded -parse-as-library
 // RUN: %target-swift-frontend -enable-experimental-feature Extern -c -I %t %t/Main.swift -enable-experimental-feature Embedded -o %t/a.o
 // RUN: %target-clang -x c -c %S/Inputs/print.c -o %t/print.o
-// RUN: %target-clang %target-clang-resource-dir-opt %t/a.o %t/print.o %target-embedded-posix-shim -o %t/a.out
+// RUN: %target-embedded-link %target-clang-resource-dir-opt %t/a.o %t/print.o %target-embedded-posix-shim -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: swift_in_compiler

--- a/test/embedded/modules-print-exec.swift
+++ b/test/embedded/modules-print-exec.swift
@@ -4,7 +4,7 @@
 // RUN: %target-swift-frontend -enable-experimental-feature Extern -emit-module -o %t/MyModule.swiftmodule %t/MyModule.swift -enable-experimental-feature Embedded -parse-as-library
 // RUN: %target-swift-frontend -enable-experimental-feature Extern -c -I %t %t/Main.swift -enable-experimental-feature Embedded -o %t/a.o
 // RUN: %target-clang -x c -c %S/Inputs/print.c -o %t/print.o
-// RUN: %target-clang %target-clang-resource-dir-opt %t/a.o %t/print.o %target-embedded-posix-shim -o %t/a.out
+// RUN: %target-embedded-link %target-clang-resource-dir-opt %t/a.o %t/print.o %target-embedded-posix-shim -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: swift_in_compiler

--- a/test/embedded/modules-subclasses.swift
+++ b/test/embedded/modules-subclasses.swift
@@ -4,19 +4,19 @@
 // RUN: %target-swift-frontend -emit-module -o %t/MyModule.swiftmodule %t/MyModule.swift -enable-experimental-feature Embedded -parse-as-library
 // RUN: %target-swift-frontend -c -I %t %t/Main.swift -enable-experimental-feature Embedded -o %t/a.o
 // RUN: %target-clang -x c -c %S/Inputs/print.c -o %t/print.o
-// RUN: %target-clang %target-clang-resource-dir-opt %t/a.o %t/print.o %target-embedded-posix-shim -o %t/a.out
+// RUN: %target-embedded-link %target-clang-resource-dir-opt %t/a.o %t/print.o %target-embedded-posix-shim -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // RUN: %target-swift-frontend -O -emit-module -o %t/MyModule.swiftmodule %t/MyModule.swift -enable-experimental-feature Embedded -parse-as-library
 // RUN: %target-swift-frontend -O -c -I %t %t/Main.swift -enable-experimental-feature Embedded -o %t/a.o
 // RUN: %target-clang -x c -c %S/Inputs/print.c -o %t/print.o
-// RUN: %target-clang %target-clang-resource-dir-opt %t/a.o %t/print.o %target-embedded-posix-shim -o %t/a.out
+// RUN: %target-embedded-link %target-clang-resource-dir-opt %t/a.o %t/print.o %target-embedded-posix-shim -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // RUN: %target-swift-frontend -Osize -emit-module -o %t/MyModule.swiftmodule %t/MyModule.swift -enable-experimental-feature Embedded -parse-as-library
 // RUN: %target-swift-frontend -Osize -c -I %t %t/Main.swift -enable-experimental-feature Embedded -o %t/a.o
 // RUN: %target-clang -x c -c %S/Inputs/print.c -o %t/print.o
-// RUN: %target-clang %target-clang-resource-dir-opt %t/a.o %t/print.o %target-embedded-posix-shim -o %t/a.out
+// RUN: %target-embedded-link %target-clang-resource-dir-opt %t/a.o %t/print.o %target-embedded-posix-shim -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: swift_in_compiler

--- a/test/embedded/modules-used.swift
+++ b/test/embedded/modules-used.swift
@@ -4,7 +4,7 @@
 // RUN: %target-swift-frontend -enable-experimental-feature Embedded -parse-as-library -emit-module -o %t/MyModule.swiftmodule %t/MyModule.swift
 // RUN: %target-swift-frontend -enable-experimental-feature Embedded -parse-as-library -I %t %t/Main.swift -emit-sil | %FileCheck %s --check-prefix CHECK-SIL
 // RUN: %target-swift-frontend -enable-experimental-feature Embedded -parse-as-library -I %t %t/Main.swift -c -o %t/a.o
-// RUN: %target-clang %t/a.o %target-embedded-posix-shim -o %t/a.out
+// RUN: %target-embedded-link %t/a.o %target-embedded-posix-shim -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: swift_in_compiler

--- a/test/embedded/modules-used2.swift
+++ b/test/embedded/modules-used2.swift
@@ -4,7 +4,7 @@
 // RUN: %target-swift-frontend -enable-experimental-feature Embedded -parse-as-library -emit-module -o %t/MyModule.swiftmodule %t/MyModule.swift
 // RUN: %target-swift-frontend -enable-experimental-feature Embedded -parse-as-library -I %t %t/Main.swift -emit-sil | %FileCheck %s --check-prefix CHECK-SIL
 // RUN: %target-swift-frontend -enable-experimental-feature Embedded -parse-as-library -I %t %t/Main.swift -c -o %t/a.o
-// RUN: %target-clang %target-clang-resource-dir-opt %t/a.o %target-embedded-posix-shim -o %t/a.out
+// RUN: %target-embedded-link %target-clang-resource-dir-opt %t/a.o %target-embedded-posix-shim -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: swift_in_compiler

--- a/test/embedded/noncopyable-deinits.swift
+++ b/test/embedded/noncopyable-deinits.swift
@@ -3,7 +3,7 @@
 
 // RUN: %target-swift-frontend -enable-experimental-feature Embedded -c -I%t -parse-as-library %t/MyModule.swift -package-name P -o %t/MyModule.o -emit-module -emit-module-path %t/MyModule.swiftmodule -emit-empty-object-file
 // RUN: %target-swift-frontend -enable-experimental-feature Embedded -c -I%t %t/Main.swift -package-name P -o %t/Main.o
-// RUN: %target-clang %target-clang-resource-dir-opt %t/Main.o %t/MyModule.o %target-embedded-posix-shim -o %t/a.out
+// RUN: %target-embedded-link %target-clang-resource-dir-opt %t/Main.o %t/MyModule.o %target-embedded-posix-shim -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: executable_test

--- a/test/embedded/once-dependent.swift
+++ b/test/embedded/once-dependent.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-frontend %s -parse-as-library -enable-experimental-feature Embedded -c -o %t/main.o
-// RUN: %target-clang %target-clang-resource-dir-opt %t/main.o %target-embedded-posix-shim -o %t/a.out -dead_strip
+// RUN: %target-embedded-link %target-clang-resource-dir-opt %t/main.o %target-embedded-posix-shim -o %t/a.out -dead_strip
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: swift_in_compiler

--- a/test/embedded/once-multithreaded.swift
+++ b/test/embedded/once-multithreaded.swift
@@ -2,7 +2,7 @@
 // RUN: %{python} %utils/split_file.py -o %t %s
 
 // RUN: %target-swift-frontend %t/Main.swift -parse-as-library -import-bridging-header %t/BridgingHeader.h -enable-experimental-feature Embedded -c -o %t/main.o
-// RUN: %target-clang %target-clang-resource-dir-opt %t/main.o %target-embedded-posix-shim -o %t/a.out -dead_strip -pthreads
+// RUN: %target-embedded-link %target-clang-resource-dir-opt %t/main.o %target-embedded-posix-shim -o %t/a.out -dead_strip -pthreads
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: swift_in_compiler

--- a/test/embedded/refcounting-leak.swift
+++ b/test/embedded/refcounting-leak.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -enable-experimental-feature Embedded -parse-as-library %s -c -o %t/a.o
 // RUN: %target-clang -x c -std=c11 -c %S/Inputs/debug-malloc.c -o %t/debug-malloc.o
-// RUN: %target-clang %target-clang-resource-dir-opt %t/a.o %t/debug-malloc.o %target-embedded-posix-shim -o %t/a.out
+// RUN: %target-embedded-link %target-clang-resource-dir-opt %t/a.o %t/debug-malloc.o %target-embedded-posix-shim -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: executable_test

--- a/test/embedded/simd.swift
+++ b/test/embedded/simd.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 
 // RUN: %target-swift-frontend %s -parse-as-library -enable-experimental-feature Embedded -c -o %t/main.o
-// RUN: %target-clang %target-clang-resource-dir-opt %t/main.o %target-embedded-posix-shim -o %t/a.out -dead_strip
+// RUN: %target-embedded-link %target-clang-resource-dir-opt %t/main.o %target-embedded-posix-shim -o %t/a.out -dead_strip
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: swift_in_compiler

--- a/test/embedded/string-deconstruction.swift
+++ b/test/embedded/string-deconstruction.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %s -parse-as-library -enable-experimental-feature Embedded -c -o %t/main.o
-// RUN: %target-clang %target-clang-resource-dir-opt %t/main.o %target-embedded-posix-shim -o %t/a.out -dead_strip -Xlinker %swift_obj_root/lib/swift/embedded/%module-target-triple/libswiftUnicodeDataTables.a
+// RUN: %target-embedded-link %target-clang-resource-dir-opt %t/main.o %target-embedded-posix-shim -o %t/a.out -dead_strip -Xlinker %swift_obj_root/lib/swift/embedded/%module-target-triple/libswiftUnicodeDataTables.a
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: swift_in_compiler

--- a/test/embedded/unicode-dead-strip1.swift
+++ b/test/embedded/unicode-dead-strip1.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-frontend -Osize -parse-as-library -enable-experimental-feature Embedded %s -c -o %t/a.o
-// RUN: %target-clang %target-clang-resource-dir-opt %t/a.o %target-embedded-posix-shim -o %t/a.out -dead_strip %swift_obj_root/lib/swift/embedded/%module-target-triple/libswiftUnicodeDataTables.a
+// RUN: %target-embedded-link %target-clang-resource-dir-opt %t/a.o %target-embedded-posix-shim -o %t/a.out -dead_strip %swift_obj_root/lib/swift/embedded/%module-target-triple/libswiftUnicodeDataTables.a
 // RUN: %llvm-nm --defined-only --format=just-symbols --demangle %t/a.out | grep swift_stdlib_ | sort | %FileCheck %s --check-prefix=INCLUDES
 // RUN: %llvm-nm --defined-only --format=just-symbols --demangle %t/a.out | grep swift_stdlib_ | sort | %FileCheck %s --check-prefix=EXCLUDES
 

--- a/test/embedded/unicode-dead-strip2.swift
+++ b/test/embedded/unicode-dead-strip2.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-frontend -Osize -parse-as-library -enable-experimental-feature Embedded %s -c -o %t/a.o
-// RUN: %target-clang %t/a.o %target-embedded-posix-shim -o %t/a.out -dead_strip %swift_obj_root/lib/swift/embedded/%target-cpu-apple-macos/libswiftUnicodeDataTables.a
+// RUN: %target-embedded-link %t/a.o %target-embedded-posix-shim -o %t/a.out -dead_strip %swift_obj_root/lib/swift/embedded/%target-cpu-apple-macos/libswiftUnicodeDataTables.a
 // RUN: %llvm-nm --defined-only --format=just-symbols --demangle %t/a.out | grep swift_stdlib_ | sort | %FileCheck %s --check-prefix=INCLUDES
 // RUN: %llvm-nm --defined-only --format=just-symbols --demangle %t/a.out | grep swift_stdlib_ | sort | %FileCheck %s --check-prefix=EXCLUDES
 

--- a/test/embedded/unicode-dead-strip3.swift
+++ b/test/embedded/unicode-dead-strip3.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-frontend -Osize -parse-as-library -enable-experimental-feature Embedded %s -c -o %t/a.o
-// RUN: %target-clang %target-clang-resource-dir-opt %t/a.o %target-embedded-posix-shim -o %t/a.out -dead_strip %swift_obj_root/lib/swift/embedded/%module-target-triple/libswiftUnicodeDataTables.a
+// RUN: %target-embedded-link %target-clang-resource-dir-opt %t/a.o %target-embedded-posix-shim -o %t/a.out -dead_strip %swift_obj_root/lib/swift/embedded/%module-target-triple/libswiftUnicodeDataTables.a
 // RUN: %llvm-nm --defined-only --format=just-symbols --demangle %t/a.out | grep swift_stdlib_ | sort | %FileCheck %s --check-prefix=INCLUDES
 // RUN: %llvm-nm --defined-only --format=just-symbols --demangle %t/a.out | grep swift_stdlib_ | sort | %FileCheck %s --check-prefix=EXCLUDES
 

--- a/test/embedded/unicode-dead-strip4.swift
+++ b/test/embedded/unicode-dead-strip4.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-frontend -Osize -parse-as-library -enable-experimental-feature Embedded -enable-experimental-feature Extern %s -c -o %t/a.o
-// RUN: %target-clang %target-clang-resource-dir-opt %t/a.o %target-embedded-posix-shim -o %t/a.out -dead_strip %swift_obj_root/lib/swift/embedded/%module-target-triple/libswiftUnicodeDataTables.a
+// RUN: %target-embedded-link %target-clang-resource-dir-opt %t/a.o %target-embedded-posix-shim -o %t/a.out -dead_strip %swift_obj_root/lib/swift/embedded/%module-target-triple/libswiftUnicodeDataTables.a
 // RUN: %llvm-nm --defined-only --format=just-symbols --demangle %t/a.out | sort | %FileCheck %s --check-prefix=EXCLUDES
 
 // REQUIRES: swift_in_compiler

--- a/test/embedded/wasm/classes.swift
+++ b/test/embedded/wasm/classes.swift
@@ -11,6 +11,11 @@
 // REQUIRES: embedded_stdlib_cross_compiling
 // REQUIRES: swift_feature_Embedded
 
+// This test pins the freestanding wasm32-unknown-none-wasm target (-nostdlib,
+// its own rt.c and _start). The Emscripten triple has no freestanding
+// configuration; it is always hosted and launched through emcc's JS glue.
+// UNSUPPORTED: OS=emscripten
+
 //--- rt.c
 
 #include <stddef.h>

--- a/test/embedded/wasm/concurrency-implicit-import.swift
+++ b/test/embedded/wasm/concurrency-implicit-import.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -enable-experimental-feature Embedded -parse-as-library %s -c -o %t/a.o
-// RUN: %target-clang %target-clang-resource-dir-opt %t/a.o %target-embedded-posix-shim -o %t/a.out -L%swift_obj_root/lib/swift/embedded/%module-target-triple -lc++ -lswift_Concurrency %target-swift-default-executor-opt -dead_strip
+// RUN: %target-embedded-link %target-clang-resource-dir-opt %t/a.o %target-embedded-posix-shim -o %t/a.out -L%swift_obj_root/lib/swift/embedded/%module-target-triple -lc++ -lswift_Concurrency %target-swift-default-executor-opt -dead_strip
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: executable_test

--- a/test/embedded/wasm/libc_functions.swift
+++ b/test/embedded/wasm/libc_functions.swift
@@ -1,10 +1,17 @@
 // RUN: %target-run-simple-swift(-enable-experimental-feature Embedded -parse-as-library -wmo) | %FileCheck %s
 
 // REQUIRES: executable_test
-// REQUIRES: OS=wasip1
+// REQUIRES: OS=wasip1 || OS=emscripten
 // REQUIRES: swift_feature_Embedded
 
+#if canImport(WASILibc)
 import WASILibc
+#elseif canImport(EmscriptenLibc)
+import EmscriptenLibc
+#else
+#error("Unsupported libc")
+#endif
+
 @main struct Main {
   static func main() {
     puts("Hello")

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -257,6 +257,7 @@ else:
 
 # Allow using using same condition in WASI test suites.
 kIsWASI = run_os.startswith('wasi')
+kIsEmscripten = (run_os == 'emscripten')
 
 if kIsWASI:
   run_os = f"{run_os}{run_vers}"
@@ -274,7 +275,7 @@ if platform.system() == 'OpenBSD':
         lit_config.fatal('No LLVM libs dir set.')
     config.environment['LD_LIBRARY_PATH'] = llvm_libs_dir
 
-elif platform.system() == 'Darwin' and not kIsWASI:
+elif platform.system() == 'Darwin' and not kIsWASI and not kIsEmscripten:
     if not llvm_libs_dir:
         lit_config.fatal('No LLVM libs dir set.')
     lto_flags = "-Xlinker -lto_library -Xlinker %s/libLTO.dylib" % llvm_libs_dir
@@ -376,6 +377,7 @@ config.swift_symbolgraph_extract = inferSwiftBinary('swift-symbolgraph-extract')
 config.swift_synthesize_interface = inferSwiftBinary('swift-synthesize-interface')
 config.clang = inferSwiftBinary('clang')
 config.clangxx = inferSwiftBinary('clang++')
+config.target_emcc = None  # Set to absolute path inside the kIsEmscripten branch below.
 config.llvm_link = inferSwiftBinary('llvm-link')
 config.swift_llvm_opt = inferSwiftBinary('swift-llvm-opt')
 config.llvm_profdata = inferSwiftBinary('llvm-profdata')
@@ -2141,16 +2143,39 @@ elif run_os == 'linux-androideabi' or run_os == 'linux-android':
         '-L%s' % make_path(test_resource_dir, config.target_sdk_name)])
     # The Swift interpreter is not available when targeting Android.
     config.available_features.discard('swift_interpreter')
-elif kIsWASI:
-    lit_config.note("Testing WebAssembly/WASI " + config.variant_triple)
+elif kIsWASI or kIsEmscripten:
+    if kIsEmscripten:
+        platform_label = "Emscripten"
+        config.target_sdk_name = "emscripten"
+        sysroot_dirname = "emscripten-sysroot"
+        config.target_run = os.path.join(config.swift_utils, 'wasm', 'emscripten-run.py')
+        target_linker = inferSwiftBinary("emcc")
+        # inferSwiftBinary returns the literal name "emcc" (not None) when the PATH
+        # lookup fails, so check for that sentinel and fail here rather than letting
+        # tests fail later with `command not found: emcc`.
+        if target_linker == "emcc":
+            lit_config.fatal(
+                "emcc not found on PATH while configuring kIsEmscripten lit suite. "
+                "Install emsdk and add it to PATH, or set the EMCC env var to the "
+                "absolute path of emcc.")
+        config.target_emcc = target_linker
+    else:
+        platform_label = "WASI"
+        config.target_sdk_name = "wasi"
+        sysroot_dirname = "wasi-sysroot"
+        config.target_run = os.path.join(config.swift_utils, 'wasm', 'wasi-run.py')
+        target_linker = config.wasm_ld
+
+    lit_config.note(f"Testing WebAssembly/{platform_label} " + config.variant_triple)
 
     config.target_object_format = "wasm"
     config.target_shared_library_prefix = 'lib'
     config.target_shared_library_suffix = ".a"
-    config.target_sdk_name = "wasi"
     config.target_runtime = "native"
     config.target_not_crash = "not"
-    config.target_clang_resource_dir_opt = f"-resource-dir {test_resource_dir}/../../../wasi-sysroot/wasm32-wasip1/resource-dir"
+    config.target_clang_resource_dir_opt = (
+        f"-resource-dir {test_resource_dir}/../../../"
+        f"{sysroot_dirname}/wasm32-{run_os}/resource-dir")
     config.target_swift_default_executor_opt = ''
 
     config.target_swift_autolink_extract = inferSwiftBinary("swift-autolink-extract")
@@ -2171,7 +2196,7 @@ elif kIsWASI:
     config.target_swift_frontend = ' '.join([
         config.swift_frontend,
         '-target', config.variant_triple,
-	'-sdk', config.variant_sdk,
+        '-sdk', config.variant_sdk,
         config.resource_dir_opt, mcp_opt,
         config.swift_test_options, config.swift_frontend_test_options])
     config.target_swift_frontend_plain = ' '.join([
@@ -2181,7 +2206,6 @@ elif kIsWASI:
     ])
     subst_target_swift_frontend_mock_sdk = config.target_swift_frontend
     subst_target_swift_frontend_mock_sdk_after = ""
-    config.target_run = os.path.join(config.swift_utils, 'wasm', 'wasi-run.py')
     config.target_env_prefix = 'WASM_RUN_CHILD_'
 
     if 'interpret' in lit_config.params:
@@ -2223,8 +2247,8 @@ elif kIsWASI:
         (config.clang, config.variant_triple, clang_mcp_opt, config.variant_sdk))
     config.target_ld = (
         "%s -L%r" %
-        (config.wasm_ld, make_path(test_resource_dir, config.target_sdk_name)))
-    # The Swift interpreter is not available when targeting WebAssembly/WASI.
+        (target_linker, make_path(test_resource_dir, config.target_sdk_name)))
+    # The Swift interpreter is not available when targeting WebAssembly.
     config.available_features.discard('swift_interpreter')
 
 elif config.external_embedded_platform:
@@ -2793,7 +2817,7 @@ if run_vendor != 'apple':
 
 if 'remote_run_host' in lit_config.params:
     configure_remote_run()
-elif not kIsWindows and not kIsWASI:
+elif not kIsWindows and not kIsWASI and not kIsEmscripten:
     if 'use_os_stdlib' in lit_config.params:
         config.available_features.add('use_os_stdlib')
 

--- a/test/stdlib/CharacterTraps.swift
+++ b/test/stdlib/CharacterTraps.swift
@@ -7,7 +7,7 @@
 // RUN: %target-run %t/a.out_Debug
 // RUN: %target-run %t/a.out_Release
 // REQUIRES: executable_test
-// UNSUPPORTED: OS=wasip1
+// UNSUPPORTED: OS=wasip1 || OS=emscripten
 
 import StdlibUnittest
 

--- a/test/stdlib/DictionaryTraps.swift
+++ b/test/stdlib/DictionaryTraps.swift
@@ -7,7 +7,7 @@
 // RUN: %target-run %t/a.out_Debug
 // RUN: %target-run %t/a.out_Release
 // REQUIRES: executable_test
-// UNSUPPORTED: OS=wasip1
+// UNSUPPORTED: OS=wasip1 || OS=emscripten
 
 import StdlibUnittest
 

--- a/test/stdlib/FloatConstants.swift
+++ b/test/stdlib/FloatConstants.swift
@@ -6,6 +6,8 @@
   import Glibc
 #elseif os(WASI)
   import WASILibc
+#elseif os(Emscripten)
+  import EmscriptenLibc
 #elseif canImport(Android)
   import Android
 #elseif os(Windows)

--- a/test/stdlib/InputStream.swift.gyb
+++ b/test/stdlib/InputStream.swift.gyb
@@ -13,7 +13,7 @@
 // RUN: %target-run-simple-swiftgyb
 // REQUIRES: executable_test
 // UNSUPPORTED: freestanding
-// UNSUPPORTED: OS=wasip1
+// UNSUPPORTED: OS=wasip1 || OS=emscripten
 
 import StdlibUnittest
 

--- a/test/stdlib/IntervalTraps.swift
+++ b/test/stdlib/IntervalTraps.swift
@@ -18,7 +18,7 @@
 // RUN: %target-run %t/a.out_Debug
 // RUN: %target-run %t/a.out_Release
 // REQUIRES: executable_test
-// UNSUPPORTED: OS=wasip1
+// UNSUPPORTED: OS=wasip1 || OS=emscripten
 
 import StdlibUnittest
 

--- a/test/stdlib/ManagedBuffer.swift
+++ b/test/stdlib/ManagedBuffer.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
+// XFAIL: OS=emscripten
 // XFAIL: OS=openbsd
 
 import StdlibUnittest

--- a/test/stdlib/MathConstants.swift
+++ b/test/stdlib/MathConstants.swift
@@ -6,6 +6,8 @@
   import Glibc
 #elseif os(WASI)
   import WASILibc
+#elseif os(Emscripten)
+  import EmscriptenLibc
 #elseif canImport(Android)
   import Android
 #elseif os(Windows)

--- a/test/stdlib/OptionalTraps.swift
+++ b/test/stdlib/OptionalTraps.swift
@@ -10,7 +10,7 @@
 // RUN: %target-run %t/Assert_Release
 // RUN: %target-run %t/Assert_Unchecked
 // REQUIRES: executable_test
-// UNSUPPORTED: OS=wasip1
+// UNSUPPORTED: OS=wasip1 || OS=emscripten
 
 import StdlibUnittest
 

--- a/test/stdlib/POSIX.swift
+++ b/test/stdlib/POSIX.swift
@@ -1,7 +1,7 @@
 // RUN: %target-run-simple-swift %t
 // REQUIRES: executable_test
 // UNSUPPORTED: OS=windows-msvc
-// UNSUPPORTED: OS=wasip1
+// UNSUPPORTED: OS=wasip1 || OS=emscripten
 // UNSUPPORTED: OS=freebsd
 
 import StdlibUnittest

--- a/test/stdlib/RangeTraps.swift
+++ b/test/stdlib/RangeTraps.swift
@@ -18,7 +18,7 @@
 // RUN: %target-run %t/a.out_Debug
 // RUN: %target-run %t/a.out_Release
 // REQUIRES: executable_test
-// UNSUPPORTED: OS=wasip1
+// UNSUPPORTED: OS=wasip1 || OS=emscripten
 
 
 import StdlibUnittest

--- a/test/stdlib/Result+asyncInit.swift
+++ b/test/stdlib/Result+asyncInit.swift
@@ -4,7 +4,7 @@
 
 // FIXME: wasi-wasm32 traps in Result<T, any Error>'s value-witness copy
 // after returning from the new Result.init(catching:) async.
-// XFAIL: OS=wasip1
+// XFAIL: OS=wasip1 || OS=emscripten
 // https://github.com/swiftlang/swift/issues/89155
 
 import StdlibUnittest

--- a/test/stdlib/Runtime.swift.gyb
+++ b/test/stdlib/Runtime.swift.gyb
@@ -18,6 +18,8 @@ import SwiftShims
   import Glibc
 #elseif os(WASI)
   import WASILibc
+#elseif os(Emscripten)
+  import EmscriptenLibc
 #elseif canImport(Android)
   import Android
 #elseif os(Windows)

--- a/test/stdlib/SetTraps.swift
+++ b/test/stdlib/SetTraps.swift
@@ -7,7 +7,7 @@
 // RUN: %target-run %t/a.out_Debug
 // RUN: %target-run %t/a.out_Release
 // REQUIRES: executable_test
-// UNSUPPORTED: OS=wasip1
+// UNSUPPORTED: OS=wasip1 || OS=emscripten
 
 import StdlibUnittest
 

--- a/test/stdlib/StringIndex_bincompat.swift
+++ b/test/stdlib/StringIndex_bincompat.swift
@@ -5,6 +5,7 @@
 
 // REQUIRES: executable_test
 // UNSUPPORTED: freestanding
+// UNSUPPORTED: OS=emscripten
 // UNSUPPORTED: use_os_stdlib || back_deployment_runtime
 // UNSUPPORTED: swift_stdlib_asserts
 

--- a/test/stdlib/StringTraps.swift
+++ b/test/stdlib/StringTraps.swift
@@ -11,7 +11,7 @@
 // 5.7 so that we can test new behavior even if the SDK we're using predates it.
 
 // REQUIRES: executable_test
-// UNSUPPORTED: OS=wasip1
+// UNSUPPORTED: OS=wasip1 || OS=emscripten
 
 import StdlibUnittest
 #if _runtime(_ObjC)

--- a/test/stdlib/VarArgs.swift
+++ b/test/stdlib/VarArgs.swift
@@ -1,5 +1,6 @@
 // RUN: %target-run-stdlib-swift -parse-stdlib %s | %FileCheck %s
 // REQUIRES: executable_test
+// XFAIL: OS=emscripten
 
 import Swift
 
@@ -26,6 +27,9 @@ runAllTests()
   typealias CGFloat = Double
 #elseif os(WASI)
   import WASILibc
+  typealias CGFloat = Double
+#elseif os(Emscripten)
+  import EmscriptenLibc
   typealias CGFloat = Double
 #elseif canImport(Android)
   import Android

--- a/test/stdlib/mmap.swift
+++ b/test/stdlib/mmap.swift
@@ -1,7 +1,7 @@
 // RUN: %target-run-simple-swift %t
 // REQUIRES: executable_test
 // UNSUPPORTED: OS=windows-msvc
-// UNSUPPORTED: OS=wasip1
+// UNSUPPORTED: OS=wasip1 || OS=emscripten
 
 import StdlibUnittest
 #if canImport(Darwin)

--- a/test/stdlib/tgmath_optimized.swift
+++ b/test/stdlib/tgmath_optimized.swift
@@ -10,6 +10,8 @@
   import Glibc
 #elseif os(WASI)
   import WASILibc
+#elseif os(Emscripten)
+  import EmscriptenLibc
 #elseif canImport(Android)
   import Android
 #elseif os(Windows)


### PR DESCRIPTION
Enable the Embedded Swift and stdlib lit tests to run on `wasm32-unknown-emscripten`. Embedded Swift linker RUN lines move off the hard-coded `%target-clang` onto a `%target-embedded-link` substitution that links through `emcc` on Emscripten and keeps `%target-clang` for other platforms elsewhere. The `REQUIRES`/`UNSUPPORTED` gates gain an `OS=emscripten` arm, so emscripten runs the `wasip1` tests it shares and skips the ones it cannot satisfy yet. Also renamed `wasilibc_functions.swift` to `libc_functions.swift` and updated `docs/WebAssembly.md`.