### PR TITLE
[6.4] [stdlib] UniqueArray

### DIFF
--- a/Runtimes/Core/Core/CMakeLists.txt
+++ b/Runtimes/Core/Core/CMakeLists.txt
@@ -141,6 +141,19 @@ add_library(swiftCore
   REPL.swift
   Result.swift
   Reverse.swift
+
+  # RigidArray sources
+  RigidArray/RigidArray.swift
+  RigidArray/RigidArray+Append.swift
+  RigidArray/RigidArray+Container.swift
+  RigidArray/RigidArray+Descriptions.swift
+  RigidArray/RigidArray+Equatable.swift
+  RigidArray/RigidArray+Hashable.swift
+  RigidArray/RigidArray+Initializers.swift
+  RigidArray/RigidArray+Insertions.swift
+  RigidArray/RigidArray+Removals.swift
+  RigidArray/RigidArray+Replacements.swift
+
   Runtime.swift
   RuntimeFunctionCounters.swift
   SipHash.swift
@@ -211,6 +224,19 @@ add_library(swiftCore
   UnicodeScalarProperties.swift
   CharacterProperties.swift # ORDER DEPENDENCY: UnicodeScalarProperties.swift
   UnicodeSPI.swift
+
+  # UniqueArray sources
+  UniqueArray/UniqueArray.swift
+  UniqueArray/UniqueArray+Append.swift
+  UniqueArray/UniqueArray+Container.swift
+  UniqueArray/UniqueArray+Descriptions.swift
+  UniqueArray/UniqueArray+Equatable.swift
+  UniqueArray/UniqueArray+Hashable.swift
+  UniqueArray/UniqueArray+Initializers.swift
+  UniqueArray/UniqueArray+Insertions.swift
+  UniqueArray/UniqueArray+Removals.swift
+  UniqueArray/UniqueArray+Replacements.swift
+
   UniqueBox.swift
   Unmanaged.swift
   UnmanagedOpaqueString.swift

--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -150,6 +150,19 @@ split_embedded_sources(
   EMBEDDED Repeat.swift
   EMBEDDED Result.swift
   EMBEDDED Reverse.swift
+
+  # RigidArray sources
+  EMBEDDED RigidArray/RigidArray.swift
+  EMBEDDED RigidArray/RigidArray+Append.swift
+  EMBEDDED RigidArray/RigidArray+Container.swift
+  EMBEDDED RigidArray/RigidArray+Descriptions.swift
+  EMBEDDED RigidArray/RigidArray+Equatable.swift
+  EMBEDDED RigidArray/RigidArray+Hashable.swift
+  EMBEDDED RigidArray/RigidArray+Initializers.swift
+  EMBEDDED RigidArray/RigidArray+Insertions.swift
+  EMBEDDED RigidArray/RigidArray+Removals.swift
+  EMBEDDED RigidArray/RigidArray+Replacements.swift
+
   EMBEDDED Runtime.swift
     NORMAL RuntimeFunctionCounters.swift
   EMBEDDED Sendable.swift
@@ -217,6 +230,19 @@ split_embedded_sources(
     NORMAL ThreadLocalStorage.swift
   EMBEDDED UInt128.swift
   EMBEDDED UIntBuffer.swift
+
+  # UniqueArray sources
+  EMBEDDED UniqueArray/UniqueArray.swift
+  EMBEDDED UniqueArray/UniqueArray+Append.swift
+  EMBEDDED UniqueArray/UniqueArray+Container.swift
+  EMBEDDED UniqueArray/UniqueArray+Descriptions.swift
+  EMBEDDED UniqueArray/UniqueArray+Equatable.swift
+  EMBEDDED UniqueArray/UniqueArray+Hashable.swift
+  EMBEDDED UniqueArray/UniqueArray+Initializers.swift
+  EMBEDDED UniqueArray/UniqueArray+Insertions.swift
+  EMBEDDED UniqueArray/UniqueArray+Removals.swift
+  EMBEDDED UniqueArray/UniqueArray+Replacements.swift
+
   EMBEDDED UTF16.swift
   EMBEDDED UTF32.swift
   EMBEDDED UTF8.swift

--- a/stdlib/public/core/GroupInfo.json
+++ b/stdlib/public/core/GroupInfo.json
@@ -289,5 +289,29 @@
   ],
   "Result": [
     "Result.swift"
+  ],
+  "RigidArray": [
+    "RigidArray.swift",
+    "RigidArray+Append.swift",
+    "RigidArray+Container.swift",
+    "RigidArray+Descriptions.swift",
+    "RigidArray+Equatable.swift",
+    "RigidArray+Hashable.swift",
+    "RigidArray+Initializers.swift",
+    "RigidArray+Insertions.swift",
+    "RigidArray+Removals.swift",
+    "RigidArray+Replacements.swift"
+  ],
+  "UniqueArray": [
+    "UniqueArray.swift",
+    "UniqueArray+Append.swift",
+    "UniqueArray+Container.swift",
+    "UniqueArray+Descriptions.swift",
+    "UniqueArray+Equatable.swift",
+    "UniqueArray+Hashable.swift",
+    "UniqueArray+Initializers.swift",
+    "UniqueArray+Insertions.swift",
+    "UniqueArray+Removals.swift",
+    "UniqueArray+Replacements.swift"
   ]
 }

--- a/stdlib/public/core/RigidArray/RigidArray+Append.swift
+++ b/stdlib/public/core/RigidArray/RigidArray+Append.swift
@@ -1,0 +1,229 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@available(SwiftStdlib 6.4, *)
+extension _RigidArray where Element: ~Copyable {
+  /// Adds an element to the end of the array.
+  ///
+  /// If the array does not have sufficient capacity to hold any more elements,
+  /// then this triggers a runtime error.
+  ///
+  /// - Parameter item: The element to append to the collection.
+  ///
+  /// - Complexity: O(1)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  internal mutating func append(_ item: consuming Element) {
+    _precondition(!isFull, "RigidArray capacity overflow")
+    unsafe _storage.initializeElement(at: _count, to: item)
+    _count &+= 1
+  }
+
+  /// Adds an element to the end of the array, if possible.
+  ///
+  /// If the array does not have sufficient capacity to hold any more elements,
+  /// then this returns the given item without appending it; otherwise it
+  /// returns nil.
+  ///
+  /// - Parameter item: The element to append to the array.
+  /// - Returns: `item` if the array is full; otherwise nil.
+  ///
+  /// - Complexity: O(1)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  internal mutating func pushLast(_ item: consuming Element) -> Element? {
+    if isFull { return item }
+    append(item)
+    return nil
+  }
+}
+
+@available(SwiftStdlib 6.4, *)
+extension _RigidArray where Element: ~Copyable {
+  /// Append a given number of items to the end of this array by populating
+  /// an output span.
+  ///
+  /// If the array does not have sufficient capacity to store the new items in
+  /// the buffer, then this triggers a runtime error.
+  ///
+  /// If the callback fails to fully populate its output span or if
+  /// it throws an error, then the array keeps all items that were
+  /// successfully initialized before the callback terminated the insertion.
+  ///
+  /// - Parameters:
+  ///    - newItemCount: The number of items to append to the array.
+  ///    - initializer: A callback that gets called at most once to directly
+  ///       populate newly reserved storage within the array. The function
+  ///       is allowed to initialize fewer than `newItemCount` items.
+  ///       The array is appended however many items the callback adds to
+  ///       the output span before it returns (or before it throws an error).
+  ///
+  /// - Complexity: O(`newItemCount`)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  internal mutating func append<E: Error>(
+    addingCount newItemCount: Int,
+    initializingWith initializer: (inout OutputSpan<Element>) throws(E) -> Void
+  ) throws(E) {
+    _precondition(newItemCount >= 0, "Cannot add a negative number of items")
+    _precondition(freeCapacity >= newItemCount, "RigidArray capacity overflow")
+    let buffer = unsafe _freeSpace._extracting(first: newItemCount)
+    var span = unsafe OutputSpan(buffer: buffer, initializedCount: 0)
+    defer {
+      _count &+= unsafe span.finalize(for: buffer)
+      span = OutputSpan()
+    }
+    return try initializer(&span)
+  }
+}
+
+@available(SwiftStdlib 6.4, *)
+extension _RigidArray where Element: ~Copyable {
+  /// Moves the elements of a buffer to the end of this array, leaving the
+  /// buffer uninitialized.
+  ///
+  /// If the array does not have sufficient capacity to hold all items in the
+  /// buffer, then this triggers a runtime error.
+  ///
+  /// - Parameters:
+  ///    - items: A fully initialized buffer whose contents to move into
+  ///        the array.
+  ///
+  /// - Complexity: O(`items.count`)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  internal mutating func append(
+    moving items: UnsafeMutableBufferPointer<Element>
+  ) {
+    _precondition(items.count <= freeCapacity, "RigidArray capacity overflow")
+    guard items.count > 0 else { return }
+    let c = unsafe _freeSpace._moveInitializePrefix(from: items)
+    _internalInvariant(c == items.count)
+    _count &+= items.count
+  }
+
+  /// Moves the elements of an output span to the end of this array, leaving the
+  /// span empty.
+  ///
+  /// If the array does not have sufficient capacity to hold all items in its
+  /// storage, then this triggers a runtime error.
+  ///
+  /// - Parameters:
+  ///    - items: An output span whose contents need to be appended to this array.
+  ///
+  /// - Complexity: O(`items.count`)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  internal mutating func append(
+    moving items: inout OutputSpan<Element>
+  ) {
+    unsafe items.withUnsafeMutableBufferPointer { buffer, count in
+      let source = unsafe buffer._extracting(first: count)
+      unsafe self.append(moving: source)
+      count = 0
+    }
+  }
+}
+
+@available(SwiftStdlib 6.4, *)
+extension _RigidArray {
+  /// Copies the elements of a buffer to the end of this array.
+  ///
+  /// If the array does not have sufficient capacity to hold all items in the
+  /// buffer, then this triggers a runtime error.
+  ///
+  /// - Parameters:
+  ///    - newElements: A fully initialized buffer whose contents to copy into
+  ///       the array.
+  ///
+  /// - Complexity: O(`newElements.count`)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  internal mutating func append(
+    copying newElements: UnsafeBufferPointer<Element>
+  ) {
+    _precondition(
+      newElements.count <= freeCapacity,
+      "RigidArray capacity overflow")
+    guard newElements.count > 0 else { return }
+    unsafe _freeSpace.baseAddress.unsafelyUnwrapped.initialize(
+      from: newElements.baseAddress.unsafelyUnwrapped, count: newElements.count)
+    _count &+= newElements.count
+  }
+
+  /// Copies the elements of a buffer to the end of this array.
+  ///
+  /// If the array does not have sufficient capacity to hold all items in the
+  /// buffer, then this triggers a runtime error.
+  ///
+  /// - Parameters:
+  ///    - newElements: A fully initialized buffer whose contents to copy into
+  ///        the array.
+  ///
+  /// - Complexity: O(`newElements.count`)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  internal mutating func append(
+    copying items: UnsafeMutableBufferPointer<Element>
+  ) {
+    unsafe self.append(copying: UnsafeBufferPointer(items))
+  }
+
+  /// Copies the elements of a span to the end of this array.
+  ///
+  /// If the array does not have sufficient capacity to hold all items in the
+  /// span, then this triggers a runtime error.
+  ///
+  /// - Parameters:
+  ///    - newElements: A span whose contents to copy into the array.
+  ///
+  /// - Complexity: O(`newElements.count`)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  internal mutating func append(copying items: Span<Element>) {
+    items.withUnsafeBufferPointer { source in
+      unsafe self.append(copying: source)
+    }
+  }
+
+  @_alwaysEmitIntoClient
+  @_transparent
+  internal mutating func _append<S: Sequence<Element>>(
+    prefixOf items: S
+  ) -> S.Iterator {
+    let (it, c) = unsafe items._copyContents(initializing: _freeSpace)
+    _count += c
+    return it
+  }
+
+  /// Copies the elements of a sequence to the end of this array.
+  ///
+  /// If the array does not have sufficient capacity to hold all items in the
+  /// sequence, then this triggers a runtime error.
+  ///
+  /// - Parameters:
+  ///    - newElements: The new elements to copy into the array.
+  ///
+  /// - Complexity: O(*m*), where *m* is the length of `newElements`.
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  internal mutating func append(copying newElements: some Sequence<Element>) {
+    let done: Void? = newElements.withContiguousStorageIfAvailable { buffer in
+      unsafe self.append(copying: buffer)
+      return
+    }
+    if done != nil { return }
+
+    var it = self._append(prefixOf: newElements)
+    _precondition(it.next() == nil, "RigidArray capacity overflow")
+  }
+}

--- a/stdlib/public/core/RigidArray/RigidArray+Container.swift
+++ b/stdlib/public/core/RigidArray/RigidArray+Container.swift
@@ -1,0 +1,322 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@available(SwiftStdlib 6.4, *)
+extension _RigidArray where Element: ~Copyable {
+  /// A Boolean value indicating whether this array contains no elements.
+  ///
+  /// - Complexity: O(1)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  @_transparent
+  internal var isEmpty: Bool {
+    count == 0
+  }
+
+  /// The number of elements in this array.
+  ///
+  /// - Complexity: O(1)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  @_transparent
+  internal var count: Int {
+    _count
+  }
+}
+
+@available(SwiftStdlib 6.4, *)
+extension _RigidArray where Element: ~Copyable {
+  /// A type that represents a position in the array: an integer offset from the
+  /// start.
+  ///
+  /// Valid indices consist of the position of every element and a "past the
+  /// end” position that’s not valid for use as a subscript argument.
+  @available(SwiftStdlib 6.4, *)
+  @usableFromInline
+  internal typealias Index = Int
+
+  /// The position of the first element in a nonempty array. This is always zero.
+  ///
+  /// - Complexity: O(1)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  @_transparent
+  internal var startIndex: Int {
+    0
+  }
+
+  /// The array’s "past the end” position—that is, the position one greater than
+  /// the last valid subscript argument. This is always equal to the array's
+  /// count.
+  ///
+  /// - Complexity: O(1)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  @_transparent
+  internal var endIndex: Int {
+    count
+  }
+
+  /// The range of indices that are valid for subscripting the array.
+  ///
+  /// - Complexity: O(1)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  @_transparent
+  internal var indices: Range<Int> {
+    unsafe Range(uncheckedBounds: (0, count))
+  }
+
+  @_alwaysEmitIntoClient
+  @_transparent
+  internal func _checkItemIndex(_ index: Int) {
+    _precondition(
+      UInt(bitPattern: index) < UInt(bitPattern: _count),
+      "Index out of bounds")
+  }
+
+  @_alwaysEmitIntoClient
+  @_transparent
+  internal func _checkValidIndex(_ index: Int) {
+    _precondition(
+      UInt(bitPattern: index) <= UInt(bitPattern: _count),
+      "Index out of bounds")
+  }
+
+  @_alwaysEmitIntoClient
+  @_transparent
+  internal func _checkValidBounds(_ subrange: Range<Int>) {
+    _precondition(
+      subrange.lowerBound >= 0 && subrange.upperBound <= _count,
+      "Index range out of bounds")
+  }
+}
+
+@available(SwiftStdlib 6.4, *)
+extension _RigidArray where Element: ~Copyable {
+  @_alwaysEmitIntoClient
+  @_transparent
+  internal func _ptr(to index: Int) -> UnsafePointer<Element> {
+    _checkItemIndex(index)
+    let p = unsafe _storage.baseAddress.unsafelyUnwrapped.advanced(by: index)
+    return unsafe UnsafePointer(p)
+  }
+
+  @_alwaysEmitIntoClient
+  @_transparent
+  internal mutating func _mutablePtr(
+    to index: Int
+  ) -> UnsafeMutablePointer<Element> {
+    _checkItemIndex(index)
+    return unsafe _storage.baseAddress.unsafelyUnwrapped.advanced(by: index)
+  }
+
+  /// Accesses the element at the specified position.
+  ///
+  /// - Parameter position: The position of the element to access.
+  ///     The position must be a valid index of the array that is not equal
+  ///     to the `endIndex` property.
+  ///
+  /// - Complexity: O(1)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  internal subscript(position: Int) -> Element {
+    @_transparent
+    @_unsafeSelfDependentResult
+    borrow {
+      unsafe _ptr(to: position).pointee
+    }
+
+    @_transparent
+    @_unsafeSelfDependentResult
+    mutate {
+      unsafe &_mutablePtr(to: position).pointee
+    }
+  }
+}
+
+@available(SwiftStdlib 6.4, *)
+extension _RigidArray where Element: ~Copyable {
+  /// Exchanges the values at the specified indices of the array.
+  ///
+  /// Both parameters must be valid indices of the array and not equal to
+  /// endIndex. Passing the same index as both `i` and `j` has no effect.
+  ///
+  /// - Parameter i: The index of the first value to swap.
+  /// - Parameter j: The index of the second valud to swap.
+  ///
+  /// - Complexity: O(1)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  internal mutating func swapAt(_ i: Int, _ j: Int) {
+    _checkItemIndex(i)
+    _checkItemIndex(j)
+    unsafe _items.swapAt(i, j)
+  }
+}
+
+@available(SwiftStdlib 6.4, *)
+extension _RigidArray where Element: ~Copyable {
+  /// Returns the position immediately after the given index.
+  ///
+  /// - Note: To improve performance, this method does not validate that the
+  ///    index is valid before incrementing it. Index validation is
+  ///    deferred until the resulting index is used to access an element.
+  ///    This optimization may be removed in future versions; do not rely on it.
+  ///
+  /// - Parameter index: A valid index of the array. `i` must be less
+  ///     than `endIndex`.
+  /// - Returns: The index immediately following `i`.
+  /// - Complexity: O(1)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  @_transparent
+  internal func index(after index: Int) -> Int {
+    index + 1
+  }
+
+  /// Returns the position immediately before the given index.
+  ///
+  /// - Note: To improve performance, this method does not validate that the
+  ///    index is valid before decrementing it. Index validation is
+  ///    deferred until the resulting index is used to access an element.
+  ///    This optimization may be removed in future versions; do not rely on it.
+  ///
+  /// - Parameter index: A valid index of the array. `i` must be greater
+  ///     than `startIndex`.
+  /// - Returns: The index immediately preceding `i`.
+  /// - Complexity: O(1)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  @_transparent
+  internal func index(before index: Int) -> Int {
+    index - 1
+  }
+
+  /// Replaces the given index with its successor.
+  ///
+  /// - Note: To improve performance, this method does not validate that the
+  ///    given index is valid before incrementing it. Index validation is
+  ///    deferred until the resulting index is used to access an element.
+  ///    This optimization may be removed in future versions; do not rely on it.
+  ///
+  /// - Parameter index: A valid index of the array. `i` must be less
+  ///     than `endIndex`.
+  /// - Complexity: O(1)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  @_transparent
+  internal func formIndex(after index: inout Int) {
+    index += 1
+  }
+
+  /// Replaces the given index with its predecessor.
+  ///
+  /// - Note: To improve performance, this method does not validate that the
+  ///    given index is valid before decrementing it. Index validation is
+  ///    deferred until the resulting index is used to access an element.
+  ///    This optimization may be removed in future versions; do not rely on it.
+  ///
+  /// - Parameter index: A valid index of the array. `i` must be greater than
+  ///     `startIndex`.
+  /// - Complexity: O(1)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  @_transparent
+  internal func formIndex(before index: inout Int) {
+    index -= 1
+  }
+
+  /// Returns an index that is the specified distance from the given index.
+  ///
+  /// The value passed as `n` must not offset `index` beyond the bounds of the
+  /// array.
+  ///
+  /// - Note: To improve performance, this method does not validate that the
+  ///    given index is valid before offseting it. Index validation is
+  ///    deferred until the resulting index is used to access an element.
+  ///    This optimization may be removed in future versions; do not rely on it.
+  ///
+  /// - Parameter index: A valid index of the array.
+  /// - Parameter n: The distance by which to offset `index`.
+  /// - Returns: An index offset by distance from `index`. If `n` is positive,
+  ///    this is the same value as the result of `n` calls to `index(after:)`.
+  ///    If `n` is negative, this is the same value as the result of `abs(n)`
+  ///    calls to `index(before:)`.
+  /// - Complexity: O(1)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  @_transparent
+  internal func index(_ index: Int, offsetBy n: Int) -> Int {
+    index + n
+  }
+  
+  /// Returns the distance between two indices.
+  ///
+  /// - Note: To improve performance, this method does not validate that the
+  ///    given index is valid before offseting it. Index validation is
+  ///    deferred until the resulting index is used to access an element.
+  ///    This optimization may be removed in future versions; do not rely on it.
+  ///
+  /// - Parameter start: A valid index of the collection.
+  /// - Parameter end: Another valid index of the collection. If end is equal
+  ///    to start, the result is zero.
+  /// - Returns: The distance between `start` and `end`.
+  /// - Complexity: O(1)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  @_transparent
+  internal func distance(from start: Index, to end: Index) -> Int {
+    end - start
+  }
+  
+  /// Offsets the given index by the specified distance, but no further than
+  /// the given limiting index.
+  ///
+  /// If the operation was able to offset `index` by exactly the requested
+  /// number of steps without hitting `limit`, then on return `n` is set to `0`,
+  /// and `index` is set to the adjusted index.
+  ///
+  /// If the operation hits the limit before it can take the requested number
+  /// of steps, then on return `index` is set to `limit`, and `n` is set
+  /// to the number of steps that couldn't be taken.
+  ///
+  /// The value passed as `n` must not offset `index` beyond the bounds of the
+  /// container, unless the index passed as `limit` prevents offsetting beyond
+  /// those bounds.
+  ///
+  /// - Note: To improve performance, this method does not validate that the
+  ///    given index is valid before offseting it. Index validation is
+  ///    deferred until the resulting index is used to access an element.
+  ///    This optimization may be removed in future versions; do not rely on it.
+  ///
+  /// - Parameter index: A valid index of the array. On return, `index` is
+  ///    set to the resulting position.
+  /// - Parameter n: The distance to offset `index`.
+  ///    On return, `n` is set to zero if the operation succeeded without
+  ///    hitting the limit; otherwise, `n` reflects the number of steps that
+  ///    couldn't be taken.
+  /// - Parameter limit: A valid index of the array to use as a limit.
+  ///    If `n > 0`, a limit that is less than `index` has no effect.
+  ///    Likewise, if `n < 0`, a limit that is greater than `index` has no
+  ///    effect.
+  /// - Complexity: O(1)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  internal func formIndex(
+    _ index: inout Index,
+    offsetBy n: inout Int,
+    limitedBy limit: Index
+  ) {
+    index._advance(by: &n, limitedBy: limit)
+  }
+}

