### PR TITLE
[swift-inspect][android] Get DumpConcurrency building on linux/Android

### DIFF
--- a/tools/swift-inspect/Sources/swift-inspect/Operations/DumpConcurrency.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/Operations/DumpConcurrency.swift
@@ -10,8 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if !os(Linux)
-
 import ArgumentParser
 import SwiftRemoteMirror
 #if canImport(string_h)
@@ -19,6 +17,10 @@ import string_h
 #endif
 #if canImport(ucrt)
 import ucrt
+#elseif canImport(Glibc)
+import Glibc
+#elseif canImport(Android)
+import Android
 #endif
 
 struct DumpConcurrency: ParsableCommand {
@@ -475,5 +477,3 @@ fileprivate class ConcurrencyDumper {
     }
   }
 }
-
-#endif


### PR DESCRIPTION
Let's see if this fixes [the Windows trunk toolchain CI](https://ci-external.swift.org/job/swift-main-windows-toolchain/2157/console).