### PR TITLE
Fix link and parameter documentation errors in Swift stdlib source

### DIFF
--- a/stdlib/public/Concurrency/CheckedContinuation.swift
+++ b/stdlib/public/Concurrency/CheckedContinuation.swift
@@ -427,7 +427,7 @@ public nonisolated(nonsending) func withCheckedThrowingContinuation<T>( // nonse
 }
 
 /// Source-compatibility overload; replaced by
-/// ``withCheckedThrowingContinuation(function:_:)``.
+/// ``withCheckedThrowingContinuation(function:_:)-(_,(CheckedContinuation<T,E>)->Void)``.
 @inlinable
 @available(SwiftStdlib 5.1, *)
 @backDeployed(before: SwiftStdlib 6.0)

--- a/stdlib/public/Concurrency/Continuation.swift
+++ b/stdlib/public/Concurrency/Continuation.swift
@@ -30,7 +30,7 @@ import Swift
 /// To create a continuation
 /// call ``withContinuation(of:throwing:_:)``.
 ///
-/// To resume the task, suspended on a continuation, call ``resume(returning:)``,
+/// To resume the task, suspended on a continuation, call ``resume(returning:)-5fa8w``,
 /// ``resume(throwing:)``, ``resume(with:)``, or ``resume()``.
 ///
 /// - SeeAlso: ``CheckedContinuation``

--- a/stdlib/public/Concurrency/DiscardingTaskGroup.swift
+++ b/stdlib/public/Concurrency/DiscardingTaskGroup.swift
@@ -65,10 +65,10 @@ import Swift
 /// The tasks must handle cancellation in some other way,
 /// such as returning the work completed so far, returning an empty result, or returning `nil`.
 /// For tasks that need to handle cancellation by throwing an error,
-/// use the `withThrowingDiscardingTaskGroup(returning:body:)` method instead.
+/// use the `withThrowingDiscardingTaskGroup(returning:isolation:body:)` method instead.
 ///
 /// - SeeAlso: ``TaskGroup``
-/// - SeeAlso: ``withThrowingDiscardingTaskGroup(returning:body:)``
+/// - SeeAlso: ``withThrowingDiscardingTaskGroup(returning:isolation:body:)``
 @available(SwiftStdlib 5.9, *)
 @backDeployed(before: SwiftStdlib 6.0)
 @inlinable
