### PR TITLE
[windows][arm64] use lld-link to build the compiler

### DIFF
--- a/lib/CompilerSwiftSyntax/CMakeLists.txt
+++ b/lib/CompilerSwiftSyntax/CMakeLists.txt
@@ -58,6 +58,18 @@ foreach(lib ${compiler_swiftsyntax_libs})
   _add_swift_caching_compile_options(${lib})
 endforeach()
 
+# FIXME(https://github.com/swiftlang/swift/issues/90100): On Windows ARM64 the
+# MSVC linker 'link.exe' aborts with LNK1322 (Cortex-A53 erratum #843419
+# hazard) while linking SyntaxVisitor.swift.obj. Link swift-syntax with
+# lld-link, which emits the hazard workaround.
+if(SWIFT_HOST_VARIANT_SDK STREQUAL "WINDOWS" AND
+   SWIFT_HOST_VARIANT_ARCH STREQUAL "aarch64" AND
+   NOT LLVM_ENABLE_LTO)
+  foreach(lib ${compiler_swiftsyntax_libs})
+    target_link_options(${lib} PRIVATE "-use-ld=lld-link")
+  endforeach()
+endif()
+
 swift_install_in_component(TARGETS ${compiler_swiftsyntax_libs}
   ARCHIVE DESTINATION "lib${LLVM_LIBDIR_SUFFIX}/swift/host/compiler" COMPONENT compiler-swift-syntax-lib
   LIBRARY DESTINATION "lib${LLVM_LIBDIR_SUFFIX}/swift/host/compiler" COMPONENT compiler-swift-syntax-lib

--- a/lib/SwiftSyntax/CMakeLists.txt
+++ b/lib/SwiftSyntax/CMakeLists.txt
@@ -58,6 +58,18 @@ foreach(module ${SWIFT_SYNTAX_MODULES})
   _add_swift_caching_compile_options(${module})
 endforeach()
 
+# FIXME(https://github.com/swiftlang/swift/issues/90100): On Windows ARM64 the
+# MSVC linker 'link.exe' aborts with LNK1322 (Cortex-A53 erratum #843419
+# hazard) while linking SyntaxVisitor.swift.obj. Link swift-syntax with
+# lld-link, which emits the hazard workaround.
+if(SWIFT_HOST_VARIANT_SDK STREQUAL "WINDOWS" AND
+   SWIFT_HOST_VARIANT_ARCH STREQUAL "aarch64" AND
+   NOT LLVM_ENABLE_LTO)
+  foreach(module ${SWIFT_SYNTAX_MODULES})
+    target_link_options(${module} PRIVATE "-use-ld=lld-link")
+  endforeach()
+endif()
+
 # Install shared runtime libraries
 if(CMAKE_SYSTEM_NAME MATCHES Windows)
   swift_install_in_component(TARGETS ${SWIFT_SYNTAX_MODULES}


### PR DESCRIPTION
This patch fixes building the toolchain on ARM64 Windows while linking the Stage 0 compiler:
```
fatal error LNK1322: cannot avoid potential ARM hazard (Cortex-A53 MPCore processor bug #843419) in section 0x1; please consider using compiler option /Gy if it was not used
```

This is a similar fix as 034a15846a2a638d4d9aee258fef88f2f9acaa50.

This is a workaround for https://github.com/swiftlang/swift/issues/90100.