### PR TITLE
[6.4🍒][test] Mark arm64 watchOS as mandating the stable ABI

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1181,7 +1181,7 @@ target_os_abi = run_os
 target_os_is_maccatalyst = "FALSE"
 target_mandates_stable_abi = "FALSE"
 if (run_cpu in ('arm64e',) or \
-    (run_os == 'watchos' and run_cpu == 'x86_64') or \
+    (run_os == 'watchos' and run_cpu in ('x86_64', 'arm64')) or \
     (run_os == 'xros')):
   target_mandates_stable_abi = "TRUE"
   config.available_features.add('swift_only_stable_abi')


### PR DESCRIPTION
- **Explanation**:
In lit tests configure arm64 watchOS as requiring the stable ABI -- this was missed when adding this architecture to the opensource toolchain in https://github.com/swiftlang/swift/pull/89774

- **Scope**:
Configuration of lit tests, in particular tests that rely on the `target_mandates_stable_abi` features

- **Issues**:
rdar://179535264

- **Original PRs**:
https://github.com/swiftlang/swift/pull/90047#pullrequestreview-4528447907

- **Risk**:
Low -- this is a well understood part of the configuration, so it is unlikely we regress other architectures/platforms requiring the stable abi, in the worst case the affected tests will keep failing.

- **Testing**:
CI testing, in particular using the `buildbot,tools=RA,stdlib=RD,test=non_executable` preset
- **Reviewers**:
@edymtt

