### PR TITLE
[ASTMangler] Handle `clang::NamespaceAliasDecl` in `appendAnyGenericType`

### DIFF
--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -3249,7 +3249,8 @@ void ASTMangler::appendAnyGenericType(const GenericTypeDecl *decl,
       // imported as a Swift enum.
       appendOperator("V");
     } else if (isa<clang::TypedefNameDecl>(namedDecl) ||
-               isa<clang::ObjCCompatibleAliasDecl>(namedDecl)) {
+               isa<clang::ObjCCompatibleAliasDecl>(namedDecl) ||
+               isa<clang::NamespaceAliasDecl>(namedDecl)) {
       appendOperator("a");
     } else if (isa<clang::NamespaceDecl>(namedDecl)) {
       // Note: Namespaces are not really enums, but since namespaces are

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -3194,7 +3194,6 @@ void ASTMangler::appendAnyGenericType(const GenericTypeDecl *decl,
         return false;
     }
 
-    auto *nominal = dyn_cast<NominalTypeDecl>(decl);
     auto namedDecl = getClangDeclForMangling(decl);
     if (!namedDecl) {
       if (auto typedefType = getTypeDefForCXXCFOptionsDefinition(decl)) {
@@ -3231,7 +3230,7 @@ void ASTMangler::appendAnyGenericType(const GenericTypeDecl *decl,
       // `ClassTemplateSpecializationDecl`'s name does not include information about
       // template arguments, and in order to prevent name clashes we use the
       // name of the Swift decl which does include template arguments.
-      appendIdentifier(nominal->getName().str(),
+      appendIdentifier(decl->getName().str(),
                        /*allowRawIdentifiers=*/false);
     } else {
       appendIdentifier(namedDecl->getName());
@@ -3257,7 +3256,7 @@ void ASTMangler::appendAnyGenericType(const GenericTypeDecl *decl,
       // imported as enums, be consistent.
       appendOperator("O");
     } else if (isa<clang::ClassTemplateDecl>(namedDecl)) {
-      appendIdentifier(nominal->getName().str(),
+      appendIdentifier(decl->getName().str(),
                        /*allowRawIdentifiers=*/false);
     } else {
       llvm_unreachable("unknown imported Clang type");

--- a/test/Interop/Cxx/namespace/namespace-alias-completion.swift
+++ b/test/Interop/Cxx/namespace/namespace-alias-completion.swift
@@ -1,0 +1,30 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: %target-swift-ide-test -batch-code-completion -source-filename %t/main.swift -filecheck %raw-FileCheck -I %t/Inputs -cxx-interoperability-mode=default -completion-output-dir %t/out
+
+// Make sure we don't crash when attempting to mangle a USR for the namespace
+// alias here.
+
+//--- Inputs/module.modulemap
+module CxxModule {
+  header "cxx-module.h"
+  requires cplusplus
+}
+
+//--- Inputs/cxx-module.h
+namespace Foo {
+struct Bar {};
+}
+
+namespace FooAlias = Foo;
+
+//--- main.swift
+import CxxModule
+
+func test() {
+  let _ = #^GLOBAL^#
+  let _ = FooAlias.#^IN_ALIAS^#
+}
+
+// GLOBAL: Decl[TypeAlias]/OtherModule[CxxModule]: FooAlias[#Foo#]; name=FooAlias
+// IN_ALIAS: Decl[Struct]/CurrNominal: Bar[#Foo.Bar#]; name=Bar


### PR DESCRIPTION
Mangle as a typealias, which matches how it's imported. This fixes a code completion crash when attempting to mangle a USR for the decl.

rdar://170650596