### PR TITLE
[rbi][docs] Clarify isolation-history overview wording

### DIFF
--- a/userdocs/diagnostics/region-isolation-isolation-history.md
+++ b/userdocs/diagnostics/region-isolation-isolation-history.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The region-based isolation checker tracks values using regions, conservative approximations of object graphs. When a value is sent across an isolation boundary and that send risks a data race, the primary diagnostic explains *what* was sent and *where*. The isolation-history notes in this group explain *why* the sent value is considered isolated to a particular concurrency domain — that is, how the value came to be merged into an isolated region.
+The region-based isolation checker tracks values using regions, conservative approximations of object graphs. When a value is sent across an isolation boundary and that send risks a data race, the primary diagnostic explains *what* was sent and *where*. The isolation-history notes in this group explain *why* the sent value is considered isolated to a particular concurrency domain — that is, how the value came to be considered to be in the same object graph as a value that is isolated to said concurrency domain.
 
 A typical isolation-history explanation is a chain of "X is connected to Y" notes, anchored at each named intermediate's declaration, terminating in an "originating" note at the merge that brought the sent value into an isolated region. These notes make it possible to reconstruct the merge history by following the chain backward from the value at the point of send.
 
@@ -10,4 +10,4 @@ We say "connected" because the region-based isolation checker reasons over regio
 
 Isolation-history notes are opt-in and are enabled by applying the `@diagnose(RegionIsolationIsolationHistory, as: warning)` attribute to the function. This opts that single function in to history-note emission.
 
-When neither opt-in is active, only the primary `SendingRisksDataRace` (or related) diagnostic is emitted; the auxiliary history notes are suppressed.
+When the opt-in is not active, only the primary `SendingRisksDataRace` (or related) diagnostic is emitted; the auxiliary history notes are suppressed.

--- a/userdocs/diagnostics/region-isolation-isolation-history.md
+++ b/userdocs/diagnostics/region-isolation-isolation-history.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The region-based isolation checker tracks values using regions, conservative approximations of object graphs. When a value is sent across an isolation boundary and that send risks a data race, the primary diagnostic explains *what* was sent and *where*. The isolation-history notes in this group explain *why* the sent value is considered isolated to a particular concurrency domain — that is, how the value came to be considered to be in the same object graph as a value that is isolated to said concurrency domain.
+The region-based isolation checker tracks values using "regions", which are conservative approximations of object graphs. When a value is sent across an isolation boundary and that send risks a data race, the primary diagnostic explains *what* was sent and *where*. The isolation-history notes in this group explain *why* the sent value is considered isolated to a particular concurrency domain — that is, how the value came to be considered to be in the same object graph as a value that is isolated to said concurrency domain.
 
 A typical isolation-history explanation is a chain of "X is connected to Y" notes, anchored at each named intermediate's declaration, terminating in an "originating" note at the merge that brought the sent value into an isolated region. These notes make it possible to reconstruct the merge history by following the chain backward from the value at the point of send.
 


### PR DESCRIPTION
Reword the "what isolation history explains" sentence to be more precise: rather than describing the merge in terms of "how the value came to be merged into an isolated region", describe it as "how the value came to be considered to be in the same object graph as a value isolated to that domain". This matches the region-based reasoning the checker actually performs.

Also drop the dangling "neither opt-in is active" phrasing — there is only one opt-in mechanism documented, so say "the opt-in" directly.
