### PR TITLE
[6.4] Sema: Don't produce spurious diagnostic when an opaque result has an invalid constraint type

### DIFF
--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -185,8 +185,10 @@ OpaqueResultTypeRequest::evaluate(Evaluator &evaluator,
                                 /*packElementOpener*/ nullptr)
                                 .resolveType(constraint);
 
-      if (constraintType->hasError())
+      if (constraintType->hasError()) {
+        currentRepr->setInvalid();
         return nullptr;
+      }
 
       RequirementKind kind;
       if (constraintType->isConstraintType())

--- a/test/type/opaque.swift
+++ b/test/type/opaque.swift
@@ -609,3 +609,13 @@ do {
     // expected-error@-1 {{return type of local function 'test3()' requires that 'S' inherit from 'A'}}
   }
 }
+
+// https://github.com/swiftlang/swift/issues/89853 - Make sure we don't emit a
+// second spurious diagnostic in the below cases:
+do {
+  func f1() -> some P3<Int, String> {}
+  // expected-error@-1 {{protocol type 'P3' specialized with too many type arguments (got 2, but expected 1)}}
+
+  func f2() -> some P33333 {}
+  // expected-error@-1 {{cannot find type 'P33333' in scope}}
+}


### PR DESCRIPTION
6.4 cherry-pick of https://github.com/swiftlang/swift/pull/89857

* **Description:** As the bug report says, we would emit a second bogus `'some' types are only permitted in properties, subscripts, and functions` error, even though the `some` was clearly in this position already, and the problem was that the type that follows was invalid.

* **Origination:** Always broken.

* **Risk:** Extremely low, the change is to an error path.

* **Reviewed by:** @jckarter 

* **Bugs:**

- Fixes https://github.com/swiftlang/swift/issues/89853.
- Fixes rdar://179302087.