### PR TITLE
[6.4] [Sema] Allow member on opaque parameter type

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6639,6 +6639,9 @@ ERROR(invalid_isolated_and_convention_attributes,none,
       (StringRef))
 GROUPED_ERROR(unreferenced_generic_parameter,NoUsage,NoUsage,
       "generic parameter '%0' is not used in function signature", (StringRef))
+ERROR(non_inferrable_opaque_generic_parameter,none,
+      "opaque generic parameter %0 appears in position that cannot be inferred "
+      "from a function call", (TypeRepr *))
 ERROR(unexpected_ctype_for_non_c_convention,none,
       "convention '%0' does not support the 'cType' argument label, did you "
       "mean '@convention(c, cType: \"%1\")' or "

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -674,8 +674,8 @@ void TypeChecker::checkReferencedGenericParams(GenericContext *dc) {
       if (paramDecl->isOpaqueType()) {
         paramDecl->getASTContext().Diags
           .diagnose(paramDecl->getOpaqueTypeRepr()->getLoc(),
-                    diag::unreferenced_generic_parameter,
-                    paramDecl->getNameStr());
+                    diag::non_inferrable_opaque_generic_parameter,
+                    paramDecl->getOpaqueTypeRepr());
       } else {
         paramDecl->diagnose(diag::unreferenced_generic_parameter,
                             paramDecl->getNameStr());

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -2539,11 +2539,15 @@ TypeResolver::resolveQualifiedIdentTypeRepr(Type parentTy,
 
   // Short-circuiting.
   if (repr->isInvalid()) return ErrorType::get(ctx);
-  // Reject member type access only when the base is explicitly written as an
-  // opaque type, e.g. `(some P).T`.
+  // Reject member type access only when the base is both explicitly written as
+  // an opaque type and resolves to an opaque archetype, e.g. `(some P).T` in
+  // result/binding position. Accessing a member on an opaque parameter,
+  // e.g. `func foo(_: (some P).S)`, is sugar for a generic parameter and is
+  // well-formed.
   auto *baseRepr = repr->getBase()->getWithoutParens();
-  if (isa<OpaqueReturnTypeRepr>(baseRepr) ||
-      isa<NamedOpaqueReturnTypeRepr>(baseRepr)) {
+  if ((isa<OpaqueReturnTypeRepr>(baseRepr) ||
+       isa<NamedOpaqueReturnTypeRepr>(baseRepr)) &&
+      parentTy->is<OpaqueTypeArchetypeType>()) {
     if (!options.contains(TypeResolutionFlags::SilenceDiagnostics)) {
       diagnose(repr->getNameLoc(), diag::opaque_type_member_type,
                repr->getNameRef(), parentTy)

--- a/test/Sema/opaque_member_type.swift
+++ b/test/Sema/opaque_member_type.swift
@@ -10,3 +10,23 @@ struct S: P {
 }
 
 let spt: (some P).T = S().t // expected-error {{cannot access member type}}
+
+struct S2<T> {}
+
+protocol Q {}
+
+extension Q {
+  typealias X = S2<Self>
+}
+
+protocol R {
+  associatedtype X
+}
+
+// These are fine, `some Q` is implicitly a generic parameter.
+func asParameter1(_: (some Q).X) {}
+func asParameter2(_: [(some Q).X]) {}
+
+// This is not fine, there is no way to infer the generic parameter.
+// FIXME: We ought to have a better diagnostic for this.
+func asParameter3(_: (some R).X) {} // expected-error {{generic parameter '_' is not used in function signature}}

--- a/test/Sema/opaque_member_type.swift
+++ b/test/Sema/opaque_member_type.swift
@@ -28,5 +28,4 @@ func asParameter1(_: (some Q).X) {}
 func asParameter2(_: [(some Q).X]) {}
 
 // This is not fine, there is no way to infer the generic parameter.
-// FIXME: We ought to have a better diagnostic for this.
-func asParameter3(_: (some R).X) {} // expected-error {{generic parameter '_' is not used in function signature}}
+func asParameter3(_: (some R).X) {} // expected-error@:23 {{opaque generic parameter 'some R' appears in position that cannot be inferred from a function call}}


### PR DESCRIPTION
*6.4 cherry-pick of #89845*

- Explanation: Fixes an issue where the type-checker would incorrectly reject member types on opaque generic parameters, which were previously valid in 6.3. Also improves the wording of a diagnostic.
- Scope: Affects member types on opaque generic parameters
- Issue: rdar://179028131, https://github.com/swiftlang/swift/issues/89777
- Risk: Low, strictly diagnoses in fewer cases, matching the 6.3 behavior in this particular case
- Testing: Added tests to test suite
- Reviewer: Pavel Yaskevich