### PR TITLE
[cxx-interop] Fix ownership mismatch for Unmanaged<UnsafeFRT>

### DIFF
--- a/lib/SIL/IR/ValueOwnership.cpp
+++ b/lib/SIL/IR/ValueOwnership.cpp
@@ -52,24 +52,36 @@ public:
     return OwnershipKind::OWNERSHIP;                                           \
   }
 
+// Like CONSTANT_OWNERSHIP_INST, but yields None ownership when the result type
+// is trivial. strong_copy_*_value normally produces an owned value, but its
+// result type is trivial for C++ foreign reference types imported with
+// immortal/unsafe (no-op) retain/release.
+#define CONSTANT_OR_TRIVIAL_OWNERSHIP_INST(OWNERSHIP, INST)                    \
+  ValueOwnershipKind ValueOwnershipKindClassifier::visit##INST##Inst(          \
+      INST##Inst *I) {                                                         \
+    if (I->getType().isTrivial(*I->getFunction()))                            \
+      return OwnershipKind::None;                                              \
+    return OwnershipKind::OWNERSHIP;                                           \
+  }
+
 CONSTANT_OWNERSHIP_INST(Owned, UnownedCopyValue)
 CONSTANT_OWNERSHIP_INST(Owned, WeakCopyValue)
 #define NEVER_LOADABLE_CHECKED_REF_STORAGE(Name, ...)                          \
-  CONSTANT_OWNERSHIP_INST(Owned, StrongCopy##Name##Value)                      \
+  CONSTANT_OR_TRIVIAL_OWNERSHIP_INST(Owned, StrongCopy##Name##Value)           \
   CONSTANT_OWNERSHIP_INST(Owned, Load##Name)
 #define ALWAYS_LOADABLE_CHECKED_REF_STORAGE(Name, ...)                         \
   CONSTANT_OWNERSHIP_INST(Unowned, RefTo##Name)                                \
   CONSTANT_OWNERSHIP_INST(Unowned, Name##ToRef)                                \
-  CONSTANT_OWNERSHIP_INST(Owned, StrongCopy##Name##Value)
+  CONSTANT_OR_TRIVIAL_OWNERSHIP_INST(Owned, StrongCopy##Name##Value)
 #define SOMETIMES_LOADABLE_CHECKED_REF_STORAGE(Name, ...)                      \
   CONSTANT_OWNERSHIP_INST(Owned, Load##Name)                                   \
   CONSTANT_OWNERSHIP_INST(Unowned, RefTo##Name)                                \
   CONSTANT_OWNERSHIP_INST(Unowned, Name##ToRef)                                \
-  CONSTANT_OWNERSHIP_INST(Owned, StrongCopy##Name##Value)
+  CONSTANT_OR_TRIVIAL_OWNERSHIP_INST(Owned, StrongCopy##Name##Value)
 #define UNCHECKED_REF_STORAGE(Name, ...)                                       \
   CONSTANT_OWNERSHIP_INST(None, RefTo##Name)                                   \
   CONSTANT_OWNERSHIP_INST(Unowned, Name##ToRef)                                \
-  CONSTANT_OWNERSHIP_INST(Owned, StrongCopy##Name##Value)
+  CONSTANT_OR_TRIVIAL_OWNERSHIP_INST(Owned, StrongCopy##Name##Value)
 #include "swift/AST/ReferenceStorage.def"
 
 CONSTANT_OWNERSHIP_INST(Guaranteed, BeginBorrow)

--- a/test/Interop/Cxx/foreign-reference/unmanaged-take-unretained-passed-to-function.swift
+++ b/test/Interop/Cxx/foreign-reference/unmanaged-take-unretained-passed-to-function.swift
@@ -1,0 +1,55 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: %target-swift-emit-sil -I %t/Inputs -I %swift_src_root/lib/ClangImporter/SwiftBridging -cxx-interoperability-mode=default -disable-availability-checking %t/test.swift | %FileCheck %s
+
+//--- Inputs/module.modulemap
+module FRT {
+  header "frt.h"
+  requires cplusplus
+}
+
+//--- Inputs/frt.h
+#pragma once
+
+#include <swift/bridging>
+
+struct SWIFT_UNSAFE_REFERENCE Unsafe {
+  static Unsafe *_Nonnull create();
+};
+
+struct SWIFT_IMMORTAL_REFERENCE Immortal {
+  static Immortal *_Nonnull create();
+};
+
+struct Shared {
+  static Shared *_Nonnull create();
+  void retain();
+  void release();
+} SWIFT_SHARED_REFERENCE(.retain, .release);
+
+inline void takeUnsafe(Unsafe *_Nonnull) {}
+inline void takeImmortal(Immortal *_Nonnull) {}
+inline void takeShared(Shared *_Nonnull) {}
+
+//--- test.swift
+import FRT
+
+// CHECK-LABEL: sil {{.*}}@$s4test9useUnsafeyyF
+// CHECK: return
+public func useUnsafe() {
+  // Used to crash due to ownership mismatch between the trivial
+  // unsafe reference type and the expectations of strong copy operations.
+  takeUnsafe(Unmanaged.passRetained(Unsafe.create()).takeUnretainedValue())
+}
+
+// CHECK-LABEL: sil {{.*}}@$s4test11useImmortalyyF
+// CHECK: return
+public func useImmortal() {
+  takeImmortal(Unmanaged.passRetained(Immortal.create()).takeUnretainedValue())
+}
+
+// CHECK-LABEL: sil {{.*}}@$s4test9useSharedyyF
+// CHECK: return
+public func useShared() {
+  takeShared(Unmanaged.passRetained(Shared.create()).takeUnretainedValue())
+}


### PR DESCRIPTION
Unsafe and immortal foreing references are represented as trivial types, they do not need any retain/release operations. Some Unmanaged operations emitted strong copy SIL instructions on these types resulting in the SILVerifier finding an ownership mismatch.

This patch admits that these instructions can be emitted for trivial types that do not have ownership.

rdar://178264836
