### PR TITLE
[rbi] Add support for per argument SILLocations for apply sites but only enable it when isolation history is enabled.

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/OptUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/OptUtils.swift
@@ -246,12 +246,18 @@ extension ApplySite {
     let builder = Builder(before: self, context)
     let calleeRef = builder.createFunctionRef(callee)
 
+    // Preserve any per-argument SILLocations stored on the original apply.
+    // The bridged Builder factories silently drop the locations when the
+    // count doesn't match the rewritten argument list (e.g., callee shape
+    // change); see SILBridgingImpl.h:getBridgedArgLocsFrom for the
+    // count-match guard.
     switch self {
     case let applyInst as ApplyInst:
       let newApply = builder.createApply(function: calleeRef,
                                          applyInst.substitutionMap,
                                          arguments: newArguments,
-                                         isNonThrowing: applyInst.isNonThrowing)
+                                         isNonThrowing: applyInst.isNonThrowing,
+                                         argumentLocationsFrom: self)
       applyInst.replace(with: newApply, context)
 
     case let partialAp as PartialApplyInst:
@@ -261,20 +267,23 @@ extension ApplySite {
                                                 calleeConvention: partialAp.calleeConvention,
                                                 hasUnknownResultIsolation: partialAp.hasUnknownResultIsolation,
                                                 isOnStack: partialAp.isOnStack,
-                                                isNested:  partialAp.isNested)
+                                                isNested:  partialAp.isNested,
+                                                argumentLocationsFrom: self)
       partialAp.replace(with: newApply, context)
 
     case let tryApply as TryApplyInst:
       builder.createTryApply(function: calleeRef,
                              tryApply.substitutionMap,
                              arguments: newArguments,
-                             normalBlock: tryApply.normalBlock, errorBlock: tryApply.errorBlock)
+                             normalBlock: tryApply.normalBlock, errorBlock: tryApply.errorBlock,
+                             argumentLocationsFrom: self)
       context.erase(instruction: tryApply)
 
     case let beginApply as BeginApplyInst:
       let newApply = builder.createBeginApply(function: calleeRef,
                                               beginApply.substitutionMap,
-                                              arguments: newArguments)
+                                              arguments: newArguments,
+                                              argumentLocationsFrom: self)
       beginApply.replace(with: newApply, context)
 
     default:

--- a/SwiftCompilerSources/Sources/SIL/ApplySite.swift
+++ b/SwiftCompilerSources/Sources/SIL/ApplySite.swift
@@ -197,6 +197,30 @@ extension ApplySite {
     argumentOperands.values
   }
 
+  /// Returns true when this apply has per-argument SILLocations stored on it.
+  ///
+  /// Per-argument locations are reserved today for the IsolationHistory
+  /// diagnostic feature: they are filled in by SILGen for functions opted
+  /// in to isolation-history (frontend flag or
+  /// `@diagnose(RegionIsolationIsolationHistory, ...)`). Other producers do
+  /// not currently fill them in. See `getArgumentLocation(operand:)` for the
+  /// anchor-fallback semantics callers should rely on.
+  public var hasArgumentLocations: Bool {
+    bridged.ApplySite_hasArgumentLocations()
+  }
+
+  /// Returns the SILLocation associated with the given apply argument
+  /// operand. Falls back to the apply's anchor location when no
+  /// per-argument override has been stored, so callers that don't need to
+  /// distinguish stored-vs-anchor can use this directly.
+  ///
+  /// `operand` must be one of this apply's argument operands (i.e., come
+  /// from `argumentOperands`); it must not be the callee operand or a
+  /// type-dependent operand.
+  public func getArgumentLocation(operand: Operand) -> Location {
+    Location(bridged: bridged.ApplySite_getArgumentLocation(operand.bridged))
+  }
+
   /// Indirect results including the error result.
   public var indirectResultOperands: OperandArray {
     let ops = operandConventions

--- a/SwiftCompilerSources/Sources/SIL/Builder.swift
+++ b/SwiftCompilerSources/Sources/SIL/Builder.swift
@@ -503,15 +503,17 @@ public struct Builder {
     arguments: [Value],
     isNonThrowing: Bool = false,
     isNonAsync: Bool = false,
-    specializationInfo: ApplyInst.SpecializationInfo = ApplyInst.SpecializationInfo()
+    specializationInfo: ApplyInst.SpecializationInfo = ApplyInst.SpecializationInfo(),
+    argumentLocationsFrom: ApplySite? = nil
   ) -> ApplyInst {
     let apply = arguments.withBridgedValues { valuesRef in
       bridged.createApply(function.bridged, substitutionMap.bridged, valuesRef,
-                          isNonThrowing, isNonAsync, specializationInfo)
+                          isNonThrowing, isNonAsync, specializationInfo,
+                          argumentLocationsFrom.bridged)
     }
     return notifyNew(apply.getAs(ApplyInst.self))
   }
-  
+
   @discardableResult
   public func createTryApply(
     function: Value,
@@ -520,26 +522,30 @@ public struct Builder {
     normalBlock: BasicBlock,
     errorBlock: BasicBlock,
     isNonAsync: Bool = false,
-    specializationInfo: ApplyInst.SpecializationInfo = ApplyInst.SpecializationInfo()
+    specializationInfo: ApplyInst.SpecializationInfo = ApplyInst.SpecializationInfo(),
+    argumentLocationsFrom: ApplySite? = nil
   ) -> TryApplyInst {
     let apply = arguments.withBridgedValues { valuesRef in
       bridged.createTryApply(function.bridged, substitutionMap.bridged, valuesRef,
                              normalBlock.bridged, errorBlock.bridged,
-                             isNonAsync, specializationInfo)
+                             isNonAsync, specializationInfo,
+                             argumentLocationsFrom.bridged)
     }
     return notifyNew(apply.getAs(TryApplyInst.self))
   }
-  
+
   public func createBeginApply(function: Value,
                                _ substitutionMap: SubstitutionMap,
                                arguments: [Value],
                                isNonThrowing: Bool = false,
                                isNonAsync: Bool = false,
-                               specializationInfo: ApplyInst.SpecializationInfo = ApplyInst.SpecializationInfo()
+                               specializationInfo: ApplyInst.SpecializationInfo = ApplyInst.SpecializationInfo(),
+                               argumentLocationsFrom: ApplySite? = nil
   ) -> BeginApplyInst {
     let apply = arguments.withBridgedValues { valuesRef in
       bridged.createBeginApply(function.bridged, substitutionMap.bridged, valuesRef,
-                               isNonThrowing, isNonAsync, specializationInfo)
+                               isNonThrowing, isNonAsync, specializationInfo,
+                               argumentLocationsFrom.bridged)
     }
     return notifyNew(apply.getAs(BeginApplyInst.self))
   }
@@ -616,17 +622,19 @@ public struct Builder {
 
   public func createPartialApply(
     function: Value,
-    substitutionMap: SubstitutionMap, 
-    capturedArguments: [Value], 
-    calleeConvention: ArgumentConvention, 
-    hasUnknownResultIsolation: Bool, 
+    substitutionMap: SubstitutionMap,
+    capturedArguments: [Value],
+    calleeConvention: ArgumentConvention,
+    hasUnknownResultIsolation: Bool,
     isOnStack: Bool,
     /// If true this `partial_apply [on_stack]` must follow proper stack allocation nesting rules.
-    isNested: Bool
+    isNested: Bool,
+    argumentLocationsFrom: ApplySite? = nil
   ) -> PartialApplyInst {
     return capturedArguments.withBridgedValues { capturedArgsRef in
       let pai = bridged.createPartialApply(function.bridged, capturedArgsRef, calleeConvention.bridged,
-                                           substitutionMap.bridged, hasUnknownResultIsolation, isOnStack, isNested)
+                                           substitutionMap.bridged, hasUnknownResultIsolation, isOnStack, isNested,
+                                           argumentLocationsFrom.bridged)
       return notifyNew(pai.getAs(PartialApplyInst.self))
     }
   }

--- a/SwiftCompilerSources/Sources/SIL/Instruction.swift
+++ b/SwiftCompilerSources/Sources/SIL/Instruction.swift
@@ -319,6 +319,17 @@ extension Optional where Wrapped == Instruction {
   }
 }
 
