### PR TITLE
[Parse] A couple of overlapping ASTScope children fixes

### DIFF
--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -8681,7 +8681,7 @@ Parser::parseDeclVarGetSet(PatternBindingEntry &entry, ParseDeclOptions Flags,
   if (!storage) {
     storage = new (Context) VarDecl(StaticLoc.isValid(),
                                     VarDecl::Introducer::Var,
-                                    VarLoc, Identifier(),
+                                    pattern->getStartLoc(), Identifier(),
                                     CurDeclContext);
     storage->setInvalid();
 

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -1924,7 +1924,7 @@ ParserResult<Stmt> Parser::parseStmtIf(LabeledStmtInfo LabelInfo,
   if (IfWasImplicitlyInserted) {
     // The code was invalid due to a missing 'if' (e.g. 'else x < y {') and a
     // fixit implicitly inserted it.
-    IfLoc = Tok.getLoc();
+    IfLoc = PreviousLoc;
   } else {
     IfLoc = consumeToken(tok::kw_if);
   }

--- a/test/SourceKit/DocumentStructure/structure.swift.empty.response
+++ b/test/SourceKit/DocumentStructure/structure.swift.empty.response
@@ -546,8 +546,8 @@
       key.accessibility: source.lang.swift.accessibility.internal,
       key.setter_accessibility: source.lang.swift.accessibility.internal,
       key.offset: 1079,
-      key.length: 3,
-      key.nameoffset: 1079,
+      key.length: 5,
+      key.nameoffset: 1083,
       key.namelength: 0
     },
     {

--- a/test/SourceKit/DocumentStructure/structure.swift.foobar.response
+++ b/test/SourceKit/DocumentStructure/structure.swift.foobar.response
@@ -546,8 +546,8 @@
       key.accessibility: source.lang.swift.accessibility.internal,
       key.setter_accessibility: source.lang.swift.accessibility.internal,
       key.offset: 1079,
-      key.length: 3,
-      key.nameoffset: 1079,
+      key.length: 5,
+      key.nameoffset: 1083,
       key.namelength: 0
     },
     {

--- a/test/SourceKit/DocumentStructure/structure.swift.response
+++ b/test/SourceKit/DocumentStructure/structure.swift.response
@@ -546,8 +546,8 @@
       key.accessibility: source.lang.swift.accessibility.internal,
       key.setter_accessibility: source.lang.swift.accessibility.internal,
       key.offset: 1079,
-      key.length: 3,
-      key.nameoffset: 1079,
+      key.length: 5,
+      key.nameoffset: 1083,
       key.namelength: 0
     },
     {

--- a/validation-test/IDE/crashers_fixed/ASTScopeImpl-addChild-825c80.swift
+++ b/validation-test/IDE/crashers_fixed/ASTScopeImpl-addChild-825c80.swift
@@ -1,5 +1,5 @@
 // {"kind":"complete","original":"081c2cc3","signature":"swift::ast_scope::ASTScopeImpl::addChild(swift::ast_scope::ASTScopeImpl*, swift::ASTContext&)","signatureNext":"ScopeCreator::constructExpandAndInsert"}
-// RUN: not --crash %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -source-filename %s
+// RUN: %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -source-filename %s
 protocol a {
   associatedtype b: SignedInteger
     c,

--- a/validation-test/IDE/crashers_fixed/Decl-getSemanticAvailableAttr-ae7830.swift
+++ b/validation-test/IDE/crashers_fixed/Decl-getSemanticAvailableAttr-ae7830.swift
@@ -1,5 +1,5 @@
 // {"kind":"complete","original":"0715e0e8","signature":"swift::Decl::getSemanticAvailableAttr(swift::AvailableAttr const*) const"}
-// RUN: not --crash %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -source-filename %s
+// RUN: %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -source-filename %s
 class a {
   @available(*, renamed: "request0")
   !

--- a/validation-test/IDE/crashers_fixed/abortWithVerificationError-386709.swift
+++ b/validation-test/IDE/crashers_fixed/abortWithVerificationError-386709.swift
@@ -1,5 +1,5 @@
 // {"kind":"complete","original":"ae634063","signature":"abortWithVerificationError"}
-// RUN: not --crash %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -source-filename %s
+// RUN: %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -source-filename %s
 protocol a {
   associatedtype
     b:

--- a/validation-test/compiler_crashers_fixed/ASTScopeImpl-addChild-522004.swift
+++ b/validation-test/compiler_crashers_fixed/ASTScopeImpl-addChild-522004.swift
@@ -1,4 +1,4 @@
 // {"kind":"typecheck","original":"1c9cb9fd","signature":"swift::ast_scope::ASTScopeImpl::addChild(swift::ast_scope::ASTScopeImpl*, swift::ASTContext&)","signatureNext":"ScopeCreator::constructWithPortionExpandAndInsert"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 if { }
 else extension {

--- a/validation-test/compiler_crashers_fixed/ASTScopeImpl-addChild-e4b31d.swift
+++ b/validation-test/compiler_crashers_fixed/ASTScopeImpl-addChild-e4b31d.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","original":"cb3e622a","signature":"swift::ast_scope::ASTScopeImpl::addChild(swift::ast_scope::ASTScopeImpl*, swift::ASTContext&)","signatureNext":"ScopeCreator::constructExpandAndInsert"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 {
   let a,
     () {

--- a/validation-test/compiler_crashers_fixed/Decl-getResolvedCustomAttrType-442f5c.swift
+++ b/validation-test/compiler_crashers_fixed/Decl-getResolvedCustomAttrType-442f5c.swift
@@ -1,4 +1,4 @@
 // {"kind":"typecheck","signature":"swift::Decl::getResolvedCustomAttrType(swift::CustomAttr*) const"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 struct a {
   @b c, () {

--- a/validation-test/compiler_crashers_fixed/TypeDecl-getName-51a729.swift
+++ b/validation-test/compiler_crashers_fixed/TypeDecl-getName-51a729.swift
@@ -1,4 +1,4 @@
 // {"extraArgs":["-experimental-allow-module-with-compiler-errors"],"kind":"emit-sil","original":"d04192e0","signature":"swift::TypeDecl::getName() const"}
-// RUN: not --crash %target-swift-frontend -emit-sil -experimental-allow-module-with-compiler-errors %s
+// RUN: not %target-swift-frontend -emit-sil -experimental-allow-module-with-compiler-errors %s
 extension {
   @a b, : {


### PR DESCRIPTION
Ensure when synthesizing implicit nodes for parser recovery that we pick source locations that will not overlap with previous or subsequent AST nodes.