### PR TITLE
[6.4] SIL: Fix updating borrowed-from instructions for guaranteed phis

### DIFF
--- a/SwiftCompilerSources/Sources/SIL/Utilities/BorrowUtils.swift
+++ b/SwiftCompilerSources/Sources/SIL/Utilities/BorrowUtils.swift
@@ -672,10 +672,19 @@ public func gatherEnclosingValuesFromPredecessors(
   for predecessor in phi.predecessors {
     let incomingOperand = phi.incomingOperand(inPredecessor: predecessor)
 
-    for predEV in incomingOperand.value.getEnclosingValues(context) {
-      let ev = predecessor.getEnclosingValueInSuccessor(ofIncoming: predEV)
-      if alreadyAdded.insert(ev) {
-        enclosingValues.push(ev)
+    if phi.isReborrow {
+      for predEV in incomingOperand.value.getEnclosingValues(context) {
+        let ev = predecessor.getEnclosingValueInSuccessor(ofIncoming: predEV)
+        if alreadyAdded.insert(ev) {
+          enclosingValues.push(ev)
+        }
+      }
+    } else {
+      for predEV in incomingOperand.value.getBorrowIntroducers(context) {
+        let ev = predecessor.getEnclosingValueInSuccessor(ofIncoming: predEV.value)
+        if alreadyAdded.insert(ev) {
+          enclosingValues.push(ev)
+        }
       }
     }
   }

--- a/test/SILOptimizer/borrowed_from_updater.sil
+++ b/test/SILOptimizer/borrowed_from_updater.sil
@@ -26,6 +26,10 @@ class C {
 
 class D : C {}
 
+struct S {
+  var c: C
+}
+
 sil @coro : $@yield_once @convention(thin) () -> @yields @guaranteed C
 
 // The introducer of an introducer is always itself.
@@ -321,3 +325,41 @@ bb3(%7 : @guaranteed $Klass):
   return %t
 }
 
+// CHECK-LABEL: sil [ossa] @forwarding_phi1 :
+// CHECK:       bb1([[PHI:%.*]] : @guaranteed $C):
+// CHECK-NEXT:    = borrowed [[PHI]] : $C from (%1 : $C)
+// CHECK-LABEL: } // end sil function 'forwarding_phi1'
+sil [ossa] @forwarding_phi1 : $@convention(thin) (@owned C) -> @owned C {
+bb0(%0 : @owned $C):
+  specify_test "update_borrowed_from"
+  %1 = begin_borrow %0
+  br bb1(%1)
+
+bb1(%3 : @guaranteed $C):
+  end_borrow %1
+  return %0
+}
+
+// CHECK-LABEL: sil [ossa] @forwarding_phi2 :
+// CHECK:       bb3([[PHI:%.*]] : @guaranteed $C):
+// CHECK-NEXT:    = borrowed [[PHI]] : $C from (%1 : $C)
+// CHECK-LABEL: } // end sil function 'forwarding_phi2'
+sil [ossa] @forwarding_phi2 : $@convention(thin) (@owned C) -> @owned C {
+bb0(%0 : @owned $C):
+  specify_test "update_borrowed_from"
+  %1 = begin_borrow %0
+  cond_br undef, bb1, bb2
+
+bb1:
+  br bb3(%1)
+
+bb2:
+  %10 = struct $S (%1)
+  %11 = struct_extract %10, #S.c
+  br bb3(%11)
+
+bb3(%3 : @guaranteed $C):
+  %4 = borrowed %3 from (%1)
+  end_borrow %1
+  return %0
+}

--- a/test/SILOptimizer/enclosing_def_unit.sil
+++ b/test/SILOptimizer/enclosing_def_unit.sil
@@ -213,9 +213,8 @@ bb3(%9 : @guaranteed $C):
 // CHECK: sil [ossa] @enclosing_def_cycle : $@convention(thin) (@guaranteed C) -> () {
 // CHECK: bb1([[REBORROW:%.*]] : @guaranteed $C,
 // CHECK: } // end sil function 'enclosing_def_cycle'
-// CHECK: Enclosing values for:   %7 = borrowed %6 : $C from (%0 : $C, %1 : $C)
+// CHECK: Enclosing values for:   %7 = borrowed %6 : $C from (%1 : $C)
 // CHECK-NEXT: %1 = begin_borrow %0
-// CHECK-NEXT: %0 = argument of bb0
 // CHECK-NEXT: enclosing_def_cycle: enclosing_values with: %forward
 sil [ossa] @enclosing_def_cycle : $@convention(thin) (@guaranteed C) -> () {
 bb0(%0 : @guaranteed $C):
@@ -225,8 +224,8 @@ bb0(%0 : @guaranteed $C):
   br bb1(%borrow : $C, %first1 : $C)
 
 bb1(%5 : @guaranteed $C, %6 : @guaranteed $C):
-  %forward = borrowed %6 from (%0, %borrow)
-  %reborrow_outer = borrowed %5 from (%0)
+  %forward = borrowed %6 from (%borrow)
+  %reborrow_outer = borrowed %5 from (%borrow)
   specify_test "find_enclosing_defs %forward"
   specify_test "enclosing_values %forward"
   %aggregate2 = struct $PairC(%reborrow_outer : $C, %forward : $C)

--- a/test/SILOptimizer/sil_combine_inst_passes.sil
+++ b/test/SILOptimizer/sil_combine_inst_passes.sil
@@ -167,7 +167,7 @@ bb2:
   br bb3(%1 : $Buffer)
 
 bb3(%9 : @guaranteed $Buffer):
-  %10 = borrowed %9 : $Buffer from (%1 : $Buffer)
+  %10 = borrowed %9 : $Buffer from (%0, %1)
   %r = tuple ()
   return %r : $()
 }

--- a/test/SILOptimizer/simplify_unchecked_switch_enum.sil
+++ b/test/SILOptimizer/simplify_unchecked_switch_enum.sil
@@ -76,7 +76,7 @@ bb2(%4 : @owned $E):
 // CHECK:       bb0(%0 : @guaranteed $String):
 // CHECK-NEXT:    br bb1(%0 : $String)
 // CHECK:       bb1(%2 : @guaranteed $String):
-// CHECK-NEXT:    %3 = borrowed %2 : $String from ()
+// CHECK-NEXT:    %3 = borrowed %2 : $String from (%0 : $String)
 // CHECK-NEXT:    %4 = copy_value %3
 // CHECK-NEXT:    return %4 : $String
 // CHECK-NOT:   bb2
@@ -118,7 +118,7 @@ bb2(%7 : @owned $E):
 // CHECK-NEXT:    end_borrow
 // CHECK-NEXT:    br bb1(%0 : $String)
 // CHECK:       bb1([[A:%.*]] : @guaranteed $String):
-// CHECK-NEXT:    [[B:%.*]] = borrowed [[A]] : $String from ()
+// CHECK-NEXT:    [[B:%.*]] = borrowed [[A]] : $String from (%0 : $String)
 // CHECK-NEXT:    [[C:%.*]] = copy_value [[B]]
 // CHECK-NEXT:    return [[C]] : $String
 // CHECK-NOT:   bb2


### PR DESCRIPTION
* **Explanation**: Fixes a compiler crash in LoopInvariantCodeMotion. The utility to update borrowed-from SIL instructions was wrong if the incoming value of a guaranteed phi is a `begin_borrow`
* **Risk**: Low. It's a small change just fixes this isolated problem
* **Testing**: by lit tests
* **Issue**: rdar://179360684
* **Reviewers**: @elsakeirouz
* **Main branch PR**: https://github.com/swiftlang/swift/pull/89944
