### PR TITLE
[6.4][Runtime] Gracefully fail when looking up a mangled name with an integer where a type is required.

### DIFF
--- a/include/swift/AST/ASTDemangler.h
+++ b/include/swift/AST/ASTDemangler.h
@@ -167,6 +167,14 @@ public:
   Type createBoundGenericType(GenericTypeDecl *decl, ArrayRef<Type> args,
                               Type parent);
 
+  // This is used by the runtime's type lookup to catch the case where a mangled
+  // name specifies a value argument where a type argument is supposed to go.
+  // The AST builder doesn't have that problem so we skip that check entirely.
+  std::optional<bool> isValueGenericParameter(GenericTypeDecl *decl,
+                                              unsigned index) {
+    return std::nullopt;
+  }
+
   Type createTupleType(ArrayRef<Type> eltTypes, ArrayRef<StringRef> labels);
 
   Type createPackType(ArrayRef<Type> eltTypes);

--- a/include/swift/Demangling/TypeDecoder.h
+++ b/include/swift/Demangling/TypeDecoder.h
@@ -662,9 +662,13 @@ public:
   explicit TypeDecoder(BuilderType &Builder) : Builder(Builder) {}
 
   /// Given a demangle tree, attempt to turn it into a type.
+  ///
+  /// If a mangling may legitimately denote a bare integer value at the root
+  /// level, pass true for allowValue.
   TypeLookupErrorOr<BuiltType> decodeMangledType(NodePointer Node,
-                                                 bool forRequirement = true) {
-    return decodeMangledType(Node, 0, forRequirement);
+                                                 bool forRequirement = true,
+                                                 bool allowValue = true) {
+    return decodeMangledType(Node, 0, forRequirement, allowValue);
   }
 
 protected:
@@ -672,7 +676,8 @@ protected:
 
   TypeLookupErrorOr<BuiltType> decodeMangledType(NodePointer Node,
                                                  unsigned depth,
-                                                 bool forRequirement = true) {
+                                                 bool forRequirement = true,
+                                                 bool allowValue = false) {
     if (depth > TypeDecoder::MaxDepth)
       return TypeLookupError("Mangled type is too complex");
 
@@ -685,18 +690,20 @@ protected:
       if (Node->getNumChildren() < 1)
         return MAKE_NODE_TYPE_ERROR0(Node, "no children.");
 
-      return decodeMangledType(Node->getChild(0), depth + 1);
+      return decodeMangledType(Node->getChild(0), depth + 1, forRequirement,
+                               allowValue);
     case NodeKind::TypeMangling:
       if (Node->getNumChildren() < 1)
         return MAKE_NODE_TYPE_ERROR0(Node, "no children.");
 
-      return decodeMangledType(Node->getChild(0), depth + 1);
+      return decodeMangledType(Node->getChild(0), depth + 1, forRequirement,
+                               allowValue);
     case NodeKind::Type:
       if (Node->getNumChildren() < 1)
         return MAKE_NODE_TYPE_ERROR0(Node, "no children.");
 
-      return decodeMangledType(Node->getChild(0), depth + 1,
-                               forRequirement);
+      return decodeMangledType(Node->getChild(0), depth + 1, forRequirement,
+                               allowValue);
     case NodeKind::Class:
     {
 #if SWIFT_OBJC_INTEROP
@@ -743,6 +750,9 @@ protected:
         ChildNode = ChildNode->getChild(0);
 
 #if SWIFT_OBJC_INTEROP
+      // Lightweight ObjC generics are type-erased:
+      // createBoundGenericObjCClassType ignores the generic arguments entirely,
+      // so a value argument here is harmless and needs no validation.
       if (auto mangledName = getObjCClassOrProtocolName(ChildNode))
         return Builder.createBoundGenericObjCClassType(mangledName->str(),
                                                        args);
@@ -754,6 +764,21 @@ protected:
       if (auto error = decodeMangledTypeDecl(ChildNode, depth, typeDecl, parent,
                                              typeAlias))
         return *error;
+
+      // Reject ill-formed manglings that bind a concrete integer value to a
+      // generic parameter that is not a value parameter (e.g. `Optional<99>`).
+      // This prevents the integer value from being interpreted as a metadata
+      // pointer and crashing.
+      auto genericArgsList = Node->getChild(1);
+      for (unsigned i = 0, e = genericArgsList->getNumChildren(); i != e; ++i) {
+        if (!isConcreteIntegerValue(genericArgsList->getChild(i)))
+          continue;
+        auto isValueParam = Builder.isValueGenericParameter(typeDecl, i);
+        if (isValueParam && !*isValueParam)
+          return MAKE_NODE_TYPE_ERROR0(
+              genericArgsList->getChild(i),
+              "integer value bound to non-value generic parameter");
+      }
 
       return Builder.createBoundGenericType(typeDecl, args, parent);
     }
@@ -1551,7 +1576,7 @@ protected:
                                     "fewer children (%zu) than required (2)",
                                     Node->getNumChildren());
       }
