### PR TITLE
Embedded: Enable readLine() on targets with a hosted libc

### DIFF
--- a/stdlib/public/EmbeddedPlatform/CMakeLists.txt
+++ b/stdlib/public/EmbeddedPlatform/CMakeLists.txt
@@ -42,6 +42,14 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
     endif()
     list(APPEND extra_c_compile_flags -nostdinc++)
 
+    # EmbeddedReadLine.swift needs a hosted libc (getline + stdin). Exclude every
+    # bare-metal triple (the "-none-" OS: wasm/elf/eabi/macho); keep it for hosted
+    # targets (apple-macos/ios, linux-gnu, wasip1, emscripten).
+    set(posix_shim_sources EmbeddedPlatformPOSIX.swift)
+    if(NOT "${triple}" MATCHES "-none-")
+      list(APPEND posix_shim_sources EmbeddedReadLine.swift)
+    endif()
+
     set(SWIFT_SDK_embedded_ARCH_${mod}_MODULE "${mod}")
     set(SWIFT_SDK_embedded_LIB_SUBDIR "embedded")
     set(SWIFT_SDK_embedded_ARCH_${mod}_TRIPLE "${triple}")
@@ -55,7 +63,7 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
       STATIC
       IS_FRAGILE
 
-      EmbeddedPlatformPOSIX.swift
+      ${posix_shim_sources}
 
       C_COMPILE_FLAGS ${extra_c_compile_flags}
       SWIFT_COMPILE_FLAGS ${swift_stdlib_compile_flags} -Xcc -ffreestanding -enable-experimental-feature Embedded "-import-bridging-header" ${CMAKE_CURRENT_SOURCE_DIR}/swift/EmbeddedPlatform.h -enable-experimental-feature Extern -enable-experimental-feature AllowRuntimeSymbolDeclarations "-disable-bridging-pch"

