### PR TITLE
[CSStep] Skip default `Void` for closure result in presence of other …

### DIFF
--- a/lib/Sema/CSStep.cpp
+++ b/lib/Sema/CSStep.cpp
@@ -446,6 +446,24 @@ void TypeVariableStep::setup() {
   ++CS.solverState->NumTypeVariablesBound;
 }
 
+bool TypeVariableStep::shouldSkip(const TypeVariableBinding &choice) const {
+  // Let's always attempt types inferred from "defaultable" constraints
+  // in diagnostic mode. This allows the solver to attempt i.e. `Any`
+  // for collection literals and produce better diagnostics for for-in
+  // statements like `for (x, y, z) in [] { ... }` when pattern type
+  // could not be inferred.
+  //
+  // A notable exception are closure result types, there is no reason
+  // to attempt `Void` if there is a contextual type, it would always
+  // produce a worse solution.
+  if (CS.shouldAttemptFixes() && !TypeVar->getImpl().isClosureResultType())
+    return false;
+
+  // If this is a defaultable binding and we have found solutions,
+  // don't explore the default binding.
+  return AnySolved && choice.isDefaultable();
+}
+
 bool TypeVariableStep::attempt(const TypeVariableBinding &choice) {
   ++CS.solverState->NumTypeVariableBindings;
 

--- a/lib/Sema/CSStep.h
+++ b/lib/Sema/CSStep.h
@@ -564,19 +564,7 @@ public:
 protected:
   bool attempt(const TypeVariableBinding &choice) override;
 
-  bool shouldSkip(const TypeVariableBinding &choice) const override {
-    // Let's always attempt types inferred from "defaultable" constraints
-    // in diagnostic mode. This allows the solver to attempt i.e. `Any`
-    // for collection literals and produce better diagnostics for for-in
-    // statements like `for (x, y, z) in [] { ... }` when pattern type
-    // could not be inferred.
-    if (CS.shouldAttemptFixes())
-      return false;
-
-    // If this is a defaultable binding and we have found solutions,
-    // don't explore the default binding.
-    return AnySolved && choice.isDefaultable();
-  }
+  bool shouldSkip(const TypeVariableBinding &choice) const override;
 
   /// Check whether attempting type variable binding choices should
   /// be stopped, because optimal solution has already been found.

--- a/validation-test/IDE/crashers_fixed/ConstraintSystem-getType-c8e58a.swift
+++ b/validation-test/IDE/crashers_fixed/ConstraintSystem-getType-c8e58a.swift
@@ -1,5 +1,5 @@
 // {"extraArgs":["-language-mode","6"],"kind":"complete","original":"5adecb41","signature":"swift::constraints::ConstraintSystem::getType(swift::ASTNode) const","signatureAssert":"Assertion failed: (found != NodeTypes.end() && \"Expected type to have been set!\"), function getType","signatureNext":"UnableToInferClosureParameterType::diagnoseAsError"}
-// RUN: not --crash %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -swift-version 6 -source-filename %s
+// RUN: %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -swift-version 6 -source-filename %s
 @propertyWrapper struct a<b> {
   var wrappedValue: b
 }


### PR DESCRIPTION
…successful choices

`TypeVariableStep::shouldSkip` would always produce `false` in diagnostic mode. This creates unnecessary work for closure result type variables if there is a contextual type available, because `Void` binding would always produce a worse solution in this case due to conversion mismatch with the contextual type and could be safely skipped.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
