### PR TITLE
Adjust to some low-risk upstream LLVM changes

### DIFF
--- a/include/swift/AST/ModuleDependencies.h
+++ b/include/swift/AST/ModuleDependencies.h
@@ -24,9 +24,9 @@
 #include "swift/Basic/LLVM.h"
 #include "swift/Basic/LangOptions.h"
 #include "swift/Serialization/Validation.h"
-#include "clang/Tooling/DependencyScanning/DependencyScanningService.h"
-#include "clang/Tooling/DependencyScanning/DependencyScanningTool.h"
-#include "clang/Tooling/DependencyScanning/ModuleDepCollector.h"
+#include "clang/DependencyScanning/DependencyScanningService.h"
+#include "clang/DependencyScanning/ModuleDepCollector.h"
+#include "clang/Tooling/DependencyScanningTool.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/StringSet.h"
@@ -1057,7 +1057,7 @@ using ModuleDependenciesKindMap =
     std::unordered_map<ModuleDependencyKind, ModuleNameToDependencyMap,
                        ModuleDependencyKindHash>;
 using BridgeClangDependencyCallback = llvm::function_ref<ModuleDependencyInfo(
-    const clang::tooling::dependencies::ModuleDeps &clangModuleDep)>;
+    const clang::dependencies::ModuleDeps &clangModuleDep)>;
 
 // MARK: SwiftDependencyScanningService
 /// A carrier of state shared among possibly multiple invocations of the