--- a/stdlib/public/core/RigidArray/RigidArray+Descriptions.swift
+++ b/stdlib/public/core/RigidArray/RigidArray+Descriptions.swift
@@ -1,0 +1,39 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+// FIXME: Enable once SE-0499 is implemented
+// @available(SwiftStdlib x.y, *)
+// extension RigidArray: CustomStringConvertible where Element: ~Copyable {
+// }
+
+@available(SwiftStdlib 6.4, *)
+extension _RigidArray where Element: ~Copyable {
+  @available(SwiftStdlib 6.4, *)
+  internal var description: String {
+    /// FIXME: Print the item descriptions when available.
+    "<\(count) items>"
+  }
+}
+
+// FIXME: Enable once SE-0499 is implemented
+// @available(SwiftStdlib x.y, *)
+// extension RigidArray: CustomDebugStringConvertible where Element: ~Copyable {
+// }
+
+@available(SwiftStdlib 6.4, *)
+extension _RigidArray where Element: ~Copyable {
+  @available(SwiftStdlib 6.4, *)
+  internal var debugDescription: String {
+    /// FIXME: Print the item descriptions when available.
+    "<\(count) items>"
+  }
+}

--- a/stdlib/public/core/RigidArray/RigidArray+Equatable.swift
+++ b/stdlib/public/core/RigidArray/RigidArray+Equatable.swift
@@ -1,0 +1,32 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@available(SwiftStdlib 6.4, *)
+extension _RigidArray where Element: ~Copyable {
+  @_alwaysEmitIntoClient
+  internal func isTriviallyIdentical(to other: borrowing Self) -> Bool {
+    unsafe _count == other._count &&
+    _storage.isTriviallyIdentical(to: other._storage)
+  }
+}
+
+@available(SwiftStdlib 6.4, *)
+extension _RigidArray: Equatable where Element: Equatable & ~Copyable {
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  internal static func ==(
+    left: borrowing Self,
+    right: borrowing Self
+  ) -> Bool {
+    left.span._elementsEqual(to: right.span)
+  }
+}

--- a/stdlib/public/core/RigidArray/RigidArray+Hashable.swift
+++ b/stdlib/public/core/RigidArray/RigidArray+Hashable.swift
@@ -1,0 +1,21 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@available(SwiftStdlib 6.4, *)
+extension _RigidArray: Hashable where Element: Hashable & ~Copyable {
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  internal func hash(into hasher: inout Hasher) {
+    hasher.combine(self.count)
+    self.span._hashContents(into: &hasher)
+  }
+}

--- a/stdlib/public/core/RigidArray/RigidArray+Initializers.swift
+++ b/stdlib/public/core/RigidArray/RigidArray+Initializers.swift
@@ -1,0 +1,140 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@available(SwiftStdlib 6.4, *)
+extension _RigidArray where Element: ~Copyable {
+  /// Initializes a new rigid array with zero capacity and no elements.
+  ///
+  /// - Complexity: O(1)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  @_transparent
+  internal init() {
+    unsafe _storage = .init(start: nil, count: 0)
+    _count = 0
+  }
+  
+  /// Initializes a new rigid array with the specified capacity and no elements.
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  internal init(capacity: Int) {
+    _precondition(capacity >= 0, "Array capacity must be nonnegative")
+    if capacity > 0 {
+      unsafe _storage = .allocate(capacity: capacity)
+    } else {
+      unsafe _storage = .init(start: nil, count: 0)
+    }
+    _count = 0
+  }
+}
+
+@available(SwiftStdlib 6.4, *)
+extension _RigidArray where Element: ~Copyable {
+  /// Creates a new array with the specified capacity, directly initializing
+  /// its storage using an output span.
+  ///
+  /// - Parameters:
+  ///   - capacity: The storage capacity of the new array.
+  ///   - body: A callback that gets called at most once to directly
+  ///       populate newly reserved storage within the array. The function
+  ///       is allowed to add fewer than `capacity` items. The array is
+  ///       initialized with however many items the callback adds to the
+  ///       output span before it returns (or before it throws an error).
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  internal init<E: Error>(
+    capacity: Int,
+    initializingWith initializer: (inout OutputSpan<Element>) throws(E) -> Void
+  ) throws(E) {
+    self.init(capacity: capacity)
+    try edit(initializer)
+  }
+}
+
+@available(SwiftStdlib 6.4, *)
+extension _RigidArray where Element: Copyable {
+  /// Creates a new array containing the specified number of a single,
+  /// repeated value.
+  ///
+  /// - Parameters:
+  ///   - repeatedValue: The element to repeat.
+  ///   - count: The number of times to repeat the value passed in the
+  ///     `repeating` parameter. `count` must be zero or greater.
+  ///
+  /// - Complexity: O(`count`)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  internal init(repeating repeatedValue: Element, count: Int) {
+    self.init(capacity: count)
+    unsafe _freeSpace.initialize(repeating: repeatedValue)
+    _count = count
+  }
+}
+
+@available(SwiftStdlib 6.4, *)
+extension _RigidArray where Element: Copyable {
+  /// Creates a new array with the specified capacity, holding a copy
+  /// of the contents of a given sequence.
+  ///
+  /// - Parameters:
+  ///   - capacity: The storage capacity of the new array.
+  ///   - contents: The sequence whose contents to copy into the new array.
+  ///      The sequence must not contain more than `capacity` elements.
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  @_transparent
+  internal init(
+    capacity: Int,
+    copying contents: some Sequence<Element>
+  ) {
+    self.init(capacity: capacity)
+    self.append(copying: contents)
+  }
+
+  /// Creates a new array with the specified capacity, holding a copy
+  /// of the contents of a given collection.
+  ///
+  /// - Parameters:
+  ///   - capacity: The storage capacity of the new array, or nil to allocate
+  ///      just enough capacity to store the contents.
+  ///   - contents: The collection whose contents to copy into the new array.
+  ///      The collection must not contain more than `capacity` elements.
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  @_transparent
+  internal init(
+    capacity: Int? = nil,
+    copying contents: some Collection<Element>
+  ) {
+    self.init(capacity: capacity ?? contents.count)
+    self.append(copying: contents)
+  }
+
+  /// Creates a new array with the specified capacity, holding a copy
+  /// of the contents of the given span.
+  ///
+  /// - Parameters:
+  ///   - capacity: The storage capacity of the new array, or nil to allocate
+  ///      just enough capacity to store the contents of the span.
+  ///   - span: The span whose contents to copy into the new array.
+  ///      The span must not contain more than `capacity` elements.
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  @_transparent
+  internal init(
+    capacity: Int? = nil,
+    copying span: Span<Element>
+  ) {
+    self.init(capacity: capacity ?? span.count)
+    self.append(copying: span)
+  }
+}

--- a/stdlib/public/core/RigidArray/RigidArray+Insertions.swift
+++ b/stdlib/public/core/RigidArray/RigidArray+Insertions.swift
@@ -38,7 +38,7 @@ extension _RigidArray where Element: ~Copyable {
       let source = unsafe _storage.extracting(index ..< count)
       let target = unsafe _storage.extracting(index + 1 ..< count + 1)
       let last = unsafe target.moveInitialize(fromContentsOf: source)
-      assert(last == target.endIndex)
+      _internalInvariant(last == target.endIndex)
     }
     unsafe _storage.initializeElement(at: index, to: item)
     _count += 1

--- a/stdlib/public/core/RigidArray/RigidArray+Insertions.swift
+++ b/stdlib/public/core/RigidArray/RigidArray+Insertions.swift
@@ -1,0 +1,319 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@available(SwiftStdlib 6.4, *)
+extension _RigidArray where Element: ~Copyable {
+  /// Inserts a new element into the array at the specified position.
+  ///
+  /// If the array does not have sufficient capacity to hold any more elements,
+  /// then this triggers a runtime error.
+  ///
+  /// The new element is inserted before the element currently at the specified
+  /// index. If you pass the array's `endIndex` as the `index` parameter, then
+  /// the new element is appended to the container.
+  ///
+  /// All existing elements at or following the specified position are moved to
+  /// make room for the new item.
+  ///
+  /// - Parameter item: The new element to insert into the array.
+  /// - Parameter index: The position at which to insert the new element.
+  ///   `index` must be a valid index in the array.
+  ///
+  /// - Complexity: O(`self.count`)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  internal mutating func insert(_ item: consuming Element, at index: Int) {
+    _checkValidIndex(index)
+    _precondition(!isFull, "RigidArray capacity overflow")
+    if index < count {
+      let source = unsafe _storage.extracting(index ..< count)
+      let target = unsafe _storage.extracting(index + 1 ..< count + 1)
+      let last = unsafe target.moveInitialize(fromContentsOf: source)
+      assert(last == target.endIndex)
+    }
+    unsafe _storage.initializeElement(at: index, to: item)
+    _count += 1
+  }
+}
+
+@available(SwiftStdlib 6.4, *)
+extension _RigidArray where Element: ~Copyable {
+  /// Inserts a given number of new items into this array at the specified
+  /// position, using a callback to directly initialize array storage by
+  /// populating an output span.
+  ///
+  /// Existing elements in the array's storage are moved towards the back as
+  /// needed to make room for the new items.
+  ///
+  /// If the capacity of the array isn't sufficient to accommodate the specified
+  /// number of new elements, then this method triggers a runtime error.
+  ///
+  ///     var buffer = RigidArray<Int>(capacity: 20)
+  ///     buffer.append([-999, 999])
+  ///     var i = 0
+  ///     buffer.insert(capacity: 3, at: 1) { target in
+  ///       while !target.isFull {
+  ///         target.append(i)
+  ///         i += 1
+  ///       }
+  ///     }
+  ///     // `buffer` now contains [-999, 0, 1, 2, 999]
+  ///
+  /// If the callback fails to fully populate its output span or if
+  /// it throws an error, then the array keeps all items that were
+  /// successfully initialized before the callback terminated the insertion.
+  ///
+  /// Partial insertions create a gap in array storage that needs to be
+  /// closed by moving already inserted items to their correct positions given
+  /// the adjusted count. This adds some overhead compared to adding exactly as
+  /// many items as promised.
+  ///
+  /// - Parameters:
+  ///    - newItemCount: The maximum number of items to insert into the array.
+  ///    - index: The position at which to insert the new items.
+  ///       `index` must be a valid index in the array.
+  ///    - initializer: A callback that gets called at most once to directly
+  ///       populate newly reserved storage within the array. The function
+  ///      is always called with an empty output span.
+  ///
+  /// - Complexity: O(`self.count` + `newItemCount`) in addition to the complexity
+  ///    of the callback invocations.
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  internal mutating func insert<E: Error>(
+    addingCount newItemCount: Int,
+    at index: Int,
+    initializingWith initializer: (inout OutputSpan<Element>) throws(E) -> Void
+  ) throws(E) {
+    _checkValidIndex(index)
+    _precondition(newItemCount >= 0, "Cannot add a negative number of items")
+    _precondition(newItemCount <= freeCapacity, "RigidArray capacity overflow")
+    let target = unsafe _openGap(at: index, count: newItemCount)
+    _count &+= newItemCount
+    var span = unsafe OutputSpan(buffer: target, initializedCount: 0)
+    defer {
+      let c = unsafe span.finalize(for: target)
+      if c < newItemCount {
+        _closeGap(at: index &+ c, count: newItemCount &- c)
+        _count &-= newItemCount &- c
+      }
+      span = OutputSpan()
+    }
+    try initializer(&span)
+  }
+}
+
+@available(SwiftStdlib 6.4, *)
+extension _RigidArray where Element: ~Copyable {
+  /// Moves the elements of a fully initialized buffer into this array,
+  /// starting at the specified position, and leaving the buffer
+  /// uninitialized.
+  ///
+  /// All existing elements at or following the specified position are moved to
+  /// make room for the new items.
+  ///
+  /// If the capacity of the array isn't sufficient to accommodate the new
+  /// elements, then this method triggers a runtime error.
+  ///
+  /// - Parameters:
+  ///    - items: A fully initialized buffer whose contents to move into
+  ///        the array.
+  ///    - index: The position at which to insert the new items.
+  ///       `index` must be a valid index in the array.
+  ///
+  /// - Complexity: O(`self.count` + `items.count`)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  internal mutating func insert(
+    moving items: UnsafeMutableBufferPointer<Element>,
+    at index: Int
+  ) {
+    insert(addingCount: items.count, at: index) { target in
+      unsafe target._append(moving: items)
+    }
+  }
+
+  /// Moves the elements of an output span into this array,
+  /// starting at the specified position, and leaving the span empty.
+  ///
+  /// All existing elements at or following the specified position are moved to
+  /// make room for the new items.
+  ///
+  /// If the capacity of the array isn't sufficient to accommodate the new
+  /// elements, then this method triggers a runtime error.
+  ///
+  /// - Parameters:
+  ///    - items: An output span whose contents to move into
+  ///        the array.
+  ///    - index: The position at which to insert the new items.
+  ///       `index` must be a valid index in the array.
+  ///
+  /// - Complexity: O(`self.count` + `items.count`)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  internal mutating func insert(
+    moving items: inout OutputSpan<Element>,
+    at index: Int
+  ) {
+    unsafe items.withUnsafeMutableBufferPointer { buffer, count in
+      let source = unsafe buffer._extracting(first: count)
+      unsafe self.insert(moving: source, at: index)
+      count = 0
+    }
+  }
+}
+
+@available(SwiftStdlib 6.4, *)
+extension _RigidArray where Element: Copyable {
+  /// Copies the elements of a fully initialized buffer pointer into this
+  /// array at the specified position.
+  ///
+  /// The new elements are inserted before the element currently at the
+  /// specified index. If you pass the array’s `endIndex` as the `index`
+  /// parameter, then the new elements are appended to the end of the array.
+  ///
+  /// All existing elements at or following the specified position are moved to
+  /// make room for the new items.
+  ///
+  /// If the capacity of the array isn't sufficient to accommodate the new
+  /// elements, then this method triggers a runtime error.
+  ///
+  /// - Parameters:
+  ///    - newElements: The new elements to insert into the array. The buffer
+  ///       must be fully initialized.
+  ///    - index: The position at which to insert the new elements. It must be
+  ///       a valid index of the array.
+  ///
+  /// - Complexity: O(`count` + `newElements.count`)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  internal mutating func insert(
+    copying newElements: UnsafeBufferPointer<Element>, at index: Int
+  ) {
+    guard newElements.count > 0 else { return }
+    self.insert(addingCount: newElements.count, at: index) { target in
+      unsafe target._append(copying: newElements)
+    }
+  }
+
+  /// Copies the elements of a fully initialized buffer pointer into this
+  /// array at the specified position.
+  ///
+  /// The new elements are inserted before the element currently at the
+  /// specified index. If you pass the array’s `endIndex` as the `index`
+  /// parameter, then the new elements are appended to the end of the array.
+  ///
+  /// All existing elements at or following the specified position are moved to
+  /// make room for the new item.
+  ///
+  /// If the capacity of the array isn't sufficient to accommodate the new
+  /// elements, then this method triggers a runtime error.
+  ///
+  /// - Parameters:
+  ///    - newElements: The new elements to insert into the array. The buffer
+  ///       must be fully initialized.
+  ///    - index: The position at which to insert the new elements. It must be
+  ///       a valid index of the array.
+  ///
+  /// - Complexity: O(`count` + `newElements.count`)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  internal mutating func insert(
+    copying newElements: UnsafeMutableBufferPointer<Element>,
+    at index: Int
+  ) {
+    unsafe self.insert(copying: UnsafeBufferPointer(newElements), at: index)
+  }
+
+  /// Copies the elements of a span into this array at the specified position.
+  ///
+  /// The new elements are inserted before the element currently at the
+  /// specified index. If you pass the array’s `endIndex` as the `index`
+  /// parameter, then the new elements are appended to the end of the array.
+  ///
+  /// All existing elements at or following the specified position are moved to
+  /// make room for the new item.
+  ///
+  /// If the capacity of the array isn't sufficient to accommodate the new
+  /// elements, then this method triggers a runtime error.
+  ///
+  /// - Parameters:
+  ///    - newElements: The new elements to insert into the array.
+  ///    - index: The position at which to insert the new elements. It must be
+  ///        a valid index of the array.
+  ///
+  /// - Complexity: O(`count` + `newElements.count`)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  internal mutating func insert(
+    copying newElements: Span<Element>, at index: Int
+  ) {
+    guard newElements.count > 0 else { return }
+    self.insert(addingCount: newElements.count, at: index) { target in
+      target._append(copying: newElements)
+    }
+  }
+
+  @_alwaysEmitIntoClient
+  internal mutating func _insertCollection(
+    at index: Int,
+    copying items: some Collection<Element>,
+    newCount: Int
+  ) {
+    _checkValidIndex(index)
+    _precondition(newCount <= freeCapacity, "RigidArray capacity overflow")
+    let gap = unsafe _openGap(at: index, count: newCount)
+
+    let done: Void? = items.withContiguousStorageIfAvailable { buffer in
+      let i = unsafe gap._initializePrefix(copying: buffer)
+      _precondition(
+        i == newCount,
+        "Broken Collection: count doesn't match contents")
+      _count += newCount
+    }
+    if done != nil { return }
+
+    var (it, copied) = unsafe items._copyContents(initializing: gap)
+    _precondition(
+      it.next() == nil && copied == newCount,
+      "Broken Collection: count doesn't match contents")
+    _count += newCount
+  }
+
+  /// Copies the elements of a collection into this array at the specified
+  /// position.
+  ///
+  /// The new elements are inserted before the element currently at the
+  /// specified index. If you pass the array’s `endIndex` as the `index`
+  /// parameter, then the new elements are appended to the end of the array.
+  ///
+  /// All existing elements at or following the specified position are moved
+  /// to make room for the new item.
+  ///
+  /// If the capacity of the array isn't sufficient to accommodate the new
+  /// elements, then this method triggers a runtime error.
+  ///
+  /// - Parameters:
+  ///    - newElements: The new elements to insert into the array.
+  ///    - index: The position at which to insert the new elements. It must be
+  ///        a valid index of the array.
+  ///
+  /// - Complexity: O(`count` + `newElements.count`)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  internal mutating func insert(
+    copying newElements: some Collection<Element>, at index: Int
+  ) {
+    _insertCollection(
+      at: index, copying: newElements, newCount: newElements.count)
+  }
+}

