### PR TITLE
close up trailing triple-backtick with docc comment (///) 

### DIFF
--- a/stdlib/public/Distributed/DistributedActor.swift
+++ b/stdlib/public/Distributed/DistributedActor.swift
@@ -186,7 +186,7 @@ import _Concurrency
 ///
 /// ```swift
 /// decoder.userInfo[.actorSystemKey] as? ActorSystem
-// ```
+/// ```
 ///
 /// The such obtained actor system is then used to ``resolve(id:using:)`` the decoded ``ID``.
 ///


### PR DESCRIPTION
regular comment should be a docc comment (///) otherwise the code block isn't terminated properly.

Causes rendering issue in the docs themselves (thank you for the head's up @invalidname)