### PR TITLE
[ConstraintSystem] Fail key path type inference if one of the member …

### DIFF
--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -5187,7 +5187,7 @@ ConstraintSystem::inferKeyPathLiteralCapability(KeyPathExpr *keyPath) {
       if (!overload) {
         // If overload cannot be found because member is missing,
         // that's a failure.
-        if (hasFixFor(componentLoc, FixKind::DefineMemberBasedOnUse))
+        if (hasFixFor(calleeLoc, FixKind::DefineMemberBasedOnUse))
           return fail();
 
         return delay();

--- a/test/expr/unary/keypath/keypath.swift
+++ b/test/expr/unary/keypath/keypath.swift
@@ -1439,3 +1439,23 @@ func testKeypathWithTypeReference() {
 
   _ = \S.Type.Q // expected-error {{key path cannot refer to type 'Q'}}
 }
+
+// Invalid reference combined with a missing member shouldn't prevent key path from being resolved.
+protocol P1 {
+  subscript(name: String) -> Int { get }
+}
+
+protocol P2 {
+  func access<T>(keyPath: KeyPath<Self, T>)
+}
+
+extension P1 {
+  subscript(name: String) -> Int {
+    get {
+      (self as? any P2)?.access(keyPath: \.[name: name])
+      // expected-error@-1 {{member 'access' cannot be used on value of type 'any P2'; consider using a generic constraint instead}}
+      // expected-error@-2 {{value of type 'any P2' has no subscripts}}
+      return 1
+    }
+  }
+}


### PR DESCRIPTION
…references is invalid

Previously only a component was checked but the fix could be anchored on a callee locator as well.

Resolves: rdar://179374241

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
