### PR TITLE
[6.4] swift-inspect dump-concurrency for Linux/Windows

### DIFF
--- a/tools/swift-inspect/README.md
+++ b/tools/swift-inspect/README.md
@@ -90,6 +90,8 @@ The following inspection operations are available currently.
 
 ##### All Platforms
 
+> FreeBSD is currently not supported; all other platforms, such as macOS, Linux, Windows and some Android offer the following functionality.
+
 dump-cache-nodes &lt;name-or-pid&gt;
 : Print the metadata cache nodes.
 
@@ -102,12 +104,12 @@ dump-generic-metadata &lt;name-or-pid&gt; [--backtrace] [--backtrace-long]
 dump-raw-metadata &lt;name-or-pid&gt; [--backtrace] [--backtrace-long]
 : Print metadata allocations.
 
+dump-concurrency &lt;name-or-pid&gt;
+: Print information about tasks, actors, and threads under Concurrency.
+  On Linux this needs `CAP_SYS_PTRACE` (run as root, via sudo, or grant
+  the binary `cap_sys_ptrace+ep` with setcap).
+
 #### Darwin and Windows Only
 
 dump-arrays &lt;name-or-pid&gt;
 : Print information about array objects in the target
-
-##### Darwin Only
-
-dump-concurrency &lt;name-or-pid&gt;
-: Print information about tasks, actors, and threads under Concurrency.

--- a/tools/swift-inspect/Sources/SwiftInspectLinux/Process.swift
+++ b/tools/swift-inspect/Sources/SwiftInspectLinux/Process.swift
@@ -92,7 +92,14 @@ public class Process {
       var remote = iovec(
         iov_base: UnsafeMutableRawPointer(bitPattern: UInt(address)), iov_len: maxSize)
       let bytesRead = process_vm_readv(self.pid, &local, 1, &remote, 1, 0)
-      initCount = bytesRead / MemoryLayout<T>.stride
+      // process_vm_readv returns -1 on failure (e.g. unmapped page in the
+      // requested range). Clamp to [0, upToCount] so we never trip the
+      // unsafeUninitializedCapacity precondition that initCount <= capacity.
+      if bytesRead <= 0 {
+        initCount = 0
+      } else {
+        initCount = min(bytesRead / MemoryLayout<T>.stride, Int(upToCount))
+      }
     }
 
     guard array.count > 0 else {

--- a/tools/swift-inspect/Sources/swift-inspect/AndroidRemoteProcess.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/AndroidRemoteProcess.swift
@@ -242,6 +242,10 @@ internal final class AndroidRemoteProcess: LinuxRemoteProcess {
     }
     _ = try ptrace.jump(to: sym)
   }
+
+  override var currentTasks: [(threadID: UInt64, currentTask: swift_addr_t)] {
+    fatalError("thread task pointer lookup is not supported on Android")
+  }
 }
 
 #endif

--- a/tools/swift-inspect/Sources/swift-inspect/AndroidRemoteProcess.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/AndroidRemoteProcess.swift
@@ -36,19 +36,6 @@ internal final class AndroidRemoteProcess: LinuxRemoteProcess {
     case heapIterationFailed
   }
 
-  struct RemoteSymbol {
-    let addr: UInt64?
-    let name: String
-    init(_ name: String, _ symbolCache: SymbolCache) {
-      self.name = name
-      if let symbolRange = symbolCache.address(of: name) {
-        self.addr = symbolRange.start
-      } else {
-        self.addr = nil
-      }
-    }
-  }
-
   // We call mmap/munmap in the remote process to alloc/free memory for our own
   // use without impacting existing allocations in the remote process.
   lazy var mmapSymbol: RemoteSymbol = RemoteSymbol("mmap", self.symbolCache)

