### PR TITLE
[Diagnostics] Apply warnings as errors to preconcurrency diagnostics

### DIFF
--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -771,9 +771,12 @@ namespace swift {
     DiagnosticState(DiagnosticState &&) = default;
     DiagnosticState &operator=(DiagnosticState &&) = default;
 
-    /// If this diagnostic is a warning belonging to a diagnostic group,
-    /// figure out if there is a source-level (`@warn`) control for this group
-    /// for this diagnostic's source location.
+    /// Determine any user-configured behavior for this diagnostic's group,
+    /// combining the command-line warning controls (`-Werror`, `-Wwarning`,
+    /// `-warnings-as-errors`) with any source-level (`@diagnose`) control at
+    /// the diagnostic's source location.
+    ///
+    /// Caller must ensure \p diag's effective behavior is a warning.
     std::optional<DiagnosticBehavior>
     determineUserControlledWarningBehavior(const Diagnostic &diag,
                                            SourceManager &sourceMgr) const;

--- a/include/swift/AST/ModuleLoader.h
+++ b/include/swift/AST/ModuleLoader.h
@@ -283,9 +283,17 @@ public:
   ///
   /// If a non-null \p versionInfo is provided, the module version will be
   /// parsed and populated.
+  ///
+  /// HACK: \p isSourceCanImport is true only for the canonical source query (a
+  /// real import or a source `#if canImport`), which may emit diagnostics and
+  /// record the resolved version. Other queries intend to be side-effect-free
+  /// and must pass false. A diagnostic counts as a side effect here: we can
+  /// query `canImport` while discovering regions for `@diagnose`, so emitting
+  /// one leads to a cycle.
   virtual bool canImportModule(ImportPath::Module named, SourceLoc loc,
                                ModuleVersionInfo *versionInfo,
-                               bool isTestableImport = false) = 0;
+                               bool isTestableImport,
+                               bool isSourceCanImport) = 0;
 
   /// Import a module with the given module path.
   ///

--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -289,7 +289,8 @@ public:
   /// parsed and populated.
   virtual bool canImportModule(ImportPath::Module named, SourceLoc loc,
                                ModuleVersionInfo *versionInfo,
-                               bool isTestableImport = false) override;
+                               bool isTestableImport,
+                               bool isSourceCanImport) override;
 
   /// Import a module with the given module path.
   ///

--- a/include/swift/Frontend/ModuleInterfaceLoader.h
+++ b/include/swift/Frontend/ModuleInterfaceLoader.h
@@ -156,7 +156,7 @@ class ExplicitSwiftModuleLoader : public SerializedModuleLoaderBase {
                   std::unique_ptr<llvm::MemoryBuffer> *moduleSourceInfoBuffer,
                   std::string *cacheKey, bool isCanImportLookup,
                   bool isTestableDependencyLookup, bool &isFramework,
-                  bool &isSystemModule) override;
+                  bool &isSystemModule, bool isSourceCanImport) override;
 
   std::error_code findModuleFilesInDirectory(
       ImportPath::Element ModuleID, const SerializedModuleBaseName &BaseName,
@@ -170,7 +170,8 @@ class ExplicitSwiftModuleLoader : public SerializedModuleLoaderBase {
 
   bool canImportModule(ImportPath::Module named, SourceLoc loc,
                        ModuleVersionInfo *versionInfo,
-                       bool isTestableDependencyLookup = false) override;
+                       bool isTestableDependencyLookup,
+                       bool isSourceCanImport) override;
 
   bool isCached(StringRef DepPath) override { return false; };
 
@@ -211,7 +212,7 @@ class ExplicitCASModuleLoader : public SerializedModuleLoaderBase {
                   std::unique_ptr<llvm::MemoryBuffer> *moduleSourceInfoBuffer,
                   std::string *cacheKey, bool isCanImportLookup,
                   bool isTestableDependencyLookup, bool &isFramework,
-                  bool &isSystemModule) override;
+                  bool &isSystemModule, bool isSourceCanImport) override;
 
   std::error_code findModuleFilesInDirectory(
       ImportPath::Element ModuleID, const SerializedModuleBaseName &BaseName,
@@ -225,7 +226,8 @@ class ExplicitCASModuleLoader : public SerializedModuleLoaderBase {
 
   bool canImportModule(ImportPath::Module named, SourceLoc loc,
                        ModuleVersionInfo *versionInfo,
-                       bool isTestableDependencyLookup = false) override;
+                       bool isTestableDependencyLookup,
+                       bool isSourceCanImport) override;
 
   struct Implementation;
   Implementation &Impl;

--- a/include/swift/Sema/SourceLoader.h
+++ b/include/swift/Sema/SourceLoader.h
@@ -59,7 +59,8 @@ public:
   virtual bool
   canImportModule(ImportPath::Module named, SourceLoc loc,
                   ModuleVersionInfo *versionInfo,
-                  bool isTestableDependencyLookup = false) override;
+                  bool isTestableDependencyLookup,
+                  bool isSourceCanImport) override;
 
   /// Import a module with the given module path.
   ///

