### PR TITLE
[DebugInfo] Fix undef type of async propagated alloc_box debug value

### DIFF
--- a/lib/SILOptimizer/Mandatory/MovedAsyncVarDebugInfoPropagator.cpp
+++ b/lib/SILOptimizer/Mandatory/MovedAsyncVarDebugInfoPropagator.cpp
@@ -95,6 +95,12 @@ cloneDebugValueMakeUndef(DebugVarCarryingInst original, SILBasicBlock *block) {
   SILBuilderWithScope builder(&block->front());
   builder.setCurrentDebugScope(original->getDebugScope());
   auto *undef = SILUndef::get(original.getOperandForDebugValueClone());
+  // Non-undef debug_values on alloc_box are allowed and fixed by IRGen to
+  // refer to the project_box. Undef debug_values, however, should always
+  // have the type of the variable.
+  if (auto *abi = dyn_cast<AllocBoxInst>(*original))
+    undef = SILUndef::get(original->getFunction(),
+                          abi->getAddressType().getObjectType());
   return builder.createDebugValue(original->getLoc(), undef,
                                   *original.getVarInfo(), DontPoisonRefs,
                                   UsesMoveableValueDebugInfo);
@@ -106,6 +112,9 @@ cloneDebugValueMakeUndef(DebugVarCarryingInst original,
   SILBuilderWithScope builder(std::next(insertPt->getIterator()));
   builder.setCurrentDebugScope(original->getDebugScope());
   auto *undef = SILUndef::get(original.getOperandForDebugValueClone());
+  if (auto *abi = dyn_cast<AllocBoxInst>(*original))
+    undef = SILUndef::get(original->getFunction(),
+                          abi->getAddressType().getObjectType());
   return builder.createDebugValue(original->getLoc(), undef,
                                   *original.getVarInfo(), DontPoisonRefs,
                                   UsesMoveableValueDebugInfo);

--- a/test/DebugInfo/async_box_undef_propagation.sil
+++ b/test/DebugInfo/async_box_undef_propagation.sil
@@ -1,0 +1,63 @@
+// RUN: %target-sil-opt -sil-print-types -sil-moved-async-var-dbginfo-propagator -enable-sil-verify-all %s 2>&1 | %FileCheck %s
+
+// Test that when the MovedAsyncVarDbgInfoPropagator creates undef debug_values
+// from an alloc_box at a merge point, the undef uses the variable's type
+// ($Builtin.Int64) rather than the box type (${ var Builtin.Int64 }).
+
+// The verifier would otherwise catch a mismatched variable type.
+
+sil_stage canonical
+
+import Swift
+import Builtin
+
+sil_scope 1 { parent @test_alloc_box_undef : $@convention(thin) @async (Builtin.Int64) -> () }
+
+// CHECK-LABEL: sil @test_alloc_box_undef : $@convention(thin) @async (Builtin.Int64) -> () {
+// CHECK: bb0(
+// CHECK:   [[BOX:%[0-9]+]] = alloc_box
+// CHECK:   hop_to_executor
+// CHECK-NEXT: debug_value [moveable_value_debuginfo] [[BOX]] : ${ var Builtin.Int64 }
+// CHECK:   cond_br undef, [[BB1:bb[0-9]+]], [[BB2:bb[0-9]+]]
+//
+// CHECK: [[BB1]]:
+// CHECK:   debug_value [moveable_value_debuginfo] %0 : $Builtin.Int64
+// CHECK:   hop_to_executor
+// CHECK-NEXT: debug_value [moveable_value_debuginfo] %0 : $Builtin.Int64
+//
+// CHECK: [[BB2]]:
+// CHECK:   hop_to_executor
+// CHECK-NEXT: debug_value [moveable_value_debuginfo] [[BOX]] : ${ var Builtin.Int64 }
+//
+// At the merge, bb2 (alloc_box) is the first predecessor. The alloc_box and
+// debug_value disagree, so the pass creates an undef from the alloc_box.
+// The type must be $Builtin.Int64, NOT ${ var Builtin.Int64 }.
+// CHECK: [[MERGE:bb[0-9]+]]:
+// CHECK-NEXT: debug_value [moveable_value_debuginfo] undef : $Builtin.Int64
+// CHECK: } // end sil function 'test_alloc_box_undef'
+sil @test_alloc_box_undef : $@convention(thin) @async (Builtin.Int64) -> () {
+bb0(%0 : $Builtin.Int64):
+  %1 = alloc_box [moveable_value_debuginfo] ${ var Builtin.Int64 }, var, name "k", loc "test.swift":1:3, scope 1
+  %2 = project_box %1 : ${ var Builtin.Int64 }, 0, scope 1
+  store %0 to %2 : $*Builtin.Int64, scope 1
+
+  %ex = enum $Optional<Builtin.Executor>, #Optional.none!enumelt, scope 1
+  hop_to_executor %ex : $Optional<Builtin.Executor>, scope 1
+
+  cond_br undef, bb1, bb2, scope 1
+
+bb1:
+  // Override variable "k" with a different operand so the merge disagrees.
+  debug_value [moveable_value_debuginfo] %0 : $Builtin.Int64, var, name "k", loc "test.swift":1:3, scope 1
+  hop_to_executor %ex : $Optional<Builtin.Executor>, scope 1
+  br bb3, scope 1
+
+bb2:
+  hop_to_executor %ex : $Optional<Builtin.Executor>, scope 1
+  br bb3, scope 1
+
+bb3:
+  strong_release %1 : ${ var Builtin.Int64 }, scope 1
+  %r = tuple (), scope 1
+  return %r : $(), scope 1
+}


### PR DESCRIPTION
The debug value type chain verifier checks that the type of variables and debug values match. The undef must therefore match the underlying variable type.

This fixes the root cause of compiler crashes in [SwiftPM](https://github.com/swiftlang/swift-package-manager/actions/runs/27420176578/job/81043477227?pr=9957#logs) and [Swift Testing](https://github.com/swiftlang/swift-testing/actions/runs/27439674385/job/81110369616?pr=1752)