### PR TITLE
[IRGen][Runtime] Propagate isPOD for raw layout types

### DIFF
--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -1651,7 +1651,7 @@ enum class RawLayoutFlags : uintptr_t {
 
   /// Whether the given raw layout type is considered "plain old data". This can
   /// occur when the like type is concretely something like an 'Int'.
-  IsPOD = 0x8
+  IsNonPOD = 0x8
 };
 static inline RawLayoutFlags operator|(RawLayoutFlags lhs,
                                        RawLayoutFlags rhs) {
@@ -1671,7 +1671,7 @@ static inline bool isRawLayoutBitwiseBorrowable(RawLayoutFlags flags) {
   return uintptr_t(flags) & uintptr_t(RawLayoutFlags::BitwiseBorrowable);
 }
 static inline bool isRawLayoutPOD(RawLayoutFlags flags) {
-  return uintptr_t(flags) & uintptr_t(RawLayoutFlags::IsPOD);
+  return (uintptr_t(flags) & uintptr_t(RawLayoutFlags::IsNonPOD)) == 0;
 }
 
 namespace SpecialPointerAuthDiscriminators {

--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -1648,6 +1648,10 @@ enum class RawLayoutFlags : uintptr_t {
   /// No raw layout types are yet, but should we change our mind about that in the future,
   /// this flag is here.
   BitwiseBorrowable = 0x4,
+
+  /// Whether the given raw layout type is considered "plain old data". This can
+  /// occur when the like type is concretely something like an 'Int'.
+  IsPOD = 0x8
 };
 static inline RawLayoutFlags operator|(RawLayoutFlags lhs,
                                        RawLayoutFlags rhs) {
@@ -1665,6 +1669,9 @@ static inline bool shouldRawLayoutMoveAsLike(RawLayoutFlags flags) {
 }
 static inline bool isRawLayoutBitwiseBorrowable(RawLayoutFlags flags) {
   return uintptr_t(flags) & uintptr_t(RawLayoutFlags::BitwiseBorrowable);
+}
+static inline bool isRawLayoutPOD(RawLayoutFlags flags) {
+  return uintptr_t(flags) & uintptr_t(RawLayoutFlags::IsPOD);
 }
 
 namespace SpecialPointerAuthDiscriminators {

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -3632,17 +3632,33 @@ static void emitInitializeRawLayout(IRGenFunction &IGF, SILType likeType,
   auto rawLayout = T.getRawLayout();
   auto likeTypeLayout = emitTypeLayoutRef(IGF, likeType, collector);
   auto structLayoutflags = StructLayoutFlags::Swift5Algorithm;
-  auto rawLayoutFlags = (RawLayoutFlags) 0;
+  llvm::Value *rawLayoutFlags = IGM.getSize(Size(0));
 
-  if (rawLayout->shouldMoveAsLikeType())
-    rawLayoutFlags |= RawLayoutFlags::MovesAsLike;
+  if (rawLayout->shouldMoveAsLikeType()) {
+    rawLayoutFlags = IGF.Builder.CreateOr(rawLayoutFlags,
+                      IGM.getSize(Size((uint8_t) RawLayoutFlags::MovesAsLike)));
+
+    // PODness comes directly from the like type if we 'movesAsLike'. A custom
+    // deinit on the raw layout type however automatically forces non-pod.
+    if (!T.getStructOrBoundGenericStruct()->getValueTypeDestructor()) {
+      auto &likeTypeInfo = IGM.getTypeInfo(likeType);
+      auto isPOD = likeTypeInfo.getIsTriviallyDestroyable(IGF, likeType);
+      auto isPODFlags = IGF.Builder.CreateOr(rawLayoutFlags,
+                            IGM.getSize(Size((uint8_t) RawLayoutFlags::IsPOD)));
+      rawLayoutFlags = IGF.Builder.CreateSelect(isPOD, isPODFlags, rawLayoutFlags);
+    }
+  } else if (!T.getStructOrBoundGenericStruct()->getValueTypeDestructor()) {
+    rawLayoutFlags = IGF.Builder.CreateOr(rawLayoutFlags,
+                            IGM.getSize(Size((uint8_t) RawLayoutFlags::IsPOD)));
+  }
 
   // If we don't have a count, then we're the 'like:' variant so just pass some
   // 0 to the runtime call.
   if (!count) {
     count = IGM.getSize(Size(0));
   } else {
-    rawLayoutFlags |= RawLayoutFlags::IsArray;
+    rawLayoutFlags = IGF.Builder.CreateOr(rawLayoutFlags,
+                          IGM.getSize(Size((uint8_t) RawLayoutFlags::IsArray)));
   }
 
   // Call swift_initRawStructMetadata2().
@@ -3651,7 +3667,7 @@ static void emitInitializeRawLayout(IRGenFunction &IGF, SILType likeType,
                           IGM.getSize(Size(uintptr_t(structLayoutflags))),
                           likeTypeLayout,
                           count,
-                          IGM.getSize(Size(uintptr_t(rawLayoutFlags)))});
+                          rawLayoutFlags});
 }
 
 static void emitInitializeValueMetadata(IRGenFunction &IGF,

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -3640,16 +3640,19 @@ static void emitInitializeRawLayout(IRGenFunction &IGF, SILType likeType,
 
     // PODness comes directly from the like type if we 'movesAsLike'. A custom
     // deinit on the raw layout type however automatically forces non-pod.
-    if (!T.getStructOrBoundGenericStruct()->getValueTypeDestructor()) {
+    if (T.getStructOrBoundGenericStruct()->getValueTypeDestructor()) {
+      rawLayoutFlags = IGF.Builder.CreateOr(rawLayoutFlags,
+                          IGM.getSize(Size((uint8_t) RawLayoutFlags::IsNonPOD)));
+    } else {
       auto &likeTypeInfo = IGM.getTypeInfo(likeType);
       auto isPOD = likeTypeInfo.getIsTriviallyDestroyable(IGF, likeType);
-      auto isPODFlags = IGF.Builder.CreateOr(rawLayoutFlags,
-                            IGM.getSize(Size((uint8_t) RawLayoutFlags::IsPOD)));
-      rawLayoutFlags = IGF.Builder.CreateSelect(isPOD, isPODFlags, rawLayoutFlags);
+      auto isNonPODFlags = IGF.Builder.CreateOr(rawLayoutFlags,
+                            IGM.getSize(Size((uint8_t) RawLayoutFlags::IsNonPOD)));
+      rawLayoutFlags = IGF.Builder.CreateSelect(isPOD, rawLayoutFlags, isNonPODFlags);
     }
-  } else if (!T.getStructOrBoundGenericStruct()->getValueTypeDestructor()) {
+  } else if (T.getStructOrBoundGenericStruct()->getValueTypeDestructor()) {
     rawLayoutFlags = IGF.Builder.CreateOr(rawLayoutFlags,
-                            IGM.getSize(Size((uint8_t) RawLayoutFlags::IsPOD)));
+                            IGM.getSize(Size((uint8_t) RawLayoutFlags::IsNonPOD)));
   }
 
   // If we don't have a count, then we're the 'like:' variant so just pass some

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -3605,6 +3605,7 @@ void swift::swift_initRawStructMetadata2(StructMetadata *structType,
   
   vwtable->flags = vwtable->flags
     .withBitwiseBorrowable(isRawLayoutBitwiseBorrowable(rawLayoutFlags));
+  vwtable->flags = vwtable->flags.withPOD(isRawLayoutPOD(rawLayoutFlags));
 
   // If the calculated size of this raw layout type is available to be put in
   // value buffers, then set the inline storage bit if our like type is also

--- a/test/IRGen/raw_layout.swift
+++ b/test/IRGen/raw_layout.swift
@@ -396,7 +396,8 @@ entry(%0 : $*Cell<T>):
 //===----------------------------------------------------------------------===//
 
 // CHECK-LABEL: define {{.*}} swiftcc %swift.metadata_response @"$s{{[A-Za-z0-9_]*}}19CellThatMovesAsLikeVMr"(ptr %"CellThatMovesAsLike<T>", ptr {{.*}}, ptr {{.*}})
-// CHECK: call void @swift_initRawStructMetadata2(ptr %"CellThatMovesAsLike<T>", {{i64|i32}} 0, ptr {{%.*}}, {{i64|i32}} 0, {{i64|i32}} 2)
+// CHECK: [[IS_POD:%.*]] = select i1 {{.*}}, {{i64|i32}} 2, {{i64|i32}} 10
+// CHECK: call void @swift_initRawStructMetadata2(ptr %"CellThatMovesAsLike<T>", {{i64|i32}} 0, ptr {{%.*}}, {{i64|i32}} 0, {{i64|i32}} [[IS_POD]])
 
 //===----------------------------------------------------------------------===//
 // CellThatMovesAsLike<T> destroy
@@ -632,7 +633,9 @@ entry(%0 : $*Cell<T>):
 // CHECK-LABEL: define {{.*}} swiftcc %swift.metadata_response @"$s{{[A-Za-z0-9_]*}}17VectorMovesAsLikeVMr"(ptr %"VectorMovesAsLike<T, N>", ptr {{.*}}, ptr {{.*}})
 // CHECK:         [[N_GEP:%.*]] = getelementptr inbounds {{i64|i32}}, ptr %"VectorMovesAsLike<T, N>", {{i64|i32}} 3
 // CHECK-NEXT:    [[N:%.*]] = load {{i64|i32}}, ptr [[N_GEP]]
-// CHECK:         call void @swift_initRawStructMetadata2(ptr %"VectorMovesAsLike<T, N>", {{i64|i32}} 0, ptr {{%.*}}, {{i64|i32}} [[N]], {{i64|i32}} 3)
+// CHECK:         [[IS_POD:%.*]] = select i1 {{.*}}, {{i64|i32}} 2, {{i64|i32}} 10
+// CHECK-NEXT:    [[IS_ARRAY:%.*]] = or {{i64|i32}} [[IS_POD]], 1
+// CHECK:         call void @swift_initRawStructMetadata2(ptr %"VectorMovesAsLike<T, N>", {{i64|i32}} 0, ptr {{%.*}}, {{i64|i32}} [[N]], {{i64|i32}} [[IS_ARRAY]])
 
 //===----------------------------------------------------------------------===//
 // VectorMovesAsLike destroy

--- a/test/Interpreter/raw_layout.swift
+++ b/test/Interpreter/raw_layout.swift
@@ -1,14 +1,34 @@
-// RUN: %target-run-simple-swift(-enable-experimental-feature RawLayout) | %FileCheck %s
+// RUN: %target-run-simple-swift(-enable-experimental-feature RawLayout -enable-builtin-module -Xfrontend -disable-availability-checking) | %FileCheck %s
 // REQUIRES: executable_test
 // REQUIRES: swift_feature_RawLayout
+// REQUIRES: synchronization
+
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
+import Builtin
+import Synchronization
 
 @_rawLayout(like: T)
-struct Cell<T>: ~Copyable {}
+struct Cell<T: ~Copyable>: ~Copyable {}
 
 struct Foo<T>: ~Copyable {
   let cell = Cell<T>()
   let myValue = 123
 }
+
+@_rawLayout(like: T, movesAsLike)
+struct RealCell<T: ~Copyable>: ~Copyable {}
+
+@_rawLayout(like: T, movesAsLike)
+struct ActuallyRealCell<T: ~Copyable>: ~Copyable {
+  deinit {
+    UnsafeMutablePointer<T>(Builtin.addressOfRawLayout(self)).deinitialize(count: 1)
+  }
+}
+
+@_rawLayout(like: Int)
+struct RawInt: ~Copyable {}
 
 func something<T>(_ x: borrowing Foo<T>) -> Int {
   x.myValue
@@ -19,3 +39,69 @@ print(something(Foo<Bool>()))
 
 // CHECK: 123
 print(something(Foo<Int>()))
+
+class MyCls {
+  init() { print("MyCls.init" )}
+  deinit { print("MyCls.deinit") }
+}
+
+// This function is intentionally testing runtime behavior, so we inspect
+// the raw value witness flags instead of using compiler builtins to check
+// type traits. 
+// The unsafe pointer chasing here ought to be opaque to the compiler, but
+// just as a hedge against any future inlining or constant-folding capabilities
+// let's prevent inlining or other optimizations as much as we can here.
+@inline(never)
+@_optimize(none)
+func valueWitnessFlags(for type: any ~Copyable.Type) -> UInt {
+	let metadataPtr = unsafeBitCast(type, to: UnsafePointer<UnsafeRawPointer>.self)
+	let vwPtr = metadataPtr[-1].assumingMemoryBound(to: UInt.self)
+	return vwPtr[10]
+}
+
+func isPOD(_ type: any ~Copyable.Type) -> Bool {
+  // 0x00010000: is not pod
+  // flag must be 0 to be pod
+  valueWitnessFlags(for: type) & 0x00010000 == 0
+}
+
+// CHECK: start
+print("start")
+
+// CHECK-NEXT: true
+print(isPOD(RawInt.self))
+
+// CHECK-NEXT: true
+print(isPOD(Cell<Int>.self))
+
+// Note: Even though 'String' is NOT POD, we can't assume a value of 'Cell' is
+//       ever fully initialized.
+// CHECK-NEXT: true
+print(isPOD(Cell<String>.self))
+
+// CHECK-NEXT: true
+print(isPOD(RealCell<Int>.self))
+
+// CHECK-NEXT: false
+print(isPOD(RealCell<String>.self))
+
+// CHECK-NEXT: false
+print(isPOD(ActuallyRealCell<Int>.self))
+
+// CHECK-NEXT: false
+print(isPOD(ActuallyRealCell<String>.self))
+
+// FIXME: This could be POD on some platforms...
+// CHECK-NEXT: false
+print(isPOD(Mutex<Int>.self))
+
+// CHECK-NEXT: false
+print(isPOD(Mutex<MyCls>.self))
+
+// FIXME: This is POD, but 'Atomic' itself has a deinit that kind of defeats the
+//        compiler right now...
+// CHECK-NEXT: false
+print(isPOD(Atomic<Int>.self))
+
+// CHECK: done
+print("done")


### PR DESCRIPTION
`swift_initRawStructMetadata2` was not correctly setting the `isPOD` bit for raw layout types. Calculate this bit with the following definition:
> 1. `@_rawLayout(like: T)` is always considered POD because we cannot assume an initialization state of the value (unless it has its own `deinit`)
> 2. `@_rawLayout(like: T, movesAsLike)` is considered POD if the raw layout type itself doesn't have a custom `deinit` AND `T` itself is POD.

Resolves: rdar://179961254