### PR TITLE
[SwiftMacros] Type information parsing for derived conformances

### DIFF
--- a/lib/Macros/Sources/SwiftMacros/CMakeLists.txt
+++ b/lib/Macros/Sources/SwiftMacros/CMakeLists.txt
@@ -17,6 +17,7 @@ add_swift_macro_library(SwiftMacros
   SyntaxExtensions.swift
   TaskLocalMacro.swift
   SwiftifyImportMacro.swift
+  TypeInfoParser.swift
   SWIFT_DEPENDENCIES
     SwiftDiagnostics
     SwiftSyntax

--- a/lib/Macros/Sources/SwiftMacros/TypeInfoParser.swift
+++ b/lib/Macros/Sources/SwiftMacros/TypeInfoParser.swift
@@ -14,6 +14,7 @@
 //===----------------------------------------------------------------------===//
 
 import SwiftSyntax
+import SwiftSyntaxBuilder
 
 public struct NominalTypeInfo {
   var name: String
@@ -163,7 +164,7 @@ extension LabeledExprListSyntax {
   }
 }
 
-extension NominalTypeInfo: FromSyntax {
+extension NominalTypeInfo: TypeInfoSyntax {
   public static func fromSyntax(node: ExprSyntax) throws -> Self {
     guard let fcall = node.as(FunctionCallExprSyntax.self) else {
       throw TypeInfoParseError.expectedFunctionCall(got: node)
@@ -181,9 +182,15 @@ extension NominalTypeInfo: FromSyntax {
 
     return Self(name: parsed.0, kind: parsed.1, isUnsafe: parsed.2)
   }
+
+  public var syntax: ExprSyntax {
+    """
+    NominalTypeInfo(name: \(stringlit(name)), kind: \(kind.syntax), isUnsafe: \(boollit(isUnsafe)))
+    """
+  }
 }
 
-extension NominalTypeKind: FromSyntax {
+extension NominalTypeKind: TypeInfoSyntax {
   public static func fromSyntax(node: ExprSyntax) throws -> Self {
     guard let fcall = node.as(FunctionCallExprSyntax.self) else {
       throw TypeInfoParseError.expectedFunctionCall(got: node)
@@ -204,9 +211,22 @@ extension NominalTypeKind: FromSyntax {
         names: ["structLike", "enumLike"], got: fcall.calledExpression)
     }
   }
+
+  public var syntax: ExprSyntax {
+    switch self {
+    case .enumLike(let e):
+      """
+      enumLike(\(e.syntax))
+      """
+    case .structLike(let s):
+      """
+      structLike(\(s.syntax))
+      """
+    }
+  }
 }
 
-extension StructTypeInfo: FromSyntax {
+extension StructTypeInfo: TypeInfoSyntax {
   public static func fromSyntax(node: ExprSyntax) throws -> Self {
     guard let fcall = node.as(FunctionCallExprSyntax.self) else {
       throw TypeInfoParseError.expectedFunctionCall(got: node)
@@ -219,9 +239,15 @@ extension StructTypeInfo: FromSyntax {
       properties: try fcall.arguments.expect(
         .arrArg("properties", parser: StoredProperty.fromSyntax)))
   }
+
+  public var syntax: ExprSyntax {
+    """
+    StructTypeInfo(properties: \(arrSyntax(properties)))
+    """
+  }
 }
 
-extension EnumTypeInfo: FromSyntax {
+extension EnumTypeInfo: TypeInfoSyntax {
   public static func fromSyntax(node: ExprSyntax) throws -> Self {
     guard let fcall = node.as(FunctionCallExprSyntax.self) else {
       throw TypeInfoParseError.expectedFunctionCall(got: node)
@@ -239,9 +265,15 @@ extension EnumTypeInfo: FromSyntax {
 
     return Self(isObjC: parsed.0, cases: parsed.1)
   }
+
+  public var syntax: ExprSyntax {
+    """
+    EnumTypeInfo(isObjC: \(boollit(isObjC)), cases: \(arrSyntax(cases)))
+    """
+  }
 }
 
-extension StoredProperty: FromSyntax {
+extension StoredProperty: TypeInfoSyntax {
   public static func fromSyntax(node: ExprSyntax) throws -> Self {
     guard let fcall = node.as(FunctionCallExprSyntax.self) else {
       throw TypeInfoParseError.expectedFunctionCall(got: node)
@@ -261,9 +293,15 @@ extension StoredProperty: FromSyntax {
 
     return Self(name: parsed.0, typeName: parsed.1, isVar: parsed.2, isStatic: parsed.3)
   }
+
+  public var syntax: ExprSyntax {
+    """
+    StoredProperty(name: \(stringlit(name)), typeName: \(stringlit(typeName)), isVar: \(boollit(isVar)), isStatic: \(boollit(isStatic)))
+    """
+  }
 }
 
-extension CaseInfo: FromSyntax {
+extension CaseInfo: TypeInfoSyntax {
   public static func fromSyntax(node: ExprSyntax) throws -> Self {
     guard let fcall = node.as(FunctionCallExprSyntax.self) else {
       throw TypeInfoParseError.expectedFunctionCall(got: node)
@@ -281,13 +319,20 @@ extension CaseInfo: FromSyntax {
 
     return Self(name: parsed.0, associatedValues: parsed.1)
   }
+
+  public var syntax: ExprSyntax {
+    """
+    CaseInfo(name: \(stringlit(name)), associatedValues: \(arrSyntax(associatedValues, {optSyntax($0, stringlit)}))
+    """
+  }
 }
 
-public protocol FromSyntax {
+public protocol TypeInfoSyntax {
   static func fromSyntax(node: ExprSyntax) throws -> Self
+  var syntax: ExprSyntax { get }
 }
 
-extension FromSyntax {
+extension TypeInfoSyntax {
   public static func fromStringLit(strlit: StringLiteralExprSyntax) throws -> Self {
     guard let underlying = strlit.representedLiteralValue else {
       throw TypeInfoParseError.expectedStrLitAsInput(got: ExprSyntax(strlit))
@@ -300,5 +345,33 @@ extension FromSyntax {
       throw TypeInfoParseError.expectedStrLitAsInput(got: expr)
     }
     return try fromStringLit(strlit: strlit)
+  }
+}
+
+func stringlit(_ str: String) -> ExprSyntax {
+  ExprSyntax(StringLiteralExprSyntax(content: str))
+}
+
+func boollit(_ b: Bool) -> ExprSyntax {
+  ExprSyntax(BooleanLiteralExprSyntax(booleanLiteral: b))
+}
+
+func arrSyntax<T: TypeInfoSyntax>(_ values: [T]) -> ExprSyntax {
+  arrSyntax(values, \.syntax)
+}
+
+func arrSyntax<T>(_ values: [T], _ toSyntax: (T) -> ExprSyntax) -> ExprSyntax {
+  ExprSyntax(ArrayExprSyntax(expressions: values.map(toSyntax)))
+}
+
+func optSyntax<T: TypeInfoSyntax>(_ value: T?) -> ExprSyntax {
+  optSyntax(value, \.syntax)
+}
+
+func optSyntax<T>(_ value: T?, _ toSyntax: (T) -> ExprSyntax) -> ExprSyntax {
+  if let value = value {
+    toSyntax(value)
+  } else {
+    "nil"
   }
 }

--- a/lib/Macros/Sources/SwiftMacros/TypeInfoParser.swift
+++ b/lib/Macros/Sources/SwiftMacros/TypeInfoParser.swift
@@ -106,7 +106,8 @@ public enum TypeInfoParseError: Error {
 
 /// Parses a string literal and returns its contents. Throws in case of error.
 func parseString(node: ExprSyntax) throws -> String {
-  guard let res = node.as(StringLiteralExprSyntax.self)?.representedLiteralValue else {
+  guard let res = node.as(StringLiteralExprSyntax.self)?.representedLiteralValue
+  else {
     throw TypeInfoParseError.expectedStringLiteral(got: node)
   }
   return res
@@ -122,7 +123,9 @@ func parseBool(node: ExprSyntax) throws -> Bool {
 
 /// Parses either `nil` or an expression with the `parser` parsing function.
 /// Throws if `parser` throws
-func parseOptional<T>(node: ExprSyntax, parser: (ExprSyntax) throws -> T) throws -> T? {
+func parseOptional<T>(node: ExprSyntax, parser: (ExprSyntax) throws -> T) throws
+  -> T?
+{
   // Eagerly checks if it is nil. This means that T?? can never be some(nil)
   // parsed this way as we just expect either nil or a value.
   if node.is(NilLiteralExprSyntax.self) {
@@ -134,7 +137,9 @@ func parseOptional<T>(node: ExprSyntax, parser: (ExprSyntax) throws -> T) throws
 /// Parses an array literal containing elements parsed with the `parse` function
 /// and returns them all. Will throw if it is not an array literal or if one
 /// of the elements throws during parsing.
-func parseArray<T>(node: ExprSyntax, parser: (ExprSyntax) throws -> T) throws -> [T] {
+func parseArray<T>(node: ExprSyntax, parser: (ExprSyntax) throws -> T) throws
+  -> [T]
+{
   guard let arr = node.as(ArrayExprSyntax.self) else {
     throw TypeInfoParseError.expectedArrayLiteral(got: node)
   }
@@ -162,21 +167,27 @@ struct ArgParser<T> {
   /// Returns an argument with the `name` label of type `U?` where `U`
   /// expressions can be parsed using the `parser` function.
   static func optionalArg<U>(
-    _ name: String?, parser: @escaping (ExprSyntax) throws -> U
+    _ name: String?,
+    parser: @escaping (ExprSyntax) throws -> U
   ) -> ArgParser<U?> {
     .init(
       name: name,
-      parser: { node in try parseOptional(node: node, parser: parser) })
+      parser: { node in try parseOptional(node: node, parser: parser) }
+    )
   }
 
   /// Returns an argument with the `name` label of type `[U]` where `U`
   /// expressions can be parsed using the `parser` function.
-  static func arrayArg<U>(_ name: String?, parser: @escaping (ExprSyntax) throws -> U) -> ArgParser<
+  static func arrayArg<U>(
+    _ name: String?,
+    parser: @escaping (ExprSyntax) throws -> U
+  ) -> ArgParser<
     [U]
   > {
     .init(
       name: name,
-      parser: { node in try parseArray(node: node, parser: parser) })
+      parser: { node in try parseArray(node: node, parser: parser) }
+    )
   }
 
   /// Returns a new argument with the same name but expecting an array of the
@@ -232,7 +243,9 @@ extension LabeledExprListSyntax {
     /// be able to parse the next one. This could not be a closure as it is
     /// generic in the type of the parsed expression `T`.
     func makeArg<T>(
-      _ info: ArgParser<T>, _ elems: inout [LabeledExprSyntax], _ idx: inout Int
+      _ info: ArgParser<T>,
+      _ elems: inout [LabeledExprSyntax],
+      _ idx: inout Int
     ) throws -> T {
       let val = try info.expect(arg: elems[idx])
       idx += 1
@@ -263,26 +276,24 @@ extension NominalTypeInfo: TypeInfoProtocol {
     //       kind: <NominalTypeKind>,
     //       isUnsafe: <Bool>)
 
-    guard let fcall = node.as(FunctionCallExprSyntax.self) else {
-      throw TypeInfoParseError.expectedFunctionCall(got: node)
-    }
-
-    guard fcall.calledExpression.trimmedDescription == "NominalTypeInfo" else {
-      throw TypeInfoParseError.expectedFunctionCallNames(
-        names: ["NominalTypeInfo"], got: node)
-    }
-
-    let parsed = try fcall.arguments.expect(
+    let (name, kind, isUnsafe) = try getNamedFuncallArgs(
+      node: node,
+      name: "NominalTypeInfo"
+    )
+    .expect(
       .stringArg("name"),
       .init(name: "kind", parser: NominalTypeKind.fromSyntax),
-      .boolArg("isUnsafe"))
+      .boolArg("isUnsafe")
+    )
 
-    return Self(name: parsed.0, kind: parsed.1, isUnsafe: parsed.2)
+    return Self(name: name, kind: kind, isUnsafe: isUnsafe)
   }
 
   public var syntax: ExprSyntax {
     """
-    NominalTypeInfo(name: \(stringlit(name)), kind: \(kind.syntax), isUnsafe: \(boollit(isUnsafe)))
+    NominalTypeInfo(name: \(stringlit(name)), 
+                    kind: \(kind.syntax), 
+                    isUnsafe: \(boollit(isUnsafe)))
     """
   }
 }
@@ -302,15 +313,19 @@ extension NominalTypeKind: TypeInfoProtocol {
       return try .structLike(
         fcall.arguments.expect(
           ArgParser(name: nil, parser: StructTypeInfo.fromSyntax)
-        ))
+        )
+      )
     case "enumLike":
       return try .enumLike(
         fcall.arguments.expect(
           ArgParser(name: nil, parser: EnumTypeInfo.fromSyntax)
-        ))
+        )
+      )
     default:
       throw TypeInfoParseError.expectedFunctionCallNames(
-        names: ["structLike", "enumLike"], got: fcall.calledExpression)
+        names: ["structLike", "enumLike"],
+        got: fcall.calledExpression
+      )
     }
   }
 
@@ -328,21 +343,32 @@ extension NominalTypeKind: TypeInfoProtocol {
   }
 }
 
+private func getNamedFuncallArgs(node: ExprSyntax, name: String) throws
+  -> LabeledExprListSyntax
+{
+  guard let fcall = node.as(FunctionCallExprSyntax.self) else {
+    throw TypeInfoParseError.expectedFunctionCall(got: node)
+  }
+  guard fcall.calledExpression.trimmedDescription == name else {
+    throw TypeInfoParseError.expectedFunctionCallNames(
+      names: [name],
+      got: fcall.calledExpression
+    )
+  }
+  return fcall.arguments
+}
+
 extension StructTypeInfo: TypeInfoProtocol {
   public static func fromSyntax(node: ExprSyntax) throws -> Self {
     // Expecting:
     //   StructTypeInfo(properties: <[StoredProperty]>)
 
-    guard let fcall = node.as(FunctionCallExprSyntax.self) else {
-      throw TypeInfoParseError.expectedFunctionCall(got: node)
-    }
-    guard fcall.calledExpression.trimmedDescription == "StructTypeInfo" else {
-      throw TypeInfoParseError.expectedFunctionCallNames(
-        names: ["StructTypeInfo"], got: fcall.calledExpression)
-    }
     return Self(
-      properties: try fcall.arguments.expect(
-        .arrayArg("properties", parser: StoredProperty.fromSyntax)))
+      properties: try getNamedFuncallArgs(node: node, name: "StructTypeInfo")
+        .expect(
+          .arrayArg("properties", parser: StoredProperty.fromSyntax)
+        )
+    )
   }
 
   public var syntax: ExprSyntax {
@@ -356,22 +382,15 @@ extension EnumTypeInfo: TypeInfoProtocol {
   public static func fromSyntax(node: ExprSyntax) throws -> Self {
     // Expecting:
     //   EnumTypeInfo(isObjC: <Bool>, cases: <[EnumCaseInfo]>)
-
-    guard let fcall = node.as(FunctionCallExprSyntax.self) else {
-      throw TypeInfoParseError.expectedFunctionCall(got: node)
-    }
-
-    guard fcall.calledExpression.trimmedDescription == "EnumTypeInfo" else {
-      throw TypeInfoParseError.expectedFunctionCallNames(
-        names: ["EnumTypeInfo"], got: fcall.calledExpression)
-    }
-
-    let parsed = try fcall.arguments.expect(
+    let (isObjC, cases) = try getNamedFuncallArgs(
+      node: node,
+      name: "EnumTypeInfo"
+    )
+    .expect(
       .boolArg("isObjC"),
       .arrayArg("cases", parser: EnumCaseInfo.fromSyntax)
     )
-
-    return Self(isObjC: parsed.0, cases: parsed.1)
+    return Self(isObjC: isObjC, cases: cases)
   }
 
   public var syntax: ExprSyntax {
@@ -390,22 +409,22 @@ extension StoredProperty: TypeInfoProtocol {
     //       isVar: <Bool>,
     //       isStatic: <Bool>)
 
-    guard let fcall = node.as(FunctionCallExprSyntax.self) else {
-      throw TypeInfoParseError.expectedFunctionCall(got: node)
-    }
-
-    guard fcall.calledExpression.trimmedDescription == "StoredProperty" else {
-      throw TypeInfoParseError.expectedFunctionCallNames(
-        names: ["StoredProperty"], got: fcall.calledExpression)
-    }
-
-    let parsed = try fcall.arguments.expect(
+    let (name, typeName, isVar, isStatic) = try getNamedFuncallArgs(
+      node: node,
+      name: "StoredProperty"
+    ).expect(
       .stringArg("name"),
       .stringArg("typeName"),
       .boolArg("isVar"),
-      .boolArg("isStatic"))
+      .boolArg("isStatic")
+    )
 
-    return Self(name: parsed.0, typeName: parsed.1, isVar: parsed.2, isStatic: parsed.3)
+    return Self(
+      name: name,
+      typeName: typeName,
+      isVar: isVar,
+      isStatic: isStatic
+    )
   }
 
   public var syntax: ExprSyntax {
@@ -420,21 +439,15 @@ extension EnumCaseInfo: TypeInfoProtocol {
     // Expecting:
     //   EnumCaseInfo(name: <String>, associatedValueLabels: <[String?]>)
 
-    guard let fcall = node.as(FunctionCallExprSyntax.self) else {
-      throw TypeInfoParseError.expectedFunctionCall(got: node)
-    }
-
-    guard fcall.calledExpression.trimmedDescription == "EnumCaseInfo" else {
-      throw TypeInfoParseError.expectedFunctionCallNames(
-        names: ["EnumCaseInfo"], got: fcall.calledExpression)
-    }
-
-    let parsed = try fcall.arguments.expect(
+    let (name, associatedValueLabels) = try getNamedFuncallArgs(
+      node: node,
+      name: "StoredProperty"
+    ).expect(
       .stringArg("name"),
       .stringArg("associatedValueLabels").toOptional().toArray()
     )
 
-    return Self(name: parsed.0, associatedValueLabels: parsed.1)
+    return Self(name: name, associatedValueLabels: associatedValueLabels)
   }
 
   public var syntax: ExprSyntax {
@@ -448,7 +461,9 @@ extension TypeInfoProtocol {
 
   /// Returns the parsed `Self` from a payloaded string literal containing
   /// Swift syntax.
-  public static func fromStringLit(strlit: StringLiteralExprSyntax) throws -> Self {
+  public static func fromStringLit(strlit: StringLiteralExprSyntax) throws
+    -> Self
+  {
     guard let underlying = strlit.representedLiteralValue else {
       throw TypeInfoParseError.expectedStrLitAsInput(got: ExprSyntax(strlit))
     }
@@ -481,7 +496,8 @@ func arraySyntax<T: TypeInfoProtocol>(_ values: [T]) -> ExprSyntax {
 
 /// Creates an array syntax node, with the element values from the mapping of
 /// `values` by the `toSyntax` function.
-func arraySyntax<T>(_ values: [T], _ toSyntax: (T) -> ExprSyntax) -> ExprSyntax {
+func arraySyntax<T>(_ values: [T], _ toSyntax: (T) -> ExprSyntax) -> ExprSyntax
+{
   ExprSyntax(ArrayExprSyntax(expressions: values.map(toSyntax)))
 }
 
@@ -493,7 +509,8 @@ func optionalSyntax<T: TypeInfoProtocol>(_ value: T?) -> ExprSyntax {
 
 /// Creates a `nil` syntax node if `value` is `nil` and the syntax node
 /// produced by calling `toSyntax` on `value` otherwise.
-func optionalSyntax<T>(_ value: T?, _ toSyntax: (T) -> ExprSyntax) -> ExprSyntax {
+func optionalSyntax<T>(_ value: T?, _ toSyntax: (T) -> ExprSyntax) -> ExprSyntax
+{
   if let value = value {
     toSyntax(value)
   } else {

--- a/lib/Macros/Sources/SwiftMacros/TypeInfoParser.swift
+++ b/lib/Macros/Sources/SwiftMacros/TypeInfoParser.swift
@@ -217,7 +217,6 @@ extension LabeledExprListSyntax {
   func expect<each ArgType>(
     _ infos: repeat ArgInfo<each ArgType>
   ) throws -> (repeat each ArgType) {
-    print("Inside expect")
     // Building the list of arguments syntax
     var lst = self.map { $0 }
     let count = arityOf(repeat each infos)

--- a/lib/Macros/Sources/SwiftMacros/TypeInfoParser.swift
+++ b/lib/Macros/Sources/SwiftMacros/TypeInfoParser.swift
@@ -45,7 +45,7 @@ public struct CaseInfo {
 
   /// For each associated value, we have the label's name and `nil` if there
   /// isn't one
-  var associatedValues: [String?]
+  var associatedValueLabels: [String?]
 }
 
 public struct StructTypeInfo {

--- a/lib/Macros/Sources/SwiftMacros/TypeInfoParser.swift
+++ b/lib/Macros/Sources/SwiftMacros/TypeInfoParser.swift
@@ -327,7 +327,7 @@ extension CaseInfo: TypeInfoSyntax {
   }
 }
 
-public protocol TypeInfoSyntax {
+public protocol TypeInfoSyntax: Equatable {
   static func fromSyntax(node: ExprSyntax) throws -> Self
   var syntax: ExprSyntax { get }
 }

--- a/lib/Macros/Sources/SwiftMacros/TypeInfoParser.swift
+++ b/lib/Macros/Sources/SwiftMacros/TypeInfoParser.swift
@@ -36,11 +36,11 @@ public struct EnumTypeInfo {
   var isObjC: Bool
 
   /// Information on all its cases
-  var cases: [CaseInfo]
+  var cases: [EnumCaseInfo]
 }
 
 /// Represents information on a single case of an enumeration.
-public struct CaseInfo {
+public struct EnumCaseInfo {
   var name: String
 
   /// For each associated value, we have the label's name and `nil` if there
@@ -355,7 +355,7 @@ extension StructTypeInfo: TypeInfoSyntax {
 extension EnumTypeInfo: TypeInfoSyntax {
   public static func fromSyntax(node: ExprSyntax) throws -> Self {
     // Expecting:
-    //   EnumTypeInfo(isObjC: <Bool>, cases: <[CaseInfo]>)
+    //   EnumTypeInfo(isObjC: <Bool>, cases: <[EnumCaseInfo]>)
 
     guard let fcall = node.as(FunctionCallExprSyntax.self) else {
       throw TypeInfoParseError.expectedFunctionCall(got: node)
@@ -368,7 +368,7 @@ extension EnumTypeInfo: TypeInfoSyntax {
 
     let parsed = try fcall.arguments.expect(
       .boolArg("isObjC"),
-      .arrArg("cases", parser: CaseInfo.fromSyntax)
+      .arrArg("cases", parser: EnumCaseInfo.fromSyntax)
     )
 
     return Self(isObjC: parsed.0, cases: parsed.1)
@@ -415,18 +415,18 @@ extension StoredProperty: TypeInfoSyntax {
   }
 }
 
-extension CaseInfo: TypeInfoSyntax {
+extension EnumCaseInfo: TypeInfoSyntax {
   public static func fromSyntax(node: ExprSyntax) throws -> Self {
     // Expecting:
-    //   CaseInfo(name: <String>, associatedValues: <[String?]>)
+    //   EnumCaseInfo(name: <String>, associatedValues: <[String?]>)
 
     guard let fcall = node.as(FunctionCallExprSyntax.self) else {
       throw TypeInfoParseError.expectedFunctionCall(got: node)
     }
 
-    guard fcall.calledExpression.trimmedDescription == "CaseInfo" else {
+    guard fcall.calledExpression.trimmedDescription == "EnumCaseInfo" else {
       throw TypeInfoParseError.expectedFunctionCallNames(
-        names: ["CaseInfo"], got: fcall.calledExpression)
+        names: ["EnumCaseInfo"], got: fcall.calledExpression)
     }
 
     let parsed = try fcall.arguments.expect(
@@ -439,7 +439,7 @@ extension CaseInfo: TypeInfoSyntax {
 
   public var syntax: ExprSyntax {
     """
-    CaseInfo(name: \(stringlit(name)), associatedValues: \(arrSyntax(associatedValues, {optSyntax($0, stringlit)})))
+    EnumCaseInfo(name: \(stringlit(name)), associatedValues: \(arrSyntax(associatedValues, {optSyntax($0, stringlit)})))
     """
   }
 }
@@ -493,7 +493,7 @@ func optSyntax<T: TypeInfoSyntax>(_ value: T?) -> ExprSyntax {
 
 /// Creates a `nil` syntax node if `value` is `nil` and the syntax node
 /// produced by calling `toSyntax` on `value` otherwise.
-func optSyntax<T>(_ value: T?, _ toSyntax: (T) -> ExprSyntax) -> ExprSyntax {
+func optionalSyntax<T>(_ value: T?, _ toSyntax: (T) -> ExprSyntax) -> ExprSyntax {
   if let value = value {
     toSyntax(value)
   } else {

--- a/lib/Macros/Sources/SwiftMacros/TypeInfoParser.swift
+++ b/lib/Macros/Sources/SwiftMacros/TypeInfoParser.swift
@@ -60,17 +60,17 @@ public struct StoredProperty {
   /// Textual representation of the property's type.
   var typeName: String
 
-  /// Wether the property was introduced with `var`
+  /// Whether the property was introduced with `var`
   var isVar: Bool
 
-  /// Wether the property is static
+  /// Whether the property is static
   var isStatic: Bool
 }
 
-/// Error type thrown by the various parsign functions in case of ill-formed
+/// Error type thrown by the various parsing functions in case of ill-formed
 /// input
 public enum TypeInfoParseError: Error {
-  /// Inside a function call, we expected a specific label if `expected is a
+  /// Inside a function call, we expected a specific label if `expected` is a
   /// string or no label if it is `nil` but we got the `got` syntax node
   /// instead.
   case badArgName(expected: String?, got: LabeledExprSyntax)

--- a/lib/Macros/Sources/SwiftMacros/TypeInfoParser.swift
+++ b/lib/Macros/Sources/SwiftMacros/TypeInfoParser.swift
@@ -122,7 +122,7 @@ func parseBool(node: ExprSyntax) throws -> Bool {
 
 /// Parses either `nil` or an expression with the `parser` parsing function.
 /// Throws if `parser` throws
-func parseOpt<T>(node: ExprSyntax, parser: (ExprSyntax) throws -> T) throws -> T? {
+func parseOptional<T>(node: ExprSyntax, parser: (ExprSyntax) throws -> T) throws -> T? {
   // Eagerly checks if it is nil. This means that T?? can never be some(nil)
   // parsed this way as we just expect either nil or a value.
   if node.is(NilLiteralExprSyntax.self) {
@@ -134,7 +134,7 @@ func parseOpt<T>(node: ExprSyntax, parser: (ExprSyntax) throws -> T) throws -> T
 /// Parses an array literal containing elements parsed with the `parse` function
 /// and returns them all. Will throw if it is not an array literal or if one
 /// of the elements throws during parsing.
-func parseArr<T>(node: ExprSyntax, parser: (ExprSyntax) throws -> T) throws -> [T] {
+func parseArray<T>(node: ExprSyntax, parser: (ExprSyntax) throws -> T) throws -> [T] {
   guard let arr = node.as(ArrayExprSyntax.self) else {
     throw TypeInfoParseError.expectedArrayLiteral(got: node)
   }
@@ -161,34 +161,34 @@ struct ArgInfo<T> {
 
   /// Returns an argument with the `name` label of type `U?` where `U`
   /// expressions can be parsed using the `parser` function.
-  static func optArg<U>(
+  static func optionalArg<U>(
     _ name: String?, parser: @escaping (ExprSyntax) throws -> U
   ) -> ArgInfo<U?> {
     .init(
       name: name,
-      parser: { node in try parseOpt(node: node, parser: parser) })
+      parser: { node in try parseOptional(node: node, parser: parser) })
   }
 
   /// Returns an argument with the `name` label of type `[U]` where `U`
   /// expressions can be parsed using the `parser` function.
-  static func arrArg<U>(_ name: String?, parser: @escaping (ExprSyntax) throws -> U) -> ArgInfo<
+  static func arrayArg<U>(_ name: String?, parser: @escaping (ExprSyntax) throws -> U) -> ArgInfo<
     [U]
   > {
     .init(
       name: name,
-      parser: { node in try parseArr(node: node, parser: parser) })
+      parser: { node in try parseArray(node: node, parser: parser) })
   }
 
   /// Returns a new argument with the same name but expecting an array of the
   /// elements expected by `self`. This is meant to be used like a builder.
-  func toArr() -> ArgInfo<[T]> {
-    .arrArg(name, parser: parser)
+  func toArray() -> ArgInfo<[T]> {
+    .arrayArg(name, parser: parser)
   }
 
   /// Returns a new argument with the same name but expecting an optional of the
   /// elements expected by `self`. This is meant to be used like a builder.
-  func toOpt() -> ArgInfo<T?> {
-    .optArg(name, parser: parser)
+  func toOptional() -> ArgInfo<T?> {
+    .optionalArg(name, parser: parser)
   }
 
   /// Returns the parsed argument from `arg` and throws if the name is
@@ -342,7 +342,7 @@ extension StructTypeInfo: TypeInfoSyntax {
     }
     return Self(
       properties: try fcall.arguments.expect(
-        .arrArg("properties", parser: StoredProperty.fromSyntax)))
+        .arrayArg("properties", parser: StoredProperty.fromSyntax)))
   }
 
   public var syntax: ExprSyntax {
@@ -368,7 +368,7 @@ extension EnumTypeInfo: TypeInfoSyntax {
 
     let parsed = try fcall.arguments.expect(
       .boolArg("isObjC"),
-      .arrArg("cases", parser: EnumCaseInfo.fromSyntax)
+      .arrayArg("cases", parser: EnumCaseInfo.fromSyntax)
     )
 
     return Self(isObjC: parsed.0, cases: parsed.1)
@@ -431,7 +431,7 @@ extension EnumCaseInfo: TypeInfoSyntax {
 
     let parsed = try fcall.arguments.expect(
       .stringArg("name"),
-      .stringArg("associatedValues").toOpt().toArr()
+      .stringArg("associatedValues").toOptional().toArray()
     )
 
     return Self(name: parsed.0, associatedValues: parsed.1)

--- a/lib/Macros/Sources/SwiftMacros/TypeInfoParser.swift
+++ b/lib/Macros/Sources/SwiftMacros/TypeInfoParser.swift
@@ -104,46 +104,54 @@ public enum TypeInfoParseError: Error {
   case expectedStrLitAsInput(got: ExprSyntax)
 }
 
-/// Parses a string literal and returns its contents. Throws in case of error.
-func parseString(node: ExprSyntax) throws -> String {
-  guard let res = node.as(StringLiteralExprSyntax.self)?.representedLiteralValue
-  else {
-    throw TypeInfoParseError.expectedStringLiteral(got: node)
-  }
-  return res
-}
+private struct Parser {
 
-/// Parses a bool literal and returns its contents. Throws in case of error.
-func parseBool(node: ExprSyntax) throws -> Bool {
-  guard let lit = node.as(BooleanLiteralExprSyntax.self) else {
-    throw TypeInfoParseError.expectedBoolLiteral(got: node)
+  /// Parses a string literal and returns its contents. Throws in case of error.
+  static func parseString(node: ExprSyntax) throws -> String {
+    guard
+      let res = node.as(StringLiteralExprSyntax.self)?.representedLiteralValue
+    else {
+      throw TypeInfoParseError.expectedStringLiteral(got: node)
+    }
+    return res
   }
-  return lit.trimmedDescription == "true"
-}
 
-/// Parses either `nil` or an expression with the `parser` parsing function.
-/// Throws if `parser` throws
-func parseOptional<T>(node: ExprSyntax, parser: (ExprSyntax) throws -> T) throws
-  -> T?
-{
-  // Eagerly checks if it is nil. This means that T?? can never be some(nil)
-  // parsed this way as we just expect either nil or a value.
-  if node.is(NilLiteralExprSyntax.self) {
-    return nil
+  /// Parses a bool literal and returns its contents. Throws in case of error.
+  static func parseBool(node: ExprSyntax) throws -> Bool {
+    guard let lit = node.as(BooleanLiteralExprSyntax.self) else {
+      throw TypeInfoParseError.expectedBoolLiteral(got: node)
+    }
+    return lit.trimmedDescription == "true"
   }
-  return try parser(node)
-}
 
-/// Parses an array literal containing elements parsed with the `parse` function
-/// and returns them all. Will throw if it is not an array literal or if one
-/// of the elements throws during parsing.
-func parseArray<T>(node: ExprSyntax, parser: (ExprSyntax) throws -> T) throws
-  -> [T]
-{
-  guard let arr = node.as(ArrayExprSyntax.self) else {
-    throw TypeInfoParseError.expectedArrayLiteral(got: node)
+  /// Parses either `nil` or an expression with the `parser` parsing function.
+  /// Throws if `parser` throws
+  static func parseOptional<T>(
+    node: ExprSyntax,
+    parser: (ExprSyntax) throws -> T
+  ) throws
+    -> T?
+  {
+    // Eagerly checks if it is nil. This means that T?? can never be some(nil)
+    // parsed this way as we just expect either nil or a value.
+    if node.is(NilLiteralExprSyntax.self) {
+      return nil
+    }
+    return try parser(node)
   }
-  return try arr.elements.map({ try parser($0.expression) })
+
+  /// Parses an array literal containing elements parsed with the `parse` function
+  /// and returns them all. Will throw if it is not an array literal or if one
+  /// of the elements throws during parsing.
+  static func parseArray<T>(node: ExprSyntax, parser: (ExprSyntax) throws -> T)
+    throws
+    -> [T]
+  {
+    guard let arr = node.as(ArrayExprSyntax.self) else {
+      throw TypeInfoParseError.expectedArrayLiteral(got: node)
+    }
+    return try arr.elements.map({ try parser($0.expression) })
+  }
 }
 
 /// Helper struct to represent an function call argument to be parsed.
@@ -156,12 +164,12 @@ struct ArgParser<T> {
 
   /// Returns a string argument with the `name` label.
   static func stringArg(_ name: String?) -> ArgParser<String> {
-    .init(name: name, parser: parseString)
+    .init(name: name, parser: Parser.parseString)
   }
 
   /// Returns a boolean argument with the `name` label.
   static func boolArg(_ name: String?) -> ArgParser<Bool> {
-    .init(name: name, parser: parseBool)
+    .init(name: name, parser: Parser.parseBool)
   }
 
   /// Returns an argument with the `name` label of type `U?` where `U`
@@ -172,7 +180,7 @@ struct ArgParser<T> {
   ) -> ArgParser<U?> {
     .init(
       name: name,
-      parser: { node in try parseOptional(node: node, parser: parser) }
+      parser: { node in try Parser.parseOptional(node: node, parser: parser) }
     )
   }
 
@@ -186,7 +194,7 @@ struct ArgParser<T> {
   > {
     .init(
       name: name,
-      parser: { node in try parseArray(node: node, parser: parser) }
+      parser: { node in try Parser.parseArray(node: node, parser: parser) }
     )
   }
 

--- a/lib/Macros/Sources/SwiftMacros/TypeInfoParser.swift
+++ b/lib/Macros/Sources/SwiftMacros/TypeInfoParser.swift
@@ -202,6 +202,13 @@ struct ArgInfo<T> {
   }
 }
 
+func arityOf<each T>(_ args: repeat each T) -> Int {
+  var n = 0
+  func increment<U>(_: U) { n += 1 }
+  _ = (repeat increment(each args))
+  return n
+}
+
 extension LabeledExprListSyntax {
 
   /// Given a LabeledExprListSyntax and a variable number of argument infos,
@@ -210,14 +217,10 @@ extension LabeledExprListSyntax {
   func expect<each ArgType>(
     _ infos: repeat ArgInfo<each ArgType>
   ) throws -> (repeat each ArgType) {
+    print("Inside expect")
     // Building the list of arguments syntax
     var lst = self.map { $0 }
-
-    // How many arguments to expect
-    var count = 0
-    for _ in repeat each infos {
-      count += 1
-    }
+    let count = arityOf(repeat each infos)
 
     // Throw if there is a count mismatch, no need to try parsing anything.
     if count != lst.count {

--- a/lib/Macros/Sources/SwiftMacros/TypeInfoParser.swift
+++ b/lib/Macros/Sources/SwiftMacros/TypeInfoParser.swift
@@ -243,13 +243,24 @@ extension LabeledExprListSyntax {
   }
 }
 
+/// Protocol for `NominalTypeInfo` and associated types to conform to.
 public protocol TypeInfoSyntax: Equatable {
+  /// Parses `node` into `Self` and throws if an error occured
   static func fromSyntax(node: ExprSyntax) throws -> Self
+
+  /// Builds a syntax node that can be parsed again to the same value as `self`.
   var syntax: ExprSyntax { get }
 }
 
 extension NominalTypeInfo: TypeInfoSyntax {
+
   public static func fromSyntax(node: ExprSyntax) throws -> Self {
+    // Expecting:
+    //   NominalTypeInfo(
+    //       name: <String>,
+    //       kind: <NominalTypeKind>,
+    //       isUnsafe: <Bool>)
+
     guard let fcall = node.as(FunctionCallExprSyntax.self) else {
       throw TypeInfoParseError.expectedFunctionCall(got: node)
     }
@@ -276,6 +287,11 @@ extension NominalTypeInfo: TypeInfoSyntax {
 
 extension NominalTypeKind: TypeInfoSyntax {
   public static func fromSyntax(node: ExprSyntax) throws -> Self {
+    // Expecting:
+    //   NominalTypeKind(structLike(<StructTypeInfo>))
+    // or
+    //   NominalTypeKind(enumLike(<EnumTypeInfo>))
+
     guard let fcall = node.as(FunctionCallExprSyntax.self) else {
       throw TypeInfoParseError.expectedFunctionCall(got: node)
     }
@@ -312,6 +328,9 @@ extension NominalTypeKind: TypeInfoSyntax {
 
 extension StructTypeInfo: TypeInfoSyntax {
   public static func fromSyntax(node: ExprSyntax) throws -> Self {
+    // Expecting:
+    //   StructTypeInfo(properties: <[StoredProperty]>)
+
     guard let fcall = node.as(FunctionCallExprSyntax.self) else {
       throw TypeInfoParseError.expectedFunctionCall(got: node)
     }
@@ -333,6 +352,9 @@ extension StructTypeInfo: TypeInfoSyntax {
 
 extension EnumTypeInfo: TypeInfoSyntax {
   public static func fromSyntax(node: ExprSyntax) throws -> Self {
+    // Expecting:
+    //   EnumTypeInfo(isObjC: <Bool>, cases: <[CaseInfo]>)
+
     guard let fcall = node.as(FunctionCallExprSyntax.self) else {
       throw TypeInfoParseError.expectedFunctionCall(got: node)
     }
@@ -359,6 +381,13 @@ extension EnumTypeInfo: TypeInfoSyntax {
 
 extension StoredProperty: TypeInfoSyntax {
   public static func fromSyntax(node: ExprSyntax) throws -> Self {
+    // Expecting:
+    //   StoredProperty(
+    //       name: <String>,
+    //       typeName: <String>,
+    //       isVar: <Bool>,
+    //       isStatic: <Bool>)
+
     guard let fcall = node.as(FunctionCallExprSyntax.self) else {
       throw TypeInfoParseError.expectedFunctionCall(got: node)
     }
@@ -387,6 +416,9 @@ extension StoredProperty: TypeInfoSyntax {
 
 extension CaseInfo: TypeInfoSyntax {
   public static func fromSyntax(node: ExprSyntax) throws -> Self {
+    // Expecting:
+    //   CaseInfo(name: <String>, associatedValues: <[String?]>)
+
     guard let fcall = node.as(FunctionCallExprSyntax.self) else {
       throw TypeInfoParseError.expectedFunctionCall(got: node)
     }
@@ -412,6 +444,9 @@ extension CaseInfo: TypeInfoSyntax {
 }
 
 extension TypeInfoSyntax {
+
+  /// Returns the parsed `Self` from a payloaded string literal containing
+  /// Swift syntax.
   public static func fromStringLit(strlit: StringLiteralExprSyntax) throws -> Self {
     guard let underlying = strlit.representedLiteralValue else {
       throw TypeInfoParseError.expectedStrLitAsInput(got: ExprSyntax(strlit))
@@ -427,26 +462,36 @@ extension TypeInfoSyntax {
   }
 }
 
+/// Creates a string literal syntax node with `str` contents.
 func stringlit(_ str: String) -> ExprSyntax {
   ExprSyntax(StringLiteralExprSyntax(content: str))
 }
 
+/// Creates a bool literal syntax node with the value `b`.
 func boollit(_ b: Bool) -> ExprSyntax {
   ExprSyntax(BooleanLiteralExprSyntax(booleanLiteral: b))
 }
 
+/// Creates an array syntax node, with the element values from which we can
+/// derive syntax.
 func arrSyntax<T: TypeInfoSyntax>(_ values: [T]) -> ExprSyntax {
   arrSyntax(values, \.syntax)
 }
 
+/// Creates an array syntax node, with the element values from the mapping of
+/// `values` by the `toSyntax` function.
 func arrSyntax<T>(_ values: [T], _ toSyntax: (T) -> ExprSyntax) -> ExprSyntax {
   ExprSyntax(ArrayExprSyntax(expressions: values.map(toSyntax)))
 }
 
+/// Creates a `nil` syntax node if `value` is `nil` and the derived syntax of
+/// `value` otherwise.
 func optSyntax<T: TypeInfoSyntax>(_ value: T?) -> ExprSyntax {
   optSyntax(value, \.syntax)
 }
 
+/// Creates a `nil` syntax node if `value` is `nil` and the syntax node
+/// produced by calling `toSyntax` on `value` otherwise.
 func optSyntax<T>(_ value: T?, _ toSyntax: (T) -> ExprSyntax) -> ExprSyntax {
   if let value = value {
     toSyntax(value)

--- a/lib/Macros/Sources/SwiftMacros/TypeInfoParser.swift
+++ b/lib/Macros/Sources/SwiftMacros/TypeInfoParser.swift
@@ -13,7 +13,10 @@
 // conformances.                                                              //
 //===----------------------------------------------------------------------===//
 
+import SwiftSyntax
+
 public struct NominalTypeInfo {
+  var name: String
   var kind: NominalTypeKind
   var isUnsafe: Bool
 }
@@ -42,4 +45,260 @@ public struct StoredProperty {
   var typeName: String
   var isVar: Bool
   var isStatic: Bool
+}
+
+public enum TypeInfoParseError: Error {
+  case badArgName(expected: String?, got: LabeledExprSyntax)
+  case argCountMismatch(expected: Int, args: LabeledExprListSyntax)
+  case expectedStringLiteral(got: ExprSyntax)
+  case expectedBoolLiteral(got: ExprSyntax)
+  case expectedArrayLiteral(got: ExprSyntax)
+  case expectedFunctionCall(got: ExprSyntax)
+  case expectedFunctionCallNames(names: [String], got: ExprSyntax)
+
+  case expectedStrLitAsInput(got: ExprSyntax)
+}
+
+func parseString(node: ExprSyntax) throws -> String {
+  guard let res = node.as(StringLiteralExprSyntax.self)?.representedLiteralValue else {
+    throw TypeInfoParseError.expectedStringLiteral(got: node)
+  }
+  return res
+}
+
+func parseBool(node: ExprSyntax) throws -> Bool {
+  guard let lit = node.as(BooleanLiteralExprSyntax.self) else {
+    throw TypeInfoParseError.expectedBoolLiteral(got: node)
+  }
+  return lit.trimmedDescription == "true"
+}
+
+func parseOpt<T>(node: ExprSyntax, parser f: (ExprSyntax) throws -> T) throws -> T? {
+  // Eagerly checks if it is nil. This means that T?? can never be some(nil)
+  // parsed this way as we just expect either nil or a value.
+  if node.is(NilLiteralExprSyntax.self) {
+    return nil
+  }
+  return try f(node)
+}
+
+func parseArr<T>(node: ExprSyntax, parser f: (ExprSyntax) throws -> T) throws -> [T] {
+  guard let arr = node.as(ArrayExprSyntax.self) else {
+    throw TypeInfoParseError.expectedArrayLiteral(got: node)
+  }
+  return try arr.elements.map({ try f($0.expression) })
+}
+
+struct ArgInfo<T> {
+  var name: String?
+  var parser: (ExprSyntax) throws -> T
+
+  static func stringArg(_ name: String?) -> ArgInfo<String> {
+    .init(name: name, parser: parseString)
+  }
+
+  static func boolArg(_ name: String?) -> ArgInfo<Bool> {
+    .init(name: name, parser: parseBool)
+  }
+
+  static func optArg<U>(
+    _ name: String?, parser: @escaping (ExprSyntax) throws -> U
+  ) -> ArgInfo<U?> {
+    .init(
+      name: name,
+      parser: { node in try parseOpt(node: node, parser: parser) })
+  }
+
+  static func arrArg<U>(_ name: String?, parser: @escaping (ExprSyntax) throws -> U) -> ArgInfo<
+    [U]
+  > {
+    .init(
+      name: name,
+      parser: { node in try parseArr(node: node, parser: parser) })
+  }
+
+  func toArr() -> ArgInfo<[T]> {
+    .arrArg(name, parser: parser)
+  }
+
+  func toOpt() -> ArgInfo<T?> {
+    .optArg(name, parser: parser)
+  }
+
+  func expect(arg: LabeledExprSyntax) throws -> T {
+    let lbl = arg.label?.text
+    if lbl != name {
+      throw TypeInfoParseError.badArgName(expected: name, got: arg)
+    }
+    return try parser(arg.expression)
+  }
+}
+
+extension LabeledExprListSyntax {
+  func expect<each ArgType>(
+    _ infos: repeat ArgInfo<each ArgType>
+  ) throws -> (repeat each ArgType) {
+    var lst = self.map { $0 }
+
+    var count = 0
+    for _ in repeat each infos {
+      count += 1
+    }
+
+    if count != lst.count {
+      throw TypeInfoParseError.argCountMismatch(expected: count, args: self)
+    }
+
+    var idx = 0
+
+    func makeArg<T>(
+      _ info: ArgInfo<T>, _ elems: inout [LabeledExprSyntax], _ idx: inout Int
+    ) throws -> T {
+      let val = try info.expect(arg: elems[idx])
+      idx += 1
+      return val
+    }
+
+    return (repeat try makeArg(each infos, &lst, &idx))
+  }
+}
+
+extension NominalTypeInfo: FromSyntax {
+  public static func fromSyntax(node: ExprSyntax) throws -> Self {
+    guard let fcall = node.as(FunctionCallExprSyntax.self) else {
+      throw TypeInfoParseError.expectedFunctionCall(got: node)
+    }
+
+    guard fcall.calledExpression.trimmedDescription == "NominalTypeInfo" else {
+      throw TypeInfoParseError.expectedFunctionCallNames(
+        names: ["NominalTypeInfo"], got: node)
+    }
+
+    let parsed = try fcall.arguments.expect(
+      .stringArg("name"),
+      .init(name: "kind", parser: NominalTypeKind.fromSyntax),
+      .boolArg("isUnsafe"))
+
+    return Self(name: parsed.0, kind: parsed.1, isUnsafe: parsed.2)
+  }
+}
+
+extension NominalTypeKind: FromSyntax {
+  public static func fromSyntax(node: ExprSyntax) throws -> Self {
+    guard let fcall = node.as(FunctionCallExprSyntax.self) else {
+      throw TypeInfoParseError.expectedFunctionCall(got: node)
+    }
+    switch fcall.calledExpression.trimmedDescription {
+    case "structLike":
+      return try .structLike(
+        fcall.arguments.expect(
+          ArgInfo(name: nil, parser: StructTypeInfo.fromSyntax)
+        ))
+    case "enumLike":
+      return try .enumLike(
+        fcall.arguments.expect(
+          ArgInfo(name: nil, parser: EnumTypeInfo.fromSyntax)
+        ))
+    default:
+      throw TypeInfoParseError.expectedFunctionCallNames(
+        names: ["structLike", "enumLike"], got: fcall.calledExpression)
+    }
+  }
+}
+
+extension StructTypeInfo: FromSyntax {
+  public static func fromSyntax(node: ExprSyntax) throws -> Self {
+    guard let fcall = node.as(FunctionCallExprSyntax.self) else {
+      throw TypeInfoParseError.expectedFunctionCall(got: node)
+    }
+    guard fcall.calledExpression.trimmedDescription == "StructTypeInfo" else {
+      throw TypeInfoParseError.expectedFunctionCallNames(
+        names: ["StructTypeInfo"], got: fcall.calledExpression)
+    }
+    return Self(
+      properties: try fcall.arguments.expect(
+        .arrArg("properties", parser: StoredProperty.fromSyntax)))
+  }
+}
+
+extension EnumTypeInfo: FromSyntax {
+  public static func fromSyntax(node: ExprSyntax) throws -> Self {
+    guard let fcall = node.as(FunctionCallExprSyntax.self) else {
+      throw TypeInfoParseError.expectedFunctionCall(got: node)
+    }
+
+    guard fcall.calledExpression.trimmedDescription == "EnumTypeInfo" else {
+      throw TypeInfoParseError.expectedFunctionCallNames(
+        names: ["EnumTypeInfo"], got: fcall.calledExpression)
+    }
+
+    let parsed = try fcall.arguments.expect(
+      .boolArg("isObjC"),
+      .arrArg("cases", parser: CaseInfo.fromSyntax)
+    )
+
+    return Self(isObjC: parsed.0, cases: parsed.1)
+  }
+}
+
+extension StoredProperty: FromSyntax {
+  public static func fromSyntax(node: ExprSyntax) throws -> Self {
+    guard let fcall = node.as(FunctionCallExprSyntax.self) else {
+      throw TypeInfoParseError.expectedFunctionCall(got: node)
+    }
+
+    guard fcall.calledExpression.trimmedDescription == "StoredProperty" else {
+      throw TypeInfoParseError.expectedFunctionCallNames(
+        names: ["StoredProperty"], got: fcall.calledExpression)
+    }
+
+    let parsed = try fcall.arguments.expect(
+      .stringArg("name"),
+      .stringArg("typeName"),
+      .boolArg("isVar"),
+      .boolArg("isStatic"),
+    )
+
+    return Self(name: parsed.0, typeName: parsed.1, isVar: parsed.2, isStatic: parsed.3)
+  }
+}
+
+extension CaseInfo: FromSyntax {
+  public static func fromSyntax(node: ExprSyntax) throws -> Self {
+    guard let fcall = node.as(FunctionCallExprSyntax.self) else {
+      throw TypeInfoParseError.expectedFunctionCall(got: node)
+    }
+
+    guard fcall.calledExpression.trimmedDescription == "CaseInfo" else {
+      throw TypeInfoParseError.expectedFunctionCallNames(
+        names: ["CaseInfo"], got: fcall.calledExpression)
+    }
+
+    let parsed = try fcall.arguments.expect(
+      .stringArg("name"),
+      .stringArg("associatedValues").toOpt().toArr()
+    )
+
+    return Self(name: parsed.0, associatedValues: parsed.1)
+  }
+}
+
+public protocol FromSyntax {
+  static func fromSyntax(node: ExprSyntax) throws -> Self
+}
+
+extension FromSyntax {
+  public static func fromStringLit(strlit: StringLiteralExprSyntax) throws -> Self {
+    guard let underlying = strlit.representedLiteralValue else {
+      throw TypeInfoParseError.expectedStrLitAsInput(got: ExprSyntax(strlit))
+    }
+    return try fromSyntax(node: "\(raw: underlying)")
+  }
+
+  public static func fromStringLit(expr: ExprSyntax) throws -> Self {
+    guard let strlit = expr.as(StringLiteralExprSyntax.self) else {
+      throw TypeInfoParseError.expectedStrLitAsInput(got: expr)
+    }
+    return try fromStringLit(strlit: strlit)
+  }
 }

--- a/lib/Macros/Sources/SwiftMacros/TypeInfoParser.swift
+++ b/lib/Macros/Sources/SwiftMacros/TypeInfoParser.swift
@@ -142,7 +142,7 @@ func parseArray<T>(node: ExprSyntax, parser: (ExprSyntax) throws -> T) throws ->
 }
 
 /// Helper struct to represent an function call argument to be parsed.
-struct ArgInfo<T> {
+struct ArgParser<T> {
   /// The label of the argument, `nil` if there is none.
   var name: String?
 
@@ -150,12 +150,12 @@ struct ArgInfo<T> {
   var parser: (ExprSyntax) throws -> T
 
   /// Returns a string argument with the `name` label.
-  static func stringArg(_ name: String?) -> ArgInfo<String> {
+  static func stringArg(_ name: String?) -> ArgParser<String> {
     .init(name: name, parser: parseString)
   }
 
   /// Returns a boolean argument with the `name` label.
-  static func boolArg(_ name: String?) -> ArgInfo<Bool> {
+  static func boolArg(_ name: String?) -> ArgParser<Bool> {
     .init(name: name, parser: parseBool)
   }
 
@@ -163,7 +163,7 @@ struct ArgInfo<T> {
   /// expressions can be parsed using the `parser` function.
   static func optionalArg<U>(
     _ name: String?, parser: @escaping (ExprSyntax) throws -> U
-  ) -> ArgInfo<U?> {
+  ) -> ArgParser<U?> {
     .init(
       name: name,
       parser: { node in try parseOptional(node: node, parser: parser) })
@@ -171,7 +171,7 @@ struct ArgInfo<T> {
 
   /// Returns an argument with the `name` label of type `[U]` where `U`
   /// expressions can be parsed using the `parser` function.
-  static func arrayArg<U>(_ name: String?, parser: @escaping (ExprSyntax) throws -> U) -> ArgInfo<
+  static func arrayArg<U>(_ name: String?, parser: @escaping (ExprSyntax) throws -> U) -> ArgParser<
     [U]
   > {
     .init(
@@ -181,13 +181,13 @@ struct ArgInfo<T> {
 
   /// Returns a new argument with the same name but expecting an array of the
   /// elements expected by `self`. This is meant to be used like a builder.
-  func toArray() -> ArgInfo<[T]> {
+  func toArray() -> ArgParser<[T]> {
     .arrayArg(name, parser: parser)
   }
 
   /// Returns a new argument with the same name but expecting an optional of the
   /// elements expected by `self`. This is meant to be used like a builder.
-  func toOptional() -> ArgInfo<T?> {
+  func toOptional() -> ArgParser<T?> {
     .optionalArg(name, parser: parser)
   }
 
@@ -215,7 +215,7 @@ extension LabeledExprListSyntax {
   /// try to parse the argument list as expected by the infos. Throws if one
   /// of the arguments fails to parse.
   func expect<each ArgType>(
-    _ infos: repeat ArgInfo<each ArgType>
+    _ infos: repeat ArgParser<each ArgType>
   ) throws -> (repeat each ArgType) {
     // Building the list of arguments syntax
     var lst = self.map { $0 }
@@ -232,7 +232,7 @@ extension LabeledExprListSyntax {
     /// be able to parse the next one. This could not be a closure as it is
     /// generic in the type of the parsed expression `T`.
     func makeArg<T>(
-      _ info: ArgInfo<T>, _ elems: inout [LabeledExprSyntax], _ idx: inout Int
+      _ info: ArgParser<T>, _ elems: inout [LabeledExprSyntax], _ idx: inout Int
     ) throws -> T {
       let val = try info.expect(arg: elems[idx])
       idx += 1
@@ -246,7 +246,7 @@ extension LabeledExprListSyntax {
 }
 
 /// Protocol for `NominalTypeInfo` and associated types to conform to.
-public protocol TypeInfoSyntax: Equatable {
+public protocol TypeInfoProtocol: Equatable {
   /// Parses `node` into `Self` and throws if an error occured
   static func fromSyntax(node: ExprSyntax) throws -> Self
 
@@ -254,7 +254,7 @@ public protocol TypeInfoSyntax: Equatable {
   var syntax: ExprSyntax { get }
 }
 
-extension NominalTypeInfo: TypeInfoSyntax {
+extension NominalTypeInfo: TypeInfoProtocol {
 
   public static func fromSyntax(node: ExprSyntax) throws -> Self {
     // Expecting:
@@ -287,7 +287,7 @@ extension NominalTypeInfo: TypeInfoSyntax {
   }
 }
 
-extension NominalTypeKind: TypeInfoSyntax {
+extension NominalTypeKind: TypeInfoProtocol {
   public static func fromSyntax(node: ExprSyntax) throws -> Self {
     // Expecting:
     //   NominalTypeKind(structLike(<StructTypeInfo>))
@@ -301,12 +301,12 @@ extension NominalTypeKind: TypeInfoSyntax {
     case "structLike":
       return try .structLike(
         fcall.arguments.expect(
-          ArgInfo(name: nil, parser: StructTypeInfo.fromSyntax)
+          ArgParser(name: nil, parser: StructTypeInfo.fromSyntax)
         ))
     case "enumLike":
       return try .enumLike(
         fcall.arguments.expect(
-          ArgInfo(name: nil, parser: EnumTypeInfo.fromSyntax)
+          ArgParser(name: nil, parser: EnumTypeInfo.fromSyntax)
         ))
     default:
       throw TypeInfoParseError.expectedFunctionCallNames(
@@ -328,7 +328,7 @@ extension NominalTypeKind: TypeInfoSyntax {
   }
 }
 
-extension StructTypeInfo: TypeInfoSyntax {
+extension StructTypeInfo: TypeInfoProtocol {
   public static func fromSyntax(node: ExprSyntax) throws -> Self {
     // Expecting:
     //   StructTypeInfo(properties: <[StoredProperty]>)
@@ -347,12 +347,12 @@ extension StructTypeInfo: TypeInfoSyntax {
 
   public var syntax: ExprSyntax {
     """
-    StructTypeInfo(properties: \(arrSyntax(properties)))
+    StructTypeInfo(properties: \(arraySyntax(properties)))
     """
   }
 }
 
-extension EnumTypeInfo: TypeInfoSyntax {
+extension EnumTypeInfo: TypeInfoProtocol {
   public static func fromSyntax(node: ExprSyntax) throws -> Self {
     // Expecting:
     //   EnumTypeInfo(isObjC: <Bool>, cases: <[EnumCaseInfo]>)
@@ -376,12 +376,12 @@ extension EnumTypeInfo: TypeInfoSyntax {
 
   public var syntax: ExprSyntax {
     """
-    EnumTypeInfo(isObjC: \(boollit(isObjC)), cases: \(arrSyntax(cases)))
+    EnumTypeInfo(isObjC: \(boollit(isObjC)), cases: \(arraySyntax(cases)))
     """
   }
 }
 
-extension StoredProperty: TypeInfoSyntax {
+extension StoredProperty: TypeInfoProtocol {
   public static func fromSyntax(node: ExprSyntax) throws -> Self {
     // Expecting:
     //   StoredProperty(
@@ -415,10 +415,10 @@ extension StoredProperty: TypeInfoSyntax {
   }
 }
 
-extension EnumCaseInfo: TypeInfoSyntax {
+extension EnumCaseInfo: TypeInfoProtocol {
   public static func fromSyntax(node: ExprSyntax) throws -> Self {
     // Expecting:
-    //   EnumCaseInfo(name: <String>, associatedValues: <[String?]>)
+    //   EnumCaseInfo(name: <String>, associatedValueLabels: <[String?]>)
 
     guard let fcall = node.as(FunctionCallExprSyntax.self) else {
       throw TypeInfoParseError.expectedFunctionCall(got: node)
@@ -431,20 +431,20 @@ extension EnumCaseInfo: TypeInfoSyntax {
 
     let parsed = try fcall.arguments.expect(
       .stringArg("name"),
-      .stringArg("associatedValues").toOptional().toArray()
+      .stringArg("associatedValueLabels").toOptional().toArray()
     )
 
-    return Self(name: parsed.0, associatedValues: parsed.1)
+    return Self(name: parsed.0, associatedValueLabels: parsed.1)
   }
 
   public var syntax: ExprSyntax {
     """
-    EnumCaseInfo(name: \(stringlit(name)), associatedValues: \(arrSyntax(associatedValues, {optSyntax($0, stringlit)})))
+    EnumCaseInfo(name: \(stringlit(name)), associatedValueLabels: \(arraySyntax(associatedValueLabels, {optionalSyntax($0, stringlit)})))
     """
   }
 }
 
-extension TypeInfoSyntax {
+extension TypeInfoProtocol {
 
   /// Returns the parsed `Self` from a payloaded string literal containing
   /// Swift syntax.
@@ -475,20 +475,20 @@ func boollit(_ b: Bool) -> ExprSyntax {
 
 /// Creates an array syntax node, with the element values from which we can
 /// derive syntax.
-func arrSyntax<T: TypeInfoSyntax>(_ values: [T]) -> ExprSyntax {
-  arrSyntax(values, \.syntax)
+func arraySyntax<T: TypeInfoProtocol>(_ values: [T]) -> ExprSyntax {
+  arraySyntax(values, \.syntax)
 }
 
 /// Creates an array syntax node, with the element values from the mapping of
 /// `values` by the `toSyntax` function.
-func arrSyntax<T>(_ values: [T], _ toSyntax: (T) -> ExprSyntax) -> ExprSyntax {
+func arraySyntax<T>(_ values: [T], _ toSyntax: (T) -> ExprSyntax) -> ExprSyntax {
   ExprSyntax(ArrayExprSyntax(expressions: values.map(toSyntax)))
 }
 
 /// Creates a `nil` syntax node if `value` is `nil` and the derived syntax of
 /// `value` otherwise.
-func optSyntax<T: TypeInfoSyntax>(_ value: T?) -> ExprSyntax {
-  optSyntax(value, \.syntax)
+func optionalSyntax<T: TypeInfoProtocol>(_ value: T?) -> ExprSyntax {
+  optionalSyntax(value, \.syntax)
 }
 
 /// Creates a `nil` syntax node if `value` is `nil` and the syntax node

--- a/lib/Macros/Sources/SwiftMacros/TypeInfoParser.swift
+++ b/lib/Macros/Sources/SwiftMacros/TypeInfoParser.swift
@@ -240,7 +240,7 @@ extension LabeledExprListSyntax {
     }
     return (
       try a.expect(arg: lst[0]),
-      try b.expect(arg: lst[1]),
+      try b.expect(arg: lst[1])
     )
   }
 
@@ -255,7 +255,7 @@ extension LabeledExprListSyntax {
     return (
       try a.expect(arg: lst[0]),
       try b.expect(arg: lst[1]),
-      try c.expect(arg: lst[2]),
+      try c.expect(arg: lst[2])
     )
   }
 
@@ -271,7 +271,7 @@ extension LabeledExprListSyntax {
       try a.expect(arg: lst[0]),
       try b.expect(arg: lst[1]),
       try c.expect(arg: lst[2]),
-      try d.expect(arg: lst[3]),
+      try d.expect(arg: lst[3])
     )
   }
 }

--- a/lib/Macros/Sources/SwiftMacros/TypeInfoParser.swift
+++ b/lib/Macros/Sources/SwiftMacros/TypeInfoParser.swift
@@ -221,48 +221,58 @@ struct ArgParser<T> {
   }
 }
 
-func arityOf<each T>(_ args: repeat each T) -> Int {
-  var n = 0
-  func increment<U>(_: U) { n += 1 }
-  _ = (repeat increment(each args))
-  return n
-}
-
 extension LabeledExprListSyntax {
 
-  /// Given a LabeledExprListSyntax and a variable number of argument infos,
-  /// try to parse the argument list as expected by the infos. Throws if one
-  /// of the arguments fails to parse.
-  func expect<each ArgType>(
-    _ infos: repeat ArgParser<each ArgType>
-  ) throws -> (repeat each ArgType) {
-    // Building the list of arguments syntax
-    var lst = self.map { $0 }
-    let count = arityOf(repeat each infos)
-
-    // Throw if there is a count mismatch, no need to try parsing anything.
-    if count != lst.count {
-      throw TypeInfoParseError.argCountMismatch(expected: count, args: self)
+  /// Parses one labelled argument from the argument list.
+  func expect<A>(_ a: ArgParser<A>) throws -> A {
+    let lst = Array(self)
+    guard lst.count == 1 else {
+      throw TypeInfoParseError.argCountMismatch(expected: 1, args: self)
     }
+    return try a.expect(arg: lst[0])
+  }
 
-    var idx = 0
-
-    /// Helper function to parse a single argument and increment the count to
-    /// be able to parse the next one. This could not be a closure as it is
-    /// generic in the type of the parsed expression `T`.
-    func makeArg<T>(
-      _ info: ArgParser<T>,
-      _ elems: inout [LabeledExprSyntax],
-      _ idx: inout Int
-    ) throws -> T {
-      let val = try info.expect(arg: elems[idx])
-      idx += 1
-      return val
+  /// Parses two labelled arguments from the argument list.
+  func expect<A, B>(_ a: ArgParser<A>, _ b: ArgParser<B>) throws -> (A, B) {
+    let lst = Array(self)
+    guard lst.count == 2 else {
+      throw TypeInfoParseError.argCountMismatch(expected: 2, args: self)
     }
+    return (
+      try a.expect(arg: lst[0]),
+      try b.expect(arg: lst[1]),
+    )
+  }
 
-    // For each argument, try and parse it. If all goes well a tuple containing
-    // all args is returned.
-    return (repeat try makeArg(each infos, &lst, &idx))
+  /// Parses three labelled arguments from the argument list.
+  func expect<A, B, C>(
+    _ a: ArgParser<A>, _ b: ArgParser<B>, _ c: ArgParser<C>
+  ) throws -> (A, B, C) {
+    let lst = Array(self)
+    guard lst.count == 3 else {
+      throw TypeInfoParseError.argCountMismatch(expected: 3, args: self)
+    }
+    return (
+      try a.expect(arg: lst[0]),
+      try b.expect(arg: lst[1]),
+      try c.expect(arg: lst[2]),
+    )
+  }
+
+  /// Parses four labelled arguments from the argument list.
+  func expect<A, B, C, D>(
+    _ a: ArgParser<A>, _ b: ArgParser<B>, _ c: ArgParser<C>, _ d: ArgParser<D>
+  ) throws -> (A, B, C, D) {
+    let lst = Array(self)
+    guard lst.count == 4 else {
+      throw TypeInfoParseError.argCountMismatch(expected: 4, args: self)
+    }
+    return (
+      try a.expect(arg: lst[0]),
+      try b.expect(arg: lst[1]),
+      try c.expect(arg: lst[2]),
+      try d.expect(arg: lst[3]),
+    )
   }
 }
 

--- a/lib/Macros/Sources/SwiftMacros/TypeInfoParser.swift
+++ b/lib/Macros/Sources/SwiftMacros/TypeInfoParser.swift
@@ -401,8 +401,7 @@ extension StoredProperty: TypeInfoSyntax {
       .stringArg("name"),
       .stringArg("typeName"),
       .boolArg("isVar"),
-      .boolArg("isStatic"),
-    )
+      .boolArg("isStatic"))
 
     return Self(name: parsed.0, typeName: parsed.1, isVar: parsed.2, isStatic: parsed.3)
   }

--- a/lib/Macros/Sources/SwiftMacros/TypeInfoParser.swift
+++ b/lib/Macros/Sources/SwiftMacros/TypeInfoParser.swift
@@ -469,20 +469,14 @@ extension TypeInfoProtocol {
 
   /// Returns the parsed `Self` from a payloaded string literal containing
   /// Swift syntax.
-  public static func fromStringLit(strlit: StringLiteralExprSyntax) throws
-    -> Self
-  {
-    guard let underlying = strlit.representedLiteralValue else {
-      throw TypeInfoParseError.expectedStrLitAsInput(got: ExprSyntax(strlit))
-    }
-    return try fromSyntax(node: "\(raw: underlying)")
-  }
-
   public static func fromStringLit(expr: ExprSyntax) throws -> Self {
-    guard let strlit = expr.as(StringLiteralExprSyntax.self) else {
+    guard
+      let underlying = expr.as(StringLiteralExprSyntax.self)?
+        .representedLiteralValue
+    else {
       throw TypeInfoParseError.expectedStrLitAsInput(got: expr)
     }
-    return try fromStringLit(strlit: strlit)
+    return try fromSyntax(node: "\(raw: underlying)")
   }
 }
 

--- a/lib/Macros/Sources/SwiftMacros/TypeInfoParser.swift
+++ b/lib/Macros/Sources/SwiftMacros/TypeInfoParser.swift
@@ -10,56 +10,101 @@
 //
 //===----------------------------------------------------------------------===//
 // Utilities to handle type information passed as arguments to macros         //
-// conformances.                                                              //
+// deriving conformances.                                                     //
 //===----------------------------------------------------------------------===//
 
 import SwiftSyntax
 import SwiftSyntaxBuilder
 
+/// Represents information on a type for which a macro derives a conformance
+/// to a protocol.
 public struct NominalTypeInfo {
   var name: String
   var kind: NominalTypeKind
   var isUnsafe: Bool
 }
 
+/// Represents the kind of nominal type this is, for the moment only structs
+/// and enums are supported.
 public enum NominalTypeKind {
   case enumLike(EnumTypeInfo)
   case structLike(StructTypeInfo)
 }
 
 public struct EnumTypeInfo {
+  /// Does this enum have the `@objc` attribute ?
   var isObjC: Bool
+
+  /// Information on all its cases
   var cases: [CaseInfo]
 }
 
+/// Represents information on a single case of an enumeration.
 public struct CaseInfo {
   var name: String
+
+  /// For each associated value, we have the label's name and `nil` if there
+  /// isn't one
   var associatedValues: [String?]
 }
 
 public struct StructTypeInfo {
+  /// Information on all the struct's properties
   var properties: [StoredProperty]
 }
 
 public struct StoredProperty {
+  /// name of the stored property
   var name: String
+
+  /// Textual representation of the property's type.
   var typeName: String
+
+  /// Wether the property was introduced with `var`
   var isVar: Bool
+
+  /// Wether the property is static
   var isStatic: Bool
 }
 
+/// Error type thrown by the various parsign functions in case of ill-formed
+/// input
 public enum TypeInfoParseError: Error {
+  /// Inside a function call, we expected a specific label if `expected is a
+  /// string or no label if it is `nil` but we got the `got` syntax node
+  /// instead.
   case badArgName(expected: String?, got: LabeledExprSyntax)
+
+  /// Inside a function call, we expected `expected` arguments but got the ones
+  /// in the `args` syntax node.
   case argCountMismatch(expected: Int, args: LabeledExprListSyntax)
+
+  /// We were expecting to parse a string literal but found the `got` syntax
+  /// node instead.
   case expectedStringLiteral(got: ExprSyntax)
+
+  /// We were expecting to parse a boolean literal but found the `got` syntax
+  /// node instead.
   case expectedBoolLiteral(got: ExprSyntax)
+
+  /// We were expecting to parse an array literal but found the `got` syntax
+  /// node instead.
   case expectedArrayLiteral(got: ExprSyntax)
+
+  /// We were expecting to parse a function call expression but found the `got`
+  /// syntax node instead.
   case expectedFunctionCall(got: ExprSyntax)
+
+  /// We expected a function call which caller's name was in `names` but found
+  /// the `got` syntax node instead.
   case expectedFunctionCallNames(names: [String], got: ExprSyntax)
 
+  /// We expected a string literal carrying Swift syntax as payload but found
+  /// the `got` syntax node instead.
   case expectedStrLitAsInput(got: ExprSyntax)
 }
 
+/// Parses a string literal and returns its contents. Throws in case of error.
 func parseString(node: ExprSyntax) throws -> String {
   guard let res = node.as(StringLiteralExprSyntax.self)?.representedLiteralValue else {
     throw TypeInfoParseError.expectedStringLiteral(got: node)
@@ -67,6 +112,7 @@ func parseString(node: ExprSyntax) throws -> String {
   return res
 }
 
+/// Parses a bool literal and returns its contents. Throws in case of error.
 func parseBool(node: ExprSyntax) throws -> Bool {
   guard let lit = node.as(BooleanLiteralExprSyntax.self) else {
     throw TypeInfoParseError.expectedBoolLiteral(got: node)
@@ -74,34 +120,47 @@ func parseBool(node: ExprSyntax) throws -> Bool {
   return lit.trimmedDescription == "true"
 }
 
-func parseOpt<T>(node: ExprSyntax, parser f: (ExprSyntax) throws -> T) throws -> T? {
+/// Parses either `nil` or an expression with the `parser` parsing function.
+/// Throws if `parser` throws
+func parseOpt<T>(node: ExprSyntax, parser: (ExprSyntax) throws -> T) throws -> T? {
   // Eagerly checks if it is nil. This means that T?? can never be some(nil)
   // parsed this way as we just expect either nil or a value.
   if node.is(NilLiteralExprSyntax.self) {
     return nil
   }
-  return try f(node)
+  return try parser(node)
 }
 
-func parseArr<T>(node: ExprSyntax, parser f: (ExprSyntax) throws -> T) throws -> [T] {
+/// Parses an array literal containing elements parsed with the `parse` function
+/// and returns them all. Will throw if it is not an array literal or if one
+/// of the elements throws during parsing.
+func parseArr<T>(node: ExprSyntax, parser: (ExprSyntax) throws -> T) throws -> [T] {
   guard let arr = node.as(ArrayExprSyntax.self) else {
     throw TypeInfoParseError.expectedArrayLiteral(got: node)
   }
-  return try arr.elements.map({ try f($0.expression) })
+  return try arr.elements.map({ try parser($0.expression) })
 }
 
+/// Helper struct to represent an function call argument to be parsed.
 struct ArgInfo<T> {
+  /// The label of the argument, `nil` if there is none.
   var name: String?
+
+  /// The parsing function
   var parser: (ExprSyntax) throws -> T
 
+  /// Returns a string argument with the `name` label.
   static func stringArg(_ name: String?) -> ArgInfo<String> {
     .init(name: name, parser: parseString)
   }
 
+  /// Returns a boolean argument with the `name` label.
   static func boolArg(_ name: String?) -> ArgInfo<Bool> {
     .init(name: name, parser: parseBool)
   }
 
+  /// Returns an argument with the `name` label of type `U?` where `U`
+  /// expressions can be parsed using the `parser` function.
   static func optArg<U>(
     _ name: String?, parser: @escaping (ExprSyntax) throws -> U
   ) -> ArgInfo<U?> {
@@ -110,6 +169,8 @@ struct ArgInfo<T> {
       parser: { node in try parseOpt(node: node, parser: parser) })
   }
 
+  /// Returns an argument with the `name` label of type `[U]` where `U`
+  /// expressions can be parsed using the `parser` function.
   static func arrArg<U>(_ name: String?, parser: @escaping (ExprSyntax) throws -> U) -> ArgInfo<
     [U]
   > {
@@ -118,14 +179,20 @@ struct ArgInfo<T> {
       parser: { node in try parseArr(node: node, parser: parser) })
   }
 
+  /// Returns a new argument with the same name but expecting an array of the
+  /// elements expected by `self`. This is meant to be used like a builder.
   func toArr() -> ArgInfo<[T]> {
     .arrArg(name, parser: parser)
   }
 
+  /// Returns a new argument with the same name but expecting an optional of the
+  /// elements expected by `self`. This is meant to be used like a builder.
   func toOpt() -> ArgInfo<T?> {
     .optArg(name, parser: parser)
   }
 
+  /// Returns the parsed argument from `arg` and throws if the name is
+  /// mismatched or if the parsing function fails.
   func expect(arg: LabeledExprSyntax) throws -> T {
     let lbl = arg.label?.text
     if lbl != name {
@@ -136,22 +203,32 @@ struct ArgInfo<T> {
 }
 
 extension LabeledExprListSyntax {
+
+  /// Given a LabeledExprListSyntax and a variable number of argument infos,
+  /// try to parse the argument list as expected by the infos. Throws if one
+  /// of the arguments fails to parse.
   func expect<each ArgType>(
     _ infos: repeat ArgInfo<each ArgType>
   ) throws -> (repeat each ArgType) {
+    // Building the list of arguments syntax
     var lst = self.map { $0 }
 
+    // How many arguments to expect
     var count = 0
     for _ in repeat each infos {
       count += 1
     }
 
+    // Throw if there is a count mismatch, no need to try parsing anything.
     if count != lst.count {
       throw TypeInfoParseError.argCountMismatch(expected: count, args: self)
     }
 
     var idx = 0
 
+    /// Helper function to parse a single argument and increment the count to
+    /// be able to parse the next one. This could not be a closure as it is
+    /// generic in the type of the parsed expression `T`.
     func makeArg<T>(
       _ info: ArgInfo<T>, _ elems: inout [LabeledExprSyntax], _ idx: inout Int
     ) throws -> T {
@@ -160,8 +237,15 @@ extension LabeledExprListSyntax {
       return val
     }
 
+    // For each argument, try and parse it. If all goes well a tuple containing
+    // all args is returned.
     return (repeat try makeArg(each infos, &lst, &idx))
   }
+}
+
+public protocol TypeInfoSyntax: Equatable {
+  static func fromSyntax(node: ExprSyntax) throws -> Self
+  var syntax: ExprSyntax { get }
 }
 
 extension NominalTypeInfo: TypeInfoSyntax {
@@ -325,11 +409,6 @@ extension CaseInfo: TypeInfoSyntax {
     CaseInfo(name: \(stringlit(name)), associatedValues: \(arrSyntax(associatedValues, {optSyntax($0, stringlit)})))
     """
   }
-}
-
-public protocol TypeInfoSyntax: Equatable {
-  static func fromSyntax(node: ExprSyntax) throws -> Self
-  var syntax: ExprSyntax { get }
 }
 
 extension TypeInfoSyntax {

--- a/lib/Macros/Sources/SwiftMacros/TypeInfoParser.swift
+++ b/lib/Macros/Sources/SwiftMacros/TypeInfoParser.swift
@@ -322,7 +322,7 @@ extension CaseInfo: TypeInfoSyntax {
 
   public var syntax: ExprSyntax {
     """
-    CaseInfo(name: \(stringlit(name)), associatedValues: \(arrSyntax(associatedValues, {optSyntax($0, stringlit)}))
+    CaseInfo(name: \(stringlit(name)), associatedValues: \(arrSyntax(associatedValues, {optSyntax($0, stringlit)})))
     """
   }
 }

--- a/lib/Macros/Sources/SwiftMacros/TypeInfoParser.swift
+++ b/lib/Macros/Sources/SwiftMacros/TypeInfoParser.swift
@@ -1,0 +1,45 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+// Utilities to handle type information passed as arguments to macros         //
+// conformances.                                                              //
+//===----------------------------------------------------------------------===//
+
+public struct NominalTypeInfo {
+  var kind: NominalTypeKind
+  var isUnsafe: Bool
+}
+
+public enum NominalTypeKind {
+  case enumLike(EnumTypeInfo)
+  case structLike(StructTypeInfo)
+}
+
+public struct EnumTypeInfo {
+  var isObjC: Bool
+  var cases: [CaseInfo]
+}
+
+public struct CaseInfo {
+  var name: String
+  var associatedValues: [String?]
+}
+
+public struct StructTypeInfo {
+  var properties: [StoredProperty]
+}
+
+public struct StoredProperty {
+  var name: String
+  var typeName: String
+  var isVar: Bool
+  var isStatic: Bool
+}

--- a/lib/Macros/Sources/SwiftMacros/TypeInfoParser.swift
+++ b/lib/Macros/Sources/SwiftMacros/TypeInfoParser.swift
@@ -481,37 +481,37 @@ extension TypeInfoProtocol {
 }
 
 /// Creates a string literal syntax node with `str` contents.
-func stringlit(_ str: String) -> ExprSyntax {
+fileprivate func stringlit(_ str: String) -> ExprSyntax {
   ExprSyntax(StringLiteralExprSyntax(content: str))
 }
 
 /// Creates a bool literal syntax node with the value `b`.
-func boollit(_ b: Bool) -> ExprSyntax {
+fileprivate func boollit(_ b: Bool) -> ExprSyntax {
   ExprSyntax(BooleanLiteralExprSyntax(booleanLiteral: b))
 }
 
 /// Creates an array syntax node, with the element values from which we can
 /// derive syntax.
-func arraySyntax<T: TypeInfoProtocol>(_ values: [T]) -> ExprSyntax {
+fileprivate func arraySyntax<T: TypeInfoProtocol>(_ values: [T]) -> ExprSyntax {
   arraySyntax(values, \.syntax)
 }
 
 /// Creates an array syntax node, with the element values from the mapping of
 /// `values` by the `toSyntax` function.
-func arraySyntax<T>(_ values: [T], _ toSyntax: (T) -> ExprSyntax) -> ExprSyntax
+fileprivate func arraySyntax<T>(_ values: [T], _ toSyntax: (T) -> ExprSyntax) -> ExprSyntax
 {
   ExprSyntax(ArrayExprSyntax(expressions: values.map(toSyntax)))
 }
 
 /// Creates a `nil` syntax node if `value` is `nil` and the derived syntax of
 /// `value` otherwise.
-func optionalSyntax<T: TypeInfoProtocol>(_ value: T?) -> ExprSyntax {
+fileprivate func optionalSyntax<T: TypeInfoProtocol>(_ value: T?) -> ExprSyntax {
   optionalSyntax(value, \.syntax)
 }
 
 /// Creates a `nil` syntax node if `value` is `nil` and the syntax node
 /// produced by calling `toSyntax` on `value` otherwise.
-func optionalSyntax<T>(_ value: T?, _ toSyntax: (T) -> ExprSyntax) -> ExprSyntax
+fileprivate func optionalSyntax<T>(_ value: T?, _ toSyntax: (T) -> ExprSyntax) -> ExprSyntax
 {
   if let value = value {
     toSyntax(value)

--- a/lib/Sema/DerivedConformance/DerivedConformance.cpp
+++ b/lib/Sema/DerivedConformance/DerivedConformance.cpp
@@ -1141,8 +1141,8 @@ ValueDecl *swift::deriveRequirementViaMacro(DerivedConformance &derived,
 
 /// Prints a string containing swift syntax describing the case \p  decl with
 /// relevant information to \p out.
-static void printCaseInfo(llvm::raw_ostream &out, const EnumElementDecl *decl) {
-  out << "CaseInfo(name: " << QuotedString(decl->getNameStr())
+static void printEnumCaseInfo(llvm::raw_ostream &out, const EnumElementDecl *decl) {
+  out << "EnumCaseInfo(name: " << QuotedString(decl->getNameStr())
       << ", associatedValueLabels: [";
   llvm::interleaveComma(decl->getName().getArgumentNames(), out,
                         [&](Identifier name) {
@@ -1163,7 +1163,7 @@ static void printEnumTypeKind(llvm::raw_ostream &out, EnumDecl *decl) {
       << ", cases: [";
   llvm::interleaveComma(decl->getAllElements(), out,
                         [&](const EnumElementDecl *elem) {
-                          printCaseInfo(out, elem);
+                          printEnumCaseInfo(out, elem);
                         });
   out << "]))";
 }

--- a/lib/Sema/DerivedConformance/DerivedConformance.cpp
+++ b/lib/Sema/DerivedConformance/DerivedConformance.cpp
@@ -1143,7 +1143,7 @@ ValueDecl *swift::deriveRequirementViaMacro(DerivedConformance &derived,
 /// relevant information to \p out.
 static void printCaseInfo(llvm::raw_ostream &out, const EnumElementDecl *decl) {
   out << "CaseInfo(name: " << QuotedString(decl->getNameStr())
-      << ", associatedValues: [";
+      << ", associatedValueLabels: [";
   llvm::interleaveComma(decl->getName().getArgumentNames(), out,
                         [&](Identifier name) {
                           if (name.empty()) {


### PR DESCRIPTION
**Overview** 
This PR introduces the types representing type information first described here: https://github.com/swiftlang/swift/pull/89463 as well as their parsers from SwiftSyntax nodes to values.

**Motivation**
A case for deriving conformances via macros is made here: https://github.com/swiftlang/swift/pull/89419.
The type information generated when deriving conformances via macros is passed as arguments to the deriving macros. In order to use this type information, we need a way to parse it. This is meant to be a common utility shared between all deriving macros. Having a single way of generating / parsing type information makes it easier to test and iterate on the design.

**Changes**
- New `TypeInfoParser.swift` file in SwiftMacros that implements:
	- `NominalTypeInfo.fromSyntax(node:)`: parses `ExprSyntax` into `NominalTypeInfo` (and inner types).
	- `NominalTypeInfo.syntax` computed property: emits `NominalTypeInfo` to `ExprSyntax`, guaranteed re-parseable to the original value.
		```swift
		let value = NominalTypeInfo.fromSyntax(node: node)
		let new_value = NominalTypeInfo.fromSyntax(node: value.syntax)
		// We have value == new_value
		```
- Entry for the new file in SwiftMacro's `CMakeLists.txt`

These changes are additive only and do not interact with pre-existing code.

Note: A first attempt was https://github.com/swiftlang/swift/pull/89624 but the usage of value/parameter packs crashed some older compilers when the `-package-cmo` flag was used.