### PR TITLE
Add test case for https://github.com/swiftlang/swift/issues/90116

### DIFF
--- a/validation-test/Sema/type_checker_perf/slow/issue-90116.swift
+++ b/validation-test/Sema/type_checker_perf/slow/issue-90116.swift
@@ -1,0 +1,24 @@
+// RUN: %target-typecheck-verify-swift -solver-scope-threshold=2000
+
+// This used to type check quickly in 6.2 and regressed in 6.3.
+// https://github.com/swiftlang/swift/issues/90116
+
+@_disfavoredOverload
+func __checkBinaryOperation<T, U>(_: T, _: (T, () -> U) -> Bool, _: @autoclosure () -> U) {}
+
+@_disfavoredOverload
+func __checkBinaryOperation<T>(_: T, _: (T, () -> T) -> Bool, _: @autoclosure () -> T)
+    where T: BidirectionalCollection, T.Element: Equatable {}
+
+func __checkBinaryOperation(_: String, _: (String, () -> String) -> Bool, _: @autoclosure () -> String) {}
+
+func __checkBinaryOperation<T, U>(_: T, _: (T, () -> U) -> Bool, _: @autoclosure () -> U)
+    where T: RangeExpression, U: RangeExpression {}
+
+@_disfavoredOverload
+func __checkBinaryOperation<T>(_: T?, _: (T?, () -> T?) -> T?, _: @autoclosure () -> T?) {}
+
+func f() {
+  __checkBinaryOperation([],{ $0 == $1() },["" + "" + "", "" + "" + ""])
+  // expected-error@-1 {{reasonable time}}
+}


### PR DESCRIPTION
This worked in 6.2 because shrink solved it, but regressed in 6.3 unfortunately, because bindings are not propagated aggressively enough. Definitely should be fixable, though.