--- a/stdlib/public/core/RigidArray/RigidArray+Removals.swift
+++ b/stdlib/public/core/RigidArray/RigidArray+Removals.swift
@@ -1,0 +1,135 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@available(SwiftStdlib 6.4, *)
+extension _RigidArray where Element: ~Copyable {
+  /// Removes and returns the element at the specified position.
+  ///
+  /// All the elements following the specified position are moved to close the
+  /// gap.
+  ///
+  /// - Parameter i: The position of the element to remove. `index` must be
+  ///   a valid index of the array that is not equal to the end index.
+  /// - Returns: The removed element.
+  ///
+  /// - Complexity: O(`count`)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  @discardableResult
+  internal mutating func remove(at index: Int) -> Element {
+    _checkItemIndex(index)
+    let old = unsafe _storage.moveElement(from: index)
+    _closeGap(at: index, count: 1)
+    _count -= 1
+    return old
+  }
+
+  /// Removes all elements from the array, preserving its allocated capacity.
+  ///
+  /// - Complexity: O(*n*), where *n* is the original count of the array.
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  internal mutating func removeAll() {
+    unsafe _items.deinitialize()
+    _count = 0
+  }
+
+  /// Removes and returns the last element of the array.
+  ///
+  /// The array must not be empty.
+  ///
+  /// - Returns: The last element of the original array.
+  ///
+  /// - Complexity: O(1)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  @discardableResult
+  internal mutating func removeLast() -> Element {
+    _precondition(!isEmpty, "Cannot remove last element from an empty array")
+    let old = unsafe _storage.moveElement(from: _count - 1)
+    _count -= 1
+    return old
+  }
+
+  /// Removes and discards the specified number of elements from the end of the
+  /// array.
+  ///
+  /// Attempting to remove more elements than exist in the array
+  /// triggers a runtime error.
+  ///
+  /// - Parameter k: The number of elements to remove from the array.
+  ///   `k` must be greater than or equal to zero and must not exceed
+  ///   the count of the array.
+  ///
+  /// - Complexity: O(`k`)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  internal mutating func removeLast(_ k: Int) {
+    if k == 0 { return }
+    _precondition(
+      k >= 0 && k <= _count,
+      "Count of elements to remove is out of bounds")
+    unsafe _storage.extracting(
+      Range(uncheckedBounds: (_count - k, _count))
+    ).deinitialize()
+    _count &-= k
+  }
+
+  /// Removes the specified subrange of elements from the array.
+  ///
+  /// All the elements following the specified subrange are moved to close the
+  /// resulting gap.
+  ///
+  /// - Parameter bounds: The subrange of the array to remove. The bounds
+  ///   of the range must be valid indices of the array.
+  ///
+  /// - Complexity: O(`count`)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  internal mutating func removeSubrange(_  bounds: Range<Int>) {
+    _checkValidBounds(bounds)
+    guard !bounds.isEmpty else { return }
+    unsafe _storage.extracting(bounds).deinitialize()
+    _closeGap(at: bounds.lowerBound, count: bounds.count)
+    _count -= bounds.count
+  }
+
+  /// Removes the specified subrange of elements from the array.
+  ///
+  /// - Parameter bounds: The subrange of the array to remove. The bounds of the
+  ///   range must be valid indices of the array.
+  ///
+  /// - Complexity: O(`count`)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  internal mutating func removeSubrange(_  bounds: some RangeExpression<Int>) {
+    // FIXME: Remove this in favor of a standard algorithm.
+    removeSubrange(bounds.relative(to: indices))
+  }
+}
+
+@available(SwiftStdlib 6.4, *)
+extension _RigidArray where Element: ~Copyable {
+  /// Removes and returns the last element of the array, if there is one.
+  ///
+  /// - Returns: The last element of the array if the array is not empty;
+  ///     otherwise, `nil`.
+  ///
+  /// - Complexity: O(1)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  internal mutating func popLast() -> Element? {
+    // FIXME: Remove this in favor of a standard algorithm.
+    if isEmpty { return nil }
+    return removeLast()
+  }
+}

--- a/stdlib/public/core/RigidArray/RigidArray+Replacements.swift
+++ b/stdlib/public/core/RigidArray/RigidArray+Replacements.swift
@@ -1,0 +1,358 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@available(SwiftStdlib 6.4, *)
+extension _RigidArray where Element: ~Copyable {
+  /// Replaces the specified range of elements by a given count of new items,
+  /// using a callback to directly initialize array storage by populating
+  /// an output span.
+  ///
+  /// The number of new items need not match the number of elements being
+  /// removed.
+  ///
+  /// This method has the same overall effect as calling
+  ///
+  ///     try array.removeSubrange(subrange)
+  ///     try array.insert(
+  ///       addingCount: newItemCount,
+  ///       at: subrange.lowerBound,
+  ///       initializingWith: initializer)
+  ///
+  /// Except it performs faster (by a constant factor), by avoiding moving
+  /// some items in the array twice.
+  ///
+  /// If the array does not have sufficient capacity to accommodate the new
+  /// elements, then this method triggers a runtime error.
+  ///
+  /// If the callback fails to fully populate its output span or if
+  /// it throws an error, then the array keeps all items that were
+  /// successfully initialized before the callback terminated the prepend.
+  ///
+  /// Partial insertions create a gap in array storage that needs to be
+  /// closed by moving newly inserted items to their correct positions given
+  /// the adjusted count. This adds some overhead compared to adding exactly as
+  /// many items as promised.
+  ///
+  /// - Parameters:
+  ///   - subrange: The subrange of the array to replace. The bounds of
+  ///      the range must be valid indices in the array.
+  ///   - newItemCount: the maximum number of items to replace the old subrange.
+  ///   - initializer: A callback that gets called at most once to directly
+  ///      populate newly reserved storage within the array. The function
+  ///      is always called with an empty output span.
+  ///
+  /// - Complexity: O(`self.count` + `newItemCount`) in addition to the complexity
+  ///    of the callback invocations.
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  internal mutating func replaceSubrange<E: Error>(
+    _ subrange: Range<Int>,
+    addingCount newItemCount: Int,
+    initializingWith initializer: (inout OutputSpan<Element>) throws(E) -> Void
+  ) throws(E) -> Void {
+    _checkValidBounds(subrange)
+    _precondition(newItemCount >= 0, "Cannot add a negative number of items")
+    _precondition(
+      newItemCount - subrange.count <= freeCapacity,
+      "RigidArray capacity overflow")
+    try _uncheckedReplaceSubrange(
+      subrange,
+      addingCount: newItemCount,
+      initializingWith: initializer)
+  }
+
+  @_alwaysEmitIntoClient
+  internal mutating func _uncheckedReplaceSubrange<E: Error>(
+    _ subrange: Range<Int>,
+    addingCount newItemCount: Int,
+    initializingWith initializer: (inout OutputSpan<Element>) throws(E) -> Void
+  ) throws(E) -> Void {
+    // Destroy removed items
+    unsafe _items.extracting(subrange).deinitialize()
+    let target = unsafe _resizeGap(in: subrange, to: newItemCount)
+    var span = unsafe OutputSpan(buffer: target, initializedCount: 0)
+    defer {
+      let c = unsafe span.finalize(for: target)
+      if c < newItemCount {
+        self._closeGap(
+          at: subrange.lowerBound &+ c,
+          count: newItemCount &- c)
+        _count &-= newItemCount &- c
+      }
+      span = OutputSpan()
+    }
+    try initializer(&span)
+  }
+}
+
+@available(SwiftStdlib 6.4, *)
+extension _RigidArray where Element: ~Copyable {
+  /// Replaces the specified range of elements by moving the elements of a
+  /// fully initialized buffer into their place. On return, the buffer is left
+  /// in an uninitialized state.
+  ///
+  /// This method has the effect of removing the specified range of elements
+  /// from the array and inserting the new elements starting at the same
+  /// location. The number of new elements need not match the number of elements
+  /// being removed.
+  ///
+  /// If the capacity of the array isn't sufficient to accommodate the new
+  /// elements, then this method triggers a runtime error.
+  ///
+  /// If you pass a zero-length range as the `subrange` parameter, this method
+  /// inserts the elements of `newElements` at `subrange.lowerBound`. This case
+  /// is more directly expressed by calling `insert(moving:at:)`.
+  ///
+  /// Likewise, if you pass a zero-length buffer as the `newElements`
+  /// parameter, this method removes the elements in the given subrange
+  /// without replacement. This case is more directly expressed by calling
+  /// `removeSubrange`.
+  ///
+  /// - Parameters:
+  ///   - subrange: The subrange of the array to replace. The bounds of
+  ///     the range must be valid indices in the array.
+  ///   - newElements: A fully initialized buffer whose contents to move into
+  ///     the array.
+  ///
+  /// - Complexity: O(`self.count` + `newElements.count`)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  internal mutating func replaceSubrange(
+    _ subrange: Range<Int>,
+    moving newElements: UnsafeMutableBufferPointer<Element>,
+  ) {
+    replaceSubrange(subrange, addingCount: newElements.count) { target in
+      unsafe target.withUnsafeMutableBufferPointer { buffer, count in
+        count = unsafe buffer._moveInitializePrefix(from: newElements)
+      }
+    }
+  }
+
+  /// Replaces the specified range of elements by moving the contents of an
+  /// output span into their place. On return, the span is left empty.
+  ///
+  /// This method has the effect of removing the specified range of elements
+  /// from the array and inserting the new elements starting at the same
+  /// location. The number of new elements need not match the number of elements
+  /// being removed.
+  ///
+  /// If the capacity of the array isn't sufficient to accommodate the new
+  /// elements, then this method triggers a runtime error.
+  ///
+  /// If you pass a zero-length range as the `subrange` parameter, this method
+  /// inserts the elements of `newElements` at `subrange.lowerBound`. This case
+  /// is more directly expressed by calling `insert(moving:at:)`.
+  ///
+  /// Likewise, if you pass a zero-length buffer as the `newElements`
+  /// parameter, this method removes the elements in the given subrange
+  /// without replacement. This case is more directly expressed by calling
+  /// `removeSubrange`.
+  ///
+  /// - Parameters:
+  ///   - subrange: The subrange of the array to replace. The bounds of
+  ///     the range must be valid indices in the array.
+  ///   - items: An output span whose contents are to be moved into the array.
+  ///
+  /// - Complexity: O(`self.count` + `items.count`)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  internal mutating func replaceSubrange(
+    _ subrange: Range<Int>,
+    moving items: inout OutputSpan<Element>
+  ) {
+    unsafe items.withUnsafeMutableBufferPointer { buffer, count in
+      let source = unsafe buffer._extracting(first: count)
+      unsafe replaceSubrange(subrange, moving: source)
+      count = 0
+    }
+  }
+}
+
+@available(SwiftStdlib 6.4, *)
+extension _RigidArray where Element: Copyable {
+  /// Replaces the specified subrange of elements by copying the elements of
+  /// the given buffer pointer, which must be fully initialized.
+  ///
+  /// This method has the effect of removing the specified range of elements
+  /// from the array and inserting the new elements starting at the same
+  /// location. The number of new elements need not match the number of elements
+  /// being removed.
+  ///
+  /// If the capacity of the array isn't sufficient to accommodate the new
+  /// elements, then this method triggers a runtime error.
+  ///
+  /// If you pass a zero-length range as the `subrange` parameter, this method
+  /// inserts the elements of `newElements` at `subrange.lowerBound`. This case
+  /// is more directly expressed by calling `insert(copying:at:)`.
+  ///
+  /// Likewise, if you pass a zero-length buffer as the `newElements`
+  /// parameter, this method removes the elements in the given subrange
+  /// without replacement. This case is more directly expressed by calling
+  /// `removeSubrange`.
+  ///
+  /// - Parameters:
+  ///   - subrange: The subrange of the array to replace. The bounds of
+  ///     the range must be valid indices in the array.
+  ///   - newElements: The new elements to copy into the collection.
+  ///
+  /// - Complexity: O(`self.count` + `newElements.count`)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  internal mutating func replaceSubrange(
+    _ subrange: Range<Int>,
+    copying newElements: UnsafeBufferPointer<Element>
+  ) {
+    replaceSubrange(subrange, addingCount: newElements.count) { target in
+      unsafe target.withUnsafeMutableBufferPointer { buffer, count in
+        count = unsafe buffer._initializePrefix(copying: newElements)
+      }
+    }
+  }
+
+  /// Replaces the specified subrange of elements by copying the elements of
+  /// the given buffer pointer, which must be fully initialized.
+  ///
+  /// This method has the effect of removing the specified range of elements
+  /// from the array and inserting the new elements starting at the same
+  /// location. The number of new elements need not match the number of elements
+  /// being removed.
+  ///
+  /// If the capacity of the array isn't sufficient to accommodate the new
+  /// elements, then this method triggers a runtime error.
+  ///
+  /// If you pass a zero-length range as the `subrange` parameter, this method
+  /// inserts the elements of `newElements` at `subrange.lowerBound`. This case
+  /// is more directly expressed by calling `insert(copying:at:)`.
+  ///
+  /// Likewise, if you pass a zero-length buffer as the `newElements`
+  /// parameter, this method removes the elements in the given subrange
+  /// without replacement. This case is more directly expressed by calling
+  /// `removeSubrange`.
+  ///
+  /// - Parameters:
+  ///   - subrange: The subrange of the array to replace. The bounds of
+  ///     the range must be valid indices in the array.
+  ///   - newElements: The new elements to copy into the collection.
+  ///
+  /// - Complexity: O(`self.count` + `newElements.count`)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  internal mutating func replaceSubrange(
+    _ subrange: Range<Int>,
+    copying newElements: UnsafeMutableBufferPointer<Element>
+  ) {
+    unsafe replaceSubrange(
+      subrange,
+      copying: UnsafeBufferPointer(newElements))
+  }
+
+  /// Replaces the specified subrange of elements by copying the elements of
+  /// the given span.
+  ///
+  /// This method has the effect of removing the specified range of elements
+  /// from the array and inserting the new elements starting at the same
+  /// location. The number of new elements need not match the number of elements
+  /// being removed.
+  ///
+  /// If the capacity of the array isn't sufficient to accommodate the new
+  /// elements, then this method triggers a runtime error.
+  ///
+  /// If you pass a zero-length range as the `subrange` parameter, this method
+  /// inserts the elements of `newElements` at `subrange.lowerBound`. This case
+  /// is more directly expressed by calling `insert(copying:at:)`.
+  ///
+  /// Likewise, if you pass a zero-length span as the `newElements`
+  /// parameter, this method removes the elements in the given subrange
+  /// without replacement. This case is more directly expressed by calling
+  /// `removeSubrange`.
+  ///
+  /// - Parameters:
+  ///   - subrange: The subrange of the array to replace. The bounds of
+  ///     the range must be valid indices in the array.
+  ///   - newElements: The new elements to copy into the collection.
+  ///
+  /// - Complexity: O(`self.count` + `newElements.count`)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  internal mutating func replaceSubrange(
+    _ subrange: Range<Int>,
+    copying newElements: Span<Element>
+  ) {
+    newElements.withUnsafeBufferPointer { buffer in
+      unsafe replaceSubrange(subrange, copying: buffer)
+    }
+  }
+
+  @_alwaysEmitIntoClient
+  internal mutating func _replaceSubrange(
+    _ subrange: Range<Int>,
+    copyingCollection newElements: __owned some Collection<Element>,
+    newCount: Int
+  ) {
+    replaceSubrange(subrange, addingCount: newCount) { target in
+      unsafe target.withUnsafeMutableBufferPointer { dst, dstCount in
+        let done: Void? = newElements.withContiguousStorageIfAvailable { src in
+          let i = unsafe dst._initializePrefix(copying: src)
+          _precondition(
+            i == newCount,
+            "Broken Collection: count doesn't match contents")
+          dstCount = i
+        }
+        if done != nil { return }
+
+        var (it, copied) = unsafe newElements._copyContents(initializing: dst)
+        dstCount = copied
+        _precondition(
+          it.next() == nil && copied == newCount,
+          "Broken Collection: count doesn't match contents")
+      }
+    }
+  }
+
+  /// Replaces the specified subrange of elements by copying the elements of
+  /// the given collection.
+  ///
+  /// This method has the effect of removing the specified range of elements
+  /// from the array and inserting the new elements starting at the same
+  /// location. The number of new elements need not match the number of elements
+  /// being removed.
+  ///
+  /// If the capacity of the array isn't sufficient to accommodate the new
+  /// elements, then this method triggers a runtime error.
+  ///
+  /// If you pass a zero-length range as the `subrange` parameter, this method
+  /// inserts the elements of `newElements` at `subrange.lowerBound`. This case
+  /// is more directly expressed by calling `insert(copying:at:)`.
+  ///
+  /// Likewise, if you pass a zero-length collection as the `newElements`
+  /// parameter, this method removes the elements in the given subrange
+  /// without replacement. This case is more directly expressed by calling
+  /// `removeSubrange`.
+  ///
+  /// - Parameters:
+  ///   - subrange: The subrange of the array to replace. The bounds of
+  ///     the range must be valid indices in the array.
+  ///   - newElements: The new elements to copy into the collection.
+  ///
+  /// - Complexity: O(`self.count` + `newElements.count`)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  internal mutating func replaceSubrange(
+    _ subrange: Range<Int>,
+    copying newElements: consuming some Collection<Element>
+  ) {
+    _replaceSubrange(
+      subrange,
+      copyingCollection: newElements,
+      newCount: newElements.count)
+  }
+}

