### PR TITLE
tests: add new reference counting runtime functions in ABI tests for macOS arm64

### DIFF
--- a/test/abi/Inputs/macOS/x86_64/stdlib/baseline
+++ b/test/abi/Inputs/macOS/x86_64/stdlib/baseline
@@ -13660,13 +13660,11 @@ _swift_registerProtocolConformances
 _swift_registerProtocols
 _swift_registerTypeMetadataRecords
 _swift_release
-_swift_releaseReturningCount
 _swift_release_n
 _swift_relocateClassMetadata
 _swift_reportError
 _swift_reportWarning
 _swift_retain
-_swift_retainReturningCount
 _swift_retainCount
 _swift_retain_n
 _swift_rootObjCDealloc

--- a/test/abi/Inputs/macOS/x86_64/stdlib/baseline-asserts
+++ b/test/abi/Inputs/macOS/x86_64/stdlib/baseline-asserts
@@ -13756,14 +13756,12 @@ _swift_registerProtocolConformances
 _swift_registerProtocols
 _swift_registerTypeMetadataRecords
 _swift_release
-_swift_releaseReturningCount
 _swift_release_n
 _swift_relocateClassMetadata
 _swift_reportError
 _swift_reportWarning
 _swift_retain
 _swift_retainCount
-_swift_retainReturningCount
 _swift_retain_n
 _swift_rootObjCDealloc
 _swift_runtimeSupportsNoncopyableTypes

--- a/test/abi/macOS/arm64/stdlib.swift
+++ b/test/abi/macOS/arm64/stdlib.swift
@@ -1338,3 +1338,8 @@ Added: _$ss11UniqueArrayVyxGSHsSHRzRi_zrlMc
 Added: _$ss11UniqueArrayVyxGSQsSQRzRi_zrlMc
 Added: _$ss11UniqueArrayVsRi_zrlE11descriptionSSvg
 Added: _$ss11UniqueArrayVsRi_zrlE16debugDescriptionSSvg
+
+// Reference counting
+Added: _swift_releaseReturningCount
+Added: _swift_retainReturningCount
+

--- a/test/abi/macOS/x86_64/stdlib.swift
+++ b/test/abi/macOS/x86_64/stdlib.swift
@@ -1333,3 +1333,8 @@ Added: _$ss11UniqueArrayVyxGSHsSHRzRi_zrlMc
 Added: _$ss11UniqueArrayVyxGSQsSQRzRi_zrlMc
 Added: _$ss11UniqueArrayVsRi_zrlE11descriptionSSvg
 Added: _$ss11UniqueArrayVsRi_zrlE16debugDescriptionSSvg
+
+// Reference counting
+Added: _swift_releaseReturningCount
+Added: _swift_retainReturningCount
+


### PR DESCRIPTION
Also, add those new functions as "Added:" lines instead of changing the base line

This is a follow-up on https://github.com/swiftlang/swift/pull/89914