### PR TITLE
[stdlib] Propagate underestimatedCount in PrefixSequence and DropFirstSequence

### DIFF
--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -570,6 +570,9 @@ extension PrefixSequence.Iterator: IteratorProtocol {
 
 extension PrefixSequence: Sequence {
   @inlinable
+  public var underestimatedCount: Int { Swift.min(_maxLength, _base.underestimatedCount) }
+
+  @inlinable
   public __consuming func makeIterator() -> Iterator {
     return Iterator(_base.makeIterator(), maxLength: _maxLength)
   }

--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -496,7 +496,7 @@ extension DropFirstSequence: Sequence {
   public typealias SubSequence = AnySequence<Element>
   
   @inlinable
-  public var underestimatedCount: Int { _base.underestimatedCount > _limit ? _base.underestimatedCount &- _limit : 0 }
+  public var underestimatedCount: Int { Swift.max(_assumeNonNegative(_base.underestimatedCount) - _assumeNonNegative(_limit), 0) }
 
   @inlinable
   @inline(__always)

--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -496,6 +496,9 @@ extension DropFirstSequence: Sequence {
   public typealias SubSequence = AnySequence<Element>
   
   @inlinable
+  public var underestimatedCount: Int { _base.underestimatedCount > _limit ? _base.underestimatedCount &- _limit : 0 }
+
+  @inlinable
   @inline(__always)
   public __consuming func makeIterator() -> Iterator {
     var it = _base.makeIterator()

--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -496,7 +496,9 @@ extension DropFirstSequence: Sequence {
   public typealias SubSequence = AnySequence<Element>
   
   @inlinable
-  public var underestimatedCount: Int { Swift.max(_assumeNonNegative(_base.underestimatedCount) - _assumeNonNegative(_limit), 0) }
+public var underestimatedCount: Int {
+  Swift.max(_assumeNonNegative(_base.underestimatedCount) - _assumeNonNegative(_limit), 0)
+}
 
   @inlinable
   @inline(__always)


### PR DESCRIPTION
The sequence will now provide the smaller of either the underestimated count of the underlying sequence or the prefix length.

Fixes: https://github.com/swiftlang/swift/issues/90036