### PR TITLE
AllocBoxToStack: don't forget to rewrite `debug_value` users

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/AllocBoxToStack.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/AllocBoxToStack.swift
@@ -237,6 +237,8 @@ private struct FunctionSpecializations {
         // First, replace the instruction with the original `box`, which adds more uses to `box`.
         // In a later iteration those additional uses will be handled.
         (user as! SingleValueInstruction).replace(with: box, context)
+      case let debugValue as DebugValueInst:
+        debugValue.operand.set(to: stack, context)
       case let apply as ApplySite:
         specialize(apply: apply, context)
       default:

--- a/test/SILOptimizer/allocbox_to_stack.sil
+++ b/test/SILOptimizer/allocbox_to_stack.sil
@@ -20,13 +20,15 @@ class C {}
 sil @simple_promotion : $(Int) -> Int {
 bb0(%0 : $Int):
   %1 = alloc_box ${ var Int }
+  debug_value %1, var, name "x"
   %1a = project_box %1 : ${ var Int }, 0
   store %0 to %1a : $*Int
   %3 = load %1a : $*Int
   strong_release %1 : ${ var Int }
   return %3 : $Int
 
-// CHECK: alloc_stack
+// CHECK: [[S:%.*]] = alloc_stack
+// CHECK-NEXT: debug_value [[S]]
 // CHECK-NOT: alloc_box
 // CHECK-NOT: strong_release
 // CHECK: return


### PR DESCRIPTION
AllocBoxToStack can handle boxes with `debug_value` users. However, the code to rewrite the box was missing handling `debug_value` users.

Fixes a compiler crash
rdar://179740189
