### PR TITLE
[6.4][CSApply] Don't set callee to `subscript(dynamicMember:)` for dynamic…

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -8439,17 +8439,13 @@ Expr *ExprRewriter::finishApply(ApplyExpr *apply, Type openedType,
   ConcreteDeclRef callee;
   auto *calleeLoc = cs.getConstraintLocator(calleeLocator);
   auto overload = solution.getOverloadChoiceIfAvailable(calleeLoc);
-  if (overload) {
-    // If this is a call through an implicit `dynamicMember:` subscript,
-    // of a `@dynamicMemberLookup` type there is no callee because the
-    // call happens on a value returned by the subscript invocation and
-    // not necessary the member looked up.
-    if (overload->choice.isKeyPathDynamicMemberLookup()) {
-      callee = ConcreteDeclRef();
-    } else {
-      auto *decl = overload->choice.getDeclOrNull();
-      callee = resolveConcreteDeclRef(decl, calleeLoc);
-    }
+  // If this is a call through an implicit `dynamicMember:` subscript
+  // of a `@dynamicMemberLookup` type there is no callee because the
+  // call happens on a value returned by the subscript invocation and
+  // not necessary the member looked up.
+  if (overload && !overload->choice.isAnyDynamicMemberLookup()) {
+    auto *decl = overload->choice.getDeclOrNull();
+    callee = resolveConcreteDeclRef(decl, calleeLoc);
   }
 
   // Make sure we have a function type that is callable. This helps ensure

--- a/test/Constraints/dynamic_member_lookup_closure_result.swift
+++ b/test/Constraints/dynamic_member_lookup_closure_result.swift
@@ -1,0 +1,36 @@
+// RUN: %target-typecheck-verify-swift
+
+// Applying the closure *returned* by a `@dynamicMemberLookup` subscript used to
+// crash the type checker while building `ParameterListInfo` for the call. The
+// applied closure has more parameters than the subscript's own parameter list,
+// so the per-parameter lookup was indexed out of range: `getOrigParamIndex`
+// aborted for the generic form, and `ParameterList::get` tripped an ArrayRef
+// bounds assert for the non-generic form.
+
+// A generic subscript whose result is a closure over its generic parameters.
+@dynamicMemberLookup
+struct Generic {
+  subscript<A0, A1>(dynamicMember name: String) -> ((A0, A1) -> Int) {
+    { _, _ in 0 }
+  }
+}
+
+func callGeneric(o: Generic) -> Int {
+  // `o.foo` resolves to the generic subscript; applying the returned closure to
+  // two arguments drives inference of A0/A1 and used to crash in
+  // getOrigParamIndex.
+  o.foo(1, 2)
+}
+
+// A non-generic subscript returning a multi-argument closure triggers the same
+// out-of-range indexing through the empty-substitutions path.
+@dynamicMemberLookup
+struct NonGeneric {
+  subscript(dynamicMember name: String) -> ((Int, Int) -> Int) {
+    { _, _ in 0 }
+  }
+}
+
+func callNonGeneric(o: NonGeneric) -> Int {
+  o.foo(1, 2)
+}


### PR DESCRIPTION
… calls

- Explanation:

  Fixes a crash due to an incorrect callee selection for dynamic member lookup calls.

  This is a follow-up to https://github.com/swiftlang/swift/pull/89444 which fixed this for key path based dynamic lookup but missed a case the untyped case.

- Resolves: https://github.com/swiftlang/swift/issues/89990 rdar://179803348

- Main Branch PR: https://github.com/swiftlang/swift/pull/89998

- Risk: Very low. A narrow change that adds an additional check to guard against selecting wrong a callee declaration for untyped dynamic member lookup calls.

- Reviewed By: @hamishknight  

- Testing: Added new test-cases to the suite.

(cherry picked from commit 6d3107b3f3028a642dbd053183e22ee120e38494)

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
