### PR TITLE
[6.4] [Sema] A few invalid extension fixes

### DIFF
--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -686,7 +686,8 @@ static bool usesFeatureReparenting(Decl *decl) {
 
   // Check if this decl itself is a reparentable protocol (of extension of).
   if (auto ext = dyn_cast<ExtensionDecl>(decl)) {
-    decl = ext->getExtendedNominal();
+    if (auto *nominal = ext->getExtendedNominal())
+      decl = nominal;
   }
 
   if (auto proto = dyn_cast<ProtocolDecl>(decl)) {

--- a/lib/PrintAsClang/ModuleContentsWriter.cpp
+++ b/lib/PrintAsClang/ModuleContentsWriter.cpp
@@ -946,6 +946,9 @@ public:
                          }
 
                          if (auto ED = dyn_cast<ExtensionDecl>(D)) {
+                           // Immediately filter out invalid extensions.
+                           if (ED->isInvalid())
+                             return true;
                            if (outputLangMode == OutputLanguageMode::Cxx)
                              return false;
                            auto baseClass = ED->getSelfClassDecl();

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -2243,52 +2243,52 @@ bool AssignmentFailure::diagnoseAsError() {
       // If there is a masked property of the same type, emit a
       // note to fixit prepend a 'self.' or 'Type.'.
       if (auto typeContext = DC->getInnermostTypeContext()) {
-        SmallVector<ValueDecl *, 2> results;
-        DC->lookupQualified(typeContext->getSelfNominalTypeDecl(),
-                            VD->createNameRef(), Loc,
-                            NL_QualifiedDefault, results);
+        if (auto *nominal = typeContext->getSelfNominalTypeDecl()) {
+          SmallVector<ValueDecl *, 2> results;
+          DC->lookupQualified(nominal, VD->createNameRef(), Loc,
+                              NL_QualifiedDefault, results);
 
-        auto foundProperty = llvm::find_if(results, [&](ValueDecl *decl) {
-          // We're looking for a settable property that is the same type as the
-          // var we found.
-          auto *var = dyn_cast<VarDecl>(decl);
-          if (!var || var == VD)
-            return false;
-
-          if (!var->isSettable(DC) || !var->isSetterAccessibleFrom(DC))
-            return false;
-
-          if (!var->getTypeInContext()->isEqual(VD->getTypeInContext()))
-            return false;
-
-          // Don't suggest a property if we're in one of its accessors.
-          auto *methodDC = DC->getInnermostMethodContext();
-          if (auto *AD = dyn_cast_or_null<AccessorDecl>(methodDC))
-            if (AD->getStorage() == var)
+          auto foundProperty = llvm::find_if(results, [&](ValueDecl *decl) {
+            // We're looking for a settable property that is the same type as
+            // the var we found.
+            auto *var = dyn_cast<VarDecl>(decl);
+            if (!var || var == VD)
               return false;
 
-          return true;
-        });
+            if (!var->isSettable(DC) || !var->isSetterAccessibleFrom(DC))
+              return false;
 
-        if (foundProperty != results.end()) {
-          auto startLoc = immutableExpr->getStartLoc();
-          auto *property = cast<VarDecl>(*foundProperty);
-          auto selfTy = typeContext->getSelfTypeInContext();
+            if (!var->getTypeInContext()->isEqual(VD->getTypeInContext()))
+              return false;
 
-          // If we found an instance property, suggest inserting "self.",
-          // otherwise suggest "Type." for a static property.
-          std::string fixItText;
-          if (property->isInstanceMember()) {
-            fixItText = "self.";
-          } else {
-            fixItText = selfTy->getString() + ".";
+            // Don't suggest a property if we're in one of its accessors.
+            auto *methodDC = DC->getInnermostMethodContext();
+            if (auto *AD = dyn_cast_or_null<AccessorDecl>(methodDC))
+              if (AD->getStorage() == var)
+                return false;
+
+            return true;
+          });
+
+          if (foundProperty != results.end()) {
+            auto startLoc = immutableExpr->getStartLoc();
+            auto *property = cast<VarDecl>(*foundProperty);
+            auto selfTy = typeContext->getSelfTypeInContext();
+
+            // If we found an instance property, suggest inserting "self.",
+            // otherwise suggest "Type." for a static property.
+            std::string fixItText;
+            if (property->isInstanceMember()) {
+              fixItText = "self.";
+            } else {
+              fixItText = selfTy->getString() + ".";
+            }
+            emitDiagnosticAt(startLoc, diag::masked_mutable_property, fixItText,
+                             property, selfTy)
+            .fixItInsert(startLoc, fixItText);
           }
-          emitDiagnosticAt(startLoc, diag::masked_mutable_property, fixItText,
-                           property, selfTy)
-              .fixItInsert(startLoc, fixItText);
         }
       }
-
       // If this is a simple variable marked with a 'let', emit a note to fixit
       // hint it to 'var'.
       VD->emitLetToVarNoteIfSimple(DC);

--- a/lib/Sema/CSSyntacticElement.cpp
+++ b/lib/Sema/CSSyntacticElement.cpp
@@ -799,13 +799,12 @@ private:
       return;
     }
 
-    auto nominalType =
-        fn->getDeclContext()->getSelfNominalTypeDecl()->getDeclaredType();
-    if (!nominalType) {
+    auto nominal = fn->getDeclContext()->getSelfNominalTypeDecl();
+    if (!nominal) {
       hadError = true;
       return;
     }
-
+    auto nominalType = nominal->getDeclaredType();
     auto *selfExpr = discardStmt->getSubExpr();
 
     createConjunction(

--- a/lib/Sema/PreCheckTarget.cpp
+++ b/lib/Sema/PreCheckTarget.cpp
@@ -2195,6 +2195,9 @@ VarDecl *PreCheckTarget::getImplicitSelfDeclForSuperContext(SourceLoc Loc) {
 
   if (auto *typeContext = DC->getInnermostTypeContext()) {
     auto *nominal = typeContext->getSelfNominalTypeDecl();
+    if (!nominal)
+      return nullptr;
+
     auto *classDecl = dyn_cast<ClassDecl>(nominal);
 
     if (!classDecl) {

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -4670,8 +4670,12 @@ void AttributeChecker::visitImplementsAttr(ImplementsAttr *attr) {
   }
 
   // Check that the decl we're decorating is a member of a type that actually
-  // conforms to the specified protocol.
+  // conforms to the specified protocol. If we have an invalid extension, we
+  // can bail.
   NominalTypeDecl *NTD = DC->getSelfNominalTypeDecl();
+  if (!NTD)
+    return;
+
   if (auto *OtherPD = dyn_cast<ProtocolDecl>(NTD)) {
     if (!(OtherPD == PD || OtherPD->inheritsFrom(PD)) &&
         !(OtherPD->isSpecificProtocol(KnownProtocolKind::DistributedActor) ||

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -3170,8 +3170,9 @@ namespace {
     PreWalkAction walkToDeclPre(Decl *decl) override {
       // Don't walk into local types because nothing in them can
       // change the outcome of our analysis, and we don't want to
-      // assume things there have been type checked yet.
-      if (isa<TypeDecl>(decl)) {
+      // assume things there have been type checked yet. Extensions
+      // may also occur here for invalid code, skip them too.
+      if (isa<TypeDecl>(decl) || isa<ExtensionDecl>(decl)) {
         return Action::SkipChildren();
       }
 

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -1281,6 +1281,7 @@ public:
     bool diagnosed = false;
 
     auto *outerDC = climbContextForDiscardStmt(DC);
+    auto *nominalDecl = outerDC->getParent()->getSelfNominalTypeDecl();
     AbstractFunctionDecl *fn = nullptr; // the type member we reside in.
     if (outerDC->getParent()->isTypeContext()) {
       fn = dyn_cast<AbstractFunctionDecl>(outerDC);
@@ -1315,8 +1316,7 @@ public:
     }
 
     // check the kind of type this discard statement appears within.
-    if (!diagnosed) {
-      auto *nominalDecl = fn->getDeclContext()->getSelfNominalTypeDecl();
+    if (!diagnosed && nominalDecl) {
       Type nominalType =
           fn->mapTypeIntoEnvironment(nominalDecl->getDeclaredInterfaceType());
 

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -4451,8 +4451,8 @@ StorageImplInfoRequest::evaluate(Evaluator &evaluator,
   if (borrow || mutate) {
     if (auto *extDecl = dyn_cast<ExtensionDecl>(DC)) {
       auto extNominal = extDecl->getExtendedNominal();
-      if (!isa<StructDecl>(extNominal) && !isa<EnumDecl>(extNominal) &&
-          !isa<ClassDecl>(extNominal)) {
+      if (extNominal && !isa<StructDecl>(extNominal) &&
+          !isa<EnumDecl>(extNominal) && !isa<ClassDecl>(extNominal)) {
         if (borrow) {
           storage->getASTContext().Diags.diagnose(
               borrow->getLoc(),

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -1149,10 +1149,15 @@ bool TypeChecker::checkContextualRequirements(GenericTypeDecl *decl,
 
   auto *dc = decl->getDeclContext();
 
+  // If we have an invalid extension parent, don't bother checking requirements.
+  auto *nominalParent = dc->getSelfNominalTypeDecl();
+  if (!nominalParent)
+    return true;
+
   const auto genericSig = decl->getGenericSignature();
 
   if (genericSig.getPointer() ==
-      dc->getSelfNominalTypeDecl()->getGenericSignature().getPointer()) {
+      nominalParent->getGenericSignature().getPointer()) {
     return true;
   }
 
@@ -2264,6 +2269,8 @@ static SelfTypeKind getSelfTypeKind(DeclContext *dc,
 void TypeResolver::diagnoseGenericArgumentsOnSelf(
     UnqualifiedIdentTypeRepr *repr, DeclContext *typeDC) {
   auto *selfNominal = typeDC->getSelfNominalTypeDecl();
+  if (!selfNominal)
+    return;
   auto declaredType = selfNominal->getDeclaredType();
 
   diagnose(repr->getNameLoc(), diag::cannot_specialize_self);

--- a/lib/SymbolGraphGen/SymbolGraphASTWalker.cpp
+++ b/lib/SymbolGraphGen/SymbolGraphASTWalker.cpp
@@ -230,7 +230,11 @@ bool SymbolGraphASTWalker::walkToDeclPre(Decl *D, CharSourceRange Range) {
   // If this is an extension, let's check that it implies some new conformances,
   // potentially with generic requirements.
   if (const auto *Extension = dyn_cast<ExtensionDecl>(D)) {
+    // Ignore extensions with no nominal.
     const auto *ExtendedNominal = Extension->getExtendedNominal();
+    if (!ExtendedNominal)
+      return false;
+
     auto ExtendedSG = getModuleSymbolGraph(ExtendedNominal);
     // Ignore effectively private decls.
     if (ExtendedSG->isImplicitlyPrivate(Extension)) {

--- a/validation-test/IDE/crashers_fixed/StmtChecker-typeCheckStmt-8659dc.swift
+++ b/validation-test/IDE/crashers_fixed/StmtChecker-typeCheckStmt-8659dc.swift
@@ -1,4 +1,4 @@
 // {"kind":"complete","signature":"bool (anonymous namespace)::StmtChecker::typeCheckStmt<swift::Stmt>(swift::Stmt*&)","signatureNext":"StmtChecker::typeCheckASTNode"}
-// RUN: not --crash %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -source-filename %s
+// RUN: %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -source-filename %s
 extension {
 a { discard b#^COMPLETE^#

--- a/validation-test/compiler_crashers_fixed/ActorIsolationChecker-checkApply-8156ba.swift
+++ b/validation-test/compiler_crashers_fixed/ActorIsolationChecker-checkApply-8156ba.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","original":"b281d585","signature":"(anonymous namespace)::ActorIsolationChecker::checkApply(swift::ApplyExpr*)","signatureAssert":"Assertion failed: (!IsolationCrossing.has_value() && \"IsolationCrossing should not be set twice\"), function setIsolationCrossing","signatureNext":"ActorIsolationChecker::walkToExprPre"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 actor a@globalActor actor b {
   static var shared = {
     extension a {

--- a/validation-test/compiler_crashers_fixed/ActorIsolationChecker-checkLocalCaptures-40188c.swift
+++ b/validation-test/compiler_crashers_fixed/ActorIsolationChecker-checkLocalCaptures-40188c.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","original":"b8967a13","signature":"(anonymous namespace)::ActorIsolationChecker::checkLocalCaptures(swift::AnyFunctionRef)","signatureAssert":"Assertion failed: (Captures.hasBeenComputed()), function getCaptureInfo","signatureNext":"ActorIsolationChecker::walkToExprPre"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 func a() {
   extension <#type#> {
     var b = {

--- a/validation-test/compiler_crashers_fixed/AttributeChecker-visitImplementsAttr-23dbe8.swift
+++ b/validation-test/compiler_crashers_fixed/AttributeChecker-visitImplementsAttr-23dbe8.swift
@@ -1,4 +1,4 @@
 // {"kind":"typecheck","signature":"(anonymous namespace)::AttributeChecker::visitImplementsAttr(swift::ImplementsAttr*)","signatureAssert":"Assertion failed: (detail::isPresent(Val) && \"dyn_cast on a non-existent value\"), function dyn_cast","signatureNext":"TypeChecker::checkDeclAttributes"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 protocol a { b }
 @_implements(a, b) typealias c =

--- a/validation-test/compiler_crashers_fixed/ModuleWriter-write-393891.swift
+++ b/validation-test/compiler_crashers_fixed/ModuleWriter-write-393891.swift
@@ -1,4 +1,4 @@
 // {"extraArgs":["-experimental-allow-module-with-compiler-errors","-cxx-interoperability-mode=default","-emit-clang-header-min-access","internal","-emit-clang-header-path","/dev/null"],"kind":"emit-sil","original":"c761e8c4","signature":"(anonymous namespace)::ModuleWriter::write()","signatureAssert":"Assertion failed: (Val && \"isa<> used on a null pointer\"), function doit","signatureNext":"printModuleContentsAsCxx"}
-// RUN: not --crash %target-swift-frontend -emit-sil -experimental-allow-module-with-compiler-errors -cxx-interoperability-mode=default -emit-clang-header-min-access internal -emit-clang-header-path /dev/null %s
+// RUN: not %target-swift-frontend -emit-sil -experimental-allow-module-with-compiler-errors -cxx-interoperability-mode=default -emit-clang-header-min-access internal -emit-clang-header-path /dev/null %s
 extension <#type#> {
 }

--- a/validation-test/compiler_crashers_fixed/ModuleWriter-write-7e2336.swift
+++ b/validation-test/compiler_crashers_fixed/ModuleWriter-write-7e2336.swift
@@ -1,4 +1,4 @@
 // {"extraArgs":["-experimental-allow-module-with-compiler-errors","-cxx-interoperability-mode=default","-emit-clang-header-path","/dev/null"],"kind":"emit-sil","original":"9385ecce","signature":"(anonymous namespace)::ModuleWriter::write()","signatureNext":"printModuleContentsAsCxx"}
-// RUN: not --crash %target-swift-frontend -emit-sil -experimental-allow-module-with-compiler-errors -cxx-interoperability-mode=default -emit-clang-header-path /dev/null %s
+// RUN: not %target-swift-frontend -emit-sil -experimental-allow-module-with-compiler-errors -cxx-interoperability-mode=default -emit-clang-header-path /dev/null %s
 extension a
   extension

--- a/validation-test/compiler_crashers_fixed/PreCheckTarget-walkToExprPre-9f3063.swift
+++ b/validation-test/compiler_crashers_fixed/PreCheckTarget-walkToExprPre-9f3063.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","signature":"(anonymous namespace)::PreCheckTarget::walkToExprPre(swift::Expr*)","signatureAssert":"Assertion failed: (detail::isPresent(Val) && \"dyn_cast on a non-existent value\"), function dyn_cast","signatureNext":"Traversal::doIt"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 {
   extension a {
     b {

--- a/validation-test/compiler_crashers_fixed/QualifiedLookupRequest-evaluate-78fae7.swift
+++ b/validation-test/compiler_crashers_fixed/QualifiedLookupRequest-evaluate-78fae7.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","signature":"swift::QualifiedLookupRequest::evaluate(swift::Evaluator&, swift::DeclContext const*, llvm::SmallVector<swift::NominalTypeDecl*, 4u>, swift::DeclNameRef, swift::NLOptions) const","signatureAssert":"Assertion failed: (Val && \"isa<> used on a null pointer\"), function doit","signatureNext":"SimpleRequest::evaluateRequest"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 {
   extension a {
   b {

--- a/validation-test/compiler_crashers_fixed/SymbolGraphASTWalker-getRealModuleOf-393891.swift
+++ b/validation-test/compiler_crashers_fixed/SymbolGraphASTWalker-getRealModuleOf-393891.swift
@@ -1,0 +1,5 @@
+// {"frontendArgs":["-emit-module","-o","/dev/null","-emit-symbol-graph","-emit-symbol-graph-dir","%t/out","-experimental-allow-module-with-compiler-errors"],"kind":"custom","signature":"swift::symbolgraphgen::SymbolGraphASTWalker::getRealModuleOf(swift::Decl const*) const","signatureNext":"SymbolGraphASTWalker::getModuleSymbolGraph"}
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -o /dev/null -emit-symbol-graph -emit-symbol-graph-dir %t/out -experimental-allow-module-with-compiler-errors %s
+extension <#type#> {
+}

--- a/validation-test/compiler_crashers_fixed/TypeDecl-getName-0d2654.swift
+++ b/validation-test/compiler_crashers_fixed/TypeDecl-getName-0d2654.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","original":"132f5134","signature":"swift::TypeDecl::getName() const","signatureAssert":"Assertion failed: (Context.SourceMgr.hasIDEInspectionTargetBuffer() || Context.LangOpts.IsForSourceKit || Context.TypeCheckerOpts.EnableLazyTypecheck && \"Querying VarDecl's type before type-checking parent stmt\"), function evaluate"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 {
   extension {
 a { for

--- a/validation-test/compiler_crashers_fixed/TypeDecl-getName-30c6aa.swift
+++ b/validation-test/compiler_crashers_fixed/TypeDecl-getName-30c6aa.swift
@@ -1,0 +1,4 @@
+// {"kind":"typecheck","original":"d2c2e41b","signature":"swift::TypeDecl::getName() const","signatureAssert":"Assertion failed: (Val && \"isa<> used on a null pointer\"), function doit"}
+// RUN: not %target-swift-frontend -typecheck %s
+extension {
+a { let b: UInt8 c(&b

--- a/validation-test/compiler_crashers_fixed/TypeDecl-getName-c25aed.swift
+++ b/validation-test/compiler_crashers_fixed/TypeDecl-getName-c25aed.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","signature":"swift::TypeDecl::getName() const","signatureAssert":"Assertion failed: (detail::isPresent(Val) && \"dyn_cast on a non-existent value\"), function dyn_cast"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 {
   extension {
     a {

--- a/validation-test/compiler_crashers_fixed/TypeResolver-diagnoseGenericArgumentsOnSelf-abe282.swift
+++ b/validation-test/compiler_crashers_fixed/TypeResolver-diagnoseGenericArgumentsOnSelf-abe282.swift
@@ -1,0 +1,5 @@
+// {"extraArgs":["-experimental-allow-module-with-compiler-errors"],"kind":"emit-sil","original":"02a7072e","signature":"(anonymous namespace)::TypeResolver::diagnoseGenericArgumentsOnSelf(swift::UnqualifiedIdentTypeRepr*, swift::DeclContext*)","signatureNext":"TypeResolver::resolveDeclRefTypeReprRec"}
+// RUN: not %target-swift-frontend -emit-sil -experimental-allow-module-with-compiler-errors %s
+extension <#type#> {
+  typealias a = Self<>
+}


### PR DESCRIPTION
*6.4 partial cherry-pick of #89973*

- Explanation: Fixes a bunch of compiler crashers by adding missing null/invalid checks for invalid extension decls
- Scope: Affects invalid extension type-checking
- Issue: rdar://179811114
- Risk: Low, only affects invalid code, and the individual changes are straightforward
- Testing: Added tests to test suite
- Reviewer: Pavel Yaskevich