### PR TITLE
[test] Mark arm64 watchOS as mandating the stable ABI

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1199,7 +1199,7 @@ target_os_abi = run_os
 target_os_is_maccatalyst = "FALSE"
 target_mandates_stable_abi = "FALSE"
 if (run_cpu in ('arm64e',) or \
-    (run_os == 'watchos' and run_cpu == 'x86_64') or \
+    (run_os == 'watchos' and run_cpu in ('x86_64', 'arm64')) or \
     (run_os == 'xros')):
   target_mandates_stable_abi = "TRUE"
   config.available_features.add('swift_only_stable_abi')


### PR DESCRIPTION
arm64 watchOS (device) is new with watchOS 26 / Xcode 27 and, like arm64e, arm64 macOS, arm64 simulators, and the x86_64 watchOS simulator, only ever shipped with Swift in the OS.

It therefore mandates the stable ABI, but was missing from the `target_mandates_stable_abi`/`swift_only_stable_abi` set in test/lit.cfg.

When the supported watchOS test architectures were updated to match Xcode 27.0 (adding arm64 to the watchOS arch set), several IRGen tests began failing on arm64-apple-watchos because lit treated it as a pre-stable-ABI target. On 64-bit watchOS, `ASTContext::getSwiftAvailability()` makes Swift 5.0 features always-available, so `getClassMetadataStrategy()` selects the Update pattern (`swift_updateClassMetadata2`) rather than the Singleton/init pattern. The compiler is correct; the tests' expectations just didn't account for arm64 watchOS.

Adding arm64 watchOS to this set fixes the affected tests through the existing machinery: tests gated on `swift_only_stable_abi` become unsupported on arm64 watchOS, and tests parameterized on `%target-mandates-stable-abi` select the STABLE-ABI-TRUE expectations.

Addresses rdar://179535264
