### PR TITLE
Split ELF and Wasm Swift runtime registration files

### DIFF
--- a/Runtimes/Core/runtime/CMakeLists.txt
+++ b/Runtimes/Core/runtime/CMakeLists.txt
@@ -161,7 +161,7 @@ endif()
 
 string(TOLOWER "${SwiftCore_OBJECT_FORMAT}x" SwiftCore_OBJECT_FORMAT)
 if("${SwiftCore_OBJECT_FORMAT}" STREQUAL "elfx")
-  add_library(swiftrt OBJECT SwiftRT-ELF-WASM.cpp)
+  add_library(swiftrt OBJECT SwiftRT-ELF.cpp)
   target_compile_definitions(swiftrt PRIVATE
     -DSWIFT_ENABLE_BACKTRACING=$<BOOL:${SwiftCore_ENABLE_BACKTRACING}>)
   target_include_directories(swiftrt PRIVATE

--- a/stdlib/public/runtime/CMakeLists.txt
+++ b/stdlib/public/runtime/CMakeLists.txt
@@ -99,7 +99,8 @@ set(swift_runtime_backtracing_sources
 # Acknowledge that the following sources are known.
 set(LLVM_OPTIONAL_SOURCES
     SwiftRT-COFF.cpp
-    SwiftRT-ELF-WASM.cpp
+    SwiftRT-ELF.cpp
+    SwiftRT-WASM.cpp
     ${swift_runtime_sources}
     ${swift_runtime_objc_sources}
     ${swift_runtime_leaks_sources}
@@ -179,7 +180,7 @@ endforeach()
 # with LTO, force swift runtime to compile without LTO for Linux.
 add_swift_target_library(swiftImageRegistrationObjectELF
                   OBJECT_LIBRARY IS_STDLIB IS_STDLIB_CORE
-                  SwiftRT-ELF-WASM.cpp
+                  SwiftRT-ELF.cpp
                   C_COMPILE_FLAGS
                     ${SWIFT_RUNTIME_CORE_CXX_FLAGS}
                     ${swift_enable_backtracing}
@@ -203,7 +204,7 @@ add_swift_target_library(swiftImageRegistrationObjectCOFF
 
 add_swift_target_library(swiftImageRegistrationObjectWASM
                   OBJECT_LIBRARY IS_STDLIB IS_STDLIB_CORE
-                  SwiftRT-ELF-WASM.cpp
+                  SwiftRT-WASM.cpp
                   C_COMPILE_FLAGS
                     ${SWIFT_RUNTIME_CORE_CXX_FLAGS}
                     ${swift_enable_backtracing}
@@ -224,10 +225,6 @@ foreach(sdk ${SWIFT_SDKS})
       # to a version which supports it.
       # set(swiftrtObject "$<TARGET_OBJECTS:swiftImageRegistrationObject${SWIFT_SDK_${sdk}_OBJECT_FORMAT}-${arch_suffix}>")
       set(swiftrtSourceName SwiftRT-${SWIFT_SDK_${sdk}_OBJECT_FORMAT}.cpp)
-      if("${SWIFT_SDK_${sdk}_OBJECT_FORMAT}" STREQUAL "ELF" OR
-         "${SWIFT_SDK_${sdk}_OBJECT_FORMAT}" STREQUAL "WASM")
-       set(swiftrtSourceName SwiftRT-ELF-WASM.cpp)
-      endif()
       set(swiftrtObject ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/swiftImageRegistrationObject${SWIFT_SDK_${sdk}_OBJECT_FORMAT}-${arch_suffix}.dir/${swiftrtSourceName}${CMAKE_C_OUTPUT_EXTENSION})
 
       if(sdk STREQUAL "WINDOWS")

--- a/stdlib/public/runtime/SwiftRT-ELF.cpp
+++ b/stdlib/public/runtime/SwiftRT-ELF.cpp
@@ -1,4 +1,4 @@
-//===--- SwiftRT-ELF-WASM.cpp ---------------------------------------------===//
+//===--- SwiftRT-ELF.cpp --------------------------------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //
@@ -18,9 +18,7 @@
 #include <cstddef>
 #include <new>
 
-#if defined(__ELF__)
 extern "C" const char __ehdr_start[] __attribute__((__weak__));
-#endif
 
 #if SWIFT_ENABLE_BACKTRACING
 // Drag in a symbol from the backtracer, to force the static linker to include
@@ -32,11 +30,7 @@ static const void *__backtraceRef __attribute__((used, retain))
 // Create empty sections to ensure that the start/stop symbols are synthesized
 // by the linker.  Otherwise, we may end up with undefined symbol references as
 // the linker table section was never constructed.
-#if defined(__ELF__)
 # define DECLARE_EMPTY_METADATA_SECTION(name, attrs) __asm__("\t.section " #name ",\"" attrs "\"\n");
-#elif defined(__wasm__)
-# define DECLARE_EMPTY_METADATA_SECTION(name, attrs) __asm__("\t.section " #name ",\"R\",@\n");
-#endif
 
 #define BOUNDS_VISIBILITY __attribute__((__visibility__("hidden"), \
                                          __aligned__(1)))
@@ -88,15 +82,10 @@ static void swift_image_constructor() {
   { reinterpret_cast<uintptr_t>(&__start_##name),                              \
     static_cast<uintptr_t>(&__stop_##name - &__start_##name) }
 
-    const void *baseAddress = nullptr;
-#if defined(__ELF__)
+  const void *baseAddress = nullptr;
   if (&__ehdr_start != nullptr) {
     baseAddress = __ehdr_start;
   }
-#elif defined(__wasm__)
-  // NOTE: Multi images in a single process is not yet stabilized in WebAssembly
-  // toolchain outside of Emscripten.
-#endif
 
   ::new (&sections) swift::MetadataSections {
       swift::CurrentSectionMetadataVersion,

--- a/stdlib/public/runtime/SwiftRT-WASM.cpp
+++ b/stdlib/public/runtime/SwiftRT-WASM.cpp
@@ -1,0 +1,116 @@
+//===--- SwiftRT-WASM.cpp -------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "ImageInspectionCommon.h"
+#include "swift/shims/MetadataSections.h"
+#include "swift/Runtime/Backtrace.h"
+#include "swift/Runtime/Config.h"
+
+#include <cstddef>
+#include <new>
+
+#if SWIFT_ENABLE_BACKTRACING
+// Drag in a symbol from the backtracer, to force the static linker to include
+// the code.
+static const void *__backtraceRef __attribute__((used, retain))
+  = (const void *)swift::runtime::backtrace::_swift_backtrace_isThunkFunction;
+#endif
+
+// Create empty sections to ensure that the start/stop symbols are synthesized
+// by the linker.  Otherwise, we may end up with undefined symbol references as
+// the linker table section was never constructed.
+#define DECLARE_EMPTY_METADATA_SECTION(name, attrs) __asm__("\t.section " #name ",\"R\",@\n");
+
+#define BOUNDS_VISIBILITY __attribute__((__visibility__("hidden"), \
+                                         __aligned__(1)))
+
+#define DECLARE_BOUNDS(name)                            \
+  BOUNDS_VISIBILITY extern const char __start_##name;   \
+  BOUNDS_VISIBILITY extern const char __stop_##name;
+
+#define DECLARE_SWIFT_SECTION(name)             \
+  DECLARE_EMPTY_METADATA_SECTION(name, "aR")    \
+  DECLARE_BOUNDS(name)
+
+// These may or may not be present, depending on compiler switches; it's
+// worth calling them out as a result.
+#define DECLARE_SWIFT_REFLECTION_SECTION(name)  \
+  DECLARE_SWIFT_SECTION(name)
+
+extern "C" {
+DECLARE_SWIFT_SECTION(swift5_protocols)
+DECLARE_SWIFT_SECTION(swift5_protocol_conformances)
+DECLARE_SWIFT_SECTION(swift5_type_metadata)
+
+DECLARE_SWIFT_REFLECTION_SECTION(swift5_fieldmd)
+DECLARE_SWIFT_REFLECTION_SECTION(swift5_builtin)
+DECLARE_SWIFT_REFLECTION_SECTION(swift5_assocty)
+DECLARE_SWIFT_REFLECTION_SECTION(swift5_capture)
+DECLARE_SWIFT_REFLECTION_SECTION(swift5_reflstr)
+DECLARE_SWIFT_REFLECTION_SECTION(swift5_typeref)
+DECLARE_SWIFT_REFLECTION_SECTION(swift5_mpenum)
+
+DECLARE_SWIFT_SECTION(swift5_replace)
+DECLARE_SWIFT_SECTION(swift5_replac2)
+DECLARE_SWIFT_SECTION(swift5_accessible_functions)
+DECLARE_SWIFT_SECTION(swift5_runtime_attributes)
+
+DECLARE_SWIFT_SECTION(swift5_tests)
+}
+
+#undef DECLARE_SWIFT_SECTION
+
+namespace {
+static swift::MetadataSections sections{};
+}
+
+SWIFT_ALLOWED_RUNTIME_GLOBAL_CTOR_BEGIN
+__attribute__((__constructor__))
+static void swift_image_constructor() {
+#define SWIFT_SECTION_RANGE(name)                                              \
+  { reinterpret_cast<uintptr_t>(&__start_##name),                              \
+    static_cast<uintptr_t>(&__stop_##name - &__start_##name) }
+
+  // NOTE: Multi images in a single process is not yet stabilized in WebAssembly
+  // toolchain outside of Emscripten.
+  const void *baseAddress = nullptr;
+
+  ::new (&sections) swift::MetadataSections {
+      swift::CurrentSectionMetadataVersion,
+      baseAddress,
+
+      nullptr,
+      nullptr,
+
+      SWIFT_SECTION_RANGE(swift5_protocols),
+      SWIFT_SECTION_RANGE(swift5_protocol_conformances),
+      SWIFT_SECTION_RANGE(swift5_type_metadata),
+
+      SWIFT_SECTION_RANGE(swift5_typeref),
+      SWIFT_SECTION_RANGE(swift5_reflstr),
+      SWIFT_SECTION_RANGE(swift5_fieldmd),
+      SWIFT_SECTION_RANGE(swift5_assocty),
+      SWIFT_SECTION_RANGE(swift5_replace),
+      SWIFT_SECTION_RANGE(swift5_replac2),
+      SWIFT_SECTION_RANGE(swift5_builtin),
+      SWIFT_SECTION_RANGE(swift5_capture),
+      SWIFT_SECTION_RANGE(swift5_mpenum),
+      SWIFT_SECTION_RANGE(swift5_accessible_functions),
+      SWIFT_SECTION_RANGE(swift5_runtime_attributes),
+      SWIFT_SECTION_RANGE(swift5_tests),
+  };
+
+#undef SWIFT_SECTION_RANGE
+
+  swift_addNewDSOImage(&sections);
+}
+SWIFT_ALLOWED_RUNTIME_GLOBAL_CTOR_END


### PR DESCRIPTION
Section headers aren't available in loaded ELF files. We will be adding some additional tables to ELF binaries containing a table of the metadata sections.

Wasm does make the section headers available and doesn't really seem to change the layout of an image when loading, so we don't need to include the new metadata section linker set table in Wasm binaries.

In the interest of keeping them small, and keeping the code cleaner, splitting it now to make it easier to target each object format directly.