### PR TITLE
[IRGen] Emit __objc_classrefs for ObjC classes in mangled type metadata

### DIFF
--- a/lib/IRGen/GenReflection.cpp
+++ b/lib/IRGen/GenReflection.cpp
@@ -547,27 +547,21 @@ getTypeRefImpl(IRGenModule &IGM,
     // in-process.
     IGM.IRGen.noteUseOfTypeMetadata(type);
 
-    // Ensure ObjC classes referenced by mangled type metadata strings are
-    // visible to the linker. The runtime resolves these classes by name via
-    // objc_getClass() at runtime, but without a linker-visible reference the
-    // linker may not pull in the archive member defining the class when
-    // linking static archives without -ObjC. Emitting a classref entry
-    // creates an undefined reference to _OBJC_CLASS_$_<name> that forces
-    // the linker to include the class definition.
+    // ObjC lightweight-generic classes (e.g. NSArray<T>) have their type
+    // parameters erased at runtime. The mangled type metadata string
+    // embeds the class name textually and the runtime resolves it via
+    // objc_getClass(). Without a linker-visible reference, the linker may
+    // not extract the archive member defining the class when linking
+    // static archives without -ObjC. Emit a classref to force extraction.
     if (IGM.ObjCInterop) {
       type.visit([&](Type t) {
-        // Use getAnyNominal to catch ObjC generic classes whose erased
-        // type is a NominalType (ClassType) rather than a
-        // BoundGenericClassType.
         auto *nominal = t->getAnyNominal();
         if (!nominal)
           return;
         auto *classDecl = dyn_cast<ClassDecl>(nominal);
         if (!classDecl)
           return;
-        if (classDecl->hasKnownSwiftImplementation())
-          return;
-        if (classDecl->isForeign())
+        if (!classDecl->isTypeErasedGenericClass())
           return;
         (void)IGM.getAddrOfObjCClassRef(classDecl);
       });

--- a/lib/IRGen/GenReflection.cpp
+++ b/lib/IRGen/GenReflection.cpp
@@ -547,6 +547,32 @@ getTypeRefImpl(IRGenModule &IGM,
     // in-process.
     IGM.IRGen.noteUseOfTypeMetadata(type);
 
+    // Ensure ObjC classes referenced by mangled type metadata strings are
+    // visible to the linker. The runtime resolves these classes by name via
+    // objc_getClass() at runtime, but without a linker-visible reference the
+    // linker may not pull in the archive member defining the class when
+    // linking static archives without -ObjC. Emitting a classref entry
+    // creates an undefined reference to _OBJC_CLASS_$_<name> that forces
+    // the linker to include the class definition.
+    if (IGM.ObjCInterop) {
+      type.visit([&](Type t) {
+        // Use getAnyNominal to catch ObjC generic classes whose erased
+        // type is a NominalType (ClassType) rather than a
+        // BoundGenericClassType.
+        auto *nominal = t->getAnyNominal();
+        if (!nominal)
+          return;
+        auto *classDecl = dyn_cast<ClassDecl>(nominal);
+        if (!classDecl)
+          return;
+        if (classDecl->hasKnownSwiftImplementation())
+          return;
+        if (classDecl->isForeign())
+          return;
+        (void)IGM.getAddrOfObjCClassRef(classDecl);
+      });
+    }
+
     // If the minimum deployment target's runtime demangler wouldn't understand
     // this mangled name, then fall back to generating a "mangled name" with a
     // symbolic reference with a callback function.

--- a/test/IRGen/objc_generic_class_metadata_classref.swift
+++ b/test/IRGen/objc_generic_class_metadata_classref.swift
@@ -1,0 +1,25 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) %s -emit-ir | %FileCheck %s
+
+// REQUIRES: objc_interop
+
+// Verify that ObjC classes referenced only through mangled type metadata
+// strings (e.g., in a generic function instantiation) get a linker-visible
+// classref entry emitted. This prevents a runtime crash when linking
+// static archives without -ObjC, where the linker may not pull in the
+// archive member defining the class since only the Swift runtime (via
+// objc_getClass) actually references it.
+//
+// https://github.com/swiftlang/swift/issues/85441
+
+import Foundation
+import objc_generics
+
+// CHECK-DAG: @"OBJC_CLASS_REF_$_GenericClass" = {{.*}}section "__DATA,__objc_classrefs
+
+func useMetadata<T>(_ t: T.Type) {}
+
+public func testObjCClassInMetadataRef() {
+  // This triggers emitMetadataAccessByMangledName for Optional<GenericClass>
+  // which should cause an __objc_classrefs entry for GenericClass
+  useMetadata(Optional<GenericClass<NSString>>.self)
+}


### PR DESCRIPTION
## Summary

When Swift emits a type metadata reference via a mangled name string (e.g., for `Optional<SomeObjCGenericClass>`), the ObjC class name is encoded textually and resolved at runtime via `objc_getClass()`. Unlike direct ObjC class usage (alloc/init, message sends), which emits a classref entry in `__DATA,__objc_classrefs` creating a linker-visible undefined reference to `_OBJC_CLASS_$_<name>`, the mangled-name path created **no such reference**.

This means when ObjC classes are provided by static archives and the only Swift reference to them is through generic type metadata (e.g., `Optional<SomeObjCClass>`, `Array<(SomeObjCClass, Int)>`), the linker has no undefined symbol to trigger archive member extraction. The class definition is never linked.

At runtime, `objc_getClass()` returns nil, the demangling cache stores 0 (a non-negative i64, treated as "filled"), and the next access dereferences null-8 for the value witness table: `EXC_BAD_ACCESS` at `0xFFFFFFFFFFFFFFF8`.

## Fix

In `getTypeRefImpl`, when emitting type refs for the `Metadata` role, walk the type to find ObjC class declarations and emit an `__objc_classrefs` entry for each. This creates the same undefined `_OBJC_CLASS_$_<name>` reference that direct ObjC usage already produces, ensuring the linker pulls the class from static archives via normal symbol resolution -- no `-ObjC` flag required.

Implementation note: uses `getAnyNominal()` + `dyn_cast<ClassDecl>` rather than `getClassOrBoundGenericClass()`, because after ObjC generic type parameter erasure (`getRuntimeReifiedType`), the class appears as a type node that `getClassOrBoundGenericClass()` does not recognize.

## Reproduction

4 modules (3 ObjC, 1 Swift property wrapper) compiled into static archives, linked without `-ObjC`:

| Compiler | ObjC class symbols in binary | Result |
|---|---|---|
| Unfixed (Swift 6.4) | 0 | SIGSEGV (exit 139) |
| Fixed | 4 (Model, BaseType, WRP, ObjCGenericType) | Success |

Fixes https://github.com/swiftlang/swift/issues/85441