### PR TITLE
LifetimeDependenceScopeFixup: Don't extend disjoint ranges

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceScopeFixup.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceScopeFixup.swift
@@ -772,9 +772,8 @@ extension ScopeExtension {
       // because the stack allocation effectively covers the entire unreachable path.
       for scopeEndInst in extScope.endInstructions {
         switch extendedUseRange.overlaps(pathBegin: extScope.firstInstruction, pathEnd: scopeEndInst, context) {
-        case .containsPath, .containsEnd, .disjoint:
+        case .containsPath, .containsEnd:
           // containsPath can occur when the extendable scope has the same begin as the use range.
-          // disjoint is unexpected, but if it occurs then `extScope` must be before the useRange.
           mustExtend = true
           break
         case .containsBegin, .overlappedByPath:
@@ -784,6 +783,16 @@ extension ScopeExtension {
           // to cover this scope's end instructions. The extended scope must at least cover the original scopes because
           // the original scopes may protect other operations.
           extendedUseRange.insert(scopeEndInst)
+          break
+        case .disjoint:
+          // The outer scope may contain CFG paths that never reach the inner
+          // scope. This check for overlapping paths only considers the CFG
+          // paths that end in a single scope-ending instruction. When that
+          // scope-ending instruction occurs on a path that never reaches the
+          // inner scope, the overlap check reports a disjoint path. Such paths
+          // are simply ignored since they do not contain any uses in the
+          // extendedUseRange. The outer scope will still be extended if
+          // necessary when this loop visits the other scope-ending uses.
           break
         }
       }

--- a/test/SILOptimizer/lifetime_dependence/scope_fixup.sil
+++ b/test/SILOptimizer/lifetime_dependence/scope_fixup.sil
@@ -970,3 +970,57 @@ bb3:
   %18 = tuple ()
   return %18
 }
+
+// Test handling of disjoint scopes that should not be extended.
+
+sil [ossa] @getDependentHolder : $@convention(thin) (@in_guaranteed Holder) -> @lifetime(borrow address_for_deps 0) @guaranteed Holder
+
+// The path from the loadborrow to the end_borrow in b5 never reaches the inner
+// store_borrow scope, so scope extension should simply ignore it.
+// 
+// CHECK-LABEL: sil hidden [noinline] [ossa] @testDisjointParentScopes : $@convention(thin) (@in_guaranteed Holder) -> () {
+// CHECK:       bb0(%0 : $*Holder):
+// CHECK:         %1 = load_borrow %0
+// CHECK-NEXT:    cond_br undef, bb1, bb2
+// CHECK:       bb1:
+// CHECK:         cond_br undef, bb4, bb5
+// CHECK:       bb2:
+// CHECK-NEXT:    br bb3
+// CHECK:       bb3:
+// CHECK-NEXT:    %5 = alloc_stack $Holder
+// CHECK:       bb4:
+// CHECK-NEXT:    br bb3
+// CHECK:       bb5:
+// CHECK-NEXT:    end_borrow %1
+// CHECK-NEXT:    unreachable
+// CHECK-LABEL: } // end sil function 'testDisjointParentScopes'
+sil hidden [noinline] [ossa] @testDisjointParentScopes : $@convention(thin) (@in_guaranteed Holder) -> () {
+bb0(%0 : $*Holder):
+  %1 = load_borrow %0
+  cond_br undef, bb1, bb2
+
+bb1:
+  cond_br undef, bb4, bb5
+
+bb2:
+  br bb3
+
+bb3:
+  %5 = alloc_stack $Holder
+  %6 = store_borrow %1 to %5
+  %7 = function_ref @getDependentHolder : $@convention(thin) (@in_guaranteed Holder) -> @lifetime(borrow address_for_deps 0) @guaranteed Holder
+  %8 = apply %7(%6) : $@convention(thin) (@in_guaranteed Holder) -> @lifetime(borrow address_for_deps 0) @guaranteed Holder
+  %9 = mark_dependence [unresolved] %8 on %6
+  end_borrow %6
+  dealloc_stack %5
+  end_borrow %1
+  %13 = tuple ()
+  return %13
+
+bb4:
+  br bb3
+
+bb5:
+  end_borrow %1
+  unreachable
+}

--- a/validation-test/SILGen/rdar179316467.swift
+++ b/validation-test/SILGen/rdar179316467.swift
@@ -1,0 +1,33 @@
+// RUN: %target-swift-emit-silgen -sil-verify-all -enable-library-evolution -enable-experimental-feature Lifetimes %s
+// RUN: %target-swift-emit-sil -sil-verify-all -enable-library-evolution -enable-experimental-feature Lifetimes -verify %s
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: swift_feature_Lifetimes
+// REQUIRES: objc_interop
+
+import Foundation
+
+public struct SK {
+  var obj: AnyObject = NSObject()
+  public init<D: DataProtocol>(data: D) {}
+
+  public var bytes: RawSpan {
+    @_lifetime(borrow self)
+    _read {
+      yield _overrideLifetime(RawSpan(), borrowing: self)
+    }
+  }
+}
+
+public func consume(data: RawSpan, using key: SK) {}
+
+public func extract(input: SK, salt: Data) {
+  let key: SK
+  if salt.regions.count != 1 {
+    let bytes = Array(salt)
+    key = SK(data: bytes)
+  } else {
+    key = SK(data: salt.regions.first!)
+  }
+  consume(data: input.bytes, using: key)
+}


### PR DESCRIPTION
Attempting to extend a disjoint range can introduce multiple end_borrows on the same path, triggering a SIL verifier error. Disjoint ranges should never intersect the lifetime of the object, so we should never need to extend them.

Fixes:
rdar://179316467
<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
