### PR TITLE
[Mangler] Fall back to new mangling for ObjC runtime names the old mangler can't represent.

### DIFF
--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -953,7 +953,11 @@ std::string ASTMangler::mangleObjCRuntimeName(const NominalTypeDecl *Nominal) {
   Node *NewGlobal = Dem.createNode(Node::Kind::Global);
   NewGlobal->addChild(TyMangling, Dem);
   auto mangling = mangleNodeOld(NewGlobal);
-  ASSERT(mangling.isSuccess());
+  if (!mangling.isSuccess()) {
+    // The old mangler doesn't support every kind of type (e.g. opaque types).
+    // Fall back to the new mangling in those cases.
+    return NewName;
+  }
   return mangling.result();
 #endif
 }

--- a/lib/Demangling/OldDemangler.cpp
+++ b/lib/Demangling/OldDemangler.cpp
@@ -2110,36 +2110,6 @@ private:
           Factory.createNode(Node::Kind::OpaqueReturnTypeIndex, ordinal), Factory);
         return result;
       }
-      if (Mangled.nextIf('o')) {
-        // Special mangling for opaque type.
-        Node::IndexType index;
-        if (!demangleIndex(index, depth))
-          return nullptr;
-        if (!Mangled.nextIf('Q') || !Mangled.nextIf('O'))
-          return nullptr;
-        NodePointer context = demangleContext(depth + 1);
-        if (!context)
-          return nullptr;
-        auto opaqueReturnTypeOf =
-            Factory.createNode(Node::Kind::OpaqueReturnTypeOf);
-        opaqueReturnTypeOf->addChild(context, Factory);
-        // The generic arguments are flattened into a single '_'-terminated
-        // list; wrap them in the list-of-lists shape the printer expects.
-        auto innerArgs = Factory.createNode(Node::Kind::TypeList);
-        while (!Mangled.nextIf('_')) {
-          NodePointer arg = demangleType(depth + 1);
-          if (!arg)
-            return nullptr;
-          innerArgs->addChild(arg, Factory);
-        }
-        auto args = Factory.createNode(Node::Kind::TypeList);
-        args->addChild(innerArgs, Factory);
-        auto opaque = Factory.createNode(Node::Kind::OpaqueType);
-        opaque->addChild(opaqueReturnTypeOf, Factory);
-        opaque->addChild(Factory.createNode(Node::Kind::Index, index), Factory);
-        opaque->addChild(args, Factory);
-        return opaque;
-      }
       return demangleArchetypeType(depth + 1);
     }
     if (c == 'q') {

--- a/lib/Demangling/OldRemangler.cpp
+++ b/lib/Demangling/OldRemangler.cpp
@@ -860,8 +860,10 @@ ManglingError Remangler::mangleDifferentiableFunctionType(Node *node,
 
 ManglingError Remangler::mangleGlobalActorFunctionType(Node *node,
                                                        unsigned depth) {
-  Buffer << "Y" << (char)node->getIndex(); // differentiability kind
-  return ManglingError::Success;
+  // The old mangling has no representation for global-actor isolation. We
+  // previously attempted to generate one, but it called node->getIndex() on a
+  // node that has no index. Instead, fail gracefully.
+  return MANGLING_ERROR(ManglingError::UnsupportedNodeKind, node);
 }
 
 ManglingError Remangler::mangleIsolatedAnyFunctionType(Node *node,
@@ -2953,22 +2955,10 @@ ManglingError Remangler::mangleOpaqueReturnTypeParent(Node *node, unsigned depth
 ManglingError Remangler::mangleOpaqueReturnTypeOf(Node *node,
                                                   EntityContext &ctx,
                                                   unsigned depth) {
-  DEMANGLER_ASSERT(node->getNumChildren() >= 1, node);
-  Buffer << "QO";
-  return mangleEntityContext(node->getChild(0), ctx, depth + 1);
+  return MANGLING_ERROR(ManglingError::UnsupportedNodeKind, node);
 }
 ManglingError Remangler::mangleOpaqueType(Node *node, unsigned depth) {
-  DEMANGLER_ASSERT(node->getNumChildren() >= 2, node);
-  Buffer << "Qo";
-  mangleIndex(node->getChild(1)->getIndex());
-  RETURN_IF_ERROR(mangle(node->getChild(0), depth + 1));
-  if (node->getNumChildren() >= 3) {
-    Node *boundGenerics = node->getChild(2);
-    for (unsigned i = 0, e = boundGenerics->getNumChildren(); i < e; ++i)
-      RETURN_IF_ERROR(mangleChildNodes(boundGenerics->getChild(i), depth + 1));
-  }
-  Buffer << '_';
-  return ManglingError::Success;
+  return MANGLING_ERROR(ManglingError::UnsupportedNodeKind, node);
 }
 ManglingError Remangler::mangleOpaqueTypeDescriptor(Node *node,
                                                     unsigned depth) {

--- a/test/Demangle/remangle.swift
+++ b/test/Demangle/remangle.swift
@@ -23,10 +23,3 @@ RUN: swift-demangle -remangle-objc-rt '$sSIxip6foobarP' | %FileCheck -check-pref
 
 // CHECK-GENERICEXT: _TtGCs23_ContiguousArrayStorageGVEsVs15FlattenSequence5IndexGV24StdlibCollectionUnittest30MinimalBidirectionalCollectionGS3_Si_____
 RUN: swift-demangle -remangle-objc-rt '$ss23_ContiguousArrayStorageCys15FlattenSequenceVsE5IndexVy24StdlibCollectionUnittest020MinimalBidirectionalH0VyAIySiGG_GGD' | %FileCheck -check-prefix CHECK-GENERICEXT %s
-
-
-// CHECK-OPAQUE: _TCFF1A5outerFT_T_U_FT_Qo_QOFES_PS_1P8decorateFT_QuVS_4Impl_L_9MenuState
-RUN: swift-demangle -remangle-objc-rt '$s1A5outeryyFAA1PPAAE8decorateQryFQOyAA4ImplV_Qo_yXEfU_9MenuStateL_C' | %FileCheck -check-prefix CHECK-OPAQUE %s
-
-// CHECK-OPAQUE-RT: MenuState #1 in closure #1 () -> <<opaque return type of (extension in A):A.P.decorate() -> some>>.0 in A.outer() -> (){{$}}
-RUN: swift-demangle '_TCFF1A5outerFT_T_U_FT_Qo_QOFES_PS_1P8decorateFT_QuVS_4Impl_L_9MenuState' | %FileCheck -check-prefix CHECK-OPAQUE-RT %s

--- a/test/IRGen/objc_runtime_name_local_class_opaque_type.swift
+++ b/test/IRGen/objc_runtime_name_local_class_opaque_type.swift
@@ -29,6 +29,19 @@ func returnsClass3() {
   _ = c
 }
 
+func returnsClass4() {
+  let c: @MainActor () -> Void = {
+    class MyClass4: MyProtocol {}
+    _ = MyClass4()
+  }
+  _ = c
+}
+
 // CHECK: @_DATA__TtCF41objc_runtime_name_local_class_opaque_type13returnsClass1FT_QuL_8MyClass1 = internal constant
 // CHECK: @_DATA__TtCF41objc_runtime_name_local_class_opaque_typeg13returnsClass2QuL_8MyClass2 = internal constant
-// CHECK: @{{[A-Za-z0-9_.]+}} = {{(private|internal)}} {{(unnamed_addr )?}}constant [{{[0-9]+}} x i8] c"_TtC{{[^"]*}}MyClass3\00", section "__TEXT,__objc_classname,cstring_literals"
+// MyClass3 is nested in a scope that the old mangler can't represent (an
+// opaque type), so the runtime name falls back to the new mangling.
+// CHECK: @{{.*}} = {{(private|internal)}} {{(unnamed_addr )?}}constant [{{[0-9]+}} x i8] c"$s41objc_runtime_name_local_class_opaque_type13returnsClass3yyFAA10MyProtocolPAAE8decorateQryFQOyAA4ImplV_Qo_ycfU_0jI0L_C\00", section "__TEXT,__objc_classname,cstring_literals"
+// MyClass4 is nested in a global-actor-isolated function type, which the old
+// mangler can't represent either, so it also falls back to the new mangling.
+// CHECK: @{{.*}} = {{(private|internal)}} {{(unnamed_addr )?}}constant [{{[0-9]+}} x i8] c"$s41objc_runtime_name_local_class_opaque_type13returnsClass4yyFyyScMYccfU_02MyI0L_C\00", section "__TEXT,__objc_classname,cstring_literals"


### PR DESCRIPTION
Revert the support for opaque types in the old mangler. There are too many new cases the old mangler doesn't handle. Instead, let the old mangler handle things it can handle, and use the new mangling for anything it can't. The old mangling only exists so that existing classes have a stable mangled name. Classes that the old mangler couldn't handle weren't getting a useful name in the first place, so there's nothing to preserve. The new mangling will be stable for them.

rdar://178851613