### PR TITLE
[stdlib] Map char32_t to UInt32 instead of Unicode.Scalar

### DIFF
--- a/docs/HowSwiftImportsCAPIs.md
+++ b/docs/HowSwiftImportsCAPIs.md
@@ -227,7 +227,7 @@ Swift types.  This table is based on
 | `wchar_t`, regardless if the target defines it as signed or unsigned | `typealias CWideChar = Unicode.Scalar`<br>`Unicode.Scalar` is a wrapper around `UInt32` |
 | `char8_t` (proposed for C++20) | Not mapped |
 | `char16_t`                           | `typealias CChar16 = UInt16` |
-| `char32_t`                           | `typealias CChar32 = Unicode.Scalar` |
+| `char32_t`                           | `typealias CChar32 = UInt32` |
 | `float`                              | `typealias CFloat = Float` |
 | `double`                             | `typealias CDouble = Double` |
 | `long double`                        | `CLongDouble`, which is a typealias to `Float80` or `Double`, depending on the platform.<br>There is no support for 128-bit floating point. |

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2226,6 +2226,12 @@ ERROR(c_func_unsupported_specifier, none,
       (StringRef, DeclName, const ValueDecl *))
 ERROR(c_unsupported_type, none, "%0 cannot be represented in C",
       (Type))
