### PR TITLE
embedded: Deserialize witness tables for untyped throws

### DIFF
--- a/lib/SIL/IR/Linker.cpp
+++ b/lib/SIL/IR/Linker.cpp
@@ -430,33 +430,41 @@ void SILLinkerVisitor::visitApplySubstitutions(SubstitutionMap subs) {
   }
 }
 
+/// Force-deserialize the witness tables for an existential's conformances.
+///
+/// A normal embedded conformance is shared and emitted lazily into the module
+/// that forms the existential, so without this the importer references a witness
+/// table no module defines, an undefined symbol at link. `init_existential_value`
+/// has no visitor: the linker runs after AddressLowering, which has already
+/// lowered it to `init_existential_addr`.
+///
+/// TODO: a two-step scheme (declare here, deserialize at the witness_method use)
+/// would be lazier, but risks visiting witness_method before this instruction.
+void SILLinkerVisitor::linkInExistentialConformances(
+    ArrayRef<ProtocolConformanceRef> conformances) {
+  for (ProtocolConformanceRef C : conformances) {
+    visitProtocolConformance(C, /*referencedFromInitExistential=*/true);
+  }
+}
+
 void SILLinkerVisitor::visitInitExistentialAddrInst(
     InitExistentialAddrInst *IEI) {
-  // Link in all protocol conformances that this touches.
-  //
-  // TODO: There might be a two step solution where the init_existential_inst
-  // causes the witness table to be brought in as a declaration and then the
-  // protocol method inst causes the actual deserialization. For now we are
-  // not going to be smart about this to enable avoiding any issues with
-  // visiting the open_existential_addr/witness_method before the
-  // init_existential_inst.
-  for (ProtocolConformanceRef C : IEI->getConformances()) {
-    visitProtocolConformance(C, true);
-  }
+  linkInExistentialConformances(IEI->getConformances());
 }
 
 void SILLinkerVisitor::visitInitExistentialRefInst(
     InitExistentialRefInst *IERI) {
-  // Link in all protocol conformances that this touches.
-  //
-  // TODO: There might be a two step solution where the init_existential_inst
-  // causes the witness table to be brought in as a declaration and then the
-  // protocol method inst causes the actual deserialization. For now we are
-  // not going to be smart about this to enable avoiding any issues with
-  // visiting the protocol_method before the init_existential_inst.
-  for (ProtocolConformanceRef C : IERI->getConformances()) {
-    visitProtocolConformance(C, true);
-  }
+  linkInExistentialConformances(IERI->getConformances());
+}
+
+void SILLinkerVisitor::visitAllocExistentialBoxInst(
+    AllocExistentialBoxInst *AEBI) {
+  linkInExistentialConformances(AEBI->getConformances());
+}
+
+void SILLinkerVisitor::visitInitExistentialMetatypeInst(
+    InitExistentialMetatypeInst *IEMI) {
+  linkInExistentialConformances(IEMI->getConformances());
 }
 
 void SILLinkerVisitor::visitBuiltinInst(BuiltinInst *bi) {

--- a/lib/SIL/IR/Linker.h
+++ b/lib/SIL/IR/Linker.h
@@ -129,6 +129,8 @@ public:
   }
   void visitInitExistentialAddrInst(InitExistentialAddrInst *IEI);
   void visitInitExistentialRefInst(InitExistentialRefInst *IERI);
+  void visitAllocExistentialBoxInst(AllocExistentialBoxInst *AEBI);
+  void visitInitExistentialMetatypeInst(InitExistentialMetatypeInst *IEMI);
   void visitBuiltinInst(BuiltinInst *bi);
   void visitAllocRefInst(AllocRefInst *ARI);
   void visitAllocRefDynamicInst(AllocRefDynamicInst *ARI);
@@ -156,6 +158,11 @@ private:
   }
 
   void linkInVTable(ClassDecl *D);
+
+  /// Force-deserialize the witness tables for an existential's conformances.
+  /// See the definition for why this is needed in embedded mode.
+  void linkInExistentialConformances(
+      ArrayRef<ProtocolConformanceRef> conformances);
 
   // Main loop of the visitor. Called by one of the other *visit* methods.
   void process();

