### PR TITLE
[Runtime] Avoid optimizing away user deinit on ~C struct when fields …

### DIFF
--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -3218,10 +3218,14 @@ void swift::swift_initStructMetadata(StructMetadata *structType,
       });
 
   // If the struct is always noncopyable, we must honor that.
-  if (layout.flags.isCopyable() &&
-      structType->getDescription()->isUnconditionallySuppressing(
-          InvertibleProtocolKind::Copyable))
+  if (structType->getDescription()->isUnconditionallySuppressing(
+          InvertibleProtocolKind::Copyable)) {
     layout.flags = layout.flags.withCopyable(false);
+    // Unconditionally ~Copyable types may have a user-defined deinit.
+    // Mark as non-POD to avoid optimizations which may skip calling that
+    // deinit.
+    layout.flags = layout.flags.withPOD(false);
+  }
 
   // We have extra inhabitants if any element does. Use the field with the most.
   unsigned extraInhabitantCount = 0;

--- a/test/Interpreter/Inputs/noncopyable_pod_generic_deinit_lib.swift
+++ b/test/Interpreter/Inputs/noncopyable_pod_generic_deinit_lib.swift
@@ -1,0 +1,13 @@
+public struct SomePOD {
+  public var x: Int = 0
+  public init() {}
+}
+
+// ~Copyable type which is POD according to its fields as long as T is also POD
+public struct NCWrapper<T: ~Copyable>: ~Copyable {
+  var inner: T
+  public init(_ t: consuming T) { inner = t }
+  deinit {
+    print("Container.deinit fired")
+  }
+}

--- a/test/Interpreter/noncopyable_pod_generic_deinit_separate_file.swift
+++ b/test/Interpreter/noncopyable_pod_generic_deinit_separate_file.swift
@@ -1,0 +1,32 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift-dylib(%t/%target-library-name(deinit_lib)) \
+// RUN:     -emit-module -emit-module-path %t/deinit_lib.swiftmodule \
+// RUN:     -module-name deinit_lib \
+// RUN:     %S/Inputs/noncopyable_pod_generic_deinit_lib.swift
+// RUN: %target-codesign %t/%target-library-name(deinit_lib)
+// RUN: %target-build-swift -parse-as-library -I %t -L %t -ldeinit_lib %s -o %t/a.out %target-rpath(%t)
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out %t/%target-library-name(deinit_lib) | %FileCheck %s
+
+// REQUIRES: executable_test
+
+// Verifies that runtime metadata initialization does not optimize away
+// the user-defined deinit for a ~Copyable struct which is determined to be POD
+// based on its fields alone (rdar://166549159).
+
+import deinit_lib
+
+@main
+struct App {
+  static func main() {
+    print("-- start")
+    do {
+      let _ = NCWrapper<SomePOD>(SomePOD())
+    }
+    print("-- done")
+  }
+}
+
+// CHECK:      -- start
+// CHECK-NEXT: Container.deinit fired
+// CHECK-NEXT: -- done


### PR DESCRIPTION
- **Explanation**:
`~Copyable` types with generic arguments whose fields are POD will not have their `deinit` called when the `destroy` is invoked from the VWT.
- **Scope**:
 This can only break existing code if it was intentionally relying on the `deinit` not being run, but this would be incorrect and even then inconsistent because the `deinit` does get invoked whenever the destroy call doesn't go through the VWT.
- **Issues**:
rdar://166549159
- **Original PRs**:
https://github.com/swiftlang/swift/pull/89686
- **Risk**:
Noted in scope, this can change behavior if some code was relying on the deinit not being run, but that would have been incorrect to begin with.
- **Testing**:
Testing: Added unit test to verify the deinit is invoked as expected.
- **Reviewers**:
@jckarter 