### PR TITLE
Fix `update-checkout --stash` regression

### DIFF
--- a/utils/update_checkout/tests/scheme_mock.py
+++ b/utils/update_checkout/tests/scheme_mock.py
@@ -147,6 +147,28 @@ def get_path_from_url(url: str) -> str:
     return urllib.parse.urlsplit(url).path
 
 
+def configure_git_identity(repo_path):
+    """Configure a deterministic local git identity and disable commit signing
+    for the clone at `repo_path`.
+
+    update-checkout's own clones (under `source_root`) do not set these up, so a
+    test that commits into such a clone must call this first; otherwise the
+    commit depends on an ambient global identity, which is absent on a pristine
+    CI worker, and aborts. The harness's `local_path` clones go through this too,
+    via `setup_mock_remote`.
+    """
+    call_quietly(
+        ["git", "config", "--local", "user.name", "swift_test"], cwd=repo_path
+    )
+    call_quietly(
+        ["git", "config", "--local", "user.email", "no-reply@swift.org"],
+        cwd=repo_path,
+    )
+    call_quietly(
+        ["git", "config", "--local", "commit.gpgsign", "false"], cwd=repo_path
+    )
+
+
 # TODO: Move this to SchemeMockTestCase.
 def setup_mock_remote(test_case, base_dir, base_config, remotes_path, local_path):
     for local_repo_name in base_config["repos"].keys():
@@ -160,16 +182,7 @@ def setup_mock_remote(test_case, base_dir, base_config, remotes_path, local_path
             ["git", "symbolic-ref", "HEAD", "refs/heads/main"], cwd=remote_repo_path
         )
         call_quietly(["git", "clone", "-l", remote_repo_path, local_repo_path])
-        call_quietly(
-            ["git", "config", "--local", "user.name", "swift_test"], cwd=local_repo_path
-        )
-        call_quietly(
-            ["git", "config", "--local", "user.email", "no-reply@swift.org"],
-            cwd=local_repo_path,
-        )
-        call_quietly(
-            ["git", "config", "--local", "commit.gpgsign", "false"], cwd=local_repo_path
-        )
+        configure_git_identity(local_repo_path)
         call_quietly(
             ["git", "symbolic-ref", "HEAD", "refs/heads/main"], cwd=local_repo_path
         )
@@ -250,6 +263,14 @@ class SchemeMockTestCase(unittest.TestCase):
         self._remotes_path = os.path.join(self.workspace, "remote")
         # We use local as a workspace for creating commits.
         self.local_path = os.path.join(self.workspace, "local")
+
+        self.base_args = [
+            self.update_checkout_path,
+            "--config",
+            self.config_path,
+            "--source-root",
+            self.source_root,
+        ]
 
     def setUp(self):
         create_dir(self.source_root)

--- a/utils/update_checkout/tests/test_clone.py
+++ b/utils/update_checkout/tests/test_clone.py
@@ -319,14 +319,6 @@ class SchemeWithMissingRepoTestCase(scheme_mock.SchemeMockTestCase):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        self.base_args = [
-            self.update_checkout_path,
-            "--config",
-            self.config_path,
-            "--source-root",
-            self.source_root,
-        ]
-
         repos = self.repo_names
         repos.pop()
 

--- a/utils/update_checkout/tests/test_stash_clean.py
+++ b/utils/update_checkout/tests/test_stash_clean.py
@@ -24,16 +24,6 @@ class StashAndCleanTestCase(scheme_mock.SchemeMockTestCase):
     ignored files via the shared trailing `git clean -fdx`.
     """
 
-    def __init__(self, *args, **kwargs):
-        super(StashAndCleanTestCase, self).__init__(*args, **kwargs)
-        self.base_args = [
-            self.update_checkout_path,
-            "--config",
-            self.config_path,
-            "--source-root",
-            self.source_root,
-        ]
-
     def _repo1_path(self):
         return os.path.join(self.source_root, "repo1")
 
@@ -53,15 +43,10 @@ class StashAndCleanTestCase(scheme_mock.SchemeMockTestCase):
         update that follows the stash/clean step is a no-op; only the working
         tree is later made dirty. Requires `_clone()` to have run first."""
         repo = self._repo1_path()
