### PR TITLE
[6.4] SILGenApply: Pick up lifetime dependencies from inner function type in static methods.

### DIFF
--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -5648,6 +5648,13 @@ RValue CallEmission::applyNormalCall(SGFContext C) {
       calleeTypeInfo.origResultType->getFunctionResultType();
     calleeTypeInfo.substResultType =
       cast<FunctionType>(calleeTypeInfo.substResultType).getResult();
+
+    // Static methods have their lifetime dependencies placed on the inner
+    // function type, since the outer function parameter is always an independent
+    // metatype.
+    if (lifetimeDependencies.empty()) {
+      lifetimeDependencies = calleeTypeInfo.origFormalType->getLifetimeDependencies();
+    }
   }
 
   ResultPlanPtr resultPlan = ResultPlanBuilder::computeResultPlan(

--- a/test/SILGen/afd_static_method.swift
+++ b/test/SILGen/afd_static_method.swift
@@ -1,0 +1,45 @@
+// RUN: %target-swift-emit-silgen -enable-experimental-feature Lifetimes -enable-experimental-feature AddressableTypes -module-name main %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-sil -verify -enable-experimental-feature Lifetimes -enable-experimental-feature AddressableTypes -module-name main %s
+
+// REQUIRES: swift_feature_Lifetimes
+// REQUIRES: swift_feature_AddressableTypes
+
+// Ensure that address dependencies are properly lowered
+// through static method calls in the same way they are for free function
+// calls.
+
+@_addressableForDependencies
+struct Owner: ~Copyable {}
+
+// CHECK-LABEL: sil{{.*}} @$s{{.*}}10wrapStatic
+// CHECK:       bb0([[OWNER:%.*]] : $*Owner):
+@_lifetime(borrow owner)
+func wrapStatic(_ owner: borrowing Owner) -> View {
+	// CHECK:         [[MARK:%.*]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[OWNER]]
+	// CHECK:         [[METHOD:%.*]] = function_ref @$s{{.*}}4ViewV4into
+	// CHECK:         apply [[METHOD]]([[MARK]],
+    return View.into(owner) 
+}
+
+// CHECK-LABEL: sil{{.*}} @$s{{.*}}8wrapFree
+// CHECK:       bb0([[OWNER:%.*]] : $*Owner):
+@_lifetime(borrow owner)
+func wrapFree(_ owner: borrowing Owner) -> View {
+	// CHECK:         [[MARK:%.*]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[OWNER]]
+	// CHECK:         [[METHOD:%.*]] = function_ref @$s{{.*}}8viewInto
+	// CHECK:         apply [[METHOD]]([[MARK]])
+    return viewInto(owner) 
+}
+
+@_lifetime(borrow owner)
+func viewInto(_ owner: borrowing Owner) -> View {
+	fatalError()
+}
+
+struct View: ~Escapable {
+	@_lifetime(borrow owner)
+	static func into(_ owner: borrowing Owner) -> View {
+		fatalError()
+	}
+}
+


### PR DESCRIPTION
Explanation: Fixes a bug where calls into `static` methods with lifetime dependencies would raise incorrect lifetime dependency errors in some circumstances.

Scope: Bug fix.

Issue: rdar://179057474

Risk: Low. There is a small fix to match SILGen's handling of lifetime dependencies to how they are encoded in the AST for static methods.

Reviewed by: @aidan-hall, @kavon 

Testing: Swift CI, test case from bug report