### PR TITLE
[Sema] A few invalid `extension` fixes

### DIFF
--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -673,7 +673,8 @@ static bool usesFeatureReparenting(Decl *decl) {
 
   // Check if this decl itself is a reparentable protocol (of extension of).
   if (auto ext = dyn_cast<ExtensionDecl>(decl)) {
-    decl = ext->getExtendedNominal();
+    if (auto *nominal = ext->getExtendedNominal())
+      decl = nominal;
   }
 
   if (auto proto = dyn_cast<ProtocolDecl>(decl)) {

--- a/lib/PrintAsClang/ModuleContentsWriter.cpp
+++ b/lib/PrintAsClang/ModuleContentsWriter.cpp
@@ -946,6 +946,9 @@ public:
                          }
 
                          if (auto ED = dyn_cast<ExtensionDecl>(D)) {
+                           // Immediately filter out invalid extensions.
+                           if (ED->isInvalid())
+                             return true;
                            if (outputLangMode == OutputLanguageMode::Cxx)
                              return false;
                            auto baseClass = ED->getSelfClassDecl();

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -2250,52 +2250,52 @@ bool AssignmentFailure::diagnoseAsError() {
       // If there is a masked property of the same type, emit a
       // note to fixit prepend a 'self.' or 'Type.'.
       if (auto typeContext = DC->getInnermostTypeContext()) {
-        SmallVector<ValueDecl *, 2> results;
-        DC->lookupQualified(typeContext->getSelfNominalTypeDecl(),
-                            VD->createNameRef(), Loc,
-                            NL_QualifiedDefault, results);
+        if (auto *nominal = typeContext->getSelfNominalTypeDecl()) {
+          SmallVector<ValueDecl *, 2> results;
+          DC->lookupQualified(nominal, VD->createNameRef(), Loc,
+                              NL_QualifiedDefault, results);
 
-        auto foundProperty = llvm::find_if(results, [&](ValueDecl *decl) {
-          // We're looking for a settable property that is the same type as the
-          // var we found.
-          auto *var = dyn_cast<VarDecl>(decl);
-          if (!var || var == VD)
-            return false;
-
-          if (!var->isSettable(DC) || !var->isSetterAccessibleFrom(DC))
-            return false;
-
-          if (!var->getTypeInContext()->isEqual(VD->getTypeInContext()))
-            return false;
-
-          // Don't suggest a property if we're in one of its accessors.
-          auto *methodDC = DC->getInnermostMethodContext();
-          if (auto *AD = dyn_cast_or_null<AccessorDecl>(methodDC))
-            if (AD->getStorage() == var)
+          auto foundProperty = llvm::find_if(results, [&](ValueDecl *decl) {
+            // We're looking for a settable property that is the same type as
+            // the var we found.
+            auto *var = dyn_cast<VarDecl>(decl);
+            if (!var || var == VD)
               return false;
 
-          return true;
-        });
+            if (!var->isSettable(DC) || !var->isSetterAccessibleFrom(DC))
+              return false;
 
-        if (foundProperty != results.end()) {
-          auto startLoc = immutableExpr->getStartLoc();
-          auto *property = cast<VarDecl>(*foundProperty);
-          auto selfTy = typeContext->getSelfTypeInContext();
+            if (!var->getTypeInContext()->isEqual(VD->getTypeInContext()))
+              return false;
 
-          // If we found an instance property, suggest inserting "self.",
-          // otherwise suggest "Type." for a static property.
-          std::string fixItText;
-          if (property->isInstanceMember()) {
-            fixItText = "self.";
-          } else {
-            fixItText = selfTy->getString() + ".";
+            // Don't suggest a property if we're in one of its accessors.
+            auto *methodDC = DC->getInnermostMethodContext();
+            if (auto *AD = dyn_cast_or_null<AccessorDecl>(methodDC))
+              if (AD->getStorage() == var)
+                return false;
+
+            return true;
+          });
+
+          if (foundProperty != results.end()) {
+            auto startLoc = immutableExpr->getStartLoc();
+            auto *property = cast<VarDecl>(*foundProperty);
+            auto selfTy = typeContext->getSelfTypeInContext();
+
+            // If we found an instance property, suggest inserting "self.",
+            // otherwise suggest "Type." for a static property.
+            std::string fixItText;
+            if (property->isInstanceMember()) {
+              fixItText = "self.";
+            } else {
+              fixItText = selfTy->getString() + ".";
+            }
+            emitDiagnosticAt(startLoc, diag::masked_mutable_property, fixItText,
+                             property, selfTy)
+            .fixItInsert(startLoc, fixItText);
           }
-          emitDiagnosticAt(startLoc, diag::masked_mutable_property, fixItText,
-                           property, selfTy)
-              .fixItInsert(startLoc, fixItText);
         }
       }
-
       // If this is a simple variable marked with a 'let', emit a note to fixit
       // hint it to 'var'.
       VD->emitLetToVarNoteIfSimple(DC);

--- a/lib/Sema/CSSyntacticElement.cpp
+++ b/lib/Sema/CSSyntacticElement.cpp
@@ -799,13 +799,12 @@ private:
       return;
     }
 
-    auto nominalType =
-        fn->getDeclContext()->getSelfNominalTypeDecl()->getDeclaredType();
-    if (!nominalType) {
+    auto nominal = fn->getDeclContext()->getSelfNominalTypeDecl();
+    if (!nominal) {
       hadError = true;
       return;
     }
-
+    auto nominalType = nominal->getDeclaredType();
     auto *selfExpr = discardStmt->getSubExpr();
 
     createConjunction(

--- a/lib/Sema/PreCheckTarget.cpp
+++ b/lib/Sema/PreCheckTarget.cpp
@@ -2195,6 +2195,9 @@ VarDecl *PreCheckTarget::getImplicitSelfDeclForSuperContext(SourceLoc Loc) {
 
   if (auto *typeContext = DC->getInnermostTypeContext()) {
     auto *nominal = typeContext->getSelfNominalTypeDecl();
+    if (!nominal)
+      return nullptr;
+
     auto *classDecl = dyn_cast<ClassDecl>(nominal);
 
     if (!classDecl) {

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -4570,8 +4570,12 @@ void AttributeChecker::visitImplementsAttr(ImplementsAttr *attr) {
   }
 
   // Check that the decl we're decorating is a member of a type that actually
-  // conforms to the specified protocol.
+  // conforms to the specified protocol. If we have an invalid extension, we
+  // can bail.
   NominalTypeDecl *NTD = DC->getSelfNominalTypeDecl();
+  if (!NTD)
+    return;
+
   if (auto *OtherPD = dyn_cast<ProtocolDecl>(NTD)) {
     if (!(OtherPD == PD || OtherPD->inheritsFrom(PD)) &&
         !(OtherPD->isSpecificProtocol(KnownProtocolKind::DistributedActor) ||

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -3184,8 +3184,9 @@ namespace {
     PreWalkAction walkToDeclPre(Decl *decl) override {
       // Don't walk into local types because nothing in them can
       // change the outcome of our analysis, and we don't want to
-      // assume things there have been type checked yet.
-      if (isa<TypeDecl>(decl)) {
+      // assume things there have been type checked yet. Extensions
+      // may also occur here for invalid code, skip them too.
+      if (isa<TypeDecl>(decl) || isa<ExtensionDecl>(decl)) {
         return Action::SkipChildren();
       }
 

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -3921,49 +3921,65 @@ public:
     }
   }
 
+  void diagnoseInvalidExtension(ExtensionDecl *ED, Type extType) {
+    const bool wasAlreadyInvalid = ED->isInvalid();
+    ED->setInvalid();
+
+    // Diagnose unsupported cases.
+    if (!extType->hasError() && extType->getAnyNominal()) {
+      auto canExtType = extType->getCanonicalType();
+      if (auto existential = canExtType->getAs<ExistentialType>()) {
+        ED->diagnose(diag::unsupported_existential_extension, extType)
+            .highlight(ED->getExtendedTypeRepr()->getSourceRange());
+        ED->diagnose(diag::invalid_extension_rewrite,
+                     existential->getConstraintType())
+            .fixItReplace(ED->getExtendedTypeRepr()->getSourceRange(),
+                          existential->getConstraintType()->getString());
+        return;
+      }
+
+      // If we've got here, then we have some kind of extension of a prima
+      // facie non-nominal type.  This can come up when we're projecting
+      // typealiases out of bound generic types.
+      //
+      // struct Array<T> { typealias Indices = Range<Int> }
+      // extension Array.Indices.Bound {}
+      //
+      // Offer to rewrite it to the underlying nominal type.
+      if (canExtType.getPointer() != extType.getPointer()) {
+        ED->diagnose(diag::invalid_nominal_extension, extType, canExtType)
+            .highlight(ED->getExtendedTypeRepr()->getSourceRange());
+        ED->diagnose(diag::invalid_extension_rewrite, canExtType)
+            .fixItReplace(ED->getExtendedTypeRepr()->getSourceRange(),
+                          canExtType->getString());
+        return;
+      }
+    }
+
+    if (wasAlreadyInvalid)
+      return;
+
+    // If nothing else applies, fall back to a generic diagnostic.
+    ED->diagnose(diag::non_nominal_extension, extType);
+  }
+
   void visitExtensionDecl(ExtensionDecl *ED) {
     // Produce any diagnostics for the extended type.
     auto extType = ED->getExtendedType();
 
     auto *nominal = ED->getExtendedNominal();
 
+    // If we couldn't resolve the extended decl, diagnose.
+    // FIXME: We shouldn't be diagnosing here, we should be diagnosing directly
+    // in the request such that the extension's "is invalid" bit is accurate.
     if (nominal == nullptr) {
-      const bool wasAlreadyInvalid = ED->isInvalid();
-      ED->setInvalid();
-      if (!extType->hasError() && extType->getAnyNominal()) {
-        auto canExtType = extType->getCanonicalType();
-        if (auto existential = canExtType->getAs<ExistentialType>()) {
-          ED->diagnose(diag::unsupported_existential_extension, extType)
-              .highlight(ED->getExtendedTypeRepr()->getSourceRange());
-          ED->diagnose(diag::invalid_extension_rewrite,
-                       existential->getConstraintType())
-              .fixItReplace(ED->getExtendedTypeRepr()->getSourceRange(),
-                            existential->getConstraintType()->getString());
-          return;
-        }
+      diagnoseInvalidExtension(ED, extType);
 
-        // If we've got here, then we have some kind of extension of a prima
-        // facie non-nominal type.  This can come up when we're projecting
-        // typealiases out of bound generic types.
-        //
-        // struct Array<T> { typealias Indices = Range<Int> }
-        // extension Array.Indices.Bound {}
-        //
-        // Offer to rewrite it to the underlying nominal type.
-        if (canExtType.getPointer() != extType.getPointer()) {
-          ED->diagnose(diag::invalid_nominal_extension, extType, canExtType)
-              .highlight(ED->getExtendedTypeRepr()->getSourceRange());
-          ED->diagnose(diag::invalid_extension_rewrite, canExtType)
-              .fixItReplace(ED->getExtendedTypeRepr()->getSourceRange(),
-                            canExtType->getString());
-          return;
-        }
-      }
-
-      if (!wasAlreadyInvalid) {
-        // If nothing else applies, fall back to a generic diagnostic.
-        ED->diagnose(diag::non_nominal_extension, extType);
-      }
+      // Make sure to still recurse into the extension members though, otherwise
+      // they will be left un-type-checked, which violates the assumption that
+      // all AST is type-checked after Sema runs.
+      for (Decl *Member : ED->getMembers())
+        visit(Member);
 
       return;
     }

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -1521,6 +1521,7 @@ public:
     bool diagnosed = false;
 
     auto *outerDC = climbContextForDiscardStmt(DC);
+    auto *nominalDecl = outerDC->getParent()->getSelfNominalTypeDecl();
     AbstractFunctionDecl *fn = nullptr; // the type member we reside in.
     if (outerDC->getParent()->isTypeContext()) {
       fn = dyn_cast<AbstractFunctionDecl>(outerDC);
@@ -1555,8 +1556,7 @@ public:
     }
 
     // check the kind of type this discard statement appears within.
-    if (!diagnosed) {
-      auto *nominalDecl = fn->getDeclContext()->getSelfNominalTypeDecl();
+    if (!diagnosed && nominalDecl) {
       Type nominalType =
           fn->mapTypeIntoEnvironment(nominalDecl->getDeclaredInterfaceType());
 

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -4513,8 +4513,8 @@ StorageImplInfoRequest::evaluate(Evaluator &evaluator,
   if (borrow || mutate) {
     if (auto *extDecl = dyn_cast<ExtensionDecl>(DC)) {
       auto extNominal = extDecl->getExtendedNominal();
-      if (!isa<StructDecl>(extNominal) && !isa<EnumDecl>(extNominal) &&
-          !isa<ClassDecl>(extNominal)) {
+      if (extNominal && !isa<StructDecl>(extNominal) &&
+          !isa<EnumDecl>(extNominal) && !isa<ClassDecl>(extNominal)) {
         if (borrow) {
           storage->getASTContext().Diags.diagnose(
               borrow->getLoc(),

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -1149,10 +1149,15 @@ bool TypeChecker::checkContextualRequirements(GenericTypeDecl *decl,
 
   auto *dc = decl->getDeclContext();
 
+  // If we have an invalid extension parent, don't bother checking requirements.
+  auto *nominalParent = dc->getSelfNominalTypeDecl();
+  if (!nominalParent)
+    return true;
+
   const auto genericSig = decl->getGenericSignature();
 
   if (genericSig.getPointer() ==
-      dc->getSelfNominalTypeDecl()->getGenericSignature().getPointer()) {
+      nominalParent->getGenericSignature().getPointer()) {
     return true;
   }
 
@@ -2274,6 +2279,8 @@ static SelfTypeKind getSelfTypeKind(DeclContext *dc,
 void TypeResolver::diagnoseGenericArgumentsOnSelf(
     UnqualifiedIdentTypeRepr *repr, DeclContext *typeDC) {
   auto *selfNominal = typeDC->getSelfNominalTypeDecl();
+  if (!selfNominal)
+    return;
   auto declaredType = selfNominal->getDeclaredType();
 
   diagnose(repr->getNameLoc(), diag::cannot_specialize_self);

--- a/lib/SymbolGraphGen/SymbolGraphASTWalker.cpp
+++ b/lib/SymbolGraphGen/SymbolGraphASTWalker.cpp
@@ -230,7 +230,11 @@ bool SymbolGraphASTWalker::walkToDeclPre(Decl *D, CharSourceRange Range) {
   // If this is an extension, let's check that it implies some new conformances,
   // potentially with generic requirements.
   if (const auto *Extension = dyn_cast<ExtensionDecl>(D)) {
+    // Ignore extensions with no nominal.
     const auto *ExtendedNominal = Extension->getExtendedNominal();
+    if (!ExtendedNominal)
+      return false;
+
     auto ExtendedSG = getModuleSymbolGraph(ExtendedNominal);
     // Ignore effectively private decls.
     if (ExtendedSG->isImplicitlyPrivate(Extension)) {

--- a/test/Sema/diag_variable_used_in_initial.swift
+++ b/test/Sema/diag_variable_used_in_initial.swift
@@ -53,6 +53,9 @@ func localContext() {
         func foo1() {}
         func foo2() {
           var foo1 = foo1()
+          // expected-warning@-1 {{initialization of variable 'foo1' was never used; consider replacing with assignment to '_' or removing it}}
+          // expected-warning@-2 {{variable 'foo1' inferred to have type '()', which may be unexpected}}
+          // expected-note@-3 {{add an explicit type annotation to silence this warning}}
         }
       }
     }

--- a/test/attr/dynamicReplacement.swift
+++ b/test/attr/dynamicReplacement.swift
@@ -54,7 +54,7 @@ extension undeclared { // expected-error{{cannot find type 'undeclared' in scope
   @_dynamicReplacement(for: property)
   var replacement_property: Int { return 2 }
 
-  @_dynamicReplacement(for: func)
+  @_dynamicReplacement(for: func) // expected-error {{replaced function 'func' could not be found}}
   func func2() -> Int { return 2 }
 }
 

--- a/test/decl/nested/type_in_extension.swift
+++ b/test/decl/nested/type_in_extension.swift
@@ -13,7 +13,9 @@ extension { // expected-error {{expected type name in extension declaration}}
     func foo(t: T) {}
   }
 
-  class M : S {}
+  // A little unfortunate we emit this error, but because there's no
+  // extended nominal, there's no way to do a qualified lookup.
+  class M : S {} // expected-error {{cannot find type 'S' in scope}}
 
   protocol P {
     associatedtype A

--- a/test/decl/protocol/protocol_with_superclass.swift
+++ b/test/decl/protocol/protocol_with_superclass.swift
@@ -334,7 +334,7 @@ protocol Amb : Concrete {}
 
 extension Amb { // expected-error {{'Amb' is ambiguous for type lookup in this context}}
   func extensionMethodUsesClassTypes() {
-    _ = ConcreteAlias.self
+    _ = ConcreteAlias.self // expected-error {{cannot find 'ConcreteAlias' in scope}}
   }
 }
 

--- a/test/decl/protocol/protocol_with_superclass_where_clause.swift
+++ b/test/decl/protocol/protocol_with_superclass_where_clause.swift
@@ -336,6 +336,6 @@ protocol Amb where Self : Concrete {}
 
 extension Amb { // expected-error {{'Amb' is ambiguous for type lookup in this context}}
   func extensionMethodUsesClassTypes() {
-    _ = ConcreteAlias.self
+    _ = ConcreteAlias.self // expected-error {{cannot find 'ConcreteAlias' in scope}}
   }
 }

--- a/validation-test/IDE/crashers/TypeChecker-typeCheckBinding-e3b1a7.swift
+++ b/validation-test/IDE/crashers/TypeChecker-typeCheckBinding-e3b1a7.swift
@@ -1,6 +1,0 @@
-// RUN: not --crash %target-swift-ide-test -print-indexed-symbols -include-locals -source-filename %s
-extension Undefined {
-  func f() {
-    _ = { let x = 0 }
-  }
-}

--- a/validation-test/IDE/crashers_fixed/StmtChecker-typeCheckStmt-8659dc.swift
+++ b/validation-test/IDE/crashers_fixed/StmtChecker-typeCheckStmt-8659dc.swift
@@ -1,4 +1,4 @@
 // {"kind":"complete","signature":"bool (anonymous namespace)::StmtChecker::typeCheckStmt<swift::Stmt>(swift::Stmt*&)","signatureNext":"StmtChecker::typeCheckASTNode"}
-// RUN: not --crash %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -source-filename %s
+// RUN: %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -source-filename %s
 extension {
 a { discard b#^COMPLETE^#

--- a/validation-test/IDE/crashers_fixed/TypeChecker-typeCheckBinding-e3b1a7.swift
+++ b/validation-test/IDE/crashers_fixed/TypeChecker-typeCheckBinding-e3b1a7.swift
@@ -1,0 +1,6 @@
+// RUN: %target-swift-ide-test -print-indexed-symbols -include-locals -source-filename %s
+extension Undefined {
+  func f() {
+    _ = { let x = 0 }
+  }
+}

--- a/validation-test/compiler_crashers_fixed/ActorIsolationChecker-checkApply-8156ba.swift
+++ b/validation-test/compiler_crashers_fixed/ActorIsolationChecker-checkApply-8156ba.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","original":"b281d585","signature":"(anonymous namespace)::ActorIsolationChecker::checkApply(swift::ApplyExpr*)","signatureAssert":"Assertion failed: (!IsolationCrossing.has_value() && \"IsolationCrossing should not be set twice\"), function setIsolationCrossing","signatureNext":"ActorIsolationChecker::walkToExprPre"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 actor a@globalActor actor b {
   static var shared = {
     extension a {

--- a/validation-test/compiler_crashers_fixed/ActorIsolationChecker-checkLocalCaptures-40188c.swift
+++ b/validation-test/compiler_crashers_fixed/ActorIsolationChecker-checkLocalCaptures-40188c.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","original":"b8967a13","signature":"(anonymous namespace)::ActorIsolationChecker::checkLocalCaptures(swift::AnyFunctionRef)","signatureAssert":"Assertion failed: (Captures.hasBeenComputed()), function getCaptureInfo","signatureNext":"ActorIsolationChecker::walkToExprPre"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 func a() {
   extension <#type#> {
     var b = {

--- a/validation-test/compiler_crashers_fixed/AttributeChecker-visitImplementsAttr-23dbe8.swift
+++ b/validation-test/compiler_crashers_fixed/AttributeChecker-visitImplementsAttr-23dbe8.swift
@@ -1,4 +1,4 @@
 // {"kind":"typecheck","signature":"(anonymous namespace)::AttributeChecker::visitImplementsAttr(swift::ImplementsAttr*)","signatureAssert":"Assertion failed: (detail::isPresent(Val) && \"dyn_cast on a non-existent value\"), function dyn_cast","signatureNext":"TypeChecker::checkDeclAttributes"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 protocol a { b }
 @_implements(a, b) typealias c =

--- a/validation-test/compiler_crashers_fixed/DeclSerializer-writeDeclAttribute-f6536b.swift
+++ b/validation-test/compiler_crashers_fixed/DeclSerializer-writeDeclAttribute-f6536b.swift
@@ -1,5 +1,5 @@
 // {"extraArgs":["-experimental-allow-module-with-compiler-errors","-emit-module-path","/dev/null"],"kind":"emit-sil","original":"2b4d2148","signature":"swift::serialization::Serializer::DeclSerializer::writeDeclAttribute(swift::Decl const*, swift::DeclAttribute const*)","signatureAssert":"Assertion failed: (afd && \"Missing replaced decl!\"), function writeDeclAttribute","signatureNext":"Serializer::DeclSerializer::visit"}
-// RUN: not --crash %target-swift-frontend -emit-sil -experimental-allow-module-with-compiler-errors -emit-module-path /dev/null %s
+// RUN: not %target-swift-frontend -emit-sil -experimental-allow-module-with-compiler-errors -emit-module-path /dev/null %s
 extension <#type#> {
   @_dynamicReplacement(for:) var a: <#type#>
 }

--- a/validation-test/compiler_crashers_fixed/ModuleWriter-write-393891.swift
+++ b/validation-test/compiler_crashers_fixed/ModuleWriter-write-393891.swift
@@ -1,4 +1,4 @@
 // {"extraArgs":["-experimental-allow-module-with-compiler-errors","-cxx-interoperability-mode=default","-emit-clang-header-min-access","internal","-emit-clang-header-path","/dev/null"],"kind":"emit-sil","original":"c761e8c4","signature":"(anonymous namespace)::ModuleWriter::write()","signatureAssert":"Assertion failed: (Val && \"isa<> used on a null pointer\"), function doit","signatureNext":"printModuleContentsAsCxx"}
-// RUN: not --crash %target-swift-frontend -emit-sil -experimental-allow-module-with-compiler-errors -cxx-interoperability-mode=default -emit-clang-header-min-access internal -emit-clang-header-path /dev/null %s
+// RUN: not %target-swift-frontend -emit-sil -experimental-allow-module-with-compiler-errors -cxx-interoperability-mode=default -emit-clang-header-min-access internal -emit-clang-header-path /dev/null %s
 extension <#type#> {
 }

--- a/validation-test/compiler_crashers_fixed/ModuleWriter-write-7e2336.swift
+++ b/validation-test/compiler_crashers_fixed/ModuleWriter-write-7e2336.swift
@@ -1,4 +1,4 @@
 // {"extraArgs":["-experimental-allow-module-with-compiler-errors","-cxx-interoperability-mode=default","-emit-clang-header-path","/dev/null"],"kind":"emit-sil","original":"9385ecce","signature":"(anonymous namespace)::ModuleWriter::write()","signatureNext":"printModuleContentsAsCxx"}
-// RUN: not --crash %target-swift-frontend -emit-sil -experimental-allow-module-with-compiler-errors -cxx-interoperability-mode=default -emit-clang-header-path /dev/null %s
+// RUN: not %target-swift-frontend -emit-sil -experimental-allow-module-with-compiler-errors -cxx-interoperability-mode=default -emit-clang-header-path /dev/null %s
 extension a
   extension

--- a/validation-test/compiler_crashers_fixed/PreCheckTarget-walkToExprPre-9f3063.swift
+++ b/validation-test/compiler_crashers_fixed/PreCheckTarget-walkToExprPre-9f3063.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","signature":"(anonymous namespace)::PreCheckTarget::walkToExprPre(swift::Expr*)","signatureAssert":"Assertion failed: (detail::isPresent(Val) && \"dyn_cast on a non-existent value\"), function dyn_cast","signatureNext":"Traversal::doIt"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 {
   extension a {
     b {

--- a/validation-test/compiler_crashers_fixed/QualifiedLookupRequest-evaluate-78fae7.swift
+++ b/validation-test/compiler_crashers_fixed/QualifiedLookupRequest-evaluate-78fae7.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","signature":"swift::QualifiedLookupRequest::evaluate(swift::Evaluator&, swift::DeclContext const*, llvm::SmallVector<swift::NominalTypeDecl*, 4u>, swift::DeclNameRef, swift::NLOptions) const","signatureAssert":"Assertion failed: (Val && \"isa<> used on a null pointer\"), function doit","signatureNext":"SimpleRequest::evaluateRequest"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 {
   extension a {
   b {

--- a/validation-test/compiler_crashers_fixed/StmtChecker-typeCheckStmt-412378.swift
+++ b/validation-test/compiler_crashers_fixed/StmtChecker-typeCheckStmt-412378.swift
@@ -1,0 +1,6 @@
+// {"kind":"typecheck","signature":"bool (anonymous namespace)::StmtChecker::typeCheckStmt<swift::Stmt>(swift::Stmt*&)","signatureNext":"StmtChecker::typeCheckASTNode"}
+// RUN: not %target-swift-frontend -typecheck %s
+extension <#type#> {
+  a {
+  discard b
+  }

--- a/validation-test/compiler_crashers_fixed/StorageImplInfoRequest-evaluate-6deb81.swift
+++ b/validation-test/compiler_crashers_fixed/StorageImplInfoRequest-evaluate-6deb81.swift
@@ -1,0 +1,8 @@
+// {"frontendArgs":["-typecheck","-enable-experimental-feature","BorrowAndMutateAccessors"],"kind":"custom","signature":"swift::StorageImplInfoRequest::evaluate(swift::Evaluator&, swift::AbstractStorageDecl*) const","signatureAssert":"Assertion failed: (Val && \"isa<> used on a null pointer\"), function doit","signatureNext":"StorageImplInfoRequest::OutputType"}
+// RUN: not %target-swift-frontend -typecheck -enable-experimental-feature BorrowAndMutateAccessors %s
+// REQUIRES: swift_feature_BorrowAndMutateAccessors
+extension <#type#> {
+  var a: <#type#> {
+    borrow
+  }
+}

--- a/validation-test/compiler_crashers_fixed/SymbolGraphASTWalker-getRealModuleOf-393891.swift
+++ b/validation-test/compiler_crashers_fixed/SymbolGraphASTWalker-getRealModuleOf-393891.swift
@@ -1,5 +1,5 @@
 // {"frontendArgs":["-emit-module","-o","/dev/null","-emit-symbol-graph","-emit-symbol-graph-dir","%t/out","-experimental-allow-module-with-compiler-errors"],"kind":"custom","signature":"swift::symbolgraphgen::SymbolGraphASTWalker::getRealModuleOf(swift::Decl const*) const","signatureNext":"SymbolGraphASTWalker::getModuleSymbolGraph"}
 // RUN: %empty-directory(%t)
-// RUN: not --crash %target-swift-frontend -emit-module -o /dev/null -emit-symbol-graph -emit-symbol-graph-dir %t/out -experimental-allow-module-with-compiler-errors %s
+// RUN: %target-swift-frontend -emit-module -o /dev/null -emit-symbol-graph -emit-symbol-graph-dir %t/out -experimental-allow-module-with-compiler-errors %s
 extension <#type#> {
 }

--- a/validation-test/compiler_crashers_fixed/TypeDecl-getName-0d2654.swift
+++ b/validation-test/compiler_crashers_fixed/TypeDecl-getName-0d2654.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","original":"132f5134","signature":"swift::TypeDecl::getName() const","signatureAssert":"Assertion failed: (Context.SourceMgr.hasIDEInspectionTargetBuffer() || Context.LangOpts.IsForSourceKit || Context.TypeCheckerOpts.EnableLazyTypecheck || inSecondaryScriptFile() && \"Querying VarDecl's type before type-checking parent stmt\"), function evaluate"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 {
   extension {
 a { for

--- a/validation-test/compiler_crashers_fixed/TypeDecl-getName-30c6aa.swift
+++ b/validation-test/compiler_crashers_fixed/TypeDecl-getName-30c6aa.swift
@@ -1,0 +1,4 @@
+// {"kind":"typecheck","original":"d2c2e41b","signature":"swift::TypeDecl::getName() const","signatureAssert":"Assertion failed: (Val && \"isa<> used on a null pointer\"), function doit"}
+// RUN: not %target-swift-frontend -typecheck %s
+extension {
+a { let b: UInt8 c(&b

--- a/validation-test/compiler_crashers_fixed/TypeDecl-getName-adeaaa.swift
+++ b/validation-test/compiler_crashers_fixed/TypeDecl-getName-adeaaa.swift
@@ -1,4 +1,4 @@
 // {"extraArgs":["-experimental-allow-module-with-compiler-errors"],"kind":"emit-sil","original":"2a255fd2","signature":"swift::TypeDecl::getName() const","signatureAssert":"Assertion failed: (!isa<SendableAttr>(attr) && \"Conformance should have been added by SynthesizedProtocolAttr!\"), function deriveImplicitSendableConformance"}
-// RUN: not --crash %target-swift-frontend -emit-sil -experimental-allow-module-with-compiler-errors %s
+// RUN: not %target-swift-frontend -emit-sil -experimental-allow-module-with-compiler-errors %s
 extension {
   @Sendable struct a

--- a/validation-test/compiler_crashers_fixed/TypeDecl-getName-c25aed.swift
+++ b/validation-test/compiler_crashers_fixed/TypeDecl-getName-c25aed.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","signature":"swift::TypeDecl::getName() const","signatureAssert":"Assertion failed: (detail::isPresent(Val) && \"dyn_cast on a non-existent value\"), function dyn_cast"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 {
   extension {
     a {

--- a/validation-test/compiler_crashers_fixed/TypeDecl-getName-edf709.swift
+++ b/validation-test/compiler_crashers_fixed/TypeDecl-getName-edf709.swift
@@ -1,5 +1,5 @@
 // {"extraArgs":["-experimental-allow-module-with-compiler-errors","-emit-module-path","/dev/null"],"kind":"emit-sil","original":"f3a2e711","signature":"swift::TypeDecl::getName() const","signatureAssert":"Assertion failed: (Captures.hasBeenComputed()), function getCaptureInfo"}
-// RUN: not --crash %target-swift-frontend -emit-sil -experimental-allow-module-with-compiler-errors -emit-module-path /dev/null %s
+// RUN: not %target-swift-frontend -emit-sil -experimental-allow-module-with-compiler-errors -emit-module-path /dev/null %s
 @expression macro a<each b>(repeat each b) -> String
 extension {
   >(c: @autoclosure () -> String = #a

--- a/validation-test/compiler_crashers_fixed/TypeResolver-diagnoseGenericArgumentsOnSelf-abe282.swift
+++ b/validation-test/compiler_crashers_fixed/TypeResolver-diagnoseGenericArgumentsOnSelf-abe282.swift
@@ -1,5 +1,5 @@
 // {"extraArgs":["-experimental-allow-module-with-compiler-errors"],"kind":"emit-sil","original":"02a7072e","signature":"(anonymous namespace)::TypeResolver::diagnoseGenericArgumentsOnSelf(swift::UnqualifiedIdentTypeRepr*, swift::DeclContext*)","signatureNext":"TypeResolver::resolveDeclRefTypeReprRec"}
-// RUN: not --crash %target-swift-frontend -emit-sil -experimental-allow-module-with-compiler-errors %s
+// RUN: not %target-swift-frontend -emit-sil -experimental-allow-module-with-compiler-errors %s
 extension <#type#> {
   typealias a = Self<>
 }


### PR DESCRIPTION
- Avoid printing invalid extensions in generated Clang headers, matching the existing logic that excludes invalid ValueDecls
- Add some missing null checks for `getExtendedNominal`
- Avoid walking into invalid nested extensions in `ActorIsolationChecker`
- Continue to type-check members of invalid extensions 

rdar://176933373