### PR TITLE
[DeadObjectElimination] Fix owned-value leak when deleting consuming users

### DIFF
--- a/lib/SILOptimizer/Transforms/DeadObjectElimination.cpp
+++ b/lib/SILOptimizer/Transforms/DeadObjectElimination.cpp
@@ -853,10 +853,26 @@ class DeadObjectElimination : public SILFunctionTransform {
 
 void
 DeadObjectElimination::removeInstructions(ArrayRef<SILInstruction*> toRemove) {
-  for (auto *I : toRemove) {
+  // Drop all result uses up front so each instruction satisfies
+  // InstructionDeleter's incidental-use precondition. This also prevents
+  // lifetime fixup from compensating uses within the dead graph itself.
+  // The dead-object analysis has already checked that these users are
+  // removable.
+  for (auto *I : toRemove)
     I->replaceAllUsesOfAllResultsWithUndef();
-    // Now we know that I should not have any uses... erase it from its parent.
-    deleter.forceDelete(I);
+
+  bool fixLifetimes = getFunction()->hasOwnership();
+
+  for (auto *I : toRemove) {
+    // Callers have already inserted compensating destroys for the consumed
+    // sources of dead stores, so fixing their lifetimes here would insert
+    // duplicate destroys. Other instructions may consume values defined
+    // outside the dead object graph, so let InstructionDeleter compensate
+    // for those consumes.
+    if (fixLifetimes && !isa<StoreInst>(I))
+      deleter.forceDeleteAndFixLifetimes(I);
+    else
+      deleter.forceDelete(I);
   }
 }
 
@@ -1079,18 +1095,12 @@ bool DeadObjectElimination::processKeyPath(KeyPathInst *KPI) {
     for (const Operand &Op : KPI->getPatternOperands()) {
       if (Op.get()->getType().isTrivial(*KPI->getFunction()))
         continue;
-      // In ossa, we are going to delete the dead keypath which was consuming
-      // the pattern operand and insert a destroy_value of the pattern operand
-      // value. This is shortening the pattern operand value's lifetime. Check
-      // if there was a pointer escape, if so bail out.
+      // In ossa, deleting the dead keypath compensates its consuming pattern
+      // operand with a destroy_value. This is shortening the pattern operand
+      // value's lifetime. Check if there was a pointer escape, if so bail out.
       if (findPointerEscape(Op.get())) {
         return false;
       }
-    }
-    for (const Operand &Op : KPI->getPatternOperands()) {
-      if (Op.get()->getType().isTrivial(*KPI->getFunction()))
-        continue;
-      SILBuilderWithScope(KPI).createDestroyValue(KPI->getLoc(), Op.get());
     }
   }
 

--- a/lib/SILOptimizer/Transforms/DeadObjectElimination.cpp
+++ b/lib/SILOptimizer/Transforms/DeadObjectElimination.cpp
@@ -1101,6 +1101,9 @@ bool DeadObjectElimination::processKeyPath(KeyPathInst *KPI) {
     // owned value). Inserting the destroy at the deletion point shortens those
     // values' lifetimes, so bail out if any of them is lexical or has a pointer
     // escape.
+    InstructionSet usersToRemoveSet(KPI->getFunction());
+    for (auto *user : UsersToRemove)
+      usersToRemoveSet.insert(user);
     for (auto *user : UsersToRemove) {
       for (const Operand &op : user->getAllOperands()) {
         if (!op.isConsuming())
@@ -1109,7 +1112,7 @@ bool DeadObjectElimination::processKeyPath(KeyPathInst *KPI) {
         // Values defined within the dead graph are replaced with undef before
         // deletion, so they are never compensated.
         if (auto *def = value->getDefiningInstruction())
-          if (UsersToRemove.count(def))
+          if (usersToRemoveSet.contains(def))
             continue;
         if (value->isLexical() || findPointerEscape(value))
           return false;

--- a/lib/SILOptimizer/Transforms/DeadObjectElimination.cpp
+++ b/lib/SILOptimizer/Transforms/DeadObjectElimination.cpp
@@ -787,7 +787,8 @@ class DeadObjectElimination : public SILFunctionTransform {
   DominanceInfo *domInfo = nullptr;
 
   void removeInstructions(ArrayRef<SILInstruction*> toRemove);
-  
+  void removeKeyPathAndUsers(ArrayRef<SILInstruction*> toRemove);
+
   /// Try to salvage the debug info for a dead instruction removed by
   /// DeadObjectElimination.
   ///
@@ -853,27 +854,36 @@ class DeadObjectElimination : public SILFunctionTransform {
 
 void
 DeadObjectElimination::removeInstructions(ArrayRef<SILInstruction*> toRemove) {
+  for (auto *I : toRemove) {
+    I->replaceAllUsesOfAllResultsWithUndef();
+    // Now we know that I should not have any uses... erase it from its parent.
+    deleter.forceDelete(I);
+  }
+}
+
+void
+DeadObjectElimination::removeKeyPathAndUsers(
+    ArrayRef<SILInstruction*> toRemove) {
   // Drop all result uses up front so each instruction satisfies
-  // InstructionDeleter's incidental-use precondition. This also prevents
-  // lifetime fixup from compensating uses within the dead graph itself.
-  // The dead-object analysis has already checked that these users are
-  // removable.
+  // InstructionDeleter's incidental-use precondition. This also keeps the
+  // lifetime fixup below from compensating uses within the dead graph itself:
+  // undef operands have None ownership and are never consuming.
   for (auto *I : toRemove)
     I->replaceAllUsesOfAllResultsWithUndef();
 
-  bool fixLifetimes = getFunction()->hasOwnership();
-
-  for (auto *I : toRemove) {
-    // Callers have already inserted compensating destroys for the consumed
-    // sources of dead stores, so fixing their lifetimes here would insert
-    // duplicate destroys. Other instructions may consume values defined
-    // outside the dead object graph, so let InstructionDeleter compensate
-    // for those consumes.
-    if (fixLifetimes && !isa<StoreInst>(I))
-      deleter.forceDeleteAndFixLifetimes(I);
-    else
+  if (!getFunction()->hasOwnership()) {
+    for (auto *I : toRemove)
       deleter.forceDelete(I);
+    return;
   }
+
+  // In ossa, fix lifetimes so that consuming operands defined outside the dead
+  // graph get a compensating destroy_value. This covers the keypath's own
+  // pattern operands as well as owned values consumed by a removed user (e.g. a
+  // struct that packages the dead keypath together with an unrelated owned
+  // value, as in https://github.com/swiftlang/swift/issues/89791).
+  for (auto *I : toRemove)
+    deleter.forceDeleteAndFixLifetimes(I);
 }
 
 void DeadObjectElimination::salvageDebugInfo(SILInstruction *toBeRemoved) {
@@ -1076,36 +1086,39 @@ bool DeadObjectElimination::processKeyPath(KeyPathInst *KPI) {
     return false;
   }
 
-  bool hasOwnership = KPI->getFunction()->hasOwnership();
-  for (const Operand &Op : KPI->getPatternOperands()) {
+  if (!KPI->getFunction()->hasOwnership()) {
     // In non-ossa, bail out if we have non-trivial pattern operands.
-    if (!hasOwnership) {
-      if (Op.get()->getType().isTrivial(*KPI->getFunction()))
-        return false;
-      continue;
-    }
-    // In ossa, bail out if we have non-trivial pattern operand values that are
-    // lexical.
-    if (Op.get()->isLexical()) {
-      return false;
-    }
-  }
-
-  if (KPI->getFunction()->hasOwnership()) {
     for (const Operand &Op : KPI->getPatternOperands()) {
       if (Op.get()->getType().isTrivial(*KPI->getFunction()))
-        continue;
-      // In ossa, deleting the dead keypath compensates its consuming pattern
-      // operand with a destroy_value. This is shortening the pattern operand
-      // value's lifetime. Check if there was a pointer escape, if so bail out.
-      if (findPointerEscape(Op.get())) {
         return false;
+    }
+  } else {
+    // In ossa, removeKeyPathAndUsers compensates every consuming operand of a
+    // removed instruction whose value is defined outside the dead graph with a
+    // destroy_value inserted at the deletion point. This covers the keypath's
+    // own pattern operands as well as owned values consumed by a removed user
+    // (e.g. a struct that packages the dead keypath together with an unrelated
+    // owned value). Inserting the destroy at the deletion point shortens those
+    // values' lifetimes, so bail out if any of them is lexical or has a pointer
+    // escape.
+    for (auto *user : UsersToRemove) {
+      for (const Operand &op : user->getAllOperands()) {
+        if (!op.isConsuming())
+          continue;
+        SILValue value = op.get();
+        // Values defined within the dead graph are replaced with undef before
+        // deletion, so they are never compensated.
+        if (auto *def = value->getDefiningInstruction())
+          if (UsersToRemove.count(def))
+            continue;
+        if (value->isLexical() || findPointerEscape(value))
+          return false;
       }
     }
   }
 
   // Remove the keypath and all of its users.
-  removeInstructions(
+  removeKeyPathAndUsers(
     ArrayRef<SILInstruction*>(UsersToRemove.begin(), UsersToRemove.end()));
   LLVM_DEBUG(llvm::dbgs() << "    Success! Eliminating keypath.\n");
 

--- a/test/SILOptimizer/dead_alloc_elim_ossa.sil
+++ b/test/SILOptimizer/dead_alloc_elim_ossa.sil
@@ -509,6 +509,8 @@ struct Foo {
 
 // CHECK-LABEL: sil [ossa] @remove_nontrivial_dead_keypath
 // CHECK-NOT:   keypath
+// CHECK:       destroy_value %0
+// CHECK-NOT:   keypath
 // CHECK: } // end sil function 'remove_nontrivial_dead_keypath'
 sil [ossa] @remove_nontrivial_dead_keypath : $@convention(thin) (@owned String) -> () {
 bb0(%0 : @owned $String):
@@ -518,7 +520,42 @@ bb0(%0 : @owned $String):
   return %r : $()
 } 
 
+struct KeyPathRoot {
+  @_hasStorage var int: Int { get set }
+}
+
+struct KeyPathWrapper<Root, Value> {
+  @_hasStorage var object: Kl { get set }
+  @_hasStorage var value: Optional<Value> { get set }
+  @_hasStorage var keyPath: KeyPath<Root, Value> { get set }
+}
+
 sil @createit : $@convention(thin) () -> @owned Kl
+
+// https://github.com/swiftlang/swift/issues/89791
+// A removed keypath user may consume an owned value defined outside the dead
+// object graph. DeadObjectElimination must replace that consume with an
+// explicit destroy.
+//
+// CHECK-LABEL: sil [ossa] @dead_keypath_user_with_consumed_operand
+// CHECK: %[[OBJECT:[0-9]+]] = apply
+// CHECK-NEXT: destroy_value %[[OBJECT]]
+// CHECK-NOT: keypath
+// CHECK-NOT: struct $KeyPathWrapper
+// CHECK: } // end sil function 'dead_keypath_user_with_consumed_operand'
+sil [ossa] @dead_keypath_user_with_consumed_operand : $@convention(thin) () -> () {
+bb0:
+  %0 = function_ref @createit : $@convention(thin) () -> @owned Kl
+  %1 = apply %0() : $@convention(thin) () -> @owned Kl
+  %2 = keypath $any KeyPath<KeyPathRoot, Int> & Sendable, (root $KeyPathRoot; stored_property #KeyPathRoot.int : $Int)
+  %3 = open_existential_ref %2 to $@opened("11111111-1111-1111-1111-111111111111", any KeyPath<KeyPathRoot, Int> & Sendable) Self
+  %4 = upcast %3 to $KeyPath<KeyPathRoot, Int>
+  %5 = enum $Optional<Int>, #Optional.none!enumelt
+  %6 = struct $KeyPathWrapper<KeyPathRoot, Int> (%1, %5, %4)
+  destroy_value %6 : $KeyPathWrapper<KeyPathRoot, Int>
+  %7 = tuple ()
+  return %7 : $()
+}
 
 // Check that we don't crash here.
 sil [ossa] @not_dominating_stores : $@convention(thin) () -> () {

--- a/test/SILOptimizer/dead_alloc_elim_ossa.sil
+++ b/test/SILOptimizer/dead_alloc_elim_ossa.sil
@@ -557,6 +557,32 @@ bb0:
   return %7 : $()
 }
 
+struct LexicalKeyPathWrapper<Root, Value> {
+  @_hasStorage var object: Kl { get set }
+  @_hasStorage var keyPath: KeyPath<Root, Value> { get set }
+}
+
+// A removed keypath user that consumes a lexical owned value defined outside
+// the dead object graph must make DeadObjectElimination bail out. This keeps
+// the function unchanged rather than shortening the lexical value's lifetime.
+//
+// CHECK-LABEL: sil [ossa] @dead_keypath_user_with_lexical_operand
+// CHECK: move_value [lexical]
+// CHECK: keypath
+// CHECK: struct $LexicalKeyPathWrapper
+// CHECK: } // end sil function 'dead_keypath_user_with_lexical_operand'
+sil [ossa] @dead_keypath_user_with_lexical_operand : $@convention(thin) () -> () {
+bb0:
+  %0 = function_ref @createit : $@convention(thin) () -> @owned Kl
+  %1 = apply %0() : $@convention(thin) () -> @owned Kl
+  %2 = move_value [lexical] %1 : $Kl
+  %3 = keypath $KeyPath<KeyPathRoot, Int>, (root $KeyPathRoot; stored_property #KeyPathRoot.int : $Int)
+  %4 = struct $LexicalKeyPathWrapper<KeyPathRoot, Int> (%2, %3)
+  destroy_value %4 : $LexicalKeyPathWrapper<KeyPathRoot, Int>
+  %5 = tuple ()
+  return %5 : $()
+}
+
 // Check that we don't crash here.
 sil [ossa] @not_dominating_stores : $@convention(thin) () -> () {
 bb0:

--- a/test/SILOptimizer/dead_keypath_ossa_crash.swift
+++ b/test/SILOptimizer/dead_keypath_ossa_crash.swift
@@ -1,0 +1,106 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// Build a resilient module first: the key path's Output type must have opaque
+// (resilient) layout to reproduce the issue. (#89791 originally used
+// Foundation.Date; a local resilient type keeps this test SDK-independent.)
+// RUN: %target-swift-frontend -emit-module %t/ResLib.swift -parse-as-library -O -swift-version 6 -enable-library-evolution -module-name ResLib -emit-module-path %t/ResLib.swiftmodule
+
+// Build the generic key-path wrapper with cross-module optimization so that its
+// initializer is inlined into Main, which is what exposes the dead key path.
+// RUN: %target-swift-frontend -emit-module %t/BoxLib.swift -parse-as-library -O -swift-version 6 -enable-default-cmo -module-name BoxLib -I %t -emit-module-path %t/BoxLib.swiftmodule
+
+// Optimizing Main used to crash DeadObjectElimination's OSSA ownership verifier
+// with "Found a leaked owned value that was never consumed": removing the dead
+// key path also removed a struct that consumed an owned value defined outside
+// the dead graph, without inserting a compensating destroy_value.
+// https://github.com/swiftlang/swift/issues/89791
+// RUN: %target-swift-frontend -c %t/Main.swift -parse-as-library -O -swift-version 6 -enable-default-cmo -sil-verify-all -I %t -module-name Main -o /dev/null
+
+// REQUIRES: swift_in_compiler
+
+//--- ResLib.swift
+
+// A resilient struct, so that `Stamp` has opaque layout in the client.
+public struct Stamp {
+  public var t: Int
+  public init(_ t: Int) { self.t = t }
+}
+
+//--- BoxLib.swift
+
+public protocol E<Q> {
+  associatedtype Q
+}
+
+public protocol M: E where Q == Self {
+  associatedtype Fields: L<Self>
+  static var fields: Fields { get }
+}
+
+public protocol L<Q>: E where Q: M {
+  static var all: [any BP] { get }
+}
+
+public protocol P<Base, Output>: E where Q == Self, Base: M {
+  associatedtype Base
+  associatedtype Output
+}
+
+public protocol BP<T>: E where Q == T, T: P {
+  associatedtype T: P
+  var payload: T.Output? { get }
+  var keyPath: KeyPath<T.Base, T.Output> { get }
+}
+
+public struct Box<T: P>: BP {
+  public typealias Q = T
+
+  public let name: String
+  public let payload: T.Output?
+  public let keyPath: KeyPath<T.Base, T.Output>
+
+  public init(_ name: String, keyPath: KeyPath<T.Base, T.Output>, payload: T.Output? = nil) {
+    self.name = name
+    self.payload = payload
+    self.keyPath = keyPath
+  }
+
+  public var all: [any BP] { [self] }
+}
+
+//--- Main.swift
+
+import BoxLib
+import ResLib
+
+struct Root {
+  var value: Int
+  var date: Stamp
+}
+
+struct IntField: P {
+  typealias Base = Root
+  typealias Output = Int
+}
+
+struct StampField: P {
+  typealias Base = Root
+  typealias Output = Stamp
+}
+
+extension Root: M {
+  static var fields: Fields { Fields() }
+
+  struct Fields: L {
+    typealias Q = Root
+
+    let value = Box<IntField>("value", keyPath: \.value)
+    let unused = Box<IntField>("value", keyPath: \.value)
+    let date = Box<StampField>("date", keyPath: \.date)
+
+    static var all: [any BP] {
+      Root.fields.value.all + Root.fields.date.all
+    }
+  }
+}


### PR DESCRIPTION
When `DeadObjectElimination` removes a dead key path, a removable user inside the dead graph may consume an owned value defined outside of it (in #89791, a `struct` packages the dead key path together with an unrelated owned object). `processKeyPath` replaced all result uses with undef and force-deleted each instruction, so the consuming use disappeared without a compensating `destroy_value`, and the OSSA ownership verifier reported the value as leaked.

Per review, `DeadObjectElimination` is expected to be replaced by a new Swift implementation, so this is a deliberately minimal, low-risk fix suitable for a 6.4 cherry-pick: it is scoped to `processKeyPath` and leaves the other dead-object paths unchanged.

### Changes

- Keep the shared `removeInstructions` on its original behavior (`replaceAllUsesOfAllResultsWithUndef()` + `forceDelete`), so the `alloc_ref` / `alloc_stack` / array paths are untouched.
- Add `removeKeyPathAndUsers`, used only by `processKeyPath`. It drops all result uses up front (satisfying `InstructionDeleter`'s incidental-use precondition; undef operands have `None` ownership, so the lifetime fixup never compensates values defined within the dead graph). In OSSA it then deletes via `InstructionDeleter::forceDeleteAndFixLifetimes`, which inserts a compensating `destroy_value` for consuming operands defined outside the dead graph — both the key path's own pattern operands and an owned value consumed by a removed user such as a `struct`. Non-OSSA functions keep plain `forceDelete`. This subsumes the manual `destroy_value` loop `processKeyPath` previously inserted for the pattern operands, which is removed.
- Since `forceDeleteAndFixLifetimes` inserts the compensating destroy at the deletion point (shortening that value's lifetime), `processKeyPath` bails out before deleting if any consuming operand of a removed instruction whose value is defined outside the dead graph is lexical or has a pointer escape. This preserves the existing lifetime-shortening guard for key path pattern operands and applies the same check to the external consumed value.

### Tests

- Added `test/SILOptimizer/dead_keypath_ossa_crash.swift`, a Swift-source reproducer reduced from #89791: a generic key-path wrapper is inlined via cross-module optimization, and a dead wrapper packages a key path together with an owned value. It uses a local resilient type instead of `Foundation.Date` so it does not depend on the SDK. Without this change it crashes `DeadObjectElimination`'s ownership verifier with `Found a leaked owned value that was never consumed`.
- Added `dead_keypath_user_with_consumed_operand` to `test/SILOptimizer/dead_alloc_elim_ossa.sil`, the SIL-level reduction: a dead key path is wrapped in a `struct` with an owned object created outside the dead graph, and the test checks that the object now gets an explicit `destroy_value`.
- Added a `destroy_value` check to the existing `remove_nontrivial_dead_keypath` test, pinning the compensating destroy for the key path pattern operand.

All lit tests that exercise `-deadobject-elim` pass locally:

- `test/SILOptimizer/dead_keypath_ossa_crash.swift`
- `test/SILOptimizer/dead_alloc_elim_ossa.sil`
- `test/SILOptimizer/dead_alloc_elim.sil`
- `test/SILOptimizer/dead_array_elim.sil`
- `test/SILOptimizer/dead_array_elim_ossa.sil`
- `test/SILOptimizer/temp_rvalue_rle.sil`

Resolves https://github.com/swiftlang/swift/issues/89791
