### PR TITLE
swift-xcodegen: Infer project root from build directory first

### DIFF
--- a/utils/swift-dev-utils/Sources/SwiftXcodeGen/Ninja/NinjaBuildDir.swift
+++ b/utils/swift-dev-utils/Sources/SwiftXcodeGen/Ninja/NinjaBuildDir.swift
@@ -44,16 +44,41 @@ public final class NinjaBuildDir: Sendable {
   // We can infer the project root from the location of swift-xcodegen itself.
   //                      1     2         3          4           5         6      7
   // #filePath = <root>/swift/utils/swift-dev-utils/Sources/SwiftXcodeGen/Ninja/NinjaBuildDir.swift
-  private static let inferredProjectRootPath = AbsolutePath(#filePath).dropLast(7)
+  internal static let fallbackProjectRootPath = AbsolutePath(#filePath).dropLast(7)
 
-  private static func detectProjectRoot() throws -> AbsolutePath {
-    let inferredSwiftPath = inferredProjectRootPath.appending(Repo.swift.relativePath)
+  private static func detectProjectRoot(
+    buildDir: AbsolutePath
+  ) throws -> AbsolutePath {
+    // First try to infer the project root relative to the build directory,
+    // according to where build-script normally puts it:
+    // '<root>/build/<build-dir>'. This lets swift-xcodegen produce a
+    // correct project when run against a build directory belonging to a
+    // different checkout than the one containing this file.
+    //
+    // TODO: Explore the possibility of inferring source directories on demand
+    //       from CMake cache files instead of inferring a project root early.
+    //       This will cover both the case described above and worktrees.
+    if let parent = buildDir.parentDir, parent.fileName == "build",
+      let projectRoot = parent.parentDir,
+      projectRoot.appending(Repo.swift.relativePath).exists
+    {
+      return projectRoot
+    }
+
+    log.warning(
+      """
+      Failed to infer project root directory from build directory \
+      '\(buildDir)'; falling back to '\(Self.fallbackProjectRootPath)'
+      """
+    )
+
+    let inferredSwiftPath = fallbackProjectRootPath.appending(Repo.swift.relativePath)
     guard inferredSwiftPath.exists else {
       throw XcodeGenError.couldNotInferProjectRoot(
         reason: "expected swift repo at '\(inferredSwiftPath)'"
       )
     }
-    return inferredProjectRootPath
+    return fallbackProjectRootPath
   }
   
   public init(at path: AbsolutePath, projectRootDir: AbsolutePath?) throws {
@@ -62,7 +87,13 @@ public final class NinjaBuildDir: Sendable {
     }
     self.path = path
     self._tripleSuffix = Self.detectTripleSuffix(buildDir: path)
-    self.projectRootDir = try projectRootDir ?? Self.detectProjectRoot()
+
+    if let projectRootDir {
+      self.projectRootDir = projectRootDir
+    } else {
+      self.projectRootDir = try Self.detectProjectRoot(buildDir: path)
+      log.debug("Inferred project root directory as '\(self.projectRootDir)'")
+    }
   }
   
   public func buildDir(for repo: Repo) throws -> RepoBuildDir {

--- a/utils/swift-dev-utils/Tests/CrashReduceTests/CrashReduceTests.swift
+++ b/utils/swift-dev-utils/Tests/CrashReduceTests/CrashReduceTests.swift
@@ -28,8 +28,7 @@ func assertShortSig(
   _ expected: String, crash: String,
   sourceLocation: SourceLocation = #_sourceLocation
 ) {
-  guard let crashLog = CrashLog(from: crash),
-  let short = crashLog.signature.short else {
+  guard let short = CrashLog(from: crash).signature.short else {
     Issue.record("failed to parse crash", sourceLocation: sourceLocation)
     return
   }

--- a/utils/swift-dev-utils/Tests/SwiftXcodeGenTest/NinjaBuildDirTests.swift
+++ b/utils/swift-dev-utils/Tests/SwiftXcodeGenTest/NinjaBuildDirTests.swift
@@ -1,0 +1,75 @@
+//===--- NinjaBuildDirTests.swift -----------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Testing
+
+@testable import SwiftXcodeGen
+
+/// Creates a minimal Ninja build dir layout under `parent`.
+private func makeBuildDir(in parent: AbsolutePath) throws -> AbsolutePath {
+  let buildDir = parent.appending("Ninja")
+  try buildDir.appending("swift-dreamos-leg46").makeDir()
+  return buildDir
+}
+
+@Suite
+struct NinjaBuildDirTests {
+  @Test
+  func explicitProjectRoot() throws {
+    try withTemporaryDirectory { root in
+      try root.appending("swift").makeDir()
+      let buildDir = try makeBuildDir(in: root.appending("build"))
+
+      let explicit = root.appending("explicit")
+      try explicit.makeDir()
+
+      let ninja = try NinjaBuildDir(at: buildDir, projectRootDir: explicit)
+      #expect(ninja.projectRootDir == explicit)
+    }
+  }
+
+  @Test
+  func inferProjectRootFromBuildDir() throws {
+    try withTemporaryDirectory { root in
+      try root.appending("swift").makeDir()
+      let buildDir = try makeBuildDir(in: root.appending("build"))
+
+      let ninja = try NinjaBuildDir(at: buildDir, projectRootDir: nil)
+      // Note: Not normalising the paths for comparison because we do not expect
+      // them to be normalised.
+      #expect(ninja.projectRootDir == root)
+    }
+  }
+
+  @Test
+  func fallBackWhenSwiftNotFoundRelativeToBuildDir() throws {
+    try withTemporaryDirectory { root in
+      // '<build-dir>/../../swift' does not exist.
+      let buildDir = try makeBuildDir(in: root.appending("build"))
+
+      let ninja = try NinjaBuildDir(at: buildDir, projectRootDir: nil)
+      #expect(ninja.projectRootDir == NinjaBuildDir.fallbackProjectRootPath)
+    }
+  }
+
+  @Test
+  func fallBackWhenBuildDirParentNotNamedBuild() throws {
+    try withTemporaryDirectory { root in
+      // '<build-dir>/..' not named 'build'.
+      try root.appending("swift").makeDir()
+      let buildDir = try makeBuildDir(in: root.appending("notbuild"))
+
+      let ninja = try NinjaBuildDir(at: buildDir, projectRootDir: nil)
+      #expect(ninja.projectRootDir == NinjaBuildDir.fallbackProjectRootPath)
+    }
+  }
+}


### PR DESCRIPTION
This lets `swift-xcodegen` produce a correct project when run against a build directory belonging to a different checkout than the one containing this `swift-xcodegen`'s sources.