### PR TITLE
[stdlib] Collection span getters can use the unchecked initializer

### DIFF
--- a/stdlib/public/core/Array.swift
+++ b/stdlib/public/core/Array.swift
@@ -1764,13 +1764,13 @@ extension Array {
         let buffer = _buffer.getOrAllocateAssociatedObjectBuffer()
         let pointer = unsafe buffer.firstElementAddress
         let count = buffer.immutableCount
-        let span = unsafe Span(_unsafeStart: pointer, count: count)
+        let span = unsafe Span(_unchecked: pointer, count: count)
         return unsafe _overrideLifetime(span, borrowing: self)
       }
 #endif
       let pointer = unsafe _buffer.firstElementAddress
       let count = _buffer.immutableCount
-      let span = unsafe Span(_unsafeStart: pointer, count: count)
+      let span = unsafe Span(_unchecked: pointer, count: count)
       return unsafe _overrideLifetime(span, borrowing: self)
     }
   }
@@ -1896,7 +1896,7 @@ extension Array {
 #endif
       let pointer = unsafe _buffer.firstElementAddress
       let count = _buffer.mutableCount
-      let span = unsafe MutableSpan(_unsafeStart: pointer, count: count)
+      let span = unsafe MutableSpan(_unchecked: pointer, count: count)
       return unsafe _overrideLifetime(span, mutating: &self)
     }
   }

--- a/stdlib/public/core/ArraySlice.swift
+++ b/stdlib/public/core/ArraySlice.swift
@@ -1239,7 +1239,7 @@ extension ArraySlice {
     @_lifetime(borrow self)
     borrowing get {
       let (pointer, count) = unsafe (_buffer.firstElementAddress, _buffer.count)
-      let span = unsafe Span(_unsafeStart: pointer, count: count)
+      let span = unsafe Span(_unchecked: pointer, count: count)
       return unsafe _overrideLifetime(span, borrowing: self)
     }
   }
@@ -1351,7 +1351,7 @@ extension ArraySlice {
 #endif
       // LifetimeDependence analysis inserts call to Builtin.endCOWMutation.
       let (pointer, count) = unsafe (_buffer.firstElementAddress, _buffer.count)
-      let span = unsafe MutableSpan(_unsafeStart: pointer, count: count)
+      let span = unsafe MutableSpan(_unchecked: pointer, count: count)
       return unsafe _overrideLifetime(span, mutating: &self)
     }
   }

--- a/stdlib/public/core/CollectionOfOne.swift
+++ b/stdlib/public/core/CollectionOfOne.swift
@@ -184,7 +184,7 @@ extension CollectionOfOne {
     @_lifetime(borrow self)
     get {
       let pointer = unsafe UnsafePointer<Element>(Builtin.addressOfBorrow(self))
-      let span = unsafe Span(_unsafeStart: pointer, count: 1)
+      let span = unsafe Span(_unchecked: pointer, count: 1)
       return unsafe _overrideLifetime(span, borrowing: self)
     }
   }
@@ -199,9 +199,9 @@ extension CollectionOfOne {
     @_lifetime(&self)
     mutating get {
       let pointer = unsafe UnsafeMutablePointer<Element>(
-        Builtin.addressOfBorrow(self)
+        Builtin.addressof(&self)
       )
-      let span = unsafe MutableSpan(_unsafeStart: pointer, count: 1)
+      let span = unsafe MutableSpan(_unchecked: pointer, count: 1)
       return unsafe _overrideLifetime(span, mutating: &self)
     }
   }

--- a/stdlib/public/core/ContiguousArray.swift
+++ b/stdlib/public/core/ContiguousArray.swift
@@ -1304,7 +1304,7 @@ extension ContiguousArray {
     borrowing get {
       let pointer = unsafe _buffer.firstElementAddress
       let count = _buffer.immutableCount
-      let span = unsafe Span(_unsafeStart: pointer, count: count)
+      let span = unsafe Span(_unchecked: pointer, count: count)
       return unsafe _overrideLifetime(span, borrowing: self)
     }
   }
