### PR TITLE
build-script: Add --llvm-enable-index-store, defaulted ON

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -980,6 +980,24 @@ else()
   swift_common_unified_build_config(SWIFT)
 endif()
 
+# Mirror HandleLLVMOptions.cmake's LLVM_ENABLE_INDEX_STORE behavior for the
+# Swift compile language. HandleLLVMOptions only appends -index-store-path to
+# CMAKE_C_FLAGS / CMAKE_CXX_FLAGS, so swiftc invocations would otherwise miss
+# the flag. Forwarding it here lets sourcekit-lsp's IndexStoreDB resolve
+# Swift-side symbols (stdlib, swift-syntax, libswift compiler modules) and
+# answer cross-language queries between Swift and the C++ toolchain. Probe
+# CMAKE_Swift_COMPILER for the flag so we no-op against a swiftc that does
+# not understand it, matching the check_{c,cxx}_compiler_flag gating used on
+# the C/C++ side.
+if(LLVM_ENABLE_INDEX_STORE AND CMAKE_Swift_COMPILER AND NOT XCODE AND NOT MSVC_IDE)
+  swift_supports_compiler_arguments(SWIFT_SUPPORTS_INDEX_STORE
+    -index-store-path "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/IndexStore")
+  if(SWIFT_SUPPORTS_INDEX_STORE)
+    add_compile_options(
+      "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-index-store-path ${INDEX_DATA_STORE_PATH}>")
+  endif()
+endif()
+
 include(SwiftComponents)
 include(SwiftHandleGybSources)
 include(SwiftSetIfArchBitness)

--- a/SwiftCompilerSources/CMakeLists.txt
+++ b/SwiftCompilerSources/CMakeLists.txt
@@ -154,6 +154,21 @@ function(add_swift_compiler_modules_library name)
     list(APPEND swift_compile_options "-Xfrontend" "-disable-legacy-type-info")
   endif()
 
+  # NOTE: We deliberately do NOT pass -index-store-path here.
+  # add_swift_compiler_modules_library invokes swiftc as
+  #   swiftc -wmo -c -o ${module}.o source1.swift source2.swift ...
+  # i.e. WMO with a single merged object output for many input source files.
+  # The Swift indexer walks every SourceFile in the module and expects an
+  # index-unit-output token per source (IndexRecord.cpp's
+  # error_index_inputs_more_than_outputs), but in WMO+single-output mode
+  # only the last input "produces a main output" so only one token is
+  # available - swiftc emits "index output filenames do not match input
+  # source files" and fails. FrontendTool.cpp:2379 has a FIXME calling out
+  # this exact limitation. Until that FIXME is resolved (or the
+  # SwiftCompilerSources build switches to per-source outputs via an
+  # output-file-map), the libswift compiler modules cannot be added to the
+  # IndexStore from this build path.
+
   get_bootstrapping_path(build_dir ${CMAKE_CURRENT_BINARY_DIR} "${ALS_BOOTSTRAPPING}")
 
   set(sdk_option ${SWIFT_COMPILER_SOURCES_SDK_FLAGS})