-      auto count = decodeMangledType(Node->getChild(0), depth + 1);
+      auto count = decodeMangledGenericArgument(Node->getChild(0), depth + 1);
       if (count.isError())
         return count;
 
@@ -1612,8 +1637,8 @@ protected:
         if (genericsNode->getKind() != NodeKind::TypeList)
           break;
         for (auto argNode : *genericsNode) {
-          auto arg = decodeMangledType(argNode, depth + 1,
-                                       /*forRequirement=*/false);
+          auto arg = decodeMangledGenericArgument(argNode, depth + 1,
+                                                  /*forRequirement=*/false);
           if (arg.isError())
             return arg;
           genericArgsBuf.push_back(arg.getType());
@@ -1626,17 +1651,18 @@ protected:
         genericArgs.emplace_back(genericArgsBuf.data() + start,
                                  end - start);
       }
-      
+
       return Builder.resolveOpaqueType(descriptor, genericArgs, ordinal);
     }
 
-    case NodeKind::Integer: {
-      return Builder.createIntegerType((intptr_t)Node->getIndex());
-    }
-
-    case NodeKind::NegativeInteger: {
+    case NodeKind::Integer:
+    case NodeKind::NegativeInteger:
+      if (!allowValue)
+        return MAKE_NODE_TYPE_ERROR0(Node,
+                                     "integer value where a type is required");
+      if (Node->getKind() == NodeKind::Integer)
+        return Builder.createIntegerType((intptr_t)Node->getIndex());
       return Builder.createNegativeIntegerType((intptr_t)Node->getIndex());
-    }
 
     case NodeKind::BuiltinBorrow: {
       if (Node->getNumChildren() < 1) {
@@ -1656,9 +1682,10 @@ protected:
                                     "fewer children (%zu) than required (2)",
                                     Node->getNumChildren());
       }
-      auto size = decodeMangledType(Node->getChild(0), depth + 1);
+      auto size = decodeMangledGenericArgument(Node->getChild(0), depth + 1);
       if (size.isError())
         return size;
+
       auto element = decodeMangledType(Node->getChild(1), depth + 1);
       if (element.isError())
         return element;
@@ -1673,6 +1700,22 @@ protected:
 
       return MAKE_NODE_TYPE_ERROR0(Node, "unexpected kind");
     }
+  }
+
+  /// Decode a generic argument which may be an integer value or a type.
+  /// Positions that must always be a type call decodeMangledType directly,
+  /// which rejects integers.
+  TypeLookupErrorOr<BuiltType>
+  decodeMangledGenericArgument(NodePointer Node, unsigned depth,
+                               bool forRequirement = true) {
+    auto node = Node;
+    if (node->getKind() == NodeKind::Type && node->getNumChildren() == 1)
+      node = node->getChild(0);
+    if (node->getKind() == NodeKind::Integer)
+      return Builder.createIntegerType((intptr_t)node->getIndex());
+    if (node->getKind() == NodeKind::NegativeInteger)
+      return Builder.createNegativeIntegerType((intptr_t)node->getIndex());
+    return decodeMangledType(Node, depth, forRequirement);
   }
 
 private:
@@ -1692,7 +1735,7 @@ private:
       auto patternType = node->getChild(0);
 
       // Decode the shape pack first, to form a metadata pack.
-      auto countType = decodeMangledType(node->getChild(1), depth);
+      auto countType = decodeMangledGenericArgument(node->getChild(1), depth);
       if (countType.isError())
         return *countType.getError();
 
@@ -1841,13 +1884,24 @@ private:
       return MAKE_NODE_TYPE_ERROR0(node, "is not TypeList");
 
     for (auto genericArg : *node) {
-      auto paramType = decodeMangledType(genericArg, depth,
-                                         /*forRequirement=*/false);
+      auto paramType = decodeMangledGenericArgument(genericArg, depth,
+                                                    /*forRequirement=*/false);
       if (paramType.isError())
         return *paramType.getError();
       args.push_back(paramType.getType());
     }
     return std::nullopt;
+  }
+
+  /// Whether \p node (after unwrapping a \c Type node) is a literal integer
+  /// generic value, e.g. the `99` in a mangled `Optional<99>`. Such a node is
+  /// always a value generic argument, so it is only well-formed in a value
+  /// generic parameter position.
+  static bool isConcreteIntegerValue(Demangle::NodePointer node) {
+    if (node->getKind() == NodeKind::Type && node->getNumChildren() == 1)
+      node = node->getChild(0);
+    return node->getKind() == NodeKind::Integer ||
+           node->getKind() == NodeKind::NegativeInteger;
   }
 
   std::optional<TypeLookupError>