@@ -1415,7 +1415,7 @@ extension ContiguousArray {
 #endif
       let pointer = unsafe _buffer.firstElementAddress
       let count = _buffer.mutableCount
-      let span = unsafe MutableSpan(_unsafeStart: pointer, count: count)
+      let span = unsafe MutableSpan(_unchecked: pointer, count: count)
       return unsafe _overrideLifetime(span, mutating: &self)
     }
   }

--- a/stdlib/public/core/InlineArray.swift
+++ b/stdlib/public/core/InlineArray.swift
@@ -600,7 +600,7 @@ extension InlineArray where Element: ~Copyable {
         let span = Span<Element>()
         return unsafe _overrideLifetime(span, borrowing: self)
       }
-      let span = unsafe Span(_unsafeStart: _protectedAddress, count: count)
+      let span = unsafe Span(_unchecked: _protectedAddress, count: count)
       return unsafe _overrideLifetime(span, borrowing: self)
     }
   }
@@ -621,7 +621,7 @@ extension InlineArray where Element: ~Copyable {
         return unsafe _overrideLifetime(span, mutating: &self)
       }
       let span = unsafe MutableSpan(
-        _unsafeStart: _protectedMutableAddress,
+        _unchecked: _protectedMutableAddress,
         count: count
       )
       return unsafe _overrideLifetime(span, mutating: &self)

--- a/stdlib/public/core/RigidArray/RigidArray.swift
+++ b/stdlib/public/core/RigidArray/RigidArray.swift
@@ -134,7 +134,10 @@ extension _RigidArray where Element: ~Copyable {
   internal var span: Span<Element> {
     @_lifetime(borrow self)
     get {
-      let result = unsafe Span(_unsafeElements: _items)
+      let result = unsafe Span(
+        _unchecked: _storage.baseAddress._unsafelyUnwrappedUnchecked,
+        count: _count
+      )
       return unsafe _overrideLifetime(result, borrowing: self)
     }
   }
@@ -149,7 +152,10 @@ extension _RigidArray where Element: ~Copyable {
   internal var mutableSpan: MutableSpan<Element> {
     @_lifetime(&self)
     mutating get {
-      let result = unsafe MutableSpan(_unsafeElements: _items)
+      let result = unsafe MutableSpan(
+        _unchecked: _storage.baseAddress._unsafelyUnwrappedUnchecked,
+        count: _count
+      )
       return unsafe _overrideLifetime(result, mutating: &self)
     }
   }

--- a/stdlib/public/core/Span/MutableSpan.swift
+++ b/stdlib/public/core/Span/MutableSpan.swift
@@ -54,6 +54,18 @@ public struct MutableSpan<Element: ~Copyable>
     unsafe _pointer = start
     _count = count
   }
+
+  @unsafe
+  @_alwaysEmitIntoClient
+  @_lifetime(borrow start)
+  @_transparent
+  internal init(
+    _unchecked start: UnsafeMutablePointer<Element>,
+    count: Int
+  ) {
+    unsafe _pointer = UnsafeMutableRawPointer(start)
+    _count = count
+  }
 }
 
 @available(SwiftCompatibilitySpan 5.0, *)
