### PR TITLE
[Sema] Use target's start location to create the synthesized CodingKeys enum.

### DIFF
--- a/lib/Sema/DerivedConformance/DerivedConformanceCodable.cpp
+++ b/lib/Sema/DerivedConformance/DerivedConformanceCodable.cpp
@@ -27,6 +27,7 @@
 #include "swift/AST/Stmt.h"
 #include "swift/AST/Types.h"
 #include "swift/Basic/Assertions.h"
+#include "swift/Basic/SourceLoc.h"
 #include "swift/Basic/StringExtras.h"
 #include "llvm/ADT/STLExtras.h"
 
@@ -149,8 +150,10 @@ addImplicitCodingKeys(NominalTypeDecl *target,
     InheritedEntry(TypeLoc::withoutLoc(codingKeyType))};
   ArrayRef<InheritedEntry> inherited = C.AllocateCopy(protoTypeLoc);
 
-  auto *enumDecl = new (C) EnumDecl(SourceLoc(), codingKeysEnumIdentifier,
+  auto anchorLoc = target->getStartLoc();
+  auto *enumDecl = new (C) EnumDecl(anchorLoc, codingKeysEnumIdentifier,
                                     SourceLoc(), inherited, nullptr, target);
+  enumDecl->setBraces(anchorLoc);
   enumDecl->setImplicit();
   enumDecl->setSynthesized();
   enumDecl->setAccess(AccessLevel::Private);


### PR DESCRIPTION
When deriving `Codable`, the synthesized implicit `CodingKeys` enum now inherits the source range of its target.

This is required to correctly construct the `AvailabilityScope` for synthesized source files (synthetic macros, macro expansions, or default arguments) when the implicit `CodingKeys` enum is the enclosing node.

I've deliberately left the location off the enum's elements, since adding it caused other problems. That can be the subject of a follow-up PR.