### PR TITLE
stdlib: introduce new RR operations for supporting COM interop

### DIFF
--- a/include/swift/Runtime/HeapObject.h
+++ b/include/swift/Runtime/HeapObject.h
@@ -140,6 +140,14 @@ SWIFT_RUNTIME_EXPORT
 SWIFT_REFCOUNT_CC
 HeapObject *swift_retain(HeapObject *object);
 
+/// Atomically increments the strong reference count of \p object and returns
+/// the new strong reference count. This is the count-only retain; unlike
+/// `swift_retain` it returns the count rather than the object.
+///
+/// \param object - may be null, in which case this is a no-op returning 0.
+SWIFT_RUNTIME_EXPORT
+size_t swift_retainReturningCount(HeapObject *object);
+
 SWIFT_RUNTIME_EXPORT
 HeapObject *swift_retain_n(HeapObject *object, uint32_t n);
 
@@ -176,6 +184,17 @@ bool swift_isDeallocating(HeapObject *object);
 SWIFT_RUNTIME_EXPORT
 SWIFT_REFCOUNT_CC
 void swift_release(HeapObject *object);
+
+/// Atomically decrements the strong reference count of \p object and returns
+/// the new strong reference count, or 0 if this released the last strong
+/// reference (in which case the object is deinited exactly as by
+/// `swift_release`). The returned count is taken from the decrementing
+/// operation itself; it must not be re-read from the object, which may already
+/// be deallocated.
+///
+/// \param object - may be null, in which case this is a no-op returning 0.
+SWIFT_RUNTIME_EXPORT
+size_t swift_releaseReturningCount(HeapObject *object);
 
 SWIFT_RUNTIME_EXPORT
 void swift_nonatomic_release(HeapObject *object);