@@ -1073,7 +1073,7 @@ class SwiftDependencyScanningService {
   std::optional<llvm::cas::CASConfiguration> CASConfig;
 
   /// The persistent Clang dependency scanner service
-  std::optional<clang::tooling::dependencies::DependencyScanningService>
+  std::optional<clang::dependencies::DependencyScanningService>
       ClangScanningService;
 
   /// Shared state mutual-exclusivity lock
@@ -1094,7 +1094,7 @@ public:
   StringRef save(StringRef str);
 
   /// Get clang scanning service.
-  const clang::tooling::dependencies::DependencyScanningService &
+  const clang::dependencies::DependencyScanningService &
   getClangScanningService() const {
     assert(ClangScanningService);
     return *ClangScanningService;
@@ -1123,7 +1123,7 @@ private:
   /// to discover a Swift module dependency
   llvm::StringSet<> negativeSwiftDependencyCache;
   /// Set containing all of the Clang modules that have already been seen.
-  llvm::DenseSet<clang::tooling::dependencies::ModuleID> alreadySeenClangModules;
+  llvm::DenseSet<clang::dependencies::ModuleID> alreadySeenClangModules;
   /// Name of the module under scan
   std::string mainScanModuleName;
   /// The context hash of the current scanning invocation
@@ -1170,11 +1170,11 @@ public:
   /// (Textual + Binary)
   int numberOfSwiftDependencies() const;
 
-  const llvm::DenseSet<clang::tooling::dependencies::ModuleID> &
+  const llvm::DenseSet<clang::dependencies::ModuleID> &
   getAlreadySeenClangModules() const {
     return alreadySeenClangModules;
   }
-  void addSeenClangModule(clang::tooling::dependencies::ModuleID newModule) {
+  void addSeenClangModule(clang::dependencies::ModuleID newModule) {
     alreadySeenClangModules.insert(newModule);
   }
 
@@ -1255,13 +1255,13 @@ public:
 
   /// Record dependencies for the given collection of Clang modules.
   void recordClangDependencies(
-      const clang::tooling::dependencies::ModuleDepsGraph &dependencies,
+      const clang::dependencies::ModuleDepsGraph &dependencies,
       DiagnosticEngine &diags,
       BridgeClangDependencyCallback bridgeClangModule);
 
   /// Record Clang module dependency.
   void recordClangDependency(
-      const clang::tooling::dependencies::ModuleDeps &dependency,
+      const clang::dependencies::ModuleDeps &dependency,
       DiagnosticEngine &diags,
       BridgeClangDependencyCallback bridgeClangModule);
 

--- a/include/swift/AST/ModuleLoader.h
+++ b/include/swift/AST/ModuleLoader.h
@@ -41,11 +41,11 @@ class OutputBackend;
 
 namespace clang {
 class DependencyCollector;
-namespace tooling {
 namespace dependencies {
 struct ModuleID;
-class DependencyScanningTool;
 }
+namespace tooling {
+class DependencyScanningTool;
 }
 }
 

--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -63,15 +63,13 @@ namespace clang {
   namespace driver {
     class Driver;
   }
-namespace tooling {
 namespace dependencies {
   struct ModuleDeps;
   struct TranslationUnitDeps;
   enum class ModuleOutputKind;
   using ModuleDepsGraph = std::vector<ModuleDeps>;
 }
-}
-}
+} // namespace clang
 
 namespace swift {
 enum class ResultConvention : uint8_t;
@@ -527,7 +525,7 @@ public:
 
   static void getBridgingHeaderOptions(
       const ASTContext &ctx,
-      const clang::tooling::dependencies::TranslationUnitDeps &deps,
+      const clang::dependencies::TranslationUnitDeps &deps,
       std::vector<std::string> &swiftArgs);
 
   clang::TargetInfo &getModuleAvailabilityTarget() const override;

--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -556,7 +556,7 @@ public:
   clang::TargetInfo &getTargetInfo() const;
   clang::CodeGenOptions &getCodeGenOpts() const;
 
-  std::string getClangModuleHash() const;
+  std::string computeClangContextHash() const;
 
   /// Get clang file mapping.
   const ClangInvocationFileMapping &getClangFileMapping() const {

--- a/include/swift/DependencyScan/ModuleDependencyScanner.h
+++ b/include/swift/DependencyScan/ModuleDependencyScanner.h
@@ -16,7 +16,7 @@
 #include "swift/AST/ModuleDependencies.h"
 #include "swift/Frontend/ModuleInterfaceLoader.h"
 #include "swift/Serialization/ScanningLoaders.h"
-#include "clang/Tooling/DependencyScanning/DependencyScanningTool.h"
+#include "clang/Tooling/DependencyScanningTool.h"
 #include "llvm/CAS/CASReference.h"
 #include "llvm/CAS/CASFileSystem.h"
 #include "llvm/Support/ThreadPool.h"
@@ -29,8 +29,8 @@ namespace swift {
 
 /// A callback to lookup module outputs for "-fmodule-file=", "-o" etc.
 using LookupModuleOutputCallback = llvm::function_ref<std::string(
-    const clang::tooling::dependencies::ModuleDeps &,
-    clang::tooling::dependencies::ModuleOutputKind)>;
+    const clang::dependencies::ModuleDeps &,
+    clang::dependencies::ModuleOutputKind)>;
 using RemapPathCallback = llvm::function_ref<std::string(StringRef)>;
 
 /// A map from a module id to a collection of import statement infos.
@@ -147,11 +147,11 @@ private:
   /// by the scanner, as to avoid processing them all over again
   ///
   /// \returns Clang dependency scanner's \c TranslationUnitDeps result
-  std::optional<clang::tooling::dependencies::TranslationUnitDeps>
+  std::optional<clang::dependencies::TranslationUnitDeps>
   scanFilesystemForClangModuleDependency(
       Identifier moduleName,
       LookupModuleOutputCallback lookupModuleCallback,
-      const llvm::DenseSet<clang::tooling::dependencies::ModuleID>
+      const llvm::DenseSet<clang::dependencies::ModuleID>
           &alreadySeenModules);
 
   /// Query dependency information for header dependencies
@@ -172,12 +172,12 @@ private:
   /// by the scanner, as to avoid processing them all over again
   ///
   /// \returns Clang dependency scanner's \c TranslationUnitDeps result
-  std::optional<clang::tooling::dependencies::TranslationUnitDeps>
+  std::optional<clang::dependencies::TranslationUnitDeps>
   scanHeaderDependenciesOfSwiftModule(
       ModuleDependencyID moduleID, std::optional<StringRef> headerPath,
       std::optional<llvm::MemoryBufferRef> sourceBuffer,
       LookupModuleOutputCallback lookupModuleCallback,
-      const llvm::DenseSet<clang::tooling::dependencies::ModuleID>
+      const llvm::DenseSet<clang::dependencies::ModuleID>
          &alreadySeenModules);
 
   /// Query dependency information for a named Swift module
@@ -207,7 +207,7 @@ private:
   // An AST delegate for interface scanning.
   std::unique_ptr<InterfaceSubContextDelegateImpl> scanningASTDelegate;
   // The Clang scanner tool used by this worker.
-  clang::tooling::dependencies::DependencyScanningTool clangScanningTool;
+  clang::tooling::DependencyScanningTool clangScanningTool;
   // Swift and Clang module loaders acting as scanners.
   std::unique_ptr<SwiftModuleScanner> swiftModuleScannerLoader;
 
@@ -384,7 +384,7 @@ private:
   /// to the Swift scanner's `ModuleDependencyInfo`.
   ModuleDependencyInfo
   bridgeClangModuleDependency(
-      const clang::tooling::dependencies::ModuleDeps &clangDependency);
+      const clang::dependencies::ModuleDeps &clangDependency);
 
   /// Perform an operation utilizing one of the Scanning workers
   /// available to this scanner.
@@ -393,8 +393,8 @@ private:
 
   /// Determine cache-relative output path for a given Clang module
   std::string clangModuleOutputPathLookup(
-      const clang::tooling::dependencies::ModuleDeps &clangDep,
-      clang::tooling::dependencies::ModuleOutputKind moduleOutputKind) const;
+      const clang::dependencies::ModuleDeps &clangDep,
+      clang::dependencies::ModuleOutputKind moduleOutputKind) const;
 
   /// Use the scanner's ASTContext to construct an `Identifier`
   /// for a given module name.
@@ -402,7 +402,7 @@ private:
 
 private:
   struct BatchClangModuleLookupResult {
-    llvm::StringMap<clang::tooling::dependencies::ModuleDeps>
+    llvm::StringMap<clang::dependencies::ModuleDeps>
         discoveredDependencyInfos;
     llvm::StringMap<std::vector<std::string>> visibleModules;
   };

--- a/lib/AST/ModuleDependencies.cpp
+++ b/lib/AST/ModuleDependencies.cpp
@@ -538,8 +538,8 @@ void ModuleDependencyInfo::setOutputPathAndHash(StringRef outputPath,
 SwiftDependencyScanningService::SwiftDependencyScanningService()
     : Alloc(), Saver(Alloc) {
   ClangScanningService.emplace(
-      clang::tooling::dependencies::ScanningMode::DependencyDirectivesScan,
-      clang::tooling::dependencies::ScanningOutputFormat::Full,
+      clang::dependencies::ScanningMode::DependencyDirectivesScan,
+      clang::dependencies::ScanningOutputFormat::Full,
       clang::CASOptions(),
       /* CAS (llvm::cas::ObjectStore) */ nullptr,
       /* Cache (llvm::cas::ActionCache) */ nullptr,
@@ -548,7 +548,7 @@ SwiftDependencyScanningService::SwiftDependencyScanningService()
       // the build system to handle the optimization safely.
       // Swift can handle the working directory optimizaiton
       // already so it is safe to turn on all optimizations.
-      clang::tooling::dependencies::ScanningOptimizations::All);
+      clang::dependencies::ScanningOptimizations::All);
 }
 
 bool
@@ -677,14 +677,14 @@ bool SwiftDependencyScanningService::setupCachingDependencyScanningService(
   CASOpts.PluginOptions = CASConfig->PluginOptions;
 
   ClangScanningService.emplace(
-      clang::tooling::dependencies::ScanningMode::DependencyDirectivesScan,
-      clang::tooling::dependencies::ScanningOutputFormat::FullIncludeTree,
+      clang::dependencies::ScanningMode::DependencyDirectivesScan,
+      clang::dependencies::ScanningOutputFormat::FullIncludeTree,
       CASOpts, Instance.getSharedCASInstance(),
       Instance.getSharedCacheInstance(),
       // The current working directory optimization (off by default)
       // should not impact CAS. We set the optization to all to be
       // consistent with the non-CAS case.
-      clang::tooling::dependencies::ScanningOptimizations::All);
+      clang::dependencies::ScanningOptimizations::All);
 
   return false;
 }
@@ -800,7 +800,7 @@ void ModuleDependenciesCache::recordDependency(
 }
 
 void ModuleDependenciesCache::recordClangDependencies(
-    const clang::tooling::dependencies::ModuleDepsGraph &dependencies,
+    const clang::dependencies::ModuleDepsGraph &dependencies,
     DiagnosticEngine &diags,
     BridgeClangDependencyCallback bridgeClangModule) {
   for (const auto &dep : dependencies)
@@ -808,7 +808,7 @@ void ModuleDependenciesCache::recordClangDependencies(
 }
 
 void ModuleDependenciesCache::recordClangDependency(
-    const clang::tooling::dependencies::ModuleDeps &dependency,
+    const clang::dependencies::ModuleDeps &dependency,
     DiagnosticEngine &diags, BridgeClangDependencyCallback bridgeClangModule) {
   if (!hasClangDependency(dependency.ID.ModuleName)) {
     recordDependency(dependency.ID.ModuleName, bridgeClangModule(dependency));

--- a/lib/ClangImporter/CMakeLists.txt
+++ b/lib/ClangImporter/CMakeLists.txt
@@ -37,6 +37,7 @@ target_link_libraries(swiftClangImporter PRIVATE
   swiftAST
   swiftParse
   clangOptions
+  clangDriver
   clangTooling)
 
 target_link_libraries(swiftClangImporter INTERFACE

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -1102,7 +1102,7 @@ bool ClangImporter::canReadPCH(StringRef PCHFilename) {
   clang::DiagnosticOptions diagOpts;
   clang::CompilerInstance CI(std::move(invocation),
                              Impl.Instance->getPCHContainerOperations(),
-                             &Impl.Instance->getModuleCache());
+                             Impl.Instance->getModuleCachePtr());
   CI.setTarget(&Impl.Instance->getTarget());
   CI.setDiagnostics(&*clang::CompilerInstance::createDiagnostics(
       Impl.Instance->getVirtualFileSystem(), diagOpts));
@@ -2124,7 +2124,7 @@ std::string ClangImporter::getBridgingHeaderContents(
 
   clang::CompilerInstance rewriteInstance(
       std::move(invocation), Impl.Instance->getPCHContainerOperations(),
-      &Impl.Instance->getModuleCache());
+      Impl.Instance->getModuleCachePtr());
 
   if (Impl.CAS)
     rewriteInstance.setCASDatabases(Impl.CAS, Impl.ResultCache);
@@ -2232,7 +2232,7 @@ ClangImporter::cloneCompilerInstanceForPrecompiling() {
 
   auto clonedInstance = std::make_unique<clang::CompilerInstance>(
       std::move(invocation), Impl.Instance->getPCHContainerOperations(),
-      &Impl.Instance->getModuleCache());
+      Impl.Instance->getModuleCachePtr());
 
   if (Impl.CAS)
     clonedInstance->setCASDatabases(Impl.CAS, Impl.ResultCache);

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -73,6 +73,8 @@
 #include "clang/CAS/CASOptions.h"
 #include "clang/CAS/IncludeTree.h"
 #include "clang/CodeGen/ObjectFilePCHContainerWriter.h"
+#include "clang/DependencyScanning/ModuleDepCollector.h"
+#include "clang/DependencyScanning/ScanAndUpdateArgs.h"
 #include "clang/Driver/Compilation.h"
 #include "clang/Driver/CreateInvocationFromArgs.h"
 #include "clang/Driver/Driver.h"
@@ -94,8 +96,6 @@
 #include "clang/Serialization/ASTReader.h"
 #include "clang/Serialization/ASTWriter.h"
 #include "clang/Serialization/ObjectFilePCHContainerReader.h"
-#include "clang/Tooling/DependencyScanning/ModuleDepCollector.h"
-#include "clang/Tooling/DependencyScanning/ScanAndUpdateArgs.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/IntrusiveRefCntPtr.h"
 #include "llvm/ADT/PointerIntPair.h"
@@ -4557,7 +4557,7 @@ ClangImporter::getSwiftExplicitModuleDirectCC1Args() const {
   PPOpts.Includes.clear();
 
   // Clear benign CodeGenOptions.
-  clang::tooling::dependencies::resetBenignCodeGenOptions(
+  clang::dependencies::resetBenignCodeGenOptions(
       clang::frontend::ActionKind::GenerateModule, instance.getLangOpts(),
       instance.getCodeGenOpts());
 
@@ -4568,9 +4568,9 @@ ClangImporter::getSwiftExplicitModuleDirectCC1Args() const {
   if (!Impl.SwiftContext.SearchPathOpts.ScannerPrefixMapper.empty()) {
     // Remap all the paths if requested.
     llvm::PrefixMapper Mapper;
-    clang::tooling::dependencies::DepscanPrefixMapping::configurePrefixMapper(
+    clang::dependencies::DepscanPrefixMapping::configurePrefixMapper(
         Impl.SwiftContext.SearchPathOpts.ScannerPrefixMapper, Mapper);
-    clang::tooling::dependencies::DepscanPrefixMapping::remapInvocationPaths(
+    clang::dependencies::DepscanPrefixMapping::remapInvocationPaths(
         instance, Mapper);
     instance.getFrontendOpts().PathPrefixMappings.clear();
   }

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -1190,7 +1190,7 @@ ClangImporter::getPCHFilename(const ClangImporterOptions &ImporterOptions,
   PCHBasename.append("-swift_");
   PCHBasename.append(SwiftPCHHash);
   PCHBasename.append("-clang_");
-  PCHBasename.append(getClangModuleHash());
+  PCHBasename.append(computeClangContextHash());
   PCHBasename.append(".pch");
   SmallString<256> PCHFilename { PCHOutputDir };
   llvm::sys::path::append(PCHFilename, PCHBasename);
@@ -4498,8 +4498,8 @@ clang::CodeGenOptions &ClangImporter::getCodeGenOpts() const {
   return Impl.getCodeGenOptions();
 }
 
-std::string ClangImporter::getClangModuleHash() const {
-  return Impl.Invocation->getModuleHash(Impl.Instance->getDiagnostics());
+std::string ClangImporter::computeClangContextHash() const {
+  return Impl.Invocation->computeContextHash(Impl.Instance->getDiagnostics());
 }
 
 std::vector<std::string>
@@ -7260,8 +7260,10 @@ std::string
 swift::getModuleCachePathFromClang(const clang::CompilerInstance &Clang) {
   if (!Clang.hasPreprocessor())
     return "";
-  std::string SpecificModuleCachePath =
-      Clang.getPreprocessor().getHeaderSearchInfo().getModuleCachePath().str();
+  std::string SpecificModuleCachePath = Clang.getPreprocessor()
+                                            .getHeaderSearchInfo()
+                                            .getSpecificModuleCachePath()
+                                            .str();
 
   // The returned-from-clang module cache path includes a suffix directory
   // that is specific to the clang version and invocation; we want the

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -74,6 +74,7 @@
 #include "clang/CAS/IncludeTree.h"
 #include "clang/CodeGen/ObjectFilePCHContainerWriter.h"
 #include "clang/Driver/Compilation.h"
+#include "clang/Driver/CreateInvocationFromArgs.h"
 #include "clang/Driver/Driver.h"
 #include "clang/Driver/ToolChain.h"
 #include "clang/Frontend/CompilerInvocation.h"

--- a/lib/ClangImporter/ClangModuleDependencyScanner.cpp
+++ b/lib/ClangImporter/ClangModuleDependencyScanner.cpp
@@ -16,6 +16,7 @@
 #include "ImporterImpl.h"
 #include "swift/AST/DiagnosticsSema.h"
 #include "swift/AST/ModuleDependencies.h"
+#include "swift/AST/SILOptions.h"
 #include "swift/Basic/Assertions.h"
 #include "swift/Basic/CASOptions.h"
 #include "swift/Basic/SourceManager.h"
@@ -99,6 +100,27 @@ void ClangImporter::getBridgingHeaderOptions(
   // Ensure that the resulting PCM build invocation uses Clang frontend
   // directly
   swiftArgs.push_back("-direct-clang-cc1-module-build");
+
+  // `ClangImporter::create` overwrites the
+  // `clang::CodeGenOptions::OptimizationLevel` setting based on
+  // `swift::IRGenOptions::OptMode`. Respect the swift optimisation mode here
+  // so that the bridging header PCH, which is emitted using these options, is
+  // emitted and later consumed using the same clang optimisation level.
+  // Otherwise, the mismatch will be caught and reported as an error when
+  // reading the PCH.
+  switch (ctx.SILOpts.OptMode) {
+  case OptimizationMode::NotSet:
+    break;
+  case OptimizationMode::NoOptimization:
+    swiftArgs.push_back("-Onone");
+    break;
+  case OptimizationMode::ForSpeed:
+    swiftArgs.push_back("-O");
+    break;
+  case OptimizationMode::ForSize:
+    swiftArgs.push_back("-Osize");
+    break;
+  }
 
   // Add args reported by the scanner.
 

--- a/lib/ClangImporter/ClangModuleDependencyScanner.cpp
+++ b/lib/ClangImporter/ClangModuleDependencyScanner.cpp
@@ -22,10 +22,10 @@
 #include "swift/ClangImporter/ClangImporter.h"
 #include "clang/Basic/Diagnostic.h"
 #include "clang/CAS/CASOptions.h"
+#include "clang/DependencyScanning/DependencyScanningService.h"
 #include "clang/Frontend/CompilerInvocation.h"
 #include "clang/Frontend/FrontendOptions.h"
-#include "clang/Tooling/DependencyScanning/DependencyScanningService.h"
-#include "clang/Tooling/DependencyScanning/DependencyScanningTool.h"
+#include "clang/Tooling/DependencyScanningTool.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/Allocator.h"
 #include "llvm/Support/FileSystem.h"
@@ -36,7 +36,7 @@
 using namespace swift;
 
 using namespace clang::tooling;
-using namespace clang::tooling::dependencies;
+using namespace clang::dependencies;
 
 static void addScannerPrefixMapperInvocationArguments(
     std::vector<std::string> &invocationArgStrs, ASTContext &ctx) {
@@ -83,7 +83,7 @@ std::vector<std::string> ClangImporter::getClangDepScanningInvocationArguments(
 
 void ClangImporter::getBridgingHeaderOptions(
     const ASTContext &ctx,
-    const clang::tooling::dependencies::TranslationUnitDeps &deps,
+    const clang::dependencies::TranslationUnitDeps &deps,
     std::vector<std::string> &swiftArgs) {
   auto addClangArg = [&](Twine arg) {
     swiftArgs.push_back("-Xcc");

--- a/lib/DependencyScan/ModuleDependencyScanner.cpp
+++ b/lib/DependencyScan/ModuleDependencyScanner.cpp
@@ -138,8 +138,8 @@ computeClangWorkingDirectory(const std::vector<std::string> &commandLineArgs,
 }
 
 std::string ModuleDependencyScanner::clangModuleOutputPathLookup(
-    const clang::tooling::dependencies::ModuleDeps &clangDeps,
-    clang::tooling::dependencies::ModuleOutputKind moduleOutputKind) const {
+    const clang::dependencies::ModuleDeps &clangDeps,
+    clang::dependencies::ModuleOutputKind moduleOutputKind) const {
   llvm::SmallString<128> outputPath(ModuleOutputPath);
   if (clangDeps.IsInStableDirectories)
     outputPath = SDKModuleOutputPath;
@@ -159,17 +159,17 @@ std::string ModuleDependencyScanner::clangModuleOutputPathLookup(
   llvm::sys::path::append(outputPath, clangDeps.ID.ModuleName + "-" +
                                           clangDeps.ID.ContextHash);
   switch (moduleOutputKind) {
-  case clang::tooling::dependencies::ModuleOutputKind::ModuleFile:
+  case clang::dependencies::ModuleOutputKind::ModuleFile:
     llvm::sys::path::replace_extension(
         outputPath, getExtension(swift::file_types::TY_ClangModuleFile));
     break;
-  case clang::tooling::dependencies::ModuleOutputKind::DependencyFile:
+  case clang::dependencies::ModuleOutputKind::DependencyFile:
     llvm::sys::path::replace_extension(
         outputPath, getExtension(swift::file_types::TY_Dependencies));
     break;
-  case clang::tooling::dependencies::ModuleOutputKind::DependencyTargets:
+  case clang::dependencies::ModuleOutputKind::DependencyTargets:
     return clangDeps.ID.ModuleName + "-" + clangDeps.ID.ContextHash;
-  case clang::tooling::dependencies::ModuleOutputKind::
+  case clang::dependencies::ModuleOutputKind::
       DiagnosticSerializationFile:
     llvm::sys::path::replace_extension(
         outputPath, getExtension(swift::file_types::TY_SerializedDiagnostics));
@@ -328,10 +328,10 @@ ModuleDependencyScanningWorker::scanFilesystemForSwiftModuleDependency(
                                                      isTestableImport);
 }
 
-std::optional<clang::tooling::dependencies::TranslationUnitDeps>
+std::optional<clang::dependencies::TranslationUnitDeps>
 ModuleDependencyScanningWorker::scanFilesystemForClangModuleDependency(
     Identifier moduleName, LookupModuleOutputCallback lookupModuleOutput,
-    const llvm::DenseSet<clang::tooling::dependencies::ModuleID>
+    const llvm::DenseSet<clang::dependencies::ModuleID>
         &alreadySeenModules) {
   diagnosticReporter.registerNamedClangModuleQuery();
   auto clangModuleDependencies =
@@ -361,17 +361,17 @@ ModuleDependencyScanningWorker::scanFilesystemForClangModuleDependency(
   return clangModuleDependencies.get();
 }
 
-std::optional<clang::tooling::dependencies::TranslationUnitDeps>
+std::optional<clang::dependencies::TranslationUnitDeps>
 ModuleDependencyScanningWorker::scanHeaderDependenciesOfSwiftModule(
     ModuleDependencyID moduleID,
     std::optional<StringRef> headerPath,
     std::optional<llvm::MemoryBufferRef> sourceBuffer,
     LookupModuleOutputCallback lookupModuleOutput,
-    const llvm::DenseSet<clang::tooling::dependencies::ModuleID>
+    const llvm::DenseSet<clang::dependencies::ModuleID>
        &alreadySeenModules) {
   // Scan the specified textual header file and collect its dependencies
   auto scanHeaderDependencies = [&]()
-      -> llvm::Expected<clang::tooling::dependencies::TranslationUnitDeps> {
+      -> llvm::Expected<clang::dependencies::TranslationUnitDeps> {
     auto dependencies = clangScanningTool.getTranslationUnitDependencies(
         inputSpecificClangScannerCommand(clangScanningBaseCommandLineArgs,
                                          headerPath),
@@ -2179,7 +2179,7 @@ LibraryLevel swift::libraryLevelFromPath(StringRef modulePath,
 }
 
 ModuleDependencyInfo ModuleDependencyScanner::bridgeClangModuleDependency(
-    const clang::tooling::dependencies::ModuleDeps &clangModuleDep) {
+    const clang::dependencies::ModuleDeps &clangModuleDep) {
   // File dependencies for this module.
   std::vector<std::string> fileDeps;
   clangModuleDep.forEachFileDep(
@@ -2201,7 +2201,7 @@ ModuleDependencyInfo ModuleDependencyScanner::bridgeClangModuleDependency(
 
   auto pcmPath = clangModuleOutputPathLookup(
       clangModuleDep,
-      clang::tooling::dependencies::ModuleOutputKind::ModuleFile);
+      clang::dependencies::ModuleOutputKind::ModuleFile);
   swiftArgs.push_back("-o");
   swiftArgs.push_back(pcmPath);
 

--- a/lib/IDETool/CMakeLists.txt
+++ b/lib/IDETool/CMakeLists.txt
@@ -13,6 +13,7 @@ target_link_libraries(swiftIDETool PRIVATE
   swiftFrontend
   swiftFrontendTool
   clangAST
+  clangDriver
   clangFrontend)
 
 set_swift_llvm_is_available(swiftIDETool)

--- a/lib/IDETool/CompilerInvocation.cpp
+++ b/lib/IDETool/CompilerInvocation.cpp
@@ -17,6 +17,7 @@
 #include "swift/Frontend/Frontend.h"
 #include "clang/AST/DeclObjC.h"
 #include "clang/Basic/TargetInfo.h"
+#include "clang/Driver/CreateInvocationFromArgs.h"
 #include "clang/Frontend/CompilerInstance.h"
 #include "clang/Frontend/PCHContainerOperations.h"
 #include "clang/Frontend/TextDiagnosticBuffer.h"


### PR DESCRIPTION
Targeting main to minimise the difference between main and rebranch.

Paired with https://github.com/swiftlang/llvm-project/pull/13210.