### PR TITLE
[update-checkout] Re-read config after updating swift first

### DIFF
--- a/utils/update_checkout/tests/test_in_tree_config_change.py
+++ b/utils/update_checkout/tests/test_in_tree_config_change.py
@@ -1,0 +1,151 @@
+# ===--- test_in_tree_config_change.py -------------------------------------===#
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2026 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+# ===----------------------------------------------------------------------===#
+
+"""Tests that update-checkout re-reads the config after updating the `swift`
+repo. The config that drives the run lives inside `swift`, so it can change
+when switching schemes or when picking up a new revision of the same scheme
+branch. The rest of the repos must be updated against the version of the
+config that matches the swift checkout the run ends up at.
+"""
+
+import copy
+import json
+import os
+
+from . import scheme_mock
+
+
+class InTreeConfigChangeTestCase(scheme_mock.SchemeMockTestCase):
+
+    IN_TREE_CONFIG_RELPATH = os.path.join("utils", "update-checkout-config.json")
+
+    def setUp(self):
+        self.config["repos"]["swift"] = {"remote": {"id": "swift"}}
+        self.config["branch-schemes"]["main"]["repos"]["swift"] = "main"
+        self.config["branch-schemes"]["release"] = {
+            "aliases": ["release"],
+            "repos": {
+                "repo1": "main",
+                "repo2": "main",
+                "swift": "main",
+            },
+        }
+
+        super().setUp()
+
+        local_swift_path = os.path.join(self.local_path, "swift")
+        in_tree_config = os.path.join(local_swift_path, self.IN_TREE_CONFIG_RELPATH)
+        os.makedirs(os.path.dirname(in_tree_config))
+        with open(in_tree_config, "w") as f:
+            json.dump(self.config, f)
+        self.call(["git", "add", "."], cwd=local_swift_path)
+        self.call(
+            ["git", "commit", "-m", "Add in-tree update-checkout-config.json"],
+            cwd=local_swift_path,
+        )
+        self.call(["git", "push", "origin", "main"], cwd=local_swift_path)
+        self.call(
+            [
+                self.update_checkout_path,
+                "--config",
+                self.config_path,
+                "--source-root",
+                self.source_root,
+                "--scheme",
+                "main",
+                "--max-retries",
+                "0",
+                "--clone",
+            ]
+        )
+
+    def _push_branch(self, repo_name, new_branch):
+        local_repo_path = os.path.join(self.local_path, repo_name)
+        self.call(["git", "checkout", "-b", new_branch], cwd=local_repo_path)
+        self.call(
+            ["git", "commit", "--allow-empty", "-m", f"commit on {new_branch}"],
+            cwd=local_repo_path,
+        )
+        self.call(["git", "push", "origin", new_branch], cwd=local_repo_path)
+
+    def _push_swift_main_with_config(self, new_config):
+        local_swift_path = os.path.join(self.local_path, "swift")
+        self.call(["git", "checkout", "main"], cwd=local_swift_path)
+        with open(
+            os.path.join(local_swift_path, self.IN_TREE_CONFIG_RELPATH), "w"
+        ) as f:
+            json.dump(new_config, f)
+        self.call(["git", "add", "."], cwd=local_swift_path)
+        self.call(
+            ["git", "commit", "-m", "Update update-checkout-config.json"],
+            cwd=local_swift_path,
+        )
+        self.call(["git", "push", "origin", "main"], cwd=local_swift_path)
+
+    def _in_tree_config_path(self):
+        return os.path.join(
+            self.source_root, "swift", self.IN_TREE_CONFIG_RELPATH
+        )
+
+    def _head_ref(self, repo_name):
+        repo_path = os.path.join(self.source_root, repo_name)
+        return self.call(["git", "symbolic-ref", "HEAD"], cwd=repo_path).strip()
+
+    def test_config_change_between_revisions_is_picked_up(self):
+        """A new revision on the same scheme branch that updates a repo's
+        branch mapping must take effect in the same run that pulls it in."""
+        self._push_branch(repo_name="repo1", new_branch="branch-x")
+
+        new_config = copy.deepcopy(self.config)
+        new_config["branch-schemes"]["main"]["repos"]["repo1"] = "branch-x"
+        self._push_swift_main_with_config(new_config)
+
+        self.call(
+            [
+                self.update_checkout_path,
+                "--config",
+                self._in_tree_config_path(),
+                "--source-root",
+                self.source_root,
+                "--scheme",
+                "main",
+                "--max-retries",
+                "0",
+            ]
+        )
+
+        self.assertEqual(self._head_ref("repo1"), "refs/heads/branch-x")
+
+    def test_scheme_switch_uses_new_schemes_config(self):
+        """Switching to a scheme whose mapping changed in a yet-to-be-fetched
+        revision of swift main must use the post-fetch mapping."""
+        self._push_branch(repo_name="repo1", new_branch="release-branch")
+
+        new_config = copy.deepcopy(self.config)
+        new_config["branch-schemes"]["release"]["repos"]["repo1"] = "release-branch"
+        self._push_swift_main_with_config(new_config)
+
+        self.call(
+            [
+                self.update_checkout_path,
+                "--config",
+                self._in_tree_config_path(),
+                "--source-root",
+                self.source_root,
+                "--scheme",
+                "release",
+                "--max-retries",
+                "0",
+            ]
+        )
+
+        self.assertEqual(self._head_ref("repo1"), "refs/heads/release-branch")

