### PR TITLE
[windows] restore force-load anchors in CRT/WinSDK overlays

### DIFF
--- a/Runtimes/Overlay/Windows/CRT/CMakeLists.txt
+++ b/Runtimes/Overlay/Windows/CRT/CMakeLists.txt
@@ -12,7 +12,6 @@ set_target_properties(swiftCRT PROPERTIES
 target_compile_definitions(swiftCRT PRIVATE
   $<$<BOOL:${SwiftOverlay_ENABLE_REFLECTION}>:SWIFT_ENABLE_REFLECTION>)
 target_compile_options(swiftCRT PRIVATE
-  "SHELL:-Xfrontend -disable-force-load-symbols"
   "SHELL:-Xcc -D_USE_MATH_DEFINES")
 target_link_libraries(swiftCRT PUBLIC
   ClangModules)

--- a/Runtimes/Overlay/Windows/WinSDK/CMakeLists.txt
+++ b/Runtimes/Overlay/Windows/WinSDK/CMakeLists.txt
@@ -5,8 +5,6 @@ set_target_properties(swiftWinSDK PROPERTIES
   Swift_MODULE_NAME WinSDK)
 target_compile_definitions(swiftWinSDK PRIVATE
   $<$<BOOL:${SwiftOverlay_ENABLE_REFLECTION}>:SWIFT_ENABLE_REFLECTION>)
-target_compile_options(swiftWinSDK PRIVATE
-  "SHELL:-Xfrontend -disable-force-load-symbols")
 target_link_libraries(swiftWinSDK PUBLIC
   ClangModules)
 target_link_libraries(swiftWinSDK PRIVATE


### PR DESCRIPTION
45cfb07b0d6 added `-Xfrontend -disable-force-load-symbols` to the CRT and WinSDK overlays. The flag prevent the anchor symbol's emission in the overlay's own `object/lib`, but it does NOT prevent the matching reference `(_swift_FORCE_LOAD_$_swift{CRT,WinSDK}_$_<consumer>)` in consumers. This causes `lld-link` failures with "undefined symbol".

This causes swift lldb tests failures: https://github.com/swiftlang/llvm-project/pull/13212

This patch drops the flag from both overlays.