### PR TITLE
[AllocBoxToStack] Fix missing dealloc_stack for promoted weak capture boxes

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/AllocBoxToStack.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/AllocBoxToStack.swift
@@ -96,8 +96,18 @@ private func tryConvertBoxesToStack(in function: Function, isMandatory: Bool,
 
   functionsToSpecialize.createSpecializedFunctions(context)
 
+  // First, create all alloc_stacks (and insert destroy_addr/dealloc_stack)
+  // before rewriting any uses. This is important because rewriteUses may
+  // specialize apply sites, changing their argument conventions from @owned
+  // to @inout_aliasable. If we interleave createAllocStack and rewriteUses,
+  // processing the first box rewrites the apply for ALL boxes, so
+  // getFinalDestroys for subsequent boxes won't find the apply as a final
+  // destroy, and their dealloc_stacks will be missing.
+  var stacks = Array<Value>()
   for (box, flags) in promotableBoxes {
-    let stack = createAllocStack(for: box, flags: flags, context)
+    stacks.append(createAllocStack(for: box, flags: flags, context))
+  }
+  for ((box, _), stack) in zip(promotableBoxes, stacks) {
     functionsToSpecialize.rewriteUses(of: box, with: stack, context)
     context.erase(instruction: box)
 

--- a/test/SILOptimizer/allocbox_to_stack_ownership.sil
+++ b/test/SILOptimizer/allocbox_to_stack_ownership.sil
@@ -1496,3 +1496,65 @@ bb0(%0 : $Int):
   destroy_value %1
   return %4 : $Int
 }
+
+// Two promotable boxes each captured by separate closures, both closures
+// passed to the same apply. The pass must insert dealloc_stack for both,
+// not just the first.
+// https://github.com/swiftlang/swift/issues/90119
+//
+// CHECK-LABEL: sil [ossa] @test_two_boxes_one_apply :
+// CHECK:         alloc_stack
+// CHECK:         alloc_stack
+// CHECK-NOT:     alloc_box
+// CHECK:         dealloc_stack
+// CHECK:         dealloc_stack
+// CHECK:       } // end sil function 'test_two_boxes_one_apply'
+sil [ossa] @test_two_boxes_one_apply : $@convention(thin) (Int) -> () {
+bb0(%0 : $Int):
+  %box1 = alloc_box ${ var Int }
+  %proj1 = project_box %box1 : ${ var Int }, 0
+  store %0 to [trivial] %proj1 : $*Int
+
+  %box2 = alloc_box ${ var Int }
+  %proj2 = project_box %box2 : ${ var Int }, 0
+  store %0 to [trivial] %proj2 : $*Int
+
+  %fn1 = function_ref @two_boxes_closure1 : $@convention(thin) (@owned { var Int }) -> ()
+  %copy1 = copy_value %box1 : ${ var Int }
+  %pa1 = partial_apply %fn1(%copy1) : $@convention(thin) (@owned { var Int }) -> ()
+
+  %fn2 = function_ref @two_boxes_closure2 : $@convention(thin) (@owned { var Int }) -> ()
+  %copy2 = copy_value %box2 : ${ var Int }
+  %pa2 = partial_apply %fn2(%copy2) : $@convention(thin) (@owned { var Int }) -> ()
+
+  %callee = function_ref @take_two_closures : $@convention(thin) (@owned @callee_owned () -> (), @owned @callee_owned () -> ()) -> ()
+  apply %callee(%pa1, %pa2) : $@convention(thin) (@owned @callee_owned () -> (), @owned @callee_owned () -> ()) -> ()
+  destroy_value %box1 : ${ var Int }
+  destroy_value %box2 : ${ var Int }
+  %r = tuple ()
+  return %r : $()
+}
+
+sil private [ossa] @two_boxes_closure1 : $@convention(thin) (@owned { var Int }) -> () {
+bb0(%0 : @owned ${ var Int }):
+  %p = project_box %0 : ${ var Int }, 0
+  destroy_value %0 : ${ var Int }
+  %r = tuple ()
+  return %r : $()
+}
+
+sil private [ossa] @two_boxes_closure2 : $@convention(thin) (@owned { var Int }) -> () {
+bb0(%0 : @owned ${ var Int }):
+  %p = project_box %0 : ${ var Int }, 0
+  destroy_value %0 : ${ var Int }
+  %r = tuple ()
+  return %r : $()
+}
+
+sil private [ossa] @take_two_closures : $@convention(thin) (@owned @callee_owned () -> (), @owned @callee_owned () -> ()) -> () {
+bb0(%0 : @owned $@callee_owned () -> (), %1 : @owned $@callee_owned () -> ()):
+  apply %0() : $@callee_owned () -> ()
+  apply %1() : $@callee_owned () -> ()
+  %r = tuple ()
+  return %r : $()
+}

--- a/test/SILOptimizer/weak_capture_osize_stack_leak.swift
+++ b/test/SILOptimizer/weak_capture_osize_stack_leak.swift
@@ -1,0 +1,24 @@
+// RUN: %target-swiftc_driver -Osize -emit-sil %s -o /dev/null
+
+// https://github.com/swiftlang/swift/issues/90119
+//
+// With -Osize and cross-module optimization, two distinct [weak self] closures
+// stored in escaping-typed locals and passed to a function that iterates a
+// Dictionary and calls both closures produced SIL where the alloc_stacks for
+// the promoted weak-capture boxes were never deallocated before the return.
+//
+// SIL verification failed: return with stack allocs that haven't been
+// deallocated
+
+class C {
+  func trigger(_ dict: [Int: Int]) {
+    let f: () -> Void = { [weak self] in _ = self }
+    let g: () -> Void = { [weak self] in _ = self }
+    callee(dict: dict, f: f, g: g)
+  }
+}
+
+func callee(dict: [Int: Int], f: () -> Void, g: () -> Void) {
+  for v in dict.keys { _ = v }
+  f(); g()
+}


### PR DESCRIPTION
## Summary

Fixes https://github.com/swiftlang/swift/issues/90119

With `-Osize` and cross-module optimization, two or more `[weak self]` closures stored in escaping-typed locals and passed to a function that iterates a `Dictionary` and calls both closures cause a SIL verification failure:

```
SIL verification failed: return with stack allocs that haven't been deallocated
```

## Root Cause

`AllocBoxToStack` processes promotable boxes in a loop that interleaves two operations per box:

1. `createAllocStack` -- finds the final destroys of the box (via `getFinalDestroys`) and inserts `destroy_addr`/`dealloc_stack` after each one
2. `rewriteUses` -- replaces box uses, including specializing apply sites by changing `@owned` box arguments to `@inout_aliasable` addresses

The callee specializations are created **upfront** for all promotable arguments. So when `rewriteUses` runs for the first box, `specialize(apply:)` replaces the apply with the fully-specialized version that takes `@inout_aliasable` for **all** box arguments -- not just the one being processed. When the second box is then processed, `getFinalDestroys` cannot find the apply as a final destroy (it no longer consumes the box `@owned`), so no `destroy_addr` or `dealloc_stack` is emitted for it.

**Before** AllocBoxToStack (both boxes consumed `@owned` by the apply):
```
bb0(%0 : $Dictionary<Int, Int>, %1 : $C):
  %4 = alloc_box ${ var @sil_weak Optional<C> }
  %10 = alloc_box ${ var @sil_weak Optional<C> }
  %16 = apply %15(%0, %4, %10)  // consumes both @owned
  return %17
```

**After** (broken -- `%7` has no `destroy_addr` or `dealloc_stack`):
```
bb0(%0 : $Dictionary<Int, Int>, %1 : $C):
  %4 = alloc_stack $@sil_weak Optional<C>
  %7 = alloc_stack $@sil_weak Optional<C>
  %10 = apply %9(%0, %4, %7)   // specialized: @inout_aliasable
  destroy_addr %4               // only first box cleaned up
  return %12                    // %7 leaked, neither stack deallocated
```

## Fix

Split the promotion loop into two phases:

1. **First**, call `createAllocStack` for all boxes -- this collects final destroys and inserts `destroy_addr`/`dealloc_stack` while the original `@owned` apply conventions are still intact
2. **Then**, call `rewriteUses` for all boxes -- this specializes the apply sites

This is a 12-line change in `AllocBoxToStack.swift`.

## Reproducer

```swift
class C {
  func trigger(_ dict: [Int: Int]) {
    let f: () -> Void = { [weak self] in _ = self }
    let g: () -> Void = { [weak self] in _ = self }
    callee(dict: dict, f: f, g: g)
  }
}
func callee(dict: [Int: Int], f: () -> Void, g: () -> Void) {
  for v in dict.keys { _ = v }
  f(); g()
}
```

`swiftc -Osize -emit-sil repro.swift` crashes with the SIL verification failure. Only `-Osize` (not `-O` or `-Onone`) triggers it because only `-Osize` runs the late-pipeline `AllocBoxToStack` pass that encounters this pattern after earlier optimization passes have specialized the closures.