-        # Configure a local identity + disable commit signing on the
-        # update-checkout-managed clone. Unlike the harness's `local_path`
-        # clones, update-checkout does not set these up, so without this the
-        # seed commit would depend on an ambient global git identity and abort
-        # with a missing-identity error on a pristine CI worker. Mirrors
-        # scheme_mock.setup_mock_remote.
-        self._git(["config", "--local", "user.name", "swift_test"])
-        self._git(["config", "--local", "user.email", "no-reply@swift.org"])
-        self._git(["config", "--local", "commit.gpgsign", "false"])
+        # update-checkout's own clone of source_root has no git identity (only
+        # the harness's local_path clones get one), so configure it before the
+        # seed commit. See scheme_mock.configure_git_identity.
+        scheme_mock.configure_git_identity(repo)
         with open(os.path.join(repo, "tracked.txt"), "w") as f:
             f.write("committed content\n")
         with open(os.path.join(repo, ".gitignore"), "w") as f:

--- a/utils/update_checkout/tests/test_stash_clean.py
+++ b/utils/update_checkout/tests/test_stash_clean.py
@@ -21,14 +21,7 @@ class StashAndCleanTestCase(scheme_mock.SchemeMockTestCase):
 
     --stash MUST preserve uncommitted tracked + untracked work (recoverable
     from `git stash`); --clean MUST discard it. Both modes additionally delete