--- a/stdlib/public/core/RigidArray/RigidArray.swift
+++ b/stdlib/public/core/RigidArray/RigidArray.swift
@@ -1,0 +1,364 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// A fixed capacity, heap allocated, noncopyable array of potentially
+/// noncopyable elements.
+///
+/// `RigidArray` instances are created with a specific maximum capacity. Elements
+/// can be added to the array up to that capacity, but no more: trying to add an
+/// item to a full array results in a runtime trap.
+///
+///      var items = RigidArray<Int>(capacity: 2)
+///      items.append(1)
+///      items.append(2)
+///      items.append(3) // Runtime error: RigidArray capacity overflow
+///
+/// Rigid arrays provide convenience properties to help verify that it has
+/// enough available capacity: `isFull` and `freeCapacity`.
+///
+///     guard items.freeCapacity >= 4 else { throw CapacityOverflow() }
+///     items.append(copying: newItems)
+///
+/// It is possible to extend or shrink the capacity of a rigid array instance,
+/// but this needs to be done explicitly, with operations dedicated to this
+/// purpose (such as ``reserveCapacity`` and ``reallocate(capacity:)``).
+/// The array never resizes itself automatically.
+///
+/// It therefore requires careful manual analysis or up front runtime capacity
+/// checks to prevent the array from overflowing its storage. This makes
+/// this type more difficult to use than a dynamic array. However, it allows
+/// this construct to provide predictably stable performance.
+///
+/// This trading of usability in favor of stable performance limits `RigidArray`
+/// to the most resource-constrained of use cases, such as space-constrained
+/// environments that require carefully accounting of every heap allocation, or
+/// time-constrained applications that cannot accommodate unexpected latency
+/// spikes due to a reallocation getting triggered at an inopportune moment.
+///
+/// For use cases outside of these narrow domains, we generally recommmend
+/// the use of ``UniqueArray`` rather than `RigidArray`. (For copyable elements,
+/// the standard `Array` is an even more convenient choice.)
+@available(SwiftStdlib 6.4, *)
+@frozen
+@safe
+@usableFromInline
+internal struct _RigidArray<Element: ~Copyable>: ~Copyable {
+  @usableFromInline
+  internal var _storage: UnsafeMutableBufferPointer<Element>
+
+  @usableFromInline
+  internal var _count: Int
+
+  @_alwaysEmitIntoClient
+  deinit {
+    unsafe _storage.extracting(0 ..< _count).deinitialize()
+    unsafe _storage.deallocate()
+  }
+  
+  @_alwaysEmitIntoClient
+  internal init(_storage: UnsafeMutableBufferPointer<Element>, count: Int) {
+    unsafe self._storage = _storage
+    self._count = count
+  }
+}
+
+@available(SwiftStdlib 6.4, *)
+extension _RigidArray: @unchecked Sendable where Element: Sendable & ~Copyable {}
+
+@available(SwiftStdlib 6.4, *)
+extension _RigidArray where Element: ~Copyable {
+  /// The maximum number of elements this rigid array can hold.
+  ///
+  /// - Complexity: O(1)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  @_transparent
+  internal var capacity: Int {
+    _assumeNonNegative(unsafe _storage.count)
+  }
+
+  /// The number of additional elements that can be added to this array without
+  /// exceeding its storage capacity.
+  ///
+  /// - Complexity: O(1)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  @_transparent
+  internal var freeCapacity: Int {
+    _assumeNonNegative(capacity &- count)
+  }
+
+  /// A Boolean value indicating whether this rigid array is fully populated.
+  /// If this property returns true, then the array's storage is at capacity,
+  /// and it cannot accommodate any additional elements.
+  ///
+  /// - Complexity: O(1)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  @_transparent
+  internal var isFull: Bool {
+    freeCapacity == 0
+  }
+}
+
+@available(SwiftStdlib 6.4, *)
+extension _RigidArray where Element: ~Copyable {
+  @_alwaysEmitIntoClient
+  internal var _items: UnsafeMutableBufferPointer<Element> {
+    unsafe _storage.extracting(Range(uncheckedBounds: (0, _count)))
+  }
+
+  @_alwaysEmitIntoClient
+  internal var _freeSpace: UnsafeMutableBufferPointer<Element> {
+    unsafe _storage.extracting(Range(uncheckedBounds: (_count, capacity)))
+  }
+}
+
+@available(SwiftStdlib 6.4, *)
+extension _RigidArray where Element: ~Copyable {
+  /// A span over the elements of this array, providing direct read-only access.
+  ///
+  /// - Complexity: O(1)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  @_transparent
+  internal var span: Span<Element> {
+    @_lifetime(borrow self)
+    get {
+      let result = unsafe Span(_unsafeElements: _items)
+      return unsafe _overrideLifetime(result, borrowing: self)
+    }
+  }
+
+  /// A mutable span over the elements of this array, providing direct
+  /// mutating access.
+  ///
+  /// - Complexity: O(1)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  @_transparent
+  internal var mutableSpan: MutableSpan<Element> {
+    @_lifetime(&self)
+    mutating get {
+      let result = unsafe MutableSpan(_unsafeElements: _items)
+      return unsafe _overrideLifetime(result, mutating: &self)
+    }
+  }
+
+  @_alwaysEmitIntoClient
+  @_lifetime(borrow self)
+  internal func _span(in range: Range<Int>) -> Span<Element> {
+    span.extracting(range)
+  }
+
+  @_alwaysEmitIntoClient
+  @_lifetime(&self)
+  internal mutating func _mutableSpan(
+    in range: Range<Int>
+  ) -> MutableSpan<Element> {
+    let result = unsafe MutableSpan(_unsafeElements: _items.extracting(range))
+    return unsafe _overrideLifetime(result, mutating: &self)
+  }
+}
+
+@available(SwiftStdlib 6.4, *)
+extension _RigidArray where Element: ~Copyable {
+  /// Arbitrarily edit the storage underlying this array by invoking a
+  /// user-supplied closure with a mutable `OutputSpan` view over it.
+  /// This method calls its function argument at most once, allowing it to
+  /// arbitrarily modify the contents of the output span it is given.
+  /// The argument is free to add, remove or reorder any items; however,
+  /// it is not allowed to replace the span or change its capacity.
+  ///
+  /// When the function argument finishes (whether by returning or throwing an
+  /// error) the rigid array instance is updated to match the final contents of
+  /// the output span.
+  ///
+  /// - Parameter body: A function that edits the contents of this array through
+  ///    an `OutputSpan` argument. This method invokes this function
+  ///    at most once.
+  /// - Returns: This method returns the result of its function argument.
+  /// - Complexity: Adds O(1) overhead to the complexity of the function
+  ///    argument.
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  internal mutating func edit<E: Error, R: ~Copyable>(
+    _ body: (inout OutputSpan<Element>) throws(E) -> R
+  ) throws(E) -> R {
+    var span = unsafe OutputSpan(buffer: _storage, initializedCount: _count)
+    defer {
+      _count = unsafe span.finalize(for: _storage)
+      span = OutputSpan()
+    }
+    return try body(&span)
+  }
+
+  // FIXME: Stop using and remove this in favor of `edit`
+  @unsafe
+  @_alwaysEmitIntoClient
+  internal mutating func _unsafeEdit<E: Error, R: ~Copyable>(
+    _ body: (UnsafeMutableBufferPointer<Element>, inout Int) throws(E) -> R
+  ) throws(E) -> R {
+    defer { _precondition(_count >= 0 && _count <= capacity) }
+    return unsafe try body(_storage, &_count)
+  }
+}
+
+@available(SwiftStdlib 6.4, *)
+extension _RigidArray where Element: ~Copyable {
+  @_alwaysEmitIntoClient
+  internal func _contiguousSubrange(following index: inout Int) -> Range<Int> {
+    _precondition(index >= 0 && index <= _count, "Index out of bounds")
+    defer { index = _count }
+    return unsafe Range(uncheckedBounds: (index, _count))
+  }
+
+  @_alwaysEmitIntoClient
+  internal func _contiguousSubrange(preceding index: inout Int) -> Range<Int> {
+    _precondition(index >= 0 && index <= _count, "Index out of bounds")
+    defer { index = 0 }
+    return unsafe Range(uncheckedBounds: (0, index))
+  }
+}
+
+@available(SwiftStdlib 6.4, *)
+extension _RigidArray where Element: ~Copyable {
+  /// Grow or shrink the capacity of a rigid array instance without discarding
+  /// its contents.
+  ///
+  /// This operation replaces the array's storage buffer with a newly allocated
+  /// buffer of the specified capacity, moving all existing elements
+  /// to its new storage. The old storage is then deallocated.
+  ///
+  /// - Parameter newCapacity: The desired new capacity. `newCapacity` must be
+  ///    greater than or equal to the current count.
+  ///
+  /// - Complexity: O(`count`)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  internal mutating func reallocate(capacity newCapacity: Int) {
+    _precondition(newCapacity >= count, "RigidArray capacity overflow")
+    guard newCapacity != capacity else { return }
+    let newStorage: UnsafeMutableBufferPointer<Element> = .allocate(
+      capacity: newCapacity)
+    let i = unsafe newStorage.moveInitialize(fromContentsOf: self._items)
+    assert(i == count)
+    unsafe _storage.deallocate()
+    unsafe _storage = newStorage
+  }
+
+  /// Ensure that the array has capacity to store the specified number of
+  /// elements, by growing its storage buffer if necessary.
+  ///
+  /// If `capacity < n`, then this operation reallocates the rigid array's
+  /// storage to grow it; on return, the array's capacity becomes `n`.
+  /// Otherwise the array is left as is.
+  ///
+  /// - Complexity: O(`count`)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  internal mutating func reserveCapacity(_ n: Int) {
+    guard capacity < n else { return }
+    reallocate(capacity: n)
+  }
+}
+
+@available(SwiftStdlib 6.4, *)
+extension _RigidArray {
+  /// Copy the contents of this array into a newly allocated rigid array
+  /// instance with just enough capacity to hold all its elements.
+  ///
+  /// - Complexity: O(`count`)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  internal func clone() -> Self {
+    clone(capacity: self.count)
+  }
+  
+  /// Copy the contents of this array into a newly allocated rigid array
+  /// instance with the specified capacity.
+  ///
+  /// - Parameter capacity: The desired capacity of the resulting rigid array.
+  ///    `capacity` must be greater than or equal to `count`.
+  ///
+  /// - Complexity: O(`count`)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  internal func clone(capacity: Int) -> Self {
+    _precondition(capacity >= count, "RigidArray capacity overflow")
+    var result = Self(capacity: capacity)
+    let initialized = unsafe result._storage.initialize(fromContentsOf: _items)
+    _precondition(initialized == count)
+    result._count = count
+    return result
+  }
+}
+
+@available(SwiftStdlib 6.4, *)
+extension _RigidArray where Element: ~Copyable {
+  @_alwaysEmitIntoClient
+  internal mutating func _closeGap(
+    at index: Int, count: Int
+  ) {
+    guard count > 0 else { return }
+    let source = unsafe _storage.extracting(
+      Range(uncheckedBounds: (index + count, _count)))
+    let target = unsafe _storage.extracting(
+      Range(uncheckedBounds: (index, index + source.count)))
+    let i = unsafe target.moveInitialize(fromContentsOf: source)
+    _internalInvariant(i == target.endIndex)
+  }
+
+  @unsafe
+  @_alwaysEmitIntoClient
+  internal mutating func _openGap(
+    at index: Int, count: Int
+  ) -> UnsafeMutableBufferPointer<Element> {
+    _internalInvariant(index >= 0 && index <= _count)
+    _internalInvariant(count <= freeCapacity)
+    guard count > 0 else { return unsafe _storage.extracting(index ..< index) }
+    let source = unsafe _storage.extracting(
+      Range(uncheckedBounds: (index, _count)))
+    let target = unsafe _storage.extracting(
+      Range(uncheckedBounds: (index + count, _count + count)))
+    let i = unsafe target.moveInitialize(fromContentsOf: source)
+    _internalInvariant(i == target.count)
+    return unsafe _storage.extracting(
+      Range(uncheckedBounds: (index, index + count)))
+  }
+  
+  /// Resize the gap in the given subrange to have the specified count.
+  /// This operation moves elements following the gap to be at their expected
+  /// new location, and it adjusts the container's count to reflect the change.
+  ///
+  /// - Returns: A buffer pointer addressing the newly opened gap, to be
+  ///     initialized by the caller.
+  @unsafe
+  @_alwaysEmitIntoClient
+  internal mutating func _resizeGap(
+    in subrange: Range<Int>, to newItemCount: Int
+  ) -> UnsafeMutableBufferPointer<Element> {
+    _internalInvariant(subrange.lowerBound >= 0 && subrange.upperBound <= _count)
+    _internalInvariant(newItemCount >= 0 && newItemCount - subrange.count <= freeCapacity)
+    if newItemCount > subrange.count {
+      _ = unsafe _openGap(
+        at: subrange.upperBound, count: newItemCount - subrange.count)
+    } else if newItemCount < subrange.count {
+      _closeGap(
+        at: subrange.lowerBound + newItemCount, count: subrange.count - newItemCount)
+    }
+    _count += newItemCount - subrange.count
+    let gapRange = unsafe Range(
+      uncheckedBounds: (subrange.lowerBound, subrange.lowerBound + newItemCount))
+    return unsafe _storage.extracting(gapRange)
+  }
+}

