### PR TITLE
[Runtime] Make TypeDecoder more robust against malformed node trees.

### DIFF
--- a/include/swift/Demangling/TypeDecoder.h
+++ b/include/swift/Demangling/TypeDecoder.h
@@ -524,8 +524,11 @@ void decodeRequirement(
           constraintNode->getNumChildren() != 1)
         return;
 
+      auto protocolKindNode = child->getChild(1);
+      if (!protocolKindNode->hasIndex())
+        return;
       auto protocolKind =
-          static_cast<InvertibleProtocolKind>(child->getChild(1)->getIndex());
+          static_cast<InvertibleProtocolKind>(protocolKindNode->getIndex());
       inverseRequirements.push_back(
           Builder.createInverseRequirement(subjectType, protocolKind));
       continue;
@@ -575,11 +578,16 @@ void decodeRequirement(
           kind != LayoutConstraintKind::TrivialStride) {
         layout = Builder.getLayoutConstraint(*kind);
       } else {
+        if (child->getNumChildren() < 3 || !child->getChild(2)->hasIndex())
+          return;
         auto size = child->getChild(2)->getIndex();
         auto alignment = 0;
 
-        if (child->getNumChildren() == 4)
+        if (child->getNumChildren() == 4) {
+          if (!child->getChild(3)->hasIndex())
+            return;
           alignment = child->getChild(3)->getIndex();
+        }
 
         layout =
             Builder.getLayoutConstraintWithSizeAlign(*kind, size, alignment);
@@ -978,8 +986,17 @@ protected:
       return Builder.createDynamicSelfType(selfType.getType());
     }
     case NodeKind::DependentGenericParamType: {
-      auto depth = Node->getChild(0)->getIndex();
-      auto index = Node->getChild(1)->getIndex();
+      if (Node->getNumChildren() < 2)
+        return MAKE_NODE_TYPE_ERROR(Node,
+                                    "fewer children (%zu) than required (2)",
+                                    Node->getNumChildren());
+      auto depthNode = Node->getChild(0);
+      auto indexNode = Node->getChild(1);
+      if (!depthNode->hasIndex() || !indexNode->hasIndex())
+        return MAKE_NODE_TYPE_ERROR0(
+            Node, "depth and index nodes must carry an index payload");
+      auto depth = depthNode->getIndex();
+      auto index = indexNode->getIndex();
       return TypeLookupErrorOr<BuiltType>(
           Builder.createGenericTypeParameterType(depth, index),
           /*ignoreValueCheck*/ true);
@@ -1461,7 +1478,7 @@ protected:
 
       bool pushedGenericParams = false;
 
-      if (Node->getNumChildren() > 1) {
+      if (Node->getNumChildren() > 2) {
         auto *substNode = Node->getChild(2);
         if (substNode->getKind() != NodeKind::TypeList)
           return MAKE_NODE_TYPE_ERROR0(substNode, "expected type list");
@@ -1488,7 +1505,20 @@ protected:
         llvm::SmallVector<std::pair<unsigned, unsigned>> parameterPacks;
         for (auto &child : *dependentGenericSignatureNode) {
           if (child->getKind() == Demangle::Node::Kind::DependentGenericParamPackMarker) {
-            auto *marker = child->getChild(0)->getChild(0);
+            if (child->getNumChildren() < 1)
+              return MAKE_NODE_TYPE_ERROR0(child, "expected one child node");
+            auto *typeNode = child->getChild(0);
+            if (typeNode->getNumChildren() < 1)
+              return MAKE_NODE_TYPE_ERROR0(typeNode, "expected one child node");
+            auto *marker = typeNode->getChild(0);
+            if (marker->getNumChildren() < 2)
+              return MAKE_NODE_TYPE_ERROR(
+                  marker, "fewer children (%zu) than required (2)",
+                  marker->getNumChildren());
+            if (!marker->getChild(0)->hasIndex() ||
+                !marker->getChild(1)->hasIndex())
+              return MAKE_NODE_TYPE_ERROR0(marker,
+                                           "child nodes must have indexes");
             parameterPacks.emplace_back(marker->getChild(0)->getIndex(),
                                         marker->getChild(1)->getIndex());
           }


### PR DESCRIPTION
Add a few checks for child count and hasIndex before calling getChild and getIndex.

rdar://180193987