### PR TITLE
[DebugInfo] Fix alloc_pack salvage scope

### DIFF
--- a/lib/SILOptimizer/Utils/InstOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/InstOptUtils.cpp
@@ -2047,7 +2047,7 @@ static void salvagePackElementSetDebugInfo(PackElementSetInst *PESI) {
           tupleType, SPII->getComponentIndex());
       VarInfo.DIExpr.append(FragDIExpr);
     }
-    SILBuilder(PESI, API->getDebugScope())
+    SILBuilder(PESI, DbgInst->getDebugScope())
         .createDebugValue(DbgInst->getLoc(), PESI->getValue(), VarInfo);
   }
 }

--- a/test/DebugInfo/parameter-pack-inline.swift
+++ b/test/DebugInfo/parameter-pack-inline.swift
@@ -1,0 +1,16 @@
+// RUN: %target-swift-frontend -emit-ir %s -g -O -parse-as-library -module-name a
+
+// rdar://179749587
+// Make sure inlining a function with a parameter pack does not produce
+// conflicting debug variable scopes.
+
+@_alwaysEmitIntoClient
+@inline(always)
+public func build<each C>(_ content: repeat each C) -> (repeat each C) {
+    (repeat each content)
+}
+
+@inlinable
+public func test() -> (Int, Int) {
+    build(1, 2)
+}


### PR DESCRIPTION
The scope of the salvaged debug value must match the old debug_value instruction's scope, otherwise this causes an assertion failure in the added test file