### PR TITLE
[Completion] Look through storage reference type in `addVarDeclRef`

### DIFF
--- a/lib/IDE/CompletionLookup.cpp
+++ b/lib/IDE/CompletionLookup.cpp
@@ -794,6 +794,12 @@ void CompletionLookup::addVarDeclRef(const VarDecl *VD,
     VarType = getTypeOfMember(VD, dynamicLookupInfo);
   }
 
+  // Make sure to look through the storage reference type if present. These
+  // shouldn't be presented to the user, and cannot be used in the constraint
+  // system when e.g computing type relations.
+  if (VarType)
+    VarType = VarType->getReferenceStorageReferent();
+
   std::optional<ContextualNotRecommendedReason> NotRecommended;
   // "not recommended" in its own getter.
   if (Kind == LookupKind::ValueInDeclContext) {

--- a/test/IDE/complete_weak.swift
+++ b/test/IDE/complete_weak.swift
@@ -1,5 +1,7 @@
 // RUN: %batch-code-completion
 
+protocol P {}
+
 class CompleteWeak {
   func instanceFunc() {}
 
@@ -35,4 +37,12 @@ class CompleteWeak {
   }
 // UNOWNED_DOT_1-DAG: Decl[InstanceMethod]/CurrNominal: instanceFunc()[#Void#]{{; name=.+$}}
 
+  func takesSomeP(_ x: some P) {}
+
+  func weakInGenericArg() {
+    // Make sure we correctly strip the weak reference type here when computing type relation.
+    weak var weakSelf = self
+    takesSomeP(#^WEAK_IN_GENERIC_ARG^#)
+    // WEAK_IN_GENERIC_ARG-DAG: Decl[LocalVar]/Local: weakSelf[#CompleteWeak?#]{{; name=.+$}}
+  }
 }

--- a/test/IDE/complete_weak.swift
+++ b/test/IDE/complete_weak.swift
@@ -1,8 +1,4 @@
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=WEAK_VARS_1 | %FileCheck %s -check-prefix=WEAK_VARS_1
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=WEAK_NO_DOT_1 | %FileCheck %s -check-prefix=WEAK_NO_DOT_1
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=WEAK_DOT_1 | %FileCheck %s -check-prefix=WEAK_DOT_1
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=UNOWNED_NO_DOT_1 | %FileCheck %s -check-prefix=UNOWNED_NO_DOT_1
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=UNOWNED_DOT_1 | %FileCheck %s -check-prefix=UNOWNED_DOT_1
+// RUN: %batch-code-completion
 
 class CompleteWeak {
   func instanceFunc() {}

--- a/validation-test/IDE/crashers_fixed/ReferenceStorageType-get-364574.swift
+++ b/validation-test/IDE/crashers_fixed/ReferenceStorageType-get-364574.swift
@@ -1,4 +1,4 @@
 // {"kind":"complete","original":"186a3233","signature":"swift::ReferenceStorageType::get(swift::Type, swift::ReferenceOwnership, swift::ASTContext const&)","signatureAssert":"Assertion failed: (!T->hasTypeVariable()), function get","signatureNext":"TypeTransform::doIt"}
-// RUN: not --crash %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -source-filename %s
+// RUN: %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -source-filename %s
 struct a<b{ c: b weak var d = \ c {
 a()#^^#


### PR DESCRIPTION
Make sure we don't end up feeding a storage reference type to the constraint system when computing type relations.