### PR TITLE
SimplifyCFG: Extract enum payload with unchecked_enum_data

### DIFF
--- a/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
+++ b/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
@@ -509,21 +509,27 @@ bool SimplifyCFG::simplifyThreadedTerminators() {
         auto *LiveBlock = SEI->getCaseDestination(EI->getElement());
         if (!LiveBlock->args_empty()) {
           auto *LiveBlockArg = LiveBlock->getArgument(0);
+
+          auto builder = SILBuilderWithScope(SEI);
+
           // The default block receives the whole enum value, not the extracted
           // payload. Only use the payload for explicitly matched case blocks.
+          //
+          // Use unchecked_enum_data to extract the payload instead of using the
+          // enum instruction's operand, to avoid over-consuming the operand if
+          // the enum has other users.
           bool isDefaultBlock = SEI->hasDefault() && LiveBlock == SEI->getDefaultBB();
           SILValue NewValue = (!isDefaultBlock && EI->hasOperand())
-                                  ? EI->getOperand()
+                                  ? builder.createUncheckedEnumData(
+                                        SEI->getLoc(), EI, EI->getElement())
                                   : SILValue(EI);
           LiveBlockArg->replaceAllUsesWith(NewValue);
           LiveBlock->eraseArgument(0);
-          SILBuilderWithScope(SEI).createBranch(SEI->getLoc(), LiveBlock);
+          builder.createBranch(SEI->getLoc(), LiveBlock);
         } else {
           SILBuilderWithScope(SEI).createBranch(SEI->getLoc(), LiveBlock);
         }
         SEI->eraseFromParent();
-        if (EI->use_empty())
-          EI->eraseFromParent();
         HaveChangedCFG = true;
       }
       continue;

--- a/test/SILOptimizer/simplify_switch_enum_objc.swift
+++ b/test/SILOptimizer/simplify_switch_enum_objc.swift
@@ -3,7 +3,6 @@
 
 // REQUIRES: objc_interop
 // REQUIRES: swift_stdlib_no_asserts,optimized_stdlib
-// REQUIRES: rdar114110966
 
 import Foundation
 
@@ -66,5 +65,22 @@ public class InClass {
 // CHECK:  return
   public func testOptionalShortCut2() {
     t?.other?.other = v?.other?.other
+  }
+}
+
+// Regression test for rdar://177840176
+class Baz {
+    @objc dynamic func bar(_ title: String?) {}
+}
+
+class Qux {
+  var baz: Baz!
+  func foo(strings: [String]?) {
+    guard strings?.isEmpty ?? false else { return }
+    let firstString = strings?[0]
+    baz.bar(firstString)
+    baz.bar(firstString)
+
+    guard strings?.isEmpty ?? false else { return }
   }
 }


### PR DESCRIPTION
This prevents an over-consumption of an owned payload if the enum has other users.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
