### PR TITLE
BorrowingForLoop: make experimental feature available in production

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -579,7 +579,7 @@ EXPERIMENTAL_FEATURE(ImportMacroAliases, true)
 LANGUAGE_FEATURE(BorrowAndMutateAccessors, 507, "borrow and mutate accessors")
 
 /// Enable borrowing for-in loops
-EXPERIMENTAL_FEATURE(BorrowingForLoop, false)
+EXPERIMENTAL_FEATURE(BorrowingForLoop, true)
 
 /// Allow use of @inline(always) attribute
 SUPPRESSIBLE_LANGUAGE_FEATURE(InlineAlways, 496, "@inline(always) attribute")


### PR DESCRIPTION
Resolves rdar://179931659.

The BorrowingForLoop feature is hidden behind an experimental flag. This renders it available in production to make it easier for users to take advantage of it.