### PR TITLE
[DO NOT MERGE] Run BorrowingForLoop by default

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -590,7 +590,7 @@ EXPERIMENTAL_FEATURE(ImportMacroAliases, true)
 LANGUAGE_FEATURE(BorrowAndMutateAccessors, 507, "borrow and mutate accessors")
 
 /// Enable borrowing for-in loops
-EXPERIMENTAL_FEATURE(BorrowingForLoop, true)
+LANGUAGE_FEATURE(BorrowingForLoop, 0, "borrowing for-in loops")
 
 /// Allow use of @inline(always) attribute
 SUPPRESSIBLE_LANGUAGE_FEATURE(InlineAlways, 496, "@inline(always) attribute")

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -3704,10 +3704,6 @@ FuncDecl *TypeChecker::getForEachIteratorNextFunction(
 bool swift::shouldUseBorrowingSequence(ASTContext &ctx, Type seqTy,
                                        bool isAsync, SourceLoc loc,
                                        DeclContext *dc) {
-  if (!ctx.LangOpts.hasFeature(Feature::BorrowingForLoop)) {
-    return false;
-  }
-
   if (isAsync || seqTy->isExistentialType()) {
     return false;
   }

--- a/test/Availability/foreach_borrowing.swift
+++ b/test/Availability/foreach_borrowing.swift
@@ -1,9 +1,7 @@
 // RUN: %target-typecheck-verify-swift \
-// RUN:     -enable-experimental-feature BorrowingForLoop \
 // RUN:     -enable-experimental-feature BorrowingSequence \
 // RUN:     -verify-ignore-unrelated
 
-// REQUIRES: swift_feature_BorrowingForLoop
 // REQUIRES: swift_feature_BorrowingSequence
 // REQUIRES: OS=macosx
 

--- a/test/Interop/Cxx/stdlib/use-std-span-typechecker.swift
+++ b/test/Interop/Cxx/stdlib/use-std-span-typechecker.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -I %S/Inputs -enable-experimental-cxx-interop -Xcc -std=c++20 2>&1 -disable-availability-checking -enable-experimental-feature BorrowingSequence
+// RUN: %target-typecheck-verify-swift -I %S/Inputs -cxx-interoperability-mode=default -Xcc -std=c++20 -enable-experimental-feature BorrowingSequence %if OS_FAMILY=darwin %{ -verify-additional-prefix darwin- %}
 // REQUIRES: std_span
 // REQUIRES: swift_feature_BorrowingSequence
 
@@ -7,6 +7,7 @@ import StdSpan
 func takesSequence<T: Sequence>(_ _: T) {}
 // expected-note@-1 {{where 'T' = 'SpanOfNonCopyable'}}
 
+@available(SwiftStdlib 6.4, *)
 func takesBorrowingSequence<T: CxxBorrowingSequence>(_ _: T) where T.Element: ~Copyable {}
 
 func takesSpan<S: CxxMutableSpan>(_ _: S) where S.Element: ~Copyable {}
@@ -15,23 +16,31 @@ let arr: [Int32] = [1, 2, 3]
 arr.withUnsafeBufferPointer { ubpointer in
     let _ = ConstSpanOfInt(ubpointer) // okay
     let _ = ConstSpanOfInt(ubpointer.baseAddress!, ubpointer.count) 
+    // expected-warning@-1 {{'init(_:_:)' is deprecated: use 'init(_:)' instead.}}
 }
 
 arr.withUnsafeBufferPointer { ubpointer in 
     // FIXME: this crashes the compiler once we import span's templated ctors as Swift generics.
     let _ = ConstSpanOfInt(ubpointer.baseAddress, ubpointer.count)
+    // expected-warning@-1 {{'init(_:_:)' is deprecated: use 'init(_:)' instead.}}
 }
 
 let s1 = initSpan()
 for _ in s1 {}
 takesSequence(s1)
-takesBorrowingSequence(s1)
+if #available(SwiftStdlib 6.4, *) {
+    takesBorrowingSequence(s1)
+}
 takesSpan(s1)
 
 let s2 = makeSpanOfNonCopyable()
 for _ in s2 {}
-// expected-error@-1 {{for-in loop requires 'SpanOfNonCopyable'}} to conform to 'Sequence'
+// expected-darwin-error@-1 {{conform to 'BorrowingSequence', which is only available in}}
+// expected-darwin-note@-2 {{add 'if #available' version check}}
 takesSequence(s2)
 // expected-error@-1 {{global function 'takesSequence' requires that 'SpanOfNonCopyable'}} conform to 'Sequence'
-takesBorrowingSequence(s2)
+if #available(SwiftStdlib 6.4, *) {
+    takesBorrowingSequence(s2)
+    for _ in s2 {}
+}
 takesSpan(s2)