--- a/include/swift/Serialization/ScanningLoaders.h
+++ b/include/swift/Serialization/ScanningLoaders.h
@@ -73,7 +73,8 @@ private:
 
   bool canImportModule(ImportPath::Module named, SourceLoc loc,
                        ModuleVersionInfo *versionInfo,
-                       bool isTestableImport) override;
+                       bool isTestableImport,
+                       bool isSourceCanImport) override;
 
   bool handlePossibleTargetMismatch(
       SourceLoc sourceLocation,

--- a/include/swift/Serialization/SerializedModuleLoader.h
+++ b/include/swift/Serialization/SerializedModuleLoader.h
@@ -99,6 +99,8 @@ protected:
   void collectVisibleTopLevelModuleNamesImpl(SmallVectorImpl<Identifier> &names,
                                              StringRef extension) const;
 
+  /// \p isSourceCanImport is threaded to the target-mismatch guard below; see
+  /// \c ModuleLoader::canImportModule.
   virtual bool findModule(
       ImportPath::Element moduleID, SmallVectorImpl<char> *moduleInterfacePath,
       SmallVectorImpl<char> *moduleInterfaceSourcePath,
@@ -106,7 +108,8 @@ protected:
       std::unique_ptr<llvm::MemoryBuffer> *moduleDocBuffer,
       std::unique_ptr<llvm::MemoryBuffer> *moduleSourceInfoBuffer,
       std::string *CacheKey, bool isCanImportLookup,
-      bool isTestableDependencyLookup, bool &isFramework, bool &isSystemModule);
+      bool isTestableDependencyLookup, bool &isFramework, bool &isSystemModule,
+      bool isSourceCanImport);
 
   /// Attempts to search the provided directory for a loadable serialized
   /// .swiftmodule with the provided `ModuleFilename`. Subclasses must
@@ -235,7 +238,8 @@ public:
   virtual bool
   canImportModule(ImportPath::Module named, SourceLoc loc,
                   ModuleVersionInfo *versionInfo,
-                  bool isTestableDependencyLookup = false) override;
+                  bool isTestableDependencyLookup,
+                  bool isSourceCanImport) override;
 
   /// Import a module with the given module path.
   ///
