### PR TITLE
NFC: refactor getRequirementsWithInversesAndOmitted

### DIFF
--- a/include/swift/AST/GenericSignature.h
+++ b/include/swift/AST/GenericSignature.h
@@ -328,10 +328,11 @@ public:
   /// SuppressedAssociatedTypesWithDefaults (aka SE-503).
   ///
   /// Do not introduce new uses of this function. It should be removed!
-  void getRequirementsWithInversesAndOmitted(
+  ///
+  /// \param reqs will include extra requirements for the ASTPrinter.
+  void getRequirementsWithInversesForPrinting(
       SmallVector<Requirement, 2> &reqs,
-      SmallVector<InverseRequirement, 2> &inverses,
-      SmallVector<Requirement, 2> &omitted) const;
+      SmallVector<InverseRequirement, 2> &inverses) const;
 
   /// Iterate over all generic parameters, passing a flag to the callback
   /// indicating if the generic parameter is canonical or not.
@@ -561,6 +562,17 @@ private:
   /// Return the reduced version of the given type under this generic
   /// signature.
   CanType getReducedType(Type type) const;
+
+  /// Transform the requirements into a form where implicit Copyable and
+  /// Escapable conformances are omitted, and their absence is explicitly
+  /// noted.
+  ///
+  /// \param ForPrinting controls whether some Requirements are not omitted,
+  /// for the ASTPrinter's needs.
+  void getRequirementsWithInversesImpl(
+      SmallVector<Requirement, 2> &reqs,
+      SmallVector<InverseRequirement, 2> &inverses,
+      bool ForPrinting) const;
 };
 
 void simple_display(raw_ostream &out, GenericSignature sig);

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -2054,8 +2054,7 @@ void PrintAST::printGenericSignature(
     requirements.append(genericSig.getRequirements().begin(),
                         genericSig.getRequirements().end());
   } else if (flags & PrintInverseRequirements) {
-    genericSig->getRequirementsWithInversesAndOmitted(requirements, inverses,
-                                                      /*omitted=*/requirements);
+    genericSig->getRequirementsWithInversesForPrinting(requirements, inverses);
     llvm::erase_if(inverses, [&](InverseRequirement inverse) -> bool {
       return !inverseFilter(inverse);
     });
@@ -3455,8 +3454,7 @@ void PrintAST::printSynthesizedExtensionImpl(Type ExtendedType,
     SmallVector<Requirement, 2> requirements;
     SmallVector<InverseRequirement, 2> inverses;
     auto Sig = ED->getGenericSignature();
-    Sig->getRequirementsWithInversesAndOmitted(requirements, inverses,
-                                               /*omitted=*/requirements);
+    Sig->getRequirementsWithInversesForPrinting(requirements, inverses);
     printSingleDepthOfGenericSignature(
         Sig.getGenericParams(),
         requirements,

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -1360,15 +1360,19 @@ GenericSignature GenericSignature::withoutMarkerProtocols() const {
 void GenericSignatureImpl::getRequirementsWithInverses(
     SmallVector<Requirement, 2> &reqs,
     SmallVector<InverseRequirement, 2> &inverses) const {
-  // Throwing away the omitted requirements is the normal behavior.
-  SmallVector<Requirement, 2> _throw_away_omitted;
-  getRequirementsWithInversesAndOmitted(reqs, inverses, _throw_away_omitted);
+  getRequirementsWithInversesImpl(reqs, inverses, /*ForPrinting*/ false);
 }
 
-void GenericSignatureImpl::getRequirementsWithInversesAndOmitted(
+void GenericSignatureImpl::getRequirementsWithInversesForPrinting(
+    SmallVector<Requirement, 2> &reqs,
+    SmallVector<InverseRequirement, 2> &inverses) const {
+  getRequirementsWithInversesImpl(reqs, inverses, /*ForPrinting*/ true);
+}
+
+void GenericSignatureImpl::getRequirementsWithInversesImpl(
     SmallVector<Requirement, 2> &reqs,
     SmallVector<InverseRequirement, 2> &inverses,
-    SmallVector<Requirement, 2> &omitted) const {
+    bool ForPrinting) const {
   auto &ctx = getASTContext();
 
   llvm::SmallSet<CanType, 12> seenDMTs;
@@ -1479,13 +1483,12 @@ void GenericSignatureImpl::getRequirementsWithInversesAndOmitted(
 
     // If the subject matches a primary associated type we identified earlier,
     // then we will infer a default for them, so drop this requirement.
-    if (seenDMTs.contains(subject->getCanonicalType())) {
-      // To maintain with compatability between SE-503 and the deprecated
-      // SuppressedAssociatedTypes, preserve provide these in the "omitted"
-      // output for the ASTPrinter.
-      omitted.push_back(req);
+    //
+    // To maintain with compatability between SE-503 and the deprecated
+    // SuppressedAssociatedTypes, we preserve these requirements when the
+    // purpose is for the ASTPrinter.
+    if (!ForPrinting && seenDMTs.contains(subject->getCanonicalType()))
       continue;
-    }
 
     // Otherwise, for a non-primary associated type, no default is inferred,
     // thus this conformance requirement was explicitly stated. Keep it.


### PR DESCRIPTION
- Avoids stack space allocation for the common non-printing case of omitting the extra requirements.

- Avoids the pattern of passing the same mutable vector twice to the function, instead opting for a boolean and adding them to the existing output vector argument if true.
