### PR TITLE
[Embedded] Clean up the abstraction layer and add alloc/free flags

### DIFF
--- a/stdlib/public/EmbeddedPlatform/EmbeddedPlatformPOSIX.swift
+++ b/stdlib/public/EmbeddedPlatform/EmbeddedPlatformPOSIX.swift
@@ -14,54 +14,82 @@ func putchar(_: CInt) -> CInt
 @_extern(c, "exit")
 func exit(_: CInt)
 
-// Implementations of the Embedded Swift Platform layer on top of the POSIX dependencies.
-@implementation @c
-public func _swift_alignedAllocate(_ pointer: UnsafeMutablePointer<UnsafeMutableRawPointer?>, _ alignment: Int, _ size: Int) -> CInt {
-  posix_memalign(pointer, alignment, size)
+@inline(never)
+private func clearMemory(pointer: UnsafeMutableRawPointer, numBytes: Int) {
+  let bytePtr = unsafe pointer.assumingMemoryBound(to: UInt8.self)
+  for i in 0..<numBytes {
+    unsafe bytePtr[i] = 0
+  }
 }
 
+// Implementations of the Embedded Swift Platform layer on top of the POSIX
+// dependencies.
+
+@export(interface)
 @implementation @c
-public func _swift_alignedFree(_ p: UnsafeMutableRawPointer, _ alignment: Int, _ size: Int) {
-  free(p)
+public func _swift_allocate(_ alignment: Int, _ size: Int, _ flags: SwiftAllocateFlags) -> UnsafeMutableRawPointer? {
+  var pointer: UnsafeMutableRawPointer? = nil
+  guard posix_memalign(&pointer, alignment, size) == 0 else {
+    return nil
+  }
+
+  // Clear the memory if requested.
+  if flags.contains(.zeroMemory), let pointer {
+    clearMemory(pointer: pointer, numBytes: size)
+  }
+
+  return pointer
 }
 
+@export(interface)
+@implementation @c
+public func _swift_free(_ pointer: UnsafeMutableRawPointer, _ alignment: Int, _ size: Int, _ flags: SwiftFreeFlags) {
+  free(pointer)
+}
+
+@export(interface)
 @implementation @c
 public func _swift_generateRandom(_ buf: UnsafeMutableRawPointer, _ nbytes: Int) {
   arc4random_buf(buf, nbytes)
 }
 
+@export(interface)
 @implementation @c
 public func _swift_generateRandomHashSeed(_ buf: UnsafeMutableRawPointer, _ nbytes: Int) {
   arc4random_buf(buf, nbytes)
 }
 
+@export(interface)
 @implementation @c
 public func _swift_writeToStandardOutput(
   _ pointer: UnsafePointer<UInt8>?,
   _ count: Int
-) -> CInt {
+) -> Int {
   for unsafe char in unsafe UnsafeBufferPointer(start: pointer, count: count) {
     _ = putchar(CInt(char))
   }
-  return CInt(count)
+  return count
 }
 
+@export(interface)
 @implementation @c
-public func _swift_exit(_ code: CInt) {
-  exit(code)
+public func _swift_exit(_ code: Int) {
+  exit(CInt(code))
 }
 
+@export(interface)
 @implementation @c
-public func _swift_typedAllocate(_ buf: UnsafeMutablePointer<UnsafeMutableRawPointer?>, _ size: Int, _ alignMask: Int, _ typeId: UInt64) {
+public func _swift_typedAllocate(_ size: Int, _ alignMask: Int, _ flags: SwiftAllocateFlags, _ typeId: UInt64) -> UnsafeMutableRawPointer? {
   if (size == 0) {
-    return unsafe _swift_typedAllocate(buf, 1, alignMask, typeId)
+    return unsafe _swift_typedAllocate(1, alignMask, flags, typeId)
   }
 
 #if SWIFT_STDLIB_HAS_MALLOC_TYPE
+  var pointer: UnsafeMutableRawPointer? = nil
   if #available(macOS 15, iOS 17, tvOS 17, watchOS 10, *) {
     // This check also forces "default" alignment to use malloc_memalign().
     if (alignMask <= MALLOC_ALIGN_MASK) {
-      buf.pointee = unsafe malloc_type_malloc(size, typeId);
+      return unsafe malloc_type_malloc(size, typeId);
     } else {
       if alignMask == -1 {
         alignment = _swift_MinAllocationAlignment
@@ -72,13 +100,14 @@ public func _swift_typedAllocate(_ buf: UnsafeMutablePointer<UnsafeMutableRawPoi
       // Do not use malloc_type_aligned_alloc() here, because we want this
       // to work if `size` is not an integer multiple of `alignment`, which
       // was a requirement of the latter in C11 (but not C17 and later).
-      let err = unsafe malloc_type_posix_memalign(buf, alignment, size, typeId)
-      if (err != 0) {
-        buf.pointee = nil
+      guard unsafe malloc_type_posix_memalign(&pointer, alignment, size, typeId) == 0 else {
+        return nil
       }
     }
   }
+
+  return pointer
 #else
-  buf.pointee = unsafe swift_slowAlloc(size, alignMask)
+  return unsafe swift_slowAlloc(size, alignMask)
 #endif
 }

--- a/stdlib/public/EmbeddedPlatform/swift/EmbeddedPlatform.h
+++ b/stdlib/public/EmbeddedPlatform/swift/EmbeddedPlatform.h
@@ -26,12 +26,26 @@
 #ifndef EMBEDDED_SWIFT_PLATFORM_H
 #define EMBEDDED_SWIFT_PLATFORM_H
 
-#ifdef __SIZE_TYPE__
+#if defined(__SIZE_TYPE__) && defined(__PTRDIFF_TYPE__)
 typedef __SIZE_TYPE__ __swift_size_t;
+typedef __PTRDIFF_TYPE__ __swift_ptrdiff_t;
 #else
 #include <stddef.h>
 typedef size_t __swift_size_t;
+typedef ptrdiff_t __swift_ptrdiff_t;
 #endif
+
+/**
+ * 64-bit type identifier information that is used for typed allocation and
+ * deallocation.
+ */
+typedef unsigned long long __swift_typeid_t;
+
+/**
+ * 64-bit type  information that is used for typed allocation and
+ * deallocation.
+ */
+typedef unsigned long long __swift_options_t;
 
 #if __has_feature(nullability)
 #define EMBEDDED_SWIFT_NONNULL _Nonnull
@@ -51,25 +65,62 @@ typedef size_t __swift_size_t;
 #define EMBEDDED_SWIFT_SINGLE
 #endif
 
+#if defined(__has_feature) && __has_attribute(flag_enum)
+#define EMBEDDED_SWIFT_OPTION_SET __attribute__((flag_enum,enum_extensibility(open)))
+#else
+#define EMBEDDED_SWIFT_OPTION_SET
+#endif
+
+#if defined(__has_feature) && __has_attribute(swift_name)
+#define EMBEDDED_SWIFT_NAME(_name) __attribute__((swift_name(#_name)))
+#else
+#define EMBEDDED_SWIFT_NAME(_name)
+#endif
+
 /**
- * Allocates memory and places the resulting pointer in `*memptr`.
+ * Options provided to the Swift memory allocation function.
+ */
+typedef enum EMBEDDED_SWIFT_OPTION_SET: __swift_options_t {
+  /**
+   * No options.
+   */
+  SWIFT_ALLOC_NONE EMBEDDED_SWIFT_NAME(none) = 0,
+
+  /**
+   * Zero the memory before returning it, like the C library function `calloc`.
+   */
+  SWIFT_ALLOC_ZERO_MEMORY EMBEDDED_SWIFT_NAME(zeroMemory) = 0x01
+} swift_alloc_flags_t EMBEDDED_SWIFT_NAME(SwiftAllocateFlags);
+
+/**
+ * Options provided to the Swift memory deallocation function.
+ */
+typedef enum EMBEDDED_SWIFT_OPTION_SET: __swift_options_t {
+  /**
+   * No options.
+   */
+  SWIFT_FREE_NONE EMBEDDED_SWIFT_NAME(none) = 0,
+} swift_free_flags_t EMBEDDED_SWIFT_NAME(SwiftFreeFlags);
+
+/**
+ * Allocates memory and returns the resulting pointer.
  *
  * Parameters:
- *   - `memptr`: the resulting pointer will be written into *memptr on success.
  *   - `size`: the minimum number of bytes to allocate.
  *   - `alignment`: the minimum alignment of the resulting pointer, which must
  *     be a power of at least as large as `sizeof(void *)`.
+ *   - `flags`: flags to control the behavior of the allocation.
  *
- * Returns 0 on success, any other value on failure.
+ * Returns the allocated pointer, or NULL on failure.
  *
  * This function is required when using any Embedded Swift facility that
  * requires memory allocation from the heap, whether explicitly (e.g., via the
  * `allocate` operation on unsafe pointers) or implicitly (e.g., creating a
  * copy-on-write array or an instance of a class type).
  * 
- * This function can be implemented as a direct call to `posix_memalign`.
+ * This function can be implemented as a call to `posix_memalign`.
  */
-int _swift_alignedAllocate(void * EMBEDDED_SWIFT_NULLABLE * EMBEDDED_SWIFT_NONNULL EMBEDDED_SWIFT_SINGLE memptr, __swift_size_t alignment, __swift_size_t size);
+void * EMBEDDED_SWIFT_NULLABLE _swift_allocate(__swift_size_t alignment, __swift_size_t size, swift_alloc_flags_t flags);
 
 /**
  * Frees the memory referenced by `ptr`.
@@ -82,6 +133,7 @@ int _swift_alignedAllocate(void * EMBEDDED_SWIFT_NULLABLE * EMBEDDED_SWIFT_NONNU
  *   - `alignment`: the minimum alignment of the resulting pointer, which must
  *     be a power of at least as large as `sizeof(void *)`, or be zero to
  *     indicate that the alignment is not known.
+ *   - `flags`: flags to control the behavior of the free.
  *
  * This function is required when using any Embedded Swift facility that
  * requires memory allocation from the heap, whether explicitly (e.g., via the
@@ -90,18 +142,20 @@ int _swift_alignedAllocate(void * EMBEDDED_SWIFT_NULLABLE * EMBEDDED_SWIFT_NONNU
  * 
  * This function can be implemented as a direct call to `free`.
  */
-void _swift_alignedFree(void * EMBEDDED_SWIFT_NONNULL ptr, __swift_size_t alignment, __swift_size_t size);
+void _swift_free(void * EMBEDDED_SWIFT_NONNULL ptr, __swift_size_t alignment, __swift_size_t size, swift_free_flags_t flags);
 
 /**
- * Allocates memory and places the resulting pointer in `*memptr`.
+ * Allocates memory with a given type and returns the resulting pointer.
  *
  * Parameters:
- *   - `memptr`: the resulting pointer will be written into *memptr on success.
  *   - `size`: the minimum number of bytes to allocate.
  *   - `alignment`: the minimum alignment of the resulting pointer, which must
  *     be a power of at least as large as `sizeof(void *)`.
+ *   - `flags`: flags to control the behavior of the allocation.
  *   - `typeId`: an identifier used by a typed allocator to e.g. place the
  *     allocation in a particular bucket.
+ *
+ * Returns the allocated pointer, or NULL on failure.
  *
  * This function is required when using any Embedded Swift facility that
  * requires typed memory allocation from the heap, e.g. class instance
@@ -110,9 +164,8 @@ void _swift_alignedFree(void * EMBEDDED_SWIFT_NONNULL ptr, __swift_size_t alignm
  * This function can be implemented as a direct call to `posix_memalign`,
  * if the target platform does not support typed allocations.
  */
-void _swift_typedAllocate(
-    void *EMBEDDED_SWIFT_NULLABLE *EMBEDDED_SWIFT_NONNULL EMBEDDED_SWIFT_SINGLE ptr,
-    __swift_size_t size, __swift_size_t alignment, unsigned long long typeId);
+void * EMBEDDED_SWIFT_NULLABLE _swift_typedAllocate(
+    __swift_size_t size, __swift_size_t alignment, swift_alloc_flags_t flags, __swift_typeid_t typeId);
 
 /**
  * Writes a sequence of UTF-8 code points to standard output.
@@ -129,7 +182,7 @@ void _swift_typedAllocate(
  * This function can be implemented as a call to fwrite or printf with the
  * specified number of code points.
  */
-int _swift_writeToStandardOutput(
+__swift_size_t _swift_writeToStandardOutput(
     const unsigned char * EMBEDDED_SWIFT_NULLABLE EMBEDDED_SWIFT_COUNTED_BY(count) chars,
     __swift_size_t count);
 
@@ -219,12 +272,14 @@ void _swift_setExclusivityTLS(void * EMBEDDED_SWIFT_NULLABLE ptr);
  * This function can be implemented directly with a call to the POSIX exit()
  * function.
  */
-void _swift_exit(int code);
+void _swift_exit(__swift_ptrdiff_t code);
 
 #undef EMBEDDED_SWIFT_SINGLE
 #undef EMBEDDED_SWIFT_SIZED_BY
 #undef EMBEDDED_SWIFT_COUNTED_BY
 #undef EMBEDDED_SWIFT_NULLABLE
 #undef EMBEDDED_SWIFT_NONNULL
+#undef EMBEDDED_SWIFT_NAME
+#undef EMBEDDED_SWIFT_OPTION_SET
 
 #endif

--- a/stdlib/public/core/EmbeddedRuntime.swift
+++ b/stdlib/public/core/EmbeddedRuntime.swift
@@ -134,11 +134,11 @@ public struct HeapObject {
 #if SWIFT_USE_EMBEDDED_SWIFT_PLATFORM
 // Mirrors the interface defined in swift/EmbeddedPlatform.h
 
-@_extern(c, "_swift_alignedAllocate")
-public func _swift_alignedAllocate(_ pointer: UnsafeMutablePointer<UnsafeMutableRawPointer?>, _ alignment: Int, _ size: Int) -> CInt
+@_extern(c, "_swift_allocate")
+public func _swift_allocate(_ alignment: Int, _ size: Int, _ flags: CUnsignedLongLong) -> UnsafeMutableRawPointer?
 
-@_extern(c, "_swift_alignedFree")
-public func _swift_alignedFree(_ p: UnsafeMutableRawPointer, _ alignment: Int, _ size: Int)
+@_extern(c, "_swift_free")
+public func _swift_free(_ p: UnsafeMutableRawPointer, _ alignment: Int, _ size: Int, _ flags: CUnsignedLongLong)
 
 @_extern(c, "_swift_generateRandom")
 public func _swift_generateRandom(_ buf: UnsafeMutableRawPointer, _ nbytes: Int)
@@ -167,13 +167,13 @@ func arc4random_buf(buf: UnsafeMutableRawPointer, nbytes: Int)
 
 func alignedAlloc(size: Int, alignment: Int) -> UnsafeMutableRawPointer? {
   let alignment = max(alignment, unsafe MemoryLayout<UnsafeRawPointer>.size)
-  var r: UnsafeMutableRawPointer? = nil
 #if SWIFT_USE_EMBEDDED_SWIFT_PLATFORM
-  _ = unsafe _swift_alignedAllocate(&r, alignment, size)
+  return unsafe _swift_allocate(alignment, size, 0)
 #else
+  var r: UnsafeMutableRawPointer? = nil
   _ = unsafe posix_memalign(&r, alignment, size)
-#endif
   return unsafe r
+#endif
 }
 
 @c
@@ -197,7 +197,7 @@ public func swift_slowAlloc(_ size: Int, _ alignMask: Int) -> UnsafeMutableRawPo
 @c
 public func swift_slowDealloc(_ ptr: UnsafeMutableRawPointer, _ size: Int, _ alignMask: Int) {
 #if SWIFT_USE_EMBEDDED_SWIFT_PLATFORM
-  unsafe _swift_alignedFree(ptr, size, alignMask)
+  unsafe _swift_free(ptr, size, alignMask, 0)
 #else
   unsafe free(ptr)
 #endif

--- a/test/embedded/dependencies-concurrency-custom-executor.swift
+++ b/test/embedded/dependencies-concurrency-custom-executor.swift
@@ -10,6 +10,9 @@
 // RUN: comm -13 %t/allowed-dependencies_macos.txt %t/actual-dependencies.txt > %t/extra.txt
 // RUN: test ! -s %t/extra.txt
 
+// Expects the POSIX-based dependencies, not the Embedded Swift platform ones.
+// XFAIL: swift_embedded_platform
+
 //--- allowed-dependencies_macos.txt
 ___assert_rtn
 ___stack_chk_fail

--- a/test/embedded/dependencies-concurrency.swift
+++ b/test/embedded/dependencies-concurrency.swift
@@ -9,6 +9,9 @@
 // RUN: comm -13 %t/allowed-dependencies.txt %t/actual-dependencies.txt > %t/extra.txt
 // RUN: test ! -s %t/extra.txt
 
+// Expects the POSIX-based dependencies, not the Embedded Swift platform ones.
+// XFAIL: swift_embedded_platform
+
 //--- allowed-dependencies.txt
 ___assert_rtn
 ___error

--- a/test/embedded/dependencies-concurrency2.swift
+++ b/test/embedded/dependencies-concurrency2.swift
@@ -9,6 +9,9 @@
 // RUN: comm -13 %t/allowed-dependencies.txt %t/actual-dependencies.txt > %t/extra.txt
 // RUN: test ! -s %t/extra.txt
 
+// Expects the POSIX-based dependencies, not the Embedded Swift platform ones.
+// XFAIL: swift_embedded_platform
+
 //--- allowed-dependencies.txt
 ___assert_rtn
 ___stack_chk_fail

--- a/test/embedded/untyped-throws-class-hierarchy-exec.swift
+++ b/test/embedded/untyped-throws-class-hierarchy-exec.swift
@@ -1,5 +1,5 @@
-// RUN: %target-run-simple-swift(-enable-experimental-feature Embedded -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
-// RUN: %target-run-simple-swift(-O -enable-experimental-feature Embedded -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
+// RUN: %target-run-simple-swift(-enable-experimental-feature Embedded -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop %target-embedded-posix-shim) | %FileCheck %s
+// RUN: %target-run-simple-swift(-O -enable-experimental-feature Embedded -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop %target-embedded-posix-shim) | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test

--- a/test/embedded/untyped-throws-exec.swift
+++ b/test/embedded/untyped-throws-exec.swift
@@ -1,5 +1,5 @@
-// RUN: %target-run-simple-swift(-enable-experimental-feature Embedded -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
-// RUN: %target-run-simple-swift(-O -enable-experimental-feature Embedded -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
+// RUN: %target-run-simple-swift(-enable-experimental-feature Embedded -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop %target-embedded-posix-shim) | %FileCheck %s
+// RUN: %target-run-simple-swift(-O -enable-experimental-feature Embedded -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop %target-embedded-posix-shim) | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test


### PR DESCRIPTION
Extend the signature of the allocation and free operations in the
embedded abstraction layer to have a "flags" option set we can extend
in the future. For now, we only have the calloc-like "clear memory
after allocating it".

Renamed the _swift_aligned* to drop the "aligned". These are just
_swift_allocate and _swift_free.

Use ptrdiff_t rather than "int" so we get nicer Swift types (Int)
rather than CInt.

Tracked by rdar://177746266.