### PR TITLE
[build] bump swift-subprocess to 0.5

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -4708,6 +4708,7 @@ function Build-Build([Hashtable] $Platform,
       LLBuild_DIR = (Get-ProjectCMakeModules $Platform LLBuild);
       SwiftDriver_DIR = (Get-ProjectCMakeModules $Platform Driver);
       SwiftSystem_DIR = (Get-ProjectCMakeModules $Platform System);
+      SwiftSubprocess_DIR = (Get-ProjectCMakeModules $Platform Subprocess);
       TSC_DIR = (Get-ProjectCMakeModules $Platform ToolsSupportCore);
       SwiftToolsProtocols_DIR = (Get-ProjectCMakeModules $Platform ToolsProtocols);
       SQLite3_INCLUDE_DIR = "$SourceCache\swift-toolchain-sqlite\Sources\CSQLite\include";
@@ -4943,6 +4944,7 @@ function Build-PackageManager([Hashtable] $Platform,
       CMAKE_Swift_FLAGS = @("-DCRYPTO_v2");
       CMAKE_STATIC_LIBRARY_PREFIX_Swift = "lib";
       SwiftSystem_DIR = (Get-ProjectCMakeModules $Platform System);
+      SwiftSubprocess_DIR = (Get-ProjectCMakeModules $Platform Subprocess);
       TSC_DIR = (Get-ProjectCMakeModules $Platform ToolsSupportCore);
       LLBuild_DIR = (Get-ProjectCMakeModules $Platform LLBuild);
       ArgumentParser_DIR = (Get-ProjectCMakeModules $Platform ArgumentParser);

--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -197,7 +197,7 @@
                 "zlib": "v1.3.1",
                 "brotli": "v1.2.0",
                 "mimalloc": "v3.0.3",
-                "swift-subprocess": "0.4",
+                "swift-subprocess": "0.5",
                 "boringssl": "0226f30467f540a3f62ef48d453f93927da199b6"
             }
         },
@@ -257,7 +257,7 @@
                 "zlib": "v1.3.1",
                 "brotli": "v1.2.0",
                 "mimalloc": "v3.0.3",
-                "swift-subprocess": "0.4",
+                "swift-subprocess": "0.5",
                 "boringssl": "817ab07ebb53da35afea409ab9328f578492832d"
             }
         },
@@ -810,7 +810,7 @@
                 "zlib": "v1.3.1",
                 "brotli": "v1.2.0",
                 "mimalloc": "v3.0.3",
-                "swift-subprocess": "0.4",
+                "swift-subprocess": "0.5",
                 "boringssl": "0226f30467f540a3f62ef48d453f93927da199b6"
             }
         },
@@ -872,7 +872,7 @@
                 "zlib": "v1.3.1",
                 "brotli": "v1.2.0",
                 "mimalloc": "v3.0.3",
-                "swift-subprocess": "0.4",
+                "swift-subprocess": "0.5",
                 "boringssl": "0226f30467f540a3f62ef48d453f93927da199b6"
             }
         }


### PR DESCRIPTION
Bump the swift-subprocess pin from 0.4 to 0.5

Needed for swiftPM adoption of swift-subprocess