### PR TITLE
[Completion] Avoid creating accessor with invalid SourceLoc

### DIFF
--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -8434,7 +8434,13 @@ ParserStatus Parser::parseGetSet(ParseDeclOptions Flags, ParameterList *Indices,
     ParserStatus AccessorStatus = parseAccessorIntroducer(
         *this, Attributes, Kind, Loc, IsFirstAccessor, &featureUnavailable);
     Status |= AccessorStatus;
-    if (AccessorStatus.isError() && !AccessorStatus.hasCodeCompletion()) {
+    if (AccessorStatus.isError()) {
+      // If we have a code completion token in an attribute but no accessor
+      // introducer, bail.
+      if (AccessorStatus.hasCodeCompletion()) {
+        accessorHasCodeCompletion = true;
+        break;
+      }
       if (Tok.is(tok::code_complete)) {
         // Handle code completion here only if it's not the first accessor.
         // If it's the first accessor, it's handled in function body parsing

--- a/test/IDE/complete_accessor.swift
+++ b/test/IDE/complete_accessor.swift
@@ -124,3 +124,14 @@ extension UNKNOWN_TYPE {
     #^UNKNOWN_EXT_SUBSCRIPT_SECOND?check=NO_GLOBAL;check=NO_SELF;check=WITH_GETSET;check=NO_OBSERVER^#
   }
 }
+
+var incompleteAccessor1: Int {
+  @#^INCOMPLETE_ACCESSOR_ATTR1^#
+  // INCOMPLETE_ACCESSOR_ATTR1: Keyword/None: storageRestrictions[#Declaration Attribute#]; name=storageRestrictions
+}
+
+var incompleteAccessor2: Int {
+  set {}
+  @#^INCOMPLETE_ACCESSOR_ATTR2^#
+  // INCOMPLETE_ACCESSOR_ATTR2: Keyword/None: storageRestrictions[#Declaration Attribute#]; name=storageRestrictions
+}

--- a/validation-test/IDE/crashers/TypeDecl-getName-9fefcf.swift
+++ b/validation-test/IDE/crashers/TypeDecl-getName-9fefcf.swift
@@ -1,6 +1,0 @@
-// {"kind":"complete","original":"2ab8a74a","signature":"swift::TypeDecl::getName() const"}
-// RUN: not --crash %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -source-filename %s
-extension {
-  subscript -> a {
-    @
-    #^^#

--- a/validation-test/IDE/crashers_fixed/ASTScopeImpl-getCharSourceRangeOfScope-284706.swift
+++ b/validation-test/IDE/crashers_fixed/ASTScopeImpl-getCharSourceRangeOfScope-284706.swift
@@ -1,3 +1,3 @@
 // {"kind":"complete","original":"265e5934","signature":"swift::ast_scope::ASTScopeImpl::getCharSourceRangeOfScope(swift::SourceManager&, bool) const","signatureAssert":"Assertion failed: ((range.isValid()) && \"scope has invalid source range\"), function getCharSourceRangeOfScope","signatureNext":"ASTScopeImpl::checkSourceRangeBeforeAddingChild"}
-// RUN: not --crash %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -source-filename %s
+// RUN: %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -source-filename %s
 let a { @b#^^#

--- a/validation-test/IDE/crashers_fixed/ASTScopeImpl-getCharSourceRangeOfScope-34e018.swift
+++ b/validation-test/IDE/crashers_fixed/ASTScopeImpl-getCharSourceRangeOfScope-34e018.swift
@@ -1,4 +1,4 @@
 // {"kind":"complete","signature":"swift::ast_scope::ASTScopeImpl::getCharSourceRangeOfScope(swift::SourceManager&, bool) const","signatureAssert":"Assertion failed: ((range.isValid()) && \"scope has invalid source range\"), function getCharSourceRangeOfScope"}
-// RUN: not --crash %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -source-filename %s
+// RUN: %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -source-filename %s
 var a: b {
   @ #^COMPLETE^#

--- a/validation-test/IDE/crashers_fixed/TypeDecl-getName-9fefcf.swift
+++ b/validation-test/IDE/crashers_fixed/TypeDecl-getName-9fefcf.swift
@@ -1,0 +1,6 @@
+// {"kind":"complete","original":"2ab8a74a","signature":"swift::TypeDecl::getName() const"}
+// RUN: %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -source-filename %s
+extension {
+  subscript -> a {
+    @
+    #^^#

--- a/validation-test/IDE/crashers_fixed/printContext-0af7ab.swift
+++ b/validation-test/IDE/crashers_fixed/printContext-0af7ab.swift
@@ -1,5 +1,5 @@
 // {"kind":"complete","original":"33e6423a","signature":"swift::printContext(llvm::raw_ostream&, swift::DeclContext*)"}
-// RUN: not --crash %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -source-filename %s
+// RUN: %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -source-filename %s
 extension {
   subscript -> {
     @


### PR DESCRIPTION
If we have a completion token in an accessor attribute, if the introducer is missing, avoid creating the AccessorDecl with an invalid SourceLoc. Instead just bail out, same as if we had an immediate completion token. This avoids crashing in name lookup.

rdar://171578403