### PR TITLE
[build] Make it easier to update-doc-index

### DIFF
--- a/userdocs/CMakeLists.txt
+++ b/userdocs/CMakeLists.txt
@@ -1,3 +1,45 @@
 swift_install_in_component(DIRECTORY diagnostics
                            DESTINATION "share/doc/swift"
                            COMPONENT compiler)
+
+# 'update-doc-index' regenerates the auto-generated files
+# 'userdocs/diagnostics/diagnostic-groups.md' and
+# 'userdocs/diagnostics/upcoming-language-features.md' from the current
+# 'DiagnosticGroups.def' and the diagnostic markdown files. 
+#
+# This target writes back into the source tree, so it is intentionally not
+# part of the default build.
+if(SWIFT_NATIVE_SWIFT_TOOLS_PATH)
+  set(_swift_doc_index_swiftc "${SWIFT_NATIVE_SWIFT_TOOLS_PATH}/swiftc")
+elseif(CMAKE_Swift_COMPILER)
+  set(_swift_doc_index_swiftc "${CMAKE_Swift_COMPILER}")
+else()
+  set(_swift_doc_index_swiftc "swiftc")
+endif()
+
+# 'generate-doc-index.swift' imports Foundation, so we need an SDK on Apple
+# platforms; otherwise swiftc fails with "no such module 'Foundation'".
+if(APPLE AND CMAKE_OSX_SYSROOT)
+  set(_swift_doc_index_sdk_args -sdk "${CMAKE_OSX_SYSROOT}")
+else()
+  set(_swift_doc_index_sdk_args "")
+endif()
+
+add_custom_command(
+  OUTPUT  ${CMAKE_CURRENT_BINARY_DIR}/generate-doc-index
+  COMMAND ${_swift_doc_index_swiftc}
+            ${_swift_doc_index_sdk_args}
+            -swift-version 5
+            -enable-upcoming-feature BareSlashRegexLiterals
+            ${SWIFT_SOURCE_DIR}/utils/generate-doc-index.swift
+            -o ${CMAKE_CURRENT_BINARY_DIR}/generate-doc-index
+  DEPENDS ${SWIFT_SOURCE_DIR}/utils/generate-doc-index.swift
+  COMMENT "Building generate-doc-index")
+
+add_custom_target(update-doc-index
+  COMMAND ${CMAKE_CURRENT_BINARY_DIR}/generate-doc-index
+            ${SWIFT_SOURCE_DIR}
+            ${SWIFT_SOURCE_DIR}/userdocs/diagnostics
+  DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/generate-doc-index
+  COMMENT "Regenerating userdocs/diagnostics index files"
+  USES_TERMINAL)

--- a/validation-test/docs/userdoc_indices.test
+++ b/validation-test/docs/userdoc_indices.test
@@ -5,8 +5,11 @@
 
 # RUN: %empty-directory(%t)
 
-# Check that the generated doc indices match those in the repo. Run
-# `./utils/generate-doc-index.swift <swift-source-directory>` to regenerate.
+# Check that the generated doc indices match those in the repo.
+#
+# To regenerate after adding/renaming a diagnostic doc:
+#   - In a CMake/ninja build:   ninja update-doc-index
+#   - Or manually:              swift utils/generate-doc-index.swift <swift-source-dir> userdocs/diagnostics
 
 # RUN: %host-build-swift -swift-version 5 -enable-upcoming-feature BareSlashRegexLiterals %swift_src_root/utils/generate-doc-index.swift -o %t/generate-doc-index
 # RUN: %t/generate-doc-index %swift_src_root %t


### PR DESCRIPTION
I've found it's too easy to forget and too annoying to run update-doc-index script when adding diagnostic groups.

How about we add it do the build so one can `ninja update-doc-index`?

WDYT @etcwilde 