### PR TITLE
[Frontend] Convert `NLOptions` to an `OptionSet`

### DIFF
--- a/docs/Generics/chapters/compilation-model.tex
+++ b/docs/Generics/chapters/compilation-model.tex
@@ -673,11 +673,11 @@ Declaration contexts will be \IndexSource{declaration context}introduced in \Cha
 \end{itemize}
 
 \apiref{NLOptions}{enum}
-Similar to \texttt{UnqualifiedLookupFlags}, but for \texttt{DeclContext::lookupQualified()} and consisting of \texttt{NLFlag}s.
+Similar to \texttt{UnqualifiedLookupFlags}, but for \texttt{DeclContext::lookupQualified()} and consisting of \texttt{NLFlags}s.
 \begin{itemize}
-\item \verb|NLFlag::OnlyTypes|: if set, lookup ignores declarations other than type declarations. This is used in type resolution.
-\item \verb|NLFlag::ProtocolMembers|: if set, lookup finds members of protocols and protocol extensions. Generally should always be set, except to avoid request cycles in cases where it is known the result of the lookup cannot appear in a protocol or protocol extension.
-\item \verb|NLFlag::IgnoreAccessControl|: if set, lookup ignores access control. Generally should never be set, except when recovering from errors in diagnostics.
+\item \verb|NLFlags::OnlyTypes|: if set, lookup ignores declarations other than type declarations. This is used in type resolution.
+\item \verb|NLFlags::ProtocolMembers|: if set, lookup finds members of protocols and protocol extensions. Generally should always be set, except to avoid request cycles in cases where it is known the result of the lookup cannot appear in a protocol or protocol extension.
+\item \verb|NLFlags::IgnoreAccessControl|: if set, lookup ignores access control. Generally should never be set, except when recovering from errors in diagnostics.
 \end{itemize}
 
 \IndexSource{direct lookup}

--- a/docs/Generics/chapters/compilation-model.tex
+++ b/docs/Generics/chapters/compilation-model.tex
@@ -673,7 +673,7 @@ Declaration contexts will be \IndexSource{declaration context}introduced in \Cha
 \end{itemize}
 
 \apiref{NLOptions}{enum}
-Similar to \texttt{UnqualifiedLookupFlags}, but for \texttt{DeclContext::lookupQualified()} and consisting of \texttt{NLFlags}s.
+Similar to \texttt{UnqualifiedLookupFlags}, but for \texttt{DeclContext::lookupQualified()} and consisting of \texttt{NLFlags}.
 \begin{itemize}
 \item \verb|NLFlags::OnlyTypes|: if set, lookup ignores declarations other than type declarations. This is used in type resolution.
 \item \verb|NLFlags::ProtocolMembers|: if set, lookup finds members of protocols and protocol extensions. Generally should always be set, except to avoid request cycles in cases where it is known the result of the lookup cannot appear in a protocol or protocol extension.

--- a/docs/Generics/chapters/compilation-model.tex
+++ b/docs/Generics/chapters/compilation-model.tex
@@ -673,11 +673,11 @@ Declaration contexts will be \IndexSource{declaration context}introduced in \Cha
 \end{itemize}
 
 \apiref{NLOptions}{enum}
-Similar to \texttt{UnqualifiedLookupFlags}, but for \texttt{DeclContext::lookupQualified()}.
+Similar to \texttt{UnqualifiedLookupFlags}, but for \texttt{DeclContext::lookupQualified()} and consisting of \texttt{NLFlag}s.
 \begin{itemize}
-\item \verb|NL_OnlyTypes|: if set, lookup ignores declarations other than type declarations. This is used in type resolution.
-\item \verb|NL_ProtocolMembers|: if set, lookup finds members of protocols and protocol extensions. Generally should always be set, except to avoid request cycles in cases where it is known the result of the lookup cannot appear in a protocol or protocol extension.
-\item \verb|NL_IgnoreAccessControl|: if set, lookup ignores access control. Generally should never be set, except when recovering from errors in diagnostics.
+\item \verb|NLFlag::OnlyTypes|: if set, lookup ignores declarations other than type declarations. This is used in type resolution.
+\item \verb|NLFlag::ProtocolMembers|: if set, lookup finds members of protocols and protocol extensions. Generally should always be set, except to avoid request cycles in cases where it is known the result of the lookup cannot appear in a protocol or protocol extension.
+\item \verb|NLFlag::IgnoreAccessControl|: if set, lookup ignores access control. Generally should never be set, except when recovering from errors in diagnostics.
 \end{itemize}
 
 \IndexSource{direct lookup}

--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -25,6 +25,7 @@
 #include "swift/AST/GenericTypeParamKind.h"
 #include "swift/AST/Identifier.h"
 #include "swift/AST/LayoutConstraintKind.h"
+#include "swift/AST/LookupKinds.h"
 #include "swift/AST/PlatformKind.h"
 #include "swift/Basic/BasicBridging.h"
 #include "swift/Basic/WarningGroupBehavior.h"

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -34,6 +34,7 @@
 #include "swift/AST/Import.h"
 #include "swift/AST/Initializer.h"
 #include "swift/AST/LayoutConstraint.h"
+#include "swift/AST/LookupKinds.h"
 #include "swift/AST/LifetimeAnnotation.h"
 #include "swift/AST/ProtocolConformanceOptions.h"
 #include "swift/AST/ReferenceCounting.h"
