### PR TITLE
[DependencyScanning] Prototype: Refactor the Threading Interface to Use a Concurrent Name Queue

### DIFF
--- a/include/swift/DependencyScan/ModuleDependencyScanner.h
+++ b/include/swift/DependencyScan/ModuleDependencyScanner.h
@@ -415,6 +415,16 @@ private:
       const ImportStatementInfoMap &unresolvedOptionalImportsMap,
       BatchClangModuleLookupResult &result);
 
+  void performClangModuleLookupBaseline(
+      const ImportStatementInfoMap &unresolvedImportsMap,
+      const ImportStatementInfoMap &unresolvedOptionalImportsMap,
+      BatchClangModuleLookupResult &result);
+
+  void performClangModuleLookupWithDrain(
+      const ImportStatementInfoMap &unresolvedImportsMap,
+      const ImportStatementInfoMap &unresolvedOptionalImportsMap,
+      BatchClangModuleLookupResult &result);
+
   /// Given a result of a batch Clang module dependency lookup,
   /// record its results in the cache:
   /// 1. Record all discovered Clang module dependency infos
@@ -482,7 +492,7 @@ private:
   /// Flag to use a single clang compiler instance to do all
   /// dependency queries during the life time of each worker this
   /// scanner owns.
-  //bool ShareClangCompilerInstance = true;
+  bool ShareClangCompilerInstance = true;
 };
 
 /// Check if a module path is under one of the known SDK private framework

--- a/include/swift/DependencyScan/ModuleDependencyScanner.h
+++ b/include/swift/DependencyScan/ModuleDependencyScanner.h
@@ -482,7 +482,7 @@ private:
   /// Flag to use a single clang compiler instance to do all
   /// dependency queries during the life time of each worker this
   /// scanner owns.
-  bool ShareClangCompilerInstance = true;
+  //bool ShareClangCompilerInstance = true;
 };
 
 /// Check if a module path is under one of the known SDK private framework

--- a/include/swift/DependencyScan/ModuleDependencyScanner.h
+++ b/include/swift/DependencyScan/ModuleDependencyScanner.h
@@ -196,6 +196,17 @@ private:
   createCacheKeyForEmbeddedHeader(std::string embeddedHeaderIncludeTree,
                                   std::string chainedHeaderIncludeTree);
 
+  // Prototype: this can replace scanFilesystemForClangModuleDependency.
+  void drainClangModuleDependencies(
+      const llvm::DenseSet<clang::tooling::dependencies::ModuleID> &alreadySeen,
+      clang::tooling::dependencies::LookupModuleOutputCallback
+          lookupModuleOutput,
+      llvm::function_ref<std::optional<std::string>()> getNextName,
+      llvm::function_ref<void(
+          StringRef,
+          llvm::Expected<clang::tooling::dependencies::TranslationUnitDeps>)>
+          deliverResult);
+
   // Worker-specific instance of CompilerInvocation
   std::unique_ptr<CompilerInvocation> workerCompilerInvocation;
   // Worker-specific SourceManager

--- a/lib/DependencyScan/ModuleDependencyScanner.cpp
+++ b/lib/DependencyScan/ModuleDependencyScanner.cpp
@@ -355,6 +355,34 @@ ModuleDependencyScanningWorker::scanFilesystemForClangModuleDependency(
   return clangModuleDependencies.get();
 }
 
