### PR TITLE
[cxx-interop] Honor empty C++ member offsets in loadable clang records

### DIFF
--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -56,6 +56,7 @@
 #include "GenPointerAuth.h"
 #include "GenPoly.h"
 #include "GenProto.h"
+#include "GenStruct.h"
 #include "GenType.h"
 #include "IRGenDebugInfo.h"
 #include "IRGenFunction.h"
@@ -2783,6 +2784,11 @@ irgen::getCoroFunctionValues(IRGenFunction &IGF,
   return {fn, size, typeID};
 }
 
+static void
+emitClangRecordCallResult(IRGenFunction &IGF, const LoadableTypeInfo &recordTI,
+                          llvm::Value *result, Address indirectReturn,
+                          bool convertDirectToIndirectReturn, Explosion &out);
+
 namespace {
 
 class SyncCallEmission final : public CallEmission {
@@ -3098,6 +3104,11 @@ public:
     if (expectedNativeResultType->isVoidTy())
       return;
     if (result->getType() != expectedNativeResultType) {
+      if (auto *recordTI = getAsLoadableCXXRecord(IGF.IGM, resultType)) {
+        emitClangRecordCallResult(IGF, *recordTI, result, indirectReturnAddress,
+                                  convertDirectToIndirectReturn, out);
+        return;
+      }
       result =
           IGF.coerceValue(result, expectedNativeResultType, IGF.IGM.DataLayout);
     }
@@ -4800,6 +4811,34 @@ void CallEmission::emitToUnmappedExplosionWithDirectTypedError(
                          [](auto i) { return i; });
     out = nativeSchema.mapFromNative(IGF.IGM, IGF, resultExplosion, resultType);
   }
+}
+
+static void
+emitClangRecordCallResult(IRGenFunction &IGF, const LoadableTypeInfo &recordTI,
+                          llvm::Value *result, Address indirectReturn,
+                          bool convertDirectToIndirectReturn, Explosion &out) {
+  auto *returnTy = result->getType();
+
+  if (convertDirectToIndirectReturn) {
+    Address indirectAddr =
+        IGF.Builder.CreateElementBitCast(indirectReturn, returnTy);
+    IGF.Builder.CreateStore(result, indirectAddr);
+    return;
+  }
+
+  auto *storageTy = recordTI.getStorageType();
+  StackAddress temporary =
+      allocateForCoercion(IGF, returnTy, storageTy, "clang.record.return");
+
+  Address coercionAddr =
+      IGF.Builder.CreateElementBitCast(temporary.getAddress(), returnTy);
+  IGF.Builder.CreateStore(result, coercionAddr);
+
+  Address storageAddr =
+      IGF.Builder.CreateElementBitCast(temporary.getAddress(), storageTy);
+  recordTI.loadAsTake(IGF, storageAddr, out);
+
+  IGF.emitDeallocateStaticAlloca(temporary);
 }
 
 void CallEmission::setKeyPathAccessorArguments(Explosion &in, bool isOutlined,

--- a/lib/IRGen/GenStruct.cpp
+++ b/lib/IRGen/GenStruct.cpp
@@ -50,6 +50,7 @@
 #include "llvm/Support/Error.h"
 #include <iterator>
 
+#include "GenCall.h"
 #include "GenDecl.h"
 #include "GenMeta.h"
 #include "GenRecord.h"
@@ -1880,4 +1881,18 @@ const TypeInfo *TypeConverter::convertStructType(TypeBase *key, CanType type,
   // Build the type.
   StructTypeBuilder builder(IGM, ty, type);
   return builder.layout(fields);
+}
+
+const LoadableTypeInfo *irgen::getAsLoadableCXXRecord(IRGenModule &IGM,
+                                                      SILType silType) {
+  auto *structDecl = silType.getStructOrBoundGenericStruct();
+  if (!structDecl ||
+      !isa_and_nonnull<clang::CXXRecordDecl>(structDecl->getClangDecl()))
+    return nullptr;
+
+  auto &type = IGM.getTypeInfo(silType);
+  if (getStructTypeInfoKind(type) !=
+      StructTypeInfoKind::LoadableClangRecordTypeInfo)
+    return nullptr;
+  return &cast<LoadableTypeInfo>(type);
 }

--- a/lib/IRGen/GenStruct.h
+++ b/lib/IRGen/GenStruct.h
@@ -33,6 +33,7 @@ namespace irgen {
   class Explosion;
   class IRGenFunction;
   class IRGenModule;
+  class LoadableTypeInfo;
   class MemberAccessStrategy;
   class TypeInfo;
 
@@ -71,6 +72,11 @@ namespace irgen {
   std::optional<unsigned> getPhysicalStructFieldIndex(IRGenModule &IGM,
                                                       SILType baseType,
                                                       VarDecl *field);
+
+  /// If \p silType is a loadable C++ record,
+  /// return its LoadableTypeInfo.
+  const LoadableTypeInfo *getAsLoadableCXXRecord(IRGenModule &IGM,
+                                                 SILType silType);
 } // end namespace irgen
 } // end namespace swift
 

--- a/test/Interop/Cxx/class/Inputs/empty-field-layout.h
+++ b/test/Interop/Cxx/class/Inputs/empty-field-layout.h
@@ -1,0 +1,100 @@
+#ifndef EMPTY_FIELD_LAYOUT_H
+#define EMPTY_FIELD_LAYOUT_H
+
+struct Empty {};
+
+struct BaseEmpty {
+  Empty e;
+};
+
+struct EmptyThenInt {
+  Empty e;
+  int i;
+};
+
+inline EmptyThenInt makeEmptyThenInt(int n) { return EmptyThenInt{{}, n}; }
+
+struct IntThenEmpty {
+  int i;
+  Empty e;
+};
+
+inline IntThenEmpty makeIntThenEmpty(int n) { return IntThenEmpty{n, {}}; }
+
+struct EmptyEmptyInt {
+  Empty e1;
+  Empty e2;
+  int i;
+};
+
+inline EmptyEmptyInt makeEmptyEmptyInt(int n) {
+  return EmptyEmptyInt{{}, {}, n};
+}
+
+struct IntEmptyInt {
+  int a;
+  Empty e;
+  int b;
+};
+
+inline IntEmptyInt makeIntEmptyInt(int a, int b) { return IntEmptyInt{a, {}, b}; }
+
+// Empty-base optimization: empty base contributes 0 bytes, i is at offset 0.
+struct DerivedFromEmpty : Empty {
+  int i;
+};
+
+inline DerivedFromEmpty makeDerivedFromEmpty(int n) {
+  DerivedFromEmpty v;
+  v.i = n;
+  return v;
+}
+
+// `[[no_unique_address]]` lets the empty member share another field's address.
+// sizeof(NoUniqueAddressEmpty) is typically 4 bytes, i at offset 0.
+struct NoUniqueAddressEmpty {
+  [[no_unique_address]] Empty e;
+  int i;
+};
+
+inline NoUniqueAddressEmpty makeNoUniqueAddressEmpty(int n) {
+  return NoUniqueAddressEmpty{{}, n};
+}
+
+struct IntTrailingNoUniqueAddressEmpty {
+  int i;
+  [[no_unique_address]] Empty e;
+};
+
+inline IntTrailingNoUniqueAddressEmpty
+makeIntTrailingNoUniqueAddressEmpty(int n) {
+  return IntTrailingNoUniqueAddressEmpty{n, {}};
+}
+
+// Multi-register C ABI return
+struct IntEmptyIntInt {
+  int a;
+  Empty e;
+  int b;
+  int c;
+};
+
+inline IntEmptyIntInt makeIntEmptyIntInt(int a, int b, int c) {
+  return IntEmptyIntInt{a, {}, b, c};
+}
+
+// Address-only: non-trivial destructor forces sret.
+// This shouldn't exercise the `getAsLoadableCXXRecord` path
+struct EmptyAndIntNonTrivial {
+  Empty e;
+  int i;
+  ~EmptyAndIntNonTrivial() {}
+};
+
+inline EmptyAndIntNonTrivial makeEmptyAndIntNonTrivial(int n) {
+  EmptyAndIntNonTrivial v;
+  v.i = n;
+  return v;
+}
+
+#endif

--- a/test/Interop/Cxx/class/Inputs/module.modulemap
+++ b/test/Interop/Cxx/class/Inputs/module.modulemap
@@ -28,6 +28,11 @@ module DestructorsWithTemporaryValues {
   requires cplusplus
 }
 
+module EmptyFieldLayout {
+  header "empty-field-layout.h"
+  requires cplusplus
+}
+
 module Extensions {
   header "extensions.h"
   requires cplusplus

--- a/test/Interop/Cxx/class/empty-field-layout-irgen.swift
+++ b/test/Interop/Cxx/class/empty-field-layout-irgen.swift
@@ -1,0 +1,29 @@
+// RUN: %target-swiftxx-frontend -emit-ir -I %S/Inputs -module-name main %s | %FileCheck %s
+
+import EmptyFieldLayout
+
+public func readEmptyThenInt() -> Int32 {
+  let v = makeEmptyThenInt(2026)
+  return v.i
+}
+
+// CHECK-LABEL: define {{.*}} @"$s4main16readEmptyThenInts5Int32VyF"
+// CHECK: %[[BUF:clang\.record\.return\.coerced]] = alloca
+// CHECK: %[[CALL:[0-9]+]] = {{(invoke|call)}} i64 @{{.*}}makeEmptyThenInt
+// CHECK: store i64 %[[CALL]], ptr %[[BUF]]
+// CHECK: getelementptr inbounds {{.*}} %[[BUF]],
+// CHECK: load i32
+// CHECK-NOT: load i32, ptr %{{[^,]*}}.coercion.coerced
+
+public func readNonTrivial() -> Int32 {
+  let v = makeEmptyAndIntNonTrivial(2026)
+  return v.i
+}
+
+// A struct with a non-trivial destructor is address-only, 
+// so the C ABI returns it via `sret` — no `clang.record.return.coerced` alloca.
+
+// CHECK-LABEL: define {{.*}} @"$s4main14readNonTrivials5Int32VyF"
+// CHECK: alloca %TSo21EmptyAndIntNonTrivialV
+// CHECK: {{(invoke|call)}} void @{{.*}}makeEmptyAndIntNonTrivial{{.*}}(ptr {{.*}}sret(%TSo21EmptyAndIntNonTrivialV)
+// CHECK-NOT: clang.record.return.coerced = alloca

--- a/test/Interop/Cxx/class/empty-field-layout.swift
+++ b/test/Interop/Cxx/class/empty-field-layout.swift
@@ -1,0 +1,56 @@
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -cxx-interoperability-mode=default)
+// REQUIRES: executable_test
+
+import EmptyFieldLayout
+import StdlibUnittest
+
+var Tests = TestSuite("EmptyFieldLayout")
+
+Tests.test("empty before int") {
+  let v = makeEmptyThenInt(42)
+  expectEqual(42, v.i)
+}
+
+Tests.test("int before empty") {
+  let v = makeIntThenEmpty(7)
+  expectEqual(7, v.i)
+}
+
+Tests.test("two empties then int") {
+  let v = makeEmptyEmptyInt(99)
+  expectEqual(99, v.i)
+}
+
+Tests.test("int empty int") {
+  let v = makeIntEmptyInt(11, 22)
+  expectEqual(11, v.a)
+  expectEqual(22, v.b)
+}
+
+Tests.test("derived from empty base") {
+  let v = makeDerivedFromEmpty(123)
+  expectEqual(123, v.i)
+}
+
+Tests.test("no_unique_address empty") {
+  let v1 = makeNoUniqueAddressEmpty(77)
+  expectEqual(77, v1.i)
+
+  let v2 = makeIntTrailingNoUniqueAddressEmpty(88)
+  expectEqual(88, v2.i)
+}
+
+Tests.test("int empty int int (16 bytes, mid empty)") {
+  let v = makeIntEmptyIntInt(11, 22, 33)
+  expectEqual(11, v.a)
+  expectEqual(22, v.b)
+  expectEqual(33, v.c)
+}
+
+Tests.test("non-trivial dtor (address-only, sret path)") {
+  let v = makeEmptyAndIntNonTrivial(2026)
+  expectEqual(2026, v.i)
+}
+
+runAllTests()
+


### PR DESCRIPTION
Swift assumes the first _non-empty_ field of any struct sits at offset 0, which isn't true for C++ structs with empty fields. When the schema and C ABI return type don't agree, instead of coercing (which would erroneously put the first non-empty field at offset 0), we now go through memory.

rdar://180310311