### PR TITLE
[6.4][Concurrency][Docs] Fix incorrect isolation sentence

### DIFF
--- a/stdlib/public/Concurrency/TaskCancellation.swift
+++ b/stdlib/public/Concurrency/TaskCancellation.swift
@@ -99,7 +99,7 @@ public nonisolated(nonsending) func withTaskCancellationHandler<Return, Failure>
 ///   - handler: A closure to execute on cancellation.
 ///     If the task is canceled, this closure is called at most once;
 ///     otherwise, it isn't called.
-///   - isolation: The actor that the operation and cancellation handler are isolated to.
+///   - isolation: The actor that the operation is isolated to.
 ///
 /// This differs from the operation cooperatively checking for cancellation
 /// and reacting to it in that the cancellation handler is _always_ and


### PR DESCRIPTION
Clarified the documentation for the 'isolation' parameter's impact on closures -- it only applies to the operation, not to the cancellation handler.

Original PR: https://github.com/swiftlang/swift/pull/89826