@@ -363,7 +367,8 @@ public:
 
   bool canImportModule(ImportPath::Module named, SourceLoc loc,
                        ModuleVersionInfo *versionInfo,
-                       bool isTestableDependencyLookup = false) override;
+                       bool isTestableDependencyLookup,
+                       bool isSourceCanImport) override;
 
   ModuleDecl *
   loadModule(SourceLoc importLoc,

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -2895,7 +2895,9 @@ bool ASTContext::canImportModuleImpl(
           ModuleLoader::ModuleVersionInfo &bestUnderlyingVersionInfo) -> bool {
     for (auto &importer : getImpl().ModuleLoaders) {
       ModuleLoader::ModuleVersionInfo versionInfo;
-      if (!importer->canImportModule(ModuleName, loc, &versionInfo))
+      if (!importer->canImportModule(ModuleName, loc, &versionInfo,
+                                     /*isTestableImport=*/false,
+                                     isSourceCanImport))
         continue; // The loader can't find the module.
 
       if (validateVersion(bestVersionInfo, versionInfo,
@@ -2923,7 +2925,9 @@ bool ASTContext::canImportModuleImpl(
   auto lookupModule = [&]() -> bool {
     for (auto &importer : getImpl().ModuleLoaders) {
       ModuleLoader::ModuleVersionInfo versionInfo;
-      if (!importer->canImportModule(ModuleName, loc, &versionInfo))
+      if (!importer->canImportModule(ModuleName, loc, &versionInfo,
+                                     /*isTestableImport=*/false,
+                                     isSourceCanImport))
         continue; // The loader can't find the module.
       return true;
     }

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -1330,10 +1330,6 @@ DiagnosticBehavior toDiagnosticBehavior(DiagnosticKind kind, bool isFatal) {
 std::optional<DiagnosticBehavior>
 DiagnosticState::determineUserControlledWarningBehavior(
     const Diagnostic &diag, SourceManager &sourceMgr) const {
-  auto &diagInfo = storedDiagnosticInfos[(unsigned)diag.getID()];
-  if (diagInfo.kind != DiagnosticKind::Warning)
-    return std::nullopt;
-
   // Compute a behavior relying strictly on command-line provided
   // `warningGroupBehaviorMap`.
   std::optional<DiagnosticBehavior> userControlledBehavior;

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -2480,7 +2480,8 @@ static llvm::VersionTuple getCurrentVersionFromTBD(llvm::vfs::FileSystem &FS,
 bool ClangImporter::canImportModule(ImportPath::Module modulePath,
                                     SourceLoc loc,
                                     ModuleVersionInfo *versionInfo,
-                                    bool isTestableDependencyLookup) {
+                                    bool isTestableDependencyLookup,
+                                    bool isSourceCanImport) {
   // Look up the top-level module to see if it exists, mapping any -module-alias
   // to the real module name so canImport(<alias>) matches import <alias>.
   auto topModule = modulePath.front();

--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -2316,7 +2316,8 @@ bool ExplicitSwiftModuleLoader::findModule(
     std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer,
     std::unique_ptr<llvm::MemoryBuffer> *ModuleSourceInfoBuffer,
     std::string *cacheKey, bool IsCanImportLookup,
-    bool isTestableDependencyLookup, bool &IsFramework, bool &IsSystemModule) {
+    bool isTestableDependencyLookup, bool &IsFramework, bool &IsSystemModule,
+    bool isSourceCanImport) {
   // Find a module with an actual, physical name on disk, in case
   // -module-alias is used (otherwise same).
   //
@@ -2401,7 +2402,7 @@ std::error_code ExplicitSwiftModuleLoader::findModuleFilesInDirectory(
 
 bool ExplicitSwiftModuleLoader::canImportModule(
     ImportPath::Module path, SourceLoc loc, ModuleVersionInfo *versionInfo,
-    bool isTestableDependencyLookup) {
+    bool isTestableDependencyLookup, bool isSourceCanImport) {
   // FIXME: Swift submodules?
   if (path.hasSubmodule())
     return false;
@@ -2709,7 +2710,8 @@ bool ExplicitCASModuleLoader::findModule(
     std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer,
     std::unique_ptr<llvm::MemoryBuffer> *ModuleSourceInfoBuffer,
     std::string *CacheKey, bool IsCanImportLookup,
-    bool IsTestableDependencyLookup, bool &IsFramework, bool &IsSystemModule) {
+    bool IsTestableDependencyLookup, bool &IsFramework, bool &IsSystemModule,
+    bool isSourceCanImport) {
   // Find a module with an actual, physical name on disk, in case
   // -module-alias is used (otherwise same).
   //
@@ -2774,7 +2776,7 @@ std::error_code ExplicitCASModuleLoader::findModuleFilesInDirectory(
 
 bool ExplicitCASModuleLoader::canImportModule(
     ImportPath::Module path, SourceLoc loc, ModuleVersionInfo *versionInfo,
-    bool isTestableDependencyLookup) {
+    bool isTestableDependencyLookup, bool isSourceCanImport) {
   // FIXME: Swift submodules?
   if (path.hasSubmodule())
     return false;

--- a/lib/Sema/SourceLoader.cpp
+++ b/lib/Sema/SourceLoader.cpp
@@ -73,7 +73,8 @@ void SourceLoader::collectVisibleTopLevelModuleNames(
 
 bool SourceLoader::canImportModule(ImportPath::Module path, SourceLoc loc,
                                    ModuleVersionInfo *versionInfo,
-                                   bool isTestableDependencyLookup) {
+                                   bool isTestableDependencyLookup,
+                                   bool isSourceCanImport) {
   // FIXME: Swift submodules?
   if (path.hasSubmodule())
     return false;

--- a/lib/Serialization/ScanningLoaders.cpp
+++ b/lib/Serialization/ScanningLoaders.cpp
@@ -86,7 +86,7 @@ std::error_code SwiftModuleScanner::findModuleFilesInDirectory(
 
 bool SwiftModuleScanner::canImportModule(
     ImportPath::Module path, SourceLoc loc, ModuleVersionInfo *versionInfo,
-    bool isTestableDependencyLookup) {
+    bool isTestableDependencyLookup, bool isSourceCanImport) {
   if (path.hasSubmodule())
     return false;
 
@@ -105,7 +105,7 @@ bool SwiftModuleScanner::canImportModule(
   }
 
   return SerializedModuleLoaderBase::canImportModule(
-      path, loc, versionInfo, isTestableDependencyLookup);
+      path, loc, versionInfo, isTestableDependencyLookup, isSourceCanImport);
 }
 
 bool SwiftModuleScanner::handlePossibleTargetMismatch(
@@ -427,7 +427,8 @@ SwiftModuleScanner::lookupSwiftModule(Identifier moduleName,
   // Execute the check to determine whether there is a module with this name
   // that we can import. This check will populate the result fields if one is
   // found.
-  canImportModule(modulePath, SourceLoc(), nullptr, isTestableImport);
+  canImportModule(modulePath, SourceLoc(), nullptr, isTestableImport,
+                  /*isSourceCanImport=*/true);
   return SwiftModuleScannerQueryResult(
       std::move(foundDependencyInfo), std::move(incompatibleCandidates));
 }

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -736,7 +736,8 @@ bool SerializedModuleLoaderBase::findModule(
     std::unique_ptr<llvm::MemoryBuffer> *moduleDocBuffer,
     std::unique_ptr<llvm::MemoryBuffer> *moduleSourceInfoBuffer,
     std::string *cacheKey, bool isCanImportLookup,
-    bool isTestableDependencyLookup, bool &isFramework, bool &isSystemModule) {
+    bool isTestableDependencyLookup, bool &isFramework, bool &isSystemModule,
+    bool isSourceCanImport) {
   // Find a module with an actual, physical name on disk, in case
   // -module-alias is used (otherwise same).
   //
@@ -793,7 +794,12 @@ bool SerializedModuleLoaderBase::findModule(
 
     // We can only get here if all targetFileNamePairs failed with
     // 'std::errc::no_such_file_or_directory'.
-    if (firstAbsoluteBaseName &&
+    //
+    // A side-effect-free `canImport` probe (e.g. the secondary `#if`-region
+    // walk that resolves `@diagnose`) isn't the canonical source `canImport` so
+    // don't diagnose for it. Emitting was recursing through `#if` evaluation.
+    const bool isCanImportProbe = isCanImportLookup && !isSourceCanImport;
+    if (firstAbsoluteBaseName && !isCanImportProbe &&
         handlePossibleTargetMismatch(moduleID.Loc, moduleName,
                                      *firstAbsoluteBaseName, isCanImportLookup))
       return SearchResult::Error;
@@ -1503,7 +1509,7 @@ std::unique_ptr<llvm::MemoryBuffer> swift::extractEmbeddedBridgingHeaderContent(
 
 bool SerializedModuleLoaderBase::canImportModule(
     ImportPath::Module path, SourceLoc loc, ModuleVersionInfo *versionInfo,
-    bool isTestableDependencyLookup) {
+    bool isTestableDependencyLookup, bool isSourceCanImport) {
   // FIXME: Swift submodules?
   if (path.hasSubmodule())
     return false;
@@ -1521,7 +1527,7 @@ bool SerializedModuleLoaderBase::canImportModule(
                  /*moduleDocBuffer=*/nullptr,
                  /*moduleSourceInfoBuffer=*/nullptr, /*cacheKey=*/nullptr,
                  /*isCanImportLookup=*/true, isTestableDependencyLookup,
-                 isFramework, isSystemModule);
+                 isFramework, isSystemModule, isSourceCanImport);
   // If we cannot find the module, don't continue.
   if (!found)
     return false;
@@ -1577,7 +1583,7 @@ bool SerializedModuleLoaderBase::canImportModule(
 
 bool MemoryBufferSerializedModuleLoader::canImportModule(
     ImportPath::Module path, SourceLoc loc, ModuleVersionInfo *versionInfo,
-    bool isTestableDependencyLookup) {
+    bool isTestableDependencyLookup, bool isSourceCanImport) {
   // FIXME: Swift submodules?
   if (path.hasSubmodule())
     return false;
@@ -1620,7 +1626,7 @@ SerializedModuleLoaderBase::loadModule(SourceLoc importLoc,
                   &moduleSourceInfoInputBuffer, &cacheKey,
                   /*isCanImportLookup=*/false,
                   /*isTestableDependencyLookup=*/false, isFramework,
-                  isSystemModule)) {
+                  isSystemModule, /*isSourceCanImport=*/false)) {
     return nullptr;
   }
 

--- a/test/Serialization/can-import-invalid-swiftmodule.swift
+++ b/test/Serialization/can-import-invalid-swiftmodule.swift
@@ -1,0 +1,13 @@
+// RUN: %empty-directory(%t)
+// RUN: echo 'C is for Cookie' > %t/Garbage.swiftmodule
+// RUN: %target-swift-frontend %s -typecheck -I %t 2>&1 | %FileCheck %s
+
+// Invalid .swiftmodule found during the `#if canImport` needs to warn, but that
+// reenters `#if` region resolution to determine the behavior of that warning. Test
+// that it doesn't recurse forever!
+
+// CHECK: {{.*}} warning: canImport() evaluated to false due to invalid swiftmodule: {{.*}}Garbage.swiftmodule
+
+#if canImport(Garbage)
+  import Garbage
+#endif

--- a/test/diagnostics/warnings_as_errors_preconcurrency.swift
+++ b/test/diagnostics/warnings_as_errors_preconcurrency.swift
@@ -1,0 +1,16 @@
+// RUN: %target-swift-frontend -typecheck -verify -verify-additional-prefix wae- -strict-concurrency=complete -warnings-as-errors %s
+// RUN: %target-swift-frontend -typecheck -verify -verify-additional-prefix nowae- -strict-concurrency=complete %s
+
+// REQUIRES: concurrency
+
+// Preconcurrency downgrades change the effective behavior of diagnostics without
+// wrapping them. Check that WAE applies to errors which were downgraded to
+// warnings.
+
+class NS {} // expected-note {{class 'NS' does not conform to the 'Sendable' protocol}}
+
+@preconcurrency func takeSendable<T: Sendable>(_ s: T) {}
+
+takeSendable(NS())
+// expected-wae-error@-1 {{type 'NS' does not conform to the 'Sendable' protocol}}
+// expected-nowae-warning@-2 {{type 'NS' does not conform to the 'Sendable' protocol}}


### PR DESCRIPTION
This commit stops filtering out diagnostics that are defined to be errors from the WAE handling. That check was wrong when a diagnostic that is normally an error had been downgraded but not wrapped, like in the case of preconcurrency.

Resolves rdar://175566663

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
