### PR TITLE
[6.4] ASTPrinter: always print suppressed primary associated types

### DIFF
--- a/include/swift/AST/GenericSignature.h
+++ b/include/swift/AST/GenericSignature.h
@@ -323,6 +323,16 @@ public:
       SmallVector<Requirement, 2> &reqs,
       SmallVector<InverseRequirement, 2> &inverses) const;
 
+  /// A version of `getRequirementsWithInverses` for the ASTPrinter, to help
+  /// with the migration from the legacy SuppressedAssociatedTypes and the new
+  /// SuppressedAssociatedTypesWithDefaults (aka SE-503).
+  ///
+  /// Do not introduce new uses of this function. It should be removed!
+  void getRequirementsWithInversesAndOmitted(
+      SmallVector<Requirement, 2> &reqs,
+      SmallVector<InverseRequirement, 2> &inverses,
+      SmallVector<Requirement, 2> &omitted) const;
+
   /// Iterate over all generic parameters, passing a flag to the callback
   /// indicating if the generic parameter is canonical or not.
   void forEachParam(

--- a/include/swift/AST/GenericSignature.h
+++ b/include/swift/AST/GenericSignature.h
@@ -328,10 +328,11 @@ public:
   /// SuppressedAssociatedTypesWithDefaults (aka SE-503).
   ///
   /// Do not introduce new uses of this function. It should be removed!
-  void getRequirementsWithInversesAndOmitted(
+  ///
+  /// \param reqs will include extra requirements for the ASTPrinter.
+  void getRequirementsWithInversesForPrinting(
       SmallVector<Requirement, 2> &reqs,
-      SmallVector<InverseRequirement, 2> &inverses,
-      SmallVector<Requirement, 2> &omitted) const;
+      SmallVector<InverseRequirement, 2> &inverses) const;
 
   /// Iterate over all generic parameters, passing a flag to the callback
   /// indicating if the generic parameter is canonical or not.
@@ -561,6 +562,17 @@ private:
   /// Return the reduced version of the given type under this generic
   /// signature.
   CanType getReducedType(Type type) const;
+
+  /// Transform the requirements into a form where implicit Copyable and
+  /// Escapable conformances are omitted, and their absence is explicitly
+  /// noted.
+  ///
+  /// \param ForPrinting controls whether some Requirements are not omitted,
+  /// for the ASTPrinter's needs.
+  void getRequirementsWithInversesImpl(
+      SmallVector<Requirement, 2> &reqs,
+      SmallVector<InverseRequirement, 2> &inverses,
+      bool ForPrinting) const;
 };
 
 void simple_display(raw_ostream &out, GenericSignature sig);

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -2022,8 +2022,7 @@ void PrintAST::printGenericSignature(
     requirements.append(genericSig.getRequirements().begin(),
                         genericSig.getRequirements().end());
   } else if (flags & PrintInverseRequirements) {
-    genericSig->getRequirementsWithInversesAndOmitted(requirements, inverses,
-                                                      /*omitted=*/requirements);
+    genericSig->getRequirementsWithInversesForPrinting(requirements, inverses);
     llvm::erase_if(inverses, [&](InverseRequirement inverse) -> bool {
       return !inverseFilter(inverse);
     });
@@ -3510,8 +3509,7 @@ void PrintAST::printSynthesizedExtensionImpl(Type ExtendedType,
     SmallVector<Requirement, 2> requirements;
     SmallVector<InverseRequirement, 2> inverses;
     auto Sig = ED->getGenericSignature();
-    Sig->getRequirementsWithInversesAndOmitted(requirements, inverses,
-                                               /*omitted=*/requirements);
+    Sig->getRequirementsWithInversesForPrinting(requirements, inverses);
     printSingleDepthOfGenericSignature(
         Sig.getGenericParams(),
         requirements,

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -2022,7 +2022,8 @@ void PrintAST::printGenericSignature(
     requirements.append(genericSig.getRequirements().begin(),
                         genericSig.getRequirements().end());
   } else if (flags & PrintInverseRequirements) {
-    genericSig->getRequirementsWithInverses(requirements, inverses);
+    genericSig->getRequirementsWithInversesAndOmitted(requirements, inverses,
+                                                      /*omitted=*/requirements);
     llvm::erase_if(inverses, [&](InverseRequirement inverse) -> bool {
       return !inverseFilter(inverse);
     });
@@ -3509,7 +3510,8 @@ void PrintAST::printSynthesizedExtensionImpl(Type ExtendedType,
     SmallVector<Requirement, 2> requirements;
     SmallVector<InverseRequirement, 2> inverses;
     auto Sig = ED->getGenericSignature();
-    Sig->getRequirementsWithInverses(requirements, inverses);
+    Sig->getRequirementsWithInversesAndOmitted(requirements, inverses,
+                                               /*omitted=*/requirements);
     printSingleDepthOfGenericSignature(
         Sig.getGenericParams(),
         requirements,

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -1360,15 +1360,19 @@ GenericSignature GenericSignature::withoutMarkerProtocols() const {
 void GenericSignatureImpl::getRequirementsWithInverses(
     SmallVector<Requirement, 2> &reqs,
     SmallVector<InverseRequirement, 2> &inverses) const {
-  // Throwing away the omitted requirements is the normal behavior.
-  SmallVector<Requirement, 2> _throw_away_omitted;
-  getRequirementsWithInversesAndOmitted(reqs, inverses, _throw_away_omitted);
+  getRequirementsWithInversesImpl(reqs, inverses, /*ForPrinting*/ false);
 }
 
-void GenericSignatureImpl::getRequirementsWithInversesAndOmitted(
+void GenericSignatureImpl::getRequirementsWithInversesForPrinting(
+    SmallVector<Requirement, 2> &reqs,
+    SmallVector<InverseRequirement, 2> &inverses) const {
+  getRequirementsWithInversesImpl(reqs, inverses, /*ForPrinting*/ true);
+}
+
+void GenericSignatureImpl::getRequirementsWithInversesImpl(
     SmallVector<Requirement, 2> &reqs,
     SmallVector<InverseRequirement, 2> &inverses,
-    SmallVector<Requirement, 2> &omitted) const {
+    bool ForPrinting) const {
   auto &ctx = getASTContext();
 
   llvm::SmallSet<CanType, 12> seenDMTs;
@@ -1479,13 +1483,12 @@ void GenericSignatureImpl::getRequirementsWithInversesAndOmitted(
 
     // If the subject matches a primary associated type we identified earlier,
     // then we will infer a default for them, so drop this requirement.
-    if (seenDMTs.contains(subject->getCanonicalType())) {
-      // To maintain with compatability between SE-503 and the deprecated
-      // SuppressedAssociatedTypes, preserve provide these in the "omitted"
-      // output for the ASTPrinter.
-      omitted.push_back(req);
+    //
+    // To maintain with compatability between SE-503 and the deprecated
+    // SuppressedAssociatedTypes, we preserve these requirements when the
+    // purpose is for the ASTPrinter.
+    if (!ForPrinting && seenDMTs.contains(subject->getCanonicalType()))
       continue;
-    }
 
     // Otherwise, for a non-primary associated type, no default is inferred,
     // thus this conformance requirement was explicitly stated. Keep it.

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -1360,6 +1360,15 @@ GenericSignature GenericSignature::withoutMarkerProtocols() const {
 void GenericSignatureImpl::getRequirementsWithInverses(
     SmallVector<Requirement, 2> &reqs,
     SmallVector<InverseRequirement, 2> &inverses) const {
+  // Throwing away the omitted requirements is the normal behavior.
+  SmallVector<Requirement, 2> _throw_away_omitted;
+  getRequirementsWithInversesAndOmitted(reqs, inverses, _throw_away_omitted);
+}
+
+void GenericSignatureImpl::getRequirementsWithInversesAndOmitted(
+    SmallVector<Requirement, 2> &reqs,
+    SmallVector<InverseRequirement, 2> &inverses,
+    SmallVector<Requirement, 2> &omitted) const {
   auto &ctx = getASTContext();
 
   llvm::SmallSet<CanType, 12> seenDMTs;
@@ -1470,8 +1479,13 @@ void GenericSignatureImpl::getRequirementsWithInverses(
 
     // If the subject matches a primary associated type we identified earlier,
     // then we will infer a default for them, so drop this requirement.
-    if (seenDMTs.contains(subject->getCanonicalType()))
+    if (seenDMTs.contains(subject->getCanonicalType())) {
+      // To maintain with compatability between SE-503 and the deprecated
+      // SuppressedAssociatedTypes, preserve provide these in the "omitted"
+      // output for the ASTPrinter.
+      omitted.push_back(req);
       continue;
+    }
 
     // Otherwise, for a non-primary associated type, no default is inferred,
     // thus this conformance requirement was explicitly stated. Keep it.

--- a/test/ModuleInterface/associated_type_suppressed.swift
+++ b/test/ModuleInterface/associated_type_suppressed.swift
@@ -77,10 +77,9 @@ public func ncIter3<T: P>(_ t: T) where T.Element: Copyable {}
 // SIL: @$s5assoc6ncBothyyxAA1PRz7ElementRj_zlF :
 public func ncBoth<T: P>(_ t: T) where T.Iterator: ~Copyable, T.Element: ~Copyable {}
 
-// INTERFACE: public func bothCopyable<T>(_ t: T) where T : assoc::P, T.Iterator : Swift::Copyable
-// SIL-NEW:    @$s5assoc12bothCopyableyyxAA1PRzs0C08IteratorRpzlF :
-// SIL-LEGACY: @$s5assoc12bothCopyableyyxAA1PRzs0C08IteratorRpz7ElementRj_zlF :
-public func bothCopyable<T: P>(_ t: T) where T.Iterator: Copyable {}
+// INTERFACE: public func bothCopyable<T>(_ t: T) where T : assoc::P, T.Element : Swift::Copyable, T.Iterator : Swift::Copyable
+// SIL:    @$s5assoc12bothCopyableyyxAA1PRzs0C08IteratorRpzlF :
+public func bothCopyable<T: P>(_ t: T) where T.Element: Copyable, T.Iterator: Copyable {}
 
 // INTERFACE-LABEL: public struct Holder<S> where S : assoc::P, S : ~Copyable, S.Element : ~Copyable {
 public struct Holder<S> where S.Element: ~Copyable, S: P & ~Copyable {
@@ -94,13 +93,14 @@ public struct Holder<S> where S.Element: ~Copyable, S: P & ~Copyable {
 // SIL: @$s5assoc6HolderVAARi_z7ElementRj_zrlE02ncC0yyqd__AA1PRd__ADRj_d__lF :
   public func ncElement<T>(_ t: T) where T: P, T.Element: ~Copyable {}
 
-// INTERFACE: public func copyableIter<T>(_ t: T) where T : assoc::P, T.Iterator : Swift::Copyable
+// INTERFACE-NEW: public func copyableIter<T>(_ t: T) where T : assoc::P, T.Element : Swift::Copyable, T.Iterator : Swift::Copyable
+// INTERFACE-OLD: public func copyableIter<T>(_ t: T) where T : assoc::P, T.Iterator : Swift::Copyable, T.Element : ~Copyable
 // SIL-NEW:    @$s5assoc6HolderVAARi_z7ElementRj_zrlE12copyableIteryyqd__AA1PRd__s8Copyable8IteratorRpd__lF :
 // SIL-LEGACY: @$s5assoc6HolderVAARi_z7ElementRj_zrlE12copyableIteryyqd__AA1PRd__s8Copyable8IteratorRpd__ADRj_d__lF :
 public func copyableIter<T: P>(_ t: T) where T.Iterator: Copyable {}
 }
 
-// INTERFACE-NEW: extension assoc::Holder {
+// INTERFACE-NEW: extension assoc::Holder where S.Element : Swift::Copyable {
 // INTERFACE-LEGACY: extension assoc::Holder where S.Element : ~Copyable {
 extension Holder {
   // SIL-NEW:    @$s5assoc6HolderV19forceIntoInterface1yyF :
@@ -111,7 +111,7 @@ extension Holder {
   public func forceIntoInterface1c() where S.Element: Copyable {}
 }
 
-// INTERFACE-NEW: extension assoc::Holder where S.Iterator : Swift::Copyable {
+// INTERFACE-NEW: extension assoc::Holder where S.Element : Swift::Copyable, S.Iterator : Swift::Copyable {
 // INTERFACE-LEGACY: extension assoc::Holder where S.Iterator : Swift::Copyable, S.Element : ~Copyable {
 extension Holder where S.Iterator: Copyable {
   // SIL-NEW:    @$s5assoc6HolderVAAs8Copyable8IteratorRpzrlE19forceIntoInterface2yyF :
@@ -128,7 +128,7 @@ extension Holder where S.Element: ~Copyable {
   public func forceIntoInterface5() {}
 }
 
-// INTERFACE-NEW: extension assoc::P {
+// INTERFACE-NEW: extension assoc::P where Self.Element : Swift::Copyable {
 // INTERFACE-LEGACY: extension assoc::P where Self.Element : ~Copyable {
 extension P {
   // SIL-NEW:    @$s5assoc1PPAAE19forceIntoInterface3yyF :
@@ -138,7 +138,7 @@ extension P {
   public func forceIntoInterface3c() where Element: Copyable {}
 }
 
-// INTERFACE-NEW: extension assoc::P where Self.Iterator : Swift::Copyable {
+// INTERFACE-NEW: extension assoc::P where Self.Element : Swift::Copyable, Self.Iterator : Swift::Copyable {
 // INTERFACE-LEGACY: extension assoc::P where Self.Iterator : Swift::Copyable, Self.Element : ~Copyable {
 extension P where Iterator: Copyable {
   // SIL-NEW:    @$s5assoc1PPAAs8Copyable8IteratorRpzrlE19forceIntoInterface4yyF :
@@ -147,4 +147,10 @@ extension P where Iterator: Copyable {
 
   // SIL:        @$s5assoc1PPAAs8Copyable8IteratorRpzrlE20forceIntoInterface4cyyF :
   public func forceIntoInterface4c() where Element: Copyable {}
+}
+
+// INTERFACE: extension assoc::P where Self.Element : Swift::Copyable {
+extension P where Element: Copyable {
+  // SIL:    @$s5assoc1PPAAE19forceIntoInterface5yyF :
+  public func forceIntoInterface5() {}
 }


### PR DESCRIPTION
- Explanation: The swiftinterface files need to always print whether a suppressed primary associated type is Copyable or Escapable, to make the fix in https://github.com/swiftlang/swift/pull/89558 work correctly.
- Scope: ASTPrinter / swiftinterface emission
- Issues: rdar://179726255
- Risk: Low. It's just emitting more information in the swiftinterface file than we were before.
- Testing: regression tests included
- Original PRs: https://github.com/swiftlang/swift/pull/89970, https://github.com/swiftlang/swift/pull/90026
- Reviewers: Pavel