--- a/stdlib/public/core/RigidArray/RigidArray.swift
+++ b/stdlib/public/core/RigidArray/RigidArray.swift
@@ -245,13 +245,12 @@ extension _RigidArray where Element: ~Copyable {
   /// - Complexity: O(`count`)
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
-  internal mutating func reallocate(capacity newCapacity: Int) {
-    _precondition(newCapacity >= count, "RigidArray capacity overflow")
+  internal mutating func setCapacity(_ newCapacity: Int) {
     guard newCapacity != capacity else { return }
     let newStorage: UnsafeMutableBufferPointer<Element> = .allocate(
-      capacity: newCapacity)
-    let i = unsafe newStorage.moveInitialize(fromContentsOf: self._items)
-    assert(i == count)
+      capacity: Swift.max(newCapacity, count))
+    let i = unsafe newStorage.moveInitialize(fromContentsOf: _items)
+    _internalInvariant(i == count)
     unsafe _storage.deallocate()
     unsafe _storage = newStorage
   }
@@ -268,7 +267,7 @@ extension _RigidArray where Element: ~Copyable {
   @_alwaysEmitIntoClient
   internal mutating func reserveCapacity(_ n: Int) {
     guard capacity < n else { return }
-    reallocate(capacity: n)
+    setCapacity(n)
   }
 }
 

--- a/stdlib/public/core/Span/OutputSpan.swift
+++ b/stdlib/public/core/Span/OutputSpan.swift
@@ -520,3 +520,59 @@ extension OutputSpan {
     unsafe finalize(for: UnsafeMutableBufferPointer(rebasing: buffer))
   }
 }
+
+@available(SwiftCompatibilitySpan 5.0, *)
+@_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
+extension OutputSpan where Element: ~Copyable {
+  @_alwaysEmitIntoClient
+  @_lifetime(self: copy self)
+  internal mutating func _append(
+    moving source: UnsafeMutableBufferPointer<Element>
+  ) {
+    guard source.count > 0 else { return }
+    unsafe self.withUnsafeMutableBufferPointer { dst, dstCount in
+      let dstEnd = dstCount + source.count
+      precondition(dstEnd <= dst.count, "OutputSpan capacity overflow")
+      unsafe dst
+        ._extracting(uncheckedFrom: dstCount, to: dstEnd)
+        ._moveInitializeAll(fromContentsOf: source)
+      dstCount &+= source.count
+    }
+  }
+
+  @_alwaysEmitIntoClient
+  @_lifetime(self: copy self)
+  @_lifetime(source: copy source)
+  internal mutating func _append(moving source: inout OutputSpan<Element>) {
+    unsafe source.withUnsafeMutableBufferPointer { src, srcCount in
+      let items = unsafe src._extracting(uncheckedFrom: 0, to: srcCount)
+      unsafe self._append(moving: items)
+      srcCount = 0
+    }
+  }
+}
+
+@available(SwiftCompatibilitySpan 5.0, *)
+@_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
+extension OutputSpan where Element: Copyable {
+  @_alwaysEmitIntoClient
+  @_lifetime(self: copy self)
+  internal mutating func _append(copying source: UnsafeBufferPointer<Element>) {
+    unsafe self.withUnsafeMutableBufferPointer { dst, dstCount in
+      let dstEnd = dstCount + source.count
+      precondition(dstEnd <= dst.count, "OutputSpan capacity overflow")
+      unsafe dst
+        ._extracting(uncheckedFrom: dstCount, to: dstEnd)
+        ._initializeAll(fromContentsOf: source)
+      dstCount &+= source.count
+    }
+  }
+
+  @_alwaysEmitIntoClient
+  @_lifetime(self: copy self)
+  internal mutating func _append(copying source: Span<Element>) {
+    source.withUnsafeBufferPointer { buffer in
+      unsafe self._append(copying: buffer)
+    }
+  }
+}

--- a/stdlib/public/core/Span/Span.swift
+++ b/stdlib/public/core/Span/Span.swift
@@ -1007,3 +1007,38 @@ extension Span: BorrowingSequence where Element: ~Copyable {
   }
 }
 #endif
+
+@available(SwiftCompatibilitySpan 5.0, *)
+@_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
+extension Span where Element: Equatable & ~Copyable {
+  @_alwaysEmitIntoClient
+  internal func _elementsEqual(to other: borrowing Self) -> Bool {
+    return self.withUnsafeBufferPointer { a in
+      other.withUnsafeBufferPointer { b in
+        guard a.count == b.count else { return false }
+        guard unsafe a.baseAddress != b.baseAddress else { return true }
+        var i = 0
+        while i < self.count {
+          guard unsafe a[i] == b[i] else { return false }
+          i &+= 1
+        }
+        return true
+      }
+    }
+  }
+}
+
+@available(SwiftCompatibilitySpan 5.0, *)
+@_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
+extension Span where Element: Hashable & ~Copyable {
+  @_alwaysEmitIntoClient
+  internal func _hashContents(into hasher: inout Hasher) {
+    // Note: no discriminating combine call -- caller is expected to do that
+    // separately when needed.
+    var i = 0
+    while i < self.count {
+      hasher.combine(unsafe self[unchecked: i])
+      i &+= 1
+    }
+  }
+}

--- a/stdlib/public/core/Stride.swift
+++ b/stdlib/public/core/Stride.swift
@@ -288,6 +288,33 @@ extension Strideable where Self: FloatingPoint, Self == Stride {
   }
 }
 
+extension Strideable {
+  @_alwaysEmitIntoClient
+  internal mutating func _advance(
+    by distance: inout Stride, limitedBy limit: Self
+  ) {
+    if distance >= 0 {
+      guard limit >= self else {
+        self = self.advanced(by: distance)
+        distance = 0
+        return
+      }
+      let d = Swift.min(distance, self.distance(to: limit))
+      self = self.advanced(by: d)
+      distance -= d
+    } else {
+      guard limit <= self else {
+        self = self.advanced(by: distance)
+        distance = 0
+        return
+      }
+      let d = Swift.max(distance, self.distance(to: limit))
+      self = self.advanced(by: d)
+      distance -= d
+    }
+  }
+}
+
 /// An iterator for a `StrideTo` instance.
 @frozen
 public struct StrideToIterator<Element: Strideable> {

--- a/stdlib/public/core/UniqueArray/UniqueArray+Append.swift
+++ b/stdlib/public/core/UniqueArray/UniqueArray+Append.swift
@@ -1,0 +1,202 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@available(SwiftStdlib 6.4, *)
+extension UniqueArray where Element: ~Copyable {
+  /// Adds an element to the end of the array.
+  ///
+  /// If the array does not have sufficient capacity to hold any more elements,
+  /// then this reallocates the array's storage to grow its capacity, using a
+  /// geometric growth rate.
+  ///
+  /// - Parameter item: The element to append to the collection.
+  ///
+  /// - Complexity: O(1) as amortized over many invocations on the same array.
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  public mutating func append(_ item: consuming Element) {
+    _ensureFreeCapacity(1)
+    _storage.append(item)
+  }
+}
+
+@available(SwiftStdlib 6.4, *)
+extension UniqueArray where Element: ~Copyable {
+  /// Append a given number of items to the end of this array by populating
+  /// an output span.
+  ///
+  /// If the array does not have sufficient capacity to hold the requested
+  /// number of new elements, then this reallocates the array's storage to
+  /// grow its capacity, using a geometric growth rate.
+  ///
+  /// If the callback fails to fully populate its output span or if
+  /// it throws an error, then the array keeps all items that were
+  /// successfully initialized before the callback terminated the insertion.
+  ///
+  /// - Parameters:
+  ///    - newItemCount: The number of items to append to the array.
+  ///    - initializer: A callback that gets called at most once to directly
+  ///       populate newly reserved storage within the array. The function
+  ///       is allowed to initialize fewer than `uninitializedCount` items.
+  ///       The array is appended however many items the callback adds to the
+  ///       output span before it returns (or before it throws an error).
+  ///
+  /// - Complexity: O(`uninitializedCount`)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  public mutating func append<E: Error>(
+    addingCount newItemCount: Int,
+    initializingWith initializer: (inout OutputSpan<Element>) throws(E) -> Void
+  ) throws(E) {
+    _ensureFreeCapacity(newItemCount)
+    return try _storage.append(
+      addingCount: newItemCount,
+      initializingWith: initializer)
+  }
+}
+
+@available(SwiftStdlib 6.4, *)
+extension UniqueArray where Element: ~Copyable {
+  /// Moves the elements of a buffer to the end of this array, leaving the
+  /// buffer uninitialized.
+  ///
+  /// If the array does not have sufficient capacity to hold all items in the
+  /// buffer, then this reallocates the array's storage to grow its capacity,
+  /// using a geometric growth rate.
+  ///
+  /// - Parameters:
+  ///    - items: A fully initialized buffer whose contents to move into
+  ///        the array.
+  ///
+  /// - Complexity: O(`count` + `items.count`)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  public mutating func append(
+    moving items: UnsafeMutableBufferPointer<Element>
+  ) {
+    _ensureFreeCapacity(items.count)
+    unsafe _storage.append(moving: items)
+  }
+
+  /// Moves the elements of a output span to the end of this array, leaving the
+  /// span empty.
+  ///
+  /// If the array does not have sufficient capacity to hold all new items,
+  /// then this reallocates the array's storage to grow its capacity,
+  /// using a geometric growth rate.
+  ///
+  /// - Parameters:
+  ///    - items: An output span whose contents need to be appended to this array.
+  ///
+  /// - Complexity: O(`items.count`)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  public mutating func append(
+    moving items: inout OutputSpan<Element>
+  ) {
+    _ensureFreeCapacity(items.count)
+    _storage.append(moving: &items)
+  }
+}
+
+@available(SwiftStdlib 6.4, *)
+extension UniqueArray where Element: Copyable {
+  /// Copies the elements of a buffer to the end of this array.
+  ///
+  /// If the array does not have sufficient capacity to hold all items
+  /// in the source buffer, then this automatically grows the array's
+  /// capacity, using a geometric growth rate.
+  ///
+  /// - Parameters:
+  ///    - newElements: A fully initialized buffer whose contents to copy into
+  ///       the array.
+  ///
+  /// - Complexity: O(`newElements.count`) when amortized over many
+  ///     invocations on the same array.
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  public mutating func append(
+    copying newElements: UnsafeBufferPointer<Element>
+  ) {
+    _ensureFreeCapacity(newElements.count)
+    unsafe _storage.append(copying: newElements)
+  }
+
+  /// Copies the elements of a buffer to the end of this array.
+  ///
+  /// If the array does not have sufficient capacity to hold enough elements,
+  /// then this reallocates the array's storage to extend its capacity, using
+  /// a geometric growth rate.
+  ///
+  /// - Parameters:
+  ///    - newElements: A fully initialized buffer whose contents to copy into
+  ///       the array.
+  ///
+  /// - Complexity: O(`newElements.count`) when amortized over many
+  ///     invocations on the same array.
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  public mutating func append(
+    copying newElements: UnsafeMutableBufferPointer<Element>
+  ) {
+    unsafe self.append(copying: UnsafeBufferPointer(newElements))
+  }
+
+  /// Copies the elements of a span to the end of this array.
+  ///
+  /// If the array does not have sufficient capacity to hold enough elements,
+  /// then this reallocates the array's storage to extend its capacity, using a
+  /// geometric growth rate.
+  ///
+  /// - Parameters:
+  ///    - newElements: A span whose contents to copy into the array.
+  ///
+  /// - Complexity: O(`newElements.count`) when amortized over many
+  ///     invocations on the same array.
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  public mutating func append(copying newElements: Span<Element>) {
+    _ensureFreeCapacity(newElements.count)
+    _storage.append(copying: newElements)
+  }
+
+  /// Copies the elements of a sequence to the end of this array.
+  ///
+  /// If the array does not have sufficient capacity to hold enough elements,
+  /// then this reallocates the array's storage to extend its capacity, using
+  /// a geometric growth rate. If the input sequence does not provide a precise
+  /// estimate of its count, then the array's storage may need to be resized
+  /// more than once.
+  ///
+  /// - Parameters:
+  ///    - newElements: The new elements to copy into the array.
+  ///
+  /// - Complexity: O(*m*), where *m* is the length of `newElements`, when
+  ///     amortized over many invocations over the same array.
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  public mutating func append(copying newElements: some Sequence<Element>) {
+    let done: Void? = newElements.withContiguousStorageIfAvailable { buffer in
+      _ensureFreeCapacity(buffer.count)
+      unsafe _storage.append(copying: buffer)
+      return
+    }
+    if done != nil { return }
+
+    _ensureFreeCapacity(newElements.underestimatedCount)
+    var it = _storage._append(prefixOf: newElements)
+    while let item = it.next() {
+      _ensureFreeCapacity(1)
+      _storage.append(item)
+    }
+  }
+}

--- a/stdlib/public/core/UniqueArray/UniqueArray+Container.swift
+++ b/stdlib/public/core/UniqueArray/UniqueArray+Container.swift
@@ -1,0 +1,274 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@available(SwiftStdlib 6.4, *)
+extension UniqueArray where Element: ~Copyable {
+  /// A Boolean value indicating whether this array contains no elements.
+  ///
+  /// - Complexity: O(1)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  @_transparent
+  public var isEmpty: Bool {
+    _storage.isEmpty
+  }
+
+  /// The number of elements in this array.
+  ///
+  /// - Complexity: O(1)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  @_transparent
+  public var count: Int {
+    _storage.count
+  }
+}
+
+@available(SwiftStdlib 6.4, *)
+extension UniqueArray where Element: ~Copyable {
+  /// A type that represents a position in the array: an integer offset from the
+  /// start.
+  ///
+  /// Valid indices consist of the position of every element and a "past the
+  /// end” position that’s not valid for use as a subscript argument.
+  @available(SwiftStdlib 6.4, *)
+  public typealias Index = Int
+
+  /// The position of the first element in a nonempty array. This is always zero.
+  ///
+  /// - Complexity: O(1)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  @_transparent
+  public var startIndex: Int {
+    _storage.startIndex
+  }
+
+  /// The array’s "past the end” position—that is, the position one greater than
+  /// the last valid subscript argument. This is always equal to array's count.
+  ///
+  /// - Complexity: O(1)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  @_transparent
+  public var endIndex: Int {
+    _storage.count
+  }
+
+  /// The range of indices that are valid for subscripting the array.
+  ///
+  /// - Complexity: O(1)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  @_transparent
+  public var indices: Range<Int> {
+    _storage.indices
+  }
+
+  /// Accesses the element at the specified position.
+  ///
+  /// - Parameter position: The position of the element to access.
+  ///     The position must be a valid index of the array that is not equal
+  ///     to the `endIndex` property.
+  ///
+  /// - Complexity: O(1)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  public subscript(position: Int) -> Element {
+    @_transparent
+    @_unsafeSelfDependentResult
+    borrow {
+      unsafe _storage._ptr(to: position).pointee
+    }
+
+    @_transparent
+    @_unsafeSelfDependentResult
+    mutate {
+      unsafe &_storage._mutablePtr(to: position).pointee
+    }
+  }
+}
+
+@available(SwiftStdlib 6.4, *)
+extension UniqueArray where Element: ~Copyable {
+  /// Exchanges the values at the specified indices of the array.
+  ///
+  /// Both parameters must be valid indices of the array and not equal to
+  /// endIndex. Passing the same index as both `i` and `j` has no effect.
+  ///
+  /// - Parameter i: The index of the first value to swap.
+  /// - Parameter j: The index of the second valud to swap.
+  ///
+  /// - Complexity: O(1)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  public mutating func swapAt(_ i: Int, _ j: Int) {
+    _storage.swapAt(i, j)
+  }
+}
+
+@available(SwiftStdlib 6.4, *)
+extension UniqueArray where Element: ~Copyable {
+  /// Returns the position immediately after the given index.
+  ///
+  /// - Note: To improve performance, this method does not validate that the
+  ///    index is valid before incrementing it. Index validation is
+  ///    deferred until the resulting index is used to access an element.
+  ///    This optimization may be removed in future versions; do not rely on it.
+  ///
+  /// - Parameter index: A valid index of the array. `i` must be less
+  ///     than `endIndex`.
+  /// - Returns: The index immediately following `i`.
+  /// - Complexity: O(1)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  @_transparent
+  public func index(after index: Int) -> Int {
+    index + 1
+  }
+  
+  /// Returns the position immediately before the given index.
+  ///
+  /// - Note: To improve performance, this method does not validate that the
+  ///    index is valid before decrementing it. Index validation is
+  ///    deferred until the resulting index is used to access an element.
+  ///    This optimization may be removed in future versions; do not rely on it.
+  ///
+  /// - Parameter index: A valid index of the array. `i` must be greater
+  ///     than `startIndex`.
+  /// - Returns: The index immediately preceding `i`.
+  /// - Complexity: O(1)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  @_transparent
+  public func index(before index: Int) -> Int {
+    index - 1
+  }
+
+  /// Replaces the given index with its successor.
+  ///
+  /// - Note: To improve performance, this method does not validate that the
+  ///    given index is valid before incrementing it. Index validation is
+  ///    deferred until the resulting index is used to access an element.
+  ///    This optimization may be removed in future versions; do not rely on it.
+  ///
+  /// - Parameter index: A valid index of the array. `i` must be less
+  ///     than `endIndex`.
+  /// - Complexity: O(1)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  @_transparent
+  public func formIndex(after index: inout Int) {
+    index += 1
+  }
+
+  /// Replaces the given index with its predecessor.
+  ///
+  /// - Note: To improve performance, this method does not validate that the
+  ///    given index is valid before decrementing it. Index validation is
+  ///    deferred until the resulting index is used to access an element.
+  ///    This optimization may be removed in future versions; do not rely on it.
+  ///
+  /// - Parameter index: A valid index of the array. `i` must be greater than
+  ///     `startIndex`.
+  /// - Complexity: O(1)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  @_transparent
+  public func formIndex(before index: inout Int) {
+    index -= 1
+  }
+
+  /// Returns an index that is the specified distance from the given index.
+  ///
+  /// The value passed as `n` must not offset `index` beyond the bounds of the
+  /// array.
+  ///
+  /// - Note: To improve performance, this method does not validate that the
+  ///    given index is valid before offseting it. Index validation is
+  ///    deferred until the resulting index is used to access an element.
+  ///    This optimization may be removed in future versions; do not rely on it.
+  ///
+  /// - Parameter index: A valid index of the array.
+  /// - Parameter n: The distance by which to offset `index`.
+  /// - Returns: An index offset by distance from `index`. If `n` is positive,
+  ///    this is the same value as the result of `n` calls to `index(after:)`.
+  ///    If `n` is negative, this is the same value as the result of `abs(n)`
+  ///    calls to `index(before:)`.
+  /// - Complexity: O(1)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  @_transparent
+  public func index(_ index: Int, offsetBy n: Int) -> Int {
+    index + n
+  }
+  
+  /// Returns the distance between two indices.
+  ///
+  /// - Note: To improve performance, this method does not validate that the
+  ///    given index is valid before offseting it. Index validation is
+  ///    deferred until the resulting index is used to access an element.
+  ///    This optimization may be removed in future versions; do not rely on it.
+  ///
+  /// - Parameter start: A valid index of the collection.
+  /// - Parameter end: Another valid index of the collection. If end is equal
+  ///    to start, the result is zero.
+  /// - Returns: The distance between `start` and `end`.
+  /// - Complexity: O(1)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  @_transparent
+  public func distance(from start: Index, to end: Index) -> Int {
+    end - start
+  }
+  
+  /// Offsets the given index by the specified distance, but no further than
+  /// the given limiting index.
+  ///
+  /// If the operation was able to offset `index` by exactly the requested
+  /// number of steps without hitting `limit`, then on return `n` is set to `0`,
+  /// and `index` is set to the adjusted index.
+  ///
+  /// If the operation hits the limit before it can take the requested number
+  /// of steps, then on return `index` is set to `limit`, and `n` is set
+  /// to the number of steps that couldn't be taken.
+  ///
+  /// The value passed as `n` must not offset `index` beyond the bounds of the
+  /// container, unless the index passed as `limit` prevents offsetting beyond
+  /// those bounds.
+  ///
+  /// - Note: To improve performance, this method does not validate that the
+  ///    given index is valid before offseting it. Index validation is
+  ///    deferred until the resulting index is used to access an element.
+  ///    This optimization may be removed in future versions; do not rely on it.
+  ///
+  /// - Parameter index: A valid index of the array. On return, `index` is
+  ///    set to the resulting position.
+  /// - Parameter n: The distance to offset `index`.
+  ///    On return, `n` is set to zero if the operation succeeded without
+  ///    hitting the limit; otherwise, `n` reflects the number of steps that
+  ///    couldn't be taken.
+  /// - Parameter limit: A valid index of the array to use as a limit.
+  ///    If `n > 0`, a limit that is less than `index` has no effect.
+  ///    Likewise, if `n < 0`, a limit that is greater than `index` has no
+  ///    effect.
+  /// - Complexity: O(1)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  public func formIndex(
+    _ index: inout Index,
+    offsetBy n: inout Int,
+    limitedBy limit: Index
+  ) {
+    _storage.formIndex(&index, offsetBy: &n, limitedBy: limit)
+  }
+}

