### PR TITLE
[swift_snapshot_tool] Add `download` subcommand

### DIFF
--- a/utils/swift_snapshot_tool/Sources/swift_snapshot_tool/bisect_toolchains.swift
+++ b/utils/swift_snapshot_tool/Sources/swift_snapshot_tool/bisect_toolchains.swift
@@ -52,7 +52,7 @@ struct BisectToolchains: AsyncParsableCommand {
     let d = DateFormatter()
     d.dateFormat = "yyyy-MM-dd"
     guard let result = d.date(from: oldDate) else {
-      log("Improperly formatted date: \(oldDate)! Expected format: yyyy_MM_dd.")
+      log("Improperly formatted date: \(oldDate)! Expected format: yyyy-MM-dd.")
       fatalError()
     }
     return result
@@ -70,7 +70,7 @@ struct BisectToolchains: AsyncParsableCommand {
     let d = DateFormatter()
     d.dateFormat = "yyyy-MM-dd"
     guard let result = d.date(from: newDate) else {
-      log("Improperly formatted date: \(newDate)! Expected format: yyyy_MM_dd.")
+      log("Improperly formatted date: \(newDate)! Expected format: yyyy-MM-dd.")
       fatalError()
     }
     return result
@@ -101,14 +101,14 @@ struct BisectToolchains: AsyncParsableCommand {
     // just say 50 toolchains ago. To get a few weeks worth. This is easier than
     // writing dates a lot.
     let oldDateAsDate = self.oldDateAsDate
-    guard let goodTagIndex = tags.firstIndex(where: { $0.tag.date(branch: self.branch) <= oldDateAsDate }) else {
+    guard let goodTagIndex = selectTagIndex(tags, onOrBefore: oldDateAsDate) else {
       log("Failed to find tag with date: \(oldDateAsDate)")
       fatalError()
     }
 
     let badTagIndex: Int
     if let newDateAsDate = self.newDateAsDate {
-      let b = tags.firstIndex(where: { $0.tag.date(branch: self.branch) <= newDateAsDate })
+      let b = selectTagIndex(tags, onOrBefore: newDateAsDate)
       guard let b else {
         log("Failed to find tag newer than date: \(newDateAsDate)")
         fatalError()

--- a/utils/swift_snapshot_tool/Sources/swift_snapshot_tool/download_snapshot.swift
+++ b/utils/swift_snapshot_tool/Sources/swift_snapshot_tool/download_snapshot.swift
@@ -1,0 +1,76 @@
+//===--- download_snapshot.swift ------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import ArgumentParser
+import Foundation
+
+struct DownloadSnapshot: AsyncParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "download",
+    discussion: """
+      Downloads and extracts a snapshot from swift.org. On success, prints the
+      toolchain root directory to stdout. Append usr/bin/swiftc,
+      usr/bin/swift-frontend, etc. to obtain individual tool paths, or pass the
+      printed directory directly to flags that accept a toolchain root.
+      """)
+
+  @Flag var platform: Platform = .osx
+
+  @Flag(help: "The specific branch of toolchains we should download")
+  var branch: Branch = .development
+
+  @Option(
+    help: """
+      The directory where toolchains should be downloaded to.
+      """)
+  var workspace: String = "/tmp/swift_snapshot_tool_workspace_v1"
+
+  @Option(help: "Date of the snapshot to download (yyyy-MM-dd). Uses the first snapshot on or before this date.")
+  var date: String
+
+  var dateAsDate: Date {
+    let d = DateFormatter()
+    d.dateFormat = "yyyy-MM-dd"
+    guard let result = d.date(from: date) else {
+      log("Improperly formatted date: \(date)! Expected format: yyyy-MM-dd.")
+      fatalError()
+    }
+    return result
+  }
+
+  mutating func run() async throws {
+    if !FileManager.default.fileExists(atPath: workspace) {
+      do {
+        log("[INFO] Creating workspace: \(workspace)")
+        try FileManager.default.createDirectory(
+          atPath: workspace,
+          withIntermediateDirectories: true, attributes: nil)
+      } catch {
+        log(error.localizedDescription)
+      }
+    }
+
+    let tags = try! await getTagsFromSwiftRepo(branch: branch)
+
+    let date = self.dateAsDate
+    guard let tagIndex = selectTagIndex(tags, onOrBefore: date) else {
+      log("Failed to find tag with date: \(date)")
+      fatalError()
+    }
+
+    let tag = tags[tagIndex].tag
+    let toolchainDir = try await downloadAndExtractToolchain(
+      platform: platform, tag: tag, branch: branch, workspace: workspace)
+
+    print(toolchainDir)
+  }
+}

--- a/utils/swift_snapshot_tool/Sources/swift_snapshot_tool/download_toolchain.swift
+++ b/utils/swift_snapshot_tool/Sources/swift_snapshot_tool/download_toolchain.swift
@@ -119,12 +119,11 @@ private func shell(_ command: String, environment: [String: String] = [:],
   return (stdout: stdoutData, stderr: stderrData, Int(task.terminationStatus))
 }
 
-func downloadToolchainAndRunTest(
+// Downloads and extracts a toolchain snapshot, returning the toolchain root directory.
+func downloadAndExtractToolchain(
   platform: Platform, tag: Tag, branch: Branch,
-  workspace: String, script: String,
-  extraArgs: [String],
-  verbose: Bool = false
-) async throws -> Int {
+  workspace: String
+) async throws -> String {
   let fileType = platform.fileType
   let toolchainType = platform.toolchainType
 
@@ -153,23 +152,35 @@ func downloadToolchainAndRunTest(
     } else {
       log("[INFO] No need to install: \(downloadPath)")
     }
-
-    let swiftcPath = "\(toolchainDir)/usr/bin/swiftc"
-    let swiftFrontendPath = "\(toolchainDir)/usr/bin/swift-frontend"
-    // Just for now just support macosx.
-    let platform = "macosx"
-    let swiftLibraryPath = "\(toolchainDir)/usr/lib/swift/\(platform)"
-    log(shell("\(swiftcPath) --version").stdout)
-    let exitCode = shell(
-      "\(script)", environment: ["SWIFTC": swiftcPath, "SWIFT_FRONTEND": swiftFrontendPath,
-        "SWIFT_LIBRARY_PATH": swiftLibraryPath],
-      mustSucceed: false,
-      verbose: verbose,
-      extraArgs: extraArgs
-    ).exitCode
-    log("[INFO] Exit code: \(exitCode). Tag: \(tag.name). Script: \(script)")
-    return exitCode
   case .ubuntu1404, .ubuntu1604, .ubuntu1804:
     fatalError("Unsupported platform: \(platform)")
   }
+
+  return toolchainDir
+}
+
+func downloadToolchainAndRunTest(
+  platform: Platform, tag: Tag, branch: Branch,
+  workspace: String, script: String,
+  extraArgs: [String],
+  verbose: Bool = false
+) async throws -> Int {
+  let toolchainDir = try await downloadAndExtractToolchain(
+    platform: platform, tag: tag, branch: branch, workspace: workspace)
+
+  // downloadAndExtractToolchain fatal-errors on non-osx platforms, so by here
+  // platform is .osx.
+  let swiftcPath = "\(toolchainDir)/usr/bin/swiftc"
+  let swiftFrontendPath = "\(toolchainDir)/usr/bin/swift-frontend"
+  let swiftLibraryPath = "\(toolchainDir)/usr/lib/swift/macosx"
+  log(shell("\(swiftcPath) --version").stdout)
+  let exitCode = shell(
+    "\(script)", environment: ["SWIFTC": swiftcPath, "SWIFT_FRONTEND": swiftFrontendPath,
+      "SWIFT_LIBRARY_PATH": swiftLibraryPath],
+    mustSucceed: false,
+    verbose: verbose,
+    extraArgs: extraArgs
+  ).exitCode
+  log("[INFO] Exit code: \(exitCode). Tag: \(tag.name). Script: \(script)")
+  return exitCode
 }

--- a/utils/swift_snapshot_tool/Sources/swift_snapshot_tool/get_tags.swift
+++ b/utils/swift_snapshot_tool/Sources/swift_snapshot_tool/get_tags.swift
@@ -66,6 +66,13 @@ extension BranchTag: CustomDebugStringConvertible {
   }
 }
 
+/// Returns the index of the newest tag whose snapshot date is on or before
+/// `date`, given a tag list sorted newest-first as produced by
+/// `getTagsFromSwiftRepo`. Returns nil if no such tag exists.
+func selectTagIndex(_ tags: [BranchTag], onOrBefore date: Date) -> Int? {
+  tags.firstIndex(where: { $0.tag.date(branch: $0.branch) <= date })
+}
+
 func getTagsFromSwiftRepo(branch: Branch, dryRun: Bool = false) async throws -> [BranchTag] {
   let github_tag_list_url: URL
   if !dryRun {

--- a/utils/swift_snapshot_tool/Sources/swift_snapshot_tool/run_toolchain.swift
+++ b/utils/swift_snapshot_tool/Sources/swift_snapshot_tool/run_toolchain.swift
@@ -49,7 +49,7 @@ struct RunToolchains: AsyncParsableCommand {
     let d = DateFormatter()
     d.dateFormat = "yyyy-MM-dd"
     guard let result = d.date(from: date) else {
-      log("Improperly formatted date: \(date)! Expected format: yyyy_MM_dd.")
+      log("Improperly formatted date: \(date)! Expected format: yyyy-MM-dd.")
       fatalError()
     }
     return result
@@ -83,7 +83,7 @@ struct RunToolchains: AsyncParsableCommand {
     let tags = try! await getTagsFromSwiftRepo(branch: branch)
 
     let date = self.dateAsDate
-    guard var tagIndex = tags.firstIndex(where: { $0.tag.date(branch: self.branch) <= date }) else {
+    guard var tagIndex = selectTagIndex(tags, onOrBefore: date) else {
       log("Failed to find tag with date: \(date)")
       fatalError()
     }

--- a/utils/swift_snapshot_tool/Sources/swift_snapshot_tool/swift_snapshot_tool.swift
+++ b/utils/swift_snapshot_tool/Sources/swift_snapshot_tool/swift_snapshot_tool.swift
@@ -17,6 +17,7 @@ struct SwiftSnapshotTool: ParsableCommand {
     abstract: "A utility for working with swift snapshots from swift.org.",
     subcommands: [
       BisectToolchains.self,
+      DownloadSnapshot.self,
       ListSnapshots.self,
       RunToolchains.self,
     ])

--- a/utils/swift_snapshot_tool/Tests/swift_snapshot_toolTests/swift_snapshot_toolTests.swift
+++ b/utils/swift_snapshot_tool/Tests/swift_snapshot_toolTests/swift_snapshot_toolTests.swift
@@ -1,12 +1,197 @@
 import XCTest
+import Foundation
 @testable import swift_snapshot_tool
 
 final class swift_snapshot_toolTests: XCTestCase {
-    func testExample() throws {
-        // XCTest Documentation
-        // https://developer.apple.com/documentation/xctest
 
-        // Defining Test Cases and Test Methods
-        // https://developer.apple.com/documentation/xctest/defining_test_cases_and_test_methods
-    }
+  // MARK: - Tag.date()
+
+  func makeTag(ref: String) throws -> Tag {
+    let json = """
+      {
+        "ref": "\(ref)",
+        "node_id": "test",
+        "object": {"sha": "abc123", "type": "commit", "url": "https://example.com"},
+        "url": "https://example.com"
+      }
+      """
+    let decoder = JSONDecoder()
+    decoder.keyDecodingStrategy = .convertFromSnakeCase
+    return try decoder.decode(Tag.self, from: Data(json.utf8))
+  }
+
+  func date(year: Int, month: Int, day: Int) -> Date {
+    var c = DateComponents()
+    c.year = year; c.month = month; c.day = day
+    return Calendar(identifier: .gregorian).date(from: c)!
+  }
+
+  func testTagDateDevelopment() throws {
+    let tag = try makeTag(ref: "refs/tags/swift-DEVELOPMENT-SNAPSHOT-2024-01-15-a")
+    XCTAssertEqual(tag.date(branch: .development), date(year: 2024, month: 1, day: 15))
+  }
+
+  func testTagDateRelease() throws {
+    let tag = try makeTag(ref: "refs/tags/swift-6.0-DEVELOPMENT-SNAPSHOT-2023-11-07-a")
+    XCTAssertEqual(tag.date(branch: .release_6_0), date(year: 2023, month: 11, day: 7))
+  }
+
+  func testTagName() throws {
+    let tag = try makeTag(ref: "refs/tags/swift-DEVELOPMENT-SNAPSHOT-2024-03-22-a")
+    XCTAssertEqual(String(tag.name), "swift-DEVELOPMENT-SNAPSHOT-2024-03-22-a")
+  }
+
+  func testTagNameStripsRefsTagsPrefix() throws {
+    // Pin the contract that `name` strips exactly the "refs/tags/" prefix
+    // (currently implemented as dropFirst(10)).
+    let tag = try makeTag(ref: "refs/tags/foo-bar")
+    XCTAssertEqual(String(tag.name), "foo-bar")
+  }
+
+  func testTagDecodingSnakeCase() throws {
+    // Pin the dependency on JSONDecoder.keyDecodingStrategy = .convertFromSnakeCase:
+    // GitHub returns `node_id` but our struct field is `nodeId`.
+    let json = """
+      {
+        "ref": "refs/tags/swift-DEVELOPMENT-SNAPSHOT-2024-01-15-a",
+        "node_id": "MDM6UmVmMTIzNA==",
+        "object": {"sha": "abc123", "type": "commit", "url": "https://example.com/o"},
+        "url": "https://example.com/t"
+      }
+      """
+    let decoder = JSONDecoder()
+    decoder.keyDecodingStrategy = .convertFromSnakeCase
+    let tag = try decoder.decode(Tag.self, from: Data(json.utf8))
+    XCTAssertEqual(tag.nodeId, "MDM6UmVmMTIzNA==")
+    XCTAssertEqual(tag.object.sha, "abc123")
+  }
+
+  // MARK: - Branch
+
+  func testBranchTagPrefixDevelopment() {
+    XCTAssertEqual(Branch.development.tagPrefix, "swift-DEVELOPMENT")
+  }
+
+  func testBranchTagPrefixRelease50() {
+    XCTAssertEqual(Branch.release_5_0.tagPrefix, "swift-5.0-DEVELOPMENT")
+  }
+
+  func testBranchTagPrefixRelease60() {
+    XCTAssertEqual(Branch.release_6_0.tagPrefix, "swift-6.0-DEVELOPMENT")
+  }
+
+  func testBranchTagPrefixRelease62() {
+    XCTAssertEqual(Branch.release_6_2.tagPrefix, "swift-6.2-DEVELOPMENT")
+  }
+
+  func testBranchURLNameDevelopment() {
+    XCTAssertEqual(Branch.development.urlBranchName, "development")
+  }
+
+  func testBranchURLNameRelease50() {
+    XCTAssertEqual(Branch.release_5_0.urlBranchName, "swift-5.0-branch")
+  }
+
+  func testBranchURLNameRelease60() {
+    XCTAssertEqual(Branch.release_6_0.urlBranchName, "swift-6.0-branch")
+  }
+
+  // MARK: - Platform
+
+  func testPlatformFileType() {
+    XCTAssertEqual(Platform.osx.fileType, "pkg")
+    XCTAssertEqual(Platform.ubuntu1404.fileType, "tar.gz")
+    XCTAssertEqual(Platform.ubuntu1604.fileType, "tar.gz")
+    XCTAssertEqual(Platform.ubuntu1804.fileType, "tar.gz")
+  }
+
+  func testPlatformToolchainType() {
+    XCTAssertEqual(Platform.osx.toolchainType, "xcode")
+    XCTAssertEqual(Platform.ubuntu1404.toolchainType, "ubuntu1404")
+    XCTAssertEqual(Platform.ubuntu1604.toolchainType, "ubuntu1604")
+    XCTAssertEqual(Platform.ubuntu1804.toolchainType, "ubuntu1804")
+  }
+
+  // MARK: - Download URL assembly
+
+  func testDownloadURLShape() throws {
+    // Verify the URL pattern used by downloadAndExtractToolchain.
+    let tag = try makeTag(ref: "refs/tags/swift-DEVELOPMENT-SNAPSHOT-2024-03-22-a")
+    let branch = Branch.development
+    let platform = Platform.osx
+    let base = "https://swift.org/builds"
+    let expected =
+      "\(base)/\(branch.urlBranchName)/\(platform.toolchainType)/\(tag.name)/\(tag.name)-\(platform).\(platform.fileType)"
+    let url = URL(string: expected)
+    XCTAssertNotNil(url)
+    XCTAssertTrue(
+      expected.contains("development/xcode/swift-DEVELOPMENT-SNAPSHOT-2024-03-22-a"))
+  }
+
+  func testDownloadURLShapeUbuntu() throws {
+    let tag = try makeTag(ref: "refs/tags/swift-DEVELOPMENT-SNAPSHOT-2024-03-22-a")
+    let branch = Branch.development
+    let platform = Platform.ubuntu1804
+    let base = "https://swift.org/builds"
+    let expected =
+      "\(base)/\(branch.urlBranchName)/\(platform.toolchainType)/\(tag.name)/\(tag.name)-\(platform).\(platform.fileType)"
+    XCTAssertNotNil(URL(string: expected))
+    XCTAssertTrue(
+      expected.contains("development/ubuntu1804/swift-DEVELOPMENT-SNAPSHOT-2024-03-22-a"))
+    XCTAssertTrue(expected.hasSuffix(".tar.gz"))
+  }
+
+  // MARK: - selectTagIndex
+
+  func makeBranchTag(year: Int, month: Int, day: Int) throws -> BranchTag {
+    let s = String(format: "%04d-%02d-%02d", year, month, day)
+    let tag = try makeTag(ref: "refs/tags/swift-DEVELOPMENT-SNAPSHOT-\(s)-a")
+    return BranchTag(tag: tag, branch: .development)
+  }
+
+  func testSelectTagIndexExactMatch() throws {
+    // Tags are sorted newest-first, mirroring getTagsFromSwiftRepo's output.
+    let tags: [BranchTag] = [
+      try makeBranchTag(year: 2024, month: 3, day: 15),
+      try makeBranchTag(year: 2024, month: 2, day: 10),
+      try makeBranchTag(year: 2024, month: 1, day: 5),
+    ]
+    let idx = selectTagIndex(tags, onOrBefore: date(year: 2024, month: 2, day: 10))
+    XCTAssertEqual(idx, 1)
+  }
+
+  func testSelectTagIndexFallsBackToOlder() throws {
+    let tags: [BranchTag] = [
+      try makeBranchTag(year: 2024, month: 3, day: 15),
+      try makeBranchTag(year: 2024, month: 2, day: 10),
+      try makeBranchTag(year: 2024, month: 1, day: 5),
+    ]
+    // No exact match for 2024-02-20; should pick the next-older tag (2024-02-10).
+    let idx = selectTagIndex(tags, onOrBefore: date(year: 2024, month: 2, day: 20))
+    XCTAssertEqual(idx, 1)
+  }
+
+  func testSelectTagIndexTargetOlderThanAll() throws {
+    let tags: [BranchTag] = [
+      try makeBranchTag(year: 2024, month: 3, day: 15),
+      try makeBranchTag(year: 2024, month: 2, day: 10),
+    ]
+    let idx = selectTagIndex(tags, onOrBefore: date(year: 2023, month: 1, day: 1))
+    XCTAssertNil(idx)
+  }
+
+  func testSelectTagIndexTargetNewerThanAll() throws {
+    let tags: [BranchTag] = [
+      try makeBranchTag(year: 2024, month: 3, day: 15),
+      try makeBranchTag(year: 2024, month: 2, day: 10),
+    ]
+    // Newer than every tag — should pick the newest (index 0).
+    let idx = selectTagIndex(tags, onOrBefore: date(year: 2025, month: 1, day: 1))
+    XCTAssertEqual(idx, 0)
+  }
+
+  func testSelectTagIndexEmpty() {
+    let idx = selectTagIndex([], onOrBefore: date(year: 2024, month: 1, day: 1))
+    XCTAssertNil(idx)
+  }
 }


### PR DESCRIPTION
Adds a new `download` subcommand that fetches a snapshot for a given date, extracts it, and prints the toolchain root path to stdout so it can be captured by shell scripts or other tools.

Also refactors `downloadToolchainAndRunTest` to delegate the download+extract step to a new `downloadAndExtractToolchain` helper, and adds unit tests covering Tag date parsing, Branch/Platform URL construction, and the overall download URL shape.
