### PR TITLE
[6.4][CSSimplify] Increase score of invalid property wrapper fixes

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -11959,7 +11959,8 @@ ConstraintSystem::simplifyPropertyWrapperConstraint(
     if (shouldAttemptFixes()) {
       auto *fix = AllowInvalidPropertyWrapperType::create(
           *this, wrapperType, getConstraintLocator(locator));
-      if (!recordFix(fix))
+      // The impact here matches that of a missing member, because it's the same problem.
+      if (!recordFix(fix, /*impact=*/5))
         return SolutionKind::Solved;
     }
 
@@ -11973,8 +11974,10 @@ ConstraintSystem::simplifyPropertyWrapperConstraint(
       !(typeInfo.projectedValueVar && typeInfo.hasProjectedValueInit)) {
     if (shouldAttemptFixes()) {
       auto *fix = RemoveProjectedValueArgument::create(
-          *this, wrapperType, cast<ParamDecl>(wrappedVar), getConstraintLocator(locator));
-      if (!recordFix(fix))
+          *this, wrapperType, cast<ParamDecl>(wrappedVar),
+          getConstraintLocator(locator));
+      // The impact here matches that of a missing member, because it's the same problem.
+      if (!recordFix(fix, /*impact=*/5))
         return SolutionKind::Solved;
     }
 

--- a/validation-test/IDE/crashers_fixed/InterfaceTypeRequest-cacheResult-26ba10.swift
+++ b/validation-test/IDE/crashers_fixed/InterfaceTypeRequest-cacheResult-26ba10.swift
@@ -1,5 +1,5 @@
 // {"kind":"complete","original":"9af9ff34","signature":"swift::InterfaceTypeRequest::cacheResult(swift::Type) const","signatureAssert":"Assertion failed: (!type->is<InOutType>() && \"Interface type must be materializable\"), function cacheResult","signatureNext":"WithSolutionSpecificVarTypesRAII::setInterfaceType"}
-// RUN: not --crash %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -source-filename %s
+// RUN: %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -source-filename %s
 [
   [
     #^^#

--- a/validation-test/Sema/SwiftUI/rdar148350982.swift
+++ b/validation-test/Sema/SwiftUI/rdar148350982.swift
@@ -1,0 +1,37 @@
+// RUN: %target-typecheck-verify-swift -target %target-cpu-apple-macosx10.15
+// REQUIRES: objc_interop
+// REQUIRES: OS=macosx
+
+import SwiftUI
+
+final class Item: Identifiable, ObservableObject {
+  var id = 42
+  var text: String
+
+  init(index: Int) {
+    self.text = "Item \(index)"
+  }
+}
+
+enum MessageKind: CaseIterable, Hashable, Identifiable {
+  var id: Self { self }
+
+  case channel
+  case system
+}
+
+struct ContentView: View {
+  @State var items = (0..<100).map { Item(index: $0) }
+  var body: some View {
+    List {
+      ForEach($items) { $item in
+        HStack {
+          Text(item.text)
+          ForEach(MessageKind.allCases) { kind in
+            Text("\(kind.noSuchMember)") // expected-error {{value of type 'MessageKind' has no member 'noSuchMember'}}
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
- Explanation:

  Incorrect use of `$` should result in a fix that is scored the same as a missing member would when the type doesn't support such access.

- Resolves: rdar://148350982

- Main Branch PR: https://github.com/swiftlang/swift/pull/89847

- Risk: No risk, this is a narrow diagnostic mode change.

- Reviewed By: @hamishknight 

- Testing: Added new test-cases to the suite.

(cherry picked from commit 7c60e749d8314db5b6337545403df50a00b41b20)

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
