### PR TITLE
[build-script-impl] Inject `--` into every `call env ...` site

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -77,6 +77,7 @@ KNOWN_SETTINGS=(
     workspace                                     "${HOME}/src"     "source directory containing llvm, clang, swift"
     dsymutil-jobs                                 "1"               "number of parallel invocations of dsymutil"
     extra-dsymutil-args                           ""                "additional arguments to pass to dsymutil"
+    env-supports-end-of-options                   ""                "set if env(1) recognizes '--' as an end-of-options marker; build-script probes for this and forwards the flag"
 
     ## Build Tools
     host-cc                                       ""                "the path to CC, the 'clang' compiler for the host platform. **This argument is required**"
@@ -1039,6 +1040,17 @@ fi
 
 if [[ "${SKIP_RECONFIGURE}" ]]; then
     RECONFIGURE=""
+fi
+
+# `env(1)` end-of-options terminator. macOS 26's env(1) is stricter about
+# option scanning past the program token, so callers must explicitly end
+# option scanning with `--` before the program. build-script probes whether
+# the local env(1) recognizes `--` and forwards
+# --env-supports-end-of-options when it does; otherwise this expands to
+# nothing so we don't break older env(1)s that would try to exec `--`.
+ENV_OPT_TERMINATOR=()
+if [[ "${ENV_SUPPORTS_END_OF_OPTIONS}" ]]; then
+    ENV_OPT_TERMINATOR=(--)
 fi
 
 # WORKSPACE, BUILD_DIR, and INSTALLABLE_PACKAGE must be absolute paths
@@ -2604,7 +2616,7 @@ for host in "${ALL_HOSTS[@]}"; do
                 EXTRA_DISTCC_OPTIONS=("DISTCC_HOSTS=localhost,lzo,cpp")
             fi
             with_pushd "${build_dir}" \
-                call env "${EXTRA_DISTCC_OPTIONS[@]}" "${CMAKE}" "${cmake_options[@]}" "${EXTRA_CMAKE_OPTIONS[@]}" "${source_dir}"
+                call env "${EXTRA_DISTCC_OPTIONS[@]}" "${ENV_OPT_TERMINATOR[@]}" "${CMAKE}" "${cmake_options[@]}" "${EXTRA_CMAKE_OPTIONS[@]}" "${source_dir}"
         fi
 
         # Build.
@@ -2797,7 +2809,7 @@ for host in "${ALL_HOSTS[@]}"; do
                   LIBDISPATCH_BUILD_DIR=$(build_directory ${host} ${product})
                   echo "--- Running tests for ${product} ---"
                   with_pushd "${LIBDISPATCH_BUILD_DIR}" \
-                      call env VERBOSE=1 make check
+                      call env VERBOSE=1 "${ENV_OPT_TERMINATOR[@]}" make check
                   echo "--- Finished tests for ${product} ---"
                   continue
                 ;;
@@ -3021,7 +3033,7 @@ for host in "${ALL_HOSTS[@]}"; do
         echo "--- Installing ${product} ---"
         build_dir=$(build_directory ${host} ${product})
 
-        call env DESTDIR="${host_install_destdir}" "${CMAKE_BUILD[@]}" "${build_dir}" -- ${INSTALL_TARGETS}
+        call env DESTDIR="${host_install_destdir}" "${ENV_OPT_TERMINATOR[@]}" "${CMAKE_BUILD[@]}" "${build_dir}" -- ${INSTALL_TARGETS}
     done
 done
 

--- a/utils/swift_build_support/swift_build_support/build_script_invocation.py
+++ b/utils/swift_build_support/swift_build_support/build_script_invocation.py
@@ -13,6 +13,7 @@
 import os
 import platform
 import shlex
+import subprocess
 
 from build_swift.build_swift import argparse
 from build_swift.build_swift.constants import BUILD_SCRIPT_IMPL_PATH
@@ -61,6 +62,26 @@ class BuildScriptInvocation(object):
     @property
     def install_all(self):
         return self.args.install_all or self.args.infer_dependencies
+
+    @staticmethod
+    def _env_supports_end_of_options():
+        """Probe whether env(1) recognizes '--' as an end-of-options marker.
+
+        macOS 26's env(1) is stricter about option scanning past the program
+        token, so callers must terminate option parsing with '--' before
+        flag-like program arguments (e.g. cmake's '-G Ninja') to keep env from
+        consuming them. Older env(1)s that don't recognize '--' would try to
+        exec a program literally named '--' and fail; treat a non-zero exit
+        (or a missing env binary) as no support.
+        """
+        try:
+            return subprocess.call(
+                ['env', 'A=1', '--', '/bin/sh', '-c', 'exit 0'],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            ) == 0
+        except OSError:
+            return False
 
     def convert_to_impl_arguments(self):
         """convert_to_impl_arguments() -> (env, args)
@@ -135,6 +156,9 @@ class BuildScriptInvocation(object):
             '--build-swift-remote-mirror', str(args.build_swift_remote_mirror).lower(),
             "--swift-source-dirname", products.Swift.product_source_name(),
         ]
+
+        if self._env_supports_end_of_options():
+            impl_args += ["--env-supports-end-of-options"]
 
         # Compute any product specific cmake arguments.
         #


### PR DESCRIPTION
macOS 26's env(1) is stricter about parsing flag-like args past the program token: `env /path/cmake -G Ninja ...` aborts with `env: -G: No such file or directory` because env keeps option-scanning beyond the cmake path. The portable workaround is to terminate env's option scan with `--` between VAR=VAL assignments and the program.

`--` is recognized as end-of-options by GNU coreutils, FreeBSD 9+, and all relevant Darwin env(1) versions, so we emit it unconditionally at all three `call env ...` sites in build-script-impl:

  - cmake configure (the macOS 26 failure point)
  - libdispatch make check
  - install-time cmake --build

