### PR TITLE
[6.4] Eliminate unnecessary error while defining macros with borrow/mutate accessors

### DIFF
--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -8546,9 +8546,9 @@ void Parser::parseTopLevelAccessors(
     if (accessorStatus.isError())
       break;
 
-    (void)parseAccessorAfterIntroducer(loc, kind, accessors, hasEffectfulGet,
-                                       parsingLimitedSyntax, attributes,
-                                       PD_Default, storage, status);
+    (void)parseAccessorAfterIntroducer(
+        loc, kind, accessors, hasEffectfulGet, parsingLimitedSyntax, attributes,
+        getParseDeclOptions(storage->getDeclContext()), storage, status);
     if (IsFirstAccessor) {
       IsFirstAccessor = false;
     }

--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -3057,3 +3057,17 @@ public struct CustomConditionCheckMacro: ExpressionMacro {
     return "\(literal: isSet)"
   }
 }
+
+public enum BorrowMutateMacro: AccessorMacro {
+    public static func expansion(
+        of node: AttributeSyntax,
+        providingAccessorsOf declaration: some DeclSyntaxProtocol,
+        in context: some MacroExpansionContext
+    ) throws -> [AccessorDeclSyntax] {
+        [
+            "borrow { _x }",
+            "mutate { return &_x }",
+        ]
+    }
+}
+

--- a/test/Macros/borrow_accessor.swift
+++ b/test/Macros/borrow_accessor.swift
@@ -1,0 +1,20 @@
+// RUN: %empty-directory(%t)
+// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath
+// RUN: %target-typecheck-verify-swift -disable-availability-checking -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) -module-name MacroUser -DTEST_DIAGNOSTICS -swift-version 5
+
+// REQUIRES: swift_swift_parser
+
+@attached(accessor)
+macro BorrowMutate() = #externalMacro(module: "MacroDefinition", type: "BorrowMutateMacro")
+
+struct MacroBased {
+    private var _x: [Int] = []
+    @BorrowMutate var x: [Int] 
+}
+
+func testUsage() {
+    var instance = MacroBased()
+    _ = instance.x
+    instance.x.append(42)
+}
+


### PR DESCRIPTION
Explanation: There were unnecessary errors when parsing accessor macros that generate borrow and mutate accessors. This was happening because the parser was using default declaration options instead of using appropriate ones from the DeclContext.

Reviewer: @atrick 

Main PR: https://github.com/swiftlang/swift/pull/89821

Risk: Low. Removes unnecessary errors while using borrow accessors in borrows.

Scope: Borrow accessors

Testing: Added unit test, ci testing

Issue: rdar://179180822

