### PR TITLE
[6.4] [ASTMangler] Handle `clang::NamespaceAliasDecl` in `appendAnyGenericType`

### DIFF
--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -3233,7 +3233,8 @@ void ASTMangler::appendAnyGenericType(const GenericTypeDecl *decl,
       // imported as a Swift enum.
       appendOperator("V");
     } else if (isa<clang::TypedefNameDecl>(namedDecl) ||
-               isa<clang::ObjCCompatibleAliasDecl>(namedDecl)) {
+               isa<clang::ObjCCompatibleAliasDecl>(namedDecl) ||
+               isa<clang::NamespaceAliasDecl>(namedDecl)) {
       appendOperator("a");
     } else if (isa<clang::NamespaceDecl>(namedDecl)) {
       // Note: Namespaces are not really enums, but since namespaces are

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -3178,7 +3178,6 @@ void ASTMangler::appendAnyGenericType(const GenericTypeDecl *decl,
         return false;
     }
 
-    auto *nominal = dyn_cast<NominalTypeDecl>(decl);
     auto namedDecl = getClangDeclForMangling(decl);
     if (!namedDecl) {
       if (auto typedefType = getTypeDefForCXXCFOptionsDefinition(decl)) {
@@ -3215,7 +3214,7 @@ void ASTMangler::appendAnyGenericType(const GenericTypeDecl *decl,
       // `ClassTemplateSpecializationDecl`'s name does not include information about
       // template arguments, and in order to prevent name clashes we use the
       // name of the Swift decl which does include template arguments.
-      appendIdentifier(nominal->getName().str(),
+      appendIdentifier(decl->getName().str(),
                        /*allowRawIdentifiers=*/false);
     } else {
       appendIdentifier(namedDecl->getName());
@@ -3241,7 +3240,7 @@ void ASTMangler::appendAnyGenericType(const GenericTypeDecl *decl,
       // imported as enums, be consistent.
       appendOperator("O");
     } else if (isa<clang::ClassTemplateDecl>(namedDecl)) {
-      appendIdentifier(nominal->getName().str(),
+      appendIdentifier(decl->getName().str(),
                        /*allowRawIdentifiers=*/false);
     } else {
       llvm_unreachable("unknown imported Clang type");

--- a/test/Interop/Cxx/namespace/namespace-alias-completion.swift
+++ b/test/Interop/Cxx/namespace/namespace-alias-completion.swift
@@ -1,0 +1,30 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: %target-swift-ide-test -batch-code-completion -source-filename %t/main.swift -filecheck %raw-FileCheck -I %t/Inputs -cxx-interoperability-mode=default -completion-output-dir %t/out
+
+// Make sure we don't crash when attempting to mangle a USR for the namespace
+// alias here.
+
+//--- Inputs/module.modulemap
+module CxxModule {
+  header "cxx-module.h"
+  requires cplusplus
+}
+
+//--- Inputs/cxx-module.h
+namespace Foo {
+struct Bar {};
+}
+
+namespace FooAlias = Foo;
+
+//--- main.swift
+import CxxModule
+
+func test() {
+  let _ = #^GLOBAL^#
+  let _ = FooAlias.#^IN_ALIAS^#
+}
+
+// GLOBAL: Decl[TypeAlias]/OtherModule[CxxModule]: FooAlias[#Foo#]; name=FooAlias
+// IN_ALIAS: Decl[Struct]/CurrNominal: Bar[#Foo.Bar#]; name=Bar


### PR DESCRIPTION
*6.4 cherry-pick of #89890*

- Explanation: Fixes a crash that could occur when doing a global code completion in the presence of an imported C++ namespace alias
- Scope: Affects code completion for projects using C++ interop
- Issue: rdar://170650596
- Risk: Low, adds a new ASTMangler case that would have previously just hit an `llvm_unreachable`
- Testing: Added tests to test suite
- Reviewer: Gábor Horváth