### PR TITLE
[Sema] Pre-check capture list bindings inside macro expansion buffers

### DIFF
--- a/lib/Sema/PreCheckTarget.cpp
+++ b/lib/Sema/PreCheckTarget.cpp
@@ -1170,6 +1170,12 @@ class PreCheckTarget final : public ASTWalker {
   ASTContext &Ctx;
   DeclContext *DC;
 
+  /// The location of the target being pre-checked. Used to recognize when the
+  /// walk itself targets code inside a macro expansion buffer, in which case
+  /// declarations belonging to that same buffer are part of the target and
+  /// must be walked rather than skipped as macro-generated.
+  SourceLoc TargetLoc;
+
   /// A stack of expressions being walked, used to determine where to
   /// insert RebindSelfInConstructorExpr nodes.
   llvm::SmallVector<Expr *, 8> ExprStack;
@@ -1248,12 +1254,13 @@ class PreCheckTarget final : public ASTWalker {
   /// expressions do nothing.
   void transformForExpression(SingleValueStmtExpr *E);
 
-  PreCheckTarget(DeclContext *dc) : Ctx(dc->getASTContext()), DC(dc) {}
+  PreCheckTarget(DeclContext *dc, SourceLoc targetLoc)
+      : Ctx(dc->getASTContext()), DC(dc), TargetLoc(targetLoc) {}
 
 public:
   static std::optional<SyntacticElementTarget>
   check(const SyntacticElementTarget &target) {
-    PreCheckTarget checker(target.getDeclContext());
+    PreCheckTarget checker(target.getDeclContext(), target.getLoc());
     auto newTarget = target.walk(checker);
     if (!newTarget)
       return std::nullopt;
@@ -1268,6 +1275,25 @@ public:
 
   MacroWalking getMacroWalkingBehavior() const override {
     return MacroWalking::Arguments;
+  }
+
+  bool isDeclInMacroExpansion(Decl *decl) const override {
+    if (!ASTWalker::isDeclInMacroExpansion(decl))
+      return false;
+
+    // The pre-checked target may itself be code in a macro expansion buffer,
+    // e.g. the rewritten expression of an expression macro. Declarations that
+    // live in the same buffer as the target - such as the pattern bindings of
+    // a closure's capture list - are part of the target and must be walked;
+    // treating them as foreign macro-generated declarations would leave their
+    // initializers unresolved when they reach the constraint system.
+    auto declLoc = decl->getLoc();
+    if (TargetLoc.isInvalid() || declLoc.isInvalid())
+      return true;
+
+    auto &SM = Ctx.SourceMgr;
+    return SM.findBufferContainingLoc(declLoc) !=
+           SM.findBufferContainingLoc(TargetLoc);
   }
 
   VarDecl *getImplicitSelfDeclForSuperContext(SourceLoc Loc);

--- a/test/Macros/macro_expand_closure_capture_list.swift
+++ b/test/Macros/macro_expand_closure_capture_list.swift
@@ -1,0 +1,121 @@
+// REQUIRES: swift_swift_parser
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %t/macro.swift -g -no-toolchain-stdlib-rpath
+
+// RUN: %target-swift-frontend -typecheck -verify -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) %t/main.swift
+
+// A closure with a capture list used as a macro argument must type-check:
+// the capture list's pattern bindings belong to the expansion buffer being
+// checked and used to be skipped as macro-generated declarations, leaving
+// their initializers unresolved and failing with "failed to produce
+// diagnostic for expression".
+// https://github.com/swiftlang/swift/issues/86871
+// https://github.com/swiftlang/swift/issues/80050
+
+//--- macro.swift
+
+import SwiftSyntax
+import SwiftSyntaxMacros
+
+public struct CallClosureMacro: ExpressionMacro {
+  public static func expansion(
+    of node: some FreestandingMacroExpansionSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> ExprSyntax {
+    guard let closure = node.trailingClosure else {
+      fatalError("#callClosure requires a trailing closure")
+    }
+    return "(\(closure.trimmed))()"
+  }
+}
+
+public struct WrapMacro: ExpressionMacro {
+  public static func expansion(
+    of node: some FreestandingMacroExpansionSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> ExprSyntax {
+    guard let closure = node.trailingClosure else {
+      fatalError("#wrap requires a trailing closure")
+    }
+    return "wrap(\(closure.trimmed))"
+  }
+}
+
+public struct NoOpBodyMacro: BodyMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingBodyFor declaration: some DeclSyntaxProtocol & WithOptionalCodeBlockSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> [CodeBlockItemSyntax] {
+    declaration.body.map { Array($0.statements) } ?? []
+  }
+}
+
+//--- main.swift
+
+@freestanding(expression)
+macro callClosure(_ body: () -> Void) = #externalMacro(module: "MacroDefinition", type: "CallClosureMacro")
+
+func wrap<T>(_ body: @escaping () -> T) -> () -> T { body }
+
+@freestanding(expression)
+macro wrap<T>(_ body: @escaping () -> T) -> () -> T = #externalMacro(module: "MacroDefinition", type: "WrapMacro")
+
+@attached(body)
+macro NoOpBody() = #externalMacro(module: "MacroDefinition", type: "NoOpBodyMacro")
+
+func shorthandCaptureOfLocal() {
+  var x = 1
+  #callClosure { [x] in _ = x }
+  x += 1
+  _ = x
+}
+
+func explicitInitializerCapture() {
+  let x = 2
+  #callClosure { [y = x] in _ = y }
+}
+
+func parameterCapture(value: Int) {
+  #callClosure { [value] in _ = value }
+}
+
+final class Object {
+  func weakCapture() {
+    #callClosure { [weak self] in _ = self }
+  }
+}
+
+func bodyOnlyReference() {
+  let x = 4
+  #callClosure { _ = x }
+}
+
+func nestedClosureCapture() {
+  let x = 5
+  #callClosure {
+    let inner = { [x] in _ = x }
+    inner()
+  }
+}
+
+// https://github.com/swiftlang/swift/issues/86871
+func genericWrap() {
+  let y = 42
+  _ = wrap({ [y] in y })
+  _ = #wrap { [y] in y }
+}
+
+// https://github.com/swiftlang/swift/issues/80050
+class Demo {
+  @NoOpBody
+  func demo() {
+    let closure = { [weak self] in
+      _ = self
+    }
+    _ = closure
+  }
+}


### PR DESCRIPTION
Macro expansions fail to type check when a closure in the expanded code has a capture list whose entries reference declarations from outside the expansion buffer, surfacing as "type of expression is ambiguous" or "failed to produce diagnostic for expression". The identical code written by hand compiles.

`Traversal::shouldSkip(Decl *)` skips declarations that are in a macro expansion when the walker does not walk into expansions. `PreCheckTarget` (`MacroWalking::Arguments`) trips this guard while pre-checking *the expansion itself*: the capture list's `PatternBindingDecl`s are the only `Decl`s in an expression tree, so they are skipped, and their initializers reach the constraint system as unresolved declaration references that can only be solved as holes whose fix produces no diagnostic. Closure bodies contain no `Decl`s, which is why every other reference in a buffer resolves fine.

This PR teaches `PreCheckTarget` to recognize declarations that live in the same buffer as the target being checked: those are part of the target, not foreign macro-generated declarations. Declarations from other expansion buffers keep being skipped, preserving the guard's purpose. This restores parity with hand-written code, in the same spirit as the availability-scope fix in #77517 and adjacent to #88741.

The regression test covers shorthand/explicit/`weak`/parameter captures, a nested-closure contrast case, the generic reproducer from #86871, and the body-macro reproducer from #80050.

Resolves #86871
Fixes #80050

(cc @hamishknight @xedin — #76193/#88741 touch the same walker behavior; a `@swift-ci please smoke test` from someone with access would be appreciated.)
