### PR TITLE
[sil-mode] Add sil-mode-demangle command

### DIFF
--- a/utils/sil-mode.el
+++ b/utils/sil-mode.el
@@ -262,11 +262,23 @@
 
 (unless sil-mode-map
   (setq sil-mode-map (make-sparse-keymap))
+  (define-key sil-mode-map (kbd "C-c C-d") 'sil-mode-demangle)
   (define-key sil-mode-map "\t" 'tab-to-tab-stop)
   (define-key sil-mode-map "\es" 'center-line)
   (define-key sil-mode-map "\eS" 'center-paragraph))
 
 ;;; Helper functions
+
+(defun sil-mode-demangle ()
+  "Demangle the symbol at point, or the region if active."
+  (interactive)
+  (let ((region
+          (if (use-region-p)
+            (car (region-bounds))
+            (bounds-of-thing-at-point 'symbol))))
+    (shell-command-on-region (car region) (cdr region)
+      "swift demangle"
+      "*Swift Demangle*")))
 
 ;; ViewCFG Integration
 ;;


### PR DESCRIPTION
This command is based on shell-command-on-region, which will display the demangled text in the minibuffer, or a dedicated buffer if there is too much for the minibuffer.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
