### PR TITLE
DebugInfo: test "Two variables with different type but same scope" crash

### DIFF
--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -1072,11 +1072,6 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
     if (!Options.SerializeDebugInfoSIL)
      return;
     auto DVI = cast<DebugValueInst>(&SI);
-    // Reconstruction blocks (the `transform { ... }` clause) aren't serialized
-    // yet, so drop any debug_value carrying one rather than emit a corrupted
-    // record whose variable type reverts to the operand type on read.
-    if (DVI->getDebugReconstructionBlock())
-      return;
     unsigned attrs = unsigned(DVI->poisonRefs() & 0x1);
     attrs |= unsigned(DVI->usesMoveableValueDebugInfo()) << 1;
     attrs |= unsigned(DVI->hasTrace()) << 2;

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -1072,6 +1072,11 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
     if (!Options.SerializeDebugInfoSIL)
      return;
     auto DVI = cast<DebugValueInst>(&SI);
+    // Reconstruction blocks (the `transform { ... }` clause) aren't serialized
+    // yet, so drop any debug_value carrying one rather than emit a corrupted
+    // record whose variable type reverts to the operand type on read.
+    if (DVI->getDebugReconstructionBlock())
+      return;
     unsigned attrs = unsigned(DVI->poisonRefs() & 0x1);
     attrs |= unsigned(DVI->usesMoveableValueDebugInfo()) << 1;
     attrs |= unsigned(DVI->hasTrace()) << 2;

--- a/test/embedded/multi-module-debug-scope-crash.swift
+++ b/test/embedded/multi-module-debug-scope-crash.swift
@@ -1,0 +1,31 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -emit-module -o %t/MyModule.swiftmodule %t/MyModule.swift -enable-experimental-feature Embedded -parse-as-library -O
+// RUN: %target-swift-frontend -c -I %t %t/Main.swift -enable-experimental-feature Embedded -O -o /dev/null
+
+// REQUIRES: OS=macosx || OS=linux-gnu || OS=wasip1
+// REQUIRES: swift_feature_Embedded
+
+//--- MyModule.swift
+
+public struct ParseContainerStack {
+    var stack: [Int] = [0]
+    public init() {}
+    public mutating func run() {
+        let i = stack.first
+        if let i {
+            _ = i
+            for _ in 0..<stack.count { }
+        }
+    }
+}
+
+//--- Main.swift
+
+import MyModule
+
+public func test() {
+    var s = ParseContainerStack()
+    s.run()
+}


### PR DESCRIPTION
Add a regression test for a recently fixed compiler crash.

Resolves https://github.com/swiftlang/swift/issues/89962

rdar://179727895