### PR TITLE
[Sema] Fix a few places that should use `FixImpact::{InvalidReference, InvalidAST}`

### DIFF
--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -1110,8 +1110,10 @@ ConstraintSystem::matchResultBuilder(AnyFunctionRef fn, Type builderType,
   assert(!builderType->hasTypeParameter());
 
   if (InvalidResultBuilderBodies.count(fn)) {
-    (void)recordFix(IgnoreInvalidResultBuilderBody::create(
-        *this, getConstraintLocator(fn.getAbstractClosureExpr())));
+    (void)recordFix(
+        IgnoreInvalidResultBuilderBody::create(
+            *this, getConstraintLocator(fn.getAbstractClosureExpr())),
+        FixImpact::InvalidAST);
     return getTypeMatchSuccess();
   }
 
@@ -1127,8 +1129,9 @@ ConstraintSystem::matchResultBuilder(AnyFunctionRef fn, Type builderType,
     // continue solving the body.
     if (shouldAttemptFixes() && !isForCodeCompletion()) {
       if (recordFix(IgnoreResultBuilderWithReturnStmts::create(
-              *this, builderType,
-              getConstraintLocator(fn.getAbstractClosureExpr()))))
+                        *this, builderType,
+                        getConstraintLocator(fn.getAbstractClosureExpr())),
+                    FixImpact::InvalidAST))
         return getTypeMatchFailure(locator);
 
       return getTypeMatchSuccess();

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -708,7 +708,8 @@ namespace {
     /// Records a fix for an invalid AST node, and returns a hole for it.
     Type recordInvalidNode(ASTNode node) {
       CS.recordFix(
-          IgnoreInvalidASTNode::create(CS, CS.getConstraintLocator(node)));
+          IgnoreInvalidASTNode::create(CS, CS.getConstraintLocator(node)),
+          FixImpact::InvalidAST);
 
       // Ideally we wouldn't need a type variable here, but we don't have a
       // suitable placeholder originator for all the cases here.

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -9972,7 +9972,7 @@ ConstraintSystem::lookupDependentMember(Type base, AssociatedTypeDecl *assocTy,
     // If the type witness is invalid we'll have emitted an error, record a
     // fix to ensure the solution is marked invalid.
     auto *loc = getConstraintLocator(locator);
-    recordFix(IgnoreInvalidASTNode::create(*this, loc));
+    recordFix(IgnoreInvalidASTNode::create(*this, loc), FixImpact::InvalidAST);
     return Type();
   }
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -9406,7 +9406,9 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyConformsToConstraint(
           auto *fix = AllowInvalidStaticMemberRefOnProtocolMetatype::create(
               *this, memberLoc);
 
-          return recordFix(fix) ? SolutionKind::Error : SolutionKind::Solved;
+          return recordFix(fix, FixImpact::InvalidReference)
+                     ? SolutionKind::Error
+                     : SolutionKind::Solved;
         }
       }
 
@@ -11909,7 +11911,8 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyMemberConstraint(
           solveWithNewBaseOrName(baseTy, DeclNameRef::createSubscript());
       // Looks like it was indeed meant to be a subscript operator.
       if (result == SolutionKind::Solved)
-        return recordFix(UseSubscriptOperator::create(*this, locator))
+        return recordFix(UseSubscriptOperator::create(*this, locator),
+                         FixImpact::InvalidReference)
                    ? SolutionKind::Error
                    : SolutionKind::Solved;
     }
@@ -12634,7 +12637,8 @@ ConstraintSystem::simplifyDynamicTypeOfConstraint(
     recordAnyTypeVarAsPotentialHole(type2);
 
     recordFix(IgnoreNonMetatypeDynamicType::create(
-        *this, type2, type1, getConstraintLocator(locator)));
+                  *this, type2, type1, getConstraintLocator(locator)),
+              FixImpact::TypeMismatch);
     return SolutionKind::Solved;
   }
 
@@ -13935,7 +13939,7 @@ ConstraintSystem::simplifyDynamicCallableApplicableFnConstraint(
         *this, desugar2, memberName, /*alreadyDiagnosed=*/false,
         getConstraintLocator(loc, ConstraintLocator::DynamicCallable));
 
-    if (recordFix(fix))
+    if (recordFix(fix, FixImpact::InvalidReference))
       return SolutionKind::Error;
 
     recordPotentialHole(tv);

