### PR TITLE
[wasm][Synchronization] Use busywait when wasi-libc's busywait mode is opted in

### DIFF
--- a/stdlib/public/SwiftShims/swift/shims/_SynchronizationShims.h
+++ b/stdlib/public/SwiftShims/swift/shims/_SynchronizationShims.h
@@ -16,6 +16,27 @@
 #include "SwiftStdbool.h"
 #include "SwiftStdint.h"
 
+#if defined(__wasi__) && defined(__wasm__)
+// Note: `__wasilibc_use_busy_futex` is a thread-local Wasm global defined by
+// wasi-libc in `__wasilibc_busywait.c`:
+// https://github.com/WebAssembly/wasi-libc/blob/wasi-sdk-32/libc-top-half/musl/src/thread/wasi-threads/__wasilibc_busywait.c#L33
+//
+// It becomes nonzero on the current thread after calling
+// `__wasilibc_enable_futex_busywait_on_current_thread()`.
+//
+// Background:
+// https://github.com/WebAssembly/wasi-libc/pull/562
+static inline __swift_uint32_t _swift_stdlib_wasilibc_use_busy_futex_get() {
+  __swift_uint32_t val;
+  __asm__(
+      ".globaltype __wasilibc_use_busy_futex, i32\n"
+      "global.get __wasilibc_use_busy_futex\n"
+      "local.set %0\n"
+      : "=r"(val));
+  return val;
+}
+#endif
+
 #if defined(__linux__)
 #include <errno.h>
 #include <linux/futex.h>

--- a/stdlib/public/Synchronization/Mutex/WasmImpl.swift
+++ b/stdlib/public/Synchronization/Mutex/WasmImpl.swift
@@ -13,6 +13,8 @@
 // Note: All atomic accesses on Wasm are sequentially consistent regardless of
 // what ordering we tell LLVM to use.
 
