### PR TITLE
[ClangImporter] Diagnose swift_name renaming a declaration to `deinit`

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4398,6 +4398,14 @@ namespace {
       if (correctSwiftName)
         markAsVariant(result, *correctSwiftName);
 
+      // If we ignored an invalid custom Swift name (e.g. a rename to
+      // `deinit`), diagnose that now.
+      if (importedName.hasInvalidCustomName() && isActiveSwiftVersion()) {
+        if (auto customName = NameImporter::findCustomName(decl, getVersion()))
+          result->diagnose(diag::invalid_swift_name_for_decl, *customName,
+                           result);
+      }
+
       return result;
     }
 

--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -1679,6 +1679,14 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
     if (!parsedName || parsedName.isOperator())
       return result;
 
+    // swift_name can't rename a declaration to `deinit`; forming a FuncDecl
+    // with that special name asserts. Ignore it and import under the original
+    // name.
+    if (parsedName.BaseNameKind == DeclBaseName::Kind::Destructor) {
+      skipCustomName = true;
+      result.info.hasInvalidCustomName = true;
+    }
+
     // If we have an Objective-C method that is being mapped to an
     // initializer (e.g., a factory method whose name doesn't fit the
     // convention for factory methods), make sure that it can be

--- a/test/Interop/C/struct/Inputs/module.modulemap
+++ b/test/Interop/C/struct/Inputs/module.modulemap
@@ -19,6 +19,10 @@ module NoncopyableStructs {
   header "noncopyable-struct.h"
 }
 
+module NoncopyableDestroyRenamed {
+  header "noncopyable-destroy-renamed.h"
+}
+
 module NoncopyableMethod {
   header "noncopyable-method.h"
 }

--- a/test/Interop/C/struct/Inputs/noncopyable-destroy-renamed.h
+++ b/test/Interop/C/struct/Inputs/noncopyable-destroy-renamed.h
@@ -1,0 +1,10 @@
+// The swift_name rename to `deinit` is invalid, so it is ignored (with a
+// warning) and the function is imported under its original C name, which the
+// `destroy:` attribute resolves to.
+
+typedef struct __attribute__((swift_attr("~Copyable"))) __attribute__((swift_attr("destroy:renamedDestroyType_free"))) RenamedDestroyType {
+  void *storage;
+} RenamedDestroyType;
+
+// expected-warning@+1{{custom Swift name 'RenamedDestroyType.deinit(self:)' ignored because it is not valid for global function; imported as 'renamedDestroyType_free' instead}}
+void renamedDestroyType_free(RenamedDestroyType x) __attribute__((swift_name("RenamedDestroyType.deinit(self:)")));

--- a/test/Interop/C/struct/noncopyable_destroy_renamed.swift
+++ b/test/Interop/C/struct/noncopyable_destroy_renamed.swift
@@ -1,0 +1,14 @@
+// A swift_name renaming a C function to a type's `deinit` used to crash the
+// importer. It should ignore the invalid name and import under the original C
+// name, which the `destroy:` attribute then resolves to.
+
+// RUN: %target-swift-frontend -emit-sil -I %S%{fs-sep}Inputs %s -verify -verify-additional-file %S%{fs-sep}Inputs%{fs-sep}noncopyable-destroy-renamed.h | %FileCheck %s
+
+import NoncopyableDestroyRenamed
+
+func use(_ x: borrowing RenamedDestroyType) { }
+
+// The synthesized deinit calls the destroy function, imported under its
+// original C name.
+// CHECK-LABEL: sil_moveonlydeinit RenamedDestroyType {
+// CHECK: @$sSo18RenamedDestroyTypeVfD


### PR DESCRIPTION
A `swift_name` (SWIFT_NAME) attribute that renames a C function to a type's `deinit` — e.g. `swift_name("MyType.deinit(self:)")` — crashed the compiler. This fix treats a destructor base name as an invalid custom name in NameImporter so the attribute is ignored and the function is imported under its original name, and emit a warning for the invalid name.

rdar://178052945
