### PR TITLE
[cxx-interop] Prevent upcasting through explicit FRT annotation

### DIFF
--- a/lib/ClangImporter/ClangAnalysis.cpp
+++ b/lib/ClangImporter/ClangAnalysis.cpp
@@ -92,40 +92,13 @@ class ForeignReferenceTypeChecker {
   }
 
   /// Whether \p base is non-null and has an offset of zero from \c checkedDecl.
-  bool atOffsetZero(const clang::CXXRecordDecl *base) const {
+  bool isPresentAndAtOffsetZero(const clang::CXXRecordDecl *base) const {
     ASSERT(checkedDecl);
     if (base == nullptr)
       return false;
     auto &clangCtx = checkedDecl->getASTContext();
     auto &layout = clangCtx.getASTRecordLayout(checkedDecl);
     return layout.getBaseClassOffset(base).isZero();
-  }
-
-  /// Extract the retain and release operation annotations from \p decl.
-  static std::pair<StringRef, StringRef>
-  getRetainReleaseOps(const clang::RecordDecl *decl) {
-    if (!decl->hasAttrs())
-      return {StringRef(), StringRef()};
-
-    StringRef retain{}, release{};
-    for (auto attr : decl->getAttrs()) {
-      auto swiftAttr = dyn_cast<clang::SwiftAttrAttr>(attr);
-      if (!swiftAttr)
-        continue;
-
-      auto attrStr = swiftAttr->getAttribute();
-
-      if (attrStr.consume_front("retain:"))
-        retain = attrStr;
-      else if (attrStr.consume_front("release:"))
-        release = attrStr;
-    }
-    return {retain, release};
-  }
-
-  /// Whether \p x is non-nullopt and matches \p y.
-  static bool opsMatch(StringRef x, StringRef y) {
-    return !x.empty() && x == y;
   }
 
 public:
@@ -142,10 +115,16 @@ public:
     ASSERT(checkedDecl && "ForeignReferenceTypeInfo should only be used once");
     SWIFT_DEFER { checkedDecl = nullptr; };
 
-    bool explicitlyAnnotated = importer::hasImportReferenceAttr(checkedDecl);
-    const clang::CXXRecordDecl *uniqueDirectFRTBase = visitBases(checkedDecl);
+    if (importer::hasImportReferenceAttr(checkedDecl)) {
+      // checkedDecl is explicitly annotated as a foreign reference type.
+      // Do not let it have a primarySuperclass, to prevent upcasting past the
+      // annotation boundary in the class hierarchy.
+      return ForeignReferenceTypeInfo::Shared(checkedDecl,
+                                              /*primarySuperclass=*/nullptr);
+    }
 
-    if (!explicitlyAnnotated && FRTBases.empty()) {
+    const clang::CXXRecordDecl *uniqueDirectFRTBase = visitBases(checkedDecl);
+    if (FRTBases.empty()) {
       // Neither checkedDecl nor any of its base classes are annotated as
       // a reference type, so checkedDecl is a value type.
       ASSERT(uniqueDirectFRTBase == nullptr &&
@@ -155,59 +134,48 @@ public:
 
     // The primary FRT superclass is the unique direct FRT base of checkedDecl,
     // but only if it is at offset 0 (so a pointer bitcast suffices for upcast).
-    auto *primarySuperclass =
-        atOffsetZero(uniqueDirectFRTBase) ? uniqueDirectFRTBase : nullptr;
+    auto *primarySuperclass = isPresentAndAtOffsetZero(uniqueDirectFRTBase)
+                                  ? uniqueDirectFRTBase
+                                  : nullptr;
 
-    if (explicitlyAnnotated && primarySuperclass) {
-      auto [retain, release] = getRetainReleaseOps(checkedDecl);
-      auto [superRetain, superRelease] = getRetainReleaseOps(primarySuperclass);
-      if (!opsMatch(retain, superRetain) || !opsMatch(release, superRelease))
-        primarySuperclass = nullptr;
-    }
+    const clang::CXXRecordDecl *FRTBase = nullptr;
+    bool seenShared = false, seenMultipleShared = false, seenImmortal = false;
 
-    const clang::CXXRecordDecl *FRTBase;
-    if (explicitlyAnnotated) {
-      FRTBase = checkedDecl;
-    } else {
-      ASSERT(!FRTBases.empty() && "if checkedDecl wasn't explicitly annotated,"
-                                  "at least one of its bases should be an FRT");
-      FRTBase = nullptr;
-      bool seenShared = false, seenMultipleShared = false, seenImmortal = false;
-      for (auto *base : FRTBases) {
-        if (importer::hasAnyImmortalAttr(base)) {
-          seenImmortal = true;
-        } else if (!FRTBase) {
-          FRTBase = base;
-          seenShared = true;
-        } else {
-          seenMultipleShared = true;
-        }
-      }
-
-      // If there are no shared references, FRTBase is the first immortal base
-      FRTBase = FRTBase ? FRTBase : FRTBases.front();
-
-      if (seenMultipleShared || (seenShared && seenImmortal)) {
-        // checkedDecl is an invalid FRT, either because it has multiple shared
-        // FRT bases (ambiguous retain/release ops), or because it has mixed
-        // ancestry between shared and immortal bases.
-        if (Impl)
-          Impl->diagnose(HeaderLoc{checkedDecl->getLocation()},
-                         diag::cant_infer_frt_in_cxx_inheritance, checkedDecl);
-
-        // decl inherits from FRT base, so we should treat it as a reference
-        // type, albeit an invalid one (due to ambiguity).
-        //
-        // return ForeignReferenceTypeInfo::Shared(FRTBase, nullptr,
-        //                                         /*isValid=*/false);
-        //
-        // However, to honor the existing behavior, (for now) we will report
-        // that this is an (invalid) value type.
-        return ForeignReferenceTypeInfo::Value(/*isValid=*/false);
+    for (auto *base : FRTBases) {
+      if (importer::hasAnyImmortalAttr(base)) {
+        seenImmortal = true;
+      } else if (!FRTBase) {
+        FRTBase = base;
+        seenShared = true;
+      } else {
+        seenMultipleShared = true;
       }
     }
 
-    ASSERT(FRTBase && "should have encountered FRTBase");
+    // If there are no shared references, FRTBase is the first immortal base.
+    if (!FRTBase) {
+      ASSERT(seenImmortal && "should have encountered immortal FRTBase");
+      FRTBase = FRTBases.front();
+    }
+
+    if (seenMultipleShared || (seenShared && seenImmortal)) {
+      // checkedDecl is an invalid FRT, either because it has multiple shared
+      // FRT bases (ambiguous retain/release ops), or because it has mixed
+      // ancestry between shared and immortal bases.
+      if (Impl)
+        Impl->diagnose(HeaderLoc{checkedDecl->getLocation()},
+                       diag::cant_infer_frt_in_cxx_inheritance, checkedDecl);
+
+      // decl inherits from FRT base, so we should treat it as a reference
+      // type, albeit an invalid one (due to ambiguity).
+      //
+      // return ForeignReferenceTypeInfo::Shared(FRTBase, nullptr,
+      //                                         /*isValid=*/false);
+      //
+      // However, to honor the existing behavior, (for now) we will report
+      // that this is an (invalid) value type.
+      return ForeignReferenceTypeInfo::Value(/*isValid=*/false);
+    }
     return ForeignReferenceTypeInfo::Shared(FRTBase, primarySuperclass);
   }
 };

--- a/test/Interop/Cxx/foreign-reference/Inputs/member-inheritance.h
+++ b/test/Interop/Cxx/foreign-reference/Inputs/member-inheritance.h
@@ -37,7 +37,7 @@ public:
     int getDerivedX() const {
         return getX();
     }
-} IMMORTAL_FRT;
+};
 
 CopyTrackedDerivedClass *makeCopyTrackedDerivedClass(int x) {
     return new CopyTrackedDerivedClass(x);
@@ -55,7 +55,7 @@ private:
 class CopyTrackedDerivedDerivedClass: public NonEmptyBase, public CopyTrackedDerivedClass {
 public:
     CopyTrackedDerivedDerivedClass(int x) : CopyTrackedDerivedClass(x) {}
-} IMMORTAL_FRT;
+};
 
 CopyTrackedDerivedDerivedClass *makeCopyTrackedDerivedDerivedClass(int x) {
     return new CopyTrackedDerivedDerivedClass(x);
@@ -73,7 +73,7 @@ BaseReturningFRTFromSubscript *makeBaseReturningFRTFromSubscript() {
 }
 
 class DerivedFromBaseReturningFRTFromSubscript
-    : public BaseReturningFRTFromSubscript{public : } IMMORTAL_FRT;
+    : public BaseReturningFRTFromSubscript{public : };
 
 DerivedFromBaseReturningFRTFromSubscript *makeDerivedFromBaseReturningFRTFromSubscript() {
     return new DerivedFromBaseReturningFRTFromSubscript();
@@ -92,7 +92,7 @@ private:
 } IMMORTAL_FRT;
 
 class DerivedFromBaseReturningFRTFromSubscriptPointer
-    : public BaseReturningFRTFromSubscriptPointer{public : } IMMORTAL_FRT;
+    : public BaseReturningFRTFromSubscriptPointer{public : };
 
 DerivedFromBaseReturningFRTFromSubscriptPointer *makeDerivedFromBaseReturningFRTFromSubscriptPointer() {
     return new DerivedFromBaseReturningFRTFromSubscriptPointer();
@@ -106,14 +106,14 @@ struct IMMORTAL_FRT ImmortalBase {
   virtual int getIntValue() const { return value; }
 };
 
-struct IMMORTAL_FRT Immortal : public ImmortalBase {
+struct Immortal : public ImmortalBase {
   static Immortal *_Nonnull create() { return new Immortal(); }
 
   virtual int getOverridden42() const override { return 42; }
   virtual void setIntValue(int newValue) { this->value = newValue; }
 };
 
-struct IMMORTAL_FRT DerivedFromImmortal : public Immortal {
+struct DerivedFromImmortal : public Immortal {
   static DerivedFromImmortal *_Nonnull create() {
     return new DerivedFromImmortal();
   }
@@ -371,7 +371,7 @@ struct IMMORTAL_FRT BaseWithInitMethod {
   static BaseWithInitMethod *_Nonnull create() { return new BaseWithInitMethod(); }
 };
 
-struct IMMORTAL_FRT DerivedWithInitMethod : BaseWithInitMethod {
+struct DerivedWithInitMethod : BaseWithInitMethod {
   virtual int init() const override { return 2; }
   static DerivedWithInitMethod *_Nonnull create() {
     return new DerivedWithInitMethod();
@@ -387,7 +387,7 @@ struct IMMORTAL_FRT RenamedBaseWithInitMethod {
   }
 };
 
-struct IMMORTAL_FRT RenamedDerivedWithInitMethod : RenamedBaseWithInitMethod {
+struct RenamedDerivedWithInitMethod : RenamedBaseWithInitMethod {
   virtual int method() const override __attribute__((swift_name("init()"))) {
     return 12;
   }

--- a/test/Interop/Cxx/foreign-reference/Inputs/super-static-dispatch.h
+++ b/test/Interop/Cxx/foreign-reference/Inputs/super-static-dispatch.h
@@ -12,7 +12,7 @@ struct FRT_IMMORTAL Base {
   }
 };
 
-struct FRT_IMMORTAL Derived : Base {
+struct Derived : Base {
   int nonVirtualMethod() const { return 99; }
 
   static Derived &create() {

--- a/test/Interop/Cxx/foreign-reference/Inputs/super-virtual-dispatch.h
+++ b/test/Interop/Cxx/foreign-reference/Inputs/super-virtual-dispatch.h
@@ -13,7 +13,7 @@ struct FRT_IMMORTAL Base {
   }
 };
 
-struct FRT_IMMORTAL Derived : Base {
+struct Derived : Base {
   int virtualMethod() const override { return 200; }
 
   static Derived &create() {
@@ -22,7 +22,7 @@ struct FRT_IMMORTAL Derived : Base {
   }
 };
 
-struct FRT_IMMORTAL LeafDerived : Derived {
+struct LeafDerived : Derived {
   int virtualMethod() const override { return 300; }
 
   static LeafDerived &create() {
@@ -31,14 +31,14 @@ struct FRT_IMMORTAL LeafDerived : Derived {
   }
 };
 
-struct FRT_IMMORTAL DerivedNoOverride : Base {
+struct DerivedNoOverride : Base {
   static DerivedNoOverride &create() {
     static DerivedNoOverride instance;
     return instance;
   }
 };
 
-struct FRT_IMMORTAL LeafOverNoOverride : DerivedNoOverride {
+struct LeafOverNoOverride : DerivedNoOverride {
   int virtualMethod() const override { return 400; }
 
   static LeafOverNoOverride &create() {
@@ -51,7 +51,7 @@ struct UnrelatedBase {
   int unrelatedMethod() const { return 999; }
 };
 
-struct FRT_IMMORTAL DerivedWithUnrelatedBase : Base, UnrelatedBase {
+struct DerivedWithUnrelatedBase : Base, UnrelatedBase {
   int virtualMethod() const override { return 500; }
 
   static DerivedWithUnrelatedBase &create() {
@@ -65,7 +65,7 @@ struct SecondBaseWithSameMethod {
   virtual ~SecondBaseWithSameMethod() = default;
 };
 
-struct FRT_IMMORTAL DerivedWithConflictingBase : Base, SecondBaseWithSameMethod {
+struct DerivedWithConflictingBase : Base, SecondBaseWithSameMethod {
   int virtualMethod() const override { return 600; }
 
   static DerivedWithConflictingBase &create() {
@@ -79,7 +79,7 @@ struct FRT_IMMORTAL AbstractBase {
   virtual ~AbstractBase() = default;
 };
 
-struct FRT_IMMORTAL ConcreteDerived : AbstractBase {
+struct ConcreteDerived : AbstractBase {
   int pureMethod() const override { return 42; }
 
   static ConcreteDerived &create() {

--- a/test/Interop/Cxx/foreign-reference/Inputs/upcast.h
+++ b/test/Interop/Cxx/foreign-reference/Inputs/upcast.h
@@ -18,7 +18,7 @@ struct FRT_IMMORTAL Base {
   }
 };
 
-struct FRT_IMMORTAL Derived : Base {
+struct Derived : Base {
   int derivedValue;
 
   Derived() : derivedValue(2) {}
@@ -32,7 +32,7 @@ struct FRT_IMMORTAL Derived : Base {
   }
 };
 
-struct FRT_IMMORTAL LeafDerived : Derived {
+struct LeafDerived : Derived {
   int leafValue;
 
   LeafDerived() : leafValue(3) {}
@@ -129,6 +129,23 @@ __attribute__((swift_attr("release:.releaseC")));
 // FIXME: this redeclares the lifetime operations, since ClangImporter currently
 // reports a conflict between annotations on base types otherwise
 
+// A derived FRT that re-annotates SWIFT_SHARED_REFERENCE with the same
+// retain/release ops as its base. Despite the matching ops, the explicit
+// annotation acts as an upcast barrier.
+struct ReannotatedRefCountedDerived : RefCountedBase {
+  int reannotatedField = 30;
+
+  ReannotatedRefCountedDerived() = default;
+  ReannotatedRefCountedDerived(const ReannotatedRefCountedDerived &) = delete;
+
+  static ReannotatedRefCountedDerived &create() {
+    static ReannotatedRefCountedDerived instance;
+    return instance;
+  }
+} __attribute__((swift_attr("import_reference")))
+__attribute__((swift_attr("retain:.retain")))
+__attribute__((swift_attr("release:.release")));
+
 // Private inheritance: should NOT produce a Swift superclass relationship.
 struct FRT_IMMORTAL PrivateDerived : private Base {
   int privateDerivedValue;
@@ -161,7 +178,7 @@ struct FRT_IMMORTAL ProtectedDerived : protected Base {
 
 struct EmptyTag {};
 
-struct FRT_IMMORTAL DerivedFromEmptyAndBase : EmptyTag, Base {
+struct DerivedFromEmptyAndBase : EmptyTag, Base {
   int extraValue;
 
   DerivedFromEmptyAndBase() : extraValue(7) {}
@@ -184,7 +201,7 @@ struct FRT_IMMORTAL CRTPBase {
   Derived *derivedSelf() { return static_cast<Derived *>(this); }
 };
 
-struct FRT_IMMORTAL CRTPDerived : CRTPBase<CRTPDerived> {
+struct CRTPDerived : CRTPBase<CRTPDerived> {
   int crtpDerivedValue;
 
   CRTPDerived() : crtpDerivedValue(11) {}

--- a/test/Interop/Cxx/foreign-reference/upcast-module-interface.swift
+++ b/test/Interop/Cxx/foreign-reference/upcast-module-interface.swift
@@ -43,7 +43,9 @@
 
 // CHECK: class OverridesLifetimeOps {
 
-// CHECK: class OverridesLifetimeOpsDerived : OverridesLifetimeOps {
+// CHECK: class OverridesLifetimeOpsDerived {
+
+// CHECK: class ReannotatedRefCountedDerived {
 
 // CHECK: class DerivedFromEmptyAndBase : Base {
 // CHECK:   var extraValue: Int32

--- a/test/Interop/Cxx/foreign-reference/upcast-typechecker.swift
+++ b/test/Interop/Cxx/foreign-reference/upcast-typechecker.swift
@@ -26,7 +26,10 @@ func implicitConversionLeaf(_ l: LeafDerived) -> Int32 {
   return takesBase(l)
 }
 
-// MARK: - Overridden lifetime operations:
+// MARK: - Explicit SWIFT_SHARED_REFERENCE annotations block upcasting:
+
+// An explicit shared reference annotation on a derived FRT acts as an upcast
+// barrier, regardless of whether its retain/release ops match the base's.
 
 func upcastOverridesToDerived(_ c: OverridesLifetimeOps) -> RefCountedDerived {
   return c as RefCountedDerived // expected-error {{cannot convert value of type 'OverridesLifetimeOps' to type 'RefCountedDerived' in coercion}}
@@ -37,11 +40,20 @@ func upcastOverridesToBase(_ c: OverridesLifetimeOps) -> RefCountedBase {
 }
 
 func upcastDerivedToOverrides(_ d: OverridesLifetimeOpsDerived) -> OverridesLifetimeOps {
-  return d as OverridesLifetimeOps
+  return d as OverridesLifetimeOps // expected-error {{cannot convert value of type 'OverridesLifetimeOpsDerived' to type 'OverridesLifetimeOps' in coercion}}
 }
 
 func upcastDerivedToRefCountedDerived(_ d: OverridesLifetimeOpsDerived) -> RefCountedDerived {
   return d as RefCountedDerived // expected-error {{cannot convert value of type 'OverridesLifetimeOpsDerived' to type 'RefCountedDerived' in coercion}}
+}
+
+func upcastReannotatedToBase(_ d: ReannotatedRefCountedDerived) -> RefCountedBase {
+  return d as RefCountedBase // expected-error {{cannot convert value of type 'ReannotatedRefCountedDerived' to type 'RefCountedBase' in coercion}}
+}
+
+func implicitConversionReannotated(_ d: ReannotatedRefCountedDerived) -> Int32 {
+  func takesRefBase(_ b: RefCountedBase) -> Int32 { b.getBaseValue() }
+  return takesRefBase(d) // expected-error {{cannot convert value of type 'ReannotatedRefCountedDerived' to expected argument type 'RefCountedBase'}}
 }
 
 func unrelatedCast(_ u: Unrelated) -> Base {


### PR DESCRIPTION
Previously, when a derived class re-stated a SWIFT_SHARED_REFERENCE annotation (or any other reference type annotation), ClangImporter would allow upcasting to its base if the retain/release op *strings* matched the base's. This is unsound: two unrelated classes that happen to name their retain/release ops the same way would be considered upcast-able, and a string match between overriding methods doesn't actually guarantee that calling the base's retain/release op on a derived pointer is correct.

This change removes the string-matching upcast logic. An explicit annotation on a class now acts as an upcast barrier: the class is imported as a foreign reference type with no Swift superclass, regardless of whether its base is also an FRT.

To participate in the FRT inheritance chain, intermediate classes should inherit the annotation from their base instead of re-stating it.

rdar://179748445