### PR TITLE
Option: introduce two new COM related options

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -329,6 +329,9 @@ namespace swift {
     /// configuration options.
     bool EnableObjCInterop = true;
 
+    /// Enable COM interop code generation and build configuration options.
+    bool EnableCOMInterop = false;
+
     /// Enable C++ interop code generation and build configuration
     /// options. Disabled by default because there is no way to control the
     /// language mode of clang on a per-header or even per-module basis. Also
@@ -426,6 +429,9 @@ namespace swift {
 
     /// Disable the implicit import of the _StringProcessing module.
     bool DisableImplicitStringProcessingModuleImport = false;
+
+    /// Disable the implicit import of the COM module.
+    bool DisableImplicitCOMModuleImport = false;
 
     /// Disable the implicit import of the Cxx module.
     bool DisableImplicitCxxModuleImport = false;

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -429,6 +429,10 @@ let Flags = [FrontendOption, NoDriverOption, HelpHidden, ModuleInterfaceOption] 
   def public_autolink_library :
     Separate<["-"], "public-autolink-library">,
     HelpText<"Add public dependent library">;
+
+  def enable_com_interop
+    : Flag<["-"], "enable-experimental-com-interop">,
+      HelpText<"Enable COM interop code generation and configuration directives">;
 }
 
 // HIDDEN FLAGS
@@ -615,6 +619,10 @@ def disable_implicit_concurrency_module_import : Flag<["-"],
 def disable_implicit_string_processing_module_import : Flag<["-"],
   "disable-implicit-string-processing-module-import">,
   HelpText<"Disable the implicit import of the _StringProcessing module.">;
+
+def disable_implicit_com_module_import
+  : Flag<["-"], "disable-implicit-com-module-import">,
+    HelpText<"Disable the implicit import of the COM module.">;
 
 def disable_implicit_cxx_module_import : Flag<["-"],
   "disable-implicit-cxx-module-import">,

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1168,6 +1168,9 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   Opts.DisableImplicitStringProcessingModuleImport |=
     Args.hasArg(OPT_disable_implicit_string_processing_module_import);
 
+  Opts.DisableImplicitCOMModuleImport |=
+      Args.hasArg(OPT_disable_implicit_com_module_import);
+
   Opts.DisableImplicitCxxModuleImport |=
     Args.hasArg(OPT_disable_implicit_cxx_module_import);
 
@@ -1678,6 +1681,7 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
         " " + printFormalCxxInteropVersion(Opts);
 
   Opts.UseStaticStandardLibrary = Args.hasArg(OPT_use_static_resource_dir);
+  Opts.EnableCOMInterop = Args.hasArg(OPT_enable_com_interop);
   Opts.EnableObjCInterop =
       Args.hasFlag(OPT_enable_objc_interop, OPT_disable_objc_interop,
                    Target.isOSDarwin() && !Opts.hasFeature(Feature::Embedded));


### PR DESCRIPTION
Add the `-enable-experimental-com-interop` flag to start building out the COM interop support. COM support will require a new core runtime module, which is tentatively planned to be the `COM` module (similar to StringProcessing, Concurrency, Differentiation). Add an option to disable the implicit import.  Wire up the new `-enable-com-interop` and `-disable-implicit-com-module-import` to the LangOptions to gate the feature.