### PR TITLE
[CMake] Remove stray BUILD_WITH_INSTALL_RPATH in swift-plugin-server

### DIFF
--- a/tools/swift-plugin-server/CMakeLists.txt
+++ b/tools/swift-plugin-server/CMakeLists.txt
@@ -30,9 +30,6 @@ if (SWIFT_BUILD_SWIFT_SYNTAX)
     _set_pure_swift_link_flags(SwiftInProcPluginServer "../../")
   endif()
 
-  set_property(TARGET ${name}
-    PROPERTY BUILD_WITH_INSTALL_RPATH YES)
-
   add_dependencies(compiler SwiftInProcPluginServer)
   swift_install_in_component(TARGETS SwiftInProcPluginServer
     ARCHIVE DESTINATION "lib${LLVM_LIBDIR_SUFFIX}/swift/host" COMPONENT compiler


### PR DESCRIPTION
This is unnecessary because `add_pure_swift_host_tool` already sets BUILD_WITH_INSTALL_RPATH. The fact that this line references `${name}` leads me to believe this is left over from a previous refactor.