### PR TITLE
[typechecker] lazy typechecking must still eagerly expand extension macros

### DIFF
--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -21,6 +21,7 @@
 #include "MiscDiagnostics.h"
 #include "TypeCheckConcurrency.h"
 #include "TypeCheckDecl.h"
+#include "TypeCheckMacros.h"
 #include "TypeCheckObjC.h"
 #include "TypeCheckType.h"
 #include "swift/AST/ASTBridging.h"
@@ -268,10 +269,33 @@ void swift::bindExtensions(ModuleDecl &mod) {
   (void)evaluateOrDefault(eval, BindExtensionsRequest{&mod}, {});
 }
 
+static void expandAttachedExtensionMacros(Decl *decl) {
+  auto &Ctx = decl->getASTContext();
+  IterableDeclContext *DC = nullptr;
+  if (auto *nominal = dyn_cast<NominalTypeDecl>(decl)) {
+    (void)evaluateOrDefault(Ctx.evaluator, ExpandExtensionMacros{nominal}, {});
+    DC = nominal;
+  } else if (auto *ext = dyn_cast<ExtensionDecl>(decl)) {
+    DC = ext;
+  } else {
+    return;
+  }
+
+  for (auto *member : DC->getMembers())
+    expandAttachedExtensionMacros(member);
+}
+
 void swift::performTypeChecking(SourceFile &SF) {
-  if (SF.getASTContext().TypeCheckerOpts.EnableLazyTypecheck) {
-    // Skip eager type checking. Instead, let later stages of compilation drive
-    // type checking as needed through request evaluation.
+  auto &Ctx = SF.getASTContext();
+  if (Ctx.TypeCheckerOpts.EnableLazyTypecheck) {
+    // Lazy typechecking otherwise skips eager type checking and lets later
+    // stages drive type checking through request evaluation.
+    //
+    // However, attached extension macros must still be expanded before the
+    // module is serialized so that their emitted conformances and members
+    // appear in the produced .swiftmodule. See #90068 and sourcekit-lsp#2696.
+    for (auto *decl : SF.getTopLevelDecls())
+      expandAttachedExtensionMacros(decl);
     return;
   }
 

--- a/test/Macros/macro_expand_conformances.swift
+++ b/test/Macros/macro_expand_conformances.swift
@@ -14,6 +14,18 @@
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main | %FileCheck %s
 
+// Regression test for sourcekit-lsp #2696: lazy typechecking + skip-all-function-bodies
+//
+// The SwiftPM `--experimental-prepare-for-indexing` combo) must not drop
+// macro-synthesized extension conformances from the produced .swiftmodule. 
+// RUN: %empty-directory(%t/lazy)
+// RUN: %target-swift-frontend -swift-version 5 -emit-module -o %t/lazy/ModuleWithEquatable.swiftmodule %s -DMODULE_EXPORTING_TYPE -module-name ModuleWithEquatable -load-plugin-library %t/%target-library-name(MacroDefinition) -experimental-lazy-typecheck -experimental-skip-all-function-bodies
+// RUN: %target-swift-ide-test -print-module -module-to-print=ModuleWithEquatable -source-filename %s -I %t/lazy -load-plugin-library %t/%target-library-name(MacroDefinition) | %FileCheck -check-prefix CHECK-LAZY %s
+
+// CHECK-LAZY: struct PublicEquatable
+// CHECK-LAZY: extension PublicEquatable : Equatable
+// CHECK-LAZY: extension PublicEquatable.Inner : Equatable
+
 #if TEST_DIAGNOSTICS
 @attached(conformance) // expected-error{{conformance macros are replaced by extension macros}}
 macro InvalidEquatable() = #externalMacro(module: "MacroDefinition", type: "EquatableMacro")
@@ -29,6 +41,13 @@ macro Hashable() = #externalMacro(module: "MacroDefinition", type: "HashableMacr
 @Equatable
 public struct PublicEquatable {
   public init() { }
+}
+
+extension PublicEquatable {
+  @Equatable
+  public struct Inner {
+    public init() { }
+  }
 }
 
 // INTERFACE-NOT: @Equatable


### PR DESCRIPTION
Otherwise swift module files which tools like sourcekit-lsp and therefore consumers like the vscode plugin will be missing conformances leading to false errors being displayed in the IDE and preventing many IDE features from being used.

This was a problem in swift-java which has macros which add conformances to @JavaClass annotated types, leading to an avallanche of '... does not conform ...' errors when the project was opened in VS Code.

Resolves #90068
Resolves https://github.com/swiftlang/sourcekit-lsp/issues/2696 - more detailed writeup of symptoms here