@@ -80,11 +92,15 @@ extension MutableSpan where Element: ~Copyable {
   public init(
     _unsafeElements buffer: UnsafeMutableBufferPointer<Element>
   ) {
-    _precondition(
-      ((Int(bitPattern: buffer.baseAddress) &
-        (MemoryLayout<Element>.alignment &- 1)) == 0),
-      "baseAddress must be properly aligned to access Element"
-    )
+    // 1 byte aligned elements can skip this check.
+    if MemoryLayout<Element>.alignment != 1 {
+      _precondition(
+        ((Int(bitPattern: buffer.baseAddress) &
+          (MemoryLayout<Element>.alignment &- 1)) == 0),
+        "baseAddress must be properly aligned to access Element"
+      )
+    }
+
     let ms = unsafe MutableSpan<Element>(_unchecked: buffer)
     self = unsafe _overrideLifetime(ms, borrowing: buffer)
   }

--- a/stdlib/public/core/Span/MutableSpan.swift
+++ b/stdlib/public/core/Span/MutableSpan.swift
@@ -92,14 +92,10 @@ extension MutableSpan where Element: ~Copyable {
   public init(
     _unsafeElements buffer: UnsafeMutableBufferPointer<Element>
   ) {
-    // 1 byte aligned elements can skip this check.
-    if MemoryLayout<Element>.alignment != 1 {
-      _precondition(
-        ((Int(bitPattern: buffer.baseAddress) &
-          (MemoryLayout<Element>.alignment &- 1)) == 0),
-        "baseAddress must be properly aligned to access Element"
-      )
-    }
+    _precondition(
+      buffer._isWellAligned(),
+      "baseAddress must be properly aligned to access Element"
+    )
 
     let ms = unsafe MutableSpan<Element>(_unchecked: buffer)
     self = unsafe _overrideLifetime(ms, borrowing: buffer)

--- a/stdlib/public/core/Span/OutputSpan.swift
+++ b/stdlib/public/core/Span/OutputSpan.swift
@@ -382,8 +382,10 @@ extension OutputSpan where Element: ~Copyable {
     @_lifetime(borrow self)
     borrowing get {
       let pointer = unsafe _pointer?.assumingMemoryBound(to: Element.self)
-      let buffer = unsafe UnsafeBufferPointer(start: pointer, count: _count)
-      let span = unsafe Span(_unsafeElements: buffer)
+      let span = unsafe Span(
+        _unchecked: pointer._unsafelyUnwrappedUnchecked,
+        count: _count
+      )
       return unsafe _overrideLifetime(span, borrowing: self)
     }
   }
@@ -395,10 +397,10 @@ extension OutputSpan where Element: ~Copyable {
     @_lifetime(&self)
     mutating get {
       let pointer = unsafe _pointer?.assumingMemoryBound(to: Element.self)
-      let buffer = unsafe UnsafeMutableBufferPointer(
-        start: pointer, count: _count
+      let span = unsafe MutableSpan(
+        _unchecked: pointer._unsafelyUnwrappedUnchecked,
+        count: _count
       )
-      let span = unsafe MutableSpan(_unsafeElements: buffer)
       return unsafe _overrideLifetime(span, mutating: &self)
     }
   }

--- a/stdlib/public/core/Span/Span.swift
+++ b/stdlib/public/core/Span/Span.swift
@@ -84,6 +84,30 @@ public struct Span<Element: ~Copyable>: ~Escapable, Copyable, BitwiseCopyable {
     unsafe _pointer = pointer
     _count = count
   }
+
+  /// Unsafely create a `Span` over initialized memory.
+  ///
+  /// `pointer` must point to a region of `count` initialized instances.
+  ///
+  /// The region of memory representing `count` instances starting at `pointer`
+  /// must remain valid, initialized and immutable
+  /// throughout the lifetime of the newly-created `Span`.
+  /// Failure to maintain this invariant results in undefined behaviour.
+  ///
+  /// - Parameters:
+  ///   - pointer: a pointer to the first initialized element.
+  ///   - count: the number of initialized elements in the span.
+  @lifetime(borrow pointer)
+  @unsafe
+  @_alwaysEmitIntoClient
+  @_transparent
+  internal init(
+    _unchecked pointer: UnsafePointer<Element>,
+    count: Int
+  ) {
+    unsafe _pointer = UnsafeRawPointer(pointer)
+    _count = count
+  }
 }
 
 @available(SwiftCompatibilitySpan 5.0, *)
@@ -110,11 +134,16 @@ extension Span where Element: ~Copyable {
   ) {
     //FIXME: Workaround for https://github.com/swiftlang/swift/issues/77235
     let baseAddress = unsafe UnsafeRawPointer(buffer.baseAddress)
-    _precondition(
-      ((Int(bitPattern: baseAddress) &
-        (MemoryLayout<Element>.alignment &- 1)) == 0),
-      "baseAddress must be properly aligned to access Element"
-    )
+
+    // 1 byte aligned elements can skip this check.
+    if MemoryLayout<Element>.alignment != 1 {
+      _precondition(
+        ((Int(bitPattern: baseAddress) &
+          (MemoryLayout<Element>.alignment &- 1)) == 0),
+        "baseAddress must be properly aligned to access Element"
+      )
+    }
+
     let span = unsafe Span(_unchecked: baseAddress, count: buffer.count)
     // As a trivial value, 'baseAddress' does not formally depend on the
     // lifetime of 'buffer'. Make the dependence explicit.

--- a/stdlib/public/core/Span/Span.swift
+++ b/stdlib/public/core/Span/Span.swift
@@ -139,7 +139,7 @@ extension Span where Element: ~Copyable {
     )
 
     let span = unsafe Span(
-      _unchecked: buffer.baseAddress._unsafelyUnwrappedUnchecked,
+      _unchecked: UnsafeRawPointer(buffer.baseAddress),
       count: buffer.count
     )
 

--- a/stdlib/public/core/Span/Span.swift
+++ b/stdlib/public/core/Span/Span.swift
@@ -77,6 +77,7 @@ public struct Span<Element: ~Copyable>: ~Escapable, Copyable, BitwiseCopyable {
   @_alwaysEmitIntoClient
   @inline(__always)
   @lifetime(borrow pointer)
+  @_disfavoredOverload
   internal init(
     _unchecked pointer: UnsafeRawPointer?,
     count: Int

--- a/stdlib/public/core/Span/Span.swift
+++ b/stdlib/public/core/Span/Span.swift
@@ -133,19 +133,15 @@ extension Span where Element: ~Copyable {
   public init(
     _unsafeElements buffer: UnsafeBufferPointer<Element>
   ) {
-    //FIXME: Workaround for https://github.com/swiftlang/swift/issues/77235
+    _precondition(
+      buffer._isWellAligned(),
+      "baseAddress must be properly aligned to access Element"
+    )
+
+    // FIXME: Workaround for https://github.com/swiftlang/swift/issues/77235
     let baseAddress = unsafe UnsafeRawPointer(buffer.baseAddress)
-
-    // 1 byte aligned elements can skip this check.
-    if MemoryLayout<Element>.alignment != 1 {
-      _precondition(
-        ((Int(bitPattern: baseAddress) &
-          (MemoryLayout<Element>.alignment &- 1)) == 0),
-        "baseAddress must be properly aligned to access Element"
-      )
-    }
-
     let span = unsafe Span(_unchecked: baseAddress, count: buffer.count)
+
     // As a trivial value, 'baseAddress' does not formally depend on the
     // lifetime of 'buffer'. Make the dependence explicit.
     self = unsafe _overrideLifetime(span, borrowing: buffer)

--- a/stdlib/public/core/Span/Span.swift
+++ b/stdlib/public/core/Span/Span.swift
@@ -138,9 +138,10 @@ extension Span where Element: ~Copyable {
       "baseAddress must be properly aligned to access Element"
     )
 
-    // FIXME: Workaround for https://github.com/swiftlang/swift/issues/77235
-    let baseAddress = unsafe UnsafeRawPointer(buffer.baseAddress)
-    let span = unsafe Span(_unchecked: baseAddress, count: buffer.count)
+    let span = unsafe Span(
+      _unchecked: buffer.baseAddress._unsafelyUnwrappedUnchecked,
+      count: buffer.count
+    )
 
     // As a trivial value, 'baseAddress' does not formally depend on the
     // lifetime of 'buffer'. Make the dependence explicit.

--- a/stdlib/public/core/UniqueBox.swift
+++ b/stdlib/public/core/UniqueBox.swift
@@ -87,7 +87,7 @@ extension UniqueBox where Value: ~Copyable {
     @_lifetime(borrow self)
     @_transparent
     get {
-      unsafe Span(_unsafeStart: pointer, count: 1)
+      unsafe Span(_unchecked: UnsafePointer(pointer), count: 1)
     }
   }
 
@@ -102,7 +102,7 @@ extension UniqueBox where Value: ~Copyable {
     @_lifetime(&self)
     @_transparent
     mutating get {
-      unsafe MutableSpan(_unsafeStart: pointer, count: 1)
+      unsafe MutableSpan(_unchecked: pointer, count: 1)
     }
   }
 }

--- a/stdlib/public/core/UniqueBox.swift
+++ b/stdlib/public/core/UniqueBox.swift
@@ -87,7 +87,8 @@ extension UniqueBox where Value: ~Copyable {
     @_lifetime(borrow self)
     @_transparent
     get {
-      unsafe Span(_unchecked: UnsafePointer(pointer), count: 1)
+      let s = unsafe Span(_unchecked: UnsafePointer(pointer), count: 1)
+      return unsafe _overrideLifetime(s, borrowing: self)
     }
   }
 

--- a/stdlib/public/core/UnsafePointer.swift
+++ b/stdlib/public/core/UnsafePointer.swift
@@ -473,8 +473,7 @@ extension UnsafePointer where Pointee: ~Copyable {
   @safe
   @_alwaysEmitIntoClient
   public func _isWellAligned() -> Bool {
-    MemoryLayout<Pointee>.alignment == 1 ||
-      (Int(bitPattern: self) & (MemoryLayout<Pointee>.alignment &- 1)) == 0
+    (Int(bitPattern: self) & (MemoryLayout<Pointee>.alignment &- 1)) == 0
   }
 }
 
@@ -1399,8 +1398,7 @@ extension UnsafeMutablePointer where Pointee: ~Copyable {
   @safe
   @_alwaysEmitIntoClient
   public func _isWellAligned() -> Bool {
-    MemoryLayout<Pointee>.alignment == 1 ||
-      (Int(bitPattern: self) & (MemoryLayout<Pointee>.alignment &- 1)) == 0
+    (Int(bitPattern: self) & (MemoryLayout<Pointee>.alignment &- 1)) == 0
   }
 }
 

--- a/stdlib/public/core/UnsafePointer.swift
+++ b/stdlib/public/core/UnsafePointer.swift
@@ -473,7 +473,8 @@ extension UnsafePointer where Pointee: ~Copyable {
   @safe
   @_alwaysEmitIntoClient
   public func _isWellAligned() -> Bool {
-    (Int(bitPattern: self) & (MemoryLayout<Pointee>.alignment &- 1)) == 0
+    MemoryLayout<Pointee>.alignment == 1 ||
+      (Int(bitPattern: self) & (MemoryLayout<Pointee>.alignment &- 1)) == 0
   }
 }
 
@@ -1398,7 +1399,8 @@ extension UnsafeMutablePointer where Pointee: ~Copyable {
   @safe
   @_alwaysEmitIntoClient
   public func _isWellAligned() -> Bool {
-    (Int(bitPattern: self) & (MemoryLayout<Pointee>.alignment &- 1)) == 0
+    MemoryLayout<Pointee>.alignment == 1 ||
+      (Int(bitPattern: self) & (MemoryLayout<Pointee>.alignment &- 1)) == 0
   }
 }
 


### PR DESCRIPTION
Our collections can safely elide the alignment and count checks that occur when initializing values of `Span`s or `MutableSpan`s from them. Also conditionalize the alignment check for types with an alignment greater than 1 because an element type of `UInt8` for example can be pointed to by any pointer.

Resolves: https://github.com/swiftlang/swift/issues/89954 and rdar://179715713