@@ -2067,9 +2121,9 @@ private:
 template <typename BuilderType>
 inline TypeLookupErrorOr<typename BuilderType::BuiltType>
 decodeMangledType(BuilderType &Builder, NodePointer Node,
-                  bool forRequirement = false) {
-  return TypeDecoder<BuilderType>(Builder)
-      .decodeMangledType(Node, forRequirement);
+                  bool forRequirement = false, bool allowValue = true) {
+  return TypeDecoder<BuilderType>(Builder).decodeMangledType(
+      Node, forRequirement, allowValue);
 }
 
 SWIFT_END_INLINE_NAMESPACE

--- a/include/swift/RemoteInspection/TypeRefBuilder.h
+++ b/include/swift/RemoteInspection/TypeRefBuilder.h
@@ -954,6 +954,14 @@ public:
     return IntegerTypeRef::create(*this, value);
   }
 
+  // TypeRefs model generic values as distinct IntegerTypeRefs, so a value
+  // argument is never misinterpreted as a type; the demangler's value/type
+  // consistency check is unnecessary here.
+  std::optional<bool> isValueGenericParameter(const BuiltTypeDecl &,
+                                              unsigned index) {
+    return std::nullopt;
+  }
+
   const TypeRef *createNegativeIntegerType(intptr_t value) {
     return IntegerTypeRef::create(*this, value);
   }

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -1955,6 +1955,20 @@ public:
     return createNominalType(typeAliasDecl, parent);
   }
 
