### PR TITLE
[6.4][Sema] Fix a few places that should use fix impact for invalid reference and invalid AST

### DIFF
--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -1110,8 +1110,10 @@ ConstraintSystem::matchResultBuilder(AnyFunctionRef fn, Type builderType,
   assert(!builderType->hasTypeParameter());
 
   if (InvalidResultBuilderBodies.count(fn)) {
-    (void)recordFix(IgnoreInvalidResultBuilderBody::create(
-        *this, getConstraintLocator(fn.getAbstractClosureExpr())));
+    (void)recordFix(
+        IgnoreInvalidResultBuilderBody::create(
+            *this, getConstraintLocator(fn.getAbstractClosureExpr())),
+        /*impact=*/10);
     return getTypeMatchSuccess();
   }
 
@@ -1128,7 +1130,8 @@ ConstraintSystem::matchResultBuilder(AnyFunctionRef fn, Type builderType,
     if (shouldAttemptFixes() && !isForCodeCompletion()) {
       if (recordFix(IgnoreResultBuilderWithReturnStmts::create(
               *this, builderType,
-              getConstraintLocator(fn.getAbstractClosureExpr()))))
+              getConstraintLocator(fn.getAbstractClosureExpr()))),
+          /*impact=*/10)
         return getTypeMatchFailure(locator);
 
       return getTypeMatchSuccess();

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -708,7 +708,8 @@ namespace {
     /// Records a fix for an invalid AST node, and returns a hole for it.
     Type recordInvalidNode(ASTNode node) {
       CS.recordFix(
-          IgnoreInvalidASTNode::create(CS, CS.getConstraintLocator(node)));
+          IgnoreInvalidASTNode::create(CS, CS.getConstraintLocator(node)),
+          /*impact=*/10);
 
       // Ideally we wouldn't need a type variable here, but we don't have a
       // suitable placeholder originator for all the cases here.

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -9349,7 +9349,8 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyConformsToConstraint(
           auto *fix = AllowInvalidStaticMemberRefOnProtocolMetatype::create(
               *this, memberLoc);
 
-          return recordFix(fix) ? SolutionKind::Error : SolutionKind::Solved;
+          return recordFix(fix, /*impact=*/5) ? SolutionKind::Error
+                                              : SolutionKind::Solved;
         }
       }
 
@@ -9915,7 +9916,7 @@ ConstraintSystem::lookupDependentMember(Type base, AssociatedTypeDecl *assocTy,
     // If the type witness is invalid we'll have emitted an error, record a
     // fix to ensure the solution is marked invalid.
     auto *loc = getConstraintLocator(locator);
-    recordFix(IgnoreInvalidASTNode::create(*this, loc));
+    recordFix(IgnoreInvalidASTNode::create(*this, loc), /*impact=*/10);
     return Type();
   }
 
@@ -11842,7 +11843,8 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyMemberConstraint(
           solveWithNewBaseOrName(baseTy, DeclNameRef::createSubscript());
       // Looks like it was indeed meant to be a subscript operator.
       if (result == SolutionKind::Solved)
-        return recordFix(UseSubscriptOperator::create(*this, locator))
+        return recordFix(UseSubscriptOperator::create(*this, locator),
+                         /*impact=*/5)
                    ? SolutionKind::Error
                    : SolutionKind::Solved;
     }
@@ -12567,7 +12569,8 @@ ConstraintSystem::simplifyDynamicTypeOfConstraint(
     recordAnyTypeVarAsPotentialHole(type2);
 
     recordFix(IgnoreNonMetatypeDynamicType::create(
-        *this, type2, type1, getConstraintLocator(locator)));
+                  *this, type2, type1, getConstraintLocator(locator)),
+              /*impact=*/2);
     return SolutionKind::Solved;
   }
 
@@ -13868,7 +13871,7 @@ ConstraintSystem::simplifyDynamicCallableApplicableFnConstraint(
         *this, desugar2, memberName, /*alreadyDiagnosed=*/false,
         getConstraintLocator(loc, ConstraintLocator::DynamicCallable));
 
-    if (recordFix(fix))
+    if (recordFix(fix, /*impact=*/5))
       return SolutionKind::Error;
 
     recordPotentialHole(tv);

--- a/test/Constraints/result_builder_diags.swift
+++ b/test/Constraints/result_builder_diags.swift
@@ -1079,3 +1079,33 @@ func testNoDuplicateStmtDiags() {
     }
   }
 }
+
+func testInvalidTransforDoesntHideConversionFailure() {
+  @resultBuilder
+  struct BuilderA {
+    static func buildBlock<T>(_ v1: T) -> T { v1 }
+    static func buildBlock<T, U>(_ v1: T, _ v2: U) -> (T, U) { (v1, v2) }
+  }
+
+  func fn(@BuilderA a: () -> Void) {}
+  func fn(@BuilderA b: () -> Void) {}
+  func fn(_: () -> Void) {}
+
+  func test(_: Int) {}
+
+  fn {
+    if true {
+      return
+    }
+
+    test("") // expected-error {{cannot convert value of type 'String' to expected argument type 'Int'}}
+  }
+
+  fn {
+    if true {
+      0
+    }
+
+    test("") // expected-error {{cannot convert value of type 'String' to expected argument type 'Int'}}
+  }
+}

--- a/validation-test/compiler_crashers/SubscriptMisuseFailure-diagnoseAsError-d3bddf.swift
+++ b/validation-test/compiler_crashers/SubscriptMisuseFailure-diagnoseAsError-d3bddf.swift
@@ -1,2 +1,0 @@
-// RUN: not --crash %target-swift-frontend -typecheck %s
-"" [.subscript

--- a/validation-test/compiler_crashers_fixed/SubscriptMisuseFailure-diagnoseAsError-d3bddf.swift
+++ b/validation-test/compiler_crashers_fixed/SubscriptMisuseFailure-diagnoseAsError-d3bddf.swift
@@ -1,0 +1,2 @@
+// RUN: not %target-swift-frontend -typecheck %s
+"" [.subscript


### PR DESCRIPTION
- Explanation:

  Fixes a few issues with scoring that lead to incorrect diagnostics.

  - Invalid base type fixes should have non-default score
  - Failing to apply a transform due to capability or other issues should be marked as invalid AST because otherwise it could hide issues with other overloads that are valid.

- Resolves: rdar://180275757

- Main branch PR: https://github.com/swiftlang/swift/pull/90059

- Risk: Very low. The changes affect only diagnostics and should have no effect on valid code.

- Reviewed By: @hamishknight  

- Testing: Added new test-cases to the suite.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
