### PR TITLE
[RemoteInspection] Fix mixed @objc/Swift protocol composition existentials

### DIFF
--- a/stdlib/public/RemoteInspection/TypeLowering.cpp
+++ b/stdlib/public/RemoteInspection/TypeLowering.cpp
@@ -1228,6 +1228,9 @@ class ExistentialTypeInfoBuilder {
       // Don't look up field info for imported Objective-C protocols.
       if (OP) {
         ObjC = true;
+        // @objc protocols are class-constrained, so they class-constrain the
+        // whole existential.
+        Representation = ExistentialTypeRepresentation::Class;
         continue;
       }
 
@@ -1241,6 +1244,7 @@ class ExistentialTypeInfoBuilder {
         case FieldDescriptorKind::ObjCProtocol:
           // Objective-C protocols do not have any witness tables.
           ObjC = true;
+          Representation = ExistentialTypeRepresentation::Class;
           continue;
         case FieldDescriptorKind::ClassProtocol:
           Representation = ExistentialTypeRepresentation::Class;
@@ -1370,13 +1374,14 @@ public:
       return nullptr;
 
     if (ObjC) {
-      if (WitnessTableCount > 0) {
-        TC.setError("@objc existential with witness tables");
-        return nullptr;
-      }
+      // A pure-@objc existential is a single retainable pointer.
+      if (WitnessTableCount == 0)
+        return TC.getReferenceTypeInfo(ReferenceKind::Strong, Refcounting);
 
-      return TC.getReferenceTypeInfo(ReferenceKind::Strong,
-                                     Refcounting);
+      // A mixed existential — one or more @objc protocols combined with one or
+      // more Swift protocols that do carry witness tables.
+      assert(Representation == ExistentialTypeRepresentation::Class &&
+             "@objc existential is always class-constrained");
     }
 
     RecordKind Kind;
@@ -1442,12 +1447,14 @@ public:
       return nullptr;
 
     if (ObjC) {
-      if (WitnessTableCount > 0) {
-        markInvalid("@objc existential with witness tables");
-        return nullptr;
-      }
+      // A pure-@objc existential is a single retainable pointer.
+      if (WitnessTableCount == 0)
+        return TC.getReferenceTypeInfo(ReferenceKind::Strong, Refcounting);
 
-      return TC.getAnyMetatypeTypeInfo();
+      // A mixed existential — one or more @objc protocols combined with one or
+      // more Swift protocols that do carry witness tables.
+      assert(Representation == ExistentialTypeRepresentation::Class &&
+             "@objc existential metatype is always class-constrained");
     }
 
     RecordTypeInfoBuilder builder(TC, RecordKind::ExistentialMetatype);

--- a/test/Reflection/Inputs/MixedExistential.swift
+++ b/test/Reflection/Inputs/MixedExistential.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+@objc public protocol ObjCProto {}
+
+public protocol ClassConstrainedProto: AnyObject {
+    var payload: Int { get }
+}
+
+public protocol UnconstrainedProto {
+    var payload: Int { get }
+}
+
+public struct MixedWithClassConstrainedProto {
+    public var existential: ObjCProto & ClassConstrainedProto
+    public init(existential: ObjCProto & ClassConstrainedProto) {
+        self.existential = existential
+    }
+}
+
+public struct MixedWithUnconstrainedProto {
+    public var existential: ObjCProto & UnconstrainedProto
+    public init(existential: ObjCProto & UnconstrainedProto) {
+        self.existential = existential
+    }
+}
+
+public struct MixedExistentialMetatype {
+    public var metatype: (ObjCProto & UnconstrainedProto).Type
+    public init(metatype: (ObjCProto & UnconstrainedProto).Type) {
+        self.metatype = metatype
+    }
+}

--- a/test/Reflection/typeref_lowering_mixed_objc_existential.swift
+++ b/test/Reflection/typeref_lowering_mixed_objc_existential.swift
@@ -1,0 +1,76 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %S/Inputs/MixedExistential.swift -parse-as-library -emit-module -emit-library -module-name MixedExistential -o %t/libTypesToReflect
+// RUN: %target-swift-reflection-dump %t/libTypesToReflect %platform-module-dir/%target-library-name(swiftCore) -dump-type-lowering < %s | %FileCheck %s --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK
+
+// REQUIRES: objc_interop
+
+// A class-constrained protocol composition that mixes an @objc protocol
+// (contributing no witness table) with a Swift protocol (contributing one)
+// must lower as a class_existential record — one object pointer plus one
+// witness-table pointer — rather than being rejected as
+// `@objc existential with witness tables`.
+
+// An @objc protocol composed with a Swift protocol that is itself
+// class-constrained (`: AnyObject`).
+16MixedExistential30MixedWithClassConstrainedProtoVD
+// CHECK-NOT: Invalid lowering
+// CHECK-64: (struct MixedExistential.MixedWithClassConstrainedProto)
+// CHECK-64-NEXT: (struct size=16 alignment=8 stride=16 num_extra_inhabitants=[[PTR_XI:2048|4096|2147483647]] bitwise_takable=1
+// CHECK-64-NEXT:   (field name=existential offset=0
+// CHECK-64-NEXT:     (class_existential size=16 alignment=8 stride=16 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=1
+// CHECK-64-NEXT:       (field name=object offset=0
+// CHECK-64-NEXT:         (reference kind=strong refcounting=unknown))
+// CHECK-64-NEXT:       (field name=wtable offset=8
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=1)))))
+// CHECK-32: (struct MixedExistential.MixedWithClassConstrainedProto)
+// CHECK-32-NEXT: (struct size=8 alignment=4 stride=8 num_extra_inhabitants=4096 bitwise_takable=1
+// CHECK-32-NEXT:   (field name=existential offset=0
+// CHECK-32-NEXT:     (class_existential size=8 alignment=4 stride=8 num_extra_inhabitants=4096 bitwise_takable=1
+// CHECK-32-NEXT:       (field name=object offset=0
+// CHECK-32-NEXT:         (reference kind=strong refcounting=unknown))
+// CHECK-32-NEXT:       (field name=wtable offset=4
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1 bitwise_takable=1)))))
+
+// An @objc protocol composed with a Swift protocol that is NOT independently
+// class-constrained.
+16MixedExistential27MixedWithUnconstrainedProtoVD
+// CHECK-NOT: Invalid lowering
+// CHECK-64: (struct MixedExistential.MixedWithUnconstrainedProto)
+// CHECK-64-NEXT: (struct size=16 alignment=8 stride=16 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=1
+// CHECK-64-NEXT:   (field name=existential offset=0
+// CHECK-64-NEXT:     (class_existential size=16 alignment=8 stride=16 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=1
+// CHECK-64-NEXT:       (field name=object offset=0
+// CHECK-64-NEXT:         (reference kind=strong refcounting=unknown))
+// CHECK-64-NEXT:       (field name=wtable offset=8
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=1)))))
+// CHECK-32: (struct MixedExistential.MixedWithUnconstrainedProto)
+// CHECK-32-NEXT: (struct size=8 alignment=4 stride=8 num_extra_inhabitants=4096 bitwise_takable=1
+// CHECK-32-NEXT:   (field name=existential offset=0
+// CHECK-32-NEXT:     (class_existential size=8 alignment=4 stride=8 num_extra_inhabitants=4096 bitwise_takable=1
+// CHECK-32-NEXT:       (field name=object offset=0
+// CHECK-32-NEXT:         (reference kind=strong refcounting=unknown))
+// CHECK-32-NEXT:       (field name=wtable offset=4
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1 bitwise_takable=1)))))
+
+// The existential metatype of the mixed composition lowers as an
+// existential_metatype record — a metadata pointer plus one witness-table
+// pointer.
+16MixedExistential24MixedExistentialMetatypeVD
+// CHECK-NOT: Invalid lowering
+// CHECK-64: (struct MixedExistential.MixedExistentialMetatype)
+// CHECK-64-NEXT: (struct size=16 alignment=8 stride=16 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=1
+// CHECK-64-NEXT:   (field name=metatype offset=0
+// CHECK-64-NEXT:     (existential_metatype size=16 alignment=8 stride=16 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=1
+// CHECK-64-NEXT:       (field name=metadata offset=0
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI]] bitwise_takable=1))
+// CHECK-64-NEXT:       (field name=wtable offset=8
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=1)))))
+// CHECK-32: (struct MixedExistential.MixedExistentialMetatype)
+// CHECK-32-NEXT: (struct size=8 alignment=4 stride=8 num_extra_inhabitants=4096 bitwise_takable=1
+// CHECK-32-NEXT:   (field name=metatype offset=0
+// CHECK-32-NEXT:     (existential_metatype size=8 alignment=4 stride=8 num_extra_inhabitants=4096 bitwise_takable=1
+// CHECK-32-NEXT:       (field name=metadata offset=0
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=1))
+// CHECK-32-NEXT:       (field name=wtable offset=4
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1 bitwise_takable=1)))))
+// CHECK-NOT: Invalid lowering


### PR DESCRIPTION
An existential that mixes an @objc protocol with a Swift protocol that carries a witness table is class-constrained, since an @objc protocol can only be adopted by classes.

Assisted-by: claude

rdar://177199463