@@ -100,7 +101,7 @@ namespace swift {
   class MacroDefinition;
   class ModuleDecl;
   class NamedPattern;
-  enum NLOptions : unsigned;
+  // enum NLOptions : unsigned;
   class EnumCaseDecl;
   class EnumElementDecl;
   class ParameterList;

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -101,7 +101,6 @@ namespace swift {
   class MacroDefinition;
   class ModuleDecl;
   class NamedPattern;
-  // enum NLOptions : unsigned;
   class EnumCaseDecl;
   class EnumElementDecl;
   class ParameterList;

--- a/include/swift/AST/DeclContext.h
+++ b/include/swift/AST/DeclContext.h
@@ -642,7 +642,7 @@ public:
   /// \param member The member to search for.
   ///
   /// \param options Options that control name lookup, based on the
-  /// \c NL_* constants in \c NameLookupOptions.
+  /// \c NameLookupFlags* constants in \c NameLookupOptions.
   ///
   /// \param[out] decls Will be populated with the declarations found by name
   /// lookup.
@@ -660,7 +660,7 @@ public:
   /// \param member The member to search for.
   ///
   /// \param options Options that control name lookup, based on the
-  /// \c NL_* constants in \c NameLookupOptions.
+  /// \c NameLookupFlags* constants in \c NameLookupOptions.
   ///
   /// \param[out] decls Will be populated with the declarations found by name
   /// lookup.

--- a/include/swift/AST/LookupKinds.h
+++ b/include/swift/AST/LookupKinds.h
@@ -17,6 +17,14 @@
 #ifndef SWIFT_LOOKUPKINDS_H
 #define SWIFT_LOOKUPKINDS_H
 
+/// `LookupKinds.h` is imported into Swift. Be *very* careful with what you
+/// include here and keep these includes minimal!
+/// If you don't need to import a header into Swift, include it in a
+/// `#ifdef NOT_COMPILED_WITH_SWIFT_PURE_BRIDGING_MODE`
+/// block below instead.
+///
+/// See include guidelines and caveats in `BasicBridging.h`.
+
 #include "swift/Basic/OptionSet.h"
 
 namespace swift {
@@ -91,28 +99,15 @@ inline bool operator==(NLOptions lhs, NLOptions rhs) {
   return lhs.containsOnly(rhs);
 }
 
+#ifdef NOT_COMPILED_WITH_SWIFT_PURE_BRIDGING_MODE
+
 inline llvm::hash_code hash_value(NLOptions options) {
   return llvm::hash_value(options.toRaw());
 }
 
-// static inline NLOptions operator|(NLOptions lhs, NLOptions rhs) {
-//   return NLOptions(unsigned(lhs) | unsigned(rhs));
-// }
-// static inline NLOptions &operator|=(NLOptions &lhs, NLOptions rhs) {
-//   return (lhs = lhs | rhs);
-// }
-// static inline NLOptions operator&(NLOptions lhs, NLOptions rhs) {
-//   return NLOptions(unsigned(lhs) & unsigned(rhs));
-// }
-// static inline NLOptions &operator&=(NLOptions &lhs, NLOptions rhs) {
-//   return (lhs = lhs & rhs);
-// }
-// static inline NLOptions operator~(NLOptions value) {
-//   return NLOptions(~(unsigned)value);
-// }
-
 void simple_display(llvm::raw_ostream &out, NLOptions options);
 
+#endif // #ifdef NOT_COMPILED_WITH_SWIFT_PURE_BRIDGING_MODE
 
 /// Flags affecting module-level lookup.
 enum class ModuleLookupFlags : unsigned {

--- a/include/swift/AST/LookupKinds.h
+++ b/include/swift/AST/LookupKinds.h
@@ -17,6 +17,8 @@
 #ifndef SWIFT_LOOKUPKINDS_H
 #define SWIFT_LOOKUPKINDS_H
 
+#include "swift/Basic/OptionSet.h"
+
 namespace swift {
 
 /// NLKind - This is a specifier for the kind of name lookup being performed
@@ -29,74 +31,85 @@ enum class NLKind {
 void simple_display(llvm::raw_ostream &out, NLKind kind);
 
 /// Constants used to customize name lookup.
-enum NLOptions : unsigned {
+enum class NLFlag : unsigned {
   /// Consider declarations within protocols to which the context type conforms.
-  NL_ProtocolMembers = 1 << 0,
+  ProtocolMembers = 1 << 0,
 
   /// Remove non-visible declarations from the set of results.
-  NL_RemoveNonVisible = 1 << 1,
+  RemoveNonVisible = 1 << 1,
 
   /// Remove overridden declarations from the set of results.
-  NL_RemoveOverridden = 1 << 2,
+  RemoveOverridden = 1 << 2,
 
   /// Remove associated type declarations from the set of results. This is used
   /// by conformance checking for resolving type witnesses.
-  NL_RemoveAssociatedTypes = 1 << 3,
+  RemoveAssociatedTypes = 1 << 3,
 
   /// Don't check access when doing lookup into a type.
   ///
   /// When performing lookup into a module, this option only applies to
   /// declarations in the same module the lookup is coming from.
-  NL_IgnoreAccessControl = 1 << 4,
+  IgnoreAccessControl = 1 << 4,
 
   /// This lookup should only return type declarations.
-  NL_OnlyTypes = 1 << 5,
+  OnlyTypes = 1 << 5,
 
   /// Include synonyms declared with @_implements()
-  NL_IncludeAttributeImplements = 1 << 6,
+  IncludeAttributeImplements = 1 << 6,
 
   // Include @usableFromInline and @inlinable
-  NL_IncludeUsableFromInline = 1 << 7,
+  IncludeUsableFromInline = 1 << 7,
 
   /// Exclude names introduced by macro expansions in the top-level module.
-  NL_ExcludeMacroExpansions = 1 << 8,
+  ExcludeMacroExpansions = 1 << 8,
 
   /// This lookup should only return macro declarations.
-  NL_OnlyMacros = 1 << 9,
+  OnlyMacros = 1 << 9,
 
   /// Include members that would otherwise be filtered out because they come
   /// from a module that has not been imported.
-  NL_IgnoreMissingImports = 1 << 10,
+  IgnoreMissingImports = 1 << 10,
 
   /// If @abi attributes are present, return the decls representing the ABI,
   /// not the API.
-  NL_ABIProviding = 1 << 11,
+  ABIProviding = 1 << 11,
 
   /// The default set of options used for qualified name lookup.
   ///
-  /// FIXME: Eventually, add NL_ProtocolMembers to this, once all of the
+  /// FIXME: Eventually, add ProtocolMembers to this, once all of the
   /// callers can handle it.
-  NL_QualifiedDefault = NL_RemoveNonVisible | NL_RemoveOverridden,
+  QualifiedDefault = RemoveNonVisible | RemoveOverridden,
 
   /// The default set of options used for unqualified name lookup.
-  NL_UnqualifiedDefault = NL_RemoveNonVisible | NL_RemoveOverridden
+  UnqualifiedDefault = RemoveNonVisible | RemoveOverridden
 };
 
-static inline NLOptions operator|(NLOptions lhs, NLOptions rhs) {
-  return NLOptions(unsigned(lhs) | unsigned(rhs));
+/// A set of `NLFlag` options for name lookup.
+using NLOptions = OptionSet<NLFlag>;
+
+inline bool operator==(NLOptions lhs, NLOptions rhs) {
+  return lhs.containsOnly(rhs);
 }
-static inline NLOptions &operator|=(NLOptions &lhs, NLOptions rhs) {
-  return (lhs = lhs | rhs);
+
+inline llvm::hash_code hash_value(NLOptions options) {
+  return llvm::hash_value(options.toRaw());
 }
-static inline NLOptions operator&(NLOptions lhs, NLOptions rhs) {
-  return NLOptions(unsigned(lhs) & unsigned(rhs));
-}
-static inline NLOptions &operator&=(NLOptions &lhs, NLOptions rhs) {
-  return (lhs = lhs & rhs);
-}
-static inline NLOptions operator~(NLOptions value) {
-  return NLOptions(~(unsigned)value);
-}
+
+// static inline NLOptions operator|(NLOptions lhs, NLOptions rhs) {
+//   return NLOptions(unsigned(lhs) | unsigned(rhs));
+// }
+// static inline NLOptions &operator|=(NLOptions &lhs, NLOptions rhs) {
+//   return (lhs = lhs | rhs);
+// }
+// static inline NLOptions operator&(NLOptions lhs, NLOptions rhs) {
+//   return NLOptions(unsigned(lhs) & unsigned(rhs));
+// }
+// static inline NLOptions &operator&=(NLOptions &lhs, NLOptions rhs) {
+//   return (lhs = lhs & rhs);
+// }
+// static inline NLOptions operator~(NLOptions value) {
+//   return NLOptions(~(unsigned)value);
+// }
 
 void simple_display(llvm::raw_ostream &out, NLOptions options);
 

--- a/include/swift/AST/LookupKinds.h
+++ b/include/swift/AST/LookupKinds.h
@@ -39,7 +39,7 @@ enum class NLKind {
 void simple_display(llvm::raw_ostream &out, NLKind kind);
 
 /// Constants used to customize name lookup.
-enum class NLFlag : unsigned {
+enum class NLFlags : unsigned {
   /// Consider declarations within protocols to which the context type conforms.
   ProtocolMembers = 1 << 0,
 
@@ -92,8 +92,8 @@ enum class NLFlag : unsigned {
   UnqualifiedDefault = RemoveNonVisible | RemoveOverridden
 };
 
-/// A set of `NLFlag` options for name lookup.
-using NLOptions = OptionSet<NLFlag>;
+/// A set of `NLFlags` options for name lookup.
+using NLOptions = OptionSet<NLFlags>;
 
 inline bool operator==(NLOptions lhs, NLOptions rhs) {
   return lhs.containsOnly(rhs);

--- a/include/swift/AST/ModuleNameLookup.h
+++ b/include/swift/AST/ModuleNameLookup.h
@@ -66,7 +66,7 @@ void simple_display(llvm::raw_ostream &out, ResolutionKind kind);
 /// \param loc Source location of the lookup. Used to add contextual options,
 ///        such as disabling macro expansions inside macro arguments.
 /// \param options name lookup options. Currently only used to communicate the
-///        NLFlag::IncludeUsableFromInline option.
+///        NLFlags::IncludeUsableFromInline option.
 void lookupInModule(const DeclContext *moduleOrFile,
                     DeclName name,
                     bool hasModuleSelector,

--- a/include/swift/AST/ModuleNameLookup.h
+++ b/include/swift/AST/ModuleNameLookup.h
@@ -66,7 +66,7 @@ void simple_display(llvm::raw_ostream &out, ResolutionKind kind);
 /// \param loc Source location of the lookup. Used to add contextual options,
 ///        such as disabling macro expansions inside macro arguments.
 /// \param options name lookup options. Currently only used to communicate the
-///        NL_IncludeUsableFromInline option.
+///        NLFlag::IncludeUsableFromInline option.
 void lookupInModule(const DeclContext *moduleOrFile,
                     DeclName name,
                     bool hasModuleSelector,

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -1424,7 +1424,7 @@ DECLTYPE *ASTContext::get##NAME##Decl() const { \
        * and the Clang module it imports. */ \
       SmallVector<ValueDecl *, 1> decls; \
       M->lookupQualified(M, DeclNameRef(getIdentifier(#NAME)), SourceLoc(), \
-                         (NLFlag::OnlyTypes), decls); \
+                         (NLFlags::OnlyTypes), decls); \
       if (decls.size() == 1 && isa<DECLTYPE>(decls[0])) { \
         auto decl = cast<DECLTYPE>(decls[0]); \
         if (isa<ProtocolDecl>(decl) \
@@ -1766,7 +1766,7 @@ ConcreteDeclRef ASTContext::getRegexInitDecl(Type regexType) const {
                 {Id_regexString, Id_version});
   SmallVector<ValueDecl *, 1> results;
   spModule->lookupQualified(getRegexType(), DeclNameRef(name),
-                            SourceLoc(), NLFlag::IncludeUsableFromInline,
+                            SourceLoc(), NLFlags::IncludeUsableFromInline,
                             results);
   assert(results.size() == 1);
   auto *foundDecl = cast<ConstructorDecl>(results[0]);
@@ -1791,7 +1791,7 @@ static ConcreteDeclRef getCGFloatOrDoubleInitDecl(
   // control. But there is only going to be one overload that exactly
   // with no label and the right argument type.
   toDecl->lookupQualified(toDecl, initRef, SourceLoc(),
-                          NLFlag::QualifiedDefault, candidates);
+                          NLFlags::QualifiedDefault, candidates);
 
   for (auto *candidate : candidates) {
     auto *ctor = cast<ConstructorDecl>(candidate);

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -1424,7 +1424,7 @@ DECLTYPE *ASTContext::get##NAME##Decl() const { \
        * and the Clang module it imports. */ \
       SmallVector<ValueDecl *, 1> decls; \
       M->lookupQualified(M, DeclNameRef(getIdentifier(#NAME)), SourceLoc(), \
-                         {NLFlag::OnlyTypes}, decls); \
+                         (NLFlag::OnlyTypes), decls); \
       if (decls.size() == 1 && isa<DECLTYPE>(decls[0])) { \
         auto decl = cast<DECLTYPE>(decls[0]); \
         if (isa<ProtocolDecl>(decl) \
@@ -1766,7 +1766,7 @@ ConcreteDeclRef ASTContext::getRegexInitDecl(Type regexType) const {
                 {Id_regexString, Id_version});
   SmallVector<ValueDecl *, 1> results;
   spModule->lookupQualified(getRegexType(), DeclNameRef(name),
-                            SourceLoc(), {NLFlag::IncludeUsableFromInline},
+                            SourceLoc(), NLFlag::IncludeUsableFromInline,
                             results);
   assert(results.size() == 1);
   auto *foundDecl = cast<ConstructorDecl>(results[0]);
@@ -1791,7 +1791,7 @@ static ConcreteDeclRef getCGFloatOrDoubleInitDecl(
   // control. But there is only going to be one overload that exactly
   // with no label and the right argument type.
   toDecl->lookupQualified(toDecl, initRef, SourceLoc(),
-                          {NLFlag::QualifiedDefault}, candidates);
+                          NLFlag::QualifiedDefault, candidates);
 
   for (auto *candidate : candidates) {
     auto *ctor = cast<ConstructorDecl>(candidate);

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -1424,7 +1424,7 @@ DECLTYPE *ASTContext::get##NAME##Decl() const { \
        * and the Clang module it imports. */ \
       SmallVector<ValueDecl *, 1> decls; \
       M->lookupQualified(M, DeclNameRef(getIdentifier(#NAME)), SourceLoc(), \
-                         NL_OnlyTypes, decls); \
+                         {NLFlag::OnlyTypes}, decls); \
       if (decls.size() == 1 && isa<DECLTYPE>(decls[0])) { \
         auto decl = cast<DECLTYPE>(decls[0]); \
         if (isa<ProtocolDecl>(decl) \
@@ -1766,7 +1766,7 @@ ConcreteDeclRef ASTContext::getRegexInitDecl(Type regexType) const {
                 {Id_regexString, Id_version});
   SmallVector<ValueDecl *, 1> results;
   spModule->lookupQualified(getRegexType(), DeclNameRef(name),
-                            SourceLoc(), NL_IncludeUsableFromInline,
+                            SourceLoc(), {NLFlag::IncludeUsableFromInline},
                             results);
   assert(results.size() == 1);
   auto *foundDecl = cast<ConstructorDecl>(results[0]);
@@ -1791,7 +1791,7 @@ static ConcreteDeclRef getCGFloatOrDoubleInitDecl(
   // control. But there is only going to be one overload that exactly
   // with no label and the right argument type.
   toDecl->lookupQualified(toDecl, initRef, SourceLoc(),
-                          NL_QualifiedDefault, candidates);
+                          {NLFlag::QualifiedDefault}, candidates);
 
   for (auto *candidate : candidates) {
     auto *ctor = cast<ConstructorDecl>(candidate);

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -6847,7 +6847,7 @@ NominalTypeDecl::getExecutorOwnedEnqueueFunction() const {
   llvm::SmallVector<ValueDecl *, 2> results;
   lookupQualified(getSelfNominalTypeDecl(),
                   DeclNameRef(C.Id_enqueue),
-                  getLoc(), {NLFlag::ProtocolMembers},
+                  getLoc(), NLFlag::ProtocolMembers,
                   results);
 
   for (auto candidate: results) {
@@ -6886,7 +6886,7 @@ NominalTypeDecl::getExecutorLegacyOwnedEnqueueFunction() const {
   llvm::SmallVector<ValueDecl *, 2> results;
   lookupQualified(getSelfNominalTypeDecl(),
                   DeclNameRef(C.Id_enqueue),
-                  getLoc(), {NLFlag::ProtocolMembers},
+                  getLoc(), NLFlag::ProtocolMembers,
                   results);
 
   for (auto candidate: results) {
@@ -6925,7 +6925,7 @@ NominalTypeDecl::getExecutorLegacyUnownedEnqueueFunction() const {
   llvm::SmallVector<ValueDecl *, 2> results;
   lookupQualified(getSelfNominalTypeDecl(),
                   DeclNameRef(C.Id_enqueue),
-                  getLoc(), {NLFlag::ProtocolMembers},
+                  getLoc(), NLFlag::ProtocolMembers,
                   results);
 
   for (auto candidate: results) {
@@ -12470,7 +12470,7 @@ const VarDecl *ClassDecl::getUnownedExecutorProperty() const {
   llvm::SmallVector<ValueDecl *, 2> results;
   this->lookupQualified(getSelfNominalTypeDecl(),
                         DeclNameRef(C.Id_unownedExecutor),
-                        getLoc(), {NLFlag::ProtocolMembers},
+                        getLoc(), NLFlag::ProtocolMembers,
                         results);
 
   for (auto candidate: results) {

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -5075,7 +5075,7 @@ abi_role_detail::Storage abi_role_detail::computeStorage(Decl *decl) {
 }
 
 ABIRole::ABIRole(NLOptions opts)
-  : value(opts.contains(NLFlag::ABIProviding) ? ProvidesABI : ProvidesAPI)
+  : value(opts.contains(NLFlags::ABIProviding) ? ProvidesABI : ProvidesAPI)
 { }
 
 VarDecl *PatternBindingDecl::
@@ -6847,7 +6847,7 @@ NominalTypeDecl::getExecutorOwnedEnqueueFunction() const {
   llvm::SmallVector<ValueDecl *, 2> results;
   lookupQualified(getSelfNominalTypeDecl(),
                   DeclNameRef(C.Id_enqueue),
-                  getLoc(), NLFlag::ProtocolMembers,
+                  getLoc(), NLFlags::ProtocolMembers,
                   results);
 
   for (auto candidate: results) {
@@ -6886,7 +6886,7 @@ NominalTypeDecl::getExecutorLegacyOwnedEnqueueFunction() const {
   llvm::SmallVector<ValueDecl *, 2> results;
   lookupQualified(getSelfNominalTypeDecl(),
                   DeclNameRef(C.Id_enqueue),
-                  getLoc(), NLFlag::ProtocolMembers,
+                  getLoc(), NLFlags::ProtocolMembers,
                   results);
 
   for (auto candidate: results) {
@@ -6925,7 +6925,7 @@ NominalTypeDecl::getExecutorLegacyUnownedEnqueueFunction() const {
   llvm::SmallVector<ValueDecl *, 2> results;
   lookupQualified(getSelfNominalTypeDecl(),
                   DeclNameRef(C.Id_enqueue),
-                  getLoc(), NLFlag::ProtocolMembers,
+                  getLoc(), NLFlags::ProtocolMembers,
                   results);
 
   for (auto candidate: results) {
@@ -12470,7 +12470,7 @@ const VarDecl *ClassDecl::getUnownedExecutorProperty() const {
   llvm::SmallVector<ValueDecl *, 2> results;
   this->lookupQualified(getSelfNominalTypeDecl(),
                         DeclNameRef(C.Id_unownedExecutor),
-                        getLoc(), NLFlag::ProtocolMembers,
+                        getLoc(), NLFlags::ProtocolMembers,
                         results);
 
   for (auto candidate: results) {

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -5075,7 +5075,7 @@ abi_role_detail::Storage abi_role_detail::computeStorage(Decl *decl) {
 }
 
 ABIRole::ABIRole(NLOptions opts)
-  : value(opts & NL_ABIProviding ? ProvidesABI : ProvidesAPI)
+  : value(opts.contains(NLFlag::ABIProviding) ? ProvidesABI : ProvidesAPI)
 { }
 
 VarDecl *PatternBindingDecl::
@@ -6847,7 +6847,7 @@ NominalTypeDecl::getExecutorOwnedEnqueueFunction() const {
   llvm::SmallVector<ValueDecl *, 2> results;
   lookupQualified(getSelfNominalTypeDecl(),
                   DeclNameRef(C.Id_enqueue),
-                  getLoc(), NL_ProtocolMembers,
+                  getLoc(), {NLFlag::ProtocolMembers},
                   results);
 
   for (auto candidate: results) {
@@ -6886,7 +6886,7 @@ NominalTypeDecl::getExecutorLegacyOwnedEnqueueFunction() const {
   llvm::SmallVector<ValueDecl *, 2> results;
   lookupQualified(getSelfNominalTypeDecl(),
                   DeclNameRef(C.Id_enqueue),
-                  getLoc(), NL_ProtocolMembers,
+                  getLoc(), {NLFlag::ProtocolMembers},
                   results);
 
   for (auto candidate: results) {
@@ -6925,7 +6925,7 @@ NominalTypeDecl::getExecutorLegacyUnownedEnqueueFunction() const {
   llvm::SmallVector<ValueDecl *, 2> results;
   lookupQualified(getSelfNominalTypeDecl(),
                   DeclNameRef(C.Id_enqueue),
-                  getLoc(), NL_ProtocolMembers,
+                  getLoc(), {NLFlag::ProtocolMembers},
                   results);
 
   for (auto candidate: results) {
@@ -12470,7 +12470,7 @@ const VarDecl *ClassDecl::getUnownedExecutorProperty() const {
   llvm::SmallVector<ValueDecl *, 2> results;
   this->lookupQualified(getSelfNominalTypeDecl(),
                         DeclNameRef(C.Id_unownedExecutor),
-                        getLoc(), NL_ProtocolMembers,
+                        getLoc(), {NLFlag::ProtocolMembers},
                         results);
 
   for (auto candidate: results) {

--- a/lib/AST/DistributedDecl.cpp
+++ b/lib/AST/DistributedDecl.cpp
@@ -1605,7 +1605,7 @@ FuncDecl *swift::getDoneRecordingOnDistributedInvocationEncoder(
 
   llvm::SmallVector<ValueDecl *, 2> results;
   nominal->lookupQualified(nominal, DeclNameRef(ctx.Id_doneRecording),
-                           SourceLoc(), NL_QualifiedDefault, results);
+                           SourceLoc(), {NLFlag::QualifiedDefault}, results);
   for (auto result : results) {
     auto *fd = dyn_cast<FuncDecl>(result);
     if (!fd)

--- a/lib/AST/DistributedDecl.cpp
+++ b/lib/AST/DistributedDecl.cpp
@@ -1605,7 +1605,7 @@ FuncDecl *swift::getDoneRecordingOnDistributedInvocationEncoder(
 
   llvm::SmallVector<ValueDecl *, 2> results;
   nominal->lookupQualified(nominal, DeclNameRef(ctx.Id_doneRecording),
-                           SourceLoc(), {NLFlag::QualifiedDefault}, results);
+                           SourceLoc(), NLFlag::QualifiedDefault, results);
   for (auto result : results) {
     auto *fd = dyn_cast<FuncDecl>(result);
     if (!fd)

--- a/lib/AST/DistributedDecl.cpp
+++ b/lib/AST/DistributedDecl.cpp
@@ -1605,7 +1605,7 @@ FuncDecl *swift::getDoneRecordingOnDistributedInvocationEncoder(
 
   llvm::SmallVector<ValueDecl *, 2> results;
   nominal->lookupQualified(nominal, DeclNameRef(ctx.Id_doneRecording),
-                           SourceLoc(), NLFlag::QualifiedDefault, results);
+                           SourceLoc(), NLFlags::QualifiedDefault, results);
   for (auto result : results) {
     auto *fd = dyn_cast<FuncDecl>(result);
     if (!fd)

--- a/lib/AST/ModuleNameLookup.cpp
+++ b/lib/AST/ModuleNameLookup.cpp
@@ -422,7 +422,7 @@ void namelookup::lookupVisibleDeclsInModule(
   LookupVisibleDecls lookup(ctx, resolutionKind, lookupKind);
   lookup.lookupInModule(decls, moduleOrFile, accessPath, moduleScopeContext,
                         /*hasModuleSelector=*/false,
-                        {NLFlag::QualifiedDefault});
+                        NLFlag::QualifiedDefault);
 }
 
 void namelookup::simple_display(llvm::raw_ostream &out, ResolutionKind kind) {

--- a/lib/AST/ModuleNameLookup.cpp
+++ b/lib/AST/ModuleNameLookup.cpp
@@ -159,15 +159,15 @@ private:
 bool swift::declIsVisibleToNameLookup(
     const ValueDecl *decl, const DeclContext *moduleScopeContext,
     NLOptions options) {
-  // NLFlag::IgnoreAccessControl only applies to the current module. If
+  // NLFlags::IgnoreAccessControl only applies to the current module. If
   // it applies here, the declaration is visible.
-  if (options.contains(NLFlag::IgnoreAccessControl) &&
+  if (options.contains(NLFlags::IgnoreAccessControl) &&
       moduleScopeContext &&
       moduleScopeContext->getParentModule() ==
           decl->getDeclContext()->getParentModule())
     return true;
 
-  bool includeUsableFromInline = options.contains(NLFlag::IncludeUsableFromInline);
+  bool includeUsableFromInline = options.contains(NLFlags::IncludeUsableFromInline);
   return decl->isAccessibleFrom(moduleScopeContext, false,
                                 includeUsableFromInline);
 }
@@ -234,9 +234,9 @@ void ModuleNameLookup<LookupStrategy>::lookupInModule(
   };
 
   OptionSet<ModuleLookupFlags> currentModuleLookupFlags = {};
-  if (options.contains(NLFlag::ExcludeMacroExpansions))
+  if (options.contains(NLFlags::ExcludeMacroExpansions))
     currentModuleLookupFlags |= ModuleLookupFlags::ExcludeMacroExpansions;
-  if (options.contains(NLFlag::ABIProviding))
+  if (options.contains(NLFlags::ABIProviding))
     currentModuleLookupFlags |= ModuleLookupFlags::ABIProviding;
   if (hasModuleSelector)
     currentModuleLookupFlags |= ModuleLookupFlags::HasModuleSelector;
@@ -277,7 +277,7 @@ void ModuleNameLookup<LookupStrategy>::lookupInModule(
     auto &imports = ctx.getImportCache().getImportSet(moduleOrFile);
 
     OptionSet<ModuleLookupFlags> importedModuleLookupFlags = {};
-    if (options.contains(NLFlag::ABIProviding))
+    if (options.contains(NLFlags::ABIProviding))
       currentModuleLookupFlags |= ModuleLookupFlags::ABIProviding;
     // Do not propagate HasModuleSelector here; the selector wasn't specific.
 
@@ -422,7 +422,7 @@ void namelookup::lookupVisibleDeclsInModule(
   LookupVisibleDecls lookup(ctx, resolutionKind, lookupKind);
   lookup.lookupInModule(decls, moduleOrFile, accessPath, moduleScopeContext,
                         /*hasModuleSelector=*/false,
-                        NLFlag::QualifiedDefault);
+                        NLFlags::QualifiedDefault);
 }
 
 void namelookup::simple_display(llvm::raw_ostream &out, ResolutionKind kind) {

--- a/lib/AST/ModuleNameLookup.cpp
+++ b/lib/AST/ModuleNameLookup.cpp
@@ -159,15 +159,15 @@ private:
 bool swift::declIsVisibleToNameLookup(
     const ValueDecl *decl, const DeclContext *moduleScopeContext,
     NLOptions options) {
-  // NL_IgnoreAccessControl only applies to the current module. If
+  // NLFlag::IgnoreAccessControl only applies to the current module. If
   // it applies here, the declaration is visible.
-  if ((options & NL_IgnoreAccessControl) &&
+  if (options.contains(NLFlag::IgnoreAccessControl) &&
       moduleScopeContext &&
       moduleScopeContext->getParentModule() ==
           decl->getDeclContext()->getParentModule())
     return true;
 
-  bool includeUsableFromInline = options & NL_IncludeUsableFromInline;
+  bool includeUsableFromInline = options.contains(NLFlag::IncludeUsableFromInline);
   return decl->isAccessibleFrom(moduleScopeContext, false,
                                 includeUsableFromInline);
 }
@@ -234,9 +234,9 @@ void ModuleNameLookup<LookupStrategy>::lookupInModule(
   };
 
   OptionSet<ModuleLookupFlags> currentModuleLookupFlags = {};
-  if (options & NL_ExcludeMacroExpansions)
+  if (options.contains(NLFlag::ExcludeMacroExpansions))
     currentModuleLookupFlags |= ModuleLookupFlags::ExcludeMacroExpansions;
-  if (options & NL_ABIProviding)
+  if (options.contains(NLFlag::ABIProviding))
     currentModuleLookupFlags |= ModuleLookupFlags::ABIProviding;
   if (hasModuleSelector)
     currentModuleLookupFlags |= ModuleLookupFlags::HasModuleSelector;
@@ -277,7 +277,7 @@ void ModuleNameLookup<LookupStrategy>::lookupInModule(
     auto &imports = ctx.getImportCache().getImportSet(moduleOrFile);
 
     OptionSet<ModuleLookupFlags> importedModuleLookupFlags = {};
-    if (options & NL_ABIProviding)
+    if (options.contains(NLFlag::ABIProviding))
       currentModuleLookupFlags |= ModuleLookupFlags::ABIProviding;
     // Do not propagate HasModuleSelector here; the selector wasn't specific.
 
@@ -422,7 +422,7 @@ void namelookup::lookupVisibleDeclsInModule(
   LookupVisibleDecls lookup(ctx, resolutionKind, lookupKind);
   lookup.lookupInModule(decls, moduleOrFile, accessPath, moduleScopeContext,
                         /*hasModuleSelector=*/false,
-                        NL_QualifiedDefault);
+                        {NLFlag::QualifiedDefault});
 }
 
 void namelookup::simple_display(llvm::raw_ostream &out, ResolutionKind kind) {

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -3226,15 +3226,15 @@ static llvm::TinyPtrVector<TypeDecl *> directReferencesForQualifiedTypeLookup(
 
     if (typeLookupOptions.contains(
             DirectlyReferencedTypeLookupFlags::AllowUsableFromInline))
-      options |= NLFlag::IncludeUsableFromInline;
+      options |= NLOptions(NLFlag::IncludeUsableFromInline);
 
     if (typeLookupOptions.contains(
             DirectlyReferencedTypeLookupFlags::IgnoreMissingImports))
-      options |= NLFlag::IgnoreMissingImports;
+      options |= NLOptions(NLFlag::IgnoreMissingImports);
 
     if (typeLookupOptions.contains(
             DirectlyReferencedTypeLookupFlags::ExcludeMacroExpansions))
-      options |= NLFlag::ExcludeMacroExpansions;
+      options |= NLOptions(NLFlag::ExcludeMacroExpansions);
 
     // Look through the type declarations we were given, resolving them down
     // to nominal type declarations, module declarations, and

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -1846,7 +1846,7 @@ SmallVector<MacroDecl *, 1> namelookup::lookupMacros(DeclContext *dc,
 
     ModuleQualifiedLookupRequest req{moduleScopeDC, moduleDecl, macroName,
                                      SourceLoc(),
-                                     NL_ExcludeMacroExpansions | NL_OnlyMacros};
+                                     {NLFlag::ExcludeMacroExpansions, NLFlag::OnlyMacros}};
     auto lookup = evaluateOrDefault(ctx.evaluator, req, {});
     for (auto *found : lookup)
       addChoiceIfApplicable(found);
@@ -2490,8 +2490,8 @@ static bool isAcceptableLookupResult(const DeclContext *dc, NLOptions options,
   }
 
   // Check access.
-  if (!(options & NL_IgnoreAccessControl) && !ctx.isAccessControlDisabled()) {
-    bool allowUsableFromInline = options & NL_IncludeUsableFromInline;
+  if (!options.contains(NLFlag::IgnoreAccessControl) && !ctx.isAccessControlDisabled()) {
+    bool allowUsableFromInline = options.contains(NLFlag::IncludeUsableFromInline);
     if (!decl->isAccessibleFrom(dc, /*forConformance*/ false,
                                 allowUsableFromInline))
       return false;
@@ -2501,7 +2501,7 @@ static bool isAcceptableLookupResult(const DeclContext *dc, NLOptions options,
   if (requireImport) {
     // If the options indicate that visibility should be enforced in this
     // lookup, check if the decl is imported.
-    bool checkDeclImport = !(options & NL_IgnoreMissingImports);
+    bool checkDeclImport = !options.contains(NLFlag::IgnoreMissingImports);
 
     // Even when missing imports are being ignored, we still need to filter out
     // overrides that haven't been imported. Otherwise, removeOverriddenDecls()
@@ -2537,7 +2537,7 @@ void namelookup::pruneLookupResultSet(const DeclContext *dc, NLOptions options,
                                       Identifier moduleSelector,
                                       SmallVectorImpl<ValueDecl *> &decls) {
   // If we're supposed to remove associated type declarations, do so now.
-  if (options & NL_RemoveAssociatedTypes) {
+  if (options.contains(NLFlag::RemoveAssociatedTypes)) {
     decls.erase(
       std::remove_if(decls.begin(), decls.end(),
                      [&](ValueDecl *decl) {
@@ -2547,11 +2547,11 @@ void namelookup::pruneLookupResultSet(const DeclContext *dc, NLOptions options,
   }
 
   // If we're supposed to remove overridden declarations, do so now.
-  if (options & NL_RemoveOverridden)
+  if (options.contains(NLFlag::RemoveOverridden))
     removeOverriddenDecls(decls);
 
   // If we're supposed to remove shadowed/hidden declarations, do so now.
-  if (options & NL_RemoveNonVisible) {
+  if (options.contains(NLFlag::RemoveNonVisible)) {
     removeOutOfModuleDecls(decls, moduleSelector, dc);
     removeShadowedDecls(decls, dc);
   }
@@ -2763,7 +2763,7 @@ QualifiedLookupRequest::evaluate(Evaluator &eval, const DeclContext *DC,
 
   // Visit all of the nominal types we know about, discovering any others
   // we need along the way.
-  bool wantProtocolMembers = (options & NL_ProtocolMembers);
+  bool wantProtocolMembers = options.contains(NLFlag::ProtocolMembers);
   while (!stack.empty()) {
     auto current = stack.back();
     stack.pop_back();
@@ -2774,11 +2774,11 @@ QualifiedLookupRequest::evaluate(Evaluator &eval, const DeclContext *DC,
     // Look for results within the current nominal type and its extensions.
     bool currentIsProtocol = isa<ProtocolDecl>(current);
     auto flags = OptionSet<NominalTypeDecl::LookupDirectFlags>();
-    if (options & NL_IncludeAttributeImplements)
+    if (options.contains(NLFlag::IncludeAttributeImplements))
       flags |= NominalTypeDecl::LookupDirectFlags::IncludeAttrImplements;
-    if (options & NL_ExcludeMacroExpansions)
+    if (options.contains(NLFlag::ExcludeMacroExpansions))
       flags |= NominalTypeDecl::LookupDirectFlags::ExcludeMacroExpansions;
-    if (options & NL_ABIProviding)
+    if (options.contains(NLFlag::ABIProviding))
       flags |= NominalTypeDecl::LookupDirectFlags::ABIProviding;
 
     // Note that the source loc argument doesn't matter, because excluding
@@ -2787,12 +2787,12 @@ QualifiedLookupRequest::evaluate(Evaluator &eval, const DeclContext *DC,
                                            SourceLoc(), flags)) {
       // If we're performing a type lookup, don't even attempt to validate
       // the decl if its not a type.
-      if ((options & NL_OnlyTypes) && !isa<TypeDecl>(decl))
+      if (options.contains(NLFlag::OnlyTypes) && !isa<TypeDecl>(decl))
         continue;
 
       // If we're performing a macro lookup, don't even attempt to validate
       // the decl if its not a macro.
-      if ((options & NL_OnlyMacros) && !isa<MacroDecl>(decl))
+      if (options.contains(NLFlag::OnlyMacros) && !isa<MacroDecl>(decl))
         continue;
 
       if (isAcceptableLookupResult(DC, options, decl, onlyCompleteObjectInits,
@@ -2824,7 +2824,7 @@ QualifiedLookupRequest::evaluate(Evaluator &eval, const DeclContext *DC,
     auto gpList = current->getGenericParams();
 
     // .. But not in type contexts (yet)
-    if (!(options & NL_OnlyTypes) && gpList && !member.isSpecial()) {
+    if (!options.contains(NLFlag::OnlyTypes) && gpList && !member.isSpecial()) {
       auto gp = gpList->lookUpGenericParam(member.getBaseIdentifier());
 
       if (gp && gp->isValue()) {
@@ -2891,8 +2891,8 @@ ModuleQualifiedLookupRequest::evaluate(Evaluator &eval, const DeclContext *DC,
   using namespace namelookup;
   QualifiedLookupResult decls;
 
-  auto kind = (options & NL_OnlyTypes ? ResolutionKind::TypesOnly
-               : options & NL_OnlyMacros ? ResolutionKind::MacrosOnly
+  auto kind = (options.contains(NLFlag::OnlyTypes)    ? ResolutionKind::TypesOnly
+               : options.contains(NLFlag::OnlyMacros) ? ResolutionKind::MacrosOnly
                : ResolutionKind::Overloadable);
   auto topLevelScope = DC->getModuleScopeContext();
   if (module == topLevelScope->getParentModule()) {
@@ -2937,7 +2937,8 @@ AnyObjectLookupRequest::evaluate(Evaluator &evaluator, const DeclContext *dc,
 
   // Type-only and macro lookup won't find anything on AnyObject.
   // AnyObject doesn't provide ABI.
-  if (options & (NL_OnlyTypes | NL_OnlyMacros | NL_ABIProviding))
+  if (options.contains(NLFlag::OnlyTypes) || options.contains(NLFlag::OnlyMacros)
+      || options.contains(NLFlag::ABIProviding))
     return decls;
 
   // Collect all of the visible declarations.
@@ -3221,19 +3222,19 @@ static llvm::TinyPtrVector<TypeDecl *> directReferencesForQualifiedTypeLookup(
   {
     // Look into the base types.
     SmallVector<ValueDecl *, 4> members;
-    auto options = NL_RemoveNonVisible | NL_OnlyTypes;
+    NLOptions options = {NLFlag::RemoveNonVisible, NLFlag::OnlyTypes};
 
     if (typeLookupOptions.contains(
             DirectlyReferencedTypeLookupFlags::AllowUsableFromInline))
-      options |= NL_IncludeUsableFromInline;
+      options |= NLFlag::IncludeUsableFromInline;
 
     if (typeLookupOptions.contains(
             DirectlyReferencedTypeLookupFlags::IgnoreMissingImports))
-      options |= NL_IgnoreMissingImports;
+      options |= NLFlag::IgnoreMissingImports;
 
     if (typeLookupOptions.contains(
             DirectlyReferencedTypeLookupFlags::ExcludeMacroExpansions))
-      options |= NL_ExcludeMacroExpansions;
+      options |= NLFlag::ExcludeMacroExpansions;
 
     // Look through the type declarations we were given, resolving them down
     // to nominal type declarations, module declarations, and
@@ -3249,8 +3250,8 @@ static llvm::TinyPtrVector<TypeDecl *> directReferencesForQualifiedTypeLookup(
     // Search all of the modules.
     for (auto module : moduleDecls) {
       auto innerOptions = options;
-      innerOptions &= ~NL_RemoveOverridden;
-      innerOptions &= ~NL_RemoveNonVisible;
+      innerOptions -= NLOptions(NLFlag::RemoveOverridden);
+      innerOptions -= NLOptions(NLFlag::RemoveNonVisible);
       SmallVector<ValueDecl *, 4> moduleMembers;
       dc->lookupQualified(module, name, loc, innerOptions, moduleMembers);
       members.append(moduleMembers.begin(), moduleMembers.end());
@@ -4358,8 +4359,8 @@ bool IsCallAsFunctionNominalRequest::evaluate(Evaluator &evaluator,
   // that will be checked when we actually try to solve with a `callAsFunction`
   // member access.
   SmallVector<ValueDecl *, 4> results;
-  auto opts = NL_QualifiedDefault | NL_ProtocolMembers |
-              NL_IgnoreAccessControl | NL_IgnoreMissingImports;
+  NLOptions opts = {NLFlag::QualifiedDefault, NLFlag::ProtocolMembers,
+              NLFlag::IgnoreAccessControl, NLFlag::IgnoreMissingImports};
   dc->lookupQualified(decl, DeclNameRef(ctx.Id_callAsFunction),
                       decl->getLoc(), opts, results);
 
@@ -4482,7 +4483,7 @@ FuncDecl *LookupIntrinsicRequest::evaluate(Evaluator &evaluator,
                                            Identifier funcName) const {
   llvm::SmallVector<ValueDecl *, 1> decls;
   module->lookupQualified(module, DeclNameRef(funcName), SourceLoc(),
-                          NL_QualifiedDefault | NL_IncludeUsableFromInline,
+                          {NLFlag::QualifiedDefault, NLFlag::IncludeUsableFromInline},
                           decls);
   if (decls.size() != 1)
     return nullptr;
@@ -4506,22 +4507,22 @@ void swift::simple_display(llvm::raw_ostream &out, NLOptions options) {
   using Flag = std::pair<NLOptions, StringRef>;
   Flag possibleFlags[] = {
 #define FLAG(Name) {Name, #Name},
-    FLAG(NL_ProtocolMembers)
-    FLAG(NL_RemoveNonVisible)
-    FLAG(NL_RemoveOverridden)
-    FLAG(NL_IgnoreAccessControl)
-    FLAG(NL_OnlyTypes)
-    FLAG(NL_IncludeAttributeImplements)
-    FLAG(NL_IncludeUsableFromInline)
-    FLAG(NL_ExcludeMacroExpansions)
-    FLAG(NL_OnlyMacros)
-    FLAG(NL_IgnoreMissingImports)
-    FLAG(NL_ABIProviding)
+    FLAG(NLFlag::ProtocolMembers)
+    FLAG(NLFlag::RemoveNonVisible)
+    FLAG(NLFlag::RemoveOverridden)
+    FLAG(NLFlag::IgnoreAccessControl)
+    FLAG(NLFlag::OnlyTypes)
+    FLAG(NLFlag::IncludeAttributeImplements)
+    FLAG(NLFlag::IncludeUsableFromInline)
+    FLAG(NLFlag::ExcludeMacroExpansions)
+    FLAG(NLFlag::OnlyMacros)
+    FLAG(NLFlag::IgnoreMissingImports)
+    FLAG(NLFlag::ABIProviding)
 #undef FLAG
   };
 
   auto flagsToPrint = llvm::make_filter_range(
-      possibleFlags, [&](Flag flag) { return options & flag.first; });
+      possibleFlags, [&](Flag flag) { return options.contains(flag.first); });
 
   out << "{ ";
   interleave(

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -1846,7 +1846,7 @@ SmallVector<MacroDecl *, 1> namelookup::lookupMacros(DeclContext *dc,
 
     ModuleQualifiedLookupRequest req{moduleScopeDC, moduleDecl, macroName,
                                      SourceLoc(),
-                                     {NLFlag::ExcludeMacroExpansions, NLFlag::OnlyMacros}};
+                                     {NLFlags::ExcludeMacroExpansions, NLFlags::OnlyMacros}};
     auto lookup = evaluateOrDefault(ctx.evaluator, req, {});
     for (auto *found : lookup)
       addChoiceIfApplicable(found);
@@ -2490,8 +2490,8 @@ static bool isAcceptableLookupResult(const DeclContext *dc, NLOptions options,
   }
 
   // Check access.
-  if (!options.contains(NLFlag::IgnoreAccessControl) && !ctx.isAccessControlDisabled()) {
-    bool allowUsableFromInline = options.contains(NLFlag::IncludeUsableFromInline);
+  if (!options.contains(NLFlags::IgnoreAccessControl) && !ctx.isAccessControlDisabled()) {
+    bool allowUsableFromInline = options.contains(NLFlags::IncludeUsableFromInline);
     if (!decl->isAccessibleFrom(dc, /*forConformance*/ false,
                                 allowUsableFromInline))
       return false;
@@ -2501,7 +2501,7 @@ static bool isAcceptableLookupResult(const DeclContext *dc, NLOptions options,
   if (requireImport) {
     // If the options indicate that visibility should be enforced in this
     // lookup, check if the decl is imported.
-    bool checkDeclImport = !options.contains(NLFlag::IgnoreMissingImports);
+    bool checkDeclImport = !options.contains(NLFlags::IgnoreMissingImports);
 
     // Even when missing imports are being ignored, we still need to filter out
     // overrides that haven't been imported. Otherwise, removeOverriddenDecls()
@@ -2537,7 +2537,7 @@ void namelookup::pruneLookupResultSet(const DeclContext *dc, NLOptions options,
                                       Identifier moduleSelector,
                                       SmallVectorImpl<ValueDecl *> &decls) {
   // If we're supposed to remove associated type declarations, do so now.
-  if (options.contains(NLFlag::RemoveAssociatedTypes)) {
+  if (options.contains(NLFlags::RemoveAssociatedTypes)) {
     decls.erase(
       std::remove_if(decls.begin(), decls.end(),
                      [&](ValueDecl *decl) {
@@ -2547,11 +2547,11 @@ void namelookup::pruneLookupResultSet(const DeclContext *dc, NLOptions options,
   }
 
   // If we're supposed to remove overridden declarations, do so now.
-  if (options.contains(NLFlag::RemoveOverridden))
+  if (options.contains(NLFlags::RemoveOverridden))
     removeOverriddenDecls(decls);
 
   // If we're supposed to remove shadowed/hidden declarations, do so now.
-  if (options.contains(NLFlag::RemoveNonVisible)) {
+  if (options.contains(NLFlags::RemoveNonVisible)) {
     removeOutOfModuleDecls(decls, moduleSelector, dc);
     removeShadowedDecls(decls, dc);
   }
@@ -2763,7 +2763,7 @@ QualifiedLookupRequest::evaluate(Evaluator &eval, const DeclContext *DC,
 
   // Visit all of the nominal types we know about, discovering any others
   // we need along the way.
-  bool wantProtocolMembers = options.contains(NLFlag::ProtocolMembers);
+  bool wantProtocolMembers = options.contains(NLFlags::ProtocolMembers);
   while (!stack.empty()) {
     auto current = stack.back();
     stack.pop_back();
@@ -2774,11 +2774,11 @@ QualifiedLookupRequest::evaluate(Evaluator &eval, const DeclContext *DC,
     // Look for results within the current nominal type and its extensions.
     bool currentIsProtocol = isa<ProtocolDecl>(current);
     auto flags = OptionSet<NominalTypeDecl::LookupDirectFlags>();
-    if (options.contains(NLFlag::IncludeAttributeImplements))
+    if (options.contains(NLFlags::IncludeAttributeImplements))
       flags |= NominalTypeDecl::LookupDirectFlags::IncludeAttrImplements;
-    if (options.contains(NLFlag::ExcludeMacroExpansions))
+    if (options.contains(NLFlags::ExcludeMacroExpansions))
       flags |= NominalTypeDecl::LookupDirectFlags::ExcludeMacroExpansions;
-    if (options.contains(NLFlag::ABIProviding))
+    if (options.contains(NLFlags::ABIProviding))
       flags |= NominalTypeDecl::LookupDirectFlags::ABIProviding;
 
     // Note that the source loc argument doesn't matter, because excluding
@@ -2787,12 +2787,12 @@ QualifiedLookupRequest::evaluate(Evaluator &eval, const DeclContext *DC,
                                            SourceLoc(), flags)) {
       // If we're performing a type lookup, don't even attempt to validate
       // the decl if its not a type.
-      if (options.contains(NLFlag::OnlyTypes) && !isa<TypeDecl>(decl))
+      if (options.contains(NLFlags::OnlyTypes) && !isa<TypeDecl>(decl))
         continue;
 
       // If we're performing a macro lookup, don't even attempt to validate
       // the decl if its not a macro.
-      if (options.contains(NLFlag::OnlyMacros) && !isa<MacroDecl>(decl))
+      if (options.contains(NLFlags::OnlyMacros) && !isa<MacroDecl>(decl))
         continue;
 
       if (isAcceptableLookupResult(DC, options, decl, onlyCompleteObjectInits,
@@ -2824,7 +2824,7 @@ QualifiedLookupRequest::evaluate(Evaluator &eval, const DeclContext *DC,
     auto gpList = current->getGenericParams();
 
     // .. But not in type contexts (yet)
-    if (!options.contains(NLFlag::OnlyTypes) && gpList && !member.isSpecial()) {
+    if (!options.contains(NLFlags::OnlyTypes) && gpList && !member.isSpecial()) {
       auto gp = gpList->lookUpGenericParam(member.getBaseIdentifier());
 
       if (gp && gp->isValue()) {
@@ -2891,8 +2891,8 @@ ModuleQualifiedLookupRequest::evaluate(Evaluator &eval, const DeclContext *DC,
   using namespace namelookup;
   QualifiedLookupResult decls;
 
-  auto kind = (options.contains(NLFlag::OnlyTypes)    ? ResolutionKind::TypesOnly
-               : options.contains(NLFlag::OnlyMacros) ? ResolutionKind::MacrosOnly
+  auto kind = (options.contains(NLFlags::OnlyTypes)    ? ResolutionKind::TypesOnly
+               : options.contains(NLFlags::OnlyMacros) ? ResolutionKind::MacrosOnly
                : ResolutionKind::Overloadable);
   auto topLevelScope = DC->getModuleScopeContext();
   if (module == topLevelScope->getParentModule()) {
@@ -2937,8 +2937,8 @@ AnyObjectLookupRequest::evaluate(Evaluator &evaluator, const DeclContext *dc,
 
   // Type-only and macro lookup won't find anything on AnyObject.
   // AnyObject doesn't provide ABI.
-  if (options.contains(NLFlag::OnlyTypes) || options.contains(NLFlag::OnlyMacros)
-      || options.contains(NLFlag::ABIProviding))
+  if (options.contains(NLFlags::OnlyTypes) || options.contains(NLFlags::OnlyMacros)
+      || options.contains(NLFlags::ABIProviding))
     return decls;
 
   // Collect all of the visible declarations.
@@ -3222,19 +3222,19 @@ static llvm::TinyPtrVector<TypeDecl *> directReferencesForQualifiedTypeLookup(
   {
     // Look into the base types.
     SmallVector<ValueDecl *, 4> members;
-    NLOptions options = {NLFlag::RemoveNonVisible, NLFlag::OnlyTypes};
+    NLOptions options = {NLFlags::RemoveNonVisible, NLFlags::OnlyTypes};
 
     if (typeLookupOptions.contains(
             DirectlyReferencedTypeLookupFlags::AllowUsableFromInline))
-      options |= NLFlag::IncludeUsableFromInline;
+      options |= NLFlags::IncludeUsableFromInline;
 
     if (typeLookupOptions.contains(
             DirectlyReferencedTypeLookupFlags::IgnoreMissingImports))
-      options |= NLFlag::IgnoreMissingImports;
+      options |= NLFlags::IgnoreMissingImports;
 
     if (typeLookupOptions.contains(
             DirectlyReferencedTypeLookupFlags::ExcludeMacroExpansions))
-      options |= NLFlag::ExcludeMacroExpansions;
+      options |= NLFlags::ExcludeMacroExpansions;
 
     // Look through the type declarations we were given, resolving them down
     // to nominal type declarations, module declarations, and
@@ -3250,8 +3250,8 @@ static llvm::TinyPtrVector<TypeDecl *> directReferencesForQualifiedTypeLookup(
     // Search all of the modules.
     for (auto module : moduleDecls) {
       auto innerOptions = options;
-      innerOptions -= NLFlag::RemoveOverridden;
-      innerOptions -= NLFlag::RemoveNonVisible;
+      innerOptions -= NLFlags::RemoveOverridden;
+      innerOptions -= NLFlags::RemoveNonVisible;
       SmallVector<ValueDecl *, 4> moduleMembers;
       dc->lookupQualified(module, name, loc, innerOptions, moduleMembers);
       members.append(moduleMembers.begin(), moduleMembers.end());
@@ -4359,8 +4359,8 @@ bool IsCallAsFunctionNominalRequest::evaluate(Evaluator &evaluator,
   // that will be checked when we actually try to solve with a `callAsFunction`
   // member access.
   SmallVector<ValueDecl *, 4> results;
-  NLOptions opts = {NLFlag::QualifiedDefault, NLFlag::ProtocolMembers,
-              NLFlag::IgnoreAccessControl, NLFlag::IgnoreMissingImports};
+  NLOptions opts = {NLFlags::QualifiedDefault, NLFlags::ProtocolMembers,
+              NLFlags::IgnoreAccessControl, NLFlags::IgnoreMissingImports};
   dc->lookupQualified(decl, DeclNameRef(ctx.Id_callAsFunction),
                       decl->getLoc(), opts, results);
 
@@ -4483,7 +4483,7 @@ FuncDecl *LookupIntrinsicRequest::evaluate(Evaluator &evaluator,
                                            Identifier funcName) const {
   llvm::SmallVector<ValueDecl *, 1> decls;
   module->lookupQualified(module, DeclNameRef(funcName), SourceLoc(),
-                          {NLFlag::QualifiedDefault, NLFlag::IncludeUsableFromInline},
+                          {NLFlags::QualifiedDefault, NLFlags::IncludeUsableFromInline},
                           decls);
   if (decls.size() != 1)
     return nullptr;
@@ -4507,17 +4507,17 @@ void swift::simple_display(llvm::raw_ostream &out, NLOptions options) {
   using Flag = std::pair<NLOptions, StringRef>;
   Flag possibleFlags[] = {
 #define FLAG(Name) {Name, #Name},
-    FLAG(NLFlag::ProtocolMembers)
-    FLAG(NLFlag::RemoveNonVisible)
-    FLAG(NLFlag::RemoveOverridden)
-    FLAG(NLFlag::IgnoreAccessControl)
-    FLAG(NLFlag::OnlyTypes)
-    FLAG(NLFlag::IncludeAttributeImplements)
-    FLAG(NLFlag::IncludeUsableFromInline)
-    FLAG(NLFlag::ExcludeMacroExpansions)
-    FLAG(NLFlag::OnlyMacros)
-    FLAG(NLFlag::IgnoreMissingImports)
-    FLAG(NLFlag::ABIProviding)
+    FLAG(NLFlags::ProtocolMembers)
+    FLAG(NLFlags::RemoveNonVisible)
+    FLAG(NLFlags::RemoveOverridden)
+    FLAG(NLFlags::IgnoreAccessControl)
+    FLAG(NLFlags::OnlyTypes)
+    FLAG(NLFlags::IncludeAttributeImplements)
+    FLAG(NLFlags::IncludeUsableFromInline)
+    FLAG(NLFlags::ExcludeMacroExpansions)
+    FLAG(NLFlags::OnlyMacros)
+    FLAG(NLFlags::IgnoreMissingImports)
+    FLAG(NLFlags::ABIProviding)
 #undef FLAG
   };
 

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -3226,15 +3226,15 @@ static llvm::TinyPtrVector<TypeDecl *> directReferencesForQualifiedTypeLookup(
 
     if (typeLookupOptions.contains(
             DirectlyReferencedTypeLookupFlags::AllowUsableFromInline))
-      options |= NLOptions(NLFlag::IncludeUsableFromInline);
+      options |= NLFlag::IncludeUsableFromInline;
 
     if (typeLookupOptions.contains(
             DirectlyReferencedTypeLookupFlags::IgnoreMissingImports))
-      options |= NLOptions(NLFlag::IgnoreMissingImports);
+      options |= NLFlag::IgnoreMissingImports;
 
     if (typeLookupOptions.contains(
             DirectlyReferencedTypeLookupFlags::ExcludeMacroExpansions))
-      options |= NLOptions(NLFlag::ExcludeMacroExpansions);
+      options |= NLFlag::ExcludeMacroExpansions;
 
     // Look through the type declarations we were given, resolving them down
     // to nominal type declarations, module declarations, and
@@ -3250,8 +3250,8 @@ static llvm::TinyPtrVector<TypeDecl *> directReferencesForQualifiedTypeLookup(
     // Search all of the modules.
     for (auto module : moduleDecls) {
       auto innerOptions = options;
-      innerOptions -= NLOptions(NLFlag::RemoveOverridden);
-      innerOptions -= NLOptions(NLFlag::RemoveNonVisible);
+      innerOptions -= NLFlag::RemoveOverridden;
+      innerOptions -= NLFlag::RemoveNonVisible;
       SmallVector<ValueDecl *, 4> moduleMembers;
       dc->lookupQualified(module, name, loc, innerOptions, moduleMembers);
       members.append(moduleMembers.begin(), moduleMembers.end());

--- a/lib/AST/NameLookupRequests.cpp
+++ b/lib/AST/NameLookupRequests.cpp
@@ -601,10 +601,10 @@ contextualizeOptions(const DeclContext *dc, SourceLoc loc,
                      NLOptions options) {
   if (!options.contains(NLFlag::ExcludeMacroExpansions)
       && namelookup::isInMacroArgument(dc->getParentSourceFile(), loc))
-    options |= NLOptions(NLFlag::ExcludeMacroExpansions);
+    options |= NLFlag::ExcludeMacroExpansions;
   if (!options.contains(NLFlag::ABIProviding)
       && namelookup::isInABIAttr(dc->getParentSourceFile(), loc))
-    options |= NLOptions(NLFlag::ABIProviding);
+    options |= NLFlag::ABIProviding;
 
   return options;
 }

--- a/lib/AST/NameLookupRequests.cpp
+++ b/lib/AST/NameLookupRequests.cpp
@@ -599,12 +599,12 @@ static DirectLookupDescriptor contextualizeOptions(
 static NLOptions
 contextualizeOptions(const DeclContext *dc, SourceLoc loc,
                      NLOptions options) {
-  if (!(options & NL_ExcludeMacroExpansions)
+  if (!options.contains(NLFlag::ExcludeMacroExpansions)
       && namelookup::isInMacroArgument(dc->getParentSourceFile(), loc))
-    options |= NL_ExcludeMacroExpansions;
-  if (!(options & NL_ABIProviding)
+    options |= NLFlag::ExcludeMacroExpansions;
+  if (!options.contains(NLFlag::ABIProviding)
       && namelookup::isInABIAttr(dc->getParentSourceFile(), loc))
-    options |= NL_ABIProviding;
+    options |= NLFlag::ABIProviding;
 
   return options;
 }

--- a/lib/AST/NameLookupRequests.cpp
+++ b/lib/AST/NameLookupRequests.cpp
@@ -599,12 +599,12 @@ static DirectLookupDescriptor contextualizeOptions(
 static NLOptions
 contextualizeOptions(const DeclContext *dc, SourceLoc loc,
                      NLOptions options) {
-  if (!options.contains(NLFlag::ExcludeMacroExpansions)
+  if (!options.contains(NLFlags::ExcludeMacroExpansions)
       && namelookup::isInMacroArgument(dc->getParentSourceFile(), loc))
-    options |= NLFlag::ExcludeMacroExpansions;
-  if (!options.contains(NLFlag::ABIProviding)
+    options |= NLFlags::ExcludeMacroExpansions;
+  if (!options.contains(NLFlags::ABIProviding)
       && namelookup::isInABIAttr(dc->getParentSourceFile(), loc))
-    options |= NLFlag::ABIProviding;
+    options |= NLFlags::ABIProviding;
 
   return options;
 }

--- a/lib/AST/NameLookupRequests.cpp
+++ b/lib/AST/NameLookupRequests.cpp
@@ -601,10 +601,10 @@ contextualizeOptions(const DeclContext *dc, SourceLoc loc,
                      NLOptions options) {
   if (!options.contains(NLFlag::ExcludeMacroExpansions)
       && namelookup::isInMacroArgument(dc->getParentSourceFile(), loc))
-    options |= NLFlag::ExcludeMacroExpansions;
+    options |= NLOptions(NLFlag::ExcludeMacroExpansions);
   if (!options.contains(NLFlag::ABIProviding)
       && namelookup::isInABIAttr(dc->getParentSourceFile(), loc))
-    options |= NLFlag::ABIProviding;
+    options |= NLOptions(NLFlag::ABIProviding);
 
   return options;
 }

--- a/lib/AST/RequirementMachine/NameLookup.cpp
+++ b/lib/AST/RequirementMachine/NameLookup.cpp
@@ -49,7 +49,7 @@ swift::rewriting::lookupConcreteNestedType(
   SmallVector<ValueDecl *, 2> foundMembers;
   decl->getParentModule()->lookupQualified(
       decl, DeclNameRef(name), decl->getLoc(),
-      NL_QualifiedDefault | NL_OnlyTypes | NL_ProtocolMembers,
+      {NLFlag::QualifiedDefault, NLFlag::OnlyTypes, NLFlag::ProtocolMembers},
       foundMembers);
   for (auto member : foundMembers)
     concreteDecls.push_back(cast<TypeDecl>(member));

--- a/lib/AST/RequirementMachine/NameLookup.cpp
+++ b/lib/AST/RequirementMachine/NameLookup.cpp
@@ -49,7 +49,7 @@ swift::rewriting::lookupConcreteNestedType(
   SmallVector<ValueDecl *, 2> foundMembers;
   decl->getParentModule()->lookupQualified(
       decl, DeclNameRef(name), decl->getLoc(),
-      {NLFlag::QualifiedDefault, NLFlag::OnlyTypes, NLFlag::ProtocolMembers},
+      {NLFlags::QualifiedDefault, NLFlags::OnlyTypes, NLFlags::ProtocolMembers},
       foundMembers);
   for (auto member : foundMembers)
     concreteDecls.push_back(cast<TypeDecl>(member));

--- a/lib/AST/UnqualifiedLookup.cpp
+++ b/lib/AST/UnqualifiedLookup.cpp
@@ -499,15 +499,15 @@ void UnqualifiedLookupFactory::addImportedResults(const DeclContext *const dc) {
   if (!moduleToLookIn)
     return;
 
-  NLOptions nlOptions = NLFlag::UnqualifiedDefault;
+  NLOptions nlOptions = NLFlags::UnqualifiedDefault;
   if (options.contains(Flags::IncludeUsableFromInline))
-    nlOptions |= NLFlag::IncludeUsableFromInline;
+    nlOptions |= NLFlags::IncludeUsableFromInline;
   if (options.contains(Flags::ExcludeMacroExpansions))
-    nlOptions |= NLFlag::ExcludeMacroExpansions;
+    nlOptions |= NLFlags::ExcludeMacroExpansions;
   if (options.contains(Flags::ABIProviding))
-    nlOptions |= NLFlag::ABIProviding;
+    nlOptions |= NLFlags::ABIProviding;
   if (options.contains(Flags::IgnoreAccessControl))
-    nlOptions |= NLFlag::IgnoreAccessControl;
+    nlOptions |= NLFlags::IgnoreAccessControl;
 
   lookupInModule(moduleToLookIn, Name.getFullName(), Name.hasModuleSelector(),
                  CurModuleResults, NLKind::UnqualifiedLookup, resolutionKind,
@@ -624,19 +624,19 @@ NLOptions UnqualifiedLookupFactory::computeBaseNLOptions(
     const UnqualifiedLookupOptions options,
     const bool isOriginallyTypeLookup,
     const bool isOriginallyMacroLookup) {
-  NLOptions baseNLOptions = NLFlag::UnqualifiedDefault;
+  NLOptions baseNLOptions = NLFlags::UnqualifiedDefault;
   if (options.contains(Flags::AllowProtocolMembers))
-    baseNLOptions |= NLFlag::ProtocolMembers;
+    baseNLOptions |= NLFlags::ProtocolMembers;
   if (isOriginallyTypeLookup)
-    baseNLOptions |= NLFlag::OnlyTypes;
+    baseNLOptions |= NLFlags::OnlyTypes;
   if (isOriginallyMacroLookup)
-    baseNLOptions |= NLFlag::OnlyMacros;
+    baseNLOptions |= NLFlags::OnlyMacros;
   if (options.contains(Flags::IgnoreAccessControl))
-    baseNLOptions |= NLFlag::IgnoreAccessControl;
+    baseNLOptions |= NLFlags::IgnoreAccessControl;
   if (options.contains(Flags::IgnoreMissingImports))
-    baseNLOptions |= NLFlag::IgnoreMissingImports;
+    baseNLOptions |= NLFlags::IgnoreMissingImports;
   if (options.contains(Flags::ABIProviding))
-    baseNLOptions |= NLFlag::ABIProviding;
+    baseNLOptions |= NLFlags::ABIProviding;
   return baseNLOptions;
 }
 

--- a/lib/AST/UnqualifiedLookup.cpp
+++ b/lib/AST/UnqualifiedLookup.cpp
@@ -499,15 +499,15 @@ void UnqualifiedLookupFactory::addImportedResults(const DeclContext *const dc) {
   if (!moduleToLookIn)
     return;
 
-  auto nlOptions = NL_UnqualifiedDefault;
+  NLOptions nlOptions = {NLFlag::UnqualifiedDefault};
   if (options.contains(Flags::IncludeUsableFromInline))
-    nlOptions |= NL_IncludeUsableFromInline;
+    nlOptions |= NLFlag::IncludeUsableFromInline;
   if (options.contains(Flags::ExcludeMacroExpansions))
-    nlOptions |= NL_ExcludeMacroExpansions;
+    nlOptions |= NLFlag::ExcludeMacroExpansions;
   if (options.contains(Flags::ABIProviding))
-    nlOptions |= NL_ABIProviding;
+    nlOptions |= NLFlag::ABIProviding;
   if (options.contains(Flags::IgnoreAccessControl))
-    nlOptions |= NL_IgnoreAccessControl;
+    nlOptions |= NLFlag::IgnoreAccessControl;
 
   lookupInModule(moduleToLookIn, Name.getFullName(), Name.hasModuleSelector(),
                  CurModuleResults, NLKind::UnqualifiedLookup, resolutionKind,
@@ -624,19 +624,19 @@ NLOptions UnqualifiedLookupFactory::computeBaseNLOptions(
     const UnqualifiedLookupOptions options,
     const bool isOriginallyTypeLookup,
     const bool isOriginallyMacroLookup) {
-  NLOptions baseNLOptions = NL_UnqualifiedDefault;
+  NLOptions baseNLOptions = {NLFlag::UnqualifiedDefault};
   if (options.contains(Flags::AllowProtocolMembers))
-    baseNLOptions |= NL_ProtocolMembers;
+    baseNLOptions |= NLFlag::ProtocolMembers;
   if (isOriginallyTypeLookup)
-    baseNLOptions |= NL_OnlyTypes;
+    baseNLOptions |= NLFlag::OnlyTypes;
   if (isOriginallyMacroLookup)
-    baseNLOptions |= NL_OnlyMacros;
+    baseNLOptions |= NLFlag::OnlyMacros;
   if (options.contains(Flags::IgnoreAccessControl))
-    baseNLOptions |= NL_IgnoreAccessControl;
+    baseNLOptions |= NLFlag::IgnoreAccessControl;
   if (options.contains(Flags::IgnoreMissingImports))
-    baseNLOptions |= NL_IgnoreMissingImports;
+    baseNLOptions |= NLFlag::IgnoreMissingImports;
   if (options.contains(Flags::ABIProviding))
-    baseNLOptions |= NL_ABIProviding;
+    baseNLOptions |= NLFlag::ABIProviding;
   return baseNLOptions;
 }
 

--- a/lib/AST/UnqualifiedLookup.cpp
+++ b/lib/AST/UnqualifiedLookup.cpp
@@ -499,15 +499,15 @@ void UnqualifiedLookupFactory::addImportedResults(const DeclContext *const dc) {
   if (!moduleToLookIn)
     return;
 
-  NLOptions nlOptions = {NLFlag::UnqualifiedDefault};
+  NLOptions nlOptions = NLFlag::UnqualifiedDefault;
   if (options.contains(Flags::IncludeUsableFromInline))
-    nlOptions |= NLOptions(NLFlag::IncludeUsableFromInline);
+    nlOptions |= NLFlag::IncludeUsableFromInline;
   if (options.contains(Flags::ExcludeMacroExpansions))
-    nlOptions |= NLOptions(NLFlag::ExcludeMacroExpansions);
+    nlOptions |= NLFlag::ExcludeMacroExpansions;
   if (options.contains(Flags::ABIProviding))
-    nlOptions |= NLOptions(NLFlag::ABIProviding);
+    nlOptions |= NLFlag::ABIProviding;
   if (options.contains(Flags::IgnoreAccessControl))
-    nlOptions |= NLOptions(NLFlag::IgnoreAccessControl);
+    nlOptions |= NLFlag::IgnoreAccessControl;
 
   lookupInModule(moduleToLookIn, Name.getFullName(), Name.hasModuleSelector(),
                  CurModuleResults, NLKind::UnqualifiedLookup, resolutionKind,
@@ -624,19 +624,19 @@ NLOptions UnqualifiedLookupFactory::computeBaseNLOptions(
     const UnqualifiedLookupOptions options,
     const bool isOriginallyTypeLookup,
     const bool isOriginallyMacroLookup) {
-  NLOptions baseNLOptions = {NLFlag::UnqualifiedDefault};
+  NLOptions baseNLOptions = NLFlag::UnqualifiedDefault;
   if (options.contains(Flags::AllowProtocolMembers))
-    baseNLOptions |= NLOptions(NLFlag::ProtocolMembers);
+    baseNLOptions |= NLFlag::ProtocolMembers;
   if (isOriginallyTypeLookup)
-    baseNLOptions |= NLOptions(NLFlag::OnlyTypes);
+    baseNLOptions |= NLFlag::OnlyTypes;
   if (isOriginallyMacroLookup)
-    baseNLOptions |= NLOptions(NLFlag::OnlyMacros);
+    baseNLOptions |= NLFlag::OnlyMacros;
   if (options.contains(Flags::IgnoreAccessControl))
-    baseNLOptions |= NLOptions(NLFlag::IgnoreAccessControl);
+    baseNLOptions |= NLFlag::IgnoreAccessControl;
   if (options.contains(Flags::IgnoreMissingImports))
-    baseNLOptions |= NLOptions(NLFlag::IgnoreMissingImports);
+    baseNLOptions |= NLFlag::IgnoreMissingImports;
   if (options.contains(Flags::ABIProviding))
-    baseNLOptions |= NLOptions(NLFlag::ABIProviding);
+    baseNLOptions |= NLFlag::ABIProviding;
   return baseNLOptions;
 }
 

--- a/lib/AST/UnqualifiedLookup.cpp
+++ b/lib/AST/UnqualifiedLookup.cpp
@@ -501,13 +501,13 @@ void UnqualifiedLookupFactory::addImportedResults(const DeclContext *const dc) {
 
   NLOptions nlOptions = {NLFlag::UnqualifiedDefault};
   if (options.contains(Flags::IncludeUsableFromInline))
-    nlOptions |= NLFlag::IncludeUsableFromInline;
+    nlOptions |= NLOptions(NLFlag::IncludeUsableFromInline);
   if (options.contains(Flags::ExcludeMacroExpansions))
-    nlOptions |= NLFlag::ExcludeMacroExpansions;
+    nlOptions |= NLOptions(NLFlag::ExcludeMacroExpansions);
   if (options.contains(Flags::ABIProviding))
-    nlOptions |= NLFlag::ABIProviding;
+    nlOptions |= NLOptions(NLFlag::ABIProviding);
   if (options.contains(Flags::IgnoreAccessControl))
-    nlOptions |= NLFlag::IgnoreAccessControl;
+    nlOptions |= NLOptions(NLFlag::IgnoreAccessControl);
 
   lookupInModule(moduleToLookIn, Name.getFullName(), Name.hasModuleSelector(),
                  CurModuleResults, NLKind::UnqualifiedLookup, resolutionKind,
@@ -626,17 +626,17 @@ NLOptions UnqualifiedLookupFactory::computeBaseNLOptions(
     const bool isOriginallyMacroLookup) {
   NLOptions baseNLOptions = {NLFlag::UnqualifiedDefault};
   if (options.contains(Flags::AllowProtocolMembers))
-    baseNLOptions |= NLFlag::ProtocolMembers;
+    baseNLOptions |= NLOptions(NLFlag::ProtocolMembers);
   if (isOriginallyTypeLookup)
-    baseNLOptions |= NLFlag::OnlyTypes;
+    baseNLOptions |= NLOptions(NLFlag::OnlyTypes);
   if (isOriginallyMacroLookup)
-    baseNLOptions |= NLFlag::OnlyMacros;
+    baseNLOptions |= NLOptions(NLFlag::OnlyMacros);
   if (options.contains(Flags::IgnoreAccessControl))
-    baseNLOptions |= NLFlag::IgnoreAccessControl;
+    baseNLOptions |= NLOptions(NLFlag::IgnoreAccessControl);
   if (options.contains(Flags::IgnoreMissingImports))
-    baseNLOptions |= NLFlag::IgnoreMissingImports;
+    baseNLOptions |= NLOptions(NLFlag::IgnoreMissingImports);
   if (options.contains(Flags::ABIProviding))
-    baseNLOptions |= NLFlag::ABIProviding;
+    baseNLOptions |= NLOptions(NLFlag::ABIProviding);
   return baseNLOptions;
 }
 

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -6728,9 +6728,9 @@ static void lookupRelatedFuncs(AbstractFunctionDecl *func,
     swiftName = func->getName();
 
   if (auto ty = func->getDeclContext()->getSelfNominalTypeDecl()) {
-    NLOptions options = NL_IgnoreAccessControl | NL_IgnoreMissingImports;
+    NLOptions options = {NLFlag::IgnoreAccessControl, NLFlag::IgnoreMissingImports};
     ty->lookupQualified({ ty }, DeclNameRef(swiftName), func->getLoc(),
-                        NL_QualifiedDefault | options, results);
+                        NLOptions(NLFlag::QualifiedDefault) | options, results);
   }
   else {
     ASTContext &ctx = func->getASTContext();
@@ -8214,7 +8214,7 @@ importer::getValueDeclsForName(NominalTypeDecl *decl, StringRef name) {
         ctx.MainModule, ctx.getIdentifier(name), /*hasModuleSelector=*/false,
         results, NLKind::UnqualifiedLookup,
         namelookup::ResolutionKind::Overloadable, ctx.MainModule, SourceLoc(),
-        NL_UnqualifiedDefault);
+        {NLFlag::UnqualifiedDefault});
 
     // Filter out any declarations that didn't come from Clang.
     auto newEnd =

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -6728,9 +6728,9 @@ static void lookupRelatedFuncs(AbstractFunctionDecl *func,
     swiftName = func->getName();
 
   if (auto ty = func->getDeclContext()->getSelfNominalTypeDecl()) {
-    NLOptions options = {NLFlag::IgnoreAccessControl, NLFlag::IgnoreMissingImports};
+    NLOptions options = {NLFlags::IgnoreAccessControl, NLFlags::IgnoreMissingImports};
     ty->lookupQualified({ ty }, DeclNameRef(swiftName), func->getLoc(),
-                        (NLFlag::QualifiedDefault) | options, results);
+                        (NLFlags::QualifiedDefault) | options, results);
   }
   else {
     ASTContext &ctx = func->getASTContext();
@@ -8214,7 +8214,7 @@ importer::getValueDeclsForName(NominalTypeDecl *decl, StringRef name) {
         ctx.MainModule, ctx.getIdentifier(name), /*hasModuleSelector=*/false,
         results, NLKind::UnqualifiedLookup,
         namelookup::ResolutionKind::Overloadable, ctx.MainModule, SourceLoc(),
-        NLFlag::UnqualifiedDefault);
+        NLFlags::UnqualifiedDefault);
 
     // Filter out any declarations that didn't come from Clang.
     auto newEnd =

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -6730,7 +6730,7 @@ static void lookupRelatedFuncs(AbstractFunctionDecl *func,
   if (auto ty = func->getDeclContext()->getSelfNominalTypeDecl()) {
     NLOptions options = {NLFlag::IgnoreAccessControl, NLFlag::IgnoreMissingImports};
     ty->lookupQualified({ ty }, DeclNameRef(swiftName), func->getLoc(),
-                        NLOptions(NLFlag::QualifiedDefault) | options, results);
+                        (NLFlag::QualifiedDefault) | options, results);
   }
   else {
     ASTContext &ctx = func->getASTContext();
@@ -8214,7 +8214,7 @@ importer::getValueDeclsForName(NominalTypeDecl *decl, StringRef name) {
         ctx.MainModule, ctx.getIdentifier(name), /*hasModuleSelector=*/false,
         results, NLKind::UnqualifiedLookup,
         namelookup::ResolutionKind::Overloadable, ctx.MainModule, SourceLoc(),
-        {NLFlag::UnqualifiedDefault});
+        NLFlag::UnqualifiedDefault);
 
     // Filter out any declarations that didn't come from Clang.
     auto newEnd =

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -8153,7 +8153,7 @@ void SwiftDeclConverter::recordObjCOverride(SubscriptDecl *subscript) {
   SmallVector<ValueDecl *, 2> lookup;
   subscript->getModuleContext()->lookupQualified(
       superDecl, DeclNameRef(subscript->getName()),
-      subscript->getLoc(), {NLFlag::QualifiedDefault}, lookup);
+      subscript->getLoc(), NLFlag::QualifiedDefault, lookup);
 
   for (auto result : lookup) {
     auto parentSub = dyn_cast<SubscriptDecl>(result);

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -8081,7 +8081,7 @@ void SwiftDeclConverter::recordObjCOverride(AbstractFunctionDecl *decl) const {
   SmallVector<ValueDecl *, 4> results;
   superDecl->lookupQualified(
       superDecl, DeclNameRef(decl->getName()), decl->getLoc(),
-      NL_QualifiedDefault | NL_IgnoreMissingImports, results);
+      {NLFlag::QualifiedDefault, NLFlag::IgnoreMissingImports}, results);
   for (auto member : results) {
     if (member->getKind() != decl->getKind() ||
         member->isInstanceMember() != decl->isInstanceMember() ||
@@ -8153,7 +8153,7 @@ void SwiftDeclConverter::recordObjCOverride(SubscriptDecl *subscript) {
   SmallVector<ValueDecl *, 2> lookup;
   subscript->getModuleContext()->lookupQualified(
       superDecl, DeclNameRef(subscript->getName()),
-      subscript->getLoc(), NL_QualifiedDefault, lookup);
+      subscript->getLoc(), {NLFlag::QualifiedDefault}, lookup);
 
   for (auto result : lookup) {
     auto parentSub = dyn_cast<SubscriptDecl>(result);
@@ -10232,10 +10232,10 @@ static void finishTypeWitnesses(NormalProtocolConformance *conformance,
     bool satisfied = false;
 
     SmallVector<ValueDecl *, 4> lookupResults;
-    NLOptions options = (NL_QualifiedDefault |
-                         NL_RemoveAssociatedTypes |
-                         NL_OnlyTypes |
-                         NL_ProtocolMembers);
+    NLOptions options = {NLFlag::QualifiedDefault,
+                         NLFlag::RemoveAssociatedTypes,
+                         NLFlag::OnlyTypes,
+                         NLFlag::ProtocolMembers};
 
     dc->lookupQualified(nominal, DeclNameRef(assocType->getName()),
                         nominal->getLoc(), options,

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -8081,7 +8081,7 @@ void SwiftDeclConverter::recordObjCOverride(AbstractFunctionDecl *decl) const {
   SmallVector<ValueDecl *, 4> results;
   superDecl->lookupQualified(
       superDecl, DeclNameRef(decl->getName()), decl->getLoc(),
-      {NLFlag::QualifiedDefault, NLFlag::IgnoreMissingImports}, results);
+      {NLFlags::QualifiedDefault, NLFlags::IgnoreMissingImports}, results);
   for (auto member : results) {
     if (member->getKind() != decl->getKind() ||
         member->isInstanceMember() != decl->isInstanceMember() ||
@@ -8153,7 +8153,7 @@ void SwiftDeclConverter::recordObjCOverride(SubscriptDecl *subscript) {
   SmallVector<ValueDecl *, 2> lookup;
   subscript->getModuleContext()->lookupQualified(
       superDecl, DeclNameRef(subscript->getName()),
-      subscript->getLoc(), NLFlag::QualifiedDefault, lookup);
+      subscript->getLoc(), NLFlags::QualifiedDefault, lookup);
 
   for (auto result : lookup) {
     auto parentSub = dyn_cast<SubscriptDecl>(result);
@@ -10232,10 +10232,10 @@ static void finishTypeWitnesses(NormalProtocolConformance *conformance,
     bool satisfied = false;
 
     SmallVector<ValueDecl *, 4> lookupResults;
-    NLOptions options = {NLFlag::QualifiedDefault,
-                         NLFlag::RemoveAssociatedTypes,
-                         NLFlag::OnlyTypes,
-                         NLFlag::ProtocolMembers};
+    NLOptions options = {NLFlags::QualifiedDefault,
+                         NLFlags::RemoveAssociatedTypes,
+                         NLFlags::OnlyTypes,
+                         NLFlags::ProtocolMembers};
 
     dc->lookupQualified(nominal, DeclNameRef(assocType->getName()),
                         nominal->getLoc(), options,

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -1310,7 +1310,7 @@ static CanType getKnownType(std::optional<CanType> &cacheSlot, ASTContext &C,
       // themselves.
       SmallVector<ValueDecl *, 2> decls;
       mod->lookupQualified(mod, DeclNameRef(C.getIdentifier(typeName)),
-                           SourceLoc(), NLFlag::QualifiedDefault, decls);
+                           SourceLoc(), NLFlags::QualifiedDefault, decls);
       if (decls.size() != 1)
         return CanType();
 

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -1310,7 +1310,7 @@ static CanType getKnownType(std::optional<CanType> &cacheSlot, ASTContext &C,
       // themselves.
       SmallVector<ValueDecl *, 2> decls;
       mod->lookupQualified(mod, DeclNameRef(C.getIdentifier(typeName)),
-                           SourceLoc(), NL_QualifiedDefault, decls);
+                           SourceLoc(), {NLFlag::QualifiedDefault}, decls);
       if (decls.size() != 1)
         return CanType();
 

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -1310,7 +1310,7 @@ static CanType getKnownType(std::optional<CanType> &cacheSlot, ASTContext &C,
       // themselves.
       SmallVector<ValueDecl *, 2> decls;
       mod->lookupQualified(mod, DeclNameRef(C.getIdentifier(typeName)),
-                           SourceLoc(), {NLFlag::QualifiedDefault}, decls);
+                           SourceLoc(), NLFlag::QualifiedDefault, decls);
       if (decls.size() != 1)
         return CanType();
 

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -529,11 +529,11 @@ Type SILGenModule::getConfiguredExecutorFactory() {
     mainType->lookupQualified(mainType,
                               DeclNameRef(identifier),
                               SourceLoc(),
-                              NL_RemoveNonVisible |
-                              NL_RemoveOverridden |
-                              NL_OnlyTypes |
-                              NL_RemoveAssociatedTypes |
-                              NL_ProtocolMembers,
+                              {NLFlag::RemoveNonVisible,
+                               NLFlag::RemoveOverridden,
+                               NLFlag::OnlyTypes,
+                               NLFlag::RemoveAssociatedTypes,
+                               NLFlag::ProtocolMembers},
                               decls);
     for (auto decl : decls) {
       auto *genericDecl = cast<GenericTypeDecl>(decl);

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -529,11 +529,11 @@ Type SILGenModule::getConfiguredExecutorFactory() {
     mainType->lookupQualified(mainType,
                               DeclNameRef(identifier),
                               SourceLoc(),
-                              {NLFlag::RemoveNonVisible,
-                               NLFlag::RemoveOverridden,
-                               NLFlag::OnlyTypes,
-                               NLFlag::RemoveAssociatedTypes,
-                               NLFlag::ProtocolMembers},
+                              {NLFlags::RemoveNonVisible,
+                               NLFlags::RemoveOverridden,
+                               NLFlags::OnlyTypes,
+                               NLFlags::RemoveAssociatedTypes,
+                               NLFlags::ProtocolMembers},
                               decls);
     for (auto decl : decls) {
       auto *genericDecl = cast<GenericTypeDecl>(decl);

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -1252,7 +1252,7 @@ void SILGenFunction::emitArtificialTopLevel(Decl *mainDecl) {
     SmallVector<ValueDecl *, 2> results;
     UIKit->lookupQualified(UIKit,
                            DeclNameRef(ctx.getIdentifier("UIApplicationMain")),
-                           SourceLoc(), NL_QualifiedDefault,
+                           SourceLoc(), {NLFlag::QualifiedDefault},
                            results);
 
     // As the comment above alludes, using a qualified lookup into UIKit is

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -1252,7 +1252,7 @@ void SILGenFunction::emitArtificialTopLevel(Decl *mainDecl) {
     SmallVector<ValueDecl *, 2> results;
     UIKit->lookupQualified(UIKit,
                            DeclNameRef(ctx.getIdentifier("UIApplicationMain")),
-                           SourceLoc(), {NLFlag::QualifiedDefault},
+                           SourceLoc(), NLFlag::QualifiedDefault,
                            results);
 
     // As the comment above alludes, using a qualified lookup into UIKit is

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -1252,7 +1252,7 @@ void SILGenFunction::emitArtificialTopLevel(Decl *mainDecl) {
     SmallVector<ValueDecl *, 2> results;
     UIKit->lookupQualified(UIKit,
                            DeclNameRef(ctx.getIdentifier("UIApplicationMain")),
-                           SourceLoc(), NLFlag::QualifiedDefault,
+                           SourceLoc(), NLFlags::QualifiedDefault,
                            results);
 
     // As the comment above alludes, using a qualified lookup into UIKit is

--- a/lib/Sema/AssociatedTypeInference.cpp
+++ b/lib/Sema/AssociatedTypeInference.cpp
@@ -558,11 +558,11 @@ static ResolveWitnessResult resolveTypeWitnessViaLookup(
   }
 
   // Next, look for a member type declaration with this name.
-  NLOptions subOptions = {NLFlag::QualifiedDefault,
-                          NLFlag::RemoveAssociatedTypes,
-                          NLFlag::OnlyTypes,
-                          NLFlag::ProtocolMembers,
-                          NLFlag::IncludeAttributeImplements};
+  NLOptions subOptions = {NLFlags::QualifiedDefault,
+                          NLFlags::RemoveAssociatedTypes,
+                          NLFlags::OnlyTypes,
+                          NLFlags::ProtocolMembers,
+                          NLFlags::IncludeAttributeImplements};
 
   // Look for a member type with the same name as the associated type.
   SmallVector<ValueDecl *, 4> candidates;
@@ -2193,10 +2193,10 @@ AssociatedTypeInference::inferTypeWitnessesViaAssociatedType(
     defaultName = DeclNameRef(getASTContext().getIdentifier(defaultNameStr));
   }
 
-  NLOptions subOptions = {NLFlag::OnlyTypes,
-                          NLFlag::RemoveAssociatedTypes,
-                          NLFlag::ProtocolMembers,
-                          NLFlag::IncludeAttributeImplements};
+  NLOptions subOptions = {NLFlags::OnlyTypes,
+                          NLFlags::RemoveAssociatedTypes,
+                          NLFlags::ProtocolMembers,
+                          NLFlags::IncludeAttributeImplements};
 
   // Look for types with the given default name that have appropriate
   // @_implements attributes.
@@ -2563,7 +2563,7 @@ AssociatedTypeDecl *swift::findDefaultedAssociatedType(
   // Otherwise, look for all associated types with the same name along all the
   // protocols that the adoptee conforms to.
   SmallVector<ValueDecl *, 4> decls;
-  NLOptions options = {NLFlag::ProtocolMembers, NLFlag::OnlyTypes};
+  NLOptions options = {NLFlags::ProtocolMembers, NLFlags::OnlyTypes};
   dc->lookupQualified(adoptee, DeclNameRef(assocType->getName()),
                       SourceLoc(), options, decls);
 

--- a/lib/Sema/AssociatedTypeInference.cpp
+++ b/lib/Sema/AssociatedTypeInference.cpp
@@ -558,11 +558,11 @@ static ResolveWitnessResult resolveTypeWitnessViaLookup(
   }
 
   // Next, look for a member type declaration with this name.
-  NLOptions subOptions = (NL_QualifiedDefault |
-                          NL_RemoveAssociatedTypes |
-                          NL_OnlyTypes |
-                          NL_ProtocolMembers |
-                          NL_IncludeAttributeImplements);
+  NLOptions subOptions = {NLFlag::QualifiedDefault,
+                          NLFlag::RemoveAssociatedTypes,
+                          NLFlag::OnlyTypes,
+                          NLFlag::ProtocolMembers,
+                          NLFlag::IncludeAttributeImplements};
 
   // Look for a member type with the same name as the associated type.
   SmallVector<ValueDecl *, 4> candidates;
@@ -2193,10 +2193,10 @@ AssociatedTypeInference::inferTypeWitnessesViaAssociatedType(
     defaultName = DeclNameRef(getASTContext().getIdentifier(defaultNameStr));
   }
 
-  NLOptions subOptions = (NL_OnlyTypes |
-                          NL_RemoveAssociatedTypes |
-                          NL_ProtocolMembers |
-                          NL_IncludeAttributeImplements);
+  NLOptions subOptions = {NLFlag::OnlyTypes,
+                          NLFlag::RemoveAssociatedTypes,
+                          NLFlag::ProtocolMembers,
+                          NLFlag::IncludeAttributeImplements};
 
   // Look for types with the given default name that have appropriate
   // @_implements attributes.
@@ -2563,7 +2563,7 @@ AssociatedTypeDecl *swift::findDefaultedAssociatedType(
   // Otherwise, look for all associated types with the same name along all the
   // protocols that the adoptee conforms to.
   SmallVector<ValueDecl *, 4> decls;
-  auto options = NL_ProtocolMembers | NL_OnlyTypes;
+  NLOptions options = {NLFlag::ProtocolMembers, NLFlag::OnlyTypes};
   dc->lookupQualified(adoptee, DeclNameRef(assocType->getName()),
                       SourceLoc(), options, decls);
 

--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -1321,7 +1321,7 @@ ResultBuilderOpSupport TypeChecker::checkBuilderOpSupport(
   dc->lookupQualified(
       builderType, DeclNameRef(fnName),
       builderType->getAnyNominal()->getLoc(),
-      {NLFlag::QualifiedDefault, NLFlag::ProtocolMembers, NLFlag::IgnoreMissingImports},
+      {NLFlags::QualifiedDefault, NLFlags::ProtocolMembers, NLFlags::IgnoreMissingImports},
       foundDecls);
   for (auto decl : foundDecls) {
     if (auto func = dyn_cast<FuncDecl>(decl)) {

--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -1321,7 +1321,7 @@ ResultBuilderOpSupport TypeChecker::checkBuilderOpSupport(
   dc->lookupQualified(
       builderType, DeclNameRef(fnName),
       builderType->getAnyNominal()->getLoc(),
-      NL_QualifiedDefault | NL_ProtocolMembers | NL_IgnoreMissingImports,
+      {NLFlag::QualifiedDefault, NLFlag::ProtocolMembers, NLFlag::IgnoreMissingImports},
       foundDecls);
   for (auto decl : foundDecls) {
     if (auto func = dyn_cast<FuncDecl>(decl)) {

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -2258,7 +2258,7 @@ bool AssignmentFailure::diagnoseAsError() {
         if (auto *nominal = typeContext->getSelfNominalTypeDecl()) {
           SmallVector<ValueDecl *, 2> results;
           DC->lookupQualified(nominal, VD->createNameRef(), Loc,
-                              {NLFlag::QualifiedDefault}, results);
+                              NLFlag::QualifiedDefault, results);
 
           auto foundProperty = llvm::find_if(results, [&](ValueDecl *decl) {
             // We're looking for a settable property that is the same type as

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -2258,7 +2258,7 @@ bool AssignmentFailure::diagnoseAsError() {
         if (auto *nominal = typeContext->getSelfNominalTypeDecl()) {
           SmallVector<ValueDecl *, 2> results;
           DC->lookupQualified(nominal, VD->createNameRef(), Loc,
-                              NLFlag::QualifiedDefault, results);
+                              NLFlags::QualifiedDefault, results);
 
           auto foundProperty = llvm::find_if(results, [&](ValueDecl *decl) {
             // We're looking for a settable property that is the same type as

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -2258,7 +2258,7 @@ bool AssignmentFailure::diagnoseAsError() {
         if (auto *nominal = typeContext->getSelfNominalTypeDecl()) {
           SmallVector<ValueDecl *, 2> results;
           DC->lookupQualified(nominal, VD->createNameRef(), Loc,
-                              {NL_QualifiedDefault}, results);
+                              {NLFlag::QualifiedDefault}, results);
 
           auto foundProperty = llvm::find_if(results, [&](ValueDecl *decl) {
             // We're looking for a settable property that is the same type as

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -2258,7 +2258,7 @@ bool AssignmentFailure::diagnoseAsError() {
         if (auto *nominal = typeContext->getSelfNominalTypeDecl()) {
           SmallVector<ValueDecl *, 2> results;
           DC->lookupQualified(nominal, VD->createNameRef(), Loc,
-                              NL_QualifiedDefault, results);
+                              {NL_QualifiedDefault}, results);
 
           auto foundProperty = llvm::find_if(results, [&](ValueDecl *decl) {
             // We're looking for a settable property that is the same type as

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -1181,8 +1181,9 @@ static void collectNonOveriddenSuperclassInits(
   superclassDecl->synthesizeSemanticMembersIfNeeded(
     DeclBaseName::createConstructor());
 
-  NLOptions subOptions =
-      (NL_QualifiedDefault | NL_IgnoreAccessControl | NL_IgnoreMissingImports);
+  NLOptions subOptions = {NLFlag::QualifiedDefault,
+                          NLFlag::IgnoreAccessControl,
+                          NLFlag::IgnoreMissingImports};
   SmallVector<ValueDecl *, 4> lookupResults;
   subclass->lookupQualified(
       superclassDecl, DeclNameRef::createConstructor(),

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -1181,9 +1181,9 @@ static void collectNonOveriddenSuperclassInits(
   superclassDecl->synthesizeSemanticMembersIfNeeded(
     DeclBaseName::createConstructor());
 
-  NLOptions subOptions = {NLFlag::QualifiedDefault,
-                          NLFlag::IgnoreAccessControl,
-                          NLFlag::IgnoreMissingImports};
+  NLOptions subOptions = {NLFlags::QualifiedDefault,
+                          NLFlags::IgnoreAccessControl,
+                          NLFlags::IgnoreMissingImports};
   SmallVector<ValueDecl *, 4> lookupResults;
   subclass->lookupQualified(
       superclassDecl, DeclNameRef::createConstructor(),

--- a/lib/Sema/Comment.cpp
+++ b/lib/Sema/Comment.cpp
@@ -67,7 +67,7 @@ private:
 
     SmallVector<ValueDecl *, 2> members;
     nominalType->lookupQualified(nominalType, DeclNameRef(VD->getName()),
-                                 VD->getLoc(), NLOptions::NL_ProtocolMembers,
+                                 VD->getLoc(), {NLFlag::ProtocolMembers},
                                  members);
 
     std::optional<ResultWithDecl> result;

--- a/lib/Sema/Comment.cpp
+++ b/lib/Sema/Comment.cpp
@@ -67,7 +67,7 @@ private:
 
     SmallVector<ValueDecl *, 2> members;
     nominalType->lookupQualified(nominalType, DeclNameRef(VD->getName()),
-                                 VD->getLoc(), NLFlag::ProtocolMembers,
+                                 VD->getLoc(), NLFlags::ProtocolMembers,
                                  members);
 
     std::optional<ResultWithDecl> result;

--- a/lib/Sema/Comment.cpp
+++ b/lib/Sema/Comment.cpp
@@ -67,7 +67,7 @@ private:
 
     SmallVector<ValueDecl *, 2> members;
     nominalType->lookupQualified(nominalType, DeclNameRef(VD->getName()),
-                                 VD->getLoc(), {NLFlag::ProtocolMembers},
+                                 VD->getLoc(), NLFlag::ProtocolMembers,
                                  members);
 
     std::optional<ResultWithDecl> result;

--- a/lib/Sema/ImportResolution.cpp
+++ b/lib/Sema/ImportResolution.cpp
@@ -1358,7 +1358,7 @@ ScopedImportLookupRequest::evaluate(Evaluator &evaluator,
                  /*hasModuleSelector=*/true, decls,
                  NLKind::QualifiedLookup, ResolutionKind::Overloadable,
                  import->getDeclContext()->getModuleScopeContext(),
-                 import->getLoc(), {NLFlag::QualifiedDefault});
+                 import->getLoc(), NLFlag::QualifiedDefault);
 
   // `import macro` has not been implementd. Filter them out for now.
   llvm::erase_if(decls, [](ValueDecl *VD) {

--- a/lib/Sema/ImportResolution.cpp
+++ b/lib/Sema/ImportResolution.cpp
@@ -1358,7 +1358,7 @@ ScopedImportLookupRequest::evaluate(Evaluator &evaluator,
                  /*hasModuleSelector=*/true, decls,
                  NLKind::QualifiedLookup, ResolutionKind::Overloadable,
                  import->getDeclContext()->getModuleScopeContext(),
-                 import->getLoc(), NL_QualifiedDefault);
+                 import->getLoc(), {NLFlag::QualifiedDefault});
 
   // `import macro` has not been implementd. Filter them out for now.
   llvm::erase_if(decls, [](ValueDecl *VD) {

--- a/lib/Sema/ImportResolution.cpp
+++ b/lib/Sema/ImportResolution.cpp
@@ -1358,7 +1358,7 @@ ScopedImportLookupRequest::evaluate(Evaluator &evaluator,
                  /*hasModuleSelector=*/true, decls,
                  NLKind::QualifiedLookup, ResolutionKind::Overloadable,
                  import->getDeclContext()->getModuleScopeContext(),
-                 import->getLoc(), NLFlag::QualifiedDefault);
+                 import->getLoc(), NLFlags::QualifiedDefault);
 
   // `import macro` has not been implementd. Filter them out for now.
   llvm::erase_if(decls, [](ValueDecl *VD) {

--- a/lib/Sema/LookupVisibleDecls.cpp
+++ b/lib/Sema/LookupVisibleDecls.cpp
@@ -1066,7 +1066,7 @@ static void lookupVisibleDynamicMemberLookupDecls(
 
   SmallVector<ValueDecl *, 4> subscripts;
   dc->lookupQualified(baseType, DeclNameRef::createSubscript(), loc,
-                      {NLFlag::QualifiedDefault, NLFlag::ProtocolMembers}, subscripts);
+                      {NLFlags::QualifiedDefault, NLFlags::ProtocolMembers}, subscripts);
 
   for (ValueDecl *VD : subscripts) {
     auto *subscript = dyn_cast<SubscriptDecl>(VD);

--- a/lib/Sema/LookupVisibleDecls.cpp
+++ b/lib/Sema/LookupVisibleDecls.cpp
@@ -1066,7 +1066,7 @@ static void lookupVisibleDynamicMemberLookupDecls(
 
   SmallVector<ValueDecl *, 4> subscripts;
   dc->lookupQualified(baseType, DeclNameRef::createSubscript(), loc,
-                      NL_QualifiedDefault | NL_ProtocolMembers, subscripts);
+                      {NLFlag::QualifiedDefault, NLFlag::ProtocolMembers}, subscripts);
 
   for (ValueDecl *VD : subscripts) {
     auto *subscript = dyn_cast<SubscriptDecl>(VD);

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2976,7 +2976,7 @@ void AttributeChecker::checkApplicationMainAttribute(DeclAttribute *attr,
                                decls, NLKind::QualifiedLookup,
                                namelookup::ResolutionKind::TypesOnly,
                                SF, attr->getLocation(),
-                               {NLFlag::QualifiedDefault});
+                               NLFlag::QualifiedDefault);
     if (decls.size() == 1)
       ApplicationDelegateProto = dyn_cast<ProtocolDecl>(decls[0]);
   }
@@ -3902,9 +3902,9 @@ static void lookupReplacedDecl(DeclNameRef replacedDeclName,
   if (!typeCtx)
     typeCtx = cast<ExtensionDecl>(declCtxt->getAsDecl())->getExtendedNominal();
 
-  NLOptions options = {NLFlag::QualifiedDefault};
+  NLOptions options = NLFlag::QualifiedDefault;
   if (declCtxt->isInSpecializeExtensionContext())
-    options |= NLOptions(NLFlag::IncludeUsableFromInline);
+    options |= NLFlag::IncludeUsableFromInline;
 
   if (typeCtx)
     moduleScopeCtxt->lookupQualified({typeCtx}, replacedDeclName,
@@ -5002,11 +5002,11 @@ void AttributeChecker::visitResultBuilderAttr(ResultBuilderAttr *attr) {
 
       auto builderType = nominal->getDeclaredType();
       nominal->lookupQualified(builderType, DeclNameRef(buildPartialBlockFirst),
-                               attr->getLocation(), {NLFlag::QualifiedDefault},
+                               attr->getLocation(), NLFlag::QualifiedDefault,
                                buildPartialBlockFirstMatches);
       nominal->lookupQualified(
           builderType, DeclNameRef(buildPartialBlockAccumulated),
-          attr->getLocation(), {NLFlag::QualifiedDefault},
+          attr->getLocation(), NLFlag::QualifiedDefault,
           buildPartialBlockAccumulatedMatches);
 
       hasAccessibleBuildPartialBlockFirst = llvm::any_of(
@@ -9139,7 +9139,7 @@ ValueDecl *RenamedDeclRequest::evaluate(Evaluator &evaluator,
     SmallVector<ValueDecl *, 1> lookupResults;
     attachedContext->lookupQualified(attachedContext->getParentModule(),
                                      nameRef.withoutArgumentLabels(ctx),
-                                     attr->getLocation(), {NLFlag::OnlyTypes},
+                                     attr->getLocation(), NLFlag::OnlyTypes,
                                      lookupResults);
     if (lookupResults.size() == 1)
       return lookupResults[0];

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -3904,7 +3904,7 @@ static void lookupReplacedDecl(DeclNameRef replacedDeclName,
 
   NLOptions options = {NLFlag::QualifiedDefault};
   if (declCtxt->isInSpecializeExtensionContext())
-    options |= NLFlag::IncludeUsableFromInline;
+    options |= NLOptions(NLFlag::IncludeUsableFromInline);
 
   if (typeCtx)
     moduleScopeCtxt->lookupQualified({typeCtx}, replacedDeclName,

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2976,7 +2976,7 @@ void AttributeChecker::checkApplicationMainAttribute(DeclAttribute *attr,
                                decls, NLKind::QualifiedLookup,
                                namelookup::ResolutionKind::TypesOnly,
                                SF, attr->getLocation(),
-                               NL_QualifiedDefault);
+                               {NLFlag::QualifiedDefault});
     if (decls.size() == 1)
       ApplicationDelegateProto = dyn_cast<ProtocolDecl>(decls[0]);
   }
@@ -3902,9 +3902,9 @@ static void lookupReplacedDecl(DeclNameRef replacedDeclName,
   if (!typeCtx)
     typeCtx = cast<ExtensionDecl>(declCtxt->getAsDecl())->getExtendedNominal();
 
-  auto options = NL_QualifiedDefault;
+  NLOptions options = {NLFlag::QualifiedDefault};
   if (declCtxt->isInSpecializeExtensionContext())
-    options |= NL_IncludeUsableFromInline;
+    options |= NLFlag::IncludeUsableFromInline;
 
   if (typeCtx)
     moduleScopeCtxt->lookupQualified({typeCtx}, replacedDeclName,
@@ -5002,11 +5002,11 @@ void AttributeChecker::visitResultBuilderAttr(ResultBuilderAttr *attr) {
 
       auto builderType = nominal->getDeclaredType();
       nominal->lookupQualified(builderType, DeclNameRef(buildPartialBlockFirst),
-                               attr->getLocation(), NL_QualifiedDefault,
+                               attr->getLocation(), {NLFlag::QualifiedDefault},
                                buildPartialBlockFirstMatches);
       nominal->lookupQualified(
           builderType, DeclNameRef(buildPartialBlockAccumulated),
-          attr->getLocation(), NL_QualifiedDefault,
+          attr->getLocation(), {NLFlag::QualifiedDefault},
           buildPartialBlockAccumulatedMatches);
 
       hasAccessibleBuildPartialBlockFirst = llvm::any_of(
@@ -9139,7 +9139,7 @@ ValueDecl *RenamedDeclRequest::evaluate(Evaluator &evaluator,
     SmallVector<ValueDecl *, 1> lookupResults;
     attachedContext->lookupQualified(attachedContext->getParentModule(),
                                      nameRef.withoutArgumentLabels(ctx),
-                                     attr->getLocation(), NL_OnlyTypes,
+                                     attr->getLocation(), {NLFlag::OnlyTypes},
                                      lookupResults);
     if (lookupResults.size() == 1)
       return lookupResults[0];

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2976,7 +2976,7 @@ void AttributeChecker::checkApplicationMainAttribute(DeclAttribute *attr,
                                decls, NLKind::QualifiedLookup,
                                namelookup::ResolutionKind::TypesOnly,
                                SF, attr->getLocation(),
-                               NLFlag::QualifiedDefault);
+                               NLFlags::QualifiedDefault);
     if (decls.size() == 1)
       ApplicationDelegateProto = dyn_cast<ProtocolDecl>(decls[0]);
   }
@@ -3902,9 +3902,9 @@ static void lookupReplacedDecl(DeclNameRef replacedDeclName,
   if (!typeCtx)
     typeCtx = cast<ExtensionDecl>(declCtxt->getAsDecl())->getExtendedNominal();
 
-  NLOptions options = NLFlag::QualifiedDefault;
+  NLOptions options = NLFlags::QualifiedDefault;
   if (declCtxt->isInSpecializeExtensionContext())
-    options |= NLFlag::IncludeUsableFromInline;
+    options |= NLFlags::IncludeUsableFromInline;
 
   if (typeCtx)
     moduleScopeCtxt->lookupQualified({typeCtx}, replacedDeclName,
@@ -5002,11 +5002,11 @@ void AttributeChecker::visitResultBuilderAttr(ResultBuilderAttr *attr) {
 
       auto builderType = nominal->getDeclaredType();
       nominal->lookupQualified(builderType, DeclNameRef(buildPartialBlockFirst),
-                               attr->getLocation(), NLFlag::QualifiedDefault,
+                               attr->getLocation(), NLFlags::QualifiedDefault,
                                buildPartialBlockFirstMatches);
       nominal->lookupQualified(
           builderType, DeclNameRef(buildPartialBlockAccumulated),
-          attr->getLocation(), NLFlag::QualifiedDefault,
+          attr->getLocation(), NLFlags::QualifiedDefault,
           buildPartialBlockAccumulatedMatches);
 
       hasAccessibleBuildPartialBlockFirst = llvm::any_of(
@@ -9139,7 +9139,7 @@ ValueDecl *RenamedDeclRequest::evaluate(Evaluator &evaluator,
     SmallVector<ValueDecl *, 1> lookupResults;
     attachedContext->lookupQualified(attachedContext->getParentModule(),
                                      nameRef.withoutArgumentLabels(ctx),
-                                     attr->getLocation(), NLFlag::OnlyTypes,
+                                     attr->getLocation(), NLFlags::OnlyTypes,
                                      lookupResults);
     if (lookupResults.size() == 1)
       return lookupResults[0];

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -317,7 +317,7 @@ VarDecl *GlobalActorInstanceRequest::evaluate(
   SmallVector<ValueDecl *, 4> decls;
   nominal->lookupQualified(
       nominal, DeclNameRef(ctx.Id_shared),
-      nominal->getLoc(), {NLFlag::QualifiedDefault}, decls);
+      nominal->getLoc(), NLFlag::QualifiedDefault, decls);
   for (auto decl : decls) {
     auto var = dyn_cast<VarDecl>(decl);
     if (!var)

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -317,7 +317,7 @@ VarDecl *GlobalActorInstanceRequest::evaluate(
   SmallVector<ValueDecl *, 4> decls;
   nominal->lookupQualified(
       nominal, DeclNameRef(ctx.Id_shared),
-      nominal->getLoc(), NLFlag::QualifiedDefault, decls);
+      nominal->getLoc(), NLFlags::QualifiedDefault, decls);
   for (auto decl : decls) {
     auto var = dyn_cast<VarDecl>(decl);
     if (!var)

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -317,7 +317,7 @@ VarDecl *GlobalActorInstanceRequest::evaluate(
   SmallVector<ValueDecl *, 4> decls;
   nominal->lookupQualified(
       nominal, DeclNameRef(ctx.Id_shared),
-      nominal->getLoc(), NL_QualifiedDefault, decls);
+      nominal->getLoc(), {NLFlag::QualifiedDefault}, decls);
   for (auto decl : decls) {
     auto var = dyn_cast<VarDecl>(decl);
     if (!var)

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -771,7 +771,7 @@ PrimaryAssociatedTypesRequest::evaluate(Evaluator &evaluator,
 
     decl->lookupQualified(ArrayRef<NominalTypeDecl *>(decl),
                           DeclNameRef(pair.first), decl->getLoc(),
-                          {NLFlag::QualifiedDefault, NLFlag::OnlyTypes},
+                          {NLFlags::QualifiedDefault, NLFlags::OnlyTypes},
                           result);
 
     AssociatedTypeDecl *bestAssocType = nullptr;

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -771,7 +771,7 @@ PrimaryAssociatedTypesRequest::evaluate(Evaluator &evaluator,
 
     decl->lookupQualified(ArrayRef<NominalTypeDecl *>(decl),
                           DeclNameRef(pair.first), decl->getLoc(),
-                          NL_QualifiedDefault | NL_OnlyTypes,
+                          {NLFlag::QualifiedDefault, NLFlag::OnlyTypes},
                           result);
 
     AssociatedTypeDecl *bestAssocType = nullptr;

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -966,9 +966,9 @@ SmallVector<OverrideMatch, 2> OverrideMatcher::match(
     for (auto *ctx : superContexts) {
       ctx->synthesizeSemanticMembersIfNeeded(membersName);
     }
-    NLOptions lookupOptions = NLFlag::QualifiedDefault;
+    NLOptions lookupOptions = NLFlags::QualifiedDefault;
     if (ignoreMissingImports)
-      lookupOptions |= NLFlag::IgnoreMissingImports;
+      lookupOptions |= NLFlags::IgnoreMissingImports;
 
     dc->lookupQualified(superContexts, DeclNameRef(membersName), decl->getLoc(),
                         lookupOptions, members);

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -966,9 +966,9 @@ SmallVector<OverrideMatch, 2> OverrideMatcher::match(
     for (auto *ctx : superContexts) {
       ctx->synthesizeSemanticMembersIfNeeded(membersName);
     }
-    NLOptions lookupOptions = {NLFlag::QualifiedDefault};
+    NLOptions lookupOptions = NLFlag::QualifiedDefault;
     if (ignoreMissingImports)
-      lookupOptions |= NLOptions(NLFlag::IgnoreMissingImports);
+      lookupOptions |= NLFlag::IgnoreMissingImports;
 
     dc->lookupQualified(superContexts, DeclNameRef(membersName), decl->getLoc(),
                         lookupOptions, members);

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -966,9 +966,9 @@ SmallVector<OverrideMatch, 2> OverrideMatcher::match(
     for (auto *ctx : superContexts) {
       ctx->synthesizeSemanticMembersIfNeeded(membersName);
     }
-    auto lookupOptions = {NLFlag::QualifiedDefault};
+    NLOptions lookupOptions = {NLFlag::QualifiedDefault};
     if (ignoreMissingImports)
-      lookupOptions |= NLFlag::IgnoreMissingImports;
+      lookupOptions |= NLOptions(NLFlag::IgnoreMissingImports);
 
     dc->lookupQualified(superContexts, DeclNameRef(membersName), decl->getLoc(),
                         lookupOptions, members);

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -966,9 +966,9 @@ SmallVector<OverrideMatch, 2> OverrideMatcher::match(
     for (auto *ctx : superContexts) {
       ctx->synthesizeSemanticMembersIfNeeded(membersName);
     }
-    auto lookupOptions = NL_QualifiedDefault;
+    auto lookupOptions = {NLFlag::QualifiedDefault};
     if (ignoreMissingImports)
-      lookupOptions |= NL_IgnoreMissingImports;
+      lookupOptions |= NLFlag::IgnoreMissingImports;
 
     dc->lookupQualified(superContexts, DeclNameRef(membersName), decl->getLoc(),
                         lookupOptions, members);

--- a/lib/Sema/TypeCheckDistributed.cpp
+++ b/lib/Sema/TypeCheckDistributed.cpp
@@ -88,7 +88,7 @@ static AbstractFunctionDecl *findDistributedAdHocRequirement(
 
   llvm::SmallVector<ValueDecl *, 2> results;
   decl->lookupQualified(decl, DeclNameRef(identifier),
-                        SourceLoc(), NL_QualifiedDefault, results);
+                        SourceLoc(), {NLFlag::QualifiedDefault}, results);
   for (auto value : results) {
     auto func = dyn_cast<AbstractFunctionDecl>(value);
     if (func && matchFn(func))

--- a/lib/Sema/TypeCheckDistributed.cpp
+++ b/lib/Sema/TypeCheckDistributed.cpp
@@ -88,7 +88,7 @@ static AbstractFunctionDecl *findDistributedAdHocRequirement(
 
   llvm::SmallVector<ValueDecl *, 2> results;
   decl->lookupQualified(decl, DeclNameRef(identifier),
-                        SourceLoc(), NLFlag::QualifiedDefault, results);
+                        SourceLoc(), NLFlags::QualifiedDefault, results);
   for (auto value : results) {
     auto func = dyn_cast<AbstractFunctionDecl>(value);
     if (func && matchFn(func))

--- a/lib/Sema/TypeCheckDistributed.cpp
+++ b/lib/Sema/TypeCheckDistributed.cpp
@@ -88,7 +88,7 @@ static AbstractFunctionDecl *findDistributedAdHocRequirement(
 
   llvm::SmallVector<ValueDecl *, 2> results;
   decl->lookupQualified(decl, DeclNameRef(identifier),
-                        SourceLoc(), {NLFlag::QualifiedDefault}, results);
+                        SourceLoc(), NLFlag::QualifiedDefault, results);
   for (auto value : results) {
     auto func = dyn_cast<AbstractFunctionDecl>(value);
     if (func && matchFn(func))

--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -377,11 +377,11 @@ LookupResult TypeChecker::lookupMember(DeclContext *dc,
   LookupResult result;
   NLOptions subOptions = {NLFlag::QualifiedDefault, NLFlag::ProtocolMembers};
   if (options.contains(NameLookupFlags::IgnoreAccessControl))
-    subOptions |= NLFlag::IgnoreAccessControl;
+    subOptions |= NLOptions(NLFlag::IgnoreAccessControl);
   if (options.contains(NameLookupFlags::IgnoreMissingImports))
-    subOptions |= NLFlag::IgnoreMissingImports;
+    subOptions |= NLOptions(NLFlag::IgnoreMissingImports);
   if (options.contains(NameLookupFlags::ABIProviding))
-    subOptions |= NLFlag::ABIProviding;
+    subOptions |= NLOptions(NLFlag::ABIProviding);
 
   // We handle our own overriding/shadowing filtering.
   subOptions -= NLOptions(NLFlag::RemoveOverridden);
@@ -479,13 +479,13 @@ LookupTypeResult TypeChecker::lookupMemberType(DeclContext *dc,
                           NLFlag::ProtocolMembers};
 
   if (options.contains(NameLookupFlags::IgnoreAccessControl))
-    subOptions |= NLFlag::IgnoreAccessControl;
+    subOptions |= NLOptions(NLFlag::IgnoreAccessControl);
   if (options.contains(NameLookupFlags::IgnoreMissingImports))
-    subOptions |= NLFlag::IgnoreMissingImports;
+    subOptions |= NLOptions(NLFlag::IgnoreMissingImports);
   if (options.contains(NameLookupFlags::IncludeUsableFromInline))
-    subOptions |= NLFlag::IncludeUsableFromInline;
+    subOptions |= NLOptions(NLFlag::IncludeUsableFromInline);
   if (options.contains(NameLookupFlags::ABIProviding))
-    subOptions |= NLFlag::ABIProviding;
+    subOptions |= NLOptions(NLFlag::ABIProviding);
 
   // Make sure we've resolved implicit members, if we need them.
   namelookup::installSemanticMembersIfNeeded(type, name);

--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -377,15 +377,15 @@ LookupResult TypeChecker::lookupMember(DeclContext *dc,
   LookupResult result;
   NLOptions subOptions = {NLFlag::QualifiedDefault, NLFlag::ProtocolMembers};
   if (options.contains(NameLookupFlags::IgnoreAccessControl))
-    subOptions |= NLOptions(NLFlag::IgnoreAccessControl);
+    subOptions |= NLFlag::IgnoreAccessControl;
   if (options.contains(NameLookupFlags::IgnoreMissingImports))
-    subOptions |= NLOptions(NLFlag::IgnoreMissingImports);
+    subOptions |= NLFlag::IgnoreMissingImports;
   if (options.contains(NameLookupFlags::ABIProviding))
-    subOptions |= NLOptions(NLFlag::ABIProviding);
+    subOptions |= NLFlag::ABIProviding;
 
   // We handle our own overriding/shadowing filtering.
-  subOptions -= NLOptions(NLFlag::RemoveOverridden);
-  subOptions -= NLOptions(NLFlag::RemoveNonVisible);
+  subOptions -= NLFlag::RemoveOverridden;
+  subOptions -= NLFlag::RemoveNonVisible;
 
   // Make sure we've resolved implicit members, if we need them.
   namelookup::installSemanticMembersIfNeeded(type, name);
@@ -479,13 +479,13 @@ LookupTypeResult TypeChecker::lookupMemberType(DeclContext *dc,
                           NLFlag::ProtocolMembers};
 
   if (options.contains(NameLookupFlags::IgnoreAccessControl))
-    subOptions |= NLOptions(NLFlag::IgnoreAccessControl);
+    subOptions |= NLFlag::IgnoreAccessControl;
   if (options.contains(NameLookupFlags::IgnoreMissingImports))
-    subOptions |= NLOptions(NLFlag::IgnoreMissingImports);
+    subOptions |= NLFlag::IgnoreMissingImports;
   if (options.contains(NameLookupFlags::IncludeUsableFromInline))
-    subOptions |= NLOptions(NLFlag::IncludeUsableFromInline);
+    subOptions |= NLFlag::IncludeUsableFromInline;
   if (options.contains(NameLookupFlags::ABIProviding))
-    subOptions |= NLOptions(NLFlag::ABIProviding);
+    subOptions |= NLFlag::ABIProviding;
 
   // Make sure we've resolved implicit members, if we need them.
   namelookup::installSemanticMembersIfNeeded(type, name);

--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -375,17 +375,17 @@ LookupResult TypeChecker::lookupMember(DeclContext *dc,
   assert(type->mayHaveMembers());
 
   LookupResult result;
-  NLOptions subOptions = {NLFlag::QualifiedDefault, NLFlag::ProtocolMembers};
+  NLOptions subOptions = {NLFlags::QualifiedDefault, NLFlags::ProtocolMembers};
   if (options.contains(NameLookupFlags::IgnoreAccessControl))
-    subOptions |= NLFlag::IgnoreAccessControl;
+    subOptions |= NLFlags::IgnoreAccessControl;
   if (options.contains(NameLookupFlags::IgnoreMissingImports))
-    subOptions |= NLFlag::IgnoreMissingImports;
+    subOptions |= NLFlags::IgnoreMissingImports;
   if (options.contains(NameLookupFlags::ABIProviding))
-    subOptions |= NLFlag::ABIProviding;
+    subOptions |= NLFlags::ABIProviding;
 
   // We handle our own overriding/shadowing filtering.
-  subOptions -= NLFlag::RemoveOverridden;
-  subOptions -= NLFlag::RemoveNonVisible;
+  subOptions -= NLFlags::RemoveOverridden;
+  subOptions -= NLFlags::RemoveNonVisible;
 
   // Make sure we've resolved implicit members, if we need them.
   namelookup::installSemanticMembersIfNeeded(type, name);
@@ -474,18 +474,18 @@ LookupTypeResult TypeChecker::lookupMemberType(DeclContext *dc,
 
   // Look for members with the given name.
   SmallVector<ValueDecl *, 4> decls;
-  NLOptions subOptions = {NLFlag::QualifiedDefault,
-                          NLFlag::OnlyTypes,
-                          NLFlag::ProtocolMembers};
+  NLOptions subOptions = {NLFlags::QualifiedDefault,
+                          NLFlags::OnlyTypes,
+                          NLFlags::ProtocolMembers};
 
   if (options.contains(NameLookupFlags::IgnoreAccessControl))
-    subOptions |= NLFlag::IgnoreAccessControl;
+    subOptions |= NLFlags::IgnoreAccessControl;
   if (options.contains(NameLookupFlags::IgnoreMissingImports))
-    subOptions |= NLFlag::IgnoreMissingImports;
+    subOptions |= NLFlags::IgnoreMissingImports;
   if (options.contains(NameLookupFlags::IncludeUsableFromInline))
-    subOptions |= NLFlag::IncludeUsableFromInline;
+    subOptions |= NLFlags::IncludeUsableFromInline;
   if (options.contains(NameLookupFlags::ABIProviding))
-    subOptions |= NLFlag::ABIProviding;
+    subOptions |= NLFlags::ABIProviding;
 
   // Make sure we've resolved implicit members, if we need them.
   namelookup::installSemanticMembersIfNeeded(type, name);

--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -375,17 +375,17 @@ LookupResult TypeChecker::lookupMember(DeclContext *dc,
   assert(type->mayHaveMembers());
 
   LookupResult result;
-  NLOptions subOptions = (NL_QualifiedDefault | NL_ProtocolMembers);
+  NLOptions subOptions = {NLFlag::QualifiedDefault, NLFlag::ProtocolMembers};
   if (options.contains(NameLookupFlags::IgnoreAccessControl))
-    subOptions |= NL_IgnoreAccessControl;
+    subOptions |= NLFlag::IgnoreAccessControl;
   if (options.contains(NameLookupFlags::IgnoreMissingImports))
-    subOptions |= NL_IgnoreMissingImports;
+    subOptions |= NLFlag::IgnoreMissingImports;
   if (options.contains(NameLookupFlags::ABIProviding))
-    subOptions |= NL_ABIProviding;
+    subOptions |= NLFlag::ABIProviding;
 
   // We handle our own overriding/shadowing filtering.
-  subOptions &= ~NL_RemoveOverridden;
-  subOptions &= ~NL_RemoveNonVisible;
+  subOptions -= NLOptions(NLFlag::RemoveOverridden);
+  subOptions -= NLOptions(NLFlag::RemoveNonVisible);
 
   // Make sure we've resolved implicit members, if we need them.
   namelookup::installSemanticMembersIfNeeded(type, name);
@@ -474,16 +474,18 @@ LookupTypeResult TypeChecker::lookupMemberType(DeclContext *dc,
 
   // Look for members with the given name.
   SmallVector<ValueDecl *, 4> decls;
-  NLOptions subOptions = (NL_QualifiedDefault | NL_OnlyTypes | NL_ProtocolMembers);
+  NLOptions subOptions = {NLFlag::QualifiedDefault,
+                          NLFlag::OnlyTypes,
+                          NLFlag::ProtocolMembers};
 
   if (options.contains(NameLookupFlags::IgnoreAccessControl))
-    subOptions |= NL_IgnoreAccessControl;
+    subOptions |= NLFlag::IgnoreAccessControl;
   if (options.contains(NameLookupFlags::IgnoreMissingImports))
-    subOptions |= NL_IgnoreMissingImports;
+    subOptions |= NLFlag::IgnoreMissingImports;
   if (options.contains(NameLookupFlags::IncludeUsableFromInline))
-    subOptions |= NL_IncludeUsableFromInline;
+    subOptions |= NLFlag::IncludeUsableFromInline;
   if (options.contains(NameLookupFlags::ABIProviding))
-    subOptions |= NL_ABIProviding;
+    subOptions |= NLFlag::ABIProviding;
 
   // Make sure we've resolved implicit members, if we need them.
   namelookup::installSemanticMembersIfNeeded(type, name);

--- a/lib/Sema/TypeCheckPropertyWrapper.cpp
+++ b/lib/Sema/TypeCheckPropertyWrapper.cpp
@@ -42,7 +42,7 @@ static VarDecl *findValueProperty(ASTContext &ctx, NominalTypeDecl *nominal,
     SmallVector<ValueDecl *, 2> decls;
     nominal->lookupQualified(nominal, DeclNameRef(name),
                              nominal->getStartLoc(),
-                             NLFlag::QualifiedDefault,
+                             NLFlags::QualifiedDefault,
                              decls);
     for (const auto &foundDecl : decls) {
       auto foundVar = dyn_cast<VarDecl>(foundDecl);
@@ -395,7 +395,7 @@ PropertyWrapperTypeInfoRequest::evaluate(
   SmallVector<ValueDecl *, 2> decls;
   nominal->lookupQualified(nominal, DeclNameRef::createConstructor(),
                            nominal->getStartLoc(),
-                           NLFlag::QualifiedDefault, decls);
+                           NLFlags::QualifiedDefault, decls);
 
   PropertyWrapperTypeInfo result;
   result.valueVar = valueVar;

--- a/lib/Sema/TypeCheckPropertyWrapper.cpp
+++ b/lib/Sema/TypeCheckPropertyWrapper.cpp
@@ -42,7 +42,7 @@ static VarDecl *findValueProperty(ASTContext &ctx, NominalTypeDecl *nominal,
     SmallVector<ValueDecl *, 2> decls;
     nominal->lookupQualified(nominal, DeclNameRef(name),
                              nominal->getStartLoc(),
-                             NL_QualifiedDefault,
+                             NLFlag::QualifiedDefault,
                              decls);
     for (const auto &foundDecl : decls) {
       auto foundVar = dyn_cast<VarDecl>(foundDecl);
@@ -395,7 +395,7 @@ PropertyWrapperTypeInfoRequest::evaluate(
   SmallVector<ValueDecl *, 2> decls;
   nominal->lookupQualified(nominal, DeclNameRef::createConstructor(),
                            nominal->getStartLoc(),
-                           NL_QualifiedDefault, decls);
+                           NLFlag::QualifiedDefault, decls);
 
   PropertyWrapperTypeInfo result;
   result.valueVar = valueVar;

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1665,8 +1665,8 @@ swift::lookupValueWitnesses(DeclContext *DC, ValueDecl *req, bool *ignoringNames
     // to restate them in the resulting list, or else an otherwise valid
     // conformance will become ambiguous.
     const NLOptions options =
-        (doUnqualifiedLookup ? NLOptions() : NLOptions(NLFlag::ProtocolMembers)) |
-        NLOptions(NLFlag::IgnoreMissingImports);
+        (doUnqualifiedLookup ? NLOptions() : NLFlag::ProtocolMembers) |
+        NLFlag::IgnoreMissingImports;
 
     auto getWitness = [req, DC](ValueDecl *witness) -> ValueDecl * {
       // Protocol members can't be witnesses.
@@ -6768,8 +6768,8 @@ diagnoseMissingAppendInterpolationMethod(NominalTypeDecl *typeDecl) {
 
     static bool hasValidMethod(NominalTypeDecl *typeDecl,
                                SmallVectorImpl<InvalidMethod> &invalid) {
-      NLOptions subOptions = {NLFlag::QualifiedDefault};
-      subOptions |= NLOptions(NLFlag::ProtocolMembers);
+      NLOptions subOptions = NLFlag::QualifiedDefault;
+      subOptions |= NLFlag::ProtocolMembers;
 
       DeclNameRef baseName(typeDecl->getASTContext().Id_appendInterpolation);
 

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1516,7 +1516,7 @@ lookupValueWitnessesViaImplementsAttr(
   auto name = req->createNameRef();
   auto *nominal = DC->getSelfNominalTypeDecl();
 
-  NLOptions subOptions = {NLFlag::ProtocolMembers, NLFlag::IncludeAttributeImplements};
+  NLOptions subOptions = {NLFlags::ProtocolMembers, NLFlags::IncludeAttributeImplements};
 
   nominal->synthesizeSemanticMembersIfNeeded(name.getFullName());
 
@@ -1665,8 +1665,8 @@ swift::lookupValueWitnesses(DeclContext *DC, ValueDecl *req, bool *ignoringNames
     // to restate them in the resulting list, or else an otherwise valid
     // conformance will become ambiguous.
     const NLOptions options =
-        (doUnqualifiedLookup ? NLOptions() : NLFlag::ProtocolMembers) |
-        NLFlag::IgnoreMissingImports;
+        (doUnqualifiedLookup ? NLOptions() : NLFlags::ProtocolMembers) |
+        NLFlags::IgnoreMissingImports;
 
     auto getWitness = [req, DC](ValueDecl *witness) -> ValueDecl * {
       // Protocol members can't be witnesses.
@@ -6768,8 +6768,8 @@ diagnoseMissingAppendInterpolationMethod(NominalTypeDecl *typeDecl) {
 
     static bool hasValidMethod(NominalTypeDecl *typeDecl,
                                SmallVectorImpl<InvalidMethod> &invalid) {
-      NLOptions subOptions = NLFlag::QualifiedDefault;
-      subOptions |= NLFlag::ProtocolMembers;
+      NLOptions subOptions = NLFlags::QualifiedDefault;
+      subOptions |= NLFlags::ProtocolMembers;
 
       DeclNameRef baseName(typeDecl->getASTContext().Id_appendInterpolation);
 
@@ -7666,7 +7666,7 @@ void TypeChecker::inferDefaultWitnesses(ProtocolDecl *proto) {
     // (canonicalized) requirement.
     if (assocType->getProtocol() != proto) {
       SmallVector<ValueDecl *, 2> found;
-      NLOptions options = {NLFlag::QualifiedDefault, NLFlag::ProtocolMembers, NLFlag::OnlyTypes};
+      NLOptions options = {NLFlags::QualifiedDefault, NLFlags::ProtocolMembers, NLFlags::OnlyTypes};
       module->lookupQualified(
                            proto, DeclNameRef(assocType->getName()),
                            proto->getLoc(),

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1516,7 +1516,7 @@ lookupValueWitnessesViaImplementsAttr(
   auto name = req->createNameRef();
   auto *nominal = DC->getSelfNominalTypeDecl();
 
-  NLOptions subOptions = (NL_ProtocolMembers | NL_IncludeAttributeImplements);
+  NLOptions subOptions = {NLFlag::ProtocolMembers, NLFlag::IncludeAttributeImplements};
 
   nominal->synthesizeSemanticMembersIfNeeded(name.getFullName());
 
@@ -1665,8 +1665,8 @@ swift::lookupValueWitnesses(DeclContext *DC, ValueDecl *req, bool *ignoringNames
     // to restate them in the resulting list, or else an otherwise valid
     // conformance will become ambiguous.
     const NLOptions options =
-        (doUnqualifiedLookup ? NLOptions(0) : NL_ProtocolMembers) |
-        NL_IgnoreMissingImports;
+        (doUnqualifiedLookup ? NLOptions() : {NLFlag::ProtocolMembers}) |
+        {NLFlag::IgnoreMissingImports};
 
     auto getWitness = [req, DC](ValueDecl *witness) -> ValueDecl * {
       // Protocol members can't be witnesses.
@@ -6768,8 +6768,8 @@ diagnoseMissingAppendInterpolationMethod(NominalTypeDecl *typeDecl) {
 
     static bool hasValidMethod(NominalTypeDecl *typeDecl,
                                SmallVectorImpl<InvalidMethod> &invalid) {
-      NLOptions subOptions = NL_QualifiedDefault;
-      subOptions |= NL_ProtocolMembers;
+      NLOptions subOptions = {NLFlag::QualifiedDefault};
+      subOptions |= NLFlag::ProtocolMembers;
 
       DeclNameRef baseName(typeDecl->getASTContext().Id_appendInterpolation);
 
@@ -7666,10 +7666,11 @@ void TypeChecker::inferDefaultWitnesses(ProtocolDecl *proto) {
     // (canonicalized) requirement.
     if (assocType->getProtocol() != proto) {
       SmallVector<ValueDecl *, 2> found;
+      NLOptions options = {NLFlag::QualifiedDefault, NLFlag::ProtocolMembers, NLFlag::OnlyTypes};
       module->lookupQualified(
                            proto, DeclNameRef(assocType->getName()),
                            proto->getLoc(),
-                           NL_QualifiedDefault|NL_ProtocolMembers|NL_OnlyTypes,
+                           options,
                            found);
       if (found.size() == 1 && isa<AssociatedTypeDecl>(found[0]))
         assocType = cast<AssociatedTypeDecl>(found[0]);

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1665,8 +1665,8 @@ swift::lookupValueWitnesses(DeclContext *DC, ValueDecl *req, bool *ignoringNames
     // to restate them in the resulting list, or else an otherwise valid
     // conformance will become ambiguous.
     const NLOptions options =
-        (doUnqualifiedLookup ? NLOptions() : {NLFlag::ProtocolMembers}) |
-        {NLFlag::IgnoreMissingImports};
+        (doUnqualifiedLookup ? NLOptions() : NLOptions(NLFlag::ProtocolMembers)) |
+        NLOptions(NLFlag::IgnoreMissingImports);
 
     auto getWitness = [req, DC](ValueDecl *witness) -> ValueDecl * {
       // Protocol members can't be witnesses.
@@ -6769,7 +6769,7 @@ diagnoseMissingAppendInterpolationMethod(NominalTypeDecl *typeDecl) {
     static bool hasValidMethod(NominalTypeDecl *typeDecl,
                                SmallVectorImpl<InvalidMethod> &invalid) {
       NLOptions subOptions = {NLFlag::QualifiedDefault};
-      subOptions |= NLFlag::ProtocolMembers;
+      subOptions |= NLOptions(NLFlag::ProtocolMembers);
 
       DeclNameRef baseName(typeDecl->getASTContext().Id_appendInterpolation);
 

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -2588,7 +2588,7 @@ static bool checkSuperInit(ConstructorDecl *fromCtor,
     superclassDecl->synthesizeSemanticMembersIfNeeded(
         DeclBaseName::createConstructor());
 
-    NLOptions subOptions = NL_QualifiedDefault;
+    NLOptions subOptions = {NLFlag::QualifiedDefault};
 
     SmallVector<ValueDecl *, 4> lookupResults;
     fromCtor->lookupQualified(superclassDecl,

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -2588,7 +2588,7 @@ static bool checkSuperInit(ConstructorDecl *fromCtor,
     superclassDecl->synthesizeSemanticMembersIfNeeded(
         DeclBaseName::createConstructor());
 
-    NLOptions subOptions = NLFlag::QualifiedDefault;
+    NLOptions subOptions = NLFlags::QualifiedDefault;
 
     SmallVector<ValueDecl *, 4> lookupResults;
     fromCtor->lookupQualified(superclassDecl,

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -2588,7 +2588,7 @@ static bool checkSuperInit(ConstructorDecl *fromCtor,
     superclassDecl->synthesizeSemanticMembersIfNeeded(
         DeclBaseName::createConstructor());
 
-    NLOptions subOptions = {NLFlag::QualifiedDefault};
+    NLOptions subOptions = NLFlag::QualifiedDefault;
 
     SmallVector<ValueDecl *, 4> lookupResults;
     fromCtor->lookupQualified(superclassDecl,

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -3445,10 +3445,10 @@ static VarDecl *synthesizePropertyWrapperProjectionVar(
     auto dc = var->getDeclContext();
     if (dc->isTypeContext()) {
       dc->lookupQualified(dc->getSelfNominalTypeDecl(), projectionName,
-                          var->getLoc(), {NLFlag::QualifiedDefault}, declsFound);
+                          var->getLoc(), NLFlag::QualifiedDefault, declsFound);
     } else if (dc->isModuleScopeContext()) {
       dc->lookupQualified(dc->getParentModule(), projectionName,
-                          var->getLoc(), {NLFlag::QualifiedDefault}, declsFound);
+                          var->getLoc(), NLFlag::QualifiedDefault, declsFound);
     } else {
       llvm_unreachable("Property wrappers don't work in local contexts");
     }

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -3445,10 +3445,10 @@ static VarDecl *synthesizePropertyWrapperProjectionVar(
     auto dc = var->getDeclContext();
     if (dc->isTypeContext()) {
       dc->lookupQualified(dc->getSelfNominalTypeDecl(), projectionName,
-                          var->getLoc(), NLFlag::QualifiedDefault, declsFound);
+                          var->getLoc(), NLFlags::QualifiedDefault, declsFound);
     } else if (dc->isModuleScopeContext()) {
       dc->lookupQualified(dc->getParentModule(), projectionName,
-                          var->getLoc(), NLFlag::QualifiedDefault, declsFound);
+                          var->getLoc(), NLFlags::QualifiedDefault, declsFound);
     } else {
       llvm_unreachable("Property wrappers don't work in local contexts");
     }

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -3445,10 +3445,10 @@ static VarDecl *synthesizePropertyWrapperProjectionVar(
     auto dc = var->getDeclContext();
     if (dc->isTypeContext()) {
       dc->lookupQualified(dc->getSelfNominalTypeDecl(), projectionName,
-                          var->getLoc(), NL_QualifiedDefault, declsFound);
+                          var->getLoc(), {NLFlag::QualifiedDefault}, declsFound);
     } else if (dc->isModuleScopeContext()) {
       dc->lookupQualified(dc->getParentModule(), projectionName,
-                          var->getLoc(), NL_QualifiedDefault, declsFound);
+                          var->getLoc(), {NLFlag::QualifiedDefault}, declsFound);
     } else {
       llvm_unreachable("Property wrappers don't work in local contexts");
     }

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -2194,9 +2194,9 @@ TypeResolver::diagnoseUnknownType(Type parentType, SourceRange parentRange,
     LookupResult memberLookup;
     // Let's try to look any member of the parent type with the given name,
     // even if it is not a type, allowing for a more precise diagnostic.
-    NLOptions memberLookupOptions = {NLFlag::QualifiedDefault,
-                                     NLFlag::IgnoreAccessControl,
-                                     NLFlag::IgnoreMissingImports};
+    NLOptions memberLookupOptions = {NLFlags::QualifiedDefault,
+                                     NLFlags::IgnoreAccessControl,
+                                     NLFlags::IgnoreMissingImports};
     SmallVector<ValueDecl *, 2> results;
     dc->lookupQualified(parentType, repr->getNameRef(), repr->getLoc(),
                         memberLookupOptions, results);

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -2194,9 +2194,9 @@ TypeResolver::diagnoseUnknownType(Type parentType, SourceRange parentRange,
     LookupResult memberLookup;
     // Let's try to look any member of the parent type with the given name,
     // even if it is not a type, allowing for a more precise diagnostic.
-    NLOptions memberLookupOptions = (NL_QualifiedDefault |
-                                     NL_IgnoreAccessControl |
-                                     NL_IgnoreMissingImports);
+    NLOptions memberLookupOptions = {NLFlag::QualifiedDefault,
+                                     NLFlag::IgnoreAccessControl,
+                                     NLFlag::IgnoreMissingImports};
     SmallVector<ValueDecl *, 2> results;
     dc->lookupQualified(parentType, repr->getNameRef(), repr->getLoc(),
                         memberLookupOptions, results);

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -2227,7 +2227,7 @@ ModuleFile::resolveCrossReference(ModuleID MID, uint32_t pathLen) {
                                getIdentifier(privateDiscriminator));
     } else {
       baseModule->lookupQualified(baseModule, DeclNameRef(name),
-                                  SourceLoc(), NLFlag::RemoveOverridden,
+                                  SourceLoc(), NLFlags::RemoveOverridden,
                                   values);
     }
     filterValues(filterTy, nullptr, nullptr, isType, inProtocolExt,
@@ -2437,7 +2437,7 @@ ModuleFile::resolveCrossReference(ModuleID MID, uint32_t pathLen) {
                                    getIdentifier(privateDiscriminator));
         } else {
           otherModule->lookupQualified(otherModule, DeclNameRef(name),
-                                       SourceLoc(), NLFlag::RemoveOverridden,
+                                       SourceLoc(), NLFlags::RemoveOverridden,
                                        values);
         }
 

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -2227,7 +2227,7 @@ ModuleFile::resolveCrossReference(ModuleID MID, uint32_t pathLen) {
                                getIdentifier(privateDiscriminator));
     } else {
       baseModule->lookupQualified(baseModule, DeclNameRef(name),
-                                  SourceLoc(), {NLFlag::RemoveOverridden},
+                                  SourceLoc(), NLFlag::RemoveOverridden,
                                   values);
     }
     filterValues(filterTy, nullptr, nullptr, isType, inProtocolExt,
@@ -2437,7 +2437,7 @@ ModuleFile::resolveCrossReference(ModuleID MID, uint32_t pathLen) {
                                    getIdentifier(privateDiscriminator));
         } else {
           otherModule->lookupQualified(otherModule, DeclNameRef(name),
-                                       SourceLoc(), {NLFlag::RemoveOverridden},
+                                       SourceLoc(), NLFlag::RemoveOverridden,
                                        values);
         }
 

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -2227,7 +2227,7 @@ ModuleFile::resolveCrossReference(ModuleID MID, uint32_t pathLen) {
                                getIdentifier(privateDiscriminator));
     } else {
       baseModule->lookupQualified(baseModule, DeclNameRef(name),
-                                  SourceLoc(), NL_RemoveOverridden,
+                                  SourceLoc(), {NLFlag::RemoveOverridden},
                                   values);
     }
     filterValues(filterTy, nullptr, nullptr, isType, inProtocolExt,
@@ -2437,7 +2437,7 @@ ModuleFile::resolveCrossReference(ModuleID MID, uint32_t pathLen) {
                                    getIdentifier(privateDiscriminator));
         } else {
           otherModule->lookupQualified(otherModule, DeclNameRef(name),
-                                       SourceLoc(), NL_RemoveOverridden,
+                                       SourceLoc(), {NLFlag::RemoveOverridden},
                                        values);
         }
 

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -605,7 +605,7 @@ void ModuleFile::getImportDecls(SmallVectorImpl<Decl *> &Results) {
           SmallVector<ValueDecl *, 8> Decls;
           TopLevelModule->lookupQualified(
               TopLevelModule, DeclNameRef(ScopeID),
-              SourceLoc(), {NLFlag::QualifiedDefault}, Decls);
+              SourceLoc(), NLFlag::QualifiedDefault, Decls);
           // Skip macro until `import macro` is implemented.
           llvm::erase_if(Decls, [](ValueDecl *VD) {
             return isa<MacroDecl>(VD);

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -605,7 +605,7 @@ void ModuleFile::getImportDecls(SmallVectorImpl<Decl *> &Results) {
           SmallVector<ValueDecl *, 8> Decls;
           TopLevelModule->lookupQualified(
               TopLevelModule, DeclNameRef(ScopeID),
-              SourceLoc(), NLFlag::QualifiedDefault, Decls);
+              SourceLoc(), NLFlags::QualifiedDefault, Decls);
           // Skip macro until `import macro` is implemented.
           llvm::erase_if(Decls, [](ValueDecl *VD) {
             return isa<MacroDecl>(VD);

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -605,7 +605,7 @@ void ModuleFile::getImportDecls(SmallVectorImpl<Decl *> &Results) {
           SmallVector<ValueDecl *, 8> Decls;
           TopLevelModule->lookupQualified(
               TopLevelModule, DeclNameRef(ScopeID),
-              SourceLoc(), NL_QualifiedDefault, Decls);
+              SourceLoc(), {NLFlag::QualifiedDefault}, Decls);
           // Skip macro until `import macro` is implemented.
           llvm::erase_if(Decls, [](ValueDecl *VD) {
             return isa<MacroDecl>(VD);

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -538,7 +538,7 @@ static void walkRelatedDecls(const ValueDecl *VD, const FnTy &Fn) {
     auto type = DC->getDeclaredInterfaceType();
     if (!type->is<ErrorType>()) {
       DC->lookupQualified(type, DeclNameRef(VD->getBaseName()),
-                          VD->getLoc(), {NLFlag::QualifiedDefault},
+                          VD->getLoc(), NLFlag::QualifiedDefault,
                           results);
     }
   } else {
@@ -548,7 +548,7 @@ static void walkRelatedDecls(const ValueDecl *VD, const FnTy &Fn) {
                                namelookup::ResolutionKind::Overloadable,
                                DC->getModuleScopeContext(),
                                VD->getLoc(),
-                               {NLFlag::UnqualifiedDefault});
+                               NLFlag::UnqualifiedDefault);
   }
 
   SmallVector<ValueDecl *, 8> RelatedDecls;

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -538,7 +538,7 @@ static void walkRelatedDecls(const ValueDecl *VD, const FnTy &Fn) {
     auto type = DC->getDeclaredInterfaceType();
     if (!type->is<ErrorType>()) {
       DC->lookupQualified(type, DeclNameRef(VD->getBaseName()),
-                          VD->getLoc(), NL_QualifiedDefault,
+                          VD->getLoc(), {NLFlag::QualifiedDefault},
                           results);
     }
   } else {
@@ -548,7 +548,7 @@ static void walkRelatedDecls(const ValueDecl *VD, const FnTy &Fn) {
                                namelookup::ResolutionKind::Overloadable,
                                DC->getModuleScopeContext(),
                                VD->getLoc(),
-                               NL_UnqualifiedDefault);
+                               {NLFlag::UnqualifiedDefault});
   }
 
   SmallVector<ValueDecl *, 8> RelatedDecls;

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -538,7 +538,7 @@ static void walkRelatedDecls(const ValueDecl *VD, const FnTy &Fn) {
     auto type = DC->getDeclaredInterfaceType();
     if (!type->is<ErrorType>()) {
       DC->lookupQualified(type, DeclNameRef(VD->getBaseName()),
-                          VD->getLoc(), NLFlag::QualifiedDefault,
+                          VD->getLoc(), NLFlags::QualifiedDefault,
                           results);
     }
   } else {
@@ -548,7 +548,7 @@ static void walkRelatedDecls(const ValueDecl *VD, const FnTy &Fn) {
                                namelookup::ResolutionKind::Overloadable,
                                DC->getModuleScopeContext(),
                                VD->getLoc(),
-                               NLFlag::UnqualifiedDefault);
+                               NLFlags::UnqualifiedDefault);
   }
 
   SmallVector<ValueDecl *, 8> RelatedDecls;


### PR DESCRIPTION
Converts the NLOptions enum to an `OptionSet` of `NLFlag`, an enum class representing the name-lookup flag constants. From my understanding, the codebase wants to use more namespaced enums in general. More particularly, this change allows us to expose NLOptions to ASTGen (by including it in ASTBridging.h), which I need to validate the upcoming https://github.com/swiftlang/swift-syntax/pull/3346 in swift-syntax. 

Like other conversions to `NLOptions`, the callsite needs to be updated:
1. When providing a list of options, `OptionSet` has a convenient initializer that allows us to rewrite the following:
    ```diff
    - NLOptions options = NL_OptionA | NL_OptionB | NL_OptionC;
    + NLOptions options = { NLFlags::OptionA, NLFlags::OptionB, NLFlags::OptionC };
    ```
2. Checks of the form `& NL_MyOption` become `options.contains(NLFlags::MyOption)`
3. Removing options with ` innerOptions &= ~NL_MyOption` becomes `innerOptions -= NLFlags::MyOption`

---
Replaces this [original attempt](https://github.com/swiftlang/swift/pull/89992), which recreated a lot of `OptionSet` functionality.