### PR TITLE
[6.4][Distributed] @R must properly handle #if ... blocks in protocol

### DIFF
--- a/lib/Macros/Sources/SwiftMacros/DistributedResolvableMacro.swift
+++ b/lib/Macros/Sources/SwiftMacros/DistributedResolvableMacro.swift
@@ -56,22 +56,8 @@ extension DistributedResolvableMacro {
         attr.as(AttributeSyntax.self)?.attributeName.trimmed.description ?? ""
       )
     }
-    let accessModifiers = proto.accessControlModifiers
-
-    let requirementStubs =
-      proto.memberBlock.members // requirements
-        .filter { member in
-          switch member.decl.kind {
-          case .functionDecl: return true
-          case .variableDecl: return true
-          default:
-            return false
-          }
-        }
-        .map { member in
-          stubMethodDecl(access: accessModifiers, member.trimmed)
-        }
-        .joined(separator: "\n    ")
+    let access = proto.accessControlModifiers
+    let requirementStubs = stubsFor(members: proto.memberBlock.members, access: access)
 
     let extensionDecl: DeclSyntax =
       """
@@ -81,6 +67,40 @@ extension DistributedResolvableMacro {
       }
       """
     return [extensionDecl.cast(ExtensionDeclSyntax.self)]
+  }
+
+  /// Returns rendered string with all stub declarations for given members.
+  /// This includes any necessary #if/#endif guards that the original protocol might have.
+  private static func stubsFor(
+    members: MemberBlockItemListSyntax,
+    access: DeclModifierListSyntax
+  ) -> String {
+    var parts: [String] = []
+    for member in members {
+      if let ifConfig = member.decl.as(IfConfigDeclSyntax.self) {
+        // emit the '#if ...' exactly as in the original protocol.
+        var ifConfigBlock = ""
+        for clause in ifConfig.clauses {
+          let kw = clause.poundKeyword.text
+          if let cond = clause.condition {  // #if or #elseif
+            ifConfigBlock += "\(kw) \(cond.trimmed)\n"
+          } else {
+            ifConfigBlock += "\(kw)\n"
+          }
+          if let innerMembers = clause.elements?.as(MemberBlockItemListSyntax.self) {
+            // recurse, there may be more nested #if conditions, or just the actual decls
+            ifConfigBlock += stubsFor(members: innerMembers, access: access)
+            ifConfigBlock += "\n"
+          }
+        }
+        ifConfigBlock += "#endif"
+        parts.append(ifConfigBlock)
+      } else if member.decl.is(FunctionDeclSyntax.self) ||
+                member.decl.is(VariableDeclSyntax.self) {
+        parts.append(stubMethodDecl(access: access, member.trimmed))
+      }
+    }
+    return parts.joined(separator: "\n    ")
   }
 
   static func stubMethodDecl(access: DeclModifierListSyntax, _ requirement: MemberBlockItemListSyntax.Element) -> String {

--- a/test/Distributed/Macros/distributed_macro_expansion_DistributedProtocol_IfConfigMembers.swift
+++ b/test/Distributed/Macros/distributed_macro_expansion_DistributedProtocol_IfConfigMembers.swift
@@ -1,0 +1,90 @@
+// REQUIRES: swift_swift_parser, asserts
+//
+// UNSUPPORTED: back_deploy_concurrency
+// REQUIRES: concurrency
+// REQUIRES: distributed
+//
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// The @Resolvable macro must properly handle #if ... blocks.
+//
+// Feature is disabled:
+// RUN: %target-swift-frontend -typecheck -target %target-swift-6.0-abi-triple -plugin-path %swift-plugin-dir -dump-macro-expansions %t/Protocol.swift %t/Server.swift 2>&1 | %FileCheck %s
+//
+// Feature OUTER is enabled:
+// RUN: %target-swift-frontend -typecheck -target %target-swift-6.0-abi-triple -plugin-path %swift-plugin-dir -D OUTER %t/Protocol.swift %t/Server.swift
+//
+// Nested #if branches (OUTER, INNER):
+// RUN: %target-swift-frontend -typecheck -target %target-swift-6.0-abi-triple -plugin-path %swift-plugin-dir -D OUTER %t/Protocol.swift %t/Server.swift
+// RUN: %target-swift-frontend -typecheck -target %target-swift-6.0-abi-triple -plugin-path %swift-plugin-dir -D OUTER -D INNER %t/Protocol.swift %t/Server.swift
+
+//--- Protocol.swift
+import Distributed
+
+@Resolvable
+public protocol MyService: DistributedActor
+  where ActorSystem: DistributedActorSystem<any Codable> {
+  distributed func always() async -> String
+#if OUTER
+  distributed func outer() async -> String
+#endif
+}
+
+// CHECK: extension MyService where Self: Distributed._DistributedActorStub {
+// CHECK:   public distributed func always() async -> String {
+// CHECK:   }
+// CHECK:   #if OUTER
+// CHECK:   public distributed func outer() async -> String {
+// CHECK:   }
+// CHECK:   #endif
+// CHECK: }
+
+
+@Resolvable
+public protocol MyNestedService: DistributedActor
+  where ActorSystem: DistributedActorSystem<any Codable> {
+  distributed func always() async -> String
+#if OUTER
+  distributed func outer() async -> String
+  #if INNER
+  distributed func inner() async -> String
+  #endif
+#endif
+}
+
+// CHECK: extension MyNestedService where Self: Distributed._DistributedActorStub {
+// CHECK:   public distributed func always() async -> String {
+// CHECK:   }
+// CHECK:   #if OUTER
+// CHECK:   public distributed func outer() async -> String {
+// CHECK:   }
+// CHECK:   #if INNER
+// CHECK:   public distributed func inner() async -> String {
+// CHECK:   }
+// CHECK:   #endif
+// CHECK:   #endif
+// CHECK: }
+//--- Server.swift
+import Distributed
+
+public distributed actor MyServer: MyService {
+  public typealias ActorSystem = LocalTestingDistributedActorSystem
+
+  public distributed func always() async -> String { "always" }
+#if OUTER
+  public distributed func outer() async -> String { "outer" }
+#endif
+}
+
+public distributed actor MyNestedServer: MyNestedService {
+  public typealias ActorSystem = LocalTestingDistributedActorSystem
+
+  public distributed func always() async -> String { "always" }
+#if OUTER
+  public distributed func outer() async -> String { "outer" }
+  #if INNER
+  public distributed func inner() async -> String { "inner" }
+  #endif
+#endif
+}


### PR DESCRIPTION
**Explanation**: 
We fix this by just mirroring the #ifs into the generated $Proxy type, because if the requirement is there, the stub must be as well. But we don't really need to understand the conditions, we just need to emit the same conditions in the stub.

This prevented developers from using distributed functions where they have to guard methods with `#if SOME_FEATURE` blocks.


**Scope**: 
- Distributed's `@Resolvable` macro specifically

**Risk**: 
- Low, fixes specific new code handling that the macro didn't handle before
- no impact on other aspects of the language; just the macro handling `#if ...` blocks

**Testing**: 
- CI testing, added tests

**Original PR**:
- https://github.com/swiftlang/swift/pull/89860

**Reviewed by**:
- @xedin 

**Issues**: 
- Resolves rdar://179290387