### PR TITLE
[cxx-interop] [NFCi] Handle ambiguous virtual overrides outside NameImporter

### DIFF
--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -1010,7 +1010,9 @@ public:
   /// was inherited with private inheritance.
   ///
   /// Does nothing if this ClangInheritanceInfo::isInheriting() is \c false.
-  void setUnavailableIfNecessary(const ValueDecl *baseDecl,
+  ///
+  /// Returns true if \param clonedDecl was marked unavailable.
+  bool setUnavailableIfNecessary(const ValueDecl *baseDecl,
                                  ValueDecl *clonedDecl) const;
 
   friend llvm::hash_code hash_value(const ClangInheritanceInfo &info) {

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -6466,9 +6466,8 @@ static void cloneImportedAttributes(ValueDecl *fromDecl, ValueDecl *toDecl) {
 static void handleAmbiguousOverrides(ClangImporter::Implementation &Impl,
                                      FuncDecl *baseFunc,
                                      ValueDecl *clonedDecl) {
-  auto it = Impl.virtualThunkToOriginal.find(baseFunc);
-  if (it != Impl.virtualThunkToOriginal.end())
-    baseFunc = it->second;
+  if (auto *original = Impl.getOriginalForVirtualThunk(baseFunc))
+    baseFunc = original;
 
   const auto *baseCxxMethod =
       dyn_cast_or_null<clang::CXXMethodDecl>(baseFunc->getClangDecl());

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -6463,7 +6463,31 @@ static void cloneImportedAttributes(ValueDecl *fromDecl, ValueDecl *toDecl) {
   }
 }
 
-static ValueDecl *cloneBaseMemberDecl(ValueDecl *decl, DeclContext *newContext,
+static void handleAmbiguousOverrides(ClangImporter::Implementation &Impl,
+                                     FuncDecl *baseFunc,
+                                     ValueDecl *clonedDecl) {
+  auto it = Impl.virtualThunkToOriginal.find(baseFunc);
+  if (it != Impl.virtualThunkToOriginal.end())
+    baseFunc = it->second;
+
+  const auto *baseCxxMethod =
+      dyn_cast_or_null<clang::CXXMethodDecl>(baseFunc->getClangDecl());
+  if (!baseCxxMethod)
+    return;
+
+  const auto *derivedCxxRecord = dyn_cast<clang::CXXRecordDecl>(
+      clonedDecl->getDeclContext()->getAsDecl()->getClangDecl());
+  if (!derivedCxxRecord)
+    return;
+
+  if (Impl.isAmbiguouslyOverridden(derivedCxxRecord, baseCxxMethod))
+    Impl.markUnavailable(
+        clonedDecl,
+        "overrides multiple C++ methods with different Swift names");
+}
+
+static ValueDecl *cloneBaseMemberDecl(ClangImporter::Implementation &Impl,
+                                      ValueDecl *decl, DeclContext *newContext,
                                       ClangInheritanceInfo inheritance) {
   AccessLevel access = inheritance.accessForBaseDecl(decl);
   ASTContext &context = decl->getASTContext();
@@ -6491,7 +6515,9 @@ static ValueDecl *cloneBaseMemberDecl(ValueDecl *decl, DeclContext *newContext,
         fn->getResultInterfaceType(), newContext, /*isSynthesized=*/true);
     cloneImportedAttributes(decl, out);
     out->setAccess(access);
-    inheritance.setUnavailableIfNecessary(decl, out);
+    auto markedUnavailable = inheritance.setUnavailableIfNecessary(decl, out);
+    if (!markedUnavailable)
+      handleAmbiguousOverrides(Impl, fn, out);
     out->setBodySynthesizer(synthesizeBaseClassMethodBody, fn);
     out->setSelfAccessKind(fn->getSelfAccessKind());
     return out;
@@ -7991,16 +8017,14 @@ Decl *ClangImporter::lookupImportedDecl(const clang::NamedDecl *decl) {
 }
 
 ValueDecl *ClangImporter::Implementation::importBaseMemberDecl(
-    ValueDecl *decl, DeclContext *newContext,
-    ClangInheritanceInfo inheritance) {
+    ValueDecl *decl, DeclContext *newContext, ClangInheritanceInfo inherit) {
 
   // Make sure we don't clone the decl again for this class, as that would
   // result in multiple definitions of the same symbol.
   std::pair<ValueDecl *, DeclContext *> key = {decl, newContext};
   auto known = clonedBaseMembers.find(key);
   if (known == clonedBaseMembers.end()) {
-    ValueDecl *cloned = cloneBaseMemberDecl(decl, newContext, inheritance);
-    handleAmbiguousSwiftName(cloned);
+    ValueDecl *cloned = cloneBaseMemberDecl(*this, decl, newContext, inherit);
     known = clonedBaseMembers.try_emplace(key, cloned).first;
     clonedMembers.try_emplace(cloned, decl);
   }
@@ -9198,15 +9222,15 @@ ClangInheritanceInfo::accessForBaseDecl(const ValueDecl *baseDecl) const {
   return std::min(baseDecl->getFormalAccess(), inherited);
 }
 
-void ClangInheritanceInfo::setUnavailableIfNecessary(
+bool ClangInheritanceInfo::setUnavailableIfNecessary(
     const ValueDecl *baseDecl, ValueDecl *clonedDecl) const {
   if (!isInheriting())
-    return;
+    return false;
 
   auto *clangDecl =
       dyn_cast_or_null<clang::NamedDecl>(baseDecl->getClangDecl());
   if (!clangDecl)
-    return;
+    return false;
 
   const char *msg = nullptr;
 
@@ -9218,6 +9242,7 @@ void ClangInheritanceInfo::setUnavailableIfNecessary(
   if (msg)
     clonedDecl->addAttribute(AvailableAttr::createUniversallyUnavailable(
         clonedDecl->getASTContext(), msg));
+  return static_cast<bool>(msg);
 }
 
 SmallVector<std::pair<StringRef, clang::SourceLocation>, 1>

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -6421,7 +6421,7 @@ makeBaseClassMemberAccessors(DeclContext *declContext,
 }
 
 // Clone attributes that have been imported from Clang.
-void cloneImportedAttributes(ValueDecl *fromDecl, ValueDecl* toDecl) {
+static void cloneImportedAttributes(ValueDecl *fromDecl, ValueDecl *toDecl) {
   ASTContext &context = fromDecl->getASTContext();
   for (auto attr : fromDecl->getAttrs()) {
     switch (attr->getKind()) {

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -10761,22 +10761,6 @@ ValueDecl *ClangImporter::Implementation::createUnavailableDecl(
   return var;
 }
 
-void ClangImporter::Implementation::handleAmbiguousSwiftName(ValueDecl *decl) {
-  if (!decl || decl->isUnavailable())
-    return;
-
-  auto *cxxRecordDecl = dyn_cast<clang::CXXRecordDecl>(
-      decl->getDeclContext()->getAsDecl()->getClangDecl());
-
-  if (!cxxRecordDecl)
-    return;
-
-  if (findUnavailableMethod(cxxRecordDecl, decl->getName())) {
-    markUnavailable(decl,
-                    "overrides multiple C++ methods with different Swift names");
-  }
-}
-
 // Force the members of the entire inheritance hierarchy to be loaded and
 // deserialized before loading the members of this class. This allows the
 // decl members table to be warmed up and enables the correct identification of

--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -560,6 +560,10 @@ struct AnySwiftNameAttr {
   friend bool operator==(AnySwiftNameAttr lhs, AnySwiftNameAttr rhs) {
     return lhs.name == rhs.name && lhs.isAsync == rhs.isAsync;
   }
+
+  friend bool operator!=(AnySwiftNameAttr lhs, AnySwiftNameAttr rhs) {
+    return !(lhs == rhs);
+  }
 };
 
 /// Aggregate struct for the common members of clang::SwiftVersionedAdditionAttr and
@@ -1159,6 +1163,65 @@ static bool shouldBeSwiftPrivate(NameImporter &nameImporter,
   return false;
 }
 
+static bool overridesVirtualMethods(const clang::CXXMethodDecl *method) {
+  return method->isVirtual() && method->size_overridden_methods() > 0;
+}
+
+static std::pair<std::optional<AnySwiftNameAttr>, bool>
+getOverridingMethodSwiftName(const clang::CXXMethodDecl *method,
+                             ImportNameVersion version) {
+  bool seen = false;
+  std::optional<AnySwiftNameAttr> firstName;
+  for (const auto *overridden : method->overridden_methods()) {
+    auto [name, ambiguous] =
+        overridesVirtualMethods(overridden)
+            ? getOverridingMethodSwiftName(overridden, version)
+            : std::make_pair(findSwiftNameAttr(overridden, version), false);
+
+    if (ambiguous)
+      return {std::nullopt, true};
+
+    if (!seen) {
+      firstName = name;
+      seen = true;
+    } else if (name != firstName) {
+      return {std::nullopt, true};
+    }
+  }
+  return {firstName, false};
+}
+
+bool ClangImporter::Implementation::isAmbiguouslyOverridden(
+    const clang::CXXRecordDecl *Record, const clang::CXXMethodDecl *Method) {
+  if (!Method->isVirtual())
+    // This isn't virtual, so it can't be overridden.
+    return false;
+
+  auto [it, inserted] = ambiguousVirtualOverrides.try_emplace(Record);
+  if (!inserted)
+    return it->second.contains(Method);
+
+  // First time we are looking this up in Record. Build the set of ambiguously
+  // overridden virtual methods for it and cache the result.
+  bool result = false;
+  for (const auto *RecordMethod : Record->methods()) {
+    if (!overridesVirtualMethods(RecordMethod))
+      continue;
+
+    auto [_, ambiguous] =
+        getOverridingMethodSwiftName(RecordMethod, CurrentVersion);
+
+    if (ambiguous) {
+      for (const auto *overridden : RecordMethod->overridden_methods()) {
+        it->second.insert(overridden);
+        if (overridden == Method)
+          result = true;
+      }
+    }
+  }
+  return result;
+}
+
 std::optional<ForeignErrorConvention::Info>
 NameImporter::considerErrorImport(const clang::ObjCMethodDecl *clangDecl,
                                   StringRef &baseName,
@@ -1748,6 +1811,11 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
         if (cxxMethod->isVirtual() && cxxMethod->size_overridden_methods() > 0)
           skipCustomName = true;
       }
+
+      // `swift_name` attribute is not supported in virtual methods overrides
+      if (auto method = dyn_cast<clang::CXXMethodDecl>(D);
+          method && overridesVirtualMethods(method))
+        skipCustomName = true;
 
       if (!skipCustomName &&
           parsedName.BaseNameKind == DeclBaseName::Kind::Constructor &&
@@ -2396,40 +2464,21 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
       newName = baseName.substr(StringRef("__synthesizedVirtualCall_").size());
       baseName = newName;
     }
-    if (method->isVirtual()) {
-      // The name should be imported from the base method
-      if (method->size_overridden_methods() > 0) {
-        DeclName overriddenName;
-        bool foundDivergentMethod = false;
-        for (auto overriddenMethod : method->overridden_methods()) {
-          ImportedName importedName =
-              importName(overriddenMethod, version, givenName);
-          if (!overriddenName) {
-            overriddenName = importedName.getDeclName();
-          } else if (overriddenName.compare(importedName.getDeclName())) {
-            importerImpl->insertUnavailableMethod(method->getParent(),
-                                                  importedName.getDeclName());
-            foundDivergentMethod = true;
-          }
-        }
 
-        if (foundDivergentMethod) {
-          // The method we want to mark as unavailable will be generated
-          // lazily, when we clone the methods from base classes to the derived
-          // class method->getParent().
-          // Since we don't have the actual method here, we store this
-          // information to be accessed when we generate the actual method.
-          importerImpl->insertUnavailableMethod(method->getParent(),
-                                                overriddenName);
+    if (overridesVirtualMethods(method)) {
+      auto [effectiveName, isAmbiguous] =
+          getOverridingMethodSwiftName(method, version);
+      if (isAmbiguous)
+        return ImportedName();
+
+      if (effectiveName) {
+        ParsedDeclName parsed = parseDeclName(effectiveName->name);
+        if (!parsed)
           return ImportedName();
-        }
-
-        baseName = overriddenName.getBaseIdentifier().str();
-        // Also inherit argument names from base method
+        baseName = parsed.BaseName;
         argumentNames.clear();
-        llvm::for_each(overriddenName.getArgumentNames(), [&](Identifier arg) {
-          argumentNames.push_back(arg.str());
-        });
+        for (auto label : parsed.ArgumentLabels)
+          argumentNames.push_back(label);
       }
     }
   }

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -702,14 +702,6 @@ private:
   llvm::DenseMap<ValueDecl *, ValueDecl *> clonedMembers;
   llvm::DenseSet<const ValueDecl *> membersSynthesizedPerType;
 
-  // Keep track of methods that are unavailale in each class.
-  // We need this set because these methods will be imported lazily. We don't
-  // have the corresponding Swift method when the availability check is
-  // performed, so instead we store the information in this set and then, when
-  // the method is finally generated, we check if it's present here
-  llvm::DenseSet<std::pair<const clang::CXXRecordDecl *, DeclName>>
-      unavailableMethods;
-
 public:
   /// Attempt to lookup and import the synthesized .pointee computed property.
   /// It also synthesizes __operatorStar(), which is used as the getter and
@@ -787,7 +779,7 @@ public:
   static bool isSwiftFunctionWrapper(const clang::RecordDecl *decl);
 
   ValueDecl *importBaseMemberDecl(ValueDecl *decl, DeclContext *newContext,
-                                  ClangInheritanceInfo inheritance);
+                                  ClangInheritanceInfo inherit);
 
   ValueDecl *getOriginalForClonedMember(const ValueDecl *decl);
   FuncDecl *getOriginalForVirtualThunk(const FuncDecl *decl);
@@ -817,17 +809,14 @@ public:
     return getNameImporter().getEnumKind(decl);
   }
 
-  bool findUnavailableMethod(const clang::CXXRecordDecl *classDecl,
-                             DeclName name) {
-    return unavailableMethods.contains({classDecl, name});
-  }
+private:
+  llvm::DenseMap<const clang::CXXRecordDecl *,
+                 llvm::SmallDenseSet<const clang::CXXMethodDecl *>>
+      ambiguousVirtualOverrides;
 
-  void insertUnavailableMethod(const clang::CXXRecordDecl *classDecl,
-                               DeclName name) {
-    unavailableMethods.insert({classDecl, name});
-  }
-
-  void handleAmbiguousSwiftName(ValueDecl *decl);
+public:
+  bool isAmbiguouslyOverridden(const clang::CXXRecordDecl *Record,
+                               const clang::CXXMethodDecl *Method);
 
 private:
   /// A mapping from imported declarations to their "alternate" declarations,

--- a/test/Interop/Cxx/class/method/unsafe-divergent-overrides.swift
+++ b/test/Interop/Cxx/class/method/unsafe-divergent-overrides.swift
@@ -1,0 +1,58 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: %target-swift-frontend -typecheck -verify %t%{fs-sep}test.swift \
+// RUN:   -suppress-notes \
+// RUN:   -I %t%{fs-sep}Inputs -cxx-interoperability-mode=default
+
+// Regression test: when a virtual method overrides multiple base methods whose
+// imported Swift names diverge, every cloned base member in the derived class
+// must be marked unavailable, including ones whose Swift name was rewritten by
+// the `__<base>Unsafe` rename applied to unsafe projection methods.
+
+//--- Inputs/module.modulemap
+module UnsafeDivergentOverrides {
+  header "unsafe-divergent-overrides.h"
+  requires cplusplus
+}
+
+//--- Inputs/unsafe-divergent-overrides.h
+#ifndef TEST_INTEROP_CXX_CLASS_METHOD_UNSAFE_DIVERGENT_OVERRIDES_H
+#define TEST_INTEROP_CXX_CLASS_METHOD_UNSAFE_DIVERGENT_OVERRIDES_H
+
+struct UnsafeReturn {
+  void *ptr;
+};
+
+struct SelfContainedBase1 {
+  void *ptr;
+  SelfContainedBase1(const SelfContainedBase1 &);
+  virtual ~SelfContainedBase1();
+
+  virtual UnsafeReturn view() const;
+};
+
+struct SelfContainedBase2 {
+  void *ptr;
+  SelfContainedBase2(const SelfContainedBase2 &);
+  virtual ~SelfContainedBase2();
+
+  virtual UnsafeReturn view() const __attribute__((swift_name("getView()")));
+};
+
+struct DerivedDivergent : SelfContainedBase1, SelfContainedBase2 {
+  UnsafeReturn view() const override;
+};
+
+#endif // TEST_INTEROP_CXX_CLASS_METHOD_UNSAFE_DIVERGENT_OVERRIDES_H
+
+//--- test.swift
+
+// Both cloned base members must be marked unavailable on the derived class,
+// including the one renamed to `__viewUnsafe` by the unsafe-projection rename.
+
+import UnsafeDivergentOverrides
+
+func use(_ d: DerivedDivergent) {
+  let _ = d.getView()  // expected-error {{'getView()' is unavailable: overrides multiple C++ methods with different Swift names}}
+  let _ = d.__viewUnsafe()  // expected-error {{'__viewUnsafe()' is unavailable: overrides multiple C++ methods with different Swift names}}
+}

--- a/test/Interop/Cxx/foreign-reference/member-inheritance-module-interface.swift
+++ b/test/Interop/Cxx/foreign-reference/member-inheritance-module-interface.swift
@@ -1,7 +1,12 @@
-// RUN: %target-swift-ide-test -print-module -cxx-interoperability-mode=swift-5.9 -print-implicit-attrs -module-to-print=MemberInheritance -I %S/Inputs -source-filename=x | %FileCheck --check-prefixes=CHECK,CHECK-OFF %s
-// RUN: %target-swift-ide-test -print-module -cxx-interoperability-mode=swift-6 -print-implicit-attrs -module-to-print=MemberInheritance -I %S/Inputs -source-filename=x | %FileCheck --check-prefixes=CHECK,CHECK-OFF %s
-// RUN: %target-swift-ide-test -print-module -cxx-interoperability-mode=upcoming-swift -print-implicit-attrs -module-to-print=MemberInheritance -I %S/Inputs -source-filename=x | %FileCheck --check-prefixes=CHECK,CHECK-OFF %s
-// RUN: %target-swift-ide-test -print-module -cxx-interoperability-mode=upcoming-swift -enable-experimental-feature ForeignReferenceTypeInheritance -print-implicit-attrs -module-to-print=MemberInheritance -I %S/Inputs -source-filename=x | %FileCheck --check-prefixes=CHECK,CHECK-ON %s
+// RUN: %target-swift-ide-test -source-filename=x -print-module -print-implicit-attrs \
+// RUN:   -cxx-interoperability-mode=default \
+// RUN:   -module-to-print=MemberInheritance -I %S/Inputs  \
+// RUN: | %FileCheck --check-prefixes=CHECK,CHECK-OFF %s
+// RUN: %target-swift-ide-test -source-filename=x -print-module -print-implicit-attrs \
+// RUN:   -cxx-interoperability-mode=default \
+// RUN:   -module-to-print=MemberInheritance -I %S/Inputs  \
+// RUN:   -enable-experimental-feature ForeignReferenceTypeInheritance \
+// RUN: | %FileCheck --check-prefixes=CHECK,CHECK-ON %s
 
 // REQUIRES: swift_feature_ForeignReferenceTypeInheritance
 
@@ -213,5 +218,4 @@
 // CHECK-OFF:   func method() -> Int32
 // CHECK-OFF: }
 // CHECK-ON: class RenamedDerivedWithInitMethod : RenamedBaseWithInitMethod {
-// CHECK-ON:   func method() -> Int32
 // CHECK-ON: }


### PR DESCRIPTION
Detect divergent virtual overrides via a pure helper that walks the
clang override chain, instead of recursively re-entering NameImporter.

Key the ambiguous-override cache on clang::CXXMethodDecl (unwrapping
synthesized virtual thunks via virtualThunkToOriginal) rather than
DeclName, replacing the unavailableMethod* API with
isAmbiguouslyOverridden.

Adds regression coverage for the case where divergent overrides collide
with the __<base>Unsafe rename on unsafe projection methods.