+extension Optional where Wrapped == ApplySite {
+  /// Bridges an optional ApplySite to OptionalBridgedInstruction. Used by
+  /// the Builder.createApply / createTryApply / createBeginApply /
+  /// createPartialApply factories so they can take an optional source-apply
+  /// hint for per-argument SILLocations without forcing every caller to
+  /// materialize the bridged value themselves.
+  public var bridged: OptionalBridgedInstruction {
+    OptionalBridgedInstruction(self?.bridged.obj)
+  }
+}
+
 public class SingleValueInstruction : Instruction, Value {
   final public var definingInstruction: Instruction? { self }
 

--- a/include/swift/AST/SILOptions.h
+++ b/include/swift/AST/SILOptions.h
@@ -334,6 +334,13 @@ public:
   /// For compiler developers only.
   bool AbortOnUnknownRegionIsolationPatternError = false;
 
+  /// Emit notes explaining why a disconnected value ended up in an isolated
+  /// region, for the SendNonSendable diagnostic. When true, isolation-history
+  /// is enabled for every function in the module; when false, only functions
+  /// carrying @diagnose(RegionIsolationIsolationHistory, as: <not ignored>)
+  /// participate. Defaults to false.
+  bool EmitIsolationHistory = false;
+
   SILOptions() {}
 
   /// Return a hash code of any components from these options that should

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -1126,6 +1126,14 @@ def sil_region_isolation_assert_on_unknown_pattern :
   HelpText<"Abort if SIL region isolation detects an unknown pattern. "
            "For compiler developers only.">;
 
+def sil_region_isolation_emit_isolation_history
+    : Flag<["-"], "sil-region-isolation-emit-isolation-history">,
+      HelpText<
+          "Emit notes explaining why a disconnected value ended up in an "
+          "isolated region. Enables isolation-history for every function in "
+          "the module; otherwise, isolation-history is opt-in per function "
+          "via @diagnose(RegionIsolationIsolationHistory, ...).">;
+
 def verify_all_substitution_maps : Flag<["-"], "verify-all-substitution-maps">,
   HelpText<"Verify all SubstitutionMaps on construction">;
 

--- a/include/swift/SIL/ApplySite.h
+++ b/include/swift/SIL/ApplySite.h
@@ -334,7 +334,37 @@ public:
   unsigned getOperandIndexOfFirstArgument() const {
     FOREACH_IMPL_RETURN(getArgumentOperandNumber());
   }
+
+  /// Returns the SILLocation associated with the argument at \p argIdx,
+  /// falling back to the apply's anchor location when no per-argument
+  /// override has been stored.
+  SILLocation getArgumentLoc(unsigned argIdx) const {
+    FOREACH_IMPL_RETURN(getArgumentLoc(argIdx));
+  }
+
+  /// Set the per-argument location for the argument at \p argIdx. Requires
+  /// that the apply was constructed with per-argument location storage;
+  /// \p loc must be a valid (non-null) SILLocation.
+  void setArgumentLoc(unsigned argIdx, SILLocation loc) const {
+    FOREACH_IMPL_RETURN(setArgumentLoc(argIdx, loc));
+  }
+
+  /// Returns the per-argument SILLocations stored on this apply, parallel
+  /// to `getArguments()`. `std::nullopt` when no per-argument storage was
+  /// reserved at construction time.
+  std::optional<ArrayRef<SILLocation>> getArgumentLocs() const {
+    FOREACH_IMPL_RETURN(getArgumentLocs());
+  }
 #undef FOREACH_IMPL_RETURN
+
+  /// Returns the SILLocation associated with the apply argument referred to
+  /// by \p op, with anchor fallback. \p op must be an argument operand of
+  /// this apply (not the callee or a type-dependent operand).
+  SILLocation getArgumentLoc(const Operand *op) const {
+    assert(op->getUser() == Inst && "operand is not from this apply");
+    assert(isArgumentOperand(*op) && "operand is not an argument operand");
+    return getArgumentLoc(getAppliedArgIndex(*op));
+  }
 
   /// Returns true if \p oper is an argument operand and not the callee
   /// operand.

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -962,6 +962,9 @@ struct BridgedInstruction {
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedCanType ApplySite_getSubstitutedCalleeType() const;
   BRIDGED_INLINE SwiftInt ApplySite_getNumArguments() const;
   BRIDGED_INLINE bool ApplySite_isCalleeNoReturn() const;
+  BRIDGED_INLINE bool ApplySite_hasArgumentLocations() const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedLocation
+  ApplySite_getArgumentLocation(BridgedOperand operand) const;
   BRIDGED_INLINE SwiftInt FullApplySite_numIndirectResultArguments() const;
   BRIDGED_INLINE bool ConvertFunctionInst_withoutActuallyEscaping() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedCanType TypeValueInst_getParamType() const;
@@ -1372,20 +1375,22 @@ struct BridgedBuilder{
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedInstruction createDebugValue(BridgedValue src,
                                                                          BridgedSILDebugVariable var) const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedInstruction createDebugStep() const;
-  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedInstruction createApply(BridgedValue function,
-                                          BridgedSubstitutionMap subMap,
-                                          BridgedValueArray arguments, bool isNonThrowing, bool isNonAsync,
-                                          BridgedGenericSpecializationInformation specInfo) const;
-  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedInstruction createTryApply(BridgedValue function,
-                                          BridgedSubstitutionMap subMap,
-                                          BridgedValueArray arguments,
-                                          BridgedBasicBlock normalBB, BridgedBasicBlock errorBB,
-                                          bool isNonAsync,
-                                          BridgedGenericSpecializationInformation specInfo) const;
-  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedInstruction createBeginApply(BridgedValue function,
-                                          BridgedSubstitutionMap subMap,
-                                          BridgedValueArray arguments, bool isNonThrowing, bool isNonAsync,
-                                          BridgedGenericSpecializationInformation specInfo) const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedInstruction
+  createApply(BridgedValue function, BridgedSubstitutionMap subMap,
+              BridgedValueArray arguments, bool isNonThrowing, bool isNonAsync,
+              BridgedGenericSpecializationInformation specInfo,
+              OptionalBridgedInstruction argLocsFrom) const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedInstruction
+  createTryApply(BridgedValue function, BridgedSubstitutionMap subMap,
+                 BridgedValueArray arguments, BridgedBasicBlock normalBB,
+                 BridgedBasicBlock errorBB, bool isNonAsync,
+                 BridgedGenericSpecializationInformation specInfo,
+                 OptionalBridgedInstruction argLocsFrom) const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedInstruction createBeginApply(
+      BridgedValue function, BridgedSubstitutionMap subMap,
+      BridgedValueArray arguments, bool isNonThrowing, bool isNonAsync,
+      BridgedGenericSpecializationInformation specInfo,
+      OptionalBridgedInstruction argLocsFrom) const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedInstruction createWitnessMethod(BridgedCanType lookupType,
                                           BridgedConformance conformance,
                                           BridgedDeclRef member, BridgedType methodType) const;
@@ -1413,13 +1418,12 @@ struct BridgedBuilder{
                                           BridgedType resultType) const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedInstruction createThinToThickFunction(BridgedValue fn,
                                                                                   BridgedType resultType) const;
-  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedInstruction createPartialApply(BridgedValue fn,
-                                                                           BridgedValueArray bridgedCapturedArgs,
-                                                                           BridgedArgumentConvention calleeConvention,
-                                                                           BridgedSubstitutionMap bridgedSubstitutionMap,
-                                                                           bool hasUnknownIsolation,
-                                                                           bool isOnStack,
-                                                                           bool isNested) const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedInstruction
+  createPartialApply(BridgedValue fn, BridgedValueArray bridgedCapturedArgs,
+                     BridgedArgumentConvention calleeConvention,
+                     BridgedSubstitutionMap bridgedSubstitutionMap,
+                     bool hasUnknownIsolation, bool isOnStack, bool isNested,
+                     OptionalBridgedInstruction argLocsFrom) const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedInstruction createBranch(BridgedBasicBlock destBlock,
                                                                      BridgedValueArray arguments) const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedInstruction createCondBranch(BridgedValue condition,

--- a/include/swift/SIL/SILBridgingImpl.h
+++ b/include/swift/SIL/SILBridgingImpl.h
@@ -1923,6 +1923,21 @@ bool BridgedInstruction::ApplySite_isCalleeNoReturn() const {
   return swift::ApplySite(unbridged()).isCalleeNoReturn();
 }
 
+bool BridgedInstruction::ApplySite_hasArgumentLocations() const {
+  return swift::ApplySite(unbridged()).getArgumentLocs().has_value();
+}
+
+BridgedLocation
+BridgedInstruction::ApplySite_getArgumentLocation(BridgedOperand operand) const {
+  // ApplySite::getArgumentLoc() applies the apply-anchor fallback when no
+  // per-argument location is stored, so the Swift caller never has to
+  // distinguish present-vs-absent unless they explicitly check
+  // hasArgumentLocations() first.
+  auto as = swift::ApplySite(unbridged());
+  swift::SILLocation loc = as.getArgumentLoc(operand.op);
+  return swift::SILDebugLocation(loc, unbridged()->getDebugScope());
+}
+
 SwiftInt BridgedInstruction::FullApplySite_numIndirectResultArguments() const {
   auto fas = swift::FullApplySite(unbridged());
   return fas.getNumIndirectSILResults();
@@ -2781,44 +2796,85 @@ BridgedInstruction BridgedBuilder::createDebugStep() const {
   return {unbridged().createDebugStep(regularLoc())};
 }
 
-BridgedInstruction BridgedBuilder::createApply(BridgedValue function, BridgedSubstitutionMap subMap,
-                               BridgedValueArray arguments, bool isNonThrowing, bool isNonAsync,
-                               BridgedGenericSpecializationInformation specInfo) const {
+// Returns the per-argument SILLocations stored on \p argLocsFrom, but only
+// when their count matches \p expectedCount. Used by the bridged Builder
+// apply factories so the Swift-side `replace(withCallTo:arguments:)` helper
+// (which rebuilds an apply via SILBuilder rather than going through
+// SILCloner) can preserve per-argument SILLocations from the apply being
+// replaced. When `argLocsFrom` is null, has no per-argument storage, or
+// has a mismatched argument count (rewriter changed the shape), returns
+// std::nullopt and the new apply is constructed without per-argument
+// storage.
+static std::optional<llvm::ArrayRef<swift::SILLocation>>
+getBridgedArgLocsFrom(OptionalBridgedInstruction argLocsFrom,
+                      unsigned expectedCount) {
+  swift::SILInstruction *fromInst = argLocsFrom.unbridged();
+  if (!fromInst)
+    return std::nullopt;
+  auto fromApply = swift::ApplySite::isa(fromInst);
+  if (!fromApply)
+    return std::nullopt;
+  std::optional<llvm::ArrayRef<swift::SILLocation>> stored =
+      fromApply.getArgumentLocs();
+  if (!stored || stored->size() != expectedCount)
+    return std::nullopt;
+  return stored;
+}
+
+BridgedInstruction BridgedBuilder::createApply(
+    BridgedValue function, BridgedSubstitutionMap subMap,
+    BridgedValueArray arguments, bool isNonThrowing, bool isNonAsync,
+    BridgedGenericSpecializationInformation specInfo,
+    OptionalBridgedInstruction argLocsFrom) const {
   llvm::SmallVector<swift::SILValue, 16> argValues;
   swift::ApplyOptions applyOpts;
   if (isNonThrowing) { applyOpts |= swift::ApplyFlags::DoesNotThrow; }
   if (isNonAsync) { applyOpts |= swift::ApplyFlags::DoesNotAwait; }
 
+  llvm::ArrayRef<swift::SILValue> args = arguments.getValues(argValues);
   return {unbridged().createApply(
-      regularLoc(), function.getSILValue(), subMap.unbridged(),
-      arguments.getValues(argValues), applyOpts, specInfo.data)};
+      regularLoc(), function.getSILValue(), subMap.unbridged(), args, applyOpts,
+      specInfo.data,
+      /*isolationCrossing=*/std::nullopt,
+      getBridgedArgLocsFrom(argLocsFrom, (unsigned)args.size()))};
 }
 
-BridgedInstruction BridgedBuilder::createTryApply(BridgedValue function, BridgedSubstitutionMap subMap,
-                               BridgedValueArray arguments,
-                               BridgedBasicBlock normalBB, BridgedBasicBlock errorBB,
-                               bool isNonAsync,
-                               BridgedGenericSpecializationInformation specInfo) const {
+BridgedInstruction BridgedBuilder::createTryApply(
+    BridgedValue function, BridgedSubstitutionMap subMap,
+    BridgedValueArray arguments, BridgedBasicBlock normalBB,
+    BridgedBasicBlock errorBB, bool isNonAsync,
+    BridgedGenericSpecializationInformation specInfo,
+    OptionalBridgedInstruction argLocsFrom) const {
   llvm::SmallVector<swift::SILValue, 16> argValues;
   swift::ApplyOptions applyOpts;
   if (isNonAsync) { applyOpts |= swift::ApplyFlags::DoesNotAwait; }
 
+  llvm::ArrayRef<swift::SILValue> args = arguments.getValues(argValues);
   return {unbridged().createTryApply(
-      regularLoc(), function.getSILValue(), subMap.unbridged(),
-      arguments.getValues(argValues), normalBB.unbridged(), errorBB.unbridged(), applyOpts, specInfo.data)};
+      regularLoc(), function.getSILValue(), subMap.unbridged(), args,
+      normalBB.unbridged(), errorBB.unbridged(), applyOpts, specInfo.data,
+      /*isolationCrossing=*/std::nullopt,
+      /*normalCount=*/swift::ProfileCounter(),
+      /*errorCount=*/swift::ProfileCounter(),
+      getBridgedArgLocsFrom(argLocsFrom, (unsigned)args.size()))};
 }
 
-BridgedInstruction BridgedBuilder::createBeginApply(BridgedValue function, BridgedSubstitutionMap subMap,
-                               BridgedValueArray arguments, bool isNonThrowing, bool isNonAsync,
-                               BridgedGenericSpecializationInformation specInfo) const {
+BridgedInstruction BridgedBuilder::createBeginApply(
+    BridgedValue function, BridgedSubstitutionMap subMap,
+    BridgedValueArray arguments, bool isNonThrowing, bool isNonAsync,
+    BridgedGenericSpecializationInformation specInfo,
+    OptionalBridgedInstruction argLocsFrom) const {
   llvm::SmallVector<swift::SILValue, 16> argValues;
   swift::ApplyOptions applyOpts;
   if (isNonThrowing) { applyOpts |= swift::ApplyFlags::DoesNotThrow; }
   if (isNonAsync) { applyOpts |= swift::ApplyFlags::DoesNotAwait; }
 
+  llvm::ArrayRef<swift::SILValue> args = arguments.getValues(argValues);
   return {unbridged().createBeginApply(
-      regularLoc(), function.getSILValue(), subMap.unbridged(),
-      arguments.getValues(argValues), applyOpts, specInfo.data)};
+      regularLoc(), function.getSILValue(), subMap.unbridged(), args, applyOpts,
+      specInfo.data,
+      /*isolationCrossing=*/std::nullopt,
+      getBridgedArgLocsFrom(argLocsFrom, (unsigned)args.size()))};
 }
 
 BridgedInstruction BridgedBuilder::createWitnessMethod(BridgedCanType lookupType,
@@ -2883,23 +2939,25 @@ BridgedInstruction BridgedBuilder::createThinToThickFunction(BridgedValue fn, Br
                                                 resultType.unbridged())};
 }
 
-BridgedInstruction BridgedBuilder::createPartialApply(BridgedValue funcRef,
-                                                      BridgedValueArray bridgedCapturedArgs,
-                                                      BridgedArgumentConvention calleeConvention,
-                                                      BridgedSubstitutionMap bridgedSubstitutionMap,
-                                                      bool hasUnknownIsolation,
-                                                      bool isOnStack,
-                                                      bool isNested) const {
+BridgedInstruction BridgedBuilder::createPartialApply(
+    BridgedValue funcRef, BridgedValueArray bridgedCapturedArgs,
+    BridgedArgumentConvention calleeConvention,
+    BridgedSubstitutionMap bridgedSubstitutionMap, bool hasUnknownIsolation,
+    bool isOnStack, bool isNested,
+    OptionalBridgedInstruction argLocsFrom) const {
   llvm::SmallVector<swift::SILValue, 8> capturedArgs;
+  llvm::ArrayRef<swift::SILValue> args =
+      bridgedCapturedArgs.getValues(capturedArgs);
   return {unbridged().createPartialApply(
       regularLoc(), funcRef.getSILValue(), bridgedSubstitutionMap.unbridged(),
-      bridgedCapturedArgs.getValues(capturedArgs),
-      getParameterConvention(calleeConvention),
+      args, getParameterConvention(calleeConvention),
       hasUnknownIsolation ? swift::SILFunctionTypeIsolation::forUnknown()
                           : swift::SILFunctionTypeIsolation::forErased(),
       isOnStack ? swift::PartialApplyInst::OnStack
                 : swift::PartialApplyInst::NotOnStack,
-      swift::StackAllocationIsNested_t(isNested))};
+      swift::StackAllocationIsNested_t(isNested),
+      /*SpecializationInfo=*/nullptr,
+      getBridgedArgLocsFrom(argLocsFrom, (unsigned)args.size()))};
 }
 
 BridgedInstruction BridgedBuilder::createBranch(BridgedBasicBlock destBlock, BridgedValueArray arguments) const {

--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -559,10 +559,13 @@ public:
       SILLocation loc, SILValue callee, SubstitutionMap subs,
       ArrayRef<SILValue> args, ApplyOptions options,
       const GenericSpecializationInformation *specializationInfo = nullptr,
-      std::optional<ApplyIsolationCrossing> isolationCrossing = std::nullopt) {
-    return insert(ApplyInst::create(getSILDebugLocation(loc), callee, subs,
-                                    args, options, C.silConv, *F,
-                                    specializationInfo, isolationCrossing));
+      std::optional<ApplyIsolationCrossing> isolationCrossing = std::nullopt,
+      std::optional<ArrayRef<SILLocation>> argLocs = std::nullopt) {
+    ASSERT((!argLocs || argLocs->empty() || argLocs->size() == args.size()) &&
+           "createApply argLocs, when supplied, must be parallel to args");
+    return insert(ApplyInst::create(
+        getSILDebugLocation(loc), callee, subs, args, options, C.silConv, *F,
+        specializationInfo, isolationCrossing, argLocs));
   }
 
   TryApplyInst *createTryApply(
@@ -572,11 +575,14 @@ public:
       const GenericSpecializationInformation *specializationInfo = nullptr,
       std::optional<ApplyIsolationCrossing> isolationCrossing = std::nullopt,
       ProfileCounter normalCount = ProfileCounter(),
-      ProfileCounter errorCount = ProfileCounter()) {
+      ProfileCounter errorCount = ProfileCounter(),
+      std::optional<ArrayRef<SILLocation>> argLocs = std::nullopt) {
+    ASSERT((!argLocs || argLocs->empty() || argLocs->size() == args.size()) &&
+           "createTryApply argLocs, when supplied, must be parallel to args");
     return insertTerminator(TryApplyInst::create(
         getSILDebugLocation(loc), callee, subs, args, normalBB, errorBB,
-        options, *F, specializationInfo, isolationCrossing,
-        normalCount, errorCount));
+        options, *F, specializationInfo, isolationCrossing, normalCount,
+        errorCount, argLocs));
   }
 
   PartialApplyInst *createPartialApply(
@@ -587,7 +593,8 @@ public:
       PartialApplyInst::OnStackKind OnStack =
           PartialApplyInst::OnStackKind::NotOnStack,
       StackAllocationIsNested_t IsNested = StackAllocationIsNested,
-      const GenericSpecializationInformation *SpecializationInfo = nullptr) {
+      const GenericSpecializationInformation *SpecializationInfo = nullptr,
+      std::optional<ArrayRef<SILLocation>> ArgLocs = std::nullopt) {
     ASSERT(OnStack == PartialApplyInst::OnStackKind::OnStack ||
            llvm::all_of(Args,
                         [](SILValue value) {
@@ -595,19 +602,25 @@ public:
                               OwnershipKind::Owned);
                         }) &&
                "Must have an owned compatible object");