--- a/stdlib/public/core/UniqueArray/UniqueArray+Descriptions.swift
+++ b/stdlib/public/core/UniqueArray/UniqueArray+Descriptions.swift
@@ -1,0 +1,37 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+// FIXME: Enable once SE-0499 is implemented
+// @available(SwiftStdlib x.y, *)
+// extension UniqueArray: CustomStringConvertible where Element: ~Copyable {
+// }
+
+@available(SwiftStdlib 6.4, *)
+extension UniqueArray where Element: ~Copyable {
+  public var description: String {
+    /// FIXME: Print the item descriptions when available.
+    "<\(count) items>"
+  }
+}
+
+// FIXME: Enable once SE-0499 is implemented
+// @available(SwiftStdlib x.y, *)
+// extension UniqueArray: CustomDebugStringConvertible where Element: ~Copyable {
+// }
+
+@available(SwiftStdlib 6.4, *)
+extension UniqueArray where Element: ~Copyable {
+  public var debugDescription: String {
+    /// FIXME: Print the item descriptions when available.
+    "<\(count) items>"
+  }
+}

--- a/stdlib/public/core/UniqueArray/UniqueArray+Equatable.swift
+++ b/stdlib/public/core/UniqueArray/UniqueArray+Equatable.swift
@@ -1,0 +1,31 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@available(SwiftStdlib 6.4, *)
+extension UniqueArray where Element: ~Copyable {
+  @_alwaysEmitIntoClient
+  public func isTriviallyIdentical(to other: borrowing Self) -> Bool {
+    _storage.isTriviallyIdentical(to: other._storage)
+  }
+}
+
+@available(SwiftStdlib 6.4, *)
+extension UniqueArray: Equatable where Element: Equatable & ~Copyable {
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  public static func ==(
+    left: borrowing Self,
+    right: borrowing Self
+  ) -> Bool {
+    left.span._elementsEqual(to: right.span)
+  }
+}

--- a/stdlib/public/core/UniqueArray/UniqueArray+Hashable.swift
+++ b/stdlib/public/core/UniqueArray/UniqueArray+Hashable.swift
@@ -1,0 +1,20 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@available(SwiftStdlib 6.4, *)
+extension UniqueArray: Hashable where Element: Hashable & ~Copyable {
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  public func hash(into hasher: inout Hasher) {
+    _storage.hash(into: &hasher)
+  }
+}

--- a/stdlib/public/core/UniqueArray/UniqueArray+Initializers.swift
+++ b/stdlib/public/core/UniqueArray/UniqueArray+Initializers.swift
@@ -1,0 +1,127 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@available(SwiftStdlib 6.4, *)
+extension UniqueArray where Element: ~Copyable {
+  /// Initializes a new unique array with no elements.
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  public init() {
+    _storage = .init(capacity: 0)
+  }
+  
+  /// Initializes a new unique array with the specified capacity and no elements.
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  public init(capacity: Int) {
+    _storage = .init(capacity: capacity)
+  }
+
+  /// Initializes a new unique array with the specified capacity and no elements.
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  public init(minimumCapacity: Int) {
+    self.init(capacity: minimumCapacity)
+  }
+}
+
+@available(SwiftStdlib 6.4, *)
+extension UniqueArray where Element: ~Copyable {
+  /// Creates a new array with the specified capacity, directly initializing
+  /// its storage using an output span.
+  ///
+  /// - Parameters:
+  ///   - capacity: The storage capacity of the new array.
+  ///   - body: A callback that gets called at most once to directly
+  ///       populate newly reserved storage within the array. The function
+  ///       is allowed to add fewer than `capacity` items. The array is
+  ///       initialized with however many items the callback adds to the
+  ///       output span before it returns (or before it throws an error).
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  public init<E: Error>(
+    capacity: Int,
+    initializingWith body: (inout OutputSpan<Element>) throws(E) -> Void
+  ) throws(E) {
+    self.init(capacity: capacity)
+    try edit(body)
+  }
+}
+
+@available(SwiftStdlib 6.4, *)
+extension UniqueArray where Element: Copyable {
+  /// Creates a new array containing the specified number of a single,
+  /// repeated value.
+  ///
+  /// - Parameters:
+  ///   - repeatedValue: The element to repeat.
+  ///   - count: The number of times to repeat the value passed in the
+  ///     `repeating` parameter. `count` must be zero or greater.
+  ///
+  /// - Complexity: O(`count`)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  public init(repeating repeatedValue: Element, count: Int) {
+    self.init(consuming: _RigidArray(repeating: repeatedValue, count: count))
+  }
+}
+
+@available(SwiftStdlib 6.4, *)
+extension UniqueArray where Element: ~Copyable {
+  /// Creates a new unique array taking over the storage of the specified
+  /// rigid array instance, consuming it in the process.
+  ///
+  /// - Complexity: O(1)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  internal init(consuming storage: consuming _RigidArray<Element>) {
+    self._storage = storage
+  }
+}
+
+@available(SwiftStdlib 6.4, *)
+extension UniqueArray where Element: Copyable {
+  /// Creates a new array with the specified initial capacity, holding a copy
+  /// of the contents of a given sequence.
+  ///
+  /// - Parameters:
+  ///   - capacity: The storage capacity of the new array, or nil to allocate
+  ///      just enough capacity to store the contents.
+  ///   - contents: The sequence whose contents to copy into the new array.
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  public init(
+    capacity: Int? = nil,
+    copying contents: some Sequence<Element>
+  ) {
+    self.init(capacity: capacity ?? 0)
+    self.append(copying: contents)
+  }
+
+  /// Creates a new array with the specified capacity, holding a copy
+  /// of the contents of the given span.
+  ///
+  /// - Parameters:
+  ///   - capacity: The storage capacity of the new array, or nil to allocate
+  ///      just enough capacity to store the contents of the span.
+  ///   - span: The span whose contents to copy into the new array.
+  ///      The span must not contain more than `capacity` elements.
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  public init(
+    capacity: Int? = nil,
+    copying span: Span<Element>
+  ) {
+    self.init(capacity: capacity ?? span.count)
+    self.append(copying: span)
+  }
+}

--- a/stdlib/public/core/UniqueArray/UniqueArray+Insertions.swift
+++ b/stdlib/public/core/UniqueArray/UniqueArray+Insertions.swift
@@ -1,0 +1,269 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@available(SwiftStdlib 6.4, *)
+extension UniqueArray where Element: ~Copyable {
+  /// Inserts a new element into the array at the specified position.
+  ///
+  /// If the array does not have sufficient capacity to hold any more elements,
+  /// then this reallocates storage to extend its capacity, using a geometric
+  /// growth rate.
+  ///
+  /// The new element is inserted before the element currently at the specified
+  /// index. If you pass the array's `endIndex` as the `index` parameter, then
+  /// the new element is appended to the container.
+  ///
+  /// All existing elements at or following the specified position are moved to
+  /// make room for the new item.
+  ///
+  /// - Parameter item: The new element to insert into the array.
+  /// - Parameter i: The position at which to insert the new element.
+  ///   `index` must be a valid index in the array.
+  ///
+  /// - Complexity: O(`self.count`)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  public mutating func insert(_ item: consuming Element, at index: Int) {
+    _precondition(index >= 0 && index <= count)
+    // FIXME: Avoid moving the subsequent elements twice.
+    _ensureFreeCapacity(1)
+    _storage.insert(item, at: index)
+  }
+}
+
+@available(SwiftStdlib 6.4, *)
+extension UniqueArray where Element: ~Copyable {
+  /// Inserts a given number of new items into this array at the specified
+  /// position, using a callback to directly initialize array storage by
+  /// populating an output span.
+  ///
+  /// Existing elements in the array's storage are moved towards the back as
+  /// needed to make room for the new items.
+  ///
+  /// If the array does not have sufficient capacity to hold the new elements,
+  /// then this operation reallocates storage to extend its capacity, using a
+  /// geometric growth rate.
+  ///
+  ///     var buffer = UniqueArray<Int>()
+  ///     buffer.append([-999, 999])
+  ///     var i = 0
+  ///     buffer.insert(capacity: 3, at: 1) { target in
+  ///       while !target.isFull {
+  ///         target.append(i)
+  ///         i += 1
+  ///       }
+  ///     }
+  ///     // `buffer` now contains [-999, 0, 1, 2, 999]
+  ///
+  /// - Parameters:
+  ///    - count: The number of items to insert into the array.
+  ///    - index: The position at which to insert the new items.
+  ///       `index` must be a valid index in the array.
+  ///    - body: A callback that gets called at most once to directly
+  ///       populate newly reserved storage within the array. The function
+  ///       is called with an empty output span of capacity matching the
+  ///       supplied count, and it must fully populate it before returning.
+  ///
+  /// - Complexity: O(`self.count` + `count`)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  public mutating func insert<E: Error>(
+    addingCount newItemCount: Int,
+    at index: Int,
+    initializingWith initializer: (inout OutputSpan<Element>) throws(E) -> Void
+  ) throws(E) {
+    _ensureFreeCapacity(newItemCount)
+    try _storage.insert(
+      addingCount: newItemCount,
+      at: index,
+      initializingWith: initializer)
+  }
+}
+
+@available(SwiftStdlib 6.4, *)
+extension UniqueArray where Element: ~Copyable {
+  /// Moves the elements of a fully initialized buffer into this array,
+  /// starting at the specified position, and leaving the buffer
+  /// uninitialized.
+  ///
+  /// If the array does not have sufficient capacity to hold all elements,
+  /// then this reallocates storage to extend its capacity, using a geometric
+  /// growth rate.
+  ///
+  /// - Parameters:
+  ///    - items: A fully initialized buffer whose contents to move into
+  ///        the array.
+  ///
+  /// - Complexity: O(`self.count` + `items.count`)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  public mutating func insert(
+    moving items: UnsafeMutableBufferPointer<Element>,
+    at index: Int
+  ) {
+    // FIXME: Avoid moving the subsequent elements twice.
+    _ensureFreeCapacity(items.count)
+    unsafe _storage.insert(moving: items, at: index)
+  }
+
+  /// Moves the elements of an output span into this array,
+  /// starting at the specified position, and leaving the span empty.
+  ///
+  /// All existing elements at or following the specified position are moved to
+  /// make room for the new items.
+  ///
+  /// If the array does not have sufficient capacity to hold the new elements,
+  /// then this reallocates storage to extend its capacity, using a geometric
+  /// growth rate.
+  ///
+  /// - Parameters:
+  ///    - items: An output span whose contents to move into
+  ///        the array.
+  ///    - index: The position at which to insert the new items.
+  ///       `index` must be a valid index in the array.
+  ///
+  /// - Complexity: O(`self.count` + `items.count`)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  public mutating func insert(
+    moving items: inout OutputSpan<Element>,
+    at index: Int
+  ) {
+    _ensureFreeCapacity(items.count)
+    _storage.insert(moving: &items, at: index)
+  }
+}
+
+@available(SwiftStdlib 6.4, *)
+extension UniqueArray where Element: Copyable {
+  /// Copies the elements of a fully initialized buffer pointer into this
+  /// array at the specified position.
+  ///
+  /// The new elements are inserted before the element currently at the
+  /// specified index. If you pass the array’s `endIndex` as the `index`
+  /// parameter, then the new elements are appended to the end of the array.
+  ///
+  /// All existing elements at or following the specified position are moved to
+  /// make room for the new item.
+  ///
+  /// If the array does not have sufficient capacity to hold enough elements,
+  /// then this reallocates the array's storage to extend its capacity, using a
+  /// geometric growth rate.
+  ///
+  /// - Parameters:
+  ///    - newElements: The new elements to insert into the array. The buffer
+  ///       must be fully initialized.
+  ///    - index: The position at which to insert the new elements. It must be
+  ///       a valid index of the array.
+  ///
+  /// - Complexity: O(`self.count` + `newElements.count`)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  public mutating func insert(
+    copying newElements: UnsafeBufferPointer<Element>, at index: Int
+  ) {
+    // FIXME: Avoid moving the subsequent elements twice.
+    _ensureFreeCapacity(newElements.count)
+    unsafe _storage.insert(copying: newElements, at: index)
+  }
+
+  /// Copies the elements of a fully initialized buffer pointer into this
+  /// array at the specified position.
+  ///
+  /// The new elements are inserted before the element currently at the
+  /// specified index. If you pass the array’s `endIndex` as the `index`
+  /// parameter, then the new elements are appended to the end of the array.
+  ///
+  /// All existing elements at or following the specified position are moved to
+  /// make room for the new item.
+  ///
+  /// If the array does not have sufficient capacity to hold enough elements,
+  /// then this reallocates the array's storage to extend its capacity, using a
+  /// geometric growth rate.
+  ///
+  /// - Parameters:
+  ///    - newElements: The new elements to insert into the array. The buffer
+  ///       must be fully initialized.
+  ///    - index: The position at which to insert the new elements. It must be
+  ///       a valid index of the array.
+  ///
+  /// - Complexity: O(`self.count` + `newElements.count`)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  public mutating func insert(
+    copying newElements: UnsafeMutableBufferPointer<Element>,
+    at index: Int
+  ) {
+    unsafe self.insert(copying: UnsafeBufferPointer(newElements), at: index)
+  }
+
+  /// Copies the elements of a span into this array at the specified position.
+  ///
+  /// The new elements are inserted before the element currently at the
+  /// specified index. If you pass the array’s `endIndex` as the `index`
+  /// parameter, then the new elements are appended to the end of the array.
+  ///
+  /// All existing elements at or following the specified position are moved to
+  /// make room for the new item.
+  ///
+  /// If the array does not have sufficient capacity to hold enough elements,
+  /// then this reallocates the array's storage to extend its capacity, using a
+  /// geometric growth rate.
+  ///
+  /// - Parameters:
+  ///    - newElements: The new elements to insert into the array.
+  ///    - index: The position at which to insert the new elements. It must be
+  ///        a valid index of the array.
+  ///
+  /// - Complexity: O(`self.count` + `newElements.count`)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  public mutating func insert(
+    copying newElements: Span<Element>, at index: Int
+  ) {
+    // FIXME: Avoid moving the subsequent elements twice.
+    _ensureFreeCapacity(newElements.count)
+    _storage.insert(copying: newElements, at: index)
+  }
+
+  /// Copies the elements of a collection into this array at the specified
+  /// position.
+  ///
+  /// The new elements are inserted before the element currently at the
+  /// specified index. If you pass the array’s `endIndex` as the `index`
+  /// parameter, then the new elements are appended to the end of the array.
+  ///
+  /// All existing elements at or following the specified position are moved
+  /// to make room for the new item.
+  ///
+  /// If the array does not have sufficient capacity to hold enough elements,
+  /// then this reallocates the array's storage to extend its capacity, using a
+  /// geometric growth rate.
+  ///
+  /// - Parameters:
+  ///    - newElements: The new elements to insert into the array.
+  ///    - index: The position at which to insert the new elements. It must be
+  ///        a valid index of the array.
+  ///
+  /// - Complexity: O(`self.count` + `newElements.count`)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  public mutating func insert(
+    copying newElements: some Collection<Element>, at index: Int
+  ) {
+    // FIXME: Avoid moving the subsequent elements twice.
+    let newCount = newElements.count
+    _ensureFreeCapacity(newCount)
+    _storage._insertCollection(
+      at: index, copying: newElements, newCount: newCount)
+  }
+}

