### PR TITLE
Macros: Propagate @available, @usableFromInline, and @_spi through @TaskLocal

### DIFF
--- a/lib/Macros/Sources/SwiftMacros/TaskLocalMacro.swift
+++ b/lib/Macros/Sources/SwiftMacros/TaskLocalMacro.swift
@@ -18,7 +18,15 @@ import SwiftDiagnostics
 ///
 /// It introduces a peer `static let $name: TaskLocal<Type>` as well as a getter
 /// that accesses the task local storage.
-public enum TaskLocalMacro {}
+public enum TaskLocalMacro {
+  /// Attributes to copy onto the synthesized `$name` peer.
+  static let attributesToCopy: [String] = [
+    "usableFromInline",
+    "available",
+    "_spi",
+    "_spi_available",
+  ]
+}
 
 extension TaskLocalMacro: PeerMacro {
   public static func expansion(
@@ -78,6 +86,17 @@ extension TaskLocalMacro: PeerMacro {
     // Copy access modifiers
     let access = varDecl.accessControlModifiers
 
+    // Keep the projected property visible anywhere the original is.
+    let attributes = varDecl.attributes.filter { element in
+      guard let attribute = element.as(AttributeSyntax.self) else {
+        return false
+      }
+      if let identifier = attribute.attributeName.as(IdentifierTypeSyntax.self) {
+        return Self.attributesToCopy.contains(identifier.name.text)
+      }
+      return Self.attributesToCopy.contains(attribute.attributeName.trimmed.description)
+    }
+
     // If the property is global, do not prefix the synthesised decl with 'static'
     let isGlobal = context.lexicalContext.isEmpty
     let staticKeyword: TokenSyntax?
@@ -89,7 +108,7 @@ extension TaskLocalMacro: PeerMacro {
 
     return [
       """
-      \(access)\(staticKeyword)let $\(name)\(explicitTypeAnnotation) = TaskLocal(wrappedValue: \(initialValue))
+      \(attributes)\(access)\(staticKeyword)let $\(name)\(explicitTypeAnnotation) = TaskLocal(wrappedValue: \(initialValue))
       """
     ]
   }

--- a/test/Concurrency/Macros/task_local_macro_expansion.swift
+++ b/test/Concurrency/Macros/task_local_macro_expansion.swift
@@ -30,6 +30,7 @@ struct Available {
   private static var example: AvailableValue?
 }
 
+// CHECK: @available(OSX 10.9, *)
 // CHECK: private static let $example: TaskLocal<AvailableValue?> = TaskLocal(wrappedValue: nil)
 //
 // CHECK:  {
@@ -37,3 +38,41 @@ struct Available {
 // CHECK:      $example.get()
 // CHECK:    }
 // CHECK:  }
+
+// '@usableFromInline' should be copied to the synthesized '$name' projected property
+// so that '@inlinable' code can reference it. https://github.com/swiftlang/swift/issues/90093
+@available(SwiftStdlib 5.1, *)
+public struct UsableFromInline {
+  @TaskLocal
+  @usableFromInline
+  internal static var usableVar: Int?
+}
+
+// CHECK: @usableFromInline
+// CHECK: internal static let $usableVar: TaskLocal<Int?>
+
+@available(SwiftStdlib 5.1, *)
+extension UsableFromInline {
+  @inlinable
+  public static func doWork(with newValue: Int, operation: () -> Void) {
+    UsableFromInline.$usableVar.withValue(newValue, operation: operation)
+  }
+}
+
+struct SPIExample {
+  @TaskLocal
+  @_spi(ExampleSPI)
+  public static var spiVar: Int?
+}
+
+// CHECK: @_spi(ExampleSPI)
+// CHECK: public static let $spiVar: TaskLocal<Int?>
+
+struct SPIAvailableExample {
+  @TaskLocal
+  @_spi_available(macOS 10.15, *)
+  public static var spiAvailableVar: Int?
+}
+
+// CHECK: @_spi_available(macOS 10.15, *)
+// CHECK: public static let $spiAvailableVar: TaskLocal<Int?>


### PR DESCRIPTION
## Summary

Propagate visibility-related attributes from `@TaskLocal` properties to the synthesized projected `$name` peer.

This fixes a case where the projected task-local property was missing attributes such as `@available`, `@usableFromInline`, and `@_spi`, which could make valid uses from `@inlinable` or SPI contexts fail.

## Testing

- Added macro expansion regression tests for the newly supported attributes.
- Covered both member and global `@TaskLocal` declarations

Resolves https://github.com/swiftlang/swift/issues/90094 and rdar://180296445