### PR TITLE
[test] Remove some redundant feature flags

### DIFF
--- a/test/Macros/lit.local.cfg
+++ b/test/Macros/lit.local.cfg
@@ -1,7 +1,3 @@
-# '-enable-experimental-feature Macros' requires an asserts build.
-if 'asserts' not in config.available_features:
-    config.unsupported = True
-
 config.subsitutions = list(config.substitutions)
 
 def get_target_os():

--- a/test/Macros/macro_attribute_expansiondecl.swift
+++ b/test/Macros/macro_attribute_expansiondecl.swift
@@ -1,5 +1,4 @@
 // REQUIRES: swift_swift_parser, OS=macosx
-// REQUIRES: swift_feature_FreestandingMacros
 
 // RUN: %empty-directory(%t)
 // RUN: mkdir -p %t/src
@@ -17,7 +16,6 @@
 
 // RUN: %target-swift-frontend \
 // RUN:   -typecheck -verify \
-// RUN:   -enable-experimental-feature FreestandingMacros \
 // RUN:   -parse-as-library \
 // RUN:   -dump-macro-expansions \
 // RUN:   -plugin-path %t/plugins \

--- a/test/Macros/macro_plugin_broken.swift
+++ b/test/Macros/macro_plugin_broken.swift
@@ -1,5 +1,4 @@
 // REQUIRES: swift_swift_parser
-// REQUIRES: swift_feature_Macros
 
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
@@ -11,7 +10,7 @@
 
 // RUN: not %target-swift-frontend \
 // RUN:   -typecheck \
-// RUN:   -swift-version 5 -enable-experimental-feature Macros \
+// RUN:   -swift-version 5 \
 // RUN:   -load-plugin-executable %t/broken-plugin#TestPlugin \
 // RUN:   -module-name MyApp \
 // RUN:   -serialize-diagnostics-path %t/macro_expand.dia \

--- a/test/Macros/macro_plugin_error.swift
+++ b/test/Macros/macro_plugin_error.swift
@@ -1,5 +1,4 @@
 // REQUIRES: swift_swift_parser
-// REQUIRES: swift_feature_Macros
 
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
@@ -8,7 +7,7 @@
 
 // RUN: env SWIFT_DUMP_PLUGIN_MESSAGING=1 %target-swift-frontend \
 // RUN:   -typecheck -verify \
-// RUN:   -swift-version 5 -enable-experimental-feature Macros \
+// RUN:   -swift-version 5 \
 // RUN:   -load-plugin-executable %t/mock-plugin#TestPlugin \
 // RUN:   -module-name MyApp \
 // RUN:   %t/test.swift \

--- a/test/Macros/macro_plugin_server.swift
+++ b/test/Macros/macro_plugin_server.swift
@@ -1,5 +1,4 @@
 // REQUIRES: swift_swift_parser
-// REQUIRES: swift_feature_Macros
 
 // RUN: %empty-directory(%t)
 // RUN: %empty-directory(%t/plugins)
@@ -23,7 +22,7 @@
 
 // RUN: env SWIFT_DUMP_PLUGIN_MESSAGING=1 %target-swift-frontend \
 // RUN:   -typecheck -verify \
-// RUN:   -swift-version 5 -enable-experimental-feature Macros \
+// RUN:   -swift-version 5 \
 // RUN:   -external-plugin-path %t/plugins#%swift-plugin-server \
 // RUN:   -Rmacro-loading -verify-ignore-unknown \
 // RUN:   -module-name MyApp \
@@ -39,7 +38,7 @@
 
 // RUN: env SWIFT_DUMP_PLUGIN_MESSAGING=1 %target-swift-frontend \
 // RUN:   -typecheck -verify \
-// RUN:   -swift-version 5 -enable-experimental-feature Macros \
+// RUN:   -swift-version 5 \
 // RUN:   -external-plugin-path %t/alt#%swift-plugin-server \
 // RUN:   -load-resolved-plugin lib-do-not-exist.dylib##MacroDefinition \
 // RUN:   -load-resolved-plugin %t/plugins/%target-library-name(MacroDefinition)#%swift-plugin-server#MacroDefinition \

--- a/test/Macros/macro_vfs.swift
+++ b/test/Macros/macro_vfs.swift
@@ -1,5 +1,4 @@
 // REQUIRES: swift_swift_parser
-// REQUIRES: swift_feature_Macros
 
 // RUN: %empty-directory(%t)
 // RUN: %empty-directory(%t/hidden)
@@ -9,8 +8,8 @@
 // RUN: %host-build-swift -swift-version 5 -emit-library -o %t/hidden/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath -swift-version 5
 
 // Check that loading plugins respects VFS overlays
-// RUN: %target-swift-frontend -typecheck -verify -swift-version 5 -enable-experimental-feature Macros -load-plugin-library %t/vfs/%target-library-name(MacroDefinition) -module-name MacroUser -DTEST_DIAGNOSTICS %t/macro.swift -vfsoverlay %t/overlay.yaml
-// RUN: %target-swift-frontend -typecheck -verify -swift-version 5 -enable-experimental-feature Macros -plugin-path %t/vfs -module-name MacroUser -DTEST_DIAGNOSTICS %t/macro.swift -vfsoverlay %t/overlay.yaml
+// RUN: %target-swift-frontend -typecheck -verify -swift-version 5 -load-plugin-library %t/vfs/%target-library-name(MacroDefinition) -module-name MacroUser -DTEST_DIAGNOSTICS %t/macro.swift -vfsoverlay %t/overlay.yaml
+// RUN: %target-swift-frontend -typecheck -verify -swift-version 5 -plugin-path %t/vfs -module-name MacroUser -DTEST_DIAGNOSTICS %t/macro.swift -vfsoverlay %t/overlay.yaml
 
 //--- macro.swift
 // expected-no-diagnostics

--- a/test/Macros/serialize_plugin_search_paths.swift
+++ b/test/Macros/serialize_plugin_search_paths.swift
@@ -4,7 +4,7 @@
 // RUN:   -emit-executable -emit-module \
 // RUN:   -Xfrontend -serialize-debugging-options \
 // RUN:   -module-name MyApp \
-// RUN:   -swift-version 5 -enable-experimental-feature Macros \
+// RUN:   -swift-version 5 \
 // RUN:   -plugin-path %t/plugins \
 // RUN:   -external-plugin-path %t/plugins#%swift-plugin-server \
 // RUN:   -load-plugin-library %t/%target-library-name(MacroDefinition) \
@@ -12,7 +12,6 @@
 
 // RUN: %lldb-moduleimport-test -verbose -dump-module %t/a.out | %FileCheck %s
 
-// REQUIRES: swift_feature_Macros
 // CHECK: - Plugin Search Options:
 // CHECK:     -plugin-path {{.*}}plugins
 // CHECK:     -external-plugin-path {{.*}}plugins#{{.*}}swift-plugin-server


### PR DESCRIPTION
Macros are no longer experimental so we don't need to pass these flags. Additionally, the tests should be able to run on noasserts configurations.