### PR TITLE
[Windows] [Runtime] Fix import-ability of Runtime module

### DIFF
--- a/stdlib/public/RuntimeModule/BacktraceFormatter.swift
+++ b/stdlib/public/RuntimeModule/BacktraceFormatter.swift
@@ -19,7 +19,7 @@ import Swift
 
 #if os(anyAppleOS)
 internal import Darwin
-internal import BacktracingImpl.OS.Darwin
+@_implementationOnly import BacktracingImpl.OS.Darwin
 #elseif os(Windows)
 internal import ucrt
 #elseif canImport(Glibc)

--- a/stdlib/public/RuntimeModule/Compression.swift
+++ b/stdlib/public/RuntimeModule/Compression.swift
@@ -37,8 +37,8 @@ internal import Glibc
 #elseif canImport(Musl)
 internal import Musl
 #endif
-internal import BacktracingImpl.CompressionLibs
-internal import BacktracingImpl.ImageFormats.Elf
+@_implementationOnly import BacktracingImpl.CompressionLibs
+@_implementationOnly import BacktracingImpl.ImageFormats.Elf
 
 enum CompressedImageSourceError: Error {
   case unboundedImageSource

--- a/stdlib/public/RuntimeModule/Context.swift
+++ b/stdlib/public/RuntimeModule/Context.swift
@@ -30,12 +30,12 @@ internal import Musl
 #endif
 
 #if os(anyAppleOS)
-internal import BacktracingImpl.OS.Darwin
+@_implementationOnly import BacktracingImpl.OS.Darwin
 #elseif os(Windows)
-internal import BacktracingImpl.OS.Windows
+@_implementationOnly import BacktracingImpl.OS.Windows
 #endif
 
-internal import BacktracingImpl.FixedLayout
+@_implementationOnly import BacktracingImpl.FixedLayout
 
 typealias x86_64_gprs = swift.runtime.backtrace.x86_64_gprs
 typealias i386_gprs = swift.runtime.backtrace.i386_gprs

--- a/stdlib/public/RuntimeModule/CoreSymbolication.swift
+++ b/stdlib/public/RuntimeModule/CoreSymbolication.swift
@@ -20,7 +20,7 @@
 import Swift
 
 internal import Darwin
-internal import BacktracingImpl.OS.Darwin
+@_implementationOnly import BacktracingImpl.OS.Darwin
 
 // .. Dynamic binding ..........................................................
 

--- a/stdlib/public/RuntimeModule/DefaultSymbolLocator.swift
+++ b/stdlib/public/RuntimeModule/DefaultSymbolLocator.swift
@@ -16,7 +16,7 @@
 
 import Swift
 
-internal import BacktracingImpl.Runtime
+@_implementationOnly import BacktracingImpl.Runtime
 
 // We look for symbols at SWIFT_SYMBOL_PATH.  If that is not set,
 // then on UNIX systems we look in /usr/lib/debug/, while on Windows

--- a/stdlib/public/RuntimeModule/Dwarf.swift
+++ b/stdlib/public/RuntimeModule/Dwarf.swift
@@ -17,7 +17,7 @@
 
 import Swift
 
-internal import BacktracingImpl.ImageFormats.Dwarf
+@_implementationOnly import BacktracingImpl.ImageFormats.Dwarf
 
 // .. Use *our* Dwarf definitions ..............................................
 

--- a/stdlib/public/RuntimeModule/Elf.swift
+++ b/stdlib/public/RuntimeModule/Elf.swift
@@ -28,7 +28,7 @@ internal import Glibc
 #elseif canImport(Musl)
 internal import Musl
 #endif
-internal import BacktracingImpl.ImageFormats.Elf
+@_implementationOnly import BacktracingImpl.ImageFormats.Elf
 
 // .. Use *our* Elf definitions ................................................
 

--- a/stdlib/public/RuntimeModule/ImageMap+Darwin.swift
+++ b/stdlib/public/RuntimeModule/ImageMap+Darwin.swift
@@ -19,7 +19,7 @@
 import Swift
 
 internal import Darwin
-internal import BacktracingImpl.OS.Darwin
+@_implementationOnly import BacktracingImpl.OS.Darwin
 
 fileprivate func getSysCtlString(_ name: String) -> String? {
   return withUnsafeTemporaryAllocation(byteCount: 256, alignment: 16) {

--- a/stdlib/public/RuntimeModule/ImageMap+Linux.swift
+++ b/stdlib/public/RuntimeModule/ImageMap+Linux.swift
@@ -24,7 +24,7 @@ internal import Glibc
 internal import Musl
 #endif
 
-internal import BacktracingImpl.ImageFormats.Elf
+@_implementationOnly import BacktracingImpl.ImageFormats.Elf
 
 fileprivate func readOSRelease(fd: CInt) -> [String:String]? {
   let len = lseek(fd, 0, SEEK_END)

--- a/stdlib/public/RuntimeModule/ImageMap+Win32.swift
+++ b/stdlib/public/RuntimeModule/ImageMap+Win32.swift
@@ -19,8 +19,8 @@
 import Swift
 
 internal import WinSDK
-internal import BacktracingImpl.ImageFormats.CodeView
-internal import BacktracingImpl.OS.Windows
+@_implementationOnly import BacktracingImpl.ImageFormats.CodeView
+@_implementationOnly import BacktracingImpl.OS.Windows
 
 typealias CV_PDB70_INFO = swift.runtime.CV_PDB70_INFO
 typealias RTL_GET_VERSION_FN = @convention(c) (UnsafeMutablePointer<RTL_OSVERSIONINFOW>) -> NTSTATUS

--- a/stdlib/public/RuntimeModule/ImageMap.swift
+++ b/stdlib/public/RuntimeModule/ImageMap.swift
@@ -19,12 +19,12 @@ import Swift
 
 #if os(anyAppleOS)
 internal import Darwin
-internal import BacktracingImpl.OS.Darwin
+@_implementationOnly import BacktracingImpl.OS.Darwin
 #endif
 
 #if os(Windows)
 internal import WinSDK
-internal import BacktracingImpl.OS.Windows
+@_implementationOnly import BacktracingImpl.OS.Windows
 #endif
 
 /// Holds a map of the process's address space.

--- a/stdlib/public/RuntimeModule/Libc.swift
+++ b/stdlib/public/RuntimeModule/Libc.swift
@@ -15,7 +15,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-internal import BacktracingImpl.OS.Libc
+@_implementationOnly import BacktracingImpl.OS.Libc
 
 let _swift_open = swift.runtime.backtrace._swift_open
 let _swift_get_errno = swift.runtime.backtrace._swift_get_errno

--- a/stdlib/public/RuntimeModule/Mangling.swift
+++ b/stdlib/public/RuntimeModule/Mangling.swift
@@ -25,7 +25,7 @@ internal import Glibc
 #elseif canImport(Musl)
 internal import Musl
 #endif
-internal import BacktracingImpl.Runtime
+@_implementationOnly import BacktracingImpl.Runtime
 
 // - MARK: Demangling
 

--- a/stdlib/public/RuntimeModule/MemoryReader.swift
+++ b/stdlib/public/RuntimeModule/MemoryReader.swift
@@ -29,7 +29,7 @@ internal import Musl
 #endif
 
 #if os(macOS)
-internal import BacktracingImpl.OS.Darwin
+@_implementationOnly import BacktracingImpl.OS.Darwin
 #endif
 
 @_spi(MemoryReaders)

--- a/stdlib/public/RuntimeModule/PDB/MultiStreamFile.swift
+++ b/stdlib/public/RuntimeModule/PDB/MultiStreamFile.swift
@@ -27,8 +27,8 @@ internal import Glibc
 internal import Musl
 #endif
 
-internal import BacktracingImpl.OS.Libc
-internal import BacktracingImpl.ImageFormats.PDB
+@_implementationOnly import BacktracingImpl.OS.Libc
+@_implementationOnly import BacktracingImpl.ImageFormats.PDB
 
 enum MultiStreamFileError: Error {
   #if os(Windows)

--- a/stdlib/public/RuntimeModule/PDB/NameTableNI.swift
+++ b/stdlib/public/RuntimeModule/PDB/NameTableNI.swift
@@ -17,7 +17,7 @@
 
 import Swift
 
-internal import BacktracingImpl.ImageFormats.PDB
+@_implementationOnly import BacktracingImpl.ImageFormats.PDB
 
 /// This is the name table from the PDB header, as opposed to the
 /// one in the NameMap stream.

--- a/stdlib/public/RuntimeModule/PDB/PDBFile.swift
+++ b/stdlib/public/RuntimeModule/PDB/PDBFile.swift
@@ -27,7 +27,7 @@ internal import Glibc
 internal import Musl
 #endif
 
-internal import BacktracingImpl.ImageFormats.PDB
+@_implementationOnly import BacktracingImpl.ImageFormats.PDB
 
 extension SC2 {
   static func fromSc(_ sc: SC) -> SC2 {

--- a/stdlib/public/RuntimeModule/PeCoff.swift
+++ b/stdlib/public/RuntimeModule/PeCoff.swift
@@ -26,8 +26,8 @@ internal import Glibc
 #elseif canImport(Musl)
 internal import Musl
 #endif
-internal import BacktracingImpl.ImageFormats.PeCoff
-internal import BacktracingImpl.ImageFormats.CodeView
+@_implementationOnly import BacktracingImpl.ImageFormats.PeCoff
+@_implementationOnly import BacktracingImpl.ImageFormats.CodeView
 
 // .. Typealiases ..............................................................
 

--- a/stdlib/public/RuntimeModule/Runtime.swift
+++ b/stdlib/public/RuntimeModule/Runtime.swift
@@ -17,7 +17,7 @@
 
 import Swift
 
-internal import BacktracingImpl.Runtime
+@_implementationOnly import BacktracingImpl.Runtime
 
 typealias CrashInfo = swift.runtime.backtrace.CrashInfo
 

--- a/stdlib/public/RuntimeModule/SymbolLocator.swift
+++ b/stdlib/public/RuntimeModule/SymbolLocator.swift
@@ -17,7 +17,7 @@
 
 import Swift
 
-internal import BacktracingImpl.Runtime
+@_implementationOnly import BacktracingImpl.Runtime
 
 @_spi(SymbolLocation)
 public struct SymbolLocationSymbol: Sendable, Hashable, Equatable {

--- a/stdlib/public/RuntimeModule/SymbolicatedBacktrace.swift
+++ b/stdlib/public/RuntimeModule/SymbolicatedBacktrace.swift
@@ -18,7 +18,7 @@
 import Swift
 
 #if os(anyAppleOS)
-internal import BacktracingImpl.OS.Darwin
+@_implementationOnly import BacktracingImpl.OS.Darwin
 #endif
 
 #if os(anyAppleOS)
@@ -30,7 +30,7 @@ internal import Glibc
 #elseif canImport(Musl)
 internal import Musl
 #endif
-internal import BacktracingImpl.Runtime
+@_implementationOnly import BacktracingImpl.Runtime
 
 @available(BacktracingDT 6.2, *)
 struct SimpleImageRef: SymbolLoader.Image {

--- a/stdlib/public/RuntimeModule/Win32Unwinder.swift
+++ b/stdlib/public/RuntimeModule/Win32Unwinder.swift
@@ -18,7 +18,7 @@
 
 import Swift
 internal import WinSDK
-internal import BacktracingImpl.OS.Windows
+@_implementationOnly import BacktracingImpl.OS.Windows
 
 extension WIN32_IMAGE_ARM64_RUNTIME_FUNCTION_ENTRY {
   var Flag: UInt32 { UnwindData & 0x3 }

--- a/stdlib/public/runtime/Backtrace.cpp
+++ b/stdlib/public/runtime/Backtrace.cpp
@@ -1344,11 +1344,10 @@ _swift_spawnBacktracer(CrashInfo *crashInfo)
 #endif
 {
   #if defined(_WIN32)
-  HANDLE hOutput;
-  if (_swift_backtraceSettings.outputTo == OutputTo::Stderr)
-    hOutput = GetStdHandle(STD_ERROR_HANDLE);
-  else
-    hOutput = GetStdHandle(STD_OUTPUT_HANDLE);
+  HANDLE hOutput =
+    GetStdHandle(_swift_backtraceSettings.outputTo == OutputTo::Stderr
+                    ? STD_ERROR_HANDLE
+                    : STD_OUTPUT_HANDLE);
   #endif
 
 #if !SWIFT_BACKTRACE_ON_CRASH_SUPPORTED
@@ -1577,14 +1576,13 @@ _swift_spawnBacktracer(CrashInfo *crashInfo)
   if (!bRet) {
     #if DEBUG_BACKTRACING
       char message[256];
-      int len = snprintf(message, sizeof(message),
+      int len = snprintf_s(message, sizeof(message),
                           "swift runtime: %lu return code for CreateProcessW (%ls) ",
                           (unsigned long)bRet,
                           swiftBacktracePath);
       if (len > 0) {
         DWORD written;
-        HANDLE hErr = GetStdHandle(STD_ERROR_HANDLE);
-        WriteFile(hErr, message, (DWORD)len, &written, NULL);
+        WriteFile(hOutput, message, (DWORD)len, &written, NULL);
       } else {
         const char *message = "snprintf failed... ";
         WriteFile(hOutput, message, strlen(message), NULL, NULL);
@@ -1633,8 +1631,7 @@ _swift_spawnBacktracer(CrashInfo *crashInfo)
                         (unsigned long)dwExitCode);
     if (len > 0) {
       DWORD written;
-      HANDLE hErr = GetStdHandle(STD_ERROR_HANDLE);
-      WriteFile(hErr, message, (DWORD)len, &written, NULL);
+      WriteFile(hOutput, message, (DWORD)len, &written, NULL);
     } else {
       const char *message = "snprintf failed... ";
       WriteFile(hOutput, message, strlen(message), NULL, NULL);

--- a/stdlib/public/runtime/Backtrace.cpp
+++ b/stdlib/public/runtime/Backtrace.cpp
@@ -1343,9 +1343,26 @@ _swift_spawnBacktracer(CrashInfo *crashInfo, int memserver_fd)
 _swift_spawnBacktracer(CrashInfo *crashInfo)
 #endif
 {
+  #if defined(_WIN32)
+  HANDLE hOutput;
+  if (_swift_backtraceSettings.outputTo == OutputTo::Stderr)
+    hOutput = GetStdHandle(STD_ERROR_HANDLE);
+  else
+    hOutput = GetStdHandle(STD_OUTPUT_HANDLE);
+  #endif
+
 #if !SWIFT_BACKTRACE_ON_CRASH_SUPPORTED
+  #if DEBUG_BACKTRACING
+    const char *message = "**backtracer disabled** ";
+    WriteFile(hOutput, message, strlen(message), NULL, NULL);
+  #endif
   return false;
 #else
+  #if DEBUG_BACKTRACING
+    const char *message = "preparing to launch backtracer... ";
+    WriteFile(hOutput, message, strlen(message), NULL, NULL);
+  #endif
+
   // Set-up the backtracer's command line arguments
   switch (_swift_backtraceSettings.algorithm) {
   case UnwindAlgorithm::Fast:
@@ -1518,11 +1535,6 @@ _swift_spawnBacktracer(CrashInfo *crashInfo)
   return false;
 
   #elif defined(_WIN32)
-  HANDLE hOutput;
-  if (_swift_backtraceSettings.outputTo == OutputTo::Stderr)
-    hOutput = GetStdHandle(STD_ERROR_HANDLE);
-  else
-    hOutput = GetStdHandle(STD_OUTPUT_HANDLE);
 
   // Windows actually uses a flat command line string with some rather
   // odd parsing rules.
@@ -1563,6 +1575,22 @@ _swift_spawnBacktracer(CrashInfo *crashInfo)
                              &startupInfo,
                              &processInfo);
   if (!bRet) {
+    #if DEBUG_BACKTRACING
+      char message[256];
+      int len = snprintf(message, sizeof(message),
+                          "swift runtime: %lu return code for CreateProcessW (%ls) ",
+                          (unsigned long)bRet,
+                          swiftBacktracePath);
+      if (len > 0) {
+        DWORD written;
+        HANDLE hErr = GetStdHandle(STD_ERROR_HANDLE);
+        WriteFile(hErr, message, (DWORD)len, &written, NULL);
+      } else {
+        const char *message = "snprintf failed... ";
+        WriteFile(hOutput, message, strlen(message), NULL, NULL);
+      }
+    #endif
+
     return false;
   }
 
@@ -1573,6 +1601,12 @@ _swift_spawnBacktracer(CrashInfo *crashInfo)
 
   if (dwRet != WAIT_OBJECT_0) {
     CloseHandle(processInfo.hProcess);
+
+    #if DEBUG_BACKTRACING
+      const char *message = "WaitForSingleObject failed... ";
+      WriteFile(hOutput, message, strlen(message), NULL, NULL);
+    #endif 
+
     return false;
   }
 
@@ -1580,20 +1614,30 @@ _swift_spawnBacktracer(CrashInfo *crashInfo)
   DWORD dwExitCode;
   if (!GetExitCodeProcess(processInfo.hProcess, &dwExitCode)) {
     CloseHandle(processInfo.hProcess);
+
+    #if DEBUG_BACKTRACING
+      const char *message = "GetExitCodeProcess failed... ";
+      WriteFile(hOutput, message, strlen(message), NULL, NULL);
+    #endif
+
     return false;
   }
 
 #if DEBUG_BACKTRACING
   if (dwExitCode != 0) {
-    char message[128];
+    char message[256];
     int len = snprintf(message, sizeof(message),
-                        "swift runtime: swift-backtrace.exe exited with status 0x%08lX (%lu)\n",
+                        "swift runtime: %ls exited with status 0x%08lX (%lu)\n",
+                        swiftBacktracePath,
                         (unsigned long)dwExitCode,
                         (unsigned long)dwExitCode);
     if (len > 0) {
       DWORD written;
       HANDLE hErr = GetStdHandle(STD_ERROR_HANDLE);
       WriteFile(hErr, message, (DWORD)len, &written, NULL);
+    } else {
+      const char *message = "snprintf failed... ";
+      WriteFile(hOutput, message, strlen(message), NULL, NULL);
     }
   }
 #endif  


### PR DESCRIPTION
Fixes #90019

Also added in more debug into the backtracer when DEBUG_BACKTRACING is enabled.