### PR TITLE
[6.4🍒][Literal Expressions] Prohibit references to `@usableFromInline` `internal` declaration values

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -826,6 +826,9 @@ ERROR(const_public_let_ref,none,
       "reference to a %select{%error|%error|%error|package|public|open}0 "
       "'let' binding is not permitted in a literal expression",
       (AccessLevel))
+ERROR(const_usable_from_inline_let_ref,none,
+      "reference to a '@usableFromInline' 'let' binding is not permitted "
+      "in a literal expression", ())
 ERROR(const_opaque_func_decl_ref,none,
       "unable to resolve function reference in a literal expression", ())
 ERROR(const_non_convention_c_conversion,none,

--- a/lib/Sema/LiteralExpressionFolding.cpp
+++ b/lib/Sema/LiteralExpressionFolding.cpp
@@ -351,18 +351,26 @@ private:
 
     FoldingErrorOr<ConstantValuePtr> foldDeclRefExpr(const DeclRefExpr *expr) {
       if (const VarDecl *varDecl = dyn_cast<VarDecl>(expr->getDecl())) {
-        // Swift source `let` bindings whose access level is broader than
-        // internal participate in the ABI surface of their module and may
-        // not appear in a literal expression. Emit the diagnostic inline so
-        // we can carry the access level, and return `UpstreamError` so no
-        // further generic "not a literal expression" message is added.
-        // A `var` that reaches here falls through to the existing
-        // opaque-decl-ref path, which is the correct diagnostic for it.
+        // Reject `let` bindings that are part of the module's ABI surface:
+        // package/public/open by access, and `internal` bindings marked
+        // `@usableFromInline` (or `@inlinable`), whose value an inlinable
+        // function could fold into client binaries. Return `UpstreamError` to
+        // suppress the generic "not a literal expression" follow-up. A `var`
+        // falls through to the opaque-decl-ref path, its correct diagnostic.
         if (!varDecl->hasClangNode() && varDecl->isLet()) {
           auto access = varDecl->getFormalAccess();
           if (access >= AccessLevel::Package) {
             Ctx.Diags.diagnose(expr->getLoc(), diag::const_public_let_ref,
                                access);
+            return FoldingError(IllegalConstError::UpstreamError,
+                                expr->getLoc());
+          }
+
+          // Safe here: the package/public/open cases returned above, so the
+          // formal access is below public as `isUsableFromInline()` asserts.
+          if (varDecl->isUsableFromInline()) {
+            Ctx.Diags.diagnose(expr->getLoc(),
+                               diag::const_usable_from_inline_let_ref);
             return FoldingError(IllegalConstError::UpstreamError,
                                 expr->getLoc());
           }

--- a/test/LiteralExpressions/VisibilityRestriction.swift
+++ b/test/LiteralExpressions/VisibilityRestriction.swift
@@ -1,4 +1,5 @@
-// Literal expressions may not reference publicly visible `let` bindings.
+// Literal expressions may not reference `let` bindings that are part of the
+// module's ABI surface: publicly visible bindings, or `@usableFromInline` ones.
 // REQUIRES: swift_feature_LiteralExpressions
 // RUN: %target-swift-frontend -typecheck %s -verify \
 // RUN:   -package-name myPkg \
@@ -8,6 +9,7 @@
 public let publicPageSize = 4096
 package let packagePageSize = 4096
 internal let internalPageSize = 4096
+@usableFromInline internal let usableFromInlinePageSize = 4096
 fileprivate let filePrivatePageSize = 4096
 private let privatePageSize = 4096
 
@@ -22,6 +24,9 @@ private let privatePageSize = 4096
 
 @section("mysection") let b = 2 * packagePageSize
 // expected-error@-1 {{reference to a package 'let' binding is not permitted in a literal expression}}
+
+@section("mysection") let bUFI = 2 * usableFromInlinePageSize
+// expected-error@-1 {{reference to a '@usableFromInline' 'let' binding is not permitted in a literal expression}}
 
 // Internal, fileprivate, and private bindings are allowed.
 @section("mysection") let c = 2 * internalPageSize
@@ -38,4 +43,8 @@ let f: InlineArray<(2 * publicPageSize), UInt8> = .init(repeating: 0)
 
 let g: InlineArray<(2 * packagePageSize), UInt8> = .init(repeating: 0)
 // expected-error@-1 {{reference to a package 'let' binding is not permitted in a literal expression}}
+// expected-error@-2 {{generic value must be an integer literal expression}}
+
+let gUFI: InlineArray<(2 * usableFromInlinePageSize), UInt8> = .init(repeating: 0)
+// expected-error@-1 {{reference to a '@usableFromInline' 'let' binding is not permitted in a literal expression}}
 // expected-error@-2 {{generic value must be an integer literal expression}}


### PR DESCRIPTION
Cherry-pick of https://github.com/swiftlang/swift/pull/89763
---------------------------------

- **Explanation**: Although a `@usableFromInline` variable cannot be named directly by a client, its value can still reach a client binary: an `@inlinable` function may fold the variable into an integer generic argument, and that folded value is then serialized into the function body that the client inlines. e.g.
```swift
@usableFromInline let x = 8, y = 8, z = 8
@usableFromInline func bar(_ zs: [z of Int]) {}
@inlinable public func foo() {
  let xs: [x of Int] = [1, 2, 3, 4, 5, 6, 7, 8]
  let ys: [y of Int] = xs
  bar(ys)
}
```
A subsequent change to the folded value would leave already-compiled clients inconsistent with the evolved module, so the variable's value is, in effect, part of the ABI.
- **Original PR**: https://github.com/swiftlang/swift/pull/89763
- **Scope**: Affects uses of @diagnose attribute which are contained inside a compilation conditional (#if).
- **Issue**: rdar://179803004
- **Risk**: Low, this change restricts the references allowed in literal expressions which are currently behind an experimental feature flag.
- **Testing**: Tests verifying new functionality added to the test suite.
- **Reviewers**: @kavon 