### PR TITLE
[IRGen] Propagate -disable-force-load-symbols

### DIFF
--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -426,6 +426,9 @@ let Flags = [FrontendOption, NoDriverOption, HelpHidden, ModuleInterfaceOption] 
     Flag<["-"], "enable-experimental-async-top-level">,
     HelpText<"Enable experimental concurrency in top-level code">;
 
+  def disable_force_load_symbols : Flag<["-"],"disable-force-load-symbols">,
+      HelpText<"Disable generation of all Swift _FORCE_LOAD symbols">;
+
   def public_autolink_library :
     Separate<["-"], "public-autolink-library">,
     HelpText<"Add public dependent library">;
@@ -665,10 +668,6 @@ def disable_autolink_frameworks : Flag<["-"],"disable-autolink-frameworks">,
 
 def disable_all_autolinking : Flag<["-"],"disable-all-autolinking">,
   HelpText<"Disable all Swift autolink directives">;
-
-def disable_force_load_symbols : Flag<["-"],"disable-force-load-symbols">,
-  Flags<[FrontendOption, HelpHidden]>,
-  HelpText<"Disable generation of all Swift _FORCE_LOAD symbols">;
 
 def disable_diagnostic_passes : Flag<["-"], "disable-diagnostic-passes">,
   HelpText<"Don't run diagnostic passes">;

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -235,7 +235,8 @@ SerializationOptions CompilerInvocation::computeSerializationOptions(
   serializationOpts.ABIDescriptorPath = outs.ABIDescriptorOutputPath.c_str();
   serializationOpts.emptyABIDescriptor = opts.emptyABIDescriptor;
 
-  if (!getIRGenOptions().ForceLoadSymbolName.empty())
+  if (!getIRGenOptions().ForceLoadSymbolName.empty() &&
+      !getIRGenOptions().DisableForceLoadSymbols)
     serializationOpts.AutolinkForceLoad = true;
 
   // Options contain information about the developer's computer,

--- a/lib/Frontend/ModuleInterfaceBuilder.cpp
+++ b/lib/Frontend/ModuleInterfaceBuilder.cpp
@@ -287,7 +287,8 @@ std::error_code ExplicitModuleInterfaceBuilder::buildSwiftModuleFromInterface(
   SerializationOpts.OutputPath = OutPathStr.c_str();
   SerializationOpts.ModuleLinkName = FEOpts.ModuleLinkName;
   SerializationOpts.AutolinkForceLoad =
-      !Invocation.getIRGenOptions().ForceLoadSymbolName.empty();
+      !Invocation.getIRGenOptions().ForceLoadSymbolName.empty() &&
+      !Invocation.getIRGenOptions().DisableForceLoadSymbols;
   SerializationOpts.PublicDependentLibraries =
       Invocation.getIRGenOptions().PublicLinkLibraries;
   SerializationOpts.UserModuleVersion = FEOpts.UserModuleVersion;

--- a/test/Serialization/disable-force-load-symbols.swift
+++ b/test/Serialization/disable-force-load-symbols.swift
@@ -1,0 +1,66 @@
+// Test that -disable-force-load-symbols propagates through serialized
+// LINK_LIBRARY records (and through swift-module-flags in .swiftinterface),
+// so consumers automatically skip the
+// _swift_FORCE_LOAD_$_<module>_$_<consumer> reference at IRGen.
+//
+// See also: test/ModuleInterface/force-load-autolink.swift (positive case).
+
+// RUN: %empty-directory(%t)
+
+// === 1. Producer
+// RUN: %target-swift-frontend -emit-module -parse-stdlib                       \
+// RUN:   -module-name TestModule -module-link-name TestModule                  \
+// RUN:   -autolink-force-load -disable-force-load-symbols                      \
+// RUN:   -o %t/TestModule.swiftmodule %S/../Inputs/empty.swift
+// RUN: %target-swift-ide-test -print-module-metadata                           \
+// RUN:   -module-to-print TestModule -I %t -source-filename %s                 \
+// RUN:   | %FileCheck --check-prefix=DISABLED %s
+//
+// DISABLED: link library: TestModule, force load: false
+
+// === 2. Consumer
+// RUN: %target-swift-frontend -emit-ir -parse-stdlib                           \
+// RUN:   -runtime-compatibility-version none                                   \
+// RUN:   -disable-autolinking-runtime-compatibility-dynamic-replacements       \
+// RUN:   -disable-autolinking-runtime-compatibility-concurrency                \
+// RUN:   -I %t %s | %FileCheck --check-prefix=CONSUMER %s
+//
+// CONSUMER-NOT: _swift_FORCE_LOAD_$_TestModule
+
+// === 3. Producer
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -typecheck -parse-stdlib                         \
+// RUN:   -module-name TestModule -module-link-name TestModule                  \
+// RUN:   -enable-library-evolution                                             \
+// RUN:   -autolink-force-load -disable-force-load-symbols                      \
+// RUN:   -emit-module-interface-path %t/TestModule.swiftinterface              \
+// RUN:   %S/../Inputs/empty.swift
+// RUN: %FileCheck --check-prefix=INTERFACE-FLAG %s < %t/TestModule.swiftinterface
+// RUN: %target-swift-frontend -compile-module-from-interface                   \
+// RUN:   -o %t/TestModule.swiftmodule %t/TestModule.swiftinterface
+// RUN: %target-swift-ide-test -print-module-metadata                           \
+// RUN:   -module-to-print TestModule -I %t -source-filename %s                 \
+// RUN:   | %FileCheck --check-prefix=INTERFACE-DISABLED %s
+//
+// INTERFACE-FLAG: swift-module-flags:{{.*}}-disable-force-load-symbols
+// INTERFACE-DISABLED: link library: TestModule, force load: false
+
+// === 4. Negative control
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -parse-stdlib                       \
+// RUN:   -module-name TestModule -module-link-name TestModule                  \
+// RUN:   -autolink-force-load                                                  \
+// RUN:   -o %t/TestModule.swiftmodule %S/../Inputs/empty.swift
+// RUN: %target-swift-ide-test -print-module-metadata                           \
+// RUN:   -module-to-print TestModule -I %t -source-filename %s                 \
+// RUN:   | %FileCheck --check-prefix=BASELINE %s
+// RUN: %target-swift-frontend -emit-ir -parse-stdlib                           \
+// RUN:   -runtime-compatibility-version none                                   \
+// RUN:   -disable-autolinking-runtime-compatibility-dynamic-replacements       \
+// RUN:   -disable-autolinking-runtime-compatibility-concurrency                \
+// RUN:   -I %t %s | %FileCheck --check-prefix=BASELINE-CONSUMER %s
+//
+// BASELINE: link library: TestModule, force load: true
+// BASELINE-CONSUMER: _swift_FORCE_LOAD_$_TestModule
+
+import TestModule


### PR DESCRIPTION
`-disable-force-load-symbols` deletes the anchor symbol in the producer, but serialization writes `AutolinkForceLoad=true` regardless of the value of the flag. Because of this, consumers reading the swiftmodule still emit a `_swift_FORCE_LOAD_$_<module>_$_<consumer>` reference at link time.
This causes the linker to fail with "undefined symbol".