### PR TITLE
[SILCloner] Preserve expansion level when cloning pack conformances

### DIFF
--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -19,6 +19,7 @@
 
 #include "swift/AST/ConformanceLookup.h"
 #include "swift/AST/GenericEnvironment.h"
+#include "swift/AST/InFlightSubstitution.h"
 #include "swift/AST/LocalArchetypeRequirementCollector.h"
 #include "swift/AST/ProtocolConformance.h"
 #include "swift/SIL/BasicBlockUtils.h"
@@ -107,8 +108,18 @@ struct SubstitutionMapWithLocalArchetypes {
         origType->getCanonicalType(), proto);
     }
 
-    return ProtocolConformanceRef::forAbstract(
-      origType.subst(IFS), proto);
+    // If IFS has an active pack expansion, then substituting a
+    // PackArchetypeType could cause a PackElementType to be introduced,
+    // possibly erroneously. ProtocolConformanceRef::forAbstract cannot handle
+    // PackElementType types, so set the PreservePackExpansionLevel flag
+    // prevents this.
+    //
+    // TODO: Rework handling of pack type level to make this flag unnecessary.
+    auto optionsPreservingPackExpansionLevel =
+        IFS.getOptions() | SubstFlags::PreservePackExpansionLevel;
+    return IFS.withNewOptions(optionsPreservingPackExpansionLevel, [&]() {
+      return ProtocolConformanceRef::forAbstract(origType.subst(IFS), proto);
+    });
   }
 
   void dump(llvm::raw_ostream &out) const {

--- a/test/SILOptimizer/capture_promotion_pack_conformance.swift
+++ b/test/SILOptimizer/capture_promotion_pack_conformance.swift
@@ -1,0 +1,22 @@
+// RUN: %target-swift-frontend -emit-sil -verify %s
+
+// Verify that CapturePromotion does not crash when remapping the substitution
+// map of a partial_apply whose conformances include a pack conformance.
+//
+// Cloning the closure below remaps a partial_apply of '!=' that carries a pack
+// conformance for 'Pack{repeat each V} : Equatable'. Substituting that pack
+// conformance enters an active pack expansion; the cloner's no-substitution-map
+// conformance fallback must not project a pack element lane onto the conforming
+// type, which previously produced an invalid PackElementType subject and
+// aborted in ProtocolConformanceRef::forAbstract.
+//
+// rdar://175912818
+
+public func crash<each V: Equatable & Sendable>(
+  action: sending @escaping (repeat (each V, Bool)) -> ()
+) -> ((repeat each V)) -> ()
+{
+  { o in
+    action(repeat (each o, false || (each o != each o)))
+  }
+}


### PR DESCRIPTION
If an InFlightSubstitution has an active pack expansion, then substituting a PackArchetypeType could cause a PackElementType to be introduced, possibly erroneously. ProtocolConformanceRef::forAbstract cannot handle PackElementType types, so set the PreservePackExpansionLevel flag prevents this.

Fixes:
- rdar://175912818
<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
