### PR TITLE
Serialization: Don't drop generic type-alias type witness decls cross-module

### DIFF
--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -9266,16 +9266,6 @@ void ModuleFile::finishNormalConformance(NormalProtocolConformance *conformance,
     } else {
       fatal(thirdOrError.takeError());
     }
-    if (isa_and_nonnull<TypeAliasDecl>(third) &&
-        third->getModuleContext() != getAssociatedModule() &&
-        !third->getDeclaredInterfaceType()->isEqual(second)) {
-      // Conservatively drop references to typealiases in other modules
-      // that may have changed. This may also drop references to typealiases
-      // that /haven't/ changed but just happen to have generics in them, but
-      // in practice having a declaration here isn't actually required by the
-      // rest of the compiler.
-      third = nullptr;
-    }
     typeWitnesses[first] = {second, third};
   }
   assert(rawIDIter <= rawIDs.end() && "read too much");

--- a/test/AssociatedTypeInference/cross_module_extension_typealias_witness.swift
+++ b/test/AssociatedTypeInference/cross_module_extension_typealias_witness.swift
@@ -1,0 +1,57 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// Build three separate modules: Core (declares the protocol and the
+// protocol-extension type alias that witnesses the associated type), Mid (the
+// conformer, which does *not* declare the associated type explicitly), and App
+// (which references the conformer's associated type and imports both modules).
+
+// RUN: %target-swift-frontend -emit-module -module-name Core %t/Core.swift -emit-module-path %t/Core.swiftmodule
+// RUN: %target-swift-frontend -emit-module -module-name Mid %t/Mid.swift -emit-module-path %t/Mid.swiftmodule -I %t
+// RUN: %target-swift-frontend -typecheck -verify %t/App.swift -I %t
+
+// https://github.com/swiftlang/swift/issues/89909
+//
+// Cross-module qualified lookup of an associated type whose witness is supplied
+// by a type alias in a protocol extension used to fail when the protocol
+// extension, the conformer, and the reference site each lived in a separate
+// module. Deserializing the conformer's module used to drop the witness type
+// alias declaration (because the generic type alias lives in yet another
+// module), which left qualified lookup with no declaration to resolve, so
+// 'Foo.Action' failed with "'Action' is not a member type of struct 'Foo'".
+
+//--- Core.swift
+
+public protocol Feature {
+    associatedtype State
+    associatedtype Action
+}
+
+extension Feature {
+    public typealias Action = GenericAction<Self, State>
+}
+
+public enum GenericAction<F: Feature, State> {
+    case state(State)
+}
+
+//--- Mid.swift
+
+import Core
+
+public struct Foo: Feature {
+    public typealias State = Int
+}
+
+//--- App.swift
+
+import Core
+import Mid
+
+// The associated type 'Action' resolves to the extension-supplied witness
+// 'GenericAction<Foo, Int>'.
+public func useFooAction(_ action: Foo.Action) {}
+
+func checkWitnessType() {
+    let _: Foo.Action = GenericAction<Foo, Int>.state(0)
+}


### PR DESCRIPTION
## Summary

Fixes #89909, a Swift 6.4 regression where cross-module qualified lookup of an associated type whose witness is supplied by a `typealias` in a **protocol extension** fails with `'Action' is not a member type of struct 'Foo'`, when the extension, the conformer, and the reference site each live in a separate module.

```swift
// Core
public protocol Feature {
    associatedtype State
    associatedtype Action
}
extension Feature {
    public typealias Action = GenericAction<Self, State>
}
public enum GenericAction<F: Feature, State> { case state(State) }

// Mid
import Core
public struct Foo: Feature { public typealias State = Int }

// App
import Core
import Mid
public func useFooAction(_ action: Foo.Action) {} // error before this change
```

## Root cause

When deserializing a protocol conformance, the reference to a type-alias type witness declared in another module was conservatively dropped — the resolved type witness was kept, but the witness *declaration* was nulled out. This originates in #8896 (2017): cross-module typealias references were otherwise banned for resilience, and there was no cheap way to tell whether the typealias had changed, so the decl was dropped on the assumption that "having a declaration here isn't actually required by the rest of the compiler."

The drop fires whenever the typealias's declared interface type differs from the resolved witness type:

```cpp
!third->getDeclaredInterfaceType()->isEqual(second)
```

A *generic* type-alias witness such as `typealias Action = GenericAction<Self, State>` has declared interface type `GenericAction<Self, State>` (still parameterized), which can never equal the resolved concrete witness `GenericAction<Foo, Int>`. So the decl is dropped for **every** generic type-alias witness, not just for ones that genuinely changed — exactly the collateral damage the original comment flagged.

Since 62e4979691570df8e66452eed5be71ce69c7aa54 ("AST: Prefer associated types over protocol type aliases"), qualified lookup prefers the associated type over a protocol-extension type alias of the same name and routes through the conformance's type witness. With the witness declaration missing, `TypeChecker::lookupMemberType` treated it as circularity and bailed — producing the `'Action' is not a member type of struct 'Foo'` error.

## Fix

Remove the drop. The witness declaration is retained, and lookup resolves normally.

## Testing

- Added a regression test (`test/AssociatedTypeInference/cross_module_extension_typealias_witness.swift`) reproducing the three-module setup from the issue.
- Locally green across `Serialization`, `AssociatedTypeInference`, `multifile`, `ModuleInterface`, `Generics`, `decl`, `Sema`, and `Interpreter` (incl. `test_recursive_protocol_deserialization.swift`). The dropped-decl behavior never had a test of its own.

Fixes #89909
