### PR TITLE
Allow borrow accessors to be defined in extension of protocols

### DIFF
--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -4407,7 +4407,6 @@ StorageImplInfoRequest::evaluate(Evaluator &evaluator,
   bool hasYieldingMutate = storage->getParsedAccessor(AccessorKind::YieldingMutate);
   bool hasMutableAddress = storage->getParsedAccessor(AccessorKind::MutableAddress);
   bool hasInit = storage->getParsedAccessor(AccessorKind::Init);
-  auto *borrow = storage->getParsedAccessor(AccessorKind::Borrow);
   auto *mutate = storage->getParsedAccessor(AccessorKind::Mutate);
 
   // 'get', 'read', 'borrow' and a non-mutable addressor are all exclusive.
@@ -4508,31 +4507,6 @@ StorageImplInfoRequest::evaluate(Evaluator &evaluator,
   } else {
     writeImpl = WriteImplKind::Immutable;
     readWriteImpl = ReadWriteImplKind::Immutable;
-  }
-
-  if (borrow || mutate) {
-    if (auto *extDecl = dyn_cast<ExtensionDecl>(DC)) {
-      auto extNominal = extDecl->getExtendedNominal();
-      if (extNominal && !isa<StructDecl>(extNominal) &&
-          !isa<EnumDecl>(extNominal) && !isa<ClassDecl>(extNominal)) {
-        if (borrow) {
-          storage->getASTContext().Diags.diagnose(
-              borrow->getLoc(),
-              diag::borrow_mutate_accessor_not_supported_in_decl,
-              getAccessorNameForDiagnostic(borrow->getAccessorKind(),
-                                           /*article*/ true,
-                                           /*underscored*/ false));
-        }
-        if (mutate) {
-          storage->getASTContext().Diags.diagnose(
-              mutate->getLoc(),
-              diag::borrow_mutate_accessor_not_supported_in_decl,
-              getAccessorNameForDiagnostic(mutate->getAccessorKind(),
-                                           /*article*/ true,
-                                           /*underscored*/ false));
-        }
-      }
-    }
   }
 
   StorageImplInfo info(readImpl, writeImpl, readWriteImpl);

--- a/test/Sema/borrow_and_mutate_accessors.swift
+++ b/test/Sema/borrow_and_mutate_accessors.swift
@@ -206,3 +206,25 @@ struct S10 {
   }
 }
 
+protocol CxxStorage: AnyObject {
+  associatedtype State: ~Copyable
+
+  @unsafe
+  var swiftStateRawSlot: UnsafeMutableRawPointer? { get set }
+}
+
+extension CxxStorage where State: ~Copyable {
+  @export(interface)
+  @safe
+  var state: State {
+    @_unsafeSelfDependentResult
+    borrow {
+      unsafe self.swiftStateRawSlot!.assumingMemoryBound(to: State.self).pointee
+    }
+    @_unsafeSelfDependentResult
+    mutate {
+      unsafe &self.swiftStateRawSlot!.assumingMemoryBound(to: State.self).pointee
+    }
+  }
+}
+


### PR DESCRIPTION
This was unnecesarily triggered as an error.

