### PR TITLE
[ClangImporter] don't crash on duplicate @c @implementation

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -6619,7 +6619,10 @@ constructResult(const llvm::TinyPtrVector<Decl *> &interfaces,
 
     auto &diags = interfaces.front()->getASTContext().Diags;
     for (auto extraImpl : llvm::ArrayRef<Decl *>(impls).drop_front()) {
-      auto attr = extraImpl->getAttrs().getAttribute<ObjCImplementationAttr>();
+      auto attr = extraImpl->getAttrs().getAttribute<ObjCImplementationAttr>(
+          /*AllowInvalid=*/true);
+      if (attr->isInvalid())
+        continue;
       attr->setInvalid();
 
       // @objc @implementations for categories are diagnosed as category

--- a/test/decl/ext/Inputs/objc_implementation.h
+++ b/test/decl/ext/Inputs/objc_implementation.h
@@ -244,6 +244,8 @@ void CImplFuncRenamed_C(int param) __attribute__((swift_name("CImplFuncRenamed_S
 void CImplFuncMismatch1(int param);
 void CImplFuncMismatch2(int param);
 
+void CImplDuplicate(int param);
+
 #if __OBJC__
 void CImplFuncMismatch3(_Nullable id param);
 void CImplFuncMismatch4(_Nullable id param);

--- a/test/decl/ext/cdecl_official_implementation.swift
+++ b/test/decl/ext/cdecl_official_implementation.swift
@@ -81,3 +81,13 @@ extension CImplStruct {
     // expected-error@-5 {{could not find imported function 'CImplStructStaticFunc1' matching static method 'staticFunc1'; make sure you import the module or header that declares it}}
   }
 }
+
+@implementation @c
+func CImplDuplicate(_: CInt) {
+// expected-note@-1{{previously implemented here}}
+}
+
+@implementation @c
+func CImplDuplicate(_: CInt) {
+// expected-error@-2 {{duplicate implementation of imported global function 'CImplDuplicate'}}
+}


### PR DESCRIPTION
With multiple `@implementation`s we only cache the result of the first one. When there are multiple identical decls this means that we can end up processing the same set of functions more than once. The first time around every implementation other than the first one have their `@implementation` attributes marked invalid. When we tried to fetch their attributes the second time around we would get a null pointer due to the default parameter `AllowInvalid` being false, and then we'd try to set this to be invalid, dereferencing the null pointer.

rdar://179314042