--- a/utils/update_checkout/tests/test_locked_repository.py
+++ b/utils/update_checkout/tests/test_locked_repository.py
@@ -2,6 +2,7 @@ from pathlib import Path
 import unittest
 from unittest.mock import patch
 
+from update_checkout.cli_arguments import CliArguments
 from update_checkout.update_checkout import UpdateArguments
 from update_checkout.git_command import is_any_repository_locked
 
@@ -10,21 +11,14 @@ FAKE_PATH = Path("/fake_path")
 
 def _update_arguments_with_fake_path(repo_name: str, path: Path) -> UpdateArguments:
     return UpdateArguments(
+        args=CliArguments(source_root=path),
         repo_name=repo_name,
-        source_root=path,
         config={},
         scheme_name="",
         scheme_map=None,
-        tag="",
         timestamp=None,
-        reset_to_remote=False,
-        clean=False,
-        stash=False,
         cross_repos_pr={},
-        skip_history=False,
-        partial_clone=False,
         output_prefix="",
-        verbose=False,
     )
 
 

--- a/utils/update_checkout/update_checkout/commands/status.py
+++ b/utils/update_checkout/update_checkout/commands/status.py
@@ -33,10 +33,10 @@ class StatusCommand:
             repo_name = repo_path.name
 
             my_args = RunnerArguments(
+                args=args,
+                scheme_name="",
                 repo_name=repo_name,
                 output_prefix="Checking the status of",
-                source_root=args.source_root,
-                verbose=args.verbose,
             )
             self._pool_args.append(my_args)
 
@@ -83,5 +83,5 @@ class StatusCommand:
 
     @staticmethod
     def _get_uncommitted_changes_of_repository(pool_args: RunnerArguments):
-        repo_path = pool_args.source_root.joinpath(pool_args.repo_name)
+        repo_path = pool_args.args.source_root.joinpath(pool_args.repo_name)
         return Git.run(repo_path, ["status", "--short"], fatal=True)

