### PR TITLE
[Concurrency][Docs] Fix incorrect isolation sentence

### DIFF
--- a/stdlib/public/Concurrency/TaskCancellation.swift
+++ b/stdlib/public/Concurrency/TaskCancellation.swift
@@ -99,7 +99,7 @@ public nonisolated(nonsending) func withTaskCancellationHandler<Return, Failure>
 ///   - handler: A closure to execute on cancellation.
 ///     If the task is canceled, this closure is called at most once;
 ///     otherwise, it isn't called.
-///   - isolation: The actor that the operation and cancellation handler are isolated to.
+///   - isolation: The actor that the operation is isolated to.
 ///
 /// This differs from the operation cooperatively checking for cancellation
 /// and reacting to it in that the cancellation handler is _always_ and


### PR DESCRIPTION
Clarified the documentation for the 'isolation' parameter's impact on closures -- it only applies to the operation, not to the cancellation handler.

This wording was added in https://github.com/swiftlang/swift/pull/85126 and slipped through as we focused on the at-most-once bit of the PR and missed this change...

Note also that the updated signature of this method (well, overload...) now is using `nonisolated(nonsending)` so we do not have this mistake in "the good" API.

cc @amartini51 -- we fixed one thing but made another incorrect back then 😓 Sorry I missed that.