+import _SynchronizationShims
+
 @_extern(c, "llvm.wasm.memory.atomic.wait32")
 internal func _swift_stdlib_wait(
   on: UnsafePointer<UInt32>,
@@ -26,6 +28,22 @@ internal func _swift_stdlib_wake(on: UnsafePointer<UInt32>, count: UInt32) -> UI
 extension Atomic where Value == _MutexHandle.State {
   internal borrowing func _wait(expected: _MutexHandle.State) {
     #if _runtime(_multithreaded)
+    #if os(WASI)
+    if _swift_stdlib_wasilibc_use_busy_futex_get() != 0 {
+      // Note: On WebAssembly in a web browser, waiting on the main thread with
+      // `memory.atomic.wait32` is not allowed. When wasi-libc busy-futex mode
+      // is enabled, use bounded polling instead so `Mutex` remains usable on
+      // the main thread for `wasm32-unknown-wasip1-threads`.
+      var remaining: UInt32 = 1024
+      while remaining > 0 {
+        if load(ordering: .relaxed) != expected {
+          return
+        }
+        remaining &-= 1
+      }
+      return
+    }
+    #endif
     _ = unsafe _swift_stdlib_wait(
       on: .init(_rawAddress),
       expected: expected.rawValue,


### PR DESCRIPTION
When Swift runs on wasm32-unknown-wasip1-threads in a web browser, WebAssembly waiting instructions cannot be used on the main thread. However, Synchronization mutex locking currently assumes it may block in that situation, which makes contended locking fail in browser hosts when it reaches `llvm.wasm.memory.atomic.wait32`. (you will see `Atomics.wait cannot be called in this context`)

wasi-libc has an opt-in mode that makes futex wait on a thread to use busywait instead of `atomic.wait32`. This change adopts the same model by referencing the same opt-in flag.

See: WebAssembly/wasi-libc#562.

## Validation

This is not testable on Swift CI today because we cannot run browser-based Wasm thread tests there.
I validated this with a browser-main-thread contention scenario using Playwright + Chromium.

<details>
<summary>Validation source</summary>

```swift
import Synchronization
import WASILibc

enum Globals {
  static let mutex = Mutex(())
  static let workerHasLock = Atomic<UInt32>(0)
  static let allowUnlock = Atomic<UInt32>(0)
  static let mainEntered = Atomic<UInt32>(0)
}

@_cdecl("workerMain")
func workerMain(_: UnsafeMutableRawPointer?) -> UnsafeMutableRawPointer? {
  Globals.mutex._unsafeLock()
  Globals.workerHasLock.store(1, ordering: .sequentiallyConsistent)
  while Globals.allowUnlock.load(ordering: .sequentiallyConsistent) == 0 {
    sched_yield()
  }
  Globals.mutex._unsafeUnlock()
  return nil
}

@main
struct Main {
  static func main() {
    __wasilibc_enable_futex_busywait_on_current_thread()

    var thread: UnsafeMutableRawPointer? = nil
    guard pthread_create(&thread, nil, workerMain, nil) == 0 else {
      fputs("pthread_create failed\n", stderr)
      exit(1)
    }

    while Globals.workerHasLock.load(ordering: .sequentiallyConsistent) == 0 {
      sched_yield()
    }

    Globals.allowUnlock.store(1, ordering: .sequentiallyConsistent)

    Globals.mutex._unsafeLock()
    Globals.mainEntered.store(1, ordering: .sequentiallyConsistent)
    Globals.mutex._unsafeUnlock()

    guard Globals.mainEntered.load(ordering: .sequentiallyConsistent) == 1 else {
      fputs("main failed to enter lock\n", stderr)
      exit(1)
    }

    guard pthread_join(thread, nil) == 0 else {
      fputs("pthread_join failed\n", stderr)
      exit(1)
    }

    print("PASS: main thread acquired contended Mutex._unsafeLock with busy futex enabled")
  }
}
```

</details>

<details>
<summary>Playwright harness</summary>

```js
import { createServer } from 'node:http';
import { readFileSync } from 'node:fs';
import { join } from 'node:path';
import url from 'node:url';
import playwright from 'playwright';
const { chromium } = playwright;

const wasmPath = process.argv[2];
if (!wasmPath) throw new Error('usage: node run-playwright-path.mjs /abs/path/to/module.wasm');
const assetsDir = '/workspace/swift-src/wasi-libc/test/scripts/browser-test';

async function startServer() {
  const server = createServer((req, res) => {
    res.setHeader('Cross-Origin-Opener-Policy', 'same-origin');
    res.setHeader('Cross-Origin-Embedder-Policy', 'require-corp');
    const pathname = url.parse(req.url, true).pathname;
    let filePath;
    if (pathname === '/target.wasm') {
      filePath = wasmPath;
      res.setHeader('Content-Type', 'application/wasm');
    } else {
      filePath = join(assetsDir, pathname);
      const contentTypes = { mjs: 'text/javascript', js: 'text/javascript', html: 'text/html' };
      res.setHeader('Content-Type', contentTypes[pathname.split('.').pop()] || 'text/plain');
    }
    try { res.end(readFileSync(filePath)); }
    catch { res.statusCode = 404; res.end('Not found'); }
  });
  await new Promise((resolve) => server.listen(0, resolve));
  return { server, port: server.address().port };
}

const { server, port } = await startServer();
const browser = await chromium.launch();
const page = await browser.newPage();
page.on('console', async (msg) => {
  const values = await Promise.all(msg.args().map(async (arg) => {
    try { return await arg.jsonValue(); } catch { return arg.toString(); }
  }));
  console.log(`[browser:${msg.type()}]`, ...values);
});
page.on('pageerror', (err) => console.error('[pageerror]', err.stack || String(err)));
page.on('requestfailed', (req) => console.error('[requestfailed]', req.url(), req.failure()?.errorText));
const resultPromise = new Promise((resolve) => { page.exposeFunction('exitTest', resolve); });
const timeoutPromise = new Promise((resolve) => setTimeout(() => resolve({ passed: false, error: 'timeout' }), 15000));
try {
  await page.goto(`http://localhost:${port}/run-test.html`);
  const result = await Promise.race([resultPromise, timeoutPromise]);
  console.log('PLAYWRIGHT_RESULT', JSON.stringify(result));
  const text = await page.locator('#results').innerText().catch(() => '');
  console.log('PLAYWRIGHT_DOM', text);
  if (!result?.passed) process.exitCode = 1;
} finally {
  await browser.close();
  server.close();
}
```

</details>

<details>
<summary>Result</summary>

Negative-control build (main-snapshot-2026-05-27)
```text
PLAYWRIGHT_RESULT {"passed":false,"error":"Atomics.wait cannot be called in this context"}
```

Fixed-build
```text
[browser:log] PASS: main thread acquired contended Mutex._unsafeLock with busy futex enabled
PLAYWRIGHT_RESULT {"passed":true}
```

</details>
