### PR TITLE
[Sema] Use target's start location to create the implicit CodingKeys enum.

### DIFF
--- a/lib/Sema/DerivedConformance/DerivedConformanceCodable.cpp
+++ b/lib/Sema/DerivedConformance/DerivedConformanceCodable.cpp
@@ -167,14 +167,14 @@ addImplicitCodingKeys(NominalTypeDecl *target,
     // TODO: Ensure the class doesn't already have or inherit a variable named
     // "`super`"; otherwise we will generate an invalid enum. In that case,
     // diagnose and bail.
-    auto *super = new (C) EnumElementDecl(SourceLoc(), C.Id_super, nullptr,
+    auto *super = new (C) EnumElementDecl(anchorLoc, C.Id_super, nullptr,
                                           SourceLoc(), nullptr, enumDecl);
     super->setImplicit();
     enumDecl->addMember(super);
   }
 
   for (auto caseIdentifier : caseIdentifiers) {
-    auto *elt = new (C) EnumElementDecl(SourceLoc(), caseIdentifier, nullptr,
+    auto *elt = new (C) EnumElementDecl(anchorLoc, caseIdentifier, nullptr,
                                         SourceLoc(), nullptr, enumDecl);
     elt->setImplicit();
     enumDecl->addMember(elt);

--- a/lib/Sema/DerivedConformance/DerivedConformanceCodable.cpp
+++ b/lib/Sema/DerivedConformance/DerivedConformanceCodable.cpp
@@ -170,6 +170,11 @@ addImplicitCodingKeys(NominalTypeDecl *target,
     auto *super = new (C) EnumElementDecl(anchorLoc, C.Id_super, nullptr,
                                           SourceLoc(), nullptr, enumDecl);
     super->setImplicit();
+
+    auto *caseDecl = EnumCaseDecl::create(anchorLoc, {super}, enumDecl);
+    caseDecl->setImplicit();
+
+    enumDecl->addMember(caseDecl);
     enumDecl->addMember(super);
   }
 

--- a/lib/Sema/DerivedConformance/DerivedConformanceCodable.cpp
+++ b/lib/Sema/DerivedConformance/DerivedConformanceCodable.cpp
@@ -177,9 +177,13 @@ addImplicitCodingKeys(NominalTypeDecl *target,
     auto *elt = new (C) EnumElementDecl(anchorLoc, caseIdentifier, nullptr,
                                         SourceLoc(), nullptr, enumDecl);
     elt->setImplicit();
+
+    auto *caseDecl = EnumCaseDecl::create(anchorLoc, {elt}, enumDecl);
+    caseDecl->setImplicit();
+
+    enumDecl->addMember(caseDecl);
     enumDecl->addMember(elt);
   }
-
   // Forcibly derive conformance to CodingKey.
   TypeChecker::checkConformancesInContext(enumDecl);
 

--- a/lib/Sema/DerivedConformance/DerivedConformanceCodable.cpp
+++ b/lib/Sema/DerivedConformance/DerivedConformanceCodable.cpp
@@ -140,7 +140,9 @@ addImplicitCodingKeys(NominalTypeDecl *target,
                       Identifier codingKeysEnumIdentifier) {
   auto &C = target->getASTContext();
   assert(target->lookupDirect(DeclName(codingKeysEnumIdentifier)).empty());
-
+  // use the target start location instead of an invalid location.
+  auto anchorLoc = target->getStartLoc();
+  
   // We want to look through all the var declarations of this type to create
   // enum cases based on those var names.
   auto *codingKeyProto = C.getProtocol(KnownProtocolKind::CodingKey);
@@ -149,8 +151,10 @@ addImplicitCodingKeys(NominalTypeDecl *target,
     InheritedEntry(TypeLoc::withoutLoc(codingKeyType))};
   ArrayRef<InheritedEntry> inherited = C.AllocateCopy(protoTypeLoc);
 
-  auto *enumDecl = new (C) EnumDecl(SourceLoc(), codingKeysEnumIdentifier,
+  auto *enumDecl = new (C) EnumDecl(anchorLoc, codingKeysEnumIdentifier,
                                     SourceLoc(), inherited, nullptr, target);
+
+  enumDecl->setBraces(anchorLoc);
   enumDecl->setImplicit();
   enumDecl->setSynthesized();
   enumDecl->setAccess(AccessLevel::Private);

--- a/test/decl/protocol/special/coding/Inputs/class_codable_simple_multi1.swift
+++ b/test/decl/protocol/special/coding/Inputs/class_codable_simple_multi1.swift
@@ -1,6 +1,8 @@
 // Simple classes with all Codable properties should get derived conformance to
 // Codable.
 class SimpleClass : Codable {
+  // expected-note@-1 {{did you mean 'x'?}}
+  // expected-note@-2 {{did you mean 'y'?}}
   var x: Int = 1
   var y: Double = .pi
   static var z: String = "foo"

--- a/test/decl/protocol/special/coding/Inputs/struct_codable_simple_multi1.swift
+++ b/test/decl/protocol/special/coding/Inputs/struct_codable_simple_multi1.swift
@@ -3,6 +3,8 @@
 // Simple structs with all Codable properties should get derived conformance to
 // Codable.
 struct SimpleStruct : Codable {
+  // expected-note@-1 {{did you mean 'x'?}}
+  // expected-note@-2 {{did you mean 'y'?}}
   var x: Int
   var y: Double
   static var z: String = "foo"
@@ -29,4 +31,3 @@ struct A: Codable {
   var property: String
   static let propertyName = CodingKeys.property.stringValue
 }
-

--- a/test/decl/protocol/special/coding/class_codable_computed_vars.swift
+++ b/test/decl/protocol/special/coding/class_codable_computed_vars.swift
@@ -4,6 +4,7 @@
 // but their lazy and computed members should be skipped as part of the
 // synthesis.
 class ClassWithComputedMembers : Codable {
+  // expected-note@-1 2 {{'x' declared here}}
   var x: Int = 1
   lazy var y: Double = .pi
   var z: String {
@@ -20,10 +21,9 @@ class ClassWithComputedMembers : Codable {
     let _ = ClassWithComputedMembers.CodingKeys.x
 
     // Lazy vars should not be part of the CodingKeys enum.
-    let _ = ClassWithComputedMembers.CodingKeys.y // expected-error {{type 'ClassWithComputedMembers.CodingKeys' has no member 'y'}}
-
+    let _ = ClassWithComputedMembers.CodingKeys.y // expected-error {{type 'ClassWithComputedMembers.CodingKeys' has no member 'y'; did you mean 'x'?}}
     // Computed vars should not be part of the CodingKeys enum.
-    let _ = ClassWithComputedMembers.CodingKeys.z // expected-error {{type 'ClassWithComputedMembers.CodingKeys' has no member 'z'}}
+    let _ = ClassWithComputedMembers.CodingKeys.z // expected-error {{type 'ClassWithComputedMembers.CodingKeys' has no member 'z'; did you mean 'x'?}}
   }
 }
 

--- a/test/decl/protocol/special/coding/class_codable_non_strong_vars.swift
+++ b/test/decl/protocol/special/coding/class_codable_non_strong_vars.swift
@@ -3,6 +3,8 @@
 // Classes with Codable properties (with non-strong ownership) should get
 // derived conformance to Codable.
 class NonStrongClass : Codable {
+  // expected-note@-1 {{did you mean 'x'?}}
+  // expected-note@-2 {{did you mean 'y'?}}
   class NestedClass : Codable {
     init() {}
   }

--- a/test/decl/protocol/special/coding/class_codable_nonconforming_property.swift
+++ b/test/decl/protocol/special/coding/class_codable_nonconforming_property.swift
@@ -22,6 +22,9 @@ class NonConformingClass : Codable { // expected-error {{type 'NonConformingClas
   // expected-error@-2 {{type 'NonConformingClass' does not conform to protocol 'Encodable'}}
   // expected-error@-3 {{type 'NonConformingClass' does not conform to protocol 'Encodable'}}
   // expected-note@-4 {{did you mean 'init'?}}
+  // expected-note@-5 {{did you mean 'w'?}}
+  // expected-note@-6 {{did you mean 'x'?}}
+  // expected-note@-7 {{did you mean 'y'?}}
   var w: NonCodable = NonCodable() // expected-note {{cannot automatically synthesize 'Decodable' because 'NonCodable' does not conform to 'Decodable'}}
   // expected-note@-1 {{cannot automatically synthesize 'Decodable' because 'NonCodable' does not conform to 'Decodable'}}
   // expected-note@-2 {{cannot automatically synthesize 'Encodable' because 'NonCodable' does not conform to 'Encodable'}}

--- a/test/decl/protocol/special/coding/class_codable_simple.swift
+++ b/test/decl/protocol/special/coding/class_codable_simple.swift
@@ -3,6 +3,8 @@
 // Simple classes with all Codable properties should get derived conformance to
 // Codable.
 class SimpleClass : Codable {
+  // expected-note@-1 {{did you mean 'x'?}}
+  // expected-note@-2 {{did you mean 'y'?}}
   var x: Int = 1
   var y: Double = .pi
   static var z: String = "foo"

--- a/test/decl/protocol/special/coding/class_codable_simple_conditional.swift
+++ b/test/decl/protocol/special/coding/class_codable_simple_conditional.swift
@@ -1,6 +1,8 @@
 // RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -verify-ignore-unknown -swift-version 4
 
 class Conditional<T> {
+  // expected-note@-1 {{did you mean 'x'?}}
+  // expected-note@-2 {{did you mean 'y'?}}
   var x: T
   var y: T?
 

--- a/test/decl/protocol/special/coding/class_codable_simple_conditional_final.swift
+++ b/test/decl/protocol/special/coding/class_codable_simple_conditional_final.swift
@@ -1,6 +1,8 @@
 // RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -verify-ignore-unknown -swift-version 4
 
 final class Conditional<T> {
+  // expected-note@-1 {{did you mean 'x'?}}
+  // expected-note@-2 {{did you mean 'y'?}}
   var x: T
   var y: T?
 

--- a/test/decl/protocol/special/coding/class_codable_simple_conditional_final_separate.swift
+++ b/test/decl/protocol/special/coding/class_codable_simple_conditional_final_separate.swift
@@ -1,6 +1,8 @@
 // RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -verify-ignore-unknown -swift-version 4
 
 final class Conditional<T> {
+  // expected-note@-1 {{did you mean 'x'?}}
+  // expected-note@-2 {{did you mean 'y'?}}
   var x: T
   var y: T?
 

--- a/test/decl/protocol/special/coding/class_codable_simple_conditional_separate.swift
+++ b/test/decl/protocol/special/coding/class_codable_simple_conditional_separate.swift
@@ -1,6 +1,8 @@
 // RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -verify-ignore-unknown -swift-version 4
 
 class Conditional<T> {
+  // expected-note@-1 {{did you mean 'x'?}}
+  // expected-note@-2 {{did you mean 'y'?}}
   var x: T
   var y: T?
 

--- a/test/decl/protocol/special/coding/class_codable_simple_extension.swift
+++ b/test/decl/protocol/special/coding/class_codable_simple_extension.swift
@@ -3,6 +3,8 @@
 // Non-final classes where Codable conformance is added in extensions should
 // only be able to derive conformance for Encodable.
 class SimpleClass { // expected-note {{did you mean 'init'?}}
+  // expected-note@-1 {{did you mean 'x'?}}
+  // expected-note@-2 {{did you mean 'y'?}}
   var x: Int = 1
   var y: Double = .pi
   static var z: String = "foo"

--- a/test/decl/protocol/special/coding/class_codable_simple_extension_final.swift
+++ b/test/decl/protocol/special/coding/class_codable_simple_extension_final.swift
@@ -3,6 +3,8 @@
 // Simple final classes where Codable conformance is added in extensions should
 // be able to derive conformance for both Codable protocols.
 final class SimpleClass {
+  // expected-note@-1 {{did you mean 'x'?}}
+  // expected-note@-2 {{did you mean 'y'?}}
   var x: Int = 1
   var y: Double = .pi
   static var z: String = "foo"

--- a/test/decl/protocol/special/coding/enum_codable_conflicting_parameter_identifier.swift
+++ b/test/decl/protocol/special/coding/enum_codable_conflicting_parameter_identifier.swift
@@ -2,6 +2,10 @@
 
 enum Duplicate : Codable { // expected-error {{type 'Duplicate' does not conform to protocol 'Decodable'}}
   // expected-error@-1 {{type 'Duplicate' does not conform to protocol 'Encodable'}}
+  // expected-note@-2 {{CodingKey case '_0' does not match any stored properties}}
+  // expected-note@-3 {{CodingKey case '_0' does not match any stored properties}}
+  // expected-note@-4 {{CodingKey case '_1' does not match any stored properties}}
+  // expected-note@-5 {{CodingKey case '_1' does not match any stored properties}}
   case a(Int, Int, _0: Int, _1: Int)
   // expected-note@-1 {{cannot automatically synthesize 'Decodable' for 'Duplicate' because user defined parameter name '_0' in 'a' conflicts with automatically generated parameter name}}
   // expected-note@-2 {{cannot automatically synthesize 'Decodable' for 'Duplicate' because user defined parameter name '_1' in 'a' conflicts with automatically generated parameter name}}

--- a/test/decl/protocol/special/coding/struct_codable_computed_vars.swift
+++ b/test/decl/protocol/special/coding/struct_codable_computed_vars.swift
@@ -4,6 +4,8 @@
 // but their lazy and computed members should be skipped as part of the
 // synthesis.
 struct StructWithComputedMembers : Codable {
+    // expected-note@-1 {{'x' declared here}}
+    // expected-note@-2 {{'x' declared here}}
     var x: Int
     lazy var y: Double = Double.pi
     var z: String {

--- a/test/decl/protocol/special/coding/struct_codable_non_strong_vars.swift
+++ b/test/decl/protocol/special/coding/struct_codable_non_strong_vars.swift
@@ -3,6 +3,8 @@
 // Structs with Codable properties (with non-strong ownership) should get
 // derived conformance to Codable.
 struct NonStrongStruct : Codable {
+  // expected-note@-1 {{did you mean 'x'?}}
+  // expected-note@-2 {{did you mean 'y'?}}
   class NestedClass : Codable {
     init() {}
   }

--- a/test/decl/protocol/special/coding/struct_codable_nonconforming_property.swift
+++ b/test/decl/protocol/special/coding/struct_codable_nonconforming_property.swift
@@ -22,6 +22,9 @@ struct NonConformingStruct : Codable { // expected-error {{type 'NonConformingSt
   // expected-error@-2 {{type 'NonConformingStruct' does not conform to protocol 'Encodable'}}
   // expected-error@-3 {{type 'NonConformingStruct' does not conform to protocol 'Encodable'}}
   // expected-note@-4 {{did you mean 'init'?}}
+  // expected-note@-5 {{did you mean 'w'?}}
+  // expected-note@-6 {{did you mean 'x'?}}
+  // expected-note@-7 {{did you mean 'y'?}}
   var w: NonCodable // expected-note {{cannot automatically synthesize 'Decodable' because 'NonCodable' does not conform to 'Decodable'}}
   // expected-note@-1 {{cannot automatically synthesize 'Decodable' because 'NonCodable' does not conform to 'Decodable'}}
   // expected-note@-2 {{cannot automatically synthesize 'Encodable' because 'NonCodable' does not conform to 'Encodable'}}

--- a/test/decl/protocol/special/coding/struct_codable_simple.swift
+++ b/test/decl/protocol/special/coding/struct_codable_simple.swift
@@ -3,6 +3,9 @@
 // Simple structs with all Codable properties should get derived conformance to
 // Codable.
 struct SimpleStruct : Codable {
+    // expected-note@-1 {{did you mean 'x'?}}
+    // expected-note@-2 {{did you mean 'y'?}}
+    
     var x: Int
     var y: Double
     static var z: String = "foo"
@@ -34,6 +37,8 @@ let _ = SimpleStruct.CodingKeys.self // expected-error {{'CodingKeys' is inacces
 // https://github.com/apple/swift/issues/54675
 
 struct S1_54675: Codable { // expected-error {{type 'S1_54675' does not conform to protocol 'Encodable'}} expected-error {{type 'S1_54675' does not conform to protocol 'Decodable'}}
+  // expected-note@-1 {{CodingKey case 'x' does not match any stored properties}}
+  
   var x: Int // expected-note {{'x' previously declared here}}
   var x: Int // expected-error {{invalid redeclaration of 'x'}}
   // expected-note@-1 {{cannot automatically synthesize 'Encodable' because 'Int' does not conform to 'Encodable'}}
@@ -41,11 +46,13 @@ struct S1_54675: Codable { // expected-error {{type 'S1_54675' does not conform 
 }
 
 struct S2_54675: Decodable { // expected-error {{type 'S2_54675' does not conform to protocol 'Decodable'}}
+  // expected-note@-1 {{CodingKey case 'x' does not match any stored properties}}
   var x: Int // expected-note {{'x' previously declared here}}
   var x: Int // expected-error {{invalid redeclaration of 'x'}}
 }
 
 struct S3_54675: Encodable { // expected-error {{type 'S3_54675' does not conform to protocol 'Encodable'}}
+  // expected-note@-1 {{CodingKey case 'x' does not match any stored properties}}
   var x: Int // expected-note {{'x' previously declared here}}
   var x: Int // expected-error {{invalid redeclaration of 'x'}}
 }

--- a/test/decl/protocol/special/coding/struct_codable_simple_conditional.swift
+++ b/test/decl/protocol/special/coding/struct_codable_simple_conditional.swift
@@ -1,6 +1,8 @@
 // RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -verify-ignore-unknown -swift-version 4
 
 struct Conditional<T> {
+  // expected-note@-1 {{did you mean 'x'?}}
+  // expected-note@-2 {{did you mean 'y'?}}
   var x: T
   var y: T?
   func foo() {

--- a/test/decl/protocol/special/coding/struct_codable_simple_conditional_separate.swift
+++ b/test/decl/protocol/special/coding/struct_codable_simple_conditional_separate.swift
@@ -1,6 +1,8 @@
 // RUN: %target-typecheck-verify-swift -verify-ignore-unrelated -verify-ignore-unknown -swift-version 4
 
 struct Conditional<T> {
+  // expected-note@-1 {{did you mean 'x'?}}
+  // expected-note@-2 {{did you mean 'y'?}}
   var x: T
   var y: T?
   func foo() {

--- a/test/decl/protocol/special/coding/struct_codable_simple_extension.swift
+++ b/test/decl/protocol/special/coding/struct_codable_simple_extension.swift
@@ -3,6 +3,8 @@
 // Simple structs where Codable conformance is added in extensions should derive
 // conformance.
 struct SimpleStruct {
+  // expected-note@-1 {{did you mean 'x'?}}
+  // expected-note@-2 {{did you mean 'y'?}}
   var x: Int
   var y: Double
   static var z: String = "foo"

--- a/test/decl/protocol/special/coding/struct_codable_simple_extension_flipped.swift
+++ b/test/decl/protocol/special/coding/struct_codable_simple_extension_flipped.swift
@@ -6,6 +6,8 @@
 extension SimpleStruct : Codable {}
 
 struct SimpleStruct {
+  // expected-note@-1 {{did you mean 'x'?}}
+  // expected-note@-2 {{did you mean 'y'?}}
   var x: Int
   var y: Double
   static var z: String = "foo"


### PR DESCRIPTION
When deriving `Codable`, the synthesized implicit `CodingKeys` enum now inherits the source range of its target.

This is required to correctly construct the `AvailabilityScope` for synthesized source files (synthetic macros, macro expansions, or default arguments) when the implicit `CodingKeys` enum is the enclosing node.