--- a/stdlib/public/SwiftShims/swift/shims/RefCount.h
+++ b/stdlib/public/SwiftShims/swift/shims/RefCount.h
@@ -716,7 +716,7 @@ class RefCounts {
 
   SWIFT_NOINLINE
   SWIFT_REFCOUNT_CC
-  HeapObject *incrementSlow(RefCountBits oldbits, uint32_t inc);
+  HeapObject *incrementSlow(RefCountBits oldbits, uint32_t inc, uint32_t *count);
 
   SWIFT_NOINLINE
   void incrementNonAtomicSlow(RefCountBits oldbits, uint32_t inc);
@@ -817,7 +817,8 @@ class RefCounts {
   // can be directly returned from swift_retain. This makes the call to
   // incrementSlow() a tail call.
   SWIFT_ALWAYS_INLINE
-  HeapObject *increment(HeapObject *returning, uint32_t inc = 1) {
+  HeapObject *increment(HeapObject *returning, uint32_t inc = 1,
+                        uint32_t *count = nullptr) {
     auto oldbits = refCounts.load(SWIFT_MEMORY_ORDER_CONSUME);
     
     // Constant propagation will remove this in swift_retain, it should only
@@ -831,12 +832,17 @@ class RefCounts {
       newbits = oldbits;
       bool fast = newbits.incrementStrongExtraRefCount(inc);
       if (SWIFT_UNLIKELY(!fast)) {
-        if (oldbits.isImmortal(false))
+        if (oldbits.isImmortal(false)) {
+          // Immortal objects are never deallocated, so reading the (saturated)
+          // count is safe here.
+          if (count) *count = getCount();
           return getHeapObject();
-        return incrementSlow(oldbits, inc);
+        }
+        return incrementSlow(oldbits, inc, count);
       }
     } while (!refCounts.compare_exchange_weak(oldbits, newbits,
                                               std::memory_order_relaxed));
+    if (count) *count = newbits.getStrongExtraRefCount() + 1;
     return returning;
   }
 
@@ -901,8 +907,8 @@ class RefCounts {
   // Decrement the reference count.
   // Return true if the caller should now deinit the object.
   SWIFT_ALWAYS_INLINE
-  bool decrementShouldDeinit(uint32_t dec) {
-    return doDecrement<DontPerformDeinit>(dec);
+  bool decrementShouldDeinit(uint32_t dec, uint32_t *count) {
+    return doDecrement<DontPerformDeinit>(dec, count);
   }
 
   SWIFT_ALWAYS_INLINE
@@ -911,8 +917,8 @@ class RefCounts {
   }
 
   SWIFT_ALWAYS_INLINE
-  void decrementAndMaybeDeinit(uint32_t dec) {
-    doDecrement<DoPerformDeinit>(dec);
+  void decrementAndMaybeDeinit(uint32_t dec, uint32_t *count) {
+    doDecrement<DoPerformDeinit>(dec, count);
   }
 
   SWIFT_ALWAYS_INLINE
@@ -1002,7 +1008,8 @@ class RefCounts {
   // Second slow path of doDecrement, where the
   // object may have a side table entry.
   template <PerformDeinit performDeinit>
-  bool doDecrementSideTable(RefCountBits oldbits, uint32_t dec);
+  bool doDecrementSideTable(RefCountBits oldbits, uint32_t dec,
+                            uint32_t *count = nullptr);
 
   // Second slow path of doDecrementNonAtomic, where the
   // object may have a side table entry.
@@ -1013,12 +1020,15 @@ class RefCounts {
   // Side table is handled in the second slow path, doDecrementSideTable().
   template <PerformDeinit performDeinit>
   SWIFT_REFCOUNT_CC
-  bool doDecrementSlow(RefCountBits oldbits, uint32_t dec) {
+  bool doDecrementSlow(RefCountBits oldbits, uint32_t dec, uint32_t *count) {
     RefCountBits newbits;
     
     // Constant propagation will remove this in swift_release, it should only
     // be present in swift_release_n.
     if (dec != 1 && oldbits.isImmortal(true)) {
+      // Immortal objects are never deallocated, so reading the (saturated)
+      // count is safe here.
+      if (count) *count = getCount();
       return false;
     }
     
@@ -1033,10 +1043,13 @@ class RefCounts {
         deinitNow = false;
       }
       else if (oldbits.isImmortal(false)) {
+        // Immortal objects are never deallocated, so reading the (saturated)
+        // count is safe here.
+        if (count) *count = getCount();
         return false;
       } else if (oldbits.hasSideTable()) {
         // Decrement failed because we're on some other slow path.
-        return doDecrementSideTable<performDeinit>(oldbits, dec);
+        return doDecrementSideTable<performDeinit>(oldbits, dec, count);
       }
       else {
         // Decrement underflowed. Begin deinit.
@@ -1055,6 +1068,8 @@ class RefCounts {
       _swift_release_dealloc(getHeapObject());
     }
 
+    if (count)
+      *count = deinitNow ? 0 : (newbits.getStrongExtraRefCount() + 1);
     return deinitNow;
   }
 
@@ -1109,13 +1124,16 @@ class RefCounts {
   // the caller because the compiler can optimize this arrangement better.
   template <PerformDeinit performDeinit>
   SWIFT_ALWAYS_INLINE
-  bool doDecrement(uint32_t dec) {
+  bool doDecrement(uint32_t dec, uint32_t *count) {
     auto oldbits = refCounts.load(SWIFT_MEMORY_ORDER_CONSUME);
     RefCountBits newbits;
     
     // Constant propagation will remove this in swift_release, it should only
     // be present in swift_release_n.
     if (dec != 1 && oldbits.isImmortal(true)) {
+      // Immortal objects are never deallocated, so reading the (saturated)
+      // count is safe here.
+      if (count) *count = getCount();
       return false;
     }
     
@@ -1125,15 +1143,19 @@ class RefCounts {
         newbits.decrementStrongExtraRefCount(dec);
       if (SWIFT_UNLIKELY(!fast)) {
         if (oldbits.isImmortal(false)) {
+            // Immortal objects are never deallocated, so reading the (saturated)
+            // count is safe here.
+            if (count) *count = getCount();
             return false;
         }
         // Slow paths include side table; deinit; underflow
-        return doDecrementSlow<performDeinit>(oldbits, dec);
+        return doDecrementSlow<performDeinit>(oldbits, dec, count);
       }
     } while (!refCounts.compare_exchange_weak(oldbits, newbits,
                                               std::memory_order_release,
                                               std::memory_order_relaxed));
 
+    if (count) *count = newbits.getStrongExtraRefCount() + 1;
     return false;  // don't deinit
   }
 
@@ -1381,13 +1403,13 @@ class HeapObjectSideTableEntry {
 
   // STRONG
   
-  void incrementStrong(uint32_t inc) {
-    refCounts.increment(nullptr, inc);
+  void incrementStrong(uint32_t inc, uint32_t *count) {
+    refCounts.increment(nullptr, inc, count);
   }
 
   template <PerformDeinit performDeinit>
-  bool decrementStrong(uint32_t dec) {
-    return refCounts.doDecrement<performDeinit>(dec);
+  bool decrementStrong(uint32_t dec, uint32_t *count) {
+    return refCounts.doDecrement<performDeinit>(dec, count);
   }
 
   template <PerformDeinit performDeinit>
@@ -1564,18 +1586,18 @@ RefCounts<InlineRefCountBits>::doDecrementNonAtomic(uint32_t dec) {
 // threat of concurrent read of a weak reference.
 template <>
 template <PerformDeinit performDeinit>
-inline bool RefCounts<SideTableRefCountBits>::
-doDecrementNonAtomic(uint32_t dec) {
-  return doDecrement<performDeinit>(dec);
+inline bool
+RefCounts<SideTableRefCountBits>::doDecrementNonAtomic(uint32_t dec) {
+  return doDecrement<performDeinit>(dec, nullptr);
 }
 
 
 template <>
 template <PerformDeinit performDeinit>
 inline bool RefCounts<InlineRefCountBits>::
-doDecrementSideTable(InlineRefCountBits oldbits, uint32_t dec) {
+doDecrementSideTable(InlineRefCountBits oldbits, uint32_t dec, uint32_t *count) {
   auto side = oldbits.getSideTable();
-  return side->decrementStrong<performDeinit>(dec);
+  return side->decrementStrong<performDeinit>(dec, count);
 }
 
 template <>
@@ -1589,7 +1611,8 @@ doDecrementNonAtomicSideTable(InlineRefCountBits oldbits, uint32_t dec) {
 template <>
 template <PerformDeinit performDeinit>
 inline bool RefCounts<SideTableRefCountBits>::
-doDecrementSideTable(SideTableRefCountBits oldbits, uint32_t dec) {
+doDecrementSideTable(SideTableRefCountBits oldbits, uint32_t dec,
+                     uint32_t *count) {
   swift::crash("side table refcount must not have "
                "a side table entry of its own");
 }

--- a/stdlib/public/runtime/HeapObject.cpp
+++ b/stdlib/public/runtime/HeapObject.cpp
@@ -471,8 +471,8 @@ extern "C" SWIFT_LIBRARY_VISIBILITY SWIFT_NOINLINE SWIFT_USED SWIFT_REFCOUNT_CC
 void
 _swift_release_dealloc(HeapObject *object);
 
-SWIFT_ALWAYS_INLINE static HeapObject *_swift_retain_(HeapObject *object) {
-  SWIFT_RT_TRACK_INVOCATION(object, swift_retain);
+SWIFT_ALWAYS_INLINE
+static HeapObject *_swift_retain_impl(HeapObject *object, uint32_t *count) {
   if (isValidPointerForNativeRetain(object)) {
     // swift_bridgeObjectRetain might call us with a pointer that has spare bits
     // set, and expects us to return that unmasked value. Mask off those bits
@@ -483,9 +483,14 @@ SWIFT_ALWAYS_INLINE static HeapObject *_swift_retain_(HeapObject *object) {
     // Return the result of increment() to make the eventual call to
     // incrementSlow a tail call, which avoids pushing a stack frame on the fast
     // path on ARM64.
-    return masked->refCounts.increment(object, 1);
+    return masked->refCounts.increment(object, 1, count);
   }
   return object;
+}
+
+SWIFT_ALWAYS_INLINE static HeapObject *_swift_retain_(HeapObject *object) {
+  SWIFT_RT_TRACK_INVOCATION(object, swift_retain);
+  return _swift_retain_impl(object, nullptr);
 }
 
 #ifdef SWIFT_STDLIB_OVERRIDABLE_RETAIN_RELEASE
@@ -514,6 +519,13 @@ HeapObject *swift::swift_retain(HeapObject *object) {
 
 CUSTOM_RR_ENTRYPOINTS_DEFINE_ENTRYPOINTS(swift_retain)
 
+// Atomically increment the strong reference count and return the new count.
+size_t swift::swift_retainReturningCount(HeapObject *object) {
+  uint32_t count = 0;
+  static_cast<void>(_swift_retain_impl(object, &count));
+  return count;
+}
+
 HeapObject *swift::swift_nonatomic_retain(HeapObject *object) {
   SWIFT_RT_TRACK_INVOCATION(object, swift_nonatomic_retain);
   if (isValidPointerForNativeRetain(object))
@@ -525,7 +537,7 @@ SWIFT_ALWAYS_INLINE
 static HeapObject *_swift_retain_n_(HeapObject *object, uint32_t n) {
   SWIFT_RT_TRACK_INVOCATION(object, swift_retain_n);
   if (isValidPointerForNativeRetain(object))
-    return object->refCounts.increment(object, n);
+    return object->refCounts.increment(object, n, nullptr);
   return object;
 }
 
@@ -545,10 +557,15 @@ HeapObject *swift::swift_nonatomic_retain_n(HeapObject *object, uint32_t n) {
 }
 
 SWIFT_ALWAYS_INLINE
+static void _swift_release_impl(HeapObject *object, uint32_t *count) {
+  if (isValidPointerForNativeRetain(object))
+    object->refCounts.decrementAndMaybeDeinit(1, count);
+}
+
+SWIFT_ALWAYS_INLINE
 static void _swift_release_(HeapObject *object) {
   SWIFT_RT_TRACK_INVOCATION(object, swift_release);
-  if (isValidPointerForNativeRetain(object))
-    object->refCounts.decrementAndMaybeDeinit(1);
+  _swift_release_impl(object, nullptr);
 }
 
 #ifdef SWIFT_STDLIB_OVERRIDABLE_RETAIN_RELEASE
@@ -574,11 +591,19 @@ void swift::swift_nonatomic_release(HeapObject *object) {
     object->refCounts.decrementAndMaybeDeinitNonAtomic(1);
 }
 
+// Atomically decrement the strong reference count and return the new count, or
+// zero if this released the last reference.
+size_t swift::swift_releaseReturningCount(HeapObject *object) {
+  uint32_t count = 0;
+  _swift_release_impl(object, &count);
+  return count;
+}
+
 SWIFT_ALWAYS_INLINE
 static void _swift_release_n_(HeapObject *object, uint32_t n) {
   SWIFT_RT_TRACK_INVOCATION(object, swift_release_n);
   if (isValidPointerForNativeRetain(object))
-    object->refCounts.decrementAndMaybeDeinit(n);
+    object->refCounts.decrementAndMaybeDeinit(n, nullptr);
 }
 
 void swift::swift_release_n(HeapObject *object, uint32_t n) {
@@ -946,7 +971,7 @@ void swift::swift_deallocPartialClassInstance(HeapObject *object,
 #endif
 
   // The strong reference count should be +1 -- tear down the object
-  bool shouldDeallocate = object->refCounts.decrementShouldDeinit(1);
+  bool shouldDeallocate = object->refCounts.decrementShouldDeinit(1, nullptr);
   assert(shouldDeallocate);
   (void) shouldDeallocate;
   swift_deallocClassInstance(object, allocatedSize, allocatedAlignMask);

--- a/stdlib/public/runtime/RefCount.cpp
+++ b/stdlib/public/runtime/RefCount.cpp
@@ -65,27 +65,35 @@ HeapObjectSideTableEntry* RefCounts<InlineRefCountBits>::allocateSideTable(bool 
 
 
 template <>
-HeapObject *RefCounts<InlineRefCountBits>::incrementSlow(InlineRefCountBits oldbits,
-                                                   uint32_t n) {
+HeapObject *
+RefCounts<InlineRefCountBits>::incrementSlow(InlineRefCountBits oldbits,
+                                             uint32_t n, uint32_t *count) {
   if (oldbits.isImmortal(false)) {
+    // Immortal objects are never deallocated, so reading the (saturated)
+    // count is safe here.
+    if (count) *count = getCount();
     return getHeapObject();
   }
   else if (oldbits.hasSideTable()) {
     // Out-of-line slow path.
     auto side = oldbits.getSideTable();
-    side->incrementStrong(n);
+    side->incrementStrong(n, count);
   }
   else {
     // Overflow into a new side table.
     auto side = allocateSideTable(false);
-    side->incrementStrong(n);
+    side->incrementStrong(n, count);
   }
   return getHeapObject();
 }
 template <>
-HeapObject *RefCounts<SideTableRefCountBits>::incrementSlow(SideTableRefCountBits oldbits,
-                                                uint32_t n) {
+HeapObject *
+RefCounts<SideTableRefCountBits>::incrementSlow(SideTableRefCountBits oldbits,
+                                                uint32_t n, uint32_t *count) {
   if (oldbits.isImmortal(false)) {
+    // Immortal objects are never deallocated, so reading the (saturated)
+    // count is safe here.
+    if (count) *count = getCount();
     return getHeapObject();
   }
   else {
@@ -104,11 +112,11 @@ void RefCounts<InlineRefCountBits>::incrementNonAtomicSlow(InlineRefCountBits ol
   else if (oldbits.hasSideTable()) {
     // Out-of-line slow path.
     auto side = oldbits.getSideTable();
-    side->incrementStrong(n);  // FIXME: can there be a nonatomic impl?
+    side->incrementStrong(n, nullptr);  // FIXME: can there be a nonatomic impl?
   } else {
     // Overflow into a new side table.
     auto side = allocateSideTable(false);
-    side->incrementStrong(n);  // FIXME: can there be a nonatomic impl?
+    side->incrementStrong(n, nullptr);  // FIXME: can there be a nonatomic impl?
   }
 }
 template <>

--- a/test/abi/Inputs/macOS/x86_64/stdlib/baseline
+++ b/test/abi/Inputs/macOS/x86_64/stdlib/baseline
@@ -13660,11 +13660,13 @@ _swift_registerProtocolConformances
 _swift_registerProtocols
 _swift_registerTypeMetadataRecords
 _swift_release
+_swift_releaseReturningCount
 _swift_release_n
 _swift_relocateClassMetadata
 _swift_reportError
 _swift_reportWarning
 _swift_retain
+_swift_retainReturningCount
 _swift_retainCount
 _swift_retain_n
 _swift_rootObjCDealloc

--- a/test/abi/Inputs/macOS/x86_64/stdlib/baseline-asserts
+++ b/test/abi/Inputs/macOS/x86_64/stdlib/baseline-asserts
@@ -13756,12 +13756,14 @@ _swift_registerProtocolConformances
 _swift_registerProtocols
 _swift_registerTypeMetadataRecords
 _swift_release
+_swift_releaseReturningCount
 _swift_release_n
 _swift_relocateClassMetadata
 _swift_reportError
 _swift_reportWarning
 _swift_retain
 _swift_retainCount
+_swift_retainReturningCount
 _swift_retain_n
 _swift_rootObjCDealloc
 _swift_runtimeSupportsNoncopyableTypes


### PR DESCRIPTION
COM Interop requires atomic reference counting for the objects. Introduce a new variant of `swift_retain` and `swift_release` which provide the necessary form for the interop.

`swift_retainReturningCount` and `swift_releaseReturningCount` are exposed as alternative entrypoints to reference count the object and return the new strong reference count. This prevents tail calling but is meant to service the `AddRef` and `Release` thunks in the COM Interop.

While we would have ideally preferred the ExtRR shape where `swift_retain` and `swift_release` would be extended to return the strong reference count, it could potentially impair some optimization (%0 can no longer be treated as `returned` as we return a tuple). Additionally, it would impose a reasonable hit on some platforms. In particular, Windows AMD64 would force the return to be stret rather than inreg which would impose a penalty on the current predominant architecture. i686 would allow return by eax:edx, ARMv7 and ARM64 would return inreg. Darwin platforms also would be both backwards ABI compatible and return by inreg parameters. Linux would be pessimised on both i686 and AMD64 due to the SysV calling convention.

Note that these interfaces are currently unknown to IRGen as the current design for COM intends to use a library first approach where the `AddRef` and `Release` methods are thunked through a canonical serialised form that will be AEIC'ed to avoid the cost of a cross-module trampoline. This should also help ensure that these methods are constrained to the needed case allowing us to properly optimize other cases.

The majority of this change simply threads an out parameter for the count, which is both defaulted to `nullptr`. There is some rework of the existing entry points to allow a single funnel point where the RMW count mutation occurs. With inling and constant folding/propagation, we should have no impact on existing paths.