--- a/test/embedded/linkage/error_existential_witness_crossmodule.swift
+++ b/test/embedded/linkage/error_existential_witness_crossmodule.swift
@@ -1,0 +1,29 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: swift_feature_Embedded
+// UNSUPPORTED: CPU=wasm32
+
+// RUN: %target-swift-frontend -emit-ir -emit-module -o %t/MyModule.ll -emit-module-path %t/MyModule.swiftmodule %t/MyModule.swift -enable-experimental-feature Embedded -parse-as-library -module-name MyModule
+// RUN: %FileCheck %s -check-prefix MODULE-IR < %t/MyModule.ll
+
+// RUN: %target-swift-frontend -emit-ir -o %t/Client.ll %t/Client.swift -I %t -enable-experimental-feature Embedded -parse-as-library -module-name Client
+// RUN: %FileCheck %s -check-prefix CLIENT-IR < %t/Client.ll
+
+//--- MyModule.swift
+
+// MODULE-IR-NOT: @"$e8MyModule4BoomVs5ErrorAAWP"
+public struct Boom: Error {
+  public init() {}
+}
+
+//--- Client.swift
+
+import MyModule
+
+// CLIENT-IR-DAG: @"$e8MyModule4BoomVs5ErrorAAWP" = linkonce_odr {{.*}}constant
+// CLIENT-IR-NOT: @"$e8MyModule4BoomVs5ErrorAAWP" = external
+public func mightFail() throws {
+  throw Boom()
+}

--- a/test/embedded/linkage/metatype_existential_witness_crossmodule.swift
+++ b/test/embedded/linkage/metatype_existential_witness_crossmodule.swift
@@ -1,0 +1,46 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: swift_feature_Embedded
+// UNSUPPORTED: CPU=wasm32
+
+// RUN: %target-swift-frontend -emit-ir -emit-module -o %t/MyModule.ll -emit-module-path %t/MyModule.swiftmodule %t/MyModule.swift -enable-experimental-feature Embedded -parse-as-library -module-name MyModule
+// RUN: %FileCheck %s -check-prefix MODULE-IR < %t/MyModule.ll
+
+// RUN: %target-swift-frontend -emit-ir -o %t/Client.ll %t/Client.swift -I %t -enable-experimental-feature Embedded -parse-as-library -module-name Client
+// RUN: %FileCheck %s -check-prefix CLIENT-IR < %t/Client.ll
+
+//--- MyModule.swift
+
+// MODULE-IR-NOT: @"$e8MyModule5ThingVAA1PAAWP"
+// MODULE-IR-NOT: @"$e8MyModule10ClassThingCAA1QAAWP"
+public protocol P {
+  func foo()
+}
+public struct Thing: P {
+  public init() {}
+  public func foo() {}
+}
+public protocol Q: AnyObject {
+  func bar()
+}
+public final class ClassThing: Q {
+  public init() {}
+  public func bar() {}
+}
+
+//--- Client.swift
+
+import MyModule
+
+// CLIENT-IR-DAG: @"$e8MyModule5ThingVAA1PAAWP" = linkonce_odr hidden constant
+// CLIENT-IR-DAG: @"$e8MyModule10ClassThingCAA1QAAWP" = linkonce_odr hidden constant
+// CLIENT-IR-NOT: @"$e8MyModule5ThingVAA1PAAWP" = external
+// CLIENT-IR-NOT: @"$e8MyModule10ClassThingCAA1QAAWP" = external
+public func makeStructMeta() -> any P.Type {
+  return Thing.self
+}
+public func makeClassMeta() -> any Q.Type {
+  return ClassThing.self
+}


### PR DESCRIPTION
In Embedded Swift, boxing a cross-module type into `any Error` (`alloc_existential_box`) or forming `any T.Type` (`init_existential_metatype`) left the conforming type's witness table as an `external` declaration no module defined, so linking failed with an undefined symbol such as `$e13JavaScriptKit11JSExceptionVs5ErrorAAWP`. The SIL linker force-deserialized conformances only for `init_existential_addr` and `init_existential_ref`, so the other two existential-forming instructions never brought their witness tables into the importing module. Adds visitors for both, routes all four through a shared `linkInExistentialConformances` helper, and adds lit tests for the `any Error` and `any T.Type` cases.

Resolves https://github.com/swiftlang/swift/issues/90081.