### PR TITLE
[stdlib] Rename reallocate to setCapacity for UniqueArray

### DIFF
--- a/stdlib/public/core/RigidArray/RigidArray+Insertions.swift
+++ b/stdlib/public/core/RigidArray/RigidArray+Insertions.swift
@@ -38,7 +38,7 @@ extension _RigidArray where Element: ~Copyable {
       let source = unsafe _storage.extracting(index ..< count)
       let target = unsafe _storage.extracting(index + 1 ..< count + 1)
       let last = unsafe target.moveInitialize(fromContentsOf: source)
-      assert(last == target.endIndex)
+      _internalInvariant(last == target.endIndex)
     }
     unsafe _storage.initializeElement(at: index, to: item)
     _count += 1

--- a/stdlib/public/core/RigidArray/RigidArray.swift
+++ b/stdlib/public/core/RigidArray/RigidArray.swift
@@ -245,13 +245,12 @@ extension _RigidArray where Element: ~Copyable {
   /// - Complexity: O(`count`)
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
-  internal mutating func reallocate(capacity newCapacity: Int) {
-    _precondition(newCapacity >= count, "RigidArray capacity overflow")
+  internal mutating func setCapacity(_ newCapacity: Int) {
     guard newCapacity != capacity else { return }
     let newStorage: UnsafeMutableBufferPointer<Element> = .allocate(
-      capacity: newCapacity)
-    let i = unsafe newStorage.moveInitialize(fromContentsOf: self._items)
-    assert(i == count)
+      capacity: Swift.max(newCapacity, count))
+    let i = unsafe newStorage.moveInitialize(fromContentsOf: _items)
+    _internalInvariant(i == count)
     unsafe _storage.deallocate()
     unsafe _storage = newStorage
   }
@@ -268,7 +267,7 @@ extension _RigidArray where Element: ~Copyable {
   @_alwaysEmitIntoClient
   internal mutating func reserveCapacity(_ n: Int) {
     guard capacity < n else { return }
-    reallocate(capacity: n)
+    setCapacity(n)
   }
 }
 

--- a/stdlib/public/core/UniqueArray/UniqueArray.swift
+++ b/stdlib/public/core/UniqueArray/UniqueArray.swift
@@ -160,8 +160,8 @@ extension UniqueArray where Element: ~Copyable {
   /// - Complexity: O(`count`)
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
-  public mutating func reallocate(capacity: Int) {
-    _storage.reallocate(capacity: capacity)
+  public mutating func setCapacity(_ newCapacity: Int) {
+    _storage.setCapacity(newCapacity)
   }
 
   /// Ensure that the array has capacity to store the specified number of
@@ -196,7 +196,7 @@ extension UniqueArray where Element: ~Copyable {
   @_alwaysEmitIntoClient
   internal mutating func _ensureFreeCapacitySlow(_ freeCapacity: Int) {
     let newCapacity = _grow(freeCapacity: freeCapacity)
-    reallocate(capacity: newCapacity)
+    setCapacity(newCapacity)
   }
 }
 


### PR DESCRIPTION
Based on the acceptance of `UniqueArray` and the renaming of `reallocate`. Corresponding `swift-collections` PR here: https://github.com/apple/swift-collections/pull/667