### PR TITLE
[Dependency Scanning] Resolve minor scanner issues

### DIFF
--- a/lib/DependencyScan/DependencyScanningTool.cpp
+++ b/lib/DependencyScan/DependencyScanningTool.cpp
@@ -260,6 +260,13 @@ static swiftscan_dependency_graph_t generateHollowDiagnosticOutput(
   hollowImportInfoSet->imports = nullptr;
   hollowMainModuleInfo->imports = hollowImportInfoSet;
 
+  // Empty Optional Import set
+  swiftscan_import_info_set_t *hollowOptionalImportInfoSet =
+      new swiftscan_import_info_set_t;
+  hollowOptionalImportInfoSet->count = 0;
+  hollowOptionalImportInfoSet->imports = nullptr;
+  hollowMainModuleInfo->optional_imports = hollowOptionalImportInfoSet;
+
   // Default library level
   hollowMainModuleInfo->library_level = SWIFTSCAN_LIBRARY_LEVEL_OTHER;
 

--- a/lib/DependencyScan/ModuleDependencyCacheSerialization.cpp
+++ b/lib/DependencyScan/ModuleDependencyCacheSerialization.cpp
@@ -1017,22 +1017,22 @@ ModuleDependenciesCacheDeserializer::getModuleDependencyIDArray(unsigned n) {
     static const std::string clangPrefix("clang");
     std::vector<ModuleDependencyID> result;
     for (const auto &encodedIdentifierString : *encodedIdentifierStringArray) {
+      StringRef encoded(encodedIdentifierString);
       ModuleDependencyID id;
-      if (!encodedIdentifierString.compare(0, textualPrefix.size(),
-                                           textualPrefix)) {
-        auto moduleName =
-            encodedIdentifierString.substr(textualPrefix.size() + 1);
-        id = {moduleName, ModuleDependencyKind::SwiftInterface};
-      } else if (!encodedIdentifierString.compare(0, binaryPrefix.size(),
-                                                  binaryPrefix)) {
-        auto moduleName =
-            encodedIdentifierString.substr(binaryPrefix.size() + 1);
-        id = {moduleName, ModuleDependencyKind::SwiftBinary};
-      } else {
-        auto moduleName =
-            encodedIdentifierString.substr(clangPrefix.size() + 1);
-        id = {moduleName, ModuleDependencyKind::Clang};
-      }
+      if (encoded.starts_with(textualPrefix) &&
+          encoded.size() > textualPrefix.size())
+        id = {encoded.substr(textualPrefix.size() + 1).str(),
+              ModuleDependencyKind::SwiftInterface};
+      else if (encoded.starts_with(binaryPrefix) &&
+               encoded.size() > binaryPrefix.size())
+        id = {encoded.substr(binaryPrefix.size() + 1).str(),
+              ModuleDependencyKind::SwiftBinary};
+      else if (encoded.starts_with(clangPrefix) &&
+               encoded.size() > clangPrefix.size())
+        id = {encoded.substr(clangPrefix.size() + 1).str(),
+              ModuleDependencyKind::Clang};
+      else
+        return std::nullopt;
       result.push_back(id);
     }
     return result;

--- a/lib/DependencyScan/ModuleDependencyCacheSerialization.cpp
+++ b/lib/DependencyScan/ModuleDependencyCacheSerialization.cpp
@@ -204,9 +204,13 @@ bool ModuleDependenciesCacheDeserializer::readSerializationTime(llvm::sys::TimeP
   
   TimeLayout::readRecord(Scratch);
   std::string serializedTimeStamp = BlobData.str();
-  
+
+  TimeLayout::readRecord(Scratch);
+  long long timeStampValue;
+  if (BlobData.getAsInteger(/*Radix=*/10, timeStampValue))
+    return true; // malformed timestamp -> treat as deserialization failure
   SerializationTimeStamp =
-    llvm::sys::TimePoint<>(llvm::sys::TimePoint<>::duration(std::stoll(serializedTimeStamp)));
+      llvm::sys::TimePoint<>(llvm::sys::TimePoint<>::duration(timeStampValue));
   return SerializationTimeStamp == llvm::sys::TimePoint<>();
 }
 

--- a/lib/DependencyScan/ModuleDependencyCacheSerialization.cpp
+++ b/lib/DependencyScan/ModuleDependencyCacheSerialization.cpp
@@ -678,7 +678,7 @@ bool ModuleDependenciesCacheDeserializer::readGraph(
 
       // Add dependency only imports.
       auto depOnlyImports = getStringArray(dependencyOnlyImportsID);
-      if (!dependencyOnlyImportsID)
+      if (!depOnlyImports)
         llvm::report_fatal_error("Bad dependency only imports");
       for (const auto &mod : *depOnlyImports)
         moduleDep.addDependencyOnlyImport(mod);

--- a/lib/DependencyScan/ModuleDependencyScanner.cpp
+++ b/lib/DependencyScan/ModuleDependencyScanner.cpp
@@ -2546,7 +2546,7 @@ ModuleDependencyScanner::attemptToFindResolvingSerializedSearchPath(
                   [this](const auto &cd, auto mok) -> std::string {
                     return clangModuleOutputPathLookup(cd, mok);
                   }, {});
-          if (clangResult)
+          if (clangResult && !clangResult->ModuleGraph.empty())
             return std::make_pair(
                 binaryDepID, clangResult->ModuleGraph[0].ClangModuleMapFile);
           return std::nullopt;

--- a/lib/DependencyScan/ModuleDependencyScanner.cpp
+++ b/lib/DependencyScan/ModuleDependencyScanner.cpp
@@ -112,18 +112,25 @@ static bool isSwiftDependencyKind(ModuleDependencyKind Kind) {
 static std::string
 computeClangWorkingDirectory(const std::vector<std::string> &commandLineArgs,
                              const ASTContext &ctx) {
+  auto currentWorkingDirectory = [&ctx]() -> std::string {
+    if (auto cwd =
+            ctx.SourceMgr.getFileSystem()->getCurrentWorkingDirectory())
+      return *cwd;
+    ctx.Diags.diagnose(SourceLoc(), diag::clang_dependency_scan_error,
+                       "Could not determine current working directory");
+    return std::string();
+  };
+
   std::string workingDir;
   auto clangWorkingDirPos = std::find(
       commandLineArgs.rbegin(), commandLineArgs.rend(), "-working-directory");
   if (clangWorkingDirPos == commandLineArgs.rend())
-    workingDir =
-        ctx.SourceMgr.getFileSystem()->getCurrentWorkingDirectory().get();
+    workingDir = currentWorkingDirectory();
   else {
     if (clangWorkingDirPos - 1 == commandLineArgs.rend()) {
       ctx.Diags.diagnose(SourceLoc(), diag::clang_dependency_scan_error,
                          "Missing '-working-directory' argument");
-      workingDir =
-          ctx.SourceMgr.getFileSystem()->getCurrentWorkingDirectory().get();
+      workingDir = currentWorkingDirectory();
     } else
       workingDir = *(clangWorkingDirPos - 1);
   }

--- a/lib/Tooling/libSwiftScan/libSwiftScan.cpp
+++ b/lib/Tooling/libSwiftScan/libSwiftScan.cpp
@@ -88,11 +88,18 @@ void swiftscan_dependency_info_details_dispose(
         details_impl->swift_binary_details.swift_overlay_module_dependencies);
       swiftscan_string_dispose(
         details_impl->swift_binary_details.header_dependency);
-    swiftscan_string_dispose(
-        details_impl->swift_binary_details.module_cache_key);
-    swiftscan_string_dispose(
-        details_impl->swift_binary_details.user_module_version);
-    break;
+      swiftscan_string_set_dispose(
+          details_impl->swift_binary_details
+              .header_dependencies_module_dependnecies);
+      swiftscan_string_set_dispose(
+          details_impl->swift_binary_details.header_dependencies_source_files);
+      swiftscan_macro_dependency_dispose(
+          details_impl->swift_binary_details.macro_dependencies);
+      swiftscan_string_dispose(
+          details_impl->swift_binary_details.module_cache_key);
+      swiftscan_string_dispose(
+          details_impl->swift_binary_details.user_module_version);
+      break;
   case SWIFTSCAN_DEPENDENCY_INFO_CLANG:
     swiftscan_string_dispose(details_impl->clang_details.module_map_path);
     swiftscan_string_dispose(details_impl->clang_details.context_hash);

--- a/lib/Tooling/libSwiftScan/libSwiftScan.cpp
+++ b/lib/Tooling/libSwiftScan/libSwiftScan.cpp
@@ -104,6 +104,8 @@ void swiftscan_dependency_info_details_dispose(
 }
 
 void swiftscan_link_library_set_dispose(swiftscan_link_library_set_t *set) {
+  if (!set)
+    return;
   for (size_t i = 0; i < set->count; ++i) {
     auto info = set->link_libraries[i];
     swiftscan_string_dispose(info->name);
@@ -113,12 +115,38 @@ void swiftscan_link_library_set_dispose(swiftscan_link_library_set_t *set) {
   delete set;
 }
 
+void swiftscan_source_location_set_dispose(
+    swiftscan_source_location_set_t *set) {
+  if (!set)
+    return;
+  for (size_t i = 0; i < set->count; ++i) {
+    swiftscan_string_dispose(set->source_locations[i]->buffer_identifier);
+    delete set->source_locations[i];
+  }
+  delete[] set->source_locations;
+  delete set;
+}
+
+void swiftscan_import_info_set_dispose(swiftscan_import_info_set_t *set) {
+  if (!set)
+    return;
+  for (size_t i = 0; i < set->count; ++i) {
+    swiftscan_string_dispose(set->imports[i]->import_identifier);
+    swiftscan_source_location_set_dispose(set->imports[i]->source_locations);
+    delete set->imports[i];
+  }
+  delete[] set->imports;
+  delete set;
+}
+
 void swiftscan_dependency_info_dispose(swiftscan_dependency_info_t info) {
   swiftscan_string_dispose(info->module_name);
   swiftscan_string_dispose(info->module_path);
   swiftscan_string_set_dispose(info->source_files);
   swiftscan_string_set_dispose(info->direct_dependencies);
   swiftscan_link_library_set_dispose(info->link_libraries);
+  swiftscan_import_info_set_dispose(info->imports);
+  swiftscan_import_info_set_dispose(info->optional_imports);
   swiftscan_dependency_info_details_dispose(info->details);
   delete info;
 }


### PR DESCRIPTION
- [Add missing disposal mechanisms for in-memory graph import sets](https://github.com/swiftlang/swift/pull/89950/changes/ac63917501e4a057bf5338d29bf51b74c5223b31)
- [Add missing binary module dependency field disposal actions](https://github.com/swiftlang/swift/pull/89950/changes/c434a89991f8b2f2a8bb8d7942bf8c23180ff57b)
- [Replace throwing int parser with non-throwing equivalent](https://github.com/swiftlang/swift/pull/89950/changes/de19017b277b61d522243c66b50ace581e4d5fc2)
- [Ensure that dependency ID string decode validates string size](https://github.com/swiftlang/swift/pull/89950/changes/8606e090b48683cfa57c816e374e486edb9fcf1d)
- [Fix incorrect null check on dependnecy import deserialization](https://github.com/swiftlang/swift/pull/89950/changes/e3419add217b9f79c287d7b8bf85839cea1f451a)
- [Ensure clang result is non-empty before dereferencing in attemptToFindResolvingSerializedSearchPath](https://github.com/swiftlang/swift/pull/89950/changes/6f395e89ec22b4d718639358346c467e50c2a103)
- [Ensure we check clang-returned working directory before dereferencing](https://github.com/swiftlang/swift/pull/89950/changes/7e3e0be0b6fe53f76655220a99b5e60ff561fa10)