+  /// Determine whether the generic parameter at the given index is a value
+  /// parameter. Returns std::nullopt if the type isn't generic or the index is
+  /// out of range.
+  std::optional<bool> isValueGenericParameter(BuiltTypeDecl anyTypeDecl,
+                                              unsigned index) const {
+    auto typeDecl = dyn_cast<TypeContextDescriptor>(anyTypeDecl);
+    if (!typeDecl)
+      return std::nullopt;
+    auto localParams = getLocalGenericParams(typeDecl);
+    if (index >= localParams.size())
+      return std::nullopt;
+    return localParams[index].getKind() == GenericParamKind::Value;
+  }
+
   TypeLookupErrorOr<BuiltType>
   createBoundGenericType(BuiltTypeDecl anyTypeDecl,
                          llvm::ArrayRef<BuiltType> genericArgs,
@@ -2517,7 +2531,9 @@ swift_getTypeByMangledNodeImpl(MetadataRequest request, Demangler &demangler,
   // swift_checkMetadataState after the fact.
   DecodedMetadataBuilder builder(demangler, substGenericParam,
                                  substWitnessTable);
-  auto type = Demangle::decodeMangledType(builder, node);
+  auto type =
+      Demangle::decodeMangledType(builder, node, /*forRequirement=*/false,
+                                  /*allowValue=*/false);
   if (type.isError()) {
     return *type.getError();
   }
@@ -2809,7 +2825,9 @@ swift::getTypePackByMangledName(StringRef typeName,
 
   DecodedMetadataBuilder builder(demangler, substGenericParam,
                                  substWitnessTable);
-  auto type = Demangle::decodeMangledType(builder, node);
+  auto type =
+      Demangle::decodeMangledType(builder, node, /*forRequirement=*/false,
+                                  /*allowValue=*/false);
   if (type.isError()) {
     return *type.getError();
   }

--- a/test/Runtime/value_generic_mangling_mismatch.swift
+++ b/test/Runtime/value_generic_mangling_mismatch.swift
@@ -1,0 +1,109 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -Xfrontend -disable-availability-checking %s -module-name main -o %t/a.out
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out
+// REQUIRES: executable_test
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
+// A mangled type name may place an integer (value) generic argument where a
+// type is expected, e.g. `_typeByName("$99_Sg")` asks for `Optional<99>`. The
+// runtime represents metadata and values the same way, so without validation
+// the integer is misinterpreted as a type metadata pointer and dereferenced,
+// crashing. Such names must instead fail the lookup gracefully, while genuine
+// value generics (an integer in a value parameter) keep working.
+
+import Swift
+import StdlibUnittest
+
+struct ValG<let N: Int> {}
+struct OuterG<T> { struct ValInner<let M: Int> {} }
+struct PairG<T, U> {}
+protocol P {}
+struct S: P {}
+
+let tests = TestSuite("ValueGenericManglingMismatch")
+
+tests.test("integer in a value parameter resolves") {
+  // Top-level value parameter.
+  expectEqual(ValG<3>.self, _typeByName("4main4ValGVy$2_G")!)
+  // Value parameter nested under a type parameter at an outer level.
+  expectEqual(OuterG<Int>.ValInner<5>.self,
+              _typeByName("4main6OuterGV8ValInnerVySi_$4_G")!)
+  // Plain type parameters keep working too.
+  expectEqual(PairG<Int, String>.self, _typeByName("4main5PairGVySiSSG")!)
+  // The standard-library value generic.
+  expectEqual(InlineArray<4, Int>.self, _typeByName("s11InlineArrayVy$3_SiG")!)
+  // A protocol-scoped concrete base type resolves to the base.
+  expectEqual(S.self, _typeByName("4main1PPy4main1SVG")!)
+}
+
+tests.test("integer bound to a type parameter fails gracefully") {
+  // `Optional<99>` and `Array<99>`: integer where Wrapped/Element go.
+  expectNil(_typeByName("$99_Sg"))
+  expectNil(_typeByName("Say$99_G"))
+  // An unparseable integer in Optional.
+  expectNil(_typeByName("$Sg"))
+  // Integer in either type parameter of `PairG<T, U>`.
+  expectNil(_typeByName("4main5PairGVy$98_SSG"))
+  expectNil(_typeByName("4main5PairGVySi$98_G"))
+  // Multi-level: an integer wrongly bound to `OuterG`'s type parameter while a
+  // *legitimate* value sits in the inner `ValInner.M`. Must still be rejected
+  // at the outer level rather than confused by the valid inner value.
+  expectNil(_typeByName("4main6OuterGV8ValInnerVy$0__$4_G"))
+}
+
+tests.test("integer bound to a protocol generic parameter fails gracefully") {
+  expectNil(_typeByName("4main1PPy$99_G"))
+}
+
+tests.test("integer at the root of a type name fails gracefully") {
+  // A bare value generic where a type is expected. An even value (256) would
+  // otherwise be indistinguishable from a metadata pointer and dereferenced;
+  // an odd value (255) is caught by the runtime's metadata/pack discriminator.
+  // Type lookup rejects a root value (a separate value-lookup entry point
+  // resolves these legitimately); both must fail _typeByName gracefully.
+  expectNil(_typeByName("$255_"))
+  expectNil(_typeByName("$254_"))
+}
+
+tests.test("integer where a tuple element type is expected fails gracefully") {
+  // `(100, Int)`: an integer sits where the first element type belongs. An
+  // even value passes the runtime's metadata/pack discriminator and would be
+  // dereferenced as a type metadata pointer.
+  expectNil(_typeByName("$99__Sit"))
+  // An odd value (`(99, Int)`) currently happens to look like a metadata pack
+  // and is rejected, but it must keep failing gracefully too.
+  expectNil(_typeByName("$98__Sit"))
+}
+
+tests.test("integer where a function parameter type is expected fails gracefully") {
+  // `(100) -> Int`: integer in the parameter position.
+  expectNil(_typeByName("Si$99_c"))
+  expectNil(_typeByName("Si$98_c"))
+  // `(100, String) -> Bool`: integer as a parameter inside the parameter tuple.
+  expectNil(_typeByName("Sb$99__SStc"))
+}
+
+tests.test("integer where a function result type is expected fails gracefully") {
+  // `(Int) -> 100`: integer in the result position.
+  expectNil(_typeByName("$99_Sic"))
+  expectNil(_typeByName("$98_Sic"))
+}
+
+tests.test("integer where a metatype instance type is expected fails gracefully") {
+  // `100.Type`: integer as the instance of a metatype.
+  expectNil(_typeByName("$99_m"))
+  expectNil(_typeByName("$98_m"))
+}
+
+tests.test("integer where a Builtin.FixedArray element type is expected fails gracefully") {
+  // `Builtin.FixedArray<3, 100>`: the count is legitimately a value, but the
+  // element must be a type. createBuiltinFixedArrayType calls getMetadata() on
+  // the element with no guard, so an even value is dereferenced and an odd
+  // value aborts in getMetadata() rather than failing the lookup.
+  expectNil(_typeByName("$2_$99_BV"))
+  expectNil(_typeByName("$2_$98_BV"))
+}
+
+runAllTests()


### PR DESCRIPTION
- **Explanation**: It's possible to construct a mangled name that puts an integer in the position where a type is expected, e.g. `Optional<42>`. This makes it so that calling `_typeByName` or similar runtime type-by-name entrypoints on such a type will fail gracefully rather than crashing.
- **Scope**: This changes the mangled name decoder to check for integers in various positions in the decoded type, and fail with an error if an integer is found in a place that requires a type. This should not reject anything that wouldn't have been a crash without the change.
- **Issues**: rdar://179104515
- **Original PRs**: https://github.com/swiftlang/swift/pull/89965
- **Risk**: Low. This should only change behavior in circumstances that would previously crash.
- **Testing**: Existing CI tests cover the happy paths well. Added new tests to cover the unhappy paths and ensure they now fail gracefully.
- **Reviewers**: @rjmccall