+void ModuleDependencyScanningWorker::drainClangModuleDependencies(
+    const llvm::DenseSet<clang::tooling::dependencies::ModuleID> &alreadySeen,
+    clang::tooling::dependencies::LookupModuleOutputCallback lookupModuleOutput,
+    llvm::function_ref<std::optional<std::string>()> getNextName,
+    llvm::function_ref<
+        void(StringRef,
+             llvm::Expected<clang::tooling::dependencies::TranslationUnitDeps>)>
+        deliverResult) {
+  // Prototype: we should sink everything here into clang, so in the end
+  // this method's body becomes something like:
+  //    clangDepScanningWorker->computeDependency(CWD, commandline, alreadySeen,
+  //    lookupModuleOutput, getNextName, deliverResult);
+
+  // Prototype: the initialization only need CWD and the commandline, which we
+  // can easily pull out.
+  if (auto err = initializeClangScanningTool()) {
+    // Prototype: we can pass in a function_ref to do error handling as well.
+    // This way Swift has all the freedom to deal with the errors.
+    llvm::consumeError(std::move(err));
+    return;
+  }
+
+  while (auto name = getNextName()) {
+    deliverResult(*name, clangScanningTool.computeDependenciesByNameWithContext(
+                             *name, alreadySeen, lookupModuleOutput));
+  }
+}
+
 std::optional<clang::tooling::dependencies::TranslationUnitDeps>
 ModuleDependencyScanningWorker::scanHeaderDependenciesOfSwiftModule(
     ModuleDependencyID moduleID,
@@ -579,7 +607,7 @@ ModuleDependencyScanner::create(SwiftDependencyScanningService &service,
               .getFrontendOptions()
               .EmitDependencyScannerRemarks));
 
