### PR TITLE
[Test] Make deinit_escape even more robust.

### DIFF
--- a/test/Runtime/deinit_escape.swift
+++ b/test/Runtime/deinit_escape.swift
@@ -11,9 +11,16 @@ var DeinitEscapeTestSuite = TestSuite("DeinitEscape")
 var globalObjects1: [AnyObject] = []
 var globalObjects2: [AnyObject] = []
 
+// Hide the array modifications in never-inline functions so the optimizer can't
+// notice that they're dead stores.
 @inline(never)
 func clearGlobalObjects1() {
   globalObjects1 = []
+}
+
+@inline(never)
+func escapeToGlobalObjects2(_ object: AnyObject) {
+  globalObjects2.append(object)
 }
 
 DeinitEscapeTestSuite.test("deinit escapes self") {
@@ -21,7 +28,7 @@ DeinitEscapeTestSuite.test("deinit escapes self") {
 
   class C {
     deinit {
-      globalObjects2.append(self)
+      escapeToGlobalObjects2(self)
     }
   }
   do {


### PR DESCRIPTION
Move the escape of self into a never-inline function to avoid it being optimized away as a dead store.

rdar://178654904