### PR TITLE
Allow Ownership-Audited CF Types in @c @implementation Declarations

### DIFF
--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -3305,8 +3305,20 @@ getForeignRepresentable(Type type, ForeignLanguage language,
   if (nominal->hasClangNode() || nominal->isObjC()) {
     switch (language) {
     case ForeignLanguage::C:
-      // Imported classes and protocols are not representable in C.
-      if (isa<ClassDecl>(nominal) || isa<ProtocolDecl>(nominal))
+      if (auto *classDecl = dyn_cast<ClassDecl>(nominal)) {
+        switch (classDecl->getForeignClassKind()) {
+        case ClassDecl::ForeignKind::Normal:
+        case ClassDecl::ForeignKind::RuntimeOnly:
+          // Imported classes cannot be represented in C.
+          return failure();
+        case ClassDecl::ForeignKind::CFType:
+          // Imported CF types can be represented as trivial pointer types in C.
+          break;
+        }
+      }
+
+      // Imported protocols are not representable in C.
+      if (isa<ProtocolDecl>(nominal))
         return failure();
 
       // @objc enums are not representable in C, @c ones and imported ones

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -4415,6 +4415,10 @@ static const clang::Decl *findClangMethod(ValueDecl *method) {
 
     if (auto overridden = methodFn->getOverriddenDecl())
       return findClangMethod(overridden);
+
+    if (auto *implementedDecl = method->getImplementedObjCDecl())
+      if (auto *implementedFunction = implementedDecl->getClangDecl())
+        return implementedFunction;
   }
 
   if (auto *constructor = dyn_cast<ConstructorDecl>(method)) {

--- a/test/SILGen/Inputs/c_implementation.h
+++ b/test/SILGen/Inputs/c_implementation.h
@@ -1,0 +1,15 @@
+@import Foundation;
+
+#define CF_RETURNS_RETAINED __attribute__((cf_returns_retained))
+#define CF_RETURNS_NOT_RETAINED __attribute__((cf_returns_not_retained))
+#define CF_CONSUMED __attribute__((cf_consumed))
+
+CF_RETURNS_RETAINED
+CFStringRef returns_retained(void);
+
+CF_RETURNS_NOT_RETAINED
+CFStringRef returns_not_retained(void);
+
+void passes_borrowed(CFStringRef string);
+
+void passes_consumed(CF_CONSUMED CFStringRef string);

--- a/test/SILGen/c_implementation.swift
+++ b/test/SILGen/c_implementation.swift
@@ -1,0 +1,38 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-silgen -import-objc-header %S/Inputs/c_implementation.h -swift-version 6 %s -target %target-stable-abi-triple > %t
+// RUN: %FileCheck --input-file %t %s
+
+// REQUIRES: objc_interop
+
+import Foundation
+
+@_silgen_name("getString")
+func getString() -> String
+
+@c @implementation
+func returns_retained() -> CFString? {
+  return getString() as CFString
+}
+
+// CHECK-LABEL: sil{{.*}} @$s16c_implementation16returns_retainedSo11CFStringRefaSgyFTo : $@convention(c) () -> @owned Optional<CFString> {
+
+@c @implementation
+func returns_not_retained() -> CFString? {
+  return getString() as CFString
+}
+
+// CHECK-LABEL: sil{{.*}} @$s16c_implementation20returns_not_retainedSo11CFStringRefaSgyFTo : $@convention(c) () -> @autoreleased Optional<CFString> {
+
+@c @implementation
+func passes_borrowed(_ string: CFString?) {
+
+}
+
+// CHECK-LABEL: sil{{.*}} @$s16c_implementation15passes_borrowedyySo11CFStringRefaSgFTo : $@convention(c) (Optional<CFString>) -> () {
+
+@c @implementation
+func passes_consumed(_ string: consuming CFString?) {
+
+}
+
+// CHECK-LABEL: sil{{.*}} @$s16c_implementation15passes_consumedyySo11CFStringRefaSgnFTo : $@convention(c) (@owned Optional<CFString>) -> () {
+

--- a/test/attr/attr_cdecl_official_with_cf.swift
+++ b/test/attr/attr_cdecl_official_with_cf.swift
@@ -1,0 +1,26 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -verify %s
+
+// REQUIRES: objc_interop
+
+import CoreFoundation
+
+@c(cfStringReturn) func cfClassReturn() -> CFString { fatalError() }
+@c(cfStringOptionalReturn) func cfClassOptionalReturn() -> CFString? { fatalError() }
+@c(cfObjectParams) func cfClassParams(a: CFArray, b: CFDictionary) { }
+@c(cfObjectOptionalParams) func cfClassParams(a: CFArray?, b: CFDictionary?) { }
+
+@c(unmanagedCFStringReturn) func unmanagedCFClassReturn() -> Unmanaged<CFString> { fatalError() }
+// expected-error@-1 {{global function cannot be marked '@c' because its result type cannot be represented in C}}
+// expected-note@-2 {{Swift structs cannot be represented in C}}
+@c(unmanagedCFObjectParams) func unmanagedCFClassParams(a: Unmanaged<CFArray>, b: Unmanaged<CFDictionary>) { }
+// expected-error@-1 {{global function cannot be marked '@c' because the type of the parameter 1 cannot be represented in C}}
+// expected-error@-2 {{global function cannot be marked '@c' because the type of the parameter 2 cannot be represented in C}}
+// expected-note@-3 {{Swift structs cannot be represented in C}}
+// expected-note@-4 {{Swift structs cannot be represented in C}}
+
+@c(unmanagedOptioanlCFStringReturn) func unmanagedCFClassReturn() -> Unmanaged<CFString>? { fatalError() }
+// expected-error@-1 {{global function cannot be marked '@c' because its result type cannot be represented in C}}
+@c(unmanagedOptioanlCFObjectParams) func unmanagedCFClassParams(a: Unmanaged<CFArray>?, b: Unmanaged<CFDictionary>?) { }
+// expected-error@-1 {{global function cannot be marked '@c' because the type of the parameter 1 cannot be represented in C}}
+// expected-error@-2 {{global function cannot be marked '@c' because the type of the parameter 2 cannot be represented in C}}
+


### PR DESCRIPTION
Relax the foreign representable predicate to enable (ownership-audited) CF Types to be specified as parameters and return types of Swift implementations.

Resolves rdar://175682727

