### PR TITLE
[CS] Avoid leaving diagnostic unset in `ContextualFailure::diagnoseAsError`

### DIFF
--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -73,6 +73,12 @@ namespace swift {
   struct Diag {
     /// The diagnostic ID corresponding to this diagnostic.
     DiagID ID;
+
+    // 0 corresponds to diag::invalid_diagnostic. Unfortunately we can't define
+    // this out-of-line due to the template, and we can't include the diagnostic
+    // since that's a header cycle.
+    Diag() : ID(static_cast<DiagID>(0)) {}
+    Diag(DiagID id) : ID(id) {}
   };
 
   namespace detail {

--- a/include/swift/AST/DiagnosticsCommon.def
+++ b/include/swift/AST/DiagnosticsCommon.def
@@ -20,8 +20,11 @@
 #define DEFINE_DIAGNOSTIC_MACROS
 #include "DefineDiagnosticMacros.h"
 
+// NOTE: This must be the first diagnostic such that matches the default
+// DiagID of 0.
 ERROR(invalid_diagnostic,none,
-      "INTERNAL ERROR: this diagnostic should not be produced", ())
+      "INTERNAL ERROR: this diagnostic should not be produced; "
+      SWIFT_BUG_REPORT_MESSAGE, ())
 
 NOTE(kind_declname_declared_here,none,
      "%0 %1 declared here", (DescriptiveDeclKind, DeclName))

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -2727,11 +2727,7 @@ bool ContextualFailure::diagnoseAsError() {
     break;
   }
   case ConstraintLocator::CoercionOperand:
-  case ConstraintLocator::InstanceType: {
-    if (diagnoseCoercionToUnrelatedType())
-      return true;
-    break;
-  }
+    return diagnoseCoercionToUnrelatedType();
 
   case ConstraintLocator::TernaryBranch: {
     auto *ternaryExpr = castToExpr<TernaryExpr>(getRawAnchor());

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -1572,6 +1572,9 @@ func testNilCoalescingOperatorRemoveFix() {
       ?? "").isEmpty {} // expected-warning {{left side of nil coalescing operator '??' has non-optional type 'String', so the right side is never used}} {{-1:9-+0:12=}}
 }
 
+// FIXME: https://github.com/swiftlang/swift/issues/89918
+let _ = type(of: Int.foo) // expected-error {{failed to produce diagnostic}}
+
 // https://github.com/apple/swift/issues/74617
 struct Foo_74617 {
   public var bar: Float { 123 }

--- a/test/Constraints/unapplied_method_in_property_init.swift
+++ b/test/Constraints/unapplied_method_in_property_init.swift
@@ -1,0 +1,23 @@
+// RUN: %target-typecheck-verify-swift -module-name main -language-mode 5 -verify-additional-prefix swift5-
+// RUN: %target-typecheck-verify-swift -module-name main -language-mode 6 -verify-additional-prefix swift6-
+
+struct S {
+  func foo(c: S) -> S {}
+  func bar(_ c: S) -> S {}
+
+  // The different diagnostics here are due to the inference of @Sendable when attempting to reference the decl on the type rather than instance.
+  let x1: ((S) -> S).Type = type(of: foo)
+  // expected-swift5-error@-1 {{cannot convert value of type '((S) -> (S) -> S).Type' to specified type '((S) -> S).Type'}}
+  // expected-swift6-error@-2 {{cannot use instance member 'foo' within property initializer; property initializers run before 'self' is available}}
+
+  let x2: ((S) -> S).Type = type(of: bar)
+  // expected-error@-1 {{cannot use instance member 'bar' within property initializer; property initializers run before 'self' is available}}
+
+  // FIXME: https://github.com/swiftlang/swift/issues/89920
+  let y1: (S) -> S = foo
+  // expected-error@-1 {{cannot convert value of type '(main.S) -> main.S' to specified type '(main.S) -> main.S'}}
+  // expected-error@-2 {{cannot use instance member 'foo' within property initializer; property initializers run before 'self' is available}}
+
+  let y2: (S) -> S = bar
+  // expected-error@-1 {{cannot use instance member 'bar' within property initializer; property initializers run before 'self' is available}}
+}

--- a/validation-test/compiler_crashers_fixed/DiagnosticEngine-diagnose-d98e8c.swift
+++ b/validation-test/compiler_crashers_fixed/DiagnosticEngine-diagnose-d98e8c.swift
@@ -1,9 +1,5 @@
 // {"aliases":["swift::DiagnosticState::determineBehavior(swift::Diagnostic const&, swift::SourceManager&) const"],"extraArgs":["-language-mode","6"],"kind":"typecheck","original":"ede44338","signature":"swift::InFlightDiagnostic swift::DiagnosticEngine::diagnose<swift::Type, swift::Type>(swift::SourceLoc, swift::Diag<swift::Type, swift::Type>, swift::detail::PassArgument<swift::Type>::type, swift::detail::PassArgument<swift::Type>::type)","signatureNext":"ContextualFailure::diagnoseAsError"}
-// RUN: not --crash %target-swift-frontend -typecheck -language-mode 6 %s
-// REQUIRES: OS=macosx
-
-// Temporarily disabled while we investigate why it's suddenly not crashing.
-// REQUIRES: rdar179474757
+// RUN: not %target-swift-frontend -typecheck -language-mode 6 %s
 class a {
   func
     b(c: a) -> a


### PR DESCRIPTION
We could end up leaving `diagnostic` unset for the `ConstraintLocator::InstanceType` case. It's not clear to me we ought to be handling this case here anyway (metatype mismatches should be diagnosed as top-level mismatches rather than instance type mismatches), so let's just remove the case. The only reason why we're ending up with the fix here is due to a bogus argument label mismatch, I've filed a bug (#89920) to track properly fixing that.

While here, ensure that the default constructor of `Diag` properly defaults to `diag::invalid_diagnostic` to avoid undefined behavior in future unset `Diag` cases. Also adjust the message to include the bug report text.

rdar://179474757