-    ignored files via the shared trailing `git clean -fdx`. These options were
-    silently inverted by a refactor, so these tests assert the recoverability /
-    discard behaviour directly.
-
-    The submodule-recursion arm of the fix is not exercised here (the mock
-    harness builds submodule-free repos); it issues the same swapped commands
-    via `git submodule foreach --recursive`. Full submodule coverage is tracked
-    as a known gap.
+    ignored files via the shared trailing `git clean -fdx`.
     """
 
     def __init__(self, *args, **kwargs):

--- a/utils/update_checkout/tests/test_stash_clean.py
+++ b/utils/update_checkout/tests/test_stash_clean.py
@@ -1,0 +1,172 @@
+# ===--- test_stash_clean.py ----------------------------------------------===#
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2026 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+# ===----------------------------------------------------------------------===#
+
+import os
+
+from . import scheme_mock
+
+
+class StashAndCleanTestCase(scheme_mock.SchemeMockTestCase):
+    """Coverage for the top-level repository's behaviour under the destructive
+    pre-update options.
+
+    --stash MUST preserve uncommitted tracked + untracked work (recoverable
+    from `git stash`); --clean MUST discard it. Both modes additionally delete
+    ignored files via the shared trailing `git clean -fdx`. These options were
+    silently inverted by a refactor, so these tests assert the recoverability /
+    discard behaviour directly.
+
+    The submodule-recursion arm of the fix is not exercised here (the mock
+    harness builds submodule-free repos); it issues the same swapped commands
+    via `git submodule foreach --recursive`. Full submodule coverage is tracked
+    as a known gap.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super(StashAndCleanTestCase, self).__init__(*args, **kwargs)
+        self.base_args = [
+            self.update_checkout_path,
+            "--config",
+            self.config_path,
+            "--source-root",
+            self.source_root,
+        ]
+
+    def _repo1_path(self):
+        return os.path.join(self.source_root, "repo1")
+
+    def _git(self, args, **kwargs):
+        kwargs.setdefault("cwd", self._repo1_path())
+        return self.call(["git"] + args, **kwargs)
+
+    def _clone(self):
+        self.call(self.base_args + ["--clone"])
+
+    def _seed_tracked_file(self):
+        """Commit and push a tracked file and a .gitignore in the
+        update-checkout-managed tree.
+
+        Operates on `source_root/repo1` (the tree update-checkout acts on), NOT
+        `local_path/repo1`. Pushing makes local `main` == remote `main` so the
+        update that follows the stash/clean step is a no-op; only the working
+        tree is later made dirty. Requires `_clone()` to have run first."""
+        repo = self._repo1_path()
+        # Configure a local identity + disable commit signing on the
+        # update-checkout-managed clone. Unlike the harness's `local_path`
+        # clones, update-checkout does not set these up, so without this the
+        # seed commit would depend on an ambient global git identity and abort
+        # with a missing-identity error on a pristine CI worker. Mirrors
+        # scheme_mock.setup_mock_remote.
+        self._git(["config", "--local", "user.name", "swift_test"])
+        self._git(["config", "--local", "user.email", "no-reply@swift.org"])
+        self._git(["config", "--local", "commit.gpgsign", "false"])
+        with open(os.path.join(repo, "tracked.txt"), "w") as f:
+            f.write("committed content\n")
+        with open(os.path.join(repo, ".gitignore"), "w") as f:
+            f.write("*.ignored\n")
+        self._git(["add", "tracked.txt", ".gitignore"])
+        self._git(["commit", "-m", "add tracked.txt and .gitignore"])
+        self._git(["push", "origin", "main"])
+
+    def _make_uncommitted_changes(self):
+        """A tracked modification, a brand-new untracked file, and an ignored
+        file."""
+        repo = self._repo1_path()
+        with open(os.path.join(repo, "tracked.txt"), "w") as f:
+            f.write("MY UNCOMMITTED EDIT\n")
+        with open(os.path.join(repo, "untracked.txt"), "w") as f:
+            f.write("brand new untracked file\n")
+        with open(os.path.join(repo, "build.ignored"), "w") as f:
+            f.write("ignored build artifact\n")
+
+    def _assert_working_tree_dirty(self):
+        """Guard against a vacuous pass: the tracked edit + untracked file must
+        actually be present before update-checkout runs (otherwise the
+        'discards' assertions below would hold trivially)."""
+        status = self._git(["status", "--porcelain"])
+        self.assertNotEqual(
+            status.strip(),
+            "",
+            "test setup is broken: repo1 working tree is not dirty before the "
+            "update-checkout run.",
+        )
+
+    def test_stash_preserves_uncommitted_changes(self):
+        self._clone()
+        self._seed_tracked_file()
+        self._make_uncommitted_changes()
+        self._assert_working_tree_dirty()
+
+        self.call(self.base_args + ["--stash"])
+
+        # A stash entry must exist (the changes were not destroyed).
+        # NOTE: this assertion MUST precede the `stash pop` below. Against the
+        # inverted code the stash is empty, so this fails here as a clean
+        # AssertionError; if `pop` ran first it would raise a subprocess error
+        # ("No stash entries found") and the RED would become a test error
+        # rather than the asserted failure.
+        stash_list = self._git(["stash", "list"])
+        self.assertNotEqual(
+            stash_list.strip(),
+            "",
+            "--stash must create a stash entry, but `git stash list` is empty "
+            "(the uncommitted changes were destroyed).",
+        )
+
+        # And the changes must be genuinely recoverable, not just a blob.
+        self._git(["stash", "pop"])
+        with open(os.path.join(self._repo1_path(), "tracked.txt")) as f:
+            self.assertEqual(f.read(), "MY UNCOMMITTED EDIT\n")
+        untracked = os.path.join(self._repo1_path(), "untracked.txt")
+        self.assertTrue(
+            os.path.isfile(untracked),
+            "--stash must preserve untracked files (via `git stash -u`).",
+        )
+        with open(untracked) as f:
+            self.assertEqual(f.read(), "brand new untracked file\n")
+        # Ignored files are NOT stashed by `stash -u`; the trailing `clean -fdx`
+        # removes them (the documented "delete ignored files" behaviour). The
+        # `stash pop` above cannot reintroduce an ignored file, so this holds
+        # post-pop.
+        self.assertFalse(
+            os.path.isfile(os.path.join(self._repo1_path(), "build.ignored")),
+            "--stash's trailing `clean -fdx` must delete ignored files.",
+        )
+
+    def test_clean_discards_uncommitted_changes(self):
+        self._clone()
+        self._seed_tracked_file()
+        self._make_uncommitted_changes()
+        self._assert_working_tree_dirty()
+
+        self.call(self.base_args + ["--clean"])
+
+        # --clean discards: no stash entry is created.
+        stash_list = self._git(["stash", "list"])
+        self.assertEqual(
+            stash_list.strip(),
+            "",
+            "--clean must not create a stash entry.",
+        )
+        # Tracked modification reverted to committed content.
+        with open(os.path.join(self._repo1_path(), "tracked.txt")) as f:
+            self.assertEqual(f.read(), "committed content\n")
+        # Untracked file removed.
+        self.assertFalse(
+            os.path.isfile(os.path.join(self._repo1_path(), "untracked.txt")),
+            "--clean must delete untracked files.",
+        )
+        # Ignored file removed by the trailing `clean -fdx`.
+        self.assertFalse(
+            os.path.isfile(os.path.join(self._repo1_path(), "build.ignored")),
+            "--clean must delete ignored files.",
+        )

