### PR TITLE
[6.4] BorrowingForLoop: make experimental feature available in production

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -579,7 +579,7 @@ EXPERIMENTAL_FEATURE(ImportMacroAliases, true)
 LANGUAGE_FEATURE(BorrowAndMutateAccessors, 507, "borrow and mutate accessors")
 
 /// Enable borrowing for-in loops
-EXPERIMENTAL_FEATURE(BorrowingForLoop, false)
+EXPERIMENTAL_FEATURE(BorrowingForLoop, true)
 
 /// Allow use of @inline(always) attribute
 SUPPRESSIBLE_LANGUAGE_FEATURE(InlineAlways, 496, "@inline(always) attribute")


### PR DESCRIPTION
Explanation: Making the BorrowingForLoop experimental feature available in production
Original PR: BorrowingForLoop: make experimental feature available in production
#90020
Issue: rdar://179931659
Risk:  Low, the feature needs to be explicitly enabled via the experimental flag.
Testing: None
Reviewers: @kavon @hamishknight 