### PR TITLE
[VariableNameUtils] Recover name for lazy global via addressor

### DIFF
--- a/lib/SILOptimizer/Utils/VariableNameUtils.cpp
+++ b/lib/SILOptimizer/Utils/VariableNameUtils.cpp
@@ -736,6 +736,14 @@ SILValue VariableNameInferrer::findDebugInfoProvidingValueHelper(
           searchValue = selfParam;
           continue;
         }
+        // For a top-level global addressor there is no self, but we can still
+        // recover the global variable's name from the callee (the addressor's
+        // AccessorDecl points back to the VarDecl via getStorage()).
+        auto fas = FullApplySite(addressorInvocation);
+        if (auto name = namer.getCalleeName(fas); !name.empty()) {
+          pushPathComponent(name, fas.getLoc().getSourceLoc());
+          return searchValue;
+        }
       }
     }
 

--- a/test/Concurrency/transfernonsendable_sending_params.swift
+++ b/test/Concurrency/transfernonsendable_sending_params.swift
@@ -10,6 +10,7 @@
 ////////////////////////
 
 class NonSendableKlass {
+  var field = NonSendableKlass?.none
   func use() {}
 }
 
@@ -220,8 +221,14 @@ actor MyActor {
 }
 
 @MainActor func canAssignTransferringIntoGlobalActor3(_ x: sending NonSendableKlass) async {
-  await transferToCustom(globalKlass) // expected-warning {{sending value of non-Sendable type 'NonSendableKlass' risks causing data races}}
-  // expected-note @-1 {{sending main actor-isolated value of non-Sendable type 'NonSendableKlass' to global actor 'CustomActor'-isolated global function 'transferToCustom' risks causing races in between main actor-isolated and global actor 'CustomActor'-isolated uses}}
+  await transferToCustom(globalKlass) // expected-warning {{sending 'globalKlass' risks causing data races}}
+  // expected-note @-1 {{sending main actor-isolated 'globalKlass' to global actor 'CustomActor'-isolated global function 'transferToCustom' risks causing data races between global actor 'CustomActor'-isolated and main actor-isolated uses}}
+}
+
+// Field access on a lazy global: the name should include the field component.
+@MainActor func canAssignTransferringIntoGlobalActor3Field(_ x: sending NonSendableKlass) async {
+  await transferToCustom(globalKlass.field) // expected-warning {{sending 'globalKlass.field' risks causing data races}}
+  // expected-note @-1 {{sending main actor-isolated 'globalKlass.field' to global actor 'CustomActor'-isolated global function 'transferToCustom' risks causing data races between global actor 'CustomActor'-isolated and main actor-isolated uses}}
 }
 
 func canTransferAssigningIntoLocal(_ x: sending NonSendableKlass) async {

--- a/test/SILOptimizer/variable_name_inference.sil
+++ b/test/SILOptimizer/variable_name_inference.sil
@@ -38,6 +38,7 @@ sil @getKlassThrows : $@convention(thin) () -> (@owned Klass, @error MyError)
 sil @getKlassCoro : $@yield_once @convention(thin) () -> @yields @owned Klass
 sil @C_throwingMethod : $@convention(method) (@guaranteed C) -> (@owned Klass, @error MyError)
 sil @C_method : $@convention(method) (@owned C) -> @owned Klass
+sil @globalVar_addressor : $@convention(thin) () -> Builtin.RawPointer
 sil @freeFunc : $@convention(thin) (@owned C) -> @owned Klass
 
 enum FakeOptional<T> {
@@ -1202,3 +1203,56 @@ bb0(%0 : @owned $Klass):
   %9999 = tuple ()
   return %9999 : $()
 }
+
+//===----------------------------------------------------------------------===//
+// MARK: Global addressor (lazy-init global variable via pointer_to_address)
+//===----------------------------------------------------------------------===//
+
+// Basic: load from a lazy global through its addressor.
+// The addressor is a free function (no self) that returns a RawPointer.
+//
+// CHECK-LABEL: begin running test 1 of 1 on global_addressor_basic: variable_name_inference with: @trace[0]
+// CHECK: Name: 'globalVar_addressor'
+// CHECK: end running test 1 of 1 on global_addressor_basic: variable_name_inference with: @trace[0]
+sil [ossa] @global_addressor_basic : $@convention(thin) () -> () {
+bb0:
+  specify_test "variable_name_inference @trace[0]"
+  %0 = function_ref @globalVar_addressor : $@convention(thin) () -> Builtin.RawPointer
+  %1 = apply %0() : $@convention(thin) () -> Builtin.RawPointer
+  %2 = pointer_to_address %1 to [strict] $*Klass
+  %3 = begin_access [read] [dynamic] %2 : $*Klass
+  %4 = load [copy] %3 : $*Klass
+  end_access %3 : $*Klass
+  debug_value [trace] %4 : $Klass
+  destroy_value %4 : $Klass
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// Composition: load a field from a struct accessed through a lazy global.
+// Chain: addressor -> ptr_to_addr -> load(ContainsKlass) -> ref_element_addr(.klass) -> load
+//
+// CHECK-LABEL: begin running test 1 of 1 on global_addressor_field: variable_name_inference with: @trace[0]
+// CHECK: Name: 'globalContainsKlass_addressor.klass'
+// CHECK: end running test 1 of 1 on global_addressor_field: variable_name_inference with: @trace[0]
+sil @globalContainsKlass_addressor : $@convention(thin) () -> Builtin.RawPointer
+sil [ossa] @global_addressor_field : $@convention(thin) () -> () {
+bb0:
+  specify_test "variable_name_inference @trace[0]"
+  %0 = function_ref @globalContainsKlass_addressor : $@convention(thin) () -> Builtin.RawPointer
+  %1 = apply %0() : $@convention(thin) () -> Builtin.RawPointer
+  %2 = pointer_to_address %1 to [strict] $*ContainsKlass
+  %3 = begin_access [read] [dynamic] %2 : $*ContainsKlass
+  %4 = load [copy] %3 : $*ContainsKlass
+  end_access %3 : $*ContainsKlass
+  %4b = begin_borrow %4 : $ContainsKlass
+  %5 = ref_element_addr %4b : $ContainsKlass, #ContainsKlass.klass
+  %6 = load [copy] %5 : $*Klass
+  debug_value [trace] %6 : $Klass
+  destroy_value %6 : $Klass
+  end_borrow %4b : $ContainsKlass
+  destroy_value %4 : $ContainsKlass
+  %9999 = tuple ()
+  return %9999 : $()
+}
+


### PR DESCRIPTION
When a @MainActor or lazy global is accessed its value flows through an unsafeMutableAddressor function that returns Builtin.RawPointer, then pointer_to_address, then load. The addressor has no self so the existing nameThroughSelf path returned nothing, leaving the name as 'unknown'.

Fall back to using the callee name from the addressor apply when no self is present. In a full compilation getDeclRef() resolves the AccessorDecl back to the VarDecl name (e.g. 'globalKlass'); in SIL unit tests the function name itself is used as the component.

rdar://179181114
