### PR TITLE
[6.4] MoveOnlyChecker: look through destructure_tuple in eraseMarkWithCopiedOperand

### DIFF
--- a/lib/SILOptimizer/Mandatory/MoveOnlyObjectCheckerUtils.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyObjectCheckerUtils.cpp
@@ -507,6 +507,23 @@ bool MoveOnlyObjectCheckerPImpl::eraseMarkWithCopiedOperand(
       orig = markDep->getValue();
       continue;
     }
+    // Look through `destructure_tuple` so that a bindBorrow `copy_value`
+    // of a destructured tuple element (e.g., the `let l, let r` binding
+    // under a `borrowing` switch over a `~Copyable` enum case with a tuple
+    // payload) finds its underlying @guaranteed source. Destructure
+    // results are `MultipleValueInstruction` results, not the defining
+    // instruction itself, so look through `getDefiningInstruction()`.
+    //
+    // `destructure_struct` is intentionally NOT handled here: SILGen's
+    // bindBorrow path doesn't reach it from any source-level construct
+    // today (noncopyable struct payloads bind as a whole; positional
+    // struct destructuring isn't accepted in switch patterns). Add it
+    // alongside a regression test if a new SILGen path ever does emit it.
+    if (auto *destructure = dyn_cast_or_null<DestructureTupleInst>(
+            orig->getDefiningInstruction())) {
+      orig = destructure->getOperand();
+      continue;
+    }
     break;
   }
 

--- a/test/Interpreter/borrowing_switch_noncopyable_payload.swift
+++ b/test/Interpreter/borrowing_switch_noncopyable_payload.swift
@@ -1,0 +1,45 @@
+// RUN: %target-run-simple-swift(-Xfrontend -disable-availability-checking)
+// RUN: %target-run-simple-swift(-O -Xfrontend -disable-availability-checking)
+
+// REQUIRES: executable_test
+
+// UNSUPPORTED: back_deployment_runtime || use_os_stdlib
+
+// Regression test for a missed-copy bug in the move-only object checker.
+// The cleanup that erases the SILGen-introduced `copy_value` feeding into
+// a `mark_unresolved_non_copyable_value [strict] [no_consume_or_assign]`
+// (the `bindBorrow` "notional copy" pattern) only looked through a fixed
+// set of producers when locating the underlying `@guaranteed` source.
+// `destructure_tuple` was missing from that set, so a `let l, let r`
+// binding under a `borrowing` switch over a `~Copyable` enum case with a
+// tuple payload would leave the copy_value alive after move-only checking,
+// at which point the missed-copy detector reported the generic compiler
+// bug diagnostic.
+//
+// Single-payload bindings (`case .single(let b)`) were unaffected because
+// the source there is the `@guaranteed` block argument directly.
+
+struct Box: ~Copyable {
+  var x: Int
+}
+
+enum E: ~Copyable {
+  case empty
+  case single(Box)
+  case pair(Box, Box)
+}
+
+func sum(_ e: borrowing E) -> Int {
+  switch e {
+  case .empty:
+    return 0
+  case .single(let b):
+    return b.x
+  case .pair(let l, let r):
+    return l.x + r.x
+  }
+}
+
+precondition(sum(.empty) == 0)
+precondition(sum(.single(Box(x: 42))) == 42)
+precondition(sum(.pair(Box(x: 3), Box(x: 4))) == 7)

--- a/test/SILOptimizer/moveonly_borrowing_switch_tuple_payload.swift
+++ b/test/SILOptimizer/moveonly_borrowing_switch_tuple_payload.swift
@@ -1,0 +1,71 @@
+// RUN: %target-swift-frontend -emit-sil -verify %s
+
+// Negative coverage for the `bindBorrow` tuple-payload destructure fix in
+// `MoveOnlyObjectCheckerUtils.cpp::eraseMarkWithCopiedOperand`. After the
+// fix, the SILGen-introduced `copy_value` for each destructured component
+// is correctly elided when the binding is genuinely borrowed, but the
+// underlying `mark_unresolved_non_copyable_value [no_consume_or_assign]`
+// must still reject any actual consume of the binding.
+//
+// Pins the proper "borrowed and cannot be consumed" + "consumed here"
+// diagnostic pair (rather than a regression to the catch-all "compiler
+// bug" missed-copy error or no diagnostic at all) for body-consume of
+// tuple-destructured `let l, let r` bindings.
+//
+// (A separate, pre-existing diagnostic-quality bug causes consumes in the
+// `where` clause of a tuple-destructured case to fall through to the
+// catch-all "escaping closure" diagnostic for the second binding; not
+// covered here because it is unrelated to this fix.)
+
+struct Box: ~Copyable { var x: Int }
+
+enum Pair: ~Copyable {
+    case both(Box, Box)
+}
+
+func eat(_: consuming Box) {}
+func borrow(_: borrowing Box) {}
+
+// Borrow-only uses must compile cleanly. Without the fix, this would
+// regress to the missed-copy "compiler bug" diagnostic on each binding.
+func borrowOnly(_ p: borrowing Pair) {
+    switch p {
+    case .both(let l, let r):
+        borrow(l)
+        borrow(r)
+    }
+}
+
+// Wildcard binding still emits `destructure_tuple` for the case payload
+// and copies just the first element. Without the destructure look-through,
+// this case would also regress to the missed-copy diagnostic.
+func wildcardBinding(_ p: borrowing Pair) {
+    switch p {
+    case .both(let l, _):
+        borrow(l)
+    }
+}
+
+// Consuming both destructured components in the body must report the
+// proper "borrowed and cannot be consumed" + "consumed here" diagnostic
+// for each binding.
+func consumeBothInBody(_ p: borrowing Pair) {
+    switch p {
+    case .both(let l, // expected-error{{'l' is borrowed and cannot be consumed}}
+               let r): // expected-error{{'r' is borrowed and cannot be consumed}}
+        eat(l) // expected-note{{consumed here}}
+        eat(r) // expected-note{{consumed here}}
+    }
+}
+
+// Mixed: consuming one element while borrowing the other must produce
+// the diagnostic only for the consumed binding, leaving the borrowed
+// binding alone.
+func consumeOneBorrowOther(_ p: borrowing Pair) {
+    switch p {
+    case .both(let l, // expected-error{{'l' is borrowed and cannot be consumed}}
+               let r):
+        eat(l) // expected-note{{consumed here}}
+        borrow(r)
+    }
+}


### PR DESCRIPTION
Explanation: Fixes spurious "copy of noncopyable value" errors when pattern-matching non-`Copyable` enums with labeled payloads.

Scope: Bug fix.

Risk: Low. Adds missing handling for a single SIL instruction to the move checker.

Reviewed by: @airspeedswift, @jckarter 

Issue: #88843, rdar://163898757

Testing: Test case from bug report, Swift CI