--- a/stdlib/public/core/UniqueArray/UniqueArray+Removals.swift
+++ b/stdlib/public/core/UniqueArray/UniqueArray+Removals.swift
@@ -1,0 +1,115 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@available(SwiftStdlib 6.4, *)
+extension UniqueArray where Element: ~Copyable {
+  /// Removes all elements from the array, preserving its allocated capacity.
+  ///
+  /// - Complexity: O(*n*), where *n* is the original count of the array.
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  public mutating func removeAll() {
+    _storage.removeAll()
+  }
+
+  /// Removes and returns the last element of the array.
+  ///
+  /// The array must not be empty.
+  ///
+  /// - Returns: The last element of the original array.
+  ///
+  /// - Complexity: O(1)
+  @available(SwiftStdlib 6.4, *)
+  @discardableResult
+  @_alwaysEmitIntoClient
+  public mutating func removeLast() -> Element {
+    _storage.removeLast()
+  }
+
+  /// Removes and discards the specified number of elements from the end of the
+  /// array.
+  ///
+  /// Attempting to remove more elements than exist in the array triggers a
+  /// runtime error.
+  ///
+  /// - Parameter k: The number of elements to remove from the array.
+  ///   `k` must be greater than or equal to zero and must not exceed
+  ///    the count of the array.
+  ///
+  /// - Complexity: O(`k`)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  public mutating func removeLast(_ k: Int) {
+    _storage.removeLast(k)
+  }
+
+  /// Removes and returns the element at the specified position.
+  ///
+  /// All the elements following the specified position are moved to close the
+  /// gap.
+  ///
+  /// - Parameter i: The position of the element to remove. `index` must be
+  ///   a valid index of the array that is not equal to the end index.
+  /// - Returns: The removed element.
+  ///
+  /// - Complexity: O(`self.count`)
+  @available(SwiftStdlib 6.4, *)
+  @discardableResult
+  @_alwaysEmitIntoClient
+  public mutating func remove(at index: Int) -> Element {
+    _storage.remove(at: index)
+  }
+
+  /// Removes the specified subrange of elements from the array.
+  ///
+  /// All the elements following the specified subrange are moved to close the
+  /// resulting gap.
+  ///
+  /// - Parameter bounds: The subrange of the array to remove. The bounds
+  ///   of the range must be valid indices of the array.
+  ///
+  /// - Complexity: O(`self.count`)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  public mutating func removeSubrange(_  bounds: Range<Int>) {
+    _storage.removeSubrange(bounds)
+  }
+
+  /// Removes the specified subrange of elements from the array.
+  ///
+  /// - Parameter bounds: The subrange of the array to remove. The bounds
+  ///   of the range must be valid indices of the array.
+  ///
+  /// - Complexity: O(`self.count`)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  public mutating func removeSubrange(_  bounds: some RangeExpression<Int>) {
+    // FIXME: Remove this in favor of a standard algorithm.
+    removeSubrange(bounds.relative(to: indices))
+  }
+}
+
+@available(SwiftStdlib 6.4, *)
+extension UniqueArray where Element: ~Copyable {
+  /// Removes and returns the last element of the array, if there is one.
+  ///
+  /// - Returns: The last element of the array if the array is not empty;
+  ///    otherwise, `nil`.
+  ///
+  /// - Complexity: O(1)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  public mutating func popLast() -> Element? {
+    if isEmpty { return nil }
+    return removeLast()
+  }
+}

--- a/stdlib/public/core/UniqueArray/UniqueArray+Replacements.swift
+++ b/stdlib/public/core/UniqueArray/UniqueArray+Replacements.swift
@@ -1,0 +1,316 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@available(SwiftStdlib 6.4, *)
+extension UniqueArray where Element: ~Copyable {
+  /// Replaces the specified range of elements by a given count of new items,
+  /// using a callback to directly initialize array storage by populating
+  /// an output span.
+  ///
+  /// The number of new items need not match the number of elements being
+  /// removed.
+  ///
+  /// This method has the same overall effect as calling
+  ///
+  ///     try array.removeSubrange(subrange)
+  ///     try array.insert(
+  ///       addingCount: newItemCount,
+  ///       at: subrange.lowerBound,
+  ///       initializingWith: initializer)
+  ///
+  /// Except it performs faster (by a constant factor), by avoiding moving
+  /// some items in the array twice.
+  ///
+  /// If the array does not have sufficient capacity to perform the replacement,
+  /// then this reallocates storage to extend its capacity, using a geometric
+  /// growth rate.
+  ///
+  /// If the callback fails to fully populate its output span or if
+  /// it throws an error, then the array keeps all items that were
+  /// successfully initialized before the callback terminated the prepend.
+  ///
+  /// Partial insertions create a gap in array storage that needs to be
+  /// closed by moving newly inserted items to their correct positions given
+  /// the adjusted count. This adds some overhead compared to adding exactly as
+  /// many items as promised.
+  ///
+  /// - Parameters:
+  ///   - subrange: The subrange of the array to replace. The bounds of
+  ///      the range must be valid indices in the array.
+  ///   - newItemCount: the maximum number of items to replace the old subrange.
+  ///   - initializer: A callback that gets called at most once to directly
+  ///      populate newly reserved storage within the array. The function
+  ///      is always called with an empty output span.
+  ///
+  /// - Complexity: O(`self.count` + `newItemCount`) in addition to the complexity
+  ///    of the callback invocations.
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  public mutating func replaceSubrange<E: Error>(
+    _ subrange: Range<Int>,
+    addingCount newItemCount: Int,
+    initializingWith initializer: (inout OutputSpan<Element>) throws(E) -> Void
+  ) throws(E) -> Void {
+    _storage._checkValidBounds(subrange)
+    _precondition(newItemCount >= 0, "Cannot add a negative number of items")
+    // FIXME: Avoid moving the subsequent elements twice on resize.
+    _ensureFreeCapacity(newItemCount - subrange.count)
+    try _storage._uncheckedReplaceSubrange(
+      subrange,
+      addingCount: newItemCount,
+      initializingWith: initializer)
+  }
+}
+
+@available(SwiftStdlib 6.4, *)
+extension UniqueArray where Element: ~Copyable {
+  /// Replaces the specified range of elements by moving the elements of a
+  /// fully initialized buffer into their place. On return, the buffer is left
+  /// in an uninitialized state.
+  ///
+  /// This method has the effect of removing the specified range of elements
+  /// from the array and inserting the new elements starting at the same
+  /// location. The number of new elements need not match the number of elements
+  /// being removed.
+  ///
+  /// If the array does not have sufficient capacity to perform the replacement,
+  /// then this reallocates the array's storage to extend its capacity, using a
+  /// geometric growth rate.
+  ///
+  /// If you pass a zero-length range as the `subrange` parameter, this method
+  /// inserts the elements of `newElements` at `subrange.lowerBound`. Calling
+  /// the `insert(copying:at:)` method instead is preferred in this case.
+  ///
+  /// Likewise, if you pass a zero-length buffer as the `newElements`
+  /// parameter, this method removes the elements in the given subrange
+  /// without replacement. Calling the `removeSubrange(_:)` method instead is
+  /// preferred in this case.
+  ///
+  /// - Parameters:
+  ///   - subrange: The subrange of the array to replace. The bounds of
+  ///     the range must be valid indices in the array.
+  ///   - newElements: A fully initialized buffer whose contents to move into
+  ///     the array.
+  ///
+  /// - Complexity: O(`self.count` + `newElements.count`)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  public mutating func replaceSubrange(
+    _ subrange: Range<Int>,
+    moving newElements: UnsafeMutableBufferPointer<Element>,
+  ) {
+    // FIXME: Avoid moving the subsequent elements twice.
+    _ensureFreeCapacity(newElements.count - subrange.count)
+    unsafe _storage.replaceSubrange(subrange, moving: newElements)
+  }
+
+  /// Replaces the specified range of elements by moving the contents of an
+  /// output span into their place. On return, the span is left empty.
+  ///
+  /// This method has the effect of removing the specified range of elements
+  /// from the array and inserting the new elements starting at the same
+  /// location. The number of new elements need not match the number of elements
+  /// being removed.
+  ///
+  /// If the array does not have sufficient capacity to perform the replacement,
+  /// then this reallocates the array's storage to extend its capacity, using a
+  /// geometric growth rate.
+  ///
+  /// If you pass a zero-length range as the `subrange` parameter, this method
+  /// inserts the elements of `newElements` at `subrange.lowerBound`. Calling
+  /// the `insert(moving:at:)` method instead is preferred in this case.
+  ///
+  /// Likewise, if you pass a zero-length buffer as the `newElements`
+  /// parameter, this method removes the elements in the given subrange
+  /// without replacement. Calling the `removeSubrange(_:)` method instead is
+  /// preferred in this case.
+  ///
+  /// - Parameters:
+  ///   - subrange: The subrange of the array to replace. The bounds of
+  ///     the range must be valid indices in the array.
+  ///   - items: An output span whose contents are to be moved into the array.
+  ///
+  /// - Complexity: O(`self.count` + `items.count`)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  public mutating func replaceSubrange(
+    _ subrange: Range<Int>,
+    moving items: inout OutputSpan<Element>
+  ) {
+    // FIXME: Avoid moving the subsequent elements twice.
+    _ensureFreeCapacity(items.count - subrange.count)
+    _storage.replaceSubrange(subrange, moving: &items)
+  }
+}
+
+@available(SwiftStdlib 6.4, *)
+extension UniqueArray where Element: Copyable {
+  /// Replaces the specified subrange of elements by copying the elements of
+  /// the given buffer pointer, which must be fully initialized.
+  ///
+  /// This method has the effect of removing the specified range of elements
+  /// from the array and inserting the new elements starting at the same location.
+  /// The number of new elements need not match the number of elements being
+  /// removed.
+  ///
+  /// If the capacity of the array isn't sufficient to perform the replacement,
+  /// then this reallocates the array's storage to extend its capacity, using a
+  /// geometric growth rate.
+  ///
+  /// If you pass a zero-length range as the `subrange` parameter, this method
+  /// inserts the elements of `newElements` at `subrange.lowerBound`. Calling
+  /// the `insert(copying:at:)` method instead is preferred in this case.
+  ///
+  /// Likewise, if you pass a zero-length buffer as the `newElements`
+  /// parameter, this method removes the elements in the given subrange
+  /// without replacement. Calling the `removeSubrange(_:)` method instead is
+  /// preferred in this case.
+  ///
+  /// - Parameters:
+  ///   - subrange: The subrange of the array to replace. The bounds of
+  ///     the range must be valid indices in the array.
+  ///   - newElements: The new elements to copy into the collection.
+  ///
+  /// - Complexity: O(*n* + *m*), where *n* is count of this array and
+  ///   *m* is the count of `newElements`.
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  public mutating func replaceSubrange(
+    _ subrange: Range<Int>,
+    copying newElements: UnsafeBufferPointer<Element>
+  ) {
+    // FIXME: Avoid moving the subsequent elements twice.
+    _ensureFreeCapacity(newElements.count - subrange.count)
+    unsafe _storage.replaceSubrange(subrange, copying: newElements)
+  }
+
+  /// Replaces the specified subrange of elements by copying the elements of
+  /// the given buffer pointer, which must be fully initialized.
+  ///
+  /// This method has the effect of removing the specified range of elements
+  /// from the array and inserting the new elements starting at the same location.
+  /// The number of new elements need not match the number of elements being
+  /// removed.
+  ///
+  /// If the capacity of the array isn't sufficient to perform the replacement,
+  /// then this reallocates the array's storage to extend its capacity, using a
+  /// geometric growth rate.
+  ///
+  /// If you pass a zero-length range as the `subrange` parameter, this method
+  /// inserts the elements of `newElements` at `subrange.lowerBound`. Calling
+  /// the `insert(copying:at:)` method instead is preferred in this case.
+  ///
+  /// Likewise, if you pass a zero-length buffer as the `newElements`
+  /// parameter, this method removes the elements in the given subrange
+  /// without replacement. Calling the `removeSubrange(_:)` method instead is
+  /// preferred in this case.
+  ///
+  /// - Parameters:
+  ///   - subrange: The subrange of the array to replace. The bounds of
+  ///     the range must be valid indices in the array.
+  ///   - newElements: The new elements to copy into the collection.
+  ///
+  /// - Complexity: O(*n* + *m*), where *n* is count of this array and
+  ///   *m* is the count of `newElements`.
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  public mutating func replaceSubrange(
+    _ subrange: Range<Int>,
+    copying newElements: UnsafeMutableBufferPointer<Element>
+  ) {
+    unsafe self.replaceSubrange(
+      subrange,
+      copying: UnsafeBufferPointer(newElements))
+  }
+
+  /// Replaces the specified subrange of elements by copying the elements of
+  /// the given span.
+  ///
+  /// This method has the effect of removing the specified range of elements
+  /// from the array and inserting the new elements starting at the same location.
+  /// The number of new elements need not match the number of elements being
+  /// removed.
+  ///
+  /// If the capacity of the array isn't sufficient to perform the replacement,
+  /// then this reallocates the array's storage to extend its capacity, using a
+  /// geometric growth rate.
+  ///
+  /// If you pass a zero-length range as the `subrange` parameter, this method
+  /// inserts the elements of `newElements` at `subrange.lowerBound`. Calling
+  /// the `insert(copying:at:)` method instead is preferred in this case.
+  ///
+  /// Likewise, if you pass a zero-length span as the `newElements`
+  /// parameter, this method removes the elements in the given subrange
+  /// without replacement. Calling the `removeSubrange(_:)` method instead is
+  /// preferred in this case.
+  ///
+  /// - Parameters:
+  ///   - subrange: The subrange of the array to replace. The bounds of
+  ///     the range must be valid indices in the array.
+  ///   - newElements: The new elements to copy into the collection.
+  ///
+  /// - Complexity: O(*n* + *m*), where *n* is count of this array and
+  ///   *m* is the count of `newElements`.
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  public mutating func replaceSubrange(
+    _ subrange: Range<Int>,
+    copying newElements: Span<Element>
+  ) {
+    // FIXME: Avoid moving the subsequent elements twice.
+    _ensureFreeCapacity(newElements.count - subrange.count)
+    _storage.replaceSubrange(subrange, copying: newElements)
+  }
+
+  /// Replaces the specified subrange of elements by copying the elements of
+  /// the given collection.
+  ///
+  /// This method has the effect of removing the specified range of elements
+  /// from the array and inserting the new elements starting at the same location.
+  /// The number of new elements need not match the number of elements being
+  /// removed.
+  ///
+  /// If the capacity of the array isn't sufficient to perform the replacement,
+  /// then this reallocates the array's storage to extend its capacity, using a
+  /// geometric growth rate.
+  ///
+  /// If you pass a zero-length range as the `subrange` parameter, this method
+  /// inserts the elements of `newElements` at `subrange.lowerBound`. Calling
+  /// the `insert(copying:at:)` method instead is preferred in this case.
+  ///
+  /// Likewise, if you pass a zero-length collection as the `newElements`
+  /// parameter, this method removes the elements in the given subrange
+  /// without replacement. Calling the `removeSubrange(_:)` method instead is
+  /// preferred in this case.
+  ///
+  /// - Parameters:
+  ///   - subrange: The subrange of the array to replace. The bounds of
+  ///     the range must be valid indices in the array.
+  ///   - newElements: The new elements to copy into the collection.
+  ///
+  /// - Complexity: O(*n* + *m*), where *n* is count of this array and
+  ///   *m* is the count of `newElements`.
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  public mutating func replaceSubrange(
+    _ subrange: Range<Int>,
+    copying newElements: consuming some Collection<Element>
+  ) {
+    // FIXME: Avoid moving the subsequent elements twice.
+    let c = newElements.count
+    _ensureFreeCapacity(c - subrange.count)
+    _storage._replaceSubrange(
+      subrange,
+      copyingCollection: newElements,
+      newCount: c)
+  }
+}