--- a/tools/swift-inspect/Sources/swift-inspect/Backtrace.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/Backtrace.swift
@@ -18,10 +18,10 @@ internal enum BacktraceStyle {
 }
 
 internal func backtrace(_ stack: [swift_reflection_ptr_t], style: BacktraceStyle,
-                        _ symbolicate: (swift_addr_t) -> (module: String?, symbol: String?)) -> String {
+                        _ symbolicate: (swift_addr_t) -> (module: String?, symbol: String?, offset: Int?)) -> String {
   func entry(_ address: swift_reflection_ptr_t) -> String {
-    let (module, symbol) = symbolicate(swift_addr_t(address))
-    return "\(hex: address) (\(module ?? "<unknown>")) \(symbol ??  "<unknown>")"
+    let (module, symbol, offset) = symbolicate(swift_addr_t(address))
+    return "\(hex: address) (\(module ?? "<unknown>")) \(symbol ??  "<unknown>") \(offset.map { "+ \($0)" })"
   }
 
   // The pointers to the locations in the backtrace are stored from deepest to

--- a/tools/swift-inspect/Sources/swift-inspect/DarwinRemoteProcess.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/DarwinRemoteProcess.swift
@@ -212,12 +212,12 @@ internal final class DarwinRemoteProcess: RemoteProcess {
     })
   }
 
