### PR TITLE
[6.4] Serialization: Don't drop generic type-alias type witness decls cross-module

### DIFF
--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -9248,16 +9248,6 @@ void ModuleFile::finishNormalConformance(NormalProtocolConformance *conformance,
     } else {
       fatal(thirdOrError.takeError());
     }
-    if (isa_and_nonnull<TypeAliasDecl>(third) &&
-        third->getModuleContext() != getAssociatedModule() &&
-        !third->getDeclaredInterfaceType()->isEqual(second)) {
-      // Conservatively drop references to typealiases in other modules
-      // that may have changed. This may also drop references to typealiases
-      // that /haven't/ changed but just happen to have generics in them, but
-      // in practice having a declaration here isn't actually required by the
-      // rest of the compiler.
-      third = nullptr;
-    }
     typeWitnesses[first] = {second, third};
   }
   assert(rawIDIter <= rawIDs.end() && "read too much");

--- a/test/AssociatedTypeInference/cross_module_extension_typealias_witness.swift
+++ b/test/AssociatedTypeInference/cross_module_extension_typealias_witness.swift
@@ -1,0 +1,57 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// Build three separate modules: Core (declares the protocol and the
+// protocol-extension type alias that witnesses the associated type), Mid (the
+// conformer, which does *not* declare the associated type explicitly), and App
+// (which references the conformer's associated type and imports both modules).
+
+// RUN: %target-swift-frontend -emit-module -module-name Core %t/Core.swift -emit-module-path %t/Core.swiftmodule
+// RUN: %target-swift-frontend -emit-module -module-name Mid %t/Mid.swift -emit-module-path %t/Mid.swiftmodule -I %t
+// RUN: %target-swift-frontend -typecheck -verify %t/App.swift -I %t
+
+// https://github.com/swiftlang/swift/issues/89909
+//
+// Cross-module qualified lookup of an associated type whose witness is supplied
+// by a type alias in a protocol extension used to fail when the protocol
+// extension, the conformer, and the reference site each lived in a separate
+// module. Deserializing the conformer's module used to drop the witness type
+// alias declaration (because the generic type alias lives in yet another
+// module), which left qualified lookup with no declaration to resolve, so
+// 'Foo.Action' failed with "'Action' is not a member type of struct 'Foo'".
+
+//--- Core.swift
+
+public protocol Feature {
+    associatedtype State
+    associatedtype Action
+}
+
+extension Feature {
+    public typealias Action = GenericAction<Self, State>
+}
+
+public enum GenericAction<F: Feature, State> {
+    case state(State)
+}
+
+//--- Mid.swift
+
+import Core
+
+public struct Foo: Feature {
+    public typealias State = Int
+}
+
+//--- App.swift
+
+import Core
+import Mid
+
+// The associated type 'Action' resolves to the extension-supplied witness
+// 'GenericAction<Foo, Int>'.
+public func useFooAction(_ action: Foo.Action) {}
+
+func checkWitnessType() {
+    let _: Foo.Action = GenericAction<Foo, Int>.state(0)
+}


### PR DESCRIPTION
Cherry-pick of https://github.com/swiftlang/swift/pull/90005

- **Explanation**:
  Fixes a Swift 6.4 regression where cross-module qualified lookup of an associated type whose witness is supplied by a protocol-extension `typealias` can fail with `'Action' is not a member type of struct 'Foo'`. The fix keeps the type-alias witness declaration during conformance deserialization instead of dropping it.

- **Scope**:
  Affects protocol conformance deserialization and associated-type member lookup for cross-module generic type-alias witnesses. Adds a focused regression test.

- **Issues**:
  https://github.com/swiftlang/swift/issues/89909

- **Original PRs**:
  https://github.com/swiftlang/swift/pull/90005

- **Risk**:
  Low-to-moderate. The patch is small and covered by a regression test, but it removes an old conservative deserialization guard for cross-module typealias witnesses. The resolved witness type is unchanged, the original PR passed CI, and the cherry-pick was requested for 6.4 because it fixes a regression.

- **Testing**:
  Original PR CI passed. Added `test/AssociatedTypeInference/cross_module_extension_typealias_witness.swift`.

- **Reviewers**:
  @slavapestov approved the original PR and requested the 6.4 cherry-pick.