--- a/stdlib/public/EmbeddedPlatform/EmbeddedPlatformPOSIX.swift
+++ b/stdlib/public/EmbeddedPlatform/EmbeddedPlatformPOSIX.swift
@@ -5,8 +5,17 @@ func posix_memalign(_: UnsafeMutablePointer<UnsafeMutableRawPointer?>, _: Int, _
 @_extern(c, "free")
 func free(_ p: UnsafeMutableRawPointer?)
 
+// Randomness source. `arc4random_buf` covers Darwin, wasi-libc, and most other
+// libcs, but it only entered glibc in 2.36, so on Linux use `getentropy`
+// (glibc >= 2.25, musl), mirroring the platform split in
+// stdlib/public/stubs/Random.cpp.
+#if os(Linux)
+@_extern(c, "getentropy")
+func getentropy(_ buf: UnsafeMutableRawPointer, _ nbytes: Int) -> CInt
+#else
 @_extern(c, "arc4random_buf")
 func arc4random_buf(_ buf: UnsafeMutableRawPointer, _ nbytes: Int)
+#endif
 
 @_extern(c, "putchar")
 func putchar(_: CInt) -> CInt
@@ -47,16 +56,36 @@ public func _swift_free(_ pointer: UnsafeMutableRawPointer, _ alignment: Int, _ 
   free(pointer)
 }
 
+// Fills `buf` with `nbytes` bytes from the platform RNG; traps on failure.
+@inline(never)
+private func generateRandomBytes(_ buf: UnsafeMutableRawPointer, _ nbytes: Int) {
+#if os(Linux)
+  // `getentropy` returns at most 256 bytes per call and either fills the whole
+  // request or fails (no partial reads). Fail closed rather than hand back
+  // uninitialized memory as randomness (cf. the fatalError in Random.cpp).
+  var offset = 0
+  while offset < nbytes {
+    let count = min(nbytes - offset, 256)
+    guard unsafe getentropy(buf.advanced(by: offset), count) == 0 else {
+      fatalError("getentropy failed")
+    }
+    offset += count
+  }
+#else
+  unsafe arc4random_buf(buf, nbytes)
+#endif
+}
+
 @export(interface)
 @implementation @c
 public func _swift_generateRandom(_ buf: UnsafeMutableRawPointer, _ nbytes: Int) {
-  arc4random_buf(buf, nbytes)
+  unsafe generateRandomBytes(buf, nbytes)
 }
 
 @export(interface)
 @implementation @c
 public func _swift_generateRandomHashSeed(_ buf: UnsafeMutableRawPointer, _ nbytes: Int) {
-  arc4random_buf(buf, nbytes)
+  unsafe generateRandomBytes(buf, nbytes)
 }
 
 @export(interface)

--- a/stdlib/public/EmbeddedPlatform/EmbeddedReadLine.swift
+++ b/stdlib/public/EmbeddedPlatform/EmbeddedReadLine.swift
@@ -1,0 +1,75 @@
+//===--- EmbeddedReadLine.swift - readLine() backing for Embedded Swift ---===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if SWIFT_STDLIB_HAS_STDIN
+
+// This reproduces the full stdlib's POSIX `swift_stdlib_readLine_stdin`
+// (the non-`_WIN32` branch in stdlib/public/stubs/Stubs.cpp): `getline` over
+// `stdin`, retrying while it fails with `errno == EINTR`. Embedded Swift has no
+// stdio.h/errno.h import, so the libc symbols the C version reaches through the
+// preprocessor must be named explicitly here. Two are spelled differently per
+// libc, and the `EINTR` value differs too:
+//   - the `stdin` FILE* global:  `__stdinp` on Darwin, `stdin` elsewhere
+//   - the errno accessor:        `__error()` on Darwin, `__errno_location()` elsewhere
+//   - EINTR:                     27 on wasi-libc, 4 on Darwin/Linux/musl
+
+@_extern(c, "getline")
+func getline(
+  _ linePtr: UnsafeMutablePointer<UnsafeMutablePointer<UInt8>?>,
+  _ capacity: UnsafeMutablePointer<Int>,
+  _ stream: OpaquePointer?
+) -> Int
+
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(visionOS)
+@_extern(c, "__stdinp")
+var _stdin: OpaquePointer?
+@_extern(c, "__error")
+func _errnoLocation() -> UnsafeMutablePointer<CInt>
+#else // linux-gnu (glibc/musl), wasip1, emscripten
+@_extern(c, "stdin")
+var _stdin: OpaquePointer?
+@_extern(c, "__errno_location")
+func _errnoLocation() -> UnsafeMutablePointer<CInt>
+#endif
+
+#if os(WASI)
+let _EINTR: CInt = 27
+#else
+let _EINTR: CInt = 4
+#endif
+
+/// Backing for `readLine()` in Embedded Swift on hosted-libc targets.
+///
+/// A direct reproduction of the full stdlib's POSIX implementation
+/// (`swift_stdlib_readLine_stdin`, stdlib/public/stubs/Stubs.cpp): read one line
+/// from `stdin` with `getline` into a `malloc`'d buffer (which the caller
+/// releases with `free`, matching `_swift_stdlib_free`), retrying while `getline`
+/// fails with `errno == EINTR`. Returns the number of bytes read including any
+/// trailing newline, or -1 at EOF. `linePtr` must be non-null (the C declaration
+/// annotates it `_Nonnull`); on success it receives the `getline`-allocated
+/// buffer.
+@c(swift_stdlib_readLine_stdin)
+public func swift_stdlib_readLine_stdin(
+  _ linePtr: UnsafeMutablePointer<UnsafeMutablePointer<UInt8>?>
+) -> Int {
+  var capacity = 0
+  while true {
+    let result = unsafe getline(linePtr, &capacity, _stdin)
+    // Retry only on an EINTR-interrupted read, exactly as the C version's
+    // `do { } while (result < 0 && errno == EINTR)`: a success or any other
+    // failure (including EOF, where getline returns -1) is returned as-is.
+    if result >= 0 { return result }
+    if unsafe _errnoLocation().pointee != _EINTR { return result }
+  }
+}
+
+#endif // SWIFT_STDLIB_HAS_STDIN

--- a/stdlib/public/core/InputStream.swift
+++ b/stdlib/public/core/InputStream.swift
@@ -28,7 +28,6 @@ import SwiftShims
 ///   or character combinations are preserved. The default is `true`.
 /// - Returns: The string of characters read from standard input. If EOF has
 ///   already been reached when `readLine()` is called, the result is `nil`.
-@_unavailableInEmbedded
 public func readLine(strippingNewline: Bool = true) -> String? {
   var utf8Start: UnsafeMutablePointer<UInt8>?
   let utf8Count = unsafe swift_stdlib_readLine_stdin(&utf8Start)

--- a/test/embedded/readline-exec.swift
+++ b/test/embedded/readline-exec.swift
@@ -1,0 +1,98 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -parse-as-library -enable-experimental-feature Embedded -wmo -Xlinker -L%swift_obj_root/lib/swift/embedded/%module-target-triple -Xlinker -lswiftEmbeddedPlatformPOSIX -o %t/a.out
+
+// Build the stdin fixture one line at a time so each case's byte count is
+// auditable (a single mega-line of literals silently shifts the `len:` checks).
+// lit's built-in shell supports external commands + redirection, but NOT
+// command substitution $(...) or brace groups, so the lengths are spelled out.
+// RUN: printf 'first\n'                  >  %t/input
+// RUN: printf '\n'                       >> %t/input
+// RUN: printf 'third\n'                  >> %t/input
+// RUN: printf 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n'                   >> %t/input
+// RUN: printf 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n'                   >> %t/input
+// RUN: printf 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\n'                   >> %t/input
+// RUN: printf 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\n'                   >> %t/input
+// RUN: printf 'has\0nul\n'               >> %t/input
+// RUN: printf 'crlf\r\n'                 >> %t/input
+// RUN: printf 'embedded\rCR\n'           >> %t/input
+// RUN: printf 'no-newline-eof'           >> %t/input
+// RUN: %target-run %t/a.out < %t/input | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: executable_test
+// REQUIRES: optimized_stdlib
+// REQUIRES: OS=macosx || OS=linux-gnu || OS=wasip1 || OS=emscripten
+// REQUIRES: swift_feature_Embedded
+
+@main
+struct Main {
+  static func main() {
+    // ordinary line
+    print("got: \(readLine() ?? "<nil>")")
+    // CHECK: got: first
+
+    // empty line -> "" (distinct from EOF nil)
+    if let line = readLine() {
+      print("empty: \(line.isEmpty)")
+    } else {
+      print("empty: <nil>")
+    }
+    // CHECK-NEXT: empty: true
+
+    // ordinary line following the empty one
+    print("got: \(readLine() ?? "<nil>")")
+    // CHECK-NEXT: got: third
+
+    // Lines of various lengths, including ones longer than getline's initial
+    // libc buffer, must round-trip with the exact byte count. Measure
+    // `.utf8.count` (bytes), not `.count` (graphemes): grapheme counting would
+    // pull in the Unicode grapheme-break tables, which the embedded shim doesn't
+    // link, and byte count is the contract here anyway.
+    print("len: \(readLine()?.utf8.count ?? -1)")
+    // CHECK-NEXT: len: 127
+    print("len: \(readLine()?.utf8.count ?? -1)")
+    // CHECK-NEXT: len: 128
+    print("len: \(readLine()?.utf8.count ?? -1)")
+    // CHECK-NEXT: len: 129
+    // A long line forces getline to grow its buffer past the initial size.
+    print("len: \(readLine()?.utf8.count ?? -1)")
+    // CHECK-NEXT: len: 500
+
+    // Embedded NUL byte: the line is length-delimited, NUL is not a terminator.
+    // Check both the byte count and that the NUL scalar actually survives into
+    // the String (so this proves preservation, not just the return length).
+    if let line = readLine() {
+      print("nul-len: \(line.utf8.count) nul-kept: \(line.unicodeScalars.contains("\u{0}"))")
+    } else {
+      print("nul-len: <nil>")
+    }
+    // CHECK-NEXT: nul-len: 7 nul-kept: true
+
+    // CRLF line ending: getline reads up to and including '\n' (its delimiter)
+    // and keeps the '\r' as data; readLine()'s removeNewline() then strips the
+    // trailing "\r\n".
+    print("got: \(readLine() ?? "<nil>")")
+    // CHECK-NEXT: got: crlf
+
+    // A lone '\r' mid-line is data, not a delimiter: getline stops only at the
+    // trailing '\n', so the interior CR survives. Assert via byte count + scalar
+    // presence (not by emitting the raw CR, which FileCheck handling of carriage
+    // returns makes fragile): "embedded\rCR" is 11 bytes with the CR preserved;
+    // if CR ended the line it would be 8.
+    if let line = readLine() {
+      print("cr-len: \(line.utf8.count) cr-kept: \(line.unicodeScalars.contains("\r"))")
+    } else {
+      print("cr-len: <nil>")
+    }
+    // CHECK-NEXT: cr-len: 11 cr-kept: true
+
+    // final line with no trailing newline at EOF
+    print("got: \(readLine() ?? "<nil>")")
+    // CHECK-NEXT: got: no-newline-eof
+
+    // EOF -> nil: a fresh call with no input left has getline return -1, which
+    // the caller maps to nil.
+    print("got: \(readLine() ?? "<nil>")")
+    // CHECK-NEXT: got: <nil>
+  }
+}


### PR DESCRIPTION
`readLine()` is currently`@_unavailableInEmbedded`, but that's too restrictive. Add `EmbeddedReadLine.swift`, a Swift port of the stdlib's `getline`-over-`stdin` path, added in `libswiftEmbeddedPlatformPOSIX` for hosted-libc triples and is skipped for bare-metal (`-none-`).

Added `test/embedded/readline-exec.swift`.