### PR TITLE
[6.4][Concurrency] Fix racy use-after-free in completeFuture.

### DIFF
--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -254,6 +254,14 @@ void AsyncTask::completeFuture(AsyncContext *context) {
 
   _swift_tsan_release(static_cast<Job *>(this));
 
+  // If this is task group child, notify the parent group about the completion.
+  if (hasGroupChildFragment()) {
+    // then we must offer into the parent group that we completed,
+    // so it may `next()` poll completed child tasks in completion order.
+    auto group = groupChildFragment()->getGroup();
+    group->offer(this, context);
+  }
+
   // Update the status to signal completion.
   auto newQueueHead = WaitQueueItem::get(
     hadErrorResult ? Status::Error : Status::Success,
@@ -265,13 +273,8 @@ void AsyncTask::completeFuture(AsyncContext *context) {
       newQueueHead, std::memory_order_acq_rel);
   assert(queueHead.getStatus() == Status::Executing);
 
-  // If this is task group child, notify the parent group about the completion.
-  if (hasGroupChildFragment()) {
-    // then we must offer into the parent group that we completed,
-    // so it may `next()` poll completed child tasks in completion order.
-    auto group = groupChildFragment()->getGroup();
-    group->offer(this, context);
-  }
+  // Once we signal completion, an async let task may be destroyed. We must not
+  // access `this` after this point in that case.
 
   // Schedule every waiting task on the executor.
   auto waitingTask = queueHead.getTask();


### PR DESCRIPTION
Perform the offer() call before setting the wait queue to signal completion. Signaling completion can cause an async let to complete, potentially deallocating `this`. The code around the offer() call can then access the deallocated task. There isn't any other ordering constraint between the two operations, so move the offer() call up where it's still safe.

- **Explanation**: A race in `completeFuture` can result in reading an `async let` task after it's been freed by the parent. Swapping the order of two otherwise independent operations resolves this.
- **Scope**: This is a small, targeted fix in the concurrency runtime.
- **Issues**: rdar://179124740
- **Original PRs**: https://github.com/swiftlang/swift/pull/89883
- **Risk**: Low. This re-orders two operations that don't depend on each other aside from the task lifetime aspect.
- **Testing**: CI testing covers this well in general, but doesn't catch the race, which is evidently very rarely hit in practice. CI does catch the issue with sleeps added to exacerbate it, and the issue no longer occurs with the fix.
- **Reviewers**: @ktoso 