--- a/utils/update_checkout/tests/test_status_command.py
+++ b/utils/update_checkout/tests/test_status_command.py
@@ -4,7 +4,7 @@ from typing import List
 import unittest
 from pathlib import Path
 
-from .scheme_mock import UPDATE_CHECKOUT_PATH
+from .scheme_mock import UPDATE_CHECKOUT_PATH, configure_git_identity
 
 
 class TestStatusCommand(unittest.TestCase):
@@ -15,14 +15,7 @@ class TestStatusCommand(unittest.TestCase):
 
     def init_repo(self, path: Path, with_changes: bool):
         self.call(args=["git", "init"], cwd=path)
-        self.call(
-            args=["git", "config", "--local", "user.name", "swift_test"], cwd=path
-        )
-        self.call(
-            args=["git", "config", "--local", "user.email", "no-reply@swift.org"],
-            cwd=path,
-        )
-        self.call(args=["git", "config", "commit.gpgsign", "false"], cwd=path)
+        configure_git_identity(path)
 
         (path / "file.txt").write_text("initial\n")
         self.call(args=["git", "add", "file.txt"], cwd=path)

--- a/utils/update_checkout/update_checkout/update_checkout.py
+++ b/utils/update_checkout/update_checkout/update_checkout.py
@@ -229,10 +229,10 @@ def update_single_repository(pool_args: UpdateArguments):
                     prefix=prefix,
                 )
 
-            if pool_args.clean:
+            if pool_args.stash:
                 # Stash tracked and untracked changes.
                 run_for_repo_and_each_submodule_rec(["stash", "-u"])
-            elif pool_args.stash:
+            elif pool_args.clean:
                 # Delete tracked changes.
                 run_for_repo_and_each_submodule_rec(["reset", "--hard", "HEAD"])
 


### PR DESCRIPTION
The `--stash` and `--clean` dispatch conditions in `update-checkout` were inverted, so `--stash` ran `git reset --hard HEAD` + `git clean -fdx` (silently destroying uncommitted work with no stash) while `--clean` ran `git stash -u` (preserving it), the opposite of both options' documented behavior. Swapping the two conditions restores `--stash` to preserve changes via `git stash -u` and `--clean` to discard them. Added `utils/update_checkout/tests/test_stash_clean.py` asserting that `--stash` leaves the changes recoverable and `--clean` discards them.