+    ASSERT((!ArgLocs || ArgLocs->empty() || ArgLocs->size() == Args.size()) &&
+           "createPartialApply ArgLocs, when supplied, must be parallel to "
+           "Args");
     return insert(PartialApplyInst::create(
         getSILDebugLocation(Loc), Fn, Args, Subs, CalleeConvention,
-        ResultIsolation, *F, SpecializationInfo, OnStack, IsNested));
+        ResultIsolation, *F, SpecializationInfo, OnStack, IsNested, ArgLocs));
   }
 
   BeginApplyInst *createBeginApply(
       SILLocation loc, SILValue callee, SubstitutionMap subs,
       ArrayRef<SILValue> args, ApplyOptions options = ApplyOptions(),
       const GenericSpecializationInformation *specializationInfo = nullptr,
-      std::optional<ApplyIsolationCrossing> isolationCrossing = std::nullopt) {
+      std::optional<ApplyIsolationCrossing> isolationCrossing = std::nullopt,
+      std::optional<ArrayRef<SILLocation>> argLocs = std::nullopt) {
+    ASSERT((!argLocs || argLocs->empty() || argLocs->size() == args.size()) &&
+           "createBeginApply argLocs, when supplied, must be parallel to args");
     return insert(BeginApplyInst::create(
         getSILDebugLocation(loc), callee, subs, args, options, C.silConv, *F,
-        specializationInfo, isolationCrossing));
+        specializationInfo, isolationCrossing, argLocs));
   }
 
   AbortApplyInst *createAbortApply(SILLocation loc, SILValue beginApply) {

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -315,6 +315,15 @@ public:
     return asImpl().remapLocation(Loc);
   }
 
+  /// Remap a per-argument SILLocation taken from an apply instruction.
+  /// \p argIdx identifies which argument the location is attached to so
+  /// inliner-style subclasses can correlate it with a parameter binding
+  /// site if they need to. Default behaviour is identical to
+  /// `getOpLocation`.
+  SILLocation getOpArgumentLocation(SILLocation Loc, unsigned argIdx) {
+    return asImpl().remapArgumentLocation(Loc, argIdx);
+  }
+
   const SILDebugScope *getOpScope(const SILDebugScope *DS) {
     return asImpl().remapScope(DS);
   }
@@ -546,6 +555,14 @@ protected:
   // the result.
 
   SILLocation remapLocation(SILLocation Loc) { return Loc; }
+
+  /// Customisation point for remapping the per-argument location attached
+  /// to apply argument \p argIdx. Defaults to `remapLocation` (identity in
+  /// the base cloner). Subclasses such as the inliner override this to
+  /// re-anchor cross-function locations.
+  SILLocation remapArgumentLocation(SILLocation Loc, unsigned argIdx) {
+    return asImpl().remapLocation(Loc);
+  }
   const SILDebugScope *remapScope(const SILDebugScope *DS) { return DS; }
 
   bool shouldSubstOpaqueArchetypes() const { return false; }
@@ -1277,43 +1294,74 @@ template<typename ImplClass>
 void
 SILCloner<ImplClass>::visitApplyInst(ApplyInst *Inst) {
   auto Args = getOpValueArray<8>(Inst->getArguments());
+  // Remap per-argument locations when the source apply has them. With
+  // the new "all-or-nothing" invariant, every slot is a valid location
+  // — no null fallback needed. When the source has no per-arg locs,
+  // the clone is constructed without storage too.
+  std::optional<SmallVector<SILLocation, 8>> ArgLocs;
+  if (auto srcLocs = Inst->getArgumentLocs()) {
+    ArgLocs.emplace();
+    ArgLocs->reserve(srcLocs->size());
+    for (auto en : llvm::enumerate(*srcLocs))
+      ArgLocs->push_back(getOpArgumentLocation(en.value(), en.index()));
+  }
   getBuilder().setCurrentDebugScope(getOpScope(Inst->getDebugScope()));
   recordClonedInstruction(
       Inst, getBuilder().createApply(
                 getOpLocation(Inst->getLoc()), getOpValue(Inst->getCallee()),
                 getOpSubstitutionMap(Inst->getSubstitutionMap()), Args,
                 Inst->getApplyOptions(),
-                GenericSpecializationInformation::create(Inst, getBuilder())));
+                GenericSpecializationInformation::create(Inst, getBuilder()),
+                /*isolationCrossing=*/std::nullopt,
+                ArgLocs ? std::optional<ArrayRef<SILLocation>>(*ArgLocs)
+                        : std::nullopt));
 }
 
 template<typename ImplClass>
 void
 SILCloner<ImplClass>::visitTryApplyInst(TryApplyInst *Inst) {
   auto Args = getOpValueArray<8>(Inst->getArguments());
+  std::optional<SmallVector<SILLocation, 8>> ArgLocs;
+  if (auto srcLocs = Inst->getArgumentLocs()) {
+    ArgLocs.emplace();
+    ArgLocs->reserve(srcLocs->size());
+    for (auto en : llvm::enumerate(*srcLocs))
+      ArgLocs->push_back(getOpArgumentLocation(en.value(), en.index()));
+  }
   getBuilder().setCurrentDebugScope(getOpScope(Inst->getDebugScope()));
   recordClonedInstruction(
       Inst, getBuilder().createTryApply(
                 getOpLocation(Inst->getLoc()), getOpValue(Inst->getCallee()),
                 getOpSubstitutionMap(Inst->getSubstitutionMap()), Args,
                 getOpBasicBlock(Inst->getNormalBB()),
-                getOpBasicBlock(Inst->getErrorBB()),
-                Inst->getApplyOptions(),
-                GenericSpecializationInformation::create(Inst, getBuilder())));
+                getOpBasicBlock(Inst->getErrorBB()), Inst->getApplyOptions(),
+                GenericSpecializationInformation::create(Inst, getBuilder()),
+                /*isolationCrossing=*/std::nullopt,
+                /*normalCount=*/ProfileCounter(),
+                /*errorCount=*/ProfileCounter(),
+                ArgLocs ? std::optional<ArrayRef<SILLocation>>(*ArgLocs)
+                        : std::nullopt));
 }
 
 template<typename ImplClass>
 void
 SILCloner<ImplClass>::visitPartialApplyInst(PartialApplyInst *Inst) {
   auto Args = getOpValueArray<8>(Inst->getArguments());
+  std::optional<SmallVector<SILLocation, 8>> ArgLocs;
+  if (auto srcLocs = Inst->getArgumentLocs()) {
+    ArgLocs.emplace();
+    ArgLocs->reserve(srcLocs->size());
+    for (auto en : llvm::enumerate(*srcLocs))
+      ArgLocs->push_back(getOpArgumentLocation(en.value(), en.index()));
+  }
   getBuilder().setCurrentDebugScope(getOpScope(Inst->getDebugScope()));
   auto NewInst = getBuilder().createPartialApply(
-                getOpLocation(Inst->getLoc()), getOpValue(Inst->getCallee()),
-                getOpSubstitutionMap(Inst->getSubstitutionMap()), Args,
-                Inst->getCalleeConvention(),
-                Inst->getResultIsolation(),
-                Inst->isOnStack(),
-                Inst->isStackAllocationNested(),
-                GenericSpecializationInformation::create(Inst, getBuilder()));
+      getOpLocation(Inst->getLoc()), getOpValue(Inst->getCallee()),
+      getOpSubstitutionMap(Inst->getSubstitutionMap()), Args,
+      Inst->getCalleeConvention(), Inst->getResultIsolation(),
+      Inst->isOnStack(), Inst->isStackAllocationNested(),
+      GenericSpecializationInformation::create(Inst, getBuilder()),
+      ArgLocs ? std::optional<ArrayRef<SILLocation>>(*ArgLocs) : std::nullopt);
   recordClonedInstruction(Inst, NewInst);
 }
 
@@ -1321,13 +1369,23 @@ template<typename ImplClass>
 void
 SILCloner<ImplClass>::visitBeginApplyInst(BeginApplyInst *Inst) {
   auto Args = getOpValueArray<8>(Inst->getArguments());
+  std::optional<SmallVector<SILLocation, 8>> ArgLocs;
+  if (auto srcLocs = Inst->getArgumentLocs()) {
+    ArgLocs.emplace();
+    ArgLocs->reserve(srcLocs->size());
+    for (auto en : llvm::enumerate(*srcLocs))
+      ArgLocs->push_back(getOpArgumentLocation(en.value(), en.index()));
+  }
   getBuilder().setCurrentDebugScope(getOpScope(Inst->getDebugScope()));
   recordClonedInstruction(
       Inst, getBuilder().createBeginApply(
                 getOpLocation(Inst->getLoc()), getOpValue(Inst->getCallee()),
                 getOpSubstitutionMap(Inst->getSubstitutionMap()), Args,
                 Inst->getApplyOptions(),
-                GenericSpecializationInformation::create(Inst, getBuilder())));
+                GenericSpecializationInformation::create(Inst, getBuilder()),
+                /*isolationCrossing=*/std::nullopt,
+                ArgLocs ? std::optional<ArrayRef<SILLocation>>(*ArgLocs)
+                        : std::nullopt));
 }
 
 template<typename ImplClass>

--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -1842,6 +1842,21 @@ inline llvm::raw_ostream &operator<<(llvm::raw_ostream &OS,
   return OS;
 }
 
+/// Returns true when isolation-history note emission should run for \p fn.
+///
+/// Isolation-history is opt-in. It is enabled when:
+///   - The frontend flag \c -sil-region-isolation-emit-isolation-history was
+///     passed (\c SILOptions::EmitIsolationHistory), or
+///   - The function carries a
+///     \c \@diagnose(RegionIsolationIsolationHistory, as: <not ignored>)
+///     attribute.
+///
+/// Both producers (SILGen, when deciding whether to record per-argument
+/// SILLocations on apply instructions) and consumers (SendNonSendable's
+/// IsolationHistoryNoteEmitter) consult this single predicate so the two
+/// sides stay in lock-step.
+bool shouldEmitIsolationHistoryFor(const SILFunction *fn);
+
 } // end swift namespace
 
 //===----------------------------------------------------------------------===//

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -2768,8 +2768,15 @@ class ApplyInstBase<Impl, Base, false> : public Base {
   /// Stores an ApplyOptions.
   unsigned Options: 2;
 
+  /// Whether this apply has trailing per-argument SILLocation storage.
+  /// When true, `numTrailingObjects(SILLocation)` is `NumCallArguments`
+  /// and every slot in the trailing array holds a valid (non-null)
+  /// location. When false, no SILLocation storage is allocated and
+  /// `getArgumentLoc()` always falls back to the apply's anchor.
+  unsigned HasArgumentLocs : 1;
+
   /// The number of call arguments as required by the callee.
-  unsigned NumCallArguments : 30;
+  unsigned NumCallArguments : 29;
 
   /// The total number of type-dependent operands.
   unsigned NumTypeDependentOperands;
@@ -2786,14 +2793,22 @@ protected:
                 SILValue callee, SILType substCalleeType, SubstitutionMap subs,
                 ArrayRef<SILValue> args,
                 ArrayRef<SILValue> typeDependentOperands,
+                std::optional<ArrayRef<SILLocation>> argLocs,
                 const GenericSpecializationInformation *specializationInfo,
                 BaseArgTys... baseArgs)
       : Base(kind, DebugLoc, baseArgs...), SubstCalleeType(substCalleeType),
