### PR TITLE
[DebugInfo] Salvage copy_value and move_value 

### DIFF
--- a/lib/SILOptimizer/Utils/InstOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/InstOptUtils.cpp
@@ -1923,7 +1923,7 @@ void swift::endLifetimeAtLeakingBlocks(SILValue value,
 static void salvageNullaryInst(SingleValueInstruction *inst) {
   assert(inst->getNumOperands() == 0 &&
          "salvageNullaryInst expects a single operand");
-  SmallVector<Operand *, 4> debugUses(getDebugUses(inst));
+  SmallVector<Operand *> debugUses(getDebugUses(inst));
   for (Operand *U : debugUses) {
     auto *DbgInst = cast<DebugValueInst>(U->getUser());
     SILBasicBlock *debugBB = DbgInst->getOrCreateDebugReconstructionBlock();
@@ -1939,7 +1939,7 @@ static void salvageNullaryInst(SingleValueInstruction *inst) {
 static void salvageUnaryInst(SingleValueInstruction *SVI) {
   assert(SVI->getNumOperands() == 1 &&
          "salvageUnaryInst expects a single operand");
-  SmallVector<Operand *, 4> debugUses(getDebugUses(SVI));
+  SmallVector<Operand *> debugUses(getDebugUses(SVI));
   for (Operand *U : debugUses) {
     auto *DbgInst = cast<DebugValueInst>(U->getUser());
     SILBasicBlock *debugBB =
@@ -1977,7 +1977,7 @@ static void salvageBinaryInst(SingleValueInstruction *SVI) {
   bool lhsNullary = isNullaryLiteral(lhs);
   bool rhsNullary = isNullaryLiteral(rhs);
 
-  SmallVector<Operand *, 4> debugUses(getDebugUses(SVI));
+  SmallVector<Operand *> debugUses(getDebugUses(SVI));
   for (Operand *U : debugUses) {
     auto *DbgInst = cast<DebugValueInst>(U->getUser());
 
@@ -2024,7 +2024,7 @@ static void salvageBinaryInst(SingleValueInstruction *SVI) {
 /// Salvage debug info for identity-like instructions (copy_value, move_value).
 /// Just repoints debug uses to the operand.
 static void salvageIdentityInst(SingleValueInstruction *SVI) {
-  SmallVector<Operand *, 4> debugUses(getDebugUses(SVI));
+  SmallVector<Operand *> debugUses(getDebugUses(SVI));
   for (Operand *U : debugUses) {
     auto *DbgInst = cast<DebugValueInst>(U->getUser());
     DbgInst->setOperand(SVI->getOperand(0));
@@ -2042,7 +2042,7 @@ static void salvageDestructureInst(SILInstruction *I) {
   SILValue structOrTupleOperand = I->getOperand(0);
 
   for (auto [i, result] : llvm::enumerate(I->getResults())) {
-    SmallVector<Operand *, 4> debugUses(getDebugUses(result));
+    SmallVector<Operand *> debugUses(getDebugUses(result));
     for (Operand *U : debugUses) {
       auto *DbgInst = cast<DebugValueInst>(U->getUser());
       SILBasicBlock *debugBB =
@@ -2195,7 +2195,7 @@ void swift::salvageDebugInfo(SILInstruction *I) {
       // Empty structs cannot use fragments, as they have no fields.
       salvageNullaryInst(STI);
     } else {
-      SmallVector<Operand *, 4> debugUses(getDebugUses(STVal));
+      SmallVector<Operand *> debugUses(getDebugUses(STVal));
       for (Operand *U : debugUses) {
         auto *DbgInst = cast<DebugValueInst>(U->getUser());
         auto VarInfo = DbgInst->getCompleteVarInfo();
@@ -2248,7 +2248,7 @@ void swift::salvageDebugInfo(SILInstruction *I) {
       // Empty tuple: clone into a debug BB and set operand to undef.
       salvageNullaryInst(TTI);
     } else {
-      SmallVector<Operand *, 4> debugUses(getDebugUses(TTVal));
+      SmallVector<Operand *> debugUses(getDebugUses(TTVal));
       for (Operand *U : debugUses) {
         auto *DbgInst = cast<DebugValueInst>(U->getUser());
         auto VarInfo = DbgInst->getCompleteVarInfo();
@@ -2325,7 +2325,7 @@ void swift::salvageDebugInfo(SILInstruction *I) {
 
 void swift::salvageLoadDebugInfo(LoadOperation load) {
   // The use list is mutated during iteration.
-  SmallVector<Operand *, 4> debugUses(getDebugUses(load.getLoadInst()));
+  SmallVector<Operand *> debugUses(getDebugUses(load.getLoadInst()));
   for (Operand *debugUse : debugUses) {
     // Update the debug_value to use the loaded address.
     auto *debugInst = cast<DebugValueInst>(debugUse->getUser());

--- a/lib/SILOptimizer/Utils/InstOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/InstOptUtils.cpp
@@ -2021,6 +2021,16 @@ static void salvageBinaryInst(SingleValueInstruction *SVI) {
   }
 }
 
+/// Salvage debug info for identity-like instructions (copy_value, move_value).
+/// Just repoints debug uses to the operand.
+static void salvageIdentityInst(SingleValueInstruction *SVI) {
+  SmallVector<Operand *, 4> debugUses(getDebugUses(SVI));
+  for (Operand *U : debugUses) {
+    auto *DbgInst = cast<DebugValueInst>(U->getUser());
+    DbgInst->setOperand(SVI->getOperand(0));
+  }
+}
+
 /// Salvage debug info for destructure_struct / destructure_tuple instructions.
 ///
 /// These are multi-value instructions. For each result that has debug uses,
@@ -2308,6 +2318,9 @@ void swift::salvageDebugInfo(SILInstruction *I) {
 
   if (isa<IndexAddrInst>(I) || isa<IndexRawPointerInst>(I))
     salvageBinaryInst(cast<SingleValueInstruction>(I));
+
+  if (isa<CopyValueInst>(I) || isa<MoveValueInst>(I))
+    salvageIdentityInst(cast<SingleValueInstruction>(I));
 }
 
 void swift::salvageLoadDebugInfo(LoadOperation load) {

--- a/test/DebugInfo/salvage_copy_move_value.sil
+++ b/test/DebugInfo/salvage_copy_move_value.sil
@@ -1,0 +1,43 @@
+// RUN: %target-sil-opt -enable-sil-verify-all -sil-combine %s | %FileCheck %s
+
+sil_stage canonical
+
+import Builtin
+import Swift
+
+class Box {
+  var value: String
+}
+
+// Real-world pattern: Box.init inlined into caller.
+// copy_value of guaranteed arg consumed by store; debug_value "v" on the copy.
+// After sil-combine, the copy is eliminated but "v" should survive pointing to %0.
+// CHECK-LABEL: sil [ossa] @copy_value_consumed_by_store
+// CHECK: debug_value %0, let, name "v"
+sil [ossa] @copy_value_consumed_by_store : $@convention(thin) (@guaranteed String) -> @owned Box {
+bb0(%0 : @guaranteed $String):
+  %2 = copy_value %0 : $String
+  %3 = alloc_ref $Box
+  debug_value %2 : $String, let, name "v"
+  %6 = end_init_let_ref %3 : $Box
+  %7 = begin_borrow %6 : $Box
+  %8 = ref_element_addr %7 : $Box, #Box.value
+  store %2 to [init] %8 : $*String
+  end_borrow %7 : $Box
+  return %6 : $Box
+}
+
+// copy+move chain from guaranteed arg. SimplifyMoveValue RAUWs the move to
+// the copy, then guaranteed canonicalization removes the destroy and deletes
+// the copy through deleteCopyAndMoveChain. salvageDebugInfo repoints to %0.
+// CHECK-LABEL: sil [ossa] @move_value_salvage
+// CHECK: debug_value %0, let, name "m"
+sil [ossa] @move_value_salvage : $@convention(thin) (@guaranteed Box) -> () {
+bb0(%0 : @guaranteed $Box):
+  %1 = copy_value %0 : $Box
+  %2 = move_value %1 : $Box
+  debug_value %2 : $Box, let, name "m"
+  destroy_value %2 : $Box
+  %r = tuple ()
+  return %r : $()
+}

--- a/test/SILOptimizer/copy_propagation_borrow.sil
+++ b/test/SILOptimizer/copy_propagation_borrow.sil
@@ -1205,10 +1205,12 @@ bb8:
 
 // Test recursively visiting a guaranteed borrow that is copied within
 // the borrow scope and used by a debug_value.
-// The copy_value will be deleted when processing the struct.
+// The copy_value will be deleted when processing the struct. Its attached
+// debug_value will be salvaged to use the original value.
 //
 // CHECK-LABEL: sil [ossa] @testCopiedDebugValue : $@convention(method) (@guaranteed String) -> @owned String.UTF16View {
 // CHECK: [[DS:%.*]] = destructure_struct %0 : $String
+// CHECK-NEXT:  debug_value [[DS]] : $_StringGuts, let, name "guts"
 // CHECK-NEXT:  [[ST:%.*]] = struct $String.UTF16View ([[DS]] : $_StringGuts)
 // CHECK-NEXT:  [[CP:%.*]] = copy_value [[ST]] : $String.UTF16View
 // CHECK-NEXT:  return [[CP]] : $String.UTF16View


### PR DESCRIPTION
Based on #89692 - only last commit is new (do review the other PR too)

Salvage `copy_value` and `move_value` by rebinding to the operand. `move_value` is a no-op at IRGen, and `copy_value` creates a copy/retain, which is unnecessary for debug info.

Uses the same lifetime checks as salvageUnaryInstruction as those salvages mostly happen in OSSA.

This salvage accounts for **10%** of the lost variables in the Swift Source Compatibility Test Suite.
In the stdlib (all), increases DWARF coverage by 0.2% (including 1.6% in _RegexParser.o), and decreases SIL level lost variables by **1%** (in Swift.o).

This is a concrete Swift file where this new salvage works:

```swift
class Box {
    var value: String
    init(_ v: String) {
        value = v // <- break here, `v` was unavailable before this PR, now available 
    }
}

@inline(never)
func escape(_ b: Box) { print(b.value) }

@inline(never)
func test(_ s: String) {
    let b = Box(s)
    let c = b
    escape(b)
    _ = c
}

test("hello")
```