### PR TITLE
test: support extended paths on Windows

### DIFF
--- a/test/ModuleInterface/ModuleCache/Inputs/make-old.py
+++ b/test/ModuleInterface/ModuleCache/Inputs/make-old.py
@@ -18,7 +18,16 @@
 
 import os
 import sys
+import platform
+
+def extended(path):
+    if platform.system() == 'Windows':
+        path = os.path.abspath(path)
+        if path.startswith('\\\\'):
+            return "\\\\?\\UNC\\{0}".format(path[2:])
+        return "\\\\?\\{0}".format(path)
+    return path
 
 OLD = 1390550700  # 2014-01-24T08:05:00+00:00
 for f in sys.argv[1:]:
-    os.utime(f, (OLD, OLD))
+    os.utime(extended(f), (OLD, OLD))

--- a/utils/swift_build_sdk_interfaces.py
+++ b/utils/swift_build_sdk_interfaces.py
@@ -6,6 +6,7 @@ import itertools
 import json
 import multiprocessing
 import os
+import platform
 import shutil
 import subprocess
 import sys
@@ -132,6 +133,13 @@ class ModuleFile:
         self.path = path
         self.is_expected_to_fail = is_expected_to_fail
 
+def extended(path):
+    if platform.system() == 'Windows':
+        path = os.path.abspath(path)
+        if path.startswith('\\\\'):
+            return "\\\\?\\UNC\\{0}".format(path[2:])
+        return "\\\\?\\{0}".format(path)
+    return path
 
 def collect_slices(xfails, swiftmodule_dir):
     if not os.path.isdir(swiftmodule_dir):
@@ -141,7 +149,7 @@ def collect_slices(xfails, swiftmodule_dir):
     assert extension == ".swiftmodule"
 
     is_xfail = module_name in xfails
-    for entry in os.listdir(swiftmodule_dir):
+    for entry in os.listdir(extended(swiftmodule_dir)):
         _, extension = os.path.splitext(entry)
         if extension == ".swiftinterface":
             yield ModuleFile(module_name, os.path.join(swiftmodule_dir, entry),


### PR DESCRIPTION
This pull request introduces improvements to path handling for Windows compatibility in both the `test/ModuleInterface/ModuleCache/Inputs/make-old.py` and `utils/swift_build_sdk_interfaces.py` scripts. The main change is the addition of a new `extended` function that ensures long or UNC paths are handled correctly on Windows systems, which helps prevent path length issues.

**Windows path handling improvements:**

* Added an `extended` function to both `make-old.py` and `swift_build_sdk_interfaces.py` that converts file paths to the extended-length format on Windows, ensuring compatibility with long and UNC paths. [[1]](diffhunk://#diff-7ecbb764738c4e9a9dadfbd4daefb98c5ca3ccfff4a6902b617f1d04719a9545R22-R32) [[2]](diffhunk://#diff-8da7eca5f7cd5b1d30b731e9c79221c2cb47ac645f1be3dbe5e131c01faf74b9R135-R141)
* Updated usages of file and directory paths in both scripts to use the new `extended` function, specifically in `os.utime` calls and directory listings, to avoid path-related errors on Windows. [[1]](diffhunk://#diff-7ecbb764738c4e9a9dadfbd4daefb98c5ca3ccfff4a6902b617f1d04719a9545R22-R32) [[2]](diffhunk://#diff-8da7eca5f7cd5b1d30b731e9c79221c2cb47ac645f1be3dbe5e131c01faf74b9L144-R151)