### PR TITLE
[SymbolGraph] Prevent a duplicate decls assertion when a Clang submodule re-exports its parent's headers.

### DIFF
--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -1529,6 +1529,9 @@ collectExportedImports(const ModuleDecl *topLevelModule,
         file->getImportedModules(exportedImports,
                                  ModuleDecl::ImportFilterKind::Exported);
         for (const auto &im : exportedImports) {
+          // Prevent self-import cycles where a submodule re-exports its parent's headers.
+          if (im.importedModule == topLevelModule)
+            continue;
           // Skip collecting the underlying clang module as we already have the relevant import.
           if (!module->isClangOverlayOf(im.importedModule))
             importCollector.collect(im);

--- a/test/SymbolGraph/ClangImporter/Inputs/SubmodulesSelfImport/SelfImport.h
+++ b/test/SymbolGraph/ClangImporter/Inputs/SubmodulesSelfImport/SelfImport.h
@@ -1,0 +1,1 @@
+void parentFunc(void);

--- a/test/SymbolGraph/ClangImporter/Inputs/SubmodulesSelfImport/Sub.h
+++ b/test/SymbolGraph/ClangImporter/Inputs/SubmodulesSelfImport/Sub.h
@@ -1,0 +1,2 @@
+#include "SelfImport.h"
+void submoduleFunc(void);

--- a/test/SymbolGraph/ClangImporter/Inputs/SubmodulesSelfImport/module.modulemap
+++ b/test/SymbolGraph/ClangImporter/Inputs/SubmodulesSelfImport/module.modulemap
@@ -1,0 +1,9 @@
+module SelfImport {
+  umbrella "."
+  export *
+
+  module Sub {
+    header "Sub.h"
+    export *
+  }
+}

--- a/test/SymbolGraph/ClangImporter/SubmodulesSelfImport.swift
+++ b/test/SymbolGraph/ClangImporter/SubmodulesSelfImport.swift
@@ -1,0 +1,8 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-symbolgraph-extract -sdk %clang-importer-sdk -module-name SelfImport -I %S/Inputs/SubmodulesSelfImport -output-dir %t -pretty-print -v
+// RUN: %FileCheck %s --input-file %t/SelfImport.symbols.json
+
+// REQUIRES: objc_interop
+
+// CHECK-DAG: "precise": "c:@F@parentFunc"
+// CHECK-DAG: "precise": "c:@F@submoduleFunc"


### PR DESCRIPTION
If you generate the symbol graph for a Clang module that has an implicit submodule that re-exports one of its top-level module's headers, we end up collecting the decls from the top-level module twice in `ModuleDecl::getDisplayDeclsRecursivelyAndImports`: once explicitly at the beginning and then later because the top-level module gets added to the import collector. In toolchains with assertions enabled, this causes the duplicate decl assertion at the end of `ModuleDecl::getDisplayDeclsRecursivelyAndImports` to get triggered.

Resolve this by not adding the top-level module that we're scanning to the import collector if we encounter it during the scan, and add a test case for future regressions.