### PR TITLE
Support ObjC protocols  in SIL thick_to_objc_metatype

### DIFF
--- a/include/swift/AST/FeatureAvailability.def
+++ b/include/swift/AST/FeatureAvailability.def
@@ -92,5 +92,7 @@ FEATURE(ClearSensitive,                                 FUTURE)
 FEATURE(UpdatePureObjCClassMetadata,                    FUTURE)
 // TODO: CoroutineAccessors: Change to correct version number.
 FEATURE(CoroutineAccessors,                             FUTURE)
+FEATURE(GetObjCMetatypeFromMetadata,                    FUTURE)
+
 #undef FEATURE
 #undef FUTURE

--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -566,6 +566,9 @@ SWIFT_RUNTIME_EXPORT
 const ClassMetadata *
 swift_getObjCClassFromMetadata(const Metadata *theClass);
 
+SWIFT_RUNTIME_EXPORT
+id swift_getObjCMetatypeFromMetadata(const Metadata *metadata);
+
 // Get the ObjC class object from class type metadata,
 // or nullptr if the type isn't an ObjC class.
 const ClassMetadata *

--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -1266,6 +1266,15 @@ FUNCTION(GetObjCClassFromMetadata, Swift, swift_getObjCClassFromMetadata,
          EFFECT(RuntimeEffect::NoEffect), // ?
          MEMEFFECTS(ReadNone))
 
+// id swift_getObjCMetatypeFromMetadata(Metadata *);
+FUNCTION(GetObjCMetatypeFromMetadata, Swift, swift_getObjCMetatypeFromMetadata,
+         C_CC, GetObjCMetatypeFromMetadataAvailability,
+         RETURNS(ObjCPtrTy),
+         ARGS(TypeMetadataPtrTy),
+         ATTRS(NoUnwind, WillReturn),
+         EFFECT(RuntimeEffect::NoEffect), // ?
+         MEMEFFECTS(ReadNone))
+
 // Metadata *swift_getObjCClassFromObject(id object);
 // This reads object metadata so cannot be marked ReadNone.
 FUNCTION(GetObjCClassFromObject, Swift, swift_getObjCClassFromObject,

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -1036,6 +1036,13 @@ namespace RuntimeConstants {
     return RuntimeAvailability::AlwaysAvailable;
   }
 
+  RuntimeAvailability GetObjCMetatypeFromMetadataAvailability(ASTContext &Context) {
+    auto featureAvailability = Context.getGetObjCMetatypeFromMetadataAvailability();
+    if (!isDeploymentAvailabilityContainedIn(Context, featureAvailability)) {
+      return RuntimeAvailability::ConditionallyAvailable;
+    }
+    return RuntimeAvailability::AlwaysAvailable;
+  }
 } // namespace RuntimeConstants
 
 // We don't use enough attributes to justify generalizing the

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -7780,9 +7780,21 @@ void IRGenSILFunction::visitThickToObjCMetatypeInst(ThickToObjCMetatypeInst *i){
   (void)from.claimAll();
   CanType instanceType(i->getType().castTo<AnyMetatypeType>().getInstanceType());
   Explosion to;
-  llvm::Value *classPtr =
-    emitClassHeapMetadataRefForMetatype(*this, swiftMeta, instanceType);
-  to.add(Builder.CreateBitCast(classPtr, IGM.ObjCClassPtrTy));
+  auto deploymentAvailability =
+      AvailabilityRange::forDeploymentTarget(IGM.Context);
+  auto getObjCMetatypeFromMetadataAvail =
+      IGM.Context.getGetObjCMetatypeFromMetadataAvailability();
+  // Use getObjCMetatypeFromMetadata if available. Otherwise, use old
+  // getObjCClassFromMetadata.
+  if (deploymentAvailability.isContainedIn(getObjCMetatypeFromMetadataAvail)) {
+    llvm::Value *objcMetatypePtr =
+        emitObjCMetatypeForMetatype(*this, swiftMeta, instanceType);
+    to.add(Builder.CreateBitCast(objcMetatypePtr, IGM.ObjCPtrTy));
+  } else {
+    llvm::Value *classPtr =
+        emitClassHeapMetadataRefForMetatype(*this, swiftMeta, instanceType);
+    to.add(Builder.CreateBitCast(classPtr, IGM.ObjCClassPtrTy));
+  }
   setLoweredExplosion(i, to);
 }
 

--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -3987,6 +3987,23 @@ llvm::Value *irgen::emitClassHeapMetadataRefForMetatype(IRGenFunction &IGF,
   return call;
 }
 
