### PR TITLE
[ASTGen] Handle #warning/#error in switch case position

### DIFF
--- a/lib/ASTGen/Sources/ASTGen/ASTGen+CompilerBuildConfiguration.swift
+++ b/lib/ASTGen/Sources/ASTGen/ASTGen+CompilerBuildConfiguration.swift
@@ -18,6 +18,10 @@ import SwiftSyntax
 enum IfConfigOrUnderlying<Element> {
   case ifConfigDecl(IfConfigDeclSyntax)
   case underlying(Element)
+
+  /// The element was handled by `split` itself (e.g. a `#warning`/`#error`
+  /// directive that was diagnosed in place) and should not be visited.
+  case skip
 }
 
 extension ASTGenVisitor {
@@ -64,6 +68,9 @@ extension ASTGenVisitor {
 
       case .underlying(let element):
         body(element)
+
+      case .skip:
+        break
     }
     }
   }

--- a/lib/ASTGen/Sources/ASTGen/BuiltinPound.swift
+++ b/lib/ASTGen/Sources/ASTGen/BuiltinPound.swift
@@ -111,7 +111,7 @@ extension ASTGenVisitor {
   func handlePoundDiagnostic(freestandingMacroExpansion node: some FreestandingMacroExpansionSyntax, kind: PoundDiagnosticKind) {
 
     switch node.parent?.kind {
-    case .codeBlockItem, .memberBlockItem, nil:
+    case .codeBlockItem, .memberBlockItem, .switchCaseList, nil:
       break
     default:
       // TODO: Diagnose.

--- a/lib/ASTGen/Sources/ASTGen/Stmts.swift
+++ b/lib/ASTGen/Sources/ASTGen/Stmts.swift
@@ -564,6 +564,11 @@ extension ASTGenVisitor {
         return .ifConfigDecl(ifConfigDecl)
       case .switchCase(let switchCase):
         return .underlying(switchCase)
+      case .macroExpansionDecl(let node):
+        // Only '#warning'/'#error' are parsed in case position; evaluate them
+        // for their diagnostic side effect. They don't produce a case.
+        _ = self.maybeGenerateBuiltinPound(macroExpansionDecl: node)
+        return .skip
       }
     } body: { caseNode in
       allBridgedCases.append(self.generate(switchCase: caseNode))

--- a/test/ASTGen/pound_diagnostic_switch.swift
+++ b/test/ASTGen/pound_diagnostic_switch.swift
@@ -36,3 +36,30 @@ func testPoundDiagnosticInSwitchIfConfig(_ x: Int) {
     break
   }
 }
+
+func testPoundDiagnosticInSwitchElse(_ x: Int) {
+  switch x {
+  #if false
+  case 1:
+    break
+  #else
+  #warning("warning in #else") // expected-warning {{warning in #else}}
+  #endif
+  default:
+    break
+  }
+}
+
+func testPoundDiagnosticInSwitchNestedIfConfig(_ x: Int) {
+  switch x {
+  #if true
+  #if true
+  #warning("warning in nested #if") // expected-warning {{warning in nested #if}}
+  #endif
+  #endif
+  case 1:
+    break
+  default:
+    break
+  }
+}

--- a/test/ASTGen/pound_diagnostic_switch.swift
+++ b/test/ASTGen/pound_diagnostic_switch.swift
@@ -1,0 +1,38 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature ParserASTGen
+
+// REQUIRES: swift_feature_ParserASTGen
+
+// '#warning'/'#error' are allowed in case position of a switch and are
+// evaluated for their diagnostic, without being treated as a case.
+
+func testPoundWarningInSwitch(_ x: Int) {
+  switch x {
+  #warning("warning in case position") // expected-warning {{warning in case position}}
+  case 1:
+    break
+  default:
+    break
+  }
+}
+
+func testPoundErrorInSwitch(_ x: Int) {
+  switch x {
+  #error("error in case position") // expected-error {{error in case position}}
+  case 1:
+    break
+  default:
+    break
+  }
+}
+
+func testPoundDiagnosticInSwitchIfConfig(_ x: Int) {
+  switch x {
+  #if true
+  #warning("warning in #if") // expected-warning {{warning in #if}}
+  #endif
+  case 1:
+    break
+  default:
+    break
+  }
+}


### PR DESCRIPTION
Companion to swiftlang/swift-syntax#3363.

That PR makes swift-syntax parse `#warning`/`#error` in case position of a `switch` as a `MacroExpansionDecl` element of the case list (instead of diagnosing them), to match the compiler. As a result `SwitchCaseListSyntax.Element` gains a `.macroExpansionDecl` case, which makes the exhaustive switch in `generate(switchCaseList:)` no longer compile.

This handles the new case in ASTGen:

- `Stmts.swift`: in `generate(switchCaseList:)`, handle `.macroExpansionDecl` by evaluating it with `maybeGenerateBuiltinPound` (for the `#warning`/`#error` diagnostic) and skipping it, since it isn't a case.
- `ASTGen+CompilerBuildConfiguration.swift`: add a `skip` case to `IfConfigOrUnderlying` so the `split` closure can handle an element itself without producing a flat element to visit.
- `BuiltinPound.swift`: `handlePoundDiagnostic` asserted that a pound diagnostic must be at code-block/member-block level; the parent in this case is a `SwitchCaseListSyntax`, so accept that parent kind too.

Added an ASTGen test covering `#warning`/`#error` in case position, including inside an `#if`.

This only builds against the swift-syntax branch above, so it needs to be cross-repo tested with it.
