### PR TITLE
[DebugInfo] Salvage index_addr and index_raw_pointer

### DIFF
--- a/include/swift/SILOptimizer/Utils/DebugOptUtils.h
+++ b/include/swift/SILOptimizer/Utils/DebugOptUtils.h
@@ -65,6 +65,8 @@ void salvageLoadDebugInfo(LoadOperation load);
 /// Erases the instruction \p I from it's parent block and deletes it, including
 /// all debug instructions which use \p I.
 /// Precondition: The instruction may only have debug instructions as uses.
+/// `salvageDebugInfo` should be called before this function which should
+/// rewrite debug users if possible.
 /// If the iterator \p InstIter references any deleted instruction, it is
 /// incremented.
 ///
@@ -95,7 +97,6 @@ eraseFromParentWithDebugInsts(SILInstruction *inst,
   // Just matching what eraseFromParentWithDebugInsts is today.
   if (nextII == inst->getIterator())
     ++nextII;
-  swift::salvageDebugInfo(inst);
   callbacks.deleteInst(inst, false /*do not notify*/);
   return nextII;
 }

--- a/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
+++ b/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
@@ -3189,10 +3189,12 @@ bool ArgumentSplitter::createNewArguments() {
   // and have them point directly at the argument.
   simplifyUsers(Agg);
 
-  // If we only had such users of Agg and Agg is dead now (ignoring debug
-  // instructions), remove it.
-  if (onlyHaveDebugUses(Agg))
+  // If we only had such users of Agg and Agg is dead now, rewrite debug values
+  // and remove it.
+  if (onlyHaveDebugUses(Agg)) {
+    salvageDebugInfo(Agg);
     eraseFromParentWithDebugInsts(Agg);
+  }
 
   return true;
 }

--- a/lib/SILOptimizer/Utils/InstOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/InstOptUtils.cpp
@@ -1961,6 +1961,66 @@ static void salvageUnaryInst(SingleValueInstruction *SVI) {
   }
 }
 
+static bool isNullaryLiteral(SILValue v) {
+  return isa<IntegerLiteralInst>(v) || isa<FloatLiteralInst>(v);
+}
+
+/// Clone a binary instruction into each debug value's reconstruction block.
+/// Because debug BBs support only one phi argument, at least one operand must
+/// be a nullary literal (IntegerLiteralInst or FloatLiteralInst) that can be
+/// cloned directly into the block.
+static void salvageBinaryInst(SingleValueInstruction *SVI) {
+  assert(SVI->getNumOperands() == 2);
+  SILValue lhs = SVI->getOperand(0);
+  SILValue rhs = SVI->getOperand(1);
+
+  bool lhsNullary = isNullaryLiteral(lhs);
+  bool rhsNullary = isNullaryLiteral(rhs);
+
+  SmallVector<Operand *, 4> debugUses(getDebugUses(SVI));
+  for (Operand *U : debugUses) {
+    auto *DbgInst = cast<DebugValueInst>(U->getUser());
+
+    if (!lhsNullary && !rhsNullary) {
+      // Debug values cannot currently have multiple operands.
+      DbgInst->killOperand();
+      continue;
+    }
+
+    SILBasicBlock *debugBB = DbgInst->getOrCreateDebugReconstructionBlock();
+    SILArgument *oldArg = debugBB->getArgument(0);
+
+    auto *cloned = cast<SingleValueInstruction>(SVI->clone(&*debugBB->begin()));
+    oldArg->replaceAllUsesWith(cloned);
+
+    SILValue clonedLhs;
+    SILValue clonedRhs;
+    if (lhsNullary)
+      clonedLhs = cast<SingleValueInstruction>(lhs)->clone(&*debugBB->begin());
+    if (rhsNullary)
+      clonedRhs = cast<SingleValueInstruction>(rhs)->clone(&*debugBB->begin());
+
+    if (lhsNullary && rhsNullary) {
+      // Both nullary, no operand remains.
+      cloned->setOperand(0, clonedLhs);
+      cloned->setOperand(1, clonedRhs);
+      DbgInst->killOperand();
+    } else if (rhsNullary) {
+      auto *newArg =
+          debugBB->replacePhiArgument(0, lhs->getType(), OwnershipKind::None);
+      cloned->setOperand(0, newArg);
+      cloned->setOperand(1, clonedRhs);
+      DbgInst->setOperand(lhs);
+    } else {
+      auto *newArg =
+          debugBB->replacePhiArgument(0, rhs->getType(), OwnershipKind::None);
+      cloned->setOperand(0, clonedLhs);
+      cloned->setOperand(1, newArg);
+      DbgInst->setOperand(rhs);
+    }
+  }
+}
+
 /// Salvage debug info for destructure_struct / destructure_tuple instructions.
 ///
 /// These are multi-value instructions. For each result that has debug uses,
@@ -2245,6 +2305,9 @@ void swift::salvageDebugInfo(SILInstruction *I) {
       isa<RefElementAddrInst>(I) || isa<VectorBaseAddrInst>(I) ||
       isa<RefTailAddrInst>(I))
     salvageUnaryInst(cast<SingleValueInstruction>(I));
