### PR TITLE
[6.4] SILGen: Mark lazily-allocated addressable representation buffers for move checking.

### DIFF
--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -37,6 +37,7 @@
 #include "swift/SIL/SILSymbolVisitor.h"
 #include "swift/SIL/SILType.h"
 #include "swift/SIL/TypeLowering.h"
+#include "clang/AST/DeclarationName.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/Support/ErrorHandling.h"
 #include <iterator>
@@ -2567,8 +2568,12 @@ SILGenFunction::getVariableAddressableBuffer(VarDecl *decl,
                           cleanupPoint.state);
     cleanupPoint.inst->eraseFromParent();
   }
-  
-  return storeBorrow;
+
+  SILValue result = storeBorrow;
+  if (result->getType().isMoveOnly()) {
+    result = B.createMarkUnresolvedNonCopyableValueInst(result.getLoc(), result, MarkUnresolvedNonCopyableValueInst::CheckKind::NoConsumeOrAssign);
+  }
+  return result;
 }
 
 void BlackHoleInitialization::performPackExpansionInitialization(

--- a/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
@@ -1052,6 +1052,11 @@ addressBeginsInitialized(MarkUnresolvedNonCopyableValueInst *address) {
     }
   }
 
+  // A stored borrow is always initialized.
+  if (isa<StoreBorrowInst>(operand)) {
+    return true;
+  }
+
   // A read or write access always begins on an initialized value.
   if (auto access = dyn_cast<BeginAccessInst>(operand)) {
     switch (access->getAccessKind()) {

--- a/test/SILOptimizer/moveonly_addressable_implicit_read.swift
+++ b/test/SILOptimizer/moveonly_addressable_implicit_read.swift
@@ -1,0 +1,21 @@
+// RUN: %target-swift-frontend -enable-experimental-feature Lifetimes -enable-experimental-feature AddressableTypes -emit-sil %s | %FileCheck %s
+
+// REQUIRES: swift_feature_Lifetimes
+// REQUIRES: swift_feature_AddressableTypes
+
+public struct Butt: ~Copyable, ~Escapable {
+  // The compiler will synthesize an implicit `_read` coroutine for external
+  // users of this property. This test ensures that the generated code is
+  // properly move-checked.
+  // CHECK-LABEL: sil{{.*}} @${{.*}}4ButtV3foo{{.*}}vr
+  // CHECK:       bb0([[SELF:%.*]] : $Butt):
+  // CHECK:         [[FOO:%.*]] = struct_extract [[SELF]]
+  // CHECK:         yield [[FOO]]
+  public let foo: Tubb
+}
+
+@_addressableForDependencies
+public struct Tubb: ~Copyable, ~Escapable {
+  var x: AnyObject
+  @_lifetime(immortal) init() { fatalError() }
+}


### PR DESCRIPTION
Explanation: Fixes a spurious internal compiler error when a type contains a noncopyable field containing certain "addressable-for-dependencies" types such as `Data`, `String` or `InlineArray`.

Scope: Bug fix.

Issue: rdar://179022026.

Risk: Low. This fixes an oversight where the move checker would fail to resolve a code pattern involving `_read` coroutines and addressable-for-dependencies types.

Testing: Swift CI, test case from bug report

Original PR: https://github.com/swiftlang/swift/pull/89776

Reviewers: @atrick 