### PR TITLE
[Concurrency] Downgrade preconcurrency sendable proto + non-sendable superclass

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -7589,6 +7589,12 @@ bool swift::checkSendableConformance(
   bool wasImplied = (conformance->getSourceKind() ==
                      ConformanceEntryKind::Implied);
 
+  // If Sendable came from a `@preconcurrency` protocol the error
+  // should be downgraded even with strict concurrency checking to
+  // allow clients time to address the new requirement.
+  bool impliedByPreconcurrencyProtocol =
+      check == SendableCheck::ImpliedByPreconcurrencyProtocol;
+
   // Sendable can only be used in the same source file.
   auto conformanceDecl = conformanceDC->getAsDecl();
   SendableCheckContext checkContext(conformanceDC, check);
@@ -7605,7 +7611,8 @@ bool swift::checkSendableConformance(
     if (!(nominal->hasClangNode() && wasImplied)) {
       conformanceDecl
           ->diagnose(diag::concurrent_value_outside_source_file, nominal)
-          .limitBehaviorUntilLanguageMode(behavior, LanguageMode::v6);
+          .limitBehaviorWithPreconcurrency(
+              behavior, impliedByPreconcurrencyProtocol, LanguageMode::v6);
 
       if (behavior == DiagnosticBehavior::Unspecified)
         return true;
@@ -7618,9 +7625,12 @@ bool swift::checkSendableConformance(
     // A non-final class cannot conform to `Sendable` unless it is protected by
     // global actor isolation.
     if (!classDecl->isSemanticallyFinal() && !isGlobalActorIsolated) {
-      classDecl->diagnose(diag::concurrent_value_nonfinal_class,classDecl->getName())
+      classDecl
+          ->diagnose(diag::concurrent_value_nonfinal_class,
+                     classDecl->getName())
           .fixItInsert(classDecl->getStartLoc(), "final ")
-          .limitBehaviorUntilLanguageMode(behavior, LanguageMode::v6);
+          .limitBehaviorWithPreconcurrency(
+              behavior, impliedByPreconcurrencyProtocol, LanguageMode::v6);
 
       if (behavior == DiagnosticBehavior::Unspecified)
         return true;
@@ -7644,12 +7654,16 @@ bool swift::checkSendableConformance(
             conformanceDecl
                 ->diagnose(diag::concurrent_value_nonsendable_superclass,
                            classDecl->getName())
-                .warnUntilLanguageMode(LanguageMode::future);
+                .limitBehaviorWithPreconcurrency(
+                    DiagnosticBehavior::Warning,
+                    impliedByPreconcurrencyProtocol, LanguageMode::future);
           } else {
             conformanceDecl
                 ->diagnose(diag::concurrent_value_nonsendable_superclass,
                            classDecl->getName())
-                .limitBehaviorUntilLanguageMode(behavior, LanguageMode::v6);
+                .limitBehaviorWithPreconcurrency(
+                    behavior, impliedByPreconcurrencyProtocol,
+                    LanguageMode::v6);
             isError = behavior == DiagnosticBehavior::Unspecified;
           }
 

--- a/test/Concurrency/concurrency_warnings.swift
+++ b/test/Concurrency/concurrency_warnings.swift
@@ -17,7 +17,7 @@ let rs = GlobalCounter() // expected-warning {{let 'rs' is not concurrency-safe 
 
 import GlobalVariables
 
-class MyError: Error { // expected-warning{{non-final class 'MyError' cannot conform to the 'Sendable' protocol; this is an error in the Swift 6 language mode}}
+class MyError: Error { // expected-warning{{non-final class 'MyError' cannot conform to the 'Sendable' protocol}}
   var storage = 0 // expected-warning{{stored property 'storage' of 'Sendable'-conforming class 'MyError' is mutable}}
 }
 

--- a/test/Concurrency/sendable_conformance_checking.swift
+++ b/test/Concurrency/sendable_conformance_checking.swift
@@ -219,11 +219,22 @@ class OtherIsolatedSendableSubclass: NonSendableSuperclass, Sendable {}
 protocol RefinesSendable: Sendable {}
 
 @available(SwiftStdlib 5.1, *)
+@preconcurrency protocol PreconcurrencyRefinesSendable: Sendable {}
+
+@available(SwiftStdlib 5.1, *)
 @MainActor
 class IsolatedImpliedSendableSubclass: NonSendableSuperclass, RefinesSendable {}
 // expected-warning@-1:7 {{class 'IsolatedImpliedSendableSubclass' cannot conform to the 'Sendable' protocol; this will be an error in a future Swift language mode}}
 // expected-note@-2:7 {{a 'Sendable' class cannot inherit from a non-Sendable class}}
 // expected-note@-3:40 {{inherits from non-Sendable class 'NonSendableSuperclass'}}
+
+// Warning even in future language version due to preconcurrency implied conformance.
+@available(SwiftStdlib 5.1, *)
+@MainActor
+class IsolatedPreconcurrencySendableSubclass: NonSendableSuperclass, PreconcurrencyRefinesSendable {}
+// expected-warning@-1:7 {{class 'IsolatedPreconcurrencySendableSubclass' cannot conform to the 'Sendable' protocol}}
+// expected-note@-2:7 {{a 'Sendable' class cannot inherit from a non-Sendable class}}
+// expected-note@-3:47 {{inherits from non-Sendable class 'NonSendableSuperclass'}}
 
 @available(SwiftStdlib 5.1, *)
 @MainActor

--- a/test/Concurrency/sendable_objc_protocol_attr.swift
+++ b/test/Concurrency/sendable_objc_protocol_attr.swift
@@ -41,7 +41,7 @@ extension MyObjCProtocol {
 }
 
 class K : NSObject, MyObjCProtocol {
-  // expected-warning@-1 {{non-final class 'K' cannot conform to the 'Sendable' protocol; this is an error in the Swift 6 language mode}}
+  // expected-warning@-1 {{non-final class 'K' cannot conform to the 'Sendable' protocol}}
   let test: String = "k"
 }
 
@@ -50,7 +50,7 @@ class UncheckedK : NSObject, MyObjCProtocol, @unchecked Sendable { // ok
 }
 
 class KRefined : NSObject, MyRefinedObjCProtocol {
-  // expected-warning@-1 {{non-final class 'KRefined' cannot conform to the 'Sendable' protocol; this is an error in the Swift 6 language mode}}
+  // expected-warning@-1 {{non-final class 'KRefined' cannot conform to the 'Sendable' protocol}}
   let test: String = "refined"
 }
 
@@ -74,9 +74,8 @@ protocol SwiftRefinesObjCProtocol : MyObjCProtocol {}
 do {
   class A : NSObject {}
 
-  // @preconcurrency P must not silence the warning.
   final class B : A, P {
-    // expected-warning@-1:15 {{class 'B' cannot conform to the 'Sendable' protocol; this is an error in the Swift 6 language mode}}
+    // expected-warning@-1:15 {{class 'B' cannot conform to the 'Sendable' protocol}}
     // expected-note@-2:15 {{a 'Sendable' class cannot inherit from a non-Sendable class}}
     // expected-note@-3:19 {{inherits from non-Sendable class 'A'}}
   }
@@ -88,8 +87,8 @@ do {
   // it gets two similar warnings. Could be nice to collect all the reasons a
   // conformance is illegal into one diagnostic.
   class C : A, MyObjCProtocol {
-    // expected-warning@-1:9 {{non-final class 'C' cannot conform to the 'Sendable' protocol; this is an error in the Swift 6 language mode}}
-    // expected-warning@-2:9 {{class 'C' cannot conform to the 'Sendable' protocol; this is an error in the Swift 6 language mode}}
+    // expected-warning@-1:9 {{non-final class 'C' cannot conform to the 'Sendable' protocol}}
+    // expected-warning@-2:9 {{class 'C' cannot conform to the 'Sendable' protocol}}
     // expected-note@-3:9 {{a 'Sendable' class cannot inherit from a non-Sendable class}}
     // expected-note@-4:13 {{inherits from non-Sendable class 'A'}}
     let test: String = "c"
@@ -106,14 +105,15 @@ do {
   }
 
   final class SwiftRefinedSub : A, SwiftRefinesObjCProtocol {
-    // expected-warning@-1:15 {{class 'SwiftRefinedSub' cannot conform to the 'Sendable' protocol; this is an error in the Swift 6 language mode}}
+    // expected-warning@-1:15 {{class 'SwiftRefinedSub' cannot conform to the 'Sendable' protocol}}
     // expected-note@-2:15 {{a 'Sendable' class cannot inherit from a non-Sendable class}}
     // expected-note@-3:33 {{inherits from non-Sendable class 'A'}}
     let test: String = "refinedSub"
   }
 
+  // Conformance through P is @preconcurrency, downgrading the error even though Q isn't...
   final class PQSub : A, P, Q {
-    // expected-warning@-1:15 {{class 'PQSub' cannot conform to the 'Sendable' protocol; this is an error in the Swift 6 language mode}}
+    // expected-warning@-1:15 {{class 'PQSub' cannot conform to the 'Sendable' protocol}}
     // expected-note@-2:15 {{a 'Sendable' class cannot inherit from a non-Sendable class}}
     // expected-note@-3:23 {{inherits from non-Sendable class 'A'}}
   }


### PR DESCRIPTION
This brings the nonfinal class and nonsendable superclass checks in line with the other sendable class checks, and adds a preconcurrency downgrade when sendable is implied by a preconcurrency conformance. That check is unfortunately lazy (a preconcurrency and a non preconcurrency implied conformance can still downgrade) and order dependent (order of the conformances affects which is discovered), but thats a preexisting issue, and the thinking is that fixing that only for this case is too suprising. In theory, this is a case where we could be more strict than the other checks without a source break (since we currently do no downgrading) but I think this is too confusing...

Resolves rdar://175462525
Resolves #88637

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