--- a/stdlib/cmake/modules/SwiftSource.cmake
+++ b/stdlib/cmake/modules/SwiftSource.cmake
@@ -537,6 +537,25 @@ function(_compile_swift_files
   # Don't include libarclite in any build products by default.
   list(APPEND swift_flags "-no-link-objc-runtime")
 
+  # _compile_swift_files invokes swiftc directly via add_custom_command, so
+  # the parent CMakeLists' add_compile_options($<COMPILE_LANGUAGE:Swift>...)
+  # forwarding of LLVM_ENABLE_INDEX_STORE does not reach these compiles.
+  # Re-do the forwarding here so the stdlib (and SDK overlay) Swift sources
+  # land in the same IndexStore as the rest of the toolchain.
+  #
+  # IMPORTANT: only do this when we are in file-map mode (one .o per .swift,
+  # i.e. num_outputs > 1). In single-output WMO mode swiftc cannot match
+  # per-source index unit tokens to inputs and bails with
+  # "index output filenames do not match input source files" - see
+  # FrontendTool.cpp:2379 / IndexRecord.cpp:882. The SwiftCompilerSources
+  # build hits exactly that path and is intentionally left unindexed.
+  #
+  # SWIFT_SUPPORTS_INDEX_STORE was probed against CMAKE_Swift_COMPILER at
+  # the parent project scope.
+  if(LLVM_ENABLE_INDEX_STORE AND SWIFT_SUPPORTS_INDEX_STORE AND num_outputs GREATER 1)
+    list(APPEND swift_flags "-index-store-path" "${INDEX_DATA_STORE_PATH}")
+  endif()
+
   if(SWIFT_SIL_VERIFY_ALL)
     list(APPEND swift_flags "-Xfrontend" "-sil-verify-all")
   endif()

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -199,6 +199,7 @@ KNOWN_SETTINGS=(
     ## LLVM Options
     llvm-enable-lto                               ""                "Must be set to one of 'thin' or 'full'"
     llvm-enable-modules                           "0"               "enable building llvm using modules"
+    llvm-enable-index-store                       "1"               "enable '-index-store-path' when compiling LLVM/Clang and Swift host tools (gated on the host compiler accepting the flag)"
     llvm-install-components                       ""                "a semicolon-separated list of LLVM components to install"
     llvm-lit-args                                 ""                "If set, override the lit args passed to LLVM"
     enable-llvm-assertions                        "1"               "set to enable llvm assertions"
@@ -809,6 +810,16 @@ function set_build_options_for_host() {
             ;;
     esac
 
+    # Forward -DLLVM_ENABLE_INDEX_STORE to both the LLVM and Swift host
+    # configures. HandleLLVMOptions.cmake (used by both) gates the actual
+    # -index-store-path append on a check_{c,cxx}_compiler_flag probe, so
+    # this is a no-op when the host compiler does not understand the flag.
+    llvm_cmake_options+=(
+        -DLLVM_ENABLE_INDEX_STORE:BOOL="$(true_false ${LLVM_ENABLE_INDEX_STORE})"
+    )
+    swift_cmake_options+=(
+        -DLLVM_ENABLE_INDEX_STORE:BOOL="$(true_false ${LLVM_ENABLE_INDEX_STORE})"
+    )
 
     # If we are asked to not generate test targets for LLVM and or Swift,
     # disable as many LLVM tools as we can. This improves compile time when

--- a/utils/build_swift/build_swift/driver_arguments.py
+++ b/utils/build_swift/build_swift/driver_arguments.py
@@ -1512,6 +1512,12 @@ def create_argument_parser():
     option('--llvm-enable-modules', toggle_true('llvm_enable_modules'),
            help='enable building llvm using modules')
 
+    option('--llvm-enable-index-store', toggle_true('llvm_enable_index_store'),
+           default=True,
+           help='emit -index-store-path while building LLVM/Clang and Swift '
+                'host tools (gated on the host compiler accepting the flag, '
+                'so it is a no-op for older compilers). Defaults to ON.')
+
     option('--llvm-targets-to-build', store,
            default='X86;ARM;AArch64;PowerPC;SystemZ;Mips;RISCV;WebAssembly;AVR;BPF',
            help='LLVM target generators to build')

--- a/utils/build_swift/tests/expected_options.py
+++ b/utils/build_swift/tests/expected_options.py
@@ -257,6 +257,7 @@ EXPECTED_DEFAULTS = {
     'llvm_build_variant': 'RelWithDebInfo',
     'llvm_cmake_options': [],
     'llvm_enable_modules': False,
+    'llvm_enable_index_store': True,
     'llvm_include_tests': True,
     'llvm_ninja_targets': [],
     'llvm_ninja_targets_for_cross_compile_hosts': [],
@@ -742,6 +743,7 @@ EXPECTED_OPTIONS = [
     EnableOption('--swift-disable-dead-stripping'),
     EnableOption('--clean-early-swift-driver', dest='clean_early_swift_driver'),
     EnableOption('--llvm-enable-modules'),
+    EnableOption('--llvm-enable-index-store'),
     EnableOption('--build-llvm', dest='_build_llvm'),
 
     DisableOption('--skip-build-cmark', dest='build_cmark'),

--- a/utils/swift_build_support/swift_build_support/products/cmake_product.py
+++ b/utils/swift_build_support/swift_build_support/products/cmake_product.py
@@ -406,6 +406,18 @@ class CMakeProduct(product.Product):
         swift_cmake_options.define('LLVM_LIT_ARGS', '{} -j {}'.format(
             self.args.lit_args, self.args.lit_jobs))
 
+        # Forward LLVM_ENABLE_INDEX_STORE to both the LLVM and Swift host
+        # configures. HandleLLVMOptions.cmake (used by both) gates the
+        # actual -index-store-path append on a check_{c,cxx}_compiler_flag
+        # probe, so this is a no-op when the host compiler does not
+        # understand the flag.
+        llvm_cmake_options.define(
+            'LLVM_ENABLE_INDEX_STORE:BOOL',
+            cmake.CMakeOptions.true_false(self.args.llvm_enable_index_store))
+        swift_cmake_options.define(
+            'LLVM_ENABLE_INDEX_STORE:BOOL',
+            cmake.CMakeOptions.true_false(self.args.llvm_enable_index_store))
+
         if self.args.clang_profile_instr_use:
             llvm_cmake_options.define('LLVM_PROFDATA_FILE',
                                       self.args.clang_profile_instr_use)

--- a/utils/swift_build_support/tests/products/test_llvm.py
+++ b/utils/swift_build_support/tests/products/test_llvm.py
@@ -187,3 +187,42 @@ class LLVMTestCase(unittest.TestCase):
             '-DCLANG_DEFAULT_LINKER=lld',
             llvm.cmake_options
         )
+
+    def _host_cmake_options_args(self, **overrides):
+        # host_cmake_options() reads these args fields. Use linux-x86_64 as
+        # the host_target so we hit only the unconditional code path
+        # (no Darwin/Android branch fields required).
+        defaults = dict(
+            lit_args='-sv',
+            lit_jobs=1,
+            clang_profile_instr_use=None,
+            swift_profile_instr_use=None,
+            coverage_db=None,
+            lto_type=None,
+            llvm_enable_index_store=True,
+        )
+        defaults.update(overrides)
+        for key, value in defaults.items():
+            setattr(self.args, key, value)
+
+    def test_llvm_enable_index_store_default_on(self):
+        self._host_cmake_options_args()
+        llvm = LLVM(
+            args=self.args,
+            toolchain=self.toolchain,
+            source_dir='/path/to/src',
+            build_dir='/path/to/build')
+        llvm_opts, swift_opts, _ = llvm.host_cmake_options('linux-x86_64')
+        self.assertIn('-DLLVM_ENABLE_INDEX_STORE:BOOL=TRUE', llvm_opts)
+        self.assertIn('-DLLVM_ENABLE_INDEX_STORE:BOOL=TRUE', swift_opts)
+
+    def test_llvm_enable_index_store_disabled(self):
+        self._host_cmake_options_args(llvm_enable_index_store=False)
+        llvm = LLVM(
+            args=self.args,
+            toolchain=self.toolchain,
+            source_dir='/path/to/src',
+            build_dir='/path/to/build')
+        llvm_opts, swift_opts, _ = llvm.host_cmake_options('linux-x86_64')
+        self.assertIn('-DLLVM_ENABLE_INDEX_STORE:BOOL=FALSE', llvm_opts)
+        self.assertIn('-DLLVM_ENABLE_INDEX_STORE:BOOL=FALSE', swift_opts)


### PR DESCRIPTION
Forward -DLLVM_ENABLE_INDEX_STORE to the LLVM and Swift host cmake configures so each compile emits an index store. The flag is gated on the host compiler accepting -index-store-path via the existing check_{c,cxx}_compiler_flag probe in HandleLLVMOptions.cmake, so it is a no-op for compilers that don't support it. Pass --llvm-enable-index-store=0 to opt out.

HandleLLVMOptions.cmake's snippet only appends -index-store-path to CMAKE_C_FLAGS / CMAKE_CXX_FLAGS, so swiftc invocations need parallel hooks. swift/CMakeLists.txt mirrors the same pattern for the Swift compile language: it probes CMAKE_Swift_COMPILER via the existing swift_supports_compiler_arguments helper (so the wiring also no-ops against an old swiftc), then emits the flag through $<COMPILE_LANGUAGE:Swift>. This covers any target built via standard CMake Swift support.

Two custom swiftc invocation paths bypass that hook:

  * stdlib/cmake/modules/SwiftSource.cmake's _compile_swift_files drives every stdlib variant, SDK overlay, and core library compile via add_custom_command. The append is gated on num_outputs > 1 (i.e. file-map mode, one .o per .swift). In single-output WMO mode swiftc cannot match per-source index unit tokens to inputs and bails with "index output filenames do not match input source files" - FrontendTool.cpp:2379 calls out this exact limitation as a FIXME.

  * SwiftCompilerSources/CMakeLists.txt builds the libswift compiler modules with -wmo -c -o module.o for many input sources, which is the broken WMO+single-output mode above. We therefore deliberately do NOT emit -index-store-path on this path - the libswift compiler modules are intentionally left out of the IndexStore until the upstream FIXME lands or the build switches to per-source outputs via an output-file-map.

With those caveats the swift compiler's C++ sources, the stdlib and SDK overlays, the swift-syntax / standard CMake Swift targets, and llvm/clang itself all land in the same IndexStore.