--- a/utils/update_checkout/update_checkout/git_command.py
+++ b/utils/update_checkout/update_checkout/git_command.py
@@ -155,7 +155,7 @@ def is_any_repository_locked(pool_args: List[RunnerArguments]) -> Set[str]:
         Set[str]: The names of the locked repositories if any.
     """
 
-    repos = [(x.source_root, x.repo_name) for x in pool_args]
+    repos = [(x.args.source_root, x.repo_name) for x in pool_args]
     locked_repositories = set()
     for source_root, repo_name in repos:
         dot_git_path = source_root.joinpath(repo_name, ".git")

--- a/utils/update_checkout/update_checkout/parallel_runner.py
+++ b/utils/update_checkout/update_checkout/parallel_runner.py
@@ -98,7 +98,7 @@ class ParallelRunner:
         self._output_prefix = pool_args[0].output_prefix
         self._nb_repos = len(pool_args)
         self._stop_event = Event()
-        self._verbose = pool_args[0].verbose
+        self._verbose = pool_args[0].args.verbose
         if not self._verbose:
             self._task_tracker = TaskTracker()
             self._monitored_fn = MonitoredFunction(self._fn, self._task_tracker)

--- a/utils/update_checkout/update_checkout/runner_arguments.py
+++ b/utils/update_checkout/update_checkout/runner_arguments.py
@@ -1,37 +1,27 @@
 from dataclasses import dataclass
-from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 from .cli_arguments import CliArguments
 
 
 @dataclass
 class RunnerArguments:
+    args: CliArguments
+    scheme_name: str
     repo_name: str
     output_prefix: str
-    source_root: Path
-    verbose: bool
 
 
 @dataclass
 class UpdateArguments(RunnerArguments):
-    scheme_name: str
     config: Dict[str, Any]
     scheme_map: Any
-    tag: Optional[str]
     timestamp: Any
-    reset_to_remote: bool
-    clean: bool
-    stash: bool
     cross_repos_pr: Dict[str, str]
-    skip_history: bool
-    partial_clone: bool
 
 
 @dataclass
 class AdditionalSwiftSourcesArguments(RunnerArguments):
-    scheme_name: str
-    args: CliArguments
     repo_info: str
     repo_branch: str
     remote: str

--- a/utils/update_checkout/update_checkout/update_checkout.py
+++ b/utils/update_checkout/update_checkout/update_checkout.py
@@ -551,10 +551,12 @@ def update_all_repositories(
     scheme_name: str,
     scheme_map: Optional[Dict[str, Any]],
     cross_repos_pr: Dict[str, str],
+    extra_skip_repository_list: Optional[List[str]] = None,
 ) -> Tuple[List[SkippedReason], List[Union[Exception, None]]]:
     skipped_repositories = []
     pool_args: List[UpdateArguments] = []
     timestamp = get_timestamp_to_match(args.match_timestamp, args.source_root)
+    extra_skip = set(extra_skip_repository_list or [])
     for repo_name in config["repos"].keys():
         if repo_name in args.skip_repository_list:
             skipped_repositories.append(
@@ -563,6 +565,9 @@ def update_all_repositories(
                     "requested by user",
                 )
             )
+            continue
+
+        if repo_name in extra_skip:
             continue
 
         # If the repository is not listed in the branch-scheme, skip it.
@@ -1030,32 +1035,34 @@ def main() -> int:
             SkippedReason.print_skipped_repositories(skipped_repositories, "clone")
 
         swift_repo_path = args.source_root.joinpath("swift")
-        if "swift" not in skip_repo_list and swift_repo_path.exists():
-            # Check if `swift` repo itself needs to switch to a cross-repo branch.
-            branch_name, cross_repo = get_branch_for_repo(
-                swift_repo_path,
-                config,
-                "swift",
-                scheme_name,
-                scheme_map,
-                cross_repos_pr,
+        swift_updated = False
+        if (
+            "swift" not in skip_repo_list
+            and "swift" not in args.skip_repository_list
+            and swift_repo_path.exists()
+        ):
+            print("Updating 'swift' first")
+            timestamp = get_timestamp_to_match(args.match_timestamp, args.source_root)
+            swift_pool_args = UpdateArguments(
+                args=args,
+                config=config,
+                repo_name="swift",
+                scheme_name=scheme_name,
+                scheme_map=scheme_map,
+                timestamp=timestamp,
+                cross_repos_pr=cross_repos_pr,
+                output_prefix="Updating",
             )
+            update_single_repository(swift_pool_args)
+            swift_updated = True
 
-            if cross_repo:
-                Git.run(
-                    swift_repo_path,
-                    ["checkout", branch_name],
-                    echo=True,
-                    prefix=output_prefix("swift"),
-                )
-
-                # Re-read the config after checkout.
-                config = {}
-                for config_path in args.configs:
-                    with open(config_path) as f:
-                        config = merge_config(config, json.load(f))
-                validate_config(config)
-                scheme_map = get_scheme_map(config, scheme_name)
+            # Re-read the config now that the swift checkout may have changed.
+            config = {}
+            for config_path in args.configs:
+                with open(config_path) as f:
+                    config = merge_config(config, json.load(f))
+            validate_config(config)
+            scheme_map = get_scheme_map(config, scheme_name)
 
         if args.dump_hashes:
             dump_repo_hashes(args, config)
@@ -1068,7 +1075,12 @@ def main() -> int:
         _check_missing_clones(args=args, config=config, scheme_map=scheme_map)
 
         skipped_repositories, update_results = update_all_repositories(
-            args, config, scheme_name, scheme_map, cross_repos_pr
+            args,
+            config,
+            scheme_name,
+            scheme_map,
+            cross_repos_pr,
+            extra_skip_repository_list=["swift"] if swift_updated else None,
         )
         SkippedReason.print_skipped_repositories(skipped_repositories, "update")
 

--- a/utils/update_checkout/update_checkout/update_checkout.py
+++ b/utils/update_checkout/update_checkout/update_checkout.py
@@ -177,10 +177,11 @@ def get_branch_for_repo(
 
 
 def update_single_repository(pool_args: UpdateArguments):
-    verbose = pool_args.verbose
+    args = pool_args.args
+    verbose = args.verbose
     repo_name = pool_args.repo_name
 
-    repo_path = pool_args.source_root.joinpath(repo_name)
+    repo_path = args.source_root.joinpath(repo_name)
     if not repo_path.is_dir() or repo_path.is_symlink():
         return
 
@@ -190,15 +191,15 @@ def update_single_repository(pool_args: UpdateArguments):
             print(f"{prefix}Updating '{repo_path}'")
 
         fetch_extra_args = []
-        if pool_args.skip_history:
+        if args.skip_history:
             fetch_extra_args.extend(["--depth", "1"])
-        if pool_args.partial_clone:
+        if args.partial_clone:
             fetch_extra_args.extend(["--filter", "blob:none"])
 
         cross_repo = False
         checkout_target = None
-        if pool_args.tag:
-            checkout_target = confirm_tag_in_repo(repo_path, pool_args.tag, repo_name)
+        if args.tag:
+            checkout_target = confirm_tag_in_repo(repo_path, args.tag, repo_name)
         elif pool_args.scheme_name:
             checkout_target, cross_repo = get_branch_for_repo(
                 repo_path,
@@ -218,21 +219,21 @@ def update_single_repository(pool_args: UpdateArguments):
         #   changes rather than discarding them)
         # 2. delete ignored files
         # 3. abort an ongoing rebase
-        if pool_args.clean or pool_args.stash:
+        if args.clean or args.stash:
 
-            def run_for_repo_and_each_submodule_rec(args: List[str]):
-                Git.run(repo_path, args, echo=verbose, prefix=prefix)
+            def run_for_repo_and_each_submodule_rec(cmd: List[str]):
+                Git.run(repo_path, cmd, echo=verbose, prefix=prefix)
                 Git.run(
                     repo_path,
-                    ["submodule", "foreach", "--recursive", "git"] + args,
+                    ["submodule", "foreach", "--recursive", "git"] + cmd,
                     echo=verbose,
                     prefix=prefix,
                 )
 
-            if pool_args.stash:
+            if args.stash:
                 # Stash tracked and untracked changes.
                 run_for_repo_and_each_submodule_rec(["stash", "-u"])
-            elif pool_args.clean:
+            elif args.clean:
                 # Delete tracked changes.
                 run_for_repo_and_each_submodule_rec(["reset", "--hard", "HEAD"])
 
@@ -351,7 +352,7 @@ def update_single_repository(pool_args: UpdateArguments):
 
         # If we were asked to reset to the specified branch, do the hard
         # reset and return.
-        if checkout_target and pool_args.reset_to_remote and not cross_repo:
+        if checkout_target and args.reset_to_remote and not cross_repo:
             full_target = full_target_name(repo_path, "origin", checkout_target)
             Git.run(
                 repo_path, ["reset", "--hard", full_target], echo=verbose, prefix=prefix
@@ -577,21 +578,14 @@ def update_all_repositories(
             continue
 
         my_args = UpdateArguments(
-            source_root=args.source_root,
+            args=args,
             config=config,
             repo_name=repo_name,
             scheme_name=scheme_name,
             scheme_map=scheme_map,
-            tag=args.tag,
             timestamp=timestamp,
-            reset_to_remote=args.reset_to_remote,
-            clean=args.clean,
-            stash=args.stash,
             cross_repos_pr=cross_repos_pr,
-            skip_history=args.skip_history,
-            partial_clone=args.partial_clone,
             output_prefix="Updating",
-            verbose=args.verbose,
         )
         pool_args.append(my_args)
 
@@ -612,7 +606,7 @@ def obtain_additional_swift_sources(pool_args: AdditionalSwiftSourcesArguments):
     args = pool_args.args
     repo_name = pool_args.repo_name
     repo_branch = pool_args.repo_branch
-    verbose = pool_args.verbose
+    verbose = args.verbose
     skip_tags = args.skip_tags
     remote = pool_args.remote
 
@@ -788,7 +782,6 @@ def obtain_all_additional_swift_sources(
 
         new_args = AdditionalSwiftSourcesArguments(
             args=args,
-            source_root=args.source_root,
             repo_name=repo_name,
             repo_info=repo_info,
             repo_branch=repo_branch,
@@ -796,7 +789,6 @@ def obtain_all_additional_swift_sources(
             scheme_name=scheme_name,
             skip_repository_list=skip_repository_list,
             output_prefix="Cloning",
-            verbose=args.verbose,
         )
 
         if args.use_submodules:


### PR DESCRIPTION
This patch does 2 things:

1. Refactor `UpdateArguments` and `AdditionalSwiftSourcesArguments` to rely more on the `args` value. This allow deduplicating arguments when constructing those classes. This is NFC.
2. Clone Swift first and re-read the configuration before cloning/updating other repositories.

When the user runs `update-checkout` and changes to a new scheme (e.g from `main` to `release/6.4.x`), the configs might differ between the 2 branches. Currently, `update-checkout` will only account for the first one. The user has to run the script twice to ensure their checkout is in sync.

This patch fetches swift first, and re-reads the config to ensure we always use the config of the scheme that is being checked out.