### PR TITLE
AST: remove InFlightSubstitution::withNewOptions

### DIFF
--- a/include/swift/AST/InFlightSubstitution.h
+++ b/include/swift/AST/InFlightSubstitution.h
@@ -122,9 +122,11 @@ public:
     SubstOptions SavedOptions;
 
   public:
-    OptionsAdjustmentScope(InFlightSubstitution &IFS, SubstOptions newOptions)
+    // Save the current substitution options of IFS, and add some extra options.
+    // The original options are restored at the end of the current scope.
+    OptionsAdjustmentScope(InFlightSubstitution &IFS, SubstOptions extraOptions)
       : IFS(IFS), SavedOptions(IFS.Options) {
-      IFS.Options = newOptions;
+      IFS.Options |= extraOptions;
     }
 
     OptionsAdjustmentScope(const OptionsAdjustmentScope &) = delete;

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -115,11 +115,8 @@ struct SubstitutionMapWithLocalArchetypes {
     // prevents this.
     //
     // TODO: Rework handling of pack type level to make this flag unnecessary.
-    auto optionsPreservingPackExpansionLevel =
-        IFS.getOptions() | SubstFlags::PreservePackExpansionLevel;
-    return IFS.withNewOptions(optionsPreservingPackExpansionLevel, [&]() {
-      return ProtocolConformanceRef::forAbstract(origType.subst(IFS), proto);
-    });
+    InFlightSubstitution::OptionsAdjustmentScope saveOptions(IFS, SubstFlags::PreservePackExpansionLevel);
+    return ProtocolConformanceRef::forAbstract(origType.subst(IFS), proto);
   }
 
   void dump(llvm::raw_ostream &out) const {

--- a/lib/SIL/IR/SILTypeSubstitution.cpp
+++ b/lib/SIL/IR/SILTypeSubstitution.cpp
@@ -273,10 +273,8 @@ public:
     // Substitute the underlying conformance of opaque type archetypes if we
     // should look through opaque archetypes.
     if (typeExpansionContext.shouldLookThroughOpaqueTypeArchetypes()) {
-      auto substType = IFS.withNewOptions(
-        SubstFlags::PreservePackExpansionLevel, [&] {
-          return selfType.subst(IFS)->getCanonicalType();
-        });
+      InFlightSubstitution::OptionsAdjustmentScope saveOptions(IFS, SubstFlags::PreservePackExpansionLevel);
+      auto substType = selfType.subst(IFS)->getCanonicalType();
       if (substType->hasOpaqueArchetype()) {
         substConformance = substOpaqueTypesWithUnderlyingTypes(
             substConformance, typeExpansionContext);


### PR DESCRIPTION
Use `InFlightSubstitution::OptionsAdjustmentScope` directly instead, and make its constructor add options, rather than replacing the existing ones.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