--- a/test/Interop/Cxx/stdlib/use-std-span.swift
+++ b/test/Interop/Cxx/stdlib/use-std-span.swift
@@ -1,12 +1,9 @@
 // RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -Xcc -std=c++20 -enable-experimental-feature BorrowingSequence)
 // RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -Xcc -std=c++20 -Xcc -D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_DEBUG -enable-experimental-feature BorrowingSequence)
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -Xcc -std=c++20 -enable-experimental-feature BorrowingForLoop -enable-experimental-feature BorrowingSequence)
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -Xcc -std=c++20 -Xcc -D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_DEBUG -enable-experimental-feature BorrowingForLoop -enable-experimental-feature BorrowingSequence)
 
 
 // REQUIRES: executable_test
 // REQUIRES: std_span
-// REQUIRES: swift_feature_BorrowingForLoop
 // REQUIRES: swift_feature_BorrowingSequence
 
 import StdlibUnittest
@@ -731,8 +728,6 @@ StdSpanTestSuite.test("CxxSpan conforms to CxxBorrowingSequence")
   expectEqual(counter, 3)
 }
 
-#if hasFeature(BorrowingForLoop)
-
 StdSpanTestSuite.test("CxxSpan of noncopyable conforms to CxxBorrowingSequence")
 .require(.stdlib_6_4).code {
   guard #available(SwiftStdlib 6.4, *) else { return }
@@ -766,7 +761,5 @@ StdSpanTestSuite.test("Borrowing for loop")
   }
   expectEqual(counter, 3)
 }
-
-#endif
 
 runAllTests()

--- a/test/Interpreter/foreach_borrowing.swift
+++ b/test/Interpreter/foreach_borrowing.swift
@@ -6,11 +6,9 @@
 // cited below, where the stdlib symbols will not be present, to avoid crashes.
 // Make sure to update this test accordingly when a more appropriate tool is added.
 
-// RUN: %target-run-simple-swift(-enable-experimental-feature BorrowingForLoop \
-// RUN: -Xfrontend -disable-availability-checking) \
+// RUN: %target-run-simple-swift(-Xfrontend -disable-availability-checking) \
 // RUN: %s | %FileCheck %s
 
-// REQUIRES: swift_feature_BorrowingForLoop
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime

--- a/test/Profiler/coverage_foreach_borrowing.swift
+++ b/test/Profiler/coverage_foreach_borrowing.swift
@@ -1,7 +1,5 @@
-// RUN: %target-swift-frontend -Xllvm -sil-full-demangle -suppress-warnings -profile-generate -profile-coverage-mapping -emit-sorted-sil -emit-sil -module-name coverage_foreach_borrowing -enable-experimental-feature BorrowingForLoop %s | %FileCheck %s
-// RUN: %target-swift-frontend -profile-generate -profile-coverage-mapping -emit-ir -enable-experimental-feature BorrowingForLoop %s
-
-// REQUIRES: swift_feature_BorrowingForLoop
+// RUN: %target-swift-frontend -Xllvm -sil-full-demangle -suppress-warnings -profile-generate -profile-coverage-mapping -emit-sorted-sil -emit-sil -module-name coverage_foreach_borrowing %s | %FileCheck %s
+// RUN: %target-swift-frontend -profile-generate -profile-coverage-mapping -emit-ir %s
 
 // CHECK-LABEL: sil_coverage_map {{.*}}// coverage_foreach_borrowing.forEachBasic
 @available(SwiftStdlib 6.4, *)

--- a/test/SILGen/foreach_borrowing.swift
+++ b/test/SILGen/foreach_borrowing.swift
@@ -1,10 +1,8 @@
 // RUN: %target-swift-emit-silgen -Xllvm -sil-print-types \
 // RUN:     -g -Xllvm -sil-print-debuginfo-verbose \
-// RUN:     -enable-experimental-feature BorrowingForLoop \
 // RUN:     -enable-experimental-feature BorrowingSequence \
 // RUN:     %s | %FileCheck %s
 
-// REQUIRES: swift_feature_BorrowingForLoop
 // REQUIRES: swift_feature_BorrowingSequence
 
 struct NoncopyableInt: ~Copyable {

--- a/test/Sema/foreach_borrowing.swift
+++ b/test/Sema/foreach_borrowing.swift
@@ -1,9 +1,7 @@
 // RUN: %target-typecheck-verify-swift \
-// RUN:     -enable-experimental-feature BorrowingForLoop \
 // RUN:     -enable-experimental-feature BorrowingSequence \
 // RUN:     -verify-ignore-unrelated
 
-// REQUIRES: swift_feature_BorrowingForLoop
 // REQUIRES: swift_feature_BorrowingSequence
 
 @available(SwiftStdlib 6.4, *)


### PR DESCRIPTION
DO NOT MERGE until swift-evolution proposal approved

Currently, BorrowingForLoop is an experimental feature. The aim is to run it by default once the swift-evolution proposal for it is approved.

Resolves rdar://180431383.