### PR TITLE
Optimizer: add the MergeBorrowScopes pass

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/CMakeLists.txt
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/CMakeLists.txt
@@ -35,6 +35,7 @@ swift_compiler_sources(Optimizer
   ObjectOutliner.swift
   ObjCBridgingOptimization.swift
   MandatoryDestroyHoisting.swift
+  MergeBorrowScopes.swift
   MergeCondFails.swift
   NamedReturnValueOptimization.swift
   RedundantLoadElimination.swift

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/MergeBorrowScopes.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/MergeBorrowScopes.swift
@@ -1,0 +1,65 @@
+//===--- MergeBorrowScopes.swift -------------------------------------------==//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SIL
+
+/// Merges to adjacent borrow scopes in a basic block.
+///
+/// ```
+///   %2 = begin_borrow %1
+///   use(%2)
+///   end_borrow %2
+///   ...
+///   %6 = begin_borrow %1
+///   use(%6)
+///   end_borrow %6
+///
+/// ```
+/// ->
+/// ```
+///   %2 = begin_borrow %1
+///   use(%2)
+///   ...
+///   use(%2)
+///   end_borrow %2
+/// ```
+///
+/// This helps other optimizations, like common-subexpression-elimination, because the
+/// borrow liveranges are larger and not split.
+///
+let mergeBorrowScopes = FunctionPass(name: "merge-borrow-scopes") {
+    (function: Function, context: FunctionPassContext) in
+  for block in function.blocks {
+    doMergeBorrowScopes(in: block, context)
+  }
+}
+
+private func doMergeBorrowScopes(in block: BasicBlock, _ context: FunctionPassContext) {
+  var endBorrows = Dictionary<ObjectIdentifier, EndBorrowInst>()
+
+  for inst in block.instructions {
+    switch inst {
+    case let endBorrow as EndBorrowInst:
+      if let beginBorrow = endBorrow.borrow as? BeginBorrowInst {
+        endBorrows[ObjectIdentifier(beginBorrow.borrowedValue)] = endBorrow
+      }
+    case let beginBorrow as BeginBorrowInst:
+      if let endBorrow = endBorrows[ObjectIdentifier(beginBorrow.borrowedValue)] {
+        endBorrows.removeValue(forKey: ObjectIdentifier(beginBorrow.borrowedValue))
+        beginBorrow.replace(with: endBorrow.borrow, context)
+        context.erase(instruction: endBorrow)
+      }
+    default:
+      break
+    }
+  }
+}

--- a/SwiftCompilerSources/Sources/Optimizer/PassManager/PassRegistration.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/PassManager/PassRegistration.swift
@@ -79,6 +79,7 @@ private func registerSwiftPasses() {
   registerPass(highLevelCSE, { highLevelCSE.run($0) })
   registerPass(embeddedWitnessCallSpecialization, { embeddedWitnessCallSpecialization.run($0) })
   registerPass(letPropertyLowering, { letPropertyLowering.run($0) })
+  registerPass(mergeBorrowScopes, { mergeBorrowScopes.run($0) })
   registerPass(mergeCondFailsPass, { mergeCondFailsPass.run($0) })
   registerPass(constantCapturePropagation, { constantCapturePropagation.run($0) })
   registerPass(computeEscapeEffects, { computeEscapeEffects.run($0) })

--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -108,6 +108,8 @@ PASS(LifetimeDependenceInsertion,
 PASS(LifetimeDependenceScopeFixup,
      "lifetime-dependence-scope-fixup",
      "Fixup scope for lifetime dependence")
+PASS(MergeBorrowScopes, "merge-borrow-scopes",
+     "Merge borrow scopes")
 PASS(MergeCondFails, "merge-cond_fails",
      "Merge SIL cond_fail to Eliminate Redundant Overflow Checks")
 PASS(ObjCBridgingOptimization, "objc-bridging-opt",

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -576,6 +576,8 @@ void addFunctionPasses(SILPassPipelinePlan &P,
   // SILCombine can expose further opportunities for SimplifyCFG.
   P.addSimplifyCFG();
 
+  // Merging borrow scopes helps CSE
+  P.addMergeBorrowScopes();
   P.addCommonSubexpressionElimination();
   if (OpLevel == OptimizationLevelKind::HighLevel) {
     // Early RLE does not touch loads from Arrays. This is important because

--- a/test/SILOptimizer/merge_borrow_scopes.sil
+++ b/test/SILOptimizer/merge_borrow_scopes.sil
@@ -1,0 +1,149 @@
+// RUN: %target-sil-opt %s -merge-borrow-scopes | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+
+sil_stage canonical
+
+import Builtin
+import Swift
+
+sil @use_obj : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+
+// Two adjacent borrow scopes of the same owned value are merged into one.
+//
+// CHECK-LABEL: sil [ossa] @merge_two_adjacent_scopes :
+// CHECK:         %2 = begin_borrow %0
+// CHECK:          = apply %1(%2)
+// CHECK-NOT:     begin_borrow
+// CHECK:          = apply %1(%2)
+// CHECK:       } // end sil function 'merge_two_adjacent_scopes'
+sil [ossa] @merge_two_adjacent_scopes : $@convention(thin) (@owned Builtin.NativeObject) -> () {
+bb0(%0 : @owned $Builtin.NativeObject):
+  %1 = function_ref @use_obj : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  %2 = begin_borrow %0 : $Builtin.NativeObject
+  %3 = apply %1(%2) : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  end_borrow %2 : $Builtin.NativeObject
+  %5 = begin_borrow %0 : $Builtin.NativeObject
+  %6 = apply %1(%5) : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  end_borrow %5 : $Builtin.NativeObject
+  destroy_value %0 : $Builtin.NativeObject
+  %9 = tuple ()
+  return %9 : $()
+}
+
+// Three adjacent borrow scopes of the same value are merged into one.
+//
+// CHECK-LABEL: sil [ossa] @merge_three_adjacent_scopes :
+// CHECK:         %2 = begin_borrow %0
+// CHECK:          = apply %1(%2)
+// CHECK-NOT:     begin_borrow
+// CHECK:          = apply %1(%2)
+// CHECK-NOT:     begin_borrow
+// CHECK:          = apply %1(%2)
+// CHECK:       } // end sil function 'merge_three_adjacent_scopes'
+sil [ossa] @merge_three_adjacent_scopes : $@convention(thin) (@owned Builtin.NativeObject) -> () {
+bb0(%0 : @owned $Builtin.NativeObject):
+  %1 = function_ref @use_obj : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  %2 = begin_borrow %0 : $Builtin.NativeObject
+  %3 = apply %1(%2) : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  end_borrow %2 : $Builtin.NativeObject
+  %5 = begin_borrow %0 : $Builtin.NativeObject
+  %6 = apply %1(%5) : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  end_borrow %5 : $Builtin.NativeObject
+  %8 = begin_borrow %0 : $Builtin.NativeObject
+  %9 = apply %1(%8) : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  end_borrow %8 : $Builtin.NativeObject
+  destroy_value %0 : $Builtin.NativeObject
+  %r = tuple ()
+  return %r : $()
+}
+
+// Non-borrow instructions between the two scopes do not prevent merging.
+//
+// CHECK-LABEL: sil [ossa] @merge_with_instructions_between :
+// CHECK:         %2 = begin_borrow %0
+// CHECK:          = apply %1(%2)
+// CHECK-NOT:     begin_borrow
+// CHECK:          = apply %1(%2)
+// CHECK:       } // end sil function 'merge_with_instructions_between'
+sil [ossa] @merge_with_instructions_between : $@convention(thin) (@owned Builtin.NativeObject) -> () {
+bb0(%0 : @owned $Builtin.NativeObject):
+  %1 = function_ref @use_obj : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  %2 = begin_borrow %0 : $Builtin.NativeObject
+  %3 = apply %1(%2) : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  end_borrow %2 : $Builtin.NativeObject
+  debug_value %0 : $Builtin.NativeObject, let, name "x"
+  %6 = begin_borrow %0 : $Builtin.NativeObject
+  %7 = apply %1(%6) : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  end_borrow %6 : $Builtin.NativeObject
+  destroy_value %0 : $Builtin.NativeObject
+  %r = tuple ()
+  return %r : $()
+}
+
+// Borrow scopes of a guaranteed function argument are also merged.
+//
+// CHECK-LABEL: sil [ossa] @merge_guaranteed_arg_borrows :
+// CHECK:         %2 = begin_borrow %0
+// CHECK:          = apply %1(%2)
+// CHECK-NOT:     begin_borrow
+// CHECK:          = apply %1(%2)
+// CHECK:       } // end sil function 'merge_guaranteed_arg_borrows'
+sil [ossa] @merge_guaranteed_arg_borrows : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
+bb0(%0 : @guaranteed $Builtin.NativeObject):
+  %1 = function_ref @use_obj : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  %2 = begin_borrow %0 : $Builtin.NativeObject
+  %3 = apply %1(%2) : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  end_borrow %2 : $Builtin.NativeObject
+  %5 = begin_borrow %0 : $Builtin.NativeObject
+  %6 = apply %1(%5) : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  end_borrow %5 : $Builtin.NativeObject
+  %r = tuple ()
+  return %r : $()
+}
+
+// Borrow scopes of two independent values are not merged with each other.
+//
+// CHECK-LABEL: sil [ossa] @dont_merge_different_values :
+// CHECK:         begin_borrow %0
+// CHECK:         begin_borrow %1
+// CHECK:       } // end sil function 'dont_merge_different_values'
+sil [ossa] @dont_merge_different_values : $@convention(thin) (@owned Builtin.NativeObject, @owned Builtin.NativeObject) -> () {
+bb0(%0 : @owned $Builtin.NativeObject, %1 : @owned $Builtin.NativeObject):
+  %use = function_ref @use_obj : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  %2 = begin_borrow %0 : $Builtin.NativeObject
+  %3 = apply %use(%2) : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  end_borrow %2 : $Builtin.NativeObject
+  %5 = begin_borrow %1 : $Builtin.NativeObject
+  %6 = apply %use(%5) : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  end_borrow %5 : $Builtin.NativeObject
+  destroy_value %0 : $Builtin.NativeObject
+  destroy_value %1 : $Builtin.NativeObject
+  %r = tuple ()
+  return %r : $()
+}
+
+// Borrow scopes in different basic blocks are not merged: the pass operates
+// per-block and does not propagate the scope dictionary across branches.
+//
+// CHECK-LABEL: sil [ossa] @dont_merge_across_blocks :
+// CHECK:       bb0
+// CHECK:         begin_borrow
+// CHECK:       bb1
+// CHECK:         begin_borrow
+// CHECK:       } // end sil function 'dont_merge_across_blocks'
+sil [ossa] @dont_merge_across_blocks : $@convention(thin) (@owned Builtin.NativeObject) -> () {
+bb0(%0 : @owned $Builtin.NativeObject):
+  %use = function_ref @use_obj : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  %1 = begin_borrow %0 : $Builtin.NativeObject
+  %2 = apply %use(%1) : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  end_borrow %1 : $Builtin.NativeObject
+  br bb1
+bb1:
+  %5 = begin_borrow %0 : $Builtin.NativeObject
+  %6 = apply %use(%5) : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  end_borrow %5 : $Builtin.NativeObject
+  destroy_value %0 : $Builtin.NativeObject
+  %r = tuple ()
+  return %r : $()
+}


### PR DESCRIPTION
The pass merges to adjacent borrow scopes in a basic block.

```
  %2 = begin_borrow %1
  use(%2)
  end_borrow %2
  ...
  %6 = begin_borrow %1
  use(%6)
  end_borrow %6

```
->
```
  %2 = begin_borrow %1
  use(%2)
  ...
  use(%2)
  end_borrow %2
```

This helps other optimizations, like common-subexpression-elimination, because the borrow liveranges are larger and not split.
