### PR TITLE
[Macros] look in aux decls based on base name during unqual lookup

### DIFF
--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -569,7 +569,7 @@ void SourceLookupCache::lookupValue(DeclName Name, NLKind LookupKind,
   populateAuxiliaryDeclCache();
   DeclName keyName = MacroDecl::isUniqueMacroName(Name.getBaseName())
     ? UniqueMacroNamePlaceholder
-    : Name;
+    : Name.getBaseName();
   auto auxDecls = TopLevelAuxiliaryDecls.find(keyName);
 
   // Check macro expansions that could produce this name.

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1905,12 +1905,12 @@ visitObjCImplementationAttr(ObjCImplementationAttr *attr) {
       attr->setCategoryNameInvalid();
     }
 
-    // FIXME: if (AFD->getCDeclName().empty())
-
     if (!AFD->getImplementedObjCDecl()) {
+      StringRef name = AFD->getCDeclName();
+      if (name.empty())
+        name = AFD->getNameStr();
       diagnose(attr->getLocation(),
-               diag::attr_objc_implementation_func_not_found,
-               AFD->getCDeclName(), AFD);
+               diag::attr_objc_implementation_func_not_found, name, AFD);
     }
   }
 }

--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -1595,6 +1595,20 @@ public struct EmptyPeerMacro: PeerMacro {
   }
 }
 
+public struct UnstringifyPeerMacro: PeerMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingPeersOf declaration: some DeclSyntaxProtocol,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    let argumentList = node.arguments!.as(LabeledExprListSyntax.self)!
+    let arguments = [LabeledExprSyntax](argumentList)
+    let arg = arguments.first!.expression.as(StringLiteralExprSyntax.self)!
+    let content = arg.representedLiteralValue!
+    return [DeclSyntax("\(raw: content)")]
+  }
+}
+
 public struct EquatableMacro: ExtensionMacro {
   public static func expansion(
     of node: AttributeSyntax,

--- a/test/Macros/macro_expansion_implementation.swift
+++ b/test/Macros/macro_expansion_implementation.swift
@@ -75,7 +75,7 @@ public func qwerty(_ x: A) {
   """)
   public final func method() {
   // expected-expansion@+6:4{{
-  //   expected-error@1{{could not find imported function '' matching instance method 'method(fromHeader1:)'; make sure you import the module or header that declares it}}
+  //   expected-error@1{{could not find imported function 'method' matching instance method 'method(fromHeader1:)'; make sure you import the module or header that declares it}}
   //   expected-remark@1{{macro content: |@objc @implementation public func method(fromHeader1: CInt) {|}}
   //   expected-remark@2{{macro content: |  print(fromHeader1)|}}
   //   expected-remark@3{{macro content: |}|}}

--- a/test/Macros/macro_expansion_implementation.swift
+++ b/test/Macros/macro_expansion_implementation.swift
@@ -1,0 +1,84 @@
+// REQUIRES: swift_swift_parser, objc_interop
+// REQUIRES: swift_feature_MacrosOnImports
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -parse-as-library \
+// RUN:    -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift -no-toolchain-stdlib-rpath
+
+// RUN: %target-swift-frontend -typecheck %t/test.swift -verify -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) -import-bridging-header %t%{fs-sep}test.h \
+// RUN:    -verify-additional-file %t%{fs-sep}test.h -enable-experimental-feature MacrosOnImports -module-name Main -Rmacro-expansions
+
+// This exercises the unqualified lookup for finding decls in macro expansions,
+// and serves as a regression test to make sure the name lookup checks
+// auxiliary decls of top level decls whose base name matches even when the
+// compound name does not, since the compound name of the auxiliary decl might.
+
+//--- test.h
+#import <Foundation/Foundation.h>
+
+void cFunctionInHeader(int x);
+
+@interface A : NSObject
+// expected-expansion@+8:20{{
+//   expected-remark@1{{macro content: |@objc @implementation public func jkl(_ x: CInt) {|}}
+//   expected-remark@2{{macro content: |    print(x)|}}
+//   expected-remark@3{{macro content: |}|}}
+// }}
+// expected-expansion@+3:1{{
+//   expected-note@1 3{{in expansion of macro 'unstringifyPeer' on instance method 'jkl' here}}
+// }}
+- (void)jkl: (int)x __attribute__((swift_attr("@Main.unstringifyPeer(\"@objc @implementation public func jkl(_ x: CInt) { print(x) }\")")));
+@end
+
+@interface B : NSObject
+- (void)methodFromHeader1:(int)param;
+@end
+
+//--- test.swift
+import Foundation
+
+@attached(peer, names: overloaded)
+public macro unstringifyPeer(_ s: String) =
+    #externalMacro(module: "MacroDefinition", type: "UnstringifyPeerMacro")
+
+
+
+// expected-note@+1 3{{in expansion of macro 'unstringifyPeer' on global function 'cFunctionInHeader()' here}}
+@unstringifyPeer("""
+@c @implementation
+public func cFunctionInHeader(_ x: CInt) {}
+""")
+// expected-expansion@+5:35{{
+//   expected-remark@1{{macro content: |@c @implementation|}}
+//   expected-remark@2{{macro content: |public func cFunctionInHeader(_ x: CInt) {|}}
+//   expected-remark@3{{macro content: |}|}}
+// }}
+public func cFunctionInHeader() {}
+
+public func qwerty(_ x: A) {
+  x.jkl(1)
+}
+
+// FIXME: Expand macros before declaring extension inadiquate.
+
+// expected-note@+3{{add stub for missing '@implementation' requirement}}
+// expected-note@+2{{missing instance method 'method(fromHeader1:)'}}
+// expected-error@+1{{extension for main class interface does not provide all required implementations}}
+@objc @implementation extension B {
+  // expected-note@+1 4{{in expansion of macro 'unstringifyPeer' on instance method 'method()' here}}
+  @unstringifyPeer("""
+  @objc @implementation public func method(fromHeader1: CInt) {
+    print(fromHeader1)
+  }
+  """)
+  public final func method() {
+  // expected-expansion@+6:4{{
+  //   expected-error@1{{could not find imported function '' matching instance method 'method(fromHeader1:)'; make sure you import the module or header that declares it}}
+  //   expected-remark@1{{macro content: |@objc @implementation public func method(fromHeader1: CInt) {|}}
+  //   expected-remark@2{{macro content: |  print(fromHeader1)|}}
+  //   expected-remark@3{{macro content: |}|}}
+  // }}
+  }
+}


### PR DESCRIPTION
When doing unqualified lookup we were previously looking into auxiliary
decls based on the compound name of the decl. However, even when the
decl itself has a mismatching compound name (e.g. function with
different number of parameters), it may have auxiliary decls whose
compound name does match. This loosens the check to search the auxiliary decls
if the base name matches.

rdar://179323602