--- a/stdlib/public/core/UniqueArray/UniqueArray.swift
+++ b/stdlib/public/core/UniqueArray/UniqueArray.swift
@@ -1,0 +1,227 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// A dynamically self-resizing, heap allocated, noncopyable array of
+/// potentially noncopyable elements.
+///
+/// `UniqueArray` instances automatically resize their underlying storage as
+/// needed to accommodate newly inserted items, using a geometric growth curve.
+/// This lets code using `UniqueArray` avoid having to allocate enough
+/// capacity in advance; on the other hand, it makes it difficult to tell
+/// when and where such reallocations may happen.
+///
+/// For example, appending an element to a `UniqueArray` has highly variable
+/// complexity; often, it runs at a constant cost, but if the operation has to
+/// resize storage, then the cost of an individual append suddenly becomes
+/// proportional to the size of the whole array.
+///
+/// The geometric growth curve allows the cost of such latency spikes to
+/// get amortized across repeated invocations, bringing the average cost back
+/// to O(1); but the spikes make this construct less suitable for use cases that
+/// expect predictable, consistent performance on every operation.
+///
+/// Implicit growth also makes it more difficult to predict/analyze the amount
+/// of memory an algorithm would need. Developers targeting environments with
+/// stringent limits on heap allocations may prefer to avoid using dynamically
+/// resizing container types as a matter of policy. The type `RigidArray` provides
+/// a fixed-capacity array variant that caters specifically for these use cases,
+/// trading ease-of-use for more consistent/predictable execution.
+/// For copyable elements, the copy-on-write `Array` type is an
+/// even more convenient and expressive choice.
+@available(SwiftStdlib 6.4, *)
+@frozen
+public struct UniqueArray<Element: ~Copyable>: ~Copyable {
+  @usableFromInline
+  internal var _storage: _RigidArray<Element>
+
+  @_alwaysEmitIntoClient
+  internal init(_storage: consuming _RigidArray<Element>) {
+    self._storage = _storage
+  }
+}
+
+@available(SwiftStdlib 6.4, *)
+extension UniqueArray: Sendable where Element: Sendable & ~Copyable {}
+
+@available(SwiftStdlib 6.4, *)
+extension UniqueArray where Element: ~Copyable {
+  /// The maximum number of elements this array can hold without having to
+  /// reallocate its storage.
+  ///
+  /// - Complexity: O(1)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  @_transparent
+  public var capacity: Int {
+    _assumeNonNegative(_storage.capacity)
+  }
+
+  /// The number of additional elements that can be added to this array without
+  /// reallocating its storage.
+  ///
+  /// - Complexity: O(1)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  @_transparent
+  public var freeCapacity: Int {
+    _assumeNonNegative(_storage.capacity &- _storage.count)
+  }
+}
+
+@available(SwiftStdlib 6.4, *)
+extension UniqueArray where Element: ~Copyable {
+  /// A span over the elements of this array, providing direct read-only access.
+  ///
+  /// - Complexity: O(1)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  public var span: Span<Element> {
+    @_lifetime(borrow self)
+    @_transparent
+    get {
+      _storage.span
+    }
+  }
+
+  /// A mutable span over the elements of this array, providing direct
+  /// mutating access.
+  ///
+  /// - Complexity: O(1)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  public var mutableSpan: MutableSpan<Element> {
+    @_lifetime(&self)
+    @_transparent
+    mutating get {
+      _storage.mutableSpan
+    }
+  }
+}
+
+@available(SwiftStdlib 6.4, *)
+extension UniqueArray where Element: ~Copyable {
+  /// Arbitrarily edit the storage underlying this array by invoking a
+  /// user-supplied closure with a mutable `OutputSpan` view over it.
+  /// This method calls its function argument at most once, allowing it to
+  /// arbitrarily modify the contents of the output span it is given.
+  /// The argument is free to add, remove or reorder any items; however,
+  /// it is not allowed to replace the span or change its capacity.
+  ///
+  /// When the function argument finishes (whether by returning or throwing an
+  /// error) the rigid array instance is updated to match the final contents of
+  /// the output span.
+  ///
+  /// - Parameter body: A function that edits the contents of this array through
+  ///    an `OutputSpan` argument. This method invokes this function
+  ///    at most once.
+  /// - Returns: This method returns the result of its function argument.
+  /// - Complexity: Adds O(1) overhead to the complexity of the function
+  ///    argument.
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  @_transparent
+  public mutating func edit<E: Error, R: ~Copyable>(
+    _ body: (inout OutputSpan<Element>) throws(E) -> R
+  ) throws(E) -> R {
+    try _storage.edit(body)
+  }
+}
+
+@_alwaysEmitIntoClient
+@_transparent
+internal func _growUniqueArrayCapacity(_ capacity: Int) -> Int {
+  // A growth factor of 1.5 seems like a reasonable compromise between
+  // over-allocating memory and wasting cycles on repeatedly resizing storage.
+  let c = (3 &* UInt(bitPattern: capacity) &+ 1) / 2
+  return Int(bitPattern: c)
+}
+
+@available(SwiftStdlib 6.4, *)
+extension UniqueArray where Element: ~Copyable {
+  /// Grow or shrink the capacity of a unique array instance without discarding
+  /// its contents.
+  ///
+  /// This operation replaces the array's storage buffer with a newly allocated
+  /// buffer of the specified capacity, moving all existing elements
+  /// to its new storage. The old storage is then deallocated.
+  ///
+  /// - Parameter newCapacity: The desired new capacity. `newCapacity` must be
+  ///    greater than or equal to the current count.
+  ///
+  /// - Complexity: O(`count`)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  public mutating func reallocate(capacity: Int) {
+    _storage.reallocate(capacity: capacity)
+  }
+
+  /// Ensure that the array has capacity to store the specified number of
+  /// elements, by growing its storage buffer if necessary.
+  ///
+  /// If `capacity < n`, then this operation reallocates the unique array's
+  /// storage to grow it; on return, the array's capacity becomes `n`.
+  /// Otherwise the array is left as is.
+  ///
+  /// - Complexity: O(`count`)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  public mutating func reserveCapacity(_ n: Int) {
+    _storage.reserveCapacity(n)
+  }
+
+  @_alwaysEmitIntoClient
+  @_transparent
+  internal mutating func _ensureFreeCapacity(_ freeCapacity: Int) {
+    guard _storage.freeCapacity < freeCapacity else { return }
+    _ensureFreeCapacitySlow(freeCapacity)
+  }
+
+  @_alwaysEmitIntoClient
+  @_transparent
+  internal func _grow(freeCapacity: Int) -> Int {
+    Swift.max(
+      count &+ freeCapacity,
+      _growUniqueArrayCapacity(capacity))
+  }
+
+  @_alwaysEmitIntoClient
+  internal mutating func _ensureFreeCapacitySlow(_ freeCapacity: Int) {
+    let newCapacity = _grow(freeCapacity: freeCapacity)
+    reallocate(capacity: newCapacity)
+  }
+}
+
+@available(SwiftStdlib 6.4, *)
+extension UniqueArray {
+  /// Copy the contents of this array into a newly allocated unique array
+  /// instance with just enough capacity to hold all its elements.
+  ///
+  /// - Complexity: O(`count`)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  public func clone() -> Self {
+    UniqueArray(consuming: _storage.clone())
+  }
+  
+  /// Copy the contents of this array into a newly allocated unique array
+  /// instance with the specified capacity.
+  ///
+  /// - Parameter capacity: The desired capacity of the resulting unique array.
+  ///    `capacity` must be greater than or equal to `count`.
+  ///
+  /// - Complexity: O(`count`)
+  @available(SwiftStdlib 6.4, *)
+  @_alwaysEmitIntoClient
+  public func clone(capacity: Int) -> Self {
+    UniqueArray(consuming: _storage.clone(capacity: capacity))
+  }
+}

--- a/stdlib/public/core/UniqueArray/UniqueArray.swift
+++ b/stdlib/public/core/UniqueArray/UniqueArray.swift
@@ -160,8 +160,8 @@ extension UniqueArray where Element: ~Copyable {
   /// - Complexity: O(`count`)
   @available(SwiftStdlib 6.4, *)
   @_alwaysEmitIntoClient
-  public mutating func reallocate(capacity: Int) {
-    _storage.reallocate(capacity: capacity)
+  public mutating func setCapacity(_ newCapacity: Int) {
+    _storage.setCapacity(newCapacity)
   }
 
   /// Ensure that the array has capacity to store the specified number of
@@ -196,7 +196,7 @@ extension UniqueArray where Element: ~Copyable {
   @_alwaysEmitIntoClient
   internal mutating func _ensureFreeCapacitySlow(_ freeCapacity: Int) {
     let newCapacity = _grow(freeCapacity: freeCapacity)
-    reallocate(capacity: newCapacity)
+    setCapacity(newCapacity)
   }
 }
 

--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -572,7 +572,88 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
   public func extracting(_ bounds: UnboundedRange) -> Self {
     unsafe self
   }
+
+  @_alwaysEmitIntoClient
+  internal func _extracting(first maxLength: Int) -> Self {
+    _precondition(maxLength >= 0, "Cannot have a prefix of negative length")
+    let newCount = Swift.min(maxLength, count)
+    return unsafe Self(start: baseAddress, count: newCount)
+  }
+
+  // Note: This is public because 'libCompatibilitySpan' builds the span sources
+  // as a separate module, so it doesn't have access to 'internal' stdlib API.
+  @_alwaysEmitIntoClient
+  public func _extracting(uncheckedFrom start: Int, to end: Int) -> Self {
+    guard let base = self.baseAddress else {
+      return Self(_empty: ())
+    }
+    return unsafe Self(start: base + start, count: end &- start)
+  }
 }
+
+%if Mutable:
+extension UnsafeMutableBufferPointer where Element: Copyable {
+  /// Initialize slots at the start of this buffer by copying data from `source`.
+  ///
+  /// If `Element` is not bitwise copyable, then the memory region addressed by `self` must be
+  /// entirely uninitialized, while `source` must be fully initialized.
+  ///
+  /// The `source` buffer must fit entirely in `self`.
+  ///
+  /// - Returns: The index after the last item that was initialized in this buffer.
+  @_alwaysEmitIntoClient
+  internal func _initializePrefix(
+    copying source: UnsafeBufferPointer<Element>
+  ) -> Int {
+    if source.isEmpty { return 0 }
+    _precondition(source.count <= self.count)
+    unsafe self.baseAddress._unsafelyUnwrappedUnchecked.initialize(
+      from: source.baseAddress._unsafelyUnwrappedUnchecked,
+      count: source.count
+    )
+    return source.count
+  }
+
+  @_alwaysEmitIntoClient
+  internal func _initializeAll(fromContentsOf source: Self) {
+    let i = unsafe self.initialize(fromContentsOf: source)
+    _internalInvariant(i == self.endIndex)
+  }
+
+  // Note: This is public because 'libCompatibilitySpan' builds the span sources
+  // as a separate module, so it doesn't have access to 'internal' stdlib API.
+  @_alwaysEmitIntoClient
+  public func _initializeAll(
+    fromContentsOf source: UnsafeBufferPointer<Element>
+  ) {
+    let i = unsafe self.initialize(fromContentsOf: source)
+    _internalInvariant(i == self.endIndex)
+  }
+}
+
+extension UnsafeMutableBufferPointer where Element: ~Copyable {
+  @_alwaysEmitIntoClient
+  internal func _moveInitializePrefix(
+    from source: UnsafeMutableBufferPointer<Element>
+  ) -> Int {
+    if source.isEmpty { return 0 }
+    _debugPrecondition(source.count <= self.count)
+    unsafe self.baseAddress._unsafelyUnwrappedUnchecked.moveInitialize(
+      from: source.baseAddress._unsafelyUnwrappedUnchecked,
+      count: source.count
+    )
+    return source.count
+  }
+
+  // Note: This is public because 'libCompatibilitySpan' builds the span sources
+  // as a separate module, so it doesn't have access to 'internal' stdlib API.
+  @_alwaysEmitIntoClient
+  public func _moveInitializeAll(fromContentsOf source: Self) {
+    let i = unsafe self.moveInitialize(fromContentsOf: source)
+    _internalInvariant(i == self.endIndex)
+  }
+}
+%end
 
 @available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)

--- a/test/abi/macOS/arm64/stdlib.swift
+++ b/test/abi/macOS/arm64/stdlib.swift
@@ -1307,12 +1307,6 @@ Added: _$ss9UniqueBoxVMn
 // UniqueBox.pointer getter
 Added: _$ss9UniqueBoxVsRi_zrlE7pointerSpyxGvg
 
-// Cross-encoding strcmp for Foundation
-Added: __swift_unicodeBuffersEqual_nonNormalizing
-
-// Debug variable for metadata allocator back pointer
-Added: __swift_debug_allocationPoolBackPointerOffset
-
 // _RigidArray
 Added: _$ss11_RigidArrayVMa
 Added: _$ss11_RigidArrayVMn

--- a/test/abi/macOS/arm64/stdlib.swift
+++ b/test/abi/macOS/arm64/stdlib.swift
@@ -1307,3 +1307,33 @@ Added: _$ss9UniqueBoxVMn
 // UniqueBox.pointer getter
 Added: _$ss9UniqueBoxVsRi_zrlE7pointerSpyxGvg
 
+// Cross-encoding strcmp for Foundation
+Added: __swift_unicodeBuffersEqual_nonNormalizing
+
+// Debug variable for metadata allocator back pointer
+Added: __swift_debug_allocationPoolBackPointerOffset
+
+// _RigidArray
+Added: _$ss11_RigidArrayVMa
+Added: _$ss11_RigidArrayVMn
+Added: _$ss11_RigidArrayVsRi_zrlE6_countSivM
+Added: _$ss11_RigidArrayVsRi_zrlE6_countSivg
+Added: _$ss11_RigidArrayVsRi_zrlE6_countSivs
+Added: _$ss11_RigidArrayVsRi_zrlE8_storageSryxGvM
+Added: _$ss11_RigidArrayVsRi_zrlE8_storageSryxGvg
+Added: _$ss11_RigidArrayVsRi_zrlE8_storageSryxGvs
+Added: _$ss11_RigidArrayVsSHRzRi_zrlE9hashValueSivg
+Added: _$ss11_RigidArrayVyxGSHsSHRzRi_zrlMc
+Added: _$ss11_RigidArrayVyxGSQsSQRzRi_zrlMc
+
+// UniqueArray
+Added: _$ss11UniqueArrayVMa
+Added: _$ss11UniqueArrayVMn
+Added: _$ss11UniqueArrayVsRi_zrlE8_storages06_RigidB0VyxGvM
+Added: _$ss11UniqueArrayVsRi_zrlE8_storages06_RigidB0VyxGvr
+Added: _$ss11UniqueArrayVsRi_zrlE8_storages06_RigidB0VyxGvs
+Added: _$ss11UniqueArrayVsSHRzRi_zrlE9hashValueSivg
+Added: _$ss11UniqueArrayVyxGSHsSHRzRi_zrlMc
+Added: _$ss11UniqueArrayVyxGSQsSQRzRi_zrlMc
+Added: _$ss11UniqueArrayVsRi_zrlE11descriptionSSvg
+Added: _$ss11UniqueArrayVsRi_zrlE16debugDescriptionSSvg

--- a/test/abi/macOS/x86_64/stdlib.swift
+++ b/test/abi/macOS/x86_64/stdlib.swift
@@ -1303,12 +1303,6 @@ Added: _$ss9UniqueBoxVMn
 // UniqueBox.pointer getter
 Added: _$ss9UniqueBoxVsRi_zrlE7pointerSpyxGvg
 
-// Cross-encoding strcmp for Foundation
-Added: __swift_unicodeBuffersEqual_nonNormalizing
-
-// Debug variable for metadata allocator back pointer
-Added: __swift_debug_allocationPoolBackPointerOffset
-
 // _RigidArray
 Added: _$ss11_RigidArrayVMa
 Added: _$ss11_RigidArrayVMn

--- a/test/abi/macOS/x86_64/stdlib.swift
+++ b/test/abi/macOS/x86_64/stdlib.swift
@@ -1303,3 +1303,33 @@ Added: _$ss9UniqueBoxVMn
 // UniqueBox.pointer getter
 Added: _$ss9UniqueBoxVsRi_zrlE7pointerSpyxGvg
 
+// Cross-encoding strcmp for Foundation
+Added: __swift_unicodeBuffersEqual_nonNormalizing
+
+// Debug variable for metadata allocator back pointer
+Added: __swift_debug_allocationPoolBackPointerOffset
+
+// _RigidArray
+Added: _$ss11_RigidArrayVMa
+Added: _$ss11_RigidArrayVMn
+Added: _$ss11_RigidArrayVsRi_zrlE6_countSivM
+Added: _$ss11_RigidArrayVsRi_zrlE6_countSivg
+Added: _$ss11_RigidArrayVsRi_zrlE6_countSivs
+Added: _$ss11_RigidArrayVsRi_zrlE8_storageSryxGvM
+Added: _$ss11_RigidArrayVsRi_zrlE8_storageSryxGvg
+Added: _$ss11_RigidArrayVsRi_zrlE8_storageSryxGvs
+Added: _$ss11_RigidArrayVsSHRzRi_zrlE9hashValueSivg
+Added: _$ss11_RigidArrayVyxGSHsSHRzRi_zrlMc
+Added: _$ss11_RigidArrayVyxGSQsSQRzRi_zrlMc
+
+// UniqueArray
+Added: _$ss11UniqueArrayVMa
+Added: _$ss11UniqueArrayVMn
+Added: _$ss11UniqueArrayVsRi_zrlE8_storages06_RigidB0VyxGvM
+Added: _$ss11UniqueArrayVsRi_zrlE8_storages06_RigidB0VyxGvr
+Added: _$ss11UniqueArrayVsRi_zrlE8_storages06_RigidB0VyxGvs
+Added: _$ss11UniqueArrayVsSHRzRi_zrlE9hashValueSivg
+Added: _$ss11UniqueArrayVyxGSHsSHRzRi_zrlMc
+Added: _$ss11UniqueArrayVyxGSQsSQRzRi_zrlMc
+Added: _$ss11UniqueArrayVsRi_zrlE11descriptionSSvg
+Added: _$ss11UniqueArrayVsRi_zrlE16debugDescriptionSSvg


### PR DESCRIPTION
- **Explanation**: Implements the recently accepted `UniqueArray` type in [SE-0527](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0527-rigidarray-uniquearray.md) in the standard library.

- **Scope**: This PR adds new API and ABI to the standard library with the `UniqueArray` type.

- **Issues**: rdar://162788483

- **Original PRs**: https://github.com/swiftlang/swift/pull/89698 and https://github.com/swiftlang/swift/pull/89840

- **Risk**: Low. While this does add new API surface to the standard library, we've long had the shadowing rules in the compiler that prefer non-standard library API. Existing source that uses the `UniqueArray` name will continue to work as normal.

- **Testing**: [swift-collections](https://github.com/apple/swift-collections) is currently testing this type. Once we bring over all the test facilities to the standard library test suite, we will test it here as well.

- **Reviewers**: @airspeedswift 


