### PR TITLE
[6.4.x] stdlib: Define availability for SwiftStdlib 6.4

### DIFF
--- a/include/swift/AST/RuntimeVersions.def
+++ b/include/swift/AST/RuntimeVersions.def
@@ -176,7 +176,10 @@ RUNTIME_VERSION(
 
 RUNTIME_VERSION(
   (6, 4),
-  FUTURE
+  PLATFORM(macOS,   (27, 0, 0))
+  PLATFORM(iOS,     (27, 0, 0))
+  PLATFORM(watchOS, (27, 0, 0))
+  PLATFORM(visionOS,(27, 0, 0))
 )
 
 END_MAJOR_VERSION(6)

--- a/stdlib/public/Concurrency/TaskCancellation.swift
+++ b/stdlib/public/Concurrency/TaskCancellation.swift
@@ -223,7 +223,7 @@ extension Task {
   @_transparent
   public var isCancelled: Bool {
     // This is @available(SwiftStdlib 6.4, *) but can't use SwiftStdlib in transparent function
-    if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, visionOS 9999, *) {
+    if #available(anyAppleOS 27, *) {
       let ignoreTaskCancellationShield: UInt64 = 0x1
       return _taskIsCancelledWithFlags(_task, flags: ignoreTaskCancellationShield)
     } else {

--- a/stdlib/public/core/StringWordBreaking.swift
+++ b/stdlib/public/core/StringWordBreaking.swift
@@ -668,7 +668,7 @@ extension String {
   ///     addressing a word boundary.
   /// - Returns: A valid index less than equal to the input that is guaranteed to
   ///     identify some word boundary at or before `i`.
-  @available(SwiftStdlib 6.3, *)
+  @available(StdlibDeploymentTarget 6.3, *)
   public func _wordIndex(somewhereAtOrBefore i: Index) -> Index {
     var j = _guts.validateInclusiveScalarIndex(i)
     if j == endIndex {

--- a/test/Availability/foreach_borrowing.swift
+++ b/test/Availability/foreach_borrowing.swift
@@ -16,7 +16,7 @@
 // Without @available(SwiftStdlib 6.4, *) on the enclosing function, the
 // availability context does not cover SwiftStdlib 6.4.
 func testForLoopOverSpanWithoutAvailability(_ seq: Span<Int>) {
-  for x in seq { // expected-error {{for-in loop requires 'Span<Int>' to conform to 'BorrowingSequence', which is only available in macOS 9999 or newer}}
+  for x in seq { // expected-error {{for-in loop requires 'Span<Int>' to conform to 'BorrowingSequence', which is only available in macOS 27.0 or newer}}
   // expected-note@-2 {{add '@available' attribute to enclosing global function}}
   // expected-note@-2 {{add 'if #available' version check}}
     _ = x
@@ -79,7 +79,7 @@ extension BorrowingFallbackNoSequence: BorrowingSequence {
 }
 
 func testInvalidBorrowingNoSequence(seq: BorrowingFallbackNoSequence) {
-  for x in seq { // expected-error {{for-in loop requires 'BorrowingFallbackNoSequence' to conform to 'BorrowingSequence', which is only available in macOS 9999 or newer}}
+  for x in seq { // expected-error {{for-in loop requires 'BorrowingFallbackNoSequence' to conform to 'BorrowingSequence', which is only available in macOS 27.0 or newer}}
   // expected-note@-2 {{add '@available' attribute to enclosing global function}}
   // expected-note@-2 {{add 'if #available' version check}}
     _ = x

--- a/test/Concurrency/Runtime/noncopyable_continuation.swift
+++ b/test/Concurrency/Runtime/noncopyable_continuation.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift( -target %target-swift-5.1-abi-triple -parse-as-library) 2>&1 | %FileCheck %s
+// RUN: %target-run-simple-swift( -target %target-swift-5.1-abi-triple -parse-as-library -disable-availability-checking) 2>&1 | %FileCheck %s
 
 // REQUIRES: executable_test
 // REQUIRES: concurrency
@@ -25,229 +25,227 @@ struct UniqueResource: ~Copyable {
   static func main() async {
     let tests = TestSuite("Continuation: ~Copyable")
 
-    if #available(SwiftStdlib 6.4, *) {
-      #if !os(WASI)
-      tests.test("trap on dropped continuation") {
-        expectCrashLater()
+    #if !os(WASI)
+    tests.test("trap on dropped continuation") {
+      expectCrashLater()
 
-        let task = Task.detached {
-          let _: Void = await withContinuation { c in
-            _ = consume c // don't do this
-          }
+      let task = Task.detached {
+        let _: Void = await withContinuation { c in
+          _ = consume c // don't do this
         }
-        await task.value
       }
+      await task.value
+    }
 
-      tests.test("trap on dropped throwing continuation") {
-        expectCrashLater()
+    tests.test("trap on dropped throwing continuation") {
+      expectCrashLater()
 
-        do {
-          let _: Void = try await withContinuation(of: Void.self, throwing: (any Error).self) { c in
-            _ = consume c // bad! should have resumed
-          }
-        } catch {}
+      do {
+        let _: Void = try await withContinuation(of: Void.self, throwing: (any Error).self) { c in
+          _ = consume c // bad! should have resumed
+        }
+      } catch {}
+    }
+    #endif
+
+    tests.test("resume returning value") {
+      let value: Int = await withContinuation { c in
+        c.resume(returning: 42)
       }
-      #endif
+      expectEqual(42, value)
+    }
 
-      tests.test("resume returning value") {
-        let value: Int = await withContinuation { c in
+    tests.test("resume void") {
+      await withContinuation { c in
+        c.resume()
+      }
+    }
+
+    tests.test("throwing continuation resume returning") {
+      do {
+        let value: Int = try await withContinuation(of: Int.self, throwing: (any Error).self) { c in
           c.resume(returning: 42)
         }
         expectEqual(42, value)
+      } catch {
+        expectUnreachable()
       }
+    }
 
-      tests.test("resume void") {
-        await withContinuation { c in
-          c.resume()
+    tests.test("throwing continuation resume throwing") {
+      do {
+        let _: Int = try await withContinuation(of: Int.self, throwing: (any Error).self) { c in
+          c.resume(throwing: TestError())
         }
+        expectUnreachable()
+      } catch {
+        // Expected
       }
+    }
 
-      tests.test("throwing continuation resume returning") {
-        do {
-          let value: Int = try await withContinuation(of: Int.self, throwing: (any Error).self) { c in
-            c.resume(returning: 42)
-          }
-          expectEqual(42, value)
-        } catch {
-          expectUnreachable()
+    tests.test("resume with result success") {
+      let value: Int = try! await withContinuation(of: Int.self, throwing: (any Error).self) { c in
+        c.resume(with: .success(17))
+      }
+      expectEqual(17, value)
+    }
+
+    tests.test("resume with result failure") {
+      do {
+        let _: Int = try await withContinuation(of: Int.self, throwing: (any Error).self) { c in
+          c.resume(with: .failure(TestError()))
         }
+        expectUnreachable()
+      } catch {
+        // Expected
       }
+    }
 
-      tests.test("throwing continuation resume throwing") {
-        do {
-          let _: Int = try await withContinuation(of: Int.self, throwing: (any Error).self) { c in
-            c.resume(throwing: TestError())
-          }
-          expectUnreachable()
-        } catch {
-          // Expected
-        }
+    // MARK: Conversion to CheckedContinuation
+
+    tests.test("convert to CheckedContinuation and resume returning") {
+      let value: Int = await withContinuation { c in
+        let checked = CheckedContinuation(c)
+        checked.resume(returning: 42)
       }
+      expectEqual(42, value)
+    }
 
-      tests.test("resume with result success") {
-        let value: Int = try! await withContinuation(of: Int.self, throwing: (any Error).self) { c in
-          c.resume(with: .success(17))
-        }
-        expectEqual(17, value)
-      }
-
-      tests.test("resume with result failure") {
-        do {
-          let _: Int = try await withContinuation(of: Int.self, throwing: (any Error).self) { c in
-            c.resume(with: .failure(TestError()))
-          }
-          expectUnreachable()
-        } catch {
-          // Expected
-        }
-      }
-
-      // MARK: Conversion to CheckedContinuation
-
-      tests.test("convert to CheckedContinuation and resume returning") {
-        let value: Int = await withContinuation { c in
+    tests.test("convert throwing to CheckedContinuation and resume returning") {
+      do {
+        let value: Int = try await withContinuation(of: Int.self, throwing: (any Error).self) { c in
           let checked = CheckedContinuation(c)
-          checked.resume(returning: 42)
+          checked.resume(returning: 99)
         }
-        expectEqual(42, value)
+        expectEqual(99, value)
+      } catch {
+        expectUnreachable()
       }
+    }
 
-      tests.test("convert throwing to CheckedContinuation and resume returning") {
-        do {
-          let value: Int = try await withContinuation(of: Int.self, throwing: (any Error).self) { c in
-            let checked = CheckedContinuation(c)
-            checked.resume(returning: 99)
-          }
-          expectEqual(99, value)
-        } catch {
-          expectUnreachable()
+    tests.test("convert throwing to CheckedContinuation and resume throwing") {
+      do {
+        let _: Int = try await withContinuation(of: Int.self, throwing: (any Error).self) { c in
+          let checked = CheckedContinuation(c)
+          checked.resume(throwing: TestError())
         }
+        expectUnreachable()
+      } catch {
+        // Expected
       }
+    }
 
-      tests.test("convert throwing to CheckedContinuation and resume throwing") {
-        do {
-          let _: Int = try await withContinuation(of: Int.self, throwing: (any Error).self) { c in
-            let checked = CheckedContinuation(c)
-            checked.resume(throwing: TestError())
-          }
-          expectUnreachable()
-        } catch {
-          // Expected
+    tests.test("convert typed-throws to CheckedContinuation and resume throwing") {
+      struct MyCoolError: Error, Equatable {}
+      do {
+        try await withContinuation(of: Void.self, throwing: MyCoolError.self) { c in
+          let checked = CheckedContinuation(c)
+          checked.resume(throwing: MyCoolError())
         }
+        expectUnreachable()
+      } catch let error as MyCoolError {
+        expectEqual(MyCoolError(), error)
+      } catch {
+        expectUnreachable()
       }
+    }
 
-      tests.test("convert typed-throws to CheckedContinuation and resume throwing") {
-        struct MyCoolError: Error, Equatable {}
-        do {
-          try await withContinuation(of: Void.self, throwing: MyCoolError.self) { c in
-            let checked = CheckedContinuation(c)
-            checked.resume(throwing: MyCoolError())
-          }
-          expectUnreachable()
-        } catch let error as MyCoolError {
-          expectEqual(MyCoolError(), error)
-        } catch {
-          expectUnreachable()
-        }
+    // MARK: Conversion to UnsafeContinuation
+
+    tests.test("convert to UnsafeContinuation and resume returning") {
+      let value: Int = await withContinuation { c in
+        let uc = UnsafeContinuation(c)
+        uc.resume(returning: 7)
       }
+      expectEqual(7, value)
+    }
 
-      // MARK: Conversion to UnsafeContinuation
-
-      tests.test("convert to UnsafeContinuation and resume returning") {
-        let value: Int = await withContinuation { c in
+    tests.test("convert throwing to UnsafeContinuation and resume returning") {
+      do {
+        let value: Int = try await withContinuation(of: Int.self, throwing: (any Error).self) { c in
           let uc = UnsafeContinuation(c)
-          uc.resume(returning: 7)
+          uc.resume(returning: 55)
         }
-        expectEqual(7, value)
+        expectEqual(55, value)
+      } catch {
+        expectUnreachable()
       }
+    }
 
-      tests.test("convert throwing to UnsafeContinuation and resume returning") {
-        do {
-          let value: Int = try await withContinuation(of: Int.self, throwing: (any Error).self) { c in
-            let uc = UnsafeContinuation(c)
-            uc.resume(returning: 55)
-          }
-          expectEqual(55, value)
-        } catch {
-          expectUnreachable()
+    tests.test("convert throwing to UnsafeContinuation and resume throwing") {
+      do {
+        let _: Int = try await withContinuation(of: Int.self, throwing: (any Error).self) { c in
+          let uc = UnsafeContinuation(c)
+          uc.resume(throwing: TestError())
         }
+        expectUnreachable()
+      } catch {
+        // Expected
       }
+    }
 
-      tests.test("convert throwing to UnsafeContinuation and resume throwing") {
-        do {
-          let _: Int = try await withContinuation(of: Int.self, throwing: (any Error).self) { c in
-            let uc = UnsafeContinuation(c)
-            uc.resume(throwing: TestError())
-          }
-          expectUnreachable()
-        } catch {
-          // Expected
-        }
+    tests.test("noncopyable resume returning value") {
+      let resource: UniqueResource = await withContinuation { c in
+        c.resume(returning: UniqueResource(99))
+        print("non-throwing resume done")
+        // CHECK: non-throwing resume done
       }
+      print("non-throwing resumed with: \(resource.value)")
+      // CHECK: non-throwing resumed with: 99
+      expectEqual(99, resource.value)
+      _ = consume resource
+      // CHECK: UniqueResource(99).deinit
+    }
 
-      tests.test("noncopyable resume returning value") {
-        let resource: UniqueResource = await withContinuation { c in
-          c.resume(returning: UniqueResource(99))
-          print("non-throwing resume done")
-          // CHECK: non-throwing resume done
+    tests.test("noncopyable throwing continuation resume returning") {
+      do {
+        let resource: UniqueResource = try await withContinuation(of: UniqueResource.self, throwing: (any Error).self) { c in
+          c.resume(returning: UniqueResource(77))
+          print("throwing resume done")
+          // CHECK: throwing resume done
         }
-        print("non-throwing resumed with: \(resource.value)")
-        // CHECK: non-throwing resumed with: 99
-        expectEqual(99, resource.value)
+        print("throwing resumed with: \(resource.value)")
+        // CHECK: throwing resumed with: 77
+        expectEqual(77, resource.value)
         _ = consume resource
-        // CHECK: UniqueResource(99).deinit
+        // CHECK: UniqueResource(77).deinit
+      } catch {
+        expectUnreachable()
       }
+    }
 
-      tests.test("noncopyable throwing continuation resume returning") {
-        do {
-          let resource: UniqueResource = try await withContinuation(of: UniqueResource.self, throwing: (any Error).self) { c in
-            c.resume(returning: UniqueResource(77))
-            print("throwing resume done")
-            // CHECK: throwing resume done
-          }
-          print("throwing resumed with: \(resource.value)")
-          // CHECK: throwing resumed with: 77
-          expectEqual(77, resource.value)
-          _ = consume resource
-          // CHECK: UniqueResource(77).deinit
-        } catch {
-          expectUnreachable()
+    tests.test("noncopyable throwing continuation resume throwing") {
+      do {
+        let _: UniqueResource = try await withContinuation(of: UniqueResource.self, throwing: (any Error).self) { c in
+          c.resume(throwing: TestError())
         }
+        expectUnreachable()
+      } catch {
+        // Expected
       }
+    }
 
-      tests.test("noncopyable throwing continuation resume throwing") {
-        do {
-          let _: UniqueResource = try await withContinuation(of: UniqueResource.self, throwing: (any Error).self) { c in
-            c.resume(throwing: TestError())
-          }
-          expectUnreachable()
-        } catch {
-          // Expected
-        }
+    tests.test("noncopyable resume with result success") {
+      let resource: UniqueResource = try! await withContinuation(of: UniqueResource.self, throwing: (any Error).self) { c in
+        c.resume(with: .success(UniqueResource(55)))
+        print("result resume done")
+        // CHECK: result resume done
       }
+      print("result resumed with: \(resource.value)")
+      // CHECK: result resumed with: 55
+      expectEqual(55, resource.value)
+      _ = consume resource
+      // CHECK: UniqueResource(55).deinit
+    }
 
-      tests.test("noncopyable resume with result success") {
-        let resource: UniqueResource = try! await withContinuation(of: UniqueResource.self, throwing: (any Error).self) { c in
-          c.resume(with: .success(UniqueResource(55)))
-          print("result resume done")
-          // CHECK: result resume done
+    tests.test("noncopyable resume with result failure") {
+      do {
+        let _: UniqueResource = try await withContinuation(of: UniqueResource.self, throwing: (any Error).self) { c in
+          c.resume(with: .failure(TestError()))
         }
-        print("result resumed with: \(resource.value)")
-        // CHECK: result resumed with: 55
-        expectEqual(55, resource.value)
-        _ = consume resource
-        // CHECK: UniqueResource(55).deinit
-      }
-
-      tests.test("noncopyable resume with result failure") {
-        do {
-          let _: UniqueResource = try await withContinuation(of: UniqueResource.self, throwing: (any Error).self) { c in
-            c.resume(with: .failure(TestError()))
-          }
-          expectUnreachable()
-        } catch {
-          // Expected
-        }
+        expectUnreachable()
+      } catch {
+        // Expected
       }
     }
 

--- a/test/stdlib/Noncopyables/UniqueBox.swift
+++ b/test/stdlib/Noncopyables/UniqueBox.swift
@@ -1,9 +1,9 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-run-simple-swift | %FileCheck %s
+// RUN: %target-run-simple-swift
+
 // REQUIRES: executable_test
 
-// CHECK: Start
-print("Start")
+import StdlibUnittest
 
 struct Foo: ~Copyable {
   func idk() -> String {
@@ -15,94 +15,53 @@ struct Foo: ~Copyable {
   }
 }
 
+let suite = TestSuite("UniqueBox")
 
-@available(SwiftStdlib 6.4, *)
-func basic() {
+if #available(SwiftStdlib 6.4, *) {
+suite.test("Basic") {
   var intBox = UniqueBox(123)
 
-  // CHECK: 123
-  print(intBox.value)
+  expectEqual(intBox.value, 123)
 
   intBox.value += 321
 
-  // CHECK: 444
-  print(intBox.value)
+  expectEqual(intBox.value, 444)
+}
 }
 
-@available(SwiftStdlib 6.4, *)
-func noncopyable() {
-  let fooBox = UniqueBox(Foo())
-
-  // CHECK: bar
-  print("bar")
-
-  // CHECK: foo
-}
-
-@available(SwiftStdlib 6.4, *)
-func consume() {
-  func help() -> Foo {
-    let fooBox = UniqueBox(Foo())
-
-    let foo = fooBox.consume()
-
-    // CHECK: bar
-    print("bar")
-
-    return foo
-  }
-
-  _ = help()
-
-  // CHECK: foo
-}
-
-@available(SwiftStdlib 6.4, *)
-func span() {
+if #available(SwiftStdlib 6.4, *) {
+suite.test("Span") {
   let fooBox = UniqueBox(Foo())
 
   let fooSpan = fooBox.span
 
-  // CHECK: 1
-  print(fooSpan.count)
-
-  // CHECK: idk
-  print(fooSpan[0].idk())
+  expectEqual(fooSpan.count, 1)
+  expectEqual(fooSpan[0].idk(), "idk")
+}
 }
 
-@available(SwiftStdlib 6.4, *)
-func mutableSpan() {
+if #available(SwiftStdlib 6.4, *) {
+suite.test("MutableSpan") {
   var intBox = UniqueBox(123)
 
   let intSpan = intBox.mutableSpan
 
-  // CHECK: 1
-  print(intSpan.count)
-
-  // CHECK: 123
-  print(intSpan[0])
+  expectEqual(intSpan.count, 1)
+  expectEqual(intSpan[0], 123)
+}
 }
 
-@available(SwiftStdlib 6.4, *)
-func clone() {
+if #available(SwiftStdlib 6.4, *) {
+suite.test("Clone") {
   var intBox = UniqueBox(8)
   var cloneIntBox = intBox.clone()
 
   intBox.value += 8
   cloneIntBox.value -= 8
 
-  // CHECK: 16
-  print(intBox.value)
-
-  // CHECK: 0
-  print(cloneIntBox.value)
+  expectEqual(intBox.value, 16)
+  expectEqual(cloneIntBox.value, 0)
+}
 }
 
-if #available(SwiftStdlib 6.4, *) {
-  basic()
-  noncopyable()
-  consume()
-  span()
-  mutableSpan()
-  clone()
-}
+runAllTests()

--- a/utils/availability-macros.def
+++ b/utils/availability-macros.def
@@ -47,7 +47,8 @@ SwiftStdlib 6.0:macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0
 SwiftStdlib 6.1:macOS 15.4, iOS 18.4, watchOS 11.4, tvOS 18.4, visionOS 2.4
 SwiftStdlib 6.2:anyAppleOS 26.0
 SwiftStdlib 6.3:anyAppleOS 26.4
-SwiftStdlib 6.4:anyAppleOS 9999
+SwiftStdlib 6.4:anyAppleOS 27.0
+SwiftStdlib 6.5:anyAppleOS 9999
 # TODO: When you add a new version, remember to tell the compiler about it
 # by also adding it to include/swift/AST/RuntimeVersions.def.
 


### PR DESCRIPTION
- **Explanation:** Map `SwiftStdlib 6.4` to Apple's 27 releases.
- **Scope:** Affects availability of standard library APIs when using the open source Swift toolchain.
- **Issue/Radar:** rdar://179383429
- **Original PR:** https://github.com/swiftlang/swift/pull/89878
- **Risk:** Low. Brings open source toolchains into alignment with the SDKs that ship with the Xcode 27 betas.
- **Testing:** CI.
- **Reviewer:** @xedin 