### PR TITLE
[SILOptimizer] Fix MovedAsyncVarDebugInfoPropagator undef of box type

### DIFF
--- a/lib/SILOptimizer/Mandatory/MovedAsyncVarDebugInfoPropagator.cpp
+++ b/lib/SILOptimizer/Mandatory/MovedAsyncVarDebugInfoPropagator.cpp
@@ -88,13 +88,24 @@ using namespace swift;
 //                                  Utility
 //===----------------------------------------------------------------------===//
 
+/// Return the SILUndef to use as the operand of an undef debug_value clone of
+/// \p original. For an alloc_box, use the boxed value's type rather than the
+/// box type so the undef matches the variable's type.
+static SILUndef *getUndefForDebugValueClone(DebugVarCarryingInst original) {
+  SILValue operand = original.getOperandForDebugValueClone();
+  if (auto *box = dyn_cast<AllocBoxInst>(operand))
+    return SILUndef::get(box->getFunction(),
+                         box->getAddressType().getObjectType());
+  return SILUndef::get(operand);
+}
+
 /// Clone \p original changing the clone's operand to be undef and insert at the
 /// beginning of \p block.
 static DebugVarCarryingInst
 cloneDebugValueMakeUndef(DebugVarCarryingInst original, SILBasicBlock *block) {
   SILBuilderWithScope builder(&block->front());
   builder.setCurrentDebugScope(original->getDebugScope());
-  auto *undef = SILUndef::get(original.getOperandForDebugValueClone());
+  auto *undef = getUndefForDebugValueClone(original);
   return builder.createDebugValue(original->getLoc(), undef,
                                   *original.getVarInfo(), DontPoisonRefs,
                                   UsesMoveableValueDebugInfo);
@@ -105,7 +116,7 @@ cloneDebugValueMakeUndef(DebugVarCarryingInst original,
                          SILInstruction *insertPt) {
   SILBuilderWithScope builder(std::next(insertPt->getIterator()));
   builder.setCurrentDebugScope(original->getDebugScope());
-  auto *undef = SILUndef::get(original.getOperandForDebugValueClone());
+  auto *undef = getUndefForDebugValueClone(original);
   return builder.createDebugValue(original->getLoc(), undef,
                                   *original.getVarInfo(), DontPoisonRefs,
                                   UsesMoveableValueDebugInfo);

--- a/test/SILOptimizer/moved_async_var_dbginfo_propagator.sil
+++ b/test/SILOptimizer/moved_async_var_dbginfo_propagator.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -sil-print-types -sil-moved-async-var-dbginfo-propagator -enable-sil-verify-all %s 2>&1 | %FileCheck %s
+// RUN: %target-sil-opt -sil-print-types -sil-moved-async-var-dbginfo-propagator -enable-sil-verify-all -verify-debug-value-expr %s 2>&1 | %FileCheck %s
 
 sil_stage canonical
 
@@ -130,6 +130,36 @@ bb1:
 bb2:
   debug_value [moveable_value_debuginfo] undef : $Klass, let, (name "arg", loc "debuginfo_canonicalizer.sil":121:3)
   abort_apply %token
+  br bb3
+
+bb3:
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// When the moved variable is held in an alloc_box, the undef debug_value
+// inserted at a merge point must use the boxed value's type ($Klass), not the
+// box type (${ var Klass }), so the debug_value type-chain verifier holds.
+//
+// CHECK-LABEL: sil @testBoxUndefMerge : $@convention(thin) () -> () {
+// CHECK: bb3:
+// CHECK-NEXT: debug_value [moveable_value_debuginfo] undef : $Klass, var, name "boxVar"
+// CHECK: } // end sil function 'testBoxUndefMerge'
+sil @testBoxUndefMerge : $@convention(thin) () -> () {
+bb0:
+  cond_br undef, bb1, bb2
+
+bb1:
+  %box = alloc_box [moveable_value_debuginfo] ${ var Klass }, var, name "boxVar"
+  %f = function_ref @yieldOnceCoroutine : $@yield_once @convention(method) (@guaranteed Klass) -> @yields @inout Int64
+  %k = project_box %box : ${ var Klass }, 0
+  %v = load %k : $*Klass
+  (%3, %token) = begin_apply %f(%v) : $@yield_once @convention(method) (@guaranteed Klass) -> @yields @inout Int64
+  end_apply %token as $()
+  dealloc_box %box : ${ var Klass }
+  br bb3
+
+bb2:
   br bb3
 
 bb3:


### PR DESCRIPTION
When the moved variable is held in an alloc_box, the undef debug_value inserted at a merge/funclet point used the box type (`${ var T }`) for its operand instead of the variable's boxed type (`$T`). IRGen's box debug_value path only applies to a real box (isBoxWithAddress), so an undef box operand instead emitted a debug record whose DWARF type is the variable type but whose backing value is the box pointer -- a silent mismatch in release builds, and a debug_value type-chain verifier (isExprTypeValid) failure in asserts builds.

Emit the undef with the boxed value's object type so it matches the variable type, matching the kill-to-undef convention in DebugValueInst::killOperand.
