### PR TITLE
[Embedded] Add ARMv5TE to list of recognized architectures

### DIFF
--- a/cmake/modules/SwiftSetIfArchBitness.cmake
+++ b/cmake/modules/SwiftSetIfArchBitness.cmake
@@ -13,6 +13,7 @@ function(set_if_arch_bitness var_name)
      "${SIA_ARCH}" STREQUAL "x86" OR
      "${SIA_ARCH}" STREQUAL "armv4t" OR
      "${SIA_ARCH}" STREQUAL "armv5" OR
+     "${SIA_ARCH}" STREQUAL "armv5te" OR
      "${SIA_ARCH}" STREQUAL "armv6" OR
      "${SIA_ARCH}" STREQUAL "armv6m" OR
      "${SIA_ARCH}" STREQUAL "armv7" OR

--- a/stdlib/public/CMakeLists.txt
+++ b/stdlib/public/CMakeLists.txt
@@ -245,6 +245,7 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB_CROSS_COMPILING)
     if("ARM" IN_LIST LLVM_TARGETS_TO_BUILD)
       list(APPEND EMBEDDED_STDLIB_TARGET_TRIPLES
         "armv4t   armv4t-none-none-eabi     armv4t-none-none-eabi"
+        "armv5te  armv5te-none-none-eabi    armv5te-none-none-eabi"
         "armv6    armv6-none-none-eabi      armv6-none-none-eabi"
         "armv6m   armv6m-none-none-eabi     armv6m-none-none-eabi"
         "armv7    armv7-none-none-eabi      armv7-none-none-eabi"


### PR DESCRIPTION
Adds support for Swift Embedded ARMv5TE target (e.g. Nintendo DS). This adds ARMv5TE as a recognized embedded architecture and builds a stdlib module for it.
Since LLVM natively supports ARMv5TE, this is all that's needed to write Swift for the Nintendo DS. Right now this is needed for [swift-embedded-nds](https://github.com/MillerTechnologyPeru/swift-embedded-nds), which is currently just compiling for Armv4 since its backwards compatible.