-        SpecializationInfo(specializationInfo), NumCallArguments(args.size()),
+        SpecializationInfo(specializationInfo),
+        // The "all-or-nothing" contract: nullopt or empty ArrayRef means
+        // no per-argument storage; otherwise the array must be parallel
+        // to `args` (asserted below).
+        HasArgumentLocs(argLocs.has_value() && !argLocs->empty()),
+        NumCallArguments(args.size()),
         NumTypeDependentOperands(typeDependentOperands.size()),
         Substitutions(subs.getCanonical()) {
     ASSERT(!!subs == !!callee->getType().castTo<SILFunctionType>()
         ->getInvocationGenericSignature());
+    assert((!argLocs || argLocs->empty() || argLocs->size() == args.size()) &&
+           "argLocs, when supplied, must be parallel to args");
 
     // Initialize the operands.
     auto allOperands = getAllOperands();
@@ -2804,6 +2819,20 @@ protected:
     for (size_t i : indices(typeDependentOperands)) {
       new (&allOperands[NumStaticOperands + args.size() + i])
         Operand(this, typeDependentOperands[i]);
+    }
+
+    // Initialize the per-argument locations only when storage was
+    // reserved. The invariant is "if HasArgumentLocs, every slot holds
+    // a valid (non-null) SILLocation". Asserted per-slot here so any
+    // producer that drops a null into the array trips a debug check
+    // rather than corrupting downstream consumers.
+    if (auto argLocsBuf = getArgumentLocsBuf()) {
+      for (size_t i : indices(args)) {
+        assert(!(*argLocs)[i].isNull() &&
+               "every argLoc slot must be a valid SILLocation when "
+               "per-argument location storage is allocated");
+        ::new (&(*argLocsBuf)[i]) SILLocation((*argLocs)[i]);
+      }
     }
   }
 