--- a/lib/Sema/TypeOfReference.cpp
+++ b/lib/Sema/TypeOfReference.cpp
@@ -2478,7 +2478,8 @@ void ConstraintSystem::bindOverloadType(const SelectedOverload &overload,
       }();
       if (lookupDepth > ctx.TypeCheckerOpts.DynamicMemberLookupDepthLimit) {
         (void)recordFix(TooManyDynamicMemberLookups::create(
-            *this, DeclNameRef(choice.getName()), locator));
+                            *this, DeclNameRef(choice.getName()), locator),
+                        FixImpact::InvalidReference);
         recordTypeVariablesAsHoles(memberTy);
       } else {
         addValueMemberConstraint(

--- a/test/Constraints/result_builder_diags.swift
+++ b/test/Constraints/result_builder_diags.swift
@@ -1079,3 +1079,33 @@ func testNoDuplicateStmtDiags() {
     }
   }
 }
+
+func testInvalidTransforDoesntHideConversionFailure() {
+  @resultBuilder
+  struct BuilderA {
+    static func buildBlock<T>(_ v1: T) -> T { v1 }
+    static func buildBlock<T, U>(_ v1: T, _ v2: U) -> (T, U) { (v1, v2) }
+  }
+
+  func fn(@BuilderA a: () -> Void) {}
+  func fn(@BuilderA b: () -> Void) {}
+  func fn(_: () -> Void) {}
+
+  func test(_: Int) {}
+
+  fn {
+    if true {
+      return
+    }
+
+    test("") // expected-error {{cannot convert value of type 'String' to expected argument type 'Int'}}
+  }
+
+  fn {
+    if true {
+      0
+    }
+
+    test("") // expected-error {{cannot convert value of type 'String' to expected argument type 'Int'}}
+  }
+}

--- a/test/attr/attr_dynamic_member_lookup.swift
+++ b/test/attr/attr_dynamic_member_lookup.swift
@@ -1337,7 +1337,7 @@ struct WithSendable {
 
 // Make sure we enforce a limit on the number of chained dynamic member lookups.
 @dynamicMemberLookup
-struct SelfRecursiveLookup<T> {
+struct SelfRecursiveLookup<T> { // expected-note {{'T' declared as parameter to type 'SelfRecursiveLookup'}}
   init(_: () -> T) {}
   init(_: () -> KeyPath<Self, T>) {}
   subscript<U>(dynamicMember kp: KeyPath<T, U>) -> SelfRecursiveLookup<U> {}
@@ -1346,13 +1346,14 @@ let selfRecurse1 = SelfRecursiveLookup { selfRecurse1.e }
 // expected-error@-1 {{could not find member 'e'; exceeded the maximum number of nested dynamic member lookups}}
 
 let selfRecurse2 = SelfRecursiveLookup { selfRecurse2[a: 0] }
-// expected-error@-1 {{could not find member 'subscript'; exceeded the maximum number of nested dynamic member lookups}}
+// expected-error@-1 {{generic parameter 'T' could not be inferred}}
+// expected-note@-2 {{explicitly specify the generic arguments to fix this issue}}
 
 let selfRecurse3 = SelfRecursiveLookup { \.e }
 // expected-error@-1 {{could not find member 'e'; exceeded the maximum number of nested dynamic member lookups}}
 
 let selfRecurse4 = SelfRecursiveLookup { \.[a: 0] }
-// expected-error@-1 {{could not find member 'subscript'; exceeded the maximum number of nested dynamic member lookups}}
+// expected-error@-1 {{cannot infer key path type from context; consider explicitly specifying a root type}}
 
 extension SelfRecursiveLookup where T == SelfRecursiveLookup<SelfRecursiveLookup<SelfRecursiveLookup<Int>>> {
   var terminator: T { fatalError() }

--- a/validation-test/compiler_crashers/SubscriptMisuseFailure-diagnoseAsError-d3bddf.swift
+++ b/validation-test/compiler_crashers/SubscriptMisuseFailure-diagnoseAsError-d3bddf.swift
@@ -1,2 +1,0 @@
-// RUN: not --crash %target-swift-frontend -typecheck %s
-"" [.subscript

--- a/validation-test/compiler_crashers_fixed/SubscriptMisuseFailure-diagnoseAsError-d3bddf.swift
+++ b/validation-test/compiler_crashers_fixed/SubscriptMisuseFailure-diagnoseAsError-d3bddf.swift
@@ -1,0 +1,2 @@
+// RUN: not %target-swift-frontend -typecheck %s
+"" [.subscript


### PR DESCRIPTION
- Invalid base type fixes should have non-default score 
- Failing to apply a transform due to capability or other issues should be marked as invalid AST because otherwise it could hide issues with other overloads that are valid.
- Recursive dynamic member lookup should be scored as an invalid reference.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