+
+  if (isa<IndexAddrInst>(I) || isa<IndexRawPointerInst>(I))
+    salvageBinaryInst(cast<SingleValueInstruction>(I));
 }
 
 void swift::salvageLoadDebugInfo(LoadOperation load) {

--- a/lib/SILOptimizer/Utils/InstructionDeleter.cpp
+++ b/lib/SILOptimizer/Utils/InstructionDeleter.cpp
@@ -434,8 +434,9 @@ void swift::recursivelyDeleteTriviallyDeadInstructions(
   while (!deadInsts.empty()) {
     for (auto inst : deadInsts) {
       // Call the callback before we mutate the to be deleted instruction in any
-      // way.
+      // way, and salvage debug info while it's meaningful.
       callbacks.notifyWillBeDeleted(inst);
+      salvageDebugInfo(inst);
 
       // Check if any of the operands will become dead as well.
       MutableArrayRef<Operand> operands = inst->getAllOperands();

--- a/test/DebugInfo/salvage_addr_projections.sil
+++ b/test/DebugInfo/salvage_addr_projections.sil
@@ -26,6 +26,8 @@ sil_scope 2 { loc "test.swift":10:1 parent @test_salvage_tuple_element_addr : $@
 sil_scope 3 { loc "test.swift":20:1 parent @test_salvage_ref_element_addr : $@convention(thin) (@guaranteed MyClass) -> () }
 sil_scope 4 { loc "test.swift":30:1 parent @test_salvage_vector_base_addr : $@convention(thin) (@in_guaranteed Builtin.FixedArray<4, Int64>) -> () }
 sil_scope 5 { loc "test.swift":40:1 parent @test_salvage_ref_tail_addr : $@convention(thin) (@guaranteed MyClass) -> () }
+sil_scope 6 { loc "test.swift":50:1 parent @test_salvage_index_addr : $@convention(thin) (@in_guaranteed Int64) -> () }
+sil_scope 7 { loc "test.swift":60:1 parent @test_salvage_index_raw_pointer : $@convention(thin) (Builtin.RawPointer) -> () }
 
 // CHECK-LABEL: sil @test_salvage_struct_element_addr
 // CHECK:       bb0([[ADDR:%[0-9]+]] : $*MyStruct):
@@ -113,6 +115,45 @@ sil @test_salvage_ref_tail_addr : $@convention(thin) (@guaranteed MyClass) -> ()
 bb0(%0 : $MyClass):
   %1 = ref_tail_addr %0 : $MyClass, $Int64
   debug_value %1 : $*Int64, let, name "tail_elt", expr op_deref, loc "test.swift":40:1, scope 5
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK-LABEL: sil @test_salvage_index_addr
+// CHECK:       bb0(%0 : $*Int64):
+// CHECK:         debug_value %0 : $*Int64, let, name "elt2", transform {
+// CHECK:           bb0(%0 : $*Int64):
+// CHECK:             %1 = integer_literal $Builtin.Word, 2
+// CHECK:             %2 = index_addr %0 : $*Int64, %1 : $Builtin.Word
+// CHECK:             %3 = load %2 : $*Int64
+// CHECK:             return %3 : $Int64
+// CHECK:         }
+// CHECK:         return
+// CHECK-LABEL: } // end sil function 'test_salvage_index_addr'
+sil @test_salvage_index_addr : $@convention(thin) (@in_guaranteed Int64) -> () {
+bb0(%0 : $*Int64):
+  %idx = integer_literal $Builtin.Word, 2
+  %1 = index_addr %0 : $*Int64, %idx : $Builtin.Word
+  debug_value %1 : $*Int64, let, name "elt2", expr op_deref, loc "test.swift":50:1, scope 6
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK-LABEL: sil @test_salvage_index_raw_pointer
+// CHECK:       bb0(%0 : $Builtin.RawPointer):
+// CHECK:         debug_value %0 : $Builtin.RawPointer, let, name "offset_ptr", transform {
+// CHECK:           bb0(%0 : $Builtin.RawPointer):
+// CHECK:             %1 = integer_literal $Builtin.Word, 8
+// CHECK:             %2 = index_raw_pointer %0 : $Builtin.RawPointer, %1 : $Builtin.Word
+// CHECK:             return %2 : $Builtin.RawPointer
+// CHECK:         }
+// CHECK:         return
+// CHECK-LABEL: } // end sil function 'test_salvage_index_raw_pointer'
+sil @test_salvage_index_raw_pointer : $@convention(thin) (Builtin.RawPointer) -> () {
+bb0(%0 : $Builtin.RawPointer):
+  %idx = integer_literal $Builtin.Word, 8
+  %1 = index_raw_pointer %0 : $Builtin.RawPointer, %idx : $Builtin.Word
+  debug_value %1 : $Builtin.RawPointer, let, name "offset_ptr", loc "test.swift":60:1, scope 7
   %r = tuple ()
   return %r : $()
 }


### PR DESCRIPTION
Accounts for 5.9% of missing salvages in the Source Compatibility Test Suite (4.9% for index_raw_pointer and 1% for index_addr).

Decreases the amount of lost variables in the stdlib by 0.1% and increases variables with DWARF location by 0.004%.

Also fixes recursivelyDeleteTriviallyDeadInstructions to salvageDebugInfo before removing operands from the instructions being deleted.