### PR TITLE
[Debug] Handle AnyObject.Protocol in stringForPrintObject(_:mangledTypeName:)

### DIFF
--- a/stdlib/public/core/DebuggerSupport.swift
+++ b/stdlib/public/core/DebuggerSupport.swift
@@ -355,14 +355,6 @@ public enum _DebuggerSupport {
       return (false, "invalid pointer")
     }
 
-    // AnyObject (s9AnyObjectaD) is a type alias (Builtin.AnyObject) which is
-    // not resolved by _getTypeByMangledNameInContext. Instead, bitcast the
-    // pointer directly to AnyObject.
-    if mangledTypeName == "s9AnyObjectaD" {
-      let object = unsafe unsafeBitCast(pointer, to: AnyObject.self)
-      return (true, stringForPrintObject(object))
-    }
-
     guard let type =
       unsafe _getTypeByMangledNameInContext(
         mangledTypeName,
@@ -374,7 +366,7 @@ public enum _DebuggerSupport {
       }
 
     func loadPointer<T>(type: T.Type) -> Any {
-      if type is AnyObject.Type {
+      if type is AnyObject.Type || type is AnyObject.Protocol {
         unsafe unsafeBitCast(pointer, to: T.self)
       } else {
         unsafe pointer.load(as: T.self)

--- a/stdlib/public/core/DebuggerSupport.swift
+++ b/stdlib/public/core/DebuggerSupport.swift
@@ -355,6 +355,14 @@ public enum _DebuggerSupport {
       return (false, "invalid pointer")
     }
 
+    // AnyObject (s9AnyObjectaD) is a type alias (Builtin.AnyObject) which is
+    // not resolved by _getTypeByMangledNameInContext. Instead, bitcast the
+    // pointer directly to AnyObject.
+    if mangledTypeName == "s9AnyObjectaD" {
+      let object = unsafe unsafeBitCast(pointer, to: AnyObject.self)
+      return (true, stringForPrintObject(object))
+    }
+
     guard let type =
       unsafe _getTypeByMangledNameInContext(
         mangledTypeName,

--- a/test/stdlib/DebuggerSupport.swift
+++ b/test/stdlib/DebuggerSupport.swift
@@ -187,7 +187,7 @@ if #available(SwiftStdlib 6.3, *) {
       let obj = ClassWithDescription()
       withExtendedLifetime(obj) { obj in
         let pointer = unsafeBitCast(obj, to: UnsafeRawPointer.self)
-        let (success, printed) = _DebuggerSupport.stringForPrintObject(pointer, mangledTypeName: "s9AnyObjectaD")
+        let (success, printed) = _DebuggerSupport.stringForPrintObject(pointer, mangledTypeName: "yXlD")
         expectTrue(success)
         expectEqual(printed, "custom description\n")
       }

--- a/test/stdlib/DebuggerSupport.swift
+++ b/test/stdlib/DebuggerSupport.swift
@@ -25,6 +25,10 @@ class ClassWithMembers {
   var b = "Hello World"
 }
 
+class ClassWithDescription: CustomStringConvertible {
+  var description: String { "custom description" }
+}
+
 class ClassWithMirror: CustomReflectable {
   var customMirror: Mirror {
     return Mirror(self, children: ["a" : 1, "b" : "Hello World"])
@@ -176,6 +180,16 @@ if #available(SwiftStdlib 6.3, *) {
         }
       } else {
         expectTrue(false)
+      }
+    }
+
+    do {
+      let obj = ClassWithDescription()
+      withExtendedLifetime(obj) { obj in
+        let pointer = unsafeBitCast(obj, to: UnsafeRawPointer.self)
+        let (success, printed) = _DebuggerSupport.stringForPrintObject(pointer, mangledTypeName: "s9AnyObjectaD")
+        expectTrue(success)
+        expectEqual(printed, "custom description\n")
       }
     }
   }


### PR DESCRIPTION
Update `stringForPrintObject(_:mangledTypeName:)` to support mangled type name for `AnyObject` ("yXlD"). Handle this by adding a second `type is AnyObject.Protocol` condition to the branch that bitcasts to `AnyObject`.

AnyObject is used by LLDB as a fallback when the dynamic type's mangled name contains a private class discriminator, which is not resolved by the Swift runtime.

Assisted-by: claude