+WARNING(c_unicode_scalar_param_unsound, none,
+        "'Unicode.Scalar' parameter %0 will be exposed as 'char32_t', which "
+        "can hold values that are not valid Unicode scalars",
+        (DeclName))
+NOTE(c_unicode_scalar_param_unsound_fixit, none,
+     "use 'UInt32' and validate with 'Unicode.Scalar.init(_:)'", ())
 ERROR(c_func_async,none,
       "async functions cannot be represented in C", ())
 ERROR(c_func_throws,none,

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -6587,6 +6587,22 @@ ASTContext::getForeignRepresentationInfo(NominalTypeDecl *nominal,
       // or UInt to a C type.
       addTrivial(getIdentifier("Int"), stdlib);
       addTrivial(getIdentifier("UInt"), stdlib);
+
+      // Register Unicode.Scalar as foreign-representable on all platforms;
+      // PrintAsClang currently prints it as 'char32_t' but no C typealias above
+      // maps to it (CChar32 is UInt32, CWideChar is UInt16 on Windows).
+      if (auto *unicodeEnum =
+              dyn_cast_or_null<EnumDecl>(findUnderlyingTypeInModule(
+                  *this, getIdentifier("Unicode"), stdlib))) {
+        for (auto *result :
+             unicodeEnum->lookupDirect(getIdentifier("Scalar"))) {
+          if (auto *scalarDecl = dyn_cast<StructDecl>(result)) {
+            getImpl().ForeignRepresentableCache.insert(
+                {scalarDecl, ForeignRepresentationInfo::forTrivial()});
+            break;
+          }
+        }
+      }
     }
 
     if (auto darwin = getLoadedModule(Id_Darwin)) {

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -1119,7 +1119,7 @@ namespace {
 
         // Import the underlying integer type.
         auto result = Visit(clangDecl->getIntegerType());
-        // Unicode.Scalar (from char32_t or wchar_t) doesn't conform to
+        // Unicode.Scalar (from wchar_t) doesn't conform to
         // _ExpressibleByBuiltinIntegerLiteral, which is required for enum
         // constant values. Use UInt32 instead.
         if (result.AbstractType && result.AbstractType->isUnicodeScalar())
@@ -1759,7 +1759,7 @@ static ImportedType adjustTypeForConcreteImport(
 
   assert(importedType);
 
-  // When Unicode.Scalar (from char32_t or wchar_t) is used as an enum's
+  // When Unicode.Scalar (from wchar_t) is used as an enum's
   // underlying type, import as UInt32 instead. Unicode.Scalar doesn't conform
   // to _ExpressibleByBuiltinIntegerLiteral, which is required for enum cases.
   if (importKind == ImportTypeKind::Enum && importedType->isUnicodeScalar())

--- a/lib/PrintAsClang/PrimitiveTypeMapping.cpp
+++ b/lib/PrintAsClang/PrimitiveTypeMapping.cpp
@@ -89,8 +89,28 @@ void PrimitiveTypeMapping::initialize(ASTContext &ctx) {
   MAP(CChar16, "char16_t", false);
   MAP(CChar32, "char32_t", false);
 
-  // Set after CChar32 to prefer char32_t for the shared underlying
-  // Unicode.Scalar. char32_t is stable across platforms.
+  // Map Unicode.Scalar to char32_t.
+  //
+  // char32_t is a superset of Unicode.Scalar value-wise (it can hold invalid
+  // Unicode scalars) so this is sound in return position but not in argument
+  // position.
+  //
+  // Can't reuse MAP macro or addMappedType here because unlike other primitive
+  // types getting Unicode.Scalar requires a qualified lookup inside Unicode.
+  if (auto *unicodeEnum = dyn_cast_or_null<EnumDecl>(findTypeInModuleByName(
+          ctx, ctx.StdlibModuleName, ctx.getIdentifier("Unicode")))) {
+    for (auto *result :
+         unicodeEnum->lookupDirect(ctx.getIdentifier("Scalar"))) {
+      if (auto *scalarDecl = dyn_cast<StructDecl>(result)) {
+        mappedTypeNames[scalarDecl] = {"char32_t",
+                                       std::optional<StringRef>("char32_t"),
+                                       std::optional<StringRef>("char32_t"),
+                                       /*canBeNullable=*/false};
+        break;
+      }
+    }
+  }
+
   MAP(CWideChar, "wchar_t", false);
 
   MAP(CSignedChar, "signed char", false);

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -402,6 +402,14 @@ static bool isParamListRepresentableInLanguage(const AbstractFunctionDecl *AFD,
     } else if (param->getTypeInContext()->isRepresentableIn(
           language,
           const_cast<AbstractFunctionDecl *>(AFD))) {
+      // Warn about Unicode.Scalar parameters in C/Objective-C-bound decl,
+      // which is exposed as 'char32_t' and can hold invalid Unicode values.
+      if (param->getTypeInContext()->getCanonicalType()->isUnicodeScalar()) {
+        param->diagnose(diag::c_unicode_scalar_param_unsound, param->getName());
+        auto note = param->diagnose(diag::c_unicode_scalar_param_unsound_fixit);
+        if (auto *typeRepr = param->getTypeRepr())
+          note.fixItReplace(typeRepr->getSourceRange(), "UInt32");
+      }
       continue;
     }
 

--- a/stdlib/public/Cxx/std/String.swift
+++ b/stdlib/public/Cxx/std/String.swift
@@ -90,7 +90,7 @@ extension std.u32string {
   public init(_ string: String) {
     self.init()
     for char in string.unicodeScalars {
-      self.push_back(char)
+      self.push_back(char.value)
     }
   }
 }
@@ -419,12 +419,10 @@ extension String {
   ///   string.
   @_alwaysEmitIntoClient
   public init(_ cxxU32String: std.u32string) {
-    let buffer = unsafe UnsafeBufferPointer<Unicode.Scalar>(
+    let buffer = unsafe UnsafeBufferPointer<UInt32>(
       start: cxxU32String.__dataUnsafe(),
       count: cxxU32String.size())
-    self = unsafe buffer.withMemoryRebound(to: UInt32.self) {
-      unsafe String(decoding: $0, as: UTF32.self)
-    }
+    self = unsafe String(decoding: buffer, as: UTF32.self)
     withExtendedLifetime(cxxU32String) {}
   }
 
@@ -510,12 +508,10 @@ extension String {
   ///   string view.
   @_alwaysEmitIntoClient
   public init(_ cxxU32StringView: std.u32string_view) {
-    let buffer = unsafe UnsafeBufferPointer<Unicode.Scalar>(
+    let buffer = unsafe UnsafeBufferPointer<UInt32>(
       start: cxxU32StringView.__dataUnsafe(),
       count: cxxU32StringView.size())
-    self = unsafe buffer.withMemoryRebound(to: UInt32.self) {
-      unsafe String(decoding: $0, as: UTF32.self)
-    }
+    self = unsafe String(decoding: buffer, as: UTF32.self)
     unsafe withExtendedLifetime(cxxU32StringView) {}
   }
 

--- a/stdlib/public/core/CTypes.swift
+++ b/stdlib/public/core/CTypes.swift
@@ -144,16 +144,14 @@ public typealias CWideChar = UInt16
 public typealias CWideChar = Unicode.Scalar
 #endif
 
-/// The C++20 'char8_t' type, which has UTF-8 encoding.
+/// The C++20 'char8_t' type.
 public typealias CChar8 = UInt8
 
-// FIXME: Swift should probably have a UTF-16 type other than UInt16.
-//
-/// The C++11 'char16_t' type, which has UTF-16 encoding.
+/// The C++11 'char16_t' type.
 public typealias CChar16 = UInt16
 
-/// The C++11 'char32_t' type, which has UTF-32 encoding.
-public typealias CChar32 = Unicode.Scalar
+/// The C++11 'char32_t' type.
+public typealias CChar32 = UInt32
 
 /// The C '_Bool' and C++ 'bool' type.
 public typealias CBool = Bool

--- a/test/IRGen/objc_type_encoding.swift
+++ b/test/IRGen/objc_type_encoding.swift
@@ -75,11 +75,11 @@ import gizmo
 // CHECK-xros: private unnamed_addr constant [23 x i8] c"v44@0:8C16S20I24Q28Q36\00"
 
   @objc func testCChars(_ basic: CChar, wchar wide: CWideChar, char8: CChar8, char16: CChar16, char32: CChar32) {}
-// CHECK-macosx: private unnamed_addr constant [23 x i8] c"v36@0:8c16i20C24S28i32\00"
-// CHECK-ios: private unnamed_addr constant [23 x i8] c"v36@0:8c16i20C24S28i32\00"
-// CHECK-tvos: private unnamed_addr constant [23 x i8] c"v36@0:8c16i20C24S28i32\00"
-// CHECK-watchos: private unnamed_addr constant [20 x i8] c"v32@0:8c16i20S24i28\00"
-// CHECK-xros: private unnamed_addr constant [20 x i8] c"v32@0:8c16i20S24i28\00"
+// CHECK-macosx: private unnamed_addr constant [23 x i8] c"v36@0:8c16i20C24S28I32\00"
+// CHECK-ios: private unnamed_addr constant [23 x i8] c"v36@0:8c16i20C24S28I32\00"
+// CHECK-tvos: private unnamed_addr constant [23 x i8] c"v36@0:8c16i20C24S28I32\00"
+// CHECK-watchos: private unnamed_addr constant [20 x i8] c"v32@0:8c16i20S24I28\00"
+// CHECK-xros: private unnamed_addr constant [20 x i8] c"v32@0:8c16i20S24I28\00"
 
   @objc func testCBool(_ a: CBool) {}
 // CHECK-macosx: private unnamed_addr constant [11 x i8] c"v20@0:8c16\00"

--- a/test/Interop/Cxx/stdlib/use-std-string.swift
+++ b/test/Interop/Cxx/stdlib/use-std-string.swift
@@ -579,7 +579,7 @@ StdStringTestSuite.test("std::u32string as Swift.CustomStringConvertible") {
       .compactMap { Unicode.Scalar($0) }
     var cxx4 = std.u32string()
     for scalar: Unicode.Scalar in scalars2 {
-        cxx4.push_back(scalar)
+        cxx4.push_back(scalar.value)
     }
     expectEqual(cxx4.description, "Hello, 世界")
 }

--- a/test/Interop/SwiftToC/functions/swift-primitive-functions-c-bridging.swift
+++ b/test/Interop/SwiftToC/functions/swift-primitive-functions-c-bridging.swift
@@ -8,7 +8,7 @@
 // CHECK-NEXT: SWIFT_EXTERN bool $s9Functions16passThroughCBoolyS2bF(bool x) SWIFT_NOEXCEPT SWIFT_CALL;
 // CHECK-NEXT: SWIFT_EXTERN char $s9Functions16passThroughCCharys4Int8VADF(char x) SWIFT_NOEXCEPT SWIFT_CALL;
 // CHECK-NEXT: SWIFT_EXTERN char16_t $s9Functions18passThroughCChar16ys6UInt16VADF(char16_t x) SWIFT_NOEXCEPT SWIFT_CALL;
-// CHECK-NEXT: SWIFT_EXTERN char32_t $s9Functions18passThroughCChar32ys7UnicodeO6ScalarVAFF(char32_t x) SWIFT_NOEXCEPT SWIFT_CALL;
+// CHECK-NEXT: SWIFT_EXTERN char32_t $s9Functions18passThroughCChar32ys6UInt32VADF(char32_t x) SWIFT_NOEXCEPT SWIFT_CALL;
 // CHECK-NEXT: SWIFT_EXTERN double $s9Functions18passThroughCDoubleyS2dF(double x) SWIFT_NOEXCEPT SWIFT_CALL;
 // CHECK-NEXT: SWIFT_EXTERN float $s9Functions17passThroughCFloatyS2fF(float x) SWIFT_NOEXCEPT SWIFT_CALL;
 // CHECK-NEXT: SWIFT_EXTERN int $s9Functions15passThroughCIntys5Int32VADF(int x) SWIFT_NOEXCEPT SWIFT_CALL;

--- a/test/Interop/SwiftToC/functions/swift-primitive-functions-execution.c
+++ b/test/Interop/SwiftToC/functions/swift-primitive-functions-execution.c
@@ -30,7 +30,7 @@ int main() {
   // passThroughCChar16
   VERIFY_PASSTHROUGH_VALUE($s9Functions18passThroughCChar16ys6UInt16VADF, 0xFE1);
   // passThroughCChar32
-  VERIFY_PASSTHROUGH_VALUE($s9Functions18passThroughCChar32ys7UnicodeO6ScalarVAFF, 0x100FE);
+  VERIFY_PASSTHROUGH_VALUE($s9Functions18passThroughCChar32ys6UInt32VADF, 0x100FE);
 
   // passThroughCSignedChar
   VERIFY_PASSTHROUGH_VALUE($s9Functions22passThroughCSignedCharys4Int8VADF, -1);

--- a/test/Interop/SwiftToCxx/functions/swift-primitive-functions-cxx-bridging.swift
+++ b/test/Interop/SwiftToCxx/functions/swift-primitive-functions-cxx-bridging.swift
@@ -21,7 +21,7 @@
 // CHECK-NEXT: }
 
 // CHECK:      SWIFT_INLINE_THUNK char32_t passThroughCChar32(char32_t x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT:   return Functions::_impl::$s9Functions18passThroughCChar32ys7UnicodeO6ScalarVAFF(x);
+// CHECK-NEXT:   return Functions::_impl::$s9Functions18passThroughCChar32ys6UInt32VADF(x);
 // CHECK-NEXT: }
 
 // CHECK:      SWIFT_INLINE_THUNK double passThroughCDouble(double x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {

--- a/test/PrintAsObjC/unicode-scalar-reference.swift
+++ b/test/PrintAsObjC/unicode-scalar-reference.swift
@@ -1,8 +1,7 @@
 // RUN: %empty-directory(%t)
 
-// Test the behavior of printing Unicode.Scalar in the compatibility header.
-// This is wrong, it should either be rejected and considered non-representable
-// or actually be printed using a C / Objective-C compatible type.
+// Test the behavior of printing Unicode.Scalar / CChar32 / CWideChar in the
+// compatibility header.
 
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) \
 // RUN:   %s -emit-module -verify -o %t -emit-module-doc \

--- a/test/PrintAsObjC/unicode-scalar-reference.swift
+++ b/test/PrintAsObjC/unicode-scalar-reference.swift
@@ -15,6 +15,10 @@ func referencesScalar() -> Unicode.Scalar { fatalError() }
 @_cdecl("referencesRelated")
 func x_referencesRelated(a: CChar32, b: CWideChar) { }
 // CHECK: SWIFT_EXTERN void referencesRelated(char32_t a, wchar_t b)
+// CWideChar is a typealias for Unicode.Scalar on non-Windows,
+// so we get a warning about using this instead of UInt32.
+// expected-warning@-4 * {{'Unicode.Scalar' parameter 'b' will be exposed as 'char32_t'}}
+// expected-note@-5 * {{use 'UInt32' and validate with 'Unicode.Scalar.init(_:)'}}
 
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
     // Actual test of Float16, on supported platforms.

--- a/test/attr/attr_cdecl.swift
+++ b/test/attr/attr_cdecl.swift
@@ -59,4 +59,15 @@ func hasNested() {
 @_cdecl("throwing") // expected-error{{raising errors from @_cdecl functions is not supported}}
 func throwing() throws { }
 
+// Unicode.Scalar parameters are mapped to char32_t in the generated C header,
+// but char32_t can hold values that are not valid Unicode scalars.
+@_cdecl("takesScalar")
+func takesScalar(x: Unicode.Scalar) {}
+// expected-warning@-1{{'Unicode.Scalar' parameter 'x' will be exposed as 'char32_t'}}
+// expected-note@-2{{use 'UInt32' and validate with 'Unicode.Scalar.init(_:)'}}{{21-35=UInt32}}
+
+// Returning Unicode.Scalar is sound (every valid scalar fits in char32_t).
+@_cdecl("returnsScalar")
+func returnsScalar() -> Unicode.Scalar { fatalError() }
+
 // TODO: cdecl name collisions

--- a/test/attr/attr_objc_unicode_scalar_param.swift
+++ b/test/attr/attr_objc_unicode_scalar_param.swift
@@ -1,0 +1,30 @@
+// RUN: %target-typecheck-verify-swift -disable-objc-attr-requires-foundation-module -enable-objc-interop
+
+// REQUIRES: objc_interop
+
+// Unicode.Scalar parameters in @objc methods are exposed as 'char32_t' in the
+// generated Objective-C header.
+
+@objc class Foo {
+  @objc func takesScalar(_ x: Unicode.Scalar) {}
+  // expected-warning@-1{{'Unicode.Scalar' parameter 'x' will be exposed as 'char32_t'}}
+  // expected-note@-2{{use 'UInt32' and validate with 'Unicode.Scalar.init(_:)'}}
+
+  // Returning Unicode.Scalar is sound (every valid scalar fits in char32_t),
+  // so no warning here.
+  @objc func returnsScalar() -> Unicode.Scalar { fatalError() }
+
+  // Multiple parameters: warn on each Unicode.Scalar, leave the others alone.
+  @objc func mixed(_ a: Int, _ b: Unicode.Scalar, _ c: Unicode.Scalar) -> Unicode.Scalar {}
+  // expected-warning@-1{{'Unicode.Scalar' parameter 'b' will be exposed as 'char32_t'}}
+  // expected-note@-2{{use 'UInt32' and validate with 'Unicode.Scalar.init(_:)'}}
+  // expected-warning@-3{{'Unicode.Scalar' parameter 'c' will be exposed as 'char32_t'}}
+  // expected-note@-4{{use 'UInt32' and validate with 'Unicode.Scalar.init(_:)'}}
+}
+
+// @objc protocol requirements get the same treatment.
+@objc protocol Bar {
+  @objc func proto(_ x: Unicode.Scalar)
+  // expected-warning@-1{{'Unicode.Scalar' parameter 'x' will be exposed as 'char32_t'}}
+  // expected-note@-2{{use 'UInt32' and validate with 'Unicode.Scalar.init(_:)'}}
+}

--- a/test/stdlib/PrintInteger.swift
+++ b/test/stdlib/PrintInteger.swift
@@ -41,7 +41,7 @@ PrintTests.test("CustomStringConvertible") {
 #endif
   hasDescription(CChar8(42))
   hasDescription(CChar16(42))
-  hasDescription(CChar32(42)!)
+  hasDescription(CChar32(42))
 }
 
 PrintTests.test("Printable") {
@@ -63,7 +63,7 @@ PrintTests.test("Printable") {
 #endif
   expectPrinted("42", CChar8(42))
   expectPrinted("42", CChar16(42))
-  expectPrinted("*", CChar32(42)!)
+  expectPrinted("42", CChar32(42))
 
   if (UInt64(Int.max) > 0x1_0000_0000 as UInt64) {
     expectPrinted("-9223372036854775808", Int.min)
@@ -159,7 +159,7 @@ PrintTests.test("Printable") {
 #endif
   expectPrinted("42", CChar8(42))
   expectPrinted("42", CChar16(42))
-  expectPrinted("*", CChar32(42)!)
+  expectPrinted("42", CChar32(42))
 }
 
 runAllTests()


### PR DESCRIPTION
Change the CChar32 typealias from Unicode.Scalar to UInt32. Mapping char32_t to Unicode.Scalar is unsound because not all char32_t values are valid Unicode.Scalar values.

Callers that want validation should now go through Unicode.Scalar's initializer explicitly.

Continue to map Unicode.Scalar to char32_t in PrintAsClang for @_cdecl/@objc exports, preserving the existing header output for code that uses Unicode.Scalar directly across the C boundary.

rdar://179235116