-  if (scanner->ShareClangCompilerInstance && !useClangScanDrainLoop()) {
+  if (scanner->ShareClangCompilerInstance) {
     auto initError = scanner->initializeWorkerClangScanningTool();
 
     if (initError) {
@@ -645,7 +673,7 @@ ModuleDependencyScanner::ModuleDependencyScanner(
 }
 
 ModuleDependencyScanner::~ModuleDependencyScanner() {
-  if (ShareClangCompilerInstance && !useClangScanDrainLoop()) {
+  if (ShareClangCompilerInstance) {
     auto finError = finalizeWorkerClangScanningTool();
     assert(!finError && "ClangScanningTool finalization must succeed.");
   }
@@ -1349,50 +1377,65 @@ void ModuleDependencyScanner::performClangModuleLookupWithDrain(
         idsToQuery.push_back(
             getModuleImportIdentifier(unresolvedImportInfo.importIdentifier));
 
+  auto numIds = idsToQuery.size();
+  if (!numIds)
+    return;
+
   ConcurrentIdentifierQueue IdQueue(std::move(idsToQuery));
-  auto drainClangModules = [&](ModuleDependencyScanningWorker *W){
-    if (auto err = W->initializeClangScanningTool()) {
-      llvm::handleAllErrors(std::move(err), [&](const llvm::StringError &E) {
-        /* prototype, do not handle init error atm. */ });
-      return true;
-    }
+  auto callIntoClang = [&](ModuleDependencyScanningWorker *W) {
     auto lookupModuleOutput = [this](const auto &cd, auto mok) -> auto {
       return clangModuleOutputPathLookup(cd, mok);
     };
 
-    auto deliverResult = [&](Identifier id, auto &scanResult) {
+    auto getNextName = [&]() -> std::optional<std::string> {
+      if (auto next = IdQueue.tryPop()) {
+        return next->str().str();
+      } else
+        return std::nullopt;
+    };
+
+    auto deliverResult = [&](StringRef Name, auto scanResult) {
       std::lock_guard<std::mutex> guard(resultAccessLock);
+      ScanDiagnosticReporter.registerNamedClangModuleQuery();
+      NumLookups++;
       if (scanResult) {
         llvm::for_each(scanResult->ModuleGraph, [&result](const auto &dep) {
           result.discoveredDependencyInfos.try_emplace(dep.ID.ModuleName, dep);
         });
-        result.visibleModules.insert_or_assign(id.str(),
+        result.visibleModules.insert_or_assign(Name.str(),
                                                scanResult->VisibleModules);
+      } else {
+        llvm::handleAllErrors(
+            scanResult.takeError(), [&](const llvm::StringError &E) {
+              const auto &message = E.getMessage();
+              // Empty messages are cached loadModule failures already reported
+              // on the first lookup; "module 'X' not found" is expected and
+              // handled elsewhere.
+              if (message.empty() ||
+                  message.find("fatal error: module '" + Name.str() +
+                               "' not found") != std::string::npos)
+                return;
+              W->workerDiagnosticEngine->diagnose(
+                  SourceLoc(), diag::clang_dependency_scan_error, message);
+            });
       }
     };
 
-    // Since withDependencyScanningWorker already incremented the counter, we
-    // decrement it once to avoid a wrong count. Keeps NumLookups increment by 1
-    // per name.
-    NumLookups--;
-    while (auto next = IdQueue.tryPop()) {
-      NumLookups++;
-      auto Deps = W->scanFilesystemForClangModuleDependency(
-          *next, lookupModuleOutput, seenClangModules);
-      deliverResult(*next, Deps);
-    }
+    W->drainClangModuleDependencies(seenClangModules, lookupModuleOutput,
+                                    getNextName, deliverResult);
 
-    llvm::consumeError(W->finalizeClangScanningTool());
     return true;
   };
 
-  auto numIds = idsToQuery.size();
-  if (!numIds) return;
-
   unsigned NumDrainers = std::min<unsigned>(NumThreads, numIds);
   for (unsigned i = 0; i < NumDrainers; ++i) {
-    ScanningThreadPool.async(
-        [&]() { withDependencyScanningWorker(drainClangModules); });
+    ScanningThreadPool.async([&]() {
+      withDependencyScanningWorker(callIntoClang);
+      // Prototype: adjust the number since we should not need to increment in
+      // withDependencyScanningWorker because we already increment per name in
+      // deliverResults.
+      NumLookups--;
+    });
   }
   ScanningThreadPool.wait();
 }

--- a/lib/DependencyScan/ModuleDependencyScanner.cpp
+++ b/lib/DependencyScan/ModuleDependencyScanner.cpp
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "swift/DependencyScan/ModuleDependencyScanner.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/DiagnosticEngine.h"
 #include "swift/AST/DiagnosticSuppression.h"
@@ -23,7 +24,6 @@
 #include "swift/Basic/PrettyStackTrace.h"
 #include "swift/Basic/Statistic.h"
 #include "swift/ClangImporter/ClangImporter.h"
-#include "swift/DependencyScan/ModuleDependencyScanner.h"
 #include "swift/Frontend/ModuleInterfaceLoader.h"
 #include "swift/Serialization/ScanningLoaders.h"
 #include "swift/Serialization/SerializedModuleLoader.h"
@@ -36,6 +36,7 @@
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/MemoryBufferRef.h"
 #include "llvm/Support/Path.h"
+#include "llvm/Support/Process.h"
 #include "llvm/Support/Threading.h"
 #include "llvm/Support/VersionTuple.h"
 #include "llvm/Support/VirtualFileSystem.h"
@@ -543,6 +544,24 @@ SwiftDependencyTracker::createTreeFromDependencies() {
   return *includeTreeList;
 }
 
+static bool useClangScanDrainLoop() {
+  static const bool Enabled = [] {
+    bool On = false;
+    if (auto V = llvm::sys::Process::GetEnv("SWIFT_CLANG_SCAN_DRAIN")) {
+      On = (*V == "1" || *V == "true" || *V == "TRUE" || *V == "on");
+      // One-time, process-wide indicator of which by-name path is active.
+      if (On)
+        llvm::errs()
+            << "[clang-scan] by-name module lookup path: "
+            << (On ? "DRAIN (experimental: shared queue, CIWC per batch)"
+                   : "BASELINE (per-name thread-pool task)")
+            << "\n";
+    }
+    return On;
+  }();
+  return Enabled;
+}
+
 llvm::ErrorOr<std::unique_ptr<ModuleDependencyScanner>>
 ModuleDependencyScanner::create(SwiftDependencyScanningService &service,
                                 CompilerInstance *instance,
@@ -560,18 +579,18 @@ ModuleDependencyScanner::create(SwiftDependencyScanningService &service,
               .getFrontendOptions()
               .EmitDependencyScannerRemarks));
 
-  // if (scanner->ShareClangCompilerInstance) {
-  //   auto initError = scanner->initializeWorkerClangScanningTool();
+  if (scanner->ShareClangCompilerInstance && !useClangScanDrainLoop()) {
+    auto initError = scanner->initializeWorkerClangScanningTool();
 
-  //   if (initError) {
-  //     llvm::handleAllErrors(
-  //         std::move(initError), [&](const llvm::StringError &E) {
-  //           instance->getDiags().diagnose(
-  //               SourceLoc(), diag::clang_dependency_scan_error, E.getMessage());
-  //         });
-  //     return std::make_error_code(std::errc::invalid_argument);
-  //   }
-  // }
+    if (initError) {
+      llvm::handleAllErrors(
+          std::move(initError), [&](const llvm::StringError &E) {
+            instance->getDiags().diagnose(
+                SourceLoc(), diag::clang_dependency_scan_error, E.getMessage());
+          });
+      return std::make_error_code(std::errc::invalid_argument);
+    }
+  }
 
   return scanner;
 }
@@ -596,8 +615,8 @@ ModuleDependencyScanner::ModuleDependencyScanner(
                      : 1),
       ScanningThreadPool(llvm::hardware_concurrency(NumThreads)),
       CAS(ScanningService.ClangScanningService->getCAS()),
-      ActionCache(ScanningService.ClangScanningService->getActionCache())/*,
-      ShareClangCompilerInstance(ShareClangCompilerInstance)*/ {
+      ActionCache(ScanningService.ClangScanningService->getActionCache()),
+      ShareClangCompilerInstance(ShareClangCompilerInstance) {
   // Setup prefix mapping.
   auto &ScannerPrefixMapper =
       ScanCompilerInvocation.getSearchPathOptions().ScannerPrefixMapper;
@@ -626,10 +645,10 @@ ModuleDependencyScanner::ModuleDependencyScanner(
 }
 
 ModuleDependencyScanner::~ModuleDependencyScanner() {
-  // if (ShareClangCompilerInstance) {
-  //   auto finError = finalizeWorkerClangScanningTool();
-  //   assert(!finError && "ClangScanningTool finalization must succeed.");
-  // }
+  if (ShareClangCompilerInstance && !useClangScanDrainLoop()) {
+    auto finError = finalizeWorkerClangScanningTool();
+    assert(!finError && "ClangScanningTool finalization must succeed.");
+  }
 }
 
 llvm::Error ModuleDependencyScanner::initializeWorkerClangScanningTool() {
@@ -1250,30 +1269,70 @@ void ModuleDependencyScanner::performClangModuleLookup(
     const ImportStatementInfoMap &unresolvedImportsMap,
     const ImportStatementInfoMap &unresolvedOptionalImportsMap,
     BatchClangModuleLookupResult &result) {
+  if (!useClangScanDrainLoop())
+    performClangModuleLookupBaseline(unresolvedImportsMap,
+                                     unresolvedOptionalImportsMap, result);
+  else
+    performClangModuleLookupWithDrain(unresolvedImportsMap,
+                                      unresolvedOptionalImportsMap, result);
+}
+
+void ModuleDependencyScanner::performClangModuleLookupBaseline(
+    const ImportStatementInfoMap &unresolvedImportsMap,
+    const ImportStatementInfoMap &unresolvedOptionalImportsMap,
+    BatchClangModuleLookupResult &result) {
   auto seenClangModules = DependencyCache.getAlreadySeenClangModules();
   std::mutex resultAccessLock;
-  // auto scanForClangModuleDependency = [this, &result, &resultAccessLock,
-  //                                      &seenClangModules](
-  //                                         Identifier moduleIdentifier) {
-  //   auto scanResult = withDependencyScanningWorker(
-  //       [&](ModuleDependencyScanningWorker *ScanningWorker) {
-  //         auto lookupModuleOutput = [this](const auto &cd, auto mok) -> auto {
-  //           return clangModuleOutputPathLookup(cd, mok);
-  //         };
-  //         return ScanningWorker->scanFilesystemForClangModuleDependency(
-  //             moduleIdentifier, lookupModuleOutput, seenClangModules);
-  //       });
-  //   {
-  //     std::lock_guard<std::mutex> guard(resultAccessLock);
-  //     if (scanResult) {
-  //       llvm::for_each(scanResult->ModuleGraph, [&result](const auto &dep) {
-  //         result.discoveredDependencyInfos.try_emplace(dep.ID.ModuleName, dep);
-  //       });
-  //       result.visibleModules.insert_or_assign(moduleIdentifier.str(),
-  //                                              scanResult->VisibleModules);
-  //     }
-  //   }
-  // };
+  auto scanForClangModuleDependency = [this, &result, &resultAccessLock,
+                                       &seenClangModules](
+                                          Identifier moduleIdentifier) {
+    auto scanResult = withDependencyScanningWorker(
+        [&](ModuleDependencyScanningWorker *ScanningWorker) {
+          auto lookupModuleOutput = [this](const auto &cd, auto mok) -> auto {
+            return clangModuleOutputPathLookup(cd, mok);
+          };
+          return ScanningWorker->scanFilesystemForClangModuleDependency(
+              moduleIdentifier, lookupModuleOutput, seenClangModules);
+        });
+    {
+      std::lock_guard<std::mutex> guard(resultAccessLock);
+      if (scanResult) {
+        llvm::for_each(scanResult->ModuleGraph, [&result](const auto &dep) {
+          result.discoveredDependencyInfos.try_emplace(dep.ID.ModuleName, dep);
+        });
+        result.visibleModules.insert_or_assign(moduleIdentifier.str(),
+                                               scanResult->VisibleModules);
+      }
+    }
+  };
+
+  // Enque asynchronous lookup tasks
+  llvm::StringSet<> queriedIdentifiers;
+  for (const auto &unresolvedImports : unresolvedImportsMap)
+    for (const auto &unresolvedImportInfo : unresolvedImports.second)
+      if (queriedIdentifiers.insert(unresolvedImportInfo.importIdentifier)
+              .second)
+        ScanningThreadPool.async(
+            scanForClangModuleDependency,
+            getModuleImportIdentifier(unresolvedImportInfo.importIdentifier));
+
+  for (const auto &unresolvedImports : unresolvedOptionalImportsMap)
+    for (const auto &unresolvedImportInfo : unresolvedImports.second)
+      if (queriedIdentifiers.insert(unresolvedImportInfo.importIdentifier)
+              .second)
+        ScanningThreadPool.async(
+            scanForClangModuleDependency,
+            getModuleImportIdentifier(unresolvedImportInfo.importIdentifier));
+
+  ScanningThreadPool.wait();
+}
+
+void ModuleDependencyScanner::performClangModuleLookupWithDrain(
+    const ImportStatementInfoMap &unresolvedImportsMap,
+    const ImportStatementInfoMap &unresolvedOptionalImportsMap,
+    BatchClangModuleLookupResult &result) {
+  auto seenClangModules = DependencyCache.getAlreadySeenClangModules();
+  std::mutex resultAccessLock;
 
   // Insert and dedupe identifiers.
   llvm::StringSet<> namesToQuery;
@@ -1290,8 +1349,7 @@ void ModuleDependencyScanner::performClangModuleLookup(
         idsToQuery.push_back(
             getModuleImportIdentifier(unresolvedImportInfo.importIdentifier));
 
-
-  ConcurrentIdentifierQueue IdQueue(idsToQuery);
+  ConcurrentIdentifierQueue IdQueue(std::move(idsToQuery));
   auto drainClangModules = [&](ModuleDependencyScanningWorker *W){
     if (auto err = W->initializeClangScanningTool()) {
       llvm::handleAllErrors(std::move(err), [&](const llvm::StringError &E) {
@@ -1302,7 +1360,7 @@ void ModuleDependencyScanner::performClangModuleLookup(
       return clangModuleOutputPathLookup(cd, mok);
     };
 
-    auto deliverResult = [&](Identifier id, auto scanResult) {
+    auto deliverResult = [&](Identifier id, auto &scanResult) {
       std::lock_guard<std::mutex> guard(resultAccessLock);
       if (scanResult) {
         llvm::for_each(scanResult->ModuleGraph, [&result](const auto &dep) {
@@ -1336,23 +1394,6 @@ void ModuleDependencyScanner::performClangModuleLookup(
     ScanningThreadPool.async(
         [&]() { withDependencyScanningWorker(drainClangModules); });
   }
-
-  // Enque asynchronous lookup tasks
-  // llvm::StringSet<> queriedIdentifiers;
-  // for (const auto &unresolvedImports : unresolvedImportsMap)
-  //   for (const auto &unresolvedImportInfo : unresolvedImports.second)
-  //     if (queriedIdentifiers.insert(unresolvedImportInfo.importIdentifier).second)
-  //       ScanningThreadPool.async(
-  //           scanForClangModuleDependency,
-  //           getModuleImportIdentifier(unresolvedImportInfo.importIdentifier));
-
-  // for (const auto &unresolvedImports : unresolvedOptionalImportsMap)
-  //   for (const auto &unresolvedImportInfo : unresolvedImports.second)
-  //     if (queriedIdentifiers.insert(unresolvedImportInfo.importIdentifier).second)
-  //       ScanningThreadPool.async(
-  //           scanForClangModuleDependency,
-  //           getModuleImportIdentifier(unresolvedImportInfo.importIdentifier));
-
   ScanningThreadPool.wait();
 }
 

--- a/lib/DependencyScan/ModuleDependencyScanner.cpp
+++ b/lib/DependencyScan/ModuleDependencyScanner.cpp
@@ -560,18 +560,18 @@ ModuleDependencyScanner::create(SwiftDependencyScanningService &service,
               .getFrontendOptions()
               .EmitDependencyScannerRemarks));
 
-  if (scanner->ShareClangCompilerInstance) {
-    auto initError = scanner->initializeWorkerClangScanningTool();
+  // if (scanner->ShareClangCompilerInstance) {
+  //   auto initError = scanner->initializeWorkerClangScanningTool();
 
-    if (initError) {
-      llvm::handleAllErrors(
-          std::move(initError), [&](const llvm::StringError &E) {
-            instance->getDiags().diagnose(
-                SourceLoc(), diag::clang_dependency_scan_error, E.getMessage());
-          });
-      return std::make_error_code(std::errc::invalid_argument);
-    }
-  }
+  //   if (initError) {
+  //     llvm::handleAllErrors(
+  //         std::move(initError), [&](const llvm::StringError &E) {
+  //           instance->getDiags().diagnose(
+  //               SourceLoc(), diag::clang_dependency_scan_error, E.getMessage());
+  //         });
+  //     return std::make_error_code(std::errc::invalid_argument);
+  //   }
+  // }
 
   return scanner;
 }
@@ -596,8 +596,8 @@ ModuleDependencyScanner::ModuleDependencyScanner(
                      : 1),
       ScanningThreadPool(llvm::hardware_concurrency(NumThreads)),
       CAS(ScanningService.ClangScanningService->getCAS()),
-      ActionCache(ScanningService.ClangScanningService->getActionCache()),
-      ShareClangCompilerInstance(ShareClangCompilerInstance) {
+      ActionCache(ScanningService.ClangScanningService->getActionCache())/*,
+      ShareClangCompilerInstance(ShareClangCompilerInstance)*/ {
   // Setup prefix mapping.
   auto &ScannerPrefixMapper =
       ScanCompilerInvocation.getSearchPathOptions().ScannerPrefixMapper;
@@ -626,10 +626,10 @@ ModuleDependencyScanner::ModuleDependencyScanner(
 }
 
 ModuleDependencyScanner::~ModuleDependencyScanner() {
-  if (ShareClangCompilerInstance) {
-    auto finError = finalizeWorkerClangScanningTool();
-    assert(!finError && "ClangScanningTool finalization must succeed.");
-  }
+  // if (ShareClangCompilerInstance) {
+  //   auto finError = finalizeWorkerClangScanningTool();
+  //   assert(!finError && "ClangScanningTool finalization must succeed.");
+  // }
 }
 
 llvm::Error ModuleDependencyScanner::initializeWorkerClangScanningTool() {
@@ -1230,50 +1230,128 @@ void ModuleDependencyScanner::reQueryMissedModulesFromCache(
   }
 }
 
+class ConcurrentIdentifierQueue {
+  std::vector<Identifier> Names;
+  std::atomic<size_t> Next = 0;
+
+public:
+  explicit ConcurrentIdentifierQueue(std::vector<Identifier> N)
+      : Names(std::move(N)) {}
+
+  std::optional<Identifier> tryPop() {
+    size_t I = Next.fetch_add(1, std::memory_order_relaxed);
+    if (I >= Names.size())
+      return std::nullopt;
+    return Names[I];
+  }
+};
+
 void ModuleDependencyScanner::performClangModuleLookup(
     const ImportStatementInfoMap &unresolvedImportsMap,
     const ImportStatementInfoMap &unresolvedOptionalImportsMap,
     BatchClangModuleLookupResult &result) {
   auto seenClangModules = DependencyCache.getAlreadySeenClangModules();
   std::mutex resultAccessLock;
-  auto scanForClangModuleDependency = [this, &result, &resultAccessLock,
-                                       &seenClangModules](
-                                          Identifier moduleIdentifier) {
-    auto scanResult = withDependencyScanningWorker(
-        [&](ModuleDependencyScanningWorker *ScanningWorker) {
-          auto lookupModuleOutput = [this](const auto &cd, auto mok) -> auto {
-            return clangModuleOutputPathLookup(cd, mok);
-          };
-          return ScanningWorker->scanFilesystemForClangModuleDependency(
-              moduleIdentifier, lookupModuleOutput, seenClangModules);
-        });
-    {
+  // auto scanForClangModuleDependency = [this, &result, &resultAccessLock,
+  //                                      &seenClangModules](
+  //                                         Identifier moduleIdentifier) {
+  //   auto scanResult = withDependencyScanningWorker(
+  //       [&](ModuleDependencyScanningWorker *ScanningWorker) {
+  //         auto lookupModuleOutput = [this](const auto &cd, auto mok) -> auto {
+  //           return clangModuleOutputPathLookup(cd, mok);
+  //         };
+  //         return ScanningWorker->scanFilesystemForClangModuleDependency(
+  //             moduleIdentifier, lookupModuleOutput, seenClangModules);
+  //       });
+  //   {
+  //     std::lock_guard<std::mutex> guard(resultAccessLock);
+  //     if (scanResult) {
+  //       llvm::for_each(scanResult->ModuleGraph, [&result](const auto &dep) {
+  //         result.discoveredDependencyInfos.try_emplace(dep.ID.ModuleName, dep);
+  //       });
+  //       result.visibleModules.insert_or_assign(moduleIdentifier.str(),
+  //                                              scanResult->VisibleModules);
+  //     }
+  //   }
+  // };
+
+  // Insert and dedupe identifiers.
+  llvm::StringSet<> namesToQuery;
+  std::vector<Identifier> idsToQuery;
+  for (const auto &unresolvedImports : unresolvedImportsMap)
+    for (const auto &unresolvedImportInfo : unresolvedImports.second)
+      if (namesToQuery.insert(unresolvedImportInfo.importIdentifier).second)
+        idsToQuery.push_back(
+            getModuleImportIdentifier(unresolvedImportInfo.importIdentifier));
+
+  for (const auto &unresolvedImports : unresolvedOptionalImportsMap)
+    for (const auto &unresolvedImportInfo : unresolvedImports.second)
+      if (namesToQuery.insert(unresolvedImportInfo.importIdentifier).second)
+        idsToQuery.push_back(
+            getModuleImportIdentifier(unresolvedImportInfo.importIdentifier));
+
+
+  ConcurrentIdentifierQueue IdQueue(idsToQuery);
+  auto drainClangModules = [&](ModuleDependencyScanningWorker *W){
+    if (auto err = W->initializeClangScanningTool()) {
+      llvm::handleAllErrors(std::move(err), [&](const llvm::StringError &E) {
+        /* prototype, do not handle init error atm. */ });
+      return true;
+    }
+    auto lookupModuleOutput = [this](const auto &cd, auto mok) -> auto {
+      return clangModuleOutputPathLookup(cd, mok);
+    };
+
+    auto deliverResult = [&](Identifier id, auto scanResult) {
       std::lock_guard<std::mutex> guard(resultAccessLock);
       if (scanResult) {
         llvm::for_each(scanResult->ModuleGraph, [&result](const auto &dep) {
           result.discoveredDependencyInfos.try_emplace(dep.ID.ModuleName, dep);
         });
-        result.visibleModules.insert_or_assign(moduleIdentifier.str(),
+        result.visibleModules.insert_or_assign(id.str(),
                                                scanResult->VisibleModules);
       }
+    };
+
+    // Since withDependencyScanningWorker already incremented the counter, we
+    // decrement it once to avoid a wrong count. Keeps NumLookups increment by 1
+    // per name.
+    NumLookups--;
+    while (auto next = IdQueue.tryPop()) {
+      NumLookups++;
+      auto Deps = W->scanFilesystemForClangModuleDependency(
+          *next, lookupModuleOutput, seenClangModules);
+      deliverResult(*next, Deps);
     }
+
+    llvm::consumeError(W->finalizeClangScanningTool());
+    return true;
   };
 
-  // Enque asynchronous lookup tasks
-  llvm::StringSet<> queriedIdentifiers;
-  for (const auto &unresolvedImports : unresolvedImportsMap)
-    for (const auto &unresolvedImportInfo : unresolvedImports.second)
-      if (queriedIdentifiers.insert(unresolvedImportInfo.importIdentifier).second)
-        ScanningThreadPool.async(
-            scanForClangModuleDependency,
-            getModuleImportIdentifier(unresolvedImportInfo.importIdentifier));
+  auto numIds = idsToQuery.size();
+  if (!numIds) return;
 
-  for (const auto &unresolvedImports : unresolvedOptionalImportsMap)
-    for (const auto &unresolvedImportInfo : unresolvedImports.second)
-      if (queriedIdentifiers.insert(unresolvedImportInfo.importIdentifier).second)
-        ScanningThreadPool.async(
-            scanForClangModuleDependency,
-            getModuleImportIdentifier(unresolvedImportInfo.importIdentifier));
+  unsigned NumDrainers = std::min<unsigned>(NumThreads, numIds);
+  for (unsigned i = 0; i < NumDrainers; ++i) {
+    ScanningThreadPool.async(
+        [&]() { withDependencyScanningWorker(drainClangModules); });
+  }
+
+  // Enque asynchronous lookup tasks
+  // llvm::StringSet<> queriedIdentifiers;
+  // for (const auto &unresolvedImports : unresolvedImportsMap)
+  //   for (const auto &unresolvedImportInfo : unresolvedImports.second)
+  //     if (queriedIdentifiers.insert(unresolvedImportInfo.importIdentifier).second)
+  //       ScanningThreadPool.async(
+  //           scanForClangModuleDependency,
+  //           getModuleImportIdentifier(unresolvedImportInfo.importIdentifier));
+
+  // for (const auto &unresolvedImports : unresolvedOptionalImportsMap)
+  //   for (const auto &unresolvedImportInfo : unresolvedImports.second)
+  //     if (queriedIdentifiers.insert(unresolvedImportInfo.importIdentifier).second)
+  //       ScanningThreadPool.async(
+  //           scanForClangModuleDependency,
+  //           getModuleImportIdentifier(unresolvedImportInfo.importIdentifier));
 
   ScanningThreadPool.wait();
 }


### PR DESCRIPTION
This is a prototype PR demonstrating what an improved clang interface may look like. **I'd like to get comments to see if there are reasons we should not do this, and other things I should consider.** 

The goal of this prototype is two folds:
1. Show that we can perform dependency scanning that uses callbacks to provide names to scan.
2. Demonstrate a possibility that we can completely hide `CompilerInstanceWithContext` initialization in the implementation of clang's API. Swift will not need functions such as `initializeWorkerClangScanningTool` any more. 

This will create the condition where we can potentially unify Swift's interface with clang driver's interface using flexible callbacks.

The key algorithm change is that we do not dispatch single names to a worker in the thread pool. Instead, we have a concurrent queue of names, and we provide each worker a function reference to call on to get the next name to scan. In other words, we currently have
```
for n in names_to_scan:
   Threadpool.async(scan(n))
```
And this PR implements:
```
Queue Names;
auto getNext = [&]()->optional<string> {
    if (auto n = Names.try_pop()) return n->str();
    return null opt
}

auto deliverResults = [&](optional<TranslationUnitDeps> res) {
    if (res)
      merge_results_with_existing(res, existing);
    else
      handle_errors;
}

for i from 0 to num_threads - 1:
   Threadpool.async(drain(getNext, deliverResults))

drain(input_callback_type getNext, output_callback_type deliverResult) {
   initialize compiler instance with context. // We can make this initialization lazy on the clang side, so we only initialize when necessary. 
   while(n = getNext()) {
      auto dep = getClangDependencies(n);
      deliverResults();
   }
}
```

I've measured the prototype's performance using a stress tester that imports all names importable in Apple's iOS SDK in a single swift file, and the new implementation is on par with the existing implementation. 



