### PR TITLE
[Concurrency] Check for Clang import during diagnostic behavior checking

### DIFF
--- a/include/swift/AST/Concurrency.h
+++ b/include/swift/AST/Concurrency.h
@@ -19,8 +19,11 @@
 
 namespace swift {
 
-/// Find the imported module that treats the given nominal type as "preconcurrency", or return `nullptr`
-/// if there is no such module.
+/// Find the imported module that treats the given nominal type as
+/// "preconcurrency", or return `nullptr` if there is no such module.
+///
+/// Does not reflect whether the nominal is from Clang or has `@preconcurrency`;
+/// use `Decl::preconcurrency()` for that.
 ModuleDecl *moduleImportForPreconcurrency(NominalTypeDecl *nominal,
                                           const DeclContext *fromDC);
 

--- a/lib/AST/Concurrency.cpp
+++ b/lib/AST/Concurrency.cpp
@@ -16,17 +16,12 @@
 #include "swift/AST/Decl.h"
 #include "swift/AST/ProtocolConformance.h"
 #include "swift/AST/SourceFile.h"
+#include "swift/Basic/LangOptions.h"
 
 using namespace swift;
 
 ModuleDecl *swift::moduleImportForPreconcurrency(
     NominalTypeDecl *nominal, const DeclContext *fromDC) {
-  // If the declaration itself has the @preconcurrency attribute,
-  // respect it.
-  if (nominal->getAttrs().hasAttribute<PreconcurrencyAttr>()) {
-    return nominal->getParentModule();
-  }
-
   // Determine whether this nominal type is visible via a @preconcurrency
   // import.
   auto import = nominal->findImport(fromDC);
@@ -46,16 +41,31 @@ swift::getConcurrencyDiagnosticBehaviorLimit(NominalTypeDecl *nominal,
                                              const DeclContext *fromDC,
                                              bool ignoreExplicitConformance) {
   ModuleDecl *importedModule = moduleImportForPreconcurrency(nominal, fromDC);
-  if (!importedModule)
+
+  // No @preconcurrency import, and the decl itself isn't preconcurrency: no
+  // limit.
+  // DISCUSSION: Check this before the conformance lookup below, which has side
+  // effects for lazy attributes like @_nonSendable. When that has been cleaned
+  // up this paranoia is no longer warranted...
+  if (!importedModule && !nominal->preconcurrency())
     return std::nullopt;
 
-  // When the type is explicitly non-Sendable, @preconcurrency imports
-  // downgrade the diagnostic to a warning in Swift 6.
+  // An explicitly non-Sendable type downgrades to a warning, whether it's a
+  // preconcurrency decl or imported. Explicit Sendable conformance warns
+  // even below complete checking.
   if (!ignoreExplicitConformance && hasExplicitSendableConformance(nominal))
     return DiagnosticBehavior::Warning;
 
-  // When the type is implicitly non-Sendable, `@preconcurrency` suppresses
-  // diagnostics until the imported module enables Swift 6.
+  // Otherwise the type is implicitly non-Sendable. A preconcurrency decl (no
+  // import) warns only under complete checking.
+  if (!importedModule)
+    return fromDC->getASTContext().LangOpts.StrictConcurrencyLevel >=
+                   StrictConcurrency::Complete
+               ? DiagnosticBehavior::Warning
+               : DiagnosticBehavior::Ignore;
+
+  // An implicitly non-Sendable type behind a @preconcurrency import is
+  // suppressed until the imported module enables Swift 6.
   return importedModule->isConcurrencyChecked() ? DiagnosticBehavior::Warning
                                                 : DiagnosticBehavior::Ignore;
 }

--- a/test/ClangImporter/objc_async.swift
+++ b/test/ClangImporter/objc_async.swift
@@ -6,7 +6,6 @@
 
 import Foundation
 import ObjCConcurrency
-// expected-warning@-1{{add '@preconcurrency' to suppress 'Sendable'-related warnings from module 'ObjCConcurrency'}}
 
 @available(SwiftStdlib 5.5, *)
 @MainActor func onlyOnMainActor() { }
@@ -369,7 +368,6 @@ func testSender(
   sender.sendGeneric(sendableGeneric) // no warning
 
   sender.sendGeneric(nonSendableGeneric)
-  // expected-warning@-1 {{type 'GenericObject<SendableClass>' does not conform to the 'Sendable' protocol}}
 
   sender.sendPtr(ptr)
   sender.sendStringArray(stringArray)

--- a/test/ClangImporter/regionbasedisolation.swift
+++ b/test/ClangImporter/regionbasedisolation.swift
@@ -133,7 +133,7 @@ nonisolated(nonsending) func useValueNonIsolatedNonSending<T>(_ t: T) async {}
 @MainActor func testMainActorMerging(_ y: NSObject) async {
   let x = ObjCObject()
   await x.useValue(y)
-  await useValueConcurrently(x)  // expected-error {{sending 'x' risks causing data races}}
+  await useValueConcurrently(x)  // expected-warning {{sending 'x' risks causing data races}}
   // expected-ni-note @-1 {{sending main actor-isolated 'x' to @concurrent global function 'useValueConcurrently' risks causing data races between @concurrent and main actor-isolated uses}}
   // expected-ni-ns-note @-2 {{sending main actor-isolated 'x' to @concurrent global function 'useValueConcurrently' risks causing data races between @concurrent and main actor-isolated uses}}
 }
@@ -141,12 +141,12 @@ nonisolated(nonsending) func useValueNonIsolatedNonSending<T>(_ t: T) async {}
 func testTaskLocal(_ y: NSObject) async {
   let x = ObjCObject()
   await x.useValue(y)
-  await useValueConcurrently(x) // expected-ni-ns-error {{sending 'x' risks causing data races}}
+  await useValueConcurrently(x) // expected-ni-ns-warning {{sending 'x' risks causing data races}}
   // expected-ni-ns-note @-1 {{sending 'x' to @concurrent global function 'useValueConcurrently' risks causing data races between @concurrent code and code in the current isolation context}}
 
   // This is not safe since we merge x into y's region making x task
   // isolated. We then try to send it to a main actor function.
-  await useValueMainActor(x) // expected-error {{sending 'x' risks causing data races}}
+  await useValueMainActor(x) // expected-warning {{sending 'x' risks causing data races}}
   // expected-note @-1 {{sending 'x' to main actor-isolated global function 'useValueMainActor' risks causing data races between main actor-isolated code and code in the current isolation context}}
 }
 

--- a/test/ClangImporter/sending.swift
+++ b/test/ClangImporter/sending.swift
@@ -27,21 +27,21 @@ func funcTestSendingResult() async {
   // Just to show that without the sending param, we generate diagnostics.
   let x2 = NonSendableCStruct()
   let y2 = returnUserDefinedFromGlobalFunction(x2)
-  await sendToMain(x2) // expected-error {{sending 'x2' risks causing data races}}
+  await sendToMain(x2) // expected-warning {{sending 'x2' risks causing data races}}
   // expected-note @-1 {{sending 'x2' to main actor-isolated global function 'sendToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   useValue(y2) // expected-note {{access can happen concurrently}}
 }
 
 func funcTestSendingArg() async {
   let x = NonSendableCStruct()
-  sendUserDefinedIntoGlobalFunction(x) // expected-error {{sending 'x' risks causing data races}}
+  sendUserDefinedIntoGlobalFunction(x) // expected-warning {{sending 'x' risks causing data races}}
   // expected-note @-1 {{'x' used after being passed as a 'sending' parameter}}
   useValue(x) // expected-note {{access can happen concurrently}}
 }
 
 func funcTestSendingClosureArg() async {
   sendingWithCompletionHandler { (x: sending NonSendableCStruct) in
-    sendUserDefinedIntoGlobalFunction(x) // expected-error {{sending 'x' risks causing data races}}
+    sendUserDefinedIntoGlobalFunction(x) // expected-warning {{sending 'x' risks causing data races}}
     // expected-note @-1 {{'x' used after being passed as a 'sending' parameter}}
     useValue(x) // expected-note {{access can happen concurrently}}
   }
@@ -49,7 +49,7 @@ func funcTestSendingClosureArg() async {
   let x = sendingWithLazyReturn { () -> sending NonSendableCStruct in
     NonSendableCStruct()
   }
-  sendUserDefinedIntoGlobalFunction(x) // expected-error {{sending 'x' risks causing data races}}
+  sendUserDefinedIntoGlobalFunction(x) // expected-warning {{sending 'x' risks causing data races}}
   // expected-note @-1 {{'x' used after being passed as a 'sending' parameter}}
   useValue(x) // expected-note {{access can happen concurrently}}
 }

--- a/test/ClangImporter/sending_objc.swift
+++ b/test/ClangImporter/sending_objc.swift
@@ -25,7 +25,7 @@ func methodTestSendingResult() async {
 func methodTestSendingArg() async {
   let x = MyType()
   let s = NSObject()
-  let _ = x.getResultWithSendingArgument(s)  // expected-error {{sending 's' risks causing data races}}
+  let _ = x.getResultWithSendingArgument(s)  // expected-warning {{sending 's' risks causing data races}}
   // expected-note @-1 {{'s' used after being passed as a 'sending' parameter; Later uses could race}}
   useValue(s) // expected-note {{access can happen concurrently}}
 }
@@ -45,14 +45,14 @@ func funcTestSendingResult() async {
   // Just to show that without the sendring param, we generate diagnostics.
   let x2 = NSObject()
   let y2 = returnNSObjectFromGlobalFunction(x2)
-  await sendToMain(x2) // expected-error {{sending 'x2' risks causing data races}}
+  await sendToMain(x2) // expected-warning {{sending 'x2' risks causing data races}}
   // expected-note @-1 {{sending 'x2' to main actor-isolated global function 'sendToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
   useValue(y2) // expected-note {{access can happen concurrently}}
 }
 
 func funcTestSendingArg() async {
   let x = NSObject()
-  sendNSObjectToGlobalFunction(x) // expected-error {{sending 'x' risks causing data races}}
+  sendNSObjectToGlobalFunction(x) // expected-warning {{sending 'x' risks causing data races}}
   // expected-note @-1 {{'x' used after being passed as a 'sending' parameter; Later uses could race}}
   useValue(x) // expected-note {{access can happen concurrently}}
 }

--- a/test/Concurrency/predates_concurrency_import.swift
+++ b/test/Concurrency/predates_concurrency_import.swift
@@ -5,7 +5,7 @@
 
 // RUN: %target-swift-frontend  -I %t %s -emit-sil -o /dev/null -verify -verify-ignore-unrelated  -parse-as-library -enable-upcoming-feature GlobalConcurrency -Wwarning PreconcurrencyImport
 // RUN: %target-swift-frontend  -I %t %s -emit-sil -o /dev/null -verify -verify-ignore-unrelated -strict-concurrency=targeted -parse-as-library -enable-upcoming-feature GlobalConcurrency -Wwarning PreconcurrencyImport
-// RUN: %target-swift-frontend  -I %t %s -emit-sil -o /dev/null -verify -verify-ignore-unrelated -strict-concurrency=complete  -parse-as-library -enable-upcoming-feature GlobalConcurrency -Wwarning PreconcurrencyImport
+// RUN: %target-swift-frontend  -I %t %s -emit-sil -o /dev/null -verify -verify-additional-prefix complete- -verify-ignore-unrelated -strict-concurrency=complete  -parse-as-library -enable-upcoming-feature GlobalConcurrency -Wwarning PreconcurrencyImport
 
 // REQUIRES: concurrency
 // REQUIRES: swift_feature_GlobalConcurrency
@@ -16,7 +16,7 @@
 // expected-warning@-1{{'@preconcurrency' on module 'OtherActors' has no effect}}{{1-17=}}
 
 @preconcurrency
-class MyPredatesConcurrencyClass { }
+class MyPredatesConcurrencyClass { } // expected-complete-note {{class 'MyPredatesConcurrencyClass' does not conform to the 'Sendable' protocol}}
 
 enum EnumWithPredatesConcurrencyValue {
   case stored(MyPredatesConcurrencyClass)
@@ -37,7 +37,10 @@ func test(
   acceptSendable(nsOpt) // silence issue entirely
   acceptSendable(oma) // okay
   acceptSendable(ssc) // okay
-  acceptSendable(mpcc)
+  // FIXME: The "; this is an error in the Swift 6 language mode" framing
+  // is wrong. See the FIXME at the limitBehaviorWithPreconcurrency call in
+  // lib/Sema/TypeCheckConcurrency.h.
+  acceptSendable(mpcc) // expected-complete-warning {{type 'MyPredatesConcurrencyClass' does not conform to the 'Sendable' protocol; this is an error in the Swift 6 language mode}}
 }
 
 let nonStrictGlobal = NonStrictClass() // no warning

--- a/test/Concurrency/sendable_objc_attr_in_type_context_swift5.swift
+++ b/test/Concurrency/sendable_objc_attr_in_type_context_swift5.swift
@@ -93,7 +93,6 @@ void doSomethingConcurrently(__attribute__((noescape)) void SWIFT_SENDABLE (^blo
 do {
   class SubTestNoActor : Test {
     @objc override func withMainActorId(_: @escaping (Any) -> Void) {}
-    // expected-warning@-1 {{declaration 'withMainActorId' has a type with different global actor isolation from any potential overrides; this is an error in the Swift 6 language mode}}
   }
 
   class SubTestWithActor : Test {
@@ -145,15 +144,12 @@ func test_sendable_attr_in_type_context(test: Test) {
 
 class TestConformanceWithStripping : InnerSendableTypes {
   func testComposition(_: MyValue) {
-    // expected-warning@-1 {{sendability of function types in instance method 'testComposition' does not match requirement in protocol 'InnerSendableTypes'; this is an error in the Swift 6 language mode}}
   }
 
   func test(_ options: [String: Any]) {
-    // expected-warning@-1 {{sendability of function types in instance method 'test' does not match requirement in protocol 'InnerSendableTypes'; this is an error in the Swift 6 language mode}}
   }
 
   func test(withCallback name: String, handler: @escaping @MainActor ([String : Any], (any Error)?) -> Void) { // Ok
-    // expected-warning@-1 {{sendability of function types in instance method 'test(withCallback:handler:)' does not match requirement in protocol 'InnerSendableTypes'; this is an error in the Swift 6 language mode}}
   }
 }
 

--- a/test/Concurrency/sendable_objc_attr_in_type_context_swift6.swift
+++ b/test/Concurrency/sendable_objc_attr_in_type_context_swift6.swift
@@ -97,7 +97,7 @@ void doSomethingConcurrently(__attribute__((noescape)) void SWIFT_SENDABLE (^blo
 do {
   class SubTestNoActor : Test {
     @objc override func withMainActorId(_: @escaping (Any) -> Void) {}
-    // expected-error@-1 {{declaration 'withMainActorId' has a type with different global actor isolation from any potential overrides}}
+    // expected-warning@-1 {{declaration 'withMainActorId' has a type with different global actor isolation from any potential overrides}}
   }
 
   class SubTestWithActor : Test {

--- a/test/Concurrency/tilde_sendable_objc.swift
+++ b/test/Concurrency/tilde_sendable_objc.swift
@@ -38,7 +38,7 @@ SWIFT_NONSENDABLE_ASSUMED
 func testSendable<T: Sendable>(_: T) {}
 
 public func test(p: Parent, v: SendableValue, ns: NonSendableValue) {
-  testSendable(p) // expected-error {{type 'Parent' does not conform to the 'Sendable' protocol}}
+  testSendable(p) // expected-warning {{type 'Parent' does not conform to the 'Sendable' protocol}}
   testSendable(v) // Ok (no diagnostics unable unavailable conformance associated with `Parent`).
   testSendable(ns) // expected-error {{conformance of 'NonSendableValue' to 'Sendable' is unavailable}}
 }

--- a/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
@@ -194,7 +194,7 @@ typedef void ( ^ObjCErrorHandler )( NSError * _Nullable inError );
   - (void) myMethod:(NSInteger)value1 foo:(NSInteger)value2;
 @end
 
-@interface GenericObject<T> : NSObject // expected-note {{generic class 'GenericObject' does not conform to the 'Sendable' protocol}}
+@interface GenericObject<T> : NSObject
 - (void)doSomethingWithCompletionHandler:(void (^)(T _Nullable_result, NSError * _Nullable))completionHandler;
 - (void)doAnotherThingWithCompletionHandler:(void (^)(GenericObject<T> *_Nullable))completionHandler;
 @end

--- a/test/Interop/Cxx/class/sendable-typechecker.swift
+++ b/test/Interop/Cxx/class/sendable-typechecker.swift
@@ -6,25 +6,25 @@ func takesSendable<T: Sendable>(_ x: T.Type) {}
 func takesSendable<T>(_: T.Type) where T: Sendable, T: ~Copyable {}
 func takesSendable(_: @Sendable () -> Void) {}
 
-takesSendable(HasPrivatePointerField.self) // expected-error {{type 'HasPrivatePointerField' does not conform to the 'Sendable' protocol}}
-takesSendable(HasProtectedPointerField.self) // expected-error {{type 'HasProtectedPointerField' does not conform to the 'Sendable' protocol}}
-takesSendable(HasPublicPointerField.self) // expected-error {{type 'HasPublicPointerField' does not conform to the 'Sendable' protocol}}
+takesSendable(HasPrivatePointerField.self) // expected-warning {{type 'HasPrivatePointerField' does not conform to the 'Sendable' protocol}}
+takesSendable(HasProtectedPointerField.self) // expected-warning {{type 'HasProtectedPointerField' does not conform to the 'Sendable' protocol}}
+takesSendable(HasPublicPointerField.self) // expected-warning {{type 'HasPublicPointerField' does not conform to the 'Sendable' protocol}}
 
-takesSendable(HasPrivateNonSendableField.self) // expected-error {{type 'HasPrivateNonSendableField' does not conform to the 'Sendable' protocol}}
-takesSendable(HasProtectedNonSendableField.self) // expected-error {{type 'HasProtectedNonSendableField' does not conform to the 'Sendable' protocol}}
-takesSendable(HasPublicNonSendableField.self) // expected-error {{type 'HasPublicNonSendableField' does not conform to the 'Sendable' protocol}}
+takesSendable(HasPrivateNonSendableField.self) // expected-warning {{type 'HasPrivateNonSendableField' does not conform to the 'Sendable' protocol}}
+takesSendable(HasProtectedNonSendableField.self) // expected-warning {{type 'HasProtectedNonSendableField' does not conform to the 'Sendable' protocol}}
+takesSendable(HasPublicNonSendableField.self) // expected-warning {{type 'HasPublicNonSendableField' does not conform to the 'Sendable' protocol}}
 
-takesSendable(DerivedFromHasPublicPointerField.self) // expected-error {{type 'DerivedFromHasPublicPointerField' does not conform to the 'Sendable' protocol}}
-takesSendable(DerivedFromHasPublicNonSendableField.self) // expected-error {{type 'DerivedFromHasPublicNonSendableField' does not conform to the 'Sendable' protocol}}
-takesSendable(DerivedFromHasPrivatePointerField.self) // expected-error {{type 'DerivedFromHasPrivatePointerField' does not conform to the 'Sendable' protocol}}
+takesSendable(DerivedFromHasPublicPointerField.self) // expected-warning {{type 'DerivedFromHasPublicPointerField' does not conform to the 'Sendable' protocol}}
+takesSendable(DerivedFromHasPublicNonSendableField.self) // expected-warning {{type 'DerivedFromHasPublicNonSendableField' does not conform to the 'Sendable' protocol}}
+takesSendable(DerivedFromHasPrivatePointerField.self) // expected-warning {{type 'DerivedFromHasPrivatePointerField' does not conform to the 'Sendable' protocol}}
 
-takesSendable(DerivedPrivatelyFromHasPublicPointerField.self) // expected-error {{type 'DerivedPrivatelyFromHasPublicPointerField' does not conform to the 'Sendable' protocol}}
-takesSendable(DerivedPrivatelyFromHasPublicNonSendableField.self) // expected-error {{type 'DerivedPrivatelyFromHasPublicNonSendableField' does not conform to the 'Sendable' protocol}}
-takesSendable(DerivedPrivatelyFromHasPrivatePointerField.self) // expected-error {{type 'DerivedPrivatelyFromHasPrivatePointerField' does not conform to the 'Sendable' protocol}}
+takesSendable(DerivedPrivatelyFromHasPublicPointerField.self) // expected-warning {{type 'DerivedPrivatelyFromHasPublicPointerField' does not conform to the 'Sendable' protocol}}
+takesSendable(DerivedPrivatelyFromHasPublicNonSendableField.self) // expected-warning {{type 'DerivedPrivatelyFromHasPublicNonSendableField' does not conform to the 'Sendable' protocol}}
+takesSendable(DerivedPrivatelyFromHasPrivatePointerField.self) // expected-warning {{type 'DerivedPrivatelyFromHasPrivatePointerField' does not conform to the 'Sendable' protocol}}
 
-takesSendable(DerivedProtectedFromHasPublicPointerField.self) // expected-error {{type 'DerivedProtectedFromHasPublicPointerField' does not conform to the 'Sendable' protocol}}
-takesSendable(DerivedProtectedFromHasPublicNonSendableField.self) // expected-error {{type 'DerivedProtectedFromHasPublicNonSendableField' does not conform to the 'Sendable' protocol}}
-takesSendable(DerivedProtectedFromHasPrivatePointerField.self) // expected-error {{type 'DerivedProtectedFromHasPrivatePointerField' does not conform to the 'Sendable' protocol}}
+takesSendable(DerivedProtectedFromHasPublicPointerField.self) // expected-warning {{type 'DerivedProtectedFromHasPublicPointerField' does not conform to the 'Sendable' protocol}}
+takesSendable(DerivedProtectedFromHasPublicNonSendableField.self) // expected-warning {{type 'DerivedProtectedFromHasPublicNonSendableField' does not conform to the 'Sendable' protocol}}
+takesSendable(DerivedProtectedFromHasPrivatePointerField.self) // expected-warning {{type 'DerivedProtectedFromHasPrivatePointerField' does not conform to the 'Sendable' protocol}}
 
 func checkSendableRef(k: borrowing SendableKlass) {
   takesSendable(SendableKlass.self) // Ok


### PR DESCRIPTION
First part of a change to check for clang types in more places. Objective-C imported declarations should be treated as preconcurrency, but we didn't check for that in `getConcurrencyDiagnosticBehaviorLimit`.

This silences some conformance warnings for objc protocols in modes below complete... We need a wider refactor of how we handle preconcurrency. We could consider fixing those sites as part of this change.