### PR TITLE
test: adjust baseline symbols for swift standard library

### DIFF
--- a/test/abi/Inputs/macOS/arm64/stdlib/baseline
+++ b/test/abi/Inputs/macOS/arm64/stdlib/baseline
@@ -13752,6 +13752,7 @@ _swift_registerProtocolConformances
 _swift_registerProtocols
 _swift_registerTypeMetadataRecords
 _swift_release
+_swift_releaseReturningCount
 _swift_release_n
 _swift_release_x1
 _swift_release_x10
@@ -13782,6 +13783,7 @@ _swift_relocateClassMetadata
 _swift_reportError
 _swift_reportWarning
 _swift_retain
+_swift_retainReturningCount
 _swift_retainCount
 _swift_retain_n
 _swift_retain_x1

--- a/test/abi/Inputs/macOS/arm64/stdlib/baseline-asserts
+++ b/test/abi/Inputs/macOS/arm64/stdlib/baseline-asserts
@@ -13848,6 +13848,7 @@ _swift_registerProtocolConformances
 _swift_registerProtocols
 _swift_registerTypeMetadataRecords
 _swift_release
+_swift_releaseReturningCount
 _swift_release_n
 _swift_release_x1
 _swift_release_x10
@@ -13878,6 +13879,7 @@ _swift_relocateClassMetadata
 _swift_reportError
 _swift_reportWarning
 _swift_retain
+_swift_retainReturningCount
 _swift_retainCount
 _swift_retain_n
 _swift_retain_x1


### PR DESCRIPTION
Add new `_swift_retainReturningCount` and `_swift_releaseReturningCount` to the baseline exports.