### PR TITLE
[Sema] Fix availability scope source range for SwitchStmt

### DIFF
--- a/lib/AST/AvailabilityScope.cpp
+++ b/lib/AST/AvailabilityScope.cpp
@@ -180,7 +180,13 @@ AvailabilityScope *AvailabilityScope::createForSwitchStmt(
   // scope's source range. The subject is type-checked before the case label
   // items, so excluding it avoids triggering this scope's lazy expansion
   // before the patterns are ready.
+  //
+  // Widen the source range to the end of its last token so it contains
+  // child availability scopes that extend their ranges similarly (such as
+  // implicit decl scopes).
   SourceRange range(S->getLBraceLoc(), S->getRBraceLoc());
+  if (range.End.isValid())
+    range.End = Lexer::getLocForEndOfToken(Ctx.SourceMgr, range.End);
   return new (Ctx)
       AvailabilityScope(Ctx, IntroNode(S, DC), Parent, range, Info);
 }

--- a/validation-test/compiler_crashers_fixed/AvailabilityScope-verify-97aef4.swift
+++ b/validation-test/compiler_crashers_fixed/AvailabilityScope-verify-97aef4.swift
@@ -1,0 +1,5 @@
+// {"frontendArgs":["-typecheck"],"kind":"custom","signature":"swift::AvailabilityScope::verify(swift::AvailabilityScope const*, swift::ASTContext&) const","signatureNext":"verify"}
+// RUN: not %target-swift-frontend -typecheck %s
+switch  {
+case :
+  let a


### PR DESCRIPTION
Ensure we extend the end loc of the range, same as we do for the case scope. This ensures the case scope is contained by the parent.