### PR TITLE
SILMem2Reg: disable optimizing non-copyable types in OSSA

### DIFF
--- a/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
+++ b/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
@@ -2225,6 +2225,12 @@ bool MemoryToRegisters::promoteAllocation(AllocStackInst *alloc,
     return false;
   }
 
+  // SILMem2Reg has a problem with non-copyable types which are empty or only
+  // have trivial fields. It produces ownership errors in OSSA. However,
+  // outside OSSA this is fine.
+  if (f.hasOwnership() && alloc->getType().isMoveOnly())
+    return false;
+
   // Don't handle captured AllocStacks.
   bool inSingleBlock = false;
   if (isCaptured(alloc, &inSingleBlock)) {

--- a/test/SILOptimizer/dead_alloc.swift
+++ b/test/SILOptimizer/dead_alloc.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -O -emit-sil -parse-as-library %s | grep -v debug_value | %FileCheck %s
+// RUN: %target-swift-frontend -O -emit-sil -parse-as-library -sil-verify-all %s | grep -v debug_value | %FileCheck %s
 
 // REQUIRES: swift_stdlib_no_asserts,optimized_stdlib
 // REQUIRES: swift_in_compiler
@@ -56,4 +56,31 @@ public func deadClassInstance() {
 // CHECK-NEXT:  } // end sil function '$s10dead_alloc0A13ManagedBufferyyF'
 public func deadManagedBuffer() -> () {
   _ = ManagedBuffer<Void, Void>.create(minimumCapacity: 1, makingHeaderWith: { _ in () })
+}
+
+// Check that the compiler doesn't crash
+
+struct NC<T: ~Copyable>: ~Copyable {
+  var t: T? = nil
+
+  mutating func take() -> T {
+    let x = consume t
+    self = .init()
+    return x!
+  }
+}
+
+func call<R>(_ c: () -> R) -> R {
+  return c()
+}
+
+public func foo<T>(_ t: consuming T) -> T {
+  var nc = NC(t: t)
+  return call {
+    return nc.take()
+  }
+}
+
+public func test(_ t: ()) -> () {
+  return foo(())
 }

--- a/test/SILOptimizer/mem2reg_ossa.sil
+++ b/test/SILOptimizer/mem2reg_ossa.sil
@@ -63,6 +63,8 @@ struct S2 {
   var t: (J, J)
 }
 
+struct NC: ~Copyable {}
+
 ///////////
 // Tests //
 ///////////
@@ -895,4 +897,19 @@ bb0:
   store %7 to [init] %0
   dealloc_stack %0
   unreachable
+}
+
+// CHECK-LABEL: sil [ossa] @empty_non_copyable :
+// Just check that mem2reg doesn't produce illegal SIL
+// CHECK-LABEL: } // end sil function 'empty_non_copyable'
+sil [ossa] @empty_non_copyable: $@convention(thin) (@owned NC, @owned NC) -> () {
+bb0(%0 : @owned $NC, %1 : @owned $NC):
+  %2 = alloc_stack $NC
+  store %0 to [init] %2
+  store %1 to [init] %2
+  %5 = load [take] %2
+  destroy_value %5
+  dealloc_stack %2
+  %r = tuple ()
+  return %r
 }


### PR DESCRIPTION
SILMem2Reg has a problem with non-copyable types which are empty or only have trivial fields. It produces ownership errors in OSSA. However, outside OSSA this is fine.

Fixes a compiler crash
https://github.com/swiftlang/swift/issues/89533
rdar://178204808
