### PR TITLE
[test] Remove custom rpath logic from SwiftDemangleTests

### DIFF
--- a/unittests/SwiftDemangle/CMakeLists.txt
+++ b/unittests/SwiftDemangle/CMakeLists.txt
@@ -2,10 +2,6 @@ if(TARGET swiftDemangle)
   add_swift_unittest(SwiftDemangleTests IS_TARGET_TEST
     DemangleTest.cpp
   )
-  set_target_properties(SwiftDemangleTests
-    PROPERTIES BUILD_WITH_INSTALL_RPATH On INSTALL_RPATH "${SWIFT_LIBRARY_OUTPUT_INTDIR}"
-  )
-  
   target_link_libraries(SwiftDemangleTests
     PRIVATE
     swiftDemangle


### PR DESCRIPTION
This logic should no longer be required, even for this being a target test. `add_swift_unittest` now accounts for rpath handling correctly. See the Threading unit tests for an example (also marked with IS_TARGET_TEST).