### PR TITLE
[Availability] Map SwiftStdlib 6.4 to OS version 27.0

### DIFF
--- a/include/swift/AST/RuntimeVersions.def
+++ b/include/swift/AST/RuntimeVersions.def
@@ -176,7 +176,10 @@ RUNTIME_VERSION(
 
 RUNTIME_VERSION(
   (6, 4),
-  FUTURE
+  PLATFORM(macOS,   (27, 0, 0))
+  PLATFORM(iOS,     (27, 0, 0))
+  PLATFORM(watchOS, (27, 0, 0))
+  PLATFORM(visionOS,(27, 0, 0))
 )
 
 RUNTIME_VERSION(

--- a/stdlib/public/Concurrency/TaskCancellation.swift
+++ b/stdlib/public/Concurrency/TaskCancellation.swift
@@ -223,7 +223,7 @@ extension Task {
   @_transparent
   public var isCancelled: Bool {
     // This is @available(SwiftStdlib 6.4, *) but can't use SwiftStdlib in transparent function
-    if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, visionOS 9999, *) {
+    if #available(anyAppleOS 27, *) {
       let ignoreTaskCancellationShield: UInt64 = 0x1
       return unsafe _taskIsCancelledWithFlags(_AsyncTask(_task), flags: ignoreTaskCancellationShield)
     } else {

--- a/stdlib/public/core/StringWordBreaking.swift
+++ b/stdlib/public/core/StringWordBreaking.swift
@@ -668,7 +668,7 @@ extension String {
   ///     addressing a word boundary.
   /// - Returns: A valid index less than equal to the input that is guaranteed to
   ///     identify some word boundary at or before `i`.
-  @available(SwiftStdlib 6.3, *)
+  @available(StdlibDeploymentTarget 6.3, *)
   public func _wordIndex(somewhereAtOrBefore i: Index) -> Index {
     var j = _guts.validateInclusiveScalarIndex(i)
     if j == endIndex {

--- a/test/Availability/foreach_borrowing.swift
+++ b/test/Availability/foreach_borrowing.swift
@@ -16,7 +16,7 @@
 // Without @available(SwiftStdlib 6.4, *) on the enclosing function, the
 // availability context does not cover SwiftStdlib 6.4.
 func testForLoopOverSpanWithoutAvailability(_ seq: Span<Int>) {
-  for x in seq { // expected-error {{for-in loop requires 'Span<Int>' to conform to 'BorrowingSequence', which is only available in macOS 9999 or newer}}
+  for x in seq { // expected-error {{for-in loop requires 'Span<Int>' to conform to 'BorrowingSequence', which is only available in macOS 27.0 or newer}}
   // expected-note@-2 {{add '@available' attribute to enclosing global function}}
   // expected-note@-2 {{add 'if #available' version check}}
     _ = x
@@ -79,7 +79,7 @@ extension BorrowingFallbackNoSequence: BorrowingSequence {
 }
 
 func testInvalidBorrowingNoSequence(seq: BorrowingFallbackNoSequence) {
-  for x in seq { // expected-error {{for-in loop requires 'BorrowingFallbackNoSequence' to conform to 'BorrowingSequence', which is only available in macOS 9999 or newer}}
+  for x in seq { // expected-error {{for-in loop requires 'BorrowingFallbackNoSequence' to conform to 'BorrowingSequence', which is only available in macOS 27.0 or newer}}
   // expected-note@-2 {{add '@available' attribute to enclosing global function}}
   // expected-note@-2 {{add 'if #available' version check}}
     _ = x

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -78,6 +78,18 @@ def darwin_get_watchos_sim_vers():
     watchos_version_str = re.findall(r'watchOS \d+\.*\d*', sim_output.decode('utf-8'))
     return [float(v.strip('watchOS')) for v in watchos_version_str]
 
+def darwin_get_ios_sim_device():
+    sim_output = subprocess.check_output(['xcrun', 'simctl', 'list', 'devices', 'iPhone'])
+    ios_sim_devices = re.findall(r'(iPhone \d+)\ \([0-9A-F-]*\).*', sim_output.decode('utf-8'))
+    assert len(ios_sim_devices) > 0, "No Simulator iPhone devices found."
+    return ios_sim_devices[0]
+
+def darwin_get_watchos_sim_device():
+    sim_output = subprocess.check_output(['xcrun', 'simctl', 'list', 'devices', 'Apple Watch'])
+    watchos_sim_devices = re.findall(r'(Apple Watch Series \d+ \(\d+mm\))\ \([0-9A-F-]*\).*', sim_output.decode('utf-8'))
+    assert len(watchos_sim_devices) > 0, "No Simulator Apple Watch devices found."
+    return watchos_sim_devices[0]
+
 # Returns the "prefix" command that should be prepended to the command line to
 # run an executable compiled for an iOS, tvOS, or watchOS simulator.
 def get_simulator_command(run_os, run_cpu):
@@ -97,7 +109,7 @@ def get_simulator_command(run_os, run_cpu):
             else:
                 return "simctl spawn --standalone 'iPhone 5'"
         else:
-            return "simctl spawn --standalone 'iPhone 15'"
+            return f"simctl spawn --standalone '{darwin_get_ios_sim_device()}'"
     elif run_os == 'tvos':
         return "simctl spawn --standalone 'Apple TV'"
     elif run_os == 'watchos':
@@ -111,7 +123,7 @@ def get_simulator_command(run_os, run_cpu):
            else:
               return "simctl spawn --standalone 'Apple Watch Series 2 - 42mm'"
         else:
-           return "simctl spawn --standalone 'Apple Watch Series 9 (45mm)'"
+           return f"simctl spawn --standalone '{darwin_get_watchos_sim_device()}'"
     elif run_os == 'xros':
         lit_config.note("xrOS Simulator Is Not Supported Yet - Tests Will Fail")
         return "simctl spawn --standalone 'Apple Vision Pro'"

--- a/utils/availability-macros.def
+++ b/utils/availability-macros.def
@@ -47,7 +47,7 @@ SwiftStdlib 6.0:macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0
 SwiftStdlib 6.1:macOS 15.4, iOS 18.4, watchOS 11.4, tvOS 18.4, visionOS 2.4
 SwiftStdlib 6.2:anyAppleOS 26.0
 SwiftStdlib 6.3:anyAppleOS 26.4
-SwiftStdlib 6.4:anyAppleOS 9999
+SwiftStdlib 6.4:anyAppleOS 27.0
 SwiftStdlib 6.5:anyAppleOS 9999
 # TODO: When you add a new version, remember to tell the compiler about it
 # by also adding it to include/swift/AST/RuntimeVersions.def.


### PR DESCRIPTION
Replace the placeholder version 9999 with concrete OS 27.0 version numbers for the SwiftStdlib 6.4 release:
- availability-macros.def: SwiftStdlib 6.4 → anyAppleOS 27.0
- RuntimeVersions.def: resolve FUTURE → macOS/iOS/watchOS/visionOS 27.0
- TaskCancellation.swift: replace per-platform 9999 checks with anyAppleOS 27
- StringWordBreaking.swift: `@available` annotation to StdlibDeploymentTarget
- foreach_borrowing.swift: update test expectations to macOS 27.0
- lit.cfg: dynamically discover iOS/watchOS simulator device names instead of hardcoding specific model strings