### PR TITLE
[cxx-interop] Move __Unsafe rename out of NameImporter

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4635,9 +4635,25 @@ namespace {
         if (result)
           return result;
       }
+
+      // First, import this CXXMethodDecl as we would any regular C/C++ function
       auto *method = cast_or_null<ValueDecl>(VisitFunctionDecl(decl));
       if (!method)
         return nullptr;
+
+      // VisitFunctionDecl() might return a FuncDecl that was already
+      // fully-imported from a CXXMethodDecl due to circular importing.
+      // In that case, the fully-imported result should already be cached.
+      if (auto known =
+              Impl.ImportedDecls.find({decl->getCanonicalDecl(), getVersion()});
+          known != Impl.ImportedDecls.end()) {
+        // Skip VisitCXXMethodDecl post-processing (which is not idempotent)
+        // and return the already-cached result.
+        return known->second;
+      }
+
+      // Post-VisitFunctionDecl(), perform special handling that is specific
+      // to importing CXXMethodDecls...
 
       // For regular methods (not operators, constructors, etc.), if the return
       // type is an uninstantiated templated class, instantiate it now and

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4656,27 +4656,21 @@ namespace {
       // Post-VisitFunctionDecl(), perform special handling that is specific
       // to importing CXXMethodDecls...
 
-      // For regular methods (not operators, constructors, etc.), if the return
-      // type is an uninstantiated templated class, instantiate it now and
-      // update the imported name if it changed. The safety detection logic
-      // (IsSafeUseOfCxxDecl) relies on the returned class being instantiated,
-      // and may affect the imported name (e.g., adding a "__*Unsafe" prefix).
-      // We defer this instantiation to after importing the method so that we
-      // don't eagerly instantiate templates for methods we may not even end up
-      // importing. The "__*Unsafe" lookup fallback in ClangRecordMemberLookup
-      // will also find methods whose imported name changes due to safety after
-      // instantiation.
+      // For regular methods (not operators, ctors, dtors, conversions),
+      // instantiate the return-type template (if needed) and apply the
+      // __Unsafe-method rename here. This is done post-import so we don't
+      // eagerly instantiate templates for methods we may not import.
       //
-      // This post-import behavior is gated on ImportCxxMembersLazily, because
-      // without that feature, IsSafeUseOfCxxDecl relies on ClangImporter
-      // (over-)eagerly instantiating typedef members.
-      if (Impl.SwiftContext.LangOpts.hasFeature(
-              Feature::ImportCxxMembersLazily)) {
-        if (!isa<clang::CXXConstructorDecl, clang::CXXDestructorDecl,
-                 clang::CXXConversionDecl>(decl) &&
-            decl->getOverloadedOperator() ==
-                clang::OverloadedOperatorKind::OO_None) {
+      // Instantiation is gated on ImportCxxMembersLazily; without that
+      // feature ClangImporter eagerly instantiates typedef members, so the
+      // return type is usually already instantiated by the time we get here.
+      if (!isa<clang::CXXConstructorDecl, clang::CXXDestructorDecl,
+               clang::CXXConversionDecl>(decl) &&
+          decl->getOverloadedOperator() ==
+              clang::OverloadedOperatorKind::OO_None) {
 
+        if (Impl.SwiftContext.LangOpts.hasFeature(
+                Feature::ImportCxxMembersLazily)) {
           using ClassTmplSpec = clang::ClassTemplateSpecializationDecl;
 
           auto retTy = desugarIfElaborated(decl->getReturnType());
@@ -4691,16 +4685,22 @@ namespace {
                 clang::TemplateSpecializationKind::TSK_ImplicitInstantiation,
                 /*Complain*/ false, /*PrimaryStrictPackMatch*/ false);
           }
-          // Re-import the name now that the return type template is (or was
-          // already) instantiated; safety may have changed, affecting the
-          // base name. Clear the cached name first so importFullName
-          // recomputes it.
-          Impl.getNameImporter().clearCachedName(decl, Impl.CurrentVersion);
-          if (auto updatedName =
-                  Impl.importFullName(decl, Impl.CurrentVersion)) {
-            if (method->getName() != updatedName.getDeclName())
-              method->setName(updatedName.getDeclName());
-          }
+        }
+
+        auto importedName = Impl.importFullName(decl, Impl.CurrentVersion);
+        if (importedName && !importedName.hasCustomName() &&
+            !evaluateOrDefault(Impl.SwiftContext.evaluator,
+                               IsSafeUseOfCxxDecl({decl, Impl.SwiftContext}),
+                               {})) {
+          DeclName currentName = method->getName();
+          Identifier unsafeId = Impl.SwiftContext.getIdentifier(
+              ("__" + currentName.getBaseIdentifier().str() + "Unsafe").str());
+          DeclName unsafeName = currentName.isCompoundName()
+                                    ? DeclName(Impl.SwiftContext, unsafeId,
+                                               currentName.getArgumentNames())
+                                    : DeclName(unsafeId);
+          if (currentName != unsafeName)
+            method->setName(unsafeName);
         }
       }
 

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4647,6 +4647,7 @@ namespace {
       if (auto known =
               Impl.ImportedDecls.find({decl->getCanonicalDecl(), getVersion()});
           known != Impl.ImportedDecls.end()) {
+        ASSERT(known->second == method && "returning different");
         // Skip VisitCXXMethodDecl post-processing (which is not idempotent)
         // and return the already-cached result.
         return known->second;

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4635,7 +4635,9 @@ namespace {
         if (result)
           return result;
       }
-      auto method = VisitFunctionDecl(decl);
+      auto *method = cast_or_null<ValueDecl>(VisitFunctionDecl(decl));
+      if (!method)
+        return nullptr;
 
       // For regular methods (not operators, constructors, etc.), if the return
       // type is an uninstantiated templated class, instantiate it now and
@@ -4651,8 +4653,8 @@ namespace {
       // This post-import behavior is gated on ImportCxxMembersLazily, because
       // without that feature, IsSafeUseOfCxxDecl relies on ClangImporter
       // (over-)eagerly instantiating typedef members.
-      if (method && Impl.SwiftContext.LangOpts.hasFeature(
-                        Feature::ImportCxxMembersLazily)) {
+      if (Impl.SwiftContext.LangOpts.hasFeature(
+              Feature::ImportCxxMembersLazily)) {
         if (!isa<clang::CXXConstructorDecl, clang::CXXDestructorDecl,
                  clang::CXXConversionDecl>(decl) &&
             decl->getOverloadedOperator() ==
@@ -4679,9 +4681,8 @@ namespace {
           Impl.getNameImporter().clearCachedName(decl, Impl.CurrentVersion);
           if (auto updatedName =
                   Impl.importFullName(decl, Impl.CurrentVersion)) {
-            auto *valueDecl = cast<ValueDecl>(method);
-            if (valueDecl->getName() != updatedName.getDeclName())
-              valueDecl->setName(updatedName.getDeclName());
+            if (method->getName() != updatedName.getDeclName())
+              method->setName(updatedName.getDeclName());
           }
         }
       }
@@ -4689,18 +4690,17 @@ namespace {
       // Do not expose constructors of abstract C++ classes.
       if (auto recordDecl =
               dyn_cast<clang::CXXRecordDecl>(decl->getDeclContext())) {
-        if (isa<clang::CXXConstructorDecl>(decl) && recordDecl->isAbstract() &&
-            isa_and_nonnull<ValueDecl>(method)) {
+        if (isa<clang::CXXConstructorDecl>(decl) && recordDecl->isAbstract()) {
           Impl.markUnavailable(
-              cast<ValueDecl>(method),
+              method,
               "constructors of abstract C++ classes are unavailable in Swift");
           return method;
         }
       }
 
       if (decl->isVirtual()) {
-        if (auto funcDecl = dyn_cast_or_null<FuncDecl>(method)) {
-          if (isa_and_nonnull<StructDecl>(method->getDeclContext())) {
+        if (auto funcDecl = dyn_cast<FuncDecl>(method)) {
+          if (isa<StructDecl>(method->getDeclContext())) {
             // If this is a method of a Swift struct, any possible override of
             // this method would get sliced away, and an invocation would get
             // dispatched statically. This is fine because it matches the C++
@@ -4712,7 +4712,7 @@ namespace {
                                    "virtual function is not available in Swift "
                                    "because it is pure");
             }
-          } else if (isa_and_nonnull<ClassDecl>(funcDecl->getDeclContext())) {
+          } else if (isa<ClassDecl>(funcDecl->getDeclContext())) {
             // This is a foreign reference type. Since `class T` on the Swift
             // side is mapped from `T*` on the C++ side, an invocation of a
             // virtual method `t->method()` should get dispatched dynamically.
@@ -4747,7 +4747,7 @@ namespace {
 
       if (Impl.SwiftContext.LangOpts.CxxInteropGettersSettersAsProperties ||
           hasComputedPropertyAttr(decl)) {
-        if (auto funcDecl = dyn_cast_or_null<FuncDecl>(method)) {
+        if (auto funcDecl = dyn_cast<FuncDecl>(method)) {
           auto parent = funcDecl->getParent()->getSelfNominalTypeDecl();
           CXXMethodBridging bridgingInfo(decl);
           if (bridgingInfo.classify() == CXXMethodBridging::Kind::getter) {

--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -1594,17 +1594,6 @@ addDefaultArgNamesForClangFunction(const clang::FunctionDecl *funcDecl,
     argumentNames.emplace_back();
 }
 
-static StringRef renameUnsafeMethod(ASTContext &ctx,
-                                    const clang::NamedDecl *decl,
-                                    StringRef name) {
-  if (isa<clang::CXXMethodDecl>(decl) &&
-      !evaluateOrDefault(ctx.evaluator, IsSafeUseOfCxxDecl({decl, ctx}), {})) {
-    return ctx.getIdentifier(("__" + name + "Unsafe").str()).str();
-  }
-
-  return name;
-}
-
 std::optional<StringRef>
 NameImporter::findCustomName(const clang::Decl *decl,
                              ImportNameVersion version) {
@@ -2575,8 +2564,6 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
       baseName = swiftPrivateScratch;
     }
   }
-
-  baseName = renameUnsafeMethod(swiftCtx, D, baseName);
 
   result.declName =
       formDeclName(swiftCtx, baseName, argumentNames, isFunction,

--- a/lib/ClangImporter/ImportName.h
+++ b/lib/ClangImporter/ImportName.h
@@ -438,13 +438,6 @@ public:
                           clang::DeclarationName preferredName =
                             clang::DeclarationName());
 
-  /// Clear the cached imported name for a particular Clang decl so that the
-  /// next call to importName will recompute it.
-  void clearCachedName(const clang::NamedDecl *decl,
-                       ImportNameVersion version) {
-    importNameCache.erase({decl, version});
-  }
-
   /// Attempts to import the name of \p decl with each possible
   /// ImportNameVersion. \p action will be called with each unique name.
   ///

--- a/lib/ClangImporter/SwiftLookupTable.h
+++ b/lib/ClangImporter/SwiftLookupTable.h
@@ -280,7 +280,7 @@ const uint16_t SWIFT_LOOKUP_TABLE_VERSION_MAJOR = 1;
 /// Lookup table minor version number.
 ///
 /// When the format changes IN ANY WAY, this number should be incremented.
-const uint16_t SWIFT_LOOKUP_TABLE_VERSION_MINOR = 24; // begin() returning FRT is __Unsafe
+const uint16_t SWIFT_LOOKUP_TABLE_VERSION_MINOR = 25; // No more __Unsafe in lookup table
 
 /// A lookup table that maps Swift names to the set of Clang
 /// declarations with that particular name.


### PR DESCRIPTION
Stop mangling `__<name>Unsafe` into imported names inside NameImporter. The Swift lookup table now stores the natural clang name; ClangRecordMemberLookup already maps `__<name>Unsafe` -> `<name>`, so callers see the same Swift-side names as before.

This patch set also includes a fix that ensures `VisitCXXMethodDecl` is idempotent when we re-encounter an already-imported method, due to circular imports.