### PR TITLE
[6.4] Sema: Remove unnecessary assertion

### DIFF
--- a/include/swift/Sema/CSBindings.h
+++ b/include/swift/Sema/CSBindings.h
@@ -139,12 +139,10 @@ struct PotentialBinding {
   }
 
   PotentialBinding withSameSource(Type type, AllowedBindingKind kind) const {
-    ASSERT(kind != AllowedBindingKind::Fallback);
     return {type, kind, BindingSource, Originator};
   }
 
   PotentialBinding asTransitiveFrom(TypeVariableType *originator) const {
-    ASSERT(Kind != AllowedBindingKind::Fallback);
     ASSERT(originator);
     return {BindingType, Kind, BindingSource, originator};
   }

--- a/test/Constraints/keypath.swift
+++ b/test/Constraints/keypath.swift
@@ -383,3 +383,14 @@ func test_transitive_key_path_root_inference2(x: Int?) -> any Shape {
   let shape = x.map(Polygon.init).map(\.shape) ?? Empty()
   return shape
 }
+
+// Interaction between closure return defaulting to Void and keypath
+// root inference
+func rdar174707424() {
+  @discardableResult
+  func f<N, V>(_ n: N, _ kp: KeyPath<N, V>) -> N { n }
+
+  let _: (S) -> Void = {
+    f($0, \.i)
+  }
+}


### PR DESCRIPTION
* **Description:** When I introduced `AllowedBindingKind::Fallback` I added asserts against it in a bunch of places while I worked on improving test coverage and working out the behavior. I think the test coverage is reasonable now and I don't think there is any real reason to prohibit fallback bindings in this specific spot, so I think it's fine to just remove these asserts.

* **Origination:** New regression in 6.4.

* **Risk:** None.

* **Tested:** Test case from radar.

* **Radar:** Fixes rdar://174707424.