+llvm::Value *irgen::emitObjCMetatypeForMetatype(IRGenFunction &IGF,
+                                                llvm::Value *metatype,
+                                                CanType type) {
+  // If the type is known to have Swift metadata, this is trivial.
+  if (hasKnownSwiftMetadata(IGF.IGM, type))
+    return metatype;
+
+  assert(IGF.IGM.Context.LangOpts.EnableObjCInterop);
+  metatype = IGF.Builder.CreateBitCast(metatype, IGF.IGM.TypeMetadataPtrTy);
+
+  auto call = IGF.Builder.CreateCall(
+      IGF.IGM.getGetObjCMetatypeFromMetadataFunctionPointer(), metatype);
+  call->setDoesNotThrow();
+  call->setDoesNotAccessMemory();
+  return call;
+}
+
 /// Produce the heap metadata pointer for the given class type.  For
 /// Swift-defined types, this is equivalent to the metatype for the
 /// class, but for Objective-C-defined types, this is the class

--- a/lib/IRGen/MetadataRequest.h
+++ b/lib/IRGen/MetadataRequest.h
@@ -690,6 +690,11 @@ llvm::Value *emitClassHeapMetadataRefForMetatype(IRGenFunction &IGF,
                                                  llvm::Value *metatype,
                                                  CanType type);
 
+/// Given a metatype, produce the appropriate ObjC metatype for it.
+llvm::Value *emitObjCMetatypeForMetatype(IRGenFunction &IGF,
+                                         llvm::Value *metatype,
+                                         CanType type);
+
 /// Emit a reference to a type layout record for the given type. The referenced
 /// data is enough to lay out an aggregate containing a value of the type, but
 /// can't uniquely represent the type or perform value witness operations on

--- a/stdlib/public/runtime/SwiftObject.mm
+++ b/stdlib/public/runtime/SwiftObject.mm
@@ -165,6 +165,32 @@ const Metadata *swift::swift_getObjectType(HeapObject *object) {
 }
 
 #if SWIFT_OBJC_INTEROP
+id swift::swift_getObjCMetatypeFromMetadata(const Metadata *theMetadata) {
+  if (!theMetadata)
+    return nil;
+  // Unwrap ObjC class wrappers.
+  if (auto wrapper = dyn_cast<ObjCClassWrapperMetadata>(theMetadata)) {
+    return (id)wrapper->Class;
+  }
+  // Get ObjC protocols.
+  if (auto *existential = dyn_cast<ExistentialTypeMetadata>(theMetadata)) {
+    if (existential->isObjC() && existential->NumProtocols == 1) {
+      auto protocolObj = existential->getProtocols()[0].getObjCProtocol();
+      return objc_retain(protocolObj);
+    }
+  }
+  // Otherwise, the input should already be a Swift class object.
+  if (auto *theClass = dyn_cast<ClassMetadata>(theMetadata)) {
+    assert(theClass->isTypeMetadata());
+    return (id)theClass;
+  }
+  fatalError(/* flags = */ 0,
+             "Failed to get objc metatype from unexpected metadata kind %s\n",
+             getStringForMetadataKind(theMetadata->getKind()).data());
+}
+#endif
+
+#if SWIFT_OBJC_INTEROP
 static SwiftObject *_allocHelper(Class cls) {
   // XXX FIXME
   // When we have layout information, do precise alignment rounding

--- a/test/IRGen/anyobject-cast-crash.swift
+++ b/test/IRGen/anyobject-cast-crash.swift
@@ -1,0 +1,29 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -target %module-target-future -o %t/anyobject-cast-crash
+// RUN: %target-codesign %t/anyobject-cast-crash
+// RUN: %target-run %t/anyobject-cast-crash
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+// Test that it doesn't crash
+
+import Foundation
+
+enum Unconstrained<P> {
+  static var `protocol`: Protocol? {
+    P.self as AnyObject as? Protocol
+  }
+}
+
+enum Constrained<P: AnyObject> {
+  static var `protocol`: Protocol? {
+    P.self as AnyObject as? Protocol
+  }
+}
+
+@objc protocol TestProtocol {
+
+}
+
+print(Unconstrained<TestProtocol>.protocol)
+print(Constrained<TestProtocol>.protocol)

--- a/test/abi/macOS/arm64/stdlib.swift
+++ b/test/abi/macOS/arm64/stdlib.swift
@@ -572,6 +572,7 @@ Added: _swift_clearSensitive
 Added: _swift_updatePureObjCClassMetadata
 Added: _swift_initRawStructMetadata2
 Added: _swift_getFixedArrayTypeMetadata
+Added: _swift_getObjCMetatypeFromMetadata
 
 // Runtime bincompat functions for Concurrency runtime to detect legacy mode
 Added: _swift_bincompat_useLegacyNonCrashingExecutorChecks

--- a/test/abi/macOS/x86_64/stdlib.swift
+++ b/test/abi/macOS/x86_64/stdlib.swift
@@ -572,6 +572,7 @@ Added: _swift_clearSensitive
 Added: _swift_updatePureObjCClassMetadata
 Added: _swift_initRawStructMetadata2
 Added: _swift_getFixedArrayTypeMetadata
+Added: _swift_getObjCMetatypeFromMetadata
 
 // Runtime bincompat functions for Concurrency runtime to detect legacy mode
 Added: _swift_bincompat_useLegacyNonCrashingExecutorChecks


### PR DESCRIPTION
This fixes a segfault in casting an ObjC protocol metadata.

rdar://163660145
