### PR TITLE
Fix exclusivity diagnostics to handle mutable ~Escapable values.

### DIFF
--- a/lib/SILOptimizer/Mandatory/DiagnoseStaticExclusivity.cpp
+++ b/lib/SILOptimizer/Mandatory/DiagnoseStaticExclusivity.cpp
@@ -683,6 +683,66 @@ findConflictingArgumentAccess(const AccessSummaryAnalysis::ArgumentSummary &AS,
                            *BestArgAccess);
 }
 
+// Return true if this instruction is immutable with respect to formally
+// accessed storage. Ref-count updates are not considered a mutation.
+static bool isImmutable(SILInstruction *inst) {
+  if (!inst->mayWriteToMemory())
+    return true;
+
+  if (isa<LoadInst>(inst))
+    return true;
+
+  if (onlyAffectsRefCount(inst))
+    return true;
+
+  // TODO: consider updating mayWriteToMemory so that
+  // "begin_access [read] [static]" is not generally considered a write.
+  if (auto *bai = dyn_cast<BeginAccessInst>(inst)) {
+    return bai->getAccessKind() == SILAccessKind::Read
+      && bai->getEnforcement() == SILAccessEnforcement::Static;
+  }
+  return false;
+}
+
+// Return true if no mutation occurs within this read scope. If so, then the
+// read can safely be considered to be a nested access within an overlapping
+// modify access.
+//
+// This is common with access extension across ~Escapable values:
+//
+// %a1 = begin_access [modify] %base
+// %dependent = mark_dependence ... on %base
+//
+// # modification via the dependent value
+// apply (%dependent) // may modify base
+//
+// # Copy the original value within the lifetime of the dependent value...
+// # handle this as if it was a read of %a1 rather than %base.
+// %a2 = begin_access [read] %base
+// %copy = load [copy] %a2
+// end_access %a2
+//
+// # modification via the dependent value
+// apply (%dependent) // may modify base
+// end_access %a1
+static bool isImmutableRead(BeginAccessInst *bai) {
+  auto endAccesses = bai->getEndAccesses();
+  if (endAccesses.empty()
+      || std::next(endAccesses.begin()) != endAccesses.end()) {
+    return false;
+  }
+  auto *eai = endAccesses.front();
+  if (eai->getParent() != bai->getParent())
+    return false;
+
+  for (SILInstruction *inst = bai; inst != eai;
+       inst = inst->getNextInstruction()) {
+    if (!isImmutable(inst))
+      return false;
+  }
+  return true;
+}
+
 // =============================================================================
 // The data flow algorithm that drives diagnostics.
 
@@ -876,8 +936,10 @@ static void checkForViolationsAtInstruction(SILInstruction &I,
     AccessInfo &Info = (*State.Accesses)[Storage];
     const IndexTrieNode *SubPath = State.ASA->findSubPathAccessed(BAI);
     if (auto Conflict = shouldReportAccess(Info, Kind, SubPath)) {
-      State.recordConflictingAccess(Storage, *Conflict,
-                                    RecordedAccess(BAI, SubPath));
+      if (!isImmutableRead(BAI)) {
+        State.recordConflictingAccess(Storage, *Conflict,
+                                      RecordedAccess(BAI, SubPath));
+      }
     }
 
     Info.beginAccess(BAI, SubPath);

--- a/test/SILOptimizer/exclusivity_static_diagnostics.sil
+++ b/test/SILOptimizer/exclusivity_static_diagnostics.sil
@@ -1623,3 +1623,30 @@ bb0(%0 : $*Int):
   %10 = tuple ()
   return %10 : $()
 }
+
+// -----------------------------------------------------------------------------
+// Test an immutable read scope that overlaps with a modify scope. This is fine as long as no actual mutation occurs
+// within the read scope.
+
+sil hidden [ossa] @testImmutableReadTrivial : $@convention(thin) (@inout Int) -> () {
+bb0(%0 : $*Int):
+  %1 = begin_access [modify] [static] %0
+  %2 = begin_access [read] [static] %0
+  %3 = load [trivial] %2
+  end_access %2
+  end_access %1
+  %r = tuple ()
+  return %r
+}
+
+sil hidden [ossa] @testImmutableReadNonTrivial : $@convention(thin) (@inout AnyObject) -> () {
+bb0(%0 : $*AnyObject):
+  %1 = begin_access [modify] [static] %0
+  %2 = begin_access [read] [static] %0
+  %3 = load [copy] %2
+  end_access %2
+  end_access %1
+  destroy_value %3
+  %r = tuple ()
+  return %r
+}

--- a/test/SILOptimizer/exclusivity_static_diagnostics_dependency.swift
+++ b/test/SILOptimizer/exclusivity_static_diagnostics_dependency.swift
@@ -20,20 +20,40 @@ struct InoutPair: ~Escapable, ~Copyable {
   }
 }
 
-func take(_ inoutPair: consuming InoutPair) {}
+func takeFunction(_ inoutPair: consuming InoutPair) {}
 
 struct Pair {
   var x: Int
   var y: Int
 
-  mutating func run() {
+  mutating func testDistinctSubobjects() {
     var inoutPair = InoutPair()
     inoutPair.insertX(&x)
     inoutPair.insertY(&y)
 
-    take(inoutPair) // OK: no overlapping access.
+    takeFunction(inoutPair) // OK: no overlapping access.
     // The access of both &x and &y are extended up to the last use of 'inoutPair'.
     // Exclusivity diagnostics determines that &x and &y are distinct sub-objects
     // so their simultaneous access does not overlap.
   }
+
+  func takeMethod(_ pair: consuming InoutPair) {}
+
+  // A 'modify' access of 'self' extends over the lifetime of 'inoutPair'. But, since the call to 'self.takeMethod()'
+  // simply copies 'self' before calling 'takeMethod()', it is an immutable read scope which does not conflict with the
+  // overlapping 'modify'.
+  mutating func testInoutOverlapsWithMethod() {
+    var inoutPair = InoutPair()
+    inoutPair.insertX(&x)
+    inoutPair.insertY(&y)
+
+    self.takeMethod(inoutPair) // OK: treated like a nested read.
+  }
+}
+
+// Verify that reading the array count does not interfere with a mutable span.
+func testMutableSpan(array: inout [Int]) {
+  var ms = array.mutableSpan
+  _ = array.count // OK
+  ms[0] = 3
 }


### PR DESCRIPTION
Allow a read access to occur within a modify access of the same storage as long
as the storage cannot be mutated within the read access. This is the behavior we
normally expect from a nested read. The only difference is that our formal
access scopes are not explicitly nested so we must rediscover the nesting. This
is a very common pattern with ~Escapable values that depend on an 'inout' scope.

With this fix, the compiler accepts patterns such as:

  var mutableSpan = array.mutableSpan
  _ = array.count
  update(&mutableSpan)

Fixes rdar://177407973 (Can't compile Swift code using mutable views...)
