### PR TITLE
swift-inspect: remove redundant glibc import

### DIFF
--- a/tools/swift-inspect/Sources/swift-inspect/Operations/DumpConcurrency.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/Operations/DumpConcurrency.swift
@@ -12,9 +12,6 @@
 
 import ArgumentParser
 import SwiftRemoteMirror
-#if canImport(Glibc)
-import Glibc
-#endif
 #if canImport(string_h)
 import string_h
 #endif


### PR DESCRIPTION
Necessary followup for https://github.com/swiftlang/swift/pull/89789/ to unbreak https://ci-external.swift.org/job/swift-main-windows-toolchain