### PR TITLE
[6.4] [Sema] Remove an `ABORT` for 6.4

### DIFF
--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -681,7 +681,8 @@ bool TypeChecker::typeCheckBinding(Pattern *&pattern, Expr *&initializer,
         target.markInvalid();
         return true;
       }
-      ABORT("Cannot type-check PatternBindingDecl without closure context");
+      // Disabled for 6.4, we'll fall through and attempt to type-check.
+      // ABORT("Cannot type-check PatternBindingDecl without closure context");
     }
   }
 

--- a/validation-test/compiler_crashers_fixed/TypeChecker-typeCheckBinding-1be790.swift
+++ b/validation-test/compiler_crashers_fixed/TypeChecker-typeCheckBinding-1be790.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","original":"16a71758","signature":"swift::TypeChecker::typeCheckBinding(swift::Pattern*&, swift::Expr*&, swift::DeclContext*, swift::Type, swift::PatternBindingDecl*, unsigned int, swift::optionset::OptionSet<swift::TypeCheckExprFlags, unsigned int>)","signatureNext":"TypeChecker::typeCheckPatternBinding"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 func a(
     = {
       let b = c {

--- a/validation-test/compiler_crashers_fixed/TypeChecker-typeCheckBinding-e3b1a7.swift
+++ b/validation-test/compiler_crashers_fixed/TypeChecker-typeCheckBinding-e3b1a7.swift
@@ -1,0 +1,6 @@
+// RUN: %target-swift-ide-test -print-indexed-symbols -include-locals -source-filename %s
+extension Undefined {
+  func f() {
+    _ = { let x = 0 }
+  }
+}


### PR DESCRIPTION
- Explanation: Removes an `ABORT` for 6.4. This is being properly fixed on main by the last commit on #89973 (the other commits I'll cherry-pick to 6.4).
- Scope: Affects lazy type-checking of bindings in invalid extensions 
- Issue: rdar://176933373
- Risk: None, changes a path that would previously always crash into a fall-through for release builds. This restores the original behavior of the code prior to the assert being added.
- Testing: Added test to test suite
- Reviewer: Anthony Latsis

