### PR TITLE
[ClangImporter] Have `ImportMacroAliases` import `#define`s that alias C/Objective-C type names as `typealias`es.

### DIFF
--- a/lib/ClangImporter/ImportMacro.cpp
+++ b/lib/ClangImporter/ImportMacro.cpp
@@ -20,6 +20,8 @@
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/DiagnosticsClangImporter.h"
 #include "swift/AST/Expr.h"
+#include "swift/AST/GenericParamList.h"
+#include "swift/AST/NameLookupRequests.h"
 #include "swift/AST/ParameterList.h"
 #include "swift/AST/Stmt.h"
 #include "swift/AST/Types.h"
@@ -28,6 +30,7 @@
 #include "swift/Basic/Unicode.h"
 #include "swift/ClangImporter/ClangModule.h"
 #include "clang/AST/ASTContext.h"
+#include "clang/AST/DeclObjC.h"
 #include "clang/AST/Expr.h"
 #include "clang/Lex/MacroInfo.h"
 #include "clang/Lex/Preprocessor.h"
@@ -497,6 +500,49 @@ ValueDecl *importDeclAlias(ClangImporter::Implementation &clang,
 
   return V;
 }
+
+ValueDecl *importTypeDeclAlias(ClangImporter::Implementation &clang,
+                               swift::DeclContext *DC, const clang::NamedDecl *D,
+                               Identifier alias) {
+  if (!DC->getASTContext().LangOpts.hasFeature(Feature::ImportMacroAliases))
+    return nullptr;
+
+  // Ignore self-referential macros.
+  if (D->getName() == alias.str())
+    return nullptr;
+
+  swift::Decl *imported = clang.importDecl(D, clang.CurrentVersion);
+  if (imported == nullptr)
+    return nullptr;
+
+  swift::TypeDecl *TD = dyn_cast<TypeDecl>(imported);
+  if (TD == nullptr)
+    return nullptr;
+
+  // If the imported type is named identically, avoid the aliasing.
+  if (TD->getName().str() == alias.str())
+    return nullptr;
+
+  auto *aliasDecl = clang.createDeclWithClangNode<TypeAliasDecl>(
+      D, swift::AccessLevel::Public,
+      /*StartLoc=*/SourceLoc(), /*EqualLoc=*/SourceLoc(),
+      alias, /*NameLoc=*/SourceLoc(), /*genericparams*/ nullptr, DC);
+
+  auto *GTD = dyn_cast<GenericTypeDecl>(TD);
+  if (GTD && !isa<ProtocolDecl>(GTD)) {
+    aliasDecl->setGenericSignature(GTD->getGenericSignature());
+    if (GTD->hasGenericParamList()) {
+      aliasDecl->getASTContext().evaluator.cacheOutput(
+            GenericParamListRequest{aliasDecl},
+            std::move(GTD->getGenericParams()->clone(aliasDecl)));
+    }
+  }
+
+  aliasDecl->setUnderlyingType(TD->getDeclaredInterfaceType());
+  aliasDecl->markAsCompatibilityAlias();
+
+  return aliasDecl;
+}
 } // namespace
 
 static ValueDecl *importMacro(ClangImporter::Implementation &impl,
@@ -642,9 +688,15 @@ static ValueDecl *importMacro(ClangImporter::Implementation &impl,
       clang::LookupResult R(S, {{tok.getIdentifierInfo()}, {}},
                             clang::Sema::LookupAnyName);
       if (S.LookupName(R, S.TUScope))
-        if (R.getResultKind() == clang::LookupResultKind::Found)
-          if (const auto *VD = dyn_cast<clang::ValueDecl>(R.getFoundDecl()))
+        if (R.getResultKind() == clang::LookupResultKind::Found) {
+          if (const auto *VD = dyn_cast<clang::ValueDecl>(R.getFoundDecl())) {
             return importDeclAlias(impl, DC, VD, name);
+          } else if (isa<clang::TypeDecl>(R.getFoundDecl()) ||
+                     isa<clang::ObjCInterfaceDecl>(R.getFoundDecl()) ||
+                     isa<clang::ObjCProtocolDecl>(R.getFoundDecl())) {
+            return importTypeDeclAlias(impl, DC, R.getFoundDecl(), name);
+          }
+        }
     }
 
     // TODO(https://github.com/apple/swift/issues/57735): Seems rare to have a single token that is neither a literal nor an identifier, but add diagnosis.

--- a/test/ClangImporter/Inputs/custom-modules/Aliases.h
+++ b/test/ClangImporter/Inputs/custom-modules/Aliases.h
@@ -51,3 +51,26 @@ extern const int const_overloaded __attribute__((__swift_name__("overload")));
 
 void variadic(int count, ...);
 #define aliased_variadic variadic
+
+struct MyStruct {
+  int x;
+};
+typedef struct MyStruct MyStruct;
+#define ALIASED_STRUCT MyStruct
+
+union MyUnion {
+  int x;
+  float y;
+};
+typedef union MyUnion MyUnion;
+#define ALIASED_UNION MyUnion
+
+enum MyEnum {
+  MY_ENUM_A,
+  MY_ENUM_B
+};
+typedef enum MyEnum MyEnum;
+#define ALIASED_ENUM MyEnum
+
+typedef int MyInt;
+#define ALIASED_INT MyInt

--- a/test/ClangImporter/Inputs/custom-modules/AliasesObjc.h
+++ b/test/ClangImporter/Inputs/custom-modules/AliasesObjc.h
@@ -1,0 +1,10 @@
+@import ObjectiveC;
+
+@interface MyObjCClass : NSObject
+- (instancetype)init;
+@end
+#define ALIASED_OBJC_CLASS MyObjCClass
+
+@protocol MyObjCProtocol
+@end
+#define ALIASED_OBJC_PROTOCOL MyObjCProtocol

--- a/test/ClangImporter/Inputs/custom-modules/module.modulemap
+++ b/test/ClangImporter/Inputs/custom-modules/module.modulemap
@@ -289,6 +289,10 @@ module Aliases {
   header "Aliases.h"
 }
 
+module AliasesObjc {
+  header "AliasesObjc.h"
+}
+
 module RetroactiveVersioning {
   header "versioning.h"
 }

--- a/test/ClangImporter/alias-objc.swift
+++ b/test/ClangImporter/alias-objc.swift
@@ -1,0 +1,27 @@
+// RUN: %target-typecheck-verify-swift %clang-importer-sdk -I %S/Inputs/custom-modules %s -enable-experimental-feature ImportMacroAliases
+// RUN: %target-swift-frontend %clang-importer-sdk -I %S/Inputs/custom-modules -parse-as-library -module-name AliasObjc -Osize -emit-ir -o - %s -enable-experimental-feature ImportMacroAliases | %FileCheck %s
+// REQUIRES: objc_interop
+// REQUIRES: swift_feature_ImportMacroAliases
+
+// expected-no-diagnostics
+
+import AliasesObjc
+
+// CHECK-DAG: @"OBJC_CLASS_REF_$_MyObjCClass" =
+// CHECK-DAG: @"OBJC_CLASS_$_MyObjCClass" =
+// CHECK-DAG: @{{.*_PROTOCOL_.*MyObjCProtocol"?}} = weak hidden
+// CHECK-DAG: @"{{.*l_OBJC_LABEL_PROTOCOL_.*MyObjCProtocol}}" = weak hidden global ptr @{{.*_PROTOCOL_.*MyObjCProtocol"?}}
+// CHECK-DAG: @"{{.*l_OBJC_PROTOCOL_REFERENCE_.*MyObjCProtocol}}" = weak hidden global ptr @{{.*_PROTOCOL_.*MyObjCProtocol"?}}
+
+public func testObjCClass(y: ALIASED_OBJC_CLASS) -> AnyObject {
+  return ALIASED_OBJC_CLASS()
+}
+// CHECK-DAG: define {{.*}}swiftcc {{.*}} @"$s9AliasObjc13testObjCClass1yyXlSo02MydE0C_tF"
+
+public func testObjCProtocol(x: ALIASED_OBJC_PROTOCOL, y: AnyObject) -> Bool {
+  return y is ALIASED_OBJC_PROTOCOL
+}
+// CHECK-LABEL: define {{.*}}swiftcc {{.*}} @"$s9AliasObjc16testObjCProtocol1x1ySbSo02MydE0_p_yXltF"
+// CHECK:         %[[PROTO_REF:[0-9]+]] = load ptr, ptr @"{{.*l_OBJC_PROTOCOL_REFERENCE_.*MyObjCProtocol}}"
+// CHECK:         store ptr %[[PROTO_REF]], ptr %[[PROTO_LIST:[a-zA-Z0-9_]+]]
+// CHECK:         call ptr @swift_dynamicCastObjCProtocolConditional(ptr {{%[0-9]+}}, i64 1, ptr {{.*}}%[[PROTO_LIST]])

--- a/test/ClangImporter/alias.swift
+++ b/test/ClangImporter/alias.swift
@@ -18,6 +18,22 @@ public func g() {
   UI = 32
 }
 
+public func testStruct(s: ALIASED_STRUCT) -> ALIASED_STRUCT {
+  return s
+}
+
+public func testUnion(u: ALIASED_UNION) -> ALIASED_UNION {
+  return u
+}
+
+public func testEnum(e: ALIASED_ENUM) -> ALIASED_ENUM {
+  return e
+}
+
+public func testInt(i: ALIASED_INT) -> ALIASED_INT {
+  return i
+}
+
 // CHECK-ANSI-IR: @VA = external {{(dso_local )?}}local_unnamed_addr constant i32
 // CHECK-ANSI-IR: @UIA = external {{(dso_local )?}}local_unnamed_addr global float
 
@@ -36,6 +52,10 @@ public func g() {
 // CHECK-ANSI-IR:   store float 3.200000e+01, ptr @UIA
 // CHECK-ANSI-IR:   ret void
 // CHECK-ANSI-IR: }
+// CHECK-ANSI-IR: define {{.*}}swiftcc i32 @"$s5Alias10testStruct1sSo02MyC0VAE_tF"(i32 returned %0)
+// CHECK-ANSI-IR: define {{.*}}swiftcc i32 @"$s5Alias9testUnion1uSo02MyC0VAE_tF"(i32 returned %0)
+// CHECK-ANSI-IR: define {{.*}}swiftcc i32 @"$s5Alias8testEnum1eSo02MyC0VAE_tF"(i32 returned %0)
+// CHECK-ANSI-IR: define {{.*}}swiftcc i32 @"$s5Alias7testInt1is5Int32VAE_tF"(i32 returned %0)
 
 // CHECK-UNICODE-IR: @VW = external {{(dso_local )?}}local_unnamed_addr constant i64
 // CHECK-UNICODE-IR: @UIW = external {{(dso_local )?}}local_unnamed_addr global double
@@ -55,6 +75,10 @@ public func g() {
 // CHECK-UNICODE-IR:   store double 3.200000e+01, ptr @UIW
 // CHECK-UNICODE-IR:   ret void
 // CHECK-UNICODE-IR: }
+// CHECK-UNICODE-IR: define {{.*}}swiftcc i32 @"$s5Alias10testStruct1sSo02MyC0VAE_tF"(i32 returned %0)
+// CHECK-UNICODE-IR: define {{.*}}swiftcc i32 @"$s5Alias9testUnion1uSo02MyC0VAE_tF"(i32 returned %0)
+// CHECK-UNICODE-IR: define {{.*}}swiftcc i32 @"$s5Alias8testEnum1eSo02MyC0VAE_tF"(i32 returned %0)
+// CHECK-UNICODE-IR: define {{.*}}swiftcc i32 @"$s5Alias7testInt1is5Int32VAE_tF"(i32 returned %0)
 
 func h() {
   let _ = CLOCK_MONOTONIC


### PR DESCRIPTION
`ImportMacroAliases` currently supports anything that's a `clang::ValueDecl`, so it picks up variables and functions, but C types and Objective-C interfaces/protocols are left behind.

@compnerd @xedin It looks like you've most recently edited this code, does this seem like a reasonable thing to have?

Rationale: some of our SDK teams use preprocessor macros to rename symbols in their Objective-C code when building their SDKs so that they can avoid symbol collisions with other SDKs (i.e., two static SDKs that share possibly different versions of a common dependency) without having to modify any of the dependencies. This technique fails if they want to add Swift to the SDK because it can't see the changed names.

Updating `ImportMacroAliases` seems like the simplest path forward where we could inject a combination of `-D` flags and an `-include`d header to get the same effect.