### PR TITLE
[RBI]: Don't suppress intra-actor sends when value is sending

### DIFF
--- a/include/swift/SILOptimizer/Utils/PartitionUtils.h
+++ b/include/swift/SILOptimizer/Utils/PartitionUtils.h
@@ -2055,9 +2055,18 @@ public:
 
       auto calleeIsolationInfo = getIsolationInfo(op);
 
+      auto *sourceInst = Impl::getSourceInst(op);
+      const bool isSourceOpSending = [&] () -> bool {
+        if (sourceInst)
+          if (auto fas = FullApplySite::isa(sourceInst))
+            return fas.isSending(*op.getSourceOp());
+        return false;
+      }();
+
       // If our callee and region are both actor isolated and part of the same
-      // isolation domain, do not treat this as a send.
-      if (calleeIsolationInfo.isActorIsolated() &&
+      // isolation domain, do not treat this as a send. If we are passed as a
+      // sending parameter, we cannot do this.
+      if (!isSourceOpSending && calleeIsolationInfo.isActorIsolated() &&
           sentRegionIsolation.hasSameIsolation(calleeIsolationInfo))
         return;
 
@@ -2069,11 +2078,10 @@ public:
 
       // Next see if we are disconnected and have the same isolation. In such a
       // case, if we are not marked explicitly as sending, we do not send
-      // since the disconnected value is allowed to be resued after we
+      // since the disconnected value is allowed to be reused after we
       // return. If we are passed as a sending parameter, we cannot do this.
-      if (auto *sourceInst = Impl::getSourceInst(op)) {
-        if (auto fas = FullApplySite::isa(sourceInst);
-            (!fas || !fas.isSending(*op.getSourceOp())) &&
+      if (sourceInst) {
+        if (!isSourceOpSending &&
             sentRegionIsolation.isDisconnected() && calleeIsolationInfo &&
             sentRegionIsolation.hasSameIsolation(calleeIsolationInfo))
           return;

--- a/test/Concurrency/transfernonsendable_sending_params.swift
+++ b/test/Concurrency/transfernonsendable_sending_params.swift
@@ -625,3 +625,60 @@ func testNonSendableCaptures(ns: NonSendableKlass, a: isolated MyActor) {
     let _ = ns
   }
 }
+
+// Regression tests for https://github.com/swiftlang/swift/issues/89736
+
+enum GH_89736 {
+  // Verbatim repro:
+
+  protocol FooDelegate: AnyObject {
+    func fooDelegateMethod()
+  }
+
+  final class Foo {
+      weak var delegate: (any FooDelegate)?
+
+      func useDelegate() {
+          delegate?.fooDelegateMethod()
+      }
+  }
+
+  @MainActor
+  final class Bar: @MainActor FooDelegate {
+
+      // @MainActor
+      func fooDelegateMethod() {
+          // ❗️ This method is unexpectedly called from outside MainActor.
+          // `MainActor.assertIsolated()` would fail here.
+      }
+  }
+
+  @MainActor
+  func useFoo() async {
+      let foo = Foo()
+      let bar = Bar()
+      foo.delegate = bar // expected-note {{isolated conformance to protocol 'FooDelegate' can be introduced here}}
+
+      // ❗️ `foo` should not be sent, but there is no diagnostic.
+      await sendAndUseDelegate(foo) // expected-warning {{sending 'foo' risks causing data races}}
+      // expected-note @-1 {{main actor-isolated 'foo' is passed as a 'sending' parameter; Uses in callee may race with later main actor-isolated uses}}
+  }
+
+  @MainActor
+  func sendAndUseDelegate(_ foo: sending Foo) async {
+      await Task.detached {
+          foo.useDelegate()
+      }.value
+  }
+
+  // Reduced repro:
+
+  @MainActor
+  func bug(ns: NonSendableKlass) {
+    sendToMain(ns) // expected-warning {{sending 'ns' risks causing data races}}
+    // expected-note @-1 {{main actor-isolated 'ns' is passed as a 'sending' parameter; Uses in callee may race with later main actor-isolated uses}}
+  }
+
+  @MainActor
+  func sendToMain(_ ns: sending NonSendableKlass) {}
+}


### PR DESCRIPTION
Make the isolated intra-actor case match the disconnected intra-actor case when applying a send partition op. Closes a data race safety hole.

Related forum post: https://forums.swift.org/t/rbi-failure-to-diagnose-invalid-use-after-sends-permits-data-race-safety-holes/87519

Resolves: https://github.com/swiftlang/swift/issues/89736