@@ -123,7 +123,7 @@ public func _unsafeInheritExecutor_withDiscardingTaskGroup<GroupResult>(
 /// A discarding group that contains dynamically created child tasks.
 ///
 /// To create a discarding task group,
-/// call the ``withDiscardingTaskGroup(returning:body:)`` method.
+/// call the ``withDiscardingTaskGroup(returning:isolation:body:)`` method.
 ///
 /// Don't use a task group from outside the task where you created it.
 /// In most cases,
@@ -152,8 +152,8 @@ public func _unsafeInheritExecutor_withDiscardingTaskGroup<GroupResult>(
 ///
 /// A canceled task group can still keep adding tasks, however they will start
 /// being immediately canceled, and may act accordingly to this. To avoid adding
-/// new tasks to an already canceled task group, use ``addTaskUnlessCancelled(priority:body:)``
-/// rather than the plain ``addTask(priority:body:)`` which adds tasks unconditionally.
+/// new tasks to an already canceled task group, use ``addTaskUnlessCancelled(priority:operation:)``
+/// rather than the plain ``addTask(priority:operation:)`` which adds tasks unconditionally.
 ///
 /// For information about the language-level concurrency model that `DiscardingTaskGroup` is part of,
 /// see [Concurrency][concurrency] in [The Swift Programming Language][tspl].
@@ -187,7 +187,7 @@ public struct DiscardingTaskGroup {
 
   /// A Boolean value that indicates whether the group has any remaining tasks.
   ///
-  /// At the start of the body of a `withDiscardingTaskGroup(returning:body:)` call,
+  /// At the start of the body of a `withDiscardingTaskGroup(returning:isolation:body:)` call,
   /// the task group is always empty.
   ///
   /// It's guaranteed to be empty when returning from that body
@@ -229,10 +229,10 @@ public struct DiscardingTaskGroup {
   /// ### Interaction with task cancellation shields
   ///
   /// Cancellation may be suppressed by an active task cancellation shield
-  /// (``withTaskCancellationShield(operation:)``), which may cause `isCancelled`
+  /// (``withTaskCancellationShield(operation:)-(()->Value)``), which may cause `isCancelled`
   /// to return `false` even though the task has been cancelled externally.
   ///
-  /// - SeeAlso: ``withTaskCancellationShield(operation:)``
+  /// - SeeAlso: ``withTaskCancellationShield(operation:)-(()->Value)``
   public var isCancelled: Bool {
     return _taskGroupIsCancelled(group: _group)
   }
@@ -409,7 +409,7 @@ public func _unsafeInheritExecutor_withThrowingDiscardingTaskGroup<GroupResult>(
 /// A throwing discarding group that contains dynamically created child tasks.
 ///
 /// To create a discarding task group,
-/// call the ``withDiscardingTaskGroup(returning:body:)`` method.
+/// call the ``withDiscardingTaskGroup(returning:isolation:body:)`` method.
 ///
 /// Don't use a task group from outside the task where you created it.
 /// In most cases,
@@ -452,8 +452,8 @@ public func _unsafeInheritExecutor_withThrowingDiscardingTaskGroup<GroupResult>(
 ///
 /// A canceled task group can still keep adding tasks, however they will start
 /// being immediately canceled, and may act accordingly to this. To avoid adding
-/// new tasks to an already canceled task group, use ``addTaskUnlessCancelled(priority:body:)``
-/// rather than the plain ``addTask(priority:body:)`` which adds tasks unconditionally.
+/// new tasks to an already canceled task group, use ``addTaskUnlessCancelled(priority:operation:)``
+/// rather than the plain ``addTask(priority:operation:)`` which adds tasks unconditionally.
 ///
 /// For information about the language-level concurrency model that `DiscardingTaskGroup` is part of,
 /// see [Concurrency][concurrency] in [The Swift Programming Language][tspl].
@@ -485,7 +485,7 @@ public struct ThrowingDiscardingTaskGroup<Failure: Error> {
 
   /// A Boolean value that indicates whether the group has any remaining tasks.
   ///
-  /// At the start of the body of a `withThrowingDiscardingTaskGroup(returning:body:)` call,
+  /// At the start of the body of a `withThrowingDiscardingTaskGroup(returning:isolation:body:)` call,
   /// the task group is always empty.
   ///
   /// It's guaranteed to be empty when returning from that body
@@ -527,10 +527,10 @@ public struct ThrowingDiscardingTaskGroup<Failure: Error> {
   /// ### Interaction with task cancellation shields
   ///
   /// Cancellation may be suppressed by an active task cancellation shield
-  /// (``withTaskCancellationShield(operation:)``), which may cause `isCancelled`
+  /// (``withTaskCancellationShield(operation:)-2lzl8``), which may cause `isCancelled`
   /// to return `false` even though the task has been cancelled externally.
   ///
-  /// - SeeAlso: ``withTaskCancellationShield(operation:)``
+  /// - SeeAlso: ``withTaskCancellationShield(operation:)-2lzl8``
   public var isCancelled: Bool {
     return _taskGroupIsCancelled(group: _group)
   }

--- a/stdlib/public/Concurrency/Executor.swift
+++ b/stdlib/public/Concurrency/Executor.swift
@@ -213,7 +213,7 @@ extension SchedulingExecutor {
 /// shared pool, as blocking it may prevent other actors from being responsive.
 ///
 /// You can implement a custom executor, by conforming a type to the
-/// ``SerialExecutor`` protocol, and implementing the ``enqueue(_:)`` method.
+/// ``SerialExecutor`` protocol, and implementing the ``enqueue(_:)-7sypu`` method.
 ///
 /// Once implemented, you can configure an actor to use such executor by
 /// implementing the actor's ``Actor/unownedExecutor`` computed property.
@@ -321,9 +321,10 @@ public protocol SerialExecutor: Executor {
   ///
   /// This check is not used when performing executor switching.
   ///
-  /// This check is used when performing ``Actor/assertIsolated()``,
-  /// ``Actor/preconditionIsolated()``, ``Actor/assumeIsolated()`` and similar
-  /// APIs which assert about the same "exclusive serial execution context".
+  /// This check is used when performing ``Actor/assertIsolated(_:file:line:)``,
+  /// ``Actor/preconditionIsolated(_:file:line:)``,
+  /// ``Actor/assumeIsolated(_:file:line:)`` and similar APIs which assert about
+  /// the same "exclusive serial execution context".
   ///
   /// - Parameter other: the executor to compare with.
   /// - Returns: `true`, if `self` and the `other` executor actually are
@@ -333,8 +334,9 @@ public protocol SerialExecutor: Executor {
   func isSameExclusiveExecutionContext(other: Self) -> Bool
 
   /// Last resort "fallback" isolation check, called when the concurrency runtime
-  /// is comparing executors e.g. during ``assumeIsolated()`` and is unable to prove
-  /// serial equivalence between the expected (this object), and the current executor.
+  /// is comparing executors e.g. during ``Actor/assumeIsolated(_:file:line:)``
+  /// and is unable to prove serial equivalence between the expected
+  /// (this object), and the current executor.
   ///
   /// During executor comparison, the Swift concurrency runtime attempts to compare
   /// current and expected executors in a few ways (including "complex" equality
@@ -441,9 +443,10 @@ extension SerialExecutor {
 /// requirements.
 ///
 /// By setting a task executor preference, either with a
-/// ``withTaskExecutorPreference(_:operation:)``, creating a task with a preference
-/// (`Task(executorPreference:)`, or `group.addTask(executorPreference:)`), the task and all of its child
-/// tasks (unless a new preference is set) will be preferring to execute on
+/// ``withTaskExecutorPreference(_:isolation:operation:)`` or creating a task
+/// with a preference -- using `Task(executorPreference:)` or
+/// `group.addTask(executorPreference:)` -- the task and all of its child tasks
+/// (unless a new preference is set) will be preferring to execute on
 /// the provided task executor.
 ///
 /// Unstructured tasks do not inherit the task executor.

--- a/stdlib/public/Concurrency/ExecutorAssertions.swift
+++ b/stdlib/public/Concurrency/ExecutorAssertions.swift
@@ -301,7 +301,7 @@ extension Actor {
   ///
   /// If the current context is not running on the actor's serial executor, or
   /// if the actor is a reference to a remote actor, this method will crash
-  /// with a fatal error (similar to ``preconditionIsolated()``).
+  /// with a fatal error (similar to ``preconditionIsolated(_:file:line:)``).
   ///
   /// Note that this check is performed against the passed in actor's serial
   /// executor, meaning that if another actor uses the same serial executor--by

--- a/stdlib/public/Concurrency/GlobalActor.swift
+++ b/stdlib/public/Concurrency/GlobalActor.swift
@@ -34,7 +34,7 @@ import Swift
 ///
 /// It is *not* necessary to override the ``sharedUnownedExecutor`` static
 /// property of the global actor, as its default implementation already
-/// delegates to the ``shared.unownedExecutor``, which is the most reasonable
+/// delegates to the `shared.unownedExecutor`, which is the most reasonable
 /// and correct implementation of this protocol requirement.
 ///
 /// You can find out more about custom executors, by referring to the

--- a/stdlib/public/Concurrency/GlobalConcurrentExecutor.swift
+++ b/stdlib/public/Concurrency/GlobalConcurrentExecutor.swift
@@ -26,7 +26,7 @@ import Swift
 /// You may pass this executor explicitly to a ``Task`` initializer as a task
 /// executor preference, in order to ensure and document that task be executed
 /// on the global executor, instead e.g. inheriting the enclosing actor's
-/// executor. Refer to ``withTaskExecutorPreference(_:operation:)`` for a
+/// executor. Refer to ``withTaskExecutorPreference(_:isolation:operation:)`` for a
 /// detailed discussion of task executor preferences.
 ///
 /// Customizing the global concurrent executor is currently not supported.

--- a/stdlib/public/Concurrency/MainActor.swift
+++ b/stdlib/public/Concurrency/MainActor.swift
@@ -106,7 +106,7 @@ extension MainActor {
   ///
   /// If the current context is not running on the actor's serial executor, or
   /// if the actor is a reference to a remote actor, this method will crash
-  /// with a fatal error (similar to ``preconditionIsolated()``).
+  /// with a fatal error (similar to ``preconditionIsolated(_:file:line:)``).
   ///
   /// This method can only be used from synchronous functions, as asynchronous
   /// functions should instead perform a normal method call to the actor, which

--- a/stdlib/public/Concurrency/PartialAsyncTask.swift
+++ b/stdlib/public/Concurrency/PartialAsyncTask.swift
@@ -55,7 +55,7 @@ internal func _swiftJobRunOnTaskExecutor(_ job: UnownedJob,
 /// Unless you're implementing a scheduler,
 /// you don't generally interact with jobs directly.
 ///
-/// An `UnownedJob` must be eventually run *exactly once* using ``runSynchronously(on:)``.
+/// An `UnownedJob` must be eventually run *exactly once* using `runSynchronously(on:)`.
 /// Not doing so is effectively going to leak and "hang" the work that the job represents (e.g. a ``Task``).
 @available(SwiftStdlib 5.1, *)
 @frozen
@@ -141,8 +141,6 @@ public struct UnownedJob: Sendable {
   /// as a job can only ever be run once, and must not be accessed after it has been run.
   ///
   /// - Parameter executor: the task executor this job will be run on.
-  ///
-  /// - SeeAlso: ``runSynchronously(isolatedTo:taskExecutor:)``
   @_unavailableInEmbedded
   @available(StdlibDeploymentTarget 6.0, *)
   @_alwaysEmitIntoClient
@@ -170,7 +168,8 @@ public struct UnownedJob: Sendable {
   /// - Parameter serialExecutor: the executor this job will be semantically running on.
   /// - Parameter taskExecutor: the task executor this job will be run on.
   ///
-  /// - SeeAlso: ``runSynchronously(on:)``
+  /// - SeeAlso: ``runSynchronously(on:)-(UnownedSerialExecutor)``
+  /// - SeeAlso: ``runSynchronously(on:)-(UnownedTaskExecutor)``
   @_unavailableInEmbedded
   @available(StdlibDeploymentTarget 6.0, *)
   @_alwaysEmitIntoClient
@@ -445,7 +444,8 @@ extension ExecutorJob {
   /// - Parameter serialExecutor: the executor this job will be semantically running on.
   /// - Parameter taskExecutor: the task executor this job will be run on.
   ///
-  /// - SeeAlso: ``runSynchronously(on:)``
+  /// - SeeAlso: ``runSynchronously(on:)-(UnownedSerialExecutor)``
+  /// - SeeAlso: ``runSynchronously(on:)-(UnownedTaskExecutor)``
   @_unavailableInEmbedded
   @available(StdlibDeploymentTarget 6.0, *)
   @_alwaysEmitIntoClient
@@ -611,7 +611,7 @@ public struct JobPriority: Sendable {
 
 @available(StdlibDeploymentTarget 5.9, *)
 extension TaskPriority {
-  /// Convert this ``UnownedJob/Priority`` to a ``TaskPriority``.
+  /// Convert this ``JobPriority`` to a ``TaskPriority``.
   ///
   /// Most values are directly interchangeable, but this initializer reserves the right to fail for certain values.
   @available(StdlibDeploymentTarget 5.9, *)
@@ -972,7 +972,7 @@ public nonisolated(nonsending) func withUnsafeThrowingContinuation<T>(
 }
 
 /// Source-compatibility overload; replaced by
-/// ``withUnsafeThrowingContinuation(_:)``.
+/// ``withUnsafeThrowingContinuation(_:)-((UnsafeContinuation<T,E>)->Void)``.
 @available(SwiftStdlib 5.1, *)
 @_alwaysEmitIntoClient
 @unsafe

--- a/stdlib/public/Concurrency/Task+immediate.swift.gyb
+++ b/stdlib/public/Concurrency/Task+immediate.swift.gyb
@@ -55,9 +55,9 @@ extension Task where Failure == ${FAILURE_TYPE} {
   /// Other than the execution semantics discussed above, the created task
   /// is semantically equivalent to a task created using
   % if IS_DETACHED:
-  /// the ``Task/detached`` function.
+  /// the `Task/detached(name:priority:operation:)` function.
   % else:
-  /// the ``Task/init`` initializer.
+  /// the `Task/init(name:priority:operation:)` initializer.
   % end
   ///
   /// - Parameters:
@@ -239,7 +239,7 @@ extension ${GROUP_TYPE} {
   ///
   /// Other than the execution semantics discussed above, the created task
   /// is semantically equivalent to its basic version which can be
-  /// created using ``${GROUP_TYPE}/addTask``.
+  /// created using ``${GROUP_TYPE}/addTask(priority:operation:)``.
   ///
   /// - Parameters:
   ///   - name: Human readable name of this task.

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -835,7 +835,7 @@ public struct UnsafeCurrentTask {
   /// There is no way to uncancel a task.
   ///
   /// This property returns the actual cancellation state of the task, regardless of whether
-  /// a cancellation shield is active. Use ``Task/isCancelled`` (the static property)
+  /// a cancellation shield is active. Use ``Task/isCancelled-type.property`` (the static property)
   /// if you need cancellation checking that respects active shields.
   ///
   /// ### Instance property isCancelled ignores Task Cancellation Shields
@@ -866,13 +866,13 @@ public struct UnsafeCurrentTask {
   /// Task.isCancelled
   /// ```
   ///
-  /// Prefer using `Task.isCancelled` (the static property) in most situations when checking
-  /// the cancellation status from inside the task.
+  /// Prefer using ``Task/isCancelled-type.property`` (the static property) in most
+  /// situations when checking the cancellation status from inside the task.
   ///
-  /// - SeeAlso: ``Task/isCancelled``
+  /// - SeeAlso: ``Task/isCancelled-type.property``
   /// - SeeAlso: ``Task/checkCancellation()``
   /// - SeeAlso: ``Task/hasActiveCancellationShield``
-  /// - SeeAlso: ``withTaskCancellationShield(operation:)``
+  /// - SeeAlso: ``withTaskCancellationShield(operation:)-(()->Value)``
   public var isCancelled: Bool {
     if #available(SwiftStdlib 6.4, *) {
       unsafe _isCancelled(ignoreTaskCancellationShield: true)
@@ -914,17 +914,17 @@ public struct UnsafeCurrentTask {
   /// Note that cancellation may not be observed if a task is currently executing with an
   /// active task cancellation shield. Refer to cancellation shield documentation for detailed semantics.
   ///
-  /// - SeeAlso: ``withTaskCancellationShield(operation:)``
-  /// - SeeAlso: ``Task/hasActiveTaskCancellationShield``
+  /// - SeeAlso: ``withTaskCancellationShield(operation:)-(()->Value)``
+  /// - SeeAlso: ``Task/hasActiveCancellationShield``
   public func cancel() {
     unsafe _taskCancel(_rawTask)
   }
 
   /// Checks if this task is executing in a scope with a task cancellation shield activated by the
-  /// ``withTaskCancellationShield(operation:)`` function.
+  /// ``withTaskCancellationShield(operation:)-(()->Value)`` function.
   ///
   /// An active task cancellation shield prevents a task's ability to observe if it was cancelled,
-  /// i.e. the ``Task/isCancelled`` property will always return `false` when the task is executing
+  /// i.e. the ``Task/isCancelled-type.property`` property will always return `false` when the task is executing
   /// with an active shield.
   ///
   /// This property is primarily aimed at debugging and understanding cancellation behavior
@@ -935,7 +935,7 @@ public struct UnsafeCurrentTask {
   /// Cancellation shields are not automatically inherited by child tasks; each child task must install
   /// its own shield if needed if it, independently, wanted to ignore cancellation during a specific scope.
   ///
-  /// - SeeAlso: ``withTaskCancellationShield(operation:)``
+  /// - SeeAlso: ``withTaskCancellationShield(operation:)-(()->Value)``
   /// - SeeAlso: ``Task/hasActiveCancellationShield``
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient

--- a/stdlib/public/Concurrency/TaskCancellation.swift
+++ b/stdlib/public/Concurrency/TaskCancellation.swift
@@ -203,23 +203,23 @@ extension Task {
   /// There is no way to uncancel a task.
   ///
   /// This property returns the actual cancellation state of the task, regardless of whether
-  /// a cancellation shield is active. Use ``Task/isCancelled`` (the static property)
+  /// a cancellation shield is active. Use ``Task/isCancelled-type.property`` (the static property)
   /// if you need cancellation checking that respects active shields.
   ///
   /// ### Instance property isCancelled ignores Task Cancellation Shields
   ///
-  /// The instance property `task.isCancelled`
+  /// The instance property ``Task/isCancelled-property``
   /// is not contextual and therefore does not respect cancellation shields.
   /// If a task was cancelled and is executing with an active cancellation shield,
   /// these properties will return the _actual_ cancellation status of the specific task.
   ///
-  /// Prefer using `Task.isCancelled` (the static property) in most situations when checking
+  /// Prefer using ``Task/isCancelled-type.property`` (the static property) in most situations when checking
   /// the cancellation status from inside the task.
   ///
-  /// - SeeAlso: ``Task/isCancelled``
+  /// - SeeAlso: ```Task/isCancelled-type.property``
   /// - SeeAlso: ``Task/checkCancellation()``
   /// - SeeAlso: ``Task/hasActiveCancellationShield``
-  /// - SeeAlso: ``withTaskCancellationShield(operation:)``
+  /// - SeeAlso: ``withTaskCancellationShield(operation:)-(()->Value)``
   @_transparent
   public var isCancelled: Bool {
     // This is @available(SwiftStdlib 6.4, *) but can't use SwiftStdlib in transparent function
@@ -242,11 +242,11 @@ extension Task where Success == Never, Failure == Never {
   /// ### Interaction with Task Cancellation Shields
   ///
   /// Cancellation may be suppressed by an active task cancellation shield
-  /// (``withTaskCancellationShield(operation:)``), which may cause `isCancelled`
+  /// (``withTaskCancellationShield(operation:)-(()->Value)``), which may cause `isCancelled`
   /// to return `false` even though the task has been cancelled externally.
   ///
   /// - SeeAlso: ``checkCancellation()``
-  /// - SeeAlso: ``withTaskCancellationShield(operation:)``
+  /// - SeeAlso: ``withTaskCancellationShield(operation:)-(()->Value)``
   public static var isCancelled: Bool {
     unsafe withUnsafeCurrentTask { task in
       if #available(SwiftStdlib 6.4, *) {
@@ -488,10 +488,10 @@ public func withTaskCancellationShield<Value, Failure>(
 @available(SwiftStdlib 6.4, *)
 extension Task where Success == Never, Failure == Never {
   /// Checks if the current task is executing in a scope with a task cancellation shield activated by the
-  /// ``withTaskCancellationShield(operation:)`` function.
+  /// ``withTaskCancellationShield(operation:)-(()->Value)`` function.
   ///
   /// An active task cancellation shield prevents a task's ability to observe if it was cancelled,
-  /// i.e. the ``Task/isCancelled`` property will always return `false` when the task is executing
+  /// i.e. the ``Task/isCancelled-type.property`` property will always return `false` when the task is executing
   /// with an active shield.
   ///
   /// This property is primarily aimed at  debugging and understanding cancellation behavior
@@ -502,7 +502,7 @@ extension Task where Success == Never, Failure == Never {
   /// Cancellation shields are not automatically inherited by child tasks; each child task must install
   /// its own shield if needed if it, independently, wanted to ignore cancellation during a specific scope.
   ///
-  /// - SeeAlso: ``withTaskCancellationShield(operation:)``
+  /// - SeeAlso: ``withTaskCancellationShield(operation:)-(()->Value)``
   /// - SeeAlso: ``UnsafeCurrentTask/hasActiveCancellationShield``
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient

--- a/stdlib/public/Concurrency/TaskGroup.swift
+++ b/stdlib/public/Concurrency/TaskGroup.swift
@@ -300,7 +300,7 @@ public func _unsafeInheritExecutor_withThrowingTaskGroup<ChildTaskResult, GroupR
 /// Rather, the child tasks need to cooperatively react to the cancellation,
 /// and return early if that's possible.
 ///
-/// To create unstructured concurrency tasks, you can use ``Task.init``, ``Task.detached`` or ``Task.immediate``.
+/// To create unstructured concurrency tasks, you can use `Task.init`, `Task.detached` or `Task.immediate`.
 ///
 /// Task Group Cancellation
 /// =======================
@@ -344,8 +344,8 @@ public func _unsafeInheritExecutor_withThrowingTaskGroup<ChildTaskResult, GroupR
 ///
 /// A canceled task group can still keep adding tasks, however they will start
 /// being immediately canceled, and might respond accordingly. To avoid adding
-/// new tasks to an already canceled task group, use ``addTaskUnlessCancelled(name:priority:body:)``
-/// rather than the plain ``addTask(name:priority:body:)`` which adds tasks unconditionally.
+/// new tasks to an already canceled task group, use ``addTaskUnlessCancelled(name:priority:operation:)``
+/// rather than the plain ``addTask(name:priority:operation:)`` which adds tasks unconditionally.
 ///
 /// For information about the language-level concurrency model that `TaskGroup` is part of,
 /// see [Concurrency][concurrency] in [The Swift Programming Language][tspl].
@@ -505,10 +505,10 @@ public struct TaskGroup<ChildTaskResult: Sendable> {
   /// ### Interaction with task cancellation shields
   ///
   /// Cancellation may be suppressed by an active task cancellation shield
-  /// (``withTaskCancellationShield(operation:)``), which may cause `isCancelled`
+  /// (``withTaskCancellationShield(operation:)-(()->Value)``), which may cause `isCancelled`
   /// to return `false` even though the task has been cancelled externally.
   ///
-  /// - SeeAlso: ``withTaskCancellationShield(operation:)``
+  /// - SeeAlso: ``withTaskCancellationShield(operation:)-(()->Value)``
   public var isCancelled: Bool {
     return _taskGroupIsCancelled(group: _group)
   }
@@ -564,8 +564,8 @@ extension TaskGroup: Sendable { }
 ///
 /// A canceled task group can still keep adding tasks, however they will start
 /// being immediately canceled, and may act accordingly to this. To avoid adding
-/// new tasks to an already canceled task group, use ``addTaskUnlessCancelled(priority:body:)``
-/// rather than the plain ``addTask(priority:body:)`` which adds tasks unconditionally.
+/// new tasks to an already canceled task group, use ``addTaskUnlessCancelled(priority:operation:)``
+/// rather than the plain ``addTask(priority:operation:)`` which adds tasks unconditionally.
 ///
 /// For information about the language-level concurrency model that `ThrowingTaskGroup` is part of,
 /// see [Concurrency][concurrency] in [The Swift Programming Language][tspl].
@@ -863,10 +863,10 @@ public struct ThrowingTaskGroup<ChildTaskResult: Sendable, Failure: Error> {
   /// ### Interaction with task cancellation shields
   ///
   /// Cancellation may be suppressed by an active task cancellation shield
-  /// (``withTaskCancellationShield(operation:)``), which may cause `isCancelled`
+  /// (``withTaskCancellationShield(operation:)-(()->Value)``), which may cause `isCancelled`
   /// to return `false` even though the task has been cancelled externally.
   ///
-  /// - SeeAlso: ``withTaskCancellationShield(operation:)``
+  /// - SeeAlso: ``withTaskCancellationShield(operation:)-(()->Value)``
   public var isCancelled: Bool {
     return _taskGroupIsCancelled(group: _group)
   }

--- a/stdlib/public/Distributed/DistributedActor.swift
+++ b/stdlib/public/Distributed/DistributedActor.swift
@@ -42,7 +42,7 @@ import _Concurrency
 /// This causes a number of other properties of the actor to be inferred:
 ///   - the ``SerializationRequirement`` that will be used at compile time to
 ///     verify `distributed` target declarations are well formed,
-///   - if the distributed actor is `Codable`, based on the ``ID`` being Codable or not,
+///   - if the distributed actor is `Codable`, based on the ``id`` being Codable or not,
 ///   - the type of the ``ActorSystem`` accepted in the synthesized default initializer.
 ///
 /// A distributed actor must declare what type of actor system it is ready to
@@ -151,8 +151,8 @@ import _Concurrency
 /// initialization, and cannot be set or mutated by the actor itself.
 ///
 /// ``id`` is the effective identity of the actor, and is used in equality checks,
-/// as well as the actor's synthesized ``Codable`` conformance if the ``ID`` type
-/// conforms to ``Codable``.
+/// as well as the actor's synthesized `Codable` conformance if the ``id`` type
+/// conforms to `Codable`.
 ///
 /// ## Automatic Conformances
 ///
@@ -172,30 +172,28 @@ import _Concurrency
 /// implementations.
 ///
 /// ### Implicit Codable conformance
-/// If created with an actor system whose ``DistributedActorSystem/ActorID`` is ``Codable``, the
+/// If created with an actor system whose ``DistributedActorSystem/ActorID`` is `Codable`, the
 /// compiler will synthesize code for the concrete distributed actor to conform
-/// to ``Codable`` as well.
+/// to `Codable` as well.
 ///
 /// This is necessary to support distributed calls where the `SerializationRequirement`
-/// is ``Codable`` and thus users may want to pass actors as arguments to remote calls.
+/// is `Codable` and thus users may want to pass actors as arguments to remote calls.
 ///
-/// The synthesized implementations use a single ``SingleValueEncodingContainer`` to
-/// encode/decode the ``id`` property of the actor. The ``Decoder`` required
-/// ``Decoder/init(from:)`` is implemented by retrieving an actor system from the
+/// The synthesized implementations use a single `SingleValueEncodingContainer` to
+/// encode/decode the ``id`` property of the actor. The `Decoder` required
+/// `Decoder.init(from:)` is implemented by retrieving an actor system from the
 /// decoders' `userInfo`, effectively like as follows:
 ///
 /// ```swift
 /// decoder.userInfo[.actorSystemKey] as? ActorSystem
 /// ```
 ///
-/// The such obtained actor system is then used to ``resolve(id:using:)`` the decoded ``ID``.
+/// The such obtained actor system is then used to ``resolve(id:using:)`` the decoded ``id``.
 ///
-/// Use the ``CodingUserInfoKey/actorSystemKey`` to provide the necessary
+/// Use the `CodingUserInfoKey.actorSystemKey` to provide the necessary
 /// actor system for the decoding initializer when decoding a distributed actor.
 ///
 /// - SeeAlso: ``DistributedActorSystem``
-/// - SeeAlso: ``Actor``
-/// - SeeAlso: ``AnyActor``
 @available(SwiftStdlib 5.7, *)
 public protocol DistributedActor: AnyObject, Sendable, Identifiable, Hashable
   where ID == ActorSystem.ActorID,
@@ -243,7 +241,7 @@ public protocol DistributedActor: AnyObject, Sendable, Identifiable, Hashable
   nonisolated var actorSystem: ActorSystem { get }
 
   /// Retrieve the executor for this distributed actor as an optimized,
-  /// unowned reference. This API is equivalent to ``Actor/unownedExecutor``,
+  /// unowned reference. This API is equivalent to `Actor.unownedExecutor`,
   /// however, by default, it intentionally returns `nil` if this actor is a reference
   /// to a remote distributed actor, because the executor for remote references
   /// is effectively never going to execute any code "on" this actor's isolated state 
@@ -307,10 +305,10 @@ extension CodingUserInfoKey {
 
   /// Key which is required to be set on a `Decoder`'s `userInfo` while attempting
   /// to `init(from:)` a `DistributedActor`. The stored value under this key must
-  /// conform to ``DistributedActorSystem``.
+  /// conform to `DistributedActorSystem`.
   ///
   /// Forgetting to set this key will result in that initializer throwing, because
-  /// an actor system is required in order to call ``DistributedActor/resolve(id:using:)`` using it.
+  /// an actor system is required in order to call `DistributedActor.resolve(id:using:)` using it.
   @available(SwiftStdlib 5.7, *)
   public static let actorSystemKey = CodingUserInfoKey(rawValue: "$distributed_actor_system")!
 }
@@ -319,13 +317,13 @@ extension CodingUserInfoKey {
 extension DistributedActor /*: implicitly Decodable */ where Self.ID: Decodable {
 
   /// Initializes an instance of this distributed actor by decoding its ``id``,
-  /// and passing it to the ``DistributedActorSystem`` obtained from `decoder.userInfo[actorSystemKey]`.
+  /// and passing it to the `DistributedActorSystem` obtained from `decoder.userInfo[actorSystemKey]`.
   ///
-  /// ## Requires: The decoder must have the ``CodingUserInfoKey/actorSystemKey`` set to
+  /// ## Requires: The decoder must have the `CodingUserInfoKey.actorSystemKey` set to
   /// the ``ActorSystem`` that this actor expects, as it will be used to call ``DistributedActor/resolve(id:using:)``
   /// on, in order to obtain the instance this initializer should return.
   ///
-  /// - Parameter decoder: used to decode the ``ID`` of this distributed actor.
+  /// - Parameter decoder: used to decode the ``id`` of this distributed actor.
   /// - Throws: If the actor system value in `decoder.userInfo` is missing or mistyped;
   ///           the `ID` fails to decode from the passed `decoder`;
   //            or if the ``DistributedActor/resolve(id:using:)`` method invoked by this initializer throws.

--- a/stdlib/public/Distributed/DistributedActorSystem.swift
+++ b/stdlib/public/Distributed/DistributedActorSystem.swift
@@ -91,11 +91,11 @@ import _Concurrency
 /// It can be as small as an integer based identifier, or as large as a series of key-value pairs identifying the actor.
 ///
 /// The actor system must retain a mapping from the ``ActorID`` to the specific actor _instance_ which it is given in
-/// ``actorReady(_:)`` in order to implement the ``resolve(id:using:)`` method, which is how incoming and outgoing remote calls are made possible.
+/// ``actorReady(_:)`` in order to implement the ``resolve(id:as:)`` method, which is how incoming and outgoing remote calls are made possible.
 ///
 /// Users have no control over this assignment, nor are they allowed to set the `id` property explicitly.
-/// The ``DistributedActor/id`` is used to implement the distributed actor's ``Hashable``, ``Equatable``,
-/// and even ``Codable`` conformance (which is synthesized if and only if the ``ActorID`` is ``Codable`` itself).
+/// The ``DistributedActor/id`` is used to implement the distributed actor's `Hashable`, `Equatable`,
+/// and even `Codable` conformance (which is synthesized if and only if the ``ActorID`` is `Codable` itself).
 ///
 /// > Tip: Take note that throwing or failable initializers complicate this somewhat. Thankfully, the compiler
 /// > will always emit the right code such that every ``assignID(_:)`` is balanced with a ``resignID(_:)`` call,
@@ -108,7 +108,7 @@ import _Concurrency
 /// Manually invoking `assignID` and `resignID` is generally not recommended but isn't strictly a programmer error,
 /// and it is up to the actor system to decide how to deal with such calls.
 ///
-/// Once the ``distributed actor`` deinitializes, a call to ``resignID(_:)`` will be made. Generally this is made from
+/// Once the `distributed actor` deinitializes, a call to ``resignID(_:)`` will be made. Generally this is made from
 /// the distributed actor's `deinit`, however in the case of throwing initializers it may also happen during such failed
 /// init, in order to release the ID that is no longer used.
 ///
@@ -133,7 +133,7 @@ import _Concurrency
 /// > Note: Generally due to actor initializer isolation rules, users will need to make their initializers `async`
 /// in order to write code that safely performs extra actions after it has fully initialized.
 ///
-/// The ``actorReady(_)`` call on the actor system is a signal to the actor system that this actor _instance_ is now ready
+/// The ``actorReady(_:)`` call on the actor system is a signal to the actor system that this actor _instance_ is now ready
 /// and may be resolved and interacted with via the actor system. Generally, a distributed actor system implementation
 /// will _weakly retain_ the actors it has readied, because retaining them strongly would mean that they will never be
 /// deallocated (and thus never resign their ID's).
@@ -177,7 +177,7 @@ import _Concurrency
 /// into some form of wire envelope, and send it over the network (or process boundary) using some
 /// transport mechanism of their choice. As they do so, they need to suspend the `remoteCall` function,
 /// and resume it once a reply to the call arrives. Unless the transport layer is also async/await aware,
-/// this will often require making use of a ``CheckedContinuation``.
+/// this will often require making use of a `CheckedContinuation`.
 ///
 /// While implementing remote calls please keep in mind any potential failure scenarios that may occur,
 /// such as message loss, connection failures and similar issues. Such situations should all be
@@ -201,9 +201,9 @@ public protocol DistributedActorSystem<SerializationRequirement>: Sendable {
   /// The type ID that will be assigned to any distributed actor managed by this actor system.
   ///
   /// ### A note on Codable IDs
-  /// If this type is ``Codable``, then any `distributed actor` using this `ActorID` as its ``DistributedActor/ID``
-  /// will gain a synthesized ``Codable`` conformance which is implemented by encoding the `ID`.
-  /// The decoding counter part of the ``Codable`` conformance is implemented by decoding the `ID` and passing it to
+  /// If this type is `Codable`, then any `distributed actor` using this `ActorID` as its ``DistributedActor/id``
+  /// will gain a synthesized `Codable` conformance which is implemented by encoding the `ID`.
+  /// The decoding counter part of the `Codable` conformance is implemented by decoding the `ID` and passing it to
   /// the ``DistributedActor/resolve(id:using:)`` method.
   associatedtype ActorID: Sendable & Hashable
 
@@ -791,14 +791,14 @@ public struct RemoteCallArgument<Value> {
 /// by the Swift runtime to decode arguments of the invocation.
 ///
 /// ### Decoding DistributedActor arguments using Codable
-/// When using an actor system where ``ActorID`` is ``Codable``, every distributed actor using that system
-/// is also implicitly ``Codable`` (see ``DistributedActorSystem``). Such distributed actors are encoded
-/// as their ``ActorID`` stored in an ``Encoder/singleValueContainer``. When ``Codable`` is being used
-/// by such a system, the ``decodeNextArgument`` method will be using ``Decoder`` to
+/// When using an actor system where `ActorID` is `Codable`, every distributed actor using that system
+/// is also implicitly `Codable` (see ``DistributedActorSystem``). Such distributed actors are encoded
+/// as their `ActorID` stored in an `Encoder.singlevaluecontainer()`. When `Codable` is being used
+/// by such a system, the ``decodeNextArgument()`` method will be using `Decoder` to
 /// decode the incoming values, which may themselves be distributed actors.
 ///
-/// An actor system must be provided to the ``Decoder`` in order for a distributed actor's ``Decodable/init(from:)``
-/// to be able to return the instance of the actor. Specifically, the decoded``ActorID`` is passed to the actor system's `resolve(id:as:)` method in order to 
+/// An actor system must be provided to the `Decoder` in order for a distributed actor's `Decodable.init(from:)`
+/// to be able to return the instance of the actor. Specifically, the decoded `ActorID` is passed to the actor system's `resolve(id:as:)` method in order to
 /// return either a local instance identified by this ID, or creating a remote actor reference.
 /// Thus, you must set the actor system the decoding is performed for, on the decoder's `userInfo`, as follows:
 ///
@@ -859,7 +859,7 @@ public protocol DistributedTargetInvocationDecoder<SerializationRequirement> {
 /// Protocol a distributed invocation execution's result handler.
 ///
 /// An instance conforming to this type must be passed when invoking
-/// ``executeDistributedTarget(on:target:invocationDecoder:handler:)`` while handling an incoming distributed call.
+/// ``DistributedActorSystem/executeDistributedTarget(on:target:invocationDecoder:handler:)`` while handling an incoming distributed call.
 ///
 /// The handler will then be invoked with the return value (or error) that the invoked target returned (or threw).
 @available(SwiftStdlib 5.7, *)

--- a/stdlib/public/Distributed/DistributedAssertions.swift
+++ b/stdlib/public/Distributed/DistributedAssertions.swift
@@ -32,7 +32,7 @@ extension DistributedActor {
   ///
   /// - Note: Because this check is performed against the actor's serial executor,
   ///   if another actor uses the same serial executor--by using
-  ///   that actor's serial executor as its own ``Actor/unownedExecutor``--this
+  ///   that actor's serial executor as its own `Actor.unownedExecutor`--this
   ///   check will succeed.  From a concurrency safety perspective, the
   ///   serial executor guarantees mutual exclusion of those two actors.
   ///
@@ -79,7 +79,7 @@ extension DistributedActor {
   ///
   /// - Note: This check is performed against the actor's serial executor,
   ///   meaning that / if another actor uses the same serial executor--by using
-  ///   that actor's serial executor as its own ``Actor/unownedExecutor``--this
+  ///   that actor's serial executor as its own `Actor.unownedExecutor`--this
   ///   check will succeed , as from a concurrency safety perspective, the
   ///   serial executor guarantees mutual exclusion of those two actors.
   ///
@@ -129,7 +129,7 @@ extension DistributedActor {
   ///
   /// If the current context is not running on the actor's serial executor,
   /// this method will crash with a fatal error (similar
-  /// to ``preconditionIsolated()``).
+  /// to ``preconditionIsolated(_:file:line:)``).
   ///
   /// This method can only be used from synchronous functions, as asynchronous
   /// functions should instead perform a normal method call to the actor, which

--- a/stdlib/public/Observation/Sources/Observation/Observations.swift
+++ b/stdlib/public/Observation/Sources/Observation/Observations.swift
@@ -141,7 +141,6 @@ public struct Observations<Element: Sendable, Failure: Error>: AsyncSequence, Se
   /// The emit closure is responsible for extracting a value out of a single or many `@Observable` types.
   ///
   /// - Parameters:
-  ///     - isolation:  The concurrency isolation domain of the caller.
   ///     - emit: A closure to generate an element for the sequence.
   public init(
     @_inheritActorContext _ emit: @escaping @isolated(any) @Sendable () throws(Failure) -> Element
@@ -155,7 +154,6 @@ public struct Observations<Element: Sendable, Failure: Error>: AsyncSequence, Se
   /// continues to be invoked until the .finished option is returned or an error is thrown.
   ///
   /// - Parameters:
-  ///     - isolation:  The concurrency isolation domain of the caller.
   ///     - emit: A closure to generate an element for the sequence.
   public static func untilFinished(
     @_inheritActorContext _ emit: @escaping @isolated(any) @Sendable () throws(Failure) -> Iteration

--- a/stdlib/public/RuntimeModule/Backtrace.swift
+++ b/stdlib/public/RuntimeModule/Backtrace.swift
@@ -33,7 +33,7 @@ public struct Backtrace: CustomStringConvertible, Sendable {
   ///
   /// This is used as an opaque type; if you have some Address, you
   /// can ask if it's NULL, and you can attempt to convert it to a
-  /// ``FixedWidthInteger``.
+  /// `FixedWidthInteger`.
   ///
   /// This is intentionally _not_ a pointer, because you shouldn't be
   /// dereferencing them; they may refer to some other process, for

--- a/stdlib/public/RuntimeModule/Mangling.swift
+++ b/stdlib/public/RuntimeModule/Mangling.swift
@@ -73,9 +73,9 @@ public func demangle(_ mangledName: String) throws(DemanglingError) -> String {
 /// of the output span.
 /// 
 /// The demangled output may be _truncated_ if the output span's capacity is insufficient for the
-/// demangled output string! You can detect this situation by inspecting the returned ``DemanglingResult``,
-/// for the ``DemanglingResult/truncated`` case.
-/// 
+/// demangled output string! You can detect this situation by inspecting the thrown ``DemanglingError``,
+/// for the ``DemanglingError/truncated(requiredBufferSize:)`` case.
+///
 /// - Parameters:
 ///   - mangledName: A mangled Swift symbol.
 ///   - output: A pre-allocated span to demangle the Swift symbol into.

--- a/stdlib/public/Synchronization/Atomics/AtomicRepresentable.swift
+++ b/stdlib/public/Synchronization/Atomics/AtomicRepresentable.swift
@@ -237,7 +237,7 @@ where
   ///   representation used in atomic operations back into the logical type for
   ///   normal use, `Self`.
   ///
-  /// - Parameter storage: The storage representation for `Self` that's used
+  /// - Parameter representation: The storage representation for `Self` that's used
   ///   within atomic operations.
   /// - Returns: The newly decoded logical type `Self`.
   @available(SwiftStdlib 6.0, *)

--- a/stdlib/public/Synchronization/Atomics/WordPair.swift
+++ b/stdlib/public/Synchronization/Atomics/WordPair.swift
@@ -122,7 +122,7 @@ extension WordPair: AtomicRepresentable {
   ///   representation used in atomic operations back into the logical type for
   ///   normal use, `Self`.
   ///
-  /// - Parameter storage: The storage representation for `Self` that's used
+  /// - Parameter representation: The storage representation for `Self` that's used
   ///   within atomic operations.
   /// - Returns: The newly decoded logical type `Self`.
   @available(SwiftStdlib 6.0, *)

--- a/stdlib/public/core/MutableRef.swift
+++ b/stdlib/public/core/MutableRef.swift
@@ -33,8 +33,8 @@ public struct MutableRef<Value: ~Copyable>: ~Copyable, ~Escapable {
   /// 'unsafeAddress' as the mutable reference based on the mutating lifetime of
   /// the given 'owner' argument.
   ///
-  /// - Parameter unsafeAddress: The address to use to mutably reference an
-  ///                            instance of type `Value`.
+  /// - Parameter pointer: The address to use to mutably reference an
+  ///                      instance of type `Value`.
   /// - Parameter owner: The owning instance that this `MutableRef` instance's
   ///                    lifetime is based on.
   @available(SwiftStdlib 6.4, *)

--- a/stdlib/public/core/Policy.swift
+++ b/stdlib/public/core/Policy.swift
@@ -376,8 +376,8 @@ public typealias AnyClass = AnyObject.Type
 ///   primarily intended to enable `case` statement pattern matching.
 ///
 /// - Parameters:
-///   - lhs: A value to compare.
-///   - rhs: Another value to compare.
+///   - a: A value to compare.
+///   - b: Another value to compare.
 @_transparent
 public func ~= <T: Equatable>(a: T, b: T) -> Bool {
   return a == b

--- a/stdlib/public/core/Range.swift
+++ b/stdlib/public/core/Range.swift
@@ -92,7 +92,7 @@ extension RangeExpression {
   ///
   /// - Parameters:
   ///   - pattern: A range.
-  ///   - bound: A value to match against `pattern`.
+  ///   - value: A value to match against `pattern`.
   @inlinable
   @inline(__always)
   public static func ~= (pattern: Self, value: Bound) -> Bool {
@@ -944,7 +944,7 @@ extension Collection {
   ///     print(streetsSlice[0])
   ///     // error: Index out of bounds
   ///
-  /// - Parameter bounds: A range of the collection's indices. The bounds of
+  /// - Parameter r: A range of the collection's indices. The bounds of
   ///   the range must be valid indices of the collection.
   ///
   /// - Complexity: O(1)

--- a/stdlib/public/core/RangeSet.swift
+++ b/stdlib/public/core/RangeSet.swift
@@ -174,8 +174,9 @@ extension RangeSet {
   /// specified indices in the given collection.
   ///
   /// - Parameters:
-  ///   - index: The index to include in the range set. `index` must be a
-  ///     valid index of `collection` that isn't the collection's `endIndex`.
+  ///   - indices: The indices to include in the range set. All members of
+  ///   `indices` must be valid indicies of `collection` that aren't
+  ///   equal to the collection's `endIndex`.
   ///   - collection: The collection that contains `index`.
   @inlinable
   public init<S: Sequence, C: Collection>(

--- a/stdlib/public/core/Ref.swift
+++ b/stdlib/public/core/Ref.swift
@@ -32,7 +32,7 @@ public struct Ref<Value: ~Copyable>: Copyable, ~Escapable {
   /// 'unsafeAddress' as the reference based on the borrowed lifetime of the
   /// given 'owner' argument.
   ///
-  /// - Parameter unsafeAddress: The address to use to reference an instance of
+  /// - Parameter pointer: The address to use to reference an instance of
   ///                            type `Value`.
   /// - Parameter owner: The owning instance that this `Ref` instance's
   ///                    lifetime is based on.

--- a/stdlib/public/core/Repeat.swift
+++ b/stdlib/public/core/Repeat.swift
@@ -100,7 +100,7 @@ extension Repeated: RandomAccessCollection {
 ///
 /// - Parameters:
 ///   - element: The element to repeat.
-///   - count: The number of times to repeat `element`.
+///   - n: The number of times to repeat `element`.
 /// - Returns: A collection that contains `count` elements that are all
 ///   `element`.
 @inlinable // trivial-implementation

--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -1109,8 +1109,8 @@ extension Sequence {
   ///     print(numbers.dropLast(10))
   ///     // Prints "[]"
   ///
-  /// - Parameter n: The number of elements to drop off the end of the
-  ///   sequence. `n` must be greater than or equal to zero.
+  /// - Parameter k: The number of elements to drop off the end of the
+  ///   sequence. `k` must be greater than or equal to zero.
   /// - Returns: A sequence leaving off the specified number of elements.
   ///
   /// - Complexity: O(*n*), where *n* is the length of the sequence.

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -623,7 +623,7 @@ extension Set: SetAlgebra {
 
   /// Removes all members from the set.
   ///
-  /// - Parameter keepingCapacity: If `true`, the set's buffer capacity is
+  /// - Parameter keepCapacity: If `true`, the set's buffer capacity is
   ///   preserved; if `false`, the underlying buffer is released. The
   ///   default is `false`.
   @inlinable

--- a/stdlib/public/core/Span/RawSpan.swift
+++ b/stdlib/public/core/Span/RawSpan.swift
@@ -330,7 +330,7 @@ extension RawSpan {
   /// Creates a `RawSpan` over the memory represented by a `Span<Element>`
   ///
   /// - Parameters:
-  ///   - unsafeElements: An existing `Span<Element>`, from which this
+  ///   - span: An existing `Span<Element>`, from which this
   ///     `RawSpan` will inherit its lifetime.
   @_alwaysEmitIntoClient
   @unsafe
@@ -349,7 +349,7 @@ extension RawSpan {
   /// Creates a `RawSpan` over the memory represented by a `Span<Element>`.
   ///
   /// - Parameters:
-  ///   - elements: An existing `Span<Element>`, from which this `RawSpan` will
+  ///   - span: An existing `Span<Element>`, from which this `RawSpan` will
   ///     inherit its lifetime.
   @_alwaysEmitIntoClient
   @_lifetime(copy span)

--- a/stdlib/public/core/StringIndex.swift
+++ b/stdlib/public/core/StringIndex.swift
@@ -139,7 +139,9 @@ extension String.Index {
 
   /// Creates a new index at the specified UTF-16 code unit offset
   ///
-  /// - Parameter offset: An offset in UTF-16 code units.
+  /// - Parameters:
+  ///   - offset: An offset in UTF-16 code units.
+  ///   - s: The string.
   public init<S: StringProtocol>(utf16Offset offset: Int, in s: S) {
     let (start, end) = (s.utf16.startIndex, s.utf16.endIndex)
     guard offset >= 0,

--- a/stdlib/public/core/StringRangeReplaceableCollection.swift
+++ b/stdlib/public/core/StringRangeReplaceableCollection.swift
@@ -285,8 +285,6 @@ extension String: RangeReplaceableCollection {
   /// - Parameter bounds: The range of the elements to remove. The upper and
   ///   lower bounds of `bounds` must be valid indices of the string and not
   ///   equal to the string's end index.
-  /// - Parameter bounds: The range of the elements to remove. The upper and
-  ///   lower bounds of `bounds` must be valid indices of the string.
   public mutating func removeSubrange(_ bounds: Range<Index>) {
     let bounds = _guts.validateScalarRange(bounds)
     _guts.remove(from: bounds.lowerBound, to: bounds.upperBound)

--- a/stdlib/public/core/StringUTF16View.swift
+++ b/stdlib/public/core/StringUTF16View.swift
@@ -415,7 +415,7 @@ extension String.UTF16View: BidirectionalCollection {
   ///     print("First character's UTF-16 code unit: \(greeting.utf16[i])")
   ///     // Prints "First character's UTF-16 code unit: 72"
   ///
-  /// - Parameter position: A valid index of the view. `position` must be
+  /// - Parameter idx: A valid index of the view. `idx` must be
   ///   less than the view's end index.
   @inlinable @inline(__always)
   public subscript(idx: Index) -> UTF16.CodeUnit {

--- a/stdlib/public/core/StringUTF8View.swift
+++ b/stdlib/public/core/StringUTF8View.swift
@@ -220,7 +220,7 @@ extension String.UTF8View: BidirectionalCollection {
   ///     print("First character's UTF-8 code unit: \(greeting.utf8[i])")
   ///     // Prints "First character's UTF-8 code unit: 72"
   ///
-  /// - Parameter position: A valid index of the view. `position`
+  /// - Parameter i: A valid index of the view. `i`
   ///   must be less than the view's end index.
   @inlinable @inline(__always)
   public subscript(i: Index) -> UTF8.CodeUnit {

--- a/stdlib/public/core/UniqueArray/UniqueArray+Insertions.swift
+++ b/stdlib/public/core/UniqueArray/UniqueArray+Insertions.swift
@@ -26,7 +26,7 @@ extension UniqueArray where Element: ~Copyable {
   /// make room for the new item.
   ///
   /// - Parameter item: The new element to insert into the array.
-  /// - Parameter i: The position at which to insert the new element.
+  /// - Parameter index: The position at which to insert the new element.
   ///   `index` must be a valid index in the array.
   ///
   /// - Complexity: O(`self.count`)
@@ -65,10 +65,10 @@ extension UniqueArray where Element: ~Copyable {
   ///     // `buffer` now contains [-999, 0, 1, 2, 999]
   ///
   /// - Parameters:
-  ///    - count: The number of items to insert into the array.
+  ///    - newItemCount: The number of items to insert into the array.
   ///    - index: The position at which to insert the new items.
   ///       `index` must be a valid index in the array.
-  ///    - body: A callback that gets called at most once to directly
+  ///    - initializer: A callback that gets called at most once to directly
   ///       populate newly reserved storage within the array. The function
   ///       is called with an empty output span of capacity matching the
   ///       supplied count, and it must fully populate it before returning.
@@ -102,6 +102,7 @@ extension UniqueArray where Element: ~Copyable {
   /// - Parameters:
   ///    - items: A fully initialized buffer whose contents to move into
   ///        the array.
+  ///    - index: The index at which to move `items`.
   ///
   /// - Complexity: O(`self.count` + `items.count`)
   @available(SwiftStdlib 6.4, *)

--- a/stdlib/public/core/UniqueArray/UniqueArray+Removals.swift
+++ b/stdlib/public/core/UniqueArray/UniqueArray+Removals.swift
@@ -57,7 +57,7 @@ extension UniqueArray where Element: ~Copyable {
   /// All the elements following the specified position are moved to close the
   /// gap.
   ///
-  /// - Parameter i: The position of the element to remove. `index` must be
+  /// - Parameter index: The position of the element to remove. `index` must be
   ///   a valid index of the array that is not equal to the end index.
   /// - Returns: The removed element.
   ///

--- a/stdlib/public/core/UniqueArray/UniqueArray.swift
+++ b/stdlib/public/core/UniqueArray/UniqueArray.swift
@@ -154,7 +154,7 @@ extension UniqueArray where Element: ~Copyable {
   /// buffer of the specified capacity, moving all existing elements
   /// to its new storage. The old storage is then deallocated.
   ///
-  /// - Parameter newCapacity: The desired new capacity. `newCapacity` must be
+  /// - Parameter capacity: The desired new capacity. `newCapacity` must be
   ///    greater than or equal to the current count.
   ///
   /// - Complexity: O(`count`)

--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -1641,7 +1641,7 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
   ///     closure's execution. If `body` has a return value, that value
   ///     is also used as the return value for the `withMemoryRebound(to:_:)`
   ///     method.
-  ///   - buffer: The buffer temporarily bound to `T`.
+  ///     - term buffer: The buffer temporarily bound to `T`.
   /// - Returns: The return value, if any, of the `body` closure parameter.
   @_alwaysEmitIntoClient @_transparent
   public func withMemoryRebound<T: ~Copyable, E: Error, Result: ~Copyable>(

--- a/stdlib/public/core/UnsafeBufferPointerSlice.swift
+++ b/stdlib/public/core/UnsafeBufferPointerSlice.swift
@@ -277,7 +277,6 @@ extension Slice where Base == UnsafeMutableRawBufferPointer {
   ///     pointer argument is valid only for the duration of the closure's
   ///     execution. If `body` has a return value, that value is also used as
   ///     the return value for the `withMemoryRebound(to:capacity:_:)` method.
-  ///   - buffer: The buffer temporarily bound to instances of `T`.
   /// - Returns: The return value, if any, of the `body` closure parameter.
   @inlinable
   @_alwaysEmitIntoClient
@@ -303,7 +302,7 @@ extension Slice where Base == UnsafeMutableRawBufferPointer {
   ///   `Int(bitPattern: base.baseAddress+startIndex) % MemoryLayout<T>.alignment`
   ///   must equal zero.
   ///
-  /// - Parameter to: The type `T` that the memory has already been bound to.
+  /// - Parameter type: The type `T` that the memory has already been bound to.
   /// - Returns: A typed pointer to the same memory as this raw pointer.
   @inlinable
   @_alwaysEmitIntoClient
@@ -517,7 +516,7 @@ extension Slice where Base == UnsafeRawBufferPointer {
   ///     pointer argument is valid only for the duration of the closure's
   ///     execution. If `body` has a return value, that value is also used as
   ///     the return value for the `withMemoryRebound(to:capacity:_:)` method.
-  ///   - buffer: The buffer temporarily bound to instances of `T`.
+  ///     - type buffer: The buffer temporarily bound to instances of `T`.
   /// - Returns: The return value, if any, of the `body` closure parameter.
   @inlinable
   @_alwaysEmitIntoClient
@@ -543,7 +542,7 @@ extension Slice where Base == UnsafeRawBufferPointer {
   ///   `Int(bitPattern: base.baseAddress+startIndex) % MemoryLayout<T>.alignment`
   ///   must equal zero.
   ///
-  /// - Parameter to: The type `T` that the memory has already been bound to.
+  /// - Parameter type: The type `T` that the memory has already been bound to.
   /// - Returns: A typed pointer to the same memory as this raw pointer.
   @inlinable
   @_alwaysEmitIntoClient
@@ -695,7 +694,6 @@ extension Slice {
   ///     closure's execution. If `body` has a return value, that value
   ///     is also used as the return value for the `withMemoryRebound(to:_:)`
   ///     method.
-  ///   - buffer: The buffer temporarily bound to `T`.
   /// - Returns: The return value, if any, of the `body` closure parameter.
   @inlinable
   @_alwaysEmitIntoClient
@@ -1143,7 +1141,6 @@ extension Slice {
   ///     closure's execution. If `body` has a return value, that value
   ///     is also used as the return value for the `withMemoryRebound(to:_:)`
   ///     method.
-  ///   - buffer: The buffer temporarily bound to `T`.
   /// - Returns: The return value, if any, of the `body` closure parameter.
   @inlinable
   @_alwaysEmitIntoClient

--- a/stdlib/public/core/UnsafePointer.swift
+++ b/stdlib/public/core/UnsafePointer.swift
@@ -392,7 +392,6 @@ extension UnsafePointer where Pointee: ~Copyable {
   ///     pointer argument is valid only for the duration of the closure's
   ///     execution. If `body` has a return value, that value is also used as
   ///     the return value for the `withMemoryRebound(to:capacity:_:)` method.
-  ///   - pointer: The pointer temporarily bound to `T`.
   /// - Returns: The return value, if any, of the `body` closure parameter.
   @_alwaysEmitIntoClient
   public func withMemoryRebound<T: ~Copyable, E: Error, Result: ~Copyable>(
@@ -1250,7 +1249,6 @@ extension UnsafeMutablePointer where Pointee: ~Copyable {
   ///     pointer argument is valid only for the duration of the closure's
   ///     execution. If `body` has a return value, that value is also used as
   ///     the return value for the `withMemoryRebound(to:capacity:_:)` method.
-  ///   - pointer: The pointer temporarily bound to `T`.
   /// - Returns: The return value, if any, of the `body` closure parameter.
   @_alwaysEmitIntoClient
   @unsafe

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -1126,7 +1126,7 @@ extension Unsafe${Mutable}RawBufferPointer {
   ///     pointer argument is valid only for the duration of the closure's
   ///     execution. If `body` has a return value, that value is also used as
   ///     the return value for the `withMemoryRebound(to:capacity:_:)` method.
-  ///   - buffer: The buffer temporarily bound to instances of `T`.
+  ///     - term buffer: The buffer temporarily bound to instances of `T`.
   /// - Returns: The return value, if any, of the `body` closure parameter.
   @_alwaysEmitIntoClient @_transparent
   public func withMemoryRebound<T: ~Copyable, E: Error, Result: ~Copyable>(

--- a/stdlib/public/core/UnsafeRawPointer.swift
+++ b/stdlib/public/core/UnsafeRawPointer.swift
@@ -391,7 +391,6 @@ extension UnsafeRawPointer {
   ///     pointer argument is valid only for the duration of the closure's
   ///     execution. If `body` has a return value, that value is also used as
   ///     the return value for the `withMemoryRebound(to:capacity:_:)` method.
-  ///   - pointer: The pointer temporarily bound to `T`.
   /// - Returns: The return value, if any, of the `body` closure parameter.
   @_alwaysEmitIntoClient
   public func withMemoryRebound<T: ~Copyable, E: Error, Result: ~Copyable>(
@@ -1011,7 +1010,6 @@ extension UnsafeMutableRawPointer {
   ///     pointer argument is valid only for the duration of the closure's
   ///     execution. If `body` has a return value, that value is also used as
   ///     the return value for the `withMemoryRebound(to:capacity:_:)` method.
-  ///   - pointer: The pointer temporarily bound to `T`.
   /// - Returns: The return value, if any, of the `body` closure parameter.
   @_alwaysEmitIntoClient
   public func withMemoryRebound<T: ~Copyable, E: Error, Result: ~Copyable>(


### PR DESCRIPTION
rdar://172117819 (Fix link and parameter documentation errors in Swift stdlib source)

While working on #88061, I found about 300 DocC errors in the stdlib source doc comments, which show up as warnings when building the docs with `docc`, and results in incomplete documentation. The problems generally fall into a few common groups:
* **Incorrect parameter name**: These occur when a DocC `- Parameter:` tag uses a name different from what's in the signature (for example, using `lhs` and `rhs` to document an `=(_:_:)` operator that actually names its parameters `a` and `b`), or it uses the outer name rather than the inner name.
* **Out-of-module links**: DocC can only create links within a symbol's module. The standard library is actually a collection of several modules, with most of what we think of as the stdlib in `core`, but there's also important stuff in `concurrency`, `observation`, etc. And the within-own-module rule means that, for example, docs on `Actor` can't create double-backtick links to `Hashable`, because that's attempting to link from `concurrency` to `core`. I've generally just demoted these to code-voice.
* **Link disambiguation**: If a given symbol has many overloads, DocC uses a [disambiguation syntax](https://www.swift.org/documentation/docc/linking-to-symbols-and-other-content#Ambiguous-Symbol-Links) to distinguish between versions with different parameter types, generic conformances, etc. In cases where there was a clear intent to link to a specific version, I added the most appropriate disambiguation link. In other cases, particularly where a doc might be speaking generally to any relevant flavor of a `doFoo()` method, I demoted the link to code voice, since there isn't a "right" disambiguation to choose in these cases.
* **Parameters to closures**: DocC has no syntax for cases where a closure parameter itself takes one or more parameters. Generally, the safest approach is to describe these parameters in the documentation of the closure parameter, and this is the only option when the parameter isn't named. In cases where the parameter is named (like `buffer` in the trailing closure for several flavors of `withMemoryRebound()`), @d-ronnqvist suggested using the DocC term list syntax to give the secondary parameter a slight indentation, which is probably what the original author would have wanted.

I'm adding the following people as reviewers just so they're aware I'm stomping around in their code:
* @ktoso  (distributed, runtimemodule)
* @phausler  (observation)
* @al45tair and @carlpeto (runtimemodule - Carl may have just done the DocC formatting)
* @Azoy  (atomics, ref)
* @jmschonfeld  (range)
* @natecook1000  (range)
* @airspeedswift  (set)
* @glessard  (rawspan)
* @milseman  (string.index)

This PR only changes comments, not declarations or code.