-  func symbolicate(_ address: swift_addr_t) -> (module: String?, symbol: String?) {
+  func symbolicate(_ address: swift_addr_t) -> (module: String?, symbol: String?, offset: Int?) {
     let symbol =
         CSSymbolicatorGetSymbolWithAddressAtTime(self.symbolicator.value, address, kCSNow)
 
     let module = CSSymbolGetSymbolOwner(symbol)
-    return (CSSymbolOwnerGetName(module), CSSymbolGetName(symbol))
+    return (CSSymbolOwnerGetName(module), CSSymbolGetName(symbol), nil)
   }
 
   internal func iterateHeap(_ body: (swift_addr_t, UInt64) -> Void) {

--- a/tools/swift-inspect/Sources/swift-inspect/LinuxRemoteProcess.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/LinuxRemoteProcess.swift
@@ -124,7 +124,7 @@
       self.context = context
     }
 
-    func symbolicate(_ address: swift_addr_t) -> (module: String?, symbol: String?) {
+    func symbolicate(_ address: swift_addr_t) -> (module: String?, symbol: String?, offset: Int?) {
       let moduleName: String?
       let symbolName: String?
       if let symbol = self.symbolCache.symbol(for: address) {
@@ -148,7 +148,7 @@
         moduleBaseName = moduleName
       }
 
-      return (moduleBaseName, symbolName)
+      return (moduleBaseName, symbolName, nil)
     }
 
     internal func iterateHeap(_ body: (swift_addr_t, UInt64) -> Void) {
@@ -157,6 +157,10 @@
 
     internal func iteratePotentialMetadataPages(_ body: (swift_addr_t, UInt64) -> Void) {
       fatalError("metadata page iteration is not supported on Linux")
+    }
+
+    var currentTasks: [(threadID: UInt64, currentTask: swift_addr_t)] {
+      fatalError("thread task pointer lookup is not supported on Linux")
     }
   }
 #endif  // os(Linux)

--- a/tools/swift-inspect/Sources/swift-inspect/LinuxRemoteProcess.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/LinuxRemoteProcess.swift
@@ -11,7 +11,11 @@
 //===----------------------------------------------------------------------===//
 
 #if os(Linux) || os(Android)
+  #if canImport(FoundationEssentials)
+  import FoundationEssentials
+  #else
   import Foundation
+  #endif
   import SwiftInspectLinux
   import SwiftRemoteMirror
 
@@ -26,6 +30,24 @@
 
     let memoryMap: SwiftInspectLinux.MemoryMap
     let symbolCache: SwiftInspectLinux.SymbolCache
+
+    /// A symbol resolved (lazily) against the target process's symbol cache.
+    /// `addr` is `nil` when the symbol isn't found.
+    struct RemoteSymbol {
+      let addr: UInt64?
+      let name: String
+      init(_ name: String, _ symbolCache: SwiftInspectLinux.SymbolCache) {
+        self.name = name
+        if let symbolRange = symbolCache.address(of: name) {
+          self.addr = symbolRange.start
+        } else {
+          self.addr = nil
+        }
+      }
+    }
+
+    lazy var swiftTaskGetCurrentSymbol: RemoteSymbol =
+      RemoteSymbol("swift_task_getCurrent", self.symbolCache)
 
     static var QueryDataLayout: QueryDataLayoutFunction {
       return { (context, type, _, output) in
@@ -112,7 +134,10 @@
         self.symbolCache = try SwiftInspectLinux.SymbolCache(for: process)
         self.memoryMap = try SwiftInspectLinux.MemoryMap(for: processId)
       } catch {
-        fatalError("failed initialization for process \(processId): \(error)")
+        if case SwiftInspectLinux.Process.ProcessError.processVmReadFailure = error {
+          Self.warnAboutMissingPtraceCapabilityOnce()
+        }
+        warn("failed to attach to process \(processId): \(error)")
         return nil
       }
 
@@ -127,17 +152,21 @@
     func symbolicate(_ address: swift_addr_t) -> (module: String?, symbol: String?, offset: Int?) {
       let moduleName: String?
       let symbolName: String?
+      let symbolOffset: Int?
       if let symbol = self.symbolCache.symbol(for: address) {
         moduleName = symbol.module
         symbolName = symbol.name
+        symbolOffset = Int(address &- symbol.start)
       } else if let mapEntry = memoryMap.findEntry(containing: address) {
         // found no name for the symbol, but there is a memory region containing
         // the address so use its name as the module name
         moduleName = mapEntry.pathname
         symbolName = nil
+        symbolOffset = Int(address &- mapEntry.startAddr)
       } else {
         moduleName = nil
         symbolName = nil
+        symbolOffset = nil
       }
 
       // return only the basename of the module path to keep callstacks brief
@@ -148,19 +177,203 @@
         moduleBaseName = moduleName
       }
 
-      return (moduleBaseName, symbolName, nil)
+      return (moduleBaseName, symbolName, symbolOffset)
     }
 
     internal func iterateHeap(_ body: (swift_addr_t, UInt64) -> Void) {
-      fatalError("heap iteration is not supported on Linux")
+      // Conservative, pointer-aligned scan of every anonymous, readable +
+      // writable, private mapping in the target's address space. 
+      // 
+      // There is no glibc API equivalent to Darwin's `task_enumerate_malloc_blocks`
+      // or Android's `malloc_iterate`, so we cannot ask the allocator for
+      // the live-allocation list like those platforms do.
+      //
+      // Instead, we scan the entire heap where Swift heap objects might possibly be located.
+      //
+      // Cheap pre-filter: read each region locally in 1 MiB chunks, and
+      // only pass through those where the first word looks like a userspace
+      // pointer (>= 0x1000 - all metadata pointers live well above).
+      // This drops body() calls for words holding 0, small ints, or other
+      // non-pointer payloads.
+      let pointerSize = MemoryLayout<UInt>.size
+      let chunkBytes: UInt64 = 1 << 20  // 1 MiB
+      let leastValid: UInt = 0x1000
+
+      for entry in memoryMap.entries where entry.isLikelyHeapRegion() {
+        var addr = entry.startAddr
+        while addr < entry.endAddr {
+          let toRead = min(chunkBytes, entry.endAddr - addr)
+          guard
+            let words: [UInt] = try? process.readArray(
+              address: addr, upToCount: UInt(toRead) / UInt(pointerSize)),
+            !words.isEmpty
+          else {
+            // The mapping vanished or contains a hole we can't read, move on.
+            break
+          }
+          for (i, firstWord) in words.enumerated() {
+            // The word *value* is what its metadata pointer would be.
+            guard firstWord >= leastValid else {
+              // The word definitely won't contain a metadata pointer
+              continue
+            }
+
+            // There's chance this contains a metadata pointer.
+            let candidateObject = addr + UInt64(i * pointerSize)
+            body(swift_addr_t(candidateObject), 0)
+          }
+          addr += UInt64(words.count * pointerSize)
+        }
+      }
     }
 
     internal func iteratePotentialMetadataPages(_ body: (swift_addr_t, UInt64) -> Void) {
-      fatalError("metadata page iteration is not supported on Linux")
+      func readWord(_ name: String) -> UInt? {
+        guard let (addr, _) = symbolCache.address(of: name),
+              let bytes: [UInt] = try? process.readArray(address: addr, upToCount: 1)
+        else { return nil }
+        return bytes.first
+      }
+      guard let initialPoolPointer = readWord("_swift_debug_allocationPoolPointer"),
+            let initialPoolSize = readWord("_swift_debug_allocationPoolSize")
+      else { return }
+      body(swift_addr_t(initialPoolPointer), UInt64(initialPoolSize))
     }
 
     var currentTasks: [(threadID: UInt64, currentTask: swift_addr_t)] {
-      fatalError("thread task pointer lookup is not supported on Linux")
+      guard let getCurrentAddr = swiftTaskGetCurrentSymbol.addr else {
+        return []
+      }
+
+      // ptrace.jump which we're about to use needs PTRACE_ATTACH.
+      // That requires either CAP_SYS_PTRACE, OR ptrace_scope=0 (which
+      // makes same-UID enough) -- if we don't have either, bail out.
+      guard Self.hasPtraceCapability || Self.yamaPtraceScope == 0 else {
+        Self.warnAboutMissingPtraceCapabilityOnce()
+        return []
+      }
+
+      // Each kernel thread of the target has its own directory under
+      // /proc/<pid>/task/<tid>. Linux ptrace operates per-thread, and a tid
+      // can be passed everywhere a `pid_t` is accepted.
+      let taskDir = "/proc/\(self.processIdentifier)/task"
+      guard let entries = try? FileManager.default.contentsOfDirectory(atPath: taskDir) else {
+        return []
+      }
+      let tids = entries.compactMap { pid_t($0) }
+
+      var result: [(threadID: UInt64, currentTask: swift_addr_t)] = []
+      for tid in tids {
+        do {
+          // We ptrace the thread and invoke `swift_task_getCurrent`
+          // to easily get the "current" task executing on it.
+          try withPTracedProcess(pid: tid) { ptrace in
+            let value = try ptrace.jump(to: getCurrentAddr)
+            result.append((threadID: UInt64(tid), currentTask: swift_addr_t(value)))
+          }
+        } catch {
+          // Best-effort: a thread may be exiting, may already be ptraced
+          // (e.g. by a debugger), or may be in an uninterruptible state.
+          // Skip it rather than fail the whole dump.
+          continue
+        }
+      }
+      return result
+    }
+
+    /// True iff this swift-inspect process has CAP_SYS_PTRACE capability.
+    static let hasPtraceCapability: Bool = {
+      guard let status = try? String(
+        contentsOfFile: "/proc/self/status", encoding: .utf8)
+      else { return false }
+      for line in status.split(whereSeparator: { $0.isNewline }) {
+        let CapEff = "CapEff:"
+        guard line.hasPrefix(CapEff) else { continue }
+
+        let hex = line.dropFirst(CapEff.count)
+          .trimmingCharacters(in: .whitespaces)
+        guard let mask = UInt64(hex, radix: 16) else { return false }
+
+        // CAP_SYS_PTRACE is 19.
+        return (mask & (UInt64(1) << 19)) != 0
+      }
+      return false
+    }()
+
+    /// `kernel.yama.ptrace_scope`:
+    ///   - 0 = anyone same-UID,
+    ///   - 1 = ancestors only,
+    ///   - 2 = CAP_SYS_PTRACE only,
+    ///   - 3 = ptrace disabled.
+    /// Defaults to 1 on most distributions.
+    static let yamaPtraceScope: Int? = {
+      guard let raw = try? String(
+        contentsOfFile: "/proc/sys/kernel/yama/ptrace_scope", encoding: .utf8)
+      else { return nil }
+      return Int(raw.trimmingCharacters(in: .whitespacesAndNewlines))
+    }()
+
+    /// Access this property to print the missing-capability warning exactly once.
+    /// Any use of process_vm_readv or ptrace needs these permissions.
+    private static let _warnAboutMissingPtraceCapabilityOnce: Void = {
+      let cap = hasPtraceCapability ? "yes" : "no"
+      let yama = yamaPtraceScope.map { String($0) } ?? "?"
+      warn("""
+        cannot inspect target - insufficient ptrace permission.
+          CAP_SYS_PTRACE: \(cap)
+          kernel.yama.ptrace_scope: \(yama)  (0=any same-UID, 1=ancestors only, 2=CAP_SYS_PTRACE only)
+
+        To grant necessary permissions, you can:
+          * run swift-inspect as root, or via sudo
+          * sudo setcap cap_sys_ptrace+ep <path-to-swift-inspect>
+          * sudo sysctl -w kernel.yama.ptrace_scope=0 (not recommended, system-wide)
+
+        When using containers, you may need to pass:
+          --cap-add=SYS_PTRACE --security-opt seccomp=unconfined
+        and run as root inside the container, OR grant file caps with
+        setcap. (Docker's --cap-add only adds to the bounding/permitted
+        sets; effective caps for non-root container UIDs need file caps.)
+        """)
+    }()
+
+    private static func warnAboutMissingPtraceCapabilityOnce() {
+      _ = _warnAboutMissingPtraceCapabilityOnce
+    }
+  }
+
+  extension SwiftInspectLinux.MemoryMap.Entry {
+    /// Heuristic for "this region might contain Swift heap objects".
+    ///
+    /// We require `r` and `w` permissions and `p` (private). Heap pages are
+    /// never executable on modern Linux, but we don't filter `x` away here -
+    /// some allocators (jemalloc with sampling, etc.) may legitimately
+    /// mmap rwx pages, and in the conservative-scan model an extra region
+    /// just adds cost, not incorrect results.
+    public func isLikelyHeapRegion() -> Bool {
+      // Permissions string is "rwxp" / "rw-p" / etc.
+      guard permissions.count >= 4 else {
+        return false
+      }
+
+      let i = permissions.startIndex
+      guard permissions[i] == "r",
+            permissions[permissions.index(after: i)] == "w",
+            permissions[permissions.index(i, offsetBy: 3)] == "p"
+      else { return false }
+
+      switch pathname {
+      case nil:
+        // Pure anonymous mapping - likely allocator-backed.
+        return true
+      case "[heap]"?:
+        return true
+      case let p? where p.hasPrefix("[anon:"):
+        // glibc-named anonymous arenas, e.g. jemalloc.
+        return true
+      default:
+        // Ignore other kinds, Swift heap objects won't be in them.
+        return false
+      }
     }
   }
 #endif  // os(Linux)

--- a/tools/swift-inspect/Sources/swift-inspect/Operations/DumpArray.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/Operations/DumpArray.swift
@@ -28,7 +28,7 @@ internal struct DumpArrays: ParsableCommand {
       process.iterateHeap { (allocation, size) in
         let metadata: UInt =
             swift_reflection_metadataForObject(process.context, UInt(allocation))
-        if metadata == 0 { return }
+        if metadata == 0 || metadata == .max { return }
 
         guard process.context.isContiguousArray(swift_reflection_ptr_t(metadata)) else {
           return

--- a/tools/swift-inspect/Sources/swift-inspect/Operations/DumpConcurrency.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/Operations/DumpConcurrency.swift
@@ -10,8 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if !os(Linux)
-
 import ArgumentParser
 import SwiftRemoteMirror
 #if canImport(string_h)
@@ -19,6 +17,10 @@ import string_h
 #endif
 #if canImport(ucrt)
 import ucrt
+#elseif canImport(Glibc)
+import Glibc
+#elseif canImport(Android)
+import Android
 #endif
 
 struct DumpConcurrency: ParsableCommand {
@@ -475,5 +477,3 @@ fileprivate class ConcurrencyDumper {
     }
   }
 }
-
-#endif

--- a/tools/swift-inspect/Sources/swift-inspect/Operations/DumpConcurrency.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/Operations/DumpConcurrency.swift
@@ -12,6 +12,9 @@
 
 import ArgumentParser
 import SwiftRemoteMirror
+#if canImport(Glibc)
+import Glibc
+#endif
 #if canImport(string_h)
 import string_h
 #endif

--- a/tools/swift-inspect/Sources/swift-inspect/Operations/DumpConcurrency.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/Operations/DumpConcurrency.swift
@@ -12,9 +12,6 @@
 
 import ArgumentParser
 import SwiftRemoteMirror
-#if canImport(Glibc)
-import Glibc
-#endif
 #if canImport(string_h)
 import string_h
 #endif

--- a/tools/swift-inspect/Sources/swift-inspect/RemoteProcess.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/RemoteProcess.swift
@@ -41,9 +41,11 @@ internal protocol RemoteProcess: AnyObject {
   static var GetStringLength: GetStringLengthFunction { get }
   static var GetSymbolAddress: GetSymbolAddressFunction { get }
 
-  func symbolicate(_ address: swift_addr_t) -> (module: String?, symbol: String?)
+  func symbolicate(_ address: swift_addr_t) -> (module: String?, symbol: String?, offset: Int?)
   func iterateHeap(_ body: (swift_addr_t, UInt64) -> Void)
   func iteratePotentialMetadataPages(_ body: (swift_addr_t, UInt64) -> Void)
+
+  var currentTasks: [(threadID: UInt64, currentTask: swift_addr_t)] { get }
 }
 
 extension RemoteProcess {

--- a/tools/swift-inspect/Sources/swift-inspect/RemoteProcess.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/RemoteProcess.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import Foundation
 import SwiftRemoteMirror
 
 internal protocol RemoteProcess: AnyObject {
@@ -60,4 +61,8 @@ extension RemoteProcess {
   internal func release() {
     Unmanaged.passUnretained(self).release()
   }
+}
+
+internal func warn(_ message: String) {
+  FileHandle.standardError.write(Data("swift-inspect: \(message)\n".utf8))
 }

--- a/tools/swift-inspect/Sources/swift-inspect/WindowsRemoteProcess.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/WindowsRemoteProcess.swift
@@ -422,19 +422,52 @@ internal final class WindowsRemoteProcess: RemoteProcess {
       throw _Win32Error(functionName: "GetProcAddress", error: GetLastError())
     }
 
+    enum InvalidPEError: Error, CustomStringConvertible {
+      case invalidDosSignature(WORD)
+      case invalidNtSignature(DWORD)
+      case missingTLSDirectoryEntry(numberOfRvaAndSizes: DWORD)
+      case emptyTLSDirectory
+
+      var description: String {
+        switch self {
+        case .invalidDosSignature(let m):
+          return "invalid DOS signature 0x\(String(m, radix: 16)), expected IMAGE_DOS_SIGNATURE (\"MZ\")"
+        case .invalidNtSignature(let s):
+          return "invalid NT signature 0x\(String(s, radix: 16)), expected IMAGE_NT_SIGNATURE (\"PE00\")"
+        case .missingTLSDirectoryEntry(let n):
+          return "PE has no TLS data directory entry (NumberOfRvaAndSizes=\(n) <= 9)"
+        case .emptyTLSDirectory:
+          return "PE TLS data directory entry is empty (VirtualAddress=0)"
+        }
+      }
+    }
+
     func getTlsDirectoryIndex(module: HMODULE) throws -> (index: DWORD, size: SIZE_T) {
       let base = UInt64(UInt(bitPattern: module))
       let dos = try pointee(base, as: IMAGE_DOS_HEADER.self)
 
-      precondition(dos.e_magic == IMAGE_DOS_SIGNATURE)
+      guard dos.e_magic == IMAGE_DOS_SIGNATURE else {
+        throw InvalidPEError.invalidDosSignature(dos.e_magic)
+      }
 
       let nt = try pointee(base + UInt64(dos.e_lfanew), as: IMAGE_NT_HEADERS.self)
 
-      precondition(nt.Signature == IMAGE_NT_SIGNATURE)
+      guard nt.Signature == IMAGE_NT_SIGNATURE else {
+        let err = InvalidPEError.invalidNtSignature(nt.Signature)
+        warn("\(err)")
+        throw err
+      }
 
-      // IMAGE_DIRECTORY_ENTRY_TLS == 9
+      // Ensure we have IMAGE_DIRECTORY_ENTRY_TLS == 9 available.
+      guard nt.OptionalHeader.NumberOfRvaAndSizes > 9 else {
+        throw InvalidPEError.missingTLSDirectoryEntry(
+          numberOfRvaAndSizes: nt.OptionalHeader.NumberOfRvaAndSizes)
+      }
+
       let tlsDirRVA = nt.OptionalHeader.DataDirectory.9.VirtualAddress
-      precondition(tlsDirRVA != 0, "No TLS directory found")
+      guard tlsDirRVA != 0 else {
+        throw InvalidPEError.emptyTLSDirectory
+      }
 
       let tls = try pointee(base + UInt64(tlsDirRVA), as: IMAGE_TLS_DIRECTORY64.self)
 

--- a/tools/swift-inspect/Sources/swift-inspect/main.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/main.swift
@@ -122,9 +122,11 @@ internal func inspect(options: UniversalOptions,
 
 @main
 internal struct SwiftInspect: ParsableCommand {
-  // DumpArrays and DumpConcurrency cannot be reliably be ported outside of
-  // Darwin due to the need to iterate the heap.
-#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+  // DumpArrays and DumpConcurrency cannot be easily be ported outside of
+  // Darwin and Windows due to the need to iterate the heap and find the
+  // offsets of thread-local-storage variables in process memory to find
+  // threads' Swift task pointers.
+#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS) || os(visionOS) || os(Windows)
   static let subcommands: [ParsableCommand.Type] = [
     DumpConformanceCache.self,
     DumpRawMetadata.self,
@@ -133,7 +135,7 @@ internal struct SwiftInspect: ParsableCommand {
     DumpArrays.self,
     DumpConcurrency.self,
   ]
-#elseif os(Windows) || os(Android)
+#elseif os(Android)
   static let subcommands: [ParsableCommand.Type] = [
     DumpConformanceCache.self,
     DumpRawMetadata.self,

--- a/tools/swift-inspect/Sources/swift-inspect/main.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/main.swift
@@ -122,10 +122,6 @@ internal func inspect(options: UniversalOptions,
 
 @main
 internal struct SwiftInspect: ParsableCommand {
-  // DumpArrays and DumpConcurrency cannot be easily be ported outside of
-  // Darwin and Windows due to the need to iterate the heap and find the
-  // offsets of thread-local-storage variables in process memory to find
-  // threads' Swift task pointers.
 #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS) || os(visionOS) || os(Windows)
   static let subcommands: [ParsableCommand.Type] = [
     DumpConformanceCache.self,
@@ -142,6 +138,14 @@ internal struct SwiftInspect: ParsableCommand {
     DumpGenericMetadata.self,
     DumpCacheNodes.self,
     DumpArrays.self,
+  ]
+#elseif os(Linux)
+  static let subcommands: [ParsableCommand.Type] = [
+    DumpConformanceCache.self,
+    DumpRawMetadata.self,
+    DumpGenericMetadata.self,
+    DumpCacheNodes.self,
+    DumpConcurrency.self,
   ]
 #else
   static let subcommands: [ParsableCommand.Type] = [

--- a/tools/swift-inspect/Tests/swiftInspectTests/SwiftInspectLinuxTests.swift
+++ b/tools/swift-inspect/Tests/swiftInspectTests/SwiftInspectLinuxTests.swift
@@ -1,0 +1,120 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if os(Linux)
+import XCTest
+import Glibc
+@testable import SwiftInspectLinux
+
+final class SwiftInspectLinuxTests: XCTestCase {
+
+  /// A representative `/proc/<pid>/maps` excerpt.
+  static let sampleMaps = """
+    55c4d3f3f000-55c4d3f44000 r--p 00000000 fd:01 1234567 /usr/bin/cat
+    55c4d3f44000-55c4d3f4c000 r-xp 00005000 fd:01 1234567 /usr/bin/cat
+    55c4d3f4c000-55c4d3f4f000 r--p 0000d000 fd:01 1234567 /usr/bin/cat
+    55c4d3f4f000-55c4d3f50000 rw-p 0000f000 fd:01 1234567 /usr/bin/cat
+    55c4d4111000-55c4d4132000 rw-p 00000000 00:00 0       [heap]
+    7f1234560000-7f1234570000 rw-p 00000000 00:00 0
+    7f1234570000-7f1234580000 rw-p 00000000 00:00 0       [anon:libc_malloc]
+    7ffe1abcd000-7ffe1abef000 rw-p 00000000 00:00 0       [stack]
+    7ffe1abf0000-7ffe1abf3000 r--p 00000000 00:00 0       [vvar]
+    7ffe1abf3000-7ffe1abf5000 r-xp 00000000 00:00 0       [vdso]
+    """
+
+  func testMemoryMapParse() {
+    let map = MemoryMap(parsing: SwiftInspectLinuxTests.sampleMaps)
+    XCTAssertEqual(map.entries.count, 10)
+
+    let heap = map.entries.first { $0.pathname == "[heap]" }
+    XCTAssertNotNil(heap)
+    XCTAssertEqual(heap?.startAddr, 0x55c4_d411_1000)
+    XCTAssertEqual(heap?.endAddr, 0x55c4_d413_2000)
+    XCTAssertEqual(heap?.permissions, "rw-p")
+
+    // Anonymous mapping (no pathname column) parses as nil pathname.
+    let anon = map.entries.first { $0.startAddr == 0x7f12_3456_0000 }
+    XCTAssertNotNil(anon)
+    XCTAssertNil(anon?.pathname)
+
+    // Labeled-anonymous mapping keeps its label.
+    let anonLabeled = map.entries.first { $0.pathname == "[anon:libc_malloc]" }
+    XCTAssertNotNil(anonLabeled)
+  }
+
+  func testMemoryMapFindEntry() {
+    let map = MemoryMap(parsing: SwiftInspectLinuxTests.sampleMaps)
+
+    // Inside the heap range.
+    let heapHit = map.findEntry(containing: 0x55c4_d411_5000)
+    XCTAssertEqual(heapHit?.pathname, "[heap]")
+
+    // Right before the heap (still inside the rw-p data segment of /usr/bin/cat).
+    let beforeHeap = map.findEntry(containing: 0x55c4_d3f4_f100)
+    XCTAssertEqual(beforeHeap?.pathname, "/usr/bin/cat")
+
+    // In a hole between mapped regions.
+    let hole = map.findEntry(containing: 0x6000_0000_0000)
+    XCTAssertNil(hole)
+
+    // Boundary: endAddr is exclusive.
+    let atEndAddr = map.findEntry(containing: 0x55c4_d413_2000)
+    XCTAssertNotEqual(atEndAddr?.pathname, "[heap]")
+  }
+
+  // ==== -----------------------------------------------------------------
+  // MARK: isLikelyHeapRegion heuristic
+
+  /// Helper: synthesize a `MemoryMap.Entry` for an isolated unit test.
+  private func entry(_ permissions: String, _ pathname: String?) -> MemoryMap.Entry {
+    return MemoryMap.Entry(
+      startAddr: 0x1000, endAddr: 0x2000,
+      permissions: permissions, offset: 0,
+      device: "00:00", inode: 0, pathname: pathname)
+  }
+
+  func testIsLikelyHeapRegion_includesHeapAndAnonymous() {
+    XCTAssertTrue(entry("rw-p", "[heap]").isLikelyHeapRegion())
+    XCTAssertTrue(entry("rw-p", nil).isLikelyHeapRegion())
+    XCTAssertTrue(entry("rw-p", "[anon:libc_malloc]").isLikelyHeapRegion())
+    XCTAssertTrue(entry("rw-p", "[anon:scudo:primary]").isLikelyHeapRegion())
+    // rwxp is unusual but we keep it (jemalloc sampling, GWP-ASan, etc.).
+    XCTAssertTrue(entry("rwxp", nil).isLikelyHeapRegion())
+  }
+
+  func testIsLikelyHeapRegion_excludesStackAndKernelRegions() {
+    XCTAssertFalse(entry("rw-p", "[stack]").isLikelyHeapRegion())
+    XCTAssertFalse(entry("rw-p", "[stack:1234]").isLikelyHeapRegion())
+    XCTAssertFalse(entry("r--p", "[vvar]").isLikelyHeapRegion())
+    XCTAssertFalse(entry("r-xp", "[vdso]").isLikelyHeapRegion())
+    XCTAssertFalse(entry("--xp", "[vsyscall]").isLikelyHeapRegion())
+  }
+
+  func testIsLikelyHeapRegion_excludesFileBacked() {
+    XCTAssertFalse(entry("rw-p", "/usr/bin/cat").isLikelyHeapRegion())
+    XCTAssertFalse(entry("rw-p", "/lib/x86_64-linux-gnu/libc.so.6").isLikelyHeapRegion())
+  }
+
+  func testIsLikelyHeapRegion_requiresReadWritePrivate() {
+    // No read.
+    XCTAssertFalse(entry("-w-p", "[heap]").isLikelyHeapRegion())
+    // No write - this is a code segment, not heap.
+    XCTAssertFalse(entry("r--p", "[heap]").isLikelyHeapRegion())
+    // Shared mapping - Swift's heap is private.
+    XCTAssertFalse(entry("rw-s", nil).isLikelyHeapRegion())
+    // Empty / malformed permissions string.
+    XCTAssertFalse(entry("", nil).isLikelyHeapRegion())
+    XCTAssertFalse(entry("rw", nil).isLikelyHeapRegion())
+  }
+
+}
+#endif  // os(Linux)


### PR DESCRIPTION
**Explanation**: 
This picks commits necessary for swift-inspect dump-concurrency to work on Windows and Linux to 6.4 branch.

Changes are limited to swift-inspect on those platforms, so should be low risk to accept these.

**Risk**: 
Low, only adds functionality to what previously would not work at all; no impact on existing functionality

**Testing**: 
- CI testing
- Manually verified Linux 

**Original PRs**:
- https://github.com/swiftlang/swift/pull/83388 - prep work and Windows
- https://github.com/swiftlang/swift/pull/89906 - fixup to Android build
- https://github.com/swiftlang/swift/pull/89789 - actual impl

**Reviewed by**:
- @mikeash 
- @al45tair 

**Issues**: 
- Resolves TBD