### PR TITLE
[6.4] IRGen: handle conformances conditioned on T.A: ~Copyable

### DIFF
--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -2352,8 +2352,7 @@ namespace {
           return;
       }
 
-      auto nominal = normal->getDeclContext()->getSelfNominalTypeDecl();
-      auto sig = nominal->getGenericSignatureOfContext();
+      auto sig = normal->getGenericSignature();
       auto metadata = irgen::addGenericRequirements(
           IGM, B, sig, condReqs, inverses);
 

--- a/test/Casting/suppressed-associated-types.swift
+++ b/test/Casting/suppressed-associated-types.swift
@@ -125,6 +125,30 @@ func castNeitherC<T>(_: T.Type) where T: Style, T.Primary: ~Copyable {
   }
 }
 
+// Additional test where conformed-to protocol itself has a Copyable associated type.
+protocol HasACopyableAssoc {
+  associatedtype Inner
+  func describe()
+}
+
+struct G<T: Style> where T.Primary: ~Copyable {}
+
+extension G: HasACopyableAssoc where T.Primary: Copyable {
+  typealias Inner = T.Primary
+  func describe() { print("G<\(T.self)<\(Inner.self), _>> : HasACopyableAssoc") }
+}
+
+@inline(never)
+func castHasA<T>(_: T.Type) where T: Style, T.Primary: ~Copyable {
+  let value = G<T>()
+  if let x = value as? any HasACopyableAssoc {
+    x.describe()
+  } else {
+    print("G<\(T.self)<\(T.Primary.self), _>> is not a HasACopyableAssoc")
+  }
+}
+
+
 func main() {
     // EXEC: going to test
     print("going to test")
@@ -164,6 +188,15 @@ func main() {
     castPrimaryC(NCBoth.self)
     castSecondC(NCBoth.self)
     castNeitherC(NCBoth.self)
+
+    // EXEC-NEXT: G<AllCopyable<Int, _>> : HasACopyableAssoc
+    // EXEC-NEXT: G<NCPrimary<NC, _>> is not a HasACopyableAssoc
+    // EXEC-NEXT: G<NCSecondary<Int, _>> : HasACopyableAssoc
+    // EXEC-NEXT: G<NCBoth<NC, _>> is not a HasACopyableAssoc
+    castHasA(AllCopyable.self)
+    castHasA(NCPrimary.self)
+    castHasA(NCSecondary.self)
+    castHasA(NCBoth.self)
 
     // EXEC-NEXT: done testing
     print("done testing")

--- a/test/IRGen/noncopyable_associatedtypes.swift
+++ b/test/IRGen/noncopyable_associatedtypes.swift
@@ -1,0 +1,83 @@
+// RUN: %target-swift-frontend -module-name test %s -emit-ir > %t.ll
+// RUN: %FileCheck %s --check-prefix=CHECK < %t.ll
+
+// REQUIRES: PTRSIZE=64
+
+public protocol P<A>: ~Copyable {
+  associatedtype A: ~Copyable
+}
+
+// T.A: ~Copyable in G's conformance to P is redundant as P already declares A: ~Copyable,
+// so two conditional requirements remain: T: P and T: ~Copyable.
+public struct G<T>: ~Copyable where T: ~Copyable {}
+extension G: P where T: P & ~Copyable, T.A: ~Copyable {
+  public typealias A = T.A
+}
+
+// CHECK: @"$s4test1GVyxGAA1PA2aERzRi_z1ARj_zrlMc" ={{.*}}constant {
+
+// ConformanceFlags == 0x20200 == 131584 == HasGenericWitnessTable (0x20000) | (NumConditionalRequirements=2 << 8)
+// CHECK-SAME: i32 131584,
+
+// ------------
+// Req #1, T: P
+
+// GenericRequirementFlags == Protocol(0) | HasKeyArgument(0x80) == 128
+// CHECK-SAME: i32 128,
+
+// mangled name of the subject type. "x" is the mangling for the first generic parameter T
+// CHECK-SAME: @"symbolic x"
+
+// relative reference to P's protocol descriptor.
+// CHECK-SAME: @"$s4test1PMp"
+
+// ------------
+// Req #2, T: ~Copyable
+
+// GenericRequirementFlags == InvertedProtocols(5)
+// CHECK-SAME: i32 5,
+
+// CHECK-SAME: @"symbolic x"
+
+// paramIndex == 0 == T == 0th generic param of the conformance's signature)
+// mask = 0x1 (Copyable bit set: suppress the implicit Copyable requirement on T).
+// CHECK-SAME: i16 0, i16 1
+
+
+// T.A: Copyable in H's conformance to P is NOT redundant. P doesn't require it but
+// the conformance does. All three conditional requirements are emitted: T: P, T.A: Copyable, and T: ~Copyable
+public struct H<T>: ~Copyable where T: ~Copyable {}
+extension H: P where T: P & ~Copyable, T.A: Copyable {
+  public typealias A = T.A
+}
+
+// CHECK: @"$s4test1HVyxGAA1PA2aERzRi_zrlMc" ={{.*}}constant {
+
+// ConformanceFlags == 0x20300 == 131840 == HasGenericWitnessTable (0x20000) | (NumConditionalRequirements=3 << 8)
+// CHECK-SAME: i32 131840,
+
+// ------------
+// Req #1, T: P: same as in G above.
+// CHECK-SAME: i32 128,
+// CHECK-SAME: @"symbolic x"
+// CHECK-SAME: @"$s4test1PMp"
+
+// ------------
+// Req #2, T.A: Copyable is encoded with the "ignore checking all except" form.
+
+// GenericRequirementFlags == InvertedProtocols(5)
+// CHECK-SAME: i32 5,
+
+// Param: mangled name for T.A aka (τ_0_0).A
+
+// CHECK-SAME: @"symbolic 1A_____Qz 4test1PP"
+
+// paramIndex = 0xFFFF == -1 == "subject is not a top-level generic param"
+// mask = 0xFFFE == -2 == "ignore all but Copyable"
+// CHECK-SAME: i16 -1, i16 -2
+
+// ------------
+// Req #3, T: ~Copyable: same in G above.
+// CHECK-SAME: i32 5,
+// CHECK-SAME: @"symbolic x"
+// CHECK-SAME: i16 0, i16 1


### PR DESCRIPTION
- Explanation: We're calling getReducedType on the wrong signature for inverse subjects when emitting conditional requirements. Those subjects now can be associated types who had an inferred default that was suppressed as a result of SE-503.
- Scope: IRGen
- Issues: rdar://179069490
- Risk: Low. It's a more correct signature to be passing into the function.
- Testing: regression tests included
- Original PRs: https://github.com/swiftlang/swift/pull/89816
Reviewers: Slava