### PR TITLE
[AST]: fix typo in self param capture isolation logic

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -12582,7 +12582,7 @@ bool VarDecl::isSelfParamCaptureIsolated() const {
       case ActorIsolation::ActorInstance:
         auto isolatedVar = isolation.getActorInstance();
         return isolatedVar->isSelfParameter() ||
-            isolatedVar-isSelfParamCapture();
+               isolatedVar->isSelfParamCapture();
       }
     }
 

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -1898,3 +1898,27 @@ class GlobalDefaultIsolationTest {
   // expected-error@-1 {{actor-isolated default value in a global actor 'SomeGlobalActor'-isolated context}}
 }
 
+// Regression test for https://github.com/swiftlang/swift/issues/89855
+
+enum GH_89855 {
+  actor A {
+      var state = 0
+      // expected-note@-1 {{mutation of this property is only permitted within the actor}}
+
+      func f(_ b: isolated B) {
+          let bIso = {
+              _ = b
+              let bug = { [self] in
+                  // Previously this was 'self-isolated'
+                  self.state += 1 // So this was allowed
+                  // expected-error@-1 {{actor-isolated property 'state' can not be mutated from a nonisolated context}}
+                  self.preconditionIsolated() // 💥 But this crashed
+              }
+              bug()
+          }
+          bIso()
+      }
+  }
+
+  actor B {}
+}

--- a/test/SILGen/actor_isolation_issue-89855.swift
+++ b/test/SILGen/actor_isolation_issue-89855.swift
@@ -1,0 +1,34 @@
+// RUN: %target-swift-emit-silgen -Xllvm -sil-print-function-isolation-info %s -swift-version 6 -target %target-swift-5.1-abi-triple | %FileCheck %s
+
+// REQUIRES: concurrency
+
+// Regression test for https://github.com/swiftlang/swift/issues/89855
+
+// CHECK-LABEL: sil private [isolation "@concurrent"] [ossa] @$s4main1CC1fyyScA_pYiYaFyycfU_yyYacfU_ : $@convention(thin) @async (@guaranteed C) -> () {
+final class C {
+  func f(_ other: isolated any Actor) async {
+    let _ = {
+      _ = other
+      let _ = { [self] () async in
+        // Previously, this closure would be "self-isolated" to a non-actor value.
+        _ = self
+      }
+    }
+  }
+}
+
+// CHECK-LABEL: sil private [isolation "actor_instance"] [ossa] @$s4main1AC1fyyScA_pYiFyycfU_yycfU_ : $@convention(thin) (@guaranteed A, @sil_isolated @guaranteed any Actor) -> () {
+actor A {
+    func f(_ other: isolated any Actor) {
+        let otherIso = {
+            _ = other
+            let bug = { [self] in
+              // Previously, this closure would be "self-isolated" instead of "other-isolated".
+              _ = self
+              _ = other
+            }
+            bug()
+        }
+        otherIso()
+    }
+}


### PR DESCRIPTION
A typo in the logic for evaluating self-capture isolation could result in an invalid type being used as the inferred "self-isolated" value. I believe there are cases in which this could have led to miscompilation, though the scenario seems somewhat unusual. For example, this was previously permitted, which allows an actor's state to be mutated from within a call isolated to a different actor:

```swift
actor A {
    var state = 0

    func f(_ b: isolated B) {
        let bIso = {
            _ = b
            let bug = { [self] () in
                // Previously this was 'self-isolated'
                self.state += 1 // So this was allowed
                self.preconditionIsolated() // 💥 But this crashed
            }
            bug()
        }
        bIso()
    }
}

actor B {}
```

After this change, the innermost closure is no longer actor-isolated unless it captures the isolated parameter, in which case it will be isolated to that actor, as expected.

Resolves https://github.com/swiftlang/swift/issues/89855
