### PR TITLE
AST: Suppress useless availability check warning inside switch case body scopes

### DIFF
--- a/lib/AST/AvailabilityScopeBuilder.cpp
+++ b/lib/AST/AvailabilityScopeBuilder.cpp
@@ -1236,6 +1236,14 @@ private:
           if (currentScope->getReason() == AvailabilityScope::Reason::Root)
             continue;
 
+          // Don't warn about checks that are always true because the enclosing
+          // scope was inferred from a switch case body's matched enum element.
+          // The inference is invisible to the developer, making the diagnostic
+          // confusing.
+          if (currentScope->getReason() ==
+              AvailabilityScope::Reason::SwitchStmtCaseBody)
+            continue;
+
           // Skip diagnosing useless availability in fragile functions with
           // opaque result types since removing an availability check could
           // change the ABI of the function and result in a miscompilation.

--- a/test/Availability/availability_versions.swift
+++ b/test/Availability/availability_versions.swift
@@ -709,6 +709,9 @@ func switchStatements(point: CompassPoint) {
   switch point {
   case .West where true:
     _ = globalFuncAvailableOn52()
+    if #available(OSX 52, *) { // no warning
+      _ = globalFuncAvailableOn52()
+    }
   default:
     break
   }


### PR DESCRIPTION
Follow-up to https://github.com/swiftlang/swift/pull/89724.

The useless-check warning for `#available` conditions that are always true inside a scope refined by switch case body inference is unhelpful. The refinement is invisible to the developer (it's inferred from the matched enum element's availability, not any explicit annotation in the function body), so flagging an explicit `#available` check as redundant is surprising.

Eventually, we could improve the diagnostic to note the case statement and explain that the matched enum element's availability is leading to inference.
