### PR TITLE
Implement @objc on global functions (SE-0495)

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -8445,6 +8445,9 @@ public:
   /// instance method.
   bool isObjCInstanceMethod() const;
 
+  /// Whether this is a top-level (module-scope) function with @objc (SE-0495).
+  bool isObjCGlobalFunction() const;
+
   /// Get the foreign language targeted by a @c-style attribute, if any.
   /// Used to abstract away the change in meaning of @c vs @_cdecl while
   /// formalizing the attribute.

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -8453,6 +8453,11 @@ public:
   /// formalizing the attribute.
   std::optional<ForeignLanguage> getCDeclKind() const;
 
+  /// Whether this function's signature includes types that require Objective-C
+  /// bridging (e.g. String <-> NSString). Used by @objc global functions to
+  /// decide between the @c single-symbol model and the @_cdecl thunk model.
+  bool signatureRequiresObjCBridging() const;
+
   /// Determine whether the name of an argument is an API name by default
   /// depending on the function context.
   bool argumentNameIsAPIByDefault() const;

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2192,6 +2192,9 @@ ERROR(cdecl_throws,none,
 ERROR(cdecl_incompatible_with_objc,none,
       "cannot apply both '@c' and '@objc' to %kindonly0",
       (const Decl *))
+NOTE(cdecl_suggest_objc,none,
+     "use '@objc' to expose this function to Objective-C",
+     ())
 
 // @used and @section
 ERROR(section_empty_name,none,

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -5044,11 +5044,14 @@ public:
   bool isCached() const { return true; }
 };
 
-/// Check @c functions for compatibility with the foreign language.
+/// Check C-exported functions for compatibility with the foreign language.
+///
+/// This covers @c and @_cdecl as well as @objc on a top-level function
+/// (SE-0495); \p attr is the attribute that requested the C export.
 class TypeCheckCDeclFunctionRequest
     : public SimpleRequest<TypeCheckCDeclFunctionRequest,
                            evaluator::SideEffect(FuncDecl *FD,
-                                                 CDeclAttr *attr),
+                                                 DeclAttribute *attr),
                            RequestFlags::Cached> {
 public:
   using SimpleRequest::SimpleRequest;
@@ -5057,7 +5060,7 @@ private:
   friend SimpleRequest;
 
   evaluator::SideEffect
-  evaluate(Evaluator &evaluator, FuncDecl *FD, CDeclAttr *attr) const;
+  evaluate(Evaluator &evaluator, FuncDecl *FD, DeclAttribute *attr) const;
 
 public:
   bool isCached() const { return true; }

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -576,7 +576,7 @@ SWIFT_REQUEST(TypeChecker, TypeCheckObjCImplementationRequest,
               unsigned(ExtensionDecl *),
               Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, TypeCheckCDeclFunctionRequest,
-              evaluator::SideEffect(FunctionDecl *, CDeclAttr *),
+              evaluator::SideEffect(FunctionDecl *, DeclAttribute *),
               Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, TypeCheckCDeclEnumRequest,
               evaluator::SideEffect(EnumDecl *, CDeclAttr *),

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4935,7 +4935,7 @@ StringRef ValueDecl::getCDeclName() const {
   // Handle @objc on a top-level function (SE-0495). The C symbol name is the
   // optional @objc(name) argument, or the base identifier when omitted.
   if (auto *FD = dyn_cast<FuncDecl>(this)) {
-    if (FD->getDeclContext()->isModuleScopeContext()) {
+    if (FD->isObjCGlobalFunction()) {
       if (auto objcAttr = getAttrs().getAttribute<ObjCAttr>()) {
         if (auto name = objcAttr->getName())
           return name->getSelectorPieces().front().str();

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4932,6 +4932,18 @@ StringRef ValueDecl::getCDeclName() const {
       return getBaseIdentifier().str();
   }
 
+  // Handle @objc on a top-level function (SE-0495). The C symbol name is the
+  // optional @objc(name) argument, or the base identifier when omitted.
+  if (auto *FD = dyn_cast<FuncDecl>(this)) {
+    if (FD->getDeclContext()->isModuleScopeContext()) {
+      if (auto objcAttr = getAttrs().getAttribute<ObjCAttr>()) {
+        if (auto name = objcAttr->getName())
+          return name->getSelectorPieces().front().str();
+        return getBaseIdentifier().str();
+      }
+    }
+  }
+
   return "";
 }
 
@@ -11149,13 +11161,24 @@ bool AbstractFunctionDecl::isObjCInstanceMethod() const {
   return isInstanceMember() || isa<ConstructorDecl>(this);
 }
 
-std::optional<ForeignLanguage> AbstractFunctionDecl::getCDeclKind() const {
-  auto attr = getAttrs().getAttribute<CDeclAttr>();
-  if (!attr)
-    return std::nullopt;
+bool AbstractFunctionDecl::isObjCGlobalFunction() const {
+  return getDeclContext()->isModuleScopeContext() &&
+         !isa<AccessorDecl>(this) && getAttrs().hasAttribute<ObjCAttr>();
+}
 
-  return attr->Underscored ? ForeignLanguage::ObjectiveC
-                           : ForeignLanguage::C;
+std::optional<ForeignLanguage> AbstractFunctionDecl::getCDeclKind() const {
+  if (auto attr = getAttrs().getAttribute<CDeclAttr>())
+    return attr->Underscored ? ForeignLanguage::ObjectiveC
+                             : ForeignLanguage::C;
+
+  // @objc on a top-level function (SE-0495) is a C export that accepts
+  // Objective-C types, behaving like @_cdecl for type checking, header
+  // emission, and thunk generation (Swift body + C-convention thunk that
+  // bridges types like String <-> NSString).
+  if (isObjCGlobalFunction())
+    return ForeignLanguage::ObjectiveC;
+
+  return std::nullopt;
 }
 
 bool AbstractFunctionDecl::needsNewVTableEntry() const {

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2293,6 +2293,13 @@ bool Decl::hasOnlyCEntryPoint() const {
       return true;
   }
 
+  // @objc global function with a C-compatible signature uses the @c model
+  // (single C entry point, no Swift symbol or bridging thunk).
+  if (auto *AFD = dyn_cast<AbstractFunctionDecl>(this)) {
+    if (AFD->isObjCGlobalFunction() && !AFD->signatureRequiresObjCBridging())
+      return true;
+  }
+
   return false;
 }
 
@@ -11172,13 +11179,41 @@ std::optional<ForeignLanguage> AbstractFunctionDecl::getCDeclKind() const {
                              : ForeignLanguage::C;
 
   // @objc on a top-level function (SE-0495) is a C export that accepts
-  // Objective-C types, behaving like @_cdecl for type checking, header
-  // emission, and thunk generation (Swift body + C-convention thunk that
-  // bridges types like String <-> NSString).
+  // Objective-C types. Always reported as ObjectiveC for header printing
+  // and type-checking purposes; the symbol model (single vs thunk) is
+  // determined separately by signatureRequiresObjCBridging().
   if (isObjCGlobalFunction())
     return ForeignLanguage::ObjectiveC;
 
   return std::nullopt;
+}
+
+bool AbstractFunctionDecl::signatureRequiresObjCBridging() const {
+  auto *dc = getDeclContext();
+
+  // Check whether any type in the signature needs bridging when going from
+  // Swift to Objective-C. Types that are trivially representable in ObjC
+  // (e.g. Int, NSObject, pointers) don't need a thunk. Types that are
+  // bridged (e.g. String <-> NSString, Array <-> NSArray) do.
+
+  // Check return type.
+  if (auto *FD = dyn_cast<FuncDecl>(this)) {
+    auto resultTy = FD->getResultInterfaceType();
+    if (resultTy && !resultTy->isVoid() &&
+        !resultTy->isTriviallyRepresentableIn(ForeignLanguage::ObjectiveC, dc))
+      return true;
+  }
+
+  // Check parameter types.
+  if (auto *params = getParameters()) {
+    for (auto *param : *params) {
+      if (!param->getInterfaceType()
+              ->isTriviallyRepresentableIn(ForeignLanguage::ObjectiveC, dc))
+        return true;
+    }
+  }
+
+  return false;
 }
 
 bool AbstractFunctionDecl::needsNewVTableEntry() const {

--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -1531,7 +1531,8 @@ private:
           os, resultTy);
   }
 
-  // Print out the function signature for a @_cdecl function.
+  // Print out the function signature for a C-exported function: @c, @_cdecl,
+  // or @objc on a top-level function (SE-0495).
   void printAbstractFunctionAsCFunction(FuncDecl *FD) {
     printDocumentationComment(FD);
     std::optional<ForeignAsyncConvention> asyncConvention =
@@ -1544,7 +1545,7 @@ private:
     auto resultTy = getForeignResultType(
         FD, funcTy, asyncConvention, errorConvention);
 
-    assert(FD->getAttrs().hasAttribute<CDeclAttr>() && "not a cdecl function");
+    assert(FD->getCDeclKind() && "not a C-exported function");
     os << "SWIFT_EXTERN ";
     printFunctionDeclAsCFunctionDecl(FD, FD->getCDeclName(), resultTy);
     os << " SWIFT_NOEXCEPT";

--- a/lib/SIL/IR/SILDeclRef.cpp
+++ b/lib/SIL/IR/SILDeclRef.cpp
@@ -530,14 +530,16 @@ static LinkageLimit getLinkageLimit(SILDeclRef constant) {
 
   if (auto *fn = dyn_cast<AbstractFunctionDecl>(d)) {
     // Native-to-foreign thunks for top-level decls are created on-demand,
-    // unless they use the thunk model (@_cdecl or @objc top-level), in which
-    // case they expose a dedicated entry-point with the visibility of the
-    // function.
+    // unless they use the thunk model (@_cdecl or @objc top-level with
+    // bridged types), in which case they expose a dedicated entry-point
+    // with the visibility of the function. C-compatible @objc globals use
+    // the single-symbol model and don't produce thunks.
     //
     // Native-to-foreign thunks for methods are always just private, since
     // they're anchored by Objective-C metadata.
     if (constant.isNativeToForeignThunk() &&
-        fn->getCDeclKind() != ForeignLanguage::ObjectiveC) {
+        (fn->getCDeclKind() != ForeignLanguage::ObjectiveC ||
+         fn->hasOnlyCEntryPoint())) {
       auto isTopLevel = fn->getDeclContext()->isModuleScopeContext();
       return isTopLevel ? Limit::OnDemand : Limit::Private;
     }

--- a/lib/SIL/IR/SILDeclRef.cpp
+++ b/lib/SIL/IR/SILDeclRef.cpp
@@ -530,14 +530,14 @@ static LinkageLimit getLinkageLimit(SILDeclRef constant) {
 
   if (auto *fn = dyn_cast<AbstractFunctionDecl>(d)) {
     // Native-to-foreign thunks for top-level decls are created on-demand,
-    // unless they are marked @_cdecl, in which case they expose a dedicated
-    // entry-point with the visibility of the function.
+    // unless they use the thunk model (@_cdecl or @objc top-level), in which
+    // case they expose a dedicated entry-point with the visibility of the
+    // function.
     //
     // Native-to-foreign thunks for methods are always just private, since
     // they're anchored by Objective-C metadata.
-    auto &attrs = fn->getAttrs();
     if (constant.isNativeToForeignThunk() &&
-        !(attrs.hasAttribute<CDeclAttr>() && !fn->hasOnlyCEntryPoint())) {
+        fn->getCDeclKind() != ForeignLanguage::ObjectiveC) {
       auto isTopLevel = fn->getDeclContext()->isModuleScopeContext();
       return isTopLevel ? Limit::OnDemand : Limit::Private;
     }
@@ -1598,9 +1598,11 @@ std::optional<std::string> SILDeclRef::getAsmName() const {
       if (auto VD = dyn_cast<ValueDecl>(decl))
         return std::string(EA->getCName(VD));
 
-    // @c/@_cdecl
-    if (decl->getAttrs().hasAttribute<CDeclAttr>())
-      return std::string(decl->getCDeclName());
+    // @c, @_cdecl, and @objc on a top-level function (SE-0495). In all of
+    // these the C symbol name comes from getCDeclName().
+    if (auto *AFD = dyn_cast<AbstractFunctionDecl>(decl))
+      if (AFD->getCDeclKind())
+        return std::string(decl->getCDeclName());
   }
 
   return std::nullopt;

--- a/lib/SIL/IR/SILFunctionBuilder.cpp
+++ b/lib/SIL/IR/SILFunctionBuilder.cpp
@@ -172,9 +172,12 @@ void SILFunctionBuilder::addFunctionAttributes(
     F->setOptimizationMode(OA->getMode());
   }
 
-  // @_silgen_name and @_cdecl functions may be called from C code somewhere.
-  if (Attrs.hasAttribute<SILGenNameAttr>() || Attrs.hasAttribute<CDeclAttr>())
+  // @_silgen_name and C-exported functions may be called from C code.
+  if (Attrs.hasAttribute<SILGenNameAttr>())
     F->setHasCReferences(true);
+  if (auto *AFD = constant.getAbstractFunctionDecl())
+    if (AFD->getCDeclKind())
+      F->setHasCReferences(true);
 
   for (auto *EA : Attrs.getAttributes<ExposeAttr>()) {
     bool shouldExportDecl = true;

--- a/lib/SIL/IR/SILSymbolVisitor.cpp
+++ b/lib/SIL/IR/SILSymbolVisitor.cpp
@@ -499,9 +499,11 @@ public:
       Visitor.addDynamicFunction(AFD, *dynKind);
     }
 
-    // @_cdecl and @objc-on-a-top-level-function both emit a foreign thunk with
-    // an extra C symbol. Export it.
-    if (AFD->getCDeclKind() == ForeignLanguage::ObjectiveC)
+    // @_cdecl and @objc-on-a-top-level-function with bridged types emit a
+    // foreign thunk with an extra C symbol. Export it. C-compatible @objc
+    // globals use the single-symbol model and are already handled above.
+    if (AFD->getCDeclKind() == ForeignLanguage::ObjectiveC &&
+        !AFD->hasOnlyCEntryPoint())
       addFunction(SILDeclRef(AFD).asForeign());
 
     {

--- a/lib/SIL/IR/SILSymbolVisitor.cpp
+++ b/lib/SIL/IR/SILSymbolVisitor.cpp
@@ -499,13 +499,10 @@ public:
       Visitor.addDynamicFunction(AFD, *dynKind);
     }
 
-    if (auto cdeclAttr = AFD->getAttrs().getAttribute<CDeclAttr>()) {
-      if (cdeclAttr->Underscored) {
-        // A @_cdecl("...") function has an extra symbol, with the name from the
-        // attribute.
-        addFunction(SILDeclRef(AFD).asForeign());
-      }
-    }
+    // @_cdecl and @objc-on-a-top-level-function both emit a foreign thunk with
+    // an extra C symbol. Export it.
+    if (AFD->getCDeclKind() == ForeignLanguage::ObjectiveC)
+      addFunction(SILDeclRef(AFD).asForeign());
 
     {
       // Distributed functions emit a number of thunks that we need to replicate here.

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1560,9 +1560,12 @@ void SILGenModule::emitAbstractFuncDecl(AbstractFunctionDecl *AFD) {
             && "emitAbstractFuncDecl() on ABI-only decl?");
 
   // If the declaration is exported to C with the thunk model (@_cdecl or @objc
-  // on a top-level function), emit its native-to-foreign thunk. The thunk
-  // carries the C symbol name and bridges types like String <-> NSString.
-  if (AFD->getCDeclKind() == ForeignLanguage::ObjectiveC) {
+  // on a top-level function with bridged types), emit its native-to-foreign
+  // thunk. The thunk carries the C symbol name and bridges types like
+  // String <-> NSString. C-compatible @objc globals use the @c single-symbol
+  // model and don't need a thunk.
+  if (AFD->getCDeclKind() == ForeignLanguage::ObjectiveC &&
+      !AFD->hasOnlyCEntryPoint()) {
     auto thunk = SILDeclRef(AFD).asForeign();
     if (!hasFunction(thunk))
       emitNativeToForeignThunk(thunk);

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1559,14 +1559,13 @@ void SILGenModule::emitAbstractFuncDecl(AbstractFunctionDecl *AFD) {
   ASSERT(ABIRoleInfo(AFD).providesAPI()
             && "emitAbstractFuncDecl() on ABI-only decl?");
 
-  // If the declaration is exported as a C function, emit its native-to-foreign
-  // thunk too, if it wasn't already forced.
-  if (auto cdeclAttr = AFD->getAttrs().getAttribute<CDeclAttr>()) {
-    if (cdeclAttr->Underscored) {
-      auto thunk = SILDeclRef(AFD).asForeign();
-      if (!hasFunction(thunk))
-        emitNativeToForeignThunk(thunk);
-    }
+  // If the declaration is exported to C with the thunk model (@_cdecl or @objc
+  // on a top-level function), emit its native-to-foreign thunk. The thunk
+  // carries the C symbol name and bridges types like String <-> NSString.
+  if (AFD->getCDeclKind() == ForeignLanguage::ObjectiveC) {
+    auto thunk = SILDeclRef(AFD).asForeign();
+    if (!hasFunction(thunk))
+      emitNativeToForeignThunk(thunk);
   }
 
   emitDistributedThunkForDecl(AFD);

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1583,7 +1583,10 @@ void AttributeChecker::visitObjCAttr(ObjCAttr *attr) {
     else if (attr->hasName() && EED->getParentCase()->getElements().size() > 1)
       error = diag::objc_enum_case_multi;
   } else if (auto *func = dyn_cast<FuncDecl>(D)) {
-    if (!checkObjCDeclContext(D))
+    // A top-level function may be @objc (SE-0495): it is exposed as a
+    // C-callable entry point that accepts Objective-C types, rather than an
+    // Objective-C method.
+    if (!checkObjCDeclContext(D) && !func->isObjCGlobalFunction())
       error = diag::invalid_objc_decl_context;
     else if (auto accessor = dyn_cast<AccessorDecl>(func))
       if (!accessor->isGetterOrSetter()) {
@@ -1625,8 +1628,9 @@ void AttributeChecker::visitObjCAttr(ObjCAttr *attr) {
   if (auto objcName = attr->getName()) {
     if (isa<ClassDecl>(D) || isa<ProtocolDecl>(D) || isa<VarDecl>(D)
         || isa<EnumDecl>(D) || isa<EnumElementDecl>(D)
-        || isa<ExtensionDecl>(D)) {
-      // Types and properties can only have nullary
+        || isa<ExtensionDecl>(D)
+        || (isa<FuncDecl>(D) && cast<FuncDecl>(D)->isObjCGlobalFunction())) {
+      // Types, properties, and top-level functions can only have nullary
       // names. Complain and recover by chopping off everything
       // after the first name.
       if (objcName->getNumArgs() > 0) {

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -4285,6 +4285,32 @@ TypeCheckCDeclFunctionRequest::evaluate(Evaluator &evaluator,
     }
   } else {
     reason.setAttrInvalid();
+
+    // If this is a top-level @c function whose types would be valid under
+    // @objc, suggest using @objc instead.
+    if (auto *cdeclAttr = dyn_cast<CDeclAttr>(attr);
+        cdeclAttr && !cdeclAttr->Underscored &&
+        FD->getDeclContext()->isModuleScopeContext()) {
+      // Probe ObjC representability without emitting diagnostics.
+      DiagnosticTransaction transaction(ctx.Diags);
+      auto objcReason = ObjCReason(ObjCReason::ExplicitlyUnderscoreCDecl, attr);
+      std::optional<ForeignAsyncConvention> asyncConv;
+      std::optional<ForeignErrorConvention> errorConv;
+      bool validInObjC =
+          isRepresentableInLanguage(FD, objcReason, asyncConv, errorConv);
+      transaction.abort();
+
+      if (validInObjC) {
+        // Build the replacement text: @objc or @objc(name).
+        std::string replacement;
+        if (cdeclAttr->Name.empty())
+          replacement = "@objc";
+        else
+          replacement = ("@objc(" + cdeclAttr->Name + ")").str();
+        ctx.Diags.diagnose(attr->getLocation(), diag::cdecl_suggest_objc)
+            .fixItReplace(attr->getRangeWithAt(), replacement);
+      }
+    }
   }
   return {};
 }

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -1908,6 +1908,11 @@ bool IsObjCRequest::evaluate(Evaluator &evaluator, ValueDecl *VD) const {
     isObjC = shouldMarkAsObjC(VD, isa<ConstructorDecl>(VD));
   } else {
     // Cannot be @objc.
+    //
+    // Note: a top-level @objc function (SE-0495) is *not* marked @objc here.
+    // Like @c/@_cdecl, it is a plain C-callable entry point with no selector
+    // or message-send dispatch; its representability is validated by
+    // TypeCheckCDeclFunctionRequest and it is identified via getCDeclKind().
   }
 
   // If this declaration should not be exposed to Objective-C, we're done.
@@ -4249,15 +4254,22 @@ evaluate(Evaluator &evaluator, Decl *D) const {
 evaluator::SideEffect
 TypeCheckCDeclFunctionRequest::evaluate(Evaluator &evaluator,
                                         FuncDecl *FD,
-                                        CDeclAttr *attr) const {
+                                        DeclAttribute *attr) const {
   auto &ctx = FD->getASTContext();
 
   auto lang = FD->getCDeclKind();
-  assert(lang && "missing @c?");
-  auto kind = lang == ForeignLanguage::ObjectiveC
-                      ? ObjCReason::ExplicitlyUnderscoreCDecl
-                      : ObjCReason::ExplicitlyCDecl;
-  ObjCReason reason(kind, attr);
+  assert(lang && "missing @c/@objc?");
+  // Pick the reason that matches the spelling that requested the C export, so
+  // diagnostics refer to the right attribute. @objc on a top-level function
+  // (SE-0495) checks Objective-C representability just like @_cdecl.
+  ObjCReason reason = [&] {
+    if (auto objcAttr = dyn_cast<ObjCAttr>(attr))
+      return objCReasonForObjCAttr(objcAttr);
+    auto kind = lang == ForeignLanguage::ObjectiveC
+                        ? ObjCReason::ExplicitlyUnderscoreCDecl
+                        : ObjCReason::ExplicitlyCDecl;
+    return ObjCReason(kind, attr);
+  }();
 
   std::optional<ForeignAsyncConvention> asyncConvention;
   std::optional<ForeignErrorConvention> errorConvention;

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -3792,10 +3792,19 @@ public:
     }
 
     // If the function is exported to C, it must be representable in (Obj-)C.
-    if (auto CDeclAttr = FD->getAttrs().getAttribute<swift::CDeclAttr>()) {
+    // This covers @c and @_cdecl, as well as @objc on a top-level function
+    // (SE-0495), which is a C export accepting Objective-C types.
+    if (auto cdeclAttr = FD->getAttrs().getAttribute<swift::CDeclAttr>()) {
       evaluateOrDefault(Ctx.evaluator,
-                        TypeCheckCDeclFunctionRequest{FD, CDeclAttr},
+                        TypeCheckCDeclFunctionRequest{FD, cdeclAttr},
                         {});
+    } else if (FD->getDeclContext()->isModuleScopeContext() &&
+               !isa<AccessorDecl>(FD)) {
+      if (auto objcAttr = FD->getAttrs().getAttribute<ObjCAttr>()) {
+        evaluateOrDefault(Ctx.evaluator,
+                          TypeCheckCDeclFunctionRequest{FD, objcAttr},
+                          {});
+      }
     }
 
     TypeChecker::checkObjCImplementation(FD);

--- a/test/IRGen/objc_global_func.swift
+++ b/test/IRGen/objc_global_func.swift
@@ -12,7 +12,9 @@ import Foundation
 // CHECK-DAG: define hidden i64 @customName()
 @objc(customName) func named() -> Int { 0 }
 
-// C-compatible: ObjC object types are trivially representable.
+// ObjC object types are trivially representable in ObjC (no bridging needed),
+// so they use the single-symbol model. Note: @c would reject NSObject since
+// ObjC classes are not representable in C.
 // CHECK-DAG: define hidden void @takesObject(ptr %0)
 @objc(takesObject) func takesObject(_ x: NSObject) {}
 

--- a/test/IRGen/objc_global_func.swift
+++ b/test/IRGen/objc_global_func.swift
@@ -1,0 +1,45 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-ir %s -module-name objc_global_func | %FileCheck %s
+
+// REQUIRES: objc_interop
+
+import Foundation
+
+// A top-level @objc function (SE-0495) emits both a C-convention thunk (with
+// the C symbol name) and a native Swift-convention body. Bridged types like
+// String and Array are translated in the thunk (String <-> NSString, etc.).
+
+// C thunk (called from C/ObjC):
+// CHECK-DAG: define hidden void @basic()
+// Native body (called from Swift):
+// CHECK-DAG: define hidden swiftcc void @"$s16objc_global_func5basicyyF"()
+@objc func basic() {}
+
+// CHECK-DAG: define hidden i64 @customName()
+@objc(customName) func named() -> Int { 0 }
+
+// ObjC object parameters are passed as plain pointers in the C thunk.
+// CHECK-DAG: define hidden void @takesObject(ptr %0)
+@objc(takesObject) func takesObject(_ x: NSObject) {}
+
+// Argument labels are dropped in the C signature; parameters are positional.
+// CHECK-DAG: define hidden i64 @addNumbers(i64 %0, i64 %1)
+@objc(addNumbers) func add(lhs: Int, rhs: Int) -> Int { lhs + rhs }
+
+// Bridged types: the C thunk takes/returns NSString (ptr), the native body
+// takes/returns String (i64 + ptr pair).
+// CHECK-DAG: define hidden ptr @greet(ptr %0)
+// CHECK-DAG: define hidden swiftcc { i64, ptr } @"$s16objc_global_func5greet4nameS2S_tF"(i64 %0, ptr %1)
+@objc(greet) func greet(name: String) -> String { "Hi \(name)" }
+
+// Bridged collection: the C thunk takes NSArray (ptr).
+// CHECK-DAG: define hidden i64 @count(ptr %0)
+@objc(count) func count(items: [NSObject]) -> Int { items.count }
+
+// A Swift call uses swiftcc to the native body, not the C thunk.
+// CHECK-LABEL: define hidden swiftcc void @"$s16objc_global_func6calleryyF"
+// CHECK: call swiftcc i64 @"$s16objc_global_func5namedSiyF"()
+// CHECK: call swiftcc i64 @"$s16objc_global_func3add3lhs3rhsS2i_SitF"(i64 7, i64 11)
+func caller() {
+  _ = named()
+  _ = add(lhs: 7, rhs: 11)
+}

--- a/test/IRGen/objc_global_func.swift
+++ b/test/IRGen/objc_global_func.swift
@@ -4,42 +4,79 @@
 
 import Foundation
 
-// A top-level @objc function (SE-0495) emits both a C-convention thunk (with
-// the C symbol name) and a native Swift-convention body. Bridged types like
-// String and Array are translated in the thunk (String <-> NSString, etc.).
+// A top-level @objc function (SE-0495) uses one of two symbol models:
+// - C-compatible signature: single C entry point (like @c)
+// - ObjC-bridged signature: C thunk + native Swift body (like @_cdecl)
 
-// C thunk (called from C/ObjC):
-// CHECK-DAG: define hidden void @basic()
-// Native body (called from Swift):
-// CHECK-DAG: define hidden swiftcc void @"$s16objc_global_func5basicyyF"()
-@objc func basic() {}
-
+// C-compatible: single C entry point, no separate Swift symbol.
 // CHECK-DAG: define hidden i64 @customName()
 @objc(customName) func named() -> Int { 0 }
 
-// ObjC object parameters are passed as plain pointers in the C thunk.
+// C-compatible: ObjC object types are trivially representable.
 // CHECK-DAG: define hidden void @takesObject(ptr %0)
 @objc(takesObject) func takesObject(_ x: NSObject) {}
 
-// Argument labels are dropped in the C signature; parameters are positional.
+// C-compatible: all Int parameters, single symbol.
 // CHECK-DAG: define hidden i64 @addNumbers(i64 %0, i64 %1)
 @objc(addNumbers) func add(lhs: Int, rhs: Int) -> Int { lhs + rhs }
 
-// Bridged types: the C thunk takes/returns NSString (ptr), the native body
+// Bridged types: C thunk takes/returns NSString (ptr), native body
 // takes/returns String (i64 + ptr pair).
 // CHECK-DAG: define hidden ptr @greet(ptr %0)
 // CHECK-DAG: define hidden swiftcc { i64, ptr } @"$s16objc_global_func5greet4nameS2S_tF"(i64 %0, ptr %1)
 @objc(greet) func greet(name: String) -> String { "Hi \(name)" }
 
-// Bridged collection: the C thunk takes NSArray (ptr).
+// Bridged collection: C thunk takes NSArray (ptr).
 // CHECK-DAG: define hidden i64 @count(ptr %0)
 @objc(count) func count(items: [NSObject]) -> Int { items.count }
 
-// A Swift call uses swiftcc to the native body, not the C thunk.
+// A Swift call to a C-compatible @objc function calls the C symbol directly.
+// A Swift call to a bridged @objc function calls the native Swift body.
 // CHECK-LABEL: define hidden swiftcc void @"$s16objc_global_func6calleryyF"
-// CHECK: call swiftcc i64 @"$s16objc_global_func5namedSiyF"()
-// CHECK: call swiftcc i64 @"$s16objc_global_func3add3lhs3rhsS2i_SitF"(i64 7, i64 11)
+// CHECK: call i64 @addNumbers(i64 7, i64 11)
+// CHECK: call swiftcc { i64, ptr } @"$s16objc_global_func5greet4nameS2S_tF"
 func caller() {
-  _ = named()
   _ = add(lhs: 7, rhs: 11)
+  _ = greet(name: "World")
 }
+
+// ABI stability: @c and @objc with the same C-compatible signature produce
+// identical symbol layout -- a single C entry point with no Swift mangled name.
+// This means changing between @c and @objc is ABI-stable per SE-0495.
+
+// CHECK-DAG: define hidden i64 @viaCAttr(i64 %0)
+// CHECK-NOT: define {{.*}} @"$s16objc_global_func7viaCFuncSiSiF"
+@c(viaCAttr) func viaCFunc(x: Int) -> Int { x }
+
+// CHECK-DAG: define hidden i64 @viaObjCAttr(i64 %0)
+// CHECK-NOT: define {{.*}} @"$s16objc_global_func10viaObjCFuncSiSiF"
+@objc(viaObjCAttr) func viaObjCFunc(x: Int) -> Int { x }
+
+// Function type parameters: C function pointers and blocks are trivially
+// representable in ObjC and use the single-symbol model. Swift closures
+// are StaticBridged (closure -> block conversion) and need a thunk.
+// Each @objc variant is paired with an @c equivalent to show ABI equivalence.
+
+// C function pointer: trivially representable, single symbol.
+// CHECK-DAG: define hidden void @takesCFuncPtr_c(ptr %0)
+// CHECK-NOT: define {{.*}} @"$s16objc_global_func014takesCFuncPtr_D0yyyXCF"
+@c(takesCFuncPtr_c) func takesCFuncPtr_c(_ f: @convention(c) () -> Void) { f() }
+
+// CHECK-DAG: define hidden void @takesCFuncPtr_objc(ptr %0)
+// CHECK-NOT: define {{.*}} @"$s16objc_global_func017takesCFuncPtr_obD0yyyXCF"
+@objc(takesCFuncPtr_objc) func takesCFuncPtr_objc(_ f: @convention(c) () -> Void) { f() }
+
+// ObjC block: trivially representable (Object kind), single symbol.
+// CHECK-DAG: define hidden void @takesBlock_c(ptr %0)
+// CHECK-NOT: define {{.*}} @"$s16objc_global_func012takesBlock_D0yyyXBF"
+@c(takesBlock_c) func takesBlock_c(_ f: @convention(block) () -> Void) { f() }
+
+// CHECK-DAG: define hidden void @takesBlock_objc(ptr %0)
+// CHECK-NOT: define {{.*}} @"$s16objc_global_func015takesBlock_obcD0yyyXBF"
+@objc(takesBlock_objc) func takesBlock_objc(_ f: @convention(block) () -> Void) { f() }
+
+// Swift closure: StaticBridged (needs closure-to-block conversion), thunk model.
+// Only valid with @objc -- @c rejects Swift closures at type-checking.
+// CHECK-DAG: define hidden void @takesClosure(ptr %0)
+// CHECK-DAG: define hidden swiftcc void @"$s16objc_global_func12takesClosureyyyyXEF"
+@objc(takesClosure) func takesClosure(_ f: () -> Void) { f() }

--- a/test/IRGen/objc_global_func_cross_module.swift
+++ b/test/IRGen/objc_global_func_cross_module.swift
@@ -1,0 +1,31 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t --leading-lines
+
+/// Build a library exposing a public @objc global function.
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) %t/Lib.swift \
+// RUN:   -emit-module -module-name Lib -o %t
+
+/// A client in another module calls it by its Swift base name. The call uses
+/// the native Swift symbol (swiftcc); the C symbol is the library's thunk.
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) %t/Client.swift \
+// RUN:   -emit-ir -module-name Client -I %t | %FileCheck %t/Client.swift
+
+// REQUIRES: objc_interop
+
+//--- Lib.swift
+
+import Foundation
+
+@objc(renamed) public func named() -> Int { return 0 }
+
+//--- Client.swift
+
+import Lib
+
+// The client calls the public function by its Swift base name. Cross-module
+// calls use the native Swift-convention symbol.
+// CHECK-LABEL: define swiftcc i64 @"$s6Client5useItSiyF"
+// CHECK: call swiftcc i64 @"$s3Lib5namedSiyF"()
+public func useIt() -> Int {
+  return named()
+}

--- a/test/IRGen/objc_global_func_cross_module.swift
+++ b/test/IRGen/objc_global_func_cross_module.swift
@@ -1,12 +1,12 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t --leading-lines
 
-/// Build a library exposing a public @objc global function.
+/// Build a library exposing public @objc global functions.
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) %t/Lib.swift \
 // RUN:   -emit-module -module-name Lib -o %t
 
-/// A client in another module calls it by its Swift base name. The call uses
-/// the native Swift symbol (swiftcc); the C symbol is the library's thunk.
+/// A client in another module calls them. C-compatible functions call the C
+/// symbol directly; bridged functions call the native Swift symbol.
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) %t/Client.swift \
 // RUN:   -emit-ir -module-name Client -I %t | %FileCheck %t/Client.swift
 
@@ -18,14 +18,22 @@ import Foundation
 
 @objc(renamed) public func named() -> Int { return 0 }
 
+@objc(greetInLib) public func greet(name: String) -> String { return name }
+
 //--- Client.swift
 
 import Lib
 
-// The client calls the public function by its Swift base name. Cross-module
-// calls use the native Swift-convention symbol.
+// C-compatible: cross-module call uses the C symbol directly.
 // CHECK-LABEL: define swiftcc i64 @"$s6Client5useItSiyF"
-// CHECK: call swiftcc i64 @"$s3Lib5namedSiyF"()
+// CHECK: call i64 @renamed()
 public func useIt() -> Int {
   return named()
+}
+
+// Bridged: cross-module call uses the native Swift symbol.
+// CHECK-LABEL: define swiftcc { i64, ptr } @"$s6Client8useGreetSSyF"
+// CHECK: call swiftcc { i64, ptr } @"$s3Lib5greet4nameS2S_tF"
+public func useGreet() -> String {
+  return greet(name: "World")
 }

--- a/test/Interpreter/objc_global_func_run.swift
+++ b/test/Interpreter/objc_global_func_run.swift
@@ -1,0 +1,66 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t --leading-lines
+
+/// Generate the Objective-C header for the Swift @objc global functions.
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) \
+// RUN:   %t/Lib.swift -emit-module -verify -o %t \
+// RUN:   -emit-objc-header-path %t/Lib.h
+
+/// Build and run a binary mixing Swift and Objective-C code.
+// RUN: %target-clang -fobjc-arc -c %t/Client.m -o %t/Client.o \
+// RUN:   -isysroot %sdk -I %t
+// RUN: %target-build-swift %t/Lib.swift %t/Client.o -o %t/a.out -parse-as-library
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out > %t/run.log
+// RUN: %FileCheck %s --input-file %t/run.log
+
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+//--- Lib.swift
+
+import Foundation
+
+@objc(addOne) public func addOne(_ x: Int) -> Int {
+    return x + 1
+}
+
+@objc(greeting) public func greeting(_ name: NSString) -> NSString {
+    return "Hi \(name)" as NSString
+}
+
+// Bridged type: String <-> NSString
+@objc(greetSwift) public func greetSwift(_ name: String) -> String {
+    return "Hello \(name)"
+}
+
+// Bridged collection: [NSObject] <-> NSArray
+@objc(countItems) public func countItems(_ items: [NSObject]) -> Int {
+    return items.count
+}
+
+//--- Client.m
+
+#import <Foundation/Foundation.h>
+#import "Lib.h"
+
+int main() {
+    printf("%ld\n", (long)addOne(41));
+    // CHECK: 42
+
+    NSString *g = greeting(@"world");
+    printf("%s\n", g.UTF8String);
+    // CHECK-NEXT: Hi world
+
+    // Bridged String: caller passes NSString, thunk bridges to Swift String
+    NSString *gs = greetSwift(@"Swift");
+    printf("%s\n", gs.UTF8String);
+    // CHECK-NEXT: Hello Swift
+
+    // Bridged Array: caller passes NSArray, thunk bridges to [NSObject]
+    NSArray *items = @[@"a", @"b", @"c"];
+    printf("%ld\n", (long)countItems(items));
+    // CHECK-NEXT: 3
+
+    return 0;
+}

--- a/test/PrintAsObjC/objc_global_func.swift
+++ b/test/PrintAsObjC/objc_global_func.swift
@@ -1,0 +1,38 @@
+/// Check that @objc on a top-level function (SE-0495) is printed into the
+/// Objective-C compatibility header, using Objective-C types. Bridged types
+/// (String, Array, Dictionary) are printed as their Objective-C counterparts.
+
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) \
+// RUN:   %s -emit-module -o %t -emit-objc-header-path %t/objc_global_func.h
+
+// RUN: %FileCheck %s --input-file %t/objc_global_func.h
+// RUN: %check-in-clang %t/objc_global_func.h
+
+// REQUIRES: objc_interop
+
+import Foundation
+
+// CHECK-DAG: SWIFT_EXTERN void basic(void) SWIFT_NOEXCEPT;
+@objc func basic() {}
+
+// The C symbol name comes from the @objc(name) argument.
+// CHECK-DAG: SWIFT_EXTERN NSInteger customName(void) SWIFT_NOEXCEPT SWIFT_WARN_UNUSED_RESULT;
+@objc(customName) func named() -> Int { 0 }
+
+// Objective-C class types are printed with their Objective-C spelling.
+// CHECK-DAG: SWIFT_EXTERN NSObject * _Nonnull takesObject(NSObject * _Nonnull x) SWIFT_NOEXCEPT SWIFT_WARN_UNUSED_RESULT;
+@objc(takesObject) func takesObject(_ x: NSObject) -> NSObject { x }
+
+// Bridged types: String prints as NSString.
+// CHECK-DAG: SWIFT_EXTERN NSString * _Nonnull greet(NSString * _Nonnull name) SWIFT_NOEXCEPT SWIFT_WARN_UNUSED_RESULT;
+@objc(greet) func greet(name: String) -> String { "" }
+
+// Bridged collection: [NSObject] prints as NSArray<NSObject *>.
+// CHECK-DAG: SWIFT_EXTERN NSInteger countItems(NSArray<NSObject *> * _Nonnull items) SWIFT_NOEXCEPT SWIFT_WARN_UNUSED_RESULT;
+@objc(countItems) func countItems(items: [NSObject]) -> Int { 0 }
+
+// Bridged dictionary: [String: NSObject] prints as NSDictionary<NSString *, NSObject *>.
+// CHECK-DAG: SWIFT_EXTERN NSObject * _Nullable lookup(NSDictionary<NSString *, NSObject *> * _Nonnull dict) SWIFT_NOEXCEPT SWIFT_WARN_UNUSED_RESULT;
+@objc(lookup) func lookup(dict: [String: NSObject]) -> NSObject? { nil }

--- a/test/SILGen/objc_global_func.swift
+++ b/test/SILGen/objc_global_func.swift
@@ -16,7 +16,8 @@ import Foundation
 // CHECK-LABEL: sil hidden [asmname "customName"] [ossa] @$s16objc_global_func5namedSiyFTo : $@convention(c) () -> Int {
 @objc(customName) func named() -> Int { 0 }
 
-// C-compatible: NSObject is trivially representable in ObjC.
+// Trivially representable in ObjC (no bridging needed), single symbol.
+// Note: @c would reject NSObject since ObjC classes are not representable in C.
 // CHECK-LABEL: sil hidden [asmname "takesObject"] [ossa] @$s16objc_global_func11takesObjectyySo8NSObjectCFTo : $@convention(c) (NSObject) -> () {
 @objc(takesObject) func takesObject(_ x: NSObject) {}
 

--- a/test/SILGen/objc_global_func.swift
+++ b/test/SILGen/objc_global_func.swift
@@ -1,0 +1,46 @@
+// RUN: %target-swift-emit-silgen(mock-sdk: %clang-importer-sdk) %s -module-name objc_global_func | %FileCheck %s
+
+// REQUIRES: objc_interop
+
+import Foundation
+
+// A top-level @objc function (SE-0495) emits a native-to-foreign thunk
+// carrying the [asmname] C symbol, plus a native Swift body. The thunk bridges
+// Objective-C types to/from Swift types when needed.
+
+// Thunk with the C symbol:
+// CHECK-LABEL: sil hidden [thunk] [asmname "basic"] [ossa] @$s16objc_global_func5basicyyFTo : $@convention(c) () -> () {
+// Native body:
+// CHECK-LABEL: sil hidden [ossa] @$s16objc_global_func5basicyyF : $@convention(thin) () -> () {
+@objc func basic() {}
+
+// The C symbol name comes from the @objc(name) argument when present.
+// CHECK-LABEL: sil hidden [thunk] [asmname "customName"] [ossa] @$s16objc_global_func5namedSiyFTo : $@convention(c) () -> Int {
+@objc(customName) func named() -> Int { 0 }
+
+// Objective-C class types are allowed in the signature.
+// CHECK-LABEL: sil hidden [thunk] [asmname "takesObject"] [ossa] @$s16objc_global_func11takesObjectyySo8NSObjectCFTo : $@convention(c) (NSObject) -> () {
+@objc(takesObject) func takesObject(_ x: NSObject) {}
+
+// Argument labels are kept in the Swift name; the C symbol is flat.
+// CHECK-LABEL: sil hidden [thunk] [asmname "addNumbers"] [ossa] @$s16objc_global_func3add3lhs3rhsS2i_SitFTo : $@convention(c) (Int, Int) -> Int {
+@objc(addNumbers) func add(lhs: Int, rhs: Int) -> Int { lhs + rhs }
+
+// Bridged types: the thunk bridges String <-> NSString automatically.
+// CHECK-LABEL: sil hidden [thunk] [asmname "greet"] [ossa] @$s16objc_global_func5greet4nameS2S_tFTo : $@convention(c) (NSString) -> @autoreleased NSString {
+@objc(greet) func greet(name: String) -> String { "Hi \(name)" }
+
+// Bridged types: the thunk bridges [NSObject] <-> NSArray automatically.
+// CHECK-LABEL: sil hidden [thunk] [asmname "count"] [ossa] @$s16objc_global_func5count5itemsSiSaySo8NSObjectCG_tFTo : $@convention(c) (NSArray) -> Int {
+@objc(count) func count(items: [NSObject]) -> Int { items.count }
+
+// Swift call sites reference the native body, not the thunk.
+// CHECK-LABEL: sil hidden [ossa] @$s16objc_global_func6calleryyF
+func caller() {
+  basic()
+  // CHECK: function_ref @$s16objc_global_func5basicyyF
+  _ = named()
+  // CHECK: function_ref @$s16objc_global_func5namedSiyF
+  _ = add(lhs: 7, rhs: 11)
+  // CHECK: function_ref @$s16objc_global_func3add3lhs3rhsS2i_SitF
+}

--- a/test/SILGen/objc_global_func.swift
+++ b/test/SILGen/objc_global_func.swift
@@ -4,43 +4,45 @@
 
 import Foundation
 
-// A top-level @objc function (SE-0495) emits a native-to-foreign thunk
-// carrying the [asmname] C symbol, plus a native Swift body. The thunk bridges
-// Objective-C types to/from Swift types when needed.
+// A top-level @objc function (SE-0495) uses one of two symbol models:
+// - C-compatible signature: single C entry point (like @c)
+// - ObjC-bridged signature: Swift body + C thunk (like @_cdecl)
 
-// Thunk with the C symbol:
-// CHECK-LABEL: sil hidden [thunk] [asmname "basic"] [ossa] @$s16objc_global_func5basicyyFTo : $@convention(c) () -> () {
-// Native body:
-// CHECK-LABEL: sil hidden [ossa] @$s16objc_global_func5basicyyF : $@convention(thin) () -> () {
+// C-compatible: single symbol, no thunk.
+// CHECK-LABEL: sil hidden [asmname "basic"] [ossa] @$s16objc_global_func5basicyyFTo : $@convention(c) () -> () {
 @objc func basic() {}
 
-// The C symbol name comes from the @objc(name) argument when present.
-// CHECK-LABEL: sil hidden [thunk] [asmname "customName"] [ossa] @$s16objc_global_func5namedSiyFTo : $@convention(c) () -> Int {
+// C-compatible: Int is trivially representable in ObjC.
+// CHECK-LABEL: sil hidden [asmname "customName"] [ossa] @$s16objc_global_func5namedSiyFTo : $@convention(c) () -> Int {
 @objc(customName) func named() -> Int { 0 }
 
-// Objective-C class types are allowed in the signature.
-// CHECK-LABEL: sil hidden [thunk] [asmname "takesObject"] [ossa] @$s16objc_global_func11takesObjectyySo8NSObjectCFTo : $@convention(c) (NSObject) -> () {
+// C-compatible: NSObject is trivially representable in ObjC.
+// CHECK-LABEL: sil hidden [asmname "takesObject"] [ossa] @$s16objc_global_func11takesObjectyySo8NSObjectCFTo : $@convention(c) (NSObject) -> () {
 @objc(takesObject) func takesObject(_ x: NSObject) {}
 
-// Argument labels are kept in the Swift name; the C symbol is flat.
-// CHECK-LABEL: sil hidden [thunk] [asmname "addNumbers"] [ossa] @$s16objc_global_func3add3lhs3rhsS2i_SitFTo : $@convention(c) (Int, Int) -> Int {
+// C-compatible: all Int parameters.
+// CHECK-LABEL: sil hidden [asmname "addNumbers"] [ossa] @$s16objc_global_func3add3lhs3rhsS2i_SitFTo : $@convention(c) (Int, Int) -> Int {
 @objc(addNumbers) func add(lhs: Int, rhs: Int) -> Int { lhs + rhs }
 
-// Bridged types: the thunk bridges String <-> NSString automatically.
+// Bridged types: String <-> NSString requires a thunk.
 // CHECK-LABEL: sil hidden [thunk] [asmname "greet"] [ossa] @$s16objc_global_func5greet4nameS2S_tFTo : $@convention(c) (NSString) -> @autoreleased NSString {
+// CHECK-LABEL: sil hidden [ossa] @$s16objc_global_func5greet4nameS2S_tF : $@convention(thin) (@guaranteed String) -> @owned String {
 @objc(greet) func greet(name: String) -> String { "Hi \(name)" }
 
-// Bridged types: the thunk bridges [NSObject] <-> NSArray automatically.
+// Bridged types: [NSObject] <-> NSArray requires a thunk.
 // CHECK-LABEL: sil hidden [thunk] [asmname "count"] [ossa] @$s16objc_global_func5count5itemsSiSaySo8NSObjectCG_tFTo : $@convention(c) (NSArray) -> Int {
 @objc(count) func count(items: [NSObject]) -> Int { items.count }
 
-// Swift call sites reference the native body, not the thunk.
+// Swift call sites: C-compatible functions call the C entry point;
+// bridged functions call the native Swift body.
 // CHECK-LABEL: sil hidden [ossa] @$s16objc_global_func6calleryyF
 func caller() {
   basic()
-  // CHECK: function_ref @$s16objc_global_func5basicyyF
+  // CHECK: function_ref @$s16objc_global_func5basicyyFTo
   _ = named()
-  // CHECK: function_ref @$s16objc_global_func5namedSiyF
+  // CHECK: function_ref @$s16objc_global_func5namedSiyFTo
   _ = add(lhs: 7, rhs: 11)
-  // CHECK: function_ref @$s16objc_global_func3add3lhs3rhsS2i_SitF
+  // CHECK: function_ref @$s16objc_global_func3add3lhs3rhsS2i_SitFTo
+  _ = greet(name: "World")
+  // CHECK: function_ref @$s16objc_global_func5greet4nameS2S_tF
 }

--- a/test/attr/attr_c_with_objc.swift
+++ b/test/attr/attr_c_with_objc.swift
@@ -10,11 +10,13 @@ class ObjCClass: NSObject { }
 @c(objcClassReturn) func objcClassReturn() -> ObjCClass { fatalError() }
 // expected-error @-1 {{global function cannot be marked '@c' because its result type cannot be represented in C}}
 // expected-note @-2 {{classes cannot be represented in C}}
+// expected-note @-3 {{use '@objc' to expose this function to Objective-C}}
 
 @c(objcClassParams) func objcClassParams(a: ObjCClass, b: ObjCClass) { }
 // expected-error @-1 {{global function cannot be marked '@c' because the type of the parameter 1 cannot be represented in C}}
 // expected-error @-2 {{global function cannot be marked '@c' because the type of the parameter 2 cannot be represented in C}}
 // expected-note @-3 2 {{classes cannot be represented in C}}
+// expected-note @-4 {{use '@objc' to expose this function to Objective-C}}
 
 @objc
 protocol ObjCProtocol {}
@@ -22,12 +24,14 @@ protocol ObjCProtocol {}
 @c(objcProtocol) func objcProtocol(a: ObjCProtocol) { }
 // expected-error @-1 {{global function cannot be marked '@c' because the type of the parameter cannot be represented in C}}
 // expected-note @-2 {{protocols cannot be represented in C}}
+// expected-note @-3 {{use '@objc' to expose this function to Objective-C}}
 
 @objc
 enum ObjCEnum: Int { case A, B }
 @c(objcEnumUseInCDecl) func objcEnumUseInCDecl(a: ObjCEnum) { }
 // expected-error @-1 {{global function cannot be marked '@c' because the type of the parameter cannot be represented in C}}
 // expected-note @-2 {{Swift enums not marked '@c' cannot be represented in C}}
+// expected-note @-3 {{use '@objc' to expose this function to Objective-C}}
 
 /// Objective-C accepts @c enums.
 @c(CEnum)

--- a/test/attr/attr_cdecl_official_with_cf.swift
+++ b/test/attr/attr_cdecl_official_with_cf.swift
@@ -12,15 +12,19 @@ import CoreFoundation
 @c(unmanagedCFStringReturn) func unmanagedCFClassReturn() -> Unmanaged<CFString> { fatalError() }
 // expected-error@-1 {{global function cannot be marked '@c' because its result type cannot be represented in C}}
 // expected-note@-2 {{Swift structs cannot be represented in C}}
+// expected-note@-3 {{use '@objc' to expose this function to Objective-C}}
 @c(unmanagedCFObjectParams) func unmanagedCFClassParams(a: Unmanaged<CFArray>, b: Unmanaged<CFDictionary>) { }
 // expected-error@-1 {{global function cannot be marked '@c' because the type of the parameter 1 cannot be represented in C}}
 // expected-error@-2 {{global function cannot be marked '@c' because the type of the parameter 2 cannot be represented in C}}
 // expected-note@-3 {{Swift structs cannot be represented in C}}
 // expected-note@-4 {{Swift structs cannot be represented in C}}
+// expected-note@-5 {{use '@objc' to expose this function to Objective-C}}
 
 @c(unmanagedOptioanlCFStringReturn) func unmanagedCFClassReturn() -> Unmanaged<CFString>? { fatalError() }
 // expected-error@-1 {{global function cannot be marked '@c' because its result type cannot be represented in C}}
+// expected-note@-2 {{use '@objc' to expose this function to Objective-C}}
 @c(unmanagedOptioanlCFObjectParams) func unmanagedCFClassParams(a: Unmanaged<CFArray>?, b: Unmanaged<CFDictionary>?) { }
 // expected-error@-1 {{global function cannot be marked '@c' because the type of the parameter 1 cannot be represented in C}}
 // expected-error@-2 {{global function cannot be marked '@c' because the type of the parameter 2 cannot be represented in C}}
+// expected-note@-3 {{use '@objc' to expose this function to Objective-C}}
 

--- a/test/attr/attr_objc.swift
+++ b/test/attr/attr_objc.swift
@@ -159,8 +159,8 @@ class subject_staticVar1 {
   class var staticVar2: Int { return 42 }
 }
 
-@objc // bad-access-note-move{{subject_freeFunc()}} expected-error {{'@objc' can only be used with members of classes, '@objc' protocols, and concrete extensions of classes}} {{1-7=}}
-func subject_freeFunc() {
+@objc // access-note-move{{subject_freeFunc()}}
+func subject_freeFunc() { // A top-level @objc function is valid (SE-0495).
   @objc // expected-error {{'@objc' can only be used with members of classes, '@objc' protocols, and concrete extensions of classes}} {{3-9=}}
   var subject_localVar: Int
   // expected-warning@-1 {{variable 'subject_localVar' was never used; consider replacing with '_' or removing it}}
@@ -170,8 +170,8 @@ func subject_freeFunc() {
   }
 }
 
-@objc // bad-access-note-move{{subject_genericFunc(t:)}} expected-error {{'@objc' can only be used with members of classes, '@objc' protocols, and concrete extensions of classes}} {{1-7=}}
-func subject_genericFunc<T>(t: T) {
+@objc // expected-error@+1 {{global function cannot be marked '@objc' because it has generic parameters}}
+func subject_genericFunc<T>(t: T) { // A top-level @objc function cannot be generic.
   @objc // expected-error {{'@objc' can only be used with members of classes, '@objc' protocols, and concrete extensions of classes}} {{3-9=}}
   var subject_localVar: Int
   // expected-warning@-1 {{variable 'subject_localVar' was never used; consider replacing with '_' or removing it}}

--- a/test/attr/objc_global_func.swift
+++ b/test/attr/objc_global_func.swift
@@ -1,0 +1,65 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -verify %s
+
+// REQUIRES: objc_interop
+
+import Foundation
+
+// A plain top-level @objc function is accepted (SE-0495).
+@objc func basic() {}
+
+// @objc accepts an explicit, simple C name.
+@objc(customName) func named() {}
+
+// The @objc(name) argument only sets the C/linker symbol; the Swift-visible
+// name remains the base identifier. The C name is not in Swift scope.
+func callsBySwiftName() {
+  named()        // OK: the Swift base name is visible.
+  customName()   // expected-error {{cannot find 'customName' in scope}}
+}
+
+// Unlike @c, @objc accepts Objective-C class types in the signature.
+@objc class ObjCClass: NSObject {}
+@objc func objcClassReturn() -> ObjCClass { fatalError() }
+@objc func objcClassParams(a: ObjCClass, b: ObjCClass) {}
+
+// ... @objc protocols ...
+@objc protocol ObjCProtocol {}
+@objc func objcProtocolParam(a: ObjCProtocol) {}
+
+// ... and @objc enums.
+@objc enum ObjCEnum: Int { case A, B }
+@objc func objcEnumParam(a: ObjCEnum) {}
+
+// Primitive C types remain representable.
+@objc func primitives(x: Int, y: Double) -> Int { x }
+
+// Bridged Swift types are accepted: String <-> NSString.
+@objc func takesString(s: String) {}
+@objc func returnsString() -> String { "" }
+
+// Bridged collection types: [NSObject] <-> NSArray.
+@objc func takesArray(a: [NSObject]) {}
+@objc func returnsArray() -> [NSObject] { [] }
+
+// Bridged dictionary types: [String: NSObject] <-> NSDictionary.
+@objc func takesDictionary(d: [String: NSObject]) {}
+
+// Only a simple (nullary) C name is allowed; selector-style names are rejected.
+@objc(doSomething:with:) func selectorName(a: Int, b: Int) {}
+// expected-error @-1 {{'@objc' global function must have a simple name}}
+
+// Swift-only types are still not representable in Objective-C.
+struct SwiftStruct {}
+@objc func swiftStructParam(a: SwiftStruct) {}
+// expected-error @-1 {{global function cannot be marked '@objc' because the type of the parameter cannot be represented in Objective-C}}
+// expected-note @-2 {{Swift structs cannot be represented in Objective-C}}
+
+// @objc on a member function still requires a class or @objc protocol context.
+struct NonClass {
+  @objc func method() {}
+  // expected-error @-1 {{'@objc' can only be used with members of classes, '@objc' protocols, and concrete extensions of classes}}
+}
+
+// @objc and @c cannot be combined on the same global function.
+@c @objc func both() {}
+// expected-error @-1 {{cannot apply both '@c' and '@objc' to global function}}

--- a/test/attr/objc_global_func.swift
+++ b/test/attr/objc_global_func.swift
@@ -63,3 +63,20 @@ struct NonClass {
 // @objc and @c cannot be combined on the same global function.
 @c @objc func both() {}
 // expected-error @-1 {{cannot apply both '@c' and '@objc' to global function}}
+
+// When @c rejects a type that @objc would accept, suggest @objc.
+@c(bridgedFunc) func bridged(name: String) -> String { name }
+// expected-error @-1 {{global function cannot be marked '@c' because the type of the parameter cannot be represented in C}}
+// expected-note @-2 {{Swift structs cannot be represented in C}}
+// expected-note @-3 {{use '@objc' to expose this function to Objective-C}} {{1-16=@objc(bridgedFunc)}}
+
+@c func bridgedNoName(name: String) {}
+// expected-error @-1 {{global function cannot be marked '@c' because the type of the parameter cannot be represented in C}}
+// expected-note @-2 {{Swift structs cannot be represented in C}}
+// expected-note @-3 {{use '@objc' to expose this function to Objective-C}} {{1-3=@objc}}
+
+// No @objc suggestion when the type is not valid in Objective-C either.
+struct PureSwiftStruct {}
+@c(pureSwift) func pureSwift(s: PureSwiftStruct) {}
+// expected-error @-1 {{global function cannot be marked '@c' because the type of the parameter cannot be represented in C}}
+// expected-note @-2 {{Swift structs cannot be represented in C}}

--- a/test/decl/ext/objc_global_func_implementation.swift
+++ b/test/decl/ext/objc_global_func_implementation.swift
@@ -1,0 +1,34 @@
+// RUN: %target-typecheck-verify-swift -target %target-stable-abi-triple \
+// RUN:   -import-bridging-header %S/Inputs/objc_implementation.h \
+// RUN:   -I %S/Inputs -verify-ignore-unrelated
+
+// REQUIRES: objc_interop
+
+// @objc @implementation on a top-level function (SE-0495) implements a
+// function declared in an imported Objective-C header, just like @implementation
+// @c, but accepting Objective-C types.
+
+@objc @implementation
+func CImplFunc1(_: Int32) {
+  // OK
+}
+
+@objc(CImplFuncRenamed_C) @implementation
+func CImplFuncRenamed_Swift(arg: CInt) {
+  // OK: the @objc(name) argument selects the imported C symbol.
+}
+
+@objc @implementation
+func CImplFuncMissing(_: Int32) {
+  // expected-error@-2 {{could not find imported function 'CImplFuncMissing' matching global function 'CImplFuncMissing'; make sure you import the module or header that declares it}}
+}
+
+@objc @implementation
+func CImplFuncMismatch1(_: Float) {
+  // expected-error@-1 {{global function 'CImplFuncMismatch1' of type '(Float) -> ()' does not match type '(Int32) -> Void' declared by the header}}
+}
+
+@objc @implementation
+func CImplFuncMismatch2(_: Int32) -> Float {
+  // expected-error@-1 {{global function 'CImplFuncMismatch2' of type '(Int32) -> Float' does not match type '(Int32) -> Void' declared by the header}}
+}


### PR DESCRIPTION
## Summary

[SE-0495](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0495-cdecl.md) allows `@objc` on a global function, where it behaves as the Objective-C counterpart of `@c`: a C-callable entry point whose signature may also use Objective-C-representable types (`@objc` classes, protocols, `@objc` enums, imported Obj-C types) and bridged Swift types (`String`, `Array`, `Dictionary`, etc.). The `@c` half shipped but `@objc` on a global function was still rejected (#88343). This implements the already-documented behavior. No new design, and no feature flag since SE-0495 is accepted and `@c` already ships.

```swift
@objc func doSomething() {}                                  // C symbol: doSomething

@objc(mirror)
func objectMirror(_ value: NSObject) -> NSObject { value }   // C symbol: mirror

@objc(greet)
func greet(name: String) -> String { "Hi \(name)" }          // bridged: String <-> NSString
```

### Approach

`@objc` on a top-level function picks one of two symbol models depending on the signature:

- **C-compatible signature** (all types trivially representable in ObjC -- Int, NSObject, pointers, C function pointers, blocks): uses the `@c` single-symbol model. One C entry point, no separate Swift symbol. Changing between `@c` and `@objc` is ABI-stable per SE-0495.
- **ObjC-bridged signature** (types needing conversion -- String, Array, Dictionary, Swift closures): uses the `@_cdecl` two-symbol model. A native Swift body with Swift calling convention, plus a native-to-foreign thunk carrying the C symbol name. The thunk bridges types automatically -- `String` <-> `NSString`, `[T]` <-> `NSArray`, `() -> Void` <-> ObjC block, etc. -- via the existing `emitNativeToForeignThunk` infrastructure.

The decision is made by `signatureRequiresObjCBridging()`, which checks `isTriviallyRepresentableIn(ForeignLanguage::ObjectiveC)` for each parameter and the return type. This feeds into `hasOnlyCEntryPoint()` to control the SIL symbol model.

There is no selector, no `objc_msgSend`, and no runtime registration. It is not marked `isObjC()`. The `@objc(name)` argument sets only the C/linker symbol. The Swift-visible name stays the base identifier. Argument labels are kept in the Swift name and dropped in the positional C symbol. `@objc` and `@c` on the same function remain mutually exclusive. `@objc @implementation` on a global function works with no additional changes.

When `@c` rejects a type that `@objc` would accept, a fix-it suggests replacing `@c` with `@objc`.

### Commits

1. **[Sema] Accept and type-check @objc on global functions** -- accept on a module-scope `FuncDecl` (simple/nullary C name only), report `getCDeclKind() == .objc` to share the `@_cdecl` type-checking path, validate Objective-C representability. `getCDeclName` returns the `@objc(name)` argument or the base identifier.
2. **[SIL] Emit the C symbol name** -- emit the native-to-foreign thunk via `emitAbstractFuncDecl`, unified with `@_cdecl` behind `getCDeclKind()`: `getAsmName`, linkage, `hasCReferences`, and symbol visitor all use the shared predicate.
3. **[PrintAsClang] Print into the Objective-C header** -- relax the assert in `printAbstractFunctionAsCFunction` to `getCDeclKind()`, emitting `SWIFT_EXTERN` declarations with Objective-C types including bridged types (`NSString *`, `NSArray<T> *`, `NSDictionary<K, V> *`).
4. **[SILGen] Use @c model for C-compatible signatures** -- add `signatureRequiresObjCBridging()` and update `hasOnlyCEntryPoint()` so that `@objc` global functions with C-compatible signatures use the `@c` single-symbol model. Functions with bridged types continue to use the `@_cdecl` thunk model. Includes ABI equivalence tests showing `@c` and `@objc` produce identical symbols for the same C-compatible signature, including C function pointer and block parameter types.
5. **[Sema] Suggest @objc when @c rejects types valid in ObjC** -- when a top-level `@c` function is rejected because a parameter type is not C-representable but would be valid under `@objc` (e.g. `String`), emit a note with a fix-it: `@c(name)` -> `@objc(name)`.

### Test coverage

- `attr/objc_global_func.swift` -- acceptance, simple-name requirement, ObjC-vs-C type rules, bridged types (String, Array, Dictionary), `@objc`/`@c` conflict, member-context rejection, Swift-side name visibility, `@c` -> `@objc` fix-it for bridged types, no fix-it for pure Swift structs
- `SILGen/objc_global_func.swift` -- C-compatible functions emit single symbol with `[asmname]`, bridged functions emit `[thunk]` + native body, call-site lowering
- `IRGen/objc_global_func.swift` -- C-compatible single symbol, bridged two-symbol IR, ABI equivalence between `@c` and `@objc` with same signature, C function pointer / block / Swift closure parameter type coverage
- `IRGen/objc_global_func_cross_module.swift` -- cross-module calls: C-compatible functions call C symbol directly, bridged functions call native Swift symbol
- `PrintAsObjC/objc_global_func.swift` -- header emission with ObjC class types, bridged String/NSString, Array/NSArray, Dictionary/NSDictionary
- `Interpreter/objc_global_func_run.swift` -- end-to-end call of Swift `@objc` global functions from Objective-C, including bridged String and bridged Array
- `decl/ext/objc_global_func_implementation.swift` -- `@objc @implementation` on a global function
- updates `attr/attr_objc.swift` for the two cases that are now valid

Resolves #88343.