### PR TITLE
[6.4][Concurrency] Audit uses of `getMainActorType()`

### DIFF
--- a/lib/AST/ActorIsolation.cpp
+++ b/lib/AST/ActorIsolation.cpp
@@ -19,8 +19,7 @@
 using namespace swift;
 
 ActorIsolation ActorIsolation::forMainActor(ASTContext &ctx) {
-  return ActorIsolation::forGlobalActor(
-      ctx.getMainActorType()->mapTypeOutOfEnvironment());
+  return ActorIsolation::forGlobalActor(ctx.getMainActorType());
 }
 
 // These constructors are defined out-of-line so that including ActorIsolation.h

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -5828,8 +5828,7 @@ getActorIsolationForMainFuncDecl(FuncDecl *fnDecl) {
   const bool hasMainActor = !ctx.getMainActorType().isNull();
 
   return isMainFunction && hasMainActor
-             ? ActorIsolation::forGlobalActor(
-                   ctx.getMainActorType()->mapTypeOutOfEnvironment())
+             ? ActorIsolation::forGlobalActor(ctx.getMainActorType())
              : std::optional<ActorIsolation>();
 }
 
@@ -6329,9 +6328,9 @@ computeDefaultInferredActorIsolation(ValueDecl *value) {
     DefaultIsolation defaultIsolation =
         getDefaultIsolationForContext(value->getDeclContext());
     // If we are required to use main actor... just use that.
-    if (defaultIsolation == DefaultIsolation::MainActor)
-      if (auto result =
-              globalActorHelper(ctx.getMainActorType()->mapTypeOutOfEnvironment()))
+    if (defaultIsolation == DefaultIsolation::MainActor &&
+        ctx.getMainActorType())
+      if (auto result = globalActorHelper(ctx.getMainActorType()))
         return *result;
   }
 
@@ -7213,8 +7212,7 @@ void swift::checkGlobalIsolation(VarDecl *var) {
       diag.fixItReplace(fixItLoc, "let");
   }
 
-  auto mainActor = var->getASTContext().getMainActorType();
-  if (mainActor) {
+  if (auto mainActor = var->getASTContext().getMainActorType()) {
     diagVar
         ->diagnose(diag::add_globalactor_to_decl, mainActor->getString(),
                    diagVar, mainActor)
@@ -7896,9 +7894,10 @@ static Type applyUnsafeConcurrencyToParameterType(
     return type;
 
   auto isolation = fnType->getIsolation();
-  if (mainActor)
-    isolation = FunctionTypeIsolation::forGlobalActor(
-                  type->getASTContext().getMainActorType());
+  if (mainActor) {
+    if (auto mainActorTy = type->getASTContext().getMainActorType())
+      isolation = FunctionTypeIsolation::forGlobalActor(mainActorTy);
+  }
 
   return fnType->withExtInfo(fnType->getExtInfo()
                                .withSendable(sendable)

--- a/validation-test/Sema/type_checker_crashers_fixed/embedded_with_default_isolation.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/embedded_with_default_isolation.swift
@@ -1,0 +1,11 @@
+// RUN: %target-typecheck-verify-swift -target arm64-apple-macos14 -enable-experimental-feature Embedded -default-isolation MainActor
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: swift_feature_Embedded
+// REQUIRES: OS=macosx
+
+var counter = 0
+
+func tick() {
+  counter += 1
+}


### PR DESCRIPTION
- Explanation:

  Fixes a crash when `MainActor` type is unavailable.

  Sometimes `MainActor` is not available i.e. in embedded mode, so we need to make sure that all uses check for `nullptr`.

  While here, let's remove extraneous uses of `mapTypeOutOfEnvironment`.

- Resolves: rdar://179389083

- Main branch PR: https://github.com/swiftlang/swift/pull/89929

- Risk: Very low, this change adds a few null pointer checks and remove code that is no-op.

- Reviewed By: @slavapestov 

- Testing: Added new test-cases to the suite.

(cherry picked from commit 672e7fb85df563c3fbc41592f2e6e226d267c52d)

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