@@ -2817,6 +2846,29 @@ protected:
 
   unsigned numTrailingObjects(OverloadToken<Operand>) const {
     return getNumAllOperands();
+  }
+
+  unsigned numTrailingObjects(OverloadToken<SILLocation>) const {
+    return HasArgumentLocs ? NumCallArguments : 0;
+  }
+
+  /// Returns the trailing per-argument SILLocation buffer, or
+  /// `std::nullopt` when no storage was reserved on this apply. The
+  /// optional shape mirrors the in-memory invariant: an apply either
+  /// has zero per-argument location slots or it has exactly
+  /// NumCallArguments of them; "empty buffer" is not a valid state.
+  std::optional<MutableArrayRef<SILLocation>> getArgumentLocsBuf() {
+    if (!HasArgumentLocs)
+      return std::nullopt;
+    return asImpl().template getTrailingObjectsNonStrict<SILLocation>(
+        NumCallArguments);
+  }
+
+  std::optional<ArrayRef<SILLocation>> getArgumentLocsBuf() const {
+    if (!HasArgumentLocs)
+      return std::nullopt;
+    return asImpl().template getTrailingObjectsNonStrict<SILLocation>(
+        NumCallArguments);
   }
 
   static size_t getNumAllOperands(ArrayRef<SILValue> args,
@@ -3018,6 +3070,44 @@ public:
   /// Set the ith argument of this instruction.
   void setArgument(unsigned i, SILValue V) {
     return getArgumentOperands()[i].set(V);
+  }
+
+  /// Returns the per-argument SILLocations stored on this apply, parallel
+  /// to `getArguments()`. `std::nullopt` when no per-argument storage was
+  /// reserved at construction time; when present, every slot is
+  /// guaranteed to hold a valid (non-null) location for the corresponding
+  /// argument.
+  std::optional<ArrayRef<SILLocation>> getArgumentLocs() const {
+    return getArgumentLocsBuf();
+  }
+
+  /// Returns the SILLocation associated with the argument at \p argIdx,
+  /// falling back to the apply's anchor location when no per-argument
+  /// storage was allocated. Out-of-range indices also return the anchor
+  /// location — defensive for inliner / optimizer call sites that derive
+  /// `argIdx` from a callee's SIL argument list which can include
+  /// indirect-result slots not modelled in the apply's NumCallArguments.
+  SILLocation getArgumentLoc(unsigned argIdx) const {
+    if (argIdx >= NumCallArguments)
+      return this->getLoc();
+    if (auto buf = getArgumentLocsBuf())
+      return (*buf)[argIdx];
+    return this->getLoc();
+  }
+
+  /// Set the per-argument location for the argument at \p argIdx. Requires
+  /// that this apply was constructed with per-argument location storage
+  /// (i.e. `getArgumentLocs()` returns a value) and \p loc must be a
+  /// valid (non-null) SILLocation, preserving the "every slot is valid"
+  /// invariant.
+  void setArgumentLoc(unsigned argIdx, SILLocation loc) {
+    assert(argIdx < NumCallArguments);
+    assert(!loc.isNull() &&
+           "setArgumentLoc requires a valid (non-null) SILLocation");
+    auto buf = getArgumentLocsBuf();
+    assert(buf && "setArgumentLoc requires the apply to have per-argument "
+                  "location storage; pass argLocs at construction time");
+    (*buf)[argIdx] = loc;
   }
 
   ArrayRef<Operand> getTypeDependentOperands() const {
@@ -3258,13 +3348,13 @@ public:
 class ApplyInst final
     : public InstructionBase<SILInstructionKind::ApplyInst,
                              ApplyInstBase<ApplyInst, SingleValueInstruction>>,
-      public llvm::TrailingObjects<ApplyInst, Operand> {
+      public llvm::TrailingObjects<ApplyInst, Operand, SILLocation> {
   friend SILBuilder;
 
   ApplyInst(SILDebugLocation debugLoc, SILValue callee, SILType substCalleeType,
             SILType returnType, SubstitutionMap substitutions,
             ArrayRef<SILValue> args, ArrayRef<SILValue> typeDependentOperands,
-            ApplyOptions options,
+            std::optional<ArrayRef<SILLocation>> argLocs, ApplyOptions options,
             const GenericSpecializationInformation *sSpecializationInfo,
             std::optional<ApplyIsolationCrossing> isolationCrossing);
 
@@ -3275,7 +3365,8 @@ class ApplyInst final
          std::optional<SILModuleConventions> moduleConventions,
          SILFunction &parentFunction,
          const GenericSpecializationInformation *specializationInfo,
-         std::optional<ApplyIsolationCrossing> isolationCrossing);
+         std::optional<ApplyIsolationCrossing> isolationCrossing,
+         std::optional<ArrayRef<SILLocation>> argLocs = std::nullopt);
 
 public:
   bool hasGuaranteedResult() const {
@@ -3296,10 +3387,10 @@ public:
 /// PartialApplyInst - Represents the creation of a closure object by partial
 /// application of a function value.
 class PartialApplyInst final
-    : public InstructionBase<SILInstructionKind::PartialApplyInst,
-                             ApplyInstBase<PartialApplyInst,
-                                           SingleValueInstruction>>,
-      public llvm::TrailingObjects<PartialApplyInst, Operand> {
+    : public InstructionBase<
+          SILInstructionKind::PartialApplyInst,
+          ApplyInstBase<PartialApplyInst, SingleValueInstruction>>,
+      public llvm::TrailingObjects<PartialApplyInst, Operand, SILLocation> {
   USE_SHARED_UINT8;
 
   friend SILBuilder;
@@ -3311,12 +3402,11 @@ public:
 
 private:
   PartialApplyInst(SILDebugLocation DebugLoc, SILValue Callee,
-                   SILType SubstCalleeType,
-                   SubstitutionMap Substitutions,
+                   SILType SubstCalleeType, SubstitutionMap Substitutions,
                    ArrayRef<SILValue> Args,
                    ArrayRef<SILValue> TypeDependentOperands,
-                   SILType ClosureType,
-                   StackAllocationIsNested_t IsNested,
+                   std::optional<ArrayRef<SILLocation>> ArgLocs,
+                   SILType ClosureType, StackAllocationIsNested_t IsNested,
                    const GenericSpecializationInformation *SpecializationInfo);
 
   static PartialApplyInst *
@@ -3324,7 +3414,8 @@ private:
          SubstitutionMap Substitutions, ParameterConvention CalleeConvention,
          SILFunctionTypeIsolation ResultIsolation, SILFunction &F,
          const GenericSpecializationInformation *SpecializationInfo,
-         OnStackKind onStack, StackAllocationIsNested_t isNested);
+         OnStackKind onStack, StackAllocationIsNested_t isNested,
+         std::optional<ArrayRef<SILLocation>> ArgLocs = std::nullopt);
 
 public:
   /// Return the result function type of this partial apply.
@@ -3370,14 +3461,14 @@ using EndApplyRange = OptionalTransformRange<ValueBase::use_range,
 /// BeginApplyInst - Represents the beginning of the full application of
 /// a yield_once coroutine (up until the coroutine yields a value back).
 class BeginApplyInst final
-    : public InstructionBase<SILInstructionKind::BeginApplyInst,
-                             ApplyInstBase<BeginApplyInst,
-                                           MultipleValueInstruction>>,
+    : public InstructionBase<
+          SILInstructionKind::BeginApplyInst,
+          ApplyInstBase<BeginApplyInst, MultipleValueInstruction>>,
       public MultipleValueInstructionTrailingObjects<
           BeginApplyInst,
           // These must be earlier trailing objects because their
           // count fields are initialized by an earlier base class.
-          InitialTrailingObjects<Operand>> {
+          InitialTrailingObjects<Operand, SILLocation>> {
   friend SILBuilder;
 
   template <class, class...>
@@ -3392,7 +3483,9 @@ class BeginApplyInst final
                  SILType substCalleeType, ArrayRef<SILType> allResultTypes,
                  ArrayRef<ValueOwnershipKind> allResultOwnerships,
                  SubstitutionMap substitutions, ArrayRef<SILValue> args,
-                 ArrayRef<SILValue> typeDependentOperands, ApplyOptions options,
+                 ArrayRef<SILValue> typeDependentOperands,
+                 std::optional<ArrayRef<SILLocation>> argLocs,
+                 ApplyOptions options,
                  const GenericSpecializationInformation *specializationInfo,
                  std::optional<ApplyIsolationCrossing> isolationCrossing);
 
@@ -3403,7 +3496,8 @@ class BeginApplyInst final
          std::optional<SILModuleConventions> moduleConventions,
          SILFunction &parentFunction,
          const GenericSpecializationInformation *specializationInfo,
-         std::optional<ApplyIsolationCrossing> isolationCrossing);
+         std::optional<ApplyIsolationCrossing> isolationCrossing,
+         std::optional<ArrayRef<SILLocation>> argLocs = std::nullopt);
 
 public:
   using MultipleValueInstructionTrailingObjects::totalSizeToAlloc;
@@ -11745,19 +11839,19 @@ public:
 class TryApplyInst final
     : public InstructionBase<SILInstructionKind::TryApplyInst,
                              ApplyInstBase<TryApplyInst, TryApplyInstBase>>,
-      public llvm::TrailingObjects<TryApplyInst, Operand> {
+      public llvm::TrailingObjects<TryApplyInst, Operand, SILLocation> {
   friend SILBuilder;
 
   TryApplyInst(SILDebugLocation debugLoc, SILValue callee,
                SILType substCalleeType, SubstitutionMap substitutions,
                ArrayRef<SILValue> args,
                ArrayRef<SILValue> typeDependentOperands,
+               std::optional<ArrayRef<SILLocation>> argLocs,
                SILBasicBlock *normalBB, SILBasicBlock *errorBB,
                ApplyOptions options,
                const GenericSpecializationInformation *specializationInfo,
                std::optional<ApplyIsolationCrossing> isolationCrossing,
-               ProfileCounter normalCount,
-               ProfileCounter errorCount);
+               ProfileCounter normalCount, ProfileCounter errorCount);
 
   static TryApplyInst *
   create(SILDebugLocation debugLoc, SILValue callee,
@@ -11766,8 +11860,8 @@ class TryApplyInst final
          SILFunction &parentFunction,
          const GenericSpecializationInformation *specializationInfo,
          std::optional<ApplyIsolationCrossing> isolationCrossing,
-         ProfileCounter normalCount,
-         ProfileCounter errorCount);
+         ProfileCounter normalCount, ProfileCounter errorCount,
+         std::optional<ArrayRef<SILLocation>> argLocs = std::nullopt);
 };
 
 /// DifferentiableFunctionInst - creates a `@differentiable` function-typed

--- a/include/swift/SILOptimizer/Utils/PartitionUtils.h
+++ b/include/swift/SILOptimizer/Utils/PartitionUtils.h
@@ -1922,8 +1922,21 @@ public:
 
     // Set the boundary so that as we push, this shows when to stop processing
     // for this PartitionOp.
-    SILLocation loc = op.hasSourceInst() ? getLoc(op.getSourceInst())
-                                         : getLoc(op.getSourceOp());
+    //
+    // For PartitionOps sourced from a specific apply argument operand, prefer
+    // the apply's per-argument SILLocation when one is stored. This is the
+    // ONLY consumer of those per-argument locations today: the location ends
+    // up on a SequenceBoundary node and is read back by the
+    // IsolationHistoryNoteEmitter chain walker. When the producer (SILGen)
+    // hasn't filled in per-argument locations, getArgumentLoc() falls back to
+    // the apply's anchor location, so behavior is unchanged for functions
+    // that haven't opted in to isolation-history.
+    SILLocation loc = SILLocation::invalid();
+    if (op.hasSourceInst()) {
+      loc = getLoc(op.getSourceInst());
+    } else if (Operand *srcOp = op.getSourceOp()) {
+      loc = getLoc(srcOp);
+    }
     p.pushHistorySequenceBoundary(loc);
 
     switch (op.getKind()) {
@@ -2514,7 +2527,20 @@ struct PartitionOpEvaluatorBaseImpl : PartitionOpEvaluator<Subclass> {
   bool shouldTryToSquelchErrors() const { return true; }
 
   static SILLocation getLoc(SILInstruction *inst) { return inst->getLoc(); }
-  static SILLocation getLoc(Operand *op) { return op->getUser()->getLoc(); }
+  static SILLocation getLoc(Operand *op) {
+    // For PartitionOps sourced from a specific apply argument operand, prefer
+    // the apply's per-argument SILLocation when one is stored. This is the
+    // ONLY consumer of those per-argument locations today: the location ends
+    // up on a SequenceBoundary node and is read back by the
+    // IsolationHistoryNoteEmitter chain walker. When the producer (SILGen)
+    // hasn't filled in per-argument locations, getArgumentLoc() falls back to
+    // the apply's anchor location, so behavior is unchanged for functions
+    // that haven't opted in to isolation-history.
+    if (auto as = ApplySite::isa(op->getUser());
+        as && as.isArgumentOperand(*op))
+      return as.getArgumentLoc(op);
+    return op->getUser()->getLoc();
+  }
   static SILInstruction *getSourceInst(const PartitionOp &partitionOp) {
     return partitionOp.getSourceInst();
   }

--- a/lib/DriverTool/sil_opt_main.cpp
+++ b/lib/DriverTool/sil_opt_main.cpp
@@ -413,6 +413,12 @@ struct SILOptOptions {
                      llvm::cl::init(true),
                      llvm::cl::desc("Run sil verifications after every pass."));
 
+  llvm::cl::opt<bool> EmitIsolationHistory = llvm::cl::opt<bool>(
+      "sil-region-isolation-emit-isolation-history",
+      llvm::cl::desc("Emit notes explaining why a disconnected value ended up "
+                     "in an isolated region. Mirrors the frontend flag of the "
+                     "same name; controls SILOptions::EmitIsolationHistory."));
+
   llvm::cl::opt<bool>
   SILVerifyAll = llvm::cl::opt<bool>("sil-verify-all",
                llvm::cl::Hidden,
@@ -856,6 +862,7 @@ int sil_opt_main(ArrayRef<const char *> argv, void *MainAddr) {
   SILOpts.OptRecordPasses = options.RemarksPasses;
   SILOpts.EnableStackProtection = true;
   SILOpts.EnableMoveInoutStackProtection = options.EnableMoveInoutStackProtection;
+  SILOpts.EmitIsolationHistory = options.EmitIsolationHistory;
 
   SILOpts.VerifyExclusivity = options.VerifyExclusivity;
   if (options.EnforceExclusivity.getNumOccurrences() != 0) {

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -3330,6 +3330,8 @@ static bool ParseSILArgs(SILOptions &Opts, ArgList &Args,
   Opts.VerifyOwnershipAll |= Args.hasArg(OPT_sil_ownership_verify_all);
   Opts.AbortOnUnknownRegionIsolationPatternError |=
       Args.hasArg(OPT_sil_region_isolation_assert_on_unknown_pattern);
+  Opts.EmitIsolationHistory |=
+      Args.hasArg(OPT_sil_region_isolation_emit_isolation_history);
   Opts.DebugSerialization |= Args.hasArg(OPT_sil_debug_serialization);
   Opts.EmitVerboseSIL |= Args.hasArg(OPT_emit_verbose_sil);
   Opts.EmitSortedSIL |= Args.hasArg(OPT_emit_sorted_sil);

--- a/lib/SIL/IR/SILFunction.cpp
+++ b/lib/SIL/IR/SILFunction.cpp
@@ -13,7 +13,9 @@
 #define DEBUG_TYPE "sil-function"
 
 #include "swift/SIL/SILFunction.h"
+#include "swift/AST/Attr.h"
 #include "swift/AST/AvailabilityRange.h"
+#include "swift/AST/DiagnosticGroups.h"
 #include "swift/AST/Expr.h"
 #include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/LocalArchetypeRequirementCollector.h"
@@ -1425,4 +1427,27 @@ SourceFile *SILFunction::getSourceFile() const {
     return nullptr;
 
   return declRef.getInnermostDeclContext()->getParentSourceFile();
+}
+
+bool swift::shouldEmitIsolationHistoryFor(const SILFunction *fn) {
+  if (fn->getModule().getOptions().EmitIsolationHistory)
+    return true;
+
+  // Per-function opt-in: a `@diagnose(RegionIsolationIsolationHistory,
+  // as: <not ignored>)` on the function's own decl turns it on for that
+  // function only.
+  auto *dc = fn->getDeclContext();
+  if (!dc)
+    return false;
+  auto *decl = dc->getAsDecl();
+  if (!decl)
+    return false;
+
+  for (auto *attr : decl->getAttrs().getAttributes<DiagnoseAttr>()) {
+    if (attr->DiagnosticGroupID ==
+            DiagGroupID::RegionIsolationIsolationHistory &&
+        attr->DiagnosticBehavior != WarningGroupBehavior::Ignored)
+      return true;
+  }
+  return false;
 }

--- a/lib/SIL/IR/SILInstructions.cpp
+++ b/lib/SIL/IR/SILInstructions.cpp
@@ -816,11 +816,13 @@ ApplyInst::ApplyInst(SILDebugLocation loc, SILValue callee,
                      SILType substCalleeTy, SILType result,
                      SubstitutionMap subs, ArrayRef<SILValue> args,
                      ArrayRef<SILValue> typeDependentOperands,
+                     std::optional<ArrayRef<SILLocation>> argLocs,
                      ApplyOptions options,
                      const GenericSpecializationInformation *specializationInfo,
                      std::optional<ApplyIsolationCrossing> isolationCrossing)
     : InstructionBase(isolationCrossing, loc, callee, substCalleeTy, subs, args,
-                      typeDependentOperands, specializationInfo, result) {
+                      typeDependentOperands, argLocs, specializationInfo,
+                      result) {
   setApplyOptions(options);
   assert(!substCalleeTy.castTo<SILFunctionType>()->isCoroutine());
 }
@@ -831,7 +833,8 @@ ApplyInst::create(SILDebugLocation loc, SILValue callee, SubstitutionMap subs,
                   std::optional<SILModuleConventions> moduleConventions,
                   SILFunction &parentFunction,
                   const GenericSpecializationInformation *specializationInfo,
-                  std::optional<ApplyIsolationCrossing> isolationCrossing) {
+                  std::optional<ApplyIsolationCrossing> isolationCrossing,
+                  std::optional<ArrayRef<SILLocation>> argLocs) {
   SILType substCalleeSILTy = callee->getType().substGenericArgs(
       parentFunction.getModule(), subs,
       parentFunction.getTypeExpansionContext());
@@ -847,10 +850,14 @@ ApplyInst::create(SILDebugLocation loc, SILValue callee, SubstitutionMap subs,
   SmallVector<SILValue, 32> typeDependentOperands;
   collectTypeDependentOperands(typeDependentOperands, parentFunction,
                                substCalleeSILTy.getASTType(), subs);
-  void *buffer = allocateTrailingInst<ApplyInst, Operand>(
-      parentFunction, getNumAllOperands(args, typeDependentOperands));
+  // Per the all-or-nothing contract: reserve trailing storage for argLocs
+  // only when the caller actually supplied a non-empty array.
+  bool reserveArgLocs = argLocs.has_value() && !argLocs->empty();
+  void *buffer = allocateTrailingInst<ApplyInst, Operand, SILLocation>(
+      parentFunction, getNumAllOperands(args, typeDependentOperands),
+      reserveArgLocs ? args.size() : 0);
   return ::new (buffer) ApplyInst(loc, callee, substCalleeSILTy, result, subs,
-                                  args, typeDependentOperands, options,
+                                  args, typeDependentOperands, argLocs, options,
                                   specializationInfo, isolationCrossing);
 }
 
@@ -859,11 +866,11 @@ BeginApplyInst::BeginApplyInst(
     ArrayRef<SILType> allResultTypes,
     ArrayRef<ValueOwnershipKind> allResultOwnerships, SubstitutionMap subs,
     ArrayRef<SILValue> args, ArrayRef<SILValue> typeDependentOperands,
-    ApplyOptions options,
+    std::optional<ArrayRef<SILLocation>> argLocs, ApplyOptions options,
     const GenericSpecializationInformation *specializationInfo,
     std::optional<ApplyIsolationCrossing> isolationCrossing)
     : InstructionBase(isolationCrossing, loc, callee, substCalleeTy, subs, args,
-                      typeDependentOperands, specializationInfo),
+                      typeDependentOperands, argLocs, specializationInfo),
       MultipleValueInstructionTrailingObjects(this, allResultTypes,
                                               allResultOwnerships) {
   setApplyOptions(options);
@@ -876,7 +883,8 @@ BeginApplyInst *BeginApplyInst::create(
     std::optional<SILModuleConventions> moduleConventions,
     SILFunction &parentFunction,
     const GenericSpecializationInformation *specializationInfo,
-    std::optional<ApplyIsolationCrossing> isolationCrossing) {
+    std::optional<ApplyIsolationCrossing> isolationCrossing,
+    std::optional<ArrayRef<SILLocation>> argLocs) {
   SILType substCalleeSILType = callee->getType().substGenericArgs(
       parentFunction.getModule(), subs,
       parentFunction.getTypeExpansionContext());
@@ -918,15 +926,16 @@ BeginApplyInst *BeginApplyInst::create(
   SmallVector<SILValue, 32> typeDependentOperands;
   collectTypeDependentOperands(typeDependentOperands, parentFunction,
                                substCalleeType, subs);
-  void *buffer =
-      allocateTrailingInst<BeginApplyInst, Operand, MultipleValueInstruction *,
-                           MultipleValueInstructionResult>(
-          parentFunction, getNumAllOperands(args, typeDependentOperands), 1,
-          resultTypes.size());
+  bool reserveArgLocs = argLocs.has_value() && !argLocs->empty();
+  void *buffer = allocateTrailingInst<BeginApplyInst, Operand, SILLocation,
+                                      MultipleValueInstruction *,
+                                      MultipleValueInstructionResult>(
+      parentFunction, getNumAllOperands(args, typeDependentOperands),
+      reserveArgLocs ? args.size() : 0, 1, resultTypes.size());
   return ::new (buffer)
       BeginApplyInst(loc, callee, substCalleeSILType, resultTypes,
                      resultOwnerships, subs, args, typeDependentOperands,
-                     options, specializationInfo, isolationCrossing);
+                     argLocs, options, specializationInfo, isolationCrossing);
 }
 
 void BeginApplyInst::getCoroutineEndPoints(
@@ -980,7 +989,8 @@ bool swift::doesApplyCalleeHaveSemantics(SILValue callee, StringRef semantics) {
 PartialApplyInst::PartialApplyInst(
     SILDebugLocation Loc, SILValue Callee, SILType SubstCalleeTy,
     SubstitutionMap Subs, ArrayRef<SILValue> Args,
-    ArrayRef<SILValue> TypeDependentOperands, SILType ClosureType,
+    ArrayRef<SILValue> TypeDependentOperands,
+    std::optional<ArrayRef<SILLocation>> ArgLocs, SILType ClosureType,
     StackAllocationIsNested_t IsNested,
     const GenericSpecializationInformation *SpecializationInfo)
     // FIXME: the callee should have a lowered SIL function type, and
@@ -988,7 +998,8 @@ PartialApplyInst::PartialApplyInst(
     // should derive the type of its result by partially applying the callee's
     // type.
     : InstructionBase(Loc, Callee, SubstCalleeTy, Subs, Args,
-                      TypeDependentOperands, SpecializationInfo, ClosureType) {
+                      TypeDependentOperands, ArgLocs, SpecializationInfo,
+                      ClosureType) {
   sharedUInt8().PartialApplyInst.isNested = uint8_t(IsNested);
 }
 
@@ -997,7 +1008,8 @@ PartialApplyInst *PartialApplyInst::create(
     SubstitutionMap Subs, ParameterConvention calleeConvention,
     SILFunctionTypeIsolation resultIsolation, SILFunction &F,
     const GenericSpecializationInformation *specializationInfo,
-    OnStackKind onStack, StackAllocationIsNested_t isNested) {
+    OnStackKind onStack, StackAllocationIsNested_t isNested,
+    std::optional<ArrayRef<SILLocation>> ArgLocs) {
   SILType SubstCalleeTy = Callee->getType().substGenericArgs(
       F.getModule(), Subs, F.getTypeExpansionContext());
 
@@ -1008,13 +1020,13 @@ PartialApplyInst *PartialApplyInst::create(
   SmallVector<SILValue, 32> TypeDependentOperands;
   collectTypeDependentOperands(TypeDependentOperands, F,
                                SubstCalleeTy.getASTType(), Subs);
-  void *Buffer =
-    allocateTrailingInst<PartialApplyInst, Operand>(
-      F, getNumAllOperands(Args, TypeDependentOperands));
-  return ::new(Buffer) PartialApplyInst(Loc, Callee, SubstCalleeTy,
-                                        Subs, Args,
-                                        TypeDependentOperands, ClosureType,
-                                        isNested, specializationInfo);
+  bool reserveArgLocs = ArgLocs.has_value() && !ArgLocs->empty();
+  void *Buffer = allocateTrailingInst<PartialApplyInst, Operand, SILLocation>(
+      F, getNumAllOperands(Args, TypeDependentOperands),
+      reserveArgLocs ? Args.size() : 0);
+  return ::new (Buffer) PartialApplyInst(
+      Loc, Callee, SubstCalleeTy, Subs, Args, TypeDependentOperands, ArgLocs,
+      ClosureType, isNested, specializationInfo);
 }
 
 TryApplyInstBase::TryApplyInstBase(SILInstructionKind kind,
@@ -1029,15 +1041,15 @@ TryApplyInstBase::TryApplyInstBase(SILInstructionKind kind,
 TryApplyInst::TryApplyInst(
     SILDebugLocation loc, SILValue callee, SILType substCalleeTy,
     SubstitutionMap subs, ArrayRef<SILValue> args,
-    ArrayRef<SILValue> typeDependentOperands, SILBasicBlock *normalBB,
+    ArrayRef<SILValue> typeDependentOperands,
+    std::optional<ArrayRef<SILLocation>> argLocs, SILBasicBlock *normalBB,
     SILBasicBlock *errorBB, ApplyOptions options,
     const GenericSpecializationInformation *specializationInfo,
     std::optional<ApplyIsolationCrossing> isolationCrossing,
-    ProfileCounter normalCount,
-    ProfileCounter errorCount)
+    ProfileCounter normalCount, ProfileCounter errorCount)
     : InstructionBase(isolationCrossing, loc, callee, substCalleeTy, subs, args,
-                      typeDependentOperands, specializationInfo, normalBB,
-                      errorBB, normalCount, errorCount) {
+                      typeDependentOperands, argLocs, specializationInfo,
+                      normalBB, errorBB, normalCount, errorCount) {
   setApplyOptions(options);
 }
 
@@ -1048,8 +1060,8 @@ TryApplyInst::create(SILDebugLocation loc, SILValue callee,
                      ApplyOptions options, SILFunction &parentFunction,
                      const GenericSpecializationInformation *specializationInfo,
                      std::optional<ApplyIsolationCrossing> isolationCrossing,
-                     ProfileCounter normalCount,
-                     ProfileCounter errorCount) {
+                     ProfileCounter normalCount, ProfileCounter errorCount,
+                     std::optional<ArrayRef<SILLocation>> argLocs) {
   SILType substCalleeTy = callee->getType().substGenericArgs(
       parentFunction.getModule(), subs,
       parentFunction.getTypeExpansionContext());
@@ -1068,11 +1080,13 @@ TryApplyInst::create(SILDebugLocation loc, SILValue callee,
   SmallVector<SILValue, 32> typeDependentOperands;
   collectTypeDependentOperands(typeDependentOperands, parentFunction,
                                substCalleeTy.getASTType(), subs);
-  void *buffer = allocateTrailingInst<TryApplyInst, Operand>(
-      parentFunction, getNumAllOperands(args, typeDependentOperands));
+  bool reserveArgLocs = argLocs.has_value() && !argLocs->empty();
+  void *buffer = allocateTrailingInst<TryApplyInst, Operand, SILLocation>(
+      parentFunction, getNumAllOperands(args, typeDependentOperands),
+      reserveArgLocs ? args.size() : 0);
   return ::new (buffer) TryApplyInst(
-      loc, callee, substCalleeTy, subs, args, typeDependentOperands, normalBB,
-      errorBB, options, specializationInfo, isolationCrossing,
+      loc, callee, substCalleeTy, subs, args, typeDependentOperands, argLocs,
+      normalBB, errorBB, options, specializationInfo, isolationCrossing,
       normalCount, errorCount);
 }
 

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -2082,12 +2082,55 @@ static void emitRawApply(SILGenFunction &SGF,
     argValues.push_back(argValue);
   }
 
+  // Build the per-argument SILLocation array, but ONLY for functions that
+  // have opted in to isolation-history emission. The trailing per-argument
+  // location storage on apply instructions is reserved exclusively for that
+  // feature today (see PartitionUtils.h's SequenceBoundary push, which is the
+  // sole consumer). Skipping the array entirely for everyone else keeps the
+  // per-apply storage cost out of the common path and the change cherry-pick
+  // safe.
+  SmallVector<SILLocation, 4> argLocs;
+  bool haveArgLocs = false;
+  if (swift::shouldEmitIsolationHistoryFor(&SGF.F)) {
+    // Default every slot to the apply's anchor; getArgumentLoc()'s anchor
+    // fallback uses the same value, so this is the safe baseline.
+    argLocs.assign(argValues.size(), loc);
+    haveArgLocs = true;
+
+    // Best-effort refinement: when `loc` is an ApplyExpr and the AST
+    // argument count matches the lowered call-argument count exactly, copy
+    // each AST argument's source position into the corresponding slot. The
+    // call-arg portion of `argValues` is the trailing `args.size()` entries
+    // (preceded by indirect-result buffers and possibly an indirect-error
+    // address). On any count mismatch (curried calls, captures, foreign
+    // error/async params, tuple expansion, default args) we leave every
+    // slot at the anchor — the chain walker then sees identical locations
+    // and produces the same notes it does today.
+    if (auto *applyExpr = loc.getAsASTNode<ApplyExpr>()) {
+      auto *argList = applyExpr->getArgs();
+      if (argList && argList->size() == args.size()) {
+        unsigned callArgOffset = argValues.size() - args.size();
+        for (unsigned i = 0, n = args.size(); i != n; ++i) {
+          if (Expr *argExpr = argList->getExpr(i))
+            argLocs[callArgOffset + i] = RegularLocation(argExpr);
+        }
+      }
+    }
+  }
+
+  std::optional<ArrayRef<SILLocation>> argLocsRef =
+      haveArgLocs ? std::optional<ArrayRef<SILLocation>>(argLocs)
+                  : std::nullopt;
+
   auto resultType = substFnConv.getSILResultType(SGF.getTypeExpansionContext());
 
   // If the function is a coroutine, we need to use 'begin_apply'.
   if (substFnType->isCoroutine()) {
     assert(!substFnType->hasErrorResult());
-    auto apply = SGF.B.createBeginApply(loc, fnValue, subs, argValues);
+    auto apply =
+        SGF.B.createBeginApply(loc, fnValue, subs, argValues, ApplyOptions(),
+                               /*specializationInfo=*/nullptr,
+                               /*isolationCrossing=*/std::nullopt, argLocsRef);
     for (auto result : apply->getAllResults())
       rawResults.push_back(result);
     return;
@@ -2102,11 +2145,17 @@ static void emitRawApply(SILGenFunction &SGF,
   if (substFnType->hasErrorResult() &&
       SGF.F.isDistributed() &&
       dyn_cast<ClassDecl>(fnValue->getFunction()->getDeclContext()) ) {
-    auto result = SGF.B.createApply(loc, fnValue, subs, argValues, options);
+    auto result =
+        SGF.B.createApply(loc, fnValue, subs, argValues, options,
+                          /*specializationInfo=*/nullptr,
+                          /*isolationCrossing=*/std::nullopt, argLocsRef);
     rawResults.push_back(result);
 
   } else if (!substFnType->hasErrorResult()) {
-    auto result = SGF.B.createApply(loc, fnValue, subs, argValues, options);
+    auto result =
+        SGF.B.createApply(loc, fnValue, subs, argValues, options,
+                          /*specializationInfo=*/nullptr,
+                          /*isolationCrossing=*/std::nullopt, argLocsRef);
     rawResults.push_back(result);
 
   // Otherwise, we need to create a try_apply.
@@ -2138,7 +2187,10 @@ static void emitRawApply(SILGenFunction &SGF,
 
     options -= ApplyFlags::DoesNotThrow;
     SGF.B.createTryApply(loc, fnValue, subs, argValues, normalBB, errorBB,
-                         options);
+                         options, /*specializationInfo=*/nullptr,
+                         /*isolationCrossing=*/std::nullopt,
+                         /*normalCount=*/ProfileCounter(),
+                         /*errorCount=*/ProfileCounter(), argLocsRef);
 
     SGF.B.emitBlock(normalBB);
   }

--- a/lib/SILOptimizer/Mandatory/AddressLowering.cpp
+++ b/lib/SILOptimizer/Mandatory/AddressLowering.cpp
@@ -2686,9 +2686,21 @@ SILValue ApplyRewriter::materializeIndirectOutputAddress(ApplyOutput kind,
 void ApplyRewriter::rewriteApply(ArrayRef<SILValue> newCallArgs) {
   auto *oldCall = cast<ApplyInst>(apply.getInstruction());
 
+  // Address lowering may change the rewritten apply's argument count
+  // when opaque-value lowering inserts or merges operands. Forward the
+  // original per-argument SILLocations only when the count is preserved;
+  // otherwise pass nullopt and the new apply has no per-argument storage.
+  // (The SILBuilder factory asserts on size mismatch by design — that's
+  // why this guard is at the call site rather than inside the factory.)
+  std::optional<ArrayRef<SILLocation>> argLocs =
+      ApplySite(oldCall).getArgumentLocs();
+  if (argLocs && argLocs->size() != newCallArgs.size())
+    argLocs = std::nullopt;
+
   auto *newCall = argBuilder.createApply(
       callLoc, apply.getCallee(), apply.getSubstitutionMap(), newCallArgs,
-      oldCall->getApplyOptions(), oldCall->getSpecializationInfo());
+      oldCall->getApplyOptions(), oldCall->getSpecializationInfo(),
+      /*isolationCrossing=*/std::nullopt, argLocs);
 
   this->apply = FullApplySite(newCall);
 
@@ -2721,11 +2733,18 @@ void ApplyRewriter::convertBeginApplyWithOpaqueYield() {
     opValues.push_back(oper.get());
   }
 
+  // begin_apply yield-rewrite is a strict argument-preserving rewrite: we
+  // copy every operand through unchanged and only the result conventions
+  // change. The original per-argument SILLocations remain positionally
+  // valid 1:1 with `opValues`; just pass them through.
+
   // Recreate the begin_apply so that the instruction results have the right
   // ownership kind as per the lowered addresses convention.
   auto *newCall = argBuilder.createBeginApply(
       callLoc, apply.getCallee(), apply.getSubstitutionMap(), opValues,
-      origCall->getApplyOptions(), origCall->getSpecializationInfo());
+      origCall->getApplyOptions(), origCall->getSpecializationInfo(),
+      /*isolationCrossing=*/std::nullopt,
+      ApplySite(origCall).getArgumentLocs());
   this->apply = FullApplySite(newCall);
 
   // Replace uses of orig begin_apply with the new begin_apply
@@ -2907,10 +2926,23 @@ void ApplyRewriter::rewriteTryApply(ArrayRef<SILValue> newCallArgs) {
 
   auto *tryApply = cast<TryApplyInst>(apply.getInstruction());
 
+  // Same shape as rewriteApply above: forward per-argument SILLocations
+  // only when the rewritten try_apply has the same argument count as the
+  // original; otherwise pass nullopt and the new try_apply has no
+  // per-argument storage. The SILBuilder factory asserts on size mismatch
+  // by design, so the guard has to live here.
+  std::optional<ArrayRef<SILLocation>> argLocs =
+      ApplySite(tryApply).getArgumentLocs();
+  if (argLocs && argLocs->size() != newCallArgs.size())
+    argLocs = std::nullopt;
+
   auto *newCallInst = argBuilder.createTryApply(
       callLoc, apply.getCallee(), apply.getSubstitutionMap(), newCallArgs,
       tryApply->getNormalBB(), tryApply->getErrorBB(),
-      tryApply->getApplyOptions(), tryApply->getSpecializationInfo());
+      tryApply->getApplyOptions(), tryApply->getSpecializationInfo(),
+      /*isolationCrossing=*/std::nullopt,
+      /*normalCount=*/ProfileCounter(),
+      /*errorCount=*/ProfileCounter(), argLocs);
 
   // Immediately delete the old try_apply (old applies hang around until
   // dead code removal because they directly define values).

--- a/lib/SILOptimizer/Mandatory/CapturePromotion.cpp
+++ b/lib/SILOptimizer/Mandatory/CapturePromotion.cpp
@@ -1568,11 +1568,17 @@ processPartialApplyInst(SILOptFunctionBuilder &funcBuilder,
     ++NumCapturesPromoted;
   }
 
-  // Create a new partial apply with the new arguments.
+  // Create a new partial apply with the new arguments. Capture promotion
+  // replaces each box-typed capture with the loaded value while keeping the
+  // surrounding argument order, so the original apply's per-argument
+  // SILLocations remain positionally valid 1:1 with `args`. Forward the
+  // optional storage straight through; the SILBuilder factory will assert
+  // in debug builds if the sizes ever diverge from this 1:1 invariant.
   auto *newPAI = builder.createPartialApply(
       pai->getLoc(), fnVal, pai->getSubstitutionMap(), args,
-      pai->getCalleeConvention(), pai->getResultIsolation(),
-      pai->isOnStack(), pai->isStackAllocationNested());
+      pai->getCalleeConvention(), pai->getResultIsolation(), pai->isOnStack(),
+      pai->isStackAllocationNested(),
+      /*SpecializationInfo=*/nullptr, ApplySite(pai).getArgumentLocs());
   pai->replaceAllUsesWith(newPAI);
   pai->eraseFromParent();
   if (fri->use_empty()) {

--- a/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
@@ -78,12 +78,6 @@ static llvm::cl::opt<bool> ForceTypedErrors(
                    "it easier to test typed errors"),
     llvm::cl::Hidden);
 
-static llvm::cl::opt<bool> EmitIsolationHistory(
-    "sil-regionbasedisolation-emit-isolation-history",
-    llvm::cl::desc("Emit notes explaining why a disconnected value ended up "
-                   "in an isolated region"),
-    llvm::cl::Hidden);
-
 //===----------------------------------------------------------------------===//
 //                              MARK: Utilities
 //===----------------------------------------------------------------------===//
@@ -473,25 +467,7 @@ static InFlightDiagnostic diagnoseNote(const PartitionOp &op, Diag<T...> diag,
 //===----------------------------------------------------------------------===//
 
 static bool shouldEmitIsolationHistory(SILFunction *fn) {
-  if (EmitIsolationHistory)
-    return true;
-
-  // Isolation history emission is opt-in. We accept either the LLVM testing
-  // flag or a `@diagnose(RegionIsolationIsolationHistory, as: <not ignored>)`
-  // attribute on the SIL function's own decl.
-  if (auto *dc = fn->getDeclContext()) {
-    if (auto *decl = dc->getAsDecl()) {
-      for (auto *attr : decl->getAttrs().getAttributes<DiagnoseAttr>()) {
-        if (attr->DiagnosticGroupID ==
-                DiagGroupID::RegionIsolationIsolationHistory &&
-            attr->DiagnosticBehavior != WarningGroupBehavior::Ignored) {
-          return true;
-        }
-      }
-    }
-  }
-
-  return false;
+  return swift::shouldEmitIsolationHistoryFor(fn);
 }
 
 namespace {
@@ -2704,7 +2680,8 @@ private:
     return {};
   }
 
-  /// If \p EmitIsolationHistory is set and \p sentElement is disconnected
+  /// If isolation-history emission is enabled for this function (see
+  /// \c shouldEmitIsolationHistoryFor) and \p sentElement is disconnected
   /// (i.e., not itself actor-isolated), walk the isolation history DAG to find
   /// the most recent instruction where the element was merged into an isolated
   /// region and emit a note there.

--- a/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
+++ b/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
@@ -1195,6 +1195,14 @@ specializeApplySite(SILOptFunctionBuilder &FuncBuilder, ApplySite Apply,
   auto ApplyInst = Apply.getInstruction();
   SILBuilderWithScope Builder(ApplyInst);
 
+  // AllocBoxToStack rewrites the argument list with a 1:1 mapping — each
+  // operand becomes either itself or a project_box on a stack-promoted box
+  // (see the loop above). The original apply's per-argument SILLocations
+  // remain positionally valid, so just forward the optional storage hint
+  // through to the SILBuilder factory; the factory will assert in debug
+  // builds if the sizes ever diverge from this 1:1 invariant.
+  std::optional<ArrayRef<SILLocation>> ArgLocs = Apply.getArgumentLocs();
+
   // Build the function_ref and ApplySite.
   SILValue FunctionRef = Builder.createFunctionRef(Apply.getLoc(), ClonedFn);
   switch (Apply.getKind()) {
@@ -1204,25 +1212,29 @@ specializeApplySite(SILOptFunctionBuilder &FuncBuilder, ApplySite Apply,
         Apply.getLoc(), FunctionRef, Apply.getSubstitutionMap(), Args,
         PAI->getCalleeConvention(), PAI->getResultIsolation(), PAI->isOnStack(),
         PAI->isStackAllocationNested(),
-        GenericSpecializationInformation::create(ApplyInst, Builder));
+        GenericSpecializationInformation::create(ApplyInst, Builder), ArgLocs);
   }
   case ApplySiteKind::ApplyInst:
     return Builder.createApply(
         Apply.getLoc(), FunctionRef, Apply.getSubstitutionMap(), Args,
         Apply.getApplyOptions(),
-        GenericSpecializationInformation::create(ApplyInst, Builder));
+        GenericSpecializationInformation::create(ApplyInst, Builder),
+        /*isolationCrossing=*/std::nullopt, ArgLocs);
   case ApplySiteKind::BeginApplyInst:
     return Builder.createBeginApply(
         Apply.getLoc(), FunctionRef, Apply.getSubstitutionMap(), Args,
         Apply.getApplyOptions(),
-        GenericSpecializationInformation::create(ApplyInst, Builder));
+        GenericSpecializationInformation::create(ApplyInst, Builder),
+        /*isolationCrossing=*/std::nullopt, ArgLocs);
   case ApplySiteKind::TryApplyInst: {
     auto TAI = cast<TryApplyInst>(Apply);
     return Builder.createTryApply(
         Apply.getLoc(), FunctionRef, Apply.getSubstitutionMap(), Args,
-        TAI->getNormalBB(), TAI->getErrorBB(),
-        TAI->getApplyOptions(),
-        GenericSpecializationInformation::create(ApplyInst, Builder));
+        TAI->getNormalBB(), TAI->getErrorBB(), TAI->getApplyOptions(),
+        GenericSpecializationInformation::create(ApplyInst, Builder),
+        /*isolationCrossing=*/std::nullopt,
+        /*normalCount=*/ProfileCounter(),
+        /*errorCount=*/ProfileCounter(), ArgLocs);
   }
   }
   llvm_unreachable("unhandled apply inst kind!");

--- a/lib/SILOptimizer/Utils/SILInliner.cpp
+++ b/lib/SILOptimizer/Utils/SILInliner.cpp
@@ -677,7 +677,7 @@ void SILInlineCloner::cloneInline(ArrayRef<SILValue> AppliedArgs) {
 
       for (auto *insertPt : endBorrowInsertPts) {
         SILBuilderWithScope returnBuilder(insertPt, getBuilder());
-        returnBuilder.createEndBorrow(Apply.getLoc(), entryArgs[i]);
+        returnBuilder.createEndBorrow(Apply.getArgumentLoc(i), entryArgs[i]);
       }
     }
   }
@@ -691,7 +691,8 @@ void SILInlineCloner::cloneInline(ArrayRef<SILValue> AppliedArgs) {
       for (auto *insertPt : endBorrowInsertPts) {
         SILBuilderWithScope returnBuilder(insertPt->getParent()->begin(),
                                           getBuilder());
-        returnBuilder.emitDestroyOperation(Apply.getLoc(), entryArgs[i]);
+        returnBuilder.emitDestroyOperation(Apply.getArgumentLoc(i),
+                                           entryArgs[i]);
       }
     }
   }
@@ -879,7 +880,8 @@ SILValue SILInlineCloner::borrowFunctionArgument(SILValue callArg,
     break;
   }
   SILBuilderWithScope beginBuilder(Apply.getInstruction(), getBuilder());
-  return beginBuilder.createBeginBorrow(Apply.getLoc(), callArg, isLexical);
+  return beginBuilder.createBeginBorrow(Apply.getArgumentLoc(index), callArg,
+                                        isLexical);
 }
 
 SILValue SILInlineCloner::moveFunctionArgument(SILValue callArg,
@@ -899,7 +901,8 @@ SILValue SILInlineCloner::moveFunctionArgument(SILValue callArg,
     break;
   }
   SILBuilderWithScope beginBuilder(Apply.getInstruction(), getBuilder());
-  return beginBuilder.createMoveValue(Apply.getLoc(), callArg, isLexical);
+  return beginBuilder.createMoveValue(Apply.getArgumentLoc(index), callArg,
+                                      isLexical);
 }
 
 void SILInlineCloner::visitDebugValueInst(DebugValueInst *Inst) {

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -1282,6 +1282,43 @@ llvm::Expected<SILFunction *> SILDeserializer::readSILFunctionChecked(
       // Handle a SILInstruction record.
       if (readSILInstruction(fn, Builder, kind, scratch, DebugBBWorklist))
         return MF->diagnoseFatal("readSILInstruction returns error");
+
+      // If readSILInstruction just produced an apply whose record carried
+      // HasArgumentLocs=1, NumArguments source-loc records follow inline.
+      // Decode them via the shared readLoc path and stamp each onto the
+      // apply (overwriting the placeholder anchor locations the apply
+      // ctor seeded with). The bit on the apply record is the only
+      // signal — there is no separate marker record.
+      if (!CurrentBB->empty()) {
+        auto applySite = ApplySite::isa(&CurrentBB->back());
+        if (applySite && applySite.getArgumentLocs()) {
+          for (unsigned i = 0, e = applySite.getNumArguments(); i != e; ++i) {
+            scratch.clear();
+            auto maybeNext = SILCursor.advance(AF_DontPopBlockAtEnd);
+            if (!maybeNext)
+              return maybeNext.takeError();
+            auto next = maybeNext.get();
+            if (next.Kind != llvm::BitstreamEntry::Record)
+              return MF->diagnoseFatal(
+                  "expected SIL_SOURCE_LOC record while deserializing "
+                  "per-argument apply locations");
+            auto maybeRecKind = SILCursor.readRecord(next.ID, scratch);
+            if (!maybeRecKind)
+              return maybeRecKind.takeError();
+            unsigned recKind = maybeRecKind.get();
+            if (recKind != SIL_SOURCE_LOC && recKind != SIL_SOURCE_LOC_REF)
+              return MF->diagnoseFatal(
+                  "unexpected record kind in per-argument apply locations");
+            auto maybeLoc = readLoc(recKind, scratch);
+            if (!maybeLoc)
+              return maybeLoc.takeError();
+            // A null SILLocation is encoded as a SIL_SOURCE_LOC_REF with
+            // LocID=0; leave the placeholder anchor in place for those.
+            if (auto loc = maybeLoc.get())
+              applySite.setArgumentLoc(i, *loc);
+          }
+        }
+      }
     }
 
     // Fetch the next record.
@@ -1584,6 +1621,7 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
 
   unsigned ApplyCallerIsolation = unsigned(ActorIsolation::Unspecified);
   unsigned ApplyCalleeIsolation = unsigned(ActorIsolation::Unspecified);
+  unsigned ApplyHasArgumentLocs = 0;
 
   switch (RecordKind) {
   default:
@@ -1667,9 +1705,9 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     break;
   case SIL_INST_APPLY: {
     unsigned Kind, RawApplyOpts;
-    SILInstApplyLayout::readRecord(scratch, Kind, RawApplyOpts, SubID, TyID,
-                                   TyID2, ValID, ApplyCallerIsolation,
-                                   ApplyCalleeIsolation, ListOfValues);
+    SILInstApplyLayout::readRecord(
+        scratch, Kind, RawApplyOpts, ApplyHasArgumentLocs, SubID, TyID, TyID2,
+        ValID, ApplyCallerIsolation, ApplyCalleeIsolation, ListOfValues);
     switch (Kind) {
     case SIL_APPLY:
       RawOpCode = (unsigned)SILInstructionKind::ApplyInst;
@@ -2343,14 +2381,30 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
       IsolationCrossing = {caller, callee};
     }
 
+    // When the apply record carried HasArgumentLocs=1, NumArguments
+    // SIL_SOURCE_LOC / SIL_SOURCE_LOC_REF records arrive immediately
+    // after this instruction. Reserve trailing per-arg location storage
+    // now, with placeholder anchor locations satisfying the "every slot
+    // valid" invariant; the post-instruction loop in the main read loop
+    // overwrites each slot with the real deserialized location via
+    // setArgumentLoc.
+    SmallVector<SILLocation, 8> placeholderArgLocs;
+    std::optional<ArrayRef<SILLocation>> argLocsRef;
+    if (ApplyHasArgumentLocs) {
+      placeholderArgLocs.assign(Args.size(), Loc);
+      argLocsRef = ArrayRef<SILLocation>(placeholderArgLocs);
+    }
+
     if (OpCode == SILInstructionKind::ApplyInst) {
       ResultInst = Builder.createApply(
           Loc, getLocalValue(Builder.maybeGetFunction(), ValID, FnTy),
-          Substitutions, Args, ApplyOpts, nullptr, IsolationCrossing);
+          Substitutions, Args, ApplyOpts, nullptr, IsolationCrossing,
+          argLocsRef);
     } else {
       ResultInst = Builder.createBeginApply(
           Loc, getLocalValue(Builder.maybeGetFunction(), ValID, FnTy),
-          Substitutions, Args, ApplyOpts, nullptr, IsolationCrossing);
+          Substitutions, Args, ApplyOpts, nullptr, IsolationCrossing,
+          argLocsRef);
     }
     break;
   }
@@ -2389,10 +2443,19 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
       IsolationCrossing = {caller, callee};
     }
 
+    SmallVector<SILLocation, 8> placeholderArgLocs;
+    std::optional<ArrayRef<SILLocation>> argLocsRef;
+    if (ApplyHasArgumentLocs) {
+      placeholderArgLocs.assign(Args.size(), Loc);
+      argLocsRef = ArrayRef<SILLocation>(placeholderArgLocs);
+    }
+
     ResultInst = Builder.createTryApply(
         Loc, getLocalValue(Builder.maybeGetFunction(), ValID, FnTy),
         Substitutions, Args, normalBB, errorBB, ApplyOpts, nullptr,
-        IsolationCrossing);
+        IsolationCrossing,
+        /*normalCount=*/ProfileCounter(),
+        /*errorCount=*/ProfileCounter(), argLocsRef);
     break;
   }
   case SILInstructionKind::PartialApplyInst: {
@@ -2431,11 +2494,18 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     auto isNested = StackAllocationIsNested_t(
       IsNestedEncoding((flags >> 0) & 1) == IsNestedEncoding::IsNested);
 
+    SmallVector<SILLocation, 8> placeholderArgLocs;
+    std::optional<ArrayRef<SILLocation>> argLocsRef;
+    if (ApplyHasArgumentLocs) {
+      placeholderArgLocs.assign(Args.size(), Loc);
+      argLocsRef = ArrayRef<SILLocation>(placeholderArgLocs);
+    }
+
     // FIXME: Why the arbitrary order difference in IRBuilder type argument?
     ResultInst = Builder.createPartialApply(
-        Loc, FnVal, Substitutions, Args,
-        closureTy->getCalleeConvention(), closureTy->getIsolation(), onStack,
-        isNested);
+        Loc, FnVal, Substitutions, Args, closureTy->getCalleeConvention(),
+        closureTy->getIsolation(), onStack, isNested,
+        /*SpecializationInfo=*/nullptr, argLocsRef);
     break;
   }
   case SILInstructionKind::BuiltinInst: {

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,8 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 1006; // debug reconstruction blocks
+const uint16_t SWIFTMODULE_VERSION_MINOR =
+    1007; // per-argument SILLocations on apply
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///

--- a/lib/Serialization/SILFormat.h
+++ b/lib/Serialization/SILFormat.h
@@ -562,6 +562,7 @@ namespace sil_block {
     SIL_INST_APPLY,
     BCFixed<3>,           // ApplyKind
     BCFixed<2>,           // ApplyOptions
+    BCFixed<1>,           // HasArgumentLocs (1 = NumCallArguments source-loc records follow)
     SubstitutionMapIDField,  // substitution map
     TypeIDField,          // callee unsubstituted type
     TypeIDField,          // callee substituted type

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -364,6 +364,7 @@ namespace {
     /// Serialize and write SILDebugScope graph in post order.
     void writeDebugScopes(const SILDebugScope *Scope, const SourceManager &SM);
     void writeSourceLoc(SILLocation SLoc, const SourceManager &SM);
+    void writeApplyArgLocs(ApplySite AS, const SourceManager &SM);
 
     void writeNoOperandLayout(const SILInstruction *I) {
       unsigned abbrCode = SILAbbrCodes[SILInstNoOperandLayout::Code];
@@ -1466,7 +1467,8 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
     }
     SILInstApplyLayout::emitRecord(
         Out, ScratchRecord, SILAbbrCodes[SILInstApplyLayout::Code], SIL_BUILTIN,
-        0, S.addSubstitutionMapRef(BI->getSubstitutions()),
+        0, /*HasArgumentLocs=*/0,
+        S.addSubstitutionMapRef(BI->getSubstitutions()),
         S.addTypeRef(BI->getType().getRawASTType()),
         (unsigned)BI->getType().getCategory(),
         S.addDeclBaseNameRef(BI->getName()),
@@ -1496,10 +1498,13 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
     SILInstApplyLayout::emitRecord(
         Out, ScratchRecord, SILAbbrCodes[SILInstApplyLayout::Code], SIL_APPLY,
         unsigned(AI->getApplyOptions().toRaw()),
+        unsigned(AI->getArgumentLocs().has_value()),
         S.addSubstitutionMapRef(AI->getSubstitutionMap()),
         S.addTypeRef(AI->getCallee()->getType().getRawASTType()),
         S.addTypeRef(AI->getSubstCalleeType()), addValueRef(AI->getCallee()),
         unsigned(callerIsolation), unsigned(calleeIsolation), Args);
+    writeApplyArgLocs(ApplySite(const_cast<ApplyInst *>(AI)),
+                      SI.getModule().getSourceManager());
     break;
   }
   case SILInstructionKind::BeginApplyInst: {
@@ -1524,10 +1529,13 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
     SILInstApplyLayout::emitRecord(
         Out, ScratchRecord, SILAbbrCodes[SILInstApplyLayout::Code],
         SIL_BEGIN_APPLY, unsigned(AI->getApplyOptions().toRaw()),
+        unsigned(AI->getArgumentLocs().has_value()),
         S.addSubstitutionMapRef(AI->getSubstitutionMap()),
         S.addTypeRef(AI->getCallee()->getType().getRawASTType()),
         S.addTypeRef(AI->getSubstCalleeType()), addValueRef(AI->getCallee()),
         unsigned(callerIsolation), unsigned(calleeIsolation), Args);
+    writeApplyArgLocs(ApplySite(const_cast<BeginApplyInst *>(AI)),
+                      SI.getModule().getSourceManager());
     break;
   }
   case SILInstructionKind::TryApplyInst: {
@@ -1555,10 +1563,13 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
     SILInstApplyLayout::emitRecord(
         Out, ScratchRecord, SILAbbrCodes[SILInstApplyLayout::Code],
         SIL_TRY_APPLY, unsigned(AI->getApplyOptions().toRaw()),
+        unsigned(AI->getArgumentLocs().has_value()),
         S.addSubstitutionMapRef(AI->getSubstitutionMap()),
         S.addTypeRef(AI->getCallee()->getType().getRawASTType()),
         S.addTypeRef(AI->getSubstCalleeType()), addValueRef(AI->getCallee()),
         unsigned(callerIsolation), unsigned(calleeIsolation), Args);
+    writeApplyArgLocs(ApplySite(const_cast<TryApplyInst *>(AI)),
+                      SI.getModule().getSourceManager());
     break;
   }
   case SILInstructionKind::PartialApplyInst: {
@@ -1573,13 +1584,14 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
                         : IsNestedEncoding::IsNotNested) << 0;
     SILInstApplyLayout::emitRecord(
         Out, ScratchRecord, SILAbbrCodes[SILInstApplyLayout::Code],
-        SIL_PARTIAL_APPLY, 0,
+        SIL_PARTIAL_APPLY, 0, unsigned(PAI->getArgumentLocs().has_value()),
         S.addSubstitutionMapRef(PAI->getSubstitutionMap()),
         S.addTypeRef(PAI->getCallee()->getType().getRawASTType()),
         S.addTypeRef(PAI->getType().getRawASTType()),
-        addValueRef(PAI->getCallee()),
-        flags,
+        addValueRef(PAI->getCallee()), flags,
         unsigned(swift::ActorIsolation::Unspecified), Args);
+    writeApplyArgLocs(ApplySite(const_cast<PartialApplyInst *>(PAI)),
+                      SI.getModule().getSourceManager());
     break;
   }
   case SILInstructionKind::AllocGlobalInst: {
@@ -3551,6 +3563,31 @@ void SILSerializer::writeSourceLoc(SILLocation Loc, const SourceManager &SM) {
   SourceLocLayout::emitRecord(Out, ScratchRecord,
                               SILAbbrCodes[SourceLocLayout::Code], Row, Column,
                               FNameID, LocationKind, (unsigned)Loc.isImplicit());
+}
+
+void SILSerializer::writeApplyArgLocs(ApplySite AS, const SourceManager &SM) {
+  if (!Options.SerializeDebugInfoSIL)
+    return;
+
+  // Per the in-memory invariant, an apply either has trailing per-argument
+  // location storage (every slot a valid SILLocation) or none at all. The
+  // SILInstApplyLayout HasArgumentLocs bit captures which case applies; we
+  // only emit the trailing records when storage is present.
+  auto argLocs = AS.getArgumentLocs();
+  if (!argLocs)
+    return;
+
+  assert(argLocs->size() == AS.getNumArguments() &&
+         "argLocs storage must be parallel to args when present");
+
+  // Emit one SIL_SOURCE_LOC / SIL_SOURCE_LOC_REF record per argument, in
+  // argument order. The SILInstApplyLayout HasArgumentLocs bit on the
+  // preceding apply record signals the deserializer to consume exactly
+  // NumCallArguments such records inline. Reuses writeSourceLoc so per-
+  // argument locations share the same encoding (and OpaquePtr-based
+  // cache) as instruction debug-loc overrides.
+  for (auto loc : *argLocs)
+    writeSourceLoc(loc, SM);
 }
 
 void SILSerializer::writeExtraStringIfNonEmpty(

--- a/test/Concurrency/transfernonsendable_isolationhistory.sil
+++ b/test/Concurrency/transfernonsendable_isolationhistory.sil
@@ -1,10 +1,10 @@
-// RUN: %target-sil-opt -send-non-sendable -sil-regionbasedisolation-emit-isolation-history -strict-concurrency=complete %s -o /dev/null -verify
+// RUN: %target-sil-opt -send-non-sendable -sil-region-isolation-emit-isolation-history -strict-concurrency=complete %s -o /dev/null -verify
 
 // REQUIRES: concurrency
 // REQUIRES: asserts
 
 // SIL coverage test for the
-// `-sil-regionbasedisolation-emit-isolation-history` flag. Each test below
+// `-sil-region-isolation-emit-isolation-history` flag. Each test below
 // exercises a specific class of merge translated by RegionAnalysis: apply
 // arguments/results, store_borrow, store, alloc_stack-as-var_decl, plus
 // chain and CFG-join cases.

--- a/test/Concurrency/transfernonsendable_isolationhistory.swift
+++ b/test/Concurrency/transfernonsendable_isolationhistory.swift
@@ -875,3 +875,4 @@ func continuation_chain(_ x: NS) async {
   //                                   note: 'y' is reachable from 'mid'
   //                                   note: 'mid' is reachable from 'x' which is accessible to ...
 }
+

--- a/test/Concurrency/transfernonsendable_isolationhistory.swift
+++ b/test/Concurrency/transfernonsendable_isolationhistory.swift
@@ -1,9 +1,9 @@
-// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -disable-availability-checking -parse-as-library -Xllvm -sil-regionbasedisolation-emit-isolation-history -verify %s -o /dev/null
+// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -disable-availability-checking -parse-as-library -sil-region-isolation-emit-isolation-history -verify %s -o /dev/null
 
 // REQUIRES: concurrency
 
 // Swift-source coverage test for the
-// `-sil-regionbasedisolation-emit-isolation-history` flag, which makes the
+// `-sil-region-isolation-emit-isolation-history` flag, which makes the
 // SendNonSendable pass emit additional notes describing the chain of merges
 // that brought a sent value into an actor-isolated region. The originating
 // note names the isolated source ("'y' is connected to 'x' which is
@@ -876,3 +876,75 @@ func continuation_chain(_ x: NS) async {
   //                                   note: 'mid' is reachable from 'x' which is accessible to ...
 }
 
+////////////////////////////////////////////////////////////////////////////////
+// Per-argument SILLocation: verifies that when SILGen attaches per-argument
+// locations to an apply (gated by isolation-history), the originating-merge
+// note anchors at the AST argument's source position rather than at the
+// apply's anchor (the call expression's start). Each variant exercises a
+// different apply opcode so the per-arg loc array survives ApplyInst,
+// TryApplyInst, and BeginApplyInst construction.
+////////////////////////////////////////////////////////////////////////////////
+
+// First-argument case: the offending value is in slot 0. Confirms that the
+// per-arg loc array is not silently shifted by the indirect-result / error
+// prefix when the apply has neither.
+func per_arg_loc(_ x: NS) async {
+  let y = combine(
+    x, // expected-note {{'y' is connected to 'x' which is accessible to code in the current isolation context}}
+    NS())
+  await transferToMain(y) // expected-warning {{sending 'y' risks causing data races}}
+  // expected-note @-1 {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+// Second-argument case: the offending value is in slot 1. Confirms the
+// per-arg loc array is indexed by argument position, not just the first
+// slot. A bug that always wrote the first slot would anchor the note at
+// the `NS()` line above instead of the `x,` line below.
+func per_arg_loc_second(_ x: NS) async {
+  let y = combine(
+    NS(),
+    x) // expected-note {{'y' is connected to 'x' which is accessible to code in the current isolation context}}
+  await transferToMain(y) // expected-warning {{sending 'y' risks causing data races}}
+  // expected-note @-1 {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+// Throwing call (try_apply) case: confirms that createTryApply forwards
+// the argLocs array to the constructed TryApplyInst. The PartitionOp
+// derived from this call site reads the per-argument loc; a regression in
+// TryApply argLoc threading would surface here as the note anchoring at
+// the call line instead of the argument line.
+func combineThrows(_ a: NS, _ b: NS) throws -> NS { a }
+
+func per_arg_loc_throws(_ x: NS) async throws {
+  let y = try combineThrows(
+    x, // expected-note {{'y' is connected to 'x' which is accessible to code in the current isolation context}}
+    NS())
+  await transferToMain(y) // expected-warning {{sending 'y' risks causing data races}}
+  // expected-note @-1 {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}
+
+// Coroutine (begin_apply) case: a read accessor lowers to begin_apply.
+// Reading `bag.slot` through the coroutine accessor and then folding the
+// borrowed value into a region exercises createBeginApply's argLoc path.
+final class BagWithRead {
+  private var stored: NS = NS()
+  var slot: NS {
+    _read { yield stored }
+  }
+}
+
+func per_arg_loc_coroutine(_ x: NS) async {
+  let bag = BagWithRead()
+  // Use combine() with a multi-line arg list so the per-arg loc for `x` is
+  // on a different line than the call. The merge of `x` into `bag`'s
+  // region happens inside combine; the SIL apply receives `x` at slot 0
+  // and `bag.slot` (read coroutine) at slot 1.
+  // expected-note@+1{{'y' is connected to 'bag'}}
+  let y = combine(
+    // expected-note@+1{{'bag.slot' is connected to 'y'}}
+    bag.slot,
+    x, // expected-note {{'bag' is connected to 'x' which is accessible to code in the current isolation context}}
+  )
+  await transferToMain(y) // expected-warning {{sending 'y' risks causing data races}}
+  // expected-note @-1 {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated code and code in the current isolation context}}
+}

--- a/test/Concurrency/transfernonsendable_isolationhistory_diagnose_attr.swift
+++ b/test/Concurrency/transfernonsendable_isolationhistory_diagnose_attr.swift
@@ -5,7 +5,7 @@
 // Verifies that the `@diagnose(RegionIsolationIsolationHistory, as: warning)`
 // attribute on a function opts that function in to isolation-history note
 // emission for SentNeverSendable diagnostics, even when the
-// `-sil-regionbasedisolation-emit-isolation-history` LLVM flag is not passed.
+// `-sil-region-isolation-emit-isolation-history` frontend flag is not passed.
 //
 // Conversely, a function with no attribute should NOT emit isolation-history
 // notes. The `no_attr` function below validates this by omitting the


### PR DESCRIPTION
This PR contains two changes:

1. I wire up the emission of SILLocations on ApplySites in functions where diagnose is used to turn on IsolationHistory.
2. I use it in IsolationHistory.

The reason why I am doing it this way is b/c I am finding that not having these locations impacts the isolation history diagnostics significantly and I want to also be very careful about any other impacts on the compiler. I do